### PR TITLE
Fix warning in H5C__UPDATE_STATS_FOR_DIRTY_PIN macro

### DIFF
--- a/src/H5Cpkg.h
+++ b/src/H5Cpkg.h
@@ -532,7 +532,7 @@ do {                                                          \
 #else /* H5C_COLLECT_CACHE_STATS */
 
 #define H5C__RESET_CACHE_ENTRY_STATS(entry_ptr)
-#define H5C__UPDATE_STATS_FOR_DIRTY_PIN(cache_ptr, entry_ptr)
+#define H5C__UPDATE_STATS_FOR_DIRTY_PIN(cache_ptr, entry_ptr) {}
 #define H5C__UPDATE_STATS_FOR_UNPROTECT(cache_ptr)
 #define H5C__UPDATE_STATS_FOR_MOVE(cache_ptr, entry_ptr)
 #define H5C__UPDATE_STATS_FOR_ENTRY_SIZE_CHANGE(cache_ptr, entry_ptr, new_size)


### PR DESCRIPTION
Add braces to H5C__UPDATE_STATS_FOR_DIRTY_PIN macro to fix warning causing Werror Release builds to fail