### PR TITLE
Make some changes to configure.ac to support MinGW

### DIFF
--- a/config/cmake/H5pubconf.h.in
+++ b/config/cmake/H5pubconf.h.in
@@ -14,13 +14,13 @@
 #ifndef H5_CONFIG_H_
 #define H5_CONFIG_H_
 
-/* Define if the Windows virtual file driver should be compiled */
+/* Define if this is a Windows machine */
 #cmakedefine H5_HAVE_WINDOWS @H5_HAVE_WINDOWS@
 
 /* Define if using MinGW */
 #cmakedefine H5_HAVE_MINGW @H5_HAVE_MINGW@
 
-/* Define if on the Windows platform and default WIN32 API */
+/* Define if on the Windows platform and using the Win32 API */
 #cmakedefine H5_HAVE_WIN32_API @H5_HAVE_WIN32_API@
 
 /* Define if using a Windows compiler (i.e. Visual Studio) */

--- a/configure.ac
+++ b/configure.ac
@@ -1461,7 +1461,12 @@ case "$host_cpu-$host_vendor-$host_os" in
     ## VFD on Linux systems.
     H5_CPPFLAGS="-D_GNU_SOURCE $H5_CPPFLAGS"
     ;;
-
+  *mingw*)
+    AC_DEFINE([HAVE_WINDOWS], [1], [Define if this is a Windows machine])
+    AC_DEFINE([HAVE_WIN32_API], [1], [Define if on the Windows platform using the Win32 API])
+    AC_DEFINE([HAVE_MINGW], [1], [Define if using MinGW])
+    H5_CPPFLAGS="-D_GNU_SOURCE -D__USE_MINGW_ANSI_STDIO $H5_CPPFLAGS"
+    ;;
 esac
 
 ## Need to add the AM_ and H5_ into CFLAGS/CPPFLAGS to make them visible


### PR DESCRIPTION
Adds some H5pubconf.h entries and cpp flags for building on MinGW using the Autotools.

Also updates the Windows-related H5pubconf.h comments to be more accurate in CMake.