### PR TITLE
Move encode/decode macros to a new header

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -17,6 +17,7 @@ set (H5_SOURCES
 set (H5_HDRS
     ${HDF5_SRC_DIR}/hdf5.h
     ${HDF5_SRC_DIR}/H5api_adpt.h
+    ${HDF5_SRC_DIR}/H5encode.h
     ${HDF5_SRC_DIR}/H5public.h
     #${HDF5_SRC_DIR}/H5version.h
     #${HDF5_SRC_DIR}/H5overflow.h

--- a/src/H5B2cache.c
+++ b/src/H5B2cache.c
@@ -13,10 +13,8 @@
 /*-------------------------------------------------------------------------
  *
  * Created:     H5B2cache.c
- *              Jan 31 2005
- *              Quincey Koziol
  *
- * Purpose:     Implement v2 B-tree metadata cache methods.
+ * Purpose:     Implement v2 B-tree metadata cache methods
  *
  *-------------------------------------------------------------------------
  */
@@ -30,10 +28,13 @@
 /***********/
 /* Headers */
 /***********/
-#include "H5private.h"   /* Generic Functions			*/
-#include "H5B2pkg.h"     /* v2 B-trees				*/
-#include "H5Eprivate.h"  /* Error handling		  	*/
-#include "H5WBprivate.h" /* Wrapped Buffers                      */
+#include "H5private.h"   /* Generic Functions                        */
+#include "H5ACprivate.h" /* Metadata Cache                           */
+#include "H5B2pkg.h"     /* B-Trees (Version 2)                      */
+#include "H5Eprivate.h"  /* Error Handling                           */
+#include "H5Fprivate.h"  /* Files                                    */
+#include "H5FLprivate.h" /* Free Lists                               */
+#include "H5MMprivate.h" /* Memory Management                        */
 
 /****************/
 /* Local Macros */

--- a/src/H5B2test.c
+++ b/src/H5B2test.c
@@ -11,9 +11,8 @@
  * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 
 /* Programmer:  Quincey Koziol
- *              Thursday, February  3, 2005
  *
- * Purpose:	v2 B-tree testing functions.
+ * Purpose:     v2 B-tree testing functions
  *
  */
 
@@ -27,9 +26,12 @@
 /***********/
 /* Headers */
 /***********/
-#include "H5private.h"  /* Generic Functions			*/
-#include "H5B2pkg.h"    /* v2 B-trees				*/
-#include "H5Eprivate.h" /* Error handling		  	*/
+#include "H5private.h"   /* Generic Functions                        */
+#include "H5ACprivate.h" /* Metadata Cache                           */
+#include "H5B2pkg.h"     /* B-Trees (Version 2)                      */
+#include "H5Eprivate.h"  /* Error Handling                           */
+#include "H5Fprivate.h"  /* Files                                    */
+#include "H5FLprivate.h" /* Free Lists                               */
 
 /****************/
 /* Local Macros */
@@ -251,7 +253,7 @@ H5B2__test_encode(uint8_t *raw, const void *nrecord, void *_ctx)
     /* Sanity check */
     HDassert(ctx);
 
-    H5F_ENCODE_LENGTH_LEN(raw, *(const hsize_t *)nrecord, ctx->sizeof_size);
+    H5_ENCODE_LENGTH_LEN(raw, *(const hsize_t *)nrecord, ctx->sizeof_size);
 
     FUNC_LEAVE_NOAPI(SUCCEED)
 } /* H5B2__test_encode() */
@@ -279,7 +281,7 @@ H5B2__test_decode(const uint8_t *raw, void *nrecord, void *_ctx)
     /* Sanity check */
     HDassert(ctx);
 
-    H5F_DECODE_LENGTH_LEN(raw, *(hsize_t *)nrecord, ctx->sizeof_size);
+    H5_DECODE_LENGTH_LEN(raw, *(hsize_t *)nrecord, ctx->sizeof_size);
 
     FUNC_LEAVE_NOAPI(SUCCEED)
 } /* H5B2__test_decode() */
@@ -379,8 +381,8 @@ H5B2__test2_encode(uint8_t *raw, const void *nrecord, void *_ctx)
     /* Sanity check */
     HDassert(ctx);
 
-    H5F_ENCODE_LENGTH_LEN(raw, ((const H5B2_test_rec_t *)nrecord)->key, ctx->sizeof_size);
-    H5F_ENCODE_LENGTH_LEN(raw, ((const H5B2_test_rec_t *)nrecord)->val, ctx->sizeof_size);
+    H5_ENCODE_LENGTH_LEN(raw, ((const H5B2_test_rec_t *)nrecord)->key, ctx->sizeof_size);
+    H5_ENCODE_LENGTH_LEN(raw, ((const H5B2_test_rec_t *)nrecord)->val, ctx->sizeof_size);
 
     FUNC_LEAVE_NOAPI(SUCCEED)
 } /* H5B2__test2_encode() */
@@ -408,8 +410,8 @@ H5B2__test2_decode(const uint8_t *raw, void *nrecord, void *_ctx)
     /* Sanity check */
     HDassert(ctx);
 
-    H5F_DECODE_LENGTH_LEN(raw, ((H5B2_test_rec_t *)nrecord)->key, ctx->sizeof_size);
-    H5F_DECODE_LENGTH_LEN(raw, ((H5B2_test_rec_t *)nrecord)->val, ctx->sizeof_size);
+    H5_DECODE_LENGTH_LEN(raw, ((H5B2_test_rec_t *)nrecord)->key, ctx->sizeof_size);
+    H5_DECODE_LENGTH_LEN(raw, ((H5B2_test_rec_t *)nrecord)->val, ctx->sizeof_size);
 
     FUNC_LEAVE_NOAPI(SUCCEED)
 } /* H5B2__test2_decode() */

--- a/src/H5Cepoch.c
+++ b/src/H5Cepoch.c
@@ -13,19 +13,26 @@
 /*-------------------------------------------------------------------------
  *
  * Created:     H5Cepoch.c
- *              June 5 2004
- *              Quincey Koziol
  *
- * Purpose:     Metadata cache epoch callbacks.
+ * Purpose:     Metadata cache epoch callbacks
  *
  *-------------------------------------------------------------------------
  */
 
+/****************/
+/* Module Setup */
+/****************/
+
+#include "H5Cmodule.h" /* This source code file is part of the H5C module */
+
 /***********/
 /* Headers */
 /***********/
-#include "H5private.h"   /* Generic Functions			*/
-#include "H5ACprivate.h" /* Metadata cache                       */
+#include "H5private.h"   /* Generic Functions                        */
+#include "H5ACprivate.h" /* Metadata Cache                           */
+#include "H5Cpkg.h"      /* Cache                                    */
+#include "H5Eprivate.h"  /* Error Handling                           */
+#include "H5Fprivate.h"  /* Files                                    */
 
 /****************/
 /* Local Macros */

--- a/src/H5Cprefetched.c
+++ b/src/H5Cprefetched.c
@@ -13,21 +13,28 @@
 /*-------------------------------------------------------------------------
  *
  * Created:     H5Cprefetched.c
- *              December 28 2016
- *              Quincey Koziol
  *
- * Purpose:     Metadata cache prefetched entry callbacks.
+ * Purpose:     Metadata cache prefetched entry callbacks
  *
  *-------------------------------------------------------------------------
  */
 
+/****************/
+/* Module Setup */
+/****************/
+
+#include "H5Cmodule.h" /* This source code file is part of the H5C module */
+
 /***********/
 /* Headers */
 /***********/
-#include "H5private.h"   /* Generic Functions			*/
-#include "H5ACprivate.h" /* Metadata cache                       */
-#include "H5FLprivate.h" /* Free Lists                           */
-#include "H5MMprivate.h" /* Memory management			*/
+#include "H5private.h"   /* Generic Functions                        */
+#include "H5ACprivate.h" /* Metadata Cache                           */
+#include "H5Cpkg.h"      /* Cache                                    */
+#include "H5Eprivate.h"  /* Error Handling                           */
+#include "H5Fprivate.h"  /* Files                                    */
+#include "H5FLprivate.h" /* Free Lists                               */
+#include "H5MMprivate.h" /* Memory Management                        */
 
 /****************/
 /* Local Macros */

--- a/src/H5Ctag.c
+++ b/src/H5Ctag.c
@@ -13,11 +13,9 @@
 /*-------------------------------------------------------------------------
  *
  * Created:     H5Ctag.c
- *              June 5 2016
- *              Quincey Koziol
  *
  * Purpose:     Functions in this file operate on tags for metadata
- *              cache entries.
+ *              cache entries
  *
  *-------------------------------------------------------------------------
  */
