### PR TITLE
restore CI tarball name prefix to match bin/release

### DIFF
--- a/.github/workflows/tarball.yml
+++ b/.github/workflows/tarball.yml
@@ -103,9 +103,9 @@ jobs:
         run: |
           if [[ '${{ inputs.use_environ }}' == 'snapshots' && '${{ needs.check_commits.outputs.has_changes }}' == 'true' ]]
           then
-            FILE_NAME_BASE=$(echo "${{ needs.check_commits.outputs.branch_ref }}-${{ needs.check_commits.outputs.branch_sha }}")
+            FILE_NAME_BASE=$(echo "hdf5-${{ needs.check_commits.outputs.branch_ref }}-${{ needs.check_commits.outputs.branch_sha }}")
           else
-            FILE_NAME_BASE=$(echo "${{ steps.version.outputs.TAG_VERSION }}")
+            FILE_NAME_BASE=$(echo "hdf5-${{ steps.version.outputs.TAG_VERSION }}")
           fi
           echo "FILE_BASE=$FILE_NAME_BASE" >> $GITHUB_OUTPUT
         shell: bash


### PR DESCRIPTION
bin/release puts hdf5-<version> in the filenames and github branches also use the hdf5 prefix, and if we want just one we will need to remove the hardcoded one in bin/release. And then remove the re-addition in the tarball.yml file.