### PR TITLE
Fix use of uninitialized value in testpar/t_dset.c test

### DIFF
--- a/testpar/t_dset.c
+++ b/testpar/t_dset.c
@@ -3501,6 +3501,8 @@ test_no_collective_cause_mode(int selection_mode)
         sid = H5Screate(H5S_NULL);
         VRFY((sid >= 0), "H5Screate_simple succeeded");
         is_chunked = 0;
+
+        dims[0] = dims[1] = 0;
     }
     else {
         /* Create the basic Space */


### PR DESCRIPTION
Fixes

```
==4846== Conditional jump or move depends on uninitialised value(s)
==4846==    at 0x40AE53: test_no_collective_cause_mode (t_dset.c:3633)
==4846==    by 0x420D47: no_collective_cause_tests (t_dset.c:3780)
==4846==    by 0x485B88C: PerformTests (testframe.c:311)
==4846==    by 0x40766B: main (testphdf5.c:529)
```