### PR TITLE
Remove H5F_evict_tagged_metadata()

### DIFF
--- a/src/H5AC.c
+++ b/src/H5AC.c
@@ -2308,14 +2308,15 @@ done:
 /*------------------------------------------------------------------------------
  * Function:    H5AC_evict_tagged_metadata()
  *
- * Purpose:     Wrapper for cache level function which flushes all metadata
+ * Purpose:     Wrapper for cache level function which evicts all metadata
  *              that contains the specific tag.
  *
+ *              The match_global parameter determines if the global file
+ *              data (e.g., global heaps, shared object header messages)
+ *              should be checked. This is false when closing objects
+ *              and true when flushing.
+ *
  * Return:      SUCCEED on success, FAIL otherwise.
- *
- * Programmer:  Mike McGreevy
- *              May 19, 2010
- *
  *------------------------------------------------------------------------------
  */
 herr_t

--- a/src/H5Fio.c
+++ b/src/H5Fio.c
@@ -442,33 +442,6 @@ done:
 } /* end H5F_flush_tagged_metadata */
 
 /*-------------------------------------------------------------------------
- * Function:    H5F_evict_tagged_metadata
- *
- * Purpose:     Evicts metadata from the cache with specified tag.
- *
- * Return:      Non-negative on success/Negative on failure
- *
- * Programmer:	Mike McGreevy
- *              September 9, 2010
- *
- *-------------------------------------------------------------------------
- */
-herr_t
-H5F_evict_tagged_metadata(H5F_t *f, haddr_t tag)
-{
-    herr_t ret_value = SUCCEED;
-
-    FUNC_ENTER_NOAPI(FAIL)
-
-    /* Evict the object's metadata */
-    if (H5AC_evict_tagged_metadata(f, tag, TRUE) < 0)
-        HGOTO_ERROR(H5E_CACHE, H5E_CANTEXPUNGE, FAIL, "unable to evict tagged metadata")
-
-done:
-    FUNC_LEAVE_NOAPI(ret_value)
-} /* end H5F_evict_tagged_metadata */
-
-/*-------------------------------------------------------------------------
  * Function:    H5F__evict_cache_entries
  *
  * Purpose:     To evict all cache entries except the pinned superblock entry

--- a/src/H5Fprivate.h
+++ b/src/H5Fprivate.h
@@ -604,7 +604,6 @@ H5_DLL herr_t H5F_shared_vector_write(H5F_shared_t *f_sh, uint32_t count, H5FD_m
 
 /* Functions that flush or evict */
 H5_DLL herr_t H5F_flush_tagged_metadata(H5F_t *f, haddr_t tag);
-H5_DLL herr_t H5F_evict_tagged_metadata(H5F_t *f, haddr_t tag);
 
 /* Functions that verify a piece of metadata with checksum */
 H5_DLL herr_t H5F_get_checksums(const uint8_t *buf, size_t chk_size, uint32_t *s_chksum, uint32_t *c_chksum);

--- a/src/H5Fsuper.c
+++ b/src/H5Fsuper.c
@@ -568,22 +568,21 @@ H5F__super_read(H5F_t *f, H5P_genplist_t *fa_plist, hbool_t initial_read)
      * Make sure that the data is not truncated. One case where this is
      * possible is if the first file of a family of files was opened
      * individually.
-     */
-    /* Can skip this test when it is not the initial file open--
-     * H5F__super_read() call from H5F_evict_tagged_metadata() for
-     * refreshing object.
+     *
+     * Can skip this test when it is not the initial file open.
+     *
      * When flushing file buffers and fractal heap is involved,
      * the library will allocate actual space for tmp addresses
      * via the file layer.  The aggregator allocates a block,
      * thus the eoa might be greater than eof.
      * Note: the aggregator is changed again after being reset
      * earlier before H5AC_flush due to allocation of tmp addresses.
-     */
-    /* The EOF check must be skipped when the file is opened for SWMR read,
+     *
+     * The EOF check must be skipped when the file is opened for SWMR read,
      * as the file can appear truncated if only part of it has been
      * been flushed to disk by the SWMR writer process.
-     */
-    /* The EOF check is also skipped when the private property
+     *
+     * The EOF check is also skipped when the private property
      * H5F_ACS_SKIP_EOF_CHECK_NAME exists in the fapl.
      * This property is enabled by the tool h5clear with these
      * two options: (1) --filesize (2) --increment
@@ -604,7 +603,7 @@ H5F__super_read(H5F_t *f, H5P_genplist_t *fa_plist, hbool_t initial_read)
             (sblock->status_flags & H5F_SUPER_WRITE_ACCESS) &&
             sblock->super_vers >= HDF5_SUPERBLOCK_VERSION_3)
             skip_eof_check = TRUE;
-    } /* end if */
+    }
     if (!skip_eof_check && initial_read) {
         if (HADDR_UNDEF == (eof = H5FD_get_eof(f->shared->lf, H5FD_MEM_DEFAULT)))
             HGOTO_ERROR(H5E_FILE, H5E_CANTGET, FAIL, "unable to determine file size")
@@ -615,7 +614,7 @@ H5F__super_read(H5F_t *f, H5P_genplist_t *fa_plist, hbool_t initial_read)
                         "truncated file: eof = %llu, sblock->base_addr = %llu, stored_eof = %llu",
                         (unsigned long long)eof, (unsigned long long)sblock->base_addr,
                         (unsigned long long)udata.stored_eof)
-    } /* end if */
+    }
 
     /*
      * Tell the file driver how much address space has already been

--- a/src/H5Oflush.c
+++ b/src/H5Oflush.c
@@ -335,7 +335,7 @@ H5O__refresh_metadata_close(H5O_loc_t *oloc, H5G_loc_t *obj_loc, hid_t oid)
         HGOTO_ERROR(H5E_OHDR, H5E_CANTFLUSH, FAIL, "unable to flush tagged metadata")
 
     /* Evict the object's tagged metadata */
-    if (H5F_evict_tagged_metadata(file, tag) < 0)
+    if (H5AC_evict_tagged_metadata(file, tag, TRUE) < 0)
         HGOTO_ERROR(H5E_OHDR, H5E_CANTFLUSH, FAIL, "unable to evict metadata")
 
     /* Re-cork object with tag */


### PR DESCRIPTION
The rest of the library just calls H5AC_evict_tagged_metadata() directly.