### PR TITLE
Fix CVE-2018-11202

### DIFF
--- a/release_docs/RELEASE.txt
+++ b/release_docs/RELEASE.txt
@@ -265,6 +265,20 @@ Bug Fixes since HDF5-1.14.0 release
 ===================================
     Library
     -------
+    - Fixed CVE-2018-11202
+
+      A malformed file could result in chunk index memory leaks. Under most
+      conditions (i.e., when the --enable-using-memchecker option is NOT
+      used), this would result in a small memory leak and and infinite loop
+      and abort when shutting down the library. The infinite loop would be
+      due to the "free list" package not being able to clear its resources
+      so the library couldn't shut down. When the "using a memory checker"
+      option is used, the free lists are disabled so there is just a memory
+      leak with no abort on library shutdown.
+
+      The chunk index resources are now correctly cleaned up when reading
+      misparsed files and valgrind confirms no memory leaks.
+
     - Fixed an issue where an assert statement was converted to an
       incorrect error check statement
 

--- a/src/H5Dchunk.c
+++ b/src/H5Dchunk.c
@@ -961,10 +961,13 @@ H5D__chunk_init(H5F_t *f, const H5D_t *const dset, hid_t dapl_id)
         HGOTO_ERROR(H5E_DATASET, H5E_CANTINIT, FAIL, "unable to set # of chunks for dataset");
 
 done:
-    if (FAIL == ret_value)
-        if (H5D__chunk_dest(dset) < 0)
-            HDONE_ERROR(H5E_DATASET, H5E_CANTFREE, FAIL,
-                        "unable to clean up chunk structures during error cleanup");
+    if (FAIL == ret_value) {
+        if (rdcc->slot)
+            rdcc->slot = H5FL_SEQ_FREE(H5D_rdcc_ent_ptr_t, rdcc->slot);
+
+        if (sc->ops->dest && (sc->ops->dest)(&idx_info) < 0)
+            HDONE_ERROR(H5E_DATASET, H5E_CANTFREE, FAIL, "unable to release chunk index info");
+    }
     FUNC_LEAVE_NOAPI(ret_value)
 } /* end H5D__chunk_init() */
 

--- a/src/H5Dchunk.c
+++ b/src/H5Dchunk.c
@@ -963,7 +963,8 @@ H5D__chunk_init(H5F_t *f, const H5D_t *const dset, hid_t dapl_id)
 done:
     if (FAIL == ret_value)
         if (H5D__chunk_dest(dset) < 0)
-            HDONE_ERROR(H5E_DATASET, H5E_CANTFREE, FAIL, "unable to clean up chunk structures during error cleanup");
+            HDONE_ERROR(H5E_DATASET, H5E_CANTFREE, FAIL,
+                        "unable to clean up chunk structures during error cleanup");
     FUNC_LEAVE_NOAPI(ret_value)
 } /* end H5D__chunk_init() */
 

--- a/src/H5Dchunk.c
+++ b/src/H5Dchunk.c
@@ -880,6 +880,7 @@ H5D__chunk_init(H5F_t *f, const H5D_t *const dset, hid_t dapl_id)
     H5D_rdcc_t        *rdcc = &(dset->shared->cache.chunk); /* Convenience pointer to dataset's chunk cache */
     H5P_genplist_t    *dapl;                                /* Data access property list object pointer */
     H5O_storage_chunk_t *sc        = &(dset->shared->layout.storage.u.chunk);
+    bool                 idx_init  = false;
     herr_t               ret_value = SUCCEED; /* Return value */
 
     FUNC_ENTER_PACKAGE
@@ -955,6 +956,7 @@ H5D__chunk_init(H5F_t *f, const H5D_t *const dset, hid_t dapl_id)
     /* Allocate any indexing structures */
     if (sc->ops->init && (sc->ops->init)(&idx_info, dset->shared->space, dset->oloc.addr) < 0)
         HGOTO_ERROR(H5E_DATASET, H5E_CANTINIT, FAIL, "can't initialize indexing information");
+    idx_init = true;
 
     /* Set the number of chunks in dataset, etc. */
     if (H5D__chunk_set_info(dset) < 0)
@@ -965,7 +967,7 @@ done:
         if (rdcc->slot)
             rdcc->slot = H5FL_SEQ_FREE(H5D_rdcc_ent_ptr_t, rdcc->slot);
 
-        if (sc->ops->dest && (sc->ops->dest)(&idx_info) < 0)
+        if (idx_init && sc->ops->dest && (sc->ops->dest)(&idx_info) < 0)
             HDONE_ERROR(H5E_DATASET, H5E_CANTFREE, FAIL, "unable to release chunk index info");
     }
     FUNC_LEAVE_NOAPI(ret_value)

--- a/src/H5Dchunk.c
+++ b/src/H5Dchunk.c
@@ -961,6 +961,9 @@ H5D__chunk_init(H5F_t *f, const H5D_t *const dset, hid_t dapl_id)
         HGOTO_ERROR(H5E_DATASET, H5E_CANTINIT, FAIL, "unable to set # of chunks for dataset");
 
 done:
+    if (FAIL == ret_value)
+        if (H5D__chunk_dest(dset) < 0)
+            HDONE_ERROR(H5E_DATASET, H5E_CANTFREE, FAIL, "unable to clean up chunk structures during error cleanup");
     FUNC_LEAVE_NOAPI(ret_value)
 } /* end H5D__chunk_init() */
 


### PR DESCRIPTION
A malformed file could result in chunk index memory leaks. Under most conditions (i.e., when the --enable-using-memchecker option is NOT used), this would result in a small memory leak and and infinite loop and abort when shutting down the library. The infinite loop would be due to the "free list" package not being able to clear its resources so the library couldn't shut down. When the "using a memory checker" option is used, the free lists are disabled so there is just a memory leak with no abort on library shutdown.

The chunk index resources are now correctly cleaned up when reading misparsed files and valgrind confirms no memory leaks.