### PR TITLE
Only pass efc pointer to H5F__efc_open

### DIFF
--- a/src/H5Fefc.c
+++ b/src/H5Fefc.c
@@ -137,9 +137,8 @@ done:
  *-------------------------------------------------------------------------
  */
 H5F_t *
-H5F__efc_open(H5F_t *parent, const char *name, unsigned flags, hid_t fcpl_id, hid_t fapl_id)
+H5F__efc_open(H5F_efc_t *efc, const char *name, unsigned flags, hid_t fcpl_id, hid_t fapl_id)
 {
-    H5F_efc_t            *efc       = NULL;  /* External file cache for parent file */
     H5F_efc_ent_t        *ent       = NULL;  /* Entry for target file in efc */
     hbool_t               open_file = FALSE; /* Whether ent->file needs to be closed in case of error */
     H5P_genplist_t       *plist;             /* Property list pointer for FAPL */
@@ -149,8 +148,6 @@ H5F__efc_open(H5F_t *parent, const char *name, unsigned flags, hid_t fcpl_id, hi
     FUNC_ENTER_PACKAGE
 
     /* Sanity checks */
-    HDassert(parent);
-    HDassert(parent->shared);
     HDassert(name);
 
     /* Get the VOL info from the fapl */
@@ -164,9 +161,6 @@ H5F__efc_open(H5F_t *parent, const char *name, unsigned flags, hid_t fcpl_id, hi
      */
     if (H5CX_set_vol_connector_prop(&connector_prop) < 0)
         HGOTO_ERROR(H5E_FILE, H5E_CANTSET, NULL, "can't set VOL connector info in API context")
-
-    /* Get external file cache */
-    efc = parent->shared->efc;
 
     /* Check if the EFC exists.  If it does not, just call H5F_open().  We
      * support this so clients do not have to make 2 different calls depending

--- a/src/H5Fint.c
+++ b/src/H5Fint.c
@@ -900,8 +900,7 @@ H5F_prefix_open_file(H5F_t *primary_file, H5F_prefix_open_t prefix_type, const c
                     } /* end if */
 
                     /* Try opening file */
-                    src_file =
-                        H5F__efc_open(efc, full_name, file_intent, H5P_FILE_CREATE_DEFAULT, fapl_id);
+                    src_file = H5F__efc_open(efc, full_name, file_intent, H5P_FILE_CREATE_DEFAULT, fapl_id);
 
                     /* Release copy of file name */
                     full_name = (char *)H5MM_xfree(full_name);

--- a/src/H5Fpkg.h
+++ b/src/H5Fpkg.h
@@ -452,7 +452,7 @@ H5_DLL herr_t H5F__set_mpi_atomicity(H5F_t *file, hbool_t flag);
 
 /* External file cache routines */
 H5_DLL H5F_efc_t *H5F__efc_create(unsigned max_nfiles);
-H5_DLL H5F_t   *H5F__efc_open(H5F_t *parent, const char *name, unsigned flags, hid_t fcpl_id, hid_t fapl_id);
+H5_DLL H5F_t   *H5F__efc_open(H5F_efc_t *efc, const char *name, unsigned flags, hid_t fcpl_id, hid_t fapl_id);
 H5_DLL unsigned H5F__efc_max_nfiles(H5F_efc_t *efc);
 H5_DLL herr_t   H5F__efc_release(H5F_efc_t *efc);
 H5_DLL herr_t   H5F__efc_destroy(H5F_efc_t *efc);

--- a/test/efc.c
+++ b/test/efc.c
@@ -85,7 +85,7 @@ test_single(void)
      * held open by the EFC.
      */
     if (NULL ==
-        (f1 = H5F__efc_open(f0, filename[1], H5F_ACC_RDWR | H5F_ACC_CREAT | H5F_ACC_TRUNC, fcpl_id, fapl_id)))
+        (f1 = H5F__efc_open(f0->shared->efc, filename[1], H5F_ACC_RDWR | H5F_ACC_CREAT | H5F_ACC_TRUNC, fcpl_id, fapl_id)))
         FAIL_STACK_ERROR;
     if (H5F_efc_close(f0, f1) < 0)
         FAIL_STACK_ERROR;
@@ -104,12 +104,12 @@ test_single(void)
      * level file pointer.  Open file 1 through EFC, close, open again, verify
      * file pointers are the same. */
     if (NULL ==
-        (f1 = H5F__efc_open(f0, filename[1], H5F_ACC_RDWR | H5F_ACC_CREAT | H5F_ACC_TRUNC, fcpl_id, fapl_id)))
+        (f1 = H5F__efc_open(f0->shared->efc, filename[1], H5F_ACC_RDWR | H5F_ACC_CREAT | H5F_ACC_TRUNC, fcpl_id, fapl_id)))
         FAIL_STACK_ERROR;
     ftmp1 = f1;
     if (H5F_efc_close(f0, f1) < 0)
         FAIL_STACK_ERROR;
-    if (NULL == (f1 = H5F__efc_open(f0, filename[1], H5F_ACC_RDWR, fcpl_id, fapl_id)))
+    if (NULL == (f1 = H5F__efc_open(f0->shared->efc, filename[1], H5F_ACC_RDWR, fcpl_id, fapl_id)))
         FAIL_STACK_ERROR;
     if (f1 != ftmp1)
         TEST_ERROR;
@@ -125,7 +125,7 @@ test_single(void)
      * order.  Open each file normally after closing through EFC the first time
      * to track ref counts. */
     if (NULL ==
-        (f1 = H5F__efc_open(f0, filename[1], H5F_ACC_RDWR | H5F_ACC_CREAT | H5F_ACC_TRUNC, fcpl_id, fapl_id)))
+        (f1 = H5F__efc_open(f0->shared->efc, filename[1], H5F_ACC_RDWR | H5F_ACC_CREAT | H5F_ACC_TRUNC, fcpl_id, fapl_id)))
         FAIL_STACK_ERROR;
     if (H5F_efc_close(f0, f1) < 0)
         FAIL_STACK_ERROR;
@@ -135,7 +135,7 @@ test_single(void)
         TEST_ERROR;
 
     if (NULL ==
-        (f2 = H5F__efc_open(f0, filename[2], H5F_ACC_RDWR | H5F_ACC_CREAT | H5F_ACC_TRUNC, fcpl_id, fapl_id)))
+        (f2 = H5F__efc_open(f0->shared->efc, filename[2], H5F_ACC_RDWR | H5F_ACC_CREAT | H5F_ACC_TRUNC, fcpl_id, fapl_id)))
         FAIL_STACK_ERROR;
     if (H5F_efc_close(f0, f2) < 0)
         FAIL_STACK_ERROR;
@@ -147,7 +147,7 @@ test_single(void)
         TEST_ERROR;
 
     if (NULL ==
-        (f3 = H5F__efc_open(f0, filename[3], H5F_ACC_RDWR | H5F_ACC_CREAT | H5F_ACC_TRUNC, fcpl_id, fapl_id)))
+        (f3 = H5F__efc_open(f0->shared->efc, filename[3], H5F_ACC_RDWR | H5F_ACC_CREAT | H5F_ACC_TRUNC, fcpl_id, fapl_id)))
         FAIL_STACK_ERROR;
     if (H5F_efc_close(f0, f3) < 0)
         FAIL_STACK_ERROR;
@@ -161,7 +161,7 @@ test_single(void)
         TEST_ERROR;
 
     if (NULL ==
-        (f4 = H5F__efc_open(f0, filename[4], H5F_ACC_RDWR | H5F_ACC_CREAT | H5F_ACC_TRUNC, fcpl_id, fapl_id)))
+        (f4 = H5F__efc_open(f0->shared->efc, filename[4], H5F_ACC_RDWR | H5F_ACC_CREAT | H5F_ACC_TRUNC, fcpl_id, fapl_id)))
         FAIL_STACK_ERROR;
     if (H5F_efc_close(f0, f4) < 0)
         FAIL_STACK_ERROR;
@@ -176,7 +176,7 @@ test_single(void)
     if (f4->shared->nrefs != 2)
         TEST_ERROR;
 
-    if (NULL == (ftmp3 = H5F__efc_open(f0, filename[3], H5F_ACC_RDWR, fcpl_id, fapl_id)))
+    if (NULL == (ftmp3 = H5F__efc_open(f0->shared->efc, filename[3], H5F_ACC_RDWR, fcpl_id, fapl_id)))
         FAIL_STACK_ERROR;
     if (H5F_efc_close(f0, ftmp3) < 0)
         FAIL_STACK_ERROR;
@@ -189,7 +189,7 @@ test_single(void)
     if (f4->shared->nrefs != 2)
         TEST_ERROR;
 
-    if (NULL == (ftmp2 = H5F__efc_open(f0, filename[2], H5F_ACC_RDWR, fcpl_id, fapl_id)))
+    if (NULL == (ftmp2 = H5F__efc_open(f0->shared->efc, filename[2], H5F_ACC_RDWR, fcpl_id, fapl_id)))
         FAIL_STACK_ERROR;
     if (H5F_efc_close(f0, ftmp2) < 0)
         FAIL_STACK_ERROR;
@@ -202,7 +202,7 @@ test_single(void)
     if (f4->shared->nrefs != 2)
         TEST_ERROR;
 
-    if (NULL == (ftmp1 = H5F__efc_open(f0, filename[1], H5F_ACC_RDWR, fcpl_id, fapl_id)))
+    if (NULL == (ftmp1 = H5F__efc_open(f0->shared->efc, filename[1], H5F_ACC_RDWR, fcpl_id, fapl_id)))
         FAIL_STACK_ERROR;
     if (H5F_efc_close(f0, ftmp1) < 0)
         FAIL_STACK_ERROR;
@@ -215,7 +215,7 @@ test_single(void)
     if (f4->shared->nrefs != 1)
         TEST_ERROR;
 
-    if (NULL == (ftmp4 = H5F__efc_open(f0, filename[4], H5F_ACC_RDWR, fcpl_id, fapl_id)))
+    if (NULL == (ftmp4 = H5F__efc_open(f0->shared->efc, filename[4], H5F_ACC_RDWR, fcpl_id, fapl_id)))
         FAIL_STACK_ERROR;
     if (H5F_efc_close(f0, ftmp4) < 0)
         FAIL_STACK_ERROR;
@@ -250,7 +250,7 @@ test_single(void)
     /* Test 4: Verify that files kept open through the EFC are not evicted by
      * H5F__efc_release(). */
     if (NULL ==
-        (f1 = H5F__efc_open(f0, filename[1], H5F_ACC_RDWR | H5F_ACC_CREAT | H5F_ACC_TRUNC, fcpl_id, fapl_id)))
+        (f1 = H5F__efc_open(f0->shared->efc, filename[1], H5F_ACC_RDWR | H5F_ACC_CREAT | H5F_ACC_TRUNC, fcpl_id, fapl_id)))
         FAIL_STACK_ERROR;
     if (NULL == (ftmp1 = H5F_open(filename[1], H5F_ACC_RDWR, fcpl_id, fapl_id)))
         FAIL_STACK_ERROR;
@@ -276,7 +276,7 @@ test_single(void)
      * that the second file is evicted.  Close the first file, reopen the
      * second, and verify that the first file is evicted. */
     if (NULL ==
-        (f1 = H5F__efc_open(f0, filename[1], H5F_ACC_RDWR | H5F_ACC_CREAT | H5F_ACC_TRUNC, fcpl_id, fapl_id)))
+        (f1 = H5F__efc_open(f0->shared->efc, filename[1], H5F_ACC_RDWR | H5F_ACC_CREAT | H5F_ACC_TRUNC, fcpl_id, fapl_id)))
         FAIL_STACK_ERROR;
     if (NULL == (ftmp1 = H5F_open(filename[1], H5F_ACC_RDWR, fcpl_id, fapl_id)))
         FAIL_STACK_ERROR;
@@ -286,7 +286,7 @@ test_single(void)
         TEST_ERROR;
 
     if (NULL ==
-        (f2 = H5F__efc_open(f0, filename[2], H5F_ACC_RDWR | H5F_ACC_CREAT | H5F_ACC_TRUNC, fcpl_id, fapl_id)))
+        (f2 = H5F__efc_open(f0->shared->efc, filename[2], H5F_ACC_RDWR | H5F_ACC_CREAT | H5F_ACC_TRUNC, fcpl_id, fapl_id)))
         FAIL_STACK_ERROR;
     if (H5F_efc_close(f0, f2) < 0)
         FAIL_STACK_ERROR;
@@ -296,7 +296,7 @@ test_single(void)
         TEST_ERROR;
 
     if (NULL ==
-        (f3 = H5F__efc_open(f0, filename[3], H5F_ACC_RDWR | H5F_ACC_CREAT | H5F_ACC_TRUNC, fcpl_id, fapl_id)))
+        (f3 = H5F__efc_open(f0->shared->efc, filename[3], H5F_ACC_RDWR | H5F_ACC_CREAT | H5F_ACC_TRUNC, fcpl_id, fapl_id)))
         FAIL_STACK_ERROR;
     if (H5F_efc_close(f0, f3) < 0)
         FAIL_STACK_ERROR;
@@ -304,7 +304,7 @@ test_single(void)
         TEST_ERROR;
 
     if (NULL ==
-        (f4 = H5F__efc_open(f0, filename[4], H5F_ACC_RDWR | H5F_ACC_CREAT | H5F_ACC_TRUNC, fcpl_id, fapl_id)))
+        (f4 = H5F__efc_open(f0->shared->efc, filename[4], H5F_ACC_RDWR | H5F_ACC_CREAT | H5F_ACC_TRUNC, fcpl_id, fapl_id)))
         FAIL_STACK_ERROR;
     if (H5F_efc_close(f0, f4) < 0)
         FAIL_STACK_ERROR;
@@ -317,7 +317,7 @@ test_single(void)
         FAIL_STACK_ERROR;
     if (ftmp1->shared->nrefs != 2)
         TEST_ERROR;
-    if (NULL == (f2 = H5F__efc_open(f0, filename[2], H5F_ACC_RDWR, fcpl_id, fapl_id)))
+    if (NULL == (f2 = H5F__efc_open(f0->shared->efc, filename[2], H5F_ACC_RDWR, fcpl_id, fapl_id)))
         FAIL_STACK_ERROR;
     if (H5F_efc_close(f0, f2) < 0)
         FAIL_STACK_ERROR;
@@ -325,7 +325,7 @@ test_single(void)
         TEST_ERROR;
     if (ftmp2->shared->nrefs != 2)
         TEST_ERROR;
-    if (NULL == (f1 = H5F__efc_open(f0, filename[1], H5F_ACC_RDWR, fcpl_id, fapl_id)))
+    if (NULL == (f1 = H5F__efc_open(f0->shared->efc, filename[1], H5F_ACC_RDWR, fcpl_id, fapl_id)))
         FAIL_STACK_ERROR;
     if (H5F_efc_close(f0, f1) < 0)
         FAIL_STACK_ERROR;
@@ -350,7 +350,7 @@ test_single(void)
      * through the EFC, then open the fourth and verify that it was not added to
      * the EFC. */
     if (NULL ==
-        (f1 = H5F__efc_open(f0, filename[1], H5F_ACC_RDWR | H5F_ACC_CREAT | H5F_ACC_TRUNC, fcpl_id, fapl_id)))
+        (f1 = H5F__efc_open(f0->shared->efc, filename[1], H5F_ACC_RDWR | H5F_ACC_CREAT | H5F_ACC_TRUNC, fcpl_id, fapl_id)))
         FAIL_STACK_ERROR;
     if (NULL == (ftmp1 = H5F_open(filename[1], H5F_ACC_RDWR, fcpl_id, fapl_id)))
         FAIL_STACK_ERROR;
@@ -360,7 +360,7 @@ test_single(void)
         TEST_ERROR;
 
     if (NULL ==
-        (f2 = H5F__efc_open(f0, filename[2], H5F_ACC_RDWR | H5F_ACC_CREAT | H5F_ACC_TRUNC, fcpl_id, fapl_id)))
+        (f2 = H5F__efc_open(f0->shared->efc, filename[2], H5F_ACC_RDWR | H5F_ACC_CREAT | H5F_ACC_TRUNC, fcpl_id, fapl_id)))
         FAIL_STACK_ERROR;
     if (NULL == (ftmp2 = H5F_open(filename[2], H5F_ACC_RDWR, fcpl_id, fapl_id)))
         FAIL_STACK_ERROR;
@@ -370,7 +370,7 @@ test_single(void)
         TEST_ERROR;
 
     if (NULL ==
-        (f3 = H5F__efc_open(f0, filename[3], H5F_ACC_RDWR | H5F_ACC_CREAT | H5F_ACC_TRUNC, fcpl_id, fapl_id)))
+        (f3 = H5F__efc_open(f0->shared->efc, filename[3], H5F_ACC_RDWR | H5F_ACC_CREAT | H5F_ACC_TRUNC, fcpl_id, fapl_id)))
         FAIL_STACK_ERROR;
     if (NULL == (ftmp3 = H5F_open(filename[3], H5F_ACC_RDWR, fcpl_id, fapl_id)))
         FAIL_STACK_ERROR;
@@ -380,7 +380,7 @@ test_single(void)
         TEST_ERROR;
 
     if (NULL ==
-        (f4 = H5F__efc_open(f0, filename[4], H5F_ACC_RDWR | H5F_ACC_CREAT | H5F_ACC_TRUNC, fcpl_id, fapl_id)))
+        (f4 = H5F__efc_open(f0->shared->efc, filename[4], H5F_ACC_RDWR | H5F_ACC_CREAT | H5F_ACC_TRUNC, fcpl_id, fapl_id)))
         FAIL_STACK_ERROR;
     if (H5F_efc_close(f0, f4) < 0)
         FAIL_STACK_ERROR;
@@ -423,10 +423,10 @@ test_single(void)
     /* Test 7: Test multiple file opens.  Open a file twice, close it once, then
      * verify that it is not evicted by H5F__efc_release(). */
     if (NULL ==
-        (f1 = H5F__efc_open(f0, filename[1], H5F_ACC_RDWR | H5F_ACC_CREAT | H5F_ACC_TRUNC, fcpl_id, fapl_id)))
+        (f1 = H5F__efc_open(f0->shared->efc, filename[1], H5F_ACC_RDWR | H5F_ACC_CREAT | H5F_ACC_TRUNC, fcpl_id, fapl_id)))
         FAIL_STACK_ERROR;
     if (NULL ==
-        (f2 = H5F__efc_open(f0, filename[1], H5F_ACC_RDWR | H5F_ACC_CREAT | H5F_ACC_TRUNC, fcpl_id, fapl_id)))
+        (f2 = H5F__efc_open(f0->shared->efc, filename[1], H5F_ACC_RDWR | H5F_ACC_CREAT | H5F_ACC_TRUNC, fcpl_id, fapl_id)))
         FAIL_STACK_ERROR;
     if (NULL == (ftmp1 = H5F_open(filename[1], H5F_ACC_RDWR, fcpl_id, fapl_id)))
         FAIL_STACK_ERROR;
@@ -505,10 +505,10 @@ test_graph_nocycle(void)
     if (NULL == (f0 = H5F_open(filename[0], H5F_ACC_RDWR | H5F_ACC_CREAT | H5F_ACC_TRUNC, fcpl_id, fapl_id)))
         FAIL_STACK_ERROR;
     if (NULL ==
-        (f1 = H5F__efc_open(f0, filename[1], H5F_ACC_RDWR | H5F_ACC_CREAT | H5F_ACC_TRUNC, fcpl_id, fapl_id)))
+        (f1 = H5F__efc_open(f0->shared->efc, filename[1], H5F_ACC_RDWR | H5F_ACC_CREAT | H5F_ACC_TRUNC, fcpl_id, fapl_id)))
         FAIL_STACK_ERROR;
     if (NULL ==
-        (f2 = H5F__efc_open(f1, filename[2], H5F_ACC_RDWR | H5F_ACC_CREAT | H5F_ACC_TRUNC, fcpl_id, fapl_id)))
+        (f2 = H5F__efc_open(f1->shared->efc, filename[2], H5F_ACC_RDWR | H5F_ACC_CREAT | H5F_ACC_TRUNC, fcpl_id, fapl_id)))
         FAIL_STACK_ERROR;
     if (H5F_efc_close(f1, f2) < 0)
         FAIL_STACK_ERROR;
@@ -532,10 +532,10 @@ test_graph_nocycle(void)
     if (NULL ==
         (ftmp1 = H5F_open(filename[1], H5F_ACC_RDWR | H5F_ACC_CREAT | H5F_ACC_TRUNC, fcpl_id, fapl_id)))
         FAIL_STACK_ERROR;
-    if (NULL == (f2 = H5F__efc_open(ftmp1, filename[2], H5F_ACC_RDWR | H5F_ACC_CREAT | H5F_ACC_TRUNC, fcpl_id,
+    if (NULL == (f2 = H5F__efc_open(ftmp1->shared->efc, filename[2], H5F_ACC_RDWR | H5F_ACC_CREAT | H5F_ACC_TRUNC, fcpl_id,
                                     fapl_id)))
         FAIL_STACK_ERROR;
-    if (NULL == (f1 = H5F__efc_open(f0, filename[1], H5F_ACC_RDWR, fcpl_id, fapl_id)))
+    if (NULL == (f1 = H5F__efc_open(f0->shared->efc, filename[1], H5F_ACC_RDWR, fcpl_id, fapl_id)))
         FAIL_STACK_ERROR;
     if (H5F_try_close(ftmp1, NULL) < 0)
         FAIL_STACK_ERROR;
@@ -563,10 +563,10 @@ test_graph_nocycle(void)
         FAIL_STACK_ERROR;
 
     if (NULL ==
-        (f1 = H5F__efc_open(f0, filename[1], H5F_ACC_RDWR | H5F_ACC_CREAT | H5F_ACC_TRUNC, fcpl_id, fapl_id)))
+        (f1 = H5F__efc_open(f0->shared->efc, filename[1], H5F_ACC_RDWR | H5F_ACC_CREAT | H5F_ACC_TRUNC, fcpl_id, fapl_id)))
         FAIL_STACK_ERROR;
     if (NULL ==
-        (f2 = H5F__efc_open(f1, filename[2], H5F_ACC_RDWR | H5F_ACC_CREAT | H5F_ACC_TRUNC, fcpl_id, fapl_id)))
+        (f2 = H5F__efc_open(f1->shared->efc, filename[2], H5F_ACC_RDWR | H5F_ACC_CREAT | H5F_ACC_TRUNC, fcpl_id, fapl_id)))
         FAIL_STACK_ERROR;
     if (H5F_efc_close(f1, f2) < 0)
         FAIL_STACK_ERROR;
@@ -578,10 +578,10 @@ test_graph_nocycle(void)
         TEST_ERROR;
 
     if (NULL ==
-        (f3 = H5F__efc_open(f0, filename[3], H5F_ACC_RDWR | H5F_ACC_CREAT | H5F_ACC_TRUNC, fcpl_id, fapl_id)))
+        (f3 = H5F__efc_open(f0->shared->efc, filename[3], H5F_ACC_RDWR | H5F_ACC_CREAT | H5F_ACC_TRUNC, fcpl_id, fapl_id)))
         FAIL_STACK_ERROR;
     if (NULL ==
-        (f4 = H5F__efc_open(f3, filename[4], H5F_ACC_RDWR | H5F_ACC_CREAT | H5F_ACC_TRUNC, fcpl_id, fapl_id)))
+        (f4 = H5F__efc_open(f3->shared->efc, filename[4], H5F_ACC_RDWR | H5F_ACC_CREAT | H5F_ACC_TRUNC, fcpl_id, fapl_id)))
         FAIL_STACK_ERROR;
     if (H5F_efc_close(f3, f4) < 0)
         FAIL_STACK_ERROR;
@@ -615,12 +615,12 @@ test_graph_nocycle(void)
     if (NULL == (f1 = H5F_open(filename[1], H5F_ACC_RDWR | H5F_ACC_CREAT | H5F_ACC_TRUNC, fcpl_id, fapl_id)))
         FAIL_STACK_ERROR;
     if (NULL ==
-        (f2 = H5F__efc_open(f0, filename[2], H5F_ACC_RDWR | H5F_ACC_CREAT | H5F_ACC_TRUNC, fcpl_id, fapl_id)))
+        (f2 = H5F__efc_open(f0->shared->efc, filename[2], H5F_ACC_RDWR | H5F_ACC_CREAT | H5F_ACC_TRUNC, fcpl_id, fapl_id)))
         FAIL_STACK_ERROR;
-    if (NULL == (ftmp2 = H5F__efc_open(f1, filename[2], H5F_ACC_RDWR, fcpl_id, fapl_id)))
+    if (NULL == (ftmp2 = H5F__efc_open(f1->shared->efc, filename[2], H5F_ACC_RDWR, fcpl_id, fapl_id)))
         FAIL_STACK_ERROR;
     if (NULL ==
-        (f3 = H5F__efc_open(f2, filename[3], H5F_ACC_RDWR | H5F_ACC_CREAT | H5F_ACC_TRUNC, fcpl_id, fapl_id)))
+        (f3 = H5F__efc_open(f2->shared->efc, filename[3], H5F_ACC_RDWR | H5F_ACC_CREAT | H5F_ACC_TRUNC, fcpl_id, fapl_id)))
         FAIL_STACK_ERROR;
     if (H5F_efc_close(f2, f3) < 0)
         FAIL_STACK_ERROR;
@@ -638,7 +638,7 @@ test_graph_nocycle(void)
     if (ftmp3->shared->nrefs != 2)
         TEST_ERROR;
 
-    if (NULL == (f2 = H5F__efc_open(f0, filename[2], H5F_ACC_RDWR, fcpl_id, fapl_id)))
+    if (NULL == (f2 = H5F__efc_open(f0->shared->efc, filename[2], H5F_ACC_RDWR, fcpl_id, fapl_id)))
         FAIL_STACK_ERROR;
     if (H5F_efc_close(f0, f2) < 0)
         FAIL_STACK_ERROR;