@@ -32,12 +30,14 @@
 /***********/
 /* Headers */
 /***********/
-#include "H5private.h"   /* Generic Functions			*/
-#include "H5ACprivate.h" /* Metadata cache                       */
-#include "H5Cpkg.h"      /* Cache				*/
-#include "H5CXprivate.h" /* API Contexts                         */
-#include "H5Eprivate.h"  /* Error handling		  	*/
-#include "H5Fpkg.h"      /* Files				*/
+#include "H5private.h"   /* Generic Functions                        */
+#include "H5ACprivate.h" /* Metadata Cache                           */
+#include "H5Cpkg.h"      /* Cache                                    */
+#include "H5CXprivate.h" /* API Contexts                             */
+#include "H5Eprivate.h"  /* Error Handling                           */
+#include "H5Fpkg.h"      /* Files                                    */
+#include "H5FLprivate.h" /* Free Lists                               */
+#include "H5MMprivate.h" /* Memory management                        */
 
 /****************/
 /* Local Macros */

--- a/src/H5D.c
+++ b/src/H5D.c
@@ -26,6 +26,7 @@
 #include "H5ESprivate.h" /* Event Sets                               */
 #include "H5FLprivate.h" /* Free lists                               */
 #include "H5Iprivate.h"  /* IDs                                      */
+#include "H5MMprivate.h" /* Memory management                        */
 #include "H5VLprivate.h" /* Virtual Object Layer                     */
 
 #include "H5VLnative_private.h" /* Native VOL connector                     */

--- a/src/H5Dint.c
+++ b/src/H5Dint.c
@@ -30,6 +30,7 @@
 #include "H5Lprivate.h"  /* Links                                    */
 #include "H5MMprivate.h" /* Memory management                        */
 #include "H5VLprivate.h" /* Virtual Object Layer                     */
+#include "H5VMprivate.h" /* Vector Functions                         */
 
 /****************/
 /* Local Macros */

--- a/src/H5Dselect.c
+++ b/src/H5Dselect.c
@@ -25,11 +25,12 @@
 /***********/
 /* Headers */
 /***********/
-#include "H5private.h"   /* Generic Functions			*/
-#include "H5CXprivate.h" /* API Contexts                         */
-#include "H5Dpkg.h"      /* Datasets				*/
-#include "H5Eprivate.h"  /* Error handling		  	*/
-#include "H5FLprivate.h" /* Free Lists                           */
+#include "H5private.h"   /* Generic Functions                        */
+#include "H5CXprivate.h" /* API Contexts                             */
+#include "H5Dpkg.h"      /* Datasets                                 */
+#include "H5Eprivate.h"  /* Error handling                           */
+#include "H5FLprivate.h" /* Free Lists                               */
+#include "H5VMprivate.h" /* Vector Functions                         */
 
 /****************/
 /* Local Macros */

--- a/src/H5FDint.c
+++ b/src/H5FDint.c
@@ -35,6 +35,7 @@
 #include "H5FDpkg.h"     /* File Drivers                             */
 #include "H5FLprivate.h" /* Free Lists                               */
 #include "H5Iprivate.h"  /* IDs                                      */
+#include "H5MMprivate.h" /* Memory management                        */
 #include "H5PLprivate.h" /* Plugins                                  */
 
 /****************/

--- a/src/H5FDonion_header.c
+++ b/src/H5FDonion_header.c
@@ -19,11 +19,12 @@
 /* This source code file is part of the H5FD driver module */
 #include "H5FDdrvr_module.h"
 
-#include "H5private.h"      /* Generic Functions           */
-#include "H5Eprivate.h"     /* Error handling              */
-#include "H5FDprivate.h"    /* File drivers                */
-#include "H5FDonion.h"      /* Onion file driver           */
-#include "H5FDonion_priv.h" /* Onion file driver internals */
+#include "H5private.h"      /* Generic Functions                        */
+#include "H5Eprivate.h"     /* Error handling                           */
+#include "H5FDprivate.h"    /* File drivers                             */
+#include "H5FDonion.h"      /* Onion file driver                        */
+#include "H5FDonion_priv.h" /* Onion file driver internals              */
+#include "H5MMprivate.h"    /* Memory management                        */
 
 /*-----------------------------------------------------------------------------
  * Function:    H5FD_ingest_header

--- a/src/H5FDonion_history.c
+++ b/src/H5FDonion_history.c
@@ -19,11 +19,12 @@
 /* This source code file is part of the H5FD driver module */
 #include "H5FDdrvr_module.h"
 
-#include "H5private.h"      /* Generic Functions           */
-#include "H5Eprivate.h"     /* Error handling              */
-#include "H5FDprivate.h"    /* File drivers                */
-#include "H5FDonion.h"      /* Onion file driver           */
-#include "H5FDonion_priv.h" /* Onion file driver internals */
+#include "H5private.h"      /* Generic Functions                        */
+#include "H5Eprivate.h"     /* Error handling                           */
+#include "H5FDprivate.h"    /* File drivers                             */
+#include "H5FDonion.h"      /* Onion file driver                        */
+#include "H5FDonion_priv.h" /* Onion file driver internals              */
+#include "H5MMprivate.h"    /* Memory management                        */
 
 /*-----------------------------------------------------------------------------
  * Function:    H5FD__onion_write_history

--- a/src/H5FDonion_index.c
+++ b/src/H5FDonion_index.c
@@ -19,11 +19,12 @@
 /* This source code file is part of the H5FD driver module */
 #include "H5FDdrvr_module.h"
 
-#include "H5private.h"      /* Generic Functions           */
-#include "H5Eprivate.h"     /* Error handling              */
-#include "H5FDprivate.h"    /* File drivers                */
-#include "H5FDonion.h"      /* Onion file driver           */
-#include "H5FDonion_priv.h" /* Onion file driver internals */
+#include "H5private.h"      /* Generic Functions                        */
+#include "H5Eprivate.h"     /* Error handling                           */
+#include "H5FDprivate.h"    /* File drivers                             */
+#include "H5FDonion.h"      /* Onion file driver                        */
+#include "H5FDonion_priv.h" /* Onion file driver internals              */
+#include "H5MMprivate.h"    /* Memory management                        */
 
 /* 2^n for uint64_t types -- H5_EXP2 unsafe past 32 bits */
 #define U64_EXP2(n) ((uint64_t)1 << (n))

--- a/src/H5Fprivate.h
+++ b/src/H5Fprivate.h
@@ -17,272 +17,24 @@
 #ifndef H5Fprivate_H
 #define H5Fprivate_H
 
-/* Early typedefs to avoid circular dependencies */
+/* This definition has to be early, before the other private headers,
+ * due to circular dependencies.
+ */
 typedef struct H5F_t H5F_t;
 
 /* Include package's public header */
 #include "H5Fpublic.h"
 
 /* Private headers needed by this file */
-#include "H5MMprivate.h" /* Memory management            */
 #include "H5FDprivate.h" /* File drivers                 */
 #ifdef H5_HAVE_PARALLEL
-#include "H5Pprivate.h"  /* Property lists               */
-#endif                   /* H5_HAVE_PARALLEL */
-#include "H5VMprivate.h" /* Vectors and arrays           */
+#include "H5Pprivate.h" /* Property lists               */
+#endif
 #include "H5VLprivate.h" /* Virtual Object Layer         */
 
 /**************************/
 /* Library Private Macros */
 /**************************/
