### PR TITLE
ci: set minimal permissions on GitHub Workflows

### DIFF
--- a/.github/workflows/clang-format-check.yml
+++ b/.github/workflows/clang-format-check.yml
@@ -1,6 +1,8 @@
 name: clang-format Check
 on:
   pull_request:
+permissions:
+  contents: read
 jobs:
   formatting-check:
     name: Formatting Check

--- a/.github/workflows/clang-format-fix.yml
+++ b/.github/workflows/clang-format-fix.yml
@@ -11,11 +11,15 @@ name: clang-format Commit Changes
 on: 
   workflow_dispatch:
   push:
+permissions:
+  contents: read
 jobs:
   formatting-check:
     name: Commit Format Changes
     runs-on: ubuntu-latest
     if: "!contains(github.event.head_commit.message, 'skip-ci')"
+    permissions:
+        contents: write # In order to allow EndBug/add-and-commit to commit changes
     steps:
     - uses: actions/checkout@v3
     - name: Fix C and Java formatting issues detected by clang-format

--- a/.github/workflows/cmake-ctest.yml
+++ b/.github/workflows/cmake-ctest.yml
@@ -9,6 +9,9 @@ on:
         required: true
         type: string
 
+permissions:
+  contents: read
+
 # A workflow run is made up of one or more jobs that can run sequentially or
 # in parallel
 jobs:

--- a/.github/workflows/codespell.yml
+++ b/.github/workflows/codespell.yml
@@ -3,6 +3,8 @@
 # https://github.com/codespell-project/actions-codespell
 name: codespell
 on: [push, pull_request]
+permissions:
+  contents: read
 jobs:
   codespell:
     name: Check for spelling errors

--- a/.github/workflows/daily-build.yml
+++ b/.github/workflows/daily-build.yml
@@ -6,6 +6,9 @@ on:
   schedule:
     - cron: "6 0 * * *"
 
+permissions:
+  contents: read
+
 # A workflow run is made up of one or more jobs that can run sequentially or
 # in parallel.
 jobs:

--- a/.github/workflows/hdfeos5.yml
+++ b/.github/workflows/hdfeos5.yml
@@ -19,6 +19,9 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.sha || github.event.pull_request.number }}
   cancel-in-progress: true
 
+permissions:
+  contents: read
+
 jobs:
   build:
     name: Build hdfeos5

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -20,6 +20,9 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.sha || github.event.pull_request.number }}
   cancel-in-progress: true
 
+permissions:
+  contents: read
+
 # A workflow run is made up of one or more jobs that can run sequentially or
 # in parallel. We just have one job, but the matrix items defined below will
 # run in parallel.

--- a/.github/workflows/tarball.yml
+++ b/.github/workflows/tarball.yml
@@ -11,6 +11,9 @@ on:
         description: "The common base name of the source tarballs"
         value: ${{ jobs.create_tarball.outputs.file_base }}
 
+permissions:
+  contents: read
+
 # A workflow run is made up of one or more jobs that can run sequentially or
 # in parallel
 jobs:


### PR DESCRIPTION
Closes #2973

I've tried to evaluate the permissions needed to all your workflows but I couldn't be 100% sure of some of them. It went all fine in my testings on the fork, but if you have any issues on runs on your repo, we might need to add some extra permissions. 