### PR TITLE
Convert H5F haddr_t macros to H5

### DIFF
--- a/fortran/test/tH5G_1_8.F90
+++ b/fortran/test/tH5G_1_8.F90
@@ -1220,7 +1220,7 @@ SUBROUTINE lifecycle(cleanup, fapl2, total_error)
 !!$	printf("    %d: Unexpected object type should have been a dataset\n", __LINE__);
 !!$	TEST_ERROR
 !!$    }  end if
-!!$    if(H5F_addr_ne(oinfo1.addr, oinfo2.addr)) {
+!!$    if(H5_addr_ne(oinfo1.addr, oinfo2.addr)) {
 !!$	H5_FAILED();
 !!$	puts("    Hard link test failed. Link seems not to point to the ");
 !!$	puts("    expected file location.");

--- a/src/H5AC.c
+++ b/src/H5AC.c
@@ -584,7 +584,7 @@ H5AC_expunge_entry(H5F_t *f, const H5AC_class_t *type, haddr_t addr, unsigned fl
     HDassert(f->shared->cache);
     HDassert(type);
     HDassert(type->serialize);
-    HDassert(H5F_addr_defined(addr));
+    HDassert(H5_addr_defined(addr));
 
     if (H5C_expunge_entry(f, type, addr, flags) < 0)
         HGOTO_ERROR(H5E_CACHE, H5E_CANTEXPUNGE, FAIL, "H5C_expunge_entry() failed")
@@ -689,7 +689,7 @@ H5AC_get_entry_status(const H5F_t *f, haddr_t addr, unsigned *status)
 
     FUNC_ENTER_NOAPI(FAIL)
 
-    if ((f == NULL) || (!H5F_addr_defined(addr)) || (status == NULL))
+    if ((f == NULL) || (!H5_addr_defined(addr)) || (status == NULL))
         HGOTO_ERROR(H5E_CACHE, H5E_SYSTEM, FAIL, "Bad param(s) on entry")
 
     if (H5C_get_entry_status(f, addr, NULL, &in_cache, &is_dirty, &is_protected, &is_pinned, &is_corked,
@@ -747,7 +747,7 @@ H5AC_insert_entry(H5F_t *f, const H5AC_class_t *type, haddr_t addr, void *thing,
     HDassert(f->shared->cache);
     HDassert(type);
     HDassert(type->serialize);
-    HDassert(H5F_addr_defined(addr));
+    HDassert(H5_addr_defined(addr));
     HDassert(thing);
 
     /* Check for invalid access request */
@@ -1040,9 +1040,9 @@ H5AC_move_entry(H5F_t *f, const H5AC_class_t *type, haddr_t old_addr, haddr_t ne
     HDassert(f);
     HDassert(f->shared->cache);
     HDassert(type);
-    HDassert(H5F_addr_defined(old_addr));
-    HDassert(H5F_addr_defined(new_addr));
-    HDassert(H5F_addr_ne(old_addr, new_addr));
+    HDassert(H5_addr_defined(old_addr));
+    HDassert(H5_addr_defined(new_addr));
+    HDassert(H5_addr_ne(old_addr, new_addr));
 
 #ifdef H5_HAVE_PARALLEL
     /* Log moving the entry */
@@ -1319,7 +1319,7 @@ H5AC_protect(H5F_t *f, const H5AC_class_t *type, haddr_t addr, void *udata, unsi
     HDassert(f->shared->cache);
     HDassert(type);
     HDassert(type->serialize);
-    HDassert(H5F_addr_defined(addr));
+    HDassert(H5_addr_defined(addr));
 
     /* Check for unexpected flags -- H5C__FLUSH_COLLECTIVELY_FLAG
      * only permitted in the parallel case.
@@ -1599,7 +1599,7 @@ H5AC_unprotect(H5F_t *f, const H5AC_class_t *type, haddr_t addr, void *thing, un
     HDassert(type);
     HDassert(type->deserialize);
     HDassert(type->image_len);
-    HDassert(H5F_addr_defined(addr));
+    HDassert(H5_addr_defined(addr));
     HDassert(thing);
     HDassert(((H5AC_info_t *)thing)->addr == addr);
     HDassert(((H5AC_info_t *)thing)->type == type);
@@ -2427,7 +2427,7 @@ H5AC_cork(H5F_t *f, haddr_t obj_addr, unsigned action, hbool_t *corked)
     HDassert(f);
     HDassert(f->shared);
     HDassert(f->shared->cache);
-    HDassert(H5F_addr_defined(obj_addr));
+    HDassert(H5_addr_defined(obj_addr));
     HDassert(action == H5AC__SET_CORK || action == H5AC__UNCORK || action == H5AC__GET_CORKED);
 
     /*  Skip the search on "tag_list" when there are no "corked" objects.
@@ -2510,7 +2510,7 @@ H5AC_get_entry_ring(const H5F_t *f, haddr_t addr, H5AC_ring_t *ring)
 
     /* Sanity check */
     HDassert(f);
-    HDassert(H5F_addr_defined(addr));
+    HDassert(H5_addr_defined(addr));
     HDassert(ring);
 
     /* Retrieve the ring value for the entry at address */

--- a/src/H5ACproxy_entry.c
+++ b/src/H5ACproxy_entry.c
@@ -166,7 +166,7 @@ H5AC_proxy_entry_add_parent(H5AC_proxy_entry_t *pentry, void *_parent)
     /* Add flush dependency on parent */
     if (pentry->nchildren > 0) {
         /* Sanity check */
-        HDassert(H5F_addr_defined(pentry->addr));
+        HDassert(H5_addr_defined(pentry->addr));
 
         if (H5AC_create_flush_dependency(parent, pentry) < 0)
             HGOTO_ERROR(H5E_CACHE, H5E_CANTDEPEND, FAIL, "unable to set flush dependency on proxy entry")
@@ -205,7 +205,7 @@ H5AC_proxy_entry_remove_parent(H5AC_proxy_entry_t *pentry, void *_parent)
     /* Remove parent from skip list */
     if (NULL == (rem_parent = (H5AC_info_t *)H5SL_remove(pentry->parents, &parent->addr)))
         HGOTO_ERROR(H5E_CACHE, H5E_CANTREMOVE, FAIL, "unable to remove proxy entry parent from skip list")
-    if (!H5F_addr_eq(rem_parent->addr, parent->addr))
+    if (!H5_addr_eq(rem_parent->addr, parent->addr))
         HGOTO_ERROR(H5E_CACHE, H5E_BADVALUE, FAIL, "removed proxy entry parent not the same as real parent")
 
     /* Shut down the skip list, if this is the last parent */
@@ -285,7 +285,7 @@ H5AC_proxy_entry_add_child(H5AC_proxy_entry_t *pentry, H5F_t *f, void *child)
     /* Check for first child */
     if (0 == pentry->nchildren) {
         /* Get an address, if the proxy doesn't already have one */
-        if (!H5F_addr_defined(pentry->addr))
+        if (!H5_addr_defined(pentry->addr))
             if (HADDR_UNDEF == (pentry->addr = H5MF_alloc_tmp(f, 1)))
                 HGOTO_ERROR(H5E_CACHE, H5E_CANTALLOC, FAIL,
                             "temporary file space allocation failed for proxy entry")

--- a/src/H5Adense.c
+++ b/src/H5Adense.c
@@ -364,7 +364,7 @@ H5A__dense_open(H5F_t *f, const H5O_ainfo_t *ainfo, const char *name)
             HGOTO_ERROR(H5E_ATTR, H5E_CANTGET, NULL, "can't get shared message heap address")
 
         /* Check if there are any shared messages currently */
-        if (H5F_addr_defined(shared_fheap_addr)) {
+        if (H5_addr_defined(shared_fheap_addr)) {
             /* Open the fractal heap for shared header messages */
             if (NULL == (shared_fheap = H5HF_open(f, shared_fheap_addr)))
                 HGOTO_ERROR(H5E_ATTR, H5E_CANTOPENOBJ, NULL, "unable to open fractal heap")
@@ -467,7 +467,7 @@ H5A__dense_insert(H5F_t *f, const H5O_ainfo_t *ainfo, H5A_t *attr)
             HGOTO_ERROR(H5E_ATTR, H5E_CANTGET, FAIL, "can't get shared message heap address")
 
         /* Check if there are any shared messages currently */
-        if (H5F_addr_defined(shared_fheap_addr)) {
+        if (H5_addr_defined(shared_fheap_addr)) {
             /* Open the fractal heap for shared header messages */
             if (NULL == (shared_fheap = H5HF_open(f, shared_fheap_addr)))
                 HGOTO_ERROR(H5E_ATTR, H5E_CANTOPENOBJ, FAIL, "unable to open fractal heap")
@@ -535,7 +535,7 @@ H5A__dense_insert(H5F_t *f, const H5O_ainfo_t *ainfo, H5A_t *attr)
     /* Check if we should create a creation order index v2 B-tree record */
     if (ainfo->index_corder) {
         /* Open the creation order index v2 B-tree */
-        HDassert(H5F_addr_defined(ainfo->corder_bt2_addr));
+        HDassert(H5_addr_defined(ainfo->corder_bt2_addr));
         if (NULL == (bt2_corder = H5B2_open(f, ainfo->corder_bt2_addr, NULL)))
             HGOTO_ERROR(H5E_ATTR, H5E_CANTOPENOBJ, FAIL, "unable to open v2 B-tree for creation order index")
 
@@ -632,7 +632,7 @@ H5A__dense_write_bt2_cb(void *_record, void *_op_data, hbool_t *changed)
         record->id = op_data->attr->sh_loc.u.heap_id;
 
         /* Check if we need to modify the creation order index with new heap ID */
-        if (H5F_addr_defined(op_data->corder_bt2_addr)) {
+        if (H5_addr_defined(op_data->corder_bt2_addr)) {
             H5A_bt2_ud_common_t udata; /* User data for v2 B-tree modify */
 
             /* Open the creation order index v2 B-tree */
@@ -734,8 +734,8 @@ H5A__dense_write(H5F_t *f, const H5O_ainfo_t *ainfo, H5A_t *attr)
     /* Check arguments */
     HDassert(f);
     HDassert(ainfo);
-    HDassert(H5F_addr_defined(ainfo->fheap_addr));
-    HDassert(H5F_addr_defined(ainfo->name_bt2_addr));
+    HDassert(H5_addr_defined(ainfo->fheap_addr));
+    HDassert(H5_addr_defined(ainfo->name_bt2_addr));
     HDassert(attr);
 
     /* Check if attributes are shared in this file */
@@ -751,7 +751,7 @@ H5A__dense_write(H5F_t *f, const H5O_ainfo_t *ainfo, H5A_t *attr)
             HGOTO_ERROR(H5E_ATTR, H5E_CANTGET, FAIL, "can't get shared message heap address")
 
         /* Check if there are any shared messages currently */
-        if (H5F_addr_defined(shared_fheap_addr)) {
+        if (H5_addr_defined(shared_fheap_addr)) {
             /* Open the fractal heap for shared header messages */
             if (NULL == (shared_fheap = H5HF_open(f, shared_fheap_addr)))
                 HGOTO_ERROR(H5E_ATTR, H5E_CANTOPENOBJ, FAIL, "unable to open fractal heap")
@@ -890,7 +890,7 @@ H5A__dense_rename(H5F_t *f, const H5O_ainfo_t *ainfo, const char *old_name, cons
             HGOTO_ERROR(H5E_ATTR, H5E_CANTGET, FAIL, "can't get shared message heap address")
 
         /* Check if there are any shared messages currently */
-        if (H5F_addr_defined(shared_fheap_addr)) {
+        if (H5_addr_defined(shared_fheap_addr)) {
             /* Open the fractal heap for shared header messages */
             if (NULL == (shared_fheap = H5HF_open(f, shared_fheap_addr)))
                 HGOTO_ERROR(H5E_ATTR, H5E_CANTOPENOBJ, FAIL, "unable to open fractal heap")
@@ -946,7 +946,7 @@ H5A__dense_rename(H5F_t *f, const H5O_ainfo_t *ainfo, const char *old_name, cons
         hbool_t corder_attr_exists; /* Attribute exists in v2 B-tree */
 
         /* Open the creation order index v2 B-tree */
-        HDassert(H5F_addr_defined(ainfo->corder_bt2_addr));
+        HDassert(H5_addr_defined(ainfo->corder_bt2_addr));
         if (NULL == (bt2_corder = H5B2_open(f, ainfo->corder_bt2_addr, NULL)))
             HGOTO_ERROR(H5E_ATTR, H5E_CANTOPENOBJ, FAIL, "unable to open v2 B-tree for creation index")
 
@@ -1150,8 +1150,8 @@ H5A__dense_iterate(H5F_t *f, hid_t loc_id, const H5O_ainfo_t *ainfo, H5_index_t 
     /* Check arguments */
     HDassert(f);
     HDassert(ainfo);
-    HDassert(H5F_addr_defined(ainfo->fheap_addr));
-    HDassert(H5F_addr_defined(ainfo->name_bt2_addr));
+    HDassert(H5_addr_defined(ainfo->fheap_addr));
+    HDassert(H5_addr_defined(ainfo->name_bt2_addr));
     HDassert(attr_op);
 
     /* Determine the address of the index to use */
@@ -1161,7 +1161,7 @@ H5A__dense_iterate(H5F_t *f, hid_t loc_id, const H5O_ainfo_t *ainfo, H5_index_t 
          *      table and sorting it.
          */
         if (order == H5_ITER_NATIVE) {
-            HDassert(H5F_addr_defined(ainfo->name_bt2_addr));
+            HDassert(H5_addr_defined(ainfo->name_bt2_addr));
             bt2_addr = ainfo->name_bt2_addr;
         } /* end if */
         else
@@ -1178,7 +1178,7 @@ H5A__dense_iterate(H5F_t *f, hid_t loc_id, const H5O_ainfo_t *ainfo, H5_index_t 
     } /* end else */
 
     /* Check on iteration order */
-    if (order == H5_ITER_NATIVE && H5F_addr_defined(bt2_addr)) {
+    if (order == H5_ITER_NATIVE && H5_addr_defined(bt2_addr)) {
         H5A_bt2_ud_it_t udata;         /* User data for iterator callback */
         htri_t          attr_sharable; /* Flag indicating attributes are shareable */
 
@@ -1199,7 +1199,7 @@ H5A__dense_iterate(H5F_t *f, hid_t loc_id, const H5O_ainfo_t *ainfo, H5_index_t 
                 HGOTO_ERROR(H5E_ATTR, H5E_CANTGET, FAIL, "can't get shared message heap address")
 
             /* Check if there are any shared messages currently */
-            if (H5F_addr_defined(shared_fheap_addr)) {
+            if (H5_addr_defined(shared_fheap_addr)) {
                 /* Open the fractal heap for shared header messages */
                 if (NULL == (shared_fheap = H5HF_open(f, shared_fheap_addr)))
                     HGOTO_ERROR(H5E_ATTR, H5E_CANTOPENOBJ, FAIL, "unable to open fractal heap")
@@ -1278,7 +1278,7 @@ H5A__dense_remove_bt2_cb(const void *_record, void *_udata)
     FUNC_ENTER_PACKAGE
 
     /* Check for removing the link from the creation order index */
-    if (H5F_addr_defined(udata->corder_bt2_addr)) {
+    if (H5_addr_defined(udata->corder_bt2_addr)) {
         /* Open the creation order index v2 B-tree */
         if (NULL == (bt2_corder = H5B2_open(udata->common.f, udata->corder_bt2_addr, NULL)))
             HGOTO_ERROR(H5E_ATTR, H5E_CANTOPENOBJ, FAIL, "unable to open v2 B-tree for creation order index")
@@ -1364,7 +1364,7 @@ H5A__dense_remove(H5F_t *f, const H5O_ainfo_t *ainfo, const char *name)
             HGOTO_ERROR(H5E_ATTR, H5E_CANTGET, FAIL, "can't get shared message heap address")
 
         /* Check if there are any shared messages currently */
-        if (H5F_addr_defined(shared_fheap_addr)) {
+        if (H5_addr_defined(shared_fheap_addr)) {
             /* Open the fractal heap for shared header messages */
             if (NULL == (shared_fheap = H5HF_open(f, shared_fheap_addr)))
                 HGOTO_ERROR(H5E_ATTR, H5E_CANTOPENOBJ, FAIL, "unable to open fractal heap")
@@ -1441,7 +1441,7 @@ H5A__dense_remove_by_idx_bt2_cb(const void *_record, void *_bt2_udata)
         fheap = bt2_udata->fheap;
 
     /* Check whether to make a copy of the attribute or just need the shared location info */
-    if (H5F_addr_defined(bt2_udata->other_bt2_addr) || !(record->flags & H5O_MSG_FLAG_SHARED)) {
+    if (H5_addr_defined(bt2_udata->other_bt2_addr) || !(record->flags & H5O_MSG_FLAG_SHARED)) {
         /* Call fractal heap 'op' routine, to make copy of attribute to remove */
         if (H5HF_op(fheap, &record->id, H5A__dense_copy_fh_cb, &fh_udata) < 0)
             HGOTO_ERROR(H5E_ATTR, H5E_CANTOPERATE, FAIL, "attribute removal callback failed")
@@ -1459,7 +1459,7 @@ H5A__dense_remove_by_idx_bt2_cb(const void *_record, void *_bt2_udata)
     } /* end else */
 
     /* Check for removing the link from the "other" index (creation order, when name used and vice versa) */
-    if (H5F_addr_defined(bt2_udata->other_bt2_addr)) {
+    if (H5_addr_defined(bt2_udata->other_bt2_addr)) {
         H5A_bt2_ud_common_t other_bt2_udata; /* Info for B-tree callbacks */
 
         /* Determine the index being used */
@@ -1566,7 +1566,7 @@ H5A__dense_remove_by_idx(H5F_t *f, const H5O_ainfo_t *ainfo, H5_index_t idx_type
          */
         if (order == H5_ITER_NATIVE) {
             bt2_addr = ainfo->name_bt2_addr;
-            HDassert(H5F_addr_defined(bt2_addr));
+            HDassert(H5_addr_defined(bt2_addr));
         } /* end if */
         else
             bt2_addr = HADDR_UNDEF;
@@ -1582,7 +1582,7 @@ H5A__dense_remove_by_idx(H5F_t *f, const H5O_ainfo_t *ainfo, H5_index_t idx_type
     } /* end else */
 
     /* If there is an index defined for the field, use it */
-    if (H5F_addr_defined(bt2_addr)) {
+    if (H5_addr_defined(bt2_addr)) {
         H5A_bt2_ud_rmbi_t udata;         /* User data for v2 B-tree record removal */
         htri_t            attr_sharable; /* Flag indicating attributes are shareable */
 
@@ -1603,7 +1603,7 @@ H5A__dense_remove_by_idx(H5F_t *f, const H5O_ainfo_t *ainfo, H5_index_t idx_type
                 HGOTO_ERROR(H5E_ATTR, H5E_CANTGET, FAIL, "can't get shared message heap address")
 
             /* Check if there are any shared messages currently */
-            if (H5F_addr_defined(shared_fheap_addr)) {
+            if (H5_addr_defined(shared_fheap_addr)) {
                 /* Open the fractal heap for shared header messages */
                 if (NULL == (shared_fheap = H5HF_open(f, shared_fheap_addr)))
                     HGOTO_ERROR(H5E_ATTR, H5E_CANTOPENOBJ, FAIL, "unable to open fractal heap")
@@ -1702,7 +1702,7 @@ H5A__dense_exists(H5F_t *f, const H5O_ainfo_t *ainfo, const char *name, hbool_t 
             HGOTO_ERROR(H5E_ATTR, H5E_CANTGET, FAIL, "can't get shared message heap address")
 
         /* Check if there are any shared messages currently */
-        if (H5F_addr_defined(shared_fheap_addr)) {
+        if (H5_addr_defined(shared_fheap_addr)) {
             /* Open the fractal heap for shared header messages */
             if (NULL == (shared_fheap = H5HF_open(f, shared_fheap_addr)))
                 HGOTO_ERROR(H5E_ATTR, H5E_CANTOPENOBJ, FAIL, "unable to open fractal heap")
@@ -1853,7 +1853,7 @@ H5A__dense_delete(H5F_t *f, H5O_ainfo_t *ainfo)
     fheap = NULL;
 
     /* Check if we should delete the creation order index v2 B-tree */
-    if (H5F_addr_defined(ainfo->corder_bt2_addr)) {
+    if (H5_addr_defined(ainfo->corder_bt2_addr)) {
         /* Delete the creation order index, without adjusting the ref. count on the attributes  */
         if (H5B2_delete(f, ainfo->corder_bt2_addr, NULL, NULL, NULL) < 0)
             HGOTO_ERROR(H5E_ATTR, H5E_CANTDELETE, FAIL, "unable to delete v2 B-tree for creation order index")

--- a/src/H5Aint.c
+++ b/src/H5Aint.c
@@ -1688,8 +1688,8 @@ H5A__dense_build_table(H5F_t *f, const H5O_ainfo_t *ainfo, H5_index_t idx_type, 
     /* Sanity check */
     HDassert(f);
     HDassert(ainfo);
-    HDassert(H5F_addr_defined(ainfo->fheap_addr));
-    HDassert(H5F_addr_defined(ainfo->name_bt2_addr));
+    HDassert(H5_addr_defined(ainfo->fheap_addr));
+    HDassert(H5_addr_defined(ainfo->name_bt2_addr));
     HDassert(atable);
 
     /* Open the name index v2 B-tree */
@@ -2060,7 +2060,7 @@ H5A__get_ainfo(H5F_t *f, H5O_t *oh, H5O_ainfo_t *ainfo)
         /* Check if we don't know how many attributes there are */
         if (ainfo->nattrs == HSIZET_MAX) {
             /* Check if we are using "dense" attribute storage */
-            if (H5F_addr_defined(ainfo->fheap_addr)) {
+            if (H5_addr_defined(ainfo->fheap_addr)) {
                 /* Open the name index v2 B-tree */
                 if (NULL == (bt2_name = H5B2_open(f, ainfo->name_bt2_addr, NULL)))
                     HGOTO_ERROR(H5E_ATTR, H5E_CANTOPENOBJ, FAIL, "unable to open v2 B-tree for name index")

--- a/src/H5B.c
+++ b/src/H5B.c
@@ -303,7 +303,7 @@ H5B_find(H5F_t *f, const H5B_class_t *type, haddr_t addr, hbool_t *found, void *
     HDassert(type->decode);
     HDassert(type->cmp3);
     HDassert(type->found);
-    HDassert(H5F_addr_defined(addr));
+    HDassert(H5_addr_defined(addr));
 
     /* Get shared info for B-tree */
     if (NULL == (rc_shared = (type->get_shared)(f, udata)))
@@ -395,7 +395,7 @@ H5B__split(H5F_t *f, H5B_ins_ud_t *bt_ud, unsigned idx, void *udata, H5B_ins_ud_
     HDassert(f);
     HDassert(bt_ud);
     HDassert(bt_ud->bt);
-    HDassert(H5F_addr_defined(bt_ud->addr));
+    HDassert(H5_addr_defined(bt_ud->addr));
     HDassert(split_bt_ud);
     HDassert(!split_bt_ud->bt);
 
@@ -414,11 +414,11 @@ H5B__split(H5F_t *f, H5B_ins_ud_t *bt_ud, unsigned idx, void *udata, H5B_ins_ud_
     if (H5DEBUG(B)) {
         const char *side;
 
-        if (!H5F_addr_defined(bt_ud->bt->left) && !H5F_addr_defined(bt_ud->bt->right))
+        if (!H5_addr_defined(bt_ud->bt->left) && !H5_addr_defined(bt_ud->bt->right))
             side = "ONLY";
-        else if (!H5F_addr_defined(bt_ud->bt->right))
+        else if (!H5_addr_defined(bt_ud->bt->right))
             side = "RIGHT";
-        else if (!H5F_addr_defined(bt_ud->bt->left))
+        else if (!H5_addr_defined(bt_ud->bt->left))
             side = "LEFT";
         else
             side = "MIDDLE";
@@ -431,9 +431,9 @@ H5B__split(H5F_t *f, H5B_ins_ud_t *bt_ud, unsigned idx, void *udata, H5B_ins_ud_
      * Decide how to split the children of the old node among the old node
      * and the new node.
      */
-    if (!H5F_addr_defined(bt_ud->bt->right))
+    if (!H5_addr_defined(bt_ud->bt->right))
         nleft = (unsigned)((double)shared->two_k * split_ratios[2]); /*right*/
-    else if (!H5F_addr_defined(bt_ud->bt->left))
+    else if (!H5_addr_defined(bt_ud->bt->left))
         nleft = (unsigned)((double)shared->two_k * split_ratios[0]); /*left*/
     else
         nleft = (unsigned)((double)shared->two_k * split_ratios[1]); /*middle*/
@@ -489,7 +489,7 @@ H5B__split(H5F_t *f, H5B_ins_ud_t *bt_ud, unsigned idx, void *udata, H5B_ins_ud_
     split_bt_ud->bt->left  = bt_ud->addr;
     split_bt_ud->bt->right = bt_ud->bt->right;
 
-    if (H5F_addr_defined(bt_ud->bt->right)) {
+    if (H5_addr_defined(bt_ud->bt->right)) {
         H5B_t *tmp_bt;
 
         if (NULL ==
@@ -559,7 +559,7 @@ H5B_insert(H5F_t *f, const H5B_class_t *type, haddr_t addr, void *udata)
     HDassert(f);
     HDassert(type);
     HDassert(type->sizeof_nkey <= sizeof _lt_key);
-    HDassert(H5F_addr_defined(addr));
+    HDassert(H5_addr_defined(addr));
 
     /* Get shared info for B-tree */
     if (NULL == (rc_shared = (type->get_shared)(f, udata)))
@@ -588,7 +588,7 @@ H5B_insert(H5F_t *f, const H5B_class_t *type, haddr_t addr, void *udata)
     } /* end if */
     HDassert(H5B_INS_RIGHT == my_ins);
     HDassert(split_bt_ud.bt);
-    HDassert(H5F_addr_defined(split_bt_ud.addr));
+    HDassert(H5_addr_defined(split_bt_ud.addr));
 
     /* Get level of old root */
     level = bt_ud.bt->level;
@@ -696,7 +696,7 @@ H5B__insert_child(H5B_t *bt, unsigned *bt_flags, unsigned idx, haddr_t child, H5
 
     HDassert(bt);
     HDassert(bt_flags);
-    HDassert(H5F_addr_defined(child));
+    HDassert(H5_addr_defined(child));
     shared = (H5B_shared_t *)H5UC_GET_OBJ(bt->rc_shared);
     HDassert(shared);
     HDassert(bt->nchildren < shared->two_k);
@@ -794,7 +794,7 @@ H5B__insert_helper(H5F_t *f, H5B_ins_ud_t *bt_ud, const H5B_class_t *type, uint8
     HDassert(f);
     HDassert(bt_ud);
     HDassert(bt_ud->bt);
-    HDassert(H5F_addr_defined(bt_ud->addr));
+    HDassert(H5_addr_defined(bt_ud->addr));
     HDassert(type);
     HDassert(type->decode);
     HDassert(type->cmp3);
@@ -805,7 +805,7 @@ H5B__insert_helper(H5F_t *f, H5B_ins_ud_t *bt_ud, const H5B_class_t *type, uint8
     HDassert(rt_key_changed);
     HDassert(split_bt_ud);
     HDassert(!split_bt_ud->bt);
-    HDassert(!H5F_addr_defined(split_bt_ud->addr));
+    HDassert(!H5_addr_defined(split_bt_ud->addr));
     HDassert(split_bt_ud->cache_flags == H5AC__NO_FLAGS_SET);
 
     bt = bt_ud->bt;
@@ -905,7 +905,7 @@ H5B__insert_helper(H5F_t *f, H5B_ins_ud_t *bt_ud, const H5B_class_t *type, uint8
 #ifdef H5_STRICT_FORMAT_CHECKS
         /* Since we are to the left of the leftmost key there must not be a left
          * sibling */
-        if (H5F_addr_defined(bt->left))
+        if (H5_addr_defined(bt->left))
             HGOTO_ERROR(H5E_BTREE, H5E_CANTINSERT, H5B_INS_ERROR, "internal error: likely corrupt key values")
 #endif /* H5_STRICT_FORMAT_CHECKS */
     }
@@ -956,7 +956,7 @@ H5B__insert_helper(H5F_t *f, H5B_ins_ud_t *bt_ud, const H5B_class_t *type, uint8
 #ifdef H5_STRICT_FORMAT_CHECKS
         /* Since we are to the right of the rightmost key there must not be a
          * right sibling */
-        if (H5F_addr_defined(bt->right))
+        if (H5_addr_defined(bt->right))
             HGOTO_ERROR(H5E_BTREE, H5E_CANTINSERT, H5B_INS_ERROR, "internal error: likely corrupt key values")
 #endif /* H5_STRICT_FORMAT_CHECKS */
     }
@@ -1126,7 +1126,7 @@ H5B__iterate_helper(H5F_t *f, const H5B_class_t *type, haddr_t addr, H5B_operato
      */
     HDassert(f);
     HDassert(type);
-    HDassert(H5F_addr_defined(addr));
+    HDassert(H5_addr_defined(addr));
     HDassert(op);
     HDassert(udata);
 
@@ -1185,7 +1185,7 @@ H5B_iterate(H5F_t *f, const H5B_class_t *type, haddr_t addr, H5B_operator_t op, 
      */
     HDassert(f);
     HDassert(type);
-    HDassert(H5F_addr_defined(addr));
+    HDassert(H5_addr_defined(addr));
     HDassert(op);
     HDassert(udata);
 
@@ -1237,7 +1237,7 @@ H5B__remove_helper(H5F_t *f, haddr_t addr, const H5B_class_t *type, int level, u
     FUNC_ENTER_PACKAGE
 
     HDassert(f);
-    HDassert(H5F_addr_defined(addr));
+    HDassert(H5_addr_defined(addr));
     HDassert(type);
     HDassert(type->decode);
     HDassert(type->cmp3);
@@ -1358,7 +1358,7 @@ H5B__remove_helper(H5F_t *f, haddr_t addr, const H5B_class_t *type, int level, u
                  * between siblings.  Overwrite the key that that is not
                  * "critical" for any child in its node to maintain this
                  * consistency (and avoid breaking key/child consistency) */
-                if (H5F_addr_defined(bt->left)) {
+                if (H5_addr_defined(bt->left)) {
                     if (NULL == (sibling = (H5B_t *)H5AC_protect(f, H5AC_BT, bt->left, &cache_udata,
                                                                  H5AC__NO_FLAGS_SET)))
                         HGOTO_ERROR(H5E_BTREE, H5E_CANTPROTECT, H5B_INS_ERROR,
@@ -1378,7 +1378,7 @@ H5B__remove_helper(H5F_t *f, haddr_t addr, const H5B_class_t *type, int level, u
                                     "unable to release node from tree")
                     sibling = NULL; /* Make certain future references will be caught */
                 }                   /* end if */
-                if (H5F_addr_defined(bt->right)) {
+                if (H5_addr_defined(bt->right)) {
                     if (NULL == (sibling = (H5B_t *)H5AC_protect(f, H5AC_BT, bt->right, &cache_udata,
                                                                  H5AC__NO_FLAGS_SET)))
                         HGOTO_ERROR(H5E_BTREE, H5E_CANTPROTECT, H5B_INS_ERROR,
@@ -1495,7 +1495,7 @@ H5B__remove_helper(H5F_t *f, haddr_t addr, const H5B_class_t *type, int level, u
         ret_value = H5B_INS_NOOP;
 
     /* Patch keys in neighboring trees if necessary */
-    if (*lt_key_changed && H5F_addr_defined(bt->left)) {
+    if (*lt_key_changed && H5_addr_defined(bt->left)) {
         HDassert(type->critical_key == H5B_LEFT);
         HDassert(level > 0);
 
@@ -1510,7 +1510,7 @@ H5B__remove_helper(H5F_t *f, haddr_t addr, const H5B_class_t *type, int level, u
             HGOTO_ERROR(H5E_BTREE, H5E_CANTUNPROTECT, H5B_INS_ERROR, "unable to release node from tree")
         sibling = NULL; /* Make certain future references will be caught */
     }                   /* end if */
-    else if (*rt_key_changed && H5F_addr_defined(bt->right)) {
+    else if (*rt_key_changed && H5_addr_defined(bt->right)) {
         HDassert(type->critical_key == H5B_RIGHT);
         HDassert(level > 0);
 
@@ -1566,7 +1566,7 @@ H5B_remove(H5F_t *f, const H5B_class_t *type, haddr_t addr, void *udata)
     HDassert(f);
     HDassert(type);
     HDassert(type->sizeof_nkey <= sizeof _lt_key);
-    HDassert(H5F_addr_defined(addr));
+    HDassert(H5_addr_defined(addr));
 
     /* The actual removal */
     if (H5B_INS_ERROR ==
@@ -1608,7 +1608,7 @@ H5B_delete(H5F_t *f, const H5B_class_t *type, haddr_t addr, void *udata)
     /* Check args */
     HDassert(f);
     HDassert(type);
-    HDassert(H5F_addr_defined(addr));
+    HDassert(H5_addr_defined(addr));
 
     /* Get shared info for B-tree */
     if (NULL == (rc_shared = (type->get_shared)(f, udata)))
@@ -1854,7 +1854,7 @@ H5B__get_info_helper(H5F_t *f, const H5B_class_t *type, haddr_t addr, const H5B_
      */
     HDassert(f);
     HDassert(type);
-    HDassert(H5F_addr_defined(addr));
+    HDassert(H5_addr_defined(addr));
     HDassert(info_udata);
     HDassert(info_udata->bt_info);
     HDassert(info_udata->udata);
@@ -1893,7 +1893,7 @@ H5B__get_info_helper(H5F_t *f, const H5B_class_t *type, haddr_t addr, const H5B_
      * Follow the right-sibling pointer from node to node until we've
      *      processed all nodes.
      */
-    while (H5F_addr_defined(next_addr)) {
+    while (H5_addr_defined(next_addr)) {
         /* Protect the next node to the right */
         addr = next_addr;
         if (NULL == (bt = (H5B_t *)H5AC_protect(f, H5AC_BT, addr, &cache_udata, H5AC__READ_ONLY_FLAG)))
@@ -1953,7 +1953,7 @@ H5B_get_info(H5F_t *f, const H5B_class_t *type, haddr_t addr, H5B_info_t *bt_inf
     HDassert(f);
     HDassert(type);
     HDassert(bt_info);
-    HDassert(H5F_addr_defined(addr));
+    HDassert(H5_addr_defined(addr));
     HDassert(udata);
 
     /* Portably initialize B-tree info struct */
@@ -2005,7 +2005,7 @@ H5B_valid(H5F_t *f, const H5B_class_t *type, haddr_t addr)
     HDassert(f);
     HDassert(type);
 
-    if (!H5F_addr_defined(addr))
+    if (!H5_addr_defined(addr))
         HGOTO_ERROR(H5E_BTREE, H5E_BADVALUE, FAIL, "address is undefined")
 
     /* Get shared info for B-tree */

--- a/src/H5B2.c
+++ b/src/H5B2.c
@@ -201,7 +201,7 @@ H5B2_open(H5F_t *f, haddr_t addr, void *ctx_udata)
 
     /* Check arguments. */
     HDassert(f);
-    HDassert(H5F_addr_defined(addr));
+    HDassert(H5_addr_defined(addr));
 
     /* Look up the B-tree header */
     if (NULL == (hdr = H5B2__hdr_protect(f, addr, ctx_udata, H5AC__READ_ONLY_FLAG)))
@@ -315,7 +315,7 @@ H5B2_update(H5B2_t *bt2, void *udata, H5B2_modify_t op, void *op_data)
     hdr = bt2->hdr;
 
     /* Check if the root node is allocated yet */
-    if (!H5F_addr_defined(hdr->root.addr)) {
+    if (!H5_addr_defined(hdr->root.addr)) {
         /* Create root node as leaf node in B-tree */
         if (H5B2__create_leaf(hdr, hdr, &(hdr->root)) < 0)
             HGOTO_ERROR(H5E_BTREE, H5E_CANTINIT, FAIL, "unable to create root node")
@@ -1117,7 +1117,7 @@ H5B2_neighbor(H5B2_t *bt2, H5B2_compare_t range, void *udata, H5B2_found_t op, v
     hdr = bt2->hdr;
 
     /* Check for empty tree */
-    if (!H5F_addr_defined(hdr->root.addr))
+    if (!H5_addr_defined(hdr->root.addr))
         HGOTO_ERROR(H5E_BTREE, H5E_NOTFOUND, FAIL, "B-tree has no records")
 
     /* Attempt to find neighbor record in B-tree */
@@ -1428,7 +1428,7 @@ H5B2_close(H5B2_t *bt2)
         H5B2_hdr_t *hdr; /* Another pointer to v2 B-tree header */
 
         /* Sanity check */
-        HDassert(H5F_addr_defined(bt2_addr));
+        HDassert(H5_addr_defined(bt2_addr));
 
 #ifndef NDEBUG
         {
@@ -1516,7 +1516,7 @@ H5B2_delete(H5F_t *f, haddr_t addr, void *ctx_udata, H5B2_remove_t op, void *op_
 
     /* Check arguments. */
     HDassert(f);
-    HDassert(H5F_addr_defined(addr));
+    HDassert(H5_addr_defined(addr));
 
     /* Lock the v2 B-tree header into memory */
     if (NULL == (hdr = H5B2__hdr_protect(f, addr, ctx_udata, H5AC__NO_FLAGS_SET)))

--- a/src/H5B2dbg.c
+++ b/src/H5B2dbg.c
@@ -90,8 +90,8 @@ H5B2__hdr_debug(H5F_t *f, haddr_t addr, FILE *stream, int indent, int fwidth,
      * Check arguments.
      */
     HDassert(f);
-    HDassert(H5F_addr_defined(addr));
-    HDassert(H5F_addr_defined(obj_addr));
+    HDassert(H5_addr_defined(addr));
+    HDassert(H5_addr_defined(obj_addr));
     HDassert(stream);
     HDassert(indent >= 0);
     HDassert(fwidth >= 0);
@@ -171,13 +171,13 @@ H5B2__int_debug(H5F_t *f, haddr_t addr, FILE *stream, int indent, int fwidth, co
      * Check arguments.
      */
     HDassert(f);
-    HDassert(H5F_addr_defined(addr));
+    HDassert(H5_addr_defined(addr));
     HDassert(stream);
     HDassert(indent >= 0);
     HDassert(fwidth >= 0);
     HDassert(type);
-    HDassert(H5F_addr_defined(hdr_addr));
-    HDassert(H5F_addr_defined(obj_addr));
+    HDassert(H5_addr_defined(hdr_addr));
+    HDassert(H5_addr_defined(obj_addr));
     HDassert(nrec > 0);
 
     /* Load the B-tree header */
@@ -272,13 +272,13 @@ H5B2__leaf_debug(H5F_t *f, haddr_t addr, FILE *stream, int indent, int fwidth, c
      * Check arguments.
      */
     HDassert(f);
-    HDassert(H5F_addr_defined(addr));
+    HDassert(H5_addr_defined(addr));
     HDassert(stream);
     HDassert(indent >= 0);
     HDassert(fwidth >= 0);
     HDassert(type);
-    HDassert(H5F_addr_defined(hdr_addr));
-    HDassert(H5F_addr_defined(obj_addr));
+    HDassert(H5_addr_defined(hdr_addr));
+    HDassert(H5_addr_defined(obj_addr));
     HDassert(nrec > 0);
 
     /* Load the B-tree header */

--- a/src/H5B2hdr.c
+++ b/src/H5B2hdr.c
@@ -317,7 +317,7 @@ H5B2__hdr_create(H5F_t *f, const H5B2_create_t *cparam, void *ctx_udata)
     ret_value = hdr->addr;
 
 done:
-    if (!H5F_addr_defined(ret_value))
+    if (!H5_addr_defined(ret_value))
         if (hdr) {
             /* Remove from cache, if inserted */
             if (inserted)
@@ -326,7 +326,7 @@ done:
                                 "unable to remove v2 B-tree header from cache")
 
             /* Release header's disk space */
-            if (H5F_addr_defined(hdr->addr) &&
+            if (H5_addr_defined(hdr->addr) &&
                 H5MF_xfree(f, H5FD_MEM_BTREE, hdr->addr, (hsize_t)hdr->hdr_size) < 0)
                 HDONE_ERROR(H5E_BTREE, H5E_CANTFREE, HADDR_UNDEF, "unable to free v2 B-tree header")
 
@@ -513,7 +513,7 @@ H5B2__hdr_protect(H5F_t *f, haddr_t hdr_addr, void *ctx_udata, unsigned flags)
 
     /* Sanity check */
     HDassert(f);
-    HDassert(H5F_addr_defined(hdr_addr));
+    HDassert(H5_addr_defined(hdr_addr));
 
     /* only the H5AC__READ_ONLY_FLAG may appear in flags */
     HDassert((flags & (unsigned)(~H5AC__READ_ONLY_FLAG)) == 0);
@@ -702,7 +702,7 @@ H5B2__hdr_delete(H5B2_hdr_t *hdr)
 #endif /* NDEBUG */
 
     /* Delete all nodes in B-tree */
-    if (H5F_addr_defined(hdr->root.addr))
+    if (H5_addr_defined(hdr->root.addr))
         if (H5B2__delete_node(hdr, hdr->depth, &hdr->root, hdr, hdr->remove_op, hdr->remove_op_data) < 0)
             HGOTO_ERROR(H5E_BTREE, H5E_CANTDELETE, FAIL, "unable to delete B-tree nodes")
 

--- a/src/H5B2int.c
+++ b/src/H5B2int.c
@@ -1569,7 +1569,7 @@ H5B2__insert(H5B2_hdr_t *hdr, void *udata)
     HDassert(udata);
 
     /* Check if the root node is allocated yet */
-    if (!H5F_addr_defined(hdr->root.addr)) {
+    if (!H5_addr_defined(hdr->root.addr)) {
         /* Create root node as leaf node in B-tree */
         if (H5B2__create_leaf(hdr, hdr, &(hdr->root)) < 0)
             HGOTO_ERROR(H5E_BTREE, H5E_CANTINIT, FAIL, "unable to create root node")

--- a/src/H5B2internal.c
+++ b/src/H5B2internal.c
@@ -153,7 +153,7 @@ done:
                                 "unable to remove v2 B-tree internal node from cache")
 
             /* Release internal node's disk space */
-            if (H5F_addr_defined(node_ptr->addr) &&
+            if (H5_addr_defined(node_ptr->addr) &&
                 H5MF_xfree(hdr->f, H5FD_MEM_BTREE, node_ptr->addr, (hsize_t)hdr->node_size) < 0)
                 HDONE_ERROR(H5E_BTREE, H5E_CANTFREE, FAIL,
                             "unable to release file space for v2 B-tree internal node")
@@ -192,7 +192,7 @@ H5B2__protect_internal(H5B2_hdr_t *hdr, void *parent, H5B2_node_ptr_t *node_ptr,
     /* Check arguments. */
     HDassert(hdr);
     HDassert(node_ptr);
-    HDassert(H5F_addr_defined(node_ptr->addr));
+    HDassert(H5_addr_defined(node_ptr->addr));
     HDassert(depth > 0);
 
     /* only H5AC__READ_ONLY_FLAG may appear in flags */
@@ -292,7 +292,7 @@ H5B2__neighbor_internal(H5B2_hdr_t *hdr, uint16_t depth, H5B2_node_ptr_t *curr_n
     HDassert(hdr);
     HDassert(depth > 0);
     HDassert(curr_node_ptr);
-    HDassert(H5F_addr_defined(curr_node_ptr->addr));
+    HDassert(H5_addr_defined(curr_node_ptr->addr));
     HDassert(op);
 
     /* Lock current B-tree node */
@@ -369,7 +369,7 @@ H5B2__insert_internal(H5B2_hdr_t *hdr, uint16_t depth, unsigned *parent_cache_in
     HDassert(hdr);
     HDassert(depth > 0);
     HDassert(curr_node_ptr);
-    HDassert(H5F_addr_defined(curr_node_ptr->addr));
+    HDassert(H5_addr_defined(curr_node_ptr->addr));
 
     /* Lock current B-tree node */
     if (NULL ==
@@ -540,7 +540,7 @@ H5B2__update_internal(H5B2_hdr_t *hdr, uint16_t depth, unsigned *parent_cache_in
     HDassert(hdr);
     HDassert(depth > 0);
     HDassert(curr_node_ptr);
-    HDassert(H5F_addr_defined(curr_node_ptr->addr));
+    HDassert(H5_addr_defined(curr_node_ptr->addr));
 
     /* Lock current B-tree node */
     if (NULL ==
@@ -748,7 +748,7 @@ H5B2__shadow_internal(H5B2_internal_t *internal, H5B2_node_ptr_t *curr_node_ptr)
      */
     HDassert(internal);
     HDassert(curr_node_ptr);
-    HDassert(H5F_addr_defined(curr_node_ptr->addr));
+    HDassert(H5_addr_defined(curr_node_ptr->addr));
     hdr = internal->hdr;
     HDassert(hdr);
     HDassert(hdr->swmr_write);
@@ -823,7 +823,7 @@ H5B2__remove_internal(H5B2_hdr_t *hdr, hbool_t *depth_decreased, void *swap_loc,
     HDassert(depth > 0);
     HDassert(parent_cache_info);
     HDassert(curr_node_ptr);
-    HDassert(H5F_addr_defined(curr_node_ptr->addr));
+    HDassert(H5_addr_defined(curr_node_ptr->addr));
 
     /* Lock current B-tree node */
     if (NULL == (internal = H5B2__protect_internal(hdr, parent_cache_info, curr_node_ptr, depth, FALSE,
@@ -1067,7 +1067,7 @@ H5B2__remove_internal_by_idx(H5B2_hdr_t *hdr, hbool_t *depth_decreased, void *sw
     HDassert(depth > 0);
     HDassert(parent_cache_info);
     HDassert(curr_node_ptr);
-    HDassert(H5F_addr_defined(curr_node_ptr->addr));
+    HDassert(H5_addr_defined(curr_node_ptr->addr));
 
     /* Lock current B-tree node */
     if (NULL == (internal = H5B2__protect_internal(hdr, parent_cache_info, curr_node_ptr, depth, FALSE,
@@ -1402,7 +1402,7 @@ H5B2__assert_internal(hsize_t parent_all_nrec, const H5B2_hdr_t H5_ATTR_NDEBUG_U
     for (u = 0; u < internal->nrec + 1; u++) {
         tot_all_nrec += internal->node_ptrs[u].all_nrec;
 
-        HDassert(H5F_addr_defined(internal->node_ptrs[u].addr));
+        HDassert(H5_addr_defined(internal->node_ptrs[u].addr));
         HDassert(internal->node_ptrs[u].addr > 0);
         for (v = 0; v < u; v++)
             HDassert(internal->node_ptrs[u].addr != internal->node_ptrs[v].addr);
@@ -1442,7 +1442,7 @@ H5B2__assert_internal2(hsize_t parent_all_nrec, const H5B2_hdr_t H5_ATTR_NDEBUG_
     for (u = 0; u < internal->nrec + 1; u++) {
         tot_all_nrec += internal->node_ptrs[u].all_nrec;
 
-        HDassert(H5F_addr_defined(internal->node_ptrs[u].addr));
+        HDassert(H5_addr_defined(internal->node_ptrs[u].addr));
         HDassert(internal->node_ptrs[u].addr > 0);
         for (v = 0; v < u; v++)
             HDassert(internal->node_ptrs[u].addr != internal->node_ptrs[v].addr);

--- a/src/H5B2leaf.c
+++ b/src/H5B2leaf.c
@@ -142,7 +142,7 @@ done:
                                 "unable to remove v2 B-tree leaf node from cache")
 
             /* Release leaf node's disk space */
-            if (H5F_addr_defined(node_ptr->addr) &&
+            if (H5_addr_defined(node_ptr->addr) &&
                 H5MF_xfree(hdr->f, H5FD_MEM_BTREE, node_ptr->addr, (hsize_t)hdr->node_size) < 0)
                 HDONE_ERROR(H5E_BTREE, H5E_CANTFREE, FAIL,
                             "unable to release file space for v2 B-tree leaf node")
@@ -180,7 +180,7 @@ H5B2__protect_leaf(H5B2_hdr_t *hdr, void *parent, H5B2_node_ptr_t *node_ptr, hbo
     /* Check arguments. */
     HDassert(hdr);
     HDassert(node_ptr);
-    HDassert(H5F_addr_defined(node_ptr->addr));
+    HDassert(H5_addr_defined(node_ptr->addr));
 
     /* only H5AC__READ_ONLY_FLAG may appear in flags */
     HDassert((flags & (unsigned)(~H5AC__READ_ONLY_FLAG)) == 0);
@@ -275,7 +275,7 @@ H5B2__neighbor_leaf(H5B2_hdr_t *hdr, H5B2_node_ptr_t *curr_node_ptr, void *neigh
     /* Check arguments. */
     HDassert(hdr);
     HDassert(curr_node_ptr);
-    HDassert(H5F_addr_defined(curr_node_ptr->addr));
+    HDassert(H5_addr_defined(curr_node_ptr->addr));
     HDassert(op);
 
     /* Lock current B-tree node */
@@ -347,7 +347,7 @@ H5B2__insert_leaf(H5B2_hdr_t *hdr, H5B2_node_ptr_t *curr_node_ptr, H5B2_nodepos_
     /* Check arguments. */
     HDassert(hdr);
     HDassert(curr_node_ptr);
-    HDassert(H5F_addr_defined(curr_node_ptr->addr));
+    HDassert(H5_addr_defined(curr_node_ptr->addr));
 
     /* Lock current B-tree node */
     if (NULL == (leaf = H5B2__protect_leaf(hdr, parent, curr_node_ptr, FALSE, H5AC__NO_FLAGS_SET)))
@@ -461,7 +461,7 @@ H5B2__update_leaf(H5B2_hdr_t *hdr, H5B2_node_ptr_t *curr_node_ptr, H5B2_update_s
     /* Check arguments. */
     HDassert(hdr);
     HDassert(curr_node_ptr);
-    HDassert(H5F_addr_defined(curr_node_ptr->addr));
+    HDassert(H5_addr_defined(curr_node_ptr->addr));
 
     /* Lock current B-tree node */
     if (NULL == (leaf = H5B2__protect_leaf(hdr, parent, curr_node_ptr, FALSE, H5AC__NO_FLAGS_SET)))
@@ -708,7 +708,7 @@ H5B2__shadow_leaf(H5B2_leaf_t *leaf, H5B2_node_ptr_t *curr_node_ptr)
      */
     HDassert(leaf);
     HDassert(curr_node_ptr);
-    HDassert(H5F_addr_defined(curr_node_ptr->addr));
+    HDassert(H5_addr_defined(curr_node_ptr->addr));
     hdr = leaf->hdr;
     HDassert(hdr);
     HDassert(hdr->swmr_write);
@@ -775,7 +775,7 @@ H5B2__remove_leaf(H5B2_hdr_t *hdr, H5B2_node_ptr_t *curr_node_ptr, H5B2_nodepos_
     /* Check arguments. */
     HDassert(hdr);
     HDassert(curr_node_ptr);
-    HDassert(H5F_addr_defined(curr_node_ptr->addr));
+    HDassert(H5_addr_defined(curr_node_ptr->addr));
 
     /* Lock current B-tree node */
     if (NULL == (leaf = H5B2__protect_leaf(hdr, parent, curr_node_ptr, FALSE, H5AC__NO_FLAGS_SET)))
@@ -881,7 +881,7 @@ H5B2__remove_leaf_by_idx(H5B2_hdr_t *hdr, H5B2_node_ptr_t *curr_node_ptr, H5B2_n
     /* Check arguments. */
     HDassert(hdr);
     HDassert(curr_node_ptr);
-    HDassert(H5F_addr_defined(curr_node_ptr->addr));
+    HDassert(H5_addr_defined(curr_node_ptr->addr));
 
     /* Lock B-tree leaf node */
     if (NULL == (leaf = H5B2__protect_leaf(hdr, parent, curr_node_ptr, FALSE, H5AC__NO_FLAGS_SET)))

--- a/src/H5Bdbg.c
+++ b/src/H5Bdbg.c
@@ -63,7 +63,7 @@ H5B_debug(H5F_t *f, haddr_t addr, FILE *stream, int indent, int fwidth, const H5
      * Check arguments.
      */
     HDassert(f);
-    HDassert(H5F_addr_defined(addr));
+    HDassert(H5_addr_defined(addr));
     HDassert(stream);
     HDassert(indent >= 0);
     HDassert(fwidth >= 0);
@@ -212,13 +212,13 @@ H5B__assert(H5F_t *f, haddr_t addr, const H5B_class_t *type, void *udata)
         /* Check node header */
         HDassert(bt->level == cur->level);
         if (cur->next && cur->next->level == bt->level)
-            HDassert(H5F_addr_eq(bt->right, cur->next->addr));
+            HDassert(H5_addr_eq(bt->right, cur->next->addr));
         else
-            HDassert(!H5F_addr_defined(bt->right));
+            HDassert(!H5_addr_defined(bt->right));
         if (prev && prev->level == bt->level)
-            HDassert(H5F_addr_eq(bt->left, prev->addr));
+            HDassert(H5_addr_eq(bt->left, prev->addr));
         else
-            HDassert(!H5F_addr_defined(bt->left));
+            HDassert(!H5_addr_defined(bt->left));
 
         if (cur->level > 0) {
             unsigned u;
@@ -229,7 +229,7 @@ H5B__assert(H5F_t *f, haddr_t addr, const H5B_class_t *type, void *udata)
                  * have then the tree has a cycle.
                  */
                 for (tmp = head; tmp; tmp = tmp->next)
-                    HDassert(H5F_addr_ne(tmp->addr, bt->child[u]));
+                    HDassert(H5_addr_ne(tmp->addr, bt->child[u]));
 
                 /* Add the child node to the end of the queue */
                 tmp = (struct child_t *)H5MM_calloc(sizeof(struct child_t));

--- a/src/H5C.c
+++ b/src/H5C.c
@@ -1404,7 +1404,7 @@ H5C_cork(H5C_t *cache_ptr, haddr_t obj_addr, unsigned action, hbool_t *corked)
 
     /* Assertions */
     HDassert(cache_ptr != NULL);
-    HDassert(H5F_addr_defined(obj_addr));
+    HDassert(H5_addr_defined(obj_addr));
     HDassert(action == H5C__SET_CORK || action == H5C__UNCORK || action == H5C__GET_CORKED);
 
     /* Search the list of corked object addresses in the cache */

--- a/src/H5Cdbg.c
+++ b/src/H5Cdbg.c
@@ -830,8 +830,8 @@ H5C_flush_dependency_exists(H5C_t *cache_ptr, haddr_t parent_addr, haddr_t child
 
     /* Sanity checks */
     HDassert(cache_ptr);
-    HDassert(H5F_addr_defined(parent_addr));
-    HDassert(H5F_addr_defined(child_addr));
+    HDassert(H5_addr_defined(parent_addr));
+    HDassert(H5_addr_defined(child_addr));
     HDassert(fd_exists_ptr);
 
     H5C__SEARCH_INDEX(cache_ptr, parent_addr, parent_ptr, FAIL)
@@ -1021,7 +1021,7 @@ H5C_get_entry_ptr_from_addr(H5C_t *cache_ptr, haddr_t addr, void **entry_ptr_ptr
 
     /* Sanity checks */
     HDassert(cache_ptr);
-    HDassert(H5F_addr_defined(addr));
+    HDassert(H5_addr_defined(addr));
     HDassert(entry_ptr_ptr);
 
     H5C__SEARCH_INDEX(cache_ptr, addr, entry_ptr, FAIL)
@@ -1147,7 +1147,7 @@ H5C_verify_entry_type(H5C_t *cache_ptr, haddr_t addr, const H5C_class_t *expecte
 
     /* Sanity checks */
     HDassert(cache_ptr);
-    HDassert(H5F_addr_defined(addr));
+    HDassert(H5_addr_defined(addr));
     HDassert(expected_type);
     HDassert(in_cache_ptr);
     HDassert(type_ok_ptr);

--- a/src/H5Centry.c
+++ b/src/H5Centry.c
@@ -812,7 +812,7 @@ H5C__flush_single_entry(H5F_t *f, H5C_cache_entry_t *entry_ptr, unsigned flags)
             hsize_t fsf_size;
 
             /* Sanity checks */
-            HDassert(H5F_addr_defined(entry_ptr->addr));
+            HDassert(H5_addr_defined(entry_ptr->addr));
             HDassert(!H5F_IS_TMP_ADDR(f, entry_ptr->addr));
 #ifndef NDEBUG
             {
@@ -955,15 +955,15 @@ H5C__verify_len_eoa(H5F_t *f, const H5C_class_t *type, haddr_t addr, size_t *len
 
     /* Get the file's end-of-allocation value */
     eoa = H5F_get_eoa(f, cooked_type);
-    if (!H5F_addr_defined(eoa))
+    if (!H5_addr_defined(eoa))
         HGOTO_ERROR(H5E_CACHE, H5E_BADVALUE, FAIL, "invalid EOA address for file")
 
     /* Check for bad address in general */
-    if (H5F_addr_gt(addr, eoa))
+    if (H5_addr_gt(addr, eoa))
         HGOTO_ERROR(H5E_CACHE, H5E_BADVALUE, FAIL, "address of object past end of allocation")
 
     /* Check if the amount of data to read will be past the EOA */
-    if (H5F_addr_gt((addr + *len), eoa)) {
+    if (H5_addr_gt((addr + *len), eoa)) {
         if (actual)
             HGOTO_ERROR(H5E_CACHE, H5E_BADVALUE, FAIL, "actual len exceeds EOA")
         else
@@ -1021,7 +1021,7 @@ H5C__load_entry(H5F_t *f,
     HDassert(f->shared);
     HDassert(f->shared->cache);
     HDassert(type);
-    HDassert(H5F_addr_defined(addr));
+    HDassert(H5_addr_defined(addr));
     HDassert(type->get_initial_load_size);
     if (type->flags & H5C__CLASS_SPECULATIVE_LOAD_FLAG)
         HDassert(type->get_final_load_size);
@@ -1839,7 +1839,7 @@ H5C__deserialize_prefetched_entry(H5F_t *f, H5C_t *cache_ptr, H5C_cache_entry_t 
      * either the speculative read flag.  Hence disallow.
      */
     HDassert(!((type->flags & H5C__CLASS_SKIP_READS) && (type->flags & H5C__CLASS_SPECULATIVE_LOAD_FLAG)));
-    HDassert(H5F_addr_defined(addr));
+    HDassert(H5_addr_defined(addr));
     HDassert(type->get_initial_load_size);
     HDassert(type->deserialize);
 
@@ -2159,7 +2159,7 @@ H5C_insert_entry(H5F_t *f, const H5C_class_t *type, haddr_t addr, void *thing, u
     HDassert(type);
     HDassert(type->mem_type == cache_ptr->class_table_ptr[type->id]->mem_type);
     HDassert(type->image_len);
-    HDassert(H5F_addr_defined(addr));
+    HDassert(H5_addr_defined(addr));
     HDassert(thing);
 
 #ifdef H5C_DO_EXTREME_SANITY_CHECKS
@@ -2434,7 +2434,7 @@ H5C_mark_entry_dirty(void *thing)
 
     /* Sanity checks */
     HDassert(entry_ptr);
-    HDassert(H5F_addr_defined(entry_ptr->addr));
+    HDassert(H5_addr_defined(entry_ptr->addr));
     cache_ptr = entry_ptr->cache_ptr;
     HDassert(cache_ptr);
 
@@ -2531,7 +2531,7 @@ H5C_mark_entry_clean(void *_thing)
 
     /* Sanity checks */
     HDassert(entry_ptr);
-    HDassert(H5F_addr_defined(entry_ptr->addr));
+    HDassert(H5_addr_defined(entry_ptr->addr));
     cache_ptr = entry_ptr->cache_ptr;
     HDassert(cache_ptr);
 
@@ -2605,7 +2605,7 @@ H5C_mark_entry_unserialized(void *thing)
 
     /* Sanity checks */
     HDassert(entry);
-    HDassert(H5F_addr_defined(entry->addr));
+    HDassert(H5_addr_defined(entry->addr));
 
     if (entry->is_protected || entry->is_pinned) {
         HDassert(!entry->is_read_only);
@@ -2651,7 +2651,7 @@ H5C_mark_entry_serialized(void *_thing)
 
     /* Sanity checks */
     HDassert(entry);
-    HDassert(H5F_addr_defined(entry->addr));
+    HDassert(H5_addr_defined(entry->addr));
 
     /* Operate on pinned entry */
     if (entry->is_protected)
@@ -2700,9 +2700,9 @@ H5C_move_entry(H5C_t *cache_ptr, const H5C_class_t *type, haddr_t old_addr, hadd
 
     HDassert(cache_ptr);
     HDassert(type);
-    HDassert(H5F_addr_defined(old_addr));
-    HDassert(H5F_addr_defined(new_addr));
-    HDassert(H5F_addr_ne(old_addr, new_addr));
+    HDassert(H5_addr_defined(old_addr));
+    HDassert(H5_addr_defined(new_addr));
+    HDassert(H5_addr_ne(old_addr, new_addr));
 
 #ifdef H5C_DO_EXTREME_SANITY_CHECKS
     if (H5C__validate_protected_entry_list(cache_ptr) < 0 || H5C__validate_pinned_entry_list(cache_ptr) < 0 ||
@@ -2846,7 +2846,7 @@ H5C_resize_entry(void *thing, size_t new_size)
 
     /* Sanity checks */
     HDassert(entry_ptr);
-    HDassert(H5F_addr_defined(entry_ptr->addr));
+    HDassert(H5_addr_defined(entry_ptr->addr));
     cache_ptr = entry_ptr->cache_ptr;
     HDassert(cache_ptr);
 
@@ -2978,7 +2978,7 @@ H5C_pin_protected_entry(void *thing)
 
     /* Sanity checks */
     HDassert(entry_ptr);
-    HDassert(H5F_addr_defined(entry_ptr->addr));
+    HDassert(H5_addr_defined(entry_ptr->addr));
     cache_ptr = entry_ptr->cache_ptr;
     HDassert(cache_ptr);
 
@@ -3056,7 +3056,7 @@ H5C_protect(H5F_t *f, const H5C_class_t *type, haddr_t addr, void *udata, unsign
     HDassert(cache_ptr);
     HDassert(type);
     HDassert(type->mem_type == cache_ptr->class_table_ptr[type->id]->mem_type);
-    HDassert(H5F_addr_defined(addr));
+    HDassert(H5_addr_defined(addr));
 
 #ifdef H5C_DO_EXTREME_SANITY_CHECKS
     if (H5C__validate_protected_entry_list(cache_ptr) < 0 || H5C__validate_pinned_entry_list(cache_ptr) < 0 ||
@@ -3527,7 +3527,7 @@ H5C_unprotect(H5F_t *f, haddr_t addr, void *thing, unsigned flags)
     cache_ptr = f->shared->cache;
 
     HDassert(cache_ptr);
-    HDassert(H5F_addr_defined(addr));
+    HDassert(H5_addr_defined(addr));
     HDassert(thing);
     HDassert(!(pin_entry && unpin_entry));
 
@@ -3870,9 +3870,9 @@ H5C_create_flush_dependency(void *parent_thing, void *child_thing)
 
     /* Sanity checks */
     HDassert(parent_entry);
-    HDassert(H5F_addr_defined(parent_entry->addr));
+    HDassert(H5_addr_defined(parent_entry->addr));
     HDassert(child_entry);
-    HDassert(H5F_addr_defined(child_entry->addr));
+    HDassert(H5_addr_defined(child_entry->addr));
     cache_ptr = parent_entry->cache_ptr;
     HDassert(cache_ptr);
     HDassert(cache_ptr == child_entry->cache_ptr);
@@ -4009,9 +4009,9 @@ H5C_destroy_flush_dependency(void *parent_thing, void *child_thing)
 
     /* Sanity checks */
     HDassert(parent_entry);
-    HDassert(H5F_addr_defined(parent_entry->addr));
+    HDassert(H5_addr_defined(parent_entry->addr));
     HDassert(child_entry);
-    HDassert(H5F_addr_defined(child_entry->addr));
+    HDassert(H5_addr_defined(child_entry->addr));
     cache_ptr = parent_entry->cache_ptr;
     HDassert(cache_ptr);
     HDassert(cache_ptr == child_entry->cache_ptr);
@@ -4132,7 +4132,7 @@ H5C_expunge_entry(H5F_t *f, const H5C_class_t *type, haddr_t addr, unsigned flag
     cache_ptr = f->shared->cache;
     HDassert(cache_ptr);
     HDassert(type);
-    HDassert(H5F_addr_defined(addr));
+    HDassert(H5_addr_defined(addr));
 
 #ifdef H5C_DO_EXTREME_SANITY_CHECKS
     if (H5C__validate_lru_list(cache_ptr) < 0)

--- a/src/H5Cimage.c
+++ b/src/H5Cimage.c
@@ -553,7 +553,7 @@ H5C__read_cache_image(H5F_t *f, H5C_t *cache_ptr)
     /* Sanity checks */
     HDassert(f);
     HDassert(cache_ptr);
-    HDassert(H5F_addr_defined(cache_ptr->image_addr));
+    HDassert(H5_addr_defined(cache_ptr->image_addr));
     HDassert(cache_ptr->image_len > 0);
     HDassert(cache_ptr->image_buffer);
 
@@ -636,7 +636,7 @@ H5C__load_cache_image(H5F_t *f)
      * no image exists, and that the load operation should be skipped
      * silently.
      */
-    if (H5F_addr_defined(cache_ptr->image_addr)) {
+    if (H5_addr_defined(cache_ptr->image_addr)) {
         /* Sanity checks */
         HDassert(cache_ptr->image_len > 0);
         HDassert(cache_ptr->image_buffer == NULL);
@@ -1477,7 +1477,7 @@ H5C__decode_cache_image_entry(const H5F_t *f, const H5C_t *cache_ptr, const uint
 
     /* Decode entry offset */
     H5F_addr_decode(f, &p, &addr);
-    if (!H5F_addr_defined(addr))
+    if (!H5_addr_defined(addr))
         HGOTO_ERROR(H5E_CACHE, H5E_BADVALUE, FAIL, "invalid entry offset")
 
     /* Decode entry length */
@@ -1500,7 +1500,7 @@ H5C__decode_cache_image_entry(const H5F_t *f, const H5C_t *cache_ptr, const uint
 
         for (i = 0; i < fd_parent_count; i++) {
             H5F_addr_decode(f, &p, &(fd_parent_addrs[i]));
-            if (!H5F_addr_defined(fd_parent_addrs[i]))
+            if (!H5_addr_defined(fd_parent_addrs[i]))
                 HGOTO_ERROR(H5E_CACHE, H5E_BADVALUE, FAIL, "invalid flush dependency parent offset")
         } /* end for */
     }     /* end if */
@@ -2271,7 +2271,7 @@ H5C__prep_for_file_close__scan_entries(const H5F_t *f, H5C_t *cache_ptr)
 
                 for (int i = 0; i < (int)(entry_ptr->fd_parent_count); i++) {
                     entry_ptr->fd_parent_addrs[i] = entry_ptr->flush_dep_parent[i]->addr;
-                    HDassert(H5F_addr_defined(entry_ptr->fd_parent_addrs[i]));
+                    HDassert(H5_addr_defined(entry_ptr->fd_parent_addrs[i]));
                 } /* end for */
             }     /* end if */
             else if (entry_ptr->fd_parent_count > 0) {
@@ -2499,7 +2499,7 @@ H5C__reconstruct_cache_contents(H5F_t *f, H5C_t *cache_ptr)
         for (v = 0; v < pf_entry_ptr->fd_parent_count; v++) {
             /* Sanity checks */
             HDassert(pf_entry_ptr->fd_parent_addrs);
-            HDassert(H5F_addr_defined(pf_entry_ptr->fd_parent_addrs[v]));
+            HDassert(H5_addr_defined(pf_entry_ptr->fd_parent_addrs[v]));
 
             /* Find the parent entry */
             parent_ptr = NULL;
@@ -2721,7 +2721,7 @@ H5C__reconstruct_cache_entry(const H5F_t *f, H5C_t *cache_ptr, const uint8_t **b
 
     /* Decode entry offset */
     H5F_addr_decode(f, &p, &pf_entry_ptr->addr);
-    if (!H5F_addr_defined(pf_entry_ptr->addr))
+    if (!H5_addr_defined(pf_entry_ptr->addr))
         HGOTO_ERROR(H5E_CACHE, H5E_BADVALUE, NULL, "invalid entry offset")
 
     /* Decode entry length */
@@ -2745,7 +2745,7 @@ H5C__reconstruct_cache_entry(const H5F_t *f, H5C_t *cache_ptr, const uint8_t **b
 
         for (u = 0; u < pf_entry_ptr->fd_parent_count; u++) {
             H5F_addr_decode(f, &p, &(pf_entry_ptr->fd_parent_addrs[u]));
-            if (!H5F_addr_defined(pf_entry_ptr->fd_parent_addrs[u]))
+            if (!H5_addr_defined(pf_entry_ptr->fd_parent_addrs[u]))
                 HGOTO_ERROR(H5E_CACHE, H5E_BADVALUE, NULL, "invalid flush dependency parent offset")
         } /* end for */
     }     /* end if */
@@ -2869,7 +2869,7 @@ H5C__write_cache_image(H5F_t *f, const H5C_t *cache_ptr)
     /* Sanity checks */
     HDassert(f);
     HDassert(cache_ptr);
-    HDassert(H5F_addr_defined(cache_ptr->image_addr));
+    HDassert(H5_addr_defined(cache_ptr->image_addr));
     HDassert(cache_ptr->image_len > 0);
     HDassert(cache_ptr->image_buffer);
 

--- a/src/H5Cmpio.c
+++ b/src/H5Cmpio.c
@@ -279,7 +279,7 @@ H5C_apply_candidate_list(H5F_t *f, H5C_t *cache_ptr, unsigned num_candidates, ha
 
     for (u = 0; u < num_candidates; u++) {
         addr = candidates_list_ptr[u];
-        HDassert(H5F_addr_defined(addr));
+        HDassert(H5_addr_defined(addr));
 
 #ifdef H5C_DO_SANITY_CHECKS
         if (u > 0) {
@@ -678,7 +678,7 @@ H5C_mark_entries_as_clean(H5F_t *f, unsigned ce_array_len, haddr_t *ce_array_ptr
 #endif /* H5C_DO_EXTREME_SANITY_CHECKS */
 #endif /* H5C_DO_SANITY_CHECKS */
 
-        HDassert(H5F_addr_defined(addr));
+        HDassert(H5_addr_defined(addr));
 
         H5C__SEARCH_INDEX(cache_ptr, addr, entry_ptr, FAIL)
 

--- a/src/H5Cpkg.h
+++ b/src/H5Cpkg.h
@@ -548,7 +548,7 @@ if ((new_size) > (dll_size) || ((dll_len) == 1 && (new_size) != (dll_size))) { \
 ((cache_ptr) == NULL ||                                                   \
     (cache_ptr)->index_size !=                                            \
        ((cache_ptr)->clean_index_size + (cache_ptr)->dirty_index_size) || \
-    !H5F_addr_defined(entry_addr) ||                                      \
+    !H5_addr_defined(entry_addr) ||                                      \
     H5C__HASH_FCN(entry_addr) < 0 ||                                      \
     H5C__HASH_FCN(entry_addr) >= H5C__HASH_TABLE_LEN                      \
 )
@@ -570,7 +570,7 @@ if ((new_size) > (dll_size) || ((dll_len) == 1 && (new_size) != (dll_size))) { \
 
 #define H5C__PRE_HT_INSERT_SC(cache_ptr, entry_ptr, fail_val)           \
 if ((cache_ptr) == NULL ||                                              \
-     (entry_ptr) == NULL || !H5F_addr_defined((entry_ptr)->addr) ||     \
+     (entry_ptr) == NULL || !H5_addr_defined((entry_ptr)->addr) ||     \
      (entry_ptr)->ht_next != NULL || (entry_ptr)->ht_prev != NULL ||    \
      (entry_ptr)->size <= 0 ||                                          \
      H5C__HASH_FCN((entry_ptr)->addr) < 0 ||                            \
@@ -614,7 +614,7 @@ if ((cache_ptr) == NULL ||                                              \
 if ( (cache_ptr) == NULL || (cache_ptr)->index_len < 1 ||               \
      (entry_ptr) == NULL ||                                             \
      (cache_ptr)->index_size < (entry_ptr)->size ||                     \
-     !H5F_addr_defined((entry_ptr)->addr) ||                            \
+     !H5_addr_defined((entry_ptr)->addr) ||                            \
      (entry_ptr)->size <= 0 ||                                          \
      H5C__HASH_FCN((entry_ptr)->addr) < 0 ||                            \
      H5C__HASH_FCN((entry_ptr)->addr) >= H5C__HASH_TABLE_LEN ||         \
@@ -644,7 +644,7 @@ if ( (cache_ptr) == NULL || (cache_ptr)->index_len < 1 ||               \
 
 #define H5C__POST_HT_REMOVE_SC(cache_ptr, entry_ptr, fail_val)            \
 if ((cache_ptr) == NULL ||                                                \
-     (entry_ptr) == NULL || !H5F_addr_defined((entry_ptr)->addr) ||       \
+     (entry_ptr) == NULL || !H5_addr_defined((entry_ptr)->addr) ||       \
      (entry_ptr)->size <= 0 ||                                            \
      (entry_ptr)->ht_next != NULL ||                                      \
      (entry_ptr)->ht_prev != NULL ||                                      \
@@ -889,7 +889,7 @@ if ((cache_ptr)->index_size != ((cache_ptr)->clean_index_size + (cache_ptr)->dir
     k = H5C__HASH_FCN(entry_addr);                                           \
     (entry_ptr) = (cache_ptr)->index[k];                                     \
     while(entry_ptr) {                                                       \
-        if(H5F_addr_eq(entry_addr, (entry_ptr)->addr)) {                     \
+        if(H5_addr_eq(entry_addr, (entry_ptr)->addr)) {                     \
             H5C__POST_SUC_HT_SEARCH_SC(cache_ptr, entry_ptr, k, fail_val)    \
             if((entry_ptr) != (cache_ptr)->index[k]) {                       \
                 if((entry_ptr)->ht_next)                                     \
@@ -1028,7 +1028,7 @@ if ((cache_ptr)->index_size != ((cache_ptr)->clean_index_size + (cache_ptr)->dir
     if((cache_ptr)->slist_enabled) {                                           \
         HDassert(entry_ptr);                                                   \
         HDassert((entry_ptr)->size > 0);                                       \
-        HDassert(H5F_addr_defined((entry_ptr)->addr));                         \
+        HDassert(H5_addr_defined((entry_ptr)->addr));                         \
         HDassert(!(entry_ptr)->in_slist);                                      \
         HDassert(!H5C__ENTRY_IN_SLIST((cache_ptr), (entry_ptr)));              \
         HDassert((entry_ptr)->ring > H5C_RING_UNDEFINED);                      \

--- a/src/H5Cquery.c
+++ b/src/H5Cquery.c
@@ -244,7 +244,7 @@ H5C_get_entry_status(const H5F_t *f, haddr_t addr, size_t *size_ptr, hbool_t *in
     HDassert(f->shared);
     cache_ptr = f->shared->cache;
     HDassert(cache_ptr != NULL);
-    HDassert(H5F_addr_defined(addr));
+    HDassert(H5_addr_defined(addr));
     HDassert(in_cache_ptr != NULL);
 
     if (cache_ptr == NULL)
@@ -369,7 +369,7 @@ H5C_get_entry_ring(const H5F_t *f, haddr_t addr, H5C_ring_t *ring)
     HDassert(f->shared);
     cache_ptr = f->shared->cache;
     HDassert(cache_ptr);
-    HDassert(H5F_addr_defined(addr));
+    HDassert(H5_addr_defined(addr));
 
     /* Locate the entry at the address */
     H5C__SEARCH_INDEX(cache_ptr, addr, entry_ptr, FAIL)

--- a/src/H5Ctag.c
+++ b/src/H5Ctag.c
@@ -219,7 +219,7 @@ H5C__tag_entry(H5C_t *cache, H5C_cache_entry_t *entry)
            arbitrarily set it to something for the sake of passing the tests.
            If the tag value is set, then we'll just let it get assigned without
            additional checking for correctness. */
-        if (!H5F_addr_defined(tag))
+        if (!H5_addr_defined(tag))
             tag = H5AC__IGNORE_TAG;
     }
 #ifdef H5C_DO_TAGGING_SANITY_CHECKS

--- a/src/H5Dbtree.c
+++ b/src/H5Dbtree.c
@@ -251,7 +251,7 @@ H5D__btree_new_node(H5F_t H5_ATTR_NDEBUG_UNUSED *f, H5B_ins_t op, void *_lt_key,
     HDassert(addr_p);
 
     /* Set address */
-    HDassert(H5F_addr_defined(udata->chunk_block.offset));
+    HDassert(H5_addr_defined(udata->chunk_block.offset));
     HDassert(udata->chunk_block.length > 0);
     *addr_p = udata->chunk_block.offset;
 
@@ -423,7 +423,7 @@ H5D__btree_found(H5F_t H5_ATTR_UNUSED *f, haddr_t addr, const void *_lt_key, hbo
 
     /* Check arguments */
     HDassert(f);
-    HDassert(H5F_addr_defined(addr));
+    HDassert(H5_addr_defined(addr));
     HDassert(lt_key);
     HDassert(found);
     HDassert(udata);
@@ -528,7 +528,7 @@ H5D__btree_insert(H5F_t H5_ATTR_NDEBUG_UNUSED *f, haddr_t H5_ATTR_NDEBUG_UNUSED 
 
     /* check args */
     HDassert(f);
-    HDassert(H5F_addr_defined(addr));
+    HDassert(H5_addr_defined(addr));
     HDassert(lt_key);
     HDassert(lt_key_changed);
     HDassert(md_key);
@@ -551,7 +551,7 @@ H5D__btree_insert(H5F_t H5_ATTR_NDEBUG_UNUSED *f, haddr_t H5_ATTR_NDEBUG_UNUSED 
          */
         if (lt_key->nbytes != udata->chunk_block.length) {
             /* Set node's address (already re-allocated by main chunk routines) */
-            HDassert(H5F_addr_defined(udata->chunk_block.offset));
+            HDassert(H5_addr_defined(udata->chunk_block.offset));
             *new_node_p = udata->chunk_block.offset;
             H5_CHECKED_ASSIGN(lt_key->nbytes, uint32_t, udata->chunk_block.length, hsize_t);
             lt_key->filter_mask = udata->filter_mask;
@@ -560,7 +560,7 @@ H5D__btree_insert(H5F_t H5_ATTR_NDEBUG_UNUSED *f, haddr_t H5_ATTR_NDEBUG_UNUSED 
         }
         else {
             /* Already have address in udata, from main chunk routines */
-            HDassert(H5F_addr_defined(udata->chunk_block.offset));
+            HDassert(H5_addr_defined(udata->chunk_block.offset));
             ret_value = H5B_INS_NOOP;
         }
     }
@@ -575,7 +575,7 @@ H5D__btree_insert(H5F_t H5_ATTR_NDEBUG_UNUSED *f, haddr_t H5_ATTR_NDEBUG_UNUSED 
         for (u = 0; u < udata->common.layout->ndims; u++)
             md_key->scaled[u] = udata->common.scaled[u];
 
-        HDassert(H5F_addr_defined(udata->chunk_block.offset));
+        HDassert(H5_addr_defined(udata->chunk_block.offset));
         *new_node_p = udata->chunk_block.offset;
         ret_value   = H5B_INS_RIGHT;
     }
@@ -849,7 +849,7 @@ H5D__btree_idx_init(const H5D_chk_idx_info_t *idx_info, const H5S_t H5_ATTR_UNUS
     HDassert(idx_info->pline);
     HDassert(idx_info->layout);
     HDassert(idx_info->storage);
-    HDassert(H5F_addr_defined(dset_ohdr_addr));
+    HDassert(H5_addr_defined(dset_ohdr_addr));
 
     idx_info->storage->u.btree.dset_ohdr_addr = dset_ohdr_addr;
 
@@ -893,7 +893,7 @@ H5D__btree_idx_create(const H5D_chk_idx_info_t *idx_info)
     HDassert(idx_info->pline);
     HDassert(idx_info->layout);
     HDassert(idx_info->storage);
-    HDassert(!H5F_addr_defined(idx_info->storage->idx_addr));
+    HDassert(!H5_addr_defined(idx_info->storage->idx_addr));
 
     /* Initialize "user" data for B-tree callbacks, etc. */
     udata.layout  = idx_info->layout;
@@ -927,7 +927,7 @@ H5D__btree_idx_is_space_alloc(const H5O_storage_chunk_t *storage)
     /* Check args */
     HDassert(storage);
 
-    FUNC_LEAVE_NOAPI((hbool_t)H5F_addr_defined(storage->idx_addr))
+    FUNC_LEAVE_NOAPI((hbool_t)H5_addr_defined(storage->idx_addr))
 } /* end H5D__btree_idx_is_space_alloc() */
 
 /*-------------------------------------------------------------------------
@@ -955,7 +955,7 @@ H5D__btree_idx_insert(const H5D_chk_idx_info_t *idx_info, H5D_chunk_ud_t *udata,
     HDassert(idx_info->pline);
     HDassert(idx_info->layout);
     HDassert(idx_info->storage);
-    HDassert(H5F_addr_defined(idx_info->storage->idx_addr));
+    HDassert(H5_addr_defined(idx_info->storage->idx_addr));
     HDassert(udata);
 
     /*
@@ -997,7 +997,7 @@ H5D__btree_idx_get_addr(const H5D_chk_idx_info_t *idx_info, H5D_chunk_ud_t *udat
     HDassert(idx_info->layout);
     HDassert(idx_info->layout->ndims > 0);
     HDassert(idx_info->storage);
-    HDassert(H5F_addr_defined(idx_info->storage->idx_addr));
+    HDassert(H5_addr_defined(idx_info->storage->idx_addr));
     HDassert(udata);
 
     /* Go get the chunk information from the B-tree */
@@ -1080,7 +1080,7 @@ H5D__btree_idx_iterate(const H5D_chk_idx_info_t *idx_info, H5D_chunk_cb_func_t c
     HDassert(idx_info->pline);
     HDassert(idx_info->layout);
     HDassert(idx_info->storage);
-    HDassert(H5F_addr_defined(idx_info->storage->idx_addr));
+    HDassert(H5_addr_defined(idx_info->storage->idx_addr));
     HDassert(chunk_cb);
     HDassert(chunk_udata);
 
@@ -1123,7 +1123,7 @@ H5D__btree_idx_remove(const H5D_chk_idx_info_t *idx_info, H5D_chunk_common_ud_t 
     HDassert(idx_info->pline);
     HDassert(idx_info->layout);
     HDassert(idx_info->storage);
-    HDassert(H5F_addr_defined(idx_info->storage->idx_addr));
+    HDassert(H5_addr_defined(idx_info->storage->idx_addr));
     HDassert(udata);
 
     /* Remove the chunk from the v1 B-tree index and release the space for the
@@ -1165,7 +1165,7 @@ H5D__btree_idx_delete(const H5D_chk_idx_info_t *idx_info)
     HDassert(idx_info->storage);
 
     /* Check if the index data structure has been allocated */
-    if (H5F_addr_defined(idx_info->storage->idx_addr)) {
+    if (H5_addr_defined(idx_info->storage->idx_addr)) {
         H5O_storage_chunk_t   tmp_storage; /* Local copy of storage info */
         H5D_chunk_common_ud_t udata;       /* User data for B-tree operations */
 
@@ -1225,7 +1225,7 @@ H5D__btree_idx_copy_setup(const H5D_chk_idx_info_t *idx_info_src, const H5D_chk_
     HDassert(idx_info_dst->pline);
     HDassert(idx_info_dst->layout);
     HDassert(idx_info_dst->storage);
-    HDassert(!H5F_addr_defined(idx_info_dst->storage->idx_addr));
+    HDassert(!H5_addr_defined(idx_info_dst->storage->idx_addr));
 
     /* Create shared B-tree info for each file */
     if (H5D__btree_shared_create(idx_info_src->f, idx_info_src->storage, idx_info_src->layout) < 0)
@@ -1237,7 +1237,7 @@ H5D__btree_idx_copy_setup(const H5D_chk_idx_info_t *idx_info_src, const H5D_chk_
     /* Create the root of the B-tree that describes chunked storage in the dest. file */
     if (H5D__btree_idx_create(idx_info_dst) < 0)
         HGOTO_ERROR(H5E_IO, H5E_CANTINIT, FAIL, "unable to initialize chunked storage")
-    HDassert(H5F_addr_defined(idx_info_dst->storage->idx_addr));
+    HDassert(H5_addr_defined(idx_info_dst->storage->idx_addr));
 
 done:
     FUNC_LEAVE_NOAPI_TAG(ret_value)

--- a/src/H5Dbtree2.c
+++ b/src/H5Dbtree2.c
@@ -475,7 +475,7 @@ H5D__bt2_filt_encode(uint8_t *raw, const void *_record, void *_ctx)
     /* Sanity check */
     HDassert(ctx);
     HDassert(record);
-    HDassert(H5F_addr_defined(record->chunk_addr));
+    HDassert(H5_addr_defined(record->chunk_addr));
     HDassert(0 != record->nbytes);
 
     /* Encode the record's fields */
@@ -522,7 +522,7 @@ H5D__bt2_filt_decode(const uint8_t *raw, void *_record, void *_ctx)
         UINT64DECODE(raw, record->scaled[u]);
 
     /* Sanity checks */
-    HDassert(H5F_addr_defined(record->chunk_addr));
+    HDassert(H5_addr_defined(record->chunk_addr));
     HDassert(0 != record->nbytes);
 
     FUNC_LEAVE_NOAPI(SUCCEED)
@@ -551,7 +551,7 @@ H5D__bt2_filt_debug(FILE *stream, int indent, int fwidth, const void *_record, c
 
     /* Sanity checks */
     HDassert(record);
-    HDassert(H5F_addr_defined(record->chunk_addr));
+    HDassert(H5_addr_defined(record->chunk_addr));
     HDassert(0 != record->nbytes);
 
     HDfprintf(stream, "%*s%-*s %" PRIuHADDR "\n", indent, "", fwidth, "Chunk address:", record->chunk_addr);
@@ -585,7 +585,7 @@ H5D__bt2_idx_init(const H5D_chk_idx_info_t H5_ATTR_UNUSED *idx_info, const H5S_t
     FUNC_ENTER_PACKAGE_NOERR
 
     /* Check args */
-    HDassert(H5F_addr_defined(dset_ohdr_addr));
+    HDassert(H5_addr_defined(dset_ohdr_addr));
 
     idx_info->storage->u.btree2.dset_ohdr_addr = dset_ohdr_addr;
 
@@ -625,7 +625,7 @@ H5D__btree2_idx_depend(const H5D_chk_idx_info_t *idx_info)
     HDassert(H5D_CHUNK_IDX_BT2 == idx_info->layout->idx_type);
     HDassert(idx_info->storage);
     HDassert(H5D_CHUNK_IDX_BT2 == idx_info->storage->idx_type);
-    HDassert(H5F_addr_defined(idx_info->storage->idx_addr));
+    HDassert(H5_addr_defined(idx_info->storage->idx_addr));
     HDassert(idx_info->storage->u.btree2.bt2);
 
     /* Set up object header location for dataset */
@@ -686,7 +686,7 @@ H5D__bt2_idx_open(const H5D_chk_idx_info_t *idx_info)
     HDassert(idx_info->layout);
     HDassert(H5D_CHUNK_IDX_BT2 == idx_info->layout->idx_type);
     HDassert(idx_info->storage);
-    HDassert(H5F_addr_defined(idx_info->storage->idx_addr));
+    HDassert(H5_addr_defined(idx_info->storage->idx_addr));
     HDassert(NULL == idx_info->storage->u.btree2.bt2);
 
     /* Set up the user data */
@@ -736,7 +736,7 @@ H5D__bt2_idx_create(const H5D_chk_idx_info_t *idx_info)
     HDassert(idx_info->pline);
     HDassert(idx_info->layout);
     HDassert(idx_info->storage);
-    HDassert(!H5F_addr_defined(idx_info->storage->idx_addr));
+    HDassert(!H5_addr_defined(idx_info->storage->idx_addr));
 
     bt2_cparam.rrec_size = H5F_SIZEOF_ADDR(idx_info->f)         /* Address of chunk */
                            + (idx_info->layout->ndims - 1) * 8; /* # of dimensions x 64-bit chunk offsets */
@@ -806,7 +806,7 @@ H5D__bt2_idx_is_space_alloc(const H5O_storage_chunk_t *storage)
     /* Check args */
     HDassert(storage);
 
-    FUNC_LEAVE_NOAPI((hbool_t)H5F_addr_defined(storage->idx_addr))
+    FUNC_LEAVE_NOAPI((hbool_t)H5_addr_defined(storage->idx_addr))
 } /* end H5D__bt2_idx_is_space_alloc() */
 
 /*-------------------------------------------------------------------------
@@ -885,9 +885,9 @@ H5D__bt2_idx_insert(const H5D_chk_idx_info_t *idx_info, H5D_chunk_ud_t *udata,
     HDassert(idx_info->pline);
     HDassert(idx_info->layout);
     HDassert(idx_info->storage);
-    HDassert(H5F_addr_defined(idx_info->storage->idx_addr));
+    HDassert(H5_addr_defined(idx_info->storage->idx_addr));
     HDassert(udata);
-    HDassert(H5F_addr_defined(udata->chunk_block.offset));
+    HDassert(H5_addr_defined(udata->chunk_block.offset));
 
     /* Check if the v2 B-tree is open yet */
     if (NULL == idx_info->storage->u.btree2.bt2) {
@@ -980,7 +980,7 @@ H5D__bt2_idx_get_addr(const H5D_chk_idx_info_t *idx_info, H5D_chunk_ud_t *udata)
     HDassert(idx_info->layout);
     HDassert(idx_info->layout->ndims > 0);
     HDassert(idx_info->storage);
-    HDassert(H5F_addr_defined(idx_info->storage->idx_addr));
+    HDassert(H5_addr_defined(idx_info->storage->idx_addr));
     HDassert(udata);
 
     /* Check if the v2 B-tree is open yet */
@@ -1101,7 +1101,7 @@ H5D__bt2_idx_iterate(const H5D_chk_idx_info_t *idx_info, H5D_chunk_cb_func_t chu
     HDassert(idx_info->pline);
     HDassert(idx_info->layout);
     HDassert(idx_info->storage);
-    HDassert(H5F_addr_defined(idx_info->storage->idx_addr));
+    HDassert(H5_addr_defined(idx_info->storage->idx_addr));
     HDassert(chunk_cb);
     HDassert(chunk_udata);
 
@@ -1193,7 +1193,7 @@ H5D__bt2_idx_remove(const H5D_chk_idx_info_t *idx_info, H5D_chunk_common_ud_t *u
     HDassert(idx_info->pline);
     HDassert(idx_info->layout);
     HDassert(idx_info->storage);
-    HDassert(H5F_addr_defined(idx_info->storage->idx_addr));
+    HDassert(H5_addr_defined(idx_info->storage->idx_addr));
     HDassert(udata);
 
     /* Check if the v2 B-tree is open yet */
@@ -1257,7 +1257,7 @@ H5D__bt2_idx_delete(const H5D_chk_idx_info_t *idx_info)
     HDassert(idx_info->storage);
 
     /* Check if the index data structure has been allocated */
-    if (H5F_addr_defined(idx_info->storage->idx_addr)) {
+    if (H5_addr_defined(idx_info->storage->idx_addr)) {
         /* Set up user data for creating context */
         u_ctx.f          = idx_info->f;
         u_ctx.ndims      = idx_info->layout->ndims - 1;
@@ -1313,7 +1313,7 @@ H5D__bt2_idx_copy_setup(const H5D_chk_idx_info_t *idx_info_src, const H5D_chk_id
     HDassert(idx_info_dst->pline);
     HDassert(idx_info_dst->layout);
     HDassert(idx_info_dst->storage);
-    HDassert(!H5F_addr_defined(idx_info_dst->storage->idx_addr));
+    HDassert(!H5_addr_defined(idx_info_dst->storage->idx_addr));
 
     /* Check if the source v2 B-tree is open yet */
     if (NULL == idx_info_src->storage->u.btree2.bt2)
@@ -1326,7 +1326,7 @@ H5D__bt2_idx_copy_setup(const H5D_chk_idx_info_t *idx_info_src, const H5D_chk_id
     /* Create v2 B-tree that describes the chunked dataset in the destination file */
     if (H5D__bt2_idx_create(idx_info_dst) < 0)
         HGOTO_ERROR(H5E_DATASET, H5E_CANTINIT, FAIL, "unable to initialize chunked storage")
-    HDassert(H5F_addr_defined(idx_info_dst->storage->idx_addr));
+    HDassert(H5_addr_defined(idx_info_dst->storage->idx_addr));
 
     /* Reset metadata tag */
     H5_END_TAG
@@ -1399,7 +1399,7 @@ H5D__bt2_idx_size(const H5D_chk_idx_info_t *idx_info, hsize_t *index_size)
     HDassert(idx_info->pline);
     HDassert(idx_info->layout);
     HDassert(idx_info->storage);
-    HDassert(H5F_addr_defined(idx_info->storage->idx_addr));
+    HDassert(H5_addr_defined(idx_info->storage->idx_addr));
     HDassert(index_size);
 
     /* Open v2 B-tree */

--- a/src/H5Dchunk.c
+++ b/src/H5Dchunk.c
@@ -408,8 +408,8 @@ H5D__chunk_direct_write(H5D_t *dset, uint32_t filters, hsize_t *offset, uint32_t
         HGOTO_ERROR(H5E_DATASET, H5E_CANTGET, FAIL, "error looking up chunk address")
 
     /* Sanity check */
-    HDassert((H5F_addr_defined(udata.chunk_block.offset) && udata.chunk_block.length > 0) ||
-             (!H5F_addr_defined(udata.chunk_block.offset) && udata.chunk_block.length == 0));
+    HDassert((H5_addr_defined(udata.chunk_block.offset) && udata.chunk_block.length > 0) ||
+             (!H5_addr_defined(udata.chunk_block.offset) && udata.chunk_block.length == 0));
 
     /* Set the file block information for the old chunk */
     /* (Which is only defined when overwriting an existing chunk) */
@@ -429,7 +429,7 @@ H5D__chunk_direct_write(H5D_t *dset, uint32_t filters, hsize_t *offset, uint32_t
     /* Set up the size of chunk for user data */
     udata.chunk_block.length = data_size;
 
-    if (0 == idx_info.pline->nused && H5F_addr_defined(old_chunk.offset))
+    if (0 == idx_info.pline->nused && H5_addr_defined(old_chunk.offset))
         /* If there are no filters and we are overwriting the chunk we can just set values */
         need_insert = FALSE;
     else {
@@ -444,7 +444,7 @@ H5D__chunk_direct_write(H5D_t *dset, uint32_t filters, hsize_t *offset, uint32_t
     } /* end else */
 
     /* Make sure the address of the chunk is returned. */
-    if (!H5F_addr_defined(udata.chunk_block.offset))
+    if (!H5_addr_defined(udata.chunk_block.offset))
         HGOTO_ERROR(H5E_DATASET, H5E_BADVALUE, FAIL, "chunk address isn't defined")
 
     /* Evict the (old) entry from the cache if present, but do not flush
@@ -524,8 +524,8 @@ H5D__chunk_direct_read(const H5D_t *dset, hsize_t *offset, uint32_t *filters, vo
         HGOTO_ERROR(H5E_DATASET, H5E_CANTGET, FAIL, "error looking up chunk address")
 
     /* Sanity check */
-    HDassert((H5F_addr_defined(udata.chunk_block.offset) && udata.chunk_block.length > 0) ||
-             (!H5F_addr_defined(udata.chunk_block.offset) && udata.chunk_block.length == 0));
+    HDassert((H5_addr_defined(udata.chunk_block.offset) && udata.chunk_block.length > 0) ||
+             (!H5_addr_defined(udata.chunk_block.offset) && udata.chunk_block.length == 0));
 
     /* Check if the requested chunk exists in the chunk cache */
     if (UINT_MAX != udata.idx_hint) {
@@ -554,7 +554,7 @@ H5D__chunk_direct_read(const H5D_t *dset, hsize_t *offset, uint32_t *filters, vo
     }
 
     /* Make sure the address of the chunk is returned. */
-    if (!H5F_addr_defined(udata.chunk_block.offset))
+    if (!H5_addr_defined(udata.chunk_block.offset))
         HGOTO_ERROR(H5E_DATASET, H5E_CANTGET, FAIL, "chunk address isn't defined")
 
     /* Read the chunk data into the supplied buffer */
@@ -615,11 +615,11 @@ H5D__get_chunk_storage_size(H5D_t *dset, const hsize_t *offset, hsize_t *storage
         HGOTO_ERROR(H5E_DATASET, H5E_CANTGET, FAIL, "error looking up chunk address")
 
     /* Sanity check */
-    HDassert((H5F_addr_defined(udata.chunk_block.offset) && udata.chunk_block.length > 0) ||
-             (!H5F_addr_defined(udata.chunk_block.offset) && udata.chunk_block.length == 0));
+    HDassert((H5_addr_defined(udata.chunk_block.offset) && udata.chunk_block.length > 0) ||
+             (!H5_addr_defined(udata.chunk_block.offset) && udata.chunk_block.length == 0));
 
     /* The requested chunk is not in cache or on disk */
-    if (!H5F_addr_defined(udata.chunk_block.offset) && UINT_MAX == udata.idx_hint)
+    if (!H5_addr_defined(udata.chunk_block.offset) && UINT_MAX == udata.idx_hint)
         HGOTO_ERROR(H5E_DATASET, H5E_CANTGET, FAIL, "chunk storage is not allocated")
 
     /* Check if there are filters registered to the dataset */
@@ -650,7 +650,7 @@ H5D__get_chunk_storage_size(H5D_t *dset, const hsize_t *offset, hsize_t *storage
         }
 
         /* Make sure the address of the chunk is returned. */
-        if (!H5F_addr_defined(udata.chunk_block.offset))
+        if (!H5_addr_defined(udata.chunk_block.offset))
             HGOTO_ERROR(H5E_DATASET, H5E_CANTGET, FAIL, "chunk address isn't defined")
 
         /* Return the chunk size on disk */
@@ -2456,7 +2456,7 @@ H5D__chunk_mdio_init(H5D_io_info_t *io_info, H5D_dset_io_info_t *dinfo)
         piece_info->faddr = udata.chunk_block.offset;
 
         /* Add piece to MDIO operation if it has a file address */
-        if (H5F_addr_defined(piece_info->faddr)) {
+        if (H5_addr_defined(piece_info->faddr)) {
             HDassert(io_info->sel_pieces);
             HDassert(io_info->pieces_added < io_info->piece_count);
 
@@ -2532,7 +2532,7 @@ H5D__chunk_cacheable(const H5D_io_info_t H5_ATTR_PARALLEL_USED *io_info, H5D_dse
              */
             H5_CHECK_OVERFLOW(dataset->shared->layout.u.chunk.size, uint32_t, size_t);
             if ((size_t)dataset->shared->layout.u.chunk.size > dataset->shared->cache.chunk.nbytes_max) {
-                if (write_op && !H5F_addr_defined(caddr)) {
+                if (write_op && !H5_addr_defined(caddr)) {
                     const H5O_fill_t *fill = &(dataset->shared->dcpl_cache.fill); /* Fill value info */
                     H5D_fill_value_t  fill_status;                                /* Fill value status */
 
@@ -2753,11 +2753,11 @@ H5D__chunk_read(H5D_io_info_t *io_info, H5D_dset_io_info_t *dset_info)
             HDassert(UINT_MAX == udata.idx_hint);
 
             /* Sanity check */
-            HDassert((H5F_addr_defined(udata.chunk_block.offset) && udata.chunk_block.length > 0) ||
-                     (!H5F_addr_defined(udata.chunk_block.offset) && udata.chunk_block.length == 0));
+            HDassert((H5_addr_defined(udata.chunk_block.offset) && udata.chunk_block.length > 0) ||
+                     (!H5_addr_defined(udata.chunk_block.offset) && udata.chunk_block.length == 0));
 
             /* Check for non-existent chunk & skip it if appropriate */
-            if (H5F_addr_defined(udata.chunk_block.offset)) {
+            if (H5_addr_defined(udata.chunk_block.offset)) {
                 /* Add chunk to list for selection I/O, if not performing multi dataset I/O */
                 if (H5D_LAYOUT_CB_PERFORM_IO(io_info)) {
                     chunk_mem_spaces[num_chunks]  = chunk_info->mspace;
@@ -2871,11 +2871,11 @@ H5D__chunk_read(H5D_io_info_t *io_info, H5D_dset_io_info_t *dset_info)
                 HGOTO_ERROR(H5E_DATASET, H5E_CANTGET, FAIL, "error looking up chunk address")
 
             /* Sanity check */
-            HDassert((H5F_addr_defined(udata.chunk_block.offset) && udata.chunk_block.length > 0) ||
-                     (!H5F_addr_defined(udata.chunk_block.offset) && udata.chunk_block.length == 0));
+            HDassert((H5_addr_defined(udata.chunk_block.offset) && udata.chunk_block.length > 0) ||
+                     (!H5_addr_defined(udata.chunk_block.offset) && udata.chunk_block.length == 0));
 
             /* Check for non-existent chunk & skip it if appropriate */
-            if (H5F_addr_defined(udata.chunk_block.offset) || UINT_MAX != udata.idx_hint ||
+            if (H5_addr_defined(udata.chunk_block.offset) || UINT_MAX != udata.idx_hint ||
                 !skip_missing_chunks) {
                 H5D_io_info_t *chk_io_info;  /* Pointer to I/O info object for this chunk */
                 void          *chunk = NULL; /* Pointer to locked chunk buffer */
@@ -2906,7 +2906,7 @@ H5D__chunk_read(H5D_io_info_t *io_info, H5D_dset_io_info_t *dset_info)
                     /* Point I/O info at contiguous I/O info for this chunk */
                     chk_io_info = &cpt_io_info;
                 } /* end if */
-                else if (H5F_addr_defined(udata.chunk_block.offset)) {
+                else if (H5_addr_defined(udata.chunk_block.offset)) {
                     /* Set up the storage address information for this chunk */
                     ctg_store.contig.dset_addr = udata.chunk_block.offset;
 
@@ -3077,8 +3077,8 @@ H5D__chunk_write(H5D_io_info_t *io_info, H5D_dset_io_info_t *dset_info)
             HDassert(UINT_MAX == udata.idx_hint);
 
             /* Sanity check */
-            HDassert((H5F_addr_defined(udata.chunk_block.offset) && udata.chunk_block.length > 0) ||
-                     (!H5F_addr_defined(udata.chunk_block.offset) && udata.chunk_block.length == 0));
+            HDassert((H5_addr_defined(udata.chunk_block.offset) && udata.chunk_block.length > 0) ||
+                     (!H5_addr_defined(udata.chunk_block.offset) && udata.chunk_block.length == 0));
 
             /* Set chunk's [scaled] coordinates */
             dset_info->store->chunk.scaled = chunk_info->scaled;
@@ -3125,7 +3125,7 @@ H5D__chunk_write(H5D_io_info_t *io_info, H5D_dset_io_info_t *dset_info)
             } /* end if */
             else {
                 /* If the chunk hasn't been allocated on disk, do so now. */
-                if (!H5F_addr_defined(udata.chunk_block.offset)) {
+                if (!H5_addr_defined(udata.chunk_block.offset)) {
                     /* Compose chunked index info struct */
                     idx_info.f       = dset_info->dset->oloc.file;
                     idx_info.pline   = &(dset_info->dset->shared->dcpl_cache.pline);
@@ -3142,7 +3142,7 @@ H5D__chunk_write(H5D_io_info_t *io_info, H5D_dset_io_info_t *dset_info)
                                     "unable to insert/resize chunk on chunk level")
 
                     /* Make sure the address of the chunk is returned. */
-                    if (!H5F_addr_defined(udata.chunk_block.offset))
+                    if (!H5_addr_defined(udata.chunk_block.offset))
                         HGOTO_ERROR(H5E_DATASET, H5E_CANTGET, FAIL, "chunk address isn't defined")
 
                     /* Cache the new chunk information */
@@ -3235,8 +3235,8 @@ H5D__chunk_write(H5D_io_info_t *io_info, H5D_dset_io_info_t *dset_info)
                 HGOTO_ERROR(H5E_DATASET, H5E_CANTGET, FAIL, "error looking up chunk address")
 
             /* Sanity check */
-            HDassert((H5F_addr_defined(udata.chunk_block.offset) && udata.chunk_block.length > 0) ||
-                     (!H5F_addr_defined(udata.chunk_block.offset) && udata.chunk_block.length == 0));
+            HDassert((H5_addr_defined(udata.chunk_block.offset) && udata.chunk_block.length > 0) ||
+                     (!H5_addr_defined(udata.chunk_block.offset) && udata.chunk_block.length == 0));
 
             /* Set chunk's [scaled] coordinates */
             dset_info->store->chunk.scaled = chunk_info->scaled;
@@ -3274,7 +3274,7 @@ H5D__chunk_write(H5D_io_info_t *io_info, H5D_dset_io_info_t *dset_info)
             } /* end if */
             else {
                 /* If the chunk hasn't been allocated on disk, do so now. */
-                if (!H5F_addr_defined(udata.chunk_block.offset)) {
+                if (!H5_addr_defined(udata.chunk_block.offset)) {
                     /* Compose chunked index info struct */
                     idx_info.f       = dset_info->dset->oloc.file;
                     idx_info.pline   = &(dset_info->dset->shared->dcpl_cache.pline);
@@ -3291,7 +3291,7 @@ H5D__chunk_write(H5D_io_info_t *io_info, H5D_dset_io_info_t *dset_info)
                                     "unable to insert/resize chunk on chunk level")
 
                     /* Make sure the address of the chunk is returned. */
-                    if (!H5F_addr_defined(udata.chunk_block.offset))
+                    if (!H5_addr_defined(udata.chunk_block.offset))
                         HGOTO_ERROR(H5E_DATASET, H5E_CANTGET, FAIL, "chunk address isn't defined")
 
                     /* Cache the new chunk information */
@@ -3998,7 +3998,7 @@ H5D__chunk_flush_entry(const H5D_t *dset, H5D_rdcc_ent_t *ent, hbool_t reset)
             /* Indicate that the chunk must be allocated */
             must_alloc = TRUE;
         } /* end if */
-        else if (!H5F_addr_defined(udata.chunk_block.offset)) {
+        else if (!H5_addr_defined(udata.chunk_block.offset)) {
             /* Indicate that the chunk must be allocated */
             must_alloc = TRUE;
 
@@ -4042,7 +4042,7 @@ H5D__chunk_flush_entry(const H5D_t *dset, H5D_rdcc_ent_t *ent, hbool_t reset)
         } /* end if */
 
         /* Write the data to the file */
-        HDassert(H5F_addr_defined(udata.chunk_block.offset));
+        HDassert(H5_addr_defined(udata.chunk_block.offset));
         H5_CHECK_OVERFLOW(udata.chunk_block.length, hsize_t, size_t);
         if (H5F_shared_block_write(H5F_SHARED(dset->oloc.file), H5FD_MEM_DRAW, udata.chunk_block.offset,
                                    (size_t)udata.chunk_block.length, buf) < 0)
@@ -4516,7 +4516,7 @@ H5D__chunk_lock(const H5D_io_info_t H5_ATTR_NDEBUG_UNUSED *io_info, const H5D_ds
              */
 
             /* Check if the chunk exists on disk */
-            if (H5F_addr_defined(chunk_addr)) {
+            if (H5_addr_defined(chunk_addr)) {
                 size_t my_chunk_alloc = chunk_alloc; /* Allocated buffer size */
                 size_t buf_alloc      = chunk_alloc; /* [Re-]allocated buffer size */
 
@@ -5150,7 +5150,7 @@ H5D__chunk_allocate(const H5D_t *dset, hbool_t full_overwrite, const hsize_t old
 #ifndef NDEBUG
             /* None of the chunks should be allocated */
             if (H5D_CHUNK_IDX_NONE != sc->idx_type)
-                HDassert(!H5F_addr_defined(udata.chunk_block.offset));
+                HDassert(!H5_addr_defined(udata.chunk_block.offset));
 
             /* Make sure the chunk is really in the dataset and outside the
              * original dimensions */
@@ -5235,7 +5235,7 @@ H5D__chunk_allocate(const H5D_t *dset, hbool_t full_overwrite, const hsize_t old
             /* Allocate the chunk (with all processes) */
             if (H5D__chunk_file_alloc(&idx_info, NULL, &udata.chunk_block, &need_insert, scaled) < 0)
                 HGOTO_ERROR(H5E_DATASET, H5E_CANTINSERT, FAIL, "unable to insert/resize chunk on chunk level")
-            HDassert(H5F_addr_defined(udata.chunk_block.offset));
+            HDassert(H5_addr_defined(udata.chunk_block.offset));
 
             /* Check if fill values should be written to chunks */
             if (should_fill) {
@@ -5499,7 +5499,7 @@ H5D__chunk_update_old_edge_chunks(H5D_t *dset, hsize_t old_dim[])
 
             /* If this chunk does not exist in cache or on disk, no need to do
              * anything */
-            if (H5F_addr_defined(chk_udata.chunk_block.offset) || (UINT_MAX != chk_udata.idx_hint)) {
+            if (H5_addr_defined(chk_udata.chunk_block.offset) || (UINT_MAX != chk_udata.idx_hint)) {
                 /* Lock the chunk into cache.  H5D__chunk_lock will take care of
                  * updating the chunk to no longer be an edge chunk. */
                 if (NULL ==
@@ -5817,7 +5817,7 @@ H5D__chunk_cmp_coll_fill_info(const void *_entry1, const void *_entry2)
     entry1 = (const struct chunk_coll_fill_info *)_entry1;
     entry2 = (const struct chunk_coll_fill_info *)_entry2;
 
-    FUNC_LEAVE_NOAPI(H5F_addr_cmp(entry1->addr, entry2->addr))
+    FUNC_LEAVE_NOAPI(H5_addr_cmp(entry1->addr, entry2->addr))
 } /* end H5D__chunk_cmp_coll_fill_info() */
 #endif /* H5_HAVE_PARALLEL */
 
@@ -5865,7 +5865,7 @@ H5D__chunk_prune_fill(H5D_chunk_it_ud1_t *udata, hbool_t new_unfilt_chunk)
     chk_udata.new_unfilt_chunk = new_unfilt_chunk;
 
     /* If this chunk does not exist in cache or on disk, no need to do anything */
-    if (!H5F_addr_defined(chk_udata.chunk_block.offset) && UINT_MAX == chk_udata.idx_hint)
+    if (!H5_addr_defined(chk_udata.chunk_block.offset) && UINT_MAX == chk_udata.idx_hint)
         HGOTO_DONE(SUCCEED)
 
     /* Initialize the fill value buffer, if necessary */
@@ -6310,7 +6310,7 @@ H5D__chunk_prune_by_extent(H5D_t *dset, const hsize_t *old_dim)
                         HGOTO_ERROR(H5E_DATASET, H5E_CANTREMOVE, FAIL, "unable to evict chunk")
 
                 /* Remove the chunk from disk, if present */
-                if (H5F_addr_defined(chk_udata.chunk_block.offset)) {
+                if (H5_addr_defined(chk_udata.chunk_block.offset)) {
                     /* Update the offset in idx_udata */
                     idx_udata.scaled = udata.common.scaled;
 
@@ -6741,7 +6741,7 @@ H5D__chunk_copy_cb(const H5D_chunk_rec_t *chunk_rec, void *_udata)
     } /* end if */
 
     if (udata->chunk_in_cache && udata->chunk) {
-        HDassert(!H5F_addr_defined(chunk_rec->chunk_addr));
+        HDassert(!H5_addr_defined(chunk_rec->chunk_addr));
         H5MM_memcpy(buf, udata->chunk, nbytes);
         udata->chunk = NULL;
     }
@@ -6776,8 +6776,8 @@ H5D__chunk_copy_cb(const H5D_chunk_rec_t *chunk_rec, void *_udata)
             if (NULL == ent)
                 HGOTO_ERROR(H5E_IO, H5E_BADVALUE, H5_ITER_ERROR, "NULL chunk entry pointer")
 
-            HDassert(H5F_addr_defined(chunk_rec->chunk_addr));
-            HDassert(H5F_addr_defined(ent->chunk_block.offset));
+            HDassert(H5_addr_defined(chunk_rec->chunk_addr));
+            HDassert(H5_addr_defined(ent->chunk_block.offset));
 
             H5_CHECKED_ASSIGN(nbytes, size_t, shared_fo->layout.u.chunk.size, uint32_t);
             H5MM_memcpy(buf, ent->chunk, nbytes);
@@ -6880,7 +6880,7 @@ H5D__chunk_copy_cb(const H5D_chunk_rec_t *chunk_rec, void *_udata)
         HGOTO_ERROR(H5E_DATASET, H5E_CANTINSERT, FAIL, "unable to insert/resize chunk on chunk level")
 
     /* Write chunk data to destination file */
-    HDassert(H5F_addr_defined(udata_dst.chunk_block.offset));
+    HDassert(H5_addr_defined(udata_dst.chunk_block.offset));
     if (H5F_block_write(udata->idx_info_dst->f, H5FD_MEM_DRAW, udata_dst.chunk_block.offset, nbytes, buf) < 0)
         HGOTO_ERROR(H5E_DATASET, H5E_WRITEERROR, H5_ITER_ERROR, "unable to write raw data to file")
 
@@ -7143,7 +7143,7 @@ H5D__chunk_copy(H5F_t *f_src, H5O_storage_chunk_t *storage_src, H5O_layout_chunk
         chunk_rec.chunk_addr  = HADDR_UNDEF;
 
         for (ent = shared_fo->cache.chunk.head; ent; ent = next) {
-            if (!H5F_addr_defined(ent->chunk_block.offset)) {
+            if (!H5_addr_defined(ent->chunk_block.offset)) {
                 H5MM_memcpy(chunk_rec.scaled, ent->scaled, sizeof(chunk_rec.scaled));
                 udata.chunk          = ent->chunk;
                 udata.chunk_in_cache = TRUE;
@@ -7213,7 +7213,7 @@ H5D__chunk_bh_info(const H5O_loc_t *loc, H5O_t *oh, H5O_layout_t *layout, hsize_
     /* Check args */
     HDassert(loc);
     HDassert(loc->file);
-    HDassert(H5F_addr_defined(loc->addr));
+    HDassert(H5_addr_defined(loc->addr));
     HDassert(layout);
     H5D_CHUNK_STORAGE_INDEX_CHK(sc);
     HDassert(index_size);
@@ -7628,10 +7628,9 @@ H5D__chunk_file_alloc(const H5D_chk_idx_info_t *idx_info, const H5F_block_t *old
                 HGOTO_ERROR(H5E_DATASET, H5E_BADRANGE, FAIL, "chunk size can't be encoded")
         } /* end block */
 
-        if (old_chunk && H5F_addr_defined(old_chunk->offset)) {
+        if (old_chunk && H5_addr_defined(old_chunk->offset)) {
             /* Sanity check */
-            HDassert(!H5F_addr_defined(new_chunk->offset) ||
-                     H5F_addr_eq(new_chunk->offset, old_chunk->offset));
+            HDassert(!H5_addr_defined(new_chunk->offset) || H5_addr_eq(new_chunk->offset, old_chunk->offset));
 
             /* Check for chunk being same size */
             if (new_chunk->length != old_chunk->length) {
@@ -7647,17 +7646,17 @@ H5D__chunk_file_alloc(const H5D_chk_idx_info_t *idx_info, const H5F_block_t *old
             } /* end if */
             else {
                 /* Don't need to reallocate chunk, but send its address back up */
-                if (!H5F_addr_defined(new_chunk->offset))
+                if (!H5_addr_defined(new_chunk->offset))
                     new_chunk->offset = old_chunk->offset;
             } /* end else */
         }     /* end if */
         else {
-            HDassert(!H5F_addr_defined(new_chunk->offset));
+            HDassert(!H5_addr_defined(new_chunk->offset));
             alloc_chunk = TRUE;
         } /* end else */
     }     /* end if */
     else {
-        HDassert(!H5F_addr_defined(new_chunk->offset));
+        HDassert(!H5_addr_defined(new_chunk->offset));
         HDassert(new_chunk->length == idx_info->layout->size);
         alloc_chunk = TRUE;
     } /* end else */
@@ -7684,7 +7683,7 @@ H5D__chunk_file_alloc(const H5D_chk_idx_info_t *idx_info, const H5F_block_t *old
                 HDassert(new_chunk->length > 0);
                 H5_CHECK_OVERFLOW(new_chunk->length, /*From: */ uint32_t, /*To: */ hsize_t);
                 new_chunk->offset = H5MF_alloc(idx_info->f, H5FD_MEM_DRAW, (hsize_t)new_chunk->length);
-                if (!H5F_addr_defined(new_chunk->offset))
+                if (!H5_addr_defined(new_chunk->offset))
                     HGOTO_ERROR(H5E_DATASET, H5E_CANTALLOC, FAIL, "file allocation failed")
                 *need_insert = TRUE;
                 break;
@@ -7696,7 +7695,7 @@ H5D__chunk_file_alloc(const H5D_chk_idx_info_t *idx_info, const H5F_block_t *old
         } /* end switch */
     }     /* end if */
 
-    HDassert(H5F_addr_defined(new_chunk->offset));
+    HDassert(H5_addr_defined(new_chunk->offset));
 
 done:
     FUNC_LEAVE_NOAPI(ret_value)
@@ -7775,7 +7774,7 @@ H5D__chunk_format_convert_cb(const H5D_chunk_rec_t *chunk_rec, void *_udata)
         /* Allocate space for the filtered chunk */
         if ((chunk_addr = H5MF_alloc(new_idx_info->f, H5FD_MEM_DRAW, (hsize_t)nbytes)) == HADDR_UNDEF)
             HGOTO_ERROR(H5E_DATASET, H5E_NOSPACE, H5_ITER_ERROR, "file allocation failed for filtered chunk")
-        HDassert(H5F_addr_defined(chunk_addr));
+        HDassert(H5_addr_defined(chunk_addr));
 
         /* Write the filtered chunk to disk */
         if (H5F_block_write(new_idx_info->f, H5FD_MEM_DRAW, chunk_addr, nbytes, buf) < 0)
@@ -7910,7 +7909,7 @@ H5D__chunk_index_empty(const H5D_t *dset, hbool_t *empty)
 
     *empty = TRUE;
 
-    if (H5F_addr_defined(idx_info.storage->idx_addr)) {
+    if (H5_addr_defined(idx_info.storage->idx_addr)) {
         /* Iterate over the allocated chunks */
         if ((dset->shared->layout.storage.u.chunk.ops->iterate)(&idx_info, H5D__chunk_index_empty_cb, empty) <
             0)
@@ -8001,7 +8000,7 @@ H5D__get_num_chunks(const H5D_t *dset, const H5S_t H5_ATTR_UNUSED *space, hsize_
     idx_info.storage = &dset->shared->layout.storage.u.chunk;
 
     /* If the dataset is not written, number of chunks will be 0 */
-    if (!H5F_addr_defined(idx_info.storage->idx_addr))
+    if (!H5_addr_defined(idx_info.storage->idx_addr))
         *nchunks = 0;
     else {
         /* Iterate over the allocated chunks */
@@ -8121,7 +8120,7 @@ H5D__get_chunk_info(const H5D_t *dset, const H5S_t H5_ATTR_UNUSED *space, hsize_
         *size = 0;
 
     /* If the chunk is written, get its info, otherwise, return without error */
-    if (H5F_addr_defined(idx_info.storage->idx_addr)) {
+    if (H5_addr_defined(idx_info.storage->idx_addr)) {
         /* Initialize before iteration */
         udata.chunk_idx   = chk_index;
         udata.curr_idx    = 0;
@@ -8149,7 +8148,7 @@ H5D__get_chunk_info(const H5D_t *dset, const H5S_t H5_ATTR_UNUSED *space, hsize_
                 for (ii = 0; ii < udata.ndims; ii++)
                     offset[ii] = udata.scaled[ii] * dset->shared->layout.u.chunk.dim[ii];
         } /* end if */
-    }     /* end if H5F_addr_defined */
+    }     /* end if H5_addr_defined */
 
 done:
     FUNC_LEAVE_NOAPI_TAG(ret_value)
@@ -8260,7 +8259,7 @@ H5D__get_chunk_info_by_coord(const H5D_t *dset, const hsize_t *offset, unsigned 
     idx_info.storage = &dset->shared->layout.storage.u.chunk;
 
     /* If the dataset is not written, return without errors */
-    if (H5F_addr_defined(idx_info.storage->idx_addr)) {
+    if (H5_addr_defined(idx_info.storage->idx_addr)) {
         /* Calculate the scaled of this chunk */
         H5VM_chunk_scaled(dset->shared->ndims, offset, layout->u.chunk.dim, udata.scaled);
         udata.scaled[dset->shared->ndims] = 0;
@@ -8287,7 +8286,7 @@ H5D__get_chunk_info_by_coord(const H5D_t *dset, const hsize_t *offset, unsigned 
             if (size)
                 *size = udata.nbytes;
         } /* end if */
-    }     /* end if H5F_addr_defined */
+    }     /* end if H5_addr_defined */
 
 done:
     FUNC_LEAVE_NOAPI_TAG(ret_value)
@@ -8379,7 +8378,7 @@ H5D__chunk_iter(H5D_t *dset, H5D_chunk_iter_op_t op, void *op_data)
     idx_info.storage = &layout->storage.u.chunk;
 
     /* If the dataset is not written, return without errors */
-    if (H5F_addr_defined(idx_info.storage->idx_addr)) {
+    if (H5_addr_defined(idx_info.storage->idx_addr)) {
         H5D_chunk_iter_ud_t ud;
 
         /* Set up info for iteration callback */
@@ -8390,7 +8389,7 @@ H5D__chunk_iter(H5D_t *dset, H5D_chunk_iter_op_t op, void *op_data)
         /* Iterate over the allocated chunks calling the iterator callback */
         if ((ret_value = (layout->storage.u.chunk.ops->iterate)(&idx_info, H5D__chunk_iter_cb, &ud)) < 0)
             HERROR(H5E_DATASET, H5E_CANTNEXT, "chunk iteration failed");
-    } /* end if H5F_addr_defined */
+    } /* end if H5_addr_defined */
 
 done:
     FUNC_LEAVE_NOAPI_TAG(ret_value)

--- a/src/H5Dcontig.c
+++ b/src/H5Dcontig.c
@@ -212,7 +212,7 @@ H5D__contig_fill(H5D_t *dset)
 
     /* Check args */
     HDassert(dset && H5D_CONTIGUOUS == dset->shared->layout.type);
-    HDassert(H5F_addr_defined(dset->shared->layout.storage.u.contig.addr));
+    HDassert(H5_addr_defined(dset->shared->layout.storage.u.contig.addr));
     HDassert(dset->shared->layout.storage.u.contig.size > 0);
     HDassert(dset->shared->space);
     HDassert(dset->shared->type);
@@ -538,7 +538,7 @@ H5D__contig_is_space_alloc(const H5O_storage_t *storage)
     HDassert(storage);
 
     /* Set return value */
-    ret_value = (hbool_t)H5F_addr_defined(storage->u.contig.addr);
+    ret_value = (hbool_t)H5_addr_defined(storage->u.contig.addr);
 
     FUNC_LEAVE_NOAPI(ret_value)
 } /* end H5D__contig_is_space_alloc() */

--- a/src/H5Dearray.c
+++ b/src/H5Dearray.c
@@ -605,7 +605,7 @@ H5D__earray_crt_dbg_context(H5F_t *f, haddr_t obj_addr)
 
     /* Sanity checks */
     HDassert(f);
-    HDassert(H5F_addr_defined(obj_addr));
+    HDassert(H5_addr_defined(obj_addr));
 
     /* Allocate context for debugging callback */
     if (NULL == (dbg_ctx = H5FL_MALLOC(H5D_earray_ctx_ud_t)))
@@ -716,7 +716,7 @@ H5D__earray_idx_depend(const H5D_chk_idx_info_t *idx_info)
     HDassert(H5D_CHUNK_IDX_EARRAY == idx_info->layout->idx_type);
     HDassert(idx_info->storage);
     HDassert(H5D_CHUNK_IDX_EARRAY == idx_info->storage->idx_type);
-    HDassert(H5F_addr_defined(idx_info->storage->idx_addr));
+    HDassert(H5_addr_defined(idx_info->storage->idx_addr));
     HDassert(idx_info->storage->u.earray.ea);
 
     /* Set up object header location for dataset */
@@ -779,7 +779,7 @@ H5D__earray_idx_open(const H5D_chk_idx_info_t *idx_info)
     HDassert(H5D_CHUNK_IDX_EARRAY == idx_info->layout->idx_type);
     HDassert(idx_info->storage);
     HDassert(H5D_CHUNK_IDX_EARRAY == idx_info->storage->idx_type);
-    HDassert(H5F_addr_defined(idx_info->storage->idx_addr));
+    HDassert(H5_addr_defined(idx_info->storage->idx_addr));
     HDassert(NULL == idx_info->storage->u.earray.ea);
 
     /* Set up the user data */
@@ -832,7 +832,7 @@ H5D__earray_idx_init(const H5D_chk_idx_info_t *idx_info, const H5S_t *space, had
     HDassert(idx_info->layout);
     HDassert(idx_info->storage);
     HDassert(space);
-    HDassert(H5F_addr_defined(dset_ohdr_addr));
+    HDassert(H5_addr_defined(dset_ohdr_addr));
 
     /* Get the dim info for dataset */
     if ((sndims = H5S_get_simple_extent_dims(space, NULL, max_dims)) < 0)
@@ -900,7 +900,7 @@ H5D__earray_idx_create(const H5D_chk_idx_info_t *idx_info)
     HDassert(idx_info->pline);
     HDassert(idx_info->layout);
     HDassert(idx_info->storage);
-    HDassert(!H5F_addr_defined(idx_info->storage->idx_addr));
+    HDassert(!H5_addr_defined(idx_info->storage->idx_addr));
     HDassert(NULL == idx_info->storage->u.earray.ea);
 
     /* General parameters */
@@ -974,7 +974,7 @@ H5D__earray_idx_is_space_alloc(const H5O_storage_chunk_t *storage)
     /* Check args */
     HDassert(storage);
 
-    FUNC_LEAVE_NOAPI((hbool_t)H5F_addr_defined(storage->idx_addr))
+    FUNC_LEAVE_NOAPI((hbool_t)H5_addr_defined(storage->idx_addr))
 } /* end H5D__earray_idx_is_space_alloc() */
 
 /*-------------------------------------------------------------------------
@@ -1003,7 +1003,7 @@ H5D__earray_idx_insert(const H5D_chk_idx_info_t *idx_info, H5D_chunk_ud_t *udata
     HDassert(idx_info->pline);
     HDassert(idx_info->layout);
     HDassert(idx_info->storage);
-    HDassert(H5F_addr_defined(idx_info->storage->idx_addr));
+    HDassert(H5_addr_defined(idx_info->storage->idx_addr));
     HDassert(udata);
 
     /* Check if the extensible array is open yet */
@@ -1018,7 +1018,7 @@ H5D__earray_idx_insert(const H5D_chk_idx_info_t *idx_info, H5D_chunk_ud_t *udata
     /* Set convenience pointer to extensible array structure */
     ea = idx_info->storage->u.earray.ea;
 
-    if (!H5F_addr_defined(udata->chunk_block.offset))
+    if (!H5_addr_defined(udata->chunk_block.offset))
         HGOTO_ERROR(H5E_DATASET, H5E_CANTALLOC, FAIL, "The chunk should have allocated already")
     if (udata->chunk_idx != (udata->chunk_idx & 0xffffffff)) /* negative value */
         HGOTO_ERROR(H5E_ARGS, H5E_BADRANGE, FAIL, "chunk index must be less than 2^32")
@@ -1074,7 +1074,7 @@ H5D__earray_idx_get_addr(const H5D_chk_idx_info_t *idx_info, H5D_chunk_ud_t *uda
     HDassert(idx_info->pline);
     HDassert(idx_info->layout);
     HDassert(idx_info->storage);
-    HDassert(H5F_addr_defined(idx_info->storage->idx_addr));
+    HDassert(H5_addr_defined(idx_info->storage->idx_addr));
     HDassert(udata);
 
     /* Check if the extensible array is open yet */
@@ -1136,7 +1136,7 @@ H5D__earray_idx_get_addr(const H5D_chk_idx_info_t *idx_info, H5D_chunk_ud_t *uda
         udata->filter_mask        = 0;
     } /* end else */
 
-    if (!H5F_addr_defined(udata->chunk_block.offset))
+    if (!H5_addr_defined(udata->chunk_block.offset))
         udata->chunk_block.length = 0;
 
 done:
@@ -1226,7 +1226,7 @@ H5D__earray_idx_iterate_cb(hsize_t H5_ATTR_UNUSED idx, const void *_elmt, void *
         udata->chunk_rec.chunk_addr = *(const haddr_t *)_elmt;
 
     /* Make "generic chunk" callback */
-    if (H5F_addr_defined(udata->chunk_rec.chunk_addr))
+    if (H5_addr_defined(udata->chunk_rec.chunk_addr))
         if ((ret_value = (udata->cb)(&udata->chunk_rec, udata->udata)) < 0)
             HERROR(H5E_DATASET, H5E_CALLBACK, "failure in generic chunk iterator callback");
 
@@ -1283,7 +1283,7 @@ H5D__earray_idx_iterate(const H5D_chk_idx_info_t *idx_info, H5D_chunk_cb_func_t 
     HDassert(idx_info->pline);
     HDassert(idx_info->layout);
     HDassert(idx_info->storage);
-    HDassert(H5F_addr_defined(idx_info->storage->idx_addr));
+    HDassert(H5_addr_defined(idx_info->storage->idx_addr));
     HDassert(chunk_cb);
     HDassert(chunk_udata);
 
@@ -1355,7 +1355,7 @@ H5D__earray_idx_remove(const H5D_chk_idx_info_t *idx_info, H5D_chunk_common_ud_t
     HDassert(idx_info->pline);
     HDassert(idx_info->layout);
     HDassert(idx_info->storage);
-    HDassert(H5F_addr_defined(idx_info->storage->idx_addr));
+    HDassert(H5_addr_defined(idx_info->storage->idx_addr));
     HDassert(udata);
 
     /* Check if the extensible array is open yet */
@@ -1402,7 +1402,7 @@ H5D__earray_idx_remove(const H5D_chk_idx_info_t *idx_info, H5D_chunk_common_ud_t
             HGOTO_ERROR(H5E_DATASET, H5E_CANTGET, FAIL, "can't get chunk info")
 
         /* Remove raw data chunk from file if not doing SWMR writes */
-        HDassert(H5F_addr_defined(elmt.addr));
+        HDassert(H5_addr_defined(elmt.addr));
         if (!(H5F_INTENT(idx_info->f) & H5F_ACC_SWMR_WRITE)) {
             H5_CHECK_OVERFLOW(elmt.nbytes, /*From: */ uint32_t, /*To: */ hsize_t);
             if (H5MF_xfree(idx_info->f, H5FD_MEM_DRAW, elmt.addr, (hsize_t)elmt.nbytes) < 0)
@@ -1424,7 +1424,7 @@ H5D__earray_idx_remove(const H5D_chk_idx_info_t *idx_info, H5D_chunk_common_ud_t
             HGOTO_ERROR(H5E_DATASET, H5E_CANTGET, FAIL, "can't get chunk address")
 
         /* Remove raw data chunk from file if not doing SWMR writes */
-        HDassert(H5F_addr_defined(addr));
+        HDassert(H5_addr_defined(addr));
         if (!(H5F_INTENT(idx_info->f) & H5F_ACC_SWMR_WRITE)) {
             H5_CHECK_OVERFLOW(idx_info->layout->size, /*From: */ uint32_t, /*To: */ hsize_t);
             if (H5MF_xfree(idx_info->f, H5FD_MEM_DRAW, addr, (hsize_t)idx_info->layout->size) < 0)
@@ -1464,7 +1464,7 @@ H5D__earray_idx_delete_cb(const H5D_chunk_rec_t *chunk_rec, void *_udata)
 
     /* Sanity checks */
     HDassert(chunk_rec);
-    HDassert(H5F_addr_defined(chunk_rec->chunk_addr));
+    HDassert(H5_addr_defined(chunk_rec->chunk_addr));
     HDassert(chunk_rec->nbytes > 0);
     HDassert(f);
 
@@ -1510,7 +1510,7 @@ H5D__earray_idx_delete(const H5D_chk_idx_info_t *idx_info)
     HDassert(idx_info->storage);
 
     /* Check if the index data structure has been allocated */
-    if (H5F_addr_defined(idx_info->storage->idx_addr)) {
+    if (H5_addr_defined(idx_info->storage->idx_addr)) {
         H5D_earray_ctx_ud_t ctx_udata; /* User data for extensible array open call */
 
         /* Iterate over the chunk addresses in the extensible array, deleting each chunk */
@@ -1568,7 +1568,7 @@ H5D__earray_idx_copy_setup(const H5D_chk_idx_info_t *idx_info_src, const H5D_chk
     HDassert(idx_info_dst->pline);
     HDassert(idx_info_dst->layout);
     HDassert(idx_info_dst->storage);
-    HDassert(!H5F_addr_defined(idx_info_dst->storage->idx_addr));
+    HDassert(!H5_addr_defined(idx_info_dst->storage->idx_addr));
 
     /* Check if the source extensible array is open yet */
     if (NULL == idx_info_src->storage->u.earray.ea)
@@ -1582,7 +1582,7 @@ H5D__earray_idx_copy_setup(const H5D_chk_idx_info_t *idx_info_src, const H5D_chk
     /* Create the extensible array that describes chunked storage in the dest. file */
     if (H5D__earray_idx_create(idx_info_dst) < 0)
         HGOTO_ERROR(H5E_DATASET, H5E_CANTINIT, FAIL, "unable to initialize chunked storage")
-    HDassert(H5F_addr_defined(idx_info_dst->storage->idx_addr));
+    HDassert(H5_addr_defined(idx_info_dst->storage->idx_addr));
 
     /* Reset metadata tag */
     H5_END_TAG
@@ -1656,7 +1656,7 @@ H5D__earray_idx_size(const H5D_chk_idx_info_t *idx_info, hsize_t *index_size)
     HDassert(idx_info->pline);
     HDassert(idx_info->layout);
     HDassert(idx_info->storage);
-    HDassert(H5F_addr_defined(idx_info->storage->idx_addr));
+    HDassert(H5_addr_defined(idx_info->storage->idx_addr));
     HDassert(index_size);
 
     /* Open the extensible array in file */

--- a/src/H5Defl.c
+++ b/src/H5Defl.c
@@ -253,7 +253,7 @@ H5D__efl_read(const H5O_efl_t *efl, const H5D_t *dset, haddr_t addr, size_t size
 
     /* Check args */
     HDassert(efl && efl->nused > 0);
-    HDassert(H5F_addr_defined(addr));
+    HDassert(H5_addr_defined(addr));
     HDassert(size < SIZE_MAX);
     HDassert(buf || 0 == size);
 
@@ -341,7 +341,7 @@ H5D__efl_write(const H5O_efl_t *efl, const H5D_t *dset, haddr_t addr, size_t siz
 
     /* Check args */
     HDassert(efl && efl->nused > 0);
-    HDassert(H5F_addr_defined(addr));
+    HDassert(H5_addr_defined(addr));
     HDassert(size < SIZE_MAX);
     HDassert(buf || 0 == size);
 
@@ -582,7 +582,7 @@ H5D__efl_bh_info(H5F_t *f, H5O_efl_t *efl, hsize_t *heap_size)
     /* Check args */
     HDassert(f);
     HDassert(efl);
-    HDassert(H5F_addr_defined(efl->heap_addr));
+    HDassert(H5_addr_defined(efl->heap_addr));
     HDassert(heap_size);
 
     /* Get the size of the local heap for EFL's file list */

--- a/src/H5Dfarray.c
+++ b/src/H5Dfarray.c
@@ -447,7 +447,7 @@ H5D__farray_crt_dbg_context(H5F_t *f, haddr_t obj_addr)
 
     /* Sanity checks */
     HDassert(f);
-    HDassert(H5F_addr_defined(obj_addr));
+    HDassert(H5_addr_defined(obj_addr));
 
     /* Allocate context for debugging callback */
     if (NULL == (dbg_ctx = H5FL_MALLOC(H5D_farray_ctx_ud_t)))
@@ -714,7 +714,7 @@ H5D__farray_idx_depend(const H5D_chk_idx_info_t *idx_info)
     HDassert(H5D_CHUNK_IDX_FARRAY == idx_info->layout->idx_type);
     HDassert(idx_info->storage);
     HDassert(H5D_CHUNK_IDX_FARRAY == idx_info->storage->idx_type);
-    HDassert(H5F_addr_defined(idx_info->storage->idx_addr));
+    HDassert(H5_addr_defined(idx_info->storage->idx_addr));
     HDassert(idx_info->storage->u.farray.fa);
 
     /* Set up object header location for dataset */
@@ -764,7 +764,7 @@ H5D__farray_idx_init(const H5D_chk_idx_info_t *idx_info, const H5S_t H5_ATTR_UNU
     /* Check args */
     HDassert(idx_info);
     HDassert(idx_info->storage);
-    HDassert(H5F_addr_defined(dset_ohdr_addr));
+    HDassert(H5_addr_defined(dset_ohdr_addr));
 
     idx_info->storage->u.farray.dset_ohdr_addr = dset_ohdr_addr;
 
@@ -801,7 +801,7 @@ H5D__farray_idx_open(const H5D_chk_idx_info_t *idx_info)
     HDassert(H5D_CHUNK_IDX_FARRAY == idx_info->layout->idx_type);
     HDassert(idx_info->storage);
     HDassert(H5D_CHUNK_IDX_FARRAY == idx_info->storage->idx_type);
-    HDassert(H5F_addr_defined(idx_info->storage->idx_addr));
+    HDassert(H5_addr_defined(idx_info->storage->idx_addr));
     HDassert(NULL == idx_info->storage->u.farray.fa);
 
     /* Set up the user data */
@@ -856,7 +856,7 @@ H5D__farray_idx_create(const H5D_chk_idx_info_t *idx_info)
     HDassert(idx_info->pline);
     HDassert(idx_info->layout);
     HDassert(idx_info->storage);
-    HDassert(!H5F_addr_defined(idx_info->storage->idx_addr));
+    HDassert(!H5_addr_defined(idx_info->storage->idx_addr));
     HDassert(NULL == idx_info->storage->u.farray.fa);
     HDassert(idx_info->layout->nchunks);
 
@@ -924,7 +924,7 @@ H5D__farray_idx_is_space_alloc(const H5O_storage_chunk_t *storage)
     /* Check args */
     HDassert(storage);
 
-    FUNC_LEAVE_NOAPI((hbool_t)H5F_addr_defined(storage->idx_addr))
+    FUNC_LEAVE_NOAPI((hbool_t)H5_addr_defined(storage->idx_addr))
 } /* end H5D__farray_idx_is_space_alloc() */
 
 /*-------------------------------------------------------------------------
@@ -953,7 +953,7 @@ H5D__farray_idx_insert(const H5D_chk_idx_info_t *idx_info, H5D_chunk_ud_t *udata
     HDassert(idx_info->pline);
     HDassert(idx_info->layout);
     HDassert(idx_info->storage);
-    HDassert(H5F_addr_defined(idx_info->storage->idx_addr));
+    HDassert(H5_addr_defined(idx_info->storage->idx_addr));
     HDassert(udata);
 
     /* Check if the fixed array is open yet */
@@ -968,7 +968,7 @@ H5D__farray_idx_insert(const H5D_chk_idx_info_t *idx_info, H5D_chunk_ud_t *udata
     /* Set convenience pointer to fixed array structure */
     fa = idx_info->storage->u.farray.fa;
 
-    if (!H5F_addr_defined(udata->chunk_block.offset))
+    if (!H5_addr_defined(udata->chunk_block.offset))
         HGOTO_ERROR(H5E_DATASET, H5E_CANTALLOC, FAIL, "The chunk should have allocated already")
     if (udata->chunk_idx != (udata->chunk_idx & 0xffffffff)) /* negative value */
         HGOTO_ERROR(H5E_ARGS, H5E_BADRANGE, FAIL, "chunk index must be less than 2^32")
@@ -1024,7 +1024,7 @@ H5D__farray_idx_get_addr(const H5D_chk_idx_info_t *idx_info, H5D_chunk_ud_t *uda
     HDassert(idx_info->pline);
     HDassert(idx_info->layout);
     HDassert(idx_info->storage);
-    HDassert(H5F_addr_defined(idx_info->storage->idx_addr));
+    HDassert(H5_addr_defined(idx_info->storage->idx_addr));
     HDassert(udata);
 
     /* Check if the fixed array is open yet */
@@ -1068,7 +1068,7 @@ H5D__farray_idx_get_addr(const H5D_chk_idx_info_t *idx_info, H5D_chunk_ud_t *uda
         udata->filter_mask        = 0;
     } /* end else */
 
-    if (!H5F_addr_defined(udata->chunk_block.offset))
+    if (!H5_addr_defined(udata->chunk_block.offset))
         udata->chunk_block.length = 0;
 
 done:
@@ -1109,7 +1109,7 @@ H5D__farray_idx_iterate_cb(hsize_t H5_ATTR_UNUSED idx, const void *_elmt, void *
         udata->chunk_rec.chunk_addr = *(const haddr_t *)_elmt;
 
     /* Make "generic chunk" callback */
-    if (H5F_addr_defined(udata->chunk_rec.chunk_addr))
+    if (H5_addr_defined(udata->chunk_rec.chunk_addr))
         if ((ret_value = (udata->cb)(&udata->chunk_rec, udata->udata)) < 0)
             HERROR(H5E_DATASET, H5E_CALLBACK, "failure in generic chunk iterator callback");
 
@@ -1162,7 +1162,7 @@ H5D__farray_idx_iterate(const H5D_chk_idx_info_t *idx_info, H5D_chunk_cb_func_t 
     HDassert(idx_info->pline);
     HDassert(idx_info->layout);
     HDassert(idx_info->storage);
-    HDassert(H5F_addr_defined(idx_info->storage->idx_addr));
+    HDassert(H5_addr_defined(idx_info->storage->idx_addr));
     HDassert(chunk_cb);
     HDassert(chunk_udata);
 
@@ -1235,7 +1235,7 @@ H5D__farray_idx_remove(const H5D_chk_idx_info_t *idx_info, H5D_chunk_common_ud_t
     HDassert(idx_info->pline);
     HDassert(idx_info->layout);
     HDassert(idx_info->storage);
-    HDassert(H5F_addr_defined(idx_info->storage->idx_addr));
+    HDassert(H5_addr_defined(idx_info->storage->idx_addr));
     HDassert(udata);
 
     /* Check if the fixed array is open yet */
@@ -1264,7 +1264,7 @@ H5D__farray_idx_remove(const H5D_chk_idx_info_t *idx_info, H5D_chunk_common_ud_t
             HGOTO_ERROR(H5E_DATASET, H5E_CANTGET, FAIL, "can't get chunk info")
 
         /* Remove raw data chunk from file if not doing SWMR writes */
-        HDassert(H5F_addr_defined(elmt.addr));
+        HDassert(H5_addr_defined(elmt.addr));
         if (!(H5F_INTENT(idx_info->f) & H5F_ACC_SWMR_WRITE)) {
             H5_CHECK_OVERFLOW(elmt.nbytes, /*From: */ uint32_t, /*To: */ hsize_t);
             if (H5MF_xfree(idx_info->f, H5FD_MEM_DRAW, elmt.addr, (hsize_t)elmt.nbytes) < 0)
@@ -1286,7 +1286,7 @@ H5D__farray_idx_remove(const H5D_chk_idx_info_t *idx_info, H5D_chunk_common_ud_t
             HGOTO_ERROR(H5E_DATASET, H5E_CANTGET, FAIL, "can't get chunk address")
 
         /* Remove raw data chunk from file if not doing SWMR writes */
-        HDassert(H5F_addr_defined(addr));
+        HDassert(H5_addr_defined(addr));
         if (!(H5F_INTENT(idx_info->f) & H5F_ACC_SWMR_WRITE)) {
             H5_CHECK_OVERFLOW(idx_info->layout->size, /*From: */ uint32_t, /*To: */ hsize_t);
             if (H5MF_xfree(idx_info->f, H5FD_MEM_DRAW, addr, (hsize_t)idx_info->layout->size) < 0)
@@ -1326,7 +1326,7 @@ H5D__farray_idx_delete_cb(const H5D_chunk_rec_t *chunk_rec, void *_udata)
 
     /* Sanity checks */
     HDassert(chunk_rec);
-    HDassert(H5F_addr_defined(chunk_rec->chunk_addr));
+    HDassert(H5_addr_defined(chunk_rec->chunk_addr));
     HDassert(chunk_rec->nbytes > 0);
     HDassert(f);
 
@@ -1368,7 +1368,7 @@ H5D__farray_idx_delete(const H5D_chk_idx_info_t *idx_info)
     HDassert(idx_info->storage);
 
     /* Check if the index data structure has been allocated */
-    if (H5F_addr_defined(idx_info->storage->idx_addr)) {
+    if (H5_addr_defined(idx_info->storage->idx_addr)) {
         H5D_farray_ctx_ud_t ctx_udata; /* User data for fixed array open call */
 
         /* Iterate over the chunk addresses in the fixed array, deleting each chunk */
@@ -1426,7 +1426,7 @@ H5D__farray_idx_copy_setup(const H5D_chk_idx_info_t *idx_info_src, const H5D_chk
     HDassert(idx_info_dst->pline);
     HDassert(idx_info_dst->layout);
     HDassert(idx_info_dst->storage);
-    HDassert(!H5F_addr_defined(idx_info_dst->storage->idx_addr));
+    HDassert(!H5_addr_defined(idx_info_dst->storage->idx_addr));
 
     /* Check if the source fixed array is open yet */
     if (NULL == idx_info_src->storage->u.farray.fa)
@@ -1440,7 +1440,7 @@ H5D__farray_idx_copy_setup(const H5D_chk_idx_info_t *idx_info_src, const H5D_chk
     /* Create the fixed array that describes chunked storage in the dest. file */
     if (H5D__farray_idx_create(idx_info_dst) < 0)
         HGOTO_ERROR(H5E_DATASET, H5E_CANTINIT, FAIL, "unable to initialize chunked storage")
-    HDassert(H5F_addr_defined(idx_info_dst->storage->idx_addr));
+    HDassert(H5_addr_defined(idx_info_dst->storage->idx_addr));
 
     /* Reset metadata tag */
     H5_END_TAG
@@ -1514,7 +1514,7 @@ H5D__farray_idx_size(const H5D_chk_idx_info_t *idx_info, hsize_t *index_size)
     HDassert(idx_info->pline);
     HDassert(idx_info->layout);
     HDassert(idx_info->storage);
-    HDassert(H5F_addr_defined(idx_info->storage->idx_addr));
+    HDassert(H5_addr_defined(idx_info->storage->idx_addr));
     HDassert(index_size);
 
     /* Open the fixed array in file */

--- a/src/H5Dint.c
+++ b/src/H5Dint.c
@@ -1361,7 +1361,7 @@ done:
                 } /* end else */
             }     /* end if */
 
-            if (H5F_addr_defined(new_dset->oloc.addr)) {
+            if (H5_addr_defined(new_dset->oloc.addr)) {
                 if (H5O_dec_rc_by_loc(&(new_dset->oloc)) < 0)
                     HDONE_ERROR(H5E_DATASET, H5E_CANTDEC, NULL,
                                 "unable to decrement refcount on newly created object")
@@ -1825,7 +1825,7 @@ H5D__open_oid(H5D_t *dataset, hid_t dapl_id)
 
 done:
     if (ret_value < 0) {
-        if (H5F_addr_defined(dataset->oloc.addr) && H5O_close(&(dataset->oloc), NULL) < 0)
+        if (H5_addr_defined(dataset->oloc.addr) && H5O_close(&(dataset->oloc), NULL) < 0)
             HDONE_ERROR(H5E_DATASET, H5E_CLOSEERROR, FAIL, "unable to release object header")
         if (dataset->shared) {
             if (layout_init)
@@ -2551,7 +2551,7 @@ H5D__get_offset(const H5D_t *dset)
              * an external file, the value will be HADDR_UNDEF.
              */
             if (dset->shared->dcpl_cache.efl.nused == 0 ||
-                H5F_addr_defined(dset->shared->layout.storage.u.contig.addr))
+                H5_addr_defined(dset->shared->layout.storage.u.contig.addr))
                 /* Return the absolute dataset offset from the beginning of file. */
                 ret_value = dset->shared->layout.storage.u.contig.addr + H5F_BASE_ADDR(dset->oloc.file);
             break;
@@ -3326,7 +3326,7 @@ H5D__format_convert(H5D_t *dataset)
             init_new_index = TRUE;
 
             /* If the current chunk index exists */
-            if (H5F_addr_defined(idx_info.storage->idx_addr)) {
+            if (H5_addr_defined(idx_info.storage->idx_addr)) {
 
                 /* Create v1 B-tree chunk index */
                 if ((new_idx_info.storage->ops->create)(&new_idx_info) < 0)
@@ -3395,9 +3395,9 @@ done:
 
         /* Clean up v1 b-tree chunk index */
         if (init_new_index) {
-            if (H5F_addr_defined(new_idx_info.storage->idx_addr)) {
+            if (H5_addr_defined(new_idx_info.storage->idx_addr)) {
                 /* Check for valid address i.e. tag */
-                if (!H5F_addr_defined(dataset->oloc.addr))
+                if (!H5_addr_defined(dataset->oloc.addr))
                     HDONE_ERROR(H5E_DATASET, H5E_BADVALUE, FAIL, "address undefined")
 
                 /* Expunge from cache all v1 B-tree type entries associated with tag */

--- a/src/H5Dmpio.c
+++ b/src/H5Dmpio.c
@@ -2680,7 +2680,7 @@ H5D__cmp_piece_addr(const void *piece_info1, const void *piece_info2)
     addr1 = (*((const H5D_piece_info_t *const *)piece_info1))->faddr;
     addr2 = (*((const H5D_piece_info_t *const *)piece_info2))->faddr;
 
-    FUNC_LEAVE_NOAPI(H5F_addr_cmp(addr1, addr2))
+    FUNC_LEAVE_NOAPI(H5_addr_cmp(addr1, addr2))
 } /* end H5D__cmp_chunk_addr() */
 
 /*-------------------------------------------------------------------------
@@ -2715,23 +2715,23 @@ H5D__cmp_filtered_collective_io_info_entry(const void *filtered_collective_io_in
     addr2 = entry2->chunk_new.offset;
 
     /*
-     * If both chunk addresses are defined, H5F_addr_cmp is safe to use.
+     * If both chunk addresses are defined, H5_addr_cmp is safe to use.
      * Otherwise, if both addresses aren't defined, compared chunk
      * entries based on their chunk index. Finally, if only one chunk
      * address is defined, return the appropriate value based on which
      * is defined.
      */
-    if (H5F_addr_defined(addr1) && H5F_addr_defined(addr2)) {
-        ret_value = H5F_addr_cmp(addr1, addr2);
+    if (H5_addr_defined(addr1) && H5_addr_defined(addr2)) {
+        ret_value = H5_addr_cmp(addr1, addr2);
     }
-    else if (!H5F_addr_defined(addr1) && !H5F_addr_defined(addr2)) {
+    else if (!H5_addr_defined(addr1) && !H5_addr_defined(addr2)) {
         hsize_t chunk_idx1 = entry1->index_info.chunk_idx;
         hsize_t chunk_idx2 = entry2->index_info.chunk_idx;
 
         ret_value = (chunk_idx1 > chunk_idx2) - (chunk_idx1 < chunk_idx2);
     }
     else
-        ret_value = H5F_addr_defined(addr1) ? 1 : -1;
+        ret_value = H5_addr_defined(addr1) ? 1 : -1;
 
     FUNC_LEAVE_NOAPI(ret_value)
 } /* end H5D__cmp_filtered_collective_io_info_entry() */
@@ -2814,23 +2814,23 @@ H5D__cmp_chunk_redistribute_info_orig_owner(const void *_entry1, const void *_en
         haddr_t addr2 = entry2->chunk_block.offset;
 
         /*
-         * If both chunk addresses are defined, H5F_addr_cmp is safe to use.
+         * If both chunk addresses are defined, H5_addr_cmp is safe to use.
          * Otherwise, if both addresses aren't defined, compared chunk
          * entries based on their chunk index. Finally, if only one chunk
          * address is defined, return the appropriate value based on which
          * is defined.
          */
-        if (H5F_addr_defined(addr1) && H5F_addr_defined(addr2)) {
-            ret_value = H5F_addr_cmp(addr1, addr2);
+        if (H5_addr_defined(addr1) && H5_addr_defined(addr2)) {
+            ret_value = H5_addr_cmp(addr1, addr2);
         }
-        else if (!H5F_addr_defined(addr1) && !H5F_addr_defined(addr2)) {
+        else if (!H5_addr_defined(addr1) && !H5_addr_defined(addr2)) {
             hsize_t chunk_idx1 = entry1->chunk_idx;
             hsize_t chunk_idx2 = entry2->chunk_idx;
 
             ret_value = (chunk_idx1 > chunk_idx2) - (chunk_idx1 < chunk_idx2);
         }
         else
-            ret_value = H5F_addr_defined(addr1) ? 1 : -1;
+            ret_value = H5_addr_defined(addr1) ? 1 : -1;
     }
     else
         ret_value = (owner1 > owner2) - (owner1 < owner2);
@@ -3194,7 +3194,7 @@ H5D__mpio_collective_filtered_chunk_io_setup(const H5D_io_info_t *io_info, const
                 haddr_t curr_chunk_offset = local_info_array[i].chunk_current.offset;
                 haddr_t prev_chunk_offset = local_info_array[i - 1].chunk_current.offset;
 
-                if (!H5F_addr_defined(prev_chunk_offset) || !H5F_addr_defined(curr_chunk_offset) ||
+                if (!H5_addr_defined(prev_chunk_offset) || !H5_addr_defined(curr_chunk_offset) ||
                     (curr_chunk_offset < prev_chunk_offset))
                     need_sort = TRUE;
             }
@@ -4201,7 +4201,7 @@ H5D__mpio_collective_filtered_chunk_common_io(H5D_filtered_collective_io_info_t 
             HDassert(chunk_list[i].buf);
 
             if (chunk_list[i].need_read) {
-                if (!H5F_addr_defined(base_read_offset))
+                if (!H5_addr_defined(base_read_offset))
                     base_read_offset = chunk_list[i].chunk_current.offset;
 
                 num_chunks++;
@@ -4357,7 +4357,7 @@ H5D__mpio_collective_filtered_chunk_read(H5D_filtered_collective_io_info_t *chun
          * read it from the file. Instead, just fill the chunk buffer
          * with the fill value if necessary.
          */
-        if (H5F_addr_defined(chunk_list[i].chunk_current.offset)) {
+        if (H5_addr_defined(chunk_list[i].chunk_current.offset)) {
             /* Set first read buffer */
             if (!base_read_buf)
                 base_read_buf = chunk_list[i].buf;
@@ -4579,7 +4579,7 @@ H5D__mpio_collective_filtered_chunk_update(H5D_filtered_collective_io_info_t *ch
          * out fill values to it, make sure to 0-fill its memory buffer
          * so we don't use uninitialized memory.
          */
-        if (!H5F_addr_defined(chunk_list[i].chunk_current.offset) && !should_fill)
+        if (!H5_addr_defined(chunk_list[i].chunk_current.offset) && !should_fill)
             chunk_list[i].buf = H5MM_calloc(chunk_list[i].chunk_buf_size);
         else
             chunk_list[i].buf = H5MM_malloc(chunk_list[i].chunk_buf_size);
@@ -4597,7 +4597,7 @@ H5D__mpio_collective_filtered_chunk_update(H5D_filtered_collective_io_info_t *ch
              * read it from the file. Instead, just fill the chunk buffer
              * with the fill value if fill values are to be written.
              */
-            if (H5F_addr_defined(chunk_list[i].chunk_current.offset)) {
+            if (H5_addr_defined(chunk_list[i].chunk_current.offset)) {
                 /* Set first read buffer */
                 if (!base_read_buf)
                     base_read_buf = chunk_list[i].buf;
@@ -4979,7 +4979,7 @@ H5D__mpio_collective_filtered_chunk_reallocate(H5D_filtered_collective_io_info_t
                 haddr_t curr_chunk_offset = local_chunk->chunk_new.offset;
                 haddr_t prev_chunk_offset = chunk_list[num_local_chunks_processed - 1].chunk_new.offset;
 
-                HDassert(H5F_addr_defined(prev_chunk_offset) && H5F_addr_defined(curr_chunk_offset));
+                HDassert(H5_addr_defined(prev_chunk_offset) && H5_addr_defined(curr_chunk_offset));
                 if (curr_chunk_offset < prev_chunk_offset)
                     need_sort = TRUE;
             }
@@ -5748,7 +5748,7 @@ H5D__mpio_collective_filtered_io_type(H5D_filtered_collective_io_info_t *chunk_l
                      * set the base chunk offset and base chunk
                      * data buffer if we haven't already
                      */
-                    if (!H5F_addr_defined(base_offset)) {
+                    if (!H5_addr_defined(base_offset)) {
 #if H5_CHECK_MPI_VERSION(3, 0)
                         if (MPI_SUCCESS != (mpi_code = MPI_Get_address(chunk_list[i].buf, &base_buf)))
                             HMPI_GOTO_ERROR(FAIL, "MPI_Get_address failed", mpi_code)
@@ -5768,7 +5768,7 @@ H5D__mpio_collective_filtered_io_type(H5D_filtered_collective_io_info_t *chunk_l
                  * Set the current chunk entry's offset in the file, relative to
                  * the first chunk entry
                  */
-                HDassert(H5F_addr_defined(chunk_block->offset));
+                HDassert(H5_addr_defined(chunk_block->offset));
                 file_offset_array[chunk_count] = (MPI_Aint)(chunk_block->offset - base_offset);
 
                 /*

--- a/src/H5Dnone.c
+++ b/src/H5Dnone.c
@@ -126,14 +126,14 @@ H5D__none_idx_create(const H5D_chk_idx_info_t *idx_info)
     HDassert(idx_info->layout);
     HDassert(idx_info->storage);
     HDassert(idx_info->layout->max_nchunks);
-    HDassert(!H5F_addr_defined(idx_info->storage->idx_addr)); /* address of data shouldn't be defined */
+    HDassert(!H5_addr_defined(idx_info->storage->idx_addr)); /* address of data shouldn't be defined */
 
     /* Calculate size of max dataset chunks */
     nbytes = idx_info->layout->max_nchunks * idx_info->layout->size;
 
     /* Allocate space for max dataset chunks */
     addr = H5MF_alloc(idx_info->f, H5FD_MEM_DRAW, nbytes);
-    if (!H5F_addr_defined(addr))
+    if (!H5_addr_defined(addr))
         HGOTO_ERROR(H5E_DATASET, H5E_CANTALLOC, FAIL, "file allocation failed")
 
     /* This is the address of the dataset chunks */
@@ -162,7 +162,7 @@ H5D__none_idx_is_space_alloc(const H5O_storage_chunk_t *storage)
     /* Check args */
     HDassert(storage);
 
-    FUNC_LEAVE_NOAPI((hbool_t)H5F_addr_defined(storage->idx_addr))
+    FUNC_LEAVE_NOAPI((hbool_t)H5_addr_defined(storage->idx_addr))
 } /* end H5D__none_idx_is_space_alloc() */
 
 /*-------------------------------------------------------------------------
@@ -190,7 +190,7 @@ H5D__none_idx_get_addr(const H5D_chk_idx_info_t *idx_info, H5D_chunk_ud_t *udata
     HDassert(idx_info->layout);
     HDassert(idx_info->storage);
     HDassert(udata);
-    HDassert(H5F_addr_defined(idx_info->storage->idx_addr));
+    HDassert(H5_addr_defined(idx_info->storage->idx_addr));
 
     /* Calculate the index of this chunk */
     udata->chunk_idx = H5VM_array_offset_pre((idx_info->layout->ndims - 1), idx_info->layout->max_down_chunks,
@@ -239,7 +239,7 @@ H5D__none_idx_iterate(const H5D_chk_idx_info_t *idx_info, H5D_chunk_cb_func_t ch
     HDassert(idx_info->storage);
     HDassert(chunk_cb);
     HDassert(chunk_udata);
-    HDassert(H5F_addr_defined(idx_info->storage->idx_addr));
+    HDassert(H5_addr_defined(idx_info->storage->idx_addr));
 
     /* Initialize generic chunk record */
     HDmemset(&chunk_rec, 0, sizeof(chunk_rec));
@@ -336,7 +336,7 @@ H5D__none_idx_delete(const H5D_chk_idx_info_t *idx_info)
     HDassert(!idx_info->pline->nused); /* Shouldn't have filter defined on entering here */
     HDassert(idx_info->layout);
     HDassert(idx_info->storage);
-    HDassert(H5F_addr_defined(idx_info->storage->idx_addr)); /* should be defined */
+    HDassert(H5_addr_defined(idx_info->storage->idx_addr)); /* should be defined */
 
     /* chunk size * max # of chunks */
     nbytes = idx_info->layout->max_nchunks * idx_info->layout->size;
@@ -375,7 +375,7 @@ H5D__none_idx_copy_setup(const H5D_chk_idx_info_t H5_ATTR_NDEBUG_UNUSED *idx_inf
     HDassert(!idx_info_src->pline->nused);
     HDassert(idx_info_src->layout);
     HDassert(idx_info_src->storage);
-    HDassert(H5F_addr_defined(idx_info_src->storage->idx_addr));
+    HDassert(H5_addr_defined(idx_info_src->storage->idx_addr));
 
     HDassert(idx_info_dst);
     HDassert(idx_info_dst->f);

--- a/src/H5Doh.c
+++ b/src/H5Doh.c
@@ -366,7 +366,7 @@ H5O__dset_bh_info(const H5O_loc_t *loc, H5O_t *oh, H5_ih_info_t *bh_info)
     /* Sanity check */
     HDassert(loc);
     HDassert(loc->file);
-    HDassert(H5F_addr_defined(loc->addr));
+    HDassert(H5_addr_defined(loc->addr));
     HDassert(oh);
     HDassert(bh_info);
 

--- a/src/H5Dsingle.c
+++ b/src/H5Dsingle.c
@@ -127,7 +127,7 @@ H5D__single_idx_init(const H5D_chk_idx_info_t *idx_info, const H5S_t H5_ATTR_UNU
     if (idx_info->pline->nused) {
         idx_info->layout->flags |= H5O_LAYOUT_CHUNK_SINGLE_INDEX_WITH_FILTER;
 
-        if (!H5F_addr_defined(idx_info->storage->idx_addr)) {
+        if (!H5_addr_defined(idx_info->storage->idx_addr)) {
             idx_info->storage->u.single.nbytes      = 0;
             idx_info->storage->u.single.filter_mask = 0;
         }
@@ -163,7 +163,7 @@ H5D__single_idx_create(const H5D_chk_idx_info_t *idx_info)
     HDassert(idx_info->storage);
     HDassert(idx_info->layout->max_nchunks == idx_info->layout->nchunks);
     HDassert(idx_info->layout->nchunks == 1);
-    HDassert(!H5F_addr_defined(idx_info->storage->idx_addr));
+    HDassert(!H5_addr_defined(idx_info->storage->idx_addr));
 
     if (idx_info->pline->nused)
         HDassert(idx_info->layout->flags & H5O_LAYOUT_CHUNK_SINGLE_INDEX_WITH_FILTER);
@@ -192,7 +192,7 @@ H5D__single_idx_is_space_alloc(const H5O_storage_chunk_t *storage)
     /* Check args */
     HDassert(storage);
 
-    FUNC_LEAVE_NOAPI((hbool_t)H5F_addr_defined(storage->idx_addr))
+    FUNC_LEAVE_NOAPI((hbool_t)H5_addr_defined(storage->idx_addr))
 } /* end H5D__single_idx_is_space_alloc() */
 
 /*-------------------------------------------------------------------------
@@ -224,7 +224,7 @@ H5D__single_idx_insert(const H5D_chk_idx_info_t *idx_info, H5D_chunk_ud_t *udata
     HDassert(udata);
 
     /* Set the address for the chunk */
-    HDassert(H5F_addr_defined(udata->chunk_block.offset));
+    HDassert(H5_addr_defined(udata->chunk_block.offset));
     idx_info->storage->idx_addr = udata->chunk_block.offset;
 
     if (idx_info->pline->nused > 0) {
@@ -278,7 +278,7 @@ H5D__single_idx_get_addr(const H5D_chk_idx_info_t *idx_info, H5D_chunk_ud_t *uda
         udata->chunk_block.length = idx_info->layout->size;
         udata->filter_mask        = 0;
     } /* end else */
-    if (!H5F_addr_defined(udata->chunk_block.offset))
+    if (!H5_addr_defined(udata->chunk_block.offset))
         udata->chunk_block.length = 0;
 
     FUNC_LEAVE_NOAPI(SUCCEED)
@@ -311,7 +311,7 @@ H5D__single_idx_iterate(const H5D_chk_idx_info_t *idx_info, H5D_chunk_cb_func_t 
     HDassert(idx_info->storage);
     HDassert(chunk_cb);
     HDassert(chunk_udata);
-    HDassert(H5F_addr_defined(idx_info->storage->idx_addr));
+    HDassert(H5_addr_defined(idx_info->storage->idx_addr));
 
     /* Initialize generic chunk record */
     HDmemset(&chunk_rec, 0, sizeof(chunk_rec));
@@ -358,7 +358,7 @@ H5D__single_idx_remove(const H5D_chk_idx_info_t *idx_info, H5D_chunk_common_ud_t
     HDassert(idx_info->pline);
     HDassert(idx_info->layout);
     HDassert(idx_info->storage);
-    HDassert(H5F_addr_defined(idx_info->storage->idx_addr));
+    HDassert(H5_addr_defined(idx_info->storage->idx_addr));
 
     if (idx_info->layout->flags & H5O_LAYOUT_CHUNK_SINGLE_INDEX_WITH_FILTER)
         nbytes = idx_info->storage->u.single.nbytes;
@@ -400,10 +400,10 @@ H5D__single_idx_delete(const H5D_chk_idx_info_t *idx_info)
     HDassert(idx_info->layout);
     HDassert(idx_info->storage);
 
-    if (H5F_addr_defined(idx_info->storage->idx_addr))
+    if (H5_addr_defined(idx_info->storage->idx_addr))
         ret_value = H5D__single_idx_remove(idx_info, NULL);
     else
-        HDassert(!H5F_addr_defined(idx_info->storage->idx_addr));
+        HDassert(!H5_addr_defined(idx_info->storage->idx_addr));
 
     FUNC_LEAVE_NOAPI(ret_value)
 } /* end H5D__single_idx_delete() */
@@ -433,7 +433,7 @@ H5D__single_idx_copy_setup(const H5D_chk_idx_info_t H5_ATTR_NDEBUG_UNUSED *idx_i
     HDassert(idx_info_src->pline);
     HDassert(idx_info_src->layout);
     HDassert(idx_info_src->storage);
-    HDassert(H5F_addr_defined(idx_info_src->storage->idx_addr));
+    HDassert(H5_addr_defined(idx_info_src->storage->idx_addr));
 
     HDassert(idx_info_dst);
     HDassert(idx_info_dst->f);

--- a/src/H5EA.c
+++ b/src/H5EA.c
@@ -123,7 +123,7 @@ H5EA__new(H5F_t *f, haddr_t ea_addr, hbool_t from_open, void *ctx_udata)
 
     /* Check arguments */
     HDassert(f);
-    HDassert(H5F_addr_defined(ea_addr));
+    HDassert(H5_addr_defined(ea_addr));
 
     /* Allocate extensible array wrapper */
     if (NULL == (ea = H5FL_CALLOC(H5EA_t)))
@@ -236,7 +236,7 @@ H5EA_open(H5F_t *f, haddr_t ea_addr, void *ctx_udata)
 
     /* Check arguments */
     HDassert(f);
-    HDassert(H5F_addr_defined(ea_addr));
+    HDassert(H5_addr_defined(ea_addr));
 
     /* Allocate and initialize new extensible array wrapper */
     if (NULL == (ea = H5EA__new(f, ea_addr, TRUE, ctx_udata)))
@@ -360,12 +360,12 @@ H5EA__lookup_elmt(const H5EA_t *ea, hsize_t idx, hbool_t will_extend, unsigned t
     *thing_unprot_func = (H5EA__unprotect_func_t)NULL;
 
     /* Check if we should create the index block */
-    if (!H5F_addr_defined(hdr->idx_blk_addr)) {
+    if (!H5_addr_defined(hdr->idx_blk_addr)) {
         /* Check if we are allowed to create the thing */
         if (0 == (thing_acc & H5AC__READ_ONLY_FLAG)) { /* i.e. r/w access */
             /* Create the index block */
             hdr->idx_blk_addr = H5EA__iblock_create(hdr, &stats_changed);
-            if (!H5F_addr_defined(hdr->idx_blk_addr))
+            if (!H5_addr_defined(hdr->idx_blk_addr))
                 HGOTO_ERROR(H5E_EARRAY, H5E_CANTCREATE, FAIL, "unable to create index block")
             hdr_dirty = TRUE;
         } /* end if */
@@ -406,7 +406,7 @@ H5EA__lookup_elmt(const H5EA_t *ea, hsize_t idx, hbool_t will_extend, unsigned t
             HDassert(dblk_idx < iblock->ndblk_addrs);
 
             /* Check if the data block has been allocated on disk yet */
-            if (!H5F_addr_defined(iblock->dblk_addrs[dblk_idx])) {
+            if (!H5_addr_defined(iblock->dblk_addrs[dblk_idx])) {
                 /* Check if we are allowed to create the thing */
                 if (0 == (thing_acc & H5AC__READ_ONLY_FLAG)) { /* i.e. r/w access */
                     haddr_t dblk_addr;                         /* Address of data block created */
@@ -417,7 +417,7 @@ H5EA__lookup_elmt(const H5EA_t *ea, hsize_t idx, hbool_t will_extend, unsigned t
                                (dblk_idx * hdr->sblk_info[sblk_idx].dblk_nelmts);
                     dblk_addr = H5EA__dblock_create(hdr, iblock, &stats_changed, dblk_off,
                                                     hdr->sblk_info[sblk_idx].dblk_nelmts);
-                    if (!H5F_addr_defined(dblk_addr))
+                    if (!H5_addr_defined(dblk_addr))
                         HGOTO_ERROR(H5E_EARRAY, H5E_CANTCREATE, FAIL,
                                     "unable to create extensible array data block")
 
@@ -462,14 +462,14 @@ H5EA__lookup_elmt(const H5EA_t *ea, hsize_t idx, hbool_t will_extend, unsigned t
             sblk_off = sblk_idx - iblock->nsblks;
 
             /* Check if the super block has been allocated on disk yet */
-            if (!H5F_addr_defined(iblock->sblk_addrs[sblk_off])) {
+            if (!H5_addr_defined(iblock->sblk_addrs[sblk_off])) {
                 /* Check if we are allowed to create the thing */
                 if (0 == (thing_acc & H5AC__READ_ONLY_FLAG)) { /* i.e. r/w access */
                     haddr_t sblk_addr;                         /* Address of data block created */
 
                     /* Create super block */
                     sblk_addr = H5EA__sblock_create(hdr, iblock, &stats_changed, sblk_idx);
-                    if (!H5F_addr_defined(sblk_addr))
+                    if (!H5_addr_defined(sblk_addr))
                         HGOTO_ERROR(H5E_EARRAY, H5E_CANTCREATE, FAIL,
                                     "unable to create extensible array super block")
 
@@ -493,7 +493,7 @@ H5EA__lookup_elmt(const H5EA_t *ea, hsize_t idx, hbool_t will_extend, unsigned t
             HDassert(dblk_idx < sblock->ndblks);
 
             /* Check if the data block has been allocated on disk yet */
-            if (!H5F_addr_defined(sblock->dblk_addrs[dblk_idx])) {
+            if (!H5_addr_defined(sblock->dblk_addrs[dblk_idx])) {
                 /* Check if we are allowed to create the thing */
                 if (0 == (thing_acc & H5AC__READ_ONLY_FLAG)) { /* i.e. r/w access */
                     haddr_t dblk_addr;                         /* Address of data block created */
@@ -504,7 +504,7 @@ H5EA__lookup_elmt(const H5EA_t *ea, hsize_t idx, hbool_t will_extend, unsigned t
                                (dblk_idx * hdr->sblk_info[sblk_idx].dblk_nelmts);
                     dblk_addr =
                         H5EA__dblock_create(hdr, sblock, &stats_changed, dblk_off, sblock->dblk_nelmts);
-                    if (!H5F_addr_defined(dblk_addr))
+                    if (!H5_addr_defined(dblk_addr))
                         HGOTO_ERROR(H5E_EARRAY, H5E_CANTCREATE, FAIL,
                                     "unable to create extensible array data block")
 
@@ -955,7 +955,7 @@ H5EA_delete(H5F_t *f, haddr_t ea_addr, void *ctx_udata)
 
     /* Check arguments */
     HDassert(f);
-    HDassert(H5F_addr_defined(ea_addr));
+    HDassert(H5_addr_defined(ea_addr));
 
     /* Lock the array header into memory */
     if (NULL == (hdr = H5EA__hdr_protect(f, ea_addr, ctx_udata, H5AC__NO_FLAGS_SET)))

--- a/src/H5EAcache.c
+++ b/src/H5EAcache.c
@@ -302,7 +302,7 @@ H5EA__cache_hdr_deserialize(const void *_image, size_t len, void *_udata, hbool_
     HDassert(image);
     HDassert(udata);
     HDassert(udata->f);
-    HDassert(H5F_addr_defined(udata->addr));
+    HDassert(H5_addr_defined(udata->addr));
 
     /* Allocate space for the extensible array data structure */
     if (NULL == (hdr = H5EA__hdr_alloc(udata->f)))
@@ -351,7 +351,7 @@ H5EA__cache_hdr_deserialize(const void *_image, size_t len, void *_udata, hbool_
     H5F_addr_decode(udata->f, &image, &hdr->idx_blk_addr); /* Address of index block */
 
     /* Index block statistics */
-    if (H5F_addr_defined(hdr->idx_blk_addr)) {
+    if (H5_addr_defined(hdr->idx_blk_addr)) {
         H5EA_iblock_t iblock; /* Fake index block for computing size */
 
         /* Set index block count for file */
@@ -736,7 +736,7 @@ H5EA__cache_iblock_deserialize(const void *_image, size_t len, void *_udata, hbo
 
     /* Address of header for array that owns this block (just for file integrity checks) */
     H5F_addr_decode(hdr->f, &image, &arr_addr);
-    if (H5F_addr_ne(arr_addr, hdr->addr))
+    if (H5_addr_ne(arr_addr, hdr->addr))
         HGOTO_ERROR(H5E_EARRAY, H5E_BADVALUE, NULL, "wrong extensible array header address")
 
     /* Internal information */
@@ -1036,7 +1036,7 @@ H5EA__cache_sblock_get_initial_load_size(void *_udata, size_t *image_len)
     HDassert(udata);
     HDassert(udata->hdr);
     HDassert(udata->sblk_idx > 0);
-    HDassert(H5F_addr_defined(udata->sblk_addr));
+    HDassert(H5_addr_defined(udata->sblk_addr));
     HDassert(image_len);
 
     /* Set up fake super block for computing size on disk */
@@ -1134,7 +1134,7 @@ H5EA__cache_sblock_deserialize(const void *_image, size_t len, void *_udata, hbo
     HDassert(udata->hdr);
     HDassert(udata->parent);
     HDassert(udata->sblk_idx > 0);
-    HDassert(H5F_addr_defined(udata->sblk_addr));
+    HDassert(H5_addr_defined(udata->sblk_addr));
 
     /* Allocate the extensible array super block */
     if (NULL == (sblock = H5EA__sblock_alloc(udata->hdr, udata->parent, udata->sblk_idx)))
@@ -1159,7 +1159,7 @@ H5EA__cache_sblock_deserialize(const void *_image, size_t len, void *_udata, hbo
 
     /* Address of header for array that owns this block (just for file integrity checks) */
     H5F_addr_decode(udata->hdr->f, &image, &arr_addr);
-    if (H5F_addr_ne(arr_addr, udata->hdr->addr))
+    if (H5_addr_ne(arr_addr, udata->hdr->addr))
         HGOTO_ERROR(H5E_EARRAY, H5E_BADVALUE, NULL, "wrong extensible array header address")
 
     /* Offset of block within the array's address space */
@@ -1560,7 +1560,7 @@ H5EA__cache_dblock_deserialize(const void *_image, size_t H5_ATTR_NDEBUG_UNUSED 
     HDassert(udata->hdr);
     HDassert(udata->parent);
     HDassert(udata->nelmts > 0);
-    HDassert(H5F_addr_defined(udata->dblk_addr));
+    HDassert(H5_addr_defined(udata->dblk_addr));
 
     /* Allocate the extensible array data block */
     if (NULL == (dblock = H5EA__dblock_alloc(udata->hdr, udata->parent, udata->nelmts)))
@@ -1588,7 +1588,7 @@ H5EA__cache_dblock_deserialize(const void *_image, size_t H5_ATTR_NDEBUG_UNUSED 
 
     /* Address of header for array that owns this block (just for file integrity checks) */
     H5F_addr_decode(udata->hdr->f, &image, &arr_addr);
-    if (H5F_addr_ne(arr_addr, udata->hdr->addr))
+    if (H5_addr_ne(arr_addr, udata->hdr->addr))
         HGOTO_ERROR(H5E_EARRAY, H5E_BADVALUE, NULL, "wrong extensible array header address")
 
     /* Offset of block within the array's address space */
@@ -2002,7 +2002,7 @@ H5EA__cache_dblk_page_deserialize(const void *_image, size_t len, void *_udata, 
     HDassert(udata);
     HDassert(udata->hdr);
     HDassert(udata->parent);
-    HDassert(H5F_addr_defined(udata->dblk_page_addr));
+    HDassert(H5_addr_defined(udata->dblk_page_addr));
 
     /* Allocate the extensible array data block page */
     if (NULL == (dblk_page = H5EA__dblk_page_alloc(udata->hdr, udata->parent)))

--- a/src/H5EAdbg.c
+++ b/src/H5EAdbg.c
@@ -91,8 +91,8 @@ H5EA__hdr_debug(H5F_t *f, haddr_t addr, FILE *stream, int indent, int fwidth, co
 
     /* Check arguments */
     HDassert(f);
-    HDassert(H5F_addr_defined(addr));
-    HDassert(H5F_addr_defined(obj_addr));
+    HDassert(H5_addr_defined(addr));
+    HDassert(H5_addr_defined(obj_addr));
     HDassert(stream);
     HDassert(indent >= 0);
     HDassert(fwidth >= 0);
@@ -174,13 +174,13 @@ H5EA__iblock_debug(H5F_t *f, haddr_t H5_ATTR_UNUSED addr, FILE *stream, int inde
 
     /* Check arguments */
     HDassert(f);
-    HDassert(H5F_addr_defined(addr));
+    HDassert(H5_addr_defined(addr));
     HDassert(stream);
     HDassert(indent >= 0);
     HDassert(fwidth >= 0);
     HDassert(cls);
-    HDassert(H5F_addr_defined(hdr_addr));
-    HDassert(H5F_addr_defined(obj_addr));
+    HDassert(H5_addr_defined(hdr_addr));
+    HDassert(H5_addr_defined(obj_addr));
 
     /* Check for debugging context callback available */
     if (cls->crt_dbg_ctx)
@@ -193,7 +193,7 @@ H5EA__iblock_debug(H5F_t *f, haddr_t H5_ATTR_UNUSED addr, FILE *stream, int inde
         HGOTO_ERROR(H5E_EARRAY, H5E_CANTPROTECT, FAIL, "unable to load extensible array header")
 
     /* Sanity check */
-    HDassert(H5F_addr_eq(hdr->idx_blk_addr, addr));
+    HDassert(H5_addr_eq(hdr->idx_blk_addr, addr));
 
     /* Protect index block */
     if (NULL == (iblock = H5EA__iblock_protect(hdr, H5AC__READ_ONLY_FLAG)))
@@ -294,13 +294,13 @@ H5EA__sblock_debug(H5F_t *f, haddr_t addr, FILE *stream, int indent, int fwidth,
 
     /* Check arguments */
     HDassert(f);
-    HDassert(H5F_addr_defined(addr));
+    HDassert(H5_addr_defined(addr));
     HDassert(stream);
     HDassert(indent >= 0);
     HDassert(fwidth >= 0);
     HDassert(cls);
-    HDassert(H5F_addr_defined(hdr_addr));
-    HDassert(H5F_addr_defined(obj_addr));
+    HDassert(H5_addr_defined(hdr_addr));
+    HDassert(H5_addr_defined(obj_addr));
 
     /* Check for debugging context callback available */
     if (cls->crt_dbg_ctx)
@@ -384,13 +384,13 @@ H5EA__dblock_debug(H5F_t *f, haddr_t addr, FILE *stream, int indent, int fwidth,
 
     /* Check arguments */
     HDassert(f);
-    HDassert(H5F_addr_defined(addr));
+    HDassert(H5_addr_defined(addr));
     HDassert(stream);
     HDassert(indent >= 0);
     HDassert(fwidth >= 0);
     HDassert(cls);
-    HDassert(H5F_addr_defined(hdr_addr));
-    HDassert(H5F_addr_defined(obj_addr));
+    HDassert(H5_addr_defined(hdr_addr));
+    HDassert(H5_addr_defined(obj_addr));
     HDassert(dblk_nelmts > 0);
 
     /* Check for debugging context callback available */

--- a/src/H5EAdblkpage.c
+++ b/src/H5EAdblkpage.c
@@ -216,7 +216,7 @@ H5EA__dblk_page_protect(H5EA_hdr_t *hdr, H5EA_sblock_t *parent, haddr_t dblk_pag
 
     /* Sanity check */
     HDassert(hdr);
-    HDassert(H5F_addr_defined(dblk_page_addr));
+    HDassert(H5_addr_defined(dblk_page_addr));
 
     /* only the H5AC__READ_ONLY_FLAG may be set */
     HDassert((flags & (unsigned)(~H5AC__READ_ONLY_FLAG)) == 0);

--- a/src/H5EAdblock.c
+++ b/src/H5EAdblock.c
@@ -213,7 +213,7 @@ H5EA__dblock_create(H5EA_hdr_t *hdr, void *parent, hbool_t *stats_changed, hsize
     ret_value = dblock_addr;
 
 done:
-    if (!H5F_addr_defined(ret_value))
+    if (!H5_addr_defined(ret_value))
         if (dblock) {
             /* Remove from cache, if inserted */
             if (inserted)
@@ -222,7 +222,7 @@ done:
                                 "unable to remove extensible array data block from cache")
 
             /* Release data block's disk space */
-            if (H5F_addr_defined(dblock->addr) &&
+            if (H5_addr_defined(dblock->addr) &&
                 H5MF_xfree(hdr->f, H5FD_MEM_EARRAY_DBLOCK, dblock->addr, (hsize_t)dblock->size) < 0)
                 HDONE_ERROR(H5E_EARRAY, H5E_CANTFREE, HADDR_UNDEF,
                             "unable to release extensible array data block")
@@ -293,7 +293,7 @@ H5EA__dblock_protect(H5EA_hdr_t *hdr, void *parent, haddr_t dblk_addr, size_t db
 
     /* Sanity check */
     HDassert(hdr);
-    HDassert(H5F_addr_defined(dblk_addr));
+    HDassert(H5_addr_defined(dblk_addr));
     HDassert(dblk_nelmts);
 
     /* only the H5AC__READ_ONLY_FLAG may be set */
@@ -395,7 +395,7 @@ H5EA__dblock_delete(H5EA_hdr_t *hdr, void *parent, haddr_t dblk_addr, size_t dbl
     /* Sanity check */
     HDassert(hdr);
     HDassert(parent);
-    HDassert(H5F_addr_defined(dblk_addr));
+    HDassert(H5_addr_defined(dblk_addr));
     HDassert(dblk_nelmts > 0);
 
     /* Protect data block */

--- a/src/H5EAhdr.c
+++ b/src/H5EAhdr.c
@@ -442,7 +442,7 @@ H5EA__hdr_create(H5F_t *f, const H5EA_create_t *cparam, void *ctx_udata)
     ret_value = hdr->addr;
 
 done:
-    if (!H5F_addr_defined(ret_value))
+    if (!H5_addr_defined(ret_value))
         if (hdr) {
             /* Remove from cache, if inserted */
             if (inserted)
@@ -451,7 +451,7 @@ done:
                                 "unable to remove extensible array header from cache")
 
             /* Release header's disk space */
-            if (H5F_addr_defined(hdr->addr) &&
+            if (H5_addr_defined(hdr->addr) &&
                 H5MF_xfree(f, H5FD_MEM_EARRAY_HDR, hdr->addr, (hsize_t)hdr->size) < 0)
                 HDONE_ERROR(H5E_EARRAY, H5E_CANTFREE, HADDR_UNDEF, "unable to free extensible array header")
 
@@ -648,7 +648,7 @@ H5EA__hdr_protect(H5F_t *f, haddr_t ea_addr, void *ctx_udata, unsigned flags)
 
     /* Sanity check */
     HDassert(f);
-    HDassert(H5F_addr_defined(ea_addr));
+    HDassert(H5_addr_defined(ea_addr));
 
     /* only the H5AC__READ_ONLY_FLAG may appear in flags */
     HDassert((flags & (unsigned)(~H5AC__READ_ONLY_FLAG)) == 0);
@@ -751,7 +751,7 @@ H5EA__hdr_delete(H5EA_hdr_t *hdr)
 #endif /* NDEBUG */
 
     /* Check for index block */
-    if (H5F_addr_defined(hdr->idx_blk_addr)) {
+    if (H5_addr_defined(hdr->idx_blk_addr)) {
         /* Delete index block */
         if (H5EA__iblock_delete(hdr) < 0)
             HGOTO_ERROR(H5E_EARRAY, H5E_CANTDELETE, FAIL, "unable to delete extensible array index block")

--- a/src/H5EAiblock.c
+++ b/src/H5EAiblock.c
@@ -243,7 +243,7 @@ H5EA__iblock_create(H5EA_hdr_t *hdr, hbool_t *stats_changed)
     ret_value = iblock_addr;
 
 done:
-    if (!H5F_addr_defined(ret_value))
+    if (!H5_addr_defined(ret_value))
         if (iblock) {
             /* Remove from cache, if inserted */
             if (inserted)
@@ -252,7 +252,7 @@ done:
                                 "unable to remove extensible array index block from cache")
 
             /* Release index block's disk space */
-            if (H5F_addr_defined(iblock->addr) &&
+            if (H5_addr_defined(iblock->addr) &&
                 H5MF_xfree(hdr->f, H5FD_MEM_EARRAY_IBLOCK, iblock->addr, (hsize_t)iblock->size) < 0)
                 HDONE_ERROR(H5E_EARRAY, H5E_CANTFREE, HADDR_UNDEF,
                             "unable to release file space for extensible array index block")
@@ -379,7 +379,7 @@ H5EA__iblock_delete(H5EA_hdr_t *hdr)
 
     /* Sanity check */
     HDassert(hdr);
-    HDassert(H5F_addr_defined(hdr->idx_blk_addr));
+    HDassert(H5_addr_defined(hdr->idx_blk_addr));
 
     /* Protect index block */
     if (NULL == (iblock = H5EA__iblock_protect(hdr, H5AC__NO_FLAGS_SET)))
@@ -397,7 +397,7 @@ H5EA__iblock_delete(H5EA_hdr_t *hdr)
         sblk_idx = dblk_idx = 0;
         for (u = 0; u < iblock->ndblk_addrs; u++) {
             /* Check for data block existing */
-            if (H5F_addr_defined(iblock->dblk_addrs[u])) {
+            if (H5_addr_defined(iblock->dblk_addrs[u])) {
                 /* Delete data block */
                 if (H5EA__dblock_delete(hdr, iblock, iblock->dblk_addrs[u],
                                         hdr->sblk_info[sblk_idx].dblk_nelmts) < 0)
@@ -424,7 +424,7 @@ H5EA__iblock_delete(H5EA_hdr_t *hdr)
         /* Iterate over super blocks */
         for (u = 0; u < iblock->nsblk_addrs; u++) {
             /* Check for data block existing */
-            if (H5F_addr_defined(iblock->sblk_addrs[u])) {
+            if (H5_addr_defined(iblock->sblk_addrs[u])) {
                 /* Delete super block */
                 if (H5EA__sblock_delete(hdr, iblock, iblock->sblk_addrs[u], (unsigned)(u + iblock->nsblks)) <
                     0)

--- a/src/H5EAsblock.c
+++ b/src/H5EAsblock.c
@@ -234,7 +234,7 @@ H5EA__sblock_create(H5EA_hdr_t *hdr, H5EA_iblock_t *parent, hbool_t *stats_chang
     ret_value = sblock_addr;
 
 done:
-    if (!H5F_addr_defined(ret_value))
+    if (!H5_addr_defined(ret_value))
         if (sblock) {
             /* Remove from cache, if inserted */
             if (inserted)
@@ -243,7 +243,7 @@ done:
                                 "unable to remove extensible array super block from cache")
 
             /* Release super block's disk space */
-            if (H5F_addr_defined(sblock->addr) &&
+            if (H5_addr_defined(sblock->addr) &&
                 H5MF_xfree(hdr->f, H5FD_MEM_EARRAY_SBLOCK, sblock->addr, (hsize_t)sblock->size) < 0)
                 HDONE_ERROR(H5E_EARRAY, H5E_CANTFREE, HADDR_UNDEF,
                             "unable to release extensible array super block")
@@ -281,7 +281,7 @@ H5EA__sblock_protect(H5EA_hdr_t *hdr, H5EA_iblock_t *parent, haddr_t sblk_addr, 
 
     /* Sanity check */
     HDassert(hdr);
-    HDassert(H5F_addr_defined(sblk_addr));
+    HDassert(H5_addr_defined(sblk_addr));
 
     /* only the H5AC__READ_ONLY_FLAG may be set */
     HDassert((flags & (unsigned)(~H5AC__READ_ONLY_FLAG)) == 0);
@@ -380,7 +380,7 @@ H5EA__sblock_delete(H5EA_hdr_t *hdr, H5EA_iblock_t *parent, haddr_t sblk_addr, u
 
     /* Sanity check */
     HDassert(hdr);
-    HDassert(H5F_addr_defined(sblk_addr));
+    HDassert(H5_addr_defined(sblk_addr));
 
     /* Protect super block */
     if (NULL == (sblock = H5EA__sblock_protect(hdr, parent, sblk_addr, sblk_idx, H5AC__NO_FLAGS_SET)))
@@ -391,7 +391,7 @@ H5EA__sblock_delete(H5EA_hdr_t *hdr, H5EA_iblock_t *parent, haddr_t sblk_addr, u
     /* Iterate over data blocks */
     for (u = 0; u < sblock->ndblks; u++) {
         /* Check for data block existing */
-        if (H5F_addr_defined(sblock->dblk_addrs[u])) {
+        if (H5_addr_defined(sblock->dblk_addrs[u])) {
             /* Delete data block */
             if (H5EA__dblock_delete(hdr, sblock, sblock->dblk_addrs[u], sblock->dblk_nelmts) < 0)
                 HGOTO_ERROR(H5E_EARRAY, H5E_CANTDELETE, FAIL, "unable to delete extensible array data block")

--- a/src/H5FA.c
+++ b/src/H5FA.c
@@ -112,7 +112,7 @@ H5FA__new(H5F_t *f, haddr_t fa_addr, hbool_t from_open, void *ctx_udata)
 
     /* Check arguments */
     HDassert(f);
-    HDassert(H5F_addr_defined(fa_addr));
+    HDassert(H5_addr_defined(fa_addr));
 
     /* Allocate fixed array wrapper */
     if (NULL == (fa = H5FL_CALLOC(H5FA_t)))
@@ -224,7 +224,7 @@ H5FA_open(H5F_t *f, haddr_t fa_addr, void *ctx_udata)
 
     /* Check arguments */
     HDassert(f);
-    HDassert(H5F_addr_defined(fa_addr));
+    HDassert(H5_addr_defined(fa_addr));
 
     /* Allocate and initialize new fixed array wrapper */
     if (NULL == (fa = H5FA__new(f, fa_addr, TRUE, ctx_udata)))
@@ -331,10 +331,10 @@ H5FA_set(const H5FA_t *fa, hsize_t idx, const void *elmt)
     hdr->f = fa->f;
 
     /* Check if we need to create the fixed array data block */
-    if (!H5F_addr_defined(hdr->dblk_addr)) {
+    if (!H5_addr_defined(hdr->dblk_addr)) {
         /* Create the data block */
         hdr->dblk_addr = H5FA__dblock_create(hdr, &hdr_dirty);
-        if (!H5F_addr_defined(hdr->dblk_addr))
+        if (!H5_addr_defined(hdr->dblk_addr))
             HGOTO_ERROR(H5E_FARRAY, H5E_CANTCREATE, FAIL, "unable to create fixed array data block")
     }
 
@@ -442,14 +442,14 @@ H5FA_get(const H5FA_t *fa, hsize_t idx, void *elmt)
     hdr->f = fa->f;
 
     /* Check if the fixed array data block has been allocated on disk yet */
-    if (!H5F_addr_defined(hdr->dblk_addr)) {
+    if (!H5_addr_defined(hdr->dblk_addr)) {
         /* Call the class's 'fill' callback */
         if ((hdr->cparam.cls->fill)(elmt, (size_t)1) < 0)
             HGOTO_ERROR(H5E_FARRAY, H5E_CANTSET, FAIL, "can't set element to class's fill value")
     } /* end if */
     else {
         /* Get the data block */
-        HDassert(H5F_addr_defined(hdr->dblk_addr));
+        HDassert(H5_addr_defined(hdr->dblk_addr));
         if (NULL == (dblock = H5FA__dblock_protect(hdr, hdr->dblk_addr, H5AC__READ_ONLY_FLAG)))
             HGOTO_ERROR(H5E_FARRAY, H5E_CANTPROTECT, FAIL,
                         "unable to protect fixed array data block, address = %llu",
@@ -640,7 +640,7 @@ H5FA_delete(H5F_t *f, haddr_t fa_addr, void *ctx_udata)
 
     /* Check arguments */
     HDassert(f);
-    HDassert(H5F_addr_defined(fa_addr));
+    HDassert(H5_addr_defined(fa_addr));
 
     /* Lock the array header into memory */
     if (NULL == (hdr = H5FA__hdr_protect(f, fa_addr, ctx_udata, H5AC__NO_FLAGS_SET)))

--- a/src/H5FAcache.c
+++ b/src/H5FAcache.c
@@ -248,7 +248,7 @@ H5FA__cache_hdr_deserialize(const void *_image, size_t H5_ATTR_NDEBUG_UNUSED len
     /* Check arguments */
     HDassert(udata);
     HDassert(udata->f);
-    HDassert(H5F_addr_defined(udata->addr));
+    HDassert(H5_addr_defined(udata->addr));
 
     /* Allocate space for the fixed array data structure */
     if (NULL == (hdr = H5FA__hdr_alloc(udata->f)))
@@ -285,7 +285,7 @@ H5FA__cache_hdr_deserialize(const void *_image, size_t H5_ATTR_NDEBUG_UNUSED len
     H5F_addr_decode(udata->f, &image, &hdr->dblk_addr); /* Address of index block */
 
     /* Check for data block */
-    if (H5F_addr_defined(hdr->dblk_addr)) {
+    if (H5_addr_defined(hdr->dblk_addr)) {
         H5FA_dblock_t dblock;           /* Fake data block for computing size */
         size_t        dblk_page_nelmts; /* # of elements per data block page */
 
@@ -676,7 +676,7 @@ H5FA__cache_dblock_deserialize(const void *_image, size_t H5_ATTR_NDEBUG_UNUSED 
 
     /* Address of header for array that owns this block (just for file integrity checks) */
     H5F_addr_decode(udata->hdr->f, &image, &arr_addr);
-    if (H5F_addr_ne(arr_addr, udata->hdr->addr))
+    if (H5_addr_ne(arr_addr, udata->hdr->addr))
         HGOTO_ERROR(H5E_FARRAY, H5E_BADVALUE, NULL, "wrong fixed array header address")
 
     /* Page initialization flags */
@@ -1075,7 +1075,7 @@ H5FA__cache_dblk_page_deserialize(const void *_image, size_t len, void *_udata, 
     HDassert(udata);
     HDassert(udata->hdr);
     HDassert(udata->nelmts > 0);
-    HDassert(H5F_addr_defined(udata->dblk_page_addr));
+    HDassert(H5_addr_defined(udata->dblk_page_addr));
 
     /* Allocate the fixed array data block page */
     if (NULL == (dblk_page = H5FA__dblk_page_alloc(udata->hdr, udata->nelmts)))

--- a/src/H5FAdbg.c
+++ b/src/H5FAdbg.c
@@ -91,8 +91,8 @@ H5FA__hdr_debug(H5F_t *f, haddr_t addr, FILE *stream, int indent, int fwidth, co
 
     /* Check arguments */
     HDassert(f);
-    HDassert(H5F_addr_defined(addr));
-    HDassert(H5F_addr_defined(obj_addr));
+    HDassert(H5_addr_defined(addr));
+    HDassert(H5_addr_defined(obj_addr));
     HDassert(stream);
     HDassert(indent >= 0);
     HDassert(fwidth >= 0);
@@ -164,13 +164,13 @@ H5FA__dblock_debug(H5F_t *f, haddr_t addr, FILE *stream, int indent, int fwidth,
 
     /* Check arguments */
     HDassert(f);
-    HDassert(H5F_addr_defined(addr));
+    HDassert(H5_addr_defined(addr));
     HDassert(stream);
     HDassert(indent >= 0);
     HDassert(fwidth >= 0);
     HDassert(cls);
-    HDassert(H5F_addr_defined(hdr_addr));
-    HDassert(H5F_addr_defined(obj_addr));
+    HDassert(H5_addr_defined(hdr_addr));
+    HDassert(H5_addr_defined(obj_addr));
 
     /* Check for debugging context callback available */
     if (cls->crt_dbg_ctx)

--- a/src/H5FAdblkpage.c
+++ b/src/H5FAdblkpage.c
@@ -227,7 +227,7 @@ H5FA__dblk_page_protect(H5FA_hdr_t *hdr, haddr_t dblk_page_addr, size_t dblk_pag
 
     /* Sanity check */
     HDassert(hdr);
-    HDassert(H5F_addr_defined(dblk_page_addr));
+    HDassert(H5_addr_defined(dblk_page_addr));
 
     /* only the H5AC__READ_ONLY_FLAG is permitted */
     HDassert((flags & (unsigned)(~H5AC__READ_ONLY_FLAG)) == 0);

--- a/src/H5FAdblock.c
+++ b/src/H5FAdblock.c
@@ -228,7 +228,7 @@ H5FA__dblock_create(H5FA_hdr_t *hdr, hbool_t *hdr_dirty)
 
 done:
 
-    if (!H5F_addr_defined(ret_value))
+    if (!H5_addr_defined(ret_value))
         if (dblock) {
             /* Remove from cache, if inserted */
             if (inserted)
@@ -237,7 +237,7 @@ done:
                                 "unable to remove fixed array data block from cache")
 
             /* Release data block's disk space */
-            if (H5F_addr_defined(dblock->addr) &&
+            if (H5_addr_defined(dblock->addr) &&
                 H5MF_xfree(hdr->f, H5FD_MEM_FARRAY_DBLOCK, dblock->addr, (hsize_t)dblock->size) < 0)
                 HDONE_ERROR(H5E_FARRAY, H5E_CANTFREE, HADDR_UNDEF, "unable to release fixed array data block")
 
@@ -272,7 +272,7 @@ H5FA__dblock_protect(H5FA_hdr_t *hdr, haddr_t dblk_addr, unsigned flags)
 
     /* Sanity check */
     HDassert(hdr);
-    HDassert(H5F_addr_defined(dblk_addr));
+    HDassert(H5_addr_defined(dblk_addr));
 
     /* only the H5AC__READ_ONLY_FLAG flag is permitted */
     HDassert((flags & (unsigned)(~H5AC__READ_ONLY_FLAG)) == 0);
@@ -366,7 +366,7 @@ H5FA__dblock_delete(H5FA_hdr_t *hdr, haddr_t dblk_addr)
 
     /* Sanity check */
     HDassert(hdr);
-    HDassert(H5F_addr_defined(dblk_addr));
+    HDassert(H5_addr_defined(dblk_addr));
 
     /* Protect data block */
     if (NULL == (dblock = H5FA__dblock_protect(hdr, dblk_addr, H5AC__NO_FLAGS_SET)))

--- a/src/H5FAhdr.c
+++ b/src/H5FAhdr.c
@@ -230,7 +230,7 @@ H5FA__hdr_create(H5F_t *f, const H5FA_create_t *cparam, void *ctx_udata)
     ret_value = hdr->addr;
 
 done:
-    if (!H5F_addr_defined(ret_value))
+    if (!H5_addr_defined(ret_value))
         if (hdr) {
             /* Remove from cache, if inserted */
             if (inserted)
@@ -239,7 +239,7 @@ done:
                                 "unable to remove fixed array header from cache")
 
             /* Release header's disk space */
-            if (H5F_addr_defined(hdr->addr) &&
+            if (H5_addr_defined(hdr->addr) &&
                 H5MF_xfree(f, H5FD_MEM_FARRAY_HDR, hdr->addr, (hsize_t)hdr->size) < 0)
                 HDONE_ERROR(H5E_FARRAY, H5E_CANTFREE, HADDR_UNDEF, "unable to free Fixed Array header")
 
@@ -434,7 +434,7 @@ H5FA__hdr_protect(H5F_t *f, haddr_t fa_addr, void *ctx_udata, unsigned flags)
 
     /* Sanity check */
     HDassert(f);
-    HDassert(H5F_addr_defined(fa_addr));
+    HDassert(H5_addr_defined(fa_addr));
 
     /* only the H5AC__READ_ONLY_FLAG is permitted */
     HDassert((flags & (unsigned)(~H5AC__READ_ONLY_FLAG)) == 0);
@@ -539,7 +539,7 @@ H5FA__hdr_delete(H5FA_hdr_t *hdr)
 #endif /* NDEBUG */
 
     /* Check for Fixed Array Data block */
-    if (H5F_addr_defined(hdr->dblk_addr)) {
+    if (H5_addr_defined(hdr->dblk_addr)) {
         /* Delete Fixed Array Data block */
         if (H5FA__dblock_delete(hdr, hdr->dblk_addr) < 0)
             HGOTO_ERROR(H5E_FARRAY, H5E_CANTDELETE, FAIL, "unable to delete fixed array data block")

--- a/src/H5FD.c
+++ b/src/H5FD.c
@@ -1217,7 +1217,7 @@ H5FDset_eoa(H5FD_t *file, H5FD_mem_t type, haddr_t addr)
         HGOTO_ERROR(H5E_ARGS, H5E_BADVALUE, FAIL, "file class pointer cannot be NULL")
     if (type < H5FD_MEM_DEFAULT || type >= H5FD_MEM_NTYPES)
         HGOTO_ERROR(H5E_ARGS, H5E_BADVALUE, FAIL, "invalid file type")
-    if (!H5F_addr_defined(addr) || addr > file->maxaddr)
+    if (!H5_addr_defined(addr) || addr > file->maxaddr)
         HGOTO_ERROR(H5E_ARGS, H5E_BADVALUE, FAIL, "invalid end-of-address value")
 
     /* Call private function */
@@ -2307,7 +2307,7 @@ H5FD_set_base_addr(H5FD_t *file, haddr_t base_addr)
 
     /* Sanity checks */
     HDassert(file);
-    HDassert(H5F_addr_defined(base_addr));
+    HDassert(H5_addr_defined(base_addr));
 
     /* Set the file's base address */
     file->base_addr = base_addr;

--- a/src/H5FDcore.c
+++ b/src/H5FDcore.c
@@ -1575,7 +1575,7 @@ H5FD__core_truncate(H5FD_t *_file, hid_t H5_ATTR_UNUSED dxpl_id, hbool_t closing
         } /* end else */
 
         /* Extend the file to make sure it's large enough */
-        if (!H5F_addr_eq(file->eof, (haddr_t)new_eof)) {
+        if (!H5_addr_eq(file->eof, (haddr_t)new_eof)) {
             unsigned char *x; /* Pointer to new buffer for file data */
 
             /* (Re)allocate memory for the file buffer, using callback if available */

--- a/src/H5FDint.c
+++ b/src/H5FDint.c
@@ -2034,7 +2034,7 @@ H5FD_set_eoa(H5FD_t *file, H5FD_mem_t type, haddr_t addr)
     FUNC_ENTER_NOAPI(FAIL)
 
     HDassert(file && file->cls);
-    HDassert(H5F_addr_defined(addr) && addr <= file->maxaddr);
+    HDassert(H5_addr_defined(addr) && addr <= file->maxaddr);
 
     /* Dispatch to driver, convert to absolute address */
     if ((file->cls->set_eoa)(file, type, addr + file->base_addr) < 0)
@@ -2193,13 +2193,13 @@ H5FD__vsrt_tmp_cmp(const void *element_1, const void *element_2)
     FUNC_ENTER_PACKAGE_NOERR
 
     /* Sanity checks */
-    HDassert(H5F_addr_defined(addr_1));
-    HDassert(H5F_addr_defined(addr_2));
+    HDassert(H5_addr_defined(addr_1));
+    HDassert(H5_addr_defined(addr_2));
 
     /* Compare the addresses */
-    if (H5F_addr_gt(addr_1, addr_2))
+    if (H5_addr_gt(addr_1, addr_2))
         ret_value = 1;
-    else if (H5F_addr_lt(addr_1, addr_2))
+    else if (H5_addr_lt(addr_1, addr_2))
         ret_value = -1;
 
     FUNC_LEAVE_NOAPI(ret_value)
@@ -2239,11 +2239,11 @@ H5FD_sort_vector_io_req(hbool_t *vector_was_sorted, uint32_t _count, H5FD_mem_t 
 
     /* scan the addrs array to see if it is sorted */
     for (i = 1; i < count; i++) {
-        HDassert(H5F_addr_defined(addrs[i - 1]));
+        HDassert(H5_addr_defined(addrs[i - 1]));
 
-        if (H5F_addr_gt(addrs[i - 1], addrs[i]))
+        if (H5_addr_gt(addrs[i - 1], addrs[i]))
             break;
-        else if (H5F_addr_eq(addrs[i - 1], addrs[i]))
+        else if (H5_addr_eq(addrs[i - 1], addrs[i]))
             HGOTO_ERROR(H5E_ARGS, H5E_BADVALUE, FAIL, "duplicate addr in vector")
     }
 
@@ -2298,9 +2298,9 @@ H5FD_sort_vector_io_req(hbool_t *vector_was_sorted, uint32_t _count, H5FD_mem_t 
         i = 1;
 
         for (i = 1; i < count; i++) {
-            HDassert(H5F_addr_lt(srt_tmp[i - 1].addr, srt_tmp[i].addr));
+            HDassert(H5_addr_lt(srt_tmp[i - 1].addr, srt_tmp[i].addr));
 
-            if (H5F_addr_eq(addrs[i - 1], addrs[i]))
+            if (H5_addr_eq(addrs[i - 1], addrs[i]))
                 HGOTO_ERROR(H5E_ARGS, H5E_BADVALUE, FAIL, "duplicate addr in vector")
         }
 

--- a/src/H5FDlog.c
+++ b/src/H5FDlog.c
@@ -1051,7 +1051,7 @@ H5FD__log_set_eoa(H5FD_t *_file, H5FD_mem_t type, haddr_t addr)
 
     if (file->fa.flags != 0) {
         /* Check for increasing file size */
-        if (H5F_addr_gt(addr, file->eoa) && H5F_addr_gt(addr, 0)) {
+        if (H5_addr_gt(addr, file->eoa) && H5_addr_gt(addr, 0)) {
             hsize_t size = addr - file->eoa;
 
             /* Retain the flavor of the space allocated by the extension */
@@ -1069,7 +1069,7 @@ H5FD__log_set_eoa(H5FD_t *_file, H5FD_mem_t type, haddr_t addr)
         }
 
         /* Check for decreasing file size */
-        if (H5F_addr_lt(addr, file->eoa) && H5F_addr_gt(addr, 0)) {
+        if (H5_addr_lt(addr, file->eoa) && H5_addr_gt(addr, 0)) {
             hsize_t size = file->eoa - addr;
 
             /* Reset the flavor of the space freed by the shrink */
@@ -1185,7 +1185,7 @@ H5FD__log_read(H5FD_t *_file, H5FD_mem_t type, hid_t H5_ATTR_UNUSED dxpl_id, had
     H5_timer_init(&read_timer);
 
     /* Check for overflow conditions */
-    if (!H5F_addr_defined(addr))
+    if (!H5_addr_defined(addr))
         HGOTO_ERROR(H5E_ARGS, H5E_BADVALUE, FAIL, "addr undefined, addr = %llu", (unsigned long long)addr)
     if (REGION_OVERFLOW(addr, size))
         HGOTO_ERROR(H5E_ARGS, H5E_OVERFLOW, FAIL, "addr overflow, addr = %llu", (unsigned long long)addr)
@@ -1408,7 +1408,7 @@ H5FD__log_write(H5FD_t *_file, H5FD_mem_t type, hid_t H5_ATTR_UNUSED dxpl_id, ha
     }
 
     /* Check for overflow conditions */
-    if (!H5F_addr_defined(addr))
+    if (!H5_addr_defined(addr))
         HGOTO_ERROR(H5E_ARGS, H5E_BADVALUE, FAIL, "addr undefined, addr = %llu", (unsigned long long)addr)
     if (REGION_OVERFLOW(addr, size))
         HGOTO_ERROR(H5E_ARGS, H5E_OVERFLOW, FAIL, "addr overflow, addr = %llu, size = %llu",
@@ -1606,7 +1606,7 @@ H5FD__log_truncate(H5FD_t *_file, hid_t H5_ATTR_UNUSED dxpl_id, hbool_t H5_ATTR_
     HDassert(file);
 
     /* Extend the file to make sure it's large enough */
-    if (!H5F_addr_eq(file->eoa, file->eof)) {
+    if (!H5_addr_eq(file->eoa, file->eof)) {
         H5_timer_t    trunc_timer; /* Timer for truncate operation */
         H5_timevals_t trunc_times; /* Elapsed time for truncate operation */
 

--- a/src/H5FDmpio.c
+++ b/src/H5FDmpio.c
@@ -2878,7 +2878,7 @@ H5FD__mpio_truncate(H5FD_t *_file, hid_t H5_ATTR_UNUSED dxpl_id, hbool_t H5_ATTR
     HDassert(file);
     HDassert(H5FD_MPIO == file->pub.driver_id);
 
-    if (!H5F_addr_eq(file->eoa, file->last_eoa)) {
+    if (!H5_addr_eq(file->eoa, file->last_eoa)) {
         int        mpi_code; /* mpi return code */
         MPI_Offset size;
         MPI_Offset needed_eof;

--- a/src/H5FDsec2.c
+++ b/src/H5FDsec2.c
@@ -695,7 +695,7 @@ H5FD__sec2_read(H5FD_t *_file, H5FD_mem_t H5_ATTR_UNUSED type, hid_t H5_ATTR_UNU
     HDassert(buf);
 
     /* Check for overflow conditions */
-    if (!H5F_addr_defined(addr))
+    if (!H5_addr_defined(addr))
         HGOTO_ERROR(H5E_ARGS, H5E_BADVALUE, FAIL, "addr undefined, addr = %llu", (unsigned long long)addr)
     if (REGION_OVERFLOW(addr, size))
         HGOTO_ERROR(H5E_ARGS, H5E_OVERFLOW, FAIL, "addr overflow, addr = %llu", (unsigned long long)addr)
@@ -803,7 +803,7 @@ H5FD__sec2_write(H5FD_t *_file, H5FD_mem_t H5_ATTR_UNUSED type, hid_t H5_ATTR_UN
     HDassert(buf);
 
     /* Check for overflow conditions */
-    if (!H5F_addr_defined(addr))
+    if (!H5_addr_defined(addr))
         HGOTO_ERROR(H5E_ARGS, H5E_BADVALUE, FAIL, "addr undefined, addr = %llu", (unsigned long long)addr)
     if (REGION_OVERFLOW(addr, size))
         HGOTO_ERROR(H5E_ARGS, H5E_OVERFLOW, FAIL, "addr overflow, addr = %llu, size = %llu",
@@ -904,7 +904,7 @@ H5FD__sec2_truncate(H5FD_t *_file, hid_t H5_ATTR_UNUSED dxpl_id, hbool_t H5_ATTR
     HDassert(file);
 
     /* Extend the file to make sure it's large enough */
-    if (!H5F_addr_eq(file->eoa, file->eof)) {
+    if (!H5_addr_eq(file->eoa, file->eof)) {
 #ifdef H5_HAVE_WIN32_API
         LARGE_INTEGER li;       /* 64-bit (union) integer for SetFilePointer() call */
         DWORD         dwPtrLow; /* Low-order pointer bits from SetFilePointer()

--- a/src/H5FDspace.c
+++ b/src/H5FDspace.c
@@ -105,7 +105,7 @@ H5FD__extend(H5FD_t *file, H5FD_mem_t type, hsize_t size)
     eoa = file->cls->get_eoa(file, type);
 
     /* Check for overflow when extending */
-    if (H5F_addr_overflow(eoa, size) || (eoa + size) > file->maxaddr)
+    if (H5_addr_overflow(eoa, size) || (eoa + size) > file->maxaddr)
         HGOTO_ERROR(H5E_VFL, H5E_NOSPACE, HADDR_UNDEF, "file allocation request failed")
 
     /* Set the [NOT aligned] address to return */
@@ -188,12 +188,12 @@ H5FD__alloc_real(H5FD_t *file, H5FD_mem_t type, hsize_t size, haddr_t *frag_addr
      * size */
     if (file->cls->alloc) {
         ret_value = (file->cls->alloc)(file, type, H5CX_get_dxpl(), use_alloc_size ? size : size + extra);
-        if (!H5F_addr_defined(ret_value))
+        if (!H5_addr_defined(ret_value))
             HGOTO_ERROR(H5E_VFL, H5E_NOSPACE, HADDR_UNDEF, "driver allocation request failed")
     } /* end if */
     else {
         ret_value = H5FD__extend(file, type, size + extra);
-        if (!H5F_addr_defined(ret_value))
+        if (!H5_addr_defined(ret_value))
             HGOTO_ERROR(H5E_VFL, H5E_NOSPACE, HADDR_UNDEF, "driver eoa update request failed")
     } /* end else */
 
@@ -248,7 +248,7 @@ H5FD_alloc(H5FD_t *file, H5FD_mem_t type, H5F_t *f, hsize_t size, haddr_t *frag_
 
     /* Call the real 'alloc' routine */
     ret_value = H5FD__alloc_real(file, type, size, frag_addr, frag_size);
-    if (!H5F_addr_defined(ret_value))
+    if (!H5_addr_defined(ret_value))
         HGOTO_ERROR(H5E_VFL, H5E_CANTALLOC, HADDR_UNDEF, "real 'alloc' request failed")
 
     /* Mark EOA info dirty in cache, so change will get encoded */
@@ -291,14 +291,14 @@ H5FD__free_real(H5FD_t *file, H5FD_mem_t type, haddr_t addr, hsize_t size)
 #endif /* H5FD_ALLOC_DEBUG */
 
     /* Sanity checking */
-    if (!H5F_addr_defined(addr))
+    if (!H5_addr_defined(addr))
         HGOTO_ERROR(H5E_VFL, H5E_BADVALUE, FAIL, "invalid file offset")
 
     /* Convert address to absolute file offset */
     addr += file->base_addr;
 
     /* More sanity checking */
-    if (addr > file->maxaddr || H5F_addr_overflow(addr, size) || (addr + size) > file->maxaddr)
+    if (addr > file->maxaddr || H5_addr_overflow(addr, size) || (addr + size) > file->maxaddr)
         HGOTO_ERROR(H5E_VFL, H5E_BADVALUE, FAIL, "invalid file free space region to free")
 
     /* Check for file driver 'free' callback and call it if available */
@@ -423,7 +423,7 @@ H5FD_try_extend(H5FD_t *file, H5FD_mem_t type, H5F_t *f, haddr_t blk_end, hsize_
     blk_end += file->base_addr;
 
     /* Check if the block is exactly at the end of the file */
-    if (H5F_addr_eq(blk_end, eoa)) {
+    if (H5_addr_eq(blk_end, eoa)) {
         /* Extend the object by extending the underlying file */
         if (HADDR_UNDEF == H5FD__extend(file, type, extra_requested))
             HGOTO_ERROR(H5E_VFL, H5E_CANTEXTEND, FAIL, "driver extend request failed")

--- a/src/H5FDsplitter.c
+++ b/src/H5FDsplitter.c
@@ -616,7 +616,7 @@ H5FD__splitter_read(H5FD_t *_file, H5FD_mem_t H5_ATTR_UNUSED type, hid_t H5_ATTR
     HDassert(buf);
 
     /* Check for overflow conditions */
-    if (!H5F_addr_defined(addr))
+    if (!H5_addr_defined(addr))
         HGOTO_ERROR(H5E_ARGS, H5E_BADVALUE, FAIL, "addr undefined, addr = %llu", (unsigned long long)addr)
     if (REGION_OVERFLOW(addr, size))
         HGOTO_ERROR(H5E_ARGS, H5E_OVERFLOW, FAIL, "addr overflow, addr = %llu", (unsigned long long)addr)

--- a/src/H5FDsubfiling/H5FDioc.c
+++ b/src/H5FDsubfiling/H5FDioc.c
@@ -1213,7 +1213,7 @@ H5FD__ioc_read(H5FD_t *_file, H5FD_mem_t H5_ATTR_UNUSED type, hid_t H5_ATTR_UNUS
     HDassert(buf);
 
     /* Check for overflow conditions */
-    if (!H5F_addr_defined(addr))
+    if (!H5_addr_defined(addr))
         H5_SUBFILING_GOTO_ERROR(H5E_ARGS, H5E_BADVALUE, FAIL, "addr undefined, addr = %" PRIuHADDR, addr);
     if (REGION_OVERFLOW(addr, size))
         H5_SUBFILING_GOTO_ERROR(H5E_ARGS, H5E_OVERFLOW, FAIL, "addr overflow, addr = %" PRIuHADDR, addr);
@@ -1372,7 +1372,7 @@ H5FD__ioc_truncate(H5FD_t *_file, hid_t H5_ATTR_UNUSED dxpl_id, hbool_t H5_ATTR_
     HDassert(file);
 
     /* TODO: placeholder for now since Subfiling does the truncation */
-    if (!H5F_addr_eq(file->eoa, file->last_eoa)) {
+    if (!H5_addr_eq(file->eoa, file->last_eoa)) {
         file->last_eoa = file->eoa;
     }
 

--- a/src/H5FDsubfiling/H5FDsubfiling.c
+++ b/src/H5FDsubfiling/H5FDsubfiling.c
@@ -1589,7 +1589,7 @@ H5FD__subfiling_read(H5FD_t *_file, H5FD_mem_t type, hid_t H5_ATTR_UNUSED dxpl_i
     HDassert(buf);
 
     /* Check for overflow conditions */
-    if (!H5F_addr_defined(addr))
+    if (!H5_addr_defined(addr))
         H5_SUBFILING_GOTO_ERROR(H5E_ARGS, H5E_BADVALUE, FAIL, "addr undefined, addr = %" PRIuHADDR, addr);
     if (REGION_OVERFLOW(addr, size))
         H5_SUBFILING_GOTO_ERROR(H5E_ARGS, H5E_OVERFLOW, FAIL,
@@ -1824,7 +1824,7 @@ H5FD__subfiling_write(H5FD_t *_file, H5FD_mem_t type, hid_t H5_ATTR_UNUSED dxpl_
     HDassert(buf);
 
     /* Check for overflow conditions */
-    if (!H5F_addr_defined(addr))
+    if (!H5_addr_defined(addr))
         H5_SUBFILING_GOTO_ERROR(H5E_ARGS, H5E_BADVALUE, FAIL, "addr undefined, addr = %" PRIuHADDR, addr);
     if (REGION_OVERFLOW(addr, size))
         H5_SUBFILING_GOTO_ERROR(H5E_ARGS, H5E_OVERFLOW, FAIL,
@@ -2393,7 +2393,7 @@ H5FD__subfiling_truncate(H5FD_t *_file, hid_t H5_ATTR_UNUSED dxpl_id, hbool_t H5
     HDassert(file);
 
     /* Extend the file to make sure it's large enough */
-    if (!H5F_addr_eq(file->eoa, file->last_eoa)) {
+    if (!H5_addr_eq(file->eoa, file->last_eoa)) {
         int64_t sf_eof;
         int64_t eoa;
         int     mpi_code;

--- a/src/H5FO.c
+++ b/src/H5FO.c
@@ -116,7 +116,7 @@ H5FO_opened(const H5F_t *f, haddr_t addr)
     HDassert(f);
     HDassert(f->shared);
     HDassert(f->shared->open_objs);
-    HDassert(H5F_addr_defined(addr));
+    HDassert(H5_addr_defined(addr));
 
     /* Get the object node from the container */
     if (NULL != (open_obj = (H5FO_open_obj_t *)H5SL_search(f->shared->open_objs, &addr))) {
@@ -162,7 +162,7 @@ H5FO_insert(const H5F_t *f, haddr_t addr, void *obj, hbool_t delete_flag)
     HDassert(f);
     HDassert(f->shared);
     HDassert(f->shared->open_objs);
-    HDassert(H5F_addr_defined(addr));
+    HDassert(H5_addr_defined(addr));
     HDassert(obj);
 
     /* Allocate new opened object information structure */
@@ -213,7 +213,7 @@ H5FO_delete(H5F_t *f, haddr_t addr)
     HDassert(f);
     HDassert(f->shared);
     HDassert(f->shared->open_objs);
-    HDassert(H5F_addr_defined(addr));
+    HDassert(H5_addr_defined(addr));
 
     /* Remove from container */
     if (NULL == (open_obj = (H5FO_open_obj_t *)H5SL_remove(f->shared->open_objs, &addr)))
@@ -263,7 +263,7 @@ H5FO_mark(const H5F_t *f, haddr_t addr, hbool_t deleted)
     HDassert(f);
     HDassert(f->shared);
     HDassert(f->shared->open_objs);
-    HDassert(H5F_addr_defined(addr));
+    HDassert(H5_addr_defined(addr));
 
     /* Get the object node from the container */
     if (NULL != (open_obj = (H5FO_open_obj_t *)H5SL_search(f->shared->open_objs, &addr)))
@@ -306,7 +306,7 @@ H5FO_marked(const H5F_t *f, haddr_t addr)
     HDassert(f);
     HDassert(f->shared);
     HDassert(f->shared->open_objs);
-    HDassert(H5F_addr_defined(addr));
+    HDassert(H5_addr_defined(addr));
 
     /* Get the object node from the container */
     if (NULL != (open_obj = (H5FO_open_obj_t *)H5SL_search(f->shared->open_objs, &addr)))
@@ -425,7 +425,7 @@ H5FO_top_incr(const H5F_t *f, haddr_t addr)
     /* Sanity check */
     HDassert(f);
     HDassert(f->obj_count);
-    HDassert(H5F_addr_defined(addr));
+    HDassert(H5_addr_defined(addr));
 
     /* Get the object node from the container */
     if (NULL != (obj_count = (H5FO_obj_count_t *)H5SL_search(f->obj_count, &addr))) {
@@ -479,7 +479,7 @@ H5FO_top_decr(const H5F_t *f, haddr_t addr)
     /* Sanity check */
     HDassert(f);
     HDassert(f->obj_count);
-    HDassert(H5F_addr_defined(addr));
+    HDassert(H5_addr_defined(addr));
 
     /* Get the object node from the container */
     if (NULL != (obj_count = (H5FO_obj_count_t *)H5SL_search(f->obj_count, &addr))) {
@@ -532,7 +532,7 @@ H5FO_top_count(const H5F_t *f, haddr_t addr)
     /* Sanity check */
     HDassert(f);
     HDassert(f->obj_count);
-    HDassert(H5F_addr_defined(addr));
+    HDassert(H5_addr_defined(addr));
 
     /* Get the object node from the container */
     if (NULL != (obj_count = (H5FO_obj_count_t *)H5SL_search(f->obj_count, &addr)))

--- a/src/H5FS.c
+++ b/src/H5FS.c
@@ -185,7 +185,7 @@ H5FS_open(H5F_t *f, haddr_t fs_addr, uint16_t nclasses, const H5FS_section_class
 #endif /* H5FS_DEBUG */
 
     /* Check arguments. */
-    HDassert(H5F_addr_defined(fs_addr));
+    HDassert(H5_addr_defined(fs_addr));
     HDassert(nclasses);
     HDassert(classes);
 
@@ -253,7 +253,7 @@ H5FS_delete(H5F_t *f, haddr_t fs_addr)
 
     /* Check arguments. */
     HDassert(f);
-    HDassert(H5F_addr_defined(fs_addr));
+    HDassert(H5_addr_defined(fs_addr));
 
     /* Initialize user data for protecting the free space manager */
     /* (no class information necessary for delete) */
@@ -268,7 +268,7 @@ H5FS_delete(H5F_t *f, haddr_t fs_addr)
         unsigned fspace_status = 0; /* Free space section info's status in the metadata cache */
 
         /* Sanity check */
-        HDassert(H5F_addr_defined(fs_addr));
+        HDassert(H5_addr_defined(fs_addr));
 
         /* Check the free space section info's status in the metadata cache */
         if (H5AC_get_entry_status(f, fs_addr, &fspace_status) < 0)
@@ -324,7 +324,7 @@ H5FS_delete(H5F_t *f, haddr_t fs_addr)
         unsigned sinfo_status = 0; /* Free space section info's status in the metadata cache */
 
         /* Sanity check */
-        HDassert(H5F_addr_defined(fspace->sect_addr));
+        HDassert(H5_addr_defined(fspace->sect_addr));
         HDassert(fspace->alloc_sect_size > 0);
 
         /* Check the free space section info's status in the metadata cache */
@@ -422,13 +422,13 @@ H5FS_close(H5F_t *f, H5FS_t *fspace)
 #endif /* H5FS_DEBUG */
         /* If there are sections to serialize, update them */
         /* (if the free space manager is persistent) */
-        if (fspace->serial_sect_count > 0 && H5F_addr_defined(fspace->addr)) {
+        if (fspace->serial_sect_count > 0 && H5_addr_defined(fspace->addr)) {
 #ifdef H5FS_DEBUG
             HDfprintf(stderr, "%s: Real sections to store in file\n", __func__);
 #endif /* H5FS_DEBUG */
             if (fspace->sinfo->dirty) {
                 /* Check if the section info is "floating" */
-                if (!H5F_addr_defined(fspace->sect_addr)) {
+                if (!H5_addr_defined(fspace->sect_addr)) {
                     /* Sanity check */
                     HDassert(fspace->sect_size > 0);
 
@@ -454,7 +454,7 @@ H5FS_close(H5F_t *f, H5FS_t *fspace)
             }     /* end if */
             else
                 /* Sanity check that section info has address */
-                HDassert(H5F_addr_defined(fspace->sect_addr));
+                HDassert(H5_addr_defined(fspace->sect_addr));
 
             /* Cache the free space section info */
             if (H5AC_insert_entry(f, H5AC_FSPACE_SINFO, fspace->sect_addr, fspace->sinfo,
@@ -466,10 +466,10 @@ H5FS_close(H5F_t *f, H5FS_t *fspace)
             HDfprintf(stderr, "%s: NOT storing section info in file\n", __func__);
 #endif /* H5FS_DEBUG */
             /* Check if space for the section info is allocated */
-            if (H5F_addr_defined(fspace->sect_addr)) {
+            if (H5_addr_defined(fspace->sect_addr)) {
                 /* Sanity check */
                 /* (section info should only be in the file if the header is */
-                HDassert(H5F_addr_defined(fspace->addr));
+                HDassert(H5_addr_defined(fspace->addr));
 
 #ifdef H5FS_DEBUG
                 HDfprintf(stderr, "%s: Section info allocated though\n", __func__);
@@ -567,7 +567,7 @@ H5FS_close(H5F_t *f, H5FS_t *fspace)
         /* Just sanity checks... */
         if (fspace->serial_sect_count > 0)
             /* Sanity check that section info has address */
-            HDassert(H5F_addr_defined(fspace->sect_addr));
+            HDassert(H5_addr_defined(fspace->sect_addr));
     } /* end else */
 
     /* Decrement the reference count on the free space manager header */
@@ -719,7 +719,7 @@ H5FS__incr(H5FS_t *fspace)
     HDassert(fspace);
 
     /* Check if we should pin the header in the cache */
-    if (fspace->rc == 0 && H5F_addr_defined(fspace->addr))
+    if (fspace->rc == 0 && H5_addr_defined(fspace->addr))
         if (H5AC_pin_protected_entry(fspace) < 0)
             HGOTO_ERROR(H5E_FSPACE, H5E_CANTPIN, FAIL, "unable to pin free space header")
 
@@ -763,7 +763,7 @@ H5FS__decr(H5FS_t *fspace)
 
     /* Check if we should unpin the header in the cache */
     if (fspace->rc == 0) {
-        if (H5F_addr_defined(fspace->addr)) {
+        if (H5_addr_defined(fspace->addr)) {
             if (H5AC_unpin_entry(fspace) < 0)
                 HGOTO_ERROR(H5E_FSPACE, H5E_CANTUNPIN, FAIL, "unable to unpin free space header")
         } /* end if */
@@ -800,7 +800,7 @@ H5FS__dirty(H5FS_t *fspace)
     HDassert(fspace);
 
     /* Check if the free space manager is persistent */
-    if (H5F_addr_defined(fspace->addr))
+    if (H5_addr_defined(fspace->addr))
         /* Mark header as dirty in cache */
         if (H5AC_mark_entry_dirty(fspace) < 0)
             HGOTO_ERROR(H5E_FSPACE, H5E_CANTMARKDIRTY, FAIL, "unable to mark free space header as dirty")
@@ -832,7 +832,7 @@ H5FS_alloc_hdr(H5F_t *f, H5FS_t *fspace, haddr_t *fs_addr)
     HDassert(f);
     HDassert(fspace);
 
-    if (!H5F_addr_defined(fspace->addr)) {
+    if (!H5_addr_defined(fspace->addr)) {
         /* Allocate space for the free space header */
         if (HADDR_UNDEF == (fspace->addr = H5MF_alloc(f, H5FD_MEM_FSPACE_HDR, (hsize_t)H5FS_HEADER_SIZE(f))))
             HGOTO_ERROR(H5E_RESOURCE, H5E_NOSPACE, FAIL, "file allocation failed for free space header")
@@ -872,7 +872,7 @@ H5FS_alloc_sect(H5F_t *f, H5FS_t *fspace)
     HDassert(f);
     HDassert(fspace);
 
-    if (!H5F_addr_defined(fspace->sect_addr) && fspace->sinfo && fspace->serial_sect_count > 0) {
+    if (!H5_addr_defined(fspace->sect_addr) && fspace->sinfo && fspace->serial_sect_count > 0) {
         if (HADDR_UNDEF == (fspace->sect_addr = H5MF_alloc(f, H5FD_MEM_FSPACE_SINFO, fspace->sect_size)))
             HGOTO_ERROR(H5E_FSPACE, H5E_NOSPACE, FAIL, "file allocation failed for section info")
         fspace->alloc_sect_size = fspace->sect_size;
@@ -925,7 +925,7 @@ H5FS_free(H5F_t *f, H5FS_t *fspace, hbool_t free_file_space)
     ;
 
     /* Free space for section info */
-    if (H5F_addr_defined(fspace->sect_addr)) {
+    if (H5_addr_defined(fspace->sect_addr)) {
         hsize_t  saved_size;       /* Size of previous section info */
         unsigned sinfo_status = 0; /* Section info cache status */
 
@@ -968,7 +968,7 @@ H5FS_free(H5F_t *f, H5FS_t *fspace, hbool_t free_file_space)
     } /* end if */
 
     /* Free space for header */
-    if (H5F_addr_defined(fspace->addr)) {
+    if (H5_addr_defined(fspace->addr)) {
         unsigned hdr_status = 0; /* Header entry status */
 
         /* Check whether free-space manager header is in cache or not */

--- a/src/H5FScache.c
+++ b/src/H5FScache.c
@@ -394,7 +394,7 @@ H5FS__cache_hdr_pre_serialize(H5F_t *f, void *_thing, haddr_t addr, size_t H5_AT
     HDassert(f);
     HDassert(fspace);
     HDassert(fspace->cache_info.type == H5AC_FSPACE_HDR);
-    HDassert(H5F_addr_defined(addr));
+    HDassert(H5_addr_defined(addr));
     HDassert(new_addr);
     HDassert(new_len);
     HDassert(flags);
@@ -420,7 +420,7 @@ H5FS__cache_hdr_pre_serialize(H5F_t *f, void *_thing, haddr_t addr, size_t H5_AT
          *
          * 1) The instance of H5FS_sinfo_t is not in the metadata cache.
          *
-         *    This will be TRUE iff H5F_addr_defined(fspace->sect_addr)
+         *    This will be TRUE iff H5_addr_defined(fspace->sect_addr)
          *    is FALSE, and fspace->sinfo is not NULL.  This is sometimes
          *    referred to as "floating" section info in the comments.
          *
@@ -431,11 +431,11 @@ H5FS__cache_hdr_pre_serialize(H5F_t *f, void *_thing, haddr_t addr, size_t H5_AT
          *
          *    and
          *
-         *        H5F_addr_defined(fspace->addr)
+         *        H5_addr_defined(fspace->addr)
          *
          *    will both be TRUE.  If this condition does not hold, then
          *    either the free space info is not persistent
-         *    (!H5F_addr_defined(fspace->addr)???) or the section info
+         *    (!H5_addr_defined(fspace->addr)???) or the section info
          *    contains no free space data that must be written to file
          *    ( fspace->serial_sect_count == 0 ).
          *
@@ -455,7 +455,7 @@ H5FS__cache_hdr_pre_serialize(H5F_t *f, void *_thing, haddr_t addr, size_t H5_AT
          * cases 2) and 3), as the section info should not be stored on
          * disk if it doesn't exist.  Similarly, since the section info
          * will not be stored to disk unless the header is,
-         * H5F_addr_defined(fspace->addr) must hold as well.
+         * H5_addr_defined(fspace->addr) must hold as well.
          *
          * As the objective is to touch up the free space manager header
          * so that it contains sensical data on the size and location of
@@ -463,7 +463,7 @@ H5FS__cache_hdr_pre_serialize(H5F_t *f, void *_thing, haddr_t addr, size_t H5_AT
          * cases differently.
          *
          * Case 1) If either fspace->serial_sect_count == 0 or
-         *         ! H5F_addr_defined(fspace->addr) do nothing as either
+         *         ! H5_addr_defined(fspace->addr) do nothing as either
          *         the free space manager data is not persistent, or the
          *         section info is empty.
          *
@@ -487,11 +487,11 @@ H5FS__cache_hdr_pre_serialize(H5F_t *f, void *_thing, haddr_t addr, size_t H5_AT
          * as dirty, as the metadata cache would not be attempting to
          * serialize the header if it thought it was clean.
          */
-        if (fspace->serial_sect_count > 0 && H5F_addr_defined(fspace->addr)) {
+        if (fspace->serial_sect_count > 0 && H5_addr_defined(fspace->addr)) {
             /* Sanity check */
             HDassert(fspace->sect_size > 0);
 
-            if (!H5F_addr_defined(fspace->sect_addr)) { /* case 1 */
+            if (!H5_addr_defined(fspace->sect_addr)) { /* case 1 */
                 haddr_t tag = HADDR_UNDEF;
                 haddr_t sect_addr;
                 hsize_t saved_sect_size, new_sect_size;
@@ -587,10 +587,10 @@ H5FS__cache_hdr_pre_serialize(H5F_t *f, void *_thing, haddr_t addr, size_t H5_AT
             /* for one reason or another (see comment above) there should
              * not be any file space allocated for the section info.
              */
-            HDassert(!H5F_addr_defined(fspace->sect_addr));
+            HDassert(!H5_addr_defined(fspace->sect_addr));
         } /* end else */
     }     /* end if */
-    else if (H5F_addr_defined(fspace->sect_addr)) {
+    else if (H5_addr_defined(fspace->sect_addr)) {
         /* Here the metadata cache is managing the section info.
          *
          * Do some sanity checks, and then test to see if the section
@@ -630,7 +630,7 @@ H5FS__cache_hdr_pre_serialize(H5F_t *f, void *_thing, haddr_t addr, size_t H5_AT
             fspace->alloc_sect_size = (size_t)fspace->sect_size;
 
             /* Sanity check */
-            HDassert(!H5F_addr_eq(fspace->sect_addr, new_sect_addr));
+            HDassert(!H5_addr_eq(fspace->sect_addr, new_sect_addr));
 
             /* Let the metadata cache know the section info moved */
             if (H5AC_move_entry((H5F_t *)f, H5AC_FSPACE_SINFO, fspace->sect_addr, new_sect_addr) < 0)
@@ -702,10 +702,10 @@ H5FS__cache_hdr_serialize(const H5F_t *f, void *_image, size_t H5_ATTR_NDEBUG_UN
      * into real file space if necessary before this function was called.
      * The following asserts are a cursory check on this.
      */
-    HDassert((!H5F_addr_defined(fspace->sect_addr)) || (!H5F_IS_TMP_ADDR(f, fspace->sect_addr)));
+    HDassert((!H5_addr_defined(fspace->sect_addr)) || (!H5F_IS_TMP_ADDR(f, fspace->sect_addr)));
 
     if (!H5F_POINT_OF_NO_RETURN(f))
-        HDassert((!H5F_addr_defined(fspace->sect_addr)) ||
+        HDassert((!H5_addr_defined(fspace->sect_addr)) ||
                  ((fspace->sect_size > 0) && (fspace->alloc_sect_size == (size_t)fspace->sect_size)));
 
     /* Magic number */
@@ -989,7 +989,7 @@ H5FS__cache_sinfo_deserialize(const void *_image, size_t H5_ATTR_NDEBUG_UNUSED l
 
     /* Address of free space header for these sections */
     H5F_addr_decode(udata->f, &image, &fs_addr);
-    if (H5F_addr_ne(fs_addr, fspace->addr))
+    if (H5_addr_ne(fs_addr, fspace->addr))
         HGOTO_ERROR(H5E_FSPACE, H5E_CANTLOAD, NULL, "incorrect header address for free space sections")
 
     /* Check for any serialized sections */
@@ -1161,8 +1161,8 @@ H5FS__cache_sinfo_pre_serialize(H5F_t *f, void *_thing, haddr_t addr, size_t H5_
     fspace = sinfo->fspace;
     HDassert(fspace->cache_info.type == H5AC_FSPACE_HDR);
     HDassert(fspace->cache_info.is_pinned);
-    HDassert(H5F_addr_defined(addr));
-    HDassert(H5F_addr_eq(fspace->sect_addr, addr));
+    HDassert(H5_addr_defined(addr));
+    HDassert(H5_addr_eq(fspace->sect_addr, addr));
     HDassert(fspace->sect_size == len);
     HDassert(new_addr);
     HDassert(new_len);
@@ -1174,7 +1174,7 @@ H5FS__cache_sinfo_pre_serialize(H5F_t *f, void *_thing, haddr_t addr, size_t H5_
     if (H5F_IS_TMP_ADDR(f, fspace->sect_addr)) {
         /* Sanity check */
         HDassert(fspace->sect_size > 0);
-        HDassert(H5F_addr_eq(fspace->sect_addr, addr));
+        HDassert(H5_addr_eq(fspace->sect_addr, addr));
 
         /* Allocate space for the section info in file */
         if (HADDR_UNDEF == (sinfo_addr = H5MF_alloc((H5F_t *)f, H5FD_MEM_FSPACE_SINFO, fspace->sect_size)))
@@ -1183,7 +1183,7 @@ H5FS__cache_sinfo_pre_serialize(H5F_t *f, void *_thing, haddr_t addr, size_t H5_
         fspace->alloc_sect_size = (size_t)fspace->sect_size;
 
         /* Sanity check */
-        HDassert(!H5F_addr_eq(sinfo->fspace->sect_addr, sinfo_addr));
+        HDassert(!H5_addr_eq(sinfo->fspace->sect_addr, sinfo_addr));
 
         /* Let the metadata cache know the section info moved */
         if (H5AC_move_entry((H5F_t *)f, H5AC_FSPACE_SINFO, sinfo->fspace->sect_addr, sinfo_addr) < 0)
@@ -1197,7 +1197,7 @@ H5FS__cache_sinfo_pre_serialize(H5F_t *f, void *_thing, haddr_t addr, size_t H5_
             HGOTO_ERROR(H5E_FSPACE, H5E_CANTMARKDIRTY, FAIL, "unable to mark free space header as dirty")
     } /* end if */
 
-    if (!H5F_addr_eq(addr, sinfo_addr)) {
+    if (!H5_addr_eq(addr, sinfo_addr)) {
         *new_addr = sinfo_addr;
         *flags    = H5C__SERIALIZE_MOVED_FLAG;
     } /* end if */

--- a/src/H5FSdbg.c
+++ b/src/H5FSdbg.c
@@ -91,7 +91,7 @@ H5FS_debug(H5F_t *f, haddr_t addr, FILE *stream, int indent, int fwidth)
      * Check arguments.
      */
     HDassert(f);
-    HDassert(H5F_addr_defined(addr));
+    HDassert(H5_addr_defined(addr));
     HDassert(stream);
     HDassert(indent >= 0);
     HDassert(fwidth >= 0);
@@ -214,12 +214,12 @@ H5FS_sects_debug(H5F_t *f, haddr_t H5_ATTR_UNUSED addr, FILE *stream, int indent
      * Check arguments.
      */
     HDassert(f);
-    HDassert(H5F_addr_defined(addr));
+    HDassert(H5_addr_defined(addr));
     HDassert(stream);
     HDassert(indent >= 0);
     HDassert(fwidth >= 0);
-    HDassert(H5F_addr_defined(fs_addr));
-    HDassert(H5F_addr_defined(client_addr));
+    HDassert(H5_addr_defined(fs_addr));
+    HDassert(H5_addr_defined(client_addr));
 
     /* Initialize user data for protecting the free space manager */
     cache_udata.f              = f;

--- a/src/H5FSsection.c
+++ b/src/H5FSsection.c
@@ -246,10 +246,10 @@ H5FS__sinfo_lock(H5F_t *f, H5FS_t *fspace, unsigned accmode)
     }         /* end if */
     else {
         /* If the section address is defined, load it from the file */
-        if (H5F_addr_defined(fspace->sect_addr)) {
+        if (H5_addr_defined(fspace->sect_addr)) {
             /* Sanity check */
             HDassert(fspace->sinfo_protected == FALSE);
-            HDassert(H5F_addr_defined(fspace->addr));
+            HDassert(H5_addr_defined(fspace->addr));
 
 #ifdef H5FS_SINFO_DEBUG
             HDfprintf(stderr, "%s: Reading in existing sections, fspace->sect_addr = %" PRIuHADDR "\n",
@@ -390,7 +390,7 @@ H5FS__sinfo_unlock(H5F_t *f, H5FS_t *fspace, hbool_t modified)
             unsigned cache_flags = H5AC__NO_FLAGS_SET; /* Flags for unprotecting heap */
 
             /* Sanity check */
-            HDassert(H5F_addr_defined(fspace->addr));
+            HDassert(H5_addr_defined(fspace->addr));
 
             /* Check if we've made new changes to the section info while locked */
             if (fspace->sinfo_modified) {
@@ -412,7 +412,7 @@ H5FS__sinfo_unlock(H5F_t *f, H5FS_t *fspace, hbool_t modified)
             } /* end if */
 
             /* Sanity check */
-            HDassert(H5F_addr_defined(fspace->sect_addr));
+            HDassert(H5_addr_defined(fspace->sect_addr));
 
             /* Unprotect section info in cache */
             /* (Possibly dirty) */
@@ -446,7 +446,7 @@ H5FS__sinfo_unlock(H5F_t *f, H5FS_t *fspace, hbool_t modified)
             /* Check if the section info was modified */
             if (fspace->sinfo_modified) {
                 /* Check if we need to release section info in the file */
-                if (H5F_addr_defined(fspace->sect_addr)) {
+                if (H5_addr_defined(fspace->sect_addr)) {
                     /* Set flag to release section info space in file */
                     /* On file close or flushing, only need to release section info with size
                        bigger than previous section */
@@ -465,7 +465,7 @@ H5FS__sinfo_unlock(H5F_t *f, H5FS_t *fspace, hbool_t modified)
             } /* end if */
             else {
                 /* Sanity checks... */
-                if (H5F_addr_defined(fspace->sect_addr))
+                if (H5_addr_defined(fspace->sect_addr))
                     HDassert(fspace->alloc_sect_size == fspace->sect_size);
                 else
                     HDassert(fspace->alloc_sect_size == 0);
@@ -481,7 +481,7 @@ H5FS__sinfo_unlock(H5F_t *f, H5FS_t *fspace, hbool_t modified)
             hsize_t old_alloc_sect_size = fspace->alloc_sect_size; /* Previous size of section info in file */
 
             /* Sanity check */
-            HDassert(H5F_addr_defined(fspace->addr));
+            HDassert(H5_addr_defined(fspace->addr));
 
             /* Reset section info in header */
             fspace->sect_addr       = HADDR_UNDEF;
@@ -964,7 +964,7 @@ H5FS__sect_link_size(H5FS_sinfo_t *sinfo, const H5FS_section_class_t *cls, H5FS_
     /* Check arguments. */
     HDassert(sinfo);
     HDassert(sect);
-    HDassert(H5F_addr_defined(sect->addr));
+    HDassert(H5_addr_defined(sect->addr));
     HDassert(sect->size);
 
     /* Determine correct bin which holds items of the section's size */
@@ -1154,7 +1154,7 @@ H5FS__sect_merge(H5FS_t *fspace, H5FS_section_info_t **sect, void *op_data)
     /* Check arguments. */
     HDassert(fspace);
     HDassert(*sect);
-    HDassert(H5F_addr_defined((*sect)->addr));
+    HDassert(H5_addr_defined((*sect)->addr));
     HDassert((*sect)->size);
 
     /* Loop until no more merging */
@@ -1357,7 +1357,7 @@ H5FS_sect_add(H5F_t *f, H5FS_t *fspace, H5FS_section_info_t *sect, unsigned flag
     /* Check arguments. */
     HDassert(fspace);
     HDassert(sect);
-    HDassert(H5F_addr_defined(sect->addr));
+    HDassert(H5_addr_defined(sect->addr));
     HDassert(sect->size);
 
     /* Get a pointer to the section info */
@@ -1443,7 +1443,7 @@ H5FS_sect_try_extend(H5F_t *f, H5FS_t *fspace, haddr_t addr, hsize_t size, hsize
     /* Check arguments. */
     HDassert(f);
     HDassert(fspace);
-    HDassert(H5F_addr_defined(addr));
+    HDassert(H5_addr_defined(addr));
     HDassert(size > 0);
     HDassert(extra_requested > 0);
 
@@ -1580,7 +1580,7 @@ H5FS_sect_try_merge(H5F_t *f, H5FS_t *fspace, H5FS_section_info_t *sect, unsigne
     HDassert(f);
     HDassert(fspace);
     HDassert(sect);
-    HDassert(H5F_addr_defined(sect->addr));
+    HDassert(H5_addr_defined(sect->addr));
     HDassert(sect->size);
 
     /* Get a pointer to the section info */
@@ -1708,7 +1708,7 @@ H5FS__sect_find_node(H5FS_t *fspace, hsize_t request, H5FS_section_info_t **node
                         /* Get section node */
                         curr_sect = (H5FS_section_info_t *)H5SL_item(curr_sect_node);
 
-                        HDassert(H5F_addr_defined(curr_sect->addr));
+                        HDassert(H5_addr_defined(curr_sect->addr));
                         HDassert(curr_fspace_node->sect_size == curr_sect->size);
 
                         cls = &fspace->sect_cls[curr_sect->type];
@@ -2216,7 +2216,7 @@ H5FS__sect_assert(const H5FS_t *fspace)
                         cls  = &fspace->sect_cls[sect->type];
 
                         /* Sanity check section */
-                        HDassert(H5F_addr_defined(sect->addr));
+                        HDassert(H5_addr_defined(sect->addr));
                         HDassert(fspace_node->sect_size == sect->size);
                         if (cls->valid)
                             (*cls->valid)(cls, sect);
@@ -2424,7 +2424,7 @@ H5FS_vfd_alloc_hdr_and_section_info_if_needed(H5F_t *f, H5FS_t *fspace, haddr_t 
     if (fspace->serial_sect_count > 0 && fspace->sinfo) {
         /* the section info is floating, so space->sinfo should be defined */
 
-        if (!H5F_addr_defined(fspace->addr)) {
+        if (!H5_addr_defined(fspace->addr)) {
 
             /* start by allocating file space for the header */
 
@@ -2453,7 +2453,7 @@ H5FS_vfd_alloc_hdr_and_section_info_if_needed(H5F_t *f, H5FS_t *fspace, haddr_t 
             *fs_addr_ptr = fspace->addr;
         }
 
-        if (!H5F_addr_defined(fspace->sect_addr)) {
+        if (!H5_addr_defined(fspace->sect_addr)) {
 
             /* now allocate file space for the section info */
 

--- a/src/H5Faccum.c
+++ b/src/H5Faccum.c
@@ -125,8 +125,8 @@ H5F__accum_read(H5F_shared_t *f_sh, H5FD_mem_t map_type, haddr_t addr, size_t si
             HDassert(!accum->buf || (accum->alloc_size >= accum->size));
 
             /* Current read adjoins or overlaps with metadata accumulator */
-            if (H5F_addr_defined(accum->loc) &&
-                (H5F_addr_overlap(addr, size, accum->loc, accum->size) || ((addr + size) == accum->loc) ||
+            if (H5_addr_defined(accum->loc) &&
+                (H5_addr_overlap(addr, size, accum->loc, accum->size) || ((addr + size) == accum->loc) ||
                  (accum->loc + accum->size) == addr)) {
                 size_t  amount_before; /* Amount to read before current accumulator */
                 haddr_t new_addr;      /* New address of the accumulator buffer */
@@ -213,14 +213,14 @@ H5F__accum_read(H5F_shared_t *f_sh, H5FD_mem_t map_type, haddr_t addr, size_t si
              *  just read in. -QAK)
              */
             if (accum->dirty &&
-                H5F_addr_overlap(addr, size, accum->loc + accum->dirty_off, accum->dirty_len)) {
+                H5_addr_overlap(addr, size, accum->loc + accum->dirty_off, accum->dirty_len)) {
                 haddr_t dirty_loc = accum->loc + accum->dirty_off; /* File offset of dirty information */
                 size_t  buf_off;                                   /* Offset of dirty region in buffer */
                 size_t  dirty_off;                                 /* Offset within dirty region */
                 size_t  overlap_size;                              /* Size of overlap with dirty region */
 
                 /* Check for read starting before beginning dirty region */
-                if (H5F_addr_le(addr, dirty_loc)) {
+                if (H5_addr_le(addr, dirty_loc)) {
                     /* Compute offset of dirty region within buffer */
                     buf_off = (size_t)(dirty_loc - addr);
 
@@ -228,7 +228,7 @@ H5F__accum_read(H5F_shared_t *f_sh, H5FD_mem_t map_type, haddr_t addr, size_t si
                     dirty_off = 0;
 
                     /* Check for read ending within dirty region */
-                    if (H5F_addr_lt(addr + size, dirty_loc + accum->dirty_len))
+                    if (H5_addr_lt(addr + size, dirty_loc + accum->dirty_len))
                         overlap_size = (size_t)((addr + size) - buf_off);
                     else /* Access covers whole dirty region */
                         overlap_size = accum->dirty_len;
@@ -439,7 +439,7 @@ H5F__accum_write(H5F_shared_t *f_sh, H5FD_mem_t map_type, haddr_t addr, size_t s
             /* Check if there is already metadata in the accumulator */
             if (accum->size > 0) {
                 /* Check if the new metadata adjoins the beginning of the current accumulator */
-                if (H5F_addr_defined(accum->loc) && (addr + size) == accum->loc) {
+                if (H5_addr_defined(accum->loc) && (addr + size) == accum->loc) {
                     /* Check if we need to adjust accumulator size */
                     if (H5F__accum_adjust(accum, file, H5F_ACCUM_PREPEND, size) < 0)
                         HGOTO_ERROR(H5E_IO, H5E_CANTRESIZE, FAIL, "can't adjust metadata accumulator")
@@ -464,7 +464,7 @@ H5F__accum_write(H5F_shared_t *f_sh, H5FD_mem_t map_type, haddr_t addr, size_t s
                     accum->dirty_off = 0;
                 } /* end if */
                 /* Check if the new metadata adjoins the end of the current accumulator */
-                else if (H5F_addr_defined(accum->loc) && addr == (accum->loc + accum->size)) {
+                else if (H5_addr_defined(accum->loc) && addr == (accum->loc + accum->size)) {
                     /* Check if we need to adjust accumulator size */
                     if (H5F__accum_adjust(accum, file, H5F_ACCUM_APPEND, size) < 0)
                         HGOTO_ERROR(H5E_IO, H5E_CANTRESIZE, FAIL, "can't adjust metadata accumulator")
@@ -485,8 +485,8 @@ H5F__accum_write(H5F_shared_t *f_sh, H5FD_mem_t map_type, haddr_t addr, size_t s
                     accum->size += size;
                 } /* end if */
                 /* Check if the piece of metadata being written overlaps the metadata accumulator */
-                else if (H5F_addr_defined(accum->loc) &&
-                         H5F_addr_overlap(addr, size, accum->loc, accum->size)) {
+                else if (H5_addr_defined(accum->loc) &&
+                         H5_addr_overlap(addr, size, accum->loc, accum->size)) {
                     size_t add_size; /* New size of the accumulator buffer */
 
                     /* Check if the new metadata is entirely within the current accumulator */
@@ -746,11 +746,11 @@ H5F__accum_write(H5F_shared_t *f_sh, H5FD_mem_t map_type, haddr_t addr, size_t s
             /* (Note that this could be improved by updating the accumulator
              *  with [some of] the information just read in. -QAK)
              */
-            if (H5F_addr_defined(accum->loc) && H5F_addr_overlap(addr, size, accum->loc, accum->size)) {
+            if (H5_addr_defined(accum->loc) && H5_addr_overlap(addr, size, accum->loc, accum->size)) {
                 /* Check for write starting before beginning of accumulator */
-                if (H5F_addr_le(addr, accum->loc)) {
+                if (H5_addr_le(addr, accum->loc)) {
                     /* Check for write ending within accumulator */
-                    if (H5F_addr_le(addr + size, accum->loc + accum->size)) {
+                    if (H5_addr_le(addr + size, accum->loc + accum->size)) {
                         size_t overlap_size; /* Size of overlapping region */
 
                         /* Compute overlap size */
@@ -764,13 +764,13 @@ H5F__accum_write(H5F_shared_t *f_sh, H5FD_mem_t map_type, haddr_t addr, size_t s
                                 dirty_start + accum->dirty_len; /* File address of end of dirty region */
 
                             /* Check if entire dirty region is overwritten */
-                            if (H5F_addr_le(dirty_end, addr + size)) {
+                            if (H5_addr_le(dirty_end, addr + size)) {
                                 accum->dirty     = FALSE;
                                 accum->dirty_len = 0;
                             } /* end if */
                             else {
                                 /* Check for dirty region falling after write */
-                                if (H5F_addr_le(addr + size, dirty_start))
+                                if (H5_addr_le(addr + size, dirty_start))
                                     accum->dirty_off = overlap_size;
                                 else { /* Dirty region overlaps w/written region */
                                     accum->dirty_off = 0;
@@ -794,7 +794,7 @@ H5F__accum_write(H5F_shared_t *f_sh, H5FD_mem_t map_type, haddr_t addr, size_t s
                     size_t overlap_size; /* Size of overlapping region */
 
                     /* Sanity check */
-                    HDassert(H5F_addr_gt(addr + size, accum->loc + accum->size));
+                    HDassert(H5_addr_gt(addr + size, accum->loc + accum->size));
 
                     /* Compute overlap size */
                     overlap_size = (size_t)((accum->loc + accum->size) - addr);
@@ -807,13 +807,13 @@ H5F__accum_write(H5F_shared_t *f_sh, H5FD_mem_t map_type, haddr_t addr, size_t s
                             dirty_start + accum->dirty_len; /* File address of end of dirty region */
 
                         /* Check if entire dirty region is overwritten */
-                        if (H5F_addr_ge(dirty_start, addr)) {
+                        if (H5_addr_ge(dirty_start, addr)) {
                             accum->dirty     = FALSE;
                             accum->dirty_len = 0;
                         } /* end if */
                         else {
                             /* Check for dirty region falling before write */
-                            if (H5F_addr_le(dirty_end, addr))
+                            if (H5_addr_le(dirty_end, addr))
                                 ; /* noop */
                             else  /* Dirty region overlaps w/written region */
                                 accum->dirty_len = (size_t)(addr - dirty_start);
@@ -868,8 +868,8 @@ H5F__accum_free(H5F_shared_t *f_sh, H5FD_mem_t H5_ATTR_UNUSED type, haddr_t addr
     file = f_sh->lf;
 
     /* Adjust the metadata accumulator to remove the freed block, if it overlaps */
-    if ((f_sh->feature_flags & H5FD_FEAT_ACCUMULATE_METADATA) && H5F_addr_defined(accum->loc) &&
-        H5F_addr_overlap(addr, size, accum->loc, accum->size)) {
+    if ((f_sh->feature_flags & H5FD_FEAT_ACCUMULATE_METADATA) && H5_addr_defined(accum->loc) &&
+        H5_addr_overlap(addr, size, accum->loc, accum->size)) {
         size_t overlap_size; /* Size of overlap with accumulator */
 
         /* Sanity check */
@@ -878,9 +878,9 @@ H5F__accum_free(H5F_shared_t *f_sh, H5FD_mem_t H5_ATTR_UNUSED type, haddr_t addr
         HDassert(H5FD_MEM_GHEAP != type); /* (global heap data is being treated as raw data currently) */
 
         /* Check for overlapping the beginning of the accumulator */
-        if (H5F_addr_le(addr, accum->loc)) {
+        if (H5_addr_le(addr, accum->loc)) {
             /* Check for completely overlapping the accumulator */
-            if (H5F_addr_ge(addr + size, accum->loc + accum->size)) {
+            if (H5_addr_ge(addr + size, accum->loc + accum->size)) {
                 /* Reset the accumulator, but don't free buffer */
                 accum->loc   = HADDR_UNDEF;
                 accum->size  = 0;
@@ -928,16 +928,16 @@ H5F__accum_free(H5F_shared_t *f_sh, H5FD_mem_t H5_ATTR_UNUSED type, haddr_t addr
             H5_CHECKED_ASSIGN(overlap_size, size_t, (accum->loc + accum->size) - addr, haddr_t);
 
             /* Check if block to free begins before end of dirty region */
-            if (accum->dirty && H5F_addr_lt(addr, dirty_end)) {
+            if (accum->dirty && H5_addr_lt(addr, dirty_end)) {
                 haddr_t tail_addr;
 
                 /* Calculate the address of the tail to write */
                 tail_addr = addr + size;
 
                 /* Check if the block to free begins before dirty region */
-                if (H5F_addr_lt(addr, dirty_start)) {
+                if (H5_addr_lt(addr, dirty_start)) {
                     /* Check if block to free is entirely before dirty region */
-                    if (H5F_addr_le(tail_addr, dirty_start)) {
+                    if (H5_addr_le(tail_addr, dirty_start)) {
                         /* Write out the entire dirty region of the accumulator */
                         if (H5FD_write(file, H5FD_MEM_DEFAULT, dirty_start, accum->dirty_len,
                                        accum->buf + accum->dirty_off) < 0)
@@ -945,7 +945,7 @@ H5F__accum_free(H5F_shared_t *f_sh, H5FD_mem_t H5_ATTR_UNUSED type, haddr_t addr
                     } /* end if */
                     /* Block to free overlaps with some/all of dirty region */
                     /* Check for unfreed dirty region to write */
-                    else if (H5F_addr_lt(tail_addr, dirty_end)) {
+                    else if (H5_addr_lt(tail_addr, dirty_end)) {
                         size_t write_size;
                         size_t dirty_delta;
 
@@ -966,7 +966,7 @@ H5F__accum_free(H5F_shared_t *f_sh, H5FD_mem_t H5_ATTR_UNUSED type, haddr_t addr
                 /* Block to free begins at beginning of or in middle of dirty region */
                 else {
                     /* Check if block to free ends before end of dirty region */
-                    if (H5F_addr_lt(tail_addr, dirty_end)) {
+                    if (H5_addr_lt(tail_addr, dirty_end)) {
                         size_t write_size;
                         size_t dirty_delta;
 
@@ -982,7 +982,7 @@ H5F__accum_free(H5F_shared_t *f_sh, H5FD_mem_t H5_ATTR_UNUSED type, haddr_t addr
                     } /* end if */
 
                     /* Check for block to free beginning at same location as dirty region */
-                    if (H5F_addr_eq(addr, dirty_start)) {
+                    if (H5_addr_eq(addr, dirty_start)) {
                         /* Reset dirty flag */
                         accum->dirty = FALSE;
                     } /* end if */

--- a/src/H5Fint.c
+++ b/src/H5Fint.c
@@ -1215,7 +1215,7 @@ H5F__new(H5F_shared_t *shared, unsigned flags, hid_t fcpl_id, hid_t fapl_id, H5F
 
         /* Get the VFD values to cache */
         f->shared->maxaddr = H5FD_get_maxaddr(lf);
-        if (!H5F_addr_defined(f->shared->maxaddr))
+        if (!H5_addr_defined(f->shared->maxaddr))
             HGOTO_ERROR(H5E_FILE, H5E_BADVALUE, NULL, "bad maximum address from VFD")
         if (H5FD_get_feature_flags(lf, &f->shared->feature_flags) < 0)
             HGOTO_ERROR(H5E_FILE, H5E_CANTGET, NULL, "can't get feature flags from VFD")
@@ -2819,7 +2819,7 @@ H5F_addr_encode_len(size_t addr_len, uint8_t **pp /*in,out*/, haddr_t addr)
     HDassert(addr_len);
     HDassert(pp && *pp);
 
-    if (H5F_addr_defined(addr)) {
+    if (H5_addr_defined(addr)) {
         for (u = 0; u < addr_len; u++) {
             *(*pp)++ = (uint8_t)(addr & 0xff);
             addr >>= 8;
@@ -3256,7 +3256,7 @@ H5F__get_info(H5F_t *f, H5F_info2_t *finfo)
         HGOTO_ERROR(H5E_FILE, H5E_CANTGET, FAIL, "unable to retrieve free space information")
 
     /* Check for SOHM info */
-    if (H5F_addr_defined(f->shared->sohm_addr))
+    if (H5_addr_defined(f->shared->sohm_addr))
         if (H5SM_ih_size(f, &finfo->sohm.hdr_size, &finfo->sohm.msgs_info) < 0)
             HGOTO_ERROR(H5E_FILE, H5E_CANTGET, FAIL, "unable to retrieve SOHM index & heap storage info")
 
@@ -3934,7 +3934,7 @@ H5F__format_convert(H5F_t *f)
           f->shared->fs_page_size == H5F_FILE_SPACE_PAGE_SIZE_DEF)) {
 
         /* Check to remove free-space manager info message from superblock extension */
-        if (H5F_addr_defined(f->shared->sblock->ext_addr))
+        if (H5_addr_defined(f->shared->sblock->ext_addr))
             if (H5F__super_ext_remove_msg(f, H5O_FSINFO_ID) < 0)
                 HGOTO_ERROR(H5E_FILE, H5E_CANTRELEASE, FAIL,
                             "error in removing message from superblock extension")

--- a/src/H5Fio.c
+++ b/src/H5Fio.c
@@ -90,10 +90,10 @@ H5F_shared_block_read(H5F_shared_t *f_sh, H5FD_mem_t type, haddr_t addr, size_t 
     /* Sanity checks */
     HDassert(f_sh);
     HDassert(buf);
-    HDassert(H5F_addr_defined(addr));
+    HDassert(H5_addr_defined(addr));
 
     /* Check for attempting I/O on 'temporary' file address */
-    if (H5F_addr_le(f_sh->tmp_addr, (addr + size)))
+    if (H5_addr_le(f_sh->tmp_addr, (addr + size)))
         HGOTO_ERROR(H5E_IO, H5E_BADRANGE, FAIL, "attempting I/O in temporary file space")
 
     /* Treat global heap as raw data */
@@ -133,10 +133,10 @@ H5F_block_read(H5F_t *f, H5FD_mem_t type, haddr_t addr, size_t size, void *buf /
     HDassert(f);
     HDassert(f->shared);
     HDassert(buf);
-    HDassert(H5F_addr_defined(addr));
+    HDassert(H5_addr_defined(addr));
 
     /* Check for attempting I/O on 'temporary' file address */
-    if (H5F_addr_le(f->shared->tmp_addr, (addr + size)))
+    if (H5_addr_le(f->shared->tmp_addr, (addr + size)))
         HGOTO_ERROR(H5E_IO, H5E_BADRANGE, FAIL, "attempting I/O in temporary file space")
 
     /* Treat global heap as raw data */
@@ -176,10 +176,10 @@ H5F_shared_block_write(H5F_shared_t *f_sh, H5FD_mem_t type, haddr_t addr, size_t
     HDassert(f_sh);
     HDassert(H5F_SHARED_INTENT(f_sh) & H5F_ACC_RDWR);
     HDassert(buf);
-    HDassert(H5F_addr_defined(addr));
+    HDassert(H5_addr_defined(addr));
 
     /* Check for attempting I/O on 'temporary' file address */
-    if (H5F_addr_le(f_sh->tmp_addr, (addr + size)))
+    if (H5_addr_le(f_sh->tmp_addr, (addr + size)))
         HGOTO_ERROR(H5E_IO, H5E_BADRANGE, FAIL, "attempting I/O in temporary file space")
 
     /* Treat global heap as raw data */
@@ -220,10 +220,10 @@ H5F_block_write(H5F_t *f, H5FD_mem_t type, haddr_t addr, size_t size, const void
     HDassert(f->shared);
     HDassert(H5F_INTENT(f) & H5F_ACC_RDWR);
     HDassert(buf);
-    HDassert(H5F_addr_defined(addr));
+    HDassert(H5_addr_defined(addr));
 
     /* Check for attempting I/O on 'temporary' file address */
-    if (H5F_addr_le(f->shared->tmp_addr, (addr + size)))
+    if (H5_addr_le(f->shared->tmp_addr, (addr + size)))
         HGOTO_ERROR(H5E_IO, H5E_BADRANGE, FAIL, "attempting I/O in temporary file space")
 
     /* Treat global heap as raw data */

--- a/src/H5Fmount.c
+++ b/src/H5Fmount.c
@@ -177,7 +177,7 @@ H5F_mount(const H5G_loc_t *loc, const char *name, H5F_t *child, hid_t H5_ATTR_UN
 
         md   = (lt + rt) / 2;
         oloc = H5G_oloc(parent->shared->mtab.child[md].group);
-        cmp  = H5F_addr_cmp(mp_loc.oloc->addr, oloc->addr);
+        cmp  = H5_addr_cmp(mp_loc.oloc->addr, oloc->addr);
         if (cmp < 0)
             rt = md;
         else if (cmp > 0)
@@ -295,7 +295,7 @@ H5F_unmount(const H5G_loc_t *loc, const char *name)
     mnt_oloc     = H5G_oloc(child->shared->root_grp);
     child_idx    = -1;
 
-    if (child->parent && H5F_addr_eq(mp_oloc.addr, mnt_oloc->addr)) {
+    if (child->parent && H5_addr_eq(mp_oloc.addr, mnt_oloc->addr)) {
         unsigned u; /*counters			*/
 
         /*
@@ -326,7 +326,7 @@ H5F_unmount(const H5G_loc_t *loc, const char *name)
         while (lt < rt && cmp) {
             md       = (lt + rt) / 2;
             mnt_oloc = H5G_oloc(parent->shared->mtab.child[md].group);
-            cmp      = H5F_addr_cmp(mp_oloc.addr, mnt_oloc->addr);
+            cmp      = H5_addr_cmp(mp_oloc.addr, mnt_oloc->addr);
             if (cmp < 0)
                 rt = md;
             else
@@ -621,7 +621,7 @@ H5F_traverse_mount(H5O_loc_t *oloc /*in,out*/)
         while (lt < rt && cmp) {
             md       = (lt + rt) / 2;
             mnt_oloc = H5G_oloc(parent->shared->mtab.child[md].group);
-            cmp      = H5F_addr_cmp(oloc->addr, mnt_oloc->addr);
+            cmp      = H5_addr_cmp(oloc->addr, mnt_oloc->addr);
             if (cmp < 0)
                 rt = md;
             else

--- a/src/H5Fprivate.h
+++ b/src/H5Fprivate.h
@@ -284,37 +284,6 @@ typedef struct H5F_t H5F_t;
         (p) += 8;                                                                                            \
     }
 
-/* clang-format off */
-/* Address-related macros */
-#define H5F_addr_overflow(X,Z)    (HADDR_UNDEF==(X) ||                      \
-                HADDR_UNDEF==(X)+(haddr_t)(Z) ||                            \
-                (X)+(haddr_t)(Z)<(X))
-#define H5F_addr_defined(X)    ((X)!=HADDR_UNDEF)
-/* The H5F_addr_eq() macro guarantees that Y is not HADDR_UNDEF by making
- * certain that X is not HADDR_UNDEF and then checking that X equals Y
- */
-#define H5F_addr_eq(X,Y)    ((X)!=HADDR_UNDEF &&                            \
-                (X)==(Y))
-#define H5F_addr_ne(X,Y)    (!H5F_addr_eq((X),(Y)))
-#define H5F_addr_lt(X,Y)     ((X)!=HADDR_UNDEF &&                           \
-                (Y)!=HADDR_UNDEF &&                                         \
-                (X)<(Y))
-#define H5F_addr_le(X,Y)    ((X)!=HADDR_UNDEF &&                            \
-                (Y)!=HADDR_UNDEF &&                                         \
-                (X)<=(Y))
-#define H5F_addr_gt(X,Y)    ((X)!=HADDR_UNDEF &&                            \
-                (Y)!=HADDR_UNDEF &&                                         \
-                (X)>(Y))
-#define H5F_addr_ge(X,Y)    ((X)!=HADDR_UNDEF &&                            \
-                (Y)!=HADDR_UNDEF &&                                         \
-                (X)>=(Y))
-#define H5F_addr_cmp(X,Y)    (H5F_addr_eq((X), (Y)) ? 0 :                   \
-                (H5F_addr_lt((X), (Y)) ? -1 : 1))
-#define H5F_addr_pow2(N)    ((haddr_t)1<<(N))
-#define H5F_addr_overlap(O1,L1,O2,L2) (((O1) < (O2) && ((O1) + (L1)) > (O2)) || \
-                                 ((O1) >= (O2) && (O1) < ((O2) + (L2))))
-/* clang-format on */
-
 /* If the module using this macro is allowed access to the private variables, access them directly */
 #ifdef H5F_MODULE
 #define H5F_LOW_BOUND(F)                 ((F)->shared->low_bound)
@@ -362,7 +331,7 @@ typedef struct H5F_t H5F_t;
 #define H5F_GRP_BTREE_SHARED(F)          ((F)->shared->grp_btree_shared)
 #define H5F_SET_GRP_BTREE_SHARED(F, RC)  (((F)->shared->grp_btree_shared = (RC)) ? SUCCEED : FAIL)
 #define H5F_USE_TMP_SPACE(F)             ((F)->shared->fs.use_tmp_space)
-#define H5F_IS_TMP_ADDR(F, ADDR)         (H5F_addr_le((F)->shared->fs.tmp_addr, (ADDR)))
+#define H5F_IS_TMP_ADDR(F, ADDR)         (H5_addr_le((F)->shared->fs.tmp_addr, (ADDR)))
 #ifdef H5_HAVE_PARALLEL
 #define H5F_COLL_MD_READ(F) ((F)->shared->coll_md_read)
 #endif /* H5_HAVE_PARALLEL */

--- a/src/H5Fquery.c
+++ b/src/H5Fquery.c
@@ -1020,7 +1020,7 @@ H5F_is_tmp_addr(const H5F_t *f, haddr_t addr)
     HDassert(f);
     HDassert(f->shared);
 
-    FUNC_LEAVE_NOAPI(H5F_addr_le(f->shared->tmp_addr, addr))
+    FUNC_LEAVE_NOAPI(H5_addr_le(f->shared->tmp_addr, addr))
 } /* end H5F_is_tmp_addr() */
 
 /*-------------------------------------------------------------------------

--- a/src/H5Fspace.c
+++ b/src/H5Fspace.c
@@ -104,14 +104,14 @@ H5F__alloc(H5F_t *f, H5F_mem_t type, hsize_t size, haddr_t *frag_addr, hsize_t *
             HGOTO_ERROR(H5E_FILE, H5E_CANTGET, HADDR_UNDEF, "Unable to get eoa")
 
         /* Check for overlapping into file's temporary allocation space */
-        if (H5F_addr_gt((eoa + size), f->shared->tmp_addr))
+        if (H5_addr_gt((eoa + size), f->shared->tmp_addr))
             HGOTO_ERROR(H5E_FILE, H5E_BADRANGE, HADDR_UNDEF,
                         "'normal' file space allocation request will overlap into 'temporary' file space")
     } /* end if */
 
     /* Call the file driver 'alloc' routine */
     ret_value = H5FD_alloc(f->shared->lf, type, f, size, frag_addr, frag_size);
-    if (!H5F_addr_defined(ret_value))
+    if (!H5_addr_defined(ret_value))
         HGOTO_ERROR(H5E_FILE, H5E_CANTALLOC, HADDR_UNDEF, "file driver 'alloc' request failed")
 
     /* Mark EOA dirty */

--- a/src/H5Fsuper.c
+++ b/src/H5Fsuper.c
@@ -97,7 +97,7 @@ H5F__super_ext_create(H5F_t *f, H5O_loc_t *ext_ptr)
     HDassert(f);
     HDassert(f->shared);
     HDassert(f->shared->sblock);
-    HDassert(!H5F_addr_defined(f->shared->sblock->ext_addr));
+    HDassert(!H5_addr_defined(f->shared->sblock->ext_addr));
     HDassert(ext_ptr);
 
     /* Check for older version of superblock format that can't support superblock extensions */
@@ -105,7 +105,7 @@ H5F__super_ext_create(H5F_t *f, H5O_loc_t *ext_ptr)
         HGOTO_ERROR(H5E_FILE, H5E_CANTCREATE, FAIL,
                     "superblock extension not permitted with version %u of superblock",
                     f->shared->sblock->super_vers)
-    else if (H5F_addr_defined(f->shared->sblock->ext_addr))
+    else if (H5_addr_defined(f->shared->sblock->ext_addr))
         HGOTO_ERROR(H5E_FILE, H5E_CANTCREATE, FAIL, "superblock extension already exists?!?!")
     else {
         /* The superblock extension isn't actually a group, but the
@@ -149,7 +149,7 @@ H5F__super_ext_open(H5F_t *f, haddr_t ext_addr, H5O_loc_t *ext_ptr)
 
     /* Sanity check */
     HDassert(f);
-    HDassert(H5F_addr_defined(ext_addr));
+    HDassert(H5_addr_defined(ext_addr));
     HDassert(ext_ptr);
 
     /* Set up "fake" object location for superblock extension */
@@ -254,7 +254,7 @@ H5F__update_super_ext_driver_msg(H5F_t *f)
      * if appropriate.
      */
     if (sblock->super_vers >= HDF5_SUPERBLOCK_VERSION_2) {
-        if (H5F_addr_defined(sblock->ext_addr)) {
+        if (H5_addr_defined(sblock->ext_addr)) {
             /* Check for ignoring the driver info for this file */
             if (!H5F_HAS_FEATURE(f, H5FD_FEAT_IGNORE_DRVRINFO)) {
                 size_t driver_size; /* Size of driver info block (bytes)*/
@@ -401,11 +401,11 @@ H5F__super_read(H5F_t *f, H5P_genplist_t *fa_plist, hbool_t initial_read)
 #ifdef H5_HAVE_PARALLEL
     }  /* end else */
 #endif /* H5_HAVE_PARALLEL */
-    if (!H5F_addr_defined(super_addr))
+    if (!H5_addr_defined(super_addr))
         HGOTO_ERROR(H5E_FILE, H5E_NOTHDF5, FAIL, "file signature not found")
 
     /* Check for userblock present */
-    if (H5F_addr_gt(super_addr, 0)) {
+    if (H5_addr_gt(super_addr, 0)) {
         /* Set the base address for the file in the VFD now */
         if (H5F__set_base_addr(f, super_addr) < 0)
             HGOTO_ERROR(H5E_FILE, H5E_CANTSET, FAIL, "failed to set base address for file driver")
@@ -508,7 +508,7 @@ H5F__super_read(H5F_t *f, H5P_genplist_t *fa_plist, hbool_t initial_read)
     /* Check if superblock address is different from base address and adjust
      * base address and "end of file" address if so.
      */
-    if (!H5F_addr_eq(super_addr, sblock->base_addr)) {
+    if (!H5_addr_eq(super_addr, sblock->base_addr)) {
         /* If the superblock moved in the file, adjust the EOF */
         /* (Handles moving earlier & later) */
         udata.stored_eof -= (sblock->base_addr - super_addr);
@@ -626,7 +626,7 @@ H5F__super_read(H5F_t *f, H5P_genplist_t *fa_plist, hbool_t initial_read)
     H5AC_set_ring(H5AC_RING_SBE, NULL);
 
     /* Decode the optional driver information block */
-    if (H5F_addr_defined(sblock->driver_addr)) {
+    if (H5_addr_defined(sblock->driver_addr)) {
         H5O_drvinfo_t          *drvinfo;             /* Driver info */
         H5F_drvrinfo_cache_ud_t drvrinfo_udata;      /* User data for metadata callbacks */
         unsigned drvinfo_flags = H5AC__NO_FLAGS_SET; /* Flags used in driver info block unprotect call */
@@ -676,7 +676,7 @@ H5F__super_read(H5F_t *f, H5P_genplist_t *fa_plist, hbool_t initial_read)
         HGOTO_ERROR(H5E_FILE, H5E_CANTSET, FAIL, "unable to set end-of-address marker for file")
 
     /* Decode the optional superblock extension info */
-    if (H5F_addr_defined(sblock->ext_addr)) {
+    if (H5_addr_defined(sblock->ext_addr)) {
         H5O_loc_t     ext_loc; /* "Object location" for superblock extension */
         H5O_btreek_t  btreek;  /* v1 B-tree 'K' value message from superblock extension */
         H5O_drvinfo_t drvinfo; /* Driver info message from superblock extension */
@@ -693,7 +693,7 @@ H5F__super_read(H5F_t *f, H5P_genplist_t *fa_plist, hbool_t initial_read)
         /* Check for superblock extension being located "outside" the stored
          *      'eoa' value, which can occur with the split/multi VFD.
          */
-        if (H5F_addr_gt(sblock->ext_addr, udata.stored_eof)) {
+        if (H5_addr_gt(sblock->ext_addr, udata.stored_eof)) {
             /* Set the 'eoa' for the object header memory type large enough
              *  to give some room for a reasonably sized superblock extension.
              *  (This is _rather_ a kludge -QAK)
@@ -961,7 +961,7 @@ H5F__super_read(H5F_t *f, H5P_genplist_t *fa_plist, hbool_t initial_read)
      *          earlier in this routine.
      */
     if (((rw_flags & H5AC__READ_ONLY_FLAG) == 0) && sblock->super_vers >= HDF5_SUPERBLOCK_VERSION_2 &&
-        H5F_addr_defined(sblock->ext_addr)) {
+        H5_addr_defined(sblock->ext_addr)) {
         /* Check for modifying the driver info when opening the file */
         if (H5F_HAS_FEATURE(f, H5FD_FEAT_DIRTY_DRVRINFO_LOAD)) {
             size_t driver_size; /* Size of driver info block (bytes) */
@@ -1013,7 +1013,7 @@ H5F__super_read(H5F_t *f, H5P_genplist_t *fa_plist, hbool_t initial_read)
                             "error in removing message from superblock extension")
 
             /* Check if the superblock extension was removed */
-            if (!H5F_addr_defined(sblock->ext_addr))
+            if (!H5_addr_defined(sblock->ext_addr))
                 sblock_flags |= H5AC__DIRTIED_FLAG;
         } /* end if */
     }     /* end if */
@@ -1428,7 +1428,7 @@ H5F__super_init(H5F_t *f)
         /* Check for creating an "old-style" driver info block */
         if (driver_size > 0) {
             /* Sanity check */
-            HDassert(H5F_addr_defined(sblock->driver_addr));
+            HDassert(H5_addr_defined(sblock->driver_addr));
 
             /* Allocate space for the driver info */
             if (NULL == (drvinfo = (H5O_drvinfo_t *)H5MM_calloc(sizeof(H5O_drvinfo_t))))
@@ -1451,7 +1451,7 @@ H5F__super_init(H5F_t *f)
             f->shared->drvinfo = drvinfo;
         } /* end if */
         else
-            HDassert(!H5F_addr_defined(sblock->driver_addr));
+            HDassert(!H5_addr_defined(sblock->driver_addr));
     } /* end if */
 
 done:
@@ -1649,7 +1649,7 @@ H5F__super_size(H5F_t *f, hsize_t *super_size, hsize_t *super_ext_size)
 
     /* Set the superblock extension size */
     if (super_ext_size) {
-        if (H5F_addr_defined(f->shared->sblock->ext_addr)) {
+        if (H5_addr_defined(f->shared->sblock->ext_addr)) {
             H5O_loc_t      ext_loc;  /* "Object location" for superblock extension */
             H5O_hdr_info_t hdr_info; /* Object info for superblock extension */
 
@@ -1713,7 +1713,7 @@ H5F__super_ext_write_msg(H5F_t *f, unsigned id, void *mesg, hbool_t may_create, 
     H5AC_set_ring(H5AC_RING_SBE, &orig_ring);
 
     /* Open/create the superblock extension object header */
-    if (H5F_addr_defined(f->shared->sblock->ext_addr)) {
+    if (H5_addr_defined(f->shared->sblock->ext_addr)) {
         if (H5F__super_ext_open(f, f->shared->sblock->ext_addr, &ext_loc) < 0)
             HGOTO_ERROR(H5E_FILE, H5E_CANTOPENOBJ, FAIL, "unable to open file's superblock extension")
     } /* end if */
@@ -1723,7 +1723,7 @@ H5F__super_ext_write_msg(H5F_t *f, unsigned id, void *mesg, hbool_t may_create, 
             HGOTO_ERROR(H5E_FILE, H5E_CANTCREATE, FAIL, "unable to create file's superblock extension")
         ext_created = TRUE;
     } /* end else */
-    HDassert(H5F_addr_defined(ext_loc.addr));
+    HDassert(H5_addr_defined(ext_loc.addr));
     ext_opened = TRUE;
 
     /* Check if message with ID does not exist in the object header */
@@ -1789,7 +1789,7 @@ H5F__super_ext_remove_msg(H5F_t *f, unsigned id)
     FUNC_ENTER_PACKAGE
 
     /* Make sure that the superblock extension object header exists */
-    HDassert(H5F_addr_defined(f->shared->sblock->ext_addr));
+    HDassert(H5_addr_defined(f->shared->sblock->ext_addr));
 
     /* Set the ring type in the API context */
     H5AC_set_ring(H5AC_RING_SBE, &orig_ring);
@@ -1819,7 +1819,7 @@ H5F__super_ext_remove_msg(H5F_t *f, unsigned id)
             if ((null_count = H5O_msg_count(&ext_loc, H5O_NULL_ID)) < 0)
                 HGOTO_ERROR(H5E_SYM, H5E_CANTCOUNT, FAIL, "unable to count messages")
             else if ((unsigned)null_count == hdr_info.nmesgs) {
-                HDassert(H5F_addr_defined(ext_loc.addr));
+                HDassert(H5_addr_defined(ext_loc.addr));
                 if (H5O_delete(f, ext_loc.addr) < 0)
                     HGOTO_ERROR(H5E_SYM, H5E_CANTCOUNT, FAIL, "unable to count messages")
                 f->shared->sblock->ext_addr = HADDR_UNDEF;

--- a/src/H5Fsuper_cache.c
+++ b/src/H5Fsuper_cache.c
@@ -273,14 +273,14 @@ H5F__drvrinfo_prefix_decode(H5O_drvinfo_t *drvrinfo, char *drv_name, const uint8
 
         /* Get current EOA... */
         eoa = H5FD_get_eoa(udata->f->shared->lf, H5FD_MEM_SUPER);
-        if (!H5F_addr_defined(eoa))
+        if (!H5_addr_defined(eoa))
             HGOTO_ERROR(H5E_FILE, H5E_CANTGET, FAIL, "driver get_eoa request failed")
 
         /* ... if it is too small, extend it. */
         min_eoa = udata->driver_addr + H5F_DRVINFOBLOCK_HDR_SIZE + drvrinfo->len;
 
         /* If it grew, set it */
-        if (H5F_addr_gt(min_eoa, eoa))
+        if (H5_addr_gt(min_eoa, eoa))
             if (H5FD_set_eoa(udata->f->shared->lf, H5FD_MEM_SUPER, min_eoa) < 0)
                 HGOTO_ERROR(H5E_FILE, H5E_CANTINIT, FAIL, "set end of space allocation request failed")
     }
@@ -548,7 +548,7 @@ H5F__cache_superblock_deserialize(const void *_image, size_t len, void *_udata, 
          *  undefined to let the library ignore the family driver information saved
          *  in the superblock.
          */
-        if (udata->ignore_drvrinfo && H5F_addr_defined(sblock->driver_addr)) {
+        if (udata->ignore_drvrinfo && H5_addr_defined(sblock->driver_addr)) {
             /* Eliminate the driver info */
             sblock->driver_addr     = HADDR_UNDEF;
             udata->drvrinfo_removed = TRUE;

--- a/src/H5Gdense.c
+++ b/src/H5Gdense.c
@@ -415,7 +415,7 @@ H5G__dense_insert(H5F_t *f, const H5O_linfo_t *linfo, const H5O_link_t *lnk)
     /* Check if we should create a creation order index v2 B-tree record */
     if (linfo->index_corder) {
         /* Open the creation order index v2 B-tree */
-        HDassert(H5F_addr_defined(linfo->corder_bt2_addr));
+        HDassert(H5_addr_defined(linfo->corder_bt2_addr));
         if (NULL == (bt2_corder = H5B2_open(f, linfo->corder_bt2_addr, NULL)))
             HGOTO_ERROR(H5E_SYM, H5E_CANTOPENOBJ, FAIL, "unable to open v2 B-tree for creation order index")
 
@@ -663,13 +663,13 @@ H5G__dense_lookup_by_idx(H5F_t *f, const H5O_linfo_t *linfo, H5_index_t idx_type
      * use the B-tree for names instead of building a table to speed up the
      * process.
      */
-    if (order == H5_ITER_NATIVE && !H5F_addr_defined(bt2_addr)) {
+    if (order == H5_ITER_NATIVE && !H5_addr_defined(bt2_addr)) {
         bt2_addr = linfo->name_bt2_addr;
-        HDassert(H5F_addr_defined(bt2_addr));
+        HDassert(H5_addr_defined(bt2_addr));
     } /* end if */
 
     /* If there is an index defined for the field, use it */
-    if (H5F_addr_defined(bt2_addr)) {
+    if (H5_addr_defined(bt2_addr)) {
         H5G_bt2_ud_lbi_t udata; /* User data for v2 B-tree link lookup */
 
         /* Open the fractal heap */
@@ -958,8 +958,8 @@ H5G__dense_iterate(H5F_t *f, const H5O_linfo_t *linfo, H5_index_t idx_type, H5_i
      * use the B-tree for names instead of building a table to speed up the
      * process.
      */
-    if (order == H5_ITER_NATIVE && !H5F_addr_defined(bt2_addr)) {
-        HDassert(H5F_addr_defined(linfo->name_bt2_addr));
+    if (order == H5_ITER_NATIVE && !H5_addr_defined(bt2_addr)) {
+        HDassert(H5_addr_defined(linfo->name_bt2_addr));
         bt2_addr = linfo->name_bt2_addr;
     } /* end if */
 
@@ -968,7 +968,7 @@ H5G__dense_iterate(H5F_t *f, const H5O_linfo_t *linfo, H5_index_t idx_type, H5_i
         H5G_bt2_ud_it_t udata; /* User data for iterator callback */
 
         /* Sanity check */
-        HDassert(H5F_addr_defined(bt2_addr));
+        HDassert(H5_addr_defined(bt2_addr));
 
         /* Open the fractal heap */
         if (NULL == (fheap = H5HF_open(f, linfo->fheap_addr)))
@@ -1153,13 +1153,13 @@ H5G__dense_get_name_by_idx(H5F_t *f, H5O_linfo_t *linfo, H5_index_t idx_type, H5
      * use the B-tree for names instead of building a table to speed up the
      * process.
      */
-    if (order == H5_ITER_NATIVE && !H5F_addr_defined(bt2_addr)) {
+    if (order == H5_ITER_NATIVE && !H5_addr_defined(bt2_addr)) {
         bt2_addr = linfo->name_bt2_addr;
-        HDassert(H5F_addr_defined(bt2_addr));
+        HDassert(H5_addr_defined(bt2_addr));
     } /* end if */
 
     /* If there is an index defined for the field, use it */
-    if (H5F_addr_defined(bt2_addr)) {
+    if (H5_addr_defined(bt2_addr)) {
         H5G_bt2_ud_gnbi_t udata; /* User data for v2 B-tree callback */
 
         /* Open the fractal heap */
@@ -1243,7 +1243,7 @@ H5G__dense_remove_fh_cb(const void *obj, size_t obj_len, void *_udata)
         HGOTO_ERROR(H5E_SYM, H5E_CANTDECODE, FAIL, "can't decode link")
 
     /* Check for removing the link from the creation order index */
-    if (H5F_addr_defined(udata->corder_bt2_addr)) {
+    if (H5_addr_defined(udata->corder_bt2_addr)) {
         H5G_bt2_ud_common_t bt2_udata; /* Info for B-tree callbacks */
 
         /* Open the creation order index v2 B-tree */
@@ -1464,7 +1464,7 @@ H5G__dense_remove_by_idx_bt2_cb(const void *_record, void *_bt2_udata)
     HDassert(fh_udata.lnk);
 
     /* Check for removing the link from the "other" index (creation order, when name used and vice versa) */
-    if (H5F_addr_defined(bt2_udata->other_bt2_addr)) {
+    if (H5_addr_defined(bt2_udata->other_bt2_addr)) {
         H5G_bt2_ud_common_t other_bt2_udata; /* Info for B-tree callbacks */
 
         /* Determine the index being used */
@@ -1575,13 +1575,13 @@ H5G__dense_remove_by_idx(H5F_t *f, const H5O_linfo_t *linfo, H5RS_str_t *grp_ful
      * use the B-tree for names instead of building a table to speed up the
      * process.
      */
-    if (order == H5_ITER_NATIVE && !H5F_addr_defined(bt2_addr)) {
+    if (order == H5_ITER_NATIVE && !H5_addr_defined(bt2_addr)) {
         bt2_addr = linfo->name_bt2_addr;
-        HDassert(H5F_addr_defined(bt2_addr));
+        HDassert(H5_addr_defined(bt2_addr));
     } /* end if */
 
     /* If there is an index defined for the field, use it */
-    if (H5F_addr_defined(bt2_addr)) {
+    if (H5_addr_defined(bt2_addr)) {
         H5G_bt2_ud_rmbi_t udata; /* User data for v2 B-tree record removal */
 
         /* Open the fractal heap */
@@ -1696,13 +1696,13 @@ H5G__dense_delete(H5F_t *f, H5O_linfo_t *linfo, hbool_t adj_link)
     /* Check if we should delete the creation order index v2 B-tree */
     if (linfo->index_corder) {
         /* Delete the creation order index, without adjusting the ref. count on the links  */
-        HDassert(H5F_addr_defined(linfo->corder_bt2_addr));
+        HDassert(H5_addr_defined(linfo->corder_bt2_addr));
         if (H5B2_delete(f, linfo->corder_bt2_addr, NULL, NULL, NULL) < 0)
             HGOTO_ERROR(H5E_SYM, H5E_CANTDELETE, FAIL, "unable to delete v2 B-tree for creation order index")
         linfo->corder_bt2_addr = HADDR_UNDEF;
     } /* end if */
     else
-        HDassert(!H5F_addr_defined(linfo->corder_bt2_addr));
+        HDassert(!H5_addr_defined(linfo->corder_bt2_addr));
 
     /* Delete the fractal heap */
     if (H5HF_delete(f, linfo->fheap_addr) < 0)

--- a/src/H5Gnode.c
+++ b/src/H5Gnode.c
@@ -486,7 +486,7 @@ H5G__node_found(H5F_t *f, haddr_t addr, const void H5_ATTR_UNUSED *_lt_key, hboo
      * Check arguments.
      */
     HDassert(f);
-    HDassert(H5F_addr_defined(addr));
+    HDassert(H5_addr_defined(addr));
     HDassert(found);
     HDassert(udata && udata->common.heap);
 
@@ -584,7 +584,7 @@ H5G__node_insert(H5F_t *f, haddr_t addr, void H5_ATTR_UNUSED *_lt_key, hbool_t H
      * Check arguments.
      */
     HDassert(f);
-    HDassert(H5F_addr_defined(addr));
+    HDassert(H5_addr_defined(addr));
     HDassert(md_key);
     HDassert(rt_key);
     HDassert(udata && udata->common.heap);
@@ -740,7 +740,7 @@ H5G__node_remove(H5F_t *f, haddr_t addr, void H5_ATTR_NDEBUG_UNUSED *_lt_key /*i
 
     /* Check arguments */
     HDassert(f);
-    HDassert(H5F_addr_defined(addr));
+    HDassert(H5_addr_defined(addr));
     HDassert((H5G_node_key_t *)_lt_key);
     HDassert(rt_key);
     HDassert(udata && udata->common.heap);
@@ -789,7 +789,7 @@ H5G__node_remove(H5F_t *f, haddr_t addr, void H5_ATTR_NDEBUG_UNUSED *_lt_key /*i
         } /* end if */
         else {
             lnk.type = H5L_TYPE_HARD;
-            HDassert(H5F_addr_defined(sn->entry[idx].header));
+            HDassert(H5_addr_defined(sn->entry[idx].header));
             lnk.u.hard.addr = sn->entry[idx].header;
         } /* end else */
 
@@ -882,7 +882,7 @@ H5G__node_remove(H5F_t *f, haddr_t addr, void H5_ATTR_NDEBUG_UNUSED *_lt_key /*i
         for (idx = 0; idx < sn->nsyms; idx++) {
             if (!(H5G_CACHED_SLINK == sn->entry[idx].type)) {
                 /* Decrement the reference count */
-                HDassert(H5F_addr_defined(sn->entry[idx].header));
+                HDassert(H5_addr_defined(sn->entry[idx].header));
                 tmp_oloc.addr = sn->entry[idx].header;
 
                 if (H5O_link(&tmp_oloc, -1) < 0)
@@ -936,7 +936,7 @@ H5G__node_iterate(H5F_t *f, const void H5_ATTR_UNUSED *_lt_key, haddr_t addr,
      * Check arguments.
      */
     HDassert(f);
-    HDassert(H5F_addr_defined(addr));
+    HDassert(H5_addr_defined(addr));
     HDassert(udata && udata->heap);
 
     /* Protect the symbol table node & local heap while we iterate over entries */
@@ -1013,7 +1013,7 @@ H5G__node_sumup(H5F_t *f, const void H5_ATTR_UNUSED *_lt_key, haddr_t addr,
      * Check arguments.
      */
     HDassert(f);
-    HDassert(H5F_addr_defined(addr));
+    HDassert(H5_addr_defined(addr));
     HDassert(num_objs);
 
     /* Find the object node and add the number of symbol entries. */
@@ -1057,7 +1057,7 @@ H5G__node_by_idx(H5F_t *f, const void H5_ATTR_UNUSED *_lt_key, haddr_t addr,
      * Check arguments.
      */
     HDassert(f);
-    HDassert(H5F_addr_defined(addr));
+    HDassert(H5_addr_defined(addr));
     HDassert(udata);
 
     /* Get a pointer to the symbol table node */
@@ -1192,7 +1192,7 @@ H5G__node_copy(H5F_t *f, const void H5_ATTR_UNUSED *_lt_key, haddr_t addr, const
 
     /* Check arguments. */
     HDassert(f);
-    HDassert(H5F_addr_defined(addr));
+    HDassert(H5_addr_defined(addr));
     HDassert(udata);
 
     /* load the symbol table into memory from the source file */
@@ -1245,7 +1245,7 @@ H5G__node_copy(H5F_t *f, const void H5_ATTR_UNUSED *_lt_key, haddr_t addr, const
         }                              /* if ((H5G_CACHED_SLINK == src_ent->type)... */
 
         /* Check if object in source group is a hard link */
-        if (H5F_addr_defined(src_ent->header)) {
+        if (H5_addr_defined(src_ent->header)) {
             H5O_loc_t new_dst_oloc; /* Copied object location in destination */
             H5O_loc_t tmp_src_oloc; /* Temporary object location for source object */
 
@@ -1275,7 +1275,7 @@ H5G__node_copy(H5F_t *f, const void H5_ATTR_UNUSED *_lt_key, haddr_t addr, const
             /* Construct link information for eventual insertion */
             lnk.type        = H5L_TYPE_HARD;
             lnk.u.hard.addr = new_dst_oloc.addr;
-        } /* ( H5F_addr_defined(src_ent->header)) */
+        } /* ( H5_addr_defined(src_ent->header)) */
         else if (H5G_CACHED_SLINK == src_ent->type) {
             /* it is a soft link */
             /* Set object type to unknown */
@@ -1350,7 +1350,7 @@ H5G__node_build_table(H5F_t *f, const void H5_ATTR_UNUSED *_lt_key, haddr_t addr
      * Check arguments.
      */
     HDassert(f);
-    HDassert(H5F_addr_defined(addr));
+    HDassert(H5_addr_defined(addr));
     HDassert(udata && udata->heap);
 
     /*
@@ -1455,13 +1455,13 @@ H5G_node_debug(H5F_t *f, haddr_t addr, FILE *stream, int indent, int fwidth, had
      * Check arguments.
      */
     HDassert(f);
-    HDassert(H5F_addr_defined(addr));
+    HDassert(H5_addr_defined(addr));
     HDassert(stream);
     HDassert(indent >= 0);
     HDassert(fwidth >= 0);
 
     /* Pin the heap down in memory */
-    if (heap_addr > 0 && H5F_addr_defined(heap_addr))
+    if (heap_addr > 0 && H5_addr_defined(heap_addr))
         if (NULL == (heap = H5HL_protect(f, heap_addr, H5AC__READ_ONLY_FLAG)))
             HGOTO_ERROR(H5E_SYM, H5E_CANTLOAD, FAIL, "unable to protect symbol table heap")
 

--- a/src/H5Gobj.c
+++ b/src/H5Gobj.c
@@ -310,7 +310,7 @@ H5G__obj_get_linfo(const H5O_loc_t *grp_oloc, H5O_linfo_t *linfo)
         /* Check if we don't know how many links there are */
         if (linfo->nlinks == HSIZET_MAX) {
             /* Check if we are using "dense" link storage */
-            if (H5F_addr_defined(linfo->fheap_addr)) {
+            if (H5_addr_defined(linfo->fheap_addr)) {
                 /* Open the name index v2 B-tree */
                 if (NULL == (bt2_name = H5B2_open(grp_oloc->file, linfo->name_bt2_addr, NULL)))
                     HGOTO_ERROR(H5E_SYM, H5E_CANTOPENOBJ, FAIL, "unable to open v2 B-tree for name index")
@@ -473,7 +473,7 @@ H5G_obj_insert(const H5O_loc_t *grp_oloc, const char *name, H5O_link_t *obj_lnk,
         /* (If the encoded form of the link is too large to fit into an object
          *  header message, convert to using dense link storage instead of link messages)
          */
-        if (H5F_addr_defined(linfo.fheap_addr))
+        if (H5_addr_defined(linfo.fheap_addr))
             use_new_dense = TRUE;
         else if (linfo.nlinks < ginfo.max_compact && link_msg_size < H5O_MESG_MAX_SIZE)
             use_new_dense = FALSE;
@@ -649,7 +649,7 @@ H5G__obj_iterate(const H5O_loc_t *grp_oloc, H5_index_t idx_type, H5_iter_order_t
                 HGOTO_ERROR(H5E_SYM, H5E_NOTFOUND, FAIL, "creation order not tracked for links in group")
         } /* end if */
 
-        if (H5F_addr_defined(linfo.fheap_addr)) {
+        if (H5_addr_defined(linfo.fheap_addr)) {
             /* Iterate over the links in the group, building a table of the link messages */
             if ((ret_value = H5G__dense_iterate(grp_oloc->file, &linfo, idx_type, order, skip, last_lnk, op,
                                                 op_data)) < 0)
@@ -730,7 +730,7 @@ H5G__obj_info(const H5O_loc_t *oloc, H5G_info_t *grp_info)
         grp_info->max_corder = linfo.max_corder;
 
         /* Check if the group is using compact or dense storage for its links */
-        if (H5F_addr_defined(linfo.fheap_addr))
+        if (H5_addr_defined(linfo.fheap_addr))
             grp_info->storage_type = H5G_STORAGE_TYPE_DENSE;
         else
             grp_info->storage_type = H5G_STORAGE_TYPE_COMPACT;
@@ -790,7 +790,7 @@ H5G_obj_get_name_by_idx(const H5O_loc_t *oloc, H5_index_t idx_type, H5_iter_orde
                 HGOTO_ERROR(H5E_SYM, H5E_NOTFOUND, FAIL, "creation order not tracked for links in group")
 
         /* Check for dense link storage */
-        if (H5F_addr_defined(linfo.fheap_addr)) {
+        if (H5_addr_defined(linfo.fheap_addr)) {
             /* Get the object's name from the dense link storage */
             if (H5G__dense_get_name_by_idx(oloc->file, &linfo, idx_type, order, n, name, name_size,
                                            name_len) < 0)
@@ -848,7 +848,7 @@ H5G__obj_remove_update_linfo(const H5O_loc_t *oloc, H5O_linfo_t *linfo)
         linfo->max_corder = 0;
 
     /* Check for transitioning out of dense storage, if we are using it */
-    if (H5F_addr_defined(linfo->fheap_addr)) {
+    if (H5_addr_defined(linfo->fheap_addr)) {
         /* Check if there's no more links */
         if (linfo->nlinks == 0) {
             /* Delete the dense storage */
@@ -962,7 +962,7 @@ H5G_obj_remove(const H5O_loc_t *oloc, H5RS_str_t *grp_full_path_r, const char *n
         use_old_format = FALSE;
 
         /* Check for dense or compact storage */
-        if (H5F_addr_defined(linfo.fheap_addr)) {
+        if (H5_addr_defined(linfo.fheap_addr)) {
             /* Remove object from the dense link storage */
             if (H5G__dense_remove(oloc->file, &linfo, grp_full_path_r, name) < 0)
                 HGOTO_ERROR(H5E_SYM, H5E_NOTFOUND, FAIL, "can't remove object")
@@ -1032,7 +1032,7 @@ H5G_obj_remove_by_idx(const H5O_loc_t *grp_oloc, H5RS_str_t *grp_full_path_r, H5
         use_old_format = FALSE;
 
         /* Check for dense or compact storage */
-        if (H5F_addr_defined(linfo.fheap_addr)) {
+        if (H5_addr_defined(linfo.fheap_addr)) {
             /* Remove object from the dense link storage */
             if (H5G__dense_remove_by_idx(grp_oloc->file, &linfo, grp_full_path_r, idx_type, order, n) < 0)
                 HGOTO_ERROR(H5E_SYM, H5E_NOTFOUND, FAIL, "can't remove object")
@@ -1095,7 +1095,7 @@ H5G__obj_lookup(const H5O_loc_t *grp_oloc, const char *name, hbool_t *found, H5O
         HGOTO_ERROR(H5E_SYM, H5E_CANTGET, FAIL, "can't check for link info message")
     if (linfo_exists) {
         /* Check for dense link storage */
-        if (H5F_addr_defined(linfo.fheap_addr)) {
+        if (H5_addr_defined(linfo.fheap_addr)) {
             /* Get the object's info from the dense link storage */
             if (H5G__dense_lookup(grp_oloc->file, &linfo, name, found, lnk) < 0)
                 HGOTO_ERROR(H5E_SYM, H5E_NOTFOUND, FAIL, "can't locate object")
@@ -1153,7 +1153,7 @@ H5G_obj_lookup_by_idx(const H5O_loc_t *grp_oloc, H5_index_t idx_type, H5_iter_or
         } /* end if */
 
         /* Check for dense link storage */
-        if (H5F_addr_defined(linfo.fheap_addr)) {
+        if (H5_addr_defined(linfo.fheap_addr)) {
             /* Get the link from the dense storage */
             if (H5G__dense_lookup_by_idx(grp_oloc->file, &linfo, idx_type, order, n, lnk) < 0)
                 HGOTO_ERROR(H5E_SYM, H5E_NOTFOUND, FAIL, "can't locate object")

--- a/src/H5Goh.c
+++ b/src/H5Goh.c
@@ -327,7 +327,7 @@ H5O__group_bh_info(const H5O_loc_t *loc, H5O_t *oh, H5_ih_info_t *bh_info)
     /* Sanity check */
     HDassert(loc);
     HDassert(loc->file);
-    HDassert(H5F_addr_defined(loc->addr));
+    HDassert(H5_addr_defined(loc->addr));
     HDassert(oh);
     HDassert(bh_info);
 
@@ -342,7 +342,7 @@ H5O__group_bh_info(const H5O_loc_t *loc, H5O_t *oh, H5_ih_info_t *bh_info)
             HGOTO_ERROR(H5E_SYM, H5E_CANTGET, FAIL, "can't read LINFO message")
 
         /* Check if name index available */
-        if (H5F_addr_defined(linfo.name_bt2_addr)) {
+        if (H5_addr_defined(linfo.name_bt2_addr)) {
             /* Open the name index v2 B-tree */
             if (NULL == (bt2_name = H5B2_open(loc->file, linfo.name_bt2_addr, NULL)))
                 HGOTO_ERROR(H5E_SYM, H5E_CANTOPENOBJ, FAIL, "unable to open v2 B-tree for name index")
@@ -353,7 +353,7 @@ H5O__group_bh_info(const H5O_loc_t *loc, H5O_t *oh, H5_ih_info_t *bh_info)
         } /* end if */
 
         /* Check if creation order index available */
-        if (H5F_addr_defined(linfo.corder_bt2_addr)) {
+        if (H5_addr_defined(linfo.corder_bt2_addr)) {
             /* Open the creation order index v2 B-tree */
             if (NULL == (bt2_corder = H5B2_open(loc->file, linfo.corder_bt2_addr, NULL)))
                 HGOTO_ERROR(H5E_SYM, H5E_CANTOPENOBJ, FAIL,
@@ -366,7 +366,7 @@ H5O__group_bh_info(const H5O_loc_t *loc, H5O_t *oh, H5_ih_info_t *bh_info)
         } /* end if */
 
         /* Get fractal heap size, if available */
-        if (H5F_addr_defined(linfo.fheap_addr)) {
+        if (H5_addr_defined(linfo.fheap_addr)) {
             /* Open the fractal heap for links */
             if (NULL == (fheap = H5HF_open(loc->file, linfo.fheap_addr)))
                 HGOTO_ERROR(H5E_SYM, H5E_CANTOPENOBJ, FAIL, "unable to open fractal heap")

--- a/src/H5Gstab.c
+++ b/src/H5Gstab.c
@@ -452,8 +452,8 @@ H5G__stab_delete(H5F_t *f, const H5O_stab_t *stab)
 
     HDassert(f);
     HDassert(stab);
-    HDassert(H5F_addr_defined(stab->btree_addr));
-    HDassert(H5F_addr_defined(stab->heap_addr));
+    HDassert(H5_addr_defined(stab->btree_addr));
+    HDassert(H5_addr_defined(stab->heap_addr));
 
     /* Pin the heap down in memory */
     if (NULL == (heap = H5HL_protect(f, stab->heap_addr, H5AC__NO_FLAGS_SET)))

--- a/src/H5Gtest.c
+++ b/src/H5Gtest.c
@@ -134,11 +134,11 @@ H5G__is_empty_test(hid_t gid)
             HGOTO_ERROR(H5E_SYM, H5E_BADMESG, FAIL, "can't get link info")
 
         /* Check for 'dense' link storage file addresses being defined */
-        if (H5F_addr_defined(linfo.fheap_addr))
+        if (H5_addr_defined(linfo.fheap_addr))
             HGOTO_DONE(FALSE)
-        if (H5F_addr_defined(linfo.name_bt2_addr))
+        if (H5_addr_defined(linfo.name_bt2_addr))
             HGOTO_DONE(FALSE)
-        if (H5F_addr_defined(linfo.corder_bt2_addr))
+        if (H5_addr_defined(linfo.corder_bt2_addr))
             HGOTO_DONE(FALSE)
 
         /* Check for link count */
@@ -368,9 +368,9 @@ H5G__is_new_dense_test(hid_t gid)
             HGOTO_ERROR(H5E_SYM, H5E_BADMESG, FAIL, "can't get link info")
 
         /* Check for 'dense' link storage file addresses being defined */
-        if (!H5F_addr_defined(linfo.fheap_addr))
+        if (!H5_addr_defined(linfo.fheap_addr))
             HGOTO_DONE(FALSE)
-        if (!H5F_addr_defined(linfo.name_bt2_addr))
+        if (!H5_addr_defined(linfo.name_bt2_addr))
             HGOTO_DONE(FALSE)
     } /* end if */
 
@@ -431,9 +431,9 @@ H5G__new_dense_info_test(hid_t gid, hsize_t *name_count, hsize_t *corder_count)
         HGOTO_ERROR_TAG(H5E_SYM, H5E_BADMESG, FAIL, "can't get link info")
 
     /* Check for 'dense' link storage file addresses being defined */
-    if (!H5F_addr_defined(linfo.fheap_addr))
+    if (!H5_addr_defined(linfo.fheap_addr))
         HGOTO_DONE_TAG(FAIL)
-    if (!H5F_addr_defined(linfo.name_bt2_addr))
+    if (!H5_addr_defined(linfo.name_bt2_addr))
         HGOTO_DONE_TAG(FAIL)
 
     /* Open the name index v2 B-tree */
@@ -445,7 +445,7 @@ H5G__new_dense_info_test(hid_t gid, hsize_t *name_count, hsize_t *corder_count)
         HGOTO_ERROR_TAG(H5E_SYM, H5E_CANTCOUNT, FAIL, "unable to retrieve # of records from name index")
 
     /* Check if there is a creation order index */
-    if (H5F_addr_defined(linfo.corder_bt2_addr)) {
+    if (H5_addr_defined(linfo.corder_bt2_addr)) {
         /* Open the creation order index v2 B-tree */
         if (NULL == (bt2_corder = H5B2_open(grp->oloc.file, linfo.corder_bt2_addr, NULL)))
             HGOTO_ERROR_TAG(H5E_SYM, H5E_CANTOPENOBJ, FAIL,
@@ -724,7 +724,7 @@ H5G__verify_cached_stabs_test_cb(H5F_t *f, const void H5_ATTR_UNUSED *_lt_key, h
 
     /* Check arguments */
     HDassert(f);
-    HDassert(H5F_addr_defined(addr));
+    HDassert(H5_addr_defined(addr));
 
     /* Load the node */
     if (NULL == (sn = (H5G_node_t *)H5AC_protect(f, H5AC_SNODE, addr, f, H5AC__READ_ONLY_FLAG)))

--- a/src/H5Gtraverse.c
+++ b/src/H5Gtraverse.c
@@ -420,7 +420,7 @@ H5G__traverse_special(const H5G_loc_t *grp_loc, const H5O_link_t *lnk, unsigned 
      *  the status of the object (into a hard link), so don't use an 'else'
      *  statement here. -QAK)
      */
-    if (H5F_addr_defined(obj_loc->oloc->addr) && (0 == (target & H5G_TARGET_MOUNT) || !last_comp)) {
+    if (H5_addr_defined(obj_loc->oloc->addr) && (0 == (target & H5G_TARGET_MOUNT) || !last_comp)) {
         if (H5F_traverse_mount(obj_loc->oloc /*in,out*/) < 0)
             HGOTO_ERROR(H5E_SYM, H5E_NOTFOUND, FAIL, "mount point traversal failed")
     } /* end if */

--- a/src/H5HF.c
+++ b/src/H5HF.c
@@ -217,7 +217,7 @@ H5HF_open(H5F_t *f, haddr_t fh_addr)
      * Check arguments.
      */
     HDassert(f);
-    HDassert(H5F_addr_defined(fh_addr));
+    HDassert(H5_addr_defined(fh_addr));
 
     /* Load the heap header into memory */
     if (NULL == (hdr = H5HF__hdr_protect(f, fh_addr, H5AC__READ_ONLY_FLAG)))
@@ -893,7 +893,7 @@ H5HF_delete(H5F_t *f, haddr_t fh_addr)
      * Check arguments.
      */
     HDassert(f);
-    HDassert(H5F_addr_defined(fh_addr));
+    HDassert(H5_addr_defined(fh_addr));
 
     /* Lock the heap header into memory */
     if (NULL == (hdr = H5HF__hdr_protect(f, fh_addr, H5AC__NO_FLAGS_SET)))

--- a/src/H5HFcache.c
+++ b/src/H5HFcache.c
@@ -648,7 +648,7 @@ H5HF__cache_hdr_pre_serialize(H5F_t *f, void *_thing, haddr_t addr, size_t len,
     HDassert(f);
     HDassert(hdr);
     HDassert(hdr->cache_info.type == H5AC_FHEAP_HDR);
-    HDassert(H5F_addr_defined(addr));
+    HDassert(H5_addr_defined(addr));
     HDassert(addr == hdr->heap_addr);
     HDassert(new_addr);
     HDassert(new_len);
@@ -997,7 +997,7 @@ H5HF__cache_iblock_deserialize(const void *_image, size_t H5_ATTR_NDEBUG_UNUSED 
 
     /* Address of heap that owns this block */
     H5F_addr_decode(udata->f, &image, &heap_addr);
-    if (H5F_addr_ne(heap_addr, hdr->heap_addr))
+    if (H5_addr_ne(heap_addr, hdr->heap_addr))
         HGOTO_ERROR(H5E_HEAP, H5E_CANTLOAD, NULL, "incorrect heap header address for direct block")
 
     /* Address of parent block */
@@ -1065,8 +1065,8 @@ H5HF__cache_iblock_deserialize(const void *_image, size_t H5_ATTR_NDEBUG_UNUSED 
                 /* (either both the address & size are defined or both are
                  *  not defined)
                  */
-                HDassert((H5F_addr_defined(iblock->ents[u].addr) && iblock->filt_ents[u].size) ||
-                         (!H5F_addr_defined(iblock->ents[u].addr) && iblock->filt_ents[u].size == 0));
+                HDassert((H5_addr_defined(iblock->ents[u].addr) && iblock->filt_ents[u].size) ||
+                         (!H5_addr_defined(iblock->ents[u].addr) && iblock->filt_ents[u].size == 0));
 
                 /* I/O filter mask for filtered direct block */
                 UINT32DECODE(image, iblock->filt_ents[u].filter_mask);
@@ -1074,7 +1074,7 @@ H5HF__cache_iblock_deserialize(const void *_image, size_t H5_ATTR_NDEBUG_UNUSED 
         }     /* end if */
 
         /* Count child blocks */
-        if (H5F_addr_defined(iblock->ents[u].addr)) {
+        if (H5_addr_defined(iblock->ents[u].addr)) {
             iblock->nchildren++;
             iblock->max_child = u;
         } /* end if */
@@ -1182,8 +1182,8 @@ H5HF__cache_iblock_pre_serialize(H5F_t *f, void *_thing, haddr_t addr, size_t H5
     HDassert(iblock);
     HDassert(iblock->cache_info.type == H5AC_FHEAP_IBLOCK);
     HDassert(iblock->cache_info.size == iblock->size);
-    HDassert(H5F_addr_defined(addr));
-    HDassert(H5F_addr_eq(iblock->addr, addr));
+    HDassert(H5_addr_defined(addr));
+    HDassert(H5_addr_eq(iblock->addr, addr));
     HDassert(new_addr);
     HDassert(new_len);
     HDassert(flags);
@@ -1228,7 +1228,7 @@ H5HF__cache_iblock_pre_serialize(H5F_t *f, void *_thing, haddr_t addr, size_t H5
             HGOTO_ERROR(H5E_HEAP, H5E_NOSPACE, FAIL, "file allocation failed for fractal heap indirect block")
 
         /* Sanity check */
-        HDassert(!H5F_addr_eq(iblock->addr, iblock_addr));
+        HDassert(!H5_addr_eq(iblock->addr, iblock_addr));
 
         /* Let the metadata cache know the block moved */
         if (H5AC_move_entry((H5F_t *)f, H5AC_FHEAP_IBLOCK, iblock->addr, iblock_addr) < 0)
@@ -1313,7 +1313,7 @@ H5HF__cache_iblock_serialize(const H5F_t *f, void *_image, size_t H5_ATTR_NDEBUG
 
     /* Indirect block must be in 'normal' file space */
     HDassert(!H5F_IS_TMP_ADDR(f, iblock->addr));
-    HDassert(H5F_addr_eq(iblock->addr, iblock->cache_info.addr));
+    HDassert(H5_addr_eq(iblock->addr, iblock->cache_info.addr));
 
     /* Get the pointer to the shared heap header */
     hdr = iblock->hdr;
@@ -1354,8 +1354,8 @@ H5HF__cache_iblock_serialize(const H5F_t *f, void *_image, size_t H5_ATTR_NDEBUG
                 /* (either both the address & size are defined or both are
                  *  not defined)
                  */
-                HDassert((H5F_addr_defined(iblock->ents[u].addr) && iblock->filt_ents[u].size) ||
-                         (!H5F_addr_defined(iblock->ents[u].addr) && iblock->filt_ents[u].size == 0));
+                HDassert((H5_addr_defined(iblock->ents[u].addr) && iblock->filt_ents[u].size) ||
+                         (!H5_addr_defined(iblock->ents[u].addr) && iblock->filt_ents[u].size == 0));
 
                 /* Size of filtered direct block */
                 H5F_ENCODE_LENGTH(f, image, iblock->filt_ents[u].size);
@@ -1367,7 +1367,7 @@ H5HF__cache_iblock_serialize(const H5F_t *f, void *_image, size_t H5_ATTR_NDEBUG
 
 #ifndef NDEBUG
         /* Count child blocks */
-        if (H5F_addr_defined(iblock->ents[u].addr)) {
+        if (H5_addr_defined(iblock->ents[u].addr)) {
             nchildren++;
             if (u > max_child)
                 max_child = u;
@@ -1834,7 +1834,7 @@ H5HF__cache_dblock_deserialize(const void *_image, size_t len, void *_udata, hbo
 
     /* Address of heap that owns this block (just for file integrity checks) */
     H5F_addr_decode(udata->f, &image, &heap_addr);
-    if (H5F_addr_ne(heap_addr, hdr->heap_addr))
+    if (H5_addr_ne(heap_addr, hdr->heap_addr))
         HGOTO_ERROR(H5E_HEAP, H5E_CANTLOAD, NULL, "incorrect heap header address for direct block")
 
     /* Address of parent block */
@@ -2055,7 +2055,7 @@ H5HF__cache_dblock_pre_serialize(H5F_t *f, void *_thing, haddr_t addr, size_t le
     HDassert(dblock->write_buf == NULL);
     HDassert(dblock->write_size == 0);
     HDassert(dblock->cache_info.size == len);
-    HDassert(H5F_addr_defined(addr));
+    HDassert(H5_addr_defined(addr));
     HDassert(new_addr);
     HDassert(new_len);
     HDassert(flags);
@@ -2081,7 +2081,7 @@ H5HF__cache_dblock_pre_serialize(H5F_t *f, void *_thing, haddr_t addr, size_t le
         par_entry  = dblock->par_entry;
 
         HDassert(par_iblock->cache_info.type == H5AC_FHEAP_IBLOCK);
-        HDassert(H5F_addr_eq(par_iblock->ents[par_entry].addr, addr));
+        HDassert(H5_addr_eq(par_iblock->ents[par_entry].addr, addr));
     } /* end if */
     else {
         /* the direct block is a root direct block -- just set par_iblock
@@ -2181,7 +2181,7 @@ H5HF__cache_dblock_pre_serialize(H5F_t *f, void *_thing, haddr_t addr, size_t le
             hbool_t hdr_changed = FALSE; /* Whether the header info changed */
 
             /* Sanity check */
-            HDassert(H5F_addr_eq(hdr->man_dtable.table_addr, addr));
+            HDassert(H5_addr_eq(hdr->man_dtable.table_addr, addr));
             HDassert(hdr->pline_root_direct_size > 0);
 
             /* Check if the filter mask changed */
@@ -2314,8 +2314,8 @@ H5HF__cache_dblock_pre_serialize(H5F_t *f, void *_thing, haddr_t addr, size_t le
             /* Check for root direct block */
             if (NULL == dblock->parent) {
                 /* Sanity checks */
-                HDassert(H5F_addr_eq(hdr->man_dtable.table_addr, addr));
-                HDassert(!H5F_addr_eq(hdr->man_dtable.table_addr, dblock_addr));
+                HDassert(H5_addr_eq(hdr->man_dtable.table_addr, addr));
+                HDassert(!H5_addr_eq(hdr->man_dtable.table_addr, dblock_addr));
 
                 /* Update information about direct block's location */
                 hdr->man_dtable.table_addr = dblock_addr;
@@ -2328,8 +2328,8 @@ H5HF__cache_dblock_pre_serialize(H5F_t *f, void *_thing, haddr_t addr, size_t le
                 /* Sanity checks */
                 HDassert(par_iblock);
                 HDassert(par_iblock->ents);
-                HDassert(H5F_addr_eq(par_iblock->ents[par_entry].addr, addr));
-                HDassert(!H5F_addr_eq(par_iblock->ents[par_entry].addr, dblock_addr));
+                HDassert(H5_addr_eq(par_iblock->ents[par_entry].addr, addr));
+                HDassert(!H5_addr_eq(par_iblock->ents[par_entry].addr, dblock_addr));
 
                 /* Update information about direct block's location */
                 par_iblock->ents[par_entry].addr = dblock_addr;
@@ -2355,7 +2355,7 @@ H5HF__cache_dblock_pre_serialize(H5F_t *f, void *_thing, haddr_t addr, size_t le
     dblock->write_size = write_size;
 
     /* finally, pass data back to the metadata cache as appropriate */
-    if (!H5F_addr_eq(addr, dblock_addr)) {
+    if (!H5_addr_eq(addr, dblock_addr)) {
         dblock_flags |= H5AC__SERIALIZE_MOVED_FLAG;
         *new_addr = dblock_addr;
     } /* end if */
@@ -3007,7 +3007,7 @@ H5HF__cache_verify_iblock_descendants_clean(H5F_t *f, haddr_t fd_parent_addr, H5
 
     /* Sanity checks */
     HDassert(f);
-    HDassert(H5F_addr_defined(fd_parent_addr));
+    HDassert(H5_addr_defined(fd_parent_addr));
     HDassert(iblock);
     HDassert(iblock->cache_info.type == H5AC_FHEAP_IBLOCK);
     HDassert(iblock_status);
@@ -3125,7 +3125,7 @@ H5HF__cache_verify_iblocks_dblocks_clean(H5F_t *f, haddr_t fd_parent_addr, H5HF_
 
     /* Sanity checks */
     HDassert(f);
-    HDassert(H5F_addr_defined(fd_parent_addr));
+    HDassert(H5_addr_defined(fd_parent_addr));
     HDassert(iblock);
     HDassert(iblock->cache_info.type == H5AC_FHEAP_IBLOCK);
     HDassert(fd_clean);
@@ -3138,13 +3138,13 @@ H5HF__cache_verify_iblocks_dblocks_clean(H5F_t *f, haddr_t fd_parent_addr, H5HF_
     HDassert(num_direct_rows <= iblock->nrows);
     max_dblock_index = (num_direct_rows * iblock->hdr->man_dtable.cparam.width) - 1;
     iblock_addr      = iblock->addr;
-    HDassert(H5F_addr_defined(iblock_addr));
+    HDassert(H5_addr_defined(iblock_addr));
 
     while ((*fd_clean) && (i <= max_dblock_index)) {
         haddr_t dblock_addr;
 
         dblock_addr = iblock->ents[i].addr;
-        if (H5F_addr_defined(dblock_addr)) {
+        if (H5_addr_defined(dblock_addr)) {
             hbool_t in_cache;
             hbool_t type_ok;
 
@@ -3289,7 +3289,7 @@ H5HF__cache_verify_descendant_iblocks_clean(H5F_t *f, haddr_t fd_parent_addr, H5
 
     /* Sanity checks */
     HDassert(f);
-    HDassert(H5F_addr_defined(fd_parent_addr));
+    HDassert(H5_addr_defined(fd_parent_addr));
     HDassert(iblock);
     HDassert(iblock->cache_info.type == H5AC_FHEAP_IBLOCK);
     HDassert(fd_clean);
@@ -3307,7 +3307,7 @@ H5HF__cache_verify_descendant_iblocks_clean(H5F_t *f, haddr_t fd_parent_addr, H5
     while ((*fd_clean) && (i <= last_iblock_index)) {
         haddr_t child_iblock_addr = iblock->ents[i].addr;
 
-        if (H5F_addr_defined(child_iblock_addr)) {
+        if (H5_addr_defined(child_iblock_addr)) {
             unsigned child_iblock_status = 0;
 
             if (H5AC_get_entry_status(f, child_iblock_addr, &child_iblock_status) < 0)

--- a/src/H5HFdbg.c
+++ b/src/H5HFdbg.c
@@ -338,7 +338,7 @@ H5HF_hdr_debug(H5F_t *f, haddr_t addr, FILE *stream, int indent, int fwidth)
      * Check arguments.
      */
     HDassert(f);
-    HDassert(H5F_addr_defined(addr));
+    HDassert(H5_addr_defined(addr));
     HDassert(stream);
     HDassert(indent >= 0);
     HDassert(fwidth >= 0);
@@ -468,11 +468,11 @@ H5HF_dblock_debug(H5F_t *f, haddr_t addr, FILE *stream, int indent, int fwidth, 
      * Check arguments.
      */
     HDassert(f);
-    HDassert(H5F_addr_defined(addr));
+    HDassert(H5_addr_defined(addr));
     HDassert(stream);
     HDassert(indent >= 0);
     HDassert(fwidth >= 0);
-    HDassert(H5F_addr_defined(hdr_addr));
+    HDassert(H5_addr_defined(hdr_addr));
     HDassert(block_size > 0);
 
     /* Load the fractal heap header */
@@ -700,11 +700,11 @@ H5HF_iblock_debug(H5F_t *f, haddr_t addr, FILE *stream, int indent, int fwidth, 
      * Check arguments.
      */
     HDassert(f);
-    HDassert(H5F_addr_defined(addr));
+    HDassert(H5_addr_defined(addr));
     HDassert(stream);
     HDassert(indent >= 0);
     HDassert(fwidth >= 0);
-    HDassert(H5F_addr_defined(hdr_addr));
+    HDassert(H5_addr_defined(hdr_addr));
     HDassert(nrows > 0);
 
     /* Load the fractal heap header */
@@ -803,7 +803,7 @@ H5HF_sects_debug(H5F_t *f, haddr_t fh_addr, FILE *stream, int indent, int fwidth
      * Check arguments.
      */
     HDassert(f);
-    HDassert(H5F_addr_defined(fh_addr));
+    HDassert(H5_addr_defined(fh_addr));
     HDassert(stream);
     HDassert(indent >= 0);
     HDassert(fwidth >= 0);

--- a/src/H5HFdblock.c
+++ b/src/H5HFdblock.c
@@ -354,7 +354,7 @@ H5HF__man_dblock_new(H5HF_hdr_t *hdr, size_t request, H5HF_free_section_t **ret_
         min_dblock_size *= 2;
 
     /* Check if this is the first block in the heap */
-    if (!H5F_addr_defined(hdr->man_dtable.table_addr) &&
+    if (!H5_addr_defined(hdr->man_dtable.table_addr) &&
         min_dblock_size == hdr->man_dtable.cparam.start_block_size) {
         /* Create new direct block at starting offset */
         if (H5HF__man_dblock_create(hdr, NULL, 0, &dblock_addr, ret_sec_node) < 0)
@@ -440,7 +440,7 @@ H5HF__man_dblock_protect(H5HF_hdr_t *hdr, haddr_t dblock_addr, size_t dblock_siz
      * Check arguments.
      */
     HDassert(hdr);
-    HDassert(H5F_addr_defined(dblock_addr));
+    HDassert(H5_addr_defined(dblock_addr));
     HDassert(dblock_size > 0);
 
     /* only H5AC__READ_ONLY_FLAG may appear in flags */
@@ -467,7 +467,7 @@ H5HF__man_dblock_protect(H5HF_hdr_t *hdr, haddr_t dblock_addr, size_t dblock_siz
         } /* end if */
         else {
             /* Sanity check */
-            HDassert(H5F_addr_eq(par_iblock->ents[par_entry].addr, dblock_addr));
+            HDassert(H5_addr_eq(par_iblock->ents[par_entry].addr, dblock_addr));
 
             /* Set up parameters to read filtered direct block */
             udata.odi_size    = par_iblock->filt_ents[par_entry].size;
@@ -561,7 +561,7 @@ H5HF__man_dblock_locate(H5HF_hdr_t *hdr, hsize_t obj_off, H5HF_indirect_t **ret_
         iblock_addr = iblock->ents[entry].addr;
 
         /* Check if we need to (re-)create the child indirect block */
-        if (!H5F_addr_defined(iblock_addr)) {
+        if (!H5_addr_defined(iblock_addr)) {
             if (H5HF__man_iblock_create(hdr, iblock, entry, nrows, nrows, &iblock_addr) < 0)
                 HGOTO_ERROR(H5E_HEAP, H5E_CANTALLOC, FAIL, "can't allocate fractal heap indirect block")
 
@@ -627,7 +627,7 @@ H5HF__man_dblock_delete(H5F_t *f, haddr_t dblock_addr, hsize_t dblock_size)
      * Check arguments.
      */
     HDassert(f);
-    HDassert(H5F_addr_defined(dblock_addr));
+    HDassert(H5_addr_defined(dblock_addr));
     HDassert(dblock_size > 0);
 
     /* Check the direct block's status in the metadata cache */

--- a/src/H5HFhdr.c
+++ b/src/H5HFhdr.c
@@ -491,7 +491,7 @@ H5HF__hdr_create(H5F_t *f, const H5HF_create_t *cparam)
     ret_value = hdr->heap_addr;
 
 done:
-    if (!H5F_addr_defined(ret_value) && hdr)
+    if (!H5_addr_defined(ret_value) && hdr)
         if (H5HF__hdr_free(hdr) < 0)
             HDONE_ERROR(H5E_HEAP, H5E_CANTRELEASE, HADDR_UNDEF, "unable to release fractal heap header")
 
@@ -521,7 +521,7 @@ H5HF__hdr_protect(H5F_t *f, haddr_t addr, unsigned flags)
 
     /* Check arguments */
     HDassert(f);
-    HDassert(H5F_addr_defined(addr));
+    HDassert(H5_addr_defined(addr));
 
     /* only H5AC__READ_ONLY_FLAG may appear in flags */
     HDassert((flags & (unsigned)(~H5AC__READ_ONLY_FLAG)) == 0);
@@ -1039,7 +1039,7 @@ H5HF__hdr_update_iter(H5HF_hdr_t *hdr, size_t min_dblock_size)
             if (next_row >= hdr->man_dtable.max_direct_rows) {
                 unsigned child_nrows; /* Number of rows in new indirect block */
 
-                HDassert(!H5F_addr_defined(iblock->ents[next_entry].addr));
+                HDassert(!H5_addr_defined(iblock->ents[next_entry].addr));
 
                 /* Compute # of rows in next child indirect block to use */
                 child_nrows =
@@ -1215,8 +1215,8 @@ H5HF__hdr_reverse_iter(H5HF_hdr_t *hdr, haddr_t dblock_addr)
         /* Walk backwards through entries, until we find one that has a child */
         /* (Skip direct block that will be deleted, if we find it) */
         tmp_entry = (int)curr_entry;
-        while (tmp_entry >= 0 && (H5F_addr_eq(iblock->ents[tmp_entry].addr, dblock_addr) ||
-                                  !H5F_addr_defined(iblock->ents[tmp_entry].addr)))
+        while (tmp_entry >= 0 && (H5_addr_eq(iblock->ents[tmp_entry].addr, dblock_addr) ||
+                                  !H5_addr_defined(iblock->ents[tmp_entry].addr)))
             tmp_entry--;
         /* Check for no earlier blocks in this indirect block */
         if (tmp_entry < 0) {
@@ -1446,13 +1446,13 @@ H5HF__hdr_delete(H5HF_hdr_t *hdr)
     /* (must occur before attempting to delete the heap, so indirect blocks
      *  will get unpinned)
      */
-    if (H5F_addr_defined(hdr->fs_addr))
+    if (H5_addr_defined(hdr->fs_addr))
         /* Delete free space manager for heap */
         if (H5HF__space_delete(hdr) < 0)
             HGOTO_ERROR(H5E_HEAP, H5E_CANTFREE, FAIL, "unable to release fractal heap free space manager")
 
     /* Check for root direct/indirect block */
-    if (H5F_addr_defined(hdr->man_dtable.table_addr)) {
+    if (H5_addr_defined(hdr->man_dtable.table_addr)) {
         if (hdr->man_dtable.curr_root_rows == 0) {
             hsize_t dblock_size; /* Size of direct block on disk */
 
@@ -1482,7 +1482,7 @@ H5HF__hdr_delete(H5HF_hdr_t *hdr)
     }     /* end if */
 
     /* Check for 'huge' objects in heap */
-    if (H5F_addr_defined(hdr->huge_bt2_addr)) {
+    if (H5_addr_defined(hdr->huge_bt2_addr)) {
         /* Delete huge objects in heap and their tracker */
         if (H5HF__huge_delete(hdr) < 0)
             HGOTO_ERROR(H5E_HEAP, H5E_CANTFREE, FAIL,

--- a/src/H5HFhuge.c
+++ b/src/H5HFhuge.c
@@ -306,7 +306,7 @@ H5HF__huge_insert(H5HF_hdr_t *hdr, size_t obj_size, void *obj, void *_id)
     HDassert(id);
 
     /* Check if the v2 B-tree for tracking 'huge' heap objects has been created yet */
-    if (!H5F_addr_defined(hdr->huge_bt2_addr)) {
+    if (!H5_addr_defined(hdr->huge_bt2_addr)) {
         /* Go create (& open) v2 B-tree */
         if (H5HF__huge_bt2_create(hdr) < 0)
             HGOTO_ERROR(H5E_HEAP, H5E_CANTCREATE, FAIL,
@@ -482,7 +482,7 @@ H5HF__huge_get_obj_len(H5HF_hdr_t *hdr, const uint8_t *id, size_t *obj_len_p)
      * Check arguments.
      */
     HDassert(hdr);
-    HDassert(H5F_addr_defined(hdr->huge_bt2_addr));
+    HDassert(H5_addr_defined(hdr->huge_bt2_addr));
     HDassert(id);
     HDassert(obj_len_p);
 
@@ -580,7 +580,7 @@ H5HF__huge_get_obj_off(H5HF_hdr_t *hdr, const uint8_t *id, hsize_t *obj_off_p)
      * Check arguments.
      */
     HDassert(hdr);
-    HDassert(H5F_addr_defined(hdr->huge_bt2_addr));
+    HDassert(H5_addr_defined(hdr->huge_bt2_addr));
     HDassert(id);
     HDassert(obj_off_p);
 
@@ -596,7 +596,7 @@ H5HF__huge_get_obj_off(H5HF_hdr_t *hdr, const uint8_t *id, hsize_t *obj_off_p)
         hbool_t found = FALSE; /* Whether entry was found */
 
         /* Sanity check */
-        HDassert(H5F_addr_defined(hdr->huge_bt2_addr));
+        HDassert(H5_addr_defined(hdr->huge_bt2_addr));
 
         /* Check if v2 B-tree is open yet */
         if (NULL == hdr->huge_bt2) {
@@ -695,7 +695,7 @@ H5HF__huge_op_real(H5HF_hdr_t *hdr, const uint8_t *id, hbool_t is_read, H5HF_ope
         hbool_t found = FALSE; /* Whether entry was found */
 
         /* Sanity check */
-        HDassert(H5F_addr_defined(hdr->huge_bt2_addr));
+        HDassert(H5_addr_defined(hdr->huge_bt2_addr));
 
         /* Check if v2 B-tree is open yet */
         if (NULL == hdr->huge_bt2) {
@@ -852,7 +852,7 @@ H5HF__huge_write(H5HF_hdr_t *hdr, const uint8_t *id, const void *obj)
         hbool_t                   found = FALSE; /* Whether entry was found */
 
         /* Sanity check */
-        HDassert(H5F_addr_defined(hdr->huge_bt2_addr));
+        HDassert(H5_addr_defined(hdr->huge_bt2_addr));
 
         /* Check if v2 B-tree is open yet */
         if (NULL == hdr->huge_bt2) {
@@ -977,7 +977,7 @@ H5HF__huge_remove(H5HF_hdr_t *hdr, const uint8_t *id)
      * Check arguments.
      */
     HDassert(hdr);
-    HDassert(H5F_addr_defined(hdr->huge_bt2_addr));
+    HDassert(H5_addr_defined(hdr->huge_bt2_addr));
     HDassert(id);
 
     /* Check if v2 B-tree is open yet */
@@ -1087,7 +1087,7 @@ H5HF__huge_term(H5HF_hdr_t *hdr)
     /* Check if v2 B-tree index is open */
     if (hdr->huge_bt2) {
         /* Sanity check */
-        HDassert(H5F_addr_defined(hdr->huge_bt2_addr));
+        HDassert(H5_addr_defined(hdr->huge_bt2_addr));
 
         /* Close v2 B-tree index */
         if (H5B2_close(hdr->huge_bt2) < 0)
@@ -1098,7 +1098,7 @@ H5HF__huge_term(H5HF_hdr_t *hdr)
     /* Check if there are no more 'huge' objects in the heap and delete the
      *  v2 B-tree that tracks them, if so
      */
-    if (H5F_addr_defined(hdr->huge_bt2_addr) && hdr->huge_nobjs == 0) {
+    if (H5_addr_defined(hdr->huge_bt2_addr) && hdr->huge_nobjs == 0) {
         /* Sanity check */
         HDassert(hdr->huge_size == 0);
 
@@ -1147,7 +1147,7 @@ H5HF__huge_delete(H5HF_hdr_t *hdr)
      * Check arguments.
      */
     HDassert(hdr);
-    HDassert(H5F_addr_defined(hdr->huge_bt2_addr));
+    HDassert(H5_addr_defined(hdr->huge_bt2_addr));
     HDassert(hdr->huge_nobjs);
     HDassert(hdr->huge_size);
 

--- a/src/H5HFiblock.c
+++ b/src/H5HFiblock.c
@@ -377,7 +377,7 @@ H5HF__man_iblock_root_create(H5HF_hdr_t *hdr, size_t min_dblock_size)
         HGOTO_ERROR(H5E_HEAP, H5E_CANTPROTECT, FAIL, "unable to protect fractal heap indirect block")
 
     /* Check if there's already a direct block as root) */
-    have_direct_block = H5F_addr_defined(hdr->man_dtable.table_addr);
+    have_direct_block = H5_addr_defined(hdr->man_dtable.table_addr);
     if (have_direct_block) {
         H5HF_direct_t *dblock; /* Pointer to direct block to query */
 
@@ -562,7 +562,7 @@ H5HF__man_iblock_root_double(H5HF_hdr_t *hdr, size_t min_dblock_size)
     } /* end if */
 
     /* Move object in cache, if it actually was relocated */
-    if (H5F_addr_ne(iblock->addr, new_addr)) {
+    if (H5_addr_ne(iblock->addr, new_addr)) {
         if (H5AC_move_entry(hdr->f, H5AC_FHEAP_IBLOCK, iblock->addr, new_addr) < 0)
             HGOTO_ERROR(H5E_HEAP, H5E_CANTMOVE, FAIL, "unable to move fractal heap root indirect block")
         iblock->addr = new_addr;
@@ -726,7 +726,7 @@ H5HF__man_iblock_root_halve(H5HF_indirect_t *iblock)
     } /* end if */
 
     /* Move object in cache, if it actually was relocated */
-    if (H5F_addr_ne(iblock->addr, new_addr)) {
+    if (H5_addr_ne(iblock->addr, new_addr)) {
         if (H5AC_move_entry(hdr->f, H5AC_FHEAP_IBLOCK, iblock->addr, new_addr) < 0)
             HGOTO_ERROR(H5E_HEAP, H5E_CANTSPLIT, FAIL, "unable to move fractal heap root indirect block")
         iblock->addr = new_addr;
@@ -1119,7 +1119,7 @@ H5HF__man_iblock_protect(H5HF_hdr_t *hdr, haddr_t iblock_addr, unsigned iblock_n
      * Check arguments.
      */
     HDassert(hdr);
-    HDassert(H5F_addr_defined(iblock_addr));
+    HDassert(H5_addr_defined(iblock_addr));
     HDassert(iblock_nrows > 0);
     HDassert(did_protect);
 
@@ -1147,7 +1147,7 @@ H5HF__man_iblock_protect(H5HF_hdr_t *hdr, haddr_t iblock_addr, unsigned iblock_n
         } /* end if */
         else {
             /* Check for root indirect block */
-            if (H5F_addr_eq(iblock_addr, hdr->man_dtable.table_addr)) {
+            if (H5_addr_eq(iblock_addr, hdr->man_dtable.table_addr)) {
                 /* Check for valid pointer to pinned indirect block in root */
                 if (H5HF_ROOT_IBLOCK_PINNED == hdr->root_iblock_flags) {
                     /* Sanity check */
@@ -1293,8 +1293,8 @@ H5HF__man_iblock_attach(H5HF_indirect_t *iblock, unsigned entry, haddr_t child_a
      * Check arguments.
      */
     HDassert(iblock);
-    HDassert(H5F_addr_defined(child_addr));
-    HDassert(!H5F_addr_defined(iblock->ents[entry].addr));
+    HDassert(H5_addr_defined(child_addr));
+    HDassert(!H5_addr_defined(iblock->ents[entry].addr));
 
     /* Increment the reference count on this indirect block */
     if (H5HF__iblock_incr(iblock) < 0)
@@ -1409,7 +1409,7 @@ H5HF__man_iblock_detach(H5HF_indirect_t *iblock, unsigned entry)
     /* Reduce the max. entry used, if necessary */
     if (entry == iblock->max_child) {
         if (iblock->nchildren > 0)
-            while (!H5F_addr_defined(iblock->ents[iblock->max_child].addr))
+            while (!H5_addr_defined(iblock->ents[iblock->max_child].addr))
                 iblock->max_child--;
         else
             iblock->max_child = 0;
@@ -1421,7 +1421,7 @@ H5HF__man_iblock_detach(H5HF_indirect_t *iblock, unsigned entry)
          *      direct block in the heap, convert the heap back to using a root
          *      direct block
          */
-        if (iblock->nchildren == 1 && H5F_addr_defined(iblock->ents[0].addr))
+        if (iblock->nchildren == 1 && H5_addr_defined(iblock->ents[0].addr))
             if (H5HF__man_iblock_root_revert(iblock) < 0)
                 HGOTO_ERROR(H5E_HEAP, H5E_CANTSHRINK, FAIL,
                             "can't convert root indirect block back to root direct block")
@@ -1612,7 +1612,7 @@ H5HF__man_iblock_delete(H5HF_hdr_t *hdr, haddr_t iblock_addr, unsigned iblock_nr
      * Check arguments.
      */
     HDassert(hdr);
-    HDassert(H5F_addr_defined(iblock_addr));
+    HDassert(H5_addr_defined(iblock_addr));
     HDassert(iblock_nrows > 0);
 
     /* Lock indirect block */
@@ -1628,7 +1628,7 @@ H5HF__man_iblock_delete(H5HF_hdr_t *hdr, haddr_t iblock_addr, unsigned iblock_nr
         /* Iterate over entries in this row */
         for (col = 0; col < hdr->man_dtable.cparam.width; col++, entry++) {
             /* Check for child entry at this position */
-            if (H5F_addr_defined(iblock->ents[entry].addr)) {
+            if (H5_addr_defined(iblock->ents[entry].addr)) {
                 /* Are we in a direct or indirect block row */
                 if (row < hdr->man_dtable.max_direct_rows) {
                     hsize_t dblock_size; /* Size of direct block on disk */
@@ -1722,7 +1722,7 @@ H5HF__man_iblock_size(H5F_t *f, H5HF_hdr_t *hdr, haddr_t iblock_addr, unsigned n
      */
     HDassert(f);
     HDassert(hdr);
-    HDassert(H5F_addr_defined(iblock_addr));
+    HDassert(H5_addr_defined(iblock_addr));
     HDassert(heap_size);
 
     /* Protect the indirect block */
@@ -1750,7 +1750,7 @@ H5HF__man_iblock_size(H5F_t *f, H5HF_hdr_t *hdr, haddr_t iblock_addr, unsigned n
             size_t v; /* Local index variable */
 
             for (v = 0; v < hdr->man_dtable.cparam.width; v++, entry++)
-                if (H5F_addr_defined(iblock->ents[entry].addr))
+                if (H5_addr_defined(iblock->ents[entry].addr))
                     if (H5HF__man_iblock_size(f, hdr, iblock->ents[entry].addr, num_indirect_rows, iblock,
                                               entry, heap_size) < 0)
                         HGOTO_ERROR(H5E_HEAP, H5E_CANTLOAD, FAIL,

--- a/src/H5HFman.c
+++ b/src/H5HFman.c
@@ -373,7 +373,7 @@ H5HF__man_op_real(H5HF_hdr_t *hdr, const uint8_t *id, H5HF_operator_t op, void *
         dblock_size = (size_t)hdr->man_dtable.row_block_size[entry / hdr->man_dtable.cparam.width];
 
         /* Check for offset of invalid direct block */
-        if (!H5F_addr_defined(dblock_addr)) {
+        if (!H5_addr_defined(dblock_addr)) {
             /* Unlock indirect block */
             if (H5HF__man_iblock_unprotect(iblock, H5AC__NO_FLAGS_SET, did_protect) < 0)
                 HGOTO_ERROR(H5E_HEAP, H5E_CANTUNPROTECT, FAIL,
@@ -605,7 +605,7 @@ H5HF__man_remove(H5HF_hdr_t *hdr, const uint8_t *id)
             HGOTO_ERROR(H5E_HEAP, H5E_CANTCOMPUTE, FAIL, "can't compute row & column of section")
 
         /* Check for offset of invalid direct block */
-        if (!H5F_addr_defined(iblock->ents[dblock_entry].addr))
+        if (!H5_addr_defined(iblock->ents[dblock_entry].addr))
             HGOTO_ERROR(H5E_HEAP, H5E_BADRANGE, FAIL, "fractal heap ID not in allocated direct block")
 
         /* Set direct block info */

--- a/src/H5HFsection.c
+++ b/src/H5HFsection.c
@@ -377,7 +377,7 @@ H5FS__sect_node_new(unsigned sect_type, haddr_t sect_addr, hsize_t sect_size, H5
     FUNC_ENTER_PACKAGE
 
     /* Check arguments. */
-    HDassert(H5F_addr_defined(sect_addr));
+    HDassert(H5_addr_defined(sect_addr));
 
     /* Create free list section node */
     if (NULL == (new_sect = H5FL_MALLOC(H5HF_free_section_t)))
@@ -576,7 +576,7 @@ H5HF__sect_single_revive(H5HF_hdr_t *hdr, H5HF_free_section_t *sect)
     /* Check for root direct block */
     if (hdr->man_dtable.curr_root_rows == 0) {
         /* Set the information for the section */
-        HDassert(H5F_addr_defined(hdr->man_dtable.table_addr));
+        HDassert(H5_addr_defined(hdr->man_dtable.table_addr));
         sect->u.single.parent    = NULL;
         sect->u.single.par_entry = 0;
     } /* end if */
@@ -624,7 +624,7 @@ H5HF__sect_single_dblock_info(H5HF_hdr_t *hdr, const H5HF_free_section_t *sect, 
     /* Check for root direct block */
     if (hdr->man_dtable.curr_root_rows == 0) {
         /* Retrieve direct block info from heap header */
-        HDassert(H5F_addr_defined(hdr->man_dtable.table_addr));
+        HDassert(H5_addr_defined(hdr->man_dtable.table_addr));
         *dblock_addr = hdr->man_dtable.table_addr;
         *dblock_size = hdr->man_dtable.cparam.start_block_size;
     } /* end if */
@@ -733,7 +733,7 @@ H5HF__sect_single_full_dblock(H5HF_hdr_t *hdr, H5HF_free_section_t *sect)
         if (NULL == (dblock = H5HF__man_dblock_protect(hdr, dblock_addr, dblock_size, sect->u.single.parent,
                                                        sect->u.single.par_entry, H5AC__NO_FLAGS_SET)))
             HGOTO_ERROR(H5E_HEAP, H5E_CANTPROTECT, FAIL, "unable to load fractal heap direct block")
-        HDassert(H5F_addr_eq(dblock->block_off + dblock_overhead, sect->sect_info.addr));
+        HDassert(H5_addr_eq(dblock->block_off + dblock_overhead, sect->sect_info.addr));
 
         /* Convert 'single' section into 'row' section */
         if (H5HF__sect_row_from_single(hdr, sect, dblock) < 0)
@@ -830,7 +830,7 @@ H5HF__sect_single_deserialize(const H5FS_section_class_t H5_ATTR_UNUSED *cls,
     FUNC_ENTER_PACKAGE
 
     /* Check arguments. */
-    HDassert(H5F_addr_defined(sect_addr));
+    HDassert(H5_addr_defined(sect_addr));
     HDassert(sect_size);
 
     /* Create free list section node */
@@ -875,14 +875,14 @@ H5HF__sect_single_can_merge(const H5FS_section_info_t *_sect1, const H5FS_sectio
     HDassert(sect1);
     HDassert(sect2);
     HDassert(sect1->sect_info.type == sect2->sect_info.type); /* Checks "MERGE_SYM" flag */
-    HDassert(H5F_addr_lt(sect1->sect_info.addr, sect2->sect_info.addr));
+    HDassert(H5_addr_lt(sect1->sect_info.addr, sect2->sect_info.addr));
 
     /* Check if second section adjoins first section */
     /* (This can only occur within a direct block, due to the direct block
      *  overhead at the beginning of a block, so no need to check if sections
      *  are actually within the same direct block)
      */
-    if (H5F_addr_eq(sect1->sect_info.addr + sect1->sect_info.size, sect2->sect_info.addr))
+    if (H5_addr_eq(sect1->sect_info.addr + sect1->sect_info.size, sect2->sect_info.addr))
         HGOTO_DONE(TRUE)
 
 done:
@@ -921,7 +921,7 @@ H5HF__sect_single_merge(H5FS_section_info_t **_sect1, H5FS_section_info_t *_sect
     HDassert((*sect1)->sect_info.type == H5HF_FSPACE_SECT_SINGLE);
     HDassert(sect2);
     HDassert(sect2->sect_info.type == H5HF_FSPACE_SECT_SINGLE);
-    HDassert(H5F_addr_eq((*sect1)->sect_info.addr + (*sect1)->sect_info.size, sect2->sect_info.addr));
+    HDassert(H5_addr_eq((*sect1)->sect_info.addr + (*sect1)->sect_info.size, sect2->sect_info.addr));
 
     /* Add second section's size to first section */
     (*sect1)->sect_info.size += sect2->sect_info.size;
@@ -1049,7 +1049,7 @@ H5HF__sect_single_shrink(H5FS_section_info_t **_sect, void *_udata)
     if (NULL == (dblock = H5HF__man_dblock_protect(hdr, dblock_addr, dblock_size, (*sect)->u.single.parent,
                                                    (*sect)->u.single.par_entry, H5AC__NO_FLAGS_SET)))
         HGOTO_ERROR(H5E_HEAP, H5E_CANTPROTECT, FAIL, "unable to load fractal heap direct block")
-    HDassert(H5F_addr_eq(dblock->block_off + dblock_size, (*sect)->sect_info.addr + (*sect)->sect_info.size));
+    HDassert(H5_addr_eq(dblock->block_off + dblock_size, (*sect)->sect_info.addr + (*sect)->sect_info.size));
 
     /* Get rid of section */
     if (H5HF__sect_single_free((H5FS_section_info_t *)*sect) < 0)
@@ -1143,13 +1143,13 @@ H5HF__sect_single_valid(const H5FS_section_class_t H5_ATTR_UNUSED *cls, const H5
 
             /* Sanity check settings for section's direct block's parent */
             iblock = sect->u.single.parent;
-            HDassert(H5F_addr_defined(iblock->ents[sect->u.single.par_entry].addr));
+            HDassert(H5_addr_defined(iblock->ents[sect->u.single.par_entry].addr));
 
             /* Retrieve direct block address from section */
             status = H5HF__sect_single_dblock_info(iblock->hdr, (const H5HF_free_section_t *)sect,
                                                    &dblock_addr, &dblock_size);
             HDassert(status >= 0);
-            HDassert(H5F_addr_eq(iblock->ents[sect->u.single.par_entry].addr, dblock_addr));
+            HDassert(H5_addr_eq(iblock->ents[sect->u.single.par_entry].addr, dblock_addr));
             HDassert(dblock_size > 0);
 
             /* Check if the section is actually within the heap */
@@ -1178,9 +1178,9 @@ H5HF__sect_single_valid(const H5FS_section_class_t H5_ATTR_UNUSED *cls, const H5
                 /* Sanity check settings for section */
                 HDassert(dblock_size == dblock->size);
                 HDassert(dblock->size > sect->sect_info.size);
-                HDassert(H5F_addr_lt(dblock->block_off, sect->sect_info.addr));
-                HDassert(H5F_addr_ge((dblock->block_off + dblock->size),
-                                     (sect->sect_info.addr + sect->sect_info.size)));
+                HDassert(H5_addr_lt(dblock->block_off, sect->sect_info.addr));
+                HDassert(H5_addr_ge((dblock->block_off + dblock->size),
+                                    (sect->sect_info.addr + sect->sect_info.size)));
 
                 /* Release direct block */
                 status = H5AC_unprotect(iblock->hdr->f, H5AC_FHEAP_DBLOCK, dblock_addr, dblock,
@@ -1676,7 +1676,7 @@ H5HF__sect_row_deserialize(const H5FS_section_class_t *cls, const uint8_t *buf, 
     /* Check arguments. */
     HDassert(cls);
     HDassert(buf);
-    HDassert(H5F_addr_defined(sect_addr));
+    HDassert(H5_addr_defined(sect_addr));
     HDassert(sect_size);
 
     /* Forward to indirect routine to deserialize underlying section */
@@ -1721,7 +1721,7 @@ H5HF__sect_row_can_merge(const H5FS_section_info_t *_sect1, const H5FS_section_i
     HDassert(sect1->sect_info.type == H5HF_FSPACE_SECT_FIRST_ROW);
     HDassert(sect2);
     HDassert(sect1->sect_info.type == sect2->sect_info.type); /* Checks "MERGE_SYM" flag */
-    HDassert(H5F_addr_lt(sect1->sect_info.addr, sect2->sect_info.addr));
+    HDassert(H5_addr_lt(sect1->sect_info.addr, sect2->sect_info.addr));
 
     /* Get the top indirect section underlying each row */
     top_indir_sect1 = H5HF__sect_indirect_top(sect1->u.row.under);
@@ -1737,8 +1737,8 @@ H5HF__sect_row_can_merge(const H5FS_section_info_t *_sect1, const H5FS_section_i
         if (H5HF__sect_indirect_iblock_off(sect1->u.row.under) ==
             H5HF__sect_indirect_iblock_off(sect2->u.row.under))
             /* Check if second section adjoins first section */
-            if (H5F_addr_eq((top_indir_sect1->sect_info.addr + top_indir_sect1->u.indirect.span_size),
-                            top_indir_sect2->sect_info.addr))
+            if (H5_addr_eq((top_indir_sect1->sect_info.addr + top_indir_sect1->u.indirect.span_size),
+                           top_indir_sect2->sect_info.addr))
                 HGOTO_DONE(TRUE)
 
 done:
@@ -2487,7 +2487,7 @@ H5HF__sect_indirect_init_rows(H5HF_hdr_t *hdr, H5HF_free_section_t *sect, hbool_
                                     "unable to retrieve child indirect block's address")
 
                     /* If the child indirect block's address is defined, protect it */
-                    if (H5F_addr_defined(child_iblock_addr)) {
+                    if (H5_addr_defined(child_iblock_addr)) {
                         if (NULL == (child_iblock = H5HF__man_iblock_protect(
                                          hdr, child_iblock_addr, child_nrows, sect->u.indirect.u.iblock,
                                          curr_entry, FALSE, H5AC__NO_FLAGS_SET, &did_protect)))
@@ -3881,7 +3881,7 @@ H5HF__sect_indirect_deserialize(H5HF_hdr_t *hdr, const uint8_t *buf, haddr_t sec
     /* Check arguments. */
     HDassert(hdr);
     HDassert(buf);
-    HDassert(H5F_addr_defined(sect_addr));
+    HDassert(H5_addr_defined(sect_addr));
     HDassert(sect_size);
 
     /* Indirect range's indirect block's block offset */
@@ -4034,7 +4034,7 @@ H5HF__sect_indirect_valid(const H5HF_hdr_t *hdr, const H5HF_free_section_t *sect
 
                 tmp_row_sect2 = sect->u.indirect.dir_rows[u - 1];
                 HDassert(tmp_row_sect2->u.row.row < tmp_row_sect->u.row.row);
-                HDassert(H5F_addr_lt(tmp_row_sect2->sect_info.addr, tmp_row_sect->sect_info.addr));
+                HDassert(H5_addr_lt(tmp_row_sect2->sect_info.addr, tmp_row_sect->sect_info.addr));
                 HDassert(tmp_row_sect2->sect_info.size <= tmp_row_sect->sect_info.size);
             } /* end if */
         }     /* end for */
@@ -4061,7 +4061,7 @@ H5HF__sect_indirect_valid(const H5HF_hdr_t *hdr, const H5HF_free_section_t *sect
                     *tmp_child_sect2; /* Pointer to child indirect section */
 
                 tmp_child_sect2 = sect->u.indirect.indir_ents[u - 1];
-                HDassert(H5F_addr_lt(tmp_child_sect2->sect_info.addr, tmp_child_sect->sect_info.addr));
+                HDassert(H5_addr_lt(tmp_child_sect2->sect_info.addr, tmp_child_sect->sect_info.addr));
             } /* end if */
 
             /* Recursively check child indirect section */

--- a/src/H5HFspace.c
+++ b/src/H5HFspace.c
@@ -99,7 +99,7 @@ H5HF__space_start(H5HF_hdr_t *hdr, hbool_t may_create)
     HDassert(hdr);
 
     /* Check for creating free space info for the heap */
-    if (H5F_addr_defined(hdr->fs_addr)) {
+    if (H5_addr_defined(hdr->fs_addr)) {
         /* Open an existing free space structure for the heap */
         if (NULL == (hdr->fspace = H5FS_open(hdr->f, hdr->fs_addr, NELMTS(classes), classes, hdr,
                                              (hsize_t)H5HF_FSPACE_THRHD_DEF, (hsize_t)H5HF_FSPACE_ALIGN_DEF)))
@@ -122,7 +122,7 @@ H5HF__space_start(H5HF_hdr_t *hdr, hbool_t may_create)
                 (hdr->fspace = H5FS_create(hdr->f, &hdr->fs_addr, &fs_create, NELMTS(classes), classes, hdr,
                                            (hsize_t)H5HF_FSPACE_THRHD_DEF, (hsize_t)H5HF_FSPACE_ALIGN_DEF)))
                 HGOTO_ERROR(H5E_HEAP, H5E_CANTINIT, FAIL, "can't initialize free space info")
-            HDassert(H5F_addr_defined(hdr->fs_addr));
+            HDassert(H5_addr_defined(hdr->fs_addr));
         } /* end if */
     }     /* end else */
 

--- a/src/H5HFstat.c
+++ b/src/H5HFstat.c
@@ -136,14 +136,14 @@ H5HF_size(const H5HF_t *fh, hsize_t *heap_size)
     *heap_size += hdr->huge_size;      /* "huge" object storage */
 
     /* Check for indirect blocks for managed objects */
-    if (H5F_addr_defined(hdr->man_dtable.table_addr) && hdr->man_dtable.curr_root_rows != 0)
+    if (H5_addr_defined(hdr->man_dtable.table_addr) && hdr->man_dtable.curr_root_rows != 0)
         if (H5HF__man_iblock_size(hdr->f, hdr, hdr->man_dtable.table_addr, hdr->man_dtable.curr_root_rows,
                                   NULL, 0, heap_size) < 0)
             HGOTO_ERROR(H5E_HEAP, H5E_CANTGET, FAIL,
                         "unable to get fractal heap storage info for indirect block")
 
     /* Check for B-tree storage of huge objects in fractal heap */
-    if (H5F_addr_defined(hdr->huge_bt2_addr)) {
+    if (H5_addr_defined(hdr->huge_bt2_addr)) {
         /* Open the huge object index v2 B-tree */
         if (NULL == (bt2 = H5B2_open(hdr->f, hdr->huge_bt2_addr, hdr->f)))
             HGOTO_ERROR(H5E_HEAP, H5E_CANTOPENOBJ, FAIL,
@@ -155,7 +155,7 @@ H5HF_size(const H5HF_t *fh, hsize_t *heap_size)
     } /* end if */
 
     /* Get storage for free-space tracking info */
-    if (H5F_addr_defined(hdr->fs_addr)) {
+    if (H5_addr_defined(hdr->fs_addr)) {
         if (H5HF__space_size(hdr, &meta_size) < 0)
             HGOTO_ERROR(H5E_HEAP, H5E_CANTGET, FAIL, "can't retrieve FS meta storage info")
         *heap_size += meta_size;

--- a/src/H5HG.c
+++ b/src/H5HG.c
@@ -202,8 +202,8 @@ H5HG__create(H5F_t *f, size_t size)
 
 done:
     /* Cleanup on error */
-    if (!H5F_addr_defined(ret_value)) {
-        if (H5F_addr_defined(addr)) {
+    if (!H5_addr_defined(ret_value)) {
+        if (H5_addr_defined(addr)) {
             /* Release the space on disk */
             if (H5MF_xfree(f, H5FD_MEM_GHEAP, addr, (hsize_t)size) < 0)
                 HDONE_ERROR(H5E_BTREE, H5E_CANTFREE, HADDR_UNDEF, "unable to free global heap")
@@ -242,7 +242,7 @@ H5HG__protect(H5F_t *f, haddr_t addr, unsigned flags)
 
     /* Check arguments */
     HDassert(f);
-    HDassert(H5F_addr_defined(addr));
+    HDassert(H5_addr_defined(addr));
 
     /* only H5AC__READ_ONLY_FLAG may appear in flags */
     HDassert((flags & (unsigned)(~H5AC__READ_ONLY_FLAG)) == 0);
@@ -415,7 +415,7 @@ H5HG_extend(H5F_t *f, haddr_t addr, size_t need)
 
     /* Check args */
     HDassert(f);
-    HDassert(H5F_addr_defined(addr));
+    HDassert(H5_addr_defined(addr));
 
     /* Protect the heap */
     if (NULL == (heap = H5HG__protect(f, addr, H5AC__NO_FLAGS_SET)))
@@ -521,13 +521,13 @@ H5HG_insert(H5F_t *f, size_t size, const void *obj, H5HG_t *hobj /*out*/)
      * If we didn't find any collection with enough free space then allocate a
      * new collection large enough for the message plus the collection header.
      */
-    if (!H5F_addr_defined(addr)) {
+    if (!H5_addr_defined(addr)) {
         addr = H5HG__create(f, need + H5HG_SIZEOF_HDR(f));
 
-        if (!H5F_addr_defined(addr))
+        if (!H5_addr_defined(addr))
             HGOTO_ERROR(H5E_HEAP, H5E_CANTINIT, FAIL, "unable to allocate a global heap collection")
     } /* end if */
-    HDassert(H5F_addr_defined(addr));
+    HDassert(H5_addr_defined(addr));
 
     if (NULL == (heap = H5HG__protect(f, addr, H5AC__NO_FLAGS_SET)))
         HGOTO_ERROR(H5E_HEAP, H5E_CANTPROTECT, FAIL, "unable to protect global heap")

--- a/src/H5HGdbg.c
+++ b/src/H5HGdbg.c
@@ -84,7 +84,7 @@ H5HG_debug(H5F_t *f, haddr_t addr, FILE *stream, int indent, int fwidth)
 
     /* check arguments */
     HDassert(f);
-    HDassert(H5F_addr_defined(addr));
+    HDassert(H5_addr_defined(addr));
     HDassert(stream);
     HDassert(indent >= 0);
     HDassert(fwidth >= 0);

--- a/src/H5HL.c
+++ b/src/H5HL.c
@@ -164,7 +164,7 @@ done:
         }
         else {
             if (heap) {
-                if (H5F_addr_defined(heap->prfx_addr))
+                if (H5_addr_defined(heap->prfx_addr))
                     if (FAIL == H5MF_xfree(f, H5FD_MEM_LHEAP, heap->prfx_addr, total_size))
                         HDONE_ERROR(H5E_HEAP, H5E_CANTFREE, FAIL, "can't release heap data?");
                 if (FAIL == H5HL__dest(heap))
@@ -315,7 +315,7 @@ H5HL_protect(H5F_t *f, haddr_t addr, unsigned flags)
 
     /* Check arguments */
     HDassert(f);
-    HDassert(H5F_addr_defined(addr));
+    HDassert(H5_addr_defined(addr));
 
     /* Only the H5AC__READ_ONLY_FLAG may appear in flags */
     HDassert((flags & (unsigned)(~H5AC__READ_ONLY_FLAG)) == 0);
@@ -904,7 +904,7 @@ H5HL_delete(H5F_t *f, haddr_t addr)
 
     /* Check arguments */
     HDassert(f);
-    HDassert(H5F_addr_defined(addr));
+    HDassert(H5_addr_defined(addr));
 
     /* Construct the user data for protect callback */
     prfx_udata.sizeof_size = H5F_SIZEOF_SIZE(f);
@@ -966,7 +966,7 @@ H5HL_get_size(H5F_t *f, haddr_t addr, size_t *size)
 
     /* Check arguments */
     HDassert(f);
-    HDassert(H5F_addr_defined(addr));
+    HDassert(H5_addr_defined(addr));
     HDassert(size);
 
     /* Construct the user data for protect callback */
@@ -1018,7 +1018,7 @@ H5HL_heapsize(H5F_t *f, haddr_t addr, hsize_t *heap_size)
 
     /* Check arguments */
     HDassert(f);
-    HDassert(H5F_addr_defined(addr));
+    HDassert(H5_addr_defined(addr));
     HDassert(heap_size);
 
     /* Construct the user data for protect callback */

--- a/src/H5HLcache.c
+++ b/src/H5HLcache.c
@@ -377,7 +377,7 @@ H5HL__cache_prefix_get_final_load_size(const void *_image, size_t image_len, voi
     /* Check if heap block exists */
     if (heap.dblk_size)
         /* Check if heap data block is contiguous with header */
-        if (H5F_addr_eq((heap.prfx_addr + heap.prfx_size), heap.dblk_addr))
+        if (H5_addr_eq((heap.prfx_addr + heap.prfx_size), heap.dblk_addr))
             /* Note that the heap should be a single object in the cache */
             *actual_len += heap.dblk_size;
 
@@ -416,7 +416,7 @@ H5HL__cache_prefix_deserialize(const void *_image, size_t len, void *_udata, hbo
     HDassert(udata->sizeof_size > 0);
     HDassert(udata->sizeof_addr > 0);
     HDassert(udata->sizeof_prfx > 0);
-    HDassert(H5F_addr_defined(udata->prfx_addr));
+    HDassert(H5_addr_defined(udata->prfx_addr));
     HDassert(dirty);
 
     /* Allocate space in memory for the heap */
@@ -434,7 +434,7 @@ H5HL__cache_prefix_deserialize(const void *_image, size_t len, void *_udata, hbo
     /* Check if heap block exists */
     if (heap->dblk_size) {
         /* Check if heap data block is contiguous with header */
-        if (H5F_addr_eq((heap->prfx_addr + heap->prfx_size), heap->dblk_addr)) {
+        if (H5_addr_eq((heap->prfx_addr + heap->prfx_size), heap->dblk_addr)) {
             /* Note that the heap should be a single object in the cache */
             heap->single_cache_obj = TRUE;
 
@@ -551,7 +551,7 @@ H5HL__cache_prefix_serialize(const H5_ATTR_NDEBUG_UNUSED H5F_t *f, void *_image,
     HDassert(image);
     HDassert(prfx);
     HDassert(prfx->cache_info.type == H5AC_LHEAP_PRFX);
-    HDassert(H5F_addr_eq(prfx->cache_info.addr, prfx->heap->prfx_addr));
+    HDassert(H5_addr_eq(prfx->cache_info.addr, prfx->heap->prfx_addr));
     HDassert(prfx->heap);
 
     /* Get the pointer to the heap */
@@ -643,7 +643,7 @@ H5HL__cache_prefix_free_icr(void *_thing)
     /* Check arguments */
     HDassert(prfx);
     HDassert(prfx->cache_info.type == H5AC_LHEAP_PRFX);
-    HDassert(H5F_addr_eq(prfx->cache_info.addr, prfx->heap->prfx_addr));
+    HDassert(H5_addr_eq(prfx->cache_info.addr, prfx->heap->prfx_addr));
 
     /* Destroy local heap prefix */
     if (H5HL__prfx_dest(prfx) < 0)

--- a/src/H5HLdbg.c
+++ b/src/H5HLdbg.c
@@ -57,7 +57,7 @@ H5HL_debug(H5F_t *f, haddr_t addr, FILE *stream, int indent, int fwidth)
 
     /* check arguments */
     HDassert(f);
-    HDassert(H5F_addr_defined(addr));
+    HDassert(H5_addr_defined(addr));
     HDassert(stream);
     HDassert(indent >= 0);
     HDassert(fwidth >= 0);

--- a/src/H5HLdblk.c
+++ b/src/H5HLdblk.c
@@ -202,11 +202,11 @@ H5HL__dblk_realloc(H5F_t *f, H5HL_t *heap, size_t new_heap_size)
     heap->dblk_size = new_heap_size;
 
     /* Check if heap data block actually moved in the file */
-    if (H5F_addr_eq(old_addr, new_addr)) {
+    if (H5_addr_eq(old_addr, new_addr)) {
         /* Check if heap data block is contiguous w/prefix */
         if (heap->single_cache_obj) {
             /* Sanity check */
-            HDassert(H5F_addr_eq(heap->prfx_addr + heap->prfx_size, old_addr));
+            HDassert(H5_addr_eq(heap->prfx_addr + heap->prfx_size, old_addr));
             HDassert(heap->prfx);
 
             /* Resize the heap prefix in the cache */
@@ -215,7 +215,7 @@ H5HL__dblk_realloc(H5F_t *f, H5HL_t *heap, size_t new_heap_size)
         }
         else {
             /* Sanity check */
-            HDassert(H5F_addr_ne(heap->prfx_addr + heap->prfx_size, old_addr));
+            HDassert(H5_addr_ne(heap->prfx_addr + heap->prfx_size, old_addr));
             HDassert(heap->dblk);
 
             /* Resize the heap data block in the cache */

--- a/src/H5Lint.c
+++ b/src/H5Lint.c
@@ -2180,7 +2180,7 @@ H5L__link_copy_file(H5F_t *dst_file, const H5O_link_t *_src_lnk, const H5O_loc_t
             tmp_src_oloc.file = src_oloc->file;
             tmp_src_oloc.addr = src_lnk->u.hard.addr;
         } /* end if */
-        HDassert(H5F_addr_defined(tmp_src_oloc.addr));
+        HDassert(H5_addr_defined(tmp_src_oloc.addr));
 
         /* Copy the shared object from source to destination */
         /* Don't care about obj_type or udata because those are only important

--- a/src/H5MF.c
+++ b/src/H5MF.c
@@ -50,7 +50,7 @@
 #define H5MF_CHECK_FSM(FSM, CF)                                                                              \
     do {                                                                                                     \
         HDassert(*CF == FALSE);                                                                              \
-        if (!H5F_addr_defined(FSM->addr) || !H5F_addr_defined(FSM->sect_addr))                               \
+        if (!H5_addr_defined(FSM->addr) || !H5_addr_defined(FSM->sect_addr))                                 \
             *CF = TRUE;                                                                                      \
     } while (0)
 
@@ -319,7 +319,7 @@ H5MF__open_fstype(H5F_t *f, H5F_mem_page_t type)
         HDassert((H5FD_mem_t)type != H5FD_MEM_NOLIST);
     } /* end else */
     HDassert(f->shared);
-    HDassert(H5F_addr_defined(f->shared->fs_addr[type]));
+    HDassert(H5_addr_defined(f->shared->fs_addr[type]));
     HDassert(f->shared->fs_state[type] == H5F_FS_STATE_CLOSED);
 
     /* Set up the alignment and threshold to use depending on the manager type */
@@ -397,7 +397,7 @@ H5MF__create_fstype(H5F_t *f, H5F_mem_page_t type)
         HDassert((H5FD_mem_t)type != H5FD_MEM_NOLIST);
     } /* end else */
     HDassert(f->shared);
-    HDassert(!H5F_addr_defined(f->shared->fs_addr[type]));
+    HDassert(!H5_addr_defined(f->shared->fs_addr[type]));
     HDassert(f->shared->fs_state[type] == H5F_FS_STATE_CLOSED);
 
     /* Set the free space creation parameters */
@@ -474,7 +474,7 @@ H5MF__start_fstype(H5F_t *f, H5F_mem_page_t type)
     } /* end else */
 
     /* Check if the free space manager exists already */
-    if (H5F_addr_defined(f->shared->fs_addr[type])) {
+    if (H5_addr_defined(f->shared->fs_addr[type])) {
         /* Open existing free space manager */
         if (H5MF__open_fstype(f, type) < 0)
             HGOTO_ERROR(H5E_RESOURCE, H5E_CANTOPENOBJ, FAIL, "can't initialize file free space")
@@ -518,7 +518,7 @@ H5MF__delete_fstype(H5F_t *f, H5F_mem_page_t type)
         HDassert(type < H5F_MEM_PAGE_NTYPES);
     else
         HDassert((H5FD_mem_t)type < H5FD_MEM_NTYPES);
-    HDassert(H5F_addr_defined(f->shared->fs_addr[type]));
+    HDassert(H5_addr_defined(f->shared->fs_addr[type]));
 
     /* Put address into temporary variable and reset it */
     /* (Avoids loopback in file space freeing routine) */
@@ -550,7 +550,7 @@ H5MF__delete_fstype(H5F_t *f, H5F_mem_page_t type)
     f->shared->fs_state[type] = H5F_FS_STATE_CLOSED;
 
     /* Sanity check that the free space manager for this type wasn't started up again */
-    HDassert(!H5F_addr_defined(f->shared->fs_addr[type]));
+    HDassert(!H5_addr_defined(f->shared->fs_addr[type]));
 
 done:
     /* Reset the ring in the API context */
@@ -809,7 +809,7 @@ H5MF_alloc(H5F_t *f, H5FD_mem_t alloc_type, hsize_t size)
                         "attempt to notify cache that ring is unsettled failed")
 
         /* Check if the free space manager for the file has been initialized */
-        if (!f->shared->fs_man[fs_type] && H5F_addr_defined(f->shared->fs_addr[fs_type])) {
+        if (!f->shared->fs_man[fs_type] && H5_addr_defined(f->shared->fs_addr[fs_type])) {
             /* Open the free-space manager */
             if (H5MF__open_fstype(f, fs_type) < 0)
                 HGOTO_ERROR(H5E_RESOURCE, H5E_CANTOPENOBJ, HADDR_UNDEF, "can't initialize file free space")
@@ -823,7 +823,7 @@ H5MF_alloc(H5F_t *f, H5FD_mem_t alloc_type, hsize_t size)
     } /* end if */
 
     /* If no space is found from the free-space manager, continue further action */
-    if (!H5F_addr_defined(ret_value)) {
+    if (!H5_addr_defined(ret_value)) {
 #ifdef H5MF_ALLOC_DEBUG_MORE
         HDfprintf(stderr, "%s: Check 2.0\n", __func__);
 #endif /* H5MF_ALLOC_DEBUG_MORE */
@@ -838,7 +838,7 @@ H5MF_alloc(H5F_t *f, H5FD_mem_t alloc_type, hsize_t size)
                 HGOTO_ERROR(H5E_RESOURCE, H5E_CANTALLOC, HADDR_UNDEF, "allocation failed from aggr/vfd")
         } /* end else */
     }     /* end if */
-    HDassert(H5F_addr_defined(ret_value));
+    HDassert(H5_addr_defined(ret_value));
 #ifdef H5MF_ALLOC_DEBUG_MORE
     HDfprintf(stderr, "%s: Check 3.0\n", __func__);
 #endif /* H5MF_ALLOC_DEBUG_MORE */
@@ -1051,7 +1051,7 @@ H5MF_alloc_tmp(H5F_t *f, hsize_t size)
     ret_value = f->shared->tmp_addr - size;
 
     /* Check for overlap into the actual allocated space in the file */
-    if (H5F_addr_le(ret_value, eoa))
+    if (H5_addr_le(ret_value, eoa))
         HGOTO_ERROR(H5E_RESOURCE, H5E_CANTGET, HADDR_UNDEF, "driver get_eoa request failed")
 
     /* Adjust temporary address allocator in the file */
@@ -1092,7 +1092,7 @@ H5MF_xfree(H5F_t *f, H5FD_mem_t alloc_type, haddr_t addr, hsize_t size)
 
     /* check arguments */
     HDassert(f);
-    if (!H5F_addr_defined(addr) || 0 == size)
+    if (!H5_addr_defined(addr) || 0 == size)
         HGOTO_DONE(SUCCEED)
     HDassert(addr != 0); /* Can't deallocate the superblock :-) */
 
@@ -1116,7 +1116,7 @@ H5MF_xfree(H5F_t *f, H5FD_mem_t alloc_type, haddr_t addr, hsize_t size)
                         "attempt to notify cache that ring is unsettled failed")
 
     /* Check for attempting to free space that's a 'temporary' file address */
-    if (H5F_addr_le(f->shared->tmp_addr, addr))
+    if (H5_addr_le(f->shared->tmp_addr, addr))
         HGOTO_ERROR(H5E_RESOURCE, H5E_BADRANGE, FAIL, "attempting to free temporary file space")
 
     /* If it's metadata, check if the space to free intersects with the file's
@@ -1138,7 +1138,7 @@ H5MF_xfree(H5F_t *f, H5FD_mem_t alloc_type, haddr_t addr, hsize_t size)
 #ifdef H5MF_ALLOC_DEBUG_MORE
         HDfprintf(stderr, "%s: fs_addr = %" PRIuHADDR "\n", __func__, f->shared->fs_addr[fs_type]);
 #endif /* H5MF_ALLOC_DEBUG_MORE */
-        if (!H5F_addr_defined(f->shared->fs_addr[fs_type])) {
+        if (!H5_addr_defined(f->shared->fs_addr[fs_type])) {
             htri_t status; /* "can absorb" status for section into */
 
 #ifdef H5MF_ALLOC_DEBUG_MORE
@@ -1388,7 +1388,7 @@ H5MF_try_extend(H5F_t *f, H5FD_mem_t alloc_type, haddr_t addr, hsize_t size, hsi
             udata.alloc_type = alloc_type;
 
             /* Check if the free space for the file has been initialized */
-            if (!f->shared->fs_man[fs_type] && H5F_addr_defined(f->shared->fs_addr[fs_type]))
+            if (!f->shared->fs_man[fs_type] && H5_addr_defined(f->shared->fs_addr[fs_type]))
                 /* Open the free-space manager */
                 if (H5MF__open_fstype(f, fs_type) < 0)
                     HGOTO_ERROR(H5E_RESOURCE, H5E_CANTINIT, FAIL, "can't initialize file free space")
@@ -1467,7 +1467,7 @@ H5MF_try_shrink(H5F_t *f, H5FD_mem_t alloc_type, haddr_t addr, hsize_t size)
     HDassert(f);
     HDassert(f->shared);
     HDassert(f->shared->lf);
-    HDassert(H5F_addr_defined(addr));
+    HDassert(H5_addr_defined(addr));
     HDassert(size > 0);
 
     /* Set up free-space section class information */
@@ -1613,7 +1613,7 @@ H5MF__close_delete_fstype(H5F_t *f, H5F_mem_page_t type)
 #endif /* H5MF_ALLOC_DEBUG_MORE */
 
     /* If there is free space manager info for this type, delete it */
-    if (H5F_addr_defined(f->shared->fs_addr[type]))
+    if (H5_addr_defined(f->shared->fs_addr[type]))
         if (H5MF__delete_fstype(f, type) < 0)
             HGOTO_ERROR(H5E_RESOURCE, H5E_CANTRELEASE, FAIL, "can't delete the free space manager")
 
@@ -1789,7 +1789,7 @@ H5MF__close_aggrfs(H5F_t *f)
         /* superblock extension and free space manager message should
          * exist at this point -- verify at least the former.
          */
-        HDassert(H5F_addr_defined(f->shared->sblock->ext_addr));
+        HDassert(H5_addr_defined(f->shared->sblock->ext_addr));
 
         /* file space for all non-empty free space managers should be
          * allocated at this point, and these free space managers should
@@ -1961,7 +1961,7 @@ H5MF__close_pagefs(H5F_t *f)
         /* superblock extension and free space manager message should
          * exist at this point -- verify at least the former.
          */
-        HDassert(H5F_addr_defined(f->shared->sblock->ext_addr));
+        HDassert(H5_addr_defined(f->shared->sblock->ext_addr));
 
         /* file space for all non-empty free space managers should be
          * allocated at this point, and these free space managers should
@@ -2039,7 +2039,7 @@ H5MF__close_pagefs(H5F_t *f)
          * it is ignored in the following assert.
          */
         HDassert((H5F_NULL_FSM_ADDR(f)) || (final_eoa == f->shared->eoa_fsm_fsalloc) ||
-                 ((H5F_addr_defined(f->shared->eoa_post_mdci_fsalloc)) &&
+                 ((H5_addr_defined(f->shared->eoa_post_mdci_fsalloc)) &&
                   (final_eoa == f->shared->eoa_post_mdci_fsalloc)));
     } /* end if */
     else {
@@ -2259,7 +2259,7 @@ H5MF_get_freespace(H5F_t *f, hsize_t *tot_space, hsize_t *meta_size)
         fs_started[type] = FALSE;
 
         /* Check if the free space for the file has been initialized */
-        if (!f->shared->fs_man[type] && H5F_addr_defined(f->shared->fs_addr[type])) {
+        if (!f->shared->fs_man[type] && H5_addr_defined(f->shared->fs_addr[type])) {
             if (H5MF__open_fstype(f, type) < 0)
                 HGOTO_ERROR(H5E_RESOURCE, H5E_CANTINIT, FAIL, "can't initialize file free space")
             HDassert(f->shared->fs_man[type]);
@@ -2412,7 +2412,7 @@ H5MF_get_free_sections(H5F_t *f, H5FD_mem_t type, size_t nsects, H5F_sect_info_t
             curr_ring = needed_ring;
         } /* end if */
 
-        if (!f->shared->fs_man[ty] && H5F_addr_defined(f->shared->fs_addr[ty])) {
+        if (!f->shared->fs_man[ty] && H5_addr_defined(f->shared->fs_addr[ty])) {
             if (H5MF__open_fstype(f, ty) < 0)
                 HGOTO_ERROR(H5E_RESOURCE, H5E_CANTRELEASE, FAIL, "can't open the free space manager")
             HDassert(f->shared->fs_man[ty]);
@@ -2751,7 +2751,7 @@ H5MF_settle_raw_data_fsm(H5F_t *f, hbool_t *fsm_settled)
                      * space.
                      */
                     if (NULL == f->shared->fs_man[fsm_type]) {
-                        if (H5F_addr_defined(f->shared->fs_addr[fsm_type])) {
+                        if (H5_addr_defined(f->shared->fs_addr[fsm_type])) {
                             /* Sanity check */
                             HDassert(fsm_opened[fsm_type] == FALSE);
 
@@ -2779,7 +2779,7 @@ H5MF_settle_raw_data_fsm(H5F_t *f, hbool_t *fsm_settled)
                             HGOTO_ERROR(H5E_RESOURCE, H5E_CANTRELEASE, FAIL, "can't get free-space info")
 
                         /* Check if the free space manager has space in the file */
-                        if (H5F_addr_defined(fs_stat.addr) || H5F_addr_defined(fs_stat.sect_addr)) {
+                        if (H5_addr_defined(fs_stat.addr) || H5_addr_defined(fs_stat.sect_addr)) {
                             /* Delete the free space manager in the file.  Will
                              * reallocate later if the free space manager contains
                              * any free space.
@@ -2809,7 +2809,7 @@ H5MF_settle_raw_data_fsm(H5F_t *f, hbool_t *fsm_settled)
          *            file space manager info message is guaranteed to exist.
          *            Leave it in for now, but consider removing it.
          */
-        if (H5F_addr_defined(f->shared->sblock->ext_addr))
+        if (H5_addr_defined(f->shared->sblock->ext_addr))
             if (H5F__super_ext_remove_msg(f, H5O_FSINFO_ID) < 0)
                 HGOTO_ERROR(H5E_RESOURCE, H5E_CANTRELEASE, FAIL,
                             "error in removing message from superblock extension")
@@ -2928,7 +2928,7 @@ H5MF_settle_raw_data_fsm(H5F_t *f, hbool_t *fsm_settled)
                              */
                             if (fs_stat.serial_sect_count > 0) {
                                 /* Sanity check */
-                                HDassert(!H5F_addr_defined(fs_stat.addr));
+                                HDassert(!H5_addr_defined(fs_stat.addr));
 
                                 /* Allocate FSM header */
                                 if (H5FS_alloc_hdr(f, f->shared->fs_man[fsm_type],
@@ -2937,7 +2937,7 @@ H5MF_settle_raw_data_fsm(H5F_t *f, hbool_t *fsm_settled)
                                                 "can't allocated free-space header")
 
                                 /* Allocate FSM section info */
-                                HDassert(!H5F_addr_defined(fs_stat.sect_addr));
+                                HDassert(!H5_addr_defined(fs_stat.sect_addr));
                                 HDassert(fs_stat.alloc_sect_size == 0);
                                 if (H5FS_alloc_sect(f, f->shared->fs_man[fsm_type]) < 0)
                                     HGOTO_ERROR(H5E_RESOURCE, H5E_CANTALLOC, FAIL,
@@ -2949,16 +2949,16 @@ H5MF_settle_raw_data_fsm(H5F_t *f, hbool_t *fsm_settled)
                                     HGOTO_ERROR(H5E_RESOURCE, H5E_CANTRELEASE, FAIL,
                                                 "can't get free-space info")
 
-                                HDassert(H5F_addr_defined(fs_stat.addr));
-                                HDassert(H5F_addr_defined(fs_stat.sect_addr));
+                                HDassert(H5_addr_defined(fs_stat.addr));
+                                HDassert(H5_addr_defined(fs_stat.sect_addr));
                                 HDassert(fs_stat.serial_sect_count > 0);
                                 HDassert(fs_stat.alloc_sect_size > 0);
                                 HDassert(fs_stat.alloc_sect_size == fs_stat.sect_size);
 #endif                        /* NDEBUG */
                             } /* end if */
                             else {
-                                HDassert(!H5F_addr_defined(fs_stat.addr));
-                                HDassert(!H5F_addr_defined(fs_stat.sect_addr));
+                                HDassert(!H5_addr_defined(fs_stat.addr));
+                                HDassert(!H5_addr_defined(fs_stat.sect_addr));
                                 HDassert(fs_stat.serial_sect_count == 0);
                                 HDassert(fs_stat.alloc_sect_size == 0);
                             } /* end else */
@@ -3132,8 +3132,8 @@ H5MF_settle_meta_data_fsm(H5F_t *f, hbool_t *fsm_settled)
         HDassert(sm_fssinfo_fs_type > H5F_MEM_PAGE_DEFAULT);
         HDassert(sm_fssinfo_fs_type < H5F_MEM_PAGE_LARGE_SUPER);
 
-        HDassert(!H5F_addr_defined(f->shared->fs_addr[sm_fshdr_fs_type]));
-        HDassert(!H5F_addr_defined(f->shared->fs_addr[sm_fssinfo_fs_type]));
+        HDassert(!H5_addr_defined(f->shared->fs_addr[sm_fshdr_fs_type]));
+        HDassert(!H5_addr_defined(f->shared->fs_addr[sm_fssinfo_fs_type]));
 
         /* Note that in most cases, sm_hdr_fspace will equal sm_sinfo_fspace. */
         sm_hdr_fspace   = f->shared->fs_man[sm_fshdr_fs_type];
@@ -3151,8 +3151,8 @@ H5MF_settle_meta_data_fsm(H5F_t *f, hbool_t *fsm_settled)
             HDassert(lg_fssinfo_fs_type >= H5F_MEM_PAGE_LARGE_SUPER);
             HDassert(lg_fssinfo_fs_type < H5F_MEM_PAGE_NTYPES);
 
-            HDassert(!H5F_addr_defined(f->shared->fs_addr[lg_fshdr_fs_type]));
-            HDassert(!H5F_addr_defined(f->shared->fs_addr[lg_fssinfo_fs_type]));
+            HDassert(!H5_addr_defined(f->shared->fs_addr[lg_fshdr_fs_type]));
+            HDassert(!H5_addr_defined(f->shared->fs_addr[lg_fssinfo_fs_type]));
 
             /* Note that in most cases, lg_hdr_fspace will equal lg_sinfo_fspace. */
             lg_hdr_fspace   = f->shared->fs_man[lg_fshdr_fs_type];
@@ -3171,8 +3171,8 @@ H5MF_settle_meta_data_fsm(H5F_t *f, hbool_t *fsm_settled)
                 if (H5FS_stat_info(f, sm_hdr_fspace, &fs_stat) < 0)
                     HGOTO_ERROR(H5E_RESOURCE, H5E_CANTGET, FAIL, "can't get free-space info")
 
-                HDassert(!H5F_addr_defined(fs_stat.addr));
-                HDassert(!H5F_addr_defined(fs_stat.sect_addr));
+                HDassert(!H5_addr_defined(fs_stat.addr));
+                HDassert(!H5_addr_defined(fs_stat.sect_addr));
                 HDassert(fs_stat.alloc_sect_size == 0);
             } /* end if */
 
@@ -3182,8 +3182,8 @@ H5MF_settle_meta_data_fsm(H5F_t *f, hbool_t *fsm_settled)
                 if (H5FS_stat_info(f, sm_sinfo_fspace, &fs_stat) < 0)
                     HGOTO_ERROR(H5E_RESOURCE, H5E_CANTGET, FAIL, "can't get free-space info")
 
-                HDassert(!H5F_addr_defined(fs_stat.addr));
-                HDassert(!H5F_addr_defined(fs_stat.sect_addr));
+                HDassert(!H5_addr_defined(fs_stat.addr));
+                HDassert(!H5_addr_defined(fs_stat.sect_addr));
                 HDassert(fs_stat.alloc_sect_size == 0);
             } /* end if */
 
@@ -3194,8 +3194,8 @@ H5MF_settle_meta_data_fsm(H5F_t *f, hbool_t *fsm_settled)
                     if (H5FS_stat_info(f, lg_hdr_fspace, &fs_stat) < 0)
                         HGOTO_ERROR(H5E_RESOURCE, H5E_CANTGET, FAIL, "can't get free-space info (3)")
 
-                    HDassert(!H5F_addr_defined(fs_stat.addr));
-                    HDassert(!H5F_addr_defined(fs_stat.sect_addr));
+                    HDassert(!H5_addr_defined(fs_stat.addr));
+                    HDassert(!H5_addr_defined(fs_stat.sect_addr));
                     HDassert(fs_stat.alloc_sect_size == 0);
                 } /* end if */
 
@@ -3207,8 +3207,8 @@ H5MF_settle_meta_data_fsm(H5F_t *f, hbool_t *fsm_settled)
                     if (H5FS_stat_info(f, lg_sinfo_fspace, &fs_stat) < 0)
                         HGOTO_ERROR(H5E_RESOURCE, H5E_CANTGET, FAIL, "can't get free-space info (4)")
 
-                    HDassert(!H5F_addr_defined(fs_stat.addr));
-                    HDassert(!H5F_addr_defined(fs_stat.sect_addr));
+                    HDassert(!H5_addr_defined(fs_stat.addr));
+                    HDassert(!H5_addr_defined(fs_stat.sect_addr));
                     HDassert(fs_stat.alloc_sect_size == 0);
                 } /* end if */
             }     /* end if */

--- a/src/H5MFaggr.c
+++ b/src/H5MFaggr.c
@@ -115,7 +115,7 @@ H5MF_aggr_vfd_alloc(H5F_t *f, H5FD_mem_t alloc_type, hsize_t size)
     } /* end else */
 
     /* Sanity check for overlapping into file's temporary allocation space */
-    HDassert(H5F_addr_le((ret_value + size), f->shared->tmp_addr));
+    HDassert(H5_addr_le((ret_value + size), f->shared->tmp_addr));
 
 done:
 #ifdef H5MF_AGGR_DEBUG
@@ -209,7 +209,7 @@ H5MF__aggr_alloc(H5F_t *f, H5F_blk_aggr_t *aggr, H5F_blk_aggr_t *other_aggr, H5F
                 alignment = 0; /* no alignment */
 
             /* Generate fragment if aggregator is mis-aligned */
-            if (alignment && H5F_addr_gt(aggr->addr, 0) &&
+            if (alignment && H5_addr_gt(aggr->addr, 0) &&
                 (aggr_mis_align = (aggr->addr + H5F_BASE_ADDR(f)) % alignment)) {
                 aggr_frag_addr = aggr->addr;
                 aggr_frag_size = alignment - aggr_mis_align;
@@ -229,7 +229,7 @@ H5MF__aggr_alloc(H5F_t *f, H5F_blk_aggr_t *aggr, H5F_blk_aggr_t *other_aggr, H5F
                     hsize_t ext_size = size + aggr_frag_size;
 
                     /* Check for overlapping into file's temporary allocation space */
-                    if (H5F_addr_gt((aggr->addr + aggr->size + ext_size), f->shared->tmp_addr))
+                    if (H5_addr_gt((aggr->addr + aggr->size + ext_size), f->shared->tmp_addr))
                         HGOTO_ERROR(
                             H5E_RESOURCE, H5E_BADRANGE, HADDR_UNDEF,
                             "'normal' file space allocation request will overlap into 'temporary' file space")
@@ -249,7 +249,7 @@ H5MF__aggr_alloc(H5F_t *f, H5F_blk_aggr_t *aggr, H5F_blk_aggr_t *other_aggr, H5F
                          * allocation block size.
                          */
                         if ((other_aggr->size > 0) &&
-                            (H5F_addr_eq((other_aggr->addr + other_aggr->size), eoa)) &&
+                            (H5_addr_eq((other_aggr->addr + other_aggr->size), eoa)) &&
                             (other_aggr->tot_size > other_aggr->size) &&
                             ((other_aggr->tot_size - other_aggr->size) >= other_aggr->alloc_size)) {
                             if (H5MF__aggr_free(f, other_alloc_type, other_aggr) < 0)
@@ -275,7 +275,7 @@ H5MF__aggr_alloc(H5F_t *f, H5F_blk_aggr_t *aggr, H5F_blk_aggr_t *other_aggr, H5F
                         ext_size += (aggr_frag_size - (ext_size - size));
 
                     /* Check for overlapping into file's temporary allocation space */
-                    if (H5F_addr_gt((aggr->addr + aggr->size + ext_size), f->shared->tmp_addr))
+                    if (H5_addr_gt((aggr->addr + aggr->size + ext_size), f->shared->tmp_addr))
                         HGOTO_ERROR(
                             H5E_RESOURCE, H5E_BADRANGE, HADDR_UNDEF,
                             "'normal' file space allocation request will overlap into 'temporary' file space")
@@ -296,7 +296,7 @@ H5MF__aggr_alloc(H5F_t *f, H5F_blk_aggr_t *aggr, H5F_blk_aggr_t *other_aggr, H5F
                          * allocation block size.
                          */
                         if ((other_aggr->size > 0) &&
-                            (H5F_addr_eq((other_aggr->addr + other_aggr->size), eoa)) &&
+                            (H5_addr_eq((other_aggr->addr + other_aggr->size), eoa)) &&
                             (other_aggr->tot_size > other_aggr->size) &&
                             ((other_aggr->tot_size - other_aggr->size) >= other_aggr->alloc_size)) {
                             if (H5MF__aggr_free(f, other_alloc_type, other_aggr) < 0)
@@ -380,7 +380,7 @@ H5MF__aggr_alloc(H5F_t *f, H5F_blk_aggr_t *aggr, H5F_blk_aggr_t *other_aggr, H5F
         } /* end else */
 
         /* Sanity check for overlapping into file's temporary allocation space */
-        HDassert(H5F_addr_le((ret_value + size), f->shared->tmp_addr));
+        HDassert(H5_addr_le((ret_value + size), f->shared->tmp_addr));
 
         /* Post-condition sanity check */
         if (H5F_ALIGNMENT(f) && size >= H5F_THRESHOLD(f))
@@ -437,7 +437,7 @@ done:
              * If the block being tested adjoins the beginning of the aggregator
              *      block, check if the aggregator can accommodate the extension.
              */
-            if (H5F_addr_eq(blk_end, aggr->addr)) {
+            if (H5_addr_eq(blk_end, aggr->addr)) {
                 haddr_t eoa; /* EOA for the file */
 
                 /* Get the EOA for the file */
@@ -445,7 +445,7 @@ done:
                     HGOTO_ERROR(H5E_RESOURCE, H5E_CANTGET, FAIL, "Unable to get eoa")
 
                 /* If the aggregator is at the end of file: */
-                if (H5F_addr_eq(eoa, aggr->addr + aggr->size)) {
+                if (H5_addr_eq(eoa, aggr->addr + aggr->size)) {
                     /* If extra_requested is below percentage threshold, extend block into the aggregator. */
                     if (extra_requested <= (hsize_t)(EXTEND_THRESHOLD * (float)aggr->size)) {
                         aggr->size -= extra_requested;
@@ -534,8 +534,8 @@ done:
         /* Check if this aggregator is active */
         if (f->shared->feature_flags & aggr->feature_flag) {
             /* Check if the block adjoins the beginning or end of the aggregator */
-            if (H5F_addr_eq((sect->sect_info.addr + sect->sect_info.size), aggr->addr) ||
-                H5F_addr_eq((aggr->addr + aggr->size), sect->sect_info.addr)) {
+            if (H5_addr_eq((sect->sect_info.addr + sect->sect_info.size), aggr->addr) ||
+                H5_addr_eq((aggr->addr + aggr->size), sect->sect_info.addr)) {
 #ifdef H5MF_AGGR_DEBUG
                 HDfprintf(stderr,
                           "%s: section {%" PRIuHADDR ", %" PRIuHSIZE "} adjoins aggr = {%" PRIuHADDR
@@ -588,7 +588,7 @@ done:
         /* Check if aggregator would get too large and should be absorbed into section */
         if ((aggr->size + sect->sect_info.size) >= aggr->alloc_size && allow_sect_absorb) {
             /* Check if the section adjoins the beginning or end of the aggregator */
-            if (H5F_addr_eq((sect->sect_info.addr + sect->sect_info.size), aggr->addr)) {
+            if (H5_addr_eq((sect->sect_info.addr + sect->sect_info.size), aggr->addr)) {
 #ifdef H5MF_AGGR_DEBUG
                 HDfprintf(stderr,
                           "%s: aggr {%" PRIuHADDR ", %" PRIuHSIZE "} adjoins front of section = {%" PRIuHADDR
@@ -601,7 +601,7 @@ done:
             } /* end if */
             else {
                 /* Sanity check */
-                HDassert(H5F_addr_eq((aggr->addr + aggr->size), sect->sect_info.addr));
+                HDassert(H5_addr_eq((aggr->addr + aggr->size), sect->sect_info.addr));
 
 #ifdef H5MF_AGGR_DEBUG
                 HDfprintf(stderr,
@@ -622,7 +622,7 @@ done:
         } /* end if */
         else {
             /* Check if the section adjoins the beginning or end of the aggregator */
-            if (H5F_addr_eq((sect->sect_info.addr + sect->sect_info.size), aggr->addr)) {
+            if (H5_addr_eq((sect->sect_info.addr + sect->sect_info.size), aggr->addr)) {
 #ifdef H5MF_AGGR_DEBUG
                 HDfprintf(stderr,
                           "%s: section {%" PRIuHADDR ", %" PRIuHSIZE "} adjoins front of aggr = {%" PRIuHADDR
@@ -641,7 +641,7 @@ done:
             } /* end if */
             else {
                 /* Sanity check */
-                HDassert(H5F_addr_eq((aggr->addr + aggr->size), sect->sect_info.addr));
+                HDassert(H5_addr_eq((aggr->addr + aggr->size), sect->sect_info.addr));
 
 #ifdef H5MF_AGGR_DEBUG
                 HDfprintf(stderr,
@@ -794,8 +794,8 @@ done:
 
         /* Make certain we release the aggregator that's later in the file first */
         /* (so the file shrinks properly) */
-        if (H5F_addr_defined(ma_addr) && H5F_addr_defined(sda_addr)) {
-            if (H5F_addr_lt(ma_addr, sda_addr)) {
+        if (H5_addr_defined(ma_addr) && H5_addr_defined(sda_addr)) {
+            if (H5_addr_lt(ma_addr, sda_addr)) {
                 first_aggr  = &(f->shared->sdata_aggr);
                 second_aggr = &(f->shared->meta_aggr);
             } /* end if */
@@ -850,8 +850,8 @@ done:
             HGOTO_ERROR(H5E_RESOURCE, H5E_CANTGET, FAIL, "Unable to get eoa")
 
         /* Check if the aggregator is at EOA */
-        if (aggr->size > 0 && H5F_addr_defined(aggr->addr))
-            ret_value = H5F_addr_eq(eoa, aggr->addr + aggr->size);
+        if (aggr->size > 0 && H5_addr_defined(aggr->addr))
+            ret_value = H5_addr_eq(eoa, aggr->addr + aggr->size);
 
 done:
         FUNC_LEAVE_NOAPI(ret_value)
@@ -881,7 +881,7 @@ done:
         HDassert(f);
         HDassert(f->shared->lf);
         HDassert(aggr);
-        HDassert(H5F_addr_defined(aggr->addr));
+        HDassert(H5_addr_defined(aggr->addr));
         HDassert(aggr->size > 0);
         HDassert(H5F_INTENT(f) & H5F_ACC_RDWR);
         HDassert(aggr->feature_flag == H5FD_FEAT_AGGREGATE_METADATA ||

--- a/src/H5MFdbg.c
+++ b/src/H5MFdbg.c
@@ -156,7 +156,7 @@ H5MF_sects_debug(H5F_t *f, haddr_t fs_addr, FILE *stream, int indent, int fwidth
     HDassert(fwidth >= 0);
 
     for (type = H5F_MEM_PAGE_DEFAULT; type < H5F_MEM_PAGE_NTYPES; type++)
-        if (H5F_addr_eq(f->shared->fs_addr[type], fs_addr)) {
+        if (H5_addr_eq(f->shared->fs_addr[type], fs_addr)) {
             if (!f->shared->fs_man[type])
                 if (H5MF__open_fstype(f, type) < 0)
                     HGOTO_ERROR(H5E_RESOURCE, H5E_CANTINIT, FAIL, "can't initialize file free space")

--- a/src/H5MFpkg.h
+++ b/src/H5MFpkg.h
@@ -70,7 +70,7 @@
     {                                                                                                        \
         hsize_t m;                                                                                           \
                                                                                                              \
-        if (H5F_addr_gt((E), 0) && ((m) = ((E) + H5F_BASE_ADDR(F)) % (A)))                                   \
+        if (H5_addr_gt((E), 0) && ((m) = ((E) + H5F_BASE_ADDR(F)) % (A)))                                    \
             (FR) = (A)-m;                                                                                    \
         else                                                                                                 \
             (FR) = 0;                                                                                        \

--- a/src/H5MFsection.c
+++ b/src/H5MFsection.c
@@ -268,7 +268,7 @@ H5MF__sect_deserialize(const H5FS_section_class_t *cls, const uint8_t H5_ATTR_UN
 
     /* Check arguments. */
     HDassert(cls);
-    HDassert(H5F_addr_defined(sect_addr));
+    HDassert(H5_addr_defined(sect_addr));
     HDassert(sect_size);
 
     /* Create free space section for block */
@@ -379,10 +379,10 @@ H5MF__sect_simple_can_merge(const H5FS_section_info_t *_sect1, const H5FS_sectio
     HDassert(sect1);
     HDassert(sect2);
     HDassert(sect1->sect_info.type == sect2->sect_info.type); /* Checks "MERGE_SYM" flag */
-    HDassert(H5F_addr_lt(sect1->sect_info.addr, sect2->sect_info.addr));
+    HDassert(H5_addr_lt(sect1->sect_info.addr, sect2->sect_info.addr));
 
     /* Check if second section adjoins first section */
-    ret_value = H5F_addr_eq(sect1->sect_info.addr + sect1->sect_info.size, sect2->sect_info.addr);
+    ret_value = H5_addr_eq(sect1->sect_info.addr + sect1->sect_info.size, sect2->sect_info.addr);
 
     FUNC_LEAVE_NOAPI(ret_value)
 } /* H5MF__sect_simple_can_merge() */
@@ -417,7 +417,7 @@ H5MF__sect_simple_merge(H5FS_section_info_t **_sect1, H5FS_section_info_t *_sect
     HDassert((*sect1)->sect_info.type == H5MF_FSPACE_SECT_SIMPLE);
     HDassert(sect2);
     HDassert(sect2->sect_info.type == H5MF_FSPACE_SECT_SIMPLE);
-    HDassert(H5F_addr_eq((*sect1)->sect_info.addr + (*sect1)->sect_info.size, sect2->sect_info.addr));
+    HDassert(H5_addr_eq((*sect1)->sect_info.addr + (*sect1)->sect_info.size, sect2->sect_info.addr));
 
     /* Add second section's size to first section */
     (*sect1)->sect_info.size += sect2->sect_info.size;
@@ -467,7 +467,7 @@ H5MF__sect_simple_can_shrink(const H5FS_section_info_t *_sect, void *_udata)
     end = sect->sect_info.addr + sect->sect_info.size;
 
     /* Check if the section is exactly at the end of the allocated space in the file */
-    if (H5F_addr_eq(end, eoa)) {
+    if (H5_addr_eq(end, eoa)) {
         /* Set the shrinking type */
         udata->shrink = H5MF_SHRINK_EOA;
 #ifdef H5MF_ALLOC_DEBUG_MORE
@@ -693,10 +693,10 @@ H5MF__sect_small_can_merge(const H5FS_section_info_t *_sect1, const H5FS_section
     HDassert(sect1);
     HDassert(sect2);
     HDassert(sect1->sect_info.type == sect2->sect_info.type); /* Checks "MERGE_SYM" flag */
-    HDassert(H5F_addr_lt(sect1->sect_info.addr, sect2->sect_info.addr));
+    HDassert(H5_addr_lt(sect1->sect_info.addr, sect2->sect_info.addr));
 
     /* Check if second section adjoins first section */
-    ret_value = H5F_addr_eq(sect1->sect_info.addr + sect1->sect_info.size, sect2->sect_info.addr);
+    ret_value = H5_addr_eq(sect1->sect_info.addr + sect1->sect_info.size, sect2->sect_info.addr);
     if (ret_value > 0)
         /* If they are on different pages, couldn't merge */
         if ((sect1->sect_info.addr / udata->f->shared->fs_page_size) !=
@@ -741,7 +741,7 @@ H5MF__sect_small_merge(H5FS_section_info_t **_sect1, H5FS_section_info_t *_sect2
     HDassert((*sect1)->sect_info.type == H5MF_FSPACE_SECT_SMALL);
     HDassert(sect2);
     HDassert(sect2->sect_info.type == H5MF_FSPACE_SECT_SMALL);
-    HDassert(H5F_addr_eq((*sect1)->sect_info.addr + (*sect1)->sect_info.size, sect2->sect_info.addr));
+    HDassert(H5_addr_eq((*sect1)->sect_info.addr + (*sect1)->sect_info.size, sect2->sect_info.addr));
 
     /* Add second section's size to first section */
     (*sect1)->sect_info.size += sect2->sect_info.size;
@@ -803,9 +803,9 @@ H5MF__sect_large_can_merge(const H5FS_section_info_t *_sect1, const H5FS_section
     HDassert(sect1);
     HDassert(sect2);
     HDassert(sect1->sect_info.type == sect2->sect_info.type); /* Checks "MERGE_SYM" flag */
-    HDassert(H5F_addr_lt(sect1->sect_info.addr, sect2->sect_info.addr));
+    HDassert(H5_addr_lt(sect1->sect_info.addr, sect2->sect_info.addr));
 
-    ret_value = H5F_addr_eq(sect1->sect_info.addr + sect1->sect_info.size, sect2->sect_info.addr);
+    ret_value = H5_addr_eq(sect1->sect_info.addr + sect1->sect_info.size, sect2->sect_info.addr);
 
 #ifdef H5MF_ALLOC_DEBUG_MORE
     HDfprintf(stderr, "%s: Leaving: ret_value = %d\n", __func__, ret_value);
@@ -842,7 +842,7 @@ H5MF__sect_large_merge(H5FS_section_info_t **_sect1, H5FS_section_info_t *_sect2
     HDassert((*sect1)->sect_info.type == H5MF_FSPACE_SECT_LARGE);
     HDassert(sect2);
     HDassert(sect2->sect_info.type == H5MF_FSPACE_SECT_LARGE);
-    HDassert(H5F_addr_eq((*sect1)->sect_info.addr + (*sect1)->sect_info.size, sect2->sect_info.addr));
+    HDassert(H5_addr_eq((*sect1)->sect_info.addr + (*sect1)->sect_info.size, sect2->sect_info.addr));
 
     /* Add second section's size to first section */
     (*sect1)->sect_info.size += sect2->sect_info.size;
@@ -892,7 +892,7 @@ H5MF__sect_large_can_shrink(const H5FS_section_info_t *_sect, void *_udata)
     end = sect->sect_info.addr + sect->sect_info.size;
 
     /* Check if the section is exactly at the end of the allocated space in the file */
-    if (H5F_addr_eq(end, eoa) && sect->sect_info.size >= udata->f->shared->fs_page_size) {
+    if (H5_addr_eq(end, eoa) && sect->sect_info.size >= udata->f->shared->fs_page_size) {
         /* Set the shrinking type */
         udata->shrink = H5MF_SHRINK_EOA;
 #ifdef H5MF_ALLOC_DEBUG_MORE

--- a/src/H5Oainfo.c
+++ b/src/H5Oainfo.c
@@ -212,7 +212,7 @@ H5O__ainfo_encode(H5F_t *f, hbool_t H5_ATTR_UNUSED disable_shared, uint8_t *p, c
     if (ainfo->index_corder)
         H5F_addr_encode(f, &p, ainfo->corder_bt2_addr);
     else
-        HDassert(!H5F_addr_defined(ainfo->corder_bt2_addr));
+        HDassert(!H5_addr_defined(ainfo->corder_bt2_addr));
 
     FUNC_LEAVE_NOAPI(SUCCEED)
 } /* end H5O__ainfo_encode() */
@@ -344,7 +344,7 @@ H5O__ainfo_delete(H5F_t *f, H5O_t H5_ATTR_NDEBUG_UNUSED *open_oh, void *_mesg)
     HDassert(open_oh);
 
     /* If the object is using "dense" attribute storage, delete it */
-    if (H5F_addr_defined(ainfo->fheap_addr))
+    if (H5_addr_defined(ainfo->fheap_addr))
         /* Delete the attribute */
         if (H5A__dense_delete(f, ainfo) < 0)
             HGOTO_ERROR(H5E_OHDR, H5E_CANTFREE, FAIL, "unable to free dense attribute storage")
@@ -424,7 +424,7 @@ H5O__ainfo_copy_file(H5F_t H5_ATTR_NDEBUG_UNUSED *file_src, void *mesg_src, H5F_
     /* Copy the top level of the information */
     *ainfo_dst = *ainfo_src;
 
-    if (H5F_addr_defined(ainfo_src->fheap_addr)) {
+    if (H5_addr_defined(ainfo_src->fheap_addr)) {
         /* Prepare to copy dense attributes - actual copy in post_copy */
 
         /* Set copied metadata tag */
@@ -475,7 +475,7 @@ H5O__ainfo_post_copy_file(const H5O_loc_t *src_oloc, const void *mesg_src, H5O_l
 
     HDassert(ainfo_src);
 
-    if (H5F_addr_defined(ainfo_src->fheap_addr))
+    if (H5_addr_defined(ainfo_src->fheap_addr))
         if (H5A__dense_post_copy_file_all(src_oloc, ainfo_src, dst_oloc, (H5O_ainfo_t *)mesg_dst, cpy_info) <
             0)
             HGOTO_ERROR(H5E_ATTR, H5E_CANTCOPY, FAIL, "can't copy attribute")

--- a/src/H5Oalloc.c
+++ b/src/H5Oalloc.c
@@ -514,7 +514,7 @@ H5O__alloc_extend_chunk(H5F_t *f, H5O_t *oh, unsigned chunkno, size_t size, size
     HDassert(chunkno < oh->nchunks);
     HDassert(size > 0);
     HDassert(msg_idx != NULL);
-    HDassert(H5F_addr_defined(oh->chunk[chunkno].addr));
+    HDassert(H5_addr_defined(oh->chunk[chunkno].addr));
 
     /* Test to see if the specified chunk ends with a null messages.
      * If successful, set the index of the null message in extend_msg.
@@ -903,7 +903,7 @@ H5O__alloc_chunk(H5F_t *f, H5O_t *oh, size_t size, size_t found_null, const H5O_
 
     /* Allocate space in file to hold the new chunk */
     new_chunk_addr = H5MF_alloc(f, H5FD_MEM_OHDR, (hsize_t)size);
-    if (!H5F_addr_defined(new_chunk_addr))
+    if (!H5_addr_defined(new_chunk_addr))
         HGOTO_ERROR(H5E_OHDR, H5E_CANTALLOC, FAIL, "unable to allocate space for new chunk")
 
     /* Create the new chunk giving it a file address. */

--- a/src/H5Oattribute.c
+++ b/src/H5Oattribute.c
@@ -246,7 +246,7 @@ H5O__attr_create(const H5O_loc_t *loc, H5A_t *attr)
         } /* end else */
 
         /* Check if switching to "dense" attribute storage is possible */
-        if (!H5F_addr_defined(ainfo.fheap_addr)) {
+        if (!H5_addr_defined(ainfo.fheap_addr)) {
             htri_t shareable;    /* Whether the attribute will be shared */
             size_t raw_size = 0; /* Raw size of message */
 
@@ -314,7 +314,7 @@ H5O__attr_create(const H5O_loc_t *loc, H5A_t *attr)
     } /* end else */
 
     /* Check for storing attribute with dense storage */
-    if (H5F_addr_defined(ainfo.fheap_addr)) {
+    if (H5_addr_defined(ainfo.fheap_addr)) {
         /* Insert attribute into dense storage */
         if (H5A__dense_insert(loc->file, &ainfo, attr) < 0)
             HGOTO_ERROR(H5E_ATTR, H5E_CANTINSERT, FAIL, "unable to add to dense storage")
@@ -478,7 +478,7 @@ H5O__attr_open_by_name(const H5O_loc_t *loc, const char *name)
     } /* end else if */
     else {
         /* Check for attributes in dense storage */
-        if (H5F_addr_defined(ainfo.fheap_addr)) {
+        if (H5_addr_defined(ainfo.fheap_addr)) {
             /* Open attribute with dense storage */
             if (NULL == (opened_attr = H5A__dense_open(loc->file, &ainfo, name)))
                 HGOTO_ERROR(H5E_ATTR, H5E_CANTOPENOBJ, NULL, "can't open attribute")
@@ -901,7 +901,7 @@ H5O__attr_write(const H5O_loc_t *loc, H5A_t *attr)
     } /* end if */
 
     /* Check for attributes stored densely */
-    if (H5F_addr_defined(ainfo.fheap_addr)) {
+    if (H5_addr_defined(ainfo.fheap_addr)) {
         /* Modify the attribute data in dense storage */
         if (H5A__dense_write(loc->file, &ainfo, attr) < 0)
             HGOTO_ERROR(H5E_ATTR, H5E_CANTUPDATE, FAIL, "error updating attribute")
@@ -1147,7 +1147,7 @@ H5O__attr_rename(const H5O_loc_t *loc, const char *old_name, const char *new_nam
     } /* end if */
 
     /* Check for attributes stored densely */
-    if (H5F_addr_defined(ainfo.fheap_addr)) {
+    if (H5_addr_defined(ainfo.fheap_addr)) {
         /* Rename the attribute data in dense storage */
         if (H5A__dense_rename(loc->file, &ainfo, old_name, new_name) < 0)
             HGOTO_ERROR(H5E_ATTR, H5E_CANTUPDATE, FAIL, "error updating attribute")
@@ -1220,7 +1220,7 @@ H5O_attr_iterate_real(hid_t loc_id, const H5O_loc_t *loc, H5_index_t idx_type, H
     /* Check arguments */
     HDassert(loc);
     HDassert(loc->file);
-    HDassert(H5F_addr_defined(loc->addr));
+    HDassert(H5_addr_defined(loc->addr));
     HDassert(attr_op);
 
     /* Protect the object header to iterate over */
@@ -1236,7 +1236,7 @@ H5O_attr_iterate_real(hid_t loc_id, const H5O_loc_t *loc, H5_index_t idx_type, H
     } /* end if */
 
     /* Check for attributes stored densely */
-    if (H5F_addr_defined(ainfo.fheap_addr)) {
+    if (H5_addr_defined(ainfo.fheap_addr)) {
         /* Check for skipping too many attributes */
         if (skip > 0 && skip >= ainfo.nattrs)
             HGOTO_ERROR(H5E_ARGS, H5E_BADVALUE, FAIL, "invalid index specified")
@@ -1354,7 +1354,7 @@ H5O__attr_remove_update(const H5O_loc_t *loc, H5O_t *oh, H5O_ainfo_t *ainfo)
     ainfo->nattrs--;
 
     /* Check for shifting from dense storage back to compact storage */
-    if (H5F_addr_defined(ainfo->fheap_addr) && ainfo->nattrs < oh->min_dense) {
+    if (H5_addr_defined(ainfo->fheap_addr) && ainfo->nattrs < oh->min_dense) {
         hbool_t can_convert = TRUE; /* Whether converting to attribute messages is possible */
         size_t  u;                  /* Local index */
 
@@ -1529,7 +1529,7 @@ H5O__attr_remove(const H5O_loc_t *loc, const char *name)
     } /* end if */
 
     /* Check for attributes stored densely */
-    if (H5F_addr_defined(ainfo.fheap_addr)) {
+    if (H5_addr_defined(ainfo.fheap_addr)) {
         /* Delete attribute from dense storage */
         if (H5A__dense_remove(loc->file, &ainfo, name) < 0)
             HGOTO_ERROR(H5E_ATTR, H5E_CANTDELETE, FAIL, "unable to delete attribute in dense storage")
@@ -1610,7 +1610,7 @@ H5O__attr_remove_by_idx(const H5O_loc_t *loc, H5_index_t idx_type, H5_iter_order
     } /* end if */
 
     /* Check for attributes stored densely */
-    if (H5F_addr_defined(ainfo.fheap_addr)) {
+    if (H5_addr_defined(ainfo.fheap_addr)) {
         /* Delete attribute from dense storage */
         if (H5A__dense_remove_by_idx(loc->file, &ainfo, idx_type, order, n) < 0)
             HGOTO_ERROR(H5E_ATTR, H5E_CANTDELETE, FAIL, "unable to delete attribute in dense storage")
@@ -1791,7 +1791,7 @@ H5O__attr_exists(const H5O_loc_t *loc, const char *name, hbool_t *attr_exists)
     } /* end if */
 
     /* Check for attributes stored densely */
-    if (H5F_addr_defined(ainfo.fheap_addr)) {
+    if (H5_addr_defined(ainfo.fheap_addr)) {
         /* Check if attribute exists in dense storage */
         if (H5A__dense_exists(loc->file, &ainfo, name, attr_exists) < 0)
             HGOTO_ERROR(H5E_ATTR, H5E_BADITER, FAIL, "error checking for existence of attribute")
@@ -1854,7 +1854,7 @@ H5O__attr_bh_info(H5F_t *f, H5O_t *oh, H5_ih_info_t *bh_info)
             HGOTO_ERROR(H5E_ATTR, H5E_CANTGET, FAIL, "can't check for attribute info message")
         else if (ainfo_exists > 0) {
             /* Check if name index available */
-            if (H5F_addr_defined(ainfo.name_bt2_addr)) {
+            if (H5_addr_defined(ainfo.name_bt2_addr)) {
                 /* Open the name index v2 B-tree */
                 if (NULL == (bt2_name = H5B2_open(f, ainfo.name_bt2_addr, NULL)))
                     HGOTO_ERROR(H5E_ATTR, H5E_CANTOPENOBJ, FAIL, "unable to open v2 B-tree for name index")
@@ -1865,7 +1865,7 @@ H5O__attr_bh_info(H5F_t *f, H5O_t *oh, H5_ih_info_t *bh_info)
             } /* end if */
 
             /* Check if creation order index available */
-            if (H5F_addr_defined(ainfo.corder_bt2_addr)) {
+            if (H5_addr_defined(ainfo.corder_bt2_addr)) {
                 /* Open the creation order index v2 B-tree */
                 if (NULL == (bt2_corder = H5B2_open(f, ainfo.corder_bt2_addr, NULL)))
                     HGOTO_ERROR(H5E_ATTR, H5E_CANTOPENOBJ, FAIL,
@@ -1877,7 +1877,7 @@ H5O__attr_bh_info(H5F_t *f, H5O_t *oh, H5_ih_info_t *bh_info)
             } /* end if */
 
             /* Get storage size of fractal heap, if it's used */
-            if (H5F_addr_defined(ainfo.fheap_addr)) {
+            if (H5_addr_defined(ainfo.fheap_addr)) {
                 /* Open the fractal heap for attributes */
                 if (NULL == (fheap = H5HF_open(f, ainfo.fheap_addr)))
                     HGOTO_ERROR(H5E_ATTR, H5E_CANTOPENOBJ, FAIL, "unable to open fractal heap")

--- a/src/H5Ocache.c
+++ b/src/H5Ocache.c
@@ -1195,7 +1195,7 @@ H5O__chunk_deserialize(H5O_t *oh, haddr_t addr, size_t chunk_size, const uint8_t
     FUNC_ENTER_PACKAGE
 
     HDassert(oh);
-    HDassert(H5F_addr_defined(addr));
+    HDassert(H5_addr_defined(addr));
     HDassert(image);
     HDassert(len);
     HDassert(udata->f);

--- a/src/H5Ocache_image.c
+++ b/src/H5Ocache_image.c
@@ -278,7 +278,7 @@ H5O__mdci_delete(H5F_t *f, H5O_t H5_ATTR_UNUSED *open_oh, void *_mesg)
     HDassert(mesg);
 
     /* Free file space for cache image */
-    if (H5F_addr_defined(mesg->addr)) {
+    if (H5_addr_defined(mesg->addr)) {
         /* The space for the cache image block was allocated directly
          * from the VFD layer at the end of file.  As this was the
          * last file space allocation before shutdown, the cache image
@@ -289,7 +289,7 @@ H5O__mdci_delete(H5F_t *f, H5O_t H5_ATTR_UNUSED *open_oh, void *_mesg)
             if (HADDR_UNDEF == (final_eoa = H5FD_get_eoa(f->shared->lf, H5FD_MEM_DEFAULT)))
                 HGOTO_ERROR(H5E_CACHE, H5E_CANTGET, FAIL, "unable to get file size")
 
-            HDassert(H5F_addr_eq(final_eoa, mesg->addr + mesg->size));
+            HDassert(H5_addr_eq(final_eoa, mesg->addr + mesg->size));
 
             if (H5FD_free(f->shared->lf, H5FD_MEM_SUPER, f, mesg->addr, mesg->size) < 0)
                 HGOTO_ERROR(H5E_CACHE, H5E_CANTFREE, FAIL, "can't free MDC image")

--- a/src/H5Ocont.c
+++ b/src/H5Ocont.c
@@ -137,7 +137,7 @@ H5O__cont_encode(H5F_t *f, hbool_t H5_ATTR_UNUSED disable_shared, uint8_t *p, co
     HDassert(f);
     HDassert(p);
     HDassert(cont);
-    HDassert(H5F_addr_defined(cont->addr));
+    HDassert(H5_addr_defined(cont->addr));
     HDassert(cont->size > 0);
 
     /* encode */

--- a/src/H5Ocopy.c
+++ b/src/H5Ocopy.c
@@ -225,7 +225,7 @@ H5O__copy_header_real(const H5O_loc_t *oloc_src, H5O_loc_t *oloc_dst /*out*/, H5
 
     HDassert(oloc_src);
     HDassert(oloc_src->file);
-    HDassert(H5F_addr_defined(oloc_src->addr));
+    HDassert(H5_addr_defined(oloc_src->addr));
     HDassert(oloc_dst->file);
     HDassert(cpy_info);
 
@@ -650,7 +650,7 @@ H5O__copy_header_real(const H5O_loc_t *oloc_src, H5O_loc_t *oloc_dst /*out*/, H5
              (size_t)dst_oh_size + oh_dst->chunk[0].image);
 
     /* Set the dest. object location to the first chunk address */
-    HDassert(H5F_addr_defined(addr_new));
+    HDassert(H5_addr_defined(addr_new));
     oloc_dst->addr = addr_new;
 
     /* If we are merging committed datatypes and this is a committed datatype, insert
@@ -952,7 +952,7 @@ H5O__copy_header(const H5O_loc_t *oloc_src, H5O_loc_t *oloc_dst /*out */, hid_t 
     /* Sanity check */
     HDassert(oloc_src);
     HDassert(oloc_src->file);
-    HDassert(H5F_addr_defined(oloc_src->addr));
+    HDassert(H5_addr_defined(oloc_src->addr));
     HDassert(oloc_dst->file);
 
     /* Initialize copy info before errors can be thrown */
@@ -1186,7 +1186,7 @@ H5O__copy_search_comm_dt_attr_cb(const H5A_t *attr, void *_udata)
     HDassert(attr);
     HDassert(udata);
     HDassert(udata->dst_dt_list);
-    HDassert(H5F_addr_defined(udata->obj_oloc.addr));
+    HDassert(H5_addr_defined(udata->obj_oloc.addr));
 
     /* Get attribute datatype */
     if (NULL == (dt = H5A_type(attr)))

--- a/src/H5Ocopy_ref.c
+++ b/src/H5Ocopy_ref.c
@@ -107,7 +107,7 @@ H5O__copy_obj_by_ref(H5O_loc_t *src_oloc, H5O_loc_t *dst_oloc, H5G_loc_t *dst_ro
         HGOTO_ERROR(H5E_OHDR, H5E_CANTCOPY, FAIL, "unable to copy object")
 
     /* Check if a new valid object is copied to the destination */
-    if (H5F_addr_defined(dst_oloc->addr) && (ret_value > SUCCEED)) {
+    if (H5_addr_defined(dst_oloc->addr) && (ret_value > SUCCEED)) {
         char       tmp_obj_name[80];
         H5G_name_t new_path;
         H5O_loc_t  new_oloc;
@@ -134,7 +134,7 @@ H5O__copy_obj_by_ref(H5O_loc_t *src_oloc, H5O_loc_t *dst_oloc, H5G_loc_t *dst_ro
             HGOTO_ERROR(H5E_DATATYPE, H5E_CANTINIT, FAIL, "unable to insert link")
 
         H5G_loc_free(&new_loc);
-    } /* if (H5F_addr_defined(dst_oloc.addr)) */
+    } /* if (H5_addr_defined(dst_oloc.addr)) */
 
 done:
     FUNC_LEAVE_NOAPI(ret_value)
@@ -180,7 +180,7 @@ H5O__copy_expand_ref_object1(H5O_loc_t *src_oloc, const void *buf_src, H5O_loc_t
                 HGOTO_ERROR(H5E_OHDR, H5E_CANTUNSERIALIZE, FAIL,
                             "can't deserialize object token into address")
 
-            if (!H5F_addr_defined(src_oloc->addr) || src_oloc->addr == 0)
+            if (!H5_addr_defined(src_oloc->addr) || src_oloc->addr == 0)
                 HGOTO_ERROR(H5E_ARGS, H5E_BADVALUE, FAIL, "undefined reference pointer")
             dst_oloc->addr = HADDR_UNDEF;
 
@@ -243,7 +243,7 @@ H5O__copy_expand_ref_region1(H5O_loc_t *src_oloc, const void *buf_src, H5O_loc_t
             /* Get object address */
             p = (const uint8_t *)data;
             H5F_addr_decode(src_oloc->file, &p, &src_oloc->addr);
-            if (!H5F_addr_defined(src_oloc->addr) || src_oloc->addr == 0) {
+            if (!H5_addr_defined(src_oloc->addr) || src_oloc->addr == 0) {
                 H5MM_free(data);
                 HGOTO_ERROR(H5E_ARGS, H5E_BADVALUE, FAIL, "undefined reference pointer")
             }

--- a/src/H5Odbg.c
+++ b/src/H5Odbg.c
@@ -112,7 +112,7 @@ H5O__assert(const H5O_t *oh)
         HDassert(oh->chunk[u].size > (size_t)H5O_SIZEOF_CHKHDR_OH(oh));
 
         /* All chunks must be allocated on disk */
-        HDassert(H5F_addr_defined(oh->chunk[u].addr));
+        HDassert(H5_addr_defined(oh->chunk[u].addr));
 
         /* Version specific checks */
         if (oh->version > H5O_VERSION_1) {
@@ -165,7 +165,7 @@ H5O__assert(const H5O_t *oh)
             /* Sanity check that every continuation message has a matching chunk */
             /* (and only one) */
             for (v = 0; v < oh->nchunks; v++) {
-                if (H5F_addr_eq(cont->addr, oh->chunk[v].addr) && cont->size == oh->chunk[v].size) {
+                if (H5_addr_eq(cont->addr, oh->chunk[v].addr) && cont->size == oh->chunk[v].size) {
                     HDassert(cont->chunkno == v);
                     HDassert(!found_chunk);
                     found_chunk = TRUE;
@@ -286,7 +286,7 @@ H5O__debug_real(H5F_t *f, H5O_t *oh, haddr_t addr, FILE *stream, int indent, int
     /* check args */
     HDassert(f);
     HDassert(oh);
-    HDassert(H5F_addr_defined(addr));
+    HDassert(H5_addr_defined(addr));
     HDassert(stream);
     HDassert(indent >= 0);
     HDassert(fwidth >= 0);
@@ -360,7 +360,7 @@ H5O__debug_real(H5F_t *f, H5O_t *oh, haddr_t addr, FILE *stream, int indent, int
 
         /* Decrement chunk 0's size by the object header prefix size */
         if (0 == i) {
-            if (H5F_addr_ne(oh->chunk[i].addr, addr))
+            if (H5_addr_ne(oh->chunk[i].addr, addr))
                 HDfprintf(stream, "*** WRONG ADDRESS FOR CHUNK #0!\n");
             chunk_size = oh->chunk[i].size - (size_t)H5O_SIZEOF_HDR(oh);
         } /* end if */
@@ -519,7 +519,7 @@ H5O_debug(H5F_t *f, haddr_t addr, FILE *stream, int indent, int fwidth)
 
     /* check args */
     HDassert(f);
-    HDassert(H5F_addr_defined(addr));
+    HDassert(H5_addr_defined(addr));
     HDassert(stream);
     HDassert(indent >= 0);
     HDassert(fwidth >= 0);

--- a/src/H5Oefl.c
+++ b/src/H5Oefl.c
@@ -118,7 +118,7 @@ H5O__efl_decode(H5F_t *f, H5O_t H5_ATTR_UNUSED *open_oh, unsigned H5_ATTR_UNUSED
     if (H5_IS_BUFFER_OVERFLOW(p, H5F_sizeof_addr(f), p_end))
         HGOTO_ERROR(H5E_OHDR, H5E_OVERFLOW, NULL, "ran off end of input buffer while decoding");
     H5F_addr_decode(f, &p, &(mesg->heap_addr));
-    if (H5F_addr_defined(mesg->heap_addr) == FALSE)
+    if (H5_addr_defined(mesg->heap_addr) == FALSE)
         HGOTO_ERROR(H5E_OHDR, H5E_CANTLOAD, NULL, "bad local heap address when parsing efl msg")
 
     /* Decode the file list */
@@ -227,7 +227,7 @@ H5O__efl_encode(H5F_t *f, hbool_t H5_ATTR_UNUSED disable_shared, uint8_t *p, con
     UINT16ENCODE(p, mesg->nused);
 
     /* Heap address */
-    HDassert(H5F_addr_defined(mesg->heap_addr));
+    HDassert(H5_addr_defined(mesg->heap_addr));
     H5F_addr_encode(f, &p, mesg->heap_addr);
 
     /* Encode file list */

--- a/src/H5Oint.c
+++ b/src/H5Oint.c
@@ -967,7 +967,7 @@ H5O_link(const H5O_loc_t *loc, int adjust)
     /* check args */
     HDassert(loc);
     HDassert(loc->file);
-    HDassert(H5F_addr_defined(loc->addr));
+    HDassert(H5_addr_defined(loc->addr));
 
     /* Pin the object header */
     if (NULL == (oh = H5O_pin(loc)))
@@ -1021,7 +1021,7 @@ H5O_protect(const H5O_loc_t *loc, unsigned prot_flags, hbool_t pin_all_chunks)
     HDassert((prot_flags & (unsigned)(~H5AC__READ_ONLY_FLAG)) == 0);
 
     /* Check for valid address */
-    if (!H5F_addr_defined(loc->addr))
+    if (!H5_addr_defined(loc->addr))
         HGOTO_ERROR(H5E_ARGS, H5E_BADVALUE, NULL, "address undefined")
 
     /* Check for write access on the file */
@@ -1551,7 +1551,7 @@ H5O_delete(H5F_t *f, haddr_t addr)
 
     /* Check args */
     HDassert(f);
-    HDassert(H5F_addr_defined(addr));
+    HDassert(H5_addr_defined(addr));
 
     /* Set up the object location */
     loc.file         = f;

--- a/src/H5Olinfo.c
+++ b/src/H5Olinfo.c
@@ -220,7 +220,7 @@ H5O__linfo_encode(H5F_t *f, hbool_t H5_ATTR_UNUSED disable_shared, uint8_t *p, c
     if (linfo->index_corder)
         H5F_addr_encode(f, &p, linfo->corder_bt2_addr);
     else
-        HDassert(!H5F_addr_defined(linfo->corder_bt2_addr));
+        HDassert(!H5_addr_defined(linfo->corder_bt2_addr));
 
     FUNC_LEAVE_NOAPI(SUCCEED)
 } /* end H5O__linfo_encode() */
@@ -348,7 +348,7 @@ H5O__linfo_delete(H5F_t *f, H5O_t H5_ATTR_UNUSED *open_oh, void *_mesg)
     HDassert(linfo);
 
     /* If the group is using "dense" link storage, delete it */
-    if (H5F_addr_defined(linfo->fheap_addr))
+    if (H5_addr_defined(linfo->fheap_addr))
         if (H5G__dense_delete(f, linfo, TRUE) < 0)
             HGOTO_ERROR(H5E_OHDR, H5E_CANTFREE, FAIL, "unable to free dense link storage")
 
@@ -406,7 +406,7 @@ H5O__linfo_copy_file(H5F_t H5_ATTR_UNUSED *file_src, void *native_src, H5F_t *fi
         /* (XXX: should probably get the "creation" parameters for the source group's
          *      dense link storage components and use those - QAK)
          */
-        if (H5F_addr_defined(linfo_src->fheap_addr)) {
+        if (H5_addr_defined(linfo_src->fheap_addr)) {
             /* Create the dense link storage */
             if (H5G__dense_create(file_dst, linfo_dst, udata->common.src_pline) < 0)
                 HGOTO_ERROR(H5E_SYM, H5E_CANTINIT, NULL, "unable to create 'dense' form of new format group")
@@ -502,7 +502,7 @@ H5O__linfo_post_copy_file(const H5O_loc_t *src_oloc, const void *mesg_src, H5O_l
     HDassert(src_oloc && src_oloc->file);
     HDassert(linfo_src);
     HDassert(dst_oloc && dst_oloc->file);
-    HDassert(H5F_addr_defined(dst_oloc->addr));
+    HDassert(H5_addr_defined(dst_oloc->addr));
     HDassert(linfo_dst);
     HDassert(cpy_info);
 
@@ -511,7 +511,7 @@ H5O__linfo_post_copy_file(const H5O_loc_t *src_oloc, const void *mesg_src, H5O_l
         HGOTO_DONE(SUCCEED)
 
     /* Check for copying dense link storage */
-    if (H5F_addr_defined(linfo_src->fheap_addr)) {
+    if (H5_addr_defined(linfo_src->fheap_addr)) {
         H5O_linfo_postcopy_ud_t udata; /* User data for iteration callback */
 
         /* Set up dense link iteration user data */

--- a/src/H5Olink.c
+++ b/src/H5Olink.c
@@ -633,7 +633,7 @@ H5O_link_delete(H5F_t *f, H5O_t H5_ATTR_UNUSED *open_oh, void *_mesg)
         /* Construct object location for object, in order to decrement it's ref count */
         H5O_loc_reset(&oloc);
         oloc.file = f;
-        HDassert(H5F_addr_defined(lnk->u.hard.addr));
+        HDassert(H5_addr_defined(lnk->u.hard.addr));
         oloc.addr = lnk->u.hard.addr;
 
         /* Decrement the ref count for the object */
@@ -771,7 +771,7 @@ H5O__link_post_copy_file(const H5O_loc_t *src_oloc, const void *mesg_src, H5O_lo
     /* check args */
     HDassert(link_src);
     HDassert(dst_oloc);
-    HDassert(H5F_addr_defined(dst_oloc->addr));
+    HDassert(H5_addr_defined(dst_oloc->addr));
     HDassert(dst_oloc->file);
     HDassert(link_dst);
     HDassert(cpy_info);

--- a/src/H5Omessage.c
+++ b/src/H5Omessage.c
@@ -245,7 +245,7 @@ H5O_msg_write(const H5O_loc_t *loc, unsigned type_id, unsigned mesg_flags, unsig
     /* check args */
     HDassert(loc);
     HDassert(loc->file);
-    HDassert(H5F_addr_defined(loc->addr));
+    HDassert(H5_addr_defined(loc->addr));
     HDassert(H5O_ATTR_ID != type_id); /* Attributes are modified in another routine */
     HDassert(type_id < NELMTS(H5O_msg_class_g));
     type = H5O_msg_class_g[type_id]; /* map the type ID to the actual type object */
@@ -443,7 +443,7 @@ H5O_msg_read(const H5O_loc_t *loc, unsigned type_id, void *mesg)
     /* check args */
     HDassert(loc);
     HDassert(loc->file);
-    HDassert(H5F_addr_defined(loc->addr));
+    HDassert(H5_addr_defined(loc->addr));
     HDassert(type_id < NELMTS(H5O_msg_class_g));
 
     /* Get the object header */
@@ -754,7 +754,7 @@ H5O_msg_count(const H5O_loc_t *loc, unsigned type_id)
     /* Check args */
     HDassert(loc);
     HDassert(loc->file);
-    HDassert(H5F_addr_defined(loc->addr));
+    HDassert(H5_addr_defined(loc->addr));
     HDassert(type_id < NELMTS(H5O_msg_class_g));
     type = H5O_msg_class_g[type_id]; /* map the type ID to the actual type object */
     HDassert(type);
@@ -926,7 +926,7 @@ H5O_msg_remove(const H5O_loc_t *loc, unsigned type_id, int sequence, hbool_t adj
     /* check args */
     HDassert(loc);
     HDassert(loc->file);
-    HDassert(H5F_addr_defined(loc->addr));
+    HDassert(H5_addr_defined(loc->addr));
     HDassert(H5O_ATTR_ID != type_id); /* Attributes are modified in another routine */
     HDassert(type_id < NELMTS(H5O_msg_class_g));
     type = H5O_msg_class_g[type_id]; /* map the type ID to the actual type object */
@@ -976,7 +976,7 @@ H5O_msg_remove_op(const H5O_loc_t *loc, unsigned type_id, int sequence, H5O_oper
     /* check args */
     HDassert(loc);
     HDassert(loc->file);
-    HDassert(H5F_addr_defined(loc->addr));
+    HDassert(H5_addr_defined(loc->addr));
     HDassert(H5O_ATTR_ID != type_id); /* Attributes are modified in another routine */
     HDassert(type_id < NELMTS(H5O_msg_class_g));
     type = H5O_msg_class_g[type_id]; /* map the type ID to the actual type object */
@@ -1159,7 +1159,7 @@ H5O_msg_iterate(const H5O_loc_t *loc, unsigned type_id, const H5O_mesg_operator_
     /* check args */
     HDassert(loc);
     HDassert(loc->file);
-    HDassert(H5F_addr_defined(loc->addr));
+    HDassert(H5_addr_defined(loc->addr));
     HDassert(type_id < NELMTS(H5O_msg_class_g));
     type = H5O_msg_class_g[type_id]; /* map the type ID to the actual type object */
     HDassert(type);
@@ -2180,7 +2180,7 @@ H5O_msg_get_flags(const H5O_loc_t *loc, unsigned type_id, uint8_t *flags)
     /* check args */
     HDassert(loc);
     HDassert(loc->file);
-    HDassert(H5F_addr_defined(loc->addr));
+    HDassert(H5_addr_defined(loc->addr));
     HDassert(type_id < NELMTS(H5O_msg_class_g));
     type = H5O_msg_class_g[type_id]; /* map the type ID to the actual type object */
     HDassert(type);

--- a/src/H5Ostab.c
+++ b/src/H5Ostab.c
@@ -357,7 +357,7 @@ H5O__stab_post_copy_file(const H5O_loc_t *src_oloc, const void *mesg_src, H5O_lo
 
     /* check args */
     HDassert(stab_src);
-    HDassert(H5F_addr_defined(dst_oloc->addr));
+    HDassert(H5_addr_defined(dst_oloc->addr));
     HDassert(dst_oloc->file);
     HDassert(stab_dst);
     HDassert(cpy_info);

--- a/src/H5Otest.c
+++ b/src/H5Otest.c
@@ -115,7 +115,7 @@ H5O__is_attr_dense_test(hid_t oid)
     } /* end if */
 
     /* Check if dense storage is being used */
-    if (H5F_addr_defined(ainfo.fheap_addr)) {
+    if (H5_addr_defined(ainfo.fheap_addr)) {
         /* Check for any messages in object header */
         HDassert(H5O__msg_count_real(oh, H5O_MSG_ATTR) == 0);
 
@@ -192,7 +192,7 @@ H5O__is_attr_empty_test(hid_t oid)
     if (oh->version > H5O_VERSION_1) {
         if (ainfo_exists) {
             /* Check for using dense storage */
-            if (H5F_addr_defined(ainfo.fheap_addr)) {
+            if (H5_addr_defined(ainfo.fheap_addr)) {
                 /* Check for any messages in object header */
                 HDassert(nattrs == 0);
 
@@ -294,7 +294,7 @@ H5O__num_attrs_test(hid_t oid, hsize_t *nattrs)
     /* Check for later version of object header format */
     if (oh->version > H5O_VERSION_1) {
         /* Check for using dense storage */
-        if (H5F_addr_defined(ainfo.fheap_addr)) {
+        if (H5_addr_defined(ainfo.fheap_addr)) {
             /* Check for any messages in object header */
             HDassert(obj_nattrs == 0);
 
@@ -391,9 +391,9 @@ H5O__attr_dense_info_test(hid_t oid, hsize_t *name_count, hsize_t *corder_count)
     } /* end if */
 
     /* Check for 'dense' attribute storage file addresses being defined */
-    if (!H5F_addr_defined(ainfo.fheap_addr))
+    if (!H5_addr_defined(ainfo.fheap_addr))
         HGOTO_DONE_TAG(FAIL)
-    if (!H5F_addr_defined(ainfo.name_bt2_addr))
+    if (!H5_addr_defined(ainfo.name_bt2_addr))
         HGOTO_DONE_TAG(FAIL)
 
     /* Open the name index v2 B-tree */
@@ -405,7 +405,7 @@ H5O__attr_dense_info_test(hid_t oid, hsize_t *name_count, hsize_t *corder_count)
         HGOTO_ERROR_TAG(H5E_OHDR, H5E_CANTCOUNT, FAIL, "unable to retrieve # of records from name index")
 
     /* Check if there is a creation order index */
-    if (H5F_addr_defined(ainfo.corder_bt2_addr)) {
+    if (H5_addr_defined(ainfo.corder_bt2_addr)) {
         /* Open the creation order index v2 B-tree */
         if (NULL == (bt2_corder = H5B2_open(loc->file, ainfo.corder_bt2_addr, NULL)))
             HGOTO_ERROR_TAG(H5E_OHDR, H5E_CANTOPENOBJ, FAIL,

--- a/src/H5Rint.c
+++ b/src/H5Rint.c
@@ -1382,7 +1382,7 @@ H5R__decode_heap(H5F_t *f, const unsigned char *buf, size_t *nbytes, unsigned ch
 
     /* Get the heap information */
     H5F_addr_decode(f, &p, &(hobjid.addr));
-    if (!H5F_addr_defined(hobjid.addr) || hobjid.addr == 0)
+    if (!H5_addr_defined(hobjid.addr) || hobjid.addr == 0)
         HGOTO_ERROR(H5E_ARGS, H5E_BADVALUE, FAIL, "Undefined reference pointer")
     UINT32DECODE(p, hobjid.idx);
 

--- a/src/H5SM.c
+++ b/src/H5SM.c
@@ -122,7 +122,7 @@ H5SM_init(H5F_t *f, H5P_genplist_t *fc_plist, const H5O_loc_t *ext_loc)
 
     HDassert(f);
     /* File should not already have a SOHM table */
-    HDassert(!H5F_addr_defined(H5F_SOHM_ADDR(f)));
+    HDassert(!H5_addr_defined(H5F_SOHM_ADDR(f)));
 
     /* Set the ring type in the DXPL */
     H5AC_set_ring(H5AC_RING_USER, &orig_ring);
@@ -351,7 +351,7 @@ H5SM_type_shared(H5F_t *f, unsigned type_id)
         HGOTO_ERROR(H5E_SOHM, H5E_CANTGET, FAIL, "can't map message type to flag")
 
     /* Look up the master SOHM table */
-    if (H5F_addr_defined(H5F_SOHM_ADDR(f))) {
+    if (H5_addr_defined(H5F_SOHM_ADDR(f))) {
         H5SM_table_cache_ud_t cache_udata; /* User-data for callback */
 
         /* Set up user data for callback */
@@ -911,7 +911,7 @@ H5SM__can_share_common(const H5F_t *f, unsigned type_id, const void *mesg)
 
     /* Check whether this message ought to be shared or not */
     /* If sharing is disabled in this file, don't share the message */
-    if (!H5F_addr_defined(H5F_SOHM_ADDR(f)))
+    if (!H5_addr_defined(H5F_SOHM_ADDR(f)))
         HGOTO_DONE(FALSE)
 
     /* Type-specific check */
@@ -1571,7 +1571,7 @@ H5SM_delete(H5F_t *f, H5O_t *open_oh, H5O_shared_t *sh_mesg)
     FUNC_ENTER_NOAPI_TAG(H5AC__SOHM_TAG, FAIL)
 
     HDassert(f);
-    HDassert(H5F_addr_defined(H5F_SOHM_ADDR(f)));
+    HDassert(H5_addr_defined(H5F_SOHM_ADDR(f)));
     HDassert(sh_mesg);
 
     /* Get message type */
@@ -2003,7 +2003,7 @@ H5SM_get_info(const H5O_loc_t *ext_loc, H5P_genplist_t *fc_plist)
         H5F_SET_SOHM_ADDR(f, sohm_table.addr);
         H5F_SET_SOHM_VERS(f, sohm_table.version);
         H5F_SET_SOHM_NINDEXES(f, sohm_table.nindexes);
-        HDassert(H5F_addr_defined(H5F_SOHM_ADDR(f)));
+        HDassert(H5_addr_defined(H5F_SOHM_ADDR(f)));
         HDassert(H5F_SOHM_NINDEXES(f) > 0 && H5F_SOHM_NINDEXES(f) <= H5O_SHMESG_MAX_NINDEXES);
 
         /* Set up user data for callback */
@@ -2650,7 +2650,7 @@ H5SM_list_debug(H5F_t *f, haddr_t list_addr, FILE *stream, int indent, int fwidt
     /* Determine which index the list is part of */
     index_num = table->num_indexes;
     for (x = 0; x < table->num_indexes; x++) {
-        if (H5F_addr_eq(table->indexes[x].index_addr, list_addr)) {
+        if (H5_addr_eq(table->indexes[x].index_addr, list_addr)) {
             index_num = x;
             break;
         } /* end if */
@@ -2669,7 +2669,7 @@ H5SM_list_debug(H5F_t *f, haddr_t list_addr, FILE *stream, int indent, int fwidt
         HGOTO_ERROR(H5E_SOHM, H5E_CANTPROTECT, FAIL, "unable to load SOHM index")
 
     /* Open the heap, if one exists */
-    if (H5F_addr_defined(table->indexes[index_num].heap_addr))
+    if (H5_addr_defined(table->indexes[index_num].heap_addr))
         if (NULL == (fh = H5HF_open(f, table->indexes[index_num].heap_addr)))
             HGOTO_ERROR(H5E_SOHM, H5E_CANTOPENOBJ, FAIL, "unable to open SOHM heap")
 
@@ -2741,7 +2741,7 @@ H5SM_ih_size(H5F_t *f, hsize_t *hdr_size, H5_ih_info_t *ih_info)
 
     /* Sanity check */
     HDassert(f);
-    HDassert(H5F_addr_defined(H5F_SOHM_ADDR(f)));
+    HDassert(H5_addr_defined(H5F_SOHM_ADDR(f)));
     HDassert(hdr_size);
     HDassert(ih_info);
 
@@ -2760,7 +2760,7 @@ H5SM_ih_size(H5F_t *f, hsize_t *hdr_size, H5_ih_info_t *ih_info)
     for (u = 0; u < table->num_indexes; u++) {
         /* Get index storage size (for either B-tree or list) */
         if (table->indexes[u].index_type == H5SM_BTREE) {
-            if (H5F_addr_defined(table->indexes[u].index_addr)) {
+            if (H5_addr_defined(table->indexes[u].index_addr)) {
                 /* Open the index v2 B-tree */
                 if (NULL == (bt2 = H5B2_open(f, table->indexes[u].index_addr, f)))
                     HGOTO_ERROR(H5E_SOHM, H5E_CANTOPENOBJ, FAIL, "unable to open v2 B-tree for SOHM index")
@@ -2780,7 +2780,7 @@ H5SM_ih_size(H5F_t *f, hsize_t *hdr_size, H5_ih_info_t *ih_info)
         } /* end else */
 
         /* Check for heap for this index */
-        if (H5F_addr_defined(table->indexes[u].heap_addr)) {
+        if (H5_addr_defined(table->indexes[u].heap_addr)) {
             /* Open the fractal heap for this index */
             if (NULL == (fheap = H5HF_open(f, table->indexes[u].heap_addr)))
                 HGOTO_ERROR(H5E_SOHM, H5E_CANTOPENOBJ, FAIL, "unable to open fractal heap")

--- a/src/H5SMtest.c
+++ b/src/H5SMtest.c
@@ -76,7 +76,7 @@ H5SM__get_mesg_count_test(H5F_t *f, unsigned type_id, size_t *mesg_count)
     HDassert(mesg_count);
 
     /* Check for shared messages being enabled */
-    if (H5F_addr_defined(H5F_SOHM_ADDR(f))) {
+    if (H5_addr_defined(H5F_SOHM_ADDR(f))) {
         H5SM_index_header_t  *header;      /* Index header for message type */
         H5SM_table_cache_ud_t cache_udata; /* User-data for callback */
         ssize_t               index_num;   /* Table index for message type */

--- a/src/H5T.c
+++ b/src/H5T.c
@@ -4142,8 +4142,8 @@ H5T_close(H5T_t *dt)
 
         /* Sanity checks */
         HDassert(dt->sh_loc.type == H5O_SHARE_TYPE_COMMITTED);
-        HDassert(H5F_addr_defined(dt->sh_loc.u.loc.oh_addr));
-        HDassert(H5F_addr_defined(dt->oloc.addr));
+        HDassert(H5_addr_defined(dt->sh_loc.u.loc.oh_addr));
+        HDassert(H5_addr_defined(dt->oloc.addr));
 
         /* If a named type is being closed then close the object header and
          * remove from the list of open objects in the file.

--- a/src/H5Tcommit.c
+++ b/src/H5Tcommit.c
@@ -1023,7 +1023,7 @@ H5T__open_name(const H5G_loc_t *loc, const char *name)
 done:
     /* Error cleanup */
     if (NULL == ret_value)
-        if (obj_found && H5F_addr_defined(type_loc.oloc->addr))
+        if (obj_found && H5_addr_defined(type_loc.oloc->addr))
             if (H5G_loc_free(&type_loc) < 0)
                 HDONE_ERROR(H5E_DATATYPE, H5E_CANTRELEASE, NULL, "can't free location")
 

--- a/src/H5private.h
+++ b/src/H5private.h
@@ -413,6 +413,35 @@
  */
 #define H5_REQUEST_NULL NULL
 
+/* clang-format off */
+/* Address-related macros */
+#define H5_addr_overflow(X,Z)    (HADDR_UNDEF == (X) ||                     \
+                                  HADDR_UNDEF == (X) + (haddr_t)(Z) ||      \
+                                  (X) + (haddr_t)(Z) < (X))
+#define H5_addr_defined(X)       ((X) != HADDR_UNDEF)
+/* The H5_addr_eq() macro guarantees that Y is not HADDR_UNDEF by making
+ * certain that X is not HADDR_UNDEF and then checking that X equals Y
+ */
+#define H5_addr_eq(X,Y)          ((X) != HADDR_UNDEF && (X) == (Y))
+#define H5_addr_ne(X,Y)          (!H5_addr_eq((X),(Y)))
+#define H5_addr_lt(X,Y)          ((X) != HADDR_UNDEF &&                     \
+                                  (Y) != HADDR_UNDEF &&                     \
+                                  (X) < (Y))
+#define H5_addr_le(X,Y)          ((X) != HADDR_UNDEF &&                     \
+                                  (Y) != HADDR_UNDEF &&                     \
+                                  (X) <= (Y))
+#define H5_addr_gt(X,Y)          ((X) != HADDR_UNDEF &&                     \
+                                  (Y) != HADDR_UNDEF &&                     \
+                                  (X) > (Y))
+#define H5_addr_ge(X,Y)          ((X) != HADDR_UNDEF &&                     \
+                                  (Y) != HADDR_UNDEF &&                     \
+                                  (X) >= (Y))
+#define H5_addr_cmp(X,Y)         (H5_addr_eq((X), (Y)) ? 0 :                \
+                                 (H5_addr_lt((X), (Y)) ? -1 : 1))
+#define H5_addr_overlap(O1,L1,O2,L2) (((O1) < (O2) && ((O1) + (L1)) > (O2)) || \
+                                      ((O1) >= (O2) && (O1) < ((O2) + (L2))))
+/* clang-format on */
+
 /*
  * Methods to compare the equality of floating-point values:
  *

--- a/src/H5trace.c
+++ b/src/H5trace.c
@@ -443,7 +443,7 @@ H5_trace_args(H5RS_str_t *rs, const char *type, va_list ap)
                 {
                     haddr_t addr = HDva_arg(ap, haddr_t);
 
-                    if (H5F_addr_defined(addr))
+                    if (H5_addr_defined(addr))
                         H5RS_asprintf_cat(rs, "%" PRIuHADDR, addr);
                     else
                         H5RS_acat(rs, "UNDEF");

--- a/test/btree2.c
+++ b/test/btree2.c
@@ -145,7 +145,7 @@ create_btree(H5F_t *f, const H5B2_create_t *cparam, H5B2_t **bt2, haddr_t *bt2_a
         FAIL_STACK_ERROR;
     if (H5B2_get_addr(*bt2, bt2_addr /*out*/) < 0)
         FAIL_STACK_ERROR;
-    if (!H5F_addr_defined(*bt2_addr))
+    if (!H5_addr_defined(*bt2_addr))
         FAIL_STACK_ERROR;
 
     /* Success */
@@ -5400,7 +5400,7 @@ test_remove_basic(hid_t fapl, const H5B2_create_t *cparam, const bt2_test_param_
         FAIL_STACK_ERROR;
 
     /* Make certain that the address of the root node is defined */
-    if (!H5F_addr_defined(root_addr))
+    if (!H5_addr_defined(root_addr))
         TEST_ERROR;
 
     /* Attempt to remove a non-existent record from a B-tree with 1 record */
@@ -5445,7 +5445,7 @@ test_remove_basic(hid_t fapl, const H5B2_create_t *cparam, const bt2_test_param_
         FAIL_STACK_ERROR;
 
     /* Make certain that the root node has been freed */
-    if (H5F_addr_defined(root_addr))
+    if (H5_addr_defined(root_addr))
         TEST_ERROR;
 
     PASSED();
@@ -5529,7 +5529,7 @@ test_remove_basic(hid_t fapl, const H5B2_create_t *cparam, const bt2_test_param_
         FAIL_STACK_ERROR;
 
     /* Make certain that the root node has not been freed */
-    if (!H5F_addr_defined(root_addr))
+    if (!H5_addr_defined(root_addr))
         TEST_ERROR;
 
     record  = 34;
@@ -5554,7 +5554,7 @@ test_remove_basic(hid_t fapl, const H5B2_create_t *cparam, const bt2_test_param_
         FAIL_STACK_ERROR;
 
     /* Make certain that the root node has not been freed */
-    if (!H5F_addr_defined(root_addr))
+    if (!H5_addr_defined(root_addr))
         TEST_ERROR;
 
     record  = 56;
@@ -5579,7 +5579,7 @@ test_remove_basic(hid_t fapl, const H5B2_create_t *cparam, const bt2_test_param_
         FAIL_STACK_ERROR;
 
     /* Make certain that the root node has not been freed */
-    if (!H5F_addr_defined(root_addr))
+    if (!H5_addr_defined(root_addr))
         TEST_ERROR;
 
     record  = 38;
@@ -5604,7 +5604,7 @@ test_remove_basic(hid_t fapl, const H5B2_create_t *cparam, const bt2_test_param_
         FAIL_STACK_ERROR;
 
     /* Make certain that the root node has been freed */
-    if (H5F_addr_defined(root_addr))
+    if (H5_addr_defined(root_addr))
         TEST_ERROR;
 
     /* Close the v2 B-tree */
@@ -5689,7 +5689,7 @@ test_remove_level1_noredistrib(hid_t fapl, const H5B2_create_t *cparam, const bt
         FAIL_STACK_ERROR;
 
     /* Make certain that the address of the root node is defined */
-    if (!H5F_addr_defined(root_addr))
+    if (!H5_addr_defined(root_addr))
         TEST_ERROR;
 
     /* Attempt to remove a non-existent record from a B-tree with 1 record */
@@ -5920,7 +5920,7 @@ test_remove_level1_redistrib(hid_t fapl, const H5B2_create_t *cparam, const bt2_
         FAIL_STACK_ERROR;
 
     /* Make certain that the address of the root node is defined */
-    if (!H5F_addr_defined(root_addr))
+    if (!H5_addr_defined(root_addr))
         TEST_ERROR;
 
     /* Check for closing & re-opening the B-tree */
@@ -6118,7 +6118,7 @@ test_remove_level1_2leaf_merge(hid_t fapl, const H5B2_create_t *cparam, const bt
         FAIL_STACK_ERROR;
 
     /* Make certain that the address of the root node is defined */
-    if (!H5F_addr_defined(root_addr))
+    if (!H5_addr_defined(root_addr))
         TEST_ERROR;
 
     /* Check for closing & re-opening the B-tree */
@@ -6296,7 +6296,7 @@ test_remove_level1_3leaf_merge(hid_t fapl, const H5B2_create_t *cparam, const bt
         FAIL_STACK_ERROR;
 
     /* Make certain that the address of the root node is defined */
-    if (!H5F_addr_defined(root_addr))
+    if (!H5_addr_defined(root_addr))
         TEST_ERROR;
 
     /* Check for closing & re-opening the B-tree */
@@ -6427,7 +6427,7 @@ test_remove_level1_promote(hid_t fapl, const H5B2_create_t *cparam, const bt2_te
         FAIL_STACK_ERROR;
 
     /* Make certain that the address of the root node is defined */
-    if (!H5F_addr_defined(root_addr))
+    if (!H5_addr_defined(root_addr))
         TEST_ERROR;
 
     /* Check for closing & re-opening the B-tree */
@@ -6648,7 +6648,7 @@ test_remove_level1_promote_2leaf_redistrib(hid_t fapl, const H5B2_create_t *cpar
         FAIL_STACK_ERROR;
 
     /* Make certain that the address of the root node is defined */
-    if (!H5F_addr_defined(root_addr))
+    if (!H5_addr_defined(root_addr))
         TEST_ERROR;
 
     /* Check for closing & re-opening the B-tree */
@@ -6796,7 +6796,7 @@ test_remove_level1_promote_3leaf_redistrib(hid_t fapl, const H5B2_create_t *cpar
         FAIL_STACK_ERROR;
 
     /* Make certain that the address of the root node is defined */
-    if (!H5F_addr_defined(root_addr))
+    if (!H5_addr_defined(root_addr))
         TEST_ERROR;
 
     /* Check for closing & re-opening the B-tree */
@@ -6944,7 +6944,7 @@ test_remove_level1_promote_2leaf_merge(hid_t fapl, const H5B2_create_t *cparam,
         FAIL_STACK_ERROR;
 
     /* Make certain that the address of the root node is defined */
-    if (!H5F_addr_defined(root_addr))
+    if (!H5_addr_defined(root_addr))
         TEST_ERROR;
 
     /* Check for closing & re-opening the B-tree */
@@ -7089,7 +7089,7 @@ test_remove_level1_promote_3leaf_merge(hid_t fapl, const H5B2_create_t *cparam,
         FAIL_STACK_ERROR;
 
     /* Make certain that the address of the root node is defined */
-    if (!H5F_addr_defined(root_addr))
+    if (!H5_addr_defined(root_addr))
         TEST_ERROR;
 
     /* Check for closing & re-opening the B-tree */
@@ -7230,7 +7230,7 @@ test_remove_level1_collapse(hid_t fapl, const H5B2_create_t *cparam, const bt2_t
         FAIL_STACK_ERROR;
 
     /* Make certain that the address of the root node is defined */
-    if (!H5F_addr_defined(root_addr))
+    if (!H5_addr_defined(root_addr))
         TEST_ERROR;
 
     /* Check for closing & re-opening the B-tree */
@@ -7277,7 +7277,7 @@ test_remove_level1_collapse(hid_t fapl, const H5B2_create_t *cparam, const bt2_t
         FAIL_STACK_ERROR;
 
     /* Make certain that the address of the root node is defined */
-    if (!H5F_addr_defined(root_addr))
+    if (!H5_addr_defined(root_addr))
         TEST_ERROR;
 
     /* Close the v2 B-tree */
@@ -7371,7 +7371,7 @@ test_remove_level2_promote(hid_t fapl, const H5B2_create_t *cparam, const bt2_te
         FAIL_STACK_ERROR;
 
     /* Make certain that the address of the root node is defined */
-    if (!H5F_addr_defined(root_addr))
+    if (!H5_addr_defined(root_addr))
         TEST_ERROR;
 
     /* Check for closing & re-opening the B-tree */
@@ -7657,7 +7657,7 @@ test_remove_level2_promote_2internal_redistrib(hid_t fapl, const H5B2_create_t *
         FAIL_STACK_ERROR;
 
     /* Make certain that the address of the root node is defined */
-    if (!H5F_addr_defined(root_addr))
+    if (!H5_addr_defined(root_addr))
         TEST_ERROR;
 
     /* Check for closing & re-opening the B-tree */
@@ -7808,7 +7808,7 @@ test_remove_level2_promote_3internal_redistrib(hid_t fapl, const H5B2_create_t *
         FAIL_STACK_ERROR;
 
     /* Make certain that the address of the root node is defined */
-    if (!H5F_addr_defined(root_addr))
+    if (!H5_addr_defined(root_addr))
         TEST_ERROR;
 
     /* Check for closing & re-opening the B-tree */
@@ -7959,7 +7959,7 @@ test_remove_level2_promote_2internal_merge(hid_t fapl, const H5B2_create_t *cpar
         FAIL_STACK_ERROR;
 
     /* Make certain that the address of the root node is defined */
-    if (!H5F_addr_defined(root_addr))
+    if (!H5_addr_defined(root_addr))
         TEST_ERROR;
 
     /* Check for closing & re-opening the B-tree */
@@ -8111,7 +8111,7 @@ test_remove_level2_promote_3internal_merge(hid_t fapl, const H5B2_create_t *cpar
         FAIL_STACK_ERROR;
 
     /* Make certain that the address of the root node is defined */
-    if (!H5F_addr_defined(root_addr))
+    if (!H5_addr_defined(root_addr))
         TEST_ERROR;
 
     /* Check for closing & re-opening the B-tree */
@@ -8263,7 +8263,7 @@ test_remove_level2_2internal_merge_left(hid_t fapl, const H5B2_create_t *cparam,
         FAIL_STACK_ERROR;
 
     /* Make certain that the address of the root node is defined */
-    if (!H5F_addr_defined(root_addr))
+    if (!H5_addr_defined(root_addr))
         TEST_ERROR;
 
     /* Check for closing & re-opening the B-tree */
@@ -8389,7 +8389,7 @@ test_remove_level2_2internal_merge_right(hid_t fapl, const H5B2_create_t *cparam
         FAIL_STACK_ERROR;
 
     /* Make certain that the address of the root node is defined */
-    if (!H5F_addr_defined(root_addr))
+    if (!H5_addr_defined(root_addr))
         TEST_ERROR;
 
     /* Check for closing & re-opening the B-tree */
@@ -8514,7 +8514,7 @@ test_remove_level2_3internal_merge(hid_t fapl, const H5B2_create_t *cparam, cons
         FAIL_STACK_ERROR;
 
     /* Make certain that the address of the root node is defined */
-    if (!H5F_addr_defined(root_addr))
+    if (!H5_addr_defined(root_addr))
         TEST_ERROR;
 
     /* Check for closing & re-opening the B-tree */
@@ -8641,7 +8641,7 @@ test_remove_level2_collapse_right(hid_t fapl, const H5B2_create_t *cparam, const
         FAIL_STACK_ERROR;
 
     /* Make certain that the address of the root node is defined */
-    if (!H5F_addr_defined(root_addr))
+    if (!H5_addr_defined(root_addr))
         TEST_ERROR;
 
     /* Check for closing & re-opening the B-tree */
@@ -8929,7 +8929,7 @@ HDfprintf(stderr, "curr_time = %lu\n", (unsigned long)curr_time);
         FAIL_STACK_ERROR;
 
     /* Make certain that the address of the root node is defined */
-    if (H5F_addr_defined(root_addr))
+    if (H5_addr_defined(root_addr))
         TEST_ERROR;
 
     /* Close the v2 B-tree */
@@ -9013,7 +9013,7 @@ HDfprintf(stderr, "curr_time = %lu\n", (unsigned long)curr_time);
         FAIL_STACK_ERROR;
 
     /* Make certain that the address of the root node is defined */
-    if (H5F_addr_defined(root_addr))
+    if (H5_addr_defined(root_addr))
         TEST_ERROR;
 
     /* Close the v2 B-tree */
@@ -9095,7 +9095,7 @@ HDfprintf(stderr, "curr_time = %lu\n", (unsigned long)curr_time);
         FAIL_STACK_ERROR;
 
     /* Make certain that the address of the root node is defined */
-    if (H5F_addr_defined(root_addr))
+    if (H5_addr_defined(root_addr))
         TEST_ERROR;
 
     /* Close the v2 B-tree */
@@ -9177,7 +9177,7 @@ HDfprintf(stderr, "curr_time = %lu\n", (unsigned long)curr_time);
         FAIL_STACK_ERROR;
 
     /* Make certain that the address of the root node is defined */
-    if (H5F_addr_defined(root_addr))
+    if (H5_addr_defined(root_addr))
         TEST_ERROR;
 
     /* Close the v2 B-tree */

--- a/test/cache.c
+++ b/test/cache.c
@@ -34014,7 +34014,7 @@ takedown_cache(H5F_t *file_ptr, hbool_t dump_stats, hbool_t dump_detailed_stats)
 
     if (saved_fid != -1) {
 
-        if (H5F_addr_defined(saved_actual_base_addr)) {
+        if (H5_addr_defined(saved_actual_base_addr)) {
 
             if (NULL == file_ptr) {
                 file_ptr = (H5F_t *)H5VL_object_verify(saved_fid, H5I_FILE);

--- a/test/cache_common.h
+++ b/test/cache_common.h
@@ -424,7 +424,7 @@ typedef struct test_entry_t {
         k           = H5C__HASH_FCN(Addr);                                                                   \
         (entry_ptr) = (cache_ptr)->index[k];                                                                 \
         while (entry_ptr) {                                                                                  \
-            if (H5F_addr_eq(Addr, (entry_ptr)->addr)) {                                                      \
+            if (H5_addr_eq(Addr, (entry_ptr)->addr)) {                                                       \
                 H5C_TEST__POST_SUC_HT_SEARCH_SC(cache_ptr, entry_ptr, k)                                     \
                 if ((entry_ptr) != (cache_ptr)->index[k]) {                                                  \
                     if ((entry_ptr)->ht_next)                                                                \

--- a/test/cache_image.c
+++ b/test/cache_image.c
@@ -7214,9 +7214,9 @@ get_free_sections_test(hbool_t single_file_vfd)
         /* file_ptr->shared->first_alloc_dealloc is set to FALSE if the
          * file is opened R/O.
          */
-        if ((!H5F_addr_defined(file_ptr->shared->eoa_fsm_fsalloc)) ||
-            (!H5F_addr_defined(file_ptr->shared->cache->image_addr)) ||
-            (H5F_addr_gt(file_ptr->shared->eoa_fsm_fsalloc, file_ptr->shared->cache->image_addr))) {
+        if ((!H5_addr_defined(file_ptr->shared->eoa_fsm_fsalloc)) ||
+            (!H5_addr_defined(file_ptr->shared->cache->image_addr)) ||
+            (H5_addr_gt(file_ptr->shared->eoa_fsm_fsalloc, file_ptr->shared->cache->image_addr))) {
 
             pass         = FALSE;
             failure_mssg = "unexpected cache image status (1).\n";
@@ -7319,9 +7319,9 @@ get_free_sections_test(hbool_t single_file_vfd)
      */
     if (pass) {
 
-        if ((!H5F_addr_defined(file_ptr->shared->eoa_fsm_fsalloc)) ||
-            (!H5F_addr_defined(file_ptr->shared->cache->image_addr)) ||
-            (H5F_addr_gt(file_ptr->shared->eoa_fsm_fsalloc, file_ptr->shared->cache->image_addr))) {
+        if ((!H5_addr_defined(file_ptr->shared->eoa_fsm_fsalloc)) ||
+            (!H5_addr_defined(file_ptr->shared->cache->image_addr)) ||
+            (H5_addr_gt(file_ptr->shared->eoa_fsm_fsalloc, file_ptr->shared->cache->image_addr))) {
 
             pass         = FALSE;
             failure_mssg = "unexpected cache image status (2).\n";

--- a/test/earray.c
+++ b/test/earray.c
@@ -491,7 +491,7 @@ create_array(H5F_t *f, const H5EA_create_t *cparam, H5EA_t **ea, haddr_t *ea_add
         TEST_ERROR;
     if (H5EA_get_addr(*ea, ea_addr) < 0)
         FAIL_STACK_ERROR;
-    if (!H5F_addr_defined(*ea_addr))
+    if (!H5_addr_defined(*ea_addr))
         TEST_ERROR;
     HDmemset(&state, 0, sizeof(state));
     state.hdr_size = EA_HDR_SIZE;

--- a/test/farray.c
+++ b/test/farray.c
@@ -316,7 +316,7 @@ create_array(H5F_t *f, const H5FA_create_t *cparam, H5FA_t **fa, haddr_t *fa_add
     /* Check status of array */
     if (H5FA_get_addr(*fa, fa_addr) < 0)
         FAIL_STACK_ERROR;
-    if (!H5F_addr_defined(*fa_addr))
+    if (!H5_addr_defined(*fa_addr))
         TEST_ERROR;
 
     /* Check array stats */

--- a/test/fheap.c
+++ b/test/fheap.c
@@ -659,7 +659,7 @@ open_heap(char *filename, hid_t fapl, const H5HF_create_t *cparam, const fheap_t
             TEST_ERROR;
         if (H5HF_get_heap_addr(*fh, fh_addr) < 0)
             FAIL_STACK_ERROR;
-        if (!H5F_addr_defined(*fh_addr))
+        if (!H5_addr_defined(*fh_addr))
             TEST_ERROR;
         HDmemset(state, 0, sizeof(fheap_heap_state_t));
         if (check_stats(*fh, state))
@@ -704,7 +704,7 @@ open_heap(char *filename, hid_t fapl, const H5HF_create_t *cparam, const fheap_t
             TEST_ERROR;
         if (H5HF_get_heap_addr(*fh, fh_addr) < 0)
             FAIL_STACK_ERROR;
-        if (!H5F_addr_defined(*fh_addr))
+        if (!H5_addr_defined(*fh_addr))
             TEST_ERROR;
         HDmemset(state, 0, sizeof(fheap_heap_state_t));
         if (check_stats(*fh, state))
@@ -857,7 +857,7 @@ del_objs_half_refill(H5F_t *f, H5HF_t **fh, fheap_test_param_t *tparam, fheap_he
     if (tparam->reopen_heap) {
         if (H5HF_get_heap_addr(*fh, &fh_addr) < 0)
             FAIL_STACK_ERROR;
-        if (!H5F_addr_defined(fh_addr))
+        if (!H5_addr_defined(fh_addr))
             TEST_ERROR;
     } /* end if */
 
@@ -954,7 +954,7 @@ del_objs(H5F_t *f, H5HF_t **fh, fheap_test_param_t *tparam, fheap_heap_state_t *
     if (tparam->reopen_heap) {
         if (H5HF_get_heap_addr(*fh, &fh_addr) < 0)
             FAIL_STACK_ERROR;
-        if (!H5F_addr_defined(fh_addr))
+        if (!H5_addr_defined(fh_addr))
             TEST_ERROR;
     } /* end if */
 
@@ -1857,7 +1857,7 @@ test_create(hid_t fapl, H5HF_create_t *cparam, fheap_test_param_t *tparam)
         TEST_ERROR;
     if (H5HF_get_heap_addr(fh, &fh_addr) < 0)
         FAIL_STACK_ERROR;
-    if (!H5F_addr_defined(fh_addr))
+    if (!H5_addr_defined(fh_addr))
         TEST_ERROR;
     HDmemset(&state, 0, sizeof(fheap_heap_state_t));
     if (check_stats(fh, &state))
@@ -1982,7 +1982,7 @@ test_reopen(hid_t fapl, H5HF_create_t *cparam, fheap_test_param_t *tparam)
         TEST_ERROR;
     if (H5HF_get_heap_addr(fh, &fh_addr) < 0)
         FAIL_STACK_ERROR;
-    if (!H5F_addr_defined(fh_addr))
+    if (!H5_addr_defined(fh_addr))
         TEST_ERROR;
     HDmemset(&state, 0, sizeof(fheap_heap_state_t));
     if (check_stats(fh, &state))
@@ -2137,7 +2137,7 @@ test_open_twice(hid_t fapl, H5HF_create_t *cparam, fheap_test_param_t *tparam)
         TEST_ERROR;
     if (H5HF_get_heap_addr(fh, &fh_addr) < 0)
         FAIL_STACK_ERROR;
-    if (!H5F_addr_defined(fh_addr))
+    if (!H5_addr_defined(fh_addr))
         TEST_ERROR;
     HDmemset(&state, 0, sizeof(fheap_heap_state_t));
     if (check_stats(fh, &state))
@@ -2307,7 +2307,7 @@ test_delete_open(hid_t fapl, H5HF_create_t *cparam, fheap_test_param_t *tparam)
         TEST_ERROR;
     if (H5HF_get_heap_addr(fh, &fh_addr) < 0)
         FAIL_STACK_ERROR;
-    if (!H5F_addr_defined(fh_addr))
+    if (!H5_addr_defined(fh_addr))
         TEST_ERROR;
     HDmemset(&state, 0, sizeof(fheap_heap_state_t));
     if (check_stats(fh, &state))
@@ -2814,7 +2814,7 @@ test_filtered_create(hid_t fapl, H5HF_create_t *cparam, hid_t fcpl)
     /* Get heap's address */
     if (H5HF_get_heap_addr(fh, &fh_addr) < 0)
         FAIL_STACK_ERROR;
-    if (!H5F_addr_defined(fh_addr))
+    if (!H5_addr_defined(fh_addr))
         TEST_ERROR;
 
     /* Close the fractal heap */
@@ -2928,7 +2928,7 @@ test_size(hid_t fapl, H5HF_create_t *cparam, hid_t fcpl)
     /* Get heap's address */
     if (H5HF_get_heap_addr(fh, &fh_addr) < 0)
         FAIL_STACK_ERROR;
-    if (!H5F_addr_defined(fh_addr))
+    if (!H5_addr_defined(fh_addr))
         TEST_ERROR;
 
     /* Get an empty heap's size */
@@ -3069,7 +3069,7 @@ test_reopen_hdr(hid_t fapl, H5HF_create_t *cparam, hid_t fcpl)
     /* Get heap's address */
     if (H5HF_get_heap_addr(fh, &fh_addr) < 0)
         FAIL_STACK_ERROR;
-    if (!H5F_addr_defined(fh_addr))
+    if (!H5_addr_defined(fh_addr))
         TEST_ERROR;
 
     /* Insert an object */
@@ -3202,7 +3202,7 @@ test_man_insert_weird(hid_t fapl, H5HF_create_t *cparam, fheap_test_param_t *tpa
         TEST_ERROR;
     if (H5HF_get_heap_addr(fh, &fh_addr) < 0)
         FAIL_STACK_ERROR;
-    if (!H5F_addr_defined(fh_addr))
+    if (!H5_addr_defined(fh_addr))
         TEST_ERROR;
     HDmemset(&state, 0, sizeof(fheap_heap_state_t));
     if (check_stats(fh, &state))
@@ -3315,7 +3315,7 @@ test_man_insert_first(hid_t fapl, H5HF_create_t *cparam, fheap_test_param_t *tpa
         TEST_ERROR;
     if (H5HF_get_heap_addr(fh, &fh_addr) < 0)
         FAIL_STACK_ERROR;
-    if (!H5F_addr_defined(fh_addr))
+    if (!H5_addr_defined(fh_addr))
         TEST_ERROR;
     HDmemset(&state, 0, sizeof(fheap_heap_state_t));
     if (check_stats(fh, &state))
@@ -3416,7 +3416,7 @@ test_man_insert_second(hid_t fapl, H5HF_create_t *cparam, fheap_test_param_t *tp
         FAIL_STACK_ERROR;
     if (H5HF_get_heap_addr(fh, &fh_addr) < 0)
         FAIL_STACK_ERROR;
-    if (!H5F_addr_defined(fh_addr))
+    if (!H5_addr_defined(fh_addr))
         FAIL_STACK_ERROR;
     HDmemset(&state, 0, sizeof(fheap_heap_state_t));
 
@@ -3513,7 +3513,7 @@ test_man_insert_root_mult(hid_t fapl, H5HF_create_t *cparam, fheap_test_param_t 
         FAIL_STACK_ERROR;
     if (H5HF_get_heap_addr(fh, &fh_addr) < 0)
         FAIL_STACK_ERROR;
-    if (!H5F_addr_defined(fh_addr))
+    if (!H5_addr_defined(fh_addr))
         FAIL_STACK_ERROR;
     HDmemset(&state, 0, sizeof(fheap_heap_state_t));
 
@@ -3612,7 +3612,7 @@ test_man_insert_force_indirect(hid_t fapl, H5HF_create_t *cparam, fheap_test_par
         FAIL_STACK_ERROR;
     if (H5HF_get_heap_addr(fh, &fh_addr) < 0)
         FAIL_STACK_ERROR;
-    if (!H5F_addr_defined(fh_addr))
+    if (!H5_addr_defined(fh_addr))
         FAIL_STACK_ERROR;
     HDmemset(&state, 0, sizeof(fheap_heap_state_t));
 
@@ -3718,7 +3718,7 @@ test_man_insert_fill_second(hid_t fapl, H5HF_create_t *cparam, fheap_test_param_
         FAIL_STACK_ERROR;
     if (H5HF_get_heap_addr(fh, &fh_addr) < 0)
         FAIL_STACK_ERROR;
-    if (!H5F_addr_defined(fh_addr))
+    if (!H5_addr_defined(fh_addr))
         FAIL_STACK_ERROR;
     HDmemset(&state, 0, sizeof(fheap_heap_state_t));
 
@@ -3825,7 +3825,7 @@ test_man_insert_third_direct(hid_t fapl, H5HF_create_t *cparam, fheap_test_param
         FAIL_STACK_ERROR;
     if (H5HF_get_heap_addr(fh, &fh_addr) < 0)
         FAIL_STACK_ERROR;
-    if (!H5F_addr_defined(fh_addr))
+    if (!H5_addr_defined(fh_addr))
         FAIL_STACK_ERROR;
     HDmemset(&state, 0, sizeof(fheap_heap_state_t));
 
@@ -3936,7 +3936,7 @@ test_man_fill_first_row(hid_t fapl, H5HF_create_t *cparam, fheap_test_param_t *t
         FAIL_STACK_ERROR;
     if (H5HF_get_heap_addr(fh, &fh_addr) < 0)
         FAIL_STACK_ERROR;
-    if (!H5F_addr_defined(fh_addr))
+    if (!H5_addr_defined(fh_addr))
         FAIL_STACK_ERROR;
     HDmemset(&state, 0, sizeof(fheap_heap_state_t));
 
@@ -4032,7 +4032,7 @@ test_man_start_second_row(hid_t fapl, H5HF_create_t *cparam, fheap_test_param_t 
         FAIL_STACK_ERROR;
     if (H5HF_get_heap_addr(fh, &fh_addr) < 0)
         FAIL_STACK_ERROR;
-    if (!H5F_addr_defined(fh_addr))
+    if (!H5_addr_defined(fh_addr))
         FAIL_STACK_ERROR;
     HDmemset(&state, 0, sizeof(fheap_heap_state_t));
 
@@ -4135,7 +4135,7 @@ test_man_fill_second_row(hid_t fapl, H5HF_create_t *cparam, fheap_test_param_t *
         FAIL_STACK_ERROR;
     if (H5HF_get_heap_addr(fh, &fh_addr) < 0)
         FAIL_STACK_ERROR;
-    if (!H5F_addr_defined(fh_addr))
+    if (!H5_addr_defined(fh_addr))
         FAIL_STACK_ERROR;
     HDmemset(&state, 0, sizeof(fheap_heap_state_t));
 
@@ -4236,7 +4236,7 @@ test_man_start_third_row(hid_t fapl, H5HF_create_t *cparam, fheap_test_param_t *
         FAIL_STACK_ERROR;
     if (H5HF_get_heap_addr(fh, &fh_addr) < 0)
         FAIL_STACK_ERROR;
-    if (!H5F_addr_defined(fh_addr))
+    if (!H5_addr_defined(fh_addr))
         FAIL_STACK_ERROR;
     HDmemset(&state, 0, sizeof(fheap_heap_state_t));
 
@@ -4347,7 +4347,7 @@ test_man_fill_fourth_row(hid_t fapl, H5HF_create_t *cparam, fheap_test_param_t *
         FAIL_STACK_ERROR;
     if (H5HF_get_heap_addr(fh, &fh_addr) < 0)
         FAIL_STACK_ERROR;
-    if (!H5F_addr_defined(fh_addr))
+    if (!H5_addr_defined(fh_addr))
         FAIL_STACK_ERROR;
     HDmemset(&state, 0, sizeof(fheap_heap_state_t));
 
@@ -4444,7 +4444,7 @@ test_man_fill_all_root_direct(hid_t fapl, H5HF_create_t *cparam, fheap_test_para
         FAIL_STACK_ERROR;
     if (H5HF_get_heap_addr(fh, &fh_addr) < 0)
         FAIL_STACK_ERROR;
-    if (!H5F_addr_defined(fh_addr))
+    if (!H5_addr_defined(fh_addr))
         FAIL_STACK_ERROR;
     HDmemset(&state, 0, sizeof(fheap_heap_state_t));
 
@@ -4540,7 +4540,7 @@ test_man_first_recursive_indirect(hid_t fapl, H5HF_create_t *cparam, fheap_test_
         FAIL_STACK_ERROR;
     if (H5HF_get_heap_addr(fh, &fh_addr) < 0)
         FAIL_STACK_ERROR;
-    if (!H5F_addr_defined(fh_addr))
+    if (!H5_addr_defined(fh_addr))
         FAIL_STACK_ERROR;
     HDmemset(&state, 0, sizeof(fheap_heap_state_t));
 
@@ -4642,7 +4642,7 @@ test_man_second_direct_recursive_indirect(hid_t fapl, H5HF_create_t *cparam, fhe
         FAIL_STACK_ERROR;
     if (H5HF_get_heap_addr(fh, &fh_addr) < 0)
         FAIL_STACK_ERROR;
-    if (!H5F_addr_defined(fh_addr))
+    if (!H5_addr_defined(fh_addr))
         FAIL_STACK_ERROR;
     HDmemset(&state, 0, sizeof(fheap_heap_state_t));
 
@@ -4752,7 +4752,7 @@ test_man_fill_first_recursive_indirect(hid_t fapl, H5HF_create_t *cparam, fheap_
         FAIL_STACK_ERROR;
     if (H5HF_get_heap_addr(fh, &fh_addr) < 0)
         FAIL_STACK_ERROR;
-    if (!H5F_addr_defined(fh_addr))
+    if (!H5_addr_defined(fh_addr))
         FAIL_STACK_ERROR;
     HDmemset(&state, 0, sizeof(fheap_heap_state_t));
 
@@ -4855,7 +4855,7 @@ test_man_second_recursive_indirect(hid_t fapl, H5HF_create_t *cparam, fheap_test
         FAIL_STACK_ERROR;
     if (H5HF_get_heap_addr(fh, &fh_addr) < 0)
         FAIL_STACK_ERROR;
-    if (!H5F_addr_defined(fh_addr))
+    if (!H5_addr_defined(fh_addr))
         FAIL_STACK_ERROR;
     HDmemset(&state, 0, sizeof(fheap_heap_state_t));
 
@@ -4966,7 +4966,7 @@ test_man_fill_second_recursive_indirect(hid_t fapl, H5HF_create_t *cparam, fheap
         FAIL_STACK_ERROR;
     if (H5HF_get_heap_addr(fh, &fh_addr) < 0)
         FAIL_STACK_ERROR;
-    if (!H5F_addr_defined(fh_addr))
+    if (!H5_addr_defined(fh_addr))
         FAIL_STACK_ERROR;
     HDmemset(&state, 0, sizeof(fheap_heap_state_t));
 
@@ -5070,7 +5070,7 @@ test_man_fill_recursive_indirect_row(hid_t fapl, H5HF_create_t *cparam, fheap_te
         FAIL_STACK_ERROR;
     if (H5HF_get_heap_addr(fh, &fh_addr) < 0)
         FAIL_STACK_ERROR;
-    if (!H5F_addr_defined(fh_addr))
+    if (!H5_addr_defined(fh_addr))
         FAIL_STACK_ERROR;
     HDmemset(&state, 0, sizeof(fheap_heap_state_t));
 
@@ -5172,7 +5172,7 @@ test_man_start_2nd_recursive_indirect(hid_t fapl, H5HF_create_t *cparam, fheap_t
         FAIL_STACK_ERROR;
     if (H5HF_get_heap_addr(fh, &fh_addr) < 0)
         FAIL_STACK_ERROR;
-    if (!H5F_addr_defined(fh_addr))
+    if (!H5_addr_defined(fh_addr))
         FAIL_STACK_ERROR;
     HDmemset(&state, 0, sizeof(fheap_heap_state_t));
 
@@ -5281,7 +5281,7 @@ test_man_recursive_indirect_two_deep(hid_t fapl, H5HF_create_t *cparam, fheap_te
         FAIL_STACK_ERROR;
     if (H5HF_get_heap_addr(fh, &fh_addr) < 0)
         FAIL_STACK_ERROR;
-    if (!H5F_addr_defined(fh_addr))
+    if (!H5_addr_defined(fh_addr))
         FAIL_STACK_ERROR;
     HDmemset(&state, 0, sizeof(fheap_heap_state_t));
 
@@ -5384,7 +5384,7 @@ test_man_start_3rd_recursive_indirect(hid_t fapl, H5HF_create_t *cparam, fheap_t
         FAIL_STACK_ERROR;
     if (H5HF_get_heap_addr(fh, &fh_addr) < 0)
         FAIL_STACK_ERROR;
-    if (!H5F_addr_defined(fh_addr))
+    if (!H5_addr_defined(fh_addr))
         FAIL_STACK_ERROR;
     HDmemset(&state, 0, sizeof(fheap_heap_state_t));
 
@@ -5494,7 +5494,7 @@ test_man_fill_first_3rd_recursive_indirect(hid_t fapl, H5HF_create_t *cparam, fh
         FAIL_STACK_ERROR;
     if (H5HF_get_heap_addr(fh, &fh_addr) < 0)
         FAIL_STACK_ERROR;
-    if (!H5F_addr_defined(fh_addr))
+    if (!H5_addr_defined(fh_addr))
         FAIL_STACK_ERROR;
     HDmemset(&state, 0, sizeof(fheap_heap_state_t));
 
@@ -5605,7 +5605,7 @@ test_man_fill_3rd_recursive_indirect_row(hid_t fapl, H5HF_create_t *cparam, fhea
         FAIL_STACK_ERROR;
     if (H5HF_get_heap_addr(fh, &fh_addr) < 0)
         FAIL_STACK_ERROR;
-    if (!H5F_addr_defined(fh_addr))
+    if (!H5_addr_defined(fh_addr))
         FAIL_STACK_ERROR;
     HDmemset(&state, 0, sizeof(fheap_heap_state_t));
 
@@ -5713,7 +5713,7 @@ test_man_fill_all_3rd_recursive_indirect(hid_t fapl, H5HF_create_t *cparam, fhea
         FAIL_STACK_ERROR;
     if (H5HF_get_heap_addr(fh, &fh_addr) < 0)
         FAIL_STACK_ERROR;
-    if (!H5F_addr_defined(fh_addr))
+    if (!H5_addr_defined(fh_addr))
         FAIL_STACK_ERROR;
     HDmemset(&state, 0, sizeof(fheap_heap_state_t));
 
@@ -5822,7 +5822,7 @@ test_man_start_4th_recursive_indirect(hid_t fapl, H5HF_create_t *cparam, fheap_t
         FAIL_STACK_ERROR;
     if (H5HF_get_heap_addr(fh, &fh_addr) < 0)
         FAIL_STACK_ERROR;
-    if (!H5F_addr_defined(fh_addr))
+    if (!H5_addr_defined(fh_addr))
         FAIL_STACK_ERROR;
     HDmemset(&state, 0, sizeof(fheap_heap_state_t));
 
@@ -5937,7 +5937,7 @@ test_man_fill_first_4th_recursive_indirect(hid_t fapl, H5HF_create_t *cparam, fh
         FAIL_STACK_ERROR;
     if (H5HF_get_heap_addr(fh, &fh_addr) < 0)
         FAIL_STACK_ERROR;
-    if (!H5F_addr_defined(fh_addr))
+    if (!H5_addr_defined(fh_addr))
         FAIL_STACK_ERROR;
     HDmemset(&state, 0, sizeof(fheap_heap_state_t));
 
@@ -6058,7 +6058,7 @@ test_man_fill_4th_recursive_indirect_row(hid_t fapl, H5HF_create_t *cparam, fhea
         FAIL_STACK_ERROR;
     if (H5HF_get_heap_addr(fh, &fh_addr) < 0)
         FAIL_STACK_ERROR;
-    if (!H5F_addr_defined(fh_addr))
+    if (!H5_addr_defined(fh_addr))
         FAIL_STACK_ERROR;
     HDmemset(&state, 0, sizeof(fheap_heap_state_t));
 
@@ -6170,7 +6170,7 @@ test_man_fill_all_4th_recursive_indirect(hid_t fapl, H5HF_create_t *cparam, fhea
         FAIL_STACK_ERROR;
     if (H5HF_get_heap_addr(fh, &fh_addr) < 0)
         FAIL_STACK_ERROR;
-    if (!H5F_addr_defined(fh_addr))
+    if (!H5_addr_defined(fh_addr))
         FAIL_STACK_ERROR;
     HDmemset(&state, 0, sizeof(fheap_heap_state_t));
 
@@ -6284,7 +6284,7 @@ test_man_start_5th_recursive_indirect(hid_t fapl, H5HF_create_t *cparam, fheap_t
         FAIL_STACK_ERROR;
     if (H5HF_get_heap_addr(fh, &fh_addr) < 0)
         FAIL_STACK_ERROR;
-    if (!H5F_addr_defined(fh_addr))
+    if (!H5_addr_defined(fh_addr))
         FAIL_STACK_ERROR;
     HDmemset(&state, 0, sizeof(fheap_heap_state_t));
 
@@ -6416,7 +6416,7 @@ test_man_remove_bogus(hid_t fapl, H5HF_create_t *cparam, fheap_test_param_t *tpa
         FAIL_STACK_ERROR;
     if (H5HF_get_heap_addr(fh, &fh_addr) < 0)
         FAIL_STACK_ERROR;
-    if (!H5F_addr_defined(fh_addr))
+    if (!H5_addr_defined(fh_addr))
         FAIL_STACK_ERROR;
     HDmemset(&state, 0, sizeof(fheap_heap_state_t));
     if (check_stats(fh, &state))
@@ -6575,7 +6575,7 @@ test_man_remove_one(hid_t fapl, H5HF_create_t *cparam, fheap_test_param_t *tpara
         FAIL_STACK_ERROR;
     if (H5HF_get_heap_addr(fh, &fh_addr) < 0)
         FAIL_STACK_ERROR;
-    if (!H5F_addr_defined(fh_addr))
+    if (!H5_addr_defined(fh_addr))
         FAIL_STACK_ERROR;
     HDmemset(&state, 0, sizeof(fheap_heap_state_t));
     if (check_stats(fh, &state))
@@ -6740,7 +6740,7 @@ test_man_remove_two(hid_t fapl, H5HF_create_t *cparam, fheap_test_param_t *tpara
         FAIL_STACK_ERROR;
     if (H5HF_get_heap_addr(fh, &fh_addr) < 0)
         FAIL_STACK_ERROR;
-    if (!H5F_addr_defined(fh_addr))
+    if (!H5_addr_defined(fh_addr))
         FAIL_STACK_ERROR;
     HDmemset(&state, 0, sizeof(fheap_heap_state_t));
     if (check_stats(fh, &state))
@@ -6934,7 +6934,7 @@ test_man_remove_one_larger(hid_t fapl, H5HF_create_t *cparam, fheap_test_param_t
         FAIL_STACK_ERROR;
     if (H5HF_get_heap_addr(fh, &fh_addr) < 0)
         FAIL_STACK_ERROR;
-    if (!H5F_addr_defined(fh_addr))
+    if (!H5_addr_defined(fh_addr))
         FAIL_STACK_ERROR;
     HDmemset(&state, 0, sizeof(fheap_heap_state_t));
     if (check_stats(fh, &state))
@@ -7104,7 +7104,7 @@ test_man_remove_two_larger(hid_t fapl, H5HF_create_t *cparam, fheap_test_param_t
         FAIL_STACK_ERROR;
     if (H5HF_get_heap_addr(fh, &fh_addr) < 0)
         FAIL_STACK_ERROR;
-    if (!H5F_addr_defined(fh_addr))
+    if (!H5_addr_defined(fh_addr))
         FAIL_STACK_ERROR;
     HDmemset(&state, 0, sizeof(fheap_heap_state_t));
     if (check_stats(fh, &state))
@@ -7345,7 +7345,7 @@ test_man_remove_three_larger(hid_t fapl, H5HF_create_t *cparam, fheap_test_param
         FAIL_STACK_ERROR;
     if (H5HF_get_heap_addr(fh, &fh_addr) < 0)
         FAIL_STACK_ERROR;
-    if (!H5F_addr_defined(fh_addr))
+    if (!H5_addr_defined(fh_addr))
         FAIL_STACK_ERROR;
     HDmemset(&state, 0, sizeof(fheap_heap_state_t));
     if (check_stats(fh, &state))
@@ -7650,7 +7650,7 @@ test_man_incr_insert_remove(hid_t fapl, H5HF_create_t *cparam, fheap_test_param_
         FAIL_STACK_ERROR;
     if (H5HF_get_heap_addr(fh, &fh_addr) < 0)
         FAIL_STACK_ERROR;
-    if (!H5F_addr_defined(fh_addr))
+    if (!H5_addr_defined(fh_addr))
         FAIL_STACK_ERROR;
     HDmemset(&state, 0, sizeof(fheap_heap_state_t));
     if (check_stats(fh, &state))

--- a/test/freespace.c
+++ b/test/freespace.c
@@ -223,10 +223,10 @@ TEST_sect_can_merge(const H5FS_section_info_t *_sect1, const H5FS_section_info_t
     HDassert(sect1);
     HDassert(sect2);
     HDassert(sect1->sect_info.type == sect2->sect_info.type); /* Checks "MERGE_SYM" flag */
-    HDassert(H5F_addr_lt(sect1->sect_info.addr, sect2->sect_info.addr));
+    HDassert(H5_addr_lt(sect1->sect_info.addr, sect2->sect_info.addr));
 
     /* Check if second section adjoins first section */
-    ret_value = H5F_addr_eq(sect1->sect_info.addr + sect1->sect_info.size, sect2->sect_info.addr);
+    ret_value = H5_addr_eq(sect1->sect_info.addr + sect1->sect_info.size, sect2->sect_info.addr);
 
     return ret_value;
 } /* TEST_sect_can_merge() */
@@ -250,7 +250,7 @@ TEST_sect_merging(H5FS_section_info_t **_sect1, H5FS_section_info_t *_sect2, voi
     HDassert((sect2->sect_info.type == TEST_FSPACE_SECT_TYPE) ||
              (sect2->sect_info.type == TEST_FSPACE_SECT_TYPE_NEW) ||
              (sect2->sect_info.type == TEST_FSPACE_SECT_TYPE_NONE));
-    HDassert(H5F_addr_eq((*sect1)->sect_info.addr + (*sect1)->sect_info.size, sect2->sect_info.addr));
+    HDassert(H5_addr_eq((*sect1)->sect_info.addr + (*sect1)->sect_info.size, sect2->sect_info.addr));
 
     /* Add second section's size to first section */
     (*sect1)->sect_info.size += sect2->sect_info.size;
@@ -488,7 +488,7 @@ test_fs_create(hid_t fapl)
                                     (hsize_t)FSPACE_THRHD_DEF, (hsize_t)FSPACE_ALIGN_DEF)))
         FAIL_STACK_ERROR;
 
-    if (!H5F_addr_defined(fs_addr))
+    if (!H5_addr_defined(fs_addr))
         TEST_ERROR;
     if (frsp->nclasses != nclasses)
         TEST_ERROR;
@@ -513,7 +513,7 @@ test_fs_create(hid_t fapl)
                                   (hsize_t)FSPACE_ALIGN_DEF)))
         FAIL_STACK_ERROR;
 
-    if (!H5F_addr_defined(fs_addr))
+    if (!H5_addr_defined(fs_addr))
         TEST_ERROR;
     if (frsp->nclasses != nclasses)
         TEST_ERROR;
@@ -630,7 +630,7 @@ test_fs_sect_add(hid_t fapl)
                                     (hsize_t)FSPACE_THRHD_DEF, (hsize_t)FSPACE_ALIGN_DEF)))
         FAIL_STACK_ERROR;
 
-    if (!H5F_addr_defined(fs_addr))
+    if (!H5_addr_defined(fs_addr))
         TEST_ERROR;
 
     if (NULL == (sect_node = (TEST_free_section_t *)HDmalloc(sizeof(TEST_free_section_t))))
@@ -695,7 +695,7 @@ test_fs_sect_add(hid_t fapl)
                                     (hsize_t)FSPACE_THRHD_DEF, (hsize_t)FSPACE_ALIGN_DEF)))
         FAIL_STACK_ERROR;
 
-    if (!H5F_addr_defined(fs_addr))
+    if (!H5_addr_defined(fs_addr))
         TEST_ERROR;
 
     /* Create free list section node */
@@ -770,7 +770,7 @@ test_fs_sect_add(hid_t fapl)
                                     (hsize_t)FSPACE_THRHD_DEF, (hsize_t)FSPACE_ALIGN_DEF)))
         FAIL_STACK_ERROR;
 
-    if (!H5F_addr_defined(fs_addr))
+    if (!H5_addr_defined(fs_addr))
         TEST_ERROR;
 
     if (NULL == (sect_node = (TEST_free_section_t *)HDmalloc(sizeof(TEST_free_section_t))))
@@ -840,7 +840,7 @@ test_fs_sect_add(hid_t fapl)
                                     (hsize_t)FSPACE_THRHD_DEF, (hsize_t)FSPACE_ALIGN_DEF)))
         FAIL_STACK_ERROR;
 
-    if (!H5F_addr_defined(fs_addr))
+    if (!H5_addr_defined(fs_addr))
         TEST_ERROR;
 
     if (NULL == (sect_node = (TEST_free_section_t *)HDmalloc(sizeof(TEST_free_section_t))))
@@ -963,7 +963,7 @@ test_fs_sect_find(hid_t fapl)
                                     (hsize_t)FSPACE_THRHD_DEF, (hsize_t)FSPACE_ALIGN_DEF)))
         FAIL_STACK_ERROR;
 
-    if (!H5F_addr_defined(fs_addr))
+    if (!H5_addr_defined(fs_addr))
         TEST_ERROR;
 
     HDmemset(&state, 0, sizeof(frspace_state_t));
@@ -994,7 +994,7 @@ test_fs_sect_find(hid_t fapl)
                                   (hsize_t)FSPACE_ALIGN_DEF)))
         FAIL_STACK_ERROR;
 
-    if (!H5F_addr_defined(fs_addr))
+    if (!H5_addr_defined(fs_addr))
         TEST_ERROR;
     if (frsp->nclasses != nclasses)
         TEST_ERROR;
@@ -1121,7 +1121,7 @@ test_fs_sect_find(hid_t fapl)
                                   (hsize_t)FSPACE_ALIGN_DEF)))
         FAIL_STACK_ERROR;
 
-    if (!H5F_addr_defined(fs_addr))
+    if (!H5_addr_defined(fs_addr))
         TEST_ERROR;
     if (frsp->nclasses != nclasses)
         TEST_ERROR;
@@ -1200,7 +1200,7 @@ test_fs_sect_find(hid_t fapl)
                                   (hsize_t)FSPACE_ALIGN_DEF)))
         FAIL_STACK_ERROR;
 
-    if (!H5F_addr_defined(fs_addr))
+    if (!H5_addr_defined(fs_addr))
         TEST_ERROR;
     if (frsp->nclasses != nclasses)
         TEST_ERROR;
@@ -1350,7 +1350,7 @@ test_fs_sect_merge(hid_t fapl)
                                     (hsize_t)FSPACE_THRHD_DEF, (hsize_t)FSPACE_ALIGN_DEF)))
         FAIL_STACK_ERROR;
 
-    if (!H5F_addr_defined(fs_addr))
+    if (!H5_addr_defined(fs_addr))
         TEST_ERROR;
 
     /*
@@ -1479,7 +1479,7 @@ test_fs_sect_merge(hid_t fapl)
                                     (hsize_t)FSPACE_THRHD_DEF, (hsize_t)FSPACE_ALIGN_DEF)))
         FAIL_STACK_ERROR;
 
-    if (!H5F_addr_defined(fs_addr))
+    if (!H5_addr_defined(fs_addr))
         TEST_ERROR;
 
     /*
@@ -1582,7 +1582,7 @@ test_fs_sect_merge(hid_t fapl)
                                     (hsize_t)FSPACE_THRHD_DEF, (hsize_t)FSPACE_ALIGN_DEF)))
         FAIL_STACK_ERROR;
 
-    if (!H5F_addr_defined(fs_addr))
+    if (!H5_addr_defined(fs_addr))
         TEST_ERROR;
 
     /*
@@ -1828,7 +1828,7 @@ test_fs_sect_shrink(hid_t fapl)
                                     (hsize_t)FSPACE_THRHD_DEF, (hsize_t)FSPACE_ALIGN_DEF)))
         FAIL_STACK_ERROR;
 
-    if (!H5F_addr_defined(fs_addr))
+    if (!H5_addr_defined(fs_addr))
         TEST_ERROR;
 
     /*
@@ -1930,7 +1930,7 @@ test_fs_sect_shrink(hid_t fapl)
                                     (hsize_t)FSPACE_THRHD_DEF, (hsize_t)FSPACE_ALIGN_DEF)))
         FAIL_STACK_ERROR;
 
-    if (!H5F_addr_defined(fs_addr))
+    if (!H5_addr_defined(fs_addr))
         TEST_ERROR;
 
     /*
@@ -2030,7 +2030,7 @@ test_fs_sect_shrink(hid_t fapl)
                                     (hsize_t)FSPACE_THRHD_DEF, (hsize_t)FSPACE_ALIGN_DEF)))
         FAIL_STACK_ERROR;
 
-    if (!H5F_addr_defined(fs_addr))
+    if (!H5_addr_defined(fs_addr))
         TEST_ERROR;
 
     /*
@@ -2172,7 +2172,7 @@ test_fs_sect_change_class(hid_t fapl)
                                     (hsize_t)FSPACE_THRHD_DEF, (hsize_t)FSPACE_ALIGN_DEF)))
         FAIL_STACK_ERROR;
 
-    if (!H5F_addr_defined(fs_addr))
+    if (!H5_addr_defined(fs_addr))
         TEST_ERROR;
 
     /*
@@ -2276,7 +2276,7 @@ test_fs_sect_change_class(hid_t fapl)
                                     (hsize_t)FSPACE_THRHD_DEF, (hsize_t)FSPACE_ALIGN_DEF)))
         FAIL_STACK_ERROR;
 
-    if (!H5F_addr_defined(fs_addr))
+    if (!H5_addr_defined(fs_addr))
         TEST_ERROR;
 
     /*
@@ -2460,7 +2460,7 @@ test_fs_sect_extend(hid_t fapl)
                                     (hsize_t)FSPACE_THRHD_DEF, (hsize_t)FSPACE_ALIGN_DEF)))
         FAIL_STACK_ERROR;
 
-    if (!H5F_addr_defined(fs_addr))
+    if (!H5_addr_defined(fs_addr))
         TEST_ERROR;
 
     /*
@@ -2537,7 +2537,7 @@ test_fs_sect_extend(hid_t fapl)
                                     (hsize_t)FSPACE_THRHD_DEF, (hsize_t)FSPACE_ALIGN_DEF)))
         FAIL_STACK_ERROR;
 
-    if (!H5F_addr_defined(fs_addr))
+    if (!H5_addr_defined(fs_addr))
         TEST_ERROR;
 
     /*
@@ -2611,7 +2611,7 @@ test_fs_sect_extend(hid_t fapl)
                                     (hsize_t)FSPACE_THRHD_DEF, (hsize_t)FSPACE_ALIGN_DEF)))
         FAIL_STACK_ERROR;
 
-    if (!H5F_addr_defined(fs_addr))
+    if (!H5_addr_defined(fs_addr))
         TEST_ERROR;
 
     /*
@@ -2686,7 +2686,7 @@ test_fs_sect_extend(hid_t fapl)
                                     (hsize_t)FSPACE_THRHD_DEF, (hsize_t)FSPACE_ALIGN_DEF)))
         FAIL_STACK_ERROR;
 
-    if (!H5F_addr_defined(fs_addr))
+    if (!H5_addr_defined(fs_addr))
         TEST_ERROR;
 
     /*
@@ -2819,7 +2819,7 @@ test_fs_sect_iterate(hid_t fapl)
                                     (hsize_t)FSPACE_THRHD_DEF, (hsize_t)FSPACE_ALIGN_DEF)))
         FAIL_STACK_ERROR;
 
-    if (!H5F_addr_defined(fs_addr))
+    if (!H5_addr_defined(fs_addr))
         TEST_ERROR;
 
     for (i = 1; i <= NUM_SECTIONS; i++) {

--- a/test/gheap.c
+++ b/test/gheap.c
@@ -109,7 +109,7 @@ test_1(hid_t fapl)
             HDputs("    Unable to insert object into global heap");
             nerrors++;
         }
-        else if (u && H5F_addr_gt(obj[u - 1].addr, obj[u].addr)) {
+        else if (u && H5_addr_gt(obj[u - 1].addr, obj[u].addr)) {
             H5_FAILED();
             HDputs("    Collection addresses are not monotonically increasing");
             nerrors++;

--- a/test/links.c
+++ b/test/links.c
@@ -2165,7 +2165,7 @@ cklinks_deprec(hid_t fapl, hbool_t new_format)
         HDprintf("    %d: Unexpected object type should have been a dataset\n", __LINE__);
         TEST_ERROR;
     } /* end if */
-    if (H5F_addr_ne(oinfo1.addr, oinfo2.addr)) {
+    if (H5_addr_ne(oinfo1.addr, oinfo2.addr)) {
         H5_FAILED();
         HDputs("    Hard link test failed. Link seems not to point to the ");
         HDputs("    expected file location.");
@@ -2210,7 +2210,7 @@ cklinks_deprec(hid_t fapl, hbool_t new_format)
         HDprintf("    %d: Unexpected object type should have been a dataset\n", __LINE__);
         TEST_ERROR;
     } /* end if */
-    if (H5F_addr_ne(oinfo1.addr, oinfo2.addr)) {
+    if (H5_addr_ne(oinfo1.addr, oinfo2.addr)) {
         H5_FAILED();
         HDputs("    Soft link test failed. Link seems not to point to the ");
         HDputs("    expected file location.");
@@ -5377,7 +5377,7 @@ link_info_by_idx_old_deprec(hid_t fapl)
                 if (H5Lget_info_by_idx1(group_id, ".", H5_INDEX_NAME, H5_ITER_INC, (hsize_t)u, &linfo,
                                         H5P_DEFAULT) < 0)
                     TEST_ERROR;
-                if (H5F_addr_ne(linfo.u.address, objno[u]))
+                if (H5_addr_ne(linfo.u.address, objno[u]))
                     TEST_ERROR;
             } /* end if */
             else {
@@ -5400,7 +5400,7 @@ link_info_by_idx_old_deprec(hid_t fapl)
                 if (H5Lget_info_by_idx1(group_id, ".", H5_INDEX_NAME, H5_ITER_NATIVE, (hsize_t)u, &linfo,
                                         H5P_DEFAULT) < 0)
                     TEST_ERROR;
-                if (H5F_addr_ne(linfo.u.address, objno[u]))
+                if (H5_addr_ne(linfo.u.address, objno[u]))
                     TEST_ERROR;
             } /* end if */
             else {
@@ -5429,7 +5429,7 @@ link_info_by_idx_old_deprec(hid_t fapl)
                 if (H5Lget_info_by_idx1(group_id, ".", H5_INDEX_NAME, H5_ITER_DEC, (hsize_t)u, &linfo,
                                         H5P_DEFAULT) < 0)
                     TEST_ERROR;
-                if (H5F_addr_ne(linfo.u.address, objno[dec_u]))
+                if (H5_addr_ne(linfo.u.address, objno[dec_u]))
                     TEST_ERROR;
             } /* end if */
             else {
@@ -6007,11 +6007,11 @@ delete_by_idx_old_deprec(hid_t fapl)
             if (H5Lget_info_by_idx1(group_id, ".", H5_INDEX_NAME, order, (hsize_t)0, &linfo, H5P_DEFAULT) < 0)
                 TEST_ERROR;
             if (order == H5_ITER_INC) {
-                if (H5F_addr_ne(linfo.u.address, objno[u + 1]))
+                if (H5_addr_ne(linfo.u.address, objno[u + 1]))
                     TEST_ERROR;
             } /* end if */
             else {
-                if (H5F_addr_ne(linfo.u.address, objno[dec_u]))
+                if (H5_addr_ne(linfo.u.address, objno[dec_u]))
                     TEST_ERROR;
             } /* end else */
 
@@ -6081,11 +6081,11 @@ delete_by_idx_old_deprec(hid_t fapl)
             if (H5Lget_info_by_idx1(group_id, ".", H5_INDEX_NAME, order, (hsize_t)u, &linfo, H5P_DEFAULT) < 0)
                 TEST_ERROR;
             if (order == H5_ITER_INC) {
-                if (H5F_addr_ne(linfo.u.address, objno[(u * 2) + 1]))
+                if (H5_addr_ne(linfo.u.address, objno[(u * 2) + 1]))
                     TEST_ERROR;
             } /* end if */
             else {
-                if (H5F_addr_ne(linfo.u.address, objno[dec_u]))
+                if (H5_addr_ne(linfo.u.address, objno[dec_u]))
                     TEST_ERROR;
             } /* end else */
 
@@ -6115,11 +6115,11 @@ delete_by_idx_old_deprec(hid_t fapl)
             if (H5Lget_info_by_idx1(group_id, ".", H5_INDEX_NAME, order, (hsize_t)0, &linfo, H5P_DEFAULT) < 0)
                 TEST_ERROR;
             if (order == H5_ITER_INC) {
-                if (H5F_addr_ne(linfo.u.address, objno[(u * 2) + 3]))
+                if (H5_addr_ne(linfo.u.address, objno[(u * 2) + 3]))
                     TEST_ERROR;
             } /* end if */
             else {
-                if (H5F_addr_ne(linfo.u.address, objno[dec_u]))
+                if (H5_addr_ne(linfo.u.address, objno[dec_u]))
                     TEST_ERROR;
             } /* end else */
 
@@ -6208,7 +6208,7 @@ link_iterate_deprec_cb(hid_t group_id, const char *link_name, const H5L_info1_t 
             return H5_ITER_ERROR;
         if (info->cset != my_info.cset)
             return H5_ITER_ERROR;
-        if (H5F_addr_ne(info->u.address, my_info.u.address))
+        if (H5_addr_ne(info->u.address, my_info.u.address))
             return H5_ITER_ERROR;
     } /* end if */
 
@@ -6707,7 +6707,7 @@ link_iterate_old_deprec_cb(hid_t group_id, const char *link_name, const H5L_info
             return H5_ITER_ERROR;
         if (info->cset != my_info.cset)
             return H5_ITER_ERROR;
-        if (H5F_addr_ne(info->u.address, my_info.u.address))
+        if (H5_addr_ne(info->u.address, my_info.u.address))
             return H5_ITER_ERROR;
     } /* end if */
 

--- a/test/mf.c
+++ b/test/mf.c
@@ -1000,7 +1000,7 @@ test_mf_tmp(const char *env_h5_drvr, hid_t fapl, hbool_t new_format)
             check_addr = H5MF_alloc_tmp(f, (hsize_t)(maxaddr / 3));
         }
         H5E_END_TRY;
-        if (H5F_addr_defined(check_addr))
+        if (H5_addr_defined(check_addr))
             TEST_ERROR;
 
         /* Test that pushing normal space allocation into temporary space fails */
@@ -1009,7 +1009,7 @@ test_mf_tmp(const char *env_h5_drvr, hid_t fapl, hbool_t new_format)
             check_addr = H5MF_alloc(f, H5FD_MEM_DRAW, (hsize_t)(maxaddr / 3));
         }
         H5E_END_TRY;
-        if (H5F_addr_defined(check_addr))
+        if (H5_addr_defined(check_addr))
             TEST_ERROR;
 
         /* Free the normal block (so the file doesn't blow up to a huge size) */
@@ -6402,7 +6402,7 @@ test_mf_fs_persist_split(void)
         FAIL_STACK_ERROR;
 
     /* Verify that the H5FD_MEM_SUPER free-space manager is there */
-    if (!H5F_addr_defined(f->shared->fs_addr[type]))
+    if (!H5_addr_defined(f->shared->fs_addr[type]))
         TEST_ERROR;
 
     /* Start up H5FD_MEM_SUPER free-space manager */
@@ -6426,7 +6426,7 @@ test_mf_fs_persist_split(void)
         TEST_ERROR;
 
     /* Verify that the free-space manager for H5FD_MEM_DRAW is there */
-    if (!H5F_addr_defined(f->shared->fs_addr[stype]))
+    if (!H5_addr_defined(f->shared->fs_addr[stype]))
         TEST_ERROR;
 
     /* Start up H5FD_MEM_DRAW free-space manager */
@@ -6486,11 +6486,11 @@ test_mf_fs_persist_split(void)
         FAIL_STACK_ERROR;
 
     /* Verify that the free-space manager for H5FD_MEM_DRAW is not there */
-    if (H5F_addr_defined(f->shared->fs_addr[stype]))
+    if (H5_addr_defined(f->shared->fs_addr[stype]))
         TEST_ERROR;
 
     /* Verify that the free-space manager for H5FD_MEM_SUPER is there */
-    if (!H5F_addr_defined(f->shared->fs_addr[type]))
+    if (!H5_addr_defined(f->shared->fs_addr[type]))
         TEST_ERROR;
 
     /* Start up H5FD_MEM_SUPER free-space manager */
@@ -6530,7 +6530,7 @@ test_mf_fs_persist_split(void)
         FAIL_STACK_ERROR;
 
     /* Verify that the H5FD_MEM_SUPER free-space manager is there */
-    if (!H5F_addr_defined(f->shared->fs_addr[type]))
+    if (!H5_addr_defined(f->shared->fs_addr[type]))
         TEST_ERROR;
 
     /* Start up H5FD_MEM_SUPER free-space manager */
@@ -6720,7 +6720,7 @@ test_mf_fs_persist_multi(void)
         FAIL_STACK_ERROR;
 
     /* Verify that the H5FD_MEM_SUPER free-space manager is there */
-    if (!H5F_addr_defined(f->shared->fs_addr[type]))
+    if (!H5_addr_defined(f->shared->fs_addr[type]))
         TEST_ERROR;
 
     /* Start up H5FD_MEM_SUPER free-space manager */
@@ -6744,7 +6744,7 @@ test_mf_fs_persist_multi(void)
         TEST_ERROR;
 
     /* Verify that the free-space manager for H5FD_MEM_DRAW is there */
-    if (!H5F_addr_defined(f->shared->fs_addr[stype]))
+    if (!H5_addr_defined(f->shared->fs_addr[stype]))
         TEST_ERROR;
 
     /* Start up H5FD_MEM_DRAW free-space manager */
@@ -6802,7 +6802,7 @@ test_mf_fs_persist_multi(void)
         FAIL_STACK_ERROR;
 
     /* Verify that the free-space manager for H5FD_MEM_SUPER is there */
-    if (!H5F_addr_defined(f->shared->fs_addr[type]))
+    if (!H5_addr_defined(f->shared->fs_addr[type]))
         TEST_ERROR;
 
     /* Start up H5FD_MEM_SUPER free-space manager */
@@ -6824,11 +6824,11 @@ test_mf_fs_persist_multi(void)
         TEST_ERROR;
 
     /* Verify that the free-space manager for H5FD_MEM_DRAW is not there */
-    if (H5F_addr_defined(f->shared->fs_addr[stype]))
+    if (H5_addr_defined(f->shared->fs_addr[stype]))
         TEST_ERROR;
 
     /* Verify that the free-space manager for H5FD_MEM_BTREE is there */
-    if (!H5F_addr_defined(f->shared->fs_addr[btype]))
+    if (!H5_addr_defined(f->shared->fs_addr[btype]))
         TEST_ERROR;
 
     /* Start up H5FD_MEM_BTREE free-space manager */
@@ -6868,7 +6868,7 @@ test_mf_fs_persist_multi(void)
         FAIL_STACK_ERROR;
 
     /* If H5FD_MEM_SUPER is there, should not find block #1 & #3 */
-    if (H5F_addr_defined(f->shared->fs_addr[type])) {
+    if (H5_addr_defined(f->shared->fs_addr[type])) {
         /* Start up H5FD_MEM_SUPER free-space manager */
         if (H5MF__open_fstype(f, (H5F_mem_page_t)type) < 0)
             FAIL_STACK_ERROR;
@@ -6887,7 +6887,7 @@ test_mf_fs_persist_multi(void)
     }
 
     /* Verify that the H5FD_MEM_GHEAP free-space manager is there */
-    if (!H5F_addr_defined(f->shared->fs_addr[gtype]))
+    if (!H5_addr_defined(f->shared->fs_addr[gtype]))
         TEST_ERROR;
 
     /* Start up H5FD_MEM_GHEAP free-space manager */
@@ -7022,7 +7022,7 @@ test_mf_fs_persist(const char *env_h5_drvr, hid_t fapl, hbool_t new_format)
         H5MF__alloc_to_fs_type(f->shared, type, TBLOCK_SIZE6, (H5F_mem_page_t *)&tt);
 
         /* Verify that H5FD_MEM_SUPER free-space manager is there */
-        if (!H5F_addr_defined(f->shared->fs_addr[tt]))
+        if (!H5_addr_defined(f->shared->fs_addr[tt]))
             TEST_ERROR;
 
         /* Start up H5FD_MEM_SUPER free-space manager */
@@ -7065,7 +7065,7 @@ test_mf_fs_persist(const char *env_h5_drvr, hid_t fapl, hbool_t new_format)
             FAIL_STACK_ERROR;
 
         /* Verify that H5FD_MEM_SUPER free-space manager is there */
-        if (!H5F_addr_defined(f->shared->fs_addr[tt]))
+        if (!H5_addr_defined(f->shared->fs_addr[tt]))
             TEST_ERROR;
 
         /* Retrieve block #5 from H5FD_MEM_SUPER free-space manager */
@@ -7200,7 +7200,7 @@ test_mf_fs_gone(const char *env_h5_drvr, hid_t fapl, hbool_t new_format)
         H5MF__alloc_to_fs_type(f->shared, type, TBLOCK_SIZE4, (H5F_mem_page_t *)&fs_type);
 
         /* Verify that the H5FD_MEM_SUPER free-space manager is not there */
-        if (H5F_addr_defined(f->shared->fs_addr[fs_type]))
+        if (H5_addr_defined(f->shared->fs_addr[fs_type]))
             TEST_ERROR;
 
         /* Put block #3 to H5FD_MEM_SUPER free-space manager */
@@ -7219,7 +7219,7 @@ test_mf_fs_gone(const char *env_h5_drvr, hid_t fapl, hbool_t new_format)
             FAIL_STACK_ERROR;
 
         /* Verify that H5FD_MEM_SUPER free-space manager is there */
-        if (!H5F_addr_defined(f->shared->fs_addr[fs_type]))
+        if (!H5_addr_defined(f->shared->fs_addr[fs_type]))
             TEST_ERROR;
 
         /* Start up H5FD_MEM_SUPER free-space manager */
@@ -7231,7 +7231,7 @@ test_mf_fs_gone(const char *env_h5_drvr, hid_t fapl, hbool_t new_format)
         if (H5FS_stat_info(f, f->shared->fs_man[fs_type], &fs_stat) < 0)
             FAIL_STACK_ERROR;
 
-        if (!H5F_addr_defined(fs_stat.addr))
+        if (!H5_addr_defined(fs_stat.addr))
             TEST_ERROR;
 
         if (fs_stat.tot_space < TBLOCK_SIZE3)
@@ -7259,7 +7259,7 @@ test_mf_fs_gone(const char *env_h5_drvr, hid_t fapl, hbool_t new_format)
         if (NULL == (f = (H5F_t *)H5VL_object(file)))
             FAIL_STACK_ERROR;
         /* Verify that the H5FD_MEM_SUPER free-space manager is not there */
-        if (H5F_addr_defined(f->shared->fs_addr[fs_type]))
+        if (H5_addr_defined(f->shared->fs_addr[fs_type]))
             TEST_ERROR;
 
         /* Closing */
@@ -7428,7 +7428,7 @@ test_mf_strat_thres_persist(const char *env_h5_drvr, hid_t fapl, hbool_t new_for
                     }
                 }
                 else {
-                    if (H5F_addr_defined(f->shared->fs_addr[tt]))
+                    if (H5_addr_defined(f->shared->fs_addr[tt]))
                         TEST_ERROR;
                 }
 
@@ -7618,7 +7618,7 @@ test_mf_strat_thres_gone(const char *env_h5_drvr, hid_t fapl, hbool_t new_format
 
             /* Free-space manager should be empty */
             if (!(fs_type == H5F_FSPACE_STRATEGY_PAGE && fs_persist))
-                if (H5F_addr_defined(f->shared->fs_addr[tt]))
+                if (H5_addr_defined(f->shared->fs_addr[tt]))
                     TEST_ERROR;
 
             /* Closing */
@@ -7936,13 +7936,13 @@ test_page_alloc_xfree(const char *env_h5_drvr, hid_t fapl)
 
                 /* Verify that the large generic manager is there */
                 H5MF__alloc_to_fs_type(f->shared, H5FD_MEM_DRAW, TBLOCK_SIZE5000, (H5F_mem_page_t *)&fs_type);
-                if (!H5F_addr_defined(f->shared->fs_addr[fs_type]))
+                if (!H5_addr_defined(f->shared->fs_addr[fs_type]))
                     TEST_ERROR;
 
                 /* Verify that the small metadata manager is there */
                 H5MF__alloc_to_fs_type(f->shared, H5FD_MEM_OHDR, f->shared->fs_page_size - 1,
                                        (H5F_mem_page_t *)&fs_type);
-                if (!H5F_addr_defined(f->shared->fs_addr[fs_type]))
+                if (!H5_addr_defined(f->shared->fs_addr[fs_type]))
                     TEST_ERROR;
 
                 /* Set up to use the small metadata manager */
@@ -7960,7 +7960,7 @@ test_page_alloc_xfree(const char *env_h5_drvr, hid_t fapl)
                     TEST_ERROR;
 
                 /* Verify that the small raw data manager is there */
-                if (!H5F_addr_defined(f->shared->fs_addr[H5F_MEM_PAGE_DRAW]))
+                if (!H5_addr_defined(f->shared->fs_addr[H5F_MEM_PAGE_DRAW]))
                     TEST_ERROR;
 
                 /* Set up to use the small raw data manager */
@@ -8566,7 +8566,7 @@ test_page_large(const char *env_h5_drvr, hid_t fapl)
         /* Allocate a large data block with gaddr3--should be on another page */
         /* Allocate 2 pages + 3808 bytes; 288 bytes in free-space manager */
         gaddr3 = H5MF_alloc(f, H5FD_MEM_DRAW, (hsize_t)TBLOCK_SIZE12000);
-        if (!H5F_addr_defined(gaddr3))
+        if (!H5_addr_defined(gaddr3))
             TEST_ERROR;
 
         /* Free the block with gaddr2 */


### PR DESCRIPTION
Several macros for handling haddr_t values exist in H5Fprivate.h and have H5F prefixes, even though they have nothing to do with a particular file (e.g., H5F_addr_lt()).

These macros have been moved to H5private.h and renamed to have an H5 prefix.

Affected macros:
    H5F_addr_overflow
    H5F_addr_defined
    H5F_addr_eq
    H5F_addr_ne
    H5F_addr_lt
    H5F_addr_le
    H5F_addr_gt
    H5F_addr_ge
    H5F_addr_cmp
    H5F_addr_overlap

H5F_addr_pow2 was unused and removed instead of converted.