-
-/*
- * Encode and decode macros for file meta-data.
- * Currently, all file meta-data is little-endian.
- */
-
-#define INT16ENCODE(p, i)                                                                                    \
-    {                                                                                                        \
-        *(p) = (uint8_t)((unsigned)(i)&0xff);                                                                \
-        (p)++;                                                                                               \
-        *(p) = (uint8_t)(((unsigned)(i) >> 8) & 0xff);                                                       \
-        (p)++;                                                                                               \
-    }
-
-#define UINT16ENCODE(p, i)                                                                                   \
-    {                                                                                                        \
-        *(p) = (uint8_t)((unsigned)(i)&0xff);                                                                \
-        (p)++;                                                                                               \
-        *(p) = (uint8_t)(((unsigned)(i) >> 8) & 0xff);                                                       \
-        (p)++;                                                                                               \
-    }
-
-#define INT32ENCODE(p, i)                                                                                    \
-    {                                                                                                        \
-        *(p) = (uint8_t)((uint32_t)(i)&0xff);                                                                \
-        (p)++;                                                                                               \
-        *(p) = (uint8_t)(((uint32_t)(i) >> 8) & 0xff);                                                       \
-        (p)++;                                                                                               \
-        *(p) = (uint8_t)(((uint32_t)(i) >> 16) & 0xff);                                                      \
-        (p)++;                                                                                               \
-        *(p) = (uint8_t)(((uint32_t)(i) >> 24) & 0xff);                                                      \
-        (p)++;                                                                                               \
-    }
-
-#define UINT32ENCODE(p, i)                                                                                   \
-    {                                                                                                        \
-        *(p) = (uint8_t)((i)&0xff);                                                                          \
-        (p)++;                                                                                               \
-        *(p) = (uint8_t)(((i) >> 8) & 0xff);                                                                 \
-        (p)++;                                                                                               \
-        *(p) = (uint8_t)(((i) >> 16) & 0xff);                                                                \
-        (p)++;                                                                                               \
-        *(p) = (uint8_t)(((i) >> 24) & 0xff);                                                                \
-        (p)++;                                                                                               \
-    }
-
-/* Encode an unsigned integer into a variable-sized buffer */
-/* (Assumes that the high bits of the integer are zero) */
-#define ENCODE_VAR(p, typ, n, l)                                                                             \
-    {                                                                                                        \
-        typ      _n = (n);                                                                                   \
-        size_t   _i;                                                                                         \
-        uint8_t *_p = (uint8_t *)(p);                                                                        \
-                                                                                                             \
-        for (_i = 0; _i < l; _i++, _n >>= 8)                                                                 \
-            *_p++ = (uint8_t)(_n & 0xff);                                                                    \
-        (p) = (uint8_t *)(p) + l;                                                                            \
-    }
-
-/* Encode a 32-bit unsigned integer into a variable-sized buffer */
-/* (Assumes that the high bits of the integer are zero) */
-#define UINT32ENCODE_VAR(p, n, l) ENCODE_VAR(p, uint32_t, n, l)
-
-#define INT64ENCODE(p, n)                                                                                    \
-    {                                                                                                        \
-        int64_t  _n = (n);                                                                                   \
-        size_t   _i;                                                                                         \
-        uint8_t *_p = (uint8_t *)(p);                                                                        \
-                                                                                                             \
-        for (_i = 0; _i < sizeof(int64_t); _i++, _n >>= 8)                                                   \
-            *_p++ = (uint8_t)(_n & 0xff);                                                                    \
-        for (/*void*/; _i < 8; _i++)                                                                         \
-            *_p++ = (uint8_t)((n) < 0 ? 0xff : 0);                                                           \
-        (p) = (uint8_t *)(p) + 8;                                                                            \
-    }
-
-#define UINT64ENCODE(p, n)                                                                                   \
-    {                                                                                                        \
-        uint64_t _n = (n);                                                                                   \
-        size_t   _i;                                                                                         \
-        uint8_t *_p = (uint8_t *)(p);                                                                        \
-                                                                                                             \
-        for (_i = 0; _i < sizeof(uint64_t); _i++, _n >>= 8)                                                  \
-            *_p++ = (uint8_t)(_n & 0xff);                                                                    \
-        for (/*void*/; _i < 8; _i++)                                                                         \
-            *_p++ = 0;                                                                                       \
-        (p) = (uint8_t *)(p) + 8;                                                                            \
-    }
-
-/* Encode a 64-bit unsigned integer into a variable-sized buffer */
-/* (Assumes that the high bits of the integer are zero) */
-#define UINT64ENCODE_VAR(p, n, l) ENCODE_VAR(p, uint64_t, n, l)
-
-/* Encode a 64-bit unsigned integer and its length into a variable-sized buffer */
-/* (Assumes that the high bits of the integer are zero) */
-#define UINT64ENCODE_VARLEN(p, n)                                                                            \
-    {                                                                                                        \
-        uint64_t __n = (uint64_t)(n);                                                                        \
-        unsigned _s  = H5VM_limit_enc_size(__n);                                                             \
-                                                                                                             \
-        *(p)++ = (uint8_t)_s;                                                                                \
-        UINT64ENCODE_VAR(p, __n, _s);                                                                        \
-    }
-
-#define H5_ENCODE_UNSIGNED(p, n)                                                                             \
-    {                                                                                                        \
-        HDcompile_assert(sizeof(unsigned) == sizeof(uint32_t));                                              \
-        UINT32ENCODE(p, n)                                                                                   \
-    }
-
-/* Assumes the endianness of uint64_t is the same as double */
-#define H5_ENCODE_DOUBLE(p, n)                                                                               \
-    {                                                                                                        \
-        uint64_t _n;                                                                                         \
-        size_t   _u;                                                                                         \
-        uint8_t *_p = (uint8_t *)(p);                                                                        \
-                                                                                                             \
-        HDcompile_assert(sizeof(double) == 8);                                                               \
-        HDcompile_assert(sizeof(double) == sizeof(uint64_t));                                                \
-        H5MM_memcpy(&_n, &n, sizeof(double));                                                                \
-        for (_u = 0; _u < sizeof(uint64_t); _u++, _n >>= 8)                                                  \
-            *_p++ = (uint8_t)(_n & 0xff);                                                                    \
-        (p) = (uint8_t *)(p) + 8;                                                                            \
-    }
-
-/* DECODE converts little endian bytes pointed by p to integer values and store
- * it in i.  For signed values, need to do sign-extension when converting
- * the last byte which carries the sign bit.
- * The macros does not require i be of a certain byte sizes.  It just requires
- * i be big enough to hold the intended value range.  E.g. INT16DECODE works
- * correctly even if i is actually a 64bit int like in a Cray.
- */
-
-#define INT16DECODE(p, i)                                                                                    \
-    {                                                                                                        \
-        (i) = (int16_t)((*(p)&0xff));                                                                        \
-        (p)++;                                                                                               \
-        (i) |= (int16_t)(((*(p)&0xff) << 8) | ((*(p)&0x80) ? ~0xffff : 0x0));                                \
-        (p)++;                                                                                               \
-    }
-
-#define UINT16DECODE(p, i)                                                                                   \
-    {                                                                                                        \
-        (i) = (uint16_t)(*(p)&0xff);                                                                         \
-        (p)++;                                                                                               \
-        (i) |= (uint16_t)((*(p)&0xff) << 8);                                                                 \
-        (p)++;                                                                                               \
-    }
-
-#define INT32DECODE(p, i)                                                                                    \
-    {                                                                                                        \
-        (i) = ((int32_t)(*(p)&0xff));                                                                        \
-        (p)++;                                                                                               \
-        (i) |= ((int32_t)(*(p)&0xff) << 8);                                                                  \
-        (p)++;                                                                                               \
-        (i) |= ((int32_t)(*(p)&0xff) << 16);                                                                 \
-        (p)++;                                                                                               \
-        (i) |= ((int32_t)(((*(p) & (unsigned)0xff) << 24) | ((*(p)&0x80) ? ~0xffffffffULL : 0x0ULL)));       \
-        (p)++;                                                                                               \
-    }
-
-#define UINT32DECODE(p, i)                                                                                   \
-    {                                                                                                        \
-        (i) = (uint32_t)(*(p)&0xff);                                                                         \
-        (p)++;                                                                                               \
-        (i) |= ((uint32_t)(*(p)&0xff) << 8);                                                                 \
-        (p)++;                                                                                               \
-        (i) |= ((uint32_t)(*(p)&0xff) << 16);                                                                \
-        (p)++;                                                                                               \
-        (i) |= ((uint32_t)(*(p)&0xff) << 24);                                                                \
-        (p)++;                                                                                               \
-    }
-
-/* Decode a variable-sized buffer */
-/* (Assumes that the high bits of the integer will be zero) */
-#define DECODE_VAR(p, n, l)                                                                                  \
-    {                                                                                                        \
-        size_t _i;                                                                                           \
-                                                                                                             \
-        n = 0;                                                                                               \
-        (p) += l;                                                                                            \
-        for (_i = 0; _i < l; _i++)                                                                           \
-            n = (n << 8) | *(--p);                                                                           \
-        (p) += l;                                                                                            \
-    }
-
-/* Decode a variable-sized buffer into a 32-bit unsigned integer */
-/* (Assumes that the high bits of the integer will be zero) */
-#define UINT32DECODE_VAR(p, n, l) DECODE_VAR(p, n, l)
-
-#define INT64DECODE(p, n)                                                                                    \
-    {                                                                                                        \
-        /* WE DON'T CHECK FOR OVERFLOW! */                                                                   \
-        size_t _i;                                                                                           \
-                                                                                                             \
-        n = 0;                                                                                               \
-        (p) += 8;                                                                                            \
-        for (_i = 0; _i < sizeof(int64_t); _i++)                                                             \
-            n = (n << 8) | *(--p);                                                                           \
-        (p) += 8;                                                                                            \
-    }
-
-#define UINT64DECODE(p, n)                                                                                   \
-    {                                                                                                        \
-        /* WE DON'T CHECK FOR OVERFLOW! */                                                                   \
-        size_t _i;                                                                                           \
-                                                                                                             \
-        n = 0;                                                                                               \
-        (p) += 8;                                                                                            \
-        for (_i = 0; _i < sizeof(uint64_t); _i++)                                                            \
-            n = (n << 8) | *(--p);                                                                           \
-        (p) += 8;                                                                                            \
-    }
-
-/* Decode a variable-sized buffer into a 64-bit unsigned integer */
-/* (Assumes that the high bits of the integer will be zero) */
-#define UINT64DECODE_VAR(p, n, l) DECODE_VAR(p, n, l)
-
-/* Decode a 64-bit unsigned integer and its length from a variable-sized buffer */
-/* (Assumes that the high bits of the integer will be zero) */
-#define UINT64DECODE_VARLEN(p, n)                                                                            \
-    {                                                                                                        \
-        unsigned _s = *(p)++;                                                                                \
-                                                                                                             \
-        UINT64DECODE_VAR(p, n, _s);                                                                          \
-    }
-
-#define H5_DECODE_UNSIGNED(p, n)                                                                             \
-    {                                                                                                        \
-        HDcompile_assert(sizeof(unsigned) == sizeof(uint32_t));                                              \
-        UINT32DECODE(p, n)                                                                                   \
-    }
-
-/* Assumes the endianness of uint64_t is the same as double */
-#define H5_DECODE_DOUBLE(p, n)                                                                               \
-    {                                                                                                        \
-        uint64_t _n;                                                                                         \
-        size_t   _u;                                                                                         \
-                                                                                                             \
-        HDcompile_assert(sizeof(double) == 8);                                                               \
-        HDcompile_assert(sizeof(double) == sizeof(uint64_t));                                                \
-        _n = 0;                                                                                              \
-        (p) += 8;                                                                                            \
-        for (_u = 0; _u < sizeof(uint64_t); _u++)                                                            \
-            _n = (_n << 8) | *(--p);                                                                         \
-        H5MM_memcpy(&(n), &_n, sizeof(double));                                                              \
-        (p) += 8;                                                                                            \
-    }
 
 /* clang-format off */
 /* Address-related macros */
