### PR TITLE
Remove HD prefix from network calls

### DIFF
--- a/src/H5FDmirror.c
+++ b/src/H5FDmirror.c
@@ -285,7 +285,7 @@ H5FD__mirror_xmit_decode_uint16(uint16_t *out, const unsigned char *_buf)
     HDassert(_buf && out);
 
     H5MM_memcpy(&n, _buf, sizeof(n));
-    *out = (uint16_t)HDntohs(n);
+    *out = (uint16_t)ntohs(n);
 
     return 2; /* number of bytes eaten */
 } /* end H5FD__mirror_xmit_decode_uint16() */
@@ -313,7 +313,7 @@ H5FD__mirror_xmit_decode_uint32(uint32_t *out, const unsigned char *_buf)
     HDassert(_buf && out);
 
     H5MM_memcpy(&n, _buf, sizeof(n));
-    *out = (uint32_t)HDntohl(n);
+    *out = (uint32_t)ntohl(n);
 
     return 4; /* number of bytes eaten */
 } /* end H5FD__mirror_xmit_decode_uint32() */
@@ -424,7 +424,7 @@ H5FD__mirror_xmit_encode_uint16(unsigned char *_dest, uint16_t v)
 
     HDassert(_dest);
 
-    n = (uint16_t)HDhtons(v);
+    n = (uint16_t)htons(v);
     H5MM_memcpy(_dest, &n, sizeof(n));
 
     return 2;
@@ -451,7 +451,7 @@ H5FD__mirror_xmit_encode_uint32(unsigned char *_dest, uint32_t v)
 
     HDassert(_dest);
 
-    n = (uint32_t)HDhtonl(v);
+    n = (uint32_t)htonl(v);
     H5MM_memcpy(_dest, &n, sizeof(n));
 
     return 4;