@@ -665,17 +665,17 @@ test_graph_nocycle(void)
     if (NULL == (f0 = H5F_open(filename[0], H5F_ACC_RDWR | H5F_ACC_CREAT | H5F_ACC_TRUNC, fcpl_id, fapl_id)))
         FAIL_STACK_ERROR;
     if (NULL ==
-        (f1 = H5F__efc_open(f0, filename[1], H5F_ACC_RDWR | H5F_ACC_CREAT | H5F_ACC_TRUNC, fcpl_id, fapl_id)))
+        (f1 = H5F__efc_open(f0->shared->efc, filename[1], H5F_ACC_RDWR | H5F_ACC_CREAT | H5F_ACC_TRUNC, fcpl_id, fapl_id)))
         FAIL_STACK_ERROR;
     if (NULL ==
-        (f2 = H5F__efc_open(f0, filename[2], H5F_ACC_RDWR | H5F_ACC_CREAT | H5F_ACC_TRUNC, fcpl_id, fapl_id)))
+        (f2 = H5F__efc_open(f0->shared->efc, filename[2], H5F_ACC_RDWR | H5F_ACC_CREAT | H5F_ACC_TRUNC, fcpl_id, fapl_id)))
         FAIL_STACK_ERROR;
     if (NULL ==
-        (f3 = H5F__efc_open(f2, filename[3], H5F_ACC_RDWR | H5F_ACC_CREAT | H5F_ACC_TRUNC, fcpl_id, fapl_id)))
+        (f3 = H5F__efc_open(f2->shared->efc, filename[3], H5F_ACC_RDWR | H5F_ACC_CREAT | H5F_ACC_TRUNC, fcpl_id, fapl_id)))
         FAIL_STACK_ERROR;
     if (H5F_efc_close(f2, f3) < 0)
         FAIL_STACK_ERROR;
-    if (NULL == (f3 = H5F__efc_open(f1, filename[3], H5F_ACC_RDWR, fcpl_id, fapl_id)))
+    if (NULL == (f3 = H5F__efc_open(f1->shared->efc, filename[3], H5F_ACC_RDWR, fcpl_id, fapl_id)))
         FAIL_STACK_ERROR;
     if (H5F_efc_close(f1, f3) < 0)
         FAIL_STACK_ERROR;
@@ -704,24 +704,24 @@ test_graph_nocycle(void)
     if (NULL == (f0 = H5F_open(filename[0], H5F_ACC_RDWR | H5F_ACC_CREAT | H5F_ACC_TRUNC, fcpl_id, fapl_id)))
         FAIL_STACK_ERROR;
     if (NULL ==
-        (f1 = H5F__efc_open(f0, filename[1], H5F_ACC_RDWR | H5F_ACC_CREAT | H5F_ACC_TRUNC, fcpl_id, fapl_id)))
+        (f1 = H5F__efc_open(f0->shared->efc, filename[1], H5F_ACC_RDWR | H5F_ACC_CREAT | H5F_ACC_TRUNC, fcpl_id, fapl_id)))
         FAIL_STACK_ERROR;
     if (NULL ==
-        (f2 = H5F__efc_open(f0, filename[2], H5F_ACC_RDWR | H5F_ACC_CREAT | H5F_ACC_TRUNC, fcpl_id, fapl_id)))
+        (f2 = H5F__efc_open(f0->shared->efc, filename[2], H5F_ACC_RDWR | H5F_ACC_CREAT | H5F_ACC_TRUNC, fcpl_id, fapl_id)))
         FAIL_STACK_ERROR;
     if (NULL ==
-        (f3 = H5F__efc_open(f0, filename[3], H5F_ACC_RDWR | H5F_ACC_CREAT | H5F_ACC_TRUNC, fcpl_id, fapl_id)))
+        (f3 = H5F__efc_open(f0->shared->efc, filename[3], H5F_ACC_RDWR | H5F_ACC_CREAT | H5F_ACC_TRUNC, fcpl_id, fapl_id)))
         FAIL_STACK_ERROR;
     if (NULL ==
-        (f4 = H5F__efc_open(f0, filename[4], H5F_ACC_RDWR | H5F_ACC_CREAT | H5F_ACC_TRUNC, fcpl_id, fapl_id)))
+        (f4 = H5F__efc_open(f0->shared->efc, filename[4], H5F_ACC_RDWR | H5F_ACC_CREAT | H5F_ACC_TRUNC, fcpl_id, fapl_id)))
         FAIL_STACK_ERROR;
     if (H5F_efc_close(f0, f4) < 0)
         FAIL_STACK_ERROR;
     if (H5F_efc_close(f0, f3) < 0)
         FAIL_STACK_ERROR;
-    if (NULL == (f3 = H5F__efc_open(f1, filename[3], H5F_ACC_RDWR, fcpl_id, fapl_id)))
+    if (NULL == (f3 = H5F__efc_open(f1->shared->efc, filename[3], H5F_ACC_RDWR, fcpl_id, fapl_id)))
         FAIL_STACK_ERROR;
-    if (NULL == (f4 = H5F__efc_open(f1, filename[4], H5F_ACC_RDWR, fcpl_id, fapl_id)))
+    if (NULL == (f4 = H5F__efc_open(f1->shared->efc, filename[4], H5F_ACC_RDWR, fcpl_id, fapl_id)))
         FAIL_STACK_ERROR;
     if (H5F_efc_close(f1, f4) < 0)
         FAIL_STACK_ERROR;
@@ -729,15 +729,15 @@ test_graph_nocycle(void)
         FAIL_STACK_ERROR;
     if (H5F_efc_close(f0, f1) < 0)
         FAIL_STACK_ERROR;
-    if (NULL == (f3 = H5F__efc_open(f2, filename[3], H5F_ACC_RDWR, fcpl_id, fapl_id)))
+    if (NULL == (f3 = H5F__efc_open(f2->shared->efc, filename[3], H5F_ACC_RDWR, fcpl_id, fapl_id)))
         FAIL_STACK_ERROR;
-    if (NULL == (f4 = H5F__efc_open(f2, filename[4], H5F_ACC_RDWR, fcpl_id, fapl_id)))
+    if (NULL == (f4 = H5F__efc_open(f2->shared->efc, filename[4], H5F_ACC_RDWR, fcpl_id, fapl_id)))
         FAIL_STACK_ERROR;
     if (H5F_efc_close(f2, f4) < 0)
         FAIL_STACK_ERROR;
     if (H5F_efc_close(f0, f2) < 0)
         FAIL_STACK_ERROR;
-    if (NULL == (f4 = H5F__efc_open(f3, filename[4], H5F_ACC_RDWR, fcpl_id, fapl_id)))
+    if (NULL == (f4 = H5F__efc_open(f3->shared->efc, filename[4], H5F_ACC_RDWR, fcpl_id, fapl_id)))
         FAIL_STACK_ERROR;
     if (H5F_efc_close(f3, f4) < 0)
         FAIL_STACK_ERROR;
@@ -826,7 +826,7 @@ test_graph_cycle(void)
      */
     if (NULL == (f0 = H5F_open(filename[0], H5F_ACC_RDWR | H5F_ACC_CREAT | H5F_ACC_TRUNC, fcpl_id, fapl_id)))
         FAIL_STACK_ERROR;
-    if (NULL == (ftmp0 = H5F__efc_open(f0, filename[0], H5F_ACC_RDWR, fcpl_id, fapl_id)))
+    if (NULL == (ftmp0 = H5F__efc_open(f0->shared->efc, filename[0], H5F_ACC_RDWR, fcpl_id, fapl_id)))
         FAIL_STACK_ERROR;
     if (H5F_efc_close(f0, ftmp0) < 0)
         FAIL_STACK_ERROR;
@@ -837,7 +837,7 @@ test_graph_cycle(void)
     if (f0->shared->nrefs != 1)
         TEST_ERROR;
 
-    if (NULL == (ftmp0 = H5F__efc_open(f0, filename[0], H5F_ACC_RDWR, fcpl_id, fapl_id)))
+    if (NULL == (ftmp0 = H5F__efc_open(f0->shared->efc, filename[0], H5F_ACC_RDWR, fcpl_id, fapl_id)))
         FAIL_STACK_ERROR;
     if (H5F_efc_close(f0, ftmp0) < 0)
         FAIL_STACK_ERROR;
@@ -858,9 +858,9 @@ test_graph_cycle(void)
     if (NULL == (f0 = H5F_open(filename[0], H5F_ACC_RDWR | H5F_ACC_CREAT | H5F_ACC_TRUNC, fcpl_id, fapl_id)))
         FAIL_STACK_ERROR;
     if (NULL ==
-        (f1 = H5F__efc_open(f0, filename[1], H5F_ACC_RDWR | H5F_ACC_CREAT | H5F_ACC_TRUNC, fcpl_id, fapl_id)))
+        (f1 = H5F__efc_open(f0->shared->efc, filename[1], H5F_ACC_RDWR | H5F_ACC_CREAT | H5F_ACC_TRUNC, fcpl_id, fapl_id)))
         FAIL_STACK_ERROR;
-    if (NULL == (ftmp1 = H5F__efc_open(f1, filename[1], H5F_ACC_RDWR, fcpl_id, fapl_id)))
+    if (NULL == (ftmp1 = H5F__efc_open(f1->shared->efc, filename[1], H5F_ACC_RDWR, fcpl_id, fapl_id)))
         FAIL_STACK_ERROR;
     if (H5F_efc_close(f1, ftmp1) < 0)
         FAIL_STACK_ERROR;
@@ -878,9 +878,9 @@ test_graph_cycle(void)
         FAIL_STACK_ERROR;
 
     if (NULL ==
-        (f1 = H5F__efc_open(f0, filename[1], H5F_ACC_RDWR | H5F_ACC_CREAT | H5F_ACC_TRUNC, fcpl_id, fapl_id)))
+        (f1 = H5F__efc_open(f0->shared->efc, filename[1], H5F_ACC_RDWR | H5F_ACC_CREAT | H5F_ACC_TRUNC, fcpl_id, fapl_id)))
         FAIL_STACK_ERROR;
-    if (NULL == (ftmp1 = H5F__efc_open(f1, filename[1], H5F_ACC_RDWR, fcpl_id, fapl_id)))
+    if (NULL == (ftmp1 = H5F__efc_open(f1->shared->efc, filename[1], H5F_ACC_RDWR, fcpl_id, fapl_id)))
         FAIL_STACK_ERROR;
     if (H5F_efc_close(f1, ftmp1) < 0)
         FAIL_STACK_ERROR;
@@ -901,9 +901,9 @@ test_graph_cycle(void)
     if (NULL == (f0 = H5F_open(filename[0], H5F_ACC_RDWR | H5F_ACC_CREAT | H5F_ACC_TRUNC, fcpl_id, fapl_id)))
         FAIL_STACK_ERROR;
     if (NULL ==
-        (f1 = H5F__efc_open(f0, filename[1], H5F_ACC_RDWR | H5F_ACC_CREAT | H5F_ACC_TRUNC, fcpl_id, fapl_id)))
+        (f1 = H5F__efc_open(f0->shared->efc, filename[1], H5F_ACC_RDWR | H5F_ACC_CREAT | H5F_ACC_TRUNC, fcpl_id, fapl_id)))
         FAIL_STACK_ERROR;
-    if (NULL == (ftmp0 = H5F__efc_open(f1, filename[0], H5F_ACC_RDWR, fcpl_id, fapl_id)))
+    if (NULL == (ftmp0 = H5F__efc_open(f1->shared->efc, filename[0], H5F_ACC_RDWR, fcpl_id, fapl_id)))
         FAIL_STACK_ERROR;
     if (H5F_efc_close(f1, ftmp0) < 0)
         FAIL_STACK_ERROR;
@@ -917,9 +917,9 @@ test_graph_cycle(void)
         TEST_ERROR;
 
     if (NULL ==
-        (f1 = H5F__efc_open(f0, filename[1], H5F_ACC_RDWR | H5F_ACC_CREAT | H5F_ACC_TRUNC, fcpl_id, fapl_id)))
+        (f1 = H5F__efc_open(f0->shared->efc, filename[1], H5F_ACC_RDWR | H5F_ACC_CREAT | H5F_ACC_TRUNC, fcpl_id, fapl_id)))
         FAIL_STACK_ERROR;
-    if (NULL == (ftmp0 = H5F__efc_open(f1, filename[0], H5F_ACC_RDWR, fcpl_id, fapl_id)))
+    if (NULL == (ftmp0 = H5F__efc_open(f1->shared->efc, filename[0], H5F_ACC_RDWR, fcpl_id, fapl_id)))
         FAIL_STACK_ERROR;
     if (H5F_efc_close(f1, ftmp0) < 0)
         FAIL_STACK_ERROR;
@@ -940,12 +940,12 @@ test_graph_cycle(void)
     if (NULL == (f0 = H5F_open(filename[0], H5F_ACC_RDWR | H5F_ACC_CREAT | H5F_ACC_TRUNC, fcpl_id, fapl_id)))
         FAIL_STACK_ERROR;
     if (NULL ==
-        (f1 = H5F__efc_open(f0, filename[1], H5F_ACC_RDWR | H5F_ACC_CREAT | H5F_ACC_TRUNC, fcpl_id, fapl_id)))
+        (f1 = H5F__efc_open(f0->shared->efc, filename[1], H5F_ACC_RDWR | H5F_ACC_CREAT | H5F_ACC_TRUNC, fcpl_id, fapl_id)))
         FAIL_STACK_ERROR;
     if (NULL ==
-        (f2 = H5F__efc_open(f1, filename[2], H5F_ACC_RDWR | H5F_ACC_CREAT | H5F_ACC_TRUNC, fcpl_id, fapl_id)))
+        (f2 = H5F__efc_open(f1->shared->efc, filename[2], H5F_ACC_RDWR | H5F_ACC_CREAT | H5F_ACC_TRUNC, fcpl_id, fapl_id)))
         FAIL_STACK_ERROR;
-    if (NULL == (ftmp1 = H5F__efc_open(f2, filename[1], H5F_ACC_RDWR, fcpl_id, fapl_id)))
+    if (NULL == (ftmp1 = H5F__efc_open(f2->shared->efc, filename[1], H5F_ACC_RDWR, fcpl_id, fapl_id)))
         FAIL_STACK_ERROR;
     if (H5F_efc_close(f2, ftmp1) < 0)
         FAIL_STACK_ERROR;
@@ -968,18 +968,18 @@ test_graph_cycle(void)
     if (NULL == (f0 = H5F_open(filename[0], H5F_ACC_RDWR | H5F_ACC_CREAT | H5F_ACC_TRUNC, fcpl_id, fapl_id)))
         FAIL_STACK_ERROR;
     if (NULL ==
-        (f1 = H5F__efc_open(f0, filename[1], H5F_ACC_RDWR | H5F_ACC_CREAT | H5F_ACC_TRUNC, fcpl_id, fapl_id)))
+        (f1 = H5F__efc_open(f0->shared->efc, filename[1], H5F_ACC_RDWR | H5F_ACC_CREAT | H5F_ACC_TRUNC, fcpl_id, fapl_id)))
         FAIL_STACK_ERROR;
-    if (NULL == (ftmp0 = H5F__efc_open(f1, filename[0], H5F_ACC_RDWR, fcpl_id, fapl_id)))
+    if (NULL == (ftmp0 = H5F__efc_open(f1->shared->efc, filename[0], H5F_ACC_RDWR, fcpl_id, fapl_id)))
         FAIL_STACK_ERROR;
     if (H5F_efc_close(f1, ftmp0) < 0)
         FAIL_STACK_ERROR;
     if (H5F_efc_close(f0, f1) < 0)
         FAIL_STACK_ERROR;
     if (NULL ==
-        (f2 = H5F__efc_open(f0, filename[2], H5F_ACC_RDWR | H5F_ACC_CREAT | H5F_ACC_TRUNC, fcpl_id, fapl_id)))
+        (f2 = H5F__efc_open(f0->shared->efc, filename[2], H5F_ACC_RDWR | H5F_ACC_CREAT | H5F_ACC_TRUNC, fcpl_id, fapl_id)))
         FAIL_STACK_ERROR;
-    if (NULL == (ftmp0 = H5F__efc_open(f2, filename[0], H5F_ACC_RDWR, fcpl_id, fapl_id)))
+    if (NULL == (ftmp0 = H5F__efc_open(f2->shared->efc, filename[0], H5F_ACC_RDWR, fcpl_id, fapl_id)))
         FAIL_STACK_ERROR;
     if (H5F_efc_close(f2, ftmp0) < 0)
         FAIL_STACK_ERROR;
@@ -1000,18 +1000,18 @@ test_graph_cycle(void)
     if (NULL == (f0 = H5F_open(filename[0], H5F_ACC_RDWR | H5F_ACC_CREAT | H5F_ACC_TRUNC, fcpl_id, fapl_id)))
         FAIL_STACK_ERROR;
     if (NULL ==
-        (f1 = H5F__efc_open(f0, filename[1], H5F_ACC_RDWR | H5F_ACC_CREAT | H5F_ACC_TRUNC, fcpl_id, fapl_id)))
+        (f1 = H5F__efc_open(f0->shared->efc, filename[1], H5F_ACC_RDWR | H5F_ACC_CREAT | H5F_ACC_TRUNC, fcpl_id, fapl_id)))
         FAIL_STACK_ERROR;
-    if (NULL == (ftmp0 = H5F__efc_open(f1, filename[0], H5F_ACC_RDWR, fcpl_id, fapl_id)))
+    if (NULL == (ftmp0 = H5F__efc_open(f1->shared->efc, filename[0], H5F_ACC_RDWR, fcpl_id, fapl_id)))
         FAIL_STACK_ERROR;
     if (H5F_efc_close(f1, ftmp0) < 0)
         FAIL_STACK_ERROR;
     if (H5F_efc_close(f0, f1) < 0)
         FAIL_STACK_ERROR;
     if (NULL ==
-        (f2 = H5F__efc_open(f0, filename[2], H5F_ACC_RDWR | H5F_ACC_CREAT | H5F_ACC_TRUNC, fcpl_id, fapl_id)))
+        (f2 = H5F__efc_open(f0->shared->efc, filename[2], H5F_ACC_RDWR | H5F_ACC_CREAT | H5F_ACC_TRUNC, fcpl_id, fapl_id)))
         FAIL_STACK_ERROR;
-    if (NULL == (ftmp0 = H5F__efc_open(f2, filename[0], H5F_ACC_RDWR, fcpl_id, fapl_id)))
+    if (NULL == (ftmp0 = H5F__efc_open(f2->shared->efc, filename[0], H5F_ACC_RDWR, fcpl_id, fapl_id)))
         FAIL_STACK_ERROR;
     if (H5F_efc_close(f2, ftmp0) < 0)
         FAIL_STACK_ERROR;
@@ -1030,23 +1030,23 @@ test_graph_cycle(void)
     if (NULL == (f0 = H5F_open(filename[0], H5F_ACC_RDWR | H5F_ACC_CREAT | H5F_ACC_TRUNC, fcpl_id, fapl_id)))
         FAIL_STACK_ERROR;
     if (NULL ==
-        (f1 = H5F__efc_open(f0, filename[1], H5F_ACC_RDWR | H5F_ACC_CREAT | H5F_ACC_TRUNC, fcpl_id, fapl_id)))
+        (f1 = H5F__efc_open(f0->shared->efc, filename[1], H5F_ACC_RDWR | H5F_ACC_CREAT | H5F_ACC_TRUNC, fcpl_id, fapl_id)))
         FAIL_STACK_ERROR;
-    if (NULL == (ftmp0 = H5F__efc_open(f1, filename[0], H5F_ACC_RDWR, fcpl_id, fapl_id)))
+    if (NULL == (ftmp0 = H5F__efc_open(f1->shared->efc, filename[0], H5F_ACC_RDWR, fcpl_id, fapl_id)))
         FAIL_STACK_ERROR;
     if (NULL ==
-        (f2 = H5F__efc_open(f1, filename[2], H5F_ACC_RDWR | H5F_ACC_CREAT | H5F_ACC_TRUNC, fcpl_id, fapl_id)))
+        (f2 = H5F__efc_open(f1->shared->efc, filename[2], H5F_ACC_RDWR | H5F_ACC_CREAT | H5F_ACC_TRUNC, fcpl_id, fapl_id)))
         FAIL_STACK_ERROR;
-    if (NULL == (ftmp1 = H5F__efc_open(f2, filename[1], H5F_ACC_RDWR, fcpl_id, fapl_id)))
+    if (NULL == (ftmp1 = H5F__efc_open(f2->shared->efc, filename[1], H5F_ACC_RDWR, fcpl_id, fapl_id)))
         FAIL_STACK_ERROR;
     if (H5F_efc_close(f2, ftmp1) < 0)
         FAIL_STACK_ERROR;
     if (H5F_efc_close(f1, f2) < 0)
         FAIL_STACK_ERROR;
     if (NULL ==
-        (f3 = H5F__efc_open(f1, filename[3], H5F_ACC_RDWR | H5F_ACC_CREAT | H5F_ACC_TRUNC, fcpl_id, fapl_id)))
+        (f3 = H5F__efc_open(f1->shared->efc, filename[3], H5F_ACC_RDWR | H5F_ACC_CREAT | H5F_ACC_TRUNC, fcpl_id, fapl_id)))
         FAIL_STACK_ERROR;
-    if (NULL == (ftmp1 = H5F__efc_open(f3, filename[1], H5F_ACC_RDWR, fcpl_id, fapl_id)))
+    if (NULL == (ftmp1 = H5F__efc_open(f3->shared->efc, filename[1], H5F_ACC_RDWR, fcpl_id, fapl_id)))
         FAIL_STACK_ERROR;
     if (H5F_efc_close(f3, ftmp1) < 0)
         FAIL_STACK_ERROR;
@@ -1071,23 +1071,23 @@ test_graph_cycle(void)
     if (NULL == (f0 = H5F_open(filename[0], H5F_ACC_RDWR | H5F_ACC_CREAT | H5F_ACC_TRUNC, fcpl_id, fapl_id)))
         FAIL_STACK_ERROR;
     if (NULL ==
-        (f1 = H5F__efc_open(f0, filename[1], H5F_ACC_RDWR | H5F_ACC_CREAT | H5F_ACC_TRUNC, fcpl_id, fapl_id)))
+        (f1 = H5F__efc_open(f0->shared->efc, filename[1], H5F_ACC_RDWR | H5F_ACC_CREAT | H5F_ACC_TRUNC, fcpl_id, fapl_id)))
         FAIL_STACK_ERROR;
-    if (NULL == (ftmp0 = H5F__efc_open(f1, filename[0], H5F_ACC_RDWR, fcpl_id, fapl_id)))
+    if (NULL == (ftmp0 = H5F__efc_open(f1->shared->efc, filename[0], H5F_ACC_RDWR, fcpl_id, fapl_id)))
         FAIL_STACK_ERROR;
     if (NULL ==
-        (f2 = H5F__efc_open(f1, filename[2], H5F_ACC_RDWR | H5F_ACC_CREAT | H5F_ACC_TRUNC, fcpl_id, fapl_id)))
+        (f2 = H5F__efc_open(f1->shared->efc, filename[2], H5F_ACC_RDWR | H5F_ACC_CREAT | H5F_ACC_TRUNC, fcpl_id, fapl_id)))
         FAIL_STACK_ERROR;
-    if (NULL == (ftmp1 = H5F__efc_open(f2, filename[1], H5F_ACC_RDWR, fcpl_id, fapl_id)))
+    if (NULL == (ftmp1 = H5F__efc_open(f2->shared->efc, filename[1], H5F_ACC_RDWR, fcpl_id, fapl_id)))
         FAIL_STACK_ERROR;
     if (H5F_efc_close(f2, ftmp1) < 0)
         FAIL_STACK_ERROR;
     if (H5F_efc_close(f1, f2) < 0)
         FAIL_STACK_ERROR;
     if (NULL ==
-        (f3 = H5F__efc_open(f1, filename[3], H5F_ACC_RDWR | H5F_ACC_CREAT | H5F_ACC_TRUNC, fcpl_id, fapl_id)))
+        (f3 = H5F__efc_open(f1->shared->efc, filename[3], H5F_ACC_RDWR | H5F_ACC_CREAT | H5F_ACC_TRUNC, fcpl_id, fapl_id)))
         FAIL_STACK_ERROR;
-    if (NULL == (ftmp1 = H5F__efc_open(f3, filename[1], H5F_ACC_RDWR, fcpl_id, fapl_id)))
+    if (NULL == (ftmp1 = H5F__efc_open(f3->shared->efc, filename[1], H5F_ACC_RDWR, fcpl_id, fapl_id)))
         FAIL_STACK_ERROR;
     if (H5F_efc_close(f3, ftmp1) < 0)
         FAIL_STACK_ERROR;
@@ -1112,9 +1112,9 @@ test_graph_cycle(void)
     if (NULL == (ftmp0 = H5F_open(filename[0], H5F_ACC_RDWR, fcpl_id, fapl_id)))
         FAIL_STACK_ERROR;
     if (NULL ==
-        (f1 = H5F__efc_open(f0, filename[1], H5F_ACC_RDWR | H5F_ACC_CREAT | H5F_ACC_TRUNC, fcpl_id, fapl_id)))
+        (f1 = H5F__efc_open(f0->shared->efc, filename[1], H5F_ACC_RDWR | H5F_ACC_CREAT | H5F_ACC_TRUNC, fcpl_id, fapl_id)))
         FAIL_STACK_ERROR;
-    if (NULL == (ftmp1 = H5F__efc_open(f1, filename[0], H5F_ACC_RDWR, fcpl_id, fapl_id)))
+    if (NULL == (ftmp1 = H5F__efc_open(f1->shared->efc, filename[0], H5F_ACC_RDWR, fcpl_id, fapl_id)))
         FAIL_STACK_ERROR;
     if (H5F_efc_close(f1, ftmp1) < 0)
         FAIL_STACK_ERROR;
@@ -1141,11 +1141,11 @@ test_graph_cycle(void)
     if (NULL == (f0 = H5F_open(filename[0], H5F_ACC_RDWR | H5F_ACC_CREAT | H5F_ACC_TRUNC, fcpl_id, fapl_id)))
         FAIL_STACK_ERROR;
     if (NULL ==
-        (f1 = H5F__efc_open(f0, filename[1], H5F_ACC_RDWR | H5F_ACC_CREAT | H5F_ACC_TRUNC, fcpl_id, fapl_id)))
+        (f1 = H5F__efc_open(f0->shared->efc, filename[1], H5F_ACC_RDWR | H5F_ACC_CREAT | H5F_ACC_TRUNC, fcpl_id, fapl_id)))
         FAIL_STACK_ERROR;
     if (NULL == (ftmp1 = H5F_open(filename[1], H5F_ACC_RDWR, fcpl_id, fapl_id)))
         FAIL_STACK_ERROR;
