### PR TITLE
Fix links in RELEASE.txt

### DIFF
--- a/release_docs/RELEASE.txt
+++ b/release_docs/RELEASE.txt
@@ -13,9 +13,9 @@ HDF5 source.
 Note that documentation in the links below will be updated at the time of each
 final release.
 
-Links to HDF5 documentation can be found on The HDF5 web page:
+Links to HDF5 documentation can be found at:
 
-     https://portal.hdfgroup.org/display/HDF5/HDF5
+     https://hdfgroup.github.io/hdf5/
 
 The official HDF5 releases can be obtained from:
 
@@ -24,7 +24,7 @@ The official HDF5 releases can be obtained from:
 Changes from Release to Release and New Features in the HDF5-1.12.x release series
 can be found at:
 
-     https://portal.hdfgroup.org/display/HDF5/HDF5+Application+Developer%27s+Guide
+     https://portal.hdfgroup.org/display/HDF5/Software+Changes+from+Release+to+Release+for+HDF5+1.12
 
 If you have any questions or comments, please send them to the HDF Help Desk:
 

--- a/release_docs/RELEASE.txt
+++ b/release_docs/RELEASE.txt
@@ -24,7 +24,7 @@ The official HDF5 releases can be obtained from:
 Changes from Release to Release and New Features in the HDF5-1.12.x release series
 can be found at:
 
-     https://portal.hdfgroup.org/display/HDF5/Software+Changes+from+Release+to+Release+for+HDF5+1.12
+     https://portal.hdfgroup.org/display/HDF5/HDF5+1.12+Release
 
 If you have any questions or comments, please send them to the HDF Help Desk:
 


### PR DESCRIPTION
Updated documentation link to the new documentation
Corrected Software Changes link, it was Developer's Guide.