### PR TITLE
build(configure.ac): skip h5fuse.sh if subfiling VFD is not used (#3089)

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -4165,7 +4165,9 @@ AC_CONFIG_FILES([src/libhdf5.settings
                  hl/fortran/examples/Makefile
                  hl/fortran/examples/run-hlfortran-ex.sh])
 
-AC_CONFIG_FILES([utils/subfiling_vfd/h5fuse.sh], [chmod +x utils/subfiling_vfd/h5fuse.sh])
+if test "X$SUBFILING_VFD" = "Xyes"; then
+   AC_CONFIG_FILES([utils/subfiling_vfd/h5fuse.sh], [chmod +x utils/subfiling_vfd/h5fuse.sh])
+fi
 
 AC_CONFIG_COMMANDS([.classes], [], [$MKDIR_P java/src/.classes;
                 $MKDIR_P java/test/.classes;


### PR DESCRIPTION
Close #3089.