-    if (NULL == (ftmp0 = H5F__efc_open(f1, filename[0], H5F_ACC_RDWR, fcpl_id, fapl_id)))
+    if (NULL == (ftmp0 = H5F__efc_open(f1->shared->efc, filename[0], H5F_ACC_RDWR, fcpl_id, fapl_id)))
         FAIL_STACK_ERROR;
     if (H5F_efc_close(f1, ftmp0) < 0)
         FAIL_STACK_ERROR;
@@ -1186,20 +1186,20 @@ test_graph_cycle(void)
     if (NULL == (f0 = H5F_open(filename[0], H5F_ACC_RDWR | H5F_ACC_CREAT | H5F_ACC_TRUNC, fcpl_id, fapl_id)))
         FAIL_STACK_ERROR;
     if (NULL ==
-        (f1 = H5F__efc_open(f0, filename[1], H5F_ACC_RDWR | H5F_ACC_CREAT | H5F_ACC_TRUNC, fcpl_id, fapl_id)))
+        (f1 = H5F__efc_open(f0->shared->efc, filename[1], H5F_ACC_RDWR | H5F_ACC_CREAT | H5F_ACC_TRUNC, fcpl_id, fapl_id)))
         FAIL_STACK_ERROR;
-    if (NULL == (ftmp0 = H5F__efc_open(f1, filename[0], H5F_ACC_RDWR, fcpl_id, fapl_id)))
+    if (NULL == (ftmp0 = H5F__efc_open(f1->shared->efc, filename[0], H5F_ACC_RDWR, fcpl_id, fapl_id)))
         FAIL_STACK_ERROR;
     if (H5F_efc_close(f1, ftmp0) < 0)
         FAIL_STACK_ERROR;
     if (H5F_efc_close(f0, f1) < 0)
         FAIL_STACK_ERROR;
     if (NULL ==
-        (f2 = H5F__efc_open(f0, filename[2], H5F_ACC_RDWR | H5F_ACC_CREAT | H5F_ACC_TRUNC, fcpl_id, fapl_id)))
+        (f2 = H5F__efc_open(f0->shared->efc, filename[2], H5F_ACC_RDWR | H5F_ACC_CREAT | H5F_ACC_TRUNC, fcpl_id, fapl_id)))
         FAIL_STACK_ERROR;
     if (NULL == (ftmp2 = H5F_open(filename[2], H5F_ACC_RDWR, fcpl_id, fapl_id)))
         FAIL_STACK_ERROR;
-    if (NULL == (ftmp0 = H5F__efc_open(f2, filename[0], H5F_ACC_RDWR, fcpl_id, fapl_id)))
+    if (NULL == (ftmp0 = H5F__efc_open(f2->shared->efc, filename[0], H5F_ACC_RDWR, fcpl_id, fapl_id)))
         FAIL_STACK_ERROR;
     if (H5F_efc_close(f2, ftmp0) < 0)
         FAIL_STACK_ERROR;
@@ -1246,20 +1246,20 @@ test_graph_cycle(void)
     if (NULL == (f0 = H5F_open(filename[0], H5F_ACC_RDWR | H5F_ACC_CREAT | H5F_ACC_TRUNC, fcpl_id, fapl_id)))
         FAIL_STACK_ERROR;
     if (NULL ==
-        (f1 = H5F__efc_open(f0, filename[1], H5F_ACC_RDWR | H5F_ACC_CREAT | H5F_ACC_TRUNC, fcpl_id, fapl_id)))
+        (f1 = H5F__efc_open(f0->shared->efc, filename[1], H5F_ACC_RDWR | H5F_ACC_CREAT | H5F_ACC_TRUNC, fcpl_id, fapl_id)))
         FAIL_STACK_ERROR;
-    if (NULL == (ftmp0 = H5F__efc_open(f1, filename[0], H5F_ACC_RDWR, fcpl_id, fapl_id)))
+    if (NULL == (ftmp0 = H5F__efc_open(f1->shared->efc, filename[0], H5F_ACC_RDWR, fcpl_id, fapl_id)))
         FAIL_STACK_ERROR;
     if (H5F_efc_close(f1, ftmp0) < 0)
         FAIL_STACK_ERROR;
     if (H5F_efc_close(f0, f1) < 0)
         FAIL_STACK_ERROR;
     if (NULL ==
-        (f2 = H5F__efc_open(f0, filename[2], H5F_ACC_RDWR | H5F_ACC_CREAT | H5F_ACC_TRUNC, fcpl_id, fapl_id)))
+        (f2 = H5F__efc_open(f0->shared->efc, filename[2], H5F_ACC_RDWR | H5F_ACC_CREAT | H5F_ACC_TRUNC, fcpl_id, fapl_id)))
         FAIL_STACK_ERROR;
     if (NULL == (ftmp2 = H5F_open(filename[2], H5F_ACC_RDWR, fcpl_id, fapl_id)))
         FAIL_STACK_ERROR;
-    if (NULL == (ftmp0 = H5F__efc_open(f2, filename[0], H5F_ACC_RDWR, fcpl_id, fapl_id)))
+    if (NULL == (ftmp0 = H5F__efc_open(f2->shared->efc, filename[0], H5F_ACC_RDWR, fcpl_id, fapl_id)))
         FAIL_STACK_ERROR;
     if (H5F_efc_close(f2, ftmp0) < 0)
         FAIL_STACK_ERROR;
@@ -1292,25 +1292,25 @@ test_graph_cycle(void)
     if (NULL == (f0 = H5F_open(filename[0], H5F_ACC_RDWR | H5F_ACC_CREAT | H5F_ACC_TRUNC, fcpl_id, fapl_id)))
         FAIL_STACK_ERROR;
     if (NULL ==
-        (f1 = H5F__efc_open(f0, filename[1], H5F_ACC_RDWR | H5F_ACC_CREAT | H5F_ACC_TRUNC, fcpl_id, fapl_id)))
+        (f1 = H5F__efc_open(f0->shared->efc, filename[1], H5F_ACC_RDWR | H5F_ACC_CREAT | H5F_ACC_TRUNC, fcpl_id, fapl_id)))
         FAIL_STACK_ERROR;
-    if (NULL == (ftmp0 = H5F__efc_open(f1, filename[0], H5F_ACC_RDWR, fcpl_id, fapl_id)))
+    if (NULL == (ftmp0 = H5F__efc_open(f1->shared->efc, filename[0], H5F_ACC_RDWR, fcpl_id, fapl_id)))
         FAIL_STACK_ERROR;
     if (NULL ==
-        (f2 = H5F__efc_open(f1, filename[2], H5F_ACC_RDWR | H5F_ACC_CREAT | H5F_ACC_TRUNC, fcpl_id, fapl_id)))
+        (f2 = H5F__efc_open(f1->shared->efc, filename[2], H5F_ACC_RDWR | H5F_ACC_CREAT | H5F_ACC_TRUNC, fcpl_id, fapl_id)))
         FAIL_STACK_ERROR;
-    if (NULL == (ftmp1 = H5F__efc_open(f2, filename[1], H5F_ACC_RDWR, fcpl_id, fapl_id)))
+    if (NULL == (ftmp1 = H5F__efc_open(f2->shared->efc, filename[1], H5F_ACC_RDWR, fcpl_id, fapl_id)))
         FAIL_STACK_ERROR;
     if (H5F_efc_close(f2, ftmp1) < 0)
         FAIL_STACK_ERROR;
     if (H5F_efc_close(f1, f2) < 0)
         FAIL_STACK_ERROR;
     if (NULL ==
-        (f3 = H5F__efc_open(f1, filename[3], H5F_ACC_RDWR | H5F_ACC_CREAT | H5F_ACC_TRUNC, fcpl_id, fapl_id)))
+        (f3 = H5F__efc_open(f1->shared->efc, filename[3], H5F_ACC_RDWR | H5F_ACC_CREAT | H5F_ACC_TRUNC, fcpl_id, fapl_id)))
         FAIL_STACK_ERROR;
     if (NULL == (ftmp3 = H5F_open(filename[3], H5F_ACC_RDWR, fcpl_id, fapl_id)))
         FAIL_STACK_ERROR;
-    if (NULL == (ftmp1 = H5F__efc_open(f3, filename[1], H5F_ACC_RDWR, fcpl_id, fapl_id)))
+    if (NULL == (ftmp1 = H5F__efc_open(f3->shared->efc, filename[1], H5F_ACC_RDWR, fcpl_id, fapl_id)))
         FAIL_STACK_ERROR;
     if (H5F_efc_close(f3, ftmp1) < 0)
         FAIL_STACK_ERROR;
@@ -1368,25 +1368,25 @@ test_graph_cycle(void)
     if (NULL == (f0 = H5F_open(filename[0], H5F_ACC_RDWR | H5F_ACC_CREAT | H5F_ACC_TRUNC, fcpl_id, fapl_id)))
         FAIL_STACK_ERROR;
     if (NULL ==
-        (f1 = H5F__efc_open(f0, filename[1], H5F_ACC_RDWR | H5F_ACC_CREAT | H5F_ACC_TRUNC, fcpl_id, fapl_id)))
+        (f1 = H5F__efc_open(f0->shared->efc, filename[1], H5F_ACC_RDWR | H5F_ACC_CREAT | H5F_ACC_TRUNC, fcpl_id, fapl_id)))
         FAIL_STACK_ERROR;
-    if (NULL == (ftmp0 = H5F__efc_open(f1, filename[0], H5F_ACC_RDWR, fcpl_id, fapl_id)))
+    if (NULL == (ftmp0 = H5F__efc_open(f1->shared->efc, filename[0], H5F_ACC_RDWR, fcpl_id, fapl_id)))
         FAIL_STACK_ERROR;
     if (NULL ==
-        (f2 = H5F__efc_open(f1, filename[2], H5F_ACC_RDWR | H5F_ACC_CREAT | H5F_ACC_TRUNC, fcpl_id, fapl_id)))
+        (f2 = H5F__efc_open(f1->shared->efc, filename[2], H5F_ACC_RDWR | H5F_ACC_CREAT | H5F_ACC_TRUNC, fcpl_id, fapl_id)))
         FAIL_STACK_ERROR;
-    if (NULL == (ftmp1 = H5F__efc_open(f2, filename[1], H5F_ACC_RDWR, fcpl_id, fapl_id)))
+    if (NULL == (ftmp1 = H5F__efc_open(f2->shared->efc, filename[1], H5F_ACC_RDWR, fcpl_id, fapl_id)))
         FAIL_STACK_ERROR;
     if (H5F_efc_close(f2, ftmp1) < 0)
         FAIL_STACK_ERROR;
     if (H5F_efc_close(f1, f2) < 0)
         FAIL_STACK_ERROR;
     if (NULL ==
-        (f3 = H5F__efc_open(f1, filename[3], H5F_ACC_RDWR | H5F_ACC_CREAT | H5F_ACC_TRUNC, fcpl_id, fapl_id)))
+        (f3 = H5F__efc_open(f1->shared->efc, filename[3], H5F_ACC_RDWR | H5F_ACC_CREAT | H5F_ACC_TRUNC, fcpl_id, fapl_id)))
         FAIL_STACK_ERROR;
     if (NULL == (ftmp3 = H5F_open(filename[3], H5F_ACC_RDWR, fcpl_id, fapl_id)))
         FAIL_STACK_ERROR;
-    if (NULL == (ftmp1 = H5F__efc_open(f3, filename[1], H5F_ACC_RDWR, fcpl_id, fapl_id)))
+    if (NULL == (ftmp1 = H5F__efc_open(f3->shared->efc, filename[1], H5F_ACC_RDWR, fcpl_id, fapl_id)))
         FAIL_STACK_ERROR;
     if (H5F_efc_close(f3, ftmp1) < 0)
         FAIL_STACK_ERROR;
@@ -1423,21 +1423,21 @@ test_graph_cycle(void)
     if (NULL == (f0 = H5F_open(filename[0], H5F_ACC_RDWR | H5F_ACC_CREAT | H5F_ACC_TRUNC, fcpl_id, fapl_id)))
         FAIL_STACK_ERROR;
     if (NULL ==
-        (f1 = H5F__efc_open(f0, filename[1], H5F_ACC_RDWR | H5F_ACC_CREAT | H5F_ACC_TRUNC, fcpl_id, fapl_id)))
+        (f1 = H5F__efc_open(f0->shared->efc, filename[1], H5F_ACC_RDWR | H5F_ACC_CREAT | H5F_ACC_TRUNC, fcpl_id, fapl_id)))
         FAIL_STACK_ERROR;
-    if (NULL == (ftmp0 = H5F__efc_open(f1, filename[0], H5F_ACC_RDWR, fcpl_id, fapl_id)))
+    if (NULL == (ftmp0 = H5F__efc_open(f1->shared->efc, filename[0], H5F_ACC_RDWR, fcpl_id, fapl_id)))
         FAIL_STACK_ERROR;
     if (H5F_efc_close(f1, ftmp0) < 0)
         FAIL_STACK_ERROR;
     if (H5F_efc_close(f0, f1) < 0)
         FAIL_STACK_ERROR;
     if (NULL ==
-        (f2 = H5F__efc_open(f0, filename[2], H5F_ACC_RDWR | H5F_ACC_CREAT | H5F_ACC_TRUNC, fcpl_id, fapl_id)))
+        (f2 = H5F__efc_open(f0->shared->efc, filename[2], H5F_ACC_RDWR | H5F_ACC_CREAT | H5F_ACC_TRUNC, fcpl_id, fapl_id)))
         FAIL_STACK_ERROR;
     if (NULL ==
-        (f3 = H5F__efc_open(f2, filename[3], H5F_ACC_RDWR | H5F_ACC_CREAT | H5F_ACC_TRUNC, fcpl_id, fapl_id)))
+        (f3 = H5F__efc_open(f2->shared->efc, filename[3], H5F_ACC_RDWR | H5F_ACC_CREAT | H5F_ACC_TRUNC, fcpl_id, fapl_id)))
         FAIL_STACK_ERROR;
-    if (NULL == (ftmp2 = H5F__efc_open(f3, filename[2], H5F_ACC_RDWR, fcpl_id, fapl_id)))
+    if (NULL == (ftmp2 = H5F__efc_open(f3->shared->efc, filename[2], H5F_ACC_RDWR, fcpl_id, fapl_id)))
         FAIL_STACK_ERROR;
     if (H5F_efc_close(f3, ftmp2) < 0)
         FAIL_STACK_ERROR;
@@ -1479,21 +1479,21 @@ test_graph_cycle(void)
     if (NULL == (f0 = H5F_open(filename[0], H5F_ACC_RDWR | H5F_ACC_CREAT | H5F_ACC_TRUNC, fcpl_id, fapl_id)))
         FAIL_STACK_ERROR;
     if (NULL ==
-        (f1 = H5F__efc_open(f0, filename[1], H5F_ACC_RDWR | H5F_ACC_CREAT | H5F_ACC_TRUNC, fcpl_id, fapl_id)))
+        (f1 = H5F__efc_open(f0->shared->efc, filename[1], H5F_ACC_RDWR | H5F_ACC_CREAT | H5F_ACC_TRUNC, fcpl_id, fapl_id)))
         FAIL_STACK_ERROR;
-    if (NULL == (ftmp0 = H5F__efc_open(f1, filename[0], H5F_ACC_RDWR, fcpl_id, fapl_id)))
+    if (NULL == (ftmp0 = H5F__efc_open(f1->shared->efc, filename[0], H5F_ACC_RDWR, fcpl_id, fapl_id)))
         FAIL_STACK_ERROR;
     if (H5F_efc_close(f1, ftmp0) < 0)
         FAIL_STACK_ERROR;
     if (H5F_efc_close(f0, f1) < 0)
         FAIL_STACK_ERROR;
     if (NULL ==
-        (f2 = H5F__efc_open(f0, filename[2], H5F_ACC_RDWR | H5F_ACC_CREAT | H5F_ACC_TRUNC, fcpl_id, fapl_id)))
+        (f2 = H5F__efc_open(f0->shared->efc, filename[2], H5F_ACC_RDWR | H5F_ACC_CREAT | H5F_ACC_TRUNC, fcpl_id, fapl_id)))
         FAIL_STACK_ERROR;
     if (NULL ==
-        (f3 = H5F__efc_open(f2, filename[3], H5F_ACC_RDWR | H5F_ACC_CREAT | H5F_ACC_TRUNC, fcpl_id, fapl_id)))
+        (f3 = H5F__efc_open(f2->shared->efc, filename[3], H5F_ACC_RDWR | H5F_ACC_CREAT | H5F_ACC_TRUNC, fcpl_id, fapl_id)))
         FAIL_STACK_ERROR;
-    if (NULL == (ftmp2 = H5F__efc_open(f3, filename[2], H5F_ACC_RDWR, fcpl_id, fapl_id)))
+    if (NULL == (ftmp2 = H5F__efc_open(f3->shared->efc, filename[2], H5F_ACC_RDWR, fcpl_id, fapl_id)))
         FAIL_STACK_ERROR;
     if (H5F_efc_close(f3, ftmp2) < 0)
         FAIL_STACK_ERROR;
@@ -1533,23 +1533,23 @@ test_graph_cycle(void)
     if (NULL == (f0 = H5F_open(filename[0], H5F_ACC_RDWR | H5F_ACC_CREAT | H5F_ACC_TRUNC, fcpl_id, fapl_id)))
         FAIL_STACK_ERROR;
     if (NULL ==
-        (f1 = H5F__efc_open(f0, filename[1], H5F_ACC_RDWR | H5F_ACC_CREAT | H5F_ACC_TRUNC, fcpl_id, fapl_id)))
+        (f1 = H5F__efc_open(f0->shared->efc, filename[1], H5F_ACC_RDWR | H5F_ACC_CREAT | H5F_ACC_TRUNC, fcpl_id, fapl_id)))
         FAIL_STACK_ERROR;
-    if (NULL == (ftmp0 = H5F__efc_open(f1, filename[0], H5F_ACC_RDWR, fcpl_id, fapl_id)))
+    if (NULL == (ftmp0 = H5F__efc_open(f1->shared->efc, filename[0], H5F_ACC_RDWR, fcpl_id, fapl_id)))
         FAIL_STACK_ERROR;
     if (H5F_efc_close(f1, ftmp0) < 0)
         FAIL_STACK_ERROR;
     if (H5F_efc_close(f0, f1) < 0)
         FAIL_STACK_ERROR;
     if (NULL ==
-        (f2 = H5F__efc_open(f0, filename[2], H5F_ACC_RDWR | H5F_ACC_CREAT | H5F_ACC_TRUNC, fcpl_id, fapl_id)))
+        (f2 = H5F__efc_open(f0->shared->efc, filename[2], H5F_ACC_RDWR | H5F_ACC_CREAT | H5F_ACC_TRUNC, fcpl_id, fapl_id)))
         FAIL_STACK_ERROR;
     if (NULL ==
-        (f3 = H5F__efc_open(f2, filename[3], H5F_ACC_RDWR | H5F_ACC_CREAT | H5F_ACC_TRUNC, fcpl_id, fapl_id)))
+        (f3 = H5F__efc_open(f2->shared->efc, filename[3], H5F_ACC_RDWR | H5F_ACC_CREAT | H5F_ACC_TRUNC, fcpl_id, fapl_id)))
         FAIL_STACK_ERROR;
     if (NULL == (ftmp3 = H5F_open(filename[3], H5F_ACC_RDWR, fcpl_id, fapl_id)))
         FAIL_STACK_ERROR;
-    if (NULL == (ftmp2 = H5F__efc_open(f3, filename[2], H5F_ACC_RDWR, fcpl_id, fapl_id)))
+    if (NULL == (ftmp2 = H5F__efc_open(f3->shared->efc, filename[2], H5F_ACC_RDWR, fcpl_id, fapl_id)))
         FAIL_STACK_ERROR;
     if (H5F_efc_close(f3, ftmp2) < 0)
         FAIL_STACK_ERROR;
@@ -1597,23 +1597,23 @@ test_graph_cycle(void)
     if (NULL == (f0 = H5F_open(filename[0], H5F_ACC_RDWR | H5F_ACC_CREAT | H5F_ACC_TRUNC, fcpl_id, fapl_id)))
         FAIL_STACK_ERROR;
     if (NULL ==
-        (f1 = H5F__efc_open(f0, filename[1], H5F_ACC_RDWR | H5F_ACC_CREAT | H5F_ACC_TRUNC, fcpl_id, fapl_id)))
+        (f1 = H5F__efc_open(f0->shared->efc, filename[1], H5F_ACC_RDWR | H5F_ACC_CREAT | H5F_ACC_TRUNC, fcpl_id, fapl_id)))
         FAIL_STACK_ERROR;
-    if (NULL == (ftmp0 = H5F__efc_open(f1, filename[0], H5F_ACC_RDWR, fcpl_id, fapl_id)))
+    if (NULL == (ftmp0 = H5F__efc_open(f1->shared->efc, filename[0], H5F_ACC_RDWR, fcpl_id, fapl_id)))
         FAIL_STACK_ERROR;
     if (H5F_efc_close(f1, ftmp0) < 0)
         FAIL_STACK_ERROR;
     if (H5F_efc_close(f0, f1) < 0)
         FAIL_STACK_ERROR;
     if (NULL ==
-        (f2 = H5F__efc_open(f0, filename[2], H5F_ACC_RDWR | H5F_ACC_CREAT | H5F_ACC_TRUNC, fcpl_id, fapl_id)))
+        (f2 = H5F__efc_open(f0->shared->efc, filename[2], H5F_ACC_RDWR | H5F_ACC_CREAT | H5F_ACC_TRUNC, fcpl_id, fapl_id)))
         FAIL_STACK_ERROR;
     if (NULL ==
-        (f3 = H5F__efc_open(f2, filename[3], H5F_ACC_RDWR | H5F_ACC_CREAT | H5F_ACC_TRUNC, fcpl_id, fapl_id)))
+        (f3 = H5F__efc_open(f2->shared->efc, filename[3], H5F_ACC_RDWR | H5F_ACC_CREAT | H5F_ACC_TRUNC, fcpl_id, fapl_id)))
         FAIL_STACK_ERROR;
     if (NULL == (ftmp3 = H5F_open(filename[3], H5F_ACC_RDWR, fcpl_id, fapl_id)))
         FAIL_STACK_ERROR;
-    if (NULL == (ftmp2 = H5F__efc_open(f3, filename[2], H5F_ACC_RDWR, fcpl_id, fapl_id)))
+    if (NULL == (ftmp2 = H5F__efc_open(f3->shared->efc, filename[2], H5F_ACC_RDWR, fcpl_id, fapl_id)))
         FAIL_STACK_ERROR;
     if (H5F_efc_close(f3, ftmp2) < 0)
         FAIL_STACK_ERROR;
@@ -1664,41 +1664,41 @@ test_graph_cycle(void)
     if (NULL == (f0 = H5F_open(filename[0], H5F_ACC_RDWR | H5F_ACC_CREAT | H5F_ACC_TRUNC, fcpl_id, fapl_id)))
         FAIL_STACK_ERROR;
     if (NULL ==
-        (f1 = H5F__efc_open(f0, filename[1], H5F_ACC_RDWR | H5F_ACC_CREAT | H5F_ACC_TRUNC, fcpl_id, fapl_id)))
+        (f1 = H5F__efc_open(f0->shared->efc, filename[1], H5F_ACC_RDWR | H5F_ACC_CREAT | H5F_ACC_TRUNC, fcpl_id, fapl_id)))
         FAIL_STACK_ERROR;
     if (NULL ==
-        (f2 = H5F__efc_open(f0, filename[2], H5F_ACC_RDWR | H5F_ACC_CREAT | H5F_ACC_TRUNC, fcpl_id, fapl_id)))
+        (f2 = H5F__efc_open(f0->shared->efc, filename[2], H5F_ACC_RDWR | H5F_ACC_CREAT | H5F_ACC_TRUNC, fcpl_id, fapl_id)))
         FAIL_STACK_ERROR;
     if (NULL ==
-        (f3 = H5F__efc_open(f1, filename[3], H5F_ACC_RDWR | H5F_ACC_CREAT | H5F_ACC_TRUNC, fcpl_id, fapl_id)))
+        (f3 = H5F__efc_open(f1->shared->efc, filename[3], H5F_ACC_RDWR | H5F_ACC_CREAT | H5F_ACC_TRUNC, fcpl_id, fapl_id)))
         FAIL_STACK_ERROR;
     if (H5F_efc_close(f1, f3) < 0)
         FAIL_STACK_ERROR;
-    if (NULL == (f3 = H5F__efc_open(f2, filename[3], H5F_ACC_RDWR, fcpl_id, fapl_id)))
+    if (NULL == (f3 = H5F__efc_open(f2->shared->efc, filename[3], H5F_ACC_RDWR, fcpl_id, fapl_id)))
         FAIL_STACK_ERROR;
     if (H5F_efc_close(f2, f3) < 0)
         FAIL_STACK_ERROR;
-    if (NULL == (f3 = H5F__efc_open(f0, filename[3], H5F_ACC_RDWR, fcpl_id, fapl_id)))
+    if (NULL == (f3 = H5F__efc_open(f0->shared->efc, filename[3], H5F_ACC_RDWR, fcpl_id, fapl_id)))
         FAIL_STACK_ERROR;
-    if (NULL == (ftmp0 = H5F__efc_open(f3, filename[0], H5F_ACC_RDWR, fcpl_id, fapl_id)))
+    if (NULL == (ftmp0 = H5F__efc_open(f3->shared->efc, filename[0], H5F_ACC_RDWR, fcpl_id, fapl_id)))
         FAIL_STACK_ERROR;
     if (H5F_efc_close(f3, ftmp0) < 0)
         FAIL_STACK_ERROR;
     if (H5F_efc_close(f0, f3) < 0)
         FAIL_STACK_ERROR;
     if (NULL ==
-        (f4 = H5F__efc_open(f1, filename[4], H5F_ACC_RDWR | H5F_ACC_CREAT | H5F_ACC_TRUNC, fcpl_id, fapl_id)))
+        (f4 = H5F__efc_open(f1->shared->efc, filename[4], H5F_ACC_RDWR | H5F_ACC_CREAT | H5F_ACC_TRUNC, fcpl_id, fapl_id)))
         FAIL_STACK_ERROR;
