### PR TITLE
Remove some "Programmer" comments

### DIFF
--- a/src/H5B2stat.c
+++ b/src/H5B2stat.c
@@ -10,9 +10,7 @@
  * help@hdfgroup.org.                                                        *
  * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 
-/* Programmer:  Quincey Koziol
- *              Monday, March  6, 2006
- *
+/*
  * Purpose:     v2 B-tree metadata statistics functions.
  *
  */

--- a/src/H5B2test.c
+++ b/src/H5B2test.c
@@ -10,8 +10,7 @@
  * help@hdfgroup.org.                                                        *
  * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 
-/* Programmer:  Quincey Koziol
- *
+/*
  * Purpose:     v2 B-tree testing functions
  *
  */

--- a/src/H5Dearray.c
+++ b/src/H5Dearray.c
@@ -10,14 +10,11 @@
  * help@hdfgroup.org.                                                        *
  * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 
-/* Programmer:      Quincey Koziol
- *                  Tuesday, January 27, 2009
- *
+/*
  * Purpose:     Extensible array indexed (chunked) I/O functions.  The chunks
  *              are given a single-dimensional index which is used as the
  *              offset in an extensible array that maps a chunk coordinate to
  *              a disk address.
- *
  */
 
 /****************/

--- a/src/H5Dfarray.c
+++ b/src/H5Dfarray.c
@@ -10,13 +10,10 @@
  * help@hdfgroup.org.                                                        *
  * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 
-/* Programmer:  Vailin Choi
- *              Thursday, April 30, 2009
- *
+/*
  * Purpose:     Fixed array indexed (chunked) I/O functions.
  *              The chunk coordinate is mapped as an index into an array of
  *              disk addresses for the chunks.
- *
  */
 
 /****************/

--- a/src/H5Dnone.c
+++ b/src/H5Dnone.c
@@ -10,17 +10,16 @@
  * help@hdfgroup.org.                                                        *
  * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 
-/* Programmer: 	Vailin Choi
- *	       	September 2010
- *
+/*
  * Purpose:	Implicit (Non Index) chunked I/O functions.
- *		This is used when the dataset is:
- *			extendible but with fixed max. dims
- *			with early allocation
- *			without filter
- *		The chunk coordinate is mapped into the actual disk addresses
- *		for the chunk without indexing.
  *
+ *          This is used when the dataset is:
+ *			- extendible but with fixed max. dims
+ *			- with early allocation
+ *			- without filter
+ *
+ *          The chunk coordinate is mapped into the actual disk addresses
+ *          for the chunk without indexing.
  */
 
 /****************/

--- a/src/H5Dselect.c
+++ b/src/H5Dselect.c
@@ -10,9 +10,7 @@
  * help@hdfgroup.org.                                                        *
  * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 
-/* Programmer:  Quincey Koziol
- *              Thursday, September 30, 2004
- *
+/*
  * Purpose:	Dataspace I/O functions.
  */
 

--- a/src/H5Dsingle.c
+++ b/src/H5Dsingle.c
@@ -10,15 +10,12 @@
  * help@hdfgroup.org.                                                        *
  * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 
-/* Programmer: 	Vailin Choi
- *	       	May 2011; updated 10/2015
- *
- * Purpose:	Single Chunk I/O functions.
- *		This is used when the dataset has only 1 chunk (with or without filter):
- *			cur_dims[] is equal to max_dims[] is equal to the chunk dims[]
- *		non-filter chunk record: [address of the chunk]
- *		filtered chunk record: 	[address of the chunk, chunk size, filter mask]
- *
+/*
+ * Purpose: Single Chunk I/O functions.
+ *          This is used when the dataset has only 1 chunk (with or without filter):
+ *          cur_dims[] is equal to max_dims[] is equal to the chunk dims[]
+ *          non-filter chunk record: [address of the chunk]
+ *          filtered chunk record: 	[address of the chunk, chunk size, filter mask]
  */
 
 /****************/

