### PR TITLE
clang-tidy clang-analyzer-core issues addressed

### DIFF
--- a/src/H5system.c
+++ b/src/H5system.c
@@ -1290,7 +1290,7 @@ H5_get_option(int argc, const char *const *argv, const char *opts, const struct 
             }
         }
 
-        if (l_opts[i].name == NULL) {
+        if (l_opts && l_opts[i].name == NULL) {
             /* exhausted all of the l_opts we have and still didn't match */
             if (H5_opterr)
                 HDfprintf(stderr, "%s: unknown option \"%s\"\n", argv[0], arg);

--- a/src/H5trace.c
+++ b/src/H5trace.c
@@ -3984,8 +3984,8 @@ H5_trace(const double *returning, const char *func, const char *type, ...)
     hssize_t          i;
     FILE             *out                 = H5_debug_g.trace;
     static hbool_t    is_first_invocation = TRUE;
-    H5_timer_t        function_timer = {0.0, 0.0, 0.0};
-    H5_timevals_t     function_times = {0.0, 0.0, 0.0};
+    H5_timer_t        function_timer      = {0.0, 0.0, 0.0};
+    H5_timevals_t     function_times      = {0.0, 0.0, 0.0};
     static H5_timer_t running_timer;
     H5_timevals_t     running_times;
     static int        current_depth   = 0;

--- a/src/H5trace.c
+++ b/src/H5trace.c
@@ -281,8 +281,6 @@ H5_trace_args(H5RS_str_t *rs, const char *type, va_list ap)
         argname = HDva_arg(ap, char *);
         if (argname)
             H5RS_asprintf_cat(rs, "%s%s=", argno ? ", " : "", argname);
-        else
-            argname = "";
 
         /* A pointer/array */
         if (ptr) {

--- a/src/H5trace.c
+++ b/src/H5trace.c
@@ -3982,7 +3982,7 @@ H5_trace(const double *returning, const char *func, const char *type, ...)
     hssize_t          i;
     FILE             *out                 = H5_debug_g.trace;
     static hbool_t    is_first_invocation = TRUE;
-    H5_timer_t        function_timer      = {0.0, 0.0, 0.0};
+    H5_timer_t        function_timer      = {{0.0, 0.0, 0.0}, {0.0, 0.0, 0.0}, {0.0, 0.0, 0.0}, FALSE};
     H5_timevals_t     function_times      = {0.0, 0.0, 0.0};
     static H5_timer_t running_timer;
     H5_timevals_t     running_times;

--- a/src/H5trace.c
+++ b/src/H5trace.c
@@ -3984,7 +3984,7 @@ H5_trace(const double *returning, const char *func, const char *type, ...)
     hssize_t          i;
     FILE             *out                 = H5_debug_g.trace;
     static hbool_t    is_first_invocation = TRUE;
-    H5_timer_t        function_timer;
+    H5_timer_t        function_timer = {0.0, 0.0, 0.0};
     H5_timevals_t     function_times = {0.0, 0.0, 0.0};
     static H5_timer_t running_timer;
     H5_timevals_t     running_times;


### PR DESCRIPTION
src/H5system.c:1293:13: warning: Dereference of null pointer [clang-analyzer-core.NullDereference]
src/H5trace.c:4048:17: warning: Passed-by-value struct argument contains uninitialized data (e.g., via the field chain: 'initial.user') [clang-analyzer-core.CallAndMessage]