-    if (NULL == (ftmp1 = H5F__efc_open(f4, filename[1], H5F_ACC_RDWR, fcpl_id, fapl_id)))
+    if (NULL == (ftmp1 = H5F__efc_open(f4->shared->efc, filename[1], H5F_ACC_RDWR, fcpl_id, fapl_id)))
         FAIL_STACK_ERROR;
     if (H5F_efc_close(f4, ftmp1) < 0)
         FAIL_STACK_ERROR;
     if (H5F_efc_close(f1, f4) < 0)
         FAIL_STACK_ERROR;
     if (NULL ==
-        (f5 = H5F__efc_open(f2, filename[5], H5F_ACC_RDWR | H5F_ACC_CREAT | H5F_ACC_TRUNC, fcpl_id, fapl_id)))
+        (f5 = H5F__efc_open(f2->shared->efc, filename[5], H5F_ACC_RDWR | H5F_ACC_CREAT | H5F_ACC_TRUNC, fcpl_id, fapl_id)))
         FAIL_STACK_ERROR;
-    if (NULL == (ftmp2 = H5F__efc_open(f5, filename[2], H5F_ACC_RDWR, fcpl_id, fapl_id)))
+    if (NULL == (ftmp2 = H5F__efc_open(f5->shared->efc, filename[2], H5F_ACC_RDWR, fcpl_id, fapl_id)))
         FAIL_STACK_ERROR;
     if (H5F_efc_close(f5, ftmp2) < 0)
         FAIL_STACK_ERROR;
@@ -1756,41 +1756,41 @@ test_graph_cycle(void)
     if (NULL == (f0 = H5F_open(filename[0], H5F_ACC_RDWR | H5F_ACC_CREAT | H5F_ACC_TRUNC, fcpl_id, fapl_id)))
         FAIL_STACK_ERROR;
     if (NULL ==
-        (f1 = H5F__efc_open(f0, filename[1], H5F_ACC_RDWR | H5F_ACC_CREAT | H5F_ACC_TRUNC, fcpl_id, fapl_id)))
+        (f1 = H5F__efc_open(f0->shared->efc, filename[1], H5F_ACC_RDWR | H5F_ACC_CREAT | H5F_ACC_TRUNC, fcpl_id, fapl_id)))
         FAIL_STACK_ERROR;
     if (NULL ==
-        (f2 = H5F__efc_open(f0, filename[2], H5F_ACC_RDWR | H5F_ACC_CREAT | H5F_ACC_TRUNC, fcpl_id, fapl_id)))
+        (f2 = H5F__efc_open(f0->shared->efc, filename[2], H5F_ACC_RDWR | H5F_ACC_CREAT | H5F_ACC_TRUNC, fcpl_id, fapl_id)))
         FAIL_STACK_ERROR;
     if (NULL ==
-        (f3 = H5F__efc_open(f1, filename[3], H5F_ACC_RDWR | H5F_ACC_CREAT | H5F_ACC_TRUNC, fcpl_id, fapl_id)))
+        (f3 = H5F__efc_open(f1->shared->efc, filename[3], H5F_ACC_RDWR | H5F_ACC_CREAT | H5F_ACC_TRUNC, fcpl_id, fapl_id)))
         FAIL_STACK_ERROR;
     if (H5F_efc_close(f1, f3) < 0)
         FAIL_STACK_ERROR;
-    if (NULL == (f3 = H5F__efc_open(f2, filename[3], H5F_ACC_RDWR, fcpl_id, fapl_id)))
+    if (NULL == (f3 = H5F__efc_open(f2->shared->efc, filename[3], H5F_ACC_RDWR, fcpl_id, fapl_id)))
         FAIL_STACK_ERROR;
     if (H5F_efc_close(f2, f3) < 0)
         FAIL_STACK_ERROR;
-    if (NULL == (f3 = H5F__efc_open(f0, filename[3], H5F_ACC_RDWR, fcpl_id, fapl_id)))
+    if (NULL == (f3 = H5F__efc_open(f0->shared->efc, filename[3], H5F_ACC_RDWR, fcpl_id, fapl_id)))
         FAIL_STACK_ERROR;
-    if (NULL == (ftmp0 = H5F__efc_open(f3, filename[0], H5F_ACC_RDWR, fcpl_id, fapl_id)))
+    if (NULL == (ftmp0 = H5F__efc_open(f3->shared->efc, filename[0], H5F_ACC_RDWR, fcpl_id, fapl_id)))
         FAIL_STACK_ERROR;
     if (H5F_efc_close(f3, ftmp0) < 0)
         FAIL_STACK_ERROR;
     if (H5F_efc_close(f0, f3) < 0)
         FAIL_STACK_ERROR;
     if (NULL ==
-        (f4 = H5F__efc_open(f1, filename[4], H5F_ACC_RDWR | H5F_ACC_CREAT | H5F_ACC_TRUNC, fcpl_id, fapl_id)))
+        (f4 = H5F__efc_open(f1->shared->efc, filename[4], H5F_ACC_RDWR | H5F_ACC_CREAT | H5F_ACC_TRUNC, fcpl_id, fapl_id)))
         FAIL_STACK_ERROR;
-    if (NULL == (ftmp1 = H5F__efc_open(f4, filename[1], H5F_ACC_RDWR, fcpl_id, fapl_id)))
+    if (NULL == (ftmp1 = H5F__efc_open(f4->shared->efc, filename[1], H5F_ACC_RDWR, fcpl_id, fapl_id)))
         FAIL_STACK_ERROR;
     if (H5F_efc_close(f4, ftmp1) < 0)
         FAIL_STACK_ERROR;
     if (H5F_efc_close(f1, f4) < 0)
         FAIL_STACK_ERROR;
     if (NULL ==
-        (f5 = H5F__efc_open(f2, filename[5], H5F_ACC_RDWR | H5F_ACC_CREAT | H5F_ACC_TRUNC, fcpl_id, fapl_id)))
+        (f5 = H5F__efc_open(f2->shared->efc, filename[5], H5F_ACC_RDWR | H5F_ACC_CREAT | H5F_ACC_TRUNC, fcpl_id, fapl_id)))
         FAIL_STACK_ERROR;
-    if (NULL == (ftmp2 = H5F__efc_open(f5, filename[2], H5F_ACC_RDWR, fcpl_id, fapl_id)))
+    if (NULL == (ftmp2 = H5F__efc_open(f5->shared->efc, filename[2], H5F_ACC_RDWR, fcpl_id, fapl_id)))
         FAIL_STACK_ERROR;
     if (H5F_efc_close(f5, ftmp2) < 0)
         FAIL_STACK_ERROR;
@@ -1845,32 +1845,32 @@ test_graph_cycle(void)
     if (NULL == (f0 = H5F_open(filename[0], H5F_ACC_RDWR | H5F_ACC_CREAT | H5F_ACC_TRUNC, fcpl_id, fapl_id)))
         FAIL_STACK_ERROR;
     if (NULL ==
-        (f1 = H5F__efc_open(f0, filename[1], H5F_ACC_RDWR | H5F_ACC_CREAT | H5F_ACC_TRUNC, fcpl_id, fapl_id)))
+        (f1 = H5F__efc_open(f0->shared->efc, filename[1], H5F_ACC_RDWR | H5F_ACC_CREAT | H5F_ACC_TRUNC, fcpl_id, fapl_id)))
         FAIL_STACK_ERROR;
     if (NULL ==
-        (f2 = H5F__efc_open(f0, filename[2], H5F_ACC_RDWR | H5F_ACC_CREAT | H5F_ACC_TRUNC, fcpl_id, fapl_id)))
+        (f2 = H5F__efc_open(f0->shared->efc, filename[2], H5F_ACC_RDWR | H5F_ACC_CREAT | H5F_ACC_TRUNC, fcpl_id, fapl_id)))
         FAIL_STACK_ERROR;
     if (NULL ==
-        (f3 = H5F__efc_open(f1, filename[3], H5F_ACC_RDWR | H5F_ACC_CREAT | H5F_ACC_TRUNC, fcpl_id, fapl_id)))
+        (f3 = H5F__efc_open(f1->shared->efc, filename[3], H5F_ACC_RDWR | H5F_ACC_CREAT | H5F_ACC_TRUNC, fcpl_id, fapl_id)))
         FAIL_STACK_ERROR;
     if (H5F_efc_close(f1, f3) < 0)
         FAIL_STACK_ERROR;
-    if (NULL == (f3 = H5F__efc_open(f2, filename[3], H5F_ACC_RDWR, fcpl_id, fapl_id)))
+    if (NULL == (f3 = H5F__efc_open(f2->shared->efc, filename[3], H5F_ACC_RDWR, fcpl_id, fapl_id)))
         FAIL_STACK_ERROR;
     if (H5F_efc_close(f2, f3) < 0)
         FAIL_STACK_ERROR;
-    if (NULL == (f3 = H5F__efc_open(f0, filename[3], H5F_ACC_RDWR, fcpl_id, fapl_id)))
+    if (NULL == (f3 = H5F__efc_open(f0->shared->efc, filename[3], H5F_ACC_RDWR, fcpl_id, fapl_id)))
         FAIL_STACK_ERROR;
-    if (NULL == (ftmp0 = H5F__efc_open(f3, filename[0], H5F_ACC_RDWR, fcpl_id, fapl_id)))
+    if (NULL == (ftmp0 = H5F__efc_open(f3->shared->efc, filename[0], H5F_ACC_RDWR, fcpl_id, fapl_id)))
         FAIL_STACK_ERROR;
     if (H5F_efc_close(f3, ftmp0) < 0)
         FAIL_STACK_ERROR;
     if (H5F_efc_close(f0, f3) < 0)
         FAIL_STACK_ERROR;
     if (NULL ==
-        (f4 = H5F__efc_open(f1, filename[4], H5F_ACC_RDWR | H5F_ACC_CREAT | H5F_ACC_TRUNC, fcpl_id, fapl_id)))
+        (f4 = H5F__efc_open(f1->shared->efc, filename[4], H5F_ACC_RDWR | H5F_ACC_CREAT | H5F_ACC_TRUNC, fcpl_id, fapl_id)))
         FAIL_STACK_ERROR;
-    if (NULL == (ftmp1 = H5F__efc_open(f4, filename[1], H5F_ACC_RDWR, fcpl_id, fapl_id)))
+    if (NULL == (ftmp1 = H5F__efc_open(f4->shared->efc, filename[1], H5F_ACC_RDWR, fcpl_id, fapl_id)))
         FAIL_STACK_ERROR;
     if (H5F_efc_close(f4, ftmp1) < 0)
         FAIL_STACK_ERROR;
@@ -1879,9 +1879,9 @@ test_graph_cycle(void)
     if (NULL == (f4 = H5F_open(filename[4], H5F_ACC_RDWR, fcpl_id, fapl_id)))
         FAIL_STACK_ERROR;
     if (NULL ==
-        (f5 = H5F__efc_open(f2, filename[5], H5F_ACC_RDWR | H5F_ACC_CREAT | H5F_ACC_TRUNC, fcpl_id, fapl_id)))
+        (f5 = H5F__efc_open(f2->shared->efc, filename[5], H5F_ACC_RDWR | H5F_ACC_CREAT | H5F_ACC_TRUNC, fcpl_id, fapl_id)))
         FAIL_STACK_ERROR;
-    if (NULL == (ftmp2 = H5F__efc_open(f5, filename[2], H5F_ACC_RDWR, fcpl_id, fapl_id)))
+    if (NULL == (ftmp2 = H5F__efc_open(f5->shared->efc, filename[2], H5F_ACC_RDWR, fcpl_id, fapl_id)))
         FAIL_STACK_ERROR;
     if (H5F_efc_close(f5, ftmp2) < 0)
         FAIL_STACK_ERROR;
@@ -1975,32 +1975,32 @@ test_graph_cycle(void)
     if (NULL == (f0 = H5F_open(filename[0], H5F_ACC_RDWR | H5F_ACC_CREAT | H5F_ACC_TRUNC, fcpl_id, fapl_id)))
         FAIL_STACK_ERROR;
     if (NULL ==
-        (f1 = H5F__efc_open(f0, filename[1], H5F_ACC_RDWR | H5F_ACC_CREAT | H5F_ACC_TRUNC, fcpl_id, fapl_id)))
+        (f1 = H5F__efc_open(f0->shared->efc, filename[1], H5F_ACC_RDWR | H5F_ACC_CREAT | H5F_ACC_TRUNC, fcpl_id, fapl_id)))
         FAIL_STACK_ERROR;
     if (NULL ==
-        (f2 = H5F__efc_open(f0, filename[2], H5F_ACC_RDWR | H5F_ACC_CREAT | H5F_ACC_TRUNC, fcpl_id, fapl_id)))
+        (f2 = H5F__efc_open(f0->shared->efc, filename[2], H5F_ACC_RDWR | H5F_ACC_CREAT | H5F_ACC_TRUNC, fcpl_id, fapl_id)))
         FAIL_STACK_ERROR;
     if (NULL ==
-        (f3 = H5F__efc_open(f1, filename[3], H5F_ACC_RDWR | H5F_ACC_CREAT | H5F_ACC_TRUNC, fcpl_id, fapl_id)))
+        (f3 = H5F__efc_open(f1->shared->efc, filename[3], H5F_ACC_RDWR | H5F_ACC_CREAT | H5F_ACC_TRUNC, fcpl_id, fapl_id)))
         FAIL_STACK_ERROR;
     if (H5F_efc_close(f1, f3) < 0)
         FAIL_STACK_ERROR;
-    if (NULL == (f3 = H5F__efc_open(f2, filename[3], H5F_ACC_RDWR, fcpl_id, fapl_id)))
+    if (NULL == (f3 = H5F__efc_open(f2->shared->efc, filename[3], H5F_ACC_RDWR, fcpl_id, fapl_id)))
         FAIL_STACK_ERROR;
     if (H5F_efc_close(f2, f3) < 0)
         FAIL_STACK_ERROR;
-    if (NULL == (f3 = H5F__efc_open(f0, filename[3], H5F_ACC_RDWR, fcpl_id, fapl_id)))
+    if (NULL == (f3 = H5F__efc_open(f0->shared->efc, filename[3], H5F_ACC_RDWR, fcpl_id, fapl_id)))
         FAIL_STACK_ERROR;
-    if (NULL == (ftmp0 = H5F__efc_open(f3, filename[0], H5F_ACC_RDWR, fcpl_id, fapl_id)))
+    if (NULL == (ftmp0 = H5F__efc_open(f3->shared->efc, filename[0], H5F_ACC_RDWR, fcpl_id, fapl_id)))
         FAIL_STACK_ERROR;
     if (H5F_efc_close(f3, ftmp0) < 0)
         FAIL_STACK_ERROR;
     if (H5F_efc_close(f0, f3) < 0)
         FAIL_STACK_ERROR;
     if (NULL ==
-        (f4 = H5F__efc_open(f1, filename[4], H5F_ACC_RDWR | H5F_ACC_CREAT | H5F_ACC_TRUNC, fcpl_id, fapl_id)))
+        (f4 = H5F__efc_open(f1->shared->efc, filename[4], H5F_ACC_RDWR | H5F_ACC_CREAT | H5F_ACC_TRUNC, fcpl_id, fapl_id)))
         FAIL_STACK_ERROR;
-    if (NULL == (ftmp1 = H5F__efc_open(f4, filename[1], H5F_ACC_RDWR, fcpl_id, fapl_id)))
+    if (NULL == (ftmp1 = H5F__efc_open(f4->shared->efc, filename[1], H5F_ACC_RDWR, fcpl_id, fapl_id)))
         FAIL_STACK_ERROR;
     if (H5F_efc_close(f4, ftmp1) < 0)
         FAIL_STACK_ERROR;
@@ -2009,9 +2009,9 @@ test_graph_cycle(void)
     if (NULL == (f4 = H5F_open(filename[4], H5F_ACC_RDWR, fcpl_id, fapl_id)))
         FAIL_STACK_ERROR;
     if (NULL ==
-        (f5 = H5F__efc_open(f2, filename[5], H5F_ACC_RDWR | H5F_ACC_CREAT | H5F_ACC_TRUNC, fcpl_id, fapl_id)))
+        (f5 = H5F__efc_open(f2->shared->efc, filename[5], H5F_ACC_RDWR | H5F_ACC_CREAT | H5F_ACC_TRUNC, fcpl_id, fapl_id)))
         FAIL_STACK_ERROR;
-    if (NULL == (ftmp2 = H5F__efc_open(f5, filename[2], H5F_ACC_RDWR, fcpl_id, fapl_id)))
+    if (NULL == (ftmp2 = H5F__efc_open(f5->shared->efc, filename[2], H5F_ACC_RDWR, fcpl_id, fapl_id)))
         FAIL_STACK_ERROR;
     if (H5F_efc_close(f5, ftmp2) < 0)
         FAIL_STACK_ERROR;
@@ -2086,67 +2086,67 @@ test_graph_cycle(void)
      * itself). */
     if (NULL == (f0 = H5F_open(filename[0], H5F_ACC_RDWR | H5F_ACC_CREAT | H5F_ACC_TRUNC, fcpl_id, fapl_id)))
         FAIL_STACK_ERROR;
-    if (NULL == (ftmp0 = H5F__efc_open(f0, filename[0], H5F_ACC_RDWR, fcpl_id, fapl_id)))
+    if (NULL == (ftmp0 = H5F__efc_open(f0->shared->efc, filename[0], H5F_ACC_RDWR, fcpl_id, fapl_id)))
         FAIL_STACK_ERROR;
     if (H5F_efc_close(f0, ftmp0) < 0)
         FAIL_STACK_ERROR;
     if (NULL ==
-        (f1 = H5F__efc_open(f0, filename[1], H5F_ACC_RDWR | H5F_ACC_CREAT | H5F_ACC_TRUNC, fcpl_id, fapl_id)))
+        (f1 = H5F__efc_open(f0->shared->efc, filename[1], H5F_ACC_RDWR | H5F_ACC_CREAT | H5F_ACC_TRUNC, fcpl_id, fapl_id)))
         FAIL_STACK_ERROR;
     if (NULL ==
-        (f2 = H5F__efc_open(f0, filename[2], H5F_ACC_RDWR | H5F_ACC_CREAT | H5F_ACC_TRUNC, fcpl_id, fapl_id)))
+        (f2 = H5F__efc_open(f0->shared->efc, filename[2], H5F_ACC_RDWR | H5F_ACC_CREAT | H5F_ACC_TRUNC, fcpl_id, fapl_id)))
         FAIL_STACK_ERROR;
     if (NULL ==
-        (f3 = H5F__efc_open(f0, filename[3], H5F_ACC_RDWR | H5F_ACC_CREAT | H5F_ACC_TRUNC, fcpl_id, fapl_id)))
+        (f3 = H5F__efc_open(f0->shared->efc, filename[3], H5F_ACC_RDWR | H5F_ACC_CREAT | H5F_ACC_TRUNC, fcpl_id, fapl_id)))
         FAIL_STACK_ERROR;
 
-    if (NULL == (ftmp0 = H5F__efc_open(f1, filename[0], H5F_ACC_RDWR, fcpl_id, fapl_id)))
+    if (NULL == (ftmp0 = H5F__efc_open(f1->shared->efc, filename[0], H5F_ACC_RDWR, fcpl_id, fapl_id)))
         FAIL_STACK_ERROR;
     if (H5F_efc_close(f1, ftmp0) < 0)
         FAIL_STACK_ERROR;
-    if (NULL == (ftmp1 = H5F__efc_open(f1, filename[1], H5F_ACC_RDWR, fcpl_id, fapl_id)))
+    if (NULL == (ftmp1 = H5F__efc_open(f1->shared->efc, filename[1], H5F_ACC_RDWR, fcpl_id, fapl_id)))
         FAIL_STACK_ERROR;
     if (H5F_efc_close(f1, ftmp1) < 0)
         FAIL_STACK_ERROR;
-    if (NULL == (ftmp2 = H5F__efc_open(f1, filename[2], H5F_ACC_RDWR, fcpl_id, fapl_id)))
+    if (NULL == (ftmp2 = H5F__efc_open(f1->shared->efc, filename[2], H5F_ACC_RDWR, fcpl_id, fapl_id)))
         FAIL_STACK_ERROR;
     if (H5F_efc_close(f1, ftmp2) < 0)
         FAIL_STACK_ERROR;
-    if (NULL == (ftmp3 = H5F__efc_open(f1, filename[3], H5F_ACC_RDWR, fcpl_id, fapl_id)))
+    if (NULL == (ftmp3 = H5F__efc_open(f1->shared->efc, filename[3], H5F_ACC_RDWR, fcpl_id, fapl_id)))
         FAIL_STACK_ERROR;
     if (H5F_efc_close(f1, ftmp3) < 0)
         FAIL_STACK_ERROR;
 
-    if (NULL == (ftmp0 = H5F__efc_open(f2, filename[0], H5F_ACC_RDWR, fcpl_id, fapl_id)))
+    if (NULL == (ftmp0 = H5F__efc_open(f2->shared->efc, filename[0], H5F_ACC_RDWR, fcpl_id, fapl_id)))
         FAIL_STACK_ERROR;
     if (H5F_efc_close(f2, ftmp0) < 0)
         FAIL_STACK_ERROR;
-    if (NULL == (ftmp1 = H5F__efc_open(f2, filename[1], H5F_ACC_RDWR, fcpl_id, fapl_id)))
+    if (NULL == (ftmp1 = H5F__efc_open(f2->shared->efc, filename[1], H5F_ACC_RDWR, fcpl_id, fapl_id)))
         FAIL_STACK_ERROR;
     if (H5F_efc_close(f2, ftmp1) < 0)
         FAIL_STACK_ERROR;
-    if (NULL == (ftmp2 = H5F__efc_open(f2, filename[2], H5F_ACC_RDWR, fcpl_id, fapl_id)))
+    if (NULL == (ftmp2 = H5F__efc_open(f2->shared->efc, filename[2], H5F_ACC_RDWR, fcpl_id, fapl_id)))
         FAIL_STACK_ERROR;
     if (H5F_efc_close(f2, ftmp2) < 0)
         FAIL_STACK_ERROR;
-    if (NULL == (ftmp3 = H5F__efc_open(f2, filename[3], H5F_ACC_RDWR, fcpl_id, fapl_id)))
+    if (NULL == (ftmp3 = H5F__efc_open(f2->shared->efc, filename[3], H5F_ACC_RDWR, fcpl_id, fapl_id)))
         FAIL_STACK_ERROR;
     if (H5F_efc_close(f2, ftmp3) < 0)
         FAIL_STACK_ERROR;
 
-    if (NULL == (ftmp0 = H5F__efc_open(f3, filename[0], H5F_ACC_RDWR, fcpl_id, fapl_id)))
+    if (NULL == (ftmp0 = H5F__efc_open(f3->shared->efc, filename[0], H5F_ACC_RDWR, fcpl_id, fapl_id)))
         FAIL_STACK_ERROR;
     if (H5F_efc_close(f3, ftmp0) < 0)
         FAIL_STACK_ERROR;
-    if (NULL == (ftmp1 = H5F__efc_open(f3, filename[1], H5F_ACC_RDWR, fcpl_id, fapl_id)))
+    if (NULL == (ftmp1 = H5F__efc_open(f3->shared->efc, filename[1], H5F_ACC_RDWR, fcpl_id, fapl_id)))
         FAIL_STACK_ERROR;
     if (H5F_efc_close(f3, ftmp1) < 0)
         FAIL_STACK_ERROR;
-    if (NULL == (ftmp2 = H5F__efc_open(f3, filename[2], H5F_ACC_RDWR, fcpl_id, fapl_id)))
+    if (NULL == (ftmp2 = H5F__efc_open(f3->shared->efc, filename[2], H5F_ACC_RDWR, fcpl_id, fapl_id)))
         FAIL_STACK_ERROR;
     if (H5F_efc_close(f3, ftmp2) < 0)
         FAIL_STACK_ERROR;
-    if (NULL == (ftmp3 = H5F__efc_open(f3, filename[3], H5F_ACC_RDWR, fcpl_id, fapl_id)))
+    if (NULL == (ftmp3 = H5F__efc_open(f3->shared->efc, filename[3], H5F_ACC_RDWR, fcpl_id, fapl_id)))
         FAIL_STACK_ERROR;
     if (H5F_efc_close(f3, ftmp3) < 0)
         FAIL_STACK_ERROR;
@@ -2189,67 +2189,67 @@ test_graph_cycle(void)
      * itself).  Release the files instead of closing. */
     if (NULL == (f0 = H5F_open(filename[0], H5F_ACC_RDWR | H5F_ACC_CREAT | H5F_ACC_TRUNC, fcpl_id, fapl_id)))
         FAIL_STACK_ERROR;
-    if (NULL == (ftmp0 = H5F__efc_open(f0, filename[0], H5F_ACC_RDWR, fcpl_id, fapl_id)))
+    if (NULL == (ftmp0 = H5F__efc_open(f0->shared->efc, filename[0], H5F_ACC_RDWR, fcpl_id, fapl_id)))
         FAIL_STACK_ERROR;
     if (H5F_efc_close(f0, ftmp0) < 0)
         FAIL_STACK_ERROR;
     if (NULL ==
-        (f1 = H5F__efc_open(f0, filename[1], H5F_ACC_RDWR | H5F_ACC_CREAT | H5F_ACC_TRUNC, fcpl_id, fapl_id)))
+        (f1 = H5F__efc_open(f0->shared->efc, filename[1], H5F_ACC_RDWR | H5F_ACC_CREAT | H5F_ACC_TRUNC, fcpl_id, fapl_id)))
         FAIL_STACK_ERROR;
     if (NULL ==
-        (f2 = H5F__efc_open(f0, filename[2], H5F_ACC_RDWR | H5F_ACC_CREAT | H5F_ACC_TRUNC, fcpl_id, fapl_id)))
+        (f2 = H5F__efc_open(f0->shared->efc, filename[2], H5F_ACC_RDWR | H5F_ACC_CREAT | H5F_ACC_TRUNC, fcpl_id, fapl_id)))
         FAIL_STACK_ERROR;
     if (NULL ==
-        (f3 = H5F__efc_open(f0, filename[3], H5F_ACC_RDWR | H5F_ACC_CREAT | H5F_ACC_TRUNC, fcpl_id, fapl_id)))
+        (f3 = H5F__efc_open(f0->shared->efc, filename[3], H5F_ACC_RDWR | H5F_ACC_CREAT | H5F_ACC_TRUNC, fcpl_id, fapl_id)))
         FAIL_STACK_ERROR;
 
