### PR TITLE
Remove HD from protected POSIX calls

### DIFF
--- a/src/H5private.h
+++ b/src/H5private.h
@@ -614,14 +614,8 @@ typedef off_t       h5_stat_size_t;
 #ifndef HDaccess
 #define HDaccess(F, M) access(F, M)
 #endif
-#ifndef HDalarm
-#define HDalarm(N) alarm(N)
-#endif
 #ifndef HDasctime
 #define HDasctime(T) asctime(T)
-#endif
-#ifndef HDasprintf
-#define HDasprintf asprintf /*varargs*/
 #endif
 #ifndef HDatexit
 #define HDatexit(F) atexit(F)
@@ -646,9 +640,6 @@ typedef off_t       h5_stat_size_t;
 #endif
 #ifndef HDclock
 #define HDclock() clock()
-#endif
-#ifndef HDclock_gettime
-#define HDclock_gettime(CID, TS) clock_gettime(CID, TS)
 #endif
 #ifndef HDclose
 #define HDclose(F) close(F)
@@ -682,9 +673,6 @@ typedef off_t       h5_stat_size_t;
 #endif
 #ifndef HDfclose
 #define HDfclose(F) fclose(F)
-#endif
-#ifndef HDfcntl
-#define HDfcntl(F, C, ...) fcntl(F, C, __VA_ARGS__)
 #endif
 #ifndef HDfdopen
 #define HDfdopen(N, S) fdopen(N, S)
@@ -793,14 +781,8 @@ H5_DLL H5_ATTR_CONST int Nflock(int fd, int operation);
 #ifndef HDgetenv
 #define HDgetenv(S) getenv(S)
 #endif
-#ifndef HDgethostname
-#define HDgethostname(N, L) gethostname(N, L)
-#endif
 #ifndef HDgetpid
 #define HDgetpid() getpid()
-#endif
-#ifndef HDgetrusage
-#define HDgetrusage(X, S) getrusage(X, S)
 #endif
 
 /* Don't define HDgets - gets() was deprecated in C99 and removed in C11 */
@@ -1139,9 +1121,6 @@ H5_DLL H5_ATTR_CONST int Nflock(int fd, int operation);
 #endif
 #ifndef HDstrtoumax
 #define HDstrtoumax(S, R, N) strtoumax(S, R, N)
-#endif
-#ifndef HDsymlink
-#define HDsymlink(F1, F2) symlink(F1, F2)
 #endif
 #ifndef HDtime
 #define HDtime(T) time(T)

--- a/src/H5system.c
+++ b/src/H5system.c
@@ -167,7 +167,7 @@ Pflock(int fd, int operation)
     flk.l_pid    = 0; /* not used with set */
 
     /* Lock or unlock */
-    if (HDfcntl(fd, F_SETLK, &flk) < 0)
+    if (fcntl(fd, F_SETLK, &flk) < 0)
         return -1;
 
     return 0;

--- a/src/H5timer.c
+++ b/src/H5timer.c
@@ -191,7 +191,7 @@ H5_now_usec(void)
     {
         struct timespec ts;
 
-        HDclock_gettime(CLOCK_MONOTONIC, &ts);
+        clock_gettime(CLOCK_MONOTONIC, &ts);
 
         /* Cast all values in this expression to uint64_t to ensure that all intermediate
          * calculations are done in 64 bit, to prevent overflow */
@@ -240,7 +240,7 @@ H5_get_time(void)
     {
         struct timespec ts;
 
-        HDclock_gettime(CLOCK_MONOTONIC, &ts);
+        clock_gettime(CLOCK_MONOTONIC, &ts);
         ret_value = (double)ts.tv_sec + ((double)ts.tv_nsec / 1000000000.0);
     }
 #elif defined(H5_HAVE_GETTIMEOFDAY)
@@ -295,7 +295,7 @@ H5__timer_get_timevals(H5_timevals_t *times /*in,out*/)
     {
         struct rusage res;
 
-        if (HDgetrusage(RUSAGE_SELF, &res) < 0)
+        if (getrusage(RUSAGE_SELF, &res) < 0)
             return -1;
         times->system = (double)res.ru_stime.tv_sec + ((double)res.ru_stime.tv_usec / 1.0E6);
         times->user   = (double)res.ru_utime.tv_sec + ((double)res.ru_utime.tv_usec / 1.0E6);

--- a/test/h5test.c
+++ b/test/h5test.c
@@ -958,7 +958,7 @@ h5_show_hostname(void)
 
 #endif
 #ifdef H5_HAVE_GETHOSTNAME
-    if (HDgethostname(hostname, (size_t)80) < 0)
+    if (gethostname(hostname, (size_t)80) < 0)
         printf(" gethostname failed\n");
     else
         printf(" hostname=%s\n", hostname);

--- a/test/links.c
+++ b/test/links.c
@@ -12519,7 +12519,7 @@ external_symlink(const char *env_h5_drvr, hid_t fapl, hbool_t new_format)
 
     /* Create symbolic link #1 in temporary directory #1 to file #2 in temporary directory #2 */
     /* (i.e. tmp_links/sym1.h5 -> <full path to>/tmp2_links/extlinks21B.h5) */
-    if (HDsymlink(filename2b, SYMLINK1) < 0 && errno != EEXIST)
+    if (symlink(filename2b, SYMLINK1) < 0 && errno != EEXIST)
         TEST_ERROR;
 
     /* set up name for file #3 in temporary directory #2: "tmp2_links/extlinks21C" */
@@ -12533,7 +12533,7 @@ external_symlink(const char *env_h5_drvr, hid_t fapl, hbool_t new_format)
 
     /* Create symbolic link #2 in temporary directory #2 to file #4 in temporary directory #1 */
     /* (i.e. tmp2_links/sym2.h5 -> <full path to>/tmp_links/extlinks21D.h5) */
-    if (HDsymlink(filename4b, SYMLINK2) < 0 && errno != EEXIST)
+    if (symlink(filename4b, SYMLINK2) < 0 && errno != EEXIST)
         TEST_ERROR;
 
     /* set up name for file #5 in temporary directory #1: "tmp_links/extlinks21E" */

--- a/test/testframe.c
+++ b/test/testframe.c
@@ -646,7 +646,7 @@ TestAlarmOn(void)
         alarm_sec = (unsigned)HDstrtoul(env_val, (char **)NULL, 10);
 
     /* Set the number of seconds before alarm goes off */
-    HDalarm((unsigned)alarm_sec);
+    alarm((unsigned)alarm_sec);
 #endif
 }
 
@@ -656,6 +656,6 @@ TestAlarmOff(void)
 {
 #ifdef H5_HAVE_ALARM
     /* Set the number of seconds to zero */
-    HDalarm(0);
+    alarm(0);
 #endif
 }

--- a/testpar/t_mpi.c
+++ b/testpar/t_mpi.c
@@ -455,7 +455,7 @@ test_mpio_1wMr(char *filename, int special_request)
     /* show the hostname so that we can tell where the processes are running */
     if (VERBOSE_DEF) {
 #ifdef H5_HAVE_GETHOSTNAME
-        if (HDgethostname(hostname, sizeof(hostname)) < 0) {
+        if (gethostname(hostname, sizeof(hostname)) < 0) {
             printf("gethostname failed\n");
             hostname[0] = '\0';
         }

--- a/tools/lib/h5diff.c
+++ b/tools/lib/h5diff.c
@@ -706,7 +706,7 @@ h5diff(const char *fname1, const char *fname2, const char *objname1, const char 
         if (HDstrncmp(objname1, "/", 1) != 0) {
 #ifdef H5_HAVE_ASPRINTF
             /* Use the asprintf() routine, since it does what we're trying to do below */
-            if (HDasprintf(&obj1fullname, "/%s", objname1) < 0)
+            if (asprintf(&obj1fullname, "/%s", objname1) < 0)
                 H5TOOLS_GOTO_ERROR(H5DIFF_ERR, "name buffer allocation failed");
 #else  /* H5_HAVE_ASPRINTF */
             /* (malloc 2 more for "/" and end-of-line) */
@@ -725,7 +725,7 @@ h5diff(const char *fname1, const char *fname2, const char *objname1, const char 
         if (HDstrncmp(objname2, "/", 1) != 0) {
 #ifdef H5_HAVE_ASPRINTF
             /* Use the asprintf() routine, since it does what we're trying to do below */
-            if (HDasprintf(&obj2fullname, "/%s", objname2) < 0)
+            if (asprintf(&obj2fullname, "/%s", objname2) < 0)
                 H5TOOLS_GOTO_ERROR(H5DIFF_ERR, "name buffer allocation failed");
 #else  /* H5_HAVE_ASPRINTF */
             /* (malloc 2 more for "/" and end-of-line) */
@@ -1182,7 +1182,7 @@ diff_match(hid_t file1_id, const char *grp1, trav_info_t *info1, hid_t file2_id,
                 /* make full path for obj1 */
 #ifdef H5_HAVE_ASPRINTF
                 /* Use the asprintf() routine, since it does what we're trying to do below */
-                if (HDasprintf(&obj1_fullpath, "%s%s", grp1_path, table->objs[i].name) < 0) {
+                if (asprintf(&obj1_fullpath, "%s%s", grp1_path, table->objs[i].name) < 0) {
                     H5TOOLS_ERROR(H5DIFF_ERR, "name buffer allocation failed");
                 }
 #else  /* H5_HAVE_ASPRINTF */
@@ -1200,7 +1200,7 @@ diff_match(hid_t file1_id, const char *grp1, trav_info_t *info1, hid_t file2_id,
                 /* make full path for obj2 */
 #ifdef H5_HAVE_ASPRINTF
                 /* Use the asprintf() routine, since it does what we're trying to do below */
-                if (HDasprintf(&obj2_fullpath, "%s%s", grp2_path, table->objs[i].name) < 0) {
+                if (asprintf(&obj2_fullpath, "%s%s", grp2_path, table->objs[i].name) < 0) {
                     H5TOOLS_ERROR(H5DIFF_ERR, "name buffer allocation failed");
                 }
 #else  /* H5_HAVE_ASPRINTF */

--- a/tools/test/perform/iopipe.c
+++ b/tools/test/perform/iopipe.c
@@ -167,7 +167,7 @@ main(void)
     /* Fill raw */
     synchronize();
 #ifdef H5_HAVE_GETRUSAGE
-    HDgetrusage(RUSAGE_SELF, &r_start);
+    getrusage(RUSAGE_SELF, &r_start);
 #endif
     t_start = H5_get_time();
     fprintf(stderr, HEADING, "fill raw");
@@ -177,7 +177,7 @@ main(void)
         HDmemset(the_data, 0xAA, (size_t)(size[0] * size[1]));
     }
 #ifdef H5_HAVE_GETRUSAGE
-    HDgetrusage(RUSAGE_SELF, &r_stop);
+    getrusage(RUSAGE_SELF, &r_stop);
 #endif
     t_stop = H5_get_time();
     HDputc('\n', stderr);
@@ -190,7 +190,7 @@ main(void)
     /* Fill hdf5 */
     synchronize();
 #ifdef H5_HAVE_GETRUSAGE
-    HDgetrusage(RUSAGE_SELF, &r_start);
+    getrusage(RUSAGE_SELF, &r_start);
 #endif
     t_start = H5_get_time();
     fprintf(stderr, HEADING, "fill hdf5");
@@ -201,7 +201,7 @@ main(void)
         assert(status >= 0);
     }
 #ifdef H5_HAVE_GETRUSAGE
-    HDgetrusage(RUSAGE_SELF, &r_stop);
+    getrusage(RUSAGE_SELF, &r_stop);
 #endif
     t_stop = H5_get_time();
     HDputc('\n', stderr);
@@ -214,7 +214,7 @@ main(void)
     /* Write the raw dataset */
     synchronize();
 #ifdef H5_HAVE_GETRUSAGE
-    HDgetrusage(RUSAGE_SELF, &r_start);
+    getrusage(RUSAGE_SELF, &r_start);
 #endif
     t_start = H5_get_time();
     fprintf(stderr, HEADING, "out raw");
@@ -227,7 +227,7 @@ main(void)
         assert(n >= 0 && (size_t)n == (size[0] * size[1]));
     }
 #ifdef H5_HAVE_GETRUSAGE
-    HDgetrusage(RUSAGE_SELF, &r_stop);
+    getrusage(RUSAGE_SELF, &r_stop);
 #endif
     t_stop = H5_get_time();
     HDputc('\n', stderr);
@@ -240,7 +240,7 @@ main(void)
     /* Write the hdf5 dataset */
     synchronize();
 #ifdef H5_HAVE_GETRUSAGE
-    HDgetrusage(RUSAGE_SELF, &r_start);
+    getrusage(RUSAGE_SELF, &r_start);
 #endif
     t_start = H5_get_time();
     fprintf(stderr, HEADING, "out hdf5");
@@ -251,7 +251,7 @@ main(void)
         assert(status >= 0);
     }
 #ifdef H5_HAVE_GETRUSAGE
-    HDgetrusage(RUSAGE_SELF, &r_stop);
+    getrusage(RUSAGE_SELF, &r_stop);
 #endif
     t_stop = H5_get_time();
     HDputc('\n', stderr);
@@ -264,7 +264,7 @@ main(void)
     /* Read the raw dataset */
     synchronize();
 #ifdef H5_HAVE_GETRUSAGE
-    HDgetrusage(RUSAGE_SELF, &r_start);
+    getrusage(RUSAGE_SELF, &r_start);
 #endif
     t_start = H5_get_time();
     fprintf(stderr, HEADING, "in raw");
@@ -277,7 +277,7 @@ main(void)
         assert(n >= 0 && (size_t)n == (size[0] * size[1]));
     }
 #ifdef H5_HAVE_GETRUSAGE
-    HDgetrusage(RUSAGE_SELF, &r_stop);
+    getrusage(RUSAGE_SELF, &r_stop);
 #endif
     t_stop = H5_get_time();
     HDputc('\n', stderr);
@@ -290,7 +290,7 @@ main(void)
     /* Read the hdf5 dataset */
     synchronize();
 #ifdef H5_HAVE_GETRUSAGE
-    HDgetrusage(RUSAGE_SELF, &r_start);
+    getrusage(RUSAGE_SELF, &r_start);
 #endif
     t_start = H5_get_time();
     fprintf(stderr, HEADING, "in hdf5");
@@ -301,7 +301,7 @@ main(void)
         assert(status >= 0);
     }
 #ifdef H5_HAVE_GETRUSAGE
-    HDgetrusage(RUSAGE_SELF, &r_stop);
+    getrusage(RUSAGE_SELF, &r_stop);
 #endif
     t_stop = H5_get_time();
     HDputc('\n', stderr);
@@ -319,7 +319,7 @@ main(void)
     assert(status >= 0);
     synchronize();
 #ifdef H5_HAVE_GETRUSAGE
-    HDgetrusage(RUSAGE_SELF, &r_start);
+    getrusage(RUSAGE_SELF, &r_start);
 #endif
     t_start = H5_get_time();
     fprintf(stderr, HEADING, "in hdf5 partial");
@@ -330,7 +330,7 @@ main(void)
         assert(status >= 0);
     }
 #ifdef H5_HAVE_GETRUSAGE
-    HDgetrusage(RUSAGE_SELF, &r_stop);
+    getrusage(RUSAGE_SELF, &r_stop);
 #endif
     t_stop = H5_get_time();
     HDputc('\n', stderr);


### PR DESCRIPTION
These calls are non-C99 but protected by ifdefs and have no Windows equivalents:
* HDalarm
* HDasprintf
* HDclock_gettime
* HDfcntl
* HDgethostname
* HDgetrusage
* HDsymlink