### PR TITLE
Fix Use-of-uninitialized-value in H5FD__sec2_write

### DIFF
--- a/src/H5FScache.c
+++ b/src/H5FScache.c
@@ -1233,7 +1233,7 @@ H5FS__cache_sinfo_serialize(const H5F_t *f, void *_image, size_t len, void *_thi
     /* There may be empty space between entries and chksum */
     chksum_image    = (uint8_t *)(_image) + len - H5FS_SIZEOF_CHKSUM;
     /* Reset the unused space between entries and chksum */
-    memset(image, 0, len - H5FS_SIZEOF_CHKSUM - ((void*)image - _image));
+    memset(image, 0, len - H5FS_SIZEOF_CHKSUM - ((void *)image - _image));
     metadata_chksum = H5_checksum_metadata(_image, (size_t)(chksum_image - (uint8_t *)_image), 0);
     /* Metadata checksum */
     UINT32ENCODE(chksum_image, metadata_chksum);

--- a/src/H5FScache.c
+++ b/src/H5FScache.c
@@ -1232,6 +1232,8 @@ H5FS__cache_sinfo_serialize(const H5F_t *f, void *_image, size_t len, void *_thi
 
     /* There may be empty space between entries and chksum */
     chksum_image    = (uint8_t *)(_image) + len - H5FS_SIZEOF_CHKSUM;
+    /* Reset the unused space between entries and chksum */
+    memset(image, 0, len - H5FS_SIZEOF_CHKSUM - ((void*)image - _image));
     metadata_chksum = H5_checksum_metadata(_image, (size_t)(chksum_image - (uint8_t *)_image), 0);
     /* Metadata checksum */
     UINT32ENCODE(chksum_image, metadata_chksum);

--- a/src/H5FScache.c
+++ b/src/H5FScache.c
@@ -1231,7 +1231,7 @@ H5FS__cache_sinfo_serialize(const H5F_t *f, void *_image, size_t len, void *_thi
     /* Compute checksum */
 
     /* There may be empty space between entries and chksum */
-    chksum_image    = (uint8_t *)(_image) + len - H5FS_SIZEOF_CHKSUM;
+    chksum_image = (uint8_t *)(_image) + len - H5FS_SIZEOF_CHKSUM;
     /* Reset the unused space between entries and chksum */
     memset(image, 0, len - H5FS_SIZEOF_CHKSUM - ((void *)image - _image));
     metadata_chksum = H5_checksum_metadata(_image, (size_t)(chksum_image - (uint8_t *)_image), 0);


### PR DESCRIPTION
Closes #3372
Fixes https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=58644

In the reproducer case it allocates 71 bytes for the buffer in https://github.com/HDFGroup/hdf5/blob/bf68e6eb3a2e9c209024769c1193fe31ffc39e23/src/H5Centry.c#L548. Then it initializes only the first 49 bytes and the last 4 bytes in https://github.com/HDFGroup/hdf5/blob/bf68e6eb3a2e9c209024769c1193fe31ffc39e23/src/H5FScache.c#L1233-L1237 and writes the whole 71 bytes buffer in https://github.com/HDFGroup/hdf5/blob/bf68e6eb3a2e9c209024769c1193fe31ffc39e23/src/H5FDsec2.c#L794