### PR TITLE
Add NVHPC 23.7 GitHub Actions

### DIFF
--- a/.github/workflows/linux-nvhpc-auto.yml
+++ b/.github/workflows/linux-nvhpc-auto.yml
@@ -1,9 +1,26 @@
 name: linux autotools nvhpc
 
 on:
+  workflow_dispatch:
   push:
-    branches:
-      - develop
+  pull_request:
+    branches: [ develop ]
+    paths-ignore:
+      - '.github/CODEOWNERS'
+      - '.github/FUNDING.yml'
+      - 'doc/**'
+      - 'release_docs/**'
+      - 'ACKNOWLEDGEMENTS'
+      - 'COPYING**'
+      - '**.md'
+
+# Using concurrency to cancel any in-progress job or run
+concurrency:
+  group: ${{ github.workflow }}-${{ github.sha || github.event.pull_request.number }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
 
 jobs:
   build:
@@ -20,7 +37,7 @@ jobs:
           sudo apt-get update -y
           sudo apt-get install -y nvhpc-23-7          
       - name: Get Sources
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Test HDF5
         env:
           NPROCS: 2      

--- a/.github/workflows/linux-nvhpc-auto.yml
+++ b/.github/workflows/linux-nvhpc-auto.yml
@@ -1,0 +1,41 @@
+name: linux autotools nvhpc
+
+on:
+  push:
+    branches:
+      - develop
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Install System dependencies
+        run: |
+          sudo apt update
+          sudo apt install -y libaec-dev zlib1g-dev automake autoconf libcurl4-openssl-dev libjpeg-dev wget curl bzip2 m4 flex bison cmake libzip-dev doxygen openssl libtool libtool-bin build-essential
+      - name: Install NVHPC
+        run: |          
+          curl https://developer.download.nvidia.com/hpc-sdk/ubuntu/DEB-GPG-KEY-NVIDIA-HPC-SDK | sudo gpg --dearmor -o /usr/share/keyrings/nvidia-hpcsdk-archive-keyring.gpg
+          echo 'deb [signed-by=/usr/share/keyrings/nvidia-hpcsdk-archive-keyring.gpg] https://developer.download.nvidia.com/hpc-sdk/ubuntu/amd64 /' | sudo tee /etc/apt/sources.list.d/nvhpc.list
+          sudo apt-get update -y
+          sudo apt-get install -y nvhpc-23-7          
+      - name: Get Sources
+        uses: actions/checkout@v3
+      - name: Test HDF5
+        env:
+          NPROCS: 2      
+        run: |
+          export NVHPCSDK=/opt/nvidia/hpc_sdk
+          export OMPI_CXX=/opt/nvidia/hpc_sdk/Linux_x86_64/23.7/compilers/bin/nvc++
+          export OMPI_CC=/opt/nvidia/hpc_sdk/Linux_x86_64/23.7/compilers/bin/nvc
+          export OMPI_FC=/opt/nvidia/hpc_sdk/Linux_x86_64/23.7/compilers/bin/nvfortran
+          export LD_LIBRARY_PATH=/opt/nvidia/hpc_sdk/Linux_x86_64/23.7/compilers/lib
+          export PATH=/opt/nvidia/hpc_sdk/Linux_x86_64/23.7/comm_libs/openmpi4/bin:/opt/nvidia/hpc_sdk/Linux_x86_64/23.7/compilers/bin:$PATH
+          export DESTDIR=/tmp          
+          ./autogen.sh
+          ./configure CC=/opt/nvidia/hpc_sdk/Linux_x86_64/23.7/comm_libs/openmpi4/bin/mpicc FC=/opt/nvidia/hpc_sdk/Linux_x86_64/23.7/comm_libs/openmpi4/bin/mpifort FCFLAGS="-fPIC -fortranlibs" --enable-fortran --enable-shared --enable-parallel          
+          cat config.log
+          make -j
+          make check -j
+          make install
+          make uninstall

--- a/.github/workflows/linux-nvhpc.yml
+++ b/.github/workflows/linux-nvhpc.yml
@@ -1,0 +1,39 @@
+name: linux CMake nvhpc
+
+on:
+  push:
+    branches:
+      - develop
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Install System dependencies
+        run: |
+          sudo apt update
+          sudo apt install -y libaec-dev zlib1g-dev automake autoconf libcurl4-openssl-dev libjpeg-dev wget curl bzip2 m4 flex bison cmake libzip-dev doxygen openssl libtool libtool-bin build-essential
+      - name: Install NVHPC
+        run: |          
+          curl https://developer.download.nvidia.com/hpc-sdk/ubuntu/DEB-GPG-KEY-NVIDIA-HPC-SDK | sudo gpg --dearmor -o /usr/share/keyrings/nvidia-hpcsdk-archive-keyring.gpg
+          echo 'deb [signed-by=/usr/share/keyrings/nvidia-hpcsdk-archive-keyring.gpg] https://developer.download.nvidia.com/hpc-sdk/ubuntu/amd64 /' | sudo tee /etc/apt/sources.list.d/nvhpc.list
+          sudo apt-get update -y
+          sudo apt-get install -y nvhpc-23-7          
+      - name: Get Sources
+        uses: actions/checkout@v3
+      - name: Test HDF5
+        env:
+          FC: nvfortran
+          CC: nvc
+          FCFLAGS: -fPIC
+        run: |
+          export NVHPCSDK=/opt/nvidia/hpc_sdk
+          export OMPI_CXX=/opt/nvidia/hpc_sdk/Linux_x86_64/23.7/compilers/bin/nvc++
+          export OMPI_CC=/opt/nvidia/hpc_sdk/Linux_x86_64/23.7/compilers/bin/nvc
+          export OMPI_FC=/opt/nvidia/hpc_sdk/Linux_x86_64/23.7/compilers/bin/nvfortran
+          export LD_LIBRARY_PATH=/opt/nvidia/hpc_sdk/Linux_x86_64/23.7/cuda/12.2/lib64:/opt/nvidia/hpc_sdk/Linux_x86_64/23.7/compilers/lib
+          export PATH=/opt/nvidia/hpc_sdk/Linux_x86_64/23.7/comm_libs/openmpi4/bin:/opt/nvidia/hpc_sdk/Linux_x86_64/23.7/compilers/bin:$PATH        
+          cmake -B build  -DHDF5_ENABLE_SZIP_SUPPORT:BOOL=OFF -DHDF5_ENABLE_PARALLEL:BOOL=ON -DHDF5_BUILD_FORTRAN:BOOL=ON 
+          cat build/CMakeCache.txt
+          cmake --build build
+          ctest --test-dir build --output-on-failure        

--- a/.github/workflows/linux-nvhpc.yml
+++ b/.github/workflows/linux-nvhpc.yml
@@ -1,9 +1,26 @@
 name: linux CMake nvhpc
 
 on:
+  workflow_dispatch:
   push:
-    branches:
-      - develop
+  pull_request:
+    branches: [ develop ]
+    paths-ignore:
+      - '.github/CODEOWNERS'
+      - '.github/FUNDING.yml'
+      - 'doc/**'
+      - 'release_docs/**'
+      - 'ACKNOWLEDGEMENTS'
+      - 'COPYING**'
+      - '**.md'
+
+# Using concurrency to cancel any in-progress job or run
+concurrency:
+  group: ${{ github.workflow }}-${{ github.sha || github.event.pull_request.number }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
 
 jobs:
   build:
@@ -20,7 +37,7 @@ jobs:
           sudo apt-get update -y
           sudo apt-get install -y nvhpc-23-7          
       - name: Get Sources
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Test HDF5
         env:
           FC: nvfortran


### PR DESCRIPTION
All tests pass with Fortran and parallel enabled for both Autotools and CMake.
Making NVHPC work with HDF5 is quite tricky.
These actions will help AI users who want to utilize NVDIA chips.