--- a/src/H5Dtest.c
+++ b/src/H5Dtest.c
@@ -10,9 +10,7 @@
  * help@hdfgroup.org.                                                        *
  * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 
-/* Programmer:  Quincey Koziol
- *              Thursday, May 27, 2004
- *
+/*
  * Purpose:	Dataset testing functions.
  */
 

--- a/src/H5EAtest.c
+++ b/src/H5EAtest.c
@@ -10,9 +10,7 @@
  * help@hdfgroup.org.                                                        *
  * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 
-/* Programmer:  Quincey Koziol
- *              Thursday, August 28, 2008
- *
+/*
  * Purpose:	Extensible array testing functions.
  *
  */

--- a/src/H5FDstdio.c
+++ b/src/H5FDstdio.c
@@ -10,9 +10,7 @@
  * help@hdfgroup.org.                                                        *
  * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 
-/* Programmer:  Robb Matzke
- *              Wednesday, October 22, 1997
- *
+/*
  * Purpose: The C STDIO virtual file driver which only uses calls from stdio.h.
  *          This also serves as an example of coding a simple file driver,
  *          therefore, it should not use any non-public definitions.
@@ -20,6 +18,7 @@
  * NOTE:    This driver is not as well tested as the standard SEC2 driver
  *          and is not intended for production use!
  */
+
 #include <assert.h>
 #include <errno.h>
 #include <stdio.h>

--- a/src/H5Fdbg.c
+++ b/src/H5Fdbg.c
@@ -10,9 +10,7 @@
  * help@hdfgroup.org.                                                        *
  * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 
-/* Programmer:  Quincey Koziol
- *              Wednesday, July 9, 2003
- *
+/*
  * Purpose:	File object debugging functions.
  */
 

--- a/src/H5Gstab.c
+++ b/src/H5Gstab.c
@@ -10,11 +10,6 @@
  * help@hdfgroup.org.                                                        *
  * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 
-/* Programmer: Robb Matzke
- *	       Friday, September 19, 1997
- *
- */
-
 /****************/
 /* Module Setup */
 /****************/

--- a/src/H5Gtest.c
+++ b/src/H5Gtest.c
@@ -10,9 +10,7 @@
  * help@hdfgroup.org.                                                        *
  * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 
-/* Programmer:  Quincey Koziol
- *              Monday, October 17, 2005
- *
+/*
  * Purpose:	Group testing functions.
  */
 

--- a/src/H5HFstat.c
+++ b/src/H5HFstat.c
@@ -10,9 +10,7 @@
  * help@hdfgroup.org.                                                        *
  * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 
-/* Programmer:  Quincey Koziol
- *              Monday, March  6, 2006
- *
+/*
  * Purpose:	Fractal heap metadata statistics functions.
  *
  */

--- a/src/H5HFtest.c
+++ b/src/H5HFtest.c
@@ -10,9 +10,7 @@
  * help@hdfgroup.org.                                                        *
  * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 
-/* Programmer:  Quincey Koziol
- *              Thursday, February  3, 2006
- *
+/*
  * Purpose:	Fractal heap testing functions.
  *
  */

--- a/src/H5HGdbg.c
+++ b/src/H5HGdbg.c
@@ -10,9 +10,7 @@
  * help@hdfgroup.org.                                                        *
  * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 
-/* Programmer:  Quincey Koziol
- *              Wednesday, July 9, 2003
- *
+/*
  * Purpose:	Global Heap object debugging functions.
  */
 

--- a/src/H5HLdbg.c
+++ b/src/H5HLdbg.c
@@ -10,9 +10,7 @@
  * help@hdfgroup.org.                                                        *
  * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 
-/* Programmer:  Quincey Koziol
- *              Wednesday, July 9, 2003
- *
+/*
  * Purpose:     Local Heap object debugging functions.
  */
 

