### PR TITLE
Update H5private.h to fix errors with vastprintf() and astprintf() 

### DIFF
--- a/src/H5private.h
+++ b/src/H5private.h
@@ -17,6 +17,8 @@
  *          defined in H5config.h which is included by H5public.h.
  */
 
+#define _GNU_SOURCE
+
 #ifndef H5private_H
 #define H5private_H
 


### PR DESCRIPTION
When building hd5f with intel compilers on ubuntu 22.04, I got the following error message:

`
H5E.c:1339:9: error: call to undeclared function 'vasprintf'; ISO C99 and later do not support implicit function declarations [-Wimplicit-function-declaration]
    if (HDvasprintf(&tmp, fmt, ap) < 0)
        ^
./H5private.h:1498:34: note: expanded from macro 'HDvasprintf'
#define HDvasprintf(RET, FMT, A) vasprintf(RET, FMT, A)
                                 ^
H5E.c:1339:9: note: did you mean 'vsprintf'?
./H5private.h:1498:34: note: expanded from macro 'HDvasprintf'
#define HDvasprintf(RET, FMT, A) vasprintf(RET, FMT, A)
                                 ^
/usr/include/stdio.h:373:12: note: 'vsprintf' declared here
extern int vsprintf (char *__restrict __s, const char *__restrict __format,
           ^
1 error generated.
`

This error message is fixed adding `#define _GNU_SOURCE` to [H5private.h](https://github.com/HDFGroup/hdf5/commit/0228a16b26049108f8c9165362fcad0e755ca24d)

