### PR TITLE
Fix path to libhdf5.settings in cmakehdf5

### DIFF
--- a/bin/cmakehdf5
+++ b/bin/cmakehdf5
@@ -1,4 +1,4 @@
-#! /bin/sh
+#!/bin/sh
 # Build and Test HDF5 using cmake.
 # Author: Allen Byrne
 #         Albert Cheng
@@ -365,7 +365,7 @@ STEP "Configure..." \
     $with_zlib \
     $with_szlib \
     $srcdir" $configlog &&\
-    cat $config_summary >> $configlog
+    cat src/$config_summary >> $configlog
 
 #      5. Build the C library, tools and tests with this command:
 STEP "Build the library, tools and tests, ..." "cmake --build . --config Release -- $njobs" $makelog


### PR DESCRIPTION
This fixes the following error message:

```cat: libhdf5.settings: No such file or directory```
