### PR TITLE
Fixed -Wdeprecated-copy-dtor warnings by implementing a copy assignme…

### DIFF
--- a/c++/src/H5Attribute.cpp
+++ b/c++/src/H5Attribute.cpp
@@ -605,4 +605,16 @@ Attribute::~Attribute()
     }
 }
 
+//--------------------------------------------------------------------------
+// Function:    Copy assignment operator
+Attribute &
+Attribute::operator=(const Attribute &original)
+{
+    if (&original != this) {
+        setId(original.id);
+    }
+
+    return *this;
+}
+
 } // namespace H5

--- a/c++/src/H5Attribute.h
+++ b/c++/src/H5Attribute.h
@@ -78,6 +78,9 @@ class H5_DLLCPP Attribute : public AbstractDs, public H5Location {
     // Destructor: properly terminates access to this attribute.
     virtual ~Attribute() override;
 
+    // Copy assignment operator.
+    Attribute &operator=(const Attribute &original);
+
 #ifndef DOXYGEN_SHOULD_SKIP_THIS
   protected:
     // Sets the attribute id.

--- a/c++/src/H5Group.cpp
+++ b/c++/src/H5Group.cpp
@@ -274,4 +274,16 @@ Group::~Group()
     }
 }
 
+//--------------------------------------------------------------------------
+// Function:    Copy assignment operator
+Group &
+Group::operator=(const Group &original)
+{
+    if (&original != this) {
+        setId(original.id);
+    }
+
+    return *this;
+}
+
 } // namespace H5

--- a/c++/src/H5Group.h
+++ b/c++/src/H5Group.h
@@ -67,6 +67,9 @@ class H5_DLLCPP Group : public H5Object, public CommonFG {
     // Destructor
     virtual ~Group() override;
 
+    // Copy assignment operator.
+    Group &operator=(const Group &original);
+
     // Creates a copy of an existing group using its id.
     Group(const hid_t group_id);
 


### PR DESCRIPTION
…nt operator

Example warning was:

warning: definition of implicit copy assignment operator for 'Group' is deprecated because it has a user-declared destructor [-Wdeprecated-copy-dtor]