-    if (NULL == (ftmp0 = H5F__efc_open(f1, filename[0], H5F_ACC_RDWR, fcpl_id, fapl_id)))
+    if (NULL == (ftmp0 = H5F__efc_open(f1->shared->efc, filename[0], H5F_ACC_RDWR, fcpl_id, fapl_id)))
         FAIL_STACK_ERROR;
     if (H5F_efc_close(f1, ftmp0) < 0)
         FAIL_STACK_ERROR;
-    if (NULL == (ftmp1 = H5F__efc_open(f1, filename[1], H5F_ACC_RDWR, fcpl_id, fapl_id)))
+    if (NULL == (ftmp1 = H5F__efc_open(f1->shared->efc, filename[1], H5F_ACC_RDWR, fcpl_id, fapl_id)))
         FAIL_STACK_ERROR;
     if (H5F_efc_close(f1, ftmp1) < 0)
         FAIL_STACK_ERROR;
-    if (NULL == (ftmp2 = H5F__efc_open(f1, filename[2], H5F_ACC_RDWR, fcpl_id, fapl_id)))
+    if (NULL == (ftmp2 = H5F__efc_open(f1->shared->efc, filename[2], H5F_ACC_RDWR, fcpl_id, fapl_id)))
         FAIL_STACK_ERROR;
     if (H5F_efc_close(f1, ftmp2) < 0)
         FAIL_STACK_ERROR;
-    if (NULL == (ftmp3 = H5F__efc_open(f1, filename[3], H5F_ACC_RDWR, fcpl_id, fapl_id)))
+    if (NULL == (ftmp3 = H5F__efc_open(f1->shared->efc, filename[3], H5F_ACC_RDWR, fcpl_id, fapl_id)))
         FAIL_STACK_ERROR;
     if (H5F_efc_close(f1, ftmp3) < 0)
         FAIL_STACK_ERROR;
 
-    if (NULL == (ftmp0 = H5F__efc_open(f2, filename[0], H5F_ACC_RDWR, fcpl_id, fapl_id)))
+    if (NULL == (ftmp0 = H5F__efc_open(f2->shared->efc, filename[0], H5F_ACC_RDWR, fcpl_id, fapl_id)))
         FAIL_STACK_ERROR;
     if (H5F_efc_close(f2, ftmp0) < 0)
         FAIL_STACK_ERROR;
-    if (NULL == (ftmp1 = H5F__efc_open(f2, filename[1], H5F_ACC_RDWR, fcpl_id, fapl_id)))
+    if (NULL == (ftmp1 = H5F__efc_open(f2->shared->efc, filename[1], H5F_ACC_RDWR, fcpl_id, fapl_id)))
         FAIL_STACK_ERROR;
     if (H5F_efc_close(f2, ftmp1) < 0)
         FAIL_STACK_ERROR;
-    if (NULL == (ftmp2 = H5F__efc_open(f2, filename[2], H5F_ACC_RDWR, fcpl_id, fapl_id)))
+    if (NULL == (ftmp2 = H5F__efc_open(f2->shared->efc, filename[2], H5F_ACC_RDWR, fcpl_id, fapl_id)))
         FAIL_STACK_ERROR;
     if (H5F_efc_close(f2, ftmp2) < 0)
         FAIL_STACK_ERROR;
-    if (NULL == (ftmp3 = H5F__efc_open(f2, filename[3], H5F_ACC_RDWR, fcpl_id, fapl_id)))
+    if (NULL == (ftmp3 = H5F__efc_open(f2->shared->efc, filename[3], H5F_ACC_RDWR, fcpl_id, fapl_id)))
         FAIL_STACK_ERROR;
     if (H5F_efc_close(f2, ftmp3) < 0)
         FAIL_STACK_ERROR;
 
-    if (NULL == (ftmp0 = H5F__efc_open(f3, filename[0], H5F_ACC_RDWR, fcpl_id, fapl_id)))
+    if (NULL == (ftmp0 = H5F__efc_open(f3->shared->efc, filename[0], H5F_ACC_RDWR, fcpl_id, fapl_id)))
         FAIL_STACK_ERROR;
     if (H5F_efc_close(f3, ftmp0) < 0)
         FAIL_STACK_ERROR;
-    if (NULL == (ftmp1 = H5F__efc_open(f3, filename[1], H5F_ACC_RDWR, fcpl_id, fapl_id)))
+    if (NULL == (ftmp1 = H5F__efc_open(f3->shared->efc, filename[1], H5F_ACC_RDWR, fcpl_id, fapl_id)))
         FAIL_STACK_ERROR;
     if (H5F_efc_close(f3, ftmp1) < 0)
         FAIL_STACK_ERROR;
-    if (NULL == (ftmp2 = H5F__efc_open(f3, filename[2], H5F_ACC_RDWR, fcpl_id, fapl_id)))
+    if (NULL == (ftmp2 = H5F__efc_open(f3->shared->efc, filename[2], H5F_ACC_RDWR, fcpl_id, fapl_id)))
         FAIL_STACK_ERROR;
     if (H5F_efc_close(f3, ftmp2) < 0)
         FAIL_STACK_ERROR;
-    if (NULL == (ftmp3 = H5F__efc_open(f3, filename[3], H5F_ACC_RDWR, fcpl_id, fapl_id)))
+    if (NULL == (ftmp3 = H5F__efc_open(f3->shared->efc, filename[3], H5F_ACC_RDWR, fcpl_id, fapl_id)))
         FAIL_STACK_ERROR;
     if (H5F_efc_close(f3, ftmp3) < 0)
         FAIL_STACK_ERROR;
@@ -2290,9 +2290,9 @@ test_graph_cycle(void)
     if (NULL == (f0 = H5F_open(filename[0], H5F_ACC_RDWR | H5F_ACC_CREAT | H5F_ACC_TRUNC, fcpl_id, fapl_id)))
         FAIL_STACK_ERROR;
     if (NULL ==
-        (f1 = H5F__efc_open(f0, filename[1], H5F_ACC_RDWR | H5F_ACC_CREAT | H5F_ACC_TRUNC, fcpl_id, fapl_id)))
+        (f1 = H5F__efc_open(f0->shared->efc, filename[1], H5F_ACC_RDWR | H5F_ACC_CREAT | H5F_ACC_TRUNC, fcpl_id, fapl_id)))
         FAIL_STACK_ERROR;
-    if (NULL == (ftmp0 = H5F__efc_open(f1, filename[0], H5F_ACC_RDWR, fcpl_id, fapl_id)))
+    if (NULL == (ftmp0 = H5F__efc_open(f1->shared->efc, filename[0], H5F_ACC_RDWR, fcpl_id, fapl_id)))
         FAIL_STACK_ERROR;
     if (H5F_efc_close(f1, ftmp0) < 0)
         FAIL_STACK_ERROR;
@@ -2323,16 +2323,16 @@ test_graph_cycle(void)
     if (NULL == (f0 = H5F_open(filename[0], H5F_ACC_RDWR | H5F_ACC_CREAT | H5F_ACC_TRUNC, fcpl_id, fapl_id)))
         FAIL_STACK_ERROR;
     if (NULL ==
-        (f1 = H5F__efc_open(f0, filename[1], H5F_ACC_RDWR | H5F_ACC_CREAT | H5F_ACC_TRUNC, fcpl_id, fapl_id)))
+        (f1 = H5F__efc_open(f0->shared->efc, filename[1], H5F_ACC_RDWR | H5F_ACC_CREAT | H5F_ACC_TRUNC, fcpl_id, fapl_id)))
         FAIL_STACK_ERROR;
-    if (NULL == (ftmp0 = H5F__efc_open(f1, filename[0], H5F_ACC_RDWR, fcpl_id, fapl_id)))
+    if (NULL == (ftmp0 = H5F__efc_open(f1->shared->efc, filename[0], H5F_ACC_RDWR, fcpl_id, fapl_id)))
         FAIL_STACK_ERROR;
     if (H5F_efc_close(f1, ftmp0) < 0)
         FAIL_STACK_ERROR;
     if (H5F_efc_close(f0, f1) < 0)
         FAIL_STACK_ERROR;
     if (NULL ==
-        (f2 = H5F__efc_open(f0, filename[2], H5F_ACC_RDWR | H5F_ACC_CREAT | H5F_ACC_TRUNC, fcpl_id, fapl_id)))
+        (f2 = H5F__efc_open(f0->shared->efc, filename[2], H5F_ACC_RDWR | H5F_ACC_CREAT | H5F_ACC_TRUNC, fcpl_id, fapl_id)))
         FAIL_STACK_ERROR;
     if (f0->shared->nrefs != 2)
         TEST_ERROR;
@@ -2357,9 +2357,9 @@ test_graph_cycle(void)
     if (NULL == (f0 = H5F_open(filename[0], H5F_ACC_RDWR | H5F_ACC_CREAT | H5F_ACC_TRUNC, fcpl_id, fapl_id)))
         FAIL_STACK_ERROR;
     if (NULL ==
-        (f1 = H5F__efc_open(f0, filename[1], H5F_ACC_RDWR | H5F_ACC_CREAT | H5F_ACC_TRUNC, fcpl_id, fapl_id)))
+        (f1 = H5F__efc_open(f0->shared->efc, filename[1], H5F_ACC_RDWR | H5F_ACC_CREAT | H5F_ACC_TRUNC, fcpl_id, fapl_id)))
         FAIL_STACK_ERROR;
-    if (NULL == (ftmp0 = H5F__efc_open(f1, filename[0], H5F_ACC_RDWR, fcpl_id, fapl_id)))
+    if (NULL == (ftmp0 = H5F__efc_open(f1->shared->efc, filename[0], H5F_ACC_RDWR, fcpl_id, fapl_id)))
         FAIL_STACK_ERROR;
     if (H5F_efc_close(f1, ftmp0) < 0)
         FAIL_STACK_ERROR;
@@ -2367,10 +2367,10 @@ test_graph_cycle(void)
         FAIL_STACK_ERROR;
     if (NULL == (f2 = H5F_open(filename[2], H5F_ACC_RDWR | H5F_ACC_CREAT | H5F_ACC_TRUNC, fcpl_id, fapl_id)))
         FAIL_STACK_ERROR;
-    if (NULL == (f1 = H5F__efc_open(f2, filename[1], H5F_ACC_RDWR, fcpl_id, fapl_id)))
+    if (NULL == (f1 = H5F__efc_open(f2->shared->efc, filename[1], H5F_ACC_RDWR, fcpl_id, fapl_id)))
         FAIL_STACK_ERROR;
     if (NULL ==
-        (f3 = H5F__efc_open(f1, filename[3], H5F_ACC_RDWR | H5F_ACC_CREAT | H5F_ACC_TRUNC, fcpl_id, fapl_id)))
+        (f3 = H5F__efc_open(f1->shared->efc, filename[3], H5F_ACC_RDWR | H5F_ACC_CREAT | H5F_ACC_TRUNC, fcpl_id, fapl_id)))
         FAIL_STACK_ERROR;
     if (f0->shared->nrefs != 2)
         TEST_ERROR;
@@ -2471,9 +2471,9 @@ test_graph_cycle(void)
     if (NULL == (f0 = H5F_open(filename[0], H5F_ACC_RDWR | H5F_ACC_CREAT | H5F_ACC_TRUNC, fcpl_id, fapl_id)))
         FAIL_STACK_ERROR;
     if (NULL ==
-        (f1 = H5F__efc_open(f0, filename[1], H5F_ACC_RDWR | H5F_ACC_CREAT | H5F_ACC_TRUNC, fcpl_id, fapl_id)))
+        (f1 = H5F__efc_open(f0->shared->efc, filename[1], H5F_ACC_RDWR | H5F_ACC_CREAT | H5F_ACC_TRUNC, fcpl_id, fapl_id)))
         FAIL_STACK_ERROR;
-    if (NULL == (ftmp0 = H5F__efc_open(f1, filename[0], H5F_ACC_RDWR, fcpl_id, fapl_id)))
+    if (NULL == (ftmp0 = H5F__efc_open(f1->shared->efc, filename[0], H5F_ACC_RDWR, fcpl_id, fapl_id)))
         FAIL_STACK_ERROR;
     if (H5F_efc_close(f1, ftmp0) < 0)
         FAIL_STACK_ERROR;
@@ -2481,10 +2481,10 @@ test_graph_cycle(void)
         FAIL_STACK_ERROR;
     if (NULL == (f2 = H5F_open(filename[2], H5F_ACC_RDWR | H5F_ACC_CREAT | H5F_ACC_TRUNC, fcpl_id, fapl_id)))
         FAIL_STACK_ERROR;
-    if (NULL == (f1 = H5F__efc_open(f2, filename[1], H5F_ACC_RDWR, fcpl_id, fapl_id)))
+    if (NULL == (f1 = H5F__efc_open(f2->shared->efc, filename[1], H5F_ACC_RDWR, fcpl_id, fapl_id)))
         FAIL_STACK_ERROR;
     if (NULL ==
-        (f3 = H5F__efc_open(f1, filename[3], H5F_ACC_RDWR | H5F_ACC_CREAT | H5F_ACC_TRUNC, fcpl_id, fapl_id)))
+        (f3 = H5F__efc_open(f1->shared->efc, filename[3], H5F_ACC_RDWR | H5F_ACC_CREAT | H5F_ACC_TRUNC, fcpl_id, fapl_id)))
         FAIL_STACK_ERROR;
     if (f0->shared->nrefs != 2)
         TEST_ERROR;
@@ -2551,11 +2551,11 @@ test_graph_cycle(void)
     if (H5Pset_elink_file_cache_size(fapl_id, 0) < 0)
         TEST_ERROR;
     if (NULL ==
-        (f1 = H5F__efc_open(f0, filename[1], H5F_ACC_RDWR | H5F_ACC_CREAT | H5F_ACC_TRUNC, fcpl_id, fapl_id)))
+        (f1 = H5F__efc_open(f0->shared->efc, filename[1], H5F_ACC_RDWR | H5F_ACC_CREAT | H5F_ACC_TRUNC, fcpl_id, fapl_id)))
         FAIL_STACK_ERROR;
     if (H5Pset_elink_file_cache_size(fapl_id, 8) < 0)
         TEST_ERROR;
-    if (NULL == (ftmp0 = H5F__efc_open(f1, filename[0], H5F_ACC_RDWR, fcpl_id, fapl_id)))
+    if (NULL == (ftmp0 = H5F__efc_open(f1->shared->efc, filename[0], H5F_ACC_RDWR, fcpl_id, fapl_id)))
         FAIL_STACK_ERROR;
     if (f0->shared->nrefs != 2)
         TEST_ERROR;
@@ -2587,9 +2587,9 @@ test_graph_cycle(void)
     if (NULL == (f0 = H5F_open(filename[0], H5F_ACC_RDWR | H5F_ACC_CREAT | H5F_ACC_TRUNC, fcpl_id, fapl_id)))
         FAIL_STACK_ERROR;
     if (NULL ==
-        (f1 = H5F__efc_open(f0, filename[1], H5F_ACC_RDWR | H5F_ACC_CREAT | H5F_ACC_TRUNC, fcpl_id, fapl_id)))
+        (f1 = H5F__efc_open(f0->shared->efc, filename[1], H5F_ACC_RDWR | H5F_ACC_CREAT | H5F_ACC_TRUNC, fcpl_id, fapl_id)))
         FAIL_STACK_ERROR;
-    if (NULL == (ftmp0 = H5F__efc_open(f1, filename[0], H5F_ACC_RDWR, fcpl_id, fapl_id)))
+    if (NULL == (ftmp0 = H5F__efc_open(f1->shared->efc, filename[0], H5F_ACC_RDWR, fcpl_id, fapl_id)))
         FAIL_STACK_ERROR;
     if (H5F_efc_close(f1, ftmp0) < 0)
         FAIL_STACK_ERROR;
@@ -2598,7 +2598,7 @@ test_graph_cycle(void)
     if (H5Pset_elink_file_cache_size(fapl_id, 0) < 0)
         TEST_ERROR;
     if (NULL ==
-        (f2 = H5F__efc_open(f1, filename[2], H5F_ACC_RDWR | H5F_ACC_CREAT | H5F_ACC_TRUNC, fcpl_id, fapl_id)))
+        (f2 = H5F__efc_open(f1->shared->efc, filename[2], H5F_ACC_RDWR | H5F_ACC_CREAT | H5F_ACC_TRUNC, fcpl_id, fapl_id)))
         FAIL_STACK_ERROR;
     if (H5Pset_elink_file_cache_size(fapl_id, 8) < 0)
         TEST_ERROR;

--- a/test/efc.c
+++ b/test/efc.c
@@ -84,8 +84,8 @@ test_single(void)
      * count = 2, release EFC, verify ref count = 1. Verifies a file can be
      * held open by the EFC.
      */
-    if (NULL ==
-        (f1 = H5F__efc_open(f0->shared->efc, filename[1], H5F_ACC_RDWR | H5F_ACC_CREAT | H5F_ACC_TRUNC, fcpl_id, fapl_id)))
+    if (NULL == (f1 = H5F__efc_open(f0->shared->efc, filename[1],
+                                    H5F_ACC_RDWR | H5F_ACC_CREAT | H5F_ACC_TRUNC, fcpl_id, fapl_id)))
         FAIL_STACK_ERROR;
     if (H5F_efc_close(f0, f1) < 0)
         FAIL_STACK_ERROR;
@@ -103,8 +103,8 @@ test_single(void)
     /* Test 2: Verify that subsequent efc_open requests return the cached top
      * level file pointer.  Open file 1 through EFC, close, open again, verify
      * file pointers are the same. */
-    if (NULL ==
-        (f1 = H5F__efc_open(f0->shared->efc, filename[1], H5F_ACC_RDWR | H5F_ACC_CREAT | H5F_ACC_TRUNC, fcpl_id, fapl_id)))
+    if (NULL == (f1 = H5F__efc_open(f0->shared->efc, filename[1],
+                                    H5F_ACC_RDWR | H5F_ACC_CREAT | H5F_ACC_TRUNC, fcpl_id, fapl_id)))
         FAIL_STACK_ERROR;
     ftmp1 = f1;
     if (H5F_efc_close(f0, f1) < 0)
@@ -124,8 +124,8 @@ test_single(void)
      * that the one added first is evicted.  Then reopen files in a different
      * order.  Open each file normally after closing through EFC the first time
      * to track ref counts. */
-    if (NULL ==
-        (f1 = H5F__efc_open(f0->shared->efc, filename[1], H5F_ACC_RDWR | H5F_ACC_CREAT | H5F_ACC_TRUNC, fcpl_id, fapl_id)))
+    if (NULL == (f1 = H5F__efc_open(f0->shared->efc, filename[1],
+                                    H5F_ACC_RDWR | H5F_ACC_CREAT | H5F_ACC_TRUNC, fcpl_id, fapl_id)))
         FAIL_STACK_ERROR;
     if (H5F_efc_close(f0, f1) < 0)
         FAIL_STACK_ERROR;
@@ -134,8 +134,8 @@ test_single(void)
     if (f1->shared->nrefs != 2)
         TEST_ERROR;
 
-    if (NULL ==
-        (f2 = H5F__efc_open(f0->shared->efc, filename[2], H5F_ACC_RDWR | H5F_ACC_CREAT | H5F_ACC_TRUNC, fcpl_id, fapl_id)))
+    if (NULL == (f2 = H5F__efc_open(f0->shared->efc, filename[2],
+                                    H5F_ACC_RDWR | H5F_ACC_CREAT | H5F_ACC_TRUNC, fcpl_id, fapl_id)))
         FAIL_STACK_ERROR;
     if (H5F_efc_close(f0, f2) < 0)
         FAIL_STACK_ERROR;
@@ -146,8 +146,8 @@ test_single(void)
     if (f2->shared->nrefs != 2)
         TEST_ERROR;
 
-    if (NULL ==
-        (f3 = H5F__efc_open(f0->shared->efc, filename[3], H5F_ACC_RDWR | H5F_ACC_CREAT | H5F_ACC_TRUNC, fcpl_id, fapl_id)))
+    if (NULL == (f3 = H5F__efc_open(f0->shared->efc, filename[3],
+                                    H5F_ACC_RDWR | H5F_ACC_CREAT | H5F_ACC_TRUNC, fcpl_id, fapl_id)))
         FAIL_STACK_ERROR;
     if (H5F_efc_close(f0, f3) < 0)
         FAIL_STACK_ERROR;
@@ -160,8 +160,8 @@ test_single(void)
     if (f3->shared->nrefs != 2)
         TEST_ERROR;
 
-    if (NULL ==
-        (f4 = H5F__efc_open(f0->shared->efc, filename[4], H5F_ACC_RDWR | H5F_ACC_CREAT | H5F_ACC_TRUNC, fcpl_id, fapl_id)))
+    if (NULL == (f4 = H5F__efc_open(f0->shared->efc, filename[4],
+                                    H5F_ACC_RDWR | H5F_ACC_CREAT | H5F_ACC_TRUNC, fcpl_id, fapl_id)))
         FAIL_STACK_ERROR;
     if (H5F_efc_close(f0, f4) < 0)
         FAIL_STACK_ERROR;
@@ -249,8 +249,8 @@ test_single(void)
 
     /* Test 4: Verify that files kept open through the EFC are not evicted by
      * H5F__efc_release(). */
-    if (NULL ==
-        (f1 = H5F__efc_open(f0->shared->efc, filename[1], H5F_ACC_RDWR | H5F_ACC_CREAT | H5F_ACC_TRUNC, fcpl_id, fapl_id)))
+    if (NULL == (f1 = H5F__efc_open(f0->shared->efc, filename[1],
+                                    H5F_ACC_RDWR | H5F_ACC_CREAT | H5F_ACC_TRUNC, fcpl_id, fapl_id)))
         FAIL_STACK_ERROR;
     if (NULL == (ftmp1 = H5F_open(filename[1], H5F_ACC_RDWR, fcpl_id, fapl_id)))
         FAIL_STACK_ERROR;
@@ -275,8 +275,8 @@ test_single(void)
      * filling up the cache.  Open 4 files while holding the first open.  Verify
      * that the second file is evicted.  Close the first file, reopen the
      * second, and verify that the first file is evicted. */
-    if (NULL ==
-        (f1 = H5F__efc_open(f0->shared->efc, filename[1], H5F_ACC_RDWR | H5F_ACC_CREAT | H5F_ACC_TRUNC, fcpl_id, fapl_id)))
+    if (NULL == (f1 = H5F__efc_open(f0->shared->efc, filename[1],
+                                    H5F_ACC_RDWR | H5F_ACC_CREAT | H5F_ACC_TRUNC, fcpl_id, fapl_id)))
         FAIL_STACK_ERROR;
     if (NULL == (ftmp1 = H5F_open(filename[1], H5F_ACC_RDWR, fcpl_id, fapl_id)))
         FAIL_STACK_ERROR;
@@ -285,8 +285,8 @@ test_single(void)
     if (ftmp1->shared->nrefs != 2)
         TEST_ERROR;
 
-    if (NULL ==
-        (f2 = H5F__efc_open(f0->shared->efc, filename[2], H5F_ACC_RDWR | H5F_ACC_CREAT | H5F_ACC_TRUNC, fcpl_id, fapl_id)))
+    if (NULL == (f2 = H5F__efc_open(f0->shared->efc, filename[2],
+                                    H5F_ACC_RDWR | H5F_ACC_CREAT | H5F_ACC_TRUNC, fcpl_id, fapl_id)))
         FAIL_STACK_ERROR;
     if (H5F_efc_close(f0, f2) < 0)
         FAIL_STACK_ERROR;
@@ -295,16 +295,16 @@ test_single(void)
     if (ftmp2->shared->nrefs != 2)
         TEST_ERROR;
 
-    if (NULL ==
-        (f3 = H5F__efc_open(f0->shared->efc, filename[3], H5F_ACC_RDWR | H5F_ACC_CREAT | H5F_ACC_TRUNC, fcpl_id, fapl_id)))
+    if (NULL == (f3 = H5F__efc_open(f0->shared->efc, filename[3],
+                                    H5F_ACC_RDWR | H5F_ACC_CREAT | H5F_ACC_TRUNC, fcpl_id, fapl_id)))
         FAIL_STACK_ERROR;
     if (H5F_efc_close(f0, f3) < 0)
         FAIL_STACK_ERROR;
     if (ftmp2->shared->nrefs != 2)
         TEST_ERROR;
 
-    if (NULL ==
-        (f4 = H5F__efc_open(f0->shared->efc, filename[4], H5F_ACC_RDWR | H5F_ACC_CREAT | H5F_ACC_TRUNC, fcpl_id, fapl_id)))
+    if (NULL == (f4 = H5F__efc_open(f0->shared->efc, filename[4],
+                                    H5F_ACC_RDWR | H5F_ACC_CREAT | H5F_ACC_TRUNC, fcpl_id, fapl_id)))
         FAIL_STACK_ERROR;
     if (H5F_efc_close(f0, f4) < 0)
         FAIL_STACK_ERROR;
@@ -349,8 +349,8 @@ test_single(void)
      * prevents further files from being cached.  Open and hold open 3 files
      * through the EFC, then open the fourth and verify that it was not added to
      * the EFC. */
-    if (NULL ==
-        (f1 = H5F__efc_open(f0->shared->efc, filename[1], H5F_ACC_RDWR | H5F_ACC_CREAT | H5F_ACC_TRUNC, fcpl_id, fapl_id)))
+    if (NULL == (f1 = H5F__efc_open(f0->shared->efc, filename[1],
+                                    H5F_ACC_RDWR | H5F_ACC_CREAT | H5F_ACC_TRUNC, fcpl_id, fapl_id)))
         FAIL_STACK_ERROR;
     if (NULL == (ftmp1 = H5F_open(filename[1], H5F_ACC_RDWR, fcpl_id, fapl_id)))
         FAIL_STACK_ERROR;
@@ -359,8 +359,8 @@ test_single(void)
     if (ftmp1->shared->nrefs != 2)
         TEST_ERROR;
 
