### PR TITLE
Update VOL CMake for REST VOL

### DIFF
--- a/CMakeVOL.cmake
+++ b/CMakeVOL.cmake
@@ -34,30 +34,16 @@ if (HDF5_VOL_ALLOW_EXTERNAL)
     message (FATAL_ERROR "HDF5_ALLOW_EXTERNAL_SUPPORT must be set to 'GIT' to allow building of external HDF5 VOL connectors")
   endif ()
 
-  set (HDF5_LIB_TARGETS "")
-  set (HDF5_HL_LIB_TARGETS "")
-
-  if (BUILD_STATIC_LIBS)
-    list(APPEND HDF5_LIB_TARGETS ${HDF5_LIB_TARGET})
-    list(APPEND HDF5_HL_LIB_TARGETS ${HDF5_HL_LIB_TARGET})
-  endif()
-
-  if (BUILD_SHARED_LIBS)
-    list(APPEND HDF5_LIB_TARGETS ${HDF5_LIBSH_TARGET})
-    list(APPEND HDF5_HL_LIB_TARGETS ${HDF5_HL_LIBSH_TARGET})
-  endif()
-
   # For compatibility, set some variables that projects would
   # typically look for after calling find_package(HDF5)
   set (HDF5_FOUND 1)
-  set (HDF5_LIBRARIES "${HDF5_LIB_TARGETS};${LINK_LIBS};${LINK_COMP_LIBS};$<$<BOOL:${HDF5_ENABLE_PARALLEL}>:MPI::MPI_C>")
+  set (HDF5_LIBRARIES "${HDF5_LIBSH_TARGET};${LINK_LIBS};${LINK_COMP_LIBS};$<$<BOOL:${HDF5_ENABLE_PARALLEL}>:MPI::MPI_C>")
   set (HDF5_INCLUDE_DIRS "${HDF5_SRC_INCLUDE_DIRS};${HDF5_SRC_BINARY_DIR};$<$<BOOL:${HDF5_ENABLE_PARALLEL}>:${MPI_C_INCLUDE_DIRS}>")
-  set (HDF5_DIR "${HDF5_SOURCE_DIR}")
 
-  set (HDF5_C_LIBRARIES "${HDF5_LIB_TARGETS}")
-
+  set (HDF5_C_LIBRARIES "${HDF5_LIBRARIES}")
+  
   if (HDF5_BUILD_HL_LIB)
-    set (HDF5_C_HL_LIBRARIES "${HDF5_HL_LIB_TARGETS}")
+    set (HDF5_C_HL_LIBRARIES "${HDF5_HL_LIBSH_TARGET}")
   endif()
 
   set (HDF5_MAX_EXTERNAL_VOLS 10)

--- a/CMakeVOL.cmake
+++ b/CMakeVOL.cmake
@@ -34,11 +34,31 @@ if (HDF5_VOL_ALLOW_EXTERNAL)
     message (FATAL_ERROR "HDF5_ALLOW_EXTERNAL_SUPPORT must be set to 'GIT' to allow building of external HDF5 VOL connectors")
   endif ()
 
+  set (HDF5_LIB_TARGETS "")
+  set (HDF5_HL_LIB_TARGETS "")
+
+  if (BUILD_STATIC_LIBS)
+    list(APPEND HDF5_LIB_TARGETS ${HDF5_LIB_TARGET})
+    list(APPEND HDF5_HL_LIB_TARGETS ${HDF5_HL_LIB_TARGET})
+  endif()
+
+  if (BUILD_SHARED_LIBS)
+    list(APPEND HDF5_LIB_TARGETS ${HDF5_LIBSH_TARGET})
+    list(APPEND HDF5_HL_LIB_TARGETS ${HDF5_HL_LIBSH_TARGET})
+  endif()
+
   # For compatibility, set some variables that projects would
   # typically look for after calling find_package(HDF5)
   set (HDF5_FOUND 1)
-  set (HDF5_LIBRARIES "${HDF5_LIBSH_TARGET};${LINK_LIBS};${LINK_COMP_LIBS};$<$<BOOL:${HDF5_ENABLE_PARALLEL}>:MPI::MPI_C>")
+  set (HDF5_LIBRARIES "${HDF5_LIB_TARGETS};${LINK_LIBS};${LINK_COMP_LIBS};$<$<BOOL:${HDF5_ENABLE_PARALLEL}>:MPI::MPI_C>")
   set (HDF5_INCLUDE_DIRS "${HDF5_SRC_INCLUDE_DIRS};${HDF5_SRC_BINARY_DIR};$<$<BOOL:${HDF5_ENABLE_PARALLEL}>:${MPI_C_INCLUDE_DIRS}>")
+  set (HDF5_DIR "${HDF5_SOURCE_DIR}")
+
+  set (HDF5_C_LIBRARIES "${HDF5_LIB_TARGETS}")
+
+  if (HDF5_BUILD_HL_LIB)
+    set (HDF5_C_HL_LIBRARIES "${HDF5_HL_LIB_TARGETS}")
+  endif()
 
   set (HDF5_MAX_EXTERNAL_VOLS 10)
   set (HDF5_EXTERNAL_VOL_TARGETS "")
@@ -134,6 +154,8 @@ if (HDF5_VOL_ALLOW_EXTERNAL)
         define_property (
           TARGET
           PROPERTY HDF5_VOL_TARGETS
+          BRIEF_DOCS "Generated targets of this connector"
+          FULL_DOCS "Generated targets of this connector"
         )
 
         set_target_properties (
@@ -149,6 +171,7 @@ if (HDF5_VOL_ALLOW_EXTERNAL)
           TARGET
           PROPERTY HDF5_VOL_NAME
           BRIEF_DOCS "VOL connector name to use for the HDF5_VOL_CONNECTOR environment variable when testing"
+          FULL_DOCS "VOL connector name to use for the HDF5_VOL_CONNECTOR environment variable when testing"
         )
 
         set_target_properties (
@@ -164,6 +187,7 @@ if (HDF5_VOL_ALLOW_EXTERNAL)
           TARGET
           PROPERTY HDF5_VOL_TEST_PARALLEL
           BRIEF_DOCS "Whether the VOL connector should be tested with the parallel API tests"
+          FULL_DOCS "Whether the VOL connector should be tested with the parallel API tests"
         )
 
         set_target_properties (


### PR DESCRIPTION
CMakeVOL.cmake now sets some additional variables that would usually be set by `find_package(HDF5)`,  which the REST VOL's build process uses.

Also populated both docs fields in calls to `define_property`, because versions of CMake before 3.23 throw an error if not given both.