### PR TITLE
Fix for CVE-2018-15671

### DIFF
--- a/src/H5Gint.c
+++ b/src/H5Gint.c
@@ -977,15 +977,13 @@ H5G__visit_cb(const H5O_link_t *lnk, void *_udata)
         /* Check if we've seen the object the link references before */
         if (NULL == H5SL_search(udata->visited, &obj_pos)) {
             H5O_type_t otype; /* Basic object type (group, dataset, etc.) */
-            unsigned   rc;    /* Reference count of object    */
 
             /* Get the object's reference count and type */
-            if (H5O_get_rc_and_type(&obj_oloc, &rc, &otype) < 0)
+            if (H5O_get_rc_and_type(&obj_oloc, NULL, &otype) < 0)
                 HGOTO_ERROR(H5E_SYM, H5E_CANTGET, H5_ITER_ERROR, "unable to get object info");
 
-            /* If its ref count is > 1, we add it to the list of visited objects */
-            /* (because it could come up again during traversal) */
-            if (rc > 1) {
+            /* Add it to the list of visited objects */
+            {
                 H5_obj_t *new_node; /* New object node for visited list */
 
                 /* Allocate new object "position" node */
@@ -999,7 +997,7 @@ H5G__visit_cb(const H5O_link_t *lnk, void *_udata)
                 if (H5SL_insert(udata->visited, new_node, new_node) < 0)
                     HGOTO_ERROR(H5E_SYM, H5E_CANTINSERT, H5_ITER_ERROR,
                                 "can't insert object node into visited list");
-            } /* end if */
+            }
 
             /* If it's a group, we recurse into it */
             if (otype == H5O_TYPE_GROUP) {
@@ -1094,7 +1092,6 @@ H5G_visit(H5G_loc_t *loc, const char *group_name, H5_index_t idx_type, H5_iter_o
     hid_t               gid = H5I_INVALID_HID; /* Group ID */
     H5G_t              *grp = NULL;            /* Group opened */
     H5G_loc_t           start_loc;             /* Location of starting group */
-    unsigned            rc;                    /* Reference count of object    */
     herr_t              ret_value = FAIL;      /* Return value */
 
     /* Portably clear udata struct (before FUNC_ENTER) */
@@ -1136,13 +1133,8 @@ H5G_visit(H5G_loc_t *loc, const char *group_name, H5_index_t idx_type, H5_iter_o
     if ((udata.visited = H5SL_create(H5SL_TYPE_OBJ, NULL)) == NULL)
         HGOTO_ERROR(H5E_SYM, H5E_CANTCREATE, FAIL, "can't create skip list for visited objects");
 
-    /* Get the group's reference count */
-    if (H5O_get_rc_and_type(&grp->oloc, &rc, NULL) < 0)
-        HGOTO_ERROR(H5E_SYM, H5E_CANTGET, FAIL, "unable to get object info");
-
-    /* If its ref count is > 1, we add it to the list of visited objects */
-    /* (because it could come up again during traversal) */
-    if (rc > 1) {
+    /* Add it to the list of visited objects */
+    {
         H5_obj_t *obj_pos; /* New object node for visited list */
 
         /* Allocate new object "position" node */
@@ -1156,7 +1148,7 @@ H5G_visit(H5G_loc_t *loc, const char *group_name, H5_index_t idx_type, H5_iter_o
         /* Add to list of visited objects */
         if (H5SL_insert(udata.visited, obj_pos, obj_pos) < 0)
             HGOTO_ERROR(H5E_SYM, H5E_CANTINSERT, FAIL, "can't insert object node into visited list");
-    } /* end if */
+    }
 
     /* Attempt to get the link info for this group */
     if ((linfo_exists = H5G__obj_get_linfo(&(grp->oloc), &linfo)) < 0)

--- a/tools/src/h5dump/h5dump_ddl.c
+++ b/tools/src/h5dump/h5dump_ddl.c
@@ -853,10 +853,7 @@ dump_group(hid_t gid, const char *name)
 
     H5Oget_info3(gid, &oinfo, H5O_INFO_BASIC);
 
-    /* Must check for uniqueness of all objects if we've traversed an elink,
-     * otherwise only check if the reference count > 1.
-     */
-    if (oinfo.rc > 1 || hit_elink) {
+    {
         obj_t *found_obj; /* Found object */
 
         found_obj = search_obj(group_table, &oinfo.token);
@@ -879,10 +876,6 @@ dump_group(hid_t gid, const char *name)
             attr_iteration(gid, attr_crt_order_flags);
             link_iteration(gid, crt_order_flags);
         }
-    }
-    else {
-        attr_iteration(gid, attr_crt_order_flags);
-        link_iteration(gid, crt_order_flags);
     }
 
     dump_indent -= COL;

--- a/tools/testfiles/tgroup-2.ddl
+++ b/tools/testfiles/tgroup-2.ddl
@@ -17,14 +17,7 @@ GROUP "/" {
       }
    }
    GROUP "g2" {
-      GROUP "g2.1" {
-         GROUP "g2.1.1" {
-         }
-         GROUP "g2.1.2" {
-         }
-         GROUP "g2.1.3" {
-         }
-      }
+      HARDLINK "/g2"
    }
    GROUP "g3" {
       GROUP "g3.1" {


### PR DESCRIPTION
h5stat -S $POC will result in a crash with s…egmenetation fault

It is because the object in the testfile points back to the root group. When the tool tries to traverse the object, it goes back to the root group and then back again. The fix is from Dana.  Because the fix changes the behavior of how objects are considered "visited" and "displayed", a fix to one of the expected h5dump output is followed.