### PR TITLE
Switch parallel compression to use vector I/O

### DIFF
--- a/src/H5Dmpio.c
+++ b/src/H5Dmpio.c
@@ -5341,9 +5341,9 @@ static herr_t
 H5D__mpio_collective_filtered_vec_io(H5F_shared_t *f_sh, H5D_filtered_collective_io_info_t *chunk_list,
                                      size_t num_entries, H5D_io_op_type_t op_type)
 {
-    const void **io_wbufs    = NULL;
-    void       **io_rbufs    = NULL;
-    H5FD_mem_t  *io_types    = NULL;
+    const void **io_wbufs = NULL;
+    void       **io_rbufs = NULL;
+    H5FD_mem_t   io_types[2];
     uint32_t     iovec_count = 0;
     haddr_t     *io_addrs    = NULL;
     size_t      *io_sizes    = NULL;
@@ -5391,9 +5391,6 @@ H5D__mpio_collective_filtered_vec_io(H5F_shared_t *f_sh, H5D_filtered_collective
          * making use of H5FD_MEM_NOLIST to signal that all the memory types
          * are the same across the I/O vectors
          */
-        if (NULL == (io_types = H5MM_malloc(2 * sizeof(*io_types))))
-            HGOTO_ERROR(H5E_RESOURCE, H5E_CANTALLOC, FAIL,
-                        "couldn't allocate space for I/O memory types vector")
         io_types[0] = H5FD_MEM_DRAW;
         io_types[1] = H5FD_MEM_NOLIST;
 
@@ -5441,7 +5438,6 @@ H5D__mpio_collective_filtered_vec_io(H5F_shared_t *f_sh, H5D_filtered_collective
     }
 
 done:
-    H5MM_free(io_types);
     H5MM_free(io_wbufs);
     H5MM_free(io_rbufs);
     H5MM_free(io_sizes);

--- a/src/H5Fio.c
+++ b/src/H5Fio.c
@@ -328,8 +328,16 @@ H5F_shared_vector_read(H5F_shared_t *f_sh, uint32_t count, H5FD_mem_t types[], h
      * for now, assume the caller has done this already.
      */
 #ifndef NDEBUG
-    for (uint32_t i = 0; i < count; i++)
+    for (uint32_t i = 0; i < count; i++) {
+        /* Break early if H5FD_MEM_NOLIST was specified
+         * since a full 'count'-sized array may not
+         * have been passed for 'types'
+         */
+        if (i > 0 && types[i] == H5FD_MEM_NOLIST)
+            break;
+
         assert(types[i] != H5FD_MEM_GHEAP);
+    }
 #endif
 
     /* Pass down to file driver layer (bypass page buffer for now) */
@@ -373,8 +381,16 @@ H5F_shared_vector_write(H5F_shared_t *f_sh, uint32_t count, H5FD_mem_t types[], 
      * for now, assume the caller has done this already.
      */
 #ifndef NDEBUG
-    for (uint32_t i = 0; i < count; i++)
+    for (uint32_t i = 0; i < count; i++) {
+        /* Break early if H5FD_MEM_NOLIST was specified
+         * since a full 'count'-sized array may not
+         * have been passed for 'types'
+         */
+        if (i > 0 && types[i] == H5FD_MEM_NOLIST)
+            break;
+
         assert(types[i] != H5FD_MEM_GHEAP);
+    }
 #endif
 
     /* Pass down to file driver layer (bypass page buffer for now) */


### PR DESCRIPTION
Updates parallel compression feature to use vector I/O instead of creating and passing down MPI derived types to VFD