### PR TITLE
quiet warning on Sunspot (gcc 11.2.0)

### DIFF
--- a/testpar/t_vfd.c
+++ b/testpar/t_vfd.c
@@ -5902,7 +5902,7 @@ main(int argc, char **argv)
     int provided = 0;
 #endif
     int mpi_size;
-    int mpi_rank;
+    int mpi_rank = 0;
     int ret;
 
 #ifdef H5_HAVE_SUBFILING_VFD


### PR DESCRIPTION
testpar/t_vfd.c:5905:17: note: initialize the variable 'mpi_rank' to silence this warning
    int mpi_rank;
                ^
                 = 0