@@ -1380,17 +1380,17 @@ H5FD__mirror_open(const char *name, unsigned flags, hid_t fapl_id, haddr_t maxad
     /* Handshake with remote */
     /* --------------------- */
 
-    live_socket = HDsocket(AF_INET, SOCK_STREAM, 0);
+    live_socket = socket(AF_INET, SOCK_STREAM, 0);
     if (live_socket < 0)
         HGOTO_ERROR(H5E_ARGS, H5E_BADVALUE, NULL, "can't create socket");
 
     target_addr.sin_family      = AF_INET;
-    target_addr.sin_port        = HDhtons((uint16_t)fa.handshake_port);
-    target_addr.sin_addr.s_addr = HDinet_addr(fa.remote_ip);
+    target_addr.sin_port        = htons((uint16_t)fa.handshake_port);
+    target_addr.sin_addr.s_addr = inet_addr(fa.remote_ip);
     HDmemset(target_addr.sin_zero, '\0', sizeof target_addr.sin_zero);
 
     addr_size = sizeof(target_addr);
-    if (HDconnect(live_socket, (struct sockaddr *)&target_addr, addr_size) < 0)
+    if (connect(live_socket, (struct sockaddr *)&target_addr, addr_size) < 0)
         HGOTO_ERROR(H5E_ARGS, H5E_BADVALUE, NULL, "can't connect to remote server");
 
     /* ------------- */

--- a/src/H5private.h
+++ b/src/H5private.h
@@ -611,9 +611,6 @@ typedef off_t       h5_stat_size_t;
 #ifndef HDabort
 #define HDabort() abort()
 #endif
-#ifndef HDaccept
-#define HDaccept(A, B, C) accept((A), (B), (C))
-#endif
 #ifndef HDaccess
 #define HDaccess(F, M) access(F, M)
 #endif
@@ -644,9 +641,6 @@ typedef off_t       h5_stat_size_t;
 #ifndef HDatoll
 #define HDatoll(S) atoll(S)
 #endif
-#ifndef HDbind
-#define HDbind(A, B, C) bind((A), (B), (C))
-#endif
 #ifndef HDcalloc
 #define HDcalloc(N, Z) calloc(N, Z)
 #endif
@@ -667,9 +661,6 @@ typedef off_t       h5_stat_size_t;
 #endif
 #ifndef HDclosedir
 #define HDclosedir(D) closedir(D)
-#endif
-#ifndef HDconnect
-#define HDconnect(A, B, C) connect((A), (B), (C))
 #endif
 #ifndef HDcreat
 #define HDcreat(S, M) creat(S, M)
@@ -826,9 +817,6 @@ H5_DLL H5_ATTR_CONST int Nflock(int fd, int operation);
 #ifndef HDgetenv
 #define HDgetenv(S) getenv(S)
 #endif
-#ifndef HDgethostbyaddr
-#define HDgethostbyaddr(A, B, C) gethostbyaddr((A), (B), (C))
-#endif
 #ifndef HDgethostname
 #define HDgethostname(N, L) gethostname(N, L)
 #endif
@@ -849,18 +837,6 @@ H5_DLL H5_ATTR_CONST int Nflock(int fd, int operation);
 #endif
 #ifndef HDgmtime
 #define HDgmtime(T) gmtime(T)
-#endif
-#ifndef HDhtonl
-#define HDhtonl(X) htonl((X))
-#endif
-#ifndef HDhtons
-#define HDhtons(X) htons((X))
-#endif
-#ifndef HDinet_addr
-#define HDinet_addr(C) inet_addr((C))
-#endif
-#ifndef HDinet_ntoa
-#define HDinet_ntoa(C) inet_ntoa((C))
 #endif
 #ifndef HDisalnum
 #define HDisalnum(C) isalnum((int)(C)) /* Cast for Solaris warning */
@@ -906,9 +882,6 @@ H5_DLL H5_ATTR_CONST int Nflock(int fd, int operation);
 #endif
 #ifndef HDldexp
 #define HDldexp(X, N) ldexp(X, N)
-#endif
-#ifndef HDlisten
-#define HDlisten(A, B) listen((A), (B))
 #endif
 #ifndef HDllround
 #define HDllround(V) llround(V)
@@ -972,12 +945,6 @@ H5_DLL H5_ATTR_CONST int Nflock(int fd, int operation);
 #endif
 #ifndef HDnanosleep
 #define HDnanosleep(N, O) nanosleep(N, O)
-#endif
-#ifndef HDntohl
-#define HDntohl(A) ntohl((A))
-#endif
-#ifndef HDntohs
-#define HDntohs(A) ntohs((A))
 #endif
 #ifndef HDopen
 #define HDopen(F, ...) open(F, __VA_ARGS__)
@@ -1100,9 +1067,6 @@ H5_DLL H5_ATTR_CONST int Nflock(int fd, int operation);
 #ifndef HDsetenv
 #define HDsetenv(N, V, O) setenv(N, V, O)
 #endif
-#ifndef HDsetsockopt
-#define HDsetsockopt(A, B, C, D, E) setsockopt((A), (B), (C), (D), (E))
-#endif
 #ifndef HDsetvbuf
 #define HDsetvbuf(F, S, M, Z) setvbuf(F, S, M, Z)
 #endif
@@ -1123,9 +1087,6 @@ H5_DLL H5_ATTR_CONST int Nflock(int fd, int operation);
 #endif
 #ifndef HDsnprintf
 #define HDsnprintf snprintf /*varargs*/
-#endif
-#ifndef HDsocket
-#define HDsocket(A, B, C) socket((A), (B), (C))
 #endif
 #ifndef HDsprintf
 #define HDsprintf sprintf /*varargs*/
@@ -1190,9 +1151,6 @@ H5_DLL H5_ATTR_CONST int Nflock(int fd, int operation);
 #endif
 #ifndef HDstrndup
 #define HDstrndup(S, N) strndup(S, N)
-#endif
-#ifndef HDstrpbrk
-#define HDstrpbrk(X, Y) strpbrk(X, Y)
 #endif
 #ifndef HDstrrchr
 #define HDstrrchr(S, C) strrchr(S, C)

--- a/test/mirror_vfd.c
+++ b/test/mirror_vfd.c
@@ -2332,19 +2332,19 @@ confirm_server(struct mt_opts *opts)
     struct sockaddr_in target_addr;
     unsigned           attempt = 0;
 
-    live_socket = HDsocket(AF_INET, SOCK_STREAM, 0);
+    live_socket = socket(AF_INET, SOCK_STREAM, 0);
     if (live_socket < 0) {
         HDprintf("ERROR socket()\n");
         return -1;
     }
 
     target_addr.sin_family      = AF_INET;
-    target_addr.sin_port        = HDhtons((uint16_t)opts->portno);
-    target_addr.sin_addr.s_addr = HDinet_addr(opts->ip);
+    target_addr.sin_port        = htons((uint16_t)opts->portno);
+    target_addr.sin_addr.s_addr = inet_addr(opts->ip);
     HDmemset(target_addr.sin_zero, '\0', sizeof(target_addr.sin_zero));
 
     while (1) {
-        if (HDconnect(live_socket, (struct sockaddr *)&target_addr, (socklen_t)sizeof(target_addr)) < 0) {
+        if (connect(live_socket, (struct sockaddr *)&target_addr, (socklen_t)sizeof(target_addr)) < 0) {
             if (attempt > 10) {
                 HDprintf("ERROR connect() (%d)\n%s\n", errno, HDstrerror(errno));
                 return -1;
@@ -2362,7 +2362,7 @@ confirm_server(struct mt_opts *opts)
             HDprintf("attempt #%u: ERROR connect() (%d)\n%s\n", attempt, errno, HDstrerror(errno));
 
             /* Re-open socket for retry */
-            live_socket = HDsocket(AF_INET, SOCK_STREAM, 0);
+            live_socket = socket(AF_INET, SOCK_STREAM, 0);
             if (live_socket < 0) {
                 HDprintf("ERROR socket()\n");
                 return -1;

--- a/utils/mirror_vfd/mirror_server.c
+++ b/utils/mirror_vfd/mirror_server.c
@@ -241,28 +241,28 @@ prepare_listening_socket(struct server_run *run)
     mirror_log(run->loginfo, V_INFO, "preparing socket");
 
     server_addr.sin_family      = AF_INET;
-    server_addr.sin_addr.s_addr = HDhtonl(INADDR_ANY);
-    server_addr.sin_port        = HDhtons((uint16_t)run->opts.main_port);
+    server_addr.sin_addr.s_addr = htonl(INADDR_ANY);
+    server_addr.sin_port        = htons((uint16_t)run->opts.main_port);
 
     mirror_log(run->loginfo, V_INFO, "socket()");
-    ret_value = HDsocket(AF_INET, SOCK_STREAM, 0);
+    ret_value = socket(AF_INET, SOCK_STREAM, 0);
     if (ret_value < 0) {
         mirror_log(run->loginfo, V_ERR, "listening socket:%d", ret_value);
         goto error;
     }
 
     mirror_log(run->loginfo, V_ALL, "setsockopt()");
-    HDsetsockopt(ret_value, SOL_SOCKET, SO_REUSEADDR, &_true, sizeof(int));
+    setsockopt(ret_value, SOL_SOCKET, SO_REUSEADDR, &_true, sizeof(int));
 
     mirror_log(run->loginfo, V_INFO, "bind()");
-    ret = HDbind(ret_value, (struct sockaddr *)&server_addr, sizeof(server_addr));
+    ret = bind(ret_value, (struct sockaddr *)&server_addr, sizeof(server_addr));
     if (ret < 0) {
         mirror_log(run->loginfo, V_ERR, "bind() %s", HDstrerror(errno));
         goto error;
     }
 
     mirror_log(run->loginfo, V_INFO, "listen()");
-    ret = HDlisten(ret_value, LISTENQ);
+    ret = listen(ret_value, LISTENQ);
     if (ret < 0) {
         mirror_log(run->loginfo, V_ERR, "H5FD server listen:%d", ret);
         goto error;
@@ -392,7 +392,7 @@ accept_connection(struct server_run *run)
     /*------------------------------*/
     /* accept a connection on a socket */
     clilen = sizeof(client_addr);
-    connfd = HDaccept(run->listenfd, (struct sockaddr *)&client_addr, &clilen);
+    connfd = accept(run->listenfd, (struct sockaddr *)&client_addr, &clilen);
     if (connfd < 0) {
         mirror_log(run->loginfo, V_ERR, "accept:%d", connfd);
         goto error;
@@ -401,15 +401,15 @@ accept_connection(struct server_run *run)
 
     /*------------------------------*/
     /* get client address information */
-    host_port = HDgethostbyaddr((const char *)&client_addr.sin_addr.s_addr,
-                                sizeof(client_addr.sin_addr.s_addr), AF_INET);
+    host_port = gethostbyaddr((const char *)&client_addr.sin_addr.s_addr, sizeof(client_addr.sin_addr.s_addr),
+                              AF_INET);
     if (host_port == NULL) {
         mirror_log(run->loginfo, V_ERR, "gethostbyaddr()");
         goto error;
     }
 
     /* function has the string space statically scoped -- OK until next call */
-    hostaddrp = HDinet_ntoa(client_addr.sin_addr);
+    hostaddrp = inet_ntoa(client_addr.sin_addr);
     /* TODO? proper error-checking */
 
     mirror_log(run->loginfo, V_INFO, "server connected with %s (%s)", host_port->h_name, hostaddrp);

--- a/utils/mirror_vfd/mirror_server_stop.c
+++ b/utils/mirror_vfd/mirror_server_stop.c
@@ -137,18 +137,18 @@ send_shutdown(struct mshs_opts *opts)
         return -1;
     }
 
-    live_socket = HDsocket(AF_INET, SOCK_STREAM, 0);
+    live_socket = socket(AF_INET, SOCK_STREAM, 0);
     if (live_socket < 0) {
         HDprintf("ERROR socket()\n");
         return -1;
     }
 
     target_addr.sin_family      = AF_INET;
-    target_addr.sin_port        = HDhtons((uint16_t)opts->portno);
-    target_addr.sin_addr.s_addr = HDinet_addr(opts->ip);
+    target_addr.sin_port        = htons((uint16_t)opts->portno);
+    target_addr.sin_addr.s_addr = inet_addr(opts->ip);
     HDmemset(target_addr.sin_zero, 0, sizeof(target_addr.sin_zero));
 
-    if (HDconnect(live_socket, (struct sockaddr *)&target_addr, (socklen_t)sizeof(target_addr)) < 0) {
+    if (connect(live_socket, (struct sockaddr *)&target_addr, (socklen_t)sizeof(target_addr)) < 0) {
         HDprintf("ERROR connect() (%d)\n%s\n", errno, HDstrerror(errno));
         return -1;
     }


### PR DESCRIPTION
HDsocket(), etc. Only affects the mirror VFD and its test code.