### PR TITLE
Rename HDsystem() to system()

### DIFF
--- a/c++/test/titerate.cpp
+++ b/c++/test/titerate.cpp
@@ -179,7 +179,7 @@ test_iter_group(FileAccPropList &fapl)
         check_values(lnames[NDATASETS], "HDstrdup returns NULL", __LINE__, __FILE__);
 
         /* Sort the dataset names */
-        HDqsort(lnames, NDATASETS + 2, sizeof(char *), iter_strcmp);
+        qsort(lnames, NDATASETS + 2, sizeof(char *), iter_strcmp);
 
         /* Iterate through the datasets in the root group in various ways */
 

--- a/src/H5private.h
+++ b/src/H5private.h
@@ -1173,9 +1173,6 @@ H5_DLL H5_ATTR_CONST int Nflock(int fd, int operation);
 #ifndef HDsymlink
 #define HDsymlink(F1, F2) symlink(F1, F2)
 #endif
-#ifndef HDsystem
-#define HDsystem(S) system(S)
-#endif
 #ifndef HDtime
 #define HDtime(T) time(T)
 #endif

--- a/tools/test/perform/iopipe.c
+++ b/tools/test/perform/iopipe.c
@@ -99,10 +99,10 @@ synchronize(void)
 #else
     int H5_ATTR_NDEBUG_UNUSED status;
 
-    status = HDsystem("sync");
+    status = system("sync");
     HDassert(status >= 0);
 
-    status = HDsystem("df >/dev/null");
+    status = system("df >/dev/null");
     HDassert(status >= 0);
 #endif
 }


### PR DESCRIPTION
system() is only used in the iopipe test and the things it calls (which are POSIX-y) are protected by an ifdef.