### PR TITLE
Fix Heap-buffer-overflow WRITE in H5MM_memcpy

### DIFF
--- a/release_docs/RELEASE.txt
+++ b/release_docs/RELEASE.txt
@@ -523,6 +523,10 @@ Bug Fixes since HDF5-1.14.0 release
 
       Fixes Github issue #3034
 
+    - Fixed write buffer overflow in H5O__alloc_chunk
+
+      The overflow was found by OSS-Fuzz https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=58658
+
     Java Library
     ------------
     - Fixed switch case 'L' block missing a break statement.

--- a/src/H5Oalloc.c
+++ b/src/H5Oalloc.c
@@ -946,6 +946,9 @@ H5O__alloc_chunk(H5F_t *f, H5O_t *oh, size_t size, size_t found_null, const H5O_
                     else {
                         assert(curr_msg->type->id != H5O_CONT_ID);
 
+                        if (size < curr_msg->raw_size + (size_t)H5O_SIZEOF_MSGHDR_OH(oh))
+                            HGOTO_ERROR(H5E_OHDR, H5E_BADVALUE, FAIL, "invalid size");
+
                         /* Copy the raw data */
                         H5MM_memcpy(p, curr_msg->raw - (size_t)H5O_SIZEOF_MSGHDR_OH(oh),
                                     curr_msg->raw_size + (size_t)H5O_SIZEOF_MSGHDR_OH(oh));


### PR DESCRIPTION
Closes #3367
Fixes https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=58658

The root cause is that [`H5MM_memcpy(p, ...)`](https://github.com/HDFGroup/hdf5/blob/bf68e6eb3a2e9c209024769c1193fe31ffc39e23/src/H5Oalloc.c#L950-L951) is done in the loop [`for (u = 0, curr_msg = &oh->mesg[0]; u < oh->nmesgs; u++, curr_msg++)`](https://github.com/HDFGroup/hdf5/blob/bf68e6eb3a2e9c209024769c1193fe31ffc39e23/src/H5Oalloc.c#L938). The [`p` is advanced forward and `size` is decreased](https://github.com/HDFGroup/hdf5/blob/bf68e6eb3a2e9c209024769c1193fe31ffc39e23/src/H5Oalloc.c#L958-L959) on every copy, however there is no check that the `size` is still enough to accommodate the data.