### PR TITLE
Remove unnecessary fields from cache structs

### DIFF
--- a/src/H5AC.c
+++ b/src/H5AC.c
@@ -391,7 +391,7 @@ done:
                 H5SL_close(aux_ptr->c_slist_ptr);
             if (aux_ptr->candidate_slist_ptr != NULL)
                 H5SL_close(aux_ptr->candidate_slist_ptr);
-            aux_ptr        = H5FL_FREE(H5AC_aux_t, aux_ptr);
+            aux_ptr = H5FL_FREE(H5AC_aux_t, aux_ptr);
         } /* end if */
     }     /* end if */
 #endif    /* H5_HAVE_PARALLEL */
@@ -511,7 +511,7 @@ H5AC_dest(H5F_t *f)
             H5SL_close(aux_ptr->candidate_slist_ptr);
         } /* end if */
 
-        aux_ptr        = H5FL_FREE(H5AC_aux_t, aux_ptr);
+        aux_ptr = H5FL_FREE(H5AC_aux_t, aux_ptr);
     }  /* end if */
 #endif /* H5_HAVE_PARALLEL */
 

--- a/src/H5ACmpio.c
+++ b/src/H5ACmpio.c
@@ -146,7 +146,6 @@ H5AC__set_sync_point_done_callback(H5C_t *cache_ptr, H5AC_sync_point_done_cb_t s
     HDassert(cache_ptr);
     aux_ptr = (H5AC_aux_t *)H5C_get_aux_ptr(cache_ptr);
     HDassert(aux_ptr != NULL);
-    HDassert(aux_ptr->magic == H5AC__H5AC_AUX_T_MAGIC);
 
     aux_ptr->sync_point_done = sync_point_done;
 
@@ -178,7 +177,6 @@ H5AC__set_write_done_callback(H5C_t *cache_ptr, H5AC_write_done_cb_t write_done)
     HDassert(cache_ptr);
     aux_ptr = (H5AC_aux_t *)H5C_get_aux_ptr(cache_ptr);
     HDassert(aux_ptr != NULL);
-    HDassert(aux_ptr->magic == H5AC__H5AC_AUX_T_MAGIC);
 
     aux_ptr->write_done = write_done;
 
@@ -216,7 +214,6 @@ H5AC_add_candidate(H5AC_t *cache_ptr, haddr_t addr)
     HDassert(cache_ptr != NULL);
     aux_ptr = (H5AC_aux_t *)H5C_get_aux_ptr(cache_ptr);
     HDassert(aux_ptr != NULL);
-    HDassert(aux_ptr->magic == H5AC__H5AC_AUX_T_MAGIC);
     HDassert(aux_ptr->metadata_write_strategy == H5AC_METADATA_WRITE_STRATEGY__DISTRIBUTED);
     HDassert(aux_ptr->candidate_slist_ptr != NULL);
 
@@ -278,7 +275,6 @@ H5AC__broadcast_candidate_list(H5AC_t *cache_ptr, unsigned *num_entries_ptr, had
     HDassert(cache_ptr != NULL);
     aux_ptr = (H5AC_aux_t *)H5C_get_aux_ptr(cache_ptr);
     HDassert(aux_ptr != NULL);
-    HDassert(aux_ptr->magic == H5AC__H5AC_AUX_T_MAGIC);
     HDassert(aux_ptr->mpi_rank == 0);
     HDassert(aux_ptr->metadata_write_strategy == H5AC_METADATA_WRITE_STRATEGY__DISTRIBUTED);
     HDassert(aux_ptr->candidate_slist_ptr != NULL);
@@ -411,7 +407,6 @@ H5AC__broadcast_clean_list(H5AC_t *cache_ptr)
     HDassert(cache_ptr != NULL);
     aux_ptr = (H5AC_aux_t *)H5C_get_aux_ptr(cache_ptr);
     HDassert(aux_ptr != NULL);
-    HDassert(aux_ptr->magic == H5AC__H5AC_AUX_T_MAGIC);
     HDassert(aux_ptr->mpi_rank == 0);
     HDassert(aux_ptr->c_slist_ptr != NULL);
 
@@ -497,7 +492,6 @@ H5AC__construct_candidate_list(H5AC_t *cache_ptr, H5AC_aux_t H5_ATTR_NDEBUG_UNUS
     /* Sanity checks */
     HDassert(cache_ptr != NULL);
     HDassert(aux_ptr != NULL);
-    HDassert(aux_ptr->magic == H5AC__H5AC_AUX_T_MAGIC);
     HDassert(aux_ptr->metadata_write_strategy == H5AC_METADATA_WRITE_STRATEGY__DISTRIBUTED);
     HDassert((sync_point_op == H5AC_SYNC_POINT_OP__FLUSH_CACHE) || (aux_ptr->mpi_rank == 0));
     HDassert(aux_ptr->d_slist_ptr != NULL);
@@ -612,7 +606,6 @@ H5AC__copy_candidate_list_to_buffer(const H5AC_t *cache_ptr, unsigned *num_entri
     HDassert(cache_ptr != NULL);
     aux_ptr = (H5AC_aux_t *)H5C_get_aux_ptr(cache_ptr);
     HDassert(aux_ptr != NULL);
-    HDassert(aux_ptr->magic == H5AC__H5AC_AUX_T_MAGIC);
     HDassert(aux_ptr->metadata_write_strategy == H5AC_METADATA_WRITE_STRATEGY__DISTRIBUTED);
     HDassert(aux_ptr->candidate_slist_ptr != NULL);
     HDassert(H5SL_count(aux_ptr->candidate_slist_ptr) > 0);
@@ -687,7 +680,6 @@ H5AC__log_deleted_entry(const H5AC_info_t *entry_ptr)
     HDassert(cache_ptr != NULL);
     aux_ptr = (H5AC_aux_t *)H5C_get_aux_ptr(cache_ptr);
     HDassert(aux_ptr != NULL);
-    HDassert(aux_ptr->magic == H5AC__H5AC_AUX_T_MAGIC);
     HDassert(aux_ptr->mpi_rank == 0);
     HDassert(aux_ptr->d_slist_ptr != NULL);
     HDassert(aux_ptr->c_slist_ptr != NULL);
@@ -740,7 +732,6 @@ H5AC__log_dirtied_entry(const H5AC_info_t *entry_ptr)
     HDassert(cache_ptr != NULL);
     aux_ptr = (H5AC_aux_t *)H5C_get_aux_ptr(cache_ptr);
     HDassert(aux_ptr != NULL);
-    HDassert(aux_ptr->magic == H5AC__H5AC_AUX_T_MAGIC);
 
     if (aux_ptr->mpi_rank == 0) {
         H5AC_slist_entry_t *slist_entry_ptr;
@@ -817,7 +808,6 @@ H5AC__log_cleaned_entry(const H5AC_info_t *entry_ptr)
     HDassert(cache_ptr != NULL);
     aux_ptr = (H5AC_aux_t *)H5C_get_aux_ptr(cache_ptr);
     HDassert(aux_ptr != NULL);
-    HDassert(aux_ptr->magic == H5AC__H5AC_AUX_T_MAGIC);
 
     if (aux_ptr->mpi_rank == 0) {
         H5AC_slist_entry_t *slist_entry_ptr;
@@ -878,7 +868,6 @@ H5AC__log_flushed_entry(H5C_t *cache_ptr, haddr_t addr, hbool_t was_dirty, unsig
     HDassert(cache_ptr != NULL);
     aux_ptr = (H5AC_aux_t *)H5C_get_aux_ptr(cache_ptr);
     HDassert(aux_ptr != NULL);
-    HDassert(aux_ptr->magic == H5AC__H5AC_AUX_T_MAGIC);
     HDassert(aux_ptr->mpi_rank == 0);
     HDassert(aux_ptr->c_slist_ptr != NULL);
 
@@ -947,7 +936,6 @@ H5AC__log_inserted_entry(const H5AC_info_t *entry_ptr)
     HDassert(cache_ptr != NULL);
     aux_ptr = (H5AC_aux_t *)H5C_get_aux_ptr(cache_ptr);
     HDassert(aux_ptr != NULL);
-    HDassert(aux_ptr->magic == H5AC__H5AC_AUX_T_MAGIC);
 
     if (aux_ptr->mpi_rank == 0) {
         H5AC_slist_entry_t *slist_entry_ptr;
@@ -1049,7 +1037,6 @@ H5AC__log_moved_entry(const H5F_t *f, haddr_t old_addr, haddr_t new_addr)
     HDassert(cache_ptr);
     aux_ptr = (H5AC_aux_t *)H5C_get_aux_ptr(cache_ptr);
     HDassert(aux_ptr != NULL);
-    HDassert(aux_ptr->magic == H5AC__H5AC_AUX_T_MAGIC);
 
     /* get entry status, size, etc here */
     if (H5C_get_entry_status(f, old_addr, &entry_size, &entry_in_cache, &entry_dirty, NULL, NULL, NULL, NULL,
@@ -1228,7 +1215,6 @@ H5AC__propagate_and_apply_candidate_list(H5F_t *f)
     HDassert(cache_ptr != NULL);
     aux_ptr = (H5AC_aux_t *)H5C_get_aux_ptr(cache_ptr);
     HDassert(aux_ptr != NULL);
-    HDassert(aux_ptr->magic == H5AC__H5AC_AUX_T_MAGIC);
     HDassert(aux_ptr->metadata_write_strategy == H5AC_METADATA_WRITE_STRATEGY__DISTRIBUTED);
 
     /* to prevent "messages from the future" we must synchronize all
@@ -1391,7 +1377,6 @@ H5AC__propagate_flushed_and_still_clean_entries_list(H5F_t *f)
     HDassert(cache_ptr != NULL);
     aux_ptr = (H5AC_aux_t *)H5C_get_aux_ptr(cache_ptr);
     HDassert(aux_ptr != NULL);
-    HDassert(aux_ptr->magic == H5AC__H5AC_AUX_T_MAGIC);
     HDassert(aux_ptr->metadata_write_strategy == H5AC_METADATA_WRITE_STRATEGY__PROCESS_0_ONLY);
 
     if (aux_ptr->mpi_rank == 0) {
@@ -1514,7 +1499,6 @@ H5AC__receive_and_apply_clean_list(H5F_t *f)
     HDassert(cache_ptr != NULL);
     aux_ptr = (H5AC_aux_t *)H5C_get_aux_ptr(cache_ptr);
     HDassert(aux_ptr != NULL);
-    HDassert(aux_ptr->magic == H5AC__H5AC_AUX_T_MAGIC);
     HDassert(aux_ptr->mpi_rank != 0);
 
     /* Retrieve the clean list from process 0 */
@@ -1572,7 +1556,6 @@ H5AC__receive_candidate_list(const H5AC_t *cache_ptr, unsigned *num_entries_ptr,
     HDassert(cache_ptr != NULL);
     aux_ptr = (H5AC_aux_t *)H5C_get_aux_ptr(cache_ptr);
     HDassert(aux_ptr != NULL);
-    HDassert(aux_ptr->magic == H5AC__H5AC_AUX_T_MAGIC);
     HDassert(aux_ptr->mpi_rank != 0);
     HDassert(aux_ptr->metadata_write_strategy == H5AC_METADATA_WRITE_STRATEGY__DISTRIBUTED);
     HDassert(num_entries_ptr != NULL);
@@ -1655,7 +1638,6 @@ H5AC__rsp__dist_md_write__flush(H5F_t *f)
     HDassert(cache_ptr != NULL);
     aux_ptr = (H5AC_aux_t *)H5C_get_aux_ptr(cache_ptr);
     HDassert(aux_ptr != NULL);
-    HDassert(aux_ptr->magic == H5AC__H5AC_AUX_T_MAGIC);
     HDassert(aux_ptr->metadata_write_strategy == H5AC_METADATA_WRITE_STRATEGY__DISTRIBUTED);
 
     /* first construct the candidate list -- initially, this will be in the
@@ -1799,7 +1781,6 @@ H5AC__rsp__dist_md_write__flush_to_min_clean(H5F_t *f)
     HDassert(cache_ptr != NULL);
     aux_ptr = (H5AC_aux_t *)H5C_get_aux_ptr(cache_ptr);
     HDassert(aux_ptr != NULL);
-    HDassert(aux_ptr->magic == H5AC__H5AC_AUX_T_MAGIC);
     HDassert(aux_ptr->metadata_write_strategy == H5AC_METADATA_WRITE_STRATEGY__DISTRIBUTED);
 
     /* Query if evictions are allowed */
@@ -1878,7 +1859,6 @@ H5AC__rsp__p0_only__flush(H5F_t *f)
     HDassert(cache_ptr != NULL);
     aux_ptr = (H5AC_aux_t *)H5C_get_aux_ptr(cache_ptr);
     HDassert(aux_ptr != NULL);
-    HDassert(aux_ptr->magic == H5AC__H5AC_AUX_T_MAGIC);
     HDassert(aux_ptr->metadata_write_strategy == H5AC_METADATA_WRITE_STRATEGY__PROCESS_0_ONLY);
 
     /* To prevent "messages from the future" we must
@@ -1989,7 +1969,6 @@ H5AC__rsp__p0_only__flush_to_min_clean(H5F_t *f)
     HDassert(cache_ptr != NULL);
     aux_ptr = (H5AC_aux_t *)H5C_get_aux_ptr(cache_ptr);
     HDassert(aux_ptr != NULL);
-    HDassert(aux_ptr->magic == H5AC__H5AC_AUX_T_MAGIC);
     HDassert(aux_ptr->metadata_write_strategy == H5AC_METADATA_WRITE_STRATEGY__PROCESS_0_ONLY);
 
     /* Query if evictions are allowed */
@@ -2103,7 +2082,6 @@ H5AC__run_sync_point(H5F_t *f, int sync_point_op)
     HDassert(cache_ptr != NULL);
     aux_ptr = (H5AC_aux_t *)H5C_get_aux_ptr(cache_ptr);
     HDassert(aux_ptr != NULL);
-    HDassert(aux_ptr->magic == H5AC__H5AC_AUX_T_MAGIC);
     HDassert((sync_point_op == H5AC_SYNC_POINT_OP__FLUSH_TO_MIN_CLEAN) ||
              (sync_point_op == H5AC_METADATA_WRITE_STRATEGY__DISTRIBUTED));
 
@@ -2232,7 +2210,6 @@ H5AC__tidy_cache_0_lists(H5AC_t *cache_ptr, unsigned num_candidates, haddr_t *ca
     HDassert(cache_ptr != NULL);
     aux_ptr = (H5AC_aux_t *)H5C_get_aux_ptr(cache_ptr);
     HDassert(aux_ptr != NULL);
-    HDassert(aux_ptr->magic == H5AC__H5AC_AUX_T_MAGIC);
     HDassert(aux_ptr->metadata_write_strategy == H5AC_METADATA_WRITE_STRATEGY__DISTRIBUTED);
     HDassert(aux_ptr->mpi_rank == 0);
     HDassert(num_candidates > 0);

--- a/src/H5ACpkg.h
+++ b/src/H5ACpkg.h
@@ -348,12 +348,12 @@ H5FL_EXTERN(H5AC_aux_t);
 
 typedef struct H5AC_aux_t {
     MPI_Comm mpi_comm;
-    int mpi_rank;
-    int mpi_size;
+    int      mpi_rank;
+    int      mpi_size;
 
     hbool_t write_permitted;
-    size_t dirty_bytes_threshold;
-    size_t dirty_bytes;
+    size_t  dirty_bytes_threshold;
+    size_t  dirty_bytes;
     int32_t metadata_write_strategy;
 
 #ifdef H5AC_DEBUG_DIRTY_BYTES_CREATION

--- a/src/H5ACpkg.h
+++ b/src/H5ACpkg.h
@@ -165,10 +165,6 @@ H5FL_EXTERN(H5AC_aux_t);
  *
  *						JRM -- 1/6/15
  *
- * magic:       Unsigned 32 bit integer always set to
- *		H5AC__H5AC_AUX_T_MAGIC.  This field is used to validate
- *		pointers to instances of H5AC_aux_t.
- *
  * mpi_comm:	MPI communicator associated with the file for which the
  *		cache has been created.
  *
@@ -350,52 +346,34 @@ H5FL_EXTERN(H5AC_aux_t);
 
 #ifdef H5_HAVE_PARALLEL
 
-#define H5AC__H5AC_AUX_T_MAGIC (unsigned)0x00D0A01
-
 typedef struct H5AC_aux_t {
-    uint32_t magic;
-
     MPI_Comm mpi_comm;
-
     int mpi_rank;
-
     int mpi_size;
 
     hbool_t write_permitted;
-
     size_t dirty_bytes_threshold;
-
     size_t dirty_bytes;
-
     int32_t metadata_write_strategy;
 
 #ifdef H5AC_DEBUG_DIRTY_BYTES_CREATION
-
     unsigned dirty_bytes_propagations;
-
     size_t   unprotect_dirty_bytes;
     unsigned unprotect_dirty_bytes_updates;
-
     size_t   insert_dirty_bytes;
     unsigned insert_dirty_bytes_updates;
-
     size_t   move_dirty_bytes;
     unsigned move_dirty_bytes_updates;
-
 #endif /* H5AC_DEBUG_DIRTY_BYTES_CREATION */
 
     H5SL_t *d_slist_ptr;
-
     H5SL_t *c_slist_ptr;
-
     H5SL_t *candidate_slist_ptr;
 
     void (*write_done)(void);
-
     void (*sync_point_done)(unsigned num_writes, haddr_t *written_entries_tbl);
 
     unsigned p0_image_len;
-
 } H5AC_aux_t; /* struct H5AC_aux_t */
 
 /* Typedefs for debugging function pointers */

--- a/src/H5C.c
+++ b/src/H5C.c
@@ -311,8 +311,8 @@ H5C_create(size_t max_cache_size, size_t min_clean_size, int max_type_id,
 
     /* Set non-zero/FALSE/NULL fields for epoch markers */
     for (i = 0; i < H5C__MAX_EPOCH_MARKERS; i++) {
-        ((cache_ptr->epoch_markers)[i]).addr  = (haddr_t)i;
-        ((cache_ptr->epoch_markers)[i]).type  = H5AC_EPOCH_MARKER;
+        ((cache_ptr->epoch_markers)[i]).addr = (haddr_t)i;
+        ((cache_ptr->epoch_markers)[i]).type = H5AC_EPOCH_MARKER;
     }
 
     /* Initialize cache image generation on file close related fields.
@@ -373,7 +373,7 @@ done:
             if (cache_ptr->log_info != NULL)
                 H5MM_xfree(cache_ptr->log_info);
 
-            cache_ptr        = H5FL_FREE(H5C_t, cache_ptr);
+            cache_ptr = H5FL_FREE(H5C_t, cache_ptr);
         }
     }
 

--- a/src/H5Cdbg.c
+++ b/src/H5Cdbg.c
@@ -86,7 +86,6 @@ H5C_dump_cache(H5C_t *cache_ptr, const char *cache_name)
 
     /* Sanity check */
     HDassert(cache_ptr != NULL);
-    HDassert(cache_ptr->magic == H5C__H5C_T_MAGIC);
     HDassert(cache_name != NULL);
 
     /* First, create a skip list */
@@ -101,7 +100,6 @@ H5C_dump_cache(H5C_t *cache_ptr, const char *cache_name)
         entry_ptr = cache_ptr->index[i];
 
         while (entry_ptr != NULL) {
-            HDassert(entry_ptr->magic == H5C__H5C_CACHE_ENTRY_T_MAGIC);
             if (H5SL_insert(slist_ptr, entry_ptr, &(entry_ptr->addr)) < 0)
                 HGOTO_ERROR(H5E_CACHE, H5E_BADVALUE, FAIL, "can't insert entry in skip list")
 
@@ -131,8 +129,6 @@ H5C_dump_cache(H5C_t *cache_ptr, const char *cache_name)
     i         = 0;
     entry_ptr = (H5C_cache_entry_t *)H5SL_remove_first(slist_ptr);
     while (entry_ptr != NULL) {
-        HDassert(entry_ptr->magic == H5C__H5C_CACHE_ENTRY_T_MAGIC);
-
         /* Print entry */
         HDfprintf(stdout, "%s%5d ", cache_ptr->prefix, i);
         HDfprintf(stdout, "  0x%16llx ", (long long)(entry_ptr->addr));
@@ -193,7 +189,6 @@ H5C_dump_cache_LRU(H5C_t *cache_ptr, const char *cache_name)
 
     /* Sanity check */
     HDassert(cache_ptr != NULL);
-    HDassert(cache_ptr->magic == H5C__H5C_T_MAGIC);
     HDassert(cache_name != NULL);
 
     HDfprintf(stdout, "\n\nDump of metadata cache LRU \"%s\"\n", cache_name);
@@ -218,8 +213,6 @@ H5C_dump_cache_LRU(H5C_t *cache_ptr, const char *cache_name)
 
     entry_ptr = cache_ptr->LRU_head_ptr;
     while (entry_ptr != NULL) {
-        HDassert(entry_ptr->magic == H5C__H5C_CACHE_ENTRY_T_MAGIC);
-
         /* Print entry */
         HDfprintf(stdout, "%s%5d ", cache_ptr->prefix, i);
         HDfprintf(stdout, "  0x%16llx ", (long long)(entry_ptr->addr));
@@ -272,7 +265,6 @@ H5C_dump_cache_skip_list(H5C_t *cache_ptr, char *calling_fcn)
     FUNC_ENTER_NOAPI_NOERR
 
     HDassert(cache_ptr != NULL);
-    HDassert(cache_ptr->magic == H5C__H5C_T_MAGIC);
     HDassert(calling_fcn != NULL);
 
     HDfprintf(stdout, "\n\nDumping metadata cache skip list from %s.\n", calling_fcn);
@@ -296,7 +288,6 @@ H5C_dump_cache_skip_list(H5C_t *cache_ptr, char *calling_fcn)
             entry_ptr = NULL;
 
         while (entry_ptr != NULL) {
-            HDassert(entry_ptr->magic == H5C__H5C_CACHE_ENTRY_T_MAGIC);
             HDfprintf(stdout, "%s%d       0x%016llx  %4lld    %d/%d       %d    %s\n", cache_ptr->prefix, i,
                       (long long)(entry_ptr->addr), (long long)(entry_ptr->size),
                       (int)(entry_ptr->is_protected), (int)(entry_ptr->is_pinned), (int)(entry_ptr->is_dirty),
@@ -340,8 +331,7 @@ H5C_set_prefix(H5C_t *cache_ptr, char *prefix)
 
     FUNC_ENTER_NOAPI(FAIL)
 
-    if ((cache_ptr == NULL) || (cache_ptr->magic != H5C__H5C_T_MAGIC) || (prefix == NULL) ||
-        (HDstrlen(prefix) >= H5C__PREFIX_LEN))
+    if (cache_ptr == NULL || prefix == NULL || HDstrlen(prefix) >= H5C__PREFIX_LEN)
         HGOTO_ERROR(H5E_CACHE, H5E_SYSTEM, FAIL, "Bad param(s) on entry")
 
     HDstrncpy(&(cache_ptr->prefix[0]), prefix, (size_t)(H5C__PREFIX_LEN));
@@ -415,12 +405,7 @@ H5C_stats(H5C_t *cache_ptr, const char *cache_name,
 
     FUNC_ENTER_NOAPI(FAIL)
 
-    HDassert(cache_ptr->magic == H5C__H5C_T_MAGIC);
-
-    /* This would normally be an assert, but we need to use an HGOTO_ERROR
-     * call to shut up the compiler.
-     */
-    if ((NULL == cache_ptr) || (cache_ptr->magic != H5C__H5C_T_MAGIC) || (NULL == cache_name))
+    if (NULL == cache_ptr || NULL == cache_name)
         HGOTO_ERROR(H5E_CACHE, H5E_SYSTEM, FAIL, "Bad cache_ptr or cache_name")
 
 #if H5C_COLLECT_CACHE_STATS
@@ -722,7 +707,6 @@ H5C_stats__reset(H5C_t H5_ATTR_UNUSED *cache_ptr)
 #endif /* H5C_COLLECT_CACHE_STATS */
 
     HDassert(cache_ptr);
-    HDassert(cache_ptr->magic == H5C__H5C_T_MAGIC);
 
 #if H5C_COLLECT_CACHE_STATS
     for (i = 0; i <= cache_ptr->max_type_id; i++) {
@@ -846,7 +830,6 @@ H5C_flush_dependency_exists(H5C_t *cache_ptr, haddr_t parent_addr, haddr_t child
 
     /* Sanity checks */
     HDassert(cache_ptr);
-    HDassert(cache_ptr->magic == H5C__H5C_T_MAGIC);
     HDassert(H5F_addr_defined(parent_addr));
     HDassert(H5F_addr_defined(child_addr));
     HDassert(fd_exists_ptr);
@@ -855,9 +838,6 @@ H5C_flush_dependency_exists(H5C_t *cache_ptr, haddr_t parent_addr, haddr_t child
     H5C__SEARCH_INDEX(cache_ptr, child_addr, child_ptr, FAIL)
 
     if (parent_ptr && child_ptr) {
-        HDassert(parent_ptr->magic == H5C__H5C_CACHE_ENTRY_T_MAGIC);
-        HDassert(child_ptr->magic == H5C__H5C_CACHE_ENTRY_T_MAGIC);
-
         if (child_ptr->flush_dep_nparents > 0) {
             unsigned u; /* Local index variable */
 
@@ -916,7 +896,6 @@ H5C_validate_index_list(H5C_t *cache_ptr)
 
     /* Sanity checks */
     HDassert(cache_ptr);
-    HDassert(cache_ptr->magic == H5C__H5C_T_MAGIC);
 
     for (i = 0; i < H5C_RING_NTYPES; i++) {
         index_ring_len[i]        = 0;
@@ -1042,7 +1021,6 @@ H5C_get_entry_ptr_from_addr(H5C_t *cache_ptr, haddr_t addr, void **entry_ptr_ptr
 
     /* Sanity checks */
     HDassert(cache_ptr);
-    HDassert(cache_ptr->magic == H5C__H5C_T_MAGIC);
     HDassert(H5F_addr_defined(addr));
     HDassert(entry_ptr_ptr);
 
@@ -1086,7 +1064,6 @@ H5C_get_serialization_in_progress(const H5C_t *cache_ptr)
 
     /* Sanity check */
     HDassert(cache_ptr);
-    HDassert(cache_ptr->magic == H5C__H5C_T_MAGIC);
 
     FUNC_LEAVE_NOAPI(cache_ptr->serialization_in_progress)
 } /* H5C_get_serialization_in_progress() */
@@ -1119,7 +1096,6 @@ H5C_cache_is_clean(const H5C_t *cache_ptr, H5C_ring_t inner_ring)
 
     /* Sanity checks */
     HDassert(cache_ptr);
-    HDassert(cache_ptr->magic == H5C__H5C_T_MAGIC);
     HDassert(inner_ring >= H5C_RING_USER);
     HDassert(inner_ring <= H5C_RING_SB);
 
@@ -1171,7 +1147,6 @@ H5C_verify_entry_type(H5C_t *cache_ptr, haddr_t addr, const H5C_class_t *expecte
 
     /* Sanity checks */
     HDassert(cache_ptr);
-    HDassert(cache_ptr->magic == H5C__H5C_T_MAGIC);
     HDassert(H5F_addr_defined(addr));
     HDassert(expected_type);
     HDassert(in_cache_ptr);
@@ -1224,7 +1199,6 @@ H5C_def_auto_resize_rpt_fcn(H5C_t *cache_ptr,
                             size_t new_max_cache_size, size_t old_min_clean_size, size_t new_min_clean_size)
 {
     HDassert(cache_ptr != NULL);
-    HDassert(cache_ptr->magic == H5C__H5C_T_MAGIC);
     HDassert(version == H5C__CURR_AUTO_RESIZE_RPT_FCN_VER);
 
     switch (status) {
@@ -1355,7 +1329,6 @@ H5C__validate_lru_list(H5C_t *cache_ptr)
     FUNC_ENTER_PACKAGE
 
     HDassert(cache_ptr);
-    HDassert(cache_ptr->magic == H5C__H5C_T_MAGIC);
 
     if (((cache_ptr->LRU_head_ptr == NULL) || (cache_ptr->LRU_tail_ptr == NULL)) &&
         (cache_ptr->LRU_head_ptr != cache_ptr->LRU_tail_ptr))
@@ -1428,7 +1401,6 @@ H5C__validate_pinned_entry_list(H5C_t *cache_ptr)
     FUNC_ENTER_PACKAGE
 
     HDassert(cache_ptr);
-    HDassert(cache_ptr->magic == H5C__H5C_T_MAGIC);
 
     if (((cache_ptr->pel_head_ptr == NULL) || (cache_ptr->pel_tail_ptr == NULL)) &&
         (cache_ptr->pel_head_ptr != cache_ptr->pel_tail_ptr))
@@ -1504,7 +1476,6 @@ H5C__validate_protected_entry_list(H5C_t *cache_ptr)
     FUNC_ENTER_PACKAGE
 
     HDassert(cache_ptr);
-    HDassert(cache_ptr->magic == H5C__H5C_T_MAGIC);
 
     if (((cache_ptr->pl_head_ptr == NULL) || (cache_ptr->pl_tail_ptr == NULL)) &&
         (cache_ptr->pl_head_ptr != cache_ptr->pl_tail_ptr))
@@ -1578,7 +1549,6 @@ H5C__entry_in_skip_list(H5C_t *cache_ptr, H5C_cache_entry_t *target_ptr)
 
     /* Assertions */
     HDassert(cache_ptr);
-    HDassert(cache_ptr->magic == H5C__H5C_T_MAGIC);
     HDassert(cache_ptr->slist_ptr);
 
     node_ptr = H5SL_first(cache_ptr->slist_ptr);
@@ -1589,7 +1559,6 @@ H5C__entry_in_skip_list(H5C_t *cache_ptr, H5C_cache_entry_t *target_ptr)
         entry_ptr = (H5C_cache_entry_t *)H5SL_item(node_ptr);
 
         HDassert(entry_ptr);
-        HDassert(entry_ptr->magic == H5C__H5C_CACHE_ENTRY_T_MAGIC);
         HDassert(entry_ptr->is_dirty);
         HDassert(entry_ptr->in_slist);
 
@@ -1637,7 +1606,7 @@ H5C__image_stats(H5C_t *cache_ptr, hbool_t H5_ATTR_UNUSED print_header)
 
     FUNC_ENTER_NOAPI(FAIL)
 
-    if (!cache_ptr || cache_ptr->magic != H5C__H5C_T_MAGIC)
+    if (NULL == cache_ptr)
         HGOTO_ERROR(H5E_CACHE, H5E_SYSTEM, FAIL, "Bad cache_ptr")
 
 #if H5C_COLLECT_CACHE_STATS

--- a/src/H5Cimage.c
+++ b/src/H5Cimage.c
@@ -2830,7 +2830,7 @@ H5C__write_cache_image_superblock_msg(H5F_t *f, hbool_t create)
     if (cache_ptr->aux_ptr) { /* we have multiple processes */
         H5AC_aux_t *aux_ptr;
 
-        aux_ptr = (H5AC_aux_t *)cache_ptr->aux_ptr;
+        aux_ptr       = (H5AC_aux_t *)cache_ptr->aux_ptr;
         mdci_msg.size = aux_ptr->p0_image_len;
     } /* end if */
     else

--- a/src/H5Cint.c
+++ b/src/H5Cint.c
@@ -105,7 +105,6 @@ H5C__auto_adjust_cache_size(H5F_t *f, hbool_t write_permitted)
 
     HDassert(f);
     HDassert(cache_ptr);
-    HDassert(cache_ptr->magic == H5C__H5C_T_MAGIC);
     HDassert(cache_ptr->cache_accesses >= cache_ptr->resize_ctl.epoch_length);
     HDassert(0.0 <= cache_ptr->resize_ctl.min_clean_fraction);
     HDassert(cache_ptr->resize_ctl.min_clean_fraction <= 100.0);
@@ -354,7 +353,6 @@ H5C__autoadjust__ageout(H5F_t *f, double hit_rate, enum H5C_resize_status *statu
 
     HDassert(f);
     HDassert(cache_ptr);
-    HDassert(cache_ptr->magic == H5C__H5C_T_MAGIC);
     HDassert((status_ptr) && (*status_ptr == in_spec));
     HDassert((new_max_cache_size_ptr) && (*new_max_cache_size_ptr == 0));
 
@@ -433,7 +431,6 @@ H5C__autoadjust__ageout__cycle_epoch_marker(H5C_t *cache_ptr)
     FUNC_ENTER_PACKAGE
 
     HDassert(cache_ptr);
-    HDassert(cache_ptr->magic == H5C__H5C_T_MAGIC);
 
     if (cache_ptr->epoch_markers_active <= 0)
         HGOTO_ERROR(H5E_CACHE, H5E_SYSTEM, FAIL, "No active epoch markers on entry?!?!?")
@@ -528,7 +525,6 @@ H5C__autoadjust__ageout__evict_aged_out_entries(H5F_t *f, hbool_t write_permitte
 
     HDassert(f);
     HDassert(cache_ptr);
-    HDassert(cache_ptr->magic == H5C__H5C_T_MAGIC);
 
     /* if there is a limit on the amount that the cache size can be decrease
      * in any one round of the cache size reduction algorithm, load that
@@ -548,7 +544,6 @@ H5C__autoadjust__ageout__evict_aged_out_entries(H5F_t *f, hbool_t write_permitte
                bytes_evicted < eviction_size_limit) {
             hbool_t skipping_entry = FALSE;
 
-            HDassert(entry_ptr->magic == H5C__H5C_CACHE_ENTRY_T_MAGIC);
             HDassert(!(entry_ptr->is_protected));
             HDassert(!(entry_ptr->is_read_only));
             HDassert((entry_ptr->ro_ref_count) == 0);
@@ -701,7 +696,6 @@ H5C__autoadjust__ageout__insert_new_marker(H5C_t *cache_ptr)
     FUNC_ENTER_PACKAGE
 
     HDassert(cache_ptr);
-    HDassert(cache_ptr->magic == H5C__H5C_T_MAGIC);
 
     if (cache_ptr->epoch_markers_active >= cache_ptr->resize_ctl.epochs_before_eviction)
         HGOTO_ERROR(H5E_CACHE, H5E_SYSTEM, FAIL, "Already have a full complement of markers")
@@ -758,7 +752,6 @@ H5C__autoadjust__ageout__remove_all_markers(H5C_t *cache_ptr)
     FUNC_ENTER_PACKAGE
 
     HDassert(cache_ptr);
-    HDassert(cache_ptr->magic == H5C__H5C_T_MAGIC);
 
     while (cache_ptr->epoch_markers_active > 0) {
         /* get the index of the last epoch marker in the LRU list
@@ -823,7 +816,6 @@ H5C__autoadjust__ageout__remove_excess_markers(H5C_t *cache_ptr)
     FUNC_ENTER_PACKAGE
 
     HDassert(cache_ptr);
-    HDassert(cache_ptr->magic == H5C__H5C_T_MAGIC);
 
     if (cache_ptr->epoch_markers_active <= cache_ptr->resize_ctl.epochs_before_eviction)
         HGOTO_ERROR(H5E_CACHE, H5E_SYSTEM, FAIL, "no excess markers on entry")
@@ -896,7 +888,6 @@ H5C__flash_increase_cache_size(H5C_t *cache_ptr, size_t old_entry_size, size_t n
     FUNC_ENTER_PACKAGE
 
     HDassert(cache_ptr);
-    HDassert(cache_ptr->magic == H5C__H5C_T_MAGIC);
     HDassert(cache_ptr->flash_size_increase_possible);
     HDassert(new_entry_size > cache_ptr->flash_size_increase_threshold);
     HDassert(old_entry_size < new_entry_size);
@@ -1030,7 +1021,6 @@ H5C__flush_invalidate_cache(H5F_t *f, unsigned flags)
     HDassert(f->shared);
     cache_ptr = f->shared->cache;
     HDassert(cache_ptr);
-    HDassert(cache_ptr->magic == H5C__H5C_T_MAGIC);
     HDassert(cache_ptr->slist_ptr);
     HDassert(cache_ptr->slist_enabled);
 
@@ -1189,11 +1179,8 @@ H5C__flush_invalidate_ring(H5F_t *f, H5C_ring_t ring, unsigned flags)
 
     HDassert(f);
     HDassert(f->shared);
-
     cache_ptr = f->shared->cache;
-
     HDassert(cache_ptr);
-    HDassert(cache_ptr->magic == H5C__H5C_T_MAGIC);
     HDassert(cache_ptr->slist_enabled);
     HDassert(cache_ptr->slist_ptr);
     HDassert(ring > H5C_RING_UNDEFINED);
@@ -1237,7 +1224,6 @@ H5C__flush_invalidate_ring(H5F_t *f, H5C_ring_t ring, unsigned flags)
     entry_ptr        = cache_ptr->pel_head_ptr;
     cur_ring_pel_len = 0;
     while (entry_ptr != NULL) {
-        HDassert(entry_ptr->magic == H5C__H5C_CACHE_ENTRY_T_MAGIC);
         HDassert(entry_ptr->ring >= ring);
         if (entry_ptr->ring == ring)
             cur_ring_pel_len++;
@@ -1304,7 +1290,6 @@ H5C__flush_invalidate_ring(H5F_t *f, H5C_ring_t ring, unsigned flags)
                 if (NULL == next_entry_ptr)
                     HGOTO_ERROR(H5E_CACHE, H5E_SYSTEM, FAIL, "next_entry_ptr == NULL ?!?!")
 
-                HDassert(next_entry_ptr->magic == H5C__H5C_CACHE_ENTRY_T_MAGIC);
                 HDassert(next_entry_ptr->is_dirty);
                 HDassert(next_entry_ptr->in_slist);
                 HDassert(next_entry_ptr->ring >= ring);
@@ -1324,7 +1309,6 @@ H5C__flush_invalidate_ring(H5F_t *f, H5C_ring_t ring, unsigned flags)
              * sanity checking just in case.
              */
             HDassert(entry_ptr != NULL);
-            HDassert(entry_ptr->magic == H5C__H5C_CACHE_ENTRY_T_MAGIC);
             HDassert(entry_ptr->in_slist);
             HDassert(entry_ptr->is_dirty);
             HDassert(entry_ptr->ring >= ring);
@@ -1338,7 +1322,6 @@ H5C__flush_invalidate_ring(H5F_t *f, H5C_ring_t ring, unsigned flags)
                 if (NULL == next_entry_ptr)
                     HGOTO_ERROR(H5E_CACHE, H5E_SYSTEM, FAIL, "next_entry_ptr == NULL ?!?!")
 
-                HDassert(next_entry_ptr->magic == H5C__H5C_CACHE_ENTRY_T_MAGIC);
                 HDassert(next_entry_ptr->is_dirty);
                 HDassert(next_entry_ptr->in_slist);
                 HDassert(next_entry_ptr->ring >= ring);
@@ -1446,11 +1429,9 @@ H5C__flush_invalidate_ring(H5F_t *f, H5C_ring_t ring, unsigned flags)
         next_entry_ptr = cache_ptr->il_head;
         while (next_entry_ptr != NULL) {
             entry_ptr = next_entry_ptr;
-            HDassert(entry_ptr->magic == H5C__H5C_CACHE_ENTRY_T_MAGIC);
             HDassert(entry_ptr->ring >= ring);
 
             next_entry_ptr = entry_ptr->il_next;
-            HDassert((next_entry_ptr == NULL) || (next_entry_ptr->magic == H5C__H5C_CACHE_ENTRY_T_MAGIC));
 
             if (((!entry_ptr->flush_me_last) ||
                  (entry_ptr->flush_me_last && (cache_ptr->num_last_entries >= cache_ptr->slist_len))) &&
@@ -1540,7 +1521,6 @@ H5C__flush_invalidate_ring(H5F_t *f, H5C_ring_t ring, unsigned flags)
         cur_ring_pel_len = 0;
 
         while (entry_ptr != NULL) {
-            HDassert(entry_ptr->magic == H5C__H5C_CACHE_ENTRY_T_MAGIC);
             HDassert(entry_ptr->ring >= ring);
 
             if (entry_ptr->ring == ring)
@@ -1640,7 +1620,6 @@ H5C__flush_ring(H5F_t *f, H5C_ring_t ring, unsigned flags)
     FUNC_ENTER_PACKAGE
 
     HDassert(cache_ptr);
-    HDassert(cache_ptr->magic == H5C__H5C_T_MAGIC);
     HDassert(cache_ptr->slist_enabled);
     HDassert(cache_ptr->slist_ptr);
     HDassert((flags & H5C__FLUSH_INVALIDATE_FLAG) == 0);
@@ -1737,7 +1716,6 @@ H5C__flush_ring(H5F_t *f, H5C_ring_t ring, unsigned flags)
                 if (NULL == next_entry_ptr)
                     HGOTO_ERROR(H5E_CACHE, H5E_SYSTEM, FAIL, "next_entry_ptr == NULL ?!?!")
 
-                HDassert(next_entry_ptr->magic == H5C__H5C_CACHE_ENTRY_T_MAGIC);
                 HDassert(next_entry_ptr->is_dirty);
                 HDassert(next_entry_ptr->in_slist);
             } /* end if */
@@ -1761,7 +1739,6 @@ H5C__flush_ring(H5F_t *f, H5C_ring_t ring, unsigned flags)
              * with, we do a bit of extra sanity checking on
              * entry_ptr.
              */
-            HDassert(entry_ptr->magic == H5C__H5C_CACHE_ENTRY_T_MAGIC);
             HDassert(entry_ptr->in_slist);
             HDassert(entry_ptr->is_dirty);
 
@@ -1777,7 +1754,6 @@ H5C__flush_ring(H5F_t *f, H5C_ring_t ring, unsigned flags)
                 if (NULL == next_entry_ptr)
                     HGOTO_ERROR(H5E_CACHE, H5E_SYSTEM, FAIL, "next_entry_ptr == NULL ?!?!")
 
-                HDassert(next_entry_ptr->magic == H5C__H5C_CACHE_ENTRY_T_MAGIC);
                 HDassert(next_entry_ptr->is_dirty);
                 HDassert(next_entry_ptr->in_slist);
 
@@ -1909,7 +1885,6 @@ H5C__make_space_in_cache(H5F_t *f, size_t space_needed, hbool_t write_permitted)
     /* Sanity checks */
     HDassert(f);
     HDassert(cache_ptr);
-    HDassert(cache_ptr->magic == H5C__H5C_T_MAGIC);
     HDassert(cache_ptr->index_size == (cache_ptr->clean_index_size + cache_ptr->dirty_index_size));
 
     /* check to see if cache_ptr->msic_in_progress is TRUE.  If it, this
@@ -1937,7 +1912,6 @@ H5C__make_space_in_cache(H5F_t *f, size_t space_needed, hbool_t write_permitted)
         while ((((cache_ptr->index_size + space_needed) > cache_ptr->max_cache_size) ||
                 ((empty_space + cache_ptr->clean_index_size) < (cache_ptr->min_clean_size))) &&
                (entries_examined <= (2 * initial_list_len)) && (entry_ptr != NULL)) {
-            HDassert(entry_ptr->magic == H5C__H5C_CACHE_ENTRY_T_MAGIC);
             HDassert(!(entry_ptr->is_protected));
             HDassert(!(entry_ptr->is_read_only));
             HDassert((entry_ptr->ro_ref_count) == 0);
@@ -2194,7 +2168,6 @@ H5C__serialize_cache(H5F_t *f)
     HDassert(f->shared);
     cache_ptr = f->shared->cache;
     HDassert(cache_ptr);
-    HDassert(cache_ptr->magic == H5C__H5C_T_MAGIC);
     HDassert(cache_ptr->slist_ptr);
 
 #ifdef H5C_DO_SANITY_CHECKS
@@ -2242,7 +2215,6 @@ H5C__serialize_cache(H5F_t *f)
 
         scan_ptr = cache_ptr->il_head;
         while (scan_ptr != NULL) {
-            HDassert(scan_ptr->magic == H5C__H5C_CACHE_ENTRY_T_MAGIC);
             scan_ptr->serialization_count = 0;
             scan_ptr                      = scan_ptr->il_next;
         } /* end while */
@@ -2307,7 +2279,6 @@ H5C__serialize_cache(H5F_t *f)
 
         scan_ptr = cache_ptr->il_head;
         while (scan_ptr != NULL) {
-            HDassert(scan_ptr->magic == H5C__H5C_CACHE_ENTRY_T_MAGIC);
             HDassert(scan_ptr->serialization_count <= 1);
 
             scan_ptr = scan_ptr->il_next;
@@ -2364,7 +2335,6 @@ H5C__serialize_ring(H5F_t *f, H5C_ring_t ring)
     HDassert(f->shared);
     cache_ptr = f->shared->cache;
     HDassert(cache_ptr);
-    HDassert(cache_ptr->magic == H5C__H5C_T_MAGIC);
     HDassert(ring > H5C_RING_UNDEFINED);
     HDassert(ring < H5C_RING_NTYPES);
 
@@ -2457,8 +2427,6 @@ H5C__serialize_ring(H5F_t *f, H5C_ring_t ring)
         done      = TRUE; /* set to FALSE if any activity in inner loop */
         entry_ptr = cache_ptr->il_head;
         while (entry_ptr != NULL) {
-            HDassert(entry_ptr->magic == H5C__H5C_CACHE_ENTRY_T_MAGIC);
-
             /* Verify that either the entry is already serialized, or
              * that it is assigned to either the target or an inner
              * ring.
@@ -2532,7 +2500,6 @@ H5C__serialize_ring(H5F_t *f, H5C_ring_t ring)
      */
     entry_ptr = cache_ptr->il_head;
     while (entry_ptr != NULL) {
-        HDassert(entry_ptr->magic == H5C__H5C_CACHE_ENTRY_T_MAGIC);
         HDassert(entry_ptr->ring > H5C_RING_UNDEFINED);
         HDassert(entry_ptr->ring < H5C_RING_NTYPES);
         HDassert((entry_ptr->ring >= ring) || (entry_ptr->image_up_to_date));

--- a/src/H5Cmpio.c
+++ b/src/H5Cmpio.c
@@ -184,7 +184,6 @@ H5C_apply_candidate_list(H5F_t *f, H5C_t *cache_ptr, unsigned num_candidates, ha
 
     /* Sanity checks */
     HDassert(cache_ptr != NULL);
-    HDassert(cache_ptr->magic == H5C__H5C_T_MAGIC);
     HDassert(num_candidates > 0);
     HDassert((!cache_ptr->slist_enabled) || (num_candidates <= cache_ptr->slist_len));
     HDassert(candidates_list_ptr != NULL);
@@ -306,7 +305,6 @@ H5C_apply_candidate_list(H5F_t *f, H5C_t *cache_ptr, unsigned num_candidates, ha
             HGOTO_ERROR(H5E_CACHE, H5E_SYSTEM, FAIL, "Listed entry is protected?!?!?")
 
         /* Sanity checks */
-        HDassert(entry_ptr->magic == H5C__H5C_CACHE_ENTRY_T_MAGIC);
         HDassert(entry_ptr->ring >= H5C_RING_USER);
         HDassert(entry_ptr->ring <= H5C_RING_SB);
         HDassert(!entry_ptr->flush_immediately);
@@ -422,7 +420,6 @@ H5C_construct_candidate_list__clean_cache(H5C_t *cache_ptr)
     FUNC_ENTER_NOAPI(FAIL)
 
     HDassert(cache_ptr != NULL);
-    HDassert(cache_ptr->magic == H5C__H5C_T_MAGIC);
 
     /* As a sanity check, set space needed to the dirty_index_size.  This
      * should be the sum total of the sizes of all the dirty entries
@@ -533,7 +530,6 @@ H5C_construct_candidate_list__min_clean(H5C_t *cache_ptr)
     FUNC_ENTER_NOAPI(FAIL)
 
     HDassert(cache_ptr != NULL);
-    HDassert(cache_ptr->magic == H5C__H5C_T_MAGIC);
 
     /* compute the number of bytes (if any) that must be flushed to get the
      * cache back within its min clean constraints.
@@ -652,7 +648,6 @@ H5C_mark_entries_as_clean(H5F_t *f, unsigned ce_array_len, haddr_t *ce_array_ptr
     HDassert(f->shared);
     cache_ptr = f->shared->cache;
     HDassert(cache_ptr);
-    HDassert(cache_ptr->magic == H5C__H5C_T_MAGIC);
 
     HDassert(ce_array_len > 0);
     HDassert(ce_array_ptr != NULL);
@@ -1055,11 +1050,8 @@ H5C__flush_candidate_entries(H5F_t *f, unsigned entries_to_flush[H5C_RING_NTYPES
 
     HDassert(f);
     HDassert(f->shared);
-
     cache_ptr = f->shared->cache;
-
     HDassert(cache_ptr);
-    HDassert(cache_ptr->magic == H5C__H5C_T_MAGIC);
     HDassert(cache_ptr->slist_ptr);
 
     HDassert(entries_to_flush[H5C_RING_UNDEFINED] == 0);
@@ -1178,7 +1170,6 @@ H5C__flush_candidates_in_ring(H5F_t *f, H5C_ring_t ring, unsigned entries_to_flu
     HDassert(f->shared);
     cache_ptr = f->shared->cache;
     HDassert(cache_ptr);
-    HDassert(cache_ptr->magic == H5C__H5C_T_MAGIC);
     HDassert(cache_ptr->slist_ptr);
     HDassert(ring > H5C_RING_UNDEFINED);
     HDassert(ring < H5C_RING_NTYPES);

--- a/src/H5Cpkg.h
+++ b/src/H5Cpkg.h
@@ -42,11 +42,8 @@
 /* Number of epoch markers active */
 #define H5C__MAX_EPOCH_MARKERS                  10
 
-
 /* Cache configuration settings */
 #define H5C__HASH_TABLE_LEN     (64 * 1024) /* must be a power of 2 */
-#define H5C__H5C_T_MAGIC    0x005CAC0E
-
 
 /* Initial allocated size of the "flush_dep_parent" array */
 #define H5C_FLUSH_DEP_PARENT_INIT 8
@@ -548,7 +545,7 @@ if ((new_size) > (dll_size) || ((dll_len) == 1 && (new_size) != (dll_size))) { \
      (entry_ptr)->ht_prev != NULL                                   \
 )
 #define H5C__PRE_HT_SEARCH_SC_CMP(cache_ptr, entry_addr)                  \
-((cache_ptr) == NULL || (cache_ptr)->magic != H5C__H5C_T_MAGIC ||         \
+((cache_ptr) == NULL ||                                                   \
     (cache_ptr)->index_size !=                                            \
        ((cache_ptr)->clean_index_size + (cache_ptr)->dirty_index_size) || \
     !H5F_addr_defined(entry_addr) ||                                      \
@@ -556,8 +553,7 @@ if ((new_size) > (dll_size) || ((dll_len) == 1 && (new_size) != (dll_size))) { \
     H5C__HASH_FCN(entry_addr) >= H5C__HASH_TABLE_LEN                      \
 )
 #define H5C__POST_SUC_HT_SEARCH_SC_CMP(cache_ptr, entry_ptr, k)               \
-((cache_ptr) == NULL || (cache_ptr)->magic != H5C__H5C_T_MAGIC ||             \
-    (cache_ptr)->index_len < 1 ||                                             \
+((cache_ptr) == NULL || (cache_ptr)->index_len < 1 ||                         \
     (entry_ptr) == NULL ||                                                    \
     (cache_ptr)->index_size < (entry_ptr)->size ||                            \
     (cache_ptr)->index_size !=                                                \
@@ -573,7 +569,7 @@ if ((new_size) > (dll_size) || ((dll_len) == 1 && (new_size) != (dll_size))) { \
 #ifdef H5C_DO_SANITY_CHECKS
 
 #define H5C__PRE_HT_INSERT_SC(cache_ptr, entry_ptr, fail_val)           \
-if ((cache_ptr) == NULL || (cache_ptr)->magic != H5C__H5C_T_MAGIC ||    \
+if ((cache_ptr) == NULL ||                                              \
      (entry_ptr) == NULL || !H5F_addr_defined((entry_ptr)->addr) ||     \
      (entry_ptr)->ht_next != NULL || (entry_ptr)->ht_prev != NULL ||    \
      (entry_ptr)->size <= 0 ||                                          \
@@ -597,7 +593,7 @@ if ((cache_ptr) == NULL || (cache_ptr)->magic != H5C__H5C_T_MAGIC ||    \
 }
 
 #define H5C__POST_HT_INSERT_SC(cache_ptr, entry_ptr, fail_val)          \
-if ((cache_ptr) == NULL || (cache_ptr)->magic != H5C__H5C_T_MAGIC ||    \
+if ((cache_ptr) == NULL ||                                              \
      (cache_ptr)->index_size !=                                         \
        ((cache_ptr)->clean_index_size + (cache_ptr)->dirty_index_size) || \
      (cache_ptr)->index_size < (cache_ptr)->clean_index_size ||         \
@@ -615,8 +611,7 @@ if ((cache_ptr) == NULL || (cache_ptr)->magic != H5C__H5C_T_MAGIC ||    \
 }
 
 #define H5C__PRE_HT_REMOVE_SC(cache_ptr, entry_ptr, fail_val)           \
-if ( (cache_ptr) == NULL || (cache_ptr)->magic != H5C__H5C_T_MAGIC ||   \
-     (cache_ptr)->index_len < 1 ||                                      \
+if ( (cache_ptr) == NULL || (cache_ptr)->index_len < 1 ||               \
      (entry_ptr) == NULL ||                                             \
      (cache_ptr)->index_size < (entry_ptr)->size ||                     \
      !H5F_addr_defined((entry_ptr)->addr) ||                            \
@@ -648,7 +643,7 @@ if ( (cache_ptr) == NULL || (cache_ptr)->magic != H5C__H5C_T_MAGIC ||   \
 }
 
 #define H5C__POST_HT_REMOVE_SC(cache_ptr, entry_ptr, fail_val)            \
-if ((cache_ptr) == NULL || (cache_ptr)->magic != H5C__H5C_T_MAGIC ||      \
+if ((cache_ptr) == NULL ||                                                \
      (entry_ptr) == NULL || !H5F_addr_defined((entry_ptr)->addr) ||       \
      (entry_ptr)->size <= 0 ||                                            \
      (entry_ptr)->ht_next != NULL ||                                      \
@@ -735,8 +730,7 @@ if ((cache_ptr) == NULL ||                                                  \
 }
 
 #define H5C__PRE_HT_UPDATE_FOR_ENTRY_CLEAN_SC(cache_ptr, entry_ptr, fail_val) \
-if ((cache_ptr) == NULL || (cache_ptr)->magic != H5C__H5C_T_MAGIC ||          \
-    (cache_ptr)->index_len <= 0 ||                                            \
+if ((cache_ptr) == NULL || (cache_ptr)->index_len <= 0 ||                     \
     (entry_ptr) == NULL || (entry_ptr)->is_dirty != FALSE ||                  \
     (cache_ptr)->index_size < (entry_ptr)->size ||                            \
     (cache_ptr)->dirty_index_size < (entry_ptr)->size ||                      \
@@ -756,8 +750,7 @@ if ((cache_ptr) == NULL || (cache_ptr)->magic != H5C__H5C_T_MAGIC ||          \
 }
 
 #define H5C__PRE_HT_UPDATE_FOR_ENTRY_DIRTY_SC(cache_ptr, entry_ptr, fail_val) \
-if ((cache_ptr) == NULL || (cache_ptr)->magic != H5C__H5C_T_MAGIC ||          \
-    (cache_ptr)->index_len <= 0 ||                                            \
+if ((cache_ptr) == NULL || (cache_ptr)->index_len <= 0 ||                     \
     (entry_ptr) == NULL || (entry_ptr)->is_dirty != TRUE ||                   \
     (cache_ptr)->index_size < (entry_ptr)->size ||                            \
     (cache_ptr)->clean_index_size < (entry_ptr)->size ||                      \
@@ -1031,7 +1024,6 @@ if ((cache_ptr)->index_size != ((cache_ptr)->clean_index_size + (cache_ptr)->dir
 #define H5C__INSERT_ENTRY_IN_SLIST(cache_ptr, entry_ptr, fail_val)             \
 {                                                                              \
     HDassert(cache_ptr);                                                       \
-    HDassert((cache_ptr)->magic == H5C__H5C_T_MAGIC);                          \
                                                                                \
     if((cache_ptr)->slist_enabled) {                                           \
         HDassert(entry_ptr);                                                   \
@@ -1082,7 +1074,6 @@ if ((cache_ptr)->index_size != ((cache_ptr)->clean_index_size + (cache_ptr)->dir
 #define H5C__REMOVE_ENTRY_FROM_SLIST(cache_ptr, entry_ptr, during_flush, fail_val) \
 {                                                                              \
     HDassert(cache_ptr);                                                       \
-    HDassert((cache_ptr)->magic == H5C__H5C_T_MAGIC);                          \
                                                                                \
     if((cache_ptr)->slist_enabled) {                                           \
         HDassert(entry_ptr);                                                   \
@@ -1135,7 +1126,6 @@ if ((cache_ptr)->index_size != ((cache_ptr)->clean_index_size + (cache_ptr)->dir
 #define H5C__UPDATE_SLIST_FOR_SIZE_CHANGE(cache_ptr, old_size, new_size)      \
 {                                                                             \
     HDassert(cache_ptr);                                                      \
-    HDassert((cache_ptr)->magic == H5C__H5C_T_MAGIC);                         \
                                                                               \
     if((cache_ptr)->slist_enabled) {                                          \
         HDassert((old_size) > 0);                                             \
@@ -1396,7 +1386,6 @@ if ((cache_ptr)->index_size != ((cache_ptr)->clean_index_size + (cache_ptr)->dir
 #define H5C__UPDATE_RP_FOR_EVICTION(cache_ptr, entry_ptr, fail_val)          \
 {                                                                            \
     HDassert(cache_ptr);                                                     \
-    HDassert((cache_ptr)->magic == H5C__H5C_T_MAGIC);                        \
     HDassert(entry_ptr);                                                     \
     HDassert(!(entry_ptr)->is_protected);                                    \
     HDassert(!(entry_ptr)->is_read_only);                                    \
@@ -1429,7 +1418,6 @@ if ((cache_ptr)->index_size != ((cache_ptr)->clean_index_size + (cache_ptr)->dir
 #define H5C__UPDATE_RP_FOR_FLUSH(cache_ptr, entry_ptr, fail_val)            \
 {                                                                           \
     HDassert(cache_ptr);                                                    \
-    HDassert((cache_ptr)->magic == H5C__H5C_T_MAGIC);                       \
     HDassert(entry_ptr);                                                    \
     HDassert(!(entry_ptr)->is_protected);                                   \
     HDassert(!(entry_ptr)->is_read_only);                                   \
@@ -1475,7 +1463,6 @@ if ((cache_ptr)->index_size != ((cache_ptr)->clean_index_size + (cache_ptr)->dir
 #define H5C__UPDATE_RP_FOR_INSERT_APPEND(cache_ptr, entry_ptr, fail_val)   \
 {                                                                          \
     HDassert(cache_ptr);                                                   \
-    HDassert((cache_ptr)->magic == H5C__H5C_T_MAGIC);                      \
     HDassert(entry_ptr);                                                   \
     HDassert(!(entry_ptr)->is_protected);                                  \
     HDassert(!(entry_ptr)->is_read_only);                                  \
@@ -1515,7 +1502,6 @@ if ((cache_ptr)->index_size != ((cache_ptr)->clean_index_size + (cache_ptr)->dir
 #define H5C__UPDATE_RP_FOR_INSERTION(cache_ptr, entry_ptr, fail_val)        \
 {                                                                           \
     HDassert(cache_ptr);                                                    \
-    HDassert((cache_ptr)->magic == H5C__H5C_T_MAGIC);                       \
     HDassert(entry_ptr);                                                    \
     HDassert(!(entry_ptr)->is_protected);                                   \
     HDassert(!(entry_ptr)->is_read_only);                                   \
@@ -1561,7 +1547,6 @@ if ((cache_ptr)->index_size != ((cache_ptr)->clean_index_size + (cache_ptr)->dir
 #define H5C__UPDATE_RP_FOR_PROTECT(cache_ptr, entry_ptr, fail_val)        \
 {                                                                         \
     HDassert(cache_ptr);                                                  \
-    HDassert((cache_ptr)->magic == H5C__H5C_T_MAGIC);                     \
     HDassert(entry_ptr);                                                  \
     HDassert(!(entry_ptr)->is_protected);                                 \
     HDassert(!(entry_ptr)->is_read_only);                                 \
@@ -1609,7 +1594,6 @@ if ((cache_ptr)->index_size != ((cache_ptr)->clean_index_size + (cache_ptr)->dir
 #define H5C__UPDATE_RP_FOR_MOVE(cache_ptr, entry_ptr, was_dirty, fail_val)   \
 {                                                                            \
     HDassert(cache_ptr);                                                     \
-    HDassert((cache_ptr)->magic == H5C__H5C_T_MAGIC);                        \
     HDassert(entry_ptr);                                                     \
     HDassert(!(entry_ptr)->is_read_only);                                    \
     HDassert((entry_ptr)->ro_ref_count == 0);                                \
@@ -1678,7 +1662,6 @@ if ((cache_ptr)->index_size != ((cache_ptr)->clean_index_size + (cache_ptr)->dir
 #define H5C__UPDATE_RP_FOR_SIZE_CHANGE(cache_ptr, entry_ptr, new_size, fail_val)    \
 {                                                                         \
     HDassert(cache_ptr);                                                  \
-    HDassert((cache_ptr)->magic == H5C__H5C_T_MAGIC);                     \
     HDassert(entry_ptr);                                                  \
     HDassert(!(entry_ptr)->is_protected);                                 \
     HDassert(!(entry_ptr)->is_read_only);                                 \
@@ -1726,7 +1709,6 @@ if ((cache_ptr)->index_size != ((cache_ptr)->clean_index_size + (cache_ptr)->dir
 #define H5C__UPDATE_RP_FOR_UNPIN(cache_ptr, entry_ptr, fail_val)       \
 {                                                                      \
     HDassert(cache_ptr);                                               \
-    HDassert((cache_ptr)->magic == H5C__H5C_T_MAGIC);                  \
     HDassert(entry_ptr);                                               \
     HDassert(!(entry_ptr)->is_protected);                              \
     HDassert(!(entry_ptr)->is_read_only);                              \
@@ -1771,7 +1753,6 @@ if ((cache_ptr)->index_size != ((cache_ptr)->clean_index_size + (cache_ptr)->dir
 #define H5C__UPDATE_RP_FOR_UNPROTECT(cache_ptr, entry_ptr, fail_val)       \
 {                                                                          \
     HDassert(cache_ptr);                                                   \
-    HDassert((cache_ptr)->magic == H5C__H5C_T_MAGIC);                      \
     HDassert(entry_ptr);                                                   \
     HDassert((entry_ptr)->is_protected);                                   \
     HDassert((entry_ptr)->size > 0);                                       \
@@ -1824,7 +1805,6 @@ if ((cache_ptr)->index_size != ((cache_ptr)->clean_index_size + (cache_ptr)->dir
 #define H5C__INSERT_IN_COLL_LIST(cache_ptr, entry_ptr, fail_val)        \
 {                                                                       \
     HDassert(cache_ptr);                                                \
-    HDassert((cache_ptr)->magic == H5C__H5C_T_MAGIC );                  \
     HDassert(entry_ptr);                                                \
                                                                         \
     /* Insert the entry at the head of the list. */                     \
@@ -1849,7 +1829,6 @@ if ((cache_ptr)->index_size != ((cache_ptr)->clean_index_size + (cache_ptr)->dir
 #define H5C__REMOVE_FROM_COLL_LIST(cache_ptr, entry_ptr, fail_val)      \
 {                                                                       \
     HDassert(cache_ptr);                                                \
-    HDassert((cache_ptr)->magic == H5C__H5C_T_MAGIC);                   \
     HDassert(entry_ptr);                                                \
                                                                         \
     /* Remove the entry from the list. */                               \
@@ -1874,7 +1853,6 @@ if ((cache_ptr)->index_size != ((cache_ptr)->clean_index_size + (cache_ptr)->dir
 #define H5C__MOVE_TO_TOP_IN_COLL_LIST(cache_ptr, entry_ptr, fail_val)   \
 {                                                                       \
     HDassert(cache_ptr);                                                \
-    HDassert((cache_ptr)->magic == H5C__H5C_T_MAGIC);                   \
     HDassert(entry_ptr);                                                \
                                                                         \
     /* Remove entry and insert at the head of the list. */              \
@@ -1947,9 +1925,6 @@ typedef struct H5C_tag_info_t {
  * The cache has a hash table in which all entries are stored.  Given the
  * advantages of flushing entries in increasing address order, a skip list
  * is used to track dirty entries.
- *
- * magic:    Unsigned 32 bit integer always set to H5C__H5C_T_MAGIC.
- *        This field is used to validate pointers to instances of H5C_t.
  *
  * flush_in_progress: Boolean flag indicating whether a flush is in progress.
  *
@@ -3017,9 +2992,7 @@ typedef struct H5C_tag_info_t {
  *        NDEBUG is not #defined.
  *
  ****************************************************************************/
-
 struct H5C_t {
-    uint32_t            magic;
     hbool_t             flush_in_progress;
     H5C_log_info_t *    log_info;
     void *              aux_ptr;

--- a/src/H5Cprefetched.c
+++ b/src/H5Cprefetched.c
@@ -211,7 +211,6 @@ H5C__prefetched_entry_notify(H5C_notify_action_t action, void *_thing)
 
     /* Sanity checks */
     HDassert(entry_ptr);
-    HDassert(entry_ptr->magic == H5C__H5C_CACHE_ENTRY_T_MAGIC);
     HDassert(entry_ptr->prefetched);
 
     switch (action) {
@@ -235,7 +234,6 @@ H5C__prefetched_entry_notify(H5C_notify_action_t action, void *_thing)
                 HDassert(entry_ptr->flush_dep_parent);
                 parent_ptr = entry_ptr->flush_dep_parent[u];
                 HDassert(parent_ptr);
-                HDassert(parent_ptr->magic == H5C__H5C_CACHE_ENTRY_T_MAGIC);
                 HDassert(parent_ptr->flush_dep_nchildren > 0);
 
                 /* Destroy flush dependency with flush dependency parent */
@@ -289,7 +287,6 @@ H5C__prefetched_entry_free_icr(void *_thing)
 
     /* Sanity checks */
     HDassert(entry_ptr);
-    HDassert(entry_ptr->magic == H5C__H5C_CACHE_ENTRY_T_BAD_MAGIC);
     HDassert(entry_ptr->prefetched);
 
     /* Release array for flush dependency parent addresses */

--- a/src/H5Cprivate.h
+++ b/src/H5Cprivate.h
@@ -87,10 +87,6 @@
 #define H5C__DEFAULT_MAX_CACHE_SIZE ((size_t)(4 * 1024 * 1024))
 #define H5C__DEFAULT_MIN_CLEAN_SIZE ((size_t)(2 * 1024 * 1024))
 
-/* Values for cache entry magic field */
-#define H5C__H5C_CACHE_ENTRY_T_MAGIC     0x005CAC0A
-#define H5C__H5C_CACHE_ENTRY_T_BAD_MAGIC 0xDeadBeef
-
 /* Cache configuration validation definitions */
 #define H5C_RESIZE_CFG__VALIDATE_GENERAL      0x1
 #define H5C_RESIZE_CFG__VALIDATE_INCREMENT    0x2
@@ -976,25 +972,6 @@ typedef int H5C_ring_t;
  *
  * The fields of this structure are discussed individually below:
  *
- * magic:    Unsigned 32 bit integer that must always be set to
- *              H5C__H5C_CACHE_ENTRY_T_MAGIC when the entry is valid.
- *              The field must be set to H5C__H5C_CACHE_ENTRY_T_BAD_MAGIC
- *              just before the entry is freed.
- *
- *              This is necessary, as the LRU list can be changed out
- *              from under H5C__make_space_in_cache() by the serialize
- *              callback which may change the size of an existing entry,
- *              and/or load a new entry while serializing the target entry.
- *
- *              This in turn can cause a recursive call to
- *              H5C__make_space_in_cache() which may either flush or evict
- *              the next entry that the first invocation of that function
- *              was about to examine.
- *
- *              The magic field allows H5C__make_space_in_cache() to
- *              detect this case, and re-start its scan from the bottom
- *              of the LRU when this situation occurs.
- *
  * cache_ptr:    Pointer to the cache that this entry is contained within.
  *
  * addr:    Base address of the cache entry on disk.
@@ -1570,7 +1547,6 @@ typedef int H5C_ring_t;
  *
  ****************************************************************************/
 typedef struct H5C_cache_entry_t {
-    uint32_t           magic;
     H5C_t             *cache_ptr;
     haddr_t            addr;
     size_t             size;
@@ -1667,11 +1643,6 @@ typedef struct H5C_cache_entry_t {
  * of H5C_cache_entry_t.
  *
  * The fields of this structure are discussed individually below:
- *
- * magic:    Unsigned 32 bit integer that must always be set to
- *              H5C_IMAGE_ENTRY_T_MAGIC when the entry is valid.
- *              The field must be set to H5C_IMAGE_ENTRY_T_BAD_MAGIC
- *              just before the entry is freed.
  *
  * addr:    Base address of the cache entry on disk.
  *
@@ -1796,11 +1767,8 @@ typedef struct H5C_cache_entry_t {
  *               callbacks must be used to update this image before it is
  *               written to disk
  *
- *
  ****************************************************************************/
-
 typedef struct H5C_image_entry_t {
-    uint32_t   magic;
     haddr_t    addr;
     size_t     size;
     H5C_ring_t ring;

--- a/src/H5Cquery.c
+++ b/src/H5Cquery.c
@@ -82,7 +82,7 @@ H5C_get_cache_auto_resize_config(const H5C_t *cache_ptr, H5C_auto_size_ctl_t *co
 
     FUNC_ENTER_NOAPI(FAIL)
 
-    if ((cache_ptr == NULL) || (cache_ptr->magic != H5C__H5C_T_MAGIC))
+    if (cache_ptr == NULL)
         HGOTO_ERROR(H5E_CACHE, H5E_SYSTEM, FAIL, "Bad cache_ptr on entry.")
     if (config_ptr == NULL)
         HGOTO_ERROR(H5E_CACHE, H5E_SYSTEM, FAIL, "Bad config_ptr on entry.")
@@ -120,7 +120,7 @@ H5C_get_cache_size(const H5C_t *cache_ptr, size_t *max_size_ptr, size_t *min_cle
 
     FUNC_ENTER_NOAPI(FAIL)
 
-    if ((cache_ptr == NULL) || (cache_ptr->magic != H5C__H5C_T_MAGIC))
+    if (cache_ptr == NULL)
         HGOTO_ERROR(H5E_CACHE, H5E_SYSTEM, FAIL, "Bad cache_ptr on entry.")
 
     if (max_size_ptr != NULL)
@@ -156,7 +156,7 @@ H5C_get_cache_flush_in_progress(const H5C_t *cache_ptr, hbool_t *flush_in_progre
 
     FUNC_ENTER_NOAPI(FAIL)
 
-    if ((cache_ptr == NULL) || (cache_ptr->magic != H5C__H5C_T_MAGIC))
+    if (cache_ptr == NULL)
         HGOTO_ERROR(H5E_CACHE, H5E_SYSTEM, FAIL, "Bad cache_ptr on entry.")
 
     if (flush_in_progress_ptr != NULL)
@@ -189,7 +189,7 @@ H5C_get_cache_hit_rate(const H5C_t *cache_ptr, double *hit_rate_ptr)
 
     FUNC_ENTER_NOAPI(FAIL)
 
-    if ((cache_ptr == NULL) || (cache_ptr->magic != H5C__H5C_T_MAGIC))
+    if (cache_ptr == NULL)
         HGOTO_ERROR(H5E_CACHE, H5E_SYSTEM, FAIL, "Bad cache_ptr on entry.")
     if (hit_rate_ptr == NULL)
         HGOTO_ERROR(H5E_CACHE, H5E_SYSTEM, FAIL, "Bad hit_rate_ptr on entry.")
@@ -242,18 +242,12 @@ H5C_get_entry_status(const H5F_t *f, haddr_t addr, size_t *size_ptr, hbool_t *in
     /* Sanity checks */
     HDassert(f);
     HDassert(f->shared);
-
     cache_ptr = f->shared->cache;
-
     HDassert(cache_ptr != NULL);
-    HDassert(cache_ptr->magic == H5C__H5C_T_MAGIC);
     HDassert(H5F_addr_defined(addr));
     HDassert(in_cache_ptr != NULL);
 
-    /* this test duplicates two of the above asserts, but we need an
-     * invocation of HGOTO_ERROR to keep the compiler happy.
-     */
-    if ((cache_ptr == NULL) || (cache_ptr->magic != H5C__H5C_T_MAGIC))
+    if (cache_ptr == NULL)
         HGOTO_ERROR(H5E_CACHE, H5E_SYSTEM, FAIL, "Bad cache_ptr on entry.")
 
     H5C__SEARCH_INDEX(cache_ptr, addr, entry_ptr, FAIL)
@@ -308,7 +302,7 @@ H5C_get_evictions_enabled(const H5C_t *cache_ptr, hbool_t *evictions_enabled_ptr
 
     FUNC_ENTER_NOAPI(FAIL)
 
-    if ((cache_ptr == NULL) || (cache_ptr->magic != H5C__H5C_T_MAGIC))
+    if (cache_ptr == NULL)
         HGOTO_ERROR(H5E_CACHE, H5E_SYSTEM, FAIL, "Bad cache_ptr on entry.")
 
     if (evictions_enabled_ptr == NULL)
@@ -342,7 +336,6 @@ H5C_get_aux_ptr(const H5C_t *cache_ptr)
 
     /* Check arguments */
     HDassert(cache_ptr);
-    HDassert(cache_ptr->magic == H5C__H5C_T_MAGIC);
 
     FUNC_LEAVE_NOAPI(cache_ptr->aux_ptr)
 } /* H5C_get_aux_ptr() */
@@ -376,7 +369,6 @@ H5C_get_entry_ring(const H5F_t *f, haddr_t addr, H5C_ring_t *ring)
     HDassert(f->shared);
     cache_ptr = f->shared->cache;
     HDassert(cache_ptr);
-    HDassert(cache_ptr->magic == H5C__H5C_T_MAGIC);
     HDassert(H5F_addr_defined(addr));
 
     /* Locate the entry at the address */
@@ -409,7 +401,7 @@ H5C_get_mdc_image_info(const H5C_t *cache_ptr, haddr_t *image_addr, hsize_t *ima
 
     FUNC_ENTER_NOAPI(FAIL)
 
-    if ((cache_ptr == NULL) || (cache_ptr->magic != H5C__H5C_T_MAGIC))
+    if (cache_ptr == NULL)
         HGOTO_ERROR(H5E_CACHE, H5E_BADVALUE, FAIL, "bad cache_ptr on entry")
 
     if (image_addr)

--- a/src/H5Ctag.c
+++ b/src/H5Ctag.c
@@ -126,7 +126,6 @@ H5C_ignore_tags(H5C_t *cache)
 
     /* Assertions */
     HDassert(cache != NULL);
-    HDassert(cache->magic == H5C__H5C_T_MAGIC);
 
     /* Set variable to ignore tag values upon assignment */
     cache->ignore_tags = TRUE;
@@ -153,7 +152,6 @@ H5C_get_ignore_tags(const H5C_t *cache)
 
     /* Sanity checks */
     HDassert(cache);
-    HDassert(cache->magic == H5C__H5C_T_MAGIC);
 
     /* Return ignore tag value */
     FUNC_LEAVE_NOAPI(cache->ignore_tags)
@@ -177,7 +175,6 @@ H5C_get_num_objs_corked(const H5C_t *cache)
 
     /* Sanity checks */
     HDassert(cache);
-    HDassert(cache->magic == H5C__H5C_T_MAGIC);
 
     /* Return value for num_objs_corked */
     FUNC_LEAVE_NOAPI(cache->num_objs_corked)
@@ -210,7 +207,6 @@ H5C__tag_entry(H5C_t *cache, H5C_cache_entry_t *entry)
     /* Assertions */
     HDassert(cache != NULL);
     HDassert(entry != NULL);
-    HDassert(cache->magic == H5C__H5C_T_MAGIC);
 
     /* Get the tag */
     tag = H5CX_get_tag();
@@ -293,7 +289,6 @@ H5C__untag_entry(H5C_t *cache, H5C_cache_entry_t *entry)
     /* Assertions */
     HDassert(cache != NULL);
     HDassert(entry != NULL);
-    HDassert(cache->magic == H5C__H5C_T_MAGIC);
 
     /* Get the entry's tag info struct */
     if (NULL != (tag_info = entry->tag_info)) {
@@ -350,7 +345,6 @@ H5C__iter_tagged_entries_real(H5C_t *cache, haddr_t tag, H5C_tag_iter_cb_t cb, v
 
     /* Sanity checks */
     HDassert(cache != NULL);
-    HDassert(cache->magic == H5C__H5C_T_MAGIC);
 
     /* Search the list of tagged object addresses in the cache */
     HASH_FIND(hh, cache->tag_list, &tag, sizeof(haddr_t), tag_info);
@@ -405,7 +399,6 @@ H5C__iter_tagged_entries(H5C_t *cache, haddr_t tag, hbool_t match_global, H5C_ta
 
     /* Sanity checks */
     HDassert(cache != NULL);
-    HDassert(cache->magic == H5C__H5C_T_MAGIC);
 
     /* Iterate over the entries for this tag */
     if (H5C__iter_tagged_entries_real(cache, tag, cb, cb_ctx) < 0)
@@ -503,7 +496,6 @@ H5C_evict_tagged_entries(H5F_t *f, haddr_t tag, hbool_t match_global)
     HDassert(f->shared);
     cache = f->shared->cache; /* Get cache pointer */
     HDassert(cache != NULL);
-    HDassert(cache->magic == H5C__H5C_T_MAGIC);
 
     /* Construct context for iterator callbacks */
     ctx.f = f;
@@ -606,7 +598,6 @@ H5C__mark_tagged_entries(H5C_t *cache, haddr_t tag)
 
     /* Sanity check */
     HDassert(cache);
-    HDassert(cache->magic == H5C__H5C_T_MAGIC);
 
     /* Iterate through hash table entries, marking those with specified tag, as
      * well as any major global entries which should always be flushed
@@ -875,7 +866,6 @@ H5C_expunge_tag_type_metadata(H5F_t *f, haddr_t tag, int type_id, unsigned flags
     HDassert(f->shared);
     cache = f->shared->cache; /* Get cache pointer */
     HDassert(cache != NULL);
-    HDassert(cache->magic == H5C__H5C_T_MAGIC);
 
     /* Construct context for iterator callbacks */
     ctx.f       = f;

--- a/src/H5EAcache.c
+++ b/src/H5EAcache.c
@@ -1900,7 +1900,6 @@ H5EA__cache_dblock_fsf_size(const void *_thing, hsize_t *fsf_size)
 
     /* Check arguments */
     HDassert(dblock);
-    HDassert(dblock->cache_info.magic == H5C__H5C_CACHE_ENTRY_T_MAGIC);
     HDassert(dblock->cache_info.type == H5AC_EARRAY_DBLOCK);
     HDassert(fsf_size);
 

--- a/src/H5FAcache.c
+++ b/src/H5FAcache.c
@@ -972,7 +972,6 @@ H5FA__cache_dblock_fsf_size(const void *_thing, hsize_t *fsf_size)
 
     /* Check arguments */
     HDassert(dblock);
-    HDassert(dblock->cache_info.magic == H5C__H5C_CACHE_ENTRY_T_MAGIC);
     HDassert(dblock->cache_info.type == H5AC_FARRAY_DBLOCK);
     HDassert(fsf_size);
 

--- a/src/H5FScache.c
+++ b/src/H5FScache.c
@@ -343,7 +343,6 @@ H5FS__cache_hdr_image_len(const void *_thing, size_t *image_len)
 
     /* Check arguments */
     HDassert(fspace);
-    HDassert(fspace->cache_info.magic == H5C__H5C_CACHE_ENTRY_T_MAGIC);
     HDassert(fspace->cache_info.type == H5AC_FSPACE_HDR);
     HDassert(image_len);
 
@@ -394,7 +393,6 @@ H5FS__cache_hdr_pre_serialize(H5F_t *f, void *_thing, haddr_t addr, size_t H5_AT
     /* Sanity check */
     HDassert(f);
     HDassert(fspace);
-    HDassert(fspace->cache_info.magic == H5C__H5C_CACHE_ENTRY_T_MAGIC);
     HDassert(fspace->cache_info.type == H5AC_FSPACE_HDR);
     HDassert(H5F_addr_defined(addr));
     HDassert(new_addr);
@@ -693,7 +691,6 @@ H5FS__cache_hdr_serialize(const H5F_t *f, void *_image, size_t H5_ATTR_NDEBUG_UN
     HDassert(f);
     HDassert(image);
     HDassert(fspace);
-    HDassert(fspace->cache_info.magic == H5C__H5C_CACHE_ENTRY_T_MAGIC);
     HDassert(fspace->cache_info.type == H5AC_FSPACE_HDR);
     HDassert(fspace->hdr_size == len);
 
@@ -833,10 +830,6 @@ done:
  *
  * Purpose:	Destroys a free space header in memory.
  *
- * Note:	The metadata cache sets the object's cache_info.magic to
- *		H5C__H5C_CACHE_ENTRY_T_BAD_MAGIC before calling a free_icr
- *		callback (checked in assert).
- *
  * Return:	Success:        SUCCEED
  *              Failure:        FAIL
  *
@@ -855,7 +848,6 @@ H5FS__cache_hdr_free_icr(void *_thing)
 
     /* Sanity checks */
     HDassert(fspace);
-    HDassert(fspace->cache_info.magic == H5C__H5C_CACHE_ENTRY_T_BAD_MAGIC);
     HDassert(fspace->cache_info.type == H5AC_FSPACE_HDR);
 
     /* We should not still be holding on to the free space section info */
@@ -1124,10 +1116,8 @@ H5FS__cache_sinfo_image_len(const void *_thing, size_t *image_len)
 
     /* Sanity checks */
     HDassert(sinfo);
-    HDassert(sinfo->cache_info.magic == H5C__H5C_CACHE_ENTRY_T_MAGIC);
     HDassert(sinfo->cache_info.type == H5AC_FSPACE_SINFO);
     HDassert(sinfo->fspace);
-    HDassert(sinfo->fspace->cache_info.magic == H5C__H5C_CACHE_ENTRY_T_MAGIC);
     HDassert(sinfo->fspace->cache_info.type == H5AC_FSPACE_HDR);
     HDassert(image_len);
 
@@ -1167,10 +1157,8 @@ H5FS__cache_sinfo_pre_serialize(H5F_t *f, void *_thing, haddr_t addr, size_t H5_
     /* Sanity checks */
     HDassert(f);
     HDassert(sinfo);
-    HDassert(sinfo->cache_info.magic == H5C__H5C_CACHE_ENTRY_T_MAGIC);
     HDassert(sinfo->cache_info.type == H5AC_FSPACE_SINFO);
     fspace = sinfo->fspace;
-    HDassert(fspace->cache_info.magic == H5C__H5C_CACHE_ENTRY_T_MAGIC);
     HDassert(fspace->cache_info.type == H5AC_FSPACE_HDR);
     HDassert(fspace->cache_info.is_pinned);
     HDassert(H5F_addr_defined(addr));
@@ -1253,9 +1241,7 @@ H5FS__cache_sinfo_serialize(const H5F_t *f, void *_image, size_t len, void *_thi
     HDassert(f);
     HDassert(image);
     HDassert(sinfo);
-    HDassert(sinfo->cache_info.magic == H5C__H5C_CACHE_ENTRY_T_MAGIC);
     HDassert(sinfo->cache_info.type == H5AC_FSPACE_SINFO);
-    HDassert(sinfo->fspace->cache_info.magic == H5C__H5C_CACHE_ENTRY_T_MAGIC);
     HDassert(sinfo->fspace->cache_info.type == H5AC_FSPACE_HDR);
     HDassert(sinfo->fspace->cache_info.is_pinned);
     HDassert(sinfo->fspace->sect_size == len);
@@ -1373,10 +1359,6 @@ done:
  * Purpose:	Free the memory used for the in core representation of the
  *		free space manager section info.
  *
- * Note:	The metadata cache sets the object's cache_info.magic to
- *		H5C__H5C_CACHE_ENTRY_T_BAD_MAGIC before calling a free_icr
- *		callback (checked in assert).
- *
  * Return:	Success:	SUCCEED
  *		Failure:	FAIL
  *
@@ -1395,9 +1377,7 @@ H5FS__cache_sinfo_free_icr(void *_thing)
 
     /* Sanity checks */
     HDassert(sinfo);
-    HDassert(sinfo->cache_info.magic == H5C__H5C_CACHE_ENTRY_T_BAD_MAGIC);
     HDassert(sinfo->cache_info.type == H5AC_FSPACE_SINFO);
-    HDassert(sinfo->fspace->cache_info.magic == H5C__H5C_CACHE_ENTRY_T_MAGIC);
     HDassert(sinfo->fspace->cache_info.type == H5AC_FSPACE_HDR);
     HDassert(sinfo->fspace->cache_info.is_pinned);
 

--- a/src/H5Fsuper.c
+++ b/src/H5Fsuper.c
@@ -248,7 +248,6 @@ H5F__update_super_ext_driver_msg(H5F_t *f)
     HDassert(f->shared);
     sblock = f->shared->sblock;
     HDassert(sblock);
-    HDassert(sblock->cache_info.magic == H5C__H5C_CACHE_ENTRY_T_MAGIC);
     HDassert(sblock->cache_info.type == H5AC_SUPERBLOCK);
 
     /* Update the driver information message in the superblock extension

--- a/src/H5Fsuper_cache.c
+++ b/src/H5Fsuper_cache.c
@@ -633,7 +633,6 @@ H5F__cache_superblock_image_len(const void *_thing, size_t *image_len)
     FUNC_ENTER_PACKAGE_NOERR
 
     HDassert(sblock);
-    HDassert(sblock->cache_info.magic == H5C__H5C_CACHE_ENTRY_T_MAGIC);
     HDassert(sblock->cache_info.type == H5AC_SUPERBLOCK);
     HDassert(image_len);
 
@@ -780,10 +779,6 @@ done:
  * Purpose:     Destroy/release an "in core representation" of a data
  *              structure
  *
- * Note:        The metadata cache sets the object's cache_info.magic to
- *              H5C__H5C_CACHE_ENTRY_T_BAD_MAGIC before calling a free_icr
- *              callback (checked in assert).
- *
  * Return:      SUCCEED/FAIL
  *-------------------------------------------------------------------------
  */
@@ -796,7 +791,6 @@ H5F__cache_superblock_free_icr(void *_thing)
     FUNC_ENTER_PACKAGE
 
     HDassert(sblock);
-    HDassert(sblock->cache_info.magic == H5C__H5C_CACHE_ENTRY_T_BAD_MAGIC);
     HDassert(sblock->cache_info.type == H5AC_SUPERBLOCK);
 
     /* Destroy superblock */
@@ -933,7 +927,6 @@ H5F__cache_drvrinfo_image_len(const void *_thing, size_t *image_len)
     FUNC_ENTER_PACKAGE_NOERR
 
     HDassert(drvinfo);
-    HDassert(drvinfo->cache_info.magic == H5C__H5C_CACHE_ENTRY_T_MAGIC);
     HDassert(drvinfo->cache_info.type == H5AC_DRVRINFO);
     HDassert(image_len);
 
@@ -965,7 +958,6 @@ H5F__cache_drvrinfo_serialize(const H5F_t *f, void *_image, size_t H5_ATTR_NDEBU
     HDassert(f);
     HDassert(image);
     HDassert(drvinfo);
-    HDassert(drvinfo->cache_info.magic == H5C__H5C_CACHE_ENTRY_T_MAGIC);
     HDassert(drvinfo->cache_info.type == H5AC_DRVRINFO);
     HDassert(len == (size_t)(H5F_DRVINFOBLOCK_HDR_SIZE + drvinfo->len));
 
@@ -1001,10 +993,6 @@ done:
  * Purpose:     Destroy/release an "in core representation" of a data
  *              structure
  *
- * Note:        The metadata cache sets the object's cache_info.magic to
- *              H5C__H5C_CACHE_ENTRY_T_BAD_MAGIC before calling a free_icr
- *              callback (checked in assert).
- *
  * Return:      SUCCEED/FAIL
  *-------------------------------------------------------------------------
  */
@@ -1016,7 +1004,6 @@ H5F__cache_drvrinfo_free_icr(void *_thing)
     FUNC_ENTER_PACKAGE_NOERR
 
     HDassert(drvinfo);
-    HDassert(drvinfo->cache_info.magic == H5C__H5C_CACHE_ENTRY_T_BAD_MAGIC);
     HDassert(drvinfo->cache_info.type == H5AC_DRVRINFO);
 
     /* Destroy driver info message */

--- a/src/H5Gcache.c
+++ b/src/H5Gcache.c
@@ -216,7 +216,6 @@ H5G__cache_node_image_len(const void *_thing, size_t *image_len)
     FUNC_ENTER_PACKAGE_NOERR
 
     HDassert(sym);
-    HDassert(sym->cache_info.magic == H5C__H5C_CACHE_ENTRY_T_MAGIC);
     HDassert(sym->cache_info.type == H5AC_SNODE);
     HDassert(image_len);
 
@@ -248,7 +247,6 @@ H5G__cache_node_serialize(const H5F_t *f, void *_image, size_t len, void *_thing
     HDassert(f);
     HDassert(image);
     HDassert(sym);
-    HDassert(sym->cache_info.magic == H5C__H5C_CACHE_ENTRY_T_MAGIC);
     HDassert(sym->cache_info.type == H5AC_SNODE);
     HDassert(len == sym->node_size);
 
@@ -281,10 +279,6 @@ done:
  *
  * Purpose:     Destroy a symbol table node in memory
  *
- * Note:        The metadata cache sets the object's cache_info.magic to
- *              H5C__H5C_CACHE_ENTRY_T_BAD_MAGIC before calling a free_icr
- *              callback (checked in assert).
- *
  * Return:      SUCCEED/FAIL
  *-------------------------------------------------------------------------
  */
@@ -297,7 +291,6 @@ H5G__cache_node_free_icr(void *_thing)
     FUNC_ENTER_PACKAGE
 
     HDassert(sym);
-    HDassert(sym->cache_info.magic == H5C__H5C_CACHE_ENTRY_T_BAD_MAGIC);
     HDassert(sym->cache_info.type == H5AC_SNODE);
 
     /* Destroy symbol table node */

--- a/src/H5HFcache.c
+++ b/src/H5HFcache.c
@@ -606,7 +606,6 @@ H5HF__cache_hdr_image_len(const void *_thing, size_t *image_len)
 
     /* Sanity checks */
     HDassert(hdr);
-    HDassert(hdr->cache_info.magic == H5C__H5C_CACHE_ENTRY_T_MAGIC);
     HDassert(hdr->cache_info.type == H5AC_FHEAP_HDR);
     HDassert(image_len);
 
@@ -648,7 +647,6 @@ H5HF__cache_hdr_pre_serialize(H5F_t *f, void *_thing, haddr_t addr, size_t len,
     /* Sanity checks */
     HDassert(f);
     HDassert(hdr);
-    HDassert(hdr->cache_info.magic == H5C__H5C_CACHE_ENTRY_T_MAGIC);
     HDassert(hdr->cache_info.type == H5AC_FHEAP_HDR);
     HDassert(H5F_addr_defined(addr));
     HDassert(addr == hdr->heap_addr);
@@ -736,7 +734,6 @@ H5HF__cache_hdr_serialize(const H5F_t *f, void *_image, size_t H5_ATTR_NDEBUG_UN
     HDassert(f);
     HDassert(image);
     HDassert(hdr);
-    HDassert(hdr->cache_info.magic == H5C__H5C_CACHE_ENTRY_T_MAGIC);
     HDassert(hdr->cache_info.type == H5AC_FHEAP_HDR);
     HDassert(len == hdr->heap_size);
 
@@ -828,10 +825,6 @@ done:
  *		This routine also does not free the file space that may
  *		be allocated to the header.
  *
- * Note:	The metadata cache sets the object's cache_info.magic to
- *		H5C__H5C_CACHE_ENTRY_T_BAD_MAGIC before calling a free_icr
- *		callback (checked in assert).
- *
  * Return:	Success:	SUCCEED
  *		Failure:	FAIL
  *
@@ -850,7 +843,6 @@ H5HF__cache_hdr_free_icr(void *_thing)
 
     /* Sanity checks */
     HDassert(hdr);
-    HDassert(hdr->cache_info.magic == H5C__H5C_CACHE_ENTRY_T_BAD_MAGIC);
     HDassert(hdr->cache_info.type == H5AC_FHEAP_HDR);
     HDassert(hdr->rc == 0);
 
@@ -1147,7 +1139,6 @@ H5HF__cache_iblock_image_len(const void *_thing, size_t *image_len)
 
     /* Sanity checks */
     HDassert(iblock);
-    HDassert(iblock->cache_info.magic == H5C__H5C_CACHE_ENTRY_T_MAGIC);
     HDassert(iblock->cache_info.type == H5AC_FHEAP_IBLOCK);
     HDassert(image_len);
 
@@ -1189,7 +1180,6 @@ H5HF__cache_iblock_pre_serialize(H5F_t *f, void *_thing, haddr_t addr, size_t H5
     /* Sanity checks */
     HDassert(f);
     HDassert(iblock);
-    HDassert(iblock->cache_info.magic == H5C__H5C_CACHE_ENTRY_T_MAGIC);
     HDassert(iblock->cache_info.type == H5AC_FHEAP_IBLOCK);
     HDassert(iblock->cache_info.size == iblock->size);
     HDassert(H5F_addr_defined(addr));
@@ -1199,7 +1189,6 @@ H5HF__cache_iblock_pre_serialize(H5F_t *f, void *_thing, haddr_t addr, size_t H5
     HDassert(flags);
     hdr = iblock->hdr;
     HDassert(hdr);
-    HDassert(hdr->cache_info.magic == H5C__H5C_CACHE_ENTRY_T_MAGIC);
     HDassert(hdr->cache_info.type == H5AC_FHEAP_HDR);
 
 #ifndef NDEBUG
@@ -1318,7 +1307,6 @@ H5HF__cache_iblock_serialize(const H5F_t *f, void *_image, size_t H5_ATTR_NDEBUG
     HDassert(f);
     HDassert(image);
     HDassert(iblock);
-    HDassert(iblock->cache_info.magic == H5C__H5C_CACHE_ENTRY_T_MAGIC);
     HDassert(iblock->cache_info.type == H5AC_FHEAP_IBLOCK);
     HDassert(iblock->cache_info.size == iblock->size);
     HDassert(len == iblock->size);
@@ -1431,7 +1419,6 @@ H5HF__cache_iblock_notify(H5AC_notify_action_t action, void *_thing)
 
     /* Sanity checks */
     HDassert(iblock);
-    HDassert(iblock->cache_info.magic == H5C__H5C_CACHE_ENTRY_T_MAGIC);
     HDassert(iblock->cache_info.type == H5AC_FHEAP_IBLOCK);
     HDassert(iblock->hdr);
 
@@ -1508,10 +1495,6 @@ done:
  * Purpose:	Unlink the supplied instance of H5HF_indirect_t from the
  *		fractal heap and free its memory.
  *
- * Note:	The metadata cache sets the object's cache_info.magic to
- *		H5C__H5C_CACHE_ENTRY_T_BAD_MAGIC before calling a free_icr
- *		callback (checked in assert).
- *
  * Return:	Success:	SUCCEED
  *		Failure:	FAIL
  *
@@ -1530,7 +1513,6 @@ H5HF__cache_iblock_free_icr(void *thing)
 
     /* Sanity checks */
     HDassert(iblock);
-    HDassert(iblock->cache_info.magic == H5C__H5C_CACHE_ENTRY_T_BAD_MAGIC);
     HDassert(iblock->cache_info.type == H5AC_FHEAP_IBLOCK);
     HDassert(iblock->rc == 0);
     HDassert(iblock->hdr);
@@ -1757,7 +1739,6 @@ H5HF__cache_dblock_deserialize(const void *_image, size_t len, void *_udata, hbo
     HDassert(par_info);
     hdr = par_info->hdr;
     HDassert(hdr);
-    HDassert(hdr->cache_info.magic == H5C__H5C_CACHE_ENTRY_T_MAGIC);
     HDassert(hdr->cache_info.type == H5AC_FHEAP_HDR);
     HDassert(dirty);
 
@@ -1928,7 +1909,6 @@ H5HF__cache_dblock_image_len(const void *_thing, size_t *image_len)
 
     /* Sanity checks */
     HDassert(dblock);
-    HDassert(dblock->cache_info.magic == H5C__H5C_CACHE_ENTRY_T_MAGIC);
     HDassert(dblock->cache_info.type == H5AC_FHEAP_DBLOCK);
     HDassert(image_len);
 
@@ -2071,7 +2051,6 @@ H5HF__cache_dblock_pre_serialize(H5F_t *f, void *_thing, haddr_t addr, size_t le
     /* Sanity checks */
     HDassert(f);
     HDassert(dblock);
-    HDassert(dblock->cache_info.magic == H5C__H5C_CACHE_ENTRY_T_MAGIC);
     HDassert(dblock->cache_info.type == H5AC_FHEAP_DBLOCK);
     HDassert(dblock->write_buf == NULL);
     HDassert(dblock->write_size == 0);
@@ -2089,7 +2068,6 @@ H5HF__cache_dblock_pre_serialize(H5F_t *f, void *_thing, haddr_t addr, size_t le
     hdr->f = (H5F_t *)f;
 
     HDassert(hdr);
-    HDassert(hdr->cache_info.magic == H5C__H5C_CACHE_ENTRY_T_MAGIC);
     HDassert(hdr->cache_info.type == H5AC_FHEAP_HDR);
 
     if (dblock->parent) {
@@ -2102,7 +2080,6 @@ H5HF__cache_dblock_pre_serialize(H5F_t *f, void *_thing, haddr_t addr, size_t le
         par_iblock = dblock->parent;
         par_entry  = dblock->par_entry;
 
-        HDassert(par_iblock->cache_info.magic == H5C__H5C_CACHE_ENTRY_T_MAGIC);
         HDassert(par_iblock->cache_info.type == H5AC_FHEAP_IBLOCK);
         HDassert(H5F_addr_eq(par_iblock->ents[par_entry].addr, addr));
     } /* end if */
@@ -2437,7 +2414,6 @@ H5HF__cache_dblock_serialize(const H5F_t H5_ATTR_NDEBUG_UNUSED *f, void *image,
     HDassert(image);
     HDassert(len > 0);
     HDassert(dblock);
-    HDassert(dblock->cache_info.magic == H5C__H5C_CACHE_ENTRY_T_MAGIC);
     HDassert(dblock->cache_info.type == H5AC_FHEAP_DBLOCK);
     HDassert((dblock->blk != dblock->write_buf) || (dblock->cache_info.size == dblock->size));
     HDassert(dblock->write_buf);
@@ -2485,7 +2461,6 @@ H5HF__cache_dblock_notify(H5AC_notify_action_t action, void *_thing)
 
     /* Sanity checks */
     HDassert(dblock);
-    HDassert(dblock->cache_info.magic == H5C__H5C_CACHE_ENTRY_T_MAGIC);
     HDassert(dblock->cache_info.type == H5AC_FHEAP_DBLOCK);
     HDassert(dblock->hdr);
 
@@ -2532,10 +2507,6 @@ done:
  * Purpose:	Free the in core memory allocated to the supplied direct
  *		block.
  *
- * Note:	The metadata cache sets the object's cache_info.magic to
- *		H5C__H5C_CACHE_ENTRY_T_BAD_MAGIC before calling a free_icr
- *		callback (checked in assert).
- *
  * Return:	Success:	SUCCEED
  *		Failure:	FAIL
  *
@@ -2554,7 +2525,6 @@ H5HF__cache_dblock_free_icr(void *_thing)
 
     /* Sanity checks */
     HDassert(dblock);
-    HDassert(dblock->cache_info.magic == H5C__H5C_CACHE_ENTRY_T_BAD_MAGIC);
     HDassert(dblock->cache_info.type == H5AC_FHEAP_DBLOCK);
 
     /* Destroy fractal heap direct block */
@@ -2589,7 +2559,6 @@ H5HF__cache_dblock_fsf_size(const void *_thing, hsize_t *fsf_size)
 
     /* Sanity checks */
     HDassert(dblock);
-    HDassert(dblock->cache_info.magic == H5C__H5C_CACHE_ENTRY_T_MAGIC);
     HDassert(dblock->cache_info.type == H5AC_FHEAP_DBLOCK);
     HDassert(dblock->file_size > 0);
     HDassert(fsf_size);
@@ -2677,7 +2646,6 @@ H5HF__cache_verify_hdr_descendants_clean(H5F_t *f, H5HF_hdr_t *hdr, hbool_t *fd_
     /* Sanity checks */
     HDassert(f);
     HDassert(hdr);
-    HDassert(hdr->cache_info.magic == H5C__H5C_CACHE_ENTRY_T_MAGIC);
     HDassert(hdr->cache_info.type == H5AC_FHEAP_HDR);
     HDassert(fd_clean);
     HDassert(clean);
@@ -2884,7 +2852,6 @@ H5HF__cache_verify_hdr_descendants_clean(H5F_t *f, H5HF_hdr_t *hdr, hbool_t *fd_
              * in memory for the duration of the call.  Do some sanity checks,
              * and then call H5HF__cache_verify_iblock_descendants_clean().
              */
-            HDassert(root_iblock->cache_info.magic == H5C__H5C_CACHE_ENTRY_T_MAGIC);
             HDassert(root_iblock->cache_info.type == H5AC_FHEAP_IBLOCK);
 
             if (H5HF__cache_verify_iblock_descendants_clean(f, hdr->heap_addr, root_iblock,
@@ -3042,7 +3009,6 @@ H5HF__cache_verify_iblock_descendants_clean(H5F_t *f, haddr_t fd_parent_addr, H5
     HDassert(f);
     HDassert(H5F_addr_defined(fd_parent_addr));
     HDassert(iblock);
-    HDassert(iblock->cache_info.magic == H5C__H5C_CACHE_ENTRY_T_MAGIC);
     HDassert(iblock->cache_info.type == H5AC_FHEAP_IBLOCK);
     HDassert(iblock_status);
     HDassert(fd_clean);
@@ -3161,7 +3127,6 @@ H5HF__cache_verify_iblocks_dblocks_clean(H5F_t *f, haddr_t fd_parent_addr, H5HF_
     HDassert(f);
     HDassert(H5F_addr_defined(fd_parent_addr));
     HDassert(iblock);
-    HDassert(iblock->cache_info.magic == H5C__H5C_CACHE_ENTRY_T_MAGIC);
     HDassert(iblock->cache_info.type == H5AC_FHEAP_IBLOCK);
     HDassert(fd_clean);
     HDassert(*fd_clean);
@@ -3326,7 +3291,6 @@ H5HF__cache_verify_descendant_iblocks_clean(H5F_t *f, haddr_t fd_parent_addr, H5
     HDassert(f);
     HDassert(H5F_addr_defined(fd_parent_addr));
     HDassert(iblock);
-    HDassert(iblock->cache_info.magic == H5C__H5C_CACHE_ENTRY_T_MAGIC);
     HDassert(iblock->cache_info.type == H5AC_FHEAP_IBLOCK);
     HDassert(fd_clean);
     HDassert(*fd_clean);
@@ -3479,7 +3443,6 @@ H5HF__cache_verify_descendant_iblocks_clean(H5F_t *f, haddr_t fd_parent_addr, H5
                      * that we have the correct one.
                      */
                     HDassert(child_iblock);
-                    HDassert(child_iblock->cache_info.magic == H5C__H5C_CACHE_ENTRY_T_MAGIC);
                     HDassert(child_iblock->cache_info.type == H5AC_FHEAP_IBLOCK);
                     HDassert(child_iblock->addr == child_iblock_addr);
 

--- a/src/H5HGcache.c
+++ b/src/H5HGcache.c
@@ -411,7 +411,6 @@ H5HG__cache_heap_image_len(const void *_thing, size_t *image_len)
     FUNC_ENTER_PACKAGE_NOERR
 
     HDassert(heap);
-    HDassert(heap->cache_info.magic == H5C__H5C_CACHE_ENTRY_T_MAGIC);
     HDassert(heap->cache_info.type == H5AC_GHEAP);
     HDassert(heap->size >= H5HG_MINSIZE);
     HDassert(image_len);
@@ -442,7 +441,6 @@ H5HG__cache_heap_serialize(const H5F_t H5_ATTR_NDEBUG_UNUSED *f, void *image, si
     HDassert(f);
     HDassert(image);
     HDassert(heap);
-    HDassert(heap->cache_info.magic == H5C__H5C_CACHE_ENTRY_T_MAGIC);
     HDassert(heap->cache_info.type == H5AC_GHEAP);
     HDassert(heap->size == len);
     HDassert(heap->chunk);
@@ -458,10 +456,6 @@ H5HG__cache_heap_serialize(const H5F_t H5_ATTR_NDEBUG_UNUSED *f, void *image, si
  *
  * Purpose:     Free the in memory representation of the supplied global heap.
  *
- * Note:        The metadata cache sets the object's cache_info.magic to
- *              H5C__H5C_CACHE_ENTRY_T_BAD_MAGIC before calling a free_icr
- *              callback (checked in assert).
- *
  * Return:      SUCCEED/FAIL
  *-------------------------------------------------------------------------
  */
@@ -474,7 +468,6 @@ H5HG__cache_heap_free_icr(void *_thing)
     FUNC_ENTER_PACKAGE
 
     HDassert(heap);
-    HDassert(heap->cache_info.magic == H5C__H5C_CACHE_ENTRY_T_BAD_MAGIC);
     HDassert(heap->cache_info.type == H5AC_GHEAP);
 
     /* Destroy global heap collection */

--- a/src/H5HLcache.c
+++ b/src/H5HLcache.c
@@ -505,7 +505,6 @@ H5HL__cache_prefix_image_len(const void *_thing, size_t *image_len)
 
     /* Check arguments */
     HDassert(prfx);
-    HDassert(prfx->cache_info.magic == H5C__H5C_CACHE_ENTRY_T_MAGIC);
     HDassert(prfx->cache_info.type == H5AC_LHEAP_PRFX);
     HDassert(image_len);
 
@@ -551,7 +550,6 @@ H5HL__cache_prefix_serialize(const H5_ATTR_NDEBUG_UNUSED H5F_t *f, void *_image,
     HDassert(f);
     HDassert(image);
     HDassert(prfx);
-    HDassert(prfx->cache_info.magic == H5C__H5C_CACHE_ENTRY_T_MAGIC);
     HDassert(prfx->cache_info.type == H5AC_LHEAP_PRFX);
     HDassert(H5F_addr_eq(prfx->cache_info.addr, prfx->heap->prfx_addr));
     HDassert(prfx->heap);
@@ -626,10 +624,6 @@ H5HL__cache_prefix_serialize(const H5_ATTR_NDEBUG_UNUSED H5F_t *f, void *_image,
  *		from a failed speculative load attempt.  See comments below for
  *		details.
  *
- * Note:	The metadata cache sets the object's cache_info.magic to
- *		H5C__H5C_CACHE_ENTRY_T_BAD_MAGIC before calling a free_icr
- *		callback (checked in assert).
- *
  * Return:      Success:        SUCCEED
  *              Failure:        FAIL
  *
@@ -648,7 +642,6 @@ H5HL__cache_prefix_free_icr(void *_thing)
 
     /* Check arguments */
     HDassert(prfx);
-    HDassert(prfx->cache_info.magic == H5C__H5C_CACHE_ENTRY_T_BAD_MAGIC);
     HDassert(prfx->cache_info.type == H5AC_LHEAP_PRFX);
     HDassert(H5F_addr_eq(prfx->cache_info.addr, prfx->heap->prfx_addr));
 
@@ -778,7 +771,6 @@ H5HL__cache_datablock_image_len(const void *_thing, size_t *image_len)
 
     /* Check arguments */
     HDassert(dblk);
-    HDassert(dblk->cache_info.magic == H5C__H5C_CACHE_ENTRY_T_MAGIC);
     HDassert(dblk->cache_info.type == H5AC_LHEAP_DBLK);
     HDassert(dblk->heap);
     HDassert(dblk->heap->dblk_size > 0);
@@ -816,7 +808,6 @@ H5HL__cache_datablock_serialize(const H5F_t H5_ATTR_NDEBUG_UNUSED *f, void *imag
     HDassert(f);
     HDassert(image);
     HDassert(dblk);
-    HDassert(dblk->cache_info.magic == H5C__H5C_CACHE_ENTRY_T_MAGIC);
     HDassert(dblk->cache_info.type == H5AC_LHEAP_DBLK);
     HDassert(dblk->heap);
     heap = dblk->heap;
@@ -909,10 +900,6 @@ done:
  *
  * Purpose:	Free the in memory representation of the supplied local heap data block.
  *
- * Note:	The metadata cache sets the object's cache_info.magic to
- *		H5C__H5C_CACHE_ENTRY_T_BAD_MAGIC before calling a free_icr
- *		callback (checked in assert).
- *
  * Return:      Success:        SUCCEED
  *              Failure:        FAIL
  *
@@ -931,7 +918,6 @@ H5HL__cache_datablock_free_icr(void *_thing)
 
     /* Check arguments */
     HDassert(dblk);
-    HDassert(dblk->cache_info.magic == H5C__H5C_CACHE_ENTRY_T_BAD_MAGIC);
     HDassert(dblk->cache_info.type == H5AC_LHEAP_DBLK);
 
     /* Destroy the data block */

--- a/src/H5Oalloc.c
+++ b/src/H5Oalloc.c
@@ -1758,8 +1758,6 @@ H5O__move_msgs_forward(H5F_t *f, H5O_t *oh)
                             if (0 != null_msg->chunkno) {
                                 /* Sanity checks */
                                 HDassert(null_chk_mdc_obj);
-                                HDassert(((H5C_cache_entry_t *)null_chk_mdc_obj)->magic ==
-                                         H5C__H5C_CACHE_ENTRY_T_MAGIC);
                                 HDassert(((H5C_cache_entry_t *)null_chk_mdc_obj)->type);
                                 HDassert(((H5C_cache_entry_t *)null_chk_mdc_obj)->type->id ==
                                          H5AC_OHDR_CHK_ID);

--- a/src/H5Ocache.c
+++ b/src/H5Ocache.c
@@ -344,7 +344,6 @@ H5O__cache_image_len(const void *_thing, size_t *image_len)
     FUNC_ENTER_PACKAGE_NOERR
 
     HDassert(oh);
-    HDassert(oh->cache_info.magic == H5C__H5C_CACHE_ENTRY_T_MAGIC);
     HDassert(oh->cache_info.type == H5AC_OHDR);
     HDassert(image_len);
 
@@ -375,7 +374,6 @@ H5O__cache_serialize(const H5F_t *f, void *image, size_t len, void *_thing)
     HDassert(f);
     HDassert(image);
     HDassert(oh);
-    HDassert(oh->cache_info.magic == H5C__H5C_CACHE_ENTRY_T_MAGIC);
     HDassert(oh->cache_info.type == H5AC_OHDR);
     HDassert(oh->chunk[0].size == len);
 #ifdef H5O_DEBUG
@@ -568,10 +566,6 @@ done:
  *
  * Purpose:     Free the in core representation of the supplied object header.
  *
- * Note:        The metadata cache sets the object's cache_info.magic to
- *              H5C__H5C_CACHE_ENTRY_T_BAD_MAGIC before calling a free_icr
- *              callback (checked in assert).
- *
  * Return:      SUCCEED/FAIL
  *-------------------------------------------------------------------------
  */
@@ -584,7 +578,6 @@ H5O__cache_free_icr(void *_thing)
     FUNC_ENTER_PACKAGE
 
     HDassert(oh);
-    HDassert(oh->cache_info.magic == H5C__H5C_CACHE_ENTRY_T_BAD_MAGIC);
     HDassert(oh->cache_info.type == H5AC_OHDR);
 
     /* Destroy object header */
@@ -749,7 +742,6 @@ H5O__cache_chk_image_len(const void *_thing, size_t *image_len)
     FUNC_ENTER_PACKAGE_NOERR
 
     HDassert(chk_proxy);
-    HDassert(chk_proxy->cache_info.magic == H5C__H5C_CACHE_ENTRY_T_MAGIC);
     HDassert(chk_proxy->cache_info.type == H5AC_OHDR_CHK);
     HDassert(chk_proxy->oh);
     HDassert(image_len);
@@ -781,7 +773,6 @@ H5O__cache_chk_serialize(const H5F_t *f, void *image, size_t len, void *_thing)
     HDassert(f);
     HDassert(image);
     HDassert(chk_proxy);
-    HDassert(chk_proxy->cache_info.magic == H5C__H5C_CACHE_ENTRY_T_MAGIC);
     HDassert(chk_proxy->cache_info.type == H5AC_OHDR_CHK);
     HDassert(chk_proxy->oh);
     HDassert(chk_proxy->oh->chunk[chk_proxy->chunkno].size == len);
@@ -825,8 +816,6 @@ H5O__cache_chk_notify(H5AC_notify_action_t action, void *_thing)
                 /* Add flush dependency on chunk with continuation, if one exists */
                 if (chk_proxy->fd_parent) {
                     /* Sanity checks */
-                    HDassert(((H5C_cache_entry_t *)(chk_proxy->fd_parent))->magic ==
-                             H5C__H5C_CACHE_ENTRY_T_MAGIC);
                     HDassert(((H5C_cache_entry_t *)(chk_proxy->fd_parent))->type);
                     HDassert((((H5C_cache_entry_t *)(chk_proxy->fd_parent))->type->id == H5AC_OHDR_ID) ||
                              (((H5C_cache_entry_t *)(chk_proxy->fd_parent))->type->id == H5AC_OHDR_CHK_ID));
@@ -883,8 +872,6 @@ H5O__cache_chk_notify(H5AC_notify_action_t action, void *_thing)
                 /* Remove flush dependency on parent object header chunk, if one is set */
                 if (chk_proxy->fd_parent) {
                     /* Sanity checks */
-                    HDassert(((H5C_cache_entry_t *)(chk_proxy->fd_parent))->magic ==
-                             H5C__H5C_CACHE_ENTRY_T_MAGIC);
                     HDassert(((H5C_cache_entry_t *)(chk_proxy->fd_parent))->type);
                     HDassert((((H5C_cache_entry_t *)(chk_proxy->fd_parent))->type->id == H5AC_OHDR_ID) ||
                              (((H5C_cache_entry_t *)(chk_proxy->fd_parent))->type->id == H5AC_OHDR_CHK_ID));
@@ -919,10 +906,6 @@ done:
  * Purpose:     Free the in core memory associated with the supplied object
  *              header continuation chunk.
  *
- * Note:        The metadata cache sets the object's cache_info.magic to
- *              H5C__H5C_CACHE_ENTRY_T_BAD_MAGIC before calling a free_icr
- *              callback (checked in assert).
- *
  * Return:      SUCCEED/FAIL
  *-------------------------------------------------------------------------
  */
@@ -935,7 +918,6 @@ H5O__cache_chk_free_icr(void *_thing)
     FUNC_ENTER_PACKAGE
 
     HDassert(chk_proxy);
-    HDassert(chk_proxy->cache_info.magic == H5C__H5C_CACHE_ENTRY_T_BAD_MAGIC);
     HDassert(chk_proxy->cache_info.type == H5AC_OHDR_CHK);
 
     /* Destroy object header chunk proxy */

--- a/src/H5SMcache.c
+++ b/src/H5SMcache.c
@@ -324,7 +324,6 @@ H5SM__cache_table_image_len(const void *_thing, size_t *image_len)
 
     /* Check arguments */
     HDassert(table);
-    HDassert(table->cache_info.magic == H5C__H5C_CACHE_ENTRY_T_MAGIC);
     HDassert(table->cache_info.type == H5AC_SOHM_TABLE);
     HDassert(image_len);
 
@@ -361,7 +360,6 @@ H5SM__cache_table_serialize(const H5F_t *f, void *_image, size_t H5_ATTR_NDEBUG_
     HDassert(f);
     HDassert(image);
     HDassert(table);
-    HDassert(table->cache_info.magic == H5C__H5C_CACHE_ENTRY_T_MAGIC);
     HDassert(table->cache_info.type == H5AC_SOHM_TABLE);
     HDassert(table->table_size == len);
 
@@ -423,10 +421,6 @@ H5SM__cache_table_serialize(const H5F_t *f, void *_image, size_t H5_ATTR_NDEBUG_
  *
  * Purpose:	Free memory used by the SOHM table.
  *
- * Note:	The metadata cache sets the object's cache_info.magic to
- *		H5C__H5C_CACHE_ENTRY_T_BAD_MAGIC before calling a free_icr
- *		callback (checked in assert).
- *
  * Return:      Success:        SUCCEED
  *              Failure:        FAIL
  *
@@ -445,7 +439,6 @@ H5SM__cache_table_free_icr(void *_thing)
 
     /* Check arguments */
     HDassert(table);
-    HDassert(table->cache_info.magic == H5C__H5C_CACHE_ENTRY_T_BAD_MAGIC);
     HDassert(table->cache_info.type == H5AC_SOHM_TABLE);
 
     /* Destroy Shared Object Header Message table */
@@ -639,7 +632,6 @@ H5SM__cache_list_image_len(const void *_thing, size_t *image_len)
 
     /* Check arguments */
     HDassert(list);
-    HDassert(list->cache_info.magic == H5C__H5C_CACHE_ENTRY_T_MAGIC);
     HDassert(list->cache_info.type == H5AC_SOHM_LIST);
     HDassert(list->header);
     HDassert(image_len);
@@ -680,7 +672,6 @@ H5SM__cache_list_serialize(const H5F_t *f, void *_image, size_t H5_ATTR_NDEBUG_U
     HDassert(f);
     HDassert(image);
     HDassert(list);
-    HDassert(list->cache_info.magic == H5C__H5C_CACHE_ENTRY_T_MAGIC);
     HDassert(list->cache_info.type == H5AC_SOHM_LIST);
     HDassert(list->header);
     HDassert(list->header->list_size == len);
@@ -727,10 +718,6 @@ done:
  *
  * Purpose:	Free all memory used by the list.
  *
- * Note:	The metadata cache sets the object's cache_info.magic to
- *		H5C__H5C_CACHE_ENTRY_T_BAD_MAGIC before calling a free_icr
- *		callback (checked in assert).
- *
  * Return:      Success:        SUCCEED
  *              Failure:        FAIL
  *
@@ -749,7 +736,6 @@ H5SM__cache_list_free_icr(void *_thing)
 
     /* Check arguments */
     HDassert(list);
-    HDassert(list->cache_info.magic == H5C__H5C_CACHE_ENTRY_T_BAD_MAGIC);
     HDassert(list->cache_info.type == H5AC_SOHM_LIST);
 
     /* Destroy Shared Object Header Message list */

--- a/test/cache.c
+++ b/test/cache.c
@@ -24795,17 +24795,6 @@ check_auto_cache_resize_input_errs(unsigned paged)
 
     if (pass) {
 
-        result = H5C_get_cache_auto_resize_config((const H5C_t *)&test_auto_size_ctl, &test_auto_size_ctl);
-
-        if (result != FAIL) {
-
-            pass         = FALSE;
-            failure_mssg = "H5C_get_cache_auto_resize_config accepted bad cache_ptr.\n";
-        }
-    }
-
-    if (pass) {
-
         result = H5C_get_cache_auto_resize_config(cache_ptr, NULL);
 
         if (result != FAIL) {
@@ -33917,13 +33906,6 @@ setup_cache(size_t max_cache_size, size_t min_clean_size, unsigned paged)
 
             if (verbose)
                 HDfprintf(stdout, "%s: H5C_create() failed.\n", __func__);
-        }
-        else if (cache_ptr->magic != H5C__H5C_T_MAGIC) {
-            pass         = FALSE;
-            failure_mssg = "Bad cache_ptr magic.";
-
-            if (verbose)
-                HDfprintf(stdout, "%s: Bad cache_ptr magic.\n", __func__);
         }
     }
 

--- a/test/cache_api.c
+++ b/test/cache_api.c
@@ -241,8 +241,8 @@ check_fapl_mdc_api_calls(unsigned paged, hid_t fcpl_id)
     /* verify that we can access the internal version of the cache config */
     if (pass) {
 
-        if ((cache_ptr == NULL) || (cache_ptr->magic != H5C__H5C_T_MAGIC) ||
-            (cache_ptr->resize_ctl.version != H5C__CURR_AUTO_SIZE_CTL_VER)) {
+        if (cache_ptr == NULL ||
+            cache_ptr->resize_ctl.version != H5C__CURR_AUTO_SIZE_CTL_VER) {
 
             pass         = FALSE;
             failure_mssg = "Can't access cache resize_ctl.\n";
@@ -385,8 +385,8 @@ check_fapl_mdc_api_calls(unsigned paged, hid_t fcpl_id)
     /* verify that we can access the internal version of the cache config */
     if (pass) {
 
-        if ((cache_ptr == NULL) || (cache_ptr->magic != H5C__H5C_T_MAGIC) ||
-            (cache_ptr->resize_ctl.version != H5C__CURR_AUTO_SIZE_CTL_VER)) {
+        if (cache_ptr == NULL ||
+            cache_ptr->resize_ctl.version != H5C__CURR_AUTO_SIZE_CTL_VER) {
 
             pass         = FALSE;
             failure_mssg = "Can't access cache resize_ctl.\n";

--- a/test/cache_api.c
+++ b/test/cache_api.c
@@ -241,8 +241,7 @@ check_fapl_mdc_api_calls(unsigned paged, hid_t fcpl_id)
     /* verify that we can access the internal version of the cache config */
     if (pass) {
 
-        if (cache_ptr == NULL ||
-            cache_ptr->resize_ctl.version != H5C__CURR_AUTO_SIZE_CTL_VER) {
+        if (cache_ptr == NULL || cache_ptr->resize_ctl.version != H5C__CURR_AUTO_SIZE_CTL_VER) {
 
             pass         = FALSE;
             failure_mssg = "Can't access cache resize_ctl.\n";
@@ -385,8 +384,7 @@ check_fapl_mdc_api_calls(unsigned paged, hid_t fcpl_id)
     /* verify that we can access the internal version of the cache config */
     if (pass) {
 
-        if (cache_ptr == NULL ||
-            cache_ptr->resize_ctl.version != H5C__CURR_AUTO_SIZE_CTL_VER) {
+        if (cache_ptr == NULL || cache_ptr->resize_ctl.version != H5C__CURR_AUTO_SIZE_CTL_VER) {
 
             pass         = FALSE;
             failure_mssg = "Can't access cache resize_ctl.\n";

--- a/test/cache_common.c
+++ b/test/cache_common.c
@@ -1334,9 +1334,7 @@ free_icr(test_entry_t *entry, int32_t H5_ATTR_NDEBUG_UNUSED entry_type)
     HDassert(entry == &(entries[entry->type][entry->index]));
     HDassert(entry == entry->self);
     HDassert(entry->cache_ptr != NULL);
-    HDassert(entry->cache_ptr->magic == H5C__H5C_T_MAGIC);
     HDassert((entry->header.destroy_in_progress) || (entry->header.addr == entry->addr));
-    HDassert(entry->header.magic == H5C__H5C_CACHE_ENTRY_T_BAD_MAGIC);
     HDassert(entry->header.size == entry->size);
     HDassert((entry->type == VARIABLE_ENTRY_TYPE) || (entry->size == entry_sizes[entry->type]));
     HDassert(entry->header.tl_next == NULL);
@@ -1674,7 +1672,6 @@ execute_flush_op(H5F_t *file_ptr, struct test_entry_t *entry_ptr, struct flush_o
     HDassert(file_ptr);
     cache_ptr = file_ptr->shared->cache;
     HDassert(cache_ptr != NULL);
-    HDassert(cache_ptr->magic == H5C__H5C_T_MAGIC);
     HDassert(entry_ptr != NULL);
     HDassert(entry_ptr == entry_ptr->self);
     HDassert(entry_ptr->header.addr == entry_ptr->addr);
@@ -4960,16 +4957,6 @@ check_and_validate_cache_hit_rate(hid_t file_id, double *hit_rate_ptr, hbool_t d
         }
     }
 
-    /* verify that we can access the cache data structure */
-    if (pass) {
-
-        if (cache_ptr->magic != H5C__H5C_T_MAGIC) {
-
-            pass         = FALSE;
-            failure_mssg = "Can't access cache resize_ctl.";
-        }
-    }
-
     /* compare the cache's internal configuration with the expected value */
     if (pass) {
 
@@ -5086,16 +5073,6 @@ check_and_validate_cache_size(hid_t file_id, size_t *max_size_ptr, size_t *min_c
                 pass         = FALSE;
                 failure_mssg = "NULL cache pointer";
             }
-        }
-    }
-
-    /* verify that we can access the cache data structure */
-    if (pass) {
-
-        if (cache_ptr->magic != H5C__H5C_T_MAGIC) {
-
-            pass         = FALSE;
-            failure_mssg = "Can't access cache data structure.";
         }
     }
 
@@ -5256,8 +5233,8 @@ validate_mdc_config(hid_t file_id, H5AC_cache_config_t *ext_config_ptr, hbool_t 
     /* verify that we can access the internal version of the cache config */
     if (pass) {
 
-        if ((cache_ptr == NULL) || (cache_ptr->magic != H5C__H5C_T_MAGIC) ||
-            (cache_ptr->resize_ctl.version != H5C__CURR_AUTO_SIZE_CTL_VER)) {
+        if (cache_ptr == NULL ||
+            cache_ptr->resize_ctl.version != H5C__CURR_AUTO_SIZE_CTL_VER) {
 
             pass = FALSE;
             HDsnprintf(msg, (size_t)128, "Can't access cache resize_ctl #%d.", test_num);
@@ -5340,7 +5317,6 @@ dump_LRU(H5F_t * file_ptr)
     H5C_t *cache_ptr = file_ptr->shared->cache;
 
     HDassert(cache_ptr);
-    HDassert(cache_ptr->magic == H5C__H5C_T_MAGIC);
 
     entry_ptr = cache_ptr->LRU_head_ptr;
 

--- a/test/cache_common.c
+++ b/test/cache_common.c
@@ -5233,8 +5233,7 @@ validate_mdc_config(hid_t file_id, H5AC_cache_config_t *ext_config_ptr, hbool_t 
     /* verify that we can access the internal version of the cache config */
     if (pass) {
 
-        if (cache_ptr == NULL ||
-            cache_ptr->resize_ctl.version != H5C__CURR_AUTO_SIZE_CTL_VER) {
+        if (cache_ptr == NULL || cache_ptr->resize_ctl.version != H5C__CURR_AUTO_SIZE_CTL_VER) {
 
             pass = FALSE;
             HDsnprintf(msg, (size_t)128, "Can't access cache resize_ctl #%d.", test_num);

--- a/test/cache_image.c
+++ b/test/cache_image.c
@@ -7659,7 +7659,6 @@ evict_on_close_test(hbool_t H5_ATTR_PARALLEL_UNUSED single_file_vfd)
     if (verbose) {
 
         HDassert(cache_ptr);
-        HDassert(cache_ptr->magic == H5C__H5C_T_MAGIC);
 
         HDfprintf(stdout, "index size / index dirty size = %lld / %lld\n", (long long)(cache_ptr->index_size),
                   (long long)(cache_ptr->dirty_index_size));

--- a/testpar/t_cache.c
+++ b/testpar/t_cache.c
@@ -2293,13 +2293,11 @@ datum_serialize(const H5F_t *f, void H5_ATTR_NDEBUG_UNUSED *image_ptr, size_t le
     HDassert(f);
     HDassert(f->shared);
     HDassert(f->shared->cache);
-    HDassert(f->shared->cache->magic == H5C__H5C_T_MAGIC);
     HDassert(f->shared->cache->aux_ptr);
 
     aux_ptr = (H5AC_aux_t *)(f->shared->cache->aux_ptr);
 
     HDassert(aux_ptr);
-    HDassert(aux_ptr->magic == H5AC__H5AC_AUX_T_MAGIC);
 
     entry_ptr->aux_ptr = aux_ptr;
 
@@ -2526,7 +2524,6 @@ datum_notify(H5C_notify_action_t action, void *thing)
             }
 
             HDassert(entry_ptr->aux_ptr);
-            HDassert(entry_ptr->aux_ptr->magic == H5AC__H5AC_AUX_T_MAGIC);
             aux_ptr            = entry_ptr->aux_ptr;
             entry_ptr->aux_ptr = NULL;
 
@@ -2898,8 +2895,7 @@ insert_entry(H5C_t *cache_ptr, H5F_t *file_ptr, int32_t idx, unsigned int flags)
 
             aux_ptr = ((H5AC_aux_t *)(cache_ptr->aux_ptr));
 
-            if (!((aux_ptr != NULL) && (aux_ptr->magic == H5AC__H5AC_AUX_T_MAGIC) &&
-                  (aux_ptr->dirty_bytes == 0))) {
+            if (!(aux_ptr != NULL && aux_ptr->dirty_bytes == 0)) {
 
                 nerrors++;
                 if (verbose) {
@@ -3525,8 +3521,7 @@ move_entry(H5F_t *file_ptr, int32_t old_idx, int32_t new_idx)
 
                 aux_ptr = ((H5AC_aux_t *)(file_ptr->shared->cache->aux_ptr));
 
-                if (!((aux_ptr != NULL) && (aux_ptr->magic == H5AC__H5AC_AUX_T_MAGIC) &&
-                      (aux_ptr->dirty_bytes == 0))) {
+                if (!(aux_ptr != NULL && aux_ptr->dirty_bytes == 0)) {
 
                     nerrors++;
                     if (verbose) {
@@ -3750,12 +3745,6 @@ setup_cache_for_test(hid_t *fid_ptr, H5F_t **file_ptr_ptr, H5C_t **cache_ptr_ptr
             HDfprintf(stdout, "%d:%s: Can't get cache_ptr.\n", world_mpi_rank, __func__);
         }
     }
-    else if (cache_ptr->magic != H5C__H5C_T_MAGIC) {
-        nerrors++;
-        if (verbose) {
-            HDfprintf(stdout, "%d:%s: Bad cache_ptr magic.\n", world_mpi_rank, __func__);
-        }
-    }
     else {
         cache_ptr->ignore_tags = TRUE;
         *fid_ptr               = fid;
@@ -3803,14 +3792,6 @@ setup_cache_for_test(hid_t *fid_ptr, H5F_t **file_ptr_ptr, H5C_t **cache_ptr_ptr
             nerrors++;
             if (verbose) {
                 HDfprintf(stdout, "%d:%s: cache_ptr->aux_ptr == NULL.\n", world_mpi_rank, __func__);
-            }
-        }
-        else if (((H5AC_aux_t *)(cache_ptr->aux_ptr))->magic != H5AC__H5AC_AUX_T_MAGIC) {
-
-            nerrors++;
-            if (verbose) {
-                HDfprintf(stdout, "%d:%s: cache_ptr->aux_ptr->magic != H5AC__H5AC_AUX_T_MAGIC.\n",
-                          world_mpi_rank, __func__);
             }
         }
         else if (((H5AC_aux_t *)(cache_ptr->aux_ptr))->metadata_write_strategy != metadata_write_strategy) {

--- a/testpar/t_file.c
+++ b/testpar/t_file.c
@@ -467,7 +467,6 @@ create_file(const char *filename, hid_t fcpl, hid_t fapl, int metadata_write_str
     VRFY((f != NULL), "");
 
     cache_ptr = f->shared->cache;
-    VRFY((cache_ptr->magic == H5C__H5C_T_MAGIC), "");
 
     cache_ptr->ignore_tags = TRUE;
     H5C_stats__reset(cache_ptr);
@@ -634,7 +633,6 @@ open_file(const char *filename, hid_t fapl, int metadata_write_strategy, hsize_t
     VRFY((f != NULL), "");
 
     cache_ptr = f->shared->cache;
-    VRFY((cache_ptr->magic == H5C__H5C_T_MAGIC), "");
 
     MPI_Barrier(MPI_COMM_WORLD);
 
@@ -713,7 +711,6 @@ open_file(const char *filename, hid_t fapl, int metadata_write_strategy, hsize_t
         entry_ptr = cache_ptr->index[i];
 
         while (entry_ptr != NULL) {
-            HDassert(entry_ptr->magic == H5C__H5C_CACHE_ENTRY_T_MAGIC);
             HDassert(entry_ptr->is_dirty == FALSE);
 
             if (!entry_ptr->is_pinned && !entry_ptr->is_protected) {


### PR DESCRIPTION
Remove unnecessary 'magic' fields from cache structs