@@ -445,39 +197,8 @@ typedef struct H5F_t H5F_t;
 #endif /* H5F_MODULE */
 
 /* Macros to encode/decode offset/length's for storing in the file */
-#define H5F_ENCODE_LENGTH_LEN(p, l, s)                                                                       \
-    switch (s) {                                                                                             \
-        case 4:                                                                                              \
-            UINT32ENCODE(p, l);                                                                              \
-            break;                                                                                           \
-        case 8:                                                                                              \
-            UINT64ENCODE(p, l);                                                                              \
-            break;                                                                                           \
-        case 2:                                                                                              \
-            UINT16ENCODE(p, l);                                                                              \
-            break;                                                                                           \
-        default:                                                                                             \
-            HDassert("bad sizeof size" && 0);                                                                \
-    }
-
-#define H5F_ENCODE_LENGTH(f, p, l) H5F_ENCODE_LENGTH_LEN(p, l, H5F_SIZEOF_SIZE(f))
-
-#define H5F_DECODE_LENGTH_LEN(p, l, s)                                                                       \
-    switch (s) {                                                                                             \
-        case 4:                                                                                              \
-            UINT32DECODE(p, l);                                                                              \
-            break;                                                                                           \
-        case 8:                                                                                              \
-            UINT64DECODE(p, l);                                                                              \
-            break;                                                                                           \
-        case 2:                                                                                              \
-            UINT16DECODE(p, l);                                                                              \
-            break;                                                                                           \
-        default:                                                                                             \
-            HDassert("bad sizeof size" && 0);                                                                \
-    }
-
-#define H5F_DECODE_LENGTH(f, p, l) DECODE_VAR(p, l, H5F_SIZEOF_SIZE(f))
+#define H5F_ENCODE_LENGTH(f, p, l) H5_ENCODE_LENGTH_LEN(p, l, H5F_SIZEOF_SIZE(f))
+#define H5F_DECODE_LENGTH(f, p, l) H5_DECODE_LENGTH_LEN(p, l, H5F_SIZEOF_SIZE(f))
 
 /*
  * Macros that check for overflows.  These are somewhat dangerous to fiddle

--- a/src/H5Gnode.c
+++ b/src/H5Gnode.c
@@ -169,7 +169,7 @@ H5G__node_decode_key(const H5B_shared_t *shared, const uint8_t *raw, void *_key)
     HDassert(raw);
     HDassert(key);
 
-    H5F_DECODE_LENGTH_LEN(raw, key->offset, shared->sizeof_len);
+    H5_DECODE_LENGTH_LEN(raw, key->offset, shared->sizeof_len);
 
     FUNC_LEAVE_NOAPI(SUCCEED)
 } /* end H5G__node_decode_key() */
@@ -197,7 +197,7 @@ H5G__node_encode_key(const H5B_shared_t *shared, uint8_t *raw, const void *_key)
     HDassert(raw);
     HDassert(key);
 
-    H5F_ENCODE_LENGTH_LEN(raw, key->offset, shared->sizeof_len);
+    H5_ENCODE_LENGTH_LEN(raw, key->offset, shared->sizeof_len);
 
     FUNC_LEAVE_NOAPI(SUCCEED)
 } /* end H5G__node_encode_key() */

--- a/src/H5HFbtree2.c
+++ b/src/H5HFbtree2.c
@@ -13,8 +13,6 @@
 /*-------------------------------------------------------------------------
  *
  * Created:		H5HFbtree2.c
- *			Aug  7 2006
- *			Quincey Koziol
  *
  * Purpose:		v2 B-tree callbacks for "huge" object tracker
  *
@@ -30,10 +28,13 @@
 /***********/
 /* Headers */
 /***********/
-#include "H5private.h"   /* Generic Functions			*/
-#include "H5Eprivate.h"  /* Error handling		  	*/
-#include "H5HFpkg.h"     /* Fractal heaps			*/
-#include "H5MFprivate.h" /* File memory management		*/
+#include "H5private.h"   /* Generic Functions                        */
+#include "H5B2private.h" /* B-Trees (Version 2)                      */
+#include "H5Eprivate.h"  /* Error Handling                           */
+#include "H5Fprivate.h"  /* Files                                    */
+#include "H5FLprivate.h" /* Free Lists                               */
+#include "H5HFpkg.h"     /* Fractal Heaps                            */
+#include "H5MFprivate.h" /* File Memory Management                   */
 
 /****************/
 /* Local Macros */
@@ -374,8 +375,8 @@ H5HF__huge_bt2_indir_encode(uint8_t *raw, const void *_nrecord, void *_ctx)
 
     /* Encode the record's fields */
     H5F_addr_encode_len(ctx->sizeof_addr, &raw, nrecord->addr);
-    H5F_ENCODE_LENGTH_LEN(raw, nrecord->len, ctx->sizeof_size);
-    H5F_ENCODE_LENGTH_LEN(raw, nrecord->id, ctx->sizeof_size);
+    H5_ENCODE_LENGTH_LEN(raw, nrecord->len, ctx->sizeof_size);
+    H5_ENCODE_LENGTH_LEN(raw, nrecord->id, ctx->sizeof_size);
 
     FUNC_LEAVE_NOAPI(SUCCEED)
 } /* H5HF__huge_bt2_indir_encode() */
@@ -406,8 +407,8 @@ H5HF__huge_bt2_indir_decode(const uint8_t *raw, void *_nrecord, void *_ctx)
 
     /* Decode the record's fields */
     H5F_addr_decode_len(ctx->sizeof_addr, &raw, &nrecord->addr);
-    H5F_DECODE_LENGTH_LEN(raw, nrecord->len, ctx->sizeof_size);
-    H5F_DECODE_LENGTH_LEN(raw, nrecord->id, ctx->sizeof_size);
+    H5_DECODE_LENGTH_LEN(raw, nrecord->len, ctx->sizeof_size);
+    H5_DECODE_LENGTH_LEN(raw, nrecord->id, ctx->sizeof_size);
 
     FUNC_LEAVE_NOAPI(SUCCEED)
 } /* H5HF__huge_bt2_indir_decode() */
@@ -572,10 +573,10 @@ H5HF__huge_bt2_filt_indir_encode(uint8_t *raw, const void *_nrecord, void *_ctx)
 
     /* Encode the record's fields */
     H5F_addr_encode_len(ctx->sizeof_addr, &raw, nrecord->addr);
-    H5F_ENCODE_LENGTH_LEN(raw, nrecord->len, ctx->sizeof_size);
+    H5_ENCODE_LENGTH_LEN(raw, nrecord->len, ctx->sizeof_size);
     UINT32ENCODE(raw, nrecord->filter_mask);
