### PR TITLE
Fix CVE-2018-13867

### DIFF
--- a/release_docs/RELEASE.txt
+++ b/release_docs/RELEASE.txt
@@ -265,6 +265,15 @@ Bug Fixes since HDF5-1.14.0 release
 ===================================
     Library
     -------
+    - Fixed CVE-2018-13867
+
+      A corrupt file containing an invalid local heap datablock address
+      could trigger an assert failure when the metadata cache attempted
+      to load the datablock from storage.
+
+      The local heap now verifies that the datablock address is valid
+      when the local heap header information is parsed.
+
     - Fixed CVE-2018-11202
 
       A malformed file could result in chunk index memory leaks. Under most

--- a/src/H5HLcache.c
+++ b/src/H5HLcache.c
@@ -194,6 +194,12 @@ H5HL__hdr_deserialize(H5HL_t *heap, const uint8_t *image, size_t len, H5HL_cache
         HGOTO_ERROR(H5E_HEAP, H5E_OVERFLOW, FAIL, "ran off end of input buffer while decoding");
     H5F_addr_decode_len(udata->sizeof_addr, &image, &(heap->dblk_addr));
 
+    /* Check that the datablock address is valid (might not be true
+     * in a corrupt file)
+     */
+    if (!H5_addr_defined(heap->dblk_addr))
+        HGOTO_ERROR(H5E_HEAP, H5E_BADVALUE, FAIL, "bad datablock address");
+
 done:
     FUNC_LEAVE_NOAPI(ret_value)
 } /* end H5HL__hdr_deserialize() */


### PR DESCRIPTION
A corrupt file containing an invalid local heap datablock address could trigger an assert failure when the metadata cache attempted to load the datablock from storage.

The local heap now verifies that the datablock address is valid when the local heap header information is parsed.