### PR TITLE
Fix a memory leak when parsing corrupt files

### DIFF
--- a/release_docs/RELEASE.txt
+++ b/release_docs/RELEASE.txt
@@ -135,6 +135,17 @@ Bug Fixes since HDF5-1.10.10 release
 ===================================
     Library
     -------
+    - Fix a memory leak when parsing corrupt files
+
+      When parsing a file with a corrupt attribute object header message,
+      allocated memory would not be cleaned up. This could also trip
+      asserts in the memory sanity check code when that feature is enabled.
+
+      This fix ensures that memory allocated in the function is freed on
+      errors.
+
+      Fixes HDFFV-10774
+
     - Seg fault on file close
 
       h5debug fails at file close with core dump on a file that has an

--- a/src/H5Oattr.c
+++ b/src/H5Oattr.c
@@ -256,6 +256,8 @@ H5O_attr_decode(H5F_t *f, H5O_t *open_oh, unsigned H5_ATTR_UNUSED mesg_flags, un
 done:
     if (NULL == ret_value)
         if (attr) {
+            if(attr->shared->ds)
+                attr->shared->ds = H5FL_FREE(H5S_t, attr->shared->ds);
             if (attr->shared) {
                 /* Free any dynamically allocated items */
                 if (H5A__free(attr) < 0)

--- a/src/H5Oattr.c
+++ b/src/H5Oattr.c
@@ -256,7 +256,7 @@ H5O_attr_decode(H5F_t *f, H5O_t *open_oh, unsigned H5_ATTR_UNUSED mesg_flags, un
 done:
     if (NULL == ret_value)
         if (attr) {
-            if(attr->shared->ds)
+            if (attr->shared->ds)
                 attr->shared->ds = H5FL_FREE(H5S_t, attr->shared->ds);
             if (attr->shared) {
                 /* Free any dynamically allocated items */


### PR DESCRIPTION
When parsing a file with a corrupt attribute object header message,
allocated memory would not be cleaned up. This could also trip
asserts in the memory sanity check code when that feature is enabled.

This fix ensures that memory allocated in the function is freed on
errors.

Fixes HDFFV-10774