-    H5F_ENCODE_LENGTH_LEN(raw, nrecord->obj_size, ctx->sizeof_size);
-    H5F_ENCODE_LENGTH_LEN(raw, nrecord->id, ctx->sizeof_size);
+    H5_ENCODE_LENGTH_LEN(raw, nrecord->obj_size, ctx->sizeof_size);
+    H5_ENCODE_LENGTH_LEN(raw, nrecord->id, ctx->sizeof_size);
 
     FUNC_LEAVE_NOAPI(SUCCEED)
 } /* H5HF__huge_bt2_filt_indir_encode() */
@@ -606,10 +607,10 @@ H5HF__huge_bt2_filt_indir_decode(const uint8_t *raw, void *_nrecord, void *_ctx)
 
     /* Decode the record's fields */
     H5F_addr_decode_len(ctx->sizeof_addr, &raw, &nrecord->addr);
-    H5F_DECODE_LENGTH_LEN(raw, nrecord->len, ctx->sizeof_size);
+    H5_DECODE_LENGTH_LEN(raw, nrecord->len, ctx->sizeof_size);
     UINT32DECODE(raw, nrecord->filter_mask);
-    H5F_DECODE_LENGTH_LEN(raw, nrecord->obj_size, ctx->sizeof_size);
-    H5F_DECODE_LENGTH_LEN(raw, nrecord->id, ctx->sizeof_size);
+    H5_DECODE_LENGTH_LEN(raw, nrecord->obj_size, ctx->sizeof_size);
+    H5_DECODE_LENGTH_LEN(raw, nrecord->id, ctx->sizeof_size);
 
     FUNC_LEAVE_NOAPI(SUCCEED)
 } /* H5HF__huge_bt2_filt_indir_decode() */
@@ -761,7 +762,7 @@ H5HF__huge_bt2_dir_encode(uint8_t *raw, const void *_nrecord, void *_ctx)
 
     /* Encode the record's fields */
     H5F_addr_encode_len(ctx->sizeof_addr, &raw, nrecord->addr);
-    H5F_ENCODE_LENGTH_LEN(raw, nrecord->len, ctx->sizeof_size);
+    H5_ENCODE_LENGTH_LEN(raw, nrecord->len, ctx->sizeof_size);
 
     FUNC_LEAVE_NOAPI(SUCCEED)
 } /* H5HF__huge_bt2_dir_encode() */
@@ -792,7 +793,7 @@ H5HF__huge_bt2_dir_decode(const uint8_t *raw, void *_nrecord, void *_ctx)
 
     /* Decode the record's fields */
     H5F_addr_decode_len(ctx->sizeof_addr, &raw, &nrecord->addr);
-    H5F_DECODE_LENGTH_LEN(raw, nrecord->len, ctx->sizeof_size);
+    H5_DECODE_LENGTH_LEN(raw, nrecord->len, ctx->sizeof_size);
 
     FUNC_LEAVE_NOAPI(SUCCEED)
 } /* H5HF__huge_bt2_dir_decode() */
@@ -968,9 +969,9 @@ H5HF__huge_bt2_filt_dir_encode(uint8_t *raw, const void *_nrecord, void *_ctx)
 
     /* Encode the record's fields */
     H5F_addr_encode_len(ctx->sizeof_addr, &raw, nrecord->addr);
-    H5F_ENCODE_LENGTH_LEN(raw, nrecord->len, ctx->sizeof_size);
+    H5_ENCODE_LENGTH_LEN(raw, nrecord->len, ctx->sizeof_size);
     UINT32ENCODE(raw, nrecord->filter_mask);
-    H5F_ENCODE_LENGTH_LEN(raw, nrecord->obj_size, ctx->sizeof_size);
+    H5_ENCODE_LENGTH_LEN(raw, nrecord->obj_size, ctx->sizeof_size);
 
     FUNC_LEAVE_NOAPI(SUCCEED)
 } /* H5HF__huge_bt2_filt_dir_encode() */
@@ -1001,9 +1002,9 @@ H5HF__huge_bt2_filt_dir_decode(const uint8_t *raw, void *_nrecord, void *_ctx)
 
     /* Decode the record's fields */
     H5F_addr_decode_len(ctx->sizeof_addr, &raw, &nrecord->addr);
-    H5F_DECODE_LENGTH_LEN(raw, nrecord->len, ctx->sizeof_size);
+    H5_DECODE_LENGTH_LEN(raw, nrecord->len, ctx->sizeof_size);
     UINT32DECODE(raw, nrecord->filter_mask);
-    H5F_DECODE_LENGTH_LEN(raw, nrecord->obj_size, ctx->sizeof_size);
+    H5_DECODE_LENGTH_LEN(raw, nrecord->obj_size, ctx->sizeof_size);
 
     FUNC_LEAVE_NOAPI(SUCCEED)
 } /* H5HF__huge_bt2_filt_dir_decode() */

--- a/src/H5HFcache.c
+++ b/src/H5HFcache.c
@@ -13,10 +13,8 @@
 /*-------------------------------------------------------------------------
  *
  * Created:		H5HFcache.c
- *			Feb 24 2006
- *			Quincey Koziol
  *
- * Purpose:		Implement fractal heap metadata cache methods.
+ * Purpose:		Implement fractal heap metadata cache methods
  *
  *-------------------------------------------------------------------------
  */

--- a/src/H5HFhuge.c
+++ b/src/H5HFhuge.c
@@ -13,8 +13,6 @@
 /*-------------------------------------------------------------------------
  *
  * Created:		H5HFhuge.c
- *			Aug  7 2006
- *			Quincey Koziol
  *
  * Purpose:		Routines for "huge" objects in fractal heap
  *
@@ -801,34 +799,28 @@ done:
 } /* end H5HF__huge_op_real() */
 
 /*-------------------------------------------------------------------------
- * Function:	H5HF__huge_write
+ * Function:    H5HF__huge_write
  *
- * Purpose:	Write a 'huge' object to the heap
+ * Purpose:     Write a 'huge' object to the heap
  *
- * Note:	This implementation somewhat limited: it doesn't handle
- *		heaps with filters, which would require re-compressing the
- *		huge object and probably changing the address of the object
- *		on disk (and possibly the heap ID for "direct" huge IDs).
+ * Note:        This implementation somewhat limited: it doesn't handle
+ *              heaps with filters, which would require re-compressing the
+ *              huge object and probably changing the address of the object
+ *              on disk (and possibly the heap ID for "direct" huge IDs).
  *
- * Return:	SUCCEED/FAIL
- *
- * Programmer:	Quincey Koziol
- *		Feb 21 2007
+ * Return:      SUCCEED/FAIL
  *
  *-------------------------------------------------------------------------
  */
 herr_t
 H5HF__huge_write(H5HF_hdr_t *hdr, const uint8_t *id, const void *obj)
 {
-    haddr_t obj_addr;            /* Object's address in the file */
-    size_t  obj_size;            /* Object's size in the file */
-    herr_t  ret_value = SUCCEED; /* Return value */
+    haddr_t obj_addr  = HADDR_UNDEF; /* Object's address in the file */
+    size_t  obj_size  = 0;           /* Object's size in the file */
+    herr_t  ret_value = SUCCEED;
 
     FUNC_ENTER_PACKAGE
 
-    /*
-     * Check arguments.
-     */
     HDassert(hdr);
     HDassert(id);
     HDassert(obj);
@@ -845,7 +837,7 @@ H5HF__huge_write(H5HF_hdr_t *hdr, const uint8_t *id, const void *obj)
         /* Retrieve the object's address and length (common) */
         H5F_addr_decode(hdr->f, &id, &obj_addr);
         H5F_DECODE_LENGTH(hdr->f, id, obj_size);
-    } /* end if */
+    }
     else {
         H5HF_huge_bt2_indir_rec_t found_rec;     /* Record found from tracking object */
         H5HF_huge_bt2_indir_rec_t search_rec;    /* Record for searching for object */
@@ -860,7 +852,7 @@ H5HF__huge_write(H5HF_hdr_t *hdr, const uint8_t *id, const void *obj)
             if (NULL == (hdr->huge_bt2 = H5B2_open(hdr->f, hdr->huge_bt2_addr, hdr->f)))
                 HGOTO_ERROR(H5E_HEAP, H5E_CANTOPENOBJ, FAIL,
                             "unable to open v2 B-tree for tracking 'huge' heap objects")
-        } /* end if */
+        }
 
         /* Get ID for looking up 'huge' object in v2 B-tree */
         UINT64DECODE_VAR(id, search_rec.id, hdr->huge_id_size)
