### PR TITLE
Remove Win32 POSIX redefinitions

### DIFF
--- a/src/H5win32defs.h
+++ b/src/H5win32defs.h
@@ -42,6 +42,7 @@ struct timezone {
 #define HDcreat(S, M)        Wopen_utf8(S, O_CREAT | O_TRUNC | O_RDWR, M)
 #define HDflock(F, L)        Wflock(F, L)
 #define HDfstat(F, B)        _fstati64(F, B)
+#define HDgetdcwd(D, S, Z)   _getdcwd(D, S, Z)
 #define HDgetdrive()         _getdrive()
 #define HDgettimeofday(V, Z) Wgettimeofday(V, Z)
 #define HDlseek(F, O, W)     _lseeki64(F, O, W)

--- a/src/H5win32defs.h
+++ b/src/H5win32defs.h
@@ -15,7 +15,7 @@
  *          things and MinGW.
  *
  *          This file must be included before the H5private.h HD mappings, so
- *          the definitions here will supercede them.
+ *          the definitions here will supersede them.
  */
 
 #ifdef H5_HAVE_WIN32_API

--- a/src/H5win32defs.h
+++ b/src/H5win32defs.h
@@ -42,6 +42,7 @@ struct timezone {
 #define HDcreat(S, M)        Wopen_utf8(S, O_CREAT | O_TRUNC | O_RDWR, M)
 #define HDflock(F, L)        Wflock(F, L)
 #define HDfstat(F, B)        _fstati64(F, B)
+#define HDgetdrive()         _getdrive()
 #define HDgettimeofday(V, Z) Wgettimeofday(V, Z)
 #define HDlseek(F, O, W)     _lseeki64(F, O, W)
 #define HDlstat(S, B)        _lstati64(S, B)

--- a/src/H5win32defs.h
+++ b/src/H5win32defs.h
@@ -10,20 +10,21 @@
  * help@hdfgroup.org.                                                        *
  * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 
-/* Purpose: This file is used to map HDF macros to Windows functions.  This
- *          should get included H5private mappings, so as to override them.
- *          Any macro not mapped here, however, will receive a similar mapping
- *          inside H5private.h
+/* Purpose: This file deals with Windows compatibility. MSVC is largely C99
+ *          compliant now, but we still need work-arounds for some POSIX
+ *          things and MinGW.
  *
+ *          This file must be included before the H5private.h HD mappings, so
+ *          the definitions here will supercede them.
  */
 
-/* _MSC_VER = 192x  VS2019
- * _MSC_VER = 191x  VS2017
- * _MSC_VER = 1900  VS2015
- * _MSC_VER = 1800  VS2013
- * _MSC_VER = 1700  VS2012
- */
 #ifdef H5_HAVE_WIN32_API
+
+/* off_t exists on Windows, but is always a 32-bit long, even on 64-bit Windows,
+ * so we define HDoff_t to be __int64, which is the type of the st_size field
+ * of the _stati64 struct.
+ */
+#define HDoff_t __int64
 
 /* __int64 is the correct type for the st_size field of the _stati64 struct.
  * MSDN isn't very clear about this.
@@ -32,37 +33,18 @@ typedef struct _stati64 h5_stat_t;
 typedef __int64         h5_stat_size_t;
 
 #ifdef H5_HAVE_VISUAL_STUDIO
-
 struct timezone {
     int tz_minuteswest;
     int tz_dsttime;
 };
+#endif
 
-#endif /* H5_HAVE_VISUAL_STUDIO */
-
-#define HDaccess(F, M)       _access(F, M)
-#define HDchdir(S)           _chdir(S)
-#define HDclose(F)           _close(F)
 #define HDcreat(S, M)        Wopen_utf8(S, O_CREAT | O_TRUNC | O_RDWR, M)
-#define HDdup(F)             _dup(F)
-#define HDfdopen(N, S)       _fdopen(N, S)
-#define HDfileno(F)          _fileno(F)
 #define HDflock(F, L)        Wflock(F, L)
 #define HDfstat(F, B)        _fstati64(F, B)
-#define HDgetcwd(S, Z)       _getcwd(S, Z)
-#define HDgetdcwd(D, S, Z)   _getdcwd(D, S, Z)
-#define HDgetdrive()         _getdrive()
 #define HDgettimeofday(V, Z) Wgettimeofday(V, Z)
-#define HDisatty(F)          _isatty(F)
 #define HDlseek(F, O, W)     _lseeki64(F, O, W)
 #define HDlstat(S, B)        _lstati64(S, B)
-#define HDmkdir(S, M)        _mkdir(S)
-
-/* off_t exists on Windows, but is always a 32-bit long, even on 64-bit Windows,
- * so we define HDoff_t to be __int64, which is the type of the st_size field
- * of the _stati64 struct.
- */
-#define HDoff_t __int64
 
 /* Note that the variadic HDopen macro is using a VC++ extension
  * where the comma is dropped if nothing is passed to the ellipsis.
@@ -73,9 +55,7 @@ struct timezone {
 #define HDopen(S, F, ...) Wopen_utf8(S, F, ##__VA_ARGS__)
 #endif
 
-#define HDread(F, M, Z)       _read(F, M, Z)
 #define HDremove(S)           Wremove_utf8(S)
-#define HDrmdir(S)            _rmdir(S)
 #define HDsetenv(N, V, O)     Wsetenv(N, V, O)
 #define HDsetvbuf(F, S, M, Z) setvbuf(F, S, M, (Z > 1 ? Z : 2))
 #define HDsleep(S)            Sleep(S * 1000)
@@ -84,19 +64,16 @@ struct timezone {
 #define HDstrcasestr(A, B)    Wstrcasestr_wrap(A, B)
 #define HDstrndup(S, N)       H5_strndup(S, N)
 #define HDstrtok_r(X, Y, Z)   strtok_s(X, Y, Z)
-#define HDtzset()             _tzset()
-#define HDunlink(S)           _unlink(S)
 #define HDunsetenv(N)         Wsetenv(N, "", 1)
-#define HDwrite(F, M, Z)      _write(F, M, Z)
 
 #ifndef H5_HAVE_MINGW
 #define HDftruncate(F, L) _chsize_s(F, L)
 #define HDfseek(F, O, W)  _fseeki64(F, O, W)
-#endif /* H5_HAVE_MINGW */
+#endif
 
 #ifdef __cplusplus
 extern "C" {
-#endif /* __cplusplus */
+#endif
 H5_DLL int      Wgettimeofday(struct timeval *tv, struct timezone *tz);
 H5_DLL int      Wsetenv(const char *name, const char *value, int overwrite);
 H5_DLL int      Wflock(int fd, int operation);
@@ -109,6 +86,6 @@ H5_DLL char    *H5_strndup(const char *s, size_t n);
 H5_DLL char    *Wstrcasestr_wrap(const char *haystack, const char *needle);
 #ifdef __cplusplus
 }
-#endif /* __cplusplus */
+#endif
 
 #endif /* H5_HAVE_WIN32_API */

--- a/src/H5win32defs.h
+++ b/src/H5win32defs.h
@@ -45,6 +45,7 @@ struct timezone {
 #define HDgettimeofday(V, Z) Wgettimeofday(V, Z)
 #define HDlseek(F, O, W)     _lseeki64(F, O, W)
 #define HDlstat(S, B)        _lstati64(S, B)
+#define HDmkdir(S, M)        _mkdir(S)
 
 /* Note that the variadic HDopen macro is using a VC++ extension
  * where the comma is dropped if nothing is passed to the ellipsis.


### PR DESCRIPTION
Microsoft has redefined most POSIX API calls with a leading underscore in order to strictly comply with C99. Nobody else cares about this and we define _CRT_NONSTDC_NO_WARNINGS in CMake Windows builds to suppress their warnings.