### PR TITLE
removed the use of encoded single apostrophe

### DIFF
--- a/config/sanitizer/README.md
+++ b/config/sanitizer/README.md
@@ -53,7 +53,7 @@ These obviously force the standard to be required, and also disables compiler-sp
 
 ## Sanitizer Builds [`sanitizers.cmake`](sanitizers.cmake)
 
-Sanitizers are tools that perform checks during a program's runtime and returns issues, and as such, along with unit testing, code coverage and static analysis, is another tool to add to the programmers toolbox. And of course, like the previous tools, are tragically simple to add into any project using CMake, allowing any project and developer to quickly and easily use.
+Sanitizers are tools that perform checks during a program's runtime and return issues, and as such, along with unit testing, code coverage and static analysis, are another tool to add to the programmer's toolbox. And, of course, like the previous tools, they are simple to add to any project using CMake, allowing any project and developer to quickly and easily use them.
 
 A quick rundown of the tools available, and what they do:
 - [LeakSanitizer](https://clang.llvm.org/docs/LeakSanitizer.html) detects memory leaks, or issues where memory is allocated and never deallocated, causing programs to slowly consume more and more memory, eventually leading to a crash.

--- a/config/sanitizer/README.md
+++ b/config/sanitizer/README.md
@@ -53,7 +53,7 @@ These obviously force the standard to be required, and also disables compiler-sp
 
 ## Sanitizer Builds [`sanitizers.cmake`](sanitizers.cmake)
 
-Sanitizers are tools that perform checks during a program’s runtime and returns issues, and as such, along with unit testing, code coverage and static analysis, is another tool to add to the programmers toolbox. And of course, like the previous tools, are tragically simple to add into any project using CMake, allowing any project and developer to quickly and easily use.
+Sanitizers are tools that perform checks during a program's runtime and returns issues, and as such, along with unit testing, code coverage and static analysis, is another tool to add to the programmers toolbox. And of course, like the previous tools, are tragically simple to add into any project using CMake, allowing any project and developer to quickly and easily use.
 
 A quick rundown of the tools available, and what they do:
 - [LeakSanitizer](https://clang.llvm.org/docs/LeakSanitizer.html) detects memory leaks, or issues where memory is allocated and never deallocated, causing programs to slowly consume more and more memory, eventually leading to a crash.

--- a/doxygen/aliases
+++ b/doxygen/aliases
@@ -306,7 +306,7 @@ ALIASES += ref_rfc20120523="<a href=\"https://docs.hdfgroup.org/hdf5/rfc/paged_a
 ALIASES += ref_rfc20120501="<a href=\"https://docs.hdfgroup.org/hdf5/rfc/HDF5FileImageOperations.pdf\">HDF5 File Image Operations</a>"
 ALIASES += ref_rfc20120305="<a href=\"https://docs.hdfgroup.org/hdf5/rfc/RFC%20PHDF5%20Consistency%20Semantics%20MC%20120328.docx.pdf\">Enabling a Strict Consistency Semantics Model in Parallel HDF5</a>"
 ALIASES += ref_rfc20120220="<a href=\"https://docs.hdfgroup.org/hdf5/rfc/h5repack_improve_hyperslab_over_chunked_dataset_v1.pdf\"><tt>h5repack</tt>: Improved Hyperslab selections for Large Chunked Datasets</a>"
-ALIASES += ref_rfc20120120="<a href=\"https://docs.hdfgroup.org/hdf5/rfc/2012-1-25-Maintainers-guide-for-datatype.docx.pdf\">A Maintainer’s Guide for the Datatype Module in HDF5 Library</a>"
+ALIASES += ref_rfc20120120="<a href=\"https://docs.hdfgroup.org/hdf5/rfc/2012-1-25-Maintainers-guide-for-datatype.docx.pdf\">A Maintainer's Guide for the Datatype Module in HDF5 Library</a>"
 ALIASES += ref_rfc20120104="<a href=\"https://docs.hdfgroup.org/hdf5/rfc/RFC_actual_io_v4-1_done.docx.pdf\">Actual I/O Mode</a>"
 ALIASES += ref_rfc20111119="<a href=\"https://docs.hdfgroup.org/hdf5/rfc/RFC-H5Ocompare-review_v6.pdf\">New public functions to handle comparison</a>"
 ALIASES += ref_rfc20110825="<a href=\"https://docs.hdfgroup.org/hdf5/rfc/2011-08-31-RFC_H5Ocopy_Named_DT_v2.docx.pdf\">Merging Named Datatypes in H5Ocopy()</a>"

--- a/doxygen/dox/IntroHDF5.dox
+++ b/doxygen/dox/IntroHDF5.dox
@@ -124,7 +124,7 @@ It is a 2-dimensional 5 x 3 array (the dataspace). The datatype should not be co
 </ul>
 
 \subsubsection subsec_intro_desc_prop_dspace Dataspaces
-A dataspace describes the layout of a dataset’s data elements. It can consist of no elements (NULL),
+A dataspace describes the layout of a dataset's data elements. It can consist of no elements (NULL),
 a single element (scalar), or a simple array.
 
 <table>
@@ -141,7 +141,7 @@ in size (i.e. they are extendible).
 
 There are two roles of a dataspace:
 \li It contains the spatial information (logical layout) of a dataset stored in a file. This includes the rank and dimensions of a dataset, which are a permanent part of the dataset definition.
-\li It describes an application’s data buffers and data elements participating in I/O. In other words, it can be used to select a portion or subset of a dataset.
+\li It describes an application's data buffers and data elements participating in I/O. In other words, it can be used to select a portion or subset of a dataset.
 
 <table>
 <caption>The dataspace is used to describe both the logical layout of a dataset and a subset of a dataset.</caption>

--- a/doxygen/dox/high_level/extension.dox
+++ b/doxygen/dox/high_level/extension.dox
@@ -392,7 +392,7 @@ H5_HLRDLL herr_t H5LRread_region(hid_t obj_id,
  *
  * \details H5LRget_region_info() queries information about the data
  *          pointed by a region reference \p ref. It returns one of the
- *          absolute paths to a dataset, length of the path, dataset’s rank
+ *          absolute paths to a dataset, length of the path, dataset's rank
  *          and datatype, description of the referenced region and type of
  *          the referenced region. Any output argument can be NULL if that
  *          argument does not need to be returned.

--- a/doxygen/examples/tables/fileDriverLists.dox
+++ b/doxygen/examples/tables/fileDriverLists.dox
@@ -94,8 +94,8 @@ version of the file can be written back to disk or abandoned.</td>
 <tr>
 <td>Family</td>
 <td>#H5FD_FAMILY</td>
-<td>With this driver, the HDF5 file’s address space is partitioned into pieces and sent to
-separate storage files using an underlying driver of the user’s choice. This driver is for
+<td>With this driver, the HDF5 file's address space is partitioned into pieces and sent to
+separate storage files using an underlying driver of the user's choice. This driver is for
 systems that do not support files larger than 2 gigabytes.</td>
 <td>#H5Pset_fapl_family</td>
 </tr>

--- a/fortran/src/H5Af.c
+++ b/fortran/src/H5Af.c
@@ -259,7 +259,7 @@ done:
  *                          H5_ITER_NATIVE   - No particular order, whatever is fastest
  *                          H5_ITER_N	     - Number of iteration orders
  *
- *  n  - Attribute’s position in index
+ *  n  - Attribute's position in index
  *  attr_id  - Attribute identifier
  *  size  - Buffer size ! *TEST* check for 0 value *CHECK* should this return the correct value
  *
@@ -331,7 +331,7 @@ done:
  *
  *  corder_valid - Indicates whether the creation order data is valid for this attribute
  *  corder - Is a positive integer containing the creation order of the attribute
- *  cset - Indicates the character set used for the attribute’s name
+ *  cset - Indicates the character set used for the attribute's name
  *  data_size - indicates the size, in the number of characters, of the attribute
  *
  * RETURNS
@@ -388,13 +388,13 @@ done:
  *                          H5_ITER_NATIVE   - No particular order, whatever is fastest
  *                          H5_ITER_N	     - Number of iteration orders
  *
- *  n - Attribute’s position in index
+ *  n - Attribute's position in index
  *  lapl_id - Link access property list
  * OUTPUTS
  *
  *  corder_valid - Indicates whether the creation order data is valid for this attribute
  *  corder - Is a positive integer containing the creation order of the attribute
- *  cset - Indicates the character set used for the attribute’s name
+ *  cset - Indicates the character set used for the attribute's name
  *  data_size - indicates the size, in the number of characters, of the attribute
  *
  * RETURNS
@@ -455,7 +455,7 @@ done:
  *
  *  corder_valid - Indicates whether the creation order data is valid for this attribute
  *  corder - Is a positive integer containing the creation order of the attribute
- *  cset - Indicates the character set used for the attribute’s name
+ *  cset - Indicates the character set used for the attribute's name
  *  data_size - indicates the size, in the number of characters, of the attribute
  *
  * RETURNS

--- a/fortran/src/H5Aff.F90
+++ b/fortran/src/H5Aff.F90
@@ -456,7 +456,7 @@ CONTAINS
 !!                 \li H5_ITER_DEC_F       - Decreasing order
 !!                 \li H5_ITER_NATIVE_F    - No particular order, whatever is fastest
 !!                 \li H5_ITER_N_F         - Number of iteration orders
-!! \param n        Attribute’s position in index
+!! \param n        Attribute&apos;s position in index
 !! \param name     Attribute name
 !! \param hdferr   \fortran_error
 !!
@@ -687,7 +687,7 @@ CONTAINS
 !! \brief Gets an attribute creation property list identifier
 !!
 !! \param attr_id          Identifier of the attribute
-!! \param creation_prop_id Identifier for the attribute’s creation property
+!! \param creation_prop_id Identifier for the attribute&apos;s creation property
 !! \param hdferr           \fortran_error
 !!
 !! See C API: @ref H5Aget_create_plist()
@@ -1080,7 +1080,7 @@ CONTAINS
 !!                 \li H5_ITER_DEC_F       - Decreasing order
 !!                 \li H5_ITER_NATIVE_F    - No particular order, whatever is fastest
 !!                 \li H5_ITER_N_F         - Number of iteration orders
-!! \param n        Attribute’s position in index.
+!! \param n        Attribute&apos;s position in index.
 !! \param attr_id  Attribute identifier.
 !! \param hdferr   \fortran_error
 !! \param aapl_id  Attribute access property list.
@@ -1152,7 +1152,7 @@ CONTAINS
 !!                 \li H5_ITER_DEC_F       - Decreasing order
 !!                 \li H5_ITER_NATIVE_F    - No particular order, whatever is fastest
 !!                 \li H5_ITER_N_F         - Number of iteration orders
-!! \param n        Attribute’s position in index.
+!! \param n        Attribute&apos;s position in index.
 !! \param attr_id  Attribute identifier.
 !! \param es_id    \fortran_es_id
 !! \param hdferr   \fortran_error
@@ -1237,7 +1237,7 @@ CONTAINS
 !!                       NOTE: In C it is defined as a structure: H5A_info_t.
 !! \param f_corder_valid Indicates whether the creation order data is valid for this attribute.
 !! \param corder         Is a positive integer containing the creation order of the attribute.
-!! \param cset           Indicates the character set used for the attribute’s name.
+!! \param cset           Indicates the character set used for the attribute&apos;s name.
 !! \param data_size      Indicates the size, in the number of characters, of the attribute.
 !! \param hdferr         \fortran_error
 !!
@@ -1283,10 +1283,10 @@ CONTAINS
 !! \param obj_name       Name of object to which attribute is attached, relative to location
 !! \param idx_type       Type of index
 !! \param order          Index traversal order
-!! \param n              Attribute’s position in index
+!! \param n              Attribute&apos;s position in index
 !! \param f_corder_valid Indicates whether the creation order data is valid for this attribute
 !! \param corder         Is a positive integer containing the creation order of the attribute
-!! \param cset           Indicates the character set used for the attribute’s name
+!! \param cset           Indicates the character set used for the attribute&apos;s name
 !! \param data_size      Indicates the size, in the number of characters, of the attribute
 !! \param hdferr         \fortran_error
 !! \param lapl_id        Link access property list
@@ -1359,7 +1359,7 @@ CONTAINS
 !! \param attr_name      Attribute name
 !! \param f_corder_valid Indicates whether the creation order data is valid for this attribute
 !! \param corder         Is a positive integer containing the creation order of the attribute
-!! \param cset           Indicates the character set used for the attribute’s name
+!! \param cset           Indicates the character set used for the attribute&apos;s name
 !! \param data_size      Indicates the size, in the number of characters, of the attribute
 !! \param hdferr         \fortran_error
 !! \param lapl_id        Link access property list
@@ -1701,7 +1701,7 @@ CONTAINS
 !! \brief Determines whether an attribute with a given name exists on an object
 !!
 !! \param loc_id      Location identifier
-!! \param obj_name    Object name either relative to loc_id, absolute from the file’s root group, or &apos;. &apos;(a dot)
+!! \param obj_name    Object name either relative to loc_id, absolute from the file&apos;s root group, or &apos;. &apos;(a dot)
 !! \param attr_name   Attribute name
 !! \param attr_exists Attribute exists status
 !! \param hdferr      \fortran_error
@@ -1758,7 +1758,7 @@ CONTAINS
 !! \brief Asynchronously determines whether an attribute with a given name exists on an object
 !!
 !! \param loc_id      Location identifier
-!! \param obj_name    Object name either relative to loc_id, absolute from the file’s root group, or &apos;. &apos;(a dot)
+!! \param obj_name    Object name either relative to loc_id, absolute from the file&apos;s root group, or &apos;. &apos;(a dot)
 !! \param attr_name   Attribute name
 !! \param attr_exists Pointer to attribute exists status, must be of type LOGICAL(C_BOOL) and initialize to .FALSE.
 !! \param es_id       \fortran_es_id
@@ -1829,7 +1829,7 @@ CONTAINS
 !! \brief Opens an attribute for an object by object name and attribute name.
 !!
 !! \param loc_id    Location from which to find object to which attribute is attached
-!! \param obj_name  Object name either relative to loc_id, absolute from the file’s root group, or &apos;.&apos; (a dot)
+!! \param obj_name  Object name either relative to loc_id, absolute from the file&apos;s root group, or &apos;.&apos; (a dot)
 !! \param attr_name Attribute name
 !! \param attr_id   Attribute identifier
 !! \param hdferr    \fortran_error
@@ -1888,7 +1888,7 @@ CONTAINS
 !! \brief Asynchronously opens an attribute for an object by object name and attribute name.
 !!
 !! \param loc_id    Location from which to find object to which attribute is attached
-!! \param obj_name  Object name either relative to loc_id, absolute from the file’s root group, or &apos;.&apos; (a dot)
+!! \param obj_name  Object name either relative to loc_id, absolute from the file&apos;s root group, or &apos;.&apos; (a dot)
 !! \param attr_name Attribute name
 !! \param attr_id   Attribute identifier
 !! \param es_id     \fortran_es_id

--- a/fortran/src/H5Gff.F90
+++ b/fortran/src/H5Gff.F90
@@ -1171,7 +1171,7 @@ CONTAINS
 !>
 !! \ingroup FH5G
 !!
-!! \brief Retrieves information about a group, according to the group’s position within an index.
+!! \brief Retrieves information about a group, according to the group&apos;s position within an index.
 !!
 !! \attention  \fortran_approved
 !!
@@ -1226,7 +1226,7 @@ CONTAINS
 !>
 !! \ingroup FH5G
 !!
-!! \brief Asynchronously retrieves information about a group, according to the group’s position within an index.
+!! \brief Asynchronously retrieves information about a group, according to the group&apos;s position within an index.
 !!
 !! \param loc_id     Location identifier. The identifier may be that of a file, group, dataset, named datatype, or attribute.
 !! \param group_name Name of group containing group for which information is to be retrieved.
@@ -1285,7 +1285,7 @@ CONTAINS
 !>
 !! \ingroup FH5G
 !!
-!! \brief Retrieves information about a group, according to the group’s position within an index.
+!! \brief Retrieves information about a group, according to the group&apos;s position within an index.
 !!
 !! \attention  \fortran_obsolete. Both nlinks and max_corder can overflow.
 !!

--- a/fortran/src/H5Lf.c
+++ b/fortran/src/H5Lf.c
@@ -150,8 +150,8 @@ done:
  * OUTPUTS
  *
  *
- *  cset - indicates the character set used for link’s name.
- *  corder - specifies the link’s creation order position.
+ *  cset - indicates the character set used for link's name.
+ *  corder - specifies the link's creation order position.
  *  corder_valid - indicates whether the value in corder is valid.
  *  link_type -  specifies the link class:
  *     	                H5L_LINK_HARD_F      - Hard link
@@ -221,7 +221,7 @@ done:
  *
  *  corder_valid - Indicates whether the creation order data is valid for this attribute
  *  corder - Is a positive integer containing the creation order of the attribute
- *  cset - Indicates the character set used for the attribute’s name
+ *  cset - Indicates the character set used for the attribute's name
  *  data_size - indicates the size, in the number of characters, of the attribute
  *
  * RETURNS

--- a/fortran/src/H5Lff.F90
+++ b/fortran/src/H5Lff.F90
@@ -830,8 +830,8 @@ CONTAINS
 !! \param link_loc_id File or group identifier.
 !! \param link_name   Name of the link for which information is being sought.
 !!                     NOTE: In C these are contained in the structure H5L_info_t
-!! \param cset         Indicates the character set used for link’s name.
-!! \param corder       Specifies the link’s creation order position.
+!! \param cset         Indicates the character set used for link&apos;s name.
+!! \param corder       Specifies the link&apos;s creation order position.
 !! \param f_corder_valid Indicates whether the value in corder is valid.
 !! \param link_type    Specifies the link class:
 !!                     \li H5L_TYPE_HARD_F     - Hard link
@@ -926,7 +926,7 @@ CONTAINS
 !!                       \li H5L_TYPE_ERROR _F    - Error
 !! \param f_corder_valid Indicates whether the creation order data is valid for this attribute.
 !! \param corder         Is a positive integer containing the creation order of the attribute.
-!! \param cset           Indicates the character set used for the attribute’s name.
+!! \param cset           Indicates the character set used for the attribute&apos;s name.
 !! \param token          If the link is a hard link, token specifies the object token that the link points to.
 !! \param val_size       If the link is a symbolic link, val_size will be the length of the link value, e.g.,
 !!                       the length of the name of the pointed-to object with a null terminator.

--- a/fortran/src/H5Of.c
+++ b/fortran/src/H5Of.c
@@ -136,7 +136,7 @@ done:
  *  Calls H5open_by_token
  * INPUTS
  *  loc_id - File or group identifier
- *  token  - Object’s token in the file
+ *  token  - Object's token in the file
  *
  * OUTPUTS
  *  obj_id  - Object identifier

--- a/fortran/src/H5Off.F90
+++ b/fortran/src/H5Off.F90
@@ -404,7 +404,7 @@ CONTAINS
 !! \brief Opens an object using its token within an HDF5 file.
 !!
 !! \param loc_id File or group identifier.
-!! \param token  Object’s token in the file.
+!! \param token  Object&apos;s token in the file.
 !! \param obj_id Object identifier for the opened object.
 !! \param hdferr \fortran_error
 !!

--- a/fortran/src/H5Pff.F90
+++ b/fortran/src/H5Pff.F90
@@ -5775,7 +5775,7 @@ SUBROUTINE h5pset_attr_phase_change_f(ocpl_id, max_compact, min_dense, hdferr)
 !!                      unlimited selection.
 !! \param src_file_name The name of the HDF5 file where the source dataset is located.
 !! \param src_dset_name The path to the HDF5 dataset in the file specified by src_file_name.
-!! \param src_space_id  The source dataset’s dataspace identifier with a selection applied, possibly an unlimited selection.
+!! \param src_space_id  The source dataset&apos;s dataspace identifier with a selection applied, possibly an unlimited selection.
 !! \param hdferr        \fortran_error
 !!
 !! See C API: @ref H5Pset_virtual()

--- a/fortran/src/H5Tff.F90
+++ b/fortran/src/H5Tff.F90
@@ -1945,7 +1945,7 @@ CONTAINS
 !>
 !! \ingroup FH5T
 !!
-!! \brief Check whether the library’s default conversion is hard conversion.
+!! \brief Check whether the library&apos;s default conversion is hard conversion.
 !!
 !! \param src_id Identifier for the source datatype.
 !! \param dst_id Identifier for the destination datatype.

--- a/fortran/test/tH5A_1_8.F90
+++ b/fortran/test/tH5A_1_8.F90
@@ -236,7 +236,7 @@ SUBROUTINE test_attr_corder_create_compact(fcpl,fapl, total_error)
 
   LOGICAL :: f_corder_valid ! Indicates whether the creation order data is valid for this attribute
   INTEGER :: corder ! Is a positive integer containing the creation order of the attribute
-  INTEGER :: cset ! Indicates the character set used for the attribute’s name
+  INTEGER :: cset ! Indicates the character set used for the attribute's name
   INTEGER(HSIZE_T) :: data_size   ! indicates the size, in the number of characters
 
   data_dims = 0
@@ -413,7 +413,7 @@ SUBROUTINE test_attr_null_space(fcpl, fapl, total_error)
 
   LOGICAL :: f_corder_valid ! Indicates whether the creation order data is valid for this attribute
   INTEGER :: corder ! Is a positive integer containing the creation order of the attribute
-  INTEGER :: cset ! Indicates the character set used for the attribute’s name
+  INTEGER :: cset ! Indicates the character set used for the attribute's name
   INTEGER(HSIZE_T) :: data_size   ! indicates the size, in the number of characters
 
   LOGICAL :: equal
@@ -755,7 +755,7 @@ SUBROUTINE test_attr_info_by_idx(new_format, fcpl, fapl, total_error)
 
   LOGICAL :: f_corder_valid ! Indicates whether the creation order data is valid for this attribute
   INTEGER :: corder ! Is a positive integer containing the creation order of the attribute
-  INTEGER :: cset ! Indicates the character set used for the attribute’s name
+  INTEGER :: cset ! Indicates the character set used for the attribute's name
   INTEGER(HSIZE_T) :: data_size   ! indicates the size, in the number of characters
   INTEGER(HSIZE_T) :: n
   LOGICAL, DIMENSION(1:2) :: use_index = (/.FALSE.,.TRUE./)
@@ -936,7 +936,7 @@ SUBROUTINE attr_info_by_idx_check(obj_id, attrname, n, use_index, total_error )
   LOGICAL :: use_index
   LOGICAL :: f_corder_valid ! Indicates whether the creation order data is valid for this attribute
   INTEGER :: corder ! Is a positive integer containing the creation order of the attribute
-  INTEGER :: cset ! Indicates the character set used for the attribute’s name
+  INTEGER :: cset ! Indicates the character set used for the attribute's name
   INTEGER(HSIZE_T) :: data_size   ! indicates the size, in the number of characters
 
   INTEGER(SIZE_T) :: NAME_BUF_SIZE = 7
@@ -1399,7 +1399,7 @@ SUBROUTINE test_attr_delete_by_idx(new_format, fcpl, fapl, total_error)
 
   LOGICAL :: f_corder_valid ! Indicates whether the creation order data is valid for this attribute
   INTEGER :: corder ! Is a positive integer containing the creation order of the attribute
-  INTEGER :: cset ! Indicates the character set used for the attribute’s name
+  INTEGER :: cset ! Indicates the character set used for the attribute's name
   INTEGER(HSIZE_T) :: data_size   ! indicates the size, in the number of characters
   LOGICAL, DIMENSION(1:2) :: use_index = (/.FALSE.,.TRUE./)
 
@@ -2688,7 +2688,7 @@ SUBROUTINE attr_open_check(fid, dsetname, obj_id, max_attrs, total_error )
   INTEGER :: error
   LOGICAL :: f_corder_valid ! Indicates whether the creation order data is valid for this attribute
   INTEGER :: corder ! Is a positive integer containing the creation order of the attribute
-  INTEGER :: cset ! Indicates the character set used for the attribute’s name
+  INTEGER :: cset ! Indicates the character set used for the attribute's name
   INTEGER(HSIZE_T) :: data_size   ! indicates the size, in the number of characters
 
   INTEGER(HSIZE_T) :: storage_size   ! attributes storage requirements

--- a/fortran/test/tH5G_1_8.F90
+++ b/fortran/test/tH5G_1_8.F90
@@ -751,8 +751,8 @@ END SUBROUTINE group_info
      INTEGER ::   arank = 1                      ! Attribute rank
      INTEGER :: error
 
-     INTEGER :: cset ! Indicates the character set used for the link’s name.
-     INTEGER :: corder ! Specifies the link’s creation order position.
+     INTEGER :: cset ! Indicates the character set used for the link's name.
+     INTEGER :: corder ! Specifies the link's creation order position.
      LOGICAL :: f_corder_valid ! Indicates whether the value in corder is valid.
      INTEGER :: link_type ! Specifies the link class:
                           !  H5L_TYPE_HARD_F      - Hard link
@@ -850,8 +850,8 @@ END SUBROUTINE group_info
     INTEGER :: crt_order_flags !  Status of creation order info for GCPL
     CHARACTER(LEN=12), PARAMETER :: filename = 'TestLinks.h5'
 
-    INTEGER :: cset ! Indicates the character set used for the link’s name.
-    INTEGER :: corder ! Specifies the link’s creation order position.
+    INTEGER :: cset ! Indicates the character set used for the link's name.
+    INTEGER :: corder ! Specifies the link's creation order position.
     LOGICAL :: f_corder_valid ! Indicates whether the value in corder is valid.
     INTEGER :: link_type ! Specifies the link class:
                          !  H5L_TYPE_HARD_F      - Hard link
@@ -1250,7 +1250,7 @@ SUBROUTINE delete_by_idx(cleanup, fapl, total_error)
 
   LOGICAL :: f_corder_valid ! Indicates whether the creation order data is valid for this attribute
   INTEGER :: corder ! Is a positive integer containing the creation order of the attribute
-  INTEGER :: cset ! Indicates the character set used for the attribute’s name
+  INTEGER :: cset ! Indicates the character set used for the attribute's name
   INTEGER(SIZE_T) :: val_size
   INTEGER :: link_type
   TYPE(H5O_TOKEN_T_F) :: token
@@ -1475,7 +1475,7 @@ SUBROUTINE link_info_by_idx_check(group_id, linkname, n, &
 
   LOGICAL :: f_corder_valid ! Indicates whether the creation order data is valid for this attribute
   INTEGER :: corder ! Is a positive integer containing the creation order of the attribute
-  INTEGER :: cset ! Indicates the character set used for the attribute’s name
+  INTEGER :: cset ! Indicates the character set used for the attribute's name
   INTEGER :: link_type
   TYPE(H5O_TOKEN_T_F) :: token
   INTEGER(SIZE_T) :: val_size   ! Indicates the size, in the number of characters, of the attribute
@@ -1572,8 +1572,8 @@ SUBROUTINE link_info_by_idx_check(group_id, linkname, n, &
   INTEGER(HID_T) :: type_id
   INTEGER(HID_T) :: lcpl_id
 
-  INTEGER :: cset ! Indicates the character set used for the link’s name.
-  INTEGER :: corder ! Specifies the link’s creation order position.
+  INTEGER :: cset ! Indicates the character set used for the link's name.
+  INTEGER :: corder ! Specifies the link's creation order position.
   LOGICAL :: f_corder_valid ! Indicates whether the value in corder is valid.
   INTEGER :: link_type ! Specifies the link class:
                        !  H5L_TYPE_HARD_F      - Hard link

--- a/hl/src/H5DOpublic.h
+++ b/hl/src/H5DOpublic.h
@@ -29,7 +29,7 @@ extern "C" {
  * HDF5 functions described is this section are implemented in the HDF5 High-level
  * library as optimized functions. These functions generally require careful setup
  * and testing as they enable an application to bypass portions of the HDF5
- * library’s I/O pipeline for performance purposes.
+ * library's I/O pipeline for performance purposes.
  *
  * These functions are distributed in the standard HDF5 distribution and are
  * available any time the HDF5 High-level library is available.
@@ -113,7 +113,7 @@ H5_HLDLL herr_t H5DOappend(hid_t dset_id, hid_t dxpl_id, unsigned axis, size_t e
  * \param[in] dxpl_id       Transfer property list identifier for
  *                          this I/O operation
  * \param[in] filters       Mask for identifying the filters in use
- * \param[in] offset        Logical position of the chunk’s first element
+ * \param[in] offset        Logical position of the chunk's first element
  *                          in the dataspace
  * \param[in] data_size     Size of the actual data to be written in bytes
  * \param[in] buf           Buffer containing data to be written to the chunk
@@ -131,7 +131,7 @@ H5_HLDLL herr_t H5DOappend(hid_t dset_id, hid_t dxpl_id, unsigned axis, size_t e
  *          logical \p offset in a chunked dataset \p dset_id from the application
  *          memory buffer \p buf to the dataset in the file. Typically, the data
  *          in \p buf is preprocessed in memory by a custom transformation, such as
- *          compression. The chunk will bypass the library’s internal data
+ *          compression. The chunk will bypass the library's internal data
  *          transfer pipeline, including filters, and will be written directly to the file.
  *
  *          \p dxpl_id is a data transfer property list identifier.
@@ -139,12 +139,12 @@ H5_HLDLL herr_t H5DOappend(hid_t dset_id, hid_t dxpl_id, unsigned axis, size_t e
  *          \p filters is a mask providing a record of which filters are used
  *          with the chunk. The default value of the mask is zero (\c 0),
  *          indicating that all enabled filters are applied. A filter is skipped
- *          if the bit corresponding to the filter’s position in the pipeline
+ *          if the bit corresponding to the filter's position in the pipeline
  *          (<tt>0 ≤ position < 32</tt>) is turned on. This mask is saved
  *          with the chunk in the file.
  *
  *          \p offset is an array specifying the logical position of the first
- *          element of the chunk in the dataset’s dataspace. The length of the
+ *          element of the chunk in the dataset's dataspace. The length of the
  *          offset array must equal the number of dimensions, or rank, of the
  *          dataspace. The values in \p offset must not exceed the dimension limits
  *          and must specify a point that falls on a dataset chunk boundary.
@@ -189,7 +189,7 @@ H5_HLDLL herr_t H5DOwrite_chunk(hid_t dset_id, hid_t dxpl_id, uint32_t filters, 
  * \param[in] dset_id           Identifier for the dataset to be read
  * \param[in] dxpl_id           Transfer property list identifier for
  *                              this I/O operation
- * \param[in] offset            Logical position of the chunk’s first
+ * \param[in] offset            Logical position of the chunk's first
                                 element in the dataspace
  * \param[in,out] filters       Mask for identifying the filters used
  *                              with the chunk
@@ -209,7 +209,7 @@ H5_HLDLL herr_t H5DOwrite_chunk(hid_t dset_id, hid_t dxpl_id, uint32_t filters, 
  *          by its logical \p offset in a chunked dataset \p dset_id
  *          from the dataset in the file into the application memory
  *          buffer \p buf. The data in \p buf is read directly from the file
- *          bypassing the library’s internal data transfer pipeline,
+ *          bypassing the library's internal data transfer pipeline,
  *          including filters.
  *
  *          \p dxpl_id is a data transfer property list identifier.
@@ -217,11 +217,11 @@ H5_HLDLL herr_t H5DOwrite_chunk(hid_t dset_id, hid_t dxpl_id, uint32_t filters, 
  *          The mask \p filters indicates which filters are used with the
  *          chunk when written. A zero value indicates that all enabled filters
  *          are applied on the chunk. A filter is skipped if the bit corresponding
- *          to the filter’s position in the pipeline
+ *          to the filter's position in the pipeline
  *          (<tt>0 ≤ position < 32</tt>) is turned on.
  *
  *          \p offset is an array specifying the logical position of the first
- *          element of the chunk in the dataset’s dataspace. The length of the
+ *          element of the chunk in the dataset's dataspace. The length of the
  *          offset array must equal the number of dimensions, or rank, of the
  *          dataspace. The values in \p offset must not exceed the dimension
  *          limits and must specify a point that falls on a dataset chunk boundary.

--- a/hl/src/H5LDpublic.h
+++ b/hl/src/H5LDpublic.h
@@ -50,18 +50,18 @@ H5_HLDLL herr_t H5LDget_dset_dims(hid_t did, hsize_t *cur_dims);
  *-------------------------------------------------------------------------
  * \ingroup H5LT
  *
- * \brief Returns the size in bytes of the dataset’s datatype
+ * \brief Returns the size in bytes of the dataset's datatype
  *
  * \param[in] did       The dataset identifier
  * \param[in] fields    The pointer to a comma-separated list of fields for a compound datatype
  *
  * \return If successful, returns the size in bytes of the
- *         dataset’s datatype. Otherwise, returns 0.
+ *         dataset's datatype. Otherwise, returns 0.
  *
  * \details H5LDget_dset_type_size() allows the user to find out the datatype
  *          size for the dataset associated with \p did. If the
  *          parameter \p fields is NULL, this routine just returns the size
- *          of the dataset’s datatype. If the dataset has a compound datatype
+ *          of the dataset's datatype. If the dataset has a compound datatype
  *          and \p fields is non-NULL, this routine returns the size of the
  *          datatype(s) for the selected fields specified in \p fields.
  *          Note that ’,’ is the separator for the fields of a compound

--- a/hl/src/H5LTpublic.h
+++ b/hl/src/H5LTpublic.h
@@ -208,7 +208,7 @@ H5_HLDLL herr_t H5LTmake_dataset(hid_t loc_id, const char *dset_name, int rank, 
  *          named \p dset_name attached to the object specified by
  *          the identifier \p loc_id.
  *
- *          The dataset’s datatype will be \e character, #H5T_NATIVE_CHAR.
+ *          The dataset's datatype will be \e character, #H5T_NATIVE_CHAR.
  *
  */
 H5_HLDLL herr_t H5LTmake_dataset_char(hid_t loc_id, const char *dset_name, int rank, const hsize_t *dims,
@@ -232,7 +232,7 @@ H5_HLDLL herr_t H5LTmake_dataset_char(hid_t loc_id, const char *dset_name, int r
  *          named \p dset_name attached to the object specified by
  *          the identifier \p loc_id.
  *
- *          The dataset’s datatype will be <em>short signed integer</em>,
+ *          The dataset's datatype will be <em>short signed integer</em>,
  *          #H5T_NATIVE_SHORT.
  *
  */
@@ -257,7 +257,7 @@ H5_HLDLL herr_t H5LTmake_dataset_short(hid_t loc_id, const char *dset_name, int 
  *          named \p dset_name attached to the object specified by
  *          the identifier \p loc_id.
  *
- *          The dataset’s datatype will be <em>native signed integer</em>,
+ *          The dataset's datatype will be <em>native signed integer</em>,
  *          #H5T_NATIVE_INT.
  *
  * \version Fortran subroutine modified in this release to accommodate
@@ -285,7 +285,7 @@ H5_HLDLL herr_t H5LTmake_dataset_int(hid_t loc_id, const char *dset_name, int ra
  *          named \p dset_name attached to the object specified by
  *          the identifier \p loc_id.
  *
- *          The dataset’s datatype will be <em>long signed integer</em>,
+ *          The dataset's datatype will be <em>long signed integer</em>,
  *          #H5T_NATIVE_LONG.
  *
  */
@@ -310,7 +310,7 @@ H5_HLDLL herr_t H5LTmake_dataset_long(hid_t loc_id, const char *dset_name, int r
  *          named \p dset_name attached to the object specified by
  *          the identifier \p loc_id.
  *
- *          The dataset’s datatype will be <em>native floating point</em>,
+ *          The dataset's datatype will be <em>native floating point</em>,
  *          #H5T_NATIVE_FLOAT.
  *
  * \version 1.8.7 Fortran subroutine modified in this release to accommodate
@@ -338,7 +338,7 @@ H5_HLDLL herr_t H5LTmake_dataset_float(hid_t loc_id, const char *dset_name, int 
  *          named \p dset_name attached to the object specified by
  *          the identifier \p loc_id.
  *
- *          The dataset’s datatype will be
+ *          The dataset's datatype will be
  *          <em>native floating-point double</em>, #H5T_NATIVE_DOUBLE.
  *
  * \version 1.8.7 Fortran subroutine modified in this release to accommodate
@@ -364,7 +364,7 @@ H5_HLDLL herr_t H5LTmake_dataset_double(hid_t loc_id, const char *dset_name, int
  *          named \p dset_name attached to the object specified by
  *          the identifier \p loc_id.
  *
- *          The dataset’s datatype will be <em>C string</em>, #H5T_C_S1.
+ *          The dataset's datatype will be <em>C string</em>, #H5T_C_S1.
  *
  */
 H5_HLDLL herr_t H5LTmake_dataset_string(hid_t loc_id, const char *dset_name, const char *buf);
@@ -1496,7 +1496,7 @@ H5_HLDLL herr_t H5LTfind_attribute(hid_t loc_id, const char *name);
  *          final component of \p path resolves to an HDF5 object;
  *          if not, the final component is a dangling link.
  *
- *          The meaning of the function’s return value depends on the
+ *          The meaning of the function's return value depends on the
  *          value of \p check_object_valid:
  *
  *          If \p check_object_valid is set to \c FALSE, H5LTpath_valid()
@@ -1516,7 +1516,7 @@ H5_HLDLL herr_t H5LTfind_attribute(hid_t loc_id, const char *name);
  *          \p path can be any one of the following:
  *
  *          - An absolute path, which starts with a slash (\c /)
- *            indicating the file’s root group, followed by the members
+ *            indicating the file's root group, followed by the members
  *          - A relative path with respect to \p loc_id
  *          - A dot (\c .), if \p loc_id is the object identifier for
  *            the object itself.

--- a/src/H5Amodule.h
+++ b/src/H5Amodule.h
@@ -77,7 +77,7 @@
  * data, and the attribute creation property list.
  *
  * The following steps are required to create and write an HDF5 attribute:
- * \li Obtain the object identifier for the attribute’s primary data object
+ * \li Obtain the object identifier for the attribute's primary data object
  * \li Define the characteristics of the attribute and specify the attribute creation property list
  * <ul> <li> Define the datatype</li>
  * <li> Define the dataspace</li>
@@ -88,12 +88,12 @@
  * \li Close the primary data object (if appropriate)
  *
  * The following steps are required to open and read/write an existing attribute. Since HDF5 attributes
- *  allow no partial I/O, you need specify only the attribute and the attribute’s memory datatype to read it:
- * \li Obtain the object identifier for the attribute’s primary data object
- * \li Obtain the attribute’s name or index
+ *  allow no partial I/O, you need specify only the attribute and the attribute's memory datatype to read it:
+ * \li Obtain the object identifier for the attribute's primary data object
+ * \li Obtain the attribute's name or index
  * \li Open the attribute
  * \li Get attribute dataspace and datatype (optional)
- * \li Specify the attribute’s memory type
+ * \li Specify the attribute's memory type
  * \li Read and/or write the attribute data
  * \li Close the attribute
  * \li Close the primary data object (if appropriate)
@@ -126,7 +126,7 @@
  *
  * HDF5 attributes are sometimes discussed as name/value pairs in the form name=value.
  *
- * An attribute’s name is a null-terminated ASCII or UTF-8 character string. Each attribute attached to an
+ * An attribute's name is a null-terminated ASCII or UTF-8 character string. Each attribute attached to an
  * object has a unique name.
  *
  * The value portion of the attribute contains one or more data elements of the same datatype.
@@ -148,8 +148,8 @@
  *                      hid_t access_plist)
  * \endcode
  * loc_id identifies the object (dataset, group, or committed datatype) to which the attribute is to be
- * attached. name, type_id, space_id, and create_plist convey, respectively, the attribute’s name, datatype,
- * dataspace, and attribute creation property list. The attribute’s name must be locally unique: it must be
+ * attached. name, type_id, space_id, and create_plist convey, respectively, the attribute's name, datatype,
+ * dataspace, and attribute creation property list. The attribute's name must be locally unique: it must be
  * unique within the context of the object to which it is attached.
  *
  * \ref H5Acreate creates the attribute in memory. The attribute does not exist in the file until
@@ -175,14 +175,14 @@
  *
  * To access an attribute by its name, use the \ref H5Aopen_by_name function. \ref H5Aopen_by_name returns an
  * attribute identifier that can then be used by any function that must access an attribute such as \ref
- * H5Aread. Use the function \ref H5Aget_name to determine an attribute’s name.
+ * H5Aread. Use the function \ref H5Aget_name to determine an attribute's name.
  *
  * To access an attribute by its index value, use the \ref H5Aopen_by_idx function. To determine an attribute
  * index value when it is not already known, use the H5Oget_info function. \ref H5Aopen_by_idx is generally
  * used in the course of opening several attributes for later access. Use \ref H5Aiterate if the intent is to
  * perform the same operation on every attribute attached to an object.
  *
- * \subsubsection subsubsec_attribute_work_info Obtaining Information Regarding an Object’s Attributes
+ * \subsubsection subsubsec_attribute_work_info Obtaining Information Regarding an Object's Attributes
  *
  * In the course of working with HDF5 attributes, one may need to obtain any of several pieces of information:
  * \li An attribute name
@@ -190,12 +190,12 @@
  * \li The datatype of an attribute
  * \li The number of attributes attached to an object
  *
- * To obtain an attribute’s name, call H5Aget_name with an attribute identifier, attr_id:
+ * To obtain an attribute's name, call H5Aget_name with an attribute identifier, attr_id:
  * \code
  *      ssize_t H5Aget_name (hid_t attr_id, size_t buf_size, char *buf)
  * \endcode
  * As with other attribute functions, attr_id identifies the attribute; buf_size defines the size of the
- * buffer; and buf is the buffer to which the attribute’s name will be read.
+ * buffer; and buf is the buffer to which the attribute's name will be read.
  *
  * If the length of the attribute name, and hence the value required for buf_size, is unknown, a first call
  * to \ref H5Aget_name will return that size. If the value of buf_size used in that first call is too small,
@@ -213,7 +213,7 @@
  * step in determining attribute index values. If the call returns N, the attributes attached to the object
  * object_id have index values of 0 through N-1.
  *
- * \subsubsection subsubsec_attribute_work_iterate Iterating across an Object’s Attributes
+ * \subsubsection subsubsec_attribute_work_iterate Iterating across an Object's Attributes
  *
  * It is sometimes useful to be able to perform the identical operation across all of the attributes attached
  * to an object. At the simplest level, you might just want to open each attribute. At a higher level, you
@@ -235,7 +235,7 @@
  * null pointer, then all attributes have been processed, and the iterative process is complete.
  *
  * op_func is a user-defined operation that adheres to the \ref H5A_operator_t prototype. This prototype and
- * certain requirements imposed on the operator’s behavior are described in the \ref H5Aiterate entry in the
+ * certain requirements imposed on the operator's behavior are described in the \ref H5Aiterate entry in the
  * \ref RM.
  *
  * op_data is also user-defined to meet the requirements of op_func. Beyond providing a parameter with which

--- a/src/H5Apublic.h
+++ b/src/H5Apublic.h
@@ -39,7 +39,7 @@ typedef struct {
  * \param[in] location_id The identifier for the group, dataset
  *            or named datatype being iterated over
  * \param[in] attr_name The name of the current object attribute
- * \param[in] ainfo The attribute’s info struct
+ * \param[in] ainfo The attribute's info struct
  * \param[in,out] op_data A pointer to the operator data passed in to
  *                H5Aiterate2() or H5Aiterate_by_name()
  * \returns The return values from an operator are:
@@ -128,7 +128,7 @@ H5_DLL herr_t H5Aclose_async(hid_t attr_id, hid_t es_id);
  *          with H5Aclose() resource leaks will develop.
  *
  * \note If \p loc_id is a file identifier, the attribute will be attached to
- *       that file’s root group.
+ *       that file's root group.
  *
  * \par Example
  * \snippet H5A_examples.c create
@@ -429,7 +429,7 @@ H5_DLL herr_t H5Aget_info(hid_t attr_id, H5A_info_t *ainfo /*out*/);
  *                       relative to location
  * \param[in]  idx_type  Type of index
  * \param[in]  order     Index traversal order
- * \param[in]  n         Attribute’s position in index
+ * \param[in]  n         Attribute's position in index
  * \param[out] ainfo     Struct containing returned attribute information
  * \lapl_id
  *
@@ -523,7 +523,7 @@ H5_DLL ssize_t H5Aget_name(hid_t attr_id, size_t buf_size, char *buf);
  *                        relative to location
  * \param[in]  idx_type   Type of index
  * \param[in]  order      Index traversal order
- * \param[in]  n          Attribute’s position in index
+ * \param[in]  n          Attribute's position in index
  * \param[out] name       Attribute name
  * \param[in]  size       Size, in bytes, of attribute name
  * \lapl_id
@@ -541,9 +541,9 @@ H5_DLL ssize_t H5Aget_name(hid_t attr_id, size_t buf_size, char *buf);
  *          traversal order, and a position in the index, \p idx_type,
  *          \p order and \p n, respectively.
  *
- *          If the attribute name’s size is unknown, the values 0 and NULL
+ *          If the attribute name's size is unknown, the values 0 and NULL
  *          can be passed in for the parameters \p size and \p name. The
- *          function’s return value will provide the correct value for
+ *          function's return value will provide the correct value for
  *          \p size.
  *
  *          The link access property list, \p lapl_id, may provide
@@ -645,7 +645,7 @@ H5_DLL hid_t H5Aget_type(hid_t attr_id);
  *          The order of the iteration and the attributes iterated over
  *          are specified by three parameters: the index type,
  *          \p idx_type; the order in which the index is to be traversed,
- *          \p order; and the attribute’s position in the index, \p idx.
+ *          \p order; and the attribute's position in the index, \p idx.
  *          The next attribute to be operated on is specified by \p idx,
  *          a position in the index.
  *
@@ -703,7 +703,7 @@ H5_DLL herr_t H5Aiterate2(hid_t loc_id, H5_index_t idx_type, H5_iter_order_t ord
  *          The order of the iteration and the attributes iterated over
  *          are specified by three parameters: the index type, \p idx_type;
  *          the order in which the index is to be traversed, \p order;
- *          and the attribute’s position in the index, \p idx.
+ *          and the attribute's position in the index, \p idx.
  *          The next attribute to be operated on is specified by \p idx,
  *          a position in the index.
  *
@@ -788,7 +788,7 @@ H5_DLL hid_t  H5Aopen_async(hid_t obj_id, const char *attr_name, hid_t aapl_id, 
  *                      relative to location
  * \param[in] idx_type  Type of index
  * \param[in] order     Index traversal order
- * \param[in] n         Attribute’s position in index
+ * \param[in] n         Attribute's position in index
  * \aapl_id
  * \lapl_id
  *
@@ -1172,7 +1172,7 @@ H5_DLL int H5Aget_num_attrs(hid_t loc_id);
 /**
  * \ingroup H5A
  *
- * \brief Calls a user’s function for each attribute on an object
+ * \brief Calls a user's function for each attribute on an object
  *
  * \loc_id
  * \param[in,out] idx     Starting (in) and ending (out) attribute index

--- a/src/H5D.c
+++ b/src/H5D.c
@@ -791,13 +791,13 @@ done:
  *
  *              The chunk cache parameters in the returned property lists will be
  *              those used by the dataset.  If the properties in the file access
- *              property list were used to determine the dataset’s chunk cache
+ *              property list were used to determine the dataset's chunk cache
  *              configuration, then those properties will be present in the
  *              returned dataset access property list.  If the dataset does not
  *              use a chunked layout, then the chunk cache properties will be set
  *              to the default.  The chunk cache properties in the returned list
  *              are considered to be “set”, and any use of this list will override
- *              the corresponding properties in the file’s file access property
+ *              the corresponding properties in the file's file access property
  *              list.
  *
  *              All link access properties in the returned list will be set to the
@@ -2325,7 +2325,7 @@ done:
  *              hid_t dset_id;          IN: Chunked dataset ID
  *              hid_t fspace_id;        IN: File dataspace ID
  *              hsize_t index;          IN: Index of written chunk
- *              hsize_t *offset         OUT: Logical position of the chunk’s
+ *              hsize_t *offset         OUT: Logical position of the chunk's
  *                                           first element in the dataspace
  *              unsigned *filter_mask   OUT: Mask for identifying the filters in use
  *              haddr_t *addr           OUT: Address of the chunk
@@ -2395,7 +2395,7 @@ done:
  *
  * Parameters:
  *              hid_t dset_id;          IN: Chunked dataset ID
- *              hsize_t *offset         IN: Logical position of the chunk’s
+ *              hsize_t *offset         IN: Logical position of the chunk's
  *                                           first element in the dataspace
  *              unsigned *filter_mask   OUT: Mask for identifying the filters in use
  *              haddr_t *addr           OUT: Address of the chunk

--- a/src/H5Dmodule.h
+++ b/src/H5Dmodule.h
@@ -52,7 +52,7 @@
  * pointers to metadata) that describes or annotates the dataset. Header information includes the
  * name of the object, its dimensionality, its number-type, information about how the data itself is
  * stored on disk (the storage layout), and other information used by the library to speed up access
- * to the dataset or maintain the file’s integrity.
+ * to the dataset or maintain the file's integrity.
  *
  * The HDF5 dataset interface, comprising the @ref H5D functions, provides a mechanism for managing
  * HDF5 datasets including the transfer of data between memory and disk and the description of
@@ -174,7 +174,7 @@
  * </tr>
  * <tr>
  * <td>#H5Dset_extent</td>
- * <td>Changes the sizes of a dataset’s dimensions.</td>
+ * <td>Changes the sizes of a dataset's dimensions.</td>
  * </tr>
  * </table>
  *
@@ -268,7 +268,7 @@
  * of each dimension. The maximum dimension size can be a fixed value or the constant
  * #H5S_UNLIMITED, in which case the actual dimension size can be changed with calls to
  * #H5Dset_extent, up to the maximum set with the maxdims parameter in the #H5Screate_simple
- * call that established the dataset’s original dimensions. The maximum dimension size is set when
+ * call that established the dataset's original dimensions. The maximum dimension size is set when
  * the dataset is created and cannot be changed.
  *
  * <h4>Datatype</h4>
@@ -738,11 +738,11 @@
  * </tr>
  * <tr>
  * <td>I/O initiation</td>
- * <td>Initiation of HDF5 I/O activities (#H5Dwrite and #H5Dread) in a user’s application program.</td>
+ * <td>Initiation of HDF5 I/O activities (#H5Dwrite and #H5Dread) in a user's application program.</td>
  * </tr>
  * <tr>
  * <td>Memory hyperslab operation</td>
- * <td>Data is scattered to (for read), or gathered from (for write) the application’s memory buffer
+ * <td>Data is scattered to (for read), or gathered from (for write) the application's memory buffer
  * (bypassed if no datatype conversion is needed).</td>
  * </tr>
  * <tr>
@@ -849,7 +849,7 @@
  * Filters are selected by dataset creation properties, and some behavior may be controlled by data
  * transfer properties. The library determines what filters must be applied and applies them in the
  * order in which they were set by the application. That is, if an application calls
- * #H5Pset_shuffle and then #H5Pset_deflate when creating a dataset’s creation property list, the
+ * #H5Pset_shuffle and then #H5Pset_deflate when creating a dataset's creation property list, the
  * library will apply the shuffle filter first and then the deflate filter.
  *
  * For more information,
@@ -1147,8 +1147,8 @@ allocated if necessary.
  * are defined. See the example code below.
  *
  * The dimensions of the dataset can also be reduced. If the sizes specified are smaller than the
- * dataset’s current dimension sizes, #H5Dset_extent will reduce the dataset’s dimension sizes to the
- * specified values. It is the user’s responsibility to ensure that valuable data is not lost;
+ * dataset's current dimension sizes, #H5Dset_extent will reduce the dataset's dimension sizes to the
+ * specified values. It is the user's responsibility to ensure that valuable data is not lost;
  * #H5Dset_extent does not check.
  *
  * <em>Using #H5Dset_extent to increase the size of a dataset</em>
@@ -1298,7 +1298,7 @@ allocated if necessary.
  * </tr>
  * </table>
  *
- * Together these three properties control the library’s behavior. The table below summarizes the
+ * Together these three properties control the library's behavior. The table below summarizes the
  * possibilities during the dataset create-write-close cycle.
  *
  * <table>
@@ -1812,7 +1812,7 @@ allocated if necessary.
  * The first and second parameters can be obtained using the HDF5 dataspace and datatype
  * interface calls.
  *
- * A compound datatype can have members of array or compound datatype. An array datatype’s
+ * A compound datatype can have members of array or compound datatype. An array datatype's
  * base datatype can be a complex compound datatype. Recursive calls are required to set
  * parameters for these complex situations.
  *
@@ -1821,16 +1821,16 @@ allocated if necessary.
  * recursive calls.
  *
  * For an atomic datatype (integer or floating-point), parameters that will be stored include the
- * datatype’s size, endianness, precision, and offset.
+ * datatype's size, endianness, precision, and offset.
  *
  * For a no-op datatype, only the size is required.
  *
- * For a compound datatype, parameters that will be stored include the datatype’s total size and
+ * For a compound datatype, parameters that will be stored include the datatype's total size and
  * number of members. For each member, its member offset needs to be stored. Other parameters
  * for members will depend on the respective datatype class.
  *
- * For an array datatype, the total size parameter should be stored. Other parameters for the array’s
- * base type depend on the base type’s datatype class.
+ * For an array datatype, the total size parameter should be stored. Other parameters for the array's
+ * base type depend on the base type's datatype class.
  *
  * Further, to correctly retrieve the parameter for use of n-bit compression or decompression later,
  * parameters for distinguishing between datatype classes should be stored.
@@ -1897,7 +1897,7 @@ allocated if necessary.
  * In the function H5Z__set_parms_array:
  * <ul><li>1. Store the assigned numeric code for the array datatype in cd_value[i]; increment i</li>
  * <li>2. Get the size of the array datatype and store in cd_value[i]; increment i</li>
- * <li>3. Get the class of the array’s base datatype.
+ * <li>3. Get the class of the array's base datatype.
  *   <ul><li>For an integer or floating-point datatype, call H5Z__set_parms_atomic</li>
  *   <li>For an array datatype, call H5Z__set_parms_array</li>
  *   <li>For a compound datatype, call H5Z__set_parms_compound</li>

--- a/src/H5Dpublic.h
+++ b/src/H5Dpublic.h
@@ -222,7 +222,7 @@ typedef herr_t (*H5D_gather_func_t)(const void *dst_buf, size_t dst_buf_bytes_us
 /**
  * \brief Callback for H5Dchunk_iter()
  *
- * \param[in]     offset      Logical position of the chunk’s first element in units of dataset elements
+ * \param[in]     offset      Logical position of the chunk's first element in units of dataset elements
  * \param[in]     filter_mask Bitmask indicating the filters used when the chunk was written
  * \param[in]     addr        Chunk address in the file
  * \param[in]     size        Chunk size in bytes, 0 if the chunk does not exist
@@ -348,7 +348,7 @@ H5_DLL hid_t  H5Dcreate_async(hid_t loc_id, const char *name, hid_t type_id, hid
  *          specified, then the dataset will be created at the location
  *          where the attribute, dataset, or named datatype is attached.
  *
- *          The dataset’s datatype and dataspace are specified by
+ *          The dataset's datatype and dataspace are specified by
  *          \p type_id and \p space_id, respectively. These are the
  *          datatype and dataspace of the dataset as they will exist in
  *          the file, which may differ from the datatype and dataspace
@@ -543,7 +543,7 @@ H5_DLL hid_t H5Dget_create_plist(hid_t dset_id);
  *          cache properties will be set to the default. The chunk cache
  *          properties in the returned list are considered to be “set”,
  *          and any use of this list will override the corresponding
- *          properties in the file’s file access property list.
+ *          properties in the file's file access property list.
  *
  *          All link access properties in the returned list will be set
  *          to the default values.
@@ -660,7 +660,7 @@ H5_DLL herr_t H5Dget_num_chunks(hid_t dset_id, hid_t fspace_id, hsize_t *nchunks
  * \brief Retrieves information about a chunk specified by its coordinates
  *
  * \dset_id
- * \param[in]  offset      Logical position of the chunk’s first element in units of dataset elements
+ * \param[in]  offset      Logical position of the chunk's first element in units of dataset elements
  * \param[out] filter_mask Bitmask indicating the filters used when the chunk was written
  * \param[out] addr        Chunk address in the file
  * \param[out] size        Chunk size in bytes, 0 if the chunk does not exist
@@ -676,8 +676,8 @@ H5_DLL herr_t H5Dget_num_chunks(hid_t dset_id, hid_t fspace_id, hsize_t *nchunks
  *          filter_mask will not be modified.
  *
  *          \p offset is a pointer to a one-dimensional array with a size
- *          equal to the dataset’s rank. Each element is the logical
- *          position of the chunk’s first element in a dimension.
+ *          equal to the dataset's rank. Each element is the logical
+ *          position of the chunk's first element in a dimension.
  *
  * \since 1.10.5
  *
@@ -722,7 +722,7 @@ H5_DLL herr_t H5Dchunk_iter(hid_t dset_id, hid_t dxpl_id, H5D_chunk_iter_op_t cb
  * \dset_id
  * \param[in]  fspace_id File dataspace selection identifier (See Note below)
  * \param[in]  chk_idx   Index of the chunk
- * \param[out] offset    Logical position of the chunk’s first element in units of dataset elements
+ * \param[out] offset    Logical position of the chunk's first element in units of dataset elements
  * \param[out] filter_mask Bitmask indicating the filters used when the chunk was written
  * \param[out] addr      Chunk address in the file
  * \param[out] size      Chunk size in bytes, 0 if the chunk does not exist
@@ -1150,7 +1150,7 @@ H5_DLL herr_t H5Dwrite_multi_async(size_t count, hid_t dset_id[], hid_t mem_type
  * \dset_id
  * \dxpl_id
  * \param[in]  filters  Mask for identifying the filters in use
- * \param[in]  offset   Logical position of the chunk’s first element in the
+ * \param[in]  offset   Logical position of the chunk's first element in the
  *                      dataspace
  * \param[in]  data_size    Size of the actual data to be written in bytes
  * \param[in]  buf          Buffer containing data to be written to the chunk
@@ -1162,19 +1162,19 @@ H5_DLL herr_t H5Dwrite_multi_async(size_t count, hid_t dset_id[], hid_t mem_type
  *          from the application memory buffer \p buf to the dataset in
  *          the file. Typically, the data in \p buf is preprocessed in
  *          memory by a custom transformation, such as compression. The
- *          chunk will bypass the library’s internal data transfer
+ *          chunk will bypass the library's internal data transfer
  *          pipeline, including filters, and will be written directly to
  *          the file. Only one chunk can be written with this function.
  *
  *          \p filters is a mask providing a record of which filters are
  *          used with the chunk. The default value of the mask is
  *          zero (0), indicating that all enabled filters are applied. A
- *          filter is skipped if the bit corresponding to the filter’s
+ *          filter is skipped if the bit corresponding to the filter's
  *          position in the pipeline (0 ≤ position < 32) is turned on.
  *          This mask is saved with the chunk in the file.
  *
  *          \p offset is an array specifying the logical position of the
- *          first element of the chunk in the dataset’s dataspace. The
+ *          first element of the chunk in the dataset's dataspace. The
  *          length of the offset array must equal the number of dimensions,
  *          or rank, of the dataspace. The values in offset must not exceed
  *          the dimension limits and must specify a point that falls on
@@ -1213,10 +1213,10 @@ H5_DLL herr_t H5Dwrite_chunk(hid_t dset_id, hid_t dxpl_id, uint32_t filters, con
  *
  * \dset_id
  * \dxpl_id
- * \param[in]  offset   Logical position of the chunk’s first element in the
+ * \param[in]  offset   Logical position of the chunk's first element in the
  *                      dataspace
  * \param[in,out]  filters  Mask for identifying the filters in use
- * \param[out]  buf     Buffer containing data to be written to the chunk
+ * \param[out]  buf     Buffer containing data to be read from the chunk
  *
  * \return \herr_t
  *
@@ -1224,11 +1224,11 @@ H5_DLL herr_t H5Dwrite_chunk(hid_t dset_id, hid_t dxpl_id, uint32_t filters, con
  *          its logical offset \p offset in a chunked dataset \p dset_id
  *          from the dataset in the file into the application memory
  *          buffer \p buf. The data in \p buf is read directly from the
- *          file bypassing the library’s internal data transfer pipeline,
+ *          file bypassing the library's internal data transfer pipeline,
  *          including filters.
  *
  *          \p offset is an array specifying the logical position of the
- *          first element of the chunk in the dataset’s dataspace. The
+ *          first element of the chunk in the dataset's dataspace. The
  *          length of the \p offset array must equal the number of dimensions,
  *          or rank, of the dataspace. The values in \p offset must not exceed
  *          the dimension limits and must specify a point that falls on
@@ -1237,7 +1237,7 @@ H5_DLL herr_t H5Dwrite_chunk(hid_t dset_id, hid_t dxpl_id, uint32_t filters, con
  *          The mask \p filters indicates which filters were used when the
  *          chunk was written. A zero value (all bits 0) indicates that all
  *          enabled filters are applied on the chunk. A filter is skipped if
- *          the bit corresponding to the filter’s position in the pipeline
+ *          the bit corresponding to the filter's position in the pipeline
  *          (0 ≤ position < 32) is turned on.
  *
  *          \p buf is the memory buffer containing the chunk read from
@@ -1363,7 +1363,7 @@ H5_DLL herr_t H5Dfill(const void *fill, hid_t fill_type_id, void *buf, hid_t buf
  * --------------------------------------------------------------------------
  * \ingroup H5D
  *
- * \brief Changes the sizes of a dataset’s dimensions
+ * \brief Changes the sizes of a dataset's dimensions
  *
  * \dset_id
  * \param[in] size[]   Array containing the new magnitude of each dimension
@@ -1375,7 +1375,7 @@ H5_DLL herr_t H5Dfill(const void *fill, hid_t fill_type_id, void *buf, hid_t buf
  *          chunked dataset \p dset_id to the sizes specified in size.
  *
  *          \p size is a 1-dimensional array with n elements, where \p n is
- *          the rank of the dataset’s current dataspace.
+ *          the rank of the dataset's current dataspace.
  *
  *          This function can be applied to the following datasets:
  *          - A chunked dataset with unlimited dimensions
@@ -1390,20 +1390,20 @@ H5_DLL herr_t H5Dfill(const void *fill, hid_t fill_type_id, void *buf, hid_t buf
  *          extended only along the first dimension.
  *
  *          Space on disk is immediately allocated for the new dataset extent if
- *          the dataset’s space allocation time is set to #H5D_ALLOC_TIME_EARLY.
+ *          the dataset's space allocation time is set to #H5D_ALLOC_TIME_EARLY.
  *
  *          Fill values will be written to the dataset in either of the
  *          following situations, but not otherwise:
  *
- *          - If the dataset’s fill time is set to #H5D_FILL_TIME_IFSET and a
+ *          - If the dataset's fill time is set to #H5D_FILL_TIME_IFSET and a
  *            fill value is defined (see H5Pset_fill_time() and
  *            H5Pset_fill_value())
- *          - If the dataset’s fill time is set to #H5D_FILL_TIME_ALLOC
+ *          - If the dataset's fill time is set to #H5D_FILL_TIME_ALLOC
  *            (see H5Pset_alloc_time())
  *
- * \note If the sizes specified in \p size array are smaller than the dataset’s
- *       current dimension sizes, H5Dset_extent() will reduce the dataset’s
- *       dimension sizes to the specified values. It is the user application’s
+ * \note If the sizes specified in \p size array are smaller than the dataset's
+ *       current dimension sizes, H5Dset_extent() will reduce the dataset's
+ *       dimension sizes to the specified values. It is the user application's
  *       responsibility to ensure that valuable data is not lost as
  *       H5Dset_extent() does not check.
  *
@@ -1703,7 +1703,7 @@ H5_DLL herr_t H5Dget_chunk_index_type(hid_t did, H5D_chunk_index_t *idx_type);
  *          path from the root of the file. Use of this function requires that
  *          any intermediate groups specified in the path already exist.
  *
- *          The dataset’s datatype and dataspace are specified by \p type_id and
+ *          The dataset's datatype and dataspace are specified by \p type_id and
  *          \p space_id, respectively. These are the datatype and dataspace of
  *          the dataset as it will exist in the file, which may differ from the
  *          datatype and dataspace in application memory.
@@ -1719,7 +1719,7 @@ H5_DLL herr_t H5Dget_chunk_index_type(hid_t did, H5D_chunk_index_t *idx_type);
  *          H5reate1() and initialized with various property list functions
  *          described in Property List Interface.
  *
- *          H5Dcreate() and H5Dcreate_anon() return an error if the dataset’s
+ *          H5Dcreate() and H5Dcreate_anon() return an error if the dataset's
  *          datatype includes a variable-length (VL) datatype and the fill value
  *          is undefined, i.e., set to \c NULL in the dataset creation property
  *          list. Such a VL datatype may be directly included, indirectly
@@ -1799,9 +1799,9 @@ H5_DLL hid_t H5Dopen1(hid_t loc_id, const char *name);
  *              (see H5Screate_simple())
  *
  *          Space on disk is immediately allocated for the new dataset extent if
- *          the dataset’s space allocation time is set to
+ *          the dataset's space allocation time is set to
  *          #H5D_ALLOC_TIME_EARLY. Fill values will be written to the dataset if
- *          the dataset’s fill time is set to #H5D_FILL_TIME_IFSET or
+ *          the dataset's fill time is set to #H5D_FILL_TIME_IFSET or
  *          #H5D_FILL_TIME_ALLOC. (See H5Pset_fill_time() and
  *          H5Pset_alloc_time().)
  *

--- a/src/H5Emodule.h
+++ b/src/H5Emodule.h
@@ -44,7 +44,7 @@
  *
  * \ref subsec_error_adv talks about the advanced concepts of error
  * class and error stack handle and talks about the related functions. With these concepts and functions, an
- * application library or program using the HDF5 Library can have its own error report blended with HDF5’s
+ * application library or program using the HDF5 Library can have its own error report blended with HDF5's
  * error report.
  *
  * Starting with Release 1.8, we have a new set of Error Handling API functions. For the purpose of backward
@@ -76,8 +76,8 @@
  * \subsubsection subsubsec_error_ops_stack Error Stack and Error Message
  * In normal circumstances, an error causes the stack to be printed on the standard error stream
  * automatically.
- * This automatic error stack is the library’s default stack. For all the functions in this section, whenever
- * an error stack ID is needed as a parameter, \ref H5E_DEFAULT can be used to indicate the library’s default
+ * This automatic error stack is the library's default stack. For all the functions in this section, whenever
+ * an error stack ID is needed as a parameter, \ref H5E_DEFAULT can be used to indicate the library's default
  * stack. The first error record of the error stack, number #000, is produced by the API function itself and
  * is usually sufficient to indicate to the application what went wrong.
  *  <table>
@@ -164,7 +164,7 @@
  *      H5Eget_auto2(error_stack, &old_func, &old_client_data);
  *      ***  Turn off error handling  ***
  *      H5Eset_auto2(error_stack, NULL, NULL);
- *      ***  Probe. Likely to fail, but that’s okay  ***
+ *      ***  Probe. Likely to fail, but that's okay  ***
  *      status = H5Fopen (......);
  *      ***  Restore previous error handler  ***
  *      H5Eset_auto2(error_stack, old_func, old_client_data);
@@ -300,7 +300,7 @@
  *   <caption align=top>Example:  An Error Report</caption>
  *   <tr>
  *     <td>
- *       <p>An error report shows both the library’s error record and the application’s error records.
+ *       <p>An error report shows both the library's error record and the application's error records.
  *          See the example below.
  *       <p><code><pre>
  * Error Test-DIAG: Error detected in Error Program (1.0)
@@ -323,9 +323,9 @@
  *   </tr>
  * </table>
  * In the line above error record #002 in the example above, the starting phrase is HDF5. This is the error
- * class name of the HDF5 Library. All of the library’s error messages (major and minor) are in this default
+ * class name of the HDF5 Library. All of the library's error messages (major and minor) are in this default
  * error class. The Error Test in the beginning of the line above error record #000 is the name of the
- * application’s error class. The first two error records, #000 and #001, are from application’s error class.
+ * application's error class. The first two error records, #000 and #001, are from application's error class.
  * By definition, an error class is a group of major and minor error messages for a library (the HDF5 Library
  * or an application library built on top of the HDF5 Library) or an application program. The error class can
  * be registered for a library or program through the HDF5 Error API. Major and minor messages can be defined

--- a/src/H5Epublic.h
+++ b/src/H5Epublic.h
@@ -276,7 +276,7 @@ H5_DLL hid_t H5Ecreate_msg(hid_t cls, H5E_type_t msg_type, const char *msg);
  * \return \hid_ti{error stack}
  *
  * \details H5Ecreate_stack() creates a new empty error stack and returns the
- *          new stack’s identifier. Use H5Eclose_stack() to close the error stack
+ *          new stack's identifier. Use H5Eclose_stack() to close the error stack
  *          identifier returned by this function.
  *
  * \since 1.8.0
@@ -530,7 +530,7 @@ H5_DLL herr_t H5Ewalk2(hid_t err_stack, H5E_direction_t direction, H5E_walk2_t f
  *          H5Eget_auto2() will fail and will indicate that the application has
  *          mixed H5Eset_auto1() and H5Eget_auto2(). On the other hand, mixing
  *          H5Eset_auto2() and H5Eget_auto1() will also cause a failure. But if
- *          the traversal functions are the library’s default H5Eprint1() or
+ *          the traversal functions are the library's default H5Eprint1() or
  *          H5Eprint2(), mixing H5Eset_auto1() and H5Eget_auto2() or mixing
  *          H5Eset_auto2() and H5Eget_auto1() does not fail.
  *
@@ -768,7 +768,7 @@ H5_DLL herr_t H5Eclear1(void);
  *          H5Eget_auto2() will fail and will indicate that the application has
  *          mixed H5Eset_auto1() and H5Eget_auto2(). On the other hand, mixing
  *          H5Eset_auto2() and H5Eget_auto1() will also cause a failure. But if
- *          the traversal functions are the library’s default H5Eprint1() or
+ *          the traversal functions are the library's default H5Eprint1() or
  *          H5Eprint2(), mixing H5Eset_auto1() and H5Eget_auto2() or mixing
  *          H5Eset_auto2() and H5Eget_auto1() does not fail.
  *

--- a/src/H5FDdevelop.h
+++ b/src/H5FDdevelop.h
@@ -163,7 +163,7 @@ typedef struct H5FD_t H5FD_t;
 
 /* Class information for each file driver */
 typedef struct H5FD_class_t {
-    unsigned           version; /**< File driver class struct version #     */
+    unsigned           version; /**< File driver class struct version number */
     H5FD_class_value_t value;
     const char        *name;
     haddr_t            maxaddr;

--- a/src/H5FDdirect.h
+++ b/src/H5FDdirect.h
@@ -54,7 +54,7 @@ H5_DLL hid_t H5FD_direct_init(void);
  *          cached by the system.
  *
  *          File systems usually require the data address in memory, the file
- *          address, and the size of the data to be aligned. The HDF5 library’s
+ *          address, and the size of the data to be aligned. The HDF5 library's
  *          direct I/O driver is able to handle unaligned data, though that will
  *          consume some additional memory resources and may slow
  *          performance. To get better performance, use the system function \p
@@ -67,7 +67,7 @@ H5_DLL hid_t H5FD_direct_init(void);
  *          \p alignment specifies the required alignment boundary in memory.
  *
  *          \p block_size specifies the file system block size. A value of 0
- *          (zero) means to use HDF5 library’s default value of 4KB.
+ *          (zero) means to use HDF5 library's default value of 4KB.
  *
  *          \p cbuf_size specifies the copy buffer size.
  *

--- a/src/H5FDwindows.h
+++ b/src/H5FDwindows.h
@@ -44,7 +44,7 @@ extern "C" {
  *          comes.
  *
  *          Only the Windows driver is tested on Windows systems; other drivers
- *          are used at the application’s and the user’s risk.
+ *          are used at the application's and the user's risk.
  *
  *          Furthermore, the Windows driver is tested and available only on
  *          Windows systems; it is not available on non-Windows systems.

--- a/src/H5Fmodule.h
+++ b/src/H5Fmodule.h
@@ -133,7 +133,7 @@
  * \li Single file on a standard file system
  * \li Multiple files on a standard file system
  * \li Multiple files on a parallel file system
- * \li Block of memory within an application’s memory space
+ * \li Block of memory within an application's memory space
  * \li More abstract situations such as virtual files
  *
  * This HDF5 address space is generally referred to as an HDF5 file regardless of its organization at
@@ -347,7 +347,7 @@
  * </tr>
  * <tr>
  * <td>#H5Fget_mdc_hit_rate</td>
- * <td>Obtains target file’s metadata cache hit rate.</td>
+ * <td>Obtains target file's metadata cache hit rate.</td>
  * </tr>
  * <tr>
  * <td>#H5Fget_mdc_size</td>
@@ -436,7 +436,7 @@
  *
  * The new file is created with the properties specified in the property lists fcpl_id and fapl_id.
  * fcpl is short for file creation property list. fapl is short for file access property list. Specifying
- * #H5P_DEFAULT for either the creation or access property list will use the library’s default
+ * #H5P_DEFAULT for either the creation or access property list will use the library's default
  * creation or access properties.
  *
  * If #H5Fcreate successfully creates the file, it returns a file identifier for the new file. This
@@ -629,7 +629,7 @@
  * #H5Pget_sieve_buf_size retrieves the current maximum size of the data sieve buffer.
  *
  * <h4>Garbage Collection References</h4>
- * Dataset region references and other reference types use space in an HDF5 file’s global heap. If
+ * Dataset region references and other reference types use space in an HDF5 file's global heap. If
  * garbage collection is on (1) and the user passes in an uninitialized value in a reference structure,
  * the heap might become corrupted. When garbage collection is off (0), however, and the user reuses
  * a reference, the previous heap block will be orphaned and not returned to the free heap
@@ -644,7 +644,7 @@
  * \li Single file on standard file system
  * \li Multiple files on standard file system
  * \li Multiple files on parallel file system
- * \li Block of memory within application’s memory space
+ * \li Block of memory within application's memory space
  * \li More abstract situations such as virtual files
  *
  * This HDF5 address space is generally referred to as an HDF5 file regardless of its organization at
@@ -1029,7 +1029,7 @@
  * function.
  *
  * \subsubsection subsubsec_file_alternate_drivers_par The Parallel Driver
- * Parallel environments require a parallel low-level driver. HDF5’s default driver for parallel
+ * Parallel environments require a parallel low-level driver. HDF5's default driver for parallel
  * systems is called the Parallel driver, #H5FD_MPIO. This driver uses the MPI standard for both
  * communication and file I/O.
  *

--- a/src/H5Fprivate.h
+++ b/src/H5Fprivate.h
@@ -293,7 +293,7 @@ typedef struct H5F_t H5F_t;
 #define H5F_SIGNATURE     "\211HDF\r\n\032\n"
 #define H5F_SIGNATURE_LEN 8
 
-/* Version #'s of the major components of the file format */
+/* Version number's of the major components of the file format */
 #define HDF5_SUPERBLOCK_VERSION_DEF 0 /* The default super block format      */
 #define HDF5_SUPERBLOCK_VERSION_1   1 /* Version with non-default B-tree 'K' value */
 #define HDF5_SUPERBLOCK_VERSION_2   2 /* Revised version with superblock extension and checksum */

--- a/src/H5Fpublic.h
+++ b/src/H5Fpublic.h
@@ -124,17 +124,17 @@ typedef enum H5F_close_degree_t {
 //! <!-- [H5F_info2_t_snip] -->
 typedef struct H5F_info2_t {
     struct {
-        unsigned version;        /**< Superblock version # */
+        unsigned version;        /**< Superblock version number */
         hsize_t  super_size;     /**< Superblock size */
         hsize_t  super_ext_size; /**< Superblock extension size */
     } super;
     struct {
-        unsigned version;   /**< Version # of file free space management */
+        unsigned version;   /**< Version number of file free space management */
         hsize_t  meta_size; /**< Free space manager metadata size */
         hsize_t  tot_space; /**< Amount of free space in the file */
     } free;
     struct {
-        unsigned     version;   /**< Version # of shared object header info */
+        unsigned     version;   /**< Version number of shared object header info */
         hsize_t      hdr_size;  /**< Shared object header message header size */
         H5_ih_info_t msgs_info; /**< Shared object header message index & heap size */
     } sohm;

--- a/src/H5Fpublic.h
+++ b/src/H5Fpublic.h
@@ -1172,7 +1172,7 @@ H5_DLL ssize_t H5Fget_name(hid_t obj_id, char *name, size_t size);
 /**
  * \ingroup H5F
  *
- * \brief Retrieves name of file to which object belongs
+ * \brief Retrieves global file information
  *
  * \fgdta_obj_id
  * \param[out] file_info Buffer for global file information
@@ -1845,7 +1845,7 @@ typedef struct H5F_info1_t {
 /**
  * \ingroup H5F
  *
- * \brief Retrieves name of file to which object belongs
+ * \brief Retrieves global file information
  *
  * \fgdta_obj_id
  * \param[out] file_info Buffer for global file information

--- a/src/H5Fpublic.h
+++ b/src/H5Fpublic.h
@@ -957,7 +957,7 @@ H5_DLL herr_t H5Fincrement_filesize(hid_t file_id, hsize_t increment);
  * \file_id
  * \param[out] buf_ptr Pointer to the buffer into which the image of the
  *                     HDF5 file is to be copied. If \p buf_ptr is NULL,
- *                     no data will be copied but the function’s return value
+ *                     no data will be copied but the function's return value
  *                     will still indicate the buffer size required (or a
  *                     negative value on error).
  * \param[out] buf_len Size of the supplied buffer
@@ -974,7 +974,7 @@ H5_DLL herr_t H5Fincrement_filesize(hid_t file_id, hsize_t increment);
  *          file image. So if the file size is unknown, it can be safely
  *          determined with an initial H5Fget_file_image() call with buf_ptr
  *          set to NULL. The file image can then be retrieved with a second
- *          H5Fget_file_image() call with \p buf_len set to the initial call’s
+ *          H5Fget_file_image() call with \p buf_len set to the initial call's
  *          return value.
  *
  *          While the current file size can also be retrieved with
@@ -1320,7 +1320,7 @@ H5_DLL herr_t H5Fget_metadata_read_retry_info(hid_t file_id, H5F_retry_info_t *i
  *              on a system that is not atomic.
  *          \li Turn off usage of the library's accumulator to avoid possible
  *              ordering problem on a system that is not atomic.
- *          \li Perform a flush of the file’s data buffers and metadata to set
+ *          \li Perform a flush of the file's data buffers and metadata to set
  *              a consistent state for starting SWMR write operations.
  *
  *          Library objects are groups, datasets, and committed datatypes. For
@@ -1390,7 +1390,7 @@ H5_DLL ssize_t H5Fget_free_sections(hid_t file_id, H5F_mem_t type, size_t nsects
  * \return \herr_t
  *
  * \details H5Fclear_elink_file_cache() evicts all the cached child files in
- *          the specified file’s external file cache, causing them to be closed
+ *          the specified file's external file cache, causing them to be closed
  *          if there is nothing else holding them open.
  *
  *          H5Fclear_elink_file_cache() does not close the cache itself;

--- a/src/H5Gmodule.h
+++ b/src/H5Gmodule.h
@@ -46,7 +46,7 @@
  * In the first figure below, the group structure is strictly hierarchical, identical to the file system
  * analogs.
  *
- * In the next two figures below, the structure takes advantage of the directed graph’s allowance of
+ * In the next two figures below, the structure takes advantage of the directed graph's allowance of
  * circular references. In the second figure, GroupA is not only a member of the root group, /, but a
  * member of GroupC. Since Group C is a member of Group B and Group B is a member of Group
  * A, Dataset1 can be accessed by means of the circular reference /Group A/Group B/Group
@@ -189,7 +189,7 @@
  * like a regular or hard link. The differences are that the hard link cannot be created if the target
  * object does not exist and it always points to the same object. A soft link can be created with any
  * path name, whether or not the object exists; it may or may not, therefore, be possible to follow a
- * soft link. Furthermore, a soft link’s target object may be changed.
+ * soft link. Furthermore, a soft link's target object may be changed.
  *
  * \subsubsection subsubsec_group_descr_path HDF5 Path Names
  * The structure of the HDF5 file constitutes the name space for the objects in the file. A path name
@@ -257,14 +257,14 @@
  * for very small groups, improved link indexing for large groups, and other advanced features.
  * <ul>
  * <li>The original indexed format remains the default. Links are stored in a B-tree in the
- * group’s local heap.</li>
+ * group's local heap.</li>
  * <li>Groups created in the new compact-or-indexed format, the implementation introduced
  * with Release 1.8.0, can be tuned for performance, switching between the compact and
  * indexed formats at thresholds set in the user application.
  * <ul>
  * <li>The compact format will conserve file space and processing overhead when
  * working with small groups and is particularly valuable when a group contains
- * no links. Links are stored as a list of messages in the group’s header.</li>
+ * no links. Links are stored as a list of messages in the group's header.</li>
  * <li>The indexed format will yield improved performance when working with large
  * groups. A large group may contain thousands to millions of members. Links
  * are stored in a fractal heap and indexed with an improved B-tree.</li>
@@ -385,7 +385,7 @@
  * </tr>
  * <tr>
  * <td>#H5Gget_info_by_idx</td>
- * <td>Retrieves information about a group according to the group’s position within an index.</td>
+ * <td>Retrieves information about a group according to the group's position within an index.</td>
  * </tr>
  * <tr>
  * <td>#H5Gget_info_by_name</td>
@@ -523,7 +523,7 @@
  * A path that begins with a slash (/) is
  * an absolute path indicating that it locates the new group from the root group of the HDF5 file. A
  * path that begins with any other character is a relative path. When the location is a file, a relative
- * path is a path from that file’s root group; when the location is a group, a relative path is a path
+ * path is a path from that file's root group; when the location is a group, a relative path is a path
  * from that group.
  *
  * The sample code in the example below creates three groups. The group Data is created in the
@@ -692,7 +692,7 @@
  * entry in the \ref RM for the #H5Pset_elink_file_cache_size function call.
  *
  * <h4>Note Regarding Hard Links and Soft Links</h4>
- * Note that an object’s existence in a file is governed by the presence of at least one hard link to
+ * Note that an object's existence in a file is governed by the presence of at least one hard link to
  * that object. If the last hard link to an object is removed, the object is removed from the file and
  * any remaining soft link becomes a dangling link, a link whose target object does not exist.
  *
@@ -710,7 +710,7 @@
  *
  * <h5>Scenario 2: Moving a Link that Isolates an Object</h5>
  * Consider the following example: assume that the group group2 can only be accessed via the
- * following path, where top_group is a member of the file’s root group:
+ * following path, where top_group is a member of the file's root group:
  * <em>/top_group/group1/group2/</em>
  *
  * Using #H5Lmove, top_group is renamed to be a member ofgroup2. At this point, since
@@ -780,7 +780,7 @@
  * </table>
  *
  * Figure 10 illustrates loops in an HDF5 file structure. The file in part a contains three groups
- * and a dataset; group2 is a member of the root group and of the root group’s other member group,
+ * and a dataset; group2 is a member of the root group and of the root group's other member group,
  * group1. group2 thus can be accessed by either of two paths: /group2 or /group1/GXX. Similarly,
  * the dataset can be accessed either as /group2/dset1 or as /group1/GXX/dset1.
  *
@@ -906,7 +906,7 @@
  *          indexing for large groups, and other advanced features.
  *
  *          \li The \Emph{original indexed} format remains the default. Links
- *              are stored in a B-tree in the group’s local heap.
+ *              are stored in a B-tree in the group's local heap.
  *          \li Groups created in the new \Emph{compact-or-indexed} format, the
  *              implementation introduced with Release 1.8.0, can be tuned for
  *              performance, switching between the compact and indexed formats
@@ -914,7 +914,7 @@
  *              - The \Emph{compact} format will conserve file space and processing
  *                overhead when working with small groups and is particularly
  *                valuable when a group contains no links. Links are stored
- *                as a list of messages in the group’s header.
+ *                as a list of messages in the group's header.
  *              - The \Emph{indexed} format will yield improved
  *                performance when working with large groups, e.g., groups
  *                containing thousands to millions of members. Links are stored in

--- a/src/H5Gpublic.h
+++ b/src/H5Gpublic.h
@@ -148,7 +148,7 @@ H5_DLL hid_t  H5Gcreate_async(hid_t loc_id, const char *name, hid_t lcpl_id, hid
  *          provides similar functionality to that provided by
  *          H5Gcreate1(), with the differences described in the list below.
  *
- *          The new group’s creation and access properties are specified
+ *          The new group's creation and access properties are specified
  *          in \p gcpl_id and \p gapl_id, respectively.
  *
  *          H5Gcreate_anon() returns a new group identifier. This identifier
@@ -160,12 +160,12 @@ H5_DLL hid_t  H5Gcreate_async(hid_t loc_id, const char *name, hid_t lcpl_id, hid
  *
  *          \li H5Gcreate1() does not provide for the use of custom property
  *              lists; H5Gcreate1() always uses default properties.
- *          \li H5Gcreate_anon() neither provides the new group’s name
+ *          \li H5Gcreate_anon() neither provides the new group's name
  *              nor links it into the HDF5 file structure; those actions
  *              must be performed separately through a call to H5Olink(),
  *              which offers greater control over linking.
  *          \li H5Gcreate_anon() does not directly provide a hint mechanism
- *              for the group’s heap size. Comparable information can be
+ *              for the group's heap size. Comparable information can be
  *              included in the group creation property list \p gcpl_id through
  *              a H5Pset_local_heap_size_hint() call.
  *
@@ -331,7 +331,7 @@ H5_DLL herr_t H5Gget_info_by_name_async(hid_t loc_id, const char *name, H5G_info
  *-------------------------------------------------------------------------
  * \ingroup H5G
  *
- * \brief Retrieves information about a group, according to the group’s
+ * \brief Retrieves information about a group, according to the group's
  *        position within an index
  *
  * \fgdta_loc_id
@@ -884,7 +884,7 @@ H5_DLL herr_t H5Gget_linkval(hid_t loc_id, const char *name, size_t size, char *
  *          \p loc_id can specify any object in the file. name can be one of the
  *          following:
  *          \li The name of the object relative to \p loc_id
- *          \li An absolute name of the object, starting from \c /, the file’s
+ *          \li An absolute name of the object, starting from \c /, the file's
  *              root group
  *          \li A dot (\c .), if \p loc_id fully specifies the object
  *
@@ -927,7 +927,7 @@ H5_DLL herr_t H5Gset_comment(hid_t loc_id, const char *name, const char *comment
  *          \p loc_id can specify any object in the file. name can be one of the
  *          following:
  *          \li The name of the object relative to \p loc_id
- *          \li An absolute name of the object, starting from \c /, the file’s
+ *          \li An absolute name of the object, starting from \c /, the file's
  *              root group
  *          \li A dot (\c .), if \p loc_id fully specifies the object
  *

--- a/src/H5Ipublic.h
+++ b/src/H5Ipublic.h
@@ -144,7 +144,7 @@ H5_DLL hid_t H5Iregister(H5I_type_t type, const void *object);
  *
  * \note H5Iobject_verify() does not change the ID it is called on in any way
  *       (as opposed to H5Iremove_verify(), which removes the ID from its
- *       type’s hash table).
+ *       type's hash table).
  *
  * \see H5Iregister()
  *
@@ -335,14 +335,14 @@ H5_DLL int H5Iinc_ref(hid_t id);
  *
  *          The reference count for a newly created object will be 1. Reference
  *          counts for objects may be explicitly modified with this function or
- *          with H5Iinc_ref(). When an object identifier’s reference count
+ *          with H5Iinc_ref(). When an object identifier's reference count
  *          reaches zero, the object will be closed. Calling an object
- *          identifier’s \c close function decrements the reference count for
+ *          identifier's \c close function decrements the reference count for
  *          the identifier, which normally closes the object, but if the
  *          reference count for the identifier has been incremented with
  *          H5Iinc_ref(), the object will only be closed when the reference
  *          count reaches zero with further calls to this function or the
- *          object identifier’s \c close function.
+ *          object identifier's \c close function.
  *
  *          If the object ID was created by a collective parallel call (such as
  *          H5Dcreate(), H5Gopen(), etc.), the reference count should be
@@ -454,9 +454,9 @@ H5_DLL herr_t H5Iclear_type(H5I_type_t type, hbool_t force);
  *          identifiers of this type are destroyed and no new identifiers of
  *          this type can be registered.
  *
- *          The type’s free function is called on all of the identifiers which
+ *          The type's free function is called on all of the identifiers which
  *          are deleted by this function, freeing their memory. In addition,
- *          all memory used by this type’s hash table is freed.
+ *          all memory used by this type's hash table is freed.
  *
  *          Since the H5I_type_t values of destroyed identifier types are
  *          reused when new types are registered, it is a good idea to set the

--- a/src/H5Lpublic.h
+++ b/src/H5Lpublic.h
@@ -198,7 +198,7 @@ H5_DLL herr_t H5Lmove(hid_t src_loc, const char *src_name, hid_t dst_loc, const 
  *          \p dst_name.
  *
  *          If \p dst_loc_id is a file identifier, \p dst_name will be
- *          interpreted relative to that file’s root group.
+ *          interpreted relative to that file's root group.
  *
  *          The new link is created with the creation and access property lists
  *          specified by \p lcpl_id and \p lapl_id. The interpretation of
@@ -342,7 +342,7 @@ H5_DLL herr_t H5Lcreate_hard_async(hid_t cur_loc_id, const char *cur_name, hid_t
  *       the new link, use H5Lcreate_external() to create an external link.
  *
  * \note Soft links and external links are also known as symbolic links as they
- *       use a name to point to an object; hard links employ an object’s
+ *       use a name to point to an object; hard links employ an object's
  *       address in the file.
  *
  * \note Unlike hard links, a soft link in an HDF5 file is allowed to dangle,
@@ -617,7 +617,7 @@ H5_DLL herr_t H5Lget_val_by_idx(hid_t loc_id, const char *group_name, H5_index_t
  *
  *          If the link to be verified is specified with an absolute path, the
  *          same approach should be used, but starting with the first link in
- *          the file’s root group. For instance, if \c datasetD were in
+ *          the file's root group. For instance, if \c datasetD were in
  *          \c /group1/group2/softlink_to_group3, the first call to H5Lexists()
  *          would have name set to \c /group1.
  *
@@ -710,7 +710,7 @@ H5_DLL herr_t H5Lexists_async(hid_t loc_id, const char *name, hbool_t *exists, h
  *          There will be additional valid values if user-defined links have
  *          been registered.
  *
- *          \p corder specifies the link’s creation order position, while
+ *          \p corder specifies the link's creation order position, while
  *          \p corder_valid indicates whether the value in corder is valid.
  *
  *          If \p corder_valid is \c TRUE, the value in \p corder is known to
@@ -982,7 +982,7 @@ H5_DLL herr_t H5Literate_async(hid_t group_id, H5_index_t idx_type, H5_iter_orde
  *
  * \warning H5Literate_by_name2() assumes that the membership of the group being
  *          iterated over remains unchanged through the iteration; if any of the
- *          links in the group change during the iteration, the function’s
+ *          links in the group change during the iteration, the function's
  *          behavior is undefined. Note, however, that objects pointed to by the
  *          links can be modified.
  *
@@ -1112,7 +1112,7 @@ H5_DLL herr_t H5Lvisit2(hid_t grp_id, H5_index_t idx_type, H5_iter_order_t order
  *          The group serving as the root of the iteration is specified by the
  *          \p loc_id / \p group_name parameter pair. \p loc_id specifies a
  *          file or group; group_name specifies either a group in the file
- *          (with an absolute name based in the file’s root group) or a group
+ *          (with an absolute name based in the file's root group) or a group
  *          relative to \p loc_id. If \p loc_id fully specifies the group that
  *          is to serve as the root of the iteration, group_name should be '.'
  *          (a dot). (Note that when \p loc_id fully specifies the group
@@ -1301,7 +1301,7 @@ H5_DLL herr_t H5Lunpack_elink_val(const void *ext_linkval /*in*/, size_t link_si
  *          \p file_name identifies the target file containing the target
  *          object; \p obj_name specifies the path of the target object within
  *          that file. \p obj_name must be an absolute pathname in
- *          \p file_name, i.e., it must start at the target file’s root group,
+ *          \p file_name, i.e., it must start at the target file's root group,
  *          but it is not interpreted until an application attempts to traverse
  *          it.
  *
@@ -1507,7 +1507,7 @@ typedef herr_t (*H5L_iterate1_t)(hid_t group, const char *name, const H5L_info1_
  *          There will be additional valid values if user-defined links have
  *          been registered.
  *
- *          \c corder specifies the link’s creation order position while
+ *          \c corder specifies the link's creation order position while
  *          \c corder_valid indicates whether the value in \c corder is valid.
  *
  *          If \c corder_valid is \c TRUE, the value in \c corder is known to
@@ -1516,7 +1516,7 @@ typedef herr_t (*H5L_iterate1_t)(hid_t group, const char *name, const H5L_info1_
  *
  *          \c corder starts at zero (0) and is incremented by one (1) as new
  *          links are created. But higher-numbered entries are not adjusted
- *          when a lower-numbered link is deleted; the deleted link’s creation
+ *          when a lower-numbered link is deleted; the deleted link's creation
  *          order position is simply left vacant. In such situations, the value
  *          of \c corder for the last link created will be larger than the
  *          number of links remaining in the group.
@@ -1728,7 +1728,7 @@ H5_DLL herr_t H5Literate1(hid_t grp_id, H5_index_t idx_type, H5_iter_order_t ord
  *
  * \warning H5Literate_by_name1() assumes that the membership of the group being
  *          iterated over remains unchanged through the iteration; if any of the
- *          links in the group change during the iteration, the function’s
+ *          links in the group change during the iteration, the function's
  *          behavior is undefined. Note, however, that objects pointed to by the
  *          links can be modified.
  *
@@ -1872,7 +1872,7 @@ H5_DLL herr_t H5Lvisit1(hid_t grp_id, H5_index_t idx_type, H5_iter_order_t order
  *          The group serving as the root of the iteration is specified by the
  *          \p loc_id / \p group_name parameter pair. \p loc_id specifies a
  *          file or group; group_name specifies either a group in the file
- *          (with an absolute name based in the file’s root group) or a group
+ *          (with an absolute name based in the file's root group) or a group
  *          relative to \p loc_id. If \p loc_id fully specifies the group that
  *          is to serve as the root of the iteration, group_name should be '.'
  *          (a dot). (Note that when \p loc_id fully specifies the group

--- a/src/H5Oprivate.h
+++ b/src/H5Oprivate.h
@@ -402,7 +402,7 @@ typedef struct H5O_efl_t {
 #define H5O_LAYOUT_ALL_CHUNK_FLAGS                                                                           \
     (H5O_LAYOUT_CHUNK_DONT_FILTER_PARTIAL_BOUND_CHUNKS | H5O_LAYOUT_CHUNK_SINGLE_INDEX_WITH_FILTER)
 
-/* Version # of encoded virtual dataset global heap blocks */
+/* Version number of encoded virtual dataset global heap blocks */
 #define H5O_LAYOUT_VDS_GH_ENC_VERS 0
 
 /* Initial version of the layout information.  Used when space is allocated */

--- a/src/H5Opublic.h
+++ b/src/H5Opublic.h
@@ -428,7 +428,7 @@ H5_DLL hid_t  H5Oopen_by_idx_async(hid_t loc_id, const char *group_name, H5_inde
  * \par
  *          If the link to be verified is specified with an absolute path,
  *          the same approach should be used, but starting with the first
- *          link in the file’s root group. For instance, if \c datasetD
+ *          link in the file's root group. For instance, if \c datasetD
  *          were in \c /group1/group2/softlink_to_group3, the first call to
  *          H5Lexists() would have name set to \c /group1.
  *
@@ -517,7 +517,7 @@ H5_DLL herr_t H5Oget_info3(hid_t loc_id, H5O_info2_t *oinfo, unsigned fields);
  *
  * \return \herr_t
  *
- * \details H5Oget_info_by_name3() specifies an object’s location and name,
+ * \details H5Oget_info_by_name3() specifies an object's location and name,
  *          \p loc_id and \p name, respectively, and retrieves the metadata
  *          describing that object in \p oinfo, an H5O_info2_t struct.
  *
@@ -575,7 +575,7 @@ H5_DLL herr_t H5Oget_info_by_name_async(hid_t loc_id, const char *name, H5O_info
  *          object in the \c struct \p oinfo, as specified by the location,
  *          \p loc_id, group name, \p group_name, the index by which objects
  *          in that group are tracked, \p idx_type, the order by which the
- *          index is to be traversed, \p order, and an object’s position
+ *          index is to be traversed, \p order, and an object's position
  *          \p n within that index.
  *
  *          If \p loc_id fully specifies the group in which the object resides,
@@ -785,12 +785,12 @@ H5_DLL herr_t H5Olink(hid_t obj_id, hid_t new_loc_id, const char *new_name, hid_
  *          an object by address is added. When the link is deleted,
  *          H5Odecr_refcount() should be used.
  *
- *          An object’s reference count is the number of hard links in the
+ *          An object's reference count is the number of hard links in the
  *          file that point to that object. See the “Programming Model”
  *          section of the HDF5 Groups chapter in the -- <em>\ref UG</em>
  *          for a complete discussion of reference counts.
  *
- *          If a user application needs to determine an object’s reference
+ *          If a user application needs to determine an object's reference
  *          count, an H5Oget_info() call is required; the reference count
  *          is returned in the \c rc field of the #H5O_info_t \c struct.
  *
@@ -820,12 +820,12 @@ H5_DLL herr_t H5Oincr_refcount(hid_t object_id);
  *          an object by address is deleted. In general, H5Oincr_refcount() will have
  *          been used previously, when the link was created.
  *
- *          An object’s reference count is the number of hard links in the
+ *          An object's reference count is the number of hard links in the
  *          file that point to that object. See the “Programming Model”
  *          section of the HDF5 Groups chapter in the <em>\ref UG</em>
  *          for a more complete discussion of reference counts.
  *
- *          If a user application needs to determine an object’s reference
+ *          If a user application needs to determine an object's reference
  *          count, an H5Oget_info() call is required; the reference count
  *          is returned in the \c rc field of the #H5O_info_t \c struct.
  *
@@ -863,13 +863,13 @@ H5_DLL herr_t H5Odecr_refcount(hid_t object_id);
  *          The destination location, as specified in dst_loc_id, may
  *          be a group in the current file or a location in a different
  *          file. If dst_loc_id is a file identifier, the copy will be
- *          placed in that file’s root group.
+ *          placed in that file's root group.
  *
  *          The copy will be created with the path specified in \p dst_name,
  *          which must not pre-exist in the destination location. If
  *          \p dst_name already exists at the location \p dst_loc_id,
  *          H5Ocopy() will fail. If \p dst_name is an absolute path,
- *          the copy will be created relative to the file’s root group.
+ *          the copy will be created relative to the file's root group.
  *
  *          The copy of the object is created with the property lists
  *          specified by \p ocpypl_id and \p lcpl_id. #H5P_DEFAULT can be passed
@@ -1003,7 +1003,7 @@ H5_DLL herr_t H5Oset_comment(hid_t obj_id, const char *comment);
  *          \p name can be one of the following:
  *
  *          - The name of the object specified as a path relative to \p loc_id
- *          - An absolute name of the object, starting from \c /, the file’s root group
+ *          - An absolute name of the object, starting from \c /, the file's root group
  *          - A dot (\c .), if \p loc_id fully specifies the object
  *
  *          If \p comment is an empty string or a null pointer, any existing
@@ -1095,7 +1095,7 @@ H5_DLL ssize_t H5Oget_comment(hid_t obj_id, char *comment, size_t bufsize);
  *          \p name can be one of the following:
  *
  *          - The name of the object relative to \p loc_id
- *          - An absolute name of the object, starting from \c /, the file’s root group
+ *          - An absolute name of the object, starting from \c /, the file's root group
  *          - A dot (\c .), if \p loc_id fully specifies the object
  *
  *          The size in bytes of the comment, including the \c NULL terminator,
@@ -1157,7 +1157,7 @@ H5_DLL ssize_t H5Oget_comment_by_name(hid_t loc_id, const char *name, char *comm
  *
  *          If \p obj_id is a group identifier, that group serves as the
  *          root of a recursive iteration. If \p obj_id is a file identifier,
- *          that file’s root group serves as the root of the recursive
+ *          that file's root group serves as the root of the recursive
  *          iteration.  If \p obj_id is an attribute identifier,
  *          then the object where the attribute is attached will be iterated.
  *          If \p obj_id is any other type of object, such as a dataset or
@@ -1186,7 +1186,7 @@ H5_DLL ssize_t H5Oget_comment_by_name(hid_t loc_id, const char *name, char *comm
  *          The H5Ovisit3() \p op_data parameter is a user-defined pointer to the data
  *          required to process objects in the course of the iteration. This pointer
  *          is passed back to each step of the iteration in the callback
- *          function’s \p op_data parameter.
+ *          function's \p op_data parameter.
  *
  *          The \p fields parameter contains flags to determine which fields will
  *          be retrieved by the \p op callback function. These flags are defined
@@ -1255,7 +1255,7 @@ H5_DLL herr_t H5Ovisit3(hid_t obj_id, H5_index_t idx_type, H5_iter_order_t order
  *          a file or an object in a file;  if \p loc_id is an attribute identifier,
  *          the object where the attribute is attached will be used.
  *          \p obj_name specifies either an object in the file (with an absolute
- *          name based on the file’s root group) or an object name relative
+ *          name based on the file's root group) or an object name relative
  *          to \p loc_id. If \p loc_id fully specifies the object that is to serve
  *          as the root of the iteration, \p obj_name should be '\c .' (a dot).
  *          (Note that when \p loc_id fully specifies the object that is to serve
@@ -1285,7 +1285,7 @@ H5_DLL herr_t H5Ovisit3(hid_t obj_id, H5_index_t idx_type, H5_iter_order_t order
  *          The H5Ovisit_by_name3() \p op_data parameter is a user-defined
  *          pointer to the data required to process objects in the course
  *          of the iteration. This pointer is passed back to each step of
- *          the iteration in the callback function’s \p op_data parameter.
+ *          the iteration in the callback function's \p op_data parameter.
  *
  *          \p lapl_id is a link access property list. In the general case,
  *          when default link access properties are acceptable, this can
@@ -1453,9 +1453,9 @@ H5_DLL herr_t H5Orefresh_async(hid_t oid, hid_t es_id);
  *
  * \details H5Odisable_mdc_flushes(), H5Oenable_mdc_flushes() and associated flush
  *          functions can be used to control the flushing of entries from
- *          a file’s metadata cache.
+ *          a file's metadata cache.
  *
- *          This function prevents an object’s or cache’s dirty metadata
+ *          This function prevents an object's or cache's dirty metadata
  *          entries from being flushed from the cache by the usual cache
  *          eviction/flush policy. Instead, users must manually flush the
  *          cache or entries for individual objects via the appropriate
@@ -1486,7 +1486,7 @@ H5_DLL herr_t H5Odisable_mdc_flushes(hid_t object_id);
  *-------------------------------------------------------------------------
  * \ingroup H5O
  *
- * \brief Enables flushing of dirty metadata entries from a file’s metadata cache
+ * \brief Enables flushing of dirty metadata entries from a file's metadata cache
  *
  * \param[in] object_id Identifier of the object that will have flushes re-enabled;
  *                      may be a group, named datatype, or dataset identifier
@@ -1495,9 +1495,9 @@ H5_DLL herr_t H5Odisable_mdc_flushes(hid_t object_id);
  *
  * \details H5Oenable_mdc_flushes(), H5Odisable_mdc_flushes()
  *          and associated flush functions can be used to control the flushing
- *          of entries from a file’s metadata cache.
+ *          of entries from a file's metadata cache.
  *
- *          This function allows an object or cache’s dirty metadata entries to be
+ *          This function allows an object or cache's dirty metadata entries to be
  *          flushed from the cache by the usual cache eviction/flush policy.
  *
  *          Metadata cache entries can be controlled at both the individual HDF5
@@ -1515,7 +1515,7 @@ H5_DLL herr_t H5Odisable_mdc_flushes(hid_t object_id);
  *       determined with H5Oare_mdc_flushes_disabled().  An object will be
  *       returned to the default flush algorithm when it is closed.  All objects
  *       will be returned to the default flush algorithm when the file is
- *       closed.  An object’s entries will not necessarily be flushed as a
+ *       closed.  An object's entries will not necessarily be flushed as a
  *       result of calling this function.
  *
  * \since 1.10.0
@@ -1542,7 +1542,7 @@ H5_DLL herr_t H5Oenable_mdc_flushes(hid_t object_id);
  *
  *          The H5Oenable_mdc_flushes(), H5Odisable_mdc_flushes() and
  *          associated flush functions can be used to control the flushing of
- *          entries from a file’s metadata cache. Metadata cache entries can be controlled
+ *          entries from a file's metadata cache. Metadata cache entries can be controlled
  *          at both the individual HDF5 object level (datasets, groups,
  *          committed datatypes) and the entire metadata cache level.
  *
@@ -1775,18 +1775,18 @@ typedef herr_t (*H5O_iterate1_t)(hid_t obj, const char *name, const H5O_info1_t 
  *
  *          \p loc_id is a location identifier in the file.
  *
- *          The object’s address within the file, \p addr, is the byte offset of the first byte
+ *          The object's address within the file, \p addr, is the byte offset of the first byte
  *          of the object header from the beginning of the HDF5 file space, i.e., from the
  *          beginning of the superblock (see the “HDF5 Storage Model” section of the The
  *          HDF5 Data Model and File Structure chapter of the <em>HDF5 User's Guide</em>.)
  *
  *          \p addr can be obtained via either of two function calls. H5Gget_objinfo() returns
- *          the object’s address in the \c objno field of the H5G_stat_t \c struct;
+ *          the object's address in the \c objno field of the H5G_stat_t \c struct;
  *          H5Lget_info() returns the address in the \c address field of the #H5L_info_t \c struct.
  *
  *          The address of the HDF5 file on a physical device has no effect on H5Oopen_by_addr(),
  *          nor does the use of any file driver. As stated above, the object address is its
- *          offset within the HDF5 file; HDF5’s file drivers will transparently map this to an
+ *          offset within the HDF5 file; HDF5's file drivers will transparently map this to an
  *          address on a storage device.
  *
  * \warning This function must be used with care!
@@ -1868,7 +1868,7 @@ H5_DLL herr_t H5Oget_info1(hid_t loc_id, H5O_info1_t *oinfo);
  * \deprecated As of HDF5-1.12 this function has been deprecated in favor of
  *             the function H5Oget_info_by_name2() or the macro #H5Oget_info_by_name.
  *
- * \details H5Oget_info_by_name1() specifies an object’s location and name, \p loc_id
+ * \details H5Oget_info_by_name1() specifies an object's location and name, \p loc_id
  *          and \p name, respectively, and retrieves the metadata describing that object
  *          in \p oinfo, an H5O_info1_t \c struct.
  *
@@ -1914,7 +1914,7 @@ H5_DLL herr_t H5Oget_info_by_name1(hid_t loc_id, const char *name, H5O_info1_t *
  *          object in the \c struct \p oinfo, as specified by the location,
  *          \p loc_id, group name, \p group_name, the index by which objects
  *          in that group are tracked, \p idx_type, the order by which the
- *          index is to be traversed, \p order, and an object’s position
+ *          index is to be traversed, \p order, and an object's position
  *          \p n within that index.
  *
  *          If \p loc_id fully specifies the group in which the object resides,
@@ -1995,7 +1995,7 @@ H5_DLL herr_t H5Oget_info2(hid_t loc_id, H5O_info1_t *oinfo, unsigned fields);
  * \deprecated As of HDF5-1.12 this function has been deprecated in favor of
  *             the function H5Oget_info_by_name3() or the macro H5Oget_info_by_name().
  *
- * \details H5Oget_info_by_name2() specifies an object’s location and name, \p loc_id and
+ * \details H5Oget_info_by_name2() specifies an object's location and name, \p loc_id and
  *          \p name, respectively, and retrieves the metadata describing
  *          that object in \p oinfo, an H5O_info1_t \c struct.
  *
@@ -2042,7 +2042,7 @@ H5_DLL herr_t H5Oget_info_by_name2(hid_t loc_id, const char *name, H5O_info1_t *
  *          object in the \c struct \p oinfo, as specified by the location,
  *          \p loc_id, group name, \p group_name, the index by which objects
  *          in that group are tracked, \p idx_type, the order by which the
- *          index is to be traversed, \p order, and an object’s position
+ *          index is to be traversed, \p order, and an object's position
  *          \p n within that index.
  *
  *          \p oinfo, in which the object information is returned, is a \c struct of
@@ -2102,7 +2102,7 @@ H5_DLL herr_t H5Oget_info_by_idx2(hid_t loc_id, const char *group_name, H5_index
  *
  *          If \p obj_id is a group identifier, that group serves as the
  *          root of a recursive iteration. If \p obj_id is a file identifier,
- *          that file’s root group serves as the root of the recursive
+ *          that file's root group serves as the root of the recursive
  *          iteration.  If \p obj_id is an attribute identifier,
  *          then the object where the attribute is attached will be iterated.
  *          If \p obj_id is any other type of object, such as a dataset or
@@ -2193,7 +2193,7 @@ H5_DLL herr_t H5Ovisit1(hid_t obj_id, H5_index_t idx_type, H5_iter_order_t order
  *          a file or an object in a file;  if \p loc_id is an attribute identifier,
  *          the object where the attribute is attached will be used.
  *          \p obj_name specifies either an object in the file (with an absolute
- *          name based on the file’s root group) or an object name relative
+ *          name based on the file's root group) or an object name relative
  *          to \p loc_id. If \p loc_id fully specifies the object that is to serve
  *          as the root of the iteration, \p obj_name should be '\c .' (a dot).
  *          (Note that when \p loc_id fully specifies the object that is to serve
@@ -2221,7 +2221,7 @@ H5_DLL herr_t H5Ovisit1(hid_t obj_id, H5_index_t idx_type, H5_iter_order_t order
  *          along the index specified in \p idx_type.
  *
  *          The \p op callback function and the effect of the callback
- *          function’s return value on the application are described
+ *          function's return value on the application are described
  *          in H5Ovisit1().
  *
  *          The H5O_info1_t \c struct is defined in H5Opublic.h
@@ -2230,7 +2230,7 @@ H5_DLL herr_t H5Ovisit1(hid_t obj_id, H5_index_t idx_type, H5_iter_order_t order
  *          The H5Ovisit_by_name1() \p op_data parameter is a user-defined
  *          pointer to the data required to process objects in the course
  *          of the iteration. This pointer is passed back to each step of
- *          the iteration in the callback function’s \p op_data parameter.
+ *          the iteration in the callback function's \p op_data parameter.
  *
  *          \p lapl_id is a link access property list. In the general case,
  *          when default link access properties are acceptable, this can
@@ -2297,7 +2297,7 @@ H5_DLL herr_t H5Ovisit_by_name1(hid_t loc_id, const char *obj_name, H5_index_t i
  *
  *          If \p obj_id is a group identifier, that group serves as the
  *          root of a recursive iteration. If \p obj_id is a file identifier,
- *          that file’s root group serves as the root of the recursive
+ *          that file's root group serves as the root of the recursive
  *          iteration.  If \p obj_id is an attribute identifier,
  *          then the object where the attribute is attached will be iterated.
  *          If \p obj_id is any other type of object, such as a dataset or
@@ -2390,7 +2390,7 @@ H5_DLL herr_t H5Ovisit2(hid_t obj_id, H5_index_t idx_type, H5_iter_order_t order
  *          a file or an object in a file;  if \p loc_id is an attribute identifier,
  *          the object where the attribute is attached will be used.
  *          \p obj_name specifies either an object in the file (with an absolute
- *          name based in the file’s root group) or an object name relative
+ *          name based in the file's root group) or an object name relative
  *          to \p loc_id. If \p loc_id fully specifies the object that is to serve
  *          as the root of the iteration, \p obj_name should be '\c .' (a dot).
  *          (Note that when \p loc_id fully specifies the object that is to serve
@@ -2418,7 +2418,7 @@ H5_DLL herr_t H5Ovisit2(hid_t obj_id, H5_index_t idx_type, H5_iter_order_t order
  *          along the index specified in \p idx_type.
  *
  *          The \p op callback function and the effect of the callback
- *          function’s return value on the application are described
+ *          function's return value on the application are described
  *          in H5Ovisit2().
  *
  *          The H5O_info1_t \c struct is defined in H5Opublic.h
@@ -2427,7 +2427,7 @@ H5_DLL herr_t H5Ovisit2(hid_t obj_id, H5_index_t idx_type, H5_iter_order_t order
  *          The H5Ovisit_by_name2() \p op_data parameter is a user-defined
  *          pointer to the data required to process objects in the course
  *          of the iteration. This pointer is passed back to each step of
- *          the iteration in the callback function’s \p op_data parameter.
+ *          the iteration in the callback function's \p op_data parameter.
  *
  *          \p lapl_id is a link access property list. In the general case,
  *          when default link access properties are acceptable, this can

--- a/src/H5Pmodule.h
+++ b/src/H5Pmodule.h
@@ -299,7 +299,7 @@
  * creation property list. These abbreviations may appear in either uppercase or lowercase.
  *
  * The “HDF5 property list class inheritance hierarchy” figure, immediately following, illustrates
- * the inheritance hierarchy of HDF5’s property list classes. Properties are defined at the root of the
+ * the inheritance hierarchy of HDF5's property list classes. Properties are defined at the root of the
  * HDF5 property environment (\ref PLCR in the figure below). Property list
  * classes then inherit properties from that root, either directly or indirectly through a parent class.
  * In every case, a property list class inherits only the properties relevant to its role. For example,
@@ -325,14 +325,14 @@
  *
  * A property list is a collection of related properties that are used together in specific
  * circumstances. A new property list created from a property list class inherits the properties of the
- * property list class and each property’s default value. A fresh dataset creation property list, for
+ * property list class and each property's default value. A fresh dataset creation property list, for
  * example, includes all of the HDF5 properties relevant to the creation of a new dataset.
  *
  * Property lists are implemented as containers holding a collection of name/value pairs. Each pair
  * specifies a property name and a value for the property. A property list usually contains
  * information for one to many properties.
  *
- * HDF5’s default property values are designed to be reasonable for general use cases. Therefore,
+ * HDF5's default property values are designed to be reasonable for general use cases. Therefore,
  * an application can often use a property list without modification. On the other hand, adjusting
  * property list settings is a routine action and there are many reasons for an application to do so.
  *
@@ -346,7 +346,7 @@
  * Property lists can be freely reused to create consistency. For example, a single set of file, group,
  * and dataset creation property lists might be created at the beginning of a project and used to
  * create hundreds, thousands, even millions, of consistent files, file structures, and datasets over
- * the project’s life. When such consistency is important to a project, this is an economical means
+ * the project's life. When such consistency is important to a project, this is an economical means
  * of providing it.
  *
  * \subsubsection subsubsec_plist_props Properties
@@ -427,7 +427,7 @@
  * will fit easily in system memory. <br />
  * <br />
  * A chunked layout is important if a dataset is to be compressed, to enable extending
- * the dataset’s size, or to enable caching during I/O. <br />
+ * the dataset's size, or to enable caching during I/O. <br />
  * <br />
  * A compact layout is suitable only for very small datasets because the raw data is
  * stored in the object header.
@@ -530,7 +530,7 @@
  * \ref H5Pset_dxpl_mpio_chunk_opt_ratio, and \ref H5Pget_mpio_actual_chunk_opt_mode).<br />
  * <br />
  * Optimal settings differ due to the characteristics of a computing environment and due
- * to an application’s data access patterns; even when working with the same file, these
+ * to an application's data access patterns; even when working with the same file, these
  * settings might change for every application and every platform.
  * </p>
  *       </td>
@@ -558,7 +558,7 @@
  * Default property lists can simplify many routine HDF5 tasks because you do not always have to
  * create every property list you use.
  *
- * An application that would be well-served by HDF5’s default property settings can use the default
+ * An application that would be well-served by HDF5's default property settings can use the default
  * property lists simply by substituting the value \ref H5P_DEFAULT for a property list identifier.
  * HDF5 will then apply the default property list for the appropriate property list class.
  *
@@ -594,7 +594,7 @@
  * The new dataset creation property list is created as an instance of the property list class
  * \ref H5P_DATASET_CREATE.
  *
- * The new dataset creation property list’s identifier is returned in dcplA_id and the property list is
+ * The new dataset creation property list's identifier is returned in dcplA_id and the property list is
  * initialized with default dataset creation property values.
  *
  * A list of valid classes appears in the table \ref table_plist "Property list classes in HDF5".
@@ -610,7 +610,7 @@
  * values that were changed in dcplA_id before dcplB_id was created. They may, however, diverge
  * as additional property values are reset in each.
  *
- * While we are creating property lists, let’s create a link creation property list; we will need this
+ * While we are creating property lists, let's create a link creation property list; we will need this
  * property list when the new dataset is linked into the file below:
  * \code
  *     lcplAB_id = H5Pcreate (H5P_LINK_CREATE);
@@ -695,7 +695,7 @@
  *     PList_Class = H5Pget_class (dcplA_id);
  * \endcode
  *
- * Upon this function’s return, PList_Class will contain the value \ref H5P_DATASET_CREATE indicating that
+ * Upon this function's return, PList_Class will contain the value \ref H5P_DATASET_CREATE indicating that
  * dcplA_id is a dataset creation property list.
 
  * <h4>Determine Current Creation Property List Settings in an Existing Object</h4>
@@ -706,7 +706,7 @@
  *
  * But sometimes an application must do something that requires knowing the creation property
  * settings. HDF5 makes the acquisition of this information fairly straight-forward; for each
- * property setting call, H5Pset_*, there is a corresponding H5Pget_*call to retrieve the property’s
+ * property setting call, H5Pset_*, there is a corresponding H5Pget_*call to retrieve the property's
  * current setting.
  *
  * Consider the following examples which illustrate the determination of dataset layout and chunking settings:
@@ -717,9 +717,9 @@
  * \ref H5Dget_create_plist will return a property list identifier for the creation property list that was
  * used to create the dataset. Call it DCPL1_id.
  *
- * \ref H5Pset_layout sets a dataset’s layout to be compact, contiguous, or chunked.
+ * \ref H5Pset_layout sets a dataset's layout to be compact, contiguous, or chunked.
  *
- * \ref H5Pget_layout called with DCPL1_id will return the dataset’s layout,
+ * \ref H5Pget_layout called with DCPL1_id will return the dataset's layout,
  * either \ref H5D_COMPACT, \ref H5D_CONTIGUOUS, or \ref H5D_CHUNKED.
  *
  * \ref H5Pset_chunk sets the rank of a dataset, that is the number of dimensions it will have, and the
@@ -729,7 +729,7 @@
  * size of each dimension.
  *
  * If a creation property value has not been explicitly set, these H5Pget_calls will return the
- * property’s default value.
+ * property's default value.
  *
  * <h4>Determine Access Property Settings</h4>
  *
@@ -753,14 +753,14 @@
  *
  * \subsection subsec_plist_generic Generic Properties Interface and User-defined Properties
  *
- * HDF5’s generic property interface provides tools for managing the entire property hierarchy and
+ * HDF5's generic property interface provides tools for managing the entire property hierarchy and
  * for the creation and management of user-defined property lists and properties. This interface also
  * makes it possible for an application or a driver to create, modify, and manage custom properties,
  * property lists, and property list classes. A comprehensive list of functions for this interface
  * appears under "Generic Property Operations (Advanced)" in the "H5P: Property List Interface"
  * section of the \ref RM.
  *
- * Further discussion of HDF5’s generic property interface and user-defined properties and
+ * Further discussion of HDF5's generic property interface and user-defined properties and
  * property lists is beyond the scope of this document.
  *
  * \subsection subsec_plist_H5P Property List Function Summaries

--- a/src/H5Ppublic.h
+++ b/src/H5Ppublic.h
@@ -2409,7 +2409,7 @@ H5_DLL herr_t H5Pset_deflate(hid_t plist_id, unsigned level);
  *           <tr>
  *            <td>#H5Z_FLAG_MANDATORY</td>
  *            <td>If the filter is required, that is, set to mandatory,
- *                and the filter fails, the library’s behavior depends
+ *                and the filter fails, the library's behavior depends
  *                on whether the chunk cache is in use:
  *                \li If the chunk cache is enabled, data chunks will
  *                    be flushed to the file during H5Dclose() and the
@@ -2476,11 +2476,11 @@ H5_DLL herr_t H5Pset_deflate(hid_t plist_id, unsigned level);
  *       property list, the group will be created with the new group file
  *       format. The filters will come into play only when dense storage
  *       is used (see H5Pset_link_phase_change()) and will be applied to
- *       the group’s fractal heap. The fractal heap will contain most of
- *       the group’s link metadata, including link names.
+ *       the group's fractal heap. The fractal heap will contain most of
+ *       the group's link metadata, including link names.
  *
  * \note When working with group creation property lists, if you are
- *       adding a filter that is not in HDF5’s set of predefined filters,
+ *       adding a filter that is not in HDF5's set of predefined filters,
  *       i.e., a user-defined or third-party filter, you must first
  *       determine that the filter will work for a group. See the
  *       discussion of the set local and can apply callback functions
@@ -3413,9 +3413,9 @@ H5_DLL herr_t H5Pget_core_write_tracking(hid_t fapl_id, hbool_t *is_enabled, siz
  *           <tr>
  *            <td>Family</td>
  *            <td>#H5FD_FAMILY</td>
- *            <td>With this driver, the HDF5 file’s address space is partitioned
+ *            <td>With this driver, the HDF5 file's address space is partitioned
  *                into pieces and sent to separate storage files using an
- *                underlying driver of the user’s choice. This driver is for
+ *                underlying driver of the user's choice. This driver is for
  *                systems that do not support files larger than 2 gigabytes.
  *            </td>
  *            <td>H5Pset_fapl_family()</td>
@@ -3645,7 +3645,7 @@ H5_DLL herr_t H5Pget_fclose_degree(hid_t fapl_id, H5F_close_degree_t *degree);
  *          them when allocating and loading the buffer to return to the
  *          application (see H5Pset_file_image_callbacks()). If file image
  *          callbacks are not defined, the function will use \c malloc and \c
- *          memcpy. When \c malloc and \c memcpy are used, it is the caller’s
+ *          memcpy. When \c malloc and \c memcpy are used, it is the caller's
  *          responsibility to discard the returned buffer with a call to \c
  *          free.
  *
@@ -4228,11 +4228,11 @@ H5_DLL herr_t H5Pset_alignment(hid_t fapl_id, hsize_t threshold, hsize_t alignme
  *
  * \details H5Pset_cache() sets the number of elements, the total number of
  *          bytes, and the preemption policy value for all datasets in a file
- *          on the file’s file access property list.
+ *          on the file's file access property list.
  *
  *          The raw data chunk cache inserts chunks into the cache by first
  *          computing a hash value using the address of a chunk and then by
- *          using that hash value as the chunk’s index into the table of
+ *          using that hash value as the chunk's index into the table of
  *          cached chunks. In other words, the size of this hash table and the
  *          number of possible hash values are determined by the \p rdcc_nslots
  *          parameter. If a different chunk in the cache has the same hash value,
@@ -4466,8 +4466,8 @@ H5_DLL herr_t H5Pset_driver_by_value(hid_t plist_id, H5FD_class_value_t driver_v
  *          file open.
  *
  *          Files opened through external links inherit the parent
- *          file’s file access property list by default, and therefore
- *          inherit the parent file’s external link open file cache
+ *          file's file access property list by default, and therefore
+ *          inherit the parent file's external link open file cache
  *          setting.
  *
  *          When child files contain external links of their own, the
@@ -4709,7 +4709,7 @@ H5_DLL herr_t H5Pset_file_image(hid_t fapl_id, void *buf_ptr, size_t buf_len);
  *          is released from use.
  *
  *          Some file drivers allow the use of user-defined callback functions
- *          for allocating, freeing, and copying the driver’s internal buffer,
+ *          for allocating, freeing, and copying the driver's internal buffer,
  *          potentially allowing optimizations such as avoiding large \c malloc
  *          and \c memcpy operations, or to perform detailed logging.
  *
@@ -5430,7 +5430,7 @@ H5_DLL herr_t H5Pget_vol_cap_flags(hid_t plist_id, uint64_t *cap_flags);
  *          identifier will be issued collectively from all ranks irrespective
  *          of the individual setting of a particular operation. If this
  *          assumption is not adhered to, corruption will be introduced in the
- *          metadata cache and HDF5’s behavior will be undefined.
+ *          metadata cache and HDF5's behavior will be undefined.
  *
  *          Alternatively, a user may wish to avoid setting this property
  *          globally on the file access property list, and individually set it
@@ -6267,12 +6267,12 @@ H5_DLL herr_t H5Pset_chunk(hid_t plist_id, int ndims, const hsize_t dim[/*ndims*
  *          dataset creation property list \p dcpl_id.
  *
  *          The available option is detailed in the parameters section.
- *          Only chunks that are not completely filled by the dataset’s
+ *          Only chunks that are not completely filled by the dataset's
  *          dataspace are affected by this option. Such chunks are
  *          referred to as partial edge chunks.
  *
  *      \b Motivation: H5Pset_chunk_opts() is used to specify storage
- *       options for chunks on the edge of a dataset’s dataspace. This
+ *       options for chunks on the edge of a dataset's dataspace. This
  *       capability allows the user to tune performance in cases where
  *       the dataset size may not be a multiple of the chunk size and
  *       the handling of partial edge chunks can impact performance.
@@ -6819,7 +6819,7 @@ H5_DLL herr_t H5Pset_scaleoffset(hid_t plist_id, H5Z_SO_scale_type_t scale_type,
  *             property list used to create a dataset containing a
  *             non-allowed datatype, the call to H5Dcreate() will fail; the
  *             conflict can be detected only when the property list is used.
- *           - Users should be aware that there are factors that affect one’s
+ *           - Users should be aware that there are factors that affect one's
  *             rights and ability to use SZIP compression by reviewing the
  *             SZIP copyright notice.
  *
@@ -6893,7 +6893,7 @@ H5_DLL herr_t H5Pset_szip(hid_t plist_id, unsigned options_mask, unsigned pixels
  * \param[in] src_dset_name The path to the HDF5 dataset in the file specified by
  *            \p src_file_name. The dataset might not exist yet. The dataset name
  *            can be specified using a C-style \c printf statement as described below.
- * \param[in] src_space_id The source dataset’s dataspace identifier with a
+ * \param[in] src_space_id The source dataset's dataspace identifier with a
  *            selection applied, possibly an unlimited selection
  * \return \herr_t
  *
@@ -6928,7 +6928,7 @@ H5_DLL herr_t H5Pset_szip(hid_t plist_id, unsigned options_mask, unsigned pixels
  *      </tr>
  *      </table>
  *      If the printf form is used for the source file or dataset names, the
- *      selection in the source dataset’s dataspace must be fixed-size.
+ *      selection in the source dataset's dataspace must be fixed-size.
  *
  * \par Source File Resolutions:
  *      When a source dataset residing in a different file is accessed, the
@@ -7032,7 +7032,7 @@ H5_DLL herr_t H5Pset_virtual(hid_t dcpl_id, hid_t vspace_id, const char *src_fil
  *          the corresponding value that is set in the property list.
  *
  *          \p func is the user-defined callback function to invoke when
- *          a dataset’s appended dimension size reaches a boundary and
+ *          a dataset's appended dimension size reaches a boundary and
  *          \p udata is the user-defined input data for the callback
  *          function.
  *
@@ -7093,7 +7093,7 @@ H5_DLL herr_t H5Pget_chunk_cache(hid_t dapl_id, size_t *rdcc_nslots /*out*/, siz
  * \details H5Pget_efile_prefix() retrieves the file system path prefix
  *          for locating external files associated with a dataset that
  *          uses external storage. This will be the value set with
- *          H5Pset_efile_prefix() or the HDF5 library’s default.
+ *          H5Pset_efile_prefix() or the HDF5 library's default.
  *
  *          The value of \p size is the size in bytes of the prefix,
  *          including the NULL terminator. If the size is unknown, a
@@ -7197,7 +7197,7 @@ H5_DLL herr_t H5Pget_virtual_view(hid_t dapl_id, H5D_vds_view_t *view);
 /**
  * \ingroup DAPL
  *
- * \brief Sets two actions to perform when the size of a dataset’s
+ * \brief Sets two actions to perform when the size of a dataset's
  *        dimension being appended reaches a specified boundary
  *
  * \dapl_id
@@ -7218,7 +7218,7 @@ H5_DLL herr_t H5Pget_virtual_view(hid_t dapl_id, H5D_vds_view_t *view);
  *              property list
  *
  *          When a user is appending data to a dataset via H5DOappend()
- *          and the dataset’s newly extended dimension size hits a
+ *          and the dataset's newly extended dimension size hits a
  *          specified boundary, the library will perform the first action
  *          listed above. Upon return from the callback function, the
  *          library will then perform the second action listed above and
@@ -7228,7 +7228,7 @@ H5_DLL herr_t H5Pget_virtual_view(hid_t dapl_id, H5D_vds_view_t *view);
  *          The specified boundary is indicated by the parameter
  *          \p boundary. It is a 1-dimensional array with \p ndims
  *          elements, which should be the same as the rank of the
- *          dataset’s dataspace. While appending to a dataset along a
+ *          dataset's dataspace. While appending to a dataset along a
  *          particular dimension index via H5Dappend(), the library
  *          determines a boundary is reached when the resulting dimension
  *          size is divisible by \p boundary[index]. A zero value for
@@ -7249,7 +7249,7 @@ H5_DLL herr_t H5Pget_virtual_view(hid_t dapl_id, H5D_vds_view_t *view);
  *          create or open if the following conditions are true:
  *
  *          \li \p ndims, the number of elements for boundary, is not the
- *              same as the rank of the dataset’s dataspace.
+ *              same as the rank of the dataset's dataspace.
  *          \li A non-zero boundary value is specified for a non-extendible
  *          dimension.
  *
@@ -7261,7 +7261,7 @@ H5_DLL herr_t H5Pget_virtual_view(hid_t dapl_id, H5D_vds_view_t *view);
  *          prototype, are defined as follows:
  *
  *          \li \p dataset_id is the dataset identifier.
- *          \li \p cur_dims is the dataset’s current dimension sizes when
+ *          \li \p cur_dims is the dataset's current dimension sizes when
  *              a boundary is hit.
  *          \li \p user_data is the user-defined input data.
  *
@@ -7413,19 +7413,19 @@ H5_DLL herr_t H5Pset_chunk_cache(hid_t dapl_id, size_t rdcc_nslots, size_t rdcc_
  *          that uses external storage:
  *
  *          \li The default behavior of the library is to search for the
- *              dataset’s external storage raw data files in the same
+ *              dataset's external storage raw data files in the same
  *              directory as the HDF5 file which contains the dataset.
  *          \li If the prefix is set to an absolute path, the target
- *              directory will be searched for the dataset’s external
+ *              directory will be searched for the dataset's external
  *              storage raw data files.
  *          \li If the prefix is set to a relative path, the target
  *              directory, relative to the current working directory, will
- *              be searched for the dataset’s external storage raw data
+ *              be searched for the dataset's external storage raw data
  *              files.
  *          \li If the prefix is set to a relative path that begins with
  *              the special token ${ORIGIN}, that directory, relative to
  *              the HDF5 file containing the dataset, will be searched for
- *              the dataset’s external storage raw data files.
+ *              the dataset's external storage raw data files.
  *
  *           The HDF5_EXTFILE_PREFIX environment variable can be used to
  *           override the above behavior (the environment variable
@@ -7452,7 +7452,7 @@ H5_DLL herr_t H5Pset_chunk_cache(hid_t dapl_id, size_t rdcc_nslots, size_t rdcc_
  *       are unaware of the environment variable.
  *
  * \note On Windows, the prefix must be an ASCII string since the Windows
- *       standard C library’s I/O functions cannot handle UTF-8 file names.
+ *       standard C library's I/O functions cannot handle UTF-8 file names.
  *
  * \since 1.10.0, 1.8.17
  *
@@ -7518,7 +7518,7 @@ H5_DLL herr_t H5Pset_virtual_prefix(hid_t dapl_id, const char *prefix);
  *              then the virtual dataset will contain the data from
  *              d-1, d-3, ..., d-N, ... .  The blocks that are mapped to
  *              d-2 and d-3 will be filled according to the virtual
- *              dataset’s fill value setting.
+ *              dataset's fill value setting.
  *
  * \see_virtual
  *
@@ -7545,7 +7545,7 @@ H5_DLL herr_t H5Pset_virtual_printf_gap(hid_t dapl_id, hsize_t gap_size);
  *          If \p view is set to #H5D_VDS_FIRST_MISSING, the view includes
  *          all data before the first missing mapped data. This setting
  *          provides a view containing only the continuous data starting
- *          with the dataset’s first data element. Any break in
+ *          with the dataset's first data element. Any break in
  *          continuity terminates the view.
  *
  *          If \p view is set to #H5D_VDS_LAST_AVAILABLE, the view
@@ -7746,11 +7746,11 @@ H5_DLL herr_t H5Pget_type_conv_cb(hid_t dxpl_id, H5T_conv_except_func_t *op, voi
  *
  * \param[in]  plist_id   Identifier for the dataset transfer property list
  * \param[out] alloc_func User's allocate routine, or NULL for system malloc
- * \param[out] alloc_info Extra parameter for user’s allocation routine.
+ * \param[out] alloc_info Extra parameter for user's allocation routine.
  *             Contents are ignored if preceding
  * parameter is NULL \param[out] free_func  User's free routine, or NULL for
  * system free \param[out] free_info
- * Extra parameter for user’s free routine. Contents are ignored if preceding
+ * Extra parameter for user's free routine. Contents are ignored if preceding
  * parameter is NULL
  *
  * \return \herr_t
@@ -8571,7 +8571,7 @@ H5_DLL herr_t H5Pget_link_creation_order(hid_t plist_id, unsigned *crt_order_fla
  *          to require before converting a group to a dense form.
  *
  *          In the compact format, links are stored as messages in the
- *          group’s header. In the dense format, links are stored in a
+ *          group's header. In the dense format, links are stored in a
  *          fractal heap and indexed with a version 2 B-tree.
  *
  *          \p max_compact is the maximum number of links to store as
@@ -8586,7 +8586,7 @@ H5_DLL herr_t H5Pget_link_creation_order(hid_t plist_id, unsigned *crt_order_fla
  *          converted back to the compact format.
  *
  *          In the compact format, links are stored as messages in the
- *          group’s header. In the dense format, links are stored in a
+ *          group's header. In the dense format, links are stored in a
  *          fractal heap and indexed with a version 2 B-tree.
  *
  *          See H5Pset_link_phase_change() for a discussion of
@@ -8782,7 +8782,7 @@ H5_DLL herr_t H5Pset_link_phase_change(hid_t plist_id, unsigned max_compact, uns
  * \par Motivation:
  *      In situations where backward-compatibility is required, specifically, when
  *      libraries prior to HDF5 Release 1.8.0 may be used to read the file, groups
- *      must be created and maintained in the original style. This is HDF5’s default
+ *      must be created and maintained in the original style. This is HDF5's default
  *      behavior. If backward compatibility with pre-1.8.0 libraries is not a concern,
  *      greater efficiencies can be obtained with the new-format compact and indexed
  *      groups. See <a href="https://portal.hdfgroup.org/display/HDF5/Groups">Group
@@ -8804,7 +8804,7 @@ H5_DLL herr_t H5Pset_link_phase_change(hid_t plist_id, unsigned max_compact, uns
  *      of that metadata (and hence, the size of the local heap) can vary wildly from group
  *      to group. To intelligently allocate space and to avoid unnecessary fragmentation of
  *      the local heap, it can be valuable to provide the library with a hint as to the local
- *      heap’s likely eventual size. This can be particularly valuable when it is known that
+ *      heap's likely eventual size. This can be particularly valuable when it is known that
  *      a group will eventually have a great many members. It can also be useful in conserving
  *      space in a file when it is known that certain groups will never have any members.
  *
@@ -9328,7 +9328,7 @@ H5_DLL herr_t H5Pset_nlinks(hid_t plist_id, size_t nlinks);
  *          must be identical. Two attributes are considered identical if
  *          their datatype description, dataspace, and raw data values are
  *          the same. However, if an attribute uses a committed datatype,
- *          that committed datatype’s attributes will not be compared.
+ *          that committed datatype's attributes will not be compared.
  *
  *          If a match is found, H5Ocopy() will perform the following in
  *          the destination file:
@@ -9338,7 +9338,7 @@ H5_DLL herr_t H5Pset_nlinks(hid_t plist_id, size_t nlinks);
  *              will modify the copied dataset to use the found committed
  *              datatype as its datatype.
  *          \li For an object with an attribute of a committed datatype,
- *              the library will modify the copied object’s attribute to
+ *              the library will modify the copied object's attribute to
  *              use the found committed datatype as its datatype.
  *
  *          If no match is found, H5Ocopy() will perform the following in
@@ -9350,11 +9350,11 @@ H5_DLL herr_t H5Pset_nlinks(hid_t plist_id, size_t nlinks);
  *              file by a unique path.
  *          \li For a dataset that uses a committed datatype, the
  *              library will copy the datatype as an anonymous
- *              committed datatype and use that as the dataset’s
+ *              committed datatype and use that as the dataset's
  *              datatype.
  *          \li For an object with an attribute of a committed datatype,
  *              the library will copy the datatype as an anonymous
- *              committed datatype and use that as the attribute’s
+ *              committed datatype and use that as the attribute's
  *              datatype.
  *
  *      \b Motivation: H5Padd_merge_committed_dtype_path() provides a

--- a/src/H5Rpublic.h
+++ b/src/H5Rpublic.h
@@ -647,10 +647,10 @@ H5_DLL ssize_t H5Rget_attr_name(const H5R_ref_t *ref_ptr, char *name, size_t siz
  *          that can be determined with three preliminary calls:
  *
  *          \li Call H5Dget_type() on the dataset containing the reference to
- *              get a datatype identifier for the dataset’s datatype.
+ *              get a datatype identifier for the dataset's datatype.
  *          \li Using that datatype identifier, H5Tget_class() returns a datatype
  *              class.\n If the datatype class is #H5T_REFERENCE, H5Tequal() can
- *              then be used to determine whether the reference’s datatype is
+ *              then be used to determine whether the reference's datatype is
  *              #H5T_STD_REF_OBJ or #H5T_STD_REF_DSETREG:
  *              - If the datatype is #H5T_STD_REF_OBJ, the reference object type
  *                is #H5R_OBJECT.
@@ -784,10 +784,10 @@ H5_DLL herr_t H5Rcreate(void *ref, hid_t loc_id, const char *name, H5R_type_t re
  *          that can be determined with three preliminary calls:
  *
  *          \li Call H5Dget_type() on the dataset containing the reference to
- *              get a datatype identifier for the dataset’s datatype.
+ *              get a datatype identifier for the dataset's datatype.
  *          \li Using that datatype identifier, H5Tget_class() returns a datatype
  *              class.\n If the datatype class is #H5T_REFERENCE, H5Tequal() can
- *              then be used to determine whether the reference’s datatype is
+ *              then be used to determine whether the reference's datatype is
  *              #H5T_STD_REF_OBJ or #H5T_STD_REF_DSETREG:
  *              - If the datatype is #H5T_STD_REF_OBJ, the reference object type
  *                is #H5R_OBJECT.
@@ -905,7 +905,7 @@ H5_DLL hid_t H5Rget_region(hid_t dataset, H5R_type_t ref_type, const void *ref);
  *          include the following:
  *          \snippet this H5R_type_t_snip
  *
- *          \p ref is the reference for which the target object’s name is
+ *          \p ref is the reference for which the target object's name is
  *          sought.
  *
  *          If \p ref is an object reference, \p name will be returned with a

--- a/src/H5Smodule.h
+++ b/src/H5Smodule.h
@@ -63,7 +63,7 @@
  * \subsubsection subsubsec_dataspace_program_object Dataspace Objects
  *
  * An HDF5 dataspace is a required component of an HDF5 dataset or attribute. A dataspace defines the size
- * and the shape of a dataset’s or an attribute’s raw data. Currently, HDF5 supports the following types of
+ * and the shape of a dataset's or an attribute's raw data. Currently, HDF5 supports the following types of
  * the dataspaces:
  * \li Scalar dataspaces
  * \li Simple dataspaces
@@ -165,7 +165,7 @@
  *
  * <h4>Creating a Simple Dataspace</h4>
  *
- * Let’s assume that an application wants to store a two‐dimensional array of data, A(20,100). During the
+ * Let's assume that an application wants to store a two‐dimensional array of data, A(20,100). During the
  * life of the application, the first dimension of the array can grow up to 30; there is no restriction on
  * the size of the second dimension. The following steps are used to declare a dataspace for the dataset
  * in which the array data will be stored.
@@ -1221,7 +1221,7 @@
  * \subsection subsec_dataspace_sample Sample Programs
  *
  * This section contains the full programs from which several of the code examples in this chapter were
- * derived. The h5dump output from the program’s output file immediately follows each program.
+ * derived. The h5dump output from the program's output file immediately follows each program.
  *
  * <em>h5_write.c</em>
  * \code

--- a/src/H5Spublic.h
+++ b/src/H5Spublic.h
@@ -1026,7 +1026,7 @@ H5_DLL herr_t H5Sselect_copy(hid_t dst_id, hid_t src_id);
  *          The \p coord parameter is a pointer to a buffer containing a
  *          serialized 2-dimensional array of size \p num_elements by the
  *          rank of the dataspace. The array lists dataset elements in the
- *          point selection; that is, it’s a list of zero-based values
+ *          point selection; that is, it's a list of zero-based values
  *          specifying the coordinates in the dataset of the selected
  *          elements. The order of the element coordinates in the \p coord
  *          array specifies the order in which the array elements are

--- a/src/H5Tdevelop.h
+++ b/src/H5Tdevelop.h
@@ -154,9 +154,9 @@ H5_DLL herr_t H5Tregister(H5T_pers_t pers, const char *name, hid_t src_id, hid_t
  *          the conversion function.
  *
  *          If a user is trying to remove a conversion function he registered,
- *          all parameters can be used. If he is trying to remove a library’s
+ *          all parameters can be used. If he is trying to remove a library's
  *          default conversion function, there is no guarantee the \p name and
- *          \p func parameters will match the user’s chosen values. Passing in
+ *          \p func parameters will match the user's chosen values. Passing in
  *          some values may cause this function to fail. A good practice is to
  *          pass in NULL as their values.
  *
@@ -194,17 +194,17 @@ H5_DLL H5T_conv_t H5Tfind(hid_t src_id, hid_t dst_id, H5T_cdata_t **pcdata);
 /**
  * \ingroup CONV
  *
- * \brief Check whether the library’s default conversion is hard conversion
+ * \brief Check whether the library's default conversion is hard conversion
  *
  * \type_id{src_id} of source datatype
  * \type_id{dst_id} of destination datatype
  *
  * \return \htri_t
  *
- * \details H5Tcompiler_conv() determines whether the library’s conversion
+ * \details H5Tcompiler_conv() determines whether the library's conversion
  *          function from type \p src_id to type \p dst_id is a compiler (hard)
- *          conversion or not. A compiler conversion uses compiler’s casting; a
- *          library (soft) conversion uses the library’s own conversion
+ *          conversion or not. A compiler conversion uses compiler's casting; a
+ *          library (soft) conversion uses the library's own conversion
  *          function.
  *
  * \since 1.8.0

--- a/src/H5Tmodule.h
+++ b/src/H5Tmodule.h
@@ -388,7 +388,7 @@
  *       </td>
  *       <td span='3'>
  * This is an architecture that contains semi-standard datatypes like signed
- * two’s complement integers, unsigned integers, and bitfields in various
+ * two's complement integers, unsigned integers, and bitfields in various
  * byte orders.
  *       </td>
  *     </tr>
@@ -427,7 +427,7 @@
  * INTEL
  *       </td>
  *       <td span='3'>
- * All Intel and compatible CPU’s.
+ * All Intel and compatible CPU's.
  * These are little-endian systems with IEEE floating-point.
  *       </td>
  *     </tr>
@@ -436,7 +436,7 @@
  * MIPS
  *       </td>
  *       <td span='3'>
- * All MIPS CPU’s commonly used in SGI systems. These are big-endian
+ * All MIPS CPU's commonly used in SGI systems. These are big-endian
  * systems with IEEE floating-point.
  *       </td>
  *     </tr>
@@ -445,7 +445,7 @@
  * ALPHA
  *       </td>
  *       <td span='3'>
- * All DEC Alpha CPU’s, little-endian systems with IEEE floating-point.
+ * All DEC Alpha CPU's, little-endian systems with IEEE floating-point.
  *       </td>
  *     </tr>
  *   </table>
@@ -569,7 +569,7 @@
  * #H5T_STD_I32LE
  *       </td>
  *       <td span='3'>
- * Four-byte, little-endian, signed two’s complement integer
+ * Four-byte, little-endian, signed two's complement integer
  *       </td>
  *     </tr>
  *     <tr>
@@ -1174,7 +1174,7 @@
  * \ref H5T_sign_t \ref H5Tget_sign (\ref hid_t type)
  *       </td>
  *       <td>
- * (INTEGER)Integer data can be signed two’s complement (#H5T_SGN_2) or unsigned (#H5T_SGN_NONE).
+ * (INTEGER)Integer data can be signed two's complement (#H5T_SGN_2) or unsigned (#H5T_SGN_NONE).
  *       </td>
  *     </tr>
  *     <tr>
@@ -1212,7 +1212,7 @@
  * mantissa after the radix point are stored. </li>
  * <li>#H5T_NORM_IMPLIED: the mantissa is shifted left \(if non-zero) until the first
  * bit after the radix point is set and the exponent is adjusted accordingly. The first
- * bit after the radix point is not stored since it’s always set. </li>
+ * bit after the radix point is not stored since it's always set. </li>
  * <li>#H5T_NORM_NONE: the fractional part of the mantissa is stored without normalizing it.</li></ul>
  *       </td>
  *     </tr>
@@ -1565,7 +1565,7 @@
  *  \ref herr_t  \ref H5Tset_sign (\ref hid_t type, \ref H5T_sign_t sign)
  *       </td>
  *       <td>
- * (INTEGER)Integer data can be signed two’s complement (#H5T_SGN_2) or unsigned (#H5T_SGN_NONE).
+ * (INTEGER)Integer data can be signed two's complement (#H5T_SGN_2) or unsigned (#H5T_SGN_NONE).
  *       </td>
  *     </tr>
  *     <tr>
@@ -1909,7 +1909,7 @@ filled according to the value of this property. The padding can be:
  * Usually a C struct or Fortran derived type will be defined to hold a data point in memory, and the
  * offsets of the members in memory will be the offsets of the struct members from the beginning
  * of an instance of the struct. The HDF5 C library provides a macro #HOFFSET (s,m)to calculate
- * the member’s offset. The HDF5 Fortran applications have to calculate offsets by using sizes of
+ * the member's offset. The HDF5 Fortran applications have to calculate offsets by using sizes of
  * members datatypes and by taking in consideration the order of members in the Fortran derived type.
  * \code
  * HOFFSET(s,m)
@@ -2378,7 +2378,7 @@ filled according to the value of this property. The padding can be:
  *
  * Reading datasets with compound datatypes may be a challenge. For general applications there is
  * no way to know a priori the corresponding C structure. Also, C structures cannot be allocated on
- * the fly during discovery of the dataset’s datatype. For general C, C++, Fortran and Java
+ * the fly during discovery of the dataset's datatype. For general C, C++, Fortran and Java
  * application the following steps will be required to read and to interpret data from the dataset with
  * compound datatype:
  * \li 1. Get the identifier of the compound datatype in the file with the #H5Dget_type call
@@ -2492,7 +2492,7 @@ filled according to the value of this property. The padding can be:
  *
  * The example below shows how to read float and double members of a compound datatype into a
  * structure that has those fields in a different order. Please notice that #H5Tinsert calls can be used
- * in an order different from the order of the structure’s members.
+ * in an order different from the order of the structure's members.
  *
  * <em>Read float and double members of a compound datatype</em>
  * \code

--- a/src/H5Tmodule.h
+++ b/src/H5Tmodule.h
@@ -427,7 +427,7 @@
  * INTEL
  *       </td>
  *       <td span='3'>
- * All Intel and compatible CPU's.
+ * All Intel and compatible CPUs.
  * These are little-endian systems with IEEE floating-point.
  *       </td>
  *     </tr>
@@ -436,7 +436,7 @@
  * MIPS
  *       </td>
  *       <td span='3'>
- * All MIPS CPU's commonly used in SGI systems. These are big-endian
+ * All MIPS CPUs commonly used in SGI systems. These are big-endian
  * systems with IEEE floating-point.
  *       </td>
  *     </tr>
@@ -445,7 +445,7 @@
  * ALPHA
  *       </td>
  *       <td span='3'>
- * All DEC Alpha CPU's, little-endian systems with IEEE floating-point.
+ * All DEC Alpha CPUs, little-endian systems with IEEE floating-point.
  *       </td>
  *     </tr>
  *   </table>

--- a/src/H5Tpublic.h
+++ b/src/H5Tpublic.h
@@ -1140,7 +1140,7 @@ H5_DLL herr_t H5Tlock(hid_t type_id);
  *
  * \fg_loc_id
  * \param[in] name Name given to committed datatype
- * \type_id Identifier of datatype to be committed and, upon function’s
+ * \type_id Identifier of datatype to be committed and, upon function's
  *          return, identifier for the committed datatype
  * \lcpl_id
  * \tcpl_id
@@ -1266,7 +1266,7 @@ H5_DLL hid_t  H5Topen_async(hid_t loc_id, const char *name, hid_t tapl_id, hid_t
  *              which provides for greater control of the creation process
  *              and of the properties of the new named datatype. H5Tcommit()
  *              always uses default properties.
- *          \li H5Tcommit_anon() neither provides the new named datatype’s
+ *          \li H5Tcommit_anon() neither provides the new named datatype's
  *              name nor links it into the HDF5 file structure; those actions
  *              must be performed separately through a call to H5Olink(),
  *              which offers greater control over linking.
@@ -1585,7 +1585,7 @@ H5_DLL herr_t H5Tenum_nameof(hid_t type, const void *value, char *name /*out*/, 
  * \details H5Tenum_valueof() finds the value that corresponds to the
  *          specified name of the enumeration datatype \p dtype_id.
  *
- *          Values returned in \p value will be of the enumerated type’s
+ *          Values returned in \p value will be of the enumerated type's
  *          base type, that is, the datatype used by H5Tenum_create() when
  *          the enumerated type was created.
  *
@@ -2196,7 +2196,7 @@ H5_DLL hid_t H5Tget_member_type(hid_t type_id, unsigned membno);
  *
  *          The member value is returned in a user-supplied buffer pointed to
  *          by \p value. Values returned in \p value will be of the enumerated
- *          type’s base type, that is, the datatype used by H5Tenum_create()
+ *          type's base type, that is, the datatype used by H5Tenum_create()
  *          when the enumerated type was created.
  *
  *          The value buffer must be at least large enough to hold a value

--- a/src/H5VLconnector.h
+++ b/src/H5VLconnector.h
@@ -1010,13 +1010,13 @@ typedef struct H5VL_token_class_t {
 //! <!-- [H5VL_class_t_snip] -->
 typedef struct H5VL_class_t {
     /* Overall connector fields & callbacks */
-    unsigned           version;          /**< VOL connector class struct version #     */
-    H5VL_class_value_t value;            /**< Value to identify connector              */
-    const char        *name;             /**< Connector name (MUST be unique!)         */
-    unsigned           conn_version;     /**< Version # of connector                   */
-    uint64_t           cap_flags;        /**< Capability flags for connector           */
-    herr_t (*initialize)(hid_t vipl_id); /**< Connector initialization callback        */
-    herr_t (*terminate)(void);           /**< Connector termination callback           */
+    unsigned           version;          /**< VOL connector class struct version number */
+    H5VL_class_value_t value;            /**< Value to identify connector               */
+    const char        *name;             /**< Connector name (MUST be unique!)          */
+    unsigned           conn_version;     /**< Version number of connector               */
+    uint64_t           cap_flags;        /**< Capability flags for connector            */
+    herr_t (*initialize)(hid_t vipl_id); /**< Connector initialization callback         */
+    herr_t (*terminate)(void);           /**< Connector termination callback            */
 
     /* VOL framework */
     H5VL_info_class_t info_cls; /**< VOL info fields & callbacks  */

--- a/src/H5VLmodule.h
+++ b/src/H5VLmodule.h
@@ -35,7 +35,7 @@
  * that could potentially access objects in an HDF5 container and forwards those calls to a VOL
  * connector, which implements the storage. The user or application gets the benefit of using the
  * familiar and widely-used HDF5 data model and API, but can map the physical storage of the HDF5 file
- * and objects to storage that better meets the application’s data needs.
+ * and objects to storage that better meets the application's data needs.
  *
  * \subsection subsec_vol_abstract_layer The VOL Abstraction Layer
  * The VOL lies just under the public API. When a storage-oriented public APIcall is made, the library
@@ -126,7 +126,7 @@
  * due to inadequate support for pass-through connectors. These deficiencies have been addressed
  * in HDF5 1.14.0, so VOL users and connector authors should target the 1.14.0 VOL API.
  *
- * On Windows, it’s probably best to use the same debug vs release configuration for the application and
+ * On Windows, it's probably best to use the same debug vs release configuration for the application and
  * all libraries in order to avoid C runtime (CRT) issues. Pre-2015 versions of Visual Studio are not
  * supported.
  *
@@ -141,7 +141,7 @@
  *
  * Exactly how you go about setting a VOL connector in a fapl, will depend on
  * the complexity of the VOL connector and how much control you have over the
- * application’s source code. Note that the environment variable method, though
+ * application's source code. Note that the environment variable method, though
  * convenient, has some limitations in its implementation, which are discussed
  * below.
  *
@@ -170,7 +170,7 @@
  *
  * \subsection subsec_vol_use Connector Use
  * Before a VOL connector can be set in a fapl, it must be registered with the
- * library (\ref H5Pset_vol requires the connector’s #hid_t ID) and, if a plugin, it
+ * library (\ref H5Pset_vol requires the connector's #hid_t ID) and, if a plugin, it
  * must be discoverable by the library at run time.
  *
  * \subsubsection subsubsec_vol_connect_register Registration
@@ -190,7 +190,7 @@
  *
  * Note the two ways that a VOL connector can be identified: by a name or by
  * a connector-specific numerical value (#H5VL_class_value_t is typedef’d to an
- * integer). The name and value for a connector can be found in the connector’s
+ * integer). The name and value for a connector can be found in the connector's
  * documentation or public header file.
  *
  * Each call also takes a VOL initialization property list (vipl). The library adds
@@ -203,11 +203,11 @@
  * closed. If you want to close a VOL connector ID, either \ref H5VLunregister_connector()
  * or \ref H5VLclose() can be used (they have the same internal code path). The library maintains a
  * reference count on all open IDs and will not do the actual
- * work of closing an ID until its reference count drops to zero, so it’s safe to close
+ * work of closing an ID until its reference count drops to zero, so it's safe to close
  * IDs anytime after they are used, even while an HDF5 file that was opened with
  * that connector is still open.
  *
- * Note that it’s considered an error to unload the native VOL connector. The
+ * Note that it's considered an error to unload the native VOL connector. The
  * library will prevent this. This means that, for the time being, the native VOL
  * connector will always be available. This may change in the future so that
  * the memory footprint of the native VOL connector goes away when not in
@@ -222,7 +222,7 @@
  * in the fapl. These will often be in the form of \b H5Pset_fapl_<name>(). For
  * example, the <a href="https://github.com/HDFGroup/vol-daos">DAOS VOL</a> connector
  * provides a \b H5Pset_fapl_daos() API call which will take MPI parameters and
- * make this call. See the connector’s documentation or public header file(s) for
+ * make this call. See the connector's documentation or public header file(s) for
  * more information.
  *
  * \subsubsection subsubsec_vol_connect_set_vol H5Pset_vol()
@@ -234,12 +234,12 @@
  *
  * It takes the ID of the file access property list, the ID of the registered VOL
  * connector, and a pointer to whatever connector-specific data the connector is
- * expecting. This will usually be a data struct specified in the connector’s header
+ * expecting. This will usually be a data struct specified in the connector's header
  * or a NULL pointer if the connecter requires no special information (as in the
  * native VOL connector).
  *
  * As mentioned above, many connectors will provide their own replacement for
- * this call. See the connector’s documentation for more information.
+ * this call. See the connector's documentation for more information.
  *
  * \subsubsection subsubsec_vol_connect_search VOL Connector Search Path
  * Dynamically loaded VOL connector plugins are discovered and loaded by the
@@ -297,7 +297,7 @@
  *
  * NOTE: Implementing the environment variable in this way means that setting
  * the native VOL connector becomes somewhat awkward as there is no explicit
- * HDF5 API call to do this. Instead you will need to get the native VOL connector’s ID via
+ * HDF5 API call to do this. Instead you will need to get the native VOL connector's ID via
  * \ref H5VLget_connector_id_by_value(#H5_VOL_NATIVE) and set it manually in the fapl
  * using \ref H5Pset_vol().
  *
@@ -595,7 +595,7 @@
  * \code
  *  --vol-(name|value|info)
  * \endcode
- * See the individual tool’s help for the options specific to that tool.
+ * See the individual tool's help for the options specific to that tool.
  *
  * \subsection subsec_vol_compat Compatibility
  *

--- a/src/H5VLpublic.h
+++ b/src/H5VLpublic.h
@@ -26,7 +26,7 @@
 
 /**
  * \ingroup H5VLDEF
- * \brief Version # of VOL class struct & callbacks
+ * \brief Version number of VOL class struct & callbacks
  *
  * \details Each VOL connector must set the 'version' field in the H5VL_class_t
  *          struct to the version of the H5VL_class_t struct that the connector

--- a/src/H5Zdevelop.h
+++ b/src/H5Zdevelop.h
@@ -218,10 +218,10 @@ extern "C" {
  *          used instead of the literal values.
  *
  *          \c encoder_present is a library-defined value indicating whether
- *          the filter’s encoding capability is available to the application.
+ *          the filter's encoding capability is available to the application.
  *
  *          \c decoder_present is a library-defined value indicating whether
- *          the filter’s encoding capability is available to the application.
+ *          the filter's encoding capability is available to the application.
  *
  *          \c name is a descriptive comment used for debugging, may contain a
  *          descriptive name for the filter, and may be the null pointer.

--- a/src/H5module.h
+++ b/src/H5module.h
@@ -352,7 +352,7 @@
  * pass parameters from the calling program to a VFL driver or a module of the pipeline.
  *
  * Property lists are conceptually similar to attributes. Property lists are information relevant to the
- * behavior of the library while attributes are relevant to the user’s data and application.
+ * behavior of the library while attributes are relevant to the user's data and application.
  *
  * <table>
  * <tr>
@@ -761,7 +761,7 @@
  * \subsubsection subsubsec_program_model_close Closing an Object
  * An application should close an object such as a datatype, dataspace, or dataset once the object is
  * no longer needed. Since each is an independent object, each must be released (or closed)
- * separately. This action is frequently referred to as releasing the object’s identifier. The code in
+ * separately. This action is frequently referred to as releasing the object's identifier. The code in
  * the example below closes the datatype, dataspace, and dataset that were created in the preceding
  * section.
  *
@@ -779,7 +779,7 @@
  *
  * For more information,
  * @see <a href="http://www.hdfgroup.org/HDF5/doc/Advanced/UsingIdentifiers/index.html">Using Identifiers</a>
- * in the HDF5 Application Developer’s Guide under General Topics in HDF5.
+ * in the HDF5 Application Developer's Guide under General Topics in HDF5.
  *
  * <h4>How Closing a File Effects Other Open Structural Elements</h4>
  * Every structural element in an HDF5 file can be opened, and these elements can be opened more
@@ -828,7 +828,7 @@
  * portions of a dataset. These parts of datasets are known as selections.
  *
  * The simplest type of selection is a simple hyperslab. This is an n-dimensional rectangular sub-set
- * of a dataset where n is equal to the dataset’s rank. Other available selections include a more
+ * of a dataset where n is equal to the dataset's rank. Other available selections include a more
  * complex hyperslab with user-defined stride and block size, a list of independent points, or the
  * union of any of these.
  *
@@ -863,7 +863,7 @@
  * user-defined stride and block, a selection of points, or a union of any of these forms.
  *
  * Selections and hyperslabs are portions of a dataset. As described above, a simple hyperslab is a
- * rectangular array of data elements with the same rank as the dataset’s dataspace. Thus, a simple
+ * rectangular array of data elements with the same rank as the dataset's dataspace. Thus, a simple
  * hyperslab is a logically contiguous collection of points within the dataset.
  *
  * The more general case of a hyperslab can also be a regular pattern of points or blocks within the
@@ -880,7 +880,7 @@
  * </tr>
  * <tr>
  * <td>start</td>
- * <td>The coordinates of the starting location of the hyperslab in the dataset’s dataspace.</td>
+ * <td>The coordinates of the starting location of the hyperslab in the dataset's dataspace.</td>
  * </tr>
  * <tr>
  * <td>block</td>
@@ -964,7 +964,7 @@
  * count=(3,4,1), stride and block size are NULL.
  *
  * <h4>Writing Data into a Differently Shaped Disk Storage Block</h4>
- * Now let’s consider the opposite process of writing a selection from memory to a selection in a
+ * Now let's consider the opposite process of writing a selection from memory to a selection in a
  * dataset in a file. Suppose that the source dataspace in memory is a 50-element, one-dimensional
  * array called vector and that the source selection is a 48-element simple hyperslab that starts at the
  * second element of vector. See the figure below.
@@ -1372,7 +1372,7 @@
  * and a data I/O pipeline. The data I/O pipeline applies compression to data blocks, transforms
  * data elements, and implements selections.
  *
- * A substantial portion of the HDF5 library’s work is in transferring data from one environment or
+ * A substantial portion of the HDF5 library's work is in transferring data from one environment or
  * media to another. This most often involves a transfer between system memory and a storage
  * medium. Data transfers are affected by compression, encryption, machine-dependent differences
  * in numerical representation, and other features. So, the bit-by-bit arrangement of a given dataset
@@ -1399,7 +1399,7 @@
  * For a given I/O request, different combinations of actions may be performed by the pipeline. The
  * library automatically sets up the pipeline and passes data through the processing steps. For
  * example, for a read request (from disk to memory), the library must determine which logical
- * blocks contain the requested data elements and fetch each block into the library’s cache. If the
+ * blocks contain the requested data elements and fetch each block into the library's cache. If the
  * data needs to be decompressed, then the compression algorithm is applied to the block after it is
  * read from disk. If the data is a selection, the selected elements are extracted from the data block
  * after it is decompressed. If the data needs to be transformed (for example, byte swapped), then
@@ -1420,7 +1420,7 @@
  * Library by linking an appropriate module into the pipeline through the VFL. This requires
  * creating an appropriate wrapper for the compression module and registering it with the library
  * with #H5Zregister. The algorithm can then be applied to a dataset with an #H5Pset_filter call which
- * will add the algorithm to the selected dataset’s transfer property list.
+ * will add the algorithm to the selected dataset's transfer property list.
  *
  * Previous Chapter \ref sec_data_model - Next Chapter \ref sec_file
  *

--- a/src/H5public.h
+++ b/src/H5public.h
@@ -684,7 +684,7 @@ H5_DLL herr_t H5is_library_threadsafe(hbool_t *is_ts);
  *
  *          H5Tget_member_name() provides an example of memory allocation on
  *          behalf of the caller: The function returns a buffer containing the
- *          name of a compound datatype member. It is the caller’s
+ *          name of a compound datatype member. It is the caller's
  *          responsibility to eventually free that buffer with H5free_memory().
  *
  * \attention It is especially important to use this function to free memory

--- a/tools/src/misc/h5clear.c
+++ b/tools/src/misc/h5clear.c
@@ -75,7 +75,7 @@ usage(const char *prog)
     fprintf(stdout,
             "                             This option helps to repair a crashed file where the stored EOA\n");
     fprintf(stdout, "                             in the superblock is different from the actual EOF.\n");
-    fprintf(stdout, "                             The file’s EOA and EOF will be the same after applying\n");
+    fprintf(stdout, "                             The file's EOA and EOF will be the same after applying\n");
     fprintf(stdout, "                             this option to the file.\n");
     fprintf(stdout, "\n");
     fprintf(stdout, "Examples of use:\n");

--- a/tools/test/misc/testfiles/h5clear_missing_file.ddl
+++ b/tools/test/misc/testfiles/h5clear_missing_file.ddl
@@ -10,7 +10,7 @@ usage: h5clear [OPTIONS] file_name
                              C is >= 0; C is optional and will default to 1M when not set.
                              This option helps to repair a crashed file where the stored EOA
                              in the superblock is different from the actual EOF.
-                             The file’s EOA and EOF will be the same after applying
+                             The file's EOA and EOF will be the same after applying
                              this option to the file.
 
 Examples of use:

--- a/tools/test/misc/testfiles/h5clear_usage.ddl
+++ b/tools/test/misc/testfiles/h5clear_usage.ddl
@@ -10,7 +10,7 @@ usage: h5clear [OPTIONS] file_name
                              C is >= 0; C is optional and will default to 1M when not set.
                              This option helps to repair a crashed file where the stored EOA
                              in the superblock is different from the actual EOF.
-                             The file’s EOA and EOF will be the same after applying
+                             The file's EOA and EOF will be the same after applying
                              this option to the file.
 
 Examples of use:


### PR DESCRIPTION
Documentation had a mix of encoded and ascii single apostrophe, changed to ascii.
Fixed description error for H5Dread_chunk
Fixed possessive CPU
Spelled out "#"
Fixed brief description for H5Fget_info*