@@ -874,7 +866,7 @@ H5HF__huge_write(H5HF_hdr_t *hdr, const uint8_t *id, const void *obj)
         /* Retrieve the object's address & length */
         obj_addr = found_rec.addr;
         H5_CHECKED_ASSIGN(obj_size, size_t, found_rec.len, hsize_t);
-    } /* end else */
+    }
 
     /* Write the object's data to the file */
     /* (writes directly from application's buffer) */

--- a/src/H5HGcache.c
+++ b/src/H5HGcache.c
@@ -190,6 +190,7 @@ H5HG__cache_heap_get_final_load_size(const void *image, size_t image_len, void *
     HDassert(image_len == H5HG_MINSIZE);
 
     /* Deserialize the heap's header */
+    heap.size = 0;
     if (H5HG__hdr_deserialize(&heap, (const uint8_t *)image, image_len, (const H5F_t *)udata) < 0)
         HGOTO_ERROR(H5E_HEAP, H5E_CANTDECODE, FAIL, "can't decode global heap prefix")
 

--- a/src/H5HL.c
+++ b/src/H5HL.c
@@ -13,8 +13,6 @@
 /*-------------------------------------------------------------------------
  *
  * Created:         H5HL.c
- *                  Jul 16 1997
- *                  Robb Matzke
  *
  * Purpose:         Heap functions for the local heaps used by symbol
  *                  tables to store names (among other things).
@@ -31,11 +29,14 @@
 /***********/
 /* Headers */
 /***********/
-#include "H5private.h"   /* Generic Functions        */
-#include "H5Eprivate.h"  /* Error handling           */
-#include "H5Fprivate.h"  /* File access              */
-#include "H5HLpkg.h"     /* Local Heaps              */
-#include "H5MFprivate.h" /* File memory management   */
+#include "H5private.h"   /* Generic Functions                        */
+#include "H5ACprivate.h" /* Metadata Cache                           */
+#include "H5Eprivate.h"  /* Error Handling                           */
+#include "H5Fprivate.h"  /* Files                                    */
+#include "H5FLprivate.h" /* Free Lists                               */
+#include "H5HLpkg.h"     /* Local Heaps                              */
+#include "H5MFprivate.h" /* File Memory Management                   */
+#include "H5MMprivate.h" /* Memory Management                        */
 
 /****************/
 /* Local Macros */

--- a/src/H5Ocopy_ref.c
+++ b/src/H5Ocopy_ref.c
@@ -14,7 +14,7 @@
  *
  * Created:     H5Ocopy_ref.c
  *
- * Purpose:     Object with references copying routines.
+ * Purpose:     Object with references copying routines
  *
  *-------------------------------------------------------------------------
  */
@@ -30,6 +30,7 @@
 /* Headers */
 /***********/
 #include "H5private.h"   /* Generic Functions                        */
+#include "H5Eprivate.h"  /* Error handling                           */
 #include "H5Fprivate.h"  /* File                                     */
 #include "H5Iprivate.h"  /* IDs                                      */
 #include "H5Lprivate.h"  /* Links                                    */

--- a/src/H5Odeprec.c
+++ b/src/H5Odeprec.c
@@ -33,6 +33,7 @@
 #include "H5CXprivate.h" /* API Contexts                             */
 #include "H5Eprivate.h"  /* Error handling                           */
 #include "H5Iprivate.h"  /* IDs                                      */
+#include "H5MMprivate.h" /* Memory management                        */
 #include "H5Opkg.h"      /* Object headers                           */
 
 #include "H5VLnative_private.h" /* Native VOL connector                     */

--- a/src/H5Ofsinfo.c
+++ b/src/H5Ofsinfo.c
@@ -112,9 +112,9 @@ H5O__fsinfo_decode(H5F_t *f, H5O_t H5_ATTR_UNUSED *open_oh, unsigned H5_ATTR_UNU
     vers = *p++;
 
     if (vers == H5O_FSINFO_VERSION_0) {
-        H5F_file_space_type_t strategy;  /* Strategy */
-        hsize_t               threshold; /* Threshold */
-        H5FD_mem_t            type;      /* Memory type for iteration */
+        H5F_file_space_type_t strategy;      /* Strategy */
+        hsize_t               threshold = 0; /* Threshold */
+        H5FD_mem_t            type;          /* Memory type for iteration */
 
         fsinfo->persist             = H5F_FREE_SPACE_PERSIST_DEF;
         fsinfo->threshold           = H5F_FREE_SPACE_THRESHOLD_DEF;

--- a/src/H5Olayout.c
+++ b/src/H5Olayout.c
@@ -551,7 +551,7 @@ H5O__layout_decode(H5F_t *f, H5O_t H5_ATTR_UNUSED *open_oh, unsigned H5_ATTR_UNU
                     uint8_t        heap_vers;
                     size_t         block_size = 0;
                     size_t         tmp_size;
-                    hsize_t        tmp_hsize;
+                    hsize_t        tmp_hsize = 0;
                     uint32_t       stored_chksum;
                     uint32_t       computed_chksum;
 

--- a/src/H5Pdapl.c
+++ b/src/H5Pdapl.c
@@ -30,13 +30,14 @@
 /***********/
 /* Headers */
 /***********/
-#include "H5private.h"   /* Generic Functions */
-#include "H5Dprivate.h"  /* Datasets */
-#include "H5Eprivate.h"  /* Error handling */
-#include "H5Fprivate.h"  /* Files */
-#include "H5Iprivate.h"  /* IDs */
-#include "H5MMprivate.h" /* Memory management */
-#include "H5Ppkg.h"      /* Property lists */
+#include "H5private.h"   /* Generic Functions                        */
+#include "H5Dprivate.h"  /* Datasets                                 */
+#include "H5Eprivate.h"  /* Error handling                           */
+#include "H5Fprivate.h"  /* Files                                    */
+#include "H5Iprivate.h"  /* IDs                                      */
+#include "H5MMprivate.h" /* Memory management                        */
+#include "H5Ppkg.h"      /* Property lists                           */
+#include "H5VMprivate.h" /* Vector Functions                         */
 
 /****************/
 /* Local Macros */

--- a/src/H5Pdxpl.c
+++ b/src/H5Pdxpl.c
@@ -30,14 +30,15 @@
 /***********/
 /* Headers */
 /***********/
-#include "H5private.h"   /* Generic Functions			*/
-#include "H5ACprivate.h" /* Cache                                */
-#include "H5Dprivate.h"  /* Datasets				*/
-#include "H5Eprivate.h"  /* Error handling		  	*/
-#include "H5FDprivate.h" /* File drivers				*/
-#include "H5Iprivate.h"  /* IDs			  		*/
-#include "H5MMprivate.h" /* Memory management			*/
-#include "H5Ppkg.h"      /* Property lists		  	*/
+#include "H5private.h"   /* Generic Functions                        */
+#include "H5ACprivate.h" /* Cache                                    */
+#include "H5Dprivate.h"  /* Datasets                                 */
+#include "H5Eprivate.h"  /* Error handling                           */
+#include "H5FDprivate.h" /* File drivers                             */
+#include "H5Iprivate.h"  /* IDs                                      */
+#include "H5MMprivate.h" /* Memory management                        */
+#include "H5Ppkg.h"      /* Property lists                           */
+#include "H5VMprivate.h" /* Vector Functions                         */
 
 /****************/
 /* Local Macros */

--- a/src/H5Plapl.c
+++ b/src/H5Plapl.c
@@ -30,12 +30,13 @@
 /***********/
 /* Headers */
 /***********/
-#include "H5private.h"   /* Generic Functions			*/
-#include "H5Eprivate.h"  /* Error handling		  	*/
-#include "H5Iprivate.h"  /* IDs			  		*/
-#include "H5Lprivate.h"  /* Links		  		*/
-#include "H5MMprivate.h" /* Memory management			*/
-#include "H5Ppkg.h"      /* Property lists		  	*/
+#include "H5private.h"   /* Generic Functions                        */
+#include "H5Eprivate.h"  /* Error handling                           */
+#include "H5Iprivate.h"  /* IDs                                      */
+#include "H5Lprivate.h"  /* Links                                    */
+#include "H5MMprivate.h" /* Memory management                        */
+#include "H5Ppkg.h"      /* Property lists                           */
+#include "H5VMprivate.h" /* Vector Functions                         */
 
 /****************/
 /* Local Macros */

--- a/src/H5Pocpl.c
+++ b/src/H5Pocpl.c
@@ -31,14 +31,15 @@
 /***********/
 /* Headers */
 /***********/
-#include "H5private.h"   /* Generic Functions */
-#include "H5Eprivate.h"  /* Error handling    */
-#include "H5Iprivate.h"  /* IDs               */
-#include "H5MMprivate.h" /* Memory management */
-#include "H5Opkg.h"      /* Object headers    */
-#include "H5Ppkg.h"      /* Property lists    */
-#include "H5PLprivate.h" /* Dynamic plugin    */
-#include "H5Zprivate.h"  /* Filter pipeline   */
+#include "H5private.h"   /* Generic Functions                        */
+#include "H5Eprivate.h"  /* Error handling                           */
+#include "H5Iprivate.h"  /* IDs                                      */
+#include "H5MMprivate.h" /* Memory management                        */
+#include "H5Opkg.h"      /* Object headers                           */
+#include "H5Ppkg.h"      /* Property lists                           */
+#include "H5PLprivate.h" /* Dynamic plugin                           */
+#include "H5VMprivate.h" /* Vector Functions                         */
+#include "H5Zprivate.h"  /* Filter pipeline                          */
 
 /****************/
 /* Local Macros */

--- a/src/H5Rdeprec.c
+++ b/src/H5Rdeprec.c
@@ -41,6 +41,7 @@
 #include "H5Eprivate.h"  /* Error handling                           */
 #include "H5Gprivate.h"  /* Groups                                   */
 #include "H5Iprivate.h"  /* IDs                                      */
+#include "H5MMprivate.h" /* Memory management                        */
 #include "H5Oprivate.h"  /* Object headers                           */
 #include "H5Rpkg.h"      /* References                               */
 #include "H5Sprivate.h"  /* Dataspaces                               */

--- a/src/H5Tref.c
+++ b/src/H5Tref.c
@@ -19,13 +19,14 @@
 #define H5F_FRIEND     /*suppress error about including H5Fpkg   */
 #define H5R_FRIEND     /*suppress error about including H5Rpkg   */
 
-#include "H5private.h"   /* Generic Functions    */
-#include "H5CXprivate.h" /* API Contexts         */
-#include "H5Eprivate.h"  /* Error handling       */
-#include "H5Iprivate.h"  /* IDs                  */
-#include "H5Fpkg.h"      /* File                 */
-#include "H5Rpkg.h"      /* References           */
-#include "H5Tpkg.h"      /* Datatypes            */
+#include "H5private.h"   /* Generic Functions                        */
+#include "H5CXprivate.h" /* API Contexts                             */
+#include "H5Eprivate.h"  /* Error handling                           */
+#include "H5Iprivate.h"  /* IDs                                      */
+#include "H5Fpkg.h"      /* File                                     */
+#include "H5MMprivate.h" /* Memory management                        */
+#include "H5Rpkg.h"      /* References                               */
+#include "H5Tpkg.h"      /* Datatypes                                */
 
 #include "H5VLnative_private.h" /* Native VOL connector                     */
 

--- a/src/H5VLnative_dataset.c
+++ b/src/H5VLnative_dataset.c
@@ -31,6 +31,7 @@
 #include "H5Fprivate.h"  /* Files                                    */
 #include "H5Gprivate.h"  /* Groups                                   */
 #include "H5Iprivate.h"  /* IDs                                      */
+#include "H5MMprivate.h" /* Memory management                        */
 #include "H5Pprivate.h"  /* Property lists                           */
 #include "H5Sprivate.h"  /* Dataspaces                               */
 #include "H5VLprivate.h" /* Virtual Object Layer                     */

--- a/src/H5encode.h
+++ b/src/H5encode.h
@@ -1,0 +1,283 @@
+/* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * *
+ * Copyright by The HDF Group.                                               *
+ * All rights reserved.                                                      *
+ *                                                                           *
+ * This file is part of HDF5.  The full HDF5 copyright notice, including     *
+ * terms governing use, modification, and redistribution, is contained in    *
+ * the COPYING file, which can be found at the root of the source code       *
+ * distribution tree, or in https://www.hdfgroup.org/licenses.               *
+ * If you do not have access to either file, you may request a copy from     *
+ * help@hdfgroup.org.                                                        *
+ * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
+
+/*
+ * File-independent encode/decode routines
+ */
+
+#ifndef H5encode_H
+#define H5encode_H
+
+/**************************/
+/* Library Private Macros */
+/**************************/
+
+/*
+ * Encode and decode macros for file meta-data.
+ * Currently, all file meta-data is little-endian.
+ */
+
+#define INT16ENCODE(p, i)                                                                                    \
+    {                                                                                                        \
+        *(p) = (uint8_t)((unsigned)(i)&0xff);                                                                \
+        (p)++;                                                                                               \
+        *(p) = (uint8_t)(((unsigned)(i) >> 8) & 0xff);                                                       \
+        (p)++;                                                                                               \
+    }
+
+#define UINT16ENCODE(p, i)                                                                                   \
+    {                                                                                                        \
+        *(p) = (uint8_t)((unsigned)(i)&0xff);                                                                \
+        (p)++;                                                                                               \
+        *(p) = (uint8_t)(((unsigned)(i) >> 8) & 0xff);                                                       \
+        (p)++;                                                                                               \
+    }
+
+#define INT32ENCODE(p, i)                                                                                    \
+    {                                                                                                        \
+        *(p) = (uint8_t)((uint32_t)(i)&0xff);                                                                \
+        (p)++;                                                                                               \
+        *(p) = (uint8_t)(((uint32_t)(i) >> 8) & 0xff);                                                       \
+        (p)++;                                                                                               \
+        *(p) = (uint8_t)(((uint32_t)(i) >> 16) & 0xff);                                                      \
+        (p)++;                                                                                               \
+        *(p) = (uint8_t)(((uint32_t)(i) >> 24) & 0xff);                                                      \
+        (p)++;                                                                                               \
+    }
+
+#define UINT32ENCODE(p, i)                                                                                   \
+    {                                                                                                        \
+        *(p) = (uint8_t)((i)&0xff);                                                                          \
+        (p)++;                                                                                               \
+        *(p) = (uint8_t)(((i) >> 8) & 0xff);                                                                 \
+        (p)++;                                                                                               \
+        *(p) = (uint8_t)(((i) >> 16) & 0xff);                                                                \
+        (p)++;                                                                                               \
+        *(p) = (uint8_t)(((i) >> 24) & 0xff);                                                                \
+        (p)++;                                                                                               \
+    }
+
+/* Encode an unsigned integer into a variable-sized buffer */
+/* (Assumes that the high bits of the integer are zero) */
+#define ENCODE_VAR(p, typ, n, l)                                                                             \
+    {                                                                                                        \
+        typ      _n = (n);                                                                                   \
+        size_t   _i;                                                                                         \
+        uint8_t *_p = (uint8_t *)(p);                                                                        \
+                                                                                                             \
+        for (_i = 0; _i < l; _i++, _n >>= 8)                                                                 \
+            *_p++ = (uint8_t)(_n & 0xff);                                                                    \
+        (p) = (uint8_t *)(p) + l;                                                                            \
+    }
+
+/* Encode a 32-bit unsigned integer into a variable-sized buffer */
+/* (Assumes that the high bits of the integer are zero) */
+#define UINT32ENCODE_VAR(p, n, l) ENCODE_VAR(p, uint32_t, n, l)
+
+#define INT64ENCODE(p, n)                                                                                    \
+    {                                                                                                        \
+        int64_t  _n = (n);                                                                                   \
+        size_t   _i;                                                                                         \
+        uint8_t *_p = (uint8_t *)(p);                                                                        \
+                                                                                                             \
+        for (_i = 0; _i < sizeof(int64_t); _i++, _n >>= 8)                                                   \
+            *_p++ = (uint8_t)(_n & 0xff);                                                                    \
+        for (/*void*/; _i < 8; _i++)                                                                         \
+            *_p++ = (uint8_t)((n) < 0 ? 0xff : 0);                                                           \
+        (p) = (uint8_t *)(p) + 8;                                                                            \
+    }
+
+#define UINT64ENCODE(p, n)                                                                                   \
+    {                                                                                                        \
+        uint64_t _n = (n);                                                                                   \
+        size_t   _i;                                                                                         \
+        uint8_t *_p = (uint8_t *)(p);                                                                        \
+                                                                                                             \
+        for (_i = 0; _i < sizeof(uint64_t); _i++, _n >>= 8)                                                  \
+            *_p++ = (uint8_t)(_n & 0xff);                                                                    \
+        for (/*void*/; _i < 8; _i++)                                                                         \
+            *_p++ = 0;                                                                                       \
+        (p) = (uint8_t *)(p) + 8;                                                                            \
+    }
+
+/* Encode a 64-bit unsigned integer into a variable-sized buffer */
+/* (Assumes that the high bits of the integer are zero) */
+#define UINT64ENCODE_VAR(p, n, l) ENCODE_VAR(p, uint64_t, n, l)
+
+#define H5_ENCODE_UNSIGNED(p, n)                                                                             \
+    {                                                                                                        \
+        HDcompile_assert(sizeof(unsigned) == sizeof(uint32_t));                                              \
+        UINT32ENCODE(p, n)                                                                                   \
+    }
+
+/* Assumes the endianness of uint64_t is the same as double */
+#define H5_ENCODE_DOUBLE(p, n)                                                                               \
+    {                                                                                                        \
+        uint64_t _n;                                                                                         \
+        size_t   _u;                                                                                         \
+        uint8_t *_p = (uint8_t *)(p);                                                                        \
+                                                                                                             \
+        HDcompile_assert(sizeof(double) == 8);                                                               \
+        HDcompile_assert(sizeof(double) == sizeof(uint64_t));                                                \
+        HDmemcpy(&_n, &n, sizeof(double));                                                                   \
+        for (_u = 0; _u < sizeof(uint64_t); _u++, _n >>= 8)                                                  \
+            *_p++ = (uint8_t)(_n & 0xff);                                                                    \
+        (p) = (uint8_t *)(p) + 8;                                                                            \
+    }
+
+/* DECODE converts little endian bytes pointed by p to integer values and store
+ * it in i.  For signed values, need to do sign-extension when converting
+ * the last byte which carries the sign bit.
+ * The macros does not require i be of a certain byte sizes.  It just requires
+ * i be big enough to hold the intended value range.  E.g. INT16DECODE works
+ * correctly even if i is actually a 64bit int like in a Cray.
+ */
+
+#define INT16DECODE(p, i)                                                                                    \
+    {                                                                                                        \
+        (i) = (int16_t)((*(p)&0xff));                                                                        \
+        (p)++;                                                                                               \
+        (i) |= (int16_t)(((*(p)&0xff) << 8) | ((*(p)&0x80) ? ~0xffff : 0x0));                                \
+        (p)++;                                                                                               \
+    }
+
+#define UINT16DECODE(p, i)                                                                                   \
+    {                                                                                                        \
+        (i) = (uint16_t)(*(p)&0xff);                                                                         \
+        (p)++;                                                                                               \
+        (i) |= (uint16_t)((*(p)&0xff) << 8);                                                                 \
+        (p)++;                                                                                               \
+    }
+
+#define INT32DECODE(p, i)                                                                                    \
+    {                                                                                                        \
+        (i) = ((int32_t)(*(p)&0xff));                                                                        \
+        (p)++;                                                                                               \
+        (i) |= ((int32_t)(*(p)&0xff) << 8);                                                                  \
+        (p)++;                                                                                               \
+        (i) |= ((int32_t)(*(p)&0xff) << 16);                                                                 \
+        (p)++;                                                                                               \
+        (i) |= ((int32_t)(((*(p) & (unsigned)0xff) << 24) | ((*(p)&0x80) ? ~0xffffffffULL : 0x0ULL)));       \
+        (p)++;                                                                                               \
+    }
+
+#define UINT32DECODE(p, i)                                                                                   \
+    {                                                                                                        \
+        (i) = (uint32_t)(*(p)&0xff);                                                                         \
+        (p)++;                                                                                               \
+        (i) |= ((uint32_t)(*(p)&0xff) << 8);                                                                 \
+        (p)++;                                                                                               \
+        (i) |= ((uint32_t)(*(p)&0xff) << 16);                                                                \
+        (p)++;                                                                                               \
+        (i) |= ((uint32_t)(*(p)&0xff) << 24);                                                                \
+        (p)++;                                                                                               \
+    }
+
+/* Decode a variable-sized buffer */
+/* (Assumes that the high bits of the integer will be zero) */
+#define DECODE_VAR(p, n, l)                                                                                  \
+    {                                                                                                        \
+        size_t _i;                                                                                           \
+                                                                                                             \
+        n = 0;                                                                                               \
+        (p) += l;                                                                                            \
+        for (_i = 0; _i < l; _i++)                                                                           \
+            n = (n << 8) | *(--p);                                                                           \
+        (p) += l;                                                                                            \
+    }
+
+/* Decode a variable-sized buffer into a 32-bit unsigned integer */
+/* (Assumes that the high bits of the integer will be zero) */
+#define UINT32DECODE_VAR(p, n, l) DECODE_VAR(p, n, l)
+
+#define INT64DECODE(p, n)                                                                                    \
+    {                                                                                                        \
+        /* WE DON'T CHECK FOR OVERFLOW! */                                                                   \
+        size_t _i;                                                                                           \
+                                                                                                             \
+        n = 0;                                                                                               \
+        (p) += 8;                                                                                            \
+        for (_i = 0; _i < sizeof(int64_t); _i++)                                                             \
+            n = (n << 8) | *(--p);                                                                           \
+        (p) += 8;                                                                                            \
+    }
+
+#define UINT64DECODE(p, n)                                                                                   \
+    {                                                                                                        \
+        /* WE DON'T CHECK FOR OVERFLOW! */                                                                   \
+        size_t _i;                                                                                           \
+                                                                                                             \
+        n = 0;                                                                                               \
+        (p) += 8;                                                                                            \
+        for (_i = 0; _i < sizeof(uint64_t); _i++)                                                            \
+            n = (n << 8) | *(--p);                                                                           \
+        (p) += 8;                                                                                            \
+    }
+
+/* Decode a variable-sized buffer into a 64-bit unsigned integer */
+/* (Assumes that the high bits of the integer will be zero) */
+#define UINT64DECODE_VAR(p, n, l) DECODE_VAR(p, n, l)
+
+#define H5_DECODE_UNSIGNED(p, n)                                                                             \
+    {                                                                                                        \
+        HDcompile_assert(sizeof(unsigned) == sizeof(uint32_t));                                              \
+        UINT32DECODE(p, n)                                                                                   \
+    }
+
+/* Assumes the endianness of uint64_t is the same as double */
+#define H5_DECODE_DOUBLE(p, n)                                                                               \
+    {                                                                                                        \
+        uint64_t _n;                                                                                         \
+        size_t   _u;                                                                                         \
+                                                                                                             \
+        HDcompile_assert(sizeof(double) == 8);                                                               \
+        HDcompile_assert(sizeof(double) == sizeof(uint64_t));                                                \
+        _n = 0;                                                                                              \
+        (p) += 8;                                                                                            \
+        for (_u = 0; _u < sizeof(uint64_t); _u++)                                                            \
+            _n = (_n << 8) | *(--p);                                                                         \
+        HDmemcpy(&(n), &_n, sizeof(double));                                                                 \
+        (p) += 8;                                                                                            \
+    }
+
+/* Macros to encode/decode offset/length's for storing in the file */
+#define H5_ENCODE_LENGTH_LEN(p, l, s)                                                                        \
+    switch (s) {                                                                                             \
+        case 4:                                                                                              \
+            UINT32ENCODE(p, l);                                                                              \
+            break;                                                                                           \
+        case 8:                                                                                              \
+            UINT64ENCODE(p, l);                                                                              \
+            break;                                                                                           \
+        case 2:                                                                                              \
+            UINT16ENCODE(p, l);                                                                              \
+            break;                                                                                           \
+        default:                                                                                             \
+            HDassert("bad sizeof size" && 0);                                                                \
+    }
+
+#define H5_DECODE_LENGTH_LEN(p, l, s)                                                                        \
+    switch (s) {                                                                                             \
+        case 4:                                                                                              \
+            UINT32DECODE(p, l);                                                                              \
+            break;                                                                                           \
+        case 8:                                                                                              \
+            UINT64DECODE(p, l);                                                                              \
+            break;                                                                                           \
+        case 2:                                                                                              \
+            UINT16DECODE(p, l);                                                                              \
+            break;                                                                                           \
+        default:                                                                                             \
+            HDassert("bad sizeof size" && 0);                                                                \
+    }
+
+#endif /* H5encode_H */

--- a/src/H5private.h
+++ b/src/H5private.h
@@ -2440,6 +2440,9 @@ typedef union {
     const void *cvp;
 } H5_flexible_const_ptr_t;
 
+/* File-independent encode/decode routines */
+#include "H5encode.h"
+
 /* Private functions, not part of the publicly documented API */
 H5_DLL herr_t H5_init_library(void);
 H5_DLL void   H5_term_library(void);


### PR DESCRIPTION
Moves the file-independent encode and decode macros to a new H5encode.h header that is itself included in H5private.h

Removes UINT64ENCODE_VARLEN and UINT64DECODE_VARLEN, which were unused

Fixes include statements in files where H5VMprivate.h and H5MMprivate.h were included via H5Fprivate.h

Fixes new "maybe uninitialized" warnings