### PR TITLE
Add note about HDF5_VOL_CONNECTOR to tools usage

### DIFF
--- a/tools/src/h5diff/h5diff_common.c
+++ b/tools/src/h5diff/h5diff_common.c
@@ -641,6 +641,12 @@ usage(void)
                    "   --vol-info-2            VOL-specific info to pass to the VOL connector used for\n");
     PRINTVALSTREAM(rawoutstream, "                           opening the second HDF5 file specified\n");
     PRINTVALSTREAM(rawoutstream,
+                   "                           If none of the above options are used to specify a VOL for a file, then\n");
+    PRINTVALSTREAM(rawoutstream,
+                   "                           the VOL named by HDF5_VOL_CONNECTOR (or the native VOL connector,\n");
+    PRINTVALSTREAM(rawoutstream,
+                   "                           if that environment variable is unset) will be used\n");
+    PRINTVALSTREAM(rawoutstream,
                    "   --vfd-value-1           Value (ID) of the VFL driver to use for opening the\n");
     PRINTVALSTREAM(rawoutstream, "                           first HDF5 file specified\n");
     PRINTVALSTREAM(rawoutstream,

--- a/tools/src/h5diff/h5diff_common.c
+++ b/tools/src/h5diff/h5diff_common.c
@@ -640,10 +640,11 @@ usage(void)
     PRINTVALSTREAM(rawoutstream,
                    "   --vol-info-2            VOL-specific info to pass to the VOL connector used for\n");
     PRINTVALSTREAM(rawoutstream, "                           opening the second HDF5 file specified\n");
-    PRINTVALSTREAM(rawoutstream,
-                   "                           If none of the above options are used to specify a VOL for a file, then\n");
-    PRINTVALSTREAM(rawoutstream,
-                   "                           the VOL named by HDF5_VOL_CONNECTOR (or the native VOL connector,\n");
+    PRINTVALSTREAM(rawoutstream, "                           If none of the above options are used to "
+                                 "specify a VOL for a file, then\n");
+    PRINTVALSTREAM(
+        rawoutstream,
+        "                           the VOL named by HDF5_VOL_CONNECTOR (or the native VOL connector,\n");
     PRINTVALSTREAM(rawoutstream,
                    "                           if that environment variable is unset) will be used\n");
     PRINTVALSTREAM(rawoutstream,

--- a/tools/src/h5dump/h5dump.c
+++ b/tools/src/h5dump/h5dump.c
@@ -219,9 +219,14 @@ usage(const char *prog)
     PRINTVALSTREAM(rawoutstream,
                    "     --vol-info           VOL-specific info to pass to the VOL connector used for\n");
     PRINTVALSTREAM(rawoutstream, "                          opening the HDF5 file specified\n");
-    PRINTVALSTREAM(rawoutstream, "                          If none of the above options are used to specify a VOL, then\n");
-    PRINTVALSTREAM(rawoutstream, "                          the VOL named by HDF5_VOL_CONNECTOR (or the native VOL connector,\n");
-    PRINTVALSTREAM(rawoutstream, "                          if that environment variable is unset) will be used\n");
+    PRINTVALSTREAM(
+        rawoutstream,
+        "                          If none of the above options are used to specify a VOL, then\n");
+    PRINTVALSTREAM(
+        rawoutstream,
+        "                          the VOL named by HDF5_VOL_CONNECTOR (or the native VOL connector,\n");
+    PRINTVALSTREAM(rawoutstream,
+                   "                          if that environment variable is unset) will be used\n");
     PRINTVALSTREAM(rawoutstream,
                    "     --vfd-value          Value (ID) of the VFL driver to use for opening the\n");
     PRINTVALSTREAM(rawoutstream, "                          HDF5 file specified\n");

--- a/tools/src/h5dump/h5dump.c
+++ b/tools/src/h5dump/h5dump.c
@@ -219,12 +219,9 @@ usage(const char *prog)
     PRINTVALSTREAM(rawoutstream,
                    "     --vol-info           VOL-specific info to pass to the VOL connector used for\n");
     PRINTVALSTREAM(rawoutstream, "                          opening the HDF5 file specified\n");
-    PRINTVALSTREAM(
-        rawoutstream,
-        "                          If none of the above options are used to specify a VOL, then\n");
-    PRINTVALSTREAM(
-        rawoutstream,
-        "                          the VOL specified by HDF5_VOL_CONNECTOR (if any) will be used.\n");
+    PRINTVALSTREAM(rawoutstream, "                          If none of the above options are used to specify a VOL, then\n");
+    PRINTVALSTREAM(rawoutstream, "                          the VOL named by HDF5_VOL_CONNECTOR (or the native VOL connector,\n");
+    PRINTVALSTREAM(rawoutstream, "                          if that environment variable is unset) will be used\n");
     PRINTVALSTREAM(rawoutstream,
                    "     --vfd-value          Value (ID) of the VFL driver to use for opening the\n");
     PRINTVALSTREAM(rawoutstream, "                          HDF5 file specified\n");

--- a/tools/src/h5dump/h5dump.c
+++ b/tools/src/h5dump/h5dump.c
@@ -219,6 +219,10 @@ usage(const char *prog)
     PRINTVALSTREAM(rawoutstream,
                    "     --vol-info           VOL-specific info to pass to the VOL connector used for\n");
     PRINTVALSTREAM(rawoutstream, "                          opening the HDF5 file specified\n");
+    PRINTVALSTREAM(rawoutstream, 
+                   "                          If none of the above options are used to specify a VOL, then\n");
+    PRINTVALSTREAM(rawoutstream,
+                   "                          the VOL specified by HDF5_VOL_CONNECTOR (if any) will be used.\n");    
     PRINTVALSTREAM(rawoutstream,
                    "     --vfd-value          Value (ID) of the VFL driver to use for opening the\n");
     PRINTVALSTREAM(rawoutstream, "                          HDF5 file specified\n");

--- a/tools/src/h5dump/h5dump.c
+++ b/tools/src/h5dump/h5dump.c
@@ -219,10 +219,12 @@ usage(const char *prog)
     PRINTVALSTREAM(rawoutstream,
                    "     --vol-info           VOL-specific info to pass to the VOL connector used for\n");
     PRINTVALSTREAM(rawoutstream, "                          opening the HDF5 file specified\n");
-    PRINTVALSTREAM(rawoutstream, 
-                   "                          If none of the above options are used to specify a VOL, then\n");
-    PRINTVALSTREAM(rawoutstream,
-                   "                          the VOL specified by HDF5_VOL_CONNECTOR (if any) will be used.\n");    
+    PRINTVALSTREAM(
+        rawoutstream,
+        "                          If none of the above options are used to specify a VOL, then\n");
+    PRINTVALSTREAM(
+        rawoutstream,
+        "                          the VOL specified by HDF5_VOL_CONNECTOR (if any) will be used.\n");
     PRINTVALSTREAM(rawoutstream,
                    "     --vfd-value          Value (ID) of the VFL driver to use for opening the\n");
     PRINTVALSTREAM(rawoutstream, "                          HDF5 file specified\n");

--- a/tools/src/h5ls/h5ls.c
+++ b/tools/src/h5ls/h5ls.c
@@ -238,7 +238,14 @@ usage(void)
     PRINTVALSTREAM(rawoutstream, "                   HDF5 file specified\n");
     PRINTVALSTREAM(rawoutstream,
                    "   --vol-info      VOL-specific info to pass to the VOL connector used for\n");
-    PRINTVALSTREAM(rawoutstream, "                   opening the HDF5 file specified\n");
+    PRINTVALSTREAM(rawoutstream, 
+                   "                   opening the HDF5 file specified\n");
+    PRINTVALSTREAM(rawoutstream, 
+                   "                   If none of the above options are used to specify a VOL, then\n");
+    PRINTVALSTREAM(rawoutstream, 
+                   "                   the VOL named by HDF5_VOL_CONNECTOR (or the native VOL connector,\n");
+    PRINTVALSTREAM(rawoutstream, 
+                   "                   if that environment variable is unset) will be used\n");
     PRINTVALSTREAM(rawoutstream, "   --vfd-value     Value (ID) of the VFL driver to use for opening the\n");
     PRINTVALSTREAM(rawoutstream, "                   HDF5 file specified\n");
     PRINTVALSTREAM(rawoutstream, "   --vfd-name      Name of the VFL driver to use for opening the\n");

--- a/tools/src/h5ls/h5ls.c
+++ b/tools/src/h5ls/h5ls.c
@@ -238,14 +238,12 @@ usage(void)
     PRINTVALSTREAM(rawoutstream, "                   HDF5 file specified\n");
     PRINTVALSTREAM(rawoutstream,
                    "   --vol-info      VOL-specific info to pass to the VOL connector used for\n");
-    PRINTVALSTREAM(rawoutstream, 
-                   "                   opening the HDF5 file specified\n");
-    PRINTVALSTREAM(rawoutstream, 
+    PRINTVALSTREAM(rawoutstream, "                   opening the HDF5 file specified\n");
+    PRINTVALSTREAM(rawoutstream,
                    "                   If none of the above options are used to specify a VOL, then\n");
-    PRINTVALSTREAM(rawoutstream, 
+    PRINTVALSTREAM(rawoutstream,
                    "                   the VOL named by HDF5_VOL_CONNECTOR (or the native VOL connector,\n");
-    PRINTVALSTREAM(rawoutstream, 
-                   "                   if that environment variable is unset) will be used\n");
+    PRINTVALSTREAM(rawoutstream, "                   if that environment variable is unset) will be used\n");
     PRINTVALSTREAM(rawoutstream, "   --vfd-value     Value (ID) of the VFL driver to use for opening the\n");
     PRINTVALSTREAM(rawoutstream, "                   HDF5 file specified\n");
     PRINTVALSTREAM(rawoutstream, "   --vfd-name      Name of the VFL driver to use for opening the\n");

--- a/tools/src/misc/h5mkgrp.c
+++ b/tools/src/misc/h5mkgrp.c
@@ -105,9 +105,13 @@ usage(const char *prog)
     PRINTVALSTREAM(rawoutstream,
                    "      --vol-info         VOL-specific info to pass to the VOL connector used for\n");
     PRINTVALSTREAM(rawoutstream, "                         opening the HDF5 file specified\n");
-    PRINTVALSTREAM(rawoutstream, "                         If none of the above options are used to specify a VOL, then\n");
-    PRINTVALSTREAM(rawoutstream, "                         the VOL named by HDF5_VOL_CONNECTOR (or the native VOL connector,\n");
-    PRINTVALSTREAM(rawoutstream, "                         if that environment variable is unset) will be used\n");
+    PRINTVALSTREAM(rawoutstream,
+                   "                         If none of the above options are used to specify a VOL, then\n");
+    PRINTVALSTREAM(
+        rawoutstream,
+        "                         the VOL named by HDF5_VOL_CONNECTOR (or the native VOL connector,\n");
+    PRINTVALSTREAM(rawoutstream,
+                   "                         if that environment variable is unset) will be used\n");
     PRINTVALSTREAM(rawoutstream,
                    "      --vfd-value        Value (ID) of the VFL driver to use for opening the\n");
     PRINTVALSTREAM(rawoutstream, "                         HDF5 file specified\n");

--- a/tools/src/misc/h5mkgrp.c
+++ b/tools/src/misc/h5mkgrp.c
@@ -105,6 +105,9 @@ usage(const char *prog)
     PRINTVALSTREAM(rawoutstream,
                    "      --vol-info         VOL-specific info to pass to the VOL connector used for\n");
     PRINTVALSTREAM(rawoutstream, "                         opening the HDF5 file specified\n");
+    PRINTVALSTREAM(rawoutstream, "                         If none of the above options are used to specify a VOL, then\n");
+    PRINTVALSTREAM(rawoutstream, "                         the VOL named by HDF5_VOL_CONNECTOR (or the native VOL connector,\n");
+    PRINTVALSTREAM(rawoutstream, "                         if that environment variable is unset) will be used\n");
     PRINTVALSTREAM(rawoutstream,
                    "      --vfd-value        Value (ID) of the VFL driver to use for opening the\n");
     PRINTVALSTREAM(rawoutstream, "                         HDF5 file specified\n");

--- a/tools/test/h5diff/testfiles/h5diff_10.txt
+++ b/tools/test/h5diff/testfiles/h5diff_10.txt
@@ -37,6 +37,9 @@ usage: h5diff [OPTIONS] file1 file2 [obj1[ obj2]]
                            HDF5 file specified
    --vol-info-2            VOL-specific info to pass to the VOL connector used for
                            opening the second HDF5 file specified
+                           If none of the above options are used to specify a VOL for a file, then
+                           the VOL named by HDF5_VOL_CONNECTOR (or the native VOL connector,
+                           if that environment variable is unset) will be used
    --vfd-value-1           Value (ID) of the VFL driver to use for opening the
                            first HDF5 file specified
    --vfd-name-1            Name of the VFL driver to use for opening the first

--- a/tools/test/h5diff/testfiles/h5diff_600.txt
+++ b/tools/test/h5diff/testfiles/h5diff_600.txt
@@ -37,6 +37,9 @@ usage: h5diff [OPTIONS] file1 file2 [obj1[ obj2]]
                            HDF5 file specified
    --vol-info-2            VOL-specific info to pass to the VOL connector used for
                            opening the second HDF5 file specified
+                           If none of the above options are used to specify a VOL for a file, then
+                           the VOL named by HDF5_VOL_CONNECTOR (or the native VOL connector,
+                           if that environment variable is unset) will be used
    --vfd-value-1           Value (ID) of the VFL driver to use for opening the
                            first HDF5 file specified
    --vfd-name-1            Name of the VFL driver to use for opening the first

--- a/tools/test/h5diff/testfiles/h5diff_603.txt
+++ b/tools/test/h5diff/testfiles/h5diff_603.txt
@@ -38,6 +38,9 @@ usage: h5diff [OPTIONS] file1 file2 [obj1[ obj2]]
                            HDF5 file specified
    --vol-info-2            VOL-specific info to pass to the VOL connector used for
                            opening the second HDF5 file specified
+                           If none of the above options are used to specify a VOL for a file, then
+                           the VOL named by HDF5_VOL_CONNECTOR (or the native VOL connector,
+                           if that environment variable is unset) will be used
    --vfd-value-1           Value (ID) of the VFL driver to use for opening the
                            first HDF5 file specified
    --vfd-name-1            Name of the VFL driver to use for opening the first

--- a/tools/test/h5diff/testfiles/h5diff_606.txt
+++ b/tools/test/h5diff/testfiles/h5diff_606.txt
@@ -38,6 +38,9 @@ usage: h5diff [OPTIONS] file1 file2 [obj1[ obj2]]
                            HDF5 file specified
    --vol-info-2            VOL-specific info to pass to the VOL connector used for
                            opening the second HDF5 file specified
+                           If none of the above options are used to specify a VOL for a file, then
+                           the VOL named by HDF5_VOL_CONNECTOR (or the native VOL connector,
+                           if that environment variable is unset) will be used
    --vfd-value-1           Value (ID) of the VFL driver to use for opening the
                            first HDF5 file specified
    --vfd-name-1            Name of the VFL driver to use for opening the first

--- a/tools/test/h5diff/testfiles/h5diff_612.txt
+++ b/tools/test/h5diff/testfiles/h5diff_612.txt
@@ -38,6 +38,9 @@ usage: h5diff [OPTIONS] file1 file2 [obj1[ obj2]]
                            HDF5 file specified
    --vol-info-2            VOL-specific info to pass to the VOL connector used for
                            opening the second HDF5 file specified
+                           If none of the above options are used to specify a VOL for a file, then
+                           the VOL named by HDF5_VOL_CONNECTOR (or the native VOL connector,
+                           if that environment variable is unset) will be used
    --vfd-value-1           Value (ID) of the VFL driver to use for opening the
                            first HDF5 file specified
    --vfd-name-1            Name of the VFL driver to use for opening the first

--- a/tools/test/h5diff/testfiles/h5diff_615.txt
+++ b/tools/test/h5diff/testfiles/h5diff_615.txt
@@ -38,6 +38,9 @@ usage: h5diff [OPTIONS] file1 file2 [obj1[ obj2]]
                            HDF5 file specified
    --vol-info-2            VOL-specific info to pass to the VOL connector used for
                            opening the second HDF5 file specified
+                           If none of the above options are used to specify a VOL for a file, then
+                           the VOL named by HDF5_VOL_CONNECTOR (or the native VOL connector,
+                           if that environment variable is unset) will be used
    --vfd-value-1           Value (ID) of the VFL driver to use for opening the
                            first HDF5 file specified
    --vfd-name-1            Name of the VFL driver to use for opening the first

--- a/tools/test/h5diff/testfiles/h5diff_621.txt
+++ b/tools/test/h5diff/testfiles/h5diff_621.txt
@@ -38,6 +38,9 @@ usage: h5diff [OPTIONS] file1 file2 [obj1[ obj2]]
                            HDF5 file specified
    --vol-info-2            VOL-specific info to pass to the VOL connector used for
                            opening the second HDF5 file specified
+                           If none of the above options are used to specify a VOL for a file, then
+                           the VOL named by HDF5_VOL_CONNECTOR (or the native VOL connector,
+                           if that environment variable is unset) will be used
    --vfd-value-1           Value (ID) of the VFL driver to use for opening the
                            first HDF5 file specified
    --vfd-name-1            Name of the VFL driver to use for opening the first

--- a/tools/test/h5diff/testfiles/h5diff_622.txt
+++ b/tools/test/h5diff/testfiles/h5diff_622.txt
@@ -38,6 +38,9 @@ usage: h5diff [OPTIONS] file1 file2 [obj1[ obj2]]
                            HDF5 file specified
    --vol-info-2            VOL-specific info to pass to the VOL connector used for
                            opening the second HDF5 file specified
+                           If none of the above options are used to specify a VOL for a file, then
+                           the VOL named by HDF5_VOL_CONNECTOR (or the native VOL connector,
+                           if that environment variable is unset) will be used
    --vfd-value-1           Value (ID) of the VFL driver to use for opening the
                            first HDF5 file specified
    --vfd-name-1            Name of the VFL driver to use for opening the first

--- a/tools/test/h5diff/testfiles/h5diff_623.txt
+++ b/tools/test/h5diff/testfiles/h5diff_623.txt
@@ -38,6 +38,9 @@ usage: h5diff [OPTIONS] file1 file2 [obj1[ obj2]]
                            HDF5 file specified
    --vol-info-2            VOL-specific info to pass to the VOL connector used for
                            opening the second HDF5 file specified
+                           If none of the above options are used to specify a VOL for a file, then
+                           the VOL named by HDF5_VOL_CONNECTOR (or the native VOL connector,
+                           if that environment variable is unset) will be used
    --vfd-value-1           Value (ID) of the VFL driver to use for opening the
                            first HDF5 file specified
    --vfd-name-1            Name of the VFL driver to use for opening the first

--- a/tools/test/h5diff/testfiles/h5diff_624.txt
+++ b/tools/test/h5diff/testfiles/h5diff_624.txt
@@ -38,6 +38,9 @@ usage: h5diff [OPTIONS] file1 file2 [obj1[ obj2]]
                            HDF5 file specified
    --vol-info-2            VOL-specific info to pass to the VOL connector used for
                            opening the second HDF5 file specified
+                           If none of the above options are used to specify a VOL for a file, then
+                           the VOL named by HDF5_VOL_CONNECTOR (or the native VOL connector,
+                           if that environment variable is unset) will be used
    --vfd-value-1           Value (ID) of the VFL driver to use for opening the
                            first HDF5 file specified
    --vfd-name-1            Name of the VFL driver to use for opening the first

--- a/tools/test/misc/testfiles/h5mkgrp_help.txt
+++ b/tools/test/misc/testfiles/h5mkgrp_help.txt
@@ -11,6 +11,9 @@ usage: h5mkgrp [OPTIONS] FILE GROUP...
                          HDF5 file specified
       --vol-info         VOL-specific info to pass to the VOL connector used for
                          opening the HDF5 file specified
+                         If none of the above options are used to specify a VOL, then
+                         the VOL named by HDF5_VOL_CONNECTOR (or the native VOL connector,
+                         if that environment variable is unset) will be used
       --vfd-value        Value (ID) of the VFL driver to use for opening the
                          HDF5 file specified
       --vfd-name         Name of the VFL driver to use for opening the

--- a/tools/testfiles/h5dump-help.txt
+++ b/tools/testfiles/h5dump-help.txt
@@ -33,7 +33,8 @@ usage: h5dump [OPTIONS] files
      --vol-info           VOL-specific info to pass to the VOL connector used for
                           opening the HDF5 file specified
                           If none of the above options are used to specify a VOL, then
-                          the VOL specified by HDF5_VOL_CONNECTOR (if any) will be used.
+                          the VOL named by HDF5_VOL_CONNECTOR (or the native VOL connector,
+                          if that environment variable is unset) will be used
      --vfd-value          Value (ID) of the VFL driver to use for opening the
                           HDF5 file specified
      --vfd-name           Name of the VFL driver to use for opening the

--- a/tools/testfiles/h5dump-help.txt
+++ b/tools/testfiles/h5dump-help.txt
@@ -32,6 +32,8 @@ usage: h5dump [OPTIONS] files
                           HDF5 file specified
      --vol-info           VOL-specific info to pass to the VOL connector used for
                           opening the HDF5 file specified
+                          If none of the above options are used to specify a VOL, then
+                          the VOL specified by HDF5_VOL_CONNECTOR (if any) will be used.
      --vfd-value          Value (ID) of the VFL driver to use for opening the
                           HDF5 file specified
      --vfd-name           Name of the VFL driver to use for opening the

--- a/tools/testfiles/help-1.ls
+++ b/tools/testfiles/help-1.ls
@@ -52,6 +52,9 @@ usage: h5ls [OPTIONS] file[/OBJECT] [file[/[OBJECT]...]
                    HDF5 file specified
    --vol-info      VOL-specific info to pass to the VOL connector used for
                    opening the HDF5 file specified
+                   If none of the above options are used to specify a VOL, then
+                   the VOL named by HDF5_VOL_CONNECTOR (or the native VOL connector,
+                   if that environment variable is unset) will be used
    --vfd-value     Value (ID) of the VFL driver to use for opening the
                    HDF5 file specified
    --vfd-name      Name of the VFL driver to use for opening the

--- a/tools/testfiles/help-2.ls
+++ b/tools/testfiles/help-2.ls
@@ -52,6 +52,9 @@ usage: h5ls [OPTIONS] file[/OBJECT] [file[/[OBJECT]...]
                    HDF5 file specified
    --vol-info      VOL-specific info to pass to the VOL connector used for
                    opening the HDF5 file specified
+                   If none of the above options are used to specify a VOL, then
+                   the VOL named by HDF5_VOL_CONNECTOR (or the native VOL connector,
+                   if that environment variable is unset) will be used
    --vfd-value     Value (ID) of the VFL driver to use for opening the
                    HDF5 file specified
    --vfd-name      Name of the VFL driver to use for opening the

--- a/tools/testfiles/help-3.ls
+++ b/tools/testfiles/help-3.ls
@@ -52,6 +52,9 @@ usage: h5ls [OPTIONS] file[/OBJECT] [file[/[OBJECT]...]
                    HDF5 file specified
    --vol-info      VOL-specific info to pass to the VOL connector used for
                    opening the HDF5 file specified
+                   If none of the above options are used to specify a VOL, then
+                   the VOL named by HDF5_VOL_CONNECTOR (or the native VOL connector,
+                   if that environment variable is unset) will be used
    --vfd-value     Value (ID) of the VFL driver to use for opening the
                    HDF5 file specified
    --vfd-name      Name of the VFL driver to use for opening the

--- a/tools/testfiles/pbits/tnofilename-with-packed-bits.ddl
+++ b/tools/testfiles/pbits/tnofilename-with-packed-bits.ddl
@@ -33,7 +33,8 @@ usage: h5dump [OPTIONS] files
      --vol-info           VOL-specific info to pass to the VOL connector used for
                           opening the HDF5 file specified
                           If none of the above options are used to specify a VOL, then
-                          the VOL specified by HDF5_VOL_CONNECTOR (if any) will be used.
+                          the VOL named by HDF5_VOL_CONNECTOR (or the native VOL connector,
+                          if that environment variable is unset) will be used
      --vfd-value          Value (ID) of the VFL driver to use for opening the
                           HDF5 file specified
      --vfd-name           Name of the VFL driver to use for opening the

--- a/tools/testfiles/pbits/tnofilename-with-packed-bits.ddl
+++ b/tools/testfiles/pbits/tnofilename-with-packed-bits.ddl
@@ -32,6 +32,8 @@ usage: h5dump [OPTIONS] files
                           HDF5 file specified
      --vol-info           VOL-specific info to pass to the VOL connector used for
                           opening the HDF5 file specified
+                          If none of the above options are used to specify a VOL, then
+                          the VOL specified by HDF5_VOL_CONNECTOR (if any) will be used.
      --vfd-value          Value (ID) of the VFL driver to use for opening the
                           HDF5 file specified
      --vfd-name           Name of the VFL driver to use for opening the

--- a/tools/testfiles/pbits/tpbitsIncomplete.ddl
+++ b/tools/testfiles/pbits/tpbitsIncomplete.ddl
@@ -33,7 +33,8 @@ usage: h5dump [OPTIONS] files
      --vol-info           VOL-specific info to pass to the VOL connector used for
                           opening the HDF5 file specified
                           If none of the above options are used to specify a VOL, then
-                          the VOL specified by HDF5_VOL_CONNECTOR (if any) will be used.
+                          the VOL named by HDF5_VOL_CONNECTOR (or the native VOL connector,
+                          if that environment variable is unset) will be used
      --vfd-value          Value (ID) of the VFL driver to use for opening the
                           HDF5 file specified
      --vfd-name           Name of the VFL driver to use for opening the

--- a/tools/testfiles/pbits/tpbitsIncomplete.ddl
+++ b/tools/testfiles/pbits/tpbitsIncomplete.ddl
@@ -32,6 +32,8 @@ usage: h5dump [OPTIONS] files
                           HDF5 file specified
      --vol-info           VOL-specific info to pass to the VOL connector used for
                           opening the HDF5 file specified
+                          If none of the above options are used to specify a VOL, then
+                          the VOL specified by HDF5_VOL_CONNECTOR (if any) will be used.
      --vfd-value          Value (ID) of the VFL driver to use for opening the
                           HDF5 file specified
      --vfd-name           Name of the VFL driver to use for opening the

--- a/tools/testfiles/pbits/tpbitsLengthExceeded.ddl
+++ b/tools/testfiles/pbits/tpbitsLengthExceeded.ddl
@@ -33,7 +33,8 @@ usage: h5dump [OPTIONS] files
      --vol-info           VOL-specific info to pass to the VOL connector used for
                           opening the HDF5 file specified
                           If none of the above options are used to specify a VOL, then
-                          the VOL specified by HDF5_VOL_CONNECTOR (if any) will be used.
+                          the VOL named by HDF5_VOL_CONNECTOR (or the native VOL connector,
+                          if that environment variable is unset) will be used
      --vfd-value          Value (ID) of the VFL driver to use for opening the
                           HDF5 file specified
      --vfd-name           Name of the VFL driver to use for opening the

--- a/tools/testfiles/pbits/tpbitsLengthExceeded.ddl
+++ b/tools/testfiles/pbits/tpbitsLengthExceeded.ddl
@@ -32,6 +32,8 @@ usage: h5dump [OPTIONS] files
                           HDF5 file specified
      --vol-info           VOL-specific info to pass to the VOL connector used for
                           opening the HDF5 file specified
+                          If none of the above options are used to specify a VOL, then
+                          the VOL specified by HDF5_VOL_CONNECTOR (if any) will be used.
      --vfd-value          Value (ID) of the VFL driver to use for opening the
                           HDF5 file specified
      --vfd-name           Name of the VFL driver to use for opening the

--- a/tools/testfiles/pbits/tpbitsLengthPositive.ddl
+++ b/tools/testfiles/pbits/tpbitsLengthPositive.ddl
@@ -33,7 +33,8 @@ usage: h5dump [OPTIONS] files
      --vol-info           VOL-specific info to pass to the VOL connector used for
                           opening the HDF5 file specified
                           If none of the above options are used to specify a VOL, then
-                          the VOL specified by HDF5_VOL_CONNECTOR (if any) will be used.
+                          the VOL named by HDF5_VOL_CONNECTOR (or the native VOL connector,
+                          if that environment variable is unset) will be used
      --vfd-value          Value (ID) of the VFL driver to use for opening the
                           HDF5 file specified
      --vfd-name           Name of the VFL driver to use for opening the

--- a/tools/testfiles/pbits/tpbitsLengthPositive.ddl
+++ b/tools/testfiles/pbits/tpbitsLengthPositive.ddl
@@ -32,6 +32,8 @@ usage: h5dump [OPTIONS] files
                           HDF5 file specified
      --vol-info           VOL-specific info to pass to the VOL connector used for
                           opening the HDF5 file specified
+                          If none of the above options are used to specify a VOL, then
+                          the VOL specified by HDF5_VOL_CONNECTOR (if any) will be used.
      --vfd-value          Value (ID) of the VFL driver to use for opening the
                           HDF5 file specified
      --vfd-name           Name of the VFL driver to use for opening the

--- a/tools/testfiles/pbits/tpbitsMaxExceeded.ddl
+++ b/tools/testfiles/pbits/tpbitsMaxExceeded.ddl
@@ -33,7 +33,8 @@ usage: h5dump [OPTIONS] files
      --vol-info           VOL-specific info to pass to the VOL connector used for
                           opening the HDF5 file specified
                           If none of the above options are used to specify a VOL, then
-                          the VOL specified by HDF5_VOL_CONNECTOR (if any) will be used.
+                          the VOL named by HDF5_VOL_CONNECTOR (or the native VOL connector,
+                          if that environment variable is unset) will be used
      --vfd-value          Value (ID) of the VFL driver to use for opening the
                           HDF5 file specified
      --vfd-name           Name of the VFL driver to use for opening the

--- a/tools/testfiles/pbits/tpbitsMaxExceeded.ddl
+++ b/tools/testfiles/pbits/tpbitsMaxExceeded.ddl
@@ -32,6 +32,8 @@ usage: h5dump [OPTIONS] files
                           HDF5 file specified
      --vol-info           VOL-specific info to pass to the VOL connector used for
                           opening the HDF5 file specified
+                          If none of the above options are used to specify a VOL, then
+                          the VOL specified by HDF5_VOL_CONNECTOR (if any) will be used.
      --vfd-value          Value (ID) of the VFL driver to use for opening the
                           HDF5 file specified
      --vfd-name           Name of the VFL driver to use for opening the

--- a/tools/testfiles/pbits/tpbitsOffsetExceeded.ddl
+++ b/tools/testfiles/pbits/tpbitsOffsetExceeded.ddl
@@ -33,7 +33,8 @@ usage: h5dump [OPTIONS] files
      --vol-info           VOL-specific info to pass to the VOL connector used for
                           opening the HDF5 file specified
                           If none of the above options are used to specify a VOL, then
-                          the VOL specified by HDF5_VOL_CONNECTOR (if any) will be used.
+                          the VOL named by HDF5_VOL_CONNECTOR (or the native VOL connector,
+                          if that environment variable is unset) will be used
      --vfd-value          Value (ID) of the VFL driver to use for opening the
                           HDF5 file specified
      --vfd-name           Name of the VFL driver to use for opening the

--- a/tools/testfiles/pbits/tpbitsOffsetExceeded.ddl
+++ b/tools/testfiles/pbits/tpbitsOffsetExceeded.ddl
@@ -32,6 +32,8 @@ usage: h5dump [OPTIONS] files
                           HDF5 file specified
      --vol-info           VOL-specific info to pass to the VOL connector used for
                           opening the HDF5 file specified
+                          If none of the above options are used to specify a VOL, then
+                          the VOL specified by HDF5_VOL_CONNECTOR (if any) will be used.
      --vfd-value          Value (ID) of the VFL driver to use for opening the
                           HDF5 file specified
      --vfd-name           Name of the VFL driver to use for opening the

--- a/tools/testfiles/pbits/tpbitsOffsetNegative.ddl
+++ b/tools/testfiles/pbits/tpbitsOffsetNegative.ddl
@@ -33,7 +33,8 @@ usage: h5dump [OPTIONS] files
      --vol-info           VOL-specific info to pass to the VOL connector used for
                           opening the HDF5 file specified
                           If none of the above options are used to specify a VOL, then
-                          the VOL specified by HDF5_VOL_CONNECTOR (if any) will be used.
+                          the VOL named by HDF5_VOL_CONNECTOR (or the native VOL connector,
+                          if that environment variable is unset) will be used
      --vfd-value          Value (ID) of the VFL driver to use for opening the
                           HDF5 file specified
      --vfd-name           Name of the VFL driver to use for opening the

--- a/tools/testfiles/pbits/tpbitsOffsetNegative.ddl
+++ b/tools/testfiles/pbits/tpbitsOffsetNegative.ddl
@@ -32,6 +32,8 @@ usage: h5dump [OPTIONS] files
                           HDF5 file specified
      --vol-info           VOL-specific info to pass to the VOL connector used for
                           opening the HDF5 file specified
+                          If none of the above options are used to specify a VOL, then
+                          the VOL specified by HDF5_VOL_CONNECTOR (if any) will be used.
      --vfd-value          Value (ID) of the VFL driver to use for opening the
                           HDF5 file specified
      --vfd-name           Name of the VFL driver to use for opening the

--- a/tools/testfiles/textlinksrc-nodangle-1.ls
+++ b/tools/testfiles/textlinksrc-nodangle-1.ls
@@ -52,6 +52,9 @@ usage: h5ls [OPTIONS] file[/OBJECT] [file[/[OBJECT]...]
                    HDF5 file specified
    --vol-info      VOL-specific info to pass to the VOL connector used for
                    opening the HDF5 file specified
+                   If none of the above options are used to specify a VOL, then
+                   the VOL named by HDF5_VOL_CONNECTOR (or the native VOL connector,
+                   if that environment variable is unset) will be used
    --vfd-value     Value (ID) of the VFL driver to use for opening the
                    HDF5 file specified
    --vfd-name      Name of the VFL driver to use for opening the

--- a/tools/testfiles/tgroup-1.ls
+++ b/tools/testfiles/tgroup-1.ls
@@ -52,6 +52,9 @@ usage: h5ls [OPTIONS] file[/OBJECT] [file[/[OBJECT]...]
                    HDF5 file specified
    --vol-info      VOL-specific info to pass to the VOL connector used for
                    opening the HDF5 file specified
+                   If none of the above options are used to specify a VOL, then
+                   the VOL named by HDF5_VOL_CONNECTOR (or the native VOL connector,
+                   if that environment variable is unset) will be used
    --vfd-value     Value (ID) of the VFL driver to use for opening the
                    HDF5 file specified
    --vfd-name      Name of the VFL driver to use for opening the


### PR DESCRIPTION
This clarifies that it defaults to using the VOL specified by the environment variable, as discussed in #2645.

Close #2645.