### PR TITLE
Fix assertion failure during file close on error

### DIFF
--- a/release_docs/RELEASE.txt
+++ b/release_docs/RELEASE.txt
@@ -283,6 +283,17 @@ Bug Fixes since HDF5-1.14.0 release
 ===================================
     Library
     -------
+    - Fixed an assertion failure in Parallel HDF5 when a file can't be created
+      due to an invalid library version bounds setting
+
+      An assertion failure could occur in H5MF_settle_raw_data_fsm when a file
+      can't be created with Parallel HDF5 due to specifying the use of a paged,
+      persistent file free space manager
+      (H5Pset_file_space_strategy(..., H5F_FSPACE_STRATEGY_PAGE, 1, ...)) with
+      an invalid library version bounds combination
+      (H5Pset_libver_bounds(..., H5F_LIBVER_EARLIEST, H5F_LIBVER_V18)). This
+      has now been fixed.
+
     - Fixed bugs in selection I/O
 
       Previously, the library could fail in some cases when performing selection

--- a/src/H5C.c
+++ b/src/H5C.c
@@ -416,7 +416,7 @@ H5C_prep_for_file_close(H5F_t *f)
 
 #ifdef H5_HAVE_PARALLEL
     if ((H5F_INTENT(f) & H5F_ACC_RDWR) && !image_generated && cache_ptr->aux_ptr != NULL &&
-        f->shared->fs_persist) {
+        f->shared->sblock && f->shared->fs_persist) {
         /* If persistent free space managers are enabled, flushing the
          * metadata cache may result in the deletion, insertion, and/or
          * dirtying of entries.

--- a/testpar/t_file.c
+++ b/testpar/t_file.c
@@ -1009,3 +1009,54 @@ test_delete(void)
     VRFY((SUCCEED == ret), "H5Pclose");
 
 } /* end test_delete() */
+
+/*
+ * Tests for an assertion failure during file close that used
+ * to occur when the library fails to create a file in parallel
+ * due to an invalid library version bounds setting
+ */
+void
+test_invalid_libver_bounds_file_close_assert(void)
+{
+    const char *filename = NULL;
+    MPI_Comm    comm     = MPI_COMM_WORLD;
+    MPI_Info    info     = MPI_INFO_NULL;
+    herr_t      ret;
+    hid_t       fid     = H5I_INVALID_HID;
+    hid_t       fapl_id = H5I_INVALID_HID;
+    hid_t       fcpl_id = H5I_INVALID_HID;
+
+    filename = (const char *)GetTestParameters();
+
+    /* set up MPI parameters */
+    MPI_Comm_size(MPI_COMM_WORLD, &mpi_size);
+    MPI_Comm_rank(MPI_COMM_WORLD, &mpi_rank);
+
+    /* setup file access plist */
+    fapl_id = H5Pcreate(H5P_FILE_ACCESS);
+    VRFY((fapl_id != H5I_INVALID_HID), "H5Pcreate");
+    ret = H5Pset_fapl_mpio(fapl_id, comm, info);
+    VRFY((SUCCEED == ret), "H5Pset_fapl_mpio");
+    ret = H5Pset_libver_bounds(fapl_id, H5F_LIBVER_EARLIEST, H5F_LIBVER_V18);
+    VRFY((SUCCEED == ret), "H5Pset_libver_bounds");
+
+    /* setup file creation plist */
+    fcpl_id = H5Pcreate(H5P_FILE_CREATE);
+    VRFY((fcpl_id != H5I_INVALID_HID), "H5Pcreate");
+
+    ret = H5Pset_file_space_strategy(fcpl_id, H5F_FSPACE_STRATEGY_PAGE, TRUE, 1);
+    VRFY((SUCCEED == ret), "H5Pset_file_space_strategy");
+
+    /* create the file */
+    H5E_BEGIN_TRY
+    {
+        fid = H5Fcreate(filename, H5F_ACC_TRUNC, fcpl_id, fapl_id);
+    }
+    H5E_END_TRY
+    VRFY((fid == H5I_INVALID_HID), "H5Fcreate");
+
+    ret = H5Pclose(fapl_id);
+    VRFY((SUCCEED == ret), "H5Pclose");
+    ret = H5Pclose(fcpl_id);
+    VRFY((SUCCEED == ret), "H5Pclose");
+}

--- a/testpar/testphdf5.c
+++ b/testpar/testphdf5.c
@@ -359,6 +359,9 @@ main(int argc, char **argv)
 
     AddTest("delete", test_delete, NULL, "MPI-IO VFD file delete", PARATESTFILE);
 
+    AddTest("invlibverassert", test_invalid_libver_bounds_file_close_assert, NULL,
+            "Invalid libver bounds assertion failure", PARATESTFILE);
+
     AddTest("idsetw", dataset_writeInd, NULL, "dataset independent write", PARATESTFILE);
     AddTest("idsetr", dataset_readInd, NULL, "dataset independent read", PARATESTFILE);
 

--- a/testpar/testphdf5.h
+++ b/testpar/testphdf5.h
@@ -232,6 +232,7 @@ void external_links(void);
 void zero_dim_dset(void);
 void test_file_properties(void);
 void test_delete(void);
+void test_invalid_libver_bounds_file_close_assert(void);
 void multiple_dset_write(void);
 void multiple_group_write(void);
 void multiple_group_read(void);


### PR DESCRIPTION
This PR fixes the assertion failure:

/src/H5MF.c:2585: H5MF_settle_raw_data_fsm: Assertion `f->shared->sblock' failed.