-    if (NULL ==
-        (f2 = H5F__efc_open(f0->shared->efc, filename[2], H5F_ACC_RDWR | H5F_ACC_CREAT | H5F_ACC_TRUNC, fcpl_id, fapl_id)))
+    if (NULL == (f2 = H5F__efc_open(f0->shared->efc, filename[2],
+                                    H5F_ACC_RDWR | H5F_ACC_CREAT | H5F_ACC_TRUNC, fcpl_id, fapl_id)))
         FAIL_STACK_ERROR;
     if (NULL == (ftmp2 = H5F_open(filename[2], H5F_ACC_RDWR, fcpl_id, fapl_id)))
         FAIL_STACK_ERROR;
@@ -369,8 +369,8 @@ test_single(void)
     if (ftmp2->shared->nrefs != 2)
         TEST_ERROR;
 
-    if (NULL ==
-        (f3 = H5F__efc_open(f0->shared->efc, filename[3], H5F_ACC_RDWR | H5F_ACC_CREAT | H5F_ACC_TRUNC, fcpl_id, fapl_id)))
+    if (NULL == (f3 = H5F__efc_open(f0->shared->efc, filename[3],
+                                    H5F_ACC_RDWR | H5F_ACC_CREAT | H5F_ACC_TRUNC, fcpl_id, fapl_id)))
         FAIL_STACK_ERROR;
     if (NULL == (ftmp3 = H5F_open(filename[3], H5F_ACC_RDWR, fcpl_id, fapl_id)))
         FAIL_STACK_ERROR;
@@ -379,8 +379,8 @@ test_single(void)
     if (ftmp3->shared->nrefs != 2)
         TEST_ERROR;
 
-    if (NULL ==
-        (f4 = H5F__efc_open(f0->shared->efc, filename[4], H5F_ACC_RDWR | H5F_ACC_CREAT | H5F_ACC_TRUNC, fcpl_id, fapl_id)))
+    if (NULL == (f4 = H5F__efc_open(f0->shared->efc, filename[4],
+                                    H5F_ACC_RDWR | H5F_ACC_CREAT | H5F_ACC_TRUNC, fcpl_id, fapl_id)))
         FAIL_STACK_ERROR;
     if (H5F_efc_close(f0, f4) < 0)
         FAIL_STACK_ERROR;
@@ -422,11 +422,11 @@ test_single(void)
 
     /* Test 7: Test multiple file opens.  Open a file twice, close it once, then
      * verify that it is not evicted by H5F__efc_release(). */
-    if (NULL ==
-        (f1 = H5F__efc_open(f0->shared->efc, filename[1], H5F_ACC_RDWR | H5F_ACC_CREAT | H5F_ACC_TRUNC, fcpl_id, fapl_id)))
+    if (NULL == (f1 = H5F__efc_open(f0->shared->efc, filename[1],
+                                    H5F_ACC_RDWR | H5F_ACC_CREAT | H5F_ACC_TRUNC, fcpl_id, fapl_id)))
         FAIL_STACK_ERROR;
-    if (NULL ==
-        (f2 = H5F__efc_open(f0->shared->efc, filename[1], H5F_ACC_RDWR | H5F_ACC_CREAT | H5F_ACC_TRUNC, fcpl_id, fapl_id)))
+    if (NULL == (f2 = H5F__efc_open(f0->shared->efc, filename[1],
+                                    H5F_ACC_RDWR | H5F_ACC_CREAT | H5F_ACC_TRUNC, fcpl_id, fapl_id)))
         FAIL_STACK_ERROR;
     if (NULL == (ftmp1 = H5F_open(filename[1], H5F_ACC_RDWR, fcpl_id, fapl_id)))
         FAIL_STACK_ERROR;
@@ -504,11 +504,11 @@ test_graph_nocycle(void)
      */
     if (NULL == (f0 = H5F_open(filename[0], H5F_ACC_RDWR | H5F_ACC_CREAT | H5F_ACC_TRUNC, fcpl_id, fapl_id)))
         FAIL_STACK_ERROR;
-    if (NULL ==
-        (f1 = H5F__efc_open(f0->shared->efc, filename[1], H5F_ACC_RDWR | H5F_ACC_CREAT | H5F_ACC_TRUNC, fcpl_id, fapl_id)))
+    if (NULL == (f1 = H5F__efc_open(f0->shared->efc, filename[1],
+                                    H5F_ACC_RDWR | H5F_ACC_CREAT | H5F_ACC_TRUNC, fcpl_id, fapl_id)))
         FAIL_STACK_ERROR;
-    if (NULL ==
-        (f2 = H5F__efc_open(f1->shared->efc, filename[2], H5F_ACC_RDWR | H5F_ACC_CREAT | H5F_ACC_TRUNC, fcpl_id, fapl_id)))
+    if (NULL == (f2 = H5F__efc_open(f1->shared->efc, filename[2],
+                                    H5F_ACC_RDWR | H5F_ACC_CREAT | H5F_ACC_TRUNC, fcpl_id, fapl_id)))
         FAIL_STACK_ERROR;
     if (H5F_efc_close(f1, f2) < 0)
         FAIL_STACK_ERROR;
@@ -532,8 +532,8 @@ test_graph_nocycle(void)
     if (NULL ==
         (ftmp1 = H5F_open(filename[1], H5F_ACC_RDWR | H5F_ACC_CREAT | H5F_ACC_TRUNC, fcpl_id, fapl_id)))
         FAIL_STACK_ERROR;
-    if (NULL == (f2 = H5F__efc_open(ftmp1->shared->efc, filename[2], H5F_ACC_RDWR | H5F_ACC_CREAT | H5F_ACC_TRUNC, fcpl_id,
-                                    fapl_id)))
+    if (NULL == (f2 = H5F__efc_open(ftmp1->shared->efc, filename[2],
+                                    H5F_ACC_RDWR | H5F_ACC_CREAT | H5F_ACC_TRUNC, fcpl_id, fapl_id)))
         FAIL_STACK_ERROR;
     if (NULL == (f1 = H5F__efc_open(f0->shared->efc, filename[1], H5F_ACC_RDWR, fcpl_id, fapl_id)))
         FAIL_STACK_ERROR;
@@ -562,11 +562,11 @@ test_graph_nocycle(void)
     if (NULL == (f0 = H5F_open(filename[0], H5F_ACC_RDWR | H5F_ACC_CREAT | H5F_ACC_TRUNC, fcpl_id, fapl_id)))
         FAIL_STACK_ERROR;
 
-    if (NULL ==
-        (f1 = H5F__efc_open(f0->shared->efc, filename[1], H5F_ACC_RDWR | H5F_ACC_CREAT | H5F_ACC_TRUNC, fcpl_id, fapl_id)))
+    if (NULL == (f1 = H5F__efc_open(f0->shared->efc, filename[1],
+                                    H5F_ACC_RDWR | H5F_ACC_CREAT | H5F_ACC_TRUNC, fcpl_id, fapl_id)))
         FAIL_STACK_ERROR;
-    if (NULL ==
-        (f2 = H5F__efc_open(f1->shared->efc, filename[2], H5F_ACC_RDWR | H5F_ACC_CREAT | H5F_ACC_TRUNC, fcpl_id, fapl_id)))
+    if (NULL == (f2 = H5F__efc_open(f1->shared->efc, filename[2],
+                                    H5F_ACC_RDWR | H5F_ACC_CREAT | H5F_ACC_TRUNC, fcpl_id, fapl_id)))
         FAIL_STACK_ERROR;
     if (H5F_efc_close(f1, f2) < 0)
         FAIL_STACK_ERROR;
@@ -577,11 +577,11 @@ test_graph_nocycle(void)
     if (ftmp2->shared->nrefs != 2)
         TEST_ERROR;
 
-    if (NULL ==
-        (f3 = H5F__efc_open(f0->shared->efc, filename[3], H5F_ACC_RDWR | H5F_ACC_CREAT | H5F_ACC_TRUNC, fcpl_id, fapl_id)))
+    if (NULL == (f3 = H5F__efc_open(f0->shared->efc, filename[3],
+                                    H5F_ACC_RDWR | H5F_ACC_CREAT | H5F_ACC_TRUNC, fcpl_id, fapl_id)))
         FAIL_STACK_ERROR;
-    if (NULL ==
-        (f4 = H5F__efc_open(f3->shared->efc, filename[4], H5F_ACC_RDWR | H5F_ACC_CREAT | H5F_ACC_TRUNC, fcpl_id, fapl_id)))
+    if (NULL == (f4 = H5F__efc_open(f3->shared->efc, filename[4],
+                                    H5F_ACC_RDWR | H5F_ACC_CREAT | H5F_ACC_TRUNC, fcpl_id, fapl_id)))
         FAIL_STACK_ERROR;
     if (H5F_efc_close(f3, f4) < 0)
         FAIL_STACK_ERROR;
@@ -614,13 +614,13 @@ test_graph_nocycle(void)
         FAIL_STACK_ERROR;
     if (NULL == (f1 = H5F_open(filename[1], H5F_ACC_RDWR | H5F_ACC_CREAT | H5F_ACC_TRUNC, fcpl_id, fapl_id)))
         FAIL_STACK_ERROR;
-    if (NULL ==
-        (f2 = H5F__efc_open(f0->shared->efc, filename[2], H5F_ACC_RDWR | H5F_ACC_CREAT | H5F_ACC_TRUNC, fcpl_id, fapl_id)))
+    if (NULL == (f2 = H5F__efc_open(f0->shared->efc, filename[2],
+                                    H5F_ACC_RDWR | H5F_ACC_CREAT | H5F_ACC_TRUNC, fcpl_id, fapl_id)))
         FAIL_STACK_ERROR;
     if (NULL == (ftmp2 = H5F__efc_open(f1->shared->efc, filename[2], H5F_ACC_RDWR, fcpl_id, fapl_id)))
         FAIL_STACK_ERROR;
-    if (NULL ==
-        (f3 = H5F__efc_open(f2->shared->efc, filename[3], H5F_ACC_RDWR | H5F_ACC_CREAT | H5F_ACC_TRUNC, fcpl_id, fapl_id)))
+    if (NULL == (f3 = H5F__efc_open(f2->shared->efc, filename[3],
+                                    H5F_ACC_RDWR | H5F_ACC_CREAT | H5F_ACC_TRUNC, fcpl_id, fapl_id)))
         FAIL_STACK_ERROR;
     if (H5F_efc_close(f2, f3) < 0)
         FAIL_STACK_ERROR;
@@ -664,14 +664,14 @@ test_graph_nocycle(void)
      * files. */
     if (NULL == (f0 = H5F_open(filename[0], H5F_ACC_RDWR | H5F_ACC_CREAT | H5F_ACC_TRUNC, fcpl_id, fapl_id)))
         FAIL_STACK_ERROR;
-    if (NULL ==
-        (f1 = H5F__efc_open(f0->shared->efc, filename[1], H5F_ACC_RDWR | H5F_ACC_CREAT | H5F_ACC_TRUNC, fcpl_id, fapl_id)))
+    if (NULL == (f1 = H5F__efc_open(f0->shared->efc, filename[1],
+                                    H5F_ACC_RDWR | H5F_ACC_CREAT | H5F_ACC_TRUNC, fcpl_id, fapl_id)))
         FAIL_STACK_ERROR;
-    if (NULL ==
-        (f2 = H5F__efc_open(f0->shared->efc, filename[2], H5F_ACC_RDWR | H5F_ACC_CREAT | H5F_ACC_TRUNC, fcpl_id, fapl_id)))
+    if (NULL == (f2 = H5F__efc_open(f0->shared->efc, filename[2],
+                                    H5F_ACC_RDWR | H5F_ACC_CREAT | H5F_ACC_TRUNC, fcpl_id, fapl_id)))
         FAIL_STACK_ERROR;
-    if (NULL ==
-        (f3 = H5F__efc_open(f2->shared->efc, filename[3], H5F_ACC_RDWR | H5F_ACC_CREAT | H5F_ACC_TRUNC, fcpl_id, fapl_id)))
+    if (NULL == (f3 = H5F__efc_open(f2->shared->efc, filename[3],
+                                    H5F_ACC_RDWR | H5F_ACC_CREAT | H5F_ACC_TRUNC, fcpl_id, fapl_id)))
         FAIL_STACK_ERROR;
     if (H5F_efc_close(f2, f3) < 0)
         FAIL_STACK_ERROR;
@@ -703,17 +703,17 @@ test_graph_nocycle(void)
      * files. */
     if (NULL == (f0 = H5F_open(filename[0], H5F_ACC_RDWR | H5F_ACC_CREAT | H5F_ACC_TRUNC, fcpl_id, fapl_id)))
         FAIL_STACK_ERROR;
-    if (NULL ==
-        (f1 = H5F__efc_open(f0->shared->efc, filename[1], H5F_ACC_RDWR | H5F_ACC_CREAT | H5F_ACC_TRUNC, fcpl_id, fapl_id)))
+    if (NULL == (f1 = H5F__efc_open(f0->shared->efc, filename[1],
+                                    H5F_ACC_RDWR | H5F_ACC_CREAT | H5F_ACC_TRUNC, fcpl_id, fapl_id)))
         FAIL_STACK_ERROR;
-    if (NULL ==
-        (f2 = H5F__efc_open(f0->shared->efc, filename[2], H5F_ACC_RDWR | H5F_ACC_CREAT | H5F_ACC_TRUNC, fcpl_id, fapl_id)))
+    if (NULL == (f2 = H5F__efc_open(f0->shared->efc, filename[2],
+                                    H5F_ACC_RDWR | H5F_ACC_CREAT | H5F_ACC_TRUNC, fcpl_id, fapl_id)))
         FAIL_STACK_ERROR;
-    if (NULL ==
-        (f3 = H5F__efc_open(f0->shared->efc, filename[3], H5F_ACC_RDWR | H5F_ACC_CREAT | H5F_ACC_TRUNC, fcpl_id, fapl_id)))
+    if (NULL == (f3 = H5F__efc_open(f0->shared->efc, filename[3],
+                                    H5F_ACC_RDWR | H5F_ACC_CREAT | H5F_ACC_TRUNC, fcpl_id, fapl_id)))
         FAIL_STACK_ERROR;
-    if (NULL ==
-        (f4 = H5F__efc_open(f0->shared->efc, filename[4], H5F_ACC_RDWR | H5F_ACC_CREAT | H5F_ACC_TRUNC, fcpl_id, fapl_id)))
+    if (NULL == (f4 = H5F__efc_open(f0->shared->efc, filename[4],
+                                    H5F_ACC_RDWR | H5F_ACC_CREAT | H5F_ACC_TRUNC, fcpl_id, fapl_id)))
         FAIL_STACK_ERROR;
     if (H5F_efc_close(f0, f4) < 0)
         FAIL_STACK_ERROR;
@@ -857,8 +857,8 @@ test_graph_cycle(void)
      * the file is part of another file's EFC. */
     if (NULL == (f0 = H5F_open(filename[0], H5F_ACC_RDWR | H5F_ACC_CREAT | H5F_ACC_TRUNC, fcpl_id, fapl_id)))
         FAIL_STACK_ERROR;
-    if (NULL ==
-        (f1 = H5F__efc_open(f0->shared->efc, filename[1], H5F_ACC_RDWR | H5F_ACC_CREAT | H5F_ACC_TRUNC, fcpl_id, fapl_id)))
+    if (NULL == (f1 = H5F__efc_open(f0->shared->efc, filename[1],
+                                    H5F_ACC_RDWR | H5F_ACC_CREAT | H5F_ACC_TRUNC, fcpl_id, fapl_id)))
         FAIL_STACK_ERROR;
     if (NULL == (ftmp1 = H5F__efc_open(f1->shared->efc, filename[1], H5F_ACC_RDWR, fcpl_id, fapl_id)))
         FAIL_STACK_ERROR;
@@ -877,8 +877,8 @@ test_graph_cycle(void)
     if (H5F_try_close(f1, NULL) < 0)
         FAIL_STACK_ERROR;
 
-    if (NULL ==
-        (f1 = H5F__efc_open(f0->shared->efc, filename[1], H5F_ACC_RDWR | H5F_ACC_CREAT | H5F_ACC_TRUNC, fcpl_id, fapl_id)))
+    if (NULL == (f1 = H5F__efc_open(f0->shared->efc, filename[1],
+                                    H5F_ACC_RDWR | H5F_ACC_CREAT | H5F_ACC_TRUNC, fcpl_id, fapl_id)))
         FAIL_STACK_ERROR;
     if (NULL == (ftmp1 = H5F__efc_open(f1->shared->efc, filename[1], H5F_ACC_RDWR, fcpl_id, fapl_id)))
         FAIL_STACK_ERROR;
@@ -900,8 +900,8 @@ test_graph_cycle(void)
     /* Test 3: Simple 2 file cycle */
     if (NULL == (f0 = H5F_open(filename[0], H5F_ACC_RDWR | H5F_ACC_CREAT | H5F_ACC_TRUNC, fcpl_id, fapl_id)))
         FAIL_STACK_ERROR;
-    if (NULL ==
-        (f1 = H5F__efc_open(f0->shared->efc, filename[1], H5F_ACC_RDWR | H5F_ACC_CREAT | H5F_ACC_TRUNC, fcpl_id, fapl_id)))
+    if (NULL == (f1 = H5F__efc_open(f0->shared->efc, filename[1],
+                                    H5F_ACC_RDWR | H5F_ACC_CREAT | H5F_ACC_TRUNC, fcpl_id, fapl_id)))
         FAIL_STACK_ERROR;
     if (NULL == (ftmp0 = H5F__efc_open(f1->shared->efc, filename[0], H5F_ACC_RDWR, fcpl_id, fapl_id)))
         FAIL_STACK_ERROR;
@@ -916,8 +916,8 @@ test_graph_cycle(void)
     if (f0->shared->nrefs != 1)
         TEST_ERROR;
 
-    if (NULL ==
-        (f1 = H5F__efc_open(f0->shared->efc, filename[1], H5F_ACC_RDWR | H5F_ACC_CREAT | H5F_ACC_TRUNC, fcpl_id, fapl_id)))
+    if (NULL == (f1 = H5F__efc_open(f0->shared->efc, filename[1],
+                                    H5F_ACC_RDWR | H5F_ACC_CREAT | H5F_ACC_TRUNC, fcpl_id, fapl_id)))
         FAIL_STACK_ERROR;
     if (NULL == (ftmp0 = H5F__efc_open(f1->shared->efc, filename[0], H5F_ACC_RDWR, fcpl_id, fapl_id)))
         FAIL_STACK_ERROR;
@@ -939,11 +939,11 @@ test_graph_cycle(void)
     /* Test 4: Simple 2 file cycle (indirectly referenced) */
     if (NULL == (f0 = H5F_open(filename[0], H5F_ACC_RDWR | H5F_ACC_CREAT | H5F_ACC_TRUNC, fcpl_id, fapl_id)))
         FAIL_STACK_ERROR;
-    if (NULL ==
-        (f1 = H5F__efc_open(f0->shared->efc, filename[1], H5F_ACC_RDWR | H5F_ACC_CREAT | H5F_ACC_TRUNC, fcpl_id, fapl_id)))
+    if (NULL == (f1 = H5F__efc_open(f0->shared->efc, filename[1],
+                                    H5F_ACC_RDWR | H5F_ACC_CREAT | H5F_ACC_TRUNC, fcpl_id, fapl_id)))
         FAIL_STACK_ERROR;
-    if (NULL ==
-        (f2 = H5F__efc_open(f1->shared->efc, filename[2], H5F_ACC_RDWR | H5F_ACC_CREAT | H5F_ACC_TRUNC, fcpl_id, fapl_id)))
+    if (NULL == (f2 = H5F__efc_open(f1->shared->efc, filename[2],
+                                    H5F_ACC_RDWR | H5F_ACC_CREAT | H5F_ACC_TRUNC, fcpl_id, fapl_id)))
         FAIL_STACK_ERROR;
     if (NULL == (ftmp1 = H5F__efc_open(f2->shared->efc, filename[1], H5F_ACC_RDWR, fcpl_id, fapl_id)))
         FAIL_STACK_ERROR;
@@ -967,8 +967,8 @@ test_graph_cycle(void)
     /* Test 5: Parallel double cycle */
     if (NULL == (f0 = H5F_open(filename[0], H5F_ACC_RDWR | H5F_ACC_CREAT | H5F_ACC_TRUNC, fcpl_id, fapl_id)))
         FAIL_STACK_ERROR;
-    if (NULL ==
-        (f1 = H5F__efc_open(f0->shared->efc, filename[1], H5F_ACC_RDWR | H5F_ACC_CREAT | H5F_ACC_TRUNC, fcpl_id, fapl_id)))
+    if (NULL == (f1 = H5F__efc_open(f0->shared->efc, filename[1],
+                                    H5F_ACC_RDWR | H5F_ACC_CREAT | H5F_ACC_TRUNC, fcpl_id, fapl_id)))
         FAIL_STACK_ERROR;
     if (NULL == (ftmp0 = H5F__efc_open(f1->shared->efc, filename[0], H5F_ACC_RDWR, fcpl_id, fapl_id)))
         FAIL_STACK_ERROR;
@@ -976,8 +976,8 @@ test_graph_cycle(void)
         FAIL_STACK_ERROR;
     if (H5F_efc_close(f0, f1) < 0)
         FAIL_STACK_ERROR;
-    if (NULL ==
-        (f2 = H5F__efc_open(f0->shared->efc, filename[2], H5F_ACC_RDWR | H5F_ACC_CREAT | H5F_ACC_TRUNC, fcpl_id, fapl_id)))
+    if (NULL == (f2 = H5F__efc_open(f0->shared->efc, filename[2],
+                                    H5F_ACC_RDWR | H5F_ACC_CREAT | H5F_ACC_TRUNC, fcpl_id, fapl_id)))
         FAIL_STACK_ERROR;
     if (NULL == (ftmp0 = H5F__efc_open(f2->shared->efc, filename[0], H5F_ACC_RDWR, fcpl_id, fapl_id)))
         FAIL_STACK_ERROR;
@@ -999,8 +999,8 @@ test_graph_cycle(void)
     /* Test 6: Parallel double cycle with release */
     if (NULL == (f0 = H5F_open(filename[0], H5F_ACC_RDWR | H5F_ACC_CREAT | H5F_ACC_TRUNC, fcpl_id, fapl_id)))
         FAIL_STACK_ERROR;
-    if (NULL ==
-        (f1 = H5F__efc_open(f0->shared->efc, filename[1], H5F_ACC_RDWR | H5F_ACC_CREAT | H5F_ACC_TRUNC, fcpl_id, fapl_id)))
+    if (NULL == (f1 = H5F__efc_open(f0->shared->efc, filename[1],
+                                    H5F_ACC_RDWR | H5F_ACC_CREAT | H5F_ACC_TRUNC, fcpl_id, fapl_id)))
         FAIL_STACK_ERROR;
     if (NULL == (ftmp0 = H5F__efc_open(f1->shared->efc, filename[0], H5F_ACC_RDWR, fcpl_id, fapl_id)))
         FAIL_STACK_ERROR;
@@ -1008,8 +1008,8 @@ test_graph_cycle(void)
         FAIL_STACK_ERROR;
     if (H5F_efc_close(f0, f1) < 0)
         FAIL_STACK_ERROR;
-    if (NULL ==
-        (f2 = H5F__efc_open(f0->shared->efc, filename[2], H5F_ACC_RDWR | H5F_ACC_CREAT | H5F_ACC_TRUNC, fcpl_id, fapl_id)))
+    if (NULL == (f2 = H5F__efc_open(f0->shared->efc, filename[2],
+                                    H5F_ACC_RDWR | H5F_ACC_CREAT | H5F_ACC_TRUNC, fcpl_id, fapl_id)))
         FAIL_STACK_ERROR;
     if (NULL == (ftmp0 = H5F__efc_open(f2->shared->efc, filename[0], H5F_ACC_RDWR, fcpl_id, fapl_id)))
         FAIL_STACK_ERROR;
@@ -1029,13 +1029,13 @@ test_graph_cycle(void)
     /* Test 7: Chained parallel double cycle */
     if (NULL == (f0 = H5F_open(filename[0], H5F_ACC_RDWR | H5F_ACC_CREAT | H5F_ACC_TRUNC, fcpl_id, fapl_id)))
         FAIL_STACK_ERROR;
-    if (NULL ==
-        (f1 = H5F__efc_open(f0->shared->efc, filename[1], H5F_ACC_RDWR | H5F_ACC_CREAT | H5F_ACC_TRUNC, fcpl_id, fapl_id)))
+    if (NULL == (f1 = H5F__efc_open(f0->shared->efc, filename[1],
+                                    H5F_ACC_RDWR | H5F_ACC_CREAT | H5F_ACC_TRUNC, fcpl_id, fapl_id)))
         FAIL_STACK_ERROR;
     if (NULL == (ftmp0 = H5F__efc_open(f1->shared->efc, filename[0], H5F_ACC_RDWR, fcpl_id, fapl_id)))
         FAIL_STACK_ERROR;
-    if (NULL ==
-        (f2 = H5F__efc_open(f1->shared->efc, filename[2], H5F_ACC_RDWR | H5F_ACC_CREAT | H5F_ACC_TRUNC, fcpl_id, fapl_id)))
+    if (NULL == (f2 = H5F__efc_open(f1->shared->efc, filename[2],
+                                    H5F_ACC_RDWR | H5F_ACC_CREAT | H5F_ACC_TRUNC, fcpl_id, fapl_id)))
         FAIL_STACK_ERROR;
     if (NULL == (ftmp1 = H5F__efc_open(f2->shared->efc, filename[1], H5F_ACC_RDWR, fcpl_id, fapl_id)))
         FAIL_STACK_ERROR;
@@ -1043,8 +1043,8 @@ test_graph_cycle(void)
         FAIL_STACK_ERROR;
     if (H5F_efc_close(f1, f2) < 0)
         FAIL_STACK_ERROR;
-    if (NULL ==
-        (f3 = H5F__efc_open(f1->shared->efc, filename[3], H5F_ACC_RDWR | H5F_ACC_CREAT | H5F_ACC_TRUNC, fcpl_id, fapl_id)))
+    if (NULL == (f3 = H5F__efc_open(f1->shared->efc, filename[3],
+                                    H5F_ACC_RDWR | H5F_ACC_CREAT | H5F_ACC_TRUNC, fcpl_id, fapl_id)))
         FAIL_STACK_ERROR;
     if (NULL == (ftmp1 = H5F__efc_open(f3->shared->efc, filename[1], H5F_ACC_RDWR, fcpl_id, fapl_id)))
         FAIL_STACK_ERROR;
