### PR TITLE
Fix missing/misplaced h5_reset calls

### DIFF
--- a/src/H5FDtest.c
+++ b/src/H5FDtest.c
@@ -71,8 +71,6 @@
  *              VFD feature flags (which do not exist until the driver
  *              is instantiated).
  *
- *              See test/Makefile.am for a list of the VFD strings.
- *
  *              This function is only intended for use in the test code.
  *
  * Return:	    TRUE (1) if the VFD supports SWMR I/O or vfd_name is
@@ -82,10 +80,6 @@
  *
  *              This function cannot fail at this time so there is no
  *              error return value.
- *
- * Programmer:	Dana Robinson
- *              Fall 2014
- *
  *-------------------------------------------------------------------------
  */
 hbool_t

--- a/test/accum_swmr_reader.c
+++ b/test/accum_swmr_reader.c
@@ -35,23 +35,23 @@ const char *FILENAME[] = {"accum", "accum_swmr_big", NULL};
  *
  * Return:      Success: EXIT_SUCCESS
  *              Failure: EXIT_FAILURE
- *
- * Programmer:  Vailin Choi; June 2013
- *
  *-------------------------------------------------------------------------
  */
 int
 main(void)
 {
-    hid_t    fid  = -1;   /* File ID */
-    hid_t    fapl = -1;   /* file access property list ID */
-    H5F_t   *f    = NULL; /* File pointer */
+    hid_t    fid  = H5I_INVALID_HID; /* File ID */
+    hid_t    fapl = H5I_INVALID_HID; /* file access property list ID */
+    H5F_t   *f    = NULL;            /* File pointer */
     char     filename[1024];
     unsigned u;                      /* Local index variable */
     uint8_t  rbuf[1024];             /* Buffer for reading */
     uint8_t  buf[1024];              /* Buffer for holding the expected data */
     char    *driver         = NULL;  /* VFD string (from env variable) */
     hbool_t  api_ctx_pushed = FALSE; /* Whether API context pushed */
+
+    /* Testing setup */
+    h5_reset();
 
     /* Skip this test if SWMR I/O is not supported for the VFD specified
      * by the environment variable.

--- a/test/swmr.c
+++ b/test/swmr.c
@@ -7728,12 +7728,15 @@ error:
 int
 main(void)
 {
-    int     nerrors      = 0;             /* The # of errors */
-    hid_t   fapl         = -1;            /* File access property list ID */
-    char   *driver       = NULL;          /* VFD string (from env variable) */
-    char   *lock_env_var = NULL;          /* file locking env var pointer */
-    hbool_t use_file_locking;             /* read from env var */
-    hbool_t file_locking_enabled = FALSE; /* Checks if the file system supports locks */
+    int     nerrors      = 0;               /* The # of errors */
+    hid_t   fapl         = H5I_INVALID_HID; /* File access property list ID */
+    char   *driver       = NULL;            /* VFD string (from env variable) */
+    char   *lock_env_var = NULL;            /* file locking env var pointer */
+    hbool_t use_file_locking;               /* read from env var */
+    hbool_t file_locking_enabled = FALSE;   /* Checks if the file system supports locks */
+
+    /* Testing setup */
+    h5_reset();
 
     /* Skip this test if SWMR I/O is not supported for the VFD specified
      * by the environment variable.
@@ -7742,7 +7745,7 @@ main(void)
     if (!H5FD__supports_swmr_test(driver)) {
         HDprintf("This VFD does not support SWMR I/O\n");
         return EXIT_SUCCESS;
-    } /* end if */
+    }
 
     /* Check the environment variable that determines if we care
      * about file locking. File locking should be used unless explicitly
@@ -7760,9 +7763,6 @@ main(void)
             HDprintf("Error when determining if file locks are enabled\n");
             return EXIT_FAILURE;
         }
-
-    /* Set up */
-    h5_reset();
 
     /* Get file access property list */
     fapl = h5_fileaccess();
@@ -7822,7 +7822,7 @@ main(void)
          */
         nerrors += test_file_lock_swmr_same(fapl);
         nerrors += test_file_lock_swmr_concur(fapl);
-    } /* end if */
+    }
 
     /* Tests SWMR VFD compatibility flag.
      * Only needs to run when the VFD is the default (sec2).


### PR DESCRIPTION
Fixes failures when running tests after building with thread-safety w/ code stacks on.

Fixes #2990