### PR TITLE
chore: make autogen.sh output message consistent

### DIFF
--- a/bin/make_vers
+++ b/bin/make_vers
@@ -509,7 +509,7 @@ for $file (@ARGV) {
     close SOURCE;
 
     # Create header files
-    print "Generating '", $prefix, "H5version.h'\n";
+    print "Generating 'H5version.h'\n";
     create_public($prefix);
 
 #for $name (sort keys %functions) {


### PR DESCRIPTION
This will output `Generating 'H5version.h'`, not `Generating 'src/H5version.h'`.

This will match other output messages:

```
Running error generation script:
Generating 'H5Epubgen.h'
Generating 'H5Einit.h'
Generating 'H5Eterm.h'
Generating 'H5Edefin.h'
```
