### PR TITLE
Fix incorrect error check in H5Ofill.c for undefined fill values

### DIFF
--- a/release_docs/RELEASE.txt
+++ b/release_docs/RELEASE.txt
@@ -258,6 +258,14 @@ Bug Fixes since HDF5-1.14.0 release
 ===================================
     Library
     -------
+    - Fixed an issue where an assert statement was converted to an
+      incorrect error check statement
+
+      An assert statement in the library dealing with undefined dataset data
+      fill values was converted to an improper error check that would always
+      trigger when a dataset's fill value was set to NULL (undefined). This
+      has now been fixed.
+
     - Fixed an assertion failure when attempting to use the Subfiling IOC
       VFD directly
 

--- a/src/H5Ofill.c
+++ b/src/H5Ofill.c
@@ -273,7 +273,7 @@ H5O__fill_new_decode(H5F_t H5_ATTR_UNUSED *f, H5O_t H5_ATTR_UNUSED *open_oh,
         /* Check for undefined fill value */
         if (flags & H5O_FILL_FLAG_UNDEFINED_VALUE) {
 
-            if (flags & (unsigned)~H5O_FILL_FLAG_HAVE_VALUE)
+            if (flags & H5O_FILL_FLAG_HAVE_VALUE)
                 HGOTO_ERROR(H5E_OHDR, H5E_CANTLOAD, NULL, "have value and undefined value flags both set")
 
             /* Set value for "undefined" fill value */


### PR DESCRIPTION
Reported in https://forum.hdfgroup.org/t/h5dump-1-14-gives-error-with-fill-value-1-12-is-ok/11385