--- a/src/H5Obtreek.c
+++ b/src/H5Obtreek.c
@@ -10,9 +10,7 @@
  * help@hdfgroup.org.                                                        *
  * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 
-/* Programmer:  Quincey Koziol
- *              Thursday, March  1, 2007
- *
+/*
  * Purpose:	A message holding non-default v1 B-tree 'K' value
  *              information in the superblock extension.
  */

--- a/src/H5Odrvinfo.c
+++ b/src/H5Odrvinfo.c
@@ -10,11 +10,8 @@
  * help@hdfgroup.org.                                                        *
  * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 
-/* Programmer:  Quincey Koziol
- *              Thursday, March  1, 2007
- *
- * Purpose:	A message holding driver info settings
- *              in the superblock extension.
+/*
+ * Purpose: A message holding driver info settings in the superblock extension
  */
 
 #include "H5Omodule.h" /* This source code file is part of the H5O module */

--- a/src/H5Oshmesg.c
+++ b/src/H5Oshmesg.c
@@ -10,9 +10,7 @@
  * help@hdfgroup.org.                                                        *
  * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 
-/* Programmer:  James Laird
- *              Monday, January 29, 2007
- *
+/*
  * Purpose:	A message holding "implicitly shared object header message"
  *              information in the superblock extension.
  */

--- a/src/H5Otest.c
+++ b/src/H5Otest.c
@@ -10,9 +10,7 @@
  * help@hdfgroup.org.                                                        *
  * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 
-/* Programmer:  Quincey Koziol
- *              Monday, December 4, 2006
- *
+/*
  * Purpose:	Object header testing functions.
  */
 

--- a/src/H5P.c
+++ b/src/H5P.c
@@ -10,8 +10,7 @@
  * help@hdfgroup.org.                                                        *
  * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 
-/* Programmer:  Quincey Koziol
- *
+/*
  * Purpose:	Generic Property Functions
  */
 

--- a/src/H5Pencdec.c
+++ b/src/H5Pencdec.c
@@ -10,8 +10,7 @@
  * help@hdfgroup.org.                                                        *
  * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 
-/* Programmer:  Quincey Koziol
- *
+/*
  * Purpose:	Generic Property Functions
  */
 

--- a/src/H5Pint.c
+++ b/src/H5Pint.c
@@ -10,8 +10,7 @@
  * help@hdfgroup.org.                                                        *
  * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 
-/* Programmer:  Quincey Koziol
- *
+/*
  * Purpose:	Generic Property Functions
  */
 

--- a/src/H5Ptest.c
+++ b/src/H5Ptest.c
@@ -10,9 +10,7 @@
  * help@hdfgroup.org.                                                        *
  * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 
-/* Programmer:  Quincey Koziol
- *              Saturday May 31, 2003
- *
+/*
  * Purpose:	Generic Property Testing Functions
  */
 

--- a/src/H5Sselect.c
+++ b/src/H5Sselect.c
@@ -10,9 +10,7 @@
  * help@hdfgroup.org.                                                        *
  * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 
-/* Programmer:  Quincey Koziol
- *              Friday, May 29, 1998
- *
+/*
  * Purpose:	Dataspace selection functions.
  */
 

--- a/src/H5Stest.c
+++ b/src/H5Stest.c
@@ -10,9 +10,7 @@
  * help@hdfgroup.org.                                                        *
  * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 
-/* Programmer:  Quincey Koziol
- *              Saturday, May 31, 2003
- *
+/*
  * Purpose:	Dataspace selection testing functions.
  */
 

--- a/test/accum.c
+++ b/test/accum.c
@@ -10,9 +10,6 @@
  * help@hdfgroup.org.                                                        *
  * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 
-/* Programmer:  Mike McGreevy
- *              October 7, 2010
- */
 #include "h5test.h"
 
 #define H5F_FRIEND  /*suppress error about including H5Fpkg	  */

