### PR TITLE
ROS3: (fix) Replaced HDfprintf

### DIFF
--- a/src/H5FDros3.c
+++ b/src/H5FDros3.c
@@ -603,7 +603,7 @@ H5Pget_fapl_ros3_token(hid_t fapl_id, size_t size, char *token_dst /*out*/)
     H5TRACE3("e", "izx", fapl_id, size, token_dst);
 
 #if ROS3_DEBUG
-    HDfprintf(stdout, "H5Pget_fapl_ros3_token() called.\n");
+    fprintf(stdout, "H5Pget_fapl_ros3_token() called.\n");
 #endif
 
     if (size == 0)
@@ -655,7 +655,7 @@ H5FD__ros3_str_token_copy(const char H5_ATTR_UNUSED *name, size_t H5_ATTR_UNUSED
     FUNC_ENTER_PACKAGE
 
 #if ROS3_DEBUG
-    HDfprintf(stdout, "H5FD__ros3_str_token_copy() called.\n");
+    fprintf(stdout, "H5FD__ros3_str_token_copy() called.\n");
 #endif
 
     if (*value)
@@ -789,7 +789,7 @@ H5Pset_fapl_ros3_token(hid_t fapl_id, const char *token)
     H5TRACE2("e", "i*s", fapl_id, token);
 
 #if ROS3_DEBUG
-    HDfprintf(stdout, "H5Pset_fapl_ros3_token() called.\n");
+    fprintf(stdout, "H5Pset_fapl_ros3_token() called.\n");
 #endif
 
     if (fapl_id == H5P_DEFAULT)


### PR DESCRIPTION
- Replaced the HDfprintf() functions by fprintf() to be consistent with other parts of the library.