### PR TITLE
ci: generate doxygen gh-pages (#3000)

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,0 +1,72 @@
+name: doxygen gh-pages
+
+on:
+  workflow_dispatch:
+  push:
+  pull_request:
+    branches: [ develop ]
+    paths-ignore:
+      - '.github/CODEOWNERS'
+      - '.github/FUNDING.yml'
+      - 'doc/**'
+      - 'release_docs/**'
+      - 'ACKNOWLEDGEMENTS'
+      - 'COPYING**'
+      - '**.md'
+
+# Using concurrency to cancel any in-progress job or run
+concurrency:
+  group: ${{ github.workflow }}-${{ github.sha || github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  # This workflow contains a single job called "build"
+  build:
+    # The type of runner that the job will run on
+    runs-on: ubuntu-latest
+    steps:
+      - name: Get Sources
+        uses: actions/checkout@v3
+
+      - name: Install Dependencies
+        run: |
+          sudo apt update -y
+          sudo apt install -y libunwind-dev
+          sudo apt-get install -y graphviz
+          sudo apt-get install -y --no-install-recommends doxygen
+          sudo apt-get install -y cmake
+          
+      - name: Build Develop Documentation
+        run: |
+          git clone https://github.com/HDFGroup/hdf5.git
+          cd hdf5
+          mkdir build
+          cd build
+          cmake -DHDF5_BUILD_DOC:BOOL=ON ..
+          make doxygen
+
+      - name: Deploy Develop
+        uses: peaceiris/actions-gh-pages@v3
+        with:
+          publish_dir: ./hdf5/build/hdf5lib_docs/html
+          destination_dir: develop
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+
+
+      - name: Build 1.14.1 Documentation
+        run: |
+          rm -rf ./hdf5
+          git clone https://github.com/HDFGroup/hdf5.git
+          cd hdf5
+          git checkout hdf5-1_14_1-2
+          mkdir build
+          cd build
+          cmake -DHDF5_BUILD_DOC:BOOL=ON ..
+          make doxygen
+
+      - name: Deploy 1.14.1
+        uses: peaceiris/actions-gh-pages@v3
+        with:
+          publish_dir: ./hdf5/build/hdf5lib_docs/html
+          destination_dir: 1.14.1
+          github_token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
This will generate Doxgen documents under:

https://HDFGroup.github.io/hdf5/develop

https://HDFGroup.github.io/hdf5/1.14.1

To see the updated documents, 
the repository owner should give the proper permission and 
activate pages following this guide: 

https://docs.github.com/en/pages/quickstart

Here are the working demo pages:

https://hyoklee.github.io/actions/develop/
https://hyoklee.github.io/actions/1.14.1/

Close #3000.