--- a/test/btree2.c
+++ b/test/btree2.c
@@ -10,9 +10,6 @@
  * help@hdfgroup.org.                                                        *
  * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 
-/* Programmer:  Quincey Koziol
- *              Tuesday, February  1, 2005
- */
 #include "h5test.h"
 
 /*

--- a/test/cache.c
+++ b/test/cache.c
@@ -10,11 +10,8 @@
  * help@hdfgroup.org.                                                        *
  * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 
-/* Programmer:  John Mainzer
- *              6/9/04
- *
- *        This file contains tests for the cache implemented in
- *        H5C.c
+/*
+ *        This file contains tests for the cache implemented in H5C.c
  */
 #include "cache_common.h"
 #include "H5MFprivate.h"

--- a/test/cache_api.c
+++ b/test/cache_api.c
@@ -10,9 +10,7 @@
  * help@hdfgroup.org.                                                        *
  * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 
-/* Programmer:  John Mainzer
- *              11/10/05
- *
+/*
  *        This file contains tests for the API calls associated
  *        with the cache implemented in H5C.c
  */

--- a/test/cache_common.c
+++ b/test/cache_common.c
@@ -10,9 +10,7 @@
  * help@hdfgroup.org.                                                        *
  * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 
-/* Programmer:  John Mainzer
- *              10/27/05
- *
+/*
  *        This file contains common code for tests of the cache
  *        implemented in H5C.c
  */

--- a/test/cache_common.h
+++ b/test/cache_common.h
@@ -10,9 +10,7 @@
  * help@hdfgroup.org.                                                        *
  * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 
-/* Programmer:  John Mainzer
- *              10/27/05
- *
+/*
  *        This file contains common #defines, type definitions, and
  *        externs for tests of the cache implemented in H5C.c
  */

--- a/test/cache_image.c
+++ b/test/cache_image.c
@@ -10,9 +10,7 @@
  * help@hdfgroup.org.                                                        *
  * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 
-/* Programmer:  John Mainzer
- *              7/13/15
- *
+/*
  *              This file contains tests specific to the cache image
  *              feature implemented in H5C.c
  */

--- a/test/cache_tagging.c
+++ b/test/cache_tagging.c
@@ -10,11 +10,10 @@
  * help@hdfgroup.org.                                                        *
  * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 
-/* Programmer:  Mike McGreevy
- *              January 25, 2010
- *
+/*
  *              This file contains tests for metadata tagging.
  */
+
 #define H5F_FRIEND /*suppress error about including H5Fpkg      */
 #define H5F_TESTING
 #include "H5Fpkg.h"

--- a/test/cork.c
+++ b/test/cork.c
@@ -10,13 +10,11 @@
  * help@hdfgroup.org.                                                        *
  * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 
-/* Programmer:  Vailin Choi
- *              Feb 20, 2014
- *
- * This file contains tests for:
- *  H5Odisable_mdc_flushes()
- *  H5Oenable_mdc_flushes()
- *  H5Oare_mdc_flushes_disabled()
+/*
+ *      This file contains tests for:
+ *          * H5Odisable_mdc_flushes()
+ *          * H5Oenable_mdc_flushes()
+ *          * H5Oare_mdc_flushes_disabled()
  */
 #include "h5test.h"
 

--- a/test/earray.c
+++ b/test/earray.c
@@ -10,9 +10,6 @@
  * help@hdfgroup.org.                                                        *
  * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 
-/* Programmer:  Quincey Koziol
- *              Tuesday, June 17, 2008
- */
 #include "h5test.h"
 
 /*

--- a/test/efc.c
+++ b/test/efc.c
@@ -10,10 +10,6 @@
  * help@hdfgroup.org.                                                        *
  * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 
-/* Programmer:  Neil Fortner
- *              December 16, 2010
- */
-
 #include "h5test.h"
 
 #define H5F_FRIEND /*suppress error about including H5Fpkg	  */