@@ -1070,13 +1070,13 @@ test_graph_cycle(void)
     /* Test 8: Chained parallel double cycle with release */
     if (NULL == (f0 = H5F_open(filename[0], H5F_ACC_RDWR | H5F_ACC_CREAT | H5F_ACC_TRUNC, fcpl_id, fapl_id)))
         FAIL_STACK_ERROR;
-    if (NULL ==
-        (f1 = H5F__efc_open(f0->shared->efc, filename[1], H5F_ACC_RDWR | H5F_ACC_CREAT | H5F_ACC_TRUNC, fcpl_id, fapl_id)))
+    if (NULL == (f1 = H5F__efc_open(f0->shared->efc, filename[1],
+                                    H5F_ACC_RDWR | H5F_ACC_CREAT | H5F_ACC_TRUNC, fcpl_id, fapl_id)))
         FAIL_STACK_ERROR;
     if (NULL == (ftmp0 = H5F__efc_open(f1->shared->efc, filename[0], H5F_ACC_RDWR, fcpl_id, fapl_id)))
         FAIL_STACK_ERROR;
-    if (NULL ==
-        (f2 = H5F__efc_open(f1->shared->efc, filename[2], H5F_ACC_RDWR | H5F_ACC_CREAT | H5F_ACC_TRUNC, fcpl_id, fapl_id)))
+    if (NULL == (f2 = H5F__efc_open(f1->shared->efc, filename[2],
+                                    H5F_ACC_RDWR | H5F_ACC_CREAT | H5F_ACC_TRUNC, fcpl_id, fapl_id)))
         FAIL_STACK_ERROR;
     if (NULL == (ftmp1 = H5F__efc_open(f2->shared->efc, filename[1], H5F_ACC_RDWR, fcpl_id, fapl_id)))
         FAIL_STACK_ERROR;
@@ -1084,8 +1084,8 @@ test_graph_cycle(void)
         FAIL_STACK_ERROR;
     if (H5F_efc_close(f1, f2) < 0)
         FAIL_STACK_ERROR;
-    if (NULL ==
-        (f3 = H5F__efc_open(f1->shared->efc, filename[3], H5F_ACC_RDWR | H5F_ACC_CREAT | H5F_ACC_TRUNC, fcpl_id, fapl_id)))
+    if (NULL == (f3 = H5F__efc_open(f1->shared->efc, filename[3],
+                                    H5F_ACC_RDWR | H5F_ACC_CREAT | H5F_ACC_TRUNC, fcpl_id, fapl_id)))
         FAIL_STACK_ERROR;
     if (NULL == (ftmp1 = H5F__efc_open(f3->shared->efc, filename[1], H5F_ACC_RDWR, fcpl_id, fapl_id)))
         FAIL_STACK_ERROR;
@@ -1111,8 +1111,8 @@ test_graph_cycle(void)
         FAIL_STACK_ERROR;
     if (NULL == (ftmp0 = H5F_open(filename[0], H5F_ACC_RDWR, fcpl_id, fapl_id)))
         FAIL_STACK_ERROR;
-    if (NULL ==
-        (f1 = H5F__efc_open(f0->shared->efc, filename[1], H5F_ACC_RDWR | H5F_ACC_CREAT | H5F_ACC_TRUNC, fcpl_id, fapl_id)))
+    if (NULL == (f1 = H5F__efc_open(f0->shared->efc, filename[1],
+                                    H5F_ACC_RDWR | H5F_ACC_CREAT | H5F_ACC_TRUNC, fcpl_id, fapl_id)))
         FAIL_STACK_ERROR;
     if (NULL == (ftmp1 = H5F__efc_open(f1->shared->efc, filename[0], H5F_ACC_RDWR, fcpl_id, fapl_id)))
         FAIL_STACK_ERROR;
@@ -1140,8 +1140,8 @@ test_graph_cycle(void)
     /* Test 10: Simple 2 file cycle, extra ID on second file */
     if (NULL == (f0 = H5F_open(filename[0], H5F_ACC_RDWR | H5F_ACC_CREAT | H5F_ACC_TRUNC, fcpl_id, fapl_id)))
         FAIL_STACK_ERROR;
-    if (NULL ==
-        (f1 = H5F__efc_open(f0->shared->efc, filename[1], H5F_ACC_RDWR | H5F_ACC_CREAT | H5F_ACC_TRUNC, fcpl_id, fapl_id)))
+    if (NULL == (f1 = H5F__efc_open(f0->shared->efc, filename[1],
+                                    H5F_ACC_RDWR | H5F_ACC_CREAT | H5F_ACC_TRUNC, fcpl_id, fapl_id)))
         FAIL_STACK_ERROR;
     if (NULL == (ftmp1 = H5F_open(filename[1], H5F_ACC_RDWR, fcpl_id, fapl_id)))
         FAIL_STACK_ERROR;
@@ -1185,8 +1185,8 @@ test_graph_cycle(void)
     /* Test 11: Parallel double cycle, extra ID on a child file */
     if (NULL == (f0 = H5F_open(filename[0], H5F_ACC_RDWR | H5F_ACC_CREAT | H5F_ACC_TRUNC, fcpl_id, fapl_id)))
         FAIL_STACK_ERROR;
-    if (NULL ==
-        (f1 = H5F__efc_open(f0->shared->efc, filename[1], H5F_ACC_RDWR | H5F_ACC_CREAT | H5F_ACC_TRUNC, fcpl_id, fapl_id)))
+    if (NULL == (f1 = H5F__efc_open(f0->shared->efc, filename[1],
+                                    H5F_ACC_RDWR | H5F_ACC_CREAT | H5F_ACC_TRUNC, fcpl_id, fapl_id)))
         FAIL_STACK_ERROR;
     if (NULL == (ftmp0 = H5F__efc_open(f1->shared->efc, filename[0], H5F_ACC_RDWR, fcpl_id, fapl_id)))
         FAIL_STACK_ERROR;
@@ -1194,8 +1194,8 @@ test_graph_cycle(void)
         FAIL_STACK_ERROR;
     if (H5F_efc_close(f0, f1) < 0)
         FAIL_STACK_ERROR;
-    if (NULL ==
-        (f2 = H5F__efc_open(f0->shared->efc, filename[2], H5F_ACC_RDWR | H5F_ACC_CREAT | H5F_ACC_TRUNC, fcpl_id, fapl_id)))
+    if (NULL == (f2 = H5F__efc_open(f0->shared->efc, filename[2],
+                                    H5F_ACC_RDWR | H5F_ACC_CREAT | H5F_ACC_TRUNC, fcpl_id, fapl_id)))
         FAIL_STACK_ERROR;
     if (NULL == (ftmp2 = H5F_open(filename[2], H5F_ACC_RDWR, fcpl_id, fapl_id)))
         FAIL_STACK_ERROR;
@@ -1245,8 +1245,8 @@ test_graph_cycle(void)
     /* Test 12: Parallel double cycle, extra ID on a child file, with release */
     if (NULL == (f0 = H5F_open(filename[0], H5F_ACC_RDWR | H5F_ACC_CREAT | H5F_ACC_TRUNC, fcpl_id, fapl_id)))
         FAIL_STACK_ERROR;
-    if (NULL ==
-        (f1 = H5F__efc_open(f0->shared->efc, filename[1], H5F_ACC_RDWR | H5F_ACC_CREAT | H5F_ACC_TRUNC, fcpl_id, fapl_id)))
+    if (NULL == (f1 = H5F__efc_open(f0->shared->efc, filename[1],
+                                    H5F_ACC_RDWR | H5F_ACC_CREAT | H5F_ACC_TRUNC, fcpl_id, fapl_id)))
         FAIL_STACK_ERROR;
     if (NULL == (ftmp0 = H5F__efc_open(f1->shared->efc, filename[0], H5F_ACC_RDWR, fcpl_id, fapl_id)))
         FAIL_STACK_ERROR;
@@ -1254,8 +1254,8 @@ test_graph_cycle(void)
         FAIL_STACK_ERROR;
     if (H5F_efc_close(f0, f1) < 0)
         FAIL_STACK_ERROR;
-    if (NULL ==
-        (f2 = H5F__efc_open(f0->shared->efc, filename[2], H5F_ACC_RDWR | H5F_ACC_CREAT | H5F_ACC_TRUNC, fcpl_id, fapl_id)))
+    if (NULL == (f2 = H5F__efc_open(f0->shared->efc, filename[2],
+                                    H5F_ACC_RDWR | H5F_ACC_CREAT | H5F_ACC_TRUNC, fcpl_id, fapl_id)))
         FAIL_STACK_ERROR;
     if (NULL == (ftmp2 = H5F_open(filename[2], H5F_ACC_RDWR, fcpl_id, fapl_id)))
         FAIL_STACK_ERROR;
@@ -1291,13 +1291,13 @@ test_graph_cycle(void)
     /* Test 13: Chained parallel double cycle, extra ID on a child file */
     if (NULL == (f0 = H5F_open(filename[0], H5F_ACC_RDWR | H5F_ACC_CREAT | H5F_ACC_TRUNC, fcpl_id, fapl_id)))
         FAIL_STACK_ERROR;
-    if (NULL ==
-        (f1 = H5F__efc_open(f0->shared->efc, filename[1], H5F_ACC_RDWR | H5F_ACC_CREAT | H5F_ACC_TRUNC, fcpl_id, fapl_id)))
+    if (NULL == (f1 = H5F__efc_open(f0->shared->efc, filename[1],
+                                    H5F_ACC_RDWR | H5F_ACC_CREAT | H5F_ACC_TRUNC, fcpl_id, fapl_id)))
         FAIL_STACK_ERROR;
     if (NULL == (ftmp0 = H5F__efc_open(f1->shared->efc, filename[0], H5F_ACC_RDWR, fcpl_id, fapl_id)))
         FAIL_STACK_ERROR;
-    if (NULL ==
-        (f2 = H5F__efc_open(f1->shared->efc, filename[2], H5F_ACC_RDWR | H5F_ACC_CREAT | H5F_ACC_TRUNC, fcpl_id, fapl_id)))
+    if (NULL == (f2 = H5F__efc_open(f1->shared->efc, filename[2],
+                                    H5F_ACC_RDWR | H5F_ACC_CREAT | H5F_ACC_TRUNC, fcpl_id, fapl_id)))
         FAIL_STACK_ERROR;
     if (NULL == (ftmp1 = H5F__efc_open(f2->shared->efc, filename[1], H5F_ACC_RDWR, fcpl_id, fapl_id)))
         FAIL_STACK_ERROR;
@@ -1305,8 +1305,8 @@ test_graph_cycle(void)
         FAIL_STACK_ERROR;
     if (H5F_efc_close(f1, f2) < 0)
         FAIL_STACK_ERROR;
-    if (NULL ==
-        (f3 = H5F__efc_open(f1->shared->efc, filename[3], H5F_ACC_RDWR | H5F_ACC_CREAT | H5F_ACC_TRUNC, fcpl_id, fapl_id)))
+    if (NULL == (f3 = H5F__efc_open(f1->shared->efc, filename[3],
+                                    H5F_ACC_RDWR | H5F_ACC_CREAT | H5F_ACC_TRUNC, fcpl_id, fapl_id)))
         FAIL_STACK_ERROR;
     if (NULL == (ftmp3 = H5F_open(filename[3], H5F_ACC_RDWR, fcpl_id, fapl_id)))
         FAIL_STACK_ERROR;
@@ -1367,13 +1367,13 @@ test_graph_cycle(void)
      * release */
     if (NULL == (f0 = H5F_open(filename[0], H5F_ACC_RDWR | H5F_ACC_CREAT | H5F_ACC_TRUNC, fcpl_id, fapl_id)))
         FAIL_STACK_ERROR;
-    if (NULL ==
-        (f1 = H5F__efc_open(f0->shared->efc, filename[1], H5F_ACC_RDWR | H5F_ACC_CREAT | H5F_ACC_TRUNC, fcpl_id, fapl_id)))
+    if (NULL == (f1 = H5F__efc_open(f0->shared->efc, filename[1],
+                                    H5F_ACC_RDWR | H5F_ACC_CREAT | H5F_ACC_TRUNC, fcpl_id, fapl_id)))
         FAIL_STACK_ERROR;
     if (NULL == (ftmp0 = H5F__efc_open(f1->shared->efc, filename[0], H5F_ACC_RDWR, fcpl_id, fapl_id)))
         FAIL_STACK_ERROR;
-    if (NULL ==
-        (f2 = H5F__efc_open(f1->shared->efc, filename[2], H5F_ACC_RDWR | H5F_ACC_CREAT | H5F_ACC_TRUNC, fcpl_id, fapl_id)))
+    if (NULL == (f2 = H5F__efc_open(f1->shared->efc, filename[2],
+                                    H5F_ACC_RDWR | H5F_ACC_CREAT | H5F_ACC_TRUNC, fcpl_id, fapl_id)))
         FAIL_STACK_ERROR;
     if (NULL == (ftmp1 = H5F__efc_open(f2->shared->efc, filename[1], H5F_ACC_RDWR, fcpl_id, fapl_id)))
         FAIL_STACK_ERROR;
@@ -1381,8 +1381,8 @@ test_graph_cycle(void)
         FAIL_STACK_ERROR;
     if (H5F_efc_close(f1, f2) < 0)
         FAIL_STACK_ERROR;
-    if (NULL ==
-        (f3 = H5F__efc_open(f1->shared->efc, filename[3], H5F_ACC_RDWR | H5F_ACC_CREAT | H5F_ACC_TRUNC, fcpl_id, fapl_id)))
+    if (NULL == (f3 = H5F__efc_open(f1->shared->efc, filename[3],
+                                    H5F_ACC_RDWR | H5F_ACC_CREAT | H5F_ACC_TRUNC, fcpl_id, fapl_id)))
         FAIL_STACK_ERROR;
     if (NULL == (ftmp3 = H5F_open(filename[3], H5F_ACC_RDWR, fcpl_id, fapl_id)))
         FAIL_STACK_ERROR;
@@ -1422,8 +1422,8 @@ test_graph_cycle(void)
     /* Test 15: One local and one remote cycle */
     if (NULL == (f0 = H5F_open(filename[0], H5F_ACC_RDWR | H5F_ACC_CREAT | H5F_ACC_TRUNC, fcpl_id, fapl_id)))
         FAIL_STACK_ERROR;
-    if (NULL ==
-        (f1 = H5F__efc_open(f0->shared->efc, filename[1], H5F_ACC_RDWR | H5F_ACC_CREAT | H5F_ACC_TRUNC, fcpl_id, fapl_id)))
+    if (NULL == (f1 = H5F__efc_open(f0->shared->efc, filename[1],
+                                    H5F_ACC_RDWR | H5F_ACC_CREAT | H5F_ACC_TRUNC, fcpl_id, fapl_id)))
         FAIL_STACK_ERROR;
     if (NULL == (ftmp0 = H5F__efc_open(f1->shared->efc, filename[0], H5F_ACC_RDWR, fcpl_id, fapl_id)))
         FAIL_STACK_ERROR;
@@ -1431,11 +1431,11 @@ test_graph_cycle(void)
         FAIL_STACK_ERROR;
     if (H5F_efc_close(f0, f1) < 0)
         FAIL_STACK_ERROR;
-    if (NULL ==
-        (f2 = H5F__efc_open(f0->shared->efc, filename[2], H5F_ACC_RDWR | H5F_ACC_CREAT | H5F_ACC_TRUNC, fcpl_id, fapl_id)))
+    if (NULL == (f2 = H5F__efc_open(f0->shared->efc, filename[2],
+                                    H5F_ACC_RDWR | H5F_ACC_CREAT | H5F_ACC_TRUNC, fcpl_id, fapl_id)))
         FAIL_STACK_ERROR;
-    if (NULL ==
-        (f3 = H5F__efc_open(f2->shared->efc, filename[3], H5F_ACC_RDWR | H5F_ACC_CREAT | H5F_ACC_TRUNC, fcpl_id, fapl_id)))
+    if (NULL == (f3 = H5F__efc_open(f2->shared->efc, filename[3],
+                                    H5F_ACC_RDWR | H5F_ACC_CREAT | H5F_ACC_TRUNC, fcpl_id, fapl_id)))
         FAIL_STACK_ERROR;
     if (NULL == (ftmp2 = H5F__efc_open(f3->shared->efc, filename[2], H5F_ACC_RDWR, fcpl_id, fapl_id)))
         FAIL_STACK_ERROR;
@@ -1478,8 +1478,8 @@ test_graph_cycle(void)
     /* Test 16: One local and one remote cycle, with release */
     if (NULL == (f0 = H5F_open(filename[0], H5F_ACC_RDWR | H5F_ACC_CREAT | H5F_ACC_TRUNC, fcpl_id, fapl_id)))
         FAIL_STACK_ERROR;
-    if (NULL ==
-        (f1 = H5F__efc_open(f0->shared->efc, filename[1], H5F_ACC_RDWR | H5F_ACC_CREAT | H5F_ACC_TRUNC, fcpl_id, fapl_id)))
+    if (NULL == (f1 = H5F__efc_open(f0->shared->efc, filename[1],
+                                    H5F_ACC_RDWR | H5F_ACC_CREAT | H5F_ACC_TRUNC, fcpl_id, fapl_id)))
         FAIL_STACK_ERROR;
     if (NULL == (ftmp0 = H5F__efc_open(f1->shared->efc, filename[0], H5F_ACC_RDWR, fcpl_id, fapl_id)))
         FAIL_STACK_ERROR;
@@ -1487,11 +1487,11 @@ test_graph_cycle(void)
         FAIL_STACK_ERROR;
     if (H5F_efc_close(f0, f1) < 0)
         FAIL_STACK_ERROR;
-    if (NULL ==
-        (f2 = H5F__efc_open(f0->shared->efc, filename[2], H5F_ACC_RDWR | H5F_ACC_CREAT | H5F_ACC_TRUNC, fcpl_id, fapl_id)))
+    if (NULL == (f2 = H5F__efc_open(f0->shared->efc, filename[2],
+                                    H5F_ACC_RDWR | H5F_ACC_CREAT | H5F_ACC_TRUNC, fcpl_id, fapl_id)))
         FAIL_STACK_ERROR;
-    if (NULL ==
-        (f3 = H5F__efc_open(f2->shared->efc, filename[3], H5F_ACC_RDWR | H5F_ACC_CREAT | H5F_ACC_TRUNC, fcpl_id, fapl_id)))
+    if (NULL == (f3 = H5F__efc_open(f2->shared->efc, filename[3],
+                                    H5F_ACC_RDWR | H5F_ACC_CREAT | H5F_ACC_TRUNC, fcpl_id, fapl_id)))
         FAIL_STACK_ERROR;
     if (NULL == (ftmp2 = H5F__efc_open(f3->shared->efc, filename[2], H5F_ACC_RDWR, fcpl_id, fapl_id)))
         FAIL_STACK_ERROR;
@@ -1532,8 +1532,8 @@ test_graph_cycle(void)
     /* Test 17: One local and one remote cycle, remote cycle held open */
     if (NULL == (f0 = H5F_open(filename[0], H5F_ACC_RDWR | H5F_ACC_CREAT | H5F_ACC_TRUNC, fcpl_id, fapl_id)))
         FAIL_STACK_ERROR;
-    if (NULL ==
-        (f1 = H5F__efc_open(f0->shared->efc, filename[1], H5F_ACC_RDWR | H5F_ACC_CREAT | H5F_ACC_TRUNC, fcpl_id, fapl_id)))
+    if (NULL == (f1 = H5F__efc_open(f0->shared->efc, filename[1],
+                                    H5F_ACC_RDWR | H5F_ACC_CREAT | H5F_ACC_TRUNC, fcpl_id, fapl_id)))
         FAIL_STACK_ERROR;
     if (NULL == (ftmp0 = H5F__efc_open(f1->shared->efc, filename[0], H5F_ACC_RDWR, fcpl_id, fapl_id)))
         FAIL_STACK_ERROR;
@@ -1541,11 +1541,11 @@ test_graph_cycle(void)
         FAIL_STACK_ERROR;
     if (H5F_efc_close(f0, f1) < 0)
         FAIL_STACK_ERROR;
-    if (NULL ==
-        (f2 = H5F__efc_open(f0->shared->efc, filename[2], H5F_ACC_RDWR | H5F_ACC_CREAT | H5F_ACC_TRUNC, fcpl_id, fapl_id)))
+    if (NULL == (f2 = H5F__efc_open(f0->shared->efc, filename[2],
+                                    H5F_ACC_RDWR | H5F_ACC_CREAT | H5F_ACC_TRUNC, fcpl_id, fapl_id)))
         FAIL_STACK_ERROR;
-    if (NULL ==
-        (f3 = H5F__efc_open(f2->shared->efc, filename[3], H5F_ACC_RDWR | H5F_ACC_CREAT | H5F_ACC_TRUNC, fcpl_id, fapl_id)))
+    if (NULL == (f3 = H5F__efc_open(f2->shared->efc, filename[3],
+                                    H5F_ACC_RDWR | H5F_ACC_CREAT | H5F_ACC_TRUNC, fcpl_id, fapl_id)))
         FAIL_STACK_ERROR;
     if (NULL == (ftmp3 = H5F_open(filename[3], H5F_ACC_RDWR, fcpl_id, fapl_id)))
         FAIL_STACK_ERROR;
@@ -1596,8 +1596,8 @@ test_graph_cycle(void)
      * release */
     if (NULL == (f0 = H5F_open(filename[0], H5F_ACC_RDWR | H5F_ACC_CREAT | H5F_ACC_TRUNC, fcpl_id, fapl_id)))
         FAIL_STACK_ERROR;
-    if (NULL ==
-        (f1 = H5F__efc_open(f0->shared->efc, filename[1], H5F_ACC_RDWR | H5F_ACC_CREAT | H5F_ACC_TRUNC, fcpl_id, fapl_id)))
+    if (NULL == (f1 = H5F__efc_open(f0->shared->efc, filename[1],
+                                    H5F_ACC_RDWR | H5F_ACC_CREAT | H5F_ACC_TRUNC, fcpl_id, fapl_id)))
         FAIL_STACK_ERROR;
     if (NULL == (ftmp0 = H5F__efc_open(f1->shared->efc, filename[0], H5F_ACC_RDWR, fcpl_id, fapl_id)))
         FAIL_STACK_ERROR;
@@ -1605,11 +1605,11 @@ test_graph_cycle(void)
         FAIL_STACK_ERROR;
     if (H5F_efc_close(f0, f1) < 0)
         FAIL_STACK_ERROR;
-    if (NULL ==
-        (f2 = H5F__efc_open(f0->shared->efc, filename[2], H5F_ACC_RDWR | H5F_ACC_CREAT | H5F_ACC_TRUNC, fcpl_id, fapl_id)))
+    if (NULL == (f2 = H5F__efc_open(f0->shared->efc, filename[2],
+                                    H5F_ACC_RDWR | H5F_ACC_CREAT | H5F_ACC_TRUNC, fcpl_id, fapl_id)))
         FAIL_STACK_ERROR;
-    if (NULL ==
-        (f3 = H5F__efc_open(f2->shared->efc, filename[3], H5F_ACC_RDWR | H5F_ACC_CREAT | H5F_ACC_TRUNC, fcpl_id, fapl_id)))
+    if (NULL == (f3 = H5F__efc_open(f2->shared->efc, filename[3],
+                                    H5F_ACC_RDWR | H5F_ACC_CREAT | H5F_ACC_TRUNC, fcpl_id, fapl_id)))
         FAIL_STACK_ERROR;
     if (NULL == (ftmp3 = H5F_open(filename[3], H5F_ACC_RDWR, fcpl_id, fapl_id)))
         FAIL_STACK_ERROR;
@@ -1663,14 +1663,14 @@ test_graph_cycle(void)
      * Also cycle between bottom (root) and top and cycles on the sides. */
     if (NULL == (f0 = H5F_open(filename[0], H5F_ACC_RDWR | H5F_ACC_CREAT | H5F_ACC_TRUNC, fcpl_id, fapl_id)))
         FAIL_STACK_ERROR;
-    if (NULL ==
-        (f1 = H5F__efc_open(f0->shared->efc, filename[1], H5F_ACC_RDWR | H5F_ACC_CREAT | H5F_ACC_TRUNC, fcpl_id, fapl_id)))
+    if (NULL == (f1 = H5F__efc_open(f0->shared->efc, filename[1],
+                                    H5F_ACC_RDWR | H5F_ACC_CREAT | H5F_ACC_TRUNC, fcpl_id, fapl_id)))
         FAIL_STACK_ERROR;
-    if (NULL ==
-        (f2 = H5F__efc_open(f0->shared->efc, filename[2], H5F_ACC_RDWR | H5F_ACC_CREAT | H5F_ACC_TRUNC, fcpl_id, fapl_id)))
+    if (NULL == (f2 = H5F__efc_open(f0->shared->efc, filename[2],
+                                    H5F_ACC_RDWR | H5F_ACC_CREAT | H5F_ACC_TRUNC, fcpl_id, fapl_id)))
         FAIL_STACK_ERROR;
-    if (NULL ==
-        (f3 = H5F__efc_open(f1->shared->efc, filename[3], H5F_ACC_RDWR | H5F_ACC_CREAT | H5F_ACC_TRUNC, fcpl_id, fapl_id)))
+    if (NULL == (f3 = H5F__efc_open(f1->shared->efc, filename[3],
+                                    H5F_ACC_RDWR | H5F_ACC_CREAT | H5F_ACC_TRUNC, fcpl_id, fapl_id)))
         FAIL_STACK_ERROR;
     if (H5F_efc_close(f1, f3) < 0)
         FAIL_STACK_ERROR;
@@ -1686,8 +1686,8 @@ test_graph_cycle(void)
         FAIL_STACK_ERROR;
     if (H5F_efc_close(f0, f3) < 0)
         FAIL_STACK_ERROR;
-    if (NULL ==
-        (f4 = H5F__efc_open(f1->shared->efc, filename[4], H5F_ACC_RDWR | H5F_ACC_CREAT | H5F_ACC_TRUNC, fcpl_id, fapl_id)))
+    if (NULL == (f4 = H5F__efc_open(f1->shared->efc, filename[4],
+                                    H5F_ACC_RDWR | H5F_ACC_CREAT | H5F_ACC_TRUNC, fcpl_id, fapl_id)))
         FAIL_STACK_ERROR;
     if (NULL == (ftmp1 = H5F__efc_open(f4->shared->efc, filename[1], H5F_ACC_RDWR, fcpl_id, fapl_id)))
         FAIL_STACK_ERROR;
@@ -1695,8 +1695,8 @@ test_graph_cycle(void)
         FAIL_STACK_ERROR;
     if (H5F_efc_close(f1, f4) < 0)
         FAIL_STACK_ERROR;
-    if (NULL ==
-        (f5 = H5F__efc_open(f2->shared->efc, filename[5], H5F_ACC_RDWR | H5F_ACC_CREAT | H5F_ACC_TRUNC, fcpl_id, fapl_id)))
+    if (NULL == (f5 = H5F__efc_open(f2->shared->efc, filename[5],
+                                    H5F_ACC_RDWR | H5F_ACC_CREAT | H5F_ACC_TRUNC, fcpl_id, fapl_id)))
         FAIL_STACK_ERROR;
     if (NULL == (ftmp2 = H5F__efc_open(f5->shared->efc, filename[2], H5F_ACC_RDWR, fcpl_id, fapl_id)))
         FAIL_STACK_ERROR;
@@ -1755,14 +1755,14 @@ test_graph_cycle(void)
      * release the files instead of closing. */
     if (NULL == (f0 = H5F_open(filename[0], H5F_ACC_RDWR | H5F_ACC_CREAT | H5F_ACC_TRUNC, fcpl_id, fapl_id)))
         FAIL_STACK_ERROR;
-    if (NULL ==
-        (f1 = H5F__efc_open(f0->shared->efc, filename[1], H5F_ACC_RDWR | H5F_ACC_CREAT | H5F_ACC_TRUNC, fcpl_id, fapl_id)))
+    if (NULL == (f1 = H5F__efc_open(f0->shared->efc, filename[1],
+                                    H5F_ACC_RDWR | H5F_ACC_CREAT | H5F_ACC_TRUNC, fcpl_id, fapl_id)))
         FAIL_STACK_ERROR;
-    if (NULL ==
-        (f2 = H5F__efc_open(f0->shared->efc, filename[2], H5F_ACC_RDWR | H5F_ACC_CREAT | H5F_ACC_TRUNC, fcpl_id, fapl_id)))
+    if (NULL == (f2 = H5F__efc_open(f0->shared->efc, filename[2],
+                                    H5F_ACC_RDWR | H5F_ACC_CREAT | H5F_ACC_TRUNC, fcpl_id, fapl_id)))
         FAIL_STACK_ERROR;
-    if (NULL ==
-        (f3 = H5F__efc_open(f1->shared->efc, filename[3], H5F_ACC_RDWR | H5F_ACC_CREAT | H5F_ACC_TRUNC, fcpl_id, fapl_id)))
+    if (NULL == (f3 = H5F__efc_open(f1->shared->efc, filename[3],
+                                    H5F_ACC_RDWR | H5F_ACC_CREAT | H5F_ACC_TRUNC, fcpl_id, fapl_id)))
         FAIL_STACK_ERROR;
     if (H5F_efc_close(f1, f3) < 0)
         FAIL_STACK_ERROR;
@@ -1778,8 +1778,8 @@ test_graph_cycle(void)
         FAIL_STACK_ERROR;
     if (H5F_efc_close(f0, f3) < 0)
         FAIL_STACK_ERROR;
-    if (NULL ==
-        (f4 = H5F__efc_open(f1->shared->efc, filename[4], H5F_ACC_RDWR | H5F_ACC_CREAT | H5F_ACC_TRUNC, fcpl_id, fapl_id)))
+    if (NULL == (f4 = H5F__efc_open(f1->shared->efc, filename[4],
+                                    H5F_ACC_RDWR | H5F_ACC_CREAT | H5F_ACC_TRUNC, fcpl_id, fapl_id)))
         FAIL_STACK_ERROR;
     if (NULL == (ftmp1 = H5F__efc_open(f4->shared->efc, filename[1], H5F_ACC_RDWR, fcpl_id, fapl_id)))
         FAIL_STACK_ERROR;
@@ -1787,8 +1787,8 @@ test_graph_cycle(void)
         FAIL_STACK_ERROR;
     if (H5F_efc_close(f1, f4) < 0)
         FAIL_STACK_ERROR;
-    if (NULL ==
-        (f5 = H5F__efc_open(f2->shared->efc, filename[5], H5F_ACC_RDWR | H5F_ACC_CREAT | H5F_ACC_TRUNC, fcpl_id, fapl_id)))
+    if (NULL == (f5 = H5F__efc_open(f2->shared->efc, filename[5],
+                                    H5F_ACC_RDWR | H5F_ACC_CREAT | H5F_ACC_TRUNC, fcpl_id, fapl_id)))
         FAIL_STACK_ERROR;
     if (NULL == (ftmp2 = H5F__efc_open(f5->shared->efc, filename[2], H5F_ACC_RDWR, fcpl_id, fapl_id)))
         FAIL_STACK_ERROR;
@@ -1844,14 +1844,14 @@ test_graph_cycle(void)
      * Also cycle between bottom (root) and top, cycles on sides held open. */
     if (NULL == (f0 = H5F_open(filename[0], H5F_ACC_RDWR | H5F_ACC_CREAT | H5F_ACC_TRUNC, fcpl_id, fapl_id)))
         FAIL_STACK_ERROR;
-    if (NULL ==
-        (f1 = H5F__efc_open(f0->shared->efc, filename[1], H5F_ACC_RDWR | H5F_ACC_CREAT | H5F_ACC_TRUNC, fcpl_id, fapl_id)))
+    if (NULL == (f1 = H5F__efc_open(f0->shared->efc, filename[1],
+                                    H5F_ACC_RDWR | H5F_ACC_CREAT | H5F_ACC_TRUNC, fcpl_id, fapl_id)))
         FAIL_STACK_ERROR;
-    if (NULL ==
-        (f2 = H5F__efc_open(f0->shared->efc, filename[2], H5F_ACC_RDWR | H5F_ACC_CREAT | H5F_ACC_TRUNC, fcpl_id, fapl_id)))
+    if (NULL == (f2 = H5F__efc_open(f0->shared->efc, filename[2],
+                                    H5F_ACC_RDWR | H5F_ACC_CREAT | H5F_ACC_TRUNC, fcpl_id, fapl_id)))
         FAIL_STACK_ERROR;
-    if (NULL ==
-        (f3 = H5F__efc_open(f1->shared->efc, filename[3], H5F_ACC_RDWR | H5F_ACC_CREAT | H5F_ACC_TRUNC, fcpl_id, fapl_id)))
+    if (NULL == (f3 = H5F__efc_open(f1->shared->efc, filename[3],
+                                    H5F_ACC_RDWR | H5F_ACC_CREAT | H5F_ACC_TRUNC, fcpl_id, fapl_id)))
         FAIL_STACK_ERROR;
     if (H5F_efc_close(f1, f3) < 0)
         FAIL_STACK_ERROR;
@@ -1867,8 +1867,8 @@ test_graph_cycle(void)
         FAIL_STACK_ERROR;
     if (H5F_efc_close(f0, f3) < 0)
         FAIL_STACK_ERROR;
-    if (NULL ==
-        (f4 = H5F__efc_open(f1->shared->efc, filename[4], H5F_ACC_RDWR | H5F_ACC_CREAT | H5F_ACC_TRUNC, fcpl_id, fapl_id)))
+    if (NULL == (f4 = H5F__efc_open(f1->shared->efc, filename[4],
+                                    H5F_ACC_RDWR | H5F_ACC_CREAT | H5F_ACC_TRUNC, fcpl_id, fapl_id)))
         FAIL_STACK_ERROR;
     if (NULL == (ftmp1 = H5F__efc_open(f4->shared->efc, filename[1], H5F_ACC_RDWR, fcpl_id, fapl_id)))
         FAIL_STACK_ERROR;
@@ -1878,8 +1878,8 @@ test_graph_cycle(void)
         FAIL_STACK_ERROR;
     if (NULL == (f4 = H5F_open(filename[4], H5F_ACC_RDWR, fcpl_id, fapl_id)))
         FAIL_STACK_ERROR;
-    if (NULL ==
-        (f5 = H5F__efc_open(f2->shared->efc, filename[5], H5F_ACC_RDWR | H5F_ACC_CREAT | H5F_ACC_TRUNC, fcpl_id, fapl_id)))
+    if (NULL == (f5 = H5F__efc_open(f2->shared->efc, filename[5],
+                                    H5F_ACC_RDWR | H5F_ACC_CREAT | H5F_ACC_TRUNC, fcpl_id, fapl_id)))
         FAIL_STACK_ERROR;
     if (NULL == (ftmp2 = H5F__efc_open(f5->shared->efc, filename[2], H5F_ACC_RDWR, fcpl_id, fapl_id)))
         FAIL_STACK_ERROR;
@@ -1974,14 +1974,14 @@ test_graph_cycle(void)
      * Also release the files instead of closing. */
     if (NULL == (f0 = H5F_open(filename[0], H5F_ACC_RDWR | H5F_ACC_CREAT | H5F_ACC_TRUNC, fcpl_id, fapl_id)))
         FAIL_STACK_ERROR;
-    if (NULL ==
-        (f1 = H5F__efc_open(f0->shared->efc, filename[1], H5F_ACC_RDWR | H5F_ACC_CREAT | H5F_ACC_TRUNC, fcpl_id, fapl_id)))
+    if (NULL == (f1 = H5F__efc_open(f0->shared->efc, filename[1],
+                                    H5F_ACC_RDWR | H5F_ACC_CREAT | H5F_ACC_TRUNC, fcpl_id, fapl_id)))
         FAIL_STACK_ERROR;
-    if (NULL ==
-        (f2 = H5F__efc_open(f0->shared->efc, filename[2], H5F_ACC_RDWR | H5F_ACC_CREAT | H5F_ACC_TRUNC, fcpl_id, fapl_id)))
+    if (NULL == (f2 = H5F__efc_open(f0->shared->efc, filename[2],
+                                    H5F_ACC_RDWR | H5F_ACC_CREAT | H5F_ACC_TRUNC, fcpl_id, fapl_id)))
         FAIL_STACK_ERROR;
-    if (NULL ==
-        (f3 = H5F__efc_open(f1->shared->efc, filename[3], H5F_ACC_RDWR | H5F_ACC_CREAT | H5F_ACC_TRUNC, fcpl_id, fapl_id)))
+    if (NULL == (f3 = H5F__efc_open(f1->shared->efc, filename[3],
+                                    H5F_ACC_RDWR | H5F_ACC_CREAT | H5F_ACC_TRUNC, fcpl_id, fapl_id)))
         FAIL_STACK_ERROR;
     if (H5F_efc_close(f1, f3) < 0)
         FAIL_STACK_ERROR;
@@ -1997,8 +1997,8 @@ test_graph_cycle(void)
         FAIL_STACK_ERROR;
     if (H5F_efc_close(f0, f3) < 0)
         FAIL_STACK_ERROR;
-    if (NULL ==
-        (f4 = H5F__efc_open(f1->shared->efc, filename[4], H5F_ACC_RDWR | H5F_ACC_CREAT | H5F_ACC_TRUNC, fcpl_id, fapl_id)))
+    if (NULL == (f4 = H5F__efc_open(f1->shared->efc, filename[4],
+                                    H5F_ACC_RDWR | H5F_ACC_CREAT | H5F_ACC_TRUNC, fcpl_id, fapl_id)))
         FAIL_STACK_ERROR;
     if (NULL == (ftmp1 = H5F__efc_open(f4->shared->efc, filename[1], H5F_ACC_RDWR, fcpl_id, fapl_id)))
         FAIL_STACK_ERROR;
@@ -2008,8 +2008,8 @@ test_graph_cycle(void)
         FAIL_STACK_ERROR;
     if (NULL == (f4 = H5F_open(filename[4], H5F_ACC_RDWR, fcpl_id, fapl_id)))
         FAIL_STACK_ERROR;
-    if (NULL ==
-        (f5 = H5F__efc_open(f2->shared->efc, filename[5], H5F_ACC_RDWR | H5F_ACC_CREAT | H5F_ACC_TRUNC, fcpl_id, fapl_id)))
+    if (NULL == (f5 = H5F__efc_open(f2->shared->efc, filename[5],
+                                    H5F_ACC_RDWR | H5F_ACC_CREAT | H5F_ACC_TRUNC, fcpl_id, fapl_id)))
         FAIL_STACK_ERROR;
     if (NULL == (ftmp2 = H5F__efc_open(f5->shared->efc, filename[2], H5F_ACC_RDWR, fcpl_id, fapl_id)))
         FAIL_STACK_ERROR;
@@ -2090,14 +2090,14 @@ test_graph_cycle(void)
         FAIL_STACK_ERROR;
     if (H5F_efc_close(f0, ftmp0) < 0)
         FAIL_STACK_ERROR;
-    if (NULL ==
-        (f1 = H5F__efc_open(f0->shared->efc, filename[1], H5F_ACC_RDWR | H5F_ACC_CREAT | H5F_ACC_TRUNC, fcpl_id, fapl_id)))
+    if (NULL == (f1 = H5F__efc_open(f0->shared->efc, filename[1],
+                                    H5F_ACC_RDWR | H5F_ACC_CREAT | H5F_ACC_TRUNC, fcpl_id, fapl_id)))
         FAIL_STACK_ERROR;
-    if (NULL ==
-        (f2 = H5F__efc_open(f0->shared->efc, filename[2], H5F_ACC_RDWR | H5F_ACC_CREAT | H5F_ACC_TRUNC, fcpl_id, fapl_id)))
+    if (NULL == (f2 = H5F__efc_open(f0->shared->efc, filename[2],
+                                    H5F_ACC_RDWR | H5F_ACC_CREAT | H5F_ACC_TRUNC, fcpl_id, fapl_id)))
         FAIL_STACK_ERROR;
-    if (NULL ==
-        (f3 = H5F__efc_open(f0->shared->efc, filename[3], H5F_ACC_RDWR | H5F_ACC_CREAT | H5F_ACC_TRUNC, fcpl_id, fapl_id)))
+    if (NULL == (f3 = H5F__efc_open(f0->shared->efc, filename[3],
+                                    H5F_ACC_RDWR | H5F_ACC_CREAT | H5F_ACC_TRUNC, fcpl_id, fapl_id)))
         FAIL_STACK_ERROR;
 
     if (NULL == (ftmp0 = H5F__efc_open(f1->shared->efc, filename[0], H5F_ACC_RDWR, fcpl_id, fapl_id)))
@@ -2193,14 +2193,14 @@ test_graph_cycle(void)
         FAIL_STACK_ERROR;
     if (H5F_efc_close(f0, ftmp0) < 0)
         FAIL_STACK_ERROR;
-    if (NULL ==
-        (f1 = H5F__efc_open(f0->shared->efc, filename[1], H5F_ACC_RDWR | H5F_ACC_CREAT | H5F_ACC_TRUNC, fcpl_id, fapl_id)))
+    if (NULL == (f1 = H5F__efc_open(f0->shared->efc, filename[1],
+                                    H5F_ACC_RDWR | H5F_ACC_CREAT | H5F_ACC_TRUNC, fcpl_id, fapl_id)))
         FAIL_STACK_ERROR;
-    if (NULL ==
-        (f2 = H5F__efc_open(f0->shared->efc, filename[2], H5F_ACC_RDWR | H5F_ACC_CREAT | H5F_ACC_TRUNC, fcpl_id, fapl_id)))
+    if (NULL == (f2 = H5F__efc_open(f0->shared->efc, filename[2],
+                                    H5F_ACC_RDWR | H5F_ACC_CREAT | H5F_ACC_TRUNC, fcpl_id, fapl_id)))
         FAIL_STACK_ERROR;
-    if (NULL ==
-        (f3 = H5F__efc_open(f0->shared->efc, filename[3], H5F_ACC_RDWR | H5F_ACC_CREAT | H5F_ACC_TRUNC, fcpl_id, fapl_id)))
+    if (NULL == (f3 = H5F__efc_open(f0->shared->efc, filename[3],
+                                    H5F_ACC_RDWR | H5F_ACC_CREAT | H5F_ACC_TRUNC, fcpl_id, fapl_id)))
         FAIL_STACK_ERROR;
 
     if (NULL == (ftmp0 = H5F__efc_open(f1->shared->efc, filename[0], H5F_ACC_RDWR, fcpl_id, fapl_id)))
@@ -2289,8 +2289,8 @@ test_graph_cycle(void)
     /* Test 25: File held open by EFC client interrupts cycle, with release */
     if (NULL == (f0 = H5F_open(filename[0], H5F_ACC_RDWR | H5F_ACC_CREAT | H5F_ACC_TRUNC, fcpl_id, fapl_id)))
         FAIL_STACK_ERROR;
-    if (NULL ==
-        (f1 = H5F__efc_open(f0->shared->efc, filename[1], H5F_ACC_RDWR | H5F_ACC_CREAT | H5F_ACC_TRUNC, fcpl_id, fapl_id)))
+    if (NULL == (f1 = H5F__efc_open(f0->shared->efc, filename[1],
+                                    H5F_ACC_RDWR | H5F_ACC_CREAT | H5F_ACC_TRUNC, fcpl_id, fapl_id)))
         FAIL_STACK_ERROR;
     if (NULL == (ftmp0 = H5F__efc_open(f1->shared->efc, filename[0], H5F_ACC_RDWR, fcpl_id, fapl_id)))
         FAIL_STACK_ERROR;
@@ -2322,8 +2322,8 @@ test_graph_cycle(void)
     /* Test 26: File held open by EFC does not interrupt cycle, with release */
     if (NULL == (f0 = H5F_open(filename[0], H5F_ACC_RDWR | H5F_ACC_CREAT | H5F_ACC_TRUNC, fcpl_id, fapl_id)))
         FAIL_STACK_ERROR;
-    if (NULL ==
-        (f1 = H5F__efc_open(f0->shared->efc, filename[1], H5F_ACC_RDWR | H5F_ACC_CREAT | H5F_ACC_TRUNC, fcpl_id, fapl_id)))
+    if (NULL == (f1 = H5F__efc_open(f0->shared->efc, filename[1],
+                                    H5F_ACC_RDWR | H5F_ACC_CREAT | H5F_ACC_TRUNC, fcpl_id, fapl_id)))
         FAIL_STACK_ERROR;
     if (NULL == (ftmp0 = H5F__efc_open(f1->shared->efc, filename[0], H5F_ACC_RDWR, fcpl_id, fapl_id)))
         FAIL_STACK_ERROR;
@@ -2331,8 +2331,8 @@ test_graph_cycle(void)
         FAIL_STACK_ERROR;
     if (H5F_efc_close(f0, f1) < 0)
         FAIL_STACK_ERROR;
-    if (NULL ==
-        (f2 = H5F__efc_open(f0->shared->efc, filename[2], H5F_ACC_RDWR | H5F_ACC_CREAT | H5F_ACC_TRUNC, fcpl_id, fapl_id)))
+    if (NULL == (f2 = H5F__efc_open(f0->shared->efc, filename[2],
+                                    H5F_ACC_RDWR | H5F_ACC_CREAT | H5F_ACC_TRUNC, fcpl_id, fapl_id)))
         FAIL_STACK_ERROR;
     if (f0->shared->nrefs != 2)
         TEST_ERROR;
@@ -2356,8 +2356,8 @@ test_graph_cycle(void)
      * interrupt cycle, but parent file does (no valid way around it) */
     if (NULL == (f0 = H5F_open(filename[0], H5F_ACC_RDWR | H5F_ACC_CREAT | H5F_ACC_TRUNC, fcpl_id, fapl_id)))
         FAIL_STACK_ERROR;
-    if (NULL ==
-        (f1 = H5F__efc_open(f0->shared->efc, filename[1], H5F_ACC_RDWR | H5F_ACC_CREAT | H5F_ACC_TRUNC, fcpl_id, fapl_id)))
+    if (NULL == (f1 = H5F__efc_open(f0->shared->efc, filename[1],
+                                    H5F_ACC_RDWR | H5F_ACC_CREAT | H5F_ACC_TRUNC, fcpl_id, fapl_id)))
         FAIL_STACK_ERROR;
     if (NULL == (ftmp0 = H5F__efc_open(f1->shared->efc, filename[0], H5F_ACC_RDWR, fcpl_id, fapl_id)))
         FAIL_STACK_ERROR;
@@ -2369,8 +2369,8 @@ test_graph_cycle(void)
         FAIL_STACK_ERROR;
     if (NULL == (f1 = H5F__efc_open(f2->shared->efc, filename[1], H5F_ACC_RDWR, fcpl_id, fapl_id)))
         FAIL_STACK_ERROR;
-    if (NULL ==
-        (f3 = H5F__efc_open(f1->shared->efc, filename[3], H5F_ACC_RDWR | H5F_ACC_CREAT | H5F_ACC_TRUNC, fcpl_id, fapl_id)))
+    if (NULL == (f3 = H5F__efc_open(f1->shared->efc, filename[3],
+                                    H5F_ACC_RDWR | H5F_ACC_CREAT | H5F_ACC_TRUNC, fcpl_id, fapl_id)))
         FAIL_STACK_ERROR;
     if (f0->shared->nrefs != 2)
         TEST_ERROR;
@@ -2470,8 +2470,8 @@ test_graph_cycle(void)
      * release */
     if (NULL == (f0 = H5F_open(filename[0], H5F_ACC_RDWR | H5F_ACC_CREAT | H5F_ACC_TRUNC, fcpl_id, fapl_id)))
         FAIL_STACK_ERROR;
-    if (NULL ==
-        (f1 = H5F__efc_open(f0->shared->efc, filename[1], H5F_ACC_RDWR | H5F_ACC_CREAT | H5F_ACC_TRUNC, fcpl_id, fapl_id)))
+    if (NULL == (f1 = H5F__efc_open(f0->shared->efc, filename[1],
+                                    H5F_ACC_RDWR | H5F_ACC_CREAT | H5F_ACC_TRUNC, fcpl_id, fapl_id)))
         FAIL_STACK_ERROR;
     if (NULL == (ftmp0 = H5F__efc_open(f1->shared->efc, filename[0], H5F_ACC_RDWR, fcpl_id, fapl_id)))
         FAIL_STACK_ERROR;
@@ -2483,8 +2483,8 @@ test_graph_cycle(void)
         FAIL_STACK_ERROR;
     if (NULL == (f1 = H5F__efc_open(f2->shared->efc, filename[1], H5F_ACC_RDWR, fcpl_id, fapl_id)))
         FAIL_STACK_ERROR;
-    if (NULL ==
-        (f3 = H5F__efc_open(f1->shared->efc, filename[3], H5F_ACC_RDWR | H5F_ACC_CREAT | H5F_ACC_TRUNC, fcpl_id, fapl_id)))
+    if (NULL == (f3 = H5F__efc_open(f1->shared->efc, filename[3],
+                                    H5F_ACC_RDWR | H5F_ACC_CREAT | H5F_ACC_TRUNC, fcpl_id, fapl_id)))
         FAIL_STACK_ERROR;
     if (f0->shared->nrefs != 2)
         TEST_ERROR;
@@ -2550,8 +2550,8 @@ test_graph_cycle(void)
         FAIL_STACK_ERROR;
     if (H5Pset_elink_file_cache_size(fapl_id, 0) < 0)
         TEST_ERROR;
-    if (NULL ==
-        (f1 = H5F__efc_open(f0->shared->efc, filename[1], H5F_ACC_RDWR | H5F_ACC_CREAT | H5F_ACC_TRUNC, fcpl_id, fapl_id)))
+    if (NULL == (f1 = H5F__efc_open(f0->shared->efc, filename[1],
+                                    H5F_ACC_RDWR | H5F_ACC_CREAT | H5F_ACC_TRUNC, fcpl_id, fapl_id)))
         FAIL_STACK_ERROR;
     if (H5Pset_elink_file_cache_size(fapl_id, 8) < 0)
         TEST_ERROR;
@@ -2586,8 +2586,8 @@ test_graph_cycle(void)
     /* Test 30: File without EFC does not interrupt cycle */
     if (NULL == (f0 = H5F_open(filename[0], H5F_ACC_RDWR | H5F_ACC_CREAT | H5F_ACC_TRUNC, fcpl_id, fapl_id)))
         FAIL_STACK_ERROR;
-    if (NULL ==
-        (f1 = H5F__efc_open(f0->shared->efc, filename[1], H5F_ACC_RDWR | H5F_ACC_CREAT | H5F_ACC_TRUNC, fcpl_id, fapl_id)))
+    if (NULL == (f1 = H5F__efc_open(f0->shared->efc, filename[1],
+                                    H5F_ACC_RDWR | H5F_ACC_CREAT | H5F_ACC_TRUNC, fcpl_id, fapl_id)))
         FAIL_STACK_ERROR;
     if (NULL == (ftmp0 = H5F__efc_open(f1->shared->efc, filename[0], H5F_ACC_RDWR, fcpl_id, fapl_id)))
         FAIL_STACK_ERROR;
@@ -2597,8 +2597,8 @@ test_graph_cycle(void)
         FAIL_STACK_ERROR;
     if (H5Pset_elink_file_cache_size(fapl_id, 0) < 0)
         TEST_ERROR;
-    if (NULL ==
-        (f2 = H5F__efc_open(f1->shared->efc, filename[2], H5F_ACC_RDWR | H5F_ACC_CREAT | H5F_ACC_TRUNC, fcpl_id, fapl_id)))
+    if (NULL == (f2 = H5F__efc_open(f1->shared->efc, filename[2],
+                                    H5F_ACC_RDWR | H5F_ACC_CREAT | H5F_ACC_TRUNC, fcpl_id, fapl_id)))
         FAIL_STACK_ERROR;
     if (H5Pset_elink_file_cache_size(fapl_id, 8) < 0)
         TEST_ERROR;


### PR DESCRIPTION
The H5F__efc_open() API call only needs the efc pointer, so there is no need to pass the entire file struct in.