--- a/test/fheap.c
+++ b/test/fheap.c
@@ -10,9 +10,6 @@
  * help@hdfgroup.org.                                                        *
  * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 
-/* Programmer:  Quincey Koziol
- *              Friday, February 24, 2006
- */
 #include "h5test.h"
 
 /*

--- a/test/genall5.c
+++ b/test/genall5.c
@@ -10,9 +10,7 @@
  * help@hdfgroup.org.                                                        *
  * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 
-/* Programmer:  John Mainzer
- *        9/23/15
- *
+/*
  *        This file contains a heavily edited and functionally reduce
  *        version of the test code first written by Quincey in a file
  *        of the same name.

--- a/test/genall5.h
+++ b/test/genall5.h
@@ -10,11 +10,9 @@
  * help@hdfgroup.org.                                                        *
  * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 
-/* Programmer:  John Mainzer
- *              9/4/15
- *
- *              This file contains declarations of all functions defined
- *		in genall5.c
+/*
+ *      This file contains declarations of all functions defined
+ *      in genall5.c
  */
 
 void create_zoo(hid_t fid, const char *base_path, int proc_num);

--- a/test/hyperslab.c
+++ b/test/hyperslab.c
@@ -10,14 +10,12 @@
  * help@hdfgroup.org.                                                        *
  * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 
-/* Programmer:    Robb Matzke
- *        Friday, October 10, 1997
- *
- * Purpose:    Hyperslab operations are rather complex, so this file
- *        attempts to test them extensively so we can be relatively
- *        sure they really work.    We only test 1d, 2d, and 3d cases
- *        because testing general dimensionalities would require us to
- *        rewrite much of the hyperslab stuff.
+/*
+ * Purpose: Hyperslab operations are rather complex, so this file
+ *          attempts to test them extensively so we can be relatively
+ *          sure they really work.    We only test 1d, 2d, and 3d cases
+ *          because testing general dimensionalities would require us to
+ *          rewrite much of the hyperslab stuff.
  */
 #include "h5test.h"
 #include "H5VMprivate.h"

--- a/test/istore.c
+++ b/test/istore.c
@@ -10,9 +10,7 @@
  * help@hdfgroup.org.                                                        *
  * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 
-/* Programmer:    Robb Matzke
- *        Wednesday, October 15, 1997
- *
+/*
  * Purpose:    Tests various aspects of indexed raw data storage.
  */
 

--- a/test/ohdr.c
+++ b/test/ohdr.c
@@ -10,9 +10,6 @@
  * help@hdfgroup.org.                                                        *
  * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 
-/* Programmer:  Robb Matzke
- *              Tuesday, November 24, 1998
- */
 #include "h5test.h"
 
 #include "H5CXprivate.h" /* API Contexts                             */

--- a/testpar/t_cache_image.c
+++ b/testpar/t_cache_image.c
@@ -10,12 +10,11 @@
  * help@hdfgroup.org.                                                        *
  * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 
-/* Programmer:  John Mainzer
- *              7/13/15
- *
- *              This file contains tests specific to the cache image
- *        feature implemented in H5C.c
+/*
+ *      This file contains tests specific to the cache image
+ *      feature implemented in H5C.c
  */
+
 #include "testphdf5.h"
 
 #include "cache_common.h"

--- a/testpar/t_vfd.c
+++ b/testpar/t_vfd.c
@@ -10,9 +10,8 @@
  * help@hdfgroup.org.                                                        *
  * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 
-/* Programmer:  John Mainzer
- *
- *              This file is a catchall for parallel VFD tests.
+/*
+ *      This file is a catchall for parallel VFD tests.
  */
 
 #include "testphdf5.h"


### PR DESCRIPTION
These are meaningless noise.

Removes the "Programmer" lines on comment start lines:

    /* Programmer: John Smith

These complicate my sed script that will rip out the rest of the comments.