### PR TITLE
Strip HD prefix from string/char C API calls

### DIFF
--- a/c++/test/tarray.cpp
+++ b/c++/test/tarray.cpp
@@ -220,7 +220,7 @@ test_array_compound_array()
 
         // Check the 2nd field's name
         H5std_string field2_name = ctype_check.getMemberName(1);
-        if (HDstrcmp(field2_name.c_str(), "f") != 0)
+        if (strcmp(field2_name.c_str(), "f") != 0)
             TestErrPrintf("Compound field name doesn't match!, field2_name=%s\n", field2_name.c_str());
 
         // Get the 2nd field's datatype

--- a/c++/test/tattr.cpp
+++ b/c++/test/tattr.cpp
@@ -1604,7 +1604,7 @@ test_string_attr(FileAccPropList &fapl)
         // Read and verify the attribute string as a string of chars.
         char flstring_att_check[ATTR_LEN];
         gr_flattr1.read(fls_type, flstring_att_check);
-        if (HDstrcmp(flstring_att_check, ATTRSTR_DATA.c_str()) != 0)
+        if (strcmp(flstring_att_check, ATTRSTR_DATA.c_str()) != 0)
             TestErrPrintf("Line %d: Attribute data different: ATTRSTR_DATA=%s,flstring_att_check=%s\n",
                           __LINE__, ATTRSTR_DATA.c_str(), flstring_att_check);
 
@@ -1614,7 +1614,7 @@ test_string_attr(FileAccPropList &fapl)
         char  *fl_dyn_string_att_check;
         fl_dyn_string_att_check = new char[attr_size + 1];
         gr_flattr1.read(fls_type, fl_dyn_string_att_check);
-        if (HDstrcmp(fl_dyn_string_att_check, ATTRSTR_DATA.c_str()) != 0)
+        if (strcmp(fl_dyn_string_att_check, ATTRSTR_DATA.c_str()) != 0)
             TestErrPrintf("Line %d: Attribute data different: ATTRSTR_DATA=%s,flstring_att_check=%s\n",
                           __LINE__, ATTRSTR_DATA.c_str(), fl_dyn_string_att_check);
         delete[] fl_dyn_string_att_check;
@@ -1629,9 +1629,9 @@ test_string_attr(FileAccPropList &fapl)
                           ATTRSTR_DATA.c_str(), read_flstr1.c_str());
 
         // Read and verify the attribute string as a string of chars.
-        HDstrcpy(flstring_att_check, "");
+        strcpy(flstring_att_check, "");
         gr_flattr2.read(fls_type, flstring_att_check);
-        if (HDstrcmp(flstring_att_check, ATTRSTR_DATA.c_str()) != 0)
+        if (strcmp(flstring_att_check, ATTRSTR_DATA.c_str()) != 0)
             TestErrPrintf("Line %d: Attribute data different: ATTRSTR_DATA=%s,flstring_att_check=%s\n",
                           __LINE__, ATTRSTR_DATA.c_str(), flstring_att_check);
 
@@ -1660,7 +1660,7 @@ test_string_attr(FileAccPropList &fapl)
         // Read and verify the attribute string as a string of chars.
         char *string_att_check;
         gr_vlattr.read(vls_type, &string_att_check);
-        if (HDstrcmp(string_att_check, ATTRSTR_DATA.c_str()) != 0)
+        if (strcmp(string_att_check, ATTRSTR_DATA.c_str()) != 0)
             TestErrPrintf("Line %d: Attribute data different: ATTRSTR_DATA=%s,string_att_check=%s\n",
                           __LINE__, ATTRSTR_DATA.c_str(), string_att_check);
         free(string_att_check);

--- a/c++/test/titerate.cpp
+++ b/c++/test/titerate.cpp
@@ -78,7 +78,7 @@ static void printelems(const Group &group, const H5std_string &dsname, const H5s
 static int
 iter_strcmp(const void *s1, const void *s2)
 {
-    return (HDstrcmp(*reinterpret_cast<const char *const *>(s1), *reinterpret_cast<const char *const *>(s2)));
+    return (strcmp(*reinterpret_cast<const char *const *>(s1), *reinterpret_cast<const char *const *>(s2)));
 }
 
 /*-------------------------------------------------------------------------
@@ -95,7 +95,7 @@ liter_cb(hid_t H5_ATTR_UNUSED group, const char *name, const H5L_info2_t H5_ATTR
     static int count  = 0;
     static int count2 = 0;
 
-    HDstrcpy(info->name, name);
+    strcpy(info->name, name);
 
     switch (info->command) {
         case RET_ZERO:
@@ -162,18 +162,18 @@ test_iter_group(FileAccPropList &fapl)
             DataSet dataset = file.createDataSet(name, datatype, filespace);
 
             /* Keep a copy of the dataset names */
-            lnames[i] = HDstrdup(name);
-            check_values(lnames[i], "HDstrdup returns NULL", __LINE__, __FILE__);
+            lnames[i] = strdup(name);
+            check_values(lnames[i], "strdup returns NULL", __LINE__, __FILE__);
         }
 
         /* Create a group and named datatype under root group for testing */
         Group grp(file.createGroup(GROUP1, 0));
-        lnames[NDATASETS] = HDstrdup("grp");
-        check_values(lnames[NDATASETS], "HDstrdup returns NULL", __LINE__, __FILE__);
+        lnames[NDATASETS] = strdup("grp");
+        check_values(lnames[NDATASETS], "strdup returns NULL", __LINE__, __FILE__);
 
         datatype.commit(file, "dtype");
-        lnames[NDATASETS + 1] = HDstrdup("dtype");
-        check_values(lnames[NDATASETS], "HDstrdup returns NULL", __LINE__, __FILE__);
+        lnames[NDATASETS + 1] = strdup("dtype");
+        check_values(lnames[NDATASETS], "strdup returns NULL", __LINE__, __FILE__);
 
         /* Sort the dataset names */
         qsort(lnames, NDATASETS + 2, sizeof(char *), iter_strcmp);
@@ -301,7 +301,7 @@ test_iter_group(FileAccPropList &fapl)
             TestErrPrintf("Group iteration function walked too far!\n");
 
         /* Verify that the correct name is retrieved */
-        if(HDstrcmp(info.name, lnames[(size_t)(idx - 1)]) != 0)
+        if(strcmp(info.name, lnames[(size_t)(idx - 1)]) != 0)
             TestErrPrintf("Group iteration function didn't return name correctly for link - lnames[%u] = '%s'!\n", (unsigned)(idx - 1), lnames[(size_t)(idx - 1)]);
     } /* end while */
     verify_val(ret, -1, "H5Literate", __LINE__, __FILE__);
@@ -327,7 +327,7 @@ test_iter_group(FileAccPropList &fapl)
             TestErrPrintf("Group iteration function walked too far!\n");
 
         /* Verify that the correct name is retrieved */
-        if(HDstrcmp(info.name, lnames[(size_t)(idx - 1)]) != 0)
+        if(strcmp(info.name, lnames[(size_t)(idx - 1)]) != 0)
             TestErrPrintf("Group iteration function didn't return name correctly for link - lnames[%u] = '%s'!\n", (unsigned)(idx - 1), lnames[(size_t)(idx - 1)]);
     } /* end while */
     verify_val(ret, -1, "H5Literate", __LINE__, __FILE__);

--- a/c++/test/tobject.cpp
+++ b/c++/test/tobject.cpp
@@ -307,7 +307,7 @@ test_get_objname_ontypes()
         // Name this datatype
         new_int_type.commit(grp, "IntType NATIVE_INT");
         ssize_t name_len = new_int_type.getObjName(type_name); // default len
-        verify_val(name_len, static_cast<ssize_t>(HDstrlen("/typetests/IntType NATIVE_INT")),
+        verify_val(name_len, static_cast<ssize_t>(strlen("/typetests/IntType NATIVE_INT")),
                    "DataType::getObjName", __LINE__, __FILE__);
         verify_val(type_name, "/typetests/IntType NATIVE_INT", "DataType::getObjName", __LINE__, __FILE__);
 

--- a/c++/test/tvlstr.cpp
+++ b/c++/test/tvlstr.cpp
@@ -158,7 +158,7 @@ test_vlstring_dataset()
 
         // Read and verify the dataset string as a string of chars.
         dset1.read(&string_ds_check, vlst);
-        if (HDstrcmp(string_ds_check, DSET1_DATA.c_str()) != 0)
+        if (strcmp(string_ds_check, DSET1_DATA.c_str()) != 0)
             TestErrPrintf("Line %d: Attribute data different: DSET1_DATA=%s,string_ds_check=%s\n", __LINE__,
                           DSET1_DATA.c_str(), string_ds_check);
 
@@ -186,7 +186,7 @@ test_vlstring_dataset()
         dset1.read(&string_ds_check, vlst);
 
         // Verify data read.
-        if (HDstrcmp(string_ds_check, dynstring_ds_write) != 0)
+        if (strcmp(string_ds_check, dynstring_ds_write) != 0)
             TestErrPrintf("VL string datasets don't match!, dynstring_ds_write=%s, string_ds_check=%s\n",
                           dynstring_ds_write, string_ds_check);
         free(string_ds_check);
@@ -256,7 +256,7 @@ test_vlstring_array_dataset()
 
         hsize_t ii;
         for (ii = 0; ii < SPACE1_DIM1; ii++) {
-            if (HDstrcmp(string_ds_check[ii], string_ds_array[ii]) != 0)
+            if (strcmp(string_ds_check[ii], string_ds_array[ii]) != 0)
                 TestErrPrintf("Line %d: Dataset data different: written=%s,read=%s\n", __LINE__,
                               string_ds_array[ii], string_ds_check[ii]);
 
@@ -282,7 +282,7 @@ test_vlstring_array_dataset()
 
         char *rdata2;
         dataset2.read(&rdata2, vlst);
-        if (HDstrcmp(wdata2, rdata2) != 0)
+        if (strcmp(wdata2, rdata2) != 0)
             TestErrPrintf("Line %d: Dataset data different: written=%s,read=%s\n", __LINE__, wdata2, rdata2);
 
         // Release resources from second dataset operation.
@@ -355,15 +355,15 @@ test_vlstrings_special()
 
         // Compare data read in.
         for (ii = 0; ii < SPACE1_DIM1; ii++) {
-            size_t wlen = HDstrlen(wdata[ii]);
-            size_t rlen = HDstrlen(rdata[ii]);
+            size_t wlen = strlen(wdata[ii]);
+            size_t rlen = strlen(rdata[ii]);
             if (wlen != rlen) {
                 TestErrPrintf("VL data lengths don't match!, strlen(wdata[%d])=%u, strlen(rdata[%d])=%u\n",
                               static_cast<int>(ii), static_cast<unsigned>(wlen), static_cast<int>(ii),
                               static_cast<unsigned>(rlen));
                 continue;
             }
-            if (HDstrcmp(wdata[ii], rdata[ii]) != 0) {
+            if (strcmp(wdata[ii], rdata[ii]) != 0) {
                 TestErrPrintf("VL data values don't match!, wdata[%d]=%s, rdata[%d]=%s\n",
                               static_cast<int>(ii), wdata[ii], static_cast<int>(ii), rdata[ii]);
                 continue;
@@ -562,13 +562,13 @@ test_compact_vlstring()
         // Compare data read in
         hsize_t i;
         for (i = 0; i < SPACE1_DIM1; i++) {
-            if (HDstrlen(wdata[i]) != strlen(rdata[i])) {
+            if (strlen(wdata[i]) != strlen(rdata[i])) {
                 TestErrPrintf("VL data length don't match!, strlen(wdata[%d])=%d, strlen(rdata[%d])=%d\n",
-                              static_cast<int>(i), static_cast<int>(HDstrlen(wdata[i])), static_cast<int>(i),
-                              static_cast<int>(HDstrlen(rdata[i])));
+                              static_cast<int>(i), static_cast<int>(strlen(wdata[i])), static_cast<int>(i),
+                              static_cast<int>(strlen(rdata[i])));
                 continue;
             } // end if
-            if (HDstrcmp(wdata[i], rdata[i]) != 0) {
+            if (strcmp(wdata[i], rdata[i]) != 0) {
                 TestErrPrintf("VL data values don't match!, wdata[%d]=%s, rdata[%d]=%s\n",
                               static_cast<int>(i), wdata[i], static_cast<int>(i), rdata[i]);
                 continue;
@@ -634,7 +634,7 @@ test_vlstring_attribute()
         // Read and verify the attribute string as a string of chars.
         char *string_att_check;
         gr_attr.read(vlst, &string_att_check);
-        if (HDstrcmp(string_att_check, ATTRSTR_DATA.c_str()) != 0)
+        if (strcmp(string_att_check, ATTRSTR_DATA.c_str()) != 0)
             TestErrPrintf("Line %d: Attribute data different: ATTRSTR_DATA=%s,string_att_check=%s\n",
                           __LINE__, ATTRSTR_DATA.c_str(), string_att_check);
 
@@ -661,7 +661,7 @@ test_vlstring_attribute()
         gr_attr.read(vlst, &string_att_check);
 
         // Verify data read.
-        if (HDstrcmp(string_att_check, string_att_write) != 0)
+        if (strcmp(string_att_check, string_att_write) != 0)
             TestErrPrintf("VL string attributes don't match!, string_att_write=%s, string_att_check=%s\n",
                           string_att_write, string_att_check);
 
@@ -709,7 +709,7 @@ static void test_read_vl_string_attribute()
         // Test reading "normal" sized string attribute
         char *string_att_check;
         att.read(vlst, &string_att_check);
-        if(HDstrcmp(string_att_check,ATTRSTR_DATA.c_str())!=0)
+        if(strcmp(string_att_check,ATTRSTR_DATA.c_str())!=0)
             TestErrPrintf("VL string attributes don't match!, string_att=%s, string_att_check=%s\n",ATTRSTR_DATA.c_str(),string_att_check);
         free(string_att_check);
         att.close();
@@ -717,7 +717,7 @@ static void test_read_vl_string_attribute()
         // Test reading "large" sized string attribute
         att = root.openAttribute("test_scalar_large");
         att.read(vlst, &string_att_check);
-        if(HDstrcmp(string_att_check,string_att_write)!=0)
+        if(strcmp(string_att_check,string_att_write)!=0)
             TestErrPrintf("VL string attributes don't match!, string_att_write=%s, string_att_check=%s\n",string_att_write,string_att_check);
         free(string_att_check);
         free(string_att_write);   // Free string allocated in test_write_vl_string_attribute
@@ -785,7 +785,7 @@ test_vlstring_array_attribute()
 
         hsize_t ii;
         for (ii = 0; ii < SPACE1_DIM1; ii++) {
-            if (HDstrcmp(string_att_check[ii], string_att_array[ii]) != 0)
+            if (strcmp(string_att_check[ii], string_att_array[ii]) != 0)
                 TestErrPrintf("Line %d: Attribute data different: written=%s,read=%s\n", __LINE__,
                               string_att_check[ii], string_att_check[ii]);
 
@@ -834,7 +834,7 @@ read_scalar_dset(H5File &file, DataType &type, DataSpace &space, char *name, cha
         dset.read(&data_read, type, space, space);
         dset.close();
 
-        if (HDstrcmp(data, data_read) != 0)
+        if (strcmp(data, data_read) != 0)
             TestErrPrintf("Expected %s for dataset %s but read %s\n", data, name, data_read);
 
         free(data_read);

--- a/fortran/test/tH5L_F03.F90
+++ b/fortran/test/tH5L_F03.F90
@@ -276,7 +276,7 @@ SUBROUTINE test_iter_group(cleanup, total_error)
   lnames(ndatasets+2) = "grp0000000"
 
 !!$
-!!$    lnames[NDATASETS] = HDstrdup("grp");
+!!$    lnames[NDATASETS] = strdup("grp");
 !!$    CHECK(lnames[NDATASETS], NULL, "strdup");
 !!$
 

--- a/hl/c++/test/ptableTest.cpp
+++ b/hl/c++/test/ptableTest.cpp
@@ -303,7 +303,7 @@ TestCompress()
 
         char filter_name[8];
         dcpl.getFilterById(H5Z_FILTER_DEFLATE, flags, cd_nelemts, NULL, 8, filter_name, config);
-        if (HDstrncmp(filter_name, "deflate", 7) != 0)
+        if (strncmp(filter_name, "deflate", 7) != 0)
             H5_FAILED();
     }
     catch (Exception const &) {
@@ -313,7 +313,7 @@ TestCompress()
     PASSED();
 #else
     SKIPPED();
-    HDputs("    deflate filter not enabled");
+    puts("    deflate filter not enabled");
 #endif /* H5_HAVE_FILTER_DEFLATE */
     return 0;
 }
@@ -621,7 +621,7 @@ TestHDFFV_9758()
         s1[i].a = static_cast<int>(i);
         s1[i].b = 1.0F * static_cast<float>(i * i);
         s1[i].c = 1.0 / static_cast<double>(i + 1);
-        HDsnprintf(s1[i].d, STRING_LENGTH, "string%" PRIuHSIZE "", i);
+        snprintf(s1[i].d, STRING_LENGTH, "string%" PRIuHSIZE "", i);
         s1[i].e = static_cast<int>(100 + i);
     }
 
@@ -692,7 +692,7 @@ TestHDFFV_9758()
 
             if (s2.a != s1[i].a || s2.e != s1[i].e)
                 goto error;
-            else if (HDstrcmp(s2.d, s1[i].d) != 0)
+            else if (strcmp(s2.d, s1[i].d) != 0)
                 goto error;
         }
     } // end of ptable block

--- a/hl/src/H5LD.c
+++ b/hl/src/H5LD.c
@@ -344,7 +344,7 @@ H5LD_get_dset_type_size(hid_t did, const char *fields)
             goto done;
 
         /* Get a copy of "fields" */
-        if (NULL == (dup_fields = HDstrdup(fields)))
+        if (NULL == (dup_fields = strdup(fields)))
             goto done;
 
         /* Allocate memory for a list of H5LD_memb_t pointers to store "fields" info */
@@ -499,7 +499,7 @@ H5LD_get_dset_elmts(hid_t did, const hsize_t *prev_dims, const hsize_t *cur_dims
             goto done;
 
         /* Make a copy of "fields" */
-        if (NULL == (dup_fields = HDstrdup(fields)))
+        if (NULL == (dup_fields = strdup(fields)))
             goto done;
 
         /* Allocate memory for the vector of H5LD_memb_t pointers */

--- a/hl/src/H5LT.c
+++ b/hl/src/H5LT.c
@@ -1839,7 +1839,7 @@ H5LTtext_to_dtype(const char *text, H5LT_lang_t lang_type)
     }
 
     input_len = strlen(text);
-    myinput   = HDstrdup(text);
+    myinput   = strdup(text);
 
     if ((type_id = H5LTyyparse()) < 0) {
         free(myinput);
@@ -3267,7 +3267,7 @@ H5LTpath_valid(hid_t loc_id, const char *path, hbool_t check_object_valid)
     }
 
     /* Duplicate the path to use */
-    if (NULL == (tmp_path = HDstrdup(path))) {
+    if (NULL == (tmp_path = strdup(path))) {
         ret_value = FAIL;
         goto done;
     }

--- a/hl/tools/h5watch/extend_dset.c
+++ b/hl/tools/h5watch/extend_dset.c
@@ -403,8 +403,8 @@ main(int argc, char *argv[])
     } /* end if */
 
     /* Get the dataset name to be extended */
-    fname   = HDstrdup(argv[1]);
-    dname   = HDstrdup(argv[2]);
+    fname   = strdup(argv[1]);
+    dname   = strdup(argv[2]);
     action1 = atoi(argv[3]);
     action2 = atoi(argv[4]);
 

--- a/hl/tools/h5watch/h5watch.c
+++ b/hl/tools/h5watch/h5watch.c
@@ -430,7 +430,7 @@ process_cmpd_fields(hid_t fid, char *dsetname)
     }
 
     /* Make a copy of "g_list_of_fields" */
-    if ((g_dup_fields = HDstrdup(g_list_of_fields)) == NULL) {
+    if ((g_dup_fields = strdup(g_list_of_fields)) == NULL) {
         error_msg("error in duplicating g_list_of_fields\n");
         ret_value = FAIL;
         goto done;
@@ -703,7 +703,7 @@ parse_command_line(int argc, const char *const *argv)
 
             case 'f': /* --fields=<list_of_fields> */
                 if (g_list_of_fields == NULL) {
-                    if ((g_list_of_fields = HDstrdup(H5_optarg)) == NULL) {
+                    if ((g_list_of_fields = strdup(H5_optarg)) == NULL) {
                         error_msg("memory allocation failed (file %s:line %d)\n", __FILE__, __LINE__);
                         leave(EXIT_FAILURE);
                     }
@@ -711,7 +711,7 @@ parse_command_line(int argc, const char *const *argv)
                 else {
                     char *str;
 
-                    if ((str = HDstrdup(H5_optarg)) == NULL) {
+                    if ((str = strdup(H5_optarg)) == NULL) {
                         error_msg("memory allocation failed (file %s:line %d)\n", __FILE__, __LINE__);
                         leave(EXIT_FAILURE);
                     }
@@ -823,7 +823,7 @@ main(int argc, char *argv[])
      * then there must have been something wrong with the file (perhaps it
      * doesn't exist).
      */
-    if ((fname = HDstrdup(argv[H5_optind])) == NULL) {
+    if ((fname = strdup(argv[H5_optind])) == NULL) {
         error_msg("memory allocation failed (file %s:line %d)\n", __FILE__, __LINE__);
         h5tools_setstatus(EXIT_FAILURE);
         goto done;
@@ -877,7 +877,7 @@ main(int argc, char *argv[])
     else {
         *dname = '/';
         x      = dname;
-        if ((dname = HDstrdup(dname)) == NULL) {
+        if ((dname = strdup(dname)) == NULL) {
             error_msg("memory allocation failed (file %s:line %d)\n", __FILE__, __LINE__);
             h5tools_setstatus(EXIT_FAILURE);
             goto done;

--- a/java/src/jni/h5util.c
+++ b/java/src/jni/h5util.c
@@ -945,7 +945,7 @@ h5str_sprintf(JNIEnv *env, h5str_t *out_str, hid_t container, hid_t tid, void *i
             }
             else {
                 if (typeSize > 0) {
-                    if (NULL == (this_str = HDstrdup(tmp_str)))
+                    if (NULL == (this_str = strdup(tmp_str)))
                         H5_OUT_OF_MEMORY_ERROR(ENVONLY, "h5str_sprintf: failed to allocate string buffer");
                 }
             }
@@ -3881,7 +3881,7 @@ obj_info_all(hid_t loc_id, const char *name, const H5L_info2_t *info, void *op_d
     datainfo->ltype[datainfo->count]     = -1;
     datainfo->obj_token[datainfo->count] = H5O_TOKEN_UNDEF;
 
-    if (NULL == (datainfo->objname[datainfo->count] = HDstrdup(name)))
+    if (NULL == (datainfo->objname[datainfo->count] = strdup(name)))
         goto done;
 
     if ((object_exists = H5Oexists_by_name(loc_id, name, H5P_DEFAULT)) < 0)
@@ -3916,7 +3916,7 @@ obj_info_max(hid_t loc_id, const char *name, const H5L_info2_t *info, void *op_d
     datainfo->obj_token[datainfo->count] = H5O_TOKEN_UNDEF;
 
     /* This will be freed by h5str_array_free(oName, n) */
-    if (NULL == (datainfo->objname[datainfo->count] = HDstrdup(name)))
+    if (NULL == (datainfo->objname[datainfo->count] = strdup(name)))
         goto done;
 
     if (H5Oget_info3(loc_id, &object_info, H5O_INFO_ALL) < 0)

--- a/src/H5.c
+++ b/src/H5.c
@@ -460,12 +460,12 @@ H5_term_library(void)
 
                 /* log a package when its terminator needs to be retried */
                 pending++;
-                nprinted = HDsnprintf(next, nleft, "%s%s",
+                nprinted = snprintf(next, nleft, "%s%s",
                     (next != loop) ? "," : "", terminator[i].name);
                 if (nprinted < 0)
                     continue;
                 if ((size_t)nprinted >= nleft)
-                    nprinted = HDsnprintf(next, nleft, "...");
+                    nprinted = snprintf(next, nleft, "...");
                 if (nprinted < 0 || (size_t)nprinted >= nleft)
                     continue;
                 nleft -= (size_t)nprinted;
@@ -719,24 +719,24 @@ H5__debug_mask(const char *s)
             pkg_name[MIN(sizeof(pkg_name) - 1, i)] = '\0';
 
             /* Trace, all, or one? */
-            if (!HDstrcmp(pkg_name, "trace")) {
+            if (!strcmp(pkg_name, "trace")) {
                 H5_debug_g.trace = clear ? NULL : stream;
             }
-            else if (!HDstrcmp(pkg_name, "ttop")) {
+            else if (!strcmp(pkg_name, "ttop")) {
                 H5_debug_g.trace = stream;
                 H5_debug_g.ttop  = (bool)!clear;
             }
-            else if (!HDstrcmp(pkg_name, "ttimes")) {
+            else if (!strcmp(pkg_name, "ttimes")) {
                 H5_debug_g.trace  = stream;
                 H5_debug_g.ttimes = (bool)!clear;
             }
-            else if (!HDstrcmp(pkg_name, "all")) {
+            else if (!strcmp(pkg_name, "all")) {
                 for (i = 0; i < (size_t)H5_NPKGS; i++)
                     H5_debug_g.pkg[i].stream = clear ? NULL : stream;
             }
             else {
                 for (i = 0; i < (size_t)H5_NPKGS; i++) {
-                    if (!HDstrcmp(H5_debug_g.pkg[i].name, pkg_name)) {
+                    if (!strcmp(H5_debug_g.pkg[i].name, pkg_name)) {
                         H5_debug_g.pkg[i].stream = clear ? NULL : stream;
                         break;
                     } /* end if */
@@ -908,7 +908,7 @@ H5check_version(unsigned majnum, unsigned minnum, unsigned relnum)
                 fprintf(stderr, "%s", H5build_settings);
 
                 /* Bail out now. */
-                HDfputs("Bye...\n", stderr);
+                fputs("Bye...\n", stderr);
                 HDabort();
             case 1:
                 /* continue with a warning */
@@ -948,7 +948,7 @@ H5check_version(unsigned majnum, unsigned minnum, unsigned relnum)
                                 (unsigned)H5_VERS_MAJOR, (unsigned)H5_VERS_MINOR, (unsigned)H5_VERS_RELEASE);
 
                         /* Bail out now. */
-                        HDfputs("Bye...\n", stderr);
+                        fputs("Bye...\n", stderr);
                         HDabort();
                     case 1:
                         /* continue with a warning */
@@ -982,17 +982,17 @@ H5check_version(unsigned majnum, unsigned minnum, unsigned relnum)
          * Check only the first sizeof(lib_str) char.  Assume the information
          * will fit within this size or enough significance.
          */
-        HDsnprintf(lib_str, sizeof(lib_str), "HDF5 library version: %d.%d.%d%s%s", H5_VERS_MAJOR,
-                   H5_VERS_MINOR, H5_VERS_RELEASE, (*substr ? "-" : ""), substr);
+        snprintf(lib_str, sizeof(lib_str), "HDF5 library version: %d.%d.%d%s%s", H5_VERS_MAJOR, H5_VERS_MINOR,
+                 H5_VERS_RELEASE, (*substr ? "-" : ""), substr);
 
-        if (HDstrcmp(lib_str, H5_lib_vers_info_g) != 0) {
-            HDfputs("Warning!  Library version information error.\n"
-                    "The HDF5 library version information are not "
-                    "consistent in its source code.\nThis is NOT a fatal error "
-                    "but should be corrected.  Setting the environment\n"
-                    "variable 'HDF5_DISABLE_VERSION_CHECK' to a value of 1 "
-                    "will suppress\nthis warning.\n",
-                    stderr);
+        if (strcmp(lib_str, H5_lib_vers_info_g) != 0) {
+            fputs("Warning!  Library version information error.\n"
+                  "The HDF5 library version information are not "
+                  "consistent in its source code.\nThis is NOT a fatal error "
+                  "but should be corrected.  Setting the environment\n"
+                  "variable 'HDF5_DISABLE_VERSION_CHECK' to a value of 1 "
+                  "will suppress\nthis warning.\n",
+                  stderr);
             fprintf(stderr,
                     "Library version information are:\n"
                     "H5_VERS_MAJOR=%d, H5_VERS_MINOR=%d, H5_VERS_RELEASE=%d, "

--- a/src/H5A.c
+++ b/src/H5A.c
@@ -1580,7 +1580,7 @@ H5A__rename_common(H5VL_object_t *vol_obj, H5VL_loc_params_t *loc_params, const 
     assert(new_name);
 
     /* Avoid thrashing things if the names are the same */
-    if (HDstrcmp(old_name, new_name) != 0) {
+    if (strcmp(old_name, new_name) != 0) {
         H5VL_attr_specific_args_t vol_cb_args; /* Arguments to VOL callback */
 
         /* Set up VOL callback arguments */

--- a/src/H5AC.c
+++ b/src/H5AC.c
@@ -288,7 +288,7 @@ H5AC_create(const H5F_t *f, H5AC_cache_config_t *config_ptr, H5AC_cache_image_co
         aux_ptr->sync_point_done     = NULL;
         aux_ptr->p0_image_len        = 0;
 
-        HDsnprintf(prefix, sizeof(prefix), "%d:", mpi_rank);
+        snprintf(prefix, sizeof(prefix), "%d:", mpi_rank);
 
         if (mpi_rank == 0) {
             if (NULL == (aux_ptr->d_slist_ptr = H5SL_create(H5SL_TYPE_HADDR, NULL)))
@@ -1874,7 +1874,7 @@ H5AC_validate_config(const H5AC_cache_config_t *config_ptr)
          * open the file, so we will content ourselves with a couple of
          * sanity checks on the length of the file name.
          */
-        name_len = HDstrlen(config_ptr->trace_file_name);
+        name_len = strlen(config_ptr->trace_file_name);
         if (name_len == 0)
             HGOTO_ERROR(H5E_CACHE, H5E_BADVALUE, FAIL, "config_ptr->trace_file_name is empty");
         else if (name_len > H5AC__MAX_TRACE_FILE_NAME_LEN)

--- a/src/H5Abtree2.c
+++ b/src/H5Abtree2.c
@@ -154,7 +154,7 @@ H5A__dense_fh_name_cmp(const void *obj, size_t obj_len, void *_udata)
         HGOTO_ERROR(H5E_OHDR, H5E_CANTDECODE, FAIL, "can't decode attribute");
 
     /* Compare the string values */
-    udata->cmp = HDstrcmp(udata->name, attr->shared->name);
+    udata->cmp = strcmp(udata->name, attr->shared->name);
 
     /* Check for correct attribute & callback to make */
     if (udata->cmp == 0 && udata->found_op) {

--- a/src/H5Adense.c
+++ b/src/H5Adense.c
@@ -369,7 +369,7 @@ H5A__dense_open(H5F_t *f, const H5O_ainfo_t *ainfo, const char *name)
     udata.fheap         = fheap;
     udata.shared_fheap  = shared_fheap;
     udata.name          = name;
-    udata.name_hash     = H5_checksum_lookup3(name, HDstrlen(name), 0);
+    udata.name_hash     = H5_checksum_lookup3(name, strlen(name), 0);
     udata.flags         = 0;
     udata.corder        = 0;
     udata.found_op      = H5A__dense_fnd_cb; /* v2 B-tree comparison callback */
@@ -507,7 +507,7 @@ H5A__dense_insert(H5F_t *f, const H5O_ainfo_t *ainfo, H5A_t *attr)
     udata.common.fheap        = fheap;
     udata.common.shared_fheap = shared_fheap;
     udata.common.name         = attr->shared->name;
-    udata.common.name_hash    = H5_checksum_lookup3(attr->shared->name, HDstrlen(attr->shared->name), 0);
+    udata.common.name_hash    = H5_checksum_lookup3(attr->shared->name, strlen(attr->shared->name), 0);
     H5_CHECKED_ASSIGN(udata.common.flags, uint8_t, mesg_flags, unsigned);
     udata.common.corder        = attr->shared->crt_idx;
     udata.common.found_op      = NULL;
@@ -748,7 +748,7 @@ H5A__dense_write(H5F_t *f, const H5O_ainfo_t *ainfo, H5A_t *attr)
     udata.fheap         = fheap;
     udata.shared_fheap  = shared_fheap;
     udata.name          = attr->shared->name;
-    udata.name_hash     = H5_checksum_lookup3(attr->shared->name, HDstrlen(attr->shared->name), 0);
+    udata.name_hash     = H5_checksum_lookup3(attr->shared->name, strlen(attr->shared->name), 0);
     udata.flags         = 0;
     udata.corder        = 0;
     udata.found_op      = NULL;
@@ -881,7 +881,7 @@ H5A__dense_rename(H5F_t *f, const H5O_ainfo_t *ainfo, const char *old_name, cons
     udata.fheap         = fheap;
     udata.shared_fheap  = shared_fheap;
     udata.name          = old_name;
-    udata.name_hash     = H5_checksum_lookup3(old_name, HDstrlen(old_name), 0);
+    udata.name_hash     = H5_checksum_lookup3(old_name, strlen(old_name), 0);
     udata.flags         = 0;
     udata.corder        = 0;
     udata.found_op      = H5A__dense_fnd_cb; /* v2 B-tree comparison callback */
@@ -1339,7 +1339,7 @@ H5A__dense_remove(H5F_t *f, const H5O_ainfo_t *ainfo, const char *name)
     udata.common.fheap         = fheap;
     udata.common.shared_fheap  = shared_fheap;
     udata.common.name          = name;
-    udata.common.name_hash     = H5_checksum_lookup3(name, HDstrlen(name), 0);
+    udata.common.name_hash     = H5_checksum_lookup3(name, strlen(name), 0);
     udata.common.found_op      = H5A__dense_fnd_cb; /* v2 B-tree comparison callback */
     udata.common.found_op_data = &attr_copy;
     udata.corder_bt2_addr      = ainfo->corder_bt2_addr;
@@ -1432,7 +1432,7 @@ H5A__dense_remove_by_idx_bt2_cb(const void *_record, void *_bt2_udata)
             other_bt2_udata.shared_fheap = bt2_udata->shared_fheap;
             other_bt2_udata.name         = fh_udata.attr->shared->name;
             other_bt2_udata.name_hash =
-                H5_checksum_lookup3(fh_udata.attr->shared->name, HDstrlen(fh_udata.attr->shared->name), 0);
+                H5_checksum_lookup3(fh_udata.attr->shared->name, strlen(fh_udata.attr->shared->name), 0);
             other_bt2_udata.found_op      = NULL;
             other_bt2_udata.found_op_data = NULL;
         } /* end else */
@@ -1668,7 +1668,7 @@ H5A__dense_exists(H5F_t *f, const H5O_ainfo_t *ainfo, const char *name, bool *at
     udata.fheap         = fheap;
     udata.shared_fheap  = shared_fheap;
     udata.name          = name;
-    udata.name_hash     = H5_checksum_lookup3(name, HDstrlen(name), 0);
+    udata.name_hash     = H5_checksum_lookup3(name, strlen(name), 0);
     udata.flags         = 0;
     udata.corder        = 0;
     udata.found_op      = NULL; /* v2 B-tree comparison callback */

--- a/src/H5Aint.c
+++ b/src/H5Aint.c
@@ -947,7 +947,7 @@ H5A__get_name(H5A_t *attr, size_t buf_size, char *buf, size_t *attr_name_len)
     assert(attr_name_len);
 
     /* Get the real attribute length */
-    nbytes = HDstrlen(attr->shared->name);
+    nbytes = strlen(attr->shared->name);
 
     /* Compute the string length which will fit into the user's buffer */
     copy_len = MIN(buf_size - 1, nbytes);
@@ -1701,7 +1701,7 @@ H5A__attr_cmp_name_inc(const void *attr1, const void *attr2)
     FUNC_ENTER_PACKAGE_NOERR
 
     FUNC_LEAVE_NOAPI(
-        HDstrcmp((*(const H5A_t *const *)attr1)->shared->name, (*(const H5A_t *const *)attr2)->shared->name))
+        strcmp((*(const H5A_t *const *)attr1)->shared->name, (*(const H5A_t *const *)attr2)->shared->name))
 } /* end H5A__attr_cmp_name_inc() */
 
 /*-------------------------------------------------------------------------
@@ -1724,7 +1724,7 @@ H5A__attr_cmp_name_dec(const void *attr1, const void *attr2)
     FUNC_ENTER_PACKAGE_NOERR
 
     FUNC_LEAVE_NOAPI(
-        HDstrcmp((*(const H5A_t *const *)attr2)->shared->name, (*(const H5A_t *const *)attr1)->shared->name))
+        strcmp((*(const H5A_t *const *)attr2)->shared->name, (*(const H5A_t *const *)attr1)->shared->name))
 } /* end H5A__attr_cmp_name_dec() */
 
 /*-------------------------------------------------------------------------
@@ -2547,7 +2547,7 @@ H5A__rename_by_name(H5G_loc_t loc, const char *obj_name, const char *old_attr_na
     FUNC_ENTER_PACKAGE
 
     /* Avoid thrashing things if the names are the same */
-    if (HDstrcmp(old_attr_name, new_attr_name) != 0) {
+    if (strcmp(old_attr_name, new_attr_name) != 0) {
         /* Set up opened group location to fill in */
         obj_loc.oloc = &obj_oloc;
         obj_loc.path = &obj_path;

--- a/src/H5B2dbg.c
+++ b/src/H5B2dbg.c
@@ -124,7 +124,7 @@ H5B2__hdr_debug(H5F_t *f, haddr_t addr, FILE *stream, int indent, int fwidth,
     /* Print relevant node info */
     fprintf(stream, "%*sNode Info: (max_nrec/split_nrec/merge_nrec)\n", indent, "");
     for (u = 0; u < (unsigned)(hdr->depth + 1); u++) {
-        HDsnprintf(temp_str, sizeof(temp_str), "Depth %u:", u);
+        snprintf(temp_str, sizeof(temp_str), "Depth %u:", u);
         fprintf(stream, "%*s%-*s (%u/%u/%u)\n", indent + 3, "", MAX(0, fwidth - 3), temp_str,
                 hdr->node_info[u].max_nrec, hdr->node_info[u].split_nrec, hdr->node_info[u].merge_nrec);
     } /* end for */
@@ -206,13 +206,13 @@ H5B2__int_debug(H5F_t *f, haddr_t addr, FILE *stream, int indent, int fwidth, co
     /* Print all node pointers and records */
     for (u = 0; u < internal->nrec; u++) {
         /* Print node pointer */
-        HDsnprintf(temp_str, sizeof(temp_str), "Node pointer #%u: (all/node/addr)", u);
+        snprintf(temp_str, sizeof(temp_str), "Node pointer #%u: (all/node/addr)", u);
         fprintf(stream, "%*s%-*s (%" PRIuHSIZE "/%u/%" PRIuHADDR ")\n", indent + 3, "", MAX(0, fwidth - 3),
                 temp_str, internal->node_ptrs[u].all_nrec, internal->node_ptrs[u].node_nrec,
                 internal->node_ptrs[u].addr);
 
         /* Print record */
-        HDsnprintf(temp_str, sizeof(temp_str), "Record #%u:", u);
+        snprintf(temp_str, sizeof(temp_str), "Record #%u:", u);
         fprintf(stream, "%*s%-*s\n", indent + 3, "", MAX(0, fwidth - 3), temp_str);
         assert(H5B2_INT_NREC(internal, hdr, u));
         (void)(type->debug)(stream, indent + 6, MAX(0, fwidth - 6), H5B2_INT_NREC(internal, hdr, u),
@@ -220,7 +220,7 @@ H5B2__int_debug(H5F_t *f, haddr_t addr, FILE *stream, int indent, int fwidth, co
     } /* end for */
 
     /* Print final node pointer */
-    HDsnprintf(temp_str, sizeof(temp_str), "Node pointer #%u: (all/node/addr)", u);
+    snprintf(temp_str, sizeof(temp_str), "Node pointer #%u: (all/node/addr)", u);
     fprintf(stream, "%*s%-*s (%" PRIuHSIZE "/%u/%" PRIuHADDR ")\n", indent + 3, "", MAX(0, fwidth - 3),
             temp_str, internal->node_ptrs[u].all_nrec, internal->node_ptrs[u].node_nrec,
             internal->node_ptrs[u].addr);
@@ -303,7 +303,7 @@ H5B2__leaf_debug(H5F_t *f, haddr_t addr, FILE *stream, int indent, int fwidth, c
     /* Print all node pointers and records */
     for (u = 0; u < leaf->nrec; u++) {
         /* Print record */
-        HDsnprintf(temp_str, sizeof(temp_str), "Record #%u:", u);
+        snprintf(temp_str, sizeof(temp_str), "Record #%u:", u);
         fprintf(stream, "%*s%-*s\n", indent + 3, "", MAX(0, fwidth - 3), temp_str);
         assert(H5B2_LEAF_NREC(leaf, hdr, u));
         (void)(type->debug)(stream, indent + 6, MAX(0, fwidth - 6), H5B2_LEAF_NREC(leaf, hdr, u),

--- a/src/H5C.c
+++ b/src/H5C.c
@@ -138,7 +138,7 @@ H5C_create(size_t max_cache_size, size_t min_clean_size, int max_type_id,
 
     for (i = 0; i <= max_type_id; i++) {
         assert((class_table_ptr)[i]);
-        assert(HDstrlen((class_table_ptr)[i]->name) > 0);
+        assert(strlen((class_table_ptr)[i]->name) > 0);
     } /* end for */
 
     if (NULL == (cache_ptr = H5FL_CALLOC(H5C_t)))

--- a/src/H5CS.c
+++ b/src/H5CS.c
@@ -138,7 +138,7 @@ H5CS_print_stack(const H5CS_t *fstack, FILE *stream)
     fprintf(stream, "thread %" PRIu64 ".", H5TS_thread_id());
     if (fstack && fstack->nused > 0)
         fprintf(stream, "  Back trace follows.");
-    HDfputc('\n', stream);
+    fputc('\n', stream);
 
     for (i = fstack->nused - 1; i >= 0; --i)
         fprintf(stream, "%*s#%03d: Routine: %s\n", indent, "", i, fstack->rec[i]);

--- a/src/H5Cdbg.c
+++ b/src/H5Cdbg.c
@@ -317,10 +317,10 @@ H5C_set_prefix(H5C_t *cache_ptr, char *prefix)
 
     FUNC_ENTER_NOAPI(FAIL)
 
-    if (cache_ptr == NULL || prefix == NULL || HDstrlen(prefix) >= H5C__PREFIX_LEN)
+    if (cache_ptr == NULL || prefix == NULL || strlen(prefix) >= H5C__PREFIX_LEN)
         HGOTO_ERROR(H5E_CACHE, H5E_SYSTEM, FAIL, "Bad param(s) on entry");
 
-    HDstrncpy(&(cache_ptr->prefix[0]), prefix, (size_t)(H5C__PREFIX_LEN));
+    strncpy(&(cache_ptr->prefix[0]), prefix, (size_t)(H5C__PREFIX_LEN));
 
     cache_ptr->prefix[H5C__PREFIX_LEN - 1] = '\0';
 

--- a/src/H5Clog_json.c
+++ b/src/H5Clog_json.c
@@ -168,7 +168,7 @@ H5C__json_write_log_message(H5C_log_json_udata_t *json_udata)
     assert(json_udata->message);
 
     /* Write the log message and flush */
-    n_chars = HDstrlen(json_udata->message);
+    n_chars = strlen(json_udata->message);
     if ((int)n_chars != fprintf(json_udata->outfile, "%s", json_udata->message))
         HGOTO_ERROR(H5E_CACHE, H5E_LOGGING, FAIL, "error writing log message");
     memset((void *)(json_udata->message), 0, (size_t)(n_chars * sizeof(char)));
@@ -231,16 +231,16 @@ H5C__log_json_set_up(H5C_log_info_t *log_info, const char log_location[], int mp
      *
      * allocation size = "RANK_" + <rank # length> + dot + <path length> + \0
      */
-    n_chars = 5 + 39 + 1 + HDstrlen(log_location) + 1;
+    n_chars = 5 + 39 + 1 + strlen(log_location) + 1;
     if (NULL == (file_name = (char *)H5MM_calloc(n_chars * sizeof(char))))
         HGOTO_ERROR(H5E_CACHE, H5E_CANTALLOC, FAIL,
                     "can't allocate memory for mdc log file name manipulation");
 
     /* Add the rank to the log file name when MPI is in use */
     if (-1 == mpi_rank)
-        HDsnprintf(file_name, n_chars, "%s", log_location);
+        snprintf(file_name, n_chars, "%s", log_location);
     else
-        HDsnprintf(file_name, n_chars, "RANK_%d.%s", mpi_rank, log_location);
+        snprintf(file_name, n_chars, "RANK_%d.%s", mpi_rank, log_location);
 
     /* Open log file and set it to be unbuffered */
     if (NULL == (json_udata->outfile = fopen(file_name, "w")))
@@ -331,7 +331,7 @@ H5C__json_write_start_log_msg(void *udata)
     assert(json_udata->message);
 
     /* Create the log message string (opens the JSON array) */
-    HDsnprintf(json_udata->message, H5C_MAX_JSON_LOG_MSG_SIZE, "\
+    snprintf(json_udata->message, H5C_MAX_JSON_LOG_MSG_SIZE, "\
 {\n\
 \"HDF5 metadata cache log messages\" : [\n\
 {\
@@ -339,7 +339,7 @@ H5C__json_write_start_log_msg(void *udata)
 \"action\":\"logging start\"\
 },\n\
 ",
-               (long long)HDtime(NULL));
+             (long long)HDtime(NULL));
 
     /* Write the log message to the file */
     if (H5C__json_write_log_message(json_udata) < 0)
@@ -371,14 +371,14 @@ H5C__json_write_stop_log_msg(void *udata)
     assert(json_udata->message);
 
     /* Create the log message string (closes the JSON array) */
-    HDsnprintf(json_udata->message, H5C_MAX_JSON_LOG_MSG_SIZE, "\
+    snprintf(json_udata->message, H5C_MAX_JSON_LOG_MSG_SIZE, "\
 {\
 \"timestamp\":%lld,\
 \"action\":\"logging stop\"\
 }\n\
 ]}\n\
 ",
-               (long long)HDtime(NULL));
+             (long long)HDtime(NULL));
 
     /* Write the log message to the file */
     if (H5C__json_write_log_message(json_udata) < 0)
@@ -410,14 +410,14 @@ H5C__json_write_create_cache_log_msg(void *udata, herr_t fxn_ret_value)
     assert(json_udata->message);
 
     /* Create the log message string */
-    HDsnprintf(json_udata->message, H5C_MAX_JSON_LOG_MSG_SIZE, "\
+    snprintf(json_udata->message, H5C_MAX_JSON_LOG_MSG_SIZE, "\
 {\
 \"timestamp\":%lld,\
 \"action\":\"create\",\
 \"returned\":%d\
 },\n\
 ",
-               (long long)HDtime(NULL), (int)fxn_ret_value);
+             (long long)HDtime(NULL), (int)fxn_ret_value);
 
     /* Write the log message to the file */
     if (H5C__json_write_log_message(json_udata) < 0)
@@ -449,13 +449,13 @@ H5C__json_write_destroy_cache_log_msg(void *udata)
     assert(json_udata->message);
 
     /* Create the log message string */
-    HDsnprintf(json_udata->message, H5C_MAX_JSON_LOG_MSG_SIZE, "\
+    snprintf(json_udata->message, H5C_MAX_JSON_LOG_MSG_SIZE, "\
 {\
 \"timestamp\":%lld,\
 \"action\":\"destroy\"\
 },\n\
 ",
-               (long long)HDtime(NULL));
+             (long long)HDtime(NULL));
 
     /* Write the log message to the file */
     if (H5C__json_write_log_message(json_udata) < 0)
@@ -487,14 +487,14 @@ H5C__json_write_evict_cache_log_msg(void *udata, herr_t fxn_ret_value)
     assert(json_udata->message);
 
     /* Create the log message string */
-    HDsnprintf(json_udata->message, H5C_MAX_JSON_LOG_MSG_SIZE, "\
+    snprintf(json_udata->message, H5C_MAX_JSON_LOG_MSG_SIZE, "\
 {\
 \"timestamp\":%lld,\
 \"action\":\"evict\",\
 \"returned\":%d\
 },\n\
 ",
-               (long long)HDtime(NULL), (int)fxn_ret_value);
+             (long long)HDtime(NULL), (int)fxn_ret_value);
 
     /* Write the log message to the file */
     if (H5C__json_write_log_message(json_udata) < 0)
@@ -526,7 +526,7 @@ H5C__json_write_expunge_entry_log_msg(void *udata, haddr_t address, int type_id,
     assert(json_udata->message);
 
     /* Create the log message string */
-    HDsnprintf(json_udata->message, H5C_MAX_JSON_LOG_MSG_SIZE, "\
+    snprintf(json_udata->message, H5C_MAX_JSON_LOG_MSG_SIZE, "\
 {\
 \"timestamp\":%lld,\
 \"action\":\"expunge\",\
@@ -535,7 +535,7 @@ H5C__json_write_expunge_entry_log_msg(void *udata, haddr_t address, int type_id,
 \"returned\":%d\
 },\n\
 ",
-               (long long)HDtime(NULL), (unsigned long)address, (int)type_id, (int)fxn_ret_value);
+             (long long)HDtime(NULL), (unsigned long)address, (int)type_id, (int)fxn_ret_value);
 
     /* Write the log message to the file */
     if (H5C__json_write_log_message(json_udata) < 0)
@@ -567,14 +567,14 @@ H5C__json_write_flush_cache_log_msg(void *udata, herr_t fxn_ret_value)
     assert(json_udata->message);
 
     /* Create the log message string */
-    HDsnprintf(json_udata->message, H5C_MAX_JSON_LOG_MSG_SIZE, "\
+    snprintf(json_udata->message, H5C_MAX_JSON_LOG_MSG_SIZE, "\
 {\
 \"timestamp\":%lld,\
 \"action\":\"flush\",\
 \"returned\":%d\
 },\n\
 ",
-               (long long)HDtime(NULL), (int)fxn_ret_value);
+             (long long)HDtime(NULL), (int)fxn_ret_value);
 
     /* Write the log message to the file */
     if (H5C__json_write_log_message(json_udata) < 0)
@@ -607,7 +607,7 @@ H5C__json_write_insert_entry_log_msg(void *udata, haddr_t address, int type_id, 
     assert(json_udata->message);
 
     /* Create the log message string */
-    HDsnprintf(json_udata->message, H5C_MAX_JSON_LOG_MSG_SIZE, "\
+    snprintf(json_udata->message, H5C_MAX_JSON_LOG_MSG_SIZE, "\
 {\
 \"timestamp\":%lld,\
 \"action\":\"insert\",\
@@ -618,8 +618,7 @@ H5C__json_write_insert_entry_log_msg(void *udata, haddr_t address, int type_id, 
 \"returned\":%d\
 },\n\
 ",
-               (long long)HDtime(NULL), (unsigned long)address, type_id, flags, (int)size,
-               (int)fxn_ret_value);
+             (long long)HDtime(NULL), (unsigned long)address, type_id, flags, (int)size, (int)fxn_ret_value);
 
     /* Write the log message to the file */
     if (H5C__json_write_log_message(json_udata) < 0)
@@ -652,7 +651,7 @@ H5C__json_write_mark_entry_dirty_log_msg(void *udata, const H5C_cache_entry_t *e
     assert(entry);
 
     /* Create the log message string */
-    HDsnprintf(json_udata->message, H5C_MAX_JSON_LOG_MSG_SIZE, "\
+    snprintf(json_udata->message, H5C_MAX_JSON_LOG_MSG_SIZE, "\
 {\
 \"timestamp\":%lld,\
 \"action\":\"dirty\",\
@@ -660,7 +659,7 @@ H5C__json_write_mark_entry_dirty_log_msg(void *udata, const H5C_cache_entry_t *e
 \"returned\":%d\
 },\n\
 ",
-               (long long)HDtime(NULL), (unsigned long)entry->addr, (int)fxn_ret_value);
+             (long long)HDtime(NULL), (unsigned long)entry->addr, (int)fxn_ret_value);
 
     /* Write the log message to the file */
     if (H5C__json_write_log_message(json_udata) < 0)
@@ -693,7 +692,7 @@ H5C__json_write_mark_entry_clean_log_msg(void *udata, const H5C_cache_entry_t *e
     assert(entry);
 
     /* Create the log message string */
-    HDsnprintf(json_udata->message, H5C_MAX_JSON_LOG_MSG_SIZE, "\
+    snprintf(json_udata->message, H5C_MAX_JSON_LOG_MSG_SIZE, "\
 {\
 \"timestamp\":%lld,\
 \"action\":\"clean\",\
@@ -701,7 +700,7 @@ H5C__json_write_mark_entry_clean_log_msg(void *udata, const H5C_cache_entry_t *e
 \"returned\":%d\
 },\n\
 ",
-               (long long)HDtime(NULL), (unsigned long)entry->addr, (int)fxn_ret_value);
+             (long long)HDtime(NULL), (unsigned long)entry->addr, (int)fxn_ret_value);
 
     /* Write the log message to the file */
     if (H5C__json_write_log_message(json_udata) < 0)
@@ -735,7 +734,7 @@ H5C__json_write_mark_unserialized_entry_log_msg(void *udata, const H5C_cache_ent
     assert(entry);
 
     /* Create the log message string */
-    HDsnprintf(json_udata->message, H5C_MAX_JSON_LOG_MSG_SIZE, "\
+    snprintf(json_udata->message, H5C_MAX_JSON_LOG_MSG_SIZE, "\
 {\
 \"timestamp\":%lld,\
 \"action\":\"unserialized\",\
@@ -743,7 +742,7 @@ H5C__json_write_mark_unserialized_entry_log_msg(void *udata, const H5C_cache_ent
 \"returned\":%d\
 },\n\
 ",
-               (long long)HDtime(NULL), (unsigned long)entry->addr, (int)fxn_ret_value);
+             (long long)HDtime(NULL), (unsigned long)entry->addr, (int)fxn_ret_value);
 
     /* Write the log message to the file */
     if (H5C__json_write_log_message(json_udata) < 0)
@@ -777,7 +776,7 @@ H5C__json_write_mark_serialized_entry_log_msg(void *udata, const H5C_cache_entry
     assert(entry);
 
     /* Create the log message string */
-    HDsnprintf(json_udata->message, H5C_MAX_JSON_LOG_MSG_SIZE, "\
+    snprintf(json_udata->message, H5C_MAX_JSON_LOG_MSG_SIZE, "\
 {\
 \"timestamp\":%lld,\
 \"action\":\"serialized\",\
@@ -785,7 +784,7 @@ H5C__json_write_mark_serialized_entry_log_msg(void *udata, const H5C_cache_entry
 \"returned\":%d\
 },\n\
 ",
-               (long long)HDtime(NULL), (unsigned long)entry->addr, (int)fxn_ret_value);
+             (long long)HDtime(NULL), (unsigned long)entry->addr, (int)fxn_ret_value);
 
     /* Write the log message to the file */
     if (H5C__json_write_log_message(json_udata) < 0)
@@ -818,7 +817,7 @@ H5C__json_write_move_entry_log_msg(void *udata, haddr_t old_addr, haddr_t new_ad
     assert(json_udata->message);
 
     /* Create the log message string */
-    HDsnprintf(json_udata->message, H5C_MAX_JSON_LOG_MSG_SIZE, "\
+    snprintf(json_udata->message, H5C_MAX_JSON_LOG_MSG_SIZE, "\
 {\
 \"timestamp\":%lld,\
 \"action\":\"move\",\
@@ -828,8 +827,8 @@ H5C__json_write_move_entry_log_msg(void *udata, haddr_t old_addr, haddr_t new_ad
 \"returned\":%d\
 },\n\
 ",
-               (long long)HDtime(NULL), (unsigned long)old_addr, (unsigned long)new_addr, type_id,
-               (int)fxn_ret_value);
+             (long long)HDtime(NULL), (unsigned long)old_addr, (unsigned long)new_addr, type_id,
+             (int)fxn_ret_value);
 
     /* Write the log message to the file */
     if (H5C__json_write_log_message(json_udata) < 0)
@@ -862,7 +861,7 @@ H5C__json_write_pin_entry_log_msg(void *udata, const H5C_cache_entry_t *entry, h
     assert(entry);
 
     /* Create the log message string */
-    HDsnprintf(json_udata->message, H5C_MAX_JSON_LOG_MSG_SIZE, "\
+    snprintf(json_udata->message, H5C_MAX_JSON_LOG_MSG_SIZE, "\
 {\
 \"timestamp\":%lld,\
 \"action\":\"pin\",\
@@ -870,7 +869,7 @@ H5C__json_write_pin_entry_log_msg(void *udata, const H5C_cache_entry_t *entry, h
 \"returned\":%d\
 },\n\
 ",
-               (long long)HDtime(NULL), (unsigned long)entry->addr, (int)fxn_ret_value);
+             (long long)HDtime(NULL), (unsigned long)entry->addr, (int)fxn_ret_value);
 
     /* Write the log message to the file */
     if (H5C__json_write_log_message(json_udata) < 0)
@@ -906,7 +905,7 @@ H5C__json_write_create_fd_log_msg(void *udata, const H5C_cache_entry_t *parent,
     assert(child);
 
     /* Create the log message string */
-    HDsnprintf(json_udata->message, H5C_MAX_JSON_LOG_MSG_SIZE, "\
+    snprintf(json_udata->message, H5C_MAX_JSON_LOG_MSG_SIZE, "\
 {\
 \"timestamp\":%lld,\
 \"action\":\"create_fd\",\
@@ -915,8 +914,8 @@ H5C__json_write_create_fd_log_msg(void *udata, const H5C_cache_entry_t *parent,
 \"returned\":%d\
 },\n\
 ",
-               (long long)HDtime(NULL), (unsigned long)parent->addr, (unsigned long)child->addr,
-               (int)fxn_ret_value);
+             (long long)HDtime(NULL), (unsigned long)parent->addr, (unsigned long)child->addr,
+             (int)fxn_ret_value);
 
     /* Write the log message to the file */
     if (H5C__json_write_log_message(json_udata) < 0)
@@ -951,12 +950,12 @@ H5C__json_write_protect_entry_log_msg(void *udata, const H5C_cache_entry_t *entr
     assert(entry);
 
     if (H5C__READ_ONLY_FLAG == flags)
-        HDstrcpy(rw_s, "READ");
+        strcpy(rw_s, "READ");
     else
-        HDstrcpy(rw_s, "WRITE");
+        strcpy(rw_s, "WRITE");
 
     /* Create the log message string */
-    HDsnprintf(json_udata->message, H5C_MAX_JSON_LOG_MSG_SIZE, "\
+    snprintf(json_udata->message, H5C_MAX_JSON_LOG_MSG_SIZE, "\
 {\
 \"timestamp\":%lld,\
 \"action\":\"protect\",\
@@ -967,8 +966,8 @@ H5C__json_write_protect_entry_log_msg(void *udata, const H5C_cache_entry_t *entr
 \"returned\":%d\
 },\n\
 ",
-               (long long)HDtime(NULL), (unsigned long)entry->addr, type_id, rw_s, (int)entry->size,
-               (int)fxn_ret_value);
+             (long long)HDtime(NULL), (unsigned long)entry->addr, type_id, rw_s, (int)entry->size,
+             (int)fxn_ret_value);
 
     /* Write the log message to the file */
     if (H5C__json_write_log_message(json_udata) < 0)
@@ -1002,7 +1001,7 @@ H5C__json_write_resize_entry_log_msg(void *udata, const H5C_cache_entry_t *entry
     assert(entry);
 
     /* Create the log message string */
-    HDsnprintf(json_udata->message, H5C_MAX_JSON_LOG_MSG_SIZE, "\
+    snprintf(json_udata->message, H5C_MAX_JSON_LOG_MSG_SIZE, "\
 {\
 \"timestamp\":%lld,\
 \"action\":\"resize\",\
@@ -1011,7 +1010,7 @@ H5C__json_write_resize_entry_log_msg(void *udata, const H5C_cache_entry_t *entry
 \"returned\":%d\
 },\n\
 ",
-               (long long)HDtime(NULL), (unsigned long)entry->addr, (int)new_size, (int)fxn_ret_value);
+             (long long)HDtime(NULL), (unsigned long)entry->addr, (int)new_size, (int)fxn_ret_value);
 
     /* Write the log message to the file */
     if (H5C__json_write_log_message(json_udata) < 0)
@@ -1044,7 +1043,7 @@ H5C__json_write_unpin_entry_log_msg(void *udata, const H5C_cache_entry_t *entry,
     assert(entry);
 
     /* Create the log message string */
-    HDsnprintf(json_udata->message, H5C_MAX_JSON_LOG_MSG_SIZE, "\
+    snprintf(json_udata->message, H5C_MAX_JSON_LOG_MSG_SIZE, "\
 {\
 \"timestamp\":%lld,\
 \"action\":\"unpin\",\
@@ -1052,7 +1051,7 @@ H5C__json_write_unpin_entry_log_msg(void *udata, const H5C_cache_entry_t *entry,
 \"returned\":%d\
 },\n\
 ",
-               (long long)HDtime(NULL), (unsigned long)entry->addr, (int)fxn_ret_value);
+             (long long)HDtime(NULL), (unsigned long)entry->addr, (int)fxn_ret_value);
 
     /* Write the log message to the file */
     if (H5C__json_write_log_message(json_udata) < 0)
@@ -1088,7 +1087,7 @@ H5C__json_write_destroy_fd_log_msg(void *udata, const H5C_cache_entry_t *parent,
     assert(child);
 
     /* Create the log message string */
-    HDsnprintf(json_udata->message, H5C_MAX_JSON_LOG_MSG_SIZE, "\
+    snprintf(json_udata->message, H5C_MAX_JSON_LOG_MSG_SIZE, "\
 {\
 \"timestamp\":%lld,\
 \"action\":\"destroy_fd\",\
@@ -1097,8 +1096,8 @@ H5C__json_write_destroy_fd_log_msg(void *udata, const H5C_cache_entry_t *parent,
 \"returned\":%d\
 },\n\
 ",
-               (long long)HDtime(NULL), (unsigned long)parent->addr, (unsigned long)child->addr,
-               (int)fxn_ret_value);
+             (long long)HDtime(NULL), (unsigned long)parent->addr, (unsigned long)child->addr,
+             (int)fxn_ret_value);
 
     /* Write the log message to the file */
     if (H5C__json_write_log_message(json_udata) < 0)
@@ -1131,7 +1130,7 @@ H5C__json_write_unprotect_entry_log_msg(void *udata, haddr_t address, int type_i
     assert(json_udata->message);
 
     /* Create the log message string */
-    HDsnprintf(json_udata->message, H5C_MAX_JSON_LOG_MSG_SIZE, "\
+    snprintf(json_udata->message, H5C_MAX_JSON_LOG_MSG_SIZE, "\
 {\
 \"timestamp\":%lld,\
 \"action\":\"unprotect\",\
@@ -1141,7 +1140,7 @@ H5C__json_write_unprotect_entry_log_msg(void *udata, haddr_t address, int type_i
 \"returned\":%d\
 },\n\
 ",
-               (long long)HDtime(NULL), (unsigned long)address, type_id, flags, (int)fxn_ret_value);
+             (long long)HDtime(NULL), (unsigned long)address, type_id, flags, (int)fxn_ret_value);
 
     /* Write the log message to the file */
     if (H5C__json_write_log_message(json_udata) < 0)
@@ -1175,14 +1174,14 @@ H5C__json_write_set_cache_config_log_msg(void *udata, const H5AC_cache_config_t 
     assert(config);
 
     /* Create the log message string */
-    HDsnprintf(json_udata->message, H5C_MAX_JSON_LOG_MSG_SIZE, "\
+    snprintf(json_udata->message, H5C_MAX_JSON_LOG_MSG_SIZE, "\
 {\
 \"timestamp\":%lld,\
 \"action\":\"set_config\",\
 \"returned\":%d\
 },\n\
 ",
-               (long long)HDtime(NULL), (int)fxn_ret_value);
+             (long long)HDtime(NULL), (int)fxn_ret_value);
 
     /* Write the log message to the file */
     if (H5C__json_write_log_message(json_udata) < 0)
@@ -1215,7 +1214,7 @@ H5C__json_write_remove_entry_log_msg(void *udata, const H5C_cache_entry_t *entry
     assert(entry);
 
     /* Create the log message string */
-    HDsnprintf(json_udata->message, H5C_MAX_JSON_LOG_MSG_SIZE, "\
+    snprintf(json_udata->message, H5C_MAX_JSON_LOG_MSG_SIZE, "\
 {\
 \"timestamp\":%lld,\
 \"action\":\"remove\",\
@@ -1223,7 +1222,7 @@ H5C__json_write_remove_entry_log_msg(void *udata, const H5C_cache_entry_t *entry
 \"returned\":%d\
 },\n\
 ",
-               (long long)HDtime(NULL), (unsigned long)entry->addr, (int)fxn_ret_value);
+             (long long)HDtime(NULL), (unsigned long)entry->addr, (int)fxn_ret_value);
 
     /* Write the log message to the file */
     if (H5C__json_write_log_message(json_udata) < 0)

--- a/src/H5Clog_trace.c
+++ b/src/H5Clog_trace.c
@@ -163,7 +163,7 @@ H5C__trace_write_log_message(H5C_log_trace_udata_t *trace_udata)
     assert(trace_udata->message);
 
     /* Write the log message and flush */
-    n_chars = HDstrlen(trace_udata->message);
+    n_chars = strlen(trace_udata->message);
     if ((int)n_chars != fprintf(trace_udata->outfile, "%s", trace_udata->message))
         HGOTO_ERROR(H5E_CACHE, H5E_LOGGING, FAIL, "error writing log message");
     memset((void *)(trace_udata->message), 0, (size_t)(n_chars * sizeof(char)));
@@ -226,16 +226,16 @@ H5C__log_trace_set_up(H5C_log_info_t *log_info, const char log_location[], int m
      *
      * allocation size = <path length> + dot + <rank # length> + \0
      */
-    n_chars = HDstrlen(log_location) + 1 + 39 + 1;
+    n_chars = strlen(log_location) + 1 + 39 + 1;
     if (NULL == (file_name = (char *)H5MM_calloc(n_chars * sizeof(char))))
         HGOTO_ERROR(H5E_CACHE, H5E_CANTALLOC, FAIL,
                     "can't allocate memory for mdc log file name manipulation");
 
     /* Add the rank to the log file name when MPI is in use */
     if (-1 == mpi_rank)
-        HDsnprintf(file_name, n_chars, "%s", log_location);
+        snprintf(file_name, n_chars, "%s", log_location);
     else
-        HDsnprintf(file_name, n_chars, "%s.%d", log_location, mpi_rank);
+        snprintf(file_name, n_chars, "%s.%d", log_location, mpi_rank);
 
     /* Open log file and set it to be unbuffered */
     if (NULL == (trace_udata->outfile = fopen(file_name, "w")))
@@ -329,8 +329,8 @@ H5C__trace_write_expunge_entry_log_msg(void *udata, haddr_t address, int type_id
     assert(trace_udata->message);
 
     /* Create the log message string */
-    HDsnprintf(trace_udata->message, H5C_MAX_TRACE_LOG_MSG_SIZE, "H5AC_expunge_entry 0x%lx %d %d\n",
-               (unsigned long)address, type_id, (int)fxn_ret_value);
+    snprintf(trace_udata->message, H5C_MAX_TRACE_LOG_MSG_SIZE, "H5AC_expunge_entry 0x%lx %d %d\n",
+             (unsigned long)address, type_id, (int)fxn_ret_value);
 
     /* Write the log message to the file */
     if (H5C__trace_write_log_message(trace_udata) < 0)
@@ -362,7 +362,7 @@ H5C__trace_write_flush_cache_log_msg(void *udata, herr_t fxn_ret_value)
     assert(trace_udata->message);
 
     /* Create the log message string */
-    HDsnprintf(trace_udata->message, H5C_MAX_TRACE_LOG_MSG_SIZE, "H5AC_flush %d\n", (int)fxn_ret_value);
+    snprintf(trace_udata->message, H5C_MAX_TRACE_LOG_MSG_SIZE, "H5AC_flush %d\n", (int)fxn_ret_value);
 
     /* Write the log message to the file */
     if (H5C__trace_write_log_message(trace_udata) < 0)
@@ -395,8 +395,8 @@ H5C__trace_write_insert_entry_log_msg(void *udata, haddr_t address, int type_id,
     assert(trace_udata->message);
 
     /* Create the log message string */
-    HDsnprintf(trace_udata->message, H5C_MAX_TRACE_LOG_MSG_SIZE, "H5AC_insert_entry 0x%lx %d 0x%x %d %d\n",
-               (unsigned long)address, type_id, flags, (int)size, (int)fxn_ret_value);
+    snprintf(trace_udata->message, H5C_MAX_TRACE_LOG_MSG_SIZE, "H5AC_insert_entry 0x%lx %d 0x%x %d %d\n",
+             (unsigned long)address, type_id, flags, (int)size, (int)fxn_ret_value);
 
     /* Write the log message to the file */
     if (H5C__trace_write_log_message(trace_udata) < 0)
@@ -429,8 +429,8 @@ H5C__trace_write_mark_entry_dirty_log_msg(void *udata, const H5C_cache_entry_t *
     assert(entry);
 
     /* Create the log message string */
-    HDsnprintf(trace_udata->message, H5C_MAX_TRACE_LOG_MSG_SIZE, "H5AC_mark_entry_dirty 0x%lx %d\n",
-               (unsigned long)(entry->addr), (int)fxn_ret_value);
+    snprintf(trace_udata->message, H5C_MAX_TRACE_LOG_MSG_SIZE, "H5AC_mark_entry_dirty 0x%lx %d\n",
+             (unsigned long)(entry->addr), (int)fxn_ret_value);
 
     /* Write the log message to the file */
     if (H5C__trace_write_log_message(trace_udata) < 0)
@@ -463,8 +463,8 @@ H5C__trace_write_mark_entry_clean_log_msg(void *udata, const H5C_cache_entry_t *
     assert(entry);
 
     /* Create the log message string */
-    HDsnprintf(trace_udata->message, H5C_MAX_TRACE_LOG_MSG_SIZE, "H5AC_mark_entry_clean 0x%lx %d\n",
-               (unsigned long)(entry->addr), (int)fxn_ret_value);
+    snprintf(trace_udata->message, H5C_MAX_TRACE_LOG_MSG_SIZE, "H5AC_mark_entry_clean 0x%lx %d\n",
+             (unsigned long)(entry->addr), (int)fxn_ret_value);
 
     /* Write the log message to the file */
     if (H5C__trace_write_log_message(trace_udata) < 0)
@@ -498,8 +498,8 @@ H5C__trace_write_mark_unserialized_entry_log_msg(void *udata, const H5C_cache_en
     assert(entry);
 
     /* Create the log message string */
-    HDsnprintf(trace_udata->message, H5C_MAX_TRACE_LOG_MSG_SIZE, "H5AC_mark_entry_unserialized 0x%lx %d\n",
-               (unsigned long)(entry->addr), (int)fxn_ret_value);
+    snprintf(trace_udata->message, H5C_MAX_TRACE_LOG_MSG_SIZE, "H5AC_mark_entry_unserialized 0x%lx %d\n",
+             (unsigned long)(entry->addr), (int)fxn_ret_value);
 
     /* Write the log message to the file */
     if (H5C__trace_write_log_message(trace_udata) < 0)
@@ -533,8 +533,8 @@ H5C__trace_write_mark_serialized_entry_log_msg(void *udata, const H5C_cache_entr
     assert(entry);
 
     /* Create the log message string */
-    HDsnprintf(trace_udata->message, H5C_MAX_TRACE_LOG_MSG_SIZE, "H5AC_mark_entry_serialized 0x%lx %d\n",
-               (unsigned long)(entry->addr), (int)fxn_ret_value);
+    snprintf(trace_udata->message, H5C_MAX_TRACE_LOG_MSG_SIZE, "H5AC_mark_entry_serialized 0x%lx %d\n",
+             (unsigned long)(entry->addr), (int)fxn_ret_value);
 
     /* Write the log message to the file */
     if (H5C__trace_write_log_message(trace_udata) < 0)
@@ -567,8 +567,8 @@ H5C__trace_write_move_entry_log_msg(void *udata, haddr_t old_addr, haddr_t new_a
     assert(trace_udata->message);
 
     /* Create the log message string */
-    HDsnprintf(trace_udata->message, H5C_MAX_TRACE_LOG_MSG_SIZE, "H5AC_move_entry 0x%lx 0x%lx %d %d\n",
-               (unsigned long)old_addr, (unsigned long)new_addr, type_id, (int)fxn_ret_value);
+    snprintf(trace_udata->message, H5C_MAX_TRACE_LOG_MSG_SIZE, "H5AC_move_entry 0x%lx 0x%lx %d %d\n",
+             (unsigned long)old_addr, (unsigned long)new_addr, type_id, (int)fxn_ret_value);
 
     /* Write the log message to the file */
     if (H5C__trace_write_log_message(trace_udata) < 0)
@@ -601,8 +601,8 @@ H5C__trace_write_pin_entry_log_msg(void *udata, const H5C_cache_entry_t *entry, 
     assert(entry);
 
     /* Create the log message string */
-    HDsnprintf(trace_udata->message, H5C_MAX_TRACE_LOG_MSG_SIZE, "H5AC_pin_protected_entry 0x%lx %d\n",
-               (unsigned long)(entry->addr), (int)fxn_ret_value);
+    snprintf(trace_udata->message, H5C_MAX_TRACE_LOG_MSG_SIZE, "H5AC_pin_protected_entry 0x%lx %d\n",
+             (unsigned long)(entry->addr), (int)fxn_ret_value);
 
     /* Write the log message to the file */
     if (H5C__trace_write_log_message(trace_udata) < 0)
@@ -638,9 +638,9 @@ H5C__trace_write_create_fd_log_msg(void *udata, const H5C_cache_entry_t *parent,
     assert(child);
 
     /* Create the log message string */
-    HDsnprintf(trace_udata->message, H5C_MAX_TRACE_LOG_MSG_SIZE,
-               "H5AC_create_flush_dependency 0x%lx 0x%lx %d\n", (unsigned long)(parent->addr),
-               (unsigned long)(child->addr), (int)fxn_ret_value);
+    snprintf(trace_udata->message, H5C_MAX_TRACE_LOG_MSG_SIZE,
+             "H5AC_create_flush_dependency 0x%lx 0x%lx %d\n", (unsigned long)(parent->addr),
+             (unsigned long)(child->addr), (int)fxn_ret_value);
 
     /* Write the log message to the file */
     if (H5C__trace_write_log_message(trace_udata) < 0)
@@ -674,8 +674,8 @@ H5C__trace_write_protect_entry_log_msg(void *udata, const H5C_cache_entry_t *ent
     assert(entry);
 
     /* Create the log message string */
-    HDsnprintf(trace_udata->message, H5C_MAX_TRACE_LOG_MSG_SIZE, "H5AC_protect 0x%lx %d 0x%x %d %d\n",
-               (unsigned long)(entry->addr), type_id, flags, (int)(entry->size), (int)fxn_ret_value);
+    snprintf(trace_udata->message, H5C_MAX_TRACE_LOG_MSG_SIZE, "H5AC_protect 0x%lx %d 0x%x %d %d\n",
+             (unsigned long)(entry->addr), type_id, flags, (int)(entry->size), (int)fxn_ret_value);
 
     /* Write the log message to the file */
     if (H5C__trace_write_log_message(trace_udata) < 0)
@@ -709,8 +709,8 @@ H5C__trace_write_resize_entry_log_msg(void *udata, const H5C_cache_entry_t *entr
     assert(entry);
 
     /* Create the log message string */
-    HDsnprintf(trace_udata->message, H5C_MAX_TRACE_LOG_MSG_SIZE, "H5AC_resize_entry 0x%lx %d %d\n",
-               (unsigned long)(entry->addr), (int)new_size, (int)fxn_ret_value);
+    snprintf(trace_udata->message, H5C_MAX_TRACE_LOG_MSG_SIZE, "H5AC_resize_entry 0x%lx %d %d\n",
+             (unsigned long)(entry->addr), (int)new_size, (int)fxn_ret_value);
 
     /* Write the log message to the file */
     if (H5C__trace_write_log_message(trace_udata) < 0)
@@ -743,8 +743,8 @@ H5C__trace_write_unpin_entry_log_msg(void *udata, const H5C_cache_entry_t *entry
     assert(entry);
 
     /* Create the log message string */
-    HDsnprintf(trace_udata->message, H5C_MAX_TRACE_LOG_MSG_SIZE, "H5AC_unpin_entry 0x%lx %d\n",
-               (unsigned long)(entry->addr), (int)fxn_ret_value);
+    snprintf(trace_udata->message, H5C_MAX_TRACE_LOG_MSG_SIZE, "H5AC_unpin_entry 0x%lx %d\n",
+             (unsigned long)(entry->addr), (int)fxn_ret_value);
 
     /* Write the log message to the file */
     if (H5C__trace_write_log_message(trace_udata) < 0)
@@ -780,9 +780,9 @@ H5C__trace_write_destroy_fd_log_msg(void *udata, const H5C_cache_entry_t *parent
     assert(child);
 
     /* Create the log message string */
-    HDsnprintf(trace_udata->message, H5C_MAX_TRACE_LOG_MSG_SIZE,
-               "H5AC_destroy_flush_dependency 0x%lx 0x%lx %d\n", (unsigned long)(parent->addr),
-               (unsigned long)(child->addr), (int)fxn_ret_value);
+    snprintf(trace_udata->message, H5C_MAX_TRACE_LOG_MSG_SIZE,
+             "H5AC_destroy_flush_dependency 0x%lx 0x%lx %d\n", (unsigned long)(parent->addr),
+             (unsigned long)(child->addr), (int)fxn_ret_value);
 
     /* Write the log message to the file */
     if (H5C__trace_write_log_message(trace_udata) < 0)
@@ -815,8 +815,8 @@ H5C__trace_write_unprotect_entry_log_msg(void *udata, haddr_t address, int type_
     assert(trace_udata->message);
 
     /* Create the log message string */
-    HDsnprintf(trace_udata->message, H5C_MAX_TRACE_LOG_MSG_SIZE, "H5AC_unprotect 0x%lx %d 0x%x %d\n",
-               (unsigned long)(address), type_id, flags, (int)fxn_ret_value);
+    snprintf(trace_udata->message, H5C_MAX_TRACE_LOG_MSG_SIZE, "H5AC_unprotect 0x%lx %d 0x%x %d\n",
+             (unsigned long)(address), type_id, flags, (int)fxn_ret_value);
 
     /* Write the log message to the file */
     if (H5C__trace_write_log_message(trace_udata) < 0)
@@ -850,20 +850,19 @@ H5C__trace_write_set_cache_config_log_msg(void *udata, const H5AC_cache_config_t
     assert(config);
 
     /* Create the log message string */
-    HDsnprintf(trace_udata->message, H5C_MAX_TRACE_LOG_MSG_SIZE,
-               "H5AC_set_cache_auto_resize_config %d %d %d %d \"%s\" %d %d %d %f %d %d %ld %d %f %f %d %f %f "
-               "%d %d %d %f %f %d %d %d %d %f %zu %d %d\n",
-               config->version, (int)(config->rpt_fcn_enabled), (int)(config->open_trace_file),
-               (int)(config->close_trace_file), config->trace_file_name, (int)(config->evictions_enabled),
-               (int)(config->set_initial_size), (int)(config->initial_size), config->min_clean_fraction,
-               (int)(config->max_size), (int)(config->min_size), config->epoch_length,
-               (int)(config->incr_mode), config->lower_hr_threshold, config->increment,
-               (int)(config->flash_incr_mode), config->flash_multiple, config->flash_threshold,
-               (int)(config->apply_max_increment), (int)(config->max_increment), (int)(config->decr_mode),
-               config->upper_hr_threshold, config->decrement, (int)(config->apply_max_decrement),
-               (int)(config->max_decrement), config->epochs_before_eviction,
-               (int)(config->apply_empty_reserve), config->empty_reserve, config->dirty_bytes_threshold,
-               config->metadata_write_strategy, (int)fxn_ret_value);
+    snprintf(trace_udata->message, H5C_MAX_TRACE_LOG_MSG_SIZE,
+             "H5AC_set_cache_auto_resize_config %d %d %d %d \"%s\" %d %d %d %f %d %d %ld %d %f %f %d %f %f "
+             "%d %d %d %f %f %d %d %d %d %f %zu %d %d\n",
+             config->version, (int)(config->rpt_fcn_enabled), (int)(config->open_trace_file),
+             (int)(config->close_trace_file), config->trace_file_name, (int)(config->evictions_enabled),
+             (int)(config->set_initial_size), (int)(config->initial_size), config->min_clean_fraction,
+             (int)(config->max_size), (int)(config->min_size), config->epoch_length, (int)(config->incr_mode),
+             config->lower_hr_threshold, config->increment, (int)(config->flash_incr_mode),
+             config->flash_multiple, config->flash_threshold, (int)(config->apply_max_increment),
+             (int)(config->max_increment), (int)(config->decr_mode), config->upper_hr_threshold,
+             config->decrement, (int)(config->apply_max_decrement), (int)(config->max_decrement),
+             config->epochs_before_eviction, (int)(config->apply_empty_reserve), config->empty_reserve,
+             config->dirty_bytes_threshold, config->metadata_write_strategy, (int)fxn_ret_value);
 
     /* Write the log message to the file */
     if (H5C__trace_write_log_message(trace_udata) < 0)
@@ -896,8 +895,8 @@ H5C__trace_write_remove_entry_log_msg(void *udata, const H5C_cache_entry_t *entr
     assert(entry);
 
     /* Create the log message string */
-    HDsnprintf(trace_udata->message, H5C_MAX_TRACE_LOG_MSG_SIZE, "H5AC_remove_entry 0x%lx %d\n",
-               (unsigned long)(entry->addr), (int)fxn_ret_value);
+    snprintf(trace_udata->message, H5C_MAX_TRACE_LOG_MSG_SIZE, "H5AC_remove_entry 0x%lx %d\n",
+             (unsigned long)(entry->addr), (int)fxn_ret_value);
 
     /* Write the log message to the file */
     if (H5C__trace_write_log_message(trace_udata) < 0)

--- a/src/H5Cmpio.c
+++ b/src/H5Cmpio.c
@@ -194,10 +194,10 @@ H5C_apply_candidate_list(H5F_t *f, H5C_t *cache_ptr, unsigned num_candidates, ha
 
     memset(tbl_buf, 0, sizeof(tbl_buf));
 
-    HDsnprintf(tbl_buf, sizeof(tbl_buf), "candidate list = ");
+    snprintf(tbl_buf, sizeof(tbl_buf), "candidate list = ");
     for (u = 0; u < num_candidates; u++)
-        HDsprintf(&(tbl_buf[HDstrlen(tbl_buf)]), " 0x%llx", (long long)(*(candidates_list_ptr + u)));
-    HDsprintf(&(tbl_buf[HDstrlen(tbl_buf)]), "\n");
+        sprintf(&(tbl_buf[strlen(tbl_buf)]), " 0x%llx", (long long)(*(candidates_list_ptr + u)));
+    sprintf(&(tbl_buf[strlen(tbl_buf)]), "\n");
 
     fprintf(stdout, "%s", tbl_buf);
 #endif /* H5C_APPLY_CANDIDATE_LIST__DEBUG */
@@ -260,10 +260,10 @@ H5C_apply_candidate_list(H5F_t *f, H5C_t *cache_ptr, unsigned num_candidates, ha
 #if H5C_APPLY_CANDIDATE_LIST__DEBUG
     for (u = 0; u < 1024; u++)
         tbl_buf[u] = '\0';
-    HDsnprintf(tbl_buf, sizeof(tbl_buf), "candidate assignment table = ");
+    snprintf(tbl_buf, sizeof(tbl_buf), "candidate assignment table = ");
     for (u = 0; u <= (unsigned)mpi_size; u++)
-        HDsprintf(&(tbl_buf[HDstrlen(tbl_buf)]), " %u", candidate_assignment_table[u]);
-    HDsprintf(&(tbl_buf[HDstrlen(tbl_buf)]), "\n");
+        sprintf(&(tbl_buf[strlen(tbl_buf)]), " %u", candidate_assignment_table[u]);
+    sprintf(&(tbl_buf[strlen(tbl_buf)]), "\n");
     fprintf(stdout, "%s", tbl_buf);
 
     fprintf(stdout, "%s:%d: flush entries [%u, %u].\n", __func__, mpi_rank, first_entry_to_flush,

--- a/src/H5Dbtree.c
+++ b/src/H5Dbtree.c
@@ -708,7 +708,7 @@ H5D__btree_debug_key(FILE *stream, int indent, int fwidth, const void *_key, con
     fprintf(stream, "%*s%-*s {", indent, "", fwidth, "Logical offset:");
     for (u = 0; u < udata->ndims; u++)
         fprintf(stream, "%s%" PRIuHSIZE, u ? ", " : "", (key->scaled[u] * udata->common.layout->dim[u]));
-    HDfputs("}\n", stream);
+    fputs("}\n", stream);
 
     FUNC_LEAVE_NOAPI(SUCCEED)
 } /* end H5D__btree_debug_key() */

--- a/src/H5Dbtree2.c
+++ b/src/H5Dbtree2.c
@@ -431,7 +431,7 @@ H5D__bt2_unfilt_debug(FILE *stream, int indent, int fwidth, const void *_record,
     fprintf(stream, "%*s%-*s {", indent, "", fwidth, "Logical offset:");
     for (u = 0; u < ctx->ndims; u++)
         fprintf(stream, "%s%" PRIuHSIZE, u ? ", " : "", record->scaled[u] * ctx->dim[u]);
-    HDfputs("}\n", stream);
+    fputs("}\n", stream);
 
     FUNC_LEAVE_NOAPI(SUCCEED)
 } /* H5D__bt2_unfilt_debug() */
@@ -541,7 +541,7 @@ H5D__bt2_filt_debug(FILE *stream, int indent, int fwidth, const void *_record, c
     fprintf(stream, "%*s%-*s {", indent, "", fwidth, "Logical offset:");
     for (u = 0; u < ctx->ndims; u++)
         fprintf(stream, "%s%" PRIuHSIZE, u ? ", " : "", record->scaled[u] * ctx->dim[u]);
-    HDfputs("}\n", stream);
+    fputs("}\n", stream);
 
     FUNC_LEAVE_NOAPI(SUCCEED)
 } /* H5D__bt2_filt_debug() */

--- a/src/H5Dchunk.c
+++ b/src/H5Dchunk.c
@@ -7174,7 +7174,7 @@ H5D__chunk_dump_index_cb(const H5D_chunk_rec_t *chunk_rec, void *_udata)
         for (u = 0; u < udata->ndims; u++)
             fprintf(udata->stream, "%s%" PRIuHSIZE, (u ? ", " : ""),
                     (chunk_rec->scaled[u] * udata->chunk_dim[u]));
-        HDfputs("]\n", udata->stream);
+        fputs("]\n", udata->stream);
     } /* end if */
 
     FUNC_LEAVE_NOAPI(H5_ITER_CONT)
@@ -7281,10 +7281,10 @@ H5D__chunk_stats(const H5D_t *dset, bool headers)
             miss_rate = 0.0;
         }
         if (miss_rate > 100) {
-            HDsnprintf(ascii, sizeof(ascii), "%7d%%", (int)(miss_rate + 0.5));
+            snprintf(ascii, sizeof(ascii), "%7d%%", (int)(miss_rate + 0.5));
         }
         else {
-            HDsnprintf(ascii, sizeof(ascii), "%7.2f%%", miss_rate);
+            snprintf(ascii, sizeof(ascii), "%7.2f%%", miss_rate);
         }
 
         fprintf(H5DEBUG(AC), "   %-18s %8u %8u %7s %8d+%-9ld\n", "raw data chunks", rdcc->stats.nhits,

--- a/src/H5Dearray.c
+++ b/src/H5Dearray.c
@@ -395,7 +395,7 @@ H5D__earray_debug(FILE *stream, int indent, int fwidth, hsize_t idx, const void 
     assert(elmt);
 
     /* Print element */
-    HDsnprintf(temp_str, sizeof(temp_str), "Element #%" PRIuHSIZE ":", idx);
+    snprintf(temp_str, sizeof(temp_str), "Element #%" PRIuHSIZE ":", idx);
     fprintf(stream, "%*s%-*s %" PRIuHADDR "\n", indent, "", fwidth, temp_str, *(const haddr_t *)elmt);
 
     FUNC_LEAVE_NOAPI(SUCCEED)
@@ -539,7 +539,7 @@ H5D__earray_filt_debug(FILE *stream, int indent, int fwidth, hsize_t idx, const 
     assert(elmt);
 
     /* Print element */
-    HDsnprintf(temp_str, sizeof(temp_str), "Element #%" PRIuHSIZE ":", idx);
+    snprintf(temp_str, sizeof(temp_str), "Element #%" PRIuHSIZE ":", idx);
     fprintf(stream, "%*s%-*s {%" PRIuHADDR ", %u, %0x}\n", indent, "", fwidth, temp_str, elmt->addr,
             elmt->nbytes, elmt->filter_mask);
 

--- a/src/H5Dfarray.c
+++ b/src/H5Dfarray.c
@@ -393,7 +393,7 @@ H5D__farray_debug(FILE *stream, int indent, int fwidth, hsize_t idx, const void 
     assert(elmt);
 
     /* Print element */
-    HDsnprintf(temp_str, sizeof(temp_str), "Element #%" PRIuHSIZE ":", idx);
+    snprintf(temp_str, sizeof(temp_str), "Element #%" PRIuHSIZE ":", idx);
     fprintf(stream, "%*s%-*s %" PRIuHADDR "\n", indent, "", fwidth, temp_str, *(const haddr_t *)elmt);
 
     FUNC_LEAVE_NOAPI(SUCCEED)
@@ -635,7 +635,7 @@ H5D__farray_filt_debug(FILE *stream, int indent, int fwidth, hsize_t idx, const 
     assert(elmt);
 
     /* Print element */
-    HDsnprintf(temp_str, sizeof(temp_str), "Element #%" PRIuHSIZE ":", idx);
+    snprintf(temp_str, sizeof(temp_str), "Element #%" PRIuHSIZE ":", idx);
     fprintf(stream, "%*s%-*s {%" PRIuHADDR ", %u, %0x}\n", indent, "", fwidth, temp_str, elmt->addr,
             elmt->nbytes, elmt->filter_mask);
 

--- a/src/H5Dint.c
+++ b/src/H5Dint.c
@@ -1087,22 +1087,22 @@ H5D__build_file_prefix(const H5D_t *dset, H5F_prefix_open_t prefix_type, char **
     /* Prefix has to be checked for NULL / empty string again because the
      * code above might have updated it.
      */
-    if (prefix == NULL || *prefix == '\0' || HDstrcmp(prefix, ".") == 0) {
+    if (prefix == NULL || *prefix == '\0' || strcmp(prefix, ".") == 0) {
         /* filename is interpreted as relative to the current directory,
          * does not need to be expanded
          */
         *file_prefix = NULL;
     } /* end if */
     else {
-        if (HDstrncmp(prefix, "${ORIGIN}", HDstrlen("${ORIGIN}")) == 0) {
+        if (strncmp(prefix, "${ORIGIN}", strlen("${ORIGIN}")) == 0) {
             /* Replace ${ORIGIN} at beginning of prefix by directory of HDF5 file */
-            filepath_len    = HDstrlen(filepath);
-            prefix_len      = HDstrlen(prefix);
-            file_prefix_len = filepath_len + prefix_len - HDstrlen("${ORIGIN}") + 1;
+            filepath_len    = strlen(filepath);
+            prefix_len      = strlen(prefix);
+            file_prefix_len = filepath_len + prefix_len - strlen("${ORIGIN}") + 1;
 
             if (NULL == (*file_prefix = (char *)H5MM_malloc(file_prefix_len)))
                 HGOTO_ERROR(H5E_RESOURCE, H5E_NOSPACE, FAIL, "unable to allocate buffer");
-            HDsnprintf(*file_prefix, file_prefix_len, "%s%s", filepath, prefix + HDstrlen("${ORIGIN}"));
+            snprintf(*file_prefix, file_prefix_len, "%s%s", filepath, prefix + strlen("${ORIGIN}"));
         } /* end if */
         else {
             if (NULL == (*file_prefix = (char *)H5MM_strdup(prefix)))
@@ -1526,7 +1526,7 @@ H5D_open(const H5G_loc_t *loc, hid_t dapl_id)
          * matches the new external file prefix
          */
         if (extfile_prefix && dataset->shared->extfile_prefix) {
-            if (HDstrcmp(extfile_prefix, dataset->shared->extfile_prefix) != 0)
+            if (strcmp(extfile_prefix, dataset->shared->extfile_prefix) != 0)
                 HGOTO_ERROR(
                     H5E_DATASET, H5E_CANTOPENOBJ, NULL,
                     "new external file prefix does not match external file prefix of already open dataset");

--- a/src/H5Dlayout.c
+++ b/src/H5Dlayout.c
@@ -489,7 +489,7 @@ H5D__layout_oh_create(H5F_t *file, H5O_t *oh, H5D_t *dset, hid_t dapl_id)
 
         /* Determine size of heap needed to stored the file names */
         for (u = 0; u < efl->nused; ++u)
-            heap_size += H5HL_ALIGN(HDstrlen(efl->slot[u].name) + 1);
+            heap_size += H5HL_ALIGN(strlen(efl->slot[u].name) + 1);
 
         /* Create the heap for the EFL file names */
         if (H5HL_create(file, heap_size, &efl->heap_addr /*out*/) < 0)
@@ -507,8 +507,7 @@ H5D__layout_oh_create(H5F_t *file, H5O_t *oh, H5D_t *dset, hid_t dapl_id)
 
         for (u = 0; u < efl->nused; ++u) {
             /* Insert file name into heap */
-            if (H5HL_insert(file, heap, HDstrlen(efl->slot[u].name) + 1, efl->slot[u].name, &name_offset) <
-                0) {
+            if (H5HL_insert(file, heap, strlen(efl->slot[u].name) + 1, efl->slot[u].name, &name_offset) < 0) {
                 H5HL_unprotect(heap);
                 HGOTO_ERROR(H5E_DATASET, H5E_CANTINSERT, FAIL, "unable to insert file name into heap");
             }

--- a/src/H5Dmpio.c
+++ b/src/H5Dmpio.c
@@ -446,7 +446,7 @@ static FILE             *debug_stream             = NULL;
                                                                                                              \
         if (trace_flag) {                                                                                    \
             H5D_MPIO_DEBUG_VA(rank, "%s%s", trace_in_pre, __func__);                                         \
-            debug_indent += (int)HDstrlen(trace_in_pre);                                                     \
+            debug_indent += (int)strlen(trace_in_pre);                                                       \
         }                                                                                                    \
     } while (0)
 
@@ -455,7 +455,7 @@ static FILE             *debug_stream             = NULL;
         bool trace_flag = H5D_mpio_debug_flags_s[(int)'t'];                                                  \
                                                                                                              \
         if (trace_flag) {                                                                                    \
-            debug_indent -= (int)HDstrlen(trace_out_pre);                                                    \
+            debug_indent -= (int)strlen(trace_out_pre);                                                      \
             H5D_MPIO_DEBUG_VA(rank, "%s%s", trace_out_pre, __func__);                                        \
         }                                                                                                    \
     } while (0)
@@ -861,14 +861,14 @@ H5D__mpio_get_no_coll_cause_strings(char *local_cause, size_t local_cause_len, c
              * so, prepend a semicolon to separate the messages.
              */
             if (buf_space_left && local_cause_bytes_written) {
-                HDstrncat(local_cause, "; ", buf_space_left);
+                strncat(local_cause, "; ", buf_space_left);
                 local_cause_bytes_written += MIN(buf_space_left, 2);
                 buf_space_left -= MIN(buf_space_left, 2);
             }
 
             if (buf_space_left) {
-                HDstrncat(local_cause, cause_str, buf_space_left);
-                local_cause_bytes_written += MIN(buf_space_left, HDstrlen(cause_str));
+                strncat(local_cause, cause_str, buf_space_left);
+                local_cause_bytes_written += MIN(buf_space_left, strlen(cause_str));
             }
         }
 
@@ -884,14 +884,14 @@ H5D__mpio_get_no_coll_cause_strings(char *local_cause, size_t local_cause_len, c
              * so, prepend a semicolon to separate the messages.
              */
             if (buf_space_left && global_cause_bytes_written) {
-                HDstrncat(global_cause, "; ", buf_space_left);
+                strncat(global_cause, "; ", buf_space_left);
                 global_cause_bytes_written += MIN(buf_space_left, 2);
                 buf_space_left -= MIN(buf_space_left, 2);
             }
 
             if (buf_space_left) {
-                HDstrncat(global_cause, cause_str, buf_space_left);
-                global_cause_bytes_written += MIN(buf_space_left, HDstrlen(cause_str));
+                strncat(global_cause, cause_str, buf_space_left);
+                global_cause_bytes_written += MIN(buf_space_left, strlen(cause_str));
             }
         }
     }
@@ -1111,7 +1111,7 @@ H5D__piece_io(H5D_io_info_t *io_info)
         char   debug_log_filename[1024];
         time_t time_now;
 
-        HDsnprintf(debug_log_filename, 1024, "H5Dmpio_debug.rank%d", mpi_rank);
+        snprintf(debug_log_filename, 1024, "H5Dmpio_debug.rank%d", mpi_rank);
 
         if (NULL == (debug_log_file = fopen(debug_log_filename, "a")))
             HGOTO_ERROR(H5E_IO, H5E_OPENERROR, FAIL, "couldn't open debugging log file");

--- a/src/H5Dvirtual.c
+++ b/src/H5Dvirtual.c
@@ -443,11 +443,11 @@ H5D__virtual_store_layout(H5F_t *f, H5O_layout_t *layout)
             assert(ent->source_dset.virtual_select);
 
             /* Source file name */
-            str_size[2 * i] = HDstrlen(ent->source_file_name) + (size_t)1;
+            str_size[2 * i] = strlen(ent->source_file_name) + (size_t)1;
             block_size += str_size[2 * i];
 
             /* Source dset name */
-            str_size[(2 * i) + 1] = HDstrlen(ent->source_dset_name) + (size_t)1;
+            str_size[(2 * i) + 1] = strlen(ent->source_dset_name) + (size_t)1;
             block_size += str_size[(2 * i) + 1];
 
             /* Source selection */
@@ -868,7 +868,7 @@ H5D__virtual_open_source_dset(const H5D_t *vdset, H5O_storage_virtual_ent_t *vir
     assert(source_dset->dset_name);
 
     /* Check if we need to open the source file */
-    if (HDstrcmp(source_dset->file_name, ".") != 0) {
+    if (strcmp(source_dset->file_name, ".") != 0) {
         unsigned intent; /* File access permissions */
 
         /* Get the virtual dataset's file open flags ("intent") */
@@ -1115,12 +1115,12 @@ H5D_virtual_parse_source_name(const char *source_name, H5O_storage_virtual_name_
 
     /* Initialize p and tmp_static_strlen */
     p                 = source_name;
-    tmp_static_strlen = tmp_strlen = HDstrlen(source_name);
+    tmp_static_strlen = tmp_strlen = strlen(source_name);
 
     /* Iterate over name */
     /* Note this will not work with UTF-8!  We should support this eventually
      * -NAF 5/18/2015 */
-    while ((pct = HDstrchr(p, '%'))) {
+    while ((pct = strchr(p, '%'))) {
         assert(pct >= p);
 
         /* Allocate name segment struct if necessary */
@@ -1336,10 +1336,10 @@ H5D__virtual_build_source_name(char *source_name, const H5O_storage_virtual_name
         do {
             /* Add name segment */
             if (name_seg->name_segment) {
-                seg_len = HDstrlen(name_seg->name_segment);
+                seg_len = strlen(name_seg->name_segment);
                 assert(seg_len > 0);
                 assert(seg_len < name_len_rem);
-                HDstrncpy(p, name_seg->name_segment, name_len_rem);
+                strncpy(p, name_seg->name_segment, name_len_rem);
                 name_len_rem -= seg_len;
                 p += seg_len;
             } /* end if */
@@ -1347,7 +1347,7 @@ H5D__virtual_build_source_name(char *source_name, const H5O_storage_virtual_name
             /* Add block number */
             if (nsubs_rem > 0) {
                 assert(blockno_len < name_len_rem);
-                if (HDsnprintf(p, name_len_rem, "%llu", (long long unsigned)blockno) < 0)
+                if (snprintf(p, name_len_rem, "%llu", (long long unsigned)blockno) < 0)
                     HGOTO_ERROR(H5E_DATASET, H5E_WRITEERROR, FAIL, "unable to write block number to string");
                 name_len_rem -= blockno_len;
                 p += blockno_len;

--- a/src/H5E.c
+++ b/src/H5E.c
@@ -170,8 +170,8 @@ H5E_init(void)
 
     /* Allocate the HDF5 error class */
     assert(H5E_ERR_CLS_g == (-1));
-    HDsnprintf(lib_vers, sizeof(lib_vers), "%u.%u.%u%s", H5_VERS_MAJOR, H5_VERS_MINOR, H5_VERS_RELEASE,
-               (HDstrlen(H5_VERS_SUBRELEASE) > 0 ? "-" H5_VERS_SUBRELEASE : ""));
+    snprintf(lib_vers, sizeof(lib_vers), "%u.%u.%u%s", H5_VERS_MAJOR, H5_VERS_MINOR, H5_VERS_RELEASE,
+             (strlen(H5_VERS_SUBRELEASE) > 0 ? "-" H5_VERS_SUBRELEASE : ""));
     if (NULL == (cls = H5E__register_class(H5E_CLS_NAME, H5E_CLS_LIB_NAME, lib_vers)))
         HGOTO_ERROR(H5E_ERROR, H5E_CANTINIT, FAIL, "class initialization failed");
     if ((H5E_ERR_CLS_g = H5I_register(H5I_ERROR_CLASS, cls, false)) < 0)
@@ -569,11 +569,11 @@ H5E__get_class_name(const H5E_cls_t *cls, char *name, size_t size)
     assert(cls);
 
     /* Get the class's name */
-    len = (ssize_t)HDstrlen(cls->cls_name);
+    len = (ssize_t)strlen(cls->cls_name);
 
     /* Set the user's buffer, if provided */
     if (name) {
-        HDstrncpy(name, cls->cls_name, size);
+        strncpy(name, cls->cls_name, size);
         if ((size_t)len >= size)
             name[size - 1] = '\0';
     } /* end if */

--- a/src/H5EAdbg.c
+++ b/src/H5EAdbg.c
@@ -229,7 +229,7 @@ H5EA__iblock_debug(H5F_t *f, haddr_t H5_ATTR_UNUSED addr, FILE *stream, int inde
         fprintf(stream, "%*sData Block Addresses in Index Block:\n", indent, "");
         for (u = 0; u < iblock->ndblk_addrs; u++) {
             /* Print address */
-            HDsnprintf(temp_str, sizeof(temp_str), "Address #%u:", u);
+            snprintf(temp_str, sizeof(temp_str), "Address #%u:", u);
             fprintf(stream, "%*s%-*s %" PRIuHADDR "\n", (indent + 3), "", MAX(0, (fwidth - 3)), temp_str,
                     iblock->dblk_addrs[u]);
         } /* end for */
@@ -244,7 +244,7 @@ H5EA__iblock_debug(H5F_t *f, haddr_t H5_ATTR_UNUSED addr, FILE *stream, int inde
         fprintf(stream, "%*sSuper Block Addresses in Index Block:\n", indent, "");
         for (u = 0; u < iblock->nsblk_addrs; u++) {
             /* Print address */
-            HDsnprintf(temp_str, sizeof(temp_str), "Address #%u:", u);
+            snprintf(temp_str, sizeof(temp_str), "Address #%u:", u);
             fprintf(stream, "%*s%-*s %" PRIuHADDR "\n", (indent + 3), "", MAX(0, (fwidth - 3)), temp_str,
                     iblock->sblk_addrs[u]);
         } /* end for */
@@ -331,7 +331,7 @@ H5EA__sblock_debug(H5F_t *f, haddr_t addr, FILE *stream, int indent, int fwidth,
         fprintf(stream, "%*sData Block Addresses in Super Block:\n", indent, "");
         for (u = 0; u < sblock->ndblks; u++) {
             /* Print address */
-            HDsnprintf(temp_str, sizeof(temp_str), "Address #%u:", u);
+            snprintf(temp_str, sizeof(temp_str), "Address #%u:", u);
             fprintf(stream, "%*s%-*s %" PRIuHADDR "\n", (indent + 3), "", MAX(0, (fwidth - 3)), temp_str,
                     sblock->dblk_addrs[u]);
         } /* end for */

--- a/src/H5EAtest.c
+++ b/src/H5EAtest.c
@@ -301,7 +301,7 @@ H5EA__test_debug(FILE *stream, int indent, int fwidth, hsize_t idx, const void *
     assert(elmt);
 
     /* Print element */
-    HDsnprintf(temp_str, sizeof(temp_str), "Element #%llu:", (unsigned long long)idx);
+    snprintf(temp_str, sizeof(temp_str), "Element #%llu:", (unsigned long long)idx);
     fprintf(stream, "%*s%-*s %llu\n", indent, "", fwidth, temp_str,
             (unsigned long long)*(const uint64_t *)elmt);
 

--- a/src/H5ESint.c
+++ b/src/H5ESint.c
@@ -359,7 +359,7 @@ H5ES_insert(hid_t es_id, H5VL_t *connector, void *token, const char *caller, con
 
     /* Copy the string for the API routine's arguments */
     /* (skip the six characters from the app's file, function and line # arguments) */
-    assert(0 == HDstrncmp(caller_args, "*s*sIu", 6));
+    assert(0 == strncmp(caller_args, "*s*sIu", 6));
     if (H5_trace_args(rs, caller_args + 6, ap) < 0)
         HGOTO_ERROR(H5E_EVENTSET, H5E_CANTSET, FAIL, "can't create formatted API arguments");
     if (NULL == (api_args = H5RS_get_str(rs)))

--- a/src/H5Eint.c
+++ b/src/H5Eint.c
@@ -119,11 +119,11 @@ H5E__get_msg(const H5E_msg_t *msg, H5E_type_t *type, char *msg_str, size_t size)
     assert(msg);
 
     /* Get the length of the message string */
-    len = (ssize_t)HDstrlen(msg->msg);
+    len = (ssize_t)strlen(msg->msg);
 
     /* Copy the message into the user's buffer, if given */
     if (msg_str) {
-        HDstrncpy(msg_str, msg->msg, size);
+        strncpy(msg_str, msg->msg, size);
         if ((size_t)len >= size)
             msg_str[size - 1] = '\0';
     } /* end if */
@@ -209,7 +209,7 @@ H5E__walk1_cb(int n, H5E_error1_t *err_desc, void *client_data)
     cls_ptr = maj_ptr->cls;
 
     /* Print error class header if new class */
-    if (eprint->cls.lib_name == NULL || HDstrcmp(cls_ptr->lib_name, eprint->cls.lib_name) != 0) {
+    if (eprint->cls.lib_name == NULL || strcmp(cls_ptr->lib_name, eprint->cls.lib_name) != 0) {
         /* update to the new class information */
         if (cls_ptr->cls_name)
             eprint->cls.cls_name = cls_ptr->cls_name;
@@ -245,7 +245,7 @@ H5E__walk1_cb(int n, H5E_error1_t *err_desc, void *client_data)
     } /* end if */
 
     /* Check for "real" error description - used to format output more nicely */
-    if (err_desc->desc == NULL || HDstrlen(err_desc->desc) == 0)
+    if (err_desc->desc == NULL || strlen(err_desc->desc) == 0)
         have_desc = 0;
 
     /* Print error message */
@@ -333,7 +333,7 @@ H5E__walk2_cb(unsigned n, const H5E_error2_t *err_desc, void *client_data)
         HGOTO_DONE(FAIL);
 
     /* Print error class header if new class */
-    if (eprint->cls.lib_name == NULL || HDstrcmp(cls_ptr->lib_name, eprint->cls.lib_name) != 0) {
+    if (eprint->cls.lib_name == NULL || strcmp(cls_ptr->lib_name, eprint->cls.lib_name) != 0) {
         /* update to the new class information */
         if (cls_ptr->cls_name)
             eprint->cls.cls_name = cls_ptr->cls_name;
@@ -369,7 +369,7 @@ H5E__walk2_cb(unsigned n, const H5E_error2_t *err_desc, void *client_data)
     } /* end if */
 
     /* Check for "real" error description - used to format output more nicely */
-    if (err_desc->desc == NULL || HDstrlen(err_desc->desc) == 0)
+    if (err_desc->desc == NULL || strlen(err_desc->desc) == 0)
         have_desc = 0;
 
     /* Print error message */

--- a/src/H5Eprivate.h
+++ b/src/H5Eprivate.h
@@ -122,7 +122,7 @@ typedef struct H5E_t H5E_t;
          * considered as an API change                                                                       \
          */                                                                                                  \
         HDONE_ERROR(majorcode, minorcode, retcode, "%s, errno = %d, error message = '%s'", str, myerrno,     \
-                    HDstrerror(myerrno));                                                                    \
+                    strerror(myerrno));                                                                      \
     }
 #define HSYS_GOTO_ERROR(majorcode, minorcode, retcode, str)                                                  \
     {                                                                                                        \
@@ -131,7 +131,7 @@ typedef struct H5E_t H5E_t;
          * considered as an API change                                                                       \
          */                                                                                                  \
         HGOTO_ERROR(majorcode, minorcode, retcode, "%s, errno = %d, error message = '%s'", str, myerrno,     \
-                    HDstrerror(myerrno));                                                                    \
+                    strerror(myerrno));                                                                      \
     }
 #else /* H5_HAVE_WIN32_API */
 /* On Windows we also emit the result of GetLastError(). This call returns a DWORD, which is always a
@@ -148,7 +148,7 @@ typedef struct H5E_t H5E_t;
          */                                                                                                  \
         HDONE_ERROR(majorcode, minorcode, retcode,                                                           \
                     "%s, errno = %d, error message = '%s', Win32 GetLastError() = %" PRIu32 "", str,         \
-                    myerrno, HDstrerror(myerrno), win_error);                                                \
+                    myerrno, strerror(myerrno), win_error);                                                  \
     }
 #define HSYS_GOTO_ERROR(majorcode, minorcode, retcode, str)                                                  \
     {                                                                                                        \
@@ -159,7 +159,7 @@ typedef struct H5E_t H5E_t;
          */                                                                                                  \
         HGOTO_ERROR(majorcode, minorcode, retcode,                                                           \
                     "%s, errno = %d, error message = '%s', Win32 GetLastError() = %" PRIu32 "", str,         \
-                    myerrno, HDstrerror(myerrno), win_error);                                                \
+                    myerrno, strerror(myerrno), win_error);                                                  \
     }
 #endif /* H5_HAVE_WIN32_API */
 

--- a/src/H5FAtest.c
+++ b/src/H5FAtest.c
@@ -284,7 +284,7 @@ H5FA__test_debug(FILE *stream, int indent, int fwidth, hsize_t idx, const void *
     assert(elmt);
 
     /* Print element */
-    HDsnprintf(temp_str, sizeof(temp_str), "Element #%llu:", (unsigned long long)idx);
+    snprintf(temp_str, sizeof(temp_str), "Element #%llu:", (unsigned long long)idx);
     fprintf(stream, "%*s%-*s %llu\n", indent, "", fwidth, temp_str,
             (unsigned long long)*(const uint64_t *)elmt);
 

--- a/src/H5FD.c
+++ b/src/H5FD.c
@@ -543,9 +543,9 @@ H5FD_sb_load(H5FD_t *file, const char *name, const uint8_t *buf)
     /* Check if driver matches driver information saved. Unfortunately, we can't push this
      * function to each specific driver because we're checking if the driver is correct.
      */
-    if (!HDstrncmp(name, "NCSAfami", (size_t)8) && HDstrcmp(file->cls->name, "family") != 0)
+    if (!strncmp(name, "NCSAfami", (size_t)8) && strcmp(file->cls->name, "family") != 0)
         HGOTO_ERROR(H5E_VFL, H5E_BADVALUE, FAIL, "family driver should be used");
-    if (!HDstrncmp(name, "NCSAmult", (size_t)8) && HDstrcmp(file->cls->name, "multi") != 0)
+    if (!strncmp(name, "NCSAmult", (size_t)8) && strcmp(file->cls->name, "multi") != 0)
         HGOTO_ERROR(H5E_VFL, H5E_BADVALUE, FAIL, "multi driver should be used");
 
     /* Decode driver information */

--- a/src/H5FDcore.c
+++ b/src/H5FDcore.c
@@ -399,7 +399,7 @@ H5FD__core_write_to_bstore(H5FD_core_t *file, haddr_t addr, size_t size)
                         "write to backing store failed: time = %s, filename = '%s', file descriptor = %d, "
                         "errno = %d, error message = '%s', ptr = %p, total write size = %llu, bytes this "
                         "sub-write = %llu, bytes actually written = %llu, offset = %llu",
-                        HDctime(&mytime), file->name, file->fd, myerrno, HDstrerror(myerrno), (void *)ptr,
+                        HDctime(&mytime), file->name, file->fd, myerrno, strerror(myerrno), (void *)ptr,
                         (unsigned long long)size, (unsigned long long)bytes_in,
                         (unsigned long long)bytes_wrote, (unsigned long long)offset);
         } /* end if */
@@ -433,9 +433,9 @@ H5FD__core_get_default_config(void)
     char *driver = HDgetenv(HDF5_DRIVER);
 
     if (driver) {
-        if (!HDstrcmp(driver, "core"))
+        if (!strcmp(driver, "core"))
             return &H5FD_core_default_config_g;
-        else if (!HDstrcmp(driver, "core_paged"))
+        else if (!strcmp(driver, "core_paged"))
             return &H5FD_core_default_paged_config_g;
     }
 
@@ -463,9 +463,9 @@ H5FD_core_init(void)
 
     /* Check the use disabled file locks environment variable */
     lock_env_var = HDgetenv(HDF5_USE_FILE_LOCKING);
-    if (lock_env_var && !HDstrcmp(lock_env_var, "BEST_EFFORT"))
+    if (lock_env_var && !strcmp(lock_env_var, "BEST_EFFORT"))
         ignore_disabled_file_locks_s = true; /* Override: Ignore disabled locks */
-    else if (lock_env_var && (!HDstrcmp(lock_env_var, "TRUE") || !HDstrcmp(lock_env_var, "1")))
+    else if (lock_env_var && (!strcmp(lock_env_var, "TRUE") || !strcmp(lock_env_var, "1")))
         ignore_disabled_file_locks_s = false; /* Override: Don't ignore disabled locks */
     else
         ignore_disabled_file_locks_s = FAIL; /* Environment variable not set, or not set correctly */
@@ -905,7 +905,7 @@ H5FD__core_open(const char *name, unsigned flags, hid_t fapl_id, haddr_t maxaddr
                             "file read failed: time = %s, filename = '%s', file descriptor = %d, errno = %d, "
                             "error message = '%s', file->mem = %p, total read size = %llu, bytes this "
                             "sub-read = %llu, bytes actually read = %llu, offset = %llu",
-                            HDctime(&mytime), file->name, file->fd, myerrno, HDstrerror(myerrno),
+                            HDctime(&mytime), file->name, file->fd, myerrno, strerror(myerrno),
                             (void *)file->mem, (unsigned long long)size, (unsigned long long)bytes_in,
                             (unsigned long long)bytes_read, (unsigned long long)offset);
                     } /* end if */
@@ -1086,7 +1086,7 @@ H5FD__core_cmp(const H5FD_t *_f1, const H5FD_t *_f2)
         if (NULL == f2->name)
             HGOTO_DONE(1);
 
-        ret_value = HDstrcmp(f1->name, f2->name);
+        ret_value = strcmp(f1->name, f2->name);
     } /* end else */
 
 done:

--- a/src/H5FDdirect.c
+++ b/src/H5FDdirect.c
@@ -204,9 +204,9 @@ H5FD_direct_init(void)
 
     /* Check the use disabled file locks environment variable */
     lock_env_var = HDgetenv(HDF5_USE_FILE_LOCKING);
-    if (lock_env_var && !HDstrcmp(lock_env_var, "BEST_EFFORT"))
+    if (lock_env_var && !strcmp(lock_env_var, "BEST_EFFORT"))
         ignore_disabled_file_locks_s = true; /* Override: Ignore disabled locks */
-    else if (lock_env_var && (!HDstrcmp(lock_env_var, "TRUE") || !HDstrcmp(lock_env_var, "1")))
+    else if (lock_env_var && (!strcmp(lock_env_var, "TRUE") || !strcmp(lock_env_var, "1")))
         ignore_disabled_file_locks_s = false; /* Override: Don't ignore disabled locks */
     else
         ignore_disabled_file_locks_s = FAIL; /* Environment variable not set, or not set correctly */

--- a/src/H5FDfamily.c
+++ b/src/H5FDfamily.c
@@ -225,36 +225,36 @@ H5FD__family_get_default_printf_filename(const char *old_filename)
 
     assert(old_filename);
 
-    old_filename_len = HDstrlen(old_filename);
+    old_filename_len = strlen(old_filename);
     if (0 == old_filename_len)
         HGOTO_ERROR(H5E_VFL, H5E_BADVALUE, NULL, "invalid filename");
 
-    new_filename_len = old_filename_len + HDstrlen(suffix) + 1;
+    new_filename_len = old_filename_len + strlen(suffix) + 1;
     if (NULL == (tmp_buffer = H5MM_malloc(new_filename_len)))
         HGOTO_ERROR(H5E_VFL, H5E_CANTALLOC, NULL, "can't allocate new filename buffer");
 
     /* Determine if filename contains a ".h5" extension. */
-    if ((file_extension = HDstrstr(old_filename, ".h5"))) {
+    if ((file_extension = strstr(old_filename, ".h5"))) {
         /* Insert the printf format between the filename and ".h5" extension. */
-        HDstrcpy(tmp_buffer, old_filename);
-        file_extension = HDstrstr(tmp_buffer, ".h5");
-        HDsprintf(file_extension, "%s%s", suffix, ".h5");
+        strcpy(tmp_buffer, old_filename);
+        file_extension = strstr(tmp_buffer, ".h5");
+        sprintf(file_extension, "%s%s", suffix, ".h5");
     }
-    else if ((file_extension = HDstrrchr(old_filename, '.'))) {
+    else if ((file_extension = strrchr(old_filename, '.'))) {
         char *new_extension_loc = NULL;
 
         /* If the filename doesn't contain a ".h5" extension, but contains
          * AN extension, just insert the printf format before that extension.
          */
-        HDstrcpy(tmp_buffer, old_filename);
-        new_extension_loc = HDstrrchr(tmp_buffer, '.');
-        HDsprintf(new_extension_loc, "%s%s", suffix, file_extension);
+        strcpy(tmp_buffer, old_filename);
+        new_extension_loc = strrchr(tmp_buffer, '.');
+        sprintf(new_extension_loc, "%s%s", suffix, file_extension);
     }
     else {
         /* If the filename doesn't contain an extension at all, just insert
          * the printf format at the end of the filename.
          */
-        HDsnprintf(tmp_buffer, new_filename_len, "%s%s", old_filename, suffix);
+        snprintf(tmp_buffer, new_filename_len, "%s%s", old_filename, suffix);
     }
 
     ret_value = tmp_buffer;
@@ -564,7 +564,7 @@ H5FD__family_sb_encode(H5FD_t *_file, char *name /*out*/, unsigned char *buf /*o
     FUNC_ENTER_PACKAGE_NOERR
 
     /* Name and version number */
-    HDstrncpy(name, "NCSAfami", (size_t)9);
+    strncpy(name, "NCSAfami", (size_t)9);
     name[8] = '\0';
 
     /* Store member file size.  Use the member file size from the property here.
@@ -738,9 +738,9 @@ H5FD__family_open(const char *name, unsigned flags, hid_t fapl_id, haddr_t maxad
         HGOTO_ERROR(H5E_FILE, H5E_CANTALLOC, NULL, "unable to allocate temporary member name");
 
     /* Check that names are unique */
-    HDsnprintf(memb_name, H5FD_FAM_MEMB_NAME_BUF_SIZE, name, 0);
-    HDsnprintf(temp, H5FD_FAM_MEMB_NAME_BUF_SIZE, name, 1);
-    if (!HDstrcmp(memb_name, temp)) {
+    snprintf(memb_name, H5FD_FAM_MEMB_NAME_BUF_SIZE, name, 0);
+    snprintf(temp, H5FD_FAM_MEMB_NAME_BUF_SIZE, name, 1);
+    if (!strcmp(memb_name, temp)) {
         if (default_config) {
             temp = H5MM_xfree(temp);
             if (NULL == (temp = H5FD__family_get_default_printf_filename(name)))
@@ -753,7 +753,7 @@ H5FD__family_open(const char *name, unsigned flags, hid_t fapl_id, haddr_t maxad
 
     /* Open all the family members */
     while (1) {
-        HDsnprintf(memb_name, H5FD_FAM_MEMB_NAME_BUF_SIZE, name, file->nmembs);
+        snprintf(memb_name, H5FD_FAM_MEMB_NAME_BUF_SIZE, name, file->nmembs);
 
         /* Enlarge member array */
         if (file->nmembs >= file->amembs) {
@@ -1016,7 +1016,7 @@ H5FD__family_set_eoa(H5FD_t *_file, H5FD_mem_t type, haddr_t abs_eoa)
         /* Create another file if necessary */
         if (u >= file->nmembs || !file->memb[u]) {
             file->nmembs = MAX(file->nmembs, u + 1);
-            HDsnprintf(memb_name, H5FD_FAM_MEMB_NAME_BUF_SIZE, file->name, u);
+            snprintf(memb_name, H5FD_FAM_MEMB_NAME_BUF_SIZE, file->name, u);
             H5E_BEGIN_TRY
             {
                 H5_CHECK_OVERFLOW(file->memb_size, hsize_t, haddr_t);
@@ -1458,11 +1458,11 @@ H5FD__family_delete(const char *filename, hid_t fapl_id)
 
     /* Sanity check to make sure that generated names are unique */
     H5_GCC_CLANG_DIAG_OFF("format-nonliteral")
-    HDsnprintf(member_name, H5FD_FAM_MEMB_NAME_BUF_SIZE, filename, 0);
-    HDsnprintf(temp, H5FD_FAM_MEMB_NAME_BUF_SIZE, filename, 1);
+    snprintf(member_name, H5FD_FAM_MEMB_NAME_BUF_SIZE, filename, 0);
+    snprintf(temp, H5FD_FAM_MEMB_NAME_BUF_SIZE, filename, 1);
     H5_GCC_CLANG_DIAG_ON("format-nonliteral")
 
-    if (!HDstrcmp(member_name, temp)) {
+    if (!strcmp(member_name, temp)) {
         if (default_config) {
             temp = H5MM_xfree(temp);
             if (NULL == (temp = H5FD__family_get_default_printf_filename(filename)))
@@ -1479,7 +1479,7 @@ H5FD__family_delete(const char *filename, hid_t fapl_id)
     while (1) {
         /* Fix up the filename with the current member's number */
         H5_GCC_CLANG_DIAG_OFF("format-nonliteral")
-        HDsnprintf(member_name, H5FD_FAM_MEMB_NAME_BUF_SIZE, filename, current_member);
+        snprintf(member_name, H5FD_FAM_MEMB_NAME_BUF_SIZE, filename, current_member);
         H5_GCC_CLANG_DIAG_ON("format-nonliteral")
 
         /* Attempt to delete the member files. If the first file throws an error

--- a/src/H5FDhdfs.c
+++ b/src/H5FDhdfs.c
@@ -1220,10 +1220,10 @@ H5FD__hdfs_cmp(const H5FD_t *_f1, const H5FD_t *_f2)
     if (finfo1->mBlockSize != finfo2->mBlockSize) {
         HGOTO_DONE(-1);
     }
-    if (HDstrcmp(finfo1->mOwner, finfo2->mOwner)) {
+    if (strcmp(finfo1->mOwner, finfo2->mOwner)) {
         HGOTO_DONE(-1);
     }
-    if (HDstrcmp(finfo1->mGroup, finfo2->mGroup)) {
+    if (strcmp(finfo1->mGroup, finfo2->mGroup)) {
         HGOTO_DONE(-1);
     }
     if (finfo1->mPermissions != finfo2->mPermissions) {

--- a/src/H5FDint.c
+++ b/src/H5FDint.c
@@ -2921,7 +2921,7 @@ H5FD_check_plugin_load(const H5FD_class_t *cls, const H5PL_key_t *key, bool *suc
     /* Which kind of key are we looking for? */
     if (key->vfd.kind == H5FD_GET_DRIVER_BY_NAME) {
         /* Check if plugin name matches VFD class name */
-        if (cls->name && !HDstrcmp(cls->name, key->vfd.u.name))
+        if (cls->name && !strcmp(cls->name, key->vfd.u.name))
             *success = true;
     }
     else {
@@ -2957,7 +2957,7 @@ H5FD__get_driver_cb(void *obj, hid_t id, void *_op_data)
     FUNC_ENTER_PACKAGE_NOERR
 
     if (H5FD_GET_DRIVER_BY_NAME == op_data->key.kind) {
-        if (0 == HDstrcmp(cls->name, op_data->key.u.name)) {
+        if (0 == strcmp(cls->name, op_data->key.u.name)) {
             op_data->found_id = id;
             ret_value         = H5_ITER_STOP;
         } /* end if */

--- a/src/H5FDlog.c
+++ b/src/H5FDlog.c
@@ -245,9 +245,9 @@ H5FD_log_init(void)
 
     /* Check the use disabled file locks environment variable */
     lock_env_var = HDgetenv(HDF5_USE_FILE_LOCKING);
-    if (lock_env_var && !HDstrcmp(lock_env_var, "BEST_EFFORT"))
+    if (lock_env_var && !strcmp(lock_env_var, "BEST_EFFORT"))
         ignore_disabled_file_locks_s = true; /* Override: Ignore disabled locks */
-    else if (lock_env_var && (!HDstrcmp(lock_env_var, "TRUE") || !HDstrcmp(lock_env_var, "1")))
+    else if (lock_env_var && (!strcmp(lock_env_var, "TRUE") || !strcmp(lock_env_var, "1")))
         ignore_disabled_file_locks_s = false; /* Override: Don't ignore disabled locks */
     else
         ignore_disabled_file_locks_s = FAIL; /* Environment variable not set, or not set correctly */
@@ -501,7 +501,7 @@ H5FD__log_open(const char *name, unsigned flags, hid_t fapl_id, haddr_t maxaddr)
         HGOTO_ERROR(
             H5E_FILE, H5E_CANTOPENFILE, NULL,
             "unable to open file: name = '%s', errno = %d, error message = '%s', flags = %x, o_flags = %x",
-            name, myerrno, HDstrerror(myerrno), flags, (unsigned)o_flags);
+            name, myerrno, strerror(myerrno), flags, (unsigned)o_flags);
     }
 
     /* Stop timer for open() call */
@@ -545,7 +545,7 @@ H5FD__log_open(const char *name, unsigned flags, hid_t fapl_id, haddr_t maxaddr)
 #endif /* H5_HAVE_WIN32_API */
 
     /* Retain a copy of the name used to open the file, for possible error reporting */
-    HDstrncpy(file->filename, name, sizeof(file->filename));
+    strncpy(file->filename, name, sizeof(file->filename));
     file->filename[sizeof(file->filename) - 1] = '\0';
 
     /* Get the flags for logging */
@@ -1239,7 +1239,7 @@ H5FD__log_read(H5FD_t *_file, H5FD_mem_t type, hid_t H5_ATTR_UNUSED dxpl_id, had
                         "file read failed: time = %s, filename = '%s', file descriptor = %d, errno = %d, "
                         "error message = '%s', buf = %p, total read size = %llu, bytes this sub-read = %llu, "
                         "bytes actually read = %llu, offset = %llu",
-                        HDctime(&mytime), file->filename, file->fd, myerrno, HDstrerror(myerrno), buf,
+                        HDctime(&mytime), file->filename, file->fd, myerrno, strerror(myerrno), buf,
                         (unsigned long long)size, (unsigned long long)bytes_in,
                         (unsigned long long)bytes_read, (unsigned long long)offset);
         }
@@ -1458,7 +1458,7 @@ H5FD__log_write(H5FD_t *_file, H5FD_mem_t type, hid_t H5_ATTR_UNUSED dxpl_id, ha
                         "file write failed: time = %s, filename = '%s', file descriptor = %d, errno = %d, "
                         "error message = '%s', buf = %p, total write size = %llu, bytes this sub-write = "
                         "%llu, bytes actually written = %llu, offset = %llu",
-                        HDctime(&mytime), file->filename, file->fd, myerrno, HDstrerror(myerrno), buf,
+                        HDctime(&mytime), file->filename, file->fd, myerrno, strerror(myerrno), buf,
                         (unsigned long long)size, (unsigned long long)bytes_in,
                         (unsigned long long)bytes_wrote, (unsigned long long)offset);
         } /* end if */

--- a/src/H5FDmirror.c
+++ b/src/H5FDmirror.c
@@ -615,7 +615,7 @@ H5FD_mirror_xmit_decode_open(H5FD_mirror_xmit_open_t *out, const unsigned char *
     n_eaten += H5FD__mirror_xmit_decode_uint64(&(out->maxaddr), &buf[n_eaten]);
     n_eaten += H5FD__mirror_xmit_decode_uint64(&(out->size_t_blob), &buf[n_eaten]);
     assert((H5FD_MIRROR_XMIT_OPEN_SIZE - H5FD_MIRROR_XMIT_FILEPATH_MAX) == n_eaten);
-    HDstrncpy(out->filename, (const char *)&buf[n_eaten], H5FD_MIRROR_XMIT_FILEPATH_MAX - 1);
+    strncpy(out->filename, (const char *)&buf[n_eaten], H5FD_MIRROR_XMIT_FILEPATH_MAX - 1);
     out->filename[H5FD_MIRROR_XMIT_FILEPATH_MAX - 1] = 0; /* force final NULL */
 
     return H5FD_MIRROR_XMIT_OPEN_SIZE;
@@ -653,7 +653,7 @@ H5FD_mirror_xmit_decode_reply(H5FD_mirror_xmit_reply_t *out, const unsigned char
     n_eaten += H5FD_mirror_xmit_decode_header(&(out->pub), buf);
     n_eaten += H5FD__mirror_xmit_decode_uint32(&(out->status), &buf[n_eaten]);
     assert((H5FD_MIRROR_XMIT_REPLY_SIZE - H5FD_MIRROR_STATUS_MESSAGE_MAX) == n_eaten);
-    HDstrncpy(out->message, (const char *)&buf[n_eaten], H5FD_MIRROR_STATUS_MESSAGE_MAX - 1);
+    strncpy(out->message, (const char *)&buf[n_eaten], H5FD_MIRROR_STATUS_MESSAGE_MAX - 1);
     out->message[H5FD_MIRROR_STATUS_MESSAGE_MAX - 1] = 0; /* force NULL term */
 
     return H5FD_MIRROR_XMIT_REPLY_SIZE;
@@ -825,7 +825,7 @@ H5FD_mirror_xmit_encode_open(unsigned char *dest, const H5FD_mirror_xmit_open_t 
     n_writ += H5FD__mirror_xmit_encode_uint64(&dest[n_writ], x->maxaddr);
     n_writ += H5FD__mirror_xmit_encode_uint64(&dest[n_writ], x->size_t_blob);
     assert((H5FD_MIRROR_XMIT_OPEN_SIZE - H5FD_MIRROR_XMIT_FILEPATH_MAX) == n_writ);
-    HDstrncpy((char *)&dest[n_writ], x->filename, H5FD_MIRROR_XMIT_FILEPATH_MAX);
+    strncpy((char *)&dest[n_writ], x->filename, H5FD_MIRROR_XMIT_FILEPATH_MAX);
 
     return H5FD_MIRROR_XMIT_OPEN_SIZE;
 } /* end H5FD_mirror_xmit_encode_open() */
@@ -860,7 +860,7 @@ H5FD_mirror_xmit_encode_reply(unsigned char *dest, const H5FD_mirror_xmit_reply_
     n_writ += H5FD_mirror_xmit_encode_header(dest, (const H5FD_mirror_xmit_t *)&(x->pub));
     n_writ += H5FD__mirror_xmit_encode_uint32(&dest[n_writ], x->status);
     assert((H5FD_MIRROR_XMIT_REPLY_SIZE - H5FD_MIRROR_STATUS_MESSAGE_MAX) == n_writ);
-    HDstrncpy((char *)&dest[n_writ], x->message, H5FD_MIRROR_STATUS_MESSAGE_MAX);
+    strncpy((char *)&dest[n_writ], x->message, H5FD_MIRROR_STATUS_MESSAGE_MAX);
 
     return H5FD_MIRROR_XMIT_REPLY_SIZE;
 } /* end H5FD_mirror_xmit_encode_reply() */
@@ -1360,7 +1360,7 @@ H5FD__mirror_open(const char *name, unsigned flags, hid_t fapl_id, haddr_t maxad
 
     if (!name || !*name)
         HGOTO_ERROR(H5E_ARGS, H5E_BADVALUE, NULL, "invalid file name");
-    if (HDstrlen(name) >= H5FD_MIRROR_XMIT_FILEPATH_MAX)
+    if (strlen(name) >= H5FD_MIRROR_XMIT_FILEPATH_MAX)
         HGOTO_ERROR(H5E_ARGS, H5E_BADVALUE, NULL, "filename is too long");
     if (0 == maxaddr || HADDR_UNDEF == maxaddr)
         HGOTO_ERROR(H5E_ARGS, H5E_BADRANGE, NULL, "bogus maxaddr");
@@ -1417,7 +1417,7 @@ H5FD__mirror_open(const char *name, unsigned flags, hid_t fapl_id, haddr_t maxad
     open_xmit->flags       = (uint32_t)flags;
     open_xmit->maxaddr     = (uint64_t)maxaddr;
     open_xmit->size_t_blob = (uint64_t)((size_t)(-1));
-    HDsnprintf(open_xmit->filename, H5FD_MIRROR_XMIT_FILEPATH_MAX - 1, "%s", name);
+    snprintf(open_xmit->filename, H5FD_MIRROR_XMIT_FILEPATH_MAX - 1, "%s", name);
 
     xmit_buf = H5FL_BLK_MALLOC(xmit, H5FD_MIRROR_XMIT_BUFFER_MAX);
     if (NULL == xmit_buf)
@@ -1512,15 +1512,14 @@ done:
              * We can ignore any response from the writer, if we receive
              * any reply at all.
              */
-            if (HDwrite(file->sock_fd, "GOODBYE", HDstrlen("GOODBYE")) < 0) {
+            if (HDwrite(file->sock_fd, "GOODBYE", strlen("GOODBYE")) < 0) {
                 HDONE_ERROR(H5E_ARGS, H5E_BADVALUE, FAIL, "unable to transmit close");
                 if (HDclose(file->sock_fd) < 0)
                     HDONE_ERROR(H5E_VFL, H5E_CANTCLOSEFILE, FAIL, "can't close socket");
                 file->sock_fd = -1; /* invalidate for later */
             }                       /* end if problem writing goodbye; go down hard */
             else if (HDshutdown(file->sock_fd, SHUT_WR) < 0)
-                HDONE_ERROR(H5E_VFL, H5E_BADVALUE, FAIL, "can't shutdown socket write: %s",
-                            HDstrerror(errno));
+                HDONE_ERROR(H5E_VFL, H5E_BADVALUE, FAIL, "can't shutdown socket write: %s", strerror(errno));
         } /* end if xmit encode failed */
 
         if (file->sock_fd >= 0)

--- a/src/H5FDmpio.c
+++ b/src/H5FDmpio.c
@@ -281,7 +281,7 @@ H5FD_mpio_init(void)
 
         /* Check if MPI driver has been loaded dynamically */
         env = HDgetenv(HDF5_DRIVER);
-        if (env && !HDstrcmp(env, "mpio")) {
+        if (env && !strcmp(env, "mpio")) {
             int mpi_initialized = 0;
 
             /* Initialize MPI if not already initialized */

--- a/src/H5FDonion.c
+++ b/src/H5FDonion.c
@@ -464,7 +464,7 @@ H5FD__onion_commit_new_revision_record(H5FD_onion_t *file)
 
     HDtime(&rawtime);
     info = HDgmtime(&rawtime);
-    HDstrftime(rec->time_of_creation, sizeof(rec->time_of_creation), "%Y%m%dT%H%M%SZ", info);
+    strftime(rec->time_of_creation, sizeof(rec->time_of_creation), "%Y%m%dT%H%M%SZ", info);
 
     rec->logical_eof = file->logical_eof;
 
@@ -799,7 +799,7 @@ H5FD__onion_parse_config_str(const char *config_str, H5FD_onion_fapl_info_t *fa)
 
     FUNC_ENTER_PACKAGE
 
-    if (!HDstrcmp(config_str, ""))
+    if (!strcmp(config_str, ""))
         HGOTO_ERROR(H5E_VFL, H5E_BADVALUE, FAIL, "configure string can't be empty");
 
     /* Initialize to the default values */
@@ -810,7 +810,7 @@ H5FD__onion_parse_config_str(const char *config_str, H5FD_onion_fapl_info_t *fa)
     fa->revision_num     = H5FD_ONION_FAPL_INFO_REVISION_ID_LATEST;
     fa->force_write_open = 0;
     fa->creation_flags   = 0;
-    HDstrcpy(fa->comment, "initial comment");
+    strcpy(fa->comment, "initial comment");
 
     /* If a single integer is passed in as a string, it's a shortcut for the tools
      * (h5repack, h5diff, h5dump).  Otherwise, the string should have curly brackets,
@@ -829,51 +829,51 @@ H5FD__onion_parse_config_str(const char *config_str, H5FD_onion_fapl_info_t *fa)
         H5FD__onion_remove_unused_symbols(config_str_copy);
 
         /* The configure string can't be empty after removing the curly brackets */
-        if (!HDstrcmp(config_str_copy, ""))
+        if (!strcmp(config_str_copy, ""))
             HGOTO_ERROR(H5E_VFL, H5E_BADVALUE, FAIL, "configure string can't be empty");
 
-        token1 = HDstrtok(config_str_copy, ":");
-        token2 = HDstrtok(NULL, ";");
+        token1 = strtok(config_str_copy, ":");
+        token2 = strtok(NULL, ";");
 
         do {
             if (token1 && token2) {
-                if (!HDstrcmp(token1, "version")) {
-                    if (!HDstrcmp(token2, "H5FD_ONION_FAPL_INFO_VERSION_CURR"))
+                if (!strcmp(token1, "version")) {
+                    if (!strcmp(token2, "H5FD_ONION_FAPL_INFO_VERSION_CURR"))
                         fa->version = H5FD_ONION_FAPL_INFO_VERSION_CURR;
                 }
-                else if (!HDstrcmp(token1, "backing_fapl_id")) {
-                    if (!HDstrcmp(token2, "H5P_DEFAULT"))
+                else if (!strcmp(token1, "backing_fapl_id")) {
+                    if (!strcmp(token2, "H5P_DEFAULT"))
                         fa->backing_fapl_id = H5P_DEFAULT;
                     else if (!strcmp(token2, "H5I_INVALID_HID"))
                         fa->backing_fapl_id = H5I_INVALID_HID;
                     else
                         fa->backing_fapl_id = strtoll(token2, NULL, 10);
                 }
-                else if (!HDstrcmp(token1, "page_size")) {
+                else if (!strcmp(token1, "page_size")) {
                     fa->page_size = (uint32_t)strtoul(token2, NULL, 10);
                 }
-                else if (!HDstrcmp(token1, "revision_num")) {
-                    if (!HDstrcmp(token2, "H5FD_ONION_FAPL_INFO_REVISION_ID_LATEST"))
+                else if (!strcmp(token1, "revision_num")) {
+                    if (!strcmp(token2, "H5FD_ONION_FAPL_INFO_REVISION_ID_LATEST"))
                         fa->revision_num = H5FD_ONION_FAPL_INFO_REVISION_ID_LATEST;
                     else
                         fa->revision_num = (uint64_t)strtoull(token2, NULL, 10);
                 }
-                else if (!HDstrcmp(token1, "force_write_open")) {
+                else if (!strcmp(token1, "force_write_open")) {
                     fa->force_write_open = (uint8_t)strtoul(token2, NULL, 10);
                 }
-                else if (!HDstrcmp(token1, "creation_flags")) {
+                else if (!strcmp(token1, "creation_flags")) {
                     fa->creation_flags = (uint8_t)strtoul(token2, NULL, 10);
                 }
-                else if (!HDstrcmp(token1, "comment")) {
-                    HDstrcpy(fa->comment, token2);
+                else if (!strcmp(token1, "comment")) {
+                    strcpy(fa->comment, token2);
                 }
                 else
                     HGOTO_ERROR(H5E_VFL, H5E_BADVALUE, FAIL, "unknown token in the configure string: %s",
                                 token1);
             }
 
-            token1 = HDstrtok(NULL, ":");
-            token2 = HDstrtok(NULL, ";");
+            token1 = strtok(NULL, ":");
+            token2 = strtok(NULL, ";");
         } while (token1);
     }
 
@@ -960,18 +960,18 @@ H5FD__onion_open(const char *filename, unsigned flags, hid_t fapl_id, haddr_t ma
         HGOTO_ERROR(H5E_VFL, H5E_CANTALLOC, NULL, "unable to allocate file struct");
 
     /* Allocate space for onion VFD file names */
-    if (NULL == (name_onion = H5MM_malloc(sizeof(char) * (HDstrlen(filename) + 7))))
+    if (NULL == (name_onion = H5MM_malloc(sizeof(char) * (strlen(filename) + 7))))
         HGOTO_ERROR(H5E_VFL, H5E_CANTALLOC, NULL, "unable to allocate onion name string");
-    HDsnprintf(name_onion, HDstrlen(filename) + 7, "%s.onion", filename);
+    snprintf(name_onion, strlen(filename) + 7, "%s.onion", filename);
 
-    if (NULL == (recovery_file_nameery = H5MM_malloc(sizeof(char) * (HDstrlen(name_onion) + 10))))
+    if (NULL == (recovery_file_nameery = H5MM_malloc(sizeof(char) * (strlen(name_onion) + 10))))
         HGOTO_ERROR(H5E_VFL, H5E_CANTALLOC, NULL, "unable to allocate recovery name string");
-    HDsnprintf(recovery_file_nameery, HDstrlen(name_onion) + 10, "%s.recovery", name_onion);
+    snprintf(recovery_file_nameery, strlen(name_onion) + 10, "%s.recovery", name_onion);
     file->recovery_file_name = recovery_file_nameery;
 
-    if (NULL == (file->recovery_file_name = H5MM_malloc(sizeof(char) * (HDstrlen(name_onion) + 10))))
+    if (NULL == (file->recovery_file_name = H5MM_malloc(sizeof(char) * (strlen(name_onion) + 10))))
         HGOTO_ERROR(H5E_VFL, H5E_CANTALLOC, NULL, "unable to allocate recovery name string");
-    HDsnprintf(file->recovery_file_name, HDstrlen(name_onion) + 10, "%s.recovery", name_onion);
+    snprintf(file->recovery_file_name, strlen(name_onion) + 10, "%s.recovery", name_onion);
 
     /* Translate H5P_DEFAULT to a real fapl ID, if necessary */
     backing_fapl_id = H5FD__onion_get_legit_fapl_id(file->fa.backing_fapl_id);
@@ -1191,7 +1191,7 @@ H5FD__onion_open(const char *filename, unsigned flags, hid_t fapl_id, haddr_t ma
             HGOTO_ERROR(H5E_VFL, H5E_CANTALLOC, NULL, "unable to duplicate comment string");
 
         /* TODO: Lengths of strings should be size_t */
-        file->curr_rev_record.comment_size = (uint32_t)HDstrlen(fa->comment) + 1;
+        file->curr_rev_record.comment_size = (uint32_t)strlen(fa->comment) + 1;
     }
     file->origin_eof  = file->header.origin_eof;
     file->logical_eof = MAX(file->curr_rev_record.logical_eof, file->logical_eof);
@@ -1670,7 +1670,7 @@ H5FDonion_get_revision_count(const char *filename, hid_t fapl_id, uint64_t *revi
     H5TRACE3("e", "*six", filename, fapl_id, revision_count);
 
     /* Check args */
-    if (!filename || !HDstrcmp(filename, ""))
+    if (!filename || !strcmp(filename, ""))
         HGOTO_ERROR(H5E_ARGS, H5E_BADVALUE, FAIL, "not a valid file name");
     if (!revision_count)
         HGOTO_ERROR(H5E_ARGS, H5E_BADVALUE, FAIL, "revision count can't be null");

--- a/src/H5FDonion_header.c
+++ b/src/H5FDonion_header.c
@@ -134,7 +134,7 @@ H5FD__onion_header_decode(unsigned char *buf, H5FD_onion_header_t *header)
     assert(header != NULL);
     assert(H5FD_ONION_HEADER_VERSION_CURR == header->version);
 
-    if (HDstrncmp((const char *)buf, H5FD_ONION_HEADER_SIGNATURE, 4))
+    if (strncmp((const char *)buf, H5FD_ONION_HEADER_SIGNATURE, 4))
         HGOTO_ERROR(H5E_ARGS, H5E_BADVALUE, 0, "invalid header signature");
 
     if (buf[4] != H5FD_ONION_HEADER_VERSION_CURR)

--- a/src/H5FDonion_history.c
+++ b/src/H5FDonion_history.c
@@ -172,7 +172,7 @@ H5FD__onion_history_decode(unsigned char *buf, H5FD_onion_history_t *history)
     assert(history != NULL);
     assert(H5FD_ONION_HISTORY_VERSION_CURR == history->version);
 
-    if (HDstrncmp((const char *)buf, H5FD_ONION_HISTORY_SIGNATURE, 4))
+    if (strncmp((const char *)buf, H5FD_ONION_HISTORY_SIGNATURE, 4))
         HGOTO_ERROR(H5E_ARGS, H5E_BADVALUE, 0, "invalid signature");
 
     if (H5FD_ONION_HISTORY_VERSION_CURR != buf[4])

--- a/src/H5FDonion_index.c
+++ b/src/H5FDonion_index.c
@@ -604,7 +604,7 @@ H5FD__onion_revision_record_decode(unsigned char *buf, H5FD_onion_revision_recor
     assert(H5FD_ONION_REVISION_RECORD_VERSION_CURR == record->version);
     assert(H5FD_ONION_ARCHIVAL_INDEX_VERSION_CURR == record->archival_index.version);
 
-    if (HDstrncmp((const char *)buf, H5FD_ONION_REVISION_RECORD_SIGNATURE, 4))
+    if (strncmp((const char *)buf, H5FD_ONION_REVISION_RECORD_SIGNATURE, 4))
         HGOTO_ERROR(H5E_ARGS, H5E_BADVALUE, 0, "invalid signature");
 
     if (H5FD_ONION_REVISION_RECORD_VERSION_CURR != buf[4])

--- a/src/H5FDros3.c
+++ b/src/H5FDros3.c
@@ -623,7 +623,7 @@ H5Pget_fapl_ros3_token(hid_t fapl_id, size_t size, char *token_dst /*out*/)
     }
 
     /* Copy the token data out */
-    tokenlen = HDstrlen(token_src);
+    tokenlen = strlen(token_src);
     if (size <= tokenlen) {
         tokenlen = size - 1;
     }
@@ -659,7 +659,7 @@ H5FD__ros3_str_token_copy(const char H5_ATTR_UNUSED *name, size_t H5_ATTR_UNUSED
 #endif
 
     if (*value)
-        if (NULL == (*value = HDstrdup(*value)))
+        if (NULL == (*value = strdup(*value)))
             HGOTO_ERROR(H5E_RESOURCE, H5E_CANTALLOC, FAIL, "can't copy string property token");
 
 done:
@@ -691,7 +691,7 @@ H5FD__ros3_str_token_cmp(const void *_value1, const void *_value2, size_t H5_ATT
 
     if (*value1) {
         if (*value2)
-            ret_value = HDstrcmp(*value1, *value2);
+            ret_value = strcmp(*value1, *value2);
         else
             ret_value = 1;
     }
@@ -798,7 +798,7 @@ H5Pset_fapl_ros3_token(hid_t fapl_id, const char *token)
         HGOTO_ERROR(H5E_PLIST, H5E_BADTYPE, FAIL, "not a file access property list");
     if (H5FD_ROS3 != H5P_peek_driver(plist))
         HGOTO_ERROR(H5E_PLIST, H5E_BADVALUE, FAIL, "incorrect VFL driver");
-    if (HDstrlen(token) > H5FD_ROS3_MAX_SECRET_TOK_LEN)
+    if (strlen(token) > H5FD_ROS3_MAX_SECRET_TOK_LEN)
         HGOTO_ERROR(H5E_PLIST, H5E_BADVALUE, FAIL,
                     "specified token exceeds the internally specified maximum string length");
 
@@ -809,13 +809,13 @@ H5Pset_fapl_ros3_token(hid_t fapl_id, const char *token)
         if (H5P_get(plist, ROS3_TOKEN_PROP_NAME, &token_src) < 0)
             HGOTO_ERROR(H5E_PLIST, H5E_CANTGET, FAIL, "unable to get token value");
 
-        H5MM_memcpy(token_src, token, HDstrlen(token) + 1);
+        H5MM_memcpy(token_src, token, strlen(token) + 1);
     }
     else {
         token_src = (char *)malloc(sizeof(char) * (H5FD_ROS3_MAX_SECRET_TOK_LEN + 1));
         if (token_src == NULL)
             HGOTO_ERROR(H5E_RESOURCE, H5E_NOSPACE, FAIL, "cannot make space for token_src variable.");
-        H5MM_memcpy(token_src, token, HDstrlen(token) + 1);
+        H5MM_memcpy(token_src, token, strlen(token) + 1);
         if (H5P_insert(plist, ROS3_TOKEN_PROP_NAME, sizeof(char *), &token_src, NULL, NULL, NULL, NULL,
                        H5FD__ros3_str_token_delete, H5FD__ros3_str_token_copy, H5FD__ros3_str_token_cmp,
                        H5FD__ros3_str_token_close) < 0)
@@ -1398,16 +1398,16 @@ H5FD__ros3_cmp(const H5FD_t *_f1, const H5FD_t *_f2)
     assert(purl2->host != NULL);
 
     /* URL: SCHEME */
-    if (HDstrcmp(purl1->scheme, purl2->scheme))
+    if (strcmp(purl1->scheme, purl2->scheme))
         HGOTO_DONE(-1);
 
     /* URL: HOST */
-    if (HDstrcmp(purl1->host, purl2->host))
+    if (strcmp(purl1->host, purl2->host))
         HGOTO_DONE(-1);
 
     /* URL: PORT */
     if (purl1->port && purl2->port) {
-        if (HDstrcmp(purl1->port, purl2->port))
+        if (strcmp(purl1->port, purl2->port))
             HGOTO_DONE(-1);
     }
     else if (purl1->port)
@@ -1417,7 +1417,7 @@ H5FD__ros3_cmp(const H5FD_t *_f1, const H5FD_t *_f2)
 
     /* URL: PATH */
     if (purl1->path && purl2->path) {
-        if (HDstrcmp(purl1->path, purl2->path))
+        if (strcmp(purl1->path, purl2->path))
             HGOTO_DONE(-1);
     }
     else if (purl1->path && !purl2->path)
@@ -1427,7 +1427,7 @@ H5FD__ros3_cmp(const H5FD_t *_f1, const H5FD_t *_f2)
 
     /* URL: QUERY */
     if (purl1->query && purl2->query) {
-        if (HDstrcmp(purl1->query, purl2->query))
+        if (strcmp(purl1->query, purl2->query))
             HGOTO_DONE(-1);
     }
     else if (purl1->query && !purl2->query)
@@ -1437,7 +1437,7 @@ H5FD__ros3_cmp(const H5FD_t *_f1, const H5FD_t *_f2)
 
     /* FAPL: AWS_REGION */
     if (f1->fa.aws_region[0] != '\0' && f2->fa.aws_region[0] != '\0') {
-        if (HDstrcmp(f1->fa.aws_region, f2->fa.aws_region))
+        if (strcmp(f1->fa.aws_region, f2->fa.aws_region))
             HGOTO_DONE(-1);
     }
     else if (f1->fa.aws_region[0] != '\0')
@@ -1447,7 +1447,7 @@ H5FD__ros3_cmp(const H5FD_t *_f1, const H5FD_t *_f2)
 
     /* FAPL: SECRET_ID */
     if (f1->fa.secret_id[0] != '\0' && f2->fa.secret_id[0] != '\0') {
-        if (HDstrcmp(f1->fa.secret_id, f2->fa.secret_id))
+        if (strcmp(f1->fa.secret_id, f2->fa.secret_id))
             HGOTO_DONE(-1);
     }
     else if (f1->fa.secret_id[0] != '\0')
@@ -1457,7 +1457,7 @@ H5FD__ros3_cmp(const H5FD_t *_f1, const H5FD_t *_f2)
 
     /* FAPL: SECRET_KEY */
     if (f1->fa.secret_key[0] != '\0' && f2->fa.secret_key[0] != '\0') {
-        if (HDstrcmp(f1->fa.secret_key, f2->fa.secret_key))
+        if (strcmp(f1->fa.secret_key, f2->fa.secret_key))
             HGOTO_DONE(-1);
     }
     else if (f1->fa.secret_key[0] != '\0')

--- a/src/H5FDs3comms.c
+++ b/src/H5FDs3comms.c
@@ -227,7 +227,7 @@ H5FD_s3comms_hrb_node_set(hrb_node_t **L, const char *name, const char *value)
 
     if (name == NULL)
         HGOTO_ERROR(H5E_ARGS, H5E_BADVALUE, FAIL, "unable to operate on null name");
-    namelen = HDstrlen(name);
+    namelen = strlen(name);
 
     /***********************
      * PREPARE ALL STRINGS *
@@ -248,7 +248,7 @@ H5FD_s3comms_hrb_node_set(hrb_node_t **L, const char *name, const char *value)
      */
     if (value != NULL) {
         int    ret      = 0;
-        size_t valuelen = HDstrlen(value);
+        size_t valuelen = strlen(value);
         size_t catlen   = namelen + valuelen + 2; /* +2 from ": " */
         size_t catwrite = catlen + 3;             /* 3 not 1 to quiet compiler warning */
 
@@ -265,10 +265,10 @@ H5FD_s3comms_hrb_node_set(hrb_node_t **L, const char *name, const char *value)
         nvcat = (char *)H5MM_malloc(sizeof(char) * catwrite);
         if (nvcat == NULL)
             HGOTO_ERROR(H5E_RESOURCE, H5E_NOSPACE, FAIL, "cannot make space for concatenated string.");
-        ret = HDsnprintf(nvcat, catwrite, "%s: %s", name, value);
+        ret = snprintf(nvcat, catwrite, "%s: %s", name, value);
         if (ret < 0 || (size_t)ret > catlen)
             HGOTO_ERROR(H5E_ARGS, H5E_BADVALUE, FAIL, "cannot concatenate `%s: %s", name, value);
-        assert(catlen == HDstrlen(nvcat));
+        assert(catlen == strlen(nvcat));
 
         /* create new_node, should we need it
          */
@@ -318,7 +318,7 @@ H5FD_s3comms_hrb_node_set(hrb_node_t **L, const char *name, const char *value)
 
     /* Check whether to modify/remove first node in list
      */
-    if (HDstrcmp(lowername, node_ptr->lowername) == 0) {
+    if (strcmp(lowername, node_ptr->lowername) == 0) {
 
         is_looking = false;
 
@@ -396,7 +396,7 @@ H5FD_s3comms_hrb_node_set(hrb_node_t **L, const char *name, const char *value)
             new_node = NULL;
         }
     }
-    else if (HDstrcmp(lowername, node_ptr->lowername) < 0) {
+    else if (strcmp(lowername, node_ptr->lowername) < 0) {
 
         is_looking = false;
 
@@ -440,7 +440,7 @@ H5FD_s3comms_hrb_node_set(hrb_node_t **L, const char *name, const char *value)
                  * APPEND NEW NODE *
                  *******************/
 
-                assert(HDstrcmp(lowername, node_ptr->lowername) > 0);
+                assert(strcmp(lowername, node_ptr->lowername) > 0);
                 new_node->name      = namecpy;
                 new_node->value     = valuecpy;
                 new_node->lowername = lowername;
@@ -448,7 +448,7 @@ H5FD_s3comms_hrb_node_set(hrb_node_t **L, const char *name, const char *value)
                 node_ptr->next      = new_node;
             }
         }
-        else if (HDstrcmp(lowername, node_ptr->next->lowername) < 0) {
+        else if (strcmp(lowername, node_ptr->next->lowername) < 0) {
 
             is_looking = false;
 
@@ -463,7 +463,7 @@ H5FD_s3comms_hrb_node_set(hrb_node_t **L, const char *name, const char *value)
                  * INSERT NEW NODE *
                  *******************/
 
-                assert(HDstrcmp(lowername, node_ptr->lowername) > 0);
+                assert(strcmp(lowername, node_ptr->lowername) > 0);
                 new_node->name      = namecpy;
                 new_node->value     = valuecpy;
                 new_node->lowername = lowername;
@@ -472,7 +472,7 @@ H5FD_s3comms_hrb_node_set(hrb_node_t **L, const char *name, const char *value)
                 node_ptr->next      = new_node;
             }
         }
-        else if (HDstrcmp(lowername, node_ptr->next->lowername) == 0) {
+        else if (strcmp(lowername, node_ptr->next->lowername) == 0) {
 
             is_looking = false;
 
@@ -681,7 +681,7 @@ H5FD_s3comms_hrb_init_request(const char *_verb, const char *_resource, const ch
     request->first_header = NULL;
 
     /* malloc and copy strings for the structure */
-    reslen = HDstrlen(_resource);
+    reslen = strlen(_resource);
 
     if (_resource[0] == '/') {
         res = (char *)H5MM_malloc(sizeof(char) * (reslen + 1));
@@ -695,20 +695,20 @@ H5FD_s3comms_hrb_init_request(const char *_verb, const char *_resource, const ch
             HGOTO_ERROR(H5E_ARGS, H5E_CANTALLOC, NULL, "no space for resource string");
         *res = '/';
         H5MM_memcpy((&res[1]), _resource, (reslen + 1));
-        assert((reslen + 1) == HDstrlen(res));
+        assert((reslen + 1) == strlen(res));
     } /* end if (else resource string not starting with '/') */
 
-    verblen = HDstrlen(_verb) + 1;
+    verblen = strlen(_verb) + 1;
     verb    = (char *)H5MM_malloc(sizeof(char) * verblen);
     if (verb == NULL)
         HGOTO_ERROR(H5E_ARGS, H5E_BADVALUE, NULL, "no space for verb string");
-    HDstrncpy(verb, _verb, verblen);
+    strncpy(verb, _verb, verblen);
 
-    vrsnlen = HDstrlen(_http_version) + 1;
+    vrsnlen = strlen(_http_version) + 1;
     vrsn    = (char *)H5MM_malloc(sizeof(char) * vrsnlen);
     if (vrsn == NULL)
         HGOTO_ERROR(H5E_ARGS, H5E_BADVALUE, NULL, "no space for http-version string");
-    HDstrncpy(vrsn, _http_version, vrsnlen);
+    strncpy(vrsn, _http_version, vrsnlen);
 
     /* place new copies into structure */
     request->resource = res;
@@ -925,8 +925,8 @@ H5FD_s3comms_s3r_getsize(s3r_t *handle)
         HGOTO_ERROR(H5E_ARGS, H5E_BADVALUE, FAIL, "could not find \"Content-Length\" in response.");
 
     /* move "start" to beginning of value in line; find end of line */
-    start = start + HDstrlen("\r\nContent-Length: ");
-    end   = HDstrstr(start, "\r\n");
+    start = start + strlen("\r\nContent-Length: ");
+    end   = strstr(start, "\r\n");
     if (end == NULL)
         HGOTO_ERROR(H5E_ARGS, H5E_BADVALUE, FAIL, "could not find end of content length line");
 
@@ -1059,13 +1059,13 @@ H5FD_s3comms_s3r_open(const char *url, const char *region, const char *id, const
             HGOTO_ERROR(H5E_ARGS, H5E_BADVALUE, NULL, "token cannot be null.");
 
         /* copy strings */
-        tmplen         = HDstrlen(region) + 1;
+        tmplen         = strlen(region) + 1;
         handle->region = (char *)H5MM_malloc(sizeof(char) * tmplen);
         if (handle->region == NULL)
             HGOTO_ERROR(H5E_ARGS, H5E_BADVALUE, NULL, "could not malloc space for handle region copy.");
         H5MM_memcpy(handle->region, region, tmplen);
 
-        tmplen            = HDstrlen(id) + 1;
+        tmplen            = strlen(id) + 1;
         handle->secret_id = (char *)H5MM_malloc(sizeof(char) * tmplen);
         if (handle->secret_id == NULL)
             HGOTO_ERROR(H5E_ARGS, H5E_BADVALUE, NULL, "could not malloc space for handle ID copy.");
@@ -1077,7 +1077,7 @@ H5FD_s3comms_s3r_open(const char *url, const char *region, const char *id, const
             HGOTO_ERROR(H5E_ARGS, H5E_BADVALUE, NULL, "could not malloc space for handle key copy.");
         H5MM_memcpy(handle->signing_key, signing_key, tmplen);
 
-        tmplen        = HDstrlen(token) + 1;
+        tmplen        = strlen(token) + 1;
         handle->token = (char *)H5MM_malloc(sizeof(char) * tmplen);
         if (handle->token == NULL)
             HGOTO_ERROR(H5E_ARGS, H5E_BADVALUE, NULL, "could not malloc space for handle token copy.");
@@ -1203,7 +1203,7 @@ H5FD_s3comms_s3r_read(s3r_t *handle, haddr_t offset, size_t len, void *dest)
     char              *rangebytesstr = NULL;
     hrb_t             *request       = NULL;
     int                ret           = 0; /* working variable to check  */
-                                          /* return value of HDsnprintf  */
+                                          /* return value of snprintf  */
     char                  *authorization  = NULL;
     char                  *buffer1        = NULL;
     char                  *signed_headers = NULL;
@@ -1259,8 +1259,8 @@ H5FD_s3comms_s3r_read(s3r_t *handle, haddr_t offset, size_t len, void *dest)
         rangebytesstr = (char *)H5MM_malloc(sizeof(char) * (S3COMMS_MAX_RANGE_STRING_SIZE + 1));
         if (rangebytesstr == NULL)
             HGOTO_ERROR(H5E_ARGS, H5E_CANTALLOC, FAIL, "could not malloc range format string.");
-        ret = HDsnprintf(rangebytesstr, (S3COMMS_MAX_RANGE_STRING_SIZE), "bytes=%" PRIuHADDR "-%" PRIuHADDR,
-                         offset, offset + len - 1);
+        ret = snprintf(rangebytesstr, (S3COMMS_MAX_RANGE_STRING_SIZE), "bytes=%" PRIuHADDR "-%" PRIuHADDR,
+                       offset, offset + len - 1);
         if (ret <= 0 || ret >= S3COMMS_MAX_RANGE_STRING_SIZE)
             HGOTO_ERROR(H5E_ARGS, H5E_BADVALUE, FAIL, "unable to format HTTP Range value");
     }
@@ -1268,7 +1268,7 @@ H5FD_s3comms_s3r_read(s3r_t *handle, haddr_t offset, size_t len, void *dest)
         rangebytesstr = (char *)H5MM_malloc(sizeof(char) * (S3COMMS_MAX_RANGE_STRING_SIZE + 1));
         if (rangebytesstr == NULL)
             HGOTO_ERROR(H5E_ARGS, H5E_CANTALLOC, FAIL, "could not malloc range format string.");
-        ret = HDsnprintf(rangebytesstr, (S3COMMS_MAX_RANGE_STRING_SIZE), "bytes=%" PRIuHADDR "-", offset);
+        ret = snprintf(rangebytesstr, (S3COMMS_MAX_RANGE_STRING_SIZE), "bytes=%" PRIuHADDR "-", offset);
         if (ret <= 0 || ret >= S3COMMS_MAX_RANGE_STRING_SIZE)
             HGOTO_ERROR(H5E_ARGS, H5E_BADVALUE, FAIL, "unable to format HTTP Range value");
     }
@@ -1288,7 +1288,7 @@ H5FD_s3comms_s3r_read(s3r_t *handle, haddr_t offset, size_t len, void *dest)
             /* Pass in range directly */
             char *bytesrange_ptr = NULL; /* pointer past "bytes=" portion */
 
-            bytesrange_ptr = HDstrchr(rangebytesstr, '=');
+            bytesrange_ptr = strchr(rangebytesstr, '=');
             assert(bytesrange_ptr != NULL);
             bytesrange_ptr++; /* move to first char past '=' */
             assert(*bytesrange_ptr != '\0');
@@ -1376,7 +1376,7 @@ H5FD_s3comms_s3r_read(s3r_t *handle, haddr_t offset, size_t len, void *dest)
             HGOTO_ERROR(H5E_ARGS, H5E_BADVALUE, FAIL, "problem building headers list.");
         assert(headers->magic == S3COMMS_HRB_NODE_MAGIC);
 
-        if (HDstrlen((const char *)handle->token) > 0) {
+        if (strlen((const char *)handle->token) > 0) {
             if (FAIL ==
                 H5FD_s3comms_hrb_node_set(&headers, "x-amz-security-token", (const char *)handle->token))
                 HGOTO_ERROR(H5E_ARGS, H5E_BADVALUE, FAIL, "unable to set x-amz-security-token header");
@@ -1414,7 +1414,7 @@ H5FD_s3comms_s3r_read(s3r_t *handle, haddr_t offset, size_t len, void *dest)
             HGOTO_ERROR(H5E_ARGS, H5E_BADVALUE, FAIL, "bad string-to-sign");
         /* buffer1 -> signature */
         if (FAIL == H5FD_s3comms_HMAC_SHA256(handle->signing_key, SHA256_DIGEST_LENGTH, buffer2,
-                                             HDstrlen(buffer2), buffer1))
+                                             strlen(buffer2), buffer1))
             HGOTO_ERROR(H5E_ARGS, H5E_BADVALUE, FAIL, "bad signature");
 
         iso8601now[8] = 0; /* trim to yyyyMMDD */
@@ -1422,9 +1422,9 @@ H5FD_s3comms_s3r_read(s3r_t *handle, haddr_t offset, size_t len, void *dest)
         if (ret == 0 || ret >= S3COMMS_MAX_CREDENTIAL_SIZE)
             HGOTO_ERROR(H5E_ARGS, H5E_BADVALUE, FAIL, "unable to format aws4 credential string");
 
-        ret = HDsnprintf(authorization, 512 + H5FD_ROS3_MAX_SECRET_TOK_LEN,
-                         "AWS4-HMAC-SHA256 Credential=%s,SignedHeaders=%s,Signature=%s", buffer2,
-                         signed_headers, buffer1);
+        ret = snprintf(authorization, 512 + H5FD_ROS3_MAX_SECRET_TOK_LEN,
+                       "AWS4-HMAC-SHA256 Credential=%s,SignedHeaders=%s,Signature=%s", buffer2,
+                       signed_headers, buffer1);
         if (ret <= 0 || ret >= 512 + H5FD_ROS3_MAX_SECRET_TOK_LEN)
             HGOTO_ERROR(H5E_ARGS, H5E_BADVALUE, FAIL, "unable to format aws4 authorization string");
 
@@ -1674,14 +1674,14 @@ H5FD_s3comms_aws_canonical_request(char *canonical_request_dest, int _cr_size, c
         HGOTO_ERROR(H5E_ARGS, H5E_BADVALUE, FAIL, "signed headers destination cannot be null.");
 
     /* HTTP verb, resource path, and query string lines */
-    cr_len = (HDstrlen(http_request->verb) + HDstrlen(http_request->resource) + HDstrlen(query_params) +
+    cr_len = (strlen(http_request->verb) + strlen(http_request->resource) + strlen(query_params) +
               (size_t)3); /* three newline chars */
     if (cr_len >= cr_size)
         HGOTO_ERROR(H5E_ARGS, H5E_BADVALUE, FAIL, "not enough space in canonical request");
 
     /* TODO: compiler warning */
-    ret = HDsnprintf(canonical_request_dest, (cr_size - 1), "%s\n%s\n%s\n", http_request->verb,
-                     http_request->resource, query_params);
+    ret = snprintf(canonical_request_dest, (cr_size - 1), "%s\n%s\n%s\n", http_request->verb,
+                   http_request->resource, query_params);
     if (ret < 0 || (size_t)ret >= cr_size)
         HGOTO_ERROR(H5E_ARGS, H5E_BADVALUE, FAIL, "unable to compose canonical request first line");
 
@@ -1691,38 +1691,38 @@ H5FD_s3comms_aws_canonical_request(char *canonical_request_dest, int _cr_size, c
 
         assert(node->magic == S3COMMS_HRB_NODE_MAGIC);
 
-        ret = HDsnprintf(tmpstr, 1024, "%s:%s\n", node->lowername, node->value);
+        ret = snprintf(tmpstr, 1024, "%s:%s\n", node->lowername, node->value);
         if (ret < 0 || ret >= 1024)
             HGOTO_ERROR(H5E_ARGS, H5E_BADVALUE, FAIL, "unable to concatenate HTTP header %s:%s",
                         node->lowername, node->value);
-        cr_len += HDstrlen(tmpstr);
+        cr_len += strlen(tmpstr);
         if (cr_len + 1 > cr_size)
             HGOTO_ERROR(H5E_ARGS, H5E_BADVALUE, FAIL, "not enough space in canonical request");
-        HDstrcat(canonical_request_dest, tmpstr);
+        strcat(canonical_request_dest, tmpstr);
 
-        ret = HDsnprintf(tmpstr, 1024, "%s;", node->lowername);
+        ret = snprintf(tmpstr, 1024, "%s;", node->lowername);
         if (ret < 0 || ret >= 1024)
             HGOTO_ERROR(H5E_ARGS, H5E_BADVALUE, FAIL, "unable to append semicolon to lowername %s",
                         node->lowername);
-        sh_len += HDstrlen(tmpstr);
+        sh_len += strlen(tmpstr);
         if (sh_len + 1 > sh_size)
             HGOTO_ERROR(H5E_ARGS, H5E_BADVALUE, FAIL, "not enough space in signed headers");
-        HDstrcat(signed_headers_dest, tmpstr);
+        strcat(signed_headers_dest, tmpstr);
 
         node = node->next;
     } /* end while node is not NULL */
 
     /* remove trailing ';' from signed headers sequence */
-    signed_headers_dest[HDstrlen(signed_headers_dest) - 1] = '\0';
+    signed_headers_dest[strlen(signed_headers_dest) - 1] = '\0';
 
     /* append signed headers and payload hash
      * NOTE: at present, no HTTP body is handled, per the nature of
      *       requests/range-gets
      */
-    HDstrcat(canonical_request_dest, "\n");
-    HDstrcat(canonical_request_dest, signed_headers_dest);
-    HDstrcat(canonical_request_dest, "\n");
-    HDstrcat(canonical_request_dest, EMPTY_SHA256);
+    strcat(canonical_request_dest, "\n");
+    strcat(canonical_request_dest, signed_headers_dest);
+    strcat(canonical_request_dest, "\n");
+    strcat(canonical_request_dest, EMPTY_SHA256);
 
 done:
     FUNC_LEAVE_NOAPI(ret_value)
@@ -1774,8 +1774,8 @@ H5FD_s3comms_bytes_to_hex(char *dest, const unsigned char *msg, size_t msg_len, 
         HGOTO_ERROR(H5E_ARGS, H5E_BADVALUE, FAIL, "bytes sequence cannot be null.");
 
     for (i = 0; i < msg_len; i++) {
-        int chars_written = HDsnprintf(&(dest[i * 2]), 3, /* 'X', 'X', '\n' */
-                                       (lowercase == true) ? "%02x" : "%02X", msg[i]);
+        int chars_written = snprintf(&(dest[i * 2]), 3, /* 'X', 'X', '\n' */
+                                     (lowercase == true) ? "%02x" : "%02X", msg[i]);
         if (chars_written != 2)
             HGOTO_ERROR(H5E_ARGS, H5E_BADVALUE, FAIL, "problem while writing hex chars for %c", msg[i]);
     }
@@ -1957,7 +1957,7 @@ H5FD__s3comms_load_aws_creds_from_file(FILE *file, const char *profile_name, cha
 #endif
 
     /* format target line for start of profile */
-    if (32 < HDsnprintf(profile_line, 32, "[%s]", profile_name))
+    if (32 < snprintf(profile_line, 32, "[%s]", profile_name))
         HGOTO_ERROR(H5E_ARGS, H5E_CANTCOPY, FAIL, "unable to format profile label");
 
     /* look for start of profile */
@@ -1966,10 +1966,10 @@ H5FD__s3comms_load_aws_creds_from_file(FILE *file, const char *profile_name, cha
         for (buffer_i = 0; buffer_i < 128; buffer_i++)
             buffer[buffer_i] = 0;
 
-        line_buffer = HDfgets(line_buffer, 128, file);
+        line_buffer = fgets(line_buffer, 128, file);
         if (line_buffer == NULL) /* reached end of file */
             goto done;
-    } while (HDstrncmp(line_buffer, profile_line, HDstrlen(profile_line)));
+    } while (strncmp(line_buffer, profile_line, strlen(profile_line)));
 
     /* extract credentials from lines */
     do {
@@ -1978,7 +1978,7 @@ H5FD__s3comms_load_aws_creds_from_file(FILE *file, const char *profile_name, cha
             buffer[buffer_i] = 0;
 
         /* collect a line from file */
-        line_buffer = HDfgets(line_buffer, 128, file);
+        line_buffer = fgets(line_buffer, 128, file);
         if (line_buffer == NULL)
             goto done; /* end of file */
 
@@ -1989,12 +1989,12 @@ H5FD__s3comms_load_aws_creds_from_file(FILE *file, const char *profile_name, cha
             char        line_prefix[128];
 
             setting_name     = setting_names[setting_i];
-            setting_name_len = HDstrlen(setting_name);
-            if (HDsnprintf(line_prefix, 128, "%s=", setting_name) < 0)
+            setting_name_len = strlen(setting_name);
+            if (snprintf(line_prefix, 128, "%s=", setting_name) < 0)
                 HGOTO_ERROR(H5E_ARGS, H5E_CANTCOPY, FAIL, "unable to format line prefix");
 
             /* found a matching name? */
-            if (!HDstrncmp(line_buffer, line_prefix, setting_name_len + 1)) {
+            if (!strncmp(line_buffer, line_prefix, setting_name_len + 1)) {
                 found_setting = 1;
 
                 /* skip NULL destination buffer */
@@ -2011,7 +2011,7 @@ H5FD__s3comms_load_aws_creds_from_file(FILE *file, const char *profile_name, cha
                 line_buffer++; /* was pointing at '='; advance */
 
                 /* copy line buffer into out pointer */
-                HDstrncpy(setting_pointers[setting_i], (const char *)line_buffer, HDstrlen(line_buffer));
+                strncpy(setting_pointers[setting_i], (const char *)line_buffer, strlen(line_buffer));
 
                 /* "trim" tailing whitespace by replacing with null terminator*/
                 buffer_i = 0;
@@ -2074,13 +2074,13 @@ H5FD_s3comms_load_aws_profile(const char *profile_name, char *key_id_out, char *
 #endif
 
 #ifdef H5_HAVE_WIN32_API
-    ret = HDsnprintf(awspath, 117, "%s/.aws/", HDgetenv("USERPROFILE"));
+    ret = snprintf(awspath, 117, "%s/.aws/", HDgetenv("USERPROFILE"));
 #else
-    ret = HDsnprintf(awspath, 117, "%s/.aws/", HDgetenv("HOME"));
+    ret = snprintf(awspath, 117, "%s/.aws/", HDgetenv("HOME"));
 #endif
     if (ret < 0 || (size_t)ret >= 117)
         HGOTO_ERROR(H5E_ARGS, H5E_CANTCOPY, FAIL, "unable to format home-aws path");
-    ret = HDsnprintf(filepath, 128, "%s%s", awspath, "credentials");
+    ret = snprintf(filepath, 128, "%s%s", awspath, "credentials");
     if (ret < 0 || (size_t)ret >= 128)
         HGOTO_ERROR(H5E_ARGS, H5E_CANTCOPY, FAIL, "unable to format credentials path");
 
@@ -2094,7 +2094,7 @@ H5FD_s3comms_load_aws_profile(const char *profile_name, char *key_id_out, char *
         credfile = NULL;
     } /* end if credential file opened */
 
-    ret = HDsnprintf(filepath, 128, "%s%s", awspath, "config");
+    ret = snprintf(filepath, 128, "%s%s", awspath, "config");
     if (ret < 0 || (size_t)ret >= 128)
         HGOTO_ERROR(H5E_ARGS, H5E_CANTCOPY, FAIL, "unable to format config path");
     credfile = fopen(filepath, "r");
@@ -2218,7 +2218,7 @@ H5FD_s3comms_parse_url(const char *str, parsed_url_t **_purl)
     if (str == NULL || *str == '\0')
         HGOTO_ERROR(H5E_ARGS, H5E_BADVALUE, FAIL, "invalid url string");
 
-    urllen = (long int)HDstrlen(str);
+    urllen = (long int)strlen(str);
 
     purl = (parsed_url_t *)H5MM_malloc(sizeof(parsed_url_t));
     if (purl == NULL)
@@ -2234,7 +2234,7 @@ H5FD_s3comms_parse_url(const char *str, parsed_url_t **_purl)
      * READ SCHEME *
      ***************/
 
-    tmpstr = HDstrchr(curstr, ':');
+    tmpstr = strchr(curstr, ':');
     if (tmpstr == NULL)
         HGOTO_ERROR(H5E_ARGS, H5E_BADVALUE, FAIL, "invalid SCHEME construction: probably not URL");
     len = tmpstr - curstr;
@@ -2251,7 +2251,7 @@ H5FD_s3comms_parse_url(const char *str, parsed_url_t **_purl)
     purl->scheme = (char *)H5MM_malloc(sizeof(char) * (size_t)(len + 1));
     if (purl->scheme == NULL)
         HGOTO_ERROR(H5E_ARGS, H5E_CANTALLOC, FAIL, "can't allocate space for SCHEME");
-    HDstrncpy(purl->scheme, curstr, (size_t)len);
+    strncpy(purl->scheme, curstr, (size_t)len);
     purl->scheme[len] = '\0';
     for (i = 0; i < len; i++)
         purl->scheme[i] = (char)HDtolower(purl->scheme[i]);
@@ -2291,7 +2291,7 @@ H5FD_s3comms_parse_url(const char *str, parsed_url_t **_purl)
     purl->host = (char *)H5MM_malloc(sizeof(char) * (size_t)(len + 1));
     if (purl->host == NULL)
         HGOTO_ERROR(H5E_ARGS, H5E_CANTALLOC, FAIL, "can't allocate space for HOST");
-    HDstrncpy(purl->host, curstr, (size_t)len);
+    strncpy(purl->host, curstr, (size_t)len);
     purl->host[len] = 0;
 
     /*************
@@ -2316,7 +2316,7 @@ H5FD_s3comms_parse_url(const char *str, parsed_url_t **_purl)
         purl->port = (char *)H5MM_malloc(sizeof(char) * (size_t)(len + 1));
         if (purl->port == NULL)
             HGOTO_ERROR(H5E_ARGS, H5E_CANTALLOC, FAIL, "can't allocate space for PORT");
-        HDstrncpy(purl->port, curstr, (size_t)len);
+        strncpy(purl->port, curstr, (size_t)len);
         purl->port[len] = 0;
     } /* end if PORT element */
 
@@ -2339,7 +2339,7 @@ H5FD_s3comms_parse_url(const char *str, parsed_url_t **_purl)
             purl->path = (char *)H5MM_malloc(sizeof(char) * (size_t)(len + 1));
             if (purl->path == NULL)
                 HGOTO_ERROR(H5E_ARGS, H5E_CANTALLOC, FAIL, "can't allocate space for PATH");
-            HDstrncpy(purl->path, curstr, (size_t)len);
+            strncpy(purl->path, curstr, (size_t)len);
             purl->path[len] = 0;
         }
     } /* end if PATH element */
@@ -2361,7 +2361,7 @@ H5FD_s3comms_parse_url(const char *str, parsed_url_t **_purl)
         purl->query = (char *)H5MM_malloc(sizeof(char) * (size_t)(len + 1));
         if (purl->query == NULL)
             HGOTO_ERROR(H5E_ARGS, H5E_CANTALLOC, FAIL, "can't allocate space for QUERY");
-        HDstrncpy(purl->query, curstr, (size_t)len);
+        strncpy(purl->query, curstr, (size_t)len);
         purl->query[len] = 0;
     } /* end if QUERY exists */
 
@@ -2446,7 +2446,7 @@ H5FD_s3comms_percent_encode_char(char *repr, const unsigned char c, size_t *repr
         fprintf(stdout, "    SINGLE-BYTE\n");
 #endif
         *repr_len     = 3;
-        chars_written = HDsnprintf(repr, 4, "%%%02X", c);
+        chars_written = snprintf(repr, 4, "%%%02X", c);
         if (chars_written < 0)
             HGOTO_ERROR(H5E_ARGS, H5E_BADVALUE, FAIL, "cannot write char %c", c);
     } /* end if single-byte unicode char */
@@ -2497,7 +2497,7 @@ H5FD_s3comms_percent_encode_char(char *repr, const unsigned char c, size_t *repr
         acc += (stack_size > 2) ? 0x20 : 0; /* 0x00100000 */
         acc += (stack_size > 3) ? 0x10 : 0; /* 0x00010000 */
         stack_size--;
-        chars_written = HDsnprintf(repr, 4, "%%%02X", (unsigned char)(acc + stack[stack_size]));
+        chars_written = snprintf(repr, 4, "%%%02X", (unsigned char)(acc + stack[stack_size]));
         if (chars_written < 0)
             HGOTO_ERROR(H5E_ARGS, H5E_BADVALUE, FAIL, "cannot write char %c", c);
         *repr_len += 3;
@@ -2509,7 +2509,7 @@ H5FD_s3comms_percent_encode_char(char *repr, const unsigned char c, size_t *repr
         /* 10xxxxxx */
         for (i = 0; i < stack_size; i++) {
             chars_written =
-                HDsnprintf(&repr[i * 3 + 3], 4, "%%%02X", (unsigned char)(0x80 + stack[stack_size - 1 - i]));
+                snprintf(&repr[i * 3 + 3], 4, "%%%02X", (unsigned char)(0x80 + stack[stack_size - 1 - i]));
             if (chars_written < 0)
                 HGOTO_ERROR(H5E_ARGS, H5E_BADVALUE, FAIL, "cannot write char %c", c);
             *repr_len += 3;
@@ -2565,7 +2565,7 @@ H5FD_s3comms_signing_key(unsigned char *md, const char *secret, const char *regi
     unsigned char datekey[SHA256_DIGEST_LENGTH];
     unsigned char dateregionkey[SHA256_DIGEST_LENGTH];
     unsigned char dateregionservicekey[SHA256_DIGEST_LENGTH];
-    int           ret       = 0; /* return value of HDsnprintf */
+    int           ret       = 0; /* return value of snprintf */
     herr_t        ret_value = SUCCEED;
 
     FUNC_ENTER_NOAPI_NOINIT
@@ -2583,24 +2583,24 @@ H5FD_s3comms_signing_key(unsigned char *md, const char *secret, const char *regi
     if (iso8601now == NULL)
         HGOTO_ERROR(H5E_ARGS, H5E_BADVALUE, FAIL, "`iso8601now` cannot be NULL.");
 
-    AWS4_secret_len = 4 + HDstrlen(secret) + 1;
+    AWS4_secret_len = 4 + strlen(secret) + 1;
     AWS4_secret     = (char *)H5MM_malloc(sizeof(char *) * AWS4_secret_len);
     if (AWS4_secret == NULL)
         HGOTO_ERROR(H5E_ARGS, H5E_BADVALUE, FAIL, "Could not allocate space.");
 
     /* prepend "AWS4" to start of the secret key */
-    ret = HDsnprintf(AWS4_secret, AWS4_secret_len, "%s%s", "AWS4", secret);
+    ret = snprintf(AWS4_secret, AWS4_secret_len, "%s%s", "AWS4", secret);
     if ((size_t)ret != (AWS4_secret_len - 1))
         HGOTO_ERROR(H5E_ARGS, H5E_BADVALUE, FAIL, "problem writing AWS4+secret `%s`", secret);
 
     /* hash_func, key, len(key), msg, len(msg), digest_dest, digest_len_dest
      * we know digest length, so ignore via NULL
      */
-    HMAC(EVP_sha256(), (const unsigned char *)AWS4_secret, (int)HDstrlen(AWS4_secret),
+    HMAC(EVP_sha256(), (const unsigned char *)AWS4_secret, (int)strlen(AWS4_secret),
          (const unsigned char *)iso8601now, 8, /* 8 --> length of 8 --> "yyyyMMDD"  */
          datekey, NULL);
     HMAC(EVP_sha256(), (const unsigned char *)datekey, SHA256_DIGEST_LENGTH, (const unsigned char *)region,
-         HDstrlen(region), dateregionkey, NULL);
+         strlen(region), dateregionkey, NULL);
     HMAC(EVP_sha256(), (const unsigned char *)dateregionkey, SHA256_DIGEST_LENGTH,
          (const unsigned char *)"s3", 2, dateregionservicekey, NULL);
     HMAC(EVP_sha256(), (const unsigned char *)dateregionservicekey, SHA256_DIGEST_LENGTH,
@@ -2653,7 +2653,7 @@ H5FD_s3comms_tostringtosign(char *dest, const char *req, const char *now, const 
     char          day[9];
     char          hexsum[SHA256_DIGEST_LENGTH * 2 + 1];
     size_t        i         = 0;
-    int           ret       = 0; /* HDsnprintf return value */
+    int           ret       = 0; /* snprintf return value */
     herr_t        ret_value = SUCCEED;
     char          tmp[128];
 
@@ -2678,24 +2678,24 @@ H5FD_s3comms_tostringtosign(char *dest, const char *req, const char *now, const 
         checksum[i] = '\0';
         hexsum[i]   = '\0';
     }
-    HDstrncpy(day, now, 8);
+    strncpy(day, now, 8);
     day[8] = '\0';
-    ret    = HDsnprintf(tmp, 127, "%s/%s/s3/aws4_request", day, region);
+    ret    = snprintf(tmp, 127, "%s/%s/s3/aws4_request", day, region);
     if (ret <= 0 || ret >= 127)
         HGOTO_ERROR(H5E_ARGS, H5E_BADVALUE, FAIL, "problem adding day and region to string");
 
     H5MM_memcpy((dest + d), "AWS4-HMAC-SHA256\n", 17);
     d = 17;
 
-    H5MM_memcpy((dest + d), now, HDstrlen(now));
-    d += HDstrlen(now);
+    H5MM_memcpy((dest + d), now, strlen(now));
+    d += strlen(now);
     dest[d++] = '\n';
 
-    H5MM_memcpy((dest + d), tmp, HDstrlen(tmp));
-    d += HDstrlen(tmp);
+    H5MM_memcpy((dest + d), tmp, strlen(tmp));
+    d += strlen(tmp);
     dest[d++] = '\n';
 
-    SHA256((const unsigned char *)req, HDstrlen(req), checksum);
+    SHA256((const unsigned char *)req, strlen(req), checksum);
 
     if (H5FD_s3comms_bytes_to_hex(hexsum, (const unsigned char *)checksum, SHA256_DIGEST_LENGTH, true) ==
         FAIL)

--- a/src/H5FDs3comms.h
+++ b/src/H5FDs3comms.h
@@ -130,7 +130,7 @@
  *
  *     Format "S3 Credential" string from inputs, for AWS4.
  *
- *     Wrapper for HDsnprintf().
+ *     Wrapper for snprintf().
  *
  *     _HAS NO ERROR-CHECKING FACILITIES_
  *     It is left to programmer to ensure that return value confers success.
@@ -153,8 +153,8 @@
  *---------------------------------------------------------------------------
  */
 #define S3COMMS_FORMAT_CREDENTIAL(dest, access, iso8601_date, region, service)                               \
-    HDsnprintf((dest), S3COMMS_MAX_CREDENTIAL_SIZE, "%s/%s/%s/%s/aws4_request", (access), (iso8601_date),    \
-               (region), (service))
+    snprintf((dest), S3COMMS_MAX_CREDENTIAL_SIZE, "%s/%s/%s/%s/aws4_request", (access), (iso8601_date),      \
+             (region), (service))
 
 /*********************
  * PUBLIC STRUCTURES *

--- a/src/H5FDsec2.c
+++ b/src/H5FDsec2.c
@@ -205,9 +205,9 @@ H5FD_sec2_init(void)
 
     /* Check the use disabled file locks environment variable */
     lock_env_var = HDgetenv(HDF5_USE_FILE_LOCKING);
-    if (lock_env_var && !HDstrcmp(lock_env_var, "BEST_EFFORT"))
+    if (lock_env_var && !strcmp(lock_env_var, "BEST_EFFORT"))
         ignore_disabled_file_locks_s = true; /* Override: Ignore disabled locks */
-    else if (lock_env_var && (!HDstrcmp(lock_env_var, "TRUE") || !HDstrcmp(lock_env_var, "1")))
+    else if (lock_env_var && (!strcmp(lock_env_var, "TRUE") || !strcmp(lock_env_var, "1")))
         ignore_disabled_file_locks_s = false; /* Override: Don't ignore disabled locks */
     else
         ignore_disabled_file_locks_s = FAIL; /* Environment variable not set, or not set correctly */
@@ -323,7 +323,7 @@ H5FD__sec2_open(const char *name, unsigned flags, hid_t fapl_id, haddr_t maxaddr
         HGOTO_ERROR(
             H5E_FILE, H5E_CANTOPENFILE, NULL,
             "unable to open file: name = '%s', errno = %d, error message = '%s', flags = %x, o_flags = %x",
-            name, myerrno, HDstrerror(myerrno), flags, (unsigned)o_flags);
+            name, myerrno, strerror(myerrno), flags, (unsigned)o_flags);
     } /* end if */
 
     if (HDfstat(fd, &sb) < 0)
@@ -368,7 +368,7 @@ H5FD__sec2_open(const char *name, unsigned flags, hid_t fapl_id, haddr_t maxaddr
     }
 
     /* Retain a copy of the name used to open the file, for possible error reporting */
-    HDstrncpy(file->filename, name, sizeof(file->filename));
+    strncpy(file->filename, name, sizeof(file->filename));
     file->filename[sizeof(file->filename) - 1] = '\0';
 
     /* Check for non-default FAPL */
@@ -703,7 +703,7 @@ H5FD__sec2_read(H5FD_t *_file, H5FD_mem_t H5_ATTR_UNUSED type, hid_t H5_ATTR_UNU
                         "file read failed: time = %s, filename = '%s', file descriptor = %d, errno = %d, "
                         "error message = '%s', buf = %p, total read size = %llu, bytes this sub-read = %llu, "
                         "bytes actually read = %llu, offset = %llu",
-                        HDctime(&mytime), file->filename, file->fd, myerrno, HDstrerror(myerrno), buf,
+                        HDctime(&mytime), file->filename, file->fd, myerrno, strerror(myerrno), buf,
                         (unsigned long long)size, (unsigned long long)bytes_in,
                         (unsigned long long)bytes_read, (unsigned long long)offset);
         } /* end if */
@@ -809,7 +809,7 @@ H5FD__sec2_write(H5FD_t *_file, H5FD_mem_t H5_ATTR_UNUSED type, hid_t H5_ATTR_UN
                         "file write failed: time = %s, filename = '%s', file descriptor = %d, errno = %d, "
                         "error message = '%s', buf = %p, total write size = %llu, bytes this sub-write = "
                         "%llu, bytes actually written = %llu, offset = %llu",
-                        HDctime(&mytime), file->filename, file->fd, myerrno, HDstrerror(myerrno), buf,
+                        HDctime(&mytime), file->filename, file->fd, myerrno, strerror(myerrno), buf,
                         (unsigned long long)size, (unsigned long long)bytes_in,
                         (unsigned long long)bytes_wrote, (unsigned long long)offset);
         } /* end if */

--- a/src/H5FDsplitter.c
+++ b/src/H5FDsplitter.c
@@ -367,8 +367,8 @@ H5Pget_fapl_splitter(hid_t fapl_id, H5FD_splitter_vfd_config_t *config /*out*/)
         fapl_ptr = default_fapl;
     }
 
-    HDstrncpy(config->wo_path, fapl_ptr->wo_path, H5FD_SPLITTER_PATH_MAX + 1);
-    HDstrncpy(config->log_file_path, fapl_ptr->log_file_path, H5FD_SPLITTER_PATH_MAX + 1);
+    strncpy(config->wo_path, fapl_ptr->wo_path, H5FD_SPLITTER_PATH_MAX + 1);
+    strncpy(config->log_file_path, fapl_ptr->log_file_path, H5FD_SPLITTER_PATH_MAX + 1);
     config->ignore_wo_errs = fapl_ptr->ignore_wo_errs;
 
     /* Copy R/W and W/O FAPLs */
@@ -448,9 +448,9 @@ H5FD__splitter_populate_config(H5FD_splitter_vfd_config_t *vfd_config, H5FD_spli
     } /* end if W/O VFD is non-default */
 
     fapl_out->ignore_wo_errs = vfd_config->ignore_wo_errs;
-    HDstrncpy(fapl_out->wo_path, vfd_config->wo_path, H5FD_SPLITTER_PATH_MAX + 1);
+    strncpy(fapl_out->wo_path, vfd_config->wo_path, H5FD_SPLITTER_PATH_MAX + 1);
     fapl_out->wo_path[H5FD_SPLITTER_PATH_MAX] = '\0';
-    HDstrncpy(fapl_out->log_file_path, vfd_config->log_file_path, H5FD_SPLITTER_PATH_MAX + 1);
+    strncpy(fapl_out->log_file_path, vfd_config->log_file_path, H5FD_SPLITTER_PATH_MAX + 1);
     fapl_out->log_file_path[H5FD_SPLITTER_PATH_MAX] = '\0';
     fapl_out->rw_fapl_id                            = H5P_FILE_ACCESS_DEFAULT; /* pre-set value */
     fapl_out->wo_fapl_id                            = H5P_FILE_ACCESS_DEFAULT; /* pre-set value */
@@ -527,32 +527,32 @@ H5FD__splitter_get_default_wo_path(char *new_path, size_t new_path_len, const ch
     assert(base_filename);
 
     /* Check that output buffer can hold base filename + `_wo` suffix */
-    old_filename_len = HDstrlen(base_filename);
-    if (old_filename_len > H5FD_SPLITTER_PATH_MAX - HDstrlen(suffix) - 1)
+    old_filename_len = strlen(base_filename);
+    if (old_filename_len > H5FD_SPLITTER_PATH_MAX - strlen(suffix) - 1)
         HGOTO_ERROR(H5E_VFL, H5E_CANTSET, FAIL, "filename exceeds max length");
 
     /* Determine if filename contains a ".h5" extension. */
-    if ((file_extension = HDstrstr(base_filename, ".h5"))) {
+    if ((file_extension = strstr(base_filename, ".h5"))) {
         /* Insert the suffix between the filename and ".h5" extension. */
-        HDstrcpy(new_path, base_filename);
-        file_extension = HDstrstr(new_path, ".h5");
-        HDsprintf(file_extension, "%s%s", suffix, ".h5");
+        strcpy(new_path, base_filename);
+        file_extension = strstr(new_path, ".h5");
+        sprintf(file_extension, "%s%s", suffix, ".h5");
     }
-    else if ((file_extension = HDstrrchr(base_filename, '.'))) {
+    else if ((file_extension = strrchr(base_filename, '.'))) {
         char *new_extension_loc = NULL;
 
         /* If the filename doesn't contain a ".h5" extension, but contains
          * AN extension, just insert the suffix before that extension.
          */
-        HDstrcpy(new_path, base_filename);
-        new_extension_loc = HDstrrchr(new_path, '.');
-        HDsprintf(new_extension_loc, "%s%s", suffix, file_extension);
+        strcpy(new_path, base_filename);
+        new_extension_loc = strrchr(new_path, '.');
+        sprintf(new_extension_loc, "%s%s", suffix, file_extension);
     }
     else {
         /* If the filename doesn't contain an extension at all, just insert
          * the suffix at the end of the filename.
          */
-        HDsnprintf(new_path, new_path_len, "%s%s", base_filename, suffix);
+        snprintf(new_path, new_path_len, "%s%s", base_filename, suffix);
     }
 
 done:
@@ -720,8 +720,8 @@ H5FD__splitter_fapl_copy(const void *_old_fa)
         HGOTO_ERROR(H5E_VFL, H5E_CANTALLOC, NULL, "unable to allocate log file FAPL");
 
     H5MM_memcpy(new_fa_ptr, old_fa_ptr, sizeof(H5FD_splitter_fapl_t));
-    HDstrncpy(new_fa_ptr->wo_path, old_fa_ptr->wo_path, H5FD_SPLITTER_PATH_MAX + 1);
-    HDstrncpy(new_fa_ptr->log_file_path, old_fa_ptr->log_file_path, H5FD_SPLITTER_PATH_MAX + 1);
+    strncpy(new_fa_ptr->wo_path, old_fa_ptr->wo_path, H5FD_SPLITTER_PATH_MAX + 1);
+    strncpy(new_fa_ptr->log_file_path, old_fa_ptr->log_file_path, H5FD_SPLITTER_PATH_MAX + 1);
 
     /* Copy R/W and W/O FAPLs */
     if (H5FD__copy_plist(old_fa_ptr->rw_fapl_id, &(new_fa_ptr->rw_fapl_id)) < 0)
@@ -833,8 +833,8 @@ H5FD__splitter_open(const char *name, unsigned flags, hid_t splitter_fapl_id, ha
     }
 
     /* Copy simpler info */
-    HDstrncpy(file_ptr->fa.wo_path, fapl_ptr->wo_path, H5FD_SPLITTER_PATH_MAX + 1);
-    HDstrncpy(file_ptr->fa.log_file_path, fapl_ptr->log_file_path, H5FD_SPLITTER_PATH_MAX + 1);
+    strncpy(file_ptr->fa.wo_path, fapl_ptr->wo_path, H5FD_SPLITTER_PATH_MAX + 1);
+    strncpy(file_ptr->fa.log_file_path, fapl_ptr->log_file_path, H5FD_SPLITTER_PATH_MAX + 1);
     file_ptr->fa.ignore_wo_errs = fapl_ptr->ignore_wo_errs;
 
     /* Copy R/W and W/O channel FAPLs. */
@@ -1575,11 +1575,11 @@ H5FD__splitter_log_error(const H5FD_splitter_t *file, const char *atfunc, const 
         size_t size;
         char  *s;
 
-        size = HDstrlen(atfunc) + HDstrlen(msg) + 3; /* ':', ' ', '\n' */
+        size = strlen(atfunc) + strlen(msg) + 3; /* ':', ' ', '\n' */
         s    = (char *)H5MM_malloc(sizeof(char) * (size + 1));
         if (NULL == s)
             ret_value = FAIL;
-        else if (size < (size_t)HDsnprintf(s, size + 1, "%s: %s\n", atfunc, msg))
+        else if (size < (size_t)snprintf(s, size + 1, "%s: %s\n", atfunc, msg))
             ret_value = FAIL;
         else if (size != fwrite(s, 1, size, file->logfp))
             ret_value = FAIL;

--- a/src/H5FDsubfiling/H5FDioc.c
+++ b/src/H5FDsubfiling/H5FDioc.c
@@ -224,7 +224,7 @@ H5FD_ioc_init(void)
 
         /* Check if IOC VFD has been loaded dynamically */
         env_var = HDgetenv(HDF5_DRIVER);
-        if (env_var && !HDstrcmp(env_var, H5FD_IOC_NAME)) {
+        if (env_var && !strcmp(env_var, H5FD_IOC_NAME)) {
             int mpi_initialized = 0;
             int provided        = 0;
 
@@ -528,7 +528,7 @@ H5FD__ioc_sb_encode(H5FD_t *_file, char *name, unsigned char *buf)
         H5_SUBFILING_GOTO_ERROR(H5E_VFL, H5E_CANTGET, FAIL, "can't get subfiling context object");
 
     /* Encode driver name */
-    HDstrncpy(name, "IOC", 9);
+    strncpy(name, "IOC", 9);
     name[8] = '\0';
 
     /* Encode configuration structure magic number */
@@ -573,7 +573,7 @@ H5FD__ioc_sb_decode(H5FD_t *_file, const char *name, const unsigned char *buf)
     if (NULL == (sf_context = H5_get_subfiling_object(file->context_id)))
         H5_SUBFILING_GOTO_ERROR(H5E_VFL, H5E_CANTGET, FAIL, "can't get subfiling context object");
 
-    if (HDstrncmp(name, "IOC", 9))
+    if (strncmp(name, "IOC", 9))
         H5_SUBFILING_GOTO_ERROR(H5E_VFL, H5E_BADVALUE, FAIL, "invalid driver name in superblock");
 
     /* Decode configuration structure magic number */
@@ -1495,8 +1495,8 @@ H5FD__ioc_del(const char *name, hid_t fapl)
 
         /* TODO: No support for subfile directory prefix currently */
         /* TODO: Possibly try loading config file prefix from file before deleting */
-        HDsnprintf(tmp_filename, PATH_MAX, "%s/" H5FD_SUBFILING_CONFIG_FILENAME_TEMPLATE,
-                   prefix_env ? prefix_env : file_dirname, base_filename, (uint64_t)st.st_ino);
+        snprintf(tmp_filename, PATH_MAX, "%s/" H5FD_SUBFILING_CONFIG_FILENAME_TEMPLATE,
+                 prefix_env ? prefix_env : file_dirname, base_filename, (uint64_t)st.st_ino);
 
         if (NULL == (config_file = fopen(tmp_filename, "r"))) {
             if (ENOENT == errno) {
@@ -1535,8 +1535,8 @@ H5FD__ioc_del(const char *name, hid_t fapl)
 
         for (int i = 0; i < n_subfiles; i++) {
             /* TODO: No support for subfile directory prefix currently */
-            HDsnprintf(tmp_filename, PATH_MAX, "%s/" H5FD_SUBFILING_FILENAME_TEMPLATE, file_dirname,
-                       base_filename, (uint64_t)st.st_ino, num_digits, i + 1, n_subfiles);
+            snprintf(tmp_filename, PATH_MAX, "%s/" H5FD_SUBFILING_FILENAME_TEMPLATE, file_dirname,
+                     base_filename, (uint64_t)st.st_ino, num_digits, i + 1, n_subfiles);
 
             if (HDremove(tmp_filename) < 0) {
 #ifdef H5FD_IOC_DEBUG

--- a/src/H5FDsubfiling/H5FDsubfiling.c
+++ b/src/H5FDsubfiling/H5FDsubfiling.c
@@ -724,7 +724,7 @@ H5FD__subfiling_sb_size(H5FD_t *_file)
     }
     else {
         if (sf_context->config_file_prefix) {
-            ret_value += HDstrlen(sf_context->config_file_prefix) + 1;
+            ret_value += strlen(sf_context->config_file_prefix) + 1;
         }
     }
 
@@ -780,7 +780,7 @@ H5FD__subfiling_sb_encode(H5FD_t *_file, char *name, unsigned char *buf)
         H5_SUBFILING_GOTO_ERROR(H5E_VFL, H5E_CANTGET, FAIL, "can't get subfiling context object");
 
     /* Encode driver name */
-    HDstrncpy(name, "Subfilin", 9);
+    strncpy(name, "Subfilin", 9);
     name[8] = '\0';
 
     /* Encode configuration structure magic number */
@@ -802,7 +802,7 @@ H5FD__subfiling_sb_encode(H5FD_t *_file, char *name, unsigned char *buf)
 
     /* Encode config file prefix string length */
     if (sf_context->config_file_prefix) {
-        prefix_len = HDstrlen(sf_context->config_file_prefix) + 1;
+        prefix_len = strlen(sf_context->config_file_prefix) + 1;
         H5_CHECKED_ASSIGN(tmpu64, uint64_t, prefix_len, size_t);
     }
     else
@@ -862,7 +862,7 @@ H5FD__subfiling_sb_decode(H5FD_t *_file, const char *name, const unsigned char *
     if (NULL == (sf_context = H5_get_subfiling_object(file->context_id)))
         H5_SUBFILING_GOTO_ERROR(H5E_VFL, H5E_CANTGET, FAIL, "can't get subfiling context object");
 
-    if (HDstrncmp(name, "Subfilin", 9))
+    if (strncmp(name, "Subfilin", 9))
         H5_SUBFILING_GOTO_ERROR(H5E_VFL, H5E_BADVALUE, FAIL, "invalid driver name in superblock");
 
     /* Decode configuration structure magic number */
@@ -2426,7 +2426,7 @@ H5FD__subfiling_lock(H5FD_t *_file, bool rw)
 
     if (file->fa.require_ioc) {
 #ifdef VERBOSE
-        HDputs("Subfiling driver doesn't support file locking");
+        puts("Subfiling driver doesn't support file locking");
 #endif
     }
     else {

--- a/src/H5FDsubfiling/H5subfiling_common.c
+++ b/src/H5FDsubfiling/H5subfiling_common.c
@@ -562,7 +562,7 @@ H5_open_subfiling_stub_file(const char *name, unsigned flags, MPI_Comm file_comm
             stub_file_id = UINT64_MAX;
             H5_SUBFILING_GOTO_ERROR(H5E_VFL, H5E_CANTGET, FAIL,
                                     "couldn't stat HDF5 stub file, errno = %d, error message = '%s'", errno,
-                                    HDstrerror(errno));
+                                    strerror(errno));
         }
         else
             stub_file_id = (uint64_t)st.st_ino;
@@ -668,7 +668,7 @@ H5_open_subfiles(const char *base_filename, uint64_t file_id, H5FD_subfiling_par
         if (MPI_SUCCESS != (mpi_code = MPI_Comm_rank(file_comm, &mpi_rank)))
             H5_SUBFILING_MPI_GOTO_ERROR(FAIL, "MPI_Comm_rank failed", mpi_code);
 
-        HDsnprintf(sf_context->sf_logfile_name, PATH_MAX, "%s.log.%d", sf_context->h5_filename, mpi_rank);
+        snprintf(sf_context->sf_logfile_name, PATH_MAX, "%s.log.%d", sf_context->h5_filename, mpi_rank);
 
         if (NULL == (sf_context->sf_logfile = fopen(sf_context->sf_logfile_name, "a")))
             H5_SUBFILING_SYS_GOTO_ERROR(H5E_FILE, H5E_CANTOPENFILE, FAIL,
@@ -778,7 +778,7 @@ init_subfiling(const char *base_filename, uint64_t file_id, H5FD_subfiling_param
     /* Check if a prefix has been set for the configuration file name */
     prefix_env = HDgetenv(H5FD_SUBFILING_CONFIG_FILE_PREFIX);
     if (prefix_env) {
-        if (NULL == (new_context->config_file_prefix = HDstrdup(prefix_env)))
+        if (NULL == (new_context->config_file_prefix = strdup(prefix_env)))
             H5_SUBFILING_GOTO_ERROR(H5E_VFL, H5E_CANTCOPY, FAIL, "couldn't copy config file prefix string");
     }
 
@@ -1202,7 +1202,7 @@ get_ioc_selection_criteria_from_env(H5FD_subfiling_ioc_select_t *ioc_selection_t
          * '1:64' to specify the "every Nth rank" strategy with a
          * criteria of '64'.
          */
-        opt_value = HDstrchr(env_value, ':');
+        opt_value = strchr(env_value, ':');
         if (opt_value) {
             long check_value;
 
@@ -1815,13 +1815,13 @@ init_subfiling_context(subfiling_context_t *sf_context, const char *base_filenam
     sf_context->sf_logfile = NULL;
 #endif
 
-    if (NULL == (sf_context->h5_filename = HDstrdup(base_filename)))
+    if (NULL == (sf_context->h5_filename = strdup(base_filename)))
         H5_SUBFILING_GOTO_ERROR(H5E_RESOURCE, H5E_CANTALLOC, FAIL,
                                 "couldn't allocate space for subfiling filename");
 
     /* Check for a subfile name prefix setting in the environment */
     if ((env_value = HDgetenv(H5FD_SUBFILING_SUBFILE_PREFIX))) {
-        if (NULL == (sf_context->subfile_prefix = HDstrdup(env_value)))
+        if (NULL == (sf_context->subfile_prefix = strdup(env_value)))
             H5_SUBFILING_GOTO_ERROR(H5E_RESOURCE, H5E_CANTALLOC, FAIL, "couldn't copy subfile prefix value");
     }
 
@@ -2204,8 +2204,8 @@ ioc_open_files(int64_t file_context_id, int file_acc_flags)
          * and the configuration file will be named:
          *   ABC.h5.subfile_<file-number>.config
          */
-        HDsnprintf(filepath, PATH_MAX, "%s/" H5FD_SUBFILING_FILENAME_TEMPLATE, subfile_dir, base,
-                   sf_context->h5_file_id, num_digits, subfile_idx, num_subfiles);
+        snprintf(filepath, PATH_MAX, "%s/" H5FD_SUBFILING_FILENAME_TEMPLATE, subfile_dir, base,
+                 sf_context->h5_file_id, num_digits, subfile_idx, num_subfiles);
 
         if ((sf_context->sf_fids[i] = HDopen(filepath, file_acc_flags, mode)) < 0)
             H5_SUBFILING_SYS_GOTO_ERROR(H5E_FILE, H5E_CANTOPENFILE, FAIL, "failed to open subfile");
@@ -2302,8 +2302,8 @@ create_config_file(subfiling_context_t *sf_context, const char *base_filename, c
         H5_SUBFILING_GOTO_ERROR(H5E_RESOURCE, H5E_CANTALLOC, FAIL,
                                 "couldn't allocate space for subfiling configuration filename");
 
-    HDsnprintf(config_filename, PATH_MAX, "%s/" H5FD_SUBFILING_CONFIG_FILENAME_TEMPLATE, config_dir,
-               base_filename, sf_context->h5_file_id);
+    snprintf(config_filename, PATH_MAX, "%s/" H5FD_SUBFILING_CONFIG_FILENAME_TEMPLATE, config_dir,
+             base_filename, sf_context->h5_file_id);
 
     /* Determine whether a subfiling configuration file exists */
     errno = 0;
@@ -2334,42 +2334,42 @@ create_config_file(subfiling_context_t *sf_context, const char *base_filename, c
                                     "couldn't allocate buffer for writing to subfiling configuration file");
 
         /* Write the subfiling stripe size to the configuration file */
-        HDsnprintf(line_buf, PATH_MAX, "stripe_size=%" PRId64 "\n", sf_context->sf_stripe_size);
-        if (fwrite(line_buf, HDstrlen(line_buf), 1, config_file) != 1)
+        snprintf(line_buf, PATH_MAX, "stripe_size=%" PRId64 "\n", sf_context->sf_stripe_size);
+        if (fwrite(line_buf, strlen(line_buf), 1, config_file) != 1)
             H5_SUBFILING_SYS_GOTO_ERROR(H5E_FILE, H5E_WRITEERROR, FAIL,
                                         "failed to write to subfiling configuration file");
 
         /* Write the number of I/O concentrators to the configuration file */
-        HDsnprintf(line_buf, PATH_MAX, "aggregator_count=%d\n", sf_context->topology->n_io_concentrators);
-        if (fwrite(line_buf, HDstrlen(line_buf), 1, config_file) != 1)
+        snprintf(line_buf, PATH_MAX, "aggregator_count=%d\n", sf_context->topology->n_io_concentrators);
+        if (fwrite(line_buf, strlen(line_buf), 1, config_file) != 1)
             H5_SUBFILING_SYS_GOTO_ERROR(H5E_FILE, H5E_WRITEERROR, FAIL,
                                         "failed to write to subfiling configuration file");
 
         /* Write the number of subfiles to the configuration file */
-        HDsnprintf(line_buf, PATH_MAX, "subfile_count=%d\n", n_subfiles);
-        if (fwrite(line_buf, HDstrlen(line_buf), 1, config_file) != 1)
+        snprintf(line_buf, PATH_MAX, "subfile_count=%d\n", n_subfiles);
+        if (fwrite(line_buf, strlen(line_buf), 1, config_file) != 1)
             H5_SUBFILING_SYS_GOTO_ERROR(H5E_FILE, H5E_WRITEERROR, FAIL,
                                         "failed to write to subfiling configuration file");
 
         /* Write the base HDF5 filename to the configuration file */
-        HDsnprintf(line_buf, PATH_MAX, "hdf5_file=%s\n", sf_context->h5_filename);
-        if (fwrite(line_buf, HDstrlen(line_buf), 1, config_file) != 1)
+        snprintf(line_buf, PATH_MAX, "hdf5_file=%s\n", sf_context->h5_filename);
+        if (fwrite(line_buf, strlen(line_buf), 1, config_file) != 1)
             H5_SUBFILING_SYS_GOTO_ERROR(H5E_FILE, H5E_WRITEERROR, FAIL,
                                         "failed to write to subfiling configuration file");
 
         /* Write the optional subfile directory prefix to the configuration file */
-        HDsnprintf(line_buf, PATH_MAX, "subfile_dir=%s\n", subfile_dir);
-        if (fwrite(line_buf, HDstrlen(line_buf), 1, config_file) != 1)
+        snprintf(line_buf, PATH_MAX, "subfile_dir=%s\n", subfile_dir);
+        if (fwrite(line_buf, strlen(line_buf), 1, config_file) != 1)
             H5_SUBFILING_SYS_GOTO_ERROR(H5E_FILE, H5E_WRITEERROR, FAIL,
                                         "failed to write to subfiling configuration file");
 
         /* Write out each subfile name to the configuration file */
         num_digits = (int)(log10(n_subfiles) + 1);
         for (int k = 0; k < n_subfiles; k++) {
-            HDsnprintf(line_buf, PATH_MAX, H5FD_SUBFILING_FILENAME_TEMPLATE "\n", base_filename,
-                       sf_context->h5_file_id, num_digits, k + 1, n_subfiles);
+            snprintf(line_buf, PATH_MAX, H5FD_SUBFILING_FILENAME_TEMPLATE "\n", base_filename,
+                     sf_context->h5_file_id, num_digits, k + 1, n_subfiles);
 
-            if (fwrite(line_buf, HDstrlen(line_buf), 1, config_file) != 1)
+            if (fwrite(line_buf, strlen(line_buf), 1, config_file) != 1)
                 H5_SUBFILING_SYS_GOTO_ERROR(H5E_FILE, H5E_WRITEERROR, FAIL,
                                             "failed to write to subfiling configuration file");
         }
@@ -2430,8 +2430,8 @@ open_config_file(const char *base_filename, const char *config_dir, uint64_t fil
         H5_SUBFILING_GOTO_ERROR(H5E_RESOURCE, H5E_CANTALLOC, FAIL,
                                 "couldn't allocate space for subfiling configuration filename");
 
-    HDsnprintf(config_filename, PATH_MAX, "%s/" H5FD_SUBFILING_CONFIG_FILENAME_TEMPLATE, config_dir,
-               base_filename, file_id);
+    snprintf(config_filename, PATH_MAX, "%s/" H5FD_SUBFILING_CONFIG_FILENAME_TEMPLATE, config_dir,
+             base_filename, file_id);
 
     /* Determine whether a subfiling configuration file exists */
     errno = 0;
@@ -2509,11 +2509,11 @@ H5_get_subfiling_config_from_file(FILE *config_file, int64_t *stripe_size, int64
     config_buf[config_file_len] = '\0';
 
     if (stripe_size) {
-        if (NULL == (substr = HDstrstr(config_buf, "stripe_size")))
+        if (NULL == (substr = strstr(config_buf, "stripe_size")))
             H5_SUBFILING_GOTO_ERROR(H5E_FILE, H5E_BADVALUE, FAIL,
                                     "malformed subfiling configuration file - no stripe size entry");
 
-        if (EOF == HDsscanf(substr, "stripe_size=%" PRId64, &read_stripe_size))
+        if (EOF == sscanf(substr, "stripe_size=%" PRId64, &read_stripe_size))
             H5_SUBFILING_SYS_GOTO_ERROR(H5E_FILE, H5E_CANTGET, FAIL,
                                         "couldn't get stripe size from subfiling configuration file");
 
@@ -2526,11 +2526,11 @@ H5_get_subfiling_config_from_file(FILE *config_file, int64_t *stripe_size, int64
     }
 
     if (num_subfiles) {
-        if (NULL == (substr = HDstrstr(config_buf, "subfile_count")))
+        if (NULL == (substr = strstr(config_buf, "subfile_count")))
             H5_SUBFILING_GOTO_ERROR(H5E_FILE, H5E_BADVALUE, FAIL,
                                     "malformed subfiling configuration file - no subfile count entry");
 
-        if (EOF == HDsscanf(substr, "subfile_count=%" PRId64, &read_num_subfiles))
+        if (EOF == sscanf(substr, "subfile_count=%" PRId64, &read_num_subfiles))
             H5_SUBFILING_SYS_GOTO_ERROR(H5E_FILE, H5E_CANTGET, FAIL,
                                         "couldn't get number of subfiles from subfiling configuration file");
 
@@ -2594,7 +2594,7 @@ H5_resolve_pathname(const char *filepath, MPI_Comm comm, char **resolved_filepat
                     H5_SUBFILING_GOTO_ERROR(H5E_RESOURCE, H5E_CANTALLOC, FAIL, "can't get file dirname");
 
                 /* If filepath is just the filename, set up path using CWD */
-                if (!HDstrcmp(file_dirname, ".")) {
+                if (!strcmp(file_dirname, ".")) {
                     if (NULL == (resolved_path = malloc(PATH_MAX)))
                         H5_SUBFILING_GOTO_ERROR(H5E_RESOURCE, H5E_CANTALLOC, FAIL,
                                                 "can't allocate buffer for filepath");
@@ -2608,24 +2608,24 @@ H5_resolve_pathname(const char *filepath, MPI_Comm comm, char **resolved_filepat
                         H5_SUBFILING_GOTO_ERROR(
                             H5E_VFL, H5E_CANTGET, FAIL,
                             "can't get current working directory, errno = %d, error message = '%s'", errno,
-                            HDstrerror(errno));
+                            strerror(errno));
 
-                    HDsnprintf(resolved_path, PATH_MAX, "%s/%s", cwd, file_basename);
+                    snprintf(resolved_path, PATH_MAX, "%s/%s", cwd, file_basename);
                 }
                 else {
                     /* Otherwise, just use what was given as the pathname */
-                    if (NULL == (resolved_path = HDstrdup(filepath)))
+                    if (NULL == (resolved_path = strdup(filepath)))
                         H5_SUBFILING_GOTO_ERROR(H5E_RESOURCE, H5E_CANTALLOC, FAIL, "can't copy filename");
                 }
             }
             else
                 H5_SUBFILING_GOTO_ERROR(H5E_VFL, H5E_CANTGET, FAIL,
                                         "can't resolve subfile path, errno = %d, error message = '%s'", errno,
-                                        HDstrerror(errno));
+                                        strerror(errno));
         }
 
         if (resolved_path) {
-            H5_CHECKED_ASSIGN(path_len, hsize_t, (HDstrlen(resolved_path) + 1), size_t);
+            H5_CHECKED_ASSIGN(path_len, hsize_t, (strlen(resolved_path) + 1), size_t);
         }
         else
             path_len = HSIZE_UNDEF;
@@ -3138,13 +3138,13 @@ H5_subfiling_log(int64_t sf_context_id, const char *fmt, ...)
     H5FD_ioc_begin_thread_exclusive();
 
     if (sf_context->sf_logfile) {
-        HDvfprintf(sf_context->sf_logfile, fmt, log_args);
-        HDfputs("\n", sf_context->sf_logfile);
+        vfprintf(sf_context->sf_logfile, fmt, log_args);
+        fputs("\n", sf_context->sf_logfile);
         fflush(sf_context->sf_logfile);
     }
     else {
-        HDvprintf(fmt, log_args);
-        HDputs("");
+        vprintf(fmt, log_args);
+        puts("");
         fflush(stdout);
     }
 

--- a/src/H5FDtest.c
+++ b/src/H5FDtest.c
@@ -89,10 +89,10 @@ H5FD__supports_swmr_test(const char *vfd_name)
 
     FUNC_ENTER_NOAPI_NOINIT_NOERR
 
-    if (!vfd_name || !HDstrcmp(vfd_name, "") || !HDstrcmp(vfd_name, "nomatch"))
+    if (!vfd_name || !strcmp(vfd_name, "") || !strcmp(vfd_name, "nomatch"))
         ret_value = true;
     else
-        ret_value = !HDstrcmp(vfd_name, "log") || !HDstrcmp(vfd_name, "sec2");
+        ret_value = !strcmp(vfd_name, "log") || !strcmp(vfd_name, "sec2");
 
     FUNC_LEAVE_NOAPI(ret_value)
 } /* end H5FD__supports_swmr_test() */

--- a/src/H5Fint.c
+++ b/src/H5Fint.c
@@ -245,10 +245,10 @@ H5F__parse_file_lock_env_var(htri_t *use_locks)
 
     /* Check the file locking environment variable */
     lock_env_var = HDgetenv(HDF5_USE_FILE_LOCKING);
-    if (lock_env_var && (!HDstrcmp(lock_env_var, "FALSE") || !HDstrcmp(lock_env_var, "0")))
+    if (lock_env_var && (!strcmp(lock_env_var, "FALSE") || !strcmp(lock_env_var, "0")))
         *use_locks = false; /* Override: Never use locks */
-    else if (lock_env_var && (!HDstrcmp(lock_env_var, "TRUE") || !HDstrcmp(lock_env_var, "BEST_EFFORT") ||
-                              !HDstrcmp(lock_env_var, "1")))
+    else if (lock_env_var && (!strcmp(lock_env_var, "TRUE") || !strcmp(lock_env_var, "BEST_EFFORT") ||
+                              !strcmp(lock_env_var, "1")))
         *use_locks = true; /* Override: Always use locks */
     else
         *use_locks = FAIL; /* Environment variable not set, or not set correctly */
@@ -742,8 +742,8 @@ H5F__build_name(const char *prefix, const char *file_name, char **full_name /*ou
 
     FUNC_ENTER_PACKAGE
 
-    prefix_len = HDstrlen(prefix);
-    fname_len  = HDstrlen(file_name);
+    prefix_len = strlen(prefix);
+    fname_len  = strlen(file_name);
 
     /* Allocate a buffer to hold the filename + prefix + possibly the delimiter + terminating null byte */
     if (NULL == (*full_name = (char *)H5MM_malloc(prefix_len + fname_len + 2 +
@@ -751,10 +751,9 @@ H5F__build_name(const char *prefix, const char *file_name, char **full_name /*ou
         HGOTO_ERROR(H5E_FILE, H5E_CANTALLOC, FAIL, "unable to allocate filename buffer");
 
     /* Compose the full file name */
-    HDsnprintf(*full_name, (prefix_len + fname_len + 2 + 2), "%s%s%s",
-               prefix, /* Extra "+2" to quiet GCC warning - 2019/07/05, QAK */
-               ((prefix_len == 0 || H5_CHECK_DELIMITER(prefix[prefix_len - 1])) ? "" : H5_DIR_SEPS),
-               file_name);
+    snprintf(*full_name, (prefix_len + fname_len + 2 + 2), "%s%s%s",
+             prefix, /* Extra "+2" to quiet GCC warning - 2019/07/05, QAK */
+             ((prefix_len == 0 || H5_CHECK_DELIMITER(prefix[prefix_len - 1])) ? "" : H5_DIR_SEPS), file_name);
 
 done:
     FUNC_LEAVE_NOAPI(ret_value)
@@ -782,7 +781,7 @@ H5F__getenv_prefix_name(char **env_prefix /*in,out*/)
     ret_value = *env_prefix;
 
     /* Advance to next component, if possible */
-    strret = HDstrchr(*env_prefix, H5_COLON_SEPC);
+    strret = strchr(*env_prefix, H5_COLON_SEPC);
     if (strret == NULL)
         *env_prefix = NULL;
     else {
@@ -829,7 +828,7 @@ H5F_prefix_open_file(H5F_t *primary_file, H5F_prefix_open_t prefix_type, const c
     /* Copy the file name to use */
     if (NULL == (temp_file_name = H5MM_strdup(file_name)))
         HGOTO_ERROR(H5E_RESOURCE, H5E_NOSPACE, NULL, "memory allocation failed");
-    temp_file_name_len = HDstrlen(temp_file_name);
+    temp_file_name_len = strlen(temp_file_name);
 
     /* Target file_name is an absolute pathname: see RM for detailed description */
     if (H5_CHECK_ABSOLUTE(file_name) || H5_CHECK_ABS_PATH(file_name)) {
@@ -851,7 +850,7 @@ H5F_prefix_open_file(H5F_t *primary_file, H5F_prefix_open_t prefix_type, const c
             ptr++;
 
             /* Copy into the temp. file name */
-            HDstrncpy(temp_file_name, ptr, temp_file_name_len);
+            strncpy(temp_file_name, ptr, temp_file_name_len);
             temp_file_name[temp_file_name_len - 1] = '\0';
         } /* end if */
     }     /* end if */
@@ -865,7 +864,7 @@ H5F_prefix_open_file(H5F_t *primary_file, H5F_prefix_open_t prefix_type, const c
             H5E_clear_stack(NULL);
 
             /* Strip "<drive-letter>:" */
-            HDstrncpy(temp_file_name, &file_name[2], temp_file_name_len);
+            strncpy(temp_file_name, &file_name[2], temp_file_name_len);
             temp_file_name[temp_file_name_len - 1] = '\0';
         } /* end if */
     }     /* end if */
@@ -1280,11 +1279,11 @@ H5F__new(H5F_shared_t *shared, unsigned flags, hid_t fcpl_id, hid_t fapl_id, H5F
             if (H5P_get(plist, H5F_ACS_MDC_LOG_LOCATION_NAME, &mdc_log_location) < 0)
                 HGOTO_ERROR(H5E_PLIST, H5E_CANTGET, NULL, "can't get mdc log location");
             if (mdc_log_location != NULL) {
-                size_t len = HDstrlen(mdc_log_location);
+                size_t len = strlen(mdc_log_location);
                 if (NULL == (f->shared->mdc_log_location = (char *)H5MM_calloc((len + 1) * sizeof(char))))
                     HGOTO_ERROR(H5E_RESOURCE, H5E_CANTALLOC, NULL,
                                 "can't allocate memory for mdc log file name");
-                HDstrncpy(f->shared->mdc_log_location, mdc_log_location, len);
+                strncpy(f->shared->mdc_log_location, mdc_log_location, len);
             }
             else
                 f->shared->mdc_log_location = NULL;
@@ -3166,7 +3165,7 @@ H5F__get_file_image(H5F_t *file, void *buf_ptr, size_t buf_len, size_t *image_le
      *
      *                                          JRM -- 11/11/22
      */
-    if (HDstrcmp(fd_ptr->cls->name, "multi") == 0)
+    if (strcmp(fd_ptr->cls->name, "multi") == 0)
         HGOTO_ERROR(H5E_ARGS, H5E_BADVALUE, FAIL, "Not supported for multi file driver.");
 
     /* While the family file driver is conceptually fully compatible
@@ -3188,7 +3187,7 @@ H5F__get_file_image(H5F_t *file, void *buf_ptr, size_t buf_len, size_t *image_le
      * in the future.
      *                                   JRM -- 12/21/11
      */
-    if (HDstrcmp(fd_ptr->cls->name, "family") == 0)
+    if (strcmp(fd_ptr->cls->name, "family") == 0)
         HGOTO_ERROR(H5E_FILE, H5E_BADVALUE, FAIL, "Not supported for family file driver.");
 
     /* Go get the actual file size */

--- a/src/H5Gbtree2.c
+++ b/src/H5Gbtree2.c
@@ -151,7 +151,7 @@ H5G__dense_fh_name_cmp(const void *obj, size_t obj_len, void *_udata)
         HGOTO_ERROR(H5E_SYM, H5E_CANTDECODE, FAIL, "can't decode link");
 
     /* Compare the string values */
-    udata->cmp = HDstrcmp(udata->name, lnk->name);
+    udata->cmp = strcmp(udata->name, lnk->name);
 
     /* Check for correct link & callback to make */
     if (udata->cmp == 0 && udata->found_op) {

--- a/src/H5Gcompact.c
+++ b/src/H5Gcompact.c
@@ -214,11 +214,11 @@ H5G__compact_get_name_by_idx(const H5O_loc_t *oloc, const H5O_linfo_t *linfo, H5
         HGOTO_ERROR(H5E_ARGS, H5E_BADVALUE, FAIL, "index out of bound");
 
     /* Get the length of the name */
-    *name_len = HDstrlen(ltable.lnks[idx].name);
+    *name_len = strlen(ltable.lnks[idx].name);
 
     /* Copy the name into the user's buffer, if given */
     if (name) {
-        HDstrncpy(name, ltable.lnks[idx].name, MIN((*name_len + 1), name_size));
+        strncpy(name, ltable.lnks[idx].name, MIN((*name_len + 1), name_size));
         if (*name_len >= name_size)
             name[name_size - 1] = '\0';
     } /* end if */
@@ -255,7 +255,7 @@ H5G__compact_remove_common_cb(const void *_mesg, unsigned H5_ATTR_UNUSED idx, vo
     assert(udata);
 
     /* If we've found the right link, get the object type */
-    if (HDstrcmp(lnk->name, udata->name) == 0) {
+    if (strcmp(lnk->name, udata->name) == 0) {
         /* Replace path names for link being removed */
         if (H5G__link_name_replace(udata->file, udata->grp_full_path_r, lnk) < 0)
             HGOTO_ERROR(H5E_SYM, H5E_CANTGET, H5_ITER_ERROR, "unable to get object type");
@@ -412,7 +412,7 @@ H5G__compact_lookup_cb(const void *_mesg, unsigned H5_ATTR_UNUSED idx, void *_ud
     assert(udata);
 
     /* Check for name to get information */
-    if (HDstrcmp(lnk->name, udata->name) == 0) {
+    if (strcmp(lnk->name, udata->name) == 0) {
         if (udata->lnk) {
             /* Copy link information */
             if (NULL == H5O_msg_copy(H5O_LINK_ID, lnk, udata->lnk))

--- a/src/H5Gdense.c
+++ b/src/H5Gdense.c
@@ -394,7 +394,7 @@ H5G__dense_insert(H5F_t *f, const H5O_linfo_t *linfo, const H5O_link_t *lnk)
     udata.common.f             = f;
     udata.common.fheap         = fheap;
     udata.common.name          = lnk->name;
-    udata.common.name_hash     = H5_checksum_lookup3(lnk->name, HDstrlen(lnk->name), 0);
+    udata.common.name_hash     = H5_checksum_lookup3(lnk->name, strlen(lnk->name), 0);
     udata.common.corder        = lnk->corder;
     udata.common.found_op      = NULL;
     udata.common.found_op_data = NULL;
@@ -502,7 +502,7 @@ H5G__dense_lookup(H5F_t *f, const H5O_linfo_t *linfo, const char *name, bool *fo
     udata.f             = f;
     udata.fheap         = fheap;
     udata.name          = name;
-    udata.name_hash     = H5_checksum_lookup3(name, HDstrlen(name), 0);
+    udata.name_hash     = H5_checksum_lookup3(name, strlen(name), 0);
     udata.found_op      = H5G__dense_lookup_cb; /* v2 B-tree comparison callback */
     udata.found_op_data = lnk;
 
@@ -1004,11 +1004,11 @@ H5G__dense_get_name_by_idx_fh_cb(const void *obj, size_t obj_len, void *_udata)
         HGOTO_ERROR(H5E_SYM, H5E_CANTDECODE, FAIL, "can't decode link");
 
     /* Get the length of the name */
-    udata->name_len = HDstrlen(lnk->name);
+    udata->name_len = strlen(lnk->name);
 
     /* Copy the name into the user's buffer, if given */
     if (udata->name) {
-        HDstrncpy(udata->name, lnk->name, MIN((udata->name_len + 1), udata->name_size));
+        strncpy(udata->name, lnk->name, MIN((udata->name_len + 1), udata->name_size));
         if (udata->name_len >= udata->name_size)
             udata->name[udata->name_size - 1] = '\0';
     } /* end if */
@@ -1146,11 +1146,11 @@ H5G__dense_get_name_by_idx(H5F_t *f, H5O_linfo_t *linfo, H5_index_t idx_type, H5
             HGOTO_ERROR(H5E_ARGS, H5E_BADVALUE, FAIL, "index out of bound");
 
         /* Get the length of the name */
-        *name_len = HDstrlen(ltable.lnks[n].name);
+        *name_len = strlen(ltable.lnks[n].name);
 
         /* Copy the name into the user's buffer, if given */
         if (name) {
-            HDstrncpy(name, ltable.lnks[n].name, MIN((*name_len + 1), name_size));
+            strncpy(name, ltable.lnks[n].name, MIN((*name_len + 1), name_size));
             if (*name_len >= name_size)
                 name[name_size - 1] = '\0';
         } /* end if */
@@ -1306,7 +1306,7 @@ H5G__dense_remove(H5F_t *f, const H5O_linfo_t *linfo, H5RS_str_t *grp_full_path_
     udata.common.f             = f;
     udata.common.fheap         = fheap;
     udata.common.name          = name;
-    udata.common.name_hash     = H5_checksum_lookup3(name, HDstrlen(name), 0);
+    udata.common.name_hash     = H5_checksum_lookup3(name, strlen(name), 0);
     udata.common.found_op      = NULL;
     udata.common.found_op_data = NULL;
     udata.rem_from_fheap       = true;
@@ -1418,7 +1418,7 @@ H5G__dense_remove_by_idx_bt2_cb(const void *_record, void *_bt2_udata)
             other_bt2_udata.fheap = bt2_udata->fheap;
             other_bt2_udata.name  = fh_udata.lnk->name;
             other_bt2_udata.name_hash =
-                H5_checksum_lookup3(fh_udata.lnk->name, HDstrlen(fh_udata.lnk->name), 0);
+                H5_checksum_lookup3(fh_udata.lnk->name, strlen(fh_udata.lnk->name), 0);
             other_bt2_udata.found_op      = NULL;
             other_bt2_udata.found_op_data = NULL;
         } /* end else */

--- a/src/H5Gent.c
+++ b/src/H5Gent.c
@@ -371,7 +371,7 @@ H5G__ent_convert(H5F_t *f, H5HL_t *heap, const char *name, const H5O_link_t *lnk
     H5G__ent_reset(ent);
 
     /* Add the new name to the heap */
-    if (H5HL_insert(f, heap, HDstrlen(name) + 1, name, &name_offset) < 0)
+    if (H5HL_insert(f, heap, strlen(name) + 1, name, &name_offset) < 0)
         HGOTO_ERROR(H5E_SYM, H5E_CANTINSERT, FAIL, "unable to insert symbol name into heap");
     ent->name_off = name_offset;
 
@@ -459,7 +459,7 @@ H5G__ent_convert(H5F_t *f, H5HL_t *heap, const char *name, const H5O_link_t *lnk
             size_t lnk_offset; /* Offset to sym-link value	*/
 
             /* Insert link value into local heap */
-            if (H5HL_insert(f, heap, HDstrlen(lnk->u.soft.name) + 1, lnk->u.soft.name, &lnk_offset) < 0)
+            if (H5HL_insert(f, heap, strlen(lnk->u.soft.name) + 1, lnk->u.soft.name, &lnk_offset) < 0)
                 HGOTO_ERROR(H5E_SYM, H5E_CANTINIT, FAIL, "unable to write link value to local heap");
 
             ent->type                    = H5G_CACHED_SLINK;

--- a/src/H5Gint.c
+++ b/src/H5Gint.c
@@ -931,7 +931,7 @@ H5G__visit_cb(const H5O_link_t *lnk, void *_udata)
 
     /* Check if we will need more space to store this link's relative path */
     /* ("+2" is for string terminator and possible '/' for group separator later) */
-    link_name_len = HDstrlen(lnk->name);
+    link_name_len = strlen(lnk->name);
     len_needed    = udata->curr_path_len + link_name_len + 2;
     if (len_needed > udata->path_buf_size) {
         void *new_path; /* Pointer to new path buffer */
@@ -945,7 +945,7 @@ H5G__visit_cb(const H5O_link_t *lnk, void *_udata)
 
     /* Build the link's relative path name */
     assert(udata->path[old_path_len] == '\0');
-    HDstrncpy(&(udata->path[old_path_len]), lnk->name, link_name_len + 1);
+    strncpy(&(udata->path[old_path_len]), lnk->name, link_name_len + 1);
     udata->curr_path_len += link_name_len;
 
     /* Construct the link info from the link message */
@@ -1008,7 +1008,7 @@ H5G__visit_cb(const H5O_link_t *lnk, void *_udata)
 
                 /* Add the path separator to the current path */
                 assert(udata->path[udata->curr_path_len] == '\0');
-                HDstrncpy(&(udata->path[udata->curr_path_len]), "/", (size_t)2);
+                strncpy(&(udata->path[udata->curr_path_len]), "/", (size_t)2);
                 udata->curr_path_len++;
 
                 /* Attempt to get the link info for this group */

--- a/src/H5Glink.c
+++ b/src/H5Glink.c
@@ -91,7 +91,7 @@ H5G__link_cmp_name_inc(const void *lnk1, const void *lnk2)
 {
     FUNC_ENTER_PACKAGE_NOERR
 
-    FUNC_LEAVE_NOAPI(HDstrcmp(((const H5O_link_t *)lnk1)->name, ((const H5O_link_t *)lnk2)->name))
+    FUNC_LEAVE_NOAPI(strcmp(((const H5O_link_t *)lnk1)->name, ((const H5O_link_t *)lnk2)->name))
 } /* end H5G__link_cmp_name_inc() */
 
 /*-------------------------------------------------------------------------
@@ -113,7 +113,7 @@ H5G__link_cmp_name_dec(const void *lnk1, const void *lnk2)
 {
     FUNC_ENTER_PACKAGE_NOERR
 
-    FUNC_LEAVE_NOAPI(HDstrcmp(((const H5O_link_t *)lnk2)->name, ((const H5O_link_t *)lnk1)->name))
+    FUNC_LEAVE_NOAPI(strcmp(((const H5O_link_t *)lnk2)->name, ((const H5O_link_t *)lnk1)->name))
 } /* end H5G__link_cmp_name_dec() */
 
 /*-------------------------------------------------------------------------
@@ -276,7 +276,7 @@ H5G_link_to_info(const H5O_loc_t *link_loc, const H5O_link_t *lnk, H5L_info2_t *
                 break;
 
             case H5L_TYPE_SOFT:
-                info->u.val_size = HDstrlen(lnk->u.soft.name) + 1; /*count the null terminator*/
+                info->u.val_size = strlen(lnk->u.soft.name) + 1; /*count the null terminator*/
                 break;
 
             case H5L_TYPE_ERROR:

--- a/src/H5Gloc.c
+++ b/src/H5Gloc.c
@@ -871,7 +871,7 @@ H5G__loc_set_comment_cb(H5G_loc_t H5_ATTR_UNUSED *grp_loc /*in*/, const char H5_
 
     /* Add the new message */
     if (udata->comment && *udata->comment) {
-        if (NULL == (comment.s = HDstrdup(udata->comment)))
+        if (NULL == (comment.s = strdup(udata->comment)))
             HGOTO_ERROR(H5E_RESOURCE, H5E_CANTALLOC, FAIL, "can't copy group comment");
         if (H5O_msg_create(obj_loc->oloc, H5O_NAME_ID, 0, H5O_UPDATE_TIME, &comment) < 0)
             HGOTO_ERROR(H5E_OHDR, H5E_CANTINIT, FAIL, "unable to set comment object header message");
@@ -953,8 +953,8 @@ H5G__loc_get_comment_cb(H5G_loc_t H5_ATTR_UNUSED *grp_loc /*in*/, const char H5_
     }
     else {
         if (udata->comment && udata->bufsize)
-            HDstrncpy(udata->comment, comment.s, udata->bufsize);
-        udata->comment_size = HDstrlen(comment.s);
+            strncpy(udata->comment, comment.s, udata->bufsize);
+        udata->comment_size = strlen(comment.s);
         H5O_msg_reset(H5O_NAME_ID, &comment);
     }
 

--- a/src/H5Gname.c
+++ b/src/H5Gname.c
@@ -116,7 +116,7 @@ H5G__component(const char *name, size_t *size_p)
     while ('/' == *name)
         name++;
     if (size_p)
-        *size_p = HDstrcspn(name, "/");
+        *size_p = strcspn(name, "/");
 
     FUNC_LEAVE_NOAPI(name)
 } /* end H5G__component() */
@@ -217,7 +217,7 @@ H5G__common_path(const H5RS_str_t *fullpath_r, const H5RS_str_t *prefix_r)
         /* Check that the components we found are the same length */
         if (nchars1 == nchars2) {
             /* Check that the two components are equal */
-            if (HDstrncmp(fullpath, prefix, nchars1) == 0) {
+            if (strncmp(fullpath, prefix, nchars1) == 0) {
                 /* Advance the pointers in the names */
                 fullpath += nchars1;
                 prefix += nchars2;
@@ -266,7 +266,7 @@ H5G__build_fullpath(const char *prefix, const char *name)
     /* Create full path */
     if (NULL == (ret_value = H5RS_create(prefix)))
         HGOTO_ERROR(H5E_SYM, H5E_CANTCREATE, NULL, "can't create ref-counted string");
-    if (prefix[HDstrlen(prefix) - 1] != '/')
+    if (prefix[strlen(prefix) - 1] != '/')
         H5RS_aputc(ret_value, '/'); /* Add separator, if the prefix doesn't end in one */
     H5RS_acat(ret_value, name);
 
@@ -455,7 +455,7 @@ H5G_get_name(const H5G_loc_t *loc, char *name /*out*/, size_t size, size_t *name
         len = H5RS_len(loc->path->user_path_r);
 
         if (name) {
-            HDstrncpy(name, H5RS_get_str(loc->path->user_path_r), MIN((len + 1), size));
+            strncpy(name, H5RS_get_str(loc->path->user_path_r), MIN((len + 1), size));
             if (len >= size)
                 name[size - 1] = '\0';
         } /* end if */
@@ -570,8 +570,8 @@ H5G__name_move_path(H5RS_str_t **path_r_ptr, const char *full_suffix, const char
     assert(path);
 
     /* Check if path needs to be updated */
-    full_suffix_len = HDstrlen(full_suffix);
-    path_len        = HDstrlen(path);
+    full_suffix_len = strlen(full_suffix);
+    path_len        = strlen(path);
     if (full_suffix_len < path_len) {
         const char *dst_suffix;        /* Destination suffix that changes */
         const char *src_suffix;        /* Source suffix that changes */
@@ -603,7 +603,7 @@ H5G__name_move_path(H5RS_str_t **path_r_ptr, const char *full_suffix, const char
 
         /* Compute path prefix before src suffix */
         path_prefix2     = path;
-        path_prefix2_len = path_prefix_len - HDstrlen(src_suffix);
+        path_prefix2_len = path_prefix_len - strlen(src_suffix);
 
         /* Allocate new ref-counted string */
         if (NULL == (rs = H5RS_create(NULL)))
@@ -781,7 +781,7 @@ H5G__name_replace_cb(void *obj_ptr, hid_t obj_id, void *key)
                 src_path  = H5RS_get_str(names->src_full_path_r);
 
                 /* Construct full path suffix */
-                full_suffix = full_path + HDstrlen(src_path);
+                full_suffix = full_path + strlen(src_path);
 
                 /* Create new full path suffix */
                 if (NULL == (rs = H5RS_create(full_suffix)))
@@ -848,7 +848,7 @@ H5G__name_replace_cb(void *obj_ptr, hid_t obj_id, void *key)
                 assert(*dst_path == '/');
 
                 /* Get pointer to "full suffix" */
-                full_suffix = full_path + HDstrlen(src_path);
+                full_suffix = full_path + strlen(src_path);
 
                 /* Update the user path, if one exists */
                 if (obj_path->user_path_r)
@@ -1141,16 +1141,16 @@ H5G_get_name_by_addr(H5F_t *f, const H5O_loc_t *loc, char *name, size_t size, si
     /* Check for finding the object */
     if (found_obj) {
         /* Set the length of the full path */
-        len = HDstrlen(udata.path) + 1; /* Length of path + 1 (for "/") */
+        len = strlen(udata.path) + 1; /* Length of path + 1 (for "/") */
 
         /* If there's a buffer provided, copy into it, up to the limit of its size */
         if (name) {
             /* Copy the initial path separator */
-            HDstrncpy(name, "/", (size_t)2);
+            strncpy(name, "/", (size_t)2);
 
             /* Append the rest of the path */
             /* (less one character, for the initial path separator) */
-            HDstrncat(name, udata.path, (size - 2));
+            strncat(name, udata.path, (size - 2));
             if (len >= size)
                 name[size - 1] = '\0';
         } /* end if */

--- a/src/H5Gnode.c
+++ b/src/H5Gnode.c
@@ -360,7 +360,7 @@ H5G__node_cmp2(void *_lt_key, void *_udata, void *_rt_key)
         HGOTO_ERROR(H5E_SYM, H5E_CANTGET, FAIL, "unable to get key name");
 
     /* Set return value */
-    ret_value = HDstrcmp(s1, s2);
+    ret_value = strcmp(s1, s2);
 
 done:
     FUNC_LEAVE_NOAPI(ret_value)
@@ -406,13 +406,13 @@ H5G__node_cmp3(void *_lt_key, void *_udata, void *_rt_key)
     /* left side */
     if ((s = (const char *)H5HL_offset_into(udata->heap, lt_key->offset)) == NULL)
         HGOTO_ERROR(H5E_SYM, H5E_CANTGET, FAIL, "unable to get key name");
-    if (HDstrcmp(udata->name, s) <= 0)
+    if (strcmp(udata->name, s) <= 0)
         ret_value = (-1);
     else {
         /* right side */
         if ((s = (const char *)H5HL_offset_into(udata->heap, rt_key->offset)) == NULL)
             HGOTO_ERROR(H5E_SYM, H5E_CANTGET, FAIL, "unable to get key name");
-        if (HDstrcmp(udata->name, s) > 0)
+        if (strcmp(udata->name, s) > 0)
             ret_value = 1;
     } /* end else */
 
@@ -476,7 +476,7 @@ H5G__node_found(H5F_t *f, haddr_t addr, const void H5_ATTR_UNUSED *_lt_key, bool
 
         if ((s = (const char *)H5HL_offset_into(udata->common.heap, sn->entry[idx].name_off)) == NULL)
             HGOTO_ERROR(H5E_SYM, H5E_CANTGET, FAIL, "unable to get symbol table name");
-        cmp = HDstrcmp(udata->common.name, s);
+        cmp = strcmp(udata->common.name, s);
 
         if (cmp < 0)
             rt = idx;
@@ -574,7 +574,7 @@ H5G__node_insert(H5F_t *f, haddr_t addr, void H5_ATTR_UNUSED *_lt_key, bool H5_A
             HGOTO_ERROR(H5E_SYM, H5E_CANTGET, H5B_INS_ERROR, "unable to get symbol table name");
 
         /* Check if symbol is already present */
-        if (0 == (cmp = HDstrcmp(udata->common.name, s)))
+        if (0 == (cmp = strcmp(udata->common.name, s)))
             HGOTO_ERROR(H5E_SYM, H5E_CANTINSERT, H5B_INS_ERROR, "symbol is already present in symbol table");
 
         if (cmp < 0)
@@ -727,7 +727,7 @@ H5G__node_remove(H5F_t *f, haddr_t addr, void H5_ATTR_NDEBUG_UNUSED *_lt_key /*i
             idx = (lt + rt) / 2;
             if ((s = (const char *)H5HL_offset_into(udata->common.heap, sn->entry[idx].name_off)) == NULL)
                 HGOTO_ERROR(H5E_SYM, H5E_CANTGET, H5B_INS_ERROR, "unable to get symbol table name");
-            cmp = HDstrcmp(udata->common.name, s);
+            cmp = strcmp(udata->common.name, s);
             if (cmp < 0)
                 rt = idx;
             else
@@ -740,7 +740,7 @@ H5G__node_remove(H5F_t *f, haddr_t addr, void H5_ATTR_NDEBUG_UNUSED *_lt_key /*i
         /* Get a pointer to the name of the link */
         if (NULL == (lnk.name = (char *)H5HL_offset_into(udata->common.heap, sn->entry[idx].name_off)))
             HGOTO_ERROR(H5E_SYM, H5E_CANTGET, H5B_INS_ERROR, "unable to get link name");
-        link_name_len = HDstrlen(lnk.name) + 1;
+        link_name_len = strlen(lnk.name) + 1;
 
         /* Set up rest of link structure */
         lnk.corder_valid = false;
@@ -778,7 +778,7 @@ H5G__node_remove(H5F_t *f, haddr_t addr, void H5_ATTR_NDEBUG_UNUSED *_lt_key /*i
             if (lnk.u.soft.name) {
                 size_t soft_link_len; /* Length of string in local heap */
 
-                soft_link_len = HDstrlen(lnk.u.soft.name) + 1;
+                soft_link_len = strlen(lnk.u.soft.name) + 1;
                 if (H5HL_remove(f, udata->common.heap, sn->entry[idx].cache.slink.lval_offset,
                                 soft_link_len) < 0)
                     HGOTO_ERROR(H5E_SYM, H5E_CANTDELETE, H5B_INS_ERROR,

--- a/src/H5Gstab.c
+++ b/src/H5Gstab.c
@@ -725,11 +725,11 @@ H5G__stab_get_name_by_idx(const H5O_loc_t *oloc, H5_iter_order_t order, hsize_t 
         HGOTO_ERROR(H5E_ARGS, H5E_BADTYPE, FAIL, "index out of bound");
 
     /* Get the length of the name */
-    *name_len = HDstrlen(udata.name);
+    *name_len = strlen(udata.name);
 
     /* Copy the name into the user's buffer, if given */
     if (name) {
-        HDstrncpy(name, udata.name, MIN((*name_len + 1), name_size));
+        strncpy(name, udata.name, MIN((*name_len + 1), name_size));
         if (*name_len >= name_size)
             name[name_size - 1] = '\0';
     } /* end if */

--- a/src/H5Gtest.c
+++ b/src/H5Gtest.c
@@ -617,7 +617,7 @@ H5G__user_path_test(hid_t obj_id, char *user_path, size_t *user_path_len, unsign
 
         /* Set the user path, if given */
         if (user_path)
-            HDstrncpy(user_path, H5RS_get_str(obj_path->user_path_r), (len + 1));
+            strncpy(user_path, H5RS_get_str(obj_path->user_path_r), (len + 1));
 
         /* Set the length of the path */
         *user_path_len = len;

--- a/src/H5Gtraverse.c
+++ b/src/H5Gtraverse.c
@@ -511,7 +511,7 @@ H5G__traverse_real(const H5G_loc_t *_loc, const char *name, unsigned target, H5G
         HGOTO_ERROR(H5E_SYM, H5E_CANTINIT, FAIL, "can't wrap buffer");
 
     /* Get a pointer to a buffer that's large enough  */
-    if (NULL == (comp = (char *)H5WB_actual(wb, (HDstrlen(name) + 1))))
+    if (NULL == (comp = (char *)H5WB_actual(wb, (strlen(name) + 1))))
         HGOTO_ERROR(H5E_SYM, H5E_NOSPACE, FAIL, "can't get actual buffer");
 
     /* Traverse the path */
@@ -555,7 +555,7 @@ H5G__traverse_real(const H5G_loc_t *_loc, const char *name, unsigned target, H5G
         if (lookup_status) {
             /* Sanity check link and indicate it's valid */
             assert(lnk.type >= H5L_TYPE_HARD);
-            assert(!HDstrcmp(comp, lnk.name));
+            assert(!strcmp(comp, lnk.name));
             link_valid = true;
 
             /* Build object location from the link */

--- a/src/H5HFdbg.c
+++ b/src/H5HFdbg.c
@@ -398,7 +398,7 @@ H5HF_dblock_debug_cb(H5FS_section_info_t *_sect, void *_udata)
         /* Calculate the length */
         len = end - start;
 
-        HDsnprintf(temp_str, sizeof(temp_str), "Section #%u:", (unsigned)udata->sect_count);
+        snprintf(temp_str, sizeof(temp_str), "Section #%u:", (unsigned)udata->sect_count);
         fprintf(udata->stream, "%*s%-*s %8zu, %8zu\n", udata->indent + 3, "", MAX(0, udata->fwidth - 9),
                 temp_str, start, len);
         udata->sect_count++;
@@ -591,13 +591,13 @@ H5HF_iblock_print(const H5HF_indirect_t *iblock, bool dump_internal, FILE *strea
     else
         fprintf(stream, "%*sDirect Block Entries: (address)\n", indent, "");
     for (u = 0; u < hdr->man_dtable.max_direct_rows && u < iblock->nrows; u++) {
-        HDsnprintf(temp_str, sizeof(temp_str), "Row #%u: (block size: %lu)", (unsigned)u,
-                   (unsigned long)hdr->man_dtable.row_block_size[u]);
+        snprintf(temp_str, sizeof(temp_str), "Row #%u: (block size: %lu)", (unsigned)u,
+                 (unsigned long)hdr->man_dtable.row_block_size[u]);
         fprintf(stream, "%*s%-*s\n", indent + 3, "", MAX(0, fwidth - 3), temp_str);
         for (v = 0; v < hdr->man_dtable.cparam.width; v++) {
             size_t off = (u * hdr->man_dtable.cparam.width) + v;
 
-            HDsnprintf(temp_str, sizeof(temp_str), "Col #%u:", (unsigned)v);
+            snprintf(temp_str, sizeof(temp_str), "Col #%u:", (unsigned)v);
             if (hdr->filter_len > 0)
                 fprintf(stream, "%*s%-*s %9" PRIuHADDR "/%6zu/%x\n", indent + 6, "", MAX(0, fwidth - 6),
                         temp_str, iblock->ents[off].addr, iblock->filt_ents[off].size,
@@ -616,13 +616,12 @@ H5HF_iblock_print(const H5HF_indirect_t *iblock, bool dump_internal, FILE *strea
                          H5VM_log2_of2(hdr->man_dtable.cparam.width);
         for (u = hdr->man_dtable.max_direct_rows; u < iblock->nrows; u++) {
             num_indirect_rows = (H5VM_log2_gen(hdr->man_dtable.row_block_size[u]) - first_row_bits) + 1;
-            HDsnprintf(temp_str, sizeof(temp_str), "Row #%u: (# of rows: %u)", (unsigned)u,
-                       num_indirect_rows);
+            snprintf(temp_str, sizeof(temp_str), "Row #%u: (# of rows: %u)", (unsigned)u, num_indirect_rows);
             fprintf(stream, "%*s%-*s\n", indent + 3, "", MAX(0, fwidth - 3), temp_str);
             for (v = 0; v < hdr->man_dtable.cparam.width; v++) {
                 size_t off = (u * hdr->man_dtable.cparam.width) + v;
 
-                HDsnprintf(temp_str, sizeof(temp_str), "Col #%u:", (unsigned)v);
+                snprintf(temp_str, sizeof(temp_str), "Col #%u:", (unsigned)v);
                 fprintf(stream, "%*s%-*s %9" PRIuHADDR "\n", indent + 6, "", MAX(0, fwidth - 6), temp_str,
                         iblock->ents[off].addr);
             } /* end for */

--- a/src/H5HFtest.c
+++ b/src/H5HFtest.c
@@ -178,7 +178,7 @@ H5HF_cmp_cparam_test(const H5HF_create_t *cparam1, const H5HF_create_t *cparam2)
             else if(cparam1->pline.filter[u].name && !cparam2->pline.filter[u].name)
                 HGOTO_DONE(1);
             else if(cparam1->pline.filter[u].name && cparam2->pline.filter[u].name) {
-                if((ret_value = HDstrcmp(cparam1->pline.filter[u].name, cparam2->pline.filter[u].name)))
+                if((ret_value = strcmp(cparam1->pline.filter[u].name, cparam2->pline.filter[u].name)))
                     HGOTO_DONE(ret_value);
             } /* end if */
 #endif

--- a/src/H5HGdbg.c
+++ b/src/H5HGdbg.c
@@ -111,7 +111,7 @@ H5HG_debug(H5F_t *f, haddr_t addr, FILE *stream, int indent, int fwidth)
         if (h->obj[u].begin) {
             char buf[64];
 
-            HDsnprintf(buf, sizeof(buf), "Object %u", u);
+            snprintf(buf, sizeof(buf), "Object %u", u);
             fprintf(stream, "%*s%s\n", indent, "", buf);
             fprintf(stream, "%*s%-*s %lu\n", indent + 3, "", MIN(fwidth - 3, 0),
                     "Obffset in block:", (unsigned long)(h->obj[u].begin - h->chunk));
@@ -129,12 +129,12 @@ H5HG_debug(H5F_t *f, haddr_t addr, FILE *stream, int indent, int fwidth)
                     if (j + k < h->obj[u].size)
                         fprintf(stream, "%02x ", p[j + k]);
                     else
-                        HDfputs("   ", stream);
+                        fputs("   ", stream);
                 }
                 for (k = 0; k < 16 && j + k < h->obj[u].size; k++) {
                     if (8 == k)
                         fprintf(stream, " ");
-                    HDfputc(p[j + k] > ' ' && p[j + k] <= '~' ? p[j + k] : '.', stream);
+                    fputc(p[j + k] > ' ' && p[j + k] <= '~' ? p[j + k] : '.', stream);
                 }
                 fprintf(stream, "\n");
             }

--- a/src/H5HLdbg.c
+++ b/src/H5HLdbg.c
@@ -76,7 +76,7 @@ H5HL_debug(H5F_t *f, haddr_t addr, FILE *stream, int indent, int fwidth)
     for (free_block = 0, freelist = h->freelist; freelist; freelist = freelist->next, free_block++) {
         char temp_str[32];
 
-        HDsnprintf(temp_str, sizeof(temp_str), "Block #%d:", free_block);
+        snprintf(temp_str, sizeof(temp_str), "Block #%d:", free_block);
         fprintf(stream, "%*s%-*s %8zu, %8zu\n", indent + 3, "", MAX(0, fwidth - 9), temp_str,
                 freelist->offset, freelist->size);
         if ((freelist->offset + freelist->size) > h->dblk_size)

--- a/src/H5L.c
+++ b/src/H5L.c
@@ -665,8 +665,8 @@ H5Lcreate_external(const char *file_name, const char *obj_name, hid_t link_loc_i
         HGOTO_ERROR(H5E_LINK, H5E_BADVALUE, FAIL, "can't normalize object name");
 
     /* Combine the filename and link name into a single buffer to give to the UD link */
-    file_name_len     = HDstrlen(file_name) + 1;
-    norm_obj_name_len = HDstrlen(norm_obj_name) + 1;
+    file_name_len     = strlen(file_name) + 1;
+    norm_obj_name_len = strlen(norm_obj_name) + 1;
     buf_size          = 1 + file_name_len + norm_obj_name_len;
     if (NULL == (ext_link_buf = H5MM_malloc(buf_size)))
         HGOTO_ERROR(H5E_RESOURCE, H5E_NOSPACE, FAIL, "unable to allocate udata buffer");
@@ -674,9 +674,9 @@ H5Lcreate_external(const char *file_name, const char *obj_name, hid_t link_loc_i
     /* Encode the external link information */
     p    = (uint8_t *)ext_link_buf;
     *p++ = (H5L_EXT_VERSION << 4) | H5L_EXT_FLAGS_ALL; /* External link version & flags */
-    HDstrncpy((char *)p, file_name, buf_size - 1);     /* Name of file containing external link's object */
+    strncpy((char *)p, file_name, buf_size - 1);       /* Name of file containing external link's object */
     p += file_name_len;
-    HDstrncpy((char *)p, norm_obj_name, buf_size - (file_name_len + 1)); /* External link's object */
+    strncpy((char *)p, norm_obj_name, buf_size - (file_name_len + 1)); /* External link's object */
 
     loc_params.type                         = H5VL_OBJECT_BY_NAME;
     loc_params.loc_data.loc_by_name.name    = link_name;
@@ -1982,10 +1982,10 @@ H5Lunpack_elink_val(const void *_ext_linkval, size_t link_size, unsigned *flags,
     if (ext_linkval[link_size - 1] != '\0')
         HGOTO_ERROR(H5E_ARGS, H5E_BADVALUE, FAIL, "linkval buffer is not NULL-terminated");
 
-    /* We're now guaranteed that HDstrlen won't segfault, since the buffer has
+    /* We're now guaranteed that strlen won't segfault, since the buffer has
      * at least one NULL in it.
      */
-    len = HDstrlen((const char *)ext_linkval + 1);
+    len = strlen((const char *)ext_linkval + 1);
 
     /* If the first NULL we found was at the very end of the buffer, then
      * this external link value has no object name and is invalid.

--- a/src/H5Lexternal.c
+++ b/src/H5Lexternal.c
@@ -132,7 +132,7 @@ H5L__extern_traverse(const char H5_ATTR_UNUSED *link_name, hid_t cur_group, cons
 
     /* Gather some information from the external link's user data */
     file_name = (const char *)p;
-    fname_len = HDstrlen(file_name);
+    fname_len = strlen(file_name);
     obj_name  = (const char *)p + fname_len + 1;
 
     /* Get the plist structure */

--- a/src/H5Lint.c
+++ b/src/H5Lint.c
@@ -925,8 +925,8 @@ H5L__get_val_real(const H5O_link_t *lnk, void *buf, size_t size)
     if (H5L_TYPE_SOFT == lnk->type) {
         /* Copy to output buffer */
         if (size > 0 && buf) {
-            HDstrncpy((char *)buf, lnk->u.soft.name, size);
-            if (HDstrlen(lnk->u.soft.name) >= size)
+            strncpy((char *)buf, lnk->u.soft.name, size);
+            if (strlen(lnk->u.soft.name) >= size)
                 ((char *)buf)[size - 1] = '\0';
         } /* end if */
     }     /* end if */
@@ -1627,7 +1627,7 @@ H5L__exists_inter_cb(H5G_loc_t H5_ATTR_UNUSED *grp_loc /*in*/, const char H5_ATT
 
             /* Look for another separator */
             next = udata->sep;
-            if (NULL == (udata->sep = HDstrchr(udata->sep, '/')))
+            if (NULL == (udata->sep = strchr(udata->sep, '/')))
                 cb_func = H5L__exists_final_cb;
             else {
                 /* Chew through adjacent separators, if present */
@@ -1693,7 +1693,7 @@ H5L_exists_tolerant(const H5G_loc_t *loc, const char *name, bool *exists)
     else {
         /* Set up user data & correct callback */
         udata.exists = exists;
-        if (NULL == (udata.sep = HDstrchr(name_trav, '/')))
+        if (NULL == (udata.sep = strchr(name_trav, '/')))
             cb_func = H5L__exists_final_cb;
         else {
             /* Chew through adjacent separators, if present */
@@ -1742,7 +1742,7 @@ H5L__exists(const H5G_loc_t *loc, const char *name, bool *exists)
     assert(exists);
 
     /* A path of "/" will always exist in a file */
-    if (0 == HDstrcmp(name, "/"))
+    if (0 == strcmp(name, "/"))
         *exists = true;
     else {
         /* Traverse the group hierarchy to locate the object to get info about */

--- a/src/H5MM.c
+++ b/src/H5MM.c
@@ -112,7 +112,7 @@ H5MM_xstrdup(const char *s)
     FUNC_ENTER_NOAPI(NULL)
 
     if (s)
-        if (NULL == (ret_value = HDstrdup(s)))
+        if (NULL == (ret_value = strdup(s)))
             HGOTO_ERROR(H5E_RESOURCE, H5E_NOSPACE, NULL, "string duplication failed");
 done:
     FUNC_LEAVE_NOAPI(ret_value)
@@ -140,7 +140,7 @@ H5MM_strdup(const char *s)
 
     if (!s)
         HGOTO_ERROR(H5E_ARGS, H5E_BADVALUE, NULL, "NULL string not allowed");
-    if (NULL == (ret_value = HDstrdup(s)))
+    if (NULL == (ret_value = strdup(s)))
         HGOTO_ERROR(H5E_RESOURCE, H5E_NOSPACE, NULL, "string duplication failed");
 
 done:

--- a/src/H5O.c
+++ b/src/H5O.c
@@ -837,7 +837,7 @@ H5Olink(hid_t obj_id, hid_t new_loc_id, const char *new_name, hid_t lcpl_id, hid
         HGOTO_ERROR(H5E_ARGS, H5E_BADVALUE, FAIL, "no name specified");
 /* Avoid compiler warning on 32-bit machines */
 #if H5_SIZEOF_SIZE_T > H5_SIZEOF_INT32_T
-    if (HDstrlen(new_name) > H5L_MAX_LINK_NAME_LEN)
+    if (strlen(new_name) > H5L_MAX_LINK_NAME_LEN)
         HGOTO_ERROR(H5E_ARGS, H5E_BADRANGE, FAIL, "name too long");
 #endif /* H5_SIZEOF_SIZE_T > H5_SIZEOF_INT32_T */
     if (lcpl_id != H5P_DEFAULT && (true != H5P_isa_class(lcpl_id, H5P_LINK_CREATE)))

--- a/src/H5Oattr.c
+++ b/src/H5Oattr.c
@@ -193,7 +193,7 @@ H5O__attr_decode(H5F_t *f, H5O_t *open_oh, unsigned H5_ATTR_UNUSED mesg_flags, u
         HGOTO_ERROR(H5E_RESOURCE, H5E_NOSPACE, NULL, "memory allocation failed");
 
     /* Make an attempt to detect corrupted name or name length - HDFFV-10588 */
-    if (name_len != (HDstrnlen(attr->shared->name, name_len) + 1))
+    if (name_len != (strnlen(attr->shared->name, name_len) + 1))
         HGOTO_ERROR(H5E_ATTR, H5E_CANTDECODE, NULL, "attribute name has different length than stored length");
 
     /* Determine pointer movement and check if it's valid */
@@ -360,7 +360,7 @@ H5O__attr_encode(H5F_t *f, uint8_t *p, const void *mesg)
      * encoded lengths are exact but we pad each part except the data to be a
      * multiple of eight bytes (in the first version).
      */
-    name_len = HDstrlen(attr->shared->name) + 1;
+    name_len = strlen(attr->shared->name) + 1;
     UINT16ENCODE(p, name_len);
     UINT16ENCODE(p, attr->shared->dt_size);
     UINT16ENCODE(p, attr->shared->ds_size);
@@ -479,7 +479,7 @@ H5O__attr_size(const H5F_t H5_ATTR_UNUSED *f, const void *_mesg)
                 2;  /*space size		*/
 
     /* Length of attribute name */
-    name_len = HDstrlen(attr->shared->name) + 1;
+    name_len = strlen(attr->shared->name) + 1;
 
     /* Version-specific size information */
     if (attr->shared->version == H5O_ATTR_VERSION_1)
@@ -831,13 +831,13 @@ H5O__attr_debug(H5F_t *f, const void *_mesg, FILE *stream, int indent, int fwidt
         case H5T_CSET_RESERVED_13:
         case H5T_CSET_RESERVED_14:
         case H5T_CSET_RESERVED_15:
-            HDsnprintf(buf, sizeof(buf), "H5T_CSET_RESERVED_%d", (int)(mesg->shared->encoding));
+            snprintf(buf, sizeof(buf), "H5T_CSET_RESERVED_%d", (int)(mesg->shared->encoding));
             s = buf;
             break;
 
         case H5T_CSET_ERROR:
         default:
-            HDsnprintf(buf, sizeof(buf), "Unknown character set: %d", (int)(mesg->shared->encoding));
+            snprintf(buf, sizeof(buf), "Unknown character set: %d", (int)(mesg->shared->encoding));
             s = buf;
             break;
     } /* end switch */

--- a/src/H5Oattribute.c
+++ b/src/H5Oattribute.c
@@ -401,7 +401,7 @@ H5O__attr_open_cb(H5O_t *oh, H5O_mesg_t *mesg /*in,out*/, unsigned sequence,
     assert(!udata->attr);
 
     /* Check for correct attribute message to modify */
-    if (HDstrcmp(((H5A_t *)mesg->native)->shared->name, udata->name) == 0) {
+    if (strcmp(((H5A_t *)mesg->native)->shared->name, udata->name) == 0) {
         /* Make a copy of the attribute to return */
         if (NULL == (udata->attr = H5A__copy(NULL, (H5A_t *)mesg->native)))
             HGOTO_ERROR(H5E_ATTR, H5E_CANTCOPY, H5_ITER_ERROR, "unable to copy attribute");
@@ -673,7 +673,7 @@ H5O__attr_find_opened_attr(const H5O_loc_t *loc, H5A_t **attr, const char *name_
              *  address to which the attribute is attached, and file serial
              *  number should all match.
              */
-            if (!HDstrcmp(name_to_open, (*attr)->shared->name) && loc->addr == (*attr)->oloc.addr &&
+            if (!strcmp(name_to_open, (*attr)->shared->name) && loc->addr == (*attr)->oloc.addr &&
                 loc_fnum == attr_fnum) {
                 ret_value = true;
                 break;
@@ -784,7 +784,7 @@ H5O__attr_write_cb(H5O_t *oh, H5O_mesg_t *mesg /*in,out*/, unsigned H5_ATTR_UNUS
     assert(!udata->found);
 
     /* Check for correct attribute message to modify */
-    if (0 == HDstrcmp(((H5A_t *)mesg->native)->shared->name, udata->attr->shared->name)) {
+    if (0 == strcmp(((H5A_t *)mesg->native)->shared->name, udata->attr->shared->name)) {
         /* Protect chunk */
         if (NULL == (chk_proxy = H5O__chunk_protect(udata->f, oh, mesg->chunkno)))
             HGOTO_ERROR(H5E_ATTR, H5E_CANTPROTECT, H5_ITER_ERROR, "unable to load object header chunk");
@@ -935,7 +935,7 @@ H5O__attr_rename_chk_cb(H5O_t H5_ATTR_UNUSED *oh, H5O_mesg_t *mesg /*in,out*/,
     assert(!udata->found);
 
     /* Check for existing attribute with new name */
-    if (HDstrcmp(((H5A_t *)mesg->native)->shared->name, udata->new_name) == 0) {
+    if (strcmp(((H5A_t *)mesg->native)->shared->name, udata->new_name) == 0) {
         /* Indicate that we found an existing attribute with the new name*/
         udata->found = true;
 
@@ -978,7 +978,7 @@ H5O__attr_rename_mod_cb(H5O_t *oh, H5O_mesg_t *mesg /*in,out*/, unsigned H5_ATTR
     assert(!udata->found);
 
     /* Find correct attribute message to rename */
-    if (HDstrcmp(((H5A_t *)mesg->native)->shared->name, udata->old_name) == 0) {
+    if (strcmp(((H5A_t *)mesg->native)->shared->name, udata->old_name) == 0) {
         unsigned old_version = ((H5A_t *)mesg->native)->shared->version; /* Old version of the attribute */
 
         /* Protect chunk */
@@ -1015,7 +1015,7 @@ H5O__attr_rename_mod_cb(H5O_t *oh, H5O_mesg_t *mesg /*in,out*/, unsigned H5_ATTR
             assert(H5O_msg_is_shared(H5O_ATTR_ID, (H5A_t *)mesg->native) == false);
 
             /* Check for attribute message changing size */
-            if (HDstrlen(udata->new_name) != HDstrlen(udata->old_name) ||
+            if (strlen(udata->new_name) != strlen(udata->old_name) ||
                 old_version != ((H5A_t *)mesg->native)->shared->version) {
                 H5A_t *attr; /* Attribute to re-add */
 
@@ -1421,7 +1421,7 @@ H5O__attr_remove_cb(H5O_t *oh, H5O_mesg_t *mesg /*in,out*/, unsigned H5_ATTR_UNU
     assert(!udata->found);
 
     /* Check for correct attribute message to modify */
-    if (HDstrcmp(((H5A_t *)mesg->native)->shared->name, udata->name) == 0) {
+    if (strcmp(((H5A_t *)mesg->native)->shared->name, udata->name) == 0) {
         /* Convert message into a null message (i.e. delete it) */
         if (H5O__release_mesg(udata->f, oh, mesg, true) < 0)
             HGOTO_ERROR(H5E_OHDR, H5E_CANTDELETE, H5_ITER_ERROR, "unable to convert into null message");
@@ -1679,7 +1679,7 @@ H5O__attr_exists_cb(H5O_t H5_ATTR_UNUSED *oh, H5O_mesg_t *mesg /*in,out*/, unsig
     assert(udata->exists && !*udata->exists);
 
     /* Check for correct attribute message */
-    if (HDstrcmp(((H5A_t *)mesg->native)->shared->name, udata->name) == 0) {
+    if (strcmp(((H5A_t *)mesg->native)->shared->name, udata->name) == 0) {
         /* Indicate that this message is the attribute sought */
         *udata->exists = true;
 

--- a/src/H5Ocopy_ref.c
+++ b/src/H5Ocopy_ref.c
@@ -122,8 +122,8 @@ H5O__copy_obj_by_ref(H5O_loc_t *src_oloc, H5O_loc_t *dst_oloc, H5G_loc_t *dst_ro
         new_oloc.addr = dst_oloc->addr;
 
         /* Pick a default name for the new object */
-        HDsnprintf(tmp_obj_name, sizeof(tmp_obj_name), "~obj_pointed_by_%llu",
-                   (unsigned long long)dst_oloc->addr);
+        snprintf(tmp_obj_name, sizeof(tmp_obj_name), "~obj_pointed_by_%llu",
+                 (unsigned long long)dst_oloc->addr);
 
         /* Create a link to the newly copied object */
         /* Note: since H5O_copy_header_map actually copied the target object, it

--- a/src/H5Odbg.c
+++ b/src/H5Odbg.c
@@ -309,16 +309,16 @@ H5O__debug_real(H5F_t *f, H5O_t *oh, haddr_t addr, FILE *stream, int indent, int
 
             /* Time fields */
             tm = HDlocaltime(&oh->atime);
-            HDstrftime(buf, sizeof(buf), "%Y-%m-%d %H:%M:%S %Z", tm);
+            strftime(buf, sizeof(buf), "%Y-%m-%d %H:%M:%S %Z", tm);
             fprintf(stream, "%*s%-*s %s\n", indent, "", fwidth, "Access Time:", buf);
             tm = HDlocaltime(&oh->mtime);
-            HDstrftime(buf, sizeof(buf), "%Y-%m-%d %H:%M:%S %Z", tm);
+            strftime(buf, sizeof(buf), "%Y-%m-%d %H:%M:%S %Z", tm);
             fprintf(stream, "%*s%-*s %s\n", indent, "", fwidth, "Modification Time:", buf);
             tm = HDlocaltime(&oh->ctime);
-            HDstrftime(buf, sizeof(buf), "%Y-%m-%d %H:%M:%S %Z", tm);
+            strftime(buf, sizeof(buf), "%Y-%m-%d %H:%M:%S %Z", tm);
             fprintf(stream, "%*s%-*s %s\n", indent, "", fwidth, "Change Time:", buf);
             tm = HDlocaltime(&oh->btime);
-            HDstrftime(buf, sizeof(buf), "%Y-%m-%d %H:%M:%S %Z", tm);
+            strftime(buf, sizeof(buf), "%Y-%m-%d %H:%M:%S %Z", tm);
             fprintf(stream, "%*s%-*s %s\n", indent, "", fwidth, "Birth Time:", buf);
         } /* end if */
 

--- a/src/H5Odtype.c
+++ b/src/H5Odtype.c
@@ -339,7 +339,7 @@ H5O__dtype_decode_helper(unsigned *ioflags /*in,out*/, const uint8_t **pp, H5T_t
 
                     size_t max = (size_t)(p_end - *pp + 1); /* Max possible name length */
 
-                    actual_name_length = HDstrnlen((const char *)*pp, max);
+                    actual_name_length = strnlen((const char *)*pp, max);
                     if (actual_name_length == max)
                         HGOTO_ERROR(H5E_OHDR, H5E_NOSPACE, FAIL, "field name not null terminated");
                 }
@@ -348,7 +348,7 @@ H5O__dtype_decode_helper(unsigned *ioflags /*in,out*/, const uint8_t **pp, H5T_t
                      * passed via H5Tdecode(), so don't bounds check and hope for
                      * the best.
                      */
-                    actual_name_length = HDstrlen((const char *)*pp);
+                    actual_name_length = strlen((const char *)*pp);
                 }
 
                 if (H5_IS_KNOWN_BUFFER_OVERFLOW(skip, *pp, actual_name_length, p_end))
@@ -636,7 +636,7 @@ H5O__dtype_decode_helper(unsigned *ioflags /*in,out*/, const uint8_t **pp, H5T_t
 
                     size_t max = (size_t)(p_end - *pp + 1); /* Max possible name length */
 
-                    actual_name_length = HDstrnlen((const char *)*pp, max);
+                    actual_name_length = strnlen((const char *)*pp, max);
                     if (actual_name_length == max)
                         HGOTO_ERROR(H5E_OHDR, H5E_NOSPACE, FAIL, "enum name not null terminated");
                 }
@@ -645,7 +645,7 @@ H5O__dtype_decode_helper(unsigned *ioflags /*in,out*/, const uint8_t **pp, H5T_t
                      * passed via H5Tdecode(), so don't bounds check and hope for
                      * the best.
                      */
-                    actual_name_length = HDstrlen((const char *)*pp);
+                    actual_name_length = strlen((const char *)*pp);
                 }
 
                 if (H5_IS_KNOWN_BUFFER_OVERFLOW(skip, *pp, actual_name_length, p_end))
@@ -1092,7 +1092,7 @@ H5O__dtype_encode_helper(uint8_t **pp, const H5T_t *dt)
             {
                 size_t aligned;
 
-                z       = HDstrlen(dt->shared->u.opaque.tag);
+                z       = strlen(dt->shared->u.opaque.tag);
                 aligned = (z + 7) & (H5T_OPAQUE_TAG_MAX - 8);
                 flags   = (unsigned)(flags | aligned);
                 H5MM_memcpy(*pp, dt->shared->u.opaque.tag, MIN(z, aligned));
@@ -1122,10 +1122,10 @@ H5O__dtype_encode_helper(uint8_t **pp, const H5T_t *dt)
                 assert(dt->shared->version >= dt->shared->u.compnd.memb[i].type->shared->version);
 
                 /* Name */
-                HDstrcpy((char *)(*pp), dt->shared->u.compnd.memb[i].name);
+                strcpy((char *)(*pp), dt->shared->u.compnd.memb[i].name);
 
                 /* Version 3 of the datatype message removed the padding to multiple of 8 bytes */
-                n = HDstrlen(dt->shared->u.compnd.memb[i].name);
+                n = strlen(dt->shared->u.compnd.memb[i].name);
                 if (dt->shared->version >= H5O_DTYPE_VERSION_3)
                     *pp += n + 1;
                 else {
@@ -1196,10 +1196,10 @@ H5O__dtype_encode_helper(uint8_t **pp, const H5T_t *dt)
             /* Names, each a multiple of eight bytes */
             for (i = 0; i < dt->shared->u.enumer.nmembs; i++) {
                 /* Name */
-                HDstrcpy((char *)(*pp), dt->shared->u.enumer.name[i]);
+                strcpy((char *)(*pp), dt->shared->u.enumer.name[i]);
 
                 /* Version 3 of the datatype message removed the padding to multiple of 8 bytes */
-                n = HDstrlen(dt->shared->u.enumer.name[i]);
+                n = strlen(dt->shared->u.enumer.name[i]);
                 if (dt->shared->version >= H5O_DTYPE_VERSION_3)
                     *pp += n + 1;
                 else {
@@ -1485,7 +1485,7 @@ H5O__dtype_size(const H5F_t *f, const void *_mesg)
             break;
 
         case H5T_OPAQUE:
-            ret_value += (HDstrlen(dt->shared->u.opaque.tag) + 7) & (H5T_OPAQUE_TAG_MAX - 8);
+            ret_value += (strlen(dt->shared->u.opaque.tag) + 7) & (H5T_OPAQUE_TAG_MAX - 8);
             break;
 
         case H5T_COMPOUND: {
@@ -1499,7 +1499,7 @@ H5O__dtype_size(const H5F_t *f, const void *_mesg)
                 size_t name_len; /* Length of field's name */
 
                 /* Get length of field's name */
-                name_len = HDstrlen(dt->shared->u.compnd.memb[u].name);
+                name_len = strlen(dt->shared->u.compnd.memb[u].name);
 
                 /* Versions of the format >= 3 don't pad out the name */
                 if (dt->shared->version >= H5O_DTYPE_VERSION_3)
@@ -1530,7 +1530,7 @@ H5O__dtype_size(const H5F_t *f, const void *_mesg)
                 size_t name_len; /* Length of field's name */
 
                 /* Get length of field's name */
-                name_len = HDstrlen(dt->shared->u.enumer.name[u]);
+                name_len = strlen(dt->shared->u.enumer.name[u]);
 
                 /* Versions of the format >= 3 don't pad out the name */
                 if (dt->shared->version >= H5O_DTYPE_VERSION_3)
@@ -1915,7 +1915,7 @@ H5O__dtype_debug(H5F_t *f, const void *mesg, FILE *stream, int indent, int fwidt
         case H5T_NO_CLASS:
         case H5T_NCLASSES:
         default:
-            HDsnprintf(buf, sizeof(buf), "H5T_CLASS_%d", (int)(dt->shared->type));
+            snprintf(buf, sizeof(buf), "H5T_CLASS_%d", (int)(dt->shared->type));
             s = buf;
             break;
     } /* end switch */
@@ -1930,7 +1930,7 @@ H5O__dtype_debug(H5F_t *f, const void *mesg, FILE *stream, int indent, int fwidt
         fprintf(stream, "%*s%-*s %u\n", indent, "", fwidth,
                 "Number of members:", dt->shared->u.compnd.nmembs);
         for (i = 0; i < dt->shared->u.compnd.nmembs; i++) {
-            HDsnprintf(buf, sizeof(buf), "Member %u:", i);
+            snprintf(buf, sizeof(buf), "Member %u:", i);
             fprintf(stream, "%*s%-*s %s\n", indent, "", fwidth, buf, dt->shared->u.compnd.memb[i].name);
             fprintf(stream, "%*s%-*s %lu\n", indent + 3, "", MAX(0, fwidth - 3),
                     "Byte offset:", (unsigned long)(dt->shared->u.compnd.memb[i].offset));
@@ -1943,7 +1943,7 @@ H5O__dtype_debug(H5F_t *f, const void *mesg, FILE *stream, int indent, int fwidt
         fprintf(stream, "%*s%-*s %u\n", indent, "", fwidth,
                 "Number of members:", dt->shared->u.enumer.nmembs);
         for (i = 0; i < dt->shared->u.enumer.nmembs; i++) {
-            HDsnprintf(buf, sizeof(buf), "Member %u:", i);
+            snprintf(buf, sizeof(buf), "Member %u:", i);
             fprintf(stream, "%*s%-*s %s\n", indent, "", fwidth, buf, dt->shared->u.enumer.name[i]);
             fprintf(stream, "%*s%-*s 0x", indent, "", fwidth, "Raw bytes of value:");
             for (k = 0; k < dt->shared->parent->shared->size; k++)
@@ -1983,14 +1983,13 @@ H5O__dtype_debug(H5F_t *f, const void *mesg, FILE *stream, int indent, int fwidt
             case H5T_CSET_RESERVED_13:
             case H5T_CSET_RESERVED_14:
             case H5T_CSET_RESERVED_15:
-                HDsnprintf(buf, sizeof(buf), "H5T_CSET_RESERVED_%d", (int)(dt->shared->u.atomic.u.s.cset));
+                snprintf(buf, sizeof(buf), "H5T_CSET_RESERVED_%d", (int)(dt->shared->u.atomic.u.s.cset));
                 s = buf;
                 break;
 
             case H5T_CSET_ERROR:
             default:
-                HDsnprintf(buf, sizeof(buf), "Unknown character set: %d",
-                           (int)(dt->shared->u.atomic.u.s.cset));
+                snprintf(buf, sizeof(buf), "Unknown character set: %d", (int)(dt->shared->u.atomic.u.s.cset));
                 s = buf;
                 break;
         } /* end switch */
@@ -2022,14 +2021,13 @@ H5O__dtype_debug(H5F_t *f, const void *mesg, FILE *stream, int indent, int fwidt
             case H5T_STR_RESERVED_13:
             case H5T_STR_RESERVED_14:
             case H5T_STR_RESERVED_15:
-                HDsnprintf(buf, sizeof(buf), "H5T_STR_RESERVED_%d", (int)(dt->shared->u.atomic.u.s.pad));
+                snprintf(buf, sizeof(buf), "H5T_STR_RESERVED_%d", (int)(dt->shared->u.atomic.u.s.pad));
                 s = buf;
                 break;
 
             case H5T_STR_ERROR:
             default:
-                HDsnprintf(buf, sizeof(buf), "Unknown string padding: %d",
-                           (int)(dt->shared->u.atomic.u.s.pad));
+                snprintf(buf, sizeof(buf), "Unknown string padding: %d", (int)(dt->shared->u.atomic.u.s.pad));
                 s = buf;
                 break;
         } /* end switch */
@@ -2048,7 +2046,7 @@ H5O__dtype_debug(H5F_t *f, const void *mesg, FILE *stream, int indent, int fwidt
             case H5T_VLEN_BADTYPE:
             case H5T_VLEN_MAXTYPE:
             default:
-                HDsnprintf(buf, sizeof(buf), "H5T_VLEN_%d", dt->shared->u.vlen.type);
+                snprintf(buf, sizeof(buf), "H5T_VLEN_%d", dt->shared->u.vlen.type);
                 s = buf;
                 break;
         } /* end switch */
@@ -2066,7 +2064,7 @@ H5O__dtype_debug(H5F_t *f, const void *mesg, FILE *stream, int indent, int fwidt
             case H5T_LOC_BADLOC:
             case H5T_LOC_MAXLOC:
             default:
-                HDsnprintf(buf, sizeof(buf), "H5T_LOC_%d", (int)dt->shared->u.vlen.loc);
+                snprintf(buf, sizeof(buf), "H5T_LOC_%d", (int)dt->shared->u.vlen.loc);
                 s = buf;
                 break;
         } /* end switch */
@@ -2097,13 +2095,13 @@ H5O__dtype_debug(H5F_t *f, const void *mesg, FILE *stream, int indent, int fwidt
                 case H5T_CSET_RESERVED_13:
                 case H5T_CSET_RESERVED_14:
                 case H5T_CSET_RESERVED_15:
-                    HDsnprintf(buf, sizeof(buf), "H5T_CSET_RESERVED_%d", (int)(dt->shared->u.vlen.cset));
+                    snprintf(buf, sizeof(buf), "H5T_CSET_RESERVED_%d", (int)(dt->shared->u.vlen.cset));
                     s = buf;
                     break;
 
                 case H5T_CSET_ERROR:
                 default:
-                    HDsnprintf(buf, sizeof(buf), "Unknown character set: %d", (int)(dt->shared->u.vlen.cset));
+                    snprintf(buf, sizeof(buf), "Unknown character set: %d", (int)(dt->shared->u.vlen.cset));
                     s = buf;
                     break;
             } /* end switch */
@@ -2135,13 +2133,13 @@ H5O__dtype_debug(H5F_t *f, const void *mesg, FILE *stream, int indent, int fwidt
                 case H5T_STR_RESERVED_13:
                 case H5T_STR_RESERVED_14:
                 case H5T_STR_RESERVED_15:
-                    HDsnprintf(buf, sizeof(buf), "H5T_STR_RESERVED_%d", (int)(dt->shared->u.vlen.pad));
+                    snprintf(buf, sizeof(buf), "H5T_STR_RESERVED_%d", (int)(dt->shared->u.vlen.pad));
                     s = buf;
                     break;
 
                 case H5T_STR_ERROR:
                 default:
-                    HDsnprintf(buf, sizeof(buf), "Unknown string padding: %d", (int)(dt->shared->u.vlen.pad));
+                    snprintf(buf, sizeof(buf), "Unknown string padding: %d", (int)(dt->shared->u.vlen.pad));
                     s = buf;
                     break;
             } /* end switch */
@@ -2181,7 +2179,7 @@ H5O__dtype_debug(H5F_t *f, const void *mesg, FILE *stream, int indent, int fwidt
 
             case H5T_ORDER_ERROR:
             default:
-                HDsnprintf(buf, sizeof(buf), "H5T_ORDER_%d", dt->shared->u.atomic.order);
+                snprintf(buf, sizeof(buf), "H5T_ORDER_%d", dt->shared->u.atomic.order);
                 s = buf;
                 break;
         } /* end switch */
@@ -2255,9 +2253,9 @@ H5O__dtype_debug(H5F_t *f, const void *mesg, FILE *stream, int indent, int fwidt
                 case H5T_NPAD:
                 default:
                     if (dt->shared->u.atomic.u.f.pad < 0)
-                        HDsnprintf(buf, sizeof(buf), "H5T_PAD_%d", -(dt->shared->u.atomic.u.f.pad));
+                        snprintf(buf, sizeof(buf), "H5T_PAD_%d", -(dt->shared->u.atomic.u.f.pad));
                     else
-                        HDsnprintf(buf, sizeof(buf), "bit-%d", dt->shared->u.atomic.u.f.pad);
+                        snprintf(buf, sizeof(buf), "bit-%d", dt->shared->u.atomic.u.f.pad);
                     s = buf;
                     break;
             } /* end switch */
@@ -2278,7 +2276,7 @@ H5O__dtype_debug(H5F_t *f, const void *mesg, FILE *stream, int indent, int fwidt
 
                 case H5T_NORM_ERROR:
                 default:
-                    HDsnprintf(buf, sizeof(buf), "H5T_NORM_%d", (int)(dt->shared->u.atomic.u.f.norm));
+                    snprintf(buf, sizeof(buf), "H5T_NORM_%d", (int)(dt->shared->u.atomic.u.f.norm));
                     s = buf;
             } /* end switch */
             fprintf(stream, "%*s%-*s %s\n", indent, "", fwidth, "Normalization:", s);
@@ -2315,7 +2313,7 @@ H5O__dtype_debug(H5F_t *f, const void *mesg, FILE *stream, int indent, int fwidt
                 case H5T_SGN_ERROR:
                 case H5T_NSGN:
                 default:
-                    HDsnprintf(buf, sizeof(buf), "H5T_SGN_%d", (int)(dt->shared->u.atomic.u.i.sign));
+                    snprintf(buf, sizeof(buf), "H5T_SGN_%d", (int)(dt->shared->u.atomic.u.i.sign));
                     s = buf;
                     break;
             } /* end switch */

--- a/src/H5Oefl.c
+++ b/src/H5Oefl.c
@@ -450,7 +450,7 @@ H5O__efl_copy_file(H5F_t H5_ATTR_UNUSED *file_src, void *mesg_src, H5F_t *file_d
     /* Determine size needed for destination heap */
     heap_size = H5HL_ALIGN(1); /* "empty" name */
     for (idx = 0; idx < efl_src->nused; idx++)
-        heap_size += H5HL_ALIGN(HDstrlen(efl_src->slot[idx].name) + 1);
+        heap_size += H5HL_ALIGN(strlen(efl_src->slot[idx].name) + 1);
 
     /* Create name heap */
     if (H5HL_create(file_dst, heap_size, &efl_dst->heap_addr /*out*/) < 0)
@@ -478,7 +478,7 @@ H5O__efl_copy_file(H5F_t H5_ATTR_UNUSED *file_src, void *mesg_src, H5F_t *file_d
     /* copy the name from the source */
     for (idx = 0; idx < efl_src->nused; idx++) {
         efl_dst->slot[idx].name = H5MM_xstrdup(efl_src->slot[idx].name);
-        if (H5HL_insert(file_dst, heap, HDstrlen(efl_dst->slot[idx].name) + 1, efl_dst->slot[idx].name,
+        if (H5HL_insert(file_dst, heap, strlen(efl_dst->slot[idx].name) + 1, efl_dst->slot[idx].name,
                         &(efl_dst->slot[idx].name_offset)) < 0)
             HGOTO_ERROR(H5E_EFL, H5E_CANTINSERT, NULL, "can't insert file name into heap");
     }
@@ -529,7 +529,7 @@ H5O__efl_debug(H5F_t H5_ATTR_UNUSED *f, const void *_mesg, FILE *stream, int ind
     for (u = 0; u < mesg->nused; u++) {
         char buf[64];
 
-        HDsnprintf(buf, sizeof(buf), "File %zu", u);
+        snprintf(buf, sizeof(buf), "File %zu", u);
         fprintf(stream, "%*s%s:\n", indent, "", buf);
 
         fprintf(stream, "%*s%-*s \"%s\"\n", indent + 3, "", MAX(fwidth - 3, 0), "Name:", mesg->slot[u].name);

--- a/src/H5Olayout.c
+++ b/src/H5Olayout.c
@@ -604,7 +604,7 @@ H5O__layout_decode(H5F_t *f, H5O_t H5_ATTR_UNUSED *open_oh, unsigned H5_ATTR_UNU
                                         "ran off end of input buffer while decoding");
 
                         /* Source file name */
-                        tmp_size = HDstrnlen((const char *)heap_block_p, (size_t)avail_buffer_space);
+                        tmp_size = strnlen((const char *)heap_block_p, (size_t)avail_buffer_space);
                         if (tmp_size == (size_t)avail_buffer_space)
                             HGOTO_ERROR(H5E_OHDR, H5E_OVERFLOW, NULL,
                                         "ran off end of input buffer while decoding - unterminated source "
@@ -625,7 +625,7 @@ H5O__layout_decode(H5F_t *f, H5O_t H5_ATTR_UNUSED *open_oh, unsigned H5_ATTR_UNU
                                         "ran off end of input buffer while decoding");
 
                         /* Source dataset name */
-                        tmp_size = HDstrnlen((const char *)heap_block_p, (size_t)avail_buffer_space);
+                        tmp_size = strnlen((const char *)heap_block_p, (size_t)avail_buffer_space);
                         if (tmp_size == (size_t)avail_buffer_space)
                             HGOTO_ERROR(H5E_OHDR, H5E_OVERFLOW, NULL,
                                         "ran off end of input buffer while decoding - unterminated source "

--- a/src/H5Olink.c
+++ b/src/H5Olink.c
@@ -303,7 +303,7 @@ H5O__link_encode(H5F_t *f, bool H5_ATTR_UNUSED disable_shared, uint8_t *p, const
     assert(lnk);
 
     /* Get length of link's name */
-    len = (uint64_t)HDstrlen(lnk->name);
+    len = (uint64_t)strlen(lnk->name);
     assert(len > 0);
 
     /* encode */
@@ -370,7 +370,7 @@ H5O__link_encode(H5F_t *f, bool H5_ATTR_UNUSED disable_shared, uint8_t *p, const
 
         case H5L_TYPE_SOFT:
             /* Store the link value */
-            len = (uint16_t)HDstrlen(lnk->u.soft.name);
+            len = (uint16_t)strlen(lnk->u.soft.name);
             assert(len > 0);
             UINT16ENCODE(p, len);
             H5MM_memcpy(p, lnk->u.soft.name, (size_t)len);
@@ -486,7 +486,7 @@ H5O__link_size(const H5F_t *f, bool H5_ATTR_UNUSED disable_shared, const void *_
     HDcompile_assert(sizeof(uint64_t) >= sizeof(size_t));
 
     /* Get name's length */
-    name_len = (uint64_t)HDstrlen(lnk->name);
+    name_len = (uint64_t)strlen(lnk->name);
 
     /* Determine correct value for name size bits */
     if (name_len > 4294967295)
@@ -514,8 +514,8 @@ H5O__link_size(const H5F_t *f, bool H5_ATTR_UNUSED disable_shared, const void *_
             break;
 
         case H5L_TYPE_SOFT:
-            ret_value += 2 +                         /* Link value length */
-                         HDstrlen(lnk->u.soft.name); /* Link value */
+            ret_value += 2 +                       /* Link value length */
+                         strlen(lnk->u.soft.name); /* Link value */
             break;
 
         case H5L_TYPE_ERROR:
@@ -816,7 +816,7 @@ H5O__link_debug(H5F_t H5_ATTR_UNUSED *f, const void *_mesg, FILE *stream, int in
             if (lnk->type >= H5L_TYPE_UD_MIN) {
                 if (lnk->type == H5L_TYPE_EXTERNAL) {
                     const char *objname =
-                        (const char *)lnk->u.ud.udata + (HDstrlen((const char *)lnk->u.ud.udata) + 1);
+                        (const char *)lnk->u.ud.udata + (strlen((const char *)lnk->u.ud.udata) + 1);
 
                     fprintf(stream, "%*s%-*s %s\n", indent, "", fwidth,
                             "External File Name:", (const char *)lnk->u.ud.udata);

--- a/src/H5Omtime.c
+++ b/src/H5Omtime.c
@@ -271,8 +271,8 @@ H5O__mtime_encode(H5F_t H5_ATTR_UNUSED *f, bool H5_ATTR_UNUSED disable_shared, u
 
     /* encode */
     tm = HDgmtime(mesg);
-    HDsprintf((char *)p, "%04d%02d%02d%02d%02d%02d", 1900 + tm->tm_year, 1 + tm->tm_mon, tm->tm_mday,
-              tm->tm_hour, tm->tm_min, tm->tm_sec);
+    sprintf((char *)p, "%04d%02d%02d%02d%02d%02d", 1900 + tm->tm_year, 1 + tm->tm_mon, tm->tm_mday,
+            tm->tm_hour, tm->tm_min, tm->tm_sec);
 
     FUNC_LEAVE_NOAPI(SUCCEED)
 } /* end H5O__mtime_encode() */
@@ -416,7 +416,7 @@ H5O__mtime_debug(H5F_t H5_ATTR_UNUSED *f, const void *_mesg, FILE *stream, int i
     /* debug */
     tm = HDlocaltime(mesg);
 
-    HDstrftime(buf, sizeof(buf), "%Y-%m-%d %H:%M:%S %Z", tm);
+    strftime(buf, sizeof(buf), "%Y-%m-%d %H:%M:%S %Z", tm);
     fprintf(stream, "%*s%-*s %s\n", indent, "", fwidth, "Time:", buf);
 
     FUNC_LEAVE_NOAPI(SUCCEED)

--- a/src/H5Oname.c
+++ b/src/H5Oname.c
@@ -122,7 +122,7 @@ H5O__name_encode(H5F_t H5_ATTR_UNUSED *f, bool H5_ATTR_UNUSED disable_shared, ui
     assert(mesg && mesg->s);
 
     /* encode */
-    HDstrcpy((char *)p, mesg->s);
+    strcpy((char *)p, mesg->s);
 
     FUNC_LEAVE_NOAPI(SUCCEED)
 } /* end H5O__name_encode() */
@@ -196,7 +196,7 @@ H5O__name_size(const H5F_t H5_ATTR_UNUSED *f, bool H5_ATTR_UNUSED disable_shared
     assert(f);
     assert(mesg);
 
-    ret_value = mesg->s ? HDstrlen(mesg->s) + 1 : 0;
+    ret_value = mesg->s ? strlen(mesg->s) + 1 : 0;
 
     FUNC_LEAVE_NOAPI(ret_value)
 } /* end H5O__name_size() */

--- a/src/H5Opline.c
+++ b/src/H5Opline.c
@@ -192,7 +192,7 @@ H5O__pline_decode(H5F_t H5_ATTR_UNUSED *f, H5O_t H5_ATTR_UNUSED *open_oh, unsign
             size_t max = (size_t)(p_end - p + 1); /* Max possible name length */
 
             /* Determine actual name length (without padding, but with null terminator) */
-            actual_name_length = HDstrnlen((const char *)p, max);
+            actual_name_length = strnlen((const char *)p, max);
             if (actual_name_length == max)
                 HGOTO_ERROR(H5E_OHDR, H5E_NOSPACE, NULL, "filter name not null terminated");
             actual_name_length += 1; /* include \0 byte */
@@ -206,7 +206,7 @@ H5O__pline_decode(H5F_t H5_ATTR_UNUSED *f, H5O_t H5_ATTR_UNUSED *open_oh, unsign
             else
                 filter->name = filter->_name;
 
-            HDstrncpy(filter->name, (const char *)p, actual_name_length);
+            strncpy(filter->name, (const char *)p, actual_name_length);
 
             if (H5_IS_BUFFER_OVERFLOW(p, name_length, p_end))
                 HGOTO_ERROR(H5E_OHDR, H5E_OVERFLOW, NULL, "ran off end of input buffer while decoding");
@@ -311,7 +311,7 @@ H5O__pline_encode(H5F_t H5_ATTR_UNUSED *f, uint8_t *p /*out*/, const void *mesg)
              */
             if (NULL == (name = filter->name) && (cls = H5Z_find(filter->id)))
                 name = cls->name;
-            name_length = name ? HDstrlen(name) + 1 : 0;
+            name_length = name ? strlen(name) + 1 : 0;
 
             /* Filter name length */
             UINT16ENCODE(p, pline->version == H5O_PLINE_VERSION_1 ? H5O_ALIGN_OLD(name_length) : name_length);
@@ -394,7 +394,7 @@ H5O__pline_copy(const void *_src, void *_dst /*out*/)
             if (src->filter[i].name) {
                 size_t namelen; /* Length of source filter name, including null terminator  */
 
-                namelen = HDstrlen(src->filter[i].name) + 1;
+                namelen = strlen(src->filter[i].name) + 1;
 
                 /* Allocate space for the filter name, or use the internal buffer */
                 if (namelen > H5Z_COMMON_NAME_LEN) {
@@ -478,7 +478,7 @@ H5O__pline_size(const H5F_t H5_ATTR_UNUSED *f, const void *mesg)
             /* Get the name of the filter, same as done with H5O__pline_encode() */
             if (NULL == (name = pline->filter[i].name) && (cls = H5Z_find(pline->filter[i].id)))
                 name = cls->name;
-            name_len = name ? HDstrlen(name) + 1 : 0;
+            name_len = name ? strlen(name) + 1 : 0;
         } /* end else */
 
         ret_value +=
@@ -529,7 +529,7 @@ H5O__pline_reset(void *mesg)
         /* Free information for each filter */
         for (i = 0; i < pline->nused; i++) {
             if (pline->filter[i].name && pline->filter[i].name != pline->filter[i]._name)
-                assert((HDstrlen(pline->filter[i].name) + 1) > H5Z_COMMON_NAME_LEN);
+                assert((strlen(pline->filter[i].name) + 1) > H5Z_COMMON_NAME_LEN);
             if (pline->filter[i].name != pline->filter[i]._name)
                 pline->filter[i].name = (char *)H5MM_xfree(pline->filter[i].name);
             if (pline->filter[i].cd_values && pline->filter[i].cd_values != pline->filter[i]._cd_values)
@@ -652,7 +652,7 @@ H5O__pline_debug(H5F_t H5_ATTR_UNUSED *f, const void *mesg, FILE *stream, int in
         char name[64];
 
         memset(name, 0, 64);
-        HDsnprintf(name, sizeof(name), "Filter at position %zu", i);
+        snprintf(name, sizeof(name), "Filter at position %zu", i);
 
         fprintf(stream, "%*s%-*s\n", indent, "", fwidth, name);
         fprintf(stream, "%*s%-*s 0x%04x\n", indent + 3, "", MAX(0, fwidth - 3),
@@ -671,7 +671,7 @@ H5O__pline_debug(H5F_t H5_ATTR_UNUSED *f, const void *mesg, FILE *stream, int in
         for (size_t j = 0; j < pline->filter[i].cd_nelmts; j++) {
             char field_name[32];
 
-            HDsnprintf(field_name, sizeof(field_name), "CD value %lu", (unsigned long)j);
+            snprintf(field_name, sizeof(field_name), "CD value %lu", (unsigned long)j);
             fprintf(stream, "%*s%-*s %u\n", indent + 6, "", MAX(0, fwidth - 6), field_name,
                     pline->filter[i].cd_values[j]);
         }

--- a/src/H5PL.c
+++ b/src/H5PL.c
@@ -143,7 +143,7 @@ H5PLappend(const char *search_path)
     /* Check args */
     if (NULL == search_path)
         HGOTO_ERROR(H5E_ARGS, H5E_BADVALUE, FAIL, "plugin_path parameter cannot be NULL");
-    if (0 == HDstrlen(search_path))
+    if (0 == strlen(search_path))
         HGOTO_ERROR(H5E_ARGS, H5E_BADVALUE, FAIL, "plugin_path parameter cannot have length zero");
 
     /* Append the search path to the path table */
@@ -175,7 +175,7 @@ H5PLprepend(const char *search_path)
     /* Check args */
     if (NULL == search_path)
         HGOTO_ERROR(H5E_ARGS, H5E_BADVALUE, FAIL, "plugin_path parameter cannot be NULL");
-    if (0 == HDstrlen(search_path))
+    if (0 == strlen(search_path))
         HGOTO_ERROR(H5E_ARGS, H5E_BADVALUE, FAIL, "plugin_path parameter cannot have length zero");
 
     /* Prepend the search path to the path table */
@@ -208,7 +208,7 @@ H5PLreplace(const char *search_path, unsigned int idx)
     /* Check args */
     if (NULL == search_path)
         HGOTO_ERROR(H5E_ARGS, H5E_BADVALUE, FAIL, "plugin_path parameter cannot be NULL");
-    if (0 == HDstrlen(search_path))
+    if (0 == strlen(search_path))
         HGOTO_ERROR(H5E_ARGS, H5E_BADVALUE, FAIL, "plugin_path parameter cannot have length zero");
 
     /* Check index */
@@ -250,7 +250,7 @@ H5PLinsert(const char *search_path, unsigned int idx)
     /* Check args */
     if (NULL == search_path)
         HGOTO_ERROR(H5E_ARGS, H5E_BADVALUE, FAIL, "plugin_path parameter cannot be NULL");
-    if (0 == HDstrlen(search_path))
+    if (0 == strlen(search_path))
         HGOTO_ERROR(H5E_ARGS, H5E_BADVALUE, FAIL, "plugin_path parameter cannot have length zero");
 
     /* Check index */
@@ -355,11 +355,11 @@ H5PLget(unsigned int idx, char *path_buf, size_t buf_size)
     /* Get the path at the specified index and its length */
     if (NULL == (path = H5PL__get_path(idx)))
         HGOTO_ERROR(H5E_PLUGIN, H5E_BADVALUE, (-1), "no path stored at that index");
-    path_len = HDstrlen(path);
+    path_len = strlen(path);
 
     /* If the path buffer is not NULL, copy the path to the buffer */
     if (path_buf) {
-        HDstrncpy(path_buf, path, buf_size);
+        strncpy(path_buf, path, buf_size);
         if ((size_t)path_len >= buf_size)
             path_buf[buf_size - 1] = '\0';
     } /* end if */

--- a/src/H5PLint.c
+++ b/src/H5PLint.c
@@ -141,7 +141,7 @@ H5PL_init(void)
      * H5PLpublic.h) means we don't want to load plugins.
      */
     if (NULL != (env_var = HDgetenv(HDF5_PLUGIN_PRELOAD)))
-        if (!HDstrcmp(env_var, H5PL_NO_PLUGIN)) {
+        if (!strcmp(env_var, H5PL_NO_PLUGIN)) {
             H5PL_plugin_control_mask_g = 0;
             H5PL_allow_plugins_g       = false;
         }

--- a/src/H5PLpath.c
+++ b/src/H5PLpath.c
@@ -109,7 +109,7 @@ H5PL__insert_at(const char *path, unsigned int idx)
 
     /* Check args - Just assert on package functions */
     assert(path);
-    assert(HDstrlen(path));
+    assert(strlen(path));
 
     /* Expand the table if it is full */
     if (H5PL_num_paths_g == H5PL_path_capacity_g)
@@ -190,7 +190,7 @@ H5PL__replace_at(const char *path, unsigned int idx)
 
     /* Check args - Just assert on package functions */
     assert(path);
-    assert(HDstrlen(path));
+    assert(strlen(path));
 
     /* Check that the table entry is in use */
     if (!H5PL_paths_g[idx])
@@ -387,7 +387,7 @@ H5PL__append_path(const char *path)
 
     /* Check args - Just assert on package functions */
     assert(path);
-    assert(HDstrlen(path));
+    assert(strlen(path));
 
     /* Insert the path at the end of the table */
     if (H5PL__insert_at(path, H5PL_num_paths_g) < 0)
@@ -415,7 +415,7 @@ H5PL__prepend_path(const char *path)
 
     /* Check args - Just assert on package functions */
     assert(path);
-    assert(HDstrlen(path));
+    assert(strlen(path));
 
     /* Insert the path at the beginning of the table */
     if (H5PL__insert_at(path, 0) < 0)
@@ -443,7 +443,7 @@ H5PL__replace_path(const char *path, unsigned int idx)
 
     /* Check args - Just assert on package functions */
     assert(path);
-    assert(HDstrlen(path));
+    assert(strlen(path));
     assert(idx < H5PL_path_capacity_g);
 
     /* Insert the path at the requested index */
@@ -473,7 +473,7 @@ H5PL__insert_path(const char *path, unsigned int idx)
 
     /* Check args - Just assert on package functions */
     assert(path);
-    assert(HDstrlen(path));
+    assert(strlen(path));
     assert(idx < H5PL_path_capacity_g);
 
     /* Insert the path at the requested index */
@@ -625,10 +625,10 @@ H5PL__path_table_iterate_process_path(const char *plugin_path, H5PL_iterate_type
          * or libxxx.xxx.dylib on Mac.
          */
 #ifndef __CYGWIN__
-        if (!HDstrncmp(dp->d_name, "lib", (size_t)3) &&
-            (HDstrstr(dp->d_name, ".so") || HDstrstr(dp->d_name, ".dylib"))) {
+        if (!strncmp(dp->d_name, "lib", (size_t)3) &&
+            (strstr(dp->d_name, ".so") || strstr(dp->d_name, ".dylib"))) {
 #else
-        if (!HDstrncmp(dp->d_name, "cyg", (size_t)3) && HDstrstr(dp->d_name, ".dll")) {
+        if (!strncmp(dp->d_name, "cyg", (size_t)3) && strstr(dp->d_name, ".dll")) {
 #endif
 
             bool      plugin_matches;
@@ -636,18 +636,18 @@ H5PL__path_table_iterate_process_path(const char *plugin_path, H5PL_iterate_type
             size_t    len;
 
             /* Allocate & initialize the path name */
-            len = HDstrlen(plugin_path) + HDstrlen(H5PL_PATH_SEPARATOR) + HDstrlen(dp->d_name) + 1 /*\0*/ +
+            len = strlen(plugin_path) + strlen(H5PL_PATH_SEPARATOR) + strlen(dp->d_name) + 1 /*\0*/ +
                   4; /* Extra "+4" to quiet GCC warning - 2019/07/05, QAK */
 
             if (NULL == (path = (char *)H5MM_calloc(len)))
                 HGOTO_ERROR(H5E_PLUGIN, H5E_CANTALLOC, H5_ITER_ERROR, "can't allocate memory for path");
 
-            HDsnprintf(path, len, "%s/%s", plugin_path, dp->d_name);
+            snprintf(path, len, "%s/%s", plugin_path, dp->d_name);
 
             /* Get info for directory entry */
             if (HDstat(path, &my_stat) == -1)
                 HGOTO_ERROR(H5E_FILE, H5E_CANTGET, H5_ITER_ERROR, "can't stat file %s -- error was: %s", path,
-                            HDstrerror(errno));
+                            strerror(errno));
 
             /* If it is a directory, skip it */
             if (S_ISDIR(my_stat.st_mode))
@@ -681,7 +681,7 @@ done:
     if (dirp)
         if (HDclosedir(dirp) < 0)
             HDONE_ERROR(H5E_FILE, H5E_CLOSEERROR, H5_ITER_ERROR, "can't close directory: %s",
-                        HDstrerror(errno));
+                        strerror(errno));
 
     path = (char *)H5MM_xfree(path);
 
@@ -709,24 +709,24 @@ H5PL__path_table_iterate_process_path(const char *plugin_path, H5PL_iterate_type
 
     /* Specify a file mask. *.* = We want everything! -
      * skip the path if the directory can't be opened */
-    HDsnprintf(service, sizeof(service), "%s\\*.dll", plugin_path);
+    snprintf(service, sizeof(service), "%s\\*.dll", plugin_path);
     if ((hFind = FindFirstFileA(service, &fdFile)) == INVALID_HANDLE_VALUE)
         HGOTO_DONE(H5_ITER_CONT);
 
     /* Loop over all the files */
     do {
         /* Ignore '.' and '..' */
-        if (HDstrcmp(fdFile.cFileName, ".") != 0 && HDstrcmp(fdFile.cFileName, "..") != 0) {
+        if (strcmp(fdFile.cFileName, ".") != 0 && strcmp(fdFile.cFileName, "..") != 0) {
             bool   plugin_matches;
             size_t len;
 
             /* Allocate & initialize the path name */
-            len = HDstrlen(plugin_path) + HDstrlen(H5PL_PATH_SEPARATOR) + HDstrlen(fdFile.cFileName) + 1;
+            len = strlen(plugin_path) + strlen(H5PL_PATH_SEPARATOR) + strlen(fdFile.cFileName) + 1;
 
             if (NULL == (path = (char *)H5MM_calloc(len)))
                 HGOTO_ERROR(H5E_PLUGIN, H5E_CANTALLOC, H5_ITER_ERROR, "can't allocate memory for path");
 
-            HDsnprintf(path, len, "%s\\%s", plugin_path, fdFile.cFileName);
+            snprintf(path, len, "%s\\%s", plugin_path, fdFile.cFileName);
 
             /* Ignore directories */
             if (fdFile.dwFileAttributes & FILE_ATTRIBUTE_DIRECTORY)
@@ -863,28 +863,28 @@ H5PL__find_plugin_in_path(const H5PL_search_params_t *search_params, bool *found
          * or libxxx.xxx.dylib on Mac.
          */
 #ifndef __CYGWIN__
-        if (!HDstrncmp(dp->d_name, "lib", (size_t)3) &&
-            (HDstrstr(dp->d_name, ".so") || HDstrstr(dp->d_name, ".dylib"))) {
+        if (!strncmp(dp->d_name, "lib", (size_t)3) &&
+            (strstr(dp->d_name, ".so") || strstr(dp->d_name, ".dylib"))) {
 #else
-        if (!HDstrncmp(dp->d_name, "cyg", (size_t)3) && HDstrstr(dp->d_name, ".dll")) {
+        if (!strncmp(dp->d_name, "cyg", (size_t)3) && strstr(dp->d_name, ".dll")) {
 #endif
 
             h5_stat_t my_stat;
             size_t    len;
 
             /* Allocate & initialize the path name */
-            len = HDstrlen(dir) + HDstrlen(H5PL_PATH_SEPARATOR) + HDstrlen(dp->d_name) + 1 /*\0*/ +
+            len = strlen(dir) + strlen(H5PL_PATH_SEPARATOR) + strlen(dp->d_name) + 1 /*\0*/ +
                   4; /* Extra "+4" to quiet GCC warning - 2019/07/05, QAK */
 
             if (NULL == (path = (char *)H5MM_calloc(len)))
                 HGOTO_ERROR(H5E_PLUGIN, H5E_CANTALLOC, FAIL, "can't allocate memory for path");
 
-            HDsnprintf(path, len, "%s/%s", dir, dp->d_name);
+            snprintf(path, len, "%s/%s", dir, dp->d_name);
 
             /* Get info for directory entry */
             if (HDstat(path, &my_stat) == -1)
                 HGOTO_ERROR(H5E_FILE, H5E_CANTGET, FAIL, "can't stat file %s -- error was: %s", path,
-                            HDstrerror(errno));
+                            strerror(errno));
 
             /* If it is a directory, skip it */
             if (S_ISDIR(my_stat.st_mode)) {
@@ -905,7 +905,7 @@ H5PL__find_plugin_in_path(const H5PL_search_params_t *search_params, bool *found
 done:
     if (dirp)
         if (HDclosedir(dirp) < 0)
-            HDONE_ERROR(H5E_FILE, H5E_CLOSEERROR, FAIL, "can't close directory: %s", HDstrerror(errno));
+            HDONE_ERROR(H5E_FILE, H5E_CLOSEERROR, FAIL, "can't close directory: %s", strerror(errno));
 
     path = (char *)H5MM_xfree(path);
 
@@ -934,26 +934,26 @@ H5PL__find_plugin_in_path(const H5PL_search_params_t *search_params, bool *found
     *found = false;
 
     /* Specify a file mask. *.* = We want everything! */
-    HDsnprintf(service, sizeof(service), "%s\\*.dll", dir);
+    snprintf(service, sizeof(service), "%s\\*.dll", dir);
     if ((hFind = FindFirstFileA(service, &fdFile)) == INVALID_HANDLE_VALUE)
         HGOTO_ERROR(H5E_PLUGIN, H5E_OPENERROR, FAIL, "can't open directory");
 
     /* Loop over all the files */
     do {
         /* Ignore '.' and '..' */
-        if (HDstrcmp(fdFile.cFileName, ".") != 0 && HDstrcmp(fdFile.cFileName, "..") != 0) {
+        if (strcmp(fdFile.cFileName, ".") != 0 && strcmp(fdFile.cFileName, "..") != 0) {
 
             /* XXX: Probably just continue here and move the code below over one tab */
 
             size_t len;
 
             /* Allocate & initialize the path name */
-            len = HDstrlen(dir) + HDstrlen(H5PL_PATH_SEPARATOR) + HDstrlen(fdFile.cFileName) + 1;
+            len = strlen(dir) + strlen(H5PL_PATH_SEPARATOR) + strlen(fdFile.cFileName) + 1;
 
             if (NULL == (path = (char *)H5MM_calloc(len)))
                 HGOTO_ERROR(H5E_PLUGIN, H5E_CANTALLOC, FAIL, "can't allocate memory for path");
 
-            HDsnprintf(path, len, "%s\\%s", dir, fdFile.cFileName);
+            snprintf(path, len, "%s\\%s", dir, fdFile.cFileName);
 
             /* Ignore directories */
             if (fdFile.dwFileAttributes & FILE_ATTRIBUTE_DIRECTORY)

--- a/src/H5PLplugin_cache.c
+++ b/src/H5PLplugin_cache.c
@@ -284,7 +284,7 @@ H5PL__find_plugin_in_cache(const H5PL_search_params_t *search_params, bool *foun
                         continue;
 
                     /* Check if specified VOL connector name matches cache entry's name */
-                    if (!HDstrcmp(search_params->key->vol.u.name, H5PL_cache_g[u].key.vol.u.name))
+                    if (!strcmp(search_params->key->vol.u.name, H5PL_cache_g[u].key.vol.u.name))
                         matched = true;
                 }
                 else {
@@ -308,7 +308,7 @@ H5PL__find_plugin_in_cache(const H5PL_search_params_t *search_params, bool *foun
                         continue;
 
                     /* Check if specified VFD name matches cache entry's name */
-                    if (!HDstrcmp(search_params->key->vfd.u.name, H5PL_cache_g[u].key.vfd.u.name))
+                    if (!strcmp(search_params->key->vfd.u.name, H5PL_cache_g[u].key.vfd.u.name))
                         matched = true;
                 }
                 else {

--- a/src/H5Pdapl.c
+++ b/src/H5Pdapl.c
@@ -324,7 +324,7 @@ H5P__dapl_vds_file_pref_enc(const void *value, void **_pp, size_t *size)
 
     /* calculate prefix length */
     if (NULL != vds_file_pref)
-        len = HDstrlen(vds_file_pref);
+        len = strlen(vds_file_pref);
 
     enc_value = (uint64_t)len;
     enc_size  = H5VM_limit_enc_size(enc_value);
@@ -388,7 +388,7 @@ H5P__dapl_vds_file_pref_dec(const void **_pp, void *_value)
         /* Make a copy of the user's prefix string */
         if (NULL == (*vds_file_pref = (char *)H5MM_malloc(len + 1)))
             HGOTO_ERROR(H5E_RESOURCE, H5E_CANTINIT, FAIL, "memory allocation failed for prefix");
-        HDstrncpy(*vds_file_pref, *(const char **)pp, len);
+        strncpy(*vds_file_pref, *(const char **)pp, len);
         (*vds_file_pref)[len] = '\0';
 
         *pp += len;
@@ -465,7 +465,7 @@ H5P__dapl_vds_file_pref_cmp(const void *value1, const void *value2, size_t H5_AT
     if (NULL != pref1 && NULL == pref2)
         HGOTO_DONE(-1);
     if (NULL != pref1 && NULL != pref2)
-        ret_value = HDstrcmp(pref1, pref2);
+        ret_value = strcmp(pref1, pref2);
 
 done:
     FUNC_LEAVE_NOAPI(ret_value)
@@ -564,7 +564,7 @@ H5P__dapl_efile_pref_enc(const void *value, void **_pp, size_t *size)
 
     /* calculate prefix length */
     if (NULL != efile_pref)
-        len = HDstrlen(efile_pref);
+        len = strlen(efile_pref);
 
     enc_value = (uint64_t)len;
     enc_size  = H5VM_limit_enc_size(enc_value);
@@ -628,7 +628,7 @@ H5P__dapl_efile_pref_dec(const void **_pp, void *_value)
         /* Make a copy of the user's prefix string */
         if (NULL == (*efile_pref = (char *)H5MM_malloc(len + 1)))
             HGOTO_ERROR(H5E_RESOURCE, H5E_CANTINIT, FAIL, "memory allocation failed for prefix");
-        HDstrncpy(*efile_pref, *(const char **)pp, len);
+        strncpy(*efile_pref, *(const char **)pp, len);
         (*efile_pref)[len] = '\0';
 
         *pp += len;
@@ -705,7 +705,7 @@ H5P__dapl_efile_pref_cmp(const void *value1, const void *value2, size_t H5_ATTR_
     if (NULL != pref1 && NULL == pref2)
         HGOTO_DONE(-1);
     if (NULL != pref1 && NULL != pref2)
-        ret_value = HDstrcmp(pref1, pref2);
+        ret_value = strcmp(pref1, pref2);
 
 done:
     FUNC_LEAVE_NOAPI(ret_value)
@@ -1449,9 +1449,9 @@ H5Pget_efile_prefix(hid_t plist_id, char *prefix /*out*/, size_t size)
     /* Check for prefix being set */
     if (my_prefix) {
         /* Copy to user's buffer, if given */
-        len = HDstrlen(my_prefix);
+        len = strlen(my_prefix);
         if (prefix) {
-            HDstrncpy(prefix, my_prefix, size);
+            strncpy(prefix, my_prefix, size);
             if (len >= size)
                 prefix[size - 1] = '\0';
         } /* end if */
@@ -1539,9 +1539,9 @@ H5Pget_virtual_prefix(hid_t plist_id, char *prefix /*out*/, size_t size)
     /* Check for prefix being set */
     if (my_prefix) {
         /* Copy to user's buffer, if given */
-        len = HDstrlen(my_prefix);
+        len = strlen(my_prefix);
         if (prefix) {
-            HDstrncpy(prefix, my_prefix, size);
+            strncpy(prefix, my_prefix, size);
             if (len >= size)
                 prefix[size - 1] = '\0';
         } /* end if */

--- a/src/H5Pdcpl.c
+++ b/src/H5Pdcpl.c
@@ -463,13 +463,13 @@ H5P__dcrt_layout_enc(const void *value, void **_pp, size_t *size)
             /* Iterate over entries */
             for (u = 0; u < layout->storage.u.virt.list_nused; u++) {
                 /* Source file name */
-                tmp_size = HDstrlen(layout->storage.u.virt.list[u].source_file_name) + (size_t)1;
+                tmp_size = strlen(layout->storage.u.virt.list[u].source_file_name) + (size_t)1;
                 H5MM_memcpy(*pp, layout->storage.u.virt.list[u].source_file_name, tmp_size);
                 *pp += tmp_size;
                 *size += tmp_size;
 
                 /* Source dataset name */
-                tmp_size = HDstrlen(layout->storage.u.virt.list[u].source_dset_name) + (size_t)1;
+                tmp_size = strlen(layout->storage.u.virt.list[u].source_dset_name) + (size_t)1;
                 H5MM_memcpy(*pp, layout->storage.u.virt.list[u].source_dset_name, tmp_size);
                 *pp += tmp_size;
                 *size += tmp_size;
@@ -510,11 +510,11 @@ H5P__dcrt_layout_enc(const void *value, void **_pp, size_t *size)
             /* Iterate over entries */
             for (u = 0; u < layout->storage.u.virt.list_nused; u++) {
                 /* Source file name */
-                tmp_size = HDstrlen(layout->storage.u.virt.list[u].source_file_name) + (size_t)1;
+                tmp_size = strlen(layout->storage.u.virt.list[u].source_file_name) + (size_t)1;
                 *size += tmp_size;
 
                 /* Source dataset name */
-                tmp_size = HDstrlen(layout->storage.u.virt.list[u].source_dset_name) + (size_t)1;
+                tmp_size = strlen(layout->storage.u.virt.list[u].source_dset_name) + (size_t)1;
                 *size += tmp_size;
 
                 /* Source selection */
@@ -632,7 +632,7 @@ H5P__dcrt_layout_dec(const void **_pp, void *value)
                 /* Decode each entry */
                 for (u = 0; u < (size_t)nentries; u++) {
                     /* Source file name */
-                    tmp_size = HDstrlen((const char *)*pp) + 1;
+                    tmp_size = strlen((const char *)*pp) + 1;
                     if (NULL ==
                         (tmp_layout.storage.u.virt.list[u].source_file_name = (char *)H5MM_malloc(tmp_size)))
                         HGOTO_ERROR(H5E_PLIST, H5E_CANTALLOC, FAIL,
@@ -641,7 +641,7 @@ H5P__dcrt_layout_dec(const void **_pp, void *value)
                     *pp += tmp_size;
 
                     /* Source dataset name */
-                    tmp_size = HDstrlen((const char *)*pp) + 1;
+                    tmp_size = strlen((const char *)*pp) + 1;
                     if (NULL ==
                         (tmp_layout.storage.u.virt.list[u].source_dset_name = (char *)H5MM_malloc(tmp_size)))
                         HGOTO_ERROR(H5E_PLIST, H5E_CANTALLOC, FAIL,
@@ -884,16 +884,16 @@ H5P__dcrt_layout_cmp(const void *_layout1, const void *_layout2, size_t H5_ATTR_
                     HGOTO_DONE(1);
 
                 /* Compare source file names */
-                strcmp_ret = HDstrcmp(layout1->storage.u.virt.list[u].source_file_name,
-                                      layout2->storage.u.virt.list[u].source_file_name);
+                strcmp_ret = strcmp(layout1->storage.u.virt.list[u].source_file_name,
+                                    layout2->storage.u.virt.list[u].source_file_name);
                 if (strcmp_ret < 0)
                     HGOTO_DONE(-1);
                 if (strcmp_ret > 0)
                     HGOTO_DONE(1);
 
                 /* Compare source dataset names */
-                strcmp_ret = HDstrcmp(layout1->storage.u.virt.list[u].source_dset_name,
-                                      layout2->storage.u.virt.list[u].source_dset_name);
+                strcmp_ret = strcmp(layout1->storage.u.virt.list[u].source_dset_name,
+                                    layout2->storage.u.virt.list[u].source_dset_name);
                 if (strcmp_ret < 0)
                     HGOTO_DONE(-1);
                 if (strcmp_ret > 0)
@@ -1442,7 +1442,7 @@ H5P__dcrt_ext_file_list_enc(const void *value, void **_pp, size_t *size)
         /* Encode file list */
         for (u = 0; u < efl->nused; u++) {
             /* Calculate length of slot name and encode it */
-            len       = HDstrlen(efl->slot[u].name) + 1;
+            len       = strlen(efl->slot[u].name) + 1;
             enc_value = (uint64_t)len;
             enc_size  = H5VM_limit_enc_size(enc_value);
             assert(enc_size < 256);
@@ -1472,7 +1472,7 @@ H5P__dcrt_ext_file_list_enc(const void *value, void **_pp, size_t *size)
     /* Calculate size needed for encoding */
     *size += (1 + H5VM_limit_enc_size((uint64_t)efl->nused));
     for (u = 0; u < efl->nused; u++) {
-        len = HDstrlen(efl->slot[u].name) + 1;
+        len = strlen(efl->slot[u].name) + 1;
         *size += (1 + H5VM_limit_enc_size((uint64_t)len));
         *size += len;
         *size += (1 + H5VM_limit_enc_size((uint64_t)efl->slot[u].offset));
@@ -1689,7 +1689,7 @@ H5P__dcrt_ext_file_list_cmp(const void *_efl1, const void *_efl2, size_t H5_ATTR
             if (efl1->slot[u].name != NULL && efl2->slot[u].name == NULL)
                 HGOTO_DONE(1);
             if (efl1->slot[u].name != NULL)
-                if ((cmp_value = HDstrcmp(efl1->slot[u].name, efl2->slot[u].name)) != 0)
+                if ((cmp_value = strcmp(efl1->slot[u].name, efl2->slot[u].name)) != 0)
                     HGOTO_DONE(cmp_value);
 
             /* Check the file offset of the efl entry */
@@ -2418,8 +2418,8 @@ H5Pget_virtual_filename(hid_t dcpl_id, size_t idx, char *name /*out*/, size_t si
     assert(layout.storage.u.virt.list_nused <= layout.storage.u.virt.list_nalloc);
     assert(layout.storage.u.virt.list[idx].source_file_name);
     if (name && (size > 0))
-        (void)HDstrncpy(name, layout.storage.u.virt.list[idx].source_file_name, size);
-    ret_value = (ssize_t)HDstrlen(layout.storage.u.virt.list[idx].source_file_name);
+        (void)strncpy(name, layout.storage.u.virt.list[idx].source_file_name, size);
+    ret_value = (ssize_t)strlen(layout.storage.u.virt.list[idx].source_file_name);
 
 done:
     FUNC_LEAVE_API(ret_value)
@@ -2476,8 +2476,8 @@ H5Pget_virtual_dsetname(hid_t dcpl_id, size_t idx, char *name /*out*/, size_t si
     assert(layout.storage.u.virt.list_nused <= layout.storage.u.virt.list_nalloc);
     assert(layout.storage.u.virt.list[idx].source_dset_name);
     if (name && (size > 0))
-        (void)HDstrncpy(name, layout.storage.u.virt.list[idx].source_dset_name, size);
-    ret_value = (ssize_t)HDstrlen(layout.storage.u.virt.list[idx].source_dset_name);
+        (void)strncpy(name, layout.storage.u.virt.list[idx].source_dset_name, size);
+    ret_value = (ssize_t)strlen(layout.storage.u.virt.list[idx].source_dset_name);
 
 done:
     FUNC_LEAVE_API(ret_value)
@@ -2738,7 +2738,7 @@ H5Pget_external(hid_t plist_id, unsigned idx, size_t name_size, char *name /*out
 
     /* Return values */
     if (name_size > 0 && name)
-        HDstrncpy(name, efl.slot[idx].name, name_size);
+        strncpy(name, efl.slot[idx].name, name_size);
     /* XXX: Badness!
      *
      * The offset parameter is of type off_t and the offset field of H5O_efl_entry_t

--- a/src/H5Pdxpl.c
+++ b/src/H5Pdxpl.c
@@ -725,7 +725,7 @@ H5P__dxfr_xform_enc(const void *value, void **_pp, size_t *size)
             HGOTO_ERROR(H5E_PLIST, H5E_CANTGET, FAIL, "failed to retrieve transform expression");
 
         /* Get the transform string expression size */
-        len = HDstrlen(pexp) + 1;
+        len = strlen(pexp) + 1;
     } /* end if */
 
     if (NULL != *pp) {
@@ -909,7 +909,7 @@ H5P__dxfr_xform_cmp(const void *_xform1, const void *_xform2, size_t H5_ATTR_UNU
 
         if (pexp1) {
             assert(pexp2);
-            ret_value = HDstrcmp(pexp1, pexp2);
+            ret_value = strcmp(pexp1, pexp2);
         } /* end if */
     }     /* end if */
 
@@ -1039,9 +1039,9 @@ H5Pget_data_transform(hid_t plist_id, char *expression /*out*/, size_t size)
         HGOTO_ERROR(H5E_PLIST, H5E_CANTGET, FAIL, "failed to retrieve transform expression");
 
     /* Copy into application buffer */
-    len = HDstrlen(pexp);
+    len = strlen(pexp);
     if (expression) {
-        HDstrncpy(expression, pexp, size);
+        strncpy(expression, pexp, size);
         if (len >= size)
             expression[size - 1] = '\0';
     } /* end if */

--- a/src/H5Pencdec.c
+++ b/src/H5Pencdec.c
@@ -311,9 +311,9 @@ H5P__encode_cb(H5P_genprop_t *prop, void *_udata)
         size_t prop_value_len; /* Encoded size of property's value */
 
         /* Encode (or not, if the 'encode' flag is off) the property's name */
-        prop_name_len = HDstrlen(prop->name) + 1;
+        prop_name_len = strlen(prop->name) + 1;
         if (udata->encode) {
-            HDstrcpy((char *)*(udata->pp), prop->name);
+            strcpy((char *)*(udata->pp), prop->name);
             *(uint8_t **)(udata->pp) += prop_name_len;
         } /* end if */
         *(udata->enc_size_ptr) += prop_name_len;
@@ -683,7 +683,7 @@ H5P__decode(const void *buf)
 
         /* Get property list name */
         name = (const char *)p;
-        p += HDstrlen(name) + 1;
+        p += strlen(name) + 1;
 
         /* Find property with name */
         if (NULL == (prop = H5P__find_prop_plist(plist, name)))

--- a/src/H5Pfapl.c
+++ b/src/H5Pfapl.c
@@ -948,35 +948,35 @@ H5P__facc_set_def_driver_check_predefined(const char *driver_name, hid_t *driver
     assert(driver_name);
     assert(driver_id);
 
-    if (!HDstrcmp(driver_name, "sec2")) {
+    if (!strcmp(driver_name, "sec2")) {
         if ((*driver_id = H5FD_SEC2) < 0)
             HGOTO_ERROR(H5E_VFL, H5E_UNINITIALIZED, FAIL, "couldn't initialize sec2 VFD");
     }
-    else if (!HDstrcmp(driver_name, "core") || !HDstrcmp(driver_name, "core_paged")) {
+    else if (!strcmp(driver_name, "core") || !strcmp(driver_name, "core_paged")) {
         if ((*driver_id = H5FD_CORE) < 0)
             HGOTO_ERROR(H5E_VFL, H5E_UNINITIALIZED, FAIL, "couldn't initialize core VFD");
     }
-    else if (!HDstrcmp(driver_name, "log")) {
+    else if (!strcmp(driver_name, "log")) {
         if ((*driver_id = H5FD_LOG) < 0)
             HGOTO_ERROR(H5E_VFL, H5E_UNINITIALIZED, FAIL, "couldn't initialize log VFD");
     }
-    else if (!HDstrcmp(driver_name, "family")) {
+    else if (!strcmp(driver_name, "family")) {
         if ((*driver_id = H5FD_FAMILY) < 0)
             HGOTO_ERROR(H5E_VFL, H5E_UNINITIALIZED, FAIL, "couldn't initialize family VFD");
     }
-    else if (!HDstrcmp(driver_name, "multi") || !HDstrcmp(driver_name, "split")) {
+    else if (!strcmp(driver_name, "multi") || !strcmp(driver_name, "split")) {
         if ((*driver_id = H5FD_MULTI) < 0)
             HGOTO_ERROR(H5E_VFL, H5E_UNINITIALIZED, FAIL, "couldn't initialize multi VFD");
     }
-    else if (!HDstrcmp(driver_name, "stdio")) {
+    else if (!strcmp(driver_name, "stdio")) {
         if ((*driver_id = H5FD_STDIO) < 0)
             HGOTO_ERROR(H5E_VFL, H5E_UNINITIALIZED, FAIL, "couldn't initialize stdio VFD");
     }
-    else if (!HDstrcmp(driver_name, "splitter")) {
+    else if (!strcmp(driver_name, "splitter")) {
         if ((*driver_id = H5FD_SPLITTER) < 0)
             HGOTO_ERROR(H5E_VFL, H5E_UNINITIALIZED, FAIL, "couldn't initialize splitter VFD");
     }
-    else if (!HDstrcmp(driver_name, "mpio")) {
+    else if (!strcmp(driver_name, "mpio")) {
 #ifdef H5_HAVE_PARALLEL
         if ((*driver_id = H5FD_MPIO) < 0)
             HGOTO_ERROR(H5E_VFL, H5E_UNINITIALIZED, FAIL, "couldn't initialize MPI I/O VFD");
@@ -984,7 +984,7 @@ H5P__facc_set_def_driver_check_predefined(const char *driver_name, hid_t *driver
         HGOTO_ERROR(H5E_VFL, H5E_BADVALUE, FAIL, "MPI-I/O VFD is not enabled");
 #endif
     }
-    else if (!HDstrcmp(driver_name, "direct")) {
+    else if (!strcmp(driver_name, "direct")) {
 #ifdef H5_HAVE_DIRECT
         if ((*driver_id = H5FD_DIRECT) < 0)
             HGOTO_ERROR(H5E_VFL, H5E_UNINITIALIZED, FAIL, "couldn't initialize Direct I/O VFD");
@@ -992,7 +992,7 @@ H5P__facc_set_def_driver_check_predefined(const char *driver_name, hid_t *driver
         HGOTO_ERROR(H5E_VFL, H5E_BADVALUE, FAIL, "Direct I/O VFD is not enabled");
 #endif
     }
-    else if (!HDstrcmp(driver_name, "mirror")) {
+    else if (!strcmp(driver_name, "mirror")) {
 #ifdef H5_HAVE_MIRROR_VFD
         if ((*driver_id = H5FD_MIRROR) < 0)
             HGOTO_ERROR(H5E_VFL, H5E_UNINITIALIZED, FAIL, "couldn't initialize mirror VFD");
@@ -1000,7 +1000,7 @@ H5P__facc_set_def_driver_check_predefined(const char *driver_name, hid_t *driver
         HGOTO_ERROR(H5E_VFL, H5E_BADVALUE, FAIL, "Mirror VFD is not enabled");
 #endif
     }
-    else if (!HDstrcmp(driver_name, "hdfs")) {
+    else if (!strcmp(driver_name, "hdfs")) {
 #ifdef H5_HAVE_LIBHDFS
         if ((*driver_id = H5FD_HDFS) < 0)
             HGOTO_ERROR(H5E_VFL, H5E_UNINITIALIZED, FAIL, "couldn't initialize HDFS VFD");
@@ -1008,7 +1008,7 @@ H5P__facc_set_def_driver_check_predefined(const char *driver_name, hid_t *driver
         HGOTO_ERROR(H5E_VFL, H5E_BADVALUE, FAIL, "HDFS VFD is not enabled");
 #endif
     }
-    else if (!HDstrcmp(driver_name, "ros3")) {
+    else if (!strcmp(driver_name, "ros3")) {
 #ifdef H5_HAVE_ROS3_VFD
         if ((*driver_id = H5FD_ROS3) < 0)
             HGOTO_ERROR(H5E_VFL, H5E_UNINITIALIZED, FAIL, "couldn't initialize ROS3 VFD");
@@ -1016,7 +1016,7 @@ H5P__facc_set_def_driver_check_predefined(const char *driver_name, hid_t *driver
         HGOTO_ERROR(H5E_VFL, H5E_BADVALUE, FAIL, "ROS3 VFD is not enabled");
 #endif
     }
-    else if (!HDstrcmp(driver_name, "subfiling")) {
+    else if (!strcmp(driver_name, "subfiling")) {
 #ifdef H5_HAVE_SUBFILING_VFD
         if ((*driver_id = H5FD_SUBFILING) < 0)
             HGOTO_ERROR(H5E_VFL, H5E_UNINITIALIZED, FAIL, "couldn't initialize Subfiling VFD");
@@ -1024,7 +1024,7 @@ H5P__facc_set_def_driver_check_predefined(const char *driver_name, hid_t *driver
         HGOTO_ERROR(H5E_VFL, H5E_BADVALUE, FAIL, "Subfiling VFD is not enabled");
 #endif
     }
-    else if (!HDstrcmp(driver_name, "windows")) {
+    else if (!strcmp(driver_name, "windows")) {
 #ifdef H5_HAVE_WINDOWS
         if ((*driver_id = H5FD_WINDOWS) < 0)
             HGOTO_ERROR(H5E_VFL, H5E_UNINITIALIZED, FAIL, "couldn't initialize Windows VFD");
@@ -1616,10 +1616,10 @@ H5Pget_driver_config_str(hid_t fapl_id, char *config_buf, size_t buf_size)
 
     /* Retrieve configuration string property */
     if ((config_str = H5P_peek_driver_config_str(plist))) {
-        size_t config_str_len = HDstrlen(config_str);
+        size_t config_str_len = strlen(config_str);
 
         if (config_buf) {
-            HDstrncpy(config_buf, config_str, buf_size);
+            strncpy(config_buf, config_str, buf_size);
             if (config_str_len >= buf_size)
                 config_buf[buf_size - 1] = '\0';
         }
@@ -1916,7 +1916,7 @@ H5P__facc_file_driver_cmp(const void *_info1, const void *_info2, size_t H5_ATTR
         HGOTO_DONE(-1);
     if (cls1->name != NULL && cls2->name == NULL)
         HGOTO_DONE(1);
-    if (0 != (cmp_value = HDstrcmp(cls1->name, cls2->name)))
+    if (0 != (cmp_value = strcmp(cls1->name, cls2->name)))
         HGOTO_DONE(cmp_value);
 
     /* Compare driver infos */
@@ -1941,7 +1941,7 @@ H5P__facc_file_driver_cmp(const void *_info1, const void *_info2, size_t H5_ATTR
     if (info1->driver_config_str != NULL && info2->driver_config_str == NULL)
         HGOTO_DONE(1);
     if (info1->driver_config_str) {
-        if (0 != (cmp_value = HDstrcmp(info1->driver_config_str, info2->driver_config_str)))
+        if (0 != (cmp_value = strcmp(info1->driver_config_str, info2->driver_config_str)))
             HGOTO_DONE(cmp_value);
     }
 
@@ -4097,7 +4097,7 @@ H5P__facc_cache_config_dec(const void **_pp, void *_value)
 
     H5_DECODE_UNSIGNED(*pp, config->close_trace_file);
 
-    HDstrcpy(config->trace_file_name, (const char *)(*pp));
+    strcpy(config->trace_file_name, (const char *)(*pp));
     *pp += H5AC__MAX_TRACE_FILE_NAME_LEN + 1;
 
     H5_DECODE_UNSIGNED(*pp, config->evictions_enabled);
@@ -4622,7 +4622,7 @@ H5Pget_mdc_log_options(hid_t plist_id, hbool_t *is_enabled /*out*/, char *locati
     /* Get location size, including terminating NULL */
     if (location_size) {
         if (location_ptr)
-            *location_size = HDstrlen(location_ptr) + 1;
+            *location_size = strlen(location_ptr) + 1;
         else
             *location_size = 0;
     } /* end if */
@@ -4658,7 +4658,7 @@ H5P__facc_mdc_log_location_enc(const void *value, void **_pp, size_t *size)
 
     /* calculate prefix length */
     if (NULL != log_location)
-        len = HDstrlen(log_location);
+        len = strlen(log_location);
 
     enc_value = (uint64_t)len;
     enc_size  = H5VM_limit_enc_size(enc_value);
@@ -4724,7 +4724,7 @@ H5P__facc_mdc_log_location_dec(const void **_pp, void *_value)
         /* Make a copy of the user's prefix string */
         if (NULL == (*log_location = (char *)H5MM_malloc(len + 1)))
             HGOTO_ERROR(H5E_RESOURCE, H5E_CANTINIT, FAIL, "memory allocation failed for prefix");
-        HDstrncpy(*log_location, *(const char **)pp, len);
+        strncpy(*log_location, *(const char **)pp, len);
         (*log_location)[len] = '\0';
 
         *pp += len;
@@ -4804,7 +4804,7 @@ H5P__facc_mdc_log_location_cmp(const void *value1, const void *value2, size_t H5
     if (NULL != pref1 && NULL == pref2)
         HGOTO_DONE(-1);
     if (NULL != pref1 && NULL != pref2)
-        ret_value = HDstrcmp(pref1, pref2);
+        ret_value = strcmp(pref1, pref2);
 
 done:
     FUNC_LEAVE_NOAPI(ret_value)

--- a/src/H5Pint.c
+++ b/src/H5Pint.c
@@ -1677,7 +1677,7 @@ H5P__open_class_path_cb(void *_obj, hid_t H5_ATTR_UNUSED id, void *_key)
     /* Check if the class object has the same parent as the new class */
     if (obj->parent == key->parent) {
         /* Check if they have the same name */
-        if (HDstrcmp(obj->name, key->name) == 0) {
+        if (strcmp(obj->name, key->name) == 0) {
             key->new_class = obj;
             ret_value      = 1; /* Indicate a match */
         }                       /* end if */
@@ -3603,7 +3603,7 @@ H5P__cmp_prop(const H5P_genprop_t *prop1, const H5P_genprop_t *prop2)
     assert(prop2);
 
     /* Check the name */
-    if ((cmp_value = HDstrcmp(prop1->name, prop2->name)) != 0)
+    if ((cmp_value = strcmp(prop1->name, prop2->name)) != 0)
         HGOTO_DONE(cmp_value);
 
     /* Check the size of properties */
@@ -3738,7 +3738,7 @@ H5P__cmp_class(const H5P_genclass_t *pclass1, const H5P_genclass_t *pclass2)
         HGOTO_DONE(0);
 
     /* Check the name */
-    if ((cmp_value = HDstrcmp(pclass1->name, pclass2->name)) != 0)
+    if ((cmp_value = strcmp(pclass1->name, pclass2->name)) != 0)
         HGOTO_DONE(cmp_value);
 
     /* Check the number of properties */
@@ -5350,13 +5350,13 @@ H5P__get_class_path(H5P_genclass_t *pclass)
             /* Allocate enough space for the parent class's path, plus the '/'
              * separator, this class's name and the string terminator
              */
-            ret_str_len = HDstrlen(par_path) + HDstrlen(pclass->name) + 1 +
+            ret_str_len = strlen(par_path) + strlen(pclass->name) + 1 +
                           3; /* Extra "+3" to quiet GCC warning - 2019/07/05, QAK */
             if (NULL == (ret_value = (char *)H5MM_malloc(ret_str_len)))
                 HGOTO_ERROR(H5E_RESOURCE, H5E_NOSPACE, NULL, "memory allocation failed for class name");
 
             /* Build the full path for this class */
-            HDsnprintf(ret_value, ret_str_len, "%s/%s", par_path, pclass->name);
+            snprintf(ret_value, ret_str_len, "%s/%s", par_path, pclass->name);
 
             /* Free the parent class's path */
             H5MM_xfree(par_path);
@@ -5411,7 +5411,7 @@ H5P__open_class_path(const char *path)
     /* Find the generic property class with this full path */
     curr_name  = tmp_path;
     curr_class = NULL;
-    while (NULL != (delimit = HDstrchr(curr_name, '/'))) {
+    while (NULL != (delimit = strchr(curr_name, '/'))) {
         /* Change the delimiter to terminate the string */
         *delimit = '\0';
 

--- a/src/H5Plapl.c
+++ b/src/H5Plapl.c
@@ -658,7 +658,7 @@ H5P__lacc_elink_pref_enc(const void *value, void **_pp, size_t *size)
 
     /* calculate prefix length */
     if (NULL != elink_pref)
-        len = HDstrlen(elink_pref);
+        len = strlen(elink_pref);
 
     enc_value = (uint64_t)len;
     enc_size  = H5VM_limit_enc_size(enc_value);
@@ -724,7 +724,7 @@ H5P__lacc_elink_pref_dec(const void **_pp, void *_value)
         /* Make a copy of the user's prefix string */
         if (NULL == (*elink_pref = (char *)H5MM_malloc(len + 1)))
             HGOTO_ERROR(H5E_RESOURCE, H5E_CANTINIT, FAIL, "memory allocation failed for prefix");
-        HDstrncpy(*elink_pref, *(const char **)pp, len);
+        strncpy(*elink_pref, *(const char **)pp, len);
         (*elink_pref)[len] = '\0';
 
         *pp += len;
@@ -804,7 +804,7 @@ H5P__lacc_elink_pref_cmp(const void *value1, const void *value2, size_t H5_ATTR_
     if (NULL != pref1 && NULL == pref2)
         HGOTO_DONE(-1);
     if (NULL != pref1 && NULL != pref2)
-        ret_value = HDstrcmp(pref1, pref2);
+        ret_value = strcmp(pref1, pref2);
 
 done:
     FUNC_LEAVE_NOAPI(ret_value)
@@ -977,9 +977,9 @@ H5Pget_elink_prefix(hid_t plist_id, char *prefix /*out*/, size_t size)
     /* Check for prefix being set */
     if (my_prefix) {
         /* Copy to user's buffer, if given */
-        len = HDstrlen(my_prefix);
+        len = strlen(my_prefix);
         if (prefix) {
-            HDstrncpy(prefix, my_prefix, size);
+            strncpy(prefix, my_prefix, size);
             if (len >= size)
                 prefix[size - 1] = '\0';
         } /* end if */

--- a/src/H5Pocpl.c
+++ b/src/H5Pocpl.c
@@ -1178,14 +1178,14 @@ H5P__get_filter(const H5Z_filter_info_t *filter, unsigned int *flags /*out*/, si
 
         /* Check for actual name */
         if (s) {
-            HDstrncpy(name, s, namelen);
+            strncpy(name, s, namelen);
             name[namelen - 1] = '\0';
         } /* end if */
         else {
             /* Check for unknown library filter */
             /* (probably from a future version of the library) */
             if (filter->id < 256) {
-                HDstrncpy(name, "Unknown library filter", namelen);
+                strncpy(name, "Unknown library filter", namelen);
                 name[namelen - 1] = '\0';
             } /* end if */
             else
@@ -1572,7 +1572,7 @@ H5P__ocrt_pipeline_cmp(const void *_pline1, const void *_pline2, size_t H5_ATTR_
             if (pline1->filter[u].name != NULL && pline2->filter[u].name == NULL)
                 HGOTO_DONE(1);
             if (pline1->filter[u].name != NULL)
-                if ((cmp_value = HDstrcmp(pline1->filter[u].name, pline2->filter[u].name)) != 0)
+                if ((cmp_value = strcmp(pline1->filter[u].name, pline2->filter[u].name)) != 0)
                     HGOTO_DONE(cmp_value);
 
             /* Check the number of parameters for the filter */

--- a/src/H5Pocpypl.c
+++ b/src/H5Pocpypl.c
@@ -356,7 +356,7 @@ H5P__ocpy_merge_comm_dt_list_enc(const void *value, void **_pp, size_t *size)
     dt_list = *dt_list_ptr;
     while (dt_list) {
         /* Get length of encoded path */
-        len = HDstrlen(dt_list->path) + 1;
+        len = strlen(dt_list->path) + 1;
 
         /* Encode merge committed dtype list */
         if (*pp) {
@@ -415,7 +415,7 @@ H5P__ocpy_merge_comm_dt_list_dec(const void **_pp, void *_value)
     *dt_list = NULL;
 
     /* Decode the string sequence */
-    len = HDstrlen(*(const char **)pp);
+    len = strlen(*(const char **)pp);
     while (len > 0) {
         /* Create new node & duplicate string */
         if (NULL == (tmp_dt_list = H5FL_CALLOC(H5O_copy_dtype_merge_list_t)))
@@ -423,7 +423,7 @@ H5P__ocpy_merge_comm_dt_list_dec(const void **_pp, void *_value)
         if (NULL == (tmp_dt_list->path = H5MM_strdup(*(const char **)pp)))
             HGOTO_ERROR(H5E_PLIST, H5E_CANTALLOC, FAIL, "memory allocation failed");
         *pp += len + 1;
-        assert(len == HDstrlen(tmp_dt_list->path));
+        assert(len == strlen(tmp_dt_list->path));
 
         /* Add copied node to dtype list */
         if (dt_list_tail) {
@@ -437,7 +437,7 @@ H5P__ocpy_merge_comm_dt_list_dec(const void **_pp, void *_value)
         tmp_dt_list = NULL;
 
         /* Compute length of next string */
-        len = HDstrlen(*(const char **)pp);
+        len = strlen(*(const char **)pp);
     } /* end while */
 
     /* Advance past terminator for string sequence */
@@ -543,7 +543,7 @@ H5P__ocpy_merge_comm_dt_list_cmp(const void *_dt_list1, const void *_dt_list2, s
         assert(dt_list2->path);
 
         /* Compare paths */
-        ret_value = HDstrcmp(dt_list1->path, dt_list2->path);
+        ret_value = strcmp(dt_list1->path, dt_list2->path);
         if (ret_value != 0)
             HGOTO_DONE(ret_value);
 

--- a/src/H5RS.c
+++ b/src/H5RS.c
@@ -113,7 +113,7 @@ H5RS__xstrdup(H5RS_str_t *rs, const char *s)
     assert(rs);
 
     if (s) {
-        size_t len = HDstrlen(s);
+        size_t len = strlen(s);
 
         /* Determine size of buffer to allocate */
         rs->max = H5RS_ALLOC_SIZE;
@@ -322,7 +322,7 @@ H5RS_wrap(const char *s)
     ret_value->s = (char *)s;
     H5_GCC_CLANG_DIAG_ON("cast-qual")
 
-    ret_value->len = HDstrlen(s);
+    ret_value->len = strlen(s);
     ret_value->end = ret_value->s + ret_value->len;
 
     ret_value->wrapped = true;
@@ -372,7 +372,7 @@ H5RS_asprintf_cat(H5RS_str_t *rs, const char *fmt, ...)
     /* Attempt to write formatted output into the managed string */
     va_start(args1, fmt);
     va_copy(args2, args1);
-    while ((out_len = (size_t)HDvsnprintf(rs->end, (rs->max - rs->len), fmt, args1)) >= (rs->max - rs->len)) {
+    while ((out_len = (size_t)vsnprintf(rs->end, (rs->max - rs->len), fmt, args1)) >= (rs->max - rs->len)) {
         /* Allocate a large enough buffer */
         if (H5RS__resize_for_append(rs, out_len) < 0)
             HGOTO_ERROR(H5E_RS, H5E_CANTRESIZE, FAIL, "can't resize ref-counted string buffer");
@@ -418,7 +418,7 @@ H5RS_acat(H5RS_str_t *rs, const char *s)
 
     /* Concatenate the provided string on to the managed string */
     if (*s) {
-        size_t len = HDstrlen(s);
+        size_t len = strlen(s);
 
         /* Allocate the underlying string, if necessary */
         if (H5RS__prepare_for_append(rs) < 0)
@@ -464,7 +464,7 @@ H5RS_ancat(H5RS_str_t *rs, const char *s, size_t n)
 
     /* Concatenate the provided string on to the managed string */
     if (n && *s) {
-        size_t len = HDstrlen(s);
+        size_t len = strlen(s);
 
         /* Limit characters to copy to the minimum of 'n' and 'len' */
         n = MIN(len, n);
@@ -677,7 +677,7 @@ H5RS_cmp(const H5RS_str_t *rs1, const H5RS_str_t *rs2)
     assert(rs2);
     assert(rs2->s);
 
-    FUNC_LEAVE_NOAPI(HDstrcmp(rs1->s, rs2->s))
+    FUNC_LEAVE_NOAPI(strcmp(rs1->s, rs2->s))
 } /* end H5RS_cmp() */
 
 /*--------------------------------------------------------------------------
@@ -707,7 +707,7 @@ H5RS_len(const H5RS_str_t *rs)
     assert(rs);
     assert(rs->s);
 
-    FUNC_LEAVE_NOAPI(HDstrlen(rs->s))
+    FUNC_LEAVE_NOAPI(strlen(rs->s))
 } /* end H5RS_len() */
 
 /*--------------------------------------------------------------------------

--- a/src/H5Rint.c
+++ b/src/H5Rint.c
@@ -102,14 +102,13 @@ H5R__print_token(const H5O_token_t token)
     static char string[64];
 
     /* Print the raw token. */
-    HDsnprintf(string, 64, "%02X:%02X:%02X:%02X:%02X:%02X:%02X:%02X:%02X:%02X:%02X:%02X:%02X:%02X:%02X:%02X",
-               (unsigned char)token.__data[15], (unsigned char)token.__data[14],
-               (unsigned char)token.__data[13], (unsigned char)token.__data[12],
-               (unsigned char)token.__data[11], (unsigned char)token.__data[10],
-               (unsigned char)token.__data[9], (unsigned char)token.__data[8], (unsigned char)token.__data[7],
-               (unsigned char)token.__data[6], (unsigned char)token.__data[5], (unsigned char)token.__data[4],
-               (unsigned char)token.__data[3], (unsigned char)token.__data[2], (unsigned char)token.__data[1],
-               (unsigned char)token.__data[0]);
+    snprintf(string, 64, "%02X:%02X:%02X:%02X:%02X:%02X:%02X:%02X:%02X:%02X:%02X:%02X:%02X:%02X:%02X:%02X",
+             (unsigned char)token.__data[15], (unsigned char)token.__data[14],
+             (unsigned char)token.__data[13], (unsigned char)token.__data[12],
+             (unsigned char)token.__data[11], (unsigned char)token.__data[10], (unsigned char)token.__data[9],
+             (unsigned char)token.__data[8], (unsigned char)token.__data[7], (unsigned char)token.__data[6],
+             (unsigned char)token.__data[5], (unsigned char)token.__data[4], (unsigned char)token.__data[3],
+             (unsigned char)token.__data[2], (unsigned char)token.__data[1], (unsigned char)token.__data[0]);
 
     return string;
 }
@@ -279,13 +278,13 @@ H5R__create_attr(const H5O_token_t *obj_token, size_t token_size, const char *at
     assert(ref);
 
     /* Make sure that attribute name is not longer than supported encode size */
-    if (HDstrlen(attr_name) > H5R_MAX_STRING_LEN)
+    if (strlen(attr_name) > H5R_MAX_STRING_LEN)
         HGOTO_ERROR(H5E_REFERENCE, H5E_ARGS, FAIL, "attribute name too long (%d > %d)",
-                    (int)HDstrlen(attr_name), H5R_MAX_STRING_LEN);
+                    (int)strlen(attr_name), H5R_MAX_STRING_LEN);
 
     /* Create new reference */
     ref->info.obj.filename = NULL;
-    if (NULL == (ref->info.attr.name = HDstrdup(attr_name)))
+    if (NULL == (ref->info.attr.name = strdup(attr_name)))
         HGOTO_ERROR(H5E_REFERENCE, H5E_CANTCOPY, FAIL, "Cannot copy attribute name");
 
     ref->loc_id = H5I_INVALID_HID;
@@ -583,7 +582,7 @@ H5R__equal(const H5R_ref_priv_t *ref1, const H5R_ref_priv_t *ref2)
         ((NULL == ref1->info.obj.filename) && ref2->info.obj.filename))
         HGOTO_DONE(false);
     if (ref1->info.obj.filename && ref1->info.obj.filename &&
-        (0 != HDstrcmp(ref1->info.obj.filename, ref2->info.obj.filename)))
+        (0 != strcmp(ref1->info.obj.filename, ref2->info.obj.filename)))
         HGOTO_DONE(false);
 
     switch (ref1->type) {
@@ -595,7 +594,7 @@ H5R__equal(const H5R_ref_priv_t *ref1, const H5R_ref_priv_t *ref2)
             break;
         case H5R_ATTR:
             assert(ref1->info.attr.name && ref2->info.attr.name);
-            if (0 != HDstrcmp(ref1->info.attr.name, ref2->info.attr.name))
+            if (0 != strcmp(ref1->info.attr.name, ref2->info.attr.name))
                 HGOTO_DONE(false);
             break;
         case H5R_OBJECT1:
@@ -644,7 +643,7 @@ H5R__copy(const H5R_ref_priv_t *src_ref, H5R_ref_priv_t *dst_ref)
                 HGOTO_ERROR(H5E_REFERENCE, H5E_CANTCOPY, FAIL, "unable to copy dataspace");
             break;
         case H5R_ATTR:
-            if (NULL == (dst_ref->info.attr.name = HDstrdup(src_ref->info.attr.name)))
+            if (NULL == (dst_ref->info.attr.name = strdup(src_ref->info.attr.name)))
                 HGOTO_ERROR(H5E_REFERENCE, H5E_CANTCOPY, FAIL, "Cannot copy attribute name");
             break;
         case H5R_OBJECT1:
@@ -662,7 +661,7 @@ H5R__copy(const H5R_ref_priv_t *src_ref, H5R_ref_priv_t *dst_ref)
     if (src_ref->loc_id == H5I_INVALID_HID) {
         assert(src_ref->info.obj.filename);
 
-        if (NULL == (dst_ref->info.obj.filename = HDstrdup(src_ref->info.obj.filename)))
+        if (NULL == (dst_ref->info.obj.filename = strdup(src_ref->info.obj.filename)))
             HGOTO_ERROR(H5E_REFERENCE, H5E_CANTCOPY, FAIL, "Cannot copy filename");
         dst_ref->loc_id = H5I_INVALID_HID;
     }
@@ -795,7 +794,7 @@ H5R__get_file_name(const H5R_ref_priv_t *ref, char *buf, size_t size)
         HGOTO_ERROR(H5E_REFERENCE, H5E_ARGS, (-1), "no filename available for that reference");
 
     /* Get the file name length */
-    copy_len = HDstrlen(ref->info.obj.filename);
+    copy_len = strlen(ref->info.obj.filename);
     assert(copy_len <= H5R_MAX_STRING_LEN);
 
     /* Copy the file name */
@@ -832,7 +831,7 @@ H5R__get_attr_name(const H5R_ref_priv_t *ref, char *buf, size_t size)
     assert(ref->type == H5R_ATTR);
 
     /* Get the attribute name length */
-    attr_name_len = HDstrlen(ref->info.attr.name);
+    attr_name_len = strlen(ref->info.attr.name);
     assert(attr_name_len <= H5R_MAX_STRING_LEN);
 
     /* Get the attribute name */
@@ -1245,7 +1244,7 @@ H5R__encode_string(const char *string, unsigned char *buf, size_t *nalloc)
     assert(nalloc);
 
     /* Get the amount of space required to serialize the string */
-    string_len = HDstrlen(string);
+    string_len = strlen(string);
     if (string_len > H5R_MAX_STRING_LEN)
         HGOTO_ERROR(H5E_REFERENCE, H5E_ARGS, FAIL, "string too long");
 

--- a/src/H5SL.c
+++ b/src/H5SL.c
@@ -77,7 +77,7 @@
 
 /* Define a code template for comparing string keys for the "CMP" in the H5SL_LOCATE macro */
 #define H5SL_LOCATE_STRING_CMP(SLIST, TYPE, PNODE, PKEY, HASHVAL)                                            \
-    (((PNODE)->hashval == HASHVAL) ? (HDstrcmp((const char *)(PNODE)->key, (const char *)PKEY) < 0)          \
+    (((PNODE)->hashval == HASHVAL) ? (strcmp((const char *)(PNODE)->key, (const char *)PKEY) < 0)            \
                                    : ((PNODE)->hashval < HASHVAL))
 
 /* Define a code template for comparing H5_obj_t keys for the "CMP" in the H5SL_LOCATE macro */
@@ -95,7 +95,7 @@
 
 /* Define a code template for comparing string keys for the "EQ" in the H5SL_LOCATE macro */
 #define H5SL_LOCATE_STRING_EQ(SLIST, TYPE, PNODE, PKEY, HASHVAL)                                             \
-    (((PNODE)->hashval == HASHVAL) && (HDstrcmp((const char *)(PNODE)->key, (const char *)PKEY) == 0))
+    (((PNODE)->hashval == HASHVAL) && (strcmp((const char *)(PNODE)->key, (const char *)PKEY) == 0))
 
 /* Define a code template for comparing H5_obj_t keys for the "EQ" in the H5SL_LOCATE macro */
 #define H5SL_LOCATE_OBJ_EQ(SLIST, TYPE, PNODE, PKEY, HASHVAL)                                                \

--- a/src/H5T.c
+++ b/src/H5T.c
@@ -2501,7 +2501,7 @@ H5T__register(H5T_pers_t pers, const char *name, H5T_t *src, H5T_t *dst, H5T_con
             H5T_g.asoft = na;
             H5T_g.soft  = x;
         } /* end if */
-        HDstrncpy(H5T_g.soft[H5T_g.nsoft].name, name, (size_t)H5T_NAMELEN);
+        strncpy(H5T_g.soft[H5T_g.nsoft].name, name, (size_t)H5T_NAMELEN);
         H5T_g.soft[H5T_g.nsoft].name[H5T_NAMELEN - 1] = '\0';
         H5T_g.soft[H5T_g.nsoft].src                   = src->shared->type;
         H5T_g.soft[H5T_g.nsoft].dst                   = dst->shared->type;
@@ -2550,7 +2550,7 @@ H5T__register(H5T_pers_t pers, const char *name, H5T_t *src, H5T_t *dst, H5T_con
             /* Create a new conversion path */
             if (NULL == (new_path = H5FL_CALLOC(H5T_path_t)))
                 HGOTO_ERROR(H5E_RESOURCE, H5E_NOSPACE, FAIL, "memory allocation failed");
-            HDstrncpy(new_path->name, name, (size_t)H5T_NAMELEN);
+            strncpy(new_path->name, name, (size_t)H5T_NAMELEN);
             new_path->name[H5T_NAMELEN - 1] = '\0';
             if (NULL == (new_path->src = H5T_copy(old_path->src, H5T_COPY_ALL)) ||
                 NULL == (new_path->dst = H5T_copy(old_path->dst, H5T_COPY_ALL)))
@@ -2698,7 +2698,7 @@ H5T__unregister(H5T_pers_t pers, const char *name, H5T_t *src, H5T_t *dst, H5T_c
         for (i = H5T_g.nsoft - 1; i >= 0; --i) {
             soft = H5T_g.soft + i;
             assert(soft);
-            if (name && *name && HDstrcmp(name, soft->name) != 0)
+            if (name && *name && strcmp(name, soft->name) != 0)
                 continue;
             if (src && src->shared->type != soft->src)
                 continue;
@@ -2719,7 +2719,7 @@ H5T__unregister(H5T_pers_t pers, const char *name, H5T_t *src, H5T_t *dst, H5T_c
 
         /* Not a match */
         if (((H5T_PERS_SOFT == pers && path->is_hard) || (H5T_PERS_HARD == pers && !path->is_hard)) ||
-            (name && *name && HDstrcmp(name, path->name) != 0) || (src && H5T_cmp(src, path->src, false)) ||
+            (name && *name && strcmp(name, path->name) != 0) || (src && H5T_cmp(src, path->src, false)) ||
             (dst && H5T_cmp(dst, path->dst, false)) || (func && func != path->conv.u.app_func)) {
             /*
              * Notify all other functions to recalculate private data since some
@@ -3471,8 +3471,8 @@ H5T__complete_copy(H5T_t *new_dt, const H5T_t *old_dt, H5T_shared_t *reopened_fo
 
                     if (old_dt->shared->u.compnd.sorted != H5T_SORT_VALUE) {
                         for (old_match = -1, j = 0; j < old_dt->shared->u.compnd.nmembs; j++) {
-                            if (!HDstrcmp(new_dt->shared->u.compnd.memb[i].name,
-                                          old_dt->shared->u.compnd.memb[j].name)) {
+                            if (!strcmp(new_dt->shared->u.compnd.memb[i].name,
+                                        old_dt->shared->u.compnd.memb[j].name)) {
                                 old_match = (int)j;
                                 break;
                             } /* end if */
@@ -4403,8 +4403,8 @@ H5T_cmp(const H5T_t *dt1, const H5T_t *dt2, bool superset)
                     int j;
 
                     for (j = 0, swapped = false; j < i; j++)
-                        if (HDstrcmp(dt1->shared->u.compnd.memb[idx1[j]].name,
-                                     dt1->shared->u.compnd.memb[idx1[j + 1]].name) > 0) {
+                        if (strcmp(dt1->shared->u.compnd.memb[idx1[j]].name,
+                                   dt1->shared->u.compnd.memb[idx1[j + 1]].name) > 0) {
                             unsigned tmp_idx = idx1[j];
                             idx1[j]          = idx1[j + 1];
                             idx1[j + 1]      = tmp_idx;
@@ -4415,8 +4415,8 @@ H5T_cmp(const H5T_t *dt1, const H5T_t *dt2, bool superset)
                     int j;
 
                     for (j = 0, swapped = false; j < i; j++)
-                        if (HDstrcmp(dt2->shared->u.compnd.memb[idx2[j]].name,
-                                     dt2->shared->u.compnd.memb[idx2[j + 1]].name) > 0) {
+                        if (strcmp(dt2->shared->u.compnd.memb[idx2[j]].name,
+                                   dt2->shared->u.compnd.memb[idx2[j + 1]].name) > 0) {
                             unsigned tmp_idx = idx2[j];
                             idx2[j]          = idx2[j + 1];
                             idx2[j + 1]      = tmp_idx;
@@ -4428,17 +4428,17 @@ H5T_cmp(const H5T_t *dt1, const H5T_t *dt2, bool superset)
 #ifdef H5T_DEBUG
             /* I don't quite trust the code above yet :-)  --RPM */
             for (u = 0; u < dt1->shared->u.compnd.nmembs - 1; u++) {
-                assert(HDstrcmp(dt1->shared->u.compnd.memb[idx1[u]].name,
-                                dt1->shared->u.compnd.memb[idx1[u + 1]].name));
-                assert(HDstrcmp(dt2->shared->u.compnd.memb[idx2[u]].name,
-                                dt2->shared->u.compnd.memb[idx2[u + 1]].name));
+                assert(strcmp(dt1->shared->u.compnd.memb[idx1[u]].name,
+                              dt1->shared->u.compnd.memb[idx1[u + 1]].name));
+                assert(strcmp(dt2->shared->u.compnd.memb[idx2[u]].name,
+                              dt2->shared->u.compnd.memb[idx2[u + 1]].name));
             }
 #endif
 
             /* Compare the members */
             for (u = 0; u < dt1->shared->u.compnd.nmembs; u++) {
-                tmp = HDstrcmp(dt1->shared->u.compnd.memb[idx1[u]].name,
-                               dt2->shared->u.compnd.memb[idx2[u]].name);
+                tmp = strcmp(dt1->shared->u.compnd.memb[idx1[u]].name,
+                             dt2->shared->u.compnd.memb[idx2[u]].name);
                 if (tmp < 0)
                     HGOTO_DONE(-1);
                 if (tmp > 0)
@@ -4494,8 +4494,8 @@ H5T_cmp(const H5T_t *dt1, const H5T_t *dt2, bool superset)
                     int j;
 
                     for (j = 0, swapped = false; j < i; j++)
-                        if (HDstrcmp(dt1->shared->u.enumer.name[idx1[j]],
-                                     dt1->shared->u.enumer.name[idx1[j + 1]]) > 0) {
+                        if (strcmp(dt1->shared->u.enumer.name[idx1[j]],
+                                   dt1->shared->u.enumer.name[idx1[j + 1]]) > 0) {
                             unsigned tmp_idx = idx1[j];
                             idx1[j]          = idx1[j + 1];
                             idx1[j + 1]      = tmp_idx;
@@ -4512,8 +4512,8 @@ H5T_cmp(const H5T_t *dt1, const H5T_t *dt2, bool superset)
                     int j;
 
                     for (j = 0, swapped = false; j < i; j++)
-                        if (HDstrcmp(dt2->shared->u.enumer.name[idx2[j]],
-                                     dt2->shared->u.enumer.name[idx2[j + 1]]) > 0) {
+                        if (strcmp(dt2->shared->u.enumer.name[idx2[j]],
+                                   dt2->shared->u.enumer.name[idx2[j + 1]]) > 0) {
                             unsigned tmp_idx = idx2[j];
                             idx2[j]          = idx2[j + 1];
                             idx2[j + 1]      = tmp_idx;
@@ -4525,10 +4525,8 @@ H5T_cmp(const H5T_t *dt1, const H5T_t *dt2, bool superset)
 #ifdef H5T_DEBUG
             /* I don't quite trust the code above yet :-)  --RPM */
             for (u = 0; u < dt1->shared->u.enumer.nmembs - 1; u++) {
-                assert(
-                    HDstrcmp(dt1->shared->u.enumer.name[idx1[u]], dt1->shared->u.enumer.name[idx1[u + 1]]));
-                assert(
-                    HDstrcmp(dt2->shared->u.enumer.name[idx2[u]], dt2->shared->u.enumer.name[idx2[u + 1]]));
+                assert(strcmp(dt1->shared->u.enumer.name[idx1[u]], dt1->shared->u.enumer.name[idx1[u + 1]]));
+                assert(strcmp(dt2->shared->u.enumer.name[idx2[u]], dt2->shared->u.enumer.name[idx2[u + 1]]));
             }
 #endif
 
@@ -4551,8 +4549,8 @@ H5T_cmp(const H5T_t *dt1, const H5T_t *dt2, bool superset)
                         idx = (lt + rt) / 2;
 
                         /* compare */
-                        if ((cmp = HDstrcmp(dt1->shared->u.enumer.name[idx1[u]],
-                                            dt2->shared->u.enumer.name[idx2[idx]])) < 0)
+                        if ((cmp = strcmp(dt1->shared->u.enumer.name[idx1[u]],
+                                          dt2->shared->u.enumer.name[idx2[idx]])) < 0)
                             rt = idx;
                         else
                             lt = idx + 1;
@@ -4565,7 +4563,7 @@ H5T_cmp(const H5T_t *dt1, const H5T_t *dt2, bool superset)
                     /* Check for exact member name match when not doing
                      * "superset" comparison
                      */
-                    tmp = HDstrcmp(dt1->shared->u.enumer.name[idx1[u]], dt2->shared->u.enumer.name[idx2[u]]);
+                    tmp = strcmp(dt1->shared->u.enumer.name[idx1[u]], dt2->shared->u.enumer.name[idx2[u]]);
                     if (tmp < 0)
                         HGOTO_DONE(-1);
                     if (tmp > 0)
@@ -4621,7 +4619,7 @@ H5T_cmp(const H5T_t *dt1, const H5T_t *dt2, bool superset)
 
         case H5T_OPAQUE:
             if (dt1->shared->u.opaque.tag && dt2->shared->u.opaque.tag)
-                HGOTO_DONE(HDstrcmp(dt1->shared->u.opaque.tag, dt2->shared->u.opaque.tag));
+                HGOTO_DONE(strcmp(dt1->shared->u.opaque.tag, dt2->shared->u.opaque.tag));
             break;
 
         case H5T_ARRAY:
@@ -4890,7 +4888,7 @@ H5T__path_find_real(const H5T_t *src, const H5T_t *dst, const char *name, H5T_co
         if (NULL == (H5T_g.path[0] = H5FL_CALLOC(H5T_path_t)))
             HGOTO_ERROR(H5E_RESOURCE, H5E_NOSPACE, NULL,
                         "memory allocation failed for no-op conversion path");
-        HDsnprintf(H5T_g.path[0]->name, sizeof(H5T_g.path[0]->name), "no-op");
+        snprintf(H5T_g.path[0]->name, sizeof(H5T_g.path[0]->name), "no-op");
         H5T_g.path[0]->conv.is_app     = false;
         H5T_g.path[0]->conv.u.lib_func = H5T__conv_noop;
         H5T_g.path[0]->cdata.command   = H5T_CONV_INIT;
@@ -4955,11 +4953,11 @@ H5T__path_find_real(const H5T_t *src, const H5T_t *dst, const char *name, H5T_co
         if (NULL == (path = H5FL_CALLOC(H5T_path_t)))
             HGOTO_ERROR(H5E_RESOURCE, H5E_NOSPACE, NULL, "memory allocation failed for type conversion path");
         if (name && *name) {
-            HDstrncpy(path->name, name, (size_t)H5T_NAMELEN);
+            strncpy(path->name, name, (size_t)H5T_NAMELEN);
             path->name[H5T_NAMELEN - 1] = '\0';
         } /* end if */
         else
-            HDsnprintf(path->name, sizeof(path->name), "NONAME");
+            snprintf(path->name, sizeof(path->name), "NONAME");
         if (NULL == (path->src = H5T_copy(src, H5T_COPY_ALL)))
             HGOTO_ERROR(H5E_DATATYPE, H5E_CANTINIT, NULL, "unable to copy datatype for conversion path");
         if (NULL == (path->dst = H5T_copy(dst, H5T_COPY_ALL)))
@@ -5037,7 +5035,7 @@ H5T__path_find_real(const H5T_t *src, const H5T_t *dst, const char *name, H5T_co
 
         /* Finish operation, if no error */
         if (!path_init_error) {
-            HDstrncpy(path->name, H5T_g.soft[i].name, (size_t)H5T_NAMELEN);
+            strncpy(path->name, H5T_g.soft[i].name, (size_t)H5T_NAMELEN);
             path->name[H5T_NAMELEN - 1] = '\0';
             path->conv                  = H5T_g.soft[i].conv;
             path->is_hard               = false;

--- a/src/H5Tcompound.c
+++ b/src/H5Tcompound.c
@@ -410,7 +410,7 @@ H5T__insert(H5T_t *parent, const char *name, size_t offset, const H5T_t *member)
 
     /* Does NAME already exist in PARENT? */
     for (i = 0; i < parent->shared->u.compnd.nmembs; i++)
-        if (!HDstrcmp(parent->shared->u.compnd.memb[i].name, name))
+        if (!strcmp(parent->shared->u.compnd.memb[i].name, name))
             HGOTO_ERROR(H5E_DATATYPE, H5E_CANTINSERT, FAIL, "member name is not unique");
 
     /* Does the new member overlap any existing member ? */

--- a/src/H5Tconv.c
+++ b/src/H5Tconv.c
@@ -2026,7 +2026,7 @@ H5T__conv_struct_init(H5T_t *src, H5T_t *dst, H5T_cdata_t *cdata)
         for (i = 0; i < src_nmembs; i++) {
             src2dst[i] = -1;
             for (j = 0; j < dst_nmembs; j++) {
-                if (!HDstrcmp(src->shared->u.compnd.memb[i].name, dst->shared->u.compnd.memb[j].name)) {
+                if (!strcmp(src->shared->u.compnd.memb[i].name, dst->shared->u.compnd.memb[j].name)) {
                     H5_CHECKED_ASSIGN(src2dst[i], int, j, unsigned);
                     break;
                 } /* end if */
@@ -2687,7 +2687,7 @@ H5T__conv_enum_init(H5T_t *src, H5T_t *dst, H5T_cdata_t *cdata)
         HGOTO_ERROR(H5E_RESOURCE, H5E_NOSPACE, FAIL, "memory allocation failed");
     for (i = 0, j = 0; i < src->shared->u.enumer.nmembs && j < dst->shared->u.enumer.nmembs; i++, j++) {
         while (j < dst->shared->u.enumer.nmembs &&
-               HDstrcmp(src->shared->u.enumer.name[i], dst->shared->u.enumer.name[j]) != 0)
+               strcmp(src->shared->u.enumer.name[i], dst->shared->u.enumer.name[j]) != 0)
             j++;
         if (j >= dst->shared->u.enumer.nmembs)
             HGOTO_ERROR(H5E_DATATYPE, H5E_UNSUPPORTED, FAIL,

--- a/src/H5Tenum.c
+++ b/src/H5Tenum.c
@@ -171,7 +171,7 @@ H5T__enum_insert(const H5T_t *dt, const char *name, const void *value)
 
     /* The name and value had better not already exist */
     for (i = 0; i < dt->shared->u.enumer.nmembs; i++) {
-        if (!HDstrcmp(dt->shared->u.enumer.name[i], name))
+        if (!strcmp(dt->shared->u.enumer.name[i], name))
             HGOTO_ERROR(H5E_DATATYPE, H5E_CANTINIT, FAIL, "name redefinition");
         if (!memcmp((uint8_t *)dt->shared->u.enumer.value + (i * dt->shared->size), value, dt->shared->size))
             HGOTO_ERROR(H5E_DATATYPE, H5E_CANTINIT, FAIL, "value redefinition");
@@ -378,12 +378,12 @@ H5T__enum_nameof(const H5T_t *dt, const void *value, char *name /*out*/, size_t 
 
     /* Save result name */
     if (!name) {
-        if (NULL == (name = (char *)H5MM_malloc(HDstrlen(copied_dt->shared->u.enumer.name[md]) + 1)))
+        if (NULL == (name = (char *)H5MM_malloc(strlen(copied_dt->shared->u.enumer.name[md]) + 1)))
             HGOTO_ERROR(H5E_RESOURCE, H5E_NOSPACE, NULL, "memory allocation failed");
         alloc_name = true;
     } /* end if */
-    HDstrncpy(name, copied_dt->shared->u.enumer.name[md], size);
-    if (HDstrlen(copied_dt->shared->u.enumer.name[md]) >= size)
+    strncpy(name, copied_dt->shared->u.enumer.name[md], size);
+    if (strlen(copied_dt->shared->u.enumer.name[md]) >= size)
         HGOTO_ERROR(H5E_DATATYPE, H5E_NOSPACE, NULL, "name has been truncated");
 
     /* Set return value */
@@ -484,7 +484,7 @@ H5T__enum_valueof(const H5T_t *dt, const char *name, void *value /*out*/)
 
     while (lt < rt) {
         md  = (lt + rt) / 2;
-        cmp = HDstrcmp(name, copied_dt->shared->u.enumer.name[md]);
+        cmp = strcmp(name, copied_dt->shared->u.enumer.name[md]);
         if (cmp < 0) {
             rt = md;
         }

--- a/src/H5Tfields.c
+++ b/src/H5Tfields.c
@@ -215,12 +215,12 @@ H5Tget_member_index(hid_t type_id, const char *name)
     switch (dt->shared->type) {
         case H5T_COMPOUND:
             for (i = 0; i < dt->shared->u.compnd.nmembs; i++)
-                if (!HDstrcmp(dt->shared->u.compnd.memb[i].name, name))
+                if (!strcmp(dt->shared->u.compnd.memb[i].name, name))
                     HGOTO_DONE((int)i);
             break;
         case H5T_ENUM:
             for (i = 0; i < dt->shared->u.enumer.nmembs; i++)
-                if (!HDstrcmp(dt->shared->u.enumer.name[i], name))
+                if (!strcmp(dt->shared->u.enumer.name[i], name))
                     HGOTO_DONE((int)i);
             break;
 
@@ -379,7 +379,7 @@ H5T__sort_name(const H5T_t *dt, int *map)
             nmembs                      = dt->shared->u.compnd.nmembs;
             for (i = nmembs - 1, swapped = true; i > 0 && swapped; --i) {
                 for (j = 0, swapped = false; j < i; j++) {
-                    if (HDstrcmp(dt->shared->u.compnd.memb[j].name, dt->shared->u.compnd.memb[j + 1].name) >
+                    if (strcmp(dt->shared->u.compnd.memb[j].name, dt->shared->u.compnd.memb[j + 1].name) >
                         0) {
                         H5T_cmemb_t tmp                  = dt->shared->u.compnd.memb[j];
                         dt->shared->u.compnd.memb[j]     = dt->shared->u.compnd.memb[j + 1];
@@ -396,8 +396,7 @@ H5T__sort_name(const H5T_t *dt, int *map)
 #ifndef NDEBUG
             /* I never trust a sort :-) -RPM */
             for (i = 0; i < nmembs - 1; i++) {
-                assert(HDstrcmp(dt->shared->u.compnd.memb[i].name, dt->shared->u.compnd.memb[i + 1].name) <
-                       0);
+                assert(strcmp(dt->shared->u.compnd.memb[i].name, dt->shared->u.compnd.memb[i + 1].name) < 0);
             }
 #endif
         }
@@ -410,7 +409,7 @@ H5T__sort_name(const H5T_t *dt, int *map)
             assert(size <= sizeof(tbuf));
             for (i = nmembs - 1, swapped = true; i > 0 && swapped; --i) {
                 for (j = 0, swapped = false; j < i; j++) {
-                    if (HDstrcmp(dt->shared->u.enumer.name[j], dt->shared->u.enumer.name[j + 1]) > 0) {
+                    if (strcmp(dt->shared->u.enumer.name[j], dt->shared->u.enumer.name[j + 1]) > 0) {
                         /* Swap names */
                         char *tmp                        = dt->shared->u.enumer.name[j];
                         dt->shared->u.enumer.name[j]     = dt->shared->u.enumer.name[j + 1];
@@ -436,7 +435,7 @@ H5T__sort_name(const H5T_t *dt, int *map)
 #ifndef NDEBUG
             /* I never trust a sort :-) -RPM */
             for (i = 0; i < nmembs - 1; i++)
-                assert(HDstrcmp(dt->shared->u.enumer.name[i], dt->shared->u.enumer.name[i + 1]) < 0);
+                assert(strcmp(dt->shared->u.enumer.name[i], dt->shared->u.enumer.name[i + 1]) < 0);
 #endif
         }
     }

--- a/src/H5Topaque.c
+++ b/src/H5Topaque.c
@@ -52,7 +52,7 @@ H5Tset_tag(hid_t type_id, const char *tag)
         HGOTO_ERROR(H5E_ARGS, H5E_BADTYPE, FAIL, "not an opaque data type");
     if (!tag)
         HGOTO_ERROR(H5E_ARGS, H5E_BADVALUE, FAIL, "no tag");
-    if (HDstrlen(tag) >= H5T_OPAQUE_TAG_MAX)
+    if (strlen(tag) >= H5T_OPAQUE_TAG_MAX)
         HGOTO_ERROR(H5E_ARGS, H5E_BADVALUE, FAIL, "tag too long");
 
     /* Commit */

--- a/src/H5Tvlen.c
+++ b/src/H5Tvlen.c
@@ -550,7 +550,7 @@ H5T__vlen_mem_str_getlen(H5VL_object_t H5_ATTR_UNUSED *file, const void *_vl, si
     /* Copy to ensure correct alignment */
     H5MM_memcpy(&s, _vl, sizeof(char *));
 
-    *len = HDstrlen(s);
+    *len = strlen(s);
 
     FUNC_LEAVE_NOAPI(SUCCEED)
 } /* end H5T__vlen_mem_str_getlen() */

--- a/src/H5VL.c
+++ b/src/H5VL.c
@@ -129,7 +129,7 @@ H5VLregister_connector_by_name(const char *name, hid_t vipl_id)
     /* Check arguments */
     if (!name)
         HGOTO_ERROR(H5E_ARGS, H5E_UNINITIALIZED, H5I_INVALID_HID, "null VOL connector name is disallowed");
-    if (0 == HDstrlen(name))
+    if (0 == strlen(name))
         HGOTO_ERROR(H5E_ARGS, H5E_UNINITIALIZED, H5I_INVALID_HID,
                     "zero-length VOL connector name is disallowed");
 

--- a/src/H5VLint.c
+++ b/src/H5VLint.c
@@ -317,7 +317,7 @@ H5VL__get_connector_cb(void *obj, hid_t id, void *_op_data)
     FUNC_ENTER_PACKAGE_NOERR
 
     if (H5VL_GET_CONNECTOR_BY_NAME == op_data->key.kind) {
-        if (0 == HDstrcmp(cls->name, op_data->key.u.name)) {
+        if (0 == strcmp(cls->name, op_data->key.u.name)) {
             op_data->found_id = id;
             ret_value         = H5_ITER_STOP;
         } /* end if */
@@ -399,12 +399,12 @@ H5VL__set_def_conn(void)
         } /* end else-if */
         else {
             /* Check for VOL connectors that ship with the library */
-            if (!HDstrcmp(tok, "native")) {
+            if (!strcmp(tok, "native")) {
                 connector_id = H5VL_NATIVE;
                 if (H5I_inc_ref(connector_id, false) < 0)
                     HGOTO_ERROR(H5E_VOL, H5E_CANTINC, FAIL, "can't increment VOL connector refcount");
             } /* end if */
-            else if (!HDstrcmp(tok, "pass_through")) {
+            else if (!strcmp(tok, "pass_through")) {
                 connector_id = H5VL_PASSTHRU;
                 if (H5I_inc_ref(connector_id, false) < 0)
                     HGOTO_ERROR(H5E_VOL, H5E_CANTINC, FAIL, "can't increment VOL connector refcount");
@@ -1236,7 +1236,7 @@ H5VL__register_connector_by_class(const H5VL_class_t *cls, bool app_ref, hid_t v
     if (!cls->name)
         HGOTO_ERROR(H5E_VOL, H5E_CANTREGISTER, H5I_INVALID_HID,
                     "VOL connector class name cannot be the NULL pointer");
-    if (0 == HDstrlen(cls->name))
+    if (0 == strlen(cls->name))
         HGOTO_ERROR(H5E_VOL, H5E_CANTREGISTER, H5I_INVALID_HID,
                     "VOL connector class name cannot be the empty string");
     if (cls->info_cls.copy && !cls->info_cls.free)
@@ -1689,9 +1689,9 @@ H5VL__get_connector_name(hid_t id, char *name /*out*/, size_t size)
 
     cls = vol_obj->connector->cls;
 
-    len = HDstrlen(cls->name);
+    len = strlen(cls->name);
     if (name) {
-        HDstrncpy(name, cls->name, size);
+        strncpy(name, cls->name, size);
         if (len >= size)
             name[size - 1] = '\0';
     } /* end if */
@@ -1972,7 +1972,7 @@ H5VL_cmp_connector_cls(int *cmp_value, const H5VL_class_t *cls1, const H5VL_clas
         *cmp_value = 1;
         HGOTO_DONE(SUCCEED);
     } /* end if */
-    if (0 != (*cmp_value = HDstrcmp(cls1->name, cls2->name)))
+    if (0 != (*cmp_value = strcmp(cls1->name, cls2->name)))
         HGOTO_DONE(SUCCEED);
 
     /* Compare connector VOL API versions */
@@ -2457,7 +2457,7 @@ H5VL_check_plugin_load(const H5VL_class_t *cls, const H5PL_key_t *key, bool *suc
     /* Which kind of key are we looking for? */
     if (key->vol.kind == H5VL_GET_CONNECTOR_BY_NAME) {
         /* Check if plugin name matches VOL connector class name */
-        if (cls->name && !HDstrcmp(cls->name, key->vol.u.name))
+        if (cls->name && !strcmp(cls->name, key->vol.u.name))
             *success = true;
     } /* end if */
     else {

--- a/src/H5VLnative_attr.c
+++ b/src/H5VLnative_attr.c
@@ -314,12 +314,12 @@ H5VL__native_attr_get(void *obj, H5VL_attr_get_args_t *args, hid_t H5_ATTR_UNUSE
                     HGOTO_ERROR(H5E_ATTR, H5E_CANTOPENOBJ, FAIL, "can't open attribute");
 
                 /* Get the length of the name */
-                *get_name_args->attr_name_len = HDstrlen(attr->shared->name);
+                *get_name_args->attr_name_len = strlen(attr->shared->name);
 
                 /* Copy the name into the user's buffer, if given */
                 if (get_name_args->buf) {
-                    HDstrncpy(get_name_args->buf, attr->shared->name,
-                              MIN((*get_name_args->attr_name_len + 1), get_name_args->buf_size));
+                    strncpy(get_name_args->buf, attr->shared->name,
+                            MIN((*get_name_args->attr_name_len + 1), get_name_args->buf_size));
                     if (*get_name_args->attr_name_len >= get_name_args->buf_size)
                         get_name_args->buf[get_name_args->buf_size - 1] = '\0';
                 } /* end if */

--- a/src/H5VLnative_file.c
+++ b/src/H5VLnative_file.c
@@ -231,12 +231,12 @@ H5VL__native_file_get(void *obj, H5VL_file_get_args_t *args, hid_t H5_ATTR_UNUSE
                 HGOTO_ERROR(H5E_ARGS, H5E_BADTYPE, FAIL, "not a file or file object");
 
             /* Get length of file name */
-            *file_args->file_name_len = HDstrlen(H5F_OPEN_NAME(f));
+            *file_args->file_name_len = strlen(H5F_OPEN_NAME(f));
 
             /* Populate buffer with name, if given */
             if (file_args->buf) {
-                HDstrncpy(file_args->buf, H5F_OPEN_NAME(f),
-                          MIN(*file_args->file_name_len + 1, file_args->buf_size));
+                strncpy(file_args->buf, H5F_OPEN_NAME(f),
+                        MIN(*file_args->file_name_len + 1, file_args->buf_size));
                 if (*file_args->file_name_len >= file_args->buf_size)
                     file_args->buf[file_args->buf_size - 1] = '\0';
             } /* end if */

--- a/src/H5VLnative_token.c
+++ b/src/H5VLnative_token.c
@@ -112,7 +112,7 @@ H5VL__native_token_to_str(void *obj, H5I_type_t obj_type, const H5O_token_t *tok
     if (NULL == (*token_str = H5MM_malloc(addr_ndigits + 1)))
         HGOTO_ERROR(H5E_RESOURCE, H5E_CANTALLOC, FAIL, "can't allocate buffer for token string");
 
-    HDsnprintf(*token_str, addr_ndigits + 1, "%" PRIuHADDR, addr);
+    snprintf(*token_str, addr_ndigits + 1, "%" PRIuHADDR, addr);
 
 done:
     FUNC_LEAVE_NOAPI(ret_value)
@@ -139,7 +139,7 @@ H5VL__native_str_to_token(void *obj, H5I_type_t obj_type, const char *token_str,
     /* Check parameters */
     assert(token_str);
 
-    HDsscanf(token_str, "%" PRIuHADDR, &addr);
+    sscanf(token_str, "%" PRIuHADDR, &addr);
 
     if (H5VL_native_addr_to_token(obj, obj_type, addr, token) < 0)
         HGOTO_ERROR(H5E_FILE, H5E_CANTDECODE, FAIL, "can't convert address to object token");

--- a/src/H5Z.c
+++ b/src/H5Z.c
@@ -162,7 +162,7 @@ H5Z_term_package(void)
                 } /* end if */
 
                 /* Truncate the comment to fit in the field */
-                HDstrncpy(comment, H5Z_table_g[i].name, sizeof comment);
+                strncpy(comment, H5Z_table_g[i].name, sizeof comment);
                 comment[sizeof(comment) - 1] = '\0';
 
                 /*
@@ -1612,7 +1612,7 @@ H5Z_delete(H5O_pline_t *pline, H5Z_filter_t filter)
 
         /* Free information for deleted filter */
         if (pline->filter[idx].name && pline->filter[idx].name != pline->filter[idx]._name)
-            assert((HDstrlen(pline->filter[idx].name) + 1) > H5Z_COMMON_NAME_LEN);
+            assert((strlen(pline->filter[idx].name) + 1) > H5Z_COMMON_NAME_LEN);
         if (pline->filter[idx].name != pline->filter[idx]._name)
             pline->filter[idx].name = (char *)H5MM_xfree(pline->filter[idx].name);
         if (pline->filter[idx].cd_values && pline->filter[idx].cd_values != pline->filter[idx]._cd_values)
@@ -1625,7 +1625,7 @@ H5Z_delete(H5O_pline_t *pline, H5Z_filter_t filter)
             /* Copy filters down & fix up any client data value arrays using internal storage */
             for (; (idx + 1) < pline->nused; idx++) {
                 pline->filter[idx] = pline->filter[idx + 1];
-                if (pline->filter[idx].name && (HDstrlen(pline->filter[idx].name) + 1) <= H5Z_COMMON_NAME_LEN)
+                if (pline->filter[idx].name && (strlen(pline->filter[idx].name) + 1) <= H5Z_COMMON_NAME_LEN)
                     pline->filter[idx].name = pline->filter[idx]._name;
                 if (pline->filter[idx].cd_nelmts <= H5Z_COMMON_CD_VALUES)
                     pline->filter[idx].cd_values = pline->filter[idx]._cd_values;

--- a/src/H5Ztrans.c
+++ b/src/H5Ztrans.c
@@ -759,7 +759,7 @@ H5Z__parse_factor(H5Z_token *current, H5Z_datval_ptrs *dat_val_pointers)
 
             if (!factor)
                 HGOTO_ERROR(H5E_RESOURCE, H5E_NOSPACE, NULL, "Unable to allocate new node");
-            HDsscanf(current->tok_begin, "%ld", &factor->value.int_val);
+            sscanf(current->tok_begin, "%ld", &factor->value.int_val);
             break;
 
         case H5Z_XFORM_FLOAT:
@@ -767,7 +767,7 @@ H5Z__parse_factor(H5Z_token *current, H5Z_datval_ptrs *dat_val_pointers)
 
             if (!factor)
                 HGOTO_ERROR(H5E_RESOURCE, H5E_NOSPACE, NULL, "Unable to allocate new node");
-            HDsscanf(current->tok_begin, "%lf", &factor->value.float_val);
+            sscanf(current->tok_begin, "%lf", &factor->value.float_val);
             break;
 
         case H5Z_XFORM_SYMBOL:
@@ -1420,9 +1420,9 @@ H5Z_xform_create(const char *expr)
     /* Find the number of times "x" is used in this equation, and allocate room for storing that many points
      * A more sophisticated check is needed to support scientific notation.
      */
-    for (i = 0; i < HDstrlen(expr); i++) {
+    for (i = 0; i < strlen(expr); i++) {
         if (isalpha(expr[i])) {
-            if ((i > 0) && (i < (HDstrlen(expr) - 1))) {
+            if ((i > 0) && (i < (strlen(expr) - 1))) {
                 if (((expr[i] == 'E') || (expr[i] == 'e')) &&
                     (isdigit(expr[i - 1]) || (expr[i - 1] == '.')) &&
                     (isdigit(expr[i + 1]) || (expr[i + 1] == '-') || (expr[i + 1] == '+')))
@@ -1558,7 +1558,7 @@ H5Z_xform_copy(H5Z_data_xform_t **data_xform_prop)
 
         /* Find the number of times "x" is used in this equation, and allocate room for storing that many
          * points */
-        for (i = 0; i < HDstrlen(new_data_xform_prop->xform_exp); i++)
+        for (i = 0; i < strlen(new_data_xform_prop->xform_exp); i++)
             if (isalpha(new_data_xform_prop->xform_exp[i]))
                 count++;
 
@@ -1625,7 +1625,7 @@ H5Z_xform_noop(const H5Z_data_xform_t *data_xform_prop)
         ret_value = false;
 
         /* Check for trivial data transformation: expression = "x" */
-        if ((HDstrlen(data_xform_prop->xform_exp) == 1) && data_xform_prop->dat_val_pointers &&
+        if ((strlen(data_xform_prop->xform_exp) == 1) && data_xform_prop->dat_val_pointers &&
             (data_xform_prop->dat_val_pointers->num_ptrs == 1)) {
             ret_value = true;
         } /* end if */

--- a/src/H5dbg.c
+++ b/src/H5dbg.c
@@ -102,30 +102,30 @@ H5_buffer_dump(FILE *stream, int indent, const uint8_t *buf, const uint8_t *mark
                 fprintf(stream, "   ");
 
             if (7 == v)
-                HDfputc(' ', stream);
+                fputc(' ', stream);
         } /* end for */
-        HDfputc(' ', stream);
+        fputc(' ', stream);
 
         /* Print the character values */
         for (v = 0; v < 16; v++) {
             if (u + v < buf_size) {
                 if (marker[u + v])
-                    HDfputc(' ', stream);
+                    fputc(' ', stream);
                 else {
                     c = buf[buf_offset + u + v];
 
                     if (isprint(c))
-                        HDfputc(c, stream);
+                        fputc(c, stream);
                     else
-                        HDfputc('.', stream);
+                        fputc('.', stream);
                 } /* end else */
             }     /* end if */
 
             if (7 == v)
-                HDfputc(' ', stream);
+                fputc(' ', stream);
         } /* end for */
 
-        HDfputc('\n', stream);
+        fputc('\n', stream);
     } /* end for */
 
     FUNC_LEAVE_NOAPI(SUCCEED)

--- a/src/H5mpi.c
+++ b/src/H5mpi.c
@@ -812,7 +812,7 @@ H5_mpio_get_file_sync_required(MPI_File fh, bool *file_sync_required)
         MPI_Info_get(info_used, "romio_visibility_immediate", MPI_MAX_INFO_VAL - 1, value, &flag))
         HGOTO_ERROR(H5E_LIB, H5E_CANTGET, FAIL, "can't get MPI info");
 
-    if (flag && !HDstrcmp(value, "false"))
+    if (flag && !strcmp(value, "false"))
         *file_sync_required = true;
 
     if (MPI_SUCCESS != MPI_Info_free(&info_used))
@@ -820,9 +820,9 @@ H5_mpio_get_file_sync_required(MPI_File fh, bool *file_sync_required)
 
     /* Force setting the flag via env variable (temp solution before the flag is implemented in MPI) */
     sync_env_var = HDgetenv("HDF5_DO_MPI_FILE_SYNC");
-    if (sync_env_var && (!HDstrcmp(sync_env_var, "TRUE") || !HDstrcmp(sync_env_var, "1")))
+    if (sync_env_var && (!strcmp(sync_env_var, "TRUE") || !strcmp(sync_env_var, "1")))
         *file_sync_required = true;
-    if (sync_env_var && (!HDstrcmp(sync_env_var, "FALSE") || !HDstrcmp(sync_env_var, "0")))
+    if (sync_env_var && (!strcmp(sync_env_var, "FALSE") || !strcmp(sync_env_var, "0")))
         *file_sync_required = false;
 
 done:

--- a/src/H5private.h
+++ b/src/H5private.h
@@ -641,12 +641,6 @@ typedef off_t       h5_stat_size_t;
 #ifndef HDfdopen
 #define HDfdopen(N, S) fdopen(N, S)
 #endif
-#ifndef HDfgetc
-#define HDfgetc(F) fgetc(F)
-#endif
-#ifndef HDfgets
-#define HDfgets(S, N, F) fgets(S, N, F)
-#endif
 #ifndef HDfileno
 #define HDfileno(F) fileno(F)
 #endif
@@ -676,15 +670,6 @@ H5_DLL H5_ATTR_CONST int Nflock(int fd, int operation);
 
 #endif /* HDflock */
 
-#ifndef HDfputc
-#define HDfputc(C, F) fputc(C, F)
-#endif
-#ifndef HDfputs
-#define HDfputs(S, F) fputs(S, F)
-#endif
-#ifndef HDfscanf
-#define HDfscanf fscanf
-#endif
 #ifndef HDfseek
 #define HDfseek(F, O, W) fseeko(F, O, W)
 #endif
@@ -696,9 +681,6 @@ H5_DLL H5_ATTR_CONST int Nflock(int fd, int operation);
 #endif
 #ifndef HDftruncate
 #define HDftruncate(F, L) ftruncate(F, L)
-#endif
-#ifndef HDgetc
-#define HDgetc(F) getc(F)
 #endif
 #ifndef HDgetcwd
 #define HDgetcwd(S, Z) getcwd(S, Z)
@@ -718,12 +700,6 @@ H5_DLL H5_ATTR_CONST int Nflock(int fd, int operation);
 #ifndef HDgetpid
 #define HDgetpid() getpid()
 #endif
-
-/* Don't define HDgets - gets() was deprecated in C99 and removed in C11 */
-#ifdef HDgets
-#undef HDgets
-#endif
-
 #ifndef HDgettimeofday
 #define HDgettimeofday(S, P) gettimeofday(S, P)
 #endif
@@ -757,20 +733,8 @@ H5_DLL H5_ATTR_CONST int Nflock(int fd, int operation);
 #ifndef HDopendir
 #define HDopendir(S) opendir(S)
 #endif
-#ifndef HDperror
-#define HDperror(S) perror(S)
-#endif
 #ifndef HDpread
 #define HDpread(F, B, C, O) pread(F, B, C, O)
-#endif
-#ifndef HDputc
-#define HDputc(C, F) putc(C, F)
-#endif
-#ifndef HDputchar
-#define HDputchar(C) putchar(C)
-#endif
-#ifndef HDputs
-#define HDputs(S) puts(S)
 #endif
 #ifndef HDpwrite
 #define HDpwrite(F, B, C, O) pwrite(F, B, C, O)
@@ -836,9 +800,6 @@ H5_DLL H5_ATTR_CONST int Nflock(int fd, int operation);
 #ifndef HDrmdir
 #define HDrmdir(S) rmdir(S)
 #endif
-#ifndef HDscanf
-#define HDscanf scanf /*varargs*/
-#endif
 #ifndef HDsetbuf
 #define HDsetbuf(F, S) setbuf(F, S)
 #endif
@@ -863,20 +824,8 @@ H5_DLL H5_ATTR_CONST int Nflock(int fd, int operation);
 #ifndef HDsleep
 #define HDsleep(N) sleep(N)
 #endif
-#ifndef HDsnprintf
-#define HDsnprintf snprintf /*varargs*/
-#endif
-#ifndef HDsprintf
-#define HDsprintf sprintf /*varargs*/
-#endif
-#ifndef HDsscanf
-#define HDsscanf sscanf /*varargs*/
-#endif
 #ifndef HDstat
 #define HDstat(S, B) stat(S, B)
-#endif
-#ifndef HDstrcat
-#define HDstrcat(X, Y) strcat(X, Y)
 #endif
 #ifndef HDstrcasestr
 #if defined(H5_HAVE_STRCASESTR)
@@ -885,56 +834,11 @@ H5_DLL H5_ATTR_CONST int Nflock(int fd, int operation);
 #define HDstrcasestr(X, Y) H5_strcasestr(X, Y)
 #endif
 #endif
-#ifndef HDstrchr
-#define HDstrchr(S, C) strchr(S, C)
-#endif
-#ifndef HDstrcmp
-#define HDstrcmp(X, Y) strcmp(X, Y)
-#endif
 #ifndef HDstrcasecmp
 #define HDstrcasecmp(X, Y) strcasecmp(X, Y)
 #endif
-#ifndef HDstrcpy
-#define HDstrcpy(X, Y) strcpy(X, Y)
-#endif
-#ifndef HDstrcspn
-#define HDstrcspn(X, Y) strcspn(X, Y)
-#endif
-#ifndef HDstrdup
-#define HDstrdup(S) strdup(S)
-#endif
-#ifndef HDstrerror
-#define HDstrerror(N) strerror(N)
-#endif
-#ifndef HDstrftime
-#define HDstrftime(S, Z, F, T) strftime(S, Z, F, T)
-#endif
-#ifndef HDstrlen
-#define HDstrlen(S) strlen(S)
-#endif
-#ifndef HDstrnlen
-#define HDstrnlen(S, L) strnlen(S, L)
-#endif
-#ifndef HDstrncat
-#define HDstrncat(X, Y, Z) strncat(X, Y, Z)
-#endif
-#ifndef HDstrncmp
-#define HDstrncmp(X, Y, Z) strncmp(X, Y, Z)
-#endif
-#ifndef HDstrncpy
-#define HDstrncpy(X, Y, Z) strncpy(X, Y, Z)
-#endif
 #ifndef HDstrndup
 #define HDstrndup(S, N) strndup(S, N)
-#endif
-#ifndef HDstrrchr
-#define HDstrrchr(S, C) strrchr(S, C)
-#endif
-#ifndef HDstrstr
-#define HDstrstr(X, Y) strstr(X, Y)
-#endif
-#ifndef HDstrtok
-#define HDstrtok(X, Y) strtok(X, Y)
 #endif
 #ifndef HDstrtok_r
 #define HDstrtok_r(X, Y, Z) strtok_r(X, Y, Z)
@@ -969,18 +873,6 @@ H5_DLL int HDvasprintf(char **bufp, const char *fmt, va_list _ap);
 #endif
 #endif
 
-#ifndef HDvfprintf
-#define HDvfprintf(F, FMT, A) vfprintf(F, FMT, A)
-#endif
-#ifndef HDvprintf
-#define HDvprintf(FMT, A) vprintf(FMT, A)
-#endif
-#ifndef HDvsprintf
-#define HDvsprintf(S, FMT, A) vsprintf(S, FMT, A)
-#endif
-#ifndef HDvsnprintf
-#define HDvsnprintf(S, N, FMT, A) vsnprintf(S, N, FMT, A)
-#endif
 #ifndef HDwrite
 #define HDwrite(F, M, Z) write(F, M, Z)
 #endif
@@ -1095,8 +987,8 @@ H5_DLL int HDvasprintf(char **bufp, const char *fmt, va_list _ap);
     {                                                                                                        \
         char *slash, *backslash;                                                                             \
                                                                                                              \
-        slash     = HDstrrchr(NAME, H5_DIR_SLASH_SEPC);                                                      \
-        backslash = HDstrrchr(NAME, H5_DIR_SEPC);                                                            \
+        slash     = strrchr(NAME, H5_DIR_SLASH_SEPC);                                                        \
+        backslash = strrchr(NAME, H5_DIR_SEPC);                                                              \
         if (backslash > slash)                                                                               \
             (ptr = backslash);                                                                               \
         else                                                                                                 \
@@ -1111,7 +1003,7 @@ H5_DLL int HDvasprintf(char **bufp, const char *fmt, va_list _ap);
 #define H5_CHECK_ABSOLUTE(NAME)          (H5_CHECK_DELIMITER(*NAME))
 #define H5_CHECK_ABS_DRIVE(NAME)         (0)
 #define H5_CHECK_ABS_PATH(NAME)          (0)
-#define H5_GET_LAST_DELIMITER(NAME, ptr) ptr = HDstrrchr(NAME, H5_DIR_SEPC);
+#define H5_GET_LAST_DELIMITER(NAME, ptr) ptr = strrchr(NAME, H5_DIR_SEPC);
 
 #endif /* H5_HAVE_WINDOW_PATH */
 

--- a/src/H5system.c
+++ b/src/H5system.c
@@ -78,7 +78,7 @@ HDvasprintf(char **bufp, const char *fmt, va_list _ap)
         va_list ap;
 
         va_copy(ap, _ap);
-        ret = HDvsnprintf(buf, bufsz, fmt, ap);
+        ret = vsnprintf(buf, bufsz, fmt, ap);
         va_end(ap);
         if (ret >= 0 && (size_t)ret < bufsz) {
             *bufp = buf;
@@ -642,7 +642,7 @@ H5_build_extpath(const char *name, char **extpath /*out*/)
 
         if (NULL == (cwdpath = (char *)H5MM_malloc(MAX_PATH_LEN)))
             HGOTO_ERROR(H5E_INTERNAL, H5E_NOSPACE, FAIL, "memory allocation failed");
-        name_len = HDstrlen(name) + 1;
+        name_len = strlen(name) + 1;
         if (NULL == (new_name = (char *)H5MM_malloc(name_len)))
             HGOTO_ERROR(H5E_INTERNAL, H5E_NOSPACE, FAIL, "memory allocation failed");
 
@@ -654,7 +654,7 @@ H5_build_extpath(const char *name, char **extpath /*out*/)
         if (H5_CHECK_ABS_DRIVE(name)) {
             drive  = HDtoupper(name[0]) - 'A' + 1;
             retcwd = HDgetdcwd(drive, cwdpath, MAX_PATH_LEN);
-            HDstrncpy(new_name, &name[2], name_len);
+            strncpy(new_name, &name[2], name_len);
         } /* end if */
           /*
            * Windows: name[0] is a '/' or '\'
@@ -662,14 +662,14 @@ H5_build_extpath(const char *name, char **extpath /*out*/)
            * Unix: does not apply
            */
         else if (H5_CHECK_ABS_PATH(name) && (0 != (drive = HDgetdrive()))) {
-            HDsnprintf(cwdpath, MAX_PATH_LEN, "%c:%c", (drive + 'A' - 1), name[0]);
+            snprintf(cwdpath, MAX_PATH_LEN, "%c:%c", (drive + 'A' - 1), name[0]);
             retcwd = cwdpath;
-            HDstrncpy(new_name, &name[1], name_len);
+            strncpy(new_name, &name[1], name_len);
         }
         /* totally relative for Unix and Windows: get current working directory  */
         else {
             retcwd = HDgetcwd(cwdpath, MAX_PATH_LEN);
-            HDstrncpy(new_name, name, name_len);
+            strncpy(new_name, name, name_len);
         } /* end if */
 
         if (retcwd != NULL) {
@@ -677,17 +677,17 @@ H5_build_extpath(const char *name, char **extpath /*out*/)
             size_t path_len;
 
             assert(cwdpath);
-            cwdlen = HDstrlen(cwdpath);
+            cwdlen = strlen(cwdpath);
             assert(cwdlen);
             assert(new_name);
-            path_len = cwdlen + HDstrlen(new_name) + 2;
+            path_len = cwdlen + strlen(new_name) + 2;
             if (NULL == (full_path = (char *)H5MM_malloc(path_len)))
                 HGOTO_ERROR(H5E_INTERNAL, H5E_NOSPACE, FAIL, "memory allocation failed");
 
-            HDstrncpy(full_path, cwdpath, cwdlen + 1);
+            strncpy(full_path, cwdpath, cwdlen + 1);
             if (!H5_CHECK_DELIMITER(cwdpath[cwdlen - 1]))
-                HDstrncat(full_path, H5_DIR_SEPS, path_len - (cwdlen + 1));
-            HDstrncat(full_path, new_name, path_len - (cwdlen + 1) - HDstrlen(H5_DIR_SEPS));
+                strncat(full_path, H5_DIR_SEPS, path_len - (cwdlen + 1));
+            strncat(full_path, new_name, path_len - (cwdlen + 1) - strlen(H5_DIR_SEPS));
         } /* end if */
     }     /* end else */
 
@@ -734,8 +734,8 @@ H5_combine_path(const char *path1, const char *path2, char **full_name /*out*/)
     assert(path2);
 
     if (path1)
-        path1_len = HDstrlen(path1);
-    path2_len = HDstrlen(path2);
+        path1_len = strlen(path1);
+    path2_len = strlen(path2);
 
     if (path1 == NULL || *path1 == '\0' || H5_CHECK_ABSOLUTE(path2)) {
 
@@ -753,7 +753,7 @@ H5_combine_path(const char *path1, const char *path2, char **full_name /*out*/)
              */
             if (NULL == (*full_name = (char *)H5MM_malloc(path2_len + 3)))
                 HGOTO_ERROR(H5E_RESOURCE, H5E_NOSPACE, FAIL, "unable to allocate path2 buffer");
-            HDsnprintf(*full_name, (path2_len + 3), "%c:%s", path1[0], path2);
+            snprintf(*full_name, (path2_len + 3), "%c:%s", path1[0], path2);
         } /* end if */
         else {
             /* On windows path2 is path absolute name ("\foo\bar"),
@@ -777,9 +777,9 @@ H5_combine_path(const char *path1, const char *path2, char **full_name /*out*/)
             HGOTO_ERROR(H5E_RESOURCE, H5E_NOSPACE, FAIL, "unable to allocate filename buffer");
 
         /* Compose the full file name */
-        HDsnprintf(*full_name, (path1_len + path2_len + 2 + 2), "%s%s%s",
-                   path1, /* Extra "+2" to quiet GCC warning - 2019/07/05, QAK */
-                   (H5_CHECK_DELIMITER(path1[path1_len - 1]) ? "" : H5_DIR_SEPS), path2);
+        snprintf(*full_name, (path1_len + path2_len + 2 + 2), "%s%s%s",
+                 path1, /* Extra "+2" to quiet GCC warning - 2019/07/05, QAK */
+                 (H5_CHECK_DELIMITER(path1[path1_len - 1]) ? "" : H5_DIR_SEPS), path2);
     } /* end else */
 
 done:
@@ -1000,7 +1000,7 @@ H5_dirname(const char *path, char **dirname)
     if (!dirname)
         HGOTO_ERROR(H5E_ARGS, H5E_BADVALUE, FAIL, "dirname can't be NULL");
 
-    if (NULL == (sep = HDstrrchr(path, H5_DIR_SEPC))) {
+    if (NULL == (sep = strrchr(path, H5_DIR_SEPC))) {
         /* Pathname with no file separator characters */
         out = H5MM_strdup(".");
     }
@@ -1109,7 +1109,7 @@ H5_basename(const char *path, char **basename)
     if (!basename)
         HGOTO_ERROR(H5E_ARGS, H5E_BADVALUE, FAIL, "basename can't be NULL");
 
-    if (NULL == (sep = HDstrrchr(path, H5_DIR_SEPC))) {
+    if (NULL == (sep = strrchr(path, H5_DIR_SEPC))) {
         if (*path == '\0')
             /* Empty pathname */
             out = H5MM_strdup(".");
@@ -1206,7 +1206,7 @@ H5_get_option(int argc, const char *const *argv, const char *opts, const struct 
         if (H5_optind >= argc || argv[H5_optind][0] != '-' || argv[H5_optind][1] == '\0') {
             return EOF;
         }
-        else if (HDstrcmp(argv[H5_optind], "--") == 0) {
+        else if (strcmp(argv[H5_optind], "--") == 0) {
             H5_optind++;
             return EOF;
         }
@@ -1216,19 +1216,19 @@ H5_get_option(int argc, const char *const *argv, const char *opts, const struct 
         /* long command line option */
         int        i;
         const char ch      = '=';
-        char      *arg     = HDstrdup(&argv[H5_optind][2]);
+        char      *arg     = strdup(&argv[H5_optind][2]);
         size_t     arg_len = 0;
 
         H5_optarg = strchr(&argv[H5_optind][2], ch);
-        arg_len   = HDstrlen(&argv[H5_optind][2]);
+        arg_len   = strlen(&argv[H5_optind][2]);
         if (H5_optarg) {
-            arg_len -= HDstrlen(H5_optarg);
+            arg_len -= strlen(H5_optarg);
             H5_optarg++; /* skip the equal sign */
         }
         arg[arg_len] = 0;
 
         for (i = 0; l_opts && l_opts[i].name; i++) {
-            if (HDstrcmp(arg, l_opts[i].name) == 0) {
+            if (strcmp(arg, l_opts[i].name) == 0) {
                 /* we've found a matching long command line flag */
                 optchar = l_opts[i].shortval;
 
@@ -1278,7 +1278,7 @@ H5_get_option(int argc, const char *const *argv, const char *opts, const struct 
         /* short command line option */
         optchar = argv[H5_optind][sp];
 
-        if (optchar == ':' || (cp = HDstrchr(opts, optchar)) == 0) {
+        if (optchar == ':' || (cp = strchr(opts, optchar)) == 0) {
             if (H5_opterr)
                 fprintf(stderr, "%s: unknown option \"%c\"\n", argv[0], optchar);
 

--- a/src/H5timer.c
+++ b/src/H5timer.c
@@ -95,41 +95,41 @@ H5_bandwidth(char *buf /*out*/, size_t bufsize, double nbytes, double nseconds)
     double bw;
 
     if (nseconds <= 0.0)
-        HDstrcpy(buf, "       NaN");
+        strcpy(buf, "       NaN");
     else {
         bw = nbytes / nseconds;
         if (H5_DBL_ABS_EQUAL(bw, 0.0))
-            HDstrcpy(buf, "0.000  B/s");
+            strcpy(buf, "0.000  B/s");
         else if (bw < 1.0)
-            HDsnprintf(buf, bufsize, "%10.4e", bw);
+            snprintf(buf, bufsize, "%10.4e", bw);
         else if (bw < (double)H5_KB) {
-            HDsnprintf(buf, bufsize, "%05.4f", bw);
-            HDstrcpy(buf + 5, "  B/s");
+            snprintf(buf, bufsize, "%05.4f", bw);
+            strcpy(buf + 5, "  B/s");
         }
         else if (bw < (double)H5_MB) {
-            HDsnprintf(buf, bufsize, "%05.4f", bw / (double)H5_KB);
-            HDstrcpy(buf + 5, " kB/s");
+            snprintf(buf, bufsize, "%05.4f", bw / (double)H5_KB);
+            strcpy(buf + 5, " kB/s");
         }
         else if (bw < (double)H5_GB) {
-            HDsnprintf(buf, bufsize, "%05.4f", bw / (double)H5_MB);
-            HDstrcpy(buf + 5, " MB/s");
+            snprintf(buf, bufsize, "%05.4f", bw / (double)H5_MB);
+            strcpy(buf + 5, " MB/s");
         }
         else if (bw < (double)H5_TB) {
-            HDsnprintf(buf, bufsize, "%05.4f", bw / (double)H5_GB);
-            HDstrcpy(buf + 5, " GB/s");
+            snprintf(buf, bufsize, "%05.4f", bw / (double)H5_GB);
+            strcpy(buf + 5, " GB/s");
         }
         else if (bw < (double)H5_PB) {
-            HDsnprintf(buf, bufsize, "%05.4f", bw / (double)H5_TB);
-            HDstrcpy(buf + 5, " TB/s");
+            snprintf(buf, bufsize, "%05.4f", bw / (double)H5_TB);
+            strcpy(buf + 5, " TB/s");
         }
         else if (bw < (double)H5_EB) {
-            HDsnprintf(buf, bufsize, "%05.4f", bw / (double)H5_PB);
-            HDstrcpy(buf + 5, " PB/s");
+            snprintf(buf, bufsize, "%05.4f", bw / (double)H5_PB);
+            strcpy(buf + 5, " PB/s");
         }
         else {
-            HDsnprintf(buf, bufsize, "%10.4e", bw);
-            if (HDstrlen(buf) > 10)
-                HDsnprintf(buf, bufsize, "%10.3e", bw);
+            snprintf(buf, bufsize, "%10.4e", bw);
+            if (strlen(buf) > 10)
+                snprintf(buf, bufsize, "%10.3e", bw);
         } /* end else-if */
     }     /* end else */
 } /* end H5_bandwidth() */
@@ -592,31 +592,30 @@ H5_timer_get_time_string(double seconds)
      * (name? round_up_size? ?)
      */
     if (seconds < 0.0)
-        HDsnprintf(s, H5TIMER_TIME_STRING_LEN, "N/A");
+        snprintf(s, H5TIMER_TIME_STRING_LEN, "N/A");
     else if (H5_DBL_ABS_EQUAL(0.0, seconds))
-        HDsnprintf(s, H5TIMER_TIME_STRING_LEN, "0.0 s");
+        snprintf(s, H5TIMER_TIME_STRING_LEN, "0.0 s");
     else if (seconds < 1.0E-6)
         /* t < 1 us, Print time in ns */
-        HDsnprintf(s, H5TIMER_TIME_STRING_LEN, "%.f ns", seconds * 1.0E9);
+        snprintf(s, H5TIMER_TIME_STRING_LEN, "%.f ns", seconds * 1.0E9);
     else if (seconds < 1.0E-3)
         /* t < 1 ms, Print time in us */
-        HDsnprintf(s, H5TIMER_TIME_STRING_LEN, "%.1f us", seconds * 1.0E6);
+        snprintf(s, H5TIMER_TIME_STRING_LEN, "%.1f us", seconds * 1.0E6);
     else if (seconds < 1.0)
         /* t < 1 s, Print time in ms */
-        HDsnprintf(s, H5TIMER_TIME_STRING_LEN, "%.1f ms", seconds * 1.0E3);
+        snprintf(s, H5TIMER_TIME_STRING_LEN, "%.1f ms", seconds * 1.0E3);
     else if (seconds < H5_SEC_PER_MIN)
         /* t < 1 m, Print time in s */
-        HDsnprintf(s, H5TIMER_TIME_STRING_LEN, "%.2f s", seconds);
+        snprintf(s, H5TIMER_TIME_STRING_LEN, "%.2f s", seconds);
     else if (seconds < H5_SEC_PER_HOUR)
         /* t < 1 h, Print time in m and s */
-        HDsnprintf(s, H5TIMER_TIME_STRING_LEN, "%.f m %.f s", minutes, remainder_sec);
+        snprintf(s, H5TIMER_TIME_STRING_LEN, "%.f m %.f s", minutes, remainder_sec);
     else if (seconds < H5_SEC_PER_DAY)
         /* t < 1 d, Print time in h, m and s */
-        HDsnprintf(s, H5TIMER_TIME_STRING_LEN, "%.f h %.f m %.f s", hours, minutes, remainder_sec);
+        snprintf(s, H5TIMER_TIME_STRING_LEN, "%.f h %.f m %.f s", hours, minutes, remainder_sec);
     else
         /* Print time in d, h, m and s */
-        HDsnprintf(s, H5TIMER_TIME_STRING_LEN, "%.f d %.f h %.f m %.f s", days, hours, minutes,
-                   remainder_sec);
+        snprintf(s, H5TIMER_TIME_STRING_LEN, "%.f d %.f h %.f m %.f s", days, hours, minutes, remainder_sec);
 
     return s;
 } /* end H5_timer_get_time_string() */

--- a/src/H5trace.c
+++ b/src/H5trace.c
@@ -250,7 +250,7 @@ H5_trace_args(H5RS_str_t *rs, const char *type, va_list ap)
                 type = rest + 1;
             }
             else {
-                rest = (char *)HDstrchr(type, ']');
+                rest = (char *)strchr(type, ']');
                 assert(rest);
                 type      = rest + 1;
                 asize_idx = -1;
@@ -4025,8 +4025,8 @@ H5_trace(const double *returning, const char *func, const char *type, ...)
 
                 H5_timer_get_times(function_timer, &function_times);
                 H5_timer_get_times(running_timer, &running_times);
-                HDsnprintf(tmp, sizeof(tmp), "%.6f", (function_times.elapsed - running_times.elapsed));
-                H5RS_asprintf_cat(rs, " %*s ", (int)HDstrlen(tmp), "");
+                snprintf(tmp, sizeof(tmp), "%.6f", (function_times.elapsed - running_times.elapsed));
+                H5RS_asprintf_cat(rs, " %*s ", (int)strlen(tmp), "");
             }
             for (i = 0; i < current_depth; i++)
                 H5RS_aputc(rs, '+');
@@ -4069,7 +4069,7 @@ H5_trace(const double *returning, const char *func, const char *type, ...)
         last_call_depth = current_depth++;
         H5RS_acat(rs, ")");
     }
-    HDfputs(H5RS_get_str(rs), out);
+    fputs(H5RS_get_str(rs), out);
     fflush(out);
     H5RS_decr(rs);
 

--- a/test/API/H5_api_async_test.c
+++ b/test/API/H5_api_async_test.c
@@ -2676,7 +2676,7 @@ cleanup_files(void)
 
     H5Fdelete(ASYNC_API_TEST_FILE, H5P_DEFAULT);
     for (i = 0; i <= max_printf_file; i++) {
-        HDsnprintf(file_name, 64, ASYNC_API_TEST_FILE_PRINTF, i);
+        snprintf(file_name, 64, ASYNC_API_TEST_FILE_PRINTF, i);
         H5Fdelete(file_name, H5P_DEFAULT);
     } /* end for */
 }

--- a/test/API/H5_api_attribute_test.c
+++ b/test/API/H5_api_attribute_test.c
@@ -4082,8 +4082,8 @@ test_get_attribute_name(void)
                 PART_ERROR(H5Aget_name);
             }
 
-            if (HDstrncmp(name_buf, ATTRIBUTE_GET_NAME_TEST_ATTRIBUTE_NAME,
-                          strlen(ATTRIBUTE_GET_NAME_TEST_ATTRIBUTE_NAME) + 1)) {
+            if (strncmp(name_buf, ATTRIBUTE_GET_NAME_TEST_ATTRIBUTE_NAME,
+                        strlen(ATTRIBUTE_GET_NAME_TEST_ATTRIBUTE_NAME) + 1)) {
                 H5_FAILED();
                 printf("    retrieved attribute name '%s' didn't match '%s'\n", name_buf,
                        ATTRIBUTE_GET_NAME_TEST_ATTRIBUTE_NAME);
@@ -4127,8 +4127,8 @@ test_get_attribute_name(void)
                 PART_ERROR(H5Aget_name_by_idx_crt_order_increasing);
             }
 
-            if (HDstrncmp(name_buf, ATTRIBUTE_GET_NAME_TEST_ATTRIBUTE_NAME,
-                          strlen(ATTRIBUTE_GET_NAME_TEST_ATTRIBUTE_NAME) + 1)) {
+            if (strncmp(name_buf, ATTRIBUTE_GET_NAME_TEST_ATTRIBUTE_NAME,
+                        strlen(ATTRIBUTE_GET_NAME_TEST_ATTRIBUTE_NAME) + 1)) {
                 H5_FAILED();
                 printf("    retrieved attribute name '%s' didn't match '%s'\n", name_buf,
                        ATTRIBUTE_GET_NAME_TEST_ATTRIBUTE_NAME);
@@ -4145,8 +4145,8 @@ test_get_attribute_name(void)
                 PART_ERROR(H5Aget_name_by_idx_crt_order_increasing);
             }
 
-            if (HDstrncmp(name_buf, ATTRIBUTE_GET_NAME_TEST_ATTRIBUTE_NAME2,
-                          strlen(ATTRIBUTE_GET_NAME_TEST_ATTRIBUTE_NAME2) + 1)) {
+            if (strncmp(name_buf, ATTRIBUTE_GET_NAME_TEST_ATTRIBUTE_NAME2,
+                        strlen(ATTRIBUTE_GET_NAME_TEST_ATTRIBUTE_NAME2) + 1)) {
                 H5_FAILED();
                 printf("    retrieved attribute name '%s' didn't match '%s'\n", name_buf,
                        ATTRIBUTE_GET_NAME_TEST_ATTRIBUTE_NAME2);
@@ -4163,8 +4163,8 @@ test_get_attribute_name(void)
                 PART_ERROR(H5Aget_name_by_idx_crt_order_increasing);
             }
 
-            if (HDstrncmp(name_buf, ATTRIBUTE_GET_NAME_TEST_ATTRIBUTE_NAME3,
-                          strlen(ATTRIBUTE_GET_NAME_TEST_ATTRIBUTE_NAME3) + 1)) {
+            if (strncmp(name_buf, ATTRIBUTE_GET_NAME_TEST_ATTRIBUTE_NAME3,
+                        strlen(ATTRIBUTE_GET_NAME_TEST_ATTRIBUTE_NAME3) + 1)) {
                 H5_FAILED();
                 printf("    retrieved attribute name '%s' didn't match '%s'\n", name_buf,
                        ATTRIBUTE_GET_NAME_TEST_ATTRIBUTE_NAME3);
@@ -4195,8 +4195,8 @@ test_get_attribute_name(void)
                 PART_ERROR(H5Aget_name_by_idx_crt_order_decreasing);
             }
 
-            if (HDstrncmp(name_buf, ATTRIBUTE_GET_NAME_TEST_ATTRIBUTE_NAME,
-                          strlen(ATTRIBUTE_GET_NAME_TEST_ATTRIBUTE_NAME) + 1)) {
+            if (strncmp(name_buf, ATTRIBUTE_GET_NAME_TEST_ATTRIBUTE_NAME,
+                        strlen(ATTRIBUTE_GET_NAME_TEST_ATTRIBUTE_NAME) + 1)) {
                 H5_FAILED();
                 printf("    retrieved attribute name '%s' didn't match '%s'\n", name_buf,
                        ATTRIBUTE_GET_NAME_TEST_ATTRIBUTE_NAME);
@@ -4213,8 +4213,8 @@ test_get_attribute_name(void)
                 PART_ERROR(H5Aget_name_by_idx_crt_order_decreasing);
             }
 
-            if (HDstrncmp(name_buf, ATTRIBUTE_GET_NAME_TEST_ATTRIBUTE_NAME2,
-                          strlen(ATTRIBUTE_GET_NAME_TEST_ATTRIBUTE_NAME2) + 1)) {
+            if (strncmp(name_buf, ATTRIBUTE_GET_NAME_TEST_ATTRIBUTE_NAME2,
+                        strlen(ATTRIBUTE_GET_NAME_TEST_ATTRIBUTE_NAME2) + 1)) {
                 H5_FAILED();
                 printf("    retrieved attribute name '%s' didn't match '%s'\n", name_buf,
                        ATTRIBUTE_GET_NAME_TEST_ATTRIBUTE_NAME2);
@@ -4231,8 +4231,8 @@ test_get_attribute_name(void)
                 PART_ERROR(H5Aget_name_by_idx_crt_order_decreasing);
             }
 
-            if (HDstrncmp(name_buf, ATTRIBUTE_GET_NAME_TEST_ATTRIBUTE_NAME3,
-                          strlen(ATTRIBUTE_GET_NAME_TEST_ATTRIBUTE_NAME3) + 1)) {
+            if (strncmp(name_buf, ATTRIBUTE_GET_NAME_TEST_ATTRIBUTE_NAME3,
+                        strlen(ATTRIBUTE_GET_NAME_TEST_ATTRIBUTE_NAME3) + 1)) {
                 H5_FAILED();
                 printf("    retrieved attribute name '%s' didn't match '%s'\n", name_buf,
                        ATTRIBUTE_GET_NAME_TEST_ATTRIBUTE_NAME3);
@@ -4257,8 +4257,8 @@ test_get_attribute_name(void)
                 PART_ERROR(H5Aget_name_by_idx_name_order_increasing);
             }
 
-            if (HDstrncmp(name_buf, ATTRIBUTE_GET_NAME_TEST_ATTRIBUTE_NAME,
-                          strlen(ATTRIBUTE_GET_NAME_TEST_ATTRIBUTE_NAME) + 1)) {
+            if (strncmp(name_buf, ATTRIBUTE_GET_NAME_TEST_ATTRIBUTE_NAME,
+                        strlen(ATTRIBUTE_GET_NAME_TEST_ATTRIBUTE_NAME) + 1)) {
                 H5_FAILED();
                 printf("    retrieved attribute name '%s' didn't match '%s'\n", name_buf,
                        ATTRIBUTE_GET_NAME_TEST_ATTRIBUTE_NAME);
@@ -4275,8 +4275,8 @@ test_get_attribute_name(void)
                 PART_ERROR(H5Aget_name_by_idx_name_order_increasing);
             }
 
-            if (HDstrncmp(name_buf, ATTRIBUTE_GET_NAME_TEST_ATTRIBUTE_NAME2,
-                          strlen(ATTRIBUTE_GET_NAME_TEST_ATTRIBUTE_NAME2) + 1)) {
+            if (strncmp(name_buf, ATTRIBUTE_GET_NAME_TEST_ATTRIBUTE_NAME2,
+                        strlen(ATTRIBUTE_GET_NAME_TEST_ATTRIBUTE_NAME2) + 1)) {
                 H5_FAILED();
                 printf("    retrieved attribute name '%s' didn't match '%s'\n", name_buf,
                        ATTRIBUTE_GET_NAME_TEST_ATTRIBUTE_NAME2);
@@ -4293,8 +4293,8 @@ test_get_attribute_name(void)
                 PART_ERROR(H5Aget_name_by_idx_name_order_increasing);
             }
 
-            if (HDstrncmp(name_buf, ATTRIBUTE_GET_NAME_TEST_ATTRIBUTE_NAME3,
-                          strlen(ATTRIBUTE_GET_NAME_TEST_ATTRIBUTE_NAME3) + 1)) {
+            if (strncmp(name_buf, ATTRIBUTE_GET_NAME_TEST_ATTRIBUTE_NAME3,
+                        strlen(ATTRIBUTE_GET_NAME_TEST_ATTRIBUTE_NAME3) + 1)) {
                 H5_FAILED();
                 printf("    retrieved attribute name '%s' didn't match '%s'\n", name_buf,
                        ATTRIBUTE_GET_NAME_TEST_ATTRIBUTE_NAME3);
@@ -4319,8 +4319,8 @@ test_get_attribute_name(void)
                 PART_ERROR(H5Aget_name_by_idx_name_order_decreasing);
             }
 
-            if (HDstrncmp(name_buf, ATTRIBUTE_GET_NAME_TEST_ATTRIBUTE_NAME,
-                          strlen(ATTRIBUTE_GET_NAME_TEST_ATTRIBUTE_NAME) + 1)) {
+            if (strncmp(name_buf, ATTRIBUTE_GET_NAME_TEST_ATTRIBUTE_NAME,
+                        strlen(ATTRIBUTE_GET_NAME_TEST_ATTRIBUTE_NAME) + 1)) {
                 H5_FAILED();
                 printf("    retrieved attribute name '%s' didn't match '%s'\n", name_buf,
                        ATTRIBUTE_GET_NAME_TEST_ATTRIBUTE_NAME);
@@ -4337,8 +4337,8 @@ test_get_attribute_name(void)
                 PART_ERROR(H5Aget_name_by_idx_name_order_decreasing);
             }
 
-            if (HDstrncmp(name_buf, ATTRIBUTE_GET_NAME_TEST_ATTRIBUTE_NAME2,
-                          strlen(ATTRIBUTE_GET_NAME_TEST_ATTRIBUTE_NAME2) + 1)) {
+            if (strncmp(name_buf, ATTRIBUTE_GET_NAME_TEST_ATTRIBUTE_NAME2,
+                        strlen(ATTRIBUTE_GET_NAME_TEST_ATTRIBUTE_NAME2) + 1)) {
                 H5_FAILED();
                 printf("    retrieved attribute name '%s' didn't match '%s'\n", name_buf,
                        ATTRIBUTE_GET_NAME_TEST_ATTRIBUTE_NAME2);
@@ -4355,8 +4355,8 @@ test_get_attribute_name(void)
                 PART_ERROR(H5Aget_name_by_idx_name_order_decreasing);
             }
 
-            if (HDstrncmp(name_buf, ATTRIBUTE_GET_NAME_TEST_ATTRIBUTE_NAME3,
-                          strlen(ATTRIBUTE_GET_NAME_TEST_ATTRIBUTE_NAME3) + 1)) {
+            if (strncmp(name_buf, ATTRIBUTE_GET_NAME_TEST_ATTRIBUTE_NAME3,
+                        strlen(ATTRIBUTE_GET_NAME_TEST_ATTRIBUTE_NAME3) + 1)) {
                 H5_FAILED();
                 printf("    retrieved attribute name '%s' didn't match '%s'\n", name_buf,
                        ATTRIBUTE_GET_NAME_TEST_ATTRIBUTE_NAME3);
@@ -6553,8 +6553,8 @@ test_attribute_iterate_group(void)
     for (i = 0; i < ATTRIBUTE_ITERATE_TEST_NUM_ATTRS; i++) {
         char attr_name[ATTRIBUTE_ITERATE_TEST_ATTR_NAME_BUF_SIZE];
 
-        HDsnprintf(attr_name, ATTRIBUTE_ITERATE_TEST_ATTR_NAME_BUF_SIZE,
-                   ATTRIBUTE_ITERATE_TEST_ATTR_NAME "%d", (int)(ATTRIBUTE_ITERATE_TEST_NUM_ATTRS - i - 1));
+        snprintf(attr_name, ATTRIBUTE_ITERATE_TEST_ATTR_NAME_BUF_SIZE, ATTRIBUTE_ITERATE_TEST_ATTR_NAME "%d",
+                 (int)(ATTRIBUTE_ITERATE_TEST_NUM_ATTRS - i - 1));
 
         if ((attr_id = H5Acreate2(group_id, attr_name, attr_dtype, attr_space_id, H5P_DEFAULT, H5P_DEFAULT)) <
             0) {
@@ -6962,8 +6962,8 @@ test_attribute_iterate_dataset(void)
     for (i = 0; i < ATTRIBUTE_ITERATE_TEST_NUM_ATTRS; i++) {
         char attr_name[ATTRIBUTE_ITERATE_TEST_ATTR_NAME_BUF_SIZE];
 
-        HDsnprintf(attr_name, ATTRIBUTE_ITERATE_TEST_ATTR_NAME_BUF_SIZE,
-                   ATTRIBUTE_ITERATE_TEST_ATTR_NAME "%d", (int)(ATTRIBUTE_ITERATE_TEST_NUM_ATTRS - i - 1));
+        snprintf(attr_name, ATTRIBUTE_ITERATE_TEST_ATTR_NAME_BUF_SIZE, ATTRIBUTE_ITERATE_TEST_ATTR_NAME "%d",
+                 (int)(ATTRIBUTE_ITERATE_TEST_NUM_ATTRS - i - 1));
 
         if ((attr_id = H5Acreate2(dset_id, attr_name, attr_dtype, attr_space_id, H5P_DEFAULT, H5P_DEFAULT)) <
             0) {
@@ -7381,8 +7381,8 @@ test_attribute_iterate_datatype(void)
     for (i = 0; i < ATTRIBUTE_ITERATE_TEST_NUM_ATTRS; i++) {
         char attr_name[ATTRIBUTE_ITERATE_TEST_ATTR_NAME_BUF_SIZE];
 
-        HDsnprintf(attr_name, ATTRIBUTE_ITERATE_TEST_ATTR_NAME_BUF_SIZE,
-                   ATTRIBUTE_ITERATE_TEST_ATTR_NAME "%d", (int)(ATTRIBUTE_ITERATE_TEST_NUM_ATTRS - i - 1));
+        snprintf(attr_name, ATTRIBUTE_ITERATE_TEST_ATTR_NAME_BUF_SIZE, ATTRIBUTE_ITERATE_TEST_ATTR_NAME "%d",
+                 (int)(ATTRIBUTE_ITERATE_TEST_NUM_ATTRS - i - 1));
 
         if ((attr_id = H5Acreate2(type_id, attr_name, attr_dtype, attr_space_id, H5P_DEFAULT, H5P_DEFAULT)) <
             0) {
@@ -10990,18 +10990,18 @@ attr_iter_callback1(hid_t location_id, const char *attr_name, const H5A_info_t *
      */
     test_iteration = (counter_val / ATTRIBUTE_ITERATE_TEST_NUM_ATTRS);
     if (test_iteration == 0 || test_iteration == 3) {
-        HDsnprintf(expected_attr_name, ATTRIBUTE_ITERATE_TEST_ATTR_NAME_BUF_SIZE,
-                   ATTRIBUTE_ITERATE_TEST_ATTR_NAME "%d",
-                   (int)(counter_val % ATTRIBUTE_ITERATE_TEST_NUM_ATTRS));
+        snprintf(expected_attr_name, ATTRIBUTE_ITERATE_TEST_ATTR_NAME_BUF_SIZE,
+                 ATTRIBUTE_ITERATE_TEST_ATTR_NAME "%d",
+                 (int)(counter_val % ATTRIBUTE_ITERATE_TEST_NUM_ATTRS));
     }
     else {
-        HDsnprintf(
+        snprintf(
             expected_attr_name, ATTRIBUTE_ITERATE_TEST_ATTR_NAME_BUF_SIZE,
             ATTRIBUTE_ITERATE_TEST_ATTR_NAME "%d",
             (int)(ATTRIBUTE_ITERATE_TEST_NUM_ATTRS - (counter_val % ATTRIBUTE_ITERATE_TEST_NUM_ATTRS) - 1));
     }
 
-    if (HDstrncmp(attr_name, expected_attr_name, ATTRIBUTE_ITERATE_TEST_ATTR_NAME_BUF_SIZE)) {
+    if (strncmp(attr_name, expected_attr_name, ATTRIBUTE_ITERATE_TEST_ATTR_NAME_BUF_SIZE)) {
         printf("    attribute name '%s' didn't match expected name '%s'\n", attr_name, expected_attr_name);
         ret_val = H5_ITER_ERROR;
         goto done;

--- a/test/API/H5_api_dataset_test.c
+++ b/test/API/H5_api_dataset_test.c
@@ -1197,7 +1197,7 @@ test_create_dataset_random_shapes(void)
             goto error;
         }
 
-        HDsprintf(name, "%s%zu", DATASET_SHAPE_TEST_DSET_BASE_NAME, i + 1);
+        sprintf(name, "%s%zu", DATASET_SHAPE_TEST_DSET_BASE_NAME, i + 1);
 
         if ((dset_id = H5Dcreate2(group_id, name, dset_dtype, space_id, H5P_DEFAULT, H5P_DEFAULT,
                                   H5P_DEFAULT)) < 0) {
@@ -1295,7 +1295,7 @@ test_create_dataset_predefined_types(void)
                  generate_random_dataspace(DATASET_PREDEFINED_TYPE_TEST_SPACE_RANK, NULL, NULL, false)) < 0)
             TEST_ERROR;
 
-        HDsprintf(name, "%s%zu", DATASET_PREDEFINED_TYPE_TEST_BASE_NAME, i);
+        sprintf(name, "%s%zu", DATASET_PREDEFINED_TYPE_TEST_BASE_NAME, i);
 
         if ((dset_id = H5Dcreate2(group_id, name, predefined_type_test_table[i], fspace_id, H5P_DEFAULT,
                                   H5P_DEFAULT, H5P_DEFAULT)) < 0) {
@@ -1598,7 +1598,7 @@ test_create_dataset_compound_types(void)
             size_t member_size;
             char   member_name[256];
 
-            HDsnprintf(member_name, 256, "member%zu", j);
+            snprintf(member_name, 256, "member%zu", j);
 
             if ((type_pool[j] = generate_random_datatype(H5T_NO_CLASS, false)) < 0) {
                 H5_FAILED();
@@ -1626,7 +1626,7 @@ test_create_dataset_compound_types(void)
         if (H5Tpack(compound_type) < 0)
             TEST_ERROR;
 
-        HDsnprintf(dset_name, sizeof(dset_name), "%s%zu", DATASET_COMPOUND_TYPE_TEST_DSET_NAME, i);
+        snprintf(dset_name, sizeof(dset_name), "%s%zu", DATASET_COMPOUND_TYPE_TEST_DSET_NAME, i);
 
         if ((dset_id = H5Dcreate2(group_id, dset_name, compound_type, fspace_id, H5P_DEFAULT, H5P_DEFAULT,
                                   H5P_DEFAULT)) < 0) {
@@ -1747,7 +1747,7 @@ test_create_dataset_enum_types(void)
     for (i = 0; i < DATASET_ENUM_TYPE_TEST_NUM_MEMBERS; i++) {
         char val_name[15];
 
-        HDsnprintf(val_name, 15, "%s%zu", DATASET_ENUM_TYPE_TEST_VAL_BASE_NAME, i);
+        snprintf(val_name, 15, "%s%zu", DATASET_ENUM_TYPE_TEST_VAL_BASE_NAME, i);
 
         if (H5Tenum_insert(enum_non_native, val_name, &i) < 0)
             TEST_ERROR;
@@ -2118,7 +2118,7 @@ test_create_dataset_creation_properties(void)
                     PART_ERROR(DCPL_alloc_time_test);
                 }
 
-                HDsprintf(name, "%s%zu", DATASET_CREATION_PROPERTIES_TEST_ALLOC_TIMES_BASE_NAME, i);
+                sprintf(name, "%s%zu", DATASET_CREATION_PROPERTIES_TEST_ALLOC_TIMES_BASE_NAME, i);
 
                 if ((dset_id = H5Dcreate2(group_id, name, dset_dtype, fspace_id, H5P_DEFAULT, dcpl_id,
                                           H5P_DEFAULT)) < 0) {
@@ -2194,7 +2194,7 @@ test_create_dataset_creation_properties(void)
                     PART_ERROR(DCPL_attr_crt_order_test);
                 }
 
-                HDsprintf(name, "%s%zu", DATASET_CREATION_PROPERTIES_TEST_CRT_ORDER_BASE_NAME, i);
+                sprintf(name, "%s%zu", DATASET_CREATION_PROPERTIES_TEST_CRT_ORDER_BASE_NAME, i);
 
                 if ((dset_id = H5Dcreate2(group_id, name, dset_dtype, fspace_id, H5P_DEFAULT, dcpl_id,
                                           H5P_DEFAULT)) < 0) {
@@ -2327,7 +2327,7 @@ test_create_dataset_creation_properties(void)
                     PART_ERROR(DCPL_fill_time_property_test);
                 }
 
-                HDsprintf(name, "%s%zu", DATASET_CREATION_PROPERTIES_TEST_FILL_TIMES_BASE_NAME, i);
+                sprintf(name, "%s%zu", DATASET_CREATION_PROPERTIES_TEST_FILL_TIMES_BASE_NAME, i);
 
                 if ((dset_id = H5Dcreate2(group_id, name, dset_dtype, fspace_id, H5P_DEFAULT, dcpl_id,
                                           H5P_DEFAULT)) < 0) {
@@ -2513,7 +2513,7 @@ test_create_dataset_creation_properties(void)
                     }
                 }
 
-                HDsprintf(name, "%s%zu", DATASET_CREATION_PROPERTIES_TEST_LAYOUTS_BASE_NAME, i);
+                sprintf(name, "%s%zu", DATASET_CREATION_PROPERTIES_TEST_LAYOUTS_BASE_NAME, i);
 
                 if ((dset_id =
                          H5Dcreate2(group_id, name, (H5D_COMPACT == layouts[i]) ? compact_dtype : dset_dtype,
@@ -3765,7 +3765,7 @@ test_dataset_property_lists(void)
                     PART_ERROR(H5Dget_access_plist);
                 }
 
-                if (HDstrncmp(tmp_prefix, path_prefix, (size_t)buf_size + 1)) {
+                if (strncmp(tmp_prefix, path_prefix, (size_t)buf_size + 1)) {
                     H5_FAILED();
                     printf("    DAPL values were incorrect!\n");
                     PART_ERROR(H5Dget_access_plist);
@@ -3779,7 +3779,7 @@ test_dataset_property_lists(void)
                     PART_ERROR(H5Dget_access_plist);
                 }
 
-                if (!HDstrncmp(tmp_prefix, path_prefix, (size_t)buf_size + 1)) {
+                if (!strncmp(tmp_prefix, path_prefix, (size_t)buf_size + 1)) {
                     H5_FAILED();
                     printf("    DAPL property value was set!\n");
                     PART_ERROR(H5Dget_access_plist);

--- a/test/API/H5_api_file_test.c
+++ b/test/API/H5_api_file_test.c
@@ -948,7 +948,7 @@ test_flush_file(void)
     }
 
     for (u = 0; u < 10; u++) {
-        HDsprintf(dset_name, "Dataset %u", u);
+        sprintf(dset_name, "Dataset %u", u);
 
         if ((dset_id = H5Dcreate2(file_id, dset_name, H5T_STD_U32LE, dspace_id, H5P_DEFAULT, H5P_DEFAULT,
                                   H5P_DEFAULT)) < 0) {
@@ -2211,7 +2211,7 @@ test_get_file_name(void)
                 PART_ERROR(H5Fget_name_file_id);
             }
 
-            if (HDstrncmp(file_name_buf, prefixed_filename, (size_t)file_name_buf_len)) {
+            if (strncmp(file_name_buf, prefixed_filename, (size_t)file_name_buf_len)) {
                 H5_FAILED();
                 printf("    file name '%s' didn't match expected name '%s'\n", file_name_buf,
                        prefixed_filename);
@@ -2242,7 +2242,7 @@ test_get_file_name(void)
                 PART_ERROR(H5Fget_name_grp_id);
             }
 
-            if (HDstrncmp(file_name_buf, prefixed_filename, (size_t)file_name_buf_len)) {
+            if (strncmp(file_name_buf, prefixed_filename, (size_t)file_name_buf_len)) {
                 H5_FAILED();
                 printf("    file name '%s' didn't match expected name '%s'\n", file_name_buf,
                        prefixed_filename);
@@ -2287,7 +2287,7 @@ test_get_file_name(void)
                 PART_ERROR(H5Fget_name_dset_id);
             }
 
-            if (HDstrncmp(file_name_buf, prefixed_filename, (size_t)file_name_buf_len)) {
+            if (strncmp(file_name_buf, prefixed_filename, (size_t)file_name_buf_len)) {
                 H5_FAILED();
                 printf("    file name '%s' didn't match expected name '%s'\n", file_name_buf,
                        prefixed_filename);
@@ -2340,7 +2340,7 @@ test_get_file_name(void)
                 PART_ERROR(H5Fget_name_attr_id);
             }
 
-            if (HDstrncmp(file_name_buf, prefixed_filename, (size_t)file_name_buf_len)) {
+            if (strncmp(file_name_buf, prefixed_filename, (size_t)file_name_buf_len)) {
                 H5_FAILED();
                 printf("    file name '%s' didn't match expected name '%s'\n", file_name_buf,
                        prefixed_filename);
@@ -2393,7 +2393,7 @@ test_get_file_name(void)
                 PART_ERROR(H5Fget_name_dtype_id);
             }
 
-            if (HDstrncmp(file_name_buf, prefixed_filename, (size_t)file_name_buf_len)) {
+            if (strncmp(file_name_buf, prefixed_filename, (size_t)file_name_buf_len)) {
                 H5_FAILED();
                 printf("    file name '%s' didn't match expected name '%s'\n", file_name_buf,
                        prefixed_filename);

--- a/test/API/H5_api_group_test.c
+++ b/test/API/H5_api_group_test.c
@@ -1437,8 +1437,7 @@ test_get_group_info(void)
     /* Create multiple groups under the parent group */
     for (i = 0; i < GROUP_GET_INFO_TEST_GROUP_NUMB; i++) {
         /* Create the groups with a reverse-ordering naming scheme to test creation order */
-        HDsnprintf(group_name, NAME_BUF_SIZE, "group %02u",
-                   (unsigned)(GROUP_GET_INFO_TEST_GROUP_NUMB - i - 1));
+        snprintf(group_name, NAME_BUF_SIZE, "group %02u", (unsigned)(GROUP_GET_INFO_TEST_GROUP_NUMB - i - 1));
 
         if ((group_id = H5Gcreate2(parent_group_id, group_name, H5P_DEFAULT, gcpl_id, H5P_DEFAULT)) < 0) {
             H5_FAILED();

--- a/test/API/H5_api_link_test.c
+++ b/test/API/H5_api_link_test.c
@@ -512,7 +512,7 @@ test_create_hard_link_many(void)
         goto error;
     }
 
-    if (HDstrcmp(objname, "/" LINK_TEST_GROUP_NAME "/" HARD_LINK_TEST_GROUP_MANY_NAME "/hard21")) {
+    if (strcmp(objname, "/" LINK_TEST_GROUP_NAME "/" HARD_LINK_TEST_GROUP_MANY_NAME "/hard21")) {
         H5_FAILED();
         printf("    wrong name of the object '%s'\n", objname);
         goto error;
@@ -900,8 +900,7 @@ test_create_hard_link_invalid_params(void)
         {
             TESTING_2("H5Lcreate_hard across files");
 
-            HDsnprintf(ext_link_filename, H5_API_TEST_FILENAME_MAX_LENGTH, "%s",
-                       EXTERNAL_LINK_TEST_FILE_NAME);
+            snprintf(ext_link_filename, H5_API_TEST_FILENAME_MAX_LENGTH, "%s", EXTERNAL_LINK_TEST_FILE_NAME);
 
             if ((ext_file_id = H5Fcreate(ext_link_filename, H5F_ACC_TRUNC, H5P_DEFAULT, H5P_DEFAULT)) < 0) {
                 H5_FAILED();
@@ -1710,7 +1709,7 @@ test_create_soft_link_many(void)
         goto error;
     }
 
-    if (HDstrcmp(objname, "/" LINK_TEST_GROUP_NAME "/" SOFT_LINK_TEST_GROUP_MANY_NAME "/soft16")) {
+    if (strcmp(objname, "/" LINK_TEST_GROUP_NAME "/" SOFT_LINK_TEST_GROUP_MANY_NAME "/soft16")) {
         H5_FAILED();
         printf("    wrong name of the object '%s'\n", objname);
         goto error;
@@ -2000,7 +1999,7 @@ test_create_external_link(void)
         return 0;
     }
 
-    HDsnprintf(ext_link_filename, H5_API_TEST_FILENAME_MAX_LENGTH, "%s", EXTERNAL_LINK_TEST_FILE_NAME);
+    snprintf(ext_link_filename, H5_API_TEST_FILENAME_MAX_LENGTH, "%s", EXTERNAL_LINK_TEST_FILE_NAME);
 
     if ((file_id = H5Fcreate(ext_link_filename, H5F_ACC_TRUNC, H5P_DEFAULT, H5P_DEFAULT)) < 0) {
         H5_FAILED();
@@ -2108,7 +2107,7 @@ test_create_external_link_dangling(void)
         return 0;
     }
 
-    HDsnprintf(ext_link_filename, H5_API_TEST_FILENAME_MAX_LENGTH, "%s", EXTERNAL_LINK_TEST_FILE_NAME);
+    snprintf(ext_link_filename, H5_API_TEST_FILENAME_MAX_LENGTH, "%s", EXTERNAL_LINK_TEST_FILE_NAME);
 
     if ((ext_file_id = H5Fcreate(ext_link_filename, H5F_ACC_TRUNC, H5P_DEFAULT, H5P_DEFAULT)) < 0) {
         H5_FAILED();
@@ -2249,8 +2248,7 @@ test_create_external_link_multi(void)
         {
             TESTING_2("Create the first external file to be pointed to");
 
-            HDsnprintf(ext_link_filename1, H5_API_TEST_FILENAME_MAX_LENGTH, "%s",
-                       EXTERNAL_LINK_TEST_FILE_NAME);
+            snprintf(ext_link_filename1, H5_API_TEST_FILENAME_MAX_LENGTH, "%s", EXTERNAL_LINK_TEST_FILE_NAME);
 
             if ((file_id = H5Fcreate(ext_link_filename1, H5F_ACC_TRUNC, H5P_DEFAULT, H5P_DEFAULT)) < 0) {
                 H5_FAILED();
@@ -2310,8 +2308,8 @@ test_create_external_link_multi(void)
         {
             TESTING_2("Create the second external file to be pointed to");
 
-            HDsnprintf(ext_link_filename2, H5_API_TEST_FILENAME_MAX_LENGTH, "%s",
-                       EXTERNAL_LINK_TEST_FILE_NAME2);
+            snprintf(ext_link_filename2, H5_API_TEST_FILENAME_MAX_LENGTH, "%s",
+                     EXTERNAL_LINK_TEST_FILE_NAME2);
 
             if ((file_id = H5Fcreate(ext_link_filename2, H5F_ACC_TRUNC, H5P_DEFAULT, H5P_DEFAULT)) < 0) {
                 H5_FAILED();
@@ -2367,8 +2365,8 @@ test_create_external_link_multi(void)
         {
             TESTING_2("Create the third external file to be pointed to");
 
-            HDsnprintf(ext_link_filename3, H5_API_TEST_FILENAME_MAX_LENGTH, "%s",
-                       EXTERNAL_LINK_TEST_FILE_NAME3);
+            snprintf(ext_link_filename3, H5_API_TEST_FILENAME_MAX_LENGTH, "%s",
+                     EXTERNAL_LINK_TEST_FILE_NAME3);
 
             if ((file_id = H5Fcreate(ext_link_filename3, H5F_ACC_TRUNC, H5P_DEFAULT, H5P_DEFAULT)) < 0) {
                 H5_FAILED();
@@ -2464,7 +2462,7 @@ test_create_external_link_multi(void)
                 PART_ERROR(H5Lcreate_external_final_file);
             }
 
-            if (HDstrcmp(objname, "/A/B/C")) {
+            if (strcmp(objname, "/A/B/C")) {
                 H5_FAILED();
                 printf("    wrong name of the object '%s'\n", objname);
                 PART_ERROR(H5Lcreate_external_final_file);
@@ -2534,7 +2532,7 @@ test_create_external_link_multi(void)
                 PART_ERROR(H5Lcreate_external_object_created);
             }
 
-            if (HDstrcmp(objname, "/A/B/C/new_group")) {
+            if (strcmp(objname, "/A/B/C/new_group")) {
                 H5_FAILED();
                 printf("    wrong name of the object '%s'\n", objname);
                 PART_ERROR(H5Lcreate_external_object_created);
@@ -2607,8 +2605,8 @@ test_create_external_link_ping_pong(void)
         return 0;
     }
 
-    HDsnprintf(ext_link_filename1, H5_API_TEST_FILENAME_MAX_LENGTH, "%s", EXTERNAL_LINK_TEST_PING_PONG_NAME1);
-    HDsnprintf(ext_link_filename2, H5_API_TEST_FILENAME_MAX_LENGTH, "%s", EXTERNAL_LINK_TEST_PING_PONG_NAME2);
+    snprintf(ext_link_filename1, H5_API_TEST_FILENAME_MAX_LENGTH, "%s", EXTERNAL_LINK_TEST_PING_PONG_NAME1);
+    snprintf(ext_link_filename2, H5_API_TEST_FILENAME_MAX_LENGTH, "%s", EXTERNAL_LINK_TEST_PING_PONG_NAME2);
 
     BEGIN_MULTIPART
     {
@@ -2737,7 +2735,7 @@ test_create_external_link_ping_pong(void)
                 PART_ERROR(H5Lcreate_external_verify);
             }
 
-            if (HDstrcmp(objname, "/final")) {
+            if (strcmp(objname, "/final")) {
                 H5_FAILED();
                 printf("    wrong name of the object '%s'\n", objname);
                 PART_ERROR(H5Lcreate_external_verify);
@@ -2797,7 +2795,7 @@ test_create_external_link_ping_pong(void)
                 PART_ERROR(H5Lcreate_external_verify_again);
             }
 
-            if (HDstrcmp(objname, "/final/new_group")) {
+            if (strcmp(objname, "/final/new_group")) {
                 H5_FAILED();
                 printf("    wrong name of the object '%s'\n", objname);
                 PART_ERROR(H5Lcreate_external_verify_again);
@@ -2862,8 +2860,8 @@ test_create_external_link_invalid_params(void)
 
     TESTING_2("test setup");
 
-    HDsnprintf(ext_link_filename, H5_API_TEST_FILENAME_MAX_LENGTH, "%s",
-               EXTERNAL_LINK_INVALID_PARAMS_TEST_FILE_NAME);
+    snprintf(ext_link_filename, H5_API_TEST_FILENAME_MAX_LENGTH, "%s",
+             EXTERNAL_LINK_INVALID_PARAMS_TEST_FILE_NAME);
 
     if ((file_id = H5Fcreate(ext_link_filename, H5F_ACC_TRUNC, H5P_DEFAULT, H5P_DEFAULT)) < 0) {
         H5_FAILED();
@@ -3168,7 +3166,7 @@ test_create_user_defined_link(void)
         goto error;
     }
 
-    if ((udata_size = HDsnprintf(udata, UD_LINK_TEST_UDATA_MAX_SIZE, "udata")) < 0)
+    if ((udata_size = snprintf(udata, UD_LINK_TEST_UDATA_MAX_SIZE, "udata")) < 0)
         TEST_ERROR;
 
     if (H5Lcreate_ud(group_id, UD_LINK_TEST_LINK_NAME, H5L_TYPE_EXTERNAL, udata, (size_t)udata_size,
@@ -3260,7 +3258,7 @@ test_create_user_defined_link_invalid_params(void)
         goto error;
     }
 
-    if ((udata_size = HDsnprintf(udata, UD_LINK_INVALID_PARAMS_TEST_UDATA_MAX_SIZE, "udata")) < 0)
+    if ((udata_size = snprintf(udata, UD_LINK_INVALID_PARAMS_TEST_UDATA_MAX_SIZE, "udata")) < 0)
         TEST_ERROR;
 
     PASSED();
@@ -3753,8 +3751,7 @@ test_delete_link(void)
         {
             TESTING_2("H5Ldelete on external link");
 
-            HDsnprintf(ext_link_filename, H5_API_TEST_FILENAME_MAX_LENGTH, "%s",
-                       EXTERNAL_LINK_TEST_FILE_NAME);
+            snprintf(ext_link_filename, H5_API_TEST_FILENAME_MAX_LENGTH, "%s", EXTERNAL_LINK_TEST_FILE_NAME);
 
             if ((ext_file_id = H5Fcreate(ext_link_filename, H5F_ACC_TRUNC, H5P_DEFAULT, H5P_DEFAULT)) < 0) {
                 H5_FAILED();
@@ -5717,8 +5714,7 @@ test_delete_link(void)
             }
 
             /* Create file for external link to reference */
-            HDsnprintf(ext_link_filename, H5_API_TEST_FILENAME_MAX_LENGTH, "%s",
-                       EXTERNAL_LINK_TEST_FILE_NAME);
+            snprintf(ext_link_filename, H5_API_TEST_FILENAME_MAX_LENGTH, "%s", EXTERNAL_LINK_TEST_FILE_NAME);
 
             if ((ext_file_id = H5Fcreate(ext_link_filename, H5F_ACC_TRUNC, H5P_DEFAULT, H5P_DEFAULT)) < 0) {
                 H5_FAILED();
@@ -5999,8 +5995,7 @@ test_delete_link(void)
             }
 
             /* Create file for external link to reference */
-            HDsnprintf(ext_link_filename, H5_API_TEST_FILENAME_MAX_LENGTH, "%s",
-                       EXTERNAL_LINK_TEST_FILE_NAME);
+            snprintf(ext_link_filename, H5_API_TEST_FILENAME_MAX_LENGTH, "%s", EXTERNAL_LINK_TEST_FILE_NAME);
 
             if ((ext_file_id = H5Fcreate(ext_link_filename, H5F_ACC_TRUNC, H5P_DEFAULT, H5P_DEFAULT)) < 0) {
                 H5_FAILED();
@@ -6275,8 +6270,7 @@ test_delete_link(void)
             TESTING_2("H5Ldelete_by_idx on external link by alphabetical order in increasing order");
 
             /* Create file for external link to reference */
-            HDsnprintf(ext_link_filename, H5_API_TEST_FILENAME_MAX_LENGTH, "%s",
-                       EXTERNAL_LINK_TEST_FILE_NAME);
+            snprintf(ext_link_filename, H5_API_TEST_FILENAME_MAX_LENGTH, "%s", EXTERNAL_LINK_TEST_FILE_NAME);
 
             if ((ext_file_id = H5Fcreate(ext_link_filename, H5F_ACC_TRUNC, H5P_DEFAULT, H5P_DEFAULT)) < 0) {
                 H5_FAILED();
@@ -6551,8 +6545,7 @@ test_delete_link(void)
             TESTING_2("H5Ldelete_by_idx on external link by alphabetical order in decreasing order");
 
             /* Create file for external link to reference */
-            HDsnprintf(ext_link_filename, H5_API_TEST_FILENAME_MAX_LENGTH, "%s",
-                       EXTERNAL_LINK_TEST_FILE_NAME);
+            snprintf(ext_link_filename, H5_API_TEST_FILENAME_MAX_LENGTH, "%s", EXTERNAL_LINK_TEST_FILE_NAME);
 
             if ((ext_file_id = H5Fcreate(ext_link_filename, H5F_ACC_TRUNC, H5P_DEFAULT, H5P_DEFAULT)) < 0) {
                 H5_FAILED();
@@ -8127,7 +8120,7 @@ test_copy_link(void)
                 PART_ERROR(H5Lcopy_soft_check);
             }
 
-            if (HDstrncmp(orig_link_val, new_link_val, COPY_LINK_TEST_LINK_VAL_BUF_SIZE)) {
+            if (strncmp(orig_link_val, new_link_val, COPY_LINK_TEST_LINK_VAL_BUF_SIZE)) {
                 H5_FAILED();
                 printf("    copied soft link's value '%s' doesn't match original link's value '%s'\n",
                        new_link_val, orig_link_val);
@@ -8260,8 +8253,7 @@ test_copy_link(void)
         {
             TESTING_2("H5Lcopy on external link (copied link's properties not checked)");
 
-            HDsnprintf(ext_link_filename, H5_API_TEST_FILENAME_MAX_LENGTH, "%s",
-                       EXTERNAL_LINK_TEST_FILE_NAME);
+            snprintf(ext_link_filename, H5_API_TEST_FILENAME_MAX_LENGTH, "%s", EXTERNAL_LINK_TEST_FILE_NAME);
 
             if ((ext_file_id = H5Fcreate(ext_link_filename, H5F_ACC_TRUNC, H5P_DEFAULT, H5P_DEFAULT)) < 0) {
                 H5_FAILED();
@@ -8369,8 +8361,7 @@ test_copy_link(void)
 
             TESTING_2("H5Lcopy on external link (copied link's properties checked)");
 
-            HDsnprintf(ext_link_filename, H5_API_TEST_FILENAME_MAX_LENGTH, "%s",
-                       EXTERNAL_LINK_TEST_FILE_NAME);
+            snprintf(ext_link_filename, H5_API_TEST_FILENAME_MAX_LENGTH, "%s", EXTERNAL_LINK_TEST_FILE_NAME);
 
             if ((ext_file_id = H5Fcreate(ext_link_filename, H5F_ACC_TRUNC, H5P_DEFAULT, H5P_DEFAULT)) < 0) {
                 H5_FAILED();
@@ -8542,7 +8533,7 @@ test_copy_link(void)
                 PART_ERROR(H5Lcopy_external_check);
             }
 
-            if (HDstrncmp(new_filename, orig_filename, strlen(orig_filename)) < 0) {
+            if (strncmp(new_filename, orig_filename, strlen(orig_filename)) < 0) {
                 H5_FAILED();
                 printf("    copied external link's filename '%s' doesn't match original external link's "
                        "filename '%s'\n",
@@ -8550,7 +8541,7 @@ test_copy_link(void)
                 PART_ERROR(H5Lcopy_external_check);
             }
 
-            if (HDstrncmp(new_objname, orig_objname, strlen(orig_objname)) < 0) {
+            if (strncmp(new_objname, orig_objname, strlen(orig_objname)) < 0) {
                 H5_FAILED();
                 printf("    copied external link's object name '%s' doesn't match original external link's "
                        "object name '%s'\n",
@@ -8573,8 +8564,7 @@ test_copy_link(void)
         {
             TESTING_2("H5Lcopy on external link using H5L_SAME_LOC");
 
-            HDsnprintf(ext_link_filename, H5_API_TEST_FILENAME_MAX_LENGTH, "%s",
-                       EXTERNAL_LINK_TEST_FILE_NAME);
+            snprintf(ext_link_filename, H5_API_TEST_FILENAME_MAX_LENGTH, "%s", EXTERNAL_LINK_TEST_FILE_NAME);
 
             if ((ext_file_id = H5Fcreate(ext_link_filename, H5F_ACC_TRUNC, H5P_DEFAULT, H5P_DEFAULT)) < 0) {
                 H5_FAILED();
@@ -9091,8 +9081,7 @@ test_copy_link_invalid_params(void)
         {
             TESTING_2("H5Lcopy invalid across files");
 
-            HDsnprintf(ext_link_filename, H5_API_TEST_FILENAME_MAX_LENGTH, "%s",
-                       EXTERNAL_LINK_TEST_FILE_NAME);
+            snprintf(ext_link_filename, H5_API_TEST_FILENAME_MAX_LENGTH, "%s", EXTERNAL_LINK_TEST_FILE_NAME);
 
             if ((ext_file_id = H5Fcreate(ext_link_filename, H5F_ACC_TRUNC, H5P_DEFAULT, H5P_DEFAULT)) < 0) {
                 H5_FAILED();
@@ -9186,7 +9175,7 @@ test_move_link(void)
 
     TESTING_2("test setup");
 
-    HDsnprintf(ext_link_filename, H5_API_TEST_FILENAME_MAX_LENGTH, "%s", EXTERNAL_LINK_TEST_FILE_NAME);
+    snprintf(ext_link_filename, H5_API_TEST_FILENAME_MAX_LENGTH, "%s", EXTERNAL_LINK_TEST_FILE_NAME);
 
     if ((file_id = H5Fopen(H5_api_test_filename, H5F_ACC_RDWR, H5P_DEFAULT)) < 0) {
         H5_FAILED();
@@ -9857,7 +9846,7 @@ test_move_link(void)
                 PART_ERROR(H5Lmove_soft_check);
             }
 
-            if (HDstrncmp(orig_link_val, new_link_val, MOVE_LINK_TEST_LINK_VAL_BUF_SIZE)) {
+            if (strncmp(orig_link_val, new_link_val, MOVE_LINK_TEST_LINK_VAL_BUF_SIZE)) {
                 H5_FAILED();
                 printf("    moved soft link's value '%s' doesn't match original link's value '%s'\n",
                        new_link_val, orig_link_val);
@@ -10067,8 +10056,7 @@ test_move_link(void)
         {
             TESTING_2("H5Lmove on external link (moved link's properties not checked)");
 
-            HDsnprintf(ext_link_filename, H5_API_TEST_FILENAME_MAX_LENGTH, "%s",
-                       EXTERNAL_LINK_TEST_FILE_NAME);
+            snprintf(ext_link_filename, H5_API_TEST_FILENAME_MAX_LENGTH, "%s", EXTERNAL_LINK_TEST_FILE_NAME);
 
             if ((ext_file_id = H5Fcreate(ext_link_filename, H5F_ACC_TRUNC, H5P_DEFAULT, H5P_DEFAULT)) < 0) {
                 H5_FAILED();
@@ -10176,8 +10164,7 @@ test_move_link(void)
 
             TESTING_2("H5Lmove on external link (moved link's properties checked)");
 
-            HDsnprintf(ext_link_filename, H5_API_TEST_FILENAME_MAX_LENGTH, "%s",
-                       EXTERNAL_LINK_TEST_FILE_NAME);
+            snprintf(ext_link_filename, H5_API_TEST_FILENAME_MAX_LENGTH, "%s", EXTERNAL_LINK_TEST_FILE_NAME);
 
             if ((ext_file_id = H5Fcreate(ext_link_filename, H5F_ACC_TRUNC, H5P_DEFAULT, H5P_DEFAULT)) < 0) {
                 H5_FAILED();
@@ -10349,7 +10336,7 @@ test_move_link(void)
                 PART_ERROR(H5Lmove_external_check);
             }
 
-            if (HDstrncmp(new_filename, orig_filename, strlen(orig_filename)) < 0) {
+            if (strncmp(new_filename, orig_filename, strlen(orig_filename)) < 0) {
                 H5_FAILED();
                 printf("    moved external link's filename '%s' doesn't match original external link's "
                        "filename '%s'\n",
@@ -10357,7 +10344,7 @@ test_move_link(void)
                 PART_ERROR(H5Lmove_external_check);
             }
 
-            if (HDstrncmp(new_objname, orig_objname, strlen(orig_objname)) < 0) {
+            if (strncmp(new_objname, orig_objname, strlen(orig_objname)) < 0) {
                 H5_FAILED();
                 printf("    moved external link's object name '%s' doesn't match original external link's "
                        "object name '%s'\n",
@@ -10380,8 +10367,7 @@ test_move_link(void)
         {
             TESTING_2("H5Lmove on external link using H5L_SAME_LOC");
 
-            HDsnprintf(ext_link_filename, H5_API_TEST_FILENAME_MAX_LENGTH, "%s",
-                       EXTERNAL_LINK_TEST_FILE_NAME);
+            snprintf(ext_link_filename, H5_API_TEST_FILENAME_MAX_LENGTH, "%s", EXTERNAL_LINK_TEST_FILE_NAME);
 
             if ((ext_file_id = H5Fcreate(ext_link_filename, H5F_ACC_TRUNC, H5P_DEFAULT, H5P_DEFAULT)) < 0) {
                 H5_FAILED();
@@ -10519,8 +10505,7 @@ test_move_link(void)
         {
             TESTING_2("H5Lmove to rename external link without moving it");
 
-            HDsnprintf(ext_link_filename, H5_API_TEST_FILENAME_MAX_LENGTH, "%s",
-                       EXTERNAL_LINK_TEST_FILE_NAME);
+            snprintf(ext_link_filename, H5_API_TEST_FILENAME_MAX_LENGTH, "%s", EXTERNAL_LINK_TEST_FILE_NAME);
 
             if ((ext_file_id = H5Fcreate(ext_link_filename, H5F_ACC_TRUNC, H5P_DEFAULT, H5P_DEFAULT)) < 0) {
                 H5_FAILED();
@@ -11404,8 +11389,7 @@ test_move_link_invalid_params(void)
         {
             TESTING_2("H5Lmove into another file");
 
-            HDsnprintf(ext_link_filename, H5_API_TEST_FILENAME_MAX_LENGTH, "%s",
-                       EXTERNAL_LINK_TEST_FILE_NAME);
+            snprintf(ext_link_filename, H5_API_TEST_FILENAME_MAX_LENGTH, "%s", EXTERNAL_LINK_TEST_FILE_NAME);
 
             if ((ext_file_id = H5Fcreate(ext_link_filename, H5F_ACC_TRUNC, H5P_DEFAULT, H5P_DEFAULT)) < 0) {
                 H5_FAILED();
@@ -11613,7 +11597,7 @@ test_get_link_val(void)
                 PART_ERROR(H5Lget_val_soft);
             }
 
-            if (HDstrncmp(link_val_buf, link_target, link_val_size)) {
+            if (strncmp(link_val_buf, link_target, link_val_size)) {
                 H5_FAILED();
                 printf("    soft link value did not match\n");
                 PART_ERROR(H5Lget_val_soft);
@@ -11644,8 +11628,7 @@ test_get_link_val(void)
 
             memset(&link_info, 0, sizeof(link_info));
 
-            HDsnprintf(ext_link_filename, H5_API_TEST_FILENAME_MAX_LENGTH, "%s",
-                       EXTERNAL_LINK_TEST_FILE_NAME);
+            snprintf(ext_link_filename, H5_API_TEST_FILENAME_MAX_LENGTH, "%s", EXTERNAL_LINK_TEST_FILE_NAME);
 
             if ((ext_file_id = H5Fcreate(ext_link_filename, H5F_ACC_TRUNC, H5P_DEFAULT, H5P_DEFAULT)) < 0) {
                 H5_FAILED();
@@ -11714,14 +11697,14 @@ test_get_link_val(void)
                 PART_ERROR(H5Lget_val_external);
             }
 
-            if (HDstrncmp(ext_link_filepath, ext_link_filename, strlen(ext_link_filename) + 1)) {
+            if (strncmp(ext_link_filepath, ext_link_filename, strlen(ext_link_filename) + 1)) {
                 H5_FAILED();
                 printf("    external link target file '%s' did not match expected '%s'\n", ext_link_filepath,
                        ext_link_filename);
                 PART_ERROR(H5Lget_val_external);
             }
 
-            if (HDstrncmp(ext_link_val, ext_obj_name, strlen(ext_obj_name) + 1)) {
+            if (strncmp(ext_link_val, ext_obj_name, strlen(ext_obj_name) + 1)) {
                 H5_FAILED();
                 printf("    external link value '%s' did not match expected '%s'\n", ext_link_val,
                        ext_obj_name);
@@ -11873,7 +11856,7 @@ test_get_link_val(void)
                 PART_ERROR(H5Lget_val_by_idx_soft_crt_order_increasing);
             }
 
-            if (HDstrncmp(link_val_buf, link_target_a, strlen(link_target_a) + 1)) {
+            if (strncmp(link_val_buf, link_target_a, strlen(link_target_a) + 1)) {
                 H5_FAILED();
                 printf("    link value '%s' for link at index %d did not match expected value '%s'\n",
                        link_val_buf, 0, link_target_a);
@@ -11904,7 +11887,7 @@ test_get_link_val(void)
                 PART_ERROR(H5Lget_val_by_idx_soft_crt_order_increasing);
             }
 
-            if (HDstrncmp(link_val_buf, link_target_b, strlen(link_target_b) + 1)) {
+            if (strncmp(link_val_buf, link_target_b, strlen(link_target_b) + 1)) {
                 H5_FAILED();
                 printf("    link value '%s' for link at index %d did not match expected value '%s'\n",
                        link_val_buf, 1, link_target_b);
@@ -11935,7 +11918,7 @@ test_get_link_val(void)
                 PART_ERROR(H5Lget_val_by_idx_soft_crt_order_increasing);
             }
 
-            if (HDstrncmp(link_val_buf, link_target_c, strlen(link_target_c) + 1)) {
+            if (strncmp(link_val_buf, link_target_c, strlen(link_target_c) + 1)) {
                 H5_FAILED();
                 printf("    link value '%s' for link at index %d did not match expected value '%s'\n",
                        link_val_buf, 2, link_target_c);
@@ -12067,7 +12050,7 @@ test_get_link_val(void)
                 PART_ERROR(H5Lget_val_by_idx_soft_crt_order_decreasing);
             }
 
-            if (HDstrncmp(link_val_buf, link_target_a, strlen(link_target_a) + 1)) {
+            if (strncmp(link_val_buf, link_target_a, strlen(link_target_a) + 1)) {
                 H5_FAILED();
                 printf("    link value '%s' for link at index %d did not match expected value '%s'\n",
                        link_val_buf, 2, link_target_a);
@@ -12098,7 +12081,7 @@ test_get_link_val(void)
                 PART_ERROR(H5Lget_val_by_idx_soft_crt_order_decreasing);
             }
 
-            if (HDstrncmp(link_val_buf, link_target_b, strlen(link_target_b) + 1)) {
+            if (strncmp(link_val_buf, link_target_b, strlen(link_target_b) + 1)) {
                 H5_FAILED();
                 printf("    link value '%s' for link at index %d did not match expected value '%s'\n",
                        link_val_buf, 1, link_target_b);
@@ -12129,7 +12112,7 @@ test_get_link_val(void)
                 PART_ERROR(H5Lget_val_by_idx_soft_crt_order_decreasing);
             }
 
-            if (HDstrncmp(link_val_buf, link_target_c, strlen(link_target_c) + 1)) {
+            if (strncmp(link_val_buf, link_target_c, strlen(link_target_c) + 1)) {
                 H5_FAILED();
                 printf("    link value '%s' for link at index %d did not match expected value '%s'\n",
                        link_val_buf, 0, link_target_c);
@@ -12255,7 +12238,7 @@ test_get_link_val(void)
                 PART_ERROR(H5Lget_val_by_idx_soft_name_order_increasing);
             }
 
-            if (HDstrncmp(link_val_buf, link_target_a, strlen(link_target_a) + 1)) {
+            if (strncmp(link_val_buf, link_target_a, strlen(link_target_a) + 1)) {
                 H5_FAILED();
                 printf("    link value '%s' for link at index %d did not match expected value '%s'\n",
                        link_val_buf, 0, link_target_a);
@@ -12286,7 +12269,7 @@ test_get_link_val(void)
                 PART_ERROR(H5Lget_val_by_idx_soft_name_order_increasing);
             }
 
-            if (HDstrncmp(link_val_buf, link_target_b, strlen(link_target_b) + 1)) {
+            if (strncmp(link_val_buf, link_target_b, strlen(link_target_b) + 1)) {
                 H5_FAILED();
                 printf("    link value '%s' for link at index %d did not match expected value '%s'\n",
                        link_val_buf, 1, link_target_b);
@@ -12317,7 +12300,7 @@ test_get_link_val(void)
                 PART_ERROR(H5Lget_val_by_idx_soft_name_order_increasing);
             }
 
-            if (HDstrncmp(link_val_buf, link_target_c, strlen(link_target_c) + 1)) {
+            if (strncmp(link_val_buf, link_target_c, strlen(link_target_c) + 1)) {
                 H5_FAILED();
                 printf("    link value '%s' for link at index %d did not match expected value '%s'\n",
                        link_val_buf, 2, link_target_c);
@@ -12443,7 +12426,7 @@ test_get_link_val(void)
                 PART_ERROR(H5Lget_val_by_idx_soft_name_order_decreasing);
             }
 
-            if (HDstrncmp(link_val_buf, link_target_a, strlen(link_target_a) + 1)) {
+            if (strncmp(link_val_buf, link_target_a, strlen(link_target_a) + 1)) {
                 H5_FAILED();
                 printf("    link value '%s' for link at index %d did not match expected value '%s'\n",
                        link_val_buf, 2, link_target_a);
@@ -12474,7 +12457,7 @@ test_get_link_val(void)
                 PART_ERROR(H5Lget_val_by_idx_soft_name_order_decreasing);
             }
 
-            if (HDstrncmp(link_val_buf, link_target_b, strlen(link_target_b) + 1)) {
+            if (strncmp(link_val_buf, link_target_b, strlen(link_target_b) + 1)) {
                 H5_FAILED();
                 printf("    link value '%s' for link at index %d did not match expected value '%s'\n",
                        link_val_buf, 1, link_target_b);
@@ -12505,7 +12488,7 @@ test_get_link_val(void)
                 PART_ERROR(H5Lget_val_by_idx_soft_name_order_decreasing);
             }
 
-            if (HDstrncmp(link_val_buf, link_target_c, strlen(link_target_c) + 1)) {
+            if (strncmp(link_val_buf, link_target_c, strlen(link_target_c) + 1)) {
                 H5_FAILED();
                 printf("    link value '%s' for link at index %d did not match expected value '%s'\n",
                        link_val_buf, 0, link_target_c);
@@ -12543,8 +12526,7 @@ test_get_link_val(void)
                 PART_EMPTY(H5Lget_val_by_idx_external_crt_order_increasing);
             }
 
-            HDsnprintf(ext_link_filename, H5_API_TEST_FILENAME_MAX_LENGTH, "%s",
-                       EXTERNAL_LINK_TEST_FILE_NAME);
+            snprintf(ext_link_filename, H5_API_TEST_FILENAME_MAX_LENGTH, "%s", EXTERNAL_LINK_TEST_FILE_NAME);
 
             if ((ext_file_id = H5Fcreate(ext_link_filename, H5F_ACC_TRUNC, H5P_DEFAULT, H5P_DEFAULT)) < 0) {
                 H5_FAILED();
@@ -12656,14 +12638,14 @@ test_get_link_val(void)
                 PART_ERROR(H5Lget_val_by_idx_external_crt_order_increasing);
             }
 
-            if (HDstrncmp(ext_link_filepath, ext_link_filename, strlen(ext_link_filename) + 1)) {
+            if (strncmp(ext_link_filepath, ext_link_filename, strlen(ext_link_filename) + 1)) {
                 H5_FAILED();
                 printf("    external link target file '%s' did not match expected '%s'\n", ext_link_filepath,
                        ext_link_filename);
                 PART_ERROR(H5Lget_val_by_idx_external_crt_order_increasing);
             }
 
-            if (HDstrncmp(ext_link_val, ext_obj_name_a, strlen(ext_obj_name_a) + 1)) {
+            if (strncmp(ext_link_val, ext_obj_name_a, strlen(ext_obj_name_a) + 1)) {
                 H5_FAILED();
                 printf("    external link value '%s' did not match expected '%s'\n", ext_link_val,
                        ext_obj_name_a);
@@ -12701,14 +12683,14 @@ test_get_link_val(void)
                 PART_ERROR(H5Lget_val_by_idx_external_crt_order_increasing);
             }
 
-            if (HDstrncmp(ext_link_filepath, ext_link_filename, strlen(ext_link_filename) + 1)) {
+            if (strncmp(ext_link_filepath, ext_link_filename, strlen(ext_link_filename) + 1)) {
                 H5_FAILED();
                 printf("    external link target file '%s' did not match expected '%s'\n", ext_link_filepath,
                        ext_link_filename);
                 PART_ERROR(H5Lget_val_by_idx_external_crt_order_increasing);
             }
 
-            if (HDstrncmp(ext_link_val, ext_obj_name_b, strlen(ext_obj_name_b) + 1)) {
+            if (strncmp(ext_link_val, ext_obj_name_b, strlen(ext_obj_name_b) + 1)) {
                 H5_FAILED();
                 printf("    external link value '%s' did not match expected '%s'\n", ext_link_val,
                        ext_obj_name_b);
@@ -12746,14 +12728,14 @@ test_get_link_val(void)
                 PART_ERROR(H5Lget_val_by_idx_external_crt_order_increasing);
             }
 
-            if (HDstrncmp(ext_link_filepath, ext_link_filename, strlen(ext_link_filename) + 1)) {
+            if (strncmp(ext_link_filepath, ext_link_filename, strlen(ext_link_filename) + 1)) {
                 H5_FAILED();
                 printf("    external link target file '%s' did not match expected '%s'\n", ext_link_filepath,
                        ext_link_filename);
                 PART_ERROR(H5Lget_val_by_idx_external_crt_order_increasing);
             }
 
-            if (HDstrncmp(ext_link_val, ext_obj_name_c, strlen(ext_obj_name_c) + 1)) {
+            if (strncmp(ext_link_val, ext_obj_name_c, strlen(ext_obj_name_c) + 1)) {
                 H5_FAILED();
                 printf("    external link value '%s' did not match expected '%s'\n", ext_link_val,
                        ext_obj_name_c);
@@ -12793,8 +12775,7 @@ test_get_link_val(void)
                 PART_EMPTY(H5Lget_val_by_idx_external_crt_order_decreasing);
             }
 
-            HDsnprintf(ext_link_filename, H5_API_TEST_FILENAME_MAX_LENGTH, "%s",
-                       EXTERNAL_LINK_TEST_FILE_NAME);
+            snprintf(ext_link_filename, H5_API_TEST_FILENAME_MAX_LENGTH, "%s", EXTERNAL_LINK_TEST_FILE_NAME);
 
             if ((ext_file_id = H5Fcreate(ext_link_filename, H5F_ACC_TRUNC, H5P_DEFAULT, H5P_DEFAULT)) < 0) {
                 H5_FAILED();
@@ -12906,14 +12887,14 @@ test_get_link_val(void)
                 PART_ERROR(H5Lget_val_by_idx_external_crt_order_decreasing);
             }
 
-            if (HDstrncmp(ext_link_filepath, ext_link_filename, strlen(ext_link_filename) + 1)) {
+            if (strncmp(ext_link_filepath, ext_link_filename, strlen(ext_link_filename) + 1)) {
                 H5_FAILED();
                 printf("    external link target file '%s' did not match expected '%s'\n", ext_link_filepath,
                        ext_link_filename);
                 PART_ERROR(H5Lget_val_by_idx_external_crt_order_decreasing);
             }
 
-            if (HDstrncmp(ext_link_val, ext_obj_name_a, strlen(ext_obj_name_a) + 1)) {
+            if (strncmp(ext_link_val, ext_obj_name_a, strlen(ext_obj_name_a) + 1)) {
                 H5_FAILED();
                 printf("    external link value '%s' did not match expected '%s'\n", ext_link_val,
                        ext_obj_name_a);
@@ -12951,14 +12932,14 @@ test_get_link_val(void)
                 PART_ERROR(H5Lget_val_by_idx_external_crt_order_decreasing);
             }
 
-            if (HDstrncmp(ext_link_filepath, ext_link_filename, strlen(ext_link_filename) + 1)) {
+            if (strncmp(ext_link_filepath, ext_link_filename, strlen(ext_link_filename) + 1)) {
                 H5_FAILED();
                 printf("    external link target file '%s' did not match expected '%s'\n", ext_link_filepath,
                        ext_link_filename);
                 PART_ERROR(H5Lget_val_by_idx_external_crt_order_decreasing);
             }
 
-            if (HDstrncmp(ext_link_val, ext_obj_name_b, strlen(ext_obj_name_b) + 1)) {
+            if (strncmp(ext_link_val, ext_obj_name_b, strlen(ext_obj_name_b) + 1)) {
                 H5_FAILED();
                 printf("    external link value '%s' did not match expected '%s'\n", ext_link_val,
                        ext_obj_name_b);
@@ -12996,14 +12977,14 @@ test_get_link_val(void)
                 PART_ERROR(H5Lget_val_by_idx_external_crt_order_decreasing);
             }
 
-            if (HDstrncmp(ext_link_filepath, ext_link_filename, strlen(ext_link_filename) + 1)) {
+            if (strncmp(ext_link_filepath, ext_link_filename, strlen(ext_link_filename) + 1)) {
                 H5_FAILED();
                 printf("    external link target file '%s' did not match expected '%s'\n", ext_link_filepath,
                        ext_link_filename);
                 PART_ERROR(H5Lget_val_by_idx_external_crt_order_decreasing);
             }
 
-            if (HDstrncmp(ext_link_val, ext_obj_name_c, strlen(ext_obj_name_c) + 1)) {
+            if (strncmp(ext_link_val, ext_obj_name_c, strlen(ext_obj_name_c) + 1)) {
                 H5_FAILED();
                 printf("    external link value '%s' did not match expected '%s'\n", ext_link_val,
                        ext_obj_name_c);
@@ -13037,8 +13018,7 @@ test_get_link_val(void)
 
             TESTING_2("H5Lget_val_by_idx on external link by alphabetical order in increasing order");
 
-            HDsnprintf(ext_link_filename, H5_API_TEST_FILENAME_MAX_LENGTH, "%s",
-                       EXTERNAL_LINK_TEST_FILE_NAME);
+            snprintf(ext_link_filename, H5_API_TEST_FILENAME_MAX_LENGTH, "%s", EXTERNAL_LINK_TEST_FILE_NAME);
 
             if ((ext_file_id = H5Fcreate(ext_link_filename, H5F_ACC_TRUNC, H5P_DEFAULT, H5P_DEFAULT)) < 0) {
                 H5_FAILED();
@@ -13150,14 +13130,14 @@ test_get_link_val(void)
                 PART_ERROR(H5Lget_val_by_idx_external_name_order_increasing);
             }
 
-            if (HDstrncmp(ext_link_filepath, ext_link_filename, strlen(ext_link_filename) + 1)) {
+            if (strncmp(ext_link_filepath, ext_link_filename, strlen(ext_link_filename) + 1)) {
                 H5_FAILED();
                 printf("    external link target file '%s' did not match expected '%s'\n", ext_link_filepath,
                        ext_link_filename);
                 PART_ERROR(H5Lget_val_by_idx_external_name_order_increasing);
             }
 
-            if (HDstrncmp(ext_link_val, ext_obj_name_a, strlen(ext_obj_name_a) + 1)) {
+            if (strncmp(ext_link_val, ext_obj_name_a, strlen(ext_obj_name_a) + 1)) {
                 H5_FAILED();
                 printf("    external link value '%s' did not match expected '%s'\n", ext_link_val,
                        ext_obj_name_a);
@@ -13195,14 +13175,14 @@ test_get_link_val(void)
                 PART_ERROR(H5Lget_val_by_idx_external_name_order_increasing);
             }
 
-            if (HDstrncmp(ext_link_filepath, ext_link_filename, strlen(ext_link_filename) + 1)) {
+            if (strncmp(ext_link_filepath, ext_link_filename, strlen(ext_link_filename) + 1)) {
                 H5_FAILED();
                 printf("    external link target file '%s' did not match expected '%s'\n", ext_link_filepath,
                        ext_link_filename);
                 PART_ERROR(H5Lget_val_by_idx_external_name_order_increasing);
             }
 
-            if (HDstrncmp(ext_link_val, ext_obj_name_b, strlen(ext_obj_name_b) + 1)) {
+            if (strncmp(ext_link_val, ext_obj_name_b, strlen(ext_obj_name_b) + 1)) {
                 H5_FAILED();
                 printf("    external link value '%s' did not match expected '%s'\n", ext_link_val,
                        ext_obj_name_b);
@@ -13240,14 +13220,14 @@ test_get_link_val(void)
                 PART_ERROR(H5Lget_val_by_idx_external_name_order_increasing);
             }
 
-            if (HDstrncmp(ext_link_filepath, ext_link_filename, strlen(ext_link_filename) + 1)) {
+            if (strncmp(ext_link_filepath, ext_link_filename, strlen(ext_link_filename) + 1)) {
                 H5_FAILED();
                 printf("    external link target file '%s' did not match expected '%s'\n", ext_link_filepath,
                        ext_link_filename);
                 PART_ERROR(H5Lget_val_by_idx_external_name_order_increasing);
             }
 
-            if (HDstrncmp(ext_link_val, ext_obj_name_c, strlen(ext_obj_name_c) + 1)) {
+            if (strncmp(ext_link_val, ext_obj_name_c, strlen(ext_obj_name_c) + 1)) {
                 H5_FAILED();
                 printf("    external link value '%s' did not match expected '%s'\n", ext_link_val,
                        ext_obj_name_c);
@@ -13281,8 +13261,7 @@ test_get_link_val(void)
 
             TESTING_2("H5Lget_val_by_idx on external link by alphabetical order in decreasing order");
 
-            HDsnprintf(ext_link_filename, H5_API_TEST_FILENAME_MAX_LENGTH, "%s",
-                       EXTERNAL_LINK_TEST_FILE_NAME);
+            snprintf(ext_link_filename, H5_API_TEST_FILENAME_MAX_LENGTH, "%s", EXTERNAL_LINK_TEST_FILE_NAME);
 
             if ((ext_file_id = H5Fcreate(ext_link_filename, H5F_ACC_TRUNC, H5P_DEFAULT, H5P_DEFAULT)) < 0) {
                 H5_FAILED();
@@ -13394,14 +13373,14 @@ test_get_link_val(void)
                 PART_ERROR(H5Lget_val_by_idx_external_name_order_decreasing);
             }
 
-            if (HDstrncmp(ext_link_filepath, ext_link_filename, strlen(ext_link_filename) + 1)) {
+            if (strncmp(ext_link_filepath, ext_link_filename, strlen(ext_link_filename) + 1)) {
                 H5_FAILED();
                 printf("    external link target file '%s' did not match expected '%s'\n", ext_link_filepath,
                        ext_link_filename);
                 PART_ERROR(H5Lget_val_by_idx_external_name_order_decreasing);
             }
 
-            if (HDstrncmp(ext_link_val, ext_obj_name_a, strlen(ext_obj_name_a) + 1)) {
+            if (strncmp(ext_link_val, ext_obj_name_a, strlen(ext_obj_name_a) + 1)) {
                 H5_FAILED();
                 printf("    external link value '%s' did not match expected '%s'\n", ext_link_val,
                        ext_obj_name_a);
@@ -13439,14 +13418,14 @@ test_get_link_val(void)
                 PART_ERROR(H5Lget_val_by_idx_external_name_order_decreasing);
             }
 
-            if (HDstrncmp(ext_link_filepath, ext_link_filename, strlen(ext_link_filename) + 1)) {
+            if (strncmp(ext_link_filepath, ext_link_filename, strlen(ext_link_filename) + 1)) {
                 H5_FAILED();
                 printf("    external link target file '%s' did not match expected '%s'\n", ext_link_filepath,
                        ext_link_filename);
                 PART_ERROR(H5Lget_val_by_idx_external_name_order_decreasing);
             }
 
-            if (HDstrncmp(ext_link_val, ext_obj_name_b, strlen(ext_obj_name_b) + 1)) {
+            if (strncmp(ext_link_val, ext_obj_name_b, strlen(ext_obj_name_b) + 1)) {
                 H5_FAILED();
                 printf("    external link value '%s' did not match expected '%s'\n", ext_link_val,
                        ext_obj_name_b);
@@ -13484,14 +13463,14 @@ test_get_link_val(void)
                 PART_ERROR(H5Lget_val_by_idx_external_name_order_decreasing);
             }
 
-            if (HDstrncmp(ext_link_filepath, ext_link_filename, strlen(ext_link_filename) + 1)) {
+            if (strncmp(ext_link_filepath, ext_link_filename, strlen(ext_link_filename) + 1)) {
                 H5_FAILED();
                 printf("    external link target file '%s' did not match expected '%s'\n", ext_link_filepath,
                        ext_link_filename);
                 PART_ERROR(H5Lget_val_by_idx_external_name_order_decreasing);
             }
 
-            if (HDstrncmp(ext_link_val, ext_obj_name_c, strlen(ext_obj_name_c) + 1)) {
+            if (strncmp(ext_link_val, ext_obj_name_c, strlen(ext_obj_name_c) + 1)) {
                 H5_FAILED();
                 printf("    external link value '%s' did not match expected '%s'\n", ext_link_val,
                        ext_obj_name_c);
@@ -14189,8 +14168,7 @@ test_get_link_info(void)
 
             memset(&link_info, 0, sizeof(link_info));
 
-            HDsnprintf(ext_link_filename, H5_API_TEST_FILENAME_MAX_LENGTH, "%s",
-                       EXTERNAL_LINK_TEST_FILE_NAME);
+            snprintf(ext_link_filename, H5_API_TEST_FILENAME_MAX_LENGTH, "%s", EXTERNAL_LINK_TEST_FILE_NAME);
 
             if ((ext_file_id = H5Fcreate(ext_link_filename, H5F_ACC_TRUNC, H5P_DEFAULT, H5P_DEFAULT)) < 0) {
                 H5_FAILED();
@@ -15755,8 +15733,7 @@ test_get_link_info(void)
                 PART_EMPTY(H5Lget_info_by_idx_external_crt_order_increasing);
             }
 
-            HDsnprintf(ext_link_filename, H5_API_TEST_FILENAME_MAX_LENGTH, "%s",
-                       EXTERNAL_LINK_TEST_FILE_NAME);
+            snprintf(ext_link_filename, H5_API_TEST_FILENAME_MAX_LENGTH, "%s", EXTERNAL_LINK_TEST_FILE_NAME);
 
             if ((ext_file_id = H5Fcreate(ext_link_filename, H5F_ACC_TRUNC, H5P_DEFAULT, H5P_DEFAULT)) < 0) {
                 H5_FAILED();
@@ -15959,8 +15936,7 @@ test_get_link_info(void)
                 PART_EMPTY(H5Lget_info_by_idx_external_crt_order_decreasing);
             }
 
-            HDsnprintf(ext_link_filename, H5_API_TEST_FILENAME_MAX_LENGTH, "%s",
-                       EXTERNAL_LINK_TEST_FILE_NAME);
+            snprintf(ext_link_filename, H5_API_TEST_FILENAME_MAX_LENGTH, "%s", EXTERNAL_LINK_TEST_FILE_NAME);
 
             if ((ext_file_id = H5Fcreate(ext_link_filename, H5F_ACC_TRUNC, H5P_DEFAULT, H5P_DEFAULT)) < 0) {
                 H5_FAILED();
@@ -16157,8 +16133,7 @@ test_get_link_info(void)
         {
             TESTING_2("H5Lget_info_by_idx2 on external link by alphabetical order in increasing order");
 
-            HDsnprintf(ext_link_filename, H5_API_TEST_FILENAME_MAX_LENGTH, "%s",
-                       EXTERNAL_LINK_TEST_FILE_NAME);
+            snprintf(ext_link_filename, H5_API_TEST_FILENAME_MAX_LENGTH, "%s", EXTERNAL_LINK_TEST_FILE_NAME);
 
             if ((ext_file_id = H5Fcreate(ext_link_filename, H5F_ACC_TRUNC, H5P_DEFAULT, H5P_DEFAULT)) < 0) {
                 H5_FAILED();
@@ -16361,8 +16336,7 @@ test_get_link_info(void)
         {
             TESTING_2("H5Lget_info_by_idx2 on external link by alphabetical order in decreasing order");
 
-            HDsnprintf(ext_link_filename, H5_API_TEST_FILENAME_MAX_LENGTH, "%s",
-                       EXTERNAL_LINK_TEST_FILE_NAME);
+            snprintf(ext_link_filename, H5_API_TEST_FILENAME_MAX_LENGTH, "%s", EXTERNAL_LINK_TEST_FILE_NAME);
 
             if ((ext_file_id = H5Fcreate(ext_link_filename, H5F_ACC_TRUNC, H5P_DEFAULT, H5P_DEFAULT)) < 0) {
                 H5_FAILED();
@@ -17156,8 +17130,8 @@ test_get_link_name(void)
                 PART_ERROR(H5Lget_name_by_idx_hard_crt_order_increasing);
             }
 
-            if (HDstrncmp(link_name_buf, GET_LINK_NAME_TEST_HARD_LINK_NAME3,
-                          strlen(GET_LINK_NAME_TEST_HARD_LINK_NAME3) + 1)) {
+            if (strncmp(link_name_buf, GET_LINK_NAME_TEST_HARD_LINK_NAME3,
+                        strlen(GET_LINK_NAME_TEST_HARD_LINK_NAME3) + 1)) {
                 H5_FAILED();
                 printf("    link name '%s' did not match expected name '%s'\n", link_name_buf,
                        GET_LINK_NAME_TEST_HARD_LINK_NAME3);
@@ -17178,8 +17152,8 @@ test_get_link_name(void)
                 PART_ERROR(H5Lget_name_by_idx_hard_crt_order_increasing);
             }
 
-            if (HDstrncmp(link_name_buf, GET_LINK_NAME_TEST_HARD_LINK_NAME2,
-                          strlen(GET_LINK_NAME_TEST_HARD_LINK_NAME2) + 1)) {
+            if (strncmp(link_name_buf, GET_LINK_NAME_TEST_HARD_LINK_NAME2,
+                        strlen(GET_LINK_NAME_TEST_HARD_LINK_NAME2) + 1)) {
                 H5_FAILED();
                 printf("    link name '%s' did not match expected name '%s'\n", link_name_buf,
                        GET_LINK_NAME_TEST_HARD_LINK_NAME2);
@@ -17200,8 +17174,8 @@ test_get_link_name(void)
                 PART_ERROR(H5Lget_name_by_idx_hard_crt_order_increasing);
             }
 
-            if (HDstrncmp(link_name_buf, GET_LINK_NAME_TEST_HARD_LINK_NAME,
-                          strlen(GET_LINK_NAME_TEST_HARD_LINK_NAME) + 1)) {
+            if (strncmp(link_name_buf, GET_LINK_NAME_TEST_HARD_LINK_NAME,
+                        strlen(GET_LINK_NAME_TEST_HARD_LINK_NAME) + 1)) {
                 H5_FAILED();
                 printf("    link name '%s' did not match expected name '%s'\n", link_name_buf,
                        GET_LINK_NAME_TEST_HARD_LINK_NAME);
@@ -17324,8 +17298,8 @@ test_get_link_name(void)
                 PART_ERROR(H5Lget_name_by_idx_hard_crt_order_decreasing);
             }
 
-            if (HDstrncmp(link_name_buf, GET_LINK_NAME_TEST_HARD_LINK_NAME,
-                          strlen(GET_LINK_NAME_TEST_HARD_LINK_NAME) + 1)) {
+            if (strncmp(link_name_buf, GET_LINK_NAME_TEST_HARD_LINK_NAME,
+                        strlen(GET_LINK_NAME_TEST_HARD_LINK_NAME) + 1)) {
                 H5_FAILED();
                 printf("    link name '%s' did not match expected name '%s'\n", link_name_buf,
                        GET_LINK_NAME_TEST_HARD_LINK_NAME);
@@ -17346,8 +17320,8 @@ test_get_link_name(void)
                 PART_ERROR(H5Lget_name_by_idx_hard_crt_order_decreasing);
             }
 
-            if (HDstrncmp(link_name_buf, GET_LINK_NAME_TEST_HARD_LINK_NAME2,
-                          strlen(GET_LINK_NAME_TEST_HARD_LINK_NAME2) + 1)) {
+            if (strncmp(link_name_buf, GET_LINK_NAME_TEST_HARD_LINK_NAME2,
+                        strlen(GET_LINK_NAME_TEST_HARD_LINK_NAME2) + 1)) {
                 H5_FAILED();
                 printf("    link name '%s' did not match expected name '%s'\n", link_name_buf,
                        GET_LINK_NAME_TEST_HARD_LINK_NAME2);
@@ -17368,8 +17342,8 @@ test_get_link_name(void)
                 PART_ERROR(H5Lget_name_by_idx_hard_crt_order_decreasing);
             }
 
-            if (HDstrncmp(link_name_buf, GET_LINK_NAME_TEST_HARD_LINK_NAME3,
-                          strlen(GET_LINK_NAME_TEST_HARD_LINK_NAME3) + 1)) {
+            if (strncmp(link_name_buf, GET_LINK_NAME_TEST_HARD_LINK_NAME3,
+                        strlen(GET_LINK_NAME_TEST_HARD_LINK_NAME3) + 1)) {
                 H5_FAILED();
                 printf("    link name '%s' did not match expected name '%s'\n", link_name_buf,
                        GET_LINK_NAME_TEST_HARD_LINK_NAME3);
@@ -17486,8 +17460,8 @@ test_get_link_name(void)
                 PART_ERROR(H5Lget_name_by_idx_hard_name_order_increasing);
             }
 
-            if (HDstrncmp(link_name_buf, GET_LINK_NAME_TEST_HARD_LINK_NAME,
-                          strlen(GET_LINK_NAME_TEST_HARD_LINK_NAME) + 1)) {
+            if (strncmp(link_name_buf, GET_LINK_NAME_TEST_HARD_LINK_NAME,
+                        strlen(GET_LINK_NAME_TEST_HARD_LINK_NAME) + 1)) {
                 H5_FAILED();
                 printf("    link name '%s' did not match expected name '%s'\n", link_name_buf,
                        GET_LINK_NAME_TEST_HARD_LINK_NAME);
@@ -17508,8 +17482,8 @@ test_get_link_name(void)
                 PART_ERROR(H5Lget_name_by_idx_hard_name_order_increasing);
             }
 
-            if (HDstrncmp(link_name_buf, GET_LINK_NAME_TEST_HARD_LINK_NAME2,
-                          strlen(GET_LINK_NAME_TEST_HARD_LINK_NAME2) + 1)) {
+            if (strncmp(link_name_buf, GET_LINK_NAME_TEST_HARD_LINK_NAME2,
+                        strlen(GET_LINK_NAME_TEST_HARD_LINK_NAME2) + 1)) {
                 H5_FAILED();
                 printf("    link name '%s' did not match expected name '%s'\n", link_name_buf,
                        GET_LINK_NAME_TEST_HARD_LINK_NAME2);
@@ -17530,8 +17504,8 @@ test_get_link_name(void)
                 PART_ERROR(H5Lget_name_by_idx_hard_name_order_increasing);
             }
 
-            if (HDstrncmp(link_name_buf, GET_LINK_NAME_TEST_HARD_LINK_NAME3,
-                          strlen(GET_LINK_NAME_TEST_HARD_LINK_NAME3) + 1)) {
+            if (strncmp(link_name_buf, GET_LINK_NAME_TEST_HARD_LINK_NAME3,
+                        strlen(GET_LINK_NAME_TEST_HARD_LINK_NAME3) + 1)) {
                 H5_FAILED();
                 printf("    link name '%s' did not match expected name '%s'\n", link_name_buf,
                        GET_LINK_NAME_TEST_HARD_LINK_NAME3);
@@ -17648,8 +17622,8 @@ test_get_link_name(void)
                 PART_ERROR(H5Lget_name_by_idx_hard_name_order_decreasing);
             }
 
-            if (HDstrncmp(link_name_buf, GET_LINK_NAME_TEST_HARD_LINK_NAME3,
-                          strlen(GET_LINK_NAME_TEST_HARD_LINK_NAME3) + 1)) {
+            if (strncmp(link_name_buf, GET_LINK_NAME_TEST_HARD_LINK_NAME3,
+                        strlen(GET_LINK_NAME_TEST_HARD_LINK_NAME3) + 1)) {
                 H5_FAILED();
                 printf("    link name '%s' did not match expected name '%s'\n", link_name_buf,
                        GET_LINK_NAME_TEST_HARD_LINK_NAME3);
@@ -17670,8 +17644,8 @@ test_get_link_name(void)
                 PART_ERROR(H5Lget_name_by_idx_hard_name_order_decreasing);
             }
 
-            if (HDstrncmp(link_name_buf, GET_LINK_NAME_TEST_HARD_LINK_NAME2,
-                          strlen(GET_LINK_NAME_TEST_HARD_LINK_NAME2) + 1)) {
+            if (strncmp(link_name_buf, GET_LINK_NAME_TEST_HARD_LINK_NAME2,
+                        strlen(GET_LINK_NAME_TEST_HARD_LINK_NAME2) + 1)) {
                 H5_FAILED();
                 printf("    link name '%s' did not match expected name '%s'\n", link_name_buf,
                        GET_LINK_NAME_TEST_HARD_LINK_NAME2);
@@ -17692,8 +17666,8 @@ test_get_link_name(void)
                 PART_ERROR(H5Lget_name_by_idx_hard_name_order_decreasing);
             }
 
-            if (HDstrncmp(link_name_buf, GET_LINK_NAME_TEST_HARD_LINK_NAME,
-                          strlen(GET_LINK_NAME_TEST_HARD_LINK_NAME) + 1)) {
+            if (strncmp(link_name_buf, GET_LINK_NAME_TEST_HARD_LINK_NAME,
+                        strlen(GET_LINK_NAME_TEST_HARD_LINK_NAME) + 1)) {
                 H5_FAILED();
                 printf("    link name '%s' did not match expected name '%s'\n", link_name_buf,
                        GET_LINK_NAME_TEST_HARD_LINK_NAME);
@@ -17816,8 +17790,8 @@ test_get_link_name(void)
                 PART_ERROR(H5Lget_name_by_idx_soft_crt_order_increasing);
             }
 
-            if (HDstrncmp(link_name_buf, GET_LINK_NAME_TEST_SOFT_LINK_NAME3,
-                          strlen(GET_LINK_NAME_TEST_SOFT_LINK_NAME3) + 1)) {
+            if (strncmp(link_name_buf, GET_LINK_NAME_TEST_SOFT_LINK_NAME3,
+                        strlen(GET_LINK_NAME_TEST_SOFT_LINK_NAME3) + 1)) {
                 H5_FAILED();
                 printf("    link name '%s' did not match expected name '%s'\n", link_name_buf,
                        GET_LINK_NAME_TEST_SOFT_LINK_NAME3);
@@ -17838,8 +17812,8 @@ test_get_link_name(void)
                 PART_ERROR(H5Lget_name_by_idx_soft_crt_order_increasing);
             }
 
-            if (HDstrncmp(link_name_buf, GET_LINK_NAME_TEST_SOFT_LINK_NAME2,
-                          strlen(GET_LINK_NAME_TEST_SOFT_LINK_NAME2) + 1)) {
+            if (strncmp(link_name_buf, GET_LINK_NAME_TEST_SOFT_LINK_NAME2,
+                        strlen(GET_LINK_NAME_TEST_SOFT_LINK_NAME2) + 1)) {
                 H5_FAILED();
                 printf("    link name '%s' did not match expected name '%s'\n", link_name_buf,
                        GET_LINK_NAME_TEST_SOFT_LINK_NAME2);
@@ -17860,8 +17834,8 @@ test_get_link_name(void)
                 PART_ERROR(H5Lget_name_by_idx_soft_crt_order_increasing);
             }
 
-            if (HDstrncmp(link_name_buf, GET_LINK_NAME_TEST_SOFT_LINK_NAME,
-                          strlen(GET_LINK_NAME_TEST_SOFT_LINK_NAME) + 1)) {
+            if (strncmp(link_name_buf, GET_LINK_NAME_TEST_SOFT_LINK_NAME,
+                        strlen(GET_LINK_NAME_TEST_SOFT_LINK_NAME) + 1)) {
                 H5_FAILED();
                 printf("    link name '%s' did not match expected name '%s'\n", link_name_buf,
                        GET_LINK_NAME_TEST_SOFT_LINK_NAME);
@@ -17984,8 +17958,8 @@ test_get_link_name(void)
                 PART_ERROR(H5Lget_name_by_idx_soft_crt_order_decreasing);
             }
 
-            if (HDstrncmp(link_name_buf, GET_LINK_NAME_TEST_SOFT_LINK_NAME,
-                          strlen(GET_LINK_NAME_TEST_SOFT_LINK_NAME) + 1)) {
+            if (strncmp(link_name_buf, GET_LINK_NAME_TEST_SOFT_LINK_NAME,
+                        strlen(GET_LINK_NAME_TEST_SOFT_LINK_NAME) + 1)) {
                 H5_FAILED();
                 printf("    link name '%s' did not match expected name '%s'\n", link_name_buf,
                        GET_LINK_NAME_TEST_SOFT_LINK_NAME);
@@ -18006,8 +17980,8 @@ test_get_link_name(void)
                 PART_ERROR(H5Lget_name_by_idx_soft_crt_order_decreasing);
             }
 
-            if (HDstrncmp(link_name_buf, GET_LINK_NAME_TEST_SOFT_LINK_NAME2,
-                          strlen(GET_LINK_NAME_TEST_SOFT_LINK_NAME2) + 1)) {
+            if (strncmp(link_name_buf, GET_LINK_NAME_TEST_SOFT_LINK_NAME2,
+                        strlen(GET_LINK_NAME_TEST_SOFT_LINK_NAME2) + 1)) {
                 H5_FAILED();
                 printf("    link name '%s' did not match expected name '%s'\n", link_name_buf,
                        GET_LINK_NAME_TEST_SOFT_LINK_NAME2);
@@ -18028,8 +18002,8 @@ test_get_link_name(void)
                 PART_ERROR(H5Lget_name_by_idx_soft_crt_order_decreasing);
             }
 
-            if (HDstrncmp(link_name_buf, GET_LINK_NAME_TEST_SOFT_LINK_NAME3,
-                          strlen(GET_LINK_NAME_TEST_SOFT_LINK_NAME3) + 1)) {
+            if (strncmp(link_name_buf, GET_LINK_NAME_TEST_SOFT_LINK_NAME3,
+                        strlen(GET_LINK_NAME_TEST_SOFT_LINK_NAME3) + 1)) {
                 H5_FAILED();
                 printf("    link name '%s' did not match expected name '%s'\n", link_name_buf,
                        GET_LINK_NAME_TEST_SOFT_LINK_NAME3);
@@ -18146,8 +18120,8 @@ test_get_link_name(void)
                 PART_ERROR(H5Lget_name_by_idx_soft_name_order_increasing);
             }
 
-            if (HDstrncmp(link_name_buf, GET_LINK_NAME_TEST_SOFT_LINK_NAME,
-                          strlen(GET_LINK_NAME_TEST_SOFT_LINK_NAME) + 1)) {
+            if (strncmp(link_name_buf, GET_LINK_NAME_TEST_SOFT_LINK_NAME,
+                        strlen(GET_LINK_NAME_TEST_SOFT_LINK_NAME) + 1)) {
                 H5_FAILED();
                 printf("    link name '%s' did not match expected name '%s'\n", link_name_buf,
                        GET_LINK_NAME_TEST_SOFT_LINK_NAME);
@@ -18168,8 +18142,8 @@ test_get_link_name(void)
                 PART_ERROR(H5Lget_name_by_idx_soft_name_order_increasing);
             }
 
-            if (HDstrncmp(link_name_buf, GET_LINK_NAME_TEST_SOFT_LINK_NAME2,
-                          strlen(GET_LINK_NAME_TEST_SOFT_LINK_NAME2) + 1)) {
+            if (strncmp(link_name_buf, GET_LINK_NAME_TEST_SOFT_LINK_NAME2,
+                        strlen(GET_LINK_NAME_TEST_SOFT_LINK_NAME2) + 1)) {
                 H5_FAILED();
                 printf("    link name '%s' did not match expected name '%s'\n", link_name_buf,
                        GET_LINK_NAME_TEST_SOFT_LINK_NAME2);
@@ -18190,8 +18164,8 @@ test_get_link_name(void)
                 PART_ERROR(H5Lget_name_by_idx_soft_name_order_increasing);
             }
 
-            if (HDstrncmp(link_name_buf, GET_LINK_NAME_TEST_SOFT_LINK_NAME3,
-                          strlen(GET_LINK_NAME_TEST_SOFT_LINK_NAME3) + 1)) {
+            if (strncmp(link_name_buf, GET_LINK_NAME_TEST_SOFT_LINK_NAME3,
+                        strlen(GET_LINK_NAME_TEST_SOFT_LINK_NAME3) + 1)) {
                 H5_FAILED();
                 printf("    link name '%s' did not match expected name '%s'\n", link_name_buf,
                        GET_LINK_NAME_TEST_SOFT_LINK_NAME3);
@@ -18308,8 +18282,8 @@ test_get_link_name(void)
                 PART_ERROR(H5Lget_name_by_idx_soft_name_order_decreasing);
             }
 
-            if (HDstrncmp(link_name_buf, GET_LINK_NAME_TEST_SOFT_LINK_NAME3,
-                          strlen(GET_LINK_NAME_TEST_SOFT_LINK_NAME3) + 1)) {
+            if (strncmp(link_name_buf, GET_LINK_NAME_TEST_SOFT_LINK_NAME3,
+                        strlen(GET_LINK_NAME_TEST_SOFT_LINK_NAME3) + 1)) {
                 H5_FAILED();
                 printf("    link name '%s' did not match expected name '%s'\n", link_name_buf,
                        GET_LINK_NAME_TEST_SOFT_LINK_NAME3);
@@ -18330,8 +18304,8 @@ test_get_link_name(void)
                 PART_ERROR(H5Lget_name_by_idx_soft_name_order_decreasing);
             }
 
-            if (HDstrncmp(link_name_buf, GET_LINK_NAME_TEST_SOFT_LINK_NAME2,
-                          strlen(GET_LINK_NAME_TEST_SOFT_LINK_NAME2) + 1)) {
+            if (strncmp(link_name_buf, GET_LINK_NAME_TEST_SOFT_LINK_NAME2,
+                        strlen(GET_LINK_NAME_TEST_SOFT_LINK_NAME2) + 1)) {
                 H5_FAILED();
                 printf("    link name '%s' did not match expected name '%s'\n", link_name_buf,
                        GET_LINK_NAME_TEST_SOFT_LINK_NAME2);
@@ -18352,8 +18326,8 @@ test_get_link_name(void)
                 PART_ERROR(H5Lget_name_by_idx_soft_name_order_decreasing);
             }
 
-            if (HDstrncmp(link_name_buf, GET_LINK_NAME_TEST_SOFT_LINK_NAME,
-                          strlen(GET_LINK_NAME_TEST_SOFT_LINK_NAME) + 1)) {
+            if (strncmp(link_name_buf, GET_LINK_NAME_TEST_SOFT_LINK_NAME,
+                        strlen(GET_LINK_NAME_TEST_SOFT_LINK_NAME) + 1)) {
                 H5_FAILED();
                 printf("    link name '%s' did not match expected name '%s'\n", link_name_buf,
                        GET_LINK_NAME_TEST_SOFT_LINK_NAME);
@@ -18388,8 +18362,7 @@ test_get_link_name(void)
             }
 
             /* Create file for external link to reference */
-            HDsnprintf(ext_link_filename, H5_API_TEST_FILENAME_MAX_LENGTH, "%s",
-                       EXTERNAL_LINK_TEST_FILE_NAME);
+            snprintf(ext_link_filename, H5_API_TEST_FILENAME_MAX_LENGTH, "%s", EXTERNAL_LINK_TEST_FILE_NAME);
 
             if ((ext_file_id = H5Fcreate(ext_link_filename, H5F_ACC_TRUNC, H5P_DEFAULT, H5P_DEFAULT)) < 0) {
                 H5_FAILED();
@@ -18495,8 +18468,8 @@ test_get_link_name(void)
                 PART_ERROR(H5Lget_name_by_idx_external_crt_order_increasing);
             }
 
-            if (HDstrncmp(link_name_buf, GET_LINK_NAME_TEST_EXTERNAL_LINK_NAME3,
-                          strlen(GET_LINK_NAME_TEST_EXTERNAL_LINK_NAME3) + 1)) {
+            if (strncmp(link_name_buf, GET_LINK_NAME_TEST_EXTERNAL_LINK_NAME3,
+                        strlen(GET_LINK_NAME_TEST_EXTERNAL_LINK_NAME3) + 1)) {
                 H5_FAILED();
                 printf("    link name '%s' did not match expected name '%s'\n", link_name_buf,
                        GET_LINK_NAME_TEST_EXTERNAL_LINK_NAME3);
@@ -18517,8 +18490,8 @@ test_get_link_name(void)
                 PART_ERROR(H5Lget_name_by_idx_external_crt_order_increasing);
             }
 
-            if (HDstrncmp(link_name_buf, GET_LINK_NAME_TEST_EXTERNAL_LINK_NAME2,
-                          strlen(GET_LINK_NAME_TEST_EXTERNAL_LINK_NAME2) + 1)) {
+            if (strncmp(link_name_buf, GET_LINK_NAME_TEST_EXTERNAL_LINK_NAME2,
+                        strlen(GET_LINK_NAME_TEST_EXTERNAL_LINK_NAME2) + 1)) {
                 H5_FAILED();
                 printf("    link name '%s' did not match expected name '%s'\n", link_name_buf,
                        GET_LINK_NAME_TEST_EXTERNAL_LINK_NAME2);
@@ -18539,8 +18512,8 @@ test_get_link_name(void)
                 PART_ERROR(H5Lget_name_by_idx_external_crt_order_increasing);
             }
 
-            if (HDstrncmp(link_name_buf, GET_LINK_NAME_TEST_EXTERNAL_LINK_NAME,
-                          strlen(GET_LINK_NAME_TEST_EXTERNAL_LINK_NAME) + 1)) {
+            if (strncmp(link_name_buf, GET_LINK_NAME_TEST_EXTERNAL_LINK_NAME,
+                        strlen(GET_LINK_NAME_TEST_EXTERNAL_LINK_NAME) + 1)) {
                 H5_FAILED();
                 printf("    link name '%s' did not match expected name '%s'\n", link_name_buf,
                        GET_LINK_NAME_TEST_EXTERNAL_LINK_NAME);
@@ -18577,8 +18550,7 @@ test_get_link_name(void)
             }
 
             /* Create file for external link to reference */
-            HDsnprintf(ext_link_filename, H5_API_TEST_FILENAME_MAX_LENGTH, "%s",
-                       EXTERNAL_LINK_TEST_FILE_NAME);
+            snprintf(ext_link_filename, H5_API_TEST_FILENAME_MAX_LENGTH, "%s", EXTERNAL_LINK_TEST_FILE_NAME);
 
             if ((ext_file_id = H5Fcreate(ext_link_filename, H5F_ACC_TRUNC, H5P_DEFAULT, H5P_DEFAULT)) < 0) {
                 H5_FAILED();
@@ -18684,8 +18656,8 @@ test_get_link_name(void)
                 PART_ERROR(H5Lget_name_by_idx_external_crt_order_decreasing);
             }
 
-            if (HDstrncmp(link_name_buf, GET_LINK_NAME_TEST_EXTERNAL_LINK_NAME,
-                          strlen(GET_LINK_NAME_TEST_EXTERNAL_LINK_NAME) + 1)) {
+            if (strncmp(link_name_buf, GET_LINK_NAME_TEST_EXTERNAL_LINK_NAME,
+                        strlen(GET_LINK_NAME_TEST_EXTERNAL_LINK_NAME) + 1)) {
                 H5_FAILED();
                 printf("    link name '%s' did not match expected name '%s'\n", link_name_buf,
                        GET_LINK_NAME_TEST_EXTERNAL_LINK_NAME);
@@ -18706,8 +18678,8 @@ test_get_link_name(void)
                 PART_ERROR(H5Lget_name_by_idx_external_crt_order_decreasing);
             }
 
-            if (HDstrncmp(link_name_buf, GET_LINK_NAME_TEST_EXTERNAL_LINK_NAME2,
-                          strlen(GET_LINK_NAME_TEST_EXTERNAL_LINK_NAME2) + 1)) {
+            if (strncmp(link_name_buf, GET_LINK_NAME_TEST_EXTERNAL_LINK_NAME2,
+                        strlen(GET_LINK_NAME_TEST_EXTERNAL_LINK_NAME2) + 1)) {
                 H5_FAILED();
                 printf("    link name '%s' did not match expected name '%s'\n", link_name_buf,
                        GET_LINK_NAME_TEST_EXTERNAL_LINK_NAME2);
@@ -18728,8 +18700,8 @@ test_get_link_name(void)
                 PART_ERROR(H5Lget_name_by_idx_external_crt_order_decreasing);
             }
 
-            if (HDstrncmp(link_name_buf, GET_LINK_NAME_TEST_EXTERNAL_LINK_NAME3,
-                          strlen(GET_LINK_NAME_TEST_EXTERNAL_LINK_NAME3) + 1)) {
+            if (strncmp(link_name_buf, GET_LINK_NAME_TEST_EXTERNAL_LINK_NAME3,
+                        strlen(GET_LINK_NAME_TEST_EXTERNAL_LINK_NAME3) + 1)) {
                 H5_FAILED();
                 printf("    link name '%s' did not match expected name '%s'\n", link_name_buf,
                        GET_LINK_NAME_TEST_EXTERNAL_LINK_NAME3);
@@ -18760,8 +18732,7 @@ test_get_link_name(void)
             TESTING_2("H5Lget_name_by_idx on external link by alphabetical order in increasing order");
 
             /* Create file for external link to reference */
-            HDsnprintf(ext_link_filename, H5_API_TEST_FILENAME_MAX_LENGTH, "%s",
-                       EXTERNAL_LINK_TEST_FILE_NAME);
+            snprintf(ext_link_filename, H5_API_TEST_FILENAME_MAX_LENGTH, "%s", EXTERNAL_LINK_TEST_FILE_NAME);
 
             if ((ext_file_id = H5Fcreate(ext_link_filename, H5F_ACC_TRUNC, H5P_DEFAULT, H5P_DEFAULT)) < 0) {
                 H5_FAILED();
@@ -18867,8 +18838,8 @@ test_get_link_name(void)
                 PART_ERROR(H5Lget_name_by_idx_external_name_order_increasing);
             }
 
-            if (HDstrncmp(link_name_buf, GET_LINK_NAME_TEST_EXTERNAL_LINK_NAME,
-                          strlen(GET_LINK_NAME_TEST_EXTERNAL_LINK_NAME) + 1)) {
+            if (strncmp(link_name_buf, GET_LINK_NAME_TEST_EXTERNAL_LINK_NAME,
+                        strlen(GET_LINK_NAME_TEST_EXTERNAL_LINK_NAME) + 1)) {
                 H5_FAILED();
                 printf("    link name '%s' did not match expected name '%s'\n", link_name_buf,
                        GET_LINK_NAME_TEST_EXTERNAL_LINK_NAME);
@@ -18889,8 +18860,8 @@ test_get_link_name(void)
                 PART_ERROR(H5Lget_name_by_idx_external_name_order_increasing);
             }
 
-            if (HDstrncmp(link_name_buf, GET_LINK_NAME_TEST_EXTERNAL_LINK_NAME2,
-                          strlen(GET_LINK_NAME_TEST_EXTERNAL_LINK_NAME2) + 1)) {
+            if (strncmp(link_name_buf, GET_LINK_NAME_TEST_EXTERNAL_LINK_NAME2,
+                        strlen(GET_LINK_NAME_TEST_EXTERNAL_LINK_NAME2) + 1)) {
                 H5_FAILED();
                 printf("    link name '%s' did not match expected name '%s'\n", link_name_buf,
                        GET_LINK_NAME_TEST_EXTERNAL_LINK_NAME2);
@@ -18911,8 +18882,8 @@ test_get_link_name(void)
                 PART_ERROR(H5Lget_name_by_idx_external_name_order_increasing);
             }
 
-            if (HDstrncmp(link_name_buf, GET_LINK_NAME_TEST_EXTERNAL_LINK_NAME3,
-                          strlen(GET_LINK_NAME_TEST_EXTERNAL_LINK_NAME3) + 1)) {
+            if (strncmp(link_name_buf, GET_LINK_NAME_TEST_EXTERNAL_LINK_NAME3,
+                        strlen(GET_LINK_NAME_TEST_EXTERNAL_LINK_NAME3) + 1)) {
                 H5_FAILED();
                 printf("    link name '%s' did not match expected name '%s'\n", link_name_buf,
                        GET_LINK_NAME_TEST_EXTERNAL_LINK_NAME3);
@@ -18943,8 +18914,7 @@ test_get_link_name(void)
             TESTING_2("H5Lget_name_by_idx on external link by alphabetical order in decreasing order");
 
             /* Create file for external link to reference */
-            HDsnprintf(ext_link_filename, H5_API_TEST_FILENAME_MAX_LENGTH, "%s",
-                       EXTERNAL_LINK_TEST_FILE_NAME);
+            snprintf(ext_link_filename, H5_API_TEST_FILENAME_MAX_LENGTH, "%s", EXTERNAL_LINK_TEST_FILE_NAME);
 
             if ((ext_file_id = H5Fcreate(ext_link_filename, H5F_ACC_TRUNC, H5P_DEFAULT, H5P_DEFAULT)) < 0) {
                 H5_FAILED();
@@ -19050,8 +19020,8 @@ test_get_link_name(void)
                 PART_ERROR(H5Lget_name_by_idx_external_name_order_decreasing);
             }
 
-            if (HDstrncmp(link_name_buf, GET_LINK_NAME_TEST_EXTERNAL_LINK_NAME3,
-                          strlen(GET_LINK_NAME_TEST_EXTERNAL_LINK_NAME3) + 1)) {
+            if (strncmp(link_name_buf, GET_LINK_NAME_TEST_EXTERNAL_LINK_NAME3,
+                        strlen(GET_LINK_NAME_TEST_EXTERNAL_LINK_NAME3) + 1)) {
                 H5_FAILED();
                 printf("    link name '%s' did not match expected name '%s'\n", link_name_buf,
                        GET_LINK_NAME_TEST_EXTERNAL_LINK_NAME3);
@@ -19072,8 +19042,8 @@ test_get_link_name(void)
                 PART_ERROR(H5Lget_name_by_idx_external_name_order_decreasing);
             }
 
-            if (HDstrncmp(link_name_buf, GET_LINK_NAME_TEST_EXTERNAL_LINK_NAME2,
-                          strlen(GET_LINK_NAME_TEST_EXTERNAL_LINK_NAME2) + 1)) {
+            if (strncmp(link_name_buf, GET_LINK_NAME_TEST_EXTERNAL_LINK_NAME2,
+                        strlen(GET_LINK_NAME_TEST_EXTERNAL_LINK_NAME2) + 1)) {
                 H5_FAILED();
                 printf("    link name '%s' did not match expected name '%s'\n", link_name_buf,
                        GET_LINK_NAME_TEST_EXTERNAL_LINK_NAME2);
@@ -19094,8 +19064,8 @@ test_get_link_name(void)
                 PART_ERROR(H5Lget_name_by_idx_external_name_order_decreasing);
             }
 
-            if (HDstrncmp(link_name_buf, GET_LINK_NAME_TEST_EXTERNAL_LINK_NAME,
-                          strlen(GET_LINK_NAME_TEST_EXTERNAL_LINK_NAME) + 1)) {
+            if (strncmp(link_name_buf, GET_LINK_NAME_TEST_EXTERNAL_LINK_NAME,
+                        strlen(GET_LINK_NAME_TEST_EXTERNAL_LINK_NAME) + 1)) {
                 H5_FAILED();
                 printf("    link name '%s' did not match expected name '%s'\n", link_name_buf,
                        GET_LINK_NAME_TEST_EXTERNAL_LINK_NAME);
@@ -19565,8 +19535,8 @@ test_link_iterate_hard_links(void)
         char dset_name[LINK_ITER_HARD_LINKS_TEST_BUF_SIZE];
 
         /* Create the datasets with a reverse-ordering naming scheme to test creation order later */
-        HDsnprintf(dset_name, LINK_ITER_HARD_LINKS_TEST_BUF_SIZE, LINK_ITER_HARD_LINKS_TEST_LINK_NAME "%d",
-                   (int)(LINK_ITER_HARD_LINKS_TEST_NUM_LINKS - i - 1));
+        snprintf(dset_name, LINK_ITER_HARD_LINKS_TEST_BUF_SIZE, LINK_ITER_HARD_LINKS_TEST_LINK_NAME "%d",
+                 (int)(LINK_ITER_HARD_LINKS_TEST_NUM_LINKS - i - 1));
 
         if ((dset_id = H5Dcreate2(group_id, dset_name, dset_dtype, dset_dspace, H5P_DEFAULT, H5P_DEFAULT,
                                   H5P_DEFAULT)) < 0) {
@@ -19929,11 +19899,11 @@ test_link_iterate_soft_links(void)
         char link_target[LINK_ITER_SOFT_LINKS_TEST_BUF_SIZE];
 
         /* Create the links with a reverse-ordering naming scheme to test creation order later */
-        HDsnprintf(link_name, LINK_ITER_SOFT_LINKS_TEST_BUF_SIZE, LINK_ITER_SOFT_LINKS_TEST_LINK_NAME "%d",
-                   (int)(LINK_ITER_SOFT_LINKS_TEST_NUM_LINKS - i - 1));
+        snprintf(link_name, LINK_ITER_SOFT_LINKS_TEST_BUF_SIZE, LINK_ITER_SOFT_LINKS_TEST_LINK_NAME "%d",
+                 (int)(LINK_ITER_SOFT_LINKS_TEST_NUM_LINKS - i - 1));
 
-        HDsnprintf(link_target, LINK_ITER_SOFT_LINKS_TEST_BUF_SIZE, "target%d",
-                   (int)(LINK_ITER_SOFT_LINKS_TEST_NUM_LINKS - i - 1));
+        snprintf(link_target, LINK_ITER_SOFT_LINKS_TEST_BUF_SIZE, "target%d",
+                 (int)(LINK_ITER_SOFT_LINKS_TEST_NUM_LINKS - i - 1));
 
         if (H5Lcreate_soft(link_target, group_id, link_name, H5P_DEFAULT, H5P_DEFAULT) < 0) {
             H5_FAILED();
@@ -20245,7 +20215,7 @@ test_link_iterate_external_links(void)
 
     TESTING_2("test setup");
 
-    HDsnprintf(ext_link_filename, H5_API_TEST_FILENAME_MAX_LENGTH, "%s", EXTERNAL_LINK_TEST_FILE_NAME);
+    snprintf(ext_link_filename, H5_API_TEST_FILENAME_MAX_LENGTH, "%s", EXTERNAL_LINK_TEST_FILE_NAME);
 
     if ((file_id = H5Fcreate(ext_link_filename, H5F_ACC_TRUNC, H5P_DEFAULT, H5P_DEFAULT)) < 0) {
         H5_FAILED();
@@ -20293,8 +20263,8 @@ test_link_iterate_external_links(void)
         char link_name[LINK_ITER_EXT_LINKS_TEST_BUF_SIZE];
 
         /* Create the links with a reverse-ordering naming scheme to test creation order later */
-        HDsnprintf(link_name, LINK_ITER_EXT_LINKS_TEST_BUF_SIZE, LINK_ITER_EXT_LINKS_TEST_LINK_NAME "%d",
-                   (int)(LINK_ITER_EXT_LINKS_TEST_NUM_LINKS - i - 1));
+        snprintf(link_name, LINK_ITER_EXT_LINKS_TEST_BUF_SIZE, LINK_ITER_EXT_LINKS_TEST_LINK_NAME "%d",
+                 (int)(LINK_ITER_EXT_LINKS_TEST_NUM_LINKS - i - 1));
 
         if (H5Lcreate_external(ext_link_filename, "/", group_id, link_name, H5P_DEFAULT, H5P_DEFAULT) < 0) {
             H5_FAILED();
@@ -20642,7 +20612,7 @@ test_link_iterate_mixed_links(void)
 
     TESTING_2("test setup");
 
-    HDsnprintf(ext_link_filename, H5_API_TEST_FILENAME_MAX_LENGTH, "%s", EXTERNAL_LINK_TEST_FILE_NAME);
+    snprintf(ext_link_filename, H5_API_TEST_FILENAME_MAX_LENGTH, "%s", EXTERNAL_LINK_TEST_FILE_NAME);
 
     if ((file_id = H5Fcreate(ext_link_filename, H5F_ACC_TRUNC, H5P_DEFAULT, H5P_DEFAULT)) < 0) {
         H5_FAILED();
@@ -21128,7 +21098,7 @@ test_link_iterate_invalid_params(void)
 
     TESTING_2("test setup");
 
-    HDsnprintf(ext_link_filename, H5_API_TEST_FILENAME_MAX_LENGTH, "%s", EXTERNAL_LINK_TEST_FILE_NAME);
+    snprintf(ext_link_filename, H5_API_TEST_FILENAME_MAX_LENGTH, "%s", EXTERNAL_LINK_TEST_FILE_NAME);
 
     if ((file_id = H5Fcreate(ext_link_filename, H5F_ACC_TRUNC, H5P_DEFAULT, H5P_DEFAULT)) < 0) {
         H5_FAILED();
@@ -21822,9 +21792,9 @@ test_link_visit_hard_links_no_cycles(void)
         char   grp_name[LINK_VISIT_HARD_LINKS_NO_CYCLE_TEST_BUF_SIZE];
 
         /* Create the groups with a reverse-ordering naming scheme to test creation order later */
-        HDsnprintf(grp_name, LINK_VISIT_HARD_LINKS_NO_CYCLE_TEST_BUF_SIZE,
-                   LINK_VISIT_HARD_LINKS_NO_CYCLE_TEST_NESTED_GRP_NAME "%d",
-                   (int)(LINK_VISIT_HARD_LINKS_NO_CYCLE_TEST_NUM_SUBGROUPS - i - 1));
+        snprintf(grp_name, LINK_VISIT_HARD_LINKS_NO_CYCLE_TEST_BUF_SIZE,
+                 LINK_VISIT_HARD_LINKS_NO_CYCLE_TEST_NESTED_GRP_NAME "%d",
+                 (int)(LINK_VISIT_HARD_LINKS_NO_CYCLE_TEST_NUM_SUBGROUPS - i - 1));
 
         if ((subgroup_id = H5Gcreate2(group_id, grp_name, H5P_DEFAULT, gcpl_id, H5P_DEFAULT)) < 0) {
             H5_FAILED();
@@ -21836,9 +21806,9 @@ test_link_visit_hard_links_no_cycles(void)
             char dset_name[LINK_VISIT_HARD_LINKS_NO_CYCLE_TEST_BUF_SIZE];
 
             /* Create the datasets with a reverse-ordering naming scheme to test creation order later */
-            HDsnprintf(dset_name, LINK_VISIT_HARD_LINKS_NO_CYCLE_TEST_BUF_SIZE,
-                       LINK_VISIT_HARD_LINKS_NO_CYCLE_TEST_LINK_NAME "%d",
-                       (int)(LINK_VISIT_HARD_LINKS_NO_CYCLE_TEST_NUM_LINKS_PER_GROUP - j - 1));
+            snprintf(dset_name, LINK_VISIT_HARD_LINKS_NO_CYCLE_TEST_BUF_SIZE,
+                     LINK_VISIT_HARD_LINKS_NO_CYCLE_TEST_LINK_NAME "%d",
+                     (int)(LINK_VISIT_HARD_LINKS_NO_CYCLE_TEST_NUM_LINKS_PER_GROUP - j - 1));
 
             if ((dset_id = H5Dcreate2(subgroup_id, dset_name, dset_dtype, dset_dspace, H5P_DEFAULT,
                                       H5P_DEFAULT, H5P_DEFAULT)) < 0) {
@@ -22213,9 +22183,9 @@ test_link_visit_soft_links_no_cycles(void)
         char   grp_name[LINK_VISIT_SOFT_LINKS_NO_CYCLE_TEST_BUF_SIZE];
 
         /* Create the groups with a reverse-ordering naming scheme to test creation order later */
-        HDsnprintf(grp_name, LINK_VISIT_SOFT_LINKS_NO_CYCLE_TEST_BUF_SIZE,
-                   LINK_VISIT_SOFT_LINKS_NO_CYCLE_TEST_NESTED_GRP_NAME "%d",
-                   (int)(LINK_VISIT_SOFT_LINKS_NO_CYCLE_TEST_NUM_SUBGROUPS - i - 1));
+        snprintf(grp_name, LINK_VISIT_SOFT_LINKS_NO_CYCLE_TEST_BUF_SIZE,
+                 LINK_VISIT_SOFT_LINKS_NO_CYCLE_TEST_NESTED_GRP_NAME "%d",
+                 (int)(LINK_VISIT_SOFT_LINKS_NO_CYCLE_TEST_NUM_SUBGROUPS - i - 1));
 
         if ((subgroup_id = H5Gcreate2(group_id, grp_name, H5P_DEFAULT, gcpl_id, H5P_DEFAULT)) < 0) {
             H5_FAILED();
@@ -22228,12 +22198,12 @@ test_link_visit_soft_links_no_cycles(void)
             char link_target[LINK_VISIT_SOFT_LINKS_NO_CYCLE_TEST_BUF_SIZE];
 
             /* Create the links with a reverse-ordering naming scheme to test creation order later */
-            HDsnprintf(link_name, LINK_VISIT_SOFT_LINKS_NO_CYCLE_TEST_BUF_SIZE,
-                       LINK_VISIT_SOFT_LINKS_NO_CYCLE_TEST_LINK_NAME "%d",
-                       (int)(LINK_VISIT_SOFT_LINKS_NO_CYCLE_TEST_NUM_LINKS_PER_GROUP - j - 1));
+            snprintf(link_name, LINK_VISIT_SOFT_LINKS_NO_CYCLE_TEST_BUF_SIZE,
+                     LINK_VISIT_SOFT_LINKS_NO_CYCLE_TEST_LINK_NAME "%d",
+                     (int)(LINK_VISIT_SOFT_LINKS_NO_CYCLE_TEST_NUM_LINKS_PER_GROUP - j - 1));
 
-            HDsnprintf(link_target, LINK_VISIT_SOFT_LINKS_NO_CYCLE_TEST_BUF_SIZE, "target%d",
-                       (int)(LINK_VISIT_SOFT_LINKS_NO_CYCLE_TEST_NUM_LINKS_PER_GROUP - j - 1));
+            snprintf(link_target, LINK_VISIT_SOFT_LINKS_NO_CYCLE_TEST_BUF_SIZE, "target%d",
+                     (int)(LINK_VISIT_SOFT_LINKS_NO_CYCLE_TEST_NUM_LINKS_PER_GROUP - j - 1));
 
             if (H5Lcreate_soft(link_target, subgroup_id, link_name, H5P_DEFAULT, H5P_DEFAULT) < 0) {
                 H5_FAILED();
@@ -22555,7 +22525,7 @@ test_link_visit_external_links_no_cycles(void)
 
     TESTING_2("test setup");
 
-    HDsnprintf(ext_link_filename, H5_API_TEST_FILENAME_MAX_LENGTH, "%s", EXTERNAL_LINK_TEST_FILE_NAME);
+    snprintf(ext_link_filename, H5_API_TEST_FILENAME_MAX_LENGTH, "%s", EXTERNAL_LINK_TEST_FILE_NAME);
 
     if ((file_id = H5Fcreate(ext_link_filename, H5F_ACC_TRUNC, H5P_DEFAULT, H5P_DEFAULT)) < 0) {
         H5_FAILED();
@@ -22605,9 +22575,9 @@ test_link_visit_external_links_no_cycles(void)
         char   grp_name[LINK_VISIT_EXT_LINKS_NO_CYCLE_TEST_BUF_SIZE];
 
         /* Create the groups with a reverse-ordering naming scheme to test creation order later */
-        HDsnprintf(grp_name, LINK_VISIT_EXT_LINKS_NO_CYCLE_TEST_BUF_SIZE,
-                   LINK_VISIT_EXT_LINKS_NO_CYCLE_TEST_NESTED_GRP_NAME "%d",
-                   (int)(LINK_VISIT_EXT_LINKS_NO_CYCLE_TEST_NUM_SUBGROUPS - i - 1));
+        snprintf(grp_name, LINK_VISIT_EXT_LINKS_NO_CYCLE_TEST_BUF_SIZE,
+                 LINK_VISIT_EXT_LINKS_NO_CYCLE_TEST_NESTED_GRP_NAME "%d",
+                 (int)(LINK_VISIT_EXT_LINKS_NO_CYCLE_TEST_NUM_SUBGROUPS - i - 1));
 
         if ((subgroup_id = H5Gcreate2(group_id, grp_name, H5P_DEFAULT, gcpl_id, H5P_DEFAULT)) < 0) {
             H5_FAILED();
@@ -22619,9 +22589,9 @@ test_link_visit_external_links_no_cycles(void)
             char link_name[LINK_VISIT_EXT_LINKS_NO_CYCLE_TEST_BUF_SIZE];
 
             /* Create the links with a reverse-ordering naming scheme to test creation order later */
-            HDsnprintf(link_name, LINK_VISIT_EXT_LINKS_NO_CYCLE_TEST_BUF_SIZE,
-                       LINK_VISIT_EXT_LINKS_NO_CYCLE_TEST_LINK_NAME "%d",
-                       (int)(LINK_VISIT_EXT_LINKS_NO_CYCLE_TEST_NUM_LINKS_PER_GROUP - j - 1));
+            snprintf(link_name, LINK_VISIT_EXT_LINKS_NO_CYCLE_TEST_BUF_SIZE,
+                     LINK_VISIT_EXT_LINKS_NO_CYCLE_TEST_LINK_NAME "%d",
+                     (int)(LINK_VISIT_EXT_LINKS_NO_CYCLE_TEST_NUM_LINKS_PER_GROUP - j - 1));
 
             if (H5Lcreate_external(ext_link_filename, "/", subgroup_id, link_name, H5P_DEFAULT, H5P_DEFAULT) <
                 0) {
@@ -22983,7 +22953,7 @@ test_link_visit_mixed_links_no_cycles(void)
 
     TESTING_2("test setup");
 
-    HDsnprintf(ext_link_filename, H5_API_TEST_FILENAME_MAX_LENGTH, "%s", EXTERNAL_LINK_TEST_FILE_NAME);
+    snprintf(ext_link_filename, H5_API_TEST_FILENAME_MAX_LENGTH, "%s", EXTERNAL_LINK_TEST_FILE_NAME);
 
     if ((file_id = H5Fcreate(ext_link_filename, H5F_ACC_TRUNC, H5P_DEFAULT, H5P_DEFAULT)) < 0) {
         H5_FAILED();
@@ -23499,9 +23469,9 @@ test_link_visit_hard_links_cycles(void)
         char   grp_name[LINK_VISIT_HARD_LINKS_CYCLE_TEST_BUF_SIZE];
 
         /* Create the groups with a reverse-ordering naming scheme to test creation order later */
-        HDsnprintf(grp_name, LINK_VISIT_HARD_LINKS_CYCLE_TEST_BUF_SIZE,
-                   LINK_VISIT_HARD_LINKS_CYCLE_TEST_NESTED_GRP_NAME "%d",
-                   (int)(LINK_VISIT_HARD_LINKS_CYCLE_TEST_NUM_SUBGROUPS - i - 1));
+        snprintf(grp_name, LINK_VISIT_HARD_LINKS_CYCLE_TEST_BUF_SIZE,
+                 LINK_VISIT_HARD_LINKS_CYCLE_TEST_NESTED_GRP_NAME "%d",
+                 (int)(LINK_VISIT_HARD_LINKS_CYCLE_TEST_NUM_SUBGROUPS - i - 1));
 
         if ((subgroup_id = H5Gcreate2(group_id, grp_name, H5P_DEFAULT, gcpl_id, H5P_DEFAULT)) < 0) {
             H5_FAILED();
@@ -23513,9 +23483,9 @@ test_link_visit_hard_links_cycles(void)
             char link_name[LINK_VISIT_HARD_LINKS_CYCLE_TEST_BUF_SIZE];
 
             /* Create the links with a reverse-ordering naming scheme to test creation order later */
-            HDsnprintf(link_name, LINK_VISIT_HARD_LINKS_CYCLE_TEST_BUF_SIZE,
-                       LINK_VISIT_HARD_LINKS_CYCLE_TEST_LINK_NAME "%d",
-                       (int)(LINK_VISIT_HARD_LINKS_CYCLE_TEST_NUM_LINKS_PER_GROUP - j - 1));
+            snprintf(link_name, LINK_VISIT_HARD_LINKS_CYCLE_TEST_BUF_SIZE,
+                     LINK_VISIT_HARD_LINKS_CYCLE_TEST_LINK_NAME "%d",
+                     (int)(LINK_VISIT_HARD_LINKS_CYCLE_TEST_NUM_LINKS_PER_GROUP - j - 1));
 
             if (H5Lcreate_hard(subgroup_id, ".", subgroup_id, link_name, H5P_DEFAULT, H5P_DEFAULT) < 0) {
                 H5_FAILED();
@@ -23872,9 +23842,9 @@ test_link_visit_soft_links_cycles(void)
         char   grp_name[LINK_VISIT_SOFT_LINKS_CYCLE_TEST_BUF_SIZE];
 
         /* Create the groups with a reverse-ordering naming scheme to test creation order later */
-        HDsnprintf(grp_name, LINK_VISIT_SOFT_LINKS_CYCLE_TEST_BUF_SIZE,
-                   LINK_VISIT_SOFT_LINKS_CYCLE_TEST_NESTED_GRP_NAME "%d",
-                   (int)(LINK_VISIT_SOFT_LINKS_CYCLE_TEST_NUM_SUBGROUPS - i - 1));
+        snprintf(grp_name, LINK_VISIT_SOFT_LINKS_CYCLE_TEST_BUF_SIZE,
+                 LINK_VISIT_SOFT_LINKS_CYCLE_TEST_NESTED_GRP_NAME "%d",
+                 (int)(LINK_VISIT_SOFT_LINKS_CYCLE_TEST_NUM_SUBGROUPS - i - 1));
 
         if ((subgroup_id = H5Gcreate2(group_id, grp_name, H5P_DEFAULT, gcpl_id, H5P_DEFAULT)) < 0) {
             H5_FAILED();
@@ -23887,13 +23857,13 @@ test_link_visit_soft_links_cycles(void)
             char link_target[2 * LINK_VISIT_SOFT_LINKS_CYCLE_TEST_BUF_SIZE];
 
             /* Create the links with a reverse-ordering naming scheme to test creation order later */
-            HDsnprintf(link_name, LINK_VISIT_SOFT_LINKS_CYCLE_TEST_BUF_SIZE,
-                       LINK_VISIT_SOFT_LINKS_CYCLE_TEST_LINK_NAME "%d",
-                       (int)(LINK_VISIT_SOFT_LINKS_CYCLE_TEST_NUM_LINKS_PER_GROUP - j - 1));
+            snprintf(link_name, LINK_VISIT_SOFT_LINKS_CYCLE_TEST_BUF_SIZE,
+                     LINK_VISIT_SOFT_LINKS_CYCLE_TEST_LINK_NAME "%d",
+                     (int)(LINK_VISIT_SOFT_LINKS_CYCLE_TEST_NUM_LINKS_PER_GROUP - j - 1));
 
-            HDsnprintf(link_target, 2 * LINK_VISIT_SOFT_LINKS_CYCLE_TEST_BUF_SIZE,
-                       "/" LINK_TEST_GROUP_NAME "/" LINK_VISIT_SOFT_LINKS_CYCLE_TEST_SUBGROUP_NAME "/%s",
-                       grp_name);
+            snprintf(link_target, 2 * LINK_VISIT_SOFT_LINKS_CYCLE_TEST_BUF_SIZE,
+                     "/" LINK_TEST_GROUP_NAME "/" LINK_VISIT_SOFT_LINKS_CYCLE_TEST_SUBGROUP_NAME "/%s",
+                     grp_name);
 
             if (H5Lcreate_soft(link_target, subgroup_id, link_name, H5P_DEFAULT, H5P_DEFAULT) < 0) {
                 H5_FAILED();
@@ -24252,9 +24222,9 @@ test_link_visit_external_links_cycles(void)
         char   grp_name[LINK_VISIT_EXT_LINKS_CYCLE_TEST_BUF_SIZE];
 
         /* Create the groups with a reverse-ordering naming scheme to test creation order later */
-        HDsnprintf(grp_name, LINK_VISIT_EXT_LINKS_CYCLE_TEST_BUF_SIZE,
-                   LINK_VISIT_EXT_LINKS_CYCLE_TEST_NESTED_GRP_NAME "%d",
-                   (int)(LINK_VISIT_EXT_LINKS_CYCLE_TEST_NUM_SUBGROUPS - i - 1));
+        snprintf(grp_name, LINK_VISIT_EXT_LINKS_CYCLE_TEST_BUF_SIZE,
+                 LINK_VISIT_EXT_LINKS_CYCLE_TEST_NESTED_GRP_NAME "%d",
+                 (int)(LINK_VISIT_EXT_LINKS_CYCLE_TEST_NUM_SUBGROUPS - i - 1));
 
         if ((subgroup_id = H5Gcreate2(group_id, grp_name, H5P_DEFAULT, gcpl_id, H5P_DEFAULT)) < 0) {
             H5_FAILED();
@@ -24267,13 +24237,13 @@ test_link_visit_external_links_cycles(void)
             char link_target_obj[2 * LINK_VISIT_EXT_LINKS_CYCLE_TEST_BUF_SIZE];
 
             /* Create the links with a reverse-ordering naming scheme to test creation order later */
-            HDsnprintf(link_name, LINK_VISIT_EXT_LINKS_CYCLE_TEST_BUF_SIZE,
-                       LINK_VISIT_EXT_LINKS_CYCLE_TEST_LINK_NAME "%d",
-                       (int)(LINK_VISIT_EXT_LINKS_CYCLE_TEST_NUM_LINKS_PER_GROUP - j - 1));
+            snprintf(link_name, LINK_VISIT_EXT_LINKS_CYCLE_TEST_BUF_SIZE,
+                     LINK_VISIT_EXT_LINKS_CYCLE_TEST_LINK_NAME "%d",
+                     (int)(LINK_VISIT_EXT_LINKS_CYCLE_TEST_NUM_LINKS_PER_GROUP - j - 1));
 
-            HDsnprintf(link_target_obj, 2 * LINK_VISIT_EXT_LINKS_CYCLE_TEST_BUF_SIZE,
-                       "/" LINK_TEST_GROUP_NAME "/" LINK_VISIT_EXT_LINKS_CYCLE_TEST_SUBGROUP_NAME "/%s",
-                       grp_name);
+            snprintf(link_target_obj, 2 * LINK_VISIT_EXT_LINKS_CYCLE_TEST_BUF_SIZE,
+                     "/" LINK_TEST_GROUP_NAME "/" LINK_VISIT_EXT_LINKS_CYCLE_TEST_SUBGROUP_NAME "/%s",
+                     grp_name);
 
             if (H5Lcreate_external(H5_api_test_filename, link_target_obj, subgroup_id, link_name, H5P_DEFAULT,
                                    H5P_DEFAULT) < 0) {
@@ -24623,7 +24593,7 @@ test_link_visit_mixed_links_cycles(void)
 
     TESTING_2("test setup");
 
-    HDsnprintf(ext_link_filename, H5_API_TEST_FILENAME_MAX_LENGTH, "%s", EXTERNAL_LINK_TEST_FILE_NAME);
+    snprintf(ext_link_filename, H5_API_TEST_FILENAME_MAX_LENGTH, "%s", EXTERNAL_LINK_TEST_FILE_NAME);
 
     if ((file_id = H5Fcreate(ext_link_filename, H5F_ACC_TRUNC, H5P_DEFAULT, H5P_DEFAULT)) < 0) {
         H5_FAILED();
@@ -25060,7 +25030,7 @@ test_link_visit_invalid_params(void)
 
     TESTING_2("test setup");
 
-    HDsnprintf(ext_link_filename, H5_API_TEST_FILENAME_MAX_LENGTH, "%s", EXTERNAL_LINK_TEST_FILE_NAME);
+    snprintf(ext_link_filename, H5_API_TEST_FILENAME_MAX_LENGTH, "%s", EXTERNAL_LINK_TEST_FILE_NAME);
 
     if ((file_id = H5Fcreate(ext_link_filename, H5F_ACC_TRUNC, H5P_DEFAULT, H5P_DEFAULT)) < 0) {
         H5_FAILED();
@@ -25761,18 +25731,18 @@ link_iter_hard_links_cb(hid_t group_id, const char *name, const H5L_info2_t *inf
      */
     test_iteration = (counter_val / LINK_ITER_HARD_LINKS_TEST_NUM_LINKS);
     if (test_iteration == 0 || test_iteration == 3) {
-        HDsnprintf(expected_link_name, LINK_ITER_HARD_LINKS_TEST_BUF_SIZE,
-                   LINK_ITER_HARD_LINKS_TEST_LINK_NAME "%d",
-                   (int)(counter_val % LINK_ITER_HARD_LINKS_TEST_NUM_LINKS));
+        snprintf(expected_link_name, LINK_ITER_HARD_LINKS_TEST_BUF_SIZE,
+                 LINK_ITER_HARD_LINKS_TEST_LINK_NAME "%d",
+                 (int)(counter_val % LINK_ITER_HARD_LINKS_TEST_NUM_LINKS));
     }
     else {
-        HDsnprintf(expected_link_name, LINK_ITER_HARD_LINKS_TEST_BUF_SIZE,
-                   LINK_ITER_HARD_LINKS_TEST_LINK_NAME "%d",
-                   (int)(LINK_ITER_HARD_LINKS_TEST_NUM_LINKS -
-                         (counter_val % LINK_ITER_HARD_LINKS_TEST_NUM_LINKS) - 1));
+        snprintf(expected_link_name, LINK_ITER_HARD_LINKS_TEST_BUF_SIZE,
+                 LINK_ITER_HARD_LINKS_TEST_LINK_NAME "%d",
+                 (int)(LINK_ITER_HARD_LINKS_TEST_NUM_LINKS -
+                       (counter_val % LINK_ITER_HARD_LINKS_TEST_NUM_LINKS) - 1));
     }
 
-    if (HDstrncmp(name, expected_link_name, LINK_ITER_HARD_LINKS_TEST_BUF_SIZE)) {
+    if (strncmp(name, expected_link_name, LINK_ITER_HARD_LINKS_TEST_BUF_SIZE)) {
         printf("    link name '%s' didn't match expected name '%s'\n", name, expected_link_name);
         ret_val = H5_ITER_ERROR;
         goto done;
@@ -25821,18 +25791,18 @@ link_iter_soft_links_cb(hid_t group_id, const char *name, const H5L_info2_t *inf
      */
     test_iteration = (counter_val / LINK_ITER_SOFT_LINKS_TEST_NUM_LINKS);
     if (test_iteration == 0 || test_iteration == 3) {
-        HDsnprintf(expected_link_name, LINK_ITER_SOFT_LINKS_TEST_BUF_SIZE,
-                   LINK_ITER_SOFT_LINKS_TEST_LINK_NAME "%d",
-                   (int)(counter_val % LINK_ITER_SOFT_LINKS_TEST_NUM_LINKS));
+        snprintf(expected_link_name, LINK_ITER_SOFT_LINKS_TEST_BUF_SIZE,
+                 LINK_ITER_SOFT_LINKS_TEST_LINK_NAME "%d",
+                 (int)(counter_val % LINK_ITER_SOFT_LINKS_TEST_NUM_LINKS));
     }
     else {
-        HDsnprintf(expected_link_name, LINK_ITER_SOFT_LINKS_TEST_BUF_SIZE,
-                   LINK_ITER_SOFT_LINKS_TEST_LINK_NAME "%d",
-                   (int)(LINK_ITER_SOFT_LINKS_TEST_NUM_LINKS -
-                         (counter_val % LINK_ITER_SOFT_LINKS_TEST_NUM_LINKS) - 1));
+        snprintf(expected_link_name, LINK_ITER_SOFT_LINKS_TEST_BUF_SIZE,
+                 LINK_ITER_SOFT_LINKS_TEST_LINK_NAME "%d",
+                 (int)(LINK_ITER_SOFT_LINKS_TEST_NUM_LINKS -
+                       (counter_val % LINK_ITER_SOFT_LINKS_TEST_NUM_LINKS) - 1));
     }
 
-    if (HDstrncmp(name, expected_link_name, LINK_ITER_SOFT_LINKS_TEST_BUF_SIZE)) {
+    if (strncmp(name, expected_link_name, LINK_ITER_SOFT_LINKS_TEST_BUF_SIZE)) {
         printf("    link name '%s' didn't match expected name '%s'\n", name, expected_link_name);
         ret_val = H5_ITER_ERROR;
         goto done;
@@ -25888,18 +25858,18 @@ link_iter_external_links_cb(hid_t group_id, const char *name, const H5L_info2_t 
      */
     test_iteration = (counter_val / LINK_ITER_EXT_LINKS_TEST_NUM_LINKS);
     if (test_iteration == 0 || test_iteration == 3) {
-        HDsnprintf(expected_link_name, LINK_ITER_EXT_LINKS_TEST_BUF_SIZE,
-                   LINK_ITER_EXT_LINKS_TEST_LINK_NAME "%d",
-                   (int)(counter_val % LINK_ITER_EXT_LINKS_TEST_NUM_LINKS));
+        snprintf(expected_link_name, LINK_ITER_EXT_LINKS_TEST_BUF_SIZE,
+                 LINK_ITER_EXT_LINKS_TEST_LINK_NAME "%d",
+                 (int)(counter_val % LINK_ITER_EXT_LINKS_TEST_NUM_LINKS));
     }
     else {
-        HDsnprintf(expected_link_name, LINK_ITER_EXT_LINKS_TEST_BUF_SIZE,
-                   LINK_ITER_EXT_LINKS_TEST_LINK_NAME "%d",
-                   (int)(LINK_ITER_EXT_LINKS_TEST_NUM_LINKS -
-                         (counter_val % LINK_ITER_EXT_LINKS_TEST_NUM_LINKS) - 1));
+        snprintf(expected_link_name, LINK_ITER_EXT_LINKS_TEST_BUF_SIZE,
+                 LINK_ITER_EXT_LINKS_TEST_LINK_NAME "%d",
+                 (int)(LINK_ITER_EXT_LINKS_TEST_NUM_LINKS -
+                       (counter_val % LINK_ITER_EXT_LINKS_TEST_NUM_LINKS) - 1));
     }
 
-    if (HDstrncmp(name, expected_link_name, LINK_ITER_EXT_LINKS_TEST_BUF_SIZE)) {
+    if (strncmp(name, expected_link_name, LINK_ITER_EXT_LINKS_TEST_BUF_SIZE)) {
         printf("    link name '%s' didn't match expected name '%s'\n", name, expected_link_name);
         ret_val = H5_ITER_ERROR;
         goto done;
@@ -25932,8 +25902,8 @@ link_iter_mixed_links_cb(hid_t group_id, const char *name, const H5L_info2_t *in
 
     UNUSED(group_id);
 
-    if (!HDstrncmp(name, LINK_ITER_MIXED_LINKS_TEST_HARD_LINK_NAME,
-                   strlen(LINK_ITER_MIXED_LINKS_TEST_HARD_LINK_NAME) + 1) &&
+    if (!strncmp(name, LINK_ITER_MIXED_LINKS_TEST_HARD_LINK_NAME,
+                 strlen(LINK_ITER_MIXED_LINKS_TEST_HARD_LINK_NAME) + 1) &&
         (counter_val == 1 || counter_val == 4 || counter_val == 6 || counter_val == 11)) {
         if (H5L_TYPE_HARD != info->type) {
             ret_val = -1;
@@ -25942,8 +25912,8 @@ link_iter_mixed_links_cb(hid_t group_id, const char *name, const H5L_info2_t *in
 
         goto done;
     }
-    else if (!HDstrncmp(name, LINK_ITER_MIXED_LINKS_TEST_SOFT_LINK_NAME,
-                        strlen(LINK_ITER_MIXED_LINKS_TEST_SOFT_LINK_NAME) + 1) &&
+    else if (!strncmp(name, LINK_ITER_MIXED_LINKS_TEST_SOFT_LINK_NAME,
+                      strlen(LINK_ITER_MIXED_LINKS_TEST_SOFT_LINK_NAME) + 1) &&
              (counter_val == 2 || counter_val == 3 || counter_val == 7 || counter_val == 10)) {
         if (H5L_TYPE_SOFT != info->type) {
             ret_val = -1;
@@ -25952,8 +25922,8 @@ link_iter_mixed_links_cb(hid_t group_id, const char *name, const H5L_info2_t *in
 
         goto done;
     }
-    else if (!HDstrncmp(name, LINK_ITER_MIXED_LINKS_TEST_EXT_LINK_NAME,
-                        strlen(LINK_ITER_MIXED_LINKS_TEST_EXT_LINK_NAME) + 1) &&
+    else if (!strncmp(name, LINK_ITER_MIXED_LINKS_TEST_EXT_LINK_NAME,
+                      strlen(LINK_ITER_MIXED_LINKS_TEST_EXT_LINK_NAME) + 1) &&
              (counter_val == 0 || counter_val == 5 || counter_val == 8 || counter_val == 9)) {
         if (H5L_TYPE_EXTERNAL != info->type) {
             ret_val = -1;
@@ -26022,29 +25992,29 @@ link_iter_idx_saving_cb(hid_t group_id, const char *name, const H5L_info2_t *inf
     UNUSED(group_id);
 
     if (broken && !*broken &&
-        !HDstrncmp(name, LINK_ITER_MIXED_LINKS_TEST_SOFT_LINK_NAME,
-                   strlen(LINK_ITER_MIXED_LINKS_TEST_SOFT_LINK_NAME) + 1)) {
+        !strncmp(name, LINK_ITER_MIXED_LINKS_TEST_SOFT_LINK_NAME,
+                 strlen(LINK_ITER_MIXED_LINKS_TEST_SOFT_LINK_NAME) + 1)) {
         return (*broken = 1);
     }
 
-    if (!HDstrncmp(name, LINK_ITER_MIXED_LINKS_TEST_HARD_LINK_NAME,
-                   strlen(LINK_ITER_MIXED_LINKS_TEST_HARD_LINK_NAME) + 1)) {
+    if (!strncmp(name, LINK_ITER_MIXED_LINKS_TEST_HARD_LINK_NAME,
+                 strlen(LINK_ITER_MIXED_LINKS_TEST_HARD_LINK_NAME) + 1)) {
         if (H5L_TYPE_HARD != info->type) {
             H5_FAILED();
             printf("    link type did not match\n");
             goto error;
         }
     }
-    else if (!HDstrncmp(name, LINK_ITER_MIXED_LINKS_TEST_SOFT_LINK_NAME,
-                        strlen(LINK_ITER_MIXED_LINKS_TEST_SOFT_LINK_NAME) + 1)) {
+    else if (!strncmp(name, LINK_ITER_MIXED_LINKS_TEST_SOFT_LINK_NAME,
+                      strlen(LINK_ITER_MIXED_LINKS_TEST_SOFT_LINK_NAME) + 1)) {
         if (H5L_TYPE_SOFT != info->type) {
             H5_FAILED();
             printf("    link type did not match\n");
             goto error;
         }
     }
-    else if (!HDstrncmp(name, LINK_ITER_MIXED_LINKS_TEST_EXT_LINK_NAME,
-                        strlen(LINK_ITER_MIXED_LINKS_TEST_EXT_LINK_NAME) + 1)) {
+    else if (!strncmp(name, LINK_ITER_MIXED_LINKS_TEST_EXT_LINK_NAME,
+                      strlen(LINK_ITER_MIXED_LINKS_TEST_EXT_LINK_NAME) + 1)) {
         if (H5L_TYPE_EXTERNAL != info->type) {
             H5_FAILED();
             printf("    link type did not match\n");
@@ -26127,34 +26097,34 @@ link_visit_hard_links_no_cycles_cb(hid_t group_id, const char *name, const H5L_i
 
     if (test_iteration == 0 || test_iteration == 3) {
         if (is_subgroup_link) {
-            HDsnprintf(expected_link_name, LINK_VISIT_HARD_LINKS_NO_CYCLE_TEST_BUF_SIZE,
-                       LINK_VISIT_HARD_LINKS_NO_CYCLE_TEST_NESTED_GRP_NAME "%d", (int)subgroup_number);
+            snprintf(expected_link_name, LINK_VISIT_HARD_LINKS_NO_CYCLE_TEST_BUF_SIZE,
+                     LINK_VISIT_HARD_LINKS_NO_CYCLE_TEST_NESTED_GRP_NAME "%d", (int)subgroup_number);
         }
         else {
-            HDsnprintf(expected_link_name, LINK_VISIT_HARD_LINKS_NO_CYCLE_TEST_BUF_SIZE,
-                       LINK_VISIT_HARD_LINKS_NO_CYCLE_TEST_NESTED_GRP_NAME
-                       "%d"
-                       "/" LINK_VISIT_HARD_LINKS_NO_CYCLE_TEST_LINK_NAME "%d",
-                       (int)subgroup_number, (int)link_idx_val);
+            snprintf(expected_link_name, LINK_VISIT_HARD_LINKS_NO_CYCLE_TEST_BUF_SIZE,
+                     LINK_VISIT_HARD_LINKS_NO_CYCLE_TEST_NESTED_GRP_NAME
+                     "%d"
+                     "/" LINK_VISIT_HARD_LINKS_NO_CYCLE_TEST_LINK_NAME "%d",
+                     (int)subgroup_number, (int)link_idx_val);
         }
     }
     else {
         if (is_subgroup_link) {
-            HDsnprintf(expected_link_name, LINK_VISIT_HARD_LINKS_NO_CYCLE_TEST_BUF_SIZE,
-                       LINK_VISIT_HARD_LINKS_NO_CYCLE_TEST_NESTED_GRP_NAME "%d",
-                       (int)(LINK_VISIT_HARD_LINKS_NO_CYCLE_TEST_NUM_SUBGROUPS - subgroup_number - 1));
+            snprintf(expected_link_name, LINK_VISIT_HARD_LINKS_NO_CYCLE_TEST_BUF_SIZE,
+                     LINK_VISIT_HARD_LINKS_NO_CYCLE_TEST_NESTED_GRP_NAME "%d",
+                     (int)(LINK_VISIT_HARD_LINKS_NO_CYCLE_TEST_NUM_SUBGROUPS - subgroup_number - 1));
         }
         else {
-            HDsnprintf(expected_link_name, LINK_VISIT_HARD_LINKS_NO_CYCLE_TEST_BUF_SIZE,
-                       LINK_VISIT_HARD_LINKS_NO_CYCLE_TEST_NESTED_GRP_NAME
-                       "%d"
-                       "/" LINK_VISIT_HARD_LINKS_NO_CYCLE_TEST_LINK_NAME "%d",
-                       (int)(LINK_VISIT_HARD_LINKS_NO_CYCLE_TEST_NUM_SUBGROUPS - subgroup_number - 1),
-                       (int)(LINK_VISIT_HARD_LINKS_NO_CYCLE_TEST_NUM_LINKS_PER_GROUP - link_idx_val - 1));
+            snprintf(expected_link_name, LINK_VISIT_HARD_LINKS_NO_CYCLE_TEST_BUF_SIZE,
+                     LINK_VISIT_HARD_LINKS_NO_CYCLE_TEST_NESTED_GRP_NAME
+                     "%d"
+                     "/" LINK_VISIT_HARD_LINKS_NO_CYCLE_TEST_LINK_NAME "%d",
+                     (int)(LINK_VISIT_HARD_LINKS_NO_CYCLE_TEST_NUM_SUBGROUPS - subgroup_number - 1),
+                     (int)(LINK_VISIT_HARD_LINKS_NO_CYCLE_TEST_NUM_LINKS_PER_GROUP - link_idx_val - 1));
         }
     }
 
-    if (HDstrncmp(name, expected_link_name, LINK_VISIT_HARD_LINKS_NO_CYCLE_TEST_BUF_SIZE)) {
+    if (strncmp(name, expected_link_name, LINK_VISIT_HARD_LINKS_NO_CYCLE_TEST_BUF_SIZE)) {
         printf("    link name '%s' didn't match expected name '%s'\n", name, expected_link_name);
         ret_val = H5_ITER_ERROR;
         goto done;
@@ -26240,34 +26210,34 @@ link_visit_soft_links_no_cycles_cb(hid_t group_id, const char *name, const H5L_i
 
     if (test_iteration == 0 || test_iteration == 3) {
         if (is_subgroup_link) {
-            HDsnprintf(expected_link_name, LINK_VISIT_SOFT_LINKS_NO_CYCLE_TEST_BUF_SIZE,
-                       LINK_VISIT_SOFT_LINKS_NO_CYCLE_TEST_NESTED_GRP_NAME "%d", (int)subgroup_number);
+            snprintf(expected_link_name, LINK_VISIT_SOFT_LINKS_NO_CYCLE_TEST_BUF_SIZE,
+                     LINK_VISIT_SOFT_LINKS_NO_CYCLE_TEST_NESTED_GRP_NAME "%d", (int)subgroup_number);
         }
         else {
-            HDsnprintf(expected_link_name, LINK_VISIT_SOFT_LINKS_NO_CYCLE_TEST_BUF_SIZE,
-                       LINK_VISIT_SOFT_LINKS_NO_CYCLE_TEST_NESTED_GRP_NAME
-                       "%d"
-                       "/" LINK_VISIT_SOFT_LINKS_NO_CYCLE_TEST_LINK_NAME "%d",
-                       (int)subgroup_number, (int)link_idx_val);
+            snprintf(expected_link_name, LINK_VISIT_SOFT_LINKS_NO_CYCLE_TEST_BUF_SIZE,
+                     LINK_VISIT_SOFT_LINKS_NO_CYCLE_TEST_NESTED_GRP_NAME
+                     "%d"
+                     "/" LINK_VISIT_SOFT_LINKS_NO_CYCLE_TEST_LINK_NAME "%d",
+                     (int)subgroup_number, (int)link_idx_val);
         }
     }
     else {
         if (is_subgroup_link) {
-            HDsnprintf(expected_link_name, LINK_VISIT_SOFT_LINKS_NO_CYCLE_TEST_BUF_SIZE,
-                       LINK_VISIT_SOFT_LINKS_NO_CYCLE_TEST_NESTED_GRP_NAME "%d",
-                       (int)(LINK_VISIT_SOFT_LINKS_NO_CYCLE_TEST_NUM_SUBGROUPS - subgroup_number - 1));
+            snprintf(expected_link_name, LINK_VISIT_SOFT_LINKS_NO_CYCLE_TEST_BUF_SIZE,
+                     LINK_VISIT_SOFT_LINKS_NO_CYCLE_TEST_NESTED_GRP_NAME "%d",
+                     (int)(LINK_VISIT_SOFT_LINKS_NO_CYCLE_TEST_NUM_SUBGROUPS - subgroup_number - 1));
         }
         else {
-            HDsnprintf(expected_link_name, LINK_VISIT_SOFT_LINKS_NO_CYCLE_TEST_BUF_SIZE,
-                       LINK_VISIT_SOFT_LINKS_NO_CYCLE_TEST_NESTED_GRP_NAME
-                       "%d"
-                       "/" LINK_VISIT_SOFT_LINKS_NO_CYCLE_TEST_LINK_NAME "%d",
-                       (int)(LINK_VISIT_SOFT_LINKS_NO_CYCLE_TEST_NUM_SUBGROUPS - subgroup_number - 1),
-                       (int)(LINK_VISIT_SOFT_LINKS_NO_CYCLE_TEST_NUM_LINKS_PER_GROUP - link_idx_val - 1));
+            snprintf(expected_link_name, LINK_VISIT_SOFT_LINKS_NO_CYCLE_TEST_BUF_SIZE,
+                     LINK_VISIT_SOFT_LINKS_NO_CYCLE_TEST_NESTED_GRP_NAME
+                     "%d"
+                     "/" LINK_VISIT_SOFT_LINKS_NO_CYCLE_TEST_LINK_NAME "%d",
+                     (int)(LINK_VISIT_SOFT_LINKS_NO_CYCLE_TEST_NUM_SUBGROUPS - subgroup_number - 1),
+                     (int)(LINK_VISIT_SOFT_LINKS_NO_CYCLE_TEST_NUM_LINKS_PER_GROUP - link_idx_val - 1));
         }
     }
 
-    if (HDstrncmp(name, expected_link_name, LINK_VISIT_SOFT_LINKS_NO_CYCLE_TEST_BUF_SIZE)) {
+    if (strncmp(name, expected_link_name, LINK_VISIT_SOFT_LINKS_NO_CYCLE_TEST_BUF_SIZE)) {
         printf("    link name '%s' didn't match expected name '%s'\n", name, expected_link_name);
         ret_val = H5_ITER_ERROR;
         goto done;
@@ -26361,34 +26331,34 @@ link_visit_external_links_no_cycles_cb(hid_t group_id, const char *name, const H
 
     if (test_iteration == 0 || test_iteration == 3) {
         if (is_subgroup_link) {
-            HDsnprintf(expected_link_name, LINK_VISIT_EXT_LINKS_NO_CYCLE_TEST_BUF_SIZE,
-                       LINK_VISIT_EXT_LINKS_NO_CYCLE_TEST_NESTED_GRP_NAME "%d", (int)subgroup_number);
+            snprintf(expected_link_name, LINK_VISIT_EXT_LINKS_NO_CYCLE_TEST_BUF_SIZE,
+                     LINK_VISIT_EXT_LINKS_NO_CYCLE_TEST_NESTED_GRP_NAME "%d", (int)subgroup_number);
         }
         else {
-            HDsnprintf(expected_link_name, LINK_VISIT_EXT_LINKS_NO_CYCLE_TEST_BUF_SIZE,
-                       LINK_VISIT_EXT_LINKS_NO_CYCLE_TEST_NESTED_GRP_NAME
-                       "%d"
-                       "/" LINK_VISIT_EXT_LINKS_NO_CYCLE_TEST_LINK_NAME "%d",
-                       (int)subgroup_number, (int)link_idx_val);
+            snprintf(expected_link_name, LINK_VISIT_EXT_LINKS_NO_CYCLE_TEST_BUF_SIZE,
+                     LINK_VISIT_EXT_LINKS_NO_CYCLE_TEST_NESTED_GRP_NAME
+                     "%d"
+                     "/" LINK_VISIT_EXT_LINKS_NO_CYCLE_TEST_LINK_NAME "%d",
+                     (int)subgroup_number, (int)link_idx_val);
         }
     }
     else {
         if (is_subgroup_link) {
-            HDsnprintf(expected_link_name, LINK_VISIT_EXT_LINKS_NO_CYCLE_TEST_BUF_SIZE,
-                       LINK_VISIT_EXT_LINKS_NO_CYCLE_TEST_NESTED_GRP_NAME "%d",
-                       (int)(LINK_VISIT_EXT_LINKS_NO_CYCLE_TEST_NUM_SUBGROUPS - subgroup_number - 1));
+            snprintf(expected_link_name, LINK_VISIT_EXT_LINKS_NO_CYCLE_TEST_BUF_SIZE,
+                     LINK_VISIT_EXT_LINKS_NO_CYCLE_TEST_NESTED_GRP_NAME "%d",
+                     (int)(LINK_VISIT_EXT_LINKS_NO_CYCLE_TEST_NUM_SUBGROUPS - subgroup_number - 1));
         }
         else {
-            HDsnprintf(expected_link_name, LINK_VISIT_EXT_LINKS_NO_CYCLE_TEST_BUF_SIZE,
-                       LINK_VISIT_EXT_LINKS_NO_CYCLE_TEST_NESTED_GRP_NAME
-                       "%d"
-                       "/" LINK_VISIT_EXT_LINKS_NO_CYCLE_TEST_LINK_NAME "%d",
-                       (int)(LINK_VISIT_EXT_LINKS_NO_CYCLE_TEST_NUM_SUBGROUPS - subgroup_number - 1),
-                       (int)(LINK_VISIT_EXT_LINKS_NO_CYCLE_TEST_NUM_LINKS_PER_GROUP - link_idx_val - 1));
+            snprintf(expected_link_name, LINK_VISIT_EXT_LINKS_NO_CYCLE_TEST_BUF_SIZE,
+                     LINK_VISIT_EXT_LINKS_NO_CYCLE_TEST_NESTED_GRP_NAME
+                     "%d"
+                     "/" LINK_VISIT_EXT_LINKS_NO_CYCLE_TEST_LINK_NAME "%d",
+                     (int)(LINK_VISIT_EXT_LINKS_NO_CYCLE_TEST_NUM_SUBGROUPS - subgroup_number - 1),
+                     (int)(LINK_VISIT_EXT_LINKS_NO_CYCLE_TEST_NUM_LINKS_PER_GROUP - link_idx_val - 1));
         }
     }
 
-    if (HDstrncmp(name, expected_link_name, LINK_VISIT_EXT_LINKS_NO_CYCLE_TEST_BUF_SIZE)) {
+    if (strncmp(name, expected_link_name, LINK_VISIT_EXT_LINKS_NO_CYCLE_TEST_BUF_SIZE)) {
         printf("    link name '%s' didn't match expected name '%s'\n", name, expected_link_name);
         ret_val = H5_ITER_ERROR;
         goto done;
@@ -26422,12 +26392,12 @@ link_visit_mixed_links_no_cycles_cb(hid_t group_id, const char *name, const H5L_
     UNUSED(group_id);
     UNUSED(op_data);
 
-    if (!HDstrncmp(name,
-                   LINK_VISIT_MIXED_LINKS_NO_CYCLE_TEST_SUBGROUP_NAME2
-                   "/" LINK_VISIT_MIXED_LINKS_NO_CYCLE_TEST_LINK_NAME1,
-                   strlen(LINK_VISIT_MIXED_LINKS_NO_CYCLE_TEST_SUBGROUP_NAME2
-                          "/" LINK_VISIT_MIXED_LINKS_NO_CYCLE_TEST_LINK_NAME1) +
-                       1) &&
+    if (!strncmp(name,
+                 LINK_VISIT_MIXED_LINKS_NO_CYCLE_TEST_SUBGROUP_NAME2
+                 "/" LINK_VISIT_MIXED_LINKS_NO_CYCLE_TEST_LINK_NAME1,
+                 strlen(LINK_VISIT_MIXED_LINKS_NO_CYCLE_TEST_SUBGROUP_NAME2
+                        "/" LINK_VISIT_MIXED_LINKS_NO_CYCLE_TEST_LINK_NAME1) +
+                     1) &&
         (counter_val == 2 || counter_val == 14 || counter_val == 18 || counter_val == 30)) {
         if (H5L_TYPE_HARD != info->type) {
             ret_val = -1;
@@ -26438,12 +26408,12 @@ link_visit_mixed_links_no_cycles_cb(hid_t group_id, const char *name, const H5L_
 
         goto done;
     }
-    else if (!HDstrncmp(name,
-                        LINK_VISIT_MIXED_LINKS_NO_CYCLE_TEST_SUBGROUP_NAME2
-                        "/" LINK_VISIT_MIXED_LINKS_NO_CYCLE_TEST_LINK_NAME2,
-                        strlen(LINK_VISIT_MIXED_LINKS_NO_CYCLE_TEST_SUBGROUP_NAME2
-                               "/" LINK_VISIT_MIXED_LINKS_NO_CYCLE_TEST_LINK_NAME2) +
-                            1) &&
+    else if (!strncmp(name,
+                      LINK_VISIT_MIXED_LINKS_NO_CYCLE_TEST_SUBGROUP_NAME2
+                      "/" LINK_VISIT_MIXED_LINKS_NO_CYCLE_TEST_LINK_NAME2,
+                      strlen(LINK_VISIT_MIXED_LINKS_NO_CYCLE_TEST_SUBGROUP_NAME2
+                             "/" LINK_VISIT_MIXED_LINKS_NO_CYCLE_TEST_LINK_NAME2) +
+                          1) &&
              (counter_val == 3 || counter_val == 13 || counter_val == 19 || counter_val == 29)) {
         if (H5L_TYPE_SOFT != info->type) {
             ret_val = -1;
@@ -26454,12 +26424,12 @@ link_visit_mixed_links_no_cycles_cb(hid_t group_id, const char *name, const H5L_
 
         goto done;
     }
-    else if (!HDstrncmp(name,
-                        LINK_VISIT_MIXED_LINKS_NO_CYCLE_TEST_SUBGROUP_NAME3
-                        "/" LINK_VISIT_MIXED_LINKS_NO_CYCLE_TEST_LINK_NAME3,
-                        strlen(LINK_VISIT_MIXED_LINKS_NO_CYCLE_TEST_SUBGROUP_NAME3
-                               "/" LINK_VISIT_MIXED_LINKS_NO_CYCLE_TEST_LINK_NAME3) +
-                            1) &&
+    else if (!strncmp(name,
+                      LINK_VISIT_MIXED_LINKS_NO_CYCLE_TEST_SUBGROUP_NAME3
+                      "/" LINK_VISIT_MIXED_LINKS_NO_CYCLE_TEST_LINK_NAME3,
+                      strlen(LINK_VISIT_MIXED_LINKS_NO_CYCLE_TEST_SUBGROUP_NAME3
+                             "/" LINK_VISIT_MIXED_LINKS_NO_CYCLE_TEST_LINK_NAME3) +
+                          1) &&
              (counter_val == 6 || counter_val == 10 || counter_val == 22 || counter_val == 26)) {
         if (H5L_TYPE_EXTERNAL != info->type) {
             ret_val = -1;
@@ -26470,12 +26440,12 @@ link_visit_mixed_links_no_cycles_cb(hid_t group_id, const char *name, const H5L_
 
         goto done;
     }
-    else if (!HDstrncmp(name,
-                        LINK_VISIT_MIXED_LINKS_NO_CYCLE_TEST_SUBGROUP_NAME3
-                        "/" LINK_VISIT_MIXED_LINKS_NO_CYCLE_TEST_LINK_NAME4,
-                        strlen(LINK_VISIT_MIXED_LINKS_NO_CYCLE_TEST_SUBGROUP_NAME3
-                               "/" LINK_VISIT_MIXED_LINKS_NO_CYCLE_TEST_LINK_NAME4) +
-                            1) &&
+    else if (!strncmp(name,
+                      LINK_VISIT_MIXED_LINKS_NO_CYCLE_TEST_SUBGROUP_NAME3
+                      "/" LINK_VISIT_MIXED_LINKS_NO_CYCLE_TEST_LINK_NAME4,
+                      strlen(LINK_VISIT_MIXED_LINKS_NO_CYCLE_TEST_SUBGROUP_NAME3
+                             "/" LINK_VISIT_MIXED_LINKS_NO_CYCLE_TEST_LINK_NAME4) +
+                          1) &&
              (counter_val == 7 || counter_val == 9 || counter_val == 23 || counter_val == 25)) {
         if (H5L_TYPE_HARD != info->type) {
             ret_val = -1;
@@ -26486,12 +26456,12 @@ link_visit_mixed_links_no_cycles_cb(hid_t group_id, const char *name, const H5L_
 
         goto done;
     }
-    else if (!HDstrncmp(name,
-                        LINK_VISIT_MIXED_LINKS_NO_CYCLE_TEST_SUBGROUP_NAME2
-                        "/" LINK_VISIT_MIXED_LINKS_NO_CYCLE_TEST_DSET_NAME,
-                        strlen(LINK_VISIT_MIXED_LINKS_NO_CYCLE_TEST_SUBGROUP_NAME2
-                               "/" LINK_VISIT_MIXED_LINKS_NO_CYCLE_TEST_DSET_NAME) +
-                            1) &&
+    else if (!strncmp(name,
+                      LINK_VISIT_MIXED_LINKS_NO_CYCLE_TEST_SUBGROUP_NAME2
+                      "/" LINK_VISIT_MIXED_LINKS_NO_CYCLE_TEST_DSET_NAME,
+                      strlen(LINK_VISIT_MIXED_LINKS_NO_CYCLE_TEST_SUBGROUP_NAME2
+                             "/" LINK_VISIT_MIXED_LINKS_NO_CYCLE_TEST_DSET_NAME) +
+                          1) &&
              (counter_val == 1 || counter_val == 15 || counter_val == 17 || counter_val == 31)) {
         if (H5L_TYPE_HARD != info->type) {
             ret_val = -1;
@@ -26502,12 +26472,12 @@ link_visit_mixed_links_no_cycles_cb(hid_t group_id, const char *name, const H5L_
 
         goto done;
     }
-    else if (!HDstrncmp(name,
-                        LINK_VISIT_MIXED_LINKS_NO_CYCLE_TEST_SUBGROUP_NAME3
-                        "/" LINK_VISIT_MIXED_LINKS_NO_CYCLE_TEST_DSET_NAME2,
-                        strlen(LINK_VISIT_MIXED_LINKS_NO_CYCLE_TEST_SUBGROUP_NAME3
-                               "/" LINK_VISIT_MIXED_LINKS_NO_CYCLE_TEST_DSET_NAME2) +
-                            1) &&
+    else if (!strncmp(name,
+                      LINK_VISIT_MIXED_LINKS_NO_CYCLE_TEST_SUBGROUP_NAME3
+                      "/" LINK_VISIT_MIXED_LINKS_NO_CYCLE_TEST_DSET_NAME2,
+                      strlen(LINK_VISIT_MIXED_LINKS_NO_CYCLE_TEST_SUBGROUP_NAME3
+                             "/" LINK_VISIT_MIXED_LINKS_NO_CYCLE_TEST_DSET_NAME2) +
+                          1) &&
              (counter_val == 5 || counter_val == 11 || counter_val == 21 || counter_val == 27)) {
         if (H5L_TYPE_HARD != info->type) {
             ret_val = -1;
@@ -26518,8 +26488,8 @@ link_visit_mixed_links_no_cycles_cb(hid_t group_id, const char *name, const H5L_
 
         goto done;
     }
-    else if (!HDstrncmp(name, LINK_VISIT_MIXED_LINKS_NO_CYCLE_TEST_SUBGROUP_NAME2,
-                        strlen(LINK_VISIT_MIXED_LINKS_NO_CYCLE_TEST_SUBGROUP_NAME2) + 1) &&
+    else if (!strncmp(name, LINK_VISIT_MIXED_LINKS_NO_CYCLE_TEST_SUBGROUP_NAME2,
+                      strlen(LINK_VISIT_MIXED_LINKS_NO_CYCLE_TEST_SUBGROUP_NAME2) + 1) &&
              (counter_val == 0 || counter_val == 12 || counter_val == 16 || counter_val == 28)) {
         if (H5L_TYPE_HARD != info->type) {
             ret_val = -1;
@@ -26529,8 +26499,8 @@ link_visit_mixed_links_no_cycles_cb(hid_t group_id, const char *name, const H5L_
 
         goto done;
     }
-    else if (!HDstrncmp(name, LINK_VISIT_MIXED_LINKS_NO_CYCLE_TEST_SUBGROUP_NAME3,
-                        strlen(LINK_VISIT_MIXED_LINKS_NO_CYCLE_TEST_SUBGROUP_NAME3) + 1) &&
+    else if (!strncmp(name, LINK_VISIT_MIXED_LINKS_NO_CYCLE_TEST_SUBGROUP_NAME3,
+                      strlen(LINK_VISIT_MIXED_LINKS_NO_CYCLE_TEST_SUBGROUP_NAME3) + 1) &&
              (counter_val == 4 || counter_val == 8 || counter_val == 20 || counter_val == 24)) {
         if (H5L_TYPE_HARD != info->type) {
             ret_val = -1;
@@ -26615,34 +26585,34 @@ link_visit_hard_links_cycles_cb(hid_t group_id, const char *name, const H5L_info
 
     if (test_iteration == 0 || test_iteration == 3) {
         if (is_subgroup_link) {
-            HDsnprintf(expected_link_name, LINK_VISIT_HARD_LINKS_CYCLE_TEST_BUF_SIZE,
-                       LINK_VISIT_HARD_LINKS_CYCLE_TEST_NESTED_GRP_NAME "%d", (int)subgroup_number);
+            snprintf(expected_link_name, LINK_VISIT_HARD_LINKS_CYCLE_TEST_BUF_SIZE,
+                     LINK_VISIT_HARD_LINKS_CYCLE_TEST_NESTED_GRP_NAME "%d", (int)subgroup_number);
         }
         else {
-            HDsnprintf(expected_link_name, LINK_VISIT_HARD_LINKS_CYCLE_TEST_BUF_SIZE,
-                       LINK_VISIT_HARD_LINKS_CYCLE_TEST_NESTED_GRP_NAME
-                       "%d"
-                       "/" LINK_VISIT_HARD_LINKS_CYCLE_TEST_LINK_NAME "%d",
-                       (int)subgroup_number, (int)link_idx_val);
+            snprintf(expected_link_name, LINK_VISIT_HARD_LINKS_CYCLE_TEST_BUF_SIZE,
+                     LINK_VISIT_HARD_LINKS_CYCLE_TEST_NESTED_GRP_NAME
+                     "%d"
+                     "/" LINK_VISIT_HARD_LINKS_CYCLE_TEST_LINK_NAME "%d",
+                     (int)subgroup_number, (int)link_idx_val);
         }
     }
     else {
         if (is_subgroup_link) {
-            HDsnprintf(expected_link_name, LINK_VISIT_HARD_LINKS_CYCLE_TEST_BUF_SIZE,
-                       LINK_VISIT_HARD_LINKS_CYCLE_TEST_NESTED_GRP_NAME "%d",
-                       (int)(LINK_VISIT_HARD_LINKS_CYCLE_TEST_NUM_SUBGROUPS - subgroup_number - 1));
+            snprintf(expected_link_name, LINK_VISIT_HARD_LINKS_CYCLE_TEST_BUF_SIZE,
+                     LINK_VISIT_HARD_LINKS_CYCLE_TEST_NESTED_GRP_NAME "%d",
+                     (int)(LINK_VISIT_HARD_LINKS_CYCLE_TEST_NUM_SUBGROUPS - subgroup_number - 1));
         }
         else {
-            HDsnprintf(expected_link_name, LINK_VISIT_HARD_LINKS_CYCLE_TEST_BUF_SIZE,
-                       LINK_VISIT_HARD_LINKS_CYCLE_TEST_NESTED_GRP_NAME
-                       "%d"
-                       "/" LINK_VISIT_HARD_LINKS_CYCLE_TEST_LINK_NAME "%d",
-                       (int)(LINK_VISIT_HARD_LINKS_CYCLE_TEST_NUM_SUBGROUPS - subgroup_number - 1),
-                       (int)(LINK_VISIT_HARD_LINKS_CYCLE_TEST_NUM_LINKS_PER_GROUP - link_idx_val - 1));
+            snprintf(expected_link_name, LINK_VISIT_HARD_LINKS_CYCLE_TEST_BUF_SIZE,
+                     LINK_VISIT_HARD_LINKS_CYCLE_TEST_NESTED_GRP_NAME
+                     "%d"
+                     "/" LINK_VISIT_HARD_LINKS_CYCLE_TEST_LINK_NAME "%d",
+                     (int)(LINK_VISIT_HARD_LINKS_CYCLE_TEST_NUM_SUBGROUPS - subgroup_number - 1),
+                     (int)(LINK_VISIT_HARD_LINKS_CYCLE_TEST_NUM_LINKS_PER_GROUP - link_idx_val - 1));
         }
     }
 
-    if (HDstrncmp(name, expected_link_name, LINK_VISIT_HARD_LINKS_CYCLE_TEST_BUF_SIZE)) {
+    if (strncmp(name, expected_link_name, LINK_VISIT_HARD_LINKS_CYCLE_TEST_BUF_SIZE)) {
         printf("    link name '%s' didn't match expected name '%s'\n", name, expected_link_name);
         ret_val = H5_ITER_ERROR;
         goto done;
@@ -26728,34 +26698,34 @@ link_visit_soft_links_cycles_cb(hid_t group_id, const char *name, const H5L_info
 
     if (test_iteration == 0 || test_iteration == 3) {
         if (is_subgroup_link) {
-            HDsnprintf(expected_link_name, LINK_VISIT_SOFT_LINKS_CYCLE_TEST_BUF_SIZE,
-                       LINK_VISIT_SOFT_LINKS_CYCLE_TEST_NESTED_GRP_NAME "%d", (int)subgroup_number);
+            snprintf(expected_link_name, LINK_VISIT_SOFT_LINKS_CYCLE_TEST_BUF_SIZE,
+                     LINK_VISIT_SOFT_LINKS_CYCLE_TEST_NESTED_GRP_NAME "%d", (int)subgroup_number);
         }
         else {
-            HDsnprintf(expected_link_name, LINK_VISIT_SOFT_LINKS_CYCLE_TEST_BUF_SIZE,
-                       LINK_VISIT_SOFT_LINKS_CYCLE_TEST_NESTED_GRP_NAME
-                       "%d"
-                       "/" LINK_VISIT_SOFT_LINKS_CYCLE_TEST_LINK_NAME "%d",
-                       (int)subgroup_number, (int)link_idx_val);
+            snprintf(expected_link_name, LINK_VISIT_SOFT_LINKS_CYCLE_TEST_BUF_SIZE,
+                     LINK_VISIT_SOFT_LINKS_CYCLE_TEST_NESTED_GRP_NAME
+                     "%d"
+                     "/" LINK_VISIT_SOFT_LINKS_CYCLE_TEST_LINK_NAME "%d",
+                     (int)subgroup_number, (int)link_idx_val);
         }
     }
     else {
         if (is_subgroup_link) {
-            HDsnprintf(expected_link_name, LINK_VISIT_SOFT_LINKS_CYCLE_TEST_BUF_SIZE,
-                       LINK_VISIT_SOFT_LINKS_CYCLE_TEST_NESTED_GRP_NAME "%d",
-                       (int)(LINK_VISIT_SOFT_LINKS_CYCLE_TEST_NUM_SUBGROUPS - subgroup_number - 1));
+            snprintf(expected_link_name, LINK_VISIT_SOFT_LINKS_CYCLE_TEST_BUF_SIZE,
+                     LINK_VISIT_SOFT_LINKS_CYCLE_TEST_NESTED_GRP_NAME "%d",
+                     (int)(LINK_VISIT_SOFT_LINKS_CYCLE_TEST_NUM_SUBGROUPS - subgroup_number - 1));
         }
         else {
-            HDsnprintf(expected_link_name, LINK_VISIT_SOFT_LINKS_CYCLE_TEST_BUF_SIZE,
-                       LINK_VISIT_SOFT_LINKS_CYCLE_TEST_NESTED_GRP_NAME
-                       "%d"
-                       "/" LINK_VISIT_SOFT_LINKS_CYCLE_TEST_LINK_NAME "%d",
-                       (int)(LINK_VISIT_SOFT_LINKS_CYCLE_TEST_NUM_SUBGROUPS - subgroup_number - 1),
-                       (int)(LINK_VISIT_SOFT_LINKS_CYCLE_TEST_NUM_LINKS_PER_GROUP - link_idx_val - 1));
+            snprintf(expected_link_name, LINK_VISIT_SOFT_LINKS_CYCLE_TEST_BUF_SIZE,
+                     LINK_VISIT_SOFT_LINKS_CYCLE_TEST_NESTED_GRP_NAME
+                     "%d"
+                     "/" LINK_VISIT_SOFT_LINKS_CYCLE_TEST_LINK_NAME "%d",
+                     (int)(LINK_VISIT_SOFT_LINKS_CYCLE_TEST_NUM_SUBGROUPS - subgroup_number - 1),
+                     (int)(LINK_VISIT_SOFT_LINKS_CYCLE_TEST_NUM_LINKS_PER_GROUP - link_idx_val - 1));
         }
     }
 
-    if (HDstrncmp(name, expected_link_name, LINK_VISIT_SOFT_LINKS_CYCLE_TEST_BUF_SIZE)) {
+    if (strncmp(name, expected_link_name, LINK_VISIT_SOFT_LINKS_CYCLE_TEST_BUF_SIZE)) {
         printf("    link name '%s' didn't match expected name '%s'\n", name, expected_link_name);
         ret_val = H5_ITER_ERROR;
         goto done;
@@ -26848,34 +26818,34 @@ link_visit_external_links_cycles_cb(hid_t group_id, const char *name, const H5L_
 
     if (test_iteration == 0 || test_iteration == 3) {
         if (is_subgroup_link) {
-            HDsnprintf(expected_link_name, LINK_VISIT_EXT_LINKS_CYCLE_TEST_BUF_SIZE,
-                       LINK_VISIT_EXT_LINKS_CYCLE_TEST_NESTED_GRP_NAME "%d", (int)subgroup_number);
+            snprintf(expected_link_name, LINK_VISIT_EXT_LINKS_CYCLE_TEST_BUF_SIZE,
+                     LINK_VISIT_EXT_LINKS_CYCLE_TEST_NESTED_GRP_NAME "%d", (int)subgroup_number);
         }
         else {
-            HDsnprintf(expected_link_name, LINK_VISIT_EXT_LINKS_CYCLE_TEST_BUF_SIZE,
-                       LINK_VISIT_EXT_LINKS_CYCLE_TEST_NESTED_GRP_NAME
-                       "%d"
-                       "/" LINK_VISIT_EXT_LINKS_CYCLE_TEST_LINK_NAME "%d",
-                       (int)subgroup_number, (int)link_idx_val);
+            snprintf(expected_link_name, LINK_VISIT_EXT_LINKS_CYCLE_TEST_BUF_SIZE,
+                     LINK_VISIT_EXT_LINKS_CYCLE_TEST_NESTED_GRP_NAME
+                     "%d"
+                     "/" LINK_VISIT_EXT_LINKS_CYCLE_TEST_LINK_NAME "%d",
+                     (int)subgroup_number, (int)link_idx_val);
         }
     }
     else {
         if (is_subgroup_link) {
-            HDsnprintf(expected_link_name, LINK_VISIT_EXT_LINKS_CYCLE_TEST_BUF_SIZE,
-                       LINK_VISIT_EXT_LINKS_CYCLE_TEST_NESTED_GRP_NAME "%d",
-                       (int)(LINK_VISIT_EXT_LINKS_CYCLE_TEST_NUM_SUBGROUPS - subgroup_number - 1));
+            snprintf(expected_link_name, LINK_VISIT_EXT_LINKS_CYCLE_TEST_BUF_SIZE,
+                     LINK_VISIT_EXT_LINKS_CYCLE_TEST_NESTED_GRP_NAME "%d",
+                     (int)(LINK_VISIT_EXT_LINKS_CYCLE_TEST_NUM_SUBGROUPS - subgroup_number - 1));
         }
         else {
-            HDsnprintf(expected_link_name, LINK_VISIT_EXT_LINKS_CYCLE_TEST_BUF_SIZE,
-                       LINK_VISIT_EXT_LINKS_CYCLE_TEST_NESTED_GRP_NAME
-                       "%d"
-                       "/" LINK_VISIT_EXT_LINKS_CYCLE_TEST_LINK_NAME "%d",
-                       (int)(LINK_VISIT_EXT_LINKS_CYCLE_TEST_NUM_SUBGROUPS - subgroup_number - 1),
-                       (int)(LINK_VISIT_EXT_LINKS_CYCLE_TEST_NUM_LINKS_PER_GROUP - link_idx_val - 1));
+            snprintf(expected_link_name, LINK_VISIT_EXT_LINKS_CYCLE_TEST_BUF_SIZE,
+                     LINK_VISIT_EXT_LINKS_CYCLE_TEST_NESTED_GRP_NAME
+                     "%d"
+                     "/" LINK_VISIT_EXT_LINKS_CYCLE_TEST_LINK_NAME "%d",
+                     (int)(LINK_VISIT_EXT_LINKS_CYCLE_TEST_NUM_SUBGROUPS - subgroup_number - 1),
+                     (int)(LINK_VISIT_EXT_LINKS_CYCLE_TEST_NUM_LINKS_PER_GROUP - link_idx_val - 1));
         }
     }
 
-    if (HDstrncmp(name, expected_link_name, LINK_VISIT_EXT_LINKS_CYCLE_TEST_BUF_SIZE)) {
+    if (strncmp(name, expected_link_name, LINK_VISIT_EXT_LINKS_CYCLE_TEST_BUF_SIZE)) {
         printf("    link name '%s' didn't match expected name '%s'\n", name, expected_link_name);
         ret_val = H5_ITER_ERROR;
         goto done;
@@ -26909,12 +26879,12 @@ link_visit_mixed_links_cycles_cb(hid_t group_id, const char *name, const H5L_inf
     UNUSED(group_id);
     UNUSED(op_data);
 
-    if (!HDstrncmp(name,
-                   LINK_VISIT_MIXED_LINKS_CYCLE_TEST_SUBGROUP_NAME2
-                   "/" LINK_VISIT_MIXED_LINKS_CYCLE_TEST_LINK_NAME1,
-                   strlen(LINK_VISIT_MIXED_LINKS_CYCLE_TEST_SUBGROUP_NAME2
-                          "/" LINK_VISIT_MIXED_LINKS_CYCLE_TEST_LINK_NAME1) +
-                       1) &&
+    if (!strncmp(name,
+                 LINK_VISIT_MIXED_LINKS_CYCLE_TEST_SUBGROUP_NAME2
+                 "/" LINK_VISIT_MIXED_LINKS_CYCLE_TEST_LINK_NAME1,
+                 strlen(LINK_VISIT_MIXED_LINKS_CYCLE_TEST_SUBGROUP_NAME2
+                        "/" LINK_VISIT_MIXED_LINKS_CYCLE_TEST_LINK_NAME1) +
+                     1) &&
         (counter_val == 1 || counter_val == 11 || counter_val == 13 || counter_val == 23)) {
         if (H5L_TYPE_HARD != info->type) {
             ret_val = -1;
@@ -26925,12 +26895,12 @@ link_visit_mixed_links_cycles_cb(hid_t group_id, const char *name, const H5L_inf
 
         goto done;
     }
-    else if (!HDstrncmp(name,
-                        LINK_VISIT_MIXED_LINKS_CYCLE_TEST_SUBGROUP_NAME2
-                        "/" LINK_VISIT_MIXED_LINKS_CYCLE_TEST_LINK_NAME2,
-                        strlen(LINK_VISIT_MIXED_LINKS_CYCLE_TEST_SUBGROUP_NAME2
-                               "/" LINK_VISIT_MIXED_LINKS_CYCLE_TEST_LINK_NAME2) +
-                            1) &&
+    else if (!strncmp(name,
+                      LINK_VISIT_MIXED_LINKS_CYCLE_TEST_SUBGROUP_NAME2
+                      "/" LINK_VISIT_MIXED_LINKS_CYCLE_TEST_LINK_NAME2,
+                      strlen(LINK_VISIT_MIXED_LINKS_CYCLE_TEST_SUBGROUP_NAME2
+                             "/" LINK_VISIT_MIXED_LINKS_CYCLE_TEST_LINK_NAME2) +
+                          1) &&
              (counter_val == 2 || counter_val == 10 || counter_val == 14 || counter_val == 22)) {
         if (H5L_TYPE_SOFT != info->type) {
             ret_val = -1;
@@ -26941,12 +26911,12 @@ link_visit_mixed_links_cycles_cb(hid_t group_id, const char *name, const H5L_inf
 
         goto done;
     }
-    else if (!HDstrncmp(name,
-                        LINK_VISIT_MIXED_LINKS_CYCLE_TEST_SUBGROUP_NAME3
-                        "/" LINK_VISIT_MIXED_LINKS_CYCLE_TEST_LINK_NAME3,
-                        strlen(LINK_VISIT_MIXED_LINKS_CYCLE_TEST_SUBGROUP_NAME3
-                               "/" LINK_VISIT_MIXED_LINKS_CYCLE_TEST_LINK_NAME3) +
-                            1) &&
+    else if (!strncmp(name,
+                      LINK_VISIT_MIXED_LINKS_CYCLE_TEST_SUBGROUP_NAME3
+                      "/" LINK_VISIT_MIXED_LINKS_CYCLE_TEST_LINK_NAME3,
+                      strlen(LINK_VISIT_MIXED_LINKS_CYCLE_TEST_SUBGROUP_NAME3
+                             "/" LINK_VISIT_MIXED_LINKS_CYCLE_TEST_LINK_NAME3) +
+                          1) &&
              (counter_val == 4 || counter_val == 8 || counter_val == 16 || counter_val == 20)) {
         if (H5L_TYPE_EXTERNAL != info->type) {
             ret_val = -1;
@@ -26957,12 +26927,12 @@ link_visit_mixed_links_cycles_cb(hid_t group_id, const char *name, const H5L_inf
 
         goto done;
     }
-    else if (!HDstrncmp(name,
-                        LINK_VISIT_MIXED_LINKS_CYCLE_TEST_SUBGROUP_NAME3
-                        "/" LINK_VISIT_MIXED_LINKS_CYCLE_TEST_LINK_NAME4,
-                        strlen(LINK_VISIT_MIXED_LINKS_CYCLE_TEST_SUBGROUP_NAME3
-                               "/" LINK_VISIT_MIXED_LINKS_CYCLE_TEST_LINK_NAME4) +
-                            1) &&
+    else if (!strncmp(name,
+                      LINK_VISIT_MIXED_LINKS_CYCLE_TEST_SUBGROUP_NAME3
+                      "/" LINK_VISIT_MIXED_LINKS_CYCLE_TEST_LINK_NAME4,
+                      strlen(LINK_VISIT_MIXED_LINKS_CYCLE_TEST_SUBGROUP_NAME3
+                             "/" LINK_VISIT_MIXED_LINKS_CYCLE_TEST_LINK_NAME4) +
+                          1) &&
              (counter_val == 5 || counter_val == 7 || counter_val == 17 || counter_val == 19)) {
         if (H5L_TYPE_HARD != info->type) {
             ret_val = -1;
@@ -26973,8 +26943,8 @@ link_visit_mixed_links_cycles_cb(hid_t group_id, const char *name, const H5L_inf
 
         goto done;
     }
-    else if (!HDstrncmp(name, LINK_VISIT_MIXED_LINKS_CYCLE_TEST_SUBGROUP_NAME2,
-                        strlen(LINK_VISIT_MIXED_LINKS_CYCLE_TEST_SUBGROUP_NAME2) + 1) &&
+    else if (!strncmp(name, LINK_VISIT_MIXED_LINKS_CYCLE_TEST_SUBGROUP_NAME2,
+                      strlen(LINK_VISIT_MIXED_LINKS_CYCLE_TEST_SUBGROUP_NAME2) + 1) &&
              (counter_val == 0 || counter_val == 9 || counter_val == 12 || counter_val == 21)) {
         if (H5L_TYPE_HARD != info->type) {
             ret_val = -1;
@@ -26984,8 +26954,8 @@ link_visit_mixed_links_cycles_cb(hid_t group_id, const char *name, const H5L_inf
 
         goto done;
     }
-    else if (!HDstrncmp(name, LINK_VISIT_MIXED_LINKS_CYCLE_TEST_SUBGROUP_NAME3,
-                        strlen(LINK_VISIT_MIXED_LINKS_CYCLE_TEST_SUBGROUP_NAME3) + 1) &&
+    else if (!strncmp(name, LINK_VISIT_MIXED_LINKS_CYCLE_TEST_SUBGROUP_NAME3,
+                      strlen(LINK_VISIT_MIXED_LINKS_CYCLE_TEST_SUBGROUP_NAME3) + 1) &&
              (counter_val == 3 || counter_val == 6 || counter_val == 15 || counter_val == 18)) {
         if (H5L_TYPE_HARD != info->type) {
             ret_val = -1;

--- a/test/API/H5_api_misc_test.c
+++ b/test/API/H5_api_misc_test.c
@@ -948,15 +948,15 @@ test_symbols_in_compound_field_name(void)
         total_type_size += H5Tget_size(type_pool[i]);
     }
 
-    HDsnprintf(member_names[0], 256, "{{{ member0");
-    HDsnprintf(member_names[1], 256, "member1 }}}");
-    HDsnprintf(member_names[2], 256, "{{{ member2 }}");
-    HDsnprintf(member_names[3], 256, "{{ member3 }}}");
-    HDsnprintf(member_names[4], 256, "\\\"member4");
-    HDsnprintf(member_names[5], 256, "member5\\\"");
-    HDsnprintf(member_names[6], 256, "mem\\\"ber6");
-    HDsnprintf(member_names[7], 256, "{{ member7\\\" }");
-    HDsnprintf(member_names[8], 256, "{{ member8\\\\");
+    snprintf(member_names[0], 256, "{{{ member0");
+    snprintf(member_names[1], 256, "member1 }}}");
+    snprintf(member_names[2], 256, "{{{ member2 }}");
+    snprintf(member_names[3], 256, "{{ member3 }}}");
+    snprintf(member_names[4], 256, "\\\"member4");
+    snprintf(member_names[5], 256, "member5\\\"");
+    snprintf(member_names[6], 256, "mem\\\"ber6");
+    snprintf(member_names[7], 256, "{{ member7\\\" }");
+    snprintf(member_names[8], 256, "{{ member8\\\\");
 
     if ((compound_type = H5Tcreate(H5T_COMPOUND, total_type_size)) < 0) {
         H5_FAILED();

--- a/test/API/H5_api_object_test.c
+++ b/test/API/H5_api_object_test.c
@@ -6883,7 +6883,7 @@ object_copy_attribute_iter_callback(hid_t location_id, const char *attr_name, co
 
     snprintf(expected_name, 256, "attr%d", (int)(*counter));
 
-    if (HDstrncmp(attr_name, expected_name, 256)) {
+    if (strncmp(attr_name, expected_name, 256)) {
         printf("    attribute name '%s' did not match expected name '%s'\n", attr_name, expected_name);
         ret_value = H5_ITER_ERROR;
         goto done;
@@ -7028,28 +7028,28 @@ object_visit_callback(hid_t o_id, const char *name, const H5O_info2_t *object_in
 
     UNUSED(o_id);
 
-    if (!HDstrncmp(name, ".", strlen(".") + 1) &&
+    if (!strncmp(name, ".", strlen(".") + 1) &&
         (counter_val == 0 || counter_val == 4 || counter_val == 8 || counter_val == 12)) {
         if (H5O_TYPE_GROUP == object_info->type)
             goto done;
         else
             printf("    type for object '%s' was not H5O_TYPE_GROUP\n", name);
     }
-    else if (!HDstrncmp(name, OBJECT_VISIT_TEST_GROUP_NAME, strlen(OBJECT_VISIT_TEST_GROUP_NAME) + 1) &&
+    else if (!strncmp(name, OBJECT_VISIT_TEST_GROUP_NAME, strlen(OBJECT_VISIT_TEST_GROUP_NAME) + 1) &&
              (counter_val == 2 || counter_val == 6 || counter_val == 9 || counter_val == 15)) {
         if (H5O_TYPE_GROUP == object_info->type)
             goto done;
         else
             printf("    type for object '%s' was not H5O_TYPE_GROUP\n", name);
     }
-    else if (!HDstrncmp(name, OBJECT_VISIT_TEST_DSET_NAME, strlen(OBJECT_VISIT_TEST_DSET_NAME) + 1) &&
+    else if (!strncmp(name, OBJECT_VISIT_TEST_DSET_NAME, strlen(OBJECT_VISIT_TEST_DSET_NAME) + 1) &&
              (counter_val == 1 || counter_val == 7 || counter_val == 10 || counter_val == 14)) {
         if (H5O_TYPE_DATASET == object_info->type)
             goto done;
         else
             printf("    type for object '%s' was not H5O_TYPE_DATASET\n", name);
     }
-    else if (!HDstrncmp(name, OBJECT_VISIT_TEST_TYPE_NAME, strlen(OBJECT_VISIT_TEST_TYPE_NAME) + 1) &&
+    else if (!strncmp(name, OBJECT_VISIT_TEST_TYPE_NAME, strlen(OBJECT_VISIT_TEST_TYPE_NAME) + 1) &&
              (counter_val == 3 || counter_val == 5 || counter_val == 11 || counter_val == 13)) {
         if (H5O_TYPE_NAMED_DATATYPE == object_info->type)
             goto done;
@@ -7078,7 +7078,7 @@ object_visit_dset_callback(hid_t o_id, const char *name, const H5O_info2_t *obje
     UNUSED(o_id);
     UNUSED(op_data);
 
-    if (HDstrncmp(name, ".", strlen(".") + 1)) {
+    if (strncmp(name, ".", strlen(".") + 1)) {
         printf("    object '%s' didn't match known names\n", name);
         return -1;
     }
@@ -7102,7 +7102,7 @@ object_visit_dtype_callback(hid_t o_id, const char *name, const H5O_info2_t *obj
     UNUSED(o_id);
     UNUSED(op_data);
 
-    if (HDstrncmp(name, ".", strlen(".") + 1)) {
+    if (strncmp(name, ".", strlen(".") + 1)) {
         printf("    object '%s' didn't match known names\n", name);
         return -1;
     }
@@ -7128,7 +7128,7 @@ object_visit_soft_link_callback(hid_t o_id, const char *name, const H5O_info2_t 
 
     UNUSED(o_id);
 
-    if (!HDstrncmp(name, ".", strlen(".") + 1) && (counter_val <= 5)) {
+    if (!strncmp(name, ".", strlen(".") + 1) && (counter_val <= 5)) {
         if (H5O_TYPE_GROUP == object_info->type)
             goto done;
         else

--- a/test/API/H5_api_test.c
+++ b/test/API/H5_api_test.c
@@ -158,8 +158,7 @@ main(int argc, char **argv)
     if (NULL == (test_path_prefix = HDgetenv(HDF5_API_TEST_PATH_PREFIX)))
         test_path_prefix = "";
 
-    HDsnprintf(H5_api_test_filename, H5_API_TEST_FILENAME_MAX_LENGTH, "%s%s", test_path_prefix,
-               TEST_FILE_NAME);
+    snprintf(H5_api_test_filename, H5_API_TEST_FILENAME_MAX_LENGTH, "%s%s", test_path_prefix, TEST_FILE_NAME);
 
     if (NULL == (vol_connector_string = HDgetenv(HDF5_VOL_CONNECTOR))) {
         printf("No VOL connector selected; using native VOL connector\n");
@@ -169,13 +168,13 @@ main(int argc, char **argv)
     else {
         char *token;
 
-        if (NULL == (vol_connector_string_copy = HDstrdup(vol_connector_string))) {
+        if (NULL == (vol_connector_string_copy = strdup(vol_connector_string))) {
             fprintf(stderr, "Unable to copy VOL connector string\n");
             err_occurred = true;
             goto done;
         }
 
-        if (NULL == (token = HDstrtok(vol_connector_string_copy, " "))) {
+        if (NULL == (token = strtok(vol_connector_string_copy, " "))) {
             fprintf(stderr, "Error while parsing VOL connector string\n");
             err_occurred = true;
             goto done;
@@ -183,7 +182,7 @@ main(int argc, char **argv)
 
         vol_connector_name = token;
 
-        if (NULL != (token = HDstrtok(NULL, " "))) {
+        if (NULL != (token = strtok(NULL, " "))) {
             vol_connector_info = token;
         }
     }
@@ -208,7 +207,7 @@ main(int argc, char **argv)
      * Otherwise, HDF5 will default to running the tests
      * with the native connector, which could be misleading.
      */
-    if (0 != HDstrcmp(vol_connector_name, "native")) {
+    if (0 != strcmp(vol_connector_name, "native")) {
         htri_t is_registered;
 
         if ((is_registered = H5VLis_connector_registered_by_name(vol_connector_name)) < 0) {

--- a/test/API/H5_api_test_util.c
+++ b/test/API/H5_api_test_util.c
@@ -410,7 +410,7 @@ generate_random_datatype_compound(H5T_class_t H5_ATTR_UNUSED parent_class, bool 
         size_t member_size;
         char   member_name[256];
 
-        HDsnprintf(member_name, 256, "compound_member%zu", i);
+        snprintf(member_name, 256, "compound_member%zu", i);
 
         if ((compound_members[i] = generate_random_datatype(H5T_COMPOUND, is_compact)) < 0) {
             printf("    couldn't create compound datatype member %zu\n", i);
@@ -514,7 +514,7 @@ generate_random_datatype_enum(H5T_class_t H5_ATTR_UNUSED parent_class, bool H5_A
         char name[ENUM_TYPE_MAX_MEMBER_NAME_LENGTH];
         int  enum_val;
 
-        HDsnprintf(name, ENUM_TYPE_MAX_MEMBER_NAME_LENGTH, "enum_val%zu", i);
+        snprintf(name, ENUM_TYPE_MAX_MEMBER_NAME_LENGTH, "enum_val%zu", i);
 
         do {
             enum_val = rand();
@@ -750,7 +750,7 @@ prefix_filename(const char *prefix, const char *filename, char **filename_out)
         goto done;
     }
 
-    HDsnprintf(out_buf, H5_API_TEST_FILENAME_MAX_LENGTH, "%s%s", prefix, filename);
+    snprintf(out_buf, H5_API_TEST_FILENAME_MAX_LENGTH, "%s%s", prefix, filename);
 
     *filename_out = out_buf;
 

--- a/test/API/tarray.c
+++ b/test/API/tarray.c
@@ -686,7 +686,7 @@ test_array_compound_atomic(void)
     /* Check the 1st field's name */
     mname = H5Tget_member_name(tid2, 0);
     CHECK_PTR(mname, "H5Tget_member_name");
-    if (HDstrcmp(mname, "i") != 0)
+    if (strcmp(mname, "i") != 0)
         TestErrPrintf("Compound field name doesn't match!, mname=%s\n", mname);
     H5free_memory(mname);
 
@@ -705,7 +705,7 @@ test_array_compound_atomic(void)
     /* Check the 2nd field's name */
     mname = H5Tget_member_name(tid2, 1);
     CHECK_PTR(mname, "H5Tget_member_name");
-    if (HDstrcmp(mname, "f") != 0)
+    if (strcmp(mname, "f") != 0)
         TestErrPrintf("Compound field name doesn't match!, mname=%s\n", mname);
     H5free_memory(mname);
 
@@ -908,7 +908,7 @@ test_array_compound_array(void)
     /* Check the 1st field's name */
     mname = H5Tget_member_name(tid2, 0);
     CHECK_PTR(mname, "H5Tget_member_name");
-    if (HDstrcmp(mname, "i") != 0)
+    if (strcmp(mname, "i") != 0)
         TestErrPrintf("Compound field name doesn't match!, mname=%s\n", mname);
     H5free_memory(mname);
 
@@ -927,7 +927,7 @@ test_array_compound_array(void)
     /* Check the 2nd field's name */
     mname = H5Tget_member_name(tid2, 1);
     CHECK_PTR(mname, "H5Tget_member_name");
-    if (HDstrcmp(mname, "f") != 0)
+    if (strcmp(mname, "f") != 0)
         TestErrPrintf("Compound field name doesn't match!, mname=%s\n", mname);
     H5free_memory(mname);
 
@@ -1664,9 +1664,9 @@ test_array_bkg(void)
     for (i = 0; i < dtsinfo->nsubfields; i++)
         dtsinfo->name[i] = (char *)calloc((size_t)20, sizeof(char));
 
-    HDstrcpy(dtsinfo->name[0], "One");
-    HDstrcpy(dtsinfo->name[1], "Two");
-    HDstrcpy(dtsinfo->name[2], "Three");
+    strcpy(dtsinfo->name[0], "One");
+    strcpy(dtsinfo->name[1], "Two");
+    strcpy(dtsinfo->name[2], "Three");
 
     /* Create file */
     /* ----------- */
@@ -1967,7 +1967,7 @@ test_compat(void)
         /* Check the 1st field's name */
         mname = H5Tget_member_name(tid1, 0);
         CHECK_PTR(mname, "H5Tget_member_name");
-        if (HDstrcmp(mname, "i") != 0)
+        if (strcmp(mname, "i") != 0)
             TestErrPrintf("Compound field name doesn't match!, mname=%s\n", mname);
         H5free_memory(mname);
 
@@ -1986,7 +1986,7 @@ test_compat(void)
         /* Check the 2nd field's name */
         mname = H5Tget_member_name(tid1, 1);
         CHECK_PTR(mname, "H5Tget_member_name");
-        if (HDstrcmp(mname, "f") != 0)
+        if (strcmp(mname, "f") != 0)
             TestErrPrintf("Compound field name doesn't match!, mname=%s\n", mname);
         H5free_memory(mname);
 
@@ -2005,7 +2005,7 @@ test_compat(void)
         /* Check the 3rd field's name */
         mname = H5Tget_member_name(tid1, 2);
         CHECK_PTR(mname, "H5Tget_member_name");
-        if (HDstrcmp(mname, "l") != 0)
+        if (strcmp(mname, "l") != 0)
             TestErrPrintf("Compound field name doesn't match!, mname=%s\n", mname);
         H5free_memory(mname);
 
@@ -2048,7 +2048,7 @@ test_compat(void)
         /* Check the 1st field's name */
         mname = H5Tget_member_name(tid1, 0);
         CHECK_PTR(mname, "H5Tget_member_name");
-        if (mname && HDstrcmp(mname, "i") != 0)
+        if (mname && strcmp(mname, "i") != 0)
             TestErrPrintf("Compound field name doesn't match!, mname=%s\n", mname);
         if (mname)
             H5free_memory(mname);
@@ -2068,7 +2068,7 @@ test_compat(void)
         /* Check the 2nd field's name */
         mname = H5Tget_member_name(tid1, 1);
         CHECK_PTR(mname, "H5Tget_member_name");
-        if (mname && HDstrcmp(mname, "f") != 0)
+        if (mname && strcmp(mname, "f") != 0)
             TestErrPrintf("Compound field name doesn't match!, mname=%s\n", mname);
         if (mname)
             H5free_memory(mname);
@@ -2116,7 +2116,7 @@ test_compat(void)
         /* Check the 3rd field's name */
         mname = H5Tget_member_name(tid1, 2);
         CHECK_PTR(mname, "H5Tget_member_name");
-        if (mname && HDstrcmp(mname, "l") != 0)
+        if (mname && strcmp(mname, "l") != 0)
             TestErrPrintf("Compound field name doesn't match!, mname=%s\n", mname);
         if (mname)
             H5free_memory(mname);
@@ -2164,7 +2164,7 @@ test_compat(void)
         /* Check the 4th field's name */
         mname = H5Tget_member_name(tid1, 3);
         CHECK_PTR(mname, "H5Tget_member_name");
-        if (mname && HDstrcmp(mname, "d") != 0)
+        if (mname && strcmp(mname, "d") != 0)
             TestErrPrintf("Compound field name doesn't match!, mname=%s\n", mname);
         if (mname)
             H5free_memory(mname);

--- a/test/API/tattr.c
+++ b/test/API/tattr.c
@@ -314,8 +314,8 @@ test_attr_basic_write(hid_t fapl)
         if (attr_name) {
             ret = (herr_t)H5Aget_name(attr, (size_t)(attr_name_size + 1), attr_name);
             CHECK(ret, FAIL, "H5Aget_name");
-            ret = HDstrcmp(attr_name, ATTR_TMP_NAME);
-            VERIFY(ret, 0, "HDstrcmp");
+            ret = strcmp(attr_name, ATTR_TMP_NAME);
+            VERIFY(ret, 0, "strcmp");
 
             free(attr_name);
             attr_name = NULL;
@@ -351,8 +351,8 @@ test_attr_basic_write(hid_t fapl)
         if (attr_name) {
             ret = (herr_t)H5Aget_name(attr2, (size_t)(attr_name_size + 1), attr_name);
             CHECK(ret, FAIL, "H5Aget_name");
-            ret = HDstrcmp(attr_name, ATTR1A_NAME);
-            VERIFY(ret, 0, "HDstrcmp");
+            ret = strcmp(attr_name, ATTR1A_NAME);
+            VERIFY(ret, 0, "strcmp");
 
             free(attr_name);
             attr_name = NULL;
@@ -887,8 +887,8 @@ test_attr_compound_read(hid_t fapl)
     VERIFY(fields, 3, "H5Tget_nmembers");
     for (i = 0; i < fields; i++) {
         fieldname = H5Tget_member_name(type, (unsigned)i);
-        if (!(HDstrcmp(fieldname, ATTR4_FIELDNAME1) != 0 || HDstrcmp(fieldname, ATTR4_FIELDNAME2) != 0 ||
-              HDstrcmp(fieldname, ATTR4_FIELDNAME3) != 0))
+        if (!(strcmp(fieldname, ATTR4_FIELDNAME1) != 0 || strcmp(fieldname, ATTR4_FIELDNAME2) != 0 ||
+              strcmp(fieldname, ATTR4_FIELDNAME3) != 0))
             TestErrPrintf("invalid field name for field #%d: %s\n", i, fieldname);
         H5free_memory(fieldname);
     } /* end for */
@@ -947,8 +947,8 @@ test_attr_compound_read(hid_t fapl)
 
     /* Verify Name */
     name_len = H5Aget_name(attr, (size_t)ATTR_NAME_LEN, attr_name);
-    VERIFY(name_len, HDstrlen(ATTR4_NAME), "H5Aget_name");
-    if (HDstrcmp(attr_name, ATTR4_NAME) != 0)
+    VERIFY(name_len, strlen(ATTR4_NAME), "H5Aget_name");
+    if (strcmp(attr_name, ATTR4_NAME) != 0)
         TestErrPrintf("attribute name different: attr_name=%s, should be %s\n", attr_name, ATTR4_NAME);
 
     /* Close attribute datatype */
@@ -1330,16 +1330,16 @@ test_attr_mult_read(hid_t fapl)
 
     /* Verify Name */
     name_len = H5Aget_name(attr, (size_t)ATTR_NAME_LEN, attr_name);
-    VERIFY(name_len, HDstrlen(ATTR1_NAME), "H5Aget_name");
-    if (HDstrcmp(attr_name, ATTR1_NAME) != 0)
+    VERIFY(name_len, strlen(ATTR1_NAME), "H5Aget_name");
+    if (strcmp(attr_name, ATTR1_NAME) != 0)
         TestErrPrintf("attribute name different: attr_name=%s, should be %s\n", attr_name, ATTR1_NAME);
 
     /* Verify Name with too small of a buffer */
-    name_len = H5Aget_name(attr, HDstrlen(ATTR1_NAME), attr_name);
-    VERIFY(name_len, HDstrlen(ATTR1_NAME), "H5Aget_name");
-    HDstrcpy(temp_name, ATTR1_NAME);            /* make a copy of the name */
-    temp_name[HDstrlen(ATTR1_NAME) - 1] = '\0'; /* truncate it to match the one retrieved */
-    if (HDstrcmp(attr_name, temp_name) != 0)
+    name_len = H5Aget_name(attr, strlen(ATTR1_NAME), attr_name);
+    VERIFY(name_len, strlen(ATTR1_NAME), "H5Aget_name");
+    strcpy(temp_name, ATTR1_NAME);            /* make a copy of the name */
+    temp_name[strlen(ATTR1_NAME) - 1] = '\0'; /* truncate it to match the one retrieved */
+    if (strcmp(attr_name, temp_name) != 0)
         TestErrPrintf("attribute name different: attr_name=%s, should be %s\n", attr_name, temp_name);
 
     /* Close attribute */
@@ -1388,16 +1388,16 @@ test_attr_mult_read(hid_t fapl)
 
     /* Verify Name */
     name_len = H5Aget_name(attr, (size_t)ATTR_NAME_LEN, attr_name);
-    VERIFY(name_len, HDstrlen(ATTR2_NAME), "H5Aget_name");
-    if (HDstrcmp(attr_name, ATTR2_NAME) != 0)
+    VERIFY(name_len, strlen(ATTR2_NAME), "H5Aget_name");
+    if (strcmp(attr_name, ATTR2_NAME) != 0)
         TestErrPrintf("attribute name different: attr_name=%s, should be %s\n", attr_name, ATTR2_NAME);
 
     /* Verify Name with too small of a buffer */
-    name_len = H5Aget_name(attr, HDstrlen(ATTR2_NAME), attr_name);
-    VERIFY(name_len, HDstrlen(ATTR2_NAME), "H5Aget_name");
-    HDstrcpy(temp_name, ATTR2_NAME);            /* make a copy of the name */
-    temp_name[HDstrlen(ATTR2_NAME) - 1] = '\0'; /* truncate it to match the one retrieved */
-    if (HDstrcmp(attr_name, temp_name) != 0)
+    name_len = H5Aget_name(attr, strlen(ATTR2_NAME), attr_name);
+    VERIFY(name_len, strlen(ATTR2_NAME), "H5Aget_name");
+    strcpy(temp_name, ATTR2_NAME);            /* make a copy of the name */
+    temp_name[strlen(ATTR2_NAME) - 1] = '\0'; /* truncate it to match the one retrieved */
+    if (strcmp(attr_name, temp_name) != 0)
         TestErrPrintf("attribute name different: attr_name=%s, should be %s\n", attr_name, temp_name);
 
     /* Close attribute */
@@ -1450,16 +1450,16 @@ test_attr_mult_read(hid_t fapl)
 
     /* Verify Name */
     name_len = H5Aget_name(attr, (size_t)ATTR_NAME_LEN, attr_name);
-    VERIFY(name_len, HDstrlen(ATTR3_NAME), "H5Aget_name");
-    if (HDstrcmp(attr_name, ATTR3_NAME) != 0)
+    VERIFY(name_len, strlen(ATTR3_NAME), "H5Aget_name");
+    if (strcmp(attr_name, ATTR3_NAME) != 0)
         TestErrPrintf("attribute name different: attr_name=%s, should be %s\n", attr_name, ATTR3_NAME);
 
     /* Verify Name with too small of a buffer */
-    name_len = H5Aget_name(attr, HDstrlen(ATTR3_NAME), attr_name);
-    VERIFY(name_len, HDstrlen(ATTR3_NAME), "H5Aget_name");
-    HDstrcpy(temp_name, ATTR3_NAME);            /* make a copy of the name */
-    temp_name[HDstrlen(ATTR3_NAME) - 1] = '\0'; /* truncate it to match the one retrieved */
-    if (HDstrcmp(attr_name, temp_name) != 0)
+    name_len = H5Aget_name(attr, strlen(ATTR3_NAME), attr_name);
+    VERIFY(name_len, strlen(ATTR3_NAME), "H5Aget_name");
+    strcpy(temp_name, ATTR3_NAME);            /* make a copy of the name */
+    temp_name[strlen(ATTR3_NAME) - 1] = '\0'; /* truncate it to match the one retrieved */
+    if (strcmp(attr_name, temp_name) != 0)
         TestErrPrintf("attribute name different: attr_name=%s, should be %s\n", attr_name, temp_name);
 
     /* Close attribute */
@@ -1488,19 +1488,19 @@ attr_op1(hid_t H5_ATTR_UNUSED loc_id, const char *name, const H5A_info_t H5_ATTR
 
     switch (*count) {
         case 0:
-            if (HDstrcmp(name, ATTR1_NAME) != 0)
+            if (strcmp(name, ATTR1_NAME) != 0)
                 TestErrPrintf("attribute name different: name=%s, should be %s\n", name, ATTR1_NAME);
             (*count)++;
             break;
 
         case 1:
-            if (HDstrcmp(name, ATTR2_NAME) != 0)
+            if (strcmp(name, ATTR2_NAME) != 0)
                 TestErrPrintf("attribute name different: name=%s, should be %s\n", name, ATTR2_NAME);
             (*count)++;
             break;
 
         case 2:
-            if (HDstrcmp(name, ATTR3_NAME) != 0)
+            if (strcmp(name, ATTR3_NAME) != 0)
                 TestErrPrintf("attribute name different: name=%s, should be %s\n", name, ATTR3_NAME);
             (*count)++;
             break;
@@ -1647,8 +1647,8 @@ test_attr_delete(hid_t fapl)
 
     /* Verify Name */
     name_len = H5Aget_name(attr, (size_t)ATTR_NAME_LEN, attr_name);
-    VERIFY(name_len, HDstrlen(ATTR1_NAME), "H5Aget_name");
-    if (HDstrcmp(attr_name, ATTR1_NAME) != 0)
+    VERIFY(name_len, strlen(ATTR1_NAME), "H5Aget_name");
+    if (strcmp(attr_name, ATTR1_NAME) != 0)
         TestErrPrintf("attribute name different: attr_name=%s, should be %s\n", attr_name, ATTR1_NAME);
 
     /* Close attribute */
@@ -1662,8 +1662,8 @@ test_attr_delete(hid_t fapl)
 
     /* Verify Name */
     name_len = H5Aget_name(attr, (size_t)ATTR_NAME_LEN, attr_name);
-    VERIFY(name_len, HDstrlen(ATTR3_NAME), "H5Aget_name");
-    if (HDstrcmp(attr_name, ATTR3_NAME) != 0)
+    VERIFY(name_len, strlen(ATTR3_NAME), "H5Aget_name");
+    if (strcmp(attr_name, ATTR3_NAME) != 0)
         TestErrPrintf("attribute name different: attr_name=%s, should be %s\n", attr_name, ATTR3_NAME);
 
     /* Close attribute */
@@ -1686,8 +1686,8 @@ test_attr_delete(hid_t fapl)
 
     /* Verify Name */
     name_len = H5Aget_name(attr, (size_t)ATTR_NAME_LEN, attr_name);
-    VERIFY(name_len, HDstrlen(ATTR3_NAME), "H5Aget_name");
-    if (HDstrcmp(attr_name, ATTR3_NAME) != 0)
+    VERIFY(name_len, strlen(ATTR3_NAME), "H5Aget_name");
+    if (strcmp(attr_name, ATTR3_NAME) != 0)
         TestErrPrintf("attribute name different: attr_name=%s, should be %s\n", attr_name, ATTR3_NAME);
 
     /* Close attribute */
@@ -2159,7 +2159,7 @@ test_attr_dense_verify(hid_t loc_id, unsigned max_attr)
     /* Re-open all the attributes by name and verify the data */
     for (u = 0; u < max_attr; u++) {
         /* Open attribute */
-        HDsnprintf(attrname, sizeof(attrname), "attr %02u", u);
+        snprintf(attrname, sizeof(attrname), "attr %02u", u);
         attr = H5Aopen(loc_id, attrname, H5P_DEFAULT);
         CHECK(attr, FAIL, "H5Aopen");
 
@@ -2184,10 +2184,10 @@ test_attr_dense_verify(hid_t loc_id, unsigned max_attr)
         CHECK(attr, FAIL, "H5Aopen_by_idx");
 
         /* Verify Name */
-        HDsnprintf(attrname, sizeof(attrname), "attr %02u", u);
+        snprintf(attrname, sizeof(attrname), "attr %02u", u);
         name_len = H5Aget_name(attr, (size_t)ATTR_NAME_LEN, check_name);
-        VERIFY(name_len, HDstrlen(attrname), "H5Aget_name");
-        if (HDstrcmp(check_name, attrname) != 0)
+        VERIFY(name_len, strlen(attrname), "H5Aget_name");
+        if (strcmp(check_name, attrname) != 0)
             TestErrPrintf("attribute name different: attrname = '%s', should be '%s'\n", check_name,
                           attrname);
 
@@ -2288,7 +2288,7 @@ test_attr_dense_create(hid_t fcpl, hid_t fapl)
     /* Add attributes, until just before converting to dense storage */
     for (u = 0; u < max_compact; u++) {
         /* Create attribute */
-        HDsnprintf(attrname, sizeof(attrname), "attr %02u", u);
+        snprintf(attrname, sizeof(attrname), "attr %02u", u);
         attr = H5Acreate2(dataset, attrname, H5T_NATIVE_UINT, sid, H5P_DEFAULT, H5P_DEFAULT);
         CHECK(attr, FAIL, "H5Acreate2");
 
@@ -2307,7 +2307,7 @@ test_attr_dense_create(hid_t fcpl, hid_t fapl)
 #endif
     /* Add one more attribute, to push into "dense" storage */
     /* Create attribute */
-    HDsnprintf(attrname, sizeof(attrname), "attr %02u", u);
+    snprintf(attrname, sizeof(attrname), "attr %02u", u);
     attr = H5Acreate2(dataset, attrname, H5T_NATIVE_UINT, sid, H5P_DEFAULT, H5P_DEFAULT);
     CHECK(attr, FAIL, "H5Acreate2");
 #if 0
@@ -2441,7 +2441,7 @@ test_attr_dense_open(hid_t fcpl, hid_t fapl)
     /* Add attributes, until just before converting to dense storage */
     for (u = 0; u < max_compact; u++) {
         /* Create attribute */
-        HDsnprintf(attrname, sizeof(attrname), "attr %02u", u);
+        snprintf(attrname, sizeof(attrname), "attr %02u", u);
         attr = H5Acreate2(dataset, attrname, H5T_NATIVE_UINT, sid, H5P_DEFAULT, H5P_DEFAULT);
         CHECK(attr, FAIL, "H5Acreate2");
 
@@ -2464,7 +2464,7 @@ test_attr_dense_open(hid_t fcpl, hid_t fapl)
 #endif
     /* Add one more attribute, to push into "dense" storage */
     /* Create attribute */
-    HDsnprintf(attrname, sizeof(attrname), "attr %02u", u);
+    snprintf(attrname, sizeof(attrname), "attr %02u", u);
     attr = H5Acreate2(dataset, attrname, H5T_NATIVE_UINT, sid, H5P_DEFAULT, H5P_DEFAULT);
     CHECK(attr, FAIL, "H5Acreate2");
 #if 0
@@ -2608,7 +2608,7 @@ test_attr_dense_delete(hid_t fcpl, hid_t fapl)
     /* Add attributes, until well into dense storage */
     for (u = 0; u < (max_compact * 2); u++) {
         /* Create attribute */
-        HDsnprintf(attrname, sizeof(attrname), "attr %02u", u);
+        snprintf(attrname, sizeof(attrname), "attr %02u", u);
         attr = H5Acreate2(dataset, attrname, H5T_NATIVE_UINT, sid, H5P_DEFAULT, H5P_DEFAULT);
         CHECK(attr, FAIL, "H5Acreate2");
 
@@ -2653,7 +2653,7 @@ test_attr_dense_delete(hid_t fcpl, hid_t fapl)
     /* Delete attributes until the attributes revert to compact storage again */
     for (u--; u >= min_dense; u--) {
         /* Delete attribute */
-        HDsnprintf(attrname, sizeof(attrname), "attr %02u", u);
+        snprintf(attrname, sizeof(attrname), "attr %02u", u);
         ret = H5Adelete(dataset, attrname);
         CHECK(ret, FAIL, "H5Adelete");
 
@@ -2667,7 +2667,7 @@ test_attr_dense_delete(hid_t fcpl, hid_t fapl)
     VERIFY(is_dense, true, "H5O__is_attr_dense_test");
 #endif
     /* Delete one more attribute, which should cause reversion to compact storage */
-    HDsnprintf(attrname, sizeof(attrname), "attr %02u", u);
+    snprintf(attrname, sizeof(attrname), "attr %02u", u);
     ret = H5Adelete(dataset, attrname);
     CHECK(ret, FAIL, "H5Adelete");
 #if 0
@@ -2680,7 +2680,7 @@ test_attr_dense_delete(hid_t fcpl, hid_t fapl)
     CHECK(ret, FAIL, "test_attr_dense_verify");
 
     /* Delete another attribute, to verify deletion in compact storage */
-    HDsnprintf(attrname, sizeof(attrname), "attr %02u", (u - 1));
+    snprintf(attrname, sizeof(attrname), "attr %02u", (u - 1));
     ret = H5Adelete(dataset, attrname);
     CHECK(ret, FAIL, "H5Adelete");
 #if 0
@@ -2812,7 +2812,7 @@ test_attr_dense_rename(hid_t fcpl, hid_t fapl)
         /* Add attributes, until well into dense storage */
         for (u = 0; u < (max_compact * 2); u++) {
             /* Create attribute */
-            HDsnprintf(attrname, sizeof(attrname), "attr %02u", u);
+            snprintf(attrname, sizeof(attrname), "attr %02u", u);
             attr = H5Acreate2(dataset, attrname, H5T_NATIVE_UINT, sid, H5P_DEFAULT, H5P_DEFAULT);
             CHECK(attr, H5I_INVALID_HID, "H5Acreate2");
 
@@ -2825,7 +2825,7 @@ test_attr_dense_rename(hid_t fcpl, hid_t fapl)
             CHECK(ret, FAIL, "H5Aclose");
 
             /* Rename attribute */
-            HDsnprintf(new_attrname, sizeof(new_attrname), "new attr %02u", u);
+            snprintf(new_attrname, sizeof(new_attrname), "new attr %02u", u);
 
             /* Rename attribute */
             ret = H5Arename_by_name(fid, DSET1_NAME, attrname, new_attrname, H5P_DEFAULT);
@@ -2878,7 +2878,7 @@ test_attr_dense_rename(hid_t fcpl, hid_t fapl)
         unsigned value; /* Attribute value */
 
         /* Open attribute */
-        HDsnprintf(attrname, sizeof(attrname), "new attr %02u", u);
+        snprintf(attrname, sizeof(attrname), "new attr %02u", u);
         attr = H5Aopen(dataset, attrname, H5P_DEFAULT);
         CHECK(attr, H5I_INVALID_HID, "H5Aopen");
 
@@ -3005,7 +3005,7 @@ test_attr_dense_unlink(hid_t fcpl, hid_t fapl)
     /* Add attributes, until well into dense storage */
     for (u = 0; u < (max_compact * 2); u++) {
         /* Create attribute */
-        HDsnprintf(attrname, sizeof(attrname), "attr %02u", u);
+        snprintf(attrname, sizeof(attrname), "attr %02u", u);
         attr = H5Acreate2(dataset, attrname, H5T_NATIVE_UINT, sid, H5P_DEFAULT, H5P_DEFAULT);
         CHECK(attr, FAIL, "H5Acreate2");
 
@@ -3155,7 +3155,7 @@ test_attr_dense_limits(hid_t fcpl, hid_t fapl)
 
     /* Create attribute */
     u = 0;
-    HDsnprintf(attrname, sizeof(attrname), "attr %02u", u);
+    snprintf(attrname, sizeof(attrname), "attr %02u", u);
     attr = H5Acreate2(dataset, attrname, H5T_NATIVE_UINT, sid, H5P_DEFAULT, H5P_DEFAULT);
     CHECK(attr, FAIL, "H5Acreate2");
 
@@ -3176,7 +3176,7 @@ test_attr_dense_limits(hid_t fcpl, hid_t fapl)
 
     /* Create attribute */
     u = 1;
-    HDsnprintf(attrname, sizeof(attrname), "attr %02u", u);
+    snprintf(attrname, sizeof(attrname), "attr %02u", u);
     attr = H5Acreate2(dataset, attrname, H5T_NATIVE_UINT, sid, H5P_DEFAULT, H5P_DEFAULT);
     CHECK(attr, FAIL, "H5Acreate2");
 
@@ -3208,7 +3208,7 @@ test_attr_dense_limits(hid_t fcpl, hid_t fapl)
 
     /* Delete attribute */
     u = 0;
-    HDsnprintf(attrname, sizeof(attrname), "attr %02u", u);
+    snprintf(attrname, sizeof(attrname), "attr %02u", u);
     ret = H5Adelete(dataset, attrname);
     CHECK(ret, FAIL, "H5Adelete");
 #if 0
@@ -3321,7 +3321,7 @@ test_attr_dense_dup_ids(hid_t fcpl, hid_t fapl)
     /* Add attributes, until just before converting to dense storage */
     for (u = 0; u < max_compact; u++) {
         /* Create attribute */
-        HDsnprintf(attrname, sizeof(attrname), "attr %02u", u);
+        snprintf(attrname, sizeof(attrname), "attr %02u", u);
         attr = H5Acreate2(dataset, attrname, H5T_NATIVE_UINT, sid, H5P_DEFAULT, H5P_DEFAULT);
         CHECK(attr, FAIL, "H5Acreate2");
 
@@ -3344,7 +3344,7 @@ test_attr_dense_dup_ids(hid_t fcpl, hid_t fapl)
     CHECK(sid2, FAIL, "H5Screate_simple");
 
     /* Create attribute */
-    HDsnprintf(attrname, sizeof(attrname), "attr %02u", u);
+    snprintf(attrname, sizeof(attrname), "attr %02u", u);
     attr = H5Acreate2(dataset, attrname, H5T_NATIVE_INT, sid2, H5P_DEFAULT, H5P_DEFAULT);
     CHECK(attr, FAIL, "H5Acreate2");
 #if 0
@@ -3627,7 +3627,7 @@ test_attr_dense_dup_ids(hid_t fcpl, hid_t fapl)
     /* Delete a few attributes until the storage switches to compact */
     for (u = min_dense - 1; u <= max_compact; u++) {
         /* Create attribute */
-        HDsnprintf(attrname, sizeof(attrname), "attr %02u", u);
+        snprintf(attrname, sizeof(attrname), "attr %02u", u);
         add_attr = H5Acreate2(dataset, attrname, H5T_NATIVE_UINT, sid, H5P_DEFAULT, H5P_DEFAULT);
         CHECK(add_attr, FAIL, "H5Acreate2");
 
@@ -3695,7 +3695,7 @@ test_attr_dense_dup_ids(hid_t fcpl, hid_t fapl)
     /* Add attributes, until just before converting to dense storage */
     for (u = 0; u < max_compact; u++) {
         /* Create attribute */
-        HDsnprintf(attrname, sizeof(attrname), "attr %02u", u);
+        snprintf(attrname, sizeof(attrname), "attr %02u", u);
         attr = H5Acreate2(gid1, attrname, H5T_NATIVE_UINT, sid, H5P_DEFAULT, H5P_DEFAULT);
         CHECK(attr, FAIL, "H5Acreate2");
 
@@ -3867,7 +3867,7 @@ test_attr_big(hid_t fcpl, hid_t fapl)
 
     /* Create attribute */
     u = 0;
-    HDsnprintf(attrname, sizeof(attrname), "attr %02u", u);
+    snprintf(attrname, sizeof(attrname), "attr %02u", u);
     attr = H5Acreate2(dataset, attrname, H5T_NATIVE_UINT, sid, H5P_DEFAULT, H5P_DEFAULT);
     CHECK(attr, FAIL, "H5Acreate2");
 
@@ -3886,7 +3886,7 @@ test_attr_big(hid_t fcpl, hid_t fapl)
 
     /* Create attribute */
     u = 1;
-    HDsnprintf(attrname, sizeof(attrname), "attr %02u", u);
+    snprintf(attrname, sizeof(attrname), "attr %02u", u);
     attr = H5Acreate2(dataset, attrname, H5T_NATIVE_UINT, sid, H5P_DEFAULT, H5P_DEFAULT);
     CHECK(attr, FAIL, "H5Acreate2");
 
@@ -3905,7 +3905,7 @@ test_attr_big(hid_t fcpl, hid_t fapl)
 
     /* Create attribute */
     u = 2;
-    HDsnprintf(attrname, sizeof(attrname), "attr %02u", u);
+    snprintf(attrname, sizeof(attrname), "attr %02u", u);
     attr = H5Acreate2(dataset, attrname, H5T_NATIVE_UINT, big_sid, H5P_DEFAULT, H5P_DEFAULT);
     if (low == H5F_LIBVER_LATEST || attr >= 0) {
         CHECK(attr, FAIL, "H5Acreate2");
@@ -3930,7 +3930,7 @@ test_attr_big(hid_t fcpl, hid_t fapl)
 
         /* Create attribute */
         u = 3;
-        HDsnprintf(attrname, sizeof(attrname), "attr %02u", u);
+        snprintf(attrname, sizeof(attrname), "attr %02u", u);
         attr = H5Acreate2(dataset, attrname, H5T_NATIVE_UINT, big_sid, H5P_DEFAULT, H5P_DEFAULT);
         CHECK(attr, FAIL, "H5Acreate2");
 
@@ -3954,7 +3954,7 @@ test_attr_big(hid_t fcpl, hid_t fapl)
 
         /* Delete attribute */
         u = 1;
-        HDsnprintf(attrname, sizeof(attrname), "attr %02u", u);
+        snprintf(attrname, sizeof(attrname), "attr %02u", u);
         ret = H5Adelete(dataset, attrname);
         CHECK(ret, FAIL, "H5Adelete");
 #if 0
@@ -3969,7 +3969,7 @@ test_attr_big(hid_t fcpl, hid_t fapl)
 
         /* Delete attribute */
         u = 3;
-        HDsnprintf(attrname, sizeof(attrname), "attr %02u", u);
+        snprintf(attrname, sizeof(attrname), "attr %02u", u);
         ret = H5Adelete(dataset, attrname);
         CHECK(ret, FAIL, "H5Adelete");
 #if 0
@@ -3984,7 +3984,7 @@ test_attr_big(hid_t fcpl, hid_t fapl)
 
         /* Delete attribute */
         u = 2;
-        HDsnprintf(attrname, sizeof(attrname), "attr %02u", u);
+        snprintf(attrname, sizeof(attrname), "attr %02u", u);
         ret = H5Adelete(dataset, attrname);
         CHECK(ret, FAIL, "H5Adelete");
 #if 0
@@ -3999,7 +3999,7 @@ test_attr_big(hid_t fcpl, hid_t fapl)
 
         /* Delete attribute */
         u = 0;
-        HDsnprintf(attrname, sizeof(attrname), "attr %02u", u);
+        snprintf(attrname, sizeof(attrname), "attr %02u", u);
         ret = H5Adelete(dataset, attrname);
         CHECK(ret, FAIL, "H5Adelete");
 #if 0
@@ -4114,7 +4114,7 @@ test_attr_null_space(hid_t fcpl, hid_t fapl)
     /* Add attribute with 'null' dataspace */
 
     /* Create attribute */
-    HDstrcpy(attrname, "null attr");
+    strcpy(attrname, "null attr");
     attr = H5Acreate2(dataset, attrname, H5T_NATIVE_UINT, null_sid, H5P_DEFAULT, H5P_DEFAULT);
     CHECK(attr, FAIL, "H5Acreate2");
 
@@ -4155,7 +4155,7 @@ test_attr_null_space(hid_t fcpl, hid_t fapl)
     /* Add another attribute with 'null' dataspace */
 
     /* Create attribute */
-    HDstrcpy(attrname, "null attr #2");
+    strcpy(attrname, "null attr #2");
     attr = H5Acreate2(dataset, attrname, H5T_NATIVE_UINT, null_sid, H5P_DEFAULT, H5P_DEFAULT);
     CHECK(attr, FAIL, "H5Acreate2");
 
@@ -4189,7 +4189,7 @@ test_attr_null_space(hid_t fcpl, hid_t fapl)
     CHECK(dataset, FAIL, "H5Dopen2");
 
     /* Open first attribute */
-    HDstrcpy(attrname, "null attr #2");
+    strcpy(attrname, "null attr #2");
     attr = H5Aopen(dataset, attrname, H5P_DEFAULT);
     CHECK(attr, FAIL, "H5Aopen");
 
@@ -4229,7 +4229,7 @@ test_attr_null_space(hid_t fcpl, hid_t fapl)
     CHECK(ret, FAIL, "H5Aclose");
 
     /* Open second attribute */
-    HDstrcpy(attrname, "null attr");
+    strcpy(attrname, "null attr");
     attr = H5Aopen(dataset, attrname, H5P_DEFAULT);
     CHECK(attr, FAIL, "H5Aopen");
 
@@ -4416,7 +4416,7 @@ test_attr_many(bool new_format, hid_t fcpl, hid_t fapl)
 
     /* Create many attributes */
     for (u = 0; u < nattr; u++) {
-        HDsnprintf(attrname, sizeof(attrname), "a-%06u", u);
+        snprintf(attrname, sizeof(attrname), "a-%06u", u);
 
         exists = H5Aexists(gid, attrname);
         VERIFY(exists, false, "H5Aexists");
@@ -4468,7 +4468,7 @@ test_attr_many(bool new_format, hid_t fcpl, hid_t fapl)
     for (u = 0; u < nattr; u++) {
         unsigned value; /* Attribute value */
 
-        HDsnprintf(attrname, sizeof(attrname), "a-%06u", u);
+        snprintf(attrname, sizeof(attrname), "a-%06u", u);
 
         exists = H5Aexists(gid, attrname);
         VERIFY(exists, true, "H5Aexists");
@@ -4729,7 +4729,7 @@ test_attr_corder_create_compact(hid_t fcpl, hid_t fapl)
         /* Create several attributes, but keep storage in compact form */
         for (u = 0; u < max_compact; u++) {
             /* Create attribute */
-            HDsnprintf(attrname, sizeof(attrname), "attr %02u", u);
+            snprintf(attrname, sizeof(attrname), "attr %02u", u);
             attr = H5Acreate2(my_dataset, attrname, H5T_NATIVE_UINT, sid, H5P_DEFAULT, H5P_DEFAULT);
             CHECK(attr, FAIL, "H5Acreate2");
 
@@ -4819,7 +4819,7 @@ test_attr_corder_create_compact(hid_t fcpl, hid_t fapl)
             H5A_info_t ainfo; /* Attribute information */
 
             /* Retrieve information for attribute */
-            HDsnprintf(attrname, sizeof(attrname), "attr %02u", u);
+            snprintf(attrname, sizeof(attrname), "attr %02u", u);
             ret = H5Aget_info_by_name(my_dataset, ".", attrname, &ainfo, H5P_DEFAULT);
             CHECK(ret, FAIL, "H5Aget_info_by_name");
 
@@ -4936,7 +4936,7 @@ test_attr_corder_create_dense(hid_t fcpl, hid_t fapl)
         /* Create several attributes, but keep storage in compact form */
         for (u = 0; u < max_compact; u++) {
             /* Create attribute */
-            HDsnprintf(attrname, sizeof(attrname), "attr %02u", u);
+            snprintf(attrname, sizeof(attrname), "attr %02u", u);
             attr = H5Acreate2(my_dataset, attrname, H5T_NATIVE_UINT, sid, H5P_DEFAULT, H5P_DEFAULT);
             CHECK(attr, FAIL, "H5Acreate2");
 
@@ -4960,7 +4960,7 @@ test_attr_corder_create_dense(hid_t fcpl, hid_t fapl)
         } /* end for */
 
         /* Create another attribute, to push into dense storage */
-        HDsnprintf(attrname, sizeof(attrname), "attr %02u", max_compact);
+        snprintf(attrname, sizeof(attrname), "attr %02u", max_compact);
         attr = H5Acreate2(my_dataset, attrname, H5T_NATIVE_UINT, sid, H5P_DEFAULT, H5P_DEFAULT);
         CHECK(attr, FAIL, "H5Acreate2");
 
@@ -5054,7 +5054,7 @@ test_attr_corder_create_dense(hid_t fcpl, hid_t fapl)
             H5A_info_t ainfo; /* Attribute information */
 
             /* Retrieve information for attribute */
-            HDsnprintf(attrname, sizeof(attrname), "attr %02u", u);
+            snprintf(attrname, sizeof(attrname), "attr %02u", u);
             ret = H5Aget_info_by_name(my_dataset, ".", attrname, &ainfo, H5P_DEFAULT);
             CHECK(ret, FAIL, "H5Aget_info_by_name");
 
@@ -5330,7 +5330,7 @@ test_attr_corder_transition(hid_t fcpl, hid_t fapl)
         /* Create several attributes, but keep storage in compact form */
         for (u = 0; u < max_compact; u++) {
             /* Create attribute */
-            HDsnprintf(attrname, sizeof(attrname), "attr %02u", u);
+            snprintf(attrname, sizeof(attrname), "attr %02u", u);
             attr = H5Acreate2(my_dataset, attrname, H5T_NATIVE_UINT, sid, H5P_DEFAULT, H5P_DEFAULT);
             CHECK(attr, FAIL, "H5Acreate2");
 
@@ -5354,7 +5354,7 @@ test_attr_corder_transition(hid_t fcpl, hid_t fapl)
         } /* end for */
 
         /* Create another attribute, to push into dense storage */
-        HDsnprintf(attrname, sizeof(attrname), "attr %02u", max_compact);
+        snprintf(attrname, sizeof(attrname), "attr %02u", max_compact);
         attr = H5Acreate2(my_dataset, attrname, H5T_NATIVE_UINT, sid, H5P_DEFAULT, H5P_DEFAULT);
         CHECK(attr, FAIL, "H5Acreate2");
 
@@ -5382,7 +5382,7 @@ test_attr_corder_transition(hid_t fcpl, hid_t fapl)
 #endif
         /* Delete several attributes from object, until attribute storage resumes compact form */
         for (u = max_compact; u >= min_dense; u--) {
-            HDsnprintf(attrname, sizeof(attrname), "attr %02u", u);
+            snprintf(attrname, sizeof(attrname), "attr %02u", u);
             ret = H5Adelete(my_dataset, attrname);
             CHECK(ret, FAIL, "H5Adelete");
 #if 0
@@ -5403,7 +5403,7 @@ test_attr_corder_transition(hid_t fcpl, hid_t fapl)
         } /* end for */
 
         /* Delete another attribute, to push attribute storage into compact form */
-        HDsnprintf(attrname, sizeof(attrname), "attr %02u", (min_dense - 1));
+        snprintf(attrname, sizeof(attrname), "attr %02u", (min_dense - 1));
         ret = H5Adelete(my_dataset, attrname);
         CHECK(ret, FAIL, "H5Adelete");
 #if 0
@@ -5419,7 +5419,7 @@ test_attr_corder_transition(hid_t fcpl, hid_t fapl)
         /* Re-add attributes to get back into dense form */
         for (u = (min_dense - 1); u < (max_compact + 1); u++) {
             /* Create attribute */
-            HDsnprintf(attrname, sizeof(attrname), "attr %02u", u);
+            snprintf(attrname, sizeof(attrname), "attr %02u", u);
             attr = H5Acreate2(my_dataset, attrname, H5T_NATIVE_UINT, sid, H5P_DEFAULT, H5P_DEFAULT);
             CHECK(attr, FAIL, "H5Acreate2");
 
@@ -5507,7 +5507,7 @@ test_attr_corder_transition(hid_t fcpl, hid_t fapl)
 #endif
         /* Delete several attributes from object, until attribute storage resumes compact form */
         for (u = max_compact; u >= min_dense; u--) {
-            HDsnprintf(attrname, sizeof(attrname), "attr %02u", u);
+            snprintf(attrname, sizeof(attrname), "attr %02u", u);
             ret = H5Adelete(my_dataset, attrname);
             CHECK(ret, FAIL, "H5Adelete");
 #if 0
@@ -5528,7 +5528,7 @@ test_attr_corder_transition(hid_t fcpl, hid_t fapl)
         } /* end for */
 
         /* Delete another attribute, to push attribute storage into compact form */
-        HDsnprintf(attrname, sizeof(attrname), "attr %02u", (min_dense - 1));
+        snprintf(attrname, sizeof(attrname), "attr %02u", (min_dense - 1));
         ret = H5Adelete(my_dataset, attrname);
         CHECK(ret, FAIL, "H5Adelete");
 #if 0
@@ -5544,7 +5544,7 @@ test_attr_corder_transition(hid_t fcpl, hid_t fapl)
         /* Re-add attributes to get back into dense form */
         for (u = (min_dense - 1); u < (max_compact + 1); u++) {
             /* Create attribute */
-            HDsnprintf(attrname, sizeof(attrname), "attr %02u", u);
+            snprintf(attrname, sizeof(attrname), "attr %02u", u);
             attr = H5Acreate2(my_dataset, attrname, H5T_NATIVE_UINT, sid, H5P_DEFAULT, H5P_DEFAULT);
             CHECK(attr, FAIL, "H5Acreate2");
 
@@ -5573,11 +5573,11 @@ test_attr_corder_transition(hid_t fcpl, hid_t fapl)
 #endif
         /* Delete all attributes */
         for (u = max_compact; u > 0; u--) {
-            HDsnprintf(attrname, sizeof(attrname), "attr %02u", u);
+            snprintf(attrname, sizeof(attrname), "attr %02u", u);
             ret = H5Adelete(my_dataset, attrname);
             CHECK(ret, FAIL, "H5Adelete");
         } /* end for */
-        HDsnprintf(attrname, sizeof(attrname), "attr %02u", 0);
+        snprintf(attrname, sizeof(attrname), "attr %02u", 0);
         ret = H5Adelete(my_dataset, attrname);
         CHECK(ret, FAIL, "H5Adelete");
     } /* end for */
@@ -5719,7 +5719,7 @@ test_attr_corder_delete(hid_t fcpl, hid_t fapl)
             /* Create attributes, until attribute storage is in dense form */
             for (u = 0; u < max_compact * 2; u++) {
                 /* Create attribute */
-                HDsnprintf(attrname, sizeof(attrname), "attr %02u", u);
+                snprintf(attrname, sizeof(attrname), "attr %02u", u);
                 attr = H5Acreate2(my_dataset, attrname, H5T_NATIVE_UINT, sid, H5P_DEFAULT, H5P_DEFAULT);
                 CHECK(attr, FAIL, "H5Acreate2");
 
@@ -5848,7 +5848,7 @@ attr_info_by_idx_check(hid_t obj_id, const char *attrname, hsize_t n, bool use_i
     ret = (herr_t)H5Aget_name_by_idx(obj_id, ".", H5_INDEX_CRT_ORDER, H5_ITER_INC, n, tmpname,
                                      (size_t)NAME_BUF_SIZE, H5P_DEFAULT);
     CHECK(ret, FAIL, "H5Aget_name_by_idx");
-    if (HDstrcmp(attrname, tmpname) != 0)
+    if (strcmp(attrname, tmpname) != 0)
         TestErrPrintf("Line %d: attribute name size wrong!\n", __LINE__);
 
     /* Don't test "native" order if there is no creation order index, since
@@ -5875,7 +5875,7 @@ attr_info_by_idx_check(hid_t obj_id, const char *attrname, hsize_t n, bool use_i
         ret = (herr_t)H5Aget_name_by_idx(obj_id, ".", H5_INDEX_CRT_ORDER, H5_ITER_INC /* H5_ITER_NATIVE */, n,
                                          tmpname, (size_t)NAME_BUF_SIZE, H5P_DEFAULT);
         CHECK(ret, FAIL, "H5Aget_name_by_idx");
-        if (HDstrcmp(attrname, tmpname) != 0)
+        if (strcmp(attrname, tmpname) != 0)
             TestErrPrintf("Line %d: attribute name size wrong!\n", __LINE__);
     } /* end if */
 
@@ -5896,7 +5896,7 @@ attr_info_by_idx_check(hid_t obj_id, const char *attrname, hsize_t n, bool use_i
     ret = (herr_t)H5Aget_name_by_idx(obj_id, ".", H5_INDEX_CRT_ORDER, H5_ITER_DEC, (hsize_t)0, tmpname,
                                      (size_t)NAME_BUF_SIZE, H5P_DEFAULT);
     CHECK(ret, FAIL, "H5Aget_name_by_idx");
-    if (HDstrcmp(attrname, tmpname) != 0)
+    if (strcmp(attrname, tmpname) != 0)
         TestErrPrintf("Line %d: attribute name size wrong!\n", __LINE__);
 
     /* Verify the information for first attribute, in increasing name order */
@@ -5916,7 +5916,7 @@ attr_info_by_idx_check(hid_t obj_id, const char *attrname, hsize_t n, bool use_i
     ret = (herr_t)H5Aget_name_by_idx(obj_id, ".", H5_INDEX_NAME, H5_ITER_INC, n, tmpname,
                                      (size_t)NAME_BUF_SIZE, H5P_DEFAULT);
     CHECK(ret, FAIL, "H5Aget_name_by_idx");
-    if (HDstrcmp(attrname, tmpname) != 0)
+    if (strcmp(attrname, tmpname) != 0)
         TestErrPrintf("Line %d: attribute name size wrong!\n", __LINE__);
 
     /* Don't test "native" order queries on link name order, since there's not
@@ -5940,7 +5940,7 @@ attr_info_by_idx_check(hid_t obj_id, const char *attrname, hsize_t n, bool use_i
     ret = (herr_t)H5Aget_name_by_idx(obj_id, ".", H5_INDEX_NAME, H5_ITER_DEC, (hsize_t)0, tmpname,
                                      (size_t)NAME_BUF_SIZE, H5P_DEFAULT);
     CHECK(ret, FAIL, "H5Aget_name_by_idx");
-    if (HDstrcmp(attrname, tmpname) != 0)
+    if (strcmp(attrname, tmpname) != 0)
         TestErrPrintf("Line %d: attribute name size wrong!\n", __LINE__);
 
     /* Retrieve current # of errors */
@@ -6071,7 +6071,7 @@ test_attr_info_by_idx(bool new_format, hid_t fcpl, hid_t fapl)
             /* Create attributes, up to limit of compact form */
             for (u = 0; u < max_compact; u++) {
                 /* Create attribute */
-                HDsnprintf(attrname, sizeof(attrname), "attr %02u", u);
+                snprintf(attrname, sizeof(attrname), "attr %02u", u);
                 attr = H5Acreate2(my_dataset, attrname, H5T_NATIVE_UINT, sid, H5P_DEFAULT, H5P_DEFAULT);
                 CHECK(attr, FAIL, "H5Acreate2");
 
@@ -6123,7 +6123,7 @@ test_attr_info_by_idx(bool new_format, hid_t fcpl, hid_t fapl)
             /* Create more attributes, to push into dense form */
             for (; u < (max_compact * 2); u++) {
                 /* Create attribute */
-                HDsnprintf(attrname, sizeof(attrname), "attr %02u", u);
+                snprintf(attrname, sizeof(attrname), "attr %02u", u);
                 attr = H5Acreate2(my_dataset, attrname, H5T_NATIVE_UINT, sid, H5P_DEFAULT, H5P_DEFAULT);
                 CHECK(attr, FAIL, "H5Acreate2");
 
@@ -6592,7 +6592,7 @@ test_attr_delete_by_idx(bool new_format, hid_t fcpl, hid_t fapl)
                     /* Create attributes, up to limit of compact form */
                     for (u = 0; u < max_compact; u++) {
                         /* Create attribute */
-                        HDsnprintf(attrname, sizeof(attrname), "attr %02u", u);
+                        snprintf(attrname, sizeof(attrname), "attr %02u", u);
                         attr =
                             H5Acreate2(my_dataset, attrname, H5T_NATIVE_UINT, sid, H5P_DEFAULT, H5P_DEFAULT);
                         CHECK(attr, FAIL, "H5Acreate2");
@@ -6671,10 +6671,10 @@ test_attr_delete_by_idx(bool new_format, hid_t fcpl, hid_t fapl)
                         ret = (herr_t)H5Aget_name_by_idx(my_dataset, ".", idx_type, order, (hsize_t)0,
                                                          tmpname, (size_t)NAME_BUF_SIZE, H5P_DEFAULT);
                         if (order == H5_ITER_INC)
-                            HDsnprintf(attrname, sizeof(attrname), "attr %02u", (u + 1));
+                            snprintf(attrname, sizeof(attrname), "attr %02u", (u + 1));
                         else
-                            HDsnprintf(attrname, sizeof(attrname), "attr %02u", (max_compact - (u + 2)));
-                        ret = HDstrcmp(attrname, tmpname);
+                            snprintf(attrname, sizeof(attrname), "attr %02u", (max_compact - (u + 2)));
+                        ret = strcmp(attrname, tmpname);
                         VERIFY(ret, 0, "H5Aget_name_by_idx");
                     } /* end for */
 
@@ -6710,7 +6710,7 @@ test_attr_delete_by_idx(bool new_format, hid_t fcpl, hid_t fapl)
                     /* Create more attributes, to push into dense form */
                     for (u = 0; u < (max_compact * 2); u++) {
                         /* Create attribute */
-                        HDsnprintf(attrname, sizeof(attrname), "attr %02u", u);
+                        snprintf(attrname, sizeof(attrname), "attr %02u", u);
                         attr =
                             H5Acreate2(my_dataset, attrname, H5T_NATIVE_UINT, sid, H5P_DEFAULT, H5P_DEFAULT);
                         CHECK(attr, FAIL, "H5Acreate2");
@@ -6804,11 +6804,10 @@ test_attr_delete_by_idx(bool new_format, hid_t fcpl, hid_t fapl)
                         ret = (herr_t)H5Aget_name_by_idx(my_dataset, ".", idx_type, order, (hsize_t)0,
                                                          tmpname, (size_t)NAME_BUF_SIZE, H5P_DEFAULT);
                         if (order == H5_ITER_INC)
-                            HDsnprintf(attrname, sizeof(attrname), "attr %02u", (u + 1));
+                            snprintf(attrname, sizeof(attrname), "attr %02u", (u + 1));
                         else
-                            HDsnprintf(attrname, sizeof(attrname), "attr %02u",
-                                       ((max_compact * 2) - (u + 2)));
-                        ret = HDstrcmp(attrname, tmpname);
+                            snprintf(attrname, sizeof(attrname), "attr %02u", ((max_compact * 2) - (u + 2)));
+                        ret = strcmp(attrname, tmpname);
                         VERIFY(ret, 0, "H5Aget_name_by_idx");
                     } /* end for */
 
@@ -6853,7 +6852,7 @@ test_attr_delete_by_idx(bool new_format, hid_t fcpl, hid_t fapl)
                     /* Create attributes, to push into dense form */
                     for (u = 0; u < (max_compact * 2); u++) {
                         /* Create attribute */
-                        HDsnprintf(attrname, sizeof(attrname), "attr %02u", u);
+                        snprintf(attrname, sizeof(attrname), "attr %02u", u);
                         attr =
                             H5Acreate2(my_dataset, attrname, H5T_NATIVE_UINT, sid, H5P_DEFAULT, H5P_DEFAULT);
                         CHECK(attr, FAIL, "H5Acreate2");
@@ -6922,11 +6921,11 @@ test_attr_delete_by_idx(bool new_format, hid_t fcpl, hid_t fapl)
                         ret = (herr_t)H5Aget_name_by_idx(my_dataset, ".", idx_type, order, (hsize_t)u,
                                                          tmpname, (size_t)NAME_BUF_SIZE, H5P_DEFAULT);
                         if (order == H5_ITER_INC)
-                            HDsnprintf(attrname, sizeof(attrname), "attr %02u", ((u * 2) + 1));
+                            snprintf(attrname, sizeof(attrname), "attr %02u", ((u * 2) + 1));
                         else
-                            HDsnprintf(attrname, sizeof(attrname), "attr %02u",
-                                       ((max_compact * 2) - ((u * 2) + 2)));
-                        ret = HDstrcmp(attrname, tmpname);
+                            snprintf(attrname, sizeof(attrname), "attr %02u",
+                                     ((max_compact * 2) - ((u * 2) + 2)));
+                        ret = strcmp(attrname, tmpname);
                         VERIFY(ret, 0, "H5Aget_name_by_idx");
                     } /* end for */
                 }     /* end for */
@@ -6975,11 +6974,11 @@ test_attr_delete_by_idx(bool new_format, hid_t fcpl, hid_t fapl)
                         ret = (herr_t)H5Aget_name_by_idx(my_dataset, ".", idx_type, order, (hsize_t)0,
                                                          tmpname, (size_t)NAME_BUF_SIZE, H5P_DEFAULT);
                         if (order == H5_ITER_INC)
-                            HDsnprintf(attrname, sizeof(attrname), "attr %02u", ((u * 2) + 3));
+                            snprintf(attrname, sizeof(attrname), "attr %02u", ((u * 2) + 3));
                         else
-                            HDsnprintf(attrname, sizeof(attrname), "attr %02u",
-                                       ((max_compact * 2) - ((u * 2) + 4)));
-                        ret = HDstrcmp(attrname, tmpname);
+                            snprintf(attrname, sizeof(attrname), "attr %02u",
+                                     ((max_compact * 2) - ((u * 2) + 4)));
+                        ret = strcmp(attrname, tmpname);
                         VERIFY(ret, 0, "H5Aget_name_by_idx");
                     } /* end for */
 
@@ -7063,8 +7062,8 @@ attr_iterate2_cb(hid_t loc_id, const char *attr_name, const H5A_info_t *info, vo
     } /* end if */
 
     /* Verify name of link */
-    HDsnprintf(attrname, sizeof(attrname), "attr %02u", (unsigned)my_info.corder);
-    if (HDstrcmp(attr_name, attrname) != 0)
+    snprintf(attrname, sizeof(attrname), "attr %02u", (unsigned)my_info.corder);
+    if (strcmp(attr_name, attrname) != 0)
         return (H5_ITER_ERROR);
 
     /* Check if we've visited this link before */
@@ -7604,7 +7603,7 @@ test_attr_iterate2(bool new_format, hid_t fcpl, hid_t fapl)
                     /* Create attributes, up to limit of compact form */
                     for (u = 0; u < max_compact; u++) {
                         /* Create attribute */
-                        HDsnprintf(attrname, sizeof(attrname), "attr %02u", u);
+                        snprintf(attrname, sizeof(attrname), "attr %02u", u);
                         attr =
                             H5Acreate2(my_dataset, attrname, H5T_NATIVE_UINT, sid, H5P_DEFAULT, H5P_DEFAULT);
                         CHECK(attr, FAIL, "H5Acreate2");
@@ -7691,7 +7690,7 @@ test_attr_iterate2(bool new_format, hid_t fcpl, hid_t fapl)
                     /* Create more attributes, to push into dense form */
                     for (u = max_compact; u < (max_compact * 2); u++) {
                         /* Create attribute */
-                        HDsnprintf(attrname, sizeof(attrname), "attr %02u", u);
+                        snprintf(attrname, sizeof(attrname), "attr %02u", u);
                         attr =
                             H5Acreate2(my_dataset, attrname, H5T_NATIVE_UINT, sid, H5P_DEFAULT, H5P_DEFAULT);
                         CHECK(attr, FAIL, "H5Acreate2");
@@ -8005,7 +8004,7 @@ test_attr_open_by_idx(bool new_format, hid_t fcpl, hid_t fapl)
                     /* Create attributes, up to limit of compact form */
                     for (u = 0; u < max_compact; u++) {
                         /* Create attribute */
-                        HDsnprintf(attrname, sizeof(attrname), "attr %02u", u);
+                        snprintf(attrname, sizeof(attrname), "attr %02u", u);
                         attr =
                             H5Acreate2(my_dataset, attrname, H5T_NATIVE_UINT, sid, H5P_DEFAULT, H5P_DEFAULT);
                         CHECK(attr, FAIL, "H5Acreate2");
@@ -8068,7 +8067,7 @@ test_attr_open_by_idx(bool new_format, hid_t fcpl, hid_t fapl)
                     /* Create more attributes, to push into dense form */
                     for (u = max_compact; u < (max_compact * 2); u++) {
                         /* Create attribute */
-                        HDsnprintf(attrname, sizeof(attrname), "attr %02u", u);
+                        snprintf(attrname, sizeof(attrname), "attr %02u", u);
                         attr =
                             H5Acreate2(my_dataset, attrname, H5T_NATIVE_UINT, sid, H5P_DEFAULT, H5P_DEFAULT);
                         CHECK(attr, FAIL, "H5Acreate2");
@@ -8174,7 +8173,7 @@ attr_open_check(hid_t fid, const char *dsetname, hid_t obj_id, unsigned max_attr
     /* Open each attribute on object by index and check that it's the correct one */
     for (u = 0; u < max_attrs; u++) {
         /* Open the attribute */
-        HDsnprintf(attrname, sizeof(attrname), "attr %02u", u);
+        snprintf(attrname, sizeof(attrname), "attr %02u", u);
         attr_id = H5Aopen(obj_id, attrname, H5P_DEFAULT);
         CHECK(attr_id, FAIL, "H5Aopen");
 
@@ -8357,7 +8356,7 @@ test_attr_open_by_name(bool new_format, hid_t fcpl, hid_t fapl)
             /* Create attributes, up to limit of compact form */
             for (u = 0; u < max_compact; u++) {
                 /* Create attribute */
-                HDsnprintf(attrname, sizeof(attrname), "attr %02u", u);
+                snprintf(attrname, sizeof(attrname), "attr %02u", u);
                 attr = H5Acreate2(my_dataset, attrname, H5T_NATIVE_UINT, sid, H5P_DEFAULT, H5P_DEFAULT);
                 CHECK(attr, FAIL, "H5Acreate2");
 
@@ -8435,7 +8434,7 @@ test_attr_open_by_name(bool new_format, hid_t fcpl, hid_t fapl)
             /* Create more attributes, to push into dense form */
             for (u = max_compact; u < (max_compact * 2); u++) {
                 /* Create attribute */
-                HDsnprintf(attrname, sizeof(attrname), "attr %02u", u);
+                snprintf(attrname, sizeof(attrname), "attr %02u", u);
                 attr = H5Acreate2(my_dataset, attrname, H5T_NATIVE_UINT, sid, H5P_DEFAULT, H5P_DEFAULT);
                 CHECK(attr, FAIL, "H5Acreate2");
 
@@ -8632,7 +8631,7 @@ test_attr_create_by_name(bool new_format, hid_t fcpl, hid_t fapl)
             /* Create attributes, up to limit of compact form */
             for (u = 0; u < max_compact; u++) {
                 /* Create attribute */
-                HDsnprintf(attrname, sizeof(attrname), "attr %02u", u);
+                snprintf(attrname, sizeof(attrname), "attr %02u", u);
                 attr = H5Acreate_by_name(fid, dsetname, attrname, H5T_NATIVE_UINT, sid, H5P_DEFAULT,
                                          H5P_DEFAULT, H5P_DEFAULT);
                 CHECK(attr, FAIL, "H5Acreate_by_name");
@@ -8689,7 +8688,7 @@ test_attr_create_by_name(bool new_format, hid_t fcpl, hid_t fapl)
             /* Create more attributes, to push into dense form */
             for (u = max_compact; u < (max_compact * 2); u++) {
                 /* Create attribute */
-                HDsnprintf(attrname, sizeof(attrname), "attr %02u", u);
+                snprintf(attrname, sizeof(attrname), "attr %02u", u);
                 attr = H5Acreate_by_name(fid, dsetname, attrname, H5T_NATIVE_UINT, sid, H5P_DEFAULT,
                                          H5P_DEFAULT, H5P_DEFAULT);
                 CHECK(attr, FAIL, "H5Acreate_by_name");
@@ -8923,7 +8922,7 @@ test_attr_shared_write(hid_t fcpl, hid_t fapl)
         /* Add attributes to each dataset, until after converting to dense storage */
         for (u = 0; u < max_compact * 2; u++) {
             /* Create attribute name */
-            HDsnprintf(attrname, sizeof(attrname), "attr %02u", u);
+            snprintf(attrname, sizeof(attrname), "attr %02u", u);
 
             /* Alternate between creating "small" & "big" attributes */
             if (u % 2) {
@@ -9272,7 +9271,7 @@ test_attr_shared_rename(hid_t fcpl, hid_t fapl)
         /* Add attributes to each dataset, until after converting to dense storage */
         for (u = 0; u < max_compact * 2; u++) {
             /* Create attribute name */
-            HDsnprintf(attrname, sizeof(attrname), "attr %02u", u);
+            snprintf(attrname, sizeof(attrname), "attr %02u", u);
 
             /* Alternate between creating "small" & "big" attributes */
             if (u % 2) {
@@ -9381,7 +9380,7 @@ test_attr_shared_rename(hid_t fcpl, hid_t fapl)
 #endif
 
             /* Create new attribute name */
-            HDsnprintf(attrname2, sizeof(attrname2), "new attr %02u", u);
+            snprintf(attrname2, sizeof(attrname2), "new attr %02u", u);
 
             /* Change second dataset's attribute's name */
             ret = H5Arename_by_name(fid, DSET2_NAME, attrname, attrname2, H5P_DEFAULT);
@@ -9731,7 +9730,7 @@ test_attr_shared_delete(hid_t fcpl, hid_t fapl)
         /* Add attributes to each dataset, until after converting to dense storage */
         for (u = 0; u < max_compact * 2; u++) {
             /* Create attribute name */
-            HDsnprintf(attrname, sizeof(attrname), "attr %02u", u);
+            snprintf(attrname, sizeof(attrname), "attr %02u", u);
 
             /* Alternate between creating "small" & "big" attributes */
             if (u % 2) {
@@ -9843,7 +9842,7 @@ test_attr_shared_delete(hid_t fcpl, hid_t fapl)
         /* Delete attributes from second dataset */
         for (u = 0; u < max_compact * 2; u++) {
             /* Create attribute name */
-            HDsnprintf(attrname, sizeof(attrname), "attr %02u", u);
+            snprintf(attrname, sizeof(attrname), "attr %02u", u);
 
             /* Delete second dataset's attribute */
             ret = H5Adelete_by_name(fid, DSET2_NAME, attrname, H5P_DEFAULT);
@@ -10115,7 +10114,7 @@ test_attr_shared_unlink(hid_t fcpl, hid_t fapl)
         /* Add attributes to each dataset, until after converting to dense storage */
         for (u = 0; u < max_compact * 2; u++) {
             /* Create attribute name */
-            HDsnprintf(attrname, sizeof(attrname), "attr %02u", u);
+            snprintf(attrname, sizeof(attrname), "attr %02u", u);
 
             /* Alternate between creating "small" & "big" attributes */
             if (u % 2) {
@@ -10244,7 +10243,7 @@ test_attr_shared_unlink(hid_t fcpl, hid_t fapl)
         /* Check ref count on  attributes of first dataset */
         for (u = 0; u < max_compact * 2; u++) {
             /* Create attribute name */
-            HDsnprintf(attrname, sizeof(attrname), "attr %02u", u);
+            snprintf(attrname, sizeof(attrname), "attr %02u", u);
 
             /* Open attribute on first dataset */
             attr = H5Aopen(dataset, attrname, H5P_DEFAULT);
@@ -10518,7 +10517,7 @@ test_attr_bug2(hid_t fcpl, hid_t fapl)
 
     /* Create attributes on group */
     for (i = 0; i < BUG2_NATTR; i++) {
-        HDsnprintf(aname, sizeof(aname), "%03u", i);
+        snprintf(aname, sizeof(aname), "%03u", i);
         aid = H5Acreate2(gid, aname, H5T_STD_I32LE, sid, H5P_DEFAULT, H5P_DEFAULT);
         CHECK(aid, FAIL, "H5Acreate2");
 
@@ -10528,7 +10527,7 @@ test_attr_bug2(hid_t fcpl, hid_t fapl)
 
     /* Delete every other attribute */
     for (i = 1; i < BUG2_NATTR; i += 2) {
-        HDsnprintf(aname, sizeof(aname), "%03u", i);
+        snprintf(aname, sizeof(aname), "%03u", i);
         ret = H5Adelete(gid, aname);
         CHECK(ret, FAIL, "H5Adelete");
     }
@@ -10552,7 +10551,7 @@ test_attr_bug2(hid_t fcpl, hid_t fapl)
 
     /* Open an attribute in the middle */
     i = (BUG2_NATTR / 4) * 2;
-    HDsnprintf(aname, sizeof(aname), "%03u", i);
+    snprintf(aname, sizeof(aname), "%03u", i);
     aid = H5Aopen(gid, aname, H5P_DEFAULT);
     CHECK(aid, FAIL, "H5Aopen");
 
@@ -10595,7 +10594,7 @@ test_attr_bug2(hid_t fcpl, hid_t fapl)
 
     /* Create attributes on group */
     for (i = 0; i < BUG2_NATTR2; i++) {
-        HDsnprintf(aname, sizeof(aname), "%03u", i);
+        snprintf(aname, sizeof(aname), "%03u", i);
         aid = H5Acreate2(gid, aname, H5T_STD_I32LE, sid, H5P_DEFAULT, H5P_DEFAULT);
         CHECK(aid, FAIL, "H5Acreate2");
 
@@ -10605,7 +10604,7 @@ test_attr_bug2(hid_t fcpl, hid_t fapl)
 
     /* Delete every other attribute */
     for (i = 0; i < BUG2_NATTR2; i++) {
-        HDsnprintf(aname, sizeof(aname), "%03u", i);
+        snprintf(aname, sizeof(aname), "%03u", i);
         ret = H5Adelete(gid, aname);
         CHECK(ret, FAIL, "H5Adelete");
     }
@@ -11465,7 +11464,7 @@ test_attr_bug9(hid_t fcpl, hid_t fapl)
         /* Create enough attributes to cause a change to dense storage */
         for (i = 0; i < max_compact + 1; i++) {
             /* Create attribute */
-            HDsnprintf(aname, sizeof(aname), "%u", i);
+            snprintf(aname, sizeof(aname), "%u", i);
             aid = H5Acreate2(gid, aname, H5T_NATIVE_CHAR, sid, H5P_DEFAULT, H5P_DEFAULT);
             CHECK(aid, FAIL, "H5Acreate2");
 

--- a/test/API/tcoords.c
+++ b/test/API/tcoords.c
@@ -87,9 +87,9 @@ test_singleEnd_selElements(hid_t file, bool is_chunked)
 
     /* Construct dataset's name */
     memset(dset_name, 0, (size_t)NAME_LEN);
-    HDstrcat(dset_name, SINGLE_END_DSET);
+    strcat(dset_name, SINGLE_END_DSET);
     if (is_chunked)
-        HDstrcat(dset_name, "_chunked");
+        strcat(dset_name, "_chunked");
 
     did = H5Dcreate2(file, dset_name, H5T_NATIVE_INT, sid, H5P_DEFAULT, plid, H5P_DEFAULT);
     CHECK(did, FAIL, "H5Dcreate2");
@@ -259,9 +259,9 @@ test_singleEnd_selHyperslab(hid_t file, bool is_chunked)
 
     /* Construct dataset's name */
     memset(dset_name, 0, NAME_LEN);
-    HDstrcat(dset_name, SINGLE_END_DSET);
+    strcat(dset_name, SINGLE_END_DSET);
     if (is_chunked)
-        HDstrcat(dset_name, "_chunked");
+        strcat(dset_name, "_chunked");
 
     /* Dataspace for the dataset in file */
     sid = H5Screate_simple(4, da_dims, da_dims);
@@ -462,9 +462,9 @@ test_multiple_ends(hid_t file, bool is_chunked)
 
     /* Construct dataset's name */
     memset(dset_name, 0, NAME_LEN);
-    HDstrcat(dset_name, MULTI_ENDS_SEL_HYPER_DSET);
+    strcat(dset_name, MULTI_ENDS_SEL_HYPER_DSET);
     if (is_chunked)
-        HDstrcat(dset_name, "_chunked");
+        strcat(dset_name, "_chunked");
 
     did = H5Dcreate2(file, dset_name, H5T_NATIVE_INT, sid, H5P_DEFAULT, plid, H5P_DEFAULT);
     CHECK(did, FAIL, "H5Dcreate2");

--- a/test/API/testhdf5.c
+++ b/test/API/testhdf5.c
@@ -56,7 +56,7 @@ print_func(const char *format, ...)
     int     ret_value;
 
     va_start(arglist, format);
-    ret_value = HDvprintf(format, arglist);
+    ret_value = vprintf(format, arglist);
     va_end(arglist);
     return ret_value;
 }
@@ -76,7 +76,7 @@ TestErrPrintf(const char *format, ...)
 
     /* Print the requested information */
     va_start(arglist, format);
-    ret_value = HDvprintf(format, arglist);
+    ret_value = vprintf(format, arglist);
     va_end(arglist);
 
     /* Return the length of the string produced (like printf() does) */
@@ -123,7 +123,7 @@ getenv_all(MPI_Comm comm, int root, const char *name)
         if (mpi_rank == root) {
             env = HDgetenv(name);
             if (env) {
-                len = (int)HDstrlen(env);
+                len = (int)strlen(env);
                 MPI_Bcast(&len, 1, MPI_INT, root, comm);
                 MPI_Bcast(env, len, MPI_CHAR, root, comm);
             }
@@ -138,7 +138,7 @@ getenv_all(MPI_Comm comm, int root, const char *name)
             if (len >= 0) {
                 if (env == NULL)
                     env = (char *)malloc((size_t)len + 1);
-                else if (HDstrlen(env) < (size_t)len)
+                else if (strlen(env) < (size_t)len)
                     env = (char *)realloc(env, (size_t)len + 1);
 
                 MPI_Bcast(env, len, MPI_CHAR, root, comm);
@@ -235,12 +235,12 @@ h5_get_libver_fapl(hid_t fapl)
      * If it's nothing (environment variable was whitespace)
      * just return the default fapl.
      */
-    HDstrncpy(buf, env, sizeof(buf));
+    strncpy(buf, env, sizeof(buf));
     buf[sizeof(buf) - 1] = '\0';
     if (NULL == (tok = HDstrtok_r(buf, " \t\n\r", &lasts)))
         goto done;
 
-    if (!HDstrcmp(tok, "latest")) {
+    if (!strcmp(tok, "latest")) {
         /* use the latest format */
         if (H5Pset_libver_bounds(fapl, H5F_LIBVER_LATEST, H5F_LIBVER_LATEST) < 0)
             goto error;
@@ -302,7 +302,7 @@ h5_fixname_real(const char *base_name, hid_t fapl, const char *_suffix, char *fu
                  * we are using the split driver since both of those
                  * use the multi VFD under the hood.
                  */
-                if (driver_env_var && !HDstrcmp(driver_env_var, "split")) {
+                if (driver_env_var && !strcmp(driver_env_var, "split")) {
                     /* split VFD */
                     if (subst_for_superblock)
                         suffix = ".h5.meta";
@@ -396,7 +396,7 @@ h5_fixname_real(const char *base_name, hid_t fapl, const char *_suffix, char *fu
             /* This is a parallel system */
             char *subdir;
 
-            if (!HDstrcmp(prefix, HDF5_PARAPREFIX)) {
+            if (!strcmp(prefix, HDF5_PARAPREFIX)) {
                 /*
                  * If the prefix specifies the HDF5_PARAPREFIX directory, then
                  * default to using the "/tmp/$USER" or "/tmp/$LOGIN"
@@ -421,11 +421,11 @@ h5_fixname_real(const char *base_name, hid_t fapl, const char *_suffix, char *fu
 
             if (!fullname[0]) {
                 /* We didn't append the prefix yet */
-                HDstrncpy(fullname, prefix, size);
+                strncpy(fullname, prefix, size);
                 fullname[size - 1] = '\0';
             }
 
-            if (HDstrlen(fullname) + HDstrlen(base_name) + 1 < size) {
+            if (strlen(fullname) + strlen(base_name) + 1 < size) {
                 /*
                  * Append the base_name with a slash first. Multiple
                  * slashes are handled below.
@@ -440,10 +440,10 @@ h5_fixname_real(const char *base_name, hid_t fapl, const char *_suffix, char *fu
                          * subdirectory.  Default to PREFIX's original
                          * prefix value.
                          */
-                        HDstrcpy(fullname, prefix);
+                        strcpy(fullname, prefix);
 
-                HDstrcat(fullname, "/");
-                HDstrcat(fullname, base_name);
+                strcat(fullname, "/");
+                strcat(fullname, base_name);
             }
             else {
                 /* Buffer is too small */
@@ -451,25 +451,25 @@ h5_fixname_real(const char *base_name, hid_t fapl, const char *_suffix, char *fu
             }
         }
         else {
-            if (HDsnprintf(fullname, size, "%s/%s", prefix, base_name) == (int)size)
+            if (snprintf(fullname, size, "%s/%s", prefix, base_name) == (int)size)
                 /* Buffer is too small */
                 return NULL;
         }
     }
-    else if (HDstrlen(base_name) >= size) {
+    else if (strlen(base_name) >= size) {
         /* Buffer is too small */
         return NULL;
     }
     else {
-        HDstrcpy(fullname, base_name);
+        strcpy(fullname, base_name);
     }
 
     /* Append a suffix */
     if (suffix) {
-        if (HDstrlen(fullname) + HDstrlen(suffix) >= size)
+        if (strlen(fullname) + strlen(suffix) >= size)
             return NULL;
 
-        HDstrcat(fullname, suffix);
+        strcat(fullname, suffix);
     }
 
     /* Remove any double slashes in the filename */
@@ -506,7 +506,7 @@ h5_using_default_driver(const char *drv_name)
         drv_name = HDgetenv(HDF5_DRIVER);
 
     if (drv_name)
-        return (!HDstrcmp(drv_name, "sec2") || !HDstrcmp(drv_name, "nomatch"));
+        return (!strcmp(drv_name, "sec2") || !strcmp(drv_name, "nomatch"));
 
     return ret_val;
 }

--- a/test/API/testhdf5.h
+++ b/test/API/testhdf5.h
@@ -147,7 +147,7 @@
                        "%s \n",                                                                              \
                        (where), (int)__LINE__, __FILE__, x);                                                 \
         }                                                                                                    \
-        if (HDstrcmp(x, val) != 0) {                                                                         \
+        if (strcmp(x, val) != 0) {                                                                           \
             TestErrPrintf("*** UNEXPECTED VALUE from %s should be %s, but is %s at line %4d "                \
                           "in %s\n",                                                                         \
                           where, val, x, (int)__LINE__, __FILE__);                                           \
@@ -220,27 +220,27 @@
     }
 #define PASSED()                                                                                             \
     {                                                                                                        \
-        HDputs(" PASSED");                                                                                   \
+        puts(" PASSED");                                                                                     \
         fflush(stdout);                                                                                      \
     }
 #define H5_FAILED()                                                                                          \
     {                                                                                                        \
-        HDputs("*FAILED*");                                                                                  \
+        puts("*FAILED*");                                                                                    \
         fflush(stdout);                                                                                      \
     }
 #define H5_WARNING()                                                                                         \
     {                                                                                                        \
-        HDputs("*WARNING*");                                                                                 \
+        puts("*WARNING*");                                                                                   \
         fflush(stdout);                                                                                      \
     }
 #define SKIPPED()                                                                                            \
     {                                                                                                        \
-        HDputs(" -SKIP-");                                                                                   \
+        puts(" -SKIP-");                                                                                     \
         fflush(stdout);                                                                                      \
     }
 #define PUTS_ERROR(s)                                                                                        \
     {                                                                                                        \
-        HDputs(s);                                                                                           \
+        puts(s);                                                                                             \
         AT();                                                                                                \
         goto error;                                                                                          \
     }
@@ -266,7 +266,7 @@
     {                                                                                                        \
         H5_FAILED();                                                                                         \
         AT();                                                                                                \
-        HDputs(s);                                                                                           \
+        puts(s);                                                                                             \
         goto error;                                                                                          \
     }
 

--- a/test/API/tfile.c
+++ b/test/API/tfile.c
@@ -1213,14 +1213,14 @@ test_get_obj_ids(void)
 
     /* creates NGROUPS groups under the root group */
     for (m = 0; m < NGROUPS; m++) {
-        HDsnprintf(gname, sizeof(gname), "group%d", m);
+        snprintf(gname, sizeof(gname), "group%d", m);
         gid[m] = H5Gcreate2(fid, gname, H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT);
         CHECK(gid[m], FAIL, "H5Gcreate2");
     }
 
     /* create NDSETS datasets under the root group */
     for (n = 0; n < NDSETS; n++) {
-        HDsnprintf(dname, sizeof(dname), "dataset%d", n);
+        snprintf(dname, sizeof(dname), "dataset%d", n);
         dset[n] = H5Dcreate2(fid, dname, H5T_NATIVE_INT, filespace, H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT);
         CHECK(dset[n], FAIL, "H5Dcreate2");
     }
@@ -1280,7 +1280,7 @@ test_get_obj_ids(void)
 
     /* Open NDSETS datasets under the root group */
     for (n = 0; n < NDSETS; n++) {
-        HDsnprintf(dname, sizeof(dname), "dataset%d", n);
+        snprintf(dname, sizeof(dname), "dataset%d", n);
         dset[n] = H5Dopen2(fid, dname, H5P_DEFAULT);
         CHECK(dset[n], FAIL, "H5Dcreate2");
     }
@@ -1837,7 +1837,7 @@ test_file_is_accessible(const char *env_h5_drvr)
     /* This test is not currently working for the family VFD.
      * There are failures when creating files with userblocks.
      */
-    if (0 != HDstrcmp(env_h5_drvr, "family")) {
+    if (0 != strcmp(env_h5_drvr, "family")) {
         /* Create a file creation property list with a non-default user block size */
         fcpl_id = H5Pcreate(H5P_FILE_CREATE);
         CHECK(fcpl_id, H5I_INVALID_HID, "H5Pcreate");
@@ -3065,8 +3065,8 @@ test_userblock_file_size(const char *env_h5_drvr)
     herr_t        ret;              /* Generic return value */
 
     /* Don't run with multi/split, family or direct drivers */
-    if (!HDstrcmp(env_h5_drvr, "multi") || !HDstrcmp(env_h5_drvr, "split") ||
-        !HDstrcmp(env_h5_drvr, "family") || !HDstrcmp(env_h5_drvr, "direct"))
+    if (!strcmp(env_h5_drvr, "multi") || !strcmp(env_h5_drvr, "split") ||
+        !strcmp(env_h5_drvr, "family") || !strcmp(env_h5_drvr, "direct"))
         return;
 
     /* Output message about test being performed */
@@ -4119,7 +4119,7 @@ test_filespace_info(const char *env_h5_drvr)
     MESSAGE(5, ("Testing file creation public routines: H5Pget/set_file_space_strategy & "
                 "H5Pget/set_file_space_page_size\n"));
 
-    contig_addr_vfd = (bool)(HDstrcmp(env_h5_drvr, "split") != 0 && HDstrcmp(env_h5_drvr, "multi") != 0);
+    contig_addr_vfd = (bool)(strcmp(env_h5_drvr, "split") != 0 && strcmp(env_h5_drvr, "multi") != 0);
 
     fapl = h5_fileaccess();
     h5_fixname(FILESPACE_NAME[0], fapl, filename, sizeof filename);
@@ -4542,8 +4542,8 @@ test_file_freespace(const char *env_h5_drvr)
     hsize_t        expected_fs_del;        /* Freespace expected after delete */
     herr_t         ret;                    /* Return value */
 
-    split_vfd = !HDstrcmp(env_h5_drvr, "split");
-    multi_vfd = !HDstrcmp(env_h5_drvr, "multi");
+    split_vfd = !strcmp(env_h5_drvr, "split");
+    multi_vfd = !strcmp(env_h5_drvr, "multi");
 
     if (!split_vfd && !multi_vfd) {
         fapl = h5_fileaccess();
@@ -4630,7 +4630,7 @@ test_file_freespace(const char *env_h5_drvr)
 
             /* Create datasets in file */
             for (u = 0; u < 10; u++) {
-                HDsnprintf(name, sizeof(name), "Dataset %u", u);
+                snprintf(name, sizeof(name), "Dataset %u", u);
                 dset = H5Dcreate2(file, name, H5T_STD_U32LE, dspace, H5P_DEFAULT, dcpl, H5P_DEFAULT);
                 CHECK(dset, FAIL, "H5Dcreate2");
 
@@ -4653,7 +4653,7 @@ test_file_freespace(const char *env_h5_drvr)
 #endif
             /* Delete datasets in file */
             for (k = 9; k >= 0; k--) {
-                HDsnprintf(name, sizeof(name), "Dataset %u", (unsigned)k);
+                snprintf(name, sizeof(name), "Dataset %u", (unsigned)k);
                 ret = H5Ldelete(file, name, H5P_DEFAULT);
                 CHECK(ret, FAIL, "H5Ldelete");
             } /* end for */
@@ -4721,8 +4721,8 @@ test_sects_freespace(const char *env_h5_drvr, bool new_format)
     /* Output message about test being performed */
     MESSAGE(5, ("Testing H5Fget_free_sections()--free-space section info in the file\n"));
 
-    split_vfd = !HDstrcmp(env_h5_drvr, "split");
-    multi_vfd = !HDstrcmp(env_h5_drvr, "multi");
+    split_vfd = !strcmp(env_h5_drvr, "split");
+    multi_vfd = !strcmp(env_h5_drvr, "multi");
 
     if (!split_vfd && !multi_vfd) {
 
@@ -4784,7 +4784,7 @@ test_sects_freespace(const char *env_h5_drvr, bool new_format)
 
         /* Create datasets in file */
         for (u = 0; u < 10; u++) {
-            HDsnprintf(name, sizeof(name), "Dataset %u", u);
+            snprintf(name, sizeof(name), "Dataset %u", u);
             dset = H5Dcreate2(file, name, H5T_STD_U32LE, dspace, H5P_DEFAULT, dcpl, H5P_DEFAULT);
             CHECK(dset, FAIL, "H5Dcreate2");
 
@@ -4802,7 +4802,7 @@ test_sects_freespace(const char *env_h5_drvr, bool new_format)
 
         /* Delete odd-numbered datasets in file */
         for (u = 0; u < 10; u++) {
-            HDsnprintf(name, sizeof(name), "Dataset %u", u);
+            snprintf(name, sizeof(name), "Dataset %u", u);
             if (u % 2) {
                 ret = H5Ldelete(file, name, H5P_DEFAULT);
                 CHECK(ret, FAIL, "H5Ldelete");
@@ -7819,7 +7819,7 @@ test_incr_filesize(void)
 
         /* Create datasets in file */
         for (u = 0; u < 10; u++) {
-            HDsnprintf(name, sizeof(name), "Dataset %u", u);
+            snprintf(name, sizeof(name), "Dataset %u", u);
             dset = H5Dcreate2(fid, name, H5T_STD_U32LE, dspace, H5P_DEFAULT, dcpl, H5P_DEFAULT);
             CHECK(dset, FAIL, "H5Dcreate2");
 

--- a/test/API/tgenprop.c
+++ b/test/API/tgenprop.c
@@ -94,7 +94,7 @@ test_genprop_basic_class(void)
     /* Check class name */
     name = H5Pget_class_name(cid1);
     CHECK_PTR(name, "H5Pget_class_name");
-    if (HDstrcmp(name, CLASS1_NAME) != 0)
+    if (strcmp(name, CLASS1_NAME) != 0)
         TestErrPrintf("Class names don't match!, name=%s, CLASS1_NAME=%s\n", name, CLASS1_NAME);
     H5free_memory(name);
 
@@ -125,7 +125,7 @@ test_genprop_basic_class(void)
     /* Check class name */
     name = H5Pget_class_name(cid1);
     CHECK_PTR(name, "H5Pget_class_name");
-    if (HDstrcmp(name, CLASS2_NAME) != 0)
+    if (strcmp(name, CLASS2_NAME) != 0)
         TestErrPrintf("Class names don't match!, name=%s, CLASS2_NAME=%s\n", name, CLASS2_NAME);
     H5free_memory(name);
 
@@ -313,7 +313,7 @@ test_genprop_iter1(hid_t H5_ATTR_UNUSED id, const char *name, void *iter_data)
 {
     iter_data_t *idata = (iter_data_t *)iter_data;
 
-    return HDstrcmp(name, idata->names[idata->iter_count++]);
+    return strcmp(name, idata->names[idata->iter_count++]);
 }
 
 /****************************************************************
@@ -868,7 +868,7 @@ test_genprop_iter2(hid_t H5_ATTR_UNUSED id, const char *name, void *iter_data)
 {
     iter_data_t *idata = (iter_data_t *)iter_data;
 
-    return HDstrcmp(name, idata->names[idata->iter_count++]);
+    return strcmp(name, idata->names[idata->iter_count++]);
 }
 
 /****************************************************************
@@ -1026,7 +1026,7 @@ test_genprop_prop_crt_cb1(const char *name, size_t size, void *def_value)
 {
     /* Set the information from the creation call */
     prop1_cb_info.crt_count++;
-    prop1_cb_info.crt_name  = HDstrdup(name);
+    prop1_cb_info.crt_name  = strdup(name);
     prop1_cb_info.crt_value = malloc(size);
     memcpy(prop1_cb_info.crt_value, def_value, size);
 
@@ -1045,7 +1045,7 @@ test_genprop_prop_set_cb1(hid_t plist_id, const char *name, size_t size, void *v
     prop1_cb_info.set_count++;
     prop1_cb_info.set_plist_id = plist_id;
     if (prop1_cb_info.set_name == NULL)
-        prop1_cb_info.set_name = HDstrdup(name);
+        prop1_cb_info.set_name = strdup(name);
     if (prop1_cb_info.set_value == NULL)
         prop1_cb_info.set_value = malloc(size);
     memcpy(prop1_cb_info.set_value, value, size);
@@ -1065,7 +1065,7 @@ test_genprop_prop_get_cb1(hid_t plist_id, const char *name, size_t size, void *v
     prop1_cb_info.get_count++;
     prop1_cb_info.get_plist_id = plist_id;
     if (prop1_cb_info.get_name == NULL)
-        prop1_cb_info.get_name = HDstrdup(name);
+        prop1_cb_info.get_name = strdup(name);
     if (prop1_cb_info.get_value == NULL)
         prop1_cb_info.get_value = malloc(size);
     memcpy(prop1_cb_info.get_value, value, size);
@@ -1084,7 +1084,7 @@ test_genprop_prop_cop_cb1(const char *name, size_t size, void *value)
     /* Set the information from the get call */
     prop1_cb_info.cop_count++;
     if (prop1_cb_info.cop_name == NULL)
-        prop1_cb_info.cop_name = HDstrdup(name);
+        prop1_cb_info.cop_name = strdup(name);
     if (prop1_cb_info.cop_value == NULL)
         prop1_cb_info.cop_value = malloc(size);
     memcpy(prop1_cb_info.cop_value, value, size);
@@ -1131,7 +1131,7 @@ test_genprop_prop_cls_cb1(const char *name, size_t size, void *value)
     /* Set the information from the close call */
     prop1_cb_info.cls_count++;
     if (prop1_cb_info.cls_name == NULL)
-        prop1_cb_info.cls_name = HDstrdup(name);
+        prop1_cb_info.cls_name = strdup(name);
     if (prop1_cb_info.cls_value == NULL)
         prop1_cb_info.cls_value = malloc(size);
     memcpy(prop1_cb_info.cls_value, value, size);
@@ -1150,7 +1150,7 @@ test_genprop_prop_del_cb2(hid_t plist_id, const char *name, size_t size, void *v
     /* Set the information from the delete call */
     prop2_cb_info.del_count++;
     prop2_cb_info.del_plist_id = plist_id;
-    prop2_cb_info.del_name     = HDstrdup(name);
+    prop2_cb_info.del_name     = strdup(name);
     prop2_cb_info.del_value    = malloc(size);
     memcpy(prop2_cb_info.del_value, value, size);
 
@@ -1238,7 +1238,7 @@ test_genprop_list_callback(void)
 
     /* Verify creation callback information for properties tracked */
     VERIFY(prop1_cb_info.crt_count, 1, "H5Pcreate");
-    if (HDstrcmp(prop1_cb_info.crt_name, PROP1_NAME) != 0)
+    if (strcmp(prop1_cb_info.crt_name, PROP1_NAME) != 0)
         TestErrPrintf("Property #1 name doesn't match!, line=%d\n", __LINE__);
     if (memcmp(prop1_cb_info.crt_value, PROP1_DEF_VALUE, PROP1_SIZE) != 0)
         TestErrPrintf("Property #1 value doesn't match!, line=%d\n", __LINE__);
@@ -1274,7 +1274,7 @@ test_genprop_list_callback(void)
     /* Verify get callback information for properties tracked */
     VERIFY(prop1_cb_info.get_count, 1, "H5Pget");
     VERIFY(prop1_cb_info.get_plist_id, lid1, "H5Pget");
-    if (HDstrcmp(prop1_cb_info.get_name, PROP1_NAME) != 0)
+    if (strcmp(prop1_cb_info.get_name, PROP1_NAME) != 0)
         TestErrPrintf("Property #1 name doesn't match!, line=%d\n", __LINE__);
     if (memcmp(prop1_cb_info.get_value, PROP1_DEF_VALUE, PROP1_SIZE) != 0)
         TestErrPrintf("Property #1 value doesn't match!, line=%d\n", __LINE__);
@@ -1286,7 +1286,7 @@ test_genprop_list_callback(void)
     /* Verify set callback information for properties tracked */
     VERIFY(prop1_cb_info.set_count, 1, "H5Pset");
     VERIFY(prop1_cb_info.set_plist_id, lid1, "H5Pset");
-    if (HDstrcmp(prop1_cb_info.set_name, PROP1_NAME) != 0)
+    if (strcmp(prop1_cb_info.set_name, PROP1_NAME) != 0)
         TestErrPrintf("Property #1 name doesn't match!, line=%d\n", __LINE__);
     if (memcmp(prop1_cb_info.set_value, &prop1_new_value, PROP1_SIZE) != 0)
         TestErrPrintf("Property #1 value doesn't match!, line=%d\n", __LINE__);
@@ -1309,7 +1309,7 @@ test_genprop_list_callback(void)
     /* Verify get callback information again for properties tracked */
     VERIFY(prop1_cb_info.get_count, 2, "H5Pget");
     VERIFY(prop1_cb_info.get_plist_id, lid1, "H5Pget");
-    if (HDstrcmp(prop1_cb_info.get_name, PROP1_NAME) != 0)
+    if (strcmp(prop1_cb_info.get_name, PROP1_NAME) != 0)
         TestErrPrintf("Property #1 name doesn't match!, line=%d\n", __LINE__);
     if (memcmp(prop1_cb_info.get_value, &prop1_new_value, PROP1_SIZE) != 0)
         TestErrPrintf("Property #1 value doesn't match!, line=%d\n", __LINE__);
@@ -1321,7 +1321,7 @@ test_genprop_list_callback(void)
     /* Verify delete callback information for properties tracked */
     VERIFY(prop2_cb_info.del_count, 1, "H5Premove");
     VERIFY(prop2_cb_info.del_plist_id, lid1, "H5Premove");
-    if (HDstrcmp(prop2_cb_info.del_name, PROP2_NAME) != 0)
+    if (strcmp(prop2_cb_info.del_name, PROP2_NAME) != 0)
         TestErrPrintf("Property #2 name doesn't match!, line=%d\n", __LINE__);
     if (memcmp(prop2_cb_info.del_value, PROP2_DEF_VALUE, PROP2_SIZE) != 0)
         TestErrPrintf("Property #2 value doesn't match!, line=%d\n", __LINE__);
@@ -1332,7 +1332,7 @@ test_genprop_list_callback(void)
 
     /* Verify copy callback information for properties tracked */
     VERIFY(prop1_cb_info.cop_count, 1, "H5Pcopy");
-    if (HDstrcmp(prop1_cb_info.cop_name, PROP1_NAME) != 0)
+    if (strcmp(prop1_cb_info.cop_name, PROP1_NAME) != 0)
         TestErrPrintf("Property #1 name doesn't match!, line=%d\n", __LINE__);
     if (memcmp(prop1_cb_info.cop_value, &prop1_new_value, PROP1_SIZE) != 0)
         TestErrPrintf("Property #1 value doesn't match!, line=%d\n", __LINE__);
@@ -1355,7 +1355,7 @@ test_genprop_list_callback(void)
 
     /* Verify close callback information for properties tracked */
     VERIFY(prop1_cb_info.cls_count, 1, "H5Pclose");
-    if (HDstrcmp(prop1_cb_info.cls_name, PROP1_NAME) != 0)
+    if (strcmp(prop1_cb_info.cls_name, PROP1_NAME) != 0)
         TestErrPrintf("Property #1 name doesn't match!, line=%d\n", __LINE__);
     if (memcmp(prop1_cb_info.cls_value, &prop1_new_value, PROP1_SIZE) != 0)
         TestErrPrintf("Property #1 value doesn't match!, line=%d\n", __LINE__);
@@ -1811,7 +1811,7 @@ test_genprop_path(void)
     /* Get full path for first class */
     path = H5P__get_class_path_test(cid1);
     CHECK_PTR(path, "H5P__get_class_path_test");
-    if (HDstrcmp(path, CLASS1_PATH) != 0)
+    if (strcmp(path, CLASS1_PATH) != 0)
         TestErrPrintf("Class names don't match!, path=%s, CLASS1_PATH=%s\n", path, CLASS1_PATH);
     H5free_memory(path);
 #endif
@@ -1827,7 +1827,7 @@ test_genprop_path(void)
     /* Get full path for second class */
     path = H5P__get_class_path_test(cid2);
     CHECK_PTR(path, "H5P__get_class_path_test");
-    if (HDstrcmp(path, CLASS2_PATH) != 0)
+    if (strcmp(path, CLASS2_PATH) != 0)
         TestErrPrintf("Class names don't match!, path=%s, CLASS2_PATH=%s\n", path, CLASS2_PATH);
 
     /* Open a copy of the class with the path name */
@@ -1888,7 +1888,7 @@ test_genprop_refcount(void)
     /* Check class name */
     name = H5Pget_class_name(cid1);
     CHECK_PTR(name, "H5Pget_class_name");
-    if (HDstrcmp(name, CLASS1_NAME) != 0)
+    if (strcmp(name, CLASS1_NAME) != 0)
         TestErrPrintf("Class names don't match!, name=%s, CLASS1_NAME=%s\n", name, CLASS1_NAME);
     H5free_memory(name);
 
@@ -1907,7 +1907,7 @@ test_genprop_refcount(void)
     /* Check class name */
     name = H5Pget_class_name(cid1);
     CHECK_PTR(name, "H5Pget_class_name");
-    if (HDstrcmp(name, CLASS1_NAME) != 0)
+    if (strcmp(name, CLASS1_NAME) != 0)
         TestErrPrintf("Class names don't match!, name=%s, CLASS1_NAME=%s\n", name, CLASS1_NAME);
     H5free_memory(name);
 
@@ -1918,7 +1918,7 @@ test_genprop_refcount(void)
     /* Check class name */
     name = H5Pget_class_name(cid1);
     CHECK_PTR(name, "H5Pget_class_name");
-    if (HDstrcmp(name, CLASS1_NAME) != 0)
+    if (strcmp(name, CLASS1_NAME) != 0)
         TestErrPrintf("Class names don't match!, name=%s, CLASS1_NAME=%s\n", name, CLASS1_NAME);
     H5free_memory(name);
 

--- a/test/API/th5o.c
+++ b/test/API/th5o.c
@@ -1209,7 +1209,7 @@ test_h5o_comment(void)
     len = H5Oget_comment(fid, check_comment, (size_t)comment_len + 1);
     CHECK(len, FAIL, "H5Oget_comment");
 
-    ret_value = HDstrcmp(file_comment, check_comment);
+    ret_value = strcmp(file_comment, check_comment);
     VERIFY(ret_value, 0, "H5Oget_comment");
 
     /* Open the group */
@@ -1223,7 +1223,7 @@ test_h5o_comment(void)
     len = H5Oget_comment(grp, check_comment, (size_t)comment_len + 1);
     CHECK(len, FAIL, "H5Oget_comment");
 
-    ret_value = HDstrcmp(grp_comment, check_comment);
+    ret_value = strcmp(grp_comment, check_comment);
     VERIFY(ret_value, 0, "H5Oget_comment");
 
     /* Open the datatype */
@@ -1237,7 +1237,7 @@ test_h5o_comment(void)
     len = H5Oget_comment(dtype, check_comment, (size_t)comment_len + 1);
     CHECK(len, FAIL, "H5Oget_comment");
 
-    ret_value = HDstrcmp(dtype_comment, check_comment);
+    ret_value = strcmp(dtype_comment, check_comment);
     VERIFY(ret_value, 0, "H5Oget_comment");
 
     /* Open the dataset */
@@ -1251,7 +1251,7 @@ test_h5o_comment(void)
     len = H5Oget_comment(dset, check_comment, (size_t)comment_len + 1);
     CHECK(ret, len, "H5Oget_comment");
 
-    ret_value = HDstrcmp(dset_comment, check_comment);
+    ret_value = strcmp(dset_comment, check_comment);
     VERIFY(ret_value, 0, "H5Oget_comment");
 
     /* Close the IDs */
@@ -1384,7 +1384,7 @@ test_h5o_comment_by_name(void)
     len = H5Oget_comment_by_name(fid, ".", check_comment, (size_t)comment_len + 1, H5P_DEFAULT);
     CHECK(len, FAIL, "H5Oget_comment_by_name");
 
-    ret_value = HDstrcmp(file_comment, check_comment);
+    ret_value = strcmp(file_comment, check_comment);
     VERIFY(ret_value, 0, "H5Oget_comment_by_name");
 
     /* Open the group */
@@ -1398,7 +1398,7 @@ test_h5o_comment_by_name(void)
     len = H5Oget_comment_by_name(fid, "group", check_comment, (size_t)comment_len + 1, H5P_DEFAULT);
     CHECK(len, FAIL, "H5Oget_comment_by_name");
 
-    ret_value = HDstrcmp(grp_comment, check_comment);
+    ret_value = strcmp(grp_comment, check_comment);
     VERIFY(ret_value, 0, "H5Oget_comment_by_name");
 
     /* Getting the comment on the datatype and verify it */
@@ -1408,7 +1408,7 @@ test_h5o_comment_by_name(void)
     len = H5Oget_comment_by_name(grp, "datatype", check_comment, (size_t)comment_len + 1, H5P_DEFAULT);
     CHECK(len, FAIL, "H5Oget_comment");
 
-    ret_value = HDstrcmp(dtype_comment, check_comment);
+    ret_value = strcmp(dtype_comment, check_comment);
     VERIFY(ret_value, 0, "H5Oget_comment_by_name");
 
     /* Getting the comment on the dataset and verify it */
@@ -1418,7 +1418,7 @@ test_h5o_comment_by_name(void)
     len = H5Oget_comment_by_name(fid, "dataset", check_comment, (size_t)comment_len + 1, H5P_DEFAULT);
     CHECK(len, FAIL, "H5Oget_comment_by_name");
 
-    ret_value = HDstrcmp(dset_comment, check_comment);
+    ret_value = strcmp(dset_comment, check_comment);
     VERIFY(ret_value, 0, "H5Oget_comment_by_name");
 
     /* Close the IDs */
@@ -1706,16 +1706,16 @@ visit_obj_cb(hid_t group_id, const char *name, const H5O_info1_t *oinfo1, void H
     H5O_info1_t oinfo2; /* Object info structs */
 
     /* Verify the object info for "group1", "group2" and the root group */
-    if (!(HDstrcmp(name, "group1"))) {
+    if (!(strcmp(name, "group1"))) {
         H5Oget_info_by_name2(group_id, name, &oinfo2, H5O_INFO_NUM_ATTRS, H5P_DEFAULT);
         VERIFY(oinfo1->num_attrs, oinfo2.num_attrs, "obj info from H5Ovisit1");
     }
-    else if (!(HDstrcmp(name, "group2"))) {
+    else if (!(strcmp(name, "group2"))) {
         H5Oget_info_by_name2(group_id, name, &oinfo2, H5O_INFO_HDR, H5P_DEFAULT);
         VERIFY(oinfo1->hdr.nmesgs, oinfo2.hdr.nmesgs, "obj info from H5Ovisit1/H5Oget_info2");
         VERIFY(oinfo1->hdr.nchunks, oinfo2.hdr.nchunks, "obj info from H5Ovisit1/H5Oget_info2");
     }
-    else if (!(HDstrcmp(name, "."))) {
+    else if (!(strcmp(name, "."))) {
         H5Oget_info_by_name2(group_id, name, &oinfo2, H5O_INFO_META_SIZE, H5P_DEFAULT);
         VERIFY(oinfo1->meta_size.obj.index_size, oinfo2.meta_size.obj.index_size,
                "obj info from H5Ovisit1/H5Oget_info2");
@@ -1768,7 +1768,7 @@ test_h5o_getinfo_visit(void)
     /* Attach 10 attributes to "group1" */
     for (j = 0; j < 10; j++) {
         /* Create the attribute name */
-        HDsnprintf(attrname, sizeof(attrname), "attr%u", j);
+        snprintf(attrname, sizeof(attrname), "attr%u", j);
         /* Create the attribute */
         aid = H5Acreate2(gid1, attrname, H5T_NATIVE_INT, sid, H5P_DEFAULT, H5P_DEFAULT);
         CHECK(aid, FAIL, "H5Acreate2");

--- a/test/API/titerate.c
+++ b/test/API/titerate.c
@@ -74,7 +74,7 @@ herr_t        aiter_cb(hid_t group, const char *name, const H5A_info_t *ainfo, v
 H5_ATTR_PURE int
 iter_strcmp(const void *s1, const void *s2)
 {
-    return (HDstrcmp(*(const char *const *)s1, *(const char *const *)s2));
+    return (strcmp(*(const char *const *)s1, *(const char *const *)s2));
 }
 
 /****************************************************************
@@ -97,7 +97,7 @@ liter_cb(hid_t H5_ATTR_UNUSED group, const char *name, const H5L_info2_t H5_ATTR
         return 1;
     }
 
-    HDstrcpy(info->name, name);
+    strcpy(info->name, name);
 
     switch (info->command) {
         case RET_ZERO:
@@ -166,12 +166,12 @@ test_iter_group(hid_t fapl, bool new_format)
         CHECK(filespace, FAIL, "H5Screate");
 
         for (i = 0; i < NDATASETS; i++) {
-            HDsnprintf(name, sizeof(name), "Dataset %d", i);
+            snprintf(name, sizeof(name), "Dataset %d", i);
             dataset = H5Dcreate2(file, name, datatype, filespace, H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT);
             CHECK(dataset, FAIL, "H5Dcreate2");
 
             /* Keep a copy of the dataset names around for later */
-            lnames[i] = HDstrdup(name);
+            lnames[i] = strdup(name);
             CHECK_PTR(lnames[i], "strdup");
 
             ret = H5Dclose(dataset);
@@ -182,13 +182,13 @@ test_iter_group(hid_t fapl, bool new_format)
         grp = H5Gcreate2(file, "grp", H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT);
         CHECK(ret, FAIL, "H5Gcreate2");
 
-        lnames[NDATASETS] = HDstrdup("grp");
+        lnames[NDATASETS] = strdup("grp");
         CHECK_PTR(lnames[NDATASETS], "strdup");
 
         ret = H5Tcommit2(file, "dtype", datatype, H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT);
         CHECK(ret, FAIL, "H5Tcommit2");
 
-        lnames[NDATASETS + 1] = HDstrdup("dtype");
+        lnames[NDATASETS + 1] = strdup("dtype");
         CHECK_PTR(lnames[NDATASETS], "strdup");
 
         /* Close everything up */
@@ -333,7 +333,7 @@ test_iter_group(hid_t fapl, bool new_format)
                 TestErrPrintf("Group iteration function walked too far!\n");
 
             /* Verify that the correct name is retrieved */
-            if (HDstrncmp(info.name, lnames[(size_t)(idx - 1)], NAMELEN) != 0)
+            if (strncmp(info.name, lnames[(size_t)(idx - 1)], NAMELEN) != 0)
                 TestErrPrintf(
                     "Group iteration function didn't return name correctly for link - lnames[%u] = '%s'!\n",
                     (unsigned)(idx - 1), lnames[(size_t)(idx - 1)]);
@@ -365,7 +365,7 @@ test_iter_group(hid_t fapl, bool new_format)
                 TestErrPrintf("Group iteration function walked too far!\n");
 
             /* Verify that the correct name is retrieved */
-            if (HDstrncmp(info.name, lnames[(size_t)(idx - 1)], NAMELEN) != 0)
+            if (strncmp(info.name, lnames[(size_t)(idx - 1)], NAMELEN) != 0)
                 TestErrPrintf(
                     "Group iteration function didn't return name correctly for link - lnames[%u] = '%s'!\n",
                     (unsigned)(idx - 1), lnames[(size_t)(idx - 1)]);
@@ -397,7 +397,7 @@ aiter_cb(hid_t H5_ATTR_UNUSED group, const char *name, const H5A_info_t H5_ATTR_
     static int count  = 0;
     static int count2 = 0;
 
-    HDstrcpy(info->name, name);
+    strcpy(info->name, name);
 
     switch (info->command) {
         case RET_ZERO:
@@ -458,12 +458,12 @@ test_iter_attr(hid_t fapl, bool new_format)
         CHECK(dataset, FAIL, "H5Dcreate2");
 
         for (i = 0; i < NATTR; i++) {
-            HDsnprintf(name, sizeof(name), "Attribute %02d", i);
+            snprintf(name, sizeof(name), "Attribute %02d", i);
             attribute = H5Acreate2(dataset, name, H5T_NATIVE_INT, filespace, H5P_DEFAULT, H5P_DEFAULT);
             CHECK(attribute, FAIL, "H5Acreate2");
 
             /* Keep a copy of the attribute names around for later */
-            anames[i] = HDstrdup(name);
+            anames[i] = strdup(name);
             CHECK_PTR(anames[i], "strdup");
 
             ret = H5Aclose(attribute);
@@ -533,7 +533,7 @@ test_iter_attr(hid_t fapl, bool new_format)
             if (!new_format) {
                 /* Verify that the correct name is retrieved */
                 if (idx > 0) {
-                    if (HDstrcmp(info.name, anames[(size_t)idx - 1]) != 0)
+                    if (strcmp(info.name, anames[(size_t)idx - 1]) != 0)
                         TestErrPrintf(
                             "%u: Attribute iteration function didn't set names correctly, info.name = "
                             "'%s', anames[%u] = '%s'!\n",
@@ -567,7 +567,7 @@ test_iter_attr(hid_t fapl, bool new_format)
             if (!new_format) {
                 /* Verify that the correct name is retrieved */
                 if (idx > 0) {
-                    if (HDstrcmp(info.name, anames[(size_t)idx - 1]) != 0)
+                    if (strcmp(info.name, anames[(size_t)idx - 1]) != 0)
                         TestErrPrintf(
                             "%u: Attribute iteration function didn't set names correctly, info.name = "
                             "'%s', anames[%u] = '%s'!\n",
@@ -602,7 +602,7 @@ test_iter_attr(hid_t fapl, bool new_format)
 H5_ATTR_PURE int
 iter_strcmp2(const void *s1, const void *s2)
 {
-    return (HDstrcmp((const char *)s1, (const char *)s2));
+    return (strcmp((const char *)s1, (const char *)s2));
 } /* end iter_strcmp2() */
 
 /****************************************************************
@@ -624,7 +624,7 @@ liter_cb2(hid_t loc_id, const char *name, const H5L_info2_t H5_ATTR_UNUSED *link
         return 1;
     }
 
-    if (HDstrcmp(name, test_info->name) != 0) {
+    if (strcmp(name, test_info->name) != 0) {
         TestErrPrintf("name = '%s', test_info = '%s'\n", name, test_info->name);
         return (H5_ITER_ERROR);
     } /* end if */
@@ -691,10 +691,10 @@ test_iter_group_large(hid_t fapl)
 
         /* Create a bunch of groups */
         for (i = 0; i < ITER_NGROUPS; i++) {
-            HDsnprintf(gname, sizeof(gname), "Group_%d", i);
+            snprintf(gname, sizeof(gname), "Group_%d", i);
 
             /* Add the name to the list of objects in the root group */
-            HDstrcpy(names[i].name, gname);
+            strcpy(names[i].name, gname);
             names[i].type = H5O_TYPE_GROUP;
 
             /* Create a group */
@@ -711,7 +711,7 @@ test_iter_group_large(hid_t fapl)
         CHECK(dataset, FAIL, "H5Dcreate2");
 
         /* Add the name to the list of objects in the root group */
-        HDstrcpy(names[ITER_NGROUPS].name, "Dataset1");
+        strcpy(names[ITER_NGROUPS].name, "Dataset1");
         names[ITER_NGROUPS].type = H5O_TYPE_DATASET;
 
         /* Close Dataset */
@@ -741,7 +741,7 @@ test_iter_group_large(hid_t fapl)
         CHECK(ret, FAIL, "H5Tcommit2");
 
         /* Add the name to the list of objects in the root group */
-        HDstrcpy(names[ITER_NGROUPS + 1].name, "Datatype1");
+        strcpy(names[ITER_NGROUPS + 1].name, "Datatype1");
         names[ITER_NGROUPS + 1].type = H5O_TYPE_NAMED_DATATYPE;
 
         /* Close datatype */
@@ -809,12 +809,12 @@ test_grp_memb_funcs(hid_t fapl)
     CHECK(filespace, FAIL, "H5Screate");
 
     for (i = 0; i < NDATASETS; i++) {
-        HDsnprintf(name, sizeof(name), "Dataset %d", i);
+        snprintf(name, sizeof(name), "Dataset %d", i);
         dataset = H5Dcreate2(file, name, datatype, filespace, H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT);
         CHECK(dataset, FAIL, "H5Dcreate2");
 
         /* Keep a copy of the dataset names around for later */
-        dnames[i] = HDstrdup(name);
+        dnames[i] = strdup(name);
         CHECK_PTR(dnames[i], "strdup");
 
         ret = H5Dclose(dataset);
@@ -825,13 +825,13 @@ test_grp_memb_funcs(hid_t fapl)
     grp = H5Gcreate2(file, "grp", H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT);
     CHECK(ret, FAIL, "H5Gcreate2");
 
-    dnames[NDATASETS] = HDstrdup("grp");
+    dnames[NDATASETS] = strdup("grp");
     CHECK_PTR(dnames[NDATASETS], "strdup");
 
     ret = H5Tcommit2(file, "dtype", datatype, H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT);
     CHECK(ret, FAIL, "H5Tcommit2");
 
-    dnames[NDATASETS + 1] = HDstrdup("dtype");
+    dnames[NDATASETS + 1] = strdup("dtype");
     CHECK_PTR(dnames[NDATASETS], "strdup");
 
     /* Close everything up */
@@ -880,18 +880,18 @@ test_grp_memb_funcs(hid_t fapl)
         VERIFY(ret, name_len, "H5Lget_name_by_idx");
 
         /* Keep a copy of the dataset names around for later */
-        obj_names[i] = HDstrdup(dataset_name);
+        obj_names[i] = strdup(dataset_name);
         CHECK_PTR(obj_names[i], "strdup");
 
         ret = H5Oget_info_by_idx3(root_group, ".", H5_INDEX_NAME, H5_ITER_INC, (hsize_t)i, &oinfo,
                                   H5O_INFO_BASIC, H5P_DEFAULT);
         CHECK(ret, FAIL, "H5Oget_info_by_idx3");
 
-        if (!HDstrcmp(dataset_name, "grp"))
+        if (!strcmp(dataset_name, "grp"))
             VERIFY(oinfo.type, H5O_TYPE_GROUP, "H5Lget_name_by_idx");
-        if (!HDstrcmp(dataset_name, "dtype"))
+        if (!strcmp(dataset_name, "dtype"))
             VERIFY(oinfo.type, H5O_TYPE_NAMED_DATATYPE, "H5Lget_name_by_idx");
-        if (!HDstrncmp(dataset_name, "Dataset", (size_t)7))
+        if (!strncmp(dataset_name, "Dataset", (size_t)7))
             VERIFY(oinfo.type, H5O_TYPE_DATASET, "H5Lget_name_by_idx");
     } /* end for */
 
@@ -909,8 +909,8 @@ test_grp_memb_funcs(hid_t fapl)
 
     /* Compare object names */
     for (i = 0; i < (int)ginfo.nlinks; i++) {
-        ret = HDstrcmp(dnames[i], obj_names[i]);
-        VERIFY(ret, 0, "HDstrcmp");
+        ret = strcmp(dnames[i], obj_names[i]);
+        VERIFY(ret, 0, "strcmp");
     } /* end for */
 
     ret = H5Gclose(root_group);
@@ -988,11 +988,11 @@ test_links(hid_t fapl)
             CHECK(ret, FAIL, "H5Oget_info_by_idx3");
         } /* end if */
 
-        if (!HDstrcmp(obj_name, "g1.1"))
+        if (!strcmp(obj_name, "g1.1"))
             VERIFY(oinfo.type, H5O_TYPE_GROUP, "H5Lget_name_by_idx");
-        else if (!HDstrcmp(obj_name, "hardlink"))
+        else if (!strcmp(obj_name, "hardlink"))
             VERIFY(oinfo.type, H5O_TYPE_GROUP, "H5Lget_name_by_idx");
-        else if (!HDstrcmp(obj_name, "softlink"))
+        else if (!strcmp(obj_name, "softlink"))
             VERIFY(linfo.type, H5L_TYPE_SOFT, "H5Lget_name_by_idx");
         else
             ERROR("unknown object name");
@@ -1030,7 +1030,7 @@ find_err_msg_cb(unsigned H5_ATTR_UNUSED n, const H5E_error2_t *err_desc, void *_
         return H5_ITER_ERROR;
 
     /* If the searched error message is found, stop the iteration */
-    if (err_desc->desc != NULL && HDstrcmp(err_desc->desc, searched_err->message) == 0) {
+    if (err_desc->desc != NULL && strcmp(err_desc->desc, searched_err->message) == 0) {
         searched_err->found = true;
         status              = H5_ITER_STOP;
     }
@@ -1087,7 +1087,7 @@ test_corrupted_attnamelen(void)
     /* Make sure the intended error was caught */
     if (err_status == -1) {
         /* Initialize client data */
-        HDstrcpy(err_caught.message, err_message);
+        strcpy(err_caught.message, err_message);
         err_caught.found = false;
 
         /* Look for the correct error message */
@@ -1172,11 +1172,11 @@ test_links_deprec(hid_t fapl)
             CHECK(ret, FAIL, "H5Oget_info_by_idx");
         } /* end if */
 
-        if (!HDstrcmp(obj_name, "g1.1"))
+        if (!strcmp(obj_name, "g1.1"))
             VERIFY(oinfo.type, H5O_TYPE_GROUP, "H5Lget_name_by_idx");
-        else if (!HDstrcmp(obj_name, "hardlink"))
+        else if (!strcmp(obj_name, "hardlink"))
             VERIFY(oinfo.type, H5O_TYPE_GROUP, "H5Lget_name_by_idx");
-        else if (!HDstrcmp(obj_name, "softlink"))
+        else if (!strcmp(obj_name, "softlink"))
             VERIFY(linfo.type, H5L_TYPE_SOFT, "H5Lget_name_by_idx");
         else
             ERROR("unknown object name");

--- a/test/API/tmisc.c
+++ b/test/API/tmisc.c
@@ -488,8 +488,8 @@ test_misc2_write_attribute(void)
     hid_t        type;
     herr_t       ret;
     misc2_struct data, data_check;
-    char        *string_att1 = HDstrdup("string attribute in file one");
-    char        *string_att2 = HDstrdup("string attribute in file two");
+    char        *string_att1 = strdup("string attribute in file one");
+    char        *string_att2 = strdup("string attribute in file two");
 
     memset(&data, 0, sizeof(data));
     memset(&data_check, 0, sizeof(data_check));
@@ -1131,7 +1131,7 @@ test_misc6(void)
     /* Loop through adding attributes to each dataset */
     for (u = 0; u < MISC6_NUMATTR; u++) {
         /* Create name for attribute */
-        HDsnprintf(attr_name, sizeof(attr_name), "Attr#%u", u);
+        snprintf(attr_name, sizeof(attr_name), "Attr#%u", u);
 
         /* Open the file */
         loc_id = H5Fopen(MISC6_FILE, H5F_ACC_RDWR, H5P_DEFAULT);
@@ -2166,11 +2166,11 @@ test_misc12(void)
     CHECK(ret, FAIL, "H5Dread");
 
     for (i = 0; i < MISC12_SPACE1_DIM1; i++)
-        if (HDstrcmp(wdata[i], rdata[i]) != 0)
+        if (strcmp(wdata[i], rdata[i]) != 0)
             TestErrPrintf("Error on line %d: wdata[%d]=%s, rdata[%d]=%s\n", __LINE__, i, wdata[i], i,
                           rdata[i]);
     for (; i < (MISC12_SPACE1_DIM1 + MISC12_APPEND_SIZE); i++)
-        if (HDstrcmp(wdata1[i - MISC12_SPACE1_DIM1], rdata[i]) != 0)
+        if (strcmp(wdata1[i - MISC12_SPACE1_DIM1], rdata[i]) != 0)
             TestErrPrintf("Error on line %d: wdata1[%d]=%s, rdata[%d]=%s\n", __LINE__, i - MISC12_SPACE1_DIM1,
                           wdata1[i - MISC12_SPACE1_DIM1], i, rdata[i]);
 
@@ -2389,7 +2389,7 @@ misc13_insert_user_block(const char *old_name, const char *new_name, const char 
     CHECK_PTR(user_block, "calloc");
 
     /* Copy in the user block data */
-    memcpy(user_block, str, HDstrlen(str));
+    memcpy(user_block, str, strlen(str));
 
     /* Open the new file */
     new_fp = fopen(new_name, "wb");
@@ -2925,13 +2925,13 @@ test_misc16(void)
 
     /* Compare data read in */
     for (i = 0; i < MISC16_SPACE_DIM; i++) {
-        if (HDstrlen(wdata[i]) != HDstrlen(rdata[i])) {
+        if (strlen(wdata[i]) != strlen(rdata[i])) {
             TestErrPrintf(
                 "Line %u: VL data length don't match!, strlen(wdata[%d])=%d, strlen(rdata[%d])=%d\n",
-                (unsigned)__LINE__, (int)i, (int)HDstrlen(wdata[i]), (int)i, (int)HDstrlen(rdata[i]));
+                (unsigned)__LINE__, (int)i, (int)strlen(wdata[i]), (int)i, (int)strlen(rdata[i]));
             continue;
         } /* end if */
-        if (HDstrcmp(wdata[i], rdata[i]) != 0) {
+        if (strcmp(wdata[i], rdata[i]) != 0) {
             TestErrPrintf("Line %u: VL data values don't match!, wdata[%d]=%s, rdata[%d]=%s\n",
                           (unsigned)__LINE__, (int)i, wdata[i], (int)i, rdata[i]);
             continue;
@@ -3013,13 +3013,13 @@ test_misc17(void)
 
     /* Compare data in the way of strings. */
     for (i = 0; i < MISC17_SPACE_DIM1; i++) {
-        if (HDstrlen(wdata[i]) != HDstrlen(rdata[i])) {
+        if (strlen(wdata[i]) != strlen(rdata[i])) {
             TestErrPrintf(
                 "Line %u: VL data length don't match!, strlen(wdata[%d])=%d, strlen(rdata[%d])=%d\n",
-                (unsigned)__LINE__, (int)i, (int)HDstrlen(wdata[i]), (int)i, (int)HDstrlen(rdata[i]));
+                (unsigned)__LINE__, (int)i, (int)strlen(wdata[i]), (int)i, (int)strlen(rdata[i]));
             continue;
         } /* end if */
-        if (HDstrcmp(wdata[i], rdata[i]) != 0) {
+        if (strcmp(wdata[i], rdata[i]) != 0) {
             TestErrPrintf("Line %u: VL data values don't match!, wdata[%d]=%s, rdata[%d]=%s\n",
                           (unsigned)__LINE__, (int)i, wdata[i], (int)i, rdata[i]);
             continue;
@@ -3133,7 +3133,7 @@ test_misc18(void)
     /* Loop creating attributes on each dataset, flushing them to the file each time */
     for (u = 0; u < 10; u++) {
         /* Set up attribute name */
-        HDsnprintf(attr_name, sizeof(attr_name), "Attr %u", u);
+        snprintf(attr_name, sizeof(attr_name), "Attr %u", u);
 
         /* Create & close attribute on first dataset */
         aid = H5Acreate2(did1, attr_name, H5T_STD_U32LE, sid, H5P_DEFAULT, H5P_DEFAULT);
@@ -5668,7 +5668,7 @@ test_misc30(void)
                 CHECK(ret, FAIL, "test_misc30_get_info");
             }
 
-            HDsnprintf(gname, sizeof(gname), "/g0/group%d", i);
+            snprintf(gname, sizeof(gname), "/g0/group%d", i);
             gid = H5Gcreate2(fid, gname, H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT);
             CHECK(gid, FAIL, "H5Gcreate2");
 

--- a/test/API/trefer.c
+++ b/test/API/trefer.c
@@ -2126,19 +2126,19 @@ test_deref_iter_op(hid_t H5_ATTR_UNUSED group, const char *name, const H5L_info2
 
     /* Simple check for correct names */
     if (*count == 0) {
-        if (HDstrcmp(name, DSETNAME2) == 0)
+        if (strcmp(name, DSETNAME2) == 0)
             ret_value = 0;
         else
             ret_value = -1;
     } /* end if */
     else if (*count == 1) {
-        if (HDstrcmp(name, GROUPNAME2) == 0)
+        if (strcmp(name, GROUPNAME2) == 0)
             ret_value = 0;
         else
             ret_value = -1;
     } /* end if */
     else if (*count == 2) {
-        if (HDstrcmp(name, GROUPNAME3) == 0)
+        if (strcmp(name, GROUPNAME3) == 0)
             ret_value = 0;
         else
             ret_value = -1;
@@ -3595,7 +3595,7 @@ test_reference(void)
     }     /* end low bound */
 
     /* The following test is currently broken with the Direct VFD */
-    if (HDstrcmp(env_h5_drvr, "direct") != 0) {
+    if (strcmp(env_h5_drvr, "direct") != 0) {
         test_reference_obj_deleted(); /* Test H5R object reference code for deleted objects */
     }
 

--- a/test/API/tselect.c
+++ b/test/API/tselect.c
@@ -10920,15 +10920,13 @@ test_shape_same_dr__full_space_vs_slice(int test_num, int small_rank, int large_
     assert(edge_size > 0);
     assert(edge_size <= 1000);
 
-    HDsnprintf(test_desc_0, sizeof(test_desc_0), "\tn-cube slice through m-cube (n <= m) test %d.\n",
-               test_num);
+    snprintf(test_desc_0, sizeof(test_desc_0), "\tn-cube slice through m-cube (n <= m) test %d.\n", test_num);
     MESSAGE(7, ("%s", test_desc_0));
 
     /* This statement must be updated if SS_DR_MAX_RANK is changed */
-    HDsnprintf(test_desc_1, sizeof(test_desc_1),
-               "\t\tranks: %d/%d offset: %d dim_selected: %d/%d/%d/%d/%d.\n", small_rank, large_rank, offset,
-               (int)dim_selected[0], (int)dim_selected[1], (int)dim_selected[2], (int)dim_selected[3],
-               (int)dim_selected[4]);
+    snprintf(test_desc_1, sizeof(test_desc_1), "\t\tranks: %d/%d offset: %d dim_selected: %d/%d/%d/%d/%d.\n",
+             small_rank, large_rank, offset, (int)dim_selected[0], (int)dim_selected[1], (int)dim_selected[2],
+             (int)dim_selected[3], (int)dim_selected[4]);
     MESSAGE(7, ("%s", test_desc_1));
 
     /* copy the edge size into the dims array */
@@ -11180,16 +11178,16 @@ test_shape_same_dr__checkerboard(int test_num, int small_rank, int large_rank, i
     assert(dims_selected >= 0);
     assert(dims_selected <= large_rank);
 
-    HDsnprintf(test_desc_0, sizeof(test_desc_0),
-               "\tcheckerboard n-cube slice through m-cube (n <= m) test %d.\n", test_num);
+    snprintf(test_desc_0, sizeof(test_desc_0),
+             "\tcheckerboard n-cube slice through m-cube (n <= m) test %d.\n", test_num);
     MESSAGE(7, ("%s", test_desc_0));
 
     /* This statement must be updated if SS_DR_MAX_RANK is changed */
-    HDsnprintf(test_desc_1, sizeof(test_desc_1),
-               "\tranks: %d/%d edge/chkr size: %d/%d offset: %d dim_selected: %d/%d/%d/%d/%d:%d.\n",
-               small_rank, large_rank, (int)edge_size, (int)checker_size, offset, (int)dim_selected[0],
-               (int)dim_selected[1], (int)dim_selected[2], (int)dim_selected[3], (int)dim_selected[4],
-               dims_selected);
+    snprintf(test_desc_1, sizeof(test_desc_1),
+             "\tranks: %d/%d edge/chkr size: %d/%d offset: %d dim_selected: %d/%d/%d/%d/%d:%d.\n", small_rank,
+             large_rank, (int)edge_size, (int)checker_size, offset, (int)dim_selected[0],
+             (int)dim_selected[1], (int)dim_selected[2], (int)dim_selected[3], (int)dim_selected[4],
+             dims_selected);
     MESSAGE(7, ("%s", test_desc_1));
 
     /* copy the edge size into the dims array */
@@ -11725,16 +11723,15 @@ test_shape_same_dr__irregular(int test_num, int small_rank, int large_rank, int 
     assert(dims_selected >= 0);
     assert(dims_selected <= large_rank);
 
-    HDsnprintf(test_desc_0, sizeof(test_desc_0),
-               "\tirregular sub set of n-cube slice through m-cube (n <= m) test %d.\n", test_num);
+    snprintf(test_desc_0, sizeof(test_desc_0),
+             "\tirregular sub set of n-cube slice through m-cube (n <= m) test %d.\n", test_num);
     MESSAGE(7, ("%s", test_desc_0));
 
     /* This statement must be updated if SS_DR_MAX_RANK is changed */
-    HDsnprintf(test_desc_1, sizeof(test_desc_1),
-               "\tranks: %d/%d edge: %d s/p offset: %d/%d dim_selected: %d/%d/%d/%d/%d:%d.\n", small_rank,
-               large_rank, edge_size, slice_offset, pattern_offset, (int)dim_selected[0],
-               (int)dim_selected[1], (int)dim_selected[2], (int)dim_selected[3], (int)dim_selected[4],
-               dims_selected);
+    snprintf(test_desc_1, sizeof(test_desc_1),
+             "\tranks: %d/%d edge: %d s/p offset: %d/%d dim_selected: %d/%d/%d/%d/%d:%d.\n", small_rank,
+             large_rank, edge_size, slice_offset, pattern_offset, (int)dim_selected[0], (int)dim_selected[1],
+             (int)dim_selected[2], (int)dim_selected[3], (int)dim_selected[4], dims_selected);
     MESSAGE(7, ("%s", test_desc_1));
 
     /* copy the edge size into the dims array */
@@ -16171,7 +16168,7 @@ test_select(void)
     test_select_hyper_valid_combination(); /* Test different input combinations */
 
     /* The following tests are currently broken with the Direct VFD */
-    if (HDstrcmp(env_h5_drvr, "direct") != 0) {
+    if (strcmp(env_h5_drvr, "direct") != 0) {
         test_select_hyper_and_2d();  /* Test hyperslab intersection (AND) code for 2-D dataset */
         test_select_hyper_xor_2d();  /* Test hyperslab XOR code for 2-D dataset */
         test_select_hyper_notb_2d(); /* Test hyperslab NOTB code for 2-D dataset */

--- a/test/API/tunicode.c
+++ b/test/API/tunicode.c
@@ -94,7 +94,7 @@ test_fl_string(hid_t fid, const char *string)
     ret = H5Dread(dset_id, dtype_id, H5S_ALL, H5S_ALL, H5P_DEFAULT, read_buf);
     CHECK(ret, FAIL, "H5Dread");
 
-    VERIFY(HDstrcmp(string, read_buf), 0, "strcmp");
+    VERIFY(strcmp(string, read_buf), 0, "strcmp");
 
     /* Close all */
     ret = H5Dclose(dset_id);
@@ -137,14 +137,14 @@ test_strpad(hid_t H5_ATTR_UNUSED fid, const char *string)
      * the right number of bytes (even or odd, depending on the test).
      * We create a 'new_string' whose length is convenient by prepending
      * an 'x' to 'string' when necessary. */
-    length = HDstrlen(string);
+    length = strlen(string);
     if (length % 2 != 1) {
-        HDstrcpy(new_string, "x");
-        HDstrcat(new_string, string);
+        strcpy(new_string, "x");
+        strcat(new_string, string);
         length++;
     }
     else {
-        HDstrcpy(new_string, string);
+        strcpy(new_string, string);
     }
 
     /* Convert a null-terminated string to a shorter and longer null
@@ -163,8 +163,8 @@ test_strpad(hid_t H5_ATTR_UNUSED fid, const char *string)
 
     /* Fill the buffer with two copies of the UTF-8 string, each with a
      * terminating NULL.  It will look like "abcdefg\0abcdefg\0". */
-    HDstrncpy(buf, new_string, big_len);
-    HDstrncpy(&buf[big_len], new_string, big_len);
+    strncpy(buf, new_string, big_len);
+    strncpy(&buf[big_len], new_string, big_len);
 
     ret = H5Tconvert(src_type, dst_type, (size_t)2, buf, NULL, H5P_DEFAULT);
     CHECK(ret, FAIL, "H5Tconvert");
@@ -174,11 +174,11 @@ test_strpad(hid_t H5_ATTR_UNUSED fid, const char *string)
      * like; UTF-8 characters may well have been truncated.
      * To check that the conversion worked properly, we'll build this
      * string manually. */
-    HDstrncpy(cmpbuf, new_string, small_len - 1);
+    strncpy(cmpbuf, new_string, small_len - 1);
     cmpbuf[small_len - 1] = '\0';
-    HDstrncpy(&cmpbuf[small_len], new_string, small_len - 1);
+    strncpy(&cmpbuf[small_len], new_string, small_len - 1);
     cmpbuf[2 * small_len - 1] = '\0';
-    HDstrcpy(&cmpbuf[2 * small_len], new_string);
+    strcpy(&cmpbuf[2 * small_len], new_string);
 
     VERIFY(memcmp(buf, cmpbuf, 2 * big_len), 0, "memcmp");
 
@@ -190,8 +190,8 @@ test_strpad(hid_t H5_ATTR_UNUSED fid, const char *string)
     /* First fill the buffer with NULLs */
     memset(cmpbuf, '\0', (size_t)LONG_BUF_SIZE);
     /* Copy in the characters */
-    HDstrncpy(cmpbuf, new_string, small_len - 1);
-    HDstrncpy(&cmpbuf[big_len], new_string, small_len - 1);
+    strncpy(cmpbuf, new_string, small_len - 1);
+    strncpy(&cmpbuf[big_len], new_string, small_len - 1);
 
     VERIFY(memcmp(buf, cmpbuf, 2 * big_len), 0, "memcmp");
 
@@ -203,14 +203,14 @@ test_strpad(hid_t H5_ATTR_UNUSED fid, const char *string)
     /* Now test null padding.  Null-padded strings do *not* need
      * terminating NULLs, so the sizes of the datatypes are slightly
      * different and we want a string with an even number of characters. */
-    length = HDstrlen(string);
+    length = strlen(string);
     if (length % 2 != 0) {
-        HDstrcpy(new_string, "x");
-        HDstrcat(new_string, string);
+        strcpy(new_string, "x");
+        strcat(new_string, string);
         length++;
     }
     else {
-        HDstrcpy(new_string, string);
+        strcpy(new_string, string);
     }
 
     /* Create a src_type that holds the UTF-8 string */
@@ -225,8 +225,8 @@ test_strpad(hid_t H5_ATTR_UNUSED fid, const char *string)
 
     /* Fill the buffer with two copies of the UTF-8 string.
      * It will look like "abcdefghabcdefgh". */
-    HDstrncpy(buf, new_string, big_len);
-    HDstrncpy(&buf[big_len], new_string, big_len);
+    strncpy(buf, new_string, big_len);
+    strncpy(&buf[big_len], new_string, big_len);
 
     ret = H5Tconvert(src_type, dst_type, (size_t)2, buf, NULL, H5P_DEFAULT);
     CHECK(ret, FAIL, "H5Tconvert");
@@ -236,9 +236,9 @@ test_strpad(hid_t H5_ATTR_UNUSED fid, const char *string)
      * like; UTF-8 characters may well have been truncated.
      * To check that the conversion worked properly, we'll build this
      * string manually. */
-    HDstrncpy(cmpbuf, new_string, small_len);
-    HDstrncpy(&cmpbuf[small_len], new_string, small_len);
-    HDstrncpy(&cmpbuf[2 * small_len], new_string, big_len);
+    strncpy(cmpbuf, new_string, small_len);
+    strncpy(&cmpbuf[small_len], new_string, small_len);
+    strncpy(&cmpbuf[2 * small_len], new_string, big_len);
 
     VERIFY(memcmp(buf, cmpbuf, 2 * big_len), 0, "memcmp");
 
@@ -250,8 +250,8 @@ test_strpad(hid_t H5_ATTR_UNUSED fid, const char *string)
     /* First fill the buffer with NULLs */
     memset(cmpbuf, '\0', (size_t)LONG_BUF_SIZE);
     /* Copy in the characters */
-    HDstrncpy(cmpbuf, new_string, small_len);
-    HDstrncpy(&cmpbuf[big_len], new_string, small_len);
+    strncpy(cmpbuf, new_string, small_len);
+    strncpy(&cmpbuf[big_len], new_string, small_len);
 
     VERIFY(memcmp(buf, cmpbuf, 2 * big_len), 0, "memcmp");
 
@@ -270,8 +270,8 @@ test_strpad(hid_t H5_ATTR_UNUSED fid, const char *string)
 
     /* Fill the buffer with two copies of the UTF-8 string.
      * It will look like "abcdefghabcdefgh". */
-    HDstrcpy(buf, new_string);
-    HDstrcpy(&buf[big_len], new_string);
+    strcpy(buf, new_string);
+    strcpy(&buf[big_len], new_string);
 
     ret = H5Tconvert(src_type, dst_type, (size_t)2, buf, NULL, H5P_DEFAULT);
     CHECK(ret, FAIL, "H5Tconvert");
@@ -281,9 +281,9 @@ test_strpad(hid_t H5_ATTR_UNUSED fid, const char *string)
      * like; UTF-8 characters may have been truncated.
      * To check that the conversion worked properly, we'll build this
      * string manually. */
-    HDstrncpy(cmpbuf, new_string, small_len);
-    HDstrncpy(&cmpbuf[small_len], new_string, small_len);
-    HDstrncpy(&cmpbuf[2 * small_len], new_string, big_len);
+    strncpy(cmpbuf, new_string, small_len);
+    strncpy(&cmpbuf[small_len], new_string, small_len);
+    strncpy(&cmpbuf[2 * small_len], new_string, big_len);
 
     VERIFY(memcmp(buf, cmpbuf, 2 * big_len), 0, "memcmp");
 
@@ -295,8 +295,8 @@ test_strpad(hid_t H5_ATTR_UNUSED fid, const char *string)
     /* First fill the buffer with spaces */
     memset(cmpbuf, ' ', (size_t)LONG_BUF_SIZE);
     /* Copy in the characters */
-    HDstrncpy(cmpbuf, new_string, small_len);
-    HDstrncpy(&cmpbuf[big_len], new_string, small_len);
+    strncpy(cmpbuf, new_string, small_len);
+    strncpy(&cmpbuf[big_len], new_string, small_len);
 
     VERIFY(memcmp(buf, cmpbuf, 2 * big_len), 0, "memcmp");
 
@@ -340,14 +340,14 @@ test_vl_string(hid_t fid, const char *string)
     /* Make certain the correct amount of memory will be used */
     ret = H5Dvlen_get_buf_size(dset_id, type_id, space_id, &size);
     CHECK(ret, FAIL, "H5Dvlen_get_buf_size");
-    VERIFY(size, (hsize_t)HDstrlen(string) + 1, "H5Dvlen_get_buf_size");
+    VERIFY(size, (hsize_t)strlen(string) + 1, "H5Dvlen_get_buf_size");
 
     /* Read dataset from disk */
     ret = H5Dread(dset_id, type_id, H5S_ALL, H5S_ALL, H5P_DEFAULT, read_buf);
     CHECK(ret, FAIL, "H5Dread");
 
     /* Compare data read in */
-    VERIFY(HDstrcmp(string, read_buf[0]), 0, "strcmp");
+    VERIFY(strcmp(string, read_buf[0]), 0, "strcmp");
 
     /* Reclaim the read VL data */
     ret = H5Treclaim(type_id, space_id, H5P_DEFAULT, read_buf);
@@ -403,7 +403,7 @@ test_objnames(hid_t fid, const char *string)
     ret = H5Gclose(grp_id);
     CHECK(ret, FAIL, "H5Gclose");
 #if 0
-    VERIFY(HDstrcmp(string, read_buf), 0, "strcmp");
+    VERIFY(strcmp(string, read_buf), 0, "strcmp");
 #endif
     /* Create a new dataset with a UTF-8 name */
     grp1_id = H5Gcreate2(fid, GROUP1_NAME, H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT);
@@ -487,9 +487,9 @@ test_objnames(hid_t fid, const char *string)
 
     ret = H5Lcreate_hard(fid, GROUP2_NAME, grp3_id, GROUP2_NAME, H5P_DEFAULT, H5P_DEFAULT);
     CHECK(ret, FAIL, "H5Lcreate_hard");
-    HDstrcpy(path_buf, GROUP2_NAME);
-    HDstrcat(path_buf, "/");
-    HDstrcat(path_buf, string);
+    strcpy(path_buf, GROUP2_NAME);
+    strcat(path_buf, "/");
+    strcat(path_buf, string);
     ret = H5Lcreate_hard(grp3_id, path_buf, H5L_SAME_LOC, string, H5P_DEFAULT, H5P_DEFAULT);
     CHECK(ret, FAIL, "H5Lcreate_hard");
 
@@ -535,7 +535,7 @@ test_attrname(hid_t fid, const char *string)
     CHECK(attr_id, FAIL, "H5Acreate2");
     size = H5Aget_name(attr_id, (size_t)MAX_STRING_LENGTH, read_buf);
     CHECK(size, FAIL, "H5Aget_name");
-    ret = HDstrcmp(read_buf, string);
+    ret = strcmp(read_buf, string);
     VERIFY(ret, 0, "strcmp");
     read_buf[0] = '\0';
 
@@ -544,7 +544,7 @@ test_attrname(hid_t fid, const char *string)
     CHECK(ret, FAIL, "H5Awrite");
     ret = H5Aread(attr_id, dtype_id, read_buf);
     CHECK(ret, FAIL, "H5Aread");
-    ret = HDstrcmp(read_buf, string);
+    ret = strcmp(read_buf, string);
     VERIFY(ret, 0, "strcmp");
 
     /* Clean up */
@@ -602,7 +602,7 @@ test_compound(hid_t fid, const char *string)
 
     /* Check that the field name was stored correctly */
     readbuf = H5Tget_member_name(s1_tid, 0);
-    ret     = HDstrcmp(readbuf, string);
+    ret     = strcmp(readbuf, string);
     VERIFY(ret, 0, "strcmp");
     H5free_memory(readbuf);
 
@@ -685,7 +685,7 @@ test_enum(hid_t H5_ATTR_UNUSED fid, const char *string)
     VERIFY(val, E1_WHITE, "H5Tenum_valueof");
     ret = H5Tenum_nameof(type_id, &val, readbuf, (size_t)MAX_STRING_LENGTH);
     CHECK(ret, FAIL, "H5Tenum_nameof");
-    ret = HDstrcmp(readbuf, string);
+    ret = strcmp(readbuf, string);
     VERIFY(ret, 0, "strcmp");
 
     /* Close the datatype */
@@ -712,7 +712,7 @@ test_opaque(hid_t H5_ATTR_UNUSED fid, const char *string)
 
     /* Read the tag back. */
     read_buf = H5Tget_tag(type_id);
-    ret      = HDstrcmp(read_buf, string);
+    ret      = strcmp(read_buf, string);
     VERIFY(ret, 0, "H5Tget_tag");
     H5free_memory(read_buf);
 
@@ -786,7 +786,7 @@ dump_string(const char *string)
     printf("The string was:\n %s", string);
     printf("Or in hex:\n");
 
-    length = HDstrlen(string);
+    length = strlen(string);
 
     for (x = 0; x < length; x++)
         printf("%x ", string[x] & (0x000000FF));

--- a/test/API/tvlstr.c
+++ b/test/API/tvlstr.c
@@ -186,7 +186,7 @@ test_vlstrings_basic(void)
 
     /* Count the actual number of bytes used by the strings */
     for (i = 0, str_used = 0; i < SPACE1_DIM1; i++)
-        str_used += HDstrlen(wdata[i]) + 1;
+        str_used += strlen(wdata[i]) + 1;
 
     /* Compare against the strings actually written */
     VERIFY(size, (hsize_t)str_used, "H5Dvlen_get_buf_size");
@@ -200,12 +200,12 @@ test_vlstrings_basic(void)
 
     /* Compare data read in */
     for (i = 0; i < SPACE1_DIM1; i++) {
-        if (HDstrlen(wdata[i]) != HDstrlen(rdata[i])) {
+        if (strlen(wdata[i]) != strlen(rdata[i])) {
             TestErrPrintf("VL data length don't match!, strlen(wdata[%d])=%d, strlen(rdata[%d])=%d\n", (int)i,
-                          (int)HDstrlen(wdata[i]), (int)i, (int)HDstrlen(rdata[i]));
+                          (int)strlen(wdata[i]), (int)i, (int)strlen(rdata[i]));
             continue;
         } /* end if */
-        if (HDstrcmp(wdata[i], rdata[i]) != 0) {
+        if (strcmp(wdata[i], rdata[i]) != 0) {
             TestErrPrintf("VL data values don't match!, wdata[%d]=%s, rdata[%d]=%s\n", (int)i, wdata[i],
                           (int)i, rdata[i]);
             continue;
@@ -304,16 +304,16 @@ test_vlstrings_special(void)
 
     /* Compare data read in */
     for (i = 0; i < SPACE1_DIM1; i++) {
-        if (HDstrlen(wdata[i]) != HDstrlen(rdata[i])) {
+        if (strlen(wdata[i]) != strlen(rdata[i])) {
             TestErrPrintf("VL data length don't match!, strlen(wdata[%d])=%d, strlen(rdata[%d])=%d\n", (int)i,
-                          (int)HDstrlen(wdata[i]), (int)i, (int)HDstrlen(rdata[i]));
+                          (int)strlen(wdata[i]), (int)i, (int)strlen(rdata[i]));
             continue;
         } /* end if */
         if ((wdata[i] == NULL && rdata[i] != NULL) || (rdata[i] == NULL && wdata[i] != NULL)) {
             TestErrPrintf("VL data values don't match!\n");
             continue;
         } /* end if */
-        if (HDstrcmp(wdata[i], rdata[i]) != 0) {
+        if (strcmp(wdata[i], rdata[i]) != 0) {
             TestErrPrintf("VL data values don't match!, wdata[%d]=%s, rdata[%d]=%s\n", (int)i, wdata[i],
                           (int)i, rdata[i]);
             continue;
@@ -533,12 +533,12 @@ test_compact_vlstring(void)
 
     /* Compare data read in */
     for (i = 0; i < SPACE1_DIM1; i++) {
-        if (HDstrlen(wdata[i]) != HDstrlen(rdata[i])) {
+        if (strlen(wdata[i]) != strlen(rdata[i])) {
             TestErrPrintf("VL data length don't match!, strlen(wdata[%d])=%d, strlen(rdata[%d])=%d\n", (int)i,
-                          (int)HDstrlen(wdata[i]), (int)i, (int)HDstrlen(rdata[i]));
+                          (int)strlen(wdata[i]), (int)i, (int)strlen(rdata[i]));
             continue;
         } /* end if */
-        if (HDstrcmp(wdata[i], rdata[i]) != 0) {
+        if (strcmp(wdata[i], rdata[i]) != 0) {
             TestErrPrintf("VL data values don't match!, wdata[%d]=%s, rdata[%d]=%s\n", (int)i, wdata[i],
                           (int)i, rdata[i]);
             continue;
@@ -611,7 +611,7 @@ test_write_vl_string_attribute(void)
     ret = H5Aread(att, type, &string_att_check);
     CHECK(ret, FAIL, "H5Aread");
 
-    if (HDstrcmp(string_att_check, string_att) != 0)
+    if (strcmp(string_att_check, string_att) != 0)
         TestErrPrintf("VL string attributes don't match!, string_att=%s, string_att_check=%s\n", string_att,
                       string_att_check);
 
@@ -634,7 +634,7 @@ test_write_vl_string_attribute(void)
     ret = H5Aread(att, type, &string_att_check);
     CHECK(ret, FAIL, "H5Aread");
 
-    if (HDstrcmp(string_att_check, string_att_write) != 0)
+    if (strcmp(string_att_check, string_att_write) != 0)
         TestErrPrintf("VL string attributes don't match!, string_att_write=%s, string_att_check=%s\n",
                       string_att_write, string_att_check);
 
@@ -695,7 +695,7 @@ test_read_vl_string_attribute(void)
     ret = H5Aread(att, type, &string_att_check);
     CHECK(ret, FAIL, "H5Aread");
 
-    if (HDstrcmp(string_att_check, string_att) != 0)
+    if (strcmp(string_att_check, string_att) != 0)
         TestErrPrintf("VL string attributes don't match!, string_att=%s, string_att_check=%s\n", string_att,
                       string_att_check);
 
@@ -713,7 +713,7 @@ test_read_vl_string_attribute(void)
         ret = H5Aread(att, type, &string_att_check);
         CHECK(ret, FAIL, "H5Aread");
 
-        if (HDstrcmp(string_att_check, string_att_write) != 0)
+        if (strcmp(string_att_check, string_att_write) != 0)
             TestErrPrintf("VL string attributes don't match!, string_att_write=%s, string_att_check=%s\n",
                           string_att_write, string_att_check);
 
@@ -772,7 +772,7 @@ read_scalar_dset(hid_t file, hid_t type, hid_t space, char *name, char *data)
     ret = H5Dclose(dset);
     CHECK(ret, FAIL, "H5Dclose");
 
-    if (HDstrcmp(data, data_read) != 0)
+    if (strcmp(data, data_read) != 0)
         TestErrPrintf("Expected %s for dataset %s but read %s\n", data, name, data_read);
 
     ret = H5Treclaim(type, space, H5P_DEFAULT, &data_read);
@@ -816,33 +816,33 @@ test_vl_rewrite(void)
 
     /* Create in file 1 */
     for (i = 0; i < REWRITE_NDATASETS; i++) {
-        HDsnprintf(name, sizeof(name), "/set_%d", i);
+        snprintf(name, sizeof(name), "/set_%d", i);
         write_scalar_dset(file1, type, space, name, name);
     }
 
     /* Effectively copy data from file 1 to 2 */
     for (i = 0; i < REWRITE_NDATASETS; i++) {
-        HDsnprintf(name, sizeof(name), "/set_%d", i);
+        snprintf(name, sizeof(name), "/set_%d", i);
         read_scalar_dset(file1, type, space, name, name);
         write_scalar_dset(file2, type, space, name, name);
     }
 
     /* Read back from file 2 */
     for (i = 0; i < REWRITE_NDATASETS; i++) {
-        HDsnprintf(name, sizeof(name), "/set_%d", i);
+        snprintf(name, sizeof(name), "/set_%d", i);
         read_scalar_dset(file2, type, space, name, name);
     } /* end for */
 
     /* Remove from file 2. */
     for (i = 0; i < REWRITE_NDATASETS; i++) {
-        HDsnprintf(name, sizeof(name), "/set_%d", i);
+        snprintf(name, sizeof(name), "/set_%d", i);
         ret = H5Ldelete(file2, name, H5P_DEFAULT);
         CHECK(ret, FAIL, "H5Ldelete");
     } /* end for */
 
     /* Effectively copy from file 1 to file 2 */
     for (i = 0; i < REWRITE_NDATASETS; i++) {
-        HDsnprintf(name, sizeof(name), "/set_%d", i);
+        snprintf(name, sizeof(name), "/set_%d", i);
         read_scalar_dset(file1, type, space, name, name);
         write_scalar_dset(file2, type, space, name, name);
     } /* end for */

--- a/test/API/tvltypes.c
+++ b/test/API/tvltypes.c
@@ -1244,9 +1244,9 @@ test_vltypes_compound_vlstr(void)
         wdata[i].v.p   = (s2 *)malloc((i + L3_INCM) * sizeof(s2));
         wdata[i].v.len = i + L3_INCM;
         for (t1 = (s2 *)((wdata[i].v).p), j = 0; j < (i + L3_INCM); j++, t1++) {
-            HDstrcat(str, "m");
-            t1->string = (char *)malloc(HDstrlen(str) * sizeof(char) + 1);
-            HDstrcpy(t1->string, str);
+            strcat(str, "m");
+            t1->string = (char *)malloc(strlen(str) * sizeof(char) + 1);
+            strcpy(t1->string, str);
             /*t1->color = red;*/
             t1->color = blue;
         }
@@ -1387,7 +1387,7 @@ test_vltypes_compound_vlstr(void)
 
         for (t1 = (s2 *)(wdata[i].v.p), t2 = (s2 *)(rdata[i].v.p), j = 0; j < rdata[i].v.len;
              j++, t1++, t2++) {
-            if (HDstrcmp(t1->string, t2->string) != 0) {
+            if (strcmp(t1->string, t2->string) != 0) {
                 TestErrPrintf("VL data values don't match!, t1->string=%s, t2->string=%s\n", t1->string,
                               t2->string);
                 continue;
@@ -1409,14 +1409,14 @@ test_vltypes_compound_vlstr(void)
     CHECK(ret, FAIL, "H5Treclaim");
 
     /* Use this part for new data */
-    HDstrcpy(str, "bbbbbbbb\0");
+    strcpy(str, "bbbbbbbb\0");
     for (i = 0; i < SPACE1_DIM1; i++) {
         wdata2[i].v.p   = (s2 *)malloc((i + 1) * sizeof(s2));
         wdata2[i].v.len = i + 1;
         for (t1 = (s2 *)(wdata2[i].v).p, j = 0; j < i + 1; j++, t1++) {
-            HDstrcat(str, "pp");
-            t1->string = (char *)malloc(HDstrlen(str) * sizeof(char) + 1);
-            HDstrcpy(t1->string, str);
+            strcat(str, "pp");
+            t1->string = (char *)malloc(strlen(str) * sizeof(char) + 1);
+            strcpy(t1->string, str);
             t1->color = green;
         }
     } /* end for */
@@ -1448,7 +1448,7 @@ test_vltypes_compound_vlstr(void)
 
         for (t1 = (s2 *)(wdata2[i].v.p), t2 = (s2 *)(rdata2[i].v.p), j = 0; j < rdata2[i].v.len;
              j++, t1++, t2++) {
-            if (HDstrcmp(t1->string, t2->string) != 0) {
+            if (strcmp(t1->string, t2->string) != 0) {
                 TestErrPrintf("VL data values don't match!, t1->string=%s, t2->string=%s\n", t1->string,
                               t2->string);
                 continue;
@@ -2657,16 +2657,16 @@ test_vltypes_fill_value(void)
             /* Layout specific actions */
             switch (layout) {
                 case H5D_COMPACT:
-                    HDstrcpy(dset_name1, "dataset1-compact");
-                    HDstrcpy(dset_name2, "dataset2-compact");
+                    strcpy(dset_name1, "dataset1-compact");
+                    strcpy(dset_name2, "dataset2-compact");
                     dset_dspace_id = small_dspace_id;
                     ret            = H5Pset_layout(tmp_dcpl_id, H5D_COMPACT);
                     CHECK(ret, FAIL, "H5Pset_layout");
                     break;
 
                 case H5D_CONTIGUOUS:
-                    HDstrcpy(dset_name1, "dataset1-contig");
-                    HDstrcpy(dset_name2, "dataset2-contig");
+                    strcpy(dset_name1, "dataset1-contig");
+                    strcpy(dset_name2, "dataset2-contig");
                     dset_dspace_id = large_dspace_id;
                     break;
 
@@ -2678,15 +2678,15 @@ test_vltypes_fill_value(void)
                     CHECK(ret, FAIL, "H5Pset_chunk");
 #ifdef H5_HAVE_FILTER_DEFLATE
                     if (test_loop == 1) {
-                        HDstrcpy(dset_name1, "dataset1-chunked-compressed");
-                        HDstrcpy(dset_name2, "dataset2-chunked-compressed");
+                        strcpy(dset_name1, "dataset1-chunked-compressed");
+                        strcpy(dset_name2, "dataset2-chunked-compressed");
                         ret = H5Pset_deflate(tmp_dcpl_id, 3);
                         CHECK(ret, FAIL, "H5Pset_deflate");
                     } /* end if */
                     else {
 #endif /* H5_HAVE_FILTER_DEFLATE */
-                        HDstrcpy(dset_name1, "dataset1-chunked");
-                        HDstrcpy(dset_name2, "dataset2-chunked");
+                        strcpy(dset_name1, "dataset1-chunked");
+                        strcpy(dset_name2, "dataset2-chunked");
 #ifdef H5_HAVE_FILTER_DEFLATE
                     } /* end else */
 #endif                /* H5_HAVE_FILTER_DEFLATE */
@@ -2767,16 +2767,16 @@ test_vltypes_fill_value(void)
             /* Layout specific actions */
             switch (layout) {
                 case H5D_COMPACT:
-                    HDstrcpy(dset_name1, "dataset1-compact");
-                    HDstrcpy(dset_name2, "dataset2-compact");
+                    strcpy(dset_name1, "dataset1-compact");
+                    strcpy(dset_name2, "dataset2-compact");
                     dset_dspace_id        = small_dspace_id;
                     dset_select_dspace_id = small_select_dspace_id;
                     dset_elmts            = SPACE4_DIM_SMALL;
                     break;
 
                 case H5D_CONTIGUOUS:
-                    HDstrcpy(dset_name1, "dataset1-contig");
-                    HDstrcpy(dset_name2, "dataset2-contig");
+                    strcpy(dset_name1, "dataset1-contig");
+                    strcpy(dset_name2, "dataset2-contig");
                     dset_dspace_id        = large_dspace_id;
                     dset_select_dspace_id = large_select_dspace_id;
                     dset_elmts            = SPACE4_DIM_LARGE;
@@ -2785,13 +2785,13 @@ test_vltypes_fill_value(void)
                 case H5D_CHUNKED:
 #ifdef H5_HAVE_FILTER_DEFLATE
                     if (test_loop == 1) {
-                        HDstrcpy(dset_name1, "dataset1-chunked-compressed");
-                        HDstrcpy(dset_name2, "dataset2-chunked-compressed");
+                        strcpy(dset_name1, "dataset1-chunked-compressed");
+                        strcpy(dset_name2, "dataset2-chunked-compressed");
                     } /* end if */
                     else {
 #endif /* H5_HAVE_FILTER_DEFLATE */
-                        HDstrcpy(dset_name1, "dataset1-chunked");
-                        HDstrcpy(dset_name2, "dataset2-chunked");
+                        strcpy(dset_name1, "dataset1-chunked");
+                        strcpy(dset_name2, "dataset2-chunked");
 #ifdef H5_HAVE_FILTER_DEFLATE
                     } /* end else */
 #endif                /* H5_HAVE_FILTER_DEFLATE */
@@ -2821,10 +2821,10 @@ test_vltypes_fill_value(void)
 
             /* Compare data read in */
             for (i = 0; i < dset_elmts; i++) {
-                if (HDstrcmp(rbuf[i].str_id, "foobar") != 0 || HDstrcmp(rbuf[i].str_name, "") != 0 ||
-                    rbuf[i].str_desc || HDstrcmp(rbuf[i].str_orig, "\0") != 0 ||
-                    HDstrcmp(rbuf[i].str_stat, "dead") != 0 || HDstrcmp(rbuf[i].str_form, "liquid") != 0 ||
-                    HDstrcmp(rbuf[i].str_unit, "meter") != 0) {
+                if (strcmp(rbuf[i].str_id, "foobar") != 0 || strcmp(rbuf[i].str_name, "") != 0 ||
+                    rbuf[i].str_desc || strcmp(rbuf[i].str_orig, "\0") != 0 ||
+                    strcmp(rbuf[i].str_stat, "dead") != 0 || strcmp(rbuf[i].str_form, "liquid") != 0 ||
+                    strcmp(rbuf[i].str_unit, "meter") != 0) {
                     TestErrPrintf("%d: VL data doesn't match!, index(i) = %d\n", __LINE__, (int)i);
                     continue;
                 } /* end if */
@@ -2844,11 +2844,10 @@ test_vltypes_fill_value(void)
             /* Compare data read in */
             for (i = 0; i < dset_elmts; i++) {
                 if ((i % 2) == select_offset[0]) {
-                    if (HDstrcmp(rbuf[i].str_id, "foobar") != 0 || HDstrcmp(rbuf[i].str_name, "") != 0 ||
-                        rbuf[i].str_desc || HDstrcmp(rbuf[i].str_orig, "\0") != 0 ||
-                        HDstrcmp(rbuf[i].str_stat, "dead") != 0 ||
-                        HDstrcmp(rbuf[i].str_form, "liquid") != 0 ||
-                        HDstrcmp(rbuf[i].str_unit, "meter") != 0) {
+                    if (strcmp(rbuf[i].str_id, "foobar") != 0 || strcmp(rbuf[i].str_name, "") != 0 ||
+                        rbuf[i].str_desc || strcmp(rbuf[i].str_orig, "\0") != 0 ||
+                        strcmp(rbuf[i].str_stat, "dead") != 0 || strcmp(rbuf[i].str_form, "liquid") != 0 ||
+                        strcmp(rbuf[i].str_unit, "meter") != 0) {
                         TestErrPrintf("%d: VL data doesn't match!, index(i) = %d\n", __LINE__, (int)i);
                         continue;
                     } /* end if */
@@ -2879,10 +2878,10 @@ test_vltypes_fill_value(void)
 
             /* Compare data read in */
             for (i = 0; i < dset_elmts; i++) {
-                if (HDstrcmp(rbuf[i].str_id, "foobar") != 0 || HDstrcmp(rbuf[i].str_name, "") != 0 ||
-                    rbuf[i].str_desc || HDstrcmp(rbuf[i].str_orig, "\0") != 0 ||
-                    HDstrcmp(rbuf[i].str_stat, "dead") != 0 || HDstrcmp(rbuf[i].str_form, "liquid") != 0 ||
-                    HDstrcmp(rbuf[i].str_unit, "meter") != 0) {
+                if (strcmp(rbuf[i].str_id, "foobar") != 0 || strcmp(rbuf[i].str_name, "") != 0 ||
+                    rbuf[i].str_desc || strcmp(rbuf[i].str_orig, "\0") != 0 ||
+                    strcmp(rbuf[i].str_stat, "dead") != 0 || strcmp(rbuf[i].str_form, "liquid") != 0 ||
+                    strcmp(rbuf[i].str_unit, "meter") != 0) {
                     TestErrPrintf("%d: VL data doesn't match!, index(i)=%d\n", __LINE__, (int)i);
                     continue;
                 } /* end if */
@@ -2902,11 +2901,10 @@ test_vltypes_fill_value(void)
             /* Compare data read in */
             for (i = 0; i < dset_elmts; i++) {
                 if ((i % 2) == select_offset[0]) {
-                    if (HDstrcmp(rbuf[i].str_id, "foobar") != 0 || HDstrcmp(rbuf[i].str_name, "") != 0 ||
-                        rbuf[i].str_desc || HDstrcmp(rbuf[i].str_orig, "\0") != 0 ||
-                        HDstrcmp(rbuf[i].str_stat, "dead") != 0 ||
-                        HDstrcmp(rbuf[i].str_form, "liquid") != 0 ||
-                        HDstrcmp(rbuf[i].str_unit, "meter") != 0) {
+                    if (strcmp(rbuf[i].str_id, "foobar") != 0 || strcmp(rbuf[i].str_name, "") != 0 ||
+                        rbuf[i].str_desc || strcmp(rbuf[i].str_orig, "\0") != 0 ||
+                        strcmp(rbuf[i].str_stat, "dead") != 0 || strcmp(rbuf[i].str_form, "liquid") != 0 ||
+                        strcmp(rbuf[i].str_unit, "meter") != 0) {
                         TestErrPrintf("%d: VL data doesn't match!, index(i) = %d\n", __LINE__, (int)i);
                         continue;
                     } /* end if */
@@ -2954,16 +2952,16 @@ test_vltypes_fill_value(void)
             /* Layout specific actions */
             switch (layout) {
                 case H5D_COMPACT:
-                    HDstrcpy(dset_name1, "dataset1-compact");
-                    HDstrcpy(dset_name2, "dataset2-compact");
+                    strcpy(dset_name1, "dataset1-compact");
+                    strcpy(dset_name2, "dataset2-compact");
                     dset_dspace_id        = small_dspace_id;
                     dset_select_dspace_id = small_select_dspace_id;
                     dset_elmts            = SPACE4_DIM_SMALL;
                     break;
 
                 case H5D_CONTIGUOUS:
-                    HDstrcpy(dset_name1, "dataset1-contig");
-                    HDstrcpy(dset_name2, "dataset2-contig");
+                    strcpy(dset_name1, "dataset1-contig");
+                    strcpy(dset_name2, "dataset2-contig");
                     dset_dspace_id        = large_dspace_id;
                     dset_select_dspace_id = large_select_dspace_id;
                     dset_elmts            = SPACE4_DIM_LARGE;
@@ -2972,13 +2970,13 @@ test_vltypes_fill_value(void)
                 case H5D_CHUNKED:
 #ifdef H5_HAVE_FILTER_DEFLATE
                     if (test_loop == 1) {
-                        HDstrcpy(dset_name1, "dataset1-chunked-compressed");
-                        HDstrcpy(dset_name2, "dataset2-chunked-compressed");
+                        strcpy(dset_name1, "dataset1-chunked-compressed");
+                        strcpy(dset_name2, "dataset2-chunked-compressed");
                     } /* end if */
                     else {
 #endif /* H5_HAVE_FILTER_DEFLATE */
-                        HDstrcpy(dset_name1, "dataset1-chunked");
-                        HDstrcpy(dset_name2, "dataset2-chunked");
+                        strcpy(dset_name1, "dataset1-chunked");
+                        strcpy(dset_name2, "dataset2-chunked");
 #ifdef H5_HAVE_FILTER_DEFLATE
                     } /* end else */
 #endif                /* H5_HAVE_FILTER_DEFLATE */
@@ -3021,22 +3019,21 @@ test_vltypes_fill_value(void)
             /* Compare data read in */
             for (i = 0; i < dset_elmts; i++) {
                 if (i == single_offset[0]) {
-                    if (HDstrcmp(rbuf[i].str_id, wdata.str_id) != 0 || rbuf[i].str_name ||
-                        HDstrcmp(rbuf[i].str_desc, wdata.str_desc) != 0 ||
-                        HDstrcmp(rbuf[i].str_orig, wdata.str_orig) != 0 ||
-                        HDstrcmp(rbuf[i].str_stat, wdata.str_stat) != 0 ||
-                        HDstrcmp(rbuf[i].str_form, wdata.str_form) != 0 ||
-                        HDstrcmp(rbuf[i].str_unit, wdata.str_unit) != 0) {
+                    if (strcmp(rbuf[i].str_id, wdata.str_id) != 0 || rbuf[i].str_name ||
+                        strcmp(rbuf[i].str_desc, wdata.str_desc) != 0 ||
+                        strcmp(rbuf[i].str_orig, wdata.str_orig) != 0 ||
+                        strcmp(rbuf[i].str_stat, wdata.str_stat) != 0 ||
+                        strcmp(rbuf[i].str_form, wdata.str_form) != 0 ||
+                        strcmp(rbuf[i].str_unit, wdata.str_unit) != 0) {
                         TestErrPrintf("%d: VL data doesn't match!, index(i)=%d\n", __LINE__, (int)i);
                         continue;
                     } /* end if */
                 }     /* end if */
                 else {
-                    if (HDstrcmp(rbuf[i].str_id, "foobar") != 0 || HDstrcmp(rbuf[i].str_name, "") != 0 ||
-                        rbuf[i].str_desc || HDstrcmp(rbuf[i].str_orig, "\0") != 0 ||
-                        HDstrcmp(rbuf[i].str_stat, "dead") != 0 ||
-                        HDstrcmp(rbuf[i].str_form, "liquid") != 0 ||
-                        HDstrcmp(rbuf[i].str_unit, "meter") != 0) {
+                    if (strcmp(rbuf[i].str_id, "foobar") != 0 || strcmp(rbuf[i].str_name, "") != 0 ||
+                        rbuf[i].str_desc || strcmp(rbuf[i].str_orig, "\0") != 0 ||
+                        strcmp(rbuf[i].str_stat, "dead") != 0 || strcmp(rbuf[i].str_form, "liquid") != 0 ||
+                        strcmp(rbuf[i].str_unit, "meter") != 0) {
                         TestErrPrintf("%d: VL data doesn't match!, index(i)=%d\n", __LINE__, (int)i);
                         continue;
                     } /* end if */
@@ -3057,23 +3054,23 @@ test_vltypes_fill_value(void)
             /* Compare data read in */
             for (i = 0; i < dset_elmts; i++) {
                 if (i == single_offset[0]) {
-                    if (HDstrcmp(rbuf[i].str_id, wdata.str_id) != 0 || rbuf[i].str_name ||
-                        HDstrcmp(rbuf[i].str_desc, wdata.str_desc) != 0 ||
-                        HDstrcmp(rbuf[i].str_orig, wdata.str_orig) != 0 ||
-                        HDstrcmp(rbuf[i].str_stat, wdata.str_stat) != 0 ||
-                        HDstrcmp(rbuf[i].str_form, wdata.str_form) != 0 ||
-                        HDstrcmp(rbuf[i].str_unit, wdata.str_unit) != 0) {
+                    if (strcmp(rbuf[i].str_id, wdata.str_id) != 0 || rbuf[i].str_name ||
+                        strcmp(rbuf[i].str_desc, wdata.str_desc) != 0 ||
+                        strcmp(rbuf[i].str_orig, wdata.str_orig) != 0 ||
+                        strcmp(rbuf[i].str_stat, wdata.str_stat) != 0 ||
+                        strcmp(rbuf[i].str_form, wdata.str_form) != 0 ||
+                        strcmp(rbuf[i].str_unit, wdata.str_unit) != 0) {
                         TestErrPrintf("%d: VL data doesn't match!, index(i)=%d\n", __LINE__, (int)i);
                         continue;
                     } /* end if */
                 }     /* end if */
                 else {
                     if ((i % 2) == select_offset[0]) {
-                        if (HDstrcmp(rbuf[i].str_id, "foobar") != 0 || HDstrcmp(rbuf[i].str_name, "") != 0 ||
-                            rbuf[i].str_desc || HDstrcmp(rbuf[i].str_orig, "\0") != 0 ||
-                            HDstrcmp(rbuf[i].str_stat, "dead") != 0 ||
-                            HDstrcmp(rbuf[i].str_form, "liquid") != 0 ||
-                            HDstrcmp(rbuf[i].str_unit, "meter") != 0) {
+                        if (strcmp(rbuf[i].str_id, "foobar") != 0 || strcmp(rbuf[i].str_name, "") != 0 ||
+                            rbuf[i].str_desc || strcmp(rbuf[i].str_orig, "\0") != 0 ||
+                            strcmp(rbuf[i].str_stat, "dead") != 0 ||
+                            strcmp(rbuf[i].str_form, "liquid") != 0 ||
+                            strcmp(rbuf[i].str_unit, "meter") != 0) {
                             TestErrPrintf("%d: VL data doesn't match!, index(i) = %d\n", __LINE__, (int)i);
                             continue;
                         } /* end if */
@@ -3109,22 +3106,21 @@ test_vltypes_fill_value(void)
             /* Compare data read in */
             for (i = 0; i < dset_elmts; i++) {
                 if (i == single_offset[0]) {
-                    if (HDstrcmp(rbuf[i].str_id, wdata.str_id) != 0 || rbuf[i].str_name ||
-                        HDstrcmp(rbuf[i].str_desc, wdata.str_desc) != 0 ||
-                        HDstrcmp(rbuf[i].str_orig, wdata.str_orig) != 0 ||
-                        HDstrcmp(rbuf[i].str_stat, wdata.str_stat) != 0 ||
-                        HDstrcmp(rbuf[i].str_form, wdata.str_form) != 0 ||
-                        HDstrcmp(rbuf[i].str_unit, wdata.str_unit) != 0) {
+                    if (strcmp(rbuf[i].str_id, wdata.str_id) != 0 || rbuf[i].str_name ||
+                        strcmp(rbuf[i].str_desc, wdata.str_desc) != 0 ||
+                        strcmp(rbuf[i].str_orig, wdata.str_orig) != 0 ||
+                        strcmp(rbuf[i].str_stat, wdata.str_stat) != 0 ||
+                        strcmp(rbuf[i].str_form, wdata.str_form) != 0 ||
+                        strcmp(rbuf[i].str_unit, wdata.str_unit) != 0) {
                         TestErrPrintf("%d: VL data doesn't match!, index(i)=%d\n", __LINE__, (int)i);
                         continue;
                     } /* end if */
                 }     /* end if */
                 else {
-                    if (HDstrcmp(rbuf[i].str_id, "foobar") != 0 || HDstrcmp(rbuf[i].str_name, "") != 0 ||
-                        rbuf[i].str_desc || HDstrcmp(rbuf[i].str_orig, "\0") != 0 ||
-                        HDstrcmp(rbuf[i].str_stat, "dead") != 0 ||
-                        HDstrcmp(rbuf[i].str_form, "liquid") != 0 ||
-                        HDstrcmp(rbuf[i].str_unit, "meter") != 0) {
+                    if (strcmp(rbuf[i].str_id, "foobar") != 0 || strcmp(rbuf[i].str_name, "") != 0 ||
+                        rbuf[i].str_desc || strcmp(rbuf[i].str_orig, "\0") != 0 ||
+                        strcmp(rbuf[i].str_stat, "dead") != 0 || strcmp(rbuf[i].str_form, "liquid") != 0 ||
+                        strcmp(rbuf[i].str_unit, "meter") != 0) {
                         TestErrPrintf("%d: VL data doesn't match!, index(i)=%d\n", __LINE__, (int)i);
                         continue;
                     } /* end if */
@@ -3145,23 +3141,23 @@ test_vltypes_fill_value(void)
             /* Compare data read in */
             for (i = 0; i < dset_elmts; i++) {
                 if (i == single_offset[0]) {
-                    if (HDstrcmp(rbuf[i].str_id, wdata.str_id) != 0 || rbuf[i].str_name ||
-                        HDstrcmp(rbuf[i].str_desc, wdata.str_desc) != 0 ||
-                        HDstrcmp(rbuf[i].str_orig, wdata.str_orig) != 0 ||
-                        HDstrcmp(rbuf[i].str_stat, wdata.str_stat) != 0 ||
-                        HDstrcmp(rbuf[i].str_form, wdata.str_form) != 0 ||
-                        HDstrcmp(rbuf[i].str_unit, wdata.str_unit) != 0) {
+                    if (strcmp(rbuf[i].str_id, wdata.str_id) != 0 || rbuf[i].str_name ||
+                        strcmp(rbuf[i].str_desc, wdata.str_desc) != 0 ||
+                        strcmp(rbuf[i].str_orig, wdata.str_orig) != 0 ||
+                        strcmp(rbuf[i].str_stat, wdata.str_stat) != 0 ||
+                        strcmp(rbuf[i].str_form, wdata.str_form) != 0 ||
+                        strcmp(rbuf[i].str_unit, wdata.str_unit) != 0) {
                         TestErrPrintf("%d: VL data doesn't match!, index(i)=%d\n", __LINE__, (int)i);
                         continue;
                     } /* end if */
                 }     /* end if */
                 else {
                     if ((i % 2) == select_offset[0]) {
-                        if (HDstrcmp(rbuf[i].str_id, "foobar") != 0 || HDstrcmp(rbuf[i].str_name, "") != 0 ||
-                            rbuf[i].str_desc || HDstrcmp(rbuf[i].str_orig, "\0") != 0 ||
-                            HDstrcmp(rbuf[i].str_stat, "dead") != 0 ||
-                            HDstrcmp(rbuf[i].str_form, "liquid") != 0 ||
-                            HDstrcmp(rbuf[i].str_unit, "meter") != 0) {
+                        if (strcmp(rbuf[i].str_id, "foobar") != 0 || strcmp(rbuf[i].str_name, "") != 0 ||
+                            rbuf[i].str_desc || strcmp(rbuf[i].str_orig, "\0") != 0 ||
+                            strcmp(rbuf[i].str_stat, "dead") != 0 ||
+                            strcmp(rbuf[i].str_form, "liquid") != 0 ||
+                            strcmp(rbuf[i].str_unit, "meter") != 0) {
                             TestErrPrintf("%d: VL data doesn't match!, index(i) = %d\n", __LINE__, (int)i);
                             continue;
                         } /* end if */

--- a/test/accum.c
+++ b/test/accum.c
@@ -88,7 +88,7 @@ main(void)
     H5F_t   *f = NULL; /* File for all tests */
 
     /* Test Setup */
-    HDputs("Testing the metadata accumulator");
+    puts("Testing the metadata accumulator");
 
     /* File access property list */
     h5_reset();
@@ -147,7 +147,7 @@ main(void)
 
     if (nerrors)
         goto error;
-    HDputs("All metadata accumulator tests passed.");
+    puts("All metadata accumulator tests passed.");
     h5_cleanup(FILENAME, fapl);
 
     return 0;
@@ -156,7 +156,7 @@ error:
     if (api_ctx_pushed)
         H5CX_pop(false);
 
-    HDputs("*** TESTS FAILED ***");
+    puts("*** TESTS FAILED ***");
     return 1;
 } /* end main() */
 
@@ -2070,7 +2070,7 @@ test_swmr_write_big(bool newest_format)
 
     /* Not a Windows or POSIX system */
     SKIPPED();
-    HDputs("    Test skipped: Not a Windows or POSIX system.");
+    puts("    Test skipped: Not a Windows or POSIX system.");
     return 0;
 
 #else
@@ -2080,7 +2080,7 @@ test_swmr_write_big(bool newest_format)
     driver = HDgetenv(HDF5_DRIVER);
     if (!H5FD__supports_swmr_test(driver)) {
         SKIPPED();
-        HDputs("    Test skipped due to VFD not supporting SWMR I/O.");
+        puts("    Test skipped due to VFD not supporting SWMR I/O.");
         return 0;
     }
 
@@ -2215,7 +2215,7 @@ test_swmr_write_big(bool newest_format)
 
         /* Fork child process to verify that the data at [1024, 2014] does get written to disk */
         if ((pid = fork()) < 0) {
-            HDperror("fork");
+            perror("fork");
             FAIL_STACK_ERROR;
         }
         else if (0 == pid) { /* Child process */
@@ -2228,7 +2228,7 @@ test_swmr_write_big(bool newest_format)
             char *const new_argv[]    = {swmr_reader, NULL};
             /* Run the reader */
             status = execv(SWMR_READER, new_argv);
-            printf("errno from execv = %s\n", HDstrerror(errno));
+            printf("errno from execv = %s\n", strerror(errno));
             FAIL_STACK_ERROR;
         } /* end if */
 

--- a/test/app_ref.c
+++ b/test/app_ref.c
@@ -101,8 +101,8 @@ main(void)
     /* Don't run this test with the multi/split VFD. A bug in library shutdown
      * ordering causes problems with the multi VFD when IDs are left dangling.
      */
-    if (!HDstrcmp(env_h5_drvr, "multi") || !HDstrcmp(env_h5_drvr, "split")) {
-        HDputs("\n -- SKIPPED for incompatible VFD --");
+    if (!strcmp(env_h5_drvr, "multi") || !strcmp(env_h5_drvr, "split")) {
+        puts("\n -- SKIPPED for incompatible VFD --");
         return 0;
     }
 
@@ -193,7 +193,7 @@ main(void)
 
 error:
 
-    HDputs("***** APPLICATION REFERENCE COUNT TESTS FAILED *****");
+    puts("***** APPLICATION REFERENCE COUNT TESTS FAILED *****");
 
     return EXIT_FAILURE;
 }

--- a/test/big.c
+++ b/test/big.c
@@ -263,7 +263,7 @@ enough_room(hid_t fapl)
 
     /* Create files */
     for (i = 0; i < NELMTS(fd); i++) {
-        HDsnprintf(name, sizeof(name), filename, i);
+        snprintf(name, sizeof(name), filename, i);
         if ((fd[i] = HDopen(name, O_RDWR | O_CREAT | O_TRUNC, H5_POSIX_CREATE_MODE_RW)) < 0) {
             goto done;
         }
@@ -278,7 +278,7 @@ enough_room(hid_t fapl)
 
 done:
     for (i = 0; i < NELMTS(fd) && fd[i] >= 0; i++) {
-        HDsnprintf(name, sizeof(name), filename, i);
+        snprintf(name, sizeof(name), filename, i);
         if (HDclose(fd[i]) < 0)
             ret_value = 0;
         HDremove(name);
@@ -475,7 +475,7 @@ reader(char *filename, hid_t fapl)
         FAIL_STACK_ERROR;
 
     /* Read each region */
-    while (HDfgets(ln, (int)sizeof(ln), script)) {
+    while (fgets(ln, (int)sizeof(ln), script)) {
         if ('#' != ln[0])
             break;
         i            = (int)strtol(ln + 1, &s, 10);
@@ -501,7 +501,7 @@ reader(char *filename, hid_t fapl)
         }
         else if (wrong) {
             SKIPPED();
-            HDputs("    Possible overlap with another region.");
+            puts("    Possible overlap with another region.");
             nerrors++;
         }
         else {
@@ -576,7 +576,7 @@ test_sec2(hid_t fapl)
         goto quit;
     }
     /* Test big file with the SEC2 driver */
-    HDputs("Testing big file with the SEC2 Driver ");
+    puts("Testing big file with the SEC2 Driver ");
 
     h5_fixname(FILENAME[1], fapl, filename, sizeof filename);
 
@@ -585,7 +585,7 @@ test_sec2(hid_t fapl)
     if (reader(filename, fapl))
         goto error;
 
-    HDputs("Test passed with the SEC2 Driver.");
+    puts("Test passed with the SEC2 Driver.");
 
 quit:
     /* End with normal return code */
@@ -595,7 +595,7 @@ quit:
     return 0;
 
 error:
-    HDputs("*** TEST FAILED ***");
+    puts("*** TEST FAILED ***");
     return 1;
 } /* end test_sec2() */
 
@@ -610,7 +610,7 @@ test_stdio(hid_t fapl)
         fprintf(stdout, "Test for stdio is skipped because file system does not support big files.\n");
         goto quit;
     }
-    HDputs("\nTesting big file with the STDIO Driver ");
+    puts("\nTesting big file with the STDIO Driver ");
 
     h5_fixname(FILENAME[2], fapl, filename, sizeof filename);
 
@@ -618,7 +618,7 @@ test_stdio(hid_t fapl)
         goto error;
     if (reader(filename, fapl))
         goto error;
-    HDputs("Test passed with the STDIO Driver.");
+    puts("Test passed with the STDIO Driver.");
 
     /* Flush stdout at the end of this test routine to ensure later
      * output to stderr will not come out before it.
@@ -633,7 +633,7 @@ quit:
     return 0;
 
 error:
-    HDputs("*** TEST FAILED ***");
+    puts("*** TEST FAILED ***");
     fflush(stdout);
     return 1;
 } /* end test_stdio() */
@@ -644,7 +644,7 @@ test_family(hid_t fapl)
     char filename[1024];
 
     /* Test huge file with the family driver */
-    HDputs("Testing big file with the Family Driver ");
+    puts("Testing big file with the Family Driver ");
     if ((fapl = H5Pcreate(H5P_FILE_ACCESS)) < 0)
         goto error;
 
@@ -656,14 +656,14 @@ test_family(hid_t fapl)
          * We shouldn't run this test if the file system doesn't support holes
          * because we would generate multi-gigabyte files.
          */
-        HDputs("Checking if file system is adequate for this test...");
+        puts("Checking if file system is adequate for this test...");
         if (!sparse_support) {
-            HDputs("Test skipped because file system does not support holes.");
+            puts("Test skipped because file system does not support holes.");
             usage();
             goto quit;
         }
         if (!enough_room(fapl)) {
-            HDputs("Test skipped because of quota (file size or num open files).");
+            puts("Test skipped because of quota (file size or num open files).");
             usage();
             goto quit;
         }
@@ -677,7 +677,7 @@ test_family(hid_t fapl)
     if (reader(filename, fapl))
         goto error;
 
-    HDputs("Test passed with the Family Driver.");
+    puts("Test passed with the Family Driver.");
 
 quit:
     /* End with normal return code */
@@ -687,7 +687,7 @@ quit:
     return 0;
 
 error:
-    HDputs("*** TEST FAILED ***");
+    puts("*** TEST FAILED ***");
     return 1;
 } /* end test_family() */
 
@@ -713,7 +713,7 @@ main(int ac, char **av)
 
     while (--ac > 0) {
         av++;
-        if (HDstrcmp("-fsize", *av) == 0) {
+        if (strcmp("-fsize", *av) == 0) {
             /* specify a different family file size */
             ac--;
             av++;
@@ -726,11 +726,11 @@ main(int ac, char **av)
                 return 1;
             }
         }
-        else if (HDstrcmp("-c", *av) == 0) {
+        else if (strcmp("-c", *av) == 0) {
             /* turn off file system check before test */
             cflag = 0;
         }
-        else if (HDstrcmp("-h", *av) == 0) {
+        else if (strcmp("-h", *av) == 0) {
             usage();
             return 0;
         }
@@ -772,14 +772,14 @@ main(int ac, char **av)
             goto error;
     }
     else
-        HDputs("This VFD is not supported");
+        puts("This VFD is not supported");
 
     /* End with normal exit code */
     /* fapls are cleaned up in the vfd test code */
     return 0;
 
 error:
-    HDputs("*** TEST FAILED ***");
+    puts("*** TEST FAILED ***");
     if (fapl > 0)
         H5Pclose(fapl);
     return 1;

--- a/test/bittests.c
+++ b/test/bittests.c
@@ -47,13 +47,13 @@ test_find(void)
     n = H5T__bit_find(v1, (size_t)0, (size_t)0, H5T_BIT_LSB, true);
     if (-1 != n) {
         H5_FAILED();
-        HDputs("    Zero length test failed (lsb)!");
+        puts("    Zero length test failed (lsb)!");
         goto failed;
     }
     n = H5T__bit_find(v1, (size_t)0, (size_t)0, H5T_BIT_MSB, true);
     if (-1 != n) {
         H5_FAILED();
-        HDputs("    Zero length test failed (msb)!");
+        puts("    Zero length test failed (msb)!");
         goto failed;
     }
 
@@ -62,13 +62,13 @@ test_find(void)
     n = H5T__bit_find(v1, (size_t)0, 8 * sizeof(v1), H5T_BIT_LSB, true);
     if (-1 != n) {
         H5_FAILED();
-        HDputs("    Zero buffer test failed (lsb)!");
+        puts("    Zero buffer test failed (lsb)!");
         goto failed;
     }
     n = H5T__bit_find(v1, (size_t)0, 8 * sizeof(v1), H5T_BIT_MSB, true);
     if (-1 != n) {
         H5_FAILED();
-        HDputs("    Zero buffer test failed (msb)!");
+        puts("    Zero buffer test failed (msb)!");
         goto failed;
     }
 
@@ -95,13 +95,13 @@ test_find(void)
     n = H5T__bit_find(v1, (size_t)0, 8 * sizeof(v1), H5T_BIT_LSB, false);
     if (-1 != n) {
         H5_FAILED();
-        HDputs("    One buffer test failed (lsb)!");
+        puts("    One buffer test failed (lsb)!");
         goto failed;
     }
     n = H5T__bit_find(v1, (size_t)0, 8 * sizeof(v1), H5T_BIT_MSB, false);
     if (-1 != n) {
         H5_FAILED();
-        HDputs("    One buffer test failed (msb)!");
+        puts("    One buffer test failed (msb)!");
         goto failed;
     }
 
@@ -170,12 +170,12 @@ test_copy(void)
                 break;
         if (size > 0 && j >= (int)sizeof(v2)) {
             H5_FAILED();
-            HDputs("    Unabled to find copied region in destination");
+            puts("    Unabled to find copied region in destination");
             goto failed;
         }
         if (0 == size && j < (int)sizeof(v2)) {
             H5_FAILED();
-            HDputs("    Found copied bits when we shouldn't have");
+            puts("    Found copied bits when we shouldn't have");
             goto failed;
         }
 
@@ -190,7 +190,7 @@ test_copy(void)
         }
         if (0 == size && n >= 0) {
             H5_FAILED();
-            HDputs("    Found copied bits and shouldn't have!");
+            puts("    Found copied bits and shouldn't have!");
             goto failed;
         }
         n = H5T__bit_find(v2, d_offset, 8 * sizeof(v2) - d_offset, H5T_BIT_LSB, 0);
@@ -203,7 +203,7 @@ test_copy(void)
         }
         if (d_offset + size == 8 * sizeof(v2) && n >= 0) {
             H5_FAILED();
-            HDputs("    High-order zeros are present and shouldn't be!");
+            puts("    High-order zeros are present and shouldn't be!");
             goto failed;
         }
 
@@ -221,7 +221,7 @@ test_copy(void)
         }
         if (0 == size && n >= 0) {
             H5_FAILED();
-            HDputs("    Found copied bits but shouldn't have (reverse)!");
+            puts("    Found copied bits but shouldn't have (reverse)!");
             goto failed;
         }
         n = H5T__bit_find(v2, (size_t)0, d_offset + size, H5T_BIT_MSB, 0);
@@ -234,7 +234,7 @@ test_copy(void)
         }
         if (0 == d_offset && n >= 0) {
             H5_FAILED();
-            HDputs("    Found leading original data but shouldn't have!");
+            puts("    Found leading original data but shouldn't have!");
             goto failed;
         }
     }
@@ -677,12 +677,12 @@ test_set(void)
                 break;
         if (size > 0 && j >= (int)sizeof(v2)) {
             H5_FAILED();
-            HDputs("    Unabled to find set region in buffer");
+            puts("    Unabled to find set region in buffer");
             goto failed;
         }
         if (0 == size && j < (int)sizeof(v2)) {
             H5_FAILED();
-            HDputs("    Found set bits when we shouldn't have");
+            puts("    Found set bits when we shouldn't have");
             goto failed;
         }
 
@@ -697,7 +697,7 @@ test_set(void)
         }
         if (0 == size && n >= 0) {
             H5_FAILED();
-            HDputs("    Found set bits and shouldn't have!");
+            puts("    Found set bits and shouldn't have!");
             goto failed;
         }
         n = H5T__bit_find(v2, d_offset, 8 * sizeof(v2) - d_offset, H5T_BIT_LSB, 0);
@@ -710,7 +710,7 @@ test_set(void)
         }
         if (d_offset + size == 8 * sizeof(v2) && n >= 0) {
             H5_FAILED();
-            HDputs("    High-order zeros are present and shouldn't be!");
+            puts("    High-order zeros are present and shouldn't be!");
             goto failed;
         }
 
@@ -728,7 +728,7 @@ test_set(void)
         }
         if (0 == size && n >= 0) {
             H5_FAILED();
-            HDputs("    Found set bits but shouldn't have (reverse)!");
+            puts("    Found set bits but shouldn't have (reverse)!");
             goto failed;
         }
         n = H5T__bit_find(v2, (size_t)0, d_offset + size, H5T_BIT_MSB, 0);
@@ -741,7 +741,7 @@ test_set(void)
         }
         if (0 == d_offset && n >= 0) {
             H5_FAILED();
-            HDputs("    Found leading zeros but shouldn't have!");
+            puts("    Found leading zeros but shouldn't have!");
             goto failed;
         }
     }
@@ -792,12 +792,12 @@ test_clear(void)
                 break;
         if (size > 0 && j >= (int)sizeof(v2)) {
             H5_FAILED();
-            HDputs("    Unabled to find cleared region in buffer");
+            puts("    Unabled to find cleared region in buffer");
             goto failed;
         }
         if (0 == size && j < (int)sizeof(v2)) {
             H5_FAILED();
-            HDputs("    Found cleared bits when we shouldn't have");
+            puts("    Found cleared bits when we shouldn't have");
             goto failed;
         }
 
@@ -812,7 +812,7 @@ test_clear(void)
         }
         if (0 == size && n >= 0) {
             H5_FAILED();
-            HDputs("    Found cleared bits and shouldn't have!");
+            puts("    Found cleared bits and shouldn't have!");
             goto failed;
         }
         n = H5T__bit_find(v2, d_offset, 8 * sizeof(v2) - d_offset, H5T_BIT_LSB, 1);
@@ -825,7 +825,7 @@ test_clear(void)
         }
         if (d_offset + size == 8 * sizeof(v2) && n >= 0) {
             H5_FAILED();
-            HDputs("    High-order ones are present and shouldn't be!");
+            puts("    High-order ones are present and shouldn't be!");
             goto failed;
         }
 
@@ -843,7 +843,7 @@ test_clear(void)
         }
         if (0 == size && n >= 0) {
             H5_FAILED();
-            HDputs("    Found cleared bits but shouldn't have (reverse)!");
+            puts("    Found cleared bits but shouldn't have (reverse)!");
             goto failed;
         }
         n = H5T__bit_find(v2, (size_t)0, d_offset + size, H5T_BIT_MSB, 1);
@@ -856,7 +856,7 @@ test_clear(void)
         }
         if (0 == d_offset && n >= 0) {
             H5_FAILED();
-            HDputs("    Found leading ones but shouldn't have!");
+            puts("    Found leading ones but shouldn't have!");
             goto failed;
         }
     }

--- a/test/btree2.c
+++ b/test/btree2.c
@@ -9928,7 +9928,7 @@ main(void)
     ExpressMode = GetTestExpress();
 
     /* For the Direct I/O driver, skip intensive tests due to poor performance */
-    if (!HDstrcmp(envval, "direct"))
+    if (!strcmp(envval, "direct"))
         ExpressMode = 2;
 
     if (ExpressMode > 1)
@@ -10038,14 +10038,14 @@ main(void)
     if (nerrors)
         goto error;
 
-    HDputs("All v2 B-tree tests passed.");
+    puts("All v2 B-tree tests passed.");
 
     h5_cleanup(FILENAME, fapl);
 
     return 0;
 
 error:
-    HDputs("*** TESTS FAILED ***");
+    puts("*** TESTS FAILED ***");
 
     H5E_BEGIN_TRY
     {

--- a/test/cache.c
+++ b/test/cache.c
@@ -4355,20 +4355,20 @@ check_flush_cache__multi_entry_test(H5F_t *file_ptr, int test_num, unsigned int 
     if (cache_ptr == NULL) {
 
         pass = false;
-        HDsnprintf(msg, (size_t)128, "cache_ptr NULL on entry to single entry test #%d.", test_num);
+        snprintf(msg, (size_t)128, "cache_ptr NULL on entry to single entry test #%d.", test_num);
         failure_mssg = msg;
     }
     else if ((cache_ptr->index_len != 0) || (cache_ptr->index_size != 0)) {
 
         pass = false;
 
-        HDsnprintf(msg, (size_t)128, "cache not empty at beginning of multi entry test #%d.", test_num);
+        snprintf(msg, (size_t)128, "cache not empty at beginning of multi entry test #%d.", test_num);
         failure_mssg = msg;
     }
     else if ((spec_size < 1) || (spec == NULL)) {
 
         pass = false;
-        HDsnprintf(msg, (size_t)128, "missing/bad test spec on entry to multi entry test #%d.", test_num);
+        snprintf(msg, (size_t)128, "missing/bad test spec on entry to multi entry test #%d.", test_num);
         failure_mssg = msg;
     }
 
@@ -4380,8 +4380,7 @@ check_flush_cache__multi_entry_test(H5F_t *file_ptr, int test_num, unsigned int 
             (spec[u].entry_index > max_indices[spec[u].entry_type])) {
 
             pass = false;
-            HDsnprintf(msg, (size_t)128, "bad data in spec[%u] on entry to multi entry test #%d.", u,
-                       test_num);
+            snprintf(msg, (size_t)128, "bad data in spec[%u] on entry to multi entry test #%d.", u, test_num);
             failure_mssg = msg;
         }
         u++;
@@ -4412,8 +4411,8 @@ check_flush_cache__multi_entry_test(H5F_t *file_ptr, int test_num, unsigned int 
 
         if (!pass) {
 
-            HDsnprintf(msg, (size_t)128, "flush with flags 0x%x failed in multi entry test #%d.", flush_flags,
-                       test_num);
+            snprintf(msg, (size_t)128, "flush with flags 0x%x failed in multi entry test #%d.", flush_flags,
+                     test_num);
             failure_mssg = msg;
         }
     }
@@ -4428,8 +4427,8 @@ check_flush_cache__multi_entry_test(H5F_t *file_ptr, int test_num, unsigned int 
             (entry_ptr->destroyed != spec[u].expected_destroyed)) {
 
             pass = false;
-            HDsnprintf(msg, (size_t)128, "Bad status on entry %u after flush in multi entry test #%d.", u,
-                       test_num);
+            snprintf(msg, (size_t)128, "Bad status on entry %u after flush in multi entry test #%d.", u,
+                     test_num);
             failure_mssg = msg;
         }
         u++;
@@ -4443,8 +4442,8 @@ check_flush_cache__multi_entry_test(H5F_t *file_ptr, int test_num, unsigned int 
              ((cache_ptr->index_len != 0) || (cache_ptr->index_size != 0)))) {
 
             pass = false;
-            HDsnprintf(msg, (size_t)128, "Unexpected cache len/size after flush in multi entry test #%d.",
-                       test_num);
+            snprintf(msg, (size_t)128, "Unexpected cache len/size after flush in multi entry test #%d.",
+                     test_num);
             failure_mssg = msg;
         }
     }
@@ -4457,14 +4456,14 @@ check_flush_cache__multi_entry_test(H5F_t *file_ptr, int test_num, unsigned int 
         if (!pass) {
 
             pass = false;
-            HDsnprintf(msg, (size_t)128, "Flush failed on cleanup in multi entry test #%d.", test_num);
+            snprintf(msg, (size_t)128, "Flush failed on cleanup in multi entry test #%d.", test_num);
             failure_mssg = msg;
         }
         else if ((cache_ptr->index_len != 0) || (cache_ptr->index_size != 0)) {
 
             pass = false;
-            HDsnprintf(msg, (size_t)128, "Unexpected cache len/size after cleanup in multi entry test #%d.",
-                       test_num);
+            snprintf(msg, (size_t)128, "Unexpected cache len/size after cleanup in multi entry test #%d.",
+                     test_num);
             failure_mssg = msg;
         }
     }
@@ -4510,20 +4509,20 @@ check_flush_cache__pe_multi_entry_test(H5F_t *file_ptr, int test_num, unsigned i
     if (cache_ptr == NULL) {
 
         pass = false;
-        HDsnprintf(msg, (size_t)128, "cache_ptr NULL on entry to pe multi entry test #%d.", test_num);
+        snprintf(msg, (size_t)128, "cache_ptr NULL on entry to pe multi entry test #%d.", test_num);
         failure_mssg = msg;
     }
     else if ((cache_ptr->index_len != 0) || (cache_ptr->index_size != 0)) {
 
         pass = false;
 
-        HDsnprintf(msg, (size_t)128, "cache not empty at beginning of pe multi entry test #%d.", test_num);
+        snprintf(msg, (size_t)128, "cache not empty at beginning of pe multi entry test #%d.", test_num);
         failure_mssg = msg;
     }
     else if ((spec_size < 1) || (spec == NULL)) {
 
         pass = false;
-        HDsnprintf(msg, (size_t)128, "missing/bad test spec on entry to pe multi entry test #%d.", test_num);
+        snprintf(msg, (size_t)128, "missing/bad test spec on entry to pe multi entry test #%d.", test_num);
         failure_mssg = msg;
     }
 
@@ -4536,8 +4535,8 @@ check_flush_cache__pe_multi_entry_test(H5F_t *file_ptr, int test_num, unsigned i
             (spec[u].num_pins > MAX_PINS)) {
 
             pass = false;
-            HDsnprintf(msg, (size_t)128, "bad data in spec[%u] on entry to pe multi entry test #%d.", u,
-                       test_num);
+            snprintf(msg, (size_t)128, "bad data in spec[%u] on entry to pe multi entry test #%d.", u,
+                     test_num);
             failure_mssg = msg;
         }
         u++;
@@ -4573,8 +4572,8 @@ check_flush_cache__pe_multi_entry_test(H5F_t *file_ptr, int test_num, unsigned i
 
         if (!pass) {
 
-            HDsnprintf(msg, (size_t)128, "flush with flags 0x%x failed in pe multi entry test #%d.",
-                       flush_flags, test_num);
+            snprintf(msg, (size_t)128, "flush with flags 0x%x failed in pe multi entry test #%d.",
+                     flush_flags, test_num);
             failure_mssg = msg;
         }
     }
@@ -4590,8 +4589,8 @@ check_flush_cache__pe_multi_entry_test(H5F_t *file_ptr, int test_num, unsigned i
             (entry_ptr->destroyed != spec[u].expected_destroyed)) {
 
             pass = false;
-            HDsnprintf(msg, (size_t)128, "Bad status on entry %u after flush in pe multi entry test #%d.", u,
-                       test_num);
+            snprintf(msg, (size_t)128, "Bad status on entry %u after flush in pe multi entry test #%d.", u,
+                     test_num);
             failure_mssg = msg;
         }
         u++;
@@ -4605,8 +4604,8 @@ check_flush_cache__pe_multi_entry_test(H5F_t *file_ptr, int test_num, unsigned i
              ((cache_ptr->index_len != 0) || (cache_ptr->index_size != 0)))) {
 
             pass = false;
-            HDsnprintf(msg, (size_t)128, "Unexpected cache len/size after flush in pe multi entry test #%d.",
-                       test_num);
+            snprintf(msg, (size_t)128, "Unexpected cache len/size after flush in pe multi entry test #%d.",
+                     test_num);
             failure_mssg = msg;
         }
     }
@@ -4619,14 +4618,14 @@ check_flush_cache__pe_multi_entry_test(H5F_t *file_ptr, int test_num, unsigned i
         if (!pass) {
 
             pass = false;
-            HDsnprintf(msg, (size_t)128, "Flush failed on cleanup in pe multi entry test #%d.", test_num);
+            snprintf(msg, (size_t)128, "Flush failed on cleanup in pe multi entry test #%d.", test_num);
             failure_mssg = msg;
         }
         else if ((cache_ptr->index_len != 0) || (cache_ptr->index_size != 0)) {
 
             pass = false;
-            HDsnprintf(msg, (size_t)128,
-                       "Unexpected cache len/size after cleanup in pe multi entry test #%d.", test_num);
+            snprintf(msg, (size_t)128, "Unexpected cache len/size after cleanup in pe multi entry test #%d.",
+                     test_num);
             failure_mssg = msg;
         }
     }
@@ -8041,20 +8040,20 @@ check_flush_cache__flush_op_test(H5F_t *file_ptr, int test_num, unsigned int flu
     if (cache_ptr == NULL) {
 
         pass = false;
-        HDsnprintf(msg, (size_t)128, "cache_ptr NULL on entry to flush op test #%d.", test_num);
+        snprintf(msg, (size_t)128, "cache_ptr NULL on entry to flush op test #%d.", test_num);
         failure_mssg = msg;
     }
     else if ((cache_ptr->index_len != 0) || (cache_ptr->index_size != 0)) {
 
         pass = false;
 
-        HDsnprintf(msg, (size_t)128, "cache not empty at beginning of flush op test #%d.", test_num);
+        snprintf(msg, (size_t)128, "cache not empty at beginning of flush op test #%d.", test_num);
         failure_mssg = msg;
     }
     else if ((spec_size < 1) || (spec == NULL)) {
 
         pass = false;
-        HDsnprintf(msg, (size_t)128, "missing/bad test spec on entry to flush op test #%d.", test_num);
+        snprintf(msg, (size_t)128, "missing/bad test spec on entry to flush op test #%d.", test_num);
         failure_mssg = msg;
     }
 
@@ -8068,7 +8067,7 @@ check_flush_cache__flush_op_test(H5F_t *file_ptr, int test_num, unsigned int flu
             (spec[i].num_flush_ops > MAX_FLUSH_OPS)) {
 
             pass = false;
-            HDsnprintf(msg, (size_t)128, "bad data in spec[%d] on entry to flush op test #%d.", i, test_num);
+            snprintf(msg, (size_t)128, "bad data in spec[%d] on entry to flush op test #%d.", i, test_num);
             failure_mssg = msg;
         }
         i++;
@@ -8083,7 +8082,7 @@ check_flush_cache__flush_op_test(H5F_t *file_ptr, int test_num, unsigned int flu
             (check[i].expected_size <= (size_t)0)) {
 
             pass = false;
-            HDsnprintf(msg, (size_t)128, "bad data in check[%d] on entry to flush op test #%d.", i, test_num);
+            snprintf(msg, (size_t)128, "bad data in check[%d] on entry to flush op test #%d.", i, test_num);
             failure_mssg = msg;
         }
         i++;
@@ -8127,8 +8126,8 @@ check_flush_cache__flush_op_test(H5F_t *file_ptr, int test_num, unsigned int flu
             (cache_ptr->index_size != init_expected_index_size)) {
 
             pass = false;
-            HDsnprintf(msg, (size_t)128, "Unexpected cache len/size before flush in flush op test #%d.",
-                       test_num);
+            snprintf(msg, (size_t)128, "Unexpected cache len/size before flush in flush op test #%d.",
+                     test_num);
             failure_mssg = msg;
         }
     }
@@ -8140,8 +8139,8 @@ check_flush_cache__flush_op_test(H5F_t *file_ptr, int test_num, unsigned int flu
         if (!pass) {
 
             pass = false;
-            HDsnprintf(msg, (size_t)128, "flush with flags 0x%x failed in flush op test #%d.", flush_flags,
-                       test_num);
+            snprintf(msg, (size_t)128, "flush with flags 0x%x failed in flush op test #%d.", flush_flags,
+                     test_num);
             failure_mssg = msg;
         }
     }
@@ -8157,7 +8156,7 @@ check_flush_cache__flush_op_test(H5F_t *file_ptr, int test_num, unsigned int flu
             (entry_ptr->destroyed != spec[i].expected_destroyed)) {
 
             pass = false;
-            HDsnprintf(msg, (size_t)128, "Bad status on entry %d after flush op test #%d.", i, test_num);
+            snprintf(msg, (size_t)128, "Bad status on entry %d after flush op test #%d.", i, test_num);
             failure_mssg = msg;
         }
         i++;
@@ -8171,8 +8170,7 @@ check_flush_cache__flush_op_test(H5F_t *file_ptr, int test_num, unsigned int flu
             if (check[i].in_cache != entry_in_cache(cache_ptr, check[i].entry_type, check[i].entry_index)) {
 
                 pass = false;
-                HDsnprintf(msg, (size_t)128, "Check1 failed on entry %d after flush op test #%d.", i,
-                           test_num);
+                snprintf(msg, (size_t)128, "Check1 failed on entry %d after flush op test #%d.", i, test_num);
                 failure_mssg = msg;
             }
 
@@ -8194,8 +8192,7 @@ check_flush_cache__flush_op_test(H5F_t *file_ptr, int test_num, unsigned int flu
                 (entry_ptr->destroyed != check[i].expected_destroyed)) {
 
                 pass = false;
-                HDsnprintf(msg, (size_t)128, "Check2 failed on entry %d after flush op test #%d.", i,
-                           test_num);
+                snprintf(msg, (size_t)128, "Check2 failed on entry %d after flush op test #%d.", i, test_num);
                 failure_mssg = msg;
             }
             i++;
@@ -8211,8 +8208,8 @@ check_flush_cache__flush_op_test(H5F_t *file_ptr, int test_num, unsigned int flu
              ((cache_ptr->index_len != 0) || (cache_ptr->index_size != 0)))) {
 
             pass = false;
-            HDsnprintf(msg, (size_t)128, "Unexpected cache len/size after flush in flush op test #%d.",
-                       test_num);
+            snprintf(msg, (size_t)128, "Unexpected cache len/size after flush in flush op test #%d.",
+                     test_num);
             failure_mssg = msg;
         }
     }
@@ -8224,15 +8221,15 @@ check_flush_cache__flush_op_test(H5F_t *file_ptr, int test_num, unsigned int flu
 
         if (!pass) {
 
-            HDsnprintf(msg, (size_t)128, "Flush failed on cleanup in flush op test #%d.", test_num);
+            snprintf(msg, (size_t)128, "Flush failed on cleanup in flush op test #%d.", test_num);
             failure_mssg = msg;
         }
         else if ((cache_ptr->index_len != 0) || (cache_ptr->index_size != 0) ||
                  (cache_ptr->clean_index_size != 0) || (cache_ptr->dirty_index_size != 0)) {
 
             pass = false;
-            HDsnprintf(msg, (size_t)128,
-                       "Unexpected cache len/size/cs/ds after cleanup in flush op test #%d.", test_num);
+            snprintf(msg, (size_t)128, "Unexpected cache len/size/cs/ds after cleanup in flush op test #%d.",
+                     test_num);
             failure_mssg = msg;
         }
     }
@@ -10723,20 +10720,20 @@ check_flush_cache__single_entry_test(H5F_t *file_ptr, int test_num, int entry_ty
     if (cache_ptr == NULL) {
 
         pass = false;
-        HDsnprintf(msg, (size_t)128, "cache_ptr NULL on entry to single entry test #%d.", test_num);
+        snprintf(msg, (size_t)128, "cache_ptr NULL on entry to single entry test #%d.", test_num);
         failure_mssg = msg;
     }
     else if ((cache_ptr->index_len != 0) || (cache_ptr->index_size != 0)) {
 
         pass = false;
-        HDsnprintf(msg, (size_t)128, "cache not empty at beginning of single entry test #%d.", test_num);
+        snprintf(msg, (size_t)128, "cache not empty at beginning of single entry test #%d.", test_num);
         failure_mssg = msg;
     }
     else if ((entry_type < 0) || (entry_type >= NUMBER_OF_ENTRY_TYPES) || (entry_idx < 0) ||
              (entry_idx > max_indices[entry_type])) {
 
         pass = false;
-        HDsnprintf(msg, (size_t)128, "Bad parameters on entry to single entry test #%d.", test_num);
+        snprintf(msg, (size_t)128, "Bad parameters on entry to single entry test #%d.", test_num);
         failure_mssg = msg;
     }
 
@@ -10763,8 +10760,8 @@ check_flush_cache__single_entry_test(H5F_t *file_ptr, int test_num, int entry_ty
 
         if (!pass) { /* construct and set actual failure message */
 
-            HDsnprintf(msg, (size_t)128, "flush with flags 0x%x failed in single entry test #%d.",
-                       flush_flags, test_num);
+            snprintf(msg, (size_t)128, "flush with flags 0x%x failed in single entry test #%d.", flush_flags,
+                     test_num);
 
             failure_mssg = msg;
         }
@@ -10773,8 +10770,8 @@ check_flush_cache__single_entry_test(H5F_t *file_ptr, int test_num, int entry_ty
                  (entry_ptr->destroyed != expected_destroyed)) {
 
             pass = false;
-            HDsnprintf(msg, (size_t)128, "Unexpected entry status after flush in single entry test #%d.",
-                       test_num);
+            snprintf(msg, (size_t)128, "Unexpected entry status after flush in single entry test #%d.",
+                     test_num);
             failure_mssg = msg;
         }
         else if ((((flush_flags & H5C__FLUSH_INVALIDATE_FLAG) == 0) &&
@@ -10783,8 +10780,8 @@ check_flush_cache__single_entry_test(H5F_t *file_ptr, int test_num, int entry_ty
                   ((cache_ptr->index_len != 0) || (cache_ptr->index_size != 0)))) {
 
             pass = false;
-            HDsnprintf(msg, (size_t)128, "Unexpected cache len/size after flush in single entry test #%d.",
-                       test_num);
+            snprintf(msg, (size_t)128, "Unexpected cache len/size after flush in single entry test #%d.",
+                     test_num);
             failure_mssg = msg;
         }
     }
@@ -10796,14 +10793,14 @@ check_flush_cache__single_entry_test(H5F_t *file_ptr, int test_num, int entry_ty
 
         if (!pass) { /* construct and set actual failure message */
 
-            HDsnprintf(msg, (size_t)128, "Flush failed on cleanup in single entry test #%d.", test_num);
+            snprintf(msg, (size_t)128, "Flush failed on cleanup in single entry test #%d.", test_num);
             failure_mssg = msg;
         }
         else if ((cache_ptr->index_len != 0) || (cache_ptr->index_size != 0)) {
 
             pass = false;
-            HDsnprintf(msg, (size_t)128, "Unexpected cache len/size after cleanup in single entry test #%d.",
-                       test_num);
+            snprintf(msg, (size_t)128, "Unexpected cache len/size after cleanup in single entry test #%d.",
+                     test_num);
             failure_mssg = msg;
         }
         else {
@@ -10842,21 +10839,20 @@ check_flush_cache__pinned_single_entry_test(H5F_t *file_ptr, int test_num, int e
     if (cache_ptr == NULL) {
 
         pass = false;
-        HDsnprintf(msg, (size_t)128, "cache_ptr NULL on entry to pinned single entry test #%d.", test_num);
+        snprintf(msg, (size_t)128, "cache_ptr NULL on entry to pinned single entry test #%d.", test_num);
         failure_mssg = msg;
     }
     else if ((cache_ptr->index_len != 0) || (cache_ptr->index_size != 0)) {
 
         pass = false;
-        HDsnprintf(msg, (size_t)128, "cache not empty at beginning of pinned single entry test #%d.",
-                   test_num);
+        snprintf(msg, (size_t)128, "cache not empty at beginning of pinned single entry test #%d.", test_num);
         failure_mssg = msg;
     }
     else if ((entry_type < 0) || (entry_type >= NUMBER_OF_ENTRY_TYPES) || (entry_idx < 0) ||
              (entry_idx > max_indices[entry_type])) {
 
         pass = false;
-        HDsnprintf(msg, (size_t)128, "Bad parameters on entry to pinned single entry test #%d.", test_num);
+        snprintf(msg, (size_t)128, "Bad parameters on entry to pinned single entry test #%d.", test_num);
         failure_mssg = msg;
     }
 
@@ -10893,8 +10889,8 @@ check_flush_cache__pinned_single_entry_test(H5F_t *file_ptr, int test_num, int e
 
         if (!pass) { /* construct and set the correct failure message */
 
-            HDsnprintf(msg, (size_t)128, "flush with flags 0x%x failed in pinned single entry test #%d.",
-                       flush_flags, test_num);
+            snprintf(msg, (size_t)128, "flush with flags 0x%x failed in pinned single entry test #%d.",
+                     flush_flags, test_num);
             failure_mssg = msg;
         }
         else if ((entry_ptr->deserialized != expected_deserialized) ||
@@ -10902,8 +10898,8 @@ check_flush_cache__pinned_single_entry_test(H5F_t *file_ptr, int test_num, int e
                  (entry_ptr->destroyed != expected_destroyed)) {
 
             pass = false;
-            HDsnprintf(msg, (size_t)128,
-                       "Unexpected entry status after flush in pinned single entry test #%d.", test_num);
+            snprintf(msg, (size_t)128, "Unexpected entry status after flush in pinned single entry test #%d.",
+                     test_num);
             failure_mssg = msg;
         }
         else if ((((flush_flags & H5C__FLUSH_INVALIDATE_FLAG) == 0) &&
@@ -10912,8 +10908,8 @@ check_flush_cache__pinned_single_entry_test(H5F_t *file_ptr, int test_num, int e
                   ((cache_ptr->index_len != 0) || (cache_ptr->index_size != 0)))) {
 
             pass = false;
-            HDsnprintf(msg, (size_t)128,
-                       "Unexpected cache len/size after flush in pinned single entry test #%d.", test_num);
+            snprintf(msg, (size_t)128,
+                     "Unexpected cache len/size after flush in pinned single entry test #%d.", test_num);
             failure_mssg = msg;
         }
     }
@@ -10941,15 +10937,14 @@ check_flush_cache__pinned_single_entry_test(H5F_t *file_ptr, int test_num, int e
 
         if (!pass) {
 
-            HDsnprintf(msg, (size_t)128, "Flush failed on cleanup in pinned single entry test #%d.",
-                       test_num);
+            snprintf(msg, (size_t)128, "Flush failed on cleanup in pinned single entry test #%d.", test_num);
             failure_mssg = msg;
         }
         else if ((cache_ptr->index_len != 0) || (cache_ptr->index_size != 0)) {
 
             pass = false;
-            HDsnprintf(msg, (size_t)128,
-                       "Unexpected cache len/size after cleanup in pinned single entry test #%d.", test_num);
+            snprintf(msg, (size_t)128,
+                     "Unexpected cache len/size after cleanup in pinned single entry test #%d.", test_num);
             failure_mssg = msg;
         }
         else {
@@ -11023,13 +11018,13 @@ check_get_entry_status(unsigned paged)
         if (result < 0) {
 
             pass = false;
-            HDsnprintf(msg, (size_t)128, "H5C_get_entry_status() reports failure 1.");
+            snprintf(msg, (size_t)128, "H5C_get_entry_status() reports failure 1.");
             failure_mssg = msg;
         }
         else if (in_cache) {
 
             pass = false;
-            HDsnprintf(msg, (size_t)128, "Unexpected status 1.");
+            snprintf(msg, (size_t)128, "Unexpected status 1.");
             failure_mssg = msg;
         }
     }
@@ -11049,13 +11044,13 @@ check_get_entry_status(unsigned paged)
         if (result < 0) {
 
             pass = false;
-            HDsnprintf(msg, (size_t)128, "H5C_get_entry_status() reports failure 2.");
+            snprintf(msg, (size_t)128, "H5C_get_entry_status() reports failure 2.");
             failure_mssg = msg;
         }
         else if (!in_cache || is_dirty || is_protected || is_pinned) {
 
             pass = false;
-            HDsnprintf(msg, (size_t)128, "Unexpected status 2.");
+            snprintf(msg, (size_t)128, "Unexpected status 2.");
             failure_mssg = msg;
         }
     }
@@ -11073,13 +11068,13 @@ check_get_entry_status(unsigned paged)
         if (result < 0) {
 
             pass = false;
-            HDsnprintf(msg, (size_t)128, "H5C_get_entry_status() reports failure 3.");
+            snprintf(msg, (size_t)128, "H5C_get_entry_status() reports failure 3.");
             failure_mssg = msg;
         }
         else if (!in_cache || is_dirty || !is_protected || is_pinned) {
 
             pass = false;
-            HDsnprintf(msg, (size_t)128, "Unexpected status 3.");
+            snprintf(msg, (size_t)128, "Unexpected status 3.");
             failure_mssg = msg;
         }
     }
@@ -11097,13 +11092,13 @@ check_get_entry_status(unsigned paged)
         if (result < 0) {
 
             pass = false;
-            HDsnprintf(msg, (size_t)128, "H5C_get_entry_status() reports failure 4.");
+            snprintf(msg, (size_t)128, "H5C_get_entry_status() reports failure 4.");
             failure_mssg = msg;
         }
         else if (!in_cache || is_dirty || is_protected || !is_pinned) {
 
             pass = false;
-            HDsnprintf(msg, (size_t)128, "Unexpected status 4.");
+            snprintf(msg, (size_t)128, "Unexpected status 4.");
             failure_mssg = msg;
         }
     }
@@ -11121,13 +11116,13 @@ check_get_entry_status(unsigned paged)
         if (result < 0) {
 
             pass = false;
-            HDsnprintf(msg, (size_t)128, "H5C_get_entry_status() reports failure 5.");
+            snprintf(msg, (size_t)128, "H5C_get_entry_status() reports failure 5.");
             failure_mssg = msg;
         }
         else if (!in_cache || !is_dirty || is_protected || !is_pinned) {
 
             pass = false;
-            HDsnprintf(msg, (size_t)128, "Unexpected status 5.");
+            snprintf(msg, (size_t)128, "Unexpected status 5.");
             failure_mssg = msg;
         }
     }
@@ -11145,13 +11140,13 @@ check_get_entry_status(unsigned paged)
         if (result < 0) {
 
             pass = false;
-            HDsnprintf(msg, (size_t)128, "H5C_get_entry_status() reports failure 6.");
+            snprintf(msg, (size_t)128, "H5C_get_entry_status() reports failure 6.");
             failure_mssg = msg;
         }
         else if (!in_cache || !is_dirty || is_protected || is_pinned) {
 
             pass = false;
-            HDsnprintf(msg, (size_t)128, "Unexpected status 6.");
+            snprintf(msg, (size_t)128, "Unexpected status 6.");
             failure_mssg = msg;
         }
     }
@@ -11230,19 +11225,19 @@ check_expunge_entry(unsigned paged)
         if (result < 0) {
 
             pass = false;
-            HDsnprintf(msg, (size_t)128, "H5C_get_entry_status() reports failure 1.");
+            snprintf(msg, (size_t)128, "H5C_get_entry_status() reports failure 1.");
             failure_mssg = msg;
         }
         else if (in_cache) {
 
             pass = false;
-            HDsnprintf(msg, (size_t)128, "Unexpected status 1.");
+            snprintf(msg, (size_t)128, "Unexpected status 1.");
             failure_mssg = msg;
         }
         else if ((entry_ptr->deserialized) || (entry_ptr->serialized) || (entry_ptr->destroyed)) {
 
             pass = false;
-            HDsnprintf(msg, (size_t)128, "Unexpected entry history 1.");
+            snprintf(msg, (size_t)128, "Unexpected entry history 1.");
             failure_mssg = msg;
         }
     }
@@ -11266,19 +11261,19 @@ check_expunge_entry(unsigned paged)
         if (result < 0) {
 
             pass = false;
-            HDsnprintf(msg, (size_t)128, "H5C_get_entry_status() reports failure 2.");
+            snprintf(msg, (size_t)128, "H5C_get_entry_status() reports failure 2.");
             failure_mssg = msg;
         }
         else if (!in_cache || is_dirty || is_protected || is_pinned) {
 
             pass = false;
-            HDsnprintf(msg, (size_t)128, "Unexpected status 2.");
+            snprintf(msg, (size_t)128, "Unexpected status 2.");
             failure_mssg = msg;
         }
         else if ((!entry_ptr->deserialized) || (entry_ptr->serialized) || (entry_ptr->destroyed)) {
 
             pass = false;
-            HDsnprintf(msg, (size_t)128, "Unexpected entry history 2.");
+            snprintf(msg, (size_t)128, "Unexpected entry history 2.");
             failure_mssg = msg;
         }
     }
@@ -11304,19 +11299,19 @@ check_expunge_entry(unsigned paged)
         if (result < 0) {
 
             pass = false;
-            HDsnprintf(msg, (size_t)128, "H5C_get_entry_status() reports failure 3.");
+            snprintf(msg, (size_t)128, "H5C_get_entry_status() reports failure 3.");
             failure_mssg = msg;
         }
         else if (in_cache) {
 
             pass = false;
-            HDsnprintf(msg, (size_t)128, "Unexpected status 3.");
+            snprintf(msg, (size_t)128, "Unexpected status 3.");
             failure_mssg = msg;
         }
         else if ((!entry_ptr->deserialized) || (entry_ptr->serialized) || (!entry_ptr->destroyed)) {
 
             pass = false;
-            HDsnprintf(msg, (size_t)128, "Unexpected entry history 3.");
+            snprintf(msg, (size_t)128, "Unexpected entry history 3.");
             failure_mssg = msg;
         }
     }
@@ -11340,19 +11335,19 @@ check_expunge_entry(unsigned paged)
         if (result < 0) {
 
             pass = false;
-            HDsnprintf(msg, (size_t)128, "H5C_get_entry_status() reports failure 4.");
+            snprintf(msg, (size_t)128, "H5C_get_entry_status() reports failure 4.");
             failure_mssg = msg;
         }
         else if (in_cache) {
 
             pass = false;
-            HDsnprintf(msg, (size_t)128, "Unexpected status 4.");
+            snprintf(msg, (size_t)128, "Unexpected status 4.");
             failure_mssg = msg;
         }
         else if ((entry_ptr->deserialized) || (entry_ptr->serialized) || (entry_ptr->destroyed)) {
 
             pass = false;
-            HDsnprintf(msg, (size_t)128, "Unexpected entry history 4.");
+            snprintf(msg, (size_t)128, "Unexpected entry history 4.");
             failure_mssg = msg;
         }
     }
@@ -11376,19 +11371,19 @@ check_expunge_entry(unsigned paged)
         if (result < 0) {
 
             pass = false;
-            HDsnprintf(msg, (size_t)128, "H5C_get_entry_status() reports failure 5.");
+            snprintf(msg, (size_t)128, "H5C_get_entry_status() reports failure 5.");
             failure_mssg = msg;
         }
         else if (!in_cache || !is_dirty || is_protected || is_pinned) {
 
             pass = false;
-            HDsnprintf(msg, (size_t)128, "Unexpected status 5.");
+            snprintf(msg, (size_t)128, "Unexpected status 5.");
             failure_mssg = msg;
         }
         else if ((!entry_ptr->deserialized) || (entry_ptr->serialized) || (entry_ptr->destroyed)) {
 
             pass = false;
-            HDsnprintf(msg, (size_t)128, "Unexpected entry history 5.");
+            snprintf(msg, (size_t)128, "Unexpected entry history 5.");
             failure_mssg = msg;
         }
     }
@@ -11414,19 +11409,19 @@ check_expunge_entry(unsigned paged)
         if (result < 0) {
 
             pass = false;
-            HDsnprintf(msg, (size_t)128, "H5C_get_entry_status() reports failure 6.");
+            snprintf(msg, (size_t)128, "H5C_get_entry_status() reports failure 6.");
             failure_mssg = msg;
         }
         else if (in_cache) {
 
             pass = false;
-            HDsnprintf(msg, (size_t)128, "Unexpected status 6.");
+            snprintf(msg, (size_t)128, "Unexpected status 6.");
             failure_mssg = msg;
         }
         else if ((!entry_ptr->deserialized) || (entry_ptr->serialized) || (!entry_ptr->destroyed)) {
 
             pass = false;
-            HDsnprintf(msg, (size_t)128, "Unexpected entry history 6.");
+            snprintf(msg, (size_t)128, "Unexpected entry history 6.");
             failure_mssg = msg;
         }
     }
@@ -11956,13 +11951,13 @@ check_move_entry__run_test(H5F_t *file_ptr, unsigned test_num, struct move_entry
     if (cache_ptr == NULL) {
 
         pass = false;
-        HDsnprintf(msg, (size_t)128, "cache_ptr NULL on entry to move test #%u.", test_num);
+        snprintf(msg, (size_t)128, "cache_ptr NULL on entry to move test #%u.", test_num);
         failure_mssg = msg;
     }
     else if (spec_ptr == NULL) {
 
         pass = false;
-        HDsnprintf(msg, (size_t)128, "spec_ptr NULL on entry to move test #%u.", test_num);
+        snprintf(msg, (size_t)128, "spec_ptr NULL on entry to move test #%u.", test_num);
         failure_mssg = msg;
     }
 
@@ -11976,7 +11971,7 @@ check_move_entry__run_test(H5F_t *file_ptr, unsigned test_num, struct move_entry
             (!(entry_ptr->at_main_addr)) || (entry_ptr->addr != entry_ptr->main_addr)) {
 
             pass = false;
-            HDsnprintf(msg, (size_t)128, "bad entry_ptr in move test #%u.", test_num);
+            snprintf(msg, (size_t)128, "bad entry_ptr in move test #%u.", test_num);
             failure_mssg = msg;
         }
     }
@@ -12006,7 +12001,7 @@ check_move_entry__run_test(H5F_t *file_ptr, unsigned test_num, struct move_entry
             if (!(entry_ptr->header.is_pinned)) {
 
                 pass = false;
-                HDsnprintf(msg, (size_t)128, "Pinned entry not pinned after move in test #%u.", test_num);
+                snprintf(msg, (size_t)128, "Pinned entry not pinned after move in test #%u.", test_num);
                 failure_mssg = msg;
             }
 
@@ -12023,8 +12018,8 @@ check_move_entry__run_test(H5F_t *file_ptr, unsigned test_num, struct move_entry
                     if (test_ptr == NULL) {
 
                         pass = false;
-                        HDsnprintf(msg, (size_t)128, "Pinned entry not in pel after move in test #%u.",
-                                   test_num);
+                        snprintf(msg, (size_t)128, "Pinned entry not in pel after move in test #%u.",
+                                 test_num);
                         failure_mssg = msg;
                     }
                 } /* end else */
@@ -12037,7 +12032,7 @@ check_move_entry__run_test(H5F_t *file_ptr, unsigned test_num, struct move_entry
             if (entry_ptr->header.is_pinned) {
 
                 pass = false;
-                HDsnprintf(msg, (size_t)128, "Unpinned entry pinned after move in test #%u.", test_num);
+                snprintf(msg, (size_t)128, "Unpinned entry pinned after move in test #%u.", test_num);
                 failure_mssg = msg;
             }
 
@@ -12047,8 +12042,7 @@ check_move_entry__run_test(H5F_t *file_ptr, unsigned test_num, struct move_entry
                 if ((entry_ptr->header.prev != NULL) ||
                     (cache_ptr->LRU_head_ptr != (H5C_cache_entry_t *)entry_ptr)) {
                     pass = false;
-                    HDsnprintf(msg, (size_t)128, "Entry not at head of LRU after move in test #%u.",
-                               test_num);
+                    snprintf(msg, (size_t)128, "Entry not at head of LRU after move in test #%u.", test_num);
                     failure_mssg = msg;
                 }
             } /* end else */
@@ -12058,8 +12052,7 @@ check_move_entry__run_test(H5F_t *file_ptr, unsigned test_num, struct move_entry
             if (!(entry_ptr->header.is_protected)) {
 
                 pass = false;
-                HDsnprintf(msg, (size_t)128, "Protected entry not protected after move in test #%u.",
-                           test_num);
+                snprintf(msg, (size_t)128, "Protected entry not protected after move in test #%u.", test_num);
                 failure_mssg = msg;
             }
 
@@ -12070,8 +12063,8 @@ check_move_entry__run_test(H5F_t *file_ptr, unsigned test_num, struct move_entry
             if (entry_ptr->header.is_protected) {
 
                 pass = false;
-                HDsnprintf(msg, (size_t)128, "Unprotected entry not unprotected after move in test #%u.",
-                           test_num);
+                snprintf(msg, (size_t)128, "Unprotected entry not unprotected after move in test #%u.",
+                         test_num);
                 failure_mssg = msg;
             }
         } /* end else */
@@ -12141,13 +12134,13 @@ check_pin_protected_entry(unsigned paged)
         if (result < 0) {
 
             pass = false;
-            HDsnprintf(msg, (size_t)128, "H5C_pin_protected_entry() reports failure.");
+            snprintf(msg, (size_t)128, "H5C_pin_protected_entry() reports failure.");
             failure_mssg = msg;
         }
         else if (!(entry_ptr->header.is_pinned)) {
 
             pass = false;
-            HDsnprintf(msg, (size_t)128, "entry not pinned when it should be.");
+            snprintf(msg, (size_t)128, "entry not pinned when it should be.");
             failure_mssg = msg;
         }
         else {
@@ -12270,7 +12263,7 @@ check_resize_entry(unsigned paged)
             (cache_ptr->slist_size != 0)) {
 
             pass = false;
-            HDsnprintf(msg, (size_t)128, "Unexpected cache status 1.");
+            snprintf(msg, (size_t)128, "Unexpected cache status 1.");
             failure_mssg = msg;
         }
     }
@@ -12286,7 +12279,7 @@ check_resize_entry(unsigned paged)
             (cache_ptr->slist_len != 0) || (cache_ptr->slist_size != 0)) {
 
             pass = false;
-            HDsnprintf(msg, (size_t)128, "Unexpected cache status 2.");
+            snprintf(msg, (size_t)128, "Unexpected cache status 2.");
             failure_mssg = msg;
         }
     }
@@ -12299,19 +12292,19 @@ check_resize_entry(unsigned paged)
         if (result < 0) {
 
             pass = false;
-            HDsnprintf(msg, (size_t)128, "H5C_get_entry_status() reports failure 1.");
+            snprintf(msg, (size_t)128, "H5C_get_entry_status() reports failure 1.");
             failure_mssg = msg;
         }
         else if (!in_cache || is_dirty || !is_protected || is_pinned) {
 
             pass = false;
-            HDsnprintf(msg, (size_t)128, "Unexpected status 1.");
+            snprintf(msg, (size_t)128, "Unexpected status 1.");
             failure_mssg = msg;
         }
         else if ((!entry_ptr->deserialized) || (entry_ptr->serialized) || (entry_ptr->destroyed)) {
 
             pass = false;
-            HDsnprintf(msg, (size_t)128, "Unexpected entry history 1.");
+            snprintf(msg, (size_t)128, "Unexpected entry history 1.");
             failure_mssg = msg;
         }
     }
@@ -12323,7 +12316,7 @@ check_resize_entry(unsigned paged)
         if (result < 0) {
 
             pass = false;
-            HDsnprintf(msg, (size_t)128, "error(s) in H5C_resize_entry().");
+            snprintf(msg, (size_t)128, "error(s) in H5C_resize_entry().");
             failure_mssg = msg;
         }
         else {
@@ -12333,7 +12326,7 @@ check_resize_entry(unsigned paged)
             if (result < 0) {
 
                 pass = false;
-                HDsnprintf(msg, (size_t)128, "H5C_unprotect() reports failure 1.");
+                snprintf(msg, (size_t)128, "H5C_unprotect() reports failure 1.");
                 failure_mssg = msg;
             }
             else {
@@ -12355,7 +12348,7 @@ check_resize_entry(unsigned paged)
              ((cache_ptr->slist_len != 1) || (cache_ptr->slist_size != (LARGE_ENTRY_SIZE / 2))))) {
 
             pass = false;
-            HDsnprintf(msg, (size_t)128, "Unexpected cache status 3.");
+            snprintf(msg, (size_t)128, "Unexpected cache status 3.");
             failure_mssg = msg;
         }
     }
@@ -12368,20 +12361,20 @@ check_resize_entry(unsigned paged)
         if (result < 0) {
 
             pass = false;
-            HDsnprintf(msg, (size_t)128, "H5C_get_entry_status() reports failure 2.");
+            snprintf(msg, (size_t)128, "H5C_get_entry_status() reports failure 2.");
             failure_mssg = msg;
         }
         else if (!in_cache || !is_dirty || is_protected || is_pinned ||
                  (reported_entry_size != (LARGE_ENTRY_SIZE / 2))) {
 
             pass = false;
-            HDsnprintf(msg, (size_t)128, "Unexpected status 2.");
+            snprintf(msg, (size_t)128, "Unexpected status 2.");
             failure_mssg = msg;
         }
         else if ((!entry_ptr->deserialized) || (entry_ptr->serialized) || (entry_ptr->destroyed)) {
 
             pass = false;
-            HDsnprintf(msg, (size_t)128, "Unexpected entry history 2.");
+            snprintf(msg, (size_t)128, "Unexpected entry history 2.");
             failure_mssg = msg;
         }
     }
@@ -12398,7 +12391,7 @@ check_resize_entry(unsigned paged)
         if (result < 0) {
 
             pass = false;
-            HDsnprintf(msg, (size_t)128, "error(s) in H5C_resize_entry().");
+            snprintf(msg, (size_t)128, "error(s) in H5C_resize_entry().");
             failure_mssg = msg;
         }
         else {
@@ -12408,7 +12401,7 @@ check_resize_entry(unsigned paged)
             if (result < 0) {
 
                 pass = false;
-                HDsnprintf(msg, (size_t)128, "H5C_unprotect() reports failure 2.");
+                snprintf(msg, (size_t)128, "H5C_unprotect() reports failure 2.");
                 failure_mssg = msg;
             }
             else {
@@ -12430,7 +12423,7 @@ check_resize_entry(unsigned paged)
              ((cache_ptr->slist_len != 1) || (cache_ptr->slist_size != LARGE_ENTRY_SIZE)))) {
 
             pass = false;
-            HDsnprintf(msg, (size_t)128, "Unexpected cache status 4.");
+            snprintf(msg, (size_t)128, "Unexpected cache status 4.");
             failure_mssg = msg;
         }
     }
@@ -12443,20 +12436,20 @@ check_resize_entry(unsigned paged)
         if (result < 0) {
 
             pass = false;
-            HDsnprintf(msg, (size_t)128, "H5C_get_entry_status() reports failure 3.");
+            snprintf(msg, (size_t)128, "H5C_get_entry_status() reports failure 3.");
             failure_mssg = msg;
         }
         else if (!in_cache || !is_dirty || is_protected || is_pinned ||
                  (reported_entry_size != LARGE_ENTRY_SIZE)) {
 
             pass = false;
-            HDsnprintf(msg, (size_t)128, "Unexpected status 3.");
+            snprintf(msg, (size_t)128, "Unexpected status 3.");
             failure_mssg = msg;
         }
         else if ((!entry_ptr->deserialized) || (entry_ptr->serialized) || (entry_ptr->destroyed)) {
 
             pass = false;
-            HDsnprintf(msg, (size_t)128, "Unexpected entry history 3.");
+            snprintf(msg, (size_t)128, "Unexpected entry history 3.");
             failure_mssg = msg;
         }
     }
@@ -12475,7 +12468,7 @@ check_resize_entry(unsigned paged)
         if (result < 0) {
 
             pass = false;
-            HDsnprintf(msg, (size_t)128, "H5C_resize_entry() reports failure 1.");
+            snprintf(msg, (size_t)128, "H5C_resize_entry() reports failure 1.");
             failure_mssg = msg;
         }
     }
@@ -12487,7 +12480,7 @@ check_resize_entry(unsigned paged)
              ((cache_ptr->slist_len != 1) || (cache_ptr->slist_size != (LARGE_ENTRY_SIZE / 4))))) {
 
             pass = false;
-            HDsnprintf(msg, (size_t)128, "Unexpected cache status 5.");
+            snprintf(msg, (size_t)128, "Unexpected cache status 5.");
             failure_mssg = msg;
         }
     }
@@ -12500,20 +12493,20 @@ check_resize_entry(unsigned paged)
         if (result < 0) {
 
             pass = false;
-            HDsnprintf(msg, (size_t)128, "H5C_get_entry_status() reports failure 4.");
+            snprintf(msg, (size_t)128, "H5C_get_entry_status() reports failure 4.");
             failure_mssg = msg;
         }
         else if (!in_cache || !is_dirty || is_protected || !is_pinned ||
                  (reported_entry_size != (LARGE_ENTRY_SIZE / 4))) {
 
             pass = false;
-            HDsnprintf(msg, (size_t)128, "Unexpected status 4.");
+            snprintf(msg, (size_t)128, "Unexpected status 4.");
             failure_mssg = msg;
         }
         else if ((!entry_ptr->deserialized) || (entry_ptr->serialized) || (entry_ptr->destroyed)) {
 
             pass = false;
-            HDsnprintf(msg, (size_t)128, "Unexpected entry history 4.");
+            snprintf(msg, (size_t)128, "Unexpected entry history 4.");
             failure_mssg = msg;
         }
     }
@@ -12525,7 +12518,7 @@ check_resize_entry(unsigned paged)
         if (result < 0) {
 
             pass = false;
-            HDsnprintf(msg, (size_t)128, "H5C_resize_entry() reports failure 2.");
+            snprintf(msg, (size_t)128, "H5C_resize_entry() reports failure 2.");
             failure_mssg = msg;
         }
     }
@@ -12537,7 +12530,7 @@ check_resize_entry(unsigned paged)
              ((cache_ptr->slist_len != 1) || (cache_ptr->slist_size != LARGE_ENTRY_SIZE)))) {
 
             pass = false;
-            HDsnprintf(msg, (size_t)128, "Unexpected cache status 6.");
+            snprintf(msg, (size_t)128, "Unexpected cache status 6.");
             failure_mssg = msg;
         }
     }
@@ -12550,20 +12543,20 @@ check_resize_entry(unsigned paged)
         if (result < 0) {
 
             pass = false;
-            HDsnprintf(msg, (size_t)128, "H5C_get_entry_status() reports failure 5.");
+            snprintf(msg, (size_t)128, "H5C_get_entry_status() reports failure 5.");
             failure_mssg = msg;
         }
         else if (!in_cache || !is_dirty || is_protected || !is_pinned ||
                  (reported_entry_size != LARGE_ENTRY_SIZE)) {
 
             pass = false;
-            HDsnprintf(msg, (size_t)128, "Unexpected status 5.");
+            snprintf(msg, (size_t)128, "Unexpected status 5.");
             failure_mssg = msg;
         }
         else if ((!entry_ptr->deserialized) || (entry_ptr->serialized) || (entry_ptr->destroyed)) {
 
             pass = false;
-            HDsnprintf(msg, (size_t)128, "Unexpected entry history 5.");
+            snprintf(msg, (size_t)128, "Unexpected entry history 5.");
             failure_mssg = msg;
         }
     }
@@ -12583,19 +12576,19 @@ check_resize_entry(unsigned paged)
         if (result < 0) {
 
             pass = false;
-            HDsnprintf(msg, (size_t)128, "H5C_get_entry_status() reports failure 6.");
+            snprintf(msg, (size_t)128, "H5C_get_entry_status() reports failure 6.");
             failure_mssg = msg;
         }
         else if (in_cache) {
 
             pass = false;
-            HDsnprintf(msg, (size_t)128, "Unexpected status 6.");
+            snprintf(msg, (size_t)128, "Unexpected status 6.");
             failure_mssg = msg;
         }
         else if ((!entry_ptr->deserialized) || (entry_ptr->serialized) || (!entry_ptr->destroyed)) {
 
             pass = false;
-            HDsnprintf(msg, (size_t)128, "Unexpected entry history 6.");
+            snprintf(msg, (size_t)128, "Unexpected entry history 6.");
             failure_mssg = msg;
         }
     }
@@ -12606,7 +12599,7 @@ check_resize_entry(unsigned paged)
             ((cache_ptr->slist_enabled) && ((cache_ptr->slist_len != 0) || (cache_ptr->slist_size != 0)))) {
 
             pass = false;
-            HDsnprintf(msg, (size_t)128, "Unexpected cache status 7.");
+            snprintf(msg, (size_t)128, "Unexpected cache status 7.");
             failure_mssg = msg;
         }
     }
@@ -12619,7 +12612,7 @@ check_resize_entry(unsigned paged)
             ((cache_ptr->slist_enabled) && ((cache_ptr->slist_len != 0) || (cache_ptr->slist_size != 0)))) {
 
             pass = false;
-            HDsnprintf(msg, (size_t)128, "Unexpected cache status 8.");
+            snprintf(msg, (size_t)128, "Unexpected cache status 8.");
             failure_mssg = msg;
         }
 
@@ -12647,7 +12640,7 @@ check_resize_entry(unsigned paged)
              ((cache_ptr->slist_len != 1) || (cache_ptr->slist_size != LARGE_ENTRY_SIZE)))) {
 
             pass = false;
-            HDsnprintf(msg, (size_t)128, "Unexpected cache status 9.");
+            snprintf(msg, (size_t)128, "Unexpected cache status 9.");
             failure_mssg = msg;
         }
     }
@@ -12664,7 +12657,7 @@ check_resize_entry(unsigned paged)
              ((cache_ptr->slist_len != 1) || (cache_ptr->slist_size != LARGE_ENTRY_SIZE)))) {
 
             pass = false;
-            HDsnprintf(msg, (size_t)128, "Unexpected cache status 10.");
+            snprintf(msg, (size_t)128, "Unexpected cache status 10.");
             failure_mssg = msg;
         }
     }
@@ -12677,19 +12670,19 @@ check_resize_entry(unsigned paged)
         if (result < 0) {
 
             pass = false;
-            HDsnprintf(msg, (size_t)128, "H5C_get_entry_status() reports failure 7.");
+            snprintf(msg, (size_t)128, "H5C_get_entry_status() reports failure 7.");
             failure_mssg = msg;
         }
         else if (!in_cache || is_dirty || !is_protected || is_pinned) {
 
             pass = false;
-            HDsnprintf(msg, (size_t)128, "Unexpected status 7.");
+            snprintf(msg, (size_t)128, "Unexpected status 7.");
             failure_mssg = msg;
         }
         else if ((!entry_ptr->deserialized) || (entry_ptr->serialized) || (entry_ptr->destroyed)) {
 
             pass = false;
-            HDsnprintf(msg, (size_t)128, "Unexpected entry history 7.");
+            snprintf(msg, (size_t)128, "Unexpected entry history 7.");
             failure_mssg = msg;
         }
     }
@@ -12701,7 +12694,7 @@ check_resize_entry(unsigned paged)
         if (result < 0) {
 
             pass = false;
-            HDsnprintf(msg, (size_t)128, "error(s) in H5C_resize_entry().");
+            snprintf(msg, (size_t)128, "error(s) in H5C_resize_entry().");
             failure_mssg = msg;
         }
         else {
@@ -12711,7 +12704,7 @@ check_resize_entry(unsigned paged)
             if (result < 0) {
 
                 pass = false;
-                HDsnprintf(msg, (size_t)128, "H5C_unprotect() reports failure 3.");
+                snprintf(msg, (size_t)128, "H5C_unprotect() reports failure 3.");
                 failure_mssg = msg;
             }
             else {
@@ -12735,7 +12728,7 @@ check_resize_entry(unsigned paged)
               (cache_ptr->slist_size != (LARGE_ENTRY_SIZE + (LARGE_ENTRY_SIZE / 2)))))) {
 
             pass = false;
-            HDsnprintf(msg, (size_t)128, "Unexpected cache status 11.");
+            snprintf(msg, (size_t)128, "Unexpected cache status 11.");
             failure_mssg = msg;
         }
     }
@@ -12748,20 +12741,20 @@ check_resize_entry(unsigned paged)
         if (result < 0) {
 
             pass = false;
-            HDsnprintf(msg, (size_t)128, "H5C_get_entry_status() reports failure 8.");
+            snprintf(msg, (size_t)128, "H5C_get_entry_status() reports failure 8.");
             failure_mssg = msg;
         }
         else if (!in_cache || !is_dirty || is_protected || is_pinned ||
                  (reported_entry_size != (LARGE_ENTRY_SIZE / 2))) {
 
             pass = false;
-            HDsnprintf(msg, (size_t)128, "Unexpected status 8.");
+            snprintf(msg, (size_t)128, "Unexpected status 8.");
             failure_mssg = msg;
         }
         else if ((!entry_ptr->deserialized) || (entry_ptr->serialized) || (entry_ptr->destroyed)) {
 
             pass = false;
-            HDsnprintf(msg, (size_t)128, "Unexpected entry history 8.");
+            snprintf(msg, (size_t)128, "Unexpected entry history 8.");
             failure_mssg = msg;
         }
     }
@@ -12778,7 +12771,7 @@ check_resize_entry(unsigned paged)
         if (result < 0) {
 
             pass = false;
-            HDsnprintf(msg, (size_t)128, "error(s) in H5C_resize_entry().");
+            snprintf(msg, (size_t)128, "error(s) in H5C_resize_entry().");
             failure_mssg = msg;
         }
         else {
@@ -12788,7 +12781,7 @@ check_resize_entry(unsigned paged)
             if (result < 0) {
 
                 pass = false;
-                HDsnprintf(msg, (size_t)128, "H5C_unprotect() reports failure 4.");
+                snprintf(msg, (size_t)128, "H5C_unprotect() reports failure 4.");
                 failure_mssg = msg;
             }
             else {
@@ -12810,7 +12803,7 @@ check_resize_entry(unsigned paged)
              ((cache_ptr->slist_len != 2) || (cache_ptr->slist_size != 2 * LARGE_ENTRY_SIZE)))) {
 
             pass = false;
-            HDsnprintf(msg, (size_t)128, "Unexpected cache status 12.");
+            snprintf(msg, (size_t)128, "Unexpected cache status 12.");
             failure_mssg = msg;
         }
     }
@@ -12823,20 +12816,20 @@ check_resize_entry(unsigned paged)
         if (result < 0) {
 
             pass = false;
-            HDsnprintf(msg, (size_t)128, "H5C_get_entry_status() reports failure 9.");
+            snprintf(msg, (size_t)128, "H5C_get_entry_status() reports failure 9.");
             failure_mssg = msg;
         }
         else if (!in_cache || !is_dirty || is_protected || is_pinned ||
                  (reported_entry_size != LARGE_ENTRY_SIZE)) {
 
             pass = false;
-            HDsnprintf(msg, (size_t)128, "Unexpected status 9.");
+            snprintf(msg, (size_t)128, "Unexpected status 9.");
             failure_mssg = msg;
         }
         else if ((!entry_ptr->deserialized) || (entry_ptr->serialized) || (entry_ptr->destroyed)) {
 
             pass = false;
-            HDsnprintf(msg, (size_t)128, "Unexpected entry history 9.");
+            snprintf(msg, (size_t)128, "Unexpected entry history 9.");
             failure_mssg = msg;
         }
     }
@@ -12855,7 +12848,7 @@ check_resize_entry(unsigned paged)
         if (result < 0) {
 
             pass = false;
-            HDsnprintf(msg, (size_t)128, "H5C_resize_entry() reports failure 3.");
+            snprintf(msg, (size_t)128, "H5C_resize_entry() reports failure 3.");
             failure_mssg = msg;
         }
     }
@@ -12869,7 +12862,7 @@ check_resize_entry(unsigned paged)
               (cache_ptr->slist_size != (LARGE_ENTRY_SIZE + (LARGE_ENTRY_SIZE / 4)))))) {
 
             pass = false;
-            HDsnprintf(msg, (size_t)128, "Unexpected cache status 13.");
+            snprintf(msg, (size_t)128, "Unexpected cache status 13.");
             failure_mssg = msg;
         }
     }
@@ -12882,20 +12875,20 @@ check_resize_entry(unsigned paged)
         if (result < 0) {
 
             pass = false;
-            HDsnprintf(msg, (size_t)128, "H5C_get_entry_status() reports failure 10.");
+            snprintf(msg, (size_t)128, "H5C_get_entry_status() reports failure 10.");
             failure_mssg = msg;
         }
         else if (!in_cache || !is_dirty || is_protected || !is_pinned ||
                  (reported_entry_size != (LARGE_ENTRY_SIZE / 4))) {
 
             pass = false;
-            HDsnprintf(msg, (size_t)128, "Unexpected status 10.");
+            snprintf(msg, (size_t)128, "Unexpected status 10.");
             failure_mssg = msg;
         }
         else if ((!entry_ptr->deserialized) || (entry_ptr->serialized) || (entry_ptr->destroyed)) {
 
             pass = false;
-            HDsnprintf(msg, (size_t)128, "Unexpected entry history 10.");
+            snprintf(msg, (size_t)128, "Unexpected entry history 10.");
             failure_mssg = msg;
         }
     }
@@ -12907,7 +12900,7 @@ check_resize_entry(unsigned paged)
         if (result < 0) {
 
             pass = false;
-            HDsnprintf(msg, (size_t)128, "H5C_resize_entry() reports failure 4.");
+            snprintf(msg, (size_t)128, "H5C_resize_entry() reports failure 4.");
             failure_mssg = msg;
         }
     }
@@ -12919,7 +12912,7 @@ check_resize_entry(unsigned paged)
              ((cache_ptr->slist_len != 2) || (cache_ptr->slist_size != (2 * LARGE_ENTRY_SIZE))))) {
 
             pass = false;
-            HDsnprintf(msg, (size_t)128, "Unexpected cache status 14.");
+            snprintf(msg, (size_t)128, "Unexpected cache status 14.");
             failure_mssg = msg;
         }
     }
@@ -12932,20 +12925,20 @@ check_resize_entry(unsigned paged)
         if (result < 0) {
 
             pass = false;
-            HDsnprintf(msg, (size_t)128, "H5C_get_entry_status() reports failure 11.");
+            snprintf(msg, (size_t)128, "H5C_get_entry_status() reports failure 11.");
             failure_mssg = msg;
         }
         else if (!in_cache || !is_dirty || is_protected || !is_pinned ||
                  (reported_entry_size != LARGE_ENTRY_SIZE)) {
 
             pass = false;
-            HDsnprintf(msg, (size_t)128, "Unexpected status 11.");
+            snprintf(msg, (size_t)128, "Unexpected status 11.");
             failure_mssg = msg;
         }
         else if ((!entry_ptr->deserialized) || (entry_ptr->serialized) || (entry_ptr->destroyed)) {
 
             pass = false;
-            HDsnprintf(msg, (size_t)128, "Unexpected entry history 11.");
+            snprintf(msg, (size_t)128, "Unexpected entry history 11.");
             failure_mssg = msg;
         }
     }
@@ -12965,19 +12958,19 @@ check_resize_entry(unsigned paged)
         if (result < 0) {
 
             pass = false;
-            HDsnprintf(msg, (size_t)128, "H5C_get_entry_status() reports failure 12.");
+            snprintf(msg, (size_t)128, "H5C_get_entry_status() reports failure 12.");
             failure_mssg = msg;
         }
         else if (in_cache) {
 
             pass = false;
-            HDsnprintf(msg, (size_t)128, "Unexpected status 12.");
+            snprintf(msg, (size_t)128, "Unexpected status 12.");
             failure_mssg = msg;
         }
         else if ((!entry_ptr->deserialized) || (entry_ptr->serialized) || (!entry_ptr->destroyed)) {
 
             pass = false;
-            HDsnprintf(msg, (size_t)128, "Unexpected entry history 12.");
+            snprintf(msg, (size_t)128, "Unexpected entry history 12.");
             failure_mssg = msg;
         }
     }
@@ -12989,7 +12982,7 @@ check_resize_entry(unsigned paged)
              ((cache_ptr->slist_len != 1) || (cache_ptr->slist_size != LARGE_ENTRY_SIZE)))) {
 
             pass = false;
-            HDsnprintf(msg, (size_t)128, "Unexpected cache status 15.");
+            snprintf(msg, (size_t)128, "Unexpected cache status 15.");
             failure_mssg = msg;
         }
     }
@@ -13012,7 +13005,7 @@ check_resize_entry(unsigned paged)
             ((cache_ptr->slist_enabled) && ((cache_ptr->slist_len != 0) || (cache_ptr->slist_size != 0)))) {
 
             pass = false;
-            HDsnprintf(msg, (size_t)128, "Unexpected cache status 16.");
+            snprintf(msg, (size_t)128, "Unexpected cache status 16.");
             failure_mssg = msg;
         }
     }
@@ -13139,7 +13132,7 @@ check_evictions_enabled(unsigned paged)
             (cache_ptr->evictions_enabled != true)) {
 
             pass = false;
-            HDsnprintf(msg, (size_t)128, "Unexpected cache status 1.");
+            snprintf(msg, (size_t)128, "Unexpected cache status 1.");
             failure_mssg = msg;
         }
     }
@@ -13155,7 +13148,7 @@ check_evictions_enabled(unsigned paged)
         if ((result != SUCCEED) || (evictions_enabled != true)) {
 
             pass = false;
-            HDsnprintf(msg, (size_t)128, "Unexpected evictions enabled 1.");
+            snprintf(msg, (size_t)128, "Unexpected evictions enabled 1.");
             failure_mssg = msg;
         }
     }
@@ -13183,7 +13176,7 @@ check_evictions_enabled(unsigned paged)
             (cache_ptr->evictions_enabled != true)) {
 
             pass = false;
-            HDsnprintf(msg, (size_t)128, "Unexpected cache status 2.");
+            snprintf(msg, (size_t)128, "Unexpected cache status 2.");
             failure_mssg = msg;
         }
     }
@@ -13209,7 +13202,7 @@ check_evictions_enabled(unsigned paged)
             (cache_ptr->evictions_enabled != true)) {
 
             pass = false;
-            HDsnprintf(msg, (size_t)128, "Unexpected cache status 3.");
+            snprintf(msg, (size_t)128, "Unexpected cache status 3.");
             failure_mssg = msg;
         }
     }
@@ -13227,19 +13220,19 @@ check_evictions_enabled(unsigned paged)
         if (result < 0) {
 
             pass = false;
-            HDsnprintf(msg, (size_t)128, "H5C_get_entry_status() reports failure 1.");
+            snprintf(msg, (size_t)128, "H5C_get_entry_status() reports failure 1.");
             failure_mssg = msg;
         }
         else if (in_cache) {
 
             pass = false;
-            HDsnprintf(msg, (size_t)128, "Unexpected status 1.");
+            snprintf(msg, (size_t)128, "Unexpected status 1.");
             failure_mssg = msg;
         }
         else if ((!entry_ptr->deserialized) || (entry_ptr->serialized) || (!entry_ptr->destroyed)) {
 
             pass = false;
-            HDsnprintf(msg, (size_t)128, "Unexpected entry history 1.");
+            snprintf(msg, (size_t)128, "Unexpected entry history 1.");
             failure_mssg = msg;
         }
     }
@@ -13265,7 +13258,7 @@ check_evictions_enabled(unsigned paged)
             (cache_ptr->evictions_enabled != true)) {
 
             pass = false;
-            HDsnprintf(msg, (size_t)128, "Unexpected cache status 4.");
+            snprintf(msg, (size_t)128, "Unexpected cache status 4.");
             failure_mssg = msg;
         }
     }
@@ -13283,19 +13276,19 @@ check_evictions_enabled(unsigned paged)
         if (result < 0) {
 
             pass = false;
-            HDsnprintf(msg, (size_t)128, "H5C_get_entry_status() reports failure 2.");
+            snprintf(msg, (size_t)128, "H5C_get_entry_status() reports failure 2.");
             failure_mssg = msg;
         }
         else if (in_cache) {
 
             pass = false;
-            HDsnprintf(msg, (size_t)128, "Unexpected status 2.");
+            snprintf(msg, (size_t)128, "Unexpected status 2.");
             failure_mssg = msg;
         }
         else if ((!entry_ptr->deserialized) || (entry_ptr->serialized) || (!entry_ptr->destroyed)) {
 
             pass = false;
-            HDsnprintf(msg, (size_t)128, "Unexpected entry history 2.");
+            snprintf(msg, (size_t)128, "Unexpected entry history 2.");
             failure_mssg = msg;
         }
     }
@@ -13311,7 +13304,7 @@ check_evictions_enabled(unsigned paged)
         if (result != SUCCEED) {
 
             pass = false;
-            HDsnprintf(msg, (size_t)128, "can't disable evictions 1.");
+            snprintf(msg, (size_t)128, "can't disable evictions 1.");
             failure_mssg = msg;
         }
     }
@@ -13328,7 +13321,7 @@ check_evictions_enabled(unsigned paged)
             (cache_ptr->evictions_enabled != false)) {
 
             pass = false;
-            HDsnprintf(msg, (size_t)128, "Unexpected cache status 5.");
+            snprintf(msg, (size_t)128, "Unexpected cache status 5.");
             failure_mssg = msg;
         }
     }
@@ -13355,7 +13348,7 @@ check_evictions_enabled(unsigned paged)
             (cache_ptr->evictions_enabled != false)) {
 
             pass = false;
-            HDsnprintf(msg, (size_t)128, "Unexpected cache status 6.");
+            snprintf(msg, (size_t)128, "Unexpected cache status 6.");
             failure_mssg = msg;
         }
     }
@@ -13381,7 +13374,7 @@ check_evictions_enabled(unsigned paged)
             (cache_ptr->evictions_enabled != false)) {
 
             pass = false;
-            HDsnprintf(msg, (size_t)128, "Unexpected cache status 7.");
+            snprintf(msg, (size_t)128, "Unexpected cache status 7.");
             failure_mssg = msg;
         }
     }
@@ -13397,7 +13390,7 @@ check_evictions_enabled(unsigned paged)
         if (result != SUCCEED) {
 
             pass = false;
-            HDsnprintf(msg, (size_t)128, "can't enable evictions 1.");
+            snprintf(msg, (size_t)128, "can't enable evictions 1.");
             failure_mssg = msg;
         }
     }
@@ -13424,7 +13417,7 @@ check_evictions_enabled(unsigned paged)
             (cache_ptr->evictions_enabled != true)) {
 
             pass = false;
-            HDsnprintf(msg, (size_t)128, "Unexpected cache status 8.");
+            snprintf(msg, (size_t)128, "Unexpected cache status 8.");
             failure_mssg = msg;
         }
     }
@@ -13454,7 +13447,7 @@ check_evictions_enabled(unsigned paged)
             (cache_ptr->evictions_enabled != true)) {
 
             pass = false;
-            HDsnprintf(msg, (size_t)128, "Unexpected cache status 9.");
+            snprintf(msg, (size_t)128, "Unexpected cache status 9.");
             failure_mssg = msg;
         }
     }
@@ -13472,19 +13465,19 @@ check_evictions_enabled(unsigned paged)
         if (result < 0) {
 
             pass = false;
-            HDsnprintf(msg, (size_t)128, "H5C_get_entry_status() reports failure 3.");
+            snprintf(msg, (size_t)128, "H5C_get_entry_status() reports failure 3.");
             failure_mssg = msg;
         }
         else if (in_cache) {
 
             pass = false;
-            HDsnprintf(msg, (size_t)128, "Unexpected status 3.");
+            snprintf(msg, (size_t)128, "Unexpected status 3.");
             failure_mssg = msg;
         }
         else if ((!entry_ptr->deserialized) || (entry_ptr->serialized) || (!entry_ptr->destroyed)) {
 
             pass = false;
-            HDsnprintf(msg, (size_t)128, "Unexpected entry history 3.");
+            snprintf(msg, (size_t)128, "Unexpected entry history 3.");
             failure_mssg = msg;
         }
     }
@@ -13502,19 +13495,19 @@ check_evictions_enabled(unsigned paged)
         if (result < 0) {
 
             pass = false;
-            HDsnprintf(msg, (size_t)128, "H5C_get_entry_status() reports failure 4.");
+            snprintf(msg, (size_t)128, "H5C_get_entry_status() reports failure 4.");
             failure_mssg = msg;
         }
         else if (in_cache) {
 
             pass = false;
-            HDsnprintf(msg, (size_t)128, "Unexpected status 4.");
+            snprintf(msg, (size_t)128, "Unexpected status 4.");
             failure_mssg = msg;
         }
         else if ((!entry_ptr->deserialized) || (entry_ptr->serialized) || (!entry_ptr->destroyed)) {
 
             pass = false;
-            HDsnprintf(msg, (size_t)128, "Unexpected entry history 4.");
+            snprintf(msg, (size_t)128, "Unexpected entry history 4.");
             failure_mssg = msg;
         }
     }
@@ -13530,7 +13523,7 @@ check_evictions_enabled(unsigned paged)
         if (result != SUCCEED) {
 
             pass = false;
-            HDsnprintf(msg, (size_t)128, "can't disable evictions 2.");
+            snprintf(msg, (size_t)128, "can't disable evictions 2.");
             failure_mssg = msg;
         }
     }
@@ -13559,7 +13552,7 @@ check_evictions_enabled(unsigned paged)
             (cache_ptr->evictions_enabled != false)) {
 
             pass = false;
-            HDsnprintf(msg, (size_t)128, "Unexpected cache status 10.");
+            snprintf(msg, (size_t)128, "Unexpected cache status 10.");
             failure_mssg = msg;
         }
     }
@@ -13575,7 +13568,7 @@ check_evictions_enabled(unsigned paged)
         if (result != SUCCEED) {
 
             pass = false;
-            HDsnprintf(msg, (size_t)128, "can't enable evictions 2.");
+            snprintf(msg, (size_t)128, "can't enable evictions 2.");
             failure_mssg = msg;
         }
     }
@@ -13601,7 +13594,7 @@ check_evictions_enabled(unsigned paged)
             (cache_ptr->evictions_enabled != true)) {
 
             pass = false;
-            HDsnprintf(msg, (size_t)128, "Unexpected cache status 11.");
+            snprintf(msg, (size_t)128, "Unexpected cache status 11.");
             failure_mssg = msg;
         }
     }
@@ -13619,19 +13612,19 @@ check_evictions_enabled(unsigned paged)
         if (result < 0) {
 
             pass = false;
-            HDsnprintf(msg, (size_t)128, "H5C_get_entry_status() reports failure 5.");
+            snprintf(msg, (size_t)128, "H5C_get_entry_status() reports failure 5.");
             failure_mssg = msg;
         }
         else if (in_cache) {
 
             pass = false;
-            HDsnprintf(msg, (size_t)128, "Unexpected status 5.");
+            snprintf(msg, (size_t)128, "Unexpected status 5.");
             failure_mssg = msg;
         }
         else if ((!entry_ptr->deserialized) || (entry_ptr->serialized) || (!entry_ptr->destroyed)) {
 
             pass = false;
-            HDsnprintf(msg, (size_t)128, "Unexpected entry history 5.");
+            snprintf(msg, (size_t)128, "Unexpected entry history 5.");
             failure_mssg = msg;
         }
     }
@@ -13647,7 +13640,7 @@ check_evictions_enabled(unsigned paged)
         if (result != SUCCEED) {
 
             pass = false;
-            HDsnprintf(msg, (size_t)128, "can't disable evictions 3.");
+            snprintf(msg, (size_t)128, "can't disable evictions 3.");
             failure_mssg = msg;
         }
     }
@@ -33863,7 +33856,7 @@ main(void)
     printf("=========================================\n");
 
     if (!h5_using_default_driver(NULL)) {
-        HDputs(" -- SKIPPED for incompatible VFD --");
+        puts(" -- SKIPPED for incompatible VFD --");
         exit(EXIT_SUCCESS);
     }
 

--- a/test/cache_api.c
+++ b/test/cache_api.c
@@ -1050,7 +1050,7 @@ mdc_api_call_smoke_check(int express_test, unsigned paged, hid_t fcpl_id)
             /* create the dataset */
             if (pass) {
 
-                HDsnprintf(dset_name, sizeof(dset_name), "/dset%03d", i);
+                snprintf(dset_name, sizeof(dset_name), "/dset%03d", i);
                 dataset_ids[i] = H5Dcreate2(file_id, dset_name, H5T_STD_I32BE, dataspace_id, H5P_DEFAULT,
                                             properties, H5P_DEFAULT);
 
@@ -1750,7 +1750,7 @@ check_fapl_mdc_api_errs(void)
         if (result >= 0) {
 
             pass = false;
-            HDsnprintf(msg, (size_t)128, "H5Pset_mdc_config() accepted invalid_configs[%d].", i);
+            snprintf(msg, (size_t)128, "H5Pset_mdc_config() accepted invalid_configs[%d].", i);
             failure_mssg = msg;
         }
         i++;
@@ -1979,7 +1979,7 @@ check_file_mdc_api_errs(unsigned paged, hid_t fcpl_id)
         if (result >= 0) {
 
             pass = false;
-            HDsnprintf(msg, (size_t)128, "H5Fset_mdc_config() accepted invalid_configs[%d].", i);
+            snprintf(msg, (size_t)128, "H5Fset_mdc_config() accepted invalid_configs[%d].", i);
             failure_mssg = msg;
         }
         i++;

--- a/test/cache_common.c
+++ b/test/cache_common.c
@@ -2261,15 +2261,15 @@ verify_entry_status(H5C_t *cache_ptr, int tag, int num_entries, struct expected_
         if ((!expected[i].in_cache) && ((expected[i].is_protected) || (expected[i].is_pinned))) {
 
             pass = false;
-            HDsnprintf(tmp_msg_buf, sizeof(tmp_msg_buf), "%d: Contradictory data in expected[%d].\n", tag, i);
+            snprintf(tmp_msg_buf, sizeof(tmp_msg_buf), "%d: Contradictory data in expected[%d].\n", tag, i);
             failure_mssg = tmp_msg_buf;
         }
 
         if ((!expected[i].in_cache) && (expected[i].is_dirty) && (!entry_ptr->expunged)) {
 
             pass = false;
-            HDsnprintf(tmp_msg_buf, sizeof(tmp_msg_buf),
-                       "%d: expected[%d] specs non-expunged, dirty, non-resident.\n", tag, i);
+            snprintf(tmp_msg_buf, sizeof(tmp_msg_buf),
+                     "%d: expected[%d] specs non-expunged, dirty, non-resident.\n", tag, i);
             failure_mssg = tmp_msg_buf;
         }
 
@@ -2280,10 +2280,10 @@ verify_entry_status(H5C_t *cache_ptr, int tag, int num_entries, struct expected_
             if (in_cache != expected[i].in_cache) {
 
                 pass = false;
-                HDsnprintf(tmp_msg_buf, sizeof(tmp_msg_buf),
-                           "%d entry (%d, %d) in cache actual/expected = %d/%d.\n", tag,
-                           (int)expected[i].entry_type, (int)expected[i].entry_index, (int)in_cache,
-                           (int)expected[i].in_cache);
+                snprintf(tmp_msg_buf, sizeof(tmp_msg_buf),
+                         "%d entry (%d, %d) in cache actual/expected = %d/%d.\n", tag,
+                         (int)expected[i].entry_type, (int)expected[i].entry_index, (int)in_cache,
+                         (int)expected[i].in_cache);
                 failure_mssg = tmp_msg_buf;
             }
         }
@@ -2293,10 +2293,10 @@ verify_entry_status(H5C_t *cache_ptr, int tag, int num_entries, struct expected_
             if (entry_ptr->size != expected[i].size) {
 
                 pass = false;
-                HDsnprintf(tmp_msg_buf, sizeof(tmp_msg_buf),
-                           "%d entry (%d, %d) size actual/expected = %ld/%ld.\n", tag,
-                           (int)expected[i].entry_type, (int)expected[i].entry_index, (long)(entry_ptr->size),
-                           (long)expected[i].size);
+                snprintf(tmp_msg_buf, sizeof(tmp_msg_buf),
+                         "%d entry (%d, %d) size actual/expected = %ld/%ld.\n", tag,
+                         (int)expected[i].entry_type, (int)expected[i].entry_index, (long)(entry_ptr->size),
+                         (long)expected[i].size);
                 failure_mssg = tmp_msg_buf;
             }
         }
@@ -2306,10 +2306,10 @@ verify_entry_status(H5C_t *cache_ptr, int tag, int num_entries, struct expected_
             if (entry_ptr->header.size != expected[i].size) {
 
                 pass = false;
-                HDsnprintf(tmp_msg_buf, sizeof(tmp_msg_buf),
-                           "%d entry (%d, %d) header size actual/expected = %ld/%ld.\n", tag,
-                           (int)expected[i].entry_type, (int)expected[i].entry_index,
-                           (long)(entry_ptr->header.size), (long)expected[i].size);
+                snprintf(tmp_msg_buf, sizeof(tmp_msg_buf),
+                         "%d entry (%d, %d) header size actual/expected = %ld/%ld.\n", tag,
+                         (int)expected[i].entry_type, (int)expected[i].entry_index,
+                         (long)(entry_ptr->header.size), (long)expected[i].size);
                 failure_mssg = tmp_msg_buf;
             }
         }
@@ -2319,10 +2319,10 @@ verify_entry_status(H5C_t *cache_ptr, int tag, int num_entries, struct expected_
             if (entry_ptr->at_main_addr != expected[i].at_main_addr) {
 
                 pass = false;
-                HDsnprintf(tmp_msg_buf, sizeof(tmp_msg_buf),
-                           "%d entry (%d, %d) at main addr actual/expected = %d/%d.\n", tag,
-                           (int)expected[i].entry_type, (int)expected[i].entry_index,
-                           (int)(entry_ptr->at_main_addr), (int)expected[i].at_main_addr);
+                snprintf(tmp_msg_buf, sizeof(tmp_msg_buf),
+                         "%d entry (%d, %d) at main addr actual/expected = %d/%d.\n", tag,
+                         (int)expected[i].entry_type, (int)expected[i].entry_index,
+                         (int)(entry_ptr->at_main_addr), (int)expected[i].at_main_addr);
                 failure_mssg = tmp_msg_buf;
             }
         }
@@ -2332,10 +2332,10 @@ verify_entry_status(H5C_t *cache_ptr, int tag, int num_entries, struct expected_
             if (entry_ptr->is_dirty != expected[i].is_dirty) {
 
                 pass = false;
-                HDsnprintf(tmp_msg_buf, sizeof(tmp_msg_buf),
-                           "%d entry (%d, %d) is_dirty actual/expected = %d/%d.\n", tag,
-                           (int)expected[i].entry_type, (int)expected[i].entry_index,
-                           (int)(entry_ptr->is_dirty), (int)expected[i].is_dirty);
+                snprintf(tmp_msg_buf, sizeof(tmp_msg_buf),
+                         "%d entry (%d, %d) is_dirty actual/expected = %d/%d.\n", tag,
+                         (int)expected[i].entry_type, (int)expected[i].entry_index,
+                         (int)(entry_ptr->is_dirty), (int)expected[i].is_dirty);
                 failure_mssg = tmp_msg_buf;
             }
         }
@@ -2345,10 +2345,10 @@ verify_entry_status(H5C_t *cache_ptr, int tag, int num_entries, struct expected_
             if (entry_ptr->header.is_dirty != expected[i].is_dirty) {
 
                 pass = false;
-                HDsnprintf(tmp_msg_buf, sizeof(tmp_msg_buf),
-                           "%d entry (%d, %d) header is_dirty actual/expected = %d/%d.\n", tag,
-                           (int)expected[i].entry_type, (int)expected[i].entry_index,
-                           (int)(entry_ptr->header.is_dirty), (int)expected[i].is_dirty);
+                snprintf(tmp_msg_buf, sizeof(tmp_msg_buf),
+                         "%d entry (%d, %d) header is_dirty actual/expected = %d/%d.\n", tag,
+                         (int)expected[i].entry_type, (int)expected[i].entry_index,
+                         (int)(entry_ptr->header.is_dirty), (int)expected[i].is_dirty);
                 failure_mssg = tmp_msg_buf;
             }
         }
@@ -2358,10 +2358,10 @@ verify_entry_status(H5C_t *cache_ptr, int tag, int num_entries, struct expected_
             if (entry_ptr->is_protected != expected[i].is_protected) {
 
                 pass = false;
-                HDsnprintf(tmp_msg_buf, sizeof(tmp_msg_buf),
-                           "%d entry (%d, %d) is_protected actual/expected = %d/%d.\n", tag,
-                           (int)expected[i].entry_type, (int)expected[i].entry_index,
-                           (int)(entry_ptr->is_protected), (int)expected[i].is_protected);
+                snprintf(tmp_msg_buf, sizeof(tmp_msg_buf),
+                         "%d entry (%d, %d) is_protected actual/expected = %d/%d.\n", tag,
+                         (int)expected[i].entry_type, (int)expected[i].entry_index,
+                         (int)(entry_ptr->is_protected), (int)expected[i].is_protected);
                 failure_mssg = tmp_msg_buf;
             }
         }
@@ -2371,10 +2371,10 @@ verify_entry_status(H5C_t *cache_ptr, int tag, int num_entries, struct expected_
             if (entry_ptr->header.is_protected != expected[i].is_protected) {
 
                 pass = false;
-                HDsnprintf(tmp_msg_buf, sizeof(tmp_msg_buf),
-                           "%d entry (%d, %d) header is_protected actual/expected = %d/%d.\n", tag,
-                           (int)expected[i].entry_type, (int)expected[i].entry_index,
-                           (int)(entry_ptr->header.is_protected), (int)expected[i].is_protected);
+                snprintf(tmp_msg_buf, sizeof(tmp_msg_buf),
+                         "%d entry (%d, %d) header is_protected actual/expected = %d/%d.\n", tag,
+                         (int)expected[i].entry_type, (int)expected[i].entry_index,
+                         (int)(entry_ptr->header.is_protected), (int)expected[i].is_protected);
                 failure_mssg = tmp_msg_buf;
             }
         }
@@ -2384,10 +2384,10 @@ verify_entry_status(H5C_t *cache_ptr, int tag, int num_entries, struct expected_
             if (entry_ptr->is_pinned != expected[i].is_pinned) {
 
                 pass = false;
-                HDsnprintf(tmp_msg_buf, sizeof(tmp_msg_buf),
-                           "%d entry (%d, %d) is_pinned actual/expected = %d/%d.\n", tag,
-                           (int)expected[i].entry_type, (int)expected[i].entry_index,
-                           (int)(entry_ptr->is_pinned), (int)expected[i].is_pinned);
+                snprintf(tmp_msg_buf, sizeof(tmp_msg_buf),
+                         "%d entry (%d, %d) is_pinned actual/expected = %d/%d.\n", tag,
+                         (int)expected[i].entry_type, (int)expected[i].entry_index,
+                         (int)(entry_ptr->is_pinned), (int)expected[i].is_pinned);
                 failure_mssg = tmp_msg_buf;
             }
         }
@@ -2397,10 +2397,10 @@ verify_entry_status(H5C_t *cache_ptr, int tag, int num_entries, struct expected_
             if (entry_ptr->is_corked != expected[i].is_corked) {
 
                 pass = false;
-                HDsnprintf(tmp_msg_buf, sizeof(tmp_msg_buf),
-                           "%d entry (%d, %d) is_corked actual/expected = %d/%d.\n", tag,
-                           (int)expected[i].entry_type, (int)expected[i].entry_index,
-                           (int)(entry_ptr->is_corked), (int)expected[i].is_corked);
+                snprintf(tmp_msg_buf, sizeof(tmp_msg_buf),
+                         "%d entry (%d, %d) is_corked actual/expected = %d/%d.\n", tag,
+                         (int)expected[i].entry_type, (int)expected[i].entry_index,
+                         (int)(entry_ptr->is_corked), (int)expected[i].is_corked);
                 failure_mssg = tmp_msg_buf;
             }
         }
@@ -2410,10 +2410,10 @@ verify_entry_status(H5C_t *cache_ptr, int tag, int num_entries, struct expected_
             if (entry_ptr->header.is_pinned != expected[i].is_pinned) {
 
                 pass = false;
-                HDsnprintf(tmp_msg_buf, sizeof(tmp_msg_buf),
-                           "%d entry (%d, %d) header is_pinned actual/expected = %d/%d.\n", tag,
-                           (int)expected[i].entry_type, (int)expected[i].entry_index,
-                           (int)(entry_ptr->header.is_pinned), (int)expected[i].is_pinned);
+                snprintf(tmp_msg_buf, sizeof(tmp_msg_buf),
+                         "%d entry (%d, %d) header is_pinned actual/expected = %d/%d.\n", tag,
+                         (int)expected[i].entry_type, (int)expected[i].entry_index,
+                         (int)(entry_ptr->header.is_pinned), (int)expected[i].is_pinned);
                 failure_mssg = tmp_msg_buf;
             }
         }
@@ -2425,12 +2425,12 @@ verify_entry_status(H5C_t *cache_ptr, int tag, int num_entries, struct expected_
                 (entry_ptr->destroyed != expected[i].destroyed)) {
 
                 pass = false;
-                HDsnprintf(tmp_msg_buf, sizeof(tmp_msg_buf),
-                           "%d entry (%d,%d) deserialized = %d(%d), serialized = %d(%d), dest = %d(%d)\n",
-                           tag, (int)expected[i].entry_type, (int)expected[i].entry_index,
-                           (int)(entry_ptr->deserialized), (int)(expected[i].deserialized),
-                           (int)(entry_ptr->serialized), (int)(expected[i].serialized),
-                           (int)(entry_ptr->destroyed), (int)(expected[i].destroyed));
+                snprintf(tmp_msg_buf, sizeof(tmp_msg_buf),
+                         "%d entry (%d,%d) deserialized = %d(%d), serialized = %d(%d), dest = %d(%d)\n", tag,
+                         (int)expected[i].entry_type, (int)expected[i].entry_index,
+                         (int)(entry_ptr->deserialized), (int)(expected[i].deserialized),
+                         (int)(entry_ptr->serialized), (int)(expected[i].serialized),
+                         (int)(entry_ptr->destroyed), (int)(expected[i].destroyed));
                 failure_mssg = tmp_msg_buf;
             }
         }
@@ -2441,20 +2441,20 @@ verify_entry_status(H5C_t *cache_ptr, int tag, int num_entries, struct expected_
         if (pass) {
             if (entry_ptr->flush_dep_npar != expected[i].flush_dep_npar) {
                 pass = false;
-                HDsnprintf(tmp_msg_buf, sizeof(tmp_msg_buf),
-                           "%d entry (%d, %d) flush_dep_npar actual/expected = %u/%u.\n", tag,
-                           expected[i].entry_type, expected[i].entry_index, entry_ptr->flush_dep_npar,
-                           expected[i].flush_dep_npar);
+                snprintf(tmp_msg_buf, sizeof(tmp_msg_buf),
+                         "%d entry (%d, %d) flush_dep_npar actual/expected = %u/%u.\n", tag,
+                         expected[i].entry_type, expected[i].entry_index, entry_ptr->flush_dep_npar,
+                         expected[i].flush_dep_npar);
                 failure_mssg = tmp_msg_buf;
             } /* end if */
         }     /* end if */
         if ((pass) && (in_cache)) {
             if (entry_ptr->header.flush_dep_nparents != expected[i].flush_dep_npar) {
                 pass = false;
-                HDsnprintf(tmp_msg_buf, sizeof(tmp_msg_buf),
-                           "%d entry (%d, %d) header flush_dep_nparents actual/expected = %u/%u.\n", tag,
-                           expected[i].entry_type, expected[i].entry_index,
-                           entry_ptr->header.flush_dep_nparents, expected[i].flush_dep_npar);
+                snprintf(tmp_msg_buf, sizeof(tmp_msg_buf),
+                         "%d entry (%d, %d) header flush_dep_nparents actual/expected = %u/%u.\n", tag,
+                         expected[i].entry_type, expected[i].entry_index,
+                         entry_ptr->header.flush_dep_nparents, expected[i].flush_dep_npar);
                 failure_mssg = tmp_msg_buf;
             } /* end if */
         }     /* end if */
@@ -2465,10 +2465,10 @@ verify_entry_status(H5C_t *cache_ptr, int tag, int num_entries, struct expected_
             for (u = 0; u < entry_ptr->flush_dep_npar; u++) {
                 if (entry_ptr->flush_dep_par_type[u] != expected[i].flush_dep_par_type[u]) {
                     pass = false;
-                    HDsnprintf(tmp_msg_buf, sizeof(tmp_msg_buf),
-                               "%d entry (%d, %d) flush_dep_par_type[%u] actual/expected = %d/%d.\n", tag,
-                               expected[i].entry_type, expected[i].entry_index, u,
-                               entry_ptr->flush_dep_par_type[u], expected[i].flush_dep_par_type[u]);
+                    snprintf(tmp_msg_buf, sizeof(tmp_msg_buf),
+                             "%d entry (%d, %d) flush_dep_par_type[%u] actual/expected = %d/%d.\n", tag,
+                             expected[i].entry_type, expected[i].entry_index, u,
+                             entry_ptr->flush_dep_par_type[u], expected[i].flush_dep_par_type[u]);
                     failure_mssg = tmp_msg_buf;
                 } /* end if */
             }     /* end for */
@@ -2477,10 +2477,10 @@ verify_entry_status(H5C_t *cache_ptr, int tag, int num_entries, struct expected_
             for (u = 0; u < entry_ptr->flush_dep_npar; u++) {
                 if (entry_ptr->flush_dep_par_idx[u] != expected[i].flush_dep_par_idx[u]) {
                     pass = false;
-                    HDsnprintf(tmp_msg_buf, sizeof(tmp_msg_buf),
-                               "%d entry (%d, %d) flush_dep_par_idx[%u] actual/expected = %d/%d.\n", tag,
-                               expected[i].entry_type, expected[i].entry_index, u,
-                               entry_ptr->flush_dep_par_idx[u], expected[i].flush_dep_par_idx[u]);
+                    snprintf(tmp_msg_buf, sizeof(tmp_msg_buf),
+                             "%d entry (%d, %d) flush_dep_par_idx[%u] actual/expected = %d/%d.\n", tag,
+                             expected[i].entry_type, expected[i].entry_index, u,
+                             entry_ptr->flush_dep_par_idx[u], expected[i].flush_dep_par_idx[u]);
                     failure_mssg = tmp_msg_buf;
                 } /* end if */
             }     /* end for */
@@ -2490,40 +2490,40 @@ verify_entry_status(H5C_t *cache_ptr, int tag, int num_entries, struct expected_
         if (pass) {
             if (entry_ptr->flush_dep_nchd != expected[i].flush_dep_nchd) {
                 pass = false;
-                HDsnprintf(tmp_msg_buf, sizeof(tmp_msg_buf),
-                           "%d entry (%d, %d) flush_dep_nchd actual/expected = %u/%u.\n", tag,
-                           expected[i].entry_type, expected[i].entry_index, entry_ptr->flush_dep_nchd,
-                           expected[i].flush_dep_nchd);
+                snprintf(tmp_msg_buf, sizeof(tmp_msg_buf),
+                         "%d entry (%d, %d) flush_dep_nchd actual/expected = %u/%u.\n", tag,
+                         expected[i].entry_type, expected[i].entry_index, entry_ptr->flush_dep_nchd,
+                         expected[i].flush_dep_nchd);
                 failure_mssg = tmp_msg_buf;
             } /* end if */
         }     /* end if */
         if ((pass) && (in_cache)) {
             if (entry_ptr->header.flush_dep_nchildren != expected[i].flush_dep_nchd) {
                 pass = false;
-                HDsnprintf(tmp_msg_buf, sizeof(tmp_msg_buf),
-                           "%d entry (%d, %d) header flush_dep_nchildren actual/expected = %u/%u.\n", tag,
-                           expected[i].entry_type, expected[i].entry_index,
-                           entry_ptr->header.flush_dep_nchildren, expected[i].flush_dep_nchd);
+                snprintf(tmp_msg_buf, sizeof(tmp_msg_buf),
+                         "%d entry (%d, %d) header flush_dep_nchildren actual/expected = %u/%u.\n", tag,
+                         expected[i].entry_type, expected[i].entry_index,
+                         entry_ptr->header.flush_dep_nchildren, expected[i].flush_dep_nchd);
                 failure_mssg = tmp_msg_buf;
             } /* end if */
         }     /* end if */
         if (pass) {
             if (entry_ptr->flush_dep_ndirty_chd != expected[i].flush_dep_ndirty_chd) {
                 pass = false;
-                HDsnprintf(tmp_msg_buf, sizeof(tmp_msg_buf),
-                           "%d entry (%d, %d) flush_dep_ndirty_chd actual/expected = %u/%u.\n", tag,
-                           expected[i].entry_type, expected[i].entry_index, entry_ptr->flush_dep_ndirty_chd,
-                           expected[i].flush_dep_ndirty_chd);
+                snprintf(tmp_msg_buf, sizeof(tmp_msg_buf),
+                         "%d entry (%d, %d) flush_dep_ndirty_chd actual/expected = %u/%u.\n", tag,
+                         expected[i].entry_type, expected[i].entry_index, entry_ptr->flush_dep_ndirty_chd,
+                         expected[i].flush_dep_ndirty_chd);
                 failure_mssg = tmp_msg_buf;
             } /* end if */
         }     /* end if */
         if ((pass) && (in_cache)) {
             if (entry_ptr->header.flush_dep_ndirty_children != expected[i].flush_dep_ndirty_chd) {
                 pass = false;
-                HDsnprintf(tmp_msg_buf, sizeof(tmp_msg_buf),
-                           "%d entry (%d, %d) header flush_dep_ndirty_children actual/expected = %u/%u.\n",
-                           tag, expected[i].entry_type, expected[i].entry_index,
-                           entry_ptr->header.flush_dep_ndirty_children, expected[i].flush_dep_ndirty_chd);
+                snprintf(tmp_msg_buf, sizeof(tmp_msg_buf),
+                         "%d entry (%d, %d) header flush_dep_ndirty_children actual/expected = %u/%u.\n", tag,
+                         expected[i].entry_type, expected[i].entry_index,
+                         entry_ptr->header.flush_dep_ndirty_children, expected[i].flush_dep_ndirty_chd);
                 failure_mssg = tmp_msg_buf;
             } /* end if */
         }     /* end if */
@@ -2532,10 +2532,10 @@ verify_entry_status(H5C_t *cache_ptr, int tag, int num_entries, struct expected_
         if (pass) {
             if (expected[i].flush_order >= 0 && entry_ptr->flush_order != (unsigned)expected[i].flush_order) {
                 pass = false;
-                HDsnprintf(tmp_msg_buf, sizeof(tmp_msg_buf),
-                           "%d entry (%d, %d) flush_order actual/expected = %u/%d.\n", tag,
-                           expected[i].entry_type, expected[i].entry_index, entry_ptr->flush_order,
-                           expected[i].flush_order);
+                snprintf(tmp_msg_buf, sizeof(tmp_msg_buf),
+                         "%d entry (%d, %d) flush_order actual/expected = %u/%d.\n", tag,
+                         expected[i].entry_type, expected[i].entry_index, entry_ptr->flush_order,
+                         expected[i].flush_order);
                 failure_mssg = tmp_msg_buf;
             } /* end if */
         }     /* end if */
@@ -5073,7 +5073,7 @@ validate_mdc_config(hid_t file_id, H5AC_cache_config_t *ext_config_ptr, bool com
         if (file_ptr == NULL) {
 
             pass = false;
-            HDsnprintf(tmp_msg_buf, sizeof(tmp_msg_buf), "Can't get file_ptr #%d.", test_num);
+            snprintf(tmp_msg_buf, sizeof(tmp_msg_buf), "Can't get file_ptr #%d.", test_num);
             failure_mssg = tmp_msg_buf;
         }
         else {
@@ -5088,7 +5088,7 @@ validate_mdc_config(hid_t file_id, H5AC_cache_config_t *ext_config_ptr, bool com
         if (cache_ptr == NULL || cache_ptr->resize_ctl.version != H5C__CURR_AUTO_SIZE_CTL_VER) {
 
             pass = false;
-            HDsnprintf(tmp_msg_buf, sizeof(tmp_msg_buf), "Can't access cache resize_ctl #%d.", test_num);
+            snprintf(tmp_msg_buf, sizeof(tmp_msg_buf), "Can't access cache resize_ctl #%d.", test_num);
             failure_mssg = tmp_msg_buf;
         }
     }
@@ -5099,7 +5099,7 @@ validate_mdc_config(hid_t file_id, H5AC_cache_config_t *ext_config_ptr, bool com
         if (!resize_configs_are_equal(&int_config, &cache_ptr->resize_ctl, compare_init)) {
 
             pass = false;
-            HDsnprintf(tmp_msg_buf, sizeof(tmp_msg_buf), "Unexpected internal config #%d.", test_num);
+            snprintf(tmp_msg_buf, sizeof(tmp_msg_buf), "Unexpected internal config #%d.", test_num);
             failure_mssg = tmp_msg_buf;
         }
     }
@@ -5112,7 +5112,7 @@ validate_mdc_config(hid_t file_id, H5AC_cache_config_t *ext_config_ptr, bool com
         if (H5Fget_mdc_config(file_id, &scratch) < 0) {
 
             pass = false;
-            HDsnprintf(tmp_msg_buf, sizeof(tmp_msg_buf), "H5Fget_mdc_config() failed #%d.", test_num);
+            snprintf(tmp_msg_buf, sizeof(tmp_msg_buf), "H5Fget_mdc_config() failed #%d.", test_num);
             failure_mssg = tmp_msg_buf;
         }
     }
@@ -5133,7 +5133,7 @@ validate_mdc_config(hid_t file_id, H5AC_cache_config_t *ext_config_ptr, bool com
         if (!CACHE_CONFIGS_EQUAL((*ext_config_ptr), scratch, false, compare_init)) {
 
             pass = false;
-            HDsnprintf(tmp_msg_buf, sizeof(tmp_msg_buf), "Unexpected external config #%d.", test_num);
+            snprintf(tmp_msg_buf, sizeof(tmp_msg_buf), "Unexpected external config #%d.", test_num);
             failure_mssg = tmp_msg_buf;
         }
     }

--- a/test/cache_image.c
+++ b/test/cache_image.c
@@ -157,7 +157,7 @@ create_datasets(hid_t file_id, int min_dset, int max_dset)
             /* create the dataset */
             if (pass) {
 
-                HDsnprintf(dset_name, sizeof(dset_name), "/dset%03d", i);
+                snprintf(dset_name, sizeof(dset_name), "/dset%03d", i);
                 dataset_ids[i] = H5Dcreate2(file_id, dset_name, H5T_STD_I32BE, dataspace_id, H5P_DEFAULT,
                                             properties, H5P_DEFAULT);
 
@@ -433,7 +433,7 @@ delete_datasets(hid_t file_id, int min_dset, int max_dset)
         i = min_dset;
 
         while ((pass) && (i <= max_dset)) {
-            HDsnprintf(dset_name, sizeof(dset_name), "/dset%03d", i);
+            snprintf(dset_name, sizeof(dset_name), "/dset%03d", i);
 
             if (H5Ldelete(file_id, dset_name, H5P_DEFAULT) < 0) {
 
@@ -1000,7 +1000,7 @@ verify_datasets(hid_t file_id, int min_dset, int max_dset)
             /* open the dataset */
             if (pass) {
 
-                HDsnprintf(dset_name, sizeof(dset_name), "/dset%03d", i);
+                snprintf(dset_name, sizeof(dset_name), "/dset%03d", i);
                 dataset_ids[i] = H5Dopen2(file_id, dset_name, H5P_DEFAULT);
 
                 if (dataset_ids[i] < 0) {
@@ -1261,7 +1261,7 @@ check_cache_image_ctl_flow_1(bool single_file_vfd)
     /* Check for VFD that is a single file */
     if (!single_file_vfd) {
         SKIPPED();
-        HDputs("    Cache image not supported with the current VFD.");
+        puts("    Cache image not supported with the current VFD.");
         return 0;
     }
 
@@ -1535,7 +1535,7 @@ check_cache_image_ctl_flow_2(bool single_file_vfd)
     /* Check for VFD that is a single file */
     if (!single_file_vfd) {
         SKIPPED();
-        HDputs("    Cache image not supported with the current VFD.");
+        puts("    Cache image not supported with the current VFD.");
         return 0;
     }
 
@@ -1796,7 +1796,7 @@ check_cache_image_ctl_flow_3(bool single_file_vfd)
     /* Check for VFD that is a single file */
     if (!single_file_vfd) {
         SKIPPED();
-        HDputs("    Cache image not supported with the current VFD.");
+        puts("    Cache image not supported with the current VFD.");
         return 0;
     }
 
@@ -2159,7 +2159,7 @@ check_cache_image_ctl_flow_4(bool single_file_vfd)
     /* Check for VFD that is a single file */
     if (!single_file_vfd) {
         SKIPPED();
-        HDputs("    Cache image not supported with the current VFD.");
+        puts("    Cache image not supported with the current VFD.");
         return 0;
     }
 
@@ -2485,7 +2485,7 @@ check_cache_image_ctl_flow_5(bool single_file_vfd)
     /* Check for VFD that is a single file */
     if (!single_file_vfd) {
         SKIPPED();
-        HDputs("    Cache image not supported with the current VFD.");
+        puts("    Cache image not supported with the current VFD.");
         return 0;
     }
 
@@ -2763,7 +2763,7 @@ check_cache_image_ctl_flow_6(bool single_file_vfd)
     /* Check for VFD that is a single file */
     if (!single_file_vfd) {
         SKIPPED();
-        HDputs("    Cache image not supported with the current VFD.");
+        puts("    Cache image not supported with the current VFD.");
         return 0;
     }
 
@@ -3046,7 +3046,7 @@ cache_image_smoke_check_1(bool single_file_vfd)
     /* Check for VFD that is a single file */
     if (!single_file_vfd) {
         SKIPPED();
-        HDputs("    Cache image not supported with the current VFD.");
+        puts("    Cache image not supported with the current VFD.");
         return 0;
     }
 
@@ -3454,7 +3454,7 @@ cache_image_smoke_check_2(bool single_file_vfd)
     /* Check for VFD that is a single file */
     if (!single_file_vfd) {
         SKIPPED();
-        HDputs("    Cache image not supported with the current VFD.");
+        puts("    Cache image not supported with the current VFD.");
         return 0;
     }
 
@@ -3749,7 +3749,7 @@ cache_image_smoke_check_3(bool single_file_vfd)
     /* Check for VFD that is a single file */
     if (!single_file_vfd) {
         SKIPPED();
-        HDputs("    Cache image not supported with the current VFD.");
+        puts("    Cache image not supported with the current VFD.");
         return 0;
     }
 
@@ -4125,7 +4125,7 @@ cache_image_smoke_check_4(bool single_file_vfd)
     /* Check for VFD that is a single file */
     if (!single_file_vfd) {
         SKIPPED();
-        HDputs("    Cache image not supported with the current VFD.");
+        puts("    Cache image not supported with the current VFD.");
         return 0;
     }
 
@@ -4518,7 +4518,7 @@ cache_image_smoke_check_5(bool single_file_vfd)
     /* Check for VFD that is a single file */
     if (!single_file_vfd) {
         SKIPPED();
-        HDputs("    Cache image not supported with the current VFD.");
+        puts("    Cache image not supported with the current VFD.");
         return 0;
     }
 
@@ -4572,7 +4572,7 @@ cache_image_smoke_check_5(bool single_file_vfd)
     /* 2) Create a process specific group. */
     if (pass) {
 
-        HDsnprintf(process_group_name, sizeof(process_group_name), "/process_%d", min_group);
+        snprintf(process_group_name, sizeof(process_group_name), "/process_%d", min_group);
 
         proc_gid = H5Gcreate2(file_id, process_group_name, H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT);
 
@@ -4675,7 +4675,7 @@ cache_image_smoke_check_5(bool single_file_vfd)
         if (pass) {
 
             max_group++;
-            HDsnprintf(process_group_name, sizeof(process_group_name), "/process_%d", max_group);
+            snprintf(process_group_name, sizeof(process_group_name), "/process_%d", max_group);
 
             proc_gid = H5Gcreate2(file_id, process_group_name, H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT);
 
@@ -4746,7 +4746,7 @@ cache_image_smoke_check_5(bool single_file_vfd)
     /* 11) Validate all the zoos. */
     i = min_group;
     while (pass && i <= max_group) {
-        HDsnprintf(process_group_name, sizeof(process_group_name), "/process_%d", i);
+        snprintf(process_group_name, sizeof(process_group_name), "/process_%d", i);
         validate_zoo(file_id, process_group_name, i++);
     }
 
@@ -4798,7 +4798,7 @@ cache_image_smoke_check_5(bool single_file_vfd)
     i = min_group;
     while ((pass) && (i <= max_group)) {
 
-        HDsnprintf(process_group_name, sizeof(process_group_name), "/process_%d", i);
+        snprintf(process_group_name, sizeof(process_group_name), "/process_%d", i);
         validate_zoo(file_id, process_group_name, i++);
     }
 
@@ -4858,7 +4858,7 @@ cache_image_smoke_check_5(bool single_file_vfd)
      */
     i = min_group;
     while ((pass) && (i <= max_group)) {
-        HDsnprintf(process_group_name, sizeof(process_group_name), "/process_%d", i);
+        snprintf(process_group_name, sizeof(process_group_name), "/process_%d", i);
         validate_zoo(file_id, process_group_name, i++);
     }
 
@@ -5011,7 +5011,7 @@ cache_image_smoke_check_6(bool single_file_vfd)
     /* Check for VFD that is a single file */
     if (!single_file_vfd) {
         SKIPPED();
-        HDputs("    Cache image not supported with the current VFD.");
+        puts("    Cache image not supported with the current VFD.");
         return 0;
     }
 
@@ -5400,7 +5400,7 @@ cache_image_api_error_check_1(bool single_file_vfd)
     /* Check for VFD that is a single file */
     if (!single_file_vfd) {
         SKIPPED();
-        HDputs("    Cache image not supported with the current VFD.");
+        puts("    Cache image not supported with the current VFD.");
         return 0;
     }
 
@@ -5765,7 +5765,7 @@ cache_image_api_error_check_2(bool single_file_vfd)
     /* Check for VFD that is a single file */
     if (!single_file_vfd) {
         SKIPPED();
-        HDputs("    Cache image not supported with the current VFD.");
+        puts("    Cache image not supported with the current VFD.");
         return 0;
     }
 
@@ -6163,7 +6163,7 @@ cache_image_api_error_check_3(bool single_file_vfd)
     /* Check for VFD that is a single file */
     if (!single_file_vfd) {
         SKIPPED();
-        HDputs("    Cache image not supported with the current VFD.");
+        puts("    Cache image not supported with the current VFD.");
         return 0;
     }
 
@@ -6443,7 +6443,7 @@ cache_image_api_error_check_4(bool single_file_vfd)
     /* Check for VFD that is a single file */
     if (!single_file_vfd) {
         SKIPPED();
-        HDputs("    Cache image not supported with the current VFD.");
+        puts("    Cache image not supported with the current VFD.");
         return 0;
     }
 
@@ -7011,7 +7011,7 @@ get_free_sections_test(bool single_file_vfd)
     /* Check for VFD that is a single file */
     if (!single_file_vfd) {
         SKIPPED();
-        HDputs("    Cache image not supported with the current VFD.");
+        puts("    Cache image not supported with the current VFD.");
         return 0;
     }
 
@@ -7450,14 +7450,14 @@ evict_on_close_test(bool H5_ATTR_PARALLEL_UNUSED single_file_vfd)
 
 #ifdef H5_HAVE_PARALLEL
     SKIPPED();
-    HDputs("    EoC not supported in the parallel library.");
+    puts("    EoC not supported in the parallel library.");
     return 0;
 #else
 
     /* Check for VFD that is a single file */
     if (!single_file_vfd) {
         SKIPPED();
-        HDputs("    Cache image not supported with the current VFD.");
+        puts("    Cache image not supported with the current VFD.");
         return 0;
     }
 

--- a/test/cache_logging.c
+++ b/test/cache_logging.c
@@ -73,7 +73,7 @@ test_logging_api(void)
     size                = 999;
     if (H5Pget_mdc_log_options(fapl, &is_enabled_out, location, &size, &start_on_access_out) < 0)
         TEST_ERROR;
-    if (size != HDstrlen(LOG_LOCATION) + 1)
+    if (size != strlen(LOG_LOCATION) + 1)
         TEST_ERROR;
 
     /* Check to make sure that the property list getter works */
@@ -82,7 +82,7 @@ test_logging_api(void)
     if (H5Pget_mdc_log_options(fapl, &is_enabled_out, location, &size, &start_on_access_out) < 0)
         TEST_ERROR;
     if ((is_enabled != is_enabled_out) || (start_on_access != start_on_access_out) ||
-        HDstrcmp(LOG_LOCATION, location) != 0)
+        strcmp(LOG_LOCATION, location) != 0)
         TEST_ERROR;
 
     /* Create a file */
@@ -110,7 +110,7 @@ test_logging_api(void)
     /* Perform some manipulations */
     for (i = 0; i < N_GROUPS; i++) {
         memset(group_name, 0, sizeof(group_name));
-        HDsnprintf(group_name, sizeof(group_name), "%d", i);
+        snprintf(group_name, sizeof(group_name), "%d", i);
         if ((gid = H5Gcreate2(fid, group_name, H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT)) < 0)
             TEST_ERROR;
         if (H5Gclose(gid) < 0)

--- a/test/cache_tagging.c
+++ b/test/cache_tagging.c
@@ -805,7 +805,7 @@ check_multi_group_creation_tags(void)
 
     for (i = 0; i < MULTIGROUPS; i++) {
 
-        HDsnprintf(gname, sizeof(gname), "%d", i);
+        snprintf(gname, sizeof(gname), "%d", i);
         if ((gid = H5Gcreate2(fid, gname, H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT)) < 0)
             TEST_ERROR;
         if (H5Gclose(gid) < 0)
@@ -827,7 +827,7 @@ check_multi_group_creation_tags(void)
     for (i = 0; i < MULTIGROUPS; i++) {
 
         /* Re-open the group */
-        HDsnprintf(gname, sizeof(gname), "%d", i);
+        snprintf(gname, sizeof(gname), "%d", i);
         if ((gid = H5Gopen2(fid, gname, H5P_DEFAULT)) < 0)
             TEST_ERROR;
 
@@ -951,7 +951,7 @@ check_link_iteration_tags(void)
     /* Create many datasets in root group */
     for (i = 0; i < 500; i++) {
 
-        HDsnprintf(dsetname, sizeof(dsetname), "Dset %d", i);
+        snprintf(dsetname, sizeof(dsetname), "Dset %d", i);
         if ((did = H5Dcreate2(fid, dsetname, H5T_NATIVE_UCHAR, sid, H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT)) <
             0)
             TEST_ERROR;
@@ -1111,7 +1111,7 @@ check_dense_attribute_tags(void)
 
     for (i = 0; i < 50; i++) {
 
-        HDsnprintf(attrname, sizeof(attrname), "attr %d", i);
+        snprintf(attrname, sizeof(attrname), "attr %d", i);
         if ((aid = H5Acreate2(did, attrname, H5T_NATIVE_UINT, sid, H5P_DEFAULT, H5P_DEFAULT)) < 0)
             TEST_ERROR;
         if (H5Awrite(aid, H5T_NATIVE_UINT, &i) < 0)
@@ -4471,7 +4471,7 @@ main(void)
 
     /* Only run with sec2/default driver */
     if (!h5_using_default_driver(NULL)) {
-        HDputs(" -- SKIPPED for incompatible VFD --");
+        puts(" -- SKIPPED for incompatible VFD --");
         exit(EXIT_SUCCESS);
     }
 

--- a/test/chunk_info.c
+++ b/test/chunk_info.c
@@ -434,7 +434,7 @@ verify_idx_nchunks(hid_t dset, hid_t dspace, H5D_chunk_index_t exp_idx_type, hsi
     /* Ensure the correct chunk indexing scheme is used */
     if (idx_type != exp_idx_type) {
         char msg[256];
-        HDsnprintf(msg, sizeof(msg), "Should be using %s.\n", index_type_str(idx_type));
+        snprintf(msg, sizeof(msg), "Should be using %s.\n", index_type_str(idx_type));
         FAIL_PUTS_ERROR(msg);
     }
 

--- a/test/cmpd_dset.c
+++ b/test/cmpd_dset.c
@@ -286,7 +286,7 @@ test_compound(char *filename, hid_t fapl)
             s1[i].c[1] != s2[i].c[1] || s1[i].c[2] != s2[i].c[2] || s1[i].c[3] != s2[i].c[3] ||
             s1[i].d != s2[i].d || s1[i].e != s2[i].e) {
             H5_FAILED();
-            HDputs("    Incorrect values read from the file");
+            puts("    Incorrect values read from the file");
             goto error;
         }
     }
@@ -323,7 +323,7 @@ test_compound(char *filename, hid_t fapl)
             s1[i].c[1] != s3[i].c[1] || s1[i].c[2] != s3[i].c[2] || s1[i].c[3] != s3[i].c[3] ||
             s1[i].d != s3[i].d || s1[i].e != s3[i].e) {
             H5_FAILED();
-            HDputs("    Incorrect values read from the file");
+            puts("    Incorrect values read from the file");
             goto error;
         }
     }
@@ -353,7 +353,7 @@ test_compound(char *filename, hid_t fapl)
     for (i = 0; i < NX * NY; i++) {
         if (s1[i].b != s4[i].b || s1[i].d != s4[i].d) {
             H5_FAILED();
-            HDputs("    Incorrect values read from the file");
+            puts("    Incorrect values read from the file");
             goto error;
         }
     }
@@ -397,7 +397,7 @@ test_compound(char *filename, hid_t fapl)
             s1[i].c[1] != s5[i].c[1] || s1[i].c[2] != s5[i].c[2] || s1[i].c[3] != s5[i].c[3] ||
             s1[i].d != s5[i].d || s1[i].e != s5[i].e) {
             H5_FAILED();
-            HDputs("    Incorrect values read from the file");
+            puts("    Incorrect values read from the file");
             goto error;
         }
     }
@@ -407,7 +407,7 @@ test_compound(char *filename, hid_t fapl)
         if (s5[i].pre != 1000 + 4 * i || s5[i].mid1 != 1001 + 4 * i || s5[i].mid2 != 1002 + 4 * i ||
             s5[i].post != 1003 + 4 * i) {
             H5_FAILED();
-            HDputs("    Memory values were clobbered");
+            puts("    Memory values were clobbered");
             goto error;
         }
     }
@@ -466,7 +466,7 @@ test_compound(char *filename, hid_t fapl)
             s1[i].c[1] != s6[i].c[1] || s1[i].c[2] != s6[i].c[2] || s1[i].c[3] != s6[i].c[3] ||
             s1[i].d != s6[i].d || s1[i].e != s6[i].e) {
             H5_FAILED();
-            HDputs("    Incorrect values read from the file");
+            puts("    Incorrect values read from the file");
             goto error;
         }
     }
@@ -476,7 +476,7 @@ test_compound(char *filename, hid_t fapl)
         if (s6[i].pre != 1000 + 4 * i || s6[i].mid1 != 1001 + 4 * i || s6[i].mid2 != 1002 + 4 * i ||
             s6[i].post != 1003 + 4 * i) {
             H5_FAILED();
-            HDputs("    Memory values were clobbered");
+            puts("    Memory values were clobbered");
             goto error;
         }
     }
@@ -545,7 +545,7 @@ test_compound(char *filename, hid_t fapl)
             s2[i].c[1] != s1[i].c[1] || s2[i].c[2] != s1[i].c[2] || s2[i].c[3] != s1[i].c[3] ||
             s2[i].d != s1[i].d || s2[i].e != s1[i].e) {
             H5_FAILED();
-            HDputs("    Incorrect values read from file");
+            puts("    Incorrect values read from file");
             goto error;
         }
     }
@@ -588,7 +588,7 @@ test_compound(char *filename, hid_t fapl)
             if (ps8->a != ps1->a || ps8->b != ps1->b || ps8->c[0] != ps1->c[0] || ps8->c[1] != ps1->c[1] ||
                 ps8->c[2] != ps1->c[2] || ps8->c[3] != ps1->c[3] || ps8->d != ps1->d || ps8->e != ps1->e) {
                 H5_FAILED();
-                HDputs("    Incorrect values read from file");
+                puts("    Incorrect values read from file");
                 goto error;
             }
         }
@@ -627,7 +627,7 @@ test_compound(char *filename, hid_t fapl)
                     ps2->c[1] != ps1->c[1] || ps2->c[2] != ps1->c[2] || ps2->c[3] != ps1->c[3] ||
                     ps2->d != ps1->d || ps2->e != ps1->e) {
                     H5_FAILED();
-                    HDputs("    Memory values clobbered");
+                    puts("    Memory values clobbered");
                     goto error;
                 }
             }
@@ -636,7 +636,7 @@ test_compound(char *filename, hid_t fapl)
                     ps2->c[1] != (unsigned)(-1) || ps2->c[2] != (unsigned)(-1) ||
                     ps2->c[3] != (unsigned)(-1) || ps2->d != (unsigned)(-1) || ps2->e != (unsigned)(-1)) {
                     H5_FAILED();
-                    HDputs("    Incorrect values read from file");
+                    puts("    Incorrect values read from file");
                     goto error;
                 }
             }
@@ -675,7 +675,7 @@ test_compound(char *filename, hid_t fapl)
                     ps5->c[2] != ps1->c[2] || ps5->c[3] != ps1->c[3] || ps5->mid2 != (unsigned)(-1) ||
                     ps5->d != ps1->d || ps5->e != ps1->e || ps5->post != (unsigned)(-1)) {
                     H5_FAILED();
-                    HDputs("    Memory values clobbered");
+                    puts("    Memory values clobbered");
                     goto error;
                 }
             }
@@ -686,7 +686,7 @@ test_compound(char *filename, hid_t fapl)
                     ps5->c[3] != (unsigned)(-1) || ps5->mid2 != (unsigned)(-1) || ps5->d != (unsigned)(-1) ||
                     ps5->e != (unsigned)(-1) || ps5->post != (unsigned)(-1)) {
                     H5_FAILED();
-                    HDputs("    Incorrect values read from file");
+                    puts("    Incorrect values read from file");
                     goto error;
                 }
             }
@@ -735,7 +735,7 @@ test_compound(char *filename, hid_t fapl)
                 ps1->c[1] != 8 * (i * NY + j) + 3 || ps1->c[2] != 8 * (i * NY + j) + 4 ||
                 ps1->c[3] != 8 * (i * NY + j) + 5 || ps1->e != 8 * (i * NY + j) + 7) {
                 H5_FAILED();
-                HDputs("    Write clobbered values");
+                puts("    Write clobbered values");
                 goto error;
             }
 
@@ -743,14 +743,14 @@ test_compound(char *filename, hid_t fapl)
                 j < f_offset[1] + h_size[1]) {
                 if (ps1->b != (unsigned)(-1) || ps1->d != (unsigned)(-1)) {
                     H5_FAILED();
-                    HDputs("    Wrong values written or read");
+                    puts("    Wrong values written or read");
                     goto error;
                 }
             }
             else {
                 if (ps1->b != 8 * (i * NY + j) + 1 || ps1->d != 8 * (i * NY + j) + 6) {
                     H5_FAILED();
-                    HDputs("    Write clobbered values");
+                    puts("    Write clobbered values");
                     goto error;
                 }
             }
@@ -776,7 +776,7 @@ test_compound(char *filename, hid_t fapl)
     return 0;
 
 error:
-    HDputs("*** DATASET TESTS FAILED ***");
+    puts("*** DATASET TESTS FAILED ***");
 
     /* Release resources */
     if (s1)
@@ -1414,7 +1414,7 @@ error:
     free(rbuf);
     free(rew_buf);
 
-    HDputs("*** DATASET TESTS FAILED ***");
+    puts("*** DATASET TESTS FAILED ***");
     return 1;
 }
 
@@ -1613,7 +1613,7 @@ test_hdf5_dst_subset(char *filename, hid_t fapl)
     return 0;
 
 error:
-    HDputs("*** DATASET TESTS FAILED ***");
+    puts("*** DATASET TESTS FAILED ***");
     return 1;
 }
 
@@ -1686,9 +1686,9 @@ test_pack_ooo(void)
 
     for (extra_space = 0; extra_space < 2; extra_space++) {
         if (extra_space)
-            HDputs("With extra space at the end of compound...");
+            puts("With extra space at the end of compound...");
         else
-            HDputs("Without extra space at the end of compound...");
+            puts("Without extra space at the end of compound...");
 
         TESTING("random member insertion with empty compound subtype");
 
@@ -1702,7 +1702,7 @@ test_pack_ooo(void)
 
         /* Insert the compound members in the random order previously generated */
         for (i = 0; i < PACK_NMEMBS; i++) {
-            HDsnprintf(name, sizeof(name), "%05d", i);
+            snprintf(name, sizeof(name), "%05d", i);
             if (i == sub_cmpd_order) {
                 if (H5Tinsert(cmpd, name, (size_t)(4 * order[i]), sub_cmpd) < 0)
                     PACK_OOO_ERROR
@@ -1735,7 +1735,7 @@ test_pack_ooo(void)
 
         /* Insert the compound members in the random order previously generated */
         for (i = 0; i < PACK_NMEMBS; i++) {
-            HDsnprintf(name, sizeof(name), "%05d", i);
+            snprintf(name, sizeof(name), "%05d", i);
             if (i == sub_cmpd_order) {
                 if (H5Tinsert(cmpd, name, (size_t)(4 * order[i]), sub_cmpd) < 0)
                     PACK_OOO_ERROR
@@ -1770,7 +1770,7 @@ test_pack_ooo(void)
 
         /* Insert the compound members in reverse order, with compound last */
         for (i = 0; i < PACK_NMEMBS; i++) {
-            HDsnprintf(name, sizeof(name), "%05d", i);
+            snprintf(name, sizeof(name), "%05d", i);
             if (i == PACK_NMEMBS - 1) {
                 if (H5Tinsert(cmpd, name, (size_t)(4 * (PACK_NMEMBS - i - 1)), sub_cmpd) < 0)
                     PACK_OOO_ERROR
@@ -1803,7 +1803,7 @@ test_pack_ooo(void)
 
         /* Insert the compound members in reverse order, with compound last */
         for (i = 0; i < PACK_NMEMBS; i++) {
-            HDsnprintf(name, sizeof(name), "%05d", i);
+            snprintf(name, sizeof(name), "%05d", i);
             if (i == PACK_NMEMBS - 1) {
                 if (H5Tinsert(cmpd, name, (size_t)(4 * (PACK_NMEMBS - i - 1)), sub_cmpd) < 0)
                     PACK_OOO_ERROR
@@ -1838,7 +1838,7 @@ test_pack_ooo(void)
 
         /* Insert the compound members in forward order, with compound first */
         for (i = 0; i < PACK_NMEMBS; i++) {
-            HDsnprintf(name, sizeof(name), "%05d", i);
+            snprintf(name, sizeof(name), "%05d", i);
             if (i == 0) {
                 if (H5Tinsert(cmpd, name, (size_t)(4 * i), sub_cmpd) < 0)
                     PACK_OOO_ERROR
@@ -1871,7 +1871,7 @@ test_pack_ooo(void)
 
         /* Insert the compound members in forward order */
         for (i = 0; i < PACK_NMEMBS; i++) {
-            HDsnprintf(name, sizeof(name), "%05d", i);
+            snprintf(name, sizeof(name), "%05d", i);
             if (i == 0) {
                 if (H5Tinsert(cmpd, name, (size_t)(4 * i), sub_cmpd) < 0)
                     PACK_OOO_ERROR
@@ -1898,7 +1898,7 @@ test_pack_ooo(void)
     return 0;
 
 error:
-    HDputs("*** DATASET TESTS FAILED ***");
+    puts("*** DATASET TESTS FAILED ***");
     return 1;
 }
 
@@ -2138,7 +2138,7 @@ error:
         H5Fclose(file);
     }
     H5E_END_TRY
-    HDputs("*** DATASET TESTS FAILED ***");
+    puts("*** DATASET TESTS FAILED ***");
     return 1;
 } /* test_ooo_order */
 
@@ -2165,7 +2165,7 @@ main(int argc, char *argv[])
 
     /* Turn off optimized compound converter? */
     if (argc > 1) {
-        if (argc > 2 || HDstrcmp("--noopt", argv[1]) != 0) {
+        if (argc > 2 || strcmp("--noopt", argv[1]) != 0) {
             fprintf(stderr, "usage: %s [--noopt]\n", argv[0]);
             exit(EXIT_FAILURE);
         }
@@ -2178,21 +2178,21 @@ main(int argc, char *argv[])
 
     h5_fixname(FILENAME[0], fapl_id, fname, sizeof(fname));
 
-    HDputs("Testing compound dataset:");
+    puts("Testing compound dataset:");
     nerrors += test_compound(fname, fapl_id);
 
-    HDputs("Testing the optimization of when the source type is a subset of the dest:");
+    puts("Testing the optimization of when the source type is a subset of the dest:");
     h5_fixname(FILENAME[1], fapl_id, fname, sizeof(fname));
     nerrors += test_hdf5_src_subset(fname, fapl_id);
 
-    HDputs("Testing the optimization of when the dest type is a subset of the source:");
+    puts("Testing the optimization of when the dest type is a subset of the source:");
     h5_fixname(FILENAME[2], fapl_id, fname, sizeof(fname));
     nerrors += test_hdf5_dst_subset(fname, fapl_id);
 
-    HDputs("Testing that compound types can be packed out of order:");
+    puts("Testing that compound types can be packed out of order:");
     nerrors += test_pack_ooo();
 
-    HDputs("Testing compound member ordering:");
+    puts("Testing compound member ordering:");
     nerrors += test_ooo_order(fname, fapl_id);
 
     /* Verify symbol table messages are cached */
@@ -2204,6 +2204,6 @@ main(int argc, char *argv[])
     }
 
     h5_cleanup(FILENAME, fapl_id);
-    HDputs("All compound dataset tests passed.");
+    puts("All compound dataset tests passed.");
     return 0;
 }

--- a/test/cmpd_dtransform.c
+++ b/test/cmpd_dtransform.c
@@ -46,8 +46,8 @@ main(void)
     /* Compound datatype */
     if (NULL == (atts = malloc(sizeof(att_t))))
         TEST_ERROR;
-    HDstrcpy(atts[0].name, "Name");
-    HDstrcpy(atts[0].unit, "Unit");
+    strcpy(atts[0].name, "Name");
+    strcpy(atts[0].unit, "Unit");
 
     /* String type */
     if ((str_dtyp_id = H5Tcopy(H5T_C_S1)) < 0)
@@ -113,9 +113,9 @@ main(void)
         FAIL_STACK_ERROR;
 
     /* Verify attribute */
-    if (HDstrcmp(atts_res[0].name, atts[0].name) != 0)
+    if (strcmp(atts_res[0].name, atts[0].name) != 0)
         TEST_ERROR;
-    if (HDstrcmp(atts_res[0].unit, atts[0].unit) != 0)
+    if (strcmp(atts_res[0].unit, atts[0].unit) != 0)
         TEST_ERROR;
 
     /* Read the data */

--- a/test/cork.c
+++ b/test/cork.c
@@ -390,7 +390,7 @@ verify_obj_dset_cork(bool swmr)
 
     /* Attach 8 attributes to the dataset */
     for (i = 0; i < 8; i++) {
-        HDsnprintf(attrname, sizeof(attrname), "attr %d", i);
+        snprintf(attrname, sizeof(attrname), "attr %d", i);
         if ((aid = H5Acreate2(did2, attrname, H5T_NATIVE_INT, sid, H5P_DEFAULT, H5P_DEFAULT)) < 0)
             TEST_ERROR;
         if (H5Awrite(aid, H5T_NATIVE_INT, &i) < 0)
@@ -854,7 +854,7 @@ verify_group_cork(bool swmr)
 
     /* Attach 8 attributes to the third group: GRP3 */
     for (i = 0; i < 8; i++) {
-        HDsnprintf(attrname, sizeof(attrname), "attr %d", i);
+        snprintf(attrname, sizeof(attrname), "attr %d", i);
         if ((aid = H5Acreate2(gid3, attrname, H5T_NATIVE_UINT, sid, H5P_DEFAULT, H5P_DEFAULT)) < 0)
             TEST_ERROR;
         if (H5Awrite(aid, H5T_NATIVE_UINT, &i) < 0)
@@ -1069,7 +1069,7 @@ verify_named_cork(bool swmr)
 
     /* Attach 8 attributes to datatype: DT3 */
     for (i = 0; i < 8; i++) {
-        HDsnprintf(attrname, sizeof(attrname), "attr %d", i);
+        snprintf(attrname, sizeof(attrname), "attr %d", i);
         if ((aid = H5Acreate2(tid3, attrname, H5T_NATIVE_UINT, sid, H5P_DEFAULT, H5P_DEFAULT)) < 0)
             TEST_ERROR;
         if (H5Awrite(aid, H5T_NATIVE_UINT, &i) < 0)
@@ -2236,7 +2236,7 @@ main(void)
              */
             driver = HDgetenv(HDF5_DRIVER);
             if (!H5FD__supports_swmr_test(driver)) {
-                HDputs("-- SKIPPED SWMR tests for SWMR-incompatible VFD --");
+                puts("-- SKIPPED SWMR tests for SWMR-incompatible VFD --");
                 continue;
             }
         }

--- a/test/cross_read.c
+++ b/test/cross_read.c
@@ -274,7 +274,7 @@ check_file(char *filename)
     nerrors += check_data_f(DATASETNAME16, fid);
 #else  /*H5_HAVE_FILTER_DEFLATE*/
     SKIPPED();
-    HDputs(not_supported);
+    puts(not_supported);
 #endif /*H5_HAVE_FILTER_DEFLATE*/
 
     TESTING("dataset of BE FLOAT with Deflate filter");
@@ -282,7 +282,7 @@ check_file(char *filename)
     nerrors += check_data_f(DATASETNAME17, fid);
 #else  /*H5_HAVE_FILTER_DEFLATE*/
     SKIPPED();
-    HDputs(not_supported);
+    puts(not_supported);
 #endif /*H5_HAVE_FILTER_DEFLATE*/
 
     TESTING("dataset of LE FLOAT with Szip filter");
@@ -290,7 +290,7 @@ check_file(char *filename)
     nerrors += check_data_f(DATASETNAME18, fid);
 #else  /*H5_HAVE_FILTER_SZIP*/
     SKIPPED();
-    HDputs(not_supported);
+    puts(not_supported);
 #endif /*H5_HAVE_FILTER_SZIP*/
 
     TESTING("dataset of BE FLOAT with Szip filter");
@@ -298,7 +298,7 @@ check_file(char *filename)
     nerrors += check_data_f(DATASETNAME19, fid);
 #else  /*H5_HAVE_FILTER_SZIP*/
     SKIPPED();
-    HDputs(not_supported);
+    puts(not_supported);
 #endif /*H5_HAVE_FILTER_SZIP*/
 
     TESTING("dataset of LE FLOAT with Shuffle filter");
@@ -348,21 +348,21 @@ main(void)
      * Skip tests for VFDs that aren't compatible with default VFD.
      */
     if (h5_driver_is_default_vfd_compatible(H5P_DEFAULT, &driver_is_default_compatible) < 0) {
-        HDputs(" -- couldn't check if VFD is compatible with default VFD --");
+        puts(" -- couldn't check if VFD is compatible with default VFD --");
         exit(EXIT_SUCCESS);
     }
     if (!driver_is_default_compatible) {
-        HDputs(" -- SKIPPED for incompatible VFD --");
+        puts(" -- SKIPPED for incompatible VFD --");
         exit(EXIT_SUCCESS);
     }
 
-    HDputs("\n");
-    HDputs("Testing reading data created on Linux");
+    puts("\n");
+    puts("Testing reading data created on Linux");
     h5_fixname(FILENAME[1], H5P_DEFAULT, filename, sizeof(filename));
     nerrors += check_file(filename);
 
-    HDputs("\n");
-    HDputs("Testing reading data created on Solaris");
+    puts("\n");
+    puts("Testing reading data created on Solaris");
     h5_fixname(FILENAME[2], H5P_DEFAULT, filename, sizeof(filename));
     nerrors += check_file(filename);
 

--- a/test/dangle.c
+++ b/test/dangle.c
@@ -634,13 +634,13 @@ main(void)
     /* Don't run this test with the multi/split VFD. A bug in library shutdown
      * ordering causes problems with the multi VFD when IDs are left dangling.
      */
-    if (!HDstrcmp(env_h5_drvr, "multi") || !HDstrcmp(env_h5_drvr, "split")) {
-        HDputs(" -- SKIPPED for incompatible VFD --");
+    if (!strcmp(env_h5_drvr, "multi") || !strcmp(env_h5_drvr, "split")) {
+        puts(" -- SKIPPED for incompatible VFD --");
         return 0;
     }
 
     /* Run tests w/weak file close */
-    HDputs("Testing dangling objects with weak file close:");
+    puts("Testing dangling objects with weak file close:");
     nerrors += test_dangle_dataset(H5F_CLOSE_WEAK);
     nerrors += test_dangle_group(H5F_CLOSE_WEAK);
     nerrors += test_dangle_datatype1(H5F_CLOSE_WEAK);
@@ -648,7 +648,7 @@ main(void)
     nerrors += test_dangle_attribute(H5F_CLOSE_WEAK);
 
     /* Run tests w/semi file close */
-    HDputs("Testing dangling objects with semi file close:");
+    puts("Testing dangling objects with semi file close:");
     nerrors += test_dangle_dataset(H5F_CLOSE_SEMI);
     nerrors += test_dangle_group(H5F_CLOSE_SEMI);
     nerrors += test_dangle_datatype1(H5F_CLOSE_SEMI);
@@ -656,7 +656,7 @@ main(void)
     nerrors += test_dangle_attribute(H5F_CLOSE_SEMI);
 
     /* Run tests w/strong file close */
-    HDputs("Testing dangling objects with strong file close:");
+    puts("Testing dangling objects with strong file close:");
     nerrors += test_dangle_dataset(H5F_CLOSE_STRONG);
     nerrors += test_dangle_group(H5F_CLOSE_STRONG);
     nerrors += test_dangle_datatype1(H5F_CLOSE_STRONG);
@@ -669,11 +669,11 @@ main(void)
     /* Check for errors */
     if (nerrors)
         goto error;
-    HDputs("All dangling ID tests passed.");
+    puts("All dangling ID tests passed.");
 
     return 0;
 
 error:
-    HDputs("***** DANGLING ID TESTS FAILED *****");
+    puts("***** DANGLING ID TESTS FAILED *****");
     return 1;
 }

--- a/test/del_many_dense_attrs.c
+++ b/test/del_many_dense_attrs.c
@@ -114,7 +114,7 @@ main(void)
     /* Create attributes in the group */
     for (i = ATTR_COUNT; i >= 0; i--) {
         /* Set up the attribute name */
-        HDsnprintf(aname, sizeof(aname), "%s%d", basename, i);
+        snprintf(aname, sizeof(aname), "%s%d", basename, i);
 
         /* Create the attribute */
         if ((aid = H5Acreate2(gid, aname, tid, sid, H5P_DEFAULT, H5P_DEFAULT)) < 0)
@@ -160,7 +160,7 @@ main(void)
     /* Delete the attributes */
     for (i = 0; i <= ATTR_COUNT; i++) {
         /* Set up the attribute name */
-        HDsnprintf(aname, sizeof(aname), "%s%d", basename, i);
+        snprintf(aname, sizeof(aname), "%s%d", basename, i);
 
         /* Delete the attribute */
         if (H5Adelete(gid, aname) < 0)

--- a/test/direct_chunk.c
+++ b/test/direct_chunk.c
@@ -2313,10 +2313,10 @@ main(void)
     if (nerrors)
         goto error;
 
-    HDputs("All direct chunk read/write tests passed.");
+    puts("All direct chunk read/write tests passed.");
     return EXIT_SUCCESS;
 
 error:
-    HDputs("*** TESTS FAILED ***");
+    puts("*** TESTS FAILED ***");
     return EXIT_FAILURE;
 }

--- a/test/dsets.c
+++ b/test/dsets.c
@@ -416,7 +416,7 @@ test_create(hid_t file)
     H5E_END_TRY
     if (dataset >= 0) {
         H5_FAILED();
-        HDputs("    Library allowed overwrite of existing dataset.");
+        puts("    Library allowed overwrite of existing dataset.");
         goto error;
     }
 
@@ -443,7 +443,7 @@ test_create(hid_t file)
     H5E_END_TRY
     if (dataset >= 0) {
         H5_FAILED();
-        HDputs("    Opened a non-existent dataset.");
+        puts("    Opened a non-existent dataset.");
         goto error;
     }
 
@@ -467,7 +467,7 @@ test_create(hid_t file)
     H5E_END_TRY
     if (dataset >= 0) {
         H5_FAILED();
-        HDputs("    Opened a dataset with incorrect chunking parameters.");
+        puts("    Opened a dataset with incorrect chunking parameters.");
         goto error;
     }
 
@@ -544,8 +544,8 @@ test_simple_io(const char *env_h5_drvr, hid_t fapl)
     TESTING("simple I/O");
 
     /* Can't run this test with multi-file VFDs because of HDopen/read/seek the file directly */
-    if (HDstrcmp(env_h5_drvr, "split") != 0 && HDstrcmp(env_h5_drvr, "multi") != 0 &&
-        HDstrcmp(env_h5_drvr, "family") != 0) {
+    if (strcmp(env_h5_drvr, "split") != 0 && strcmp(env_h5_drvr, "multi") != 0 &&
+        strcmp(env_h5_drvr, "family") != 0) {
         h5_fixname(FILENAME[4], fapl, filename, sizeof filename);
 
         /* Set up data array */
@@ -653,7 +653,7 @@ test_simple_io(const char *env_h5_drvr, hid_t fapl)
     } /* end if */
     else {
         SKIPPED();
-        HDputs("    Current VFD doesn't support continuous address space");
+        puts("    Current VFD doesn't support continuous address space");
     } /* end else */
 
     return SUCCEED;
@@ -705,8 +705,8 @@ test_userblock_offset(const char *env_h5_drvr, hid_t fapl, bool new_format)
     TESTING("dataset offset with user block");
 
     /* Can't run this test with multi-file VFDs because of HDopen/read/seek the file directly */
-    if (HDstrcmp(env_h5_drvr, "split") != 0 && HDstrcmp(env_h5_drvr, "multi") != 0 &&
-        HDstrcmp(env_h5_drvr, "family") != 0) {
+    if (strcmp(env_h5_drvr, "split") != 0 && strcmp(env_h5_drvr, "multi") != 0 &&
+        strcmp(env_h5_drvr, "family") != 0) {
         h5_fixname(FILENAME[2], fapl, filename, sizeof filename);
 
         /* Set up data array */
@@ -789,7 +789,7 @@ test_userblock_offset(const char *env_h5_drvr, hid_t fapl, bool new_format)
     } /* end if */
     else {
         SKIPPED();
-        HDputs("    Current VFD doesn't support continuous address space");
+        puts("    Current VFD doesn't support continuous address space");
     } /* end else */
 
     return SUCCEED;
@@ -1470,7 +1470,7 @@ test_conv_buffer(hid_t fid)
     H5E_END_TRY
     if (status >= 0) {
         H5_FAILED();
-        HDputs("    Library shouldn't allow conversion buffer too small");
+        puts("    Library shouldn't allow conversion buffer too small");
         goto error;
     }
 
@@ -1505,7 +1505,7 @@ test_conv_buffer(hid_t fid)
 
     free(cf);
     free(cfrR);
-    HDputs(" PASSED");
+    puts(" PASSED");
     return SUCCEED;
 
 error:
@@ -1585,7 +1585,7 @@ test_tconv(hid_t file)
         if (in[4 * i + 0] != out[4 * i + 3] || in[4 * i + 1] != out[4 * i + 2] ||
             in[4 * i + 2] != out[4 * i + 1] || in[4 * i + 3] != out[4 * i + 0]) {
             H5_FAILED();
-            HDputs("    Read with byte order conversion failed.");
+            puts("    Read with byte order conversion failed.");
             goto error;
         }
     }
@@ -1597,7 +1597,7 @@ test_tconv(hid_t file)
     free(out);
     free(in);
 
-    HDputs(" PASSED");
+    puts(" PASSED");
     return SUCCEED;
 
 error:
@@ -2526,7 +2526,7 @@ test_filters(hid_t file)
      * STEP 0: Test null I/O filter by itself.
      *----------------------------------------------------------
      */
-    HDputs("Testing 'null' filter");
+    puts("Testing 'null' filter");
     if ((dc = H5Pcreate(H5P_DATASET_CREATE)) < 0)
         goto error;
     if (H5Pset_chunk(dc, 2, chunk_size) < 0)
@@ -2548,7 +2548,7 @@ test_filters(hid_t file)
      * STEP 1: Test Fletcher32 Checksum by itself.
      *----------------------------------------------------------
      */
-    HDputs("Testing Fletcher32 checksum(enabled for read)");
+    puts("Testing Fletcher32 checksum(enabled for read)");
     if ((dc = H5Pcreate(H5P_DATASET_CREATE)) < 0)
         goto error;
     if (H5Pset_chunk(dc, 2, chunk_size) < 0)
@@ -2562,23 +2562,23 @@ test_filters(hid_t file)
         goto error;
     if (fletcher32_size <= null_size) {
         H5_FAILED();
-        HDputs("    Size after checksumming is incorrect.");
+        puts("    Size after checksumming is incorrect.");
         goto error;
     } /* end if */
 
     /* Disable checksum during read */
-    HDputs("Testing Fletcher32 checksum(disabled for read)");
+    puts("Testing Fletcher32 checksum(disabled for read)");
     if (test_filter_internal(file, DSET_FLETCHER32_NAME_2, dc, DISABLE_FLETCHER32, DATA_NOT_CORRUPTED,
                              &fletcher32_size) < 0)
         goto error;
     if (fletcher32_size <= null_size) {
         H5_FAILED();
-        HDputs("    Size after checksumming is incorrect.");
+        puts("    Size after checksumming is incorrect.");
         goto error;
     } /* end if */
 
     /* Try to corrupt data and see if checksum fails */
-    HDputs("Testing Fletcher32 checksum(when data is corrupted)");
+    puts("Testing Fletcher32 checksum(when data is corrupted)");
     data_corrupt[0] = 52;
     data_corrupt[1] = 33;
     data_corrupt[2] = 27;
@@ -2592,7 +2592,7 @@ test_filters(hid_t file)
         goto error;
     if (fletcher32_size <= null_size) {
         H5_FAILED();
-        HDputs("    Size after checksumming is incorrect.");
+        puts("    Size after checksumming is incorrect.");
         goto error;
     } /* end if */
 
@@ -2605,7 +2605,7 @@ test_filters(hid_t file)
          *----------------------------------------------------------
          */
 #ifdef H5_HAVE_FILTER_DEFLATE
-    HDputs("Testing deflate filter");
+    puts("Testing deflate filter");
     if ((dc = H5Pcreate(H5P_DATASET_CREATE)) < 0)
         goto error;
     if (H5Pset_chunk(dc, 2, chunk_size) < 0)
@@ -2622,7 +2622,7 @@ test_filters(hid_t file)
 #else  /* H5_HAVE_FILTER_DEFLATE */
     TESTING("deflate filter");
     SKIPPED();
-    HDputs("    Deflate filter not enabled");
+    puts("    Deflate filter not enabled");
 #endif /* H5_HAVE_FILTER_DEFLATE */
 
         /*----------------------------------------------------------
@@ -2637,7 +2637,7 @@ test_filters(hid_t file)
         if (H5Pset_chunk(dc, 2, chunk_size) < 0)
             goto error;
 
-        HDputs("");
+        puts("");
         if (H5Pset_szip(dc, szip_options_mask, szip_pixels_per_block) < 0)
             goto error;
         if (test_filter_internal(file, DSET_SZIP_NAME, dc, DISABLE_FLETCHER32, DATA_NOT_CORRUPTED,
@@ -2653,7 +2653,7 @@ test_filters(hid_t file)
     TESTING("szip filter (without encoder)");
 
     if (h5_szip_can_encode() != 1) {
-        HDputs("");
+        puts("");
         if (test_filter_noencoder(NOENCODER_SZIP_DATASET) < 0)
             goto error;
     }
@@ -2664,14 +2664,14 @@ test_filters(hid_t file)
 #else  /* H5_HAVE_FILTER_SZIP */
     TESTING("szip filter");
     SKIPPED();
-    HDputs("    Szip filter not enabled");
+    puts("    Szip filter not enabled");
 #endif /* H5_HAVE_FILTER_SZIP */
 
     /*----------------------------------------------------------
      * STEP 4: Test shuffling by itself.
      *----------------------------------------------------------
      */
-    HDputs("Testing shuffle filter");
+    puts("Testing shuffle filter");
     if ((dc = H5Pcreate(H5P_DATASET_CREATE)) < 0)
         goto error;
     if (H5Pset_chunk(dc, 2, chunk_size) < 0)
@@ -2684,7 +2684,7 @@ test_filters(hid_t file)
         goto error;
     if (shuffle_size != null_size) {
         H5_FAILED();
-        HDputs("    Shuffled size not the same as uncompressed size.");
+        puts("    Shuffled size not the same as uncompressed size.");
         goto error;
     } /* end if */
 
@@ -2697,7 +2697,7 @@ test_filters(hid_t file)
          *----------------------------------------------------------
          */
 #ifdef H5_HAVE_FILTER_DEFLATE
-    HDputs("Testing shuffle+deflate+checksum filters(checksum first)");
+    puts("Testing shuffle+deflate+checksum filters(checksum first)");
     if ((dc = H5Pcreate(H5P_DATASET_CREATE)) < 0)
         goto error;
     if (H5Pset_chunk(dc, 2, chunk_size) < 0)
@@ -2717,7 +2717,7 @@ test_filters(hid_t file)
     if (H5Pclose(dc) < 0)
         goto error;
 
-    HDputs("Testing shuffle+deflate+checksum filters(checksum last)");
+    puts("Testing shuffle+deflate+checksum filters(checksum last)");
     if ((dc = H5Pcreate(H5P_DATASET_CREATE)) < 0)
         goto error;
     if (H5Pset_chunk(dc, 2, chunk_size) < 0)
@@ -2739,7 +2739,7 @@ test_filters(hid_t file)
 #else  /* H5_HAVE_FILTER_DEFLATE */
     TESTING("shuffle+deflate+fletcher32 filters");
     SKIPPED();
-    HDputs("    Deflate filter not enabled");
+    puts("    Deflate filter not enabled");
 #endif /* H5_HAVE_FILTER_DEFLATE */
 
         /*----------------------------------------------------------
@@ -2760,7 +2760,7 @@ test_filters(hid_t file)
 
     /* Make sure encoding is enabled */
     if (h5_szip_can_encode() == 1) {
-        HDputs("");
+        puts("");
         if (H5Pset_szip(dc, szip_options_mask, szip_pixels_per_block) < 0)
             goto error;
         if (test_filter_internal(file, DSET_SHUF_SZIP_FLET_NAME, dc, ENABLE_FLETCHER32, DATA_NOT_CORRUPTED,
@@ -2774,7 +2774,7 @@ test_filters(hid_t file)
     TESTING("shuffle+szip+checksum filters(checksum first, without encoder)");
 
     if (h5_szip_can_encode() != 1) {
-        HDputs("");
+        puts("");
         if (test_filter_noencoder(NOENCODER_SZIP_SHUFF_FLETCH_DATASET) < 0)
             goto error;
     }
@@ -2790,7 +2790,7 @@ test_filters(hid_t file)
 
     /* Make sure encoding is enabled */
     if (h5_szip_can_encode() == 1) {
-        HDputs("");
+        puts("");
         if ((dc = H5Pcreate(H5P_DATASET_CREATE)) < 0)
             goto error;
         if (H5Pset_chunk(dc, 2, chunk_size) < 0)
@@ -2817,7 +2817,7 @@ test_filters(hid_t file)
 #else  /* H5_HAVE_FILTER_SZIP */
     TESTING("shuffle+szip+fletcher32 filters");
     SKIPPED();
-    HDputs("    szip filter not enabled");
+    puts("    szip filter not enabled");
 #endif /* H5_HAVE_FILTER_SZIP */
     return SUCCEED;
 
@@ -3196,7 +3196,7 @@ test_nbit_int(hid_t file)
     double       power;
     size_t       i, j;
 
-    HDputs("Testing nbit filter");
+    puts("Testing nbit filter");
     TESTING("    nbit int (setup)");
 
     /* Define dataset datatype (integer), and set precision, offset */
@@ -4339,8 +4339,8 @@ test_nbit_compound_3(hid_t file)
         power = pow(2.0, 17.0 - 1.0);
         memset(&orig_data[i], 0, sizeof(orig_data[i]));
         orig_data[i].i = (int)(HDrandom() % (long)power);
-        HDstrcpy(orig_data[i].str, "fixed-length C string");
-        orig_data[i].vl_str = HDstrdup("variable-length C string");
+        strcpy(orig_data[i].str, "fixed-length C string");
+        orig_data[i].vl_str = strdup("variable-length C string");
 
         orig_data[i].v.p   = malloc((size_t)(i + 1) * sizeof(unsigned int));
         orig_data[i].v.len = (size_t)i + 1;
@@ -4380,9 +4380,9 @@ test_nbit_compound_3(hid_t file)
 
     /* Check that the values read are the same as the values written */
     for (i = 0; i < (size_t)size[0]; i++) {
-        if (new_data[i].i != orig_data[i].i || HDstrcmp(new_data[i].str, orig_data[i].str) != 0 ||
-            HDstrcmp(new_data[i].vl_str, orig_data[i].vl_str) != 0 ||
-            new_data[i].v.len != orig_data[i].v.len || new_data[i].r != orig_data[i].r) {
+        if (new_data[i].i != orig_data[i].i || strcmp(new_data[i].str, orig_data[i].str) != 0 ||
+            strcmp(new_data[i].vl_str, orig_data[i].vl_str) != 0 || new_data[i].v.len != orig_data[i].v.len ||
+            new_data[i].r != orig_data[i].r) {
             H5_FAILED();
             printf("    Read different values than written.\n");
             printf("    At index %lu\n", (unsigned long)i);
@@ -4846,7 +4846,7 @@ test_scaleoffset_int(hid_t file)
     int           new_data[2][5];
     size_t        i, j;
 
-    HDputs("Testing scaleoffset filter");
+    puts("Testing scaleoffset filter");
     TESTING("    scaleoffset int without fill value (setup)");
 
     datatype = H5Tcopy(H5T_NATIVE_INT);
@@ -6415,11 +6415,11 @@ test_can_apply_szip(hid_t
     }
     else {
         SKIPPED();
-        HDputs("    Szip encoding is not enabled.");
+        puts("    Szip encoding is not enabled.");
     }
 #else  /* H5_HAVE_FILTER_SZIP */
     SKIPPED();
-    HDputs("    Szip filter is not enabled.");
+    puts("    Szip filter is not enabled.");
 #endif /* H5_HAVE_FILTER_SZIP */
     return SUCCEED;
 
@@ -8376,7 +8376,7 @@ test_deprec(hid_t file)
     H5E_END_TRY
     if (dataset >= 0) {
         H5_FAILED();
-        HDputs("    Library allowed overwrite of existing dataset.");
+        puts("    Library allowed overwrite of existing dataset.");
         goto error;
     }
 
@@ -8401,7 +8401,7 @@ test_deprec(hid_t file)
     H5E_END_TRY
     if (dataset >= 0) {
         H5_FAILED();
-        HDputs("    Opened a non-existent dataset.");
+        puts("    Opened a non-existent dataset.");
         goto error;
     }
 
@@ -8454,7 +8454,7 @@ test_deprec(hid_t file)
     H5E_END_TRY
     if (dataset >= 0) {
         H5_FAILED();
-        HDputs("    Opened a dataset with incorrect chunking parameters.");
+        puts("    Opened a dataset with incorrect chunking parameters.");
         goto error;
     }
 
@@ -8518,7 +8518,7 @@ test_deprec(hid_t file)
     if (H5Pset_filter(dcpl, H5Z_FILTER_DEPREC, 0, (size_t)0, NULL) < 0)
         goto error;
 
-    HDputs("");
+    puts("");
     if (test_filter_internal(file, DSET_DEPREC_NAME_FILTER, dcpl, DISABLE_FLETCHER32, DATA_NOT_CORRUPTED,
                              &deprec_size) < 0)
         goto error;
@@ -10095,7 +10095,7 @@ test_chunk_expand(hid_t fapl)
 
     if (sizeof(size_t) <= 4 && low != H5F_LIBVER_LATEST) {
         SKIPPED();
-        HDputs("    Current machine can't test for error w/old file format");
+        puts("    Current machine can't test for error w/old file format");
     } /* end if */
     else {
         /* Register "expansion" filter */
@@ -11903,7 +11903,7 @@ test_swmr_non_latest(const char *env_h5_driver, hid_t fapl)
      */
     if (!H5FD__supports_swmr_test(env_h5_driver)) {
         SKIPPED();
-        HDputs("    Test skipped due to VFD not supporting SWMR I/O.");
+        puts("    Test skipped due to VFD not supporting SWMR I/O.");
         return SUCCEED;
     }
 
@@ -12173,7 +12173,7 @@ test_earray_hdr_fd(const char *env_h5_driver, hid_t fapl)
      */
     if (!H5FD__supports_swmr_test(env_h5_driver)) {
         SKIPPED();
-        HDputs("    Test skipped due to VFD not supporting SWMR I/O.");
+        puts("    Test skipped due to VFD not supporting SWMR I/O.");
         return SUCCEED;
     }
 
@@ -12294,7 +12294,7 @@ test_farray_hdr_fd(const char *env_h5_driver, hid_t fapl)
      */
     if (!H5FD__supports_swmr_test(env_h5_driver)) {
         SKIPPED();
-        HDputs("    Test skipped due to VFD not supporting SWMR I/O.");
+        puts("    Test skipped due to VFD not supporting SWMR I/O.");
         return SUCCEED;
     }
 
@@ -12421,7 +12421,7 @@ test_bt2_hdr_fd(const char *env_h5_driver, hid_t fapl)
      */
     if (!H5FD__supports_swmr_test(env_h5_driver)) {
         SKIPPED();
-        HDputs("    Test skipped due to VFD not supporting SWMR I/O.");
+        puts("    Test skipped due to VFD not supporting SWMR I/O.");
         return SUCCEED;
     }
 
@@ -14385,10 +14385,10 @@ dls_01_main(void)
     if (NULL == buffer)
         TEST_ERROR;
 
-    HDstrcpy(buffer, strings[0]);
-    HDstrcpy(buffer + DLS_01_STR_SIZE, strings[1]);
-    HDstrcpy(buffer + DLS_01_STR_SIZE * 2, strings[2]);
-    HDstrcpy(buffer + DLS_01_STR_SIZE * 3, strings[3]);
+    strcpy(buffer, strings[0]);
+    strcpy(buffer + DLS_01_STR_SIZE, strings[1]);
+    strcpy(buffer + DLS_01_STR_SIZE * 2, strings[2]);
+    strcpy(buffer + DLS_01_STR_SIZE * 3, strings[3]);
 
     fapl = H5Pcreate(H5P_FILE_ACCESS);
     if (fapl <= 0)
@@ -15283,8 +15283,8 @@ test_0sized_dset_metadata_alloc(hid_t fapl_id)
                     continue;
 
                 /* Compose dataset name */
-                HDsnprintf(dset_name, sizeof(dset_name), "/Dataset-%u-%u", (unsigned)alloc_time,
-                           (unsigned)layout);
+                snprintf(dset_name, sizeof(dset_name), "/Dataset-%u-%u", (unsigned)alloc_time,
+                         (unsigned)layout);
 
                 /* Set up DCPL */
                 if ((dcpl_id_copy = H5Pcopy(dcpl_id)) < 0)
@@ -15432,7 +15432,7 @@ main(void)
         envval = "nomatch";
 
     /* Current VFD that does not support contiguous address space */
-    contig_addr_vfd = (bool)(HDstrcmp(envval, "split") != 0 && HDstrcmp(envval, "multi") != 0);
+    contig_addr_vfd = (bool)(strcmp(envval, "split") != 0 && strcmp(envval, "multi") != 0);
 
     /* Set the random # seed */
     HDsrandom((unsigned)HDtime(NULL));
@@ -15523,22 +15523,22 @@ main(void)
                     my_fapl = fapl2;
                     if (paged) {
                         my_fcpl = fcpl2;
-                        HDputs("\nTesting with new file format and paged aggregation");
+                        puts("\nTesting with new file format and paged aggregation");
                     }
                     else {
                         my_fcpl = fcpl;
-                        HDputs("\nTesting with new file format and non-paged aggregation");
+                        puts("\nTesting with new file format and non-paged aggregation");
                     }
                 } /* end if */
                 else {
                     my_fapl = fapl;
                     if (paged) {
                         my_fcpl = fcpl2;
-                        HDputs("Testing with old file format and paged aggregation:");
+                        puts("Testing with old file format and paged aggregation:");
                     }
                     else {
                         my_fcpl = fcpl;
-                        HDputs("Testing with old file format and non-paged aggregation:");
+                        puts("Testing with old file format and non-paged aggregation:");
                     }
                 } /* end else */
 
@@ -15549,7 +15549,7 @@ main(void)
                 if (true == minimized_ohdr) {
                     if (0 > H5Fset_dset_no_attrs_hint(file, true))
                         goto error;
-                    HDputs("(minimized dataset object headers with file setting)");
+                    puts("(minimized dataset object headers with file setting)");
                 }
 
                 /* Cause the library to emit initial messages */

--- a/test/dt_arith.c
+++ b/test/dt_arith.c
@@ -403,10 +403,10 @@ static void
 fpe_handler(int H5_ATTR_UNUSED signo)
 {
     SKIPPED();
-    HDputs("    Test skipped due to SIGFPE.");
+    puts("    Test skipped due to SIGFPE.");
 #ifndef HANDLE_SIGFPE
-    HDputs("    Remaining tests could not be run.");
-    HDputs("    Please turn off SIGFPE on overflows and try again.");
+    puts("    Remaining tests could not be run.");
+    puts("    Please turn off SIGFPE on overflows and try again.");
 #endif
     exit(255);
 }
@@ -953,8 +953,8 @@ test_derived_flt(void)
 
         /* Print errors */
         if (0 == fails_this_test++) {
-            HDsnprintf(str, sizeof(str),
-                       "\nTesting random sw derived floating-point -> derived floating-point conversions");
+            snprintf(str, sizeof(str),
+                     "\nTesting random sw derived floating-point -> derived floating-point conversions");
             printf("%-70s", str);
             fflush(stdout);
             H5_FAILED();
@@ -976,7 +976,7 @@ test_derived_flt(void)
         printf(" %29d\n", *aligned);
 
         if (fails_this_test >= max_fails) {
-            HDputs("    maximum failures reached, aborting test...");
+            puts("    maximum failures reached, aborting test...");
             goto error;
         }
     }
@@ -1122,8 +1122,8 @@ test_derived_flt(void)
 
         /* Print errors */
         if (0 == fails_this_test++) {
-            HDsnprintf(str, sizeof(str),
-                       "\nTesting random sw derived floating-point -> derived floating-point conversions");
+            snprintf(str, sizeof(str),
+                     "\nTesting random sw derived floating-point -> derived floating-point conversions");
             printf("%-70s", str);
             fflush(stdout);
             H5_FAILED();
@@ -1141,7 +1141,7 @@ test_derived_flt(void)
         printf("\n");
 
         if (fails_this_test >= max_fails) {
-            HDputs("    maximum failures reached, aborting test...");
+            puts("    maximum failures reached, aborting test...");
             goto error;
         }
     }
@@ -1435,8 +1435,7 @@ test_derived_integer(void)
 
         /* Print errors */
         if (0 == fails_this_test++) {
-            HDsnprintf(str, sizeof(str),
-                       "\nTesting random sw derived integer -> derived integer conversions");
+            snprintf(str, sizeof(str), "\nTesting random sw derived integer -> derived integer conversions");
             printf("%-70s", str);
             fflush(stdout);
             H5_FAILED();
@@ -1454,7 +1453,7 @@ test_derived_integer(void)
         printf("\n");
 
         if (fails_this_test >= max_fails) {
-            HDputs("    maximum failures reached, aborting test...");
+            puts("    maximum failures reached, aborting test...");
             goto error;
         }
     }
@@ -1664,14 +1663,14 @@ test_conv_int_1(const char *name, hid_t src, hid_t dst)
 
     /* Sanity checks */
     if (OTHER == src_type || OTHER == dst_type) {
-        HDsnprintf(str, sizeof(str), "Testing %s %s -> %s conversions", name, src_type_name, dst_type_name);
+        snprintf(str, sizeof(str), "Testing %s %s -> %s conversions", name, src_type_name, dst_type_name);
         printf("%-70s", str);
         H5_FAILED();
-        HDputs("    Unknown data type.");
+        puts("    Unknown data type.");
         goto error;
     }
     else {
-        HDsnprintf(str, sizeof(str), "Testing %s %s -> %s conversions", name, src_type_name, dst_type_name);
+        snprintf(str, sizeof(str), "Testing %s %s -> %s conversions", name, src_type_name, dst_type_name);
         printf("%-70s", str);
         fflush(stdout);
         fails_this_test = 0;
@@ -2532,8 +2531,8 @@ test_conv_int_1(const char *name, hid_t src, hid_t dst)
         }
 
         if (++fails_all_tests >= max_fails) {
-            HDputs("    maximum failures reached, aborting test...");
-            HDputs("    (dst is library's conversion output. ans is compiler's conversion output.)");
+            puts("    maximum failures reached, aborting test...");
+            puts("    (dst is library's conversion output. ans is compiler's conversion output.)");
             goto done;
         }
     }
@@ -2667,26 +2666,26 @@ my_isnan(dtype_t type, void *val)
             float x = 0.0;
 
             memcpy(&x, val, sizeof(float));
-            HDsnprintf(s, sizeof(s), "%g", (double)x);
+            snprintf(s, sizeof(s), "%g", (double)x);
         }
         else if (FLT_DOUBLE == type) {
             double x = 0.0;
 
             memcpy(&x, val, sizeof(double));
-            HDsnprintf(s, sizeof(s), "%g", x);
+            snprintf(s, sizeof(s), "%g", x);
 #if H5_SIZEOF_LONG_DOUBLE != H5_SIZEOF_DOUBLE
         }
         else if (FLT_LDOUBLE == type) {
             long double x = 0.0L;
 
             memcpy(&x, val, sizeof(long double));
-            HDsnprintf(s, sizeof(s), "%Lg", x);
+            snprintf(s, sizeof(s), "%Lg", x);
 #endif
         }
         else {
             return 0;
         }
-        if (HDstrstr(s, "NaN") || HDstrstr(s, "NAN") || HDstrstr(s, "nan"))
+        if (strstr(s, "NaN") || strstr(s, "NAN") || strstr(s, "nan"))
             retval = 1;
     }
 
@@ -2786,7 +2785,7 @@ test_conv_flt_1(const char *name, int run_test, hid_t src, hid_t dst)
     fflush(stdout);
     fflush(stderr);
     if ((child_pid = fork()) < 0) {
-        HDperror("fork");
+        perror("fork");
         return 1;
     }
     else if (child_pid > 0) {
@@ -2799,12 +2798,12 @@ test_conv_flt_1(const char *name, int run_test, hid_t src, hid_t dst)
             return WEXITSTATUS(status);
         }
         else if (WIFSIGNALED(status)) {
-            HDsnprintf(str, sizeof(str), "   Child caught signal %d.", WTERMSIG(status));
-            HDputs(str);
+            snprintf(str, sizeof(str), "   Child caught signal %d.", WTERMSIG(status));
+            puts(str);
             return 1; /*child exit after catching non-SIGFPE signal */
         }
         else {
-            HDputs("   Child didn't exit normally.");
+            puts("   Child didn't exit normally.");
             return 1;
         }
     }
@@ -2857,39 +2856,37 @@ test_conv_flt_1(const char *name, int run_test, hid_t src, hid_t dst)
 
     /* Sanity checks */
     if (sizeof(float) == sizeof(double))
-        HDputs("Sizeof(float)==sizeof(double) - some tests may not be sensible.");
+        puts("Sizeof(float)==sizeof(double) - some tests may not be sensible.");
     if (OTHER == src_type || OTHER == dst_type) {
-        if (!HDstrcmp(name, "noop"))
-            HDsnprintf(str, sizeof(str), "Testing %s %s -> %s conversions", name, src_type_name,
-                       dst_type_name);
+        if (!strcmp(name, "noop"))
+            snprintf(str, sizeof(str), "Testing %s %s -> %s conversions", name, src_type_name, dst_type_name);
         else if (run_test == TEST_SPECIAL)
-            HDsnprintf(str, sizeof(str), "Testing %s special %s -> %s conversions", name, src_type_name,
-                       dst_type_name);
+            snprintf(str, sizeof(str), "Testing %s special %s -> %s conversions", name, src_type_name,
+                     dst_type_name);
         else if (run_test == TEST_NORMAL)
-            HDsnprintf(str, sizeof(str), "Testing %s normalized %s -> %s conversions", name, src_type_name,
-                       dst_type_name);
+            snprintf(str, sizeof(str), "Testing %s normalized %s -> %s conversions", name, src_type_name,
+                     dst_type_name);
         else if (run_test == TEST_DENORM)
-            HDsnprintf(str, sizeof(str), "Testing %s denormalized %s -> %s conversions", name, src_type_name,
-                       dst_type_name);
+            snprintf(str, sizeof(str), "Testing %s denormalized %s -> %s conversions", name, src_type_name,
+                     dst_type_name);
 
         printf("%-70s", str);
         H5_FAILED();
-        HDputs("    Unknown data type.");
+        puts("    Unknown data type.");
         goto error;
     }
     else {
-        if (!HDstrcmp(name, "noop"))
-            HDsnprintf(str, sizeof(str), "Testing %s %s -> %s conversions", name, src_type_name,
-                       dst_type_name);
+        if (!strcmp(name, "noop"))
+            snprintf(str, sizeof(str), "Testing %s %s -> %s conversions", name, src_type_name, dst_type_name);
         else if (run_test == TEST_SPECIAL)
-            HDsnprintf(str, sizeof(str), "Testing %s special %s -> %s conversions", name, src_type_name,
-                       dst_type_name);
+            snprintf(str, sizeof(str), "Testing %s special %s -> %s conversions", name, src_type_name,
+                     dst_type_name);
         else if (run_test == TEST_NORMAL)
-            HDsnprintf(str, sizeof(str), "Testing %s normalized %s -> %s conversions", name, src_type_name,
-                       dst_type_name);
+            snprintf(str, sizeof(str), "Testing %s normalized %s -> %s conversions", name, src_type_name,
+                     dst_type_name);
         else if (run_test == TEST_DENORM)
-            HDsnprintf(str, sizeof(str), "Testing %s denormalized %s -> %s conversions", name, src_type_name,
-                       dst_type_name);
+            snprintf(str, sizeof(str), "Testing %s denormalized %s -> %s conversions", name, src_type_name,
+                     dst_type_name);
 
         printf("%-70s", str);
         fflush(stdout);
@@ -3244,10 +3241,10 @@ test_conv_flt_1(const char *name, int run_test, hid_t src, hid_t dst)
          * denormalized or special values, print out warning message.*/
         if (++fails_all_tests >= max_fails) {
             if (run_test == TEST_NORMAL)
-                HDputs("    maximum failures reached, aborting test...");
+                puts("    maximum failures reached, aborting test...");
             else if (run_test == TEST_DENORM || run_test == TEST_SPECIAL)
-                HDputs("    maximum warnings reached, aborting test...");
-            HDputs("    (dst is library's conversion output. ans is compiler's conversion output.)");
+                puts("    maximum warnings reached, aborting test...");
+            puts("    (dst is library's conversion output. ans is compiler's conversion output.)");
 
             goto done;
         }
@@ -3496,10 +3493,10 @@ test_conv_int_fp(const char *name, int run_test, hid_t src, hid_t dst)
 
     /* Sanity checks */
     if (OTHER == src_type || OTHER == dst_type) {
-        HDsnprintf(str, sizeof(str), "Testing %s %s -> %s conversions", name, src_type_name, dst_type_name);
+        snprintf(str, sizeof(str), "Testing %s %s -> %s conversions", name, src_type_name, dst_type_name);
         printf("%-70s", str);
         H5_FAILED();
-        HDputs("    Unknown data type.");
+        puts("    Unknown data type.");
         goto error;
     }
 
@@ -3507,10 +3504,10 @@ test_conv_int_fp(const char *name, int run_test, hid_t src, hid_t dst)
          INT_INT == src_type || INT_UINT == src_type || INT_LONG == src_type || INT_ULONG == src_type ||
          INT_LLONG == src_type || INT_ULLONG == src_type) &&
         (FLT_FLOAT != dst_type && FLT_DOUBLE != dst_type && FLT_LDOUBLE != dst_type)) {
-        HDsnprintf(str, sizeof(str), "Testing %s %s -> %s conversions", name, src_type_name, dst_type_name);
+        snprintf(str, sizeof(str), "Testing %s %s -> %s conversions", name, src_type_name, dst_type_name);
         printf("%-70s", str);
         H5_FAILED();
-        HDputs("    1. Not an integer-float conversion.");
+        puts("    1. Not an integer-float conversion.");
         goto error;
     }
 
@@ -3518,31 +3515,31 @@ test_conv_int_fp(const char *name, int run_test, hid_t src, hid_t dst)
         (INT_SCHAR != dst_type && INT_UCHAR != dst_type && INT_SHORT != dst_type && INT_USHORT != dst_type &&
          INT_INT != dst_type && INT_UINT != dst_type && INT_LONG != dst_type && INT_ULONG != dst_type &&
          INT_LLONG != dst_type && INT_ULLONG != dst_type)) {
-        HDsnprintf(str, sizeof(str), "Testing %s %s -> %s conversions", name, src_type_name, dst_type_name);
+        snprintf(str, sizeof(str), "Testing %s %s -> %s conversions", name, src_type_name, dst_type_name);
         printf("%-70s", str);
         H5_FAILED();
-        HDputs("    2. Not a float-integer conversion.");
+        puts("    2. Not a float-integer conversion.");
         goto error;
     }
 
     if (INT_SCHAR == src_type || INT_UCHAR == src_type || INT_SHORT == src_type || INT_USHORT == src_type ||
         INT_INT == src_type || INT_UINT == src_type || INT_LONG == src_type || INT_ULONG == src_type ||
         INT_LLONG == src_type || INT_ULLONG == src_type) {
-        HDsnprintf(str, sizeof(str), "Testing %s %s -> %s conversions", name, src_type_name, dst_type_name);
+        snprintf(str, sizeof(str), "Testing %s %s -> %s conversions", name, src_type_name, dst_type_name);
         printf("%-70s", str);
         fflush(stdout);
         fails_this_test = 0;
     }
     else {
         if (run_test == TEST_NORMAL)
-            HDsnprintf(str, sizeof(str), "Testing %s normalized %s -> %s conversions", name, src_type_name,
-                       dst_type_name);
+            snprintf(str, sizeof(str), "Testing %s normalized %s -> %s conversions", name, src_type_name,
+                     dst_type_name);
         else if (run_test == TEST_DENORM)
-            HDsnprintf(str, sizeof(str), "Testing %s denormalized %s -> %s conversions", name, src_type_name,
-                       dst_type_name);
+            snprintf(str, sizeof(str), "Testing %s denormalized %s -> %s conversions", name, src_type_name,
+                     dst_type_name);
         else
-            HDsnprintf(str, sizeof(str), "Testing %s special %s -> %s conversions", name, src_type_name,
-                       dst_type_name);
+            snprintf(str, sizeof(str), "Testing %s special %s -> %s conversions", name, src_type_name,
+                     dst_type_name);
         printf("%-70s", str);
         fflush(stdout);
         fails_this_test = 0;
@@ -4461,10 +4458,10 @@ test_conv_int_fp(const char *name, int run_test, hid_t src, hid_t dst)
          * denormalized or special values, print out warning message.*/
         if (++fails_all_tests >= max_fails) {
             if (run_test == TEST_NORMAL)
-                HDputs("    maximum failures reached, aborting test...");
+                puts("    maximum failures reached, aborting test...");
             else if (run_test == TEST_DENORM || run_test == TEST_SPECIAL)
-                HDputs("    maximum warnings reached, aborting test...");
-            HDputs("    (dst is library's conversion output. ans is compiler's conversion output.)");
+                puts("    maximum warnings reached, aborting test...");
+            puts("    (dst is library's conversion output. ans is compiler's conversion output.)");
 
             goto done;
         }
@@ -4771,7 +4768,7 @@ run_fp_tests(const char *name)
 {
     int nerrors = 0;
 
-    if (!HDstrcmp(name, "noop")) {
+    if (!strcmp(name, "noop")) {
         nerrors += test_conv_flt_1("noop", TEST_NOOP, H5T_NATIVE_FLOAT, H5T_NATIVE_FLOAT);
         nerrors += test_conv_flt_1("noop", TEST_NOOP, H5T_NATIVE_DOUBLE, H5T_NATIVE_DOUBLE);
         nerrors += test_conv_flt_1("noop", TEST_NOOP, H5T_NATIVE_LDOUBLE, H5T_NATIVE_LDOUBLE);
@@ -4800,11 +4797,11 @@ run_fp_tests(const char *name)
     {
         char str[256]; /*string        */
 
-        HDsnprintf(str, sizeof(str), "Testing %s denormalized %s -> %s conversions", name, "long double",
-                   "float");
+        snprintf(str, sizeof(str), "Testing %s denormalized %s -> %s conversions", name, "long double",
+                 "float");
         printf("%-70s", str);
         SKIPPED();
-        HDputs("    Test skipped due to the conversion problem on IBM ppc64le cpu.");
+        puts("    Test skipped due to the conversion problem on IBM ppc64le cpu.");
     }
 #endif
 
@@ -4824,11 +4821,11 @@ run_fp_tests(const char *name)
     {
         char str[256]; /*string        */
 
-        HDsnprintf(str, sizeof(str), "Testing %s special %s -> %s conversions", name, "long double",
-                   "float or double");
+        snprintf(str, sizeof(str), "Testing %s special %s -> %s conversions", name, "long double",
+                 "float or double");
         printf("%-70s", str);
         SKIPPED();
-        HDputs("    Test skipped due to the conversion problem on IBM ppc64le cpu.");
+        puts("    Test skipped due to the conversion problem on IBM ppc64le cpu.");
     }
 #endif
 #endif
@@ -4900,11 +4897,10 @@ run_int_fp_conv(const char *name)
     {
         char str[256]; /*string        */
 
-        HDsnprintf(str, sizeof(str), "Testing %s %s -> %s conversions", name, "(unsigned) long",
-                   "long double");
+        snprintf(str, sizeof(str), "Testing %s %s -> %s conversions", name, "(unsigned) long", "long double");
         printf("%-70s", str);
         SKIPPED();
-        HDputs("    Test skipped due to the special algorithm of hardware conversion.");
+        puts("    Test skipped due to the special algorithm of hardware conversion.");
     }
 #endif
 #endif /* H5_SIZEOF_LONG!=H5_SIZEOF_INT */
@@ -4915,10 +4911,10 @@ run_int_fp_conv(const char *name)
     {
         char str[256]; /*hello string        */
 
-        HDsnprintf(str, sizeof(str), "Testing %s %s -> %s conversions", name, "long long", "long double");
+        snprintf(str, sizeof(str), "Testing %s %s -> %s conversions", name, "long long", "long double");
         printf("%-70s", str);
         SKIPPED();
-        HDputs("    Test skipped due to compiler error in handling conversion.");
+        puts("    Test skipped due to compiler error in handling conversion.");
     }
 #endif /* H5_LLONG_TO_LDOUBLE_CORRECT */
 #if H5_LLONG_TO_LDOUBLE_CORRECT
@@ -4927,11 +4923,11 @@ run_int_fp_conv(const char *name)
     {
         char str[256]; /*hello string        */
 
-        HDsnprintf(str, sizeof(str), "Testing %s %s -> %s conversions", name, "unsigned long long",
-                   "long double");
+        snprintf(str, sizeof(str), "Testing %s %s -> %s conversions", name, "unsigned long long",
+                 "long double");
         printf("%-70s", str);
         SKIPPED();
-        HDputs("    Test skipped due to compiler not handling conversion.");
+        puts("    Test skipped due to compiler not handling conversion.");
     }
 #endif /* H5_LLONG_TO_LDOUBLE_CORRECT */
 #endif
@@ -4984,7 +4980,7 @@ run_fp_int_conv(const char *name)
 #endif
 
 #if H5_SIZEOF_LONG_LONG != H5_SIZEOF_LONG
-        if (!HDstrcmp(name, "hw")) { /* Hardware conversion */
+        if (!strcmp(name, "hw")) { /* Hardware conversion */
             nerrors += test_conv_int_fp(name, test_values, H5T_NATIVE_FLOAT, H5T_NATIVE_LLONG);
             nerrors += test_conv_int_fp(name, test_values, H5T_NATIVE_DOUBLE, H5T_NATIVE_LLONG);
         }
@@ -5016,11 +5012,11 @@ run_fp_int_conv(const char *name)
 #else
             char str[256]; /*string        */
 
-            HDsnprintf(str, sizeof(str), "Testing %s special %s -> %s conversions", name, "long double",
-                       "signed and unsigned char, short, int, long");
+            snprintf(str, sizeof(str), "Testing %s special %s -> %s conversions", name, "long double",
+                     "signed and unsigned char, short, int, long");
             printf("%-70s", str);
             SKIPPED();
-            HDputs("    Test skipped due to the conversion problem on IBM ppc64le cpu.");
+            puts("    Test skipped due to the conversion problem on IBM ppc64le cpu.");
 #endif
         }
 #if H5_SIZEOF_LONG != H5_SIZEOF_INT
@@ -5039,11 +5035,11 @@ run_fp_int_conv(const char *name)
         {
             char str[256]; /*string        */
 
-            HDsnprintf(str, sizeof(str), "Testing %s %s -> %s conversions", name, "long double",
-                       "(unsigned) long");
+            snprintf(str, sizeof(str), "Testing %s %s -> %s conversions", name, "long double",
+                     "(unsigned) long");
             printf("%-70s", str);
             SKIPPED();
-            HDputs("    Test skipped due to the special algorithm of hardware conversion.");
+            puts("    Test skipped due to the special algorithm of hardware conversion.");
         }
 #endif
 #endif /*H5_SIZEOF_LONG!=H5_SIZEOF_INT */
@@ -5055,10 +5051,10 @@ run_fp_int_conv(const char *name)
         {
             char str[256]; /*string        */
 
-            HDsnprintf(str, sizeof(str), "Testing %s %s -> %s conversions", name, "long double", "long long");
+            snprintf(str, sizeof(str), "Testing %s %s -> %s conversions", name, "long double", "long long");
             printf("%-70s", str);
             SKIPPED();
-            HDputs("    Test skipped due to hardware conversion error.");
+            puts("    Test skipped due to hardware conversion error.");
         }
 #endif /*H5_LDOUBLE_TO_LLONG_ACCURATE*/
 #if defined(H5_LDOUBLE_TO_LLONG_ACCURATE)
@@ -5067,11 +5063,11 @@ run_fp_int_conv(const char *name)
         {
             char str[256]; /*string        */
 
-            HDsnprintf(str, sizeof(str), "Testing %s %s -> %s conversions", name, "long double",
-                       "unsigned long long");
+            snprintf(str, sizeof(str), "Testing %s %s -> %s conversions", name, "long double",
+                     "unsigned long long");
             printf("%-70s", str);
             SKIPPED();
-            HDputs("    Test skipped due to hardware conversion error.");
+            puts("    Test skipped due to hardware conversion error.");
         }
 #endif /*H5_LDOUBLE_TO_LLONG_ACCURATE*/
 #endif

--- a/test/dtransform.c
+++ b/test/dtransform.c
@@ -857,12 +857,12 @@ test_getset(const hid_t dxpl_id_c_to_f)
 
     TESTING("H5Pget_data_transform");
 
-    if (NULL == (ptrgetTest = (char *)malloc(HDstrlen(simple) + 1)))
+    if (NULL == (ptrgetTest = (char *)malloc(strlen(simple) + 1)))
         TEST_ERROR;
 
-    if (H5Pget_data_transform(dxpl_id_c_to_f, ptrgetTest, HDstrlen(c_to_f) + 1) < 0)
+    if (H5Pget_data_transform(dxpl_id_c_to_f, ptrgetTest, strlen(c_to_f) + 1) < 0)
         TEST_ERROR;
-    if (HDstrcmp(c_to_f, ptrgetTest) != 0)
+    if (strcmp(c_to_f, ptrgetTest) != 0)
         FAIL_PUTS_ERROR("    ERROR: Data transform failed to match what was set\n");
 
     PASSED();
@@ -888,11 +888,11 @@ test_getset(const hid_t dxpl_id_c_to_f)
 
     TESTING("H5Pget_data_transform, after resetting transform property");
 
-    if (NULL == (ptrgetTest = (char *)calloc((size_t)1, HDstrlen(simple) + 1)))
+    if (NULL == (ptrgetTest = (char *)calloc((size_t)1, strlen(simple) + 1)))
         TEST_ERROR;
-    if (H5Pget_data_transform(dxpl_id_c_to_f, ptrgetTest, HDstrlen(simple) + 1) < 0)
+    if (H5Pget_data_transform(dxpl_id_c_to_f, ptrgetTest, strlen(simple) + 1) < 0)
         TEST_ERROR;
-    if (HDstrcmp(simple, ptrgetTest) != 0)
+    if (strcmp(simple, ptrgetTest) != 0)
         FAIL_PUTS_ERROR("    ERROR: Data transform failed to match what was set\n");
 
     PASSED();
@@ -919,7 +919,7 @@ test_set(void)
 
     TESTING("H5Pget_data_transform (get before set)");
 
-    if (NULL == (ptrgetTest = (char *)malloc(HDstrlen(str) + 1)))
+    if (NULL == (ptrgetTest = (char *)malloc(strlen(str) + 1)))
         TEST_ERROR;
 
     if ((dxpl_id = H5Pcreate(H5P_DATASET_XFER)) < 0)
@@ -930,7 +930,7 @@ test_set(void)
 
     H5Eset_auto2(H5E_DEFAULT, NULL, NULL);
 
-    if (H5Pget_data_transform(dxpl_id, ptrgetTest, HDstrlen(str) + 1) < 0)
+    if (H5Pget_data_transform(dxpl_id, ptrgetTest, strlen(str) + 1) < 0)
         PASSED();
     else
         FAIL_PUTS_ERROR("    ERROR: Data transform get before set succeeded (it shouldn't have)\n");

--- a/test/dtypes.c
+++ b/test/dtypes.c
@@ -309,7 +309,7 @@ test_copy(void)
     H5E_END_TRY
     if (status >= 0) {
         H5_FAILED();
-        HDputs("    Should not be able to close a predefined type!");
+        puts("    Should not be able to close a predefined type!");
         goto error;
     }
 
@@ -1850,7 +1850,7 @@ test_compound_9(void)
         goto error;
     } /* end if */
 
-    if (rdata.i1 != wdata.i1 || rdata.i2 != wdata.i2 || HDstrcmp(rdata.str, wdata.str) != 0) {
+    if (rdata.i1 != wdata.i1 || rdata.i2 != wdata.i2 || strcmp(rdata.str, wdata.str) != 0) {
         H5_FAILED();
         AT();
         printf("incorrect read data\n");
@@ -1924,7 +1924,7 @@ test_compound_9(void)
         goto error;
     } /* end if */
 
-    if (rdata.i1 != wdata.i1 || rdata.i2 != wdata.i2 || HDstrcmp(rdata.str, wdata.str) != 0) {
+    if (rdata.i1 != wdata.i1 || rdata.i2 != wdata.i2 || strcmp(rdata.str, wdata.str) != 0) {
         H5_FAILED();
         AT();
         printf("incorrect read data\n");
@@ -1998,12 +1998,12 @@ test_compound_10(void)
 
     for (i = 0; i < ARRAY_DIM; i++) {
         wdata[i].i1     = i * 10 + i;
-        wdata[i].str    = HDstrdup("C string A");
+        wdata[i].str    = strdup("C string A");
         wdata[i].str[9] = (char)(wdata[i].str[9] + i);
         wdata[i].i2     = i * 1000 + i * 10;
 
-        wdata[i].text.p = (void *)HDstrdup("variable-length text A\0");
-        len = wdata[i].text.len              = HDstrlen((char *)wdata[i].text.p) + 1;
+        wdata[i].text.p = (void *)strdup("variable-length text A\0");
+        len = wdata[i].text.len              = strlen((char *)wdata[i].text.p) + 1;
         ((char *)(wdata[i].text.p))[len - 2] = (char)(((char *)(wdata[i].text.p))[len - 2] + i);
         ((char *)(wdata[i].text.p))[len - 1] = '\0';
     }
@@ -2109,7 +2109,7 @@ test_compound_10(void)
 
     for (i = 0; i < ARRAY_DIM; i++) {
         if (rdata[i].i1 != wdata[i].i1 || rdata[i].i2 != wdata[i].i2 ||
-            HDstrcmp(rdata[i].str, wdata[i].str) != 0) {
+            strcmp(rdata[i].str, wdata[i].str) != 0) {
             H5_FAILED();
             AT();
             printf("incorrect read data\n");
@@ -2125,7 +2125,7 @@ test_compound_10(void)
 
         t1 = rdata[i].text.p;
         t2 = wdata[i].text.p;
-        if (HDstrcmp((char *)t1, (char *)t2) != 0) {
+        if (strcmp((char *)t1, (char *)t2) != 0) {
             H5_FAILED();
             AT();
             printf("incorrect VL read data\n");
@@ -2264,7 +2264,7 @@ test_compound_11(void)
         ((big_t *)buf)[u].s1 = (char *)malloc((size_t)32);
         if (!((big_t *)buf)[u].s1)
             TEST_ERROR;
-        HDsnprintf(((big_t *)buf)[u].s1, 32, "%u", (unsigned)u);
+        snprintf(((big_t *)buf)[u].s1, 32, "%u", (unsigned)u);
     } /* end for */
 
     /* Make copy of buffer before conversion */
@@ -2307,7 +2307,7 @@ test_compound_11(void)
                    ((big_t *)buf_orig)[u].s1, (unsigned)u, ((little_t *)buf)[u].s1);
             TEST_ERROR;
         } /* end if */
-        else if (HDstrcmp(((big_t *)buf_orig)[u].s1, ((little_t *)buf)[u].s1) != 0) {
+        else if (strcmp(((big_t *)buf_orig)[u].s1, ((little_t *)buf)[u].s1) != 0) {
             printf("Error, line #%d: buf_orig[%u].s1=%s, buf[%u].s1=%s\n", __LINE__, (unsigned)u,
                    ((big_t *)buf_orig)[u].s1, (unsigned)u, ((little_t *)buf)[u].s1);
             TEST_ERROR;
@@ -2358,7 +2358,7 @@ test_compound_11(void)
                    ((big_t *)buf_orig)[u].s1, (unsigned)u, ((little_t *)buf)[u].s1);
             TEST_ERROR;
         } /* end if */
-        else if (HDstrcmp(((big_t *)buf_orig)[u].s1, ((little_t *)buf)[u].s1) != 0) {
+        else if (strcmp(((big_t *)buf_orig)[u].s1, ((little_t *)buf)[u].s1) != 0) {
             printf("Error, line #%d: buf_orig[%u].s1=%s, buf[%u].s1=%s\n", __LINE__, (unsigned)u,
                    ((big_t *)buf_orig)[u].s1, (unsigned)u, ((little_t *)buf)[u].s1);
             TEST_ERROR;
@@ -2399,7 +2399,7 @@ test_compound_11(void)
                    ((big_t *)buf_orig)[u].s1, (unsigned)u, ((little_t *)buf)[u].s1);
             TEST_ERROR;
         } /* end if */
-        else if (HDstrcmp(((big_t *)buf_orig)[u].s1, ((little_t *)buf)[u].s1) != 0) {
+        else if (strcmp(((big_t *)buf_orig)[u].s1, ((little_t *)buf)[u].s1) != 0) {
             printf("Error, line #%d: buf_orig[%u].s1=%s, buf[%u].s1=%s\n", __LINE__, (unsigned)u,
                    ((big_t *)buf_orig)[u].s1, (unsigned)u, ((little_t *)buf)[u].s1);
             TEST_ERROR;
@@ -2525,7 +2525,7 @@ test_compound_12(void)
     H5E_END_TRY
     if (ret >= 0) {
         H5_FAILED();
-        HDputs("  Tries to cut off the last member. Should have failed.");
+        puts("  Tries to cut off the last member. Should have failed.");
         goto error;
     }
 
@@ -2971,14 +2971,14 @@ test_compound_14(void)
         goto error;
     } /* end if */
 
-    if (rdata1.c1 != wdata1.c1 || rdata1.c2 != wdata1.c2 || HDstrcmp(rdata1.str, wdata1.str) != 0) {
+    if (rdata1.c1 != wdata1.c1 || rdata1.c2 != wdata1.c2 || strcmp(rdata1.str, wdata1.str) != 0) {
         H5_FAILED();
         AT();
         printf("incorrect read data\n");
         goto error;
     } /* end if */
 
-    if (rdata2.c1 != wdata2.c1 || rdata2.c2 != wdata2.c2 || HDstrcmp(rdata2.str, wdata2.str) != 0 ||
+    if (rdata2.c1 != wdata2.c1 || rdata2.c2 != wdata2.c2 || strcmp(rdata2.str, wdata2.str) != 0 ||
         rdata2.l1 != wdata2.l1 || rdata2.l2 != wdata2.l2 || rdata2.l3 != wdata2.l3 ||
         rdata2.l4 != wdata2.l4) {
         H5_FAILED();
@@ -3069,14 +3069,14 @@ test_compound_14(void)
         goto error;
     } /* end if */
 
-    if (rdata1.c1 != wdata1.c1 || rdata1.c2 != wdata1.c2 || HDstrcmp(rdata1.str, wdata1.str) != 0) {
+    if (rdata1.c1 != wdata1.c1 || rdata1.c2 != wdata1.c2 || strcmp(rdata1.str, wdata1.str) != 0) {
         H5_FAILED();
         AT();
         printf("incorrect read data\n");
         goto error;
     } /* end if */
 
-    if (rdata2.c1 != wdata2.c1 || rdata2.c2 != wdata2.c2 || HDstrcmp(rdata2.str, wdata2.str) != 0 ||
+    if (rdata2.c1 != wdata2.c1 || rdata2.c2 != wdata2.c2 || strcmp(rdata2.str, wdata2.str) != 0 ||
         rdata2.l1 != wdata2.l1 || rdata2.l2 != wdata2.l2 || rdata2.l3 != wdata2.l3 ||
         rdata2.l4 != wdata2.l4) {
         H5_FAILED();
@@ -4028,7 +4028,7 @@ test_query(void)
         printf("Can't get name for enum member\n");
         goto error;
     } /* end if */
-    if (HDstrcmp("YELLOW", enum_name) != 0) {
+    if (strcmp("YELLOW", enum_name) != 0) {
         H5_FAILED();
         printf("Incorrect name for enum member\n");
         goto error;
@@ -4104,7 +4104,7 @@ test_transient(hid_t fapl)
     H5E_END_TRY
     if (status >= 0) {
         H5_FAILED();
-        HDputs("    Predefined types should not be modifiable!");
+        puts("    Predefined types should not be modifiable!");
         goto error;
     }
     H5E_BEGIN_TRY
@@ -4114,7 +4114,7 @@ test_transient(hid_t fapl)
     H5E_END_TRY
     if (status >= 0) {
         H5_FAILED();
-        HDputs("    Predefined types should not be closable!");
+        puts("    Predefined types should not be closable!");
         goto error;
     }
 
@@ -4132,7 +4132,7 @@ test_transient(hid_t fapl)
     H5E_END_TRY
     if (ret_id >= 0) {
         H5_FAILED();
-        HDputs("    Attributes should not be allowed for transient types!");
+        puts("    Attributes should not be allowed for transient types!");
         goto error;
     }
 
@@ -4154,7 +4154,7 @@ test_transient(hid_t fapl)
     H5E_END_TRY
     if (status >= 0) {
         H5_FAILED();
-        HDputs("    Dataset datatypes should not be modifiable!");
+        puts("    Dataset datatypes should not be modifiable!");
         goto error;
     }
     if (H5Tclose(t2) < 0)
@@ -4177,7 +4177,7 @@ test_transient(hid_t fapl)
     H5E_END_TRY
     if (status >= 0) {
         H5_FAILED();
-        HDputs("    Dataset datatypes should not be modifiable!");
+        puts("    Dataset datatypes should not be modifiable!");
         goto error;
     }
     if (H5Tclose(t2) < 0)
@@ -4259,7 +4259,7 @@ test_named(hid_t fapl)
     H5E_END_TRY
     if (status >= 0) {
         H5_FAILED();
-        HDputs("    Predefined types should not be committable!");
+        puts("    Predefined types should not be committable!");
         goto error;
     }
 
@@ -4272,7 +4272,7 @@ test_named(hid_t fapl)
         goto error;
     if (0 == status) {
         H5_FAILED();
-        HDputs("    H5Tcommitted() returned false!");
+        puts("    H5Tcommitted() returned false!");
         goto error;
     }
 
@@ -4284,7 +4284,7 @@ test_named(hid_t fapl)
     H5E_END_TRY
     if (status >= 0) {
         H5_FAILED();
-        HDputs("    Committed type is not constant!");
+        puts("    Committed type is not constant!");
         goto error;
     }
 
@@ -4297,7 +4297,7 @@ test_named(hid_t fapl)
     H5E_END_TRY
     if (status >= 0) {
         H5_FAILED();
-        HDputs("    Committed types should not be recommitted!");
+        puts("    Committed types should not be recommitted!");
         goto error;
     }
 
@@ -4322,7 +4322,7 @@ test_named(hid_t fapl)
         goto error;
     if (status) {
         H5_FAILED();
-        HDputs("    Copying a named type should result in a transient type!");
+        puts("    Copying a named type should result in a transient type!");
         goto error;
     }
     if (H5Tset_precision(t2, (size_t)256) < 0)
@@ -4341,7 +4341,7 @@ test_named(hid_t fapl)
         goto error;
     if (!status) {
         H5_FAILED();
-        HDputs("    Opened named types should be named types!");
+        puts("    Opened named types should be named types!");
         goto error;
     }
 
@@ -4356,7 +4356,7 @@ test_named(hid_t fapl)
         goto error;
     if (!status) {
         H5_FAILED();
-        HDputs("    Dataset type should be a named type!");
+        puts("    Dataset type should be a named type!");
         goto error;
     }
 
@@ -4375,7 +4375,7 @@ test_named(hid_t fapl)
         goto error;
     if (!status) {
         H5_FAILED();
-        HDputs("    Dataset type should be a named type!");
+        puts("    Dataset type should be a named type!");
         goto error;
     }
 
@@ -4401,7 +4401,7 @@ test_named(hid_t fapl)
         goto error;
     if (!status) {
         H5_FAILED();
-        HDputs("    Dataset type should be a named type!");
+        puts("    Dataset type should be a named type!");
         goto error;
     }
     if (H5Tclose(t2) < 0)
@@ -4429,7 +4429,7 @@ test_named(hid_t fapl)
         goto error;
     if (status) {
         H5_FAILED();
-        HDputs("    Copied type should not be a named type!");
+        puts("    Copied type should not be a named type!");
         goto error;
     }
     if ((dset = H5Dcreate2(file, "dset3", t2, space, H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT)) < 0)
@@ -4440,7 +4440,7 @@ test_named(hid_t fapl)
         goto error;
     if (status) {
         H5_FAILED();
-        HDputs("    Datatype from dataset using copied type should not be a named type!");
+        puts("    Datatype from dataset using copied type should not be a named type!");
         goto error;
     }
     if (H5Tclose(t3) < 0)
@@ -4471,7 +4471,7 @@ test_named(hid_t fapl)
     H5E_END_TRY
     if (status >= 0) {
         H5_FAILED();
-        HDputs("    Types should not be committable to a read-only file!");
+        puts("    Types should not be committable to a read-only file!");
         goto error;
     }
 
@@ -4485,7 +4485,7 @@ test_named(hid_t fapl)
     H5E_END_TRY
     if (status >= 0) {
         H5_FAILED();
-        HDputs("    Types should not be committable to a read-only file!");
+        puts("    Types should not be committable to a read-only file!");
         goto error;
     }
 
@@ -4653,14 +4653,14 @@ test_conv_str_1(void)
         goto error;
     if (memcmp(buf, "abcd\0abcd\0abcdefghi\0", (size_t)20) != 0) {
         H5_FAILED();
-        HDputs("    Truncated C-string test failed");
+        puts("    Truncated C-string test failed");
         goto error;
     }
     if (H5Tconvert(dst_type, src_type, (size_t)2, buf, NULL, H5P_DEFAULT) < 0)
         goto error;
     if (memcmp(buf, "abcd\0\0\0\0\0\0abcd\0\0\0\0\0\0", (size_t)20) != 0) {
         H5_FAILED();
-        HDputs("    Extended C-string test failed");
+        puts("    Extended C-string test failed");
         goto error;
     }
     free(buf);
@@ -4684,14 +4684,14 @@ test_conv_str_1(void)
         goto error;
     if (memcmp(buf, "abcdeabcdeabcdefghij", (size_t)20) != 0) {
         H5_FAILED();
-        HDputs("    Truncated C buffer test failed");
+        puts("    Truncated C buffer test failed");
         goto error;
     }
     if (H5Tconvert(dst_type, src_type, (size_t)2, buf, NULL, H5P_DEFAULT) < 0)
         goto error;
     if (memcmp(buf, "abcde\0\0\0\0\0abcde\0\0\0\0\0", (size_t)20) != 0) {
         H5_FAILED();
-        HDputs("    Extended C buffer test failed");
+        puts("    Extended C buffer test failed");
         goto error;
     }
     free(buf);
@@ -4715,14 +4715,14 @@ test_conv_str_1(void)
         goto error;
     if (memcmp(buf, "abcdeabcdeabcdefghij", (size_t)20) != 0) {
         H5_FAILED();
-        HDputs("    Truncated Fortran-string test failed");
+        puts("    Truncated Fortran-string test failed");
         goto error;
     }
     if (H5Tconvert(dst_type, src_type, (size_t)2, buf, NULL, H5P_DEFAULT) < 0)
         goto error;
     if (memcmp(buf, "abcde     abcde     ", (size_t)20) != 0) {
         H5_FAILED();
-        HDputs("    Extended Fortran-string test failed");
+        puts("    Extended Fortran-string test failed");
         goto error;
     }
     free(buf);
@@ -4749,7 +4749,7 @@ test_conv_str_1(void)
         goto error;
     if (memcmp(buf, "abcdefghijabcdefghij", (size_t)20) != 0) {
         H5_FAILED();
-        HDputs("    Non-terminated string test 1");
+        puts("    Non-terminated string test 1");
         goto error;
     }
     H5Tclose(dst_type);
@@ -4760,7 +4760,7 @@ test_conv_str_1(void)
         goto error;
     if (memcmp(buf, "abcd\0abcd\0abcdefghij", (size_t)20) != 0) {
         H5_FAILED();
-        HDputs("    Non-terminated string test 2");
+        puts("    Non-terminated string test 2");
         goto error;
     }
     memcpy(buf, "abcdeabcdexxxxxxxxxx", (size_t)20);
@@ -4768,7 +4768,7 @@ test_conv_str_1(void)
         goto error;
     if (memcmp(buf, "abcde\0\0\0\0\0abcde\0\0\0\0\0", (size_t)20) != 0) {
         H5_FAILED();
-        HDputs("    Non-terminated string test 2");
+        puts("    Non-terminated string test 2");
         goto error;
     }
     free(buf);
@@ -4792,14 +4792,14 @@ test_conv_str_1(void)
         goto error;
     if (memcmp(buf, "abcdefghi abcdefghi ", (size_t)20) != 0) {
         H5_FAILED();
-        HDputs("    C string to Fortran test 1");
+        puts("    C string to Fortran test 1");
         goto error;
     }
     if (H5Tconvert(dst_type, src_type, (size_t)2, buf, NULL, H5P_DEFAULT) < 0)
         goto error;
     if (memcmp(buf, "abcdefghi\0abcdefghi\0", (size_t)20) != 0) {
         H5_FAILED();
-        HDputs("    Fortran to C string test 1");
+        puts("    Fortran to C string test 1");
         goto error;
     }
     if (H5Tclose(dst_type) < 0)
@@ -4811,14 +4811,14 @@ test_conv_str_1(void)
         goto error;
     if (memcmp(buf, "abcdeabcdeabcdefgh\0\0", (size_t)20) != 0) {
         H5_FAILED();
-        HDputs("    C string to Fortran test 2");
+        puts("    C string to Fortran test 2");
         goto error;
     }
     if (H5Tconvert(dst_type, src_type, (size_t)2, buf, NULL, H5P_DEFAULT) < 0)
         goto error;
     if (memcmp(buf, "abcde\0\0\0\0\0abcde\0\0\0\0\0", (size_t)20) != 0) {
         H5_FAILED();
-        HDputs("    Fortran to C string test 2");
+        puts("    Fortran to C string test 2");
         goto error;
     }
     if (H5Tclose(src_type) < 0)
@@ -4834,14 +4834,14 @@ test_conv_str_1(void)
         goto error;
     if (memcmp(buf, "abcd      abcd      ", (size_t)20) != 0) {
         H5_FAILED();
-        HDputs("    C string to Fortran test 3");
+        puts("    C string to Fortran test 3");
         goto error;
     }
     if (H5Tconvert(dst_type, src_type, (size_t)2, buf, NULL, H5P_DEFAULT) < 0)
         goto error;
     if (memcmp(buf, "abcd\0abcd\0abcd      ", (size_t)20) != 0) {
         H5_FAILED();
-        HDputs("    Fortran to C string test 3");
+        puts("    Fortran to C string test 3");
         goto error;
     }
     free(buf);
@@ -4865,14 +4865,14 @@ test_conv_str_1(void)
         goto error;
     if (memcmp(buf, "abcdefghijabcdefghij", (size_t)20) != 0) {
         H5_FAILED();
-        HDputs("    C buffer to Fortran test 1");
+        puts("    C buffer to Fortran test 1");
         goto error;
     }
     if (H5Tconvert(dst_type, src_type, (size_t)2, buf, NULL, H5P_DEFAULT) < 0)
         goto error;
     if (memcmp(buf, "abcdefghijabcdefghij", (size_t)20) != 0) {
         H5_FAILED();
-        HDputs("    Fortran to C buffer test 1");
+        puts("    Fortran to C buffer test 1");
         goto error;
     }
     if (H5Tclose(dst_type) < 0)
@@ -4884,14 +4884,14 @@ test_conv_str_1(void)
         goto error;
     if (memcmp(buf, "abcdeabcdeabcdefgh\0\0", (size_t)20) != 0) {
         H5_FAILED();
-        HDputs("    C buffer to Fortran test 2");
+        puts("    C buffer to Fortran test 2");
         goto error;
     }
     if (H5Tconvert(dst_type, src_type, (size_t)2, buf, NULL, H5P_DEFAULT) < 0)
         goto error;
     if (memcmp(buf, "abcde\0\0\0\0\0abcde\0\0\0\0\0", (size_t)20) != 0) {
         H5_FAILED();
-        HDputs("    Fortran to C buffer test 2");
+        puts("    Fortran to C buffer test 2");
         goto error;
     }
     if (H5Tclose(src_type) < 0)
@@ -4907,14 +4907,14 @@ test_conv_str_1(void)
         goto error;
     if (memcmp(buf, "abcd      abcd      ", (size_t)20) != 0) {
         H5_FAILED();
-        HDputs("    C buffer to Fortran test 3");
+        puts("    C buffer to Fortran test 3");
         goto error;
     }
     if (H5Tconvert(dst_type, src_type, (size_t)2, buf, NULL, H5P_DEFAULT) < 0)
         goto error;
     if (memcmp(buf, "abcd\0abcd\0abcd      ", (size_t)20) != 0) {
         H5_FAILED();
-        HDputs("    Fortran to C buffer test 3");
+        puts("    Fortran to C buffer test 3");
         goto error;
     }
     if (H5Tclose(src_type) < 0)
@@ -4988,7 +4988,7 @@ test_conv_str_2(void)
     } /* end for */
 
     /* Do the conversions */
-    HDsnprintf(s, sizeof(s), "Testing random string conversion speed");
+    snprintf(s, sizeof(s), "Testing random string conversion speed");
     printf("%-70s", s);
     fflush(stdout);
     if (H5Tconvert(c_type, f_type, nelmts, buf, NULL, H5P_DEFAULT) < 0)
@@ -5196,14 +5196,14 @@ test_conv_enum_1(void)
         buf[u] = HDrand() % 26;
 
     /* Conversions */
-    HDsnprintf(s, sizeof(s), "Testing random enum conversion O(N)");
+    snprintf(s, sizeof(s), "Testing random enum conversion O(N)");
     printf("%-70s", s);
     fflush(stdout);
     if (H5Tconvert(t1, t2, nelmts, buf, NULL, H5P_DEFAULT) < 0)
         goto error;
     PASSED();
 
-    HDsnprintf(s, sizeof(s), "Testing random enum conversion O(N log N)");
+    snprintf(s, sizeof(s), "Testing random enum conversion O(N log N)");
     printf("%-70s", s);
     fflush(stdout);
     if (H5Tconvert(t2, t1, nelmts, buf, NULL, H5P_DEFAULT) < 0)
@@ -6802,7 +6802,7 @@ test_int_float_except(void)
     PASSED();
 #else  /* H5_SIZEOF_INT==4 && H5_SIZEOF_FLOAT==4 */
     SKIPPED();
-    HDputs("    Test skipped due to int or float not 4 bytes.");
+    puts("    Test skipped due to int or float not 4 bytes.");
 #endif /* H5_SIZEOF_INT==4 && H5_SIZEOF_FLOAT==4 */
     return 0;
 
@@ -7388,7 +7388,7 @@ test_named_indirect_reopen(hid_t fapl)
         TEST_ERROR;
     if (NULL == (tag_ret = H5Tget_tag(type)))
         TEST_ERROR;
-    if (HDstrcmp(tag, tag_ret) != 0)
+    if (strcmp(tag, tag_ret) != 0)
         TEST_ERROR;
     H5free_memory(tag_ret);
     tag_ret = NULL;
@@ -7404,7 +7404,7 @@ test_named_indirect_reopen(hid_t fapl)
         TEST_ERROR;
     if (NULL == (tag_ret = H5Tget_tag(type)))
         TEST_ERROR;
-    if (HDstrcmp(tag, tag_ret) != 0)
+    if (strcmp(tag, tag_ret) != 0)
         TEST_ERROR;
     H5free_memory(tag_ret);
     tag_ret = NULL;
@@ -8042,7 +8042,7 @@ test_deprec(hid_t fapl)
     H5E_END_TRY
     if (status >= 0) {
         H5_FAILED();
-        HDputs("    Types should not be committable to a read-only file!");
+        puts("    Types should not be committable to a read-only file!");
         goto error;
     }
 

--- a/test/earray.c
+++ b/test/earray.c
@@ -753,7 +753,7 @@ test_create(hid_t fapl, H5EA_create_t *cparam, earray_test_param_t H5_ATTR_UNUSE
     }
 #else  /* NDEBUG */
     SKIPPED();
-    HDputs("    Not tested when assertions are disabled");
+    puts("    Not tested when assertions are disabled");
 #endif /* NDEBUG */
 
     /*
@@ -2349,12 +2349,12 @@ main(void)
         switch (curr_test) {
             /* "Normal" testing parameters */
             case EARRAY_TEST_NORMAL:
-                HDputs("Testing with normal parameters");
+                puts("Testing with normal parameters");
                 break;
 
             /* "Re-open array" testing parameters */
             case EARRAY_TEST_REOPEN:
-                HDputs("Testing with reopen array flag set");
+                puts("Testing with reopen array flag set");
                 tparam.reopen_array = EARRAY_TEST_REOPEN;
                 break;
 
@@ -2383,31 +2383,31 @@ main(void)
             switch (curr_iter) {
                 /* "Forward" testing parameters */
                 case EARRAY_ITER_FW:
-                    HDputs("Testing with forward iteration");
+                    puts("Testing with forward iteration");
                     tparam.eiter = &ea_iter_fw;
                     break;
 
                 /* "Reverse" testing parameters */
                 case EARRAY_ITER_RV:
-                    HDputs("Testing with reverse iteration");
+                    puts("Testing with reverse iteration");
                     tparam.eiter = &ea_iter_rv;
                     break;
 
                 /* "Random" testing parameters */
                 case EARRAY_ITER_RND:
-                    HDputs("Testing with random iteration");
+                    puts("Testing with random iteration");
                     tparam.eiter = &ea_iter_rnd;
                     break;
 
                 /* "Random #2" testing parameters */
                 case EARRAY_ITER_RND2:
-                    HDputs("Testing with random #2 iteration");
+                    puts("Testing with random #2 iteration");
                     tparam.eiter = &ea_iter_rnd2;
                     break;
 
                 /* "Cyclic" testing parameters */
                 case EARRAY_ITER_CYC:
-                    HDputs("Testing with cyclic iteration");
+                    puts("Testing with cyclic iteration");
                     tparam.eiter = &ea_iter_cyc;
                     break;
 
@@ -2429,16 +2429,15 @@ main(void)
                     /* Test first element in data block */
                     nelmts = (hsize_t)((hsize_t)1 + cparam.idx_blk_elmts + tparam.sblk_info[sblk].start_idx +
                                        (tparam.sblk_info[sblk].dblk_nelmts * dblk));
-                    HDsnprintf(test_str, sizeof(test_str),
-                               "setting first element of array's data block #%llu",
-                               (unsigned long long)ndblks);
+                    snprintf(test_str, sizeof(test_str), "setting first element of array's data block #%llu",
+                             (unsigned long long)ndblks);
                     nerrors += test_set_elmts(fapl, &cparam, &tparam, nelmts, test_str);
 
                     /* Test all elements in data block */
                     nelmts = (hsize_t)(cparam.idx_blk_elmts + tparam.sblk_info[sblk].start_idx +
                                        (tparam.sblk_info[sblk].dblk_nelmts * (dblk + 1)));
-                    HDsnprintf(test_str, sizeof(test_str), "setting all elements of array's data block #%llu",
-                               (unsigned long long)ndblks);
+                    snprintf(test_str, sizeof(test_str), "setting all elements of array's data block #%llu",
+                             (unsigned long long)ndblks);
                     nerrors += test_set_elmts(fapl, &cparam, &tparam, nelmts, test_str);
 
                     /* Increment data block being tested */
@@ -2481,7 +2480,7 @@ main(void)
 
     if (nerrors)
         goto error;
-    HDputs("All extensible array tests passed.");
+    puts("All extensible array tests passed.");
 
     /* Clean up file used */
     h5_cleanup(FILENAME, fapl);
@@ -2489,7 +2488,7 @@ main(void)
     return 0;
 
 error:
-    HDputs("*** TESTS FAILED ***");
+    puts("*** TESTS FAILED ***");
 
     H5E_BEGIN_TRY
     {

--- a/test/efc.c
+++ b/test/efc.c
@@ -2642,7 +2642,7 @@ main(void)
     int                   i;                      /* iterator */
 
     /* Test Setup */
-    HDputs("Testing the external file cache");
+    puts("Testing the external file cache");
 
     /* Create property lists */
     fcpl_id = H5Pcreate(H5P_FILE_CREATE);
@@ -2695,7 +2695,7 @@ main(void)
     if (nerrors)
         goto error;
 
-    HDputs("All external file cache tests passed.");
+    puts("All external file cache tests passed.");
 
     h5_clean_files(FILENAME, fapl_id);
 
@@ -2706,7 +2706,7 @@ main(void)
     return EXIT_SUCCESS;
 
 error:
-    HDputs("*** TESTS FAILED ***");
+    puts("*** TESTS FAILED ***");
 
     H5E_BEGIN_TRY
     {

--- a/test/enc_dec_plist.c
+++ b/test/enc_dec_plist.c
@@ -187,9 +187,9 @@ main(void)
             /* Display testing info */
             low_string  = h5_get_version_string(low);
             high_string = h5_get_version_string(high);
-            HDsnprintf(msg, sizeof(msg),
-                       "Testing ENCODE/DECODE with file version bounds: (%s, %s):", low_string, high_string);
-            HDputs(msg);
+            snprintf(msg, sizeof(msg),
+                     "Testing ENCODE/DECODE with file version bounds: (%s, %s):", low_string, high_string);
+            puts(msg);
 
             if (VERBOSE_MED)
                 printf("Encode/Decode DCPLs\n");

--- a/test/enc_dec_plist_cross_platform.c
+++ b/test/enc_dec_plist_cross_platform.c
@@ -170,8 +170,8 @@ test_plists(const char *filename_prefix)
     for (config_1 = 0; config_1 < (NCONFIG - 1); config_1++)
         for (config_2 = config_1 + 1; config_2 < NCONFIG; config_2++) {
             /* Generate filename for file 1 */
-            if (HDsnprintf(filename, sizeof(filename), "%s%s%s", filename_prefix,
-                           config_1 & CONFIG_64 ? "64" : "32", config_1 & CONFIG_LE ? "le" : "be") < 0)
+            if (snprintf(filename, sizeof(filename), "%s%s%s", filename_prefix,
+                         config_1 & CONFIG_64 ? "64" : "32", config_1 & CONFIG_LE ? "le" : "be") < 0)
                 TEST_ERROR;
 
             /* Read file 1 */
@@ -186,8 +186,8 @@ test_plists(const char *filename_prefix)
             HDclose(fd_1);
 
             /* Generate filename for file 2 */
-            if (HDsnprintf(filename, sizeof(filename), "%s%s%s", filename_prefix,
-                           config_2 & CONFIG_64 ? "64" : "32", config_2 & CONFIG_LE ? "le" : "be") < 0)
+            if (snprintf(filename, sizeof(filename), "%s%s%s", filename_prefix,
+                         config_2 & CONFIG_64 ? "64" : "32", config_2 & CONFIG_LE ? "le" : "be") < 0)
                 TEST_ERROR;
 
             /* Read file 1 */

--- a/test/enum.c
+++ b/test/enum.c
@@ -808,12 +808,12 @@ main(void)
     if (nerrors)
         goto error;
 
-    HDputs("All enum tests passed.");
+    puts("All enum tests passed.");
     h5_cleanup(FILENAME, fapl_id);
 
     return EXIT_SUCCESS;
 
 error:
-    HDputs("*** ENUM TESTS FAILED ***");
+    puts("*** ENUM TESTS FAILED ***");
     return EXIT_FAILURE;
 }

--- a/test/error_test.c
+++ b/test/error_test.c
@@ -175,15 +175,15 @@ error:
 static herr_t
 init_error(void)
 {
-    ssize_t    cls_size = (ssize_t)HDstrlen(ERR_CLS_NAME) + 1;
-    ssize_t    msg_size = (ssize_t)HDstrlen(ERR_MIN_SUBROUTINE_MSG) + 1;
+    ssize_t    cls_size = (ssize_t)strlen(ERR_CLS_NAME) + 1;
+    ssize_t    msg_size = (ssize_t)strlen(ERR_MIN_SUBROUTINE_MSG) + 1;
     char      *cls_name = NULL;
     char      *msg      = NULL;
     H5E_type_t msg_type;
 
-    if (NULL == (cls_name = (char *)malloc(HDstrlen(ERR_CLS_NAME) + 1)))
+    if (NULL == (cls_name = (char *)malloc(strlen(ERR_CLS_NAME) + 1)))
         TEST_ERROR;
-    if (NULL == (msg = (char *)malloc(HDstrlen(ERR_MIN_SUBROUTINE_MSG) + 1)))
+    if (NULL == (msg = (char *)malloc(strlen(ERR_MIN_SUBROUTINE_MSG) + 1)))
         TEST_ERROR;
 
     if ((ERR_CLS = H5Eregister_class(ERR_CLS_NAME, PROG_NAME, PROG_VERS)) < 0)
@@ -191,7 +191,7 @@ init_error(void)
 
     if (cls_size != H5Eget_class_name(ERR_CLS, cls_name, (size_t)cls_size) + 1)
         TEST_ERROR;
-    if (HDstrcmp(ERR_CLS_NAME, cls_name) != 0)
+    if (strcmp(ERR_CLS_NAME, cls_name) != 0)
         TEST_ERROR;
 
     if ((ERR_MAJ_TEST = H5Ecreate_msg(ERR_CLS, H5E_MAJOR, ERR_MAJ_TEST_MSG)) < 0)
@@ -216,7 +216,7 @@ init_error(void)
         TEST_ERROR;
     if (msg_type != H5E_MINOR)
         TEST_ERROR;
-    if (HDstrcmp(msg, ERR_MIN_SUBROUTINE_MSG) != 0)
+    if (strcmp(msg, ERR_MIN_SUBROUTINE_MSG) != 0)
         TEST_ERROR;
 
     /* Register another class for later testing. */
@@ -293,7 +293,7 @@ long_desc_cb(unsigned H5_ATTR_UNUSED n, const H5E_error2_t *err_desc, void *clie
 {
     char *real_desc = (char *)client_data;
 
-    if (err_desc->desc != NULL && HDstrcmp(err_desc->desc, real_desc) == 0)
+    if (err_desc->desc != NULL && strcmp(err_desc->desc, real_desc) == 0)
         return 0;
     else
         return -1;
@@ -345,10 +345,10 @@ test_long_desc(void)
                 long_desc) < 0)
         TEST_ERROR;
 
-    /* Create the string that should be in the description. Must use HDsnprintf here
+    /* Create the string that should be in the description. Must use snprintf here
      * because snprintf is _snprintf on Windows
      */
-    HDsnprintf(full_desc, (size_t)(LONG_DESC_SIZE + 128), format, long_desc);
+    snprintf(full_desc, (size_t)(LONG_DESC_SIZE + 128), format, long_desc);
 
     /* Make certain that the description is correct */
     if (H5Ewalk2(H5E_DEFAULT, H5E_WALK_UPWARD, long_desc_cb, full_desc) < 0)
@@ -879,7 +879,7 @@ main(void)
      * the test file was pre-generated.
      */
     h5_fixname(DATAFILE, H5P_DEFAULT, filename, sizeof filename);
-    if (!h5_using_default_driver(env_h5_drvr) && HDstrcmp(env_h5_drvr, "stdio")) {
+    if (!h5_using_default_driver(env_h5_drvr) && strcmp(env_h5_drvr, "stdio")) {
         /* If not using the library's default VFD or the stdio VFD, force
          * the library's default VFD here. The test file was pre-generated
          * and can cause issues with many VFDs.

--- a/test/event_set.c
+++ b/test/event_set.c
@@ -681,11 +681,11 @@ main(void)
         goto error;
 
     /* Report status */
-    HDputs("All event set tests passed.");
+    puts("All event set tests passed.");
 
     exit(EXIT_SUCCESS);
 
 error:
-    HDputs("***** EVENT SET TESTS FAILED *****");
+    puts("***** EVENT SET TESTS FAILED *****");
     exit(EXIT_FAILURE);
 } /* end main() */

--- a/test/evict_on_close.c
+++ b/test/evict_on_close.c
@@ -184,7 +184,7 @@ generate_eoc_test_file(hid_t fapl_id)
 
         /* Create the group name */
         memset(subgroup_name, '\0', SUBGROUP_NAME_SIZE);
-        if (HDsnprintf(subgroup_name, (size_t)(SUBGROUP_NAME_SIZE - 1), "%d", i) < 0)
+        if (snprintf(subgroup_name, (size_t)(SUBGROUP_NAME_SIZE - 1), "%d", i) < 0)
             TEST_ERROR;
 
         if ((gid2 = H5Gcreate2(gid1, subgroup_name, H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT)) < 0)
@@ -279,7 +279,7 @@ generate_eoc_test_file(hid_t fapl_id)
 
         /* Create the group name */
         memset(subgroup_name, '\0', SUBGROUP_NAME_SIZE);
-        if (HDsnprintf(subgroup_name, (size_t)(SUBGROUP_NAME_SIZE - 1), "%d", i) < 0)
+        if (snprintf(subgroup_name, (size_t)(SUBGROUP_NAME_SIZE - 1), "%d", i) < 0)
             TEST_ERROR;
 
         if ((gid2 = H5Gcreate2(gid1, subgroup_name, H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT)) < 0)
@@ -620,7 +620,7 @@ check_group_layout(hid_t fid, const char *group_name)
 
         /* Create the group name */
         memset(subgroup_name, '\0', SUBGROUP_NAME_SIZE);
-        if (HDsnprintf(subgroup_name, (size_t)(SUBGROUP_NAME_SIZE - 1), "%d", i) < 0)
+        if (snprintf(subgroup_name, (size_t)(SUBGROUP_NAME_SIZE - 1), "%d", i) < 0)
             TEST_ERROR;
 
         if ((gid2 = H5Gopen2(gid1, subgroup_name, H5P_DEFAULT)) < 0)

--- a/test/external.c
+++ b/test/external.c
@@ -139,7 +139,7 @@ test_non_extendible(hid_t file)
         FAIL_STACK_ERROR;
     if (1 != n) {
         H5_FAILED();
-        HDputs("    Returned external count is wrong.");
+        puts("    Returned external count is wrong.");
         printf("   got: %d\n    ans: 1\n", n);
         goto error;
     }
@@ -149,13 +149,13 @@ test_non_extendible(hid_t file)
         FAIL_STACK_ERROR;
     if (file_offset != 0) {
         H5_FAILED();
-        HDputs("    Wrong file offset.");
+        puts("    Wrong file offset.");
         printf("    got: %lu\n    ans: 0\n", (unsigned long)file_offset);
         goto error;
     }
     if (file_size != (max_size[0] * sizeof(int))) {
         H5_FAILED();
-        HDputs("    Wrong file size.");
+        puts("    Wrong file size.");
         printf("    got: %" PRIuHSIZE "\n    ans: %" PRIuHSIZE "\n", file_size, max_size[0] * sizeof(int));
         goto error;
     }
@@ -396,7 +396,7 @@ test_unlimited(hid_t file)
         FAIL_STACK_ERROR;
     if (1 != n) {
         H5_FAILED();
-        HDputs("    Returned external count is wrong.");
+        puts("    Returned external count is wrong.");
         printf("    got: %d\n    ans: 1\n", n);
         goto error;
     } /* end if */
@@ -405,13 +405,13 @@ test_unlimited(hid_t file)
         FAIL_STACK_ERROR;
     if (file_offset != 0) {
         H5_FAILED();
-        HDputs("    Wrong file offset.");
+        puts("    Wrong file offset.");
         printf("    got: %lu\n    ans: 0\n", (unsigned long)file_offset);
         goto error;
     }
     if (H5F_UNLIMITED != file_size) {
         H5_FAILED();
-        HDputs("    Wrong file size.");
+        puts("    Wrong file size.");
         printf("    got: %lu\n    ans: INF\n", (unsigned long)file_size);
         goto error;
     }
@@ -457,7 +457,7 @@ add_external_files(hid_t dcpl_id, unsigned int n_external_files, off_t offset, h
         return -1;
     }
     for (i = 0; i < n_external_files; i++) {
-        if (HDsnprintf(exname, AEF_EXNAME_MAX_LEN, "ext%d.data", i + 1) > AEF_EXNAME_MAX_LEN) {
+        if (snprintf(exname, AEF_EXNAME_MAX_LEN, "ext%d.data", i + 1) > AEF_EXNAME_MAX_LEN) {
             fprintf(stderr, "External file %d overflows name buffer\n", i + 1);
             fflush(stderr);
             return -1;
@@ -705,7 +705,7 @@ test_read_file_set(hid_t fapl)
     if ((dcpl = H5Pcreate(H5P_DATASET_CREATE)) < 0)
         FAIL_STACK_ERROR;
     for (i = 0; i < N_EXT_FILES; i++) {
-        HDsnprintf(filename, sizeof(filename), "extern_%dr.raw", (int)i + 1);
+        snprintf(filename, sizeof(filename), "extern_%dr.raw", (int)i + 1);
         if (H5Pset_external(dcpl, filename, (off_t)(i * GARBAGE_PER_FILE), (hsize_t)sizeof(part)) < 0)
             FAIL_STACK_ERROR;
     }
@@ -818,7 +818,7 @@ test_write_file_set(hid_t fapl)
     for (i = 0; i < N_EXT_FILES; i++) {
         hsize_t size;
 
-        HDsnprintf(filename, sizeof(filename), "extern_%dw.raw", (int)i + 1);
+        snprintf(filename, sizeof(filename), "extern_%dw.raw", (int)i + 1);
 
         if (i != N_EXT_FILES - 1)
             size = (hsize_t)sizeof(part);
@@ -849,8 +849,8 @@ test_write_file_set(hid_t fapl)
     for (i = 0; i < N_EXT_FILES; i++) {
         char name1[64], name2[64];
 
-        HDsnprintf(name1, sizeof(name1), "extern_%dr.raw", i + 1);
-        HDsnprintf(name2, sizeof(name2), "extern_%dw.raw", i + 1);
+        snprintf(name1, sizeof(name1), "extern_%dr.raw", i + 1);
+        snprintf(name2, sizeof(name2), "extern_%dw.raw", i + 1);
         if (!files_have_same_contents(name1, name2))
             FAIL_PUTS_ERROR("   Output differs from expected value.");
     } /* end for */
@@ -942,11 +942,11 @@ test_path_absolute(hid_t fapl)
     if (NULL == HDgetcwd(cwdpath, sizeof(cwdpath)))
         TEST_ERROR;
     for (i = 0; i < N_EXT_FILES; i++) {
-        HDsnprintf(filename, sizeof(filename), "%s%sextern_%zur.raw", cwdpath, H5_DIR_SEPS, i + 1);
+        snprintf(filename, sizeof(filename), "%s%sextern_%zur.raw", cwdpath, H5_DIR_SEPS, i + 1);
 #if defined(H5_HAVE_WINDOW_PATH)
         /* For windows, test path-absolute case (\dir\file.raw) for the second file */
         if (i == 1)
-            HDsnprintf(filename, sizeof(filename), "%s%sextern_%zur.raw", cwdpath + 2, H5_DIR_SEPS, i + 1);
+            snprintf(filename, sizeof(filename), "%s%sextern_%zur.raw", cwdpath + 2, H5_DIR_SEPS, i + 1);
 #endif
         if (H5Pset_external(dcpl, filename, (off_t)(i * GARBAGE_PER_FILE), (hsize_t)sizeof(part)) < 0)
             FAIL_STACK_ERROR;
@@ -1037,7 +1037,7 @@ test_path_relative(hid_t fapl)
     if ((dcpl = H5Pcreate(H5P_DATASET_CREATE)) < 0)
         FAIL_STACK_ERROR;
     for (i = 0; i < N_EXT_FILES; i++) {
-        HDsnprintf(filename, sizeof(filename), "extern_%dr.raw", (int)i + 1);
+        snprintf(filename, sizeof(filename), "extern_%dr.raw", (int)i + 1);
         if (H5Pset_external(dcpl, filename, (off_t)(i * GARBAGE_PER_FILE), (hsize_t)sizeof(part)) < 0)
             FAIL_STACK_ERROR;
     } /* end for */
@@ -1131,7 +1131,7 @@ test_path_relative_cwd(hid_t fapl)
     if ((dcpl = H5Pcreate(H5P_DATASET_CREATE)) < 0)
         FAIL_STACK_ERROR;
     for (i = 0; i < N_EXT_FILES; i++) {
-        HDsnprintf(filename, sizeof(filename), "..%sextern_%dr.raw", H5_DIR_SEPS, (int)i + 1);
+        snprintf(filename, sizeof(filename), "..%sextern_%dr.raw", H5_DIR_SEPS, (int)i + 1);
         if (H5Pset_external(dcpl, filename, (off_t)(i * GARBAGE_PER_FILE), (hsize_t)sizeof(part)) < 0)
             FAIL_STACK_ERROR;
     } /* end for */
@@ -1145,7 +1145,7 @@ test_path_relative_cwd(hid_t fapl)
         FAIL_STACK_ERROR;
     if (H5Pget_efile_prefix(dapl, buffer, sizeof(buffer)) < 0)
         FAIL_STACK_ERROR;
-    if (HDstrcmp(buffer, "${ORIGIN}") != 0)
+    if (strcmp(buffer, "${ORIGIN}") != 0)
         FAIL_PUTS_ERROR("efile prefix not set correctly");
     if ((dapl2 = H5Pcopy(dapl)) < 0)
         FAIL_STACK_ERROR;
@@ -1315,7 +1315,7 @@ test_h5d_get_access_plist(hid_t fapl_id)
         TEST_ERROR;
     if (H5Pget_efile_prefix(dapl_id, buffer, (size_t)64) < 0)
         FAIL_STACK_ERROR;
-    if (HDstrcmp(buffer, "someprefix") != 0)
+    if (strcmp(buffer, "someprefix") != 0)
         FAIL_PUTS_ERROR("external file prefix from dapl incorrect");
 
     /* Close everything */
@@ -1383,7 +1383,7 @@ main(void)
 
     /* The file format doesn't matter for this test */
     nerrors += test_h5d_get_access_plist(fapl_id_new);
-    HDputs("");
+    puts("");
 
     /* Test with old & new format groups */
     for (latest_format = false; latest_format <= true; latest_format++) {
@@ -1391,11 +1391,11 @@ main(void)
 
         /* Set the fapl for different file formats */
         if (latest_format) {
-            HDputs("\nTesting with the latest file format:");
+            puts("\nTesting with the latest file format:");
             current_fapl_id = fapl_id_new;
         }
         else {
-            HDputs("Testing with the default file format:");
+            puts("Testing with the default file format:");
             current_fapl_id = fapl_id_old;
         }
 
@@ -1444,7 +1444,7 @@ main(void)
     if (H5Pclose(fapl_id_new) < 0)
         FAIL_STACK_ERROR;
 
-    HDputs("All external storage tests passed.");
+    puts("All external storage tests passed.");
 
     /* Clean up files used by file set tests */
     if (h5_cleanup(EXT_FNAME, fapl_id_old)) {

--- a/test/external_common.c
+++ b/test/external_common.c
@@ -52,9 +52,9 @@ reset_raw_data_files(bool is_env)
 
         /* Open file */
         if (is_env)
-            HDsnprintf(filename, sizeof(filename), "extern_env_%lur.raw", (unsigned long)i + 1);
+            snprintf(filename, sizeof(filename), "extern_env_%lur.raw", (unsigned long)i + 1);
         else
-            HDsnprintf(filename, sizeof(filename), "extern_%lur.raw", (unsigned long)i + 1);
+            snprintf(filename, sizeof(filename), "extern_%lur.raw", (unsigned long)i + 1);
         if ((fd = HDopen(filename, O_RDWR | O_CREAT | O_TRUNC, H5_POSIX_CREATE_MODE_RW)) < 0)
             goto error;
 
@@ -89,9 +89,9 @@ reset_raw_data_files(bool is_env)
 
         /* Open file */
         if (is_env)
-            HDsnprintf(filename, sizeof(filename), "extern_env_%luw.raw", (unsigned long)i + 1);
+            snprintf(filename, sizeof(filename), "extern_env_%luw.raw", (unsigned long)i + 1);
         else
-            HDsnprintf(filename, sizeof(filename), "extern_%luw.raw", (unsigned long)i + 1);
+            snprintf(filename, sizeof(filename), "extern_%luw.raw", (unsigned long)i + 1);
         if ((fd = HDopen(filename, O_RDWR | O_CREAT | O_TRUNC, H5_POSIX_CREATE_MODE_RW)) < 0)
             goto error;
 

--- a/test/external_env.c
+++ b/test/external_env.c
@@ -67,7 +67,7 @@ test_path_env(hid_t fapl)
     if ((dcpl = H5Pcreate(H5P_DATASET_CREATE)) < 0)
         FAIL_STACK_ERROR;
     for (i = 0; i < N_EXT_FILES; i++) {
-        HDsnprintf(filename, sizeof(filename), "..%sextern_env_%dr.raw", H5_DIR_SEPS, (int)i + 1);
+        snprintf(filename, sizeof(filename), "..%sextern_env_%dr.raw", H5_DIR_SEPS, (int)i + 1);
         if (H5Pset_external(dcpl, filename, (off_t)(i * GARBAGE_PER_FILE), (hsize_t)sizeof(part)) < 0)
             FAIL_STACK_ERROR;
     } /* end for */
@@ -83,7 +83,7 @@ test_path_env(hid_t fapl)
         FAIL_STACK_ERROR;
     if (H5Pget_efile_prefix(dapl, buffer, sizeof(buffer)) < 0)
         FAIL_STACK_ERROR;
-    if (HDstrcmp(buffer, "someprefix") != 0)
+    if (strcmp(buffer, "someprefix") != 0)
         FAIL_PUTS_ERROR("efile prefix not set correctly");
 
     /* Create dataset */
@@ -161,11 +161,11 @@ main(void)
 
         /* Set the fapl for different file formats */
         if (latest_format) {
-            HDputs("\nTesting with the latest file format:");
+            puts("\nTesting with the latest file format:");
             current_fapl_id = fapl_id_new;
         } /* end if */
         else {
-            HDputs("Testing with the default file format:");
+            puts("Testing with the default file format:");
             current_fapl_id = fapl_id_old;
         } /* end else */
 
@@ -179,7 +179,7 @@ main(void)
     if (H5Pclose(fapl_id_new) < 0)
         FAIL_STACK_ERROR;
 
-    HDputs("All external storage tests passed.");
+    puts("All external storage tests passed.");
 
     /* Clean up files used by file set tests */
     if (h5_cleanup(EXT_ENV_FNAME, fapl_id_old)) {

--- a/test/farray.c
+++ b/test/farray.c
@@ -491,7 +491,7 @@ test_create(hid_t fapl, H5FA_create_t *cparam, farray_test_param_t H5_ATTR_UNUSE
     }
 #else  /* NDEBUG */
     SKIPPED();
-    HDputs("    Not tested when assertions are disabled");
+    puts("    Not tested when assertions are disabled");
 #endif /* NDEBUG */
 
     /*
@@ -1678,12 +1678,12 @@ main(void)
         switch (curr_test) {
             /* "Normal" testing parameters */
             case FARRAY_TEST_NORMAL:
-                HDputs("Testing with NORMAL PARAMETERS");
+                puts("Testing with NORMAL PARAMETERS");
                 break;
 
             /* "Re-open array" testing parameters */
             case FARRAY_TEST_REOPEN:
-                HDputs("Testing with reopen array flag set");
+                puts("Testing with reopen array flag set");
                 tparam.reopen_array = FARRAY_TEST_REOPEN;
                 break;
 
@@ -1710,25 +1710,25 @@ main(void)
             switch (curr_iter) {
                 /* "Forward" testing parameters */
                 case FARRAY_ITER_FW:
-                    HDputs("Testing with forward iteration");
+                    puts("Testing with forward iteration");
                     tparam.fiter = &fa_iter_fw;
                     break;
 
                 /* "Reverse" testing parameters */
                 case FARRAY_ITER_RV:
-                    HDputs("Testing with reverse iteration");
+                    puts("Testing with reverse iteration");
                     tparam.fiter = &fa_iter_rv;
                     break;
 
                 /* "Random" testing parameters */
                 case FARRAY_ITER_RND:
-                    HDputs("Testing with random iteration");
+                    puts("Testing with random iteration");
                     tparam.fiter = &fa_iter_rnd;
                     break;
 
                 /* "Cyclic" testing parameters */
                 case FARRAY_ITER_CYC:
-                    HDputs("Testing with cyclic iteration");
+                    puts("Testing with cyclic iteration");
                     tparam.fiter = &fa_iter_cyc;
                     break;
 
@@ -1782,7 +1782,7 @@ main(void)
 
     if (nerrors)
         goto error;
-    HDputs("All fixed array tests passed.");
+    puts("All fixed array tests passed.");
 
     /* Clean up file used */
     h5_cleanup(FILENAME, fapl);
@@ -1790,7 +1790,7 @@ main(void)
     exit(EXIT_SUCCESS);
 
 error:
-    HDputs("*** TESTS FAILED ***");
+    puts("*** TESTS FAILED ***");
 
     H5E_BEGIN_TRY
     {

--- a/test/fheap.c
+++ b/test/fheap.c
@@ -517,7 +517,7 @@ begin_test(fheap_test_param_t *tparam, const char *base_desc, fheap_heap_ids_t *
      */
     size_t test_desc_len = strlen(base_desc) + sizeof(" ") + strlen(del_str);
     test_desc            = H5MM_malloc(test_desc_len);
-    (void)HDsnprintf(test_desc, test_desc_len, "%s %s", base_desc, del_str);
+    (void)snprintf(test_desc, test_desc_len, "%s %s", base_desc, del_str);
 
     TESTING(test_desc);
     H5MM_xfree(test_desc);
@@ -7449,7 +7449,7 @@ test_man_incr_insert_remove(hid_t fapl, H5HF_create_t *cparam, fheap_test_param_
             if (H5HF_remove(fh, heap_id[j]) < 0)
                 FAIL_STACK_ERROR;
 
-            HDsnprintf(obj2.b, sizeof(obj2.b), "%s%2d", "ABCDEFGHIJKLMNOPQRSTUVWXYZ", j);
+            snprintf(obj2.b, sizeof(obj2.b), "%s%2d", "ABCDEFGHIJKLMNOPQRSTUVWXYZ", j);
             if (H5HF_insert(fh, (sizeof(obj2)), &obj2, heap_id[j]) < 0)
                 FAIL_STACK_ERROR;
         } /* end for */
@@ -7460,7 +7460,7 @@ test_man_incr_insert_remove(hid_t fapl, H5HF_create_t *cparam, fheap_test_param_
 
         /* Insert object */
         memset(heap_id[i], 0, id_len);
-        HDsnprintf(obj1.b, sizeof(obj1.b), "%s%2d", "ABCDEFGHIJKLMNOPQRSTUVWXYZ", i);
+        snprintf(obj1.b, sizeof(obj1.b), "%s%2d", "ABCDEFGHIJKLMNOPQRSTUVWXYZ", i);
         if (H5HF_insert(fh, (sizeof(obj1)), &obj1, heap_id[i]) < 0)
             FAIL_STACK_ERROR;
     } /* end for */
@@ -15968,7 +15968,7 @@ main(void)
         envval = "nomatch";
 
     /* Current VFD that does not support contiguous address space */
-    contig_addr_vfd = (bool)(HDstrcmp(envval, "split") != 0 && HDstrcmp(envval, "multi") != 0);
+    contig_addr_vfd = (bool)(strcmp(envval, "split") != 0 && strcmp(envval, "multi") != 0);
 
     /* Reset library */
     h5_reset();
@@ -16112,12 +16112,12 @@ main(void)
             switch (curr_test) {
                 /* "Normal" testing parameters */
                 case FHEAP_TEST_NORMAL:
-                    HDputs("Testing with normal parameters");
+                    puts("Testing with normal parameters");
                     break;
 
                 /* "Re-open heap" testing parameters */
                 case FHEAP_TEST_REOPEN:
-                    HDputs("Testing with reopen heap flag set");
+                    puts("Testing with reopen heap flag set");
                     tparam.reopen_heap = FHEAP_TEST_REOPEN;
                     break;
 
@@ -16149,12 +16149,12 @@ main(void)
                     switch (fill) {
                         /* "Bulk fill" heap blocks with 'large' objects */
                         case FHEAP_TEST_FILL_LARGE:
-                            HDputs("Bulk-filling blocks w/large objects");
+                            puts("Bulk-filling blocks w/large objects");
                             break;
 
                         /* "Bulk fill" heap blocks with 'single' objects */
                         case FHEAP_TEST_FILL_SINGLE:
-                            HDputs("Bulk-filling blocks w/single object");
+                            puts("Bulk-filling blocks w/single object");
                             break;
 
                         /* An unknown test? */
@@ -16354,12 +16354,12 @@ main(void)
                     switch (id_len) {
                         /* Use "normal" form for 'huge' object's heap IDs */
                         case 0:
-                            HDputs("Using 'normal' heap ID format for 'huge' objects");
+                            puts("Using 'normal' heap ID format for 'huge' objects");
                             break;
 
                         /* Use "direct" form for 'huge' object's heap IDs */
                         case 1:
-                            HDputs("Using 'direct' heap ID format for 'huge' objects");
+                            puts("Using 'direct' heap ID format for 'huge' objects");
 
                             /* Adjust actual length of heap IDs for directly storing 'huge' object's file
                              * offset & length in heap ID */
@@ -16369,8 +16369,8 @@ main(void)
                         /* Use "direct" storage for 'huge' objects and larger IDs for 'tiny' objects */
                         case 2:
                             small_cparam.id_len = 37;
-                            HDputs("Using 'direct' heap ID format for 'huge' objects and larger IDs for "
-                                   "'tiny' objects");
+                            puts("Using 'direct' heap ID format for 'huge' objects and larger IDs for "
+                                 "'tiny' objects");
                             tparam.actual_id_len = 37;
                             break;
 
@@ -16436,7 +16436,7 @@ main(void)
                 printf("***Express test mode on.  Some tests skipped\n");
             else {
                 /* Random tests using "small" heap creation parameters */
-                HDputs("Using 'small' heap creation parameters");
+                puts("Using 'small' heap creation parameters");
 
                 /* (reduce size of tests when re-opening each time) */
                 /* XXX: Try to speed things up enough that these tests don't have to be reduced when
@@ -16458,7 +16458,7 @@ main(void)
                                             fapl, &small_cparam, &tparam);
 
                 /* Random tests using "large" heap creation parameters */
-                HDputs("Using 'large' heap creation parameters");
+                puts("Using 'large' heap creation parameters");
                 tparam.actual_id_len = LARGE_HEAP_ID_LEN;
 
                 /* (reduce size of tests when re-opening each time) */
@@ -16513,7 +16513,7 @@ main(void)
 
     if (nerrors)
         goto error;
-    HDputs("All fractal heap tests passed.");
+    puts("All fractal heap tests passed.");
 
     /* Release space for the shared objects */
     H5MM_xfree(shared_wobj_g);
@@ -16538,7 +16538,7 @@ main(void)
     return 0;
 
 error:
-    HDputs("*** TESTS FAILED ***");
+    puts("*** TESTS FAILED ***");
     H5E_BEGIN_TRY
     {
         H5MM_xfree(shared_wobj_g);

--- a/test/file_image.c
+++ b/test/file_image.c
@@ -552,10 +552,10 @@ test_core(void)
     VERIFY(tmp != NULL, "h5_fixname failed");
 
     /* Append ".copy" to the filename from the source directory */
-    VERIFY(HDstrlen(filename) < (1023 - 5), "file name too long.");
-    HDstrncpy(copied_filename, filename, (size_t)1023);
+    VERIFY(strlen(filename) < (1023 - 5), "file name too long.");
+    strncpy(copied_filename, filename, (size_t)1023);
     copied_filename[1023] = '\0';
-    HDstrcat(copied_filename, ".copy");
+    strcat(copied_filename, ".copy");
 
     /* Make a copy of the data file from svn. */
     ret = h5_make_local_copy(filename, copied_filename);
@@ -714,7 +714,7 @@ test_get_file_image(const char *test_banner, const int file_name_num, hid_t fapl
 
     /* setup the file name */
     h5_fixname(FILENAME2[file_name_num], fapl, file_name, sizeof(file_name));
-    VERIFY(HDstrlen(file_name) > 0, "h5_fixname failed");
+    VERIFY(strlen(file_name) > 0, "h5_fixname failed");
 
     fcpl = H5Pcreate(H5P_FILE_CREATE);
     VERIFY(fcpl >= 0, "H5Pcreate");
@@ -783,7 +783,7 @@ test_get_file_image(const char *test_banner, const int file_name_num, hid_t fapl
         file_size = 0;
 
         do {
-            HDsnprintf(member_file_name, (size_t)1024, file_name, i);
+            snprintf(member_file_name, (size_t)1024, file_name, i);
 
             /* get the size of the member file */
             result = HDstat(member_file_name, &stat_buf);
@@ -811,7 +811,7 @@ test_get_file_image(const char *test_banner, const int file_name_num, hid_t fapl
 
         while (size_remaining > 0) {
             /* construct the member file name */
-            HDsnprintf(member_file_name, 1024, file_name, i);
+            snprintf(member_file_name, 1024, file_name, i);
 
             /* open the test file using standard I/O calls */
             fd = HDopen(member_file_name, O_RDONLY);
@@ -994,7 +994,7 @@ test_get_file_image_error_rejection(void)
 
     /* setup the file name */
     h5_fixname(FILENAME2[6], fapl_id, file_name, sizeof(file_name));
-    VERIFY(HDstrlen(file_name) > 0, "h5_fixname failed");
+    VERIFY(strlen(file_name) > 0, "h5_fixname failed");
 
     /* create the file */
     file_id = H5Fcreate(file_name, 0, H5P_DEFAULT, fapl_id);
@@ -1126,7 +1126,7 @@ test_get_file_image_error_rejection(void)
 
     /* setup the file name */
     h5_fixname(FILENAME2[4], fapl_id, file_name, sizeof(file_name));
-    VERIFY(HDstrlen(file_name) > 0, "h5_fixname failed");
+    VERIFY(strlen(file_name) > 0, "h5_fixname failed");
 
     /* create the file */
     file_id = H5Fcreate(file_name, 0, H5P_DEFAULT, fapl_id);
@@ -1188,7 +1188,7 @@ test_get_file_image_error_rejection(void)
 
     /* setup the file name */
     h5_fixname(FILENAME2[5], fapl_id, file_name, sizeof(file_name));
-    VERIFY(HDstrlen(file_name) > 0, "h5_fixname failed");
+    VERIFY(strlen(file_name) > 0, "h5_fixname failed");
 
     /* create the file */
     file_id = H5Fcreate(file_name, 0, H5P_DEFAULT, fapl_id);
@@ -1248,7 +1248,7 @@ test_get_file_image_error_rejection(void)
     VERIFY(err >= 0, "H5Pset_fapl_family failed");
 
     h5_fixname(FILENAME2[3], fapl_id, file_name, sizeof(file_name));
-    VERIFY(HDstrlen(file_name) > 0, "h5_fixname failed");
+    VERIFY(strlen(file_name) > 0, "h5_fixname failed");
 
     /* create the file */
     file_id = H5Fcreate(file_name, 0, H5P_DEFAULT, fapl_id);

--- a/test/filenotclosed.c
+++ b/test/filenotclosed.c
@@ -72,10 +72,10 @@ main(void)
      * Further investigation is needed to resolve the test failure with the
      * split/multi driver.  Please see HDFFV-10160.
      */
-    contig_addr_vfd = (bool)(HDstrcmp(env_h5_drvr, "split") != 0 && HDstrcmp(env_h5_drvr, "multi") != 0);
+    contig_addr_vfd = (bool)(strcmp(env_h5_drvr, "split") != 0 && strcmp(env_h5_drvr, "multi") != 0);
     if (!contig_addr_vfd) {
         SKIPPED();
-        HDputs("    Temporary skipped for a spilt/multi driver");
+        puts("    Temporary skipped for a spilt/multi driver");
         exit(EXIT_SUCCESS);
     }
 
@@ -135,6 +135,6 @@ main(void)
     exit(EXIT_SUCCESS);
 
 error:
-    HDputs("*** TEST FAILED ***");
+    puts("*** TEST FAILED ***");
     exit(EXIT_FAILURE);
 }

--- a/test/fillval.c
+++ b/test/fillval.c
@@ -190,7 +190,7 @@ test_getset(void)
     H5E_END_TRY
     if (fill_i != 0) {
         H5_FAILED();
-        HDputs("    H5Pget_fill_value() should return default 0");
+        puts("    H5Pget_fill_value() should return default 0");
         goto error;
     }
 
@@ -209,8 +209,8 @@ test_getset(void)
         goto error;
     if (fill_ss.v1 != fill_ss_rd.v1 || fill_ss.v2 != fill_ss_rd.v2) {
         H5_FAILED();
-        HDputs("    Failed to get fill value using same data type that was ");
-        HDputs("    used to set the fill value.");
+        puts("    Failed to get fill value using same data type that was ");
+        puts("    used to set the fill value.");
         goto error;
     }
 
@@ -221,8 +221,8 @@ test_getset(void)
         goto error;
     if (fill_ss.v1 != fill_si.v1 || fill_ss.v2 != fill_si.v2) {
         H5_FAILED();
-        HDputs("    Failed to get fill value using a data type other than what");
-        HDputs("    was used to set the fill value.");
+        puts("    Failed to get fill value using a data type other than what");
+        puts("    was used to set the fill value.");
         goto error;
     }
 
@@ -235,7 +235,7 @@ test_getset(void)
         goto error;
     if (fill_si.v1 != fill_ss.v1 || fill_si.v2 != fill_ss.v2) {
         H5_FAILED();
-        HDputs("    Resetting the fill value was unsuccessful.");
+        puts("    Resetting the fill value was unsuccessful.");
         goto error;
     }
 
@@ -305,7 +305,7 @@ test_getset_vl(hid_t fapl)
         TEST_ERROR;
 
     /* Verify that the fill value is the original value */
-    if (HDstrcmp(f2, orig_fill_value) != 0)
+    if (strcmp(f2, orig_fill_value) != 0)
         TEST_ERROR;
 
     /* Release the fill value retrieved */
@@ -347,7 +347,7 @@ test_getset_vl(hid_t fapl)
         TEST_ERROR;
 
     /* Verify that the fill value is the original value */
-    if (HDstrcmp(f2, orig_fill_value) != 0)
+    if (strcmp(f2, orig_fill_value) != 0)
         TEST_ERROR;
 
     /* Release the fill value retrieved */
@@ -663,12 +663,12 @@ test_create(hid_t fapl, const char *base_name, H5D_layout_t layout)
             goto error;
         if (alloc_time != H5D_ALLOC_TIME_LATE) {
             H5_FAILED();
-            HDputs("    Got non-H5D_ALLOC_TIME_LATE space allocation time.");
+            puts("    Got non-H5D_ALLOC_TIME_LATE space allocation time.");
             printf("    Got %d\n", alloc_time);
         }
         if (fill_time != H5D_FILL_TIME_ALLOC) {
             H5_FAILED();
-            HDputs("    Got non-H5D_FILL_TIME_ALLOC fill value write time.");
+            puts("    Got non-H5D_FILL_TIME_ALLOC fill value write time.");
             printf("    Got %d\n", fill_time);
         }
         if (H5Dclose(dset3) < 0)
@@ -683,7 +683,7 @@ test_create(hid_t fapl, const char *base_name, H5D_layout_t layout)
             goto error;
         if (layout == H5D_CONTIGUOUS && allocation != H5D_SPACE_STATUS_NOT_ALLOCATED) {
             H5_FAILED();
-            HDputs("    Got allocated space instead of unallocated.");
+            puts("    Got allocated space instead of unallocated.");
             printf("    Got %d\n", allocation);
             goto error;
         }
@@ -695,12 +695,12 @@ test_create(hid_t fapl, const char *base_name, H5D_layout_t layout)
             goto error;
         if (alloc_time != H5D_ALLOC_TIME_LATE) {
             H5_FAILED();
-            HDputs("    Got non-H5D_ALLOC_TIME_LATE space allocation time.");
+            puts("    Got non-H5D_ALLOC_TIME_LATE space allocation time.");
             printf("    Got %d\n", alloc_time);
         }
         if (fill_time != H5D_FILL_TIME_NEVER) {
             H5_FAILED();
-            HDputs("    Got non-H5D_FILL_TIME_NEVER fill value write time.");
+            puts("    Got non-H5D_FILL_TIME_NEVER fill value write time.");
             printf("    Got %d\n", fill_time);
         }
         if (H5Dclose(dset4) < 0)
@@ -718,7 +718,7 @@ test_create(hid_t fapl, const char *base_name, H5D_layout_t layout)
         if (!H5_FLT_ABS_EQUAL(rd_c.a, 0) || !H5_DBL_ABS_EQUAL(rd_c.y, fill_ctype.y) || rd_c.x != 0 ||
             rd_c.z != '\0') {
             H5_FAILED();
-            HDputs("    Got wrong fill value");
+            puts("    Got wrong fill value");
             printf("    Got rd_c.a=%f, rd_c.y=%f and rd_c.x=%d, rd_c.z=%c\n", (double)rd_c.a, rd_c.y, rd_c.x,
                    rd_c.z);
         }
@@ -747,14 +747,14 @@ test_create(hid_t fapl, const char *base_name, H5D_layout_t layout)
         goto error;
     if (alloc_time != H5D_ALLOC_TIME_EARLY) {
         H5_FAILED();
-        HDputs("    Got non-H5D_ALLOC_TIME_EARLY space allocation time.");
+        puts("    Got non-H5D_ALLOC_TIME_EARLY space allocation time.");
         printf("    Got %d\n", alloc_time);
     }
     if (H5Pget_fill_time(dcpl, &fill_time) < 0)
         goto error;
     if (fill_time != H5D_FILL_TIME_NEVER) {
         H5_FAILED();
-        HDputs("    Got non-H5D_FILL_TIME_NEVER fill value write time.");
+        puts("    Got non-H5D_FILL_TIME_NEVER fill value write time.");
         printf("    Got %d\n", fill_time);
     }
     if (H5Dclose(dset5) < 0)
@@ -787,14 +787,14 @@ test_create(hid_t fapl, const char *base_name, H5D_layout_t layout)
         goto error;
     if (alloc_time != H5D_ALLOC_TIME_EARLY) {
         H5_FAILED();
-        HDputs("    Got non-H5D_ALLOC_TIME_EARLY space allocation time.");
+        puts("    Got non-H5D_ALLOC_TIME_EARLY space allocation time.");
         printf("    Got %d\n", alloc_time);
     }
     if (H5Pget_fill_time(dcpl, &fill_time) < 0)
         goto error;
     if (fill_time != H5D_FILL_TIME_ALLOC) {
         H5_FAILED();
-        HDputs("    Got non-H5D_FILL_TIME_ALLOC fill value write time.");
+        puts("    Got non-H5D_FILL_TIME_ALLOC fill value write time.");
         printf("    Got %d\n", fill_time);
     }
     if (H5Dclose(dset6) < 0)
@@ -812,7 +812,7 @@ test_create(hid_t fapl, const char *base_name, H5D_layout_t layout)
     if (!H5_FLT_ABS_EQUAL(rd_c.a, 0) || !H5_DBL_ABS_EQUAL(rd_c.y, fill_ctype.y) || rd_c.x != 0 ||
         rd_c.z != '\0') {
         H5_FAILED();
-        HDputs("    Got wrong fill value");
+        puts("    Got wrong fill value");
         printf("    Got rd_c.a=%f, rd_c.y=%f and rd_c.x=%d, rd_c.z=%c\n", (double)rd_c.a, rd_c.y, rd_c.x,
                rd_c.z);
     }
@@ -901,7 +901,7 @@ test_rdwr_cases(hid_t file, hid_t dcpl, const char *dname, void *_fillval, H5D_f
         fill_c.z = ((comp_datatype *)_fillval)->z;
     }
     else {
-        HDputs("Invalid type for test");
+        puts("Invalid type for test");
         goto error;
     }
 
@@ -1482,8 +1482,8 @@ test_extend_init_cmpd_vl(void *_buf, size_t nelmts, const void *_val)
         *buf = *val;
 
         /* Deep copy string fields */
-        buf->a = HDstrdup(val->a);
-        buf->b = HDstrdup(val->b);
+        buf->a = strdup(val->a);
+        buf->b = strdup(val->b);
 
         buf++;
         nelmts--;
@@ -1511,8 +1511,8 @@ test_extend_verify_cmpd_vl(unsigned lineno, const hsize_t *offset, const void *_
         (const comp_vl_datatype *)_compare_val; /* Value to compare against */
 
     /* Verify value */
-    if ((test_val->x != compare_val->x) || HDstrcmp(test_val->a, compare_val->a) != 0 ||
-        HDstrcmp(test_val->b, compare_val->b) != 0 || (test_val->y != compare_val->y)) {
+    if ((test_val->x != compare_val->x) || strcmp(test_val->a, compare_val->a) != 0 ||
+        strcmp(test_val->b, compare_val->b) != 0 || (test_val->y != compare_val->y)) {
         fprintf(stdout, "%u: Value read was not expected.\n", lineno);
         fprintf(stdout,
                 "    Elmt = {%" PRIuHSIZE ", %" PRIuHSIZE ", %" PRIuHSIZE ", %" PRIuHSIZE ", %" PRIuHSIZE
@@ -1587,8 +1587,8 @@ test_extend_cases(hid_t file, hid_t _dcpl, const char *dset_name, const hsize_t 
     unsigned         i, j; /* Local index variables */
 
     /* Set vl datatype init value strings */
-    init_val_c.a = HDstrdup("baz");
-    init_val_c.b = HDstrdup("mumble");
+    init_val_c.a = strdup("baz");
+    init_val_c.b = strdup("mumble");
 
     /* Make copy of dataset creation property list */
     if ((dcpl = H5Pcopy(_dcpl)) < 0)
@@ -2052,8 +2052,8 @@ test_extend(hid_t fapl, const char *base_name, H5D_layout_t layout)
         TESTING("contiguous dataset extend");
 
     /* Set vl datatype fill value strings */
-    fillval_c.a = HDstrdup("foo");
-    fillval_c.b = HDstrdup("bar");
+    fillval_c.a = strdup("foo");
+    fillval_c.b = strdup("bar");
 
     /* Create dataset creation property list */
     if ((dcpl = H5Pcreate(H5P_DATASET_CREATE)) < 0)
@@ -2112,7 +2112,7 @@ test_extend(hid_t fapl, const char *base_name, H5D_layout_t layout)
      */
     if (H5D_CONTIGUOUS == layout) {
         SKIPPED();
-        HDputs("    Not implemented yet -- needs H5S_SELECT_DIFF operator");
+        puts("    Not implemented yet -- needs H5S_SELECT_DIFF operator");
         goto skip;
     }
 #endif
@@ -2226,7 +2226,7 @@ test_compatible(void)
         goto error;
     if (dims[0] != 8 || dims[1] != 8) {
         H5_FAILED();
-        HDputs("    Got a different dimension size than what was set.");
+        puts("    Got a different dimension size than what was set.");
         printf("    Got dims[0]=%ld, dims[1]=%ld, set 8x8\n", (long)dims[0], (long)dims[1]);
         goto error;
     }
@@ -2238,7 +2238,7 @@ test_compatible(void)
         goto error;
     if (val_rd != 0) {
         H5_FAILED();
-        HDputs("    Got a different value than what was set.");
+        puts("    Got a different value than what was set.");
         printf("    Got %ld, set 0\n", (long)val_rd);
         goto error;
     }
@@ -2279,7 +2279,7 @@ test_compatible(void)
         goto error;
     if (dims[0] != 8 || dims[1] != 8) {
         H5_FAILED();
-        HDputs("    Got a different dimension size than what was set.");
+        puts("    Got a different dimension size than what was set.");
         printf("    Got dims[0]=%ld, dims[1]=%ld, set 8x8\n", (long)dims[0], (long)dims[1]);
         goto error;
     }
@@ -2291,7 +2291,7 @@ test_compatible(void)
         goto error;
     if (val_rd != fill_val) {
         H5_FAILED();
-        HDputs("    Got a different value than what was set.");
+        puts("    Got a different value than what was set.");
         printf("    Got %ld, set %ld\n", (long)val_rd, (long)fill_val);
         goto error;
     }
@@ -2613,11 +2613,11 @@ main(int argc, char *argv[])
     if (argc >= 2) {
         test_contig = test_chunk = test_compact = 0;
         for (argno = 1; argno < argc; argno++) {
-            if (!HDstrcmp(argv[argno], "contiguous"))
+            if (!strcmp(argv[argno], "contiguous"))
                 test_contig = 1;
-            else if (!HDstrcmp(argv[argno], "chunked"))
+            else if (!strcmp(argv[argno], "chunked"))
                 test_chunk = 1;
-            else if (!HDstrcmp(argv[argno], "compact"))
+            else if (!strcmp(argv[argno], "compact"))
                 test_compact = 1;
             else {
                 fprintf(stderr, "usage: %s [contiguous] [chunked] [compact]\n", argv[0]);
@@ -2650,11 +2650,11 @@ main(int argc, char *argv[])
 
         /* Set the FAPL for the type of format */
         if (new_format) {
-            HDputs("\nTesting with new file format:");
+            puts("\nTesting with new file format:");
             my_fapl = fapl2;
         } /* end if */
         else {
-            HDputs("Testing with old file format:");
+            puts("Testing with old file format:");
             my_fapl = fapl;
         } /* end else */
 
@@ -2692,7 +2692,7 @@ main(int argc, char *argv[])
 
     if (nerrors)
         goto error;
-    HDputs("All fill value tests passed.");
+    puts("All fill value tests passed.");
 
     if (h5_cleanup(FILENAME, fapl))
         HDremove(FILE_NAME_RAW);
@@ -2700,6 +2700,6 @@ main(int argc, char *argv[])
     exit(EXIT_SUCCESS);
 
 error:
-    HDputs("***** FILL VALUE TESTS FAILED *****");
+    puts("***** FILL VALUE TESTS FAILED *****");
     exit(EXIT_FAILURE);
 }

--- a/test/filter_fail.c
+++ b/test/filter_fail.c
@@ -159,7 +159,7 @@ test_filter_write(char *file_name, hid_t my_fapl, bool cache_enabled)
         H5E_END_TRY
         if (ret >= 0) {
             H5_FAILED();
-            HDputs("    Data writing is supposed to fail because the chunk can't be written to file.");
+            puts("    Data writing is supposed to fail because the chunk can't be written to file.");
             TEST_ERROR;
         }
     }
@@ -180,7 +180,7 @@ test_filter_write(char *file_name, hid_t my_fapl, bool cache_enabled)
         H5E_END_TRY
         if (ret >= 0) {
             H5_FAILED();
-            HDputs("    Dataset is supposed to fail because the chunk can't be flushed to file.");
+            puts("    Dataset is supposed to fail because the chunk can't be flushed to file.");
             TEST_ERROR;
         }
     }

--- a/test/filter_plugin.c
+++ b/test/filter_plugin.c
@@ -374,13 +374,13 @@ ensure_filter_works(hid_t fid, const char *name, hid_t dcpl_id)
     /* Save the data written to the file for later comparison when the file
      * is reopened for read test.
      */
-    if (!HDstrcmp(name, DSET_DEFLATE_NAME))
+    if (!strcmp(name, DSET_DEFLATE_NAME))
         save_array = &orig_deflate_g;
-    else if (!HDstrcmp(name, DSET_FILTER1_NAME))
+    else if (!strcmp(name, DSET_FILTER1_NAME))
         save_array = &orig_dynlib1_g;
-    else if (!HDstrcmp(name, DSET_FILTER2_NAME))
+    else if (!strcmp(name, DSET_FILTER2_NAME))
         save_array = &orig_dynlib2_g;
-    else if (!HDstrcmp(name, DSET_FILTER3_NAME))
+    else if (!strcmp(name, DSET_FILTER3_NAME))
         save_array = &orig_dynlib4_g;
     else
         TEST_ERROR;
@@ -448,7 +448,7 @@ test_dataset_write_with_filters(hid_t fid)
      * STEP 1: Test deflation by itself.
      *----------------------------------------------------------
      */
-    HDputs("Testing dataset writes with deflate filter");
+    puts("Testing dataset writes with deflate filter");
 #ifdef H5_HAVE_FILTER_DEFLATE
     if ((dcpl_id = H5Pcreate(H5P_DATASET_CREATE)) < 0)
         TEST_ERROR;
@@ -467,14 +467,14 @@ test_dataset_write_with_filters(hid_t fid)
         TEST_ERROR;
 #else  /* H5_HAVE_FILTER_DEFLATE */
     SKIPPED();
-    HDputs("    Deflate filter not enabled");
+    puts("    Deflate filter not enabled");
 #endif /* H5_HAVE_FILTER_DEFLATE */
 
     /*----------------------------------------------------------
      * STEP 2: Test filter plugin 1 by itself.
      *----------------------------------------------------------
      */
-    HDputs("    dataset writes with filter plugin 1");
+    puts("    dataset writes with filter plugin 1");
     if ((dcpl_id = H5Pcreate(H5P_DATASET_CREATE)) < 0)
         TEST_ERROR;
     if (H5Pset_chunk(dcpl_id, 2, chunk_sizes_g) < 0)
@@ -506,7 +506,7 @@ test_dataset_write_with_filters(hid_t fid)
      * STEP 3: Test filter plugin 2 by itself.
      *----------------------------------------------------------
      */
-    HDputs("    dataset writes with filter plugin 2");
+    puts("    dataset writes with filter plugin 2");
     if ((dcpl_id = H5Pcreate(H5P_DATASET_CREATE)) < 0)
         TEST_ERROR;
     if (H5Pset_chunk(dcpl_id, 2, chunk_sizes_g) < 0)
@@ -534,7 +534,7 @@ test_dataset_write_with_filters(hid_t fid)
      *         (This filter plugin makes HDF5 API calls)
      *----------------------------------------------------------
      */
-    HDputs("    dataset writes with filter plugin 3");
+    puts("    dataset writes with filter plugin 3");
     if ((dcpl_id = H5Pcreate(H5P_DATASET_CREATE)) < 0)
         TEST_ERROR;
     if (H5Pset_chunk(dcpl_id, 2, chunk_sizes_g) < 0)
@@ -656,7 +656,7 @@ test_dataset_read_with_filters(hid_t fid)
 
 #else  /* H5_HAVE_FILTER_DEFLATE */
     SKIPPED();
-    HDputs("    Deflate filter not enabled");
+    puts("    Deflate filter not enabled");
 #endif /* H5_HAVE_FILTER_DEFLATE */
 
     /*----------------------------------------------------------
@@ -849,8 +849,8 @@ test_creating_groups_using_plugins(hid_t fid)
     for (i = 0; i < N_SUBGROUPS; i++) {
         char *sp = subgroup_name;
 
-        sp += HDsnprintf(subgroup_name, sizeof(subgroup_name), SUBGROUP_PREFIX);
-        HDsprintf(sp, "%d", i);
+        sp += snprintf(subgroup_name, sizeof(subgroup_name), SUBGROUP_PREFIX);
+        sprintf(sp, "%d", i);
 
         if ((sub_gid = H5Gcreate2(gid, subgroup_name, H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT)) < 0)
             TEST_ERROR;
@@ -908,8 +908,8 @@ test_opening_groups_using_plugins(hid_t fid)
     for (i = 0; i < N_SUBGROUPS; i++) {
         char *sp = subgroup_name;
 
-        sp += HDsnprintf(subgroup_name, sizeof(subgroup_name), SUBGROUP_PREFIX);
-        HDsprintf(sp, "%d", i);
+        sp += snprintf(subgroup_name, sizeof(subgroup_name), SUBGROUP_PREFIX);
+        sprintf(sp, "%d", i);
 
         if ((sub_gid = H5Gopen2(gid, subgroup_name, H5P_DEFAULT)) < 0)
             TEST_ERROR;
@@ -958,7 +958,7 @@ test_path_api_calls(void)
     char         path[256];
     char         temp_name[256];
 
-    HDputs("Testing access to the filter path table");
+    puts("Testing access to the filter path table");
 
     if (H5Zfilter_avail(FILTER1_ID) != true)
         TEST_ERROR;
@@ -1017,7 +1017,7 @@ test_path_api_calls(void)
 
     /* Add a bunch of paths to the path table */
     for (u = 0; u < n_starting_paths; u++) {
-        HDsnprintf(path, sizeof(path), "a_path_%u", u);
+        snprintf(path, sizeof(path), "a_path_%u", u);
         if (H5PLappend(path) < 0) {
             fprintf(stderr, "    at %u: %s\n", u, path);
             TEST_ERROR;
@@ -1063,7 +1063,7 @@ test_path_api_calls(void)
         fprintf(stderr, "    get 0 len: %zd : %s\n", path_len, path);
         TEST_ERROR;
     }
-    if (HDstrcmp(path, "a_path_0") != 0) {
+    if (strcmp(path, "a_path_0") != 0) {
         fprintf(stderr, "    get 0: %s\n", path);
         TEST_ERROR;
     }
@@ -1075,7 +1075,7 @@ test_path_api_calls(void)
     /* Get path at index 1 */
     if ((path_len = H5PLget(1, path, 256)) <= 0)
         TEST_ERROR;
-    if (HDstrcmp(path, "a_path_1") != 0) {
+    if (strcmp(path, "a_path_1") != 0) {
         fprintf(stderr, "    get 1: %s\n", path);
         TEST_ERROR;
     }
@@ -1083,8 +1083,8 @@ test_path_api_calls(void)
     /* Get path at the last index */
     if ((path_len = H5PLget(n_starting_paths - 1, path, 256)) <= 0)
         TEST_ERROR;
-    HDsnprintf(temp_name, sizeof(temp_name), "a_path_%u", n_starting_paths - 1);
-    if (HDstrcmp(path, temp_name) != 0) {
+    snprintf(temp_name, sizeof(temp_name), "a_path_%u", n_starting_paths - 1);
+    if (strcmp(path, temp_name) != 0) {
         fprintf(stderr, "    get %u: %s\n", n_starting_paths - 1, path);
         TEST_ERROR;
     }
@@ -1121,7 +1121,7 @@ test_path_api_calls(void)
     /* Verify that the entries were moved */
     if ((path_len = H5PLget(8, path, 256)) <= 0)
         TEST_ERROR;
-    if (HDstrcmp(path, "a_path_9") != 0) {
+    if (strcmp(path, "a_path_9") != 0) {
         fprintf(stderr, "    get 8: %s\n", path);
         TEST_ERROR;
     }
@@ -1137,7 +1137,7 @@ test_path_api_calls(void)
     TESTING("    prepend");
 
     /* Prepend one path */
-    HDsnprintf(path, sizeof(path), "a_path_%d", n_starting_paths + 1);
+    snprintf(path, sizeof(path), "a_path_%d", n_starting_paths + 1);
     if (H5PLprepend(path) < 0) {
         fprintf(stderr, "    prepend %u: %s\n", n_starting_paths + 1, path);
         TEST_ERROR;
@@ -1152,7 +1152,7 @@ test_path_api_calls(void)
     /* Verify that the entries were moved */
     if (H5PLget(8, path, 256) <= 0)
         TEST_ERROR;
-    if (HDstrcmp(path, "a_path_7") != 0) {
+    if (strcmp(path, "a_path_7") != 0) {
         fprintf(stderr, "    get 8: %s\n", path);
         TEST_ERROR;
     }
@@ -1160,8 +1160,8 @@ test_path_api_calls(void)
     /* Verify that the path was inserted at index zero */
     if (H5PLget(0, path, 256) <= 0)
         TEST_ERROR;
-    HDsnprintf(temp_name, sizeof(temp_name), "a_path_%d", n_starting_paths + 1);
-    if (HDstrcmp(path, temp_name) != 0) {
+    snprintf(temp_name, sizeof(temp_name), "a_path_%d", n_starting_paths + 1);
+    if (strcmp(path, temp_name) != 0) {
         fprintf(stderr, "    get 0: %s\n", path);
         TEST_ERROR;
     }
@@ -1175,7 +1175,7 @@ test_path_api_calls(void)
     TESTING("    replace");
 
     /* Replace one path at index 1 */
-    HDsnprintf(path, sizeof(path), "a_path_%u", n_starting_paths + 4);
+    snprintf(path, sizeof(path), "a_path_%u", n_starting_paths + 4);
     if (H5PLreplace(path, 1) < 0) {
         fprintf(stderr, "    replace 1: %s\n", path);
         TEST_ERROR;
@@ -1194,8 +1194,8 @@ test_path_api_calls(void)
     /* Check path at index 0 */
     if (H5PLget(0, path, 256) <= 0)
         TEST_ERROR;
-    HDsnprintf(temp_name, sizeof(temp_name), "a_path_%u", n_starting_paths + 1);
-    if (HDstrcmp(path, temp_name) != 0) {
+    snprintf(temp_name, sizeof(temp_name), "a_path_%u", n_starting_paths + 1);
+    if (strcmp(path, temp_name) != 0) {
         fprintf(stderr, "    get 0: %s\n", path);
         TEST_ERROR;
     }
@@ -1203,7 +1203,7 @@ test_path_api_calls(void)
     /* Check path at index 2 */
     if (H5PLget(2, path, 256) <= 0)
         TEST_ERROR;
-    if (HDstrcmp(path, "a_path_1") != 0) {
+    if (strcmp(path, "a_path_1") != 0) {
         fprintf(stderr, "    get 2: %s\n", path);
         TEST_ERROR;
     }
@@ -1227,7 +1227,7 @@ test_path_api_calls(void)
     /* Verify that the entries were moved */
     if (H5PLget(4, path, 256) <= 0)
         TEST_ERROR;
-    if (HDstrcmp(path, "a_path_4") != 0) {
+    if (strcmp(path, "a_path_4") != 0) {
         fprintf(stderr, "    get 4: %s\n", path);
         TEST_ERROR;
     }
@@ -1242,7 +1242,7 @@ test_path_api_calls(void)
     TESTING("    insert");
 
     /* Insert one path at index 3*/
-    HDsnprintf(path, sizeof(path), "a_path_%d", n_starting_paths + 5);
+    snprintf(path, sizeof(path), "a_path_%d", n_starting_paths + 5);
     if (H5PLinsert(path, 3) < 0) {
         fprintf(stderr, "    insert 3: %s\n", path);
         TEST_ERROR;
@@ -1251,7 +1251,7 @@ test_path_api_calls(void)
     /* Verify that the entries were moved */
     if (H5PLget(4, path, 256) <= 0)
         TEST_ERROR;
-    if (HDstrcmp(path, "a_path_2") != 0) {
+    if (strcmp(path, "a_path_2") != 0) {
         fprintf(stderr, "    get 4: %s\n", path);
         TEST_ERROR;
     }
@@ -1315,7 +1315,7 @@ test_filter_numbers(void)
     unsigned int flags;
     unsigned int filter_config;
 
-    HDputs("Testing filter number handling");
+    puts("Testing filter number handling");
 
     /* Check that out-of-range filter numbers are handled correctly */
     TESTING("    Filter # out of range");
@@ -1462,7 +1462,7 @@ main(void)
 
         /* Set the FAPL for the type of format */
         if (new_format) {
-            HDputs("\nTesting with new file format:");
+            puts("\nTesting with new file format:");
             /* Copy the file access property list and set the latest file format on it */
             if ((new_ff_fapl_id = H5Pcopy(old_ff_fapl_id)) < 0)
                 TEST_ERROR;
@@ -1472,7 +1472,7 @@ main(void)
             my_fapl_id = new_ff_fapl_id;
         }
         else {
-            HDputs("Testing with old file format:");
+            puts("Testing with old file format:");
             my_fapl_id = old_ff_fapl_id;
         }
 
@@ -1504,7 +1504,7 @@ main(void)
         /* ENSURE THAT READING FROM DATASETS AND OPENING GROUPS WORKS      */
         /*******************************************************************/
 
-        HDputs("\nTesting reading data with with dynamic plugin filters:");
+        puts("\nTesting reading data with with dynamic plugin filters:");
 
         /* Close the library so that all loaded plugin libraries are unloaded */
         h5_reset();

--- a/test/flush1.c
+++ b/test/flush1.c
@@ -74,7 +74,7 @@ create_file(const char *filename, hid_t fapl_id, bool swmr)
     if ((top_gid = H5Gcreate2(fid, "top_group", H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT)) < 0)
         STACK_ERROR;
     for (i = 0; i < NGROUPS; i++) {
-        HDsnprintf(group_name, sizeof(group_name), "group%02d", i);
+        snprintf(group_name, sizeof(group_name), "group%02d", i);
         if ((gid = H5Gcreate2(top_gid, group_name, H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT)) < 0)
             STACK_ERROR;
         if (H5Gclose(gid) < 0)

--- a/test/flush2.c
+++ b/test/flush2.c
@@ -134,7 +134,7 @@ file_ok(const char *filename, hid_t fapl_id, bool check_second_dset)
     if ((top_gid = H5Gopen2(fid, "top_group", H5P_DEFAULT)) < 0)
         goto error;
     for (i = 0; i < NGROUPS; i++) {
-        HDsnprintf(group_name, sizeof(group_name), "group%02d", i);
+        snprintf(group_name, sizeof(group_name), "group%02d", i);
         if ((gid = H5Gopen2(top_gid, group_name, H5P_DEFAULT)) < 0)
             goto error;
         if (H5Gclose(gid) < 0)
@@ -288,7 +288,7 @@ main(void)
     if (file_ok(filename, fapl_id, check_second_dset)) {
 #if defined H5_HAVE_WIN32_API && !defined(hdf5_EXPORTS)
         SKIPPED();
-        HDputs("   the DLL will flush the file even when calling _exit, skip this test temporarily");
+        puts("   the DLL will flush the file even when calling _exit, skip this test temporarily");
 #else
         TEST_ERROR;
 #endif
@@ -315,7 +315,7 @@ main(void)
         if (file_ok(filename, fapl_id, check_second_dset)) {
 #if defined H5_HAVE_WIN32_API && !defined(hdf5_EXPORTS)
             SKIPPED();
-            HDputs("   the DLL will flush the file even when calling _exit, skip this test temporarily");
+            puts("   the DLL will flush the file even when calling _exit, skip this test temporarily");
 #else
             TEST_ERROR;
 #endif
@@ -374,7 +374,7 @@ main(void)
     if (file_ok(filename, fapl_id, check_second_dset)) {
 #if defined H5_HAVE_WIN32_API && !defined(hdf5_EXPORTS)
         SKIPPED();
-        HDputs("   the DLL will flush the file even when calling _exit, skip this test temporarily");
+        puts("   the DLL will flush the file even when calling _exit, skip this test temporarily");
 #else
         TEST_ERROR;
 #endif
@@ -403,7 +403,7 @@ main(void)
         if (file_ok(filename, fapl_id, check_second_dset)) {
 #if defined H5_HAVE_WIN32_API && !defined(hdf5_EXPORTS)
             SKIPPED();
-            HDputs("   the DLL will flush the file even when calling _exit, skip this test temporarily");
+            puts("   the DLL will flush the file even when calling _exit, skip this test temporarily");
 #else
             TEST_ERROR;
 #endif

--- a/test/flushrefresh.c
+++ b/test/flushrefresh.c
@@ -1068,13 +1068,13 @@ flush_verification(const char *obj_pathname, const char *expected)
     H5E_END_TRY
 
     /* Compare to expected result */
-    if (HDstrcmp(expected, FLUSHED) == 0) {
+    if (strcmp(expected, FLUSHED) == 0) {
         if ((oid < 0) || (status < 0)) {
             fprintf(stderr, "Error! %s should be on disk, but was NOT!\n", obj_pathname);
             PROCESS_ERROR;
         } /* end if */
     }
-    else if (HDstrcmp(expected, NOT_FLUSHED) == 0) {
+    else if (strcmp(expected, NOT_FLUSHED) == 0) {
         if ((oid > 0) || (status > 0)) {
             fprintf(stderr, "Error! %s not expected to be flushed, but it was found on disk!\n",
                     obj_pathname);
@@ -1265,20 +1265,20 @@ refresh_verification(const char *obj_pathname)
      * test cases is easy). */
     do {
 
-        if ((HDstrcmp(obj_pathname, D1) == 0) || (HDstrcmp(obj_pathname, D2) == 0)) {
+        if ((strcmp(obj_pathname, D1) == 0) || (strcmp(obj_pathname, D2) == 0)) {
             if (H5Drefresh(oid) < 0)
                 PROCESS_ERROR;
         } /* end if */
-        else if ((HDstrcmp(obj_pathname, G1) == 0) || (HDstrcmp(obj_pathname, G2) == 0)) {
+        else if ((strcmp(obj_pathname, G1) == 0) || (strcmp(obj_pathname, G2) == 0)) {
             if (H5Grefresh(oid) < 0)
                 PROCESS_ERROR;
         } /* end if */
-        else if ((HDstrcmp(obj_pathname, T1) == 0) || (HDstrcmp(obj_pathname, T2) == 0)) {
+        else if ((strcmp(obj_pathname, T1) == 0) || (strcmp(obj_pathname, T2) == 0)) {
             if (H5Trefresh(oid) < 0)
                 PROCESS_ERROR;
         } /* end if */
-        else if ((HDstrcmp(obj_pathname, D3) == 0) || (HDstrcmp(obj_pathname, G3) == 0) ||
-                 (HDstrcmp(obj_pathname, T3) == 0)) {
+        else if ((strcmp(obj_pathname, D3) == 0) || (strcmp(obj_pathname, G3) == 0) ||
+                 (strcmp(obj_pathname, T3) == 0)) {
             if (H5Orefresh(oid) < 0)
                 PROCESS_ERROR;
         } /* end if */

--- a/test/freespace.c
+++ b/test/freespace.c
@@ -2910,7 +2910,7 @@ main(void)
 
     if (nerrors)
         goto error;
-    HDputs("All free-space tests passed.");
+    puts("All free-space tests passed.");
 
     /* Pop API context */
     if (api_ctx_pushed && H5CX_pop(false) < 0)
@@ -2921,7 +2921,7 @@ main(void)
     exit(EXIT_SUCCESS);
 
 error:
-    HDputs("*** TESTS FAILED ***");
+    puts("*** TESTS FAILED ***");
     H5E_BEGIN_TRY
     {
         H5Pclose(fapl);

--- a/test/gen_bad_ohdr.c
+++ b/test/gen_bad_ohdr.c
@@ -109,7 +109,7 @@ error:
     }
     H5E_END_TRY
 #else  /* H5O_ENABLE_BAD_MESG_COUNT */
-    HDputs("H5O_BAD_MESG_COUNT compiler macro not defined!");
+    puts("H5O_BAD_MESG_COUNT compiler macro not defined!");
 #endif /* H5O_ENABLE_BAD_MESG_COUNT */
     return 1;
 }

--- a/test/gen_bogus.c
+++ b/test/gen_bogus.c
@@ -176,7 +176,7 @@ error:
     }
     H5E_END_TRY
 #else  /* H5O_ENABLE_BOGUS */
-    HDputs("H5O_ENABLE_BOGUS compiler macro not defined!");
+    puts("H5O_ENABLE_BOGUS compiler macro not defined!");
 #endif /* H5O_ENABLE_BOGUS */
     return 1;
 }

--- a/test/gen_cross.c
+++ b/test/gen_cross.c
@@ -879,7 +879,7 @@ create_deflate_dsets_float(hid_t fid, hid_t fsid, hid_t msid)
 #else  /* H5_HAVE_FILTER_DEFLATE */
     const char *not_supported = "Deflate filter is not enabled. Can't create the dataset.";
 
-    HDputs(not_supported);
+    puts(not_supported);
 #endif /* H5_HAVE_FILTER_DEFLATE */
 
     return 0;
@@ -1263,7 +1263,7 @@ main(void)
     if (create_szip_dsets_float(file, filespace, memspace) < 0)
         TEST_ERROR;
 #else  /* H5_HAVE_FILTER_SZIP */
-    HDputs("Szip filter is not enabled. Can't create the dataset.");
+    puts("Szip filter is not enabled. Can't create the dataset.");
 #endif /* H5_HAVE_FILTER_SZIP */
 
     /* Create a dataset of FLOAT with shuffle filter */

--- a/test/gen_plist.c
+++ b/test/gen_plist.c
@@ -455,8 +455,8 @@ encode_plist(hid_t plist_id, int little_endian, int word_length, const char *fil
     char                          filename[1024];
 
     /* Generate filename */
-    if ((ret = HDsnprintf(filename, sizeof(filename), "%s%d%s", filename_prefix, word_length,
-                          little_endian ? "le" : "be")) < 0)
+    if ((ret = snprintf(filename, sizeof(filename), "%s%d%s", filename_prefix, word_length,
+                        little_endian ? "le" : "be")) < 0)
         assert(ret > 0);
 
     /* first call to encode returns only the size of the buffer needed */

--- a/test/genall5.c
+++ b/test/genall5.c
@@ -294,7 +294,7 @@ ns_grp_c(hid_t fid, const char *group_name, unsigned nlinks)
     while ((pass) && (u < nlinks)) {
         char linkname[16];
 
-        HDsnprintf(linkname, sizeof(linkname), "%u", u);
+        snprintf(linkname, sizeof(linkname), "%u", u);
 
         if (0 == (u % 3)) {
             ret = H5Lcreate_soft(group_name, gid, linkname, H5P_DEFAULT, H5P_DEFAULT);
@@ -459,7 +459,7 @@ vrfy_ns_grp_c(hid_t fid, const char *group_name, unsigned nlinks)
         char        linkname[16];
         htri_t      link_exists;
 
-        HDsnprintf(linkname, sizeof(linkname), "%u", u);
+        snprintf(linkname, sizeof(linkname), "%u", u);
         link_exists = H5Lexists(gid, linkname, H5P_DEFAULT);
 
         if (link_exists < 0) {
@@ -499,12 +499,12 @@ vrfy_ns_grp_c(hid_t fid, const char *group_name, unsigned nlinks)
                 pass         = false;
                 failure_mssg = "vrfy_ns_grp_c: H5L_TYPE_SOFT != lnk_info.type";
             }
-            else if ((HDstrlen(group_name) + 1) != lnk_info.u.val_size) {
+            else if ((strlen(group_name) + 1) != lnk_info.u.val_size) {
                 pass         = false;
-                failure_mssg = "vrfy_ns_grp_c: (HDstrlen(group_name) + 1) != lnk_info.u.val_size";
+                failure_mssg = "vrfy_ns_grp_c: (strlen(group_name) + 1) != lnk_info.u.val_size";
             }
             assert(H5L_TYPE_SOFT == lnk_info.type);
-            assert((HDstrlen(group_name) + 1) == lnk_info.u.val_size);
+            assert((strlen(group_name) + 1) == lnk_info.u.val_size);
 
             slinkval = (char *)malloc(lnk_info.u.val_size);
 
@@ -519,12 +519,12 @@ vrfy_ns_grp_c(hid_t fid, const char *group_name, unsigned nlinks)
                 pass         = false;
                 failure_mssg = "vrfy_ns_grp_c: H5Lget_val() failed";
             }
-            else if (0 != HDstrcmp(slinkval, group_name)) {
+            else if (0 != strcmp(slinkval, group_name)) {
                 pass         = false;
-                failure_mssg = "vrfy_ns_grp_c: 0 != HDstrcmp(slinkval, group_name)";
+                failure_mssg = "vrfy_ns_grp_c: 0 != strcmp(slinkval, group_name)";
             }
             assert(ret >= 0);
-            assert(0 == HDstrcmp(slinkval, group_name));
+            assert(0 == strcmp(slinkval, group_name));
 
             free(slinkval);
         } /* end if */
@@ -592,17 +592,17 @@ vrfy_ns_grp_c(hid_t fid, const char *group_name, unsigned nlinks)
                 pass         = false;
                 failure_mssg = "vrfy_ns_grp_c: H5Lunpack_elink_val() failed.";
             }
-            else if (0 != HDstrcmp(file, "external.h5")) {
+            else if (0 != strcmp(file, "external.h5")) {
                 pass         = false;
-                failure_mssg = "vrfy_ns_grp_c: 0 != HDstrcmp(file, \"external.h5\")";
+                failure_mssg = "vrfy_ns_grp_c: 0 != strcmp(file, \"external.h5\")";
             }
-            else if (0 != HDstrcmp(path, "/ext")) {
+            else if (0 != strcmp(path, "/ext")) {
                 pass         = false;
-                failure_mssg = "vrfy_ns_grp_c: 0 != HDstrcmp(path, \"/ext\")";
+                failure_mssg = "vrfy_ns_grp_c: 0 != strcmp(path, \"/ext\")";
             }
             assert(ret >= 0);
-            assert(0 == HDstrcmp(file, "external.h5"));
-            assert(0 == HDstrcmp(path, "/ext"));
+            assert(0 == strcmp(file, "external.h5"));
+            assert(0 == strcmp(path, "/ext"));
 
             free(elinkval);
         } /* end else */
@@ -697,7 +697,7 @@ ns_grp_d(hid_t fid, const char *group_name, unsigned nlinks)
     while ((pass) && (u < nlinks)) {
         char linkname[16];
 
-        HDsnprintf(linkname, sizeof(linkname), "%u", u);
+        snprintf(linkname, sizeof(linkname), "%u", u);
 
         if (0 == (u % 3)) {
             ret = H5Lcreate_soft(group_name, gid, linkname, H5P_DEFAULT, H5P_DEFAULT);
@@ -862,7 +862,7 @@ vrfy_ns_grp_d(hid_t fid, const char *group_name, unsigned nlinks)
         char        linkname[16];
         htri_t      link_exists;
 
-        HDsnprintf(linkname, sizeof(linkname), "%u", u);
+        snprintf(linkname, sizeof(linkname), "%u", u);
         link_exists = H5Lexists(gid, linkname, H5P_DEFAULT);
 
         if (link_exists < 0) {
@@ -902,12 +902,12 @@ vrfy_ns_grp_d(hid_t fid, const char *group_name, unsigned nlinks)
                 pass         = false;
                 failure_mssg = "vrfy_ns_grp_d: H5L_TYPE_SOFT != lnk_info.type";
             }
-            else if ((HDstrlen(group_name) + 1) != lnk_info.u.val_size) {
+            else if ((strlen(group_name) + 1) != lnk_info.u.val_size) {
                 pass         = false;
                 failure_mssg = "vrfy_ns_grp_d: H5L_TYPE_SOFT != lnk_info.type";
             }
             assert(H5L_TYPE_SOFT == lnk_info.type);
-            assert((HDstrlen(group_name) + 1) == lnk_info.u.val_size);
+            assert((strlen(group_name) + 1) == lnk_info.u.val_size);
 
             slinkval = (char *)malloc(lnk_info.u.val_size);
 
@@ -922,12 +922,12 @@ vrfy_ns_grp_d(hid_t fid, const char *group_name, unsigned nlinks)
                 pass         = false;
                 failure_mssg = "vrfy_ns_grp_d: H5Lget_val() failed";
             }
-            else if (0 != HDstrcmp(slinkval, group_name)) {
+            else if (0 != strcmp(slinkval, group_name)) {
                 pass         = false;
-                failure_mssg = "vrfy_ns_grp_d: 0 != HDstrcmp(slinkval, group_name)";
+                failure_mssg = "vrfy_ns_grp_d: 0 != strcmp(slinkval, group_name)";
             }
             assert(ret >= 0);
-            assert(0 == HDstrcmp(slinkval, group_name));
+            assert(0 == strcmp(slinkval, group_name));
 
             free(slinkval);
         } /* end if */
@@ -994,17 +994,17 @@ vrfy_ns_grp_d(hid_t fid, const char *group_name, unsigned nlinks)
                 pass         = false;
                 failure_mssg = "vrfy_ns_grp_d: H5Lunpack_elink_val failed.";
             }
-            else if (0 != HDstrcmp(file, "external.h5")) {
+            else if (0 != strcmp(file, "external.h5")) {
                 pass         = false;
-                failure_mssg = "vrfy_ns_grp_d: 0 != HDstrcmp(file, \"external.h5\").";
+                failure_mssg = "vrfy_ns_grp_d: 0 != strcmp(file, \"external.h5\").";
             }
-            else if (0 != HDstrcmp(path, "/ext")) {
+            else if (0 != strcmp(path, "/ext")) {
                 pass         = false;
-                failure_mssg = "vrfy_ns_grp_d: 0 != HDstrcmp(path, \"/ext\")";
+                failure_mssg = "vrfy_ns_grp_d: 0 != strcmp(path, \"/ext\")";
             }
             assert(ret >= 0);
-            assert(0 == HDstrcmp(file, "external.h5"));
-            assert(0 == HDstrcmp(path, "/ext"));
+            assert(0 == strcmp(file, "external.h5"));
+            assert(0 == strcmp(path, "/ext"));
 
             free(elinkval);
         } /* end else */
@@ -1291,7 +1291,7 @@ os_grp_n(hid_t fid, const char *group_name, int proc_num, unsigned nlinks)
     while ((pass) && (u < nlinks)) {
         char linkname[32];
 
-        HDsnprintf(linkname, sizeof(linkname), "ln%d_%u", proc_num, u);
+        snprintf(linkname, sizeof(linkname), "ln%d_%u", proc_num, u);
 
         if (0 == (u % 2)) {
             ret = H5Lcreate_soft(group_name, gid, linkname, H5P_DEFAULT, H5P_DEFAULT);
@@ -1446,7 +1446,7 @@ vrfy_os_grp_n(hid_t fid, const char *group_name, int proc_num, unsigned nlinks)
         char        linkname[32];
         htri_t      link_exists;
 
-        HDsnprintf(linkname, sizeof(linkname), "ln%d_%u", proc_num, u);
+        snprintf(linkname, sizeof(linkname), "ln%d_%u", proc_num, u);
         link_exists = H5Lexists(gid, linkname, H5P_DEFAULT);
 
         if (link_exists < 0) {
@@ -1481,12 +1481,12 @@ vrfy_os_grp_n(hid_t fid, const char *group_name, int proc_num, unsigned nlinks)
                 pass         = false;
                 failure_mssg = "vrfy_os_grp_n: H5L_TYPE_SOFT != lnk_info.type";
             }
-            else if ((HDstrlen(group_name) + 1) != lnk_info.u.val_size) {
+            else if ((strlen(group_name) + 1) != lnk_info.u.val_size) {
                 pass         = false;
-                failure_mssg = "vrfy_os_grp_n: (HDstrlen(group_name) + 1) != lnk_info.u.val_size";
+                failure_mssg = "vrfy_os_grp_n: (strlen(group_name) + 1) != lnk_info.u.val_size";
             }
             assert(H5L_TYPE_SOFT == lnk_info.type);
-            assert((HDstrlen(group_name) + 1) == lnk_info.u.val_size);
+            assert((strlen(group_name) + 1) == lnk_info.u.val_size);
 
             slinkval = (char *)malloc(lnk_info.u.val_size);
 
@@ -1502,12 +1502,12 @@ vrfy_os_grp_n(hid_t fid, const char *group_name, int proc_num, unsigned nlinks)
                 pass         = false;
                 failure_mssg = "vrfy_os_grp_n: H5Lget_val() failed";
             }
-            else if (0 != HDstrcmp(slinkval, group_name)) {
+            else if (0 != strcmp(slinkval, group_name)) {
                 pass         = false;
-                failure_mssg = "vrfy_os_grp_n: 0 != HDstrcmp(slinkval, group_name)";
+                failure_mssg = "vrfy_os_grp_n: 0 != strcmp(slinkval, group_name)";
             }
             assert(ret >= 0);
-            assert(0 == HDstrcmp(slinkval, group_name));
+            assert(0 == strcmp(slinkval, group_name));
 
             free(slinkval);
         } /* end if */
@@ -2996,27 +2996,27 @@ create_zoo(hid_t fid, const char *base_path, int proc_num)
 
     /* Add & verify an empty "new style" group */
     if (pass) {
-        HDsnprintf(full_path, sizeof(full_path), "%s/A", base_path);
-        assert(HDstrlen(full_path) < 1024);
+        snprintf(full_path, sizeof(full_path), "%s/A", base_path);
+        assert(strlen(full_path) < 1024);
         ns_grp_0(fid, full_path);
     }
 
     if (pass) {
-        HDsnprintf(full_path, sizeof(full_path), "%s/A", base_path);
-        assert(HDstrlen(full_path) < 1024);
+        snprintf(full_path, sizeof(full_path), "%s/A", base_path);
+        assert(strlen(full_path) < 1024);
         vrfy_ns_grp_0(fid, full_path);
     }
 
     /* Add & verify a compact "new style" group (3 link messages) */
     if (pass) {
-        HDsnprintf(full_path, sizeof(full_path), "%s/B", base_path);
-        assert(HDstrlen(full_path) < 1024);
+        snprintf(full_path, sizeof(full_path), "%s/B", base_path);
+        assert(strlen(full_path) < 1024);
         ns_grp_c(fid, full_path, 3);
     }
 
     if (pass) {
-        HDsnprintf(full_path, sizeof(full_path), "%s/B", base_path);
-        assert(HDstrlen(full_path) < 1024);
+        snprintf(full_path, sizeof(full_path), "%s/B", base_path);
+        assert(strlen(full_path) < 1024);
         vrfy_ns_grp_c(fid, full_path, 3);
     }
 
@@ -3024,27 +3024,27 @@ create_zoo(hid_t fid, const char *base_path, int proc_num)
      * fractal heap)
      */
     if (pass) {
-        HDsnprintf(full_path, sizeof(full_path), "%s/C", base_path);
-        assert(HDstrlen(full_path) < 1024);
+        snprintf(full_path, sizeof(full_path), "%s/C", base_path);
+        assert(strlen(full_path) < 1024);
         ns_grp_d(fid, full_path, 300);
     }
 
     if (pass) {
-        HDsnprintf(full_path, sizeof(full_path), "%s/C", base_path);
-        assert(HDstrlen(full_path) < 1024);
+        snprintf(full_path, sizeof(full_path), "%s/C", base_path);
+        assert(strlen(full_path) < 1024);
         vrfy_ns_grp_d(fid, full_path, 300);
     }
 
     /* Add & verify an empty "old style" group to file */
     if (pass) {
-        HDsnprintf(full_path, sizeof(full_path), "%s/D", base_path);
-        assert(HDstrlen(full_path) < 1024);
+        snprintf(full_path, sizeof(full_path), "%s/D", base_path);
+        assert(strlen(full_path) < 1024);
         os_grp_0(fid, full_path);
     }
 
     if (pass) {
-        HDsnprintf(full_path, sizeof(full_path), "%s/D", base_path);
-        assert(HDstrlen(full_path) < 1024);
+        snprintf(full_path, sizeof(full_path), "%s/D", base_path);
+        assert(strlen(full_path) < 1024);
         vrfy_os_grp_0(fid, full_path);
     }
 
@@ -3052,14 +3052,14 @@ create_zoo(hid_t fid, const char *base_path, int proc_num)
      * local heap) to file
      */
     if (pass) {
-        HDsnprintf(full_path, sizeof(full_path), "%s/E", base_path);
-        assert(HDstrlen(full_path) < 1024);
+        snprintf(full_path, sizeof(full_path), "%s/E", base_path);
+        assert(strlen(full_path) < 1024);
         os_grp_n(fid, full_path, proc_num, 300);
     }
 
     if (pass) {
-        HDsnprintf(full_path, sizeof(full_path), "%s/E", base_path);
-        assert(HDstrlen(full_path) < 1024);
+        snprintf(full_path, sizeof(full_path), "%s/E", base_path);
+        assert(strlen(full_path) < 1024);
         vrfy_os_grp_n(fid, full_path, proc_num, 300);
     }
 
@@ -3067,14 +3067,14 @@ create_zoo(hid_t fid, const char *base_path, int proc_num)
      * to file
      */
     if (pass) {
-        HDsnprintf(full_path, sizeof(full_path), "%s/F", base_path);
-        assert(HDstrlen(full_path) < 1024);
+        snprintf(full_path, sizeof(full_path), "%s/F", base_path);
+        assert(strlen(full_path) < 1024);
         ds_ctg_i(fid, full_path, false);
     }
 
     if (pass) {
-        HDsnprintf(full_path, sizeof(full_path), "%s/F", base_path);
-        assert(HDstrlen(full_path) < 1024);
+        snprintf(full_path, sizeof(full_path), "%s/F", base_path);
+        assert(strlen(full_path) < 1024);
         vrfy_ds_ctg_i(fid, full_path, false);
     }
 
@@ -3082,14 +3082,14 @@ create_zoo(hid_t fid, const char *base_path, int proc_num)
      * to file
      */
     if (pass) {
-        HDsnprintf(full_path, sizeof(full_path), "%s/G", base_path);
-        assert(HDstrlen(full_path) < 1024);
+        snprintf(full_path, sizeof(full_path), "%s/G", base_path);
+        assert(strlen(full_path) < 1024);
         ds_ctg_i(fid, full_path, true);
     }
 
     if (pass) {
-        HDsnprintf(full_path, sizeof(full_path), "%s/G", base_path);
-        assert(HDstrlen(full_path) < 1024);
+        snprintf(full_path, sizeof(full_path), "%s/G", base_path);
+        assert(strlen(full_path) < 1024);
         vrfy_ds_ctg_i(fid, full_path, true);
     }
 
@@ -3097,14 +3097,14 @@ create_zoo(hid_t fid, const char *base_path, int proc_num)
      * to file
      */
     if (pass) {
-        HDsnprintf(full_path, sizeof(full_path), "%s/H", base_path);
-        assert(HDstrlen(full_path) < 1024);
+        snprintf(full_path, sizeof(full_path), "%s/H", base_path);
+        assert(strlen(full_path) < 1024);
         ds_chk_i(fid, full_path, false);
     }
 
     if (pass) {
-        HDsnprintf(full_path, sizeof(full_path), "%s/H", base_path);
-        assert(HDstrlen(full_path) < 1024);
+        snprintf(full_path, sizeof(full_path), "%s/H", base_path);
+        assert(strlen(full_path) < 1024);
         vrfy_ds_chk_i(fid, full_path, false);
     }
 
@@ -3112,14 +3112,14 @@ create_zoo(hid_t fid, const char *base_path, int proc_num)
      * to file
      */
     if (pass) {
-        HDsnprintf(full_path, sizeof(full_path), "%s/I", base_path);
-        assert(HDstrlen(full_path) < 1024);
+        snprintf(full_path, sizeof(full_path), "%s/I", base_path);
+        assert(strlen(full_path) < 1024);
         ds_chk_i(fid, full_path, true);
     }
 
     if (pass) {
-        HDsnprintf(full_path, sizeof(full_path), "%s/I", base_path);
-        assert(HDstrlen(full_path) < 1024);
+        snprintf(full_path, sizeof(full_path), "%s/I", base_path);
+        assert(strlen(full_path) < 1024);
         vrfy_ds_chk_i(fid, full_path, true);
     }
 
@@ -3127,14 +3127,14 @@ create_zoo(hid_t fid, const char *base_path, int proc_num)
      * to file
      */
     if (pass) {
-        HDsnprintf(full_path, sizeof(full_path), "%s/J", base_path);
-        assert(HDstrlen(full_path) < 1024);
+        snprintf(full_path, sizeof(full_path), "%s/J", base_path);
+        assert(strlen(full_path) < 1024);
         ds_cpt_i(fid, full_path, false);
     }
 
     if (pass) {
-        HDsnprintf(full_path, sizeof(full_path), "%s/J", base_path);
-        assert(HDstrlen(full_path) < 1024);
+        snprintf(full_path, sizeof(full_path), "%s/J", base_path);
+        assert(strlen(full_path) < 1024);
         vrfy_ds_cpt_i(fid, full_path, false);
     }
 
@@ -3142,14 +3142,14 @@ create_zoo(hid_t fid, const char *base_path, int proc_num)
      * to file
      */
     if (pass) {
-        HDsnprintf(full_path, sizeof(full_path), "%s/K", base_path);
-        assert(HDstrlen(full_path) < 1024);
+        snprintf(full_path, sizeof(full_path), "%s/K", base_path);
+        assert(strlen(full_path) < 1024);
         ds_cpt_i(fid, full_path, true);
     }
 
     if (pass) {
-        HDsnprintf(full_path, sizeof(full_path), "%s/K", base_path);
-        assert(HDstrlen(full_path) < 1024);
+        snprintf(full_path, sizeof(full_path), "%s/K", base_path);
+        assert(strlen(full_path) < 1024);
         vrfy_ds_cpt_i(fid, full_path, true);
     }
 
@@ -3157,14 +3157,14 @@ create_zoo(hid_t fid, const char *base_path, int proc_num)
      * (but no data) to file
      */
     if (pass) {
-        HDsnprintf(full_path, sizeof(full_path), "%s/L", base_path);
-        assert(HDstrlen(full_path) < 1024);
+        snprintf(full_path, sizeof(full_path), "%s/L", base_path);
+        assert(strlen(full_path) < 1024);
         ds_ctg_v(fid, full_path, false);
     }
 
     if (pass) {
-        HDsnprintf(full_path, sizeof(full_path), "%s/L", base_path);
-        assert(HDstrlen(full_path) < 1024);
+        snprintf(full_path, sizeof(full_path), "%s/L", base_path);
+        assert(strlen(full_path) < 1024);
         vrfy_ds_ctg_v(fid, full_path, false);
     }
 
@@ -3172,14 +3172,14 @@ create_zoo(hid_t fid, const char *base_path, int proc_num)
      * (and data) to file
      */
     if (pass) {
-        HDsnprintf(full_path, sizeof(full_path), "%s/M", base_path);
-        assert(HDstrlen(full_path) < 1024);
+        snprintf(full_path, sizeof(full_path), "%s/M", base_path);
+        assert(strlen(full_path) < 1024);
         ds_ctg_v(fid, full_path, true);
     }
 
     if (pass) {
-        HDsnprintf(full_path, sizeof(full_path), "%s/M", base_path);
-        assert(HDstrlen(full_path) < 1024);
+        snprintf(full_path, sizeof(full_path), "%s/M", base_path);
+        assert(strlen(full_path) < 1024);
         vrfy_ds_ctg_v(fid, full_path, true);
     }
 
@@ -3218,15 +3218,15 @@ validate_zoo(hid_t fid, const char *base_path, int proc_num)
 
     /* validate an empty "new style" group */
     if (pass) {
-        HDsnprintf(full_path, sizeof(full_path), "%s/A", base_path);
-        assert(HDstrlen(full_path) < 1024);
+        snprintf(full_path, sizeof(full_path), "%s/A", base_path);
+        assert(strlen(full_path) < 1024);
         vrfy_ns_grp_0(fid, full_path);
     }
 
     /* validate a compact "new style" group (3 link messages) */
     if (pass) {
-        HDsnprintf(full_path, sizeof(full_path), "%s/B", base_path);
-        assert(HDstrlen(full_path) < 1024);
+        snprintf(full_path, sizeof(full_path), "%s/B", base_path);
+        assert(strlen(full_path) < 1024);
         vrfy_ns_grp_c(fid, full_path, 3);
     }
 
@@ -3234,15 +3234,15 @@ validate_zoo(hid_t fid, const char *base_path, int proc_num)
      * fractal heap)
      */
     if (pass) {
-        HDsnprintf(full_path, sizeof(full_path), "%s/C", base_path);
-        assert(HDstrlen(full_path) < 1024);
+        snprintf(full_path, sizeof(full_path), "%s/C", base_path);
+        assert(strlen(full_path) < 1024);
         vrfy_ns_grp_d(fid, full_path, 300);
     }
 
     /* validate an empty "old style" group in file */
     if (pass) {
-        HDsnprintf(full_path, sizeof(full_path), "%s/D", base_path);
-        assert(HDstrlen(full_path) < 1024);
+        snprintf(full_path, sizeof(full_path), "%s/D", base_path);
+        assert(strlen(full_path) < 1024);
         vrfy_os_grp_0(fid, full_path);
     }
 
@@ -3250,8 +3250,8 @@ validate_zoo(hid_t fid, const char *base_path, int proc_num)
      * local heap)
      */
     if (pass) {
-        HDsnprintf(full_path, sizeof(full_path), "%s/E", base_path);
-        assert(HDstrlen(full_path) < 1024);
+        snprintf(full_path, sizeof(full_path), "%s/E", base_path);
+        assert(strlen(full_path) < 1024);
         vrfy_os_grp_n(fid, full_path, proc_num, 300);
     }
 
@@ -3259,8 +3259,8 @@ validate_zoo(hid_t fid, const char *base_path, int proc_num)
      * in file.
      */
     if (pass) {
-        HDsnprintf(full_path, sizeof(full_path), "%s/F", base_path);
-        assert(HDstrlen(full_path) < 1024);
+        snprintf(full_path, sizeof(full_path), "%s/F", base_path);
+        assert(strlen(full_path) < 1024);
         vrfy_ds_ctg_i(fid, full_path, false);
     }
 
@@ -3268,8 +3268,8 @@ validate_zoo(hid_t fid, const char *base_path, int proc_num)
      * in file.
      */
     if (pass) {
-        HDsnprintf(full_path, sizeof(full_path), "%s/G", base_path);
-        assert(HDstrlen(full_path) < 1024);
+        snprintf(full_path, sizeof(full_path), "%s/G", base_path);
+        assert(strlen(full_path) < 1024);
         vrfy_ds_ctg_i(fid, full_path, true);
     }
 
@@ -3277,8 +3277,8 @@ validate_zoo(hid_t fid, const char *base_path, int proc_num)
      * in file
      */
     if (pass) {
-        HDsnprintf(full_path, sizeof(full_path), "%s/H", base_path);
-        assert(HDstrlen(full_path) < 1024);
+        snprintf(full_path, sizeof(full_path), "%s/H", base_path);
+        assert(strlen(full_path) < 1024);
         vrfy_ds_chk_i(fid, full_path, false);
     }
 
@@ -3286,8 +3286,8 @@ validate_zoo(hid_t fid, const char *base_path, int proc_num)
      * in file
      */
     if (pass) {
-        HDsnprintf(full_path, sizeof(full_path), "%s/I", base_path);
-        assert(HDstrlen(full_path) < 1024);
+        snprintf(full_path, sizeof(full_path), "%s/I", base_path);
+        assert(strlen(full_path) < 1024);
         vrfy_ds_chk_i(fid, full_path, true);
     }
 
@@ -3295,8 +3295,8 @@ validate_zoo(hid_t fid, const char *base_path, int proc_num)
      * in file
      */
     if (pass) {
-        HDsnprintf(full_path, sizeof(full_path), "%s/J", base_path);
-        assert(HDstrlen(full_path) < 1024);
+        snprintf(full_path, sizeof(full_path), "%s/J", base_path);
+        assert(strlen(full_path) < 1024);
         vrfy_ds_cpt_i(fid, full_path, false);
     }
 
@@ -3304,8 +3304,8 @@ validate_zoo(hid_t fid, const char *base_path, int proc_num)
      * in file
      */
     if (pass) {
-        HDsnprintf(full_path, sizeof(full_path), "%s/K", base_path);
-        assert(HDstrlen(full_path) < 1024);
+        snprintf(full_path, sizeof(full_path), "%s/K", base_path);
+        assert(strlen(full_path) < 1024);
         vrfy_ds_cpt_i(fid, full_path, true);
     }
 
@@ -3313,8 +3313,8 @@ validate_zoo(hid_t fid, const char *base_path, int proc_num)
      * (but no data) to file
      */
     if (pass) {
-        HDsnprintf(full_path, sizeof(full_path), "%s/L", base_path);
-        assert(HDstrlen(full_path) < 1024);
+        snprintf(full_path, sizeof(full_path), "%s/L", base_path);
+        assert(strlen(full_path) < 1024);
         vrfy_ds_ctg_v(fid, full_path, false);
     }
 
@@ -3322,8 +3322,8 @@ validate_zoo(hid_t fid, const char *base_path, int proc_num)
      * (and data) to file
      */
     if (pass) {
-        HDsnprintf(full_path, sizeof(full_path), "%s/M", base_path);
-        assert(HDstrlen(full_path) < 1024);
+        snprintf(full_path, sizeof(full_path), "%s/M", base_path);
+        assert(strlen(full_path) < 1024);
         vrfy_ds_ctg_v(fid, full_path, true);
     }
 

--- a/test/getname.c
+++ b/test/getname.c
@@ -64,15 +64,15 @@ check_name(hid_t id, const char *chk_name, const char *chk_user_path)
         TEST_ERROR;
 
     /* Check on name from H5Iget_name() */
-    if (HDstrcmp(name, chk_name) != 0)
+    if (strcmp(name, chk_name) != 0)
         goto error;
 
     /* Check on user path */
-    if (HDstrcmp(user_path, chk_user_path) != 0)
+    if (strcmp(user_path, chk_user_path) != 0)
         goto error;
 
     /* Check that if user path is hidden, the name from H5Iget_name() and the user path should be different */
-    if (user_path_hidden && !HDstrcmp(chk_name, chk_user_path))
+    if (user_path_hidden && !strcmp(chk_name, chk_user_path))
         TEST_ERROR;
 
     /* Everything matches */
@@ -1435,7 +1435,7 @@ test_main(hid_t file_id, hid_t fapl)
         /* Check that name is longer */
         if (name_len <= SMALL_NAME_BUF_SIZE)
             TEST_ERROR;
-        if (HDstrcmp(name2, "/") != 0)
+        if (strcmp(name2, "/") != 0)
             TEST_ERROR;
     }
 
@@ -1477,7 +1477,7 @@ test_main(hid_t file_id, hid_t fapl)
             TEST_ERROR;
 
         /* Verify */
-        if (HDstrcmp(name3, "/g17") != 0)
+        if (strcmp(name3, "/g17") != 0)
             TEST_ERROR;
         *name3 = '\0';
 
@@ -1487,7 +1487,7 @@ test_main(hid_t file_id, hid_t fapl)
             TEST_ERROR;
 
         /* Verify */
-        if (HDstrcmp(name3, "/g") != 0)
+        if (strcmp(name3, "/g") != 0)
             TEST_ERROR;
 
         free(name3);
@@ -3306,7 +3306,7 @@ test_obj_ref(hid_t fapl)
     namelen = H5Iget_name(dataset2, (char *)buf, sizeof(buf));
     if (H5Dclose(dataset2) < 0)
         FAIL_STACK_ERROR;
-    if (!((HDstrcmp(buf, "/Dataset3") == 0) && (namelen == 9)))
+    if (!((strcmp(buf, "/Dataset3") == 0) && (namelen == 9)))
         TEST_ERROR;
     *buf = '\0';
 
@@ -3320,7 +3320,7 @@ test_obj_ref(hid_t fapl)
         TEST_ERROR;
 
     namelen = H5Rget_name(dataset, H5R_OBJECT, &wbuf[0], (char *)buf, sizeof(buf));
-    if (!((HDstrcmp(buf, "/Dataset3") == 0) && (namelen == 9)))
+    if (!((strcmp(buf, "/Dataset3") == 0) && (namelen == 9)))
         TEST_ERROR;
     PASSED();
 
@@ -3332,11 +3332,11 @@ test_obj_ref(hid_t fapl)
     namelen = H5Iget_name(dataset2, (char *)buf, sizeof(buf));
     if (H5Dclose(dataset2) < 0)
         FAIL_STACK_ERROR;
-    if (!((HDstrcmp(buf, "/Group1/Dataset2") == 0) && (namelen == 16)))
+    if (!((strcmp(buf, "/Group1/Dataset2") == 0) && (namelen == 16)))
         TEST_ERROR;
     *buf    = '\0';
     namelen = H5Rget_name(dataset, H5R_OBJECT, &wbuf[1], (char *)buf, sizeof(buf));
-    if (!((HDstrcmp(buf, "/Group1/Dataset2") == 0) && (namelen == 16)))
+    if (!((strcmp(buf, "/Group1/Dataset2") == 0) && (namelen == 16)))
         TEST_ERROR;
     PASSED();
 
@@ -3348,11 +3348,11 @@ test_obj_ref(hid_t fapl)
     namelen = H5Iget_name(group, (char *)buf, sizeof(buf));
     if (H5Gclose(group) < 0)
         FAIL_STACK_ERROR;
-    if (!((HDstrcmp(buf, "/Group1") == 0) && (namelen == 7)))
+    if (!((strcmp(buf, "/Group1") == 0) && (namelen == 7)))
         TEST_ERROR;
     *buf    = '\0';
     namelen = H5Rget_name(dataset, H5R_OBJECT, &wbuf[2], (char *)buf, sizeof(buf));
-    if (!((HDstrcmp(buf, "/Group1") == 0) && (namelen == 7)))
+    if (!((strcmp(buf, "/Group1") == 0) && (namelen == 7)))
         TEST_ERROR;
     PASSED();
 
@@ -3364,11 +3364,11 @@ test_obj_ref(hid_t fapl)
     namelen = H5Iget_name(tid1, (char *)buf, sizeof(buf));
     if (H5Tclose(tid1) < 0)
         FAIL_STACK_ERROR;
-    if (!((HDstrcmp(buf, "/Group1/Datatype1") == 0) && (namelen == 17)))
+    if (!((strcmp(buf, "/Group1/Datatype1") == 0) && (namelen == 17)))
         TEST_ERROR;
     *buf    = '\0';
     namelen = H5Rget_name(dataset, H5R_OBJECT, &wbuf[3], (char *)buf, sizeof(buf));
-    if (!((HDstrcmp(buf, "/Group1/Datatype1") == 0) && (namelen == 17)))
+    if (!((strcmp(buf, "/Group1/Datatype1") == 0) && (namelen == 17)))
         TEST_ERROR;
     PASSED();
 
@@ -3380,11 +3380,11 @@ test_obj_ref(hid_t fapl)
     namelen = H5Iget_name(dataset2, (char *)buf, sizeof(buf));
     if (H5Dclose(dataset2) < 0)
         FAIL_STACK_ERROR;
-    if (!((HDstrcmp(buf, "/Group1/Group2/Dataset4") == 0) && (namelen == 23)))
+    if (!((strcmp(buf, "/Group1/Group2/Dataset4") == 0) && (namelen == 23)))
         TEST_ERROR;
     *buf    = '\0';
     namelen = H5Rget_name(dataset, H5R_OBJECT, &wbuf[4], (char *)buf, sizeof(buf));
-    if (!((HDstrcmp(buf, "/Group1/Group2/Dataset4") == 0) && (namelen == 23)))
+    if (!((strcmp(buf, "/Group1/Group2/Dataset4") == 0) && (namelen == 23)))
         TEST_ERROR;
     PASSED();
 
@@ -3396,11 +3396,11 @@ test_obj_ref(hid_t fapl)
     namelen = H5Iget_name(group, (char *)buf, sizeof(buf));
     if (H5Gclose(group) < 0)
         FAIL_STACK_ERROR;
-    if (!((HDstrcmp(buf, "/Group1/Group2") == 0) && (namelen == 14)))
+    if (!((strcmp(buf, "/Group1/Group2") == 0) && (namelen == 14)))
         TEST_ERROR;
     *buf    = '\0';
     namelen = H5Rget_name(dataset, H5R_OBJECT, &wbuf[5], (char *)buf, sizeof(buf));
-    if (!((HDstrcmp(buf, "/Group1/Group2") == 0) && (namelen == 14)))
+    if (!((strcmp(buf, "/Group1/Group2") == 0) && (namelen == 14)))
         TEST_ERROR;
     PASSED();
 
@@ -3412,11 +3412,11 @@ test_obj_ref(hid_t fapl)
     namelen = H5Iget_name(dataset2, (char *)buf, sizeof(buf));
     if (H5Dclose(dataset2) < 0)
         FAIL_STACK_ERROR;
-    if (!((HDstrcmp(buf, "/Group1/Dataset5") == 0) && (namelen == 16)))
+    if (!((strcmp(buf, "/Group1/Dataset5") == 0) && (namelen == 16)))
         TEST_ERROR;
     *buf    = '\0';
     namelen = H5Rget_name(dataset, H5R_OBJECT, &wbuf[6], (char *)buf, sizeof(buf));
-    if (!((HDstrcmp(buf, "/Group1/Dataset5") == 0) && (namelen == 16)))
+    if (!((strcmp(buf, "/Group1/Dataset5") == 0) && (namelen == 16)))
         TEST_ERROR;
     PASSED();
 
@@ -3428,11 +3428,11 @@ test_obj_ref(hid_t fapl)
     namelen = H5Iget_name(group, (char *)buf, sizeof(buf));
     if (H5Gclose(group) < 0)
         FAIL_STACK_ERROR;
-    if (!((HDstrcmp(buf, "/") == 0) && (namelen == 1)))
+    if (!((strcmp(buf, "/") == 0) && (namelen == 1)))
         TEST_ERROR;
     *buf    = '\0';
     namelen = H5Rget_name(dataset, H5R_OBJECT, &wbuf[7], (char *)buf, sizeof(buf));
-    if (!((HDstrcmp(buf, "/") == 0) && (namelen == 1)))
+    if (!((strcmp(buf, "/") == 0) && (namelen == 1)))
         TEST_ERROR;
     PASSED();
 
@@ -3600,7 +3600,7 @@ test_reg_ref(hid_t fapl)
         TEST_ERROR;
 
     name_size1 = H5Rget_name(dsetr_id, H5R_DATASET_REGION, &ref_out[0], (char *)buf1, NAME_BUF_SIZE);
-    if (!((HDstrcmp(buf1, "/MATRIX") == 0) && (name_size1 == 7)))
+    if (!((strcmp(buf1, "/MATRIX") == 0) && (name_size1 == 7)))
         TEST_ERROR;
     PASSED();
 
@@ -3612,7 +3612,7 @@ test_reg_ref(hid_t fapl)
     /* Get name of the dataset the first region reference points using H5Iget_name */
     *buf2      = '\0';
     name_size2 = H5Iget_name(dsetv_id, (char *)buf2, NAME_BUF_SIZE);
-    if (!((HDstrcmp(buf2, "/MATRIX") == 0) && (name_size2 == 7)))
+    if (!((strcmp(buf2, "/MATRIX") == 0) && (name_size2 == 7)))
         TEST_ERROR;
 
     if (H5Dclose(dsetv_id) < 0)
@@ -3624,7 +3624,7 @@ test_reg_ref(hid_t fapl)
     TESTING("H5Rget_name to get name from region reference(pnt selec)");
     *buf1      = '\0';
     name_size1 = H5Rget_name(dsetr_id, H5R_DATASET_REGION, &ref_out[1], (char *)buf1, NAME_BUF_SIZE);
-    if (!((HDstrcmp(buf1, "/MATRIX") == 0) && (name_size1 == 7)))
+    if (!((strcmp(buf1, "/MATRIX") == 0) && (name_size1 == 7)))
         TEST_ERROR;
     PASSED();
 
@@ -3637,7 +3637,7 @@ test_reg_ref(hid_t fapl)
     /* Get name of the dataset the first region reference points using H5Iget_name */
     *buf2      = '\0';
     name_size2 = H5Iget_name(dsetv_id, (char *)buf2, NAME_BUF_SIZE);
-    if (!((HDstrcmp(buf2, "/MATRIX") == 0) && (name_size2 == 7)))
+    if (!((strcmp(buf2, "/MATRIX") == 0) && (name_size2 == 7)))
         TEST_ERROR;
 
     if (H5Dclose(dsetv_id) < 0)
@@ -3713,7 +3713,7 @@ test_elinks(hid_t fapl)
     *name       = '\0';
     name_cached = false;
     namelen     = H5I__get_name_test(group, (char *)name, sizeof(name), &name_cached);
-    if (!((HDstrcmp(name, "/Group2") == 0) && (namelen == 7) && name_cached))
+    if (!((strcmp(name, "/Group2") == 0) && (namelen == 7) && name_cached))
         TEST_ERROR;
 
     /* Close Group */
@@ -3728,7 +3728,7 @@ test_elinks(hid_t fapl)
     *name       = '\0';
     name_cached = false;
     namelen     = H5I__get_name_test(group, (char *)name, sizeof(name), &name_cached);
-    if (!((HDstrcmp(name, "/Group2") == 0) && (namelen == 7) && name_cached))
+    if (!((strcmp(name, "/Group2") == 0) && (namelen == 7) && name_cached))
         TEST_ERROR;
 
     /* Close Group */
@@ -3788,7 +3788,7 @@ main(void)
 
     if (nerrors)
         goto error;
-    HDputs("All getname tests passed.");
+    puts("All getname tests passed.");
 
     h5_cleanup(FILENAME, fapl);
 
@@ -3801,7 +3801,7 @@ error:
     }
     H5E_END_TRY
 
-    HDputs("***** GET NAME TESTS FAILED *****");
+    puts("***** GET NAME TESTS FAILED *****");
 
     return 1;
 }

--- a/test/gheap.c
+++ b/test/gheap.c
@@ -38,9 +38,9 @@
         nerrors++;                                                                                           \
         if (nerrors <= GHEAP_REPEATED_ERR_LIM) {                                                             \
             H5_FAILED();                                                                                     \
-            HDputs(MSG);                                                                                     \
+            puts(MSG);                                                                                       \
             if (nerrors == GHEAP_REPEATED_ERR_LIM)                                                           \
-                HDputs("    Suppressing further errors...");                                                 \
+                puts("    Suppressing further errors...");                                                   \
         }       /* end if */                                                                                 \
     } while (0) /* end GHEAP_REPEATED_ERR */
 
@@ -84,7 +84,7 @@ test_1(hid_t fapl)
         goto error;
     if (NULL == (f = (H5F_t *)H5VL_object(file))) {
         H5_FAILED();
-        HDputs("    Unable to create file");
+        puts("    Unable to create file");
         goto error;
     }
 
@@ -100,12 +100,12 @@ test_1(hid_t fapl)
         status = H5HG_insert(f, size, out, obj + u);
         if (status < 0) {
             H5_FAILED();
-            HDputs("    Unable to insert object into global heap");
+            puts("    Unable to insert object into global heap");
             nerrors++;
         }
         else if (u && H5_addr_gt(obj[u - 1].addr, obj[u].addr)) {
             H5_FAILED();
-            HDputs("    Collection addresses are not monotonically increasing");
+            puts("    Collection addresses are not monotonically increasing");
             nerrors++;
         }
     }
@@ -119,12 +119,12 @@ test_1(hid_t fapl)
         H5Eclear2(H5E_DEFAULT);
         if (NULL == H5HG_read(f, obj + u, in, NULL)) {
             H5_FAILED();
-            HDputs("    Unable to read object");
+            puts("    Unable to read object");
             nerrors++;
         }
         else if (memcmp(in, out, size) != 0) {
             H5_FAILED();
-            HDputs("    Value read doesn't match value written");
+            puts("    Value read doesn't match value written");
             nerrors++;
         }
     }
@@ -189,7 +189,7 @@ test_2(hid_t fapl)
         goto error;
     if (NULL == (f = (H5F_t *)H5VL_object(file))) {
         H5_FAILED();
-        HDputs("    Unable to create file");
+        puts("    Unable to create file");
         goto error;
     }
 
@@ -202,7 +202,7 @@ test_2(hid_t fapl)
         H5Eclear2(H5E_DEFAULT);
         if (H5HG_insert(f, size, out, obj + u) < 0) {
             H5_FAILED();
-            HDputs("    Unable to insert object into global heap");
+            puts("    Unable to insert object into global heap");
             nerrors++;
         }
     }
@@ -216,12 +216,12 @@ test_2(hid_t fapl)
         H5Eclear2(H5E_DEFAULT);
         if (NULL == H5HG_read(f, obj + u, in, NULL)) {
             H5_FAILED();
-            HDputs("    Unable to read object");
+            puts("    Unable to read object");
             nerrors++;
         }
         else if (memcmp(in, out, size) != 0) {
             H5_FAILED();
-            HDputs("    Value read doesn't match value written");
+            puts("    Value read doesn't match value written");
             nerrors++;
         }
     }
@@ -286,7 +286,7 @@ test_3(hid_t fapl)
         goto error;
     if (NULL == (f = (H5F_t *)H5VL_object(file))) {
         H5_FAILED();
-        HDputs("    Unable to create file");
+        puts("    Unable to create file");
         goto error;
     }
 
@@ -298,7 +298,7 @@ test_3(hid_t fapl)
         status = H5HG_insert(f, size, out, obj + u);
         if (status < 0) {
             H5_FAILED();
-            HDputs("    Unable to insert object into global heap");
+            puts("    Unable to insert object into global heap");
             nerrors++;
         }
     }
@@ -308,7 +308,7 @@ test_3(hid_t fapl)
         status = H5HG_remove(f, obj + u);
         if (status < 0) {
             H5_FAILED();
-            HDputs("    Unable to remove object");
+            puts("    Unable to remove object");
             nerrors++;
         }
     }
@@ -374,7 +374,7 @@ test_4(hid_t fapl)
         goto error;
     if (NULL == (f = (H5F_t *)H5VL_object(file))) {
         H5_FAILED();
-        HDputs("    Unable to create file");
+        puts("    Unable to create file");
         goto error;
     }
 
@@ -386,7 +386,7 @@ test_4(hid_t fapl)
         status = H5HG_insert(f, size, out, obj + u);
         if (status < 0) {
             H5_FAILED();
-            HDputs("    Unable to insert object into global heap");
+            puts("    Unable to insert object into global heap");
             nerrors++;
         }
 
@@ -399,7 +399,7 @@ test_4(hid_t fapl)
             status = H5HG_remove(f, obj + u - 1);
             if (status < 0) {
                 H5_FAILED();
-                HDputs("    Unable to remove object");
+                puts("    Unable to remove object");
                 nerrors++;
             }
             memset(obj + u - 1, 0, sizeof *obj);
@@ -465,7 +465,7 @@ test_ooo_indices(hid_t fapl)
         goto error;
     if (NULL == (f = (H5F_t *)H5VL_object(file))) {
         H5_FAILED();
-        HDputs("    Unable to create file");
+        puts("    Unable to create file");
         goto error;
     }
 
@@ -509,7 +509,7 @@ test_ooo_indices(hid_t fapl)
         goto error;
     if (NULL == (f = (H5F_t *)H5VL_object(file))) {
         H5_FAILED();
-        HDputs("    Unable to open file");
+        puts("    Unable to open file");
         goto error;
     } /* end if */
 
@@ -519,7 +519,7 @@ test_ooo_indices(hid_t fapl)
             goto error;
         if (i != j) {
             H5_FAILED();
-            HDputs("    Incorrect read value");
+            puts("    Incorrect read value");
             goto error;
         }
     }
@@ -582,7 +582,7 @@ main(void)
     if (nerrors)
         goto error;
 
-    HDputs("All global heap tests passed.");
+    puts("All global heap tests passed.");
 
     /* Pop API context */
     if (api_ctx_pushed && H5CX_pop(false) < 0)
@@ -602,6 +602,6 @@ error:
     if (api_ctx_pushed)
         H5CX_pop(false);
 
-    HDputs("*** TESTS FAILED ***");
+    puts("*** TESTS FAILED ***");
     exit(EXIT_FAILURE);
 } /* end main() */

--- a/test/h5test.c
+++ b/test/h5test.c
@@ -494,7 +494,7 @@ h5_fixname_real(const char *base_name, hid_t fapl, const char *_suffix, char *fu
                 if (!driver_env_var)
                     driver_env_var = HDF5_DRIVER;
 #endif
-                if (driver_env_var && !HDstrcmp(driver_env_var, "split")) {
+                if (driver_env_var && !strcmp(driver_env_var, "split")) {
                     /* split VFD */
                     if (subst_for_superblock)
                         suffix = ".h5.meta";
@@ -588,7 +588,7 @@ h5_fixname_real(const char *base_name, hid_t fapl, const char *_suffix, char *fu
             /* This is a parallel system */
             char *subdir;
 
-            if (!HDstrcmp(prefix, HDF5_PARAPREFIX)) {
+            if (!strcmp(prefix, HDF5_PARAPREFIX)) {
                 /*
                  * If the prefix specifies the HDF5_PARAPREFIX directory, then
                  * default to using the "/tmp/$USER" or "/tmp/$LOGIN"
@@ -613,11 +613,11 @@ h5_fixname_real(const char *base_name, hid_t fapl, const char *_suffix, char *fu
 
             if (!fullname[0]) {
                 /* We didn't append the prefix yet */
-                HDstrncpy(fullname, prefix, size);
+                strncpy(fullname, prefix, size);
                 fullname[size - 1] = '\0';
             }
 
-            if (HDstrlen(fullname) + HDstrlen(base_name) + 1 < size) {
+            if (strlen(fullname) + strlen(base_name) + 1 < size) {
                 /*
                  * Append the base_name with a slash first. Multiple
                  * slashes are handled below.
@@ -632,10 +632,10 @@ h5_fixname_real(const char *base_name, hid_t fapl, const char *_suffix, char *fu
                          * subdirectory.  Default to PREFIX's original
                          * prefix value.
                          */
-                        HDstrcpy(fullname, prefix);
+                        strcpy(fullname, prefix);
 
-                HDstrcat(fullname, "/");
-                HDstrcat(fullname, base_name);
+                strcat(fullname, "/");
+                strcat(fullname, base_name);
             }
             else {
                 /* Buffer is too small */
@@ -643,25 +643,25 @@ h5_fixname_real(const char *base_name, hid_t fapl, const char *_suffix, char *fu
             }
         }
         else {
-            if (HDsnprintf(fullname, size, "%s/%s", prefix, base_name) == (int)size)
+            if (snprintf(fullname, size, "%s/%s", prefix, base_name) == (int)size)
                 /* Buffer is too small */
                 return NULL;
         }
     }
-    else if (HDstrlen(base_name) >= size) {
+    else if (strlen(base_name) >= size) {
         /* Buffer is too small */
         return NULL;
     }
     else {
-        HDstrcpy(fullname, base_name);
+        strcpy(fullname, base_name);
     }
 
     /* Append a suffix */
     if (suffix) {
-        if (HDstrlen(fullname) + HDstrlen(suffix) >= size)
+        if (strlen(fullname) + strlen(suffix) >= size)
             return NULL;
 
-        HDstrcat(fullname, suffix);
+        strcat(fullname, suffix);
     }
 
     /* Remove any double slashes in the filename */
@@ -695,7 +695,7 @@ h5_rmprefix(const char *filename)
 {
     const char *ret_ptr;
 
-    if ((ret_ptr = HDstrstr(filename, ":")) == NULL)
+    if ((ret_ptr = strstr(filename, ":")) == NULL)
         ret_ptr = filename;
     else
         ret_ptr++;
@@ -804,12 +804,12 @@ h5_get_libver_fapl(hid_t fapl)
      * If it's nothing (environment variable was whitespace)
      * just return the default fapl.
      */
-    HDstrncpy(buf, env, sizeof(buf));
+    strncpy(buf, env, sizeof(buf));
     buf[sizeof(buf) - 1] = '\0';
     if (NULL == (tok = HDstrtok_r(buf, " \t\n\r", &lasts)))
         goto done;
 
-    if (!HDstrcmp(tok, "latest")) {
+    if (!strcmp(tok, "latest")) {
         /* use the latest format */
         if (H5Pset_libver_bounds(fapl, H5F_LIBVER_LATEST, H5F_LIBVER_LATEST) < 0)
             goto error;
@@ -928,7 +928,7 @@ h5_set_info_object(void)
     if ((envp = HDgetenv("HDF5_MPI_INFO")) != NULL) {
         char *next, *valp;
 
-        valp = envp = next = HDstrdup(envp);
+        valp = envp = next = strdup(envp);
 
         if (!valp)
             return 0;
@@ -945,7 +945,7 @@ h5_set_info_object(void)
                 valp++;
 
             /* copy key/value pair into temporary buffer */
-            len  = HDstrcspn(valp, ";");
+            len  = strcspn(valp, ";");
             next = &valp[len];
             if (NULL == (key_val = (char *)calloc(1, len + 1)))
                 return -1;
@@ -954,7 +954,7 @@ h5_set_info_object(void)
             if (*next == ';')
                 ++next;
 
-            namep = HDstrncpy(key_val, valp, len);
+            namep = strncpy(key_val, valp, len);
 
             /* pass up any beginning whitespaces */
             while (*namep && (*namep == ' ' || *namep == '\t'))
@@ -964,13 +964,13 @@ h5_set_info_object(void)
                 continue; /* was all white space, so move to next k/v pair */
 
             /* eat up any ending white spaces */
-            endp = &namep[HDstrlen(namep) - 1];
+            endp = &namep[strlen(namep) - 1];
 
             while (endp && (*endp == ' ' || *endp == '\t'))
                 *endp-- = '\0';
 
             /* find the '=' */
-            valp = HDstrchr(namep, '=');
+            valp = strchr(namep, '=');
 
             if (valp != NULL) { /* it's a valid key/value pairing */
                 char *tmp_val = valp + 1;
@@ -1089,17 +1089,17 @@ h5_get_file_size(const char *filename, hid_t fapl)
             char          *driver_env_var = NULL;
 
             driver_env_var = HDgetenv(HDF5_DRIVER);
-            if (driver_env_var && !HDstrcmp(driver_env_var, "split")) {
+            if (driver_env_var && !strcmp(driver_env_var, "split")) {
                 for (mt = H5FD_MEM_DEFAULT; mt < H5FD_MEM_NTYPES; mt++) {
                     if (mt != H5FD_MEM_DRAW && mt != H5FD_MEM_SUPER)
                         continue;
 
                     /* Create the filename to query */
                     if (mt == H5FD_MEM_DRAW) {
-                        HDsnprintf(temp, sizeof temp, "%s.raw", filename);
+                        snprintf(temp, sizeof temp, "%s.raw", filename);
                     }
                     else {
-                        HDsnprintf(temp, sizeof temp, "%s.meta", filename);
+                        snprintf(temp, sizeof temp, "%s.meta", filename);
                     }
 
                     /* Check for existence of file */
@@ -1114,10 +1114,10 @@ h5_get_file_size(const char *filename, hid_t fapl)
                 }     /* end for */
             }
             else {
-                assert(HDstrlen(multi_letters) == H5FD_MEM_NTYPES);
+                assert(strlen(multi_letters) == H5FD_MEM_NTYPES);
                 for (mt = H5FD_MEM_DEFAULT; mt < H5FD_MEM_NTYPES; mt++) {
                     /* Create the filename to query */
-                    HDsnprintf(temp, sizeof temp, "%s-%c.h5", filename, multi_letters[mt]);
+                    snprintf(temp, sizeof temp, "%s-%c.h5", filename, multi_letters[mt]);
 
                     /* Check for existence of file */
                     if (0 == HDaccess(temp, F_OK)) {
@@ -1159,7 +1159,7 @@ h5_get_file_size(const char *filename, hid_t fapl)
             /* Try all filenames possible, until we find one that's missing */
             for (j = 0; /*void*/; j++) {
                 /* Create the filename to query */
-                HDsnprintf(temp, sizeof temp, filename, j);
+                snprintf(temp, sizeof temp, filename, j);
 
                 /* Check for existence of file */
                 if (HDaccess(temp, F_OK) < 0)
@@ -1216,7 +1216,7 @@ print_func(const char *format, ...)
     int     ret_value;
 
     va_start(arglist, format);
-    ret_value = HDvprintf(format, arglist);
+    ret_value = vprintf(format, arglist);
     va_end(arglist);
     return ret_value;
 }
@@ -1304,7 +1304,7 @@ getenv_all(MPI_Comm comm, int root, const char *name)
         if (mpi_rank == root) {
             env = HDgetenv(name);
             if (env) {
-                len = (int)HDstrlen(env);
+                len = (int)strlen(env);
                 MPI_Bcast(&len, 1, MPI_INT, root, comm);
                 MPI_Bcast(env, len, MPI_CHAR, root, comm);
             }
@@ -1319,7 +1319,7 @@ getenv_all(MPI_Comm comm, int root, const char *name)
             if (len >= 0) {
                 if (env == NULL)
                     env = (char *)malloc((size_t)len + 1);
-                else if (HDstrlen(env) < (size_t)len)
+                else if (strlen(env) < (size_t)len)
                     env = (char *)realloc(env, (size_t)len + 1);
 
                 MPI_Bcast(env, len, MPI_CHAR, root, comm);
@@ -1894,9 +1894,9 @@ H5_get_srcdir_filename(const char *filename)
     /* Build path to test file. We're checking the length so suppress
      * the gcc format-truncation warning.
      */
-    if ((HDstrlen(srcdir) + HDstrlen(filename) + 1) < sizeof(srcdir_testpath)) {
+    if ((strlen(srcdir) + strlen(filename) + 1) < sizeof(srcdir_testpath)) {
         H5_GCC_DIAG_OFF("format-truncation")
-        HDsnprintf(srcdir_testpath, sizeof(srcdir_testpath), "%s%s", srcdir, filename);
+        snprintf(srcdir_testpath, sizeof(srcdir_testpath), "%s%s", srcdir, filename);
         H5_GCC_DIAG_ON("format-truncation")
         return srcdir_testpath;
     }
@@ -1924,8 +1924,8 @@ H5_get_srcdir(void)
         srcdir = config_srcdir;
 
     /* Build path to all test files */
-    if ((HDstrlen(srcdir) + 2) < sizeof(srcdir_path)) {
-        HDsnprintf(srcdir_path, sizeof(srcdir_path), "%s/", srcdir);
+    if ((strlen(srcdir) + 2) < sizeof(srcdir_path)) {
+        snprintf(srcdir_path, sizeof(srcdir_path), "%s/", srcdir);
         return (srcdir_path);
     } /* end if */
     else
@@ -2079,7 +2079,7 @@ h5_using_default_driver(const char *drv_name)
         drv_name = HDgetenv(HDF5_DRIVER);
 
     if (drv_name)
-        return (!HDstrcmp(drv_name, "sec2") || !HDstrcmp(drv_name, "nomatch"));
+        return (!strcmp(drv_name, "sec2") || !strcmp(drv_name, "nomatch"));
 
     return ret_val;
 }
@@ -2201,13 +2201,13 @@ h5_driver_uses_multiple_files(const char *drv_name, unsigned flags)
 
     if (drv_name) {
         if ((flags & H5_EXCLUDE_MULTIPART_DRIVERS) == 0) {
-            if (!HDstrcmp(drv_name, "split") || !HDstrcmp(drv_name, "multi") ||
-                !HDstrcmp(drv_name, "family") || !HDstrcmp(drv_name, H5FD_SUBFILING_NAME))
+            if (!strcmp(drv_name, "split") || !strcmp(drv_name, "multi") || !strcmp(drv_name, "family") ||
+                !strcmp(drv_name, H5FD_SUBFILING_NAME))
                 return true;
         }
 
         if ((flags & H5_EXCLUDE_NON_MULTIPART_DRIVERS) == 0) {
-            if (!HDstrcmp(drv_name, "splitter"))
+            if (!strcmp(drv_name, "splitter"))
                 return true;
         }
     }

--- a/test/h5test.h
+++ b/test/h5test.h
@@ -113,30 +113,30 @@ H5TEST_DLLVAR MPI_Info h5_io_info_g; /* MPI INFO object for IO */
     } while (0)
 #define PASSED()                                                                                             \
     do {                                                                                                     \
-        HDputs(" PASSED");                                                                                   \
+        puts(" PASSED");                                                                                     \
         fflush(stdout);                                                                                      \
         n_tests_passed_g++;                                                                                  \
     } while (0)
 #define H5_FAILED()                                                                                          \
     do {                                                                                                     \
-        HDputs("*FAILED*");                                                                                  \
+        puts("*FAILED*");                                                                                    \
         fflush(stdout);                                                                                      \
         n_tests_failed_g++;                                                                                  \
     } while (0)
 #define H5_WARNING()                                                                                         \
     do {                                                                                                     \
-        HDputs("*WARNING*");                                                                                 \
+        puts("*WARNING*");                                                                                   \
         fflush(stdout);                                                                                      \
     } while (0)
 #define SKIPPED()                                                                                            \
     do {                                                                                                     \
-        HDputs(" -SKIP-");                                                                                   \
+        puts(" -SKIP-");                                                                                     \
         fflush(stdout);                                                                                      \
         n_tests_skipped_g++;                                                                                 \
     } while (0)
 #define PUTS_ERROR(s)                                                                                        \
     do {                                                                                                     \
-        HDputs(s);                                                                                           \
+        puts(s);                                                                                             \
         AT();                                                                                                \
         goto error;                                                                                          \
     } while (0)
@@ -162,7 +162,7 @@ H5TEST_DLLVAR MPI_Info h5_io_info_g; /* MPI INFO object for IO */
     do {                                                                                                     \
         H5_FAILED();                                                                                         \
         AT();                                                                                                \
-        HDputs(s);                                                                                           \
+        puts(s);                                                                                             \
         goto error;                                                                                          \
     } while (0)
 
@@ -172,7 +172,7 @@ H5TEST_DLLVAR MPI_Info h5_io_info_g; /* MPI INFO object for IO */
 #define TESTING_MULTIPART(WHAT)                                                                              \
     do {                                                                                                     \
         printf("Testing %-62s", WHAT);                                                                       \
-        HDputs("");                                                                                          \
+        puts("");                                                                                            \
         fflush(stdout);                                                                                      \
     } while (0)
 

--- a/test/hdfs.c
+++ b/test/hdfs.c
@@ -274,7 +274,7 @@
  *----------------------------------------------------------------------------
  */
 #define JSVERIFY_STR(expected, actual, reason)                                                               \
-    if (HDstrcmp((actual), (expected)) != 0) {                                                               \
+    if (strcmp((actual), (expected)) != 0) {                                                                 \
         JSERR_STR((expected), (actual), (reason));                                                           \
         goto error;                                                                                          \
     } /* JSVERIFY_STR */
@@ -313,7 +313,7 @@
  *----------------------------------------------------------------------------
  */
 #define JSVERIFY_STR(actual, expected, reason)                                                               \
-    if (HDstrcmp((actual), (expected)) != 0) {                                                               \
+    if (strcmp((actual), (expected)) != 0) {                                                                 \
         JSERR_STR((expected), (actual), (reason));                                                           \
         goto error;                                                                                          \
     } /* JSVERIFY_STR */
@@ -374,7 +374,7 @@ test_fapl_config_validation(void)
 #ifndef H5_HAVE_LIBHDFS
     TESTING("HDFS fapl configuration validation");
     SKIPPED();
-    HDputs("    HDFS VFD is not enabled");
+    puts("    HDFS VFD is not enabled");
     fflush(stdout);
     return 0;
 
@@ -579,7 +579,7 @@ test_hdfs_fapl(void)
 #ifndef H5_HAVE_LIBHDFS
     TESTING("HDFS fapl ");
     SKIPPED();
-    HDputs("    HDFS VFD is not enabled");
+    puts("    HDFS VFD is not enabled");
     fflush(stdout);
     return 0;
 
@@ -662,7 +662,7 @@ test_vfd_open(void)
 #ifndef H5_HAVE_LIBHDFS
     TESTING("HDFS VFD-level open");
     SKIPPED();
-    HDputs("    HDFS VFD is not enabled");
+    puts("    HDFS VFD is not enabled");
     fflush(stdout);
     return 0;
 
@@ -915,7 +915,7 @@ test_eof_eoa(void)
 #ifndef H5_HAVE_LIBHDFS
     TESTING("HDFS eof/eoa gets and sets");
     SKIPPED();
-    HDputs("    HDFS VFD is not enabled");
+    puts("    HDFS VFD is not enabled");
     fflush(stdout);
     return 0;
 
@@ -1025,7 +1025,7 @@ test_H5FDread_without_eoa_set_fails(void)
 #ifndef H5_HAVE_LIBHDFS
     TESTING("HDFS VFD read-eoa temporal coupling library limitation");
     SKIPPED();
-    HDputs("    HDFS VFD is not enabled");
+    puts("    HDFS VFD is not enabled");
     fflush(stdout);
     return 0;
 
@@ -1124,7 +1124,7 @@ test_read(void)
 #ifndef H5_HAVE_LIBHDFS
     TESTING("HDFS VFD read/range-gets");
     SKIPPED();
-    HDputs("    HDFS VFD is not enabled");
+    puts("    HDFS VFD is not enabled");
     fflush(stdout);
     return 0;
 
@@ -1331,7 +1331,7 @@ test_noops_and_autofails(void)
 #ifndef H5_HAVE_LIBHDFS
     TESTING("HDFS VFD always-fail and no-op routines");
     SKIPPED();
-    HDputs("    HDFS VFD is not enabled");
+    puts("    HDFS VFD is not enabled");
     fflush(stdout);
     return 0;
 
@@ -1467,7 +1467,7 @@ test_H5F_integration(void)
 #ifndef H5_HAVE_LIBHDFS
     TESTING("HDFS file access through HD5F library (H5F API)");
     SKIPPED();
-    HDputs("    HDFS VFD is not enabled");
+    puts("    HDFS VFD is not enabled");
     fflush(stdout);
     return 0;
 
@@ -1581,11 +1581,11 @@ main(void)
 
     hdfs_namenode_name_env = HDgetenv("HDFS_TEST_NAMENODE_NAME");
     if (hdfs_namenode_name_env == NULL || hdfs_namenode_name_env[0] == '\0') {
-        HDstrncpy(hdfs_namenode_name, "localhost", HDFS_NAMENODE_NAME_MAX_SIZE);
+        strncpy(hdfs_namenode_name, "localhost", HDFS_NAMENODE_NAME_MAX_SIZE);
     }
     else {
-        HDstrncpy(/* TODO: error-check? */
-                  default_fa.namenode_name, hdfs_namenode_name_env, HDFS_NAMENODE_NAME_MAX_SIZE);
+        strncpy(/* TODO: error-check? */
+                default_fa.namenode_name, hdfs_namenode_name_env, HDFS_NAMENODE_NAME_MAX_SIZE);
     }
 #endif /* H5_HAVE_LIBHDFS */
 

--- a/test/hyperslab.c
+++ b/test/hyperslab.c
@@ -148,19 +148,19 @@ test_fill(size_t nx, size_t ny, size_t nz, size_t di, size_t dj, size_t dk, size
         if (0 == ny) {
             ndims = 1;
             ny = nz = 1;
-            HDsnprintf(dim, sizeof(dim), "%lu", (unsigned long)nx);
+            snprintf(dim, sizeof(dim), "%lu", (unsigned long)nx);
         } /* end if */
         else {
             ndims = 2;
             nz    = 1;
-            HDsnprintf(dim, sizeof(dim), "%lux%lu", (unsigned long)nx, (unsigned long)ny);
+            snprintf(dim, sizeof(dim), "%lux%lu", (unsigned long)nx, (unsigned long)ny);
         } /* end else */
     }     /* end if */
     else {
         ndims = 3;
-        HDsnprintf(dim, sizeof(dim), "%lux%lux%lu", (unsigned long)nx, (unsigned long)ny, (unsigned long)nz);
+        snprintf(dim, sizeof(dim), "%lux%lux%lu", (unsigned long)nx, (unsigned long)ny, (unsigned long)nz);
     } /* end else */
-    HDsnprintf(s, sizeof(s), "Testing hyperslab fill %-11s variable hyperslab", dim);
+    snprintf(s, sizeof(s), "Testing hyperslab fill %-11s variable hyperslab", dim);
     printf("%-70s", s);
     fflush(stdout);
 
@@ -303,17 +303,17 @@ test_copy(int mode, size_t nx, size_t ny, size_t nz, size_t di, size_t dj, size_
         if (0 == ny) {
             ndims = 1;
             ny = nz = 1;
-            HDsnprintf(dim, sizeof(dim), "%lu", (unsigned long)nx);
+            snprintf(dim, sizeof(dim), "%lu", (unsigned long)nx);
         } /* end if */
         else {
             ndims = 2;
             nz    = 1;
-            HDsnprintf(dim, sizeof(dim), "%lux%lu", (unsigned long)nx, (unsigned long)ny);
+            snprintf(dim, sizeof(dim), "%lux%lu", (unsigned long)nx, (unsigned long)ny);
         } /* end else */
     }     /* end if */
     else {
         ndims = 3;
-        HDsnprintf(dim, sizeof(dim), "%lux%lux%lu", (unsigned long)nx, (unsigned long)ny, (unsigned long)nz);
+        snprintf(dim, sizeof(dim), "%lux%lux%lu", (unsigned long)nx, (unsigned long)ny, (unsigned long)nz);
     } /* end else */
 
     switch (mode) {
@@ -346,7 +346,7 @@ test_copy(int mode, size_t nx, size_t ny, size_t nz, size_t di, size_t dj, size_
             HDabort();
     } /* end switch */
 
-    HDsnprintf(s, sizeof(s), "Testing hyperslab copy %-11s %s", dim, sub);
+    snprintf(s, sizeof(s), "Testing hyperslab copy %-11s %s", dim, sub);
     printf("%-70s", s);
     fflush(stdout);
 
@@ -597,15 +597,15 @@ test_multifill(size_t nx)
     s[0] = '\0';
     for (i = 0; i < nx; i++) {
         if (dst[i].left != 3333333)
-            HDsnprintf(s, sizeof(s), "bad dst[%lu].left", (unsigned long)i);
+            snprintf(s, sizeof(s), "bad dst[%lu].left", (unsigned long)i);
         else if (!H5_DBL_ABS_EQUAL(dst[i].mid, fill.mid))
             /* Check if two DOUBLE values are equal.  If their difference
              * is smaller than the EPSILON value for double, they are
              * considered equal. See the definition in h5test.h.
              */
-            HDsnprintf(s, sizeof(s), "bad dst[%lu].mid", (unsigned long)i);
+            snprintf(s, sizeof(s), "bad dst[%lu].mid", (unsigned long)i);
         else if (dst[i].right != 4444444)
-            HDsnprintf(s, sizeof(s), "bad dst[%lu].right", (unsigned long)i);
+            snprintf(s, sizeof(s), "bad dst[%lu].right", (unsigned long)i);
         if (s[0]) {
             H5_FAILED();
             if (!HDisatty(1)) {
@@ -744,8 +744,7 @@ test_transpose(size_t nx, size_t ny)
     char    s[256];
     hsize_t i, j;
 
-    HDsnprintf(s, sizeof(s), "Testing 2d transpose by stride %4lux%-lud", (unsigned long)nx,
-               (unsigned long)ny);
+    snprintf(s, sizeof(s), "Testing 2d transpose by stride %4lux%-lud", (unsigned long)nx, (unsigned long)ny);
     printf("%-70s", s);
     fflush(stdout);
 
@@ -840,8 +839,8 @@ test_sub_super(size_t nx, size_t ny)
     hsize_t  i, j;
     char     s[256];
 
-    HDsnprintf(s, sizeof(s), "Testing image sampling %4lux%-4lu to %4lux%-4lu ", (unsigned long)(2 * nx),
-               (unsigned long)(2 * ny), (unsigned long)nx, (unsigned long)ny);
+    snprintf(s, sizeof(s), "Testing image sampling %4lux%-4lu to %4lux%-4lu ", (unsigned long)(2 * nx),
+             (unsigned long)(2 * ny), (unsigned long)nx, (unsigned long)ny);
     printf("%-70s", s);
     fflush(stdout);
 
@@ -890,8 +889,8 @@ test_sub_super(size_t nx, size_t ny)
      * Test replicating pixels to produce an image twice as large in each
      * dimension.
      */
-    HDsnprintf(s, sizeof(s), "Testing image sampling %4lux%-4lu to %4lux%-4lu ", (unsigned long)nx,
-               (unsigned long)ny, (unsigned long)(2 * nx), (unsigned long)(2 * ny));
+    snprintf(s, sizeof(s), "Testing image sampling %4lux%-4lu to %4lux%-4lu ", (unsigned long)nx,
+             (unsigned long)ny, (unsigned long)(2 * nx), (unsigned long)(2 * ny));
     printf("%-70s", s);
     fflush(stdout);
 
@@ -917,17 +916,17 @@ test_sub_super(size_t nx, size_t ny)
     for (i = 0; i < nx; i++) {
         for (j = 0; j < ny; j++) {
             if (half[i * ny + j] != twice[4 * i * ny + 2 * j])
-                HDsnprintf(s, sizeof(s), "half[%lu][%lu] != twice[%lu][%lu]", (unsigned long)i,
-                           (unsigned long)j, (unsigned long)i * 2, (unsigned long)j * 2);
+                snprintf(s, sizeof(s), "half[%lu][%lu] != twice[%lu][%lu]", (unsigned long)i,
+                         (unsigned long)j, (unsigned long)i * 2, (unsigned long)j * 2);
             else if (half[i * ny + j] != twice[4 * i * ny + 2 * j + 1])
-                HDsnprintf(s, sizeof(s), "half[%lu][%lu] != twice[%lu][%lu]", (unsigned long)i,
-                           (unsigned long)j, (unsigned long)i * 2, (unsigned long)j * 2 + 1);
+                snprintf(s, sizeof(s), "half[%lu][%lu] != twice[%lu][%lu]", (unsigned long)i,
+                         (unsigned long)j, (unsigned long)i * 2, (unsigned long)j * 2 + 1);
             else if (half[i * ny + j] != twice[(2 * i + 1) * 2 * ny + 2 * j])
-                HDsnprintf(s, sizeof(s), "half[%lu][%lu] != twice[%lu][%lu]", (unsigned long)i,
-                           (unsigned long)j, (unsigned long)i * 2 + 1, (unsigned long)j * 2);
+                snprintf(s, sizeof(s), "half[%lu][%lu] != twice[%lu][%lu]", (unsigned long)i,
+                         (unsigned long)j, (unsigned long)i * 2 + 1, (unsigned long)j * 2);
             else if (half[i * ny + j] != twice[(2 * i + 1) * 2 * ny + 2 * j + 1])
-                HDsnprintf(s, sizeof(s), "half[%lu][%lu] != twice[%lu][%lu]", (unsigned long)i,
-                           (unsigned long)j, (unsigned long)i * 2 + 1, (unsigned long)j * 2 + 1);
+                snprintf(s, sizeof(s), "half[%lu][%lu] != twice[%lu][%lu]", (unsigned long)i,
+                         (unsigned long)j, (unsigned long)i * 2 + 1, (unsigned long)j * 2 + 1);
             if (s[0]) {
                 H5_FAILED();
                 if (!HDisatty(1)) {
@@ -982,7 +981,7 @@ test_array_fill(size_t lo, size_t hi)
     size_t u, v, w;              /* Local index variables        */
     char   s[256];
 
-    HDsnprintf(s, sizeof(s), "array filling %4lu-%-4lu elements", (unsigned long)lo, (unsigned long)hi);
+    snprintf(s, sizeof(s), "array filling %4lu-%-4lu elements", (unsigned long)lo, (unsigned long)hi);
     TESTING(s);
 
     /* Initialize */
@@ -1043,8 +1042,8 @@ test_array_offset_n_calc(size_t n, size_t x, size_t y, size_t z)
     hsize_t  new_coords[ARRAY_OFFSET_NDIMS]; /* X, Y & X coordinates of offset */
     char     s[256];
 
-    HDsnprintf(s, sizeof(s), "array offset %4lux%4lux%4lu elements", (unsigned long)z, (unsigned long)y,
-               (unsigned long)x);
+    snprintf(s, sizeof(s), "array offset %4lux%4lux%4lu elements", (unsigned long)z, (unsigned long)y,
+             (unsigned long)x);
     TESTING(s);
 
     /* Initialize */
@@ -1126,9 +1125,9 @@ main(int argc, char *argv[])
         int i;
 
         for (i = 1, size_of_test = 0; i < argc; i++) {
-            if (!HDstrcmp(argv[i], "small"))
+            if (!strcmp(argv[i], "small"))
                 size_of_test |= TEST_SMALL;
-            else if (!HDstrcmp(argv[i], "medium"))
+            else if (!strcmp(argv[i], "medium"))
                 size_of_test |= TEST_MEDIUM;
             else {
                 printf("unrecognized argument: %s\n", argv[i]);

--- a/test/istore.c
+++ b/test/istore.c
@@ -194,7 +194,7 @@ test_create(hid_t f, const char *prefix)
         dims[u] = my_chunk_dims[u] = 2;
 
         /* Create chunked dataset of this dimensionality */
-        HDsnprintf(name, sizeof name, "%s_%02u", prefix, u);
+        snprintf(name, sizeof name, "%s_%02u", prefix, u);
         if ((dataset = new_object(f, name, (int)u, dims, my_chunk_dims)) < 0)
             return FAIL;
 
@@ -240,21 +240,20 @@ test_extend(hid_t f, const char *prefix, size_t nx, size_t ny, size_t nz)
         if (!ny) {
             ndims = 1;
             ny = nz = 1;
-            HDsnprintf(dims, sizeof(dims), "%lu", (unsigned long)nx);
+            snprintf(dims, sizeof(dims), "%lu", (unsigned long)nx);
         }
         else {
             ndims = 2;
             nz    = 1;
-            HDsnprintf(dims, sizeof(dims), "%lux%lu", (unsigned long)nx, (unsigned long)ny);
+            snprintf(dims, sizeof(dims), "%lux%lu", (unsigned long)nx, (unsigned long)ny);
         }
     }
     else {
         ndims = 3;
-        HDsnprintf(dims, sizeof(dims), "%lux%lux%lu", (unsigned long)nx, (unsigned long)ny,
-                   (unsigned long)nz);
+        snprintf(dims, sizeof(dims), "%lux%lux%lu", (unsigned long)nx, (unsigned long)ny, (unsigned long)nz);
     }
 
-    HDsnprintf(s, sizeof(s), "istore extend: %s", dims);
+    snprintf(s, sizeof(s), "istore extend: %s", dims);
     TESTING(s);
     buf   = (uint8_t *)malloc(nx * ny * nz);
     check = (uint8_t *)malloc(nx * ny * nz);
@@ -268,7 +267,7 @@ test_extend(hid_t f, const char *prefix, size_t nx, size_t ny, size_t nz)
     max_corner[2] = 0;
 
     /* Build the new empty object */
-    HDsnprintf(name, sizeof(name), "%s_%s", prefix, dims);
+    snprintf(name, sizeof(name), "%s_%s", prefix, dims);
     if ((dataset = new_object(f, name, ndims, whole_size, whole_size)) < 0) {
         fprintf(stderr, "    Cannot create %u-d object `%s'\n", ndims, name);
         goto error;
@@ -433,21 +432,20 @@ test_sparse(hid_t f, const char *prefix, size_t nblocks, size_t nx, size_t ny, s
         if (!ny) {
             ndims = 1;
             ny = nz = 1;
-            HDsnprintf(dims, sizeof(dims), "%lu", (unsigned long)nx);
+            snprintf(dims, sizeof(dims), "%lu", (unsigned long)nx);
         }
         else {
             ndims = 2;
             nz    = 1;
-            HDsnprintf(dims, sizeof(dims), "%lux%lu", (unsigned long)nx, (unsigned long)ny);
+            snprintf(dims, sizeof(dims), "%lux%lu", (unsigned long)nx, (unsigned long)ny);
         }
     }
     else {
         ndims = 3;
-        HDsnprintf(dims, sizeof(dims), "%lux%lux%lu", (unsigned long)nx, (unsigned long)ny,
-                   (unsigned long)nz);
+        snprintf(dims, sizeof(dims), "%lux%lux%lu", (unsigned long)nx, (unsigned long)ny, (unsigned long)nz);
     }
 
-    HDsnprintf(s, sizeof(s), "istore sparse: %s", dims);
+    snprintf(s, sizeof(s), "istore sparse: %s", dims);
     TESTING(s);
     if (skip_test) {
         SKIPPED();
@@ -466,7 +464,7 @@ test_sparse(hid_t f, const char *prefix, size_t nblocks, size_t nx, size_t ny, s
     size[2] = nz;
 
     /* Build the new empty object */
-    HDsnprintf(name, sizeof(name), "%s_%s", prefix, dims);
+    snprintf(name, sizeof(name), "%s_%s", prefix, dims);
     if ((dataset = new_object(f, name, ndims, whole_size, chunk_dims)) < 0) {
         printf("    Cannot create %u-d object `%s'\n", ndims, name);
         goto error;
@@ -559,13 +557,13 @@ main(int argc, char *argv[])
     else {
         int i;
         for (i = 1, size_of_test = 0; i < argc; i++) {
-            if (!HDstrcmp(argv[i], "small")) {
+            if (!strcmp(argv[i], "small")) {
                 size_of_test |= TEST_SMALL;
             }
-            else if (!HDstrcmp(argv[i], "medium")) {
+            else if (!strcmp(argv[i], "medium")) {
                 size_of_test |= TEST_MEDIUM;
             }
-            else if (!HDstrcmp(argv[i], "large")) {
+            else if (!strcmp(argv[i], "large")) {
                 size_of_test |= TEST_LARGE;
             }
             else {

--- a/test/lheap.c
+++ b/test/lheap.c
@@ -91,13 +91,13 @@ main(void)
         goto error;
     }
     for (i = 0; i < NOBJS; i++) {
-        HDsnprintf(buf, sizeof(buf), "%03d-", i);
+        snprintf(buf, sizeof(buf), "%03d-", i);
         for (j = 4; j < i; j++)
             buf[j] = (char)('0' + j % 10);
         if (j > 4)
             buf[j] = '\0';
 
-        if (H5HL_insert(f, heap, HDstrlen(buf) + 1, buf, &obj[i]) < 0) {
+        if (H5HL_insert(f, heap, strlen(buf) + 1, buf, &obj[i]) < 0) {
             H5_FAILED();
             H5Eprint2(H5E_DEFAULT, stdout);
             goto error;
@@ -131,7 +131,7 @@ main(void)
         goto error;
     }
     for (i = 0; i < NOBJS; i++) {
-        HDsnprintf(buf, sizeof(buf), "%03d-", i);
+        snprintf(buf, sizeof(buf), "%03d-", i);
         for (j = 4; j < i; j++)
             buf[j] = (char)('0' + j % 10);
         if (j > 4)
@@ -149,7 +149,7 @@ main(void)
             goto error;
         }
 
-        if (HDstrcmp(s, buf) != 0) {
+        if (strcmp(s, buf) != 0) {
             H5_FAILED();
             printf("    i=%d, heap offset=%lu\n", i, (unsigned long)(obj[i]));
             printf("    got: \"%s\"\n", s);
@@ -204,13 +204,13 @@ main(void)
         FAIL_STACK_ERROR;
     api_ctx_pushed = false;
 
-    HDputs("All local heap tests passed.");
+    puts("All local heap tests passed.");
     h5_cleanup(FILENAME, fapl);
 
     return EXIT_SUCCESS;
 
 error:
-    HDputs("*** TESTS FAILED ***");
+    puts("*** TESTS FAILED ***");
     H5E_BEGIN_TRY
     {
         H5Fclose(file);

--- a/test/links.c
+++ b/test/links.c
@@ -400,9 +400,9 @@ const H5L_class_t UD_plist_class[1] = {{
 static void
 fix_ext_filename(char *path_name, char *cwd, const char *file_name)
 {
-    HDstrcpy(path_name, cwd);
-    HDstrcat(path_name, "/");
-    HDstrcat(path_name, file_name);
+    strcpy(path_name, cwd);
+    strcat(path_name, "/");
+    strcat(path_name, file_name);
 }
 
 /*-------------------------------------------------------------------------
@@ -650,8 +650,8 @@ cklinks(hid_t fapl, bool new_format)
         FAIL_STACK_ERROR;
     if (token_cmp) {
         H5_FAILED();
-        HDputs("    Hard link test failed. Link seems not to point to the ");
-        HDputs("    expected file location.");
+        puts("    Hard link test failed. Link seems not to point to the ");
+        puts("    expected file location.");
         TEST_ERROR;
     } /* end if */
     if (H5Lexists(file, "/", H5P_DEFAULT) != true)
@@ -671,7 +671,7 @@ cklinks(hid_t fapl, bool new_format)
     H5E_END_TRY
     if (status >= 0) {
         H5_FAILED();
-        HDputs("    H5Lexists() should have failed for a path with missing components.");
+        puts("    H5Lexists() should have failed for a path with missing components.");
         TEST_ERROR;
     } /* end if */
     H5E_BEGIN_TRY
@@ -681,7 +681,7 @@ cklinks(hid_t fapl, bool new_format)
     H5E_END_TRY
     if (status >= 0) {
         H5_FAILED();
-        HDputs("    H5Lexists() should have failed for a path with missing components.");
+        puts("    H5Lexists() should have failed for a path with missing components.");
         TEST_ERROR;
     } /* end if */
 
@@ -697,15 +697,15 @@ cklinks(hid_t fapl, bool new_format)
         FAIL_STACK_ERROR;
     if (token_cmp) {
         H5_FAILED();
-        HDputs("    Soft link test failed. Link seems not to point to the ");
-        HDputs("    expected file location.");
+        puts("    Soft link test failed. Link seems not to point to the ");
+        puts("    expected file location.");
         TEST_ERROR;
     } /* end if */
     if (H5Lget_val(file, "grp1/soft", linkval, sizeof linkval, H5P_DEFAULT) < 0)
         FAIL_STACK_ERROR;
-    if (HDstrcmp(linkval, "/d1") != 0) {
+    if (strcmp(linkval, "/d1") != 0) {
         H5_FAILED();
-        HDputs("    Soft link test failed. Wrong link value");
+        puts("    Soft link test failed. Wrong link value");
         TEST_ERROR;
     } /* end if */
     if (H5Lexists(file, "grp1/soft", H5P_DEFAULT) != true)
@@ -719,7 +719,7 @@ cklinks(hid_t fapl, bool new_format)
     H5E_END_TRY
     if (status >= 0) {
         H5_FAILED();
-        HDputs("    H5Oget_info_by_name() should have failed for a dangling link.");
+        puts("    H5Oget_info_by_name() should have failed for a dangling link.");
         TEST_ERROR;
     } /* end if */
     if (H5Lget_info2(file, "grp1/dangle", &linfo, H5P_DEFAULT) < 0)
@@ -734,9 +734,9 @@ cklinks(hid_t fapl, bool new_format)
         printf("    %d: Can't retrieve link value\n", __LINE__);
         TEST_ERROR;
     } /* end if */
-    if (HDstrcmp(linkval, "foobar") != 0) {
+    if (strcmp(linkval, "foobar") != 0) {
         H5_FAILED();
-        HDputs("    Dangling link test failed. Wrong link value");
+        puts("    Dangling link test failed. Wrong link value");
         TEST_ERROR;
     } /* end if */
     if (H5Lexists(file, "grp1/dangle", H5P_DEFAULT) != true)
@@ -750,7 +750,7 @@ cklinks(hid_t fapl, bool new_format)
     H5E_END_TRY
     if (status >= 0) {
         H5_FAILED();
-        HDputs("    H5Oget_info_by_name() should have failed for a recursive link.");
+        puts("    H5Oget_info_by_name() should have failed for a recursive link.");
         TEST_ERROR;
     } /* end if */
     if (H5Lget_info2(file, "grp1/recursive", &linfo, H5P_DEFAULT) < 0)
@@ -765,9 +765,9 @@ cklinks(hid_t fapl, bool new_format)
         printf("    %d: Can't retrieve link value\n", __LINE__);
         TEST_ERROR;
     } /* end if */
-    if (HDstrcmp(linkval, "/grp1/recursive") != 0) {
+    if (strcmp(linkval, "/grp1/recursive") != 0) {
         H5_FAILED();
-        HDputs("   Recursive link test failed. Wrong link value");
+        puts("   Recursive link test failed. Wrong link value");
         TEST_ERROR;
     } /* end if */
 
@@ -835,8 +835,8 @@ ck_new_links(hid_t fapl, bool new_format)
         TEST_ERROR;
     if (token_cmp1 || token_cmp2) {
         H5_FAILED();
-        HDputs("    Hard link test failed.  Link seems not to point to the ");
-        HDputs("    expected file location.");
+        puts("    Hard link test failed.  Link seems not to point to the ");
+        puts("    expected file location.");
         TEST_ERROR;
     }
 
@@ -1064,7 +1064,7 @@ toomany(hid_t fapl, bool new_format)
     /* Check name */
     if (H5Iget_name(gid, objname, (size_t)NAME_BUF_SIZE) < 0)
         TEST_ERROR;
-    if (HDstrcmp(objname, "/hard21") != 0)
+    if (strcmp(objname, "/hard21") != 0)
         TEST_ERROR;
 
     /* Create object in hard-linked group */
@@ -1087,7 +1087,7 @@ toomany(hid_t fapl, bool new_format)
     H5E_END_TRY
     if (gid >= 0) {
         H5_FAILED();
-        HDputs("    Should have failed for sequence of too many nested links.");
+        puts("    Should have failed for sequence of too many nested links.");
         TEST_ERROR;
     } /* end if */
 
@@ -1098,7 +1098,7 @@ toomany(hid_t fapl, bool new_format)
     /* Check name */
     if (H5Iget_name(gid, objname, (size_t)NAME_BUF_SIZE) < 0)
         TEST_ERROR;
-    if (HDstrcmp(objname, "/soft16") != 0)
+    if (strcmp(objname, "/soft16") != 0)
         TEST_ERROR;
 
     /* Create object using soft links */
@@ -1436,7 +1436,7 @@ test_move(hid_t fapl, bool new_format)
     H5E_END_TRY
     if (moved_grp >= 0) {
         H5_FAILED();
-        HDputs("    Group still in original location?");
+        puts("    Group still in original location?");
         TEST_ERROR;
     } /* end if */
 
@@ -1969,7 +1969,7 @@ test_deprec(hid_t fapl, bool new_format)
         FAIL_STACK_ERROR;
     if (H5Gget_comment(file_id, "group1", sizeof(tmpstr), tmpstr) < 0)
         FAIL_STACK_ERROR;
-    if (HDstrcmp(tmpstr, "comment") != 0)
+    if (strcmp(tmpstr, "comment") != 0)
         TEST_ERROR;
 
     /* Create links using H5Glink and H5Glink2 */
@@ -1985,7 +1985,7 @@ test_deprec(hid_t fapl, bool new_format)
     /* Test getting the names for objects */
     if (H5Gget_objname_by_idx(group1_id, (hsize_t)0, tmpstr, sizeof(tmpstr)) < 0)
         FAIL_STACK_ERROR;
-    if (HDstrcmp(tmpstr, "link_to_group2") != 0)
+    if (strcmp(tmpstr, "link_to_group2") != 0)
         TEST_ERROR;
     H5E_BEGIN_TRY
     {
@@ -2024,8 +2024,8 @@ test_deprec(hid_t fapl, bool new_format)
 
     if (memcmp(&sb_hard1.objno, sb_hard2.objno, sizeof(sb_hard1.objno)) != 0) {
         H5_FAILED();
-        HDputs("    Hard link test failed.  Link seems not to point to the ");
-        HDputs("    expected file location.");
+        puts("    Hard link test failed.  Link seems not to point to the ");
+        puts("    expected file location.");
         TEST_ERROR;
     } /* end if */
 
@@ -2037,8 +2037,8 @@ test_deprec(hid_t fapl, bool new_format)
 
     if (memcmp(&sb_hard1.objno, sb_hard2.objno, sizeof(sb_hard1.objno)) != 0) {
         H5_FAILED();
-        HDputs("    Hard link test failed.  Link seems not to point to the ");
-        HDputs("    expected file location.");
+        puts("    Hard link test failed.  Link seems not to point to the ");
+        puts("    expected file location.");
         TEST_ERROR;
     } /* end if */
 
@@ -2047,12 +2047,12 @@ test_deprec(hid_t fapl, bool new_format)
         FAIL_STACK_ERROR;
     if (sb_soft1.type != H5G_LINK)
         TEST_ERROR;
-    if (sb_soft1.linklen != HDstrlen("link_to_group1") + 1)
+    if (sb_soft1.linklen != strlen("link_to_group1") + 1)
         TEST_ERROR;
 
     if (H5Gget_linkval(group2_id, "soft_link_to_group1", sb_soft1.linklen, tmpstr) < 0)
         FAIL_STACK_ERROR;
-    if (HDstrcmp("link_to_group1", tmpstr) != 0)
+    if (strcmp("link_to_group1", tmpstr) != 0)
         TEST_ERROR;
 
     /* Test non-existing links with H5Gget_objinfo */
@@ -2068,12 +2068,12 @@ test_deprec(hid_t fapl, bool new_format)
         FAIL_STACK_ERROR;
     if (sb_soft2.type != H5G_LINK)
         TEST_ERROR;
-    if (sb_soft2.linklen != HDstrlen("dangle") + 1)
+    if (sb_soft2.linklen != strlen("dangle") + 1)
         TEST_ERROR;
 
     if (H5Gget_linkval(group2_id, "dangle_soft_link", sb_soft2.linklen, tmpstr) < 0)
         FAIL_STACK_ERROR;
-    if (HDstrcmp("dangle", tmpstr) != 0)
+    if (strcmp("dangle", tmpstr) != 0)
         TEST_ERROR;
 
     /* Test H5Gmove and H5Gmove2 */
@@ -2170,8 +2170,8 @@ cklinks_deprec(hid_t fapl, bool new_format)
     } /* end if */
     if (H5_addr_ne(oinfo1.addr, oinfo2.addr)) {
         H5_FAILED();
-        HDputs("    Hard link test failed. Link seems not to point to the ");
-        HDputs("    expected file location.");
+        puts("    Hard link test failed. Link seems not to point to the ");
+        puts("    expected file location.");
         TEST_ERROR;
     } /* end if */
     if (H5Lexists(file, "/", H5P_DEFAULT) != true)
@@ -2191,7 +2191,7 @@ cklinks_deprec(hid_t fapl, bool new_format)
     H5E_END_TRY
     if (exists >= 0) {
         H5_FAILED();
-        HDputs("    H5Lexists() should have failed for a path with missing components.");
+        puts("    H5Lexists() should have failed for a path with missing components.");
         TEST_ERROR;
     } /* end if */
     H5E_BEGIN_TRY
@@ -2201,7 +2201,7 @@ cklinks_deprec(hid_t fapl, bool new_format)
     H5E_END_TRY
     if (exists >= 0) {
         H5_FAILED();
-        HDputs("    H5Lexists() should have failed for a path with missing components.");
+        puts("    H5Lexists() should have failed for a path with missing components.");
         TEST_ERROR;
     } /* end if */
 
@@ -2215,15 +2215,15 @@ cklinks_deprec(hid_t fapl, bool new_format)
     } /* end if */
     if (H5_addr_ne(oinfo1.addr, oinfo2.addr)) {
         H5_FAILED();
-        HDputs("    Soft link test failed. Link seems not to point to the ");
-        HDputs("    expected file location.");
+        puts("    Soft link test failed. Link seems not to point to the ");
+        puts("    expected file location.");
         TEST_ERROR;
     } /* end if */
     if (H5Lget_val(file, "grp1/soft", linkval, sizeof linkval, H5P_DEFAULT) < 0)
         FAIL_STACK_ERROR;
-    if (HDstrcmp(linkval, "/d1") != 0) {
+    if (strcmp(linkval, "/d1") != 0) {
         H5_FAILED();
-        HDputs("    Soft link test failed. Wrong link value");
+        puts("    Soft link test failed. Wrong link value");
         TEST_ERROR;
     } /* end if */
     if (H5Lexists(file, "grp1/soft", H5P_DEFAULT) != true)
@@ -2237,7 +2237,7 @@ cklinks_deprec(hid_t fapl, bool new_format)
     H5E_END_TRY
     if (status >= 0) {
         H5_FAILED();
-        HDputs("    H5Oget_info_by_name() should have failed for a dangling link.");
+        puts("    H5Oget_info_by_name() should have failed for a dangling link.");
         TEST_ERROR;
     } /* end if */
     if (H5Lget_info1(file, "grp1/dangle", &linfo, H5P_DEFAULT) < 0)
@@ -2252,9 +2252,9 @@ cklinks_deprec(hid_t fapl, bool new_format)
         printf("    %d: Can't retrieve link value\n", __LINE__);
         TEST_ERROR;
     } /* end if */
-    if (HDstrcmp(linkval, "foobar") != 0) {
+    if (strcmp(linkval, "foobar") != 0) {
         H5_FAILED();
-        HDputs("    Dangling link test failed. Wrong link value");
+        puts("    Dangling link test failed. Wrong link value");
         TEST_ERROR;
     } /* end if */
     if (H5Lexists(file, "grp1/dangle", H5P_DEFAULT) != true)
@@ -2268,7 +2268,7 @@ cklinks_deprec(hid_t fapl, bool new_format)
     H5E_END_TRY
     if (status >= 0) {
         H5_FAILED();
-        HDputs("    H5Oget_info_by_name() should have failed for a recursive link.");
+        puts("    H5Oget_info_by_name() should have failed for a recursive link.");
         TEST_ERROR;
     } /* end if */
     if (H5Lget_info1(file, "grp1/recursive", &linfo, H5P_DEFAULT) < 0)
@@ -2283,9 +2283,9 @@ cklinks_deprec(hid_t fapl, bool new_format)
         printf("    %d: Can't retrieve link value\n", __LINE__);
         TEST_ERROR;
     } /* end if */
-    if (HDstrcmp(linkval, "/grp1/recursive") != 0) {
+    if (strcmp(linkval, "/grp1/recursive") != 0) {
         H5_FAILED();
-        HDputs("   Recursive link test failed. Wrong link value");
+        puts("   Recursive link test failed. Wrong link value");
         TEST_ERROR;
     } /* end if */
 
@@ -2813,21 +2813,21 @@ external_link_root_deprec(hid_t fapl, bool new_format)
         goto error;
     if (H5L_TYPE_EXTERNAL != linfo.type) {
         H5_FAILED();
-        HDputs("    Unexpected object type - should have been an external link");
+        puts("    Unexpected object type - should have been an external link");
         goto error;
     }
     if (H5Lget_val(fid, "ext_link", objname, sizeof(objname), H5P_DEFAULT) < 0)
         TEST_ERROR;
     if (H5Lunpack_elink_val(objname, linfo.u.val_size, NULL, &file, &path) < 0)
         TEST_ERROR;
-    if (HDstrcmp(file, filename1) != 0) {
+    if (strcmp(file, filename1) != 0) {
         H5_FAILED();
-        HDputs("    External link file name incorrect");
+        puts("    External link file name incorrect");
         goto error;
     }
-    if (HDstrcmp(path, "/") != 0) {
+    if (strcmp(path, "/") != 0) {
         H5_FAILED();
-        HDputs("    External link path incorrect");
+        puts("    External link path incorrect");
         goto error;
     }
 
@@ -2841,21 +2841,21 @@ external_link_root_deprec(hid_t fapl, bool new_format)
         goto error;
     if (H5L_TYPE_EXTERNAL != linfo.type) {
         H5_FAILED();
-        HDputs("    Unexpected object type - should have been an external link");
+        puts("    Unexpected object type - should have been an external link");
         goto error;
     }
     if (H5Lget_val(fid, "ext_link", objname, sizeof(objname), H5P_DEFAULT) < 0)
         TEST_ERROR;
     if (H5Lunpack_elink_val(objname, linfo.u.val_size, NULL, &file, &path) < 0)
         TEST_ERROR;
-    if (HDstrcmp(file, filename1) != 0) {
+    if (strcmp(file, filename1) != 0) {
         H5_FAILED();
-        HDputs("    External link file name incorrect");
+        puts("    External link file name incorrect");
         goto error;
     }
-    if (HDstrcmp(path, "/") != 0) {
+    if (strcmp(path, "/") != 0) {
         H5_FAILED();
-        HDputs("    External link path incorrect");
+        puts("    External link path incorrect");
         goto error;
     }
 
@@ -2872,7 +2872,7 @@ external_link_root_deprec(hid_t fapl, bool new_format)
     /* Check name */
     if (H5Iget_name(gid, objname, (size_t)NAME_BUF_SIZE) < 0)
         TEST_ERROR;
-    if (HDstrcmp(objname, "/") != 0)
+    if (strcmp(objname, "/") != 0)
         TEST_ERROR;
 
     /* Create object in external file */
@@ -2917,11 +2917,11 @@ external_link_root_deprec(hid_t fapl, bool new_format)
     /* Check names */
     if (H5Iget_name(gid, objname, (size_t)NAME_BUF_SIZE) < 0)
         TEST_ERROR;
-    if (HDstrcmp(objname, "/new_group") != 0)
+    if (strcmp(objname, "/new_group") != 0)
         TEST_ERROR;
     if (H5Iget_name(gid2, objname, (size_t)NAME_BUF_SIZE) < 0)
         TEST_ERROR;
-    if (HDstrcmp(objname, "/newer_group") != 0)
+    if (strcmp(objname, "/newer_group") != 0)
         TEST_ERROR;
 
     /* Close opened objects */
@@ -3019,11 +3019,11 @@ external_link_query_deprec(hid_t fapl, bool new_format)
     /* Get size of buffer for external link */
     if (H5Lget_info1(fid, "src", &li, H5P_DEFAULT) < 0)
         TEST_ERROR;
-    if (li.u.val_size != (1 + (HDstrlen(filename2) + 1) + (HDstrlen("/dst") + 1)))
+    if (li.u.val_size != (1 + (strlen(filename2) + 1) + (strlen("/dst") + 1)))
         TEST_ERROR;
     if (H5L_TYPE_EXTERNAL != li.type) {
         H5_FAILED();
-        HDputs("    Unexpected link class - should have been an external link");
+        puts("    Unexpected link class - should have been an external link");
         goto error;
     }
 
@@ -3052,11 +3052,11 @@ external_link_query_deprec(hid_t fapl, bool new_format)
     /* Get size of buffer for external link */
     if (H5Lget_info1(fid, "src", &li, H5P_DEFAULT) < 0)
         TEST_ERROR;
-    if (li.u.val_size != (1 + (HDstrlen(filename2) + 1) + (HDstrlen("/dst") + 1)))
+    if (li.u.val_size != (1 + (strlen(filename2) + 1) + (strlen("/dst") + 1)))
         TEST_ERROR;
     if (H5L_TYPE_EXTERNAL != li.type) {
         H5_FAILED();
-        HDputs("    Unexpected link class - should have been an external link");
+        puts("    Unexpected link class - should have been an external link");
         goto error;
     }
 
@@ -3069,9 +3069,9 @@ external_link_query_deprec(hid_t fapl, bool new_format)
         TEST_ERROR;
 
     /* Compare the file and object names */
-    if (HDstrcmp(file_name, filename2) != 0)
+    if (strcmp(file_name, filename2) != 0)
         TEST_ERROR;
-    if (HDstrcmp(object_name, "/dst") != 0)
+    if (strcmp(object_name, "/dst") != 0)
         TEST_ERROR;
 
     /* Query information about object that external link points to */
@@ -3079,7 +3079,7 @@ external_link_query_deprec(hid_t fapl, bool new_format)
         FAIL_STACK_ERROR;
     if (H5O_TYPE_GROUP != oi.type) {
         H5_FAILED();
-        HDputs("    Unexpected object type - should have been a group");
+        puts("    Unexpected object type - should have been a group");
         goto error;
     }
 
@@ -3267,7 +3267,7 @@ external_link_closing_deprec(hid_t fapl, bool new_format)
         FAIL_STACK_ERROR;
     if (H5Oget_comment_by_name(fid1, "elink/elink/elink/group1_moved", buf, sizeof(buf), H5P_DEFAULT) < 0)
         FAIL_STACK_ERROR;
-    if (HDstrcmp(buf, "comment") != 0)
+    if (strcmp(buf, "comment") != 0)
         TEST_ERROR;
 
     /* Test H5*open */
@@ -3686,7 +3686,7 @@ ud_hard_links_deprec(hid_t fapl)
     /* Check name */
     if (H5Iget_name(gid, objname, (size_t)NAME_BUF_SIZE) < 0)
         TEST_ERROR;
-    if (HDstrcmp(objname, "/group") != 0)
+    if (strcmp(objname, "/group") != 0)
         TEST_ERROR;
 
     /* Create object in group */
@@ -3706,7 +3706,7 @@ ud_hard_links_deprec(hid_t fapl)
     /* Check name */
     if (H5Iget_name(gid, objname, (size_t)NAME_BUF_SIZE) < 0)
         TEST_ERROR;
-    if (HDstrcmp(objname, "/group/new_group") != 0)
+    if (strcmp(objname, "/group/new_group") != 0)
         TEST_ERROR;
 
     /* Close opened object */
@@ -3721,7 +3721,7 @@ ud_hard_links_deprec(hid_t fapl)
         TEST_ERROR;
     if (UD_HARD_TYPE != li.type) {
         H5_FAILED();
-        HDputs("    Unexpected link class - should have been a UD hard link");
+        puts("    Unexpected link class - should have been a UD hard link");
         goto error;
     } /* end if */
 
@@ -3869,7 +3869,7 @@ ud_link_reregister_deprec(hid_t fapl)
     /* Check name */
     if (H5Iget_name(gid, objname, (size_t)NAME_BUF_SIZE) < 0)
         TEST_ERROR;
-    if (HDstrcmp(objname, "/" REREG_TARGET_NAME) != 0)
+    if (strcmp(objname, "/" REREG_TARGET_NAME) != 0)
         TEST_ERROR;
 
     /* Create object in group */
@@ -3889,7 +3889,7 @@ ud_link_reregister_deprec(hid_t fapl)
     /* Check name */
     if (H5Iget_name(gid, objname, (size_t)NAME_BUF_SIZE) < 0)
         TEST_ERROR;
-    if (HDstrcmp(objname, "/rereg_target/new_group") != 0)
+    if (strcmp(objname, "/rereg_target/new_group") != 0)
         TEST_ERROR;
 
     /* Close opened object */
@@ -4026,14 +4026,14 @@ ud_callbacks_deprec(hid_t fapl, bool new_format)
         TEST_ERROR;
     if (UD_CB_TYPE != li.type) {
         H5_FAILED();
-        HDputs("    Unexpected link class - should have been a UD hard link");
+        puts("    Unexpected link class - should have been a UD hard link");
         goto error;
     }
 
     /* Fill the query buffer */
     if (H5Lget_val(fid, UD_CB_LINK_NAME, query_buf, (size_t)NAME_BUF_SIZE, H5P_DEFAULT) < 0)
         FAIL_STACK_ERROR;
-    if (HDstrcmp(query_buf, "query succeeded") != 0)
+    if (strcmp(query_buf, "query succeeded") != 0)
         TEST_ERROR;
 
     /* Move the link */
@@ -4233,7 +4233,7 @@ lapl_nlinks_deprec(hid_t fapl, bool new_format)
     /* Check name */
     if (H5Iget_name(gid, objname, (size_t)NAME_BUF_SIZE) < 0)
         TEST_ERROR;
-    if (HDstrcmp(objname, "/soft17") != 0)
+    if (strcmp(objname, "/soft17") != 0)
         TEST_ERROR;
 
     /* Create group using soft link */
@@ -4266,7 +4266,7 @@ lapl_nlinks_deprec(hid_t fapl, bool new_format)
     H5E_END_TRY
     if (gid >= 0) {
         H5_FAILED();
-        HDputs("    Should have failed for sequence of too many nested links.");
+        puts("    Should have failed for sequence of too many nested links.");
         goto error;
     }
 
@@ -4277,7 +4277,7 @@ lapl_nlinks_deprec(hid_t fapl, bool new_format)
     /* Check name */
     if (H5Iget_name(gid, objname, (size_t)NAME_BUF_SIZE) < 0)
         TEST_ERROR;
-    if (HDstrcmp(objname, "/soft4") != 0)
+    if (strcmp(objname, "/soft4") != 0)
         TEST_ERROR;
 
     /* Test other functions that should use a LAPL */
@@ -4597,7 +4597,7 @@ corder_create_compact_deprec(hid_t fapl)
 
     /* Create several links, but keep group in compact form */
     for (u = 0; u < max_compact; u++) {
-        HDsnprintf(objname, sizeof(objname), "filler %u", u);
+        snprintf(objname, sizeof(objname), "filler %u", u);
         if ((group_id2 = H5Gcreate2(group_id, objname, H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT)) < 0)
             TEST_ERROR;
         if (H5Gclose(group_id2) < 0)
@@ -4650,7 +4650,7 @@ corder_create_compact_deprec(hid_t fapl)
         H5L_info1_t linfo; /* Link information */
 
         /* Retrieve information for link */
-        HDsnprintf(objname, sizeof(objname), "filler %u", u);
+        snprintf(objname, sizeof(objname), "filler %u", u);
         if (H5Lget_info1(group_id, objname, &linfo, H5P_DEFAULT) < 0)
             TEST_ERROR;
 
@@ -4741,7 +4741,7 @@ corder_create_dense_deprec(hid_t fapl)
 
     /* Create several links, up to limit of compact form */
     for (u = 0; u < max_compact; u++) {
-        HDsnprintf(objname, sizeof(objname), "filler %u", u);
+        snprintf(objname, sizeof(objname), "filler %u", u);
         if ((group_id2 = H5Gcreate2(group_id, objname, H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT)) < 0)
             TEST_ERROR;
         if (H5Gclose(group_id2) < 0)
@@ -4759,7 +4759,7 @@ corder_create_dense_deprec(hid_t fapl)
     } /* end for */
 
     /* Create another link, to push group into dense form */
-    HDsnprintf(objname, sizeof(objname), "filler %u", max_compact);
+    snprintf(objname, sizeof(objname), "filler %u", max_compact);
     if ((group_id2 = H5Gcreate2(group_id, objname, H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT)) < 0)
         TEST_ERROR;
     if (H5Gclose(group_id2) < 0)
@@ -4813,7 +4813,7 @@ corder_create_dense_deprec(hid_t fapl)
         H5L_info1_t linfo; /* Link information */
 
         /* Retrieve information for link */
-        HDsnprintf(objname, sizeof(objname), "filler %u", u);
+        snprintf(objname, sizeof(objname), "filler %u", u);
         if (H5Lget_info1(group_id, objname, &linfo, H5P_DEFAULT) < 0)
             TEST_ERROR;
 
@@ -4868,7 +4868,7 @@ link_info_by_idx_check_deprec(hid_t group_id, const char *linkname, hsize_t n, b
     H5L_info1_t linfo;                  /* Link info struct */
 
     /* Make link value for increasing/native order queries */
-    HDsnprintf(valname, sizeof(valname), "value %02u", (unsigned)n);
+    snprintf(valname, sizeof(valname), "value %02u", (unsigned)n);
 
     /* Verify the link information for first link, in increasing creation order */
     memset(&linfo, 0, sizeof(linfo));
@@ -4891,7 +4891,7 @@ link_info_by_idx_check_deprec(hid_t group_id, const char *linkname, hsize_t n, b
         if (H5Lget_val_by_idx(group_id, ".", H5_INDEX_CRT_ORDER, H5_ITER_INC, n, tmpval,
                               (size_t)NAME_BUF_SIZE, H5P_DEFAULT) < 0)
             TEST_ERROR;
-        if (HDstrcmp(valname, tmpval) != 0)
+        if (strcmp(valname, tmpval) != 0)
             TEST_ERROR;
     } /* end if */
 
@@ -4900,7 +4900,7 @@ link_info_by_idx_check_deprec(hid_t group_id, const char *linkname, hsize_t n, b
     if (H5Lget_name_by_idx(group_id, ".", H5_INDEX_CRT_ORDER, H5_ITER_INC, n, tmpname, (size_t)NAME_BUF_SIZE,
                            H5P_DEFAULT) < 0)
         TEST_ERROR;
-    if (HDstrcmp(linkname, tmpname) != 0)
+    if (strcmp(linkname, tmpname) != 0)
         TEST_ERROR;
 
     /* Don't test "native" order if there is no creation order index, since
@@ -4930,7 +4930,7 @@ link_info_by_idx_check_deprec(hid_t group_id, const char *linkname, hsize_t n, b
             if (H5Lget_val_by_idx(group_id, ".", H5_INDEX_CRT_ORDER, H5_ITER_NATIVE, n, tmpval,
                                   (size_t)NAME_BUF_SIZE, H5P_DEFAULT) < 0)
                 TEST_ERROR;
-            if (HDstrcmp(valname, tmpval) != 0)
+            if (strcmp(valname, tmpval) != 0)
                 TEST_ERROR;
         } /* end if */
 
@@ -4939,7 +4939,7 @@ link_info_by_idx_check_deprec(hid_t group_id, const char *linkname, hsize_t n, b
         if (H5Lget_name_by_idx(group_id, ".", H5_INDEX_CRT_ORDER, H5_ITER_NATIVE, n, tmpname,
                                (size_t)NAME_BUF_SIZE, H5P_DEFAULT) < 0)
             TEST_ERROR;
-        if (HDstrcmp(linkname, tmpname) != 0)
+        if (strcmp(linkname, tmpname) != 0)
             TEST_ERROR;
     } /* end if */
 
@@ -4964,7 +4964,7 @@ link_info_by_idx_check_deprec(hid_t group_id, const char *linkname, hsize_t n, b
         if (H5Lget_val_by_idx(group_id, ".", H5_INDEX_CRT_ORDER, H5_ITER_DEC, (hsize_t)0, tmpval,
                               (size_t)NAME_BUF_SIZE, H5P_DEFAULT) < 0)
             TEST_ERROR;
-        if (HDstrcmp(valname, tmpval) != 0)
+        if (strcmp(valname, tmpval) != 0)
             TEST_ERROR;
     } /* end if */
 
@@ -4973,7 +4973,7 @@ link_info_by_idx_check_deprec(hid_t group_id, const char *linkname, hsize_t n, b
     if (H5Lget_name_by_idx(group_id, ".", H5_INDEX_CRT_ORDER, H5_ITER_DEC, (hsize_t)0, tmpname,
                            (size_t)NAME_BUF_SIZE, H5P_DEFAULT) < 0)
         TEST_ERROR;
-    if (HDstrcmp(linkname, tmpname) != 0)
+    if (strcmp(linkname, tmpname) != 0)
         TEST_ERROR;
 
     /* Verify the link information for first link, in increasing link name order */
@@ -4996,7 +4996,7 @@ link_info_by_idx_check_deprec(hid_t group_id, const char *linkname, hsize_t n, b
         if (H5Lget_val_by_idx(group_id, ".", H5_INDEX_NAME, H5_ITER_INC, n, tmpval, (size_t)NAME_BUF_SIZE,
                               H5P_DEFAULT) < 0)
             TEST_ERROR;
-        if (HDstrcmp(valname, tmpval) != 0)
+        if (strcmp(valname, tmpval) != 0)
             TEST_ERROR;
     } /* end if */
 
@@ -5005,7 +5005,7 @@ link_info_by_idx_check_deprec(hid_t group_id, const char *linkname, hsize_t n, b
     if (H5Lget_name_by_idx(group_id, ".", H5_INDEX_NAME, H5_ITER_INC, n, tmpname, (size_t)NAME_BUF_SIZE,
                            H5P_DEFAULT) < 0)
         TEST_ERROR;
-    if (HDstrcmp(linkname, tmpname) != 0)
+    if (strcmp(linkname, tmpname) != 0)
         TEST_ERROR;
 
     /* Don't test "native" order queries on link name order, since there's not
@@ -5032,7 +5032,7 @@ link_info_by_idx_check_deprec(hid_t group_id, const char *linkname, hsize_t n, b
         if (H5Lget_val_by_idx(group_id, ".", H5_INDEX_NAME, H5_ITER_DEC, (hsize_t)0, tmpval,
                               (size_t)NAME_BUF_SIZE, H5P_DEFAULT) < 0)
             TEST_ERROR;
-        if (HDstrcmp(valname, tmpval) != 0)
+        if (strcmp(valname, tmpval) != 0)
             TEST_ERROR;
     } /* end if */
 
@@ -5041,7 +5041,7 @@ link_info_by_idx_check_deprec(hid_t group_id, const char *linkname, hsize_t n, b
     if (H5Lget_name_by_idx(group_id, ".", H5_INDEX_NAME, H5_ITER_DEC, (hsize_t)0, tmpname,
                            (size_t)NAME_BUF_SIZE, H5P_DEFAULT) < 0)
         TEST_ERROR;
-    if (HDstrcmp(linkname, tmpname) != 0)
+    if (strcmp(linkname, tmpname) != 0)
         TEST_ERROR;
 
     /* Success */
@@ -5145,7 +5145,7 @@ link_info_by_idx_deprec(hid_t fapl)
             /* Create several links, up to limit of compact form */
             for (u = 0; u < max_compact; u++) {
                 /* Make name for link */
-                HDsnprintf(objname, sizeof(objname), "filler %02u", u);
+                snprintf(objname, sizeof(objname), "filler %02u", u);
 
                 /* Check for creating hard or soft link */
                 if (hard_link) {
@@ -5160,7 +5160,7 @@ link_info_by_idx_deprec(hid_t fapl)
                 } /* end if */
                 else {
                     /* Make value for link */
-                    HDsnprintf(valname, sizeof(valname), "value %02u", u);
+                    snprintf(valname, sizeof(valname), "value %02u", u);
 
                     /* Create soft link */
                     if (H5Lcreate_soft(valname, group_id, objname, H5P_DEFAULT, H5P_DEFAULT) < 0)
@@ -5205,7 +5205,7 @@ link_info_by_idx_deprec(hid_t fapl)
             /* Create more links, to push group into dense form */
             for (; u < (max_compact * 2); u++) {
                 /* Make name for link */
-                HDsnprintf(objname, sizeof(objname), "filler %02u", u);
+                snprintf(objname, sizeof(objname), "filler %02u", u);
 
                 /* Check for creating hard or soft link */
                 if (hard_link) {
@@ -5220,7 +5220,7 @@ link_info_by_idx_deprec(hid_t fapl)
                 } /* end if */
                 else {
                     /* Make value for link */
-                    HDsnprintf(valname, sizeof(valname), "value %02u", u);
+                    snprintf(valname, sizeof(valname), "value %02u", u);
 
                     /* Create soft link */
                     if (H5Lcreate_soft(valname, group_id, objname, H5P_DEFAULT, H5P_DEFAULT) < 0)
@@ -5337,7 +5337,7 @@ link_info_by_idx_old_deprec(hid_t fapl)
         /* Create several links */
         for (u = 0; u < CORDER_NLINKS; u++) {
             /* Make name for link */
-            HDsnprintf(objname, sizeof(objname), "filler %02u", u);
+            snprintf(objname, sizeof(objname), "filler %02u", u);
 
             /* Check for creating hard or soft link */
             if (hard_link) {
@@ -5358,7 +5358,7 @@ link_info_by_idx_old_deprec(hid_t fapl)
             } /* end if */
             else {
                 /* Make value for link */
-                HDsnprintf(valname, sizeof(valname), "value %02u", u);
+                snprintf(valname, sizeof(valname), "value %02u", u);
 
                 /* Create soft link */
                 if (H5Lcreate_soft(valname, group_id, objname, H5P_DEFAULT, H5P_DEFAULT) < 0)
@@ -5371,10 +5371,10 @@ link_info_by_idx_old_deprec(hid_t fapl)
             unsigned dec_u = CORDER_NLINKS - (u + 1); /* Decreasing mapped index */
 
             /* Make link name for increasing/native order queries */
-            HDsnprintf(objname, sizeof(objname), "filler %02u", u);
+            snprintf(objname, sizeof(objname), "filler %02u", u);
 
             /* Make link value for increasing/native order queries */
-            HDsnprintf(valname, sizeof(valname), "value %02u", u);
+            snprintf(valname, sizeof(valname), "value %02u", u);
 
             /* Verify link information (in increasing order) */
             if (hard_link) {
@@ -5388,7 +5388,7 @@ link_info_by_idx_old_deprec(hid_t fapl)
                 if (H5Lget_val_by_idx(group_id, ".", H5_INDEX_NAME, H5_ITER_INC, (hsize_t)u, tmpval,
                                       (size_t)NAME_BUF_SIZE, H5P_DEFAULT) < 0)
                     TEST_ERROR;
-                if (HDstrcmp(valname, tmpval) != 0)
+                if (strcmp(valname, tmpval) != 0)
                     TEST_ERROR;
             } /* end else */
 
@@ -5396,7 +5396,7 @@ link_info_by_idx_old_deprec(hid_t fapl)
             if (H5Lget_name_by_idx(group_id, ".", H5_INDEX_NAME, H5_ITER_INC, (hsize_t)u, tmpname,
                                    (size_t)NAME_BUF_SIZE, H5P_DEFAULT) < 0)
                 TEST_ERROR;
-            if (HDstrcmp(objname, tmpname) != 0)
+            if (strcmp(objname, tmpname) != 0)
                 TEST_ERROR;
 
             /* Verify link information (in native order - native is increasing) */
@@ -5411,7 +5411,7 @@ link_info_by_idx_old_deprec(hid_t fapl)
                 if (H5Lget_val_by_idx(group_id, ".", H5_INDEX_NAME, H5_ITER_NATIVE, (hsize_t)u, tmpval,
                                       (size_t)NAME_BUF_SIZE, H5P_DEFAULT) < 0)
                     TEST_ERROR;
-                if (HDstrcmp(valname, tmpval) != 0)
+                if (strcmp(valname, tmpval) != 0)
                     TEST_ERROR;
             } /* end else */
 
@@ -5419,14 +5419,14 @@ link_info_by_idx_old_deprec(hid_t fapl)
             if (H5Lget_name_by_idx(group_id, ".", H5_INDEX_NAME, H5_ITER_NATIVE, (hsize_t)u, tmpname,
                                    (size_t)NAME_BUF_SIZE, H5P_DEFAULT) < 0)
                 TEST_ERROR;
-            if (HDstrcmp(objname, tmpname) != 0)
+            if (strcmp(objname, tmpname) != 0)
                 TEST_ERROR;
 
             /* Make link name for decreasing order queries */
-            HDsnprintf(objname, sizeof(objname), "filler %02u", dec_u);
+            snprintf(objname, sizeof(objname), "filler %02u", dec_u);
 
             /* Make link value for decreasing order queries */
-            HDsnprintf(valname, sizeof(valname), "value %02u", dec_u);
+            snprintf(valname, sizeof(valname), "value %02u", dec_u);
 
             /* Verify link information (in decreasing order) */
             if (hard_link) {
@@ -5440,7 +5440,7 @@ link_info_by_idx_old_deprec(hid_t fapl)
                 if (H5Lget_val_by_idx(group_id, ".", H5_INDEX_NAME, H5_ITER_DEC, (hsize_t)u, tmpval,
                                       (size_t)NAME_BUF_SIZE, H5P_DEFAULT) < 0)
                     TEST_ERROR;
-                if (HDstrcmp(valname, tmpval) != 0)
+                if (strcmp(valname, tmpval) != 0)
                     TEST_ERROR;
             } /* end else */
 
@@ -5448,7 +5448,7 @@ link_info_by_idx_old_deprec(hid_t fapl)
             if (H5Lget_name_by_idx(group_id, ".", H5_INDEX_NAME, H5_ITER_DEC, (hsize_t)u, tmpname,
                                    (size_t)NAME_BUF_SIZE, H5P_DEFAULT) < 0)
                 TEST_ERROR;
-            if (HDstrcmp(objname, tmpname) != 0)
+            if (strcmp(objname, tmpname) != 0)
                 TEST_ERROR;
         } /* end for */
 
@@ -5618,7 +5618,7 @@ delete_by_idx_deprec(hid_t fapl)
                     hid_t group_id2; /* Group ID */
 
                     /* Make name for link */
-                    HDsnprintf(objname, sizeof(objname), "filler %02u", u);
+                    snprintf(objname, sizeof(objname), "filler %02u", u);
 
                     /* Create hard link, with group object */
                     if ((group_id2 = H5Gcreate2(group_id, objname, H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT)) <
@@ -5671,10 +5671,10 @@ delete_by_idx_deprec(hid_t fapl)
                                            (size_t)NAME_BUF_SIZE, H5P_DEFAULT) < 0)
                         TEST_ERROR;
                     if (order == H5_ITER_INC)
-                        HDsnprintf(objname, sizeof(objname), "filler %02u", (u + 1));
+                        snprintf(objname, sizeof(objname), "filler %02u", (u + 1));
                     else
-                        HDsnprintf(objname, sizeof(objname), "filler %02u", (max_compact - (u + 2)));
-                    if (HDstrcmp(objname, tmpname) != 0)
+                        snprintf(objname, sizeof(objname), "filler %02u", (max_compact - (u + 2)));
+                    if (strcmp(objname, tmpname) != 0)
                         TEST_ERROR;
                 } /* end for */
 
@@ -5691,7 +5691,7 @@ delete_by_idx_deprec(hid_t fapl)
                     hid_t group_id2; /* Group ID */
 
                     /* Make name for link */
-                    HDsnprintf(objname, sizeof(objname), "filler %02u", u);
+                    snprintf(objname, sizeof(objname), "filler %02u", u);
 
                     /* Create hard link, with group object */
                     if ((group_id2 = H5Gcreate2(group_id, objname, H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT)) <
@@ -5745,10 +5745,10 @@ delete_by_idx_deprec(hid_t fapl)
                                            (size_t)NAME_BUF_SIZE, H5P_DEFAULT) < 0)
                         TEST_ERROR;
                     if (order == H5_ITER_INC)
-                        HDsnprintf(objname, sizeof(objname), "filler %02u", (u + 1));
+                        snprintf(objname, sizeof(objname), "filler %02u", (u + 1));
                     else
-                        HDsnprintf(objname, sizeof(objname), "filler %02u", ((max_compact * 2) - (u + 2)));
-                    if (HDstrcmp(objname, tmpname) != 0)
+                        snprintf(objname, sizeof(objname), "filler %02u", ((max_compact * 2) - (u + 2)));
+                    if (strcmp(objname, tmpname) != 0)
                         TEST_ERROR;
                 } /* end for */
 
@@ -5778,7 +5778,7 @@ delete_by_idx_deprec(hid_t fapl)
                     hid_t group_id2; /* Group ID */
 
                     /* Make name for link */
-                    HDsnprintf(objname, sizeof(objname), "filler %02u", u);
+                    snprintf(objname, sizeof(objname), "filler %02u", u);
 
                     /* Create hard link, with group object */
                     if ((group_id2 = H5Gcreate2(group_id, objname, H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT)) <
@@ -5823,11 +5823,11 @@ delete_by_idx_deprec(hid_t fapl)
                                            (size_t)NAME_BUF_SIZE, H5P_DEFAULT) < 0)
                         TEST_ERROR;
                     if (order == H5_ITER_INC)
-                        HDsnprintf(objname, sizeof(objname), "filler %02u", ((u * 2) + 1));
+                        snprintf(objname, sizeof(objname), "filler %02u", ((u * 2) + 1));
                     else
-                        HDsnprintf(objname, sizeof(objname), "filler %02u",
-                                   ((max_compact * 2) - ((u * 2) + 2)));
-                    if (HDstrcmp(objname, tmpname) != 0)
+                        snprintf(objname, sizeof(objname), "filler %02u",
+                                 ((max_compact * 2) - ((u * 2) + 2)));
+                    if (strcmp(objname, tmpname) != 0)
                         TEST_ERROR;
                 } /* end for */
 
@@ -5857,11 +5857,11 @@ delete_by_idx_deprec(hid_t fapl)
                                            (size_t)NAME_BUF_SIZE, H5P_DEFAULT) < 0)
                         TEST_ERROR;
                     if (order == H5_ITER_INC)
-                        HDsnprintf(objname, sizeof(objname), "filler %02u", ((u * 2) + 3));
+                        snprintf(objname, sizeof(objname), "filler %02u", ((u * 2) + 3));
                     else
-                        HDsnprintf(objname, sizeof(objname), "filler %02u",
-                                   ((max_compact * 2) - ((u * 2) + 4)));
-                    if (HDstrcmp(objname, tmpname) != 0)
+                        snprintf(objname, sizeof(objname), "filler %02u",
+                                 ((max_compact * 2) - ((u * 2) + 4)));
+                    if (strcmp(objname, tmpname) != 0)
                         TEST_ERROR;
                 } /* end for */
 
@@ -5964,7 +5964,7 @@ delete_by_idx_old_deprec(hid_t fapl)
             H5O_info1_t oi; /* Buffer for querying object's info */
 
             /* Make name for link */
-            HDsnprintf(objname, sizeof(objname), "filler %02u", u);
+            snprintf(objname, sizeof(objname), "filler %02u", u);
 
             /* Create group */
             if ((group_id2 = H5Gcreate2(group_id, objname, H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT)) < 0)
@@ -6025,10 +6025,10 @@ delete_by_idx_old_deprec(hid_t fapl)
                                    (size_t)NAME_BUF_SIZE, H5P_DEFAULT) < 0)
                 TEST_ERROR;
             if (order == H5_ITER_INC)
-                HDsnprintf(objname, sizeof(objname), "filler %02u", (u + 1));
+                snprintf(objname, sizeof(objname), "filler %02u", (u + 1));
             else
-                HDsnprintf(objname, sizeof(objname), "filler %02u", dec_u);
-            if (HDstrcmp(objname, tmpname) != 0)
+                snprintf(objname, sizeof(objname), "filler %02u", dec_u);
+            if (strcmp(objname, tmpname) != 0)
                 TEST_ERROR;
         } /* end for */
 
@@ -6056,7 +6056,7 @@ delete_by_idx_old_deprec(hid_t fapl)
             H5O_info1_t oi; /* Buffer for querying object's info */
 
             /* Make name for link */
-            HDsnprintf(objname, sizeof(objname), "filler %02u", u);
+            snprintf(objname, sizeof(objname), "filler %02u", u);
 
             /* Create group */
             if ((group_id2 = H5Gcreate2(group_id, objname, H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT)) < 0)
@@ -6099,10 +6099,10 @@ delete_by_idx_old_deprec(hid_t fapl)
                                    (size_t)NAME_BUF_SIZE, H5P_DEFAULT) < 0)
                 TEST_ERROR;
             if (order == H5_ITER_INC)
-                HDsnprintf(objname, sizeof(objname), "filler %02u", ((u * 2) + 1));
+                snprintf(objname, sizeof(objname), "filler %02u", ((u * 2) + 1));
             else
-                HDsnprintf(objname, sizeof(objname), "filler %02u", dec_u);
-            if (HDstrcmp(objname, tmpname) != 0)
+                snprintf(objname, sizeof(objname), "filler %02u", dec_u);
+            if (strcmp(objname, tmpname) != 0)
                 TEST_ERROR;
         } /* end for */
 
@@ -6133,10 +6133,10 @@ delete_by_idx_old_deprec(hid_t fapl)
                                    (size_t)NAME_BUF_SIZE, H5P_DEFAULT) < 0)
                 TEST_ERROR;
             if (order == H5_ITER_INC)
-                HDsnprintf(objname, sizeof(objname), "filler %02u", ((u * 2) + 3));
+                snprintf(objname, sizeof(objname), "filler %02u", ((u * 2) + 3));
             else
-                HDsnprintf(objname, sizeof(objname), "filler %02u", dec_u);
-            if (HDstrcmp(objname, tmpname) != 0)
+                snprintf(objname, sizeof(objname), "filler %02u", dec_u);
+            if (strcmp(objname, tmpname) != 0)
                 TEST_ERROR;
         } /* end for */
 
@@ -6217,8 +6217,8 @@ link_iterate_deprec_cb(hid_t group_id, const char *link_name, const H5L_info1_t 
     } /* end if */
 
     /* Verify name of link */
-    HDsnprintf(objname, sizeof(objname), "filler %02u", (unsigned)my_info.corder);
-    if (HDstrcmp(link_name, objname) != 0)
+    snprintf(objname, sizeof(objname), "filler %02u", (unsigned)my_info.corder);
+    if (strcmp(link_name, objname) != 0)
         return H5_ITER_ERROR;
 
     /* Check if we've visited this link before */
@@ -6574,7 +6574,7 @@ link_iterate_deprec(hid_t fapl)
                     hid_t group_id2; /* Group ID */
 
                     /* Make name for link */
-                    HDsnprintf(objname, sizeof(objname), "filler %02u", u);
+                    snprintf(objname, sizeof(objname), "filler %02u", u);
 
                     /* Create hard link, with group object */
                     if ((group_id2 = H5Gcreate2(group_id, objname, H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT)) <
@@ -6607,7 +6607,7 @@ link_iterate_deprec(hid_t fapl)
                     hid_t group_id2; /* Group ID */
 
                     /* Make name for link */
-                    HDsnprintf(objname, sizeof(objname), "filler %02u", u);
+                    snprintf(objname, sizeof(objname), "filler %02u", u);
 
                     /* Create hard link, with group object */
                     if ((group_id2 = H5Gcreate2(group_id, objname, H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT)) <
@@ -6713,9 +6713,9 @@ link_iterate_old_deprec_cb(hid_t group_id, const char *link_name, const H5L_info
     } /* end if */
 
     /* Verify name of link */
-    HDsnprintf(objname, sizeof(objname), "filler %02u",
-               (info ? (unsigned)op_data->curr : (unsigned)((op_data->ncalled - 1) + op_data->nskipped)));
-    if (HDstrcmp(link_name, objname) != 0)
+    snprintf(objname, sizeof(objname), "filler %02u",
+             (info ? (unsigned)op_data->curr : (unsigned)((op_data->ncalled - 1) + op_data->nskipped)));
+    if (strcmp(link_name, objname) != 0)
         return H5_ITER_ERROR;
 
     /* Check if we've visited this link before */
@@ -7006,7 +7006,7 @@ link_iterate_old_deprec(hid_t fapl)
             hid_t group_id2; /* Group ID */
 
             /* Make name for link */
-            HDsnprintf(objname, sizeof(objname), "filler %02u", u);
+            snprintf(objname, sizeof(objname), "filler %02u", u);
 
             /* Create hard link, with group object */
             if ((group_id2 = H5Gcreate2(group_id, objname, H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT)) < 0)
@@ -7132,21 +7132,21 @@ external_link_root(hid_t fapl, bool new_format)
         goto error;
     if (H5L_TYPE_EXTERNAL != linfo.type) {
         H5_FAILED();
-        HDputs("    Unexpected object type - should have been an external link");
+        puts("    Unexpected object type - should have been an external link");
         goto error;
     }
     if (H5Lget_val(fid, "ext_link", objname, sizeof(objname), H5P_DEFAULT) < 0)
         TEST_ERROR;
     if (H5Lunpack_elink_val(objname, linfo.u.val_size, NULL, &file, &path) < 0)
         TEST_ERROR;
-    if (HDstrcmp(file, filename1) != 0) {
+    if (strcmp(file, filename1) != 0) {
         H5_FAILED();
-        HDputs("    External link file name incorrect");
+        puts("    External link file name incorrect");
         goto error;
     }
-    if (HDstrcmp(path, "/") != 0) {
+    if (strcmp(path, "/") != 0) {
         H5_FAILED();
-        HDputs("    External link path incorrect");
+        puts("    External link path incorrect");
         goto error;
     }
 
@@ -7160,21 +7160,21 @@ external_link_root(hid_t fapl, bool new_format)
         goto error;
     if (H5L_TYPE_EXTERNAL != linfo.type) {
         H5_FAILED();
-        HDputs("    Unexpected object type - should have been an external link");
+        puts("    Unexpected object type - should have been an external link");
         goto error;
     }
     if (H5Lget_val(fid, "ext_link", objname, sizeof(objname), H5P_DEFAULT) < 0)
         TEST_ERROR;
     if (H5Lunpack_elink_val(objname, linfo.u.val_size, NULL, &file, &path) < 0)
         TEST_ERROR;
-    if (HDstrcmp(file, filename1) != 0) {
+    if (strcmp(file, filename1) != 0) {
         H5_FAILED();
-        HDputs("    External link file name incorrect");
+        puts("    External link file name incorrect");
         goto error;
     }
-    if (HDstrcmp(path, "/") != 0) {
+    if (strcmp(path, "/") != 0) {
         H5_FAILED();
-        HDputs("    External link path incorrect");
+        puts("    External link path incorrect");
         goto error;
     }
 
@@ -7191,7 +7191,7 @@ external_link_root(hid_t fapl, bool new_format)
     /* Check name */
     if (H5Iget_name(gid, objname, (size_t)NAME_BUF_SIZE) < 0)
         TEST_ERROR;
-    if (HDstrcmp(objname, "/") != 0)
+    if (strcmp(objname, "/") != 0)
         TEST_ERROR;
 
     /* Create object in external file */
@@ -7236,11 +7236,11 @@ external_link_root(hid_t fapl, bool new_format)
     /* Check names */
     if (H5Iget_name(gid, objname, (size_t)NAME_BUF_SIZE) < 0)
         TEST_ERROR;
-    if (HDstrcmp(objname, "/new_group") != 0)
+    if (strcmp(objname, "/new_group") != 0)
         TEST_ERROR;
     if (H5Iget_name(gid2, objname, (size_t)NAME_BUF_SIZE) < 0)
         TEST_ERROR;
-    if (HDstrcmp(objname, "/newer_group") != 0)
+    if (strcmp(objname, "/newer_group") != 0)
         TEST_ERROR;
 
     /* Close opened objects */
@@ -7362,7 +7362,7 @@ external_link_path(hid_t fapl, bool new_format)
     /* Check name */
     if (H5Iget_name(gid, objname, (size_t)NAME_BUF_SIZE) < 0)
         TEST_ERROR;
-    if (HDstrcmp(objname, "/A/B/C") != 0)
+    if (strcmp(objname, "/A/B/C") != 0)
         TEST_ERROR;
 
     /* Create object in external file */
@@ -7392,7 +7392,7 @@ external_link_path(hid_t fapl, bool new_format)
     /* Check name */
     if (H5Iget_name(gid, objname, (size_t)NAME_BUF_SIZE) < 0)
         TEST_ERROR;
-    if (HDstrcmp(objname, "/A/B/C/new_group") != 0)
+    if (strcmp(objname, "/A/B/C/new_group") != 0)
         TEST_ERROR;
 
     /* Close opened object */
@@ -7534,7 +7534,7 @@ external_link_mult(hid_t fapl, bool new_format)
     /* Check name */
     if (H5Iget_name(gid, objname, (size_t)NAME_BUF_SIZE) < 0)
         TEST_ERROR;
-    if (HDstrcmp(objname, "/A/B/C") != 0)
+    if (strcmp(objname, "/A/B/C") != 0)
         TEST_ERROR;
 
     /* Create object in external file */
@@ -7564,7 +7564,7 @@ external_link_mult(hid_t fapl, bool new_format)
     /* Check name */
     if (H5Iget_name(gid, objname, (size_t)NAME_BUF_SIZE) < 0)
         TEST_ERROR;
-    if (HDstrcmp(objname, "/A/B/C/new_group") != 0)
+    if (strcmp(objname, "/A/B/C/new_group") != 0)
         TEST_ERROR;
 
     /* Close opened object */
@@ -7680,7 +7680,7 @@ external_link_self(hid_t fapl, bool new_format)
     /* Check name */
     if (H5Iget_name(gid, objname, (size_t)NAME_BUF_SIZE) < 0)
         TEST_ERROR;
-    if (HDstrcmp(objname, "/X") != 0)
+    if (strcmp(objname, "/X") != 0)
         TEST_ERROR;
 
     /* Create object through external link */
@@ -7702,7 +7702,7 @@ external_link_self(hid_t fapl, bool new_format)
     /* Check name */
     if (H5Iget_name(gid, objname, (size_t)NAME_BUF_SIZE) < 0)
         TEST_ERROR;
-    if (HDstrcmp(objname, "/X/new_group") != 0)
+    if (strcmp(objname, "/X/new_group") != 0)
         TEST_ERROR;
 
     /* Close opened object */
@@ -7882,7 +7882,7 @@ external_link_pingpong(hid_t fapl, bool new_format)
     /* Check name */
     if (H5Iget_name(gid, objname, (size_t)NAME_BUF_SIZE) < 0)
         TEST_ERROR;
-    if (HDstrcmp(objname, "/final") != 0)
+    if (strcmp(objname, "/final") != 0)
         TEST_ERROR;
 
     /* Create object in external file */
@@ -7912,7 +7912,7 @@ external_link_pingpong(hid_t fapl, bool new_format)
     /* Check name */
     if (H5Iget_name(gid, objname, (size_t)NAME_BUF_SIZE) < 0)
         TEST_ERROR;
-    if (HDstrcmp(objname, "/final/new_group") != 0)
+    if (strcmp(objname, "/final/new_group") != 0)
         TEST_ERROR;
 
     /* Close opened object */
@@ -8074,7 +8074,7 @@ external_link_toomany(hid_t fapl, bool new_format)
     /* Check name */
     if (H5Iget_name(gid, objname, (size_t)NAME_BUF_SIZE) < 0)
         TEST_ERROR;
-    if (HDstrcmp(objname, "/final") != 0)
+    if (strcmp(objname, "/final") != 0)
         TEST_ERROR;
 
     /* Create object in external file */
@@ -8173,7 +8173,7 @@ external_link_dangling(hid_t fapl, bool new_format)
     H5E_END_TRY
     if (gid >= 0) {
         H5_FAILED();
-        HDputs("    Should have failed for sequence of too many nested links.");
+        puts("    Should have failed for sequence of too many nested links.");
         goto error;
     }
 
@@ -8185,7 +8185,7 @@ external_link_dangling(hid_t fapl, bool new_format)
     H5E_END_TRY
     if (gid >= 0) {
         H5_FAILED();
-        HDputs("    Should have failed for sequence of too many nested links.");
+        puts("    Should have failed for sequence of too many nested links.");
         goto error;
     }
 
@@ -8197,7 +8197,7 @@ external_link_dangling(hid_t fapl, bool new_format)
     H5E_END_TRY
     if (status >= 0) {
         H5_FAILED();
-        HDputs(
+        puts(
             "    Retrieving name of object by index through dangling file external link should have failed.");
     } /* end if */
 
@@ -8298,7 +8298,7 @@ external_link_prefix(hid_t fapl, bool new_format)
     /* should be able to find the target file from pathnames set via H5Pset_elink_prefix() */
     if (gid < 0) {
         H5_FAILED();
-        HDputs("    Should have found the file in tmp_links directory.");
+        puts("    Should have found the file in tmp_links directory.");
         goto error;
     }
 
@@ -8395,7 +8395,7 @@ external_link_abs_mainpath(hid_t fapl, bool new_format)
     /* should be able to find the target file from absolute path set for main file */
     if (gid < 0) {
         H5_FAILED();
-        HDputs("    Should have found the file in tmp_links directory.");
+        puts("    Should have found the file in tmp_links directory.");
         goto error;
     }
 
@@ -8483,7 +8483,7 @@ external_link_rel_mainpath(hid_t fapl, bool new_format)
     /* should be able to find the target file from the main file's relative pathname */
     if (gid < 0) {
         H5_FAILED();
-        HDputs("    Should have found the file in current working directory");
+        puts("    Should have found the file in current working directory");
         goto error;
     }
 
@@ -8576,7 +8576,7 @@ external_link_cwd(hid_t fapl, bool new_format)
     /* should be able to find the target file from the current working directory */
     if (gid < 0) {
         H5_FAILED();
-        HDputs("    Should have found the file in current working directory");
+        puts("    Should have found the file in current working directory");
         goto error;
     }
 
@@ -8674,7 +8674,7 @@ external_link_abstar(hid_t fapl, bool new_format)
     /* should be able to find the target file with absolute path */
     if (gid < 0) {
         H5_FAILED();
-        HDputs("    Should have found the file in tmp_links directory.");
+        puts("    Should have found the file in tmp_links directory.");
         goto error;
     }
 
@@ -8772,7 +8772,7 @@ external_link_abstar_cur(hid_t fapl, bool new_format)
     /* should be able to find the target file from main file's current working directory */
     if (gid < 0) {
         H5_FAILED();
-        HDputs("    Should have found the file in current working directory.");
+        puts("    Should have found the file in current working directory.");
         goto error;
     }
 
@@ -8853,7 +8853,7 @@ external_link_reltar(hid_t fapl, bool new_format)
     /* Open object through external link */
     if ((gid = H5Gopen2(fid, "ext_link", H5P_DEFAULT)) < 0) {
         H5_FAILED();
-        HDputs("    Should have found the file in tmp_links directory.");
+        puts("    Should have found the file in tmp_links directory.");
         goto error;
     } /* end if */
 
@@ -8953,7 +8953,7 @@ external_link_chdir(hid_t fapl, bool new_format)
      */
     if (gid < 0) {
         H5_FAILED();
-        HDputs("    Should have found the file in tmp_links directory.");
+        puts("    Should have found the file in tmp_links directory.");
         goto error;
     }
 
@@ -9056,27 +9056,27 @@ external_set_elink_fapl1(hid_t fapl, bool new_format)
     memb_map[H5FD_MEM_GHEAP] = H5FD_MEM_GHEAP;
     memb_map[H5FD_MEM_LHEAP] = H5FD_MEM_LHEAP;
 
-    HDsnprintf(sv[H5FD_MEM_SUPER], sizeof(sv[H5FD_MEM_SUPER]), "%%s-%c.h5", 's');
+    snprintf(sv[H5FD_MEM_SUPER], sizeof(sv[H5FD_MEM_SUPER]), "%%s-%c.h5", 's');
     memb_name[H5FD_MEM_SUPER] = sv[H5FD_MEM_SUPER];
     memb_addr[H5FD_MEM_SUPER] = 0;
 
-    HDsnprintf(sv[H5FD_MEM_BTREE], sizeof(sv[H5FD_MEM_BTREE]), "%%s-%c.h5", 'b');
+    snprintf(sv[H5FD_MEM_BTREE], sizeof(sv[H5FD_MEM_BTREE]), "%%s-%c.h5", 'b');
     memb_name[H5FD_MEM_BTREE] = sv[H5FD_MEM_BTREE];
     memb_addr[H5FD_MEM_BTREE] = HADDR_MAX / 6;
 
-    HDsnprintf(sv[H5FD_MEM_DRAW], sizeof(sv[H5FD_MEM_DRAW]), "%%s-%c.h5", 'r');
+    snprintf(sv[H5FD_MEM_DRAW], sizeof(sv[H5FD_MEM_DRAW]), "%%s-%c.h5", 'r');
     memb_name[H5FD_MEM_DRAW] = sv[H5FD_MEM_DRAW];
     memb_addr[H5FD_MEM_DRAW] = HADDR_MAX / 3;
 
-    HDsnprintf(sv[H5FD_MEM_GHEAP], sizeof(sv[H5FD_MEM_GHEAP]), "%%s-%c.h5", 'g');
+    snprintf(sv[H5FD_MEM_GHEAP], sizeof(sv[H5FD_MEM_GHEAP]), "%%s-%c.h5", 'g');
     memb_name[H5FD_MEM_GHEAP] = sv[H5FD_MEM_GHEAP];
     memb_addr[H5FD_MEM_GHEAP] = HADDR_MAX / 2;
 
-    HDsnprintf(sv[H5FD_MEM_LHEAP], sizeof(sv[H5FD_MEM_LHEAP]), "%%s-%c.h5", 'l');
+    snprintf(sv[H5FD_MEM_LHEAP], sizeof(sv[H5FD_MEM_LHEAP]), "%%s-%c.h5", 'l');
     memb_name[H5FD_MEM_LHEAP] = sv[H5FD_MEM_LHEAP];
     memb_addr[H5FD_MEM_LHEAP] = (HADDR_MAX / 3) * 2;
 
-    HDsnprintf(sv[H5FD_MEM_OHDR], sizeof(sv[H5FD_MEM_OHDR]), "%%s-%c.h5", 'o');
+    snprintf(sv[H5FD_MEM_OHDR], sizeof(sv[H5FD_MEM_OHDR]), "%%s-%c.h5", 'o');
     memb_name[H5FD_MEM_OHDR] = sv[H5FD_MEM_OHDR];
     memb_addr[H5FD_MEM_OHDR] = (HADDR_MAX / 6) * 5;
 
@@ -9134,7 +9134,7 @@ external_set_elink_fapl1(hid_t fapl, bool new_format)
     /* should succeed in opening the target object A in the current working directory */
     if (oidA < 0) {
         H5_FAILED();
-        HDputs("    Should succeed in opening family target file A in current working directory");
+        puts("    Should succeed in opening family target file A in current working directory");
         goto error;
     }
 
@@ -9150,7 +9150,7 @@ external_set_elink_fapl1(hid_t fapl, bool new_format)
     /* should succeed in opening the target object B in the current working directory */
     if (oidB < 0) {
         H5_FAILED();
-        HDputs("    Should succeed in opening multi target file B in current working directory");
+        puts("    Should succeed in opening multi target file B in current working directory");
         goto error;
     }
 
@@ -9341,7 +9341,7 @@ external_set_elink_fapl2(hid_t fapl, bool new_format)
     did = H5Dopen2(fid, "ext_link", dapl_id);
     if (did < 0) {
         H5_FAILED();
-        HDputs("    Should succeed in opening the target dataset");
+        puts("    Should succeed in opening the target dataset");
         goto error;
     }
 
@@ -9846,13 +9846,13 @@ external_set_elink_cb_cb(const char *parent_file, const char *parent_group, cons
     set_elink_cb_t *op_data = (set_elink_cb_t *)_op_data;
 
     /* Verify file and object names are correct */
-    if (HDstrcmp(parent_file, op_data->parent_file) != 0)
+    if (strcmp(parent_file, op_data->parent_file) != 0)
         return FAIL;
-    if (HDstrcmp(parent_group, "/group1") != 0)
+    if (strcmp(parent_group, "/group1") != 0)
         return FAIL;
-    if (HDstrcmp(target_file, op_data->target_file) != 0)
+    if (strcmp(target_file, op_data->target_file) != 0)
         return FAIL;
-    if (HDstrcmp(target_obj, "/") != 0)
+    if (strcmp(target_obj, "/") != 0)
         return FAIL;
 
     /* Set flags to be read-write */
@@ -10124,9 +10124,9 @@ external_link_win1(hid_t fapl, bool new_format)
         TEST_ERROR;
 
     /* set up name for target link: "/CWD/tmp_links/extlinks10" */
-    HDstrcpy(tmpname, &cwdpath[2]); /* stripped the drive letter to make it rel drive but absolute path */
-    HDstrcat(tmpname, "/");
-    HDstrcat(tmpname, FILENAME[30]);
+    strcpy(tmpname, &cwdpath[2]); /* stripped the drive letter to make it rel drive but absolute path */
+    strcat(tmpname, "/");
+    strcat(tmpname, FILENAME[30]);
     h5_fixname(tmpname, fapl, filename2, sizeof filename2);
 
     /* set up name for target file: "extlinks10" */
@@ -10162,7 +10162,7 @@ external_link_win1(hid_t fapl, bool new_format)
     /* should be able to find the target file via main file's CWD*/
     if (gid < 0) {
         H5_FAILED();
-        HDputs("    Should have found the file in CWD.");
+        puts("    Should have found the file in CWD.");
         goto error;
     }
 
@@ -10220,10 +10220,9 @@ external_link_win2(hid_t fapl, bool new_format)
         TEST_ERROR;
 
     /* set up name for target link: "/CWD/tmp_links/extlinks11" */
-    HDstrcpy(tmpname,
-             &cwdpath[2]); /* stripped the drive letter to make it relative drive but absolute path */
-    HDstrcat(tmpname, "/");
-    HDstrcat(tmpname, FILENAME[31]);
+    strcpy(tmpname, &cwdpath[2]); /* stripped the drive letter to make it relative drive but absolute path */
+    strcat(tmpname, "/");
+    strcat(tmpname, FILENAME[31]);
     h5_fixname(tmpname, fapl, filename2, sizeof filename2);
 
     /* set up name for target file: "tmp_links/extlinks11" */
@@ -10259,7 +10258,7 @@ external_link_win2(hid_t fapl, bool new_format)
     /* should be able to find the target file directly */
     if (gid < 0) {
         H5_FAILED();
-        HDputs("    Should have found the file in tmp_links.");
+        puts("    Should have found the file in tmp_links.");
         goto error;
     }
 
@@ -10317,7 +10316,7 @@ external_link_win3(hid_t fapl, bool new_format)
 
     /* set up name for target link: "<drive-letter>:tmp_links/extlinks12" */
     drive = HDgetdrive();
-    HDsnprintf(tmpname, sizeof(tmpname), "%c:%s", (drive + 'A' - 1), FILENAME[32]);
+    snprintf(tmpname, sizeof(tmpname), "%c:%s", (drive + 'A' - 1), FILENAME[32]);
     h5_fixname(tmpname, fapl, filename2, sizeof filename2);
 
     /* set up name for target file: "tmp_links/extlinks12" */
@@ -10353,7 +10352,7 @@ external_link_win3(hid_t fapl, bool new_format)
     /* should be able to find the target file directly */
     if (gid < 0) {
         H5_FAILED();
-        HDputs("    Should have found the file in tmp_links.");
+        puts("    Should have found the file in tmp_links.");
         goto error;
     }
 
@@ -10404,11 +10403,11 @@ external_link_win4(hid_t fapl, bool new_format)
 
     /* set up name for main file: "<drive-letter>:tmp_links/extlinks0" */
     drive = HDgetdrive();
-    HDsnprintf(tmpname, sizeof(tmpname), "%c:%s", (drive + 'A' - 1), FILENAME[13]);
+    snprintf(tmpname, sizeof(tmpname), "%c:%s", (drive + 'A' - 1), FILENAME[13]);
     h5_fixname(tmpname, fapl, filename1, sizeof filename1);
 
     /* set up name for target link: "<drive-letter>:extlinks13" */
-    HDsnprintf(tmpname, sizeof(tmpname), "%c:%s", (drive + 'A' - 1), FILENAME[33]);
+    snprintf(tmpname, sizeof(tmpname), "%c:%s", (drive + 'A' - 1), FILENAME[33]);
     h5_fixname(tmpname, fapl, filename2, sizeof filename2);
 
     /* set up name for target file: "tmp_links/extlinks13" */
@@ -10444,7 +10443,7 @@ external_link_win4(hid_t fapl, bool new_format)
     /* should be able to find the target file via main file's absolute drive/relative path */
     if (gid < 0) {
         H5_FAILED();
-        HDputs("    Should have found the file in CWD.");
+        puts("    Should have found the file in CWD.");
         goto error;
     }
 
@@ -10503,13 +10502,13 @@ external_link_win5(hid_t fapl, bool new_format)
         drive += 1;
 
     /* set up name for main file: "/CWD/extlinks0" */
-    HDstrcpy(tmpname, &cwdpath[2]); /* stripped the drive letter to make it rel drive but absolute path */
-    HDstrcat(tmpname, "/");
-    HDstrcat(tmpname, FILENAME[12]);
+    strcpy(tmpname, &cwdpath[2]); /* stripped the drive letter to make it rel drive but absolute path */
+    strcat(tmpname, "/");
+    strcat(tmpname, FILENAME[12]);
     h5_fixname(tmpname, fapl, filename1, sizeof filename1);
 
     /* set up name for target link: "<drive-letter+1>:tmp_links/extlinks14" */
-    HDsnprintf(tmpname, sizeof(tmpname), "%c:%s", (drive + 'A' - 1), FILENAME[35]);
+    snprintf(tmpname, sizeof(tmpname), "%c:%s", (drive + 'A' - 1), FILENAME[35]);
     h5_fixname(tmpname, fapl, filename2, sizeof filename2);
 
     /* set up name for target file: "tmp_links/extlinks14" */
@@ -10545,7 +10544,7 @@ external_link_win5(hid_t fapl, bool new_format)
     /* should be able to find the target file via main file's rel drive/abs path */
     if (gid < 0) {
         H5_FAILED();
-        HDputs("    Should have found the file in CWD.");
+        puts("    Should have found the file in CWD.");
         goto error;
     }
 
@@ -10607,7 +10606,7 @@ external_link_win6(hid_t fapl, bool new_format)
     h5_fixname(FILENAME[12], fapl, filename1, sizeof filename1);
 
     /* set up name for target link: "<drive-letter+1>:tmp_links/extlinks15" */
-    HDsnprintf(tmpname, sizeof(tmpname), "%c:%s", (drive + 'A' - 1), FILENAME[36]);
+    snprintf(tmpname, sizeof(tmpname), "%c:%s", (drive + 'A' - 1), FILENAME[36]);
     h5_fixname(tmpname, fapl, filename2, sizeof filename2);
 
     /* set up name for target file: "tmp/extlinks15" */
@@ -10643,7 +10642,7 @@ external_link_win6(hid_t fapl, bool new_format)
     /* should be able to find the target file via target file's rel path in current drive */
     if (gid < 0) {
         H5_FAILED();
-        HDputs("    Should have found the file in tmp_links.");
+        puts("    Should have found the file in tmp_links.");
         goto error;
     }
 
@@ -10700,9 +10699,9 @@ external_link_win7(hid_t fapl, bool new_format)
         TEST_ERROR;
 
     /* set up name for target link: "\\127.0.0.1\c$/tmp_links/extlinks10" */
-    HDstrcpy(tmpname, "\\\\127.0.0.1\\c$"); /* absolute path */
-    HDstrcat(tmpname, "/");
-    HDstrcat(tmpname, FILENAME[30]);
+    strcpy(tmpname, "\\\\127.0.0.1\\c$"); /* absolute path */
+    strcat(tmpname, "/");
+    strcat(tmpname, FILENAME[30]);
     h5_fixname(tmpname, fapl, filename2, sizeof filename2);
 
     /* set up name for target file: "extlinks15" */
@@ -10738,7 +10737,7 @@ external_link_win7(hid_t fapl, bool new_format)
     /* should be able to find the target file via main file's local host/main drive*/
     if (gid < 0) {
         H5_FAILED();
-        HDputs("    Should have found the file in local host/main drive.");
+        puts("    Should have found the file in local host/main drive.");
         goto error;
     }
 
@@ -10802,7 +10801,7 @@ external_link_win8(hid_t fapl, bool new_format)
 
     /* set up name for target link: "<drive-letter>:\CWD\extlinks10" */
     drive = HDgetdrive();
-    HDsnprintf(tmpname, sizeof(tmpname), "\\\\?\\%c:%s\\%s", (drive + 'A' - 1), &cwdpath[2], FILENAME[30]);
+    snprintf(tmpname, sizeof(tmpname), "\\\\?\\%c:%s\\%s", (drive + 'A' - 1), &cwdpath[2], FILENAME[30]);
     h5_fixname(tmpname, fapl, filename2, sizeof filename2);
 
     /* set up name for target file: "extlinks10" */
@@ -10838,7 +10837,7 @@ external_link_win8(hid_t fapl, bool new_format)
     /* should be able to find the target file directly */
     if (gid < 0) {
         H5_FAILED();
-        HDputs("    Should have found the file in tmp_links.");
+        puts("    Should have found the file in tmp_links.");
         goto error;
     }
 
@@ -10895,9 +10894,9 @@ external_link_win9(hid_t fapl, bool new_format)
         TEST_ERROR;
 
     /* set up name for target link: "\\?\UNC\127.0.0.1\c$/tmp_links/extlinks10" */
-    HDstrcpy(tmpname, "\\\\?\\UNC\127.0.0.1\\c$"); /* absolute path */
-    HDstrcat(tmpname, "/");
-    HDstrcat(tmpname, FILENAME[30]);
+    strcpy(tmpname, "\\\\?\\UNC\127.0.0.1\\c$"); /* absolute path */
+    strcat(tmpname, "/");
+    strcat(tmpname, FILENAME[30]);
     h5_fixname(tmpname, fapl, filename2, sizeof filename2);
 
     /* set up name for target file: "extlinks15" */
@@ -10933,7 +10932,7 @@ external_link_win9(hid_t fapl, bool new_format)
     /* should be able to find the target file via main file's local host/main drive*/
     if (gid < 0) {
         H5_FAILED();
-        HDputs("    Should have found the file in local host/main drive.");
+        puts("    Should have found the file in local host/main drive.");
         goto error;
     }
 
@@ -11006,7 +11005,7 @@ external_link_recursive(hid_t fapl, bool new_format)
     H5E_END_TRY
     if (gid >= 0) {
         H5_FAILED();
-        HDputs("    Should have failed for recursive external links.");
+        puts("    Should have failed for recursive external links.");
         goto error;
     }
 
@@ -11070,11 +11069,11 @@ external_link_query(hid_t fapl, bool new_format)
     /* Get size of buffer for external link */
     if (H5Lget_info2(fid, "src", &li, H5P_DEFAULT) < 0)
         TEST_ERROR;
-    if (li.u.val_size != (1 + (HDstrlen(filename2) + 1) + (HDstrlen("/dst") + 1)))
+    if (li.u.val_size != (1 + (strlen(filename2) + 1) + (strlen("/dst") + 1)))
         TEST_ERROR;
     if (H5L_TYPE_EXTERNAL != li.type) {
         H5_FAILED();
-        HDputs("    Unexpected link class - should have been an external link");
+        puts("    Unexpected link class - should have been an external link");
         goto error;
     }
 
@@ -11103,11 +11102,11 @@ external_link_query(hid_t fapl, bool new_format)
     /* Get size of buffer for external link */
     if (H5Lget_info2(fid, "src", &li, H5P_DEFAULT) < 0)
         TEST_ERROR;
-    if (li.u.val_size != (1 + (HDstrlen(filename2) + 1) + (HDstrlen("/dst") + 1)))
+    if (li.u.val_size != (1 + (strlen(filename2) + 1) + (strlen("/dst") + 1)))
         TEST_ERROR;
     if (H5L_TYPE_EXTERNAL != li.type) {
         H5_FAILED();
-        HDputs("    Unexpected link class - should have been an external link");
+        puts("    Unexpected link class - should have been an external link");
         goto error;
     }
 
@@ -11120,9 +11119,9 @@ external_link_query(hid_t fapl, bool new_format)
         TEST_ERROR;
 
     /* Compare the file and object names */
-    if (HDstrcmp(file_name, filename2) != 0)
+    if (strcmp(file_name, filename2) != 0)
         TEST_ERROR;
-    if (HDstrcmp(object_name, "/dst") != 0)
+    if (strcmp(object_name, "/dst") != 0)
         TEST_ERROR;
 
     /* Query information about object that external link points to */
@@ -11130,7 +11129,7 @@ external_link_query(hid_t fapl, bool new_format)
         FAIL_STACK_ERROR;
     if (H5O_TYPE_GROUP != oi.type) {
         H5_FAILED();
-        HDputs("    Unexpected object type - should have been a group");
+        puts("    Unexpected object type - should have been a group");
         goto error;
     }
 
@@ -11341,7 +11340,7 @@ external_link_unlink_dense(hid_t fapl, bool new_format)
 
     /* Create enough objects in the root group to change it into a "dense" group */
     for (u = 0; u < max_compact; u++) {
-        HDsnprintf(objname, sizeof(objname), "filler %u", u);
+        snprintf(objname, sizeof(objname), "filler %u", u);
         if ((gid2 = H5Gcreate2(gid, objname, H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT)) < 0)
             TEST_ERROR;
         if (H5Gclose(gid2) < 0)
@@ -11396,7 +11395,7 @@ external_link_unlink_dense(hid_t fapl, bool new_format)
 
     /* Remove enough objects in the root group to change it into a "compact" group */
     for (u = 0; u < ((max_compact - min_dense) + 1); u++) {
-        HDsnprintf(objname, sizeof(objname), "filler %u", u);
+        snprintf(objname, sizeof(objname), "filler %u", u);
         if (H5Ldelete(gid, objname, H5P_DEFAULT) < 0)
             FAIL_STACK_ERROR;
     } /* end for */
@@ -11519,7 +11518,7 @@ external_link_move(hid_t fapl, bool new_format)
     /* Check name */
     if (H5Iget_name(gid, objname, (size_t)NAME_BUF_SIZE) < 0)
         FAIL_STACK_ERROR;
-    if (HDstrcmp(objname, "/dst") != 0)
+    if (strcmp(objname, "/dst") != 0)
         TEST_ERROR;
 
     /* Create object in external file */
@@ -11579,7 +11578,7 @@ external_link_move(hid_t fapl, bool new_format)
     /* Check name */
     if (H5Iget_name(gid, objname, (size_t)NAME_BUF_SIZE) < 0)
         FAIL_STACK_ERROR;
-    if (HDstrcmp(objname, "/dst") != 0)
+    if (strcmp(objname, "/dst") != 0)
         TEST_ERROR;
 
     /* Create object in external file */
@@ -11626,7 +11625,7 @@ external_link_move(hid_t fapl, bool new_format)
     /* Check name */
     if (H5Iget_name(gid, objname, (size_t)NAME_BUF_SIZE) < 0)
         FAIL_STACK_ERROR;
-    if (HDstrcmp(objname, "/dst") != 0)
+    if (strcmp(objname, "/dst") != 0)
         TEST_ERROR;
 
     /* Move external link back to original location */
@@ -11636,7 +11635,7 @@ external_link_move(hid_t fapl, bool new_format)
     /* Check name */
     if (H5Iget_name(gid, objname, (size_t)NAME_BUF_SIZE) < 0)
         FAIL_STACK_ERROR;
-    if (HDstrcmp(objname, "/dst") != 0)
+    if (strcmp(objname, "/dst") != 0)
         TEST_ERROR;
 
     /* Create object in external file */
@@ -11737,7 +11736,7 @@ external_link_ride(hid_t fapl, bool new_format)
 
     /* Create enough objects in the root group to change it into a "dense" group */
     for (u = 0; u < (max_compact + 1); u++) {
-        HDsnprintf(objname, sizeof(objname), "filler %u", u);
+        snprintf(objname, sizeof(objname), "filler %u", u);
         if ((gid2 = H5Gcreate2(gid, objname, H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT)) < 0)
             TEST_ERROR;
         if (H5Gclose(gid2) < 0)
@@ -11810,7 +11809,7 @@ external_link_ride(hid_t fapl, bool new_format)
     /* Check name */
     if (H5Iget_name(gid, objname, (size_t)NAME_BUF_SIZE) < 0)
         TEST_ERROR;
-    if (HDstrcmp(objname, "/dst") != 0)
+    if (strcmp(objname, "/dst") != 0)
         TEST_ERROR;
 
     /* Create object in external file */
@@ -11831,7 +11830,7 @@ external_link_ride(hid_t fapl, bool new_format)
 
     /* Remove enough objects in the root group to change it into a "compact" group */
     for (u = 0; u < ((max_compact - min_dense) + 3); u++) {
-        HDsnprintf(objname, sizeof(objname), "filler %u", u);
+        snprintf(objname, sizeof(objname), "filler %u", u);
         if (H5Ldelete(gid, objname, H5P_DEFAULT) < 0)
             FAIL_STACK_ERROR;
     } /* end for */
@@ -11859,7 +11858,7 @@ external_link_ride(hid_t fapl, bool new_format)
     /* Check name */
     if (H5Iget_name(gid, objname, (size_t)NAME_BUF_SIZE) < 0)
         TEST_ERROR;
-    if (HDstrcmp(objname, "/dst") != 0)
+    if (strcmp(objname, "/dst") != 0)
         TEST_ERROR;
 
     /* Create object in external file */
@@ -12054,7 +12053,7 @@ external_link_closing(hid_t fapl, bool new_format)
         FAIL_STACK_ERROR;
     if (H5Oget_comment_by_name(fid1, "elink/elink/elink/group1_moved", buf, sizeof(buf), H5P_DEFAULT) < 0)
         FAIL_STACK_ERROR;
-    if (HDstrcmp(buf, "comment") != 0)
+    if (strcmp(buf, "comment") != 0)
         TEST_ERROR;
 
     /* Test H5*open */
@@ -12397,7 +12396,7 @@ external_link_strong(hid_t fapl, bool new_format)
         FAIL_STACK_ERROR;
     if (H5Iget_name(gid2, objname, (size_t)NAME_BUF_SIZE) < 0)
         TEST_ERROR;
-    if (HDstrcmp(objname, "/A/B/C") != 0)
+    if (strcmp(objname, "/A/B/C") != 0)
         TEST_ERROR;
     if (H5Gclose(gid2) < 0)
         TEST_ERROR;
@@ -12471,11 +12470,11 @@ external_symlink(const char *env_h5_drvr, hid_t fapl, bool new_format)
     /* Skip test when using VFDs that can't provide a POSIX compatible file
      *  descriptor.
      */
-    have_posix_compat_vfd = (bool)(!HDstrcmp(env_h5_drvr, "sec2") || !HDstrcmp(env_h5_drvr, "core") ||
-                                   !HDstrcmp(env_h5_drvr, "nomatch"));
+    have_posix_compat_vfd = (bool)(!strcmp(env_h5_drvr, "sec2") || !strcmp(env_h5_drvr, "core") ||
+                                   !strcmp(env_h5_drvr, "nomatch"));
     if (!have_posix_compat_vfd) {
         SKIPPED();
-        HDputs("    Current VFD doesn't support POSIX I/O calls");
+        puts("    Current VFD doesn't support POSIX I/O calls");
         return SUCCEED;
     }
 
@@ -12716,7 +12715,7 @@ error:
 
 #else  /* H5_HAVE_SYMLINK */
     SKIPPED();
-    HDputs("    Current file system or operating system doesn't support symbolic links");
+    puts("    Current file system or operating system doesn't support symbolic links");
 
     return SUCCEED;
 #endif /* H5_HAVE_SYMLINK */
@@ -13770,7 +13769,7 @@ external_link_public_macros(hid_t fapl, bool new_format)
 
     if (H5L_TYPE_EXTERNAL != linfo.type) {
         H5_FAILED();
-        HDputs("    Unexpected object type - should have been an external link");
+        puts("    Unexpected object type - should have been an external link");
         goto error;
     }
 
@@ -13780,22 +13779,22 @@ external_link_public_macros(hid_t fapl, bool new_format)
     if (H5Lunpack_elink_val(objname, linfo.u.val_size, &flags, &file, &path) < 0)
         TEST_ERROR;
 
-    if (HDstrcmp(file, filename1) != 0) {
+    if (strcmp(file, filename1) != 0) {
         H5_FAILED();
-        HDputs("    External link file name incorrect");
+        puts("    External link file name incorrect");
         goto error;
     }
 
-    if (HDstrcmp(path, "/") != 0) {
+    if (strcmp(path, "/") != 0) {
         H5_FAILED();
-        HDputs("    External link path incorrect");
+        puts("    External link path incorrect");
         goto error;
     }
 
     /* External link version & flags */
     if (flags != ((H5L_EXT_VERSION << 4) | H5L_EXT_FLAGS_ALL)) {
         H5_FAILED();
-        HDputs("    External link version or flags are incorrect");
+        puts("    External link version or flags are incorrect");
         goto error;
     }
 
@@ -14070,7 +14069,7 @@ ud_hard_links(hid_t fapl)
     /* Check name */
     if (H5Iget_name(gid, objname, (size_t)NAME_BUF_SIZE) < 0)
         TEST_ERROR;
-    if (HDstrcmp(objname, "/group") != 0)
+    if (strcmp(objname, "/group") != 0)
         TEST_ERROR;
 
     /* Create object in group */
@@ -14090,7 +14089,7 @@ ud_hard_links(hid_t fapl)
     /* Check name */
     if (H5Iget_name(gid, objname, (size_t)NAME_BUF_SIZE) < 0)
         TEST_ERROR;
-    if (HDstrcmp(objname, "/group/new_group") != 0)
+    if (strcmp(objname, "/group/new_group") != 0)
         TEST_ERROR;
 
     /* Close opened object */
@@ -14105,7 +14104,7 @@ ud_hard_links(hid_t fapl)
         TEST_ERROR;
     if (UD_HARD_TYPE != li.type) {
         H5_FAILED();
-        HDputs("    Unexpected link class - should have been a UD hard link");
+        puts("    Unexpected link class - should have been a UD hard link");
         goto error;
     } /* end if */
 
@@ -14281,7 +14280,7 @@ ud_link_reregister(hid_t fapl)
     /* Check name */
     if (H5Iget_name(gid, objname, (size_t)NAME_BUF_SIZE) < 0)
         TEST_ERROR;
-    if (HDstrcmp(objname, "/" REREG_TARGET_NAME) != 0)
+    if (strcmp(objname, "/" REREG_TARGET_NAME) != 0)
         TEST_ERROR;
 
     /* Create object in group */
@@ -14301,7 +14300,7 @@ ud_link_reregister(hid_t fapl)
     /* Check name */
     if (H5Iget_name(gid, objname, (size_t)NAME_BUF_SIZE) < 0)
         TEST_ERROR;
-    if (HDstrcmp(objname, "/rereg_target/new_group") != 0)
+    if (strcmp(objname, "/rereg_target/new_group") != 0)
         TEST_ERROR;
 
     /* Close opened object */
@@ -14390,9 +14389,9 @@ UD_cb_create(const char *link_name, hid_t loc_group, const void *udata, size_t u
     if (lcpl_id < 0)
         TEST_ERROR;
 
-    if (HDstrcmp(link_name, UD_CB_LINK_NAME) != 0 && HDstrcmp(link_name, NEW_UD_CB_LINK_NAME) != 0)
+    if (strcmp(link_name, UD_CB_LINK_NAME) != 0 && strcmp(link_name, NEW_UD_CB_LINK_NAME) != 0)
         TEST_ERROR;
-    if (HDstrcmp((const char *)udata, UD_CB_TARGET) != 0)
+    if (strcmp((const char *)udata, UD_CB_TARGET) != 0)
         TEST_ERROR;
     if (udata_size != UD_CB_TARGET_LEN)
         TEST_ERROR;
@@ -14417,9 +14416,9 @@ UD_cb_traverse(const char *link_name, hid_t cur_group, const void *udata, size_t
     if (udata_size > 0 && !udata)
         TEST_ERROR;
 
-    if (HDstrcmp(link_name, UD_CB_LINK_NAME) != 0 && HDstrcmp(link_name, NEW_UD_CB_LINK_NAME) != 0)
+    if (strcmp(link_name, UD_CB_LINK_NAME) != 0 && strcmp(link_name, NEW_UD_CB_LINK_NAME) != 0)
         TEST_ERROR;
-    if (HDstrcmp((const char *)udata, UD_CB_TARGET) != 0)
+    if (strcmp((const char *)udata, UD_CB_TARGET) != 0)
         TEST_ERROR;
     if (udata_size != UD_CB_TARGET_LEN)
         TEST_ERROR;
@@ -14444,9 +14443,9 @@ UD_cb_move(const char *new_name, hid_t new_loc, const void *udata, size_t udata_
     if (udata_size > 0 && !udata)
         TEST_ERROR;
 
-    if (HDstrcmp(new_name, NEW_UD_CB_LINK_NAME) != 0)
+    if (strcmp(new_name, NEW_UD_CB_LINK_NAME) != 0)
         TEST_ERROR;
-    if (HDstrcmp((const char *)udata, UD_CB_TARGET) != 0)
+    if (strcmp((const char *)udata, UD_CB_TARGET) != 0)
         TEST_ERROR;
     if (udata_size != UD_CB_TARGET_LEN)
         TEST_ERROR;
@@ -14468,9 +14467,9 @@ UD_cb_delete(const char *link_name, hid_t file, const void *udata, size_t udata_
     if (udata_size > 0 && !udata)
         TEST_ERROR;
 
-    if (HDstrcmp(link_name, UD_CB_LINK_NAME) != 0 && HDstrcmp(link_name, NEW_UD_CB_LINK_NAME) != 0)
+    if (strcmp(link_name, UD_CB_LINK_NAME) != 0 && strcmp(link_name, NEW_UD_CB_LINK_NAME) != 0)
         TEST_ERROR;
-    if (HDstrcmp((const char *)udata, UD_CB_TARGET) != 0)
+    if (strcmp((const char *)udata, UD_CB_TARGET) != 0)
         TEST_ERROR;
     if (udata_size != UD_CB_TARGET_LEN)
         TEST_ERROR;
@@ -14490,9 +14489,9 @@ UD_cb_query(const char *link_name, const void *udata, size_t udata_size, void *b
     if (udata_size > 0 && !udata)
         TEST_ERROR;
 
-    if (HDstrcmp(link_name, UD_CB_LINK_NAME) != 0)
+    if (strcmp(link_name, UD_CB_LINK_NAME) != 0)
         TEST_ERROR;
-    if (HDstrcmp((const char *)udata, UD_CB_TARGET) != 0)
+    if (strcmp((const char *)udata, UD_CB_TARGET) != 0)
         TEST_ERROR;
     if (udata_size != UD_CB_TARGET_LEN)
         TEST_ERROR;
@@ -14500,7 +14499,7 @@ UD_cb_query(const char *link_name, const void *udata, size_t udata_size, void *b
     if (buf) {
         if (buf_size < 16)
             TEST_ERROR;
-        HDstrcpy((char *)buf, "query succeeded");
+        strcpy((char *)buf, "query succeeded");
     } /* end if */
 
     /* There are 15 characters and a NULL in "query succeeded" */
@@ -14582,14 +14581,14 @@ ud_callbacks(hid_t fapl, bool new_format)
         TEST_ERROR;
     if (UD_CB_TYPE != li.type) {
         H5_FAILED();
-        HDputs("    Unexpected link class - should have been a UD hard link");
+        puts("    Unexpected link class - should have been a UD hard link");
         goto error;
     }
 
     /* Fill the query buffer */
     if (H5Lget_val(fid, UD_CB_LINK_NAME, query_buf, (size_t)NAME_BUF_SIZE, H5P_DEFAULT) < 0)
         FAIL_STACK_ERROR;
-    if (HDstrcmp(query_buf, "query succeeded") != 0)
+    if (strcmp(query_buf, "query succeeded") != 0)
         TEST_ERROR;
 
     /* Move the link */
@@ -14767,7 +14766,7 @@ lapl_udata(hid_t fapl, bool new_format)
     /* Create a non-default lapl with a new property pointing to group a*/
     if ((plist_id = H5Pcreate(H5P_LINK_ACCESS)) < 0)
         TEST_ERROR;
-    HDstrcpy(group_a_name, "group_a");
+    strcpy(group_a_name, "group_a");
     if (H5Pinsert2(plist_id, DEST_PROP_NAME, (size_t)NAME_BUF_SIZE, group_a_name, NULL, NULL, NULL, NULL,
                    NULL, NULL) < 0)
         TEST_ERROR;
@@ -14789,7 +14788,7 @@ lapl_udata(hid_t fapl, bool new_format)
         TEST_ERROR;
 
     /* Now use the same ud link to access group_b */
-    HDstrcpy(group_b_name, "group_b");
+    strcpy(group_b_name, "group_b");
     if (H5Pset(plist_id, DEST_PROP_NAME, group_b_name) < 0)
         TEST_ERROR;
 
@@ -14945,7 +14944,7 @@ UD_cbsucc_query(const char H5_ATTR_UNUSED *link_name, const void H5_ATTR_UNUSED 
      */
 
     if (buf != NULL && buf_size >= 8)
-        HDstrcpy((char *)buf, "succeed");
+        strcpy((char *)buf, "succeed");
 
     return 8;
 } /* end UD_cbsucc_query() */
@@ -15103,8 +15102,8 @@ ud_link_errors(hid_t fapl, bool new_format)
     H5E_END_TRY
 
     /* Create a user-defined link to the group. */
-    HDstrcpy(group_name, "/group");
-    if (H5Lcreate_ud(fid, "/ud_link", (H5L_type_t)UD_CBFAIL_TYPE, &group_name, HDstrlen(group_name) + 1,
+    strcpy(group_name, "/group");
+    if (H5Lcreate_ud(fid, "/ud_link", (H5L_type_t)UD_CBFAIL_TYPE, &group_name, strlen(group_name) + 1,
                      H5P_DEFAULT, H5P_DEFAULT) < 0)
         FAIL_STACK_ERROR;
 
@@ -15182,7 +15181,7 @@ ud_link_errors(hid_t fapl, bool new_format)
         TEST_ERROR;
     if (H5Lget_val(fid, "ud_link", query_buf, (size_t)NAME_BUF_SIZE, H5P_DEFAULT) < 0)
         FAIL_STACK_ERROR;
-    if (HDstrcmp(query_buf, "succeed") != 0)
+    if (strcmp(query_buf, "succeed") != 0)
         TEST_ERROR;
 
     /* Moving and copying should both succeed */
@@ -15324,7 +15323,7 @@ lapl_nlinks(hid_t fapl, bool new_format)
     /* Check name */
     if (H5Iget_name(gid, objname, (size_t)NAME_BUF_SIZE) < 0)
         TEST_ERROR;
-    if (HDstrcmp(objname, "/soft17") != 0)
+    if (strcmp(objname, "/soft17") != 0)
         TEST_ERROR;
 
     /* Create group using soft link */
@@ -15357,7 +15356,7 @@ lapl_nlinks(hid_t fapl, bool new_format)
     H5E_END_TRY
     if (gid >= 0) {
         H5_FAILED();
-        HDputs("    Should have failed for sequence of too many nested links.");
+        puts("    Should have failed for sequence of too many nested links.");
         goto error;
     }
 
@@ -15368,7 +15367,7 @@ lapl_nlinks(hid_t fapl, bool new_format)
     /* Check name */
     if (H5Iget_name(gid, objname, (size_t)NAME_BUF_SIZE) < 0)
         TEST_ERROR;
-    if (HDstrcmp(objname, "/soft4") != 0)
+    if (strcmp(objname, "/soft4") != 0)
         TEST_ERROR;
 
     /* Test other functions that should use a LAPL */
@@ -15828,7 +15827,7 @@ visit_link_cb(hid_t H5_ATTR_UNUSED group_id, const char *name, const H5L_info2_t
     lvisit_ud_t *op_data = (lvisit_ud_t *)_op_data;
 
     /* Check for correct link information */
-    if (HDstrcmp(op_data->info[op_data->idx].path, name) != 0)
+    if (strcmp(op_data->info[op_data->idx].path, name) != 0)
         return (H5_ITER_ERROR);
     if (op_data->info[op_data->idx].type != linfo->type)
         return (H5_ITER_ERROR);
@@ -16019,7 +16018,7 @@ visit_obj_cb(hid_t H5_ATTR_UNUSED group_id, const char *name, const H5O_info2_t 
     ovisit_ud_t *op_data = (ovisit_ud_t *)_op_data;
 
     /* Check for correct object information */
-    if (HDstrcmp(op_data->info[op_data->idx].path, name) != 0)
+    if (strcmp(op_data->info[op_data->idx].path, name) != 0)
         return (H5_ITER_ERROR);
     if (op_data->info[op_data->idx].type != oinfo->type)
         return (H5_ITER_ERROR);
@@ -16556,13 +16555,13 @@ link_filters(hid_t fapl, bool new_format)
     if (H5Pget_filter_by_id2(gcpl2, H5Z_FILTER_RESERVED + 42, &flags_out, &cd_nelmts, &cd_value_out,
                              (size_t)24, name_out, &filter_config_out) < 0)
         TEST_ERROR;
-    if (flags_out != 0 || cd_value_out != cd_value || HDstrcmp(filter_class.name, name_out) != 0 ||
+    if (flags_out != 0 || cd_value_out != cd_value || strcmp(filter_class.name, name_out) != 0 ||
         filter_config_out != (H5Z_FILTER_CONFIG_ENCODE_ENABLED | H5Z_FILTER_CONFIG_DECODE_ENABLED))
         TEST_ERROR;
     if (H5Pget_filter2(gcpl2, (unsigned)(nfilters - 1), &flags_out, &cd_nelmts, &cd_value_out, (size_t)24,
                        name_out, &filter_config_out) < 0)
         TEST_ERROR;
-    if (flags_out != 0 || cd_value_out != cd_value || HDstrcmp(filter_class.name, name_out) != 0 ||
+    if (flags_out != 0 || cd_value_out != cd_value || strcmp(filter_class.name, name_out) != 0 ||
         filter_config_out != (H5Z_FILTER_CONFIG_ENCODE_ENABLED | H5Z_FILTER_CONFIG_DECODE_ENABLED))
         TEST_ERROR;
 
@@ -16573,7 +16572,7 @@ link_filters(hid_t fapl, bool new_format)
     if (H5Pget_filter_by_id2(gcpl2, H5Z_FILTER_RESERVED + 42, &flags_out, &cd_nelmts, &cd_value_out,
                              (size_t)24, name_out, &filter_config_out) < 0)
         TEST_ERROR;
-    if (flags_out != 0 || cd_value_out != cd_value || HDstrcmp(filter_class.name, name_out) != 0 ||
+    if (flags_out != 0 || cd_value_out != cd_value || strcmp(filter_class.name, name_out) != 0 ||
         filter_config_out != (H5Z_FILTER_CONFIG_ENCODE_ENABLED | H5Z_FILTER_CONFIG_DECODE_ENABLED))
         TEST_ERROR;
 
@@ -17142,7 +17141,7 @@ corder_create_empty(hid_t fapl)
     H5E_END_TRY
     if (ret > 0) {
         H5_FAILED();
-        HDputs(
+        puts(
             "    H5Pset_link_create_order() should have failed for a creation order index with no tracking.");
         TEST_ERROR;
     } /* end if */
@@ -17283,7 +17282,7 @@ corder_create_compact(hid_t fapl)
 
     /* Create several links, but keep group in compact form */
     for (u = 0; u < max_compact; u++) {
-        HDsnprintf(objname, sizeof(objname), "filler %u", u);
+        snprintf(objname, sizeof(objname), "filler %u", u);
         if ((group_id2 = H5Gcreate2(group_id, objname, H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT)) < 0)
             TEST_ERROR;
         if (H5Gclose(group_id2) < 0)
@@ -17336,7 +17335,7 @@ corder_create_compact(hid_t fapl)
         H5L_info2_t linfo; /* Link information */
 
         /* Retrieve information for link */
-        HDsnprintf(objname, sizeof(objname), "filler %u", u);
+        snprintf(objname, sizeof(objname), "filler %u", u);
         if (H5Lget_info2(group_id, objname, &linfo, H5P_DEFAULT) < 0)
             TEST_ERROR;
 
@@ -17427,7 +17426,7 @@ corder_create_dense(hid_t fapl)
 
     /* Create several links, up to limit of compact form */
     for (u = 0; u < max_compact; u++) {
-        HDsnprintf(objname, sizeof(objname), "filler %u", u);
+        snprintf(objname, sizeof(objname), "filler %u", u);
         if ((group_id2 = H5Gcreate2(group_id, objname, H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT)) < 0)
             TEST_ERROR;
         if (H5Gclose(group_id2) < 0)
@@ -17445,7 +17444,7 @@ corder_create_dense(hid_t fapl)
     } /* end for */
 
     /* Create another link, to push group into dense form */
-    HDsnprintf(objname, sizeof(objname), "filler %u", max_compact);
+    snprintf(objname, sizeof(objname), "filler %u", max_compact);
     if ((group_id2 = H5Gcreate2(group_id, objname, H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT)) < 0)
         TEST_ERROR;
     if (H5Gclose(group_id2) < 0)
@@ -17499,7 +17498,7 @@ corder_create_dense(hid_t fapl)
         H5L_info2_t linfo; /* Link information */
 
         /* Retrieve information for link */
-        HDsnprintf(objname, sizeof(objname), "filler %u", u);
+        snprintf(objname, sizeof(objname), "filler %u", u);
         if (H5Lget_info2(group_id, objname, &linfo, H5P_DEFAULT) < 0)
             TEST_ERROR;
 
@@ -17614,7 +17613,7 @@ corder_transition(hid_t fapl)
 
     /* Create several links, up to limit of compact form */
     for (u = 0; u < max_compact; u++) {
-        HDsnprintf(objname, sizeof(objname), "filler %u", u);
+        snprintf(objname, sizeof(objname), "filler %u", u);
         if ((group_id2 = H5Gcreate2(group_id, objname, H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT)) < 0)
             TEST_ERROR;
         if (H5Gclose(group_id2) < 0)
@@ -17622,7 +17621,7 @@ corder_transition(hid_t fapl)
     } /* end for */
 
     /* Create another link, to push group into dense form */
-    HDsnprintf(objname, sizeof(objname), "filler %u", max_compact);
+    snprintf(objname, sizeof(objname), "filler %u", max_compact);
     if ((group_id2 = H5Gcreate2(group_id, objname, H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT)) < 0)
         TEST_ERROR;
     if (H5Gclose(group_id2) < 0)
@@ -17644,7 +17643,7 @@ corder_transition(hid_t fapl)
 
     /* Delete several links from group, until it resumes compact form */
     for (u = max_compact; u >= min_dense; u--) {
-        HDsnprintf(objname, sizeof(objname), "filler %u", u);
+        snprintf(objname, sizeof(objname), "filler %u", u);
         if (H5Ldelete(group_id, objname, H5P_DEFAULT) < 0)
             TEST_ERROR;
 
@@ -17664,7 +17663,7 @@ corder_transition(hid_t fapl)
     } /* end for */
 
     /* Delete another link, to push group into compact form */
-    HDsnprintf(objname, sizeof(objname), "filler %u", (min_dense - 1));
+    snprintf(objname, sizeof(objname), "filler %u", (min_dense - 1));
     if (H5Ldelete(group_id, objname, H5P_DEFAULT) < 0)
         TEST_ERROR;
 
@@ -17680,7 +17679,7 @@ corder_transition(hid_t fapl)
 
     /* Re-add links to get back into dense form */
     for (u = (min_dense - 1); u < (max_compact + 1); u++) {
-        HDsnprintf(objname, sizeof(objname), "filler %u", u);
+        snprintf(objname, sizeof(objname), "filler %u", u);
         if ((group_id2 = H5Gcreate2(group_id, objname, H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT)) < 0)
             TEST_ERROR;
         if (H5Gclose(group_id2) < 0)
@@ -17733,7 +17732,7 @@ corder_transition(hid_t fapl)
 
     /* Delete several links from group, until it resumes compact form */
     for (u = max_compact; u >= min_dense; u--) {
-        HDsnprintf(objname, sizeof(objname), "filler %u", u);
+        snprintf(objname, sizeof(objname), "filler %u", u);
         if (H5Ldelete(group_id, objname, H5P_DEFAULT) < 0)
             TEST_ERROR;
 
@@ -17753,7 +17752,7 @@ corder_transition(hid_t fapl)
     } /* end for */
 
     /* Delete another link, to push group into compact form */
-    HDsnprintf(objname, sizeof(objname), "filler %u", (min_dense - 1));
+    snprintf(objname, sizeof(objname), "filler %u", (min_dense - 1));
     if (H5Ldelete(group_id, objname, H5P_DEFAULT) < 0)
         TEST_ERROR;
 
@@ -17769,7 +17768,7 @@ corder_transition(hid_t fapl)
 
     /* Re-add links to get back into dense form */
     for (u = (min_dense - 1); u < (max_compact + 1); u++) {
-        HDsnprintf(objname, sizeof(objname), "filler %u", u);
+        snprintf(objname, sizeof(objname), "filler %u", u);
         if ((group_id2 = H5Gcreate2(group_id, objname, H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT)) < 0)
             TEST_ERROR;
         if (H5Gclose(group_id2) < 0)
@@ -17792,11 +17791,11 @@ corder_transition(hid_t fapl)
 
     /* Delete all the links */
     for (u = max_compact; u > 0; u--) {
-        HDsnprintf(objname, sizeof(objname), "filler %u", u);
+        snprintf(objname, sizeof(objname), "filler %u", u);
         if (H5Ldelete(group_id, objname, H5P_DEFAULT) < 0)
             TEST_ERROR;
     } /* end for */
-    HDsnprintf(objname, sizeof(objname), "filler %u", (unsigned)0);
+    snprintf(objname, sizeof(objname), "filler %u", (unsigned)0);
     if (H5Ldelete(group_id, objname, H5P_DEFAULT) < 0)
         TEST_ERROR;
 
@@ -17908,7 +17907,7 @@ corder_delete(hid_t fapl)
 
         /* Create links until the group is in dense form */
         for (u = 0; u < max_compact * 2; u++) {
-            HDsnprintf(objname, sizeof(objname), "filler %u", u);
+            snprintf(objname, sizeof(objname), "filler %u", u);
             if ((group_id2 = H5Gcreate2(group_id, objname, H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT)) < 0)
                 FAIL_STACK_ERROR;
             if (H5Gclose(group_id2) < 0)
@@ -18001,7 +18000,7 @@ link_info_by_idx_check(hid_t group_id, const char *linkname, hsize_t n, bool har
     H5L_info2_t linfo;                  /* Link info struct */
 
     /* Make link value for increasing/native order queries */
-    HDsnprintf(valname, sizeof(valname), "value %02u", (unsigned)n);
+    snprintf(valname, sizeof(valname), "value %02u", (unsigned)n);
 
     /* Verify the link information for first link, in increasing creation order */
     memset(&linfo, 0, sizeof(linfo));
@@ -18024,7 +18023,7 @@ link_info_by_idx_check(hid_t group_id, const char *linkname, hsize_t n, bool har
         if (H5Lget_val_by_idx(group_id, ".", H5_INDEX_CRT_ORDER, H5_ITER_INC, n, tmpval,
                               (size_t)NAME_BUF_SIZE, H5P_DEFAULT) < 0)
             TEST_ERROR;
-        if (HDstrcmp(valname, tmpval) != 0)
+        if (strcmp(valname, tmpval) != 0)
             TEST_ERROR;
     } /* end if */
 
@@ -18033,7 +18032,7 @@ link_info_by_idx_check(hid_t group_id, const char *linkname, hsize_t n, bool har
     if (H5Lget_name_by_idx(group_id, ".", H5_INDEX_CRT_ORDER, H5_ITER_INC, n, tmpname, (size_t)NAME_BUF_SIZE,
                            H5P_DEFAULT) < 0)
         TEST_ERROR;
-    if (HDstrcmp(linkname, tmpname) != 0)
+    if (strcmp(linkname, tmpname) != 0)
         TEST_ERROR;
 
     /* Don't test "native" order if there is no creation order index, since
@@ -18063,7 +18062,7 @@ link_info_by_idx_check(hid_t group_id, const char *linkname, hsize_t n, bool har
             if (H5Lget_val_by_idx(group_id, ".", H5_INDEX_CRT_ORDER, H5_ITER_NATIVE, n, tmpval,
                                   (size_t)NAME_BUF_SIZE, H5P_DEFAULT) < 0)
                 TEST_ERROR;
-            if (HDstrcmp(valname, tmpval) != 0)
+            if (strcmp(valname, tmpval) != 0)
                 TEST_ERROR;
         } /* end if */
 
@@ -18072,7 +18071,7 @@ link_info_by_idx_check(hid_t group_id, const char *linkname, hsize_t n, bool har
         if (H5Lget_name_by_idx(group_id, ".", H5_INDEX_CRT_ORDER, H5_ITER_NATIVE, n, tmpname,
                                (size_t)NAME_BUF_SIZE, H5P_DEFAULT) < 0)
             TEST_ERROR;
-        if (HDstrcmp(linkname, tmpname) != 0)
+        if (strcmp(linkname, tmpname) != 0)
             TEST_ERROR;
     } /* end if */
 
@@ -18097,7 +18096,7 @@ link_info_by_idx_check(hid_t group_id, const char *linkname, hsize_t n, bool har
         if (H5Lget_val_by_idx(group_id, ".", H5_INDEX_CRT_ORDER, H5_ITER_DEC, (hsize_t)0, tmpval,
                               (size_t)NAME_BUF_SIZE, H5P_DEFAULT) < 0)
             TEST_ERROR;
-        if (HDstrcmp(valname, tmpval) != 0)
+        if (strcmp(valname, tmpval) != 0)
             TEST_ERROR;
     } /* end if */
 
@@ -18106,7 +18105,7 @@ link_info_by_idx_check(hid_t group_id, const char *linkname, hsize_t n, bool har
     if (H5Lget_name_by_idx(group_id, ".", H5_INDEX_CRT_ORDER, H5_ITER_DEC, (hsize_t)0, tmpname,
                            (size_t)NAME_BUF_SIZE, H5P_DEFAULT) < 0)
         TEST_ERROR;
-    if (HDstrcmp(linkname, tmpname) != 0)
+    if (strcmp(linkname, tmpname) != 0)
         TEST_ERROR;
 
     /* Verify the link information for first link, in increasing link name order */
@@ -18129,7 +18128,7 @@ link_info_by_idx_check(hid_t group_id, const char *linkname, hsize_t n, bool har
         if (H5Lget_val_by_idx(group_id, ".", H5_INDEX_NAME, H5_ITER_INC, n, tmpval, (size_t)NAME_BUF_SIZE,
                               H5P_DEFAULT) < 0)
             TEST_ERROR;
-        if (HDstrcmp(valname, tmpval) != 0)
+        if (strcmp(valname, tmpval) != 0)
             TEST_ERROR;
     } /* end if */
 
@@ -18138,7 +18137,7 @@ link_info_by_idx_check(hid_t group_id, const char *linkname, hsize_t n, bool har
     if (H5Lget_name_by_idx(group_id, ".", H5_INDEX_NAME, H5_ITER_INC, n, tmpname, (size_t)NAME_BUF_SIZE,
                            H5P_DEFAULT) < 0)
         TEST_ERROR;
-    if (HDstrcmp(linkname, tmpname) != 0)
+    if (strcmp(linkname, tmpname) != 0)
         TEST_ERROR;
 
     /* Don't test "native" order queries on link name order, since there's not
@@ -18165,7 +18164,7 @@ link_info_by_idx_check(hid_t group_id, const char *linkname, hsize_t n, bool har
         if (H5Lget_val_by_idx(group_id, ".", H5_INDEX_NAME, H5_ITER_DEC, (hsize_t)0, tmpval,
                               (size_t)NAME_BUF_SIZE, H5P_DEFAULT) < 0)
             TEST_ERROR;
-        if (HDstrcmp(valname, tmpval) != 0)
+        if (strcmp(valname, tmpval) != 0)
             TEST_ERROR;
     } /* end if */
 
@@ -18174,7 +18173,7 @@ link_info_by_idx_check(hid_t group_id, const char *linkname, hsize_t n, bool har
     if (H5Lget_name_by_idx(group_id, ".", H5_INDEX_NAME, H5_ITER_DEC, (hsize_t)0, tmpname,
                            (size_t)NAME_BUF_SIZE, H5P_DEFAULT) < 0)
         TEST_ERROR;
-    if (HDstrcmp(linkname, tmpname) != 0)
+    if (strcmp(linkname, tmpname) != 0)
         TEST_ERROR;
 
     /* Success */
@@ -18274,7 +18273,7 @@ link_info_by_idx(hid_t fapl)
             /* Create several links, up to limit of compact form */
             for (u = 0; u < max_compact; u++) {
                 /* Make name for link */
-                HDsnprintf(objname, sizeof(objname), "filler %02u", u);
+                snprintf(objname, sizeof(objname), "filler %02u", u);
 
                 /* Check for creating hard or soft link */
                 if (hard_link) {
@@ -18289,7 +18288,7 @@ link_info_by_idx(hid_t fapl)
                 } /* end if */
                 else {
                     /* Make value for link */
-                    HDsnprintf(valname, sizeof(valname), "value %02u", u);
+                    snprintf(valname, sizeof(valname), "value %02u", u);
 
                     /* Create soft link */
                     if (H5Lcreate_soft(valname, group_id, objname, H5P_DEFAULT, H5P_DEFAULT) < 0)
@@ -18334,7 +18333,7 @@ link_info_by_idx(hid_t fapl)
             /* Create more links, to push group into dense form */
             for (; u < (max_compact * 2); u++) {
                 /* Make name for link */
-                HDsnprintf(objname, sizeof(objname), "filler %02u", u);
+                snprintf(objname, sizeof(objname), "filler %02u", u);
 
                 /* Check for creating hard or soft link */
                 if (hard_link) {
@@ -18349,7 +18348,7 @@ link_info_by_idx(hid_t fapl)
                 } /* end if */
                 else {
                     /* Make value for link */
-                    HDsnprintf(valname, sizeof(valname), "value %02u", u);
+                    snprintf(valname, sizeof(valname), "value %02u", u);
 
                     /* Create soft link */
                     if (H5Lcreate_soft(valname, group_id, objname, H5P_DEFAULT, H5P_DEFAULT) < 0)
@@ -18477,7 +18476,7 @@ link_info_by_idx_old(hid_t fapl)
         /* Create several links */
         for (u = 0; u < CORDER_NLINKS; u++) {
             /* Make name for link */
-            HDsnprintf(objname, sizeof(objname), "filler %02u", u);
+            snprintf(objname, sizeof(objname), "filler %02u", u);
 
             /* Check for creating hard or soft link */
             if (hard_link) {
@@ -18499,7 +18498,7 @@ link_info_by_idx_old(hid_t fapl)
             } /* end if */
             else {
                 /* Make value for link */
-                HDsnprintf(valname, sizeof(valname), "value %02u", u);
+                snprintf(valname, sizeof(valname), "value %02u", u);
 
                 /* Create soft link */
                 if (H5Lcreate_soft(valname, group_id, objname, H5P_DEFAULT, H5P_DEFAULT) < 0)
@@ -18512,10 +18511,10 @@ link_info_by_idx_old(hid_t fapl)
             unsigned dec_u = CORDER_NLINKS - (u + 1); /* Decreasing mapped index */
 
             /* Make link name for increasing/native order queries */
-            HDsnprintf(objname, sizeof(objname), "filler %02u", u);
+            snprintf(objname, sizeof(objname), "filler %02u", u);
 
             /* Make link value for increasing/native order queries */
-            HDsnprintf(valname, sizeof(valname), "value %02u", u);
+            snprintf(valname, sizeof(valname), "value %02u", u);
 
             /* Verify link information (in increasing order) */
             if (hard_link) {
@@ -18531,7 +18530,7 @@ link_info_by_idx_old(hid_t fapl)
                 if (H5Lget_val_by_idx(group_id, ".", H5_INDEX_NAME, H5_ITER_INC, (hsize_t)u, tmpval,
                                       (size_t)NAME_BUF_SIZE, H5P_DEFAULT) < 0)
                     TEST_ERROR;
-                if (HDstrcmp(valname, tmpval) != 0)
+                if (strcmp(valname, tmpval) != 0)
                     TEST_ERROR;
             } /* end else */
 
@@ -18539,7 +18538,7 @@ link_info_by_idx_old(hid_t fapl)
             if (H5Lget_name_by_idx(group_id, ".", H5_INDEX_NAME, H5_ITER_INC, (hsize_t)u, tmpname,
                                    (size_t)NAME_BUF_SIZE, H5P_DEFAULT) < 0)
                 TEST_ERROR;
-            if (HDstrcmp(objname, tmpname) != 0)
+            if (strcmp(objname, tmpname) != 0)
                 TEST_ERROR;
 
             /* Verify link information (in native order - native is increasing) */
@@ -18556,7 +18555,7 @@ link_info_by_idx_old(hid_t fapl)
                 if (H5Lget_val_by_idx(group_id, ".", H5_INDEX_NAME, H5_ITER_NATIVE, (hsize_t)u, tmpval,
                                       (size_t)NAME_BUF_SIZE, H5P_DEFAULT) < 0)
                     TEST_ERROR;
-                if (HDstrcmp(valname, tmpval) != 0)
+                if (strcmp(valname, tmpval) != 0)
                     TEST_ERROR;
             } /* end else */
 
@@ -18564,14 +18563,14 @@ link_info_by_idx_old(hid_t fapl)
             if (H5Lget_name_by_idx(group_id, ".", H5_INDEX_NAME, H5_ITER_NATIVE, (hsize_t)u, tmpname,
                                    (size_t)NAME_BUF_SIZE, H5P_DEFAULT) < 0)
                 TEST_ERROR;
-            if (HDstrcmp(objname, tmpname) != 0)
+            if (strcmp(objname, tmpname) != 0)
                 TEST_ERROR;
 
             /* Make link name for decreasing order queries */
-            HDsnprintf(objname, sizeof(objname), "filler %02u", dec_u);
+            snprintf(objname, sizeof(objname), "filler %02u", dec_u);
 
             /* Make link value for decreasing order queries */
-            HDsnprintf(valname, sizeof(valname), "value %02u", dec_u);
+            snprintf(valname, sizeof(valname), "value %02u", dec_u);
 
             /* Verify link information (in decreasing order) */
             if (hard_link) {
@@ -18587,7 +18586,7 @@ link_info_by_idx_old(hid_t fapl)
                 if (H5Lget_val_by_idx(group_id, ".", H5_INDEX_NAME, H5_ITER_DEC, (hsize_t)u, tmpval,
                                       (size_t)NAME_BUF_SIZE, H5P_DEFAULT) < 0)
                     TEST_ERROR;
-                if (HDstrcmp(valname, tmpval) != 0)
+                if (strcmp(valname, tmpval) != 0)
                     TEST_ERROR;
             } /* end else */
 
@@ -18595,7 +18594,7 @@ link_info_by_idx_old(hid_t fapl)
             if (H5Lget_name_by_idx(group_id, ".", H5_INDEX_NAME, H5_ITER_DEC, (hsize_t)u, tmpname,
                                    (size_t)NAME_BUF_SIZE, H5P_DEFAULT) < 0)
                 TEST_ERROR;
-            if (HDstrcmp(objname, tmpname) != 0)
+            if (strcmp(objname, tmpname) != 0)
                 TEST_ERROR;
         } /* end for */
 
@@ -18765,7 +18764,7 @@ delete_by_idx(hid_t fapl)
                     hid_t group_id2; /* Group ID */
 
                     /* Make name for link */
-                    HDsnprintf(objname, sizeof(objname), "filler %02u", u);
+                    snprintf(objname, sizeof(objname), "filler %02u", u);
 
                     /* Create hard link, with group object */
                     if ((group_id2 = H5Gcreate2(group_id, objname, H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT)) <
@@ -18818,10 +18817,10 @@ delete_by_idx(hid_t fapl)
                                            (size_t)NAME_BUF_SIZE, H5P_DEFAULT) < 0)
                         TEST_ERROR;
                     if (order == H5_ITER_INC)
-                        HDsnprintf(objname, sizeof(objname), "filler %02u", (u + 1));
+                        snprintf(objname, sizeof(objname), "filler %02u", (u + 1));
                     else
-                        HDsnprintf(objname, sizeof(objname), "filler %02u", (max_compact - (u + 2)));
-                    if (HDstrcmp(objname, tmpname) != 0)
+                        snprintf(objname, sizeof(objname), "filler %02u", (max_compact - (u + 2)));
+                    if (strcmp(objname, tmpname) != 0)
                         TEST_ERROR;
                 } /* end for */
 
@@ -18838,7 +18837,7 @@ delete_by_idx(hid_t fapl)
                     hid_t group_id2; /* Group ID */
 
                     /* Make name for link */
-                    HDsnprintf(objname, sizeof(objname), "filler %02u", u);
+                    snprintf(objname, sizeof(objname), "filler %02u", u);
 
                     /* Create hard link, with group object */
                     if ((group_id2 = H5Gcreate2(group_id, objname, H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT)) <
@@ -18892,10 +18891,10 @@ delete_by_idx(hid_t fapl)
                                            (size_t)NAME_BUF_SIZE, H5P_DEFAULT) < 0)
                         TEST_ERROR;
                     if (order == H5_ITER_INC)
-                        HDsnprintf(objname, sizeof(objname), "filler %02u", (u + 1));
+                        snprintf(objname, sizeof(objname), "filler %02u", (u + 1));
                     else
-                        HDsnprintf(objname, sizeof(objname), "filler %02u", ((max_compact * 2) - (u + 2)));
-                    if (HDstrcmp(objname, tmpname) != 0)
+                        snprintf(objname, sizeof(objname), "filler %02u", ((max_compact * 2) - (u + 2)));
+                    if (strcmp(objname, tmpname) != 0)
                         TEST_ERROR;
                 } /* end for */
 
@@ -18925,7 +18924,7 @@ delete_by_idx(hid_t fapl)
                     hid_t group_id2; /* Group ID */
 
                     /* Make name for link */
-                    HDsnprintf(objname, sizeof(objname), "filler %02u", u);
+                    snprintf(objname, sizeof(objname), "filler %02u", u);
 
                     /* Create hard link, with group object */
                     if ((group_id2 = H5Gcreate2(group_id, objname, H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT)) <
@@ -18970,11 +18969,11 @@ delete_by_idx(hid_t fapl)
                                            (size_t)NAME_BUF_SIZE, H5P_DEFAULT) < 0)
                         TEST_ERROR;
                     if (order == H5_ITER_INC)
-                        HDsnprintf(objname, sizeof(objname), "filler %02u", ((u * 2) + 1));
+                        snprintf(objname, sizeof(objname), "filler %02u", ((u * 2) + 1));
                     else
-                        HDsnprintf(objname, sizeof(objname), "filler %02u",
-                                   ((max_compact * 2) - ((u * 2) + 2)));
-                    if (HDstrcmp(objname, tmpname) != 0)
+                        snprintf(objname, sizeof(objname), "filler %02u",
+                                 ((max_compact * 2) - ((u * 2) + 2)));
+                    if (strcmp(objname, tmpname) != 0)
                         TEST_ERROR;
                 } /* end for */
 
@@ -19004,11 +19003,11 @@ delete_by_idx(hid_t fapl)
                                            (size_t)NAME_BUF_SIZE, H5P_DEFAULT) < 0)
                         TEST_ERROR;
                     if (order == H5_ITER_INC)
-                        HDsnprintf(objname, sizeof(objname), "filler %02u", ((u * 2) + 3));
+                        snprintf(objname, sizeof(objname), "filler %02u", ((u * 2) + 3));
                     else
-                        HDsnprintf(objname, sizeof(objname), "filler %02u",
-                                   ((max_compact * 2) - ((u * 2) + 4)));
-                    if (HDstrcmp(objname, tmpname) != 0)
+                        snprintf(objname, sizeof(objname), "filler %02u",
+                                 ((max_compact * 2) - ((u * 2) + 4)));
+                    if (strcmp(objname, tmpname) != 0)
                         TEST_ERROR;
                 } /* end for */
 
@@ -19120,7 +19119,7 @@ delete_by_idx_old(hid_t fapl)
             H5O_info2_t oi; /* Buffer for querying object's info */
 
             /* Make name for link */
-            HDsnprintf(objname, sizeof(objname), "filler %02u", u);
+            snprintf(objname, sizeof(objname), "filler %02u", u);
 
             /* Create group */
             if ((group_id2 = H5Gcreate2(group_id, objname, H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT)) < 0)
@@ -19186,10 +19185,10 @@ delete_by_idx_old(hid_t fapl)
                                    (size_t)NAME_BUF_SIZE, H5P_DEFAULT) < 0)
                 TEST_ERROR;
             if (order == H5_ITER_INC)
-                HDsnprintf(objname, sizeof(objname), "filler %02u", (u + 1));
+                snprintf(objname, sizeof(objname), "filler %02u", (u + 1));
             else
-                HDsnprintf(objname, sizeof(objname), "filler %02u", dec_u);
-            if (HDstrcmp(objname, tmpname) != 0)
+                snprintf(objname, sizeof(objname), "filler %02u", dec_u);
+            if (strcmp(objname, tmpname) != 0)
                 TEST_ERROR;
         } /* end for */
 
@@ -19217,7 +19216,7 @@ delete_by_idx_old(hid_t fapl)
             H5O_info2_t oi; /* Buffer for querying object's info */
 
             /* Make name for link */
-            HDsnprintf(objname, sizeof(objname), "filler %02u", u);
+            snprintf(objname, sizeof(objname), "filler %02u", u);
 
             /* Create group */
             if ((group_id2 = H5Gcreate2(group_id, objname, H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT)) < 0)
@@ -19265,10 +19264,10 @@ delete_by_idx_old(hid_t fapl)
                                    (size_t)NAME_BUF_SIZE, H5P_DEFAULT) < 0)
                 TEST_ERROR;
             if (order == H5_ITER_INC)
-                HDsnprintf(objname, sizeof(objname), "filler %02u", ((u * 2) + 1));
+                snprintf(objname, sizeof(objname), "filler %02u", ((u * 2) + 1));
             else
-                HDsnprintf(objname, sizeof(objname), "filler %02u", dec_u);
-            if (HDstrcmp(objname, tmpname) != 0)
+                snprintf(objname, sizeof(objname), "filler %02u", dec_u);
+            if (strcmp(objname, tmpname) != 0)
                 TEST_ERROR;
         } /* end for */
 
@@ -19303,10 +19302,10 @@ delete_by_idx_old(hid_t fapl)
                                    (size_t)NAME_BUF_SIZE, H5P_DEFAULT) < 0)
                 TEST_ERROR;
             if (order == H5_ITER_INC)
-                HDsnprintf(objname, sizeof(objname), "filler %02u", ((u * 2) + 3));
+                snprintf(objname, sizeof(objname), "filler %02u", ((u * 2) + 3));
             else
-                HDsnprintf(objname, sizeof(objname), "filler %02u", dec_u);
-            if (HDstrcmp(objname, tmpname) != 0)
+                snprintf(objname, sizeof(objname), "filler %02u", dec_u);
+            if (strcmp(objname, tmpname) != 0)
                 TEST_ERROR;
         } /* end for */
 
@@ -19391,8 +19390,8 @@ link_iterate_cb(hid_t group_id, const char *link_name, const H5L_info2_t *info, 
     } /* end if */
 
     /* Verify name of link */
-    HDsnprintf(objname, sizeof(objname), "filler %02u", (unsigned)my_info.corder);
-    if (HDstrcmp(link_name, objname) != 0)
+    snprintf(objname, sizeof(objname), "filler %02u", (unsigned)my_info.corder);
+    if (strcmp(link_name, objname) != 0)
         return H5_ITER_ERROR;
 
     /* Check if we've visited this link before */
@@ -19759,7 +19758,7 @@ link_iterate(hid_t fapl)
                     hid_t group_id2; /* Group ID */
 
                     /* Make name for link */
-                    HDsnprintf(objname, sizeof(objname), "filler %02u", u);
+                    snprintf(objname, sizeof(objname), "filler %02u", u);
 
                     /* Create hard link, with group object */
                     if ((group_id2 = H5Gcreate2(group_id, objname, H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT)) <
@@ -19792,7 +19791,7 @@ link_iterate(hid_t fapl)
                     hid_t group_id2; /* Group ID */
 
                     /* Make name for link */
-                    HDsnprintf(objname, sizeof(objname), "filler %02u", u);
+                    snprintf(objname, sizeof(objname), "filler %02u", u);
 
                     /* Create hard link, with group object */
                     if ((group_id2 = H5Gcreate2(group_id, objname, H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT)) <
@@ -19902,9 +19901,9 @@ link_iterate_old_cb(hid_t group_id, const char *link_name, const H5L_info2_t *in
     } /* end if */
 
     /* Verify name of link */
-    HDsnprintf(objname, sizeof(objname), "filler %02u",
-               (info ? (unsigned)op_data->curr : (unsigned)((op_data->ncalled - 1) + op_data->nskipped)));
-    if (HDstrcmp(link_name, objname) != 0)
+    snprintf(objname, sizeof(objname), "filler %02u",
+             (info ? (unsigned)op_data->curr : (unsigned)((op_data->ncalled - 1) + op_data->nskipped)));
+    if (strcmp(link_name, objname) != 0)
         return H5_ITER_ERROR;
 
     /* Check if we've visited this link before */
@@ -20203,7 +20202,7 @@ link_iterate_old(hid_t fapl)
             hid_t group_id2; /* Group ID */
 
             /* Make name for link */
-            HDsnprintf(objname, sizeof(objname), "filler %02u", u);
+            snprintf(objname, sizeof(objname), "filler %02u", u);
 
             /* Create hard link, with group object */
             if ((group_id2 = H5Gcreate2(group_id, objname, H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT)) < 0)
@@ -20347,7 +20346,7 @@ open_by_idx_check(hid_t main_group_id, hid_t soft_group_id, hid_t mount_file_id,
 
     /* Mount a file over a group in main group */
     mnt_idx = 2;
-    HDsnprintf(mntname, sizeof(mntname), "/%s/filler %02u", CORDER_GROUP_NAME, mnt_idx);
+    snprintf(mntname, sizeof(mntname), "/%s/filler %02u", CORDER_GROUP_NAME, mnt_idx);
     if (H5Fmount(main_group_id, mntname, mount_file_id, H5P_DEFAULT) < 0)
         TEST_ERROR;
 
@@ -20524,7 +20523,7 @@ open_by_idx(hid_t fapl)
                     hid_t group_id2; /* Group ID */
 
                     /* Make name for link */
-                    HDsnprintf(objname, sizeof(objname), "filler %02u", u);
+                    snprintf(objname, sizeof(objname), "filler %02u", u);
 
                     /* Create hard link, with group object */
                     if ((group_id2 = H5Gcreate2(group_id, objname, H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT)) <
@@ -20541,7 +20540,7 @@ open_by_idx(hid_t fapl)
                         TEST_ERROR;
 
                     /* Create soft link in another group, to objects in main group */
-                    HDsnprintf(valname, sizeof(valname), "/%s/%s", CORDER_GROUP_NAME, objname);
+                    snprintf(valname, sizeof(valname), "/%s/%s", CORDER_GROUP_NAME, objname);
                     if (H5Lcreate_soft(valname, soft_group_id, objname, H5P_DEFAULT, H5P_DEFAULT) < 0)
                         TEST_ERROR;
                 }
@@ -20568,7 +20567,7 @@ open_by_idx(hid_t fapl)
                     hid_t group_id2; /* Group ID */
 
                     /* Make name for link */
-                    HDsnprintf(objname, sizeof(objname), "filler %02u", u);
+                    snprintf(objname, sizeof(objname), "filler %02u", u);
 
                     /* Create hard link, with group object */
                     if ((group_id2 = H5Gcreate2(group_id, objname, H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT)) <
@@ -20585,7 +20584,7 @@ open_by_idx(hid_t fapl)
                         TEST_ERROR;
 
                     /* Create soft link in another group, to objects in main group */
-                    HDsnprintf(valname, sizeof(valname), "/%s/%s", CORDER_GROUP_NAME, objname);
+                    snprintf(valname, sizeof(valname), "/%s/%s", CORDER_GROUP_NAME, objname);
                     if (H5Lcreate_soft(valname, soft_group_id, objname, H5P_DEFAULT, H5P_DEFAULT) < 0)
                         TEST_ERROR;
                 } /* end for */
@@ -20728,7 +20727,7 @@ open_by_idx_check_old(hid_t main_group_id, hid_t soft_group_id, hid_t mount_file
 
     /* Mount a file over a group in main group */
     mnt_idx = 2;
-    HDsnprintf(mntname, sizeof(mntname), "/%s/filler %02u", CORDER_GROUP_NAME, mnt_idx);
+    snprintf(mntname, sizeof(mntname), "/%s/filler %02u", CORDER_GROUP_NAME, mnt_idx);
     if (H5Fmount(main_group_id, mntname, mount_file_id, H5P_DEFAULT) < 0)
         TEST_ERROR;
 
@@ -20839,7 +20838,7 @@ open_by_idx_old(hid_t fapl)
             hid_t group_id2; /* Group ID */
 
             /* Make name for link */
-            HDsnprintf(objname, sizeof(objname), "filler %02u", u);
+            snprintf(objname, sizeof(objname), "filler %02u", u);
 
             /* Create hard link, with group object */
             if ((group_id2 = H5Gcreate2(group_id, objname, H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT)) < 0)
@@ -20855,7 +20854,7 @@ open_by_idx_old(hid_t fapl)
                 TEST_ERROR;
 
             /* Create soft link in another group, to objects in main group */
-            HDsnprintf(valname, sizeof(valname), "/%s/%s", CORDER_GROUP_NAME, objname);
+            snprintf(valname, sizeof(valname), "/%s/%s", CORDER_GROUP_NAME, objname);
             if (H5Lcreate_soft(valname, soft_group_id, objname, H5P_DEFAULT, H5P_DEFAULT) < 0)
                 TEST_ERROR;
         } /* end for */
@@ -20949,7 +20948,7 @@ object_info_check(hid_t main_group_id, hid_t soft_group_id, H5_index_t idx_type,
         /* Open each object in group by name and check that it's the correct one */
         for (u = 0; u < max_links; u++) {
             /* Make name for link */
-            HDsnprintf(objname, sizeof(objname), "filler %02u", u);
+            snprintf(objname, sizeof(objname), "filler %02u", u);
 
             /* Query the object's information, by name */
             if (H5Oget_info_by_name3(group_id, objname, &oinfo, H5O_INFO_BASIC | H5O_INFO_NUM_ATTRS,
@@ -21148,7 +21147,7 @@ object_info(hid_t fapl)
                     hid_t attr_id;   /* Attribute ID */
 
                     /* Make name for link */
-                    HDsnprintf(objname, sizeof(objname), "filler %02u", u);
+                    snprintf(objname, sizeof(objname), "filler %02u", u);
 
                     /* Create hard link, with group object */
                     if ((group_id2 = H5Gcreate2(group_id, objname, H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT)) <
@@ -21163,7 +21162,7 @@ object_info(hid_t fapl)
                     /* Create attributes on new object */
                     for (v = 0; v < u; v++) {
                         /* Make name for attribute */
-                        HDsnprintf(attrname, sizeof(attrname), "attr %02u", v);
+                        snprintf(attrname, sizeof(attrname), "attr %02u", v);
 
                         /* Create attribute */
                         if ((attr_id = H5Acreate2(group_id2, attrname, H5T_NATIVE_INT, space_id, H5P_DEFAULT,
@@ -21180,7 +21179,7 @@ object_info(hid_t fapl)
                         TEST_ERROR;
 
                     /* Create soft link in another group, to objects in main group */
-                    HDsnprintf(valname, sizeof(valname), "/%s/%s", CORDER_GROUP_NAME, objname);
+                    snprintf(valname, sizeof(valname), "/%s/%s", CORDER_GROUP_NAME, objname);
                     if (H5Lcreate_soft(valname, soft_group_id, objname, H5P_DEFAULT, H5P_DEFAULT) < 0)
                         TEST_ERROR;
                 } /* end for */
@@ -21209,7 +21208,7 @@ object_info(hid_t fapl)
                     hid_t attr_id;   /* Attribute ID */
 
                     /* Make name for link */
-                    HDsnprintf(objname, sizeof(objname), "filler %02u", u);
+                    snprintf(objname, sizeof(objname), "filler %02u", u);
 
                     /* Create hard link, with group object */
                     if ((group_id2 = H5Gcreate2(group_id, objname, H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT)) <
@@ -21224,7 +21223,7 @@ object_info(hid_t fapl)
                     /* Create attributes on new object */
                     for (v = 0; v < u; v++) {
                         /* Make name for attribute */
-                        HDsnprintf(attrname, sizeof(attrname), "attr %02u", v);
+                        snprintf(attrname, sizeof(attrname), "attr %02u", v);
 
                         /* Create attribute */
                         if ((attr_id = H5Acreate2(group_id2, attrname, H5T_NATIVE_INT, space_id, H5P_DEFAULT,
@@ -21241,7 +21240,7 @@ object_info(hid_t fapl)
                         TEST_ERROR;
 
                     /* Create soft link in another group, to objects in main group */
-                    HDsnprintf(valname, sizeof(valname), "/%s/%s", CORDER_GROUP_NAME, objname);
+                    snprintf(valname, sizeof(valname), "/%s/%s", CORDER_GROUP_NAME, objname);
                     if (H5Lcreate_soft(valname, soft_group_id, objname, H5P_DEFAULT, H5P_DEFAULT) < 0)
                         TEST_ERROR;
                 } /* end for */
@@ -21338,7 +21337,7 @@ object_info_check_old(hid_t main_group_id, hid_t soft_group_id, H5_index_t idx_t
             int cmp_value; /* Token comparison value */
 
             /* Make name for link */
-            HDsnprintf(objname, sizeof(objname), "filler %02u", u);
+            snprintf(objname, sizeof(objname), "filler %02u", u);
 
             /* Query the object's information, by name */
             if (H5Oget_info_by_name3(group_id, objname, &oinfo, H5O_INFO_BASIC | H5O_INFO_NUM_ATTRS,
@@ -21466,7 +21465,7 @@ object_info_old(hid_t fapl)
             hid_t attr_id;   /* Attribute ID */
 
             /* Make name for link */
-            HDsnprintf(objname, sizeof(objname), "filler %02u", u);
+            snprintf(objname, sizeof(objname), "filler %02u", u);
 
             /* Create hard link, with group object */
             if ((group_id2 = H5Gcreate2(group_id, objname, H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT)) < 0)
@@ -21480,7 +21479,7 @@ object_info_old(hid_t fapl)
             /* Create attributes on new object */
             for (v = 0; v < u; v++) {
                 /* Make name for attribute */
-                HDsnprintf(attrname, sizeof(attrname), "attr %02u", v);
+                snprintf(attrname, sizeof(attrname), "attr %02u", v);
 
                 /* Create attribute */
                 if ((attr_id = H5Acreate2(group_id2, attrname, H5T_NATIVE_INT, space_id, H5P_DEFAULT,
@@ -21497,7 +21496,7 @@ object_info_old(hid_t fapl)
                 TEST_ERROR;
 
             /* Create soft link in another group, to objects in main group */
-            HDsnprintf(valname, sizeof(valname), "/%s/%s", CORDER_GROUP_NAME, objname);
+            snprintf(valname, sizeof(valname), "/%s/%s", CORDER_GROUP_NAME, objname);
             if (H5Lcreate_soft(valname, soft_group_id, objname, H5P_DEFAULT, H5P_DEFAULT) < 0)
                 TEST_ERROR;
         } /* end for */
@@ -21698,7 +21697,7 @@ group_info(hid_t fapl)
                     hid_t group_id2, group_id3; /* Group IDs */
 
                     /* Make name for link */
-                    HDsnprintf(objname, sizeof(objname), "filler %02u", u);
+                    snprintf(objname, sizeof(objname), "filler %02u", u);
 
                     /* Create hard link, with group object */
                     if ((group_id2 = H5Gcreate2(group_id, objname, H5P_DEFAULT, gcpl_id, H5P_DEFAULT)) < 0)
@@ -21743,7 +21742,7 @@ group_info(hid_t fapl)
                     /* Create objects in new group created */
                     for (v = 0; v <= u; v++) {
                         /* Make name for link */
-                        HDsnprintf(objname2, sizeof(objname2), "filler %02u", v);
+                        snprintf(objname2, sizeof(objname2), "filler %02u", v);
 
                         /* Create hard link, with group object */
                         if ((group_id3 =
@@ -21854,7 +21853,7 @@ group_info(hid_t fapl)
                         TEST_ERROR;
 
                     /* Create soft link in another group, to objects in main group */
-                    HDsnprintf(valname, sizeof(valname), "/%s/%s", CORDER_GROUP_NAME, objname);
+                    snprintf(valname, sizeof(valname), "/%s/%s", CORDER_GROUP_NAME, objname);
                     if (H5Lcreate_soft(valname, soft_group_id, objname, H5P_DEFAULT, H5P_DEFAULT) < 0)
                         TEST_ERROR;
 
@@ -21890,7 +21889,7 @@ group_info(hid_t fapl)
                     hid_t group_id2, group_id3; /* Group IDs */
 
                     /* Make name for link */
-                    HDsnprintf(objname, sizeof(objname), "filler %02u", u);
+                    snprintf(objname, sizeof(objname), "filler %02u", u);
 
                     /* Create hard link, with group object */
                     if ((group_id2 = H5Gcreate2(group_id, objname, H5P_DEFAULT, gcpl_id, H5P_DEFAULT)) < 0)
@@ -21935,7 +21934,7 @@ group_info(hid_t fapl)
                     /* Create objects in new group created */
                     for (v = 0; v <= u; v++) {
                         /* Make name for link */
-                        HDsnprintf(objname2, sizeof(objname2), "filler %02u", v);
+                        snprintf(objname2, sizeof(objname2), "filler %02u", v);
 
                         /* Create hard link, with group object */
                         if ((group_id3 =
@@ -22046,7 +22045,7 @@ group_info(hid_t fapl)
                         TEST_ERROR;
 
                     /* Create soft link in another group, to objects in main group */
-                    HDsnprintf(valname, sizeof(valname), "/%s/%s", CORDER_GROUP_NAME, objname);
+                    snprintf(valname, sizeof(valname), "/%s/%s", CORDER_GROUP_NAME, objname);
                     if (H5Lcreate_soft(valname, soft_group_id, objname, H5P_DEFAULT, H5P_DEFAULT) < 0)
                         TEST_ERROR;
 
@@ -22178,7 +22177,7 @@ group_info_old(hid_t fapl)
             hid_t group_id2, group_id3; /* Group IDs */
 
             /* Make name for link */
-            HDsnprintf(objname, sizeof(objname), "filler %02u", u);
+            snprintf(objname, sizeof(objname), "filler %02u", u);
 
             /* Create hard link, with group object */
             if ((group_id2 = H5Gcreate2(group_id, objname, H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT)) < 0)
@@ -22223,7 +22222,7 @@ group_info_old(hid_t fapl)
             /* Create objects in new group created */
             for (v = 0; v <= u; v++) {
                 /* Make name for link */
-                HDsnprintf(objname2, sizeof(objname2), "filler %02u", v);
+                snprintf(objname2, sizeof(objname2), "filler %02u", v);
 
                 /* Create hard link, with group object */
                 if ((group_id3 = H5Gcreate2(group_id2, objname2, H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT)) < 0)
@@ -22333,7 +22332,7 @@ group_info_old(hid_t fapl)
                 TEST_ERROR;
 
             /* Create soft link in another group, to objects in main group */
-            HDsnprintf(valname, sizeof(valname), "/%s/%s", CORDER_GROUP_NAME, objname);
+            snprintf(valname, sizeof(valname), "/%s/%s", CORDER_GROUP_NAME, objname);
             if (H5Lcreate_soft(valname, soft_group_id, objname, H5P_DEFAULT, H5P_DEFAULT) < 0)
                 TEST_ERROR;
 
@@ -22727,7 +22726,7 @@ main(void)
 #endif /* H5_NO_DEPRECATED_SYMBOLS */
 
             /* Skip external link tests for splitter VFD, which has external link-related bugs */
-            if (HDstrcmp(env_h5_drvr, "splitter")) {
+            if (strcmp(env_h5_drvr, "splitter")) {
 
                 /* tests for external link */
                 /* Test external file cache first, so it sees the default efc setting on the fapl
@@ -22954,6 +22953,6 @@ main(void)
     exit(EXIT_SUCCESS);
 
 error:
-    HDputs("*** TESTS FAILED ***");
+    puts("*** TESTS FAILED ***");
     exit(EXIT_FAILURE);
 } /* end main() */

--- a/test/links_env.c
+++ b/test/links_env.c
@@ -63,7 +63,7 @@ external_link_env(hid_t fapl, bool new_format)
 
     if ((envval = HDgetenv("HDF5_EXT_PREFIX")) == NULL)
         envval = "nomatch";
-    if (HDstrcmp(envval, ".:tmp_links_env") != 0)
+    if (strcmp(envval, ".:tmp_links_env") != 0)
         TEST_ERROR;
 
     /* Set up name for main file:"extlinks_env0" */
@@ -109,7 +109,7 @@ external_link_env(hid_t fapl, bool new_format)
     /* Should be able to find the target file from pathnames set via HDF5_EXT_PREFIX */
     if (gid < 0) {
         H5_FAILED();
-        HDputs("    Should have found the file in tmp_links_env directory.");
+        puts("    Should have found the file in tmp_links_env directory.");
         goto error;
     }
 
@@ -154,8 +154,8 @@ main(void)
         env_h5_drvr = "nomatch";
 
     /* Splitter VFD has issues with external links */
-    if (!HDstrcmp(env_h5_drvr, "splitter")) {
-        HDputs(" -- SKIPPED for incompatible VFD --");
+    if (!strcmp(env_h5_drvr, "splitter")) {
+        puts(" -- SKIPPED for incompatible VFD --");
         exit(EXIT_SUCCESS);
     }
 
@@ -189,6 +189,6 @@ main(void)
     exit(EXIT_SUCCESS);
 
 error:
-    HDputs("*** TESTS FAILED ***");
+    puts("*** TESTS FAILED ***");
     exit(EXIT_FAILURE);
 } /* end main() */

--- a/test/mf.c
+++ b/test/mf.c
@@ -228,8 +228,8 @@ test_mf_eoa(const char *env_h5_drvr, hid_t fapl)
     /* Skip test when using VFDs that has different address spaces for each
      *  type of metadata allocation. Also skip test for Direct VFD.
      */
-    suitable_vfd = (bool)(HDstrcmp(env_h5_drvr, "split") != 0 && HDstrcmp(env_h5_drvr, "multi") != 0 &&
-                          HDstrcmp(env_h5_drvr, "direct") != 0);
+    suitable_vfd = (bool)(strcmp(env_h5_drvr, "split") != 0 && strcmp(env_h5_drvr, "multi") != 0 &&
+                          strcmp(env_h5_drvr, "direct") != 0);
     if (suitable_vfd) {
         /* Set the filename to use for this test */
         h5_fixname(FILENAME[0], fapl, filename, sizeof(filename));
@@ -324,7 +324,7 @@ test_mf_eoa(const char *env_h5_drvr, hid_t fapl)
     } /* end if */
     else {
         SKIPPED();
-        HDputs("    Current VFD doesn't support continuous address space");
+        puts("    Current VFD doesn't support continuous address space");
     } /* end else */
 
     return (0);
@@ -377,8 +377,8 @@ test_mf_eoa_shrink(const char *env_h5_drvr, hid_t fapl)
     /* Skip test when using VFDs that has different address spaces for each
      *  type of metadata allocation. Also skip test for Direct VFD.
      */
-    suitable_vfd = (bool)(HDstrcmp(env_h5_drvr, "split") != 0 && HDstrcmp(env_h5_drvr, "multi") != 0 &&
-                          HDstrcmp(env_h5_drvr, "direct") != 0);
+    suitable_vfd = (bool)(strcmp(env_h5_drvr, "split") != 0 && strcmp(env_h5_drvr, "multi") != 0 &&
+                          strcmp(env_h5_drvr, "direct") != 0);
     if (suitable_vfd) {
         /* Set the filename to use for this test (dependent on fapl) */
         h5_fixname(FILENAME[0], fapl, filename, sizeof(filename));
@@ -472,7 +472,7 @@ test_mf_eoa_shrink(const char *env_h5_drvr, hid_t fapl)
     } /* end if */
     else {
         SKIPPED();
-        HDputs("    Current VFD doesn't support metadata aggregator");
+        puts("    Current VFD doesn't support metadata aggregator");
     } /* end else */
 
     TESTING("H5MF_try_shrink() of file allocation: test 2");
@@ -522,7 +522,7 @@ test_mf_eoa_shrink(const char *env_h5_drvr, hid_t fapl)
     } /* end if */
     else {
         SKIPPED();
-        HDputs("    Current VFD doesn't support metadata aggregator");
+        puts("    Current VFD doesn't support metadata aggregator");
     } /* end else */
 
     TESTING("H5MF_try_shrink() of file allocation: test 3");
@@ -567,7 +567,7 @@ test_mf_eoa_shrink(const char *env_h5_drvr, hid_t fapl)
     } /* end if */
     else {
         SKIPPED();
-        HDputs("    Current VFD doesn't support metadata aggregator");
+        puts("    Current VFD doesn't support metadata aggregator");
     } /* end else */
 
     TESTING("H5MF_try_shrink() of file allocation: test 4");
@@ -615,7 +615,7 @@ test_mf_eoa_shrink(const char *env_h5_drvr, hid_t fapl)
     } /* end if */
     else {
         SKIPPED();
-        HDputs("    Current VFD doesn't support metadata aggregator");
+        puts("    Current VFD doesn't support metadata aggregator");
     } /* end else */
 
     return (0);
@@ -665,8 +665,8 @@ test_mf_eoa_extend(const char *env_h5_drvr, hid_t fapl)
     /* Skip test when using VFDs that has different address spaces for each
      *  type of metadata allocation. Also skip test for Direct VFD.
      */
-    suitable_vfd = (bool)(HDstrcmp(env_h5_drvr, "split") != 0 && HDstrcmp(env_h5_drvr, "multi") != 0 &&
-                          HDstrcmp(env_h5_drvr, "direct") != 0);
+    suitable_vfd = (bool)(strcmp(env_h5_drvr, "split") != 0 && strcmp(env_h5_drvr, "multi") != 0 &&
+                          strcmp(env_h5_drvr, "direct") != 0);
     if (suitable_vfd) {
         /* Set the filename to use for this test (dependent on fapl) */
         h5_fixname(FILENAME[0], fapl, filename, sizeof(filename));
@@ -758,7 +758,7 @@ test_mf_eoa_extend(const char *env_h5_drvr, hid_t fapl)
     } /* end if */
     else {
         SKIPPED();
-        HDputs("    Current VFD doesn't support metadata aggregator");
+        puts("    Current VFD doesn't support metadata aggregator");
     } /* end else */
 
     TESTING("H5MF_try_extend() of file allocation: test 2");
@@ -822,7 +822,7 @@ test_mf_eoa_extend(const char *env_h5_drvr, hid_t fapl)
     } /* end if */
     else {
         SKIPPED();
-        HDputs("    Current VFD doesn't support metadata aggregator");
+        puts("    Current VFD doesn't support metadata aggregator");
     } /* end else */
 
     return (0);
@@ -1031,7 +1031,7 @@ test_mf_tmp(const char *env_h5_drvr, hid_t fapl, bool new_format)
     } /* end if */
     else {
         SKIPPED();
-        HDputs("    Current VFD doesn't support continuous address space");
+        puts("    Current VFD doesn't support continuous address space");
     } /* end else */
 
     return (0);
@@ -2017,7 +2017,7 @@ test_mf_fs_absorb(const char *env_h5_drvr, hid_t fapl)
     TESTING("A free-space section absorbs an aggregator: test 1");
 
     /* Skip test when using VFDs that don't use the metadata aggregator */
-    contig_addr_vfd = (bool)(HDstrcmp(env_h5_drvr, "split") != 0 && HDstrcmp(env_h5_drvr, "multi") != 0);
+    contig_addr_vfd = (bool)(strcmp(env_h5_drvr, "split") != 0 && strcmp(env_h5_drvr, "multi") != 0);
     if (contig_addr_vfd) {
         /* Set the filename to use for this test (dependent on fapl) */
         h5_fixname(FILENAME[0], fapl, filename, sizeof(filename));
@@ -2082,7 +2082,7 @@ test_mf_fs_absorb(const char *env_h5_drvr, hid_t fapl)
     } /* end if */
     else {
         SKIPPED();
-        HDputs("    Current VFD doesn't support metadata aggregator");
+        puts("    Current VFD doesn't support metadata aggregator");
     } /* end else */
 
     TESTING("A free-space section absorbs an aggregator: test 2");
@@ -2144,7 +2144,7 @@ test_mf_fs_absorb(const char *env_h5_drvr, hid_t fapl)
     } /* end if */
     else {
         SKIPPED();
-        HDputs("    Current VFD doesn't support metadata aggregator");
+        puts("    Current VFD doesn't support metadata aggregator");
     } /* end else */
 
     return (0);
@@ -2193,8 +2193,8 @@ test_mf_aggr_alloc1(const char *env_h5_drvr, hid_t fapl)
     TESTING("H5MF_alloc() of meta/sdata aggregator:test 1");
 
     /* Skip test when using VFDs that don't use the metadata aggregator. Also skip test for Direct VFD. */
-    suitable_vfd = (bool)(HDstrcmp(env_h5_drvr, "split") != 0 && HDstrcmp(env_h5_drvr, "multi") != 0 &&
-                          HDstrcmp(env_h5_drvr, "direct") != 0);
+    suitable_vfd = (bool)(strcmp(env_h5_drvr, "split") != 0 && strcmp(env_h5_drvr, "multi") != 0 &&
+                          strcmp(env_h5_drvr, "direct") != 0);
     if (suitable_vfd) {
         /* Set the filename to use for this test (dependent on fapl) */
         h5_fixname(FILENAME[0], fapl, filename, sizeof(filename));
@@ -2289,7 +2289,7 @@ test_mf_aggr_alloc1(const char *env_h5_drvr, hid_t fapl)
     } /* end if */
     else {
         SKIPPED();
-        HDputs("    Current VFD doesn't support metadata aggregator");
+        puts("    Current VFD doesn't support metadata aggregator");
     } /* end else */
 
     return (0);
@@ -2345,8 +2345,8 @@ test_mf_aggr_alloc2(const char *env_h5_drvr, hid_t fapl)
     TESTING("H5MF_alloc() of meta/sdata aggregator:test 2");
 
     /* Skip test when using VFDs that don't use the metadata aggregator. Also skip test for Direct VFD. */
-    suitable_vfd = (bool)(HDstrcmp(env_h5_drvr, "split") != 0 && HDstrcmp(env_h5_drvr, "multi") != 0 &&
-                          HDstrcmp(env_h5_drvr, "direct") != 0);
+    suitable_vfd = (bool)(strcmp(env_h5_drvr, "split") != 0 && strcmp(env_h5_drvr, "multi") != 0 &&
+                          strcmp(env_h5_drvr, "direct") != 0);
     if (suitable_vfd) {
         /* Set the filename to use for this test (dependent on fapl) */
         h5_fixname(FILENAME[0], fapl, filename, sizeof(filename));
@@ -2434,7 +2434,7 @@ test_mf_aggr_alloc2(const char *env_h5_drvr, hid_t fapl)
     } /* end if */
     else {
         SKIPPED();
-        HDputs("    Current VFD doesn't support metadata aggregator");
+        puts("    Current VFD doesn't support metadata aggregator");
     } /* end else */
 
     return (0);
@@ -2504,7 +2504,7 @@ test_mf_aggr_alloc3(const char *env_h5_drvr, hid_t fapl)
     TESTING("H5MF_alloc() of meta/sdata aggregator: test 3");
 
     /* Skip test when using VFDs that don't use the metadata aggregator */
-    contig_addr_vfd = (bool)(HDstrcmp(env_h5_drvr, "split") != 0 && HDstrcmp(env_h5_drvr, "multi") != 0);
+    contig_addr_vfd = (bool)(strcmp(env_h5_drvr, "split") != 0 && strcmp(env_h5_drvr, "multi") != 0);
     if (contig_addr_vfd) {
         /* Set the filename to use for this test (dependent on fapl) */
         h5_fixname(FILENAME[0], fapl, filename, sizeof(filename));
@@ -2600,7 +2600,7 @@ test_mf_aggr_alloc3(const char *env_h5_drvr, hid_t fapl)
     } /* end if */
     else {
         SKIPPED();
-        HDputs("    Current VFD doesn't support metadata aggregator");
+        puts("    Current VFD doesn't support metadata aggregator");
     } /* end else */
 
     return (0);
@@ -2672,7 +2672,7 @@ test_mf_aggr_alloc4(const char *env_h5_drvr, hid_t fapl)
     TESTING("H5MF_alloc() of meta/sdata aggregator:test 4");
 
     /* Skip test when using VFDs that don't use the metadata aggregator */
-    contig_addr_vfd = (bool)(HDstrcmp(env_h5_drvr, "split") != 0 && HDstrcmp(env_h5_drvr, "multi") != 0);
+    contig_addr_vfd = (bool)(strcmp(env_h5_drvr, "split") != 0 && strcmp(env_h5_drvr, "multi") != 0);
     if (contig_addr_vfd) {
         /* Set the filename to use for this test (dependent on fapl) */
         h5_fixname(FILENAME[0], fapl, filename, sizeof(filename));
@@ -2768,7 +2768,7 @@ test_mf_aggr_alloc4(const char *env_h5_drvr, hid_t fapl)
     } /* end if */
     else {
         SKIPPED();
-        HDputs("    Current VFD doesn't support metadata aggregator");
+        puts("    Current VFD doesn't support metadata aggregator");
     } /* end else */
 
     return (0);
@@ -2821,7 +2821,7 @@ test_mf_aggr_alloc5(const char *env_h5_drvr, hid_t fapl)
     TESTING("H5MF_alloc() of meta/sdata aggregator:test 5");
 
     /* Skip test when using VFDs that don't use the metadata aggregator */
-    contig_addr_vfd = (bool)(HDstrcmp(env_h5_drvr, "split") != 0 && HDstrcmp(env_h5_drvr, "multi") != 0);
+    contig_addr_vfd = (bool)(strcmp(env_h5_drvr, "split") != 0 && strcmp(env_h5_drvr, "multi") != 0);
     if (contig_addr_vfd) {
         /* Set the filename to use for this test (dependent on fapl) */
         h5_fixname(FILENAME[0], fapl, filename, sizeof(filename));
@@ -2894,7 +2894,7 @@ test_mf_aggr_alloc5(const char *env_h5_drvr, hid_t fapl)
     } /* end if */
     else {
         SKIPPED();
-        HDputs("    Current VFD doesn't support metadata aggregator");
+        puts("    Current VFD doesn't support metadata aggregator");
     } /* end else */
 
     return (0);
@@ -2959,7 +2959,7 @@ test_mf_aggr_alloc6(const char *env_h5_drvr, hid_t fapl)
     TESTING("H5MF_alloc() of meta/sdata aggregator:test 6");
 
     /* Skip test when using VFDs that don't use the metadata aggregator */
-    contig_addr_vfd = (bool)(HDstrcmp(env_h5_drvr, "split") != 0 && HDstrcmp(env_h5_drvr, "multi") != 0);
+    contig_addr_vfd = (bool)(strcmp(env_h5_drvr, "split") != 0 && strcmp(env_h5_drvr, "multi") != 0);
     if (contig_addr_vfd) {
         /* Set the filename to use for this test (dependent on fapl) */
         h5_fixname(FILENAME[0], fapl, filename, sizeof(filename));
@@ -3057,7 +3057,7 @@ test_mf_aggr_alloc6(const char *env_h5_drvr, hid_t fapl)
     } /* end if */
     else {
         SKIPPED();
-        HDputs("    Current VFD doesn't support metadata aggregator");
+        puts("    Current VFD doesn't support metadata aggregator");
     } /* end else */
 
     return (0);
@@ -3133,7 +3133,7 @@ test_mf_aggr_alloc7(const char *env_h5_drvr, hid_t fapl)
     TESTING("H5MF_alloc() of meta/sdata aggregator:test 7");
 
     /* Skip test when using VFDs that don't use the metadata aggregator */
-    contig_addr_vfd = (bool)(HDstrcmp(env_h5_drvr, "split") != 0 && HDstrcmp(env_h5_drvr, "multi") != 0);
+    contig_addr_vfd = (bool)(strcmp(env_h5_drvr, "split") != 0 && strcmp(env_h5_drvr, "multi") != 0);
     if (contig_addr_vfd) {
         /* Set the filename to use for this test (dependent on fapl) */
         h5_fixname(FILENAME[0], fapl, filename, sizeof(filename));
@@ -3249,7 +3249,7 @@ test_mf_aggr_alloc7(const char *env_h5_drvr, hid_t fapl)
     } /* end if */
     else {
         SKIPPED();
-        HDputs("    Current VFD doesn't support metadata aggregator");
+        puts("    Current VFD doesn't support metadata aggregator");
     } /* end else */
 
     return (0);
@@ -3304,7 +3304,7 @@ test_mf_aggr_extend(const char *env_h5_drvr, hid_t fapl)
     TESTING("H5MF_try_extend() of meta/sdata aggregator: test 1");
 
     /* Skip test when using VFDs that don't use the metadata aggregator */
-    contig_addr_vfd = (bool)(HDstrcmp(env_h5_drvr, "split") != 0 && HDstrcmp(env_h5_drvr, "multi") != 0);
+    contig_addr_vfd = (bool)(strcmp(env_h5_drvr, "split") != 0 && strcmp(env_h5_drvr, "multi") != 0);
     if (contig_addr_vfd) {
         /* Set the filename to use for this test (dependent on fapl) */
         h5_fixname(FILENAME[0], fapl, filename, sizeof(filename));
@@ -3408,7 +3408,7 @@ test_mf_aggr_extend(const char *env_h5_drvr, hid_t fapl)
     } /* end if */
     else {
         SKIPPED();
-        HDputs("    Current VFD doesn't support metadata aggregator");
+        puts("    Current VFD doesn't support metadata aggregator");
     } /* end else */
 
     TESTING("H5MF_try_extend() of meta/sdata aggregator: test 2");
@@ -3478,7 +3478,7 @@ test_mf_aggr_extend(const char *env_h5_drvr, hid_t fapl)
     } /* end if */
     else {
         SKIPPED();
-        HDputs("    Current VFD doesn't support metadata aggregator");
+        puts("    Current VFD doesn't support metadata aggregator");
     } /* end else */
 
     TESTING("H5MF_try_extend() of meta/sdata aggregator: test 3");
@@ -3548,7 +3548,7 @@ test_mf_aggr_extend(const char *env_h5_drvr, hid_t fapl)
     } /* end if */
     else {
         SKIPPED();
-        HDputs("    Current VFD doesn't support metadata aggregator");
+        puts("    Current VFD doesn't support metadata aggregator");
     } /* end else */
 
     return (0);
@@ -3602,7 +3602,7 @@ test_mf_aggr_absorb(const char *env_h5_drvr, hid_t fapl)
     TESTING("H5MF_try_shrink() of meta/sdata aggregator: test 1");
 
     /* Skip test when using VFDs that don't use the metadata aggregator */
-    contig_addr_vfd = (bool)(HDstrcmp(env_h5_drvr, "split") != 0 && HDstrcmp(env_h5_drvr, "multi") != 0);
+    contig_addr_vfd = (bool)(strcmp(env_h5_drvr, "split") != 0 && strcmp(env_h5_drvr, "multi") != 0);
     if (contig_addr_vfd) {
         /* Set the filename to use for this test (dependent on fapl) */
         h5_fixname(FILENAME[0], fapl, filename, sizeof(filename));
@@ -3660,7 +3660,7 @@ test_mf_aggr_absorb(const char *env_h5_drvr, hid_t fapl)
     } /* end if */
     else {
         SKIPPED();
-        HDputs("    Current VFD doesn't support metadata aggregator");
+        puts("    Current VFD doesn't support metadata aggregator");
     } /* end else */
 
     TESTING("H5MF_try_shrink() of meta/sdata aggregator: test 2");
@@ -3725,7 +3725,7 @@ test_mf_aggr_absorb(const char *env_h5_drvr, hid_t fapl)
     } /* end if */
     else {
         SKIPPED();
-        HDputs("    Current VFD doesn't support metadata aggregator");
+        puts("    Current VFD doesn't support metadata aggregator");
     } /* end else */
 
     TESTING("H5MF_try_shrink() of meta/sdata aggregator: test 3");
@@ -3788,7 +3788,7 @@ test_mf_aggr_absorb(const char *env_h5_drvr, hid_t fapl)
     } /* end if */
     else {
         SKIPPED();
-        HDputs("    Current VFD doesn't support metadata aggregator");
+        puts("    Current VFD doesn't support metadata aggregator");
     } /* end else */
 
     return (0);
@@ -3857,8 +3857,8 @@ test_mf_align_eoa(const char *env_h5_drvr, hid_t fapl, hid_t new_fapl)
      *  don't push mis-aligned space fragments on the file free space list.
      *  Also skip test for Direct VFD.
      */
-    suitable_vfd = (bool)(HDstrcmp(env_h5_drvr, "stdio") != 0 && HDstrcmp(env_h5_drvr, "split") != 0 &&
-                          HDstrcmp(env_h5_drvr, "multi") != 0 && HDstrcmp(env_h5_drvr, "direct") != 0);
+    suitable_vfd = (bool)(strcmp(env_h5_drvr, "stdio") != 0 && strcmp(env_h5_drvr, "split") != 0 &&
+                          strcmp(env_h5_drvr, "multi") != 0 && strcmp(env_h5_drvr, "direct") != 0);
     if (suitable_vfd) {
         /* Set the filename to use for this test (dependent on fapl) */
         h5_fixname(FILENAME[0], fapl, filename, sizeof(filename));
@@ -3963,7 +3963,7 @@ test_mf_align_eoa(const char *env_h5_drvr, hid_t fapl, hid_t new_fapl)
     } /* end if */
     else {
         SKIPPED();
-        HDputs("    Current VFD doesn't support mis-aligned fragments");
+        puts("    Current VFD doesn't support mis-aligned fragments");
     } /* end else */
 
     TESTING("H5MF_try_shrink() of file allocation with alignment: test 2");
@@ -4021,7 +4021,7 @@ test_mf_align_eoa(const char *env_h5_drvr, hid_t fapl, hid_t new_fapl)
     } /* end if */
     else {
         SKIPPED();
-        HDputs("    Current VFD doesn't support mis-aligned fragments");
+        puts("    Current VFD doesn't support mis-aligned fragments");
     } /* end else */
 
     TESTING("H5MF_try_extend() of file allocation with alignment: test 3");
@@ -4082,7 +4082,7 @@ test_mf_align_eoa(const char *env_h5_drvr, hid_t fapl, hid_t new_fapl)
     } /* end if */
     else {
         SKIPPED();
-        HDputs("    Current VFD doesn't support mis-aligned fragments");
+        puts("    Current VFD doesn't support mis-aligned fragments");
     } /* end else */
 
     if (fapl1 >= 0 && H5Pclose(fapl1) < 0)
@@ -4307,8 +4307,8 @@ test_mf_align_fs(const char *env_h5_drvr, hid_t fapl, hid_t new_fapl)
      *  don't push mis-aligned space fragments on the file free space list
      *  Also skip test for Direct VFD.
      */
-    suitable_vfd = (bool)(HDstrcmp(env_h5_drvr, "stdio") != 0 && HDstrcmp(env_h5_drvr, "split") != 0 &&
-                          HDstrcmp(env_h5_drvr, "multi") != 0 && HDstrcmp(env_h5_drvr, "direct") != 0);
+    suitable_vfd = (bool)(strcmp(env_h5_drvr, "stdio") != 0 && strcmp(env_h5_drvr, "split") != 0 &&
+                          strcmp(env_h5_drvr, "multi") != 0 && strcmp(env_h5_drvr, "direct") != 0);
     if (suitable_vfd) {
         if ((file_size = h5_get_file_size(filename, new_fapl)) < 0)
             TEST_ERROR;
@@ -4380,7 +4380,7 @@ test_mf_align_fs(const char *env_h5_drvr, hid_t fapl, hid_t new_fapl)
     } /* end if */
     else {
         SKIPPED();
-        HDputs("    Current VFD doesn't support mis-aligned fragments");
+        puts("    Current VFD doesn't support mis-aligned fragments");
     } /* end else */
 
     return (0);
@@ -4514,8 +4514,8 @@ test_mf_align_alloc1(const char *env_h5_drvr, hid_t fapl, hid_t new_fapl)
      *  don't push mis-aligned space fragments on the file free space list.
      *  Also skip test for Direct VFD.
      */
-    suitable_vfd = (bool)(HDstrcmp(env_h5_drvr, "stdio") != 0 && HDstrcmp(env_h5_drvr, "split") != 0 &&
-                          HDstrcmp(env_h5_drvr, "multi") != 0 && HDstrcmp(env_h5_drvr, "direct") != 0);
+    suitable_vfd = (bool)(strcmp(env_h5_drvr, "stdio") != 0 && strcmp(env_h5_drvr, "split") != 0 &&
+                          strcmp(env_h5_drvr, "multi") != 0 && strcmp(env_h5_drvr, "direct") != 0);
     if (suitable_vfd) {
         /* Set the filename to use for this test (dependent on fapl) */
         h5_fixname(FILENAME[0], fapl, filename, sizeof(filename));
@@ -4656,7 +4656,7 @@ test_mf_align_alloc1(const char *env_h5_drvr, hid_t fapl, hid_t new_fapl)
     } /* end if */
     else {
         SKIPPED();
-        HDputs("    Current VFD doesn't support mis-aligned fragments");
+        puts("    Current VFD doesn't support mis-aligned fragments");
     } /* end else */
 
     return (0);
@@ -4777,8 +4777,8 @@ test_mf_align_alloc2(const char *env_h5_drvr, hid_t fapl, hid_t new_fapl)
      *  don't push mis-aligned space fragments on the file free space list.
      *  Also skip test for Direct VFD.
      */
-    suitable_vfd = (bool)(HDstrcmp(env_h5_drvr, "stdio") != 0 && HDstrcmp(env_h5_drvr, "split") != 0 &&
-                          HDstrcmp(env_h5_drvr, "multi") != 0 && HDstrcmp(env_h5_drvr, "direct") != 0);
+    suitable_vfd = (bool)(strcmp(env_h5_drvr, "stdio") != 0 && strcmp(env_h5_drvr, "split") != 0 &&
+                          strcmp(env_h5_drvr, "multi") != 0 && strcmp(env_h5_drvr, "direct") != 0);
     if (suitable_vfd) {
         /* Set the filename to use for this test (dependent on fapl) */
         h5_fixname(FILENAME[0], fapl, filename, sizeof(filename));
@@ -4950,7 +4950,7 @@ test_mf_align_alloc2(const char *env_h5_drvr, hid_t fapl, hid_t new_fapl)
     } /* end if */
     else {
         SKIPPED();
-        HDputs("    Current VFD doesn't support mis-aligned fragments");
+        puts("    Current VFD doesn't support mis-aligned fragments");
     } /* end else */
 
     return (0);
@@ -5123,8 +5123,8 @@ test_mf_align_alloc3(const char *env_h5_drvr, hid_t fapl, hid_t new_fapl)
      *  don't push mis-aligned space fragments on the file free space list.
      *  Also skip test for Direct VFD.
      */
-    suitable_vfd = (bool)(HDstrcmp(env_h5_drvr, "stdio") != 0 && HDstrcmp(env_h5_drvr, "split") != 0 &&
-                          HDstrcmp(env_h5_drvr, "multi") != 0 && HDstrcmp(env_h5_drvr, "direct") != 0);
+    suitable_vfd = (bool)(strcmp(env_h5_drvr, "stdio") != 0 && strcmp(env_h5_drvr, "split") != 0 &&
+                          strcmp(env_h5_drvr, "multi") != 0 && strcmp(env_h5_drvr, "direct") != 0);
     if (suitable_vfd) {
         /* Set the filename to use for this test (dependent on fapl) */
         h5_fixname(FILENAME[0], fapl, filename, sizeof(filename));
@@ -5336,7 +5336,7 @@ test_mf_align_alloc3(const char *env_h5_drvr, hid_t fapl, hid_t new_fapl)
     } /* end if */
     else {
         SKIPPED();
-        HDputs("    Current VFD doesn't support mis-aligned fragments");
+        puts("    Current VFD doesn't support mis-aligned fragments");
     } /* end else */
 
     return (0);
@@ -5437,8 +5437,8 @@ test_mf_align_alloc4(const char *env_h5_drvr, hid_t fapl, hid_t new_fapl)
      *  don't push mis-aligned space fragments on the file free space list.
      *  Also skip test for Direct VFD.
      */
-    suitable_vfd = (bool)(HDstrcmp(env_h5_drvr, "stdio") != 0 && HDstrcmp(env_h5_drvr, "split") != 0 &&
-                          HDstrcmp(env_h5_drvr, "multi") != 0 && HDstrcmp(env_h5_drvr, "direct") != 0);
+    suitable_vfd = (bool)(strcmp(env_h5_drvr, "stdio") != 0 && strcmp(env_h5_drvr, "split") != 0 &&
+                          strcmp(env_h5_drvr, "multi") != 0 && strcmp(env_h5_drvr, "direct") != 0);
     if (suitable_vfd) {
         /* Set the filename to use for this test (dependent on fapl) */
         h5_fixname(FILENAME[0], fapl, filename, sizeof(filename));
@@ -5552,7 +5552,7 @@ test_mf_align_alloc4(const char *env_h5_drvr, hid_t fapl, hid_t new_fapl)
     } /* end if */
     else {
         SKIPPED();
-        HDputs("    Current VFD doesn't support mis-aligned fragments");
+        puts("    Current VFD doesn't support mis-aligned fragments");
     } /* end else */
 
     return (0);
@@ -5656,8 +5656,8 @@ test_mf_align_alloc5(const char *env_h5_drvr, hid_t fapl, hid_t new_fapl)
      *  don't push mis-aligned space fragments on the file free space list.
      *  Also skip test for Direct VFD.
      */
-    suitable_vfd = (bool)(HDstrcmp(env_h5_drvr, "stdio") != 0 && HDstrcmp(env_h5_drvr, "split") != 0 &&
-                          HDstrcmp(env_h5_drvr, "multi") != 0 && HDstrcmp(env_h5_drvr, "direct") != 0);
+    suitable_vfd = (bool)(strcmp(env_h5_drvr, "stdio") != 0 && strcmp(env_h5_drvr, "split") != 0 &&
+                          strcmp(env_h5_drvr, "multi") != 0 && strcmp(env_h5_drvr, "direct") != 0);
     if (suitable_vfd) {
         /* Set the filename to use for this test (dependent on fapl) */
         h5_fixname(FILENAME[0], fapl, filename, sizeof(filename));
@@ -5782,7 +5782,7 @@ test_mf_align_alloc5(const char *env_h5_drvr, hid_t fapl, hid_t new_fapl)
     } /* end if */
     else {
         SKIPPED();
-        HDputs("    Current VFD doesn't support mis-aligned fragments");
+        puts("    Current VFD doesn't support mis-aligned fragments");
     } /* end else */
 
     return (0);
@@ -5927,8 +5927,8 @@ test_mf_align_alloc6(const char *env_h5_drvr, hid_t fapl, hid_t new_fapl)
      *  don't push mis-aligned space fragments on the file free space list.
      *  Also skip test for Direct VFD.
      */
-    suitable_vfd = (bool)(HDstrcmp(env_h5_drvr, "stdio") != 0 && HDstrcmp(env_h5_drvr, "split") != 0 &&
-                          HDstrcmp(env_h5_drvr, "multi") != 0 && HDstrcmp(env_h5_drvr, "direct") != 0);
+    suitable_vfd = (bool)(strcmp(env_h5_drvr, "stdio") != 0 && strcmp(env_h5_drvr, "split") != 0 &&
+                          strcmp(env_h5_drvr, "multi") != 0 && strcmp(env_h5_drvr, "direct") != 0);
     if (suitable_vfd) {
         /* Set the filename to use for this test (dependent on fapl) */
         h5_fixname(FILENAME[0], fapl, filename, sizeof(filename));
@@ -6097,7 +6097,7 @@ test_mf_align_alloc6(const char *env_h5_drvr, hid_t fapl, hid_t new_fapl)
     } /* end if */
     else {
         SKIPPED();
-        HDputs("    Current VFD doesn't support mis-aligned fragments");
+        puts("    Current VFD doesn't support mis-aligned fragments");
     } /* end else */
 
     return 0;
@@ -6147,9 +6147,9 @@ test_mf_bug1(const char *env_h5_drvr, hid_t fapl)
         TEST_ERROR;
 
     /* Check for split or multi driver */
-    if (!HDstrcmp(env_h5_drvr, "split"))
+    if (!strcmp(env_h5_drvr, "split"))
         split = true;
-    else if (!HDstrcmp(env_h5_drvr, "multi"))
+    else if (!strcmp(env_h5_drvr, "multi"))
         multi = true;
 
     /* Add alignment to member files for split/multi driver */
@@ -6583,22 +6583,22 @@ error:
         memb_map[H5FD_MEM_DRAW]  = H5FD_MEM_DRAW;                                                            \
         memb_map[H5FD_MEM_GHEAP] = H5FD_MEM_GHEAP;                                                           \
         memb_map[H5FD_MEM_LHEAP] = H5FD_MEM_LHEAP;                                                           \
-        HDsnprintf(sv[H5FD_MEM_SUPER], 64, "%%s-%c.h5", 's');                                                \
+        snprintf(sv[H5FD_MEM_SUPER], 64, "%%s-%c.h5", 's');                                                  \
         memb_name[H5FD_MEM_SUPER] = sv[H5FD_MEM_SUPER];                                                      \
         memb_addr[H5FD_MEM_SUPER] = 0;                                                                       \
-        HDsnprintf(sv[H5FD_MEM_BTREE], 64, "%%s-%c.h5", 'b');                                                \
+        snprintf(sv[H5FD_MEM_BTREE], 64, "%%s-%c.h5", 'b');                                                  \
         memb_name[H5FD_MEM_BTREE] = sv[H5FD_MEM_BTREE];                                                      \
         memb_addr[H5FD_MEM_BTREE] = HADDR_MAX / 6;                                                           \
-        HDsnprintf(sv[H5FD_MEM_DRAW], 64, "%%s-%c.h5", 'r');                                                 \
+        snprintf(sv[H5FD_MEM_DRAW], 64, "%%s-%c.h5", 'r');                                                   \
         memb_name[H5FD_MEM_DRAW] = sv[H5FD_MEM_DRAW];                                                        \
         memb_addr[H5FD_MEM_DRAW] = HADDR_MAX / 3;                                                            \
-        HDsnprintf(sv[H5FD_MEM_GHEAP], 64, "%%s-%c.h5", 'g');                                                \
+        snprintf(sv[H5FD_MEM_GHEAP], 64, "%%s-%c.h5", 'g');                                                  \
         memb_name[H5FD_MEM_GHEAP] = sv[H5FD_MEM_GHEAP];                                                      \
         memb_addr[H5FD_MEM_GHEAP] = HADDR_MAX / 2;                                                           \
-        HDsnprintf(sv[H5FD_MEM_LHEAP], 64, "%%s-%c.h5", 'l');                                                \
+        snprintf(sv[H5FD_MEM_LHEAP], 64, "%%s-%c.h5", 'l');                                                  \
         memb_name[H5FD_MEM_LHEAP] = sv[H5FD_MEM_LHEAP];                                                      \
         memb_addr[H5FD_MEM_LHEAP] = HADDR_MAX * 2 / 3;                                                       \
-        HDsnprintf(sv[H5FD_MEM_OHDR], 64, "%%s-%c.h5", 'o');                                                 \
+        snprintf(sv[H5FD_MEM_OHDR], 64, "%%s-%c.h5", 'o');                                                   \
         memb_name[H5FD_MEM_OHDR] = sv[H5FD_MEM_OHDR];                                                        \
         memb_addr[H5FD_MEM_OHDR] = HADDR_MAX * 5 / 6;                                                        \
     }
@@ -6949,7 +6949,7 @@ test_mf_fs_persist(const char *env_h5_drvr, hid_t fapl, bool new_format)
     else
         TESTING("File's free-space is persistent with old library format");
 
-    if (HDstrcmp(env_h5_drvr, "split") != 0 && HDstrcmp(env_h5_drvr, "multi") != 0) {
+    if (strcmp(env_h5_drvr, "split") != 0 && strcmp(env_h5_drvr, "multi") != 0) {
 
         /* File creation property list template */
         if ((fcpl = H5Pcreate(H5P_FILE_CREATE)) < 0)
@@ -7084,7 +7084,7 @@ test_mf_fs_persist(const char *env_h5_drvr, hid_t fapl, bool new_format)
     }
     else {
         SKIPPED();
-        HDputs("    Current VFD doesn't support persisting free-space or paged aggregation strategy");
+        puts("    Current VFD doesn't support persisting free-space or paged aggregation strategy");
     }
 
     return (0);
@@ -7126,7 +7126,7 @@ test_mf_fs_gone(const char *env_h5_drvr, hid_t fapl, bool new_format)
         TESTING("File's free-space is going away with old library format");
 
     /* Current VFD that does not support contiguous address space */
-    contig_addr_vfd = (bool)(HDstrcmp(env_h5_drvr, "split") != 0 && HDstrcmp(env_h5_drvr, "multi") != 0);
+    contig_addr_vfd = (bool)(strcmp(env_h5_drvr, "split") != 0 && strcmp(env_h5_drvr, "multi") != 0);
 
     if (contig_addr_vfd) {
 
@@ -7273,7 +7273,7 @@ test_mf_fs_gone(const char *env_h5_drvr, hid_t fapl, bool new_format)
     }
     else {
         SKIPPED();
-        HDputs("    Current VFD doesn't support persistent free-space manager");
+        puts("    Current VFD doesn't support persistent free-space manager");
     }
 
     return (0);
@@ -7317,7 +7317,7 @@ test_mf_strat_thres_persist(const char *env_h5_drvr, hid_t fapl, bool new_format
         TESTING("File space strategy/persisting/threshold with old library format");
 
     /* Current VFD that does not support contiguous address space */
-    contig_addr_vfd = (bool)(HDstrcmp(env_h5_drvr, "split") != 0 && HDstrcmp(env_h5_drvr, "multi") != 0);
+    contig_addr_vfd = (bool)(strcmp(env_h5_drvr, "split") != 0 && strcmp(env_h5_drvr, "multi") != 0);
 
     /* Set the filename to use for this test (dependent on fapl) */
     h5_fixname(FILENAME[0], fapl, filename, sizeof(filename));
@@ -7487,7 +7487,7 @@ test_mf_strat_thres_gone(const char *env_h5_drvr, hid_t fapl, bool new_format)
         TESTING("File space merge/shrink for section size < threshold with old library format");
 
     /* Current VFD that does not support contiguous address space */
-    contig_addr_vfd = (bool)(HDstrcmp(env_h5_drvr, "split") != 0 && HDstrcmp(env_h5_drvr, "multi") != 0);
+    contig_addr_vfd = (bool)(strcmp(env_h5_drvr, "split") != 0 && strcmp(env_h5_drvr, "multi") != 0);
 
     /* Set the filename to use for this test (dependent on fapl) */
     h5_fixname(FILENAME[0], fapl, filename, sizeof(filename));
@@ -7819,9 +7819,9 @@ test_page_alloc_xfree(const char *env_h5_drvr, hid_t fapl)
     TESTING("Paged aggregation for file space: H5MF_alloc/H5MF_xfree");
 
     /* Check for split or multi driver */
-    if (!HDstrcmp(env_h5_drvr, "split"))
+    if (!strcmp(env_h5_drvr, "split"))
         split = true;
-    else if (!HDstrcmp(env_h5_drvr, "multi"))
+    else if (!strcmp(env_h5_drvr, "multi"))
         multi = true;
 
     if (!multi && !split) {
@@ -8002,7 +8002,7 @@ test_page_alloc_xfree(const char *env_h5_drvr, hid_t fapl)
     }
     else {
         SKIPPED();
-        HDputs("    Current VFD doesn't support persisting free-space or paged aggregation strategy");
+        puts("    Current VFD doesn't support persisting free-space or paged aggregation strategy");
     }
 
     return (0);
@@ -8048,7 +8048,7 @@ test_page_try_shrink(const char *env_h5_drvr, hid_t fapl)
     TESTING("Paged aggregation for file space: H5MF_try_shrink()");
 
     /* Current VFD that does not support continuous address space */
-    contig_addr_vfd = (bool)(HDstrcmp(env_h5_drvr, "split") != 0 && HDstrcmp(env_h5_drvr, "multi") != 0);
+    contig_addr_vfd = (bool)(strcmp(env_h5_drvr, "split") != 0 && strcmp(env_h5_drvr, "multi") != 0);
 
     if (contig_addr_vfd) {
 
@@ -8132,7 +8132,7 @@ test_page_try_shrink(const char *env_h5_drvr, hid_t fapl)
     }
     else {
         SKIPPED();
-        HDputs("    Current VFD doesn't support paged aggregation");
+        puts("    Current VFD doesn't support paged aggregation");
     }
 
     return (0);
@@ -8175,8 +8175,8 @@ test_page_small_try_extend(const char *env_h5_drvr, hid_t fapl)
     TESTING("Paged aggregation for file space: H5MF_try_extend() a small block");
 
     /* Current VFD that does not support continuous address space */
-    contig_addr_vfd = (bool)(HDstrcmp(env_h5_drvr, "split") != 0 && HDstrcmp(env_h5_drvr, "multi") != 0 &&
-                             HDstrcmp(env_h5_drvr, "family") != 0);
+    contig_addr_vfd = (bool)(strcmp(env_h5_drvr, "split") != 0 && strcmp(env_h5_drvr, "multi") != 0 &&
+                             strcmp(env_h5_drvr, "family") != 0);
 
     if (contig_addr_vfd) {
 
@@ -8310,7 +8310,7 @@ test_page_small_try_extend(const char *env_h5_drvr, hid_t fapl)
     }
     else {
         SKIPPED();
-        HDputs("    Current VFD doesn't support paged aggregation");
+        puts("    Current VFD doesn't support paged aggregation");
     }
 
     return (0);
@@ -8352,7 +8352,7 @@ test_page_large_try_extend(const char *env_h5_drvr, hid_t fapl)
     TESTING("Paged aggregation for file space: H5MF_try_extend() a large block");
 
     /* Current VFD that does not support continuous address space */
-    contig_addr_vfd = (bool)(HDstrcmp(env_h5_drvr, "split") != 0 && HDstrcmp(env_h5_drvr, "multi") != 0);
+    contig_addr_vfd = (bool)(strcmp(env_h5_drvr, "split") != 0 && strcmp(env_h5_drvr, "multi") != 0);
 
     if (contig_addr_vfd) {
 
@@ -8471,7 +8471,7 @@ test_page_large_try_extend(const char *env_h5_drvr, hid_t fapl)
     }
     else {
         SKIPPED();
-        HDputs("    Current VFD doesn't support paged aggregation strategy");
+        puts("    Current VFD doesn't support paged aggregation strategy");
     }
 
     return (0);
@@ -8514,7 +8514,7 @@ test_page_large(const char *env_h5_drvr, hid_t fapl)
     TESTING("Paged aggregation for file space: large allocations and de-allocations");
 
     /* Current VFD that does not support continuous address space */
-    contig_addr_vfd = (bool)(HDstrcmp(env_h5_drvr, "split") != 0 && HDstrcmp(env_h5_drvr, "multi") != 0);
+    contig_addr_vfd = (bool)(strcmp(env_h5_drvr, "split") != 0 && strcmp(env_h5_drvr, "multi") != 0);
 
     if (contig_addr_vfd) {
 
@@ -8625,7 +8625,7 @@ test_page_large(const char *env_h5_drvr, hid_t fapl)
     }
     else {
         SKIPPED();
-        HDputs("    Current VFD doesn't support paged aggregation strategy");
+        puts("    Current VFD doesn't support paged aggregation strategy");
     }
 
     return (0);
@@ -8666,11 +8666,11 @@ test_page_small(const char *env_h5_drvr, hid_t fapl)
 
     TESTING("Paged aggregation for file space: small allocations and de-allocations");
 
-    if (!HDstrcmp(env_h5_drvr, "split"))
+    if (!strcmp(env_h5_drvr, "split"))
         split = true;
-    else if (!HDstrcmp(env_h5_drvr, "multi"))
+    else if (!strcmp(env_h5_drvr, "multi"))
         multi = true;
-    else if (!HDstrcmp(env_h5_drvr, "family"))
+    else if (!strcmp(env_h5_drvr, "family"))
         family = true;
 
     if (!multi && !split) {
@@ -8794,7 +8794,7 @@ test_page_small(const char *env_h5_drvr, hid_t fapl)
     }
     else {
         SKIPPED();
-        HDputs("    Current VFD doesn't support paged aggregation strategy");
+        puts("    Current VFD doesn't support paged aggregation strategy");
     }
 
     return (0);
@@ -8839,9 +8839,9 @@ test_page_alignment(const char *env_h5_drvr, hid_t fapl)
     TESTING("Paged aggregation and H5Pset_alignment: verify proper alignment is used");
 
     /* Check for split or multi driver */
-    if (!HDstrcmp(env_h5_drvr, "split"))
+    if (!strcmp(env_h5_drvr, "split"))
         split = true;
-    else if (!HDstrcmp(env_h5_drvr, "multi"))
+    else if (!strcmp(env_h5_drvr, "multi"))
         multi = true;
 
     if (!multi && !split) {
@@ -9106,7 +9106,7 @@ test_page_alignment(const char *env_h5_drvr, hid_t fapl)
     }
     else {
         SKIPPED();
-        HDputs("    Current VFD doesn't support persisting free-space or paged aggregation strategy");
+        puts("    Current VFD doesn't support persisting free-space or paged aggregation strategy");
     }
 
     return (0);
@@ -9268,12 +9268,12 @@ main(void)
 
     if (nerrors)
         goto error;
-    HDputs("All free-space manager tests for file memory passed.");
+    puts("All free-space manager tests for file memory passed.");
 
     return (0);
 
 error:
-    HDputs("*** TESTS FAILED ***");
+    puts("*** TESTS FAILED ***");
     H5E_BEGIN_TRY
     {
         H5Pclose(fapl);

--- a/test/mirror_vfd.c
+++ b/test/mirror_vfd.c
@@ -143,9 +143,9 @@ populate_filepath(const char *dirname, const char *basename, hid_t fapl_id, char
     if (NULL == (path = calloc(H5FD_SPLITTER_PATH_MAX, sizeof(char))))
         TEST_ERROR;
 
-    if (HDsnprintf(path, H5FD_SPLITTER_PATH_MAX, "%s%s%s", dirname,
-                   (dirname[HDstrlen(dirname)] == '/') ? "" : "/", /* slash iff needed */
-                   basename) > H5FD_SPLITTER_PATH_MAX)
+    if (snprintf(path, H5FD_SPLITTER_PATH_MAX, "%s%s%s", dirname,
+                 (dirname[strlen(dirname)] == '/') ? "" : "/", /* slash iff needed */
+                 basename) > H5FD_SPLITTER_PATH_MAX)
         TEST_ERROR;
 
     if (h5suffix == true) {
@@ -192,7 +192,7 @@ build_paths(const char *basename, H5FD_splitter_vfd_config_t *splitter_config,
 
     if (basename == NULL || *basename == 0)
         TEST_ERROR;
-    if (HDsnprintf(baselogname, H5FD_SPLITTER_PATH_MAX, "%s_err.log", basename) > H5FD_SPLITTER_PATH_MAX)
+    if (snprintf(baselogname, H5FD_SPLITTER_PATH_MAX, "%s_err.log", basename) > H5FD_SPLITTER_PATH_MAX)
         TEST_ERROR;
 
     if (populate_filepath(MIRROR_WO_DIR, baselogname, splitter_config->wo_fapl_id, names->log, false) < 0)
@@ -248,7 +248,7 @@ test_fapl_configuration(void)
     if (SERVER_HANDSHAKE_PORT != fa_out.handshake_port)
         TEST_ERROR;
 
-    if (HDstrncmp(SERVER_IP_ADDRESS, (const char *)fa_out.remote_ip, H5FD_MIRROR_MAX_IP_LEN))
+    if (strncmp(SERVER_IP_ADDRESS, (const char *)fa_out.remote_ip, H5FD_MIRROR_MAX_IP_LEN))
         TEST_ERROR;
 
     if (H5Pclose(fapl_id) < 0)
@@ -936,7 +936,7 @@ test_encdec_open(H5FD_mirror_xmit_t xmit_mock)
         TEST_ERROR;
     if (xmit_out->size_t_blob != xmit_in->size_t_blob)
         TEST_ERROR;
-    if (HDstrncmp(xmit_out->filename, xmit_in->filename, H5FD_MIRROR_XMIT_FILEPATH_MAX) != 0) {
+    if (strncmp(xmit_out->filename, xmit_in->filename, H5FD_MIRROR_XMIT_FILEPATH_MAX) != 0) {
         PRINT_BUFFER_DIFF(xmit_out->filename, xmit_in->filename, H5FD_MIRROR_XMIT_FILEPATH_MAX);
         TEST_ERROR;
     }
@@ -965,7 +965,7 @@ test_encdec_open(H5FD_mirror_xmit_t xmit_mock)
     /* Update expected "filepath" in structure */
     for (size_t i = 0x20; i < H5FD_MIRROR_XMIT_FILEPATH_MAX + 0x20; i++)
         xmit_in->filename[i - 0x20] = (i > 0xFF) ? 0 : (char)i;
-    if (HDstrncmp(xmit_out->filename, xmit_in->filename, H5FD_MIRROR_XMIT_FILEPATH_MAX) != 0) {
+    if (strncmp(xmit_out->filename, xmit_in->filename, H5FD_MIRROR_XMIT_FILEPATH_MAX) != 0) {
         PRINT_BUFFER_DIFF(xmit_out->filename, xmit_in->filename, H5FD_MIRROR_XMIT_FILEPATH_MAX);
         TEST_ERROR;
     }
@@ -1056,7 +1056,7 @@ test_encdec_reply(H5FD_mirror_xmit_t xmit_mock)
         TEST_ERROR;
     if (xmit_out.status != xmit_in.status)
         TEST_ERROR;
-    if (HDstrncmp(xmit_out.message, xmit_in.message, H5FD_MIRROR_STATUS_MESSAGE_MAX) != 0) {
+    if (strncmp(xmit_out.message, xmit_in.message, H5FD_MIRROR_STATUS_MESSAGE_MAX) != 0) {
         PRINT_BUFFER_DIFF(xmit_out.message, xmit_in.message, H5FD_MIRROR_STATUS_MESSAGE_MAX);
         TEST_ERROR;
     }
@@ -1081,7 +1081,7 @@ test_encdec_reply(H5FD_mirror_xmit_t xmit_mock)
     /* Update expected "message" in structure */
     for (i = 0x10; i < H5FD_MIRROR_STATUS_MESSAGE_MAX + 0x10; i++)
         xmit_in.message[i - 0x10] = (i > 0xFF) ? 0 : (char)i;
-    if (HDstrncmp(xmit_out.message, xmit_in.message, H5FD_MIRROR_STATUS_MESSAGE_MAX) != 0) {
+    if (strncmp(xmit_out.message, xmit_in.message, H5FD_MIRROR_STATUS_MESSAGE_MAX) != 0) {
         PRINT_BUFFER_DIFF(xmit_out.message, xmit_in.message, H5FD_MIRROR_STATUS_MESSAGE_MAX);
         TEST_ERROR;
     }
@@ -1234,7 +1234,7 @@ create_mirroring_split_fapl(const char *basename, struct mirrortest_filenames *n
     mirror_conf.magic          = H5FD_MIRROR_FAPL_MAGIC;
     mirror_conf.version        = H5FD_MIRROR_CURR_FAPL_T_VERSION;
     mirror_conf.handshake_port = opts->portno;
-    if (HDstrncpy(mirror_conf.remote_ip, opts->ip, H5FD_MIRROR_MAX_IP_LEN) == NULL)
+    if (strncpy(mirror_conf.remote_ip, opts->ip, H5FD_MIRROR_MAX_IP_LEN) == NULL)
         TEST_ERROR;
     if ((splitter_config->wo_fapl_id = H5Pcreate(H5P_FILE_ACCESS)) < 0)
         TEST_ERROR;
@@ -1246,9 +1246,9 @@ create_mirroring_split_fapl(const char *basename, struct mirrortest_filenames *n
         TEST_ERROR;
 
     /* Set file paths for w/o and logfile */
-    if (HDstrncpy(splitter_config->wo_path, (const char *)names->wo, H5FD_SPLITTER_PATH_MAX) == NULL)
+    if (strncpy(splitter_config->wo_path, (const char *)names->wo, H5FD_SPLITTER_PATH_MAX) == NULL)
         TEST_ERROR;
-    if (HDstrncpy(splitter_config->log_file_path, (const char *)names->log, H5FD_SPLITTER_PATH_MAX) == NULL)
+    if (strncpy(splitter_config->log_file_path, (const char *)names->log, H5FD_SPLITTER_PATH_MAX) == NULL)
         TEST_ERROR;
 
     /* Create Splitter FAPL */
@@ -1452,21 +1452,21 @@ _create_chunking_ids(hid_t file_id, unsigned min_dset, unsigned max_dset, hsize_
     /* Create dataspace IDs */
     for (unsigned m = min_dset; m <= max_dset; m++) {
         if ((dataspace_ids[m] = H5Screate_simple(2, dset_dims, NULL)) < 0) {
-            HDsnprintf(mesg, MIRR_MESG_SIZE, "unable to create dataspace ID %d\n", m);
+            snprintf(mesg, MIRR_MESG_SIZE, "unable to create dataspace ID %d\n", m);
             FAIL_PUTS_ERROR(mesg);
         }
     }
 
     /* Create dataset IDs */
     for (unsigned m = min_dset; m <= max_dset; m++) {
-        if (HDsnprintf(dset_name, DSET_NAME_LEN, "/dset%03d", m) > DSET_NAME_LEN) {
-            HDsnprintf(mesg, MIRR_MESG_SIZE, "unable to compose dset name %d\n", m);
+        if (snprintf(dset_name, DSET_NAME_LEN, "/dset%03d", m) > DSET_NAME_LEN) {
+            snprintf(mesg, MIRR_MESG_SIZE, "unable to compose dset name %d\n", m);
             FAIL_PUTS_ERROR(mesg);
         }
 
         if ((dataset_ids[m] = H5Dcreate2(file_id, dset_name, H5T_STD_I32BE, dataspace_ids[m], H5P_DEFAULT,
                                          dcpl_id, H5P_DEFAULT)) < 0) {
-            HDsnprintf(mesg, MIRR_MESG_SIZE, "unable to create dset ID %d\n", m);
+            snprintf(mesg, MIRR_MESG_SIZE, "unable to create dset ID %d\n", m);
             FAIL_PUTS_ERROR(mesg);
         }
     }
@@ -1474,7 +1474,7 @@ _create_chunking_ids(hid_t file_id, unsigned min_dset, unsigned max_dset, hsize_
     /* Get file space IDs */
     for (unsigned m = min_dset; m <= max_dset; m++) {
         if ((filespace_ids[m] = H5Dget_space(dataset_ids[m])) < 0) {
-            HDsnprintf(mesg, MIRR_MESG_SIZE, "unable to create filespace ID %d\n", m);
+            snprintf(mesg, MIRR_MESG_SIZE, "unable to create filespace ID %d\n", m);
             FAIL_PUTS_ERROR(mesg);
         }
     }
@@ -1522,13 +1522,13 @@ _open_chunking_ids(hid_t file_id, unsigned min_dset, unsigned max_dset, hsize_t 
 
     /* Open dataset IDs */
     for (unsigned m = min_dset; m <= max_dset; m++) {
-        if (HDsnprintf(dset_name, DSET_NAME_LEN, "/dset%03d", m) > DSET_NAME_LEN) {
-            HDsnprintf(mesg, MIRR_MESG_SIZE, "unable to compose dset name %d\n", m);
+        if (snprintf(dset_name, DSET_NAME_LEN, "/dset%03d", m) > DSET_NAME_LEN) {
+            snprintf(mesg, MIRR_MESG_SIZE, "unable to compose dset name %d\n", m);
             FAIL_PUTS_ERROR(mesg);
         }
 
         if ((dataset_ids[m] = H5Dopen2(file_id, dset_name, H5P_DEFAULT)) < 0) {
-            HDsnprintf(mesg, MIRR_MESG_SIZE, "unable to open dset ID %d\n", m);
+            snprintf(mesg, MIRR_MESG_SIZE, "unable to open dset ID %d\n", m);
             FAIL_PUTS_ERROR(mesg);
         }
     }
@@ -1536,7 +1536,7 @@ _open_chunking_ids(hid_t file_id, unsigned min_dset, unsigned max_dset, hsize_t 
     /* Open filespace IDs */
     for (unsigned m = min_dset; m <= max_dset; m++) {
         if ((filespace_ids[m] = H5Dget_space(dataset_ids[m])) < 0) {
-            HDsnprintf(mesg, MIRR_MESG_SIZE, "unable to get filespace ID %d\n", m);
+            snprintf(mesg, MIRR_MESG_SIZE, "unable to get filespace ID %d\n", m);
             FAIL_PUTS_ERROR(mesg);
         }
     }
@@ -1575,16 +1575,16 @@ _close_chunking_ids(unsigned min_dset, unsigned max_dset, hid_t *dataspace_ids, 
         LOGPRINT(3, "closing ids[%d]\n", m);
         if (dataspace_ids) {
             if (H5Sclose(dataspace_ids[m]) < 0) {
-                HDsnprintf(mesg, MIRR_MESG_SIZE, "unable to close dataspace_id[%d]\n", m);
+                snprintf(mesg, MIRR_MESG_SIZE, "unable to close dataspace_id[%d]\n", m);
                 FAIL_PUTS_ERROR(mesg);
             }
         }
         if (H5Dclose(dataset_ids[m]) < 0) {
-            HDsnprintf(mesg, MIRR_MESG_SIZE, "unable to close dataset_id[%d]\n", m);
+            snprintf(mesg, MIRR_MESG_SIZE, "unable to close dataset_id[%d]\n", m);
             FAIL_PUTS_ERROR(mesg);
         }
         if (H5Sclose(filespace_ids[m]) < 0) {
-            HDsnprintf(mesg, MIRR_MESG_SIZE, "unable to close filespace_id[%d]\n", m);
+            snprintf(mesg, MIRR_MESG_SIZE, "unable to close filespace_id[%d]\n", m);
             FAIL_PUTS_ERROR(mesg);
         }
     }
@@ -1635,7 +1635,7 @@ _verify_datasets(unsigned min_dset, unsigned max_dset, hid_t *filespace_ids, hid
 
                 if (H5Dread(dataset_ids[m], H5T_NATIVE_INT, memspace_id, filespace_ids[m], H5P_DEFAULT,
                             data_chunk) < 0) {
-                    HDsnprintf(mesg, MIRR_MESG_SIZE, "      H5Dread() [%d][%d][%d]\n", i, j, m);
+                    snprintf(mesg, MIRR_MESG_SIZE, "      H5Dread() [%d][%d][%d]\n", i, j, m);
                     FAIL_PUTS_ERROR(mesg);
                 }
 
@@ -1643,8 +1643,8 @@ _verify_datasets(unsigned min_dset, unsigned max_dset, hid_t *filespace_ids, hid
                     for (l = 0; l < CHUNK_DIM; l++) {
                         if ((unsigned)data_chunk[k][l] !=
                             ((DSET_DIM * DSET_DIM * m) + (DSET_DIM * (i + k)) + j + l)) {
-                            HDsnprintf(mesg, MIRR_MESG_SIZE, "      MISMATCH [%d][%d][%d][%d][%d]\n", i, j, m,
-                                       k, l);
+                            snprintf(mesg, MIRR_MESG_SIZE, "      MISMATCH [%d][%d][%d][%d][%d]\n", i, j, m,
+                                     k, l);
                             FAIL_PUTS_ERROR(mesg);
                         }
                     }
@@ -2059,7 +2059,7 @@ test_vanishing_datasets(const struct mt_opts *opts)
 
         /* Delete datasets */
         if (i >= max_at_one_time) {
-            if (HDsnprintf(namebuf, DSET_NAME_LEN, "/dset%02d", (i - max_at_one_time)) > DSET_NAME_LEN)
+            if (snprintf(namebuf, DSET_NAME_LEN, "/dset%02d", (i - max_at_one_time)) > DSET_NAME_LEN)
                 TEST_ERROR;
             if (H5Ldelete(file_id, namebuf, H5P_DEFAULT) < 0)
                 TEST_ERROR;
@@ -2067,7 +2067,7 @@ test_vanishing_datasets(const struct mt_opts *opts)
 
         /* Write to datasets */
         if (i < (max_loops - max_at_one_time)) {
-            if (HDsnprintf(namebuf, DSET_NAME_LEN, "/dset%02d", i) > DSET_NAME_LEN)
+            if (snprintf(namebuf, DSET_NAME_LEN, "/dset%02d", i) > DSET_NAME_LEN)
                 TEST_ERROR;
             if ((dset_id = H5Dcreate2(file_id, namebuf, H5T_STD_U32LE, dspace_id, H5P_DEFAULT, H5P_DEFAULT,
                                       H5P_DEFAULT)) < 0)
@@ -2191,7 +2191,7 @@ test_concurrent_access(const struct mt_opts *opts)
         char  name[16] = "";
         hid_t fapl_id  = H5I_INVALID_HID;
 
-        HDsnprintf(name, 15, "concurrent%d", i);
+        snprintf(name, 15, "concurrent%d", i);
         if ((fapl_id = create_mirroring_split_fapl(name, &bundle[i].names, opts)) < 0)
             TEST_ERROR;
         bundle[i].fapl_id = fapl_id;
@@ -2296,12 +2296,12 @@ parse_args(int argc, char **argv, struct mt_opts *opts)
     int i = 0;
 
     opts->portno = SERVER_HANDSHAKE_PORT;
-    HDstrncpy(opts->ip, SERVER_IP_ADDRESS, H5FD_MIRROR_MAX_IP_LEN);
+    strncpy(opts->ip, SERVER_IP_ADDRESS, H5FD_MIRROR_MAX_IP_LEN);
 
     for (i = 1; i < argc; i++) { /* start with first possible option argument */
-        if (!HDstrncmp(argv[i], "--ip=", 5))
-            HDstrncpy(opts->ip, argv[i] + 5, H5FD_MIRROR_MAX_IP_LEN);
-        else if (!HDstrncmp(argv[i], "--port=", 7))
+        if (!strncmp(argv[i], "--ip=", 5))
+            strncpy(opts->ip, argv[i] + 5, H5FD_MIRROR_MAX_IP_LEN);
+        else if (!strncmp(argv[i], "--port=", 7))
             opts->portno = atoi(argv[i] + 7);
         else {
             printf("Unrecognized option: '%s'\n", argv[i]);
@@ -2310,8 +2310,8 @@ parse_args(int argc, char **argv, struct mt_opts *opts)
     } /* end for each argument from command line */
 
     /* Auto-replace 'localhost' with numeric IP */
-    if (!HDstrncmp(opts->ip, "localhost", 10)) /* include NUL terminator */
-        HDstrncpy(opts->ip, "127.0.0.1", H5FD_MIRROR_MAX_IP_LEN);
+    if (!strncmp(opts->ip, "localhost", 10)) /* include NUL terminator */
+        strncpy(opts->ip, "127.0.0.1", H5FD_MIRROR_MAX_IP_LEN);
 
     return 0;
 } /* end parse_args() */
@@ -2346,7 +2346,7 @@ confirm_server(struct mt_opts *opts)
     while (1) {
         if (connect(live_socket, (struct sockaddr *)&target_addr, (socklen_t)sizeof(target_addr)) < 0) {
             if (attempt > 10) {
-                printf("ERROR connect() (%d)\n%s\n", errno, HDstrerror(errno));
+                printf("ERROR connect() (%d)\n%s\n", errno, strerror(errno));
                 return -1;
             }
 
@@ -2359,7 +2359,7 @@ confirm_server(struct mt_opts *opts)
 
             attempt++;
             HDsleep(1);
-            printf("attempt #%u: ERROR connect() (%d)\n%s\n", attempt, errno, HDstrerror(errno));
+            printf("attempt #%u: ERROR connect() (%d)\n%s\n", attempt, errno, strerror(errno));
 
             /* Re-open socket for retry */
             live_socket = socket(AF_INET, SOCK_STREAM, 0);
@@ -2374,7 +2374,7 @@ confirm_server(struct mt_opts *opts)
 
     /* Request confirmation from the server */
     if (HDwrite(live_socket, "CONFIRM", 8) == -1) {
-        printf("ERROR write() (%d)\n%s\n", errno, HDstrerror(errno));
+        printf("ERROR write() (%d)\n%s\n", errno, strerror(errno));
         return -1;
     }
 
@@ -2383,7 +2383,7 @@ confirm_server(struct mt_opts *opts)
         printf("ERROR read() can't receive data\n");
         return -1;
     }
-    if (HDstrncmp("ALIVE", mybuf, 6)) {
+    if (strncmp("ALIVE", mybuf, 6)) {
         printf("ERROR read() didn't receive data from server\n");
         return -1;
     }

--- a/test/mount.c
+++ b/test/mount.c
@@ -190,7 +190,7 @@ test_illegal(hid_t fapl)
     H5E_END_TRY
     if (status >= 0) {
         H5_FAILED();
-        HDputs("    Mounting a file on itself should have failed.");
+        puts("    Mounting a file on itself should have failed.");
         TEST_ERROR;
     } /* end if */
 
@@ -210,7 +210,7 @@ test_illegal(hid_t fapl)
     H5E_END_TRY
     if (status >= 0) {
         H5_FAILED();
-        HDputs("    Mounting two files at one mount point should have failed.");
+        puts("    Mounting two files at one mount point should have failed.");
         TEST_ERROR;
     } /* end if */
     if (H5Funmount(mnt, ".") < 0)
@@ -235,7 +235,7 @@ test_illegal(hid_t fapl)
     H5E_END_TRY
     if (status >= 0) {
         H5_FAILED();
-        HDputs("    Mounting same file opened twice at one mount point should have failed.");
+        puts("    Mounting same file opened twice at one mount point should have failed.");
         TEST_ERROR;
     } /* end if */
     if (H5Funmount(mnt, ".") < 0)
@@ -253,7 +253,7 @@ test_illegal(hid_t fapl)
     H5E_END_TRY
     if (status >= 0) {
         H5_FAILED();
-        HDputs("    Creating a cycle with mount points should have failed.");
+        puts("    Creating a cycle with mount points should have failed.");
         TEST_ERROR;
     } /* end if */
     if (H5Funmount(file1, "/mnt1") < 0)
@@ -474,7 +474,7 @@ test_hide(hid_t fapl)
     H5E_END_TRY
     if (grp >= 0) {
         H5_FAILED();
-        HDputs("    Name is still accessible under mount point.");
+        puts("    Name is still accessible under mount point.");
         TEST_ERROR;
     }
 
@@ -499,7 +499,7 @@ test_hide(hid_t fapl)
 
     if (!same_obj) {
         H5_FAILED();
-        HDputs("    Hard link failed for hidden object.");
+        puts("    Hard link failed for hidden object.");
         TEST_ERROR;
     }
 
@@ -583,7 +583,7 @@ test_assoc(hid_t fapl)
 
     if (!same_obj) {
         H5_FAILED();
-        HDputs("    Association failed.");
+        puts("    Association failed.");
         TEST_ERROR;
     } /* end if */
 
@@ -714,7 +714,7 @@ test_move(hid_t fapl)
     H5E_END_TRY
     if (status >= 0) {
         H5_FAILED();
-        HDputs("    Moving an object across files shouldn't have been possible");
+        puts("    Moving an object across files shouldn't have been possible");
         TEST_ERROR;
     } /* end if */
 
@@ -935,7 +935,7 @@ test_unlink(hid_t fapl)
     H5E_END_TRY
     if (status >= 0) {
         H5_FAILED();
-        HDputs("    Incorrect traversal from mount point!");
+        puts("    Incorrect traversal from mount point!");
         TEST_ERROR;
     } /* end if */
 
@@ -956,7 +956,7 @@ test_unlink(hid_t fapl)
     H5E_END_TRY
     if (status >= 0) {
         H5_FAILED();
-        HDputs("    Traversal through mount point should not have worked!");
+        puts("    Traversal through mount point should not have worked!");
         TEST_ERROR;
     } /* end if */
     H5E_BEGIN_TRY
@@ -966,7 +966,7 @@ test_unlink(hid_t fapl)
     H5E_END_TRY
     if (status >= 0) {
         H5_FAILED();
-        HDputs("    Traversal through mount point should not have worked!");
+        puts("    Traversal through mount point should not have worked!");
         TEST_ERROR;
     } /* end if */
 
@@ -1122,7 +1122,7 @@ test_interlink(hid_t fapl)
     H5E_END_TRY
     if (status >= 0) {
         H5_FAILED();
-        HDputs("    Interfile hard link should not have been allowed!");
+        puts("    Interfile hard link should not have been allowed!");
         TEST_ERROR;
     } /* end if */
 
@@ -1134,7 +1134,7 @@ test_interlink(hid_t fapl)
     H5E_END_TRY
     if (status >= 0) {
         H5_FAILED();
-        HDputs("    Interfile renaming should not have been allowed!");
+        puts("    Interfile renaming should not have been allowed!");
         TEST_ERROR;
     } /* end if */
 
@@ -1157,7 +1157,7 @@ test_interlink(hid_t fapl)
     H5E_END_TRY
     if (dset >= 0) {
         H5_FAILED();
-        HDputs("    Dataset and shared type must be in the same file!");
+        puts("    Dataset and shared type must be in the same file!");
         TEST_ERROR;
     } /* end if */
 
@@ -1168,7 +1168,7 @@ test_interlink(hid_t fapl)
         FAIL_STACK_ERROR;
 #else  /* NOT_NOW */
     SKIPPED();
-    HDputs("    Test skipped due file pointer sharing issue (Jira 7638).");
+    puts("    Test skipped due file pointer sharing issue (Jira 7638).");
 #endif /* NOT_NOW */
 
     /* Shut down */
@@ -1309,7 +1309,7 @@ test_close(hid_t fapl)
         FAIL_STACK_ERROR;
     if (H5Oget_info_by_name3(file2, "/mnt1", &oinfo, H5O_INFO_BASIC, H5P_DEFAULT) < 0) {
         H5_FAILED();
-        HDputs("    File1 contents are not accessible!");
+        puts("    File1 contents are not accessible!");
         TEST_ERROR;
     } /* end if */
     if (H5Fclose(file2) < 0)
@@ -1506,7 +1506,7 @@ test_mount_after_close(hid_t fapl)
     *objname = '\0';
     if (H5Iget_name(gidABMX, objname, (size_t)NAME_BUF_SIZE) < 0)
         FAIL_STACK_ERROR;
-    if (HDstrcmp(objname, "/A/B/M/X") != 0)
+    if (strcmp(objname, "/A/B/M/X") != 0)
         TEST_ERROR;
 
     /* Close object in mounted file */
@@ -1521,7 +1521,7 @@ test_mount_after_close(hid_t fapl)
     *objname = '\0';
     if (H5Iget_name(gidABC, objname, (size_t)NAME_BUF_SIZE) < 0)
         FAIL_STACK_ERROR;
-    if (HDstrcmp(objname, "/A/B/C") != 0)
+    if (strcmp(objname, "/A/B/C") != 0)
         TEST_ERROR;
 
     /* Close object in mounted file */
@@ -1536,7 +1536,7 @@ test_mount_after_close(hid_t fapl)
     *objname = '\0';
     if (H5Iget_name(gidABT, objname, (size_t)NAME_BUF_SIZE) < 0)
         FAIL_STACK_ERROR;
-    if (HDstrcmp(objname, "/A/B/T") != 0)
+    if (strcmp(objname, "/A/B/T") != 0)
         TEST_ERROR;
 
     /* Close object in original file */
@@ -1551,7 +1551,7 @@ test_mount_after_close(hid_t fapl)
     *objname = '\0';
     if (H5Iget_name(didABMXYD, objname, (size_t)NAME_BUF_SIZE) < 0)
         FAIL_STACK_ERROR;
-    if (HDstrcmp(objname, "/A/B/M/X/Y/D") != 0)
+    if (strcmp(objname, "/A/B/M/X/Y/D") != 0)
         TEST_ERROR;
 
     /* Close object in mounted file */
@@ -1721,7 +1721,7 @@ test_mount_after_unmount(hid_t fapl)
     *objname = '\0';
     if (H5Iget_name(gidAMXX, objname, (size_t)NAME_BUF_SIZE) < 0)
         TEST_ERROR;
-    if (HDstrcmp(objname, "/A/M/X/X") != 0)
+    if (strcmp(objname, "/A/M/X/X") != 0)
         TEST_ERROR;
 
     /* Open group in mounted file #2 */
@@ -1741,7 +1741,7 @@ test_mount_after_unmount(hid_t fapl)
     *objname = '\0';
     if (H5Iget_name(gidAMXMY, objname, (size_t)NAME_BUF_SIZE) < 0)
         TEST_ERROR;
-    if (HDstrcmp(objname, "/A/M/X/M/Y") != 0)
+    if (strcmp(objname, "/A/M/X/M/Y") != 0)
         TEST_ERROR;
 
     /* Unmount second file */
@@ -1752,7 +1752,7 @@ test_mount_after_unmount(hid_t fapl)
     *objname = '\0';
     if (H5Iget_name(gidAMXMY, objname, (size_t)NAME_BUF_SIZE) < 0)
         TEST_ERROR;
-    if (HDstrcmp(objname, "/X/M/Y") != 0)
+    if (strcmp(objname, "/X/M/Y") != 0)
         TEST_ERROR;
 
     /* Rename object in file #3 that is "disconnected" from name hierarchy */
@@ -1772,7 +1772,7 @@ test_mount_after_unmount(hid_t fapl)
     *objname = '\0';
     if (H5Iget_name(gidAMXMY, objname, (size_t)NAME_BUF_SIZE) < 0)
         TEST_ERROR;
-    if (HDstrcmp(objname, "/X/M/Z") != 0)
+    if (strcmp(objname, "/X/M/Z") != 0)
         TEST_ERROR;
 
     /* Mount fourth file */
@@ -1788,7 +1788,7 @@ test_mount_after_unmount(hid_t fapl)
     *objname = '\0';
     if (H5Iget_name(gidBMZ, objname, (size_t)NAME_BUF_SIZE) < 0)
         TEST_ERROR;
-    if (HDstrcmp(objname, "/B/M/Z") != 0)
+    if (strcmp(objname, "/B/M/Z") != 0)
         TEST_ERROR;
 
     /* Unmount third file */
@@ -2756,7 +2756,7 @@ test_acc_perm(hid_t fapl)
     /* Get and verify file name */
     if (H5Fget_name(gidA, name, NAME_BUF_SIZE) < 0)
         TEST_ERROR;
-    if (HDstrcmp(name, filename1) != 0)
+    if (strcmp(name, filename1) != 0)
         TEST_ERROR;
 
     if ((fid2 = H5Fopen(filename2, H5F_ACC_RDONLY, H5P_DEFAULT)) < 0)
@@ -2765,7 +2765,7 @@ test_acc_perm(hid_t fapl)
     /* Get and verify file name */
     if (H5Fget_name(fid2, name, NAME_BUF_SIZE) < 0)
         TEST_ERROR;
-    if (HDstrcmp(name, filename2) != 0)
+    if (strcmp(name, filename2) != 0)
         TEST_ERROR;
 
     /* Mount files together */
@@ -2775,7 +2775,7 @@ test_acc_perm(hid_t fapl)
     /* Get and verify file name */
     if (H5Fget_name(fid2, name, NAME_BUF_SIZE) < 0)
         TEST_ERROR;
-    if (HDstrcmp(name, filename2) != 0)
+    if (strcmp(name, filename2) != 0)
         TEST_ERROR;
 
     /* Open group in mounted file */
@@ -2785,7 +2785,7 @@ test_acc_perm(hid_t fapl)
     /* Get and verify file name */
     if (H5Fget_name(gidAM, name, NAME_BUF_SIZE) < 0)
         TEST_ERROR;
-    if (HDstrcmp(name, filename2) != 0)
+    if (strcmp(name, filename2) != 0)
         TEST_ERROR;
 
     /* Attempt to create objects in read only file (should fail) */
@@ -2831,7 +2831,7 @@ test_acc_perm(hid_t fapl)
     /* Get and verify file name */
     if (H5Fget_name(gidAMZ, name, NAME_BUF_SIZE) < 0)
         TEST_ERROR;
-    if (HDstrcmp(name, filename3) != 0)
+    if (strcmp(name, filename3) != 0)
         TEST_ERROR;
 
     /* Close object in file #3 */
@@ -3024,7 +3024,7 @@ test_mult_mount(hid_t fapl)
     *name = '\0';
     if (H5Iget_name(gidAMT, name, (size_t)NAME_BUF_SIZE) < 0)
         TEST_ERROR;
-    if (HDstrcmp(name, "/A/M/T") != 0)
+    if (strcmp(name, "/A/M/T") != 0)
         TEST_ERROR;
 
     /* Create object in file #3 */
@@ -3042,7 +3042,7 @@ test_mult_mount(hid_t fapl)
     *name = '\0';
     if (H5Iget_name(gidBS, name, (size_t)NAME_BUF_SIZE) < 0)
         TEST_ERROR;
-    if (HDstrcmp(name, "/B/S") != 0)
+    if (strcmp(name, "/B/S") != 0)
         TEST_ERROR;
 
     /* Re-open object created in file #3 through file #1 mount path */
@@ -3219,7 +3219,7 @@ test_nested_survive(hid_t fapl)
     *name = '\0';
     if ((name_len = H5Iget_name(gidAM, name, (size_t)NAME_BUF_SIZE)) < 0)
         TEST_ERROR;
-    if (name_len == 0 || HDstrcmp(name, "/A/M") != 0)
+    if (name_len == 0 || strcmp(name, "/A/M") != 0)
         TEST_ERROR;
 
     /* Unmount file #2 from file #1 */
@@ -3230,7 +3230,7 @@ test_nested_survive(hid_t fapl)
     *name = '\0';
     if ((name_len = H5Iget_name(gidAM, name, (size_t)NAME_BUF_SIZE)) < 0)
         TEST_ERROR;
-    if (name_len != 0 || HDstrcmp(name, "") != 0)
+    if (name_len != 0 || strcmp(name, "") != 0)
         TEST_ERROR;
 
     /* Open object in file #3 through file #1 mount path (should fail) */
@@ -3250,7 +3250,7 @@ test_nested_survive(hid_t fapl)
     *name = '\0';
     if (H5Iget_name(gidMS, name, (size_t)NAME_BUF_SIZE) < 0)
         TEST_ERROR;
-    if (HDstrcmp(name, "/M/S") != 0)
+    if (strcmp(name, "/M/S") != 0)
         TEST_ERROR;
 
     /* Close group in file #3 */
@@ -3269,7 +3269,7 @@ test_nested_survive(hid_t fapl)
     *name = '\0';
     if (H5Iget_name(gidAMS, name, (size_t)NAME_BUF_SIZE) < 0)
         TEST_ERROR;
-    if (HDstrcmp(name, "/A/M/S") != 0)
+    if (strcmp(name, "/A/M/S") != 0)
         TEST_ERROR;
 
     /* Close group in file #3 */
@@ -3413,7 +3413,7 @@ test_close_parent(hid_t fapl)
     *name = '\0';
     if ((name_len = H5Iget_name(gidM, name, (size_t)NAME_BUF_SIZE)) < 0)
         TEST_ERROR;
-    if (name_len == 0 || HDstrcmp(name, "/A/M") != 0)
+    if (name_len == 0 || strcmp(name, "/A/M") != 0)
         TEST_ERROR;
 
     /* Unmount file #2 from file #1, closing file #1 */
@@ -3424,7 +3424,7 @@ test_close_parent(hid_t fapl)
     *name = '\0';
     if ((name_len = H5Iget_name(gidM, name, (size_t)NAME_BUF_SIZE)) < 0)
         TEST_ERROR;
-    if (name_len == 0 || HDstrcmp(name, "/M") != 0)
+    if (name_len == 0 || strcmp(name, "/M") != 0)
         TEST_ERROR;
 
     /* Just file #2's underlying shared file should be open still */
@@ -3687,7 +3687,7 @@ test_cut_graph(hid_t fapl)
     *name = '\0';
     if ((name_len = H5Iget_name(gidM, name, (size_t)NAME_BUF_SIZE)) < 0)
         TEST_ERROR;
-    if (name_len == 0 || HDstrcmp(name, "/A/E/M") != 0)
+    if (name_len == 0 || strcmp(name, "/A/E/M") != 0)
         TEST_ERROR;
 
     /* Open object in file #7 */
@@ -3698,7 +3698,7 @@ test_cut_graph(hid_t fapl)
     *name = '\0';
     if ((name_len = H5Iget_name(gidQ, name, (size_t)NAME_BUF_SIZE)) < 0)
         TEST_ERROR;
-    if (name_len == 0 || HDstrcmp(name, "/B/I/Q") != 0)
+    if (name_len == 0 || strcmp(name, "/B/I/Q") != 0)
         TEST_ERROR;
 
     /* Close file #1 */
@@ -3758,7 +3758,7 @@ test_cut_graph(hid_t fapl)
     *name = '\0';
     if ((name_len = H5Iget_name(gidK, name, (size_t)NAME_BUF_SIZE)) < 0)
         TEST_ERROR;
-    if (name_len == 0 || HDstrcmp(name, "/D/K") != 0)
+    if (name_len == 0 || strcmp(name, "/D/K") != 0)
         TEST_ERROR;
 
     if (H5Gclose(gidK) < 0)
@@ -3781,7 +3781,7 @@ test_cut_graph(hid_t fapl)
     *name = '\0';
     if ((name_len = H5Iget_name(gidO, name, (size_t)NAME_BUF_SIZE)) < 0)
         TEST_ERROR;
-    if (name_len == 0 || HDstrcmp(name, "/B/H/O") != 0)
+    if (name_len == 0 || strcmp(name, "/B/H/O") != 0)
         TEST_ERROR;
 
     if (H5Gclose(gidO) < 0)
@@ -3791,14 +3791,14 @@ test_cut_graph(hid_t fapl)
     *name = '\0';
     if ((name_len = H5Iget_name(gidM, name, (size_t)NAME_BUF_SIZE)) < 0)
         TEST_ERROR;
-    if (name_len == 0 || HDstrcmp(name, "/E/M") != 0)
+    if (name_len == 0 || strcmp(name, "/E/M") != 0)
         TEST_ERROR;
 
     /* Check the name of "Q" is still defined */
     *name = '\0';
     if ((name_len = H5Iget_name(gidQ, name, (size_t)NAME_BUF_SIZE)) < 0)
         TEST_ERROR;
-    if (name_len == 0 || HDstrcmp(name, "/B/I/Q") != 0)
+    if (name_len == 0 || strcmp(name, "/B/I/Q") != 0)
         TEST_ERROR;
 
     /* Check that all seven underlying files are still opened */
@@ -3823,7 +3823,7 @@ test_cut_graph(hid_t fapl)
     *name = '\0';
     if ((name_len = H5Iget_name(gidQ, name, (size_t)NAME_BUF_SIZE)) < 0)
         TEST_ERROR;
-    if (name_len == 0 || HDstrcmp(name, "/I/Q") != 0)
+    if (name_len == 0 || strcmp(name, "/I/Q") != 0)
         TEST_ERROR;
 
     /* Open object in file #6 from file #7 */
@@ -3834,7 +3834,7 @@ test_cut_graph(hid_t fapl)
     *name = '\0';
     if ((name_len = H5Iget_name(gidO, name, (size_t)NAME_BUF_SIZE)) < 0)
         TEST_ERROR;
-    if (name_len == 0 || HDstrcmp(name, "/H/O") != 0)
+    if (name_len == 0 || strcmp(name, "/H/O") != 0)
         TEST_ERROR;
 
     if (H5Gclose(gidO) < 0)
@@ -3998,7 +3998,7 @@ test_symlink(hid_t fapl)
     *name = '\0';
     if ((name_len = H5Iget_name(gidL, name, (size_t)NAME_BUF_SIZE)) < 0)
         TEST_ERROR;
-    if (name_len == 0 || HDstrcmp(name, "/L") != 0)
+    if (name_len == 0 || strcmp(name, "/L") != 0)
         TEST_ERROR;
 
     /* Close file #1 */
@@ -4501,12 +4501,12 @@ main(void)
     if (nerrors)
         goto error;
 
-    HDputs("All mount tests passed.");
+    puts("All mount tests passed.");
     h5_cleanup(FILENAME, fapl);
 
     return 0;
 
 error:
-    HDputs("***** MOUNT ERRORS *****");
+    puts("***** MOUNT ERRORS *****");
     return 1;
 }

--- a/test/mtime.c
+++ b/test/mtime.c
@@ -96,26 +96,26 @@ main(void)
     /* Compare object tokens & times from the two ways of calling H5Oget_info() */
     if (token_cmp || oi1.ctime != oi2.ctime) {
         H5_FAILED();
-        HDputs("    Calling H5Oget_info() with the dataset ID returned");
-        HDputs("    different values than calling it with a file and dataset");
-        HDputs("    name.");
+        puts("    Calling H5Oget_info() with the dataset ID returned");
+        puts("    different values than calling it with a file and dataset");
+        puts("    name.");
         goto error;
     }
 
     /* Compare times -- they must be within 60 seconds of one another */
     if (0 == oi1.ctime) {
         SKIPPED();
-        HDputs("    The modification time could not be decoded on this OS.");
-        HDputs("    Modification times will be maintained in the file but");
-        HDputs("    cannot be queried on this system.  See H5O_mtime_decode().");
+        puts("    The modification time could not be decoded on this OS.");
+        puts("    Modification times will be maintained in the file but");
+        puts("    cannot be queried on this system.  See H5O_mtime_decode().");
         return 0;
     }
     else if (fabs(HDdifftime(now, oi1.ctime)) > 60.0) {
         H5_FAILED();
         tm = HDlocaltime(&(oi1.ctime));
-        HDstrftime((char *)buf1, sizeof buf1, "%Y-%m-%d %H:%M:%S", tm);
+        strftime((char *)buf1, sizeof buf1, "%Y-%m-%d %H:%M:%S", tm);
         tm = HDlocaltime(&now);
-        HDstrftime((char *)buf2, sizeof buf2, "%Y-%m-%d %H:%M:%S", tm);
+        strftime((char *)buf2, sizeof buf2, "%Y-%m-%d %H:%M:%S", tm);
         printf("    got: %s\n    ans: %s\n", buf1, buf2);
         goto error;
     }
@@ -138,7 +138,7 @@ main(void)
                     H5_FAILED();
                     /* If this fails, examine H5Omtime.c.  Modification time is very
                      * system dependent (e.g., on Windows DST must be hardcoded). */
-                    HDputs("    Old modification time incorrect");
+                    puts("    Old modification time incorrect");
                     goto error;
                 }
                 if (H5Fclose(file) < 0)
@@ -168,7 +168,7 @@ main(void)
                     TEST_ERROR;
                 if (oi2.ctime != MTIME2) {
                     H5_FAILED();
-                    HDputs("    Modification time incorrect.");
+                    puts("    Modification time incorrect.");
                     goto error;
                 }
                 if (H5Fclose(file) < 0)
@@ -188,7 +188,7 @@ main(void)
         TEST_ERROR;
 
     /* All looks good */
-    HDputs("All modification time tests passed.");
+    puts("All modification time tests passed.");
     h5_cleanup(FILENAME, fapl);
     return EXIT_SUCCESS;
 

--- a/test/ntypes.c
+++ b/test/ntypes.c
@@ -2048,13 +2048,13 @@ test_vlstr_dtype(hid_t file)
 
     /* Compare data read in */
     for (i = 0; i < SPACE1_DIM1; i++) {
-        if (HDstrlen(wdata[i]) != HDstrlen(rdata[i])) {
+        if (strlen(wdata[i]) != strlen(rdata[i])) {
             H5_FAILED();
             printf("    VL data length don't match!, strlen(wdata[%d])=%d, strlen(rdata[%d])=%d\n", (int)i,
-                   (int)HDstrlen(wdata[i]), (int)i, (int)HDstrlen(rdata[i]));
+                   (int)strlen(wdata[i]), (int)i, (int)strlen(rdata[i]));
             goto error;
         } /* end if */
-        if (HDstrcmp(wdata[i], rdata[i]) != 0) {
+        if (strcmp(wdata[i], rdata[i]) != 0) {
             H5_FAILED();
             printf("    VL data values don't match!, wdata[%d]=%s, rdata[%d]=%s\n", (int)i, wdata[i], (int)i,
                    rdata[i]);
@@ -2176,13 +2176,13 @@ test_str_dtype(hid_t file)
 
     /* Compare data read in */
     for (i = 0; i < SPACE1_DIM1; i++) {
-        if (HDstrlen(wdata[i]) != HDstrlen(rdata[i])) {
+        if (strlen(wdata[i]) != strlen(rdata[i])) {
             H5_FAILED();
             printf("    data length don't match!, strlen(wdata[%d])=%d, strlen(rdata[%d])=%d\n", (int)i,
-                   (int)HDstrlen(wdata[i]), (int)i, (int)HDstrlen(rdata[i]));
+                   (int)strlen(wdata[i]), (int)i, (int)strlen(rdata[i]));
             goto error;
         } /* end if */
-        if (HDstrcmp(wdata[i], rdata[i]) != 0) {
+        if (strcmp(wdata[i], rdata[i]) != 0) {
             H5_FAILED();
             printf("    data values don't match!, wdata[%d]=%s, rdata[%d]=%s\n", (int)i, wdata[i], (int)i,
                    rdata[i]);

--- a/test/objcopy.c
+++ b/test/objcopy.c
@@ -619,7 +619,7 @@ test_copy_attach_attributes(hid_t loc_id, hid_t type_id)
         goto done;
 
     for (u = 0; u < num_attributes_g; u++) {
-        HDsnprintf(attr_name, sizeof(attr_name), "%u attr", u);
+        snprintf(attr_name, sizeof(attr_name), "%u attr", u);
 
         /* Set attribute data */
         attr_data[0] = (int)(100 * u);
@@ -685,7 +685,7 @@ test_copy_attach_paired_attributes(hid_t loc_id, hid_t loc_id2, hid_t type_id)
         goto done;
 
     for (u = 0; u < num_attributes_g; u++) {
-        HDsnprintf(attr_name, sizeof(attr_name), "%u attr", u);
+        snprintf(attr_name, sizeof(attr_name), "%u attr", u);
 
         /* Set attribute data */
         attr_data[0] = (int)(100 * u);
@@ -1551,7 +1551,7 @@ compare_groups(hid_t gid, hid_t gid2, hid_t pid, int depth, unsigned copy_flags)
             if (H5Lget_name_by_idx(gid2, ".", H5_INDEX_NAME, H5_ITER_INC, idx, objname2,
                                    (size_t)NAME_BUF_SIZE, H5P_DEFAULT) < 0)
                 TEST_ERROR;
-            if (HDstrcmp(objname, objname2) != 0)
+            if (strcmp(objname, objname2) != 0)
                 TEST_ERROR;
 
             /* Get link info */
@@ -4425,7 +4425,7 @@ test_copy_dataset_compressed(hid_t fcpl_src, hid_t fcpl_dst, hid_t src_fapl, hid
     (void)src_fapl;
     (void)dst_fapl; /* Silence compiler */
     SKIPPED();
-    HDputs("    Deflation filter not available");
+    puts("    Deflation filter not available");
 #else  /* H5_HAVE_FILTER_DEFLATE */
     /* set initial data values */
     for (i = 0; i < DIM_SIZE_1; i++)
@@ -4848,7 +4848,7 @@ test_copy_dataset_no_edge_filt(hid_t fcpl_src, hid_t fcpl_dst, hid_t src_fapl, h
     (void)src_fapl;
     (void)dst_fapl; /* Silence compiler */
     SKIPPED();
-    HDputs("    Deflation filter not available");
+    puts("    Deflation filter not available");
 #else  /* H5_HAVE_FILTER_DEFLATE */
     /* set initial data values */
     for (i = 0; i < DIM_SIZE_1; i++)
@@ -6835,11 +6835,11 @@ attach_attribute_compound_vlstr(hid_t loc_id)
         goto done;
 
     /* Write to the attribute */
-    len   = HDstrlen(ATTR_CMPD_STRING) + 1;
+    len   = strlen(ATTR_CMPD_STRING) + 1;
     buf.i = 9;
     if (NULL == (buf.v = (char *)calloc(len, sizeof(char))))
         goto done;
-    HDstrncpy(buf.v, ATTR_CMPD_STRING, len);
+    strncpy(buf.v, ATTR_CMPD_STRING, len);
     if (H5Awrite(aid, cmpd_tid, &buf) < 0)
         goto done;
 
@@ -6915,9 +6915,9 @@ compare_attribute_compound_vlstr(hid_t loc, hid_t loc2)
     /* Compare the attributes' data */
     if (rbuf.i != rbuf2.i)
         FAIL_STACK_ERROR;
-    if (HDstrlen(rbuf.v) != HDstrlen(rbuf2.v))
+    if (strlen(rbuf.v) != strlen(rbuf2.v))
         FAIL_STACK_ERROR;
-    if (memcmp(rbuf.v, rbuf2.v, HDstrlen(rbuf.v)) != 0)
+    if (memcmp(rbuf.v, rbuf2.v, strlen(rbuf.v)) != 0)
         FAIL_STACK_ERROR;
 
     /* Reclaim vlen buffer */
@@ -7164,7 +7164,7 @@ test_copy_dataset_compressed_vl(hid_t fcpl_src, hid_t fcpl_dst, hid_t src_fapl, 
     (void)src_fapl;
     (void)dst_fapl; /* Silence compiler */
     SKIPPED();
-    HDputs("    Deflation filter not available");
+    puts("    Deflation filter not available");
 #else  /* H5_HAVE_FILTER_DEFLATE */
     /* set initial data values */
     for (i = 0; i < DIM_SIZE_1; i++) {
@@ -7795,17 +7795,17 @@ test_copy_group_deep(hid_t fcpl_src, hid_t fcpl_dst, hid_t src_fapl, hid_t dst_f
 
     /* create nested sub-groups & datasets */
     for (i = 0; i < NUM_SUB_GROUPS; i++) {
-        HDsnprintf(objname, sizeof(objname), "Group #%d", i);
+        snprintf(objname, sizeof(objname), "Group #%d", i);
         if ((gid_sub = H5Gcreate2(gid, objname, H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT)) < 0)
             TEST_ERROR;
 
         for (j = 0; j < NUM_SUB_GROUPS; j++) {
-            HDsnprintf(objname, sizeof(objname), "Group #%d", j);
+            snprintf(objname, sizeof(objname), "Group #%d", j);
             if ((gid_sub2 = H5Gcreate2(gid_sub, objname, H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT)) < 0)
                 TEST_ERROR;
 
             for (k = 0; k < NUM_DATASETS; k++) {
-                HDsnprintf(objname, sizeof(objname), "Dataset #%d", k);
+                snprintf(objname, sizeof(objname), "Dataset #%d", k);
 
                 /* add a dataset to the group */
                 if ((did = H5Dcreate2(gid_sub2, objname, H5T_NATIVE_INT, sid, H5P_DEFAULT, H5P_DEFAULT,
@@ -8078,12 +8078,12 @@ test_copy_group_wide_loop(hid_t fcpl_src, hid_t fcpl_dst, hid_t src_fapl, hid_t 
 
     /* create wide sub-group hierarchy, with multiple links to higher groups */
     for (u = 0; u < NUM_WIDE_LOOP_GROUPS; u++) {
-        HDsnprintf(objname, sizeof(objname), "%s-%u", NAME_GROUP_SUB, u);
+        snprintf(objname, sizeof(objname), "%s-%u", NAME_GROUP_SUB, u);
         if ((gid_sub = H5Gcreate2(gid, objname, H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT)) < 0)
             TEST_ERROR;
 
         for (v = 0; v < NUM_WIDE_LOOP_GROUPS; v++) {
-            HDsnprintf(objname, sizeof(objname), "%s-%u", NAME_GROUP_SUB_SUB2, v);
+            snprintf(objname, sizeof(objname), "%s-%u", NAME_GROUP_SUB_SUB2, v);
             if ((gid_sub2 = H5Gcreate2(gid_sub, objname, H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT)) < 0)
                 FAIL_STACK_ERROR;
 
@@ -16239,7 +16239,7 @@ test_copy_iterate(hid_t fcpl_src, hid_t fcpl_dst, hid_t src_fapl, hid_t dst_fapl
 
     /* Create groups */
     for (i = 0; i < 9; i++) {
-        HDsnprintf(grp_name, sizeof(grp_name), "grp%d", i);
+        snprintf(grp_name, sizeof(grp_name), "grp%d", i);
         if ((gid = H5Gcreate2(fid1, grp_name, H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT)) < 0)
             TEST_ERROR;
         if (H5Gclose(gid) < 0)
@@ -17185,52 +17185,52 @@ main(void)
 
         /* Test with and without shared messages */
         if (configuration & CONFIG_SHARE_SRC) {
-            HDputs("\nTesting with shared src messages:");
+            puts("\nTesting with shared src messages:");
             fcpl_src = fcpl_shared;
         }
         else {
-            HDputs("\nTesting without shared src messages:");
+            puts("\nTesting without shared src messages:");
             fcpl_src = H5P_DEFAULT;
         }
         if (configuration & CONFIG_SHARE_DST) {
-            HDputs("Testing with shared dst messages:");
+            puts("Testing with shared dst messages:");
             fcpl_dst  = fcpl_shared;
             same_file = false;
         }
         else {
-            HDputs("Testing without shared dst messages:");
+            puts("Testing without shared dst messages:");
             fcpl_dst = H5P_DEFAULT;
         }
 
         /* Set the FAPL for the source file's type of format */
         if (configuration & CONFIG_SRC_NEW_FORMAT) {
-            HDputs("Testing with latest format for source file:");
+            puts("Testing with latest format for source file:");
             src_fapl = fapl2;
 
             /* Test with and without dense attributes */
             if (configuration & CONFIG_DENSE) {
-                HDputs("Testing with dense attributes:");
+                puts("Testing with dense attributes:");
                 num_attributes_g = max_compact + 1;
             }
             else {
-                HDputs("Testing without dense attributes:");
+                puts("Testing without dense attributes:");
                 num_attributes_g = MAX(min_dense, 2) - 2;
             }
         } /* end if */
         else {
-            HDputs("Testing with oldest file format for source file:");
+            puts("Testing with oldest file format for source file:");
             src_fapl         = fapl;
             num_attributes_g = 4;
         } /* end else */
 
         /* Set the FAPL for the destination file's type of format */
         if (configuration & CONFIG_DST_NEW_FORMAT) {
-            HDputs("Testing with latest format for destination file:");
+            puts("Testing with latest format for destination file:");
             dst_fapl  = fapl2;
             same_file = false;
         } /* end if */
         else {
-            HDputs("Testing with oldest file format for destination file:");
+            puts("Testing with oldest file format for destination file:");
             dst_fapl = fapl;
         } /* end else */
 
@@ -17292,7 +17292,7 @@ main(void)
                                     false, "H5Ocopy(): expand external link");
 
         /* Splitter VFD currently has external link-related bugs */
-        if (HDstrcmp(env_h5_drvr, "splitter")) {
+        if (strcmp(env_h5_drvr, "splitter")) {
             nerrors += test_copy_option(fcpl_src, fcpl_dst, src_fapl, dst_fapl,
                                         H5O_COPY_EXPAND_SOFT_LINK_FLAG | H5O_COPY_EXPAND_EXT_LINK_FLAG, false,
                                         "H5Ocopy(): expand soft and external links");
@@ -17407,7 +17407,7 @@ main(void)
         exit(EXIT_FAILURE);
     } /* end if */
 
-    HDputs("All object copying tests passed.");
+    puts("All object copying tests passed.");
 
     /* close property list.
      * NOTE: if this property list is not closed and the test is

--- a/test/objcopy_ref.c
+++ b/test/objcopy_ref.c
@@ -488,7 +488,7 @@ test_copy_attach_attributes(hid_t loc_id, hid_t type_id)
         goto done;
 
     for (u = 0; u < num_attributes_g; u++) {
-        HDsnprintf(attr_name, sizeof(attr_name), "%u attr", u);
+        snprintf(attr_name, sizeof(attr_name), "%u attr", u);
 
         /* Set attribute data */
         attr_data[0] = (int)(100 * u);
@@ -1272,7 +1272,7 @@ compare_groups(hid_t gid, hid_t gid2, hid_t pid, int depth, unsigned copy_flags)
             if (H5Lget_name_by_idx(gid2, ".", H5_INDEX_NAME, H5_ITER_INC, idx, objname2,
                                    (size_t)NAME_BUF_SIZE, H5P_DEFAULT) < 0)
                 TEST_ERROR;
-            if (HDstrcmp(objname, objname2) != 0)
+            if (strcmp(objname, objname2) != 0)
                 TEST_ERROR;
 
             /* Get link info */
@@ -1870,50 +1870,50 @@ main(void)
 
         /* Test with and without shared messages */
         if (configuration & CONFIG_SHARE_SRC) {
-            HDputs("\nTesting with shared src messages:");
+            puts("\nTesting with shared src messages:");
             fcpl_src = fcpl_shared;
         }
         else {
-            HDputs("\nTesting without shared src messages:");
+            puts("\nTesting without shared src messages:");
             fcpl_src = H5P_DEFAULT;
         }
         if (configuration & CONFIG_SHARE_DST) {
-            HDputs("Testing with shared dst messages:");
+            puts("Testing with shared dst messages:");
             fcpl_dst = fcpl_shared;
         }
         else {
-            HDputs("Testing without shared dst messages:");
+            puts("Testing without shared dst messages:");
             fcpl_dst = H5P_DEFAULT;
         }
 
         /* Set the FAPL for the source file's type of format */
         if (configuration & CONFIG_SRC_NEW_FORMAT) {
-            HDputs("Testing with latest format for source file:");
+            puts("Testing with latest format for source file:");
             src_fapl = fapl2;
 
             /* Test with and without dense attributes */
             if (configuration & CONFIG_DENSE) {
-                HDputs("Testing with dense attributes:");
+                puts("Testing with dense attributes:");
                 num_attributes_g = max_compact + 1;
             }
             else {
-                HDputs("Testing without dense attributes:");
+                puts("Testing without dense attributes:");
                 num_attributes_g = MAX(min_dense, 2) - 2;
             }
         } /* end if */
         else {
-            HDputs("Testing with oldest file format for source file:");
+            puts("Testing with oldest file format for source file:");
             src_fapl         = fapl;
             num_attributes_g = 4;
         } /* end else */
 
         /* Set the FAPL for the destination file's type of format */
         if (configuration & CONFIG_DST_NEW_FORMAT) {
-            HDputs("Testing with latest format for destination file:");
+            puts("Testing with latest format for destination file:");
             dst_fapl = fapl2;
         } /* end if */
         else {
-            HDputs("Testing with oldest file format for destination file:");
+            puts("Testing with oldest file format for destination file:");
             dst_fapl = fapl;
         } /* end else */
 
@@ -1934,7 +1934,7 @@ main(void)
         exit(EXIT_FAILURE);
     } /* end if */
 
-    HDputs("All object copying tests passed.");
+    puts("All object copying tests passed.");
 
     /* close property list.
      * NOTE: if this property list is not closed and the test is

--- a/test/ohdr.c
+++ b/test/ohdr.c
@@ -542,9 +542,9 @@ test_unknown(unsigned bogus_id, char *filename, hid_t fapl)
     /* create a different name for a local copy of the data file to be
        opened with rd/wr file permissions in case build and test are
        done in the source directory. */
-    HDstrncpy(testfile, FILE_BOGUS, TESTFILE_LEN);
+    strncpy(testfile, FILE_BOGUS, TESTFILE_LEN);
     testfile[TESTFILE_LEN - 1] = '\0';
-    HDstrncat(testfile, ".copy", sizeof(testfile) - HDstrlen(testfile) - 1);
+    strncat(testfile, ".copy", sizeof(testfile) - strlen(testfile) - 1);
 
     /* Make a copy of the data file from svn. */
     if (h5_make_local_copy(FILE_BOGUS, testfile) < 0)
@@ -945,7 +945,7 @@ test_minimized_dset_ohdr_attribute_addition(hid_t fapl_id)
      * ADD A (STRING) ATTRIBUTE AND MANIPULATE IT *
      **********************************************/
 
-    buf_size = HDstrlen(ATTR_LONG) + 1;
+    buf_size = strlen(ATTR_LONG) + 1;
     if (NULL == (in_buf = (char *)calloc(buf_size, sizeof(char))))
         TEST_ERROR;
     if (NULL == (out_buf = (char *)calloc(buf_size, sizeof(char))))
@@ -964,7 +964,7 @@ test_minimized_dset_ohdr_attribute_addition(hid_t fapl_id)
         TEST_ERROR;
 
     /* Write attribute data */
-    HDstrcpy(in_buf, ATTR_SHORT);
+    strcpy(in_buf, ATTR_SHORT);
     if (H5Awrite(aid, H5T_NATIVE_CHAR, in_buf) < 0)
         TEST_ERROR;
 
@@ -975,12 +975,12 @@ test_minimized_dset_ohdr_attribute_addition(hid_t fapl_id)
     /* Read the data back and verify */
     if (H5Aread(aid, H5T_NATIVE_CHAR, out_buf) < 0)
         TEST_ERROR;
-    if (HDstrcmp(in_buf, out_buf) != 0)
+    if (strcmp(in_buf, out_buf) != 0)
         TEST_ERROR;
 
     /* modify the string attribute */
     memset(in_buf, 0, buf_size);
-    HDstrcpy(in_buf, ATTR_LONG);
+    strcpy(in_buf, ATTR_LONG);
     if (H5Awrite(aid, H5T_NATIVE_CHAR, in_buf) < 0)
         TEST_ERROR;
 
@@ -990,7 +990,7 @@ test_minimized_dset_ohdr_attribute_addition(hid_t fapl_id)
     /* Read the data back and verify */
     if (H5Aread(aid, H5T_NATIVE_CHAR, out_buf) < 0)
         TEST_ERROR;
-    if (HDstrcmp(in_buf, out_buf) != 0)
+    if (strcmp(in_buf, out_buf) != 0)
         TEST_ERROR;
 
     /* Close */
@@ -1010,7 +1010,7 @@ test_minimized_dset_ohdr_attribute_addition(hid_t fapl_id)
     for (i = 0; i < N_ATTRS; i++) {
 
         /* Set the attribute's name */
-        if (HDsnprintf(attr_name, ATTR_NAME_MAX, "int_attr_%d", i) < 0)
+        if (snprintf(attr_name, ATTR_NAME_MAX, "int_attr_%d", i) < 0)
             TEST_ERROR;
 
         /* Create an integer attribute on the dataset */
@@ -1876,8 +1876,8 @@ main(void)
             /* Display info about testing */
             low_string  = h5_get_version_string(low);
             high_string = h5_get_version_string(high);
-            HDsnprintf(msg, sizeof(msg), "Using file format version: (%s, %s)", low_string, high_string);
-            HDputs(msg);
+            snprintf(msg, sizeof(msg), "Using file format version: (%s, %s)", low_string, high_string);
+            puts(msg);
 
             /* test on object continuation block */
             if (test_cont(filename, fapl) < 0)
@@ -2084,23 +2084,23 @@ main(void)
             /* Test reading datasets with undefined object header messages
              * and the various "fail/mark if unknown" object header message flags
              */
-            HDputs("Accessing objects with unknown header messages: H5O_BOGUS_VALID_ID");
+            puts("Accessing objects with unknown header messages: H5O_BOGUS_VALID_ID");
             if (single_file_vfd) {
                 if (test_unknown(H5O_BOGUS_VALID_ID, filename, fapl) < 0)
                     TEST_ERROR;
             } /* end if */
             else {
                 SKIPPED();
-                HDputs("    Unknown header message test not supported with the current VFD.");
+                puts("    Unknown header message test not supported with the current VFD.");
             } /* end else */
-            HDputs("Accessing objects with unknown header messages: H5O_BOGUS_INVALID_ID");
+            puts("Accessing objects with unknown header messages: H5O_BOGUS_INVALID_ID");
             if (single_file_vfd) {
                 if (test_unknown(H5O_BOGUS_INVALID_ID, filename, fapl) < 0)
                     TEST_ERROR;
             } /* end if */
             else {
                 SKIPPED();
-                HDputs("    Unknown header message test not supported with the current VFD.");
+                puts("    Unknown header message test not supported with the current VFD.");
             } /* end else */
 
             /* Test object header creation metadata cache issues */
@@ -2140,19 +2140,19 @@ main(void)
             TEST_ERROR;
     }
     else
-        HDputs("Skipped SWMR tests for SWMR-incompatible VFD");
+        puts("Skipped SWMR tests for SWMR-incompatible VFD");
 
     /* Pop API context */
     if (api_ctx_pushed && H5CX_pop(false) < 0)
         FAIL_STACK_ERROR;
     api_ctx_pushed = false;
 
-    HDputs("All object header tests passed.");
+    puts("All object header tests passed.");
     h5_cleanup(FILENAME, fapl);
     return 0;
 
 error:
-    HDputs("*** TESTS FAILED ***");
+    puts("*** TESTS FAILED ***");
     H5E_BEGIN_TRY
     {
         H5Fclose(file);

--- a/test/onion.c
+++ b/test/onion.c
@@ -119,15 +119,15 @@ onion_filepaths_init(const char *basename)
 
     if (NULL == (paths->canon = malloc(sizeof(char) * ONION_TEST_FIXNAME_SIZE)))
         TEST_ERROR;
-    HDsnprintf(paths->canon, ONION_TEST_FIXNAME_SIZE, "%s", basename);
+    snprintf(paths->canon, ONION_TEST_FIXNAME_SIZE, "%s", basename);
 
     if (NULL == (paths->onion = malloc(sizeof(char) * ONION_TEST_FIXNAME_SIZE)))
         TEST_ERROR;
-    HDsnprintf(paths->onion, ONION_TEST_FIXNAME_SIZE, "%s.onion", paths->canon);
+    snprintf(paths->onion, ONION_TEST_FIXNAME_SIZE, "%s.onion", paths->canon);
 
     if (NULL == (paths->recovery = malloc(sizeof(char) * ONION_TEST_FIXNAME_SIZE)))
         TEST_ERROR;
-    HDsnprintf(paths->recovery, ONION_TEST_FIXNAME_SIZE, "%s.onion.recovery", paths->canon);
+    snprintf(paths->recovery, ONION_TEST_FIXNAME_SIZE, "%s.onion.recovery", paths->canon);
 
     return paths;
 
@@ -848,7 +848,7 @@ test_fapl(void)
         TEST_ERROR;
     if (0 != info_out.force_write_open)
         TEST_ERROR;
-    if (HDstrcmp(info_in.comment, info_out.comment))
+    if (strcmp(info_in.comment, info_out.comment))
         TEST_ERROR;
 
     /* Cleanup */
@@ -1328,7 +1328,7 @@ test_revision_record_encode_decode(void)
     };
     size_t exp_size = H5FD_ONION_ENCODED_SIZE_REVISION_RECORD +
                       (H5FD_ONION_ENCODED_SIZE_INDEX_ENTRY * record.archival_index.n_entries) +
-                      HDstrlen("Example comment message.") + 1;
+                      strlen("Example comment message.") + 1;
 
     r_out.archival_index.list = NULL;
     r_out.comment             = NULL;
@@ -1478,15 +1478,15 @@ test_revision_record_encode_decode(void)
         TEST_ERROR;
     if (record.checksum != r_out.checksum)
         TEST_ERROR;
-    if (HDstrncmp(record.time_of_creation, r_out.time_of_creation, 16) != 0)
+    if (strncmp(record.time_of_creation, r_out.time_of_creation, 16) != 0)
         TEST_ERROR;
     if (record.comment_size != r_out.comment_size)
         TEST_ERROR;
-    if (record.comment_size != HDstrlen(r_out.comment) + 1)
+    if (record.comment_size != strlen(r_out.comment) + 1)
         TEST_ERROR;
-    if (HDstrlen(record.comment) != HDstrlen(r_out.comment))
+    if (strlen(record.comment) != strlen(r_out.comment))
         TEST_ERROR;
-    if (HDstrcmp(record.comment, r_out.comment) != 0)
+    if (strcmp(record.comment, r_out.comment) != 0)
         TEST_ERROR;
 
     if (H5FD_ONION_ARCHIVAL_INDEX_VERSION_CURR != r_out.archival_index.version)
@@ -1766,9 +1766,9 @@ verify_history_as_expected_onion(H5FD_t *raw_file, struct expected_history *filt
                 TEST_ERROR;
         }
         else {
-            if (HDstrlen(rev_out.comment) != HDstrlen(erp->comment))
+            if (strlen(rev_out.comment) != strlen(erp->comment))
                 TEST_ERROR;
-            if (HDstrcmp(rev_out.comment, erp->comment) != 0)
+            if (strcmp(rev_out.comment, erp->comment) != 0)
                 TEST_ERROR;
         }
         if (erp->n_index_entries != (uint64_t)(-1) &&
@@ -2585,7 +2585,7 @@ do_onion_open_and_writes(const char *filename, H5FD_onion_fapl_info_t *onion_inf
 
         onion_info_p->revision_num = about[i].revision_num;
         if (about[i].comment != NULL) {
-            j = MIN(HDstrlen(about[i].comment), H5FD_ONION_FAPL_INFO_COMMENT_MAX_LEN);
+            j = MIN(strlen(about[i].comment), H5FD_ONION_FAPL_INFO_COMMENT_MAX_LEN);
             memcpy(onion_info_p->comment, about[i].comment, j);
         }
         onion_info_p->comment[j] = '\0';
@@ -2615,7 +2615,7 @@ do_onion_open_and_writes(const char *filename, H5FD_onion_fapl_info_t *onion_inf
             if (memcmp(buf_vfy, wi->buf, wi->size) != 0) {
                 const unsigned char *_buf = wi->buf;
                 size_t               z    = 0;
-                HDputs("i  exp  act");
+                puts("i  exp  act");
                 for (z = 0; z < wi->size; z++)
                     printf("%02zx %c %c\n", z, _buf[z], buf_vfy[z]);
                 fflush(stdout);
@@ -2746,7 +2746,7 @@ test_page_aligned_history_create(void)
     if (memcmp(a_list_s, buf + a_off, a_list_size_s) != 0) {
         size_t k;
         printf("aoff: %" PRIu64 "\n", a_off);
-        HDputs("i exp act");
+        puts("i exp act");
         for (k = 0; k < b_list_size_s; k++) {
             printf("%3zu:: %c : %c\n", k, (k < a_off) ? ' ' : a_list_s[k - a_off], buf[k]);
         }
@@ -2756,7 +2756,7 @@ test_page_aligned_history_create(void)
     if (memcmp(b_list_s, buf, a_off) != 0) {
         size_t k;
         printf("aoff: %" PRIu64 "\n", a_off);
-        HDputs("i exp act");
+        puts("i exp act");
         for (k = 0; k < b_list_size_s; k++) {
             printf("%3zu:: %c : %c\n", k, (k < a_off) ? b_list_s[k] : ' ', buf[k]);
         }
@@ -4921,9 +4921,9 @@ main(void)
     env_h5_drvr = HDgetenv(HDF5_DRIVER);
     if (env_h5_drvr == NULL)
         env_h5_drvr = "nomatch";
-    if ((0 != HDstrcmp(env_h5_drvr, "nomatch")) && (0 != HDstrcmp(env_h5_drvr, "sec2"))) {
+    if ((0 != strcmp(env_h5_drvr, "nomatch")) && (0 != strcmp(env_h5_drvr, "sec2"))) {
         SKIPPED();
-        HDputs("Onion VFD test skipped due to non-sec2 default VFD");
+        puts("Onion VFD test skipped due to non-sec2 default VFD");
         exit(EXIT_SUCCESS);
     }
 

--- a/test/page_buffer.c
+++ b/test/page_buffer.c
@@ -116,28 +116,28 @@ create_file(char *filename, hid_t fcpl, hid_t fapl)
 
     for (i = 0; i < NUM_DSETS; i++) {
 
-        HDsnprintf(dset_name, sizeof(dset_name), "D1dset%d", i);
+        snprintf(dset_name, sizeof(dset_name), "D1dset%d", i);
         if ((dset_id = H5Dcreate2(grp_id, dset_name, H5T_NATIVE_INT, filespace, H5P_DEFAULT, dcpl,
                                   H5P_DEFAULT)) < 0)
             FAIL_STACK_ERROR;
         if (H5Dclose(dset_id) < 0)
             FAIL_STACK_ERROR;
 
-        HDsnprintf(dset_name, sizeof(dset_name), "D2dset%d", i);
+        snprintf(dset_name, sizeof(dset_name), "D2dset%d", i);
         if ((dset_id = H5Dcreate2(grp_id, dset_name, H5T_NATIVE_INT, filespace, H5P_DEFAULT, dcpl,
                                   H5P_DEFAULT)) < 0)
             FAIL_STACK_ERROR;
         if (H5Dclose(dset_id) < 0)
             FAIL_STACK_ERROR;
 
-        HDsnprintf(dset_name, sizeof(dset_name), "D3dset%d", i);
+        snprintf(dset_name, sizeof(dset_name), "D3dset%d", i);
         if ((dset_id = H5Dcreate2(grp_id, dset_name, H5T_NATIVE_INT, filespace, H5P_DEFAULT, dcpl,
                                   H5P_DEFAULT)) < 0)
             FAIL_STACK_ERROR;
         if (H5Dclose(dset_id) < 0)
             FAIL_STACK_ERROR;
 
-        HDsnprintf(dset_name, sizeof(dset_name), "dset%d", i);
+        snprintf(dset_name, sizeof(dset_name), "dset%d", i);
         if ((dset_id = H5Dcreate2(grp_id, dset_name, H5T_NATIVE_INT, filespace, H5P_DEFAULT, dcpl,
                                   H5P_DEFAULT)) < 0)
             FAIL_STACK_ERROR;
@@ -162,13 +162,13 @@ create_file(char *filename, hid_t fcpl, hid_t fapl)
             }
         }
 
-        HDsnprintf(dset_name, sizeof(dset_name), "D1dset%d", i);
+        snprintf(dset_name, sizeof(dset_name), "D1dset%d", i);
         if (H5Ldelete(grp_id, dset_name, H5P_DEFAULT) < 0)
             FAIL_STACK_ERROR;
-        HDsnprintf(dset_name, sizeof(dset_name), "D2dset%d", i);
+        snprintf(dset_name, sizeof(dset_name), "D2dset%d", i);
         if (H5Ldelete(grp_id, dset_name, H5P_DEFAULT) < 0)
             FAIL_STACK_ERROR;
-        HDsnprintf(dset_name, sizeof(dset_name), "D3dset%d", i);
+        snprintf(dset_name, sizeof(dset_name), "D3dset%d", i);
         if (H5Ldelete(grp_id, dset_name, H5P_DEFAULT) < 0)
             FAIL_STACK_ERROR;
     }
@@ -252,7 +252,7 @@ open_file(char *filename, hid_t fapl, hsize_t page_size, size_t page_buffer_size
 
     for (i = 0; i < NUM_DSETS; i++) {
 
-        HDsnprintf(dset_name, sizeof(dset_name), "dset%d", i);
+        snprintf(dset_name, sizeof(dset_name), "dset%d", i);
         if ((dset_id = H5Dopen2(grp_id, dset_name, H5P_DEFAULT)) < 0)
             FAIL_STACK_ERROR;
 
@@ -311,9 +311,9 @@ set_multi_split(const char *env_h5_drvr, hid_t fapl, hsize_t pagesize)
     H5FD_mem_t mt;
 
     /* Check for split or multi driver */
-    if (!HDstrcmp(env_h5_drvr, "split"))
+    if (!strcmp(env_h5_drvr, "split"))
         split = true;
-    else if (!HDstrcmp(env_h5_drvr, "multi"))
+    else if (!strcmp(env_h5_drvr, "multi"))
         multi = true;
 
     if (split || multi) {
@@ -2080,10 +2080,10 @@ main(void)
      * Page buffering depends on paged aggregation which is
      * currently disabled for multi/split drivers.
      */
-    if ((0 == HDstrcmp(env_h5_drvr, "multi")) || (0 == HDstrcmp(env_h5_drvr, "split"))) {
+    if ((0 == strcmp(env_h5_drvr, "multi")) || (0 == strcmp(env_h5_drvr, "split"))) {
 
         SKIPPED();
-        HDputs("Skip page buffering test because paged aggregation is disabled for multi/split drivers");
+        puts("Skip page buffering test because paged aggregation is disabled for multi/split drivers");
         exit(EXIT_SUCCESS);
     } /* end if */
 
@@ -2099,7 +2099,7 @@ main(void)
 
 #ifdef H5_HAVE_PARALLEL
 
-    HDputs("Page Buffering is disabled for parallel.");
+    puts("Page Buffering is disabled for parallel.");
     nerrors += verify_page_buffering_disabled(fapl, env_h5_drvr);
 
 #else /* H5_HAVE_PARALLEL */
@@ -2122,7 +2122,7 @@ main(void)
         FAIL_STACK_ERROR;
     api_ctx_pushed = false;
 
-    HDputs("All Page Buffering tests passed.");
+    puts("All Page Buffering tests passed.");
 
     exit(EXIT_SUCCESS);
 

--- a/test/reserved.c
+++ b/test/reserved.c
@@ -64,7 +64,7 @@ rsrv_heap(void)
         }
         H5E_END_TRY
 
-        HDsnprintf(dset_name, sizeof(dset_name), "Dset %d", i);
+        snprintf(dset_name, sizeof(dset_name), "Dset %d", i);
 
         H5E_BEGIN_TRY
         {
@@ -108,7 +108,7 @@ rsrv_heap(void)
     if (H5open() < 0)
         TEST_ERROR;
 
-    HDsnprintf(dset_name, sizeof(dset_name), "Dset %d", i - 2);
+    snprintf(dset_name, sizeof(dset_name), "Dset %d", i - 2);
 
     file_id = H5Fopen(filename, H5F_ACC_RDONLY, H5P_DEFAULT);
     if (file_id < 0)
@@ -205,7 +205,7 @@ rsrv_ohdr(void)
     } /* end for */
 
     for (i = 0; i < 2000; i++) {
-        HDsnprintf(attrname, sizeof(attrname), "attr %d", i);
+        snprintf(attrname, sizeof(attrname), "attr %d", i);
         H5E_BEGIN_TRY
         {
             aid     = H5Screate_simple(2, dims, NULL);
@@ -470,8 +470,8 @@ main(void)
     if (envval == NULL)
         envval = "nomatch";
     /* QAK: should be able to use the core driver? */
-    if (HDstrcmp(envval, "core") && HDstrcmp(envval, "split") && HDstrcmp(envval, "multi") &&
-        HDstrcmp(envval, "family")) {
+    if (strcmp(envval, "core") && strcmp(envval, "split") && strcmp(envval, "multi") &&
+        strcmp(envval, "family")) {
         num_errs += rsrv_ohdr();
         num_errs += rsrv_heap();
         num_errs += rsrv_vlen();
@@ -479,14 +479,14 @@ main(void)
         if (num_errs > 0)
             printf("**** %d FAILURE%s! ****\n", num_errs, num_errs == 1 ? "" : "S");
         else
-            HDputs("All address space reservation tests passed.");
+            puts("All address space reservation tests passed.");
 
         fapl = h5_fileaccess();
         h5_cleanup(FILENAME, fapl);
         return num_errs;
     }
     else {
-        HDputs("All address space reservation tests skipped - Incompatible with current Virtual File Driver");
+        puts("All address space reservation tests skipped - Incompatible with current Virtual File Driver");
     }
 #endif /* BROKEN */
 

--- a/test/ros3.c
+++ b/test/ros3.c
@@ -288,7 +288,7 @@ jserr_str(const char *expected, const char *actual, const char *reason)
  *----------------------------------------------------------------------------
  */
 #define JSVERIFY_STR(expected, actual, reason)                                                               \
-    if (HDstrcmp((actual), (expected)) != 0) {                                                               \
+    if (strcmp((actual), (expected)) != 0) {                                                                 \
         JSERR_STR((expected), (actual), (reason));                                                           \
         goto error;                                                                                          \
     } /* JSVERIFY_STR */
@@ -327,7 +327,7 @@ jserr_str(const char *expected, const char *actual, const char *reason)
  *----------------------------------------------------------------------------
  */
 #define JSVERIFY_STR(actual, expected, reason)                                                               \
-    if (HDstrcmp((actual), (expected)) != 0) {                                                               \
+    if (strcmp((actual), (expected)) != 0) {                                                                 \
         JSERR_STR((expected), (actual), (reason));                                                           \
         goto error;                                                                                          \
     } /* JSVERIFY_STR */
@@ -521,7 +521,7 @@ test_fapl_config_validation(void)
 
     if (false == s3_test_bucket_defined) {
         SKIPPED();
-        HDputs("    environment variable HDF5_ROS3_TEST_BUCKET_URL not defined");
+        puts("    environment variable HDF5_ROS3_TEST_BUCKET_URL not defined");
         fflush(stdout);
         return 0;
     }
@@ -796,7 +796,7 @@ test_vfd_open(void)
 
     if (false == s3_test_bucket_defined) {
         SKIPPED();
-        HDputs("    environment variable HDF5_ROS3_TEST_BUCKET_URL not defined");
+        puts("    environment variable HDF5_ROS3_TEST_BUCKET_URL not defined");
         fflush(stdout);
         return 0;
     }
@@ -936,14 +936,14 @@ test_eof_eoa(void)
 
     if (s3_test_credentials_loaded == 0) {
         SKIPPED();
-        HDputs("    s3 credentials are not loaded");
+        puts("    s3 credentials are not loaded");
         fflush(stdout);
         return 0;
     }
 
     if (false == s3_test_bucket_defined) {
         SKIPPED();
-        HDputs("    environment variable HDF5_ROS3_TEST_BUCKET_URL not defined");
+        puts("    environment variable HDF5_ROS3_TEST_BUCKET_URL not defined");
         fflush(stdout);
         return 0;
     }
@@ -1044,14 +1044,14 @@ test_H5FDread_without_eoa_set_fails(void)
 
     if (s3_test_credentials_loaded == 0) {
         SKIPPED();
-        HDputs("    s3 credentials are not loaded");
+        puts("    s3 credentials are not loaded");
         fflush(stdout);
         return 0;
     }
 
     if (false == s3_test_bucket_defined) {
         SKIPPED();
-        HDputs("    environment variable HDF5_ROS3_TEST_BUCKET_URL not defined");
+        puts("    environment variable HDF5_ROS3_TEST_BUCKET_URL not defined");
         fflush(stdout);
         return 0;
     }
@@ -1215,14 +1215,14 @@ test_read(void)
 
     if (s3_test_credentials_loaded == 0) {
         SKIPPED();
-        HDputs("    s3 credentials are not loaded");
+        puts("    s3 credentials are not loaded");
         fflush(stdout);
         return 0;
     }
 
     if (false == s3_test_bucket_defined) {
         SKIPPED();
-        HDputs("    environment variable HDF5_ROS3_TEST_BUCKET_URL not defined");
+        puts("    environment variable HDF5_ROS3_TEST_BUCKET_URL not defined");
         fflush(stdout);
         return 0;
     }
@@ -1356,7 +1356,7 @@ test_noops_and_autofails(void)
 
     if (false == s3_test_bucket_defined) {
         SKIPPED();
-        HDputs("    environment variable HDF5_ROS3_TEST_BUCKET_URL not defined");
+        puts("    environment variable HDF5_ROS3_TEST_BUCKET_URL not defined");
         fflush(stdout);
         return 0;
     }
@@ -1473,14 +1473,14 @@ test_cmp(void)
 
     if (s3_test_credentials_loaded == 0) {
         SKIPPED();
-        HDputs("    s3 credentials are not loaded");
+        puts("    s3 credentials are not loaded");
         fflush(stdout);
         return 0;
     }
 
     if (false == s3_test_bucket_defined) {
         SKIPPED();
-        HDputs("    environment variable HDF5_ROS3_TEST_BUCKET_URL not defined");
+        puts("    environment variable HDF5_ROS3_TEST_BUCKET_URL not defined");
         fflush(stdout);
         return 0;
     }
@@ -1594,14 +1594,14 @@ test_H5F_integration(void)
 
     if (s3_test_credentials_loaded == 0) {
         SKIPPED();
-        HDputs("    s3 credentials are not loaded");
+        puts("    s3 credentials are not loaded");
         fflush(stdout);
         return 0;
     }
 
     if (false == s3_test_bucket_defined) {
         SKIPPED();
-        HDputs("    environment variable HDF5_ROS3_TEST_BUCKET_URL not defined");
+        puts("    environment variable HDF5_ROS3_TEST_BUCKET_URL not defined");
         fflush(stdout);
         return 0;
     }
@@ -1701,31 +1701,31 @@ main(void)
                "variable 'HDF5_ROS3_TEST_BUCKET_URL'!\n");
     }
     else {
-        HDstrncpy(s3_test_bucket_url, bucket_url_env, S3_TEST_MAX_URL_SIZE);
+        strncpy(s3_test_bucket_url, bucket_url_env, S3_TEST_MAX_URL_SIZE);
         s3_test_bucket_defined = true;
     }
 
-    if (S3_TEST_MAX_URL_SIZE < HDsnprintf(url_text_restricted, (size_t)S3_TEST_MAX_URL_SIZE, "%s/%s",
-                                          (const char *)s3_test_bucket_url,
-                                          (const char *)S3_TEST_RESOURCE_TEXT_RESTRICTED)) {
+    if (S3_TEST_MAX_URL_SIZE < snprintf(url_text_restricted, (size_t)S3_TEST_MAX_URL_SIZE, "%s/%s",
+                                        (const char *)s3_test_bucket_url,
+                                        (const char *)S3_TEST_RESOURCE_TEXT_RESTRICTED)) {
         printf("* ros3 setup failed (text_restricted) ! *\n");
         return 1;
     }
-    if (S3_TEST_MAX_URL_SIZE < HDsnprintf(url_text_public, (size_t)S3_TEST_MAX_URL_SIZE, "%s/%s",
-                                          (const char *)s3_test_bucket_url,
-                                          (const char *)S3_TEST_RESOURCE_TEXT_PUBLIC)) {
+    if (S3_TEST_MAX_URL_SIZE < snprintf(url_text_public, (size_t)S3_TEST_MAX_URL_SIZE, "%s/%s",
+                                        (const char *)s3_test_bucket_url,
+                                        (const char *)S3_TEST_RESOURCE_TEXT_PUBLIC)) {
         printf("* ros3 setup failed (text_public) ! *\n");
         return 1;
     }
-    if (S3_TEST_MAX_URL_SIZE < HDsnprintf(url_h5_public, (size_t)S3_TEST_MAX_URL_SIZE, "%s/%s",
-                                          (const char *)s3_test_bucket_url,
-                                          (const char *)S3_TEST_RESOURCE_H5_PUBLIC)) {
+    if (S3_TEST_MAX_URL_SIZE < snprintf(url_h5_public, (size_t)S3_TEST_MAX_URL_SIZE, "%s/%s",
+                                        (const char *)s3_test_bucket_url,
+                                        (const char *)S3_TEST_RESOURCE_H5_PUBLIC)) {
         printf("* ros3 setup failed (h5_public) ! *\n");
         return 1;
     }
-    if (S3_TEST_MAX_URL_SIZE < HDsnprintf(url_missing, S3_TEST_MAX_URL_SIZE, "%s/%s",
-                                          (const char *)s3_test_bucket_url,
-                                          (const char *)S3_TEST_RESOURCE_MISSING)) {
+    if (S3_TEST_MAX_URL_SIZE < snprintf(url_missing, S3_TEST_MAX_URL_SIZE, "%s/%s",
+                                        (const char *)s3_test_bucket_url,
+                                        (const char *)S3_TEST_RESOURCE_MISSING)) {
         printf("* ros3 setup failed (missing) ! *\n");
         return 1;
     }
@@ -1745,12 +1745,11 @@ main(void)
     if (SUCCEED == H5FD_s3comms_load_aws_profile(S3_TEST_PROFILE_NAME, s3_test_aws_access_key_id,
                                                  s3_test_aws_secret_access_key, s3_test_aws_region)) {
         s3_test_credentials_loaded = 1;
-        HDstrncpy(restricted_access_fa.aws_region, (const char *)s3_test_aws_region,
-                  H5FD_ROS3_MAX_REGION_LEN);
-        HDstrncpy(restricted_access_fa.secret_id, (const char *)s3_test_aws_access_key_id,
-                  H5FD_ROS3_MAX_SECRET_ID_LEN);
-        HDstrncpy(restricted_access_fa.secret_key, (const char *)s3_test_aws_secret_access_key,
-                  H5FD_ROS3_MAX_SECRET_KEY_LEN);
+        strncpy(restricted_access_fa.aws_region, (const char *)s3_test_aws_region, H5FD_ROS3_MAX_REGION_LEN);
+        strncpy(restricted_access_fa.secret_id, (const char *)s3_test_aws_access_key_id,
+                H5FD_ROS3_MAX_SECRET_ID_LEN);
+        strncpy(restricted_access_fa.secret_key, (const char *)s3_test_aws_secret_access_key,
+                H5FD_ROS3_MAX_SECRET_KEY_LEN);
     }
 
     /******************

--- a/test/s3comms.c
+++ b/test/s3comms.c
@@ -281,7 +281,7 @@ jserr_str(const char *expected, const char *actual, const char *reason)
  *----------------------------------------------------------------------------
  */
 #define JSVERIFY_STR(expected, actual, reason)                                                               \
-    if (HDstrcmp((actual), (expected)) != 0) {                                                               \
+    if (strcmp((actual), (expected)) != 0) {                                                                 \
         JSERR_STR((expected), (actual), (reason));                                                           \
         goto error;                                                                                          \
     } /* JSVERIFY_STR */
@@ -323,7 +323,7 @@ jserr_str(const char *expected, const char *actual, const char *reason)
  *----------------------------------------------------------------------------
  */
 #define JSVERIFY_STR(actual, expected, reason)                                                               \
-    if (HDstrcmp((actual), (expected)) != 0) {                                                               \
+    if (strcmp((actual), (expected)) != 0) {                                                                 \
         JSERR_STR((expected), (actual), (reason));                                                           \
         goto error;                                                                                          \
     } /* JSVERIFY_STR */
@@ -1188,8 +1188,8 @@ test_HMAC_SHA256(void)
             SHA256_DIGEST_LENGTH,
             "AWS4-HMAC-SHA256\n20130524T000000Z\n20130524/us-east-1/s3/"
             "aws4_request\n7344ae5b7ee6c3e7e6b0fe0640412a37625d1fbfff95c48bbb2dc43964946972",
-            HDstrlen("AWS4-HMAC-SHA256\n20130524T000000Z\n20130524/us-east-1/s3/"
-                     "aws4_request\n7344ae5b7ee6c3e7e6b0fe0640412a37625d1fbfff95c48bbb2dc43964946972"),
+            strlen("AWS4-HMAC-SHA256\n20130524T000000Z\n20130524/us-east-1/s3/"
+                   "aws4_request\n7344ae5b7ee6c3e7e6b0fe0640412a37625d1fbfff95c48bbb2dc43964946972"),
             "f0e8bdb87c964420e857bd35b5d6ed310bd44f0170aba48dd91039c6036bdb41",
             SHA256_DIGEST_LENGTH * 2 + 1, /* +1 for null terminator */
         },
@@ -1228,7 +1228,7 @@ test_HMAC_SHA256(void)
             cases[i].msg);
         if (cases[i].ret == SUCCEED) {
 #ifdef VERBOSE
-            if (0 != HDstrncmp(cases[i].exp, dest, HDstrlen(cases[i].exp))) {
+            if (0 != strncmp(cases[i].exp, dest, strlen(cases[i].exp))) {
                 /* print out how wrong things are, and then fail
                  */
                 dest = (char *)realloc(dest, cases[i].dest_size + 1);
@@ -1240,7 +1240,7 @@ test_HMAC_SHA256(void)
 #else  /* VERBOSE not defined */
             /* simple pass/fail test
              */
-            JSVERIFY(0, HDstrncmp(cases[i].exp, dest, HDstrlen(cases[i].exp)), NULL);
+            JSVERIFY(0, strncmp(cases[i].exp, dest, strlen(cases[i].exp)), NULL);
 #endif /* VERBOSE */
         }
         free(dest);
@@ -1313,7 +1313,7 @@ test_nlowercase(void)
 
         JSVERIFY(SUCCEED, H5FD_s3comms_nlowercase(dest, cases[i].in, cases[i].len), cases[i].in)
         if (cases[i].len > 0) {
-            JSVERIFY(0, HDstrncmp(dest, cases[i].exp, cases[i].len), NULL)
+            JSVERIFY(0, strncmp(dest, cases[i].exp, cases[i].len), NULL)
         }
         free(dest);
     } /* end for each testcase */
@@ -1679,7 +1679,7 @@ test_percent_encode_char(void)
         JSVERIFY(SUCCEED, H5FD_s3comms_percent_encode_char(dest, (const unsigned char)cases[i].c, &dest_len),
                  NULL)
         JSVERIFY(cases[i].exp_len, dest_len, NULL)
-        JSVERIFY(0, HDstrncmp(dest, cases[i].exp, dest_len), NULL)
+        JSVERIFY(0, strncmp(dest, cases[i].exp, dest_len), NULL)
         JSVERIFY_STR(cases[i].exp, dest, NULL)
     }
 
@@ -1713,13 +1713,13 @@ test_s3r_get_filesize(void)
      */
     if (false == s3_test_bucket_defined) {
         SKIPPED();
-        HDputs("    environment variable HDF5_ROS3_TEST_BUCKET_URL not defined");
+        puts("    environment variable HDF5_ROS3_TEST_BUCKET_URL not defined");
         fflush(stdout);
         return 0;
     }
 
-    FAIL_IF(S3_TEST_MAX_URL_SIZE < HDsnprintf(url_raven, S3_TEST_MAX_URL_SIZE, "%s/%s", s3_test_bucket_url,
-                                              S3_TEST_RESOURCE_TEXT_PUBLIC));
+    FAIL_IF(S3_TEST_MAX_URL_SIZE < snprintf(url_raven, S3_TEST_MAX_URL_SIZE, "%s/%s", s3_test_bucket_url,
+                                            S3_TEST_RESOURCE_TEXT_PUBLIC));
 
     JSVERIFY(0, H5FD_s3comms_s3r_get_filesize(NULL), "filesize of the null handle should be 0")
 
@@ -1769,13 +1769,13 @@ test_s3r_open(void)
 
     if (s3_test_credentials_loaded == 0) {
         SKIPPED();
-        HDputs("    s3 credentials are not loaded");
+        puts("    s3 credentials are not loaded");
         fflush(stdout);
         return 0;
     }
     if (false == s3_test_bucket_defined) {
         SKIPPED();
-        HDputs("    environment variable HDF5_ROS3_TEST_BUCKET_URL not defined");
+        puts("    environment variable HDF5_ROS3_TEST_BUCKET_URL not defined");
         fflush(stdout);
         return 0;
     }
@@ -1784,14 +1784,14 @@ test_s3r_open(void)
      * PRE-TEST SETUP *
      ******************/
 
-    FAIL_IF(S3_TEST_MAX_URL_SIZE < HDsnprintf(url_shakespeare, S3_TEST_MAX_URL_SIZE, "%s/%s",
-                                              s3_test_bucket_url, S3_TEST_RESOURCE_TEXT_RESTRICTED));
+    FAIL_IF(S3_TEST_MAX_URL_SIZE < snprintf(url_shakespeare, S3_TEST_MAX_URL_SIZE, "%s/%s",
+                                            s3_test_bucket_url, S3_TEST_RESOURCE_TEXT_RESTRICTED));
 
-    FAIL_IF(S3_TEST_MAX_URL_SIZE < HDsnprintf(url_missing, S3_TEST_MAX_URL_SIZE, "%s/%s", s3_test_bucket_url,
-                                              S3_TEST_RESOURCE_MISSING));
+    FAIL_IF(S3_TEST_MAX_URL_SIZE < snprintf(url_missing, S3_TEST_MAX_URL_SIZE, "%s/%s", s3_test_bucket_url,
+                                            S3_TEST_RESOURCE_MISSING));
 
-    FAIL_IF(S3_TEST_MAX_URL_SIZE < HDsnprintf(url_raven, S3_TEST_MAX_URL_SIZE, "%s/%s", s3_test_bucket_url,
-                                              S3_TEST_RESOURCE_TEXT_PUBLIC));
+    FAIL_IF(S3_TEST_MAX_URL_SIZE < snprintf(url_raven, S3_TEST_MAX_URL_SIZE, "%s/%s", s3_test_bucket_url,
+                                            S3_TEST_RESOURCE_TEXT_PUBLIC));
 
     /* Set given bucket url with invalid/inactive port number for badport.
      * Note, this sort of micro-management of parsed_url_t is not advised
@@ -1800,17 +1800,17 @@ test_s3r_open(void)
     if (purl->port == NULL) {
         purl->port = (char *)H5MM_malloc(sizeof(char) * 5);
         FAIL_IF(purl->port == NULL);
-        FAIL_IF(5 < HDsnprintf(purl->port, 5, "9000"))
+        FAIL_IF(5 < snprintf(purl->port, 5, "9000"))
     }
-    else if (HDstrcmp(purl->port, "9000") != 0) {
-        FAIL_IF(5 < HDsnprintf(purl->port, 5, "9000"))
+    else if (strcmp(purl->port, "9000") != 0) {
+        FAIL_IF(5 < snprintf(purl->port, 5, "9000"))
     }
     else {
-        FAIL_IF(5 < HDsnprintf(purl->port, 5, "1234"))
+        FAIL_IF(5 < snprintf(purl->port, 5, "1234"))
     }
-    FAIL_IF(S3_TEST_MAX_URL_SIZE < HDsnprintf(url_raven_badport, S3_TEST_MAX_URL_SIZE, "%s://%s:%s/%s",
-                                              purl->scheme, purl->host, purl->port,
-                                              S3_TEST_RESOURCE_TEXT_PUBLIC));
+    FAIL_IF(S3_TEST_MAX_URL_SIZE < snprintf(url_raven_badport, S3_TEST_MAX_URL_SIZE, "%s://%s:%s/%s",
+                                            purl->scheme, purl->host, purl->port,
+                                            S3_TEST_RESOURCE_TEXT_PUBLIC));
 
     curl_global_init(CURL_GLOBAL_DEFAULT);
     curl_ready = true;
@@ -1971,15 +1971,15 @@ test_s3r_read(void)
      */
     if (false == s3_test_bucket_defined) {
         SKIPPED();
-        HDputs("    environment variable HDF5_ROS3_TEST_BUCKET_URL not defined");
+        puts("    environment variable HDF5_ROS3_TEST_BUCKET_URL not defined");
         fflush(stdout);
         return 0;
     }
 
     curl_global_init(CURL_GLOBAL_DEFAULT);
     curl_ready = true;
-    FAIL_IF(S3_TEST_MAX_URL_SIZE < HDsnprintf(url_raven, S3_TEST_MAX_URL_SIZE, "%s/%s", s3_test_bucket_url,
-                                              S3_TEST_RESOURCE_TEXT_PUBLIC));
+    FAIL_IF(S3_TEST_MAX_URL_SIZE < snprintf(url_raven, S3_TEST_MAX_URL_SIZE, "%s/%s", s3_test_bucket_url,
+                                            S3_TEST_RESOURCE_TEXT_PUBLIC));
 
     for (i = 0; i < S3COMMS_TEST_BUFFER_SIZE; i++)
         buffer[i] = '\0';
@@ -2032,7 +2032,7 @@ test_s3r_read(void)
     JSVERIFY(SUCCEED, H5FD_s3comms_s3r_read(handle, (haddr_t)6370, (size_t)0, buffer), NULL)
     JSVERIFY(
         0,
-        HDstrncmp(
+        strncmp(
             buffer,
             "And my soul from out that shadow that lies floating on the floor\nShall be lifted—nevermore!\n",
             94),
@@ -2049,7 +2049,7 @@ test_s3r_read(void)
              H5FD_s3comms_s3r_read(handle, (haddr_t)6400, (size_t)100, /* 6400+100 > 6464 */
                                    buffer),
              NULL)
-    JSVERIFY(0, HDstrcmp("", buffer), NULL)
+    JSVERIFY(0, strcmp("", buffer), NULL)
 
     /************************
      * read starts past eof *
@@ -2059,14 +2059,14 @@ test_s3r_read(void)
              H5FD_s3comms_s3r_read(handle, (haddr_t)1200699, /* 1200699 > 6464 */
                                    (size_t)100, buffer),
              NULL)
-    JSVERIFY(0, HDstrcmp("", buffer), NULL)
+    JSVERIFY(0, strcmp("", buffer), NULL)
 
     /**********************
      * read starts on eof *
      **********************/
 
     JSVERIFY(FAIL, H5FD_s3comms_s3r_read(handle, (haddr_t)6464, (size_t)0, buffer), NULL)
-    JSVERIFY(0, HDstrcmp("", buffer), NULL)
+    JSVERIFY(0, strcmp("", buffer), NULL)
 
     /*************
      * TEAR DOWN *
@@ -2153,7 +2153,7 @@ test_signing_key(void)
         JSVERIFY(SUCCEED, H5FD_s3comms_signing_key(key, cases[i].secret_key, cases[i].region, cases[i].when),
                  NULL)
 
-        JSVERIFY(0, HDstrncmp((const char *)cases[i].exp, (const char *)key, SHA256_DIGEST_LENGTH),
+        JSVERIFY(0, strncmp((const char *)cases[i].exp, (const char *)key, SHA256_DIGEST_LENGTH),
                  (const char *)cases[i].exp)
 
         free(key);
@@ -2324,12 +2324,12 @@ test_trim(void)
         assert(str == NULL);
         str = (char *)malloc(sizeof(char) * cases[i].in_len);
         assert(str != NULL);
-        HDstrncpy(str, cases[i].in, cases[i].in_len);
+        strncpy(str, cases[i].in, cases[i].in_len);
 
         JSVERIFY(SUCCEED, H5FD_s3comms_trim(dest, str, cases[i].in_len, &dest_len), NULL)
         JSVERIFY(cases[i].exp_len, dest_len, cases[i].in)
         if (dest_len > 0) {
-            JSVERIFY(0, HDstrncmp(cases[i].exp, dest, dest_len), cases[i].exp)
+            JSVERIFY(0, strncmp(cases[i].exp, dest, dest_len), cases[i].exp)
         }
         free(str);
         str = NULL;
@@ -2439,8 +2439,8 @@ test_uriencode(void)
         JSVERIFY(SUCCEED,
                  H5FD_s3comms_uriencode(dest, cases[i].str, str_len, cases[i].encode_slash, &dest_written),
                  NULL);
-        JSVERIFY(HDstrlen(cases[i].expected), dest_written, NULL)
-        JSVERIFY(0, HDstrncmp(dest, cases[i].expected, dest_written), cases[i].expected);
+        JSVERIFY(strlen(cases[i].expected), dest_written, NULL)
+        JSVERIFY(0, strncmp(dest, cases[i].expected, dest_written), cases[i].expected);
 
         free(dest);
         dest = NULL;
@@ -2526,7 +2526,7 @@ main(void)
                "variable 'HDF5_ROS3_TEST_BUCKET_URL'!\n");
     }
     else {
-        HDstrncpy(s3_test_bucket_url, bucket_url_env, S3_TEST_MAX_URL_SIZE);
+        strncpy(s3_test_bucket_url, bucket_url_env, S3_TEST_MAX_URL_SIZE);
         s3_test_bucket_defined = true;
     }
 

--- a/test/select_io_dset.c
+++ b/test/select_io_dset.c
@@ -141,8 +141,8 @@ test_no_type_conv(hid_t fid, unsigned chunked, unsigned dtrans, unsigned mwbuf)
     }
 
     /* Generate dataset name */
-    HDsnprintf(dset_name, sizeof(dset_name), "no_tconv_%s_%s_%s", chunked ? "chunked" : "contig",
-               dtrans ? "xform" : "noxform", mwbuf ? "mwbuf" : "nomwbuf");
+    snprintf(dset_name, sizeof(dset_name), "no_tconv_%s_%s_%s", chunked ? "chunked" : "contig",
+             dtrans ? "xform" : "noxform", mwbuf ? "mwbuf" : "nomwbuf");
 
     /* Create dataset */
     if ((did = H5Dcreate2(fid, dset_name, H5T_NATIVE_INT, sid, H5P_DEFAULT, dcpl, H5P_DEFAULT)) < 0)
@@ -299,8 +299,8 @@ test_no_size_change_no_bkg(hid_t fid, unsigned chunked, unsigned mwbuf)
     }
 
     /* Generate dataset name */
-    HDsnprintf(dset_name, sizeof(dset_name), "no_size_change_%s_%s", chunked ? "chunked" : "contig",
-               mwbuf ? "mwbuf" : "nomwbuf");
+    snprintf(dset_name, sizeof(dset_name), "no_size_change_%s_%s", chunked ? "chunked" : "contig",
+             mwbuf ? "mwbuf" : "nomwbuf");
 
     /* Create 1d dataset */
     if ((did = H5Dcreate2(fid, dset_name, H5T_STD_I32BE, sid, H5P_DEFAULT, dcpl, H5P_DEFAULT)) < 0)
@@ -431,8 +431,8 @@ test_larger_mem_type_no_bkg(hid_t fid, unsigned chunked, unsigned dtrans, unsign
     }
 
     /* Generate dataset name */
-    HDsnprintf(dset_name, sizeof(dset_name), "larger_no_bkg_%s_%s_%s", chunked ? "chunked" : "contig",
-               dtrans ? "xform" : "noxform", mwbuf ? "mwbuf" : "nomwbuf");
+    snprintf(dset_name, sizeof(dset_name), "larger_no_bkg_%s_%s_%s", chunked ? "chunked" : "contig",
+             dtrans ? "xform" : "noxform", mwbuf ? "mwbuf" : "nomwbuf");
 
     /* Create dataset */
     if ((did = H5Dcreate2(fid, dset_name, H5T_NATIVE_INT, sid, H5P_DEFAULT, dcpl, H5P_DEFAULT)) < 0)
@@ -573,8 +573,8 @@ test_smaller_mem_type_no_bkg(hid_t fid, unsigned chunked, unsigned dtrans, unsig
     }
 
     /* Generate dataset name */
-    HDsnprintf(dset_name, sizeof(dset_name), "smaller_no_bkg_%s_%s_%s", chunked ? "chunked" : "contig",
-               dtrans ? "xform" : "noxform", mwbuf ? "mwbuf" : "nomwbuf");
+    snprintf(dset_name, sizeof(dset_name), "smaller_no_bkg_%s_%s_%s", chunked ? "chunked" : "contig",
+             dtrans ? "xform" : "noxform", mwbuf ? "mwbuf" : "nomwbuf");
 
     /* Create 1d chunked dataset with/without data transform */
     if ((did = H5Dcreate2(fid, dset_name, H5T_NATIVE_INT, sid, H5P_DEFAULT, dcpl, H5P_DEFAULT)) < 0)
@@ -774,8 +774,8 @@ test_cmpd_with_bkg(hid_t fid, unsigned chunked, unsigned mwbuf)
     /* Case 5(a) */
 
     /* Generate dataset name */
-    HDsnprintf(dset_name, sizeof(dset_name), "cmpd_with_bkg_%s_%s", chunked ? "chunked" : "contig",
-               mwbuf ? "mwbuf" : "nomwbuf");
+    snprintf(dset_name, sizeof(dset_name), "cmpd_with_bkg_%s_%s", chunked ? "chunked" : "contig",
+             mwbuf ? "mwbuf" : "nomwbuf");
 
     /* Create 1d dataset */
     if ((did = H5Dcreate2(fid, dset_name, s1_tid, sid, H5P_DEFAULT, dcpl, H5P_DEFAULT)) < 0)
@@ -1101,8 +1101,8 @@ test_multi_dsets_no_bkg(hid_t fid, unsigned chunked, unsigned dtrans, unsigned m
             FAIL_STACK_ERROR;
 
         /* Generate dataset name */
-        HDsnprintf(dset_names[i], sizeof(dset_names[i]), "multi_dset%d_%s_%s_%s", i,
-                   chunked ? "chunked" : "contig", dtrans ? "xform" : "noxform", mwbuf ? "mwbuf" : "nomwbuf");
+        snprintf(dset_names[i], sizeof(dset_names[i]), "multi_dset%d_%s_%s_%s", i,
+                 chunked ? "chunked" : "contig", dtrans ? "xform" : "noxform", mwbuf ? "mwbuf" : "nomwbuf");
 
         /* Create ith dataset */
         if ((dset_dids[i] =
@@ -1431,8 +1431,8 @@ test_multi_dsets_cmpd_with_bkg(hid_t fid, unsigned chunked, unsigned mwbuf)
             FAIL_STACK_ERROR;
 
         /* Generate dataset name */
-        HDsnprintf(dset_names[i], sizeof(dset_names[i]), "multi_cmpd_dset%d_%s_%s", i,
-                   chunked ? "chunked" : "contig", mwbuf ? "mwbuf" : "nomwbuf");
+        snprintf(dset_names[i], sizeof(dset_names[i]), "multi_cmpd_dset%d_%s_%s", i,
+                 chunked ? "chunked" : "contig", mwbuf ? "mwbuf" : "nomwbuf");
 
         /* Create ith dataset */
         if ((dset_dids[i] =
@@ -1865,8 +1865,8 @@ test_multi_dsets_size_change_no_bkg(hid_t fid, unsigned chunked, unsigned mwbuf)
             FAIL_STACK_ERROR;
 
         /* Generate dataset name */
-        HDsnprintf(dset_names[i], sizeof(dset_names[i]), "multi_size_dset%d_%s_%s", i,
-                   chunked ? "chunked" : "contig", mwbuf ? "mwbuf" : "nomwbuf");
+        snprintf(dset_names[i], sizeof(dset_names[i]), "multi_size_dset%d_%s_%s", i,
+                 chunked ? "chunked" : "contig", mwbuf ? "mwbuf" : "nomwbuf");
 
         /* Create ith dataset */
         if ((dset_dids[i] = H5Dcreate2(fid, dset_names[i], H5T_STD_I32BE, file_sids[i], H5P_DEFAULT, dcpl,
@@ -2332,24 +2332,24 @@ test_multi_dsets_all(int niter, hid_t fid, unsigned chunked, unsigned mwbuf)
             mm = HDrandom() % (int)ndsets;
             if (mm == 0) {
                 dset_types[i] = DSET_WITH_NO_CONV;
-                HDsnprintf(dset_names[i], sizeof(dset_names[i]), "multi_all_nconv_dset%d_%s_%s", i,
-                           chunked ? "chunked" : "contig", mwbuf ? "mwbuf" : "nomwbuf");
+                snprintf(dset_names[i], sizeof(dset_names[i]), "multi_all_nconv_dset%d_%s_%s", i,
+                         chunked ? "chunked" : "contig", mwbuf ? "mwbuf" : "nomwbuf");
                 if ((dset_dids[i] = H5Dcreate2(fid, dset_names[i], H5T_NATIVE_INT, file_sids[i], H5P_DEFAULT,
                                                dcpl, H5P_DEFAULT)) < 0)
                     FAIL_STACK_ERROR;
             }
             else if (mm == 1) {
                 dset_types[i] = DSET_WITH_CONV_AND_NO_BKG;
-                HDsnprintf(dset_names[i], sizeof(dset_names[i]), "multi_all_conv_nbkg_dset%d_%s_%s", i,
-                           chunked ? "chunked" : "contig", mwbuf ? "mwbuf" : "nomwbuf");
+                snprintf(dset_names[i], sizeof(dset_names[i]), "multi_all_conv_nbkg_dset%d_%s_%s", i,
+                         chunked ? "chunked" : "contig", mwbuf ? "mwbuf" : "nomwbuf");
                 if ((dset_dids[i] = H5Dcreate2(fid, dset_names[i], H5T_NATIVE_LONG, file_sids[i], H5P_DEFAULT,
                                                dcpl, H5P_DEFAULT)) < 0)
                     FAIL_STACK_ERROR;
             }
             else {
                 dset_types[i] = DSET_WITH_CONV_AND_BKG;
-                HDsnprintf(dset_names[i], sizeof(dset_names[i]), "multi_all_conv_bkg_dset%d_%s_%s", i,
-                           chunked ? "chunked" : "contig", mwbuf ? "mwbuf" : "nomwbuf");
+                snprintf(dset_names[i], sizeof(dset_names[i]), "multi_all_conv_bkg_dset%d_%s_%s", i,
+                         chunked ? "chunked" : "contig", mwbuf ? "mwbuf" : "nomwbuf");
                 if ((dset_dids[i] = H5Dcreate2(fid, dset_names[i], s1_tid, file_sids[i], H5P_DEFAULT, dcpl,
                                                H5P_DEFAULT)) < 0)
                     FAIL_STACK_ERROR;
@@ -2860,7 +2860,7 @@ test_no_selection_io_cause_mode(const char *filename, hid_t fapl, uint32_t test_
         /* The split and multi driver are not compatible with page buffering.  No message since the other
          * cases aren't skipped. */
         env_h5_drvr = HDgetenv(HDF5_DRIVER);
-        if (env_h5_drvr && (!HDstrcmp(env_h5_drvr, "split") || !HDstrcmp(env_h5_drvr, "multi")))
+        if (env_h5_drvr && (!strcmp(env_h5_drvr, "split") || !strcmp(env_h5_drvr, "multi")))
             return 0;
     }
 

--- a/test/set_extent.c
+++ b/test/set_extent.c
@@ -117,7 +117,7 @@ main(void)
     if (env_h5_drvr == NULL)
         env_h5_drvr = "nomatch";
     /* Current VFD that does not support contiguous address space */
-    contig_addr_vfd = (bool)(HDstrcmp(env_h5_drvr, "split") != 0 && HDstrcmp(env_h5_drvr, "multi") != 0);
+    contig_addr_vfd = (bool)(strcmp(env_h5_drvr, "split") != 0 && strcmp(env_h5_drvr, "multi") != 0);
 
     /* Initialize random number seed */
     HDsrandom((unsigned)HDtime(NULL));
@@ -155,11 +155,11 @@ main(void)
 
             /* Set the FAPL for the chunk cache settings */
             if (chunk_cache) {
-                HDputs(" and chunk cache enabled:");
+                puts(" and chunk cache enabled:");
                 my_fapl = fapl;
             } /* end if */
             else {
-                HDputs(" and chunk cache disabled:");
+                puts(" and chunk cache disabled:");
                 my_fapl = fapl2;
             } /* end else */
 
@@ -209,7 +209,7 @@ main(void)
 
     if (nerrors)
         goto error;
-    HDputs("All H5Dset_extent tests passed.");
+    puts("All H5Dset_extent tests passed.");
 
     return 0;
 

--- a/test/stab.c
+++ b/test/stab.c
@@ -125,9 +125,9 @@ test_misc(hid_t fcpl, hid_t fapl, bool new_format)
         TEST_ERROR;
     if (H5Oget_comment_by_name(g3, "././.", comment, sizeof comment, H5P_DEFAULT) < 0)
         TEST_ERROR;
-    if (HDstrcmp(comment, "hello world") != 0) {
+    if (strcmp(comment, "hello world") != 0) {
         H5_FAILED();
-        HDputs("    Read the wrong comment string from the group.");
+        puts("    Read the wrong comment string from the group.");
         printf("    got: \"%s\"\n    ans: \"hello world\"\n", comment);
         TEST_ERROR;
     }
@@ -210,7 +210,7 @@ test_long(hid_t fcpl, hid_t fapl, bool new_format)
     name1[LONG_NAME_LEN - 1] = '\0';
     name2Len                 = (2 * LONG_NAME_LEN) + 2;
     name2                    = (char *)malloc(name2Len);
-    HDsnprintf(name2, name2Len, "%s/%s", name1, name1);
+    snprintf(name2, name2Len, "%s/%s", name1, name1);
 
     /* Create groups */
     if ((g1 = H5Gcreate2(fid, name1, H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT)) < 0)
@@ -296,7 +296,7 @@ test_large(hid_t fcpl, hid_t fapl, bool new_format)
         if (H5G__has_stab_test(cwg) != false)
             TEST_ERROR;
     for (i = 0; i < LARGE_NOBJS; i++) {
-        HDsnprintf(name, sizeof(name), "%05d%05d", (HDrandom() % 100000), i);
+        snprintf(name, sizeof(name), "%05d%05d", (HDrandom() % 100000), i);
         if ((dir = H5Gcreate2(cwg, name, H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT)) < 0)
             TEST_ERROR;
         if (H5Gclose(dir) < 0)
@@ -435,7 +435,7 @@ lifecycle(hid_t fcpl, hid_t fapl2)
         TEST_ERROR;
 
     /* Create first "bottom" group */
-    HDsnprintf(objname, sizeof(objname), LIFECYCLE_BOTTOM_GROUP, (unsigned)0);
+    snprintf(objname, sizeof(objname), LIFECYCLE_BOTTOM_GROUP, (unsigned)0);
     if ((gid2 = H5Gcreate2(gid, objname, H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT)) < 0)
         TEST_ERROR;
 
@@ -458,7 +458,7 @@ lifecycle(hid_t fcpl, hid_t fapl2)
     /* Create several more bottom groups, to push the top group almost to a symbol table */
     /* (Start counting at '1', since we've already created one bottom group */
     for (u = 1; u < LIFECYCLE_MAX_COMPACT; u++) {
-        HDsnprintf(objname, sizeof(objname), LIFECYCLE_BOTTOM_GROUP, u);
+        snprintf(objname, sizeof(objname), LIFECYCLE_BOTTOM_GROUP, u);
         if ((gid2 = H5Gcreate2(gid, objname, H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT)) < 0)
             TEST_ERROR;
 
@@ -494,7 +494,7 @@ lifecycle(hid_t fcpl, hid_t fapl2)
         TEST_ERROR;
 
     /* Create one more "bottom" group, which should push top group into using a symbol table */
-    HDsnprintf(objname, sizeof(objname), LIFECYCLE_BOTTOM_GROUP, u);
+    snprintf(objname, sizeof(objname), LIFECYCLE_BOTTOM_GROUP, u);
     if ((gid2 = H5Gcreate2(gid, objname, H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT)) < 0)
         TEST_ERROR;
 
@@ -528,7 +528,7 @@ lifecycle(hid_t fcpl, hid_t fapl2)
 
     /* Unlink objects from top group */
     while (u >= LIFECYCLE_MIN_DENSE) {
-        HDsnprintf(objname, sizeof(objname), LIFECYCLE_BOTTOM_GROUP, u);
+        snprintf(objname, sizeof(objname), LIFECYCLE_BOTTOM_GROUP, u);
 
         if (H5Ldelete(gid, objname, H5P_DEFAULT) < 0)
             FAIL_STACK_ERROR;
@@ -545,7 +545,7 @@ lifecycle(hid_t fcpl, hid_t fapl2)
         TEST_ERROR;
 
     /* Unlink one more object from the group, which should transform back to using links */
-    HDsnprintf(objname, sizeof(objname), LIFECYCLE_BOTTOM_GROUP, u);
+    snprintf(objname, sizeof(objname), LIFECYCLE_BOTTOM_GROUP, u);
     if (H5Ldelete(gid, objname, H5P_DEFAULT) < 0)
         FAIL_STACK_ERROR;
     u--;
@@ -559,11 +559,11 @@ lifecycle(hid_t fcpl, hid_t fapl2)
         TEST_ERROR;
 
     /* Unlink last two objects from top group */
-    HDsnprintf(objname, sizeof(objname), LIFECYCLE_BOTTOM_GROUP, u);
+    snprintf(objname, sizeof(objname), LIFECYCLE_BOTTOM_GROUP, u);
     if (H5Ldelete(gid, objname, H5P_DEFAULT) < 0)
         FAIL_STACK_ERROR;
     u--;
-    HDsnprintf(objname, sizeof(objname), LIFECYCLE_BOTTOM_GROUP, u);
+    snprintf(objname, sizeof(objname), LIFECYCLE_BOTTOM_GROUP, u);
     if (H5Ldelete(gid, objname, H5P_DEFAULT) < 0)
         FAIL_STACK_ERROR;
 
@@ -818,7 +818,7 @@ read_old(void)
 
     /* Create a bunch of objects in the group */
     for (u = 0; u < READ_OLD_NGROUPS; u++) {
-        HDsnprintf(objname, sizeof(objname), "Group %u", u);
+        snprintf(objname, sizeof(objname), "Group %u", u);
         if ((gid2 = H5Gcreate2(gid, objname, H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT)) < 0)
             TEST_ERROR;
 
@@ -842,7 +842,7 @@ read_old(void)
 
     /* Delete new objects from old group */
     for (u = 0; u < READ_OLD_NGROUPS; u++) {
-        HDsnprintf(objname, sizeof(objname), "Group %u", u);
+        snprintf(objname, sizeof(objname), "Group %u", u);
         if (H5Ldelete(gid, objname, H5P_DEFAULT) < 0)
             FAIL_STACK_ERROR;
     } /* end for */
@@ -951,7 +951,7 @@ no_compact(hid_t fcpl, hid_t fapl2)
         TEST_ERROR;
 
     /* Create first "bottom" group */
-    HDsnprintf(objname, sizeof(objname), NO_COMPACT_BOTTOM_GROUP, (unsigned)0);
+    snprintf(objname, sizeof(objname), NO_COMPACT_BOTTOM_GROUP, (unsigned)0);
     if ((gid2 = H5Gcreate2(gid, objname, H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT)) < 0)
         TEST_ERROR;
 
@@ -972,7 +972,7 @@ no_compact(hid_t fcpl, hid_t fapl2)
         TEST_ERROR;
 
     /* Unlink object from top group */
-    HDsnprintf(objname, sizeof(objname), NO_COMPACT_BOTTOM_GROUP, (unsigned)0);
+    snprintf(objname, sizeof(objname), NO_COMPACT_BOTTOM_GROUP, (unsigned)0);
     if (H5Ldelete(gid, objname, H5P_DEFAULT) < 0)
         FAIL_STACK_ERROR;
 
@@ -1250,7 +1250,7 @@ old_api(hid_t fapl)
     (void)fapl;
 
     SKIPPED();
-    HDputs("    Deprecated API symbols not enabled");
+    puts("    Deprecated API symbols not enabled");
 #endif /* H5_NO_DEPRECATED_SYMBOLS */
 
     return 0;
@@ -1386,7 +1386,7 @@ main(void)
         env_h5_drvr = "nomatch";
 
     /* VFD that does not support contiguous address space */
-    contig_addr_vfd = (bool)(HDstrcmp(env_h5_drvr, "split") != 0 && HDstrcmp(env_h5_drvr, "multi") != 0);
+    contig_addr_vfd = (bool)(strcmp(env_h5_drvr, "split") != 0 && strcmp(env_h5_drvr, "multi") != 0);
 
     /* Reset library */
     h5_reset();
@@ -1465,7 +1465,7 @@ main(void)
     if (nerrors)
         goto error;
 
-    HDputs("All symbol table tests passed.");
+    puts("All symbol table tests passed.");
 
     /* Cleanup */
     if (GetTestCleanup()) {
@@ -1477,6 +1477,6 @@ main(void)
     return 0;
 
 error:
-    HDputs("*** TESTS FAILED ***");
+    puts("*** TESTS FAILED ***");
     return 1;
 }

--- a/test/swmr.c
+++ b/test/swmr.c
@@ -142,7 +142,7 @@ test_metadata_read_attempts(hid_t in_fapl)
 
     if (!compat_w_default_vfd) {
         SKIPPED();
-        HDputs("    The current VFD is not compatible with the default VFD.");
+        puts("    The current VFD is not compatible with the default VFD.");
         return 0;
     }
 
@@ -2411,7 +2411,7 @@ test_start_swmr_write_concur(hid_t H5_ATTR_UNUSED in_fapl, bool new_format)
     }
 
     SKIPPED();
-    HDputs("    Test skipped due to fork or waitpid not defined.");
+    puts("    Test skipped due to fork or waitpid not defined.");
     return 0;
 } /* test_start_swmr_write_concur() */
 
@@ -3247,13 +3247,13 @@ tssw_persist_dapl_verify(hid_t did, hid_t vdsid1, hid_t vdsid2, hsize_t boundary
     /* Get efile prefix property and verify */
     if (H5Pget_efile_prefix(dapl, efile_prefix_out, sizeof(efile_prefix_out)) < 0)
         TEST_ERROR;
-    if (HDstrncmp(efile_prefix, efile_prefix_out, sizeof(efile_prefix_out)))
+    if (strncmp(efile_prefix, efile_prefix_out, sizeof(efile_prefix_out)))
         TEST_ERROR;
 
     /* Get virtual prefix property and verify */
     if (H5Pget_virtual_prefix(vds_dapl1, virtual_prefix_out, sizeof(virtual_prefix_out)) < 0)
         TEST_ERROR;
-    if (HDstrncmp(virtual_prefix, virtual_prefix_out, sizeof(virtual_prefix_out)))
+    if (strncmp(virtual_prefix, virtual_prefix_out, sizeof(virtual_prefix_out)))
         TEST_ERROR;
 
     /* Get virtual printf gap property and verify */
@@ -5188,7 +5188,7 @@ test_file_lock_concur(hid_t H5_ATTR_UNUSED in_fapl)
     /* Output message about test being performed */
     TESTING("File open with different combinations of flags--concurrent access");
     SKIPPED();
-    HDputs("    Test skipped due to fork or waitpid not defined.");
+    puts("    Test skipped due to fork or waitpid not defined.");
     return 0;
 
 } /* end test_file_lock_concur() */
@@ -5581,7 +5581,7 @@ test_file_lock_swmr_concur(hid_t H5_ATTR_UNUSED in_fapl)
     /* Output message about test being performed */
     TESTING("File open with different combintations of flags + SWMR flags--concurrent access");
     SKIPPED();
-    HDputs("    Test skipped due to fork or waitpid not defined.");
+    puts("    Test skipped due to fork or waitpid not defined.");
     return 0;
 
 } /* end test_file_lock_swmr_concur() */
@@ -6608,7 +6608,7 @@ test_file_locking(hid_t in_fapl, bool turn_locking_on, bool env_var_override)
     else
         TESTING("File locking: OFF");
     SKIPPED();
-    HDputs("    Test skipped due to fork or waitpid not defined.");
+    puts("    Test skipped due to fork or waitpid not defined.");
     return 0;
 #else /* !(defined(H5_HAVE_FORK) && defined(H5_HAVE_WAITPID)) */
     hid_t  fid  = H5I_INVALID_HID;  /* File ID */
@@ -7083,7 +7083,7 @@ test_refresh_concur(hid_t H5_ATTR_UNUSED in_fapl, bool new_format)
     }
 
     SKIPPED();
-    HDputs("    Test skipped due to fork or waitpid not defined.");
+    puts("    Test skipped due to fork or waitpid not defined.");
     return 0;
 } /* test_refresh_concur() */
 
@@ -7753,7 +7753,7 @@ main(void)
      * disabled.
      */
     lock_env_var = HDgetenv(HDF5_USE_FILE_LOCKING);
-    if (lock_env_var && !HDstrcmp(lock_env_var, "FALSE"))
+    if (lock_env_var && !strcmp(lock_env_var, "FALSE"))
         use_file_locking = false;
     else
         use_file_locking = true;
@@ -7828,7 +7828,7 @@ main(void)
     /* Tests SWMR VFD compatibility flag.
      * Only needs to run when the VFD is the default (sec2).
      */
-    if (NULL == driver || !HDstrcmp(driver, "") || !HDstrcmp(driver, "sec2"))
+    if (NULL == driver || !strcmp(driver, "") || !strcmp(driver, "sec2"))
         nerrors += test_swmr_vfd_flag();
 
     /* Test multiple opens via different locking flags */

--- a/test/swmr_common.c
+++ b/test/swmr_common.c
@@ -181,7 +181,7 @@ generate_name(char *name_buf, size_t name_buf_length, unsigned level, unsigned c
 {
     assert(name_buf);
 
-    HDsnprintf(name_buf, name_buf_length, "%u-%04u", level, count);
+    snprintf(name_buf, name_buf_length, "%u-%04u", level, count);
 
     return 0;
 } /* end generate_name() */
@@ -209,7 +209,7 @@ generate_symbols(void)
             char name_buf[64];
 
             generate_name(name_buf, sizeof(name_buf), u, v);
-            symbol_info[u][v].name     = HDstrdup(name_buf);
+            symbol_info[u][v].name     = strdup(name_buf);
             symbol_info[u][v].dsid     = -1;
             symbol_info[u][v].nrecords = 0;
         } /* end for */

--- a/test/swmr_generator.c
+++ b/test/swmr_generator.c
@@ -115,7 +115,7 @@ gen_skeleton(const char *filename, bool verbose, bool swmr_write, int comp_level
      * With one unlimited dimension, we get the extensible array index
      * type, with two unlimited dimensions, we get a v2 B-tree.
      */
-    if (!HDstrcmp(index_type, "b2"))
+    if (!strcmp(index_type, "b2"))
         max_dims[0] = H5S_UNLIMITED;
 
     /* Create file creation property list */
@@ -285,7 +285,7 @@ main(int argc, char *argv[])
                     /* Chunk index type */
                     case 'i':
                         index_type = argv[u + 1];
-                        if (HDstrcmp(index_type, "ea") != 0 && HDstrcmp(index_type, "b2") != 0)
+                        if (strcmp(index_type, "ea") != 0 && strcmp(index_type, "b2") != 0)
                             usage();
                         u += 2;
                         break;

--- a/test/swmr_reader.c
+++ b/test/swmr_reader.c
@@ -278,7 +278,7 @@ read_records(const char *filename, bool verbose, FILE *verbose_file, unsigned ra
     if (use_log_vfd) {
         char verbose_name[1024];
 
-        HDsnprintf(verbose_name, sizeof(verbose_name), "swmr_reader.log.%u", random_seed);
+        snprintf(verbose_name, sizeof(verbose_name), "swmr_reader.log.%u", random_seed);
 
         H5Pset_fapl_log(fapl, verbose_name, H5FD_LOG_ALL, (size_t)(512 * 1024 * 1024));
     } /* end if */
@@ -481,7 +481,7 @@ main(int argc, char *argv[])
     if (verbose) {
         char verbose_name[1024];
 
-        HDsnprintf(verbose_name, sizeof(verbose_name), "swmr_reader.out.%u", random_seed);
+        snprintf(verbose_name, sizeof(verbose_name), "swmr_reader.out.%u", random_seed);
         if (NULL == (verbose_file = fopen(verbose_name, "w"))) {
             fprintf(stderr, "Can't open verbose output file!\n");
             exit(EXIT_FAILURE);

--- a/test/swmr_start_write.c
+++ b/test/swmr_start_write.c
@@ -155,7 +155,7 @@ create_datasets(hid_t fid, int comp_level, bool verbose, FILE *verbose_file, con
      * With one unlimited dimension, we get the extensible array index
      * type, with two unlimited dimensions, we get a v-2 B-tree.
      */
-    if (!HDstrcmp(index_type, "b2"))
+    if (!strcmp(index_type, "b2"))
         max_dims[0] = H5S_UNLIMITED;
 
     /* Create dataspace for creating datasets */
@@ -384,7 +384,7 @@ main(int argc, char *argv[])
                     /* Chunk index type */
                     case 'i':
                         index_type = argv[u + 1];
-                        if (HDstrcmp(index_type, "ea") != 0 && HDstrcmp(index_type, "b2") != 0)
+                        if (strcmp(index_type, "ea") != 0 && strcmp(index_type, "b2") != 0)
                             usage();
                         u += 2;
                         break;
@@ -448,7 +448,7 @@ main(int argc, char *argv[])
     if (verbose) {
         char verbose_name[1024];
 
-        HDsnprintf(verbose_name, sizeof(verbose_name), "swmr_writer.out.%u", random_seed);
+        snprintf(verbose_name, sizeof(verbose_name), "swmr_writer.out.%u", random_seed);
         if (NULL == (verbose_file = fopen(verbose_name, "w"))) {
             fprintf(stderr, "Can't open verbose output file!\n");
             exit(EXIT_FAILURE);

--- a/test/swmr_writer.c
+++ b/test/swmr_writer.c
@@ -90,7 +90,7 @@ open_skeleton(const char *filename, bool verbose, FILE *verbose_file, unsigned r
     if (use_log_vfd) {
         char verbose_name[1024];
 
-        HDsnprintf(verbose_name, sizeof(verbose_name), "swmr_writer.log.%u", random_seed);
+        snprintf(verbose_name, sizeof(verbose_name), "swmr_writer.log.%u", random_seed);
 
         H5Pset_fapl_log(fapl, verbose_name, H5FD_LOG_ALL, (size_t)(512 * 1024 * 1024));
     } /* end if */
@@ -356,7 +356,7 @@ main(int argc, char *argv[])
     if (verbose) {
         char verbose_name[1024];
 
-        HDsnprintf(verbose_name, sizeof(verbose_name), "swmr_writer.out.%u", random_seed);
+        snprintf(verbose_name, sizeof(verbose_name), "swmr_writer.out.%u", random_seed);
         if (NULL == (verbose_file = fopen(verbose_name, "w"))) {
             fprintf(stderr, "Can't open verbose output file!\n");
             exit(EXIT_FAILURE);

--- a/test/tarray.c
+++ b/test/tarray.c
@@ -686,7 +686,7 @@ test_array_compound_atomic(void)
     /* Check the 1st field's name */
     mname = H5Tget_member_name(tid2, 0);
     CHECK_PTR(mname, "H5Tget_member_name");
-    if (HDstrcmp(mname, "i") != 0)
+    if (strcmp(mname, "i") != 0)
         TestErrPrintf("Compound field name doesn't match!, mname=%s\n", mname);
     H5free_memory(mname);
 
@@ -705,7 +705,7 @@ test_array_compound_atomic(void)
     /* Check the 2nd field's name */
     mname = H5Tget_member_name(tid2, 1);
     CHECK_PTR(mname, "H5Tget_member_name");
-    if (HDstrcmp(mname, "f") != 0)
+    if (strcmp(mname, "f") != 0)
         TestErrPrintf("Compound field name doesn't match!, mname=%s\n", mname);
     H5free_memory(mname);
 
@@ -908,7 +908,7 @@ test_array_compound_array(void)
     /* Check the 1st field's name */
     mname = H5Tget_member_name(tid2, 0);
     CHECK_PTR(mname, "H5Tget_member_name");
-    if (HDstrcmp(mname, "i") != 0)
+    if (strcmp(mname, "i") != 0)
         TestErrPrintf("Compound field name doesn't match!, mname=%s\n", mname);
     H5free_memory(mname);
 
@@ -927,7 +927,7 @@ test_array_compound_array(void)
     /* Check the 2nd field's name */
     mname = H5Tget_member_name(tid2, 1);
     CHECK_PTR(mname, "H5Tget_member_name");
-    if (HDstrcmp(mname, "f") != 0)
+    if (strcmp(mname, "f") != 0)
         TestErrPrintf("Compound field name doesn't match!, mname=%s\n", mname);
     H5free_memory(mname);
 
@@ -1664,9 +1664,9 @@ test_array_bkg(void)
     for (i = 0; i < dtsinfo->nsubfields; i++)
         dtsinfo->name[i] = (char *)calloc((size_t)20, sizeof(char));
 
-    HDstrcpy(dtsinfo->name[0], "One");
-    HDstrcpy(dtsinfo->name[1], "Two");
-    HDstrcpy(dtsinfo->name[2], "Three");
+    strcpy(dtsinfo->name[0], "One");
+    strcpy(dtsinfo->name[1], "Two");
+    strcpy(dtsinfo->name[2], "Three");
 
     /* Create file */
     /* ----------- */
@@ -1966,7 +1966,7 @@ test_compat(void)
         /* Check the 1st field's name */
         mname = H5Tget_member_name(tid1, 0);
         CHECK_PTR(mname, "H5Tget_member_name");
-        if (HDstrcmp(mname, "i") != 0)
+        if (strcmp(mname, "i") != 0)
             TestErrPrintf("Compound field name doesn't match!, mname=%s\n", mname);
         H5free_memory(mname);
 
@@ -1985,7 +1985,7 @@ test_compat(void)
         /* Check the 2nd field's name */
         mname = H5Tget_member_name(tid1, 1);
         CHECK_PTR(mname, "H5Tget_member_name");
-        if (HDstrcmp(mname, "f") != 0)
+        if (strcmp(mname, "f") != 0)
             TestErrPrintf("Compound field name doesn't match!, mname=%s\n", mname);
         H5free_memory(mname);
 
@@ -2004,7 +2004,7 @@ test_compat(void)
         /* Check the 3rd field's name */
         mname = H5Tget_member_name(tid1, 2);
         CHECK_PTR(mname, "H5Tget_member_name");
-        if (HDstrcmp(mname, "l") != 0)
+        if (strcmp(mname, "l") != 0)
             TestErrPrintf("Compound field name doesn't match!, mname=%s\n", mname);
         H5free_memory(mname);
 
@@ -2047,7 +2047,7 @@ test_compat(void)
         /* Check the 1st field's name */
         mname = H5Tget_member_name(tid1, 0);
         CHECK_PTR(mname, "H5Tget_member_name");
-        if (mname && HDstrcmp(mname, "i") != 0)
+        if (mname && strcmp(mname, "i") != 0)
             TestErrPrintf("Compound field name doesn't match!, mname=%s\n", mname);
         if (mname)
             H5free_memory(mname);
@@ -2067,7 +2067,7 @@ test_compat(void)
         /* Check the 2nd field's name */
         mname = H5Tget_member_name(tid1, 1);
         CHECK_PTR(mname, "H5Tget_member_name");
-        if (mname && HDstrcmp(mname, "f") != 0)
+        if (mname && strcmp(mname, "f") != 0)
             TestErrPrintf("Compound field name doesn't match!, mname=%s\n", mname);
         if (mname)
             H5free_memory(mname);
@@ -2115,7 +2115,7 @@ test_compat(void)
         /* Check the 3rd field's name */
         mname = H5Tget_member_name(tid1, 2);
         CHECK_PTR(mname, "H5Tget_member_name");
-        if (mname && HDstrcmp(mname, "l") != 0)
+        if (mname && strcmp(mname, "l") != 0)
             TestErrPrintf("Compound field name doesn't match!, mname=%s\n", mname);
         if (mname)
             H5free_memory(mname);
@@ -2163,7 +2163,7 @@ test_compat(void)
         /* Check the 4th field's name */
         mname = H5Tget_member_name(tid1, 3);
         CHECK_PTR(mname, "H5Tget_member_name");
-        if (mname && HDstrcmp(mname, "d") != 0)
+        if (mname && strcmp(mname, "d") != 0)
             TestErrPrintf("Compound field name doesn't match!, mname=%s\n", mname);
         if (mname)
             H5free_memory(mname);

--- a/test/tattr.c
+++ b/test/tattr.c
@@ -308,8 +308,8 @@ test_attr_basic_write(hid_t fapl)
         if (attr_name) {
             ret = (herr_t)H5Aget_name(attr, (size_t)(attr_name_size + 1), attr_name);
             CHECK(ret, FAIL, "H5Aget_name");
-            ret = HDstrcmp(attr_name, ATTR_TMP_NAME);
-            VERIFY(ret, 0, "HDstrcmp");
+            ret = strcmp(attr_name, ATTR_TMP_NAME);
+            VERIFY(ret, 0, "strcmp");
 
             free(attr_name);
             attr_name = NULL;
@@ -345,8 +345,8 @@ test_attr_basic_write(hid_t fapl)
         if (attr_name) {
             ret = (herr_t)H5Aget_name(attr2, (size_t)(attr_name_size + 1), attr_name);
             CHECK(ret, FAIL, "H5Aget_name");
-            ret = HDstrcmp(attr_name, ATTR1A_NAME);
-            VERIFY(ret, 0, "HDstrcmp");
+            ret = strcmp(attr_name, ATTR1A_NAME);
+            VERIFY(ret, 0, "strcmp");
 
             free(attr_name);
             attr_name = NULL;
@@ -870,8 +870,8 @@ test_attr_compound_read(hid_t fapl)
     VERIFY(fields, 3, "H5Tget_nmembers");
     for (i = 0; i < fields; i++) {
         fieldname = H5Tget_member_name(type, (unsigned)i);
-        if (!(HDstrcmp(fieldname, ATTR4_FIELDNAME1) != 0 || HDstrcmp(fieldname, ATTR4_FIELDNAME2) != 0 ||
-              HDstrcmp(fieldname, ATTR4_FIELDNAME3) != 0))
+        if (!(strcmp(fieldname, ATTR4_FIELDNAME1) != 0 || strcmp(fieldname, ATTR4_FIELDNAME2) != 0 ||
+              strcmp(fieldname, ATTR4_FIELDNAME3) != 0))
             TestErrPrintf("invalid field name for field #%d: %s\n", i, fieldname);
         H5free_memory(fieldname);
     } /* end for */
@@ -930,8 +930,8 @@ test_attr_compound_read(hid_t fapl)
 
     /* Verify Name */
     name_len = H5Aget_name(attr, (size_t)ATTR_NAME_LEN, attr_name);
-    VERIFY(name_len, HDstrlen(ATTR4_NAME), "H5Aget_name");
-    if (HDstrcmp(attr_name, ATTR4_NAME) != 0)
+    VERIFY(name_len, strlen(ATTR4_NAME), "H5Aget_name");
+    if (strcmp(attr_name, ATTR4_NAME) != 0)
         TestErrPrintf("attribute name different: attr_name=%s, should be %s\n", attr_name, ATTR4_NAME);
 
     /* Close attribute datatype */
@@ -1305,16 +1305,16 @@ test_attr_mult_read(hid_t fapl)
 
     /* Verify Name */
     name_len = H5Aget_name(attr, (size_t)ATTR_NAME_LEN, attr_name);
-    VERIFY(name_len, HDstrlen(ATTR1_NAME), "H5Aget_name");
-    if (HDstrcmp(attr_name, ATTR1_NAME) != 0)
+    VERIFY(name_len, strlen(ATTR1_NAME), "H5Aget_name");
+    if (strcmp(attr_name, ATTR1_NAME) != 0)
         TestErrPrintf("attribute name different: attr_name=%s, should be %s\n", attr_name, ATTR1_NAME);
 
     /* Verify Name with too small of a buffer */
-    name_len = H5Aget_name(attr, HDstrlen(ATTR1_NAME), attr_name);
-    VERIFY(name_len, HDstrlen(ATTR1_NAME), "H5Aget_name");
-    HDstrcpy(temp_name, ATTR1_NAME);            /* make a copy of the name */
-    temp_name[HDstrlen(ATTR1_NAME) - 1] = '\0'; /* truncate it to match the one retrieved */
-    if (HDstrcmp(attr_name, temp_name) != 0)
+    name_len = H5Aget_name(attr, strlen(ATTR1_NAME), attr_name);
+    VERIFY(name_len, strlen(ATTR1_NAME), "H5Aget_name");
+    strcpy(temp_name, ATTR1_NAME);            /* make a copy of the name */
+    temp_name[strlen(ATTR1_NAME) - 1] = '\0'; /* truncate it to match the one retrieved */
+    if (strcmp(attr_name, temp_name) != 0)
         TestErrPrintf("attribute name different: attr_name=%s, should be %s\n", attr_name, temp_name);
 
     /* Close attribute */
@@ -1363,16 +1363,16 @@ test_attr_mult_read(hid_t fapl)
 
     /* Verify Name */
     name_len = H5Aget_name(attr, (size_t)ATTR_NAME_LEN, attr_name);
-    VERIFY(name_len, HDstrlen(ATTR2_NAME), "H5Aget_name");
-    if (HDstrcmp(attr_name, ATTR2_NAME) != 0)
+    VERIFY(name_len, strlen(ATTR2_NAME), "H5Aget_name");
+    if (strcmp(attr_name, ATTR2_NAME) != 0)
         TestErrPrintf("attribute name different: attr_name=%s, should be %s\n", attr_name, ATTR2_NAME);
 
     /* Verify Name with too small of a buffer */
-    name_len = H5Aget_name(attr, HDstrlen(ATTR2_NAME), attr_name);
-    VERIFY(name_len, HDstrlen(ATTR2_NAME), "H5Aget_name");
-    HDstrcpy(temp_name, ATTR2_NAME);            /* make a copy of the name */
-    temp_name[HDstrlen(ATTR2_NAME) - 1] = '\0'; /* truncate it to match the one retrieved */
-    if (HDstrcmp(attr_name, temp_name) != 0)
+    name_len = H5Aget_name(attr, strlen(ATTR2_NAME), attr_name);
+    VERIFY(name_len, strlen(ATTR2_NAME), "H5Aget_name");
+    strcpy(temp_name, ATTR2_NAME);            /* make a copy of the name */
+    temp_name[strlen(ATTR2_NAME) - 1] = '\0'; /* truncate it to match the one retrieved */
+    if (strcmp(attr_name, temp_name) != 0)
         TestErrPrintf("attribute name different: attr_name=%s, should be %s\n", attr_name, temp_name);
 
     /* Close attribute */
@@ -1425,16 +1425,16 @@ test_attr_mult_read(hid_t fapl)
 
     /* Verify Name */
     name_len = H5Aget_name(attr, (size_t)ATTR_NAME_LEN, attr_name);
-    VERIFY(name_len, HDstrlen(ATTR3_NAME), "H5Aget_name");
-    if (HDstrcmp(attr_name, ATTR3_NAME) != 0)
+    VERIFY(name_len, strlen(ATTR3_NAME), "H5Aget_name");
+    if (strcmp(attr_name, ATTR3_NAME) != 0)
         TestErrPrintf("attribute name different: attr_name=%s, should be %s\n", attr_name, ATTR3_NAME);
 
     /* Verify Name with too small of a buffer */
-    name_len = H5Aget_name(attr, HDstrlen(ATTR3_NAME), attr_name);
-    VERIFY(name_len, HDstrlen(ATTR3_NAME), "H5Aget_name");
-    HDstrcpy(temp_name, ATTR3_NAME);            /* make a copy of the name */
-    temp_name[HDstrlen(ATTR3_NAME) - 1] = '\0'; /* truncate it to match the one retrieved */
-    if (HDstrcmp(attr_name, temp_name) != 0)
+    name_len = H5Aget_name(attr, strlen(ATTR3_NAME), attr_name);
+    VERIFY(name_len, strlen(ATTR3_NAME), "H5Aget_name");
+    strcpy(temp_name, ATTR3_NAME);            /* make a copy of the name */
+    temp_name[strlen(ATTR3_NAME) - 1] = '\0'; /* truncate it to match the one retrieved */
+    if (strcmp(attr_name, temp_name) != 0)
         TestErrPrintf("attribute name different: attr_name=%s, should be %s\n", attr_name, temp_name);
 
     /* Close attribute */
@@ -1463,19 +1463,19 @@ attr_op1(hid_t H5_ATTR_UNUSED loc_id, const char *name, const H5A_info_t H5_ATTR
 
     switch (*count) {
         case 0:
-            if (HDstrcmp(name, ATTR1_NAME) != 0)
+            if (strcmp(name, ATTR1_NAME) != 0)
                 TestErrPrintf("attribute name different: name=%s, should be %s\n", name, ATTR1_NAME);
             (*count)++;
             break;
 
         case 1:
-            if (HDstrcmp(name, ATTR2_NAME) != 0)
+            if (strcmp(name, ATTR2_NAME) != 0)
                 TestErrPrintf("attribute name different: name=%s, should be %s\n", name, ATTR2_NAME);
             (*count)++;
             break;
 
         case 2:
-            if (HDstrcmp(name, ATTR3_NAME) != 0)
+            if (strcmp(name, ATTR3_NAME) != 0)
                 TestErrPrintf("attribute name different: name=%s, should be %s\n", name, ATTR3_NAME);
             (*count)++;
             break;
@@ -1620,8 +1620,8 @@ test_attr_delete(hid_t fapl)
 
     /* Verify Name */
     name_len = H5Aget_name(attr, (size_t)ATTR_NAME_LEN, attr_name);
-    VERIFY(name_len, HDstrlen(ATTR1_NAME), "H5Aget_name");
-    if (HDstrcmp(attr_name, ATTR1_NAME) != 0)
+    VERIFY(name_len, strlen(ATTR1_NAME), "H5Aget_name");
+    if (strcmp(attr_name, ATTR1_NAME) != 0)
         TestErrPrintf("attribute name different: attr_name=%s, should be %s\n", attr_name, ATTR1_NAME);
 
     /* Close attribute */
@@ -1635,8 +1635,8 @@ test_attr_delete(hid_t fapl)
 
     /* Verify Name */
     name_len = H5Aget_name(attr, (size_t)ATTR_NAME_LEN, attr_name);
-    VERIFY(name_len, HDstrlen(ATTR3_NAME), "H5Aget_name");
-    if (HDstrcmp(attr_name, ATTR3_NAME) != 0)
+    VERIFY(name_len, strlen(ATTR3_NAME), "H5Aget_name");
+    if (strcmp(attr_name, ATTR3_NAME) != 0)
         TestErrPrintf("attribute name different: attr_name=%s, should be %s\n", attr_name, ATTR3_NAME);
 
     /* Close attribute */
@@ -1659,8 +1659,8 @@ test_attr_delete(hid_t fapl)
 
     /* Verify Name */
     name_len = H5Aget_name(attr, (size_t)ATTR_NAME_LEN, attr_name);
-    VERIFY(name_len, HDstrlen(ATTR3_NAME), "H5Aget_name");
-    if (HDstrcmp(attr_name, ATTR3_NAME) != 0)
+    VERIFY(name_len, strlen(ATTR3_NAME), "H5Aget_name");
+    if (strcmp(attr_name, ATTR3_NAME) != 0)
         TestErrPrintf("attribute name different: attr_name=%s, should be %s\n", attr_name, ATTR3_NAME);
 
     /* Close attribute */
@@ -2126,7 +2126,7 @@ test_attr_dense_verify(hid_t loc_id, unsigned max_attr)
     /* Re-open all the attributes by name and verify the data */
     for (u = 0; u < max_attr; u++) {
         /* Open attribute */
-        HDsnprintf(attrname, sizeof(attrname), "attr %02u", u);
+        snprintf(attrname, sizeof(attrname), "attr %02u", u);
         attr = H5Aopen(loc_id, attrname, H5P_DEFAULT);
         CHECK(attr, FAIL, "H5Aopen");
 
@@ -2151,10 +2151,10 @@ test_attr_dense_verify(hid_t loc_id, unsigned max_attr)
         CHECK(attr, FAIL, "H5Aopen_by_idx");
 
         /* Verify Name */
-        HDsnprintf(attrname, sizeof(attrname), "attr %02u", u);
+        snprintf(attrname, sizeof(attrname), "attr %02u", u);
         name_len = H5Aget_name(attr, (size_t)ATTR_NAME_LEN, check_name);
-        VERIFY(name_len, HDstrlen(attrname), "H5Aget_name");
-        if (HDstrcmp(check_name, attrname) != 0)
+        VERIFY(name_len, strlen(attrname), "H5Aget_name");
+        if (strcmp(check_name, attrname) != 0)
             TestErrPrintf("attribute name different: attrname = '%s', should be '%s'\n", check_name,
                           attrname);
 
@@ -2251,7 +2251,7 @@ test_attr_dense_create(hid_t fcpl, hid_t fapl)
     /* Add attributes, until just before converting to dense storage */
     for (u = 0; u < max_compact; u++) {
         /* Create attribute */
-        HDsnprintf(attrname, sizeof(attrname), "attr %02u", u);
+        snprintf(attrname, sizeof(attrname), "attr %02u", u);
         attr = H5Acreate2(dataset, attrname, H5T_NATIVE_UINT, sid, H5P_DEFAULT, H5P_DEFAULT);
         CHECK(attr, FAIL, "H5Acreate2");
 
@@ -2270,7 +2270,7 @@ test_attr_dense_create(hid_t fcpl, hid_t fapl)
 
     /* Add one more attribute, to push into "dense" storage */
     /* Create attribute */
-    HDsnprintf(attrname, sizeof(attrname), "attr %02u", u);
+    snprintf(attrname, sizeof(attrname), "attr %02u", u);
     attr = H5Acreate2(dataset, attrname, H5T_NATIVE_UINT, sid, H5P_DEFAULT, H5P_DEFAULT);
     CHECK(attr, FAIL, "H5Acreate2");
 
@@ -2397,7 +2397,7 @@ test_attr_dense_open(hid_t fcpl, hid_t fapl)
     /* Add attributes, until just before converting to dense storage */
     for (u = 0; u < max_compact; u++) {
         /* Create attribute */
-        HDsnprintf(attrname, sizeof(attrname), "attr %02u", u);
+        snprintf(attrname, sizeof(attrname), "attr %02u", u);
         attr = H5Acreate2(dataset, attrname, H5T_NATIVE_UINT, sid, H5P_DEFAULT, H5P_DEFAULT);
         CHECK(attr, FAIL, "H5Acreate2");
 
@@ -2420,7 +2420,7 @@ test_attr_dense_open(hid_t fcpl, hid_t fapl)
 
     /* Add one more attribute, to push into "dense" storage */
     /* Create attribute */
-    HDsnprintf(attrname, sizeof(attrname), "attr %02u", u);
+    snprintf(attrname, sizeof(attrname), "attr %02u", u);
     attr = H5Acreate2(dataset, attrname, H5T_NATIVE_UINT, sid, H5P_DEFAULT, H5P_DEFAULT);
     CHECK(attr, FAIL, "H5Acreate2");
 
@@ -2559,7 +2559,7 @@ test_attr_dense_delete(hid_t fcpl, hid_t fapl)
     /* Add attributes, until well into dense storage */
     for (u = 0; u < (max_compact * 2); u++) {
         /* Create attribute */
-        HDsnprintf(attrname, sizeof(attrname), "attr %02u", u);
+        snprintf(attrname, sizeof(attrname), "attr %02u", u);
         attr = H5Acreate2(dataset, attrname, H5T_NATIVE_UINT, sid, H5P_DEFAULT, H5P_DEFAULT);
         CHECK(attr, FAIL, "H5Acreate2");
 
@@ -2604,7 +2604,7 @@ test_attr_dense_delete(hid_t fcpl, hid_t fapl)
     /* Delete attributes until the attributes revert to compact storage again */
     for (u--; u >= min_dense; u--) {
         /* Delete attribute */
-        HDsnprintf(attrname, sizeof(attrname), "attr %02u", u);
+        snprintf(attrname, sizeof(attrname), "attr %02u", u);
         ret = H5Adelete(dataset, attrname);
         CHECK(ret, FAIL, "H5Adelete");
 
@@ -2618,7 +2618,7 @@ test_attr_dense_delete(hid_t fcpl, hid_t fapl)
     VERIFY(is_dense, true, "H5O__is_attr_dense_test");
 
     /* Delete one more attribute, which should cause reversion to compact storage */
-    HDsnprintf(attrname, sizeof(attrname), "attr %02u", u);
+    snprintf(attrname, sizeof(attrname), "attr %02u", u);
     ret = H5Adelete(dataset, attrname);
     CHECK(ret, FAIL, "H5Adelete");
 
@@ -2631,7 +2631,7 @@ test_attr_dense_delete(hid_t fcpl, hid_t fapl)
     CHECK(ret, FAIL, "test_attr_dense_verify");
 
     /* Delete another attribute, to verify deletion in compact storage */
-    HDsnprintf(attrname, sizeof(attrname), "attr %02u", (u - 1));
+    snprintf(attrname, sizeof(attrname), "attr %02u", (u - 1));
     ret = H5Adelete(dataset, attrname);
     CHECK(ret, FAIL, "H5Adelete");
 
@@ -2760,7 +2760,7 @@ test_attr_dense_rename(hid_t fcpl, hid_t fapl)
         /* Add attributes, until well into dense storage */
         for (u = 0; u < (max_compact * 2); u++) {
             /* Create attribute */
-            HDsnprintf(attrname, sizeof(attrname), "attr %02u", u);
+            snprintf(attrname, sizeof(attrname), "attr %02u", u);
             attr = H5Acreate2(dataset, attrname, H5T_NATIVE_UINT, sid, H5P_DEFAULT, H5P_DEFAULT);
             CHECK(attr, H5I_INVALID_HID, "H5Acreate2");
 
@@ -2773,7 +2773,7 @@ test_attr_dense_rename(hid_t fcpl, hid_t fapl)
             CHECK(ret, FAIL, "H5Aclose");
 
             /* Rename attribute */
-            HDsnprintf(new_attrname, sizeof(new_attrname), "new attr %02u", u);
+            snprintf(new_attrname, sizeof(new_attrname), "new attr %02u", u);
 
             /* Rename attribute */
             ret = H5Arename_by_name(fid, DSET1_NAME, attrname, new_attrname, H5P_DEFAULT);
@@ -2826,7 +2826,7 @@ test_attr_dense_rename(hid_t fcpl, hid_t fapl)
         unsigned value; /* Attribute value */
 
         /* Open attribute */
-        HDsnprintf(attrname, sizeof(attrname), "new attr %02u", u);
+        snprintf(attrname, sizeof(attrname), "new attr %02u", u);
         attr = H5Aopen(dataset, attrname, H5P_DEFAULT);
         CHECK(attr, H5I_INVALID_HID, "H5Aopen");
 
@@ -2950,7 +2950,7 @@ test_attr_dense_unlink(hid_t fcpl, hid_t fapl)
     /* Add attributes, until well into dense storage */
     for (u = 0; u < (max_compact * 2); u++) {
         /* Create attribute */
-        HDsnprintf(attrname, sizeof(attrname), "attr %02u", u);
+        snprintf(attrname, sizeof(attrname), "attr %02u", u);
         attr = H5Acreate2(dataset, attrname, H5T_NATIVE_UINT, sid, H5P_DEFAULT, H5P_DEFAULT);
         CHECK(attr, FAIL, "H5Acreate2");
 
@@ -3093,7 +3093,7 @@ test_attr_dense_limits(hid_t fcpl, hid_t fapl)
 
     /* Create attribute */
     u = 0;
-    HDsnprintf(attrname, sizeof(attrname), "attr %02u", u);
+    snprintf(attrname, sizeof(attrname), "attr %02u", u);
     attr = H5Acreate2(dataset, attrname, H5T_NATIVE_UINT, sid, H5P_DEFAULT, H5P_DEFAULT);
     CHECK(attr, FAIL, "H5Acreate2");
 
@@ -3113,7 +3113,7 @@ test_attr_dense_limits(hid_t fcpl, hid_t fapl)
 
     /* Create attribute */
     u = 1;
-    HDsnprintf(attrname, sizeof(attrname), "attr %02u", u);
+    snprintf(attrname, sizeof(attrname), "attr %02u", u);
     attr = H5Acreate2(dataset, attrname, H5T_NATIVE_UINT, sid, H5P_DEFAULT, H5P_DEFAULT);
     CHECK(attr, FAIL, "H5Acreate2");
 
@@ -3143,7 +3143,7 @@ test_attr_dense_limits(hid_t fcpl, hid_t fapl)
 
     /* Delete attribute */
     u = 0;
-    HDsnprintf(attrname, sizeof(attrname), "attr %02u", u);
+    snprintf(attrname, sizeof(attrname), "attr %02u", u);
     ret = H5Adelete(dataset, attrname);
     CHECK(ret, FAIL, "H5Adelete");
 
@@ -3252,7 +3252,7 @@ test_attr_dense_dup_ids(hid_t fcpl, hid_t fapl)
     /* Add attributes, until just before converting to dense storage */
     for (u = 0; u < max_compact; u++) {
         /* Create attribute */
-        HDsnprintf(attrname, sizeof(attrname), "attr %02u", u);
+        snprintf(attrname, sizeof(attrname), "attr %02u", u);
         attr = H5Acreate2(dataset, attrname, H5T_NATIVE_UINT, sid, H5P_DEFAULT, H5P_DEFAULT);
         CHECK(attr, FAIL, "H5Acreate2");
 
@@ -3275,7 +3275,7 @@ test_attr_dense_dup_ids(hid_t fcpl, hid_t fapl)
     CHECK(sid2, FAIL, "H5Screate_simple");
 
     /* Create attribute */
-    HDsnprintf(attrname, sizeof(attrname), "attr %02u", u);
+    snprintf(attrname, sizeof(attrname), "attr %02u", u);
     attr = H5Acreate2(dataset, attrname, H5T_NATIVE_INT, sid2, H5P_DEFAULT, H5P_DEFAULT);
     CHECK(attr, FAIL, "H5Acreate2");
 
@@ -3558,7 +3558,7 @@ test_attr_dense_dup_ids(hid_t fcpl, hid_t fapl)
     /* Delete a few attributes until the storage switches to compact */
     for (u = min_dense - 1; u <= max_compact; u++) {
         /* Create attribute */
-        HDsnprintf(attrname, sizeof(attrname), "attr %02u", u);
+        snprintf(attrname, sizeof(attrname), "attr %02u", u);
         add_attr = H5Acreate2(dataset, attrname, H5T_NATIVE_UINT, sid, H5P_DEFAULT, H5P_DEFAULT);
         CHECK(add_attr, FAIL, "H5Acreate2");
 
@@ -3626,7 +3626,7 @@ test_attr_dense_dup_ids(hid_t fcpl, hid_t fapl)
     /* Add attributes, until just before converting to dense storage */
     for (u = 0; u < max_compact; u++) {
         /* Create attribute */
-        HDsnprintf(attrname, sizeof(attrname), "attr %02u", u);
+        snprintf(attrname, sizeof(attrname), "attr %02u", u);
         attr = H5Acreate2(gid1, attrname, H5T_NATIVE_UINT, sid, H5P_DEFAULT, H5P_DEFAULT);
         CHECK(attr, FAIL, "H5Acreate2");
 
@@ -3792,7 +3792,7 @@ test_attr_big(hid_t fcpl, hid_t fapl)
 
     /* Create attribute */
     u = 0;
-    HDsnprintf(attrname, sizeof(attrname), "attr %02u", u);
+    snprintf(attrname, sizeof(attrname), "attr %02u", u);
     attr = H5Acreate2(dataset, attrname, H5T_NATIVE_UINT, sid, H5P_DEFAULT, H5P_DEFAULT);
     CHECK(attr, FAIL, "H5Acreate2");
 
@@ -3810,7 +3810,7 @@ test_attr_big(hid_t fcpl, hid_t fapl)
 
     /* Create attribute */
     u = 1;
-    HDsnprintf(attrname, sizeof(attrname), "attr %02u", u);
+    snprintf(attrname, sizeof(attrname), "attr %02u", u);
     attr = H5Acreate2(dataset, attrname, H5T_NATIVE_UINT, sid, H5P_DEFAULT, H5P_DEFAULT);
     CHECK(attr, FAIL, "H5Acreate2");
 
@@ -3828,7 +3828,7 @@ test_attr_big(hid_t fcpl, hid_t fapl)
 
     /* Create attribute */
     u = 2;
-    HDsnprintf(attrname, sizeof(attrname), "attr %02u", u);
+    snprintf(attrname, sizeof(attrname), "attr %02u", u);
     attr = H5Acreate2(dataset, attrname, H5T_NATIVE_UINT, big_sid, H5P_DEFAULT, H5P_DEFAULT);
     if (low == H5F_LIBVER_LATEST) {
         CHECK(attr, FAIL, "H5Acreate2");
@@ -3851,7 +3851,7 @@ test_attr_big(hid_t fcpl, hid_t fapl)
 
         /* Create attribute */
         u = 3;
-        HDsnprintf(attrname, sizeof(attrname), "attr %02u", u);
+        snprintf(attrname, sizeof(attrname), "attr %02u", u);
         attr = H5Acreate2(dataset, attrname, H5T_NATIVE_UINT, big_sid, H5P_DEFAULT, H5P_DEFAULT);
         CHECK(attr, FAIL, "H5Acreate2");
 
@@ -3873,7 +3873,7 @@ test_attr_big(hid_t fcpl, hid_t fapl)
 
         /* Delete attribute */
         u = 1;
-        HDsnprintf(attrname, sizeof(attrname), "attr %02u", u);
+        snprintf(attrname, sizeof(attrname), "attr %02u", u);
         ret = H5Adelete(dataset, attrname);
         CHECK(ret, FAIL, "H5Adelete");
 
@@ -3887,7 +3887,7 @@ test_attr_big(hid_t fcpl, hid_t fapl)
 
         /* Delete attribute */
         u = 3;
-        HDsnprintf(attrname, sizeof(attrname), "attr %02u", u);
+        snprintf(attrname, sizeof(attrname), "attr %02u", u);
         ret = H5Adelete(dataset, attrname);
         CHECK(ret, FAIL, "H5Adelete");
 
@@ -3901,7 +3901,7 @@ test_attr_big(hid_t fcpl, hid_t fapl)
 
         /* Delete attribute */
         u = 2;
-        HDsnprintf(attrname, sizeof(attrname), "attr %02u", u);
+        snprintf(attrname, sizeof(attrname), "attr %02u", u);
         ret = H5Adelete(dataset, attrname);
         CHECK(ret, FAIL, "H5Adelete");
 
@@ -3915,7 +3915,7 @@ test_attr_big(hid_t fcpl, hid_t fapl)
 
         /* Delete attribute */
         u = 0;
-        HDsnprintf(attrname, sizeof(attrname), "attr %02u", u);
+        snprintf(attrname, sizeof(attrname), "attr %02u", u);
         ret = H5Adelete(dataset, attrname);
         CHECK(ret, FAIL, "H5Adelete");
 
@@ -4022,7 +4022,7 @@ test_attr_null_space(hid_t fcpl, hid_t fapl)
     /* Add attribute with 'null' dataspace */
 
     /* Create attribute */
-    HDstrcpy(attrname, "null attr");
+    strcpy(attrname, "null attr");
     attr = H5Acreate2(dataset, attrname, H5T_NATIVE_UINT, null_sid, H5P_DEFAULT, H5P_DEFAULT);
     CHECK(attr, FAIL, "H5Acreate2");
 
@@ -4062,7 +4062,7 @@ test_attr_null_space(hid_t fcpl, hid_t fapl)
     /* Add another attribute with 'null' dataspace */
 
     /* Create attribute */
-    HDstrcpy(attrname, "null attr #2");
+    strcpy(attrname, "null attr #2");
     attr = H5Acreate2(dataset, attrname, H5T_NATIVE_UINT, null_sid, H5P_DEFAULT, H5P_DEFAULT);
     CHECK(attr, FAIL, "H5Acreate2");
 
@@ -4096,7 +4096,7 @@ test_attr_null_space(hid_t fcpl, hid_t fapl)
     CHECK(dataset, FAIL, "H5Dopen2");
 
     /* Open first attribute */
-    HDstrcpy(attrname, "null attr #2");
+    strcpy(attrname, "null attr #2");
     attr = H5Aopen(dataset, attrname, H5P_DEFAULT);
     CHECK(attr, FAIL, "H5Aopen");
 
@@ -4134,7 +4134,7 @@ test_attr_null_space(hid_t fcpl, hid_t fapl)
     CHECK(ret, FAIL, "H5Aclose");
 
     /* Open second attribute */
-    HDstrcpy(attrname, "null attr");
+    strcpy(attrname, "null attr");
     attr = H5Aopen(dataset, attrname, H5P_DEFAULT);
     CHECK(attr, FAIL, "H5Aopen");
 
@@ -4318,7 +4318,7 @@ test_attr_many(bool new_format, hid_t fcpl, hid_t fapl)
 
     /* Create many attributes */
     for (u = 0; u < nattr; u++) {
-        HDsnprintf(attrname, sizeof(attrname), "a-%06u", u);
+        snprintf(attrname, sizeof(attrname), "a-%06u", u);
 
         exists = H5Aexists(gid, attrname);
         VERIFY(exists, false, "H5Aexists");
@@ -4370,7 +4370,7 @@ test_attr_many(bool new_format, hid_t fcpl, hid_t fapl)
     for (u = 0; u < nattr; u++) {
         unsigned value; /* Attribute value */
 
-        HDsnprintf(attrname, sizeof(attrname), "a-%06u", u);
+        snprintf(attrname, sizeof(attrname), "a-%06u", u);
 
         exists = H5Aexists(gid, attrname);
         VERIFY(exists, true, "H5Aexists");
@@ -4622,7 +4622,7 @@ test_attr_corder_create_compact(hid_t fcpl, hid_t fapl)
         /* Create several attributes, but keep storage in compact form */
         for (u = 0; u < max_compact; u++) {
             /* Create attribute */
-            HDsnprintf(attrname, sizeof(attrname), "attr %02u", u);
+            snprintf(attrname, sizeof(attrname), "attr %02u", u);
             attr = H5Acreate2(my_dataset, attrname, H5T_NATIVE_UINT, sid, H5P_DEFAULT, H5P_DEFAULT);
             CHECK(attr, FAIL, "H5Acreate2");
 
@@ -4711,7 +4711,7 @@ test_attr_corder_create_compact(hid_t fcpl, hid_t fapl)
             H5A_info_t ainfo; /* Attribute information */
 
             /* Retrieve information for attribute */
-            HDsnprintf(attrname, sizeof(attrname), "attr %02u", u);
+            snprintf(attrname, sizeof(attrname), "attr %02u", u);
             ret = H5Aget_info_by_name(my_dataset, ".", attrname, &ainfo, H5P_DEFAULT);
             CHECK(ret, FAIL, "H5Aget_info_by_name");
 
@@ -4826,7 +4826,7 @@ test_attr_corder_create_dense(hid_t fcpl, hid_t fapl)
         /* Create several attributes, but keep storage in compact form */
         for (u = 0; u < max_compact; u++) {
             /* Create attribute */
-            HDsnprintf(attrname, sizeof(attrname), "attr %02u", u);
+            snprintf(attrname, sizeof(attrname), "attr %02u", u);
             attr = H5Acreate2(my_dataset, attrname, H5T_NATIVE_UINT, sid, H5P_DEFAULT, H5P_DEFAULT);
             CHECK(attr, FAIL, "H5Acreate2");
 
@@ -4849,7 +4849,7 @@ test_attr_corder_create_dense(hid_t fcpl, hid_t fapl)
         } /* end for */
 
         /* Create another attribute, to push into dense storage */
-        HDsnprintf(attrname, sizeof(attrname), "attr %02u", max_compact);
+        snprintf(attrname, sizeof(attrname), "attr %02u", max_compact);
         attr = H5Acreate2(my_dataset, attrname, H5T_NATIVE_UINT, sid, H5P_DEFAULT, H5P_DEFAULT);
         CHECK(attr, FAIL, "H5Acreate2");
 
@@ -4942,7 +4942,7 @@ test_attr_corder_create_dense(hid_t fcpl, hid_t fapl)
             H5A_info_t ainfo; /* Attribute information */
 
             /* Retrieve information for attribute */
-            HDsnprintf(attrname, sizeof(attrname), "attr %02u", u);
+            snprintf(attrname, sizeof(attrname), "attr %02u", u);
             ret = H5Aget_info_by_name(my_dataset, ".", attrname, &ainfo, H5P_DEFAULT);
             CHECK(ret, FAIL, "H5Aget_info_by_name");
 
@@ -5215,7 +5215,7 @@ test_attr_corder_transition(hid_t fcpl, hid_t fapl)
         /* Create several attributes, but keep storage in compact form */
         for (u = 0; u < max_compact; u++) {
             /* Create attribute */
-            HDsnprintf(attrname, sizeof(attrname), "attr %02u", u);
+            snprintf(attrname, sizeof(attrname), "attr %02u", u);
             attr = H5Acreate2(my_dataset, attrname, H5T_NATIVE_UINT, sid, H5P_DEFAULT, H5P_DEFAULT);
             CHECK(attr, FAIL, "H5Acreate2");
 
@@ -5238,7 +5238,7 @@ test_attr_corder_transition(hid_t fcpl, hid_t fapl)
         } /* end for */
 
         /* Create another attribute, to push into dense storage */
-        HDsnprintf(attrname, sizeof(attrname), "attr %02u", max_compact);
+        snprintf(attrname, sizeof(attrname), "attr %02u", max_compact);
         attr = H5Acreate2(my_dataset, attrname, H5T_NATIVE_UINT, sid, H5P_DEFAULT, H5P_DEFAULT);
         CHECK(attr, FAIL, "H5Acreate2");
 
@@ -5266,7 +5266,7 @@ test_attr_corder_transition(hid_t fcpl, hid_t fapl)
 
         /* Delete several attributes from object, until attribute storage resumes compact form */
         for (u = max_compact; u >= min_dense; u--) {
-            HDsnprintf(attrname, sizeof(attrname), "attr %02u", u);
+            snprintf(attrname, sizeof(attrname), "attr %02u", u);
             ret = H5Adelete(my_dataset, attrname);
             CHECK(ret, FAIL, "H5Adelete");
 
@@ -5286,7 +5286,7 @@ test_attr_corder_transition(hid_t fcpl, hid_t fapl)
         } /* end for */
 
         /* Delete another attribute, to push attribute storage into compact form */
-        HDsnprintf(attrname, sizeof(attrname), "attr %02u", (min_dense - 1));
+        snprintf(attrname, sizeof(attrname), "attr %02u", (min_dense - 1));
         ret = H5Adelete(my_dataset, attrname);
         CHECK(ret, FAIL, "H5Adelete");
 
@@ -5302,7 +5302,7 @@ test_attr_corder_transition(hid_t fcpl, hid_t fapl)
         /* Re-add attributes to get back into dense form */
         for (u = (min_dense - 1); u < (max_compact + 1); u++) {
             /* Create attribute */
-            HDsnprintf(attrname, sizeof(attrname), "attr %02u", u);
+            snprintf(attrname, sizeof(attrname), "attr %02u", u);
             attr = H5Acreate2(my_dataset, attrname, H5T_NATIVE_UINT, sid, H5P_DEFAULT, H5P_DEFAULT);
             CHECK(attr, FAIL, "H5Acreate2");
 
@@ -5389,7 +5389,7 @@ test_attr_corder_transition(hid_t fcpl, hid_t fapl)
 
         /* Delete several attributes from object, until attribute storage resumes compact form */
         for (u = max_compact; u >= min_dense; u--) {
-            HDsnprintf(attrname, sizeof(attrname), "attr %02u", u);
+            snprintf(attrname, sizeof(attrname), "attr %02u", u);
             ret = H5Adelete(my_dataset, attrname);
             CHECK(ret, FAIL, "H5Adelete");
 
@@ -5409,7 +5409,7 @@ test_attr_corder_transition(hid_t fcpl, hid_t fapl)
         } /* end for */
 
         /* Delete another attribute, to push attribute storage into compact form */
-        HDsnprintf(attrname, sizeof(attrname), "attr %02u", (min_dense - 1));
+        snprintf(attrname, sizeof(attrname), "attr %02u", (min_dense - 1));
         ret = H5Adelete(my_dataset, attrname);
         CHECK(ret, FAIL, "H5Adelete");
 
@@ -5425,7 +5425,7 @@ test_attr_corder_transition(hid_t fcpl, hid_t fapl)
         /* Re-add attributes to get back into dense form */
         for (u = (min_dense - 1); u < (max_compact + 1); u++) {
             /* Create attribute */
-            HDsnprintf(attrname, sizeof(attrname), "attr %02u", u);
+            snprintf(attrname, sizeof(attrname), "attr %02u", u);
             attr = H5Acreate2(my_dataset, attrname, H5T_NATIVE_UINT, sid, H5P_DEFAULT, H5P_DEFAULT);
             CHECK(attr, FAIL, "H5Acreate2");
 
@@ -5454,11 +5454,11 @@ test_attr_corder_transition(hid_t fcpl, hid_t fapl)
 
         /* Delete all attributes */
         for (u = max_compact; u > 0; u--) {
-            HDsnprintf(attrname, sizeof(attrname), "attr %02u", u);
+            snprintf(attrname, sizeof(attrname), "attr %02u", u);
             ret = H5Adelete(my_dataset, attrname);
             CHECK(ret, FAIL, "H5Adelete");
         } /* end for */
-        HDsnprintf(attrname, sizeof(attrname), "attr %02u", 0);
+        snprintf(attrname, sizeof(attrname), "attr %02u", 0);
         ret = H5Adelete(my_dataset, attrname);
         CHECK(ret, FAIL, "H5Adelete");
     } /* end for */
@@ -5576,7 +5576,7 @@ test_attr_corder_delete(hid_t fcpl, hid_t fapl)
             /* Create attributes, until attribute storage is in dense form */
             for (u = 0; u < max_compact * 2; u++) {
                 /* Create attribute */
-                HDsnprintf(attrname, sizeof(attrname), "attr %02u", u);
+                snprintf(attrname, sizeof(attrname), "attr %02u", u);
                 attr = H5Acreate2(my_dataset, attrname, H5T_NATIVE_UINT, sid, H5P_DEFAULT, H5P_DEFAULT);
                 CHECK(attr, FAIL, "H5Acreate2");
 
@@ -5698,7 +5698,7 @@ attr_info_by_idx_check(hid_t obj_id, const char *attrname, hsize_t n, bool use_i
     ret = (herr_t)H5Aget_name_by_idx(obj_id, ".", H5_INDEX_CRT_ORDER, H5_ITER_INC, n, tmpname,
                                      (size_t)NAME_BUF_SIZE, H5P_DEFAULT);
     CHECK(ret, FAIL, "H5Aget_name_by_idx");
-    if (HDstrcmp(attrname, tmpname) != 0)
+    if (strcmp(attrname, tmpname) != 0)
         TestErrPrintf("Line %d: attribute name size wrong!\n", __LINE__);
 
     /* Don't test "native" order if there is no creation order index, since
@@ -5724,7 +5724,7 @@ attr_info_by_idx_check(hid_t obj_id, const char *attrname, hsize_t n, bool use_i
         ret = (herr_t)H5Aget_name_by_idx(obj_id, ".", H5_INDEX_CRT_ORDER, H5_ITER_NATIVE, n, tmpname,
                                          (size_t)NAME_BUF_SIZE, H5P_DEFAULT);
         CHECK(ret, FAIL, "H5Aget_name_by_idx");
-        if (HDstrcmp(attrname, tmpname) != 0)
+        if (strcmp(attrname, tmpname) != 0)
             TestErrPrintf("Line %d: attribute name size wrong!\n", __LINE__);
     } /* end if */
 
@@ -5745,7 +5745,7 @@ attr_info_by_idx_check(hid_t obj_id, const char *attrname, hsize_t n, bool use_i
     ret = (herr_t)H5Aget_name_by_idx(obj_id, ".", H5_INDEX_CRT_ORDER, H5_ITER_DEC, (hsize_t)0, tmpname,
                                      (size_t)NAME_BUF_SIZE, H5P_DEFAULT);
     CHECK(ret, FAIL, "H5Aget_name_by_idx");
-    if (HDstrcmp(attrname, tmpname) != 0)
+    if (strcmp(attrname, tmpname) != 0)
         TestErrPrintf("Line %d: attribute name size wrong!\n", __LINE__);
 
     /* Verify the information for first attribute, in increasing name order */
@@ -5765,7 +5765,7 @@ attr_info_by_idx_check(hid_t obj_id, const char *attrname, hsize_t n, bool use_i
     ret = (herr_t)H5Aget_name_by_idx(obj_id, ".", H5_INDEX_NAME, H5_ITER_INC, n, tmpname,
                                      (size_t)NAME_BUF_SIZE, H5P_DEFAULT);
     CHECK(ret, FAIL, "H5Aget_name_by_idx");
-    if (HDstrcmp(attrname, tmpname) != 0)
+    if (strcmp(attrname, tmpname) != 0)
         TestErrPrintf("Line %d: attribute name size wrong!\n", __LINE__);
 
     /* Don't test "native" order queries on link name order, since there's not
@@ -5789,7 +5789,7 @@ attr_info_by_idx_check(hid_t obj_id, const char *attrname, hsize_t n, bool use_i
     ret = (herr_t)H5Aget_name_by_idx(obj_id, ".", H5_INDEX_NAME, H5_ITER_DEC, (hsize_t)0, tmpname,
                                      (size_t)NAME_BUF_SIZE, H5P_DEFAULT);
     CHECK(ret, FAIL, "H5Aget_name_by_idx");
-    if (HDstrcmp(attrname, tmpname) != 0)
+    if (strcmp(attrname, tmpname) != 0)
         TestErrPrintf("Line %d: attribute name size wrong!\n", __LINE__);
 
     /* Retrieve current # of errors */
@@ -5918,7 +5918,7 @@ test_attr_info_by_idx(bool new_format, hid_t fcpl, hid_t fapl)
             /* Create attributes, up to limit of compact form */
             for (u = 0; u < max_compact; u++) {
                 /* Create attribute */
-                HDsnprintf(attrname, sizeof(attrname), "attr %02u", u);
+                snprintf(attrname, sizeof(attrname), "attr %02u", u);
                 attr = H5Acreate2(my_dataset, attrname, H5T_NATIVE_UINT, sid, H5P_DEFAULT, H5P_DEFAULT);
                 CHECK(attr, FAIL, "H5Acreate2");
 
@@ -5970,7 +5970,7 @@ test_attr_info_by_idx(bool new_format, hid_t fcpl, hid_t fapl)
             /* Create more attributes, to push into dense form */
             for (; u < (max_compact * 2); u++) {
                 /* Create attribute */
-                HDsnprintf(attrname, sizeof(attrname), "attr %02u", u);
+                snprintf(attrname, sizeof(attrname), "attr %02u", u);
                 attr = H5Acreate2(my_dataset, attrname, H5T_NATIVE_UINT, sid, H5P_DEFAULT, H5P_DEFAULT);
                 CHECK(attr, FAIL, "H5Acreate2");
 
@@ -6432,7 +6432,7 @@ test_attr_delete_by_idx(bool new_format, hid_t fcpl, hid_t fapl)
                     /* Create attributes, up to limit of compact form */
                     for (u = 0; u < max_compact; u++) {
                         /* Create attribute */
-                        HDsnprintf(attrname, sizeof(attrname), "attr %02u", u);
+                        snprintf(attrname, sizeof(attrname), "attr %02u", u);
                         attr =
                             H5Acreate2(my_dataset, attrname, H5T_NATIVE_UINT, sid, H5P_DEFAULT, H5P_DEFAULT);
                         CHECK(attr, FAIL, "H5Acreate2");
@@ -6511,10 +6511,10 @@ test_attr_delete_by_idx(bool new_format, hid_t fcpl, hid_t fapl)
                         ret = (herr_t)H5Aget_name_by_idx(my_dataset, ".", idx_type, order, (hsize_t)0,
                                                          tmpname, (size_t)NAME_BUF_SIZE, H5P_DEFAULT);
                         if (order == H5_ITER_INC)
-                            HDsnprintf(attrname, sizeof(attrname), "attr %02u", (u + 1));
+                            snprintf(attrname, sizeof(attrname), "attr %02u", (u + 1));
                         else
-                            HDsnprintf(attrname, sizeof(attrname), "attr %02u", (max_compact - (u + 2)));
-                        ret = HDstrcmp(attrname, tmpname);
+                            snprintf(attrname, sizeof(attrname), "attr %02u", (max_compact - (u + 2)));
+                        ret = strcmp(attrname, tmpname);
                         VERIFY(ret, 0, "H5Aget_name_by_idx");
                     } /* end for */
 
@@ -6549,7 +6549,7 @@ test_attr_delete_by_idx(bool new_format, hid_t fcpl, hid_t fapl)
                     /* Create more attributes, to push into dense form */
                     for (u = 0; u < (max_compact * 2); u++) {
                         /* Create attribute */
-                        HDsnprintf(attrname, sizeof(attrname), "attr %02u", u);
+                        snprintf(attrname, sizeof(attrname), "attr %02u", u);
                         attr =
                             H5Acreate2(my_dataset, attrname, H5T_NATIVE_UINT, sid, H5P_DEFAULT, H5P_DEFAULT);
                         CHECK(attr, FAIL, "H5Acreate2");
@@ -6643,11 +6643,10 @@ test_attr_delete_by_idx(bool new_format, hid_t fcpl, hid_t fapl)
                         ret = (herr_t)H5Aget_name_by_idx(my_dataset, ".", idx_type, order, (hsize_t)0,
                                                          tmpname, (size_t)NAME_BUF_SIZE, H5P_DEFAULT);
                         if (order == H5_ITER_INC)
-                            HDsnprintf(attrname, sizeof(attrname), "attr %02u", (u + 1));
+                            snprintf(attrname, sizeof(attrname), "attr %02u", (u + 1));
                         else
-                            HDsnprintf(attrname, sizeof(attrname), "attr %02u",
-                                       ((max_compact * 2) - (u + 2)));
-                        ret = HDstrcmp(attrname, tmpname);
+                            snprintf(attrname, sizeof(attrname), "attr %02u", ((max_compact * 2) - (u + 2)));
+                        ret = strcmp(attrname, tmpname);
                         VERIFY(ret, 0, "H5Aget_name_by_idx");
                     } /* end for */
 
@@ -6692,7 +6691,7 @@ test_attr_delete_by_idx(bool new_format, hid_t fcpl, hid_t fapl)
                     /* Create attributes, to push into dense form */
                     for (u = 0; u < (max_compact * 2); u++) {
                         /* Create attribute */
-                        HDsnprintf(attrname, sizeof(attrname), "attr %02u", u);
+                        snprintf(attrname, sizeof(attrname), "attr %02u", u);
                         attr =
                             H5Acreate2(my_dataset, attrname, H5T_NATIVE_UINT, sid, H5P_DEFAULT, H5P_DEFAULT);
                         CHECK(attr, FAIL, "H5Acreate2");
@@ -6761,11 +6760,11 @@ test_attr_delete_by_idx(bool new_format, hid_t fcpl, hid_t fapl)
                         ret = (herr_t)H5Aget_name_by_idx(my_dataset, ".", idx_type, order, (hsize_t)u,
                                                          tmpname, (size_t)NAME_BUF_SIZE, H5P_DEFAULT);
                         if (order == H5_ITER_INC)
-                            HDsnprintf(attrname, sizeof(attrname), "attr %02u", ((u * 2) + 1));
+                            snprintf(attrname, sizeof(attrname), "attr %02u", ((u * 2) + 1));
                         else
-                            HDsnprintf(attrname, sizeof(attrname), "attr %02u",
-                                       ((max_compact * 2) - ((u * 2) + 2)));
-                        ret = HDstrcmp(attrname, tmpname);
+                            snprintf(attrname, sizeof(attrname), "attr %02u",
+                                     ((max_compact * 2) - ((u * 2) + 2)));
+                        ret = strcmp(attrname, tmpname);
                         VERIFY(ret, 0, "H5Aget_name_by_idx");
                     } /* end for */
                 }     /* end for */
@@ -6814,11 +6813,11 @@ test_attr_delete_by_idx(bool new_format, hid_t fcpl, hid_t fapl)
                         ret = (herr_t)H5Aget_name_by_idx(my_dataset, ".", idx_type, order, (hsize_t)0,
                                                          tmpname, (size_t)NAME_BUF_SIZE, H5P_DEFAULT);
                         if (order == H5_ITER_INC)
-                            HDsnprintf(attrname, sizeof(attrname), "attr %02u", ((u * 2) + 3));
+                            snprintf(attrname, sizeof(attrname), "attr %02u", ((u * 2) + 3));
                         else
-                            HDsnprintf(attrname, sizeof(attrname), "attr %02u",
-                                       ((max_compact * 2) - ((u * 2) + 4)));
-                        ret = HDstrcmp(attrname, tmpname);
+                            snprintf(attrname, sizeof(attrname), "attr %02u",
+                                     ((max_compact * 2) - ((u * 2) + 4)));
+                        ret = strcmp(attrname, tmpname);
                         VERIFY(ret, 0, "H5Aget_name_by_idx");
                     } /* end for */
 
@@ -6902,8 +6901,8 @@ attr_iterate2_cb(hid_t loc_id, const char *attr_name, const H5A_info_t *info, vo
     } /* end if */
 
     /* Verify name of link */
-    HDsnprintf(attrname, sizeof(attrname), "attr %02u", (unsigned)my_info.corder);
-    if (HDstrcmp(attr_name, attrname) != 0)
+    snprintf(attrname, sizeof(attrname), "attr %02u", (unsigned)my_info.corder);
+    if (strcmp(attr_name, attrname) != 0)
         return (H5_ITER_ERROR);
 
     /* Check if we've visited this link before */
@@ -7420,7 +7419,7 @@ test_attr_iterate2(bool new_format, hid_t fcpl, hid_t fapl)
                     /* Create attributes, up to limit of compact form */
                     for (u = 0; u < max_compact; u++) {
                         /* Create attribute */
-                        HDsnprintf(attrname, sizeof(attrname), "attr %02u", u);
+                        snprintf(attrname, sizeof(attrname), "attr %02u", u);
                         attr =
                             H5Acreate2(my_dataset, attrname, H5T_NATIVE_UINT, sid, H5P_DEFAULT, H5P_DEFAULT);
                         CHECK(attr, FAIL, "H5Acreate2");
@@ -7504,7 +7503,7 @@ test_attr_iterate2(bool new_format, hid_t fcpl, hid_t fapl)
                     /* Create more attributes, to push into dense form */
                     for (u = max_compact; u < (max_compact * 2); u++) {
                         /* Create attribute */
-                        HDsnprintf(attrname, sizeof(attrname), "attr %02u", u);
+                        snprintf(attrname, sizeof(attrname), "attr %02u", u);
                         attr =
                             H5Acreate2(my_dataset, attrname, H5T_NATIVE_UINT, sid, H5P_DEFAULT, H5P_DEFAULT);
                         CHECK(attr, FAIL, "H5Acreate2");
@@ -7809,7 +7808,7 @@ test_attr_open_by_idx(bool new_format, hid_t fcpl, hid_t fapl)
                     /* Create attributes, up to limit of compact form */
                     for (u = 0; u < max_compact; u++) {
                         /* Create attribute */
-                        HDsnprintf(attrname, sizeof(attrname), "attr %02u", u);
+                        snprintf(attrname, sizeof(attrname), "attr %02u", u);
                         attr =
                             H5Acreate2(my_dataset, attrname, H5T_NATIVE_UINT, sid, H5P_DEFAULT, H5P_DEFAULT);
                         CHECK(attr, FAIL, "H5Acreate2");
@@ -7872,7 +7871,7 @@ test_attr_open_by_idx(bool new_format, hid_t fcpl, hid_t fapl)
                     /* Create more attributes, to push into dense form */
                     for (u = max_compact; u < (max_compact * 2); u++) {
                         /* Create attribute */
-                        HDsnprintf(attrname, sizeof(attrname), "attr %02u", u);
+                        snprintf(attrname, sizeof(attrname), "attr %02u", u);
                         attr =
                             H5Acreate2(my_dataset, attrname, H5T_NATIVE_UINT, sid, H5P_DEFAULT, H5P_DEFAULT);
                         CHECK(attr, FAIL, "H5Acreate2");
@@ -7978,7 +7977,7 @@ attr_open_check(hid_t fid, const char *dsetname, hid_t obj_id, unsigned max_attr
     /* Open each attribute on object by index and check that it's the correct one */
     for (u = 0; u < max_attrs; u++) {
         /* Open the attribute */
-        HDsnprintf(attrname, sizeof(attrname), "attr %02u", u);
+        snprintf(attrname, sizeof(attrname), "attr %02u", u);
         attr_id = H5Aopen(obj_id, attrname, H5P_DEFAULT);
         CHECK(attr_id, FAIL, "H5Aopen");
 
@@ -8159,7 +8158,7 @@ test_attr_open_by_name(bool new_format, hid_t fcpl, hid_t fapl)
             /* Create attributes, up to limit of compact form */
             for (u = 0; u < max_compact; u++) {
                 /* Create attribute */
-                HDsnprintf(attrname, sizeof(attrname), "attr %02u", u);
+                snprintf(attrname, sizeof(attrname), "attr %02u", u);
                 attr = H5Acreate2(my_dataset, attrname, H5T_NATIVE_UINT, sid, H5P_DEFAULT, H5P_DEFAULT);
                 CHECK(attr, FAIL, "H5Acreate2");
 
@@ -8237,7 +8236,7 @@ test_attr_open_by_name(bool new_format, hid_t fcpl, hid_t fapl)
             /* Create more attributes, to push into dense form */
             for (u = max_compact; u < (max_compact * 2); u++) {
                 /* Create attribute */
-                HDsnprintf(attrname, sizeof(attrname), "attr %02u", u);
+                snprintf(attrname, sizeof(attrname), "attr %02u", u);
                 attr = H5Acreate2(my_dataset, attrname, H5T_NATIVE_UINT, sid, H5P_DEFAULT, H5P_DEFAULT);
                 CHECK(attr, FAIL, "H5Acreate2");
 
@@ -8432,7 +8431,7 @@ test_attr_create_by_name(bool new_format, hid_t fcpl, hid_t fapl)
             /* Create attributes, up to limit of compact form */
             for (u = 0; u < max_compact; u++) {
                 /* Create attribute */
-                HDsnprintf(attrname, sizeof(attrname), "attr %02u", u);
+                snprintf(attrname, sizeof(attrname), "attr %02u", u);
                 attr = H5Acreate_by_name(fid, dsetname, attrname, H5T_NATIVE_UINT, sid, H5P_DEFAULT,
                                          H5P_DEFAULT, H5P_DEFAULT);
                 CHECK(attr, FAIL, "H5Acreate_by_name");
@@ -8489,7 +8488,7 @@ test_attr_create_by_name(bool new_format, hid_t fcpl, hid_t fapl)
             /* Create more attributes, to push into dense form */
             for (u = max_compact; u < (max_compact * 2); u++) {
                 /* Create attribute */
-                HDsnprintf(attrname, sizeof(attrname), "attr %02u", u);
+                snprintf(attrname, sizeof(attrname), "attr %02u", u);
                 attr = H5Acreate_by_name(fid, dsetname, attrname, H5T_NATIVE_UINT, sid, H5P_DEFAULT,
                                          H5P_DEFAULT, H5P_DEFAULT);
                 CHECK(attr, FAIL, "H5Acreate_by_name");
@@ -8714,7 +8713,7 @@ test_attr_shared_write(hid_t fcpl, hid_t fapl)
         /* Add attributes to each dataset, until after converting to dense storage */
         for (u = 0; u < max_compact * 2; u++) {
             /* Create attribute name */
-            HDsnprintf(attrname, sizeof(attrname), "attr %02u", u);
+            snprintf(attrname, sizeof(attrname), "attr %02u", u);
 
             /* Alternate between creating "small" & "big" attributes */
             if (u % 2) {
@@ -9051,7 +9050,7 @@ test_attr_shared_rename(hid_t fcpl, hid_t fapl)
         /* Add attributes to each dataset, until after converting to dense storage */
         for (u = 0; u < max_compact * 2; u++) {
             /* Create attribute name */
-            HDsnprintf(attrname, sizeof(attrname), "attr %02u", u);
+            snprintf(attrname, sizeof(attrname), "attr %02u", u);
 
             /* Alternate between creating "small" & "big" attributes */
             if (u % 2) {
@@ -9156,7 +9155,7 @@ test_attr_shared_rename(hid_t fcpl, hid_t fapl)
                 VERIFY(is_dense, true, "H5O__is_attr_dense_test");
 
             /* Create new attribute name */
-            HDsnprintf(attrname2, sizeof(attrname2), "new attr %02u", u);
+            snprintf(attrname2, sizeof(attrname2), "new attr %02u", u);
 
             /* Change second dataset's attribute's name */
             ret = H5Arename_by_name(fid, DSET2_NAME, attrname, attrname2, H5P_DEFAULT);
@@ -9498,7 +9497,7 @@ test_attr_shared_delete(hid_t fcpl, hid_t fapl)
         /* Add attributes to each dataset, until after converting to dense storage */
         for (u = 0; u < max_compact * 2; u++) {
             /* Create attribute name */
-            HDsnprintf(attrname, sizeof(attrname), "attr %02u", u);
+            snprintf(attrname, sizeof(attrname), "attr %02u", u);
 
             /* Alternate between creating "small" & "big" attributes */
             if (u % 2) {
@@ -9606,7 +9605,7 @@ test_attr_shared_delete(hid_t fcpl, hid_t fapl)
         /* Delete attributes from second dataset */
         for (u = 0; u < max_compact * 2; u++) {
             /* Create attribute name */
-            HDsnprintf(attrname, sizeof(attrname), "attr %02u", u);
+            snprintf(attrname, sizeof(attrname), "attr %02u", u);
 
             /* Delete second dataset's attribute */
             ret = H5Adelete_by_name(fid, DSET2_NAME, attrname, H5P_DEFAULT);
@@ -9870,7 +9869,7 @@ test_attr_shared_unlink(hid_t fcpl, hid_t fapl)
         /* Add attributes to each dataset, until after converting to dense storage */
         for (u = 0; u < max_compact * 2; u++) {
             /* Create attribute name */
-            HDsnprintf(attrname, sizeof(attrname), "attr %02u", u);
+            snprintf(attrname, sizeof(attrname), "attr %02u", u);
 
             /* Alternate between creating "small" & "big" attributes */
             if (u % 2) {
@@ -9994,7 +9993,7 @@ test_attr_shared_unlink(hid_t fcpl, hid_t fapl)
         /* Check ref count on  attributes of first dataset */
         for (u = 0; u < max_compact * 2; u++) {
             /* Create attribute name */
-            HDsnprintf(attrname, sizeof(attrname), "attr %02u", u);
+            snprintf(attrname, sizeof(attrname), "attr %02u", u);
 
             /* Open attribute on first dataset */
             attr = H5Aopen(dataset, attrname, H5P_DEFAULT);
@@ -10267,7 +10266,7 @@ test_attr_bug2(hid_t fcpl, hid_t fapl)
 
     /* Create attributes on group */
     for (i = 0; i < BUG2_NATTR; i++) {
-        HDsnprintf(aname, sizeof(aname), "%03u", i);
+        snprintf(aname, sizeof(aname), "%03u", i);
         aid = H5Acreate2(gid, aname, H5T_STD_I32LE, sid, H5P_DEFAULT, H5P_DEFAULT);
         CHECK(aid, FAIL, "H5Acreate2");
 
@@ -10277,7 +10276,7 @@ test_attr_bug2(hid_t fcpl, hid_t fapl)
 
     /* Delete every other attribute */
     for (i = 1; i < BUG2_NATTR; i += 2) {
-        HDsnprintf(aname, sizeof(aname), "%03u", i);
+        snprintf(aname, sizeof(aname), "%03u", i);
         ret = H5Adelete(gid, aname);
         CHECK(ret, FAIL, "H5Adelete");
     }
@@ -10301,7 +10300,7 @@ test_attr_bug2(hid_t fcpl, hid_t fapl)
 
     /* Open an attribute in the middle */
     i = (BUG2_NATTR / 4) * 2;
-    HDsnprintf(aname, sizeof(aname), "%03u", i);
+    snprintf(aname, sizeof(aname), "%03u", i);
     aid = H5Aopen(gid, aname, H5P_DEFAULT);
     CHECK(aid, FAIL, "H5Aopen");
 
@@ -10344,7 +10343,7 @@ test_attr_bug2(hid_t fcpl, hid_t fapl)
 
     /* Create attributes on group */
     for (i = 0; i < BUG2_NATTR2; i++) {
-        HDsnprintf(aname, sizeof(aname), "%03u", i);
+        snprintf(aname, sizeof(aname), "%03u", i);
         aid = H5Acreate2(gid, aname, H5T_STD_I32LE, sid, H5P_DEFAULT, H5P_DEFAULT);
         CHECK(aid, FAIL, "H5Acreate2");
 
@@ -10354,7 +10353,7 @@ test_attr_bug2(hid_t fcpl, hid_t fapl)
 
     /* Delete every other attribute */
     for (i = 0; i < BUG2_NATTR2; i++) {
-        HDsnprintf(aname, sizeof(aname), "%03u", i);
+        snprintf(aname, sizeof(aname), "%03u", i);
         ret = H5Adelete(gid, aname);
         CHECK(ret, FAIL, "H5Adelete");
     }
@@ -11212,7 +11211,7 @@ test_attr_bug9(hid_t fcpl, hid_t fapl)
         /* Create enough attributes to cause a change to dense storage */
         for (i = 0; i < max_compact + 1; i++) {
             /* Create attribute */
-            HDsnprintf(aname, sizeof(aname), "%u", i);
+            snprintf(aname, sizeof(aname), "%u", i);
             aid = H5Acreate2(gid, aname, H5T_NATIVE_CHAR, sid, H5P_DEFAULT, H5P_DEFAULT);
             CHECK(aid, FAIL, "H5Acreate2");
 

--- a/test/tcoords.c
+++ b/test/tcoords.c
@@ -87,9 +87,9 @@ test_singleEnd_selElements(hid_t file, bool is_chunked)
 
     /* Construct dataset's name */
     memset(dset_name, 0, (size_t)NAME_LEN);
-    HDstrcat(dset_name, SINGLE_END_DSET);
+    strcat(dset_name, SINGLE_END_DSET);
     if (is_chunked)
-        HDstrcat(dset_name, "_chunked");
+        strcat(dset_name, "_chunked");
 
     did = H5Dcreate2(file, dset_name, H5T_NATIVE_INT, sid, H5P_DEFAULT, plid, H5P_DEFAULT);
     CHECK(did, FAIL, "H5Dcreate2");
@@ -259,9 +259,9 @@ test_singleEnd_selHyperslab(hid_t file, bool is_chunked)
 
     /* Construct dataset's name */
     memset(dset_name, 0, NAME_LEN);
-    HDstrcat(dset_name, SINGLE_END_DSET);
+    strcat(dset_name, SINGLE_END_DSET);
     if (is_chunked)
-        HDstrcat(dset_name, "_chunked");
+        strcat(dset_name, "_chunked");
 
     /* Dataspace for the dataset in file */
     sid = H5Screate_simple(4, da_dims, da_dims);
@@ -462,9 +462,9 @@ test_multiple_ends(hid_t file, bool is_chunked)
 
     /* Construct dataset's name */
     memset(dset_name, 0, NAME_LEN);
-    HDstrcat(dset_name, MULTI_ENDS_SEL_HYPER_DSET);
+    strcat(dset_name, MULTI_ENDS_SEL_HYPER_DSET);
     if (is_chunked)
-        HDstrcat(dset_name, "_chunked");
+        strcat(dset_name, "_chunked");
 
     did = H5Dcreate2(file, dset_name, H5T_NATIVE_INT, sid, H5P_DEFAULT, plid, H5P_DEFAULT);
     CHECK(did, FAIL, "H5Dcreate2");

--- a/test/testframe.c
+++ b/test/testframe.c
@@ -69,11 +69,11 @@ AddTest(const char *TheName, void (*TheCall)(void), void (*Cleanup)(void), const
         const void *Parameters)
 {
     /* Sanity checking */
-    if (HDstrlen(TheDescr) >= MAXTESTDESC) {
+    if (strlen(TheDescr) >= MAXTESTDESC) {
         printf("Test description ('%s') too long, increase MAXTESTDESC(%d).\n", TheDescr, MAXTESTDESC);
         exit(EXIT_FAILURE);
     }
-    if (HDstrlen(TheName) >= MAXTESTNAME) {
+    if (strlen(TheName) >= MAXTESTNAME) {
         printf("Test name too long, increase MAXTESTNAME(%d).\n", MAXTESTNAME);
         exit(EXIT_FAILURE);
     }
@@ -96,13 +96,13 @@ AddTest(const char *TheName, void (*TheCall)(void), void (*Cleanup)(void), const
     }
 
     /* Set up test function */
-    HDstrcpy(Test[Index].Description, TheDescr);
+    strcpy(Test[Index].Description, TheDescr);
     if (*TheName != '-') {
-        HDstrcpy(Test[Index].Name, TheName);
+        strcpy(Test[Index].Name, TheName);
         Test[Index].SkipFlag = 0;
     }
     else { /* skip test by default */
-        HDstrcpy(Test[Index].Name, TheName + 1);
+        strcpy(Test[Index].Name, TheName + 1);
         Test[Index].SkipFlag = 1;
     }
     Test[Index].Call       = TheCall;
@@ -214,7 +214,7 @@ TestParseCmdLine(int argc, char *argv[])
     int  ret_code;
 
     while ((void)argv++, --argc > 0) {
-        if ((HDstrcmp(*argv, "-verbose") == 0) || (HDstrcmp(*argv, "-v") == 0)) {
+        if ((strcmp(*argv, "-verbose") == 0) || (strcmp(*argv, "-v") == 0)) {
             if (argc > 0) {
                 --argc;
                 ++argv;
@@ -225,7 +225,7 @@ TestParseCmdLine(int argc, char *argv[])
                 exit(EXIT_FAILURE);
             }
         }
-        else if (((HDstrcmp(*argv, "-exclude") == 0) || (HDstrcmp(*argv, "-x") == 0))) {
+        else if (((strcmp(*argv, "-exclude") == 0) || (strcmp(*argv, "-x") == 0))) {
             if (argc > 0) {
                 --argc;
                 ++argv;
@@ -236,7 +236,7 @@ TestParseCmdLine(int argc, char *argv[])
                 exit(EXIT_FAILURE);
             }
         }
-        else if (((HDstrcmp(*argv, "-begin") == 0) || (HDstrcmp(*argv, "-b") == 0))) {
+        else if (((strcmp(*argv, "-begin") == 0) || (strcmp(*argv, "-b") == 0))) {
             if (argc > 0) {
                 --argc;
                 ++argv;
@@ -247,7 +247,7 @@ TestParseCmdLine(int argc, char *argv[])
                 exit(EXIT_FAILURE);
             }
         }
-        else if (((HDstrcmp(*argv, "-only") == 0) || (HDstrcmp(*argv, "-o") == 0))) {
+        else if (((strcmp(*argv, "-only") == 0) || (strcmp(*argv, "-o") == 0))) {
             if (argc > 0) {
                 unsigned Loop;
 
@@ -267,15 +267,15 @@ TestParseCmdLine(int argc, char *argv[])
                 exit(EXIT_FAILURE);
             }
         }
-        else if ((HDstrcmp(*argv, "-summary") == 0) || (HDstrcmp(*argv, "-s") == 0))
+        else if ((strcmp(*argv, "-summary") == 0) || (strcmp(*argv, "-s") == 0))
             Summary = 1;
-        else if (HDstrcmp(*argv, "-enable-error-stack") == 0)
+        else if (strcmp(*argv, "-enable-error-stack") == 0)
             enable_error_stack = 1;
-        else if ((HDstrcmp(*argv, "-help") == 0) || (HDstrcmp(*argv, "-h") == 0)) {
+        else if ((strcmp(*argv, "-help") == 0) || (strcmp(*argv, "-h") == 0)) {
             TestUsage();
             exit(EXIT_SUCCESS);
         }
-        else if ((HDstrcmp(*argv, "-cleanoff") == 0) || (HDstrcmp(*argv, "-c") == 0))
+        else if ((strcmp(*argv, "-cleanoff") == 0) || (strcmp(*argv, "-c") == 0))
             SetTestNoCleanup();
         else {
             /* non-standard option.  Break out. */
@@ -447,11 +447,11 @@ GetTestExpress(void)
         /* Check if HDF5TestExpress is set to override the default level */
         env_val = HDgetenv("HDF5TestExpress");
         if (env_val) {
-            if (HDstrcmp(env_val, "0") == 0)
+            if (strcmp(env_val, "0") == 0)
                 express_val = 0;
-            else if (HDstrcmp(env_val, "1") == 0)
+            else if (strcmp(env_val, "1") == 0)
                 express_val = 1;
-            else if (HDstrcmp(env_val, "2") == 0)
+            else if (strcmp(env_val, "2") == 0)
                 express_val = 2;
             else
                 express_val = 3;
@@ -570,7 +570,7 @@ TestErrPrintf(const char *format, ...)
 
     /* Print the requested information */
     va_start(arglist, format);
-    ret_value = HDvprintf(format, arglist);
+    ret_value = vprintf(format, arglist);
     va_end(arglist);
 
     /* Return the length of the string produced (like printf() does) */
@@ -592,14 +592,14 @@ SetTest(const char *testname, int action)
     switch (action) {
         case SKIPTEST:
             for (Loop = 0; Loop < Index; Loop++)
-                if (HDstrcmp(testname, Test[Loop].Name) == 0) {
+                if (strcmp(testname, Test[Loop].Name) == 0) {
                     Test[Loop].SkipFlag = 1;
                     break;
                 }
             break;
         case BEGINTEST:
             for (Loop = 0; Loop < Index; Loop++) {
-                if (HDstrcmp(testname, Test[Loop].Name) != 0)
+                if (strcmp(testname, Test[Loop].Name) != 0)
                     Test[Loop].SkipFlag = 1;
                 else {
                     /* Found it. Set it to run.  Done. */
@@ -610,7 +610,7 @@ SetTest(const char *testname, int action)
             break;
         case ONLYTEST:
             for (Loop = 0; Loop < Index; Loop++) {
-                if (HDstrcmp(testname, Test[Loop].Name) == 0) {
+                if (strcmp(testname, Test[Loop].Name) == 0) {
                     /* Found it. Set it to run. Break to skip the rest. */
                     Test[Loop].SkipFlag = 0;
                     break;

--- a/test/testhdf5.h
+++ b/test/testhdf5.h
@@ -135,7 +135,7 @@
                        "%s \n",                                                                              \
                        (where), (int)__LINE__, __FILE__, x);                                                 \
         }                                                                                                    \
-        if (HDstrcmp(x, val) != 0) {                                                                         \
+        if (strcmp(x, val) != 0) {                                                                           \
             TestErrPrintf("*** UNEXPECTED VALUE from %s should be %s, but is %s at line %4d "                \
                           "in %s\n",                                                                         \
                           where, val, x, (int)__LINE__, __FILE__);                                           \

--- a/test/testmeta.c
+++ b/test/testmeta.c
@@ -82,7 +82,7 @@ main(void)
 
     for (i = 0; i < NEXTARRAYS; i++) {
         /* Create dataset */
-        HDsnprintf(name, sizeof(name), "/ExtArray%06d", i);
+        snprintf(name, sizeof(name), "/ExtArray%06d", i);
         dataset_id =
             H5Dcreate2(file_id, name, H5T_NATIVE_FLOAT, dataspace_id, H5P_DEFAULT, prop_id, H5P_DEFAULT);
 
@@ -107,7 +107,7 @@ main(void)
         floatval = (float)j;
 
         /* Create group to hold data arrays for this object */
-        HDsnprintf(name, sizeof(name), "/DataArray/%06d", j);
+        snprintf(name, sizeof(name), "/DataArray/%06d", j);
         group_id = H5Gcreate2(file_id, name, H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT);
         if (group_id < 0) {
             fprintf(stderr, "Failed to create DataArray group.\n");
@@ -123,7 +123,7 @@ main(void)
             dataspace_id = H5Screate_simple(1, dims, maxdims);
 
             /* Create dataset */
-            HDsnprintf(name, sizeof(name), "DataArray%06d", i);
+            snprintf(name, sizeof(name), "DataArray%06d", i);
             dataset_id = H5Dcreate2(group_id, name, H5T_NATIVE_FLOAT, dataspace_id, H5P_DEFAULT, H5P_DEFAULT,
                                     H5P_DEFAULT);
             if (dataset_id < 0) {
@@ -169,7 +169,7 @@ main(void)
         /* Extend attribute arrays */
         for (i = 0; i < NEXTARRAYS; i++) {
             /* Open extendable dataset */
-            HDsnprintf(name, sizeof(name), "/ExtArray%06d", i);
+            snprintf(name, sizeof(name), "/ExtArray%06d", i);
             dataset_id = H5Dopen2(file_id, name, H5P_DEFAULT);
             if (dataset_id < 0) {
                 fprintf(stderr, "Failed to open ExtArray dataset.\n");

--- a/test/tfile.c
+++ b/test/tfile.c
@@ -1188,14 +1188,14 @@ test_get_obj_ids(void)
 
     /* creates NGROUPS groups under the root group */
     for (m = 0; m < NGROUPS; m++) {
-        HDsnprintf(gname, sizeof(gname), "group%d", m);
+        snprintf(gname, sizeof(gname), "group%d", m);
         gid[m] = H5Gcreate2(fid, gname, H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT);
         CHECK(gid[m], FAIL, "H5Gcreate2");
     }
 
     /* create NDSETS datasets under the root group */
     for (n = 0; n < NDSETS; n++) {
-        HDsnprintf(dname, sizeof(dname), "dataset%d", n);
+        snprintf(dname, sizeof(dname), "dataset%d", n);
         dset[n] = H5Dcreate2(fid, dname, H5T_NATIVE_INT, filespace, H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT);
         CHECK(dset[n], FAIL, "H5Dcreate2");
     }
@@ -1255,7 +1255,7 @@ test_get_obj_ids(void)
 
     /* Open NDSETS datasets under the root group */
     for (n = 0; n < NDSETS; n++) {
-        HDsnprintf(dname, sizeof(dname), "dataset%d", n);
+        snprintf(dname, sizeof(dname), "dataset%d", n);
         dset[n] = H5Dopen2(fid, dname, H5P_DEFAULT);
         CHECK(dset[n], FAIL, "H5Dcreate2");
     }
@@ -1797,7 +1797,7 @@ test_file_is_accessible(const char *env_h5_drvr)
     /* This test is not currently working for the family VFD.
      * There are failures when creating files with userblocks.
      */
-    if (0 != HDstrcmp(env_h5_drvr, "family")) {
+    if (0 != strcmp(env_h5_drvr, "family")) {
         /* Create a file creation property list with a non-default user block size */
         fcpl_id = H5Pcreate(H5P_FILE_CREATE);
         CHECK(fcpl_id, H5I_INVALID_HID, "H5Pcreate");
@@ -3005,8 +3005,8 @@ test_userblock_file_size(const char *env_h5_drvr)
     herr_t        ret;              /* Generic return value */
 
     /* Don't run with multi/split, family or direct drivers */
-    if (!HDstrcmp(env_h5_drvr, "multi") || !HDstrcmp(env_h5_drvr, "split") ||
-        !HDstrcmp(env_h5_drvr, "family") || !HDstrcmp(env_h5_drvr, "direct"))
+    if (!strcmp(env_h5_drvr, "multi") || !strcmp(env_h5_drvr, "split") || !strcmp(env_h5_drvr, "family") ||
+        !strcmp(env_h5_drvr, "direct"))
         return;
 
     /* Output message about test being performed */
@@ -4049,7 +4049,7 @@ test_filespace_info(const char *env_h5_drvr)
     MESSAGE(5, ("Testing file creation public routines: H5Pget/set_file_space_strategy & "
                 "H5Pget/set_file_space_page_size\n"));
 
-    contig_addr_vfd = (bool)(HDstrcmp(env_h5_drvr, "split") != 0 && HDstrcmp(env_h5_drvr, "multi") != 0);
+    contig_addr_vfd = (bool)(strcmp(env_h5_drvr, "split") != 0 && strcmp(env_h5_drvr, "multi") != 0);
 
     fapl = h5_fileaccess();
     h5_fixname(FILESPACE_NAME[0], fapl, filename, sizeof filename);
@@ -4458,8 +4458,8 @@ test_file_freespace(const char *env_h5_drvr)
     hsize_t        expected_fs_del;        /* Freespace expected after delete */
     herr_t         ret;                    /* Return value */
 
-    split_vfd = !HDstrcmp(env_h5_drvr, "split");
-    multi_vfd = !HDstrcmp(env_h5_drvr, "multi");
+    split_vfd = !strcmp(env_h5_drvr, "split");
+    multi_vfd = !strcmp(env_h5_drvr, "multi");
 
     if (!split_vfd && !multi_vfd) {
         fapl = h5_fileaccess();
@@ -4546,7 +4546,7 @@ test_file_freespace(const char *env_h5_drvr)
 
             /* Create datasets in file */
             for (u = 0; u < 10; u++) {
-                HDsnprintf(name, sizeof(name), "Dataset %u", u);
+                snprintf(name, sizeof(name), "Dataset %u", u);
                 dset = H5Dcreate2(file, name, H5T_STD_U32LE, dspace, H5P_DEFAULT, dcpl, H5P_DEFAULT);
                 CHECK(dset, FAIL, "H5Dcreate2");
 
@@ -4569,7 +4569,7 @@ test_file_freespace(const char *env_h5_drvr)
 
             /* Delete datasets in file */
             for (k = 9; k >= 0; k--) {
-                HDsnprintf(name, sizeof(name), "Dataset %u", (unsigned)k);
+                snprintf(name, sizeof(name), "Dataset %u", (unsigned)k);
                 ret = H5Ldelete(file, name, H5P_DEFAULT);
                 CHECK(ret, FAIL, "H5Ldelete");
             } /* end for */
@@ -4634,8 +4634,8 @@ test_sects_freespace(const char *env_h5_drvr, bool new_format)
     /* Output message about test being performed */
     MESSAGE(5, ("Testing H5Fget_free_sections()--free-space section info in the file\n"));
 
-    split_vfd = !HDstrcmp(env_h5_drvr, "split");
-    multi_vfd = !HDstrcmp(env_h5_drvr, "multi");
+    split_vfd = !strcmp(env_h5_drvr, "split");
+    multi_vfd = !strcmp(env_h5_drvr, "multi");
 
     if (!split_vfd && !multi_vfd) {
 
@@ -4697,7 +4697,7 @@ test_sects_freespace(const char *env_h5_drvr, bool new_format)
 
         /* Create datasets in file */
         for (u = 0; u < 10; u++) {
-            HDsnprintf(name, sizeof(name), "Dataset %u", u);
+            snprintf(name, sizeof(name), "Dataset %u", u);
             dset = H5Dcreate2(file, name, H5T_STD_U32LE, dspace, H5P_DEFAULT, dcpl, H5P_DEFAULT);
             CHECK(dset, FAIL, "H5Dcreate2");
 
@@ -4715,7 +4715,7 @@ test_sects_freespace(const char *env_h5_drvr, bool new_format)
 
         /* Delete odd-numbered datasets in file */
         for (u = 0; u < 10; u++) {
-            HDsnprintf(name, sizeof(name), "Dataset %u", u);
+            snprintf(name, sizeof(name), "Dataset %u", u);
             if (u % 2) {
                 ret = H5Ldelete(file, name, H5P_DEFAULT);
                 CHECK(ret, FAIL, "H5Ldelete");
@@ -7687,7 +7687,7 @@ test_incr_filesize(void)
 
         /* Create datasets in file */
         for (u = 0; u < 10; u++) {
-            HDsnprintf(name, sizeof(name), "Dataset %u", u);
+            snprintf(name, sizeof(name), "Dataset %u", u);
             dset = H5Dcreate2(fid, name, H5T_STD_U32LE, dspace, H5P_DEFAULT, dcpl, H5P_DEFAULT);
             CHECK(dset, FAIL, "H5Dcreate2");
 

--- a/test/tgenprop.c
+++ b/test/tgenprop.c
@@ -94,7 +94,7 @@ test_genprop_basic_class(void)
     /* Check class name */
     name = H5Pget_class_name(cid1);
     CHECK_PTR(name, "H5Pget_class_name");
-    if (HDstrcmp(name, CLASS1_NAME) != 0)
+    if (strcmp(name, CLASS1_NAME) != 0)
         TestErrPrintf("Class names don't match!, name=%s, CLASS1_NAME=%s\n", name, CLASS1_NAME);
     H5free_memory(name);
 
@@ -125,7 +125,7 @@ test_genprop_basic_class(void)
     /* Check class name */
     name = H5Pget_class_name(cid1);
     CHECK_PTR(name, "H5Pget_class_name");
-    if (HDstrcmp(name, CLASS2_NAME) != 0)
+    if (strcmp(name, CLASS2_NAME) != 0)
         TestErrPrintf("Class names don't match!, name=%s, CLASS2_NAME=%s\n", name, CLASS2_NAME);
     H5free_memory(name);
 
@@ -313,7 +313,7 @@ test_genprop_iter1(hid_t H5_ATTR_UNUSED id, const char *name, void *iter_data)
 {
     iter_data_t *idata = (iter_data_t *)iter_data;
 
-    return HDstrcmp(name, idata->names[idata->iter_count++]);
+    return strcmp(name, idata->names[idata->iter_count++]);
 }
 
 /****************************************************************
@@ -868,7 +868,7 @@ test_genprop_iter2(hid_t H5_ATTR_UNUSED id, const char *name, void *iter_data)
 {
     iter_data_t *idata = (iter_data_t *)iter_data;
 
-    return HDstrcmp(name, idata->names[idata->iter_count++]);
+    return strcmp(name, idata->names[idata->iter_count++]);
 }
 
 /****************************************************************
@@ -1026,7 +1026,7 @@ test_genprop_prop_crt_cb1(const char *name, size_t size, void *def_value)
 {
     /* Set the information from the creation call */
     prop1_cb_info.crt_count++;
-    prop1_cb_info.crt_name  = HDstrdup(name);
+    prop1_cb_info.crt_name  = strdup(name);
     prop1_cb_info.crt_value = malloc(size);
     memcpy(prop1_cb_info.crt_value, def_value, size);
 
@@ -1045,7 +1045,7 @@ test_genprop_prop_set_cb1(hid_t plist_id, const char *name, size_t size, void *v
     prop1_cb_info.set_count++;
     prop1_cb_info.set_plist_id = plist_id;
     if (prop1_cb_info.set_name == NULL)
-        prop1_cb_info.set_name = HDstrdup(name);
+        prop1_cb_info.set_name = strdup(name);
     if (prop1_cb_info.set_value == NULL)
         prop1_cb_info.set_value = malloc(size);
     memcpy(prop1_cb_info.set_value, value, size);
@@ -1065,7 +1065,7 @@ test_genprop_prop_get_cb1(hid_t plist_id, const char *name, size_t size, void *v
     prop1_cb_info.get_count++;
     prop1_cb_info.get_plist_id = plist_id;
     if (prop1_cb_info.get_name == NULL)
-        prop1_cb_info.get_name = HDstrdup(name);
+        prop1_cb_info.get_name = strdup(name);
     if (prop1_cb_info.get_value == NULL)
         prop1_cb_info.get_value = malloc(size);
     memcpy(prop1_cb_info.get_value, value, size);
@@ -1084,7 +1084,7 @@ test_genprop_prop_cop_cb1(const char *name, size_t size, void *value)
     /* Set the information from the get call */
     prop1_cb_info.cop_count++;
     if (prop1_cb_info.cop_name == NULL)
-        prop1_cb_info.cop_name = HDstrdup(name);
+        prop1_cb_info.cop_name = strdup(name);
     if (prop1_cb_info.cop_value == NULL)
         prop1_cb_info.cop_value = malloc(size);
     memcpy(prop1_cb_info.cop_value, value, size);
@@ -1131,7 +1131,7 @@ test_genprop_prop_cls_cb1(const char *name, size_t size, void *value)
     /* Set the information from the close call */
     prop1_cb_info.cls_count++;
     if (prop1_cb_info.cls_name == NULL)
-        prop1_cb_info.cls_name = HDstrdup(name);
+        prop1_cb_info.cls_name = strdup(name);
     if (prop1_cb_info.cls_value == NULL)
         prop1_cb_info.cls_value = malloc(size);
     memcpy(prop1_cb_info.cls_value, value, size);
@@ -1150,7 +1150,7 @@ test_genprop_prop_del_cb2(hid_t plist_id, const char *name, size_t size, void *v
     /* Set the information from the delete call */
     prop2_cb_info.del_count++;
     prop2_cb_info.del_plist_id = plist_id;
-    prop2_cb_info.del_name     = HDstrdup(name);
+    prop2_cb_info.del_name     = strdup(name);
     prop2_cb_info.del_value    = malloc(size);
     memcpy(prop2_cb_info.del_value, value, size);
 
@@ -1238,7 +1238,7 @@ test_genprop_list_callback(void)
 
     /* Verify creation callback information for properties tracked */
     VERIFY(prop1_cb_info.crt_count, 1, "H5Pcreate");
-    if (HDstrcmp(prop1_cb_info.crt_name, PROP1_NAME) != 0)
+    if (strcmp(prop1_cb_info.crt_name, PROP1_NAME) != 0)
         TestErrPrintf("Property #1 name doesn't match!, line=%d\n", __LINE__);
     if (memcmp(prop1_cb_info.crt_value, PROP1_DEF_VALUE, PROP1_SIZE) != 0)
         TestErrPrintf("Property #1 value doesn't match!, line=%d\n", __LINE__);
@@ -1274,7 +1274,7 @@ test_genprop_list_callback(void)
     /* Verify get callback information for properties tracked */
     VERIFY(prop1_cb_info.get_count, 1, "H5Pget");
     VERIFY(prop1_cb_info.get_plist_id, lid1, "H5Pget");
-    if (HDstrcmp(prop1_cb_info.get_name, PROP1_NAME) != 0)
+    if (strcmp(prop1_cb_info.get_name, PROP1_NAME) != 0)
         TestErrPrintf("Property #1 name doesn't match!, line=%d\n", __LINE__);
     if (memcmp(prop1_cb_info.get_value, PROP1_DEF_VALUE, PROP1_SIZE) != 0)
         TestErrPrintf("Property #1 value doesn't match!, line=%d\n", __LINE__);
@@ -1286,7 +1286,7 @@ test_genprop_list_callback(void)
     /* Verify set callback information for properties tracked */
     VERIFY(prop1_cb_info.set_count, 1, "H5Pset");
     VERIFY(prop1_cb_info.set_plist_id, lid1, "H5Pset");
-    if (HDstrcmp(prop1_cb_info.set_name, PROP1_NAME) != 0)
+    if (strcmp(prop1_cb_info.set_name, PROP1_NAME) != 0)
         TestErrPrintf("Property #1 name doesn't match!, line=%d\n", __LINE__);
     if (memcmp(prop1_cb_info.set_value, &prop1_new_value, PROP1_SIZE) != 0)
         TestErrPrintf("Property #1 value doesn't match!, line=%d\n", __LINE__);
@@ -1309,7 +1309,7 @@ test_genprop_list_callback(void)
     /* Verify get callback information again for properties tracked */
     VERIFY(prop1_cb_info.get_count, 2, "H5Pget");
     VERIFY(prop1_cb_info.get_plist_id, lid1, "H5Pget");
-    if (HDstrcmp(prop1_cb_info.get_name, PROP1_NAME) != 0)
+    if (strcmp(prop1_cb_info.get_name, PROP1_NAME) != 0)
         TestErrPrintf("Property #1 name doesn't match!, line=%d\n", __LINE__);
     if (memcmp(prop1_cb_info.get_value, &prop1_new_value, PROP1_SIZE) != 0)
         TestErrPrintf("Property #1 value doesn't match!, line=%d\n", __LINE__);
@@ -1321,7 +1321,7 @@ test_genprop_list_callback(void)
     /* Verify delete callback information for properties tracked */
     VERIFY(prop2_cb_info.del_count, 1, "H5Premove");
     VERIFY(prop2_cb_info.del_plist_id, lid1, "H5Premove");
-    if (HDstrcmp(prop2_cb_info.del_name, PROP2_NAME) != 0)
+    if (strcmp(prop2_cb_info.del_name, PROP2_NAME) != 0)
         TestErrPrintf("Property #2 name doesn't match!, line=%d\n", __LINE__);
     if (memcmp(prop2_cb_info.del_value, PROP2_DEF_VALUE, PROP2_SIZE) != 0)
         TestErrPrintf("Property #2 value doesn't match!, line=%d\n", __LINE__);
@@ -1332,7 +1332,7 @@ test_genprop_list_callback(void)
 
     /* Verify copy callback information for properties tracked */
     VERIFY(prop1_cb_info.cop_count, 1, "H5Pcopy");
-    if (HDstrcmp(prop1_cb_info.cop_name, PROP1_NAME) != 0)
+    if (strcmp(prop1_cb_info.cop_name, PROP1_NAME) != 0)
         TestErrPrintf("Property #1 name doesn't match!, line=%d\n", __LINE__);
     if (memcmp(prop1_cb_info.cop_value, &prop1_new_value, PROP1_SIZE) != 0)
         TestErrPrintf("Property #1 value doesn't match!, line=%d\n", __LINE__);
@@ -1355,7 +1355,7 @@ test_genprop_list_callback(void)
 
     /* Verify close callback information for properties tracked */
     VERIFY(prop1_cb_info.cls_count, 1, "H5Pclose");
-    if (HDstrcmp(prop1_cb_info.cls_name, PROP1_NAME) != 0)
+    if (strcmp(prop1_cb_info.cls_name, PROP1_NAME) != 0)
         TestErrPrintf("Property #1 name doesn't match!, line=%d\n", __LINE__);
     if (memcmp(prop1_cb_info.cls_value, &prop1_new_value, PROP1_SIZE) != 0)
         TestErrPrintf("Property #1 value doesn't match!, line=%d\n", __LINE__);
@@ -1809,7 +1809,7 @@ test_genprop_path(void)
     /* Get full path for first class */
     path = H5P__get_class_path_test(cid1);
     CHECK_PTR(path, "H5P__get_class_path_test");
-    if (HDstrcmp(path, CLASS1_PATH) != 0)
+    if (strcmp(path, CLASS1_PATH) != 0)
         TestErrPrintf("Class names don't match!, path=%s, CLASS1_PATH=%s\n", path, CLASS1_PATH);
     H5free_memory(path);
 
@@ -1825,7 +1825,7 @@ test_genprop_path(void)
     /* Get full path for second class */
     path = H5P__get_class_path_test(cid2);
     CHECK_PTR(path, "H5P__get_class_path_test");
-    if (HDstrcmp(path, CLASS2_PATH) != 0)
+    if (strcmp(path, CLASS2_PATH) != 0)
         TestErrPrintf("Class names don't match!, path=%s, CLASS2_PATH=%s\n", path, CLASS2_PATH);
 
     /* Open a copy of the class with the path name */
@@ -1886,7 +1886,7 @@ test_genprop_refcount(void)
     /* Check class name */
     name = H5Pget_class_name(cid1);
     CHECK_PTR(name, "H5Pget_class_name");
-    if (HDstrcmp(name, CLASS1_NAME) != 0)
+    if (strcmp(name, CLASS1_NAME) != 0)
         TestErrPrintf("Class names don't match!, name=%s, CLASS1_NAME=%s\n", name, CLASS1_NAME);
     H5free_memory(name);
 
@@ -1905,7 +1905,7 @@ test_genprop_refcount(void)
     /* Check class name */
     name = H5Pget_class_name(cid1);
     CHECK_PTR(name, "H5Pget_class_name");
-    if (HDstrcmp(name, CLASS1_NAME) != 0)
+    if (strcmp(name, CLASS1_NAME) != 0)
         TestErrPrintf("Class names don't match!, name=%s, CLASS1_NAME=%s\n", name, CLASS1_NAME);
     H5free_memory(name);
 
@@ -1916,7 +1916,7 @@ test_genprop_refcount(void)
     /* Check class name */
     name = H5Pget_class_name(cid1);
     CHECK_PTR(name, "H5Pget_class_name");
-    if (HDstrcmp(name, CLASS1_NAME) != 0)
+    if (strcmp(name, CLASS1_NAME) != 0)
         TestErrPrintf("Class names don't match!, name=%s, CLASS1_NAME=%s\n", name, CLASS1_NAME);
     H5free_memory(name);
 

--- a/test/th5_system.c
+++ b/test/th5_system.c
@@ -50,7 +50,7 @@ test_h5_dirname(void)
 
     /* Check that H5_dirname fails for a NULL dirname pointer */
     dirname = NULL;
-    HDsnprintf(path, H5_SYSTEM_TEST_PATH_MAX, "topdir%sunderdir%sfinaldir", H5_DIR_SEPS, H5_DIR_SEPS);
+    snprintf(path, H5_SYSTEM_TEST_PATH_MAX, "topdir%sunderdir%sfinaldir", H5_DIR_SEPS, H5_DIR_SEPS);
     H5E_BEGIN_TRY
     {
         ret = H5_dirname(path, NULL);
@@ -72,7 +72,7 @@ test_h5_dirname(void)
      * doesn't contain the system file separator character
      */
     dirname = NULL;
-    HDsnprintf(path, H5_SYSTEM_TEST_PATH_MAX, "testdirname");
+    snprintf(path, H5_SYSTEM_TEST_PATH_MAX, "testdirname");
     ret = H5_dirname(path, &dirname);
     VERIFY_STR(dirname, ".", "comparing H5_dirname with non-separated path to \".\"");
     H5MM_free(dirname);
@@ -82,7 +82,7 @@ test_h5_dirname(void)
      * for the simple path containing just the system file separator
      */
     dirname = NULL;
-    HDsnprintf(path, H5_SYSTEM_TEST_PATH_MAX, H5_DIR_SEPS);
+    snprintf(path, H5_SYSTEM_TEST_PATH_MAX, H5_DIR_SEPS);
     ret = H5_dirname(path, &dirname);
     VERIFY_STR(dirname, H5_DIR_SEPS, "comparing H5_dirname with file separator path to file separator");
     H5MM_free(dirname);
@@ -93,7 +93,7 @@ test_h5_dirname(void)
      * component
      */
     dirname = NULL;
-    HDsnprintf(path, H5_SYSTEM_TEST_PATH_MAX, "%stestdir", H5_DIR_SEPS);
+    snprintf(path, H5_SYSTEM_TEST_PATH_MAX, "%stestdir", H5_DIR_SEPS);
     ret = H5_dirname(path, &dirname);
     VERIFY_STR(dirname, H5_DIR_SEPS, "comparing H5_dirname with leading separator path to file separator");
     H5MM_free(dirname);
@@ -104,8 +104,8 @@ test_h5_dirname(void)
      * a path component
      */
     dirname = NULL;
-    HDsnprintf(path, H5_SYSTEM_TEST_PATH_MAX, "%s%s%s%stestdir", H5_DIR_SEPS, H5_DIR_SEPS, H5_DIR_SEPS,
-               H5_DIR_SEPS);
+    snprintf(path, H5_SYSTEM_TEST_PATH_MAX, "%s%s%s%stestdir", H5_DIR_SEPS, H5_DIR_SEPS, H5_DIR_SEPS,
+             H5_DIR_SEPS);
     ret = H5_dirname(path, &dirname);
     VERIFY_STR(dirname, H5_DIR_SEPS, "comparing H5_dirname with leading separators path to file separator");
     H5MM_free(dirname);
@@ -115,7 +115,7 @@ test_h5_dirname(void)
      * contains a path component and a trailing separator
      */
     dirname = NULL;
-    HDsnprintf(path, H5_SYSTEM_TEST_PATH_MAX, "testdir%s", H5_DIR_SEPS);
+    snprintf(path, H5_SYSTEM_TEST_PATH_MAX, "testdir%s", H5_DIR_SEPS);
     ret = H5_dirname(path, &dirname);
     VERIFY_STR(dirname, ".", "comparing H5_dirname with trailing separator path to \".\"");
     H5MM_free(dirname);
@@ -125,8 +125,8 @@ test_h5_dirname(void)
      * contains a path component and several trailing separators
      */
     dirname = NULL;
-    HDsnprintf(path, H5_SYSTEM_TEST_PATH_MAX, "testdir%s%s%s%s", H5_DIR_SEPS, H5_DIR_SEPS, H5_DIR_SEPS,
-               H5_DIR_SEPS);
+    snprintf(path, H5_SYSTEM_TEST_PATH_MAX, "testdir%s%s%s%s", H5_DIR_SEPS, H5_DIR_SEPS, H5_DIR_SEPS,
+             H5_DIR_SEPS);
     ret = H5_dirname(path, &dirname);
     VERIFY_STR(dirname, ".", "comparing H5_dirname with trailing separators path to \".\"");
     H5MM_free(dirname);
@@ -137,7 +137,7 @@ test_h5_dirname(void)
      * component and a trailing separator
      */
     dirname = NULL;
-    HDsnprintf(path, H5_SYSTEM_TEST_PATH_MAX, "%stestdir%s", H5_DIR_SEPS, H5_DIR_SEPS);
+    snprintf(path, H5_SYSTEM_TEST_PATH_MAX, "%stestdir%s", H5_DIR_SEPS, H5_DIR_SEPS);
     ret = H5_dirname(path, &dirname);
     VERIFY_STR(dirname, H5_DIR_SEPS,
                "comparing H5_dirname with leading and trailing separator path to file separator");
@@ -149,8 +149,8 @@ test_h5_dirname(void)
      * path component and a trailing separator
      */
     dirname = NULL;
-    HDsnprintf(path, H5_SYSTEM_TEST_PATH_MAX, "%s%s%s%stestdir%s", H5_DIR_SEPS, H5_DIR_SEPS, H5_DIR_SEPS,
-               H5_DIR_SEPS, H5_DIR_SEPS);
+    snprintf(path, H5_SYSTEM_TEST_PATH_MAX, "%s%s%s%stestdir%s", H5_DIR_SEPS, H5_DIR_SEPS, H5_DIR_SEPS,
+             H5_DIR_SEPS, H5_DIR_SEPS);
     ret = H5_dirname(path, &dirname);
     VERIFY_STR(
         dirname, H5_DIR_SEPS,
@@ -163,8 +163,8 @@ test_h5_dirname(void)
      * component and several trailing separators
      */
     dirname = NULL;
-    HDsnprintf(path, H5_SYSTEM_TEST_PATH_MAX, "%stestdir%s%s%s%s", H5_DIR_SEPS, H5_DIR_SEPS, H5_DIR_SEPS,
-               H5_DIR_SEPS, H5_DIR_SEPS);
+    snprintf(path, H5_SYSTEM_TEST_PATH_MAX, "%stestdir%s%s%s%s", H5_DIR_SEPS, H5_DIR_SEPS, H5_DIR_SEPS,
+             H5_DIR_SEPS, H5_DIR_SEPS);
     ret = H5_dirname(path, &dirname);
     VERIFY_STR(dirname, H5_DIR_SEPS,
                "comparing H5_dirname with leading separator and trailing separators path to file separator");
@@ -176,8 +176,8 @@ test_h5_dirname(void)
      * path component and several trailing separators
      */
     dirname = NULL;
-    HDsnprintf(path, H5_SYSTEM_TEST_PATH_MAX, "%s%s%s%stestdir%s%s%s%s", H5_DIR_SEPS, H5_DIR_SEPS,
-               H5_DIR_SEPS, H5_DIR_SEPS, H5_DIR_SEPS, H5_DIR_SEPS, H5_DIR_SEPS, H5_DIR_SEPS);
+    snprintf(path, H5_SYSTEM_TEST_PATH_MAX, "%s%s%s%stestdir%s%s%s%s", H5_DIR_SEPS, H5_DIR_SEPS, H5_DIR_SEPS,
+             H5_DIR_SEPS, H5_DIR_SEPS, H5_DIR_SEPS, H5_DIR_SEPS, H5_DIR_SEPS);
     ret = H5_dirname(path, &dirname);
     VERIFY_STR(dirname, H5_DIR_SEPS,
                "comparing H5_dirname with leading and trailing separators path to file separator");
@@ -188,7 +188,7 @@ test_h5_dirname(void)
      * "normal" pathname that has no leading separator
      */
     dirname = NULL;
-    HDsnprintf(path, H5_SYSTEM_TEST_PATH_MAX, "topdir%sunderdir", H5_DIR_SEPS);
+    snprintf(path, H5_SYSTEM_TEST_PATH_MAX, "topdir%sunderdir", H5_DIR_SEPS);
     ret = H5_dirname(path, &dirname);
     VERIFY_STR(dirname, "topdir", "comparing H5_dirname with normal path to proper dirname");
     H5MM_free(dirname);
@@ -198,7 +198,7 @@ test_h5_dirname(void)
      * "normal" pathname that has a leading separator
      */
     dirname = NULL;
-    HDsnprintf(path, H5_SYSTEM_TEST_PATH_MAX, "%stopdir%sunderdir", H5_DIR_SEPS, H5_DIR_SEPS);
+    snprintf(path, H5_SYSTEM_TEST_PATH_MAX, "%stopdir%sunderdir", H5_DIR_SEPS, H5_DIR_SEPS);
     ret = H5_dirname(path, &dirname);
     VERIFY_STR(dirname, H5_DIR_SEPS "topdir", "comparing H5_dirname with normal path to proper dirname");
     H5MM_free(dirname);
@@ -208,7 +208,7 @@ test_h5_dirname(void)
      * "normal" pathname that has a leading and trailing separator
      */
     dirname = NULL;
-    HDsnprintf(path, H5_SYSTEM_TEST_PATH_MAX, "%stopdir%sunderdir%s", H5_DIR_SEPS, H5_DIR_SEPS, H5_DIR_SEPS);
+    snprintf(path, H5_SYSTEM_TEST_PATH_MAX, "%stopdir%sunderdir%s", H5_DIR_SEPS, H5_DIR_SEPS, H5_DIR_SEPS);
     ret = H5_dirname(path, &dirname);
     VERIFY_STR(dirname, H5_DIR_SEPS "topdir", "comparing H5_dirname with normal path to proper dirname");
     H5MM_free(dirname);
@@ -218,8 +218,8 @@ test_h5_dirname(void)
      * contrived pathname
      */
     dirname = NULL;
-    HDsnprintf(path, H5_SYSTEM_TEST_PATH_MAX, "%stopdir%sunderdir%s%s%sfinaldir%s", H5_DIR_SEPS, H5_DIR_SEPS,
-               H5_DIR_SEPS, H5_DIR_SEPS, H5_DIR_SEPS, H5_DIR_SEPS);
+    snprintf(path, H5_SYSTEM_TEST_PATH_MAX, "%stopdir%sunderdir%s%s%sfinaldir%s", H5_DIR_SEPS, H5_DIR_SEPS,
+             H5_DIR_SEPS, H5_DIR_SEPS, H5_DIR_SEPS, H5_DIR_SEPS);
     ret = H5_dirname(path, &dirname);
     VERIFY_STR(dirname, H5_DIR_SEPS "topdir" H5_DIR_SEPS "underdir",
                "comparing H5_dirname with contrived path to proper dirname");
@@ -254,7 +254,7 @@ test_h5_basename(void)
 
     /* Check that H5_basename fails for a NULL basename pointer */
     basename = NULL;
-    HDsnprintf(path, H5_SYSTEM_TEST_PATH_MAX, "topdir%sunderdir%sfinaldir", H5_DIR_SEPS, H5_DIR_SEPS);
+    snprintf(path, H5_SYSTEM_TEST_PATH_MAX, "topdir%sunderdir%sfinaldir", H5_DIR_SEPS, H5_DIR_SEPS);
     H5E_BEGIN_TRY
     {
         ret = H5_basename(path, NULL);
@@ -276,7 +276,7 @@ test_h5_basename(void)
      * path that doesn't contain the system file separator character
      */
     basename = NULL;
-    HDsnprintf(path, H5_SYSTEM_TEST_PATH_MAX, "testdirname");
+    snprintf(path, H5_SYSTEM_TEST_PATH_MAX, "testdirname");
     ret = H5_basename(path, &basename);
     VERIFY_STR(basename, "testdirname", "comparing H5_basename with non-separated path to same path");
     H5MM_free(basename);
@@ -286,7 +286,7 @@ test_h5_basename(void)
      * for the simple path containing just the system file separator
      */
     basename = NULL;
-    HDsnprintf(path, H5_SYSTEM_TEST_PATH_MAX, H5_DIR_SEPS);
+    snprintf(path, H5_SYSTEM_TEST_PATH_MAX, H5_DIR_SEPS);
     ret = H5_basename(path, &basename);
     VERIFY_STR(basename, H5_DIR_SEPS, "comparing H5_basename with file separator path to file separator");
     H5MM_free(basename);
@@ -297,7 +297,7 @@ test_h5_basename(void)
      * component
      */
     basename = NULL;
-    HDsnprintf(path, H5_SYSTEM_TEST_PATH_MAX, "%stestdir", H5_DIR_SEPS);
+    snprintf(path, H5_SYSTEM_TEST_PATH_MAX, "%stestdir", H5_DIR_SEPS);
     ret = H5_basename(path, &basename);
     VERIFY_STR(basename, "testdir",
                "comparing H5_basename with leading separator path to filename component");
@@ -309,8 +309,8 @@ test_h5_basename(void)
      * component
      */
     basename = NULL;
-    HDsnprintf(path, H5_SYSTEM_TEST_PATH_MAX, "%s%s%s%stestdir", H5_DIR_SEPS, H5_DIR_SEPS, H5_DIR_SEPS,
-               H5_DIR_SEPS);
+    snprintf(path, H5_SYSTEM_TEST_PATH_MAX, "%s%s%s%stestdir", H5_DIR_SEPS, H5_DIR_SEPS, H5_DIR_SEPS,
+             H5_DIR_SEPS);
     ret = H5_basename(path, &basename);
     VERIFY_STR(basename, "testdir",
                "comparing H5_basename with leading separators path to filename component");
@@ -321,7 +321,7 @@ test_h5_basename(void)
      * path which contains a path component and a trailing separator
      */
     basename = NULL;
-    HDsnprintf(path, H5_SYSTEM_TEST_PATH_MAX, "testdir%s", H5_DIR_SEPS);
+    snprintf(path, H5_SYSTEM_TEST_PATH_MAX, "testdir%s", H5_DIR_SEPS);
     ret = H5_basename(path, &basename);
     VERIFY_STR(basename, "testdir",
                "comparing H5_basename with trailing separator path to filename component");
@@ -333,8 +333,8 @@ test_h5_basename(void)
      * separators
      */
     basename = NULL;
-    HDsnprintf(path, H5_SYSTEM_TEST_PATH_MAX, "testdir%s%s%s%s", H5_DIR_SEPS, H5_DIR_SEPS, H5_DIR_SEPS,
-               H5_DIR_SEPS);
+    snprintf(path, H5_SYSTEM_TEST_PATH_MAX, "testdir%s%s%s%s", H5_DIR_SEPS, H5_DIR_SEPS, H5_DIR_SEPS,
+             H5_DIR_SEPS);
     ret = H5_basename(path, &basename);
     VERIFY_STR(basename, "testdir",
                "comparing H5_basename with trailing separators path to filename component");
@@ -346,7 +346,7 @@ test_h5_basename(void)
      * and a trailing separator
      */
     basename = NULL;
-    HDsnprintf(path, H5_SYSTEM_TEST_PATH_MAX, "%stestdir%s", H5_DIR_SEPS, H5_DIR_SEPS);
+    snprintf(path, H5_SYSTEM_TEST_PATH_MAX, "%stestdir%s", H5_DIR_SEPS, H5_DIR_SEPS);
     ret = H5_basename(path, &basename);
     VERIFY_STR(basename, "testdir",
                "comparing H5_basename with leading and trailing separator path to filename component");
@@ -358,8 +358,8 @@ test_h5_basename(void)
      * component and a trailing separator
      */
     basename = NULL;
-    HDsnprintf(path, H5_SYSTEM_TEST_PATH_MAX, "%s%s%s%stestdir%s", H5_DIR_SEPS, H5_DIR_SEPS, H5_DIR_SEPS,
-               H5_DIR_SEPS, H5_DIR_SEPS);
+    snprintf(path, H5_SYSTEM_TEST_PATH_MAX, "%s%s%s%stestdir%s", H5_DIR_SEPS, H5_DIR_SEPS, H5_DIR_SEPS,
+             H5_DIR_SEPS, H5_DIR_SEPS);
     ret = H5_basename(path, &basename);
     VERIFY_STR(
         basename, "testdir",
@@ -372,8 +372,8 @@ test_h5_basename(void)
      * and several trailing separators
      */
     basename = NULL;
-    HDsnprintf(path, H5_SYSTEM_TEST_PATH_MAX, "%stestdir%s%s%s%s", H5_DIR_SEPS, H5_DIR_SEPS, H5_DIR_SEPS,
-               H5_DIR_SEPS, H5_DIR_SEPS);
+    snprintf(path, H5_SYSTEM_TEST_PATH_MAX, "%stestdir%s%s%s%s", H5_DIR_SEPS, H5_DIR_SEPS, H5_DIR_SEPS,
+             H5_DIR_SEPS, H5_DIR_SEPS);
     ret = H5_basename(path, &basename);
     VERIFY_STR(
         basename, "testdir",
@@ -386,8 +386,8 @@ test_h5_basename(void)
      * component and several trailing separators
      */
     basename = NULL;
-    HDsnprintf(path, H5_SYSTEM_TEST_PATH_MAX, "%s%s%s%stestdir%s%s%s%s", H5_DIR_SEPS, H5_DIR_SEPS,
-               H5_DIR_SEPS, H5_DIR_SEPS, H5_DIR_SEPS, H5_DIR_SEPS, H5_DIR_SEPS, H5_DIR_SEPS);
+    snprintf(path, H5_SYSTEM_TEST_PATH_MAX, "%s%s%s%stestdir%s%s%s%s", H5_DIR_SEPS, H5_DIR_SEPS, H5_DIR_SEPS,
+             H5_DIR_SEPS, H5_DIR_SEPS, H5_DIR_SEPS, H5_DIR_SEPS, H5_DIR_SEPS);
     ret = H5_basename(path, &basename);
     VERIFY_STR(basename, "testdir",
                "comparing H5_basename with leading and trailing separators path to filename component");
@@ -398,7 +398,7 @@ test_h5_basename(void)
      * a "normal" pathname that has no leading separator
      */
     basename = NULL;
-    HDsnprintf(path, H5_SYSTEM_TEST_PATH_MAX, "topdir%sunderdir", H5_DIR_SEPS);
+    snprintf(path, H5_SYSTEM_TEST_PATH_MAX, "topdir%sunderdir", H5_DIR_SEPS);
     ret = H5_basename(path, &basename);
     VERIFY_STR(basename, "underdir", "comparing H5_basename with normal path to proper basename");
     H5MM_free(basename);
@@ -408,7 +408,7 @@ test_h5_basename(void)
      * a "normal" pathname that has a leading separator
      */
     basename = NULL;
-    HDsnprintf(path, H5_SYSTEM_TEST_PATH_MAX, "%stopdir%sunderdir", H5_DIR_SEPS, H5_DIR_SEPS);
+    snprintf(path, H5_SYSTEM_TEST_PATH_MAX, "%stopdir%sunderdir", H5_DIR_SEPS, H5_DIR_SEPS);
     ret = H5_basename(path, &basename);
     VERIFY_STR(basename, "underdir", "comparing H5_basename with normal path to proper basename");
     H5MM_free(basename);
@@ -418,7 +418,7 @@ test_h5_basename(void)
      * a "normal" pathname that has a leading and trailing separator
      */
     basename = NULL;
-    HDsnprintf(path, H5_SYSTEM_TEST_PATH_MAX, "%stopdir%sunderdir%s", H5_DIR_SEPS, H5_DIR_SEPS, H5_DIR_SEPS);
+    snprintf(path, H5_SYSTEM_TEST_PATH_MAX, "%stopdir%sunderdir%s", H5_DIR_SEPS, H5_DIR_SEPS, H5_DIR_SEPS);
     ret = H5_basename(path, &basename);
     VERIFY_STR(basename, "underdir", "comparing H5_basename with normal path to proper basename");
     H5MM_free(basename);
@@ -428,8 +428,8 @@ test_h5_basename(void)
      * contrived pathname
      */
     basename = NULL;
-    HDsnprintf(path, H5_SYSTEM_TEST_PATH_MAX, "%stopdir%sunderdir%s%s%sfinaldir%s", H5_DIR_SEPS, H5_DIR_SEPS,
-               H5_DIR_SEPS, H5_DIR_SEPS, H5_DIR_SEPS, H5_DIR_SEPS);
+    snprintf(path, H5_SYSTEM_TEST_PATH_MAX, "%stopdir%sunderdir%s%s%sfinaldir%s", H5_DIR_SEPS, H5_DIR_SEPS,
+             H5_DIR_SEPS, H5_DIR_SEPS, H5_DIR_SEPS, H5_DIR_SEPS);
     ret = H5_basename(path, &basename);
     VERIFY_STR(basename, "finaldir", "comparing H5_basename with contrived path to proper basename");
     H5MM_free(basename);
@@ -469,34 +469,34 @@ test_h5_strcasestr(void)
 }
 
 static void
-test_HDstrcasestr(void)
+test_strcasestr(void)
 {
     const char *const haystack = "My test string";
     char             *str      = NULL;
 
-    MESSAGE(5, ("Testing HDstrcasestr\n"));
+    MESSAGE(5, ("Testing strcasestr\n"));
 
-    /* check that HDstrcasestr returns target in empty search */
-    str = HDstrcasestr(haystack, "");
-    CHECK_PTR(str, "HDstrcasestr for empty substring");
+    /* check that strcasestr returns target in empty search */
+    str = strcasestr(haystack, "");
+    CHECK_PTR(str, "strcasestr for empty substring");
     if (str)
-        VERIFY_STR(str, haystack, "comparing HDstrcasestr to original string for empty substring");
+        VERIFY_STR(str, haystack, "comparing strcasestr to original string for empty substring");
 
-    /* Check that HDstrcasestr find a string of same case */
-    str = HDstrcasestr(haystack, "string");
-    CHECK_PTR(str, "HDstrcasestr for substring of same case");
+    /* Check that strcasestr find a string of same case */
+    str = strcasestr(haystack, "string");
+    CHECK_PTR(str, "strcasestr for substring of same case");
     if (str)
-        VERIFY_STR(str, "string", "comparing HDstrcasestr for substring of same case");
+        VERIFY_STR(str, "string", "comparing strcasestr for substring of same case");
 
-    /* Check that HDstrcasestr find a string of different case */
-    str = HDstrcasestr(haystack, "sTrInG");
-    CHECK_PTR(str, "HDstrcasestr for substring of different case");
+    /* Check that strcasestr find a string of different case */
+    str = strcasestr(haystack, "sTrInG");
+    CHECK_PTR(str, "strcasestr for substring of different case");
     if (str)
-        VERIFY_STR(str, "string", "comparing HDstrcasestr for substring of different case");
+        VERIFY_STR(str, "string", "comparing strcasestr for substring of different case");
 
-    /* Check that HDstrcasestr returns NULL if no match is found */
-    str = HDstrcasestr(haystack, "nomatch");
-    CHECK_PTR_NULL(str, "HDstrcasestr search with no match");
+    /* Check that strcasestr returns NULL if no match is found */
+    str = strcasestr(haystack, "nomatch");
+    CHECK_PTR_NULL(str, "strcasestr search with no match");
 }
 
 static void
@@ -532,7 +532,7 @@ test_h5_strndup(void)
     str = H5MM_xfree(str);
 
     /* Check that H5_strndup correctly performs identical copies */
-    str = H5_strndup(teststr, HDstrlen(teststr));
+    str = H5_strndup(teststr, strlen(teststr));
     CHECK_PTR(str, "H5_strndup for identical copy");
     if (str)
         VERIFY_STR(str, teststr, "comparing H5_strndup for identical copy to original string");
@@ -542,7 +542,7 @@ test_h5_strndup(void)
      * Check that H5_strndup correctly performs copies when
      * `n` is greater than the original string
      */
-    str = H5_strndup(teststr, HDstrlen(teststr) + 2);
+    str = H5_strndup(teststr, strlen(teststr) + 2);
     CHECK_PTR(str, "H5_strndup for larger 'n'");
     if (str)
         VERIFY_STR(str, teststr, "comparing H5_strndup with larger 'n' value to original string");
@@ -558,7 +558,7 @@ test_h5_system(void)
     test_h5_dirname();
     test_h5_basename();
     test_h5_strcasestr();
-    test_HDstrcasestr();
+    test_strcasestr();
     test_h5_strndup();
 }
 

--- a/test/th5_system.c
+++ b/test/th5_system.c
@@ -469,34 +469,34 @@ test_h5_strcasestr(void)
 }
 
 static void
-test_strcasestr(void)
+test_HDstrcasestr(void)
 {
     const char *const haystack = "My test string";
     char             *str      = NULL;
 
-    MESSAGE(5, ("Testing strcasestr\n"));
+    MESSAGE(5, ("Testing HDstrcasestr\n"));
 
-    /* check that strcasestr returns target in empty search */
-    str = strcasestr(haystack, "");
-    CHECK_PTR(str, "strcasestr for empty substring");
+    /* check that HDstrcasestr returns target in empty search */
+    str = HDstrcasestr(haystack, "");
+    CHECK_PTR(str, "HDstrcasestr for empty substring");
     if (str)
-        VERIFY_STR(str, haystack, "comparing strcasestr to original string for empty substring");
+        VERIFY_STR(str, haystack, "comparing HDstrcasestr to original string for empty substring");
 
-    /* Check that strcasestr find a string of same case */
-    str = strcasestr(haystack, "string");
-    CHECK_PTR(str, "strcasestr for substring of same case");
+    /* Check that HDstrcasestr find a string of same case */
+    str = HDstrcasestr(haystack, "string");
+    CHECK_PTR(str, "HDstrcasestr for substring of same case");
     if (str)
-        VERIFY_STR(str, "string", "comparing strcasestr for substring of same case");
+        VERIFY_STR(str, "string", "comparing HDstrcasestr for substring of same case");
 
-    /* Check that strcasestr find a string of different case */
-    str = strcasestr(haystack, "sTrInG");
-    CHECK_PTR(str, "strcasestr for substring of different case");
+    /* Check that HDstrcasestr find a string of different case */
+    str = HDstrcasestr(haystack, "sTrInG");
+    CHECK_PTR(str, "HDstrcasestr for substring of different case");
     if (str)
-        VERIFY_STR(str, "string", "comparing strcasestr for substring of different case");
+        VERIFY_STR(str, "string", "comparing HDstrcasestr for substring of different case");
 
-    /* Check that strcasestr returns NULL if no match is found */
-    str = strcasestr(haystack, "nomatch");
-    CHECK_PTR_NULL(str, "strcasestr search with no match");
+    /* Check that HDstrcasestr returns NULL if no match is found */
+    str = HDstrcasestr(haystack, "nomatch");
+    CHECK_PTR_NULL(str, "HDstrcasestr search with no match");
 }
 
 static void
@@ -558,7 +558,7 @@ test_h5_system(void)
     test_h5_dirname();
     test_h5_basename();
     test_h5_strcasestr();
-    test_strcasestr();
+    test_HDstrcasestr();
     test_h5_strndup();
 }
 

--- a/test/th5o.c
+++ b/test/th5o.c
@@ -1203,7 +1203,7 @@ test_h5o_comment(void)
     len = H5Oget_comment(fid, check_comment, (size_t)comment_len + 1);
     CHECK(len, FAIL, "H5Oget_comment");
 
-    ret_value = HDstrcmp(file_comment, check_comment);
+    ret_value = strcmp(file_comment, check_comment);
     VERIFY(ret_value, 0, "H5Oget_comment");
 
     /* Open the group */
@@ -1217,7 +1217,7 @@ test_h5o_comment(void)
     len = H5Oget_comment(grp, check_comment, (size_t)comment_len + 1);
     CHECK(len, FAIL, "H5Oget_comment");
 
-    ret_value = HDstrcmp(grp_comment, check_comment);
+    ret_value = strcmp(grp_comment, check_comment);
     VERIFY(ret_value, 0, "H5Oget_comment");
 
     /* Open the datatype */
@@ -1231,7 +1231,7 @@ test_h5o_comment(void)
     len = H5Oget_comment(dtype, check_comment, (size_t)comment_len + 1);
     CHECK(len, FAIL, "H5Oget_comment");
 
-    ret_value = HDstrcmp(dtype_comment, check_comment);
+    ret_value = strcmp(dtype_comment, check_comment);
     VERIFY(ret_value, 0, "H5Oget_comment");
 
     /* Open the dataset */
@@ -1245,7 +1245,7 @@ test_h5o_comment(void)
     len = H5Oget_comment(dset, check_comment, (size_t)comment_len + 1);
     CHECK(ret, len, "H5Oget_comment");
 
-    ret_value = HDstrcmp(dset_comment, check_comment);
+    ret_value = strcmp(dset_comment, check_comment);
     VERIFY(ret_value, 0, "H5Oget_comment");
 
     /* Close the IDs */
@@ -1378,7 +1378,7 @@ test_h5o_comment_by_name(void)
     len = H5Oget_comment_by_name(fid, ".", check_comment, (size_t)comment_len + 1, H5P_DEFAULT);
     CHECK(len, FAIL, "H5Oget_comment_by_name");
 
-    ret_value = HDstrcmp(file_comment, check_comment);
+    ret_value = strcmp(file_comment, check_comment);
     VERIFY(ret_value, 0, "H5Oget_comment_by_name");
 
     /* Open the group */
@@ -1392,7 +1392,7 @@ test_h5o_comment_by_name(void)
     len = H5Oget_comment_by_name(fid, "group", check_comment, (size_t)comment_len + 1, H5P_DEFAULT);
     CHECK(len, FAIL, "H5Oget_comment_by_name");
 
-    ret_value = HDstrcmp(grp_comment, check_comment);
+    ret_value = strcmp(grp_comment, check_comment);
     VERIFY(ret_value, 0, "H5Oget_comment_by_name");
 
     /* Getting the comment on the datatype and verify it */
@@ -1402,7 +1402,7 @@ test_h5o_comment_by_name(void)
     len = H5Oget_comment_by_name(grp, "datatype", check_comment, (size_t)comment_len + 1, H5P_DEFAULT);
     CHECK(len, FAIL, "H5Oget_comment");
 
-    ret_value = HDstrcmp(dtype_comment, check_comment);
+    ret_value = strcmp(dtype_comment, check_comment);
     VERIFY(ret_value, 0, "H5Oget_comment_by_name");
 
     /* Getting the comment on the dataset and verify it */
@@ -1412,7 +1412,7 @@ test_h5o_comment_by_name(void)
     len = H5Oget_comment_by_name(fid, "dataset", check_comment, (size_t)comment_len + 1, H5P_DEFAULT);
     CHECK(len, FAIL, "H5Oget_comment_by_name");
 
-    ret_value = HDstrcmp(dset_comment, check_comment);
+    ret_value = strcmp(dset_comment, check_comment);
     VERIFY(ret_value, 0, "H5Oget_comment_by_name");
 
     /* Close the IDs */
@@ -1699,16 +1699,16 @@ visit_obj_cb(hid_t group_id, const char *name, const H5O_info1_t *oinfo1, void H
     H5O_info1_t oinfo2; /* Object info structs */
 
     /* Verify the object info for "group1", "group2" and the root group */
-    if (!(HDstrcmp(name, "group1"))) {
+    if (!(strcmp(name, "group1"))) {
         H5Oget_info_by_name2(group_id, name, &oinfo2, H5O_INFO_NUM_ATTRS, H5P_DEFAULT);
         VERIFY(oinfo1->num_attrs, oinfo2.num_attrs, "obj info from H5Ovisit1");
     }
-    else if (!(HDstrcmp(name, "group2"))) {
+    else if (!(strcmp(name, "group2"))) {
         H5Oget_info_by_name2(group_id, name, &oinfo2, H5O_INFO_HDR, H5P_DEFAULT);
         VERIFY(oinfo1->hdr.nmesgs, oinfo2.hdr.nmesgs, "obj info from H5Ovisit1/H5Oget_info2");
         VERIFY(oinfo1->hdr.nchunks, oinfo2.hdr.nchunks, "obj info from H5Ovisit1/H5Oget_info2");
     }
-    else if (!(HDstrcmp(name, "."))) {
+    else if (!(strcmp(name, "."))) {
         H5Oget_info_by_name2(group_id, name, &oinfo2, H5O_INFO_META_SIZE, H5P_DEFAULT);
         VERIFY(oinfo1->meta_size.obj.index_size, oinfo2.meta_size.obj.index_size,
                "obj info from H5Ovisit1/H5Oget_info2");
@@ -1761,7 +1761,7 @@ test_h5o_getinfo_visit(void)
     /* Attach 10 attributes to "group1" */
     for (j = 0; j < 10; j++) {
         /* Create the attribute name */
-        HDsnprintf(attrname, sizeof(attrname), "attr%u", j);
+        snprintf(attrname, sizeof(attrname), "attr%u", j);
         /* Create the attribute */
         aid = H5Acreate2(gid1, attrname, H5T_NATIVE_INT, sid, H5P_DEFAULT, H5P_DEFAULT);
         CHECK(aid, FAIL, "H5Acreate2");

--- a/test/thread_id.c
+++ b/test/thread_id.c
@@ -36,9 +36,9 @@ my_errx(int code, const char *fmt, ...)
 
     (void)fprintf(stderr, "thread_id: ");
     va_start(ap, fmt);
-    (void)HDvfprintf(stderr, fmt, ap);
+    (void)vfprintf(stderr, fmt, ap);
     va_end(ap);
-    (void)HDfputc('\n', stderr);
+    (void)fputc('\n', stderr);
     exit(code);
 }
 
@@ -96,7 +96,7 @@ barrier_lock(pthread_barrier_t *barrier)
     int rc;
 
     if ((rc = pthread_mutex_lock(&barrier->mtx)) != 0) {
-        my_errx(EXIT_FAILURE, "%s: pthread_mutex_lock: %s", __func__, HDstrerror(rc));
+        my_errx(EXIT_FAILURE, "%s: pthread_mutex_lock: %s", __func__, strerror(rc));
     }
 }
 
@@ -106,7 +106,7 @@ barrier_unlock(pthread_barrier_t *barrier)
     int rc;
 
     if ((rc = pthread_mutex_unlock(&barrier->mtx)) != 0) {
-        my_errx(EXIT_FAILURE, "%s: pthread_mutex_unlock: %s", __func__, HDstrerror(rc));
+        my_errx(EXIT_FAILURE, "%s: pthread_mutex_unlock: %s", __func__, strerror(rc));
     }
 }
 
@@ -178,15 +178,15 @@ my_err(int code, const char *fmt, ...)
 
     (void)fprintf(stderr, "thread_id: ");
     va_start(ap, fmt);
-    (void)HDvfprintf(stderr, fmt, ap);
+    (void)vfprintf(stderr, fmt, ap);
     va_end(ap);
-    (void)fprintf(stderr, ": %s\n", HDstrerror(errno_copy));
+    (void)fprintf(stderr, ": %s\n", strerror(errno_copy));
     exit(code);
 }
 
 #define threads_failure(_call, _result)                                                                      \
     do {                                                                                                     \
-        my_errx(EXIT_FAILURE, "%s.%d: " #_call ": %s", __func__, __LINE__, HDstrerror(_result));             \
+        my_errx(EXIT_FAILURE, "%s.%d: " #_call ": %s", __func__, __LINE__, strerror(_result));               \
     } while (false)
 
 #define NTHREADS 5
@@ -204,7 +204,7 @@ atomic_printf(const char *fmt, ...)
     ssize_t nprinted, nwritten;
 
     va_start(ap, fmt);
-    nprinted = HDvsnprintf(buf, sizeof(buf), fmt, ap);
+    nprinted = vsnprintf(buf, sizeof(buf), fmt, ap);
     va_end(ap);
 
     if (nprinted == -1)

--- a/test/timer.c
+++ b/test/timer.c
@@ -35,55 +35,55 @@ test_time_formatting(void)
 
     /*      < 0,            N/A             */
     s = H5_timer_get_time_string(-1.0);
-    if (NULL == s || HDstrcmp(s, "N/A") != 0)
+    if (NULL == s || strcmp(s, "N/A") != 0)
         TEST_ERROR;
     free(s);
 
     /*      0               0               */
     s = H5_timer_get_time_string(0.0);
-    if (NULL == s || HDstrcmp(s, "0.0 s") != 0)
+    if (NULL == s || strcmp(s, "0.0 s") != 0)
         TEST_ERROR;
     free(s);
 
     /*      < 1 us          nanoseconds     */
     s = H5_timer_get_time_string(123.0E-9);
-    if (NULL == s || HDstrcmp(s, "123 ns") != 0)
+    if (NULL == s || strcmp(s, "123 ns") != 0)
         TEST_ERROR;
     free(s);
 
     /*      < 1 ms          microseconds    */
     s = H5_timer_get_time_string(23.456E-6);
-    if (NULL == s || HDstrcmp(s, "23.5 us") != 0)
+    if (NULL == s || strcmp(s, "23.5 us") != 0)
         TEST_ERROR;
     free(s);
 
     /*      < 1 s           milliseconds    */
     s = H5_timer_get_time_string(4.56789E-3);
-    if (NULL == s || HDstrcmp(s, "4.6 ms") != 0)
+    if (NULL == s || strcmp(s, "4.6 ms") != 0)
         TEST_ERROR;
     free(s);
 
     /*      < 1 min         seconds         */
     s = H5_timer_get_time_string(3.14);
-    if (NULL == s || HDstrcmp(s, "3.14 s") != 0)
+    if (NULL == s || strcmp(s, "3.14 s") != 0)
         TEST_ERROR;
     free(s);
 
     /*      < 1 hr          mins, secs      */
     s = H5_timer_get_time_string(2521.0);
-    if (NULL == s || HDstrcmp(s, "42 m 1 s") != 0)
+    if (NULL == s || strcmp(s, "42 m 1 s") != 0)
         TEST_ERROR;
     free(s);
 
     /*      < 1 d           hrs, mins, secs */
     s = H5_timer_get_time_string(9756.0);
-    if (NULL == s || HDstrcmp(s, "2 h 42 m 36 s") != 0)
+    if (NULL == s || strcmp(s, "2 h 42 m 36 s") != 0)
         TEST_ERROR;
     free(s);
 
     /*      > 1 d            days, hrs, mins, secs */
     s = H5_timer_get_time_string(280802.0);
-    if (NULL == s || HDstrcmp(s, "3 d 6 h 0 m 2 s") != 0)
+    if (NULL == s || strcmp(s, "3 d 6 h 0 m 2 s") != 0)
         TEST_ERROR;
     free(s);
 

--- a/test/titerate.c
+++ b/test/titerate.c
@@ -74,7 +74,7 @@ herr_t        aiter_cb(hid_t group, const char *name, const H5A_info_t *ainfo, v
 H5_ATTR_PURE int
 iter_strcmp(const void *s1, const void *s2)
 {
-    return (HDstrcmp(*(const char *const *)s1, *(const char *const *)s2));
+    return (strcmp(*(const char *const *)s1, *(const char *const *)s2));
 }
 
 /****************************************************************
@@ -90,7 +90,7 @@ liter_cb(hid_t H5_ATTR_UNUSED group, const char *name, const H5L_info2_t H5_ATTR
     static int count  = 0;
     static int count2 = 0;
 
-    HDstrcpy(info->name, name);
+    strcpy(info->name, name);
 
     switch (info->command) {
         case RET_ZERO:
@@ -155,12 +155,12 @@ test_iter_group(hid_t fapl, bool new_format)
     CHECK(filespace, FAIL, "H5Screate");
 
     for (i = 0; i < NDATASETS; i++) {
-        HDsnprintf(name, sizeof(name), "Dataset %d", i);
+        snprintf(name, sizeof(name), "Dataset %d", i);
         dataset = H5Dcreate2(file, name, datatype, filespace, H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT);
         CHECK(dataset, FAIL, "H5Dcreate2");
 
         /* Keep a copy of the dataset names around for later */
-        lnames[i] = HDstrdup(name);
+        lnames[i] = strdup(name);
         CHECK_PTR(lnames[i], "strdup");
 
         ret = H5Dclose(dataset);
@@ -171,13 +171,13 @@ test_iter_group(hid_t fapl, bool new_format)
     grp = H5Gcreate2(file, "grp", H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT);
     CHECK(ret, FAIL, "H5Gcreate2");
 
-    lnames[NDATASETS] = HDstrdup("grp");
+    lnames[NDATASETS] = strdup("grp");
     CHECK_PTR(lnames[NDATASETS], "strdup");
 
     ret = H5Tcommit2(file, "dtype", datatype, H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT);
     CHECK(ret, FAIL, "H5Tcommit2");
 
-    lnames[NDATASETS + 1] = HDstrdup("dtype");
+    lnames[NDATASETS + 1] = strdup("dtype");
     CHECK_PTR(lnames[NDATASETS], "strdup");
 
     /* Close everything up */
@@ -319,7 +319,7 @@ test_iter_group(hid_t fapl, bool new_format)
             TestErrPrintf("Group iteration function walked too far!\n");
 
         /* Verify that the correct name is retrieved */
-        if (HDstrcmp(info.name, lnames[(size_t)(idx - 1)]) != 0)
+        if (strcmp(info.name, lnames[(size_t)(idx - 1)]) != 0)
             TestErrPrintf(
                 "Group iteration function didn't return name correctly for link - lnames[%u] = '%s'!\n",
                 (unsigned)(idx - 1), lnames[(size_t)(idx - 1)]);
@@ -348,7 +348,7 @@ test_iter_group(hid_t fapl, bool new_format)
             TestErrPrintf("Group iteration function walked too far!\n");
 
         /* Verify that the correct name is retrieved */
-        if (HDstrcmp(info.name, lnames[(size_t)(idx - 1)]) != 0)
+        if (strcmp(info.name, lnames[(size_t)(idx - 1)]) != 0)
             TestErrPrintf(
                 "Group iteration function didn't return name correctly for link - lnames[%u] = '%s'!\n",
                 (unsigned)(idx - 1), lnames[(size_t)(idx - 1)]);
@@ -379,7 +379,7 @@ aiter_cb(hid_t H5_ATTR_UNUSED group, const char *name, const H5A_info_t H5_ATTR_
     static int count  = 0;
     static int count2 = 0;
 
-    HDstrcpy(info->name, name);
+    strcpy(info->name, name);
 
     switch (info->command) {
         case RET_ZERO:
@@ -435,12 +435,12 @@ test_iter_attr(hid_t fapl, bool new_format)
     CHECK(dataset, FAIL, "H5Dcreate2");
 
     for (i = 0; i < NATTR; i++) {
-        HDsnprintf(name, sizeof(name), "Attribute %02d", i);
+        snprintf(name, sizeof(name), "Attribute %02d", i);
         attribute = H5Acreate2(dataset, name, H5T_NATIVE_INT, filespace, H5P_DEFAULT, H5P_DEFAULT);
         CHECK(attribute, FAIL, "H5Acreate2");
 
         /* Keep a copy of the attribute names around for later */
-        anames[i] = HDstrdup(name);
+        anames[i] = strdup(name);
         CHECK_PTR(anames[i], "strdup");
 
         ret = H5Aclose(attribute);
@@ -509,7 +509,7 @@ test_iter_attr(hid_t fapl, bool new_format)
         /* Don't check name when new format is used */
         if (!new_format) {
             /* Verify that the correct name is retrieved */
-            if (HDstrcmp(info.name, anames[(size_t)idx - 1]) != 0)
+            if (strcmp(info.name, anames[(size_t)idx - 1]) != 0)
                 TestErrPrintf("%u: Attribute iteration function didn't set names correctly, info.name = "
                               "'%s', anames[%u] = '%s'!\n",
                               __LINE__, info.name, (unsigned)(idx - 1), anames[(size_t)idx - 1]);
@@ -538,7 +538,7 @@ test_iter_attr(hid_t fapl, bool new_format)
         /* Don't check name when new format is used */
         if (!new_format) {
             /* Verify that the correct name is retrieved */
-            if (HDstrcmp(info.name, anames[(size_t)idx - 1]) != 0)
+            if (strcmp(info.name, anames[(size_t)idx - 1]) != 0)
                 TestErrPrintf("%u: Attribute iteration function didn't set names correctly, info.name = "
                               "'%s', anames[%u] = '%s'!\n",
                               __LINE__, info.name, (unsigned)(idx - 1), anames[(size_t)idx - 1]);
@@ -569,7 +569,7 @@ test_iter_attr(hid_t fapl, bool new_format)
 H5_ATTR_PURE int
 iter_strcmp2(const void *s1, const void *s2)
 {
-    return (HDstrcmp((const char *)s1, (const char *)s2));
+    return (strcmp((const char *)s1, (const char *)s2));
 } /* end iter_strcmp2() */
 
 /****************************************************************
@@ -584,7 +584,7 @@ liter_cb2(hid_t loc_id, const char *name, const H5L_info2_t H5_ATTR_UNUSED *link
     H5O_info2_t      oinfo;
     herr_t           ret; /* Generic return value        */
 
-    if (HDstrcmp(name, test_info->name) != 0) {
+    if (strcmp(name, test_info->name) != 0) {
         TestErrPrintf("name = '%s', test_info = '%s'\n", name, test_info->name);
         return (H5_ITER_ERROR);
     } /* end if */
@@ -648,10 +648,10 @@ test_iter_group_large(hid_t fapl)
 
     /* Create a bunch of groups */
     for (i = 0; i < ITER_NGROUPS; i++) {
-        HDsnprintf(gname, sizeof(gname), "Group_%d", i);
+        snprintf(gname, sizeof(gname), "Group_%d", i);
 
         /* Add the name to the list of objects in the root group */
-        HDstrcpy(names[i].name, gname);
+        strcpy(names[i].name, gname);
         names[i].type = H5O_TYPE_GROUP;
 
         /* Create a group */
@@ -668,7 +668,7 @@ test_iter_group_large(hid_t fapl)
     CHECK(dataset, FAIL, "H5Dcreate2");
 
     /* Add the name to the list of objects in the root group */
-    HDstrcpy(names[ITER_NGROUPS].name, "Dataset1");
+    strcpy(names[ITER_NGROUPS].name, "Dataset1");
     names[ITER_NGROUPS].type = H5O_TYPE_DATASET;
 
     /* Close Dataset */
@@ -698,7 +698,7 @@ test_iter_group_large(hid_t fapl)
     CHECK(ret, FAIL, "H5Tcommit2");
 
     /* Add the name to the list of objects in the root group */
-    HDstrcpy(names[ITER_NGROUPS + 1].name, "Datatype1");
+    strcpy(names[ITER_NGROUPS + 1].name, "Datatype1");
     names[ITER_NGROUPS + 1].type = H5O_TYPE_NAMED_DATATYPE;
 
     /* Close datatype */
@@ -765,12 +765,12 @@ test_grp_memb_funcs(hid_t fapl)
     CHECK(filespace, FAIL, "H5Screate");
 
     for (i = 0; i < NDATASETS; i++) {
-        HDsnprintf(name, sizeof(name), "Dataset %d", i);
+        snprintf(name, sizeof(name), "Dataset %d", i);
         dataset = H5Dcreate2(file, name, datatype, filespace, H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT);
         CHECK(dataset, FAIL, "H5Dcreate2");
 
         /* Keep a copy of the dataset names around for later */
-        dnames[i] = HDstrdup(name);
+        dnames[i] = strdup(name);
         CHECK_PTR(dnames[i], "strdup");
 
         ret = H5Dclose(dataset);
@@ -781,13 +781,13 @@ test_grp_memb_funcs(hid_t fapl)
     grp = H5Gcreate2(file, "grp", H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT);
     CHECK(ret, FAIL, "H5Gcreate2");
 
-    dnames[NDATASETS] = HDstrdup("grp");
+    dnames[NDATASETS] = strdup("grp");
     CHECK_PTR(dnames[NDATASETS], "strdup");
 
     ret = H5Tcommit2(file, "dtype", datatype, H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT);
     CHECK(ret, FAIL, "H5Tcommit2");
 
-    dnames[NDATASETS + 1] = HDstrdup("dtype");
+    dnames[NDATASETS + 1] = strdup("dtype");
     CHECK_PTR(dnames[NDATASETS], "strdup");
 
     /* Close everything up */
@@ -836,18 +836,18 @@ test_grp_memb_funcs(hid_t fapl)
         VERIFY(ret, name_len, "H5Lget_name_by_idx");
 
         /* Keep a copy of the dataset names around for later */
-        obj_names[i] = HDstrdup(dataset_name);
+        obj_names[i] = strdup(dataset_name);
         CHECK_PTR(obj_names[i], "strdup");
 
         ret = H5Oget_info_by_idx3(root_group, ".", H5_INDEX_NAME, H5_ITER_INC, (hsize_t)i, &oinfo,
                                   H5O_INFO_BASIC, H5P_DEFAULT);
         CHECK(ret, FAIL, "H5Oget_info_by_idx3");
 
-        if (!HDstrcmp(dataset_name, "grp"))
+        if (!strcmp(dataset_name, "grp"))
             VERIFY(oinfo.type, H5O_TYPE_GROUP, "H5Lget_name_by_idx");
-        if (!HDstrcmp(dataset_name, "dtype"))
+        if (!strcmp(dataset_name, "dtype"))
             VERIFY(oinfo.type, H5O_TYPE_NAMED_DATATYPE, "H5Lget_name_by_idx");
-        if (!HDstrncmp(dataset_name, "Dataset", (size_t)7))
+        if (!strncmp(dataset_name, "Dataset", (size_t)7))
             VERIFY(oinfo.type, H5O_TYPE_DATASET, "H5Lget_name_by_idx");
     } /* end for */
 
@@ -865,8 +865,8 @@ test_grp_memb_funcs(hid_t fapl)
 
     /* Compare object names */
     for (i = 0; i < (int)ginfo.nlinks; i++) {
-        ret = HDstrcmp(dnames[i], obj_names[i]);
-        VERIFY(ret, 0, "HDstrcmp");
+        ret = strcmp(dnames[i], obj_names[i]);
+        VERIFY(ret, 0, "strcmp");
     } /* end for */
 
     ret = H5Gclose(root_group);
@@ -944,11 +944,11 @@ test_links(hid_t fapl)
             CHECK(ret, FAIL, "H5Oget_info_by_idx3");
         } /* end if */
 
-        if (!HDstrcmp(obj_name, "g1.1"))
+        if (!strcmp(obj_name, "g1.1"))
             VERIFY(oinfo.type, H5O_TYPE_GROUP, "H5Lget_name_by_idx");
-        else if (!HDstrcmp(obj_name, "hardlink"))
+        else if (!strcmp(obj_name, "hardlink"))
             VERIFY(oinfo.type, H5O_TYPE_GROUP, "H5Lget_name_by_idx");
-        else if (!HDstrcmp(obj_name, "softlink"))
+        else if (!strcmp(obj_name, "softlink"))
             VERIFY(linfo.type, H5L_TYPE_SOFT, "H5Lget_name_by_idx");
         else
             ERROR("unknown object name");
@@ -985,7 +985,7 @@ find_err_msg_cb(unsigned H5_ATTR_UNUSED n, const H5E_error2_t *err_desc, void *_
         return H5_ITER_ERROR;
 
     /* If the searched error message is found, stop the iteration */
-    if (err_desc->desc != NULL && HDstrcmp(err_desc->desc, searched_err->message) == 0) {
+    if (err_desc->desc != NULL && strcmp(err_desc->desc, searched_err->message) == 0) {
         searched_err->found = true;
         status              = H5_ITER_STOP;
     }
@@ -1043,7 +1043,7 @@ test_corrupted_attnamelen(void)
     /* Make sure the intended error was caught */
     if (err_status == -1) {
         /* Initialize client data */
-        HDstrcpy(err_caught.message, err_message);
+        strcpy(err_caught.message, err_message);
         err_caught.found = false;
 
         /* Look for the correct error message */
@@ -1126,11 +1126,11 @@ test_links_deprec(hid_t fapl)
             CHECK(ret, FAIL, "H5Oget_info_by_idx");
         } /* end if */
 
-        if (!HDstrcmp(obj_name, "g1.1"))
+        if (!strcmp(obj_name, "g1.1"))
             VERIFY(oinfo.type, H5O_TYPE_GROUP, "H5Lget_name_by_idx");
-        else if (!HDstrcmp(obj_name, "hardlink"))
+        else if (!strcmp(obj_name, "hardlink"))
             VERIFY(oinfo.type, H5O_TYPE_GROUP, "H5Lget_name_by_idx");
-        else if (!HDstrcmp(obj_name, "softlink"))
+        else if (!strcmp(obj_name, "softlink"))
             VERIFY(linfo.type, H5L_TYPE_SOFT, "H5Lget_name_by_idx");
         else
             ERROR("unknown object name");

--- a/test/tmisc.c
+++ b/test/tmisc.c
@@ -448,8 +448,8 @@ test_misc2_write_attribute(void)
     hid_t        type;
     herr_t       ret;
     misc2_struct data, data_check;
-    char        *string_att1 = HDstrdup("string attribute in file one");
-    char        *string_att2 = HDstrdup("string attribute in file two");
+    char        *string_att1 = strdup("string attribute in file one");
+    char        *string_att2 = strdup("string attribute in file two");
 
     type = misc2_create_type();
 
@@ -1088,7 +1088,7 @@ test_misc6(void)
     /* Loop through adding attributes to each dataset */
     for (u = 0; u < MISC6_NUMATTR; u++) {
         /* Create name for attribute */
-        HDsnprintf(attr_name, sizeof(attr_name), "Attr#%u", u);
+        snprintf(attr_name, sizeof(attr_name), "Attr#%u", u);
 
         /* Open the file */
         loc_id = H5Fopen(MISC6_FILE, H5F_ACC_RDWR, H5P_DEFAULT);
@@ -2115,11 +2115,11 @@ test_misc12(void)
     CHECK(ret, FAIL, "H5Dread");
 
     for (i = 0; i < MISC12_SPACE1_DIM1; i++)
-        if (HDstrcmp(wdata[i], rdata[i]) != 0)
+        if (strcmp(wdata[i], rdata[i]) != 0)
             TestErrPrintf("Error on line %d: wdata[%d]=%s, rdata[%d]=%s\n", __LINE__, i, wdata[i], i,
                           rdata[i]);
     for (; i < (MISC12_SPACE1_DIM1 + MISC12_APPEND_SIZE); i++)
-        if (HDstrcmp(wdata1[i - MISC12_SPACE1_DIM1], rdata[i]) != 0)
+        if (strcmp(wdata1[i - MISC12_SPACE1_DIM1], rdata[i]) != 0)
             TestErrPrintf("Error on line %d: wdata1[%d]=%s, rdata[%d]=%s\n", __LINE__, i - MISC12_SPACE1_DIM1,
                           wdata1[i - MISC12_SPACE1_DIM1], i, rdata[i]);
 
@@ -2338,7 +2338,7 @@ misc13_insert_user_block(const char *old_name, const char *new_name, const char 
     CHECK_PTR(user_block, "calloc");
 
     /* Copy in the user block data */
-    memcpy(user_block, str, HDstrlen(str));
+    memcpy(user_block, str, strlen(str));
 
     /* Open the new file */
     new_fp = fopen(new_name, "wb");
@@ -2869,13 +2869,13 @@ test_misc16(void)
 
     /* Compare data read in */
     for (i = 0; i < MISC16_SPACE_DIM; i++) {
-        if (HDstrlen(wdata[i]) != HDstrlen(rdata[i])) {
+        if (strlen(wdata[i]) != strlen(rdata[i])) {
             TestErrPrintf(
                 "Line %u: VL data length don't match!, strlen(wdata[%d])=%d, strlen(rdata[%d])=%d\n",
-                (unsigned)__LINE__, (int)i, (int)HDstrlen(wdata[i]), (int)i, (int)HDstrlen(rdata[i]));
+                (unsigned)__LINE__, (int)i, (int)strlen(wdata[i]), (int)i, (int)strlen(rdata[i]));
             continue;
         } /* end if */
-        if (HDstrcmp(wdata[i], rdata[i]) != 0) {
+        if (strcmp(wdata[i], rdata[i]) != 0) {
             TestErrPrintf("Line %u: VL data values don't match!, wdata[%d]=%s, rdata[%d]=%s\n",
                           (unsigned)__LINE__, (int)i, wdata[i], (int)i, rdata[i]);
             continue;
@@ -2954,13 +2954,13 @@ test_misc17(void)
 
     /* Compare data in the way of strings. */
     for (i = 0; i < MISC17_SPACE_DIM1; i++) {
-        if (HDstrlen(wdata[i]) != HDstrlen(rdata[i])) {
+        if (strlen(wdata[i]) != strlen(rdata[i])) {
             TestErrPrintf(
                 "Line %u: VL data length don't match!, strlen(wdata[%d])=%d, strlen(rdata[%d])=%d\n",
-                (unsigned)__LINE__, (int)i, (int)HDstrlen(wdata[i]), (int)i, (int)HDstrlen(rdata[i]));
+                (unsigned)__LINE__, (int)i, (int)strlen(wdata[i]), (int)i, (int)strlen(rdata[i]));
             continue;
         } /* end if */
-        if (HDstrcmp(wdata[i], rdata[i]) != 0) {
+        if (strcmp(wdata[i], rdata[i]) != 0) {
             TestErrPrintf("Line %u: VL data values don't match!, wdata[%d]=%s, rdata[%d]=%s\n",
                           (unsigned)__LINE__, (int)i, wdata[i], (int)i, rdata[i]);
             continue;
@@ -3066,7 +3066,7 @@ test_misc18(void)
     /* Loop creating attributes on each dataset, flushing them to the file each time */
     for (u = 0; u < 10; u++) {
         /* Set up attribute name */
-        HDsnprintf(attr_name, sizeof(attr_name), "Attr %u", u);
+        snprintf(attr_name, sizeof(attr_name), "Attr %u", u);
 
         /* Create & close attribute on first dataset */
         aid = H5Acreate2(did1, attr_name, H5T_STD_U32LE, sid, H5P_DEFAULT, H5P_DEFAULT);
@@ -5572,7 +5572,7 @@ test_misc30(void)
                 CHECK(ret, FAIL, "test_misc30_get_info");
             }
 
-            HDsnprintf(gname, sizeof(gname), "/g0/group%d", i);
+            snprintf(gname, sizeof(gname), "/g0/group%d", i);
             gid = H5Gcreate2(fid, gname, H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT);
             CHECK(gid, FAIL, "H5Gcreate2");
 

--- a/test/trefer.c
+++ b/test/trefer.c
@@ -2121,19 +2121,19 @@ test_deref_iter_op(hid_t H5_ATTR_UNUSED group, const char *name, const H5L_info2
 
     /* Simple check for correct names */
     if (*count == 0) {
-        if (HDstrcmp(name, DSETNAME2) == 0)
+        if (strcmp(name, DSETNAME2) == 0)
             ret_value = 0;
         else
             ret_value = -1;
     } /* end if */
     else if (*count == 1) {
-        if (HDstrcmp(name, GROUPNAME2) == 0)
+        if (strcmp(name, GROUPNAME2) == 0)
             ret_value = 0;
         else
             ret_value = -1;
     } /* end if */
     else if (*count == 2) {
-        if (HDstrcmp(name, GROUPNAME3) == 0)
+        if (strcmp(name, GROUPNAME3) == 0)
             ret_value = 0;
         else
             ret_value = -1;
@@ -3588,7 +3588,7 @@ test_reference(void)
     }     /* end low bound */
 
     /* The following test is currently broken with the Direct VFD */
-    if (HDstrcmp(env_h5_drvr, "direct") != 0) {
+    if (strcmp(env_h5_drvr, "direct") != 0) {
         test_reference_obj_deleted(); /* Test H5R object reference code for deleted objects */
     }
 

--- a/test/trefer_deprec.c
+++ b/test/trefer_deprec.c
@@ -437,7 +437,7 @@ test_reference_obj(void)
     CHECK(size, FAIL, "H5Oget_comment");
 
     /* Check for correct comment value */
-    if (HDstrcmp(write_comment, read_comment) != 0)
+    if (strcmp(write_comment, read_comment) != 0)
         TestErrPrintf("Error! Incorrect group comment, wanted: %s, got: %s\n", write_comment, read_comment);
 
     /* Close group */
@@ -1355,19 +1355,19 @@ test_deref_iter_op(hid_t H5_ATTR_UNUSED group, const char *name, const H5L_info2
 
     /* Simple check for correct names */
     if (*count == 0) {
-        if (HDstrcmp(name, DSETNAME2) == 0)
+        if (strcmp(name, DSETNAME2) == 0)
             ret_value = 0;
         else
             ret_value = -1;
     } /* end if */
     else if (*count == 1) {
-        if (HDstrcmp(name, GROUPNAME2) == 0)
+        if (strcmp(name, GROUPNAME2) == 0)
             ret_value = 0;
         else
             ret_value = -1;
     } /* end if */
     else if (*count == 2) {
-        if (HDstrcmp(name, GROUPNAME3) == 0)
+        if (strcmp(name, GROUPNAME3) == 0)
             ret_value = 0;
         else
             ret_value = -1;

--- a/test/trefstr.c
+++ b/test/trefstr.c
@@ -235,7 +235,7 @@ test_refstr_wrap(void)
     MESSAGE(5, ("Testing Wrapping Ref-Counted Strings\n"));
 
     /* Initialize buffer */
-    HDstrcpy(buf, "foo");
+    strcpy(buf, "foo");
 
     /* Wrap ref-counted string around existing buffer */
     rs = H5RS_wrap(buf);
@@ -245,8 +245,8 @@ test_refstr_wrap(void)
     s = H5RS_get_str(rs);
     CHECK_PTR(s, "H5RS_get_str");
     CHECK_PTR_EQ(s, buf, "wrapping");
-    cmp = HDstrcmp(s, buf);
-    VERIFY(cmp, 0, "HDstrcmp");
+    cmp = strcmp(s, buf);
+    VERIFY(cmp, 0, "strcmp");
 
     /* Increment reference count (should duplicate string) */
     ret = H5RS_incr(rs);
@@ -261,7 +261,7 @@ test_refstr_wrap(void)
     if (s == buf)
         TestErrPrintf("%d: Should not have gotten the same pointer from reference-counted string!\n",
                       __LINE__);
-    cmp = HDstrcmp(s, buf);
+    cmp = strcmp(s, buf);
     if (cmp <= 0)
         TestErrPrintf("%d: string comparison incorrect!\n", __LINE__);
 
@@ -302,9 +302,9 @@ test_refstr_asprintf_cat(void)
     /* Get pointer to raw string in ref-counted string */
     s = H5RS_get_str(rs);
     CHECK_PTR(s, "H5RS_get_str");
-    HDsnprintf(buf, sizeof(buf), "%d-%s", (int)10, "foo");
-    cmp = HDstrcmp(s, buf);
-    VERIFY(cmp, 0, "HDstrcmp");
+    snprintf(buf, sizeof(buf), "%d-%s", (int)10, "foo");
+    cmp = strcmp(s, buf);
+    VERIFY(cmp, 0, "strcmp");
 
     /* Append more output to ref-counted string */
     ret = H5RS_asprintf_cat(rs, "-%f", (double)20.0);
@@ -313,9 +313,9 @@ test_refstr_asprintf_cat(void)
     /* Get pointer to raw string in ref-counted string */
     s = H5RS_get_str(rs);
     CHECK_PTR(s, "H5RS_get_str");
-    HDsnprintf(buf, sizeof(buf), "%d-%s-%f", (int)10, "foo", (double)20.0);
-    cmp = HDstrcmp(s, buf);
-    VERIFY(cmp, 0, "HDstrcmp");
+    snprintf(buf, sizeof(buf), "%d-%s-%f", (int)10, "foo", (double)20.0);
+    cmp = strcmp(s, buf);
+    VERIFY(cmp, 0, "strcmp");
 
     /* Decrement reference count for string */
     ret = H5RS_decr(rs);
@@ -353,9 +353,9 @@ test_refstr_acat(void)
     /* Get pointer to raw string in ref-counted string */
     s = H5RS_get_str(rs);
     CHECK_PTR(s, "H5RS_get_str");
-    HDsnprintf(buf, sizeof(buf), "%s", "foo");
-    cmp = HDstrcmp(s, buf);
-    VERIFY(cmp, 0, "HDstrcmp");
+    snprintf(buf, sizeof(buf), "%s", "foo");
+    cmp = strcmp(s, buf);
+    VERIFY(cmp, 0, "strcmp");
 
     /* Append another string to ref-counted string */
     ret = H5RS_acat(rs, "bar");
@@ -364,9 +364,9 @@ test_refstr_acat(void)
     /* Get pointer to raw string in ref-counted string */
     s = H5RS_get_str(rs);
     CHECK_PTR(s, "H5RS_get_str");
-    HDsnprintf(buf, sizeof(buf), "%s", "foobar");
-    cmp = HDstrcmp(s, buf);
-    VERIFY(cmp, 0, "HDstrcmp");
+    snprintf(buf, sizeof(buf), "%s", "foobar");
+    cmp = strcmp(s, buf);
+    VERIFY(cmp, 0, "strcmp");
 
     /* Append a large string to ref-counted string */
     large_str = malloc(1024);
@@ -379,14 +379,14 @@ test_refstr_acat(void)
     /* Get pointer to raw string in ref-counted string */
     s = H5RS_get_str(rs);
     CHECK_PTR(s, "H5RS_get_str");
-    HDsnprintf(buf, sizeof(buf), "%s", "foobar");
+    snprintf(buf, sizeof(buf), "%s", "foobar");
     large_str2 = malloc(1024 + 6);
     CHECK_PTR(large_str2, "malloc");
-    HDstrcpy(large_str2, "foobar");
+    strcpy(large_str2, "foobar");
     memset(&large_str2[6], 'a', 1024);
     large_str2[1029] = '\0';
-    cmp              = HDstrcmp(s, large_str2);
-    VERIFY(cmp, 0, "HDstrcmp");
+    cmp              = strcmp(s, large_str2);
+    VERIFY(cmp, 0, "strcmp");
 
     /* Decrement reference count for string */
     ret = H5RS_decr(rs);
@@ -426,9 +426,9 @@ test_refstr_ancat(void)
     /* Get pointer to raw string in ref-counted string */
     s = H5RS_get_str(rs);
     CHECK_PTR(s, "H5RS_get_str");
-    HDstrcpy(buf, "fo");
-    cmp = HDstrcmp(s, buf);
-    VERIFY(cmp, 0, "HDstrcmp");
+    strcpy(buf, "fo");
+    cmp = strcmp(s, buf);
+    VERIFY(cmp, 0, "strcmp");
 
     /* Append another string to ref-counted string */
     ret = H5RS_ancat(rs, "bar", 2);
@@ -437,9 +437,9 @@ test_refstr_ancat(void)
     /* Get pointer to raw string in ref-counted string */
     s = H5RS_get_str(rs);
     CHECK_PTR(s, "H5RS_get_str");
-    HDstrcpy(buf, "foba");
-    cmp = HDstrcmp(s, buf);
-    VERIFY(cmp, 0, "HDstrcmp");
+    strcpy(buf, "foba");
+    cmp = strcmp(s, buf);
+    VERIFY(cmp, 0, "strcmp");
 
     /* Decrement reference count for string */
     ret = H5RS_decr(rs);
@@ -475,9 +475,9 @@ test_refstr_aputc(void)
     /* Get pointer to raw string in ref-counted string */
     s = H5RS_get_str(rs);
     CHECK_PTR(s, "H5RS_get_str");
-    HDstrcpy(buf, "f");
-    cmp = HDstrcmp(s, buf);
-    VERIFY(cmp, 0, "HDstrcmp");
+    strcpy(buf, "f");
+    cmp = strcmp(s, buf);
+    VERIFY(cmp, 0, "strcmp");
 
     /* Append another character to ref-counted string */
     ret = H5RS_aputc(rs, 'o');
@@ -486,9 +486,9 @@ test_refstr_aputc(void)
     /* Get pointer to raw string in ref-counted string */
     s = H5RS_get_str(rs);
     CHECK_PTR(s, "H5RS_get_str");
-    HDstrcpy(buf, "fo");
-    cmp = HDstrcmp(s, buf);
-    VERIFY(cmp, 0, "HDstrcmp");
+    strcpy(buf, "fo");
+    cmp = strcmp(s, buf);
+    VERIFY(cmp, 0, "strcmp");
 
     /* Decrement reference count for string */
     ret = H5RS_decr(rs);

--- a/test/tselect.c
+++ b/test/tselect.c
@@ -10909,15 +10909,13 @@ test_shape_same_dr__full_space_vs_slice(int test_num, int small_rank, int large_
     assert(edge_size > 0);
     assert(edge_size <= 1000);
 
-    HDsnprintf(test_desc_0, sizeof(test_desc_0), "\tn-cube slice through m-cube (n <= m) test %d.\n",
-               test_num);
+    snprintf(test_desc_0, sizeof(test_desc_0), "\tn-cube slice through m-cube (n <= m) test %d.\n", test_num);
     MESSAGE(7, ("%s", test_desc_0));
 
     /* This statement must be updated if SS_DR_MAX_RANK is changed */
-    HDsnprintf(test_desc_1, sizeof(test_desc_1),
-               "\t\tranks: %d/%d offset: %d dim_selected: %d/%d/%d/%d/%d.\n", small_rank, large_rank, offset,
-               (int)dim_selected[0], (int)dim_selected[1], (int)dim_selected[2], (int)dim_selected[3],
-               (int)dim_selected[4]);
+    snprintf(test_desc_1, sizeof(test_desc_1), "\t\tranks: %d/%d offset: %d dim_selected: %d/%d/%d/%d/%d.\n",
+             small_rank, large_rank, offset, (int)dim_selected[0], (int)dim_selected[1], (int)dim_selected[2],
+             (int)dim_selected[3], (int)dim_selected[4]);
     MESSAGE(7, ("%s", test_desc_1));
 
     /* copy the edge size into the dims array */
@@ -11169,16 +11167,16 @@ test_shape_same_dr__checkerboard(int test_num, int small_rank, int large_rank, i
     assert(dims_selected >= 0);
     assert(dims_selected <= large_rank);
 
-    HDsnprintf(test_desc_0, sizeof(test_desc_0),
-               "\tcheckerboard n-cube slice through m-cube (n <= m) test %d.\n", test_num);
+    snprintf(test_desc_0, sizeof(test_desc_0),
+             "\tcheckerboard n-cube slice through m-cube (n <= m) test %d.\n", test_num);
     MESSAGE(7, ("%s", test_desc_0));
 
     /* This statement must be updated if SS_DR_MAX_RANK is changed */
-    HDsnprintf(test_desc_1, sizeof(test_desc_1),
-               "\tranks: %d/%d edge/chkr size: %d/%d offset: %d dim_selected: %d/%d/%d/%d/%d:%d.\n",
-               small_rank, large_rank, (int)edge_size, (int)checker_size, offset, (int)dim_selected[0],
-               (int)dim_selected[1], (int)dim_selected[2], (int)dim_selected[3], (int)dim_selected[4],
-               dims_selected);
+    snprintf(test_desc_1, sizeof(test_desc_1),
+             "\tranks: %d/%d edge/chkr size: %d/%d offset: %d dim_selected: %d/%d/%d/%d/%d:%d.\n", small_rank,
+             large_rank, (int)edge_size, (int)checker_size, offset, (int)dim_selected[0],
+             (int)dim_selected[1], (int)dim_selected[2], (int)dim_selected[3], (int)dim_selected[4],
+             dims_selected);
     MESSAGE(7, ("%s", test_desc_1));
 
     /* copy the edge size into the dims array */
@@ -11714,16 +11712,15 @@ test_shape_same_dr__irregular(int test_num, int small_rank, int large_rank, int 
     assert(dims_selected >= 0);
     assert(dims_selected <= large_rank);
 
-    HDsnprintf(test_desc_0, sizeof(test_desc_0),
-               "\tirregular sub set of n-cube slice through m-cube (n <= m) test %d.\n", test_num);
+    snprintf(test_desc_0, sizeof(test_desc_0),
+             "\tirregular sub set of n-cube slice through m-cube (n <= m) test %d.\n", test_num);
     MESSAGE(7, ("%s", test_desc_0));
 
     /* This statement must be updated if SS_DR_MAX_RANK is changed */
-    HDsnprintf(test_desc_1, sizeof(test_desc_1),
-               "\tranks: %d/%d edge: %d s/p offset: %d/%d dim_selected: %d/%d/%d/%d/%d:%d.\n", small_rank,
-               large_rank, edge_size, slice_offset, pattern_offset, (int)dim_selected[0],
-               (int)dim_selected[1], (int)dim_selected[2], (int)dim_selected[3], (int)dim_selected[4],
-               dims_selected);
+    snprintf(test_desc_1, sizeof(test_desc_1),
+             "\tranks: %d/%d edge: %d s/p offset: %d/%d dim_selected: %d/%d/%d/%d/%d:%d.\n", small_rank,
+             large_rank, edge_size, slice_offset, pattern_offset, (int)dim_selected[0], (int)dim_selected[1],
+             (int)dim_selected[2], (int)dim_selected[3], (int)dim_selected[4], dims_selected);
     MESSAGE(7, ("%s", test_desc_1));
 
     /* copy the edge size into the dims array */
@@ -16127,7 +16124,7 @@ test_select(void)
     test_select_hyper_valid_combination(); /* Test different input combinations */
 
     /* The following tests are currently broken with the Direct VFD */
-    if (HDstrcmp(env_h5_drvr, "direct") != 0) {
+    if (strcmp(env_h5_drvr, "direct") != 0) {
         test_select_hyper_and_2d();  /* Test hyperslab intersection (AND) code for 2-D dataset */
         test_select_hyper_xor_2d();  /* Test hyperslab XOR code for 2-D dataset */
         test_select_hyper_notb_2d(); /* Test hyperslab NOTB code for 2-D dataset */

--- a/test/tsohm.c
+++ b/test/tsohm.c
@@ -604,7 +604,7 @@ size1_helper(hid_t file, const char *filename, hid_t fapl_id, bool test_file_clo
             printf("Can't read data\n");                                                                     \
             goto error;                                                                                      \
         }                                                                                                    \
-        if ((rdata.i1 != wdata.i1) || (rdata.i2 != wdata.i2) || HDstrcmp(rdata.str, wdata.str) != 0) {       \
+        if ((rdata.i1 != wdata.i1) || (rdata.i2 != wdata.i2) || strcmp(rdata.str, wdata.str) != 0) {         \
             H5_FAILED();                                                                                     \
             AT();                                                                                            \
             printf("incorrect read data\n");                                                                 \
@@ -621,7 +621,7 @@ size1_helper(hid_t file, const char *filename, hid_t fapl_id, bool test_file_clo
     /* Initialize wdata */
     memset(&wdata, 0, sizeof(wdata));
     wdata.i1 = 11;
-    HDstrcpy(wdata.str, "string");
+    strcpy(wdata.str, "string");
     wdata.i2 = 22;
     wdata.i3 = 33;
     wdata.i4 = 44;
@@ -1486,7 +1486,7 @@ size2_verify_plist2(hid_t plist)
 static void
 size2_dump_struct(const char *name, size2_helper_struct *sizes)
 {
-    HDputs(name);
+    puts(name);
     printf("    empty size: %llu\n", (unsigned long long)sizes->empty_size);
     printf(" first dataset: %llu \tdelta: %llu\n", (unsigned long long)sizes->first_dset,
            (unsigned long long)(sizes->first_dset - sizes->empty_size));
@@ -1631,8 +1631,8 @@ size2_helper(hid_t fcpl_id, int test_file_closing, size2_helper_struct *ret_size
     /* Set up attribute data */
     memset(attr_string1, 0, (size_t)NAME_BUF_SIZE);
     memset(attr_string2, 0, (size_t)NAME_BUF_SIZE);
-    HDstrcpy(attr_string1, LONG_STRING);
-    HDstrcpy(attr_string2, LONG_STRING);
+    strcpy(attr_string1, LONG_STRING);
+    strcpy(attr_string2, LONG_STRING);
     attr_string2[1] = '1'; /* The second string starts "01 index..." */
 
     /* Set up attribute metadata */
@@ -1788,7 +1788,7 @@ size2_helper(hid_t fcpl_id, int test_file_closing, size2_helper_struct *ret_size
     group_id = H5Gopen2(file_id, "group", H5P_DEFAULT);
     CHECK_I(group_id, "H5Gopen2");
 
-    HDstrcpy(attr_name, "00 index");
+    strcpy(attr_name, "00 index");
 
     for (x = 0; x < NUM_ATTRIBUTES; ++x) {
         /* Create a unique name and value for each attribute */
@@ -2038,8 +2038,8 @@ size2_verify(void)
 
     memset(attr_string, 0, (size_t)NAME_BUF_SIZE);
     memset(attr_correct_string, 0, (size_t)NAME_BUF_SIZE);
-    HDstrcpy(attr_correct_string, LONG_STRING);
-    HDstrcpy(attr_name, "00 index");
+    strcpy(attr_correct_string, LONG_STRING);
+    strcpy(attr_name, "00 index");
 
     for (x = 0; x < NUM_ATTRIBUTES; ++x) {
         /* Create the name and correct value for each attribute */

--- a/test/ttsafe.c
+++ b/test/ttsafe.c
@@ -81,7 +81,7 @@ gen_name(int value)
 
     length                     = num_digits(MAX_NUM_NAME - 1);
     temp                       = (char *)malloc(NAME_OFFSET + length + 1);
-    temp                       = HDstrcpy(temp, "attrib");
+    temp                       = strcpy(temp, "attrib");
     temp[NAME_OFFSET + length] = '\0';
 
     for (i = (int)(length - 1); i >= 0; i--) {

--- a/test/tunicode.c
+++ b/test/tunicode.c
@@ -94,7 +94,7 @@ test_fl_string(hid_t fid, const char *string)
     ret = H5Dread(dset_id, dtype_id, H5S_ALL, H5S_ALL, H5P_DEFAULT, read_buf);
     CHECK(ret, FAIL, "H5Dread");
 
-    VERIFY(HDstrcmp(string, read_buf), 0, "strcmp");
+    VERIFY(strcmp(string, read_buf), 0, "strcmp");
 
     /* Close all */
     ret = H5Dclose(dset_id);
@@ -137,14 +137,14 @@ test_strpad(hid_t H5_ATTR_UNUSED fid, const char *string)
      * the right number of bytes (even or odd, depending on the test).
      * We create a 'new_string' whose length is convenient by prepending
      * an 'x' to 'string' when necessary. */
-    length = HDstrlen(string);
+    length = strlen(string);
     if (length % 2 != 1) {
-        HDstrcpy(new_string, "x");
-        HDstrcat(new_string, string);
+        strcpy(new_string, "x");
+        strcat(new_string, string);
         length++;
     }
     else {
-        HDstrcpy(new_string, string);
+        strcpy(new_string, string);
     }
 
     /* Convert a null-terminated string to a shorter and longer null
@@ -163,8 +163,8 @@ test_strpad(hid_t H5_ATTR_UNUSED fid, const char *string)
 
     /* Fill the buffer with two copies of the UTF-8 string, each with a
      * terminating NULL.  It will look like "abcdefg\0abcdefg\0". */
-    HDstrncpy(buf, new_string, big_len);
-    HDstrncpy(&buf[big_len], new_string, big_len);
+    strncpy(buf, new_string, big_len);
+    strncpy(&buf[big_len], new_string, big_len);
 
     ret = H5Tconvert(src_type, dst_type, (size_t)2, buf, NULL, H5P_DEFAULT);
     CHECK(ret, FAIL, "H5Tconvert");
@@ -174,11 +174,11 @@ test_strpad(hid_t H5_ATTR_UNUSED fid, const char *string)
      * like; UTF-8 characters may well have been truncated.
      * To check that the conversion worked properly, we'll build this
      * string manually. */
-    HDstrncpy(cmpbuf, new_string, small_len - 1);
+    strncpy(cmpbuf, new_string, small_len - 1);
     cmpbuf[small_len - 1] = '\0';
-    HDstrncpy(&cmpbuf[small_len], new_string, small_len - 1);
+    strncpy(&cmpbuf[small_len], new_string, small_len - 1);
     cmpbuf[2 * small_len - 1] = '\0';
-    HDstrcpy(&cmpbuf[2 * small_len], new_string);
+    strcpy(&cmpbuf[2 * small_len], new_string);
 
     VERIFY(memcmp(buf, cmpbuf, 2 * big_len), 0, "memcmp");
 
@@ -190,8 +190,8 @@ test_strpad(hid_t H5_ATTR_UNUSED fid, const char *string)
     /* First fill the buffer with NULLs */
     memset(cmpbuf, '\0', (size_t)LONG_BUF_SIZE);
     /* Copy in the characters */
-    HDstrncpy(cmpbuf, new_string, small_len - 1);
-    HDstrncpy(&cmpbuf[big_len], new_string, small_len - 1);
+    strncpy(cmpbuf, new_string, small_len - 1);
+    strncpy(&cmpbuf[big_len], new_string, small_len - 1);
 
     VERIFY(memcmp(buf, cmpbuf, 2 * big_len), 0, "memcmp");
 
@@ -203,14 +203,14 @@ test_strpad(hid_t H5_ATTR_UNUSED fid, const char *string)
     /* Now test null padding.  Null-padded strings do *not* need
      * terminating NULLs, so the sizes of the datatypes are slightly
      * different and we want a string with an even number of characters. */
-    length = HDstrlen(string);
+    length = strlen(string);
     if (length % 2 != 0) {
-        HDstrcpy(new_string, "x");
-        HDstrcat(new_string, string);
+        strcpy(new_string, "x");
+        strcat(new_string, string);
         length++;
     }
     else {
-        HDstrcpy(new_string, string);
+        strcpy(new_string, string);
     }
 
     /* Create a src_type that holds the UTF-8 string */
@@ -225,8 +225,8 @@ test_strpad(hid_t H5_ATTR_UNUSED fid, const char *string)
 
     /* Fill the buffer with two copies of the UTF-8 string.
      * It will look like "abcdefghabcdefgh". */
-    HDstrncpy(buf, new_string, big_len);
-    HDstrncpy(&buf[big_len], new_string, big_len);
+    strncpy(buf, new_string, big_len);
+    strncpy(&buf[big_len], new_string, big_len);
 
     ret = H5Tconvert(src_type, dst_type, (size_t)2, buf, NULL, H5P_DEFAULT);
     CHECK(ret, FAIL, "H5Tconvert");
@@ -236,9 +236,9 @@ test_strpad(hid_t H5_ATTR_UNUSED fid, const char *string)
      * like; UTF-8 characters may well have been truncated.
      * To check that the conversion worked properly, we'll build this
      * string manually. */
-    HDstrncpy(cmpbuf, new_string, small_len);
-    HDstrncpy(&cmpbuf[small_len], new_string, small_len);
-    HDstrncpy(&cmpbuf[2 * small_len], new_string, big_len);
+    strncpy(cmpbuf, new_string, small_len);
+    strncpy(&cmpbuf[small_len], new_string, small_len);
+    strncpy(&cmpbuf[2 * small_len], new_string, big_len);
 
     VERIFY(memcmp(buf, cmpbuf, 2 * big_len), 0, "memcmp");
 
@@ -250,8 +250,8 @@ test_strpad(hid_t H5_ATTR_UNUSED fid, const char *string)
     /* First fill the buffer with NULLs */
     memset(cmpbuf, '\0', (size_t)LONG_BUF_SIZE);
     /* Copy in the characters */
-    HDstrncpy(cmpbuf, new_string, small_len);
-    HDstrncpy(&cmpbuf[big_len], new_string, small_len);
+    strncpy(cmpbuf, new_string, small_len);
+    strncpy(&cmpbuf[big_len], new_string, small_len);
 
     VERIFY(memcmp(buf, cmpbuf, 2 * big_len), 0, "memcmp");
 
@@ -270,8 +270,8 @@ test_strpad(hid_t H5_ATTR_UNUSED fid, const char *string)
 
     /* Fill the buffer with two copies of the UTF-8 string.
      * It will look like "abcdefghabcdefgh". */
-    HDstrcpy(buf, new_string);
-    HDstrcpy(&buf[big_len], new_string);
+    strcpy(buf, new_string);
+    strcpy(&buf[big_len], new_string);
 
     ret = H5Tconvert(src_type, dst_type, (size_t)2, buf, NULL, H5P_DEFAULT);
     CHECK(ret, FAIL, "H5Tconvert");
@@ -281,9 +281,9 @@ test_strpad(hid_t H5_ATTR_UNUSED fid, const char *string)
      * like; UTF-8 characters may have been truncated.
      * To check that the conversion worked properly, we'll build this
      * string manually. */
-    HDstrncpy(cmpbuf, new_string, small_len);
-    HDstrncpy(&cmpbuf[small_len], new_string, small_len);
-    HDstrncpy(&cmpbuf[2 * small_len], new_string, big_len);
+    strncpy(cmpbuf, new_string, small_len);
+    strncpy(&cmpbuf[small_len], new_string, small_len);
+    strncpy(&cmpbuf[2 * small_len], new_string, big_len);
 
     VERIFY(memcmp(buf, cmpbuf, 2 * big_len), 0, "memcmp");
 
@@ -295,8 +295,8 @@ test_strpad(hid_t H5_ATTR_UNUSED fid, const char *string)
     /* First fill the buffer with spaces */
     memset(cmpbuf, ' ', (size_t)LONG_BUF_SIZE);
     /* Copy in the characters */
-    HDstrncpy(cmpbuf, new_string, small_len);
-    HDstrncpy(&cmpbuf[big_len], new_string, small_len);
+    strncpy(cmpbuf, new_string, small_len);
+    strncpy(&cmpbuf[big_len], new_string, small_len);
 
     VERIFY(memcmp(buf, cmpbuf, 2 * big_len), 0, "memcmp");
 
@@ -340,14 +340,14 @@ test_vl_string(hid_t fid, const char *string)
     /* Make certain the correct amount of memory will be used */
     ret = H5Dvlen_get_buf_size(dset_id, type_id, space_id, &size);
     CHECK(ret, FAIL, "H5Dvlen_get_buf_size");
-    VERIFY(size, (hsize_t)HDstrlen(string) + 1, "H5Dvlen_get_buf_size");
+    VERIFY(size, (hsize_t)strlen(string) + 1, "H5Dvlen_get_buf_size");
 
     /* Read dataset from disk */
     ret = H5Dread(dset_id, type_id, H5S_ALL, H5S_ALL, H5P_DEFAULT, read_buf);
     CHECK(ret, FAIL, "H5Dread");
 
     /* Compare data read in */
-    VERIFY(HDstrcmp(string, read_buf[0]), 0, "strcmp");
+    VERIFY(strcmp(string, read_buf[0]), 0, "strcmp");
 
     /* Reclaim the read VL data */
     ret = H5Treclaim(type_id, space_id, H5P_DEFAULT, read_buf);
@@ -399,7 +399,7 @@ test_objnames(hid_t fid, const char *string)
     ret = H5Gclose(grp_id);
     CHECK(ret, FAIL, "H5Gclose");
 
-    VERIFY(HDstrcmp(string, read_buf), 0, "strcmp");
+    VERIFY(strcmp(string, read_buf), 0, "strcmp");
 
     /* Create a new dataset with a UTF-8 name */
     grp1_id = H5Gcreate2(fid, GROUP1_NAME, H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT);
@@ -483,9 +483,9 @@ test_objnames(hid_t fid, const char *string)
 
     ret = H5Lcreate_hard(fid, GROUP2_NAME, grp3_id, GROUP2_NAME, H5P_DEFAULT, H5P_DEFAULT);
     CHECK(ret, FAIL, "H5Lcreate_hard");
-    HDstrcpy(path_buf, GROUP2_NAME);
-    HDstrcat(path_buf, "/");
-    HDstrcat(path_buf, string);
+    strcpy(path_buf, GROUP2_NAME);
+    strcat(path_buf, "/");
+    strcat(path_buf, string);
     ret = H5Lcreate_hard(grp3_id, path_buf, H5L_SAME_LOC, string, H5P_DEFAULT, H5P_DEFAULT);
     CHECK(ret, FAIL, "H5Lcreate_hard");
 
@@ -531,7 +531,7 @@ test_attrname(hid_t fid, const char *string)
     CHECK(attr_id, FAIL, "H5Acreate2");
     size = H5Aget_name(attr_id, (size_t)MAX_STRING_LENGTH, read_buf);
     CHECK(size, FAIL, "H5Aget_name");
-    ret = HDstrcmp(read_buf, string);
+    ret = strcmp(read_buf, string);
     VERIFY(ret, 0, "strcmp");
     read_buf[0] = '\0';
 
@@ -540,7 +540,7 @@ test_attrname(hid_t fid, const char *string)
     CHECK(ret, FAIL, "H5Awrite");
     ret = H5Aread(attr_id, dtype_id, read_buf);
     CHECK(ret, FAIL, "H5Aread");
-    ret = HDstrcmp(read_buf, string);
+    ret = strcmp(read_buf, string);
     VERIFY(ret, 0, "strcmp");
 
     /* Clean up */
@@ -598,7 +598,7 @@ test_compound(hid_t fid, const char *string)
 
     /* Check that the field name was stored correctly */
     readbuf = H5Tget_member_name(s1_tid, 0);
-    ret     = HDstrcmp(readbuf, string);
+    ret     = strcmp(readbuf, string);
     VERIFY(ret, 0, "strcmp");
     H5free_memory(readbuf);
 
@@ -681,7 +681,7 @@ test_enum(hid_t H5_ATTR_UNUSED fid, const char *string)
     VERIFY(val, E1_WHITE, "H5Tenum_valueof");
     ret = H5Tenum_nameof(type_id, &val, readbuf, (size_t)MAX_STRING_LENGTH);
     CHECK(ret, FAIL, "H5Tenum_nameof");
-    ret = HDstrcmp(readbuf, string);
+    ret = strcmp(readbuf, string);
     VERIFY(ret, 0, "strcmp");
 
     /* Close the datatype */
@@ -708,7 +708,7 @@ test_opaque(hid_t H5_ATTR_UNUSED fid, const char *string)
 
     /* Read the tag back. */
     read_buf = H5Tget_tag(type_id);
-    ret      = HDstrcmp(read_buf, string);
+    ret      = strcmp(read_buf, string);
     VERIFY(ret, 0, "H5Tget_tag");
     H5free_memory(read_buf);
 
@@ -782,7 +782,7 @@ dump_string(const char *string)
     printf("The string was:\n %s", string);
     printf("Or in hex:\n");
 
-    length = HDstrlen(string);
+    length = strlen(string);
 
     for (x = 0; x < length; x++)
         printf("%x ", string[x] & (0x000000FF));

--- a/test/tvlstr.c
+++ b/test/tvlstr.c
@@ -186,7 +186,7 @@ test_vlstrings_basic(void)
 
     /* Count the actual number of bytes used by the strings */
     for (i = 0, str_used = 0; i < SPACE1_DIM1; i++)
-        str_used += HDstrlen(wdata[i]) + 1;
+        str_used += strlen(wdata[i]) + 1;
 
     /* Compare against the strings actually written */
     VERIFY(size, (hsize_t)str_used, "H5Dvlen_get_buf_size");
@@ -200,12 +200,12 @@ test_vlstrings_basic(void)
 
     /* Compare data read in */
     for (i = 0; i < SPACE1_DIM1; i++) {
-        if (HDstrlen(wdata[i]) != HDstrlen(rdata[i])) {
+        if (strlen(wdata[i]) != strlen(rdata[i])) {
             TestErrPrintf("VL data length don't match!, strlen(wdata[%d])=%d, strlen(rdata[%d])=%d\n", (int)i,
-                          (int)HDstrlen(wdata[i]), (int)i, (int)HDstrlen(rdata[i]));
+                          (int)strlen(wdata[i]), (int)i, (int)strlen(rdata[i]));
             continue;
         } /* end if */
-        if (HDstrcmp(wdata[i], rdata[i]) != 0) {
+        if (strcmp(wdata[i], rdata[i]) != 0) {
             TestErrPrintf("VL data values don't match!, wdata[%d]=%s, rdata[%d]=%s\n", (int)i, wdata[i],
                           (int)i, rdata[i]);
             continue;
@@ -304,16 +304,16 @@ test_vlstrings_special(void)
 
     /* Compare data read in */
     for (i = 0; i < SPACE1_DIM1; i++) {
-        if (HDstrlen(wdata[i]) != HDstrlen(rdata[i])) {
+        if (strlen(wdata[i]) != strlen(rdata[i])) {
             TestErrPrintf("VL data length don't match!, strlen(wdata[%d])=%d, strlen(rdata[%d])=%d\n", (int)i,
-                          (int)HDstrlen(wdata[i]), (int)i, (int)HDstrlen(rdata[i]));
+                          (int)strlen(wdata[i]), (int)i, (int)strlen(rdata[i]));
             continue;
         } /* end if */
         if ((wdata[i] == NULL && rdata[i] != NULL) || (rdata[i] == NULL && wdata[i] != NULL)) {
             TestErrPrintf("VL data values don't match!\n");
             continue;
         } /* end if */
-        if (HDstrcmp(wdata[i], rdata[i]) != 0) {
+        if (strcmp(wdata[i], rdata[i]) != 0) {
             TestErrPrintf("VL data values don't match!, wdata[%d]=%s, rdata[%d]=%s\n", (int)i, wdata[i],
                           (int)i, rdata[i]);
             continue;
@@ -533,12 +533,12 @@ test_compact_vlstring(void)
 
     /* Compare data read in */
     for (i = 0; i < SPACE1_DIM1; i++) {
-        if (HDstrlen(wdata[i]) != HDstrlen(rdata[i])) {
+        if (strlen(wdata[i]) != strlen(rdata[i])) {
             TestErrPrintf("VL data length don't match!, strlen(wdata[%d])=%d, strlen(rdata[%d])=%d\n", (int)i,
-                          (int)HDstrlen(wdata[i]), (int)i, (int)HDstrlen(rdata[i]));
+                          (int)strlen(wdata[i]), (int)i, (int)strlen(rdata[i]));
             continue;
         } /* end if */
-        if (HDstrcmp(wdata[i], rdata[i]) != 0) {
+        if (strcmp(wdata[i], rdata[i]) != 0) {
             TestErrPrintf("VL data values don't match!, wdata[%d]=%s, rdata[%d]=%s\n", (int)i, wdata[i],
                           (int)i, rdata[i]);
             continue;
@@ -611,7 +611,7 @@ test_write_vl_string_attribute(void)
     ret = H5Aread(att, type, &string_att_check);
     CHECK(ret, FAIL, "H5Aread");
 
-    if (HDstrcmp(string_att_check, string_att) != 0)
+    if (strcmp(string_att_check, string_att) != 0)
         TestErrPrintf("VL string attributes don't match!, string_att=%s, string_att_check=%s\n", string_att,
                       string_att_check);
 
@@ -634,7 +634,7 @@ test_write_vl_string_attribute(void)
     ret = H5Aread(att, type, &string_att_check);
     CHECK(ret, FAIL, "H5Aread");
 
-    if (HDstrcmp(string_att_check, string_att_write) != 0)
+    if (strcmp(string_att_check, string_att_write) != 0)
         TestErrPrintf("VL string attributes don't match!, string_att_write=%s, string_att_check=%s\n",
                       string_att_write, string_att_check);
 
@@ -695,7 +695,7 @@ test_read_vl_string_attribute(void)
     ret = H5Aread(att, type, &string_att_check);
     CHECK(ret, FAIL, "H5Aread");
 
-    if (HDstrcmp(string_att_check, string_att) != 0)
+    if (strcmp(string_att_check, string_att) != 0)
         TestErrPrintf("VL string attributes don't match!, string_att=%s, string_att_check=%s\n", string_att,
                       string_att_check);
 
@@ -713,7 +713,7 @@ test_read_vl_string_attribute(void)
         ret = H5Aread(att, type, &string_att_check);
         CHECK(ret, FAIL, "H5Aread");
 
-        if (HDstrcmp(string_att_check, string_att_write) != 0)
+        if (strcmp(string_att_check, string_att_write) != 0)
             TestErrPrintf("VL string attributes don't match!, string_att_write=%s, string_att_check=%s\n",
                           string_att_write, string_att_check);
 
@@ -772,7 +772,7 @@ read_scalar_dset(hid_t file, hid_t type, hid_t space, char *name, char *data)
     ret = H5Dclose(dset);
     CHECK(ret, FAIL, "H5Dclose");
 
-    if (HDstrcmp(data, data_read) != 0)
+    if (strcmp(data, data_read) != 0)
         TestErrPrintf("Expected %s for dataset %s but read %s\n", data, name, data_read);
 
     ret = H5Treclaim(type, space, H5P_DEFAULT, &data_read);
@@ -816,33 +816,33 @@ test_vl_rewrite(void)
 
     /* Create in file 1 */
     for (i = 0; i < REWRITE_NDATASETS; i++) {
-        HDsnprintf(name, sizeof(name), "/set_%d", i);
+        snprintf(name, sizeof(name), "/set_%d", i);
         write_scalar_dset(file1, type, space, name, name);
     }
 
     /* Effectively copy data from file 1 to 2 */
     for (i = 0; i < REWRITE_NDATASETS; i++) {
-        HDsnprintf(name, sizeof(name), "/set_%d", i);
+        snprintf(name, sizeof(name), "/set_%d", i);
         read_scalar_dset(file1, type, space, name, name);
         write_scalar_dset(file2, type, space, name, name);
     }
 
     /* Read back from file 2 */
     for (i = 0; i < REWRITE_NDATASETS; i++) {
-        HDsnprintf(name, sizeof(name), "/set_%d", i);
+        snprintf(name, sizeof(name), "/set_%d", i);
         read_scalar_dset(file2, type, space, name, name);
     } /* end for */
 
     /* Remove from file 2. */
     for (i = 0; i < REWRITE_NDATASETS; i++) {
-        HDsnprintf(name, sizeof(name), "/set_%d", i);
+        snprintf(name, sizeof(name), "/set_%d", i);
         ret = H5Ldelete(file2, name, H5P_DEFAULT);
         CHECK(ret, FAIL, "H5Ldelete");
     } /* end for */
 
     /* Effectively copy from file 1 to file 2 */
     for (i = 0; i < REWRITE_NDATASETS; i++) {
-        HDsnprintf(name, sizeof(name), "/set_%d", i);
+        snprintf(name, sizeof(name), "/set_%d", i);
         read_scalar_dset(file1, type, space, name, name);
         write_scalar_dset(file2, type, space, name, name);
     } /* end for */

--- a/test/tvltypes.c
+++ b/test/tvltypes.c
@@ -1241,9 +1241,9 @@ test_vltypes_compound_vlstr(void)
         wdata[i].v.p   = (s2 *)malloc((i + L3_INCM) * sizeof(s2));
         wdata[i].v.len = i + L3_INCM;
         for (t1 = (s2 *)((wdata[i].v).p), j = 0; j < (i + L3_INCM); j++, t1++) {
-            HDstrcat(str, "m");
-            t1->string = (char *)malloc(HDstrlen(str) * sizeof(char) + 1);
-            HDstrcpy(t1->string, str);
+            strcat(str, "m");
+            t1->string = (char *)malloc(strlen(str) * sizeof(char) + 1);
+            strcpy(t1->string, str);
             /*t1->color = red;*/
             t1->color = blue;
         }
@@ -1384,7 +1384,7 @@ test_vltypes_compound_vlstr(void)
 
         for (t1 = (s2 *)(wdata[i].v.p), t2 = (s2 *)(rdata[i].v.p), j = 0; j < rdata[i].v.len;
              j++, t1++, t2++) {
-            if (HDstrcmp(t1->string, t2->string) != 0) {
+            if (strcmp(t1->string, t2->string) != 0) {
                 TestErrPrintf("VL data values don't match!, t1->string=%s, t2->string=%s\n", t1->string,
                               t2->string);
                 continue;
@@ -1406,14 +1406,14 @@ test_vltypes_compound_vlstr(void)
     CHECK(ret, FAIL, "H5Treclaim");
 
     /* Use this part for new data */
-    HDstrcpy(str, "bbbbbbbb\0");
+    strcpy(str, "bbbbbbbb\0");
     for (i = 0; i < SPACE1_DIM1; i++) {
         wdata2[i].v.p   = (s2 *)malloc((i + 1) * sizeof(s2));
         wdata2[i].v.len = i + 1;
         for (t1 = (s2 *)(wdata2[i].v).p, j = 0; j < i + 1; j++, t1++) {
-            HDstrcat(str, "pp");
-            t1->string = (char *)malloc(HDstrlen(str) * sizeof(char) + 1);
-            HDstrcpy(t1->string, str);
+            strcat(str, "pp");
+            t1->string = (char *)malloc(strlen(str) * sizeof(char) + 1);
+            strcpy(t1->string, str);
             t1->color = green;
         }
     } /* end for */
@@ -1445,7 +1445,7 @@ test_vltypes_compound_vlstr(void)
 
         for (t1 = (s2 *)(wdata2[i].v.p), t2 = (s2 *)(rdata2[i].v.p), j = 0; j < rdata2[i].v.len;
              j++, t1++, t2++) {
-            if (HDstrcmp(t1->string, t2->string) != 0) {
+            if (strcmp(t1->string, t2->string) != 0) {
                 TestErrPrintf("VL data values don't match!, t1->string=%s, t2->string=%s\n", t1->string,
                               t2->string);
                 continue;
@@ -2654,16 +2654,16 @@ test_vltypes_fill_value(void)
             /* Layout specific actions */
             switch (layout) {
                 case H5D_COMPACT:
-                    HDstrcpy(dset_name1, "dataset1-compact");
-                    HDstrcpy(dset_name2, "dataset2-compact");
+                    strcpy(dset_name1, "dataset1-compact");
+                    strcpy(dset_name2, "dataset2-compact");
                     dset_dspace_id = small_dspace_id;
                     ret            = H5Pset_layout(tmp_dcpl_id, H5D_COMPACT);
                     CHECK(ret, FAIL, "H5Pset_layout");
                     break;
 
                 case H5D_CONTIGUOUS:
-                    HDstrcpy(dset_name1, "dataset1-contig");
-                    HDstrcpy(dset_name2, "dataset2-contig");
+                    strcpy(dset_name1, "dataset1-contig");
+                    strcpy(dset_name2, "dataset2-contig");
                     dset_dspace_id = large_dspace_id;
                     break;
 
@@ -2675,15 +2675,15 @@ test_vltypes_fill_value(void)
                     CHECK(ret, FAIL, "H5Pset_chunk");
 #ifdef H5_HAVE_FILTER_DEFLATE
                     if (test_loop == 1) {
-                        HDstrcpy(dset_name1, "dataset1-chunked-compressed");
-                        HDstrcpy(dset_name2, "dataset2-chunked-compressed");
+                        strcpy(dset_name1, "dataset1-chunked-compressed");
+                        strcpy(dset_name2, "dataset2-chunked-compressed");
                         ret = H5Pset_deflate(tmp_dcpl_id, 3);
                         CHECK(ret, FAIL, "H5Pset_deflate");
                     } /* end if */
                     else {
 #endif /* H5_HAVE_FILTER_DEFLATE */
-                        HDstrcpy(dset_name1, "dataset1-chunked");
-                        HDstrcpy(dset_name2, "dataset2-chunked");
+                        strcpy(dset_name1, "dataset1-chunked");
+                        strcpy(dset_name2, "dataset2-chunked");
 #ifdef H5_HAVE_FILTER_DEFLATE
                     } /* end else */
 #endif                /* H5_HAVE_FILTER_DEFLATE */
@@ -2764,16 +2764,16 @@ test_vltypes_fill_value(void)
             /* Layout specific actions */
             switch (layout) {
                 case H5D_COMPACT:
-                    HDstrcpy(dset_name1, "dataset1-compact");
-                    HDstrcpy(dset_name2, "dataset2-compact");
+                    strcpy(dset_name1, "dataset1-compact");
+                    strcpy(dset_name2, "dataset2-compact");
                     dset_dspace_id        = small_dspace_id;
                     dset_select_dspace_id = small_select_dspace_id;
                     dset_elmts            = SPACE4_DIM_SMALL;
                     break;
 
                 case H5D_CONTIGUOUS:
-                    HDstrcpy(dset_name1, "dataset1-contig");
-                    HDstrcpy(dset_name2, "dataset2-contig");
+                    strcpy(dset_name1, "dataset1-contig");
+                    strcpy(dset_name2, "dataset2-contig");
                     dset_dspace_id        = large_dspace_id;
                     dset_select_dspace_id = large_select_dspace_id;
                     dset_elmts            = SPACE4_DIM_LARGE;
@@ -2782,13 +2782,13 @@ test_vltypes_fill_value(void)
                 case H5D_CHUNKED:
 #ifdef H5_HAVE_FILTER_DEFLATE
                     if (test_loop == 1) {
-                        HDstrcpy(dset_name1, "dataset1-chunked-compressed");
-                        HDstrcpy(dset_name2, "dataset2-chunked-compressed");
+                        strcpy(dset_name1, "dataset1-chunked-compressed");
+                        strcpy(dset_name2, "dataset2-chunked-compressed");
                     } /* end if */
                     else {
 #endif /* H5_HAVE_FILTER_DEFLATE */
-                        HDstrcpy(dset_name1, "dataset1-chunked");
-                        HDstrcpy(dset_name2, "dataset2-chunked");
+                        strcpy(dset_name1, "dataset1-chunked");
+                        strcpy(dset_name2, "dataset2-chunked");
 #ifdef H5_HAVE_FILTER_DEFLATE
                     } /* end else */
 #endif                /* H5_HAVE_FILTER_DEFLATE */
@@ -2818,10 +2818,10 @@ test_vltypes_fill_value(void)
 
             /* Compare data read in */
             for (i = 0; i < dset_elmts; i++) {
-                if (HDstrcmp(rbuf[i].str_id, "foobar") != 0 || HDstrcmp(rbuf[i].str_name, "") != 0 ||
-                    rbuf[i].str_desc || HDstrcmp(rbuf[i].str_orig, "\0") != 0 ||
-                    HDstrcmp(rbuf[i].str_stat, "dead") != 0 || HDstrcmp(rbuf[i].str_form, "liquid") != 0 ||
-                    HDstrcmp(rbuf[i].str_unit, "meter") != 0) {
+                if (strcmp(rbuf[i].str_id, "foobar") != 0 || strcmp(rbuf[i].str_name, "") != 0 ||
+                    rbuf[i].str_desc || strcmp(rbuf[i].str_orig, "\0") != 0 ||
+                    strcmp(rbuf[i].str_stat, "dead") != 0 || strcmp(rbuf[i].str_form, "liquid") != 0 ||
+                    strcmp(rbuf[i].str_unit, "meter") != 0) {
                     TestErrPrintf("%d: VL data doesn't match!, index(i) = %d\n", __LINE__, (int)i);
                     continue;
                 } /* end if */
@@ -2841,11 +2841,10 @@ test_vltypes_fill_value(void)
             /* Compare data read in */
             for (i = 0; i < dset_elmts; i++) {
                 if ((i % 2) == select_offset[0]) {
-                    if (HDstrcmp(rbuf[i].str_id, "foobar") != 0 || HDstrcmp(rbuf[i].str_name, "") != 0 ||
-                        rbuf[i].str_desc || HDstrcmp(rbuf[i].str_orig, "\0") != 0 ||
-                        HDstrcmp(rbuf[i].str_stat, "dead") != 0 ||
-                        HDstrcmp(rbuf[i].str_form, "liquid") != 0 ||
-                        HDstrcmp(rbuf[i].str_unit, "meter") != 0) {
+                    if (strcmp(rbuf[i].str_id, "foobar") != 0 || strcmp(rbuf[i].str_name, "") != 0 ||
+                        rbuf[i].str_desc || strcmp(rbuf[i].str_orig, "\0") != 0 ||
+                        strcmp(rbuf[i].str_stat, "dead") != 0 || strcmp(rbuf[i].str_form, "liquid") != 0 ||
+                        strcmp(rbuf[i].str_unit, "meter") != 0) {
                         TestErrPrintf("%d: VL data doesn't match!, index(i) = %d\n", __LINE__, (int)i);
                         continue;
                     } /* end if */
@@ -2876,10 +2875,10 @@ test_vltypes_fill_value(void)
 
             /* Compare data read in */
             for (i = 0; i < dset_elmts; i++) {
-                if (HDstrcmp(rbuf[i].str_id, "foobar") != 0 || HDstrcmp(rbuf[i].str_name, "") != 0 ||
-                    rbuf[i].str_desc || HDstrcmp(rbuf[i].str_orig, "\0") != 0 ||
-                    HDstrcmp(rbuf[i].str_stat, "dead") != 0 || HDstrcmp(rbuf[i].str_form, "liquid") != 0 ||
-                    HDstrcmp(rbuf[i].str_unit, "meter") != 0) {
+                if (strcmp(rbuf[i].str_id, "foobar") != 0 || strcmp(rbuf[i].str_name, "") != 0 ||
+                    rbuf[i].str_desc || strcmp(rbuf[i].str_orig, "\0") != 0 ||
+                    strcmp(rbuf[i].str_stat, "dead") != 0 || strcmp(rbuf[i].str_form, "liquid") != 0 ||
+                    strcmp(rbuf[i].str_unit, "meter") != 0) {
                     TestErrPrintf("%d: VL data doesn't match!, index(i)=%d\n", __LINE__, (int)i);
                     continue;
                 } /* end if */
@@ -2899,11 +2898,10 @@ test_vltypes_fill_value(void)
             /* Compare data read in */
             for (i = 0; i < dset_elmts; i++) {
                 if ((i % 2) == select_offset[0]) {
-                    if (HDstrcmp(rbuf[i].str_id, "foobar") != 0 || HDstrcmp(rbuf[i].str_name, "") != 0 ||
-                        rbuf[i].str_desc || HDstrcmp(rbuf[i].str_orig, "\0") != 0 ||
-                        HDstrcmp(rbuf[i].str_stat, "dead") != 0 ||
-                        HDstrcmp(rbuf[i].str_form, "liquid") != 0 ||
-                        HDstrcmp(rbuf[i].str_unit, "meter") != 0) {
+                    if (strcmp(rbuf[i].str_id, "foobar") != 0 || strcmp(rbuf[i].str_name, "") != 0 ||
+                        rbuf[i].str_desc || strcmp(rbuf[i].str_orig, "\0") != 0 ||
+                        strcmp(rbuf[i].str_stat, "dead") != 0 || strcmp(rbuf[i].str_form, "liquid") != 0 ||
+                        strcmp(rbuf[i].str_unit, "meter") != 0) {
                         TestErrPrintf("%d: VL data doesn't match!, index(i) = %d\n", __LINE__, (int)i);
                         continue;
                     } /* end if */
@@ -2951,16 +2949,16 @@ test_vltypes_fill_value(void)
             /* Layout specific actions */
             switch (layout) {
                 case H5D_COMPACT:
-                    HDstrcpy(dset_name1, "dataset1-compact");
-                    HDstrcpy(dset_name2, "dataset2-compact");
+                    strcpy(dset_name1, "dataset1-compact");
+                    strcpy(dset_name2, "dataset2-compact");
                     dset_dspace_id        = small_dspace_id;
                     dset_select_dspace_id = small_select_dspace_id;
                     dset_elmts            = SPACE4_DIM_SMALL;
                     break;
 
                 case H5D_CONTIGUOUS:
-                    HDstrcpy(dset_name1, "dataset1-contig");
-                    HDstrcpy(dset_name2, "dataset2-contig");
+                    strcpy(dset_name1, "dataset1-contig");
+                    strcpy(dset_name2, "dataset2-contig");
                     dset_dspace_id        = large_dspace_id;
                     dset_select_dspace_id = large_select_dspace_id;
                     dset_elmts            = SPACE4_DIM_LARGE;
@@ -2969,13 +2967,13 @@ test_vltypes_fill_value(void)
                 case H5D_CHUNKED:
 #ifdef H5_HAVE_FILTER_DEFLATE
                     if (test_loop == 1) {
-                        HDstrcpy(dset_name1, "dataset1-chunked-compressed");
-                        HDstrcpy(dset_name2, "dataset2-chunked-compressed");
+                        strcpy(dset_name1, "dataset1-chunked-compressed");
+                        strcpy(dset_name2, "dataset2-chunked-compressed");
                     } /* end if */
                     else {
 #endif /* H5_HAVE_FILTER_DEFLATE */
-                        HDstrcpy(dset_name1, "dataset1-chunked");
-                        HDstrcpy(dset_name2, "dataset2-chunked");
+                        strcpy(dset_name1, "dataset1-chunked");
+                        strcpy(dset_name2, "dataset2-chunked");
 #ifdef H5_HAVE_FILTER_DEFLATE
                     } /* end else */
 #endif                /* H5_HAVE_FILTER_DEFLATE */
@@ -3018,22 +3016,21 @@ test_vltypes_fill_value(void)
             /* Compare data read in */
             for (i = 0; i < dset_elmts; i++) {
                 if (i == single_offset[0]) {
-                    if (HDstrcmp(rbuf[i].str_id, wdata.str_id) != 0 || rbuf[i].str_name ||
-                        HDstrcmp(rbuf[i].str_desc, wdata.str_desc) != 0 ||
-                        HDstrcmp(rbuf[i].str_orig, wdata.str_orig) != 0 ||
-                        HDstrcmp(rbuf[i].str_stat, wdata.str_stat) != 0 ||
-                        HDstrcmp(rbuf[i].str_form, wdata.str_form) != 0 ||
-                        HDstrcmp(rbuf[i].str_unit, wdata.str_unit) != 0) {
+                    if (strcmp(rbuf[i].str_id, wdata.str_id) != 0 || rbuf[i].str_name ||
+                        strcmp(rbuf[i].str_desc, wdata.str_desc) != 0 ||
+                        strcmp(rbuf[i].str_orig, wdata.str_orig) != 0 ||
+                        strcmp(rbuf[i].str_stat, wdata.str_stat) != 0 ||
+                        strcmp(rbuf[i].str_form, wdata.str_form) != 0 ||
+                        strcmp(rbuf[i].str_unit, wdata.str_unit) != 0) {
                         TestErrPrintf("%d: VL data doesn't match!, index(i)=%d\n", __LINE__, (int)i);
                         continue;
                     } /* end if */
                 }     /* end if */
                 else {
-                    if (HDstrcmp(rbuf[i].str_id, "foobar") != 0 || HDstrcmp(rbuf[i].str_name, "") != 0 ||
-                        rbuf[i].str_desc || HDstrcmp(rbuf[i].str_orig, "\0") != 0 ||
-                        HDstrcmp(rbuf[i].str_stat, "dead") != 0 ||
-                        HDstrcmp(rbuf[i].str_form, "liquid") != 0 ||
-                        HDstrcmp(rbuf[i].str_unit, "meter") != 0) {
+                    if (strcmp(rbuf[i].str_id, "foobar") != 0 || strcmp(rbuf[i].str_name, "") != 0 ||
+                        rbuf[i].str_desc || strcmp(rbuf[i].str_orig, "\0") != 0 ||
+                        strcmp(rbuf[i].str_stat, "dead") != 0 || strcmp(rbuf[i].str_form, "liquid") != 0 ||
+                        strcmp(rbuf[i].str_unit, "meter") != 0) {
                         TestErrPrintf("%d: VL data doesn't match!, index(i)=%d\n", __LINE__, (int)i);
                         continue;
                     } /* end if */
@@ -3054,23 +3051,23 @@ test_vltypes_fill_value(void)
             /* Compare data read in */
             for (i = 0; i < dset_elmts; i++) {
                 if (i == single_offset[0]) {
-                    if (HDstrcmp(rbuf[i].str_id, wdata.str_id) != 0 || rbuf[i].str_name ||
-                        HDstrcmp(rbuf[i].str_desc, wdata.str_desc) != 0 ||
-                        HDstrcmp(rbuf[i].str_orig, wdata.str_orig) != 0 ||
-                        HDstrcmp(rbuf[i].str_stat, wdata.str_stat) != 0 ||
-                        HDstrcmp(rbuf[i].str_form, wdata.str_form) != 0 ||
-                        HDstrcmp(rbuf[i].str_unit, wdata.str_unit) != 0) {
+                    if (strcmp(rbuf[i].str_id, wdata.str_id) != 0 || rbuf[i].str_name ||
+                        strcmp(rbuf[i].str_desc, wdata.str_desc) != 0 ||
+                        strcmp(rbuf[i].str_orig, wdata.str_orig) != 0 ||
+                        strcmp(rbuf[i].str_stat, wdata.str_stat) != 0 ||
+                        strcmp(rbuf[i].str_form, wdata.str_form) != 0 ||
+                        strcmp(rbuf[i].str_unit, wdata.str_unit) != 0) {
                         TestErrPrintf("%d: VL data doesn't match!, index(i)=%d\n", __LINE__, (int)i);
                         continue;
                     } /* end if */
                 }     /* end if */
                 else {
                     if ((i % 2) == select_offset[0]) {
-                        if (HDstrcmp(rbuf[i].str_id, "foobar") != 0 || HDstrcmp(rbuf[i].str_name, "") != 0 ||
-                            rbuf[i].str_desc || HDstrcmp(rbuf[i].str_orig, "\0") != 0 ||
-                            HDstrcmp(rbuf[i].str_stat, "dead") != 0 ||
-                            HDstrcmp(rbuf[i].str_form, "liquid") != 0 ||
-                            HDstrcmp(rbuf[i].str_unit, "meter") != 0) {
+                        if (strcmp(rbuf[i].str_id, "foobar") != 0 || strcmp(rbuf[i].str_name, "") != 0 ||
+                            rbuf[i].str_desc || strcmp(rbuf[i].str_orig, "\0") != 0 ||
+                            strcmp(rbuf[i].str_stat, "dead") != 0 ||
+                            strcmp(rbuf[i].str_form, "liquid") != 0 ||
+                            strcmp(rbuf[i].str_unit, "meter") != 0) {
                             TestErrPrintf("%d: VL data doesn't match!, index(i) = %d\n", __LINE__, (int)i);
                             continue;
                         } /* end if */
@@ -3106,22 +3103,21 @@ test_vltypes_fill_value(void)
             /* Compare data read in */
             for (i = 0; i < dset_elmts; i++) {
                 if (i == single_offset[0]) {
-                    if (HDstrcmp(rbuf[i].str_id, wdata.str_id) != 0 || rbuf[i].str_name ||
-                        HDstrcmp(rbuf[i].str_desc, wdata.str_desc) != 0 ||
-                        HDstrcmp(rbuf[i].str_orig, wdata.str_orig) != 0 ||
-                        HDstrcmp(rbuf[i].str_stat, wdata.str_stat) != 0 ||
-                        HDstrcmp(rbuf[i].str_form, wdata.str_form) != 0 ||
-                        HDstrcmp(rbuf[i].str_unit, wdata.str_unit) != 0) {
+                    if (strcmp(rbuf[i].str_id, wdata.str_id) != 0 || rbuf[i].str_name ||
+                        strcmp(rbuf[i].str_desc, wdata.str_desc) != 0 ||
+                        strcmp(rbuf[i].str_orig, wdata.str_orig) != 0 ||
+                        strcmp(rbuf[i].str_stat, wdata.str_stat) != 0 ||
+                        strcmp(rbuf[i].str_form, wdata.str_form) != 0 ||
+                        strcmp(rbuf[i].str_unit, wdata.str_unit) != 0) {
                         TestErrPrintf("%d: VL data doesn't match!, index(i)=%d\n", __LINE__, (int)i);
                         continue;
                     } /* end if */
                 }     /* end if */
                 else {
-                    if (HDstrcmp(rbuf[i].str_id, "foobar") != 0 || HDstrcmp(rbuf[i].str_name, "") != 0 ||
-                        rbuf[i].str_desc || HDstrcmp(rbuf[i].str_orig, "\0") != 0 ||
-                        HDstrcmp(rbuf[i].str_stat, "dead") != 0 ||
-                        HDstrcmp(rbuf[i].str_form, "liquid") != 0 ||
-                        HDstrcmp(rbuf[i].str_unit, "meter") != 0) {
+                    if (strcmp(rbuf[i].str_id, "foobar") != 0 || strcmp(rbuf[i].str_name, "") != 0 ||
+                        rbuf[i].str_desc || strcmp(rbuf[i].str_orig, "\0") != 0 ||
+                        strcmp(rbuf[i].str_stat, "dead") != 0 || strcmp(rbuf[i].str_form, "liquid") != 0 ||
+                        strcmp(rbuf[i].str_unit, "meter") != 0) {
                         TestErrPrintf("%d: VL data doesn't match!, index(i)=%d\n", __LINE__, (int)i);
                         continue;
                     } /* end if */
@@ -3142,23 +3138,23 @@ test_vltypes_fill_value(void)
             /* Compare data read in */
             for (i = 0; i < dset_elmts; i++) {
                 if (i == single_offset[0]) {
-                    if (HDstrcmp(rbuf[i].str_id, wdata.str_id) != 0 || rbuf[i].str_name ||
-                        HDstrcmp(rbuf[i].str_desc, wdata.str_desc) != 0 ||
-                        HDstrcmp(rbuf[i].str_orig, wdata.str_orig) != 0 ||
-                        HDstrcmp(rbuf[i].str_stat, wdata.str_stat) != 0 ||
-                        HDstrcmp(rbuf[i].str_form, wdata.str_form) != 0 ||
-                        HDstrcmp(rbuf[i].str_unit, wdata.str_unit) != 0) {
+                    if (strcmp(rbuf[i].str_id, wdata.str_id) != 0 || rbuf[i].str_name ||
+                        strcmp(rbuf[i].str_desc, wdata.str_desc) != 0 ||
+                        strcmp(rbuf[i].str_orig, wdata.str_orig) != 0 ||
+                        strcmp(rbuf[i].str_stat, wdata.str_stat) != 0 ||
+                        strcmp(rbuf[i].str_form, wdata.str_form) != 0 ||
+                        strcmp(rbuf[i].str_unit, wdata.str_unit) != 0) {
                         TestErrPrintf("%d: VL data doesn't match!, index(i)=%d\n", __LINE__, (int)i);
                         continue;
                     } /* end if */
                 }     /* end if */
                 else {
                     if ((i % 2) == select_offset[0]) {
-                        if (HDstrcmp(rbuf[i].str_id, "foobar") != 0 || HDstrcmp(rbuf[i].str_name, "") != 0 ||
-                            rbuf[i].str_desc || HDstrcmp(rbuf[i].str_orig, "\0") != 0 ||
-                            HDstrcmp(rbuf[i].str_stat, "dead") != 0 ||
-                            HDstrcmp(rbuf[i].str_form, "liquid") != 0 ||
-                            HDstrcmp(rbuf[i].str_unit, "meter") != 0) {
+                        if (strcmp(rbuf[i].str_id, "foobar") != 0 || strcmp(rbuf[i].str_name, "") != 0 ||
+                            rbuf[i].str_desc || strcmp(rbuf[i].str_orig, "\0") != 0 ||
+                            strcmp(rbuf[i].str_stat, "dead") != 0 ||
+                            strcmp(rbuf[i].str_form, "liquid") != 0 ||
+                            strcmp(rbuf[i].str_unit, "meter") != 0) {
                             TestErrPrintf("%d: VL data doesn't match!, index(i) = %d\n", __LINE__, (int)i);
                             continue;
                         } /* end if */

--- a/test/twriteorder.c
+++ b/test/twriteorder.c
@@ -379,7 +379,7 @@ main(int argc, char *argv[])
     if (launch_g == UC_READWRITE) {
         /* fork process */
         if ((childpid = fork()) < 0) {
-            HDperror("fork");
+            perror("fork");
             Hgoto_error(1);
         }
     }
@@ -417,7 +417,7 @@ main(int argc, char *argv[])
     /* ================================================ */
     if (launch_g == UC_READWRITE) {
         if ((tmppid = waitpid(childpid, &child_status, child_wait_option)) < 0) {
-            HDperror("waitpid");
+            perror("waitpid");
             Hgoto_error(1);
         }
         if (WIFEXITED(child_status)) {

--- a/test/unlink.c
+++ b/test/unlink.c
@@ -165,12 +165,12 @@ test_many(hid_t file)
     /* Create a bunch of names and unlink them in order */
     TESTING("forward unlink");
     for (i = 0; i < how_many; i++) {
-        HDsnprintf(name, sizeof(name), "obj_%05d", i);
+        snprintf(name, sizeof(name), "obj_%05d", i);
         if (H5Lcreate_hard(work, "/test_many_foo", H5L_SAME_LOC, name, H5P_DEFAULT, H5P_DEFAULT) < 0)
             FAIL_STACK_ERROR;
     } /* end for */
     for (i = 0; i < how_many; i++) {
-        HDsnprintf(name, sizeof(name), "obj_%05d", i);
+        snprintf(name, sizeof(name), "obj_%05d", i);
         if (H5Ldelete(work, name, H5P_DEFAULT) < 0)
             FAIL_STACK_ERROR;
     } /* end for */
@@ -179,12 +179,12 @@ test_many(hid_t file)
     /* Create a bunch of names and unlink them in reverse order */
     TESTING("backward unlink");
     for (i = 0; i < how_many; i++) {
-        HDsnprintf(name, sizeof(name), "obj_%05d", i);
+        snprintf(name, sizeof(name), "obj_%05d", i);
         if (H5Lcreate_hard(work, "/test_many_foo", H5L_SAME_LOC, name, H5P_DEFAULT, H5P_DEFAULT) < 0)
             FAIL_STACK_ERROR;
     } /* end for */
     for (i = (how_many - 1); i >= 0; --i) {
-        HDsnprintf(name, sizeof(name), "obj_%05d", i);
+        snprintf(name, sizeof(name), "obj_%05d", i);
         if (H5Ldelete(work, name, H5P_DEFAULT) < 0)
             FAIL_STACK_ERROR;
     } /* end for */
@@ -193,15 +193,15 @@ test_many(hid_t file)
     /* Create a bunch of names and unlink them from both directions */
     TESTING("inward unlink");
     for (i = 0; i < how_many; i++) {
-        HDsnprintf(name, sizeof(name), "obj_%05d", i);
+        snprintf(name, sizeof(name), "obj_%05d", i);
         if (H5Lcreate_hard(work, "/test_many_foo", H5L_SAME_LOC, name, H5P_DEFAULT, H5P_DEFAULT) < 0)
             FAIL_STACK_ERROR;
     } /* end for */
     for (i = 0; i < how_many; i++) {
         if (i % 2)
-            HDsnprintf(name, sizeof(name), "obj_%05d", how_many - (1 + i / 2));
+            snprintf(name, sizeof(name), "obj_%05d", how_many - (1 + i / 2));
         else
-            HDsnprintf(name, sizeof(name), "obj_%05d", i / 2);
+            snprintf(name, sizeof(name), "obj_%05d", i / 2);
         if (H5Ldelete(work, name, H5P_DEFAULT) < 0)
             FAIL_STACK_ERROR;
     } /* end for */
@@ -210,15 +210,15 @@ test_many(hid_t file)
     /* Create a bunch of names and unlink them from the midle */
     TESTING("outward unlink");
     for (i = 0; i < how_many; i++) {
-        HDsnprintf(name, sizeof(name), "obj_%05d", i);
+        snprintf(name, sizeof(name), "obj_%05d", i);
         if (H5Lcreate_hard(work, "/test_many_foo", H5L_SAME_LOC, name, H5P_DEFAULT, H5P_DEFAULT) < 0)
             FAIL_STACK_ERROR;
     } /* end for */
     for (i = (how_many - 1); i >= 0; --i) {
         if (i % 2)
-            HDsnprintf(name, sizeof(name), "obj_%05d", how_many - (1 + i / 2));
+            snprintf(name, sizeof(name), "obj_%05d", how_many - (1 + i / 2));
         else
-            HDsnprintf(name, sizeof(name), "obj_%05d", i / 2);
+            snprintf(name, sizeof(name), "obj_%05d", i / 2);
         if (H5Ldelete(work, name, H5P_DEFAULT) < 0)
             FAIL_STACK_ERROR;
     } /* end for */
@@ -485,7 +485,7 @@ check_new_move(hid_t fapl)
     /* Check soft links */
     if (H5Lget_val(file, "group2/soft", linkval, sizeof(linkval), H5P_DEFAULT) < 0)
         FAIL_STACK_ERROR;
-    if (HDstrcmp(linkval, "/group1/group_move") != 0)
+    if (strcmp(linkval, "/group1/group_move") != 0)
         FAIL_PUTS_ERROR("    Soft link test failed. Wrong link value");
 
     /* Cleanup */
@@ -545,7 +545,7 @@ test_filespace(hid_t fapl)
     size_t rdcc_nbytes;
     double rdcc_w0;
 
-    HDputs("Testing file space gets reused:");
+    puts("Testing file space gets reused:");
 
     /* Open file */
     h5_fixname(FILENAME[4], fapl, filename, sizeof filename);
@@ -902,7 +902,7 @@ test_filespace(hid_t fapl)
     /* Alternate adding attributes to each one */
     for (u = 0; u < FILESPACE_NATTR; u++) {
         /* Set the name of the attribute to create */
-        HDsnprintf(objname, sizeof(objname), "%s %u", ATTRNAME, u);
+        snprintf(objname, sizeof(objname), "%s %u", ATTRNAME, u);
 
         /* Create an attribute on the first dataset */
         if ((attr = H5Acreate2(dataset, objname, H5T_NATIVE_INT, attr_space, H5P_DEFAULT, H5P_DEFAULT)) < 0)
@@ -1034,7 +1034,7 @@ test_filespace(hid_t fapl)
 
     /* Create a many groups to remove */
     for (u = 0; u < UNLINK_NGROUPS; u++) {
-        HDsnprintf(objname, sizeof(objname), "%s %u", GROUPNAME, u);
+        snprintf(objname, sizeof(objname), "%s %u", GROUPNAME, u);
         if ((group = H5Gcreate2(file, objname, H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT)) < 0)
             FAIL_STACK_ERROR;
         if (H5Gclose(group) < 0)
@@ -1044,7 +1044,7 @@ test_filespace(hid_t fapl)
     /* Remove the all the groups */
     /* (Remove them in reverse order just to make file size calculation easier -QAK) */
     for (u = UNLINK_NGROUPS; u > 0; u--) {
-        HDsnprintf(objname, sizeof(objname), "%s %u", GROUPNAME, (u - 1));
+        snprintf(objname, sizeof(objname), "%s %u", GROUPNAME, (u - 1));
         if (H5Ldelete(file, objname, H5P_DEFAULT) < 0)
             FAIL_STACK_ERROR;
     } /* end for */
@@ -1112,21 +1112,21 @@ test_filespace(hid_t fapl)
     /* Create a complex group hierarchy to remove */
     for (u = 0; u < FILESPACE_TOP_GROUPS; u++) {
         /* Create group */
-        HDsnprintf(objname, sizeof(objname), "%s %u", GROUPNAME, u);
+        snprintf(objname, sizeof(objname), "%s %u", GROUPNAME, u);
         if ((group = H5Gcreate2(file, objname, H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT)) < 0)
             FAIL_STACK_ERROR;
 
         /* Create nested groups inside top groups */
         for (v = 0; v < FILESPACE_NESTED_GROUPS; v++) {
             /* Create group */
-            HDsnprintf(objname, sizeof(objname), "%s %u", GROUP2NAME, v);
+            snprintf(objname, sizeof(objname), "%s %u", GROUP2NAME, v);
             if ((group2 = H5Gcreate2(group, objname, H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT)) < 0)
                 FAIL_STACK_ERROR;
 
             /* Create datasets inside nested groups */
             for (w = 0; w < FILESPACE_NDATASETS; w++) {
                 /* Create & close a dataset */
-                HDsnprintf(objname, sizeof(objname), "%s %u", DATASETNAME, w);
+                snprintf(objname, sizeof(objname), "%s %u", DATASETNAME, w);
                 if ((dataset = H5Dcreate2(group2, objname, H5T_NATIVE_INT, space, H5P_DEFAULT, H5P_DEFAULT,
                                           H5P_DEFAULT)) < 0)
                     FAIL_STACK_ERROR;
@@ -1148,21 +1148,21 @@ test_filespace(hid_t fapl)
     /* (Remove them in reverse order just to make file size calculation easier -QAK) */
     for (u = FILESPACE_TOP_GROUPS; u > 0; u--) {
         /* Open group */
-        HDsnprintf(objname, sizeof(objname), "%s %u", GROUPNAME, (u - 1));
+        snprintf(objname, sizeof(objname), "%s %u", GROUPNAME, (u - 1));
         if ((group = H5Gopen2(file, objname, H5P_DEFAULT)) < 0)
             FAIL_STACK_ERROR;
 
         /* Open nested groups inside top groups */
         for (v = 0; v < FILESPACE_NESTED_GROUPS; v++) {
             /* Create group */
-            HDsnprintf(objname, sizeof(objname), "%s %u", GROUP2NAME, v);
+            snprintf(objname, sizeof(objname), "%s %u", GROUP2NAME, v);
             if ((group2 = H5Gopen2(group, objname, H5P_DEFAULT)) < 0)
                 FAIL_STACK_ERROR;
 
             /* Remove datasets inside nested groups */
             for (w = 0; w < FILESPACE_NDATASETS; w++) {
                 /* Remove dataset */
-                HDsnprintf(objname, sizeof(objname), "%s %u", DATASETNAME, w);
+                snprintf(objname, sizeof(objname), "%s %u", DATASETNAME, w);
                 if (H5Ldelete(group2, objname, H5P_DEFAULT) < 0)
                     FAIL_STACK_ERROR;
             } /* end for */
@@ -1172,7 +1172,7 @@ test_filespace(hid_t fapl)
                 FAIL_STACK_ERROR;
 
             /* Remove nested group */
-            HDsnprintf(objname, sizeof(objname), "%s %u", GROUP2NAME, v);
+            snprintf(objname, sizeof(objname), "%s %u", GROUP2NAME, v);
             if (H5Ldelete(group, objname, H5P_DEFAULT) < 0)
                 FAIL_STACK_ERROR;
         } /* end for */
@@ -1182,7 +1182,7 @@ test_filespace(hid_t fapl)
             FAIL_STACK_ERROR;
 
         /* Remove top group */
-        HDsnprintf(objname, sizeof(objname), "%s %u", GROUPNAME, (u - 1));
+        snprintf(objname, sizeof(objname), "%s %u", GROUPNAME, (u - 1));
         if (H5Ldelete(file, objname, H5P_DEFAULT) < 0)
             FAIL_STACK_ERROR;
     } /* end for */
@@ -1461,7 +1461,7 @@ test_create_unlink(const char *msg, hid_t fapl)
 
     /* Create a many groups to remove */
     for (u = 0; u < UNLINK_NGROUPS; u++) {
-        HDsnprintf(groupname, sizeof(groupname), "%s %u", GROUPNAME, u);
+        snprintf(groupname, sizeof(groupname), "%s %u", GROUPNAME, u);
         if ((group = H5Gcreate2(file, groupname, H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT)) < 0) {
             H5_FAILED();
             printf("group %s creation failed\n", groupname);
@@ -1476,7 +1476,7 @@ test_create_unlink(const char *msg, hid_t fapl)
 
     /* Remove the all the groups */
     for (u = 0; u < UNLINK_NGROUPS; u++) {
-        HDsnprintf(groupname, sizeof(groupname), "%s %u", GROUPNAME, u);
+        snprintf(groupname, sizeof(groupname), "%s %u", GROUPNAME, u);
         if (H5Ldelete(file, groupname, H5P_DEFAULT) < 0) {
             H5_FAILED();
             printf("Unlinking group %s failed\n", groupname);
@@ -1665,7 +1665,7 @@ delete_node(hid_t pid, hid_t id)
         return (-1);
 
     /* If this object is the right-most child, try opening the previous object */
-    if (HDstrcmp(name, "/Zone81") == 0) {
+    if (strcmp(name, "/Zone81") == 0) {
         hid_t gid;
 
         if ((gid = H5Gopen2(pid, "/Zone80", H5P_DEFAULT)) < 0)
@@ -1709,7 +1709,7 @@ test_unlink_rightleaf(hid_t fid)
 
     /* Create all the groups */
     for (n = 0; n < ngroups; n++) {
-        HDsnprintf(name, sizeof(name), "Zone%d", n + 1);
+        snprintf(name, sizeof(name), "Zone%d", n + 1);
         if ((gids[n] = H5Gcreate2(rootid, name, H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT)) < 0)
             TEST_ERROR;
     } /* end for */
@@ -1718,7 +1718,7 @@ test_unlink_rightleaf(hid_t fid)
     for (n = 0; n < ngroups; n++) {
         if (delete_node(rootid, gids[n]) < 0)
             TEST_ERROR;
-        HDsnprintf(name, sizeof(name), "Zone%d", n + 1);
+        snprintf(name, sizeof(name), "Zone%d", n + 1);
         if ((gids[n] = H5Gcreate2(rootid, name, H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT)) < 0)
             TEST_ERROR;
     } /* end for */
@@ -1793,7 +1793,7 @@ test_unlink_rightnode(hid_t fid)
 
     /* Create all the groups */
     for (n = 0; n < ngroups; n++) {
-        HDsnprintf(name, sizeof(name), "ZoneB%d", n + 1);
+        snprintf(name, sizeof(name), "ZoneB%d", n + 1);
         if ((gids[n] = H5Gcreate2(rootid, name, H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT)) < 0)
             FAIL_STACK_ERROR;
     } /* end for */
@@ -1880,7 +1880,7 @@ test_unlink_middlenode(hid_t fid)
 
     /* Create all the groups */
     for (n = 0; n < ngroups; n++) {
-        HDsnprintf(name, sizeof(name), "ZoneC%d", n + 1);
+        snprintf(name, sizeof(name), "ZoneC%d", n + 1);
         if ((gids[n] = H5Gcreate2(rootid, name, H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT)) < 0)
             FAIL_STACK_ERROR;
     } /* end for */
@@ -2587,7 +2587,7 @@ test_full_group_compact(hid_t fapl)
 
     /* Create several objects to link to */
     for (u = 0; u < FULL_GROUP_NUM_KEEP; u++) {
-        HDsnprintf(objname, sizeof(objname), "keep %u\n", u);
+        snprintf(objname, sizeof(objname), "keep %u\n", u);
         if ((gid2 = H5Gcreate2(gid, objname, H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT)) < 0)
             FAIL_STACK_ERROR;
         if (H5Gclose(gid2) < 0)
@@ -2624,15 +2624,15 @@ test_full_group_compact(hid_t fapl)
 
     /* Create hard links to objects in group to keep */
     for (u = 0; u < FULL_GROUP_NUM_KEEP; u++) {
-        HDsnprintf(objname, sizeof(objname), "/keep/keep %u\n", u);
-        HDsnprintf(objname2, sizeof(objname2), "keep %u\n", u);
+        snprintf(objname, sizeof(objname), "/keep/keep %u\n", u);
+        snprintf(objname2, sizeof(objname2), "keep %u\n", u);
         if (H5Lcreate_hard(file_id, objname, gid, objname2, H5P_DEFAULT, H5P_DEFAULT) < 0)
             FAIL_STACK_ERROR;
     } /* end for */
 
     /* Create several objects to delete */
     for (u = 0; u < FULL_GROUP_NUM_DELETE_COMPACT; u++) {
-        HDsnprintf(objname, sizeof(objname), "delete %u\n", u);
+        snprintf(objname, sizeof(objname), "delete %u\n", u);
         if ((gid2 = H5Gcreate2(gid, objname, H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT)) < 0)
             FAIL_STACK_ERROR;
         if (H5Gclose(gid2) < 0)
@@ -2653,7 +2653,7 @@ test_full_group_compact(hid_t fapl)
 
     /* Check reference count on objects to keep */
     for (u = 0; u < FULL_GROUP_NUM_KEEP; u++) {
-        HDsnprintf(objname, sizeof(objname), "/keep/keep %u\n", u);
+        snprintf(objname, sizeof(objname), "/keep/keep %u\n", u);
         if (H5Oget_info_by_name3(file_id, objname, &oi, H5O_INFO_BASIC, H5P_DEFAULT) < 0)
             FAIL_STACK_ERROR;
         if (oi.rc != 2)
@@ -2674,7 +2674,7 @@ test_full_group_compact(hid_t fapl)
 
     /* Check reference count on objects to keep */
     for (u = 0; u < FULL_GROUP_NUM_KEEP; u++) {
-        HDsnprintf(objname, sizeof(objname), "/keep/keep %u\n", u);
+        snprintf(objname, sizeof(objname), "/keep/keep %u\n", u);
         if (H5Oget_info_by_name3(file_id, objname, &oi, H5O_INFO_BASIC, H5P_DEFAULT) < 0)
             FAIL_STACK_ERROR;
         if (oi.rc != 1)
@@ -2746,7 +2746,7 @@ test_full_group_dense(hid_t fapl)
 
     /* Create several objects to link to */
     for (u = 0; u < FULL_GROUP_NUM_KEEP; u++) {
-        HDsnprintf(objname, sizeof(objname), "keep %u\n", u);
+        snprintf(objname, sizeof(objname), "keep %u\n", u);
         if ((gid2 = H5Gcreate2(gid, objname, H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT)) < 0)
             FAIL_STACK_ERROR;
         if (H5Gclose(gid2) < 0)
@@ -2798,15 +2798,15 @@ test_full_group_dense(hid_t fapl)
 
     /* Create hard links to objects in group to keep */
     for (u = 0; u < FULL_GROUP_NUM_KEEP; u++) {
-        HDsnprintf(objname, sizeof(objname), "/keep/keep %u\n", u);
-        HDsnprintf(objname2, sizeof(objname2), "keep %u\n", u);
+        snprintf(objname, sizeof(objname), "/keep/keep %u\n", u);
+        snprintf(objname2, sizeof(objname2), "keep %u\n", u);
         if (H5Lcreate_hard(file_id, objname, gid, objname2, H5P_DEFAULT, H5P_DEFAULT) < 0)
             FAIL_STACK_ERROR;
     } /* end for */
 
     /* Create several objects to delete */
     for (u = 0; u < FULL_GROUP_NUM_DELETE_DENSE; u++) {
-        HDsnprintf(objname, sizeof(objname), "delete %u\n", u);
+        snprintf(objname, sizeof(objname), "delete %u\n", u);
         if ((gid2 = H5Gcreate2(gid, objname, H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT)) < 0)
             FAIL_STACK_ERROR;
         if (H5Gclose(gid2) < 0)
@@ -2827,7 +2827,7 @@ test_full_group_dense(hid_t fapl)
 
     /* Check reference count on objects to keep */
     for (u = 0; u < FULL_GROUP_NUM_KEEP; u++) {
-        HDsnprintf(objname, sizeof(objname), "/keep/keep %u\n", u);
+        snprintf(objname, sizeof(objname), "/keep/keep %u\n", u);
         if (H5Oget_info_by_name3(file_id, objname, &oi, H5O_INFO_BASIC, H5P_DEFAULT) < 0)
             FAIL_STACK_ERROR;
         if (oi.rc != 2)
@@ -2848,7 +2848,7 @@ test_full_group_dense(hid_t fapl)
 
     /* Check reference count on objects to keep */
     for (u = 0; u < FULL_GROUP_NUM_KEEP; u++) {
-        HDsnprintf(objname, sizeof(objname), "/keep/keep %u\n", u);
+        snprintf(objname, sizeof(objname), "/keep/keep %u\n", u);
         if (H5Oget_info_by_name3(file_id, objname, &oi, H5O_INFO_BASIC, H5P_DEFAULT) < 0)
             FAIL_STACK_ERROR;
         if (oi.rc != 1)
@@ -2926,11 +2926,11 @@ main(void)
 
         /* Set the FAPL for the type of format */
         if (new_format) {
-            HDputs("\nTesting with new group format:");
+            puts("\nTesting with new group format:");
             my_fapl = fapl2;
         } /* end if */
         else {
-            HDputs("Testing with old group format:");
+            puts("Testing with old group format:");
             my_fapl = fapl;
         } /* end else */
 
@@ -3017,7 +3017,7 @@ main(void)
         exit(EXIT_FAILURE);
     }
 
-    HDputs("All unlink tests passed.");
+    puts("All unlink tests passed.");
 
     h5_cleanup(FILENAME, fapl);
 

--- a/test/unregister.c
+++ b/test/unregister.c
@@ -133,7 +133,7 @@ test_unregister_filters(hid_t fapl_id)
 
     /* Create multiple groups under the main group */
     for (i = 0; i < GROUP_ITERATION; i++) {
-        HDsnprintf(group_name, sizeof(group_name), "group_%d", i);
+        snprintf(group_name, sizeof(group_name), "group_%d", i);
         if ((gid_loop = H5Gcreate2(gid, group_name, H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT)) < 0)
             goto error;
         if (H5Gclose(gid_loop) < 0)

--- a/test/use_append_chunk.c
+++ b/test/use_append_chunk.c
@@ -168,7 +168,7 @@ main(int argc, char *argv[])
     /* ============ */
     if (UC_opts.launch == UC_READWRITE) {
         if ((childpid = fork()) < 0) {
-            HDperror("fork");
+            perror("fork");
             Hgoto_error(1);
         }
     }
@@ -241,7 +241,7 @@ main(int argc, char *argv[])
     /* ================================================ */
     if (UC_opts.launch == UC_READWRITE) {
         if ((tmppid = waitpid(childpid, &child_status, child_wait_option)) < 0) {
-            HDperror("waitpid");
+            perror("waitpid");
             Hgoto_error(1);
         }
 

--- a/test/use_append_chunk_mirror.c
+++ b/test/use_append_chunk_mirror.c
@@ -169,7 +169,7 @@ main(int argc, char *argv[])
     mirr_fa.magic          = H5FD_MIRROR_FAPL_MAGIC;
     mirr_fa.version        = H5FD_MIRROR_CURR_FAPL_T_VERSION;
     mirr_fa.handshake_port = SERVER_PORT;
-    HDstrncpy(mirr_fa.remote_ip, SERVER_IP, H5FD_MIRROR_MAX_IP_LEN);
+    strncpy(mirr_fa.remote_ip, SERVER_IP, H5FD_MIRROR_MAX_IP_LEN);
 
     if (NULL == (split_fa = calloc(1, sizeof(H5FD_splitter_vfd_config_t)))) {
         fprintf(stderr, "can't allocate memory for splitter config\n");
@@ -182,7 +182,7 @@ main(int argc, char *argv[])
     split_fa->version          = H5FD_CURR_SPLITTER_VFD_CONFIG_VERSION;
     split_fa->log_file_path[0] = '\0'; /* none */
     split_fa->ignore_wo_errs   = false;
-    HDstrncpy(split_fa->wo_path, MIRROR_FILE_NAME, H5FD_SPLITTER_PATH_MAX);
+    strncpy(split_fa->wo_path, MIRROR_FILE_NAME, H5FD_SPLITTER_PATH_MAX);
 
     /* Determine the need to send/wait message file*/
     if (UC_opts.launch == UC_READWRITE) {
@@ -259,7 +259,7 @@ main(int argc, char *argv[])
     /* ============ */
     if (UC_opts.launch == UC_READWRITE) {
         if ((childpid = fork()) < 0) {
-            HDperror("fork");
+            perror("fork");
             Hgoto_error(1);
         }
     }
@@ -354,7 +354,7 @@ main(int argc, char *argv[])
     /* ================================================ */
     if (UC_opts.launch == UC_READWRITE) {
         if ((tmppid = waitpid(childpid, &child_status, child_wait_option)) < 0) {
-            HDperror("waitpid");
+            perror("waitpid");
             Hgoto_error(1);
         }
 

--- a/test/use_append_mchunks.c
+++ b/test/use_append_mchunks.c
@@ -162,7 +162,7 @@ main(int argc, char *argv[])
     /* ============ */
     if (UC_opts.launch == UC_READWRITE) {
         if ((childpid = fork()) < 0) {
-            HDperror("fork");
+            perror("fork");
             Hgoto_error(1);
         }
     }
@@ -236,7 +236,7 @@ main(int argc, char *argv[])
     /* ================================================ */
     if (UC_opts.launch == UC_READWRITE) {
         if ((tmppid = waitpid(childpid, &child_status, child_wait_option)) < 0) {
-            HDperror("waitpid");
+            perror("waitpid");
             Hgoto_error(1);
         }
 

--- a/test/use_common.c
+++ b/test/use_common.c
@@ -69,7 +69,7 @@ parse_option(int argc, char *const argv[], options_t *opts)
                 exit(EXIT_SUCCESS);
                 break;
             case 'f': /* usecase data file name */
-                opts->filename = HDstrdup(optarg);
+                opts->filename = strdup(optarg);
                 break;
             case 'i': /* iterations */
                 if ((opts->iterations = atoi(optarg)) <= 0) {
@@ -137,12 +137,12 @@ parse_option(int argc, char *const argv[], options_t *opts)
     /* set test file name if not given */
     if (!opts->filename) {
         /* default data file name is <progname>.h5 */
-        if ((opts->filename = (char *)malloc(HDstrlen(opts->progname) + 4)) == NULL) {
+        if ((opts->filename = (char *)malloc(strlen(opts->progname) + 4)) == NULL) {
             fprintf(stderr, "malloc: failed\n");
             Hgoto_error(-1);
         }
-        HDstrcpy(opts->filename, opts->progname);
-        HDstrcat(opts->filename, ".h5");
+        strcpy(opts->filename, opts->progname);
+        strcat(opts->filename, ".h5");
     }
 
 done:

--- a/test/use_disable_mdc_flushes.c
+++ b/test/use_disable_mdc_flushes.c
@@ -149,12 +149,12 @@ parse_option(int argc, char *const argv[])
     /* set test file name if not given */
     if (!filename_g) {
         /* default data file name is <progname>.h5 */
-        if ((filename_g = (char *)malloc(HDstrlen(progname_g) + 4)) == NULL) {
+        if ((filename_g = (char *)malloc(strlen(progname_g) + 4)) == NULL) {
             fprintf(stderr, "malloc: failed\n");
             Hgoto_error(-1);
         }
-        HDstrcpy(filename_g, progname_g);
-        HDstrcat(filename_g, ".h5");
+        strcpy(filename_g, progname_g);
+        strcat(filename_g, ".h5");
     }
 
 done:

--- a/test/vds.c
+++ b/test/vds.c
@@ -53,7 +53,7 @@ static const char *FILENAME[] = {"vds_virt_0", "vds_virt_1", "vds_src_0",  "vds_
 #define PRINT_CONFIG(...)                                                                                    \
     do {                                                                                                     \
         printf("Config: " __VA_ARGS__);                                                                      \
-        HDputs("");                                                                                          \
+        puts("");                                                                                            \
     } while (0)
 
 #else /* VDS_TEST_VERBOSE */
@@ -65,7 +65,7 @@ char vds_test_str_g[128]   = "";
 /* Replacement for TESTING_2 for non-verbose-output */
 #define TESTING_2_SUPPRESSED(WHAT)                                                                           \
     do {                                                                                                     \
-        HDsnprintf(vds_test_str_g, sizeof(vds_test_str_g), WHAT);                                            \
+        snprintf(vds_test_str_g, sizeof(vds_test_str_g), WHAT);                                              \
     } while (0)
 
 /* Suppress output from PASSED() */
@@ -84,7 +84,7 @@ char vds_test_str_g[128]   = "";
 /* Replacement for printf for printing configuration for non-verbose output */
 #define PRINT_CONFIG(...)                                                                                    \
     do {                                                                                                     \
-        HDsnprintf(vds_config_str_g, sizeof(vds_config_str_g), __VA_ARGS__);                                 \
+        snprintf(vds_config_str_g, sizeof(vds_config_str_g), __VA_ARGS__);                                   \
     } while (0)
 
 #endif /* VDS_TEST_VERBOSE */
@@ -309,27 +309,27 @@ vds_check_mapping(hid_t dcpl, size_t i, hid_t vspace, hid_t srcspace, const char
     /* Check filename */
     if ((str_len = H5Pget_virtual_filename(dcpl, i, NULL, (size_t)0)) < 0)
         TEST_ERROR;
-    if ((size_t)str_len != HDstrlen(filename))
+    if ((size_t)str_len != strlen(filename))
         TEST_ERROR;
     assert((size_t)str_len < sizeof(name_out));
     if ((str_len = H5Pget_virtual_filename(dcpl, i, name_out, sizeof(name_out))) < 0)
         TEST_ERROR;
-    if ((size_t)str_len != HDstrlen(filename))
+    if ((size_t)str_len != strlen(filename))
         TEST_ERROR;
-    if (HDstrncmp(name_out, filename, (size_t)str_len + 1) != 0)
+    if (strncmp(name_out, filename, (size_t)str_len + 1) != 0)
         TEST_ERROR;
 
     /* Check dsetname */
     if ((str_len = H5Pget_virtual_dsetname(dcpl, i, NULL, (size_t)0)) < 0)
         TEST_ERROR;
-    if ((size_t)str_len != HDstrlen(dsetname))
+    if ((size_t)str_len != strlen(dsetname))
         TEST_ERROR;
     assert((size_t)str_len < sizeof(name_out));
     if ((str_len = H5Pget_virtual_dsetname(dcpl, i, name_out, sizeof(name_out))) < 0)
         TEST_ERROR;
-    if ((size_t)str_len != HDstrlen(dsetname))
+    if ((size_t)str_len != strlen(dsetname))
         TEST_ERROR;
-    if (HDstrncmp(name_out, dsetname, (size_t)str_len + 1) != 0)
+    if (strncmp(name_out, dsetname, (size_t)str_len + 1) != 0)
         TEST_ERROR;
 
     return 0;
@@ -1062,9 +1062,9 @@ test_api(test_api_config_t config, hid_t fapl, H5F_libver_t low)
             TEST_ERROR;
 
         /* Create file and dataset names */
-        (void)HDsnprintf(tmp_filename, sizeof(tmp_filename), "src_file%u", i);
+        (void)snprintf(tmp_filename, sizeof(tmp_filename), "src_file%u", i);
         tmp_filename[sizeof(tmp_filename) - 1] = '\0';
-        (void)HDsnprintf(tmp_dsetname, sizeof(tmp_dsetname), "src_dset%u", i);
+        (void)snprintf(tmp_dsetname, sizeof(tmp_dsetname), "src_dset%u", i);
         tmp_dsetname[sizeof(tmp_dsetname) - 1] = '\0';
 
         /* Add virtual layout mapping */
@@ -1086,11 +1086,11 @@ test_api(test_api_config_t config, hid_t fapl, H5F_libver_t low)
     /* Verify virtual layout */
     for (i = 0; i < LIST_DOUBLE_SIZE; i++) {
         /* Generate source file name */
-        (void)HDsnprintf(tmp_filename, sizeof(tmp_filename), "src_file%u", i);
+        (void)snprintf(tmp_filename, sizeof(tmp_filename), "src_file%u", i);
         tmp_filename[sizeof(tmp_filename) - 1] = '\0';
 
         /* Generate source dset name */
-        (void)HDsnprintf(tmp_dsetname, sizeof(tmp_dsetname), "src_dset%u", i);
+        (void)snprintf(tmp_dsetname, sizeof(tmp_dsetname), "src_dset%u", i);
         tmp_dsetname[sizeof(tmp_dsetname) - 1] = '\0';
 
         /* Check that the mapping in the DCPL is correct */
@@ -1247,7 +1247,7 @@ test_vds_prefix_first(unsigned config, hid_t vds_fapl, hid_t src_fapl)
     if (H5Pget_virtual_prefix(dapl, buffer, sizeof(buffer)) < 0)
         TEST_ERROR_SUPPRESSED;
 
-    if (HDstrcmp(buffer, TMPDIR) != 0)
+    if (strcmp(buffer, TMPDIR) != 0)
         FAIL_PUTS_ERROR("vds prefix not set correctly");
 
     /* Create source dataspace */
@@ -12336,8 +12336,8 @@ main(void)
      * doesn't support parallel reads and the splitter VFD has external
      * link-related bugs.
      */
-    if (driver_is_parallel || !HDstrcmp(env_h5_drvr, "splitter")) {
-        HDputs(" -- SKIPPED for incompatible VFD --");
+    if (driver_is_parallel || !strcmp(env_h5_drvr, "splitter")) {
+        puts(" -- SKIPPED for incompatible VFD --");
         exit(EXIT_SUCCESS);
     }
 
@@ -12376,10 +12376,10 @@ main(void)
             /* Display testing info */
             low_string  = h5_get_version_string(low);
             high_string = h5_get_version_string(high);
-            HDsnprintf(msg, sizeof(msg),
-                       "Testing virtual dataset I/O with file version bounds: (%s, %s):", low_string,
-                       high_string);
-            HDputs(msg);
+            snprintf(msg, sizeof(msg),
+                     "Testing virtual dataset I/O with file version bounds: (%s, %s):", low_string,
+                     high_string);
+            puts(msg);
 
             for (test_api_config = (int)TEST_API_BASIC; test_api_config < (int)TEST_API_NTESTS;
                  test_api_config++)
@@ -12387,7 +12387,7 @@ main(void)
 
             TESTING_2("Virtual dataset I/O");
 #ifdef VDS_TEST_VERBOSE
-            HDputs("");
+            puts("");
 #else  /* VDS_TEST_VERBOSE */
             tmp_nerrors = nerrors;
 #endif /* VDS_TEST_VERBOSE */

--- a/test/vds_env.c
+++ b/test/vds_env.c
@@ -111,7 +111,7 @@ test_vds_prefix_second(unsigned config, hid_t fapl)
     if (H5Pget_virtual_prefix(dapl, buffer, sizeof(buffer)) < 0)
         TEST_ERROR;
 
-    if (HDstrcmp(buffer, "someprefix") != 0)
+    if (strcmp(buffer, "someprefix") != 0)
         FAIL_PUTS_ERROR("vds prefix not set correctly");
 
     /* Create source dataspace */
@@ -347,8 +347,8 @@ main(void)
      * doesn't support parallel reads and the splitter VFD has external
      * link-related bugs.
      */
-    if (driver_is_parallel || !HDstrcmp(env_h5_drvr, "splitter")) {
-        HDputs(" -- SKIPPED for incompatible VFD --");
+    if (driver_is_parallel || !strcmp(env_h5_drvr, "splitter")) {
+        puts(" -- SKIPPED for incompatible VFD --");
         exit(EXIT_SUCCESS);
     }
 
@@ -378,10 +378,9 @@ main(void)
             /* Display testing info */
             low_string  = h5_get_version_string(low);
             high_string = h5_get_version_string(high);
-            HDsnprintf(msg, sizeof(msg),
-                       "Testing virtual dataset with file version bounds: (%s, %s):", low_string,
-                       high_string);
-            HDputs(msg);
+            snprintf(msg, sizeof(msg),
+                     "Testing virtual dataset with file version bounds: (%s, %s):", low_string, high_string);
+            puts(msg);
 
             for (bit_config = 0; bit_config < TEST_IO_NTESTS; bit_config++) {
                 printf("Config: %s%s%s\n", bit_config & TEST_IO_CLOSE_SRC ? "closed source dataset, " : "",

--- a/test/vfd.c
+++ b/test/vfd.c
@@ -932,7 +932,7 @@ test_family_opens(char *fname, hid_t fa_pl)
     int   i;
 
     /* Case 1: reopen file with 1st member file name and default property list */
-    HDsnprintf(first_name, sizeof(first_name), fname, 0);
+    snprintf(first_name, sizeof(first_name), fname, 0);
 
     H5E_BEGIN_TRY
     {
@@ -964,7 +964,7 @@ test_family_opens(char *fname, hid_t fa_pl)
         TEST_ERROR;
 
     /* Case 4: reopen file with wrong name template */
-    HDstrcpy(wrong_name, fname);
+    strcpy(wrong_name, fname);
     for (i = 0; i < 1024; i++)
         if (wrong_name[i] == '5') {
             wrong_name[i] = '4';
@@ -1232,19 +1232,19 @@ test_family_compat(void)
     h5_fixname(FILENAME[3], fapl, newname, sizeof(newname));
 
     pathname[0] = '\0';
-    HDstrcat(pathname, filename);
+    strcat(pathname, filename);
 
     /* The following code makes the copies of the family files in the source directory.
      * Since we're going to open the files with write mode, this protects the original
      * files.
      */
-    HDsnprintf(newname_individual, sizeof(newname_individual), newname, counter);
-    HDsnprintf(pathname_individual, sizeof(pathname_individual), pathname, counter);
+    snprintf(newname_individual, sizeof(newname_individual), newname, counter);
+    snprintf(pathname_individual, sizeof(pathname_individual), pathname, counter);
 
     while (h5_make_local_copy(pathname_individual, newname_individual) >= 0) {
         counter++;
-        HDsnprintf(newname_individual, sizeof(newname_individual), newname, counter);
-        HDsnprintf(pathname_individual, sizeof(pathname_individual), pathname, counter);
+        snprintf(newname_individual, sizeof(newname_individual), newname, counter);
+        snprintf(pathname_individual, sizeof(pathname_individual), pathname, counter);
     } /* end while */
 
     /* Make sure we can open the file.  Use the read and write mode to flush the
@@ -1437,8 +1437,8 @@ test_multi_opens(char *fname)
     char  sf_name[1024];    /*name string "multi_file-s.h5"*/
 
     /* Case: reopen with the name of super file and default property list */
-    HDsnprintf(super_name, sizeof(super_name), "%%s-%c.h5", 's');
-    HDsnprintf(sf_name, sizeof(sf_name), super_name, fname);
+    snprintf(super_name, sizeof(super_name), "%%s-%c.h5", 's');
+    snprintf(sf_name, sizeof(sf_name), super_name, fname);
 
     H5E_BEGIN_TRY
     {
@@ -1512,19 +1512,19 @@ test_multi(void)
     memb_map[H5FD_MEM_BTREE] = H5FD_MEM_BTREE;
     memb_map[H5FD_MEM_GHEAP] = H5FD_MEM_GHEAP;
 
-    HDsnprintf(sv[H5FD_MEM_SUPER], 32, "%%s-%c.h5", 's');
+    snprintf(sv[H5FD_MEM_SUPER], 32, "%%s-%c.h5", 's');
     memb_name[H5FD_MEM_SUPER] = sv[H5FD_MEM_SUPER];
     memb_addr[H5FD_MEM_SUPER] = 0;
 
-    HDsnprintf(sv[H5FD_MEM_BTREE], 32, "%%s-%c.h5", 'b');
+    snprintf(sv[H5FD_MEM_BTREE], 32, "%%s-%c.h5", 'b');
     memb_name[H5FD_MEM_BTREE] = sv[H5FD_MEM_BTREE];
     memb_addr[H5FD_MEM_BTREE] = HADDR_MAX / 4;
 
-    HDsnprintf(sv[H5FD_MEM_DRAW], 32, "%%s-%c.h5", 'r');
+    snprintf(sv[H5FD_MEM_DRAW], 32, "%%s-%c.h5", 'r');
     memb_name[H5FD_MEM_DRAW] = sv[H5FD_MEM_DRAW];
     memb_addr[H5FD_MEM_DRAW] = HADDR_MAX / 2;
 
-    HDsnprintf(sv[H5FD_MEM_GHEAP], 32, "%%s-%c.h5", 'g');
+    snprintf(sv[H5FD_MEM_GHEAP], 32, "%%s-%c.h5", 'g');
     memb_name[H5FD_MEM_GHEAP] = sv[H5FD_MEM_GHEAP];
     memb_addr[H5FD_MEM_GHEAP] = (HADDR_MAX / 4) * 3;
 
@@ -1641,7 +1641,7 @@ test_multi(void)
     if ((atype = H5Tcopy(H5T_C_S1)) < 0)
         TEST_ERROR;
 
-    if (H5Tset_size(atype, HDstrlen(meta) + 1) < 0)
+    if (H5Tset_size(atype, strlen(meta) + 1) < 0)
         TEST_ERROR;
 
     if (H5Tset_strpad(atype, H5T_STR_NULLTERM) < 0)
@@ -1758,12 +1758,12 @@ test_multi_compat(void)
     memb_map[H5FD_MEM_DRAW] = H5FD_MEM_DRAW;
 
     memb_fapl[H5FD_MEM_SUPER] = H5P_DEFAULT;
-    HDsnprintf(sv[H5FD_MEM_SUPER], 32, "%%s-%c.h5", 's');
+    snprintf(sv[H5FD_MEM_SUPER], 32, "%%s-%c.h5", 's');
     memb_name[H5FD_MEM_SUPER] = sv[H5FD_MEM_SUPER];
     memb_addr[H5FD_MEM_SUPER] = 0;
 
     memb_fapl[H5FD_MEM_DRAW] = H5P_DEFAULT;
-    HDsnprintf(sv[H5FD_MEM_DRAW], 32, "%%s-%c.h5", 'r');
+    snprintf(sv[H5FD_MEM_DRAW], 32, "%%s-%c.h5", 'r');
     memb_name[H5FD_MEM_DRAW] = sv[H5FD_MEM_DRAW];
     memb_addr[H5FD_MEM_DRAW] = HADDR_MAX / 2;
 
@@ -1775,12 +1775,12 @@ test_multi_compat(void)
     /* Make copy for the data file in the build directory, to protect the
      * original file in the source directory
      */
-    HDsnprintf(filename_s, sizeof(filename_s), "%s-%c.h5", MULTI_COMPAT_BASENAME, 's');
-    HDsnprintf(newname_s, sizeof(newname_s), "%s-%c.h5", FILENAME[9], 's');
+    snprintf(filename_s, sizeof(filename_s), "%s-%c.h5", MULTI_COMPAT_BASENAME, 's');
+    snprintf(newname_s, sizeof(newname_s), "%s-%c.h5", FILENAME[9], 's');
     h5_make_local_copy(filename_s, newname_s);
 
-    HDsnprintf(filename_r, sizeof(filename_r), "%s-%c.h5", MULTI_COMPAT_BASENAME, 'r');
-    HDsnprintf(newname_r, sizeof(newname_r), "%s-%c.h5", FILENAME[9], 'r');
+    snprintf(filename_r, sizeof(filename_r), "%s-%c.h5", MULTI_COMPAT_BASENAME, 'r');
+    snprintf(newname_r, sizeof(newname_r), "%s-%c.h5", FILENAME[9], 'r');
     h5_make_local_copy(filename_r, newname_r);
 
     /* Reopen the file for read only.  Verify 1.8 library can open file
@@ -2295,9 +2295,9 @@ test_ros3(void)
     /* need a macro to compare instances of H5FD_ros3_fapl_t */
     if ((test_ros3_fa.version != ros3_fa_0.version) ||
         (test_ros3_fa.authenticate != ros3_fa_0.authenticate) ||
-        (HDstrcmp(test_ros3_fa.aws_region, ros3_fa_0.aws_region) != 0) ||
-        (HDstrcmp(test_ros3_fa.secret_id, ros3_fa_0.secret_id) != 0) ||
-        (HDstrcmp(test_ros3_fa.secret_key, ros3_fa_0.secret_key) != 0))
+        (strcmp(test_ros3_fa.aws_region, ros3_fa_0.aws_region) != 0) ||
+        (strcmp(test_ros3_fa.secret_id, ros3_fa_0.secret_id) != 0) ||
+        (strcmp(test_ros3_fa.secret_key, ros3_fa_0.secret_key) != 0))
         TEST_ERROR;
 
     h5_fixname(FILENAME[10], fapl_id, filename, sizeof(filename));
@@ -2399,8 +2399,8 @@ compare_splitter_config_info(hid_t fapl_id, H5FD_splitter_vfd_config_t *info)
             SPLITTER_TEST_FAULT("Write-Only driver mismatch\n");
         }
     }
-    if ((HDstrlen(info->wo_path) != HDstrlen(fetched_info->wo_path)) ||
-        HDstrncmp(info->wo_path, fetched_info->wo_path, H5FD_SPLITTER_PATH_MAX) != 0) {
+    if ((strlen(info->wo_path) != strlen(fetched_info->wo_path)) ||
+        strncmp(info->wo_path, fetched_info->wo_path, H5FD_SPLITTER_PATH_MAX) != 0) {
         fprintf(stderr, "MISMATCH: '%s' :: '%s'\n", info->wo_path, fetched_info->wo_path);
         HEXPRINT(H5FD_SPLITTER_PATH_MAX, info->wo_path);
         HEXPRINT(H5FD_SPLITTER_PATH_MAX, fetched_info->wo_path);
@@ -2622,7 +2622,7 @@ driver_is_splitter_compatible(hid_t fapl_id)
     vfd_config->ignore_wo_errs = false;
     vfd_config->rw_fapl_id     = H5P_DEFAULT;
     vfd_config->wo_fapl_id     = fapl_id;
-    HDstrncpy(vfd_config->wo_path, "nonesuch", H5FD_SPLITTER_PATH_MAX);
+    strncpy(vfd_config->wo_path, "nonesuch", H5FD_SPLITTER_PATH_MAX);
     vfd_config->log_file_path[0] = '\0';
 
     H5E_BEGIN_TRY
@@ -3705,7 +3705,7 @@ test_ctl(void)
     hid_t                       sub_fapl_id = H5I_INVALID_HID;
 
     TESTING("VFD ctl callback");
-    HDputs("");
+    puts("");
 
     /* Register VFD for test */
     if ((driver_id = H5FDregister(&H5FD_ctl_test_vfd_g)) < 0)
@@ -4519,7 +4519,7 @@ test_vector_io(const char *vfd_name)
     void       *f_read_bufs_1[VECTOR_LEN];      /* fixed read bufs vector       */
     void       *f_read_bufs_2[VECTOR_LEN];      /* fixed read bufs vector       */
 
-    HDsnprintf(test_title, sizeof(test_title), "vector I/O with %s VFD", vfd_name);
+    snprintf(test_title, sizeof(test_title), "vector I/O with %s VFD", vfd_name);
 
     TESTING(test_title);
 
@@ -4528,14 +4528,14 @@ test_vector_io(const char *vfd_name)
     if ((fapl_id = H5Pcreate(H5P_FILE_ACCESS)) < 0)
         TEST_ERROR;
 
-    if (HDstrcmp(vfd_name, "sec2") == 0) {
+    if (strcmp(vfd_name, "sec2") == 0) {
 
         if (H5Pset_fapl_sec2(fapl_id) < 0)
             TEST_ERROR;
 
         h5_fixname(FILENAME[0], fapl_id, filename, sizeof(filename));
     }
-    else if (HDstrcmp(vfd_name, "stdio") == 0) {
+    else if (strcmp(vfd_name, "stdio") == 0) {
 
         if (H5Pset_fapl_stdio(fapl_id) < 0)
             TEST_ERROR;
@@ -5052,7 +5052,7 @@ test_selection_io(const char *vfd_name)
     int       *erbufs[2] = {erbuf1, erbuf2[0]};                     /* Array of expected read buffers */
     int        shorten_element_sizes; /* Whether to shorten the element sizes array */
 
-    HDsnprintf(test_title, sizeof(test_title), "selection I/O with %s VFD", vfd_name);
+    snprintf(test_title, sizeof(test_title), "selection I/O with %s VFD", vfd_name);
 
     TESTING(test_title);
 
@@ -5061,14 +5061,14 @@ test_selection_io(const char *vfd_name)
     if ((fapl_id = H5Pcreate(H5P_FILE_ACCESS)) < 0)
         TEST_ERROR;
 
-    if (HDstrcmp(vfd_name, "sec2") == 0) {
+    if (strcmp(vfd_name, "sec2") == 0) {
 
         if (H5Pset_fapl_sec2(fapl_id) < 0)
             TEST_ERROR;
 
         h5_fixname(FILENAME[0], fapl_id, filename, sizeof(filename));
     }
-    else if (HDstrcmp(vfd_name, "stdio") == 0) {
+    else if (strcmp(vfd_name, "stdio") == 0) {
 
         if (H5Pset_fapl_stdio(fapl_id) < 0)
             TEST_ERROR;

--- a/test/vfd_plugin.c
+++ b/test/vfd_plugin.c
@@ -297,7 +297,7 @@ test_get_config_str(void)
         TEST_ERROR;
     if (0 != config_str_len)
         TEST_ERROR;
-    if (HDstrlen(config_str_buf) > 0)
+    if (strlen(config_str_buf) > 0)
         TEST_ERROR;
 
     /* Set a new configuration string on the FAPL and retrieve it */
@@ -305,9 +305,9 @@ test_get_config_str(void)
         TEST_ERROR;
     if ((config_str_len = H5Pget_driver_config_str(fapl_id, config_str_buf, 128)) < 0)
         TEST_ERROR;
-    if (HDstrlen(config_str) != config_str_len)
+    if (strlen(config_str) != config_str_len)
         TEST_ERROR;
-    if (HDstrncmp(config_str_buf, config_str, 128))
+    if (strncmp(config_str_buf, config_str, 128))
         TEST_ERROR;
 
     if (H5Pclose(fapl_id) < 0)
@@ -355,7 +355,7 @@ test_env_var(void)
         TEST_ERROR;
     if (0 != config_str_len)
         TEST_ERROR;
-    if (HDstrlen(config_str_buf) > 0)
+    if (strlen(config_str_buf) > 0)
         TEST_ERROR;
 
     /* Set default driver and driver configuration using environment variables */
@@ -382,9 +382,9 @@ test_env_var(void)
     memset(config_str_buf, 0, 128);
     if ((config_str_len = H5Pget_driver_config_str(H5P_FILE_ACCESS_DEFAULT, config_str_buf, 128)) < 0)
         TEST_ERROR;
-    if (HDstrlen(config_str) != config_str_len)
+    if (strlen(config_str) != config_str_len)
         TEST_ERROR;
-    if (HDstrncmp(config_str_buf, config_str, 128))
+    if (strncmp(config_str_buf, config_str, 128))
         TEST_ERROR;
 
     /* Unset environment variables */
@@ -420,7 +420,7 @@ main(void)
 
     h5_reset();
 
-    HDputs("Testing VFD plugin functionality.");
+    puts("Testing VFD plugin functionality.");
 
     nerrors += (test_set_by_name() < 0) ? 1 : 0;
     nerrors += (test_set_by_value() < 0) ? 1 : 0;
@@ -433,7 +433,7 @@ main(void)
         exit(EXIT_FAILURE);
     }
 
-    HDputs("All VFD plugin tests passed.");
+    puts("All VFD plugin tests passed.");
 
     exit(EXIT_SUCCESS);
 }

--- a/test/vol.c
+++ b/test/vol.c
@@ -517,7 +517,7 @@ reg_opt_link_optional(void *obj, const H5VL_loc_params_t *loc_params, H5VL_optio
         return -1;
     if (loc_params->obj_type != H5I_GROUP)
         return -1;
-    if (HDstrcmp(loc_params->loc_data.loc_by_name.name, ".") != 0)
+    if (strcmp(loc_params->loc_data.loc_by_name.name, ".") != 0)
         return -1;
     if (loc_params->loc_data.loc_by_name.lapl_id != H5P_LINK_ACCESS_DEFAULT)
         return -1;
@@ -587,7 +587,7 @@ fake_vol_info_to_str(const void *info, char **str)
     if (NULL == (*str = (char *)calloc(1, str_size)))
         return FAIL;
 
-    HDsnprintf(*str, str_size, "%d", val);
+    snprintf(*str, str_size, "%d", val);
 
     return ret_value;
 } /* end fake_vol_info_to_str() */
@@ -913,10 +913,10 @@ test_basic_file_operation(const char *env_h5_drvr)
         TEST_ERROR;
 
     /* Can't compare VFD properties for several VFDs */
-    if ((bool)(HDstrcmp(env_h5_drvr, "split") != 0 && HDstrcmp(env_h5_drvr, "multi") != 0 &&
-               HDstrcmp(env_h5_drvr, "family") != 0 && HDstrcmp(env_h5_drvr, "direct") != 0 &&
-               HDstrcmp(env_h5_drvr, "core") != 0 && HDstrcmp(env_h5_drvr, "core_paged") != 0 &&
-               HDstrcmp(env_h5_drvr, "mpio") != 0 && HDstrcmp(env_h5_drvr, "splitter") != 0)) {
+    if ((bool)(strcmp(env_h5_drvr, "split") != 0 && strcmp(env_h5_drvr, "multi") != 0 &&
+               strcmp(env_h5_drvr, "family") != 0 && strcmp(env_h5_drvr, "direct") != 0 &&
+               strcmp(env_h5_drvr, "core") != 0 && strcmp(env_h5_drvr, "core_paged") != 0 &&
+               strcmp(env_h5_drvr, "mpio") != 0 && strcmp(env_h5_drvr, "splitter") != 0)) {
         /* H5Fget_access_plist */
         if ((fapl_id2 = H5Fget_access_plist(fid)) < 0)
             TEST_ERROR;
@@ -937,8 +937,8 @@ test_basic_file_operation(const char *env_h5_drvr)
         TEST_ERROR;
 
     /* Can't retrieve VFD handle for split / multi / family VFDs */
-    if ((bool)(HDstrcmp(env_h5_drvr, "split") != 0 && HDstrcmp(env_h5_drvr, "multi") != 0 &&
-               HDstrcmp(env_h5_drvr, "family") != 0)) {
+    if ((bool)(strcmp(env_h5_drvr, "split") != 0 && strcmp(env_h5_drvr, "multi") != 0 &&
+               strcmp(env_h5_drvr, "family") != 0)) {
         /* H5Fget_vfd_handle */
         if (H5Fget_vfd_handle(fid, H5P_DEFAULT, &os_file_handle) < 0)
             TEST_ERROR;
@@ -977,10 +977,10 @@ test_basic_file_operation(const char *env_h5_drvr)
         TEST_ERROR;
 
     /* Can't compare VFD properties for several VFDs */
-    if ((bool)(HDstrcmp(env_h5_drvr, "split") != 0 && HDstrcmp(env_h5_drvr, "multi") != 0 &&
-               HDstrcmp(env_h5_drvr, "family") != 0 && HDstrcmp(env_h5_drvr, "direct") != 0 &&
-               HDstrcmp(env_h5_drvr, "core") != 0 && HDstrcmp(env_h5_drvr, "core_paged") != 0 &&
-               HDstrcmp(env_h5_drvr, "mpio") != 0 && HDstrcmp(env_h5_drvr, "splitter") != 0)) {
+    if ((bool)(strcmp(env_h5_drvr, "split") != 0 && strcmp(env_h5_drvr, "multi") != 0 &&
+               strcmp(env_h5_drvr, "family") != 0 && strcmp(env_h5_drvr, "direct") != 0 &&
+               strcmp(env_h5_drvr, "core") != 0 && strcmp(env_h5_drvr, "core_paged") != 0 &&
+               strcmp(env_h5_drvr, "mpio") != 0 && strcmp(env_h5_drvr, "splitter") != 0)) {
         /* H5Fget_access_plist */
         if ((fapl_id2 = H5Fget_access_plist(fid)) < 0)
             TEST_ERROR;
@@ -994,10 +994,10 @@ test_basic_file_operation(const char *env_h5_drvr)
         TEST_ERROR;
 
     /* Can't compare VFD properties for several VFDs */
-    if ((bool)(HDstrcmp(env_h5_drvr, "split") != 0 && HDstrcmp(env_h5_drvr, "multi") != 0 &&
-               HDstrcmp(env_h5_drvr, "family") != 0 && HDstrcmp(env_h5_drvr, "direct") != 0 &&
-               HDstrcmp(env_h5_drvr, "core") != 0 && HDstrcmp(env_h5_drvr, "core_paged") != 0 &&
-               HDstrcmp(env_h5_drvr, "mpio") != 0 && HDstrcmp(env_h5_drvr, "splitter") != 0)) {
+    if ((bool)(strcmp(env_h5_drvr, "split") != 0 && strcmp(env_h5_drvr, "multi") != 0 &&
+               strcmp(env_h5_drvr, "family") != 0 && strcmp(env_h5_drvr, "direct") != 0 &&
+               strcmp(env_h5_drvr, "core") != 0 && strcmp(env_h5_drvr, "core_paged") != 0 &&
+               strcmp(env_h5_drvr, "mpio") != 0 && strcmp(env_h5_drvr, "splitter") != 0)) {
         /* H5Fget_access_plist */
         if ((fapl_id2 = H5Fget_access_plist(fid_reopen)) < 0)
             TEST_ERROR;
@@ -1733,7 +1733,7 @@ exercise_reg_opt_oper(hid_t fake_vol_id, hid_t reg_opt_vol_id, H5VL_subclass_t s
     herr_t               ret = SUCCEED;
 
     /* Test registering optional operation */
-    HDsnprintf(op_name, sizeof(op_name), "%s-op1", subcls_name);
+    snprintf(op_name, sizeof(op_name), "%s-op1", subcls_name);
     if (H5VLregister_opt_operation(subcls, op_name, &op_val) < 0)
         TEST_ERROR;
 
@@ -1752,7 +1752,7 @@ exercise_reg_opt_oper(hid_t fake_vol_id, hid_t reg_opt_vol_id, H5VL_subclass_t s
         TEST_ERROR;
 
     /* Test registering second optional operation */
-    HDsnprintf(op_name, sizeof(op_name), "%s-op2", subcls_name);
+    snprintf(op_name, sizeof(op_name), "%s-op2", subcls_name);
     if (H5VLregister_opt_operation(subcls, op_name, &op_val2) < 0)
         TEST_ERROR;
 
@@ -2095,7 +2095,7 @@ test_async_vol_props(void)
     /* Override possible environment variable & re-initialize default VOL connector */
     conn_env_str = HDgetenv(HDF5_VOL_CONNECTOR);
     if (conn_env_str) {
-        if (NULL == (conn_env_str = HDstrdup(conn_env_str)))
+        if (NULL == (conn_env_str = strdup(conn_env_str)))
             TEST_ERROR;
         if (HDunsetenv(HDF5_VOL_CONNECTOR) < 0)
             TEST_ERROR;
@@ -2257,7 +2257,7 @@ test_vol_cap_flags(void)
 
     /* If using the native VOL by default, check flags again with H5P_DEFAULT */
     vol_env = HDgetenv(HDF5_VOL_CONNECTOR);
-    if (!vol_env || (0 == HDstrcmp(vol_env, "native"))) {
+    if (!vol_env || (0 == strcmp(vol_env, "native"))) {
         H5VL_class_t *cls;
         hid_t         connector_id;
 
@@ -2343,7 +2343,7 @@ test_get_vol_name(void)
         conn_env_str = "native";
 
     /* Skip the connectors other than the native and pass_through connector */
-    if (HDstrcmp(conn_env_str, "native") && HDstrcmp(conn_env_str, "pass_through")) {
+    if (strcmp(conn_env_str, "native") && strcmp(conn_env_str, "pass_through")) {
         SKIPPED();
         printf("    only test the native or internal pass_through connector\n");
         return SUCCEED;
@@ -2361,8 +2361,8 @@ test_get_vol_name(void)
         TEST_ERROR;
 
     /* When comparing the pass_through connector, ignore the rest information (under_vol=0;under_info={}) */
-    if ((!HDstrcmp(conn_env_str, "native") && HDstrcmp(vol_name, "native")) ||
-        (!HDstrcmp(conn_env_str, "pass_through") && HDstrcmp(vol_name, "pass_through")))
+    if ((!strcmp(conn_env_str, "native") && strcmp(vol_name, "native")) ||
+        (!strcmp(conn_env_str, "pass_through") && strcmp(vol_name, "pass_through")))
         TEST_ERROR;
 
     if (H5Fclose(file_id) < 0)
@@ -2635,7 +2635,7 @@ main(void)
 
     h5_reset();
 
-    HDputs("Testing basic Virtual Object Layer (VOL) functionality.");
+    puts("Testing basic Virtual Object Layer (VOL) functionality.");
 
     nerrors += test_vol_registration() < 0 ? 1 : 0;
     nerrors += test_register_opt_operation() < 0 ? 1 : 0;
@@ -2659,7 +2659,7 @@ main(void)
         exit(EXIT_FAILURE);
     }
 
-    HDputs("All Virtual Object Layer (VOL) tests passed.");
+    puts("All Virtual Object Layer (VOL) tests passed.");
 
     exit(EXIT_SUCCESS);
 

--- a/test/vol_plugin.c
+++ b/test/vol_plugin.c
@@ -334,7 +334,7 @@ main(void)
 
     h5_reset();
 
-    HDputs("Testing VOL connector plugin functionality.");
+    puts("Testing VOL connector plugin functionality.");
 
     nerrors += test_registration_by_name() < 0 ? 1 : 0;
     nerrors += test_registration_by_value() < 0 ? 1 : 0;
@@ -346,7 +346,7 @@ main(void)
         exit(EXIT_FAILURE);
     }
 
-    HDputs("All VOL connector plugin tests passed.");
+    puts("All VOL connector plugin tests passed.");
 
     exit(EXIT_SUCCESS);
 

--- a/testpar/API/H5_api_test_parallel.c
+++ b/testpar/API/H5_api_test_parallel.c
@@ -239,8 +239,8 @@ main(int argc, char **argv)
     if (NULL == (test_path_prefix = HDgetenv(HDF5_API_TEST_PATH_PREFIX)))
         test_path_prefix = "";
 
-    HDsnprintf(H5_api_test_parallel_filename, H5_API_TEST_FILENAME_MAX_LENGTH, "%s%s", test_path_prefix,
-               PARALLEL_TEST_FILE_NAME);
+    snprintf(H5_api_test_parallel_filename, H5_API_TEST_FILENAME_MAX_LENGTH, "%s%s", test_path_prefix,
+             PARALLEL_TEST_FILE_NAME);
 
     if (NULL == (vol_connector_string = HDgetenv(HDF5_VOL_CONNECTOR))) {
         if (MAINPROCESS)
@@ -253,7 +253,7 @@ main(int argc, char **argv)
 
         BEGIN_INDEPENDENT_OP(copy_connector_string)
         {
-            if (NULL == (vol_connector_string_copy = HDstrdup(vol_connector_string))) {
+            if (NULL == (vol_connector_string_copy = strdup(vol_connector_string))) {
                 if (MAINPROCESS)
                     fprintf(stderr, "Unable to copy VOL connector string\n");
                 INDEPENDENT_OP_ERROR(copy_connector_string);
@@ -263,7 +263,7 @@ main(int argc, char **argv)
 
         BEGIN_INDEPENDENT_OP(get_connector_name)
         {
-            if (NULL == (token = HDstrtok(vol_connector_string_copy, " "))) {
+            if (NULL == (token = strtok(vol_connector_string_copy, " "))) {
                 if (MAINPROCESS)
                     fprintf(stderr, "Error while parsing VOL connector string\n");
                 INDEPENDENT_OP_ERROR(get_connector_name);
@@ -273,7 +273,7 @@ main(int argc, char **argv)
 
         vol_connector_name = token;
 
-        if (NULL != (token = HDstrtok(NULL, " "))) {
+        if (NULL != (token = strtok(NULL, " "))) {
             vol_connector_info = token;
         }
     }
@@ -307,7 +307,7 @@ main(int argc, char **argv)
          * Otherwise, HDF5 will default to running the tests
          * with the native connector, which could be misleading.
          */
-        if (0 != HDstrcmp(vol_connector_name, "native")) {
+        if (0 != strcmp(vol_connector_name, "native")) {
             htri_t is_registered;
 
             if ((is_registered = H5VLis_connector_registered_by_name(vol_connector_name)) < 0) {

--- a/testpar/API/H5_api_test_parallel.h
+++ b/testpar/API/H5_api_test_parallel.h
@@ -139,7 +139,7 @@ extern char H5_api_test_parallel_filename[];
     {                                                                                                        \
         if (MAINPROCESS) {                                                                                   \
             printf("Testing %-62s", WHAT);                                                                   \
-            HDputs("");                                                                                      \
+            puts("");                                                                                        \
             fflush(stdout);                                                                                  \
         }                                                                                                    \
     }

--- a/testpar/API/t_dset.c
+++ b/testpar/API/t_dset.c
@@ -3401,10 +3401,10 @@ test_actual_io_mode(int selection_mode)
     /* Test values */
     if (actual_chunk_opt_mode_expected != (H5D_mpio_actual_chunk_opt_mode_t)-1 &&
         actual_io_mode_expected != (H5D_mpio_actual_io_mode_t)-1) {
-        HDsnprintf(message, sizeof(message), "Actual Chunk Opt Mode has the correct value for %s.\n",
-                   test_name);
+        snprintf(message, sizeof(message), "Actual Chunk Opt Mode has the correct value for %s.\n",
+                 test_name);
         VRFY((actual_chunk_opt_mode_write == actual_chunk_opt_mode_expected), message);
-        HDsnprintf(message, sizeof(message), "Actual IO Mode has the correct value for %s.\n", test_name);
+        snprintf(message, sizeof(message), "Actual IO Mode has the correct value for %s.\n", test_name);
         VRFY((actual_io_mode_write == actual_io_mode_expected), message);
     }
     else {
@@ -3822,12 +3822,12 @@ test_no_collective_cause_mode(int selection_mode)
 
     /* Test values */
     memset(message, 0, sizeof(message));
-    HDsnprintf(message, sizeof(message),
-               "Local cause of Broken Collective I/O has the correct value for %s.\n", test_name);
+    snprintf(message, sizeof(message), "Local cause of Broken Collective I/O has the correct value for %s.\n",
+             test_name);
     VRFY((no_collective_cause_local_write == no_collective_cause_local_expected), message);
     memset(message, 0, sizeof(message));
-    HDsnprintf(message, sizeof(message),
-               "Global cause of Broken Collective I/O has the correct value for %s.\n", test_name);
+    snprintf(message, sizeof(message),
+             "Global cause of Broken Collective I/O has the correct value for %s.\n", test_name);
     VRFY((no_collective_cause_global_write == no_collective_cause_global_expected), message);
 
     /* Release some resources */

--- a/testpar/API/t_file.c
+++ b/testpar/API/t_file.c
@@ -529,25 +529,25 @@ create_file(const char *filename, hid_t fcpl, hid_t fapl, int metadata_write_str
     VRFY((mem_dataspace >= 0), "");
 
     for (k = 0; k < NUM_DSETS; k++) {
-        HDsnprintf(dset_name, sizeof(dset_name), "D1dset%d", k);
+        snprintf(dset_name, sizeof(dset_name), "D1dset%d", k);
         dset_id = H5Dcreate2(grp_id, dset_name, H5T_NATIVE_INT, sid, H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT);
         VRFY((dset_id >= 0), "");
         ret = H5Dclose(dset_id);
         VRFY((ret == 0), "");
 
-        HDsnprintf(dset_name, sizeof(dset_name), "D2dset%d", k);
+        snprintf(dset_name, sizeof(dset_name), "D2dset%d", k);
         dset_id = H5Dcreate2(grp_id, dset_name, H5T_NATIVE_INT, sid, H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT);
         VRFY((dset_id >= 0), "");
         ret = H5Dclose(dset_id);
         VRFY((ret == 0), "");
 
-        HDsnprintf(dset_name, sizeof(dset_name), "D3dset%d", k);
+        snprintf(dset_name, sizeof(dset_name), "D3dset%d", k);
         dset_id = H5Dcreate2(grp_id, dset_name, H5T_NATIVE_INT, sid, H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT);
         VRFY((dset_id >= 0), "");
         ret = H5Dclose(dset_id);
         VRFY((ret == 0), "");
 
-        HDsnprintf(dset_name, sizeof(dset_name), "dset%d", k);
+        snprintf(dset_name, sizeof(dset_name), "dset%d", k);
         dset_id = H5Dcreate2(grp_id, dset_name, H5T_NATIVE_INT, sid, H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT);
         VRFY((dset_id >= 0), "");
 
@@ -570,13 +570,13 @@ create_file(const char *filename, hid_t fcpl, hid_t fapl, int metadata_write_str
         for (i = 0; i < num_elements; i++)
             VRFY((data_array[i] == mpi_rank + 1), "Dataset Verify failed");
 
-        HDsnprintf(dset_name, sizeof(dset_name), "D1dset%d", k);
+        snprintf(dset_name, sizeof(dset_name), "D1dset%d", k);
         ret = H5Ldelete(grp_id, dset_name, H5P_DEFAULT);
         VRFY((ret == 0), "");
-        HDsnprintf(dset_name, sizeof(dset_name), "D2dset%d", k);
+        snprintf(dset_name, sizeof(dset_name), "D2dset%d", k);
         ret = H5Ldelete(grp_id, dset_name, H5P_DEFAULT);
         VRFY((ret == 0), "");
-        HDsnprintf(dset_name, sizeof(dset_name), "D3dset%d", k);
+        snprintf(dset_name, sizeof(dset_name), "D3dset%d", k);
         ret = H5Ldelete(grp_id, dset_name, H5P_DEFAULT);
         VRFY((ret == 0), "");
     }
@@ -682,7 +682,7 @@ open_file(const char *filename, hid_t fapl, int metadata_write_strategy, hsize_t
     VRFY((mem_dataspace >= 0), "");
 
     for (k = 0; k < NUM_DSETS; k++) {
-        HDsnprintf(dset_name, sizeof(dset_name), "dset%d", k);
+        snprintf(dset_name, sizeof(dset_name), "dset%d", k);
         dset_id = H5Dopen2(grp_id, dset_name, H5P_DEFAULT);
         VRFY((dset_id >= 0), "");
 

--- a/testpar/API/t_file_image.c
+++ b/testpar/API/t_file_image.c
@@ -100,7 +100,7 @@ file_image_daisy_chain_test(void)
     }
 
     /* setup file name */
-    HDsnprintf(file_name, 1024, "file_image_daisy_chain_test_%05d.h5", (int)mpi_rank);
+    snprintf(file_name, 1024, "file_image_daisy_chain_test_%05d.h5", (int)mpi_rank);
 
     if (mpi_rank == 0) {
 

--- a/testpar/API/t_mdset.c
+++ b/testpar/API/t_mdset.c
@@ -211,7 +211,7 @@ multiple_dset_write(void)
     VRFY((ret >= 0), "set fill-value succeeded");
 
     for (n = 0; n < ndatasets; n++) {
-        HDsnprintf(dname, sizeof(dname), "dataset %d", n);
+        snprintf(dname, sizeof(dname), "dataset %d", n);
         dataset = H5Dcreate2(iof, dname, H5T_NATIVE_DOUBLE, filespace, H5P_DEFAULT, dcpl, H5P_DEFAULT);
         VRFY((dataset > 0), dname);
 
@@ -975,11 +975,11 @@ collective_group_write(void)
     /* creates ngroups groups under the root group, writes chunked
      * datasets in parallel. */
     for (m = 0; m < ngroups; m++) {
-        HDsnprintf(gname, sizeof(gname), "group%d", m);
+        snprintf(gname, sizeof(gname), "group%d", m);
         gid = H5Gcreate2(fid, gname, H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT);
         VRFY((gid > 0), gname);
 
-        HDsnprintf(dname, sizeof(dname), "dataset%d", m);
+        snprintf(dname, sizeof(dname), "dataset%d", m);
         did = H5Dcreate2(gid, dname, H5T_NATIVE_INT, filespace, H5P_DEFAULT, dcpl, H5P_DEFAULT);
         VRFY((did > 0), dname);
 
@@ -1093,12 +1093,12 @@ group_dataset_read(hid_t fid, int mpi_rank, int m)
     VRFY((outdata != NULL), "malloc succeeded for outdata");
 
     /* open every group under root group. */
-    HDsnprintf(gname, sizeof(gname), "group%d", m);
+    snprintf(gname, sizeof(gname), "group%d", m);
     gid = H5Gopen2(fid, gname, H5P_DEFAULT);
     VRFY((gid > 0), gname);
 
     /* check the data. */
-    HDsnprintf(dname, sizeof(dname), "dataset%d", m);
+    snprintf(dname, sizeof(dname), "dataset%d", m);
     did = H5Dopen2(gid, dname, H5P_DEFAULT);
     VRFY((did > 0), dname);
 
@@ -1211,7 +1211,7 @@ multiple_group_write(void)
     /* creates ngroups groups under the root group, writes datasets in
      * parallel. */
     for (m = 0; m < ngroups; m++) {
-        HDsnprintf(gname, sizeof(gname), "group%d", m);
+        snprintf(gname, sizeof(gname), "group%d", m);
         gid = H5Gcreate2(fid, gname, H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT);
         VRFY((gid > 0), gname);
 
@@ -1267,7 +1267,7 @@ write_dataset(hid_t memspace, hid_t filespace, hid_t gid)
     VRFY((outme != NULL), "malloc succeeded for outme");
 
     for (n = 0; n < NDATASET; n++) {
-        HDsnprintf(dname, sizeof(dname), "dataset%d", n);
+        snprintf(dname, sizeof(dname), "dataset%d", n);
         did = H5Dcreate2(gid, dname, H5T_NATIVE_INT, filespace, H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT);
         VRFY((did > 0), dname);
 
@@ -1305,7 +1305,7 @@ create_group_recursive(hid_t memspace, hid_t filespace, hid_t gid, int counter)
     }
 #endif /* BARRIER_CHECKS */
 
-    HDsnprintf(gname, sizeof(gname), "%dth_child_group", counter + 1);
+    snprintf(gname, sizeof(gname), "%dth_child_group", counter + 1);
     child_gid = H5Gcreate2(gid, gname, H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT);
     VRFY((child_gid > 0), gname);
 
@@ -1376,7 +1376,7 @@ multiple_group_read(void)
 
     /* open every group under root group. */
     for (m = 0; m < ngroups; m++) {
-        HDsnprintf(gname, sizeof(gname), "group%d", m);
+        snprintf(gname, sizeof(gname), "group%d", m);
         gid = H5Gopen2(fid, gname, H5P_DEFAULT);
         VRFY((gid > 0), gname);
 
@@ -1433,7 +1433,7 @@ read_dataset(hid_t memspace, hid_t filespace, hid_t gid)
     VRFY((outdata != NULL), "malloc succeeded for outdata");
 
     for (n = 0; n < NDATASET; n++) {
-        HDsnprintf(dname, sizeof(dname), "dataset%d", n);
+        snprintf(dname, sizeof(dname), "dataset%d", n);
         did = H5Dopen2(gid, dname, H5P_DEFAULT);
         VRFY((did > 0), dname);
 
@@ -1484,7 +1484,7 @@ recursive_read_group(hid_t memspace, hid_t filespace, hid_t gid, int counter)
         nerrors += err_num;
 
     if (counter < GROUP_DEPTH) {
-        HDsnprintf(gname, sizeof(gname), "%dth_child_group", counter + 1);
+        snprintf(gname, sizeof(gname), "%dth_child_group", counter + 1);
         child_gid = H5Gopen2(gid, gname, H5P_DEFAULT);
         VRFY((child_gid > 0), gname);
         recursive_read_group(memspace, filespace, child_gid, counter + 1);
@@ -1506,7 +1506,7 @@ write_attribute(hid_t obj_id, int this_type, int num)
     MPI_Comm_rank(MPI_COMM_WORLD, &mpi_rank);
 
     if (this_type == is_group) {
-        HDsnprintf(attr_name, sizeof(attr_name), "Group Attribute %d", num);
+        snprintf(attr_name, sizeof(attr_name), "Group Attribute %d", num);
         sid = H5Screate(H5S_SCALAR);
         aid = H5Acreate2(obj_id, attr_name, H5T_NATIVE_INT, sid, H5P_DEFAULT, H5P_DEFAULT);
         H5Awrite(aid, H5T_NATIVE_INT, &num);
@@ -1514,7 +1514,7 @@ write_attribute(hid_t obj_id, int this_type, int num)
         H5Sclose(sid);
     } /* end if */
     else if (this_type == is_dset) {
-        HDsnprintf(attr_name, sizeof(attr_name), "Dataset Attribute %d", num);
+        snprintf(attr_name, sizeof(attr_name), "Dataset Attribute %d", num);
         for (i = 0; i < 8; i++)
             attr_data[i] = i;
         sid = H5Screate_simple(dspace_rank, dspace_dims, NULL);
@@ -1537,14 +1537,14 @@ read_attribute(hid_t obj_id, int this_type, int num)
     MPI_Comm_rank(MPI_COMM_WORLD, &mpi_rank);
 
     if (this_type == is_group) {
-        HDsnprintf(attr_name, sizeof(attr_name), "Group Attribute %d", num);
+        snprintf(attr_name, sizeof(attr_name), "Group Attribute %d", num);
         aid = H5Aopen(obj_id, attr_name, H5P_DEFAULT);
         H5Aread(aid, H5T_NATIVE_INT, &in_num);
         vrfy_errors = dataset_vrfy(NULL, NULL, NULL, group_block, &in_num, &num);
         H5Aclose(aid);
     }
     else if (this_type == is_dset) {
-        HDsnprintf(attr_name, sizeof(attr_name), "Dataset Attribute %d", num);
+        snprintf(attr_name, sizeof(attr_name), "Dataset Attribute %d", num);
         for (i = 0; i < 8; i++)
             out_data[i] = i;
         aid = H5Aopen(obj_id, attr_name, H5P_DEFAULT);

--- a/testpar/API/t_prop.c
+++ b/testpar/API/t_prop.c
@@ -569,7 +569,7 @@ external_links(void)
 
             /* test opening a group that is to an external link, the external linked
                file should inherit the source file's access properties */
-            HDsnprintf(link_path, sizeof(link_path), "%s%s%s", group_path, "/", link_name);
+            snprintf(link_path, sizeof(link_path), "%s%s%s", group_path, "/", link_name);
             group = H5Gopen2(fid, link_path, H5P_DEFAULT);
             VRFY((group >= 0), "H5Gopen succeeded");
             ret = H5Gclose(group);

--- a/testpar/t_2Gio.c
+++ b/testpar/t_2Gio.c
@@ -3693,10 +3693,10 @@ test_actual_io_mode(int selection_mode)
     /* Test values */
     if (actual_chunk_opt_mode_expected != (H5D_mpio_actual_chunk_opt_mode_t)-1 &&
         actual_io_mode_expected != (H5D_mpio_actual_io_mode_t)-1) {
-        HDsnprintf(message, sizeof(message), "Actual Chunk Opt Mode has the correct value for %s.\n",
-                   test_name);
+        snprintf(message, sizeof(message), "Actual Chunk Opt Mode has the correct value for %s.\n",
+                 test_name);
         VRFY((actual_chunk_opt_mode_write == actual_chunk_opt_mode_expected), message);
-        HDsnprintf(message, sizeof(message), "Actual IO Mode has the correct value for %s.\n", test_name);
+        snprintf(message, sizeof(message), "Actual IO Mode has the correct value for %s.\n", test_name);
         VRFY((actual_io_mode_write == actual_io_mode_expected), message);
     }
     else {
@@ -4135,12 +4135,12 @@ test_no_collective_cause_mode(int selection_mode)
 
     /* Test values */
     memset(message, 0, sizeof(message));
-    HDsnprintf(message, sizeof(message),
-               "Local cause of Broken Collective I/O has the correct value for %s.\n", test_name);
+    snprintf(message, sizeof(message), "Local cause of Broken Collective I/O has the correct value for %s.\n",
+             test_name);
     VRFY((no_collective_cause_local_write == no_collective_cause_local_expected), message);
     memset(message, 0, sizeof(message));
-    HDsnprintf(message, sizeof(message),
-               "Global cause of Broken Collective I/O has the correct value for %s.\n", test_name);
+    snprintf(message, sizeof(message),
+             "Global cause of Broken Collective I/O has the correct value for %s.\n", test_name);
     VRFY((no_collective_cause_global_write == no_collective_cause_global_expected), message);
 
     /* Release some resources */

--- a/testpar/t_cache.c
+++ b/testpar/t_cache.c
@@ -6273,7 +6273,7 @@ trace_file_check(int metadata_write_strategy)
         } /* end if */
 
         if (nerrors == 0) {
-            HDsnprintf(trace_file_name, sizeof(trace_file_name), "t_cache_trace.txt.%d", (int)file_mpi_rank);
+            snprintf(trace_file_name, sizeof(trace_file_name), "t_cache_trace.txt.%d", (int)file_mpi_rank);
 
             if ((trace_file_ptr = fopen(trace_file_name, "r")) == NULL) {
 
@@ -6289,10 +6289,10 @@ trace_file_check(int metadata_write_strategy)
             if ((*expected_output)[i] == NULL)
                 expected_line_len = (size_t)0;
             else
-                expected_line_len = HDstrlen((*expected_output)[i]);
+                expected_line_len = strlen((*expected_output)[i]);
 
-            if (HDfgets(buffer, 255, trace_file_ptr) != NULL)
-                actual_line_len = HDstrlen(buffer);
+            if (fgets(buffer, 255, trace_file_ptr) != NULL)
+                actual_line_len = strlen(buffer);
             else
                 actual_line_len = (size_t)0;
 
@@ -6327,8 +6327,7 @@ trace_file_check(int metadata_write_strategy)
             }
             /* We directly compare the header line (line 0) */
             else if (0 == i) {
-                if ((actual_line_len != expected_line_len) ||
-                    (HDstrcmp(buffer, (*expected_output)[i]) != 0)) {
+                if ((actual_line_len != expected_line_len) || (strcmp(buffer, (*expected_output)[i]) != 0)) {
 
                     nerrors++;
                     if (verbose) {
@@ -6347,9 +6346,9 @@ trace_file_check(int metadata_write_strategy)
             else {
                 char *tok = NULL; /* token for actual line */
 
-                tok = HDstrtok(buffer, " ");
+                tok = strtok(buffer, " ");
 
-                if (HDstrcmp(tok, (*expected_output)[i]) != 0) {
+                if (strcmp(tok, (*expected_output)[i]) != 0) {
 
                     nerrors++;
                     if (verbose) {

--- a/testpar/t_cache_image.c
+++ b/testpar/t_cache_image.c
@@ -457,7 +457,7 @@ create_data_sets(hid_t file_id, int min_dset, int max_dset)
             /* create the dataset */
             if (pass) {
 
-                HDsnprintf(dset_name, sizeof(dset_name), "/dset%03d", i);
+                snprintf(dset_name, sizeof(dset_name), "/dset%03d", i);
                 dataset_ids[i] = H5Dcreate2(file_id, dset_name, H5T_STD_I32BE, dataspace_id, H5P_DEFAULT,
                                             properties, H5P_DEFAULT);
 
@@ -738,7 +738,7 @@ delete_data_sets(hid_t file_id, int min_dset, int max_dset)
 
         while ( ( pass ) && ( i <= max_dset ) )
         {
-            HDsnprintf(dset_name, sizeof(dset_name), "/dset%03d", i);
+            snprintf(dset_name, sizeof(dset_name), "/dset%03d", i);
 
         if ( H5Ldelete(file_id, dset_name, H5P_DEFAULT) < 0) {
 
@@ -1287,7 +1287,7 @@ par_create_dataset(int dset_num, hid_t file_id, int mpi_rank, int mpi_size)
     show_progress = (show_progress && (mpi_rank == 0));
     verbose       = (verbose && (mpi_rank == 0));
 
-    HDsnprintf(dset_name, sizeof(dset_name), "/dset%03d", dset_num);
+    snprintf(dset_name, sizeof(dset_name), "/dset%03d", dset_num);
 
     if (show_progress) {
         fprintf(stdout, "%s: dset name = \"%s\".\n", fcn_name, dset_name);
@@ -1653,7 +1653,7 @@ par_delete_dataset(int dset_num, hid_t file_id, int mpi_rank)
 
     show_progress = (show_progress && (mpi_rank == 0));
 
-    HDsnprintf(dset_name, sizeof(dset_name), "/dset%03d", dset_num);
+    snprintf(dset_name, sizeof(dset_name), "/dset%03d", dset_num);
 
     if (show_progress) {
         fprintf(stdout, "%s: dset name = \"%s\".\n", fcn_name, dset_name);
@@ -1772,7 +1772,7 @@ par_verify_dataset(int dset_num, hid_t file_id, int mpi_rank)
     show_progress = (show_progress && (mpi_rank == 0));
     verbose       = (verbose && (mpi_rank == 0));
 
-    HDsnprintf(dset_name, sizeof(dset_name), "/dset%03d", dset_num);
+    snprintf(dset_name, sizeof(dset_name), "/dset%03d", dset_num);
 
     if (show_progress) {
         fprintf(stdout, "%s: dset name = \"%s\".\n", fcn_name, dset_name);
@@ -2126,7 +2126,7 @@ serial_verify_dataset(int dset_num, hid_t file_id, int mpi_size)
     hid_t       dset_id      = H5I_INVALID_HID;
     hid_t       filespace_id = H5I_INVALID_HID;
 
-    HDsnprintf(dset_name, sizeof(dset_name), "/dset%03d", dset_num);
+    snprintf(dset_name, sizeof(dset_name), "/dset%03d", dset_num);
 
     if (show_progress) {
         fprintf(stdout, "%s: dset name = \"%s\".\n", fcn_name, dset_name);
@@ -2367,7 +2367,7 @@ verify_data_sets(hid_t file_id, int min_dset, int max_dset)
             /* open the dataset */
             if (pass) {
 
-                HDsnprintf(dset_name, sizeof(dset_name), "/dset%03d", i);
+                snprintf(dset_name, sizeof(dset_name), "/dset%03d", i);
                 dataset_ids[i] = H5Dopen2(file_id, dset_name, H5P_DEFAULT);
 
                 if (dataset_ids[i] < 0) {

--- a/testpar/t_dset.c
+++ b/testpar/t_dset.c
@@ -3251,10 +3251,10 @@ test_actual_io_mode(int selection_mode)
     /* Test values */
     if (actual_chunk_opt_mode_expected != (H5D_mpio_actual_chunk_opt_mode_t)-1 &&
         actual_io_mode_expected != (H5D_mpio_actual_io_mode_t)-1) {
-        HDsnprintf(message, sizeof(message), "Actual Chunk Opt Mode has the correct value for %s.\n",
-                   test_name);
+        snprintf(message, sizeof(message), "Actual Chunk Opt Mode has the correct value for %s.\n",
+                 test_name);
         VRFY((actual_chunk_opt_mode_write == actual_chunk_opt_mode_expected), message);
-        HDsnprintf(message, sizeof(message), "Actual IO Mode has the correct value for %s.\n", test_name);
+        snprintf(message, sizeof(message), "Actual IO Mode has the correct value for %s.\n", test_name);
         VRFY((actual_io_mode_write == actual_io_mode_expected), message);
     }
     else {
@@ -3728,12 +3728,12 @@ test_no_collective_cause_mode(int selection_mode)
 
     /* Test values */
     memset(message, 0, sizeof(message));
-    HDsnprintf(message, sizeof(message),
-               "Local cause of Broken Collective I/O has the correct value for %s.\n", test_name);
+    snprintf(message, sizeof(message), "Local cause of Broken Collective I/O has the correct value for %s.\n",
+             test_name);
     VRFY((no_collective_cause_local_write == no_collective_cause_local_expected), message);
     memset(message, 0, sizeof(message));
-    HDsnprintf(message, sizeof(message),
-               "Global cause of Broken Collective I/O has the correct value for %s.\n", test_name);
+    snprintf(message, sizeof(message),
+             "Global cause of Broken Collective I/O has the correct value for %s.\n", test_name);
     VRFY((no_collective_cause_global_write == no_collective_cause_global_expected), message);
 
     /* Release some resources */

--- a/testpar/t_file.c
+++ b/testpar/t_file.c
@@ -514,25 +514,25 @@ create_file(const char *filename, hid_t fcpl, hid_t fapl, int metadata_write_str
     VRFY((mem_dataspace >= 0), "");
 
     for (k = 0; k < NUM_DSETS; k++) {
-        HDsnprintf(dset_name, sizeof(dset_name), "D1dset%d", k);
+        snprintf(dset_name, sizeof(dset_name), "D1dset%d", k);
         dset_id = H5Dcreate2(grp_id, dset_name, H5T_NATIVE_INT, sid, H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT);
         VRFY((dset_id >= 0), "");
         ret = H5Dclose(dset_id);
         VRFY((ret == 0), "");
 
-        HDsnprintf(dset_name, sizeof(dset_name), "D2dset%d", k);
+        snprintf(dset_name, sizeof(dset_name), "D2dset%d", k);
         dset_id = H5Dcreate2(grp_id, dset_name, H5T_NATIVE_INT, sid, H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT);
         VRFY((dset_id >= 0), "");
         ret = H5Dclose(dset_id);
         VRFY((ret == 0), "");
 
-        HDsnprintf(dset_name, sizeof(dset_name), "D3dset%d", k);
+        snprintf(dset_name, sizeof(dset_name), "D3dset%d", k);
         dset_id = H5Dcreate2(grp_id, dset_name, H5T_NATIVE_INT, sid, H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT);
         VRFY((dset_id >= 0), "");
         ret = H5Dclose(dset_id);
         VRFY((ret == 0), "");
 
-        HDsnprintf(dset_name, sizeof(dset_name), "dset%d", k);
+        snprintf(dset_name, sizeof(dset_name), "dset%d", k);
         dset_id = H5Dcreate2(grp_id, dset_name, H5T_NATIVE_INT, sid, H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT);
         VRFY((dset_id >= 0), "");
 
@@ -555,13 +555,13 @@ create_file(const char *filename, hid_t fcpl, hid_t fapl, int metadata_write_str
         for (i = 0; i < num_elements; i++)
             VRFY((data_array[i] == mpi_rank + 1), "Dataset Verify failed");
 
-        HDsnprintf(dset_name, sizeof(dset_name), "D1dset%d", k);
+        snprintf(dset_name, sizeof(dset_name), "D1dset%d", k);
         ret = H5Ldelete(grp_id, dset_name, H5P_DEFAULT);
         VRFY((ret == 0), "");
-        HDsnprintf(dset_name, sizeof(dset_name), "D2dset%d", k);
+        snprintf(dset_name, sizeof(dset_name), "D2dset%d", k);
         ret = H5Ldelete(grp_id, dset_name, H5P_DEFAULT);
         VRFY((ret == 0), "");
-        HDsnprintf(dset_name, sizeof(dset_name), "D3dset%d", k);
+        snprintf(dset_name, sizeof(dset_name), "D3dset%d", k);
         ret = H5Ldelete(grp_id, dset_name, H5P_DEFAULT);
         VRFY((ret == 0), "");
     }
@@ -666,7 +666,7 @@ open_file(const char *filename, hid_t fapl, int metadata_write_strategy, hsize_t
     VRFY((mem_dataspace >= 0), "");
 
     for (k = 0; k < NUM_DSETS; k++) {
-        HDsnprintf(dset_name, sizeof(dset_name), "dset%d", k);
+        snprintf(dset_name, sizeof(dset_name), "dset%d", k);
         dset_id = H5Dopen2(grp_id, dset_name, H5P_DEFAULT);
         VRFY((dset_id >= 0), "");
 

--- a/testpar/t_file_image.c
+++ b/testpar/t_file_image.c
@@ -85,7 +85,7 @@ file_image_daisy_chain_test(void)
     MPI_Comm_rank(MPI_COMM_WORLD, &mpi_rank);
 
     /* setup file name */
-    HDsnprintf(file_name, 1024, "file_image_daisy_chain_test_%05d.h5", (int)mpi_rank);
+    snprintf(file_name, 1024, "file_image_daisy_chain_test_%05d.h5", (int)mpi_rank);
 
     if (mpi_rank == 0) {
 

--- a/testpar/t_filters_parallel.c
+++ b/testpar/t_filters_parallel.c
@@ -415,7 +415,7 @@ test_write_one_chunk_filtered_dataset(const char *parent_group, H5Z_filter_t fil
     hid_t       filespace = H5I_INVALID_HID, memspace = H5I_INVALID_HID;
 
     if (MAINPROCESS)
-        HDputs("Testing write to one-chunk filtered dataset");
+        puts("Testing write to one-chunk filtered dataset");
 
     file_id = H5Fopen(filenames[0], H5F_ACC_RDWR, fapl_id);
     VRFY((file_id >= 0), "Test file open succeeded");
@@ -567,7 +567,7 @@ test_write_filtered_dataset_no_overlap(const char *parent_group, H5Z_filter_t fi
     hid_t       filespace = H5I_INVALID_HID, memspace = H5I_INVALID_HID;
 
     if (MAINPROCESS)
-        HDputs("Testing write to unshared filtered chunks");
+        puts("Testing write to unshared filtered chunks");
 
     file_id = H5Fopen(filenames[0], H5F_ACC_RDWR, fapl_id);
     VRFY((file_id >= 0), "Test file open succeeded");
@@ -716,7 +716,7 @@ test_write_filtered_dataset_no_overlap_partial(const char *parent_group, H5Z_fil
     hid_t       filespace = H5I_INVALID_HID;
 
     if (MAINPROCESS)
-        HDputs("Testing partial write to unshared filtered chunks");
+        puts("Testing partial write to unshared filtered chunks");
 
     file_id = H5Fopen(filenames[0], H5F_ACC_RDWR, fapl_id);
     VRFY((file_id >= 0), "Test file open succeeded");
@@ -874,7 +874,7 @@ test_write_filtered_dataset_overlap(const char *parent_group, H5Z_filter_t filte
     hid_t       filespace = H5I_INVALID_HID, memspace = H5I_INVALID_HID;
 
     if (MAINPROCESS)
-        HDputs("Testing write to shared filtered chunks");
+        puts("Testing write to shared filtered chunks");
 
     file_id = H5Fopen(filenames[0], H5F_ACC_RDWR, fapl_id);
     VRFY((file_id >= 0), "Test file open succeeded");
@@ -1027,7 +1027,7 @@ test_write_filtered_dataset_single_unlim_dim_no_overlap(const char *parent_group
     hid_t       filespace = H5I_INVALID_HID;
 
     if (MAINPROCESS)
-        HDputs("Testing write to unshared filtered chunks w/ single unlimited dimension");
+        puts("Testing write to unshared filtered chunks w/ single unlimited dimension");
 
     file_id = H5Fopen(filenames[0], H5F_ACC_RDWR, fapl_id);
     VRFY((file_id >= 0), "Test file open succeeded");
@@ -1181,7 +1181,7 @@ test_write_filtered_dataset_single_unlim_dim_overlap(const char *parent_group, H
     hid_t       filespace = H5I_INVALID_HID;
 
     if (MAINPROCESS)
-        HDputs("Testing write to shared filtered chunks w/ single unlimited dimension");
+        puts("Testing write to shared filtered chunks w/ single unlimited dimension");
 
     file_id = H5Fopen(filenames[0], H5F_ACC_RDWR, fapl_id);
     VRFY((file_id >= 0), "Test file open succeeded");
@@ -1336,7 +1336,7 @@ test_write_filtered_dataset_multi_unlim_dim_no_overlap(const char *parent_group,
     hid_t       filespace = H5I_INVALID_HID;
 
     if (MAINPROCESS)
-        HDputs("Testing write to unshared filtered chunks w/ two unlimited dimensions");
+        puts("Testing write to unshared filtered chunks w/ two unlimited dimensions");
 
     file_id = H5Fopen(filenames[0], H5F_ACC_RDWR, fapl_id);
     VRFY((file_id >= 0), "Test file open succeeded");
@@ -1503,7 +1503,7 @@ test_write_filtered_dataset_multi_unlim_dim_overlap(const char *parent_group, H5
     hid_t       filespace = H5I_INVALID_HID;
 
     if (MAINPROCESS)
-        HDputs("Testing write to shared filtered chunks w/ two unlimited dimensions");
+        puts("Testing write to shared filtered chunks w/ two unlimited dimensions");
 
     file_id = H5Fopen(filenames[0], H5F_ACC_RDWR, fapl_id);
     VRFY((file_id >= 0), "Test file open succeeded");
@@ -1669,7 +1669,7 @@ test_write_filtered_dataset_single_no_selection(const char *parent_group, H5Z_fi
     hid_t       filespace = H5I_INVALID_HID, memspace = H5I_INVALID_HID;
 
     if (MAINPROCESS)
-        HDputs("Testing write to filtered chunks with a single process having no selection");
+        puts("Testing write to filtered chunks with a single process having no selection");
 
     file_id = H5Fopen(filenames[0], H5F_ACC_RDWR, fapl_id);
     VRFY((file_id >= 0), "Test file open succeeded");
@@ -1833,7 +1833,7 @@ test_write_filtered_dataset_all_no_selection(const char *parent_group, H5Z_filte
     hid_t       filespace = H5I_INVALID_HID, memspace = H5I_INVALID_HID;
 
     if (MAINPROCESS)
-        HDputs("Testing write to filtered chunks with all processes having no selection");
+        puts("Testing write to filtered chunks with all processes having no selection");
 
     file_id = H5Fopen(filenames[0], H5F_ACC_RDWR, fapl_id);
     VRFY((file_id >= 0), "Test file open succeeded");
@@ -1952,7 +1952,7 @@ test_write_filtered_dataset_point_selection(const char *parent_group, H5Z_filter
     hid_t       filespace = H5I_INVALID_HID, memspace = H5I_INVALID_HID;
 
     if (MAINPROCESS)
-        HDputs("Testing write to filtered chunks with point selection");
+        puts("Testing write to filtered chunks with point selection");
 
     file_id = H5Fopen(filenames[0], H5F_ACC_RDWR, fapl_id);
     VRFY((file_id >= 0), "Test file open succeeded");
@@ -2100,7 +2100,7 @@ test_write_filtered_dataset_interleaved_write(const char *parent_group, H5Z_filt
     hid_t       filespace = H5I_INVALID_HID, memspace = H5I_INVALID_HID;
 
     if (MAINPROCESS)
-        HDputs("Testing interleaved write to filtered chunks");
+        puts("Testing interleaved write to filtered chunks");
 
     file_id = H5Fopen(filenames[0], H5F_ACC_RDWR, fapl_id);
     VRFY((file_id >= 0), "Test file open succeeded");
@@ -2269,7 +2269,7 @@ test_write_transformed_filtered_dataset_no_overlap(const char *parent_group, H5Z
     hid_t       filespace = H5I_INVALID_HID, memspace = H5I_INVALID_HID;
 
     if (MAINPROCESS)
-        HDputs("Testing write to unshared transformed and filtered chunks");
+        puts("Testing write to unshared transformed and filtered chunks");
 
     file_id = H5Fopen(filenames[0], H5F_ACC_RDWR, fapl_id);
     VRFY((file_id >= 0), "Test file open succeeded");
@@ -2431,7 +2431,7 @@ test_write_3d_filtered_dataset_no_overlap_separate_pages(const char *parent_grou
     hid_t       filespace = H5I_INVALID_HID, memspace = H5I_INVALID_HID;
 
     if (MAINPROCESS)
-        HDputs("Testing write to unshared filtered chunks on separate pages in 3D dataset");
+        puts("Testing write to unshared filtered chunks on separate pages in 3D dataset");
 
     file_id = H5Fopen(filenames[0], H5F_ACC_RDWR, fapl_id);
     VRFY((file_id >= 0), "Test file open succeeded");
@@ -2591,7 +2591,7 @@ test_write_3d_filtered_dataset_no_overlap_same_pages(const char *parent_group, H
     hid_t       filespace = H5I_INVALID_HID, memspace = H5I_INVALID_HID;
 
     if (MAINPROCESS)
-        HDputs("Testing write to unshared filtered chunks on the same pages in 3D dataset");
+        puts("Testing write to unshared filtered chunks on the same pages in 3D dataset");
 
     file_id = H5Fopen(filenames[0], H5F_ACC_RDWR, fapl_id);
     VRFY((file_id >= 0), "Test file open succeeded");
@@ -2752,7 +2752,7 @@ test_write_3d_filtered_dataset_overlap(const char *parent_group, H5Z_filter_t fi
     hid_t       filespace = H5I_INVALID_HID, memspace = H5I_INVALID_HID;
 
     if (MAINPROCESS)
-        HDputs("Testing write to shared filtered chunks in 3D dataset");
+        puts("Testing write to shared filtered chunks in 3D dataset");
 
     file_id = H5Fopen(filenames[0], H5F_ACC_RDWR, fapl_id);
     VRFY((file_id >= 0), "Test file open succeeded");
@@ -2925,8 +2925,8 @@ test_write_cmpd_filtered_dataset_no_conversion_unshared(const char *parent_group
     hid_t filespace = H5I_INVALID_HID, memspace = H5I_INVALID_HID;
 
     if (MAINPROCESS)
-        HDputs("Testing write to unshared filtered chunks in Compound Datatype dataset without Datatype "
-               "conversion");
+        puts("Testing write to unshared filtered chunks in Compound Datatype dataset without Datatype "
+             "conversion");
 
     /* SZIP and ScaleOffset filters don't support compound types */
     if (filter_id == H5Z_FILTER_SZIP || filter_id == H5Z_FILTER_SCALEOFFSET) {
@@ -3104,8 +3104,8 @@ test_write_cmpd_filtered_dataset_no_conversion_shared(const char *parent_group, 
     hid_t filespace = H5I_INVALID_HID, memspace = H5I_INVALID_HID;
 
     if (MAINPROCESS)
-        HDputs("Testing write to shared filtered chunks in Compound Datatype dataset without Datatype "
-               "conversion");
+        puts("Testing write to shared filtered chunks in Compound Datatype dataset without Datatype "
+             "conversion");
 
     /* SZIP and ScaleOffset filters don't support compound types */
     if (filter_id == H5Z_FILTER_SZIP || filter_id == H5Z_FILTER_SCALEOFFSET) {
@@ -3295,8 +3295,8 @@ test_write_cmpd_filtered_dataset_type_conversion_unshared(const char *parent_gro
     hid_t filespace = H5I_INVALID_HID, memspace = H5I_INVALID_HID;
 
     if (MAINPROCESS)
-        HDputs("Testing write to unshared filtered chunks in Compound Datatype dataset with Datatype "
-               "conversion");
+        puts("Testing write to unshared filtered chunks in Compound Datatype dataset with Datatype "
+             "conversion");
 
     /* Skip for MPI communicator size of 1 */
     if (mpi_size == 1) {
@@ -3492,8 +3492,7 @@ test_write_cmpd_filtered_dataset_type_conversion_shared(const char *parent_group
     hid_t                filespace = H5I_INVALID_HID, memspace = H5I_INVALID_HID;
 
     if (MAINPROCESS)
-        HDputs(
-            "Testing write to shared filtered chunks in Compound Datatype dataset with Datatype conversion");
+        puts("Testing write to shared filtered chunks in Compound Datatype dataset with Datatype conversion");
 
     /* Skip for MPI communicator size of 1 */
     if (mpi_size == 1) {
@@ -3690,7 +3689,7 @@ test_read_one_chunk_filtered_dataset(const char *parent_group, H5Z_filter_t filt
     int        *displs     = NULL;
 
     if (MAINPROCESS)
-        HDputs("Testing read from one-chunk filtered dataset");
+        puts("Testing read from one-chunk filtered dataset");
 
     dataset_dims[0] = (hsize_t)READ_ONE_CHUNK_FILTERED_DATASET_NROWS;
     dataset_dims[1] = (hsize_t)READ_ONE_CHUNK_FILTERED_DATASET_NCOLS;
@@ -3889,7 +3888,7 @@ test_read_filtered_dataset_no_overlap(const char *parent_group, H5Z_filter_t fil
     int        *displs     = NULL;
 
     if (MAINPROCESS)
-        HDputs("Testing read from unshared filtered chunks");
+        puts("Testing read from unshared filtered chunks");
 
     dataset_dims[0] = (hsize_t)READ_UNSHARED_FILTERED_CHUNKS_NROWS;
     dataset_dims[1] = (hsize_t)READ_UNSHARED_FILTERED_CHUNKS_NCOLS;
@@ -4088,7 +4087,7 @@ test_read_filtered_dataset_overlap(const char *parent_group, H5Z_filter_t filter
     int        *displs     = NULL;
 
     if (MAINPROCESS)
-        HDputs("Testing read from shared filtered chunks");
+        puts("Testing read from shared filtered chunks");
 
     dataset_dims[0] = (hsize_t)READ_SHARED_FILTERED_CHUNKS_NROWS;
     dataset_dims[1] = (hsize_t)READ_SHARED_FILTERED_CHUNKS_NCOLS;
@@ -4305,7 +4304,7 @@ test_read_filtered_dataset_single_no_selection(const char *parent_group, H5Z_fil
     int        *displs     = NULL;
 
     if (MAINPROCESS)
-        HDputs("Testing read from filtered chunks with a single process having no selection");
+        puts("Testing read from filtered chunks with a single process having no selection");
 
     dataset_dims[0] = (hsize_t)READ_SINGLE_NO_SELECTION_FILTERED_CHUNKS_NROWS;
     dataset_dims[1] = (hsize_t)READ_SINGLE_NO_SELECTION_FILTERED_CHUNKS_NCOLS;
@@ -4523,7 +4522,7 @@ test_read_filtered_dataset_all_no_selection(const char *parent_group, H5Z_filter
     hid_t       filespace = H5I_INVALID_HID, memspace = H5I_INVALID_HID;
 
     if (MAINPROCESS)
-        HDputs("Testing read from filtered chunks with all processes having no selection");
+        puts("Testing read from filtered chunks with all processes having no selection");
 
     dataset_dims[0] = (hsize_t)READ_ALL_NO_SELECTION_FILTERED_CHUNKS_NROWS;
     dataset_dims[1] = (hsize_t)READ_ALL_NO_SELECTION_FILTERED_CHUNKS_NCOLS;
@@ -4663,7 +4662,7 @@ test_read_filtered_dataset_point_selection(const char *parent_group, H5Z_filter_
     int        *displs     = NULL;
 
     if (MAINPROCESS)
-        HDputs("Testing read from filtered chunks with point selection");
+        puts("Testing read from filtered chunks with point selection");
 
     dataset_dims[0] = (hsize_t)READ_POINT_SELECTION_FILTERED_CHUNKS_NROWS;
     dataset_dims[1] = (hsize_t)READ_POINT_SELECTION_FILTERED_CHUNKS_NCOLS;
@@ -4877,7 +4876,7 @@ test_read_filtered_dataset_interleaved_read(const char *parent_group, H5Z_filter
     int        *displs     = NULL;
 
     if (MAINPROCESS)
-        HDputs("Testing interleaved read from filtered chunks");
+        puts("Testing interleaved read from filtered chunks");
 
     dataset_dims[0] = (hsize_t)INTERLEAVED_READ_FILTERED_DATASET_NROWS;
     dataset_dims[1] = (hsize_t)INTERLEAVED_READ_FILTERED_DATASET_NCOLS;
@@ -5103,7 +5102,7 @@ test_read_3d_filtered_dataset_no_overlap_separate_pages(const char *parent_group
     hid_t        filespace = H5I_INVALID_HID, memspace = H5I_INVALID_HID;
 
     if (MAINPROCESS)
-        HDputs("Testing read from unshared filtered chunks on separate pages in 3D dataset");
+        puts("Testing read from unshared filtered chunks on separate pages in 3D dataset");
 
     dataset_dims[0] = (hsize_t)READ_UNSHARED_FILTERED_CHUNKS_3D_SEP_PAGE_NROWS;
     dataset_dims[1] = (hsize_t)READ_UNSHARED_FILTERED_CHUNKS_3D_SEP_PAGE_NCOLS;
@@ -5320,7 +5319,7 @@ test_read_transformed_filtered_dataset_no_overlap(const char *parent_group, H5Z_
     int        *displs     = NULL;
 
     if (MAINPROCESS)
-        HDputs("Testing read from unshared transformed and filtered chunks");
+        puts("Testing read from unshared transformed and filtered chunks");
 
     dataset_dims[0] = (hsize_t)READ_UNSHARED_TRANSFORMED_FILTERED_CHUNKS_NROWS;
     dataset_dims[1] = (hsize_t)READ_UNSHARED_TRANSFORMED_FILTERED_CHUNKS_NCOLS;
@@ -5543,7 +5542,7 @@ test_read_3d_filtered_dataset_no_overlap_same_pages(const char *parent_group, H5
     int        *displs     = NULL;
 
     if (MAINPROCESS)
-        HDputs("Testing read from unshared filtered chunks on the same pages in 3D dataset");
+        puts("Testing read from unshared filtered chunks on the same pages in 3D dataset");
 
     dataset_dims[0] = (hsize_t)READ_UNSHARED_FILTERED_CHUNKS_3D_SAME_PAGE_NROWS;
     dataset_dims[1] = (hsize_t)READ_UNSHARED_FILTERED_CHUNKS_3D_SAME_PAGE_NCOLS;
@@ -5752,7 +5751,7 @@ test_read_3d_filtered_dataset_overlap(const char *parent_group, H5Z_filter_t fil
     hid_t        filespace = H5I_INVALID_HID, memspace = H5I_INVALID_HID;
 
     if (MAINPROCESS)
-        HDputs("Testing read from shared filtered chunks in 3D dataset");
+        puts("Testing read from shared filtered chunks in 3D dataset");
 
     dataset_dims[0] = (hsize_t)READ_SHARED_FILTERED_CHUNKS_3D_NROWS;
     dataset_dims[1] = (hsize_t)READ_SHARED_FILTERED_CHUNKS_3D_NCOLS;
@@ -5983,8 +5982,8 @@ test_read_cmpd_filtered_dataset_no_conversion_unshared(const char *parent_group,
     int  *displs     = NULL;
 
     if (MAINPROCESS)
-        HDputs("Testing read from unshared filtered chunks in Compound Datatype dataset without Datatype "
-               "conversion");
+        puts("Testing read from unshared filtered chunks in Compound Datatype dataset without Datatype "
+             "conversion");
 
     /* SZIP and ScaleOffset filters don't support compound types */
     if (filter_id == H5Z_FILTER_SZIP || filter_id == H5Z_FILTER_SCALEOFFSET) {
@@ -6208,8 +6207,8 @@ test_read_cmpd_filtered_dataset_no_conversion_shared(const char *parent_group, H
     int  *displs     = NULL;
 
     if (MAINPROCESS)
-        HDputs("Testing read from shared filtered chunks in Compound Datatype dataset without Datatype "
-               "conversion");
+        puts("Testing read from shared filtered chunks in Compound Datatype dataset without Datatype "
+             "conversion");
 
     /* SZIP and ScaleOffset filters don't support compound types */
     if (filter_id == H5Z_FILTER_SZIP || filter_id == H5Z_FILTER_SCALEOFFSET) {
@@ -6439,8 +6438,8 @@ test_read_cmpd_filtered_dataset_type_conversion_unshared(const char *parent_grou
     int                 *displs     = NULL;
 
     if (MAINPROCESS)
-        HDputs("Testing read from unshared filtered chunks in Compound Datatype dataset with Datatype "
-               "conversion");
+        puts("Testing read from unshared filtered chunks in Compound Datatype dataset with Datatype "
+             "conversion");
 
     /* SZIP and ScaleOffset filters don't support compound types */
     if (filter_id == H5Z_FILTER_SZIP || filter_id == H5Z_FILTER_SCALEOFFSET) {
@@ -6673,7 +6672,7 @@ test_read_cmpd_filtered_dataset_type_conversion_shared(const char *parent_group,
     int                 *displs     = NULL;
 
     if (MAINPROCESS)
-        HDputs(
+        puts(
             "Testing read from shared filtered chunks in Compound Datatype dataset with Datatype conversion");
 
     /* SZIP and ScaleOffset filters don't support compound types */
@@ -6900,7 +6899,7 @@ test_write_serial_read_parallel(const char *parent_group, H5Z_filter_t filter_id
     hid_t       filespace = H5I_INVALID_HID;
 
     if (MAINPROCESS)
-        HDputs("Testing write file serially; read file in parallel");
+        puts("Testing write file serially; read file in parallel");
 
     dataset_dims[0] = (hsize_t)WRITE_SERIAL_READ_PARALLEL_NROWS;
     dataset_dims[1] = (hsize_t)WRITE_SERIAL_READ_PARALLEL_NCOLS;
@@ -7040,7 +7039,7 @@ test_write_parallel_read_serial(const char *parent_group, H5Z_filter_t filter_id
     hid_t       filespace = H5I_INVALID_HID, memspace = H5I_INVALID_HID;
 
     if (MAINPROCESS)
-        HDputs("Testing write file in parallel; read serially");
+        puts("Testing write file in parallel; read serially");
 
     file_id = H5Fopen(filenames[0], H5F_ACC_RDWR, fapl_id);
     VRFY((file_id >= 0), "Test file open succeeded");
@@ -7214,7 +7213,7 @@ test_shrinking_growing_chunks(const char *parent_group, H5Z_filter_t filter_id, 
     hid_t   filespace = H5I_INVALID_HID, memspace = H5I_INVALID_HID;
 
     if (MAINPROCESS)
-        HDputs("Testing continually shrinking/growing chunks");
+        puts("Testing continually shrinking/growing chunks");
 
     file_id = H5Fopen(filenames[0], H5F_ACC_RDWR, fapl_id);
     VRFY((file_id >= 0), "Test file open succeeded");
@@ -7364,7 +7363,7 @@ test_edge_chunks_no_overlap(const char *parent_group, H5Z_filter_t filter_id, hi
     hid_t       filespace = H5I_INVALID_HID;
 
     if (MAINPROCESS)
-        HDputs("Testing write to unshared filtered edge chunks");
+        puts("Testing write to unshared filtered edge chunks");
 
     file_id = H5Fopen(filenames[0], H5F_ACC_RDWR, fapl_id);
     VRFY((file_id >= 0), "Test file open succeeded");
@@ -7463,7 +7462,7 @@ test_edge_chunks_no_overlap(const char *parent_group, H5Z_filter_t filter_id, hi
 
     /* Repeat the previous, but set option to not filter partial edge chunks */
     if (MAINPROCESS)
-        HDputs("Testing write to unshared unfiltered edge chunks");
+        puts("Testing write to unshared unfiltered edge chunks");
 
     H5Pset_chunk_opts(plist_id, H5D_CHUNK_DONT_FILTER_PARTIAL_CHUNKS);
 
@@ -7566,7 +7565,7 @@ test_edge_chunks_overlap(const char *parent_group, H5Z_filter_t filter_id, hid_t
     hid_t       filespace = H5I_INVALID_HID;
 
     if (MAINPROCESS)
-        HDputs("Testing write to shared filtered edge chunks");
+        puts("Testing write to shared filtered edge chunks");
 
     file_id = H5Fopen(filenames[0], H5F_ACC_RDWR, fapl_id);
     VRFY((file_id >= 0), "Test file open succeeded");
@@ -7666,7 +7665,7 @@ test_edge_chunks_overlap(const char *parent_group, H5Z_filter_t filter_id, hid_t
 
     /* Repeat the previous, but set option to not filter partial edge chunks */
     if (MAINPROCESS)
-        HDputs("Testing write to shared unfiltered edge chunks");
+        puts("Testing write to shared unfiltered edge chunks");
 
     H5Pset_chunk_opts(plist_id, H5D_CHUNK_DONT_FILTER_PARTIAL_CHUNKS);
 
@@ -7788,7 +7787,7 @@ test_fill_values(const char *parent_group, H5Z_filter_t filter_id, hid_t fapl_id
     int        *displs     = NULL;
 
     if (MAINPROCESS)
-        HDputs("Testing fill values");
+        puts("Testing fill values");
 
     file_id = H5Fopen(filenames[0], H5F_ACC_RDWR, fapl_id);
     VRFY((file_id >= 0), "Test file open succeeded");
@@ -8150,7 +8149,7 @@ test_fill_value_undefined(const char *parent_group, H5Z_filter_t filter_id, hid_
     hid_t            filespace = H5I_INVALID_HID;
 
     if (MAINPROCESS)
-        HDputs("Testing undefined fill value");
+        puts("Testing undefined fill value");
 
     VRFY((H5Pget_alloc_time(dcpl_id, &alloc_time) >= 0), "H5Pget_alloc_time succeeded");
 
@@ -8353,7 +8352,7 @@ test_fill_time_never(const char *parent_group, H5Z_filter_t filter_id, hid_t fap
     int        *displs     = NULL;
 
     if (MAINPROCESS)
-        HDputs("Testing fill time H5D_FILL_TIME_NEVER");
+        puts("Testing fill time H5D_FILL_TIME_NEVER");
 
     /*
      * Only run this test when incremental file space allocation is
@@ -8751,9 +8750,9 @@ main(int argc, char **argv)
                 file_id = H5Fopen(filenames[0], H5F_ACC_RDWR, fapl_id);
                 VRFY((file_id >= 0), "H5Fopen succeeded");
 
-                HDsnprintf(group_name, sizeof(group_name), "%s_%s_%s", filterNames[cur_filter_idx],
-                           H5FD_MPIO_CHUNK_ONE_IO == chunk_opt ? "linked-chunk-io" : "multi-chunk-io",
-                           alloc_time);
+                snprintf(group_name, sizeof(group_name), "%s_%s_%s", filterNames[cur_filter_idx],
+                         H5FD_MPIO_CHUNK_ONE_IO == chunk_opt ? "linked-chunk-io" : "multi-chunk-io",
+                         alloc_time);
 
                 group_id = H5Gcreate2(file_id, group_name, H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT);
                 VRFY((group_id >= 0), "H5Gcreate2 succeeded");
@@ -8778,7 +8777,7 @@ main(int argc, char **argv)
                 }
 
                 if (MAINPROCESS)
-                    HDputs("");
+                    puts("");
             }
         }
     }
@@ -8793,7 +8792,7 @@ main(int argc, char **argv)
         goto exit;
 
     if (MAINPROCESS)
-        HDputs("All Parallel Filters tests passed\n");
+        puts("All Parallel Filters tests passed\n");
 
 exit:
     if (nerrors)

--- a/testpar/t_mdset.c
+++ b/testpar/t_mdset.c
@@ -182,7 +182,7 @@ multiple_dset_write(void)
     VRFY((ret >= 0), "set fill-value succeeded");
 
     for (n = 0; n < ndatasets; n++) {
-        HDsnprintf(dname, sizeof(dname), "dataset %d", n);
+        snprintf(dname, sizeof(dname), "dataset %d", n);
         dataset = H5Dcreate2(iof, dname, H5T_NATIVE_DOUBLE, filespace, H5P_DEFAULT, dcpl, H5P_DEFAULT);
         VRFY((dataset > 0), dname);
 
@@ -877,11 +877,11 @@ collective_group_write(void)
     /* creates ngroups groups under the root group, writes chunked
      * datasets in parallel. */
     for (m = 0; m < ngroups; m++) {
-        HDsnprintf(gname, sizeof(gname), "group%d", m);
+        snprintf(gname, sizeof(gname), "group%d", m);
         gid = H5Gcreate2(fid, gname, H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT);
         VRFY((gid > 0), gname);
 
-        HDsnprintf(dname, sizeof(dname), "dataset%d", m);
+        snprintf(dname, sizeof(dname), "dataset%d", m);
         did = H5Dcreate2(gid, dname, H5T_NATIVE_INT, filespace, H5P_DEFAULT, dcpl, H5P_DEFAULT);
         VRFY((did > 0), dname);
 
@@ -978,12 +978,12 @@ group_dataset_read(hid_t fid, int mpi_rank, int m)
     VRFY((outdata != NULL), "malloc succeeded for outdata");
 
     /* open every group under root group. */
-    HDsnprintf(gname, sizeof(gname), "group%d", m);
+    snprintf(gname, sizeof(gname), "group%d", m);
     gid = H5Gopen2(fid, gname, H5P_DEFAULT);
     VRFY((gid > 0), gname);
 
     /* check the data. */
-    HDsnprintf(dname, sizeof(dname), "dataset%d", m);
+    snprintf(dname, sizeof(dname), "dataset%d", m);
     did = H5Dopen2(gid, dname, H5P_DEFAULT);
     VRFY((did > 0), dname);
 
@@ -1079,7 +1079,7 @@ multiple_group_write(void)
     /* creates ngroups groups under the root group, writes datasets in
      * parallel. */
     for (m = 0; m < ngroups; m++) {
-        HDsnprintf(gname, sizeof(gname), "group%d", m);
+        snprintf(gname, sizeof(gname), "group%d", m);
         gid = H5Gcreate2(fid, gname, H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT);
         VRFY((gid > 0), gname);
 
@@ -1135,7 +1135,7 @@ write_dataset(hid_t memspace, hid_t filespace, hid_t gid)
     VRFY((outme != NULL), "malloc succeeded for outme");
 
     for (n = 0; n < NDATASET; n++) {
-        HDsnprintf(dname, sizeof(dname), "dataset%d", n);
+        snprintf(dname, sizeof(dname), "dataset%d", n);
         did = H5Dcreate2(gid, dname, H5T_NATIVE_INT, filespace, H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT);
         VRFY((did > 0), dname);
 
@@ -1173,7 +1173,7 @@ create_group_recursive(hid_t memspace, hid_t filespace, hid_t gid, int counter)
     }
 #endif /* BARRIER_CHECKS */
 
-    HDsnprintf(gname, sizeof(gname), "%dth_child_group", counter + 1);
+    snprintf(gname, sizeof(gname), "%dth_child_group", counter + 1);
     child_gid = H5Gcreate2(gid, gname, H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT);
     VRFY((child_gid > 0), gname);
 
@@ -1227,7 +1227,7 @@ multiple_group_read(void)
 
     /* open every group under root group. */
     for (m = 0; m < ngroups; m++) {
-        HDsnprintf(gname, sizeof(gname), "group%d", m);
+        snprintf(gname, sizeof(gname), "group%d", m);
         gid = H5Gopen2(fid, gname, H5P_DEFAULT);
         VRFY((gid > 0), gname);
 
@@ -1284,7 +1284,7 @@ read_dataset(hid_t memspace, hid_t filespace, hid_t gid)
     VRFY((outdata != NULL), "malloc succeeded for outdata");
 
     for (n = 0; n < NDATASET; n++) {
-        HDsnprintf(dname, sizeof(dname), "dataset%d", n);
+        snprintf(dname, sizeof(dname), "dataset%d", n);
         did = H5Dopen2(gid, dname, H5P_DEFAULT);
         VRFY((did > 0), dname);
 
@@ -1335,7 +1335,7 @@ recursive_read_group(hid_t memspace, hid_t filespace, hid_t gid, int counter)
         nerrors += err_num;
 
     if (counter < GROUP_DEPTH) {
-        HDsnprintf(gname, sizeof(gname), "%dth_child_group", counter + 1);
+        snprintf(gname, sizeof(gname), "%dth_child_group", counter + 1);
         child_gid = H5Gopen2(gid, gname, H5P_DEFAULT);
         VRFY((child_gid > 0), gname);
         recursive_read_group(memspace, filespace, child_gid, counter + 1);
@@ -1357,7 +1357,7 @@ write_attribute(hid_t obj_id, int this_type, int num)
     MPI_Comm_rank(MPI_COMM_WORLD, &mpi_rank);
 
     if (this_type == is_group) {
-        HDsnprintf(attr_name, sizeof(attr_name), "Group Attribute %d", num);
+        snprintf(attr_name, sizeof(attr_name), "Group Attribute %d", num);
         sid = H5Screate(H5S_SCALAR);
         aid = H5Acreate2(obj_id, attr_name, H5T_NATIVE_INT, sid, H5P_DEFAULT, H5P_DEFAULT);
         H5Awrite(aid, H5T_NATIVE_INT, &num);
@@ -1365,7 +1365,7 @@ write_attribute(hid_t obj_id, int this_type, int num)
         H5Sclose(sid);
     } /* end if */
     else if (this_type == is_dset) {
-        HDsnprintf(attr_name, sizeof(attr_name), "Dataset Attribute %d", num);
+        snprintf(attr_name, sizeof(attr_name), "Dataset Attribute %d", num);
         for (i = 0; i < 8; i++)
             attr_data[i] = i;
         sid = H5Screate_simple(dspace_rank, dspace_dims, NULL);
@@ -1388,14 +1388,14 @@ read_attribute(hid_t obj_id, int this_type, int num)
     MPI_Comm_rank(MPI_COMM_WORLD, &mpi_rank);
 
     if (this_type == is_group) {
-        HDsnprintf(attr_name, sizeof(attr_name), "Group Attribute %d", num);
+        snprintf(attr_name, sizeof(attr_name), "Group Attribute %d", num);
         aid = H5Aopen(obj_id, attr_name, H5P_DEFAULT);
         H5Aread(aid, H5T_NATIVE_INT, &in_num);
         vrfy_errors = dataset_vrfy(NULL, NULL, NULL, group_block, &in_num, &num);
         H5Aclose(aid);
     }
     else if (this_type == is_dset) {
-        HDsnprintf(attr_name, sizeof(attr_name), "Dataset Attribute %d", num);
+        snprintf(attr_name, sizeof(attr_name), "Dataset Attribute %d", num);
         for (i = 0; i < 8; i++)
             out_data[i] = i;
         aid = H5Aopen(obj_id, attr_name, H5P_DEFAULT);

--- a/testpar/t_pflush1.c
+++ b/testpar/t_pflush1.c
@@ -78,7 +78,7 @@ create_test_file(char *name, size_t name_length, hid_t fapl_id)
     if ((top_level_gid = H5Gcreate2(fid, "some_groups", H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT)) < 0)
         goto error;
     for (i = 0; i < N_GROUPS; i++) {
-        HDsnprintf(name, name_length, "grp%02u", (unsigned)i);
+        snprintf(name, name_length, "grp%02u", (unsigned)i);
         if ((gid = H5Gcreate2(top_level_gid, name, H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT)) < 0)
             goto error;
         if (H5Gclose(gid) < 0)
@@ -125,10 +125,10 @@ main(int argc, char *argv[])
     if (envval == NULL)
         envval = "nomatch";
 
-    if (!HDstrcmp(envval, "split")) {
+    if (!strcmp(envval, "split")) {
         if (mpi_rank == 0) {
             SKIPPED();
-            HDputs("    Test not compatible with current Virtual File Driver");
+            puts("    Test not compatible with current Virtual File Driver");
         }
         MPI_Finalize();
         exit(EXIT_FAILURE);

--- a/testpar/t_pflush2.c
+++ b/testpar/t_pflush2.c
@@ -82,7 +82,7 @@ check_test_file(char *name, size_t name_length, hid_t fapl_id)
     if ((top_level_gid = H5Gopen2(fid, "some_groups", H5P_DEFAULT)) < 0)
         goto error;
     for (i = 0; i < N_GROUPS; i++) {
-        HDsnprintf(name, name_length, "grp%02u", (unsigned)i);
+        snprintf(name, name_length, "grp%02u", (unsigned)i);
         if ((gid = H5Gopen2(top_level_gid, name, H5P_DEFAULT)) < 0)
             goto error;
         if (H5Gclose(gid) < 0)
@@ -150,10 +150,10 @@ main(int argc, char *argv[])
     if (envval == NULL)
         envval = "nomatch";
 
-    if (!HDstrcmp(envval, "split")) {
+    if (!strcmp(envval, "split")) {
         if (mpi_rank == 0) {
             SKIPPED();
-            HDputs("    Test not compatible with current Virtual File Driver");
+            puts("    Test not compatible with current Virtual File Driver");
         }
         MPI_Finalize();
         exit(EXIT_SUCCESS);

--- a/testpar/t_pread.c
+++ b/testpar/t_pread.c
@@ -379,7 +379,7 @@ generate_test_file(MPI_Comm comm, int mpi_rank, int group_id)
         else
             text_to_write = hitchhiker_quote;
 
-        bytes_to_write = HDstrlen(text_to_write);
+        bytes_to_write = strlen(text_to_write);
 
         if (pass) {
             if ((header = HDopen(data_filename, O_WRONLY)) < 0) {
@@ -1063,7 +1063,7 @@ main(int argc, char **argv)
      * isn't true, then we can use a relative path that
      * should be valid for the autotools environment.
      */
-    test_argv0 = HDstrdup(argv[0]);
+    test_argv0 = strdup(argv[0]);
 
     if ((MPI_Init(&argc, &argv)) != MPI_SUCCESS) {
         fprintf(stderr, "FATAL: Unable to initialize MPI\n");

--- a/testpar/t_prop.c
+++ b/testpar/t_prop.c
@@ -563,7 +563,7 @@ external_links(void)
 
             /* test opening a group that is to an external link, the external linked
                file should inherit the source file's access properties */
-            HDsnprintf(link_path, sizeof(link_path), "%s%s%s", group_path, "/", link_name);
+            snprintf(link_path, sizeof(link_path), "%s%s%s", group_path, "/", link_name);
             group = H5Gopen2(fid, link_path, H5P_DEFAULT);
             VRFY((group >= 0), "H5Gopen succeeded");
             ret = H5Gclose(group);

--- a/testpar/t_select_io_dset.c
+++ b/testpar/t_select_io_dset.c
@@ -45,7 +45,7 @@ int curr_nerrors = 0;
             if (err_result == 0)                                                                             \
                 PASSED();                                                                                    \
             else                                                                                             \
-                HDputs("     ***TEST FAILED***");                                                            \
+                puts("     ***TEST FAILED***");                                                              \
         }                                                                                                    \
     } while (0)
 
@@ -227,8 +227,8 @@ test_no_type_conv(hid_t fid, unsigned chunked, unsigned dtrans, unsigned mwbuf)
     }
 
     /* Generate dataset name */
-    HDsnprintf(dset_name, sizeof(dset_name), "no_tconv_%s_%s_%s", chunked ? "chunked" : "contig",
-               dtrans ? "xform" : "noxform", mwbuf ? "mwbuf" : "nomwbuf");
+    snprintf(dset_name, sizeof(dset_name), "no_tconv_%s_%s_%s", chunked ? "chunked" : "contig",
+             dtrans ? "xform" : "noxform", mwbuf ? "mwbuf" : "nomwbuf");
 
     /* Create dataset */
     if ((did = H5Dcreate2(fid, dset_name, H5T_NATIVE_INT, sid, H5P_DEFAULT, dcpl, H5P_DEFAULT)) < 0)
@@ -379,8 +379,8 @@ test_no_size_change_no_bkg(hid_t fid, unsigned chunked, unsigned mwbuf)
     }
 
     /* Generate dataset name */
-    HDsnprintf(dset_name, sizeof(dset_name), "no_size_change_%s_%s", chunked ? "chunked" : "contig",
-               mwbuf ? "mwbuf" : "nomwbuf");
+    snprintf(dset_name, sizeof(dset_name), "no_size_change_%s_%s", chunked ? "chunked" : "contig",
+             mwbuf ? "mwbuf" : "nomwbuf");
 
     /* Create 1d dataset */
     if ((did = H5Dcreate2(fid, dset_name, H5T_STD_I32BE, sid, H5P_DEFAULT, dcpl, H5P_DEFAULT)) < 0)
@@ -525,8 +525,8 @@ test_larger_mem_type_no_bkg(hid_t fid, unsigned chunked, unsigned dtrans, unsign
     }
 
     /* Generate dataset name */
-    HDsnprintf(dset_name, sizeof(dset_name), "larger_no_bkg_%s_%s_%s", chunked ? "chunked" : "contig",
-               dtrans ? "xform" : "noxform", mwbuf ? "mwbuf" : "nomwbuf");
+    snprintf(dset_name, sizeof(dset_name), "larger_no_bkg_%s_%s_%s", chunked ? "chunked" : "contig",
+             dtrans ? "xform" : "noxform", mwbuf ? "mwbuf" : "nomwbuf");
 
     /* Create 1d chunked dataset with/without data transform */
     if ((did = H5Dcreate2(fid, dset_name, H5T_NATIVE_INT, sid, H5P_DEFAULT, dcpl, H5P_DEFAULT)) < 0)
@@ -673,8 +673,8 @@ test_smaller_mem_type_no_bkg(hid_t fid, unsigned chunked, unsigned dtrans, unsig
     }
 
     /* Generate dataset name */
-    HDsnprintf(dset_name, sizeof(dset_name), "smaller_no_bkg_%s_%s_%s", chunked ? "chunked" : "contig",
-               dtrans ? "xform" : "noxform", mwbuf ? "mwbuf" : "nomwbuf");
+    snprintf(dset_name, sizeof(dset_name), "smaller_no_bkg_%s_%s_%s", chunked ? "chunked" : "contig",
+             dtrans ? "xform" : "noxform", mwbuf ? "mwbuf" : "nomwbuf");
 
     /* Create 1d chunked dataset with/without data transform */
     if ((did = H5Dcreate2(fid, dset_name, H5T_NATIVE_INT, sid, H5P_DEFAULT, dcpl, H5P_DEFAULT)) < 0)
@@ -870,8 +870,8 @@ test_cmpd_with_bkg(hid_t fid, unsigned chunked, unsigned mwbuf)
     /* Case 5(a) */
 
     /* Generate dataset name */
-    HDsnprintf(dset_name, sizeof(dset_name), "cmpd_with_bkg_%s_%s", chunked ? "chunked" : "contig",
-               mwbuf ? "mwbuf" : "nomwbuf");
+    snprintf(dset_name, sizeof(dset_name), "cmpd_with_bkg_%s_%s", chunked ? "chunked" : "contig",
+             mwbuf ? "mwbuf" : "nomwbuf");
 
     /* Create 1d dataset */
     if ((did = H5Dcreate2(fid, dset_name, s1_tid, sid, H5P_DEFAULT, dcpl, H5P_DEFAULT)) < 0)
@@ -1158,8 +1158,8 @@ test_type_conv_sel_empty(hid_t fid, unsigned chunked, unsigned dtrans, unsigned 
     }
 
     /* Generate dataset name */
-    HDsnprintf(dset_name, sizeof(dset_name), "tconv_sel_empty_%s_%s_%s", chunked ? "chunked" : "contig",
-               dtrans ? "xform" : "noxform", mwbuf ? "mwbuf" : "nomwbuf");
+    snprintf(dset_name, sizeof(dset_name), "tconv_sel_empty_%s_%s_%s", chunked ? "chunked" : "contig",
+             dtrans ? "xform" : "noxform", mwbuf ? "mwbuf" : "nomwbuf");
 
     /* Create dataset */
     if ((did = H5Dcreate2(fid, dset_name, H5T_NATIVE_INT, sid, H5P_DEFAULT, dcpl, H5P_DEFAULT)) < 0)
@@ -1473,8 +1473,8 @@ test_multi_dsets_no_bkg(hid_t fid, unsigned chunked, unsigned dtrans, unsigned m
             P_TEST_ERROR;
 
         /* Generate dataset name */
-        HDsnprintf(dset_names[i], sizeof(dset_names[i]), "multi_dset%d_%s_%s_%s", i,
-                   chunked ? "chunked" : "contig", dtrans ? "xform" : "noxform", mwbuf ? "mwbuf" : "nomwbuf");
+        snprintf(dset_names[i], sizeof(dset_names[i]), "multi_dset%d_%s_%s_%s", i,
+                 chunked ? "chunked" : "contig", dtrans ? "xform" : "noxform", mwbuf ? "mwbuf" : "nomwbuf");
 
         /* Create ith dataset */
         if ((dset_dids[i] =
@@ -1794,8 +1794,8 @@ test_multi_dsets_cmpd_with_bkg(hid_t fid, unsigned chunked, unsigned mwbuf)
             P_TEST_ERROR;
 
         /* Generate dataset name */
-        HDsnprintf(dset_names[i], sizeof(dset_names[i]), "multi_cmpd_dset%d_%s_%s", i,
-                   chunked ? "chunked" : "contig", mwbuf ? "mwbuf" : "nomwbuf");
+        snprintf(dset_names[i], sizeof(dset_names[i]), "multi_cmpd_dset%d_%s_%s", i,
+                 chunked ? "chunked" : "contig", mwbuf ? "mwbuf" : "nomwbuf");
 
         /* Create ith dataset */
         if ((dset_dids[i] =
@@ -2230,8 +2230,8 @@ test_multi_dsets_size_change_no_bkg(hid_t fid, unsigned chunked, unsigned mwbuf)
             P_TEST_ERROR;
 
         /* Generate dataset name */
-        HDsnprintf(dset_names[i], sizeof(dset_names[i]), "multi_size_dset%d_%s_%s", i,
-                   chunked ? "chunked" : "contig", mwbuf ? "mwbuf" : "nomwbuf");
+        snprintf(dset_names[i], sizeof(dset_names[i]), "multi_size_dset%d_%s_%s", i,
+                 chunked ? "chunked" : "contig", mwbuf ? "mwbuf" : "nomwbuf");
 
         /* Create ith dataset */
         if ((dset_dids[i] = H5Dcreate2(fid, dset_names[i], H5T_STD_I32BE, file_sids[i], H5P_DEFAULT, dcpl,
@@ -2584,8 +2584,8 @@ test_multi_dsets_conv_sel_empty(hid_t fid, unsigned chunked, unsigned dtrans, un
             P_TEST_ERROR;
 
         /* Generate dataset name */
-        HDsnprintf(dset_names[i], sizeof(dset_names[i]), "multi_sel_dset%d_%s_%s_%s", i,
-                   chunked ? "chunked" : "contig", dtrans ? "xform" : "noxform", mwbuf ? "mwbuf" : "nomwbuf");
+        snprintf(dset_names[i], sizeof(dset_names[i]), "multi_sel_dset%d_%s_%s_%s", i,
+                 chunked ? "chunked" : "contig", dtrans ? "xform" : "noxform", mwbuf ? "mwbuf" : "nomwbuf");
 
         if (i == 0) {
             if ((dset_dids[i] = H5Dcreate2(fid, dset_names[i], H5T_NATIVE_INT, file_sids[i], H5P_DEFAULT,
@@ -3039,24 +3039,24 @@ test_multi_dsets_all(int niter, hid_t fid, unsigned chunked, unsigned mwbuf)
             mm = HDrandom() % (int)ndsets;
             if (mm == 0) {
                 dset_types[i] = DSET_WITH_NO_CONV;
-                HDsnprintf(dset_names[i], sizeof(dset_names[i]), "multi_all_nconv_dset%d_%s_%s", i,
-                           chunked ? "chunked" : "contig", mwbuf ? "mwbuf" : "nomwbuf");
+                snprintf(dset_names[i], sizeof(dset_names[i]), "multi_all_nconv_dset%d_%s_%s", i,
+                         chunked ? "chunked" : "contig", mwbuf ? "mwbuf" : "nomwbuf");
                 if ((dset_dids[i] = H5Dcreate2(fid, dset_names[i], H5T_NATIVE_INT, file_sids[i], H5P_DEFAULT,
                                                dcpl, H5P_DEFAULT)) < 0)
                     P_TEST_ERROR;
             }
             else if (mm == 1) {
                 dset_types[i] = DSET_WITH_CONV_AND_NO_BKG;
-                HDsnprintf(dset_names[i], sizeof(dset_names[i]), "multi_all_conv_nbkg_dset%d_%s_%s", i,
-                           chunked ? "chunked" : "contig", mwbuf ? "mwbuf" : "nomwbuf");
+                snprintf(dset_names[i], sizeof(dset_names[i]), "multi_all_conv_nbkg_dset%d_%s_%s", i,
+                         chunked ? "chunked" : "contig", mwbuf ? "mwbuf" : "nomwbuf");
                 if ((dset_dids[i] = H5Dcreate2(fid, dset_names[i], H5T_NATIVE_LONG, file_sids[i], H5P_DEFAULT,
                                                dcpl, H5P_DEFAULT)) < 0)
                     P_TEST_ERROR;
             }
             else {
                 dset_types[i] = DSET_WITH_CONV_AND_BKG;
-                HDsnprintf(dset_names[i], sizeof(dset_names[i]), "multi_all_conv_bkg_dset%d_%s_%s", i,
-                           chunked ? "chunked" : "contig", mwbuf ? "mwbuf" : "nomwbuf");
+                snprintf(dset_names[i], sizeof(dset_names[i]), "multi_all_conv_bkg_dset%d_%s_%s", i,
+                         chunked ? "chunked" : "contig", mwbuf ? "mwbuf" : "nomwbuf");
                 if ((dset_dids[i] = H5Dcreate2(fid, dset_names[i], s1_tid, file_sids[i], H5P_DEFAULT, dcpl,
                                                H5P_DEFAULT)) < 0)
                     P_TEST_ERROR;

--- a/testpar/t_subfiling_vfd.c
+++ b/testpar/t_subfiling_vfd.c
@@ -325,8 +325,8 @@ test_config_file(void)
         config_filename = malloc(PATH_MAX);
         VRFY(config_filename, "malloc succeeded");
 
-        HDsnprintf(config_filename, PATH_MAX, "%s/" H5FD_SUBFILING_CONFIG_FILENAME_TEMPLATE, config_dir,
-                   SUBF_FILENAME, (uint64_t)file_info.st_ino);
+        snprintf(config_filename, PATH_MAX, "%s/" H5FD_SUBFILING_CONFIG_FILENAME_TEMPLATE, config_dir,
+                 SUBF_FILENAME, (uint64_t)file_info.st_ino);
 
         config_file = fopen(config_filename, "r");
         VRFY(config_file, "fopen succeeded");
@@ -347,27 +347,27 @@ test_config_file(void)
         config_buf[config_file_len] = '\0';
 
         /* Check the stripe_size field in the configuration file */
-        substr = HDstrstr(config_buf, "stripe_size");
-        VRFY(substr, "HDstrstr succeeded");
+        substr = strstr(config_buf, "stripe_size");
+        VRFY(substr, "strstr succeeded");
 
-        VRFY((HDsscanf(substr, "stripe_size=%" PRId64, &read_stripe_size) == 1), "HDsscanf succeeded");
+        VRFY((sscanf(substr, "stripe_size=%" PRId64, &read_stripe_size) == 1), "sscanf succeeded");
         VRFY((read_stripe_size == cfg.stripe_size), "Stripe size comparison succeeded");
 
         /* Check the aggregator_count field in the configuration file */
-        substr = HDstrstr(config_buf, "aggregator_count");
-        VRFY(substr, "HDstrstr succeeded");
+        substr = strstr(config_buf, "aggregator_count");
+        VRFY(substr, "strstr succeeded");
 
-        VRFY((HDsscanf(substr, "aggregator_count=%d", &read_aggr_count) == 1), "HDsscanf succeeded");
+        VRFY((sscanf(substr, "aggregator_count=%d", &read_aggr_count) == 1), "sscanf succeeded");
         if (cfg.stripe_count < num_iocs_g)
             VRFY((read_aggr_count == cfg.stripe_count), "Aggregator count comparison succeeded");
         else
             VRFY((read_aggr_count == num_iocs_g), "Aggregator count comparison succeeded");
 
         /* Check the subfile_count field in the configuration file */
-        substr = HDstrstr(config_buf, "subfile_count");
-        VRFY(substr, "HDstrstr succeeded");
+        substr = strstr(config_buf, "subfile_count");
+        VRFY(substr, "strstr succeeded");
 
-        VRFY((HDsscanf(substr, "subfile_count=%d", &read_stripe_count) == 1), "HDsscanf succeeded");
+        VRFY((sscanf(substr, "subfile_count=%d", &read_stripe_count) == 1), "sscanf succeeded");
         VRFY((read_stripe_count == cfg.stripe_count), "Stripe count comparison succeeded");
 
         /* Check the hdf5_file and subfile_dir fields in the configuration file */
@@ -379,21 +379,21 @@ test_config_file(void)
         tmp_buf = malloc(PATH_MAX);
         VRFY(tmp_buf, "malloc succeeded");
 
-        substr = HDstrstr(config_buf, "hdf5_file");
-        VRFY(substr, "HDstrstr succeeded");
+        substr = strstr(config_buf, "hdf5_file");
+        VRFY(substr, "strstr succeeded");
 
-        HDsnprintf(scan_format, sizeof(scan_format), "hdf5_file=%%%zus", (size_t)(PATH_MAX - 1));
-        VRFY((HDsscanf(substr, scan_format, tmp_buf) == 1), "HDsscanf succeeded");
+        snprintf(scan_format, sizeof(scan_format), "hdf5_file=%%%zus", (size_t)(PATH_MAX - 1));
+        VRFY((sscanf(substr, scan_format, tmp_buf) == 1), "sscanf succeeded");
 
-        VRFY((HDstrcmp(tmp_buf, resolved_path) == 0), "HDstrcmp succeeded");
+        VRFY((strcmp(tmp_buf, resolved_path) == 0), "strcmp succeeded");
 
-        substr = HDstrstr(config_buf, "subfile_dir");
-        VRFY(substr, "HDstrstr succeeded");
+        substr = strstr(config_buf, "subfile_dir");
+        VRFY(substr, "strstr succeeded");
 
-        HDsnprintf(scan_format, sizeof(scan_format), "subfile_dir=%%%zus", (size_t)(PATH_MAX - 1));
-        VRFY((HDsscanf(substr, scan_format, tmp_buf) == 1), "HDsscanf succeeded");
+        snprintf(scan_format, sizeof(scan_format), "subfile_dir=%%%zus", (size_t)(PATH_MAX - 1));
+        VRFY((sscanf(substr, scan_format, tmp_buf) == 1), "sscanf succeeded");
 
-        VRFY((HDstrcmp(tmp_buf, subfile_dir) == 0), "HDstrcmp succeeded");
+        VRFY((strcmp(tmp_buf, subfile_dir) == 0), "strcmp succeeded");
 
         free(tmp_buf);
         H5MM_free(subfile_dir);
@@ -405,18 +405,18 @@ test_config_file(void)
         /* Verify the name of each subfile is in the configuration file */
         num_digits = (int)(HDlog10(cfg.stripe_count) + 1);
         for (size_t i = 0; i < (size_t)cfg.stripe_count; i++) {
-            HDsnprintf(subfile_name, PATH_MAX, H5FD_SUBFILING_FILENAME_TEMPLATE, SUBF_FILENAME,
-                       (uint64_t)file_info.st_ino, num_digits, (int)i + 1, cfg.stripe_count);
+            snprintf(subfile_name, PATH_MAX, H5FD_SUBFILING_FILENAME_TEMPLATE, SUBF_FILENAME,
+                     (uint64_t)file_info.st_ino, num_digits, (int)i + 1, cfg.stripe_count);
 
-            substr = HDstrstr(config_buf, subfile_name);
-            VRFY(substr, "HDstrstr succeeded");
+            substr = strstr(config_buf, subfile_name);
+            VRFY(substr, "strstr succeeded");
         }
 
         /* Verify that there aren't too many subfiles */
-        HDsnprintf(subfile_name, PATH_MAX, H5FD_SUBFILING_FILENAME_TEMPLATE, SUBF_FILENAME,
-                   (uint64_t)file_info.st_ino, num_digits, (int)cfg.stripe_count + 1, cfg.stripe_count);
-        substr = HDstrstr(config_buf, subfile_name);
-        VRFY(substr == NULL, "HDstrstr correctly failed");
+        snprintf(subfile_name, PATH_MAX, H5FD_SUBFILING_FILENAME_TEMPLATE, SUBF_FILENAME,
+                 (uint64_t)file_info.st_ino, num_digits, (int)cfg.stripe_count + 1, cfg.stripe_count);
+        substr = strstr(config_buf, subfile_name);
+        VRFY(substr == NULL, "strstr correctly failed");
 
         free(subfile_name);
         free(config_buf);
@@ -566,8 +566,8 @@ test_stripe_sizes(void)
                 h5_stat_size_t subfile_size;
                 h5_stat_t      subfile_info;
 
-                HDsnprintf(tmp_filename, PATH_MAX, H5FD_SUBFILING_FILENAME_TEMPLATE, SUBF_FILENAME,
-                           (uint64_t)file_info.st_ino, num_digits, j + 1, num_subfiles);
+                snprintf(tmp_filename, PATH_MAX, H5FD_SUBFILING_FILENAME_TEMPLATE, SUBF_FILENAME,
+                         (uint64_t)file_info.st_ino, num_digits, j + 1, num_subfiles);
 
                 /* Ensure file exists */
                 subfile_ptr = fopen(tmp_filename, "r");
@@ -582,8 +582,8 @@ test_stripe_sizes(void)
             }
 
             /* Verify that there aren't too many subfiles */
-            HDsnprintf(tmp_filename, PATH_MAX, H5FD_SUBFILING_FILENAME_TEMPLATE, SUBF_FILENAME,
-                       (uint64_t)file_info.st_ino, num_digits, num_subfiles + 1, num_subfiles);
+            snprintf(tmp_filename, PATH_MAX, H5FD_SUBFILING_FILENAME_TEMPLATE, SUBF_FILENAME,
+                     (uint64_t)file_info.st_ino, num_digits, num_subfiles + 1, num_subfiles);
 
             /* Ensure file doesn't exist */
             subfile_ptr = fopen(tmp_filename, "r");
@@ -612,8 +612,8 @@ test_stripe_sizes(void)
                 h5_stat_size_t subfile_size;
                 h5_stat_t      subfile_info;
 
-                HDsnprintf(tmp_filename, PATH_MAX, H5FD_SUBFILING_FILENAME_TEMPLATE, SUBF_FILENAME,
-                           (uint64_t)file_info.st_ino, num_digits, j + 1, num_subfiles);
+                snprintf(tmp_filename, PATH_MAX, H5FD_SUBFILING_FILENAME_TEMPLATE, SUBF_FILENAME,
+                         (uint64_t)file_info.st_ino, num_digits, j + 1, num_subfiles);
 
                 /* Ensure file exists */
                 subfile_ptr = fopen(tmp_filename, "r");
@@ -628,8 +628,8 @@ test_stripe_sizes(void)
             }
 
             /* Verify that there aren't too many subfiles */
-            HDsnprintf(tmp_filename, PATH_MAX, H5FD_SUBFILING_FILENAME_TEMPLATE, SUBF_FILENAME,
-                       (uint64_t)file_info.st_ino, num_digits, num_subfiles + 1, num_subfiles);
+            snprintf(tmp_filename, PATH_MAX, H5FD_SUBFILING_FILENAME_TEMPLATE, SUBF_FILENAME,
+                     (uint64_t)file_info.st_ino, num_digits, num_subfiles + 1, num_subfiles);
 
             /* Ensure file doesn't exist */
             subfile_ptr = fopen(tmp_filename, "r");
@@ -732,8 +732,8 @@ test_stripe_sizes(void)
                 h5_stat_size_t subfile_size;
                 h5_stat_t      subfile_info;
 
-                HDsnprintf(tmp_filename, PATH_MAX, H5FD_SUBFILING_FILENAME_TEMPLATE, SUBF_FILENAME,
-                           (uint64_t)file_info.st_ino, num_digits, j + 1, num_subfiles);
+                snprintf(tmp_filename, PATH_MAX, H5FD_SUBFILING_FILENAME_TEMPLATE, SUBF_FILENAME,
+                         (uint64_t)file_info.st_ino, num_digits, j + 1, num_subfiles);
 
                 /* Ensure file exists */
                 subfile_ptr = fopen(tmp_filename, "r");
@@ -748,8 +748,8 @@ test_stripe_sizes(void)
             }
 
             /* Verify that there aren't too many subfiles */
-            HDsnprintf(tmp_filename, PATH_MAX, H5FD_SUBFILING_FILENAME_TEMPLATE, SUBF_FILENAME,
-                       (uint64_t)file_info.st_ino, num_digits, num_subfiles + 1, num_subfiles);
+            snprintf(tmp_filename, PATH_MAX, H5FD_SUBFILING_FILENAME_TEMPLATE, SUBF_FILENAME,
+                     (uint64_t)file_info.st_ino, num_digits, num_subfiles + 1, num_subfiles);
 
             /* Ensure file doesn't exist */
             subfile_ptr = fopen(tmp_filename, "r");
@@ -789,8 +789,8 @@ test_stripe_sizes(void)
                 h5_stat_size_t subfile_size;
                 h5_stat_t      subfile_info;
 
-                HDsnprintf(tmp_filename, PATH_MAX, H5FD_SUBFILING_FILENAME_TEMPLATE, SUBF_FILENAME,
-                           (uint64_t)file_info.st_ino, num_digits, j + 1, num_subfiles);
+                snprintf(tmp_filename, PATH_MAX, H5FD_SUBFILING_FILENAME_TEMPLATE, SUBF_FILENAME,
+                         (uint64_t)file_info.st_ino, num_digits, j + 1, num_subfiles);
 
                 /* Ensure file exists */
                 subfile_ptr = fopen(tmp_filename, "r");
@@ -805,8 +805,8 @@ test_stripe_sizes(void)
             }
 
             /* Verify that there aren't too many subfiles */
-            HDsnprintf(tmp_filename, PATH_MAX, H5FD_SUBFILING_FILENAME_TEMPLATE, SUBF_FILENAME,
-                       (uint64_t)file_info.st_ino, num_digits, num_subfiles + 1, num_subfiles);
+            snprintf(tmp_filename, PATH_MAX, H5FD_SUBFILING_FILENAME_TEMPLATE, SUBF_FILENAME,
+                     (uint64_t)file_info.st_ino, num_digits, num_subfiles + 1, num_subfiles);
 
             /* Ensure file doesn't exist */
             subfile_ptr = fopen(tmp_filename, "r");
@@ -908,7 +908,7 @@ test_selection_strategies(void)
                         else
                             stride = 16;
 
-                        HDsnprintf(sel_criteria, 128, "%d", stride);
+                        snprintf(sel_criteria, 128, "%d", stride);
 
                         expected_num_subfiles = ((num_active_ranks - 1) / stride) + 1;
 
@@ -930,7 +930,7 @@ test_selection_strategies(void)
                         else
                             n_iocs = 16;
 
-                        HDsnprintf(sel_criteria, 128, "%d", n_iocs);
+                        snprintf(sel_criteria, 128, "%d", n_iocs);
 
                         expected_num_subfiles = n_iocs;
 
@@ -946,10 +946,10 @@ test_selection_strategies(void)
                 }
 
                 if (criteria_format_choice == 0) {
-                    HDsnprintf(criteria_buf, 256, "%d:%s", strategy, sel_criteria);
+                    snprintf(criteria_buf, 256, "%d:%s", strategy, sel_criteria);
                 }
                 else if (criteria_format_choice == 1) {
-                    HDsnprintf(criteria_buf, 256, "%s", sel_criteria);
+                    snprintf(criteria_buf, 256, "%s", sel_criteria);
                 }
 
                 VRFY(HDsetenv(H5FD_SUBFILING_IOC_SELECTION_CRITERIA, criteria_buf, 1) >= 0,
@@ -981,8 +981,8 @@ test_selection_strategies(void)
 
                     /* Ensure all the subfiles are present */
                     for (int i = 0; i < expected_num_subfiles; i++) {
-                        HDsnprintf(tmp_filename, PATH_MAX, H5FD_SUBFILING_FILENAME_TEMPLATE, SUBF_FILENAME,
-                                   (uint64_t)file_info.st_ino, num_digits, i + 1, expected_num_subfiles);
+                        snprintf(tmp_filename, PATH_MAX, H5FD_SUBFILING_FILENAME_TEMPLATE, SUBF_FILENAME,
+                                 (uint64_t)file_info.st_ino, num_digits, i + 1, expected_num_subfiles);
 
                         /* Ensure file exists */
                         subfile_ptr = fopen(tmp_filename, "r");
@@ -991,9 +991,9 @@ test_selection_strategies(void)
                     }
 
                     /* Ensure no extra subfiles are present */
-                    HDsnprintf(tmp_filename, PATH_MAX, H5FD_SUBFILING_FILENAME_TEMPLATE, SUBF_FILENAME,
-                               (uint64_t)file_info.st_ino, num_digits, expected_num_subfiles + 1,
-                               expected_num_subfiles);
+                    snprintf(tmp_filename, PATH_MAX, H5FD_SUBFILING_FILENAME_TEMPLATE, SUBF_FILENAME,
+                             (uint64_t)file_info.st_ino, num_digits, expected_num_subfiles + 1,
+                             expected_num_subfiles);
 
                     /* Ensure file doesn't exist */
                     subfile_ptr = fopen(tmp_filename, "r");
@@ -1140,8 +1140,8 @@ test_read_different_stripe_size(void)
             h5_stat_size_t subfile_size;
             h5_stat_t      subfile_info;
 
-            HDsnprintf(tmp_filename, PATH_MAX, H5FD_SUBFILING_FILENAME_TEMPLATE, SUBF_FILENAME,
-                       (uint64_t)file_info.st_ino, num_digits, j + 1, num_subfiles);
+            snprintf(tmp_filename, PATH_MAX, H5FD_SUBFILING_FILENAME_TEMPLATE, SUBF_FILENAME,
+                     (uint64_t)file_info.st_ino, num_digits, j + 1, num_subfiles);
 
             /* Ensure file exists */
             subfile_ptr = fopen(tmp_filename, "r");
@@ -1210,8 +1210,8 @@ test_read_different_stripe_size(void)
         VRFY((HDstat(SUBF_FILENAME, &file_info) >= 0), "HDstat succeeded");
 
         for (int j = 0; j < num_subfiles; j++) {
-            HDsnprintf(tmp_filename, PATH_MAX, H5FD_SUBFILING_FILENAME_TEMPLATE, SUBF_FILENAME,
-                       (uint64_t)file_info.st_ino, num_digits, j + 1, num_subfiles / 2);
+            snprintf(tmp_filename, PATH_MAX, H5FD_SUBFILING_FILENAME_TEMPLATE, SUBF_FILENAME,
+                     (uint64_t)file_info.st_ino, num_digits, j + 1, num_subfiles / 2);
 
             if (j < (num_subfiles / 2)) {
                 /* Ensure file exists */
@@ -1363,8 +1363,8 @@ test_subfiling_precreate_rank_0(void)
         for (int i = 0; i < num_subfiles; i++) {
             h5_stat_t subfile_info;
 
-            HDsnprintf(tmp_filename, PATH_MAX, H5FD_SUBFILING_FILENAME_TEMPLATE, SUBF_FILENAME,
-                       (uint64_t)file_info.st_ino, num_digits, i + 1, num_subfiles);
+            snprintf(tmp_filename, PATH_MAX, H5FD_SUBFILING_FILENAME_TEMPLATE, SUBF_FILENAME,
+                     (uint64_t)file_info.st_ino, num_digits, i + 1, num_subfiles);
 
             /* Ensure file exists */
             subfile_ptr = fopen(tmp_filename, "r");
@@ -1379,8 +1379,8 @@ test_subfiling_precreate_rank_0(void)
         }
 
         /* Verify that there aren't too many subfiles */
-        HDsnprintf(tmp_filename, PATH_MAX, H5FD_SUBFILING_FILENAME_TEMPLATE, SUBF_FILENAME,
-                   (uint64_t)file_info.st_ino, num_digits, num_subfiles + 1, num_subfiles);
+        snprintf(tmp_filename, PATH_MAX, H5FD_SUBFILING_FILENAME_TEMPLATE, SUBF_FILENAME,
+                 (uint64_t)file_info.st_ino, num_digits, num_subfiles + 1, num_subfiles);
 
         /* Ensure file doesn't exist */
         subfile_ptr = fopen(tmp_filename, "r");
@@ -1935,14 +1935,14 @@ test_subfiling_h5fuse(void)
             VRFY(tmp_filename, "malloc succeeded");
 
             /* Generate name for configuration file */
-            HDsnprintf(tmp_filename, PATH_MAX, "%s/" H5FD_SUBFILING_CONFIG_FILENAME_TEMPLATE, config_dir,
-                       SUBF_FILENAME, file_inode);
+            snprintf(tmp_filename, PATH_MAX, "%s/" H5FD_SUBFILING_CONFIG_FILENAME_TEMPLATE, config_dir,
+                     SUBF_FILENAME, file_inode);
 
-            args[0] = HDstrdup("env");
-            args[1] = HDstrdup("sh");
-            args[2] = HDstrdup("h5fuse.sh");
-            args[3] = HDstrdup("-q");
-            args[4] = HDstrdup("-f");
+            args[0] = strdup("env");
+            args[1] = strdup("sh");
+            args[2] = strdup("h5fuse.sh");
+            args[3] = strdup("-q");
+            args[4] = strdup("-f");
             args[5] = tmp_filename;
             args[6] = NULL;
 
@@ -2028,8 +2028,8 @@ test_subfiling_h5fuse(void)
         VRFY(filename_buf, "malloc succeeded");
 
         /* Generate name for configuration file */
-        HDsnprintf(filename_buf, PATH_MAX, "%s/" H5FD_SUBFILING_CONFIG_FILENAME_TEMPLATE, config_dir,
-                   SUBF_FILENAME, file_inode);
+        snprintf(filename_buf, PATH_MAX, "%s/" H5FD_SUBFILING_CONFIG_FILENAME_TEMPLATE, config_dir,
+                 SUBF_FILENAME, file_inode);
 
         /* Delete the configuration file */
         if (HDremove(filename_buf) < 0) {
@@ -2039,8 +2039,8 @@ test_subfiling_h5fuse(void)
 
         for (int i = 0; i < num_subfiles; i++) {
             /* Generate name for each subfile */
-            HDsnprintf(filename_buf, PATH_MAX, H5FD_SUBFILING_FILENAME_TEMPLATE, SUBF_FILENAME, file_inode,
-                       num_digits, i + 1, num_subfiles);
+            snprintf(filename_buf, PATH_MAX, H5FD_SUBFILING_FILENAME_TEMPLATE, SUBF_FILENAME, file_inode,
+                     num_digits, i + 1, num_subfiles);
 
             /* Delete the subfile */
             if (HDremove(filename_buf) < 0) {
@@ -2101,7 +2101,7 @@ parse_subfiling_env_vars(void)
     if (NULL != (env_value = HDgetenv(H5FD_SUBFILING_CONFIG_FILE_PREFIX))) {
         assert(config_dir);
 
-        HDstrncpy(config_dir, env_value, PATH_MAX);
+        strncpy(config_dir, env_value, PATH_MAX);
 
         /* Just in case.. */
         config_dir[PATH_MAX - 1] = '\0';
@@ -2257,7 +2257,7 @@ main(int argc, char **argv)
     }
 
     /* Initialize to current working directory for now */
-    HDsnprintf(config_dir, PATH_MAX, ".");
+    snprintf(config_dir, PATH_MAX, ".");
 
     /* Grab values from environment variables if set */
     parse_subfiling_env_vars();
@@ -2283,7 +2283,7 @@ main(int argc, char **argv)
     }
 
     if (MAINPROCESS)
-        HDputs("");
+        puts("");
 
     /*
      * Set any unset Subfiling environment variables and re-run
@@ -2308,7 +2308,7 @@ main(int argc, char **argv)
             VRFY((mpi_code_g == MPI_SUCCESS), "MPI_Bcast succeeded");
         }
 
-        HDsnprintf(tmp, sizeof(tmp), "%" PRId64, stripe_size);
+        snprintf(tmp, sizeof(tmp), "%" PRId64, stripe_size);
 
         if (HDsetenv(H5FD_SUBFILING_STRIPE_SIZE, tmp, 1) < 0) {
             if (MAINPROCESS)
@@ -2428,13 +2428,13 @@ main(int argc, char **argv)
     }
 
     if (MAINPROCESS)
-        HDputs("");
+        puts("");
 
     if (nerrors)
         goto exit;
 
     if (MAINPROCESS)
-        HDputs("All Subfiling VFD tests passed\n");
+        puts("All Subfiling VFD tests passed\n");
 
 exit:
     if (must_unset_stripe_size_env)

--- a/testpar/t_vfd.c
+++ b/testpar/t_vfd.c
@@ -162,7 +162,7 @@ int *erbufs[2] = {NULL, NULL}; /* Array of expected read buffers */
             if (err_result == 0)                                                                             \
                 PASSED();                                                                                    \
             else                                                                                             \
-                HDputs("     ***TEST FAILED***");                                                            \
+                puts("     ***TEST FAILED***");                                                              \
         }                                                                                                    \
     } while (0)
 
@@ -388,7 +388,7 @@ setup_vfd_test_file(int file_name_id, char *file_name, int mpi_size, H5FD_mpio_x
 
     if (pass) {
 
-        if (HDstrcmp(vfd_name, "mpio") == 0) {
+        if (strcmp(vfd_name, "mpio") == 0) {
 
             if (H5Pset_fapl_mpio(fapl_id, comm, info) < 0) {
 
@@ -397,7 +397,7 @@ setup_vfd_test_file(int file_name_id, char *file_name, int mpi_size, H5FD_mpio_x
             }
         }
 #ifdef H5_HAVE_SUBFILING_VFD
-        else if (HDstrcmp(vfd_name, H5FD_SUBFILING_NAME) == 0) {
+        else if (strcmp(vfd_name, H5FD_SUBFILING_NAME) == 0) {
 
             H5FD_subfiling_params_t shared_conf = {
                 /* ioc_selection = */ SELECT_IOC_ONE_PER_NODE,
@@ -575,7 +575,7 @@ setup_vfd_test_file(int file_name_id, char *file_name, int mpi_size, H5FD_mpio_x
 
     if (pass) { /* setup pointers with return values */
 
-        HDstrncpy(file_name, filename, 512);
+        strncpy(file_name, filename, 512);
         *lf_ptr      = lf;
         *fapl_id_ptr = fapl_id;
         *dxpl_id_ptr = dxpl_id;
@@ -749,20 +749,20 @@ vector_read_test_1(int file_name_id, int mpi_rank, int mpi_size, H5FD_mpio_xfer_
 
         if (xfer_mode == H5FD_MPIO_INDEPENDENT) {
 
-            HDsnprintf(test_title, sizeof(test_title), "parallel vector read test 1 -- %s / independent",
-                       vfd_name);
+            snprintf(test_title, sizeof(test_title), "parallel vector read test 1 -- %s / independent",
+                     vfd_name);
         }
         else if (coll_opt_mode == H5FD_MPIO_INDIVIDUAL_IO) {
 
-            HDsnprintf(test_title, sizeof(test_title), "parallel vector read test 1 -- %s / col op / ind I/O",
-                       vfd_name);
+            snprintf(test_title, sizeof(test_title), "parallel vector read test 1 -- %s / col op / ind I/O",
+                     vfd_name);
         }
         else {
 
             assert(coll_opt_mode == H5FD_MPIO_COLLECTIVE_IO);
 
-            HDsnprintf(test_title, sizeof(test_title), "parallel vector read test 1 -- %s / col op / col I/O",
-                       vfd_name);
+            snprintf(test_title, sizeof(test_title), "parallel vector read test 1 -- %s / col op / col I/O",
+                     vfd_name);
         }
 
         TESTING(test_title);
@@ -979,20 +979,20 @@ vector_read_test_2(int file_name_id, int mpi_rank, int mpi_size, H5FD_mpio_xfer_
 
         if (xfer_mode == H5FD_MPIO_INDEPENDENT) {
 
-            HDsnprintf(test_title, sizeof(test_title), "parallel vector read test 2 -- %s / independent",
-                       vfd_name);
+            snprintf(test_title, sizeof(test_title), "parallel vector read test 2 -- %s / independent",
+                     vfd_name);
         }
         else if (coll_opt_mode == H5FD_MPIO_INDIVIDUAL_IO) {
 
-            HDsnprintf(test_title, sizeof(test_title), "parallel vector read test 2 -- %s / col op / ind I/O",
-                       vfd_name);
+            snprintf(test_title, sizeof(test_title), "parallel vector read test 2 -- %s / col op / ind I/O",
+                     vfd_name);
         }
         else {
 
             assert(coll_opt_mode == H5FD_MPIO_COLLECTIVE_IO);
 
-            HDsnprintf(test_title, sizeof(test_title), "parallel vector read test 2 -- %s / col op / col I/O",
-                       vfd_name);
+            snprintf(test_title, sizeof(test_title), "parallel vector read test 2 -- %s / col op / col I/O",
+                     vfd_name);
         }
 
         TESTING(test_title);
@@ -1280,20 +1280,20 @@ vector_read_test_3(int file_name_id, int mpi_rank, int mpi_size, H5FD_mpio_xfer_
 
         if (xfer_mode == H5FD_MPIO_INDEPENDENT) {
 
-            HDsnprintf(test_title, sizeof(test_title), "parallel vector read test 3 -- %s / independent",
-                       vfd_name);
+            snprintf(test_title, sizeof(test_title), "parallel vector read test 3 -- %s / independent",
+                     vfd_name);
         }
         else if (coll_opt_mode == H5FD_MPIO_INDIVIDUAL_IO) {
 
-            HDsnprintf(test_title, sizeof(test_title), "parallel vector read test 3 -- %s / col op / ind I/O",
-                       vfd_name);
+            snprintf(test_title, sizeof(test_title), "parallel vector read test 3 -- %s / col op / ind I/O",
+                     vfd_name);
         }
         else {
 
             assert(coll_opt_mode == H5FD_MPIO_COLLECTIVE_IO);
 
-            HDsnprintf(test_title, sizeof(test_title), "parallel vector read test 3 -- %s / col op / col I/O",
-                       vfd_name);
+            snprintf(test_title, sizeof(test_title), "parallel vector read test 3 -- %s / col op / col I/O",
+                     vfd_name);
         }
 
         TESTING(test_title);
@@ -1633,20 +1633,20 @@ vector_read_test_4(int file_name_id, int mpi_rank, int mpi_size, H5FD_mpio_xfer_
 
         if (xfer_mode == H5FD_MPIO_INDEPENDENT) {
 
-            HDsnprintf(test_title, sizeof(test_title), "parallel vector read test 4 -- %s / independent",
-                       vfd_name);
+            snprintf(test_title, sizeof(test_title), "parallel vector read test 4 -- %s / independent",
+                     vfd_name);
         }
         else if (coll_opt_mode == H5FD_MPIO_INDIVIDUAL_IO) {
 
-            HDsnprintf(test_title, sizeof(test_title), "parallel vector read test 4 -- %s / col op / ind I/O",
-                       vfd_name);
+            snprintf(test_title, sizeof(test_title), "parallel vector read test 4 -- %s / col op / ind I/O",
+                     vfd_name);
         }
         else {
 
             assert(coll_opt_mode == H5FD_MPIO_COLLECTIVE_IO);
 
-            HDsnprintf(test_title, sizeof(test_title), "parallel vector read test 4 -- %s / col op / col I/O",
-                       vfd_name);
+            snprintf(test_title, sizeof(test_title), "parallel vector read test 4 -- %s / col op / col I/O",
+                     vfd_name);
         }
 
         TESTING(test_title);
@@ -2060,20 +2060,20 @@ vector_read_test_5(int file_name_id, int mpi_rank, int mpi_size, H5FD_mpio_xfer_
 
         if (xfer_mode == H5FD_MPIO_INDEPENDENT) {
 
-            HDsnprintf(test_title, sizeof(test_title), "parallel vector read test 5 -- %s / independent",
-                       vfd_name);
+            snprintf(test_title, sizeof(test_title), "parallel vector read test 5 -- %s / independent",
+                     vfd_name);
         }
         else if (coll_opt_mode == H5FD_MPIO_INDIVIDUAL_IO) {
 
-            HDsnprintf(test_title, sizeof(test_title), "parallel vector read test 5 -- %s / col op / ind I/O",
-                       vfd_name);
+            snprintf(test_title, sizeof(test_title), "parallel vector read test 5 -- %s / col op / ind I/O",
+                     vfd_name);
         }
         else {
 
             assert(coll_opt_mode == H5FD_MPIO_COLLECTIVE_IO);
 
-            HDsnprintf(test_title, sizeof(test_title), "parallel vector read test 5 -- %s / col op / col I/O",
-                       vfd_name);
+            snprintf(test_title, sizeof(test_title), "parallel vector read test 5 -- %s / col op / col I/O",
+                     vfd_name);
         }
 
         TESTING(test_title);
@@ -2296,20 +2296,20 @@ vector_write_test_1(int file_name_id, int mpi_rank, int mpi_size, H5FD_mpio_xfer
 
         if (xfer_mode == H5FD_MPIO_INDEPENDENT) {
 
-            HDsnprintf(test_title, sizeof(test_title), "parallel vector write test 1 -- %s / independent",
-                       vfd_name);
+            snprintf(test_title, sizeof(test_title), "parallel vector write test 1 -- %s / independent",
+                     vfd_name);
         }
         else if (coll_opt_mode == H5FD_MPIO_INDIVIDUAL_IO) {
 
-            HDsnprintf(test_title, sizeof(test_title),
-                       "parallel vector write test 1 -- %s / col op / ind I/O", vfd_name);
+            snprintf(test_title, sizeof(test_title), "parallel vector write test 1 -- %s / col op / ind I/O",
+                     vfd_name);
         }
         else {
 
             assert(coll_opt_mode == H5FD_MPIO_COLLECTIVE_IO);
 
-            HDsnprintf(test_title, sizeof(test_title),
-                       "parallel vector write test 1 -- %s / col op / col I/O", vfd_name);
+            snprintf(test_title, sizeof(test_title), "parallel vector write test 1 -- %s / col op / col I/O",
+                     vfd_name);
         }
 
         TESTING(test_title);
@@ -2483,20 +2483,20 @@ vector_write_test_2(int file_name_id, int mpi_rank, int mpi_size, H5FD_mpio_xfer
 
         if (xfer_mode == H5FD_MPIO_INDEPENDENT) {
 
-            HDsnprintf(test_title, sizeof(test_title), "parallel vector write test 2 -- %s / independent",
-                       vfd_name);
+            snprintf(test_title, sizeof(test_title), "parallel vector write test 2 -- %s / independent",
+                     vfd_name);
         }
         else if (coll_opt_mode == H5FD_MPIO_INDIVIDUAL_IO) {
 
-            HDsnprintf(test_title, sizeof(test_title),
-                       "parallel vector write test 2 -- %s / col op / ind I/O", vfd_name);
+            snprintf(test_title, sizeof(test_title), "parallel vector write test 2 -- %s / col op / ind I/O",
+                     vfd_name);
         }
         else {
 
             assert(coll_opt_mode == H5FD_MPIO_COLLECTIVE_IO);
 
-            HDsnprintf(test_title, sizeof(test_title),
-                       "parallel vector write test 2 -- %s / col op / col I/O", vfd_name);
+            snprintf(test_title, sizeof(test_title), "parallel vector write test 2 -- %s / col op / col I/O",
+                     vfd_name);
         }
 
         TESTING(test_title);
@@ -2736,20 +2736,20 @@ vector_write_test_3(int file_name_id, int mpi_rank, int mpi_size, H5FD_mpio_xfer
 
         if (xfer_mode == H5FD_MPIO_INDEPENDENT) {
 
-            HDsnprintf(test_title, sizeof(test_title), "parallel vector write test 3 -- %s / independent",
-                       vfd_name);
+            snprintf(test_title, sizeof(test_title), "parallel vector write test 3 -- %s / independent",
+                     vfd_name);
         }
         else if (coll_opt_mode == H5FD_MPIO_INDIVIDUAL_IO) {
 
-            HDsnprintf(test_title, sizeof(test_title),
-                       "parallel vector write test 3 -- %s / col op / ind I/O", vfd_name);
+            snprintf(test_title, sizeof(test_title), "parallel vector write test 3 -- %s / col op / ind I/O",
+                     vfd_name);
         }
         else {
 
             assert(coll_opt_mode == H5FD_MPIO_COLLECTIVE_IO);
 
-            HDsnprintf(test_title, sizeof(test_title),
-                       "parallel vector write test 3 -- %s / col op / col I/O", vfd_name);
+            snprintf(test_title, sizeof(test_title), "parallel vector write test 3 -- %s / col op / col I/O",
+                     vfd_name);
         }
 
         TESTING(test_title);
@@ -2996,20 +2996,20 @@ vector_write_test_4(int file_name_id, int mpi_rank, int mpi_size, H5FD_mpio_xfer
 
         if (xfer_mode == H5FD_MPIO_INDEPENDENT) {
 
-            HDsnprintf(test_title, sizeof(test_title), "parallel vector write test 4 -- %s / independent",
-                       vfd_name);
+            snprintf(test_title, sizeof(test_title), "parallel vector write test 4 -- %s / independent",
+                     vfd_name);
         }
         else if (coll_opt_mode == H5FD_MPIO_INDIVIDUAL_IO) {
 
-            HDsnprintf(test_title, sizeof(test_title),
-                       "parallel vector write test 4 -- %s / col op / ind I/O", vfd_name);
+            snprintf(test_title, sizeof(test_title), "parallel vector write test 4 -- %s / col op / ind I/O",
+                     vfd_name);
         }
         else {
 
             assert(coll_opt_mode == H5FD_MPIO_COLLECTIVE_IO);
 
-            HDsnprintf(test_title, sizeof(test_title),
-                       "parallel vector write test 4 -- %s / col op / col I/O", vfd_name);
+            snprintf(test_title, sizeof(test_title), "parallel vector write test 4 -- %s / col op / col I/O",
+                     vfd_name);
         }
 
         TESTING(test_title);
@@ -3293,20 +3293,20 @@ vector_write_test_5(int file_name_id, int mpi_rank, int mpi_size, H5FD_mpio_xfer
 
         if (xfer_mode == H5FD_MPIO_INDEPENDENT) {
 
-            HDsnprintf(test_title, sizeof(test_title), "parallel vector write test 5 -- %s / independent",
-                       vfd_name);
+            snprintf(test_title, sizeof(test_title), "parallel vector write test 5 -- %s / independent",
+                     vfd_name);
         }
         else if (coll_opt_mode == H5FD_MPIO_INDIVIDUAL_IO) {
 
-            HDsnprintf(test_title, sizeof(test_title),
-                       "parallel vector write test 5 -- %s / col op / ind I/O", vfd_name);
+            snprintf(test_title, sizeof(test_title), "parallel vector write test 5 -- %s / col op / ind I/O",
+                     vfd_name);
         }
         else {
 
             assert(coll_opt_mode == H5FD_MPIO_COLLECTIVE_IO);
 
-            HDsnprintf(test_title, sizeof(test_title),
-                       "parallel vector write test 5 -- %s / col op / col I/O", vfd_name);
+            snprintf(test_title, sizeof(test_title), "parallel vector write test 5 -- %s / col op / col I/O",
+                     vfd_name);
         }
 
         TESTING(test_title);
@@ -3727,20 +3727,20 @@ vector_write_test_6(int file_name_id, int mpi_rank, int mpi_size, H5FD_mpio_xfer
 
         if (xfer_mode == H5FD_MPIO_INDEPENDENT) {
 
-            HDsnprintf(test_title, sizeof(test_title), "parallel vector write test 6 -- %s / independent",
-                       vfd_name);
+            snprintf(test_title, sizeof(test_title), "parallel vector write test 6 -- %s / independent",
+                     vfd_name);
         }
         else if (coll_opt_mode == H5FD_MPIO_INDIVIDUAL_IO) {
 
-            HDsnprintf(test_title, sizeof(test_title),
-                       "parallel vector write test 6 -- %s / col op / ind I/O", vfd_name);
+            snprintf(test_title, sizeof(test_title), "parallel vector write test 6 -- %s / col op / ind I/O",
+                     vfd_name);
         }
         else {
 
             assert(coll_opt_mode == H5FD_MPIO_COLLECTIVE_IO);
 
-            HDsnprintf(test_title, sizeof(test_title),
-                       "parallel vector write test 6 -- %s / col op / col I/O", vfd_name);
+            snprintf(test_title, sizeof(test_title), "parallel vector write test 6 -- %s / col op / col I/O",
+                     vfd_name);
         }
 
         TESTING(test_title);
@@ -3984,17 +3984,17 @@ vector_write_test_7(int file_name_id, int mpi_rank, int mpi_size, H5FD_mpio_xfer
 
         if (xfer_mode == H5FD_MPIO_INDEPENDENT) {
 
-            HDsprintf(test_title, "parallel vector write test 7 -- %s / independent", vfd_name);
+            sprintf(test_title, "parallel vector write test 7 -- %s / independent", vfd_name);
         }
         else if (coll_opt_mode == H5FD_MPIO_INDIVIDUAL_IO) {
 
-            HDsprintf(test_title, "parallel vector write test 7 -- %s / col op / ind I/O", vfd_name);
+            sprintf(test_title, "parallel vector write test 7 -- %s / col op / ind I/O", vfd_name);
         }
         else {
 
             assert(coll_opt_mode == H5FD_MPIO_COLLECTIVE_IO);
 
-            HDsprintf(test_title, "parallel vector write test 7 -- %s / col op / col I/O", vfd_name);
+            sprintf(test_title, "parallel vector write test 7 -- %s / col op / col I/O", vfd_name);
         }
 
         TESTING(test_title);

--- a/tools/lib/h5diff.c
+++ b/tools/lib/h5diff.c
@@ -183,7 +183,7 @@ is_exclude_path(char *path, h5trav_type_t type, diff_opt_t *opts)
     while (NULL != exclude_path_ptr) {
         /* if exclude path is in group, exclude its members as well */
         if (exclude_path_ptr->obj_type == H5TRAV_TYPE_GROUP) {
-            ret_cmp = HDstrncmp(exclude_path_ptr->obj_path, path, HDstrlen(exclude_path_ptr->obj_path));
+            ret_cmp = strncmp(exclude_path_ptr->obj_path, path, strlen(exclude_path_ptr->obj_path));
             if (ret_cmp == 0) { /* found matching members */
                 size_t len_grp;
 
@@ -192,7 +192,7 @@ is_exclude_path(char *path, h5trav_type_t type, diff_opt_t *opts)
                  * This verifies if “/grp1/dset1” is only under “/grp1”, but
                  * not under “/grp1xxx/” group.
                  */
-                len_grp = HDstrlen(exclude_path_ptr->obj_path);
+                len_grp = strlen(exclude_path_ptr->obj_path);
                 if (path[len_grp] == '/') {
                     /* belong to excluded group! */
                     ret_value = 1;
@@ -202,7 +202,7 @@ is_exclude_path(char *path, h5trav_type_t type, diff_opt_t *opts)
         }
         /* exclude target is not group, just exclude the object */
         else {
-            ret_cmp = HDstrcmp(exclude_path_ptr->obj_path, path);
+            ret_cmp = strcmp(exclude_path_ptr->obj_path, path);
             if (ret_cmp == 0) { /* found matching object */
                 /* excluded non-group object */
                 ret_value = 1;
@@ -247,7 +247,7 @@ is_exclude_attr(const char *path, h5trav_type_t type, diff_opt_t *opts)
     while (NULL != exclude_ptr) {
         /* if exclude path is in group, exclude its members as well */
         if (exclude_ptr->obj_type == H5TRAV_TYPE_GROUP) {
-            ret_cmp = HDstrncmp(exclude_ptr->obj_path, path, HDstrlen(exclude_ptr->obj_path));
+            ret_cmp = strncmp(exclude_ptr->obj_path, path, strlen(exclude_ptr->obj_path));
             if (ret_cmp == 0) { /* found matching members */
                 size_t len_grp;
 
@@ -256,7 +256,7 @@ is_exclude_attr(const char *path, h5trav_type_t type, diff_opt_t *opts)
                  * This verifies if “/grp1/dset1” is only under “/grp1”, but
                  * not under “/grp1xxx/” group.
                  */
-                len_grp = HDstrlen(exclude_ptr->obj_path);
+                len_grp = strlen(exclude_ptr->obj_path);
                 if (path[len_grp] == '/') {
                     /* belong to excluded group! */
                     ret_value = 1;
@@ -266,7 +266,7 @@ is_exclude_attr(const char *path, h5trav_type_t type, diff_opt_t *opts)
         }
         /* exclude target is not group, just exclude the object */
         else {
-            ret_cmp = HDstrcmp(exclude_ptr->obj_path, path);
+            ret_cmp = strcmp(exclude_ptr->obj_path, path);
             if (ret_cmp == 0) { /* found matching object */
                 /* excluded non-group object */
                 ret_value = 1;
@@ -368,11 +368,11 @@ build_match_list(const char *objname1, trav_info_t *info1, const char *objname2,
     H5TOOLS_DEBUG("objname1 = %s objname2 = %s ", objname1, objname2);
 
     /* if obj1 is not root */
-    if (HDstrcmp(objname1, "/") != 0)
-        path1_offset = HDstrlen(objname1);
+    if (strcmp(objname1, "/") != 0)
+        path1_offset = strlen(objname1);
     /* if obj2 is not root */
-    if (HDstrcmp(objname2, "/") != 0)
-        path2_offset = HDstrlen(objname2);
+    if (strcmp(objname2, "/") != 0)
+        path2_offset = strlen(objname2);
 
     /*--------------------------------------------------
      * build the list
@@ -384,7 +384,7 @@ build_match_list(const char *objname1, trav_info_t *info1, const char *objname2,
         type2_l  = info2->paths[curr2].type;
 
         /* criteria is string compare */
-        cmp = HDstrcmp(path1_lp, path2_lp);
+        cmp = strcmp(path1_lp, path2_lp);
         if (cmp == 0) {
             if (!is_exclude_path(path1_lp, type1_l, opts)) {
                 infile[0] = 1;
@@ -703,47 +703,47 @@ h5diff(const char *fname1, const char *fname2, const char *objname1, const char 
     /* if any object is specified */
     if (objname1) {
         /* make the given object1 fullpath, start with "/"  */
-        if (HDstrncmp(objname1, "/", 1) != 0) {
+        if (strncmp(objname1, "/", 1) != 0) {
 #ifdef H5_HAVE_ASPRINTF
             /* Use the asprintf() routine, since it does what we're trying to do below */
             if (asprintf(&obj1fullname, "/%s", objname1) < 0)
                 H5TOOLS_GOTO_ERROR(H5DIFF_ERR, "name buffer allocation failed");
 #else  /* H5_HAVE_ASPRINTF */
             /* (malloc 2 more for "/" and end-of-line) */
-            if ((obj1fullname = (char *)malloc(HDstrlen(objname1) + 2)) == NULL)
+            if ((obj1fullname = (char *)malloc(strlen(objname1) + 2)) == NULL)
                 H5TOOLS_GOTO_ERROR(H5DIFF_ERR, "name buffer allocation failed");
 
-            HDstrcpy(obj1fullname, "/");
-            HDstrcat(obj1fullname, objname1);
+            strcpy(obj1fullname, "/");
+            strcat(obj1fullname, objname1);
 #endif /* H5_HAVE_ASPRINTF */
         }
         else
-            obj1fullname = HDstrdup(objname1);
+            obj1fullname = strdup(objname1);
         H5TOOLS_DEBUG("obj1fullname = %s", obj1fullname);
 
         /* make the given object2 fullpath, start with "/" */
-        if (HDstrncmp(objname2, "/", 1) != 0) {
+        if (strncmp(objname2, "/", 1) != 0) {
 #ifdef H5_HAVE_ASPRINTF
             /* Use the asprintf() routine, since it does what we're trying to do below */
             if (asprintf(&obj2fullname, "/%s", objname2) < 0)
                 H5TOOLS_GOTO_ERROR(H5DIFF_ERR, "name buffer allocation failed");
 #else  /* H5_HAVE_ASPRINTF */
             /* (malloc 2 more for "/" and end-of-line) */
-            if ((obj2fullname = (char *)malloc(HDstrlen(objname2) + 2)) == NULL)
+            if ((obj2fullname = (char *)malloc(strlen(objname2) + 2)) == NULL)
                 H5TOOLS_GOTO_ERROR(H5DIFF_ERR, "name buffer allocation failed");
-            HDstrcpy(obj2fullname, "/");
-            HDstrcat(obj2fullname, objname2);
+            strcpy(obj2fullname, "/");
+            strcat(obj2fullname, objname2);
 #endif /* H5_HAVE_ASPRINTF */
         }
         else
-            obj2fullname = HDstrdup(objname2);
+            obj2fullname = strdup(objname2);
         H5TOOLS_DEBUG("obj2fullname = %s", obj2fullname);
 
         /*----------------------------------------------------------
          * check if obj1 is root, group, single object or symlink
          */
         H5TOOLS_DEBUG("h5diff check if obj1=%s is root, group, single object or symlink", obj1fullname);
-        if (!HDstrcmp(obj1fullname, "/")) {
+        if (!strcmp(obj1fullname, "/")) {
             obj1type = H5TRAV_TYPE_GROUP;
         }
         else {
@@ -793,7 +793,7 @@ h5diff(const char *fname1, const char *fname2, const char *objname1, const char 
          * check if obj2 is root, group, single object or symlink
          */
         H5TOOLS_DEBUG("h5diff check if obj2=%s is root, group, single object or symlink", obj2fullname);
-        if (!HDstrcmp(obj2fullname, "/")) {
+        if (!strcmp(obj2fullname, "/")) {
             obj2type = H5TRAV_TYPE_GROUP;
         }
         else {
@@ -843,9 +843,9 @@ h5diff(const char *fname1, const char *fname2, const char *objname1, const char 
     else {
         H5TOOLS_DEBUG("h5diff no object specified");
         /* set root group */
-        obj1fullname = (char *)HDstrdup("/");
+        obj1fullname = (char *)strdup("/");
         obj1type     = H5TRAV_TYPE_GROUP;
-        obj2fullname = (char *)HDstrdup("/");
+        obj2fullname = (char *)strdup("/");
         obj2type     = H5TRAV_TYPE_GROUP;
     }
 
@@ -996,13 +996,13 @@ h5diff(const char *fname1, const char *fname2, const char *objname1, const char 
     if (g_Parallel) {
         int i;
 
-        if ((HDstrlen(fname1) > MAX_FILENAME) || (HDstrlen(fname2) > MAX_FILENAME)) {
+        if ((strlen(fname1) > MAX_FILENAME) || (strlen(fname2) > MAX_FILENAME)) {
             fprintf(stderr, "The parallel diff only supports path names up to %d characters\n", MAX_FILENAME);
             MPI_Abort(MPI_COMM_WORLD, 0);
         } /* end if */
 
-        HDstrcpy(filenames[0], fname1);
-        HDstrcpy(filenames[1], fname2);
+        strcpy(filenames[0], fname1);
+        strcpy(filenames[1], fname2);
 
         /* Alert the worker tasks that there's going to be work. */
         for (i = 1; i < g_nTasks; i++)
@@ -1028,7 +1028,7 @@ h5diff(const char *fname1, const char *fname2, const char *objname1, const char 
 
             parallel_print("\n");
             /* if given objects is group under root */
-            if (HDstrcmp(obj1fullname, "/") != 0 || HDstrcmp(obj2fullname, "/") != 0)
+            if (strcmp(obj1fullname, "/") != 0 || strcmp(obj2fullname, "/") != 0)
                 parallel_print("group1   group2\n");
             else
                 parallel_print("file1     file2\n");
@@ -1126,9 +1126,9 @@ diff_match(hid_t file1_id, const char *grp1, trav_info_t *info1, hid_t file2_id,
      * if not root, prepare object name to be pre-appended to group path to
      * make full path
      */
-    if (HDstrcmp(grp1, "/") != 0)
+    if (strcmp(grp1, "/") != 0)
         grp1_path = grp1;
-    if (HDstrcmp(grp2, "/") != 0)
+    if (strcmp(grp2, "/") != 0)
         grp2_path = grp2;
 
     /*-------------------------------------------------------------------------
@@ -1186,13 +1186,13 @@ diff_match(hid_t file1_id, const char *grp1, trav_info_t *info1, hid_t file2_id,
                     H5TOOLS_ERROR(H5DIFF_ERR, "name buffer allocation failed");
                 }
 #else  /* H5_HAVE_ASPRINTF */
-            if ((obj1_fullpath = (char *)malloc(HDstrlen(grp1_path) + HDstrlen(table->objs[i].name) + 1)) ==
+            if ((obj1_fullpath = (char *)malloc(strlen(grp1_path) + strlen(table->objs[i].name) + 1)) ==
                 NULL) {
                 H5TOOLS_ERROR(H5DIFF_ERR, "name buffer allocation failed");
             }
             else {
-                HDstrcpy(obj1_fullpath, grp1_path);
-                HDstrcat(obj1_fullpath, table->objs[i].name);
+                strcpy(obj1_fullpath, grp1_path);
+                strcat(obj1_fullpath, table->objs[i].name);
             }
 #endif /* H5_HAVE_ASPRINTF */
                 H5TOOLS_DEBUG("diff_match path1 - %s", obj1_fullpath);
@@ -1204,22 +1204,22 @@ diff_match(hid_t file1_id, const char *grp1, trav_info_t *info1, hid_t file2_id,
                     H5TOOLS_ERROR(H5DIFF_ERR, "name buffer allocation failed");
                 }
 #else  /* H5_HAVE_ASPRINTF */
-            if ((obj2_fullpath = (char *)malloc(HDstrlen(grp2_path) + HDstrlen(table->objs[i].name) + 1)) ==
+            if ((obj2_fullpath = (char *)malloc(strlen(grp2_path) + strlen(table->objs[i].name) + 1)) ==
                 NULL) {
                 H5TOOLS_ERROR(H5DIFF_ERR, "name buffer allocation failed");
             }
             else {
-                HDstrcpy(obj2_fullpath, grp2_path);
-                HDstrcat(obj2_fullpath, table->objs[i].name);
+                strcpy(obj2_fullpath, grp2_path);
+                strcat(obj2_fullpath, table->objs[i].name);
             }
 #endif /* H5_HAVE_ASPRINTF */
                 H5TOOLS_DEBUG("diff_match path2 - %s", obj2_fullpath);
 
                 /* get index to figure out type of the object in file1 */
-                while (info1->paths[idx1].path && (HDstrcmp(obj1_fullpath, info1->paths[idx1].path) != 0))
+                while (info1->paths[idx1].path && (strcmp(obj1_fullpath, info1->paths[idx1].path) != 0))
                     idx1++;
                 /* get index to figure out type of the object in file2 */
-                while (info2->paths[idx2].path && (HDstrcmp(obj2_fullpath, info2->paths[idx2].path) != 0))
+                while (info2->paths[idx2].path && (strcmp(obj2_fullpath, info2->paths[idx2].path) != 0))
                     idx2++;
 
                 /* Set argdata to pass other args into diff() */
@@ -1246,14 +1246,14 @@ diff_match(hid_t file1_id, const char *grp1, trav_info_t *info1, hid_t file2_id,
                      */
 
                     /*Set up args to pass to worker task. */
-                    if (HDstrlen(obj1_fullpath) > 255 || HDstrlen(obj2_fullpath) > 255) {
+                    if (strlen(obj1_fullpath) > 255 || strlen(obj2_fullpath) > 255) {
                         printf("The parallel diff only supports object names up to 255 characters\n");
                         MPI_Abort(MPI_COMM_WORLD, 0);
                     } /* end if */
 
                     /* set args struct to pass */
-                    HDstrcpy(args.name1, obj1_fullpath);
-                    HDstrcpy(args.name2, obj2_fullpath);
+                    strcpy(args.name1, obj1_fullpath);
+                    strcpy(args.name2, obj2_fullpath);
                     args.opts                   = *opts;
                     args.argdata.type[0]        = info1->paths[idx1].type;
                     args.argdata.type[1]        = info2->paths[idx2].type;
@@ -1810,7 +1810,7 @@ diff(hid_t file1_id, const char *path1, hid_t file2_id, const char *path2, diff_
              */
         case H5TRAV_TYPE_LINK: {
             H5TOOLS_DEBUG("H5TRAV_TYPE_LINK 1:%s  2:%s ", path1, path2);
-            status = HDstrcmp(linkinfo1.trg_path, linkinfo2.trg_path);
+            status = strcmp(linkinfo1.trg_path, linkinfo2.trg_path);
 
             /* if the target link name is not same then the links are "different" */
             nfound = (status != 0) ? 1 : 0;

--- a/tools/lib/h5diff_array.c
+++ b/tools/lib/h5diff_array.c
@@ -519,14 +519,14 @@ diff_datum(void *_mem1, void *_mem2, hsize_t elemtno, diff_opt_t *opts, hid_t co
                     /* Get pointer to first string */
                     s1 = *(char **)((void *)mem1);
                     if (s1)
-                        size1 = HDstrlen(s1);
+                        size1 = strlen(s1);
                     else
                         size1 = 0;
 
                     /* Get pointer to second string */
                     s2 = *(char **)((void *)mem2);
                     if (s2)
-                        size2 = HDstrlen(s2);
+                        size2 = strlen(s2);
                     else
                         size2 = 0;
                 }
@@ -535,7 +535,7 @@ diff_datum(void *_mem1, void *_mem2, hsize_t elemtno, diff_opt_t *opts, hid_t co
                     /* Get pointer to first string */
                     s1 = (char *)mem1;
                     if (s1)
-                        size1 = HDstrlen(s1);
+                        size1 = strlen(s1);
                     else
                         size1 = 0;
 
@@ -545,7 +545,7 @@ diff_datum(void *_mem1, void *_mem2, hsize_t elemtno, diff_opt_t *opts, hid_t co
                     /* Get pointer to second string */
                     s2 = (char *)mem2;
                     if (s2)
-                        size2 = HDstrlen(s2);
+                        size2 = strlen(s2);
                     else
                         size2 = 0;
 
@@ -648,11 +648,11 @@ diff_datum(void *_mem1, void *_mem2, hsize_t elemtno, diff_opt_t *opts, hid_t co
                      */
                     err1 = H5Tenum_nameof(opts->m_tid, mem1, enum_name1, sizeof enum_name1);
                     if (err1 < 0)
-                        HDsnprintf(enum_name1, sizeof(enum_name1), "**INVALID VALUE**");
+                        snprintf(enum_name1, sizeof(enum_name1), "**INVALID VALUE**");
 
                     err2 = H5Tenum_nameof(opts->m_tid, mem2, enum_name2, sizeof enum_name2);
                     if (err2 < 0)
-                        HDsnprintf(enum_name2, sizeof(enum_name2), "**INVALID VALUE**");
+                        snprintf(enum_name2, sizeof(enum_name2), "**INVALID VALUE**");
 
                     /* One or more bad enum values */
                     if (err1 < 0 || err2 < 0) {
@@ -669,7 +669,7 @@ diff_datum(void *_mem1, void *_mem2, hsize_t elemtno, diff_opt_t *opts, hid_t co
                     }
                     else {
                         /* Both enum values were valid */
-                        if (HDstrcmp(enum_name1, enum_name2) != 0) {
+                        if (strcmp(enum_name1, enum_name2) != 0) {
                             nfound                 = 1;
                             opts->print_percentage = 0;
                             print_pos(opts, elemtno, 0);

--- a/tools/lib/h5diff_attr.c
+++ b/tools/lib/h5diff_attr.c
@@ -112,7 +112,7 @@ table_attr_mark_exist(const unsigned *exist, char *name, table_attrs_t *table)
         table->attrs[curr_val].exist[0] = exist[0];
         table->attrs[curr_val].exist[1] = exist[1];
         if (name)
-            table->attrs[curr_val].name = (char *)HDstrdup(name);
+            table->attrs[curr_val].name = (char *)strdup(name);
         table->nattrs++;
     }
 }
@@ -186,7 +186,7 @@ build_match_list_attrs(hid_t loc1_id, hid_t loc2_id, table_attrs_t **table_out, 
             H5TOOLS_GOTO_ERROR(FAIL, "H5Aget_name second attribute failed");
 
         /* criteria is string compare */
-        cmp = HDstrcmp(name1, name2);
+        cmp = strcmp(name1, name2);
 
         if (cmp == 0) {
             infile[0] = 1;
@@ -384,19 +384,19 @@ diff_attr_data(hid_t attr1_id, hid_t attr2_id, const char *name1, const char *na
 
     H5TOOLS_DEBUG("attr_names: %s - %s", name1, name2);
     if (name1) {
-        sz = HDstrlen(name1);
+        sz = strlen(name1);
         H5TOOLS_DEBUG("attr1_name: %s - %d", name1, sz);
         if (sz > 0) {
             opts->obj_name[0] = (char *)malloc(sz + 1);
-            HDstrncpy(opts->obj_name[0], name1, sz + 1);
+            strncpy(opts->obj_name[0], name1, sz + 1);
         }
     }
     if (name2) {
-        sz = HDstrlen(name2);
+        sz = strlen(name2);
         H5TOOLS_DEBUG("attr2_name: %s - %d", name2, sz);
         if (sz > 0) {
             opts->obj_name[1] = (char *)malloc(sz + 1);
-            HDstrncpy(opts->obj_name[1], name2, sz + 1);
+            strncpy(opts->obj_name[1], name2, sz + 1);
         }
     }
     H5TOOLS_DEBUG("attr_names: %s - %s", opts->obj_name[0], opts->obj_name[1]);
@@ -464,17 +464,17 @@ diff_attr_data(hid_t attr1_id, hid_t attr2_id, const char *name1, const char *na
 
         H5TOOLS_DEBUG("attr_names: %s - %s : %s - %s", name1, name2, path1, path2);
         if (name1) {
-            sz = HDstrlen(name1) + HDstrlen(path1) + 7;
+            sz = strlen(name1) + strlen(path1) + 7;
             H5TOOLS_DEBUG("attr1_name: %s - %d", name1, sz);
             opts->obj_name[0] = (char *)calloc(sz + 1, sizeof(char));
-            HDsnprintf(opts->obj_name[0], sz, "%s of <%s>", name1, path1);
+            snprintf(opts->obj_name[0], sz, "%s of <%s>", name1, path1);
             opts->obj_name[0][sz] = '\0';
         }
         if (name2) {
-            sz = HDstrlen(name2) + HDstrlen(path2) + 7;
+            sz = strlen(name2) + strlen(path2) + 7;
             H5TOOLS_DEBUG("attr2_name: %s - %d", name2, sz);
             opts->obj_name[1] = (char *)calloc(sz + 1, sizeof(char));
-            HDsnprintf(opts->obj_name[1], sz, "%s of <%s>", name2, path2);
+            snprintf(opts->obj_name[1], sz, "%s of <%s>", name2, path2);
             opts->obj_name[1][sz] = '\0';
         }
 

--- a/tools/lib/h5diff_dset.c
+++ b/tools/lib/h5diff_dset.c
@@ -274,21 +274,21 @@ diff_datasetid(hid_t did1, hid_t did2, const char *obj1_name, const char *obj2_n
     H5TOOLS_DEBUG("obj_names: %s - %s", obj1_name, obj2_name);
     opts->obj_name[0] = NULL;
     if (obj1_name) {
-        j = (int)HDstrlen(obj1_name);
+        j = (int)strlen(obj1_name);
         H5TOOLS_DEBUG("obj1_name: %s - %d", obj1_name, j);
         if (j > 0) {
             opts->obj_name[0] = (char *)malloc((size_t)j + 1);
-            HDstrncpy(opts->obj_name[0], obj1_name, (size_t)j + 1);
+            strncpy(opts->obj_name[0], obj1_name, (size_t)j + 1);
         }
     }
 
     opts->obj_name[1] = NULL;
     if (obj2_name) {
-        j = (int)HDstrlen(obj2_name);
+        j = (int)strlen(obj2_name);
         H5TOOLS_DEBUG("obj2_name: %s - %d", obj2_name, j);
         if (j > 0) {
             opts->obj_name[1] = (char *)malloc((size_t)j + 1);
-            HDstrncpy(opts->obj_name[1], obj2_name, (size_t)j + 1);
+            strncpy(opts->obj_name[1], obj2_name, (size_t)j + 1);
         }
     }
 
@@ -431,9 +431,9 @@ diff_datasetid(hid_t did1, hid_t did2, const char *obj1_name, const char *obj2_n
         opts->obj_name[1] = NULL;
 
         if (obj1_name)
-            opts->obj_name[0] = HDstrdup(diff_basename(obj1_name));
+            opts->obj_name[0] = strdup(diff_basename(obj1_name));
         if (obj2_name)
-            opts->obj_name[1] = HDstrdup(diff_basename(obj2_name));
+            opts->obj_name[1] = strdup(diff_basename(obj2_name));
         H5TOOLS_DEBUG("obj_names: %s - %s", opts->obj_name[0], opts->obj_name[1]);
 
         H5TOOLS_DEBUG("read/compare");

--- a/tools/lib/h5diff_util.c
+++ b/tools/lib/h5diff_util.c
@@ -190,7 +190,7 @@ diff_basename(const char *name)
         return NULL;
 
     /* Find the end of the base name */
-    i = HDstrlen(name);
+    i = strlen(name);
     while (i > 0 && '/' == name[i - 1])
         --i;
 

--- a/tools/lib/h5tools.c
+++ b/tools/lib/h5tools.c
@@ -246,7 +246,7 @@ h5tools_set_data_output_file(const char *fname, int is_bin)
 
     if (rawdatastream && rawdatastream != stdout) {
         if (fclose(rawdatastream))
-            HDperror("closing rawdatastream");
+            perror("closing rawdatastream");
         else
             rawdatastream = NULL;
     }
@@ -294,7 +294,7 @@ h5tools_set_attr_output_file(const char *fname, int is_bin)
 
     if (rawattrstream && rawattrstream != stdout) {
         if (fclose(rawattrstream))
-            HDperror("closing rawattrstream");
+            perror("closing rawattrstream");
         else
             rawattrstream = NULL;
     }
@@ -343,7 +343,7 @@ h5tools_set_input_file(const char *fname, int is_bin)
 
     if (rawinstream && rawinstream != stdin) {
         if (fclose(rawinstream))
-            HDperror("closing rawinstream");
+            perror("closing rawinstream");
         else
             rawinstream = NULL;
     }
@@ -391,7 +391,7 @@ h5tools_set_output_file(const char *fname, int is_bin)
 
     if (rawoutstream && rawoutstream != stdout) {
         if (fclose(rawoutstream))
-            HDperror("closing rawoutstream");
+            perror("closing rawoutstream");
         else
             rawoutstream = NULL;
     }
@@ -438,7 +438,7 @@ h5tools_set_error_file(const char *fname, int is_bin)
 
     if (rawerrorstream && rawerrorstream != stderr) {
         if (fclose(rawerrorstream))
-            HDperror("closing rawerrorstream");
+            perror("closing rawerrorstream");
         else
             rawerrorstream = NULL;
     }
@@ -485,12 +485,12 @@ h5tools_set_fapl_vfd(hid_t fapl_id, h5tools_vfd_info_t *vfd_info)
     switch (vfd_info->type) {
         case VFD_BY_NAME:
             /* Determine which driver the user wants to open the file with */
-            if (!HDstrcmp(vfd_info->u.name, drivernames[SEC2_VFD_IDX])) {
+            if (!strcmp(vfd_info->u.name, drivernames[SEC2_VFD_IDX])) {
                 /* SEC2 Driver */
                 if (H5Pset_fapl_sec2(fapl_id) < 0)
                     H5TOOLS_GOTO_ERROR(FAIL, "H5Pset_fapl_sec2 failed");
             }
-            else if (!HDstrcmp(vfd_info->u.name, drivernames[DIRECT_VFD_IDX])) {
+            else if (!strcmp(vfd_info->u.name, drivernames[DIRECT_VFD_IDX])) {
 #ifdef H5_HAVE_DIRECT
                 /* Direct Driver */
                 if (H5Pset_fapl_direct(fapl_id, 1024, 4096, 8 * 4096) < 0)
@@ -499,14 +499,14 @@ h5tools_set_fapl_vfd(hid_t fapl_id, h5tools_vfd_info_t *vfd_info)
                 H5TOOLS_GOTO_ERROR(FAIL, "Direct VFD is not enabled");
 #endif
             }
-            else if (!HDstrcmp(vfd_info->u.name, drivernames[LOG_VFD_IDX])) {
+            else if (!strcmp(vfd_info->u.name, drivernames[LOG_VFD_IDX])) {
                 unsigned long long log_flags = H5FD_LOG_LOC_IO | H5FD_LOG_ALLOC;
 
                 /* Log Driver */
                 if (H5Pset_fapl_log(fapl_id, NULL, log_flags, (size_t)0) < 0)
                     H5TOOLS_GOTO_ERROR(FAIL, "H5Pset_fapl_log failed");
             }
-            else if (!HDstrcmp(vfd_info->u.name, drivernames[WINDOWS_VFD_IDX])) {
+            else if (!strcmp(vfd_info->u.name, drivernames[WINDOWS_VFD_IDX])) {
 #ifdef H5_HAVE_WINDOWS
                 /* There is no Windows VFD - use SEC2 */
                 if (H5Pset_fapl_sec2(fapl_id) < 0)
@@ -515,17 +515,17 @@ h5tools_set_fapl_vfd(hid_t fapl_id, h5tools_vfd_info_t *vfd_info)
                 H5TOOLS_GOTO_ERROR(FAIL, "Windows VFD is not enabled");
 #endif
             }
-            else if (!HDstrcmp(vfd_info->u.name, drivernames[STDIO_VFD_IDX])) {
+            else if (!strcmp(vfd_info->u.name, drivernames[STDIO_VFD_IDX])) {
                 /* Stdio Driver */
                 if (H5Pset_fapl_stdio(fapl_id) < 0)
                     H5TOOLS_GOTO_ERROR(FAIL, "H5Pset_fapl_stdio failed");
             }
-            else if (!HDstrcmp(vfd_info->u.name, drivernames[CORE_VFD_IDX])) {
+            else if (!strcmp(vfd_info->u.name, drivernames[CORE_VFD_IDX])) {
                 /* Core Driver */
                 if (H5Pset_fapl_core(fapl_id, (size_t)H5_MB, true) < 0)
                     H5TOOLS_GOTO_ERROR(FAIL, "H5Pset_fapl_core failed");
             }
-            else if (!HDstrcmp(vfd_info->u.name, drivernames[FAMILY_VFD_IDX])) {
+            else if (!strcmp(vfd_info->u.name, drivernames[FAMILY_VFD_IDX])) {
                 /* FAMILY Driver */
                 /* Set member size to be 0 to indicate the current first member size
                  * is the member size.
@@ -533,17 +533,17 @@ h5tools_set_fapl_vfd(hid_t fapl_id, h5tools_vfd_info_t *vfd_info)
                 if (H5Pset_fapl_family(fapl_id, (hsize_t)0, H5P_DEFAULT) < 0)
                     H5TOOLS_GOTO_ERROR(FAIL, "H5Pset_fapl_family failed");
             }
-            else if (!HDstrcmp(vfd_info->u.name, drivernames[SPLIT_VFD_IDX])) {
+            else if (!strcmp(vfd_info->u.name, drivernames[SPLIT_VFD_IDX])) {
                 /* SPLIT Driver */
                 if (H5Pset_fapl_split(fapl_id, "-m.h5", H5P_DEFAULT, "-r.h5", H5P_DEFAULT) < 0)
                     H5TOOLS_GOTO_ERROR(FAIL, "H5Pset_fapl_split failed");
             }
-            else if (!HDstrcmp(vfd_info->u.name, drivernames[MULTI_VFD_IDX])) {
+            else if (!strcmp(vfd_info->u.name, drivernames[MULTI_VFD_IDX])) {
                 /* MULTI Driver */
                 if (H5Pset_fapl_multi(fapl_id, NULL, NULL, NULL, NULL, true) < 0)
                     H5TOOLS_GOTO_ERROR(FAIL, "H5Pset_fapl_multi failed");
             }
-            else if (!HDstrcmp(vfd_info->u.name, drivernames[MPIO_VFD_IDX])) {
+            else if (!strcmp(vfd_info->u.name, drivernames[MPIO_VFD_IDX])) {
 #ifdef H5_HAVE_PARALLEL
                 int mpi_initialized, mpi_finalized;
 
@@ -561,7 +561,7 @@ h5tools_set_fapl_vfd(hid_t fapl_id, h5tools_vfd_info_t *vfd_info)
                 H5TOOLS_GOTO_ERROR(FAIL, "MPI-I/O VFD is not enabled");
 #endif /* H5_HAVE_PARALLEL */
             }
-            else if (!HDstrcmp(vfd_info->u.name, drivernames[ROS3_VFD_IDX])) {
+            else if (!strcmp(vfd_info->u.name, drivernames[ROS3_VFD_IDX])) {
 #ifdef H5_HAVE_ROS3_VFD
                 if (!vfd_info->info)
                     H5TOOLS_GOTO_ERROR(FAIL, "Read-only S3 VFD info is invalid");
@@ -575,7 +575,7 @@ h5tools_set_fapl_vfd(hid_t fapl_id, h5tools_vfd_info_t *vfd_info)
                 H5TOOLS_GOTO_ERROR(FAIL, "Read-only S3 VFD is not enabled");
 #endif
             }
-            else if (!HDstrcmp(vfd_info->u.name, drivernames[HDFS_VFD_IDX])) {
+            else if (!strcmp(vfd_info->u.name, drivernames[HDFS_VFD_IDX])) {
 #ifdef H5_HAVE_LIBHDFS
                 if (!vfd_info->info)
                     H5TOOLS_GOTO_ERROR(FAIL, "HDFS VFD info is invalid");
@@ -585,7 +585,7 @@ h5tools_set_fapl_vfd(hid_t fapl_id, h5tools_vfd_info_t *vfd_info)
                 H5TOOLS_GOTO_ERROR(FAIL, "The HDFS VFD is not enabled");
 #endif
             }
-            else if (!HDstrcmp(vfd_info->u.name, drivernames[SUBFILING_VFD_IDX])) {
+            else if (!strcmp(vfd_info->u.name, drivernames[SUBFILING_VFD_IDX])) {
 #if defined(H5_HAVE_PARALLEL) && defined(H5_HAVE_SUBFILING_VFD)
                 int mpi_initialized, mpi_finalized;
 
@@ -601,7 +601,7 @@ h5tools_set_fapl_vfd(hid_t fapl_id, h5tools_vfd_info_t *vfd_info)
                 H5TOOLS_GOTO_ERROR(FAIL, "The Subfiling VFD is not enabled");
 #endif
             }
-            else if (!HDstrcmp(vfd_info->u.name, drivernames[ONION_VFD_IDX])) {
+            else if (!strcmp(vfd_info->u.name, drivernames[ONION_VFD_IDX])) {
                 /* Onion driver */
                 if (!vfd_info->info)
                     H5TOOLS_GOTO_ERROR(FAIL, "Onion VFD info is invalid");
@@ -676,10 +676,10 @@ h5tools_set_fapl_vol(hid_t fapl_id, h5tools_vol_info_t *vol_info)
                 /* Check for VOL connectors that ship with the library, then try
                  * registering by name if that fails.
                  */
-                if (!HDstrcmp(vol_info->u.name, H5VL_NATIVE_NAME)) {
+                if (!strcmp(vol_info->u.name, H5VL_NATIVE_NAME)) {
                     connector_id = H5VL_NATIVE;
                 }
-                else if (!HDstrcmp(vol_info->u.name, H5VL_PASSTHRU_NAME)) {
+                else if (!strcmp(vol_info->u.name, H5VL_PASSTHRU_NAME)) {
                     connector_id = H5VL_PASSTHRU;
                 }
                 else {
@@ -895,7 +895,7 @@ h5tools_get_vfd_name(hid_t fid, hid_t fapl_id, char *drivername, size_t driverna
         else
             driver_name = "unknown";
 
-        HDstrncpy(drivername, driver_name, drivername_size);
+        strncpy(drivername, driver_name, drivername_size);
         drivername[drivername_size - 1] = '\0';
     }
 
@@ -1241,7 +1241,7 @@ h5tools_simple_prefix(FILE *stream, const h5tool_format_t *info, h5tools_context
                   ctx->cur_column, info->idx_fmt, info->line_suf);
     if (ctx->cur_column) {
         PUTSTREAM(OPT(info->line_suf, ""), stream);
-        HDputc('\n', stream);
+        putc('\n', stream);
         PUTSTREAM(OPT(info->line_sep, ""), stream);
     }
     H5TOOLS_DEBUG("after CR elmtno=%ld, ctx->ndims=%d", elmtno, ctx->ndims);
@@ -1334,7 +1334,7 @@ h5tools_region_simple_prefix(FILE *stream, const h5tool_format_t *info, h5tools_
     /* Terminate previous line, if any */
     if (ctx->cur_column) {
         PUTSTREAM(OPT(info->line_suf, ""), stream);
-        HDputc('\n', stream);
+        putc('\n', stream);
         PUTSTREAM(OPT(info->line_sep, ""), stream);
     }
 
@@ -1436,8 +1436,8 @@ h5tools_render_element(FILE *stream, const h5tool_format_t *info, h5tools_contex
      * current location...
      */
     if (info->line_multi_new == 1 &&
-        (ctx->cur_column + h5tools_count_ncols(s) + HDstrlen(OPT(info->elmt_suf2, " ")) +
-         HDstrlen(OPT(info->line_suf, ""))) > ncols) {
+        (ctx->cur_column + h5tools_count_ncols(s) + strlen(OPT(info->elmt_suf2, " ")) +
+         strlen(OPT(info->line_suf, ""))) > ncols) {
         if (ctx->prev_multiline) {
             /*
              * ... and the previous element also occupied more than one
@@ -1445,8 +1445,8 @@ h5tools_render_element(FILE *stream, const h5tool_format_t *info, h5tools_contex
              */
             ctx->need_prefix = true;
         }
-        else if ((ctx->prev_prefix_len + h5tools_count_ncols(s) + HDstrlen(OPT(info->elmt_suf2, " ")) +
-                  HDstrlen(OPT(info->line_suf, ""))) <= ncols) {
+        else if ((ctx->prev_prefix_len + h5tools_count_ncols(s) + strlen(OPT(info->elmt_suf2, " ")) +
+                  strlen(OPT(info->line_suf, ""))) <= ncols) {
             /*
              * ...but *could* fit on one line otherwise, then we
              * should end the current line and start this element on its
@@ -1481,8 +1481,8 @@ h5tools_render_element(FILE *stream, const h5tool_format_t *info, h5tools_contex
      * beginning of the line.
      */
     if (info->line_multi_new == 1 && ctx->prev_multiline &&
-        (ctx->cur_column + h5tools_count_ncols(s) + HDstrlen(OPT(info->elmt_suf2, " ")) +
-         HDstrlen(OPT(info->line_suf, ""))) > ncols)
+        (ctx->cur_column + h5tools_count_ncols(s) + strlen(OPT(info->elmt_suf2, " ")) +
+         strlen(OPT(info->line_suf, ""))) > ncols)
         ctx->need_prefix = true;
     H5TOOLS_DEBUG("ctx->need_prefix=%d", ctx->need_prefix);
 
@@ -1500,7 +1500,7 @@ h5tools_render_element(FILE *stream, const h5tool_format_t *info, h5tools_contex
      * one-at a time.
      */
     multiline = 0;
-    for (secnum = 0, multiline = 0; (section = HDstrtok(secnum ? NULL : s, OPTIONAL_LINE_BREAK)); secnum++) {
+    for (secnum = 0, multiline = 0; (section = strtok(secnum ? NULL : s, OPTIONAL_LINE_BREAK)); secnum++) {
         /*
          * If the current section plus possible suffix and end-of-line
          * information would cause the output to wrap then we need to
@@ -1510,8 +1510,8 @@ h5tools_render_element(FILE *stream, const h5tool_format_t *info, h5tools_contex
         /*
          * check for displaying prefix for each section
          */
-        if ((ctx->cur_column + HDstrlen(section) + HDstrlen(OPT(info->elmt_suf2, " ")) +
-             HDstrlen(OPT(info->line_suf, ""))) > ncols)
+        if ((ctx->cur_column + strlen(section) + strlen(OPT(info->elmt_suf2, " ")) +
+             strlen(OPT(info->line_suf, ""))) > ncols)
             ctx->need_prefix = 1;
 
         /*
@@ -1535,13 +1535,13 @@ h5tools_render_element(FILE *stream, const h5tool_format_t *info, h5tools_contex
         }
         else if ((local_elmt_counter || ctx->continuation) && secnum == 0) {
             PUTSTREAM(OPT(info->elmt_suf2, " "), stream);
-            ctx->cur_column += HDstrlen(OPT(info->elmt_suf2, " "));
+            ctx->cur_column += strlen(OPT(info->elmt_suf2, " "));
         }
         H5TOOLS_DEBUG("section=%s", section);
 
         /* Print the section */
         PUTSTREAM(section, stream);
-        ctx->cur_column += HDstrlen(section);
+        ctx->cur_column += strlen(section);
     }
 
     ctx->prev_multiline = multiline;
@@ -1597,8 +1597,8 @@ h5tools_render_region_element(FILE *stream, const h5tool_format_t *info, h5tools
      * current location...
      */
     if (info->line_multi_new == 1 &&
-        (ctx->cur_column + h5tools_count_ncols(s) + HDstrlen(OPT(info->elmt_suf2, " ")) +
-         HDstrlen(OPT(info->line_suf, ""))) > ncols) {
+        (ctx->cur_column + h5tools_count_ncols(s) + strlen(OPT(info->elmt_suf2, " ")) +
+         strlen(OPT(info->line_suf, ""))) > ncols) {
         if (ctx->prev_multiline) {
             /*
              * ... and the previous element also occupied more than one
@@ -1606,8 +1606,8 @@ h5tools_render_region_element(FILE *stream, const h5tool_format_t *info, h5tools
              */
             ctx->need_prefix = true;
         }
-        else if ((ctx->prev_prefix_len + h5tools_count_ncols(s) + HDstrlen(OPT(info->elmt_suf2, " ")) +
-                  HDstrlen(OPT(info->line_suf, ""))) <= ncols) {
+        else if ((ctx->prev_prefix_len + h5tools_count_ncols(s) + strlen(OPT(info->elmt_suf2, " ")) +
+                  strlen(OPT(info->line_suf, ""))) <= ncols) {
             /*
              * ...but *could* fit on one line otherwise, then we
              * should end the current line and start this element on its
@@ -1638,8 +1638,8 @@ h5tools_render_region_element(FILE *stream, const h5tool_format_t *info, h5tools
      * beginning of the line.
      */
     if (info->line_multi_new == 1 && ctx->prev_multiline &&
-        (ctx->cur_column + h5tools_count_ncols(s) + HDstrlen(OPT(info->elmt_suf2, " ")) +
-         HDstrlen(OPT(info->line_suf, ""))) > ncols)
+        (ctx->cur_column + h5tools_count_ncols(s) + strlen(OPT(info->elmt_suf2, " ")) +
+         strlen(OPT(info->line_suf, ""))) > ncols)
         ctx->need_prefix = true;
 
     /*
@@ -1655,7 +1655,7 @@ h5tools_render_region_element(FILE *stream, const h5tool_format_t *info, h5tools
      * one-at a time.
      */
     multiline = 0;
-    for (secnum = 0, multiline = 0; (section = HDstrtok(secnum ? NULL : s, OPTIONAL_LINE_BREAK)); secnum++) {
+    for (secnum = 0, multiline = 0; (section = strtok(secnum ? NULL : s, OPTIONAL_LINE_BREAK)); secnum++) {
         /*
          * If the current section plus possible suffix and end-of-line
          * information would cause the output to wrap then we need to
@@ -1667,8 +1667,8 @@ h5tools_render_region_element(FILE *stream, const h5tool_format_t *info, h5tools
          * this check to happen for the first line
          */
         if ((!info->skip_first || local_elmt_counter) &&
-            (ctx->cur_column + HDstrlen(section) + HDstrlen(OPT(info->elmt_suf2, " ")) +
-             HDstrlen(OPT(info->line_suf, ""))) > ncols)
+            (ctx->cur_column + strlen(section) + strlen(OPT(info->elmt_suf2, " ")) +
+             strlen(OPT(info->line_suf, ""))) > ncols)
             ctx->need_prefix = 1;
 
         /*
@@ -1690,12 +1690,12 @@ h5tools_render_region_element(FILE *stream, const h5tool_format_t *info, h5tools
         }
         else if ((local_elmt_counter || ctx->continuation) && secnum == 0) {
             PUTSTREAM(OPT(info->elmt_suf2, " "), stream);
-            ctx->cur_column += HDstrlen(OPT(info->elmt_suf2, " "));
+            ctx->cur_column += strlen(OPT(info->elmt_suf2, " "));
         }
 
         /* Print the section */
         PUTSTREAM(section, stream);
-        ctx->cur_column += HDstrlen(section);
+        ctx->cur_column += strlen(section);
     }
 
     ctx->prev_multiline = multiline;
@@ -1838,7 +1838,7 @@ render_bin_output(FILE *stream, hid_t container, hid_t tid, void *_mem, hsize_t 
                 if (H5Tis_variable_str(tid)) {
                     s = *(char **)((void *)mem);
                     if (s != NULL)
-                        size = HDstrlen(s);
+                        size = strlen(s);
                     else
                         H5TOOLS_THROW((-1), "NULL string");
                 }
@@ -2333,12 +2333,12 @@ h5tools_is_obj_same(hid_t loc_id1, const char *name1, hid_t loc_id2, const char 
     H5O_info2_t oinfo1, oinfo2;
     bool        ret_val = false;
 
-    if (name1 && HDstrcmp(name1, ".") != 0)
+    if (name1 && strcmp(name1, ".") != 0)
         H5Oget_info_by_name3(loc_id1, name1, &oinfo1, H5O_INFO_BASIC, H5P_DEFAULT);
     else
         H5Oget_info3(loc_id1, &oinfo1, H5O_INFO_BASIC);
 
-    if (name2 && HDstrcmp(name2, ".") != 0)
+    if (name2 && strcmp(name2, ".") != 0)
         H5Oget_info_by_name3(loc_id2, name2, &oinfo2, H5O_INFO_BASIC, H5P_DEFAULT);
     else
         H5Oget_info3(loc_id2, &oinfo2, H5O_INFO_BASIC);

--- a/tools/lib/h5tools.h
+++ b/tools/lib/h5tools.h
@@ -40,7 +40,7 @@
 #define PUTSTREAM(X, S)                                                                                      \
     do {                                                                                                     \
         if (S != NULL)                                                                                       \
-            HDfputs(X, S);                                                                                   \
+            fputs(X, S);                                                                                     \
     } while (0)
 
 /*

--- a/tools/lib/h5tools_dump.c
+++ b/tools/lib/h5tools_dump.c
@@ -391,12 +391,12 @@ h5tools_dump_region_attribute(hid_t region_id, FILE *stream, const h5tool_format
     h5tools_print_datatype(stream, buffer, info, ctx, atype, true);
     ctx->indent_level--;
 
-    if (HDstrlen(h5tools_dump_header_format->datatypeblockend)) {
+    if (strlen(h5tools_dump_header_format->datatypeblockend)) {
         h5tools_str_append(buffer, "%s", h5tools_dump_header_format->datatypeblockend);
-        if (HDstrlen(h5tools_dump_header_format->datatypeend))
+        if (strlen(h5tools_dump_header_format->datatypeend))
             h5tools_str_append(buffer, " ");
     }
-    if (HDstrlen(h5tools_dump_header_format->datatypeend))
+    if (strlen(h5tools_dump_header_format->datatypeend))
         h5tools_str_append(buffer, "%s", h5tools_dump_header_format->datatypeend);
 
     dimension_break =
@@ -411,12 +411,12 @@ h5tools_dump_region_attribute(hid_t region_id, FILE *stream, const h5tool_format
 
     h5tools_print_dataspace(buffer, region_space);
 
-    if (HDstrlen(h5tools_dump_header_format->dataspaceblockend)) {
+    if (strlen(h5tools_dump_header_format->dataspaceblockend)) {
         h5tools_str_append(buffer, "%s", h5tools_dump_header_format->dataspaceblockend);
-        if (HDstrlen(h5tools_dump_header_format->dataspaceend))
+        if (strlen(h5tools_dump_header_format->dataspaceend))
             h5tools_str_append(buffer, " ");
     }
-    if (HDstrlen(h5tools_dump_header_format->dataspaceend))
+    if (strlen(h5tools_dump_header_format->dataspaceend))
         h5tools_str_append(buffer, "%s", h5tools_dump_header_format->dataspaceblockend);
 
     dimension_break =
@@ -765,12 +765,12 @@ h5tools_dump_region_data_blocks(hid_t region_space, hid_t region_id, FILE *strea
     h5tools_print_datatype(stream, buffer, info, ctx, dtype, true);
     ctx->indent_level--;
 
-    if (HDstrlen(h5tools_dump_header_format->datatypeblockend)) {
+    if (strlen(h5tools_dump_header_format->datatypeblockend)) {
         h5tools_str_append(buffer, "%s", h5tools_dump_header_format->datatypeblockend);
-        if (HDstrlen(h5tools_dump_header_format->datatypeend))
+        if (strlen(h5tools_dump_header_format->datatypeend))
             h5tools_str_append(buffer, " ");
     }
-    if (HDstrlen(h5tools_dump_header_format->datatypeend))
+    if (strlen(h5tools_dump_header_format->datatypeend))
         h5tools_str_append(buffer, "%s", h5tools_dump_header_format->datatypeend);
 
     dimension_break =
@@ -785,12 +785,12 @@ h5tools_dump_region_data_blocks(hid_t region_space, hid_t region_id, FILE *strea
 
     h5tools_print_dataspace(buffer, region_space);
 
-    if (HDstrlen(h5tools_dump_header_format->dataspaceblockend)) {
+    if (strlen(h5tools_dump_header_format->dataspaceblockend)) {
         h5tools_str_append(buffer, "%s", h5tools_dump_header_format->dataspaceblockend);
-        if (HDstrlen(h5tools_dump_header_format->dataspaceend))
+        if (strlen(h5tools_dump_header_format->dataspaceend))
             h5tools_str_append(buffer, " ");
     }
-    if (HDstrlen(h5tools_dump_header_format->dataspaceend))
+    if (strlen(h5tools_dump_header_format->dataspaceend))
         h5tools_str_append(buffer, "%s", h5tools_dump_header_format->dataspaceblockend);
 
     dimension_break =
@@ -828,13 +828,13 @@ done:
 
         /* Render the dataend element begin */
         h5tools_str_reset(buffer);
-        if (HDstrlen(h5tools_dump_header_format->datablockend)) {
+        if (strlen(h5tools_dump_header_format->datablockend)) {
             h5tools_str_append(buffer, "%s", h5tools_dump_header_format->datablockend);
-            if (HDstrlen(h5tools_dump_header_format->dataend))
+            if (strlen(h5tools_dump_header_format->dataend))
                 h5tools_str_append(buffer, " ");
         }
 
-        if (HDstrlen(h5tools_dump_header_format->dataend))
+        if (strlen(h5tools_dump_header_format->dataend))
             h5tools_str_append(buffer, "%s", h5tools_dump_header_format->dataend);
         dimension_break = h5tools_render_element(stream, &outputformat, ctx, buffer, curr_pos, ncols,
                                                  region_elmt_counter, elmt_counter);
@@ -1119,12 +1119,12 @@ h5tools_dump_region_data_points(hid_t region_space, hid_t region_id, FILE *strea
     h5tools_print_datatype(stream, buffer, info, ctx, dtype, true);
     ctx->indent_level--;
 
-    if (HDstrlen(h5tools_dump_header_format->datatypeblockend)) {
+    if (strlen(h5tools_dump_header_format->datatypeblockend)) {
         h5tools_str_append(buffer, "%s", h5tools_dump_header_format->datatypeblockend);
-        if (HDstrlen(h5tools_dump_header_format->datatypeend))
+        if (strlen(h5tools_dump_header_format->datatypeend))
             h5tools_str_append(buffer, " ");
     }
-    if (HDstrlen(h5tools_dump_header_format->datatypeend))
+    if (strlen(h5tools_dump_header_format->datatypeend))
         h5tools_str_append(buffer, "%s", h5tools_dump_header_format->datatypeend);
 
     dimension_break =
@@ -1139,12 +1139,12 @@ h5tools_dump_region_data_points(hid_t region_space, hid_t region_id, FILE *strea
 
     h5tools_print_dataspace(buffer, region_space);
 
-    if (HDstrlen(h5tools_dump_header_format->dataspaceblockend)) {
+    if (strlen(h5tools_dump_header_format->dataspaceblockend)) {
         h5tools_str_append(buffer, "%s", h5tools_dump_header_format->dataspaceblockend);
-        if (HDstrlen(h5tools_dump_header_format->dataspaceend))
+        if (strlen(h5tools_dump_header_format->dataspaceend))
             h5tools_str_append(buffer, " ");
     }
-    if (HDstrlen(h5tools_dump_header_format->dataspaceend))
+    if (strlen(h5tools_dump_header_format->dataspaceend))
         h5tools_str_append(buffer, "%s", h5tools_dump_header_format->dataspaceblockend);
 
     dimension_break =
@@ -1183,13 +1183,13 @@ done:
 
         /* Render the dataend element begin */
         h5tools_str_reset(buffer);
-        if (HDstrlen(h5tools_dump_header_format->datablockend)) {
+        if (strlen(h5tools_dump_header_format->datablockend)) {
             h5tools_str_append(buffer, "%s", h5tools_dump_header_format->datablockend);
-            if (HDstrlen(h5tools_dump_header_format->dataend))
+            if (strlen(h5tools_dump_header_format->dataend))
                 h5tools_str_append(buffer, " ");
         }
 
-        if (HDstrlen(h5tools_dump_header_format->dataend))
+        if (strlen(h5tools_dump_header_format->dataend))
             h5tools_str_append(buffer, "%s", h5tools_dump_header_format->dataend);
         dimension_break = h5tools_render_element(stream, &outputformat, ctx, buffer, curr_pos, ncols,
                                                  region_elmt_counter, elmt_counter);
@@ -2807,7 +2807,7 @@ h5tools_print_enum(FILE *stream, h5tools_str_t *buffer, const h5tool_format_t *i
 
         h5tools_str_reset(buffer);
         h5tools_str_append(buffer, "\"%s\"", name[i]);
-        nchars = (int)HDstrlen(name[i]);
+        nchars = (int)strlen(name[i]);
         h5tools_str_append(buffer, "%*s ", MAX(0, 16 - nchars), "");
 
         if (native < 0) {
@@ -2891,12 +2891,12 @@ h5tools_dump_datatype(FILE *stream, const h5tool_format_t *info, h5tools_context
     h5tools_str_append(&buffer, "%s %s ", h5tools_dump_header_format->datatypebegin,
                        h5tools_dump_header_format->datatypeblockbegin);
     h5tools_print_datatype(stream, &buffer, info, ctx, type, true);
-    if (HDstrlen(h5tools_dump_header_format->datatypeblockend)) {
+    if (strlen(h5tools_dump_header_format->datatypeblockend)) {
         h5tools_str_append(&buffer, "%s", h5tools_dump_header_format->datatypeblockend);
-        if (HDstrlen(h5tools_dump_header_format->datatypeend))
+        if (strlen(h5tools_dump_header_format->datatypeend))
             h5tools_str_append(&buffer, " ");
     }
-    if (HDstrlen(h5tools_dump_header_format->datatypeend))
+    if (strlen(h5tools_dump_header_format->datatypeend))
         h5tools_str_append(&buffer, "%s", h5tools_dump_header_format->datatypeend);
 
     h5tools_render_element(stream, info, ctx, &buffer, &curr_pos, (size_t)ncols, (hsize_t)0, (hsize_t)0);
@@ -2938,12 +2938,12 @@ h5tools_dump_dataspace(FILE *stream, const h5tool_format_t *info, h5tools_contex
 
     h5tools_print_dataspace(&buffer, type);
 
-    if (HDstrlen(h5tools_dump_header_format->dataspaceblockend)) {
+    if (strlen(h5tools_dump_header_format->dataspaceblockend)) {
         h5tools_str_append(&buffer, "%s", h5tools_dump_header_format->dataspaceblockend);
-        if (HDstrlen(h5tools_dump_header_format->dataspaceend))
+        if (strlen(h5tools_dump_header_format->dataspaceend))
             h5tools_str_append(&buffer, " ");
     }
-    if (HDstrlen(h5tools_dump_header_format->dataspaceend))
+    if (strlen(h5tools_dump_header_format->dataspaceend))
         h5tools_str_append(&buffer, "%s", h5tools_dump_header_format->dataspaceend);
 
     h5tools_render_element(stream, info, ctx, &buffer, &curr_pos, (size_t)ncols, (hsize_t)0, (hsize_t)0);
@@ -3154,7 +3154,7 @@ h5tools_dump_dcpl(FILE *stream, const h5tool_format_t *info, h5tools_context_t *
     if (dcpl_id >= 0)
         nfilters = H5Pget_nfilters(dcpl_id);
 
-    HDstrcpy(f_name, "\0");
+    strcpy(f_name, "\0");
 
     /*-------------------------------------------------------------------------
      * STORAGE_LAYOUT
@@ -3897,12 +3897,12 @@ h5tools_dump_attribute(FILE *stream, const h5tool_format_t *info, h5tools_contex
 
     h5tools_str_reset(&buffer);
 
-    if (HDstrlen(h5tools_dump_header_format->attributeblockend)) {
+    if (strlen(h5tools_dump_header_format->attributeblockend)) {
         h5tools_str_append(&buffer, "%s", h5tools_dump_header_format->attributeblockend);
-        if (HDstrlen(h5tools_dump_header_format->attributeend))
+        if (strlen(h5tools_dump_header_format->attributeend))
             h5tools_str_append(&buffer, " ");
     }
-    if (HDstrlen(h5tools_dump_header_format->attributeend))
+    if (strlen(h5tools_dump_header_format->attributeend))
         h5tools_str_append(&buffer, "%s", h5tools_dump_header_format->attributeend);
 
     h5tools_render_element(stream, info, ctx, &buffer, &curr_pos, (size_t)ncols, (hsize_t)0, (hsize_t)0);
@@ -4478,13 +4478,13 @@ done:
     h5tools_simple_prefix(stream, &outputformat, ctx, (hsize_t)0, 0);
 
     h5tools_str_reset(&buffer);
-    if (HDstrlen(h5tools_dump_header_format->datablockend)) {
+    if (strlen(h5tools_dump_header_format->datablockend)) {
         h5tools_str_append(&buffer, "%s", h5tools_dump_header_format->datablockend);
-        if (HDstrlen(h5tools_dump_header_format->dataend))
+        if (strlen(h5tools_dump_header_format->dataend))
             h5tools_str_append(&buffer, " ");
     }
 
-    if (HDstrlen(h5tools_dump_header_format->dataend))
+    if (strlen(h5tools_dump_header_format->dataend))
         h5tools_str_append(&buffer, "%s", h5tools_dump_header_format->dataend);
     h5tools_render_element(stream, &outputformat, ctx, &buffer, &curr_pos, (size_t)ncols, (hsize_t)0,
                            (hsize_t)0);
@@ -4496,12 +4496,12 @@ done:
         h5tools_simple_prefix(stream, &outputformat, ctx, (hsize_t)0, 0);
 
         h5tools_str_reset(&buffer);
-        if (HDstrlen(h5tools_dump_header_format->subsettingblockend)) {
+        if (strlen(h5tools_dump_header_format->subsettingblockend)) {
             h5tools_str_append(&buffer, "%s", h5tools_dump_header_format->subsettingblockend);
-            if (HDstrlen(h5tools_dump_header_format->subsettingend))
+            if (strlen(h5tools_dump_header_format->subsettingend))
                 h5tools_str_append(&buffer, " ");
         }
-        if (HDstrlen(h5tools_dump_header_format->subsettingend))
+        if (strlen(h5tools_dump_header_format->subsettingend))
             h5tools_str_append(&buffer, "%s", h5tools_dump_header_format->subsettingend);
         h5tools_render_element(stream, &outputformat, ctx, &buffer, &curr_pos, (size_t)ncols, (hsize_t)0,
                                (hsize_t)0);

--- a/tools/lib/h5tools_error.h
+++ b/tools/lib/h5tools_error.h
@@ -36,7 +36,7 @@ H5TOOLS_DLLVAR hid_t H5E_tools_min_dbg_id_g;
         char lib_str[256];                                                                                   \
                                                                                                              \
         /* Initialize library version string for error class */                                              \
-        HDsnprintf(lib_str, sizeof(lib_str), "%d.%d.%d", H5_VERS_MAJOR, H5_VERS_MINOR, H5_VERS_RELEASE);     \
+        snprintf(lib_str, sizeof(lib_str), "%d.%d.%d", H5_VERS_MAJOR, H5_VERS_MINOR, H5_VERS_RELEASE);       \
                                                                                                              \
         /* Create new HDF5 error stack for the tools to use */                                               \
         if ((H5tools_ERR_STACK_g = H5Ecreate_stack()) < 0)                                                   \

--- a/tools/lib/h5tools_ref.c
+++ b/tools/lib/h5tools_ref.c
@@ -180,10 +180,10 @@ ref_path_table_lookup(const char *thepath, H5O_token_t *token)
 {
     H5O_info2_t oi;
 
-    if ((thepath == NULL) || (HDstrlen(thepath) == 0))
+    if ((thepath == NULL) || (strlen(thepath) == 0))
         return -1;
     /* Allow lookups on the root group, even though it doesn't have any link info */
-    if (HDstrcmp(thepath, "/") != 0) {
+    if (strcmp(thepath, "/") != 0) {
         H5L_info2_t li;
 
         /* Check for external link first, so we don't return the OID of an object in another file */
@@ -231,7 +231,7 @@ ref_path_table_put(const char *path, const H5O_token_t *token)
             return (-1);
 
         memcpy(&new_node->obj_token, token, sizeof(H5O_token_t));
-        new_node->path = HDstrdup(path);
+        new_node->path = strdup(path);
 
         return (H5SL_insert(ref_path_table, new_node, &(new_node->obj_token)));
     }

--- a/tools/lib/h5tools_str.c
+++ b/tools/lib/h5tools_str.c
@@ -106,7 +106,7 @@ h5tools_str_append(h5tools_str_t *str /*in,out*/, const char *fmt, ...)
     if (!str->s || str->nalloc <= 0)
         h5tools_str_reset(str);
 
-    if (HDstrlen(fmt) == 0)
+    if (strlen(fmt) == 0)
         /* nothing to print */
         return str->s;
 
@@ -117,17 +117,17 @@ h5tools_str_append(h5tools_str_t *str /*in,out*/, const char *fmt, ...)
         size_t avail  = str->nalloc - str->len;
 
         va_start(ap, fmt);
-        nchars = HDvsnprintf(str->s + str->len, avail, fmt, ap);
+        nchars = vsnprintf(str->s + str->len, avail, fmt, ap);
         va_end(ap);
 
-        /* Note: HDvsnprintf() behaves differently on Windows as Unix, when
+        /* Note: vsnprintf() behaves differently on Windows as Unix, when
          * buffer is smaller than source string. On Unix, this function
          * returns length of the source string and copy string up to the
          * buffer size with NULL at the end of the buffer. However on
          * Windows with the same condition, this function returns -1 and
          * doesn't add NULL at the end of the buffer.
          * Because of this different return results, the strlen of the new string
-         * is used to handle when HDvsnprintf() returns -1 on Windows due
+         * is used to handle when vsnprintf() returns -1 on Windows due
          * to lack of buffer size, so try one more time after realloc more
          * buffer size before return NULL.
          */
@@ -135,7 +135,7 @@ h5tools_str_append(h5tools_str_t *str /*in,out*/, const char *fmt, ...)
             /* failure, such as bad format */
             return NULL;
 
-        if ((size_t)nchars >= avail || (0 == nchars && (HDstrcmp(fmt, "%s") != 0))) {
+        if ((size_t)nchars >= avail || (0 == nchars && (strcmp(fmt, "%s") != 0))) {
             /* Truncation return value as documented by C99, or zero return value with either of the
              * following conditions, each of which indicates that the proper C99 return value probably
              *  should have been positive when the format string is
@@ -230,14 +230,14 @@ h5tools_str_fmt(h5tools_str_t *str /*in,out*/, size_t start, const char *fmt)
     assert(fmt);
 
     /* If the format string is simply "%s" then don't bother doing anything */
-    if (!HDstrcmp(fmt, "%s"))
+    if (!strcmp(fmt, "%s"))
         return str->s;
 
     /*
      * Save the input value if there is a `%' anywhere in FMT.  Otherwise
      * don't bother because we don't need a temporary copy.
      */
-    if (HDstrchr(fmt, '%')) {
+    if (strchr(fmt, '%')) {
         size_t n = sizeof(_temp);
         if (str->len - start + 1 > n) {
             n    = str->len - start + 1;
@@ -245,7 +245,7 @@ h5tools_str_fmt(h5tools_str_t *str /*in,out*/, size_t start, const char *fmt)
             assert(temp);
         }
 
-        HDstrncpy(temp, str->s + start, n - 1);
+        strncpy(temp, str->s + start, n - 1);
         temp[n - 1] = '\0';
     }
 
@@ -669,8 +669,8 @@ h5tools_str_sprint(h5tools_str_t *str, const h5tool_format_t *info, hid_t contai
     H5TOOLS_START_DEBUG(" ");
     /* Build default formats for long long types */
     if (!fmt_llong[0]) {
-        HDsnprintf(fmt_llong, sizeof(fmt_llong), "%%lld");
-        HDsnprintf(fmt_ullong, sizeof(fmt_ullong), "%%llu");
+        snprintf(fmt_llong, sizeof(fmt_llong), "%%lld");
+        snprintf(fmt_ullong, sizeof(fmt_ullong), "%%llu");
     }
 
     /* Append value depending on data type */
@@ -741,10 +741,10 @@ h5tools_str_sprint(h5tools_str_t *str, const h5tool_format_t *info, hid_t contai
                 quote = '\0';
                 if (H5Tis_variable_str(type)) {
                     /* cp_vp is the pointer into the struct where a `char*' is stored. So we have
-                     * to dereference the pointer to get the `char*' to pass to HDstrlen(). */
+                     * to dereference the pointer to get the `char*' to pass to strlen(). */
                     s = *(char **)((void *)cp_vp);
                     if (s != NULL)
-                        size = HDstrlen(s);
+                        size = strlen(s);
                 }
                 else {
                     s    = cp_vp;
@@ -1494,7 +1494,7 @@ h5tools_escape(char *s /*in,out*/, size_t size)
     size_t      i;
     const char *escape;
     char        octal[8];
-    size_t      n = HDstrlen(s);
+    size_t      n = strlen(s);
 
     for (i = 0; i < n; i++) {
         switch (s[i]) {
@@ -1533,7 +1533,7 @@ h5tools_escape(char *s /*in,out*/, size_t size)
                 break;
             default:
                 if (!isprint(s[i])) {
-                    HDsnprintf(octal, sizeof(octal), "\\%03o", (unsigned char)s[i]);
+                    snprintf(octal, sizeof(octal), "\\%03o", (unsigned char)s[i]);
                     escape = octal;
                 }
                 else
@@ -1543,7 +1543,7 @@ h5tools_escape(char *s /*in,out*/, size_t size)
         }
 
         if (escape) {
-            size_t esc_size = HDstrlen(escape);
+            size_t esc_size = strlen(escape);
 
             if (n + esc_size + 1 > size)
                 /*would overflow*/
@@ -1601,26 +1601,26 @@ h5tools_str_replace(const char *string, const char *substr, const char *replacem
     char *head   = NULL;
 
     if (substr == NULL || replacement == NULL)
-        return HDstrdup(string);
-    newstr = HDstrdup(string);
+        return strdup(string);
+    newstr = strdup(string);
     head   = newstr;
-    while ((tok = HDstrstr(head, substr))) {
+    while ((tok = strstr(head, substr))) {
         char *oldstr;
 
         oldstr = newstr;
-        newstr = (char *)malloc(HDstrlen(oldstr) - HDstrlen(substr) + HDstrlen(replacement) + 1);
+        newstr = (char *)malloc(strlen(oldstr) - strlen(substr) + strlen(replacement) + 1);
 
         if (newstr == NULL) {
             free(oldstr);
             return NULL;
         }
         memcpy(newstr, oldstr, (size_t)(tok - oldstr));
-        memcpy(newstr + (tok - oldstr), replacement, HDstrlen(replacement));
-        memcpy(newstr + (tok - oldstr) + HDstrlen(replacement), tok + HDstrlen(substr),
-               HDstrlen(oldstr) - HDstrlen(substr) - (size_t)(tok - oldstr));
-        memset(newstr + HDstrlen(oldstr) - HDstrlen(substr) + HDstrlen(replacement), 0, 1);
+        memcpy(newstr + (tok - oldstr), replacement, strlen(replacement));
+        memcpy(newstr + (tok - oldstr) + strlen(replacement), tok + strlen(substr),
+               strlen(oldstr) - strlen(substr) - (size_t)(tok - oldstr));
+        memset(newstr + strlen(oldstr) - strlen(substr) + strlen(replacement), 0, 1);
         /* move back head right after the last replacement */
-        head = newstr + (tok - oldstr) + HDstrlen(replacement);
+        head = newstr + (tok - oldstr) + strlen(replacement);
         free(oldstr);
     }
 

--- a/tools/lib/h5tools_utils.c
+++ b/tools/lib/h5tools_utils.c
@@ -68,10 +68,10 @@ parallel_print(const char *format, ...)
     va_start(ap, format);
 
     if (!g_Parallel)
-        HDvprintf(format, ap);
+        vprintf(format, ap);
     else {
         if (overflow_file == NULL) /*no overflow has occurred yet */ {
-            bytes_written = HDvsnprintf(outBuff + outBuffOffset, OUTBUFF_SIZE - outBuffOffset, format, ap);
+            bytes_written = vsnprintf(outBuff + outBuffOffset, OUTBUFF_SIZE - outBuffOffset, format, ap);
             va_end(ap);
             va_start(ap, format);
 
@@ -84,13 +84,13 @@ parallel_print(const char *format, ...)
                     fprintf(rawerrorstream,
                             "warning: could not create overflow file.  Output may be truncated.\n");
                 else
-                    bytes_written = HDvfprintf(overflow_file, format, ap);
+                    bytes_written = vfprintf(overflow_file, format, ap);
             }
             else
                 outBuffOffset += (unsigned)bytes_written;
         }
         else
-            bytes_written = HDvfprintf(overflow_file, format, ap);
+            bytes_written = vfprintf(overflow_file, format, ap);
     }
     va_end(ap);
 }
@@ -114,7 +114,7 @@ error_msg(const char *fmt, ...)
     FLUSHSTREAM(rawdatastream);
     FLUSHSTREAM(rawoutstream);
     fprintf(rawerrorstream, "%s error: ", h5tools_getprogname());
-    HDvfprintf(rawerrorstream, fmt, ap);
+    vfprintf(rawerrorstream, fmt, ap);
 
     va_end(ap);
 }
@@ -138,7 +138,7 @@ warn_msg(const char *fmt, ...)
     FLUSHSTREAM(rawdatastream);
     FLUSHSTREAM(rawoutstream);
     fprintf(rawerrorstream, "%s warning: ", h5tools_getprogname());
-    HDvfprintf(rawerrorstream, fmt, ap);
+    vfprintf(rawerrorstream, fmt, ap);
     va_end(ap);
 }
 
@@ -241,10 +241,10 @@ parse_subset_params(const char *dset)
     H5TOOLS_START_DEBUG(" - dset:%s", dset);
     /* if dset name is quoted wait till after second quote to look for subset brackets */
     if (*dset == '"')
-        q_dset = HDstrchr(dset, '"');
+        q_dset = strchr(dset, '"');
     else
         q_dset = dset;
-    if ((brace = HDstrrchr(q_dset, '[')) != NULL) {
+    if ((brace = strrchr(q_dset, '[')) != NULL) {
         *brace++ = '\0';
 
         s = (struct subset_t *)calloc(1, sizeof(struct subset_t));
@@ -388,8 +388,8 @@ parse_tuple(const char *start, int sep, char **cpy_out, unsigned *nelems, char *
 
     /* create destination string
      */
-    start++;                                                /* advance past opening paren '(' */
-    cpy = (char *)malloc(sizeof(char) * (HDstrlen(start))); /* no +1; less '(' */
+    start++;                                              /* advance past opening paren '(' */
+    cpy = (char *)malloc(sizeof(char) * (strlen(start))); /* no +1; less '(' */
     if (cpy == NULL) {
         ret_value = FAIL;
         goto done;
@@ -699,7 +699,7 @@ find_objs_cb(const char *name, const H5O_info2_t *oinfo, const char *already_see
                 else {
                     /* Use latest version of name */
                     free(found_obj->objname);
-                    found_obj->objname = HDstrdup(name);
+                    found_obj->objname = strdup(name);
 
                     /* Mark named datatype as having valid name */
                     found_obj->recorded = true;
@@ -785,7 +785,7 @@ add_obj(table_t *table, const H5O_token_t *obj_token, const char *objname, bool 
 
     /* Set information about object */
     memcpy(&table->objs[u].obj_token, obj_token, sizeof(H5O_token_t));
-    table->objs[u].objname   = HDstrdup(objname);
+    table->objs[u].objname   = strdup(objname);
     table->objs[u].recorded  = record;
     table->objs[u].displayed = 0;
 }
@@ -843,7 +843,7 @@ H5tools_get_symlink_info(hid_t file_id, const char *linkpath, h5tool_link_info_t
     link_info->trg_type = H5O_TYPE_UNKNOWN;
 
     /* if path is root, return group type */
-    if (!HDstrcmp(linkpath, "/")) {
+    if (!strcmp(linkpath, "/")) {
         link_info->trg_type = H5O_TYPE_GROUP;
         H5TOOLS_GOTO_DONE(2);
     }
@@ -1188,50 +1188,50 @@ h5tools_populate_ros3_fapl(H5FD_ros3_fapl_ext_t *fa, const char **values)
          * fail if value would overflow
          */
         if (*values[0] != '\0' && *values[1] != '\0') {
-            if (HDstrlen(values[0]) > H5FD_ROS3_MAX_REGION_LEN) {
+            if (strlen(values[0]) > H5FD_ROS3_MAX_REGION_LEN) {
                 if (show_progress) {
                     printf("  ERROR: aws_region value too long\n");
                 }
                 ret_value = 0;
                 goto done;
             }
-            memcpy(fa->fa.aws_region, values[0], (HDstrlen(values[0]) + 1));
+            memcpy(fa->fa.aws_region, values[0], (strlen(values[0]) + 1));
             if (show_progress) {
                 printf("  aws_region set\n");
             }
 
-            if (HDstrlen(values[1]) > H5FD_ROS3_MAX_SECRET_ID_LEN) {
+            if (strlen(values[1]) > H5FD_ROS3_MAX_SECRET_ID_LEN) {
                 if (show_progress) {
                     printf("  ERROR: secret_id value too long\n");
                 }
                 ret_value = 0;
                 goto done;
             }
-            memcpy(fa->fa.secret_id, values[1], (HDstrlen(values[1]) + 1));
+            memcpy(fa->fa.secret_id, values[1], (strlen(values[1]) + 1));
             if (show_progress) {
                 printf("  secret_id set\n");
             }
 
-            if (HDstrlen(values[2]) > H5FD_ROS3_MAX_SECRET_KEY_LEN) {
+            if (strlen(values[2]) > H5FD_ROS3_MAX_SECRET_KEY_LEN) {
                 if (show_progress) {
                     printf("  ERROR: secret_key value too long\n");
                 }
                 ret_value = 0;
                 goto done;
             }
-            memcpy(fa->fa.secret_key, values[2], (HDstrlen(values[2]) + 1));
+            memcpy(fa->fa.secret_key, values[2], (strlen(values[2]) + 1));
             if (show_progress) {
                 printf("  secret_key set\n");
             }
 
-            if (HDstrlen(values[3]) > H5FD_ROS3_MAX_SECRET_TOK_LEN) {
+            if (strlen(values[3]) > H5FD_ROS3_MAX_SECRET_TOK_LEN) {
                 if (show_progress) {
                     printf("  ERROR: token value too long\n");
                 }
                 ret_value = 0;
                 goto done;
             }
-            memcpy(fa->token, values[3], (HDstrlen(values[3]) + 1));
+            memcpy(fa->token, values[3], (strlen(values[3]) + 1));
             if (show_progress) {
                 printf("  token set\n");
             }
@@ -1288,22 +1288,22 @@ h5tools_parse_hdfs_fapl_tuple(const char *tuple_str, int delim, H5FD_hdfs_fapl_t
      * WARNING: No error-checking is done on length of input strings...
      *          Silent overflow is possible, albeit unlikely.
      */
-    if (HDstrncmp(props[0], "", 1)) {
-        HDstrncpy(fapl_config_out->namenode_name, (const char *)props[0], HDstrlen(props[0]));
+    if (strncmp(props[0], "", 1)) {
+        strncpy(fapl_config_out->namenode_name, (const char *)props[0], strlen(props[0]));
     }
-    if (HDstrncmp(props[1], "", 1)) {
+    if (strncmp(props[1], "", 1)) {
         k = strtoul((const char *)props[1], NULL, 0);
         if (errno == ERANGE)
             H5TOOLS_GOTO_ERROR(FAIL, "supposed port number wasn't");
         fapl_config_out->namenode_port = (int32_t)k;
     }
-    if (HDstrncmp(props[2], "", 1)) {
-        HDstrncpy(fapl_config_out->kerberos_ticket_cache, (const char *)props[2], HDstrlen(props[2]));
+    if (strncmp(props[2], "", 1)) {
+        strncpy(fapl_config_out->kerberos_ticket_cache, (const char *)props[2], strlen(props[2]));
     }
-    if (HDstrncmp(props[3], "", 1)) {
-        HDstrncpy(fapl_config_out->user_name, (const char *)props[3], HDstrlen(props[3]));
+    if (strncmp(props[3], "", 1)) {
+        strncpy(fapl_config_out->user_name, (const char *)props[3], strlen(props[3]));
     }
-    if (HDstrncmp(props[4], "", 1)) {
+    if (strncmp(props[4], "", 1)) {
         k = strtoul((const char *)props[4], NULL, 0);
         if (errno == ERANGE)
             H5TOOLS_GOTO_ERROR(FAIL, "supposed buffersize number wasn't");

--- a/tools/libtest/h5tools_test_utils.c
+++ b/tools/libtest/h5tools_test_utils.c
@@ -241,7 +241,7 @@ H5_GCC_CLANG_DIAG_OFF("format")
  *----------------------------------------------------------------------------
  */
 #define JSVERIFY_STR(expected, actual, reason)                                                               \
-    if (HDstrcmp((actual), (expected)) != 0) {                                                               \
+    if (strcmp((actual), (expected)) != 0) {                                                                 \
         JSERR_STR((expected), (actual), (reason));                                                           \
         goto error;                                                                                          \
     } /* JSVERIFY_STR */
@@ -277,7 +277,7 @@ H5_GCC_CLANG_DIAG_OFF("format")
  *----------------------------------------------------------------------------
  */
 #define JSVERIFY_STR(actual, expected, reason)                                                               \
-    if (HDstrcmp((actual), (expected)) != 0) {                                                               \
+    if (strcmp((actual), (expected)) != 0) {                                                                 \
         JSERR_STR((expected), (actual), (reason));                                                           \
         goto error;                                                                                          \
     } /* JSVERIFY_STR */
@@ -543,8 +543,8 @@ test_populate_ros3_fa(void)
     TESTING("programmatic ros3 fapl population");
 
 #ifndef H5_HAVE_ROS3_VFD
-    HDputs(" -SKIP-");
-    HDputs("    Read-Only S3 VFD not enabled");
+    puts(" -SKIP-");
+    puts("    Read-Only S3 VFD not enabled");
     fflush(stdout);
     return 0;
 #else
@@ -681,7 +681,7 @@ test_populate_ros3_fa(void)
             printf("region overflow\n");
         }
 
-        assert(HDstrlen(values[0]) > H5FD_ROS3_MAX_REGION_LEN);
+        assert(strlen(values[0]) > H5FD_ROS3_MAX_REGION_LEN);
 
         JSVERIFY(0, h5tools_populate_ros3_fapl(&fa, values), "could not fill fapl")
         JSVERIFY(H5FD_CURR_ROS3_FAPL_T_VERSION, fa.fa.version, (char *)NULL)
@@ -754,7 +754,7 @@ test_populate_ros3_fa(void)
             printf("id overflow\n");
         }
 
-        assert(HDstrlen(values[1]) > H5FD_ROS3_MAX_SECRET_ID_LEN);
+        assert(strlen(values[1]) > H5FD_ROS3_MAX_SECRET_ID_LEN);
 
         JSVERIFY(0, h5tools_populate_ros3_fapl(&fa, values), "could not fill fapl")
         JSVERIFY(H5FD_CURR_ROS3_FAPL_T_VERSION, fa.fa.version, (char *)NULL)
@@ -887,7 +887,7 @@ test_populate_ros3_fa(void)
             printf("key overflow\n");
         }
 
-        assert(HDstrlen(values[2]) > H5FD_ROS3_MAX_SECRET_KEY_LEN);
+        assert(strlen(values[2]) > H5FD_ROS3_MAX_SECRET_KEY_LEN);
 
         JSVERIFY(0, h5tools_populate_ros3_fapl(&fa, values), "could not fill fapl")
         JSVERIFY(H5FD_CURR_ROS3_FAPL_T_VERSION, fa.fa.version, (char *)NULL)

--- a/tools/src/h5copy/h5copy.c
+++ b/tools/src/h5copy/h5copy.c
@@ -156,25 +156,25 @@ parse_flag(const char *s_flag, unsigned *flag)
 {
     unsigned fla = 0;
 
-    if (HDstrcmp(s_flag, "shallow") == 0) {
+    if (strcmp(s_flag, "shallow") == 0) {
         fla = H5O_COPY_SHALLOW_HIERARCHY_FLAG;
     }
-    else if (HDstrcmp(s_flag, "soft") == 0) {
+    else if (strcmp(s_flag, "soft") == 0) {
         fla = H5O_COPY_EXPAND_SOFT_LINK_FLAG;
     }
-    else if (HDstrcmp(s_flag, "ext") == 0) {
+    else if (strcmp(s_flag, "ext") == 0) {
         fla = H5O_COPY_EXPAND_EXT_LINK_FLAG;
     }
-    else if (HDstrcmp(s_flag, "ref") == 0) {
+    else if (strcmp(s_flag, "ref") == 0) {
         fla = H5O_COPY_EXPAND_REFERENCE_FLAG;
     }
-    else if (HDstrcmp(s_flag, "noattr") == 0) {
+    else if (strcmp(s_flag, "noattr") == 0) {
         fla = H5O_COPY_WITHOUT_ATTR_FLAG;
     }
-    else if (HDstrcmp(s_flag, "allflags") == 0) {
+    else if (strcmp(s_flag, "allflags") == 0) {
         fla = H5O_COPY_ALL;
     }
-    else if (HDstrcmp(s_flag, "nullmsg") == 0) {
+    else if (strcmp(s_flag, "nullmsg") == 0) {
         fla = H5O_COPY_PRESERVE_NULL_FLAG;
     }
     else {
@@ -229,7 +229,7 @@ main(int argc, char *argv[])
     while ((opt = H5_get_option(argc, (const char *const *)argv, s_opts, l_opts)) != EOF) {
         switch ((char)opt) {
             case 'd':
-                oname_dst = HDstrdup(H5_optarg);
+                oname_dst = strdup(H5_optarg);
                 break;
 
             case 'f':
@@ -238,7 +238,7 @@ main(int argc, char *argv[])
                     usage();
                     leave(EXIT_FAILURE);
                 }
-                str_flag = HDstrdup(H5_optarg);
+                str_flag = strdup(H5_optarg);
                 break;
 
             case 'h':
@@ -247,11 +247,11 @@ main(int argc, char *argv[])
                 break;
 
             case 'i':
-                fname_src = HDstrdup(H5_optarg);
+                fname_src = strdup(H5_optarg);
                 break;
 
             case 'o':
-                fname_dst = HDstrdup(H5_optarg);
+                fname_dst = strdup(H5_optarg);
                 break;
 
             case 'p':
@@ -259,7 +259,7 @@ main(int argc, char *argv[])
                 break;
 
             case 's':
-                oname_src = HDstrdup(H5_optarg);
+                oname_src = strdup(H5_optarg);
                 break;
 
             case 'V':
@@ -403,7 +403,7 @@ main(int argc, char *argv[])
         /* error, if parent groups doesn't already exist in destination file */
         size_t i, len;
 
-        len = HDstrlen(oname_dst);
+        len = strlen(oname_dst);
 
         /* check if all the parents groups exist. skip root group */
         for (i = 1; i < len; i++) {
@@ -411,7 +411,7 @@ main(int argc, char *argv[])
                 char *str_ptr;
 
                 str_ptr = (char *)calloc(i + 1, sizeof(char));
-                HDstrncpy(str_ptr, oname_dst, i);
+                strncpy(str_ptr, oname_dst, i);
                 str_ptr[i] = '\0';
                 if (H5Lexists(fid_dst, str_ptr, H5P_DEFAULT) <= 0) {
                     error_msg("group <%s> doesn't exist. Use -p to create parent groups.\n", str_ptr);

--- a/tools/src/h5diff/h5diff_common.c
+++ b/tools/src/h5diff/h5diff_common.c
@@ -387,7 +387,7 @@ parse_command_line(int argc, const char *const *argv, const char **fname1, const
     }
 
     /* If file 1 uses the onion VFD, get the revision number */
-    if (opts->vfd_info[0].u.name && !HDstrcmp(opts->vfd_info[0].u.name, "onion")) {
+    if (opts->vfd_info[0].u.name && !strcmp(opts->vfd_info[0].u.name, "onion")) {
         if (opts->vfd_info[0].info) {
             errno                     = 0;
             onion_fa_g_1.revision_num = strtoull(opts->vfd_info[0].info, NULL, 10);
@@ -404,7 +404,7 @@ parse_command_line(int argc, const char *const *argv, const char **fname1, const
     }
 
     /* If file 2 uses the onion VFD, get the revision number */
-    if (opts->vfd_info[1].u.name && !HDstrcmp(opts->vfd_info[1].u.name, "onion")) {
+    if (opts->vfd_info[1].u.name && !strcmp(opts->vfd_info[1].u.name, "onion")) {
         if (opts->vfd_info[1].info) {
             errno                     = 0;
             onion_fa_g_2.revision_num = strtoull(opts->vfd_info[1].info, NULL, 10);
@@ -512,7 +512,7 @@ check_n_input(const char *str)
     unsigned i;
     char     c;
 
-    for (i = 0; i < HDstrlen(str); i++) {
+    for (i = 0; i < strlen(str); i++) {
         c = str[i];
         if (i == 0) {
             if (c < 49 || c > 57) /* ascii values between 1 and 9 */
@@ -541,7 +541,7 @@ check_p_input(const char *str)
      * the atof return value on a hexadecimal input is different
      * on some systems; we do a character check for this
      */
-    if (HDstrlen(str) > 2 && str[0] == '0' && str[1] == 'x')
+    if (strlen(str) > 2 && str[0] == '0' && str[1] == 'x')
         return -1;
 
     x = atof(str);
@@ -568,7 +568,7 @@ check_d_input(const char *str)
      * the atof return value on a hexadecimal input is different
      * on some systems; we do a character check for this
      */
-    if (HDstrlen(str) > 2 && str[0] == '0' && str[1] == 'x')
+    if (strlen(str) > 2 && str[0] == '0' && str[1] == 'x')
         return -1;
 
     x = atof(str);

--- a/tools/src/h5diff/ph5diff_main.c
+++ b/tools/src/h5diff/ph5diff_main.c
@@ -246,8 +246,8 @@ print_manager_output(void)
         if (overflow_file) {
             int tmp;
             rewind(overflow_file);
-            while ((tmp = HDgetc(overflow_file)) >= 0)
-                HDputchar(tmp);
+            while ((tmp = getc(overflow_file)) >= 0)
+                putchar(tmp);
             fclose(overflow_file);
             overflow_file = NULL;
         }

--- a/tools/src/h5dump/h5dump.c
+++ b/tools/src/h5dump/h5dump.c
@@ -515,15 +515,15 @@ set_binary_form(const char *form)
 {
     int bform = -1;
 
-    if (HDstrcmp(form, "NATIVE") == 0 || HDstrcmp(form, "MEMORY") == 0) {
+    if (strcmp(form, "NATIVE") == 0 || strcmp(form, "MEMORY") == 0) {
         /* native form */
         bform = 0;
     }
-    else if (HDstrcmp(form, "FILE") == 0) /* file type form */
+    else if (strcmp(form, "FILE") == 0) /* file type form */
         bform = 1;
-    else if (HDstrcmp(form, "LE") == 0) /* convert to little endian */
+    else if (strcmp(form, "LE") == 0) /* convert to little endian */
         bform = 2;
-    else if (HDstrcmp(form, "BE") == 0) /* convert to big endian */
+    else if (strcmp(form, "BE") == 0) /* convert to big endian */
         bform = 3;
 
     return bform;
@@ -544,9 +544,9 @@ set_sort_by(const char *form)
 {
     H5_index_t idx_type = H5_INDEX_UNKNOWN;
 
-    if (HDstrcmp(form, "name") == 0) /* H5_INDEX_NAME */
+    if (strcmp(form, "name") == 0) /* H5_INDEX_NAME */
         idx_type = H5_INDEX_NAME;
-    else if (HDstrcmp(form, "creation_order") == 0) /* H5_INDEX_CRT_ORDER */
+    else if (strcmp(form, "creation_order") == 0) /* H5_INDEX_CRT_ORDER */
         idx_type = H5_INDEX_CRT_ORDER;
 
     return idx_type;
@@ -567,9 +567,9 @@ set_sort_order(const char *form)
 {
     H5_iter_order_t iter_order = H5_ITER_UNKNOWN;
 
-    if (HDstrcmp(form, "ascending") == 0) /* H5_ITER_INC */
+    if (strcmp(form, "ascending") == 0) /* H5_ITER_INC */
         iter_order = H5_ITER_INC;
-    else if (HDstrcmp(form, "descending") == 0) /* H5_ITER_DEC */
+    else if (strcmp(form, "descending") == 0) /* H5_ITER_DEC */
         iter_order = H5_ITER_DEC;
 
     return iter_order;
@@ -837,7 +837,7 @@ parse_start:
                 for (i = 0; i < argc; i++)
                     if (!hand[i].func) {
                         hand[i].func = handle_paths;
-                        hand[i].obj  = HDstrdup(H5_optarg);
+                        hand[i].obj  = strdup(H5_optarg);
                         break;
                     }
 
@@ -849,7 +849,7 @@ parse_start:
                 for (i = 0; i < argc; i++)
                     if (!hand[i].func) {
                         hand[i].func = handle_attributes;
-                        hand[i].obj  = HDstrdup(H5_optarg);
+                        hand[i].obj  = strdup(H5_optarg);
                         break;
                     }
 
@@ -861,7 +861,7 @@ parse_start:
                 for (i = 0; i < argc; i++)
                     if (!hand[i].func) {
                         hand[i].func = handle_datasets;
-                        hand[i].obj  = HDstrdup(H5_optarg);
+                        hand[i].obj  = strdup(H5_optarg);
                         if (!dump_opts.disable_compact_subset)
                             hand[i].subset_info = parse_subset_params(hand[i].obj);
                         last_dset = &hand[i];
@@ -876,12 +876,12 @@ parse_start:
                 use_custom_vfd_g  = true;
 
 #ifdef H5_HAVE_ROS3_VFD
-                if (0 == HDstrcmp(vfd_info_g.u.name, drivernames[ROS3_VFD_IDX]))
+                if (0 == strcmp(vfd_info_g.u.name, drivernames[ROS3_VFD_IDX]))
                     if (!vfd_info_g.info)
                         vfd_info_g.info = &ros3_fa_g;
 #endif
 #ifdef H5_HAVE_LIBHDFS
-                if (0 == HDstrcmp(vfd_info_g.u.name, drivernames[HDFS_VFD_IDX]))
+                if (0 == strcmp(vfd_info_g.u.name, drivernames[HDFS_VFD_IDX]))
                     if (!vfd_info_g.info)
                         vfd_info_g.info = &hdfs_fa_g;
 #endif
@@ -893,7 +893,7 @@ parse_start:
                 for (i = 0; i < argc; i++)
                     if (!hand[i].func) {
                         hand[i].func = handle_groups;
-                        hand[i].obj  = HDstrdup(H5_optarg);
+                        hand[i].obj  = strdup(H5_optarg);
                         break;
                     }
 
@@ -905,7 +905,7 @@ parse_start:
                 for (i = 0; i < argc; i++)
                     if (!hand[i].func) {
                         hand[i].func = handle_links;
-                        hand[i].obj  = HDstrdup(H5_optarg);
+                        hand[i].obj  = strdup(H5_optarg);
                         break;
                     }
 
@@ -917,7 +917,7 @@ parse_start:
                 for (i = 0; i < argc; i++)
                     if (!hand[i].func) {
                         hand[i].func = handle_datatypes;
-                        hand[i].obj  = HDstrdup(H5_optarg);
+                        hand[i].obj  = strdup(H5_optarg);
                         break;
                     }
 
@@ -1053,7 +1053,7 @@ parse_start:
                     usage(h5tools_getprogname());
                     goto error;
                 }
-                if (HDstrcmp(H5_optarg, ":") == 0)
+                if (strcmp(H5_optarg, ":") == 0)
                     xmlnsprefix = "";
                 else
                     xmlnsprefix = H5_optarg;
@@ -1234,10 +1234,10 @@ end_collect:
     }
 
     /* If the file uses the onion VFD, get the revision number */
-    if (vfd_info_g.u.name && !HDstrcmp(vfd_info_g.u.name, "onion")) {
+    if (vfd_info_g.u.name && !strcmp(vfd_info_g.u.name, "onion")) {
 
         if (vfd_info_g.info) {
-            if (!HDstrcmp(vfd_info_g.info, "revision_count"))
+            if (!strcmp(vfd_info_g.info, "revision_count"))
                 get_onion_revision_count = true;
             else {
                 errno                   = 0;
@@ -1373,7 +1373,7 @@ main(int argc, char *argv[])
     }
 
     while (H5_optind < argc) {
-        fname = HDstrdup(argv[H5_optind++]);
+        fname = strdup(argv[H5_optind++]);
 
         /* A short cut to get the revision count of an onion file without opening the file */
         if (get_onion_revision_count && H5FD_ONION == H5Pget_driver(fapl_id)) {
@@ -1406,7 +1406,7 @@ main(int argc, char *argv[])
         if (doxml_g) {
             /* initialize XML */
             /* reset prefix! */
-            HDstrcpy(prefix, "");
+            strcpy(prefix, "");
 
             /* make sure the URI is initialized to something */
             if (xml_dtd_uri_g == NULL) {
@@ -1419,7 +1419,7 @@ main(int argc, char *argv[])
                 }
             }
             else {
-                if (useschema_g && HDstrcmp(xmlnsprefix, "") != 0) {
+                if (useschema_g && strcmp(xmlnsprefix, "") != 0) {
                     error_msg(
                         "Cannot set Schema URL for a qualified namespace--use -X or -U option with -D \n");
                     h5tools_setstatus(EXIT_FAILURE);
@@ -1462,7 +1462,7 @@ main(int argc, char *argv[])
 
             /* alternative first element, depending on schema or DTD. */
             if (useschema_g) {
-                if (HDstrcmp(xmlnsprefix, "") == 0) {
+                if (strcmp(xmlnsprefix, "") == 0) {
                     PRINTSTREAM(rawoutstream,
                                 "<HDF5-File xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\" "
                                 "xsi:noNamespaceSchemaLocation=\"%s\">\n",
@@ -1473,8 +1473,8 @@ main(int argc, char *argv[])
                     char *ns;
                     char *indx;
 
-                    ns   = HDstrdup(xmlnsprefix);
-                    indx = HDstrrchr(ns, (int)':');
+                    ns   = strdup(xmlnsprefix);
+                    indx = strrchr(ns, (int)':');
                     if (indx)
                         *indx = '\0';
 
@@ -1633,7 +1633,7 @@ init_prefix(char **prfx, size_t prfx_len)
 void
 add_prefix(char **prfx, size_t *prfx_len, const char *name)
 {
-    size_t new_len = HDstrlen(*prfx) + HDstrlen(name) + 2;
+    size_t new_len = strlen(*prfx) + strlen(name) + 2;
 
     /* Check if we need more space */
     if (*prfx_len <= new_len) {
@@ -1642,5 +1642,5 @@ add_prefix(char **prfx, size_t *prfx_len, const char *name)
     }
 
     /* Append object name to prefix */
-    HDstrcat(HDstrcat(*prfx, "/"), name);
+    strcat(strcat(*prfx, "/"), name);
 } /* end add_prefix */

--- a/tools/src/h5dump/h5dump_ddl.c
+++ b/tools/src/h5dump/h5dump_ddl.c
@@ -187,15 +187,15 @@ dump_all_cb(hid_t group, const char *name, const H5L_info2_t *linfo, void H5_ATT
     outputformat                = &string_dataformat;
 
     /* Build the object's path name */
-    obj_path = (char *)malloc(HDstrlen(prefix) + HDstrlen(name) + 2);
+    obj_path = (char *)malloc(strlen(prefix) + strlen(name) + 2);
     if (!obj_path) {
         ret = FAIL;
         goto done;
     }
 
-    HDstrcpy(obj_path, prefix);
-    HDstrcat(obj_path, "/");
-    HDstrcat(obj_path, name);
+    strcpy(obj_path, prefix);
+    strcat(obj_path, "/");
+    strcat(obj_path, name);
 
     if (linfo->type == H5L_TYPE_HARD) {
         H5O_info2_t oinfo;
@@ -219,7 +219,7 @@ dump_all_cb(hid_t group, const char *name, const H5L_info2_t *linfo, void H5_ATT
                     char *old_prefix; /* Pointer to previous prefix */
 
                     /* Keep copy of prefix before iterating into group */
-                    old_prefix = HDstrdup(prefix);
+                    old_prefix = strdup(prefix);
                     if (old_prefix) {
                         /* Append group name to prefix */
                         add_prefix(&prefix, &prefix_len, name);
@@ -228,7 +228,7 @@ dump_all_cb(hid_t group, const char *name, const H5L_info2_t *linfo, void H5_ATT
                         dump_function_table->dump_group_function(obj, name);
 
                         /* Restore old prefix name */
-                        HDstrcpy(prefix, old_prefix);
+                        strcpy(prefix, old_prefix);
                         free(old_prefix);
                     }
                     else
@@ -278,13 +278,13 @@ dump_all_cb(hid_t group, const char *name, const H5L_info2_t *linfo, void H5_ATT
 
                             /* Render the element */
                             h5tools_str_reset(&buffer);
-                            if (HDstrlen(h5tools_dump_header_format->datasetblockend)) {
+                            if (strlen(h5tools_dump_header_format->datasetblockend)) {
                                 h5tools_str_append(&buffer, "%s",
                                                    h5tools_dump_header_format->datasetblockend);
-                                if (HDstrlen(h5tools_dump_header_format->datasetend))
+                                if (strlen(h5tools_dump_header_format->datasetend))
                                     h5tools_str_append(&buffer, " ");
                             }
-                            if (HDstrlen(h5tools_dump_header_format->datasetend))
+                            if (strlen(h5tools_dump_header_format->datasetend))
                                 h5tools_str_append(&buffer, "%s", h5tools_dump_header_format->datasetend);
                             h5tools_render_element(rawoutstream, outputformat, &ctx, &buffer, &curr_pos,
                                                    (size_t)outputformat->line_ncols, (hsize_t)0, (hsize_t)0);
@@ -325,13 +325,13 @@ dump_all_cb(hid_t group, const char *name, const H5L_info2_t *linfo, void H5_ATT
 
                             /* Render the element */
                             h5tools_str_reset(&buffer);
-                            if (HDstrlen(h5tools_dump_header_format->datasetblockend)) {
+                            if (strlen(h5tools_dump_header_format->datasetblockend)) {
                                 h5tools_str_append(&buffer, "%s",
                                                    h5tools_dump_header_format->datasetblockend);
-                                if (HDstrlen(h5tools_dump_header_format->datasetend))
+                                if (strlen(h5tools_dump_header_format->datasetend))
                                     h5tools_str_append(&buffer, " ");
                             }
-                            if (HDstrlen(h5tools_dump_header_format->datasetend))
+                            if (strlen(h5tools_dump_header_format->datasetend))
                                 h5tools_str_append(&buffer, "%s", h5tools_dump_header_format->datasetend);
                             h5tools_render_element(rawoutstream, outputformat, &ctx, &buffer, &curr_pos,
                                                    (size_t)outputformat->line_ncols, (hsize_t)0, (hsize_t)0);
@@ -426,12 +426,12 @@ dump_all_cb(hid_t group, const char *name, const H5L_info2_t *linfo, void H5_ATT
 
                     /* Render the element */
                     h5tools_str_reset(&buffer);
-                    if (HDstrlen(h5tools_dump_header_format->softlinkblockend)) {
+                    if (strlen(h5tools_dump_header_format->softlinkblockend)) {
                         h5tools_str_append(&buffer, "%s", h5tools_dump_header_format->softlinkblockend);
-                        if (HDstrlen(h5tools_dump_header_format->softlinkend))
+                        if (strlen(h5tools_dump_header_format->softlinkend))
                             h5tools_str_append(&buffer, " ");
                     }
-                    if (HDstrlen(h5tools_dump_header_format->softlinkend))
+                    if (strlen(h5tools_dump_header_format->softlinkend))
                         h5tools_str_append(&buffer, "%s", h5tools_dump_header_format->softlinkend);
                     h5tools_render_element(rawoutstream, outputformat, &ctx, &buffer, &curr_pos,
                                            (size_t)outputformat->line_ncols, (hsize_t)0, (hsize_t)0);
@@ -500,12 +500,12 @@ dump_all_cb(hid_t group, const char *name, const H5L_info2_t *linfo, void H5_ATT
 
                     /* Render the element */
                     h5tools_str_reset(&buffer);
-                    if (HDstrlen(h5tools_dump_header_format->extlinkblockend)) {
+                    if (strlen(h5tools_dump_header_format->extlinkblockend)) {
                         h5tools_str_append(&buffer, "%s", h5tools_dump_header_format->extlinkblockend);
-                        if (HDstrlen(h5tools_dump_header_format->extlinkend))
+                        if (strlen(h5tools_dump_header_format->extlinkend))
                             h5tools_str_append(&buffer, " ");
                     }
-                    if (HDstrlen(h5tools_dump_header_format->extlinkend))
+                    if (strlen(h5tools_dump_header_format->extlinkend))
                         h5tools_str_append(&buffer, "%s", h5tools_dump_header_format->extlinkend);
                     h5tools_render_element(rawoutstream, outputformat, &ctx, &buffer, &curr_pos,
                                            (size_t)outputformat->line_ncols, (hsize_t)0, (hsize_t)0);
@@ -541,12 +541,12 @@ dump_all_cb(hid_t group, const char *name, const H5L_info2_t *linfo, void H5_ATT
                 ctx.need_prefix = true;
                 /* Render the element */
                 h5tools_str_reset(&buffer);
-                if (HDstrlen(h5tools_dump_header_format->udlinkblockend)) {
+                if (strlen(h5tools_dump_header_format->udlinkblockend)) {
                     h5tools_str_append(&buffer, "%s", h5tools_dump_header_format->udlinkblockend);
-                    if (HDstrlen(h5tools_dump_header_format->udlinkend))
+                    if (strlen(h5tools_dump_header_format->udlinkend))
                         h5tools_str_append(&buffer, " ");
                 }
-                if (HDstrlen(h5tools_dump_header_format->udlinkend))
+                if (strlen(h5tools_dump_header_format->udlinkend))
                     h5tools_str_append(&buffer, "%s", h5tools_dump_header_format->udlinkend);
                 h5tools_render_element(rawoutstream, outputformat, &ctx, &buffer, &curr_pos,
                                        (size_t)outputformat->line_ncols, (hsize_t)0, (hsize_t)0);
@@ -730,12 +730,12 @@ dump_named_datatype(hid_t tid, const char *name)
 done:
     /* Render the element */
     h5tools_str_reset(&buffer);
-    if (HDstrlen(h5tools_dump_header_format->datatypeblockend)) {
+    if (strlen(h5tools_dump_header_format->datatypeblockend)) {
         h5tools_str_append(&buffer, "%s", h5tools_dump_header_format->datatypeblockend);
-        if (HDstrlen(h5tools_dump_header_format->datatypeend))
+        if (strlen(h5tools_dump_header_format->datatypeend))
             h5tools_str_append(&buffer, " ");
     }
-    if (HDstrlen(h5tools_dump_header_format->datatypeend))
+    if (strlen(h5tools_dump_header_format->datatypeend))
         h5tools_str_append(&buffer, "%s", h5tools_dump_header_format->datatypeend);
     h5tools_render_element(rawoutstream, outputformat, &ctx, &buffer, &curr_pos,
                            (size_t)outputformat->line_ncols, (hsize_t)0, (hsize_t)0);
@@ -825,7 +825,7 @@ dump_group(hid_t gid, const char *name)
     ctx.indent_level++;
     dump_indent += COL;
 
-    if (!HDstrcmp(name, "/") && unamedtype) {
+    if (!strcmp(name, "/") && unamedtype) {
         unsigned u; /* Local index variable */
 
         /* dump unnamed type in root group */
@@ -837,7 +837,7 @@ dump_group(hid_t gid, const char *name)
                 type = H5Dget_type(dset);
 
                 H5Otoken_to_str(dset, &type_table->objs[u].obj_token, &obj_tok_str);
-                HDsnprintf(type_name, sizeof(type_name), "#%s", obj_tok_str);
+                snprintf(type_name, sizeof(type_name), "#%s", obj_tok_str);
                 H5free_memory(obj_tok_str);
 
                 dump_function_table->dump_named_datatype_function(type, type_name);
@@ -885,12 +885,12 @@ dump_group(hid_t gid, const char *name)
 
     /* Render the element */
     h5tools_str_reset(&buffer);
-    if (HDstrlen(h5tools_dump_header_format->groupblockend)) {
+    if (strlen(h5tools_dump_header_format->groupblockend)) {
         h5tools_str_append(&buffer, "%s", h5tools_dump_header_format->groupblockend);
-        if (HDstrlen(h5tools_dump_header_format->groupend))
+        if (strlen(h5tools_dump_header_format->groupend))
             h5tools_str_append(&buffer, " ");
     }
-    if (HDstrlen(h5tools_dump_header_format->groupend))
+    if (strlen(h5tools_dump_header_format->groupend))
         h5tools_str_append(&buffer, "%s", h5tools_dump_header_format->groupend);
     h5tools_render_element(rawoutstream, outputformat, &ctx, &buffer, &curr_pos,
                            (size_t)outputformat->line_ncols, (hsize_t)0, (hsize_t)0);
@@ -1063,12 +1063,12 @@ dump_dataset(hid_t did, const char *name, struct subset_t *sset)
 
     /* Render the element */
     h5tools_str_reset(&buffer);
-    if (HDstrlen(h5tools_dump_header_format->datasetblockend)) {
+    if (strlen(h5tools_dump_header_format->datasetblockend)) {
         h5tools_str_append(&buffer, "%s", h5tools_dump_header_format->datasetblockend);
-        if (HDstrlen(h5tools_dump_header_format->datasetend))
+        if (strlen(h5tools_dump_header_format->datasetend))
             h5tools_str_append(&buffer, " ");
     }
-    if (HDstrlen(h5tools_dump_header_format->datasetend))
+    if (strlen(h5tools_dump_header_format->datasetend))
         h5tools_str_append(&buffer, "%s", h5tools_dump_header_format->datasetend);
     h5tools_render_element(rawoutstream, outputformat, &ctx, &buffer, &curr_pos,
                            (size_t)outputformat->line_ncols, (hsize_t)0, (hsize_t)0);
@@ -1202,25 +1202,25 @@ dump_fcpl(hid_t fid)
 
 #ifdef SHOW_FILE_DRIVER
     if (H5FD_CORE == fdriver)
-        HDstrcpy(dname, "H5FD_CORE");
+        strcpy(dname, "H5FD_CORE");
 #ifdef H5_HAVE_DIRECT
     else if (H5FD_DIRECT == fdriver)
-        HDstrcpy(dname, "H5FD_DIRECT");
+        strcpy(dname, "H5FD_DIRECT");
 #endif
     else if (H5FD_FAMILY == fdriver)
-        HDstrcpy(dname, "H5FD_FAMILY");
+        strcpy(dname, "H5FD_FAMILY");
     else if (H5FD_LOG == fdriver)
-        HDstrcpy(dname, "H5FD_LOG");
+        strcpy(dname, "H5FD_LOG");
     else if (H5FD_MPIO == fdriver)
-        HDstrcpy(dname, "H5FD_MPIO");
+        strcpy(dname, "H5FD_MPIO");
     else if (H5FD_MULTI == fdriver)
-        HDstrcpy(dname, "H5FD_MULTI");
+        strcpy(dname, "H5FD_MULTI");
     else if (H5FD_SEC2 == fdriver)
-        HDstrcpy(dname, "H5FD_SEC2");
+        strcpy(dname, "H5FD_SEC2");
     else if (H5FD_STDIO == fdriver)
-        HDstrcpy(dname, "H5FD_STDIO");
+        strcpy(dname, "H5FD_STDIO");
     else
-        HDstrcpy(dname, "Unknown driver");
+        strcpy(dname, "Unknown driver");
 
         /* Take out this because the driver used can be different from the
          * standard output. */
@@ -1311,7 +1311,7 @@ attr_search(hid_t oid, const char *attr_name, const H5A_info_t H5_ATTR_UNUSED *a
     const char        *buf       = attr_data->path;
     const char        *op_name   = attr_data->op_name;
 
-    j = (int)HDstrlen(op_name) - 1;
+    j = (int)strlen(op_name) - 1;
     /* find the last / */
     while (j >= 0) {
         if (op_name[j] == '/' && (j == 0 || (op_name[j - 1] != '\\')))
@@ -1326,12 +1326,12 @@ attr_search(hid_t oid, const char *attr_name, const H5A_info_t H5_ATTR_UNUSED *a
         ret = FAIL;
     }
     else {
-        if (HDstrcmp(attr_name, obj_op_name) == 0) {
+        if (strcmp(attr_name, obj_op_name) == 0) {
             size_t u, v, w;
 
             /* object name */
-            u        = HDstrlen(buf);
-            v        = HDstrlen(op_name);
+            u        = strlen(buf);
+            v        = strlen(op_name);
             w        = u + 1 + v + 1 + 2;
             obj_name = (char *)malloc(w);
             if (obj_name == NULL) {
@@ -1343,16 +1343,16 @@ attr_search(hid_t oid, const char *attr_name, const H5A_info_t H5_ATTR_UNUSED *a
 
                 memset(obj_name, '\0', w);
                 if (op_name[0] != '/') {
-                    HDstrncat(obj_name, buf, buffer_space);
+                    strncat(obj_name, buf, buffer_space);
                     buffer_space -= MIN(buffer_space, u);
 
                     if (buf[u - 1] != '/') {
-                        HDstrncat(obj_name, "/", buffer_space);
+                        strncat(obj_name, "/", buffer_space);
                         buffer_space -= MIN(buffer_space, 2);
                     }
                 }
 
-                HDstrncat(obj_name, op_name, buffer_space);
+                strncat(obj_name, op_name, buffer_space);
                 buffer_space -= MIN(buffer_space, v);
 
                 handle_attributes(oid, obj_name, NULL, 0, NULL);
@@ -1377,7 +1377,7 @@ obj_search(const char *path, const H5O_info2_t *oi, const char H5_ATTR_UNUSED *a
     H5Aiterate_by_name(handle_data->fid, path, H5_INDEX_NAME, H5_ITER_INC, NULL, attr_search,
                        (void *)&attr_data, H5P_DEFAULT);
 
-    if (HDstrcmp(path, op_name) == 0) {
+    if (strcmp(path, op_name) == 0) {
         switch (oi->type) {
             case H5O_TYPE_GROUP:
                 handle_groups(handle_data->fid, path, NULL, 0, NULL);
@@ -1412,7 +1412,7 @@ lnk_search(const char *path, const H5L_info2_t *li, void *_op_data)
     trav_handle_udata_t *handle_data = (trav_handle_udata_t *)_op_data;
     const char          *op_name     = handle_data->op_name;
 
-    search_len = HDstrlen(op_name);
+    search_len = strlen(op_name);
     if (search_len > 0 && op_name[0] != '/')
         k = 2;
     else
@@ -1424,14 +1424,14 @@ lnk_search(const char *path, const H5L_info2_t *li, void *_op_data)
     }
     else {
         if (k == 2) {
-            HDstrcpy(search_name, "/");
-            HDstrcat(search_name, op_name);
+            strcpy(search_name, "/");
+            strcat(search_name, op_name);
         }
         else
-            HDstrcpy(search_name, op_name);
+            strcpy(search_name, op_name);
         search_name[search_len + k - 1] = '\0';
 
-        if (HDstrcmp(path, search_name) == 0) {
+        if (strcmp(path, search_name) == 0) {
             switch (li->type) {
                 case H5L_TYPE_SOFT:
                 case H5L_TYPE_EXTERNAL:
@@ -1530,7 +1530,7 @@ handle_attributes(hid_t fid, const char *attr, void H5_ATTR_UNUSED *data, int H5
     h5tool_format_t   string_dataformat;
     hsize_t           curr_pos = 0; /* total data element position   */
 
-    j        = (int)HDstrlen(attr) - 1;
+    j        = (int)strlen(attr) - 1;
     obj_name = (char *)malloc((size_t)j + 2);
     if (obj_name == NULL)
         goto error;
@@ -1544,9 +1544,9 @@ handle_attributes(hid_t fid, const char *attr, void H5_ATTR_UNUSED *data, int H5
 
     /* object name */
     if (j == -1)
-        HDstrcpy(obj_name, "/");
+        strcpy(obj_name, "/");
     else {
-        HDstrncpy(obj_name, attr, (size_t)j + 1);
+        strncpy(obj_name, attr, (size_t)j + 1);
         obj_name[j + 1] = '\0';
     } /* end else */
 
@@ -1595,12 +1595,12 @@ handle_attributes(hid_t fid, const char *attr, void H5_ATTR_UNUSED *data, int H5
         ctx.need_prefix = true;
         /* Render the element */
         h5tools_str_reset(&buffer);
-        if (HDstrlen(h5tools_dump_header_format->attributeblockend)) {
+        if (strlen(h5tools_dump_header_format->attributeblockend)) {
             h5tools_str_append(&buffer, "%s", h5tools_dump_header_format->attributeblockend);
-            if (HDstrlen(h5tools_dump_header_format->attributeend))
+            if (strlen(h5tools_dump_header_format->attributeend))
                 h5tools_str_append(&buffer, " ");
         }
-        if (HDstrlen(h5tools_dump_header_format->attributeend))
+        if (strlen(h5tools_dump_header_format->attributeend))
             h5tools_str_append(&buffer, "%s", h5tools_dump_header_format->attributeend);
         h5tools_render_element(rawoutstream, outputformat, &ctx, &buffer, &curr_pos,
                                (size_t)outputformat->line_ncols, (hsize_t)0, (hsize_t)0);
@@ -1849,14 +1849,14 @@ handle_groups(hid_t fid, const char *group, void H5_ATTR_UNUSED *data, int pe, c
         }
     }
     else {
-        size_t new_len = HDstrlen(group) + 1;
+        size_t new_len = strlen(group) + 1;
 
         if (prefix_len <= new_len) {
             prefix_len = new_len;
             prefix     = (char *)realloc(prefix, prefix_len);
         } /* end if */
 
-        HDstrcpy(prefix, group);
+        strcpy(prefix, group);
 
         dump_indent += COL;
         dump_group(gid, real_name);
@@ -1978,10 +1978,10 @@ handle_datatypes(hid_t fid, const char *type, void H5_ATTR_UNUSED *data, int pe,
 
                 /* unnamed datatype */
                 H5Otoken_to_str(fid, &type_table->objs[idx].obj_token, &obj_tok_str);
-                HDsnprintf(name, sizeof(name), "/#%s", obj_tok_str);
+                snprintf(name, sizeof(name), "/#%s", obj_tok_str);
                 H5free_memory(obj_tok_str);
 
-                if (!HDstrcmp(name, real_name))
+                if (!strcmp(name, real_name))
                     break;
             } /* end if */
 

--- a/tools/src/h5dump/h5dump_defines.h
+++ b/tools/src/h5dump/h5dump_defines.h
@@ -32,12 +32,12 @@
 
 #define end_obj(obj, end)                                                                                    \
     do {                                                                                                     \
-        if (HDstrlen(end)) {                                                                                 \
+        if (strlen(end)) {                                                                                   \
             PRINTSTREAM(rawoutstream, "%s", end);                                                            \
-            if (HDstrlen(obj))                                                                               \
+            if (strlen(obj))                                                                                 \
                 PRINTVALSTREAM(rawoutstream, " ");                                                           \
         }                                                                                                    \
-        if (HDstrlen(obj))                                                                                   \
+        if (strlen(obj))                                                                                     \
             PRINTSTREAM(rawoutstream, "%s", obj);                                                            \
     } while (0)
 

--- a/tools/src/h5dump/h5dump_xml.c
+++ b/tools/src/h5dump/h5dump_xml.c
@@ -164,15 +164,15 @@ xml_dump_all_cb(hid_t group, const char *name, const H5L_info2_t *linfo, void H5
     outputformat                = &string_dataformat;
 
     /* Build the object's path name */
-    obj_path = (char *)malloc(HDstrlen(prefix) + HDstrlen(name) + 2);
+    obj_path = (char *)malloc(strlen(prefix) + strlen(name) + 2);
     if (!obj_path) {
         ret = FAIL;
         goto done;
     }
 
-    HDstrcpy(obj_path, prefix);
-    HDstrcat(obj_path, "/");
-    HDstrcat(obj_path, name);
+    strcpy(obj_path, prefix);
+    strcat(obj_path, "/");
+    strcat(obj_path, name);
 
     if (linfo->type == H5L_TYPE_HARD) {
         H5O_info2_t oinfo;
@@ -196,7 +196,7 @@ xml_dump_all_cb(hid_t group, const char *name, const H5L_info2_t *linfo, void H5
                     char *old_prefix; /* Pointer to previous prefix */
 
                     /* Keep copy of prefix before iterating into group */
-                    if ((old_prefix = HDstrdup(prefix)) == NULL) {
+                    if ((old_prefix = strdup(prefix)) == NULL) {
                         error_msg("unable to allocate buffer\n");
                         h5tools_setstatus(EXIT_FAILURE);
                         ret = FAIL;
@@ -209,7 +209,7 @@ xml_dump_all_cb(hid_t group, const char *name, const H5L_info2_t *linfo, void H5
                         dump_function_table->dump_group_function(obj, name);
 
                         /* Restore old prefix name */
-                        HDstrcpy(prefix, old_prefix);
+                        strcpy(prefix, old_prefix);
                         free(old_prefix);
                     }
 
@@ -244,13 +244,13 @@ xml_dump_all_cb(hid_t group, const char *name, const H5L_info2_t *linfo, void H5
 
                             /* Render the element */
                             h5tools_str_reset(&buffer);
-                            if (HDstrlen(h5tools_dump_header_format->datasetblockend)) {
+                            if (strlen(h5tools_dump_header_format->datasetblockend)) {
                                 h5tools_str_append(&buffer, "%s",
                                                    h5tools_dump_header_format->datasetblockend);
-                                if (HDstrlen(h5tools_dump_header_format->datasetend))
+                                if (strlen(h5tools_dump_header_format->datasetend))
                                     h5tools_str_append(&buffer, " ");
                             }
-                            if (HDstrlen(h5tools_dump_header_format->datasetend))
+                            if (strlen(h5tools_dump_header_format->datasetend))
                                 h5tools_str_append(&buffer, "%s", h5tools_dump_header_format->datasetend);
                             h5tools_render_element(rawoutstream, outputformat, &ctx, &buffer, &curr_pos,
                                                    (size_t)outputformat->line_ncols, (hsize_t)0, (hsize_t)0);
@@ -265,7 +265,7 @@ xml_dump_all_cb(hid_t group, const char *name, const H5L_info2_t *linfo, void H5
                         else if (found_obj->displayed) {
                             /* the XML version */
                             char *t_obj_path = xml_escape_the_name(obj_path);
-                            char *t_prefix   = xml_escape_the_name(HDstrcmp(prefix, "") ? prefix : "/");
+                            char *t_prefix   = xml_escape_the_name(strcmp(prefix, "") ? prefix : "/");
                             char *t_name     = xml_escape_the_name(name);
                             char *t_objname  = xml_escape_the_name(found_obj->objname);
                             char  dsetxid[100];
@@ -380,19 +380,19 @@ xml_dump_all_cb(hid_t group, const char *name, const H5L_info2_t *linfo, void H5
                         char  linkxid[100];
                         char  parentxid[100];
                         char  targetxid[100];
-                        char *t_prefix   = xml_escape_the_name(HDstrcmp(prefix, "") ? prefix : "/");
+                        char *t_prefix   = xml_escape_the_name(strcmp(prefix, "") ? prefix : "/");
                         char *t_name     = xml_escape_the_name(name);
                         char *t_targbuf  = xml_escape_the_name(targbuf);
                         char *t_obj_path = xml_escape_the_name(obj_path);
                         char *t_link_path;
                         int   res;
 
-                        t_link_path = (char *)malloc(HDstrlen(prefix) + linfo->u.val_size + 1);
+                        t_link_path = (char *)malloc(strlen(prefix) + linfo->u.val_size + 1);
                         if (targbuf[0] == '/')
-                            HDstrcpy(t_link_path, targbuf);
+                            strcpy(t_link_path, targbuf);
                         else {
-                            HDstrcpy(t_link_path, prefix);
-                            HDstrcat(HDstrcat(t_link_path, "/"), targbuf);
+                            strcpy(t_link_path, prefix);
+                            strcat(strcat(t_link_path, "/"), targbuf);
                         } /* end else */
 
                         /* Create OBJ-XIDs for the parent and object */
@@ -481,7 +481,7 @@ xml_dump_all_cb(hid_t group, const char *name, const H5L_info2_t *linfo, void H5
                             char  linkxid[100];
                             char  parentxid[100];
                             char *t_name     = xml_escape_the_name(name);
-                            char *t_prefix   = xml_escape_the_name(HDstrcmp(prefix, "") ? prefix : "/");
+                            char *t_prefix   = xml_escape_the_name(strcmp(prefix, "") ? prefix : "/");
                             char *t_obj_path = xml_escape_the_name(obj_path);
                             char *t_filename = xml_escape_the_name(filename);
                             char *t_targname = xml_escape_the_name(targname);
@@ -529,7 +529,7 @@ xml_dump_all_cb(hid_t group, const char *name, const H5L_info2_t *linfo, void H5
                 char  linkxid[100];
                 char  parentxid[100];
                 char *t_name     = xml_escape_the_name(name);
-                char *t_prefix   = xml_escape_the_name(HDstrcmp(prefix, "") ? prefix : "/");
+                char *t_prefix   = xml_escape_the_name(strcmp(prefix, "") ? prefix : "/");
                 char *t_obj_path = xml_escape_the_name(obj_path);
 
                 /* Create OBJ-XIDs for the parent and object */
@@ -593,14 +593,14 @@ xml_name_to_XID(hid_t loc_id, const char *str, char *outstr, int outlen, int gen
 
     lookup_ret = ref_path_table_lookup(str, &obj_token);
     if (lookup_ret < 0) {
-        if (HDstrlen(str) == 0) {
+        if (strlen(str) == 0) {
             lookup_ret = ref_path_table_lookup("/", &obj_token);
             if (lookup_ret < 0) {
                 if (gen) {
                     ref_path_table_gen_fake(str, &obj_token);
 
                     H5Otoken_to_str(loc_id, &obj_token, &obj_tok_str);
-                    HDsnprintf(outstr, (size_t)outlen, "xid_%s", obj_tok_str);
+                    snprintf(outstr, (size_t)outlen, "xid_%s", obj_tok_str);
                     H5free_memory(obj_tok_str);
 
                     return 0;
@@ -615,7 +615,7 @@ xml_name_to_XID(hid_t loc_id, const char *str, char *outstr, int outlen, int gen
                 ref_path_table_gen_fake(str, &obj_token);
 
                 H5Otoken_to_str(loc_id, &obj_token, &obj_tok_str);
-                HDsnprintf(outstr, (size_t)outlen, "xid_%s", obj_tok_str);
+                snprintf(outstr, (size_t)outlen, "xid_%s", obj_tok_str);
                 H5free_memory(obj_tok_str);
 
                 return 0;
@@ -627,7 +627,7 @@ xml_name_to_XID(hid_t loc_id, const char *str, char *outstr, int outlen, int gen
     }
 
     H5Otoken_to_str(loc_id, &obj_token, &obj_tok_str);
-    HDsnprintf(outstr, (size_t)outlen, "xid_%s", obj_tok_str);
+    snprintf(outstr, (size_t)outlen, "xid_%s", obj_tok_str);
     H5free_memory(obj_tok_str);
 
     return 0;
@@ -664,26 +664,26 @@ xml_escape_the_name(const char *str)
         return NULL;
 
     cp    = str;
-    len   = HDstrlen(str);
+    len   = strlen(str);
     extra = 0;
 
     for (i = 0; i < len; i++) {
         if (*cp == '\"')
-            extra += (HDstrlen(quote) - 1);
+            extra += (strlen(quote) - 1);
         else if (*cp == '\'')
-            extra += (HDstrlen(apos) - 1);
+            extra += (strlen(apos) - 1);
         else if (*cp == '<')
-            extra += (HDstrlen(lt) - 1);
+            extra += (strlen(lt) - 1);
         else if (*cp == '>')
-            extra += (HDstrlen(gt) - 1);
+            extra += (strlen(gt) - 1);
         else if (*cp == '&')
-            extra += (HDstrlen(amp) - 1);
+            extra += (strlen(amp) - 1);
 
         cp++;
     }
 
     if (extra == 0)
-        return HDstrdup(str);
+        return strdup(str);
 
     cp      = str;
     ncp_len = len + extra + 1;
@@ -696,24 +696,24 @@ xml_escape_the_name(const char *str)
         size_t esc_len;
 
         if (*cp == '\'') {
-            HDstrncpy(ncp, apos, ncp_len);
-            esc_len = HDstrlen(apos);
+            strncpy(ncp, apos, ncp_len);
+            esc_len = strlen(apos);
         }
         else if (*cp == '<') {
-            HDstrncpy(ncp, lt, ncp_len);
-            esc_len = HDstrlen(lt);
+            strncpy(ncp, lt, ncp_len);
+            esc_len = strlen(lt);
         }
         else if (*cp == '>') {
-            HDstrncpy(ncp, gt, ncp_len);
-            esc_len = HDstrlen(gt);
+            strncpy(ncp, gt, ncp_len);
+            esc_len = strlen(gt);
         }
         else if (*cp == '\"') {
-            HDstrncpy(ncp, quote, ncp_len);
-            esc_len = HDstrlen(quote);
+            strncpy(ncp, quote, ncp_len);
+            esc_len = strlen(quote);
         }
         else if (*cp == '&') {
-            HDstrncpy(ncp, amp, ncp_len);
-            esc_len = HDstrlen(amp);
+            strncpy(ncp, amp, ncp_len);
+            esc_len = strlen(amp);
         }
         else {
             *ncp    = *cp;
@@ -755,7 +755,7 @@ xml_escape_the_string(const char *str, int slen)
     cp = str;
 
     if (slen < 0)
-        len = HDstrlen(str);
+        len = strlen(str);
     else
         len = (size_t)slen;
 
@@ -767,13 +767,13 @@ xml_escape_the_string(const char *str, int slen)
         else if (*cp == '\"')
             extra++;
         else if (*cp == '\'')
-            extra += (HDstrlen(apos) - 1);
+            extra += (strlen(apos) - 1);
         else if (*cp == '<')
-            extra += (HDstrlen(lt) - 1);
+            extra += (strlen(lt) - 1);
         else if (*cp == '>')
-            extra += (HDstrlen(gt) - 1);
+            extra += (strlen(gt) - 1);
         else if (*cp == '&')
-            extra += (HDstrlen(amp) - 1);
+            extra += (strlen(amp) - 1);
         cp++;
     }
 
@@ -800,20 +800,20 @@ xml_escape_the_string(const char *str, int slen)
             esc_len = 1;
         }
         else if (*cp == '\'') {
-            HDstrncpy(ncp, apos, ncp_len);
-            esc_len = HDstrlen(apos);
+            strncpy(ncp, apos, ncp_len);
+            esc_len = strlen(apos);
         }
         else if (*cp == '<') {
-            HDstrncpy(ncp, lt, ncp_len);
-            esc_len = HDstrlen(lt);
+            strncpy(ncp, lt, ncp_len);
+            esc_len = strlen(lt);
         }
         else if (*cp == '>') {
-            HDstrncpy(ncp, gt, ncp_len);
-            esc_len = HDstrlen(gt);
+            strncpy(ncp, gt, ncp_len);
+            esc_len = strlen(gt);
         }
         else if (*cp == '&') {
-            HDstrncpy(ncp, amp, ncp_len);
-            esc_len = HDstrlen(amp);
+            strncpy(ncp, amp, ncp_len);
+            esc_len = strlen(amp);
         }
         else {
             *ncp    = *cp;
@@ -2362,7 +2362,7 @@ xml_dump_named_datatype(hid_t type, const char *name)
     char             *t_prefix  = NULL;
     char             *t_name    = NULL;
 
-    tmp = (char *)malloc(HDstrlen(prefix) + HDstrlen(name) + 2);
+    tmp = (char *)malloc(strlen(prefix) + strlen(name) + 2);
     if (tmp == NULL) {
         indentation(dump_indent);
         error_msg("internal error (file %s:line %d)\n", __FILE__, __LINE__);
@@ -2370,9 +2370,9 @@ xml_dump_named_datatype(hid_t type, const char *name)
         goto done;
     }
 
-    HDstrcpy(tmp, prefix);
-    HDstrcat(tmp, "/");
-    HDstrcat(tmp, name);
+    strcpy(tmp, prefix);
+    strcat(tmp, "/");
+    strcat(tmp, name);
 
     /* setup */
     memset(&buffer, 0, sizeof(h5tools_str_t));
@@ -2406,7 +2406,7 @@ xml_dump_named_datatype(hid_t type, const char *name)
 
     xml_name_to_XID(type, tmp, dtxid, 100, 1);
     xml_name_to_XID(type, prefix, parentxid, 100, 1);
-    if (HDstrncmp(name, "#", (size_t)1) == 0) {
+    if (strncmp(name, "#", (size_t)1) == 0) {
         /*  Special:  this is an 'anonymous' NDT, deleted but
            still in use.
            We follow the dumper's undocumented practice, and
@@ -2423,7 +2423,7 @@ xml_dump_named_datatype(hid_t type, const char *name)
         h5tools_str_append(&buffer,
                            "<%sNamedDataType Name=\"%s\" OBJ-XID=\"%s\" "
                            "Parents=\"%s\" H5ParentPaths=\"%s\">",
-                           xmlnsprefix, name, dtxid, parentxid, HDstrcmp(prefix, "") ? t_prefix : "/");
+                           xmlnsprefix, name, dtxid, parentxid, strcmp(prefix, "") ? t_prefix : "/");
         h5tools_render_element(rawoutstream, outputformat, &ctx, &buffer, &curr_pos,
                                (size_t)outputformat->line_ncols, (hsize_t)0, (hsize_t)0);
     }
@@ -2438,7 +2438,7 @@ xml_dump_named_datatype(hid_t type, const char *name)
                            "<%sNamedDataType Name=\"%s\" OBJ-XID=\"%s\" "
                            "H5Path=\"%s\" Parents=\"%s\" H5ParentPaths=\"%s\">",
                            xmlnsprefix, t_name, dtxid, t_tmp, parentxid,
-                           (HDstrcmp(prefix, "") ? t_prefix : "/"));
+                           (strcmp(prefix, "") ? t_prefix : "/"));
         h5tools_render_element(rawoutstream, outputformat, &ctx, &buffer, &curr_pos,
                                (size_t)outputformat->line_ncols, (hsize_t)0, (hsize_t)0);
 
@@ -2617,12 +2617,12 @@ xml_dump_group(hid_t gid, const char *name)
     string_dataformat.do_escape = dump_opts.display_escape;
     outputformat                = &string_dataformat;
 
-    if (HDstrcmp(name, "/") == 0) {
+    if (strcmp(name, "/") == 0) {
         isRoot = 1;
-        tmp    = HDstrdup("/");
+        tmp    = strdup("/");
     }
     else {
-        tmp = (char *)malloc(HDstrlen(prefix) + HDstrlen(name) + 2);
+        tmp = (char *)malloc(strlen(prefix) + strlen(name) + 2);
         if (tmp == NULL) {
             indentation(dump_indent);
             error_msg("internal error (file %s:line %d)\n", __FILE__, __LINE__);
@@ -2630,11 +2630,11 @@ xml_dump_group(hid_t gid, const char *name)
             return;
         }
 
-        HDstrcpy(tmp, prefix);
-        par = HDstrdup(tmp);
-        cp  = HDstrrchr(par, '/');
+        strcpy(tmp, prefix);
+        par = strdup(tmp);
+        cp  = strrchr(par, '/');
         if (cp) {
-            if ((cp == par) && HDstrlen(par) > 1)
+            if ((cp == par) && strlen(par) > 1)
                 *(cp + 1) = '\0';
             else
                 *cp = '\0';
@@ -2791,7 +2791,7 @@ xml_dump_group(hid_t gid, const char *name)
                             type = H5Dget_type(dset);
 
                             H5Otoken_to_str(dset, &type_table->objs[u].obj_token, &obj_tok_str);
-                            HDsnprintf(type_name, sizeof(type_name), "#%s", obj_tok_str);
+                            snprintf(type_name, sizeof(type_name), "#%s", obj_tok_str);
                             H5free_memory(obj_tok_str);
 
                             dump_function_table->dump_named_datatype_function(type, type_name);
@@ -2884,7 +2884,7 @@ xml_dump_group(hid_t gid, const char *name)
                     type = H5Dget_type(dset);
 
                     H5Otoken_to_str(dset, &type_table->objs[u].obj_token, &obj_tok_str);
-                    HDsnprintf(type_name, sizeof(type_name), "#%s", obj_tok_str);
+                    snprintf(type_name, sizeof(type_name), "#%s", obj_tok_str);
                     H5free_memory(obj_tok_str);
 
                     dump_function_table->dump_named_datatype_function(type, type_name);
@@ -3181,10 +3181,10 @@ xml_print_strs(hid_t did, int source)
         if (is_vlstr) {
             onestring = *(char **)((void *)bp);
             if (onestring)
-                str_size = HDstrlen(onestring);
+                str_size = strlen(onestring);
         }
         else {
-            HDstrncpy(onestring, bp, tsiz);
+            strncpy(onestring, bp, tsiz);
             str_size = tsiz;
         }
 
@@ -3773,7 +3773,7 @@ xml_dump_dataset(hid_t did, const char *name, struct subset_t H5_ATTR_UNUSED *ss
     char *rstr = (char *)malloc((size_t)100);
     char *pstr = (char *)malloc((size_t)100);
 
-    tmp = (char *)malloc(HDstrlen(prefix) + HDstrlen(name) + 2);
+    tmp = (char *)malloc(strlen(prefix) + strlen(name) + 2);
     if (tmp == NULL) {
         error_msg("buffer allocation failed\n");
         h5tools_setstatus(EXIT_FAILURE);
@@ -3782,9 +3782,9 @@ xml_dump_dataset(hid_t did, const char *name, struct subset_t H5_ATTR_UNUSED *ss
         return;
     }
 
-    HDstrcpy(tmp, prefix);
-    HDstrcat(tmp, "/");
-    HDstrcat(tmp, name);
+    strcpy(tmp, prefix);
+    strcat(tmp, "/");
+    strcat(tmp, name);
 
     /* setup */
     memset(&buffer, 0, sizeof(h5tools_str_t));

--- a/tools/src/h5format_convert/h5format_convert.c
+++ b/tools/src/h5format_convert/h5format_convert.c
@@ -119,7 +119,7 @@ parse_command_line(int argc, const char *const *argv)
 
             case 'd': /* -d dname */
                 if (H5_optarg != NULL && *H5_optarg)
-                    dname_g = HDstrdup(H5_optarg);
+                    dname_g = strdup(H5_optarg);
                 if (dname_g == NULL) {
                     h5tools_setstatus(EXIT_FAILURE);
                     error_msg("No dataset name `%s`\n", H5_optarg);
@@ -152,7 +152,7 @@ parse_command_line(int argc, const char *const *argv)
         goto error;
     }
 
-    fname_g = HDstrdup(argv[H5_optind]);
+    fname_g = strdup(argv[H5_optind]);
 
     return 0;
 

--- a/tools/src/h5import/h5import.c
+++ b/tools/src/h5import/h5import.c
@@ -104,7 +104,7 @@ main(int argc, char *argv[])
     if ((opt = (struct Options *)calloc(1, sizeof(struct Options))) == NULL)
         goto err;
 
-    if (argv[1] && (HDstrcmp("-V", argv[1]) == 0)) {
+    if (argv[1] && (strcmp("-V", argv[1]) == 0)) {
         print_version(PROGRAMNAME);
         exit(EXIT_SUCCESS);
     }
@@ -133,7 +133,7 @@ main(int argc, char *argv[])
 
             case 1: /* counting input files */
                 if (opt->fcount < 29) {
-                    (void)HDstrcpy(opt->infiles[opt->fcount].datafile, argv[i]);
+                    (void)strcpy(opt->infiles[opt->fcount].datafile, argv[i]);
                     in                               = &(opt->infiles[opt->fcount].in);
                     opt->infiles[opt->fcount].config = 0;
                     setDefaultValues(in, opt->fcount);
@@ -150,7 +150,7 @@ main(int argc, char *argv[])
                 break;
 
             case 3: /* get configfile name */
-                (void)HDstrcpy(opt->infiles[opt->fcount - 1].configfile, argv[i]);
+                (void)strcpy(opt->infiles[opt->fcount - 1].configfile, argv[i]);
                 opt->infiles[opt->fcount - 1].config = 1;
                 break;
 
@@ -158,11 +158,11 @@ main(int argc, char *argv[])
                 break;
 
             case 5: /* get outfile found */
-                if (HDstrlen(argv[i]) > MAX_PATH_NAME_LENGTH) {
+                if (strlen(argv[i]) > MAX_PATH_NAME_LENGTH) {
                     (void)fprintf(stderr, err10, argv[i]);
                     goto err;
                 }
-                (void)HDstrcpy(opt->outfile, argv[i]);
+                (void)strcpy(opt->outfile, argv[i]);
                 outfile_named = true;
                 break;
 
@@ -287,40 +287,40 @@ gtoken(char *s)
      * identify the token type
      */
     if (s[0] == '-') { /* option name (or negative number) */
-        len = HDstrlen(&s[1]);
+        len = strlen(&s[1]);
         switch (s[1]) {
             case 'o':
-                if (!HDstrncmp("outfile", &s[1], len))
+                if (!strncmp("outfile", &s[1], len))
                     token = OPT_o;
                 break;
 
             case 'c':
-                if (!HDstrncmp("config", &s[1], len))
+                if (!strncmp("config", &s[1], len))
                     token = OPT_c;
                 break;
 
             case 'h':
-                if (!HDstrncmp("help", &s[1], len))
+                if (!strncmp("help", &s[1], len))
                     token = OPT_h;
                 break;
 
             case 'd':
-                if (!HDstrncmp("dims", &s[1], len))
+                if (!strncmp("dims", &s[1], len))
                     token = OPT_d;
                 break;
 
             case 'p':
-                if (!HDstrncmp("path", &s[1], len))
+                if (!strncmp("path", &s[1], len))
                     token = OPT_p;
                 break;
 
             case 't':
-                if (!HDstrncmp("type", &s[1], len))
+                if (!strncmp("type", &s[1], len))
                     token = OPT_t;
                 break;
 
             case 's':
-                if (!HDstrncmp("size", &s[1], len))
+                if (!strncmp("size", &s[1], len))
                     token = OPT_s;
                 break;
             default:
@@ -489,7 +489,7 @@ readIntegerData(FILE *strm, struct Input *in)
                 case 0: /* TEXTIN */
                     in08 = (H5DT_INT8 *)in->data;
                     for (i = 0; i < len; i++, in08++) {
-                        if (HDfscanf(strm, "%hd", &temp16) != 1) {
+                        if (fscanf(strm, "%hd", &temp16) != 1) {
                             (void)fprintf(stderr, "%s", err1);
                             return (-1);
                         }
@@ -521,7 +521,7 @@ readIntegerData(FILE *strm, struct Input *in)
             switch (in->inputClass) {
                 case 0: /* TEXTIN */
                     for (i = 0; i < len; i++, in16++) {
-                        if (HDfscanf(strm, "%hd", in16) != 1) {
+                        if (fscanf(strm, "%hd", in16) != 1) {
                             (void)fprintf(stderr, "%s", err1);
                             return (-1);
                         }
@@ -558,7 +558,7 @@ readIntegerData(FILE *strm, struct Input *in)
             switch (in->inputClass) {
                 case 0: /* TEXTIN */
                     for (i = 0; i < len; i++, in32++) {
-                        if (HDfscanf(strm, "%d", in32) != 1) {
+                        if (fscanf(strm, "%d", in32) != 1) {
                             (void)fprintf(stderr, "%s", err1);
                             return (-1);
                         }
@@ -594,7 +594,7 @@ readIntegerData(FILE *strm, struct Input *in)
             switch (in->inputClass) {
                 case 0: /* TEXTIN */
                     for (i = 0; i < len; i++, in64++) {
-                        if (HDfscanf(strm, "%s", buffer) < 1) {
+                        if (fscanf(strm, "%s", buffer) < 1) {
                             (void)fprintf(stderr, "%s", err1);
                             return (-1);
                         }
@@ -660,7 +660,7 @@ readUIntegerData(FILE *strm, struct Input *in)
                 case 6: /* TEXTUIN */
                     in08 = (H5DT_UINT8 *)in->data;
                     for (i = 0; i < len; i++, in08++) {
-                        if (HDfscanf(strm, "%hu", &temp16) != 1) {
+                        if (fscanf(strm, "%hu", &temp16) != 1) {
                             (void)fprintf(stderr, "%s", err1);
                             return (-1);
                         }
@@ -689,7 +689,7 @@ readUIntegerData(FILE *strm, struct Input *in)
             switch (in->inputClass) {
                 case 6: /* TEXTUIN */
                     for (i = 0; i < len; i++, in16++) {
-                        if (HDfscanf(strm, "%hu", in16) != 1) {
+                        if (fscanf(strm, "%hu", in16) != 1) {
                             (void)fprintf(stderr, "%s", err1);
                             return (-1);
                         }
@@ -725,7 +725,7 @@ readUIntegerData(FILE *strm, struct Input *in)
             switch (in->inputClass) {
                 case 6: /* TEXTUIN */
                     for (i = 0; i < len; i++, in32++) {
-                        if (HDfscanf(strm, "%u", in32) != 1) {
+                        if (fscanf(strm, "%u", in32) != 1) {
                             (void)fprintf(stderr, "%s", err1);
                             return (-1);
                         }
@@ -761,7 +761,7 @@ readUIntegerData(FILE *strm, struct Input *in)
             switch (in->inputClass) {
                 case 6: /* TEXTUIN */
                     for (i = 0; i < len; i++, in64++) {
-                        if (HDfscanf(strm, "%s", buffer) < 1) {
+                        if (fscanf(strm, "%s", buffer) < 1) {
                             (void)fprintf(stderr, "%s", err1);
                             return (-1);
                         }
@@ -826,7 +826,7 @@ readFloatData(FILE *strm, struct Input *in)
             switch (in->inputClass) {
                 case 1: /* TEXTFP */
                     for (i = 0; i < len; i++, fp32++) {
-                        if (HDfscanf(strm, "%f", fp32) != 1) {
+                        if (fscanf(strm, "%f", fp32) != 1) {
                             (void)fprintf(stderr, "%s", err1);
                             return (-1);
                         }
@@ -839,7 +839,7 @@ readFloatData(FILE *strm, struct Input *in)
                 case 2: /*TEXTFPE */
 
                     for (i = 0; i < len; i++, fp32++) {
-                        if (HDfscanf(strm, "%f", fp32) != 1) {
+                        if (fscanf(strm, "%f", fp32) != 1) {
                             (void)fprintf(stderr, "%s", err1);
                             return (-1);
                         }
@@ -878,7 +878,7 @@ readFloatData(FILE *strm, struct Input *in)
             switch (in->inputClass) {
                 case 1: /* TEXTFP */
                     for (i = 0; i < len; i++, fp64++) {
-                        if (HDfscanf(strm, "%lf", fp64) != 1) {
+                        if (fscanf(strm, "%lf", fp64) != 1) {
                             (void)fprintf(stderr, "%s", err1);
                             return (-1);
                         }
@@ -891,7 +891,7 @@ readFloatData(FILE *strm, struct Input *in)
                 case 2: /*TEXTFPE */
 
                     for (i = 0; i < len; i++, fp64++) {
-                        if (HDfscanf(strm, "%lf", fp64) != 1) {
+                        if (fscanf(strm, "%lf", fp64) != 1) {
                             (void)fprintf(stderr, "%s", err1);
                             return (-1);
                         }
@@ -964,7 +964,7 @@ processStrData(FILE *strm, struct Input *in, hid_t file_id)
      *-------------------------------------------------------------------------
      */
 
-    while (EOF != (c = HDfgetc(strm)))
+    while (EOF != (c = fgetc(strm)))
         if (c == 10) /* eol */
             nlines++;
 
@@ -1029,7 +1029,7 @@ processStrData(FILE *strm, struct Input *in, hid_t file_id)
 
     line = 0;
 
-    while (EOF != (c = HDfgetc(strm))) {
+    while (EOF != (c = fgetc(strm))) {
         str[i] = (char)c;
 
         i++;
@@ -1162,7 +1162,7 @@ processStrHDFData(FILE *strm, struct Input *in, hid_t file_id)
     line = 0;
     j    = 0;
 
-    while (HDfgets(str, sizeof(str), strm)) {
+    while (fgets(str, sizeof(str), strm)) {
         str1 = str;
         str2 = NULL;
         str3 = NULL;
@@ -1173,24 +1173,24 @@ processStrHDFData(FILE *strm, struct Input *in, hid_t file_id)
         str2 = strchr(str1, '"');
         if (str2 != NULL) {
 #ifdef H5DEBUGIMPORT
-            printf("processStrHDFData DATATYPE STRING len:%d for {%s}\n", HDstrlen(str2), str2);
+            printf("processStrHDFData DATATYPE STRING len:%d for {%s}\n", strlen(str2), str2);
 #endif
             str2++;
 #ifdef H5DEBUGIMPORT
-            printf("processStrHDFData DATATYPE STRING len:%d for {%s}\n", HDstrlen(str2), str2);
+            printf("processStrHDFData DATATYPE STRING len:%d for {%s}\n", strlen(str2), str2);
 #endif
             str3 = strrchr(str2, '"');
             if (str3 != NULL) {
 #ifdef H5DEBUGIMPORT
-                printf("processStrHDFData DATATYPE STRING len:%d for {%s}\n", HDstrlen(str3), str3);
+                printf("processStrHDFData DATATYPE STRING len:%d for {%s}\n", strlen(str3), str3);
 #endif
                 *str3 = '\0';
 
 #ifdef H5DEBUGIMPORT
-                printf("processStrHDFData DATATYPE STRING len:%d for {%s}\n", HDstrlen(str2), str2);
+                printf("processStrHDFData DATATYPE STRING len:%d for {%s}\n", strlen(str2), str2);
 #endif
 
-                if (HDstrlen(str2) > 0) {
+                if (strlen(str2) > 0) {
                     hid_t   fspace_id;
                     hsize_t start[1];
                     hsize_t count[1] = {1};
@@ -1461,18 +1461,18 @@ processConfigurationFile(char *infile, struct Input *in)
         goto error;
     }
 
-    scanret = HDfscanf(strm, "%254s", key);
-    if ((scanret == 1) && !HDstrcmp("HDF5", key)) {
+    scanret = fscanf(strm, "%254s", key);
+    if ((scanret == 1) && !strcmp("HDF5", key)) {
 #ifdef H5DEBUGIMPORT
         int pndx;
         printf("\nh5dump file\n");
 #endif
         in->h5dumpInput = 1;
-        scanret         = HDfscanf(strm, "%254s", temp); /* filename */
-        scanret         = HDfscanf(strm, "%254s", temp); /* start bracket */
-        scanret         = HDfscanf(strm, "%254s", key);  /* DATASET */
+        scanret         = fscanf(strm, "%254s", temp); /* filename */
+        scanret         = fscanf(strm, "%254s", temp); /* start bracket */
+        scanret         = fscanf(strm, "%254s", key);  /* DATASET */
         while (scanret == 1) {
-            if (!HDstrcmp("DATASET", key)) { /* PATH */
+            if (!strcmp("DATASET", key)) { /* PATH */
 #ifdef H5DEBUGIMPORT
                 printf("h5dump DATASET key\n");
 #endif
@@ -1480,7 +1480,7 @@ processConfigurationFile(char *infile, struct Input *in)
                     (void)fprintf(stderr, err3a, infile);
                     goto error;
                 }
-                if (HDfscanf(strm, "%254s", temp) != 1) {
+                if (fscanf(strm, "%254s", temp) != 1) {
                     (void)fprintf(stderr, "%s", err18);
                     goto error;
                 }
@@ -1492,12 +1492,12 @@ processConfigurationFile(char *infile, struct Input *in)
                     goto error;
                 }
                 in->configOptionVector[PATH] = 1;
-                scanret                      = HDfscanf(strm, "%254s", temp); /* start bracket */
+                scanret                      = fscanf(strm, "%254s", temp); /* start bracket */
 #ifdef H5DEBUGIMPORT
                 printf("h5dump DATASET %s found\n", temp);
 #endif
-            }                                      /* if(!HDstrcmp("DATASET", key))  PATH */
-            else if (!HDstrcmp("DATATYPE", key)) { /* INPUT-CLASS */
+            }                                    /* if(!strcmp("DATASET", key))  PATH */
+            else if (!strcmp("DATATYPE", key)) { /* INPUT-CLASS */
 #ifdef H5DEBUGIMPORT
                 printf("h5dump DATATYPE key\n");
 #endif
@@ -1506,7 +1506,7 @@ processConfigurationFile(char *infile, struct Input *in)
                     goto error;
                 }
 
-                if (HDfscanf(strm, "%254s", temp) != 1) {
+                if (fscanf(strm, "%254s", temp) != 1) {
                     (void)fprintf(stderr, "%s", err18);
                     goto error;
                 }
@@ -1542,27 +1542,27 @@ processConfigurationFile(char *infile, struct Input *in)
 #ifdef H5DEBUGIMPORT
                     printf("h5dump DATATYPE STRING found\n");
 #endif
-                    if (HDfscanf(strm, "%254s", temp) != 1) { /* start bracket */
+                    if (fscanf(strm, "%254s", temp) != 1) { /* start bracket */
                         (void)fprintf(stderr, "%s", err18);
                         goto error;
                     }
 #ifdef H5DEBUGIMPORT
                     printf("h5dump DATATYPE STRING %s found\n", temp);
 #endif
-                    if (HDfscanf(strm, "%254s", temp) != 1) { /* string properties */
+                    if (fscanf(strm, "%254s", temp) != 1) { /* string properties */
                         (void)fprintf(stderr, "%s", err18);
                         goto error;
                     }
                     while (get_next_prop) {
-                        if (!HDstrcmp("STRSIZE", temp)) { /* STRSIZE */
-                            if (HDfscanf(strm, "%254s", temp) != 1) {
+                        if (!strcmp("STRSIZE", temp)) { /* STRSIZE */
+                            if (fscanf(strm, "%254s", temp) != 1) {
                                 (void)fprintf(stderr, "%s", err19);
                                 goto error;
                             }
 #ifdef H5DEBUGIMPORT
                             printf("h5dump DATATYPE STRING STRSIZE %s found\n", temp);
 #endif
-                            if (HDstrcmp("H5T_VARIABLE;", temp) != 0) {
+                            if (strcmp("H5T_VARIABLE;", temp) != 0) {
                                 char *more = temp;
                                 ival       = (int)strtol(more, &more, 10);
                                 if (getInputSize(in, ival) == -1) {
@@ -1574,8 +1574,8 @@ processConfigurationFile(char *infile, struct Input *in)
 #endif
                             }
                         }
-                        else if (!HDstrcmp("STRPAD", temp)) {         /* STRPAD */
-                            if (HDfscanf(strm, "%254s", temp) != 1) { /* STRPAD type */
+                        else if (!strcmp("STRPAD", temp)) {         /* STRPAD */
+                            if (fscanf(strm, "%254s", temp) != 1) { /* STRPAD type */
                                 (void)fprintf(stderr, "%s", err18);
                                 goto error;
                             }
@@ -1583,8 +1583,8 @@ processConfigurationFile(char *infile, struct Input *in)
                             printf("h5dump DATATYPE STRING STRPAD %s found\n", temp);
 #endif
                         }
-                        else if (!HDstrcmp("CSET", key)) {            /* CSET */
-                            if (HDfscanf(strm, "%254s", temp) != 1) { /* CSET type */
+                        else if (!strcmp("CSET", key)) {            /* CSET */
+                            if (fscanf(strm, "%254s", temp) != 1) { /* CSET type */
                                 (void)fprintf(stderr, "%s", err18);
                                 goto error;
                             }
@@ -1592,69 +1592,69 @@ processConfigurationFile(char *infile, struct Input *in)
                             printf("h5dump DATATYPE STRING CSET %s found\n", temp);
 #endif
                         }
-                        else if (!HDstrcmp("CTYPE", temp)) {          /* CTYPE */
-                            if (HDfscanf(strm, "%254s", temp) != 1) { /* CTYPE type */
+                        else if (!strcmp("CTYPE", temp)) {          /* CTYPE */
+                            if (fscanf(strm, "%254s", temp) != 1) { /* CTYPE type */
                                 (void)fprintf(stderr, "%s", err18);
                                 goto error;
                             }
 #ifdef H5DEBUGIMPORT
                             printf("h5dump DATATYPE STRING  CTYPE %s found\n", temp);
 #endif
-                        } /* if(!HDstrcmp("CSET", key)) */
-                        if (HDfscanf(strm, "%254s", temp) != 1) {
+                        } /* if(!strcmp("CSET", key)) */
+                        if (fscanf(strm, "%254s", temp) != 1) {
                             (void)fprintf(stderr, "%s", err18);
                             goto error;
                         }
 #ifdef H5DEBUGIMPORT
                         printf("h5dump DATATYPE STRING %s found\n", temp);
 #endif
-                        if (!HDstrcmp("}", temp)) { /* end bracket */
+                        if (!strcmp("}", temp)) { /* end bracket */
                             get_next_prop = 0;
                         }
-                    }                               /* while (get_next_prop) */
-                }                                   /* if(kindex == 5)  STRING */
-            }                                       /* else if(!HDstrcmp("DATATYPE", key))  INPUT-CLASS */
-            else if (!HDstrcmp("DATASPACE", key)) { /* RANK and DIMENSIONS */
+                    }                             /* while (get_next_prop) */
+                }                                 /* if(kindex == 5)  STRING */
+            }                                     /* else if(!strcmp("DATATYPE", key))  INPUT-CLASS */
+            else if (!strcmp("DATASPACE", key)) { /* RANK and DIMENSIONS */
                 hsize_t temp_dims[MAX_NUM_DIMENSION];
 
 #ifdef H5DEBUGIMPORT
                 printf("h5dump DATASPACE key\n");
 #endif
-                if (HDfscanf(strm, "%254s", temp) != 1) {
+                if (fscanf(strm, "%254s", temp) != 1) {
                     (void)fprintf(stderr, "%s", err18);
                     goto error;
                 }
-                if (!HDstrcmp("SCALAR", temp)) { /* SCALAR */
+                if (!strcmp("SCALAR", temp)) { /* SCALAR */
                     in->rank = 0;
-                }                                   /* if(!HDstrcmp("SCALAR", key)) */
-                else if (!HDstrcmp("NULL", temp)) { /* NULL */
+                }                                 /* if(!strcmp("SCALAR", key)) */
+                else if (!strcmp("NULL", temp)) { /* NULL */
                     (void)fprintf(stderr, err6b, infile);
                     goto error;
-                }                                     /* else if(!HDstrcmp("NULL", key)) */
-                else if (!HDstrcmp("SIMPLE", temp)) { /* SIMPLE */
+                }                                   /* else if(!strcmp("NULL", key)) */
+                else if (!strcmp("SIMPLE", temp)) { /* SIMPLE */
                     int icount = 0;
 #ifdef H5DEBUGIMPORT
                     printf("h5dump DATASPACE SIMPLE found\n");
 #endif
-                    if (HDfscanf(strm, "%254s", temp) != 1) { /* start bracket */
+                    if (fscanf(strm, "%254s", temp) != 1) { /* start bracket */
                         (void)fprintf(stderr, err6b, infile);
                         goto error;
                     }
 #ifdef H5DEBUGIMPORT
                     printf("h5dump DATASPACE SIMPLE %s found\n", temp);
 #endif
-                    if (HDfscanf(strm, "%254s", temp) != 1) { /* start paren */
+                    if (fscanf(strm, "%254s", temp) != 1) { /* start paren */
                         (void)fprintf(stderr, err6b, infile);
                         goto error;
                     }
 #ifdef H5DEBUGIMPORT
                     printf("h5dump DATASPACE SIMPLE %s found\n", temp);
 #endif
-                    if (!HDstrcmp("(", temp)) { /* start paren */
+                    if (!strcmp("(", temp)) { /* start paren */
                         int get_next_dim = 1;
                         int i            = 0;
 
-                        if (HDfscanf(strm, "%254s", temp) != 1) { /* Dimension with optional comma */
+                        if (fscanf(strm, "%254s", temp) != 1) { /* Dimension with optional comma */
                             (void)fprintf(stderr, err16c, infile);
                             goto error;
                         }
@@ -1664,14 +1664,14 @@ processConfigurationFile(char *infile, struct Input *in)
                         while (get_next_dim) {
                             char *more        = temp;
                             temp_dims[icount] = strtoull(more, &more, 10);
-                            if (HDfscanf(strm, "%254s", temp) != 1) { /* Dimension or end paren */
+                            if (fscanf(strm, "%254s", temp) != 1) { /* Dimension or end paren */
                                 (void)fprintf(stderr, err6b, infile);
                                 goto error;
                             }
 #ifdef H5DEBUGIMPORT
                             printf("h5dump DATASPACE SIMPLE %s found\n", temp);
 #endif
-                            if (!HDstrcmp(")", temp)) { /* end paren */
+                            if (!strcmp(")", temp)) { /* end paren */
                                 in->rank                     = ++icount;
                                 in->configOptionVector[RANK] = 1;
                                 get_next_dim                 = 0;
@@ -1703,38 +1703,38 @@ processConfigurationFile(char *infile, struct Input *in)
                         printf("\n");
 #endif
                         in->configOptionVector[DIM] = 1;
-                    } /* if(!HDstrcmp("(", key))  start paren */
+                    } /* if(!strcmp("(", key))  start paren */
                     else {
                         (void)fprintf(stderr, err5b, infile);
                         goto error;
                     }
-                    if (HDfscanf(strm, "%254s", temp) != 1) {
+                    if (fscanf(strm, "%254s", temp) != 1) {
                         (void)fprintf(stderr, "%s", err18);
                         goto error;
                     }
 #ifdef H5DEBUGIMPORT
                     printf("h5dump DATASPACE SIMPLE %s found\n", temp);
 #endif
-                    if (!HDstrcmp("/", temp)) { /* / max dims */
+                    if (!strcmp("/", temp)) { /* / max dims */
                         if ((in->maxsizeOfDimension =
                                  (hsize_t *)malloc((size_t)in->rank * sizeof(hsize_t))) == NULL) {
                             goto error;
                         }
-                        if (HDfscanf(strm, "%254s", temp) != 1) { /* start paren */
+                        if (fscanf(strm, "%254s", temp) != 1) { /* start paren */
                             (void)fprintf(stderr, err6b, infile);
                             goto error;
                         }
 #ifdef H5DEBUGIMPORT
                         printf("h5dump DATASPACE SIMPLE %s found\n", temp);
 #endif
-                        if (!HDstrcmp("(", temp)) { /* start paren */
+                        if (!strcmp("(", temp)) { /* start paren */
                             int get_next_dim = 1;
                             int i            = 0;
 
 #ifdef H5DEBUGIMPORT
                             printf("h5dump DATASPACE SIMPLE process max dim values\n");
 #endif
-                            if (HDfscanf(strm, "%254s", temp) != 1) { /* max dim with optional comma */
+                            if (fscanf(strm, "%254s", temp) != 1) { /* max dim with optional comma */
                                 (void)fprintf(stderr, err16c, infile);
                                 goto error;
                             }
@@ -1745,8 +1745,8 @@ processConfigurationFile(char *infile, struct Input *in)
 #ifdef H5DEBUGIMPORT
                                 printf("h5dump DATASPACE SIMPLE get max dim value\n");
 #endif
-                                if (!HDstrcmp("H5S_UNLIMITED", temp) ||
-                                    !HDstrcmp("H5S_UNLIMITED,", temp)) { /* unlimited */
+                                if (!strcmp("H5S_UNLIMITED", temp) ||
+                                    !strcmp("H5S_UNLIMITED,", temp)) { /* unlimited */
                                     in->maxsizeOfDimension[i]      = H5S_UNLIMITED;
                                     in->configOptionVector[EXTEND] = 1;
                                 }
@@ -1754,14 +1754,14 @@ processConfigurationFile(char *infile, struct Input *in)
                                     char *more                = temp;
                                     in->maxsizeOfDimension[i] = strtoull(more, &more, 10);
                                 }
-                                if (HDfscanf(strm, "%254s", temp) != 1) { /* max dim or end paren */
+                                if (fscanf(strm, "%254s", temp) != 1) { /* max dim or end paren */
                                     (void)fprintf(stderr, err16c, infile);
                                     goto error;
                                 }
 #ifdef H5DEBUGIMPORT
                                 printf("h5dump DATASPACE SIMPLE %s found\n", temp);
 #endif
-                                if (!HDstrcmp(")", temp)) { /* end paren */
+                                if (!strcmp(")", temp)) { /* end paren */
                                     get_next_dim = 0;
                                 }
                                 else { /* comma */
@@ -1780,57 +1780,57 @@ processConfigurationFile(char *infile, struct Input *in)
                             printf("\n");
                             printf("h5dump DATASPACE SIMPLE get max dim finished\n");
 #endif
-                        } /* if(!HDstrcmp("(", key))  start paren */
+                        } /* if(!strcmp("(", key))  start paren */
                         else {
                             (void)fprintf(stderr, err16c, infile);
                             goto error;
                         }
-                        scanret = HDfscanf(strm, "%254s", temp); /* end bracket */
+                        scanret = fscanf(strm, "%254s", temp); /* end bracket */
 #ifdef H5DEBUGIMPORT
                         printf("h5dump DATASPACE SIMPLE %s found\n", temp);
 #endif
-                    } /* if(!HDstrcmp("/", key)) max dims separator */
-                }     /* else if(!HDstrcmp("SIMPLE", key)) */
+                    } /* if(!strcmp("/", key)) max dims separator */
+                }     /* else if(!strcmp("SIMPLE", key)) */
                 else {
                     (void)fprintf(stderr, err5b, infile);
                     goto error;
                 }
-            } /* else if(!HDstrcmp("DATASPACE", key))  RANK and DIMENSIONS */
-            else if (!HDstrcmp("STORAGE_LAYOUT", key)) { /* CHUNKED-DIMENSION-SIZES */
+            } /* else if(!strcmp("DATASPACE", key))  RANK and DIMENSIONS */
+            else if (!strcmp("STORAGE_LAYOUT", key)) { /* CHUNKED-DIMENSION-SIZES */
 #ifdef H5DEBUGIMPORT
                 printf("h5dump STORAGE_LAYOUT key\n");
 #endif
-                if (HDfscanf(strm, "%254s", temp) != 1) { /* start bracket */
+                if (fscanf(strm, "%254s", temp) != 1) { /* start bracket */
                     (void)fprintf(stderr, err6b, infile);
                     goto error;
                 }
 #ifdef H5DEBUGIMPORT
                 printf("h5dump STORAGE_LAYOUT %s found\n", temp);
 #endif
-                if (HDfscanf(strm, "%254s", temp) != 1) { /* CHUNKED */
+                if (fscanf(strm, "%254s", temp) != 1) { /* CHUNKED */
                     (void)fprintf(stderr, err6b, infile);
                     goto error;
                 }
 #ifdef H5DEBUGIMPORT
                 printf("h5dump STORAGE_LAYOUT %s found\n", temp);
 #endif
-                if (!HDstrcmp("CHUNKED", temp)) { /* CHUNKED */
+                if (!strcmp("CHUNKED", temp)) { /* CHUNKED */
                     if ((in->sizeOfChunk = (hsize_t *)malloc((size_t)in->rank * sizeof(hsize_t))) == NULL) {
                         (void)fprintf(stderr, "Unable to allocate dynamic memory.\n");
                         goto error;
                     }
-                    if (HDfscanf(strm, "%254s", temp) != 1) { /* start paren */
+                    if (fscanf(strm, "%254s", temp) != 1) { /* start paren */
                         (void)fprintf(stderr, err6b, infile);
                         goto error;
                     }
 #ifdef H5DEBUGIMPORT
                     printf("h5dump STORAGE_LAYOUT CHUNKED %s found\n", temp);
 #endif
-                    if (!HDstrcmp("(", temp)) { /* start paren */
+                    if (!strcmp("(", temp)) { /* start paren */
                         int get_next_dim = 1;
                         int icount       = 0;
 
-                        if (HDfscanf(strm, "%254s", temp) != 1) { /* Dimension with optional comma */
+                        if (fscanf(strm, "%254s", temp) != 1) { /* Dimension with optional comma */
                             (void)fprintf(stderr, err16c, infile);
                             goto error;
                         }
@@ -1840,14 +1840,14 @@ processConfigurationFile(char *infile, struct Input *in)
                         while (get_next_dim) {
                             char *more              = temp;
                             in->sizeOfChunk[icount] = strtoull(more, &more, 10);
-                            if (HDfscanf(strm, "%254s", temp) != 1) { /* Dimension or end paren */
+                            if (fscanf(strm, "%254s", temp) != 1) { /* Dimension or end paren */
                                 (void)fprintf(stderr, err6b, infile);
                                 goto error;
                             }
 #ifdef H5DEBUGIMPORT
                             printf("h5dump STORAGE_LAYOUT CHUNKED %s found\n", temp);
 #endif
-                            if (!HDstrcmp(")", temp)) { /* end paren */
+                            if (!strcmp(")", temp)) { /* end paren */
                                 in->configOptionVector[RANK] = 1;
                                 get_next_dim                 = 0;
                             }
@@ -1867,20 +1867,20 @@ processConfigurationFile(char *infile, struct Input *in)
                         printf("\n");
 #endif
                         in->configOptionVector[DIM] = 1;
-                    } /* if(!HDstrcmp("(", key))  start paren */
+                    } /* if(!strcmp("(", key))  start paren */
                     else {
                         (void)fprintf(stderr, err5b, infile);
                         goto error;
                     }
-                    if (HDfscanf(strm, "%254s", temp) != 1) { /* SIZE */
+                    if (fscanf(strm, "%254s", temp) != 1) { /* SIZE */
                         (void)fprintf(stderr, err6b, infile);
                         goto error;
                     }
 #ifdef H5DEBUGIMPORT
                     printf("h5dump STORAGE_LAYOUT CHUNKED %s found\n", temp);
 #endif
-                    if (!HDstrcmp("SIZE", temp)) { /* SIZE */
-                        if (HDfscanf(strm, "%d", (&ival)) != 1) {
+                    if (!strcmp("SIZE", temp)) { /* SIZE */
+                        if (fscanf(strm, "%d", (&ival)) != 1) {
                             (void)fprintf(stderr, "%s", err19);
                             goto error;
                         }
@@ -1888,8 +1888,8 @@ processConfigurationFile(char *infile, struct Input *in)
                         printf("h5dump STORAGE_LAYOUT CHUNKED SIZE %d found\n", ival);
 #endif
                     }
-                    while (HDstrcmp("}", temp) != 0) {
-                        if (HDfscanf(strm, "%254s", temp) != 1) { /* end bracket */
+                    while (strcmp("}", temp) != 0) {
+                        if (fscanf(strm, "%254s", temp) != 1) { /* end bracket */
                             (void)fprintf(stderr, "%s", err18);
                             goto error;
                         }
@@ -1898,52 +1898,52 @@ processConfigurationFile(char *infile, struct Input *in)
 #endif
                     }
                     in->configOptionVector[CHUNK] = 1;
-                } /* if(!HDstrcmp("CHUNKED", key))  CHUNKED */
-            }     /* else if(!HDstrcmp("STORAGE_LAYOUT", key))  CHUNKED-DIMENSION-SIZES */
-            else if (!HDstrcmp("FILTERS", key)) { /* FILTERS */
+                } /* if(!strcmp("CHUNKED", key))  CHUNKED */
+            }     /* else if(!strcmp("STORAGE_LAYOUT", key))  CHUNKED-DIMENSION-SIZES */
+            else if (!strcmp("FILTERS", key)) { /* FILTERS */
 #ifdef H5DEBUGIMPORT
                 printf("h5dump FILTERS key\n");
 #endif
-                if (HDfscanf(strm, "%254s", temp) != 1) { /* start bracket */
+                if (fscanf(strm, "%254s", temp) != 1) { /* start bracket */
                     (void)fprintf(stderr, err6b, infile);
                     goto error;
                 }
 #ifdef H5DEBUGIMPORT
                 printf("h5dump FILTERS %s found\n", temp);
 #endif
-                if (HDfscanf(strm, "%254s", temp) != 1) {
+                if (fscanf(strm, "%254s", temp) != 1) {
                     (void)fprintf(stderr, err6b, infile);
                     goto error;
                 }
 #ifdef H5DEBUGIMPORT
                 printf("h5dump FILTERS %s found\n", temp);
 #endif
-                if (!HDstrcmp("COMPRESSION", temp)) { /* COMPRESSION */
+                if (!strcmp("COMPRESSION", temp)) { /* COMPRESSION */
 #ifdef H5DEBUGIMPORT
                     printf("h5dump FILTERS COMPRESSION found\n");
 #endif
-                    if (HDfscanf(strm, "%254s", temp) != 1) { /* DEFLATE */
+                    if (fscanf(strm, "%254s", temp) != 1) { /* DEFLATE */
                         (void)fprintf(stderr, "%s", err18);
                         goto error;
                     }
 #ifdef H5DEBUGIMPORT
                     printf("h5dump FILTERS COMPRESSION %s found\n", temp);
 #endif
-                    if (HDfscanf(strm, "%254s", temp) != 1) { /* bgin bracket */
+                    if (fscanf(strm, "%254s", temp) != 1) { /* bgin bracket */
                         (void)fprintf(stderr, "%s", err18);
                         goto error;
                     }
 #ifdef H5DEBUGIMPORT
                     printf("h5dump FILTERS COMPRESSION %s found\n", temp);
 #endif
-                    if (HDfscanf(strm, "%254s", temp) != 1) { /* LEVEL */
+                    if (fscanf(strm, "%254s", temp) != 1) { /* LEVEL */
                         (void)fprintf(stderr, "%s", err18);
                         goto error;
                     }
 #ifdef H5DEBUGIMPORT
                     printf("h5dump FILTERS COMPRESSION %s found\n", temp);
 #endif
-                    if (HDfscanf(strm, "%d", (&ival)) != 1) {
+                    if (fscanf(strm, "%d", (&ival)) != 1) {
                         (void)fprintf(stderr, "%s", err19);
                         goto error;
                     }
@@ -1951,7 +1951,7 @@ processConfigurationFile(char *infile, struct Input *in)
                     printf("h5dump FILTERS COMPRESSION LEVEL %d found\n", ival);
 #endif
                     in->compressionParam = ival;
-                    if (HDfscanf(strm, "%254s", temp) != 1) { /* end bracket */
+                    if (fscanf(strm, "%254s", temp) != 1) { /* end bracket */
                         (void)fprintf(stderr, "%s", err18);
                         goto error;
                     }
@@ -1961,19 +1961,19 @@ processConfigurationFile(char *infile, struct Input *in)
                     in->compressionType              = 0; /* ONLY GZIP supported */
                     in->configOptionVector[COMPRESS] = 1;
                 }
-                else if (!HDstrcmp("CONTIGUOUS", temp)) { /* CONTIGUOUS */
+                else if (!strcmp("CONTIGUOUS", temp)) { /* CONTIGUOUS */
 #ifdef H5DEBUGIMPORT
                     printf("h5dump FILTERS CONTIGUOUS found\n");
 #endif
                     in->configOptionVector[COMPRESS] = 0;
                 }
-                else if (!HDstrcmp("NONE", temp)) { /* NONE */
+                else if (!strcmp("NONE", temp)) { /* NONE */
 #ifdef H5DEBUGIMPORT
                     printf("h5dump FILTERS NONE found\n");
 #endif
                     in->configOptionVector[COMPRESS] = 0;
                 }
-                if (HDfscanf(strm, "%254s", temp) != 1) { /* end bracket */
+                if (fscanf(strm, "%254s", temp) != 1) { /* end bracket */
                     (void)fprintf(stderr, "%s", err18);
                     goto error;
                 }
@@ -1981,20 +1981,20 @@ processConfigurationFile(char *infile, struct Input *in)
                 printf("h5dump FILTERS %s found\n", temp);
 #endif
             }
-            else if (!HDstrcmp("SUBSET", key)) { /* reduce dimensions */
+            else if (!strcmp("SUBSET", key)) { /* reduce dimensions */
                 hsize_t temp_dims[MAX_NUM_DIMENSION];
                 int     get_next_prop = 1;
 #ifdef H5DEBUGIMPORT
                 printf("h5dump SUBSET key\n");
 #endif
-                if (HDfscanf(strm, "%254s", temp) != 1) { /* start bracket */
+                if (fscanf(strm, "%254s", temp) != 1) { /* start bracket */
                     (void)fprintf(stderr, err20, infile);
                     goto error;
                 }
 #ifdef H5DEBUGIMPORT
                 printf("h5dump SUBSET %s found\n", temp);
 #endif
-                if (HDfscanf(strm, "%254s", temp) != 1) { /* SUBSET keyword */
+                if (fscanf(strm, "%254s", temp) != 1) { /* SUBSET keyword */
                     (void)fprintf(stderr, "%s", err18);
                     goto error;
                 }
@@ -2002,20 +2002,20 @@ processConfigurationFile(char *infile, struct Input *in)
                 printf("h5dump SUBSET %s found\n", temp);
 #endif
                 while (get_next_prop) {
-                    if (!HDstrcmp("COUNT", temp)) { /* COUNT */
+                    if (!strcmp("COUNT", temp)) { /* COUNT */
                         int icount = 0;
-                        if (HDfscanf(strm, "%254s", temp) != 1) { /* start paren */
+                        if (fscanf(strm, "%254s", temp) != 1) { /* start paren */
                             (void)fprintf(stderr, err6b, infile);
                             goto error;
                         }
 #ifdef H5DEBUGIMPORT
                         printf("h5dump SUBSET %s found\n", temp);
 #endif
-                        if (!HDstrcmp("(", temp)) { /* start paren */
+                        if (!strcmp("(", temp)) { /* start paren */
                             int get_next_dim = 1;
                             int i            = 0;
 
-                            if (HDfscanf(strm, "%254s", temp) != 1) { /* Dimension with optional comma */
+                            if (fscanf(strm, "%254s", temp) != 1) { /* Dimension with optional comma */
                                 (void)fprintf(stderr, err16c, infile);
                                 goto error;
                             }
@@ -2025,14 +2025,14 @@ processConfigurationFile(char *infile, struct Input *in)
                             while (get_next_dim) {
                                 char *more        = temp;
                                 temp_dims[icount] = strtoull(more, &more, 10);
-                                if (HDfscanf(strm, "%254s", temp) != 1) { /* Dimension or end paren */
+                                if (fscanf(strm, "%254s", temp) != 1) { /* Dimension or end paren */
                                     (void)fprintf(stderr, err6b, infile);
                                     goto error;
                                 }
 #ifdef H5DEBUGIMPORT
                                 printf("h5dump SUBSET COUNT %s found\n", temp);
 #endif
-                                if (!HDstrcmp(");", temp)) { /* end paren */
+                                if (!strcmp(");", temp)) { /* end paren */
                                     in->rank                     = ++icount;
                                     in->configOptionVector[RANK] = 1;
                                     get_next_dim                 = 0;
@@ -2056,22 +2056,22 @@ processConfigurationFile(char *infile, struct Input *in)
                             printf("\n");
 #endif
                             in->configOptionVector[DIM] = 1;
-                        }                           /* if(!HDstrcmp("(", key))  start paren */
-                    }                               /* if(!HDstrcmp("COUNT", temp))  COUNT */
-                    if (!HDstrcmp("BLOCK", temp)) { /* BLOCK */
+                        }                         /* if(!strcmp("(", key))  start paren */
+                    }                             /* if(!strcmp("COUNT", temp))  COUNT */
+                    if (!strcmp("BLOCK", temp)) { /* BLOCK */
                         int icount = 0;
-                        if (HDfscanf(strm, "%254s", temp) != 1) { /* start paren */
+                        if (fscanf(strm, "%254s", temp) != 1) { /* start paren */
                             (void)fprintf(stderr, err6b, infile);
                             goto error;
                         }
 #ifdef H5DEBUGIMPORT
                         printf("h5dump SUBSET %s found\n", temp);
 #endif
-                        if (!HDstrcmp("(", temp)) { /* start paren */
+                        if (!strcmp("(", temp)) { /* start paren */
                             int get_next_dim = 1;
                             int i            = 0;
 
-                            if (HDfscanf(strm, "%254s", temp) != 1) { /* Dimension with optional comma */
+                            if (fscanf(strm, "%254s", temp) != 1) { /* Dimension with optional comma */
                                 (void)fprintf(stderr, err16c, infile);
                                 goto error;
                             }
@@ -2081,14 +2081,14 @@ processConfigurationFile(char *infile, struct Input *in)
                             while (get_next_dim) {
                                 char *more        = temp;
                                 temp_dims[icount] = strtoull(more, &more, 10);
-                                if (HDfscanf(strm, "%254s", temp) != 1) { /* Dimension or end paren */
+                                if (fscanf(strm, "%254s", temp) != 1) { /* Dimension or end paren */
                                     (void)fprintf(stderr, err6b, infile);
                                     goto error;
                                 }
 #ifdef H5DEBUGIMPORT
                                 printf("h5dump SUBSET BLOCK %s found\n", temp);
 #endif
-                                if (!HDstrcmp(");", temp)) { /* end paren */
+                                if (!strcmp(");", temp)) { /* end paren */
                                     in->rank                     = ++icount;
                                     in->configOptionVector[RANK] = 1;
                                     get_next_dim                 = 0;
@@ -2112,28 +2112,28 @@ processConfigurationFile(char *infile, struct Input *in)
                             printf("\n");
 #endif
                             in->configOptionVector[DIM] = 1;
-                        } /* if(!HDstrcmp("(", key))  start paren */
-                    }     /* if(!HDstrcmp("BLOCK", temp))  BLOCK */
-                    if (HDfscanf(strm, "%254s", temp) != 1) {
+                        } /* if(!strcmp("(", key))  start paren */
+                    }     /* if(!strcmp("BLOCK", temp))  BLOCK */
+                    if (fscanf(strm, "%254s", temp) != 1) {
                         (void)fprintf(stderr, "%s", err18);
                         goto error;
                     }
 #ifdef H5DEBUGIMPORT
                     printf("h5dump SUBSET %s found\n", temp);
 #endif
-                    if (!HDstrcmp("}", temp)) { /* end bracket */
+                    if (!strcmp("}", temp)) { /* end bracket */
                         get_next_prop = 0;
                     }
-                }                              /* while (get_next_prop) */
-            }                                  /* else if(!HDstrcmp("SUBSET", key)) */
-            else if (!HDstrcmp("DATA", key)) { /* FINISHED */
+                }                            /* while (get_next_prop) */
+            }                                /* else if(!strcmp("SUBSET", key)) */
+            else if (!strcmp("DATA", key)) { /* FINISHED */
 #ifdef H5DEBUGIMPORT
                 printf("h5dump DATA key\n");
 #endif
                 scanret = 0;
                 break;
             }
-            scanret = HDfscanf(strm, "%254s", key);
+            scanret = fscanf(strm, "%254s", key);
         }
 #ifdef H5DEBUGIMPORT
         printf("h5dump path");
@@ -2174,7 +2174,7 @@ processConfigurationFile(char *infile, struct Input *in)
                         (void)fprintf(stderr, err3a, infile);
                         goto error;
                     }
-                    if (HDfscanf(strm, "%254s", temp) != 1) {
+                    if (fscanf(strm, "%254s", temp) != 1) {
                         (void)fprintf(stderr, "%s", err18);
                         goto error;
                     }
@@ -2191,7 +2191,7 @@ processConfigurationFile(char *infile, struct Input *in)
                         goto error;
                     }
 
-                    if (HDfscanf(strm, "%254s", temp) != 1) {
+                    if (fscanf(strm, "%254s", temp) != 1) {
                         (void)fprintf(stderr, "%s", err18);
                         goto error;
                     }
@@ -2218,7 +2218,7 @@ processConfigurationFile(char *infile, struct Input *in)
                         (void)fprintf(stderr, err5a, infile);
                         goto error;
                     }
-                    if (HDfscanf(strm, "%254d", (&ival)) != 1) {
+                    if (fscanf(strm, "%254d", (&ival)) != 1) {
                         (void)fprintf(stderr, "%s", err19);
                         goto error;
                     }
@@ -2415,7 +2415,7 @@ processConfigurationFile(char *infile, struct Input *in)
                 default:
                     break;
             }
-            scanret = HDfscanf(strm, "%254s", key);
+            scanret = fscanf(strm, "%254s", key);
         }
 
         /*
@@ -2505,7 +2505,7 @@ mapKeywordToIndex(char *key)
     int i;
 
     for (i = 0; i < NUM_KEYS; i++)
-        if (!HDstrcmp(keytable[i], key))
+        if (!strcmp(keytable[i], key))
             return i;
     return -1;
 }
@@ -2518,22 +2518,22 @@ parsePathInfo(struct path_info *path, char *temp)
     int         i    = 0;
     const char *err1 = "Path string larger than MAX_PATH_NAME_LENGTH.\n";
 
-    token = HDstrtok(temp, delimiter);
-    if (HDstrlen(token) >= MAX_PATH_NAME_LENGTH) {
+    token = strtok(temp, delimiter);
+    if (strlen(token) >= MAX_PATH_NAME_LENGTH) {
         (void)fprintf(stderr, "%s", err1);
         return (-1);
     }
-    HDstrcpy(path->group[i++], token);
+    strcpy(path->group[i++], token);
 
     while (1) {
-        token = HDstrtok(NULL, delimiter);
+        token = strtok(NULL, delimiter);
         if (token == NULL)
             break;
-        if (HDstrlen(token) >= MAX_PATH_NAME_LENGTH) {
+        if (strlen(token) >= MAX_PATH_NAME_LENGTH) {
             (void)fprintf(stderr, "%s", err1);
             return (-1);
         }
-        HDstrcpy(path->group[i++], token);
+        strcpy(path->group[i++], token);
     }
     path->count = i;
     return (0);
@@ -2548,12 +2548,12 @@ parseDimensions(struct Input *in, char *strm)
     int         i    = 0;
     const char *err1 = "Unable to allocate dynamic memory.\n";
 
-    HDstrncpy(temp, strm, sizeof(temp));
+    strncpy(temp, strm, sizeof(temp));
     temp[sizeof(temp) - 1] = '\0';
-    HDstrtok(temp, delimiter);
+    strtok(temp, delimiter);
 
     while (1) {
-        token = HDstrtok(NULL, delimiter);
+        token = strtok(NULL, delimiter);
         if (token == NULL)
             break;
         i++;
@@ -2565,12 +2565,12 @@ parseDimensions(struct Input *in, char *strm)
     }
 
     i = 0;
-    HDstrncpy(temp, strm, sizeof(temp));
+    strncpy(temp, strm, sizeof(temp));
     temp[sizeof(temp) - 1]   = '\0';
-    in->sizeOfDimension[i++] = strtoull(HDstrtok(temp, delimiter), NULL, BASE_10);
+    in->sizeOfDimension[i++] = strtoull(strtok(temp, delimiter), NULL, BASE_10);
 
     while (1) {
-        token = HDstrtok(NULL, delimiter);
+        token = strtok(NULL, delimiter);
         if (token == NULL)
             break;
         in->sizeOfDimension[i++] = strtoull(token, NULL, BASE_10);
@@ -2586,7 +2586,7 @@ getOutputClass(struct Input *in, FILE *strm)
     const char *err1 = "Unable to get 'string' value.\n";
     const char *err2 = "Invalid value for output class.\n";
 
-    if (HDfscanf(strm, "%254s", temp) != 1) {
+    if (fscanf(strm, "%254s", temp) != 1) {
         (void)fprintf(stderr, "%s", err1);
         return (-1);
     }
@@ -2606,7 +2606,7 @@ OutputClassStrToInt(char *temp)
     int  i;
     char classKeywordTable[3][15] = {"IN", "FP", "UIN"};
     for (i = 0; i < 3; i++)
-        if (!HDstrcmp(classKeywordTable[i], temp))
+        if (!strcmp(classKeywordTable[i], temp))
             return i;
 
     return -1;
@@ -2621,7 +2621,7 @@ getOutputSize(struct Input *in, FILE *strm)
     const char *err1                     = "Unable to get integer value.\n";
     const char *err2                     = "Invalid value for output size.\n";
 
-    if (HDfscanf(strm, "%d", (&ival)) != 1) {
+    if (fscanf(strm, "%d", (&ival)) != 1) {
         (void)fprintf(stderr, "%s", err1);
         return (-1);
     }
@@ -2658,7 +2658,7 @@ getInputClassType(struct Input *in, char *buffer)
     const char *err2   = "Invalid value for output architecture.\n";
     const char *err3   = "Invalid value for input byte-order.\n";
 
-    if (!HDstrcmp(buffer, "H5T_STD_I8BE")) {
+    if (!strcmp(buffer, "H5T_STD_I8BE")) {
         in->inputSize                      = 8;
         in->configOptionVector[INPUT_SIZE] = 1;
 
@@ -2679,7 +2679,7 @@ getInputClassType(struct Input *in, char *buffer)
 
         kindex = 4;
     }
-    else if (!HDstrcmp(buffer, "H5T_STD_I8LE")) {
+    else if (!strcmp(buffer, "H5T_STD_I8LE")) {
         in->inputSize                      = 8;
         in->configOptionVector[INPUT_SIZE] = 1;
 
@@ -2700,7 +2700,7 @@ getInputClassType(struct Input *in, char *buffer)
 
         kindex = 4;
     }
-    else if (!HDstrcmp(buffer, "H5T_STD_I16BE")) {
+    else if (!strcmp(buffer, "H5T_STD_I16BE")) {
         in->inputSize                      = 16;
         in->configOptionVector[INPUT_SIZE] = 1;
 
@@ -2721,7 +2721,7 @@ getInputClassType(struct Input *in, char *buffer)
 
         kindex = 4;
     }
-    else if (!HDstrcmp(buffer, "H5T_STD_I16LE")) {
+    else if (!strcmp(buffer, "H5T_STD_I16LE")) {
         in->inputSize                      = 16;
         in->configOptionVector[INPUT_SIZE] = 1;
 
@@ -2742,7 +2742,7 @@ getInputClassType(struct Input *in, char *buffer)
 
         kindex = 4;
     }
-    else if (!HDstrcmp(buffer, "H5T_STD_I32BE")) {
+    else if (!strcmp(buffer, "H5T_STD_I32BE")) {
         in->inputSize                      = 32;
         in->configOptionVector[INPUT_SIZE] = 1;
 
@@ -2763,7 +2763,7 @@ getInputClassType(struct Input *in, char *buffer)
 
         kindex = 4;
     }
-    else if (!HDstrcmp(buffer, "H5T_STD_I32LE")) {
+    else if (!strcmp(buffer, "H5T_STD_I32LE")) {
         in->inputSize                      = 32;
         in->configOptionVector[INPUT_SIZE] = 1;
 
@@ -2784,7 +2784,7 @@ getInputClassType(struct Input *in, char *buffer)
 
         kindex = 4;
     }
-    else if (!HDstrcmp(buffer, "H5T_STD_I64BE")) {
+    else if (!strcmp(buffer, "H5T_STD_I64BE")) {
         in->inputSize                      = 64;
         in->configOptionVector[INPUT_SIZE] = 1;
 
@@ -2805,7 +2805,7 @@ getInputClassType(struct Input *in, char *buffer)
 
         kindex = 4;
     }
-    else if (!HDstrcmp(buffer, "H5T_STD_I64LE")) {
+    else if (!strcmp(buffer, "H5T_STD_I64LE")) {
         in->inputSize                      = 64;
         in->configOptionVector[INPUT_SIZE] = 1;
 
@@ -2826,7 +2826,7 @@ getInputClassType(struct Input *in, char *buffer)
 
         kindex = 4;
     }
-    else if (!HDstrcmp(buffer, "H5T_STD_U8BE")) {
+    else if (!strcmp(buffer, "H5T_STD_U8BE")) {
         in->inputSize                      = 8;
         in->configOptionVector[INPUT_SIZE] = 1;
 
@@ -2847,7 +2847,7 @@ getInputClassType(struct Input *in, char *buffer)
 
         kindex = 7;
     }
-    else if (!HDstrcmp(buffer, "H5T_STD_U8LE")) {
+    else if (!strcmp(buffer, "H5T_STD_U8LE")) {
         in->inputSize                      = 8;
         in->configOptionVector[INPUT_SIZE] = 1;
 
@@ -2868,7 +2868,7 @@ getInputClassType(struct Input *in, char *buffer)
 
         kindex = 7;
     }
-    else if (!HDstrcmp(buffer, "H5T_STD_U16BE")) {
+    else if (!strcmp(buffer, "H5T_STD_U16BE")) {
         in->inputSize                      = 16;
         in->configOptionVector[INPUT_SIZE] = 1;
 
@@ -2889,7 +2889,7 @@ getInputClassType(struct Input *in, char *buffer)
 
         kindex = 7;
     }
-    else if (!HDstrcmp(buffer, "H5T_STD_U16LE")) {
+    else if (!strcmp(buffer, "H5T_STD_U16LE")) {
         in->inputSize                      = 16;
         in->configOptionVector[INPUT_SIZE] = 1;
 
@@ -2910,7 +2910,7 @@ getInputClassType(struct Input *in, char *buffer)
 
         kindex = 7;
     }
-    else if (!HDstrcmp(buffer, "H5T_STD_U32BE")) {
+    else if (!strcmp(buffer, "H5T_STD_U32BE")) {
         in->inputSize                      = 32;
         in->configOptionVector[INPUT_SIZE] = 1;
 
@@ -2931,7 +2931,7 @@ getInputClassType(struct Input *in, char *buffer)
 
         kindex = 7;
     }
-    else if (!HDstrcmp(buffer, "H5T_STD_U32LE")) {
+    else if (!strcmp(buffer, "H5T_STD_U32LE")) {
         in->inputSize                      = 32;
         in->configOptionVector[INPUT_SIZE] = 1;
 
@@ -2952,7 +2952,7 @@ getInputClassType(struct Input *in, char *buffer)
 
         kindex = 7;
     }
-    else if (!HDstrcmp(buffer, "H5T_STD_U64BE")) {
+    else if (!strcmp(buffer, "H5T_STD_U64BE")) {
         in->inputSize                      = 64;
         in->configOptionVector[INPUT_SIZE] = 1;
 
@@ -2973,7 +2973,7 @@ getInputClassType(struct Input *in, char *buffer)
 
         kindex = 7;
     }
-    else if (!HDstrcmp(buffer, "H5T_STD_U64LE")) {
+    else if (!strcmp(buffer, "H5T_STD_U64LE")) {
         in->inputSize                      = 64;
         in->configOptionVector[INPUT_SIZE] = 1;
 
@@ -2994,7 +2994,7 @@ getInputClassType(struct Input *in, char *buffer)
 
         kindex = 7;
     }
-    else if (!HDstrcmp(buffer, "H5T_NATIVE_SCHAR")) {
+    else if (!strcmp(buffer, "H5T_NATIVE_SCHAR")) {
         in->inputSize                      = 8;
         in->configOptionVector[INPUT_SIZE] = 1;
 
@@ -3006,7 +3006,7 @@ getInputClassType(struct Input *in, char *buffer)
 
         kindex = 4;
     }
-    else if (!HDstrcmp(buffer, "H5T_NATIVE_UCHAR")) {
+    else if (!strcmp(buffer, "H5T_NATIVE_UCHAR")) {
         in->inputSize                      = 8;
         in->configOptionVector[INPUT_SIZE] = 1;
 
@@ -3018,7 +3018,7 @@ getInputClassType(struct Input *in, char *buffer)
 
         kindex = 7;
     }
-    else if (!HDstrcmp(buffer, "H5T_NATIVE_SHORT")) {
+    else if (!strcmp(buffer, "H5T_NATIVE_SHORT")) {
         in->inputSize                      = 16;
         in->configOptionVector[INPUT_SIZE] = 1;
 
@@ -3030,7 +3030,7 @@ getInputClassType(struct Input *in, char *buffer)
 
         kindex = 4;
     }
-    else if (!HDstrcmp(buffer, "H5T_NATIVE_USHORT")) {
+    else if (!strcmp(buffer, "H5T_NATIVE_USHORT")) {
         in->inputSize                      = 16;
         in->configOptionVector[INPUT_SIZE] = 1;
 
@@ -3042,7 +3042,7 @@ getInputClassType(struct Input *in, char *buffer)
 
         kindex = 7;
     }
-    else if (!HDstrcmp(buffer, "H5T_NATIVE_INT")) {
+    else if (!strcmp(buffer, "H5T_NATIVE_INT")) {
         in->inputSize                      = 32;
         in->configOptionVector[INPUT_SIZE] = 1;
 
@@ -3054,7 +3054,7 @@ getInputClassType(struct Input *in, char *buffer)
 
         kindex = 4;
     }
-    else if (!HDstrcmp(buffer, "H5T_NATIVE_UINT")) {
+    else if (!strcmp(buffer, "H5T_NATIVE_UINT")) {
         in->inputSize                      = 32;
         in->configOptionVector[INPUT_SIZE] = 1;
 
@@ -3066,7 +3066,7 @@ getInputClassType(struct Input *in, char *buffer)
 
         kindex = 7;
     }
-    else if (!HDstrcmp(buffer, "H5T_NATIVE_LONG")) {
+    else if (!strcmp(buffer, "H5T_NATIVE_LONG")) {
         in->inputSize                      = 32;
         in->configOptionVector[INPUT_SIZE] = 1;
 
@@ -3078,7 +3078,7 @@ getInputClassType(struct Input *in, char *buffer)
 
         kindex = 4;
     }
-    else if (!HDstrcmp(buffer, "H5T_NATIVE_ULONG")) {
+    else if (!strcmp(buffer, "H5T_NATIVE_ULONG")) {
         in->inputSize                      = 32;
         in->configOptionVector[INPUT_SIZE] = 1;
 
@@ -3090,7 +3090,7 @@ getInputClassType(struct Input *in, char *buffer)
 
         kindex = 7;
     }
-    else if (!HDstrcmp(buffer, "H5T_NATIVE_LLONG")) {
+    else if (!strcmp(buffer, "H5T_NATIVE_LLONG")) {
         in->inputSize                      = 64;
         in->configOptionVector[INPUT_SIZE] = 1;
 
@@ -3102,7 +3102,7 @@ getInputClassType(struct Input *in, char *buffer)
 
         kindex = 4;
     }
-    else if (!HDstrcmp(buffer, "H5T_NATIVE_ULLONG")) {
+    else if (!strcmp(buffer, "H5T_NATIVE_ULLONG")) {
         in->inputSize                      = 64;
         in->configOptionVector[INPUT_SIZE] = 1;
 
@@ -3114,7 +3114,7 @@ getInputClassType(struct Input *in, char *buffer)
 
         kindex = 7;
     }
-    else if (!HDstrcmp(buffer, "H5T_IEEE_F32BE")) {
+    else if (!strcmp(buffer, "H5T_IEEE_F32BE")) {
         in->inputSize                      = 32;
         in->configOptionVector[INPUT_SIZE] = 1;
 
@@ -3135,7 +3135,7 @@ getInputClassType(struct Input *in, char *buffer)
 
         kindex = 3;
     }
-    else if (!HDstrcmp(buffer, "H5T_IEEE_F32LE")) {
+    else if (!strcmp(buffer, "H5T_IEEE_F32LE")) {
         in->inputSize                      = 32;
         in->configOptionVector[INPUT_SIZE] = 1;
 
@@ -3156,7 +3156,7 @@ getInputClassType(struct Input *in, char *buffer)
 
         kindex = 3;
     }
-    else if (!HDstrcmp(buffer, "H5T_IEEE_F64BE")) {
+    else if (!strcmp(buffer, "H5T_IEEE_F64BE")) {
         in->inputSize                      = 64;
         in->configOptionVector[INPUT_SIZE] = 1;
 
@@ -3177,7 +3177,7 @@ getInputClassType(struct Input *in, char *buffer)
 
         kindex = 3;
     }
-    else if (!HDstrcmp(buffer, "H5T_IEEE_F64LE")) {
+    else if (!strcmp(buffer, "H5T_IEEE_F64LE")) {
         in->inputSize                      = 64;
         in->configOptionVector[INPUT_SIZE] = 1;
 
@@ -3198,19 +3198,19 @@ getInputClassType(struct Input *in, char *buffer)
 
         kindex = 3;
     }
-    else if (!HDstrcmp(buffer, "H5T_VAX_F32")) {
+    else if (!strcmp(buffer, "H5T_VAX_F32")) {
         in->inputSize                      = 32;
         in->configOptionVector[INPUT_SIZE] = 1;
 
         kindex = 3;
     }
-    else if (!HDstrcmp(buffer, "H5T_VAX_F64")) {
+    else if (!strcmp(buffer, "H5T_VAX_F64")) {
         in->inputSize                      = 64;
         in->configOptionVector[INPUT_SIZE] = 1;
 
         kindex = 3;
     }
-    else if (!HDstrcmp(buffer, "H5T_NATIVE_FLOAT")) {
+    else if (!strcmp(buffer, "H5T_NATIVE_FLOAT")) {
         in->inputSize                      = 32;
         in->configOptionVector[INPUT_SIZE] = 1;
 
@@ -3222,7 +3222,7 @@ getInputClassType(struct Input *in, char *buffer)
 
         kindex = 3;
     }
-    else if (!HDstrcmp(buffer, "H5T_NATIVE_DOUBLE")) {
+    else if (!strcmp(buffer, "H5T_NATIVE_DOUBLE")) {
         in->inputSize                      = 64;
         in->configOptionVector[INPUT_SIZE] = 1;
 
@@ -3234,7 +3234,7 @@ getInputClassType(struct Input *in, char *buffer)
 
         kindex = 3;
     }
-    else if (!HDstrcmp(buffer, "H5T_NATIVE_LDOUBLE")) {
+    else if (!strcmp(buffer, "H5T_NATIVE_LDOUBLE")) {
         in->inputSize                      = H5_SIZEOF_LONG_DOUBLE;
         in->configOptionVector[INPUT_SIZE] = 1;
 
@@ -3246,14 +3246,14 @@ getInputClassType(struct Input *in, char *buffer)
 
         kindex = 3;
     }
-    else if (!HDstrcmp(buffer, "H5T_TIME: not yet implemented")) {
+    else if (!strcmp(buffer, "H5T_TIME: not yet implemented")) {
         kindex = -1;
     }
-    else if (!HDstrcmp(buffer, "H5T_STRING")) {
+    else if (!strcmp(buffer, "H5T_STRING")) {
         kindex = 5;
     }
     /*    case H5T_BITFIELD: */
-    else if (!HDstrcmp(buffer, "H5T_STD_B8BE")) {
+    else if (!strcmp(buffer, "H5T_STD_B8BE")) {
 
         if ((kindex = OutputArchStrToInt("STD")) == -1) {
             (void)fprintf(stderr, "%s", err2);
@@ -3272,7 +3272,7 @@ getInputClassType(struct Input *in, char *buffer)
 
         kindex = -1;
     }
-    else if (!HDstrcmp(buffer, "H5T_STD_B8LE")) {
+    else if (!strcmp(buffer, "H5T_STD_B8LE")) {
 
         if ((kindex = OutputArchStrToInt("STD")) == -1) {
             (void)fprintf(stderr, "%s", err2);
@@ -3291,7 +3291,7 @@ getInputClassType(struct Input *in, char *buffer)
 
         kindex = -1;
     }
-    else if (!HDstrcmp(buffer, "H5T_STD_B16BE")) {
+    else if (!strcmp(buffer, "H5T_STD_B16BE")) {
 
         if ((kindex = OutputArchStrToInt("STD")) == -1) {
             (void)fprintf(stderr, "%s", err2);
@@ -3310,7 +3310,7 @@ getInputClassType(struct Input *in, char *buffer)
 
         kindex = -1;
     }
-    else if (!HDstrcmp(buffer, "H5T_STD_B16LE")) {
+    else if (!strcmp(buffer, "H5T_STD_B16LE")) {
 
         if ((kindex = OutputArchStrToInt("STD")) == -1) {
             (void)fprintf(stderr, "%s", err2);
@@ -3329,7 +3329,7 @@ getInputClassType(struct Input *in, char *buffer)
 
         kindex = -1;
     }
-    else if (!HDstrcmp(buffer, "H5T_STD_B32BE")) {
+    else if (!strcmp(buffer, "H5T_STD_B32BE")) {
 
         if ((kindex = OutputArchStrToInt("STD")) == -1) {
             (void)fprintf(stderr, "%s", err2);
@@ -3348,7 +3348,7 @@ getInputClassType(struct Input *in, char *buffer)
 
         kindex = -1;
     }
-    else if (!HDstrcmp(buffer, "H5T_STD_B32LE")) {
+    else if (!strcmp(buffer, "H5T_STD_B32LE")) {
 
         if ((kindex = OutputArchStrToInt("STD")) == -1) {
             (void)fprintf(stderr, "%s", err2);
@@ -3367,7 +3367,7 @@ getInputClassType(struct Input *in, char *buffer)
 
         kindex = -1;
     }
-    else if (!HDstrcmp(buffer, "H5T_STD_B64BE")) {
+    else if (!strcmp(buffer, "H5T_STD_B64BE")) {
 
         if ((kindex = OutputArchStrToInt("STD")) == -1) {
             (void)fprintf(stderr, "%s", err2);
@@ -3386,7 +3386,7 @@ getInputClassType(struct Input *in, char *buffer)
 
         kindex = -1;
     }
-    else if (!HDstrcmp(buffer, "H5T_STD_B64LE")) {
+    else if (!strcmp(buffer, "H5T_STD_B64LE")) {
 
         if ((kindex = OutputArchStrToInt("STD")) == -1) {
             (void)fprintf(stderr, "%s", err2);
@@ -3406,27 +3406,27 @@ getInputClassType(struct Input *in, char *buffer)
         kindex = -1;
     }
     /*    case H5T_OPAQUE: */
-    else if (!HDstrcmp(buffer, "H5T_OPAQUE")) {
+    else if (!strcmp(buffer, "H5T_OPAQUE")) {
         kindex = -1;
     }
     /*    case H5T_COMPOUND: */
-    else if (!HDstrcmp(buffer, "H5T_COMPOUND")) {
+    else if (!strcmp(buffer, "H5T_COMPOUND")) {
         kindex = -1;
     }
     /*    case H5T_REFERENCE: */
-    else if (!HDstrcmp(buffer, "H5T_REFERENCE")) {
+    else if (!strcmp(buffer, "H5T_REFERENCE")) {
         kindex = -1;
     }
     /*    case H5T_ENUM: */
-    else if (!HDstrcmp(buffer, "H5T_ENUM")) {
+    else if (!strcmp(buffer, "H5T_ENUM")) {
         kindex = -1;
     }
     /*    case H5T_VLEN: */
-    else if (!HDstrcmp(buffer, "H5T_VLEN")) {
+    else if (!strcmp(buffer, "H5T_VLEN")) {
         kindex = -1;
     }
     /*    case H5T_ARRAY: */
-    else if (!HDstrcmp(buffer, "H5T_ARRAY")) {
+    else if (!strcmp(buffer, "H5T_ARRAY")) {
         kindex = -1;
     }
 
@@ -3454,7 +3454,7 @@ InputClassStrToInt(char *temp)
     int  i;
     char classKeywordTable[8][15] = {"TEXTIN", "TEXTFP", "TEXTFPE", "FP", "IN", "STR", "TEXTUIN", "UIN"};
     for (i = 0; i < 8; i++)
-        if (!HDstrcmp(classKeywordTable[i], temp))
+        if (!strcmp(classKeywordTable[i], temp))
             return i;
     return -1;
 }
@@ -3484,7 +3484,7 @@ getInputByteOrder(struct Input *in, FILE *strm)
     const char *err1 = "Unable to get 'string' value.\n";
     const char *err2 = "Invalid value for input byte-order.\n";
 
-    if (HDfscanf(strm, "%254s", temp) != 1) {
+    if (fscanf(strm, "%254s", temp) != 1) {
         (void)fprintf(stderr, "%s", err1);
         return (-1);
     }
@@ -3506,7 +3506,7 @@ getRank(struct Input *in, FILE *strm)
     const char *err1 = "Unable to get integer value.\n";
     const char *err2 = "Invalid value for rank.\n";
 
-    if (HDfscanf(strm, "%d", (&ival)) != 1) {
+    if (fscanf(strm, "%d", (&ival)) != 1) {
         (void)fprintf(stderr, "%s", err1);
         return (-1);
     }
@@ -3535,7 +3535,7 @@ getDimensionSizes(struct Input *in, FILE *strm)
         return (-1);
     }
 
-    while (HDfscanf(strm, "%llu", (&ullval)) == 1)
+    while (fscanf(strm, "%llu", (&ullval)) == 1)
         in->sizeOfDimension[i++] = ullval;
 
     if (in->rank != i) {
@@ -3561,7 +3561,7 @@ getChunkedDimensionSizes(struct Input *in, FILE *strm)
         return (-1);
     }
 
-    while (HDfscanf(strm, "%llu", (&ullval)) == 1)
+    while (fscanf(strm, "%llu", (&ullval)) == 1)
         in->sizeOfChunk[i++] = ullval;
 
     if (in->rank != i) {
@@ -3594,7 +3594,7 @@ getMaximumDimensionSizes(struct Input *in, FILE *strm)
         return (-1);
     }
 
-    while (HDfscanf(strm, "%lld", (&llval)) == 1) {
+    while (fscanf(strm, "%lld", (&llval)) == 1) {
         if (llval == -1)
             in->maxsizeOfDimension[i++] = H5S_UNLIMITED;
         else
@@ -3624,7 +3624,7 @@ getOutputArchitecture(struct Input *in, FILE *strm)
     const char *err1 = "Unable to get 'string' value.\n";
     const char *err2 = "Invalid value for output architecture.\n";
 
-    if (HDfscanf(strm, "%254s", temp) != 1) {
+    if (fscanf(strm, "%254s", temp) != 1) {
         (void)fprintf(stderr, "%s", err1);
         return (-1);
     }
@@ -3644,7 +3644,7 @@ OutputArchStrToInt(const char *temp)
     int  i;
     char outputArchKeywordTable[8][15] = {"NATIVE", "STD", "IEEE", "INTEL", "CRAY", "MIPS", "ALPHA", "UNIX"};
     for (i = 0; i < 8; i++)
-        if (!HDstrcmp(outputArchKeywordTable[i], temp))
+        if (!strcmp(outputArchKeywordTable[i], temp))
             return i;
     return -1;
 }
@@ -3657,7 +3657,7 @@ getOutputByteOrder(struct Input *in, FILE *strm)
     const char *err1 = "Unable to get 'string' value.\n";
     const char *err2 = "Invalid value for output byte-order.\n";
 
-    if (HDfscanf(strm, "%254s", temp) != 1) {
+    if (fscanf(strm, "%254s", temp) != 1) {
         (void)fprintf(stderr, "%s", err1);
         return (-1);
     }
@@ -3677,7 +3677,7 @@ OutputByteOrderStrToInt(const char *temp)
     int  i;
     char outputByteOrderKeywordTable[2][15] = {"BE", "LE"};
     for (i = 0; i < 2; i++)
-        if (!HDstrcmp(outputByteOrderKeywordTable[i], temp))
+        if (!strcmp(outputByteOrderKeywordTable[i], temp))
             return i;
     return -1;
 }
@@ -3690,7 +3690,7 @@ getCompressionType(struct Input *in, FILE *strm)
     const char *err1 = "Unable to get 'string' value.\n";
     const char *err2 = "Invalid value for compression.\n";
 
-    if (HDfscanf(strm, "%254s", temp) != 1) {
+    if (fscanf(strm, "%254s", temp) != 1) {
         (void)fprintf(stderr, "%s", err1);
         return (-1);
     }
@@ -3713,7 +3713,7 @@ CompressionTypeStrToInt(char *temp)
     int  i;
     char CompressionTypeKeywordTable[1][15] = {"GZIP"};
     for (i = 0; i < 1; i++)
-        if (!HDstrcmp(CompressionTypeKeywordTable[i], temp))
+        if (!strcmp(CompressionTypeKeywordTable[i], temp))
             return i;
     return -1;
 }
@@ -3732,7 +3732,7 @@ getCompressionParameter(struct Input *in, FILE *strm)
 
     switch (in->compressionType) {
         case 0: /* GZIP */
-            if (HDfscanf(strm, "%d", (&ival)) != 1) {
+            if (fscanf(strm, "%d", (&ival)) != 1) {
                 (void)fprintf(stderr, "%s", err1);
                 return (-1);
             }
@@ -3757,14 +3757,14 @@ getExternalFilename(struct Input *in, FILE *strm)
     char        temp[255];
     const char *err1 = "Unable to get 'string' value.\n";
 
-    if (HDfscanf(strm, "%254s", temp) != 1) {
+    if (fscanf(strm, "%254s", temp) != 1) {
         (void)fprintf(stderr, "%s", err1);
         return (-1);
     }
 
-    temp_len           = HDstrlen(temp);
+    temp_len           = strlen(temp);
     in->externFilename = (char *)malloc((temp_len + 1) * sizeof(char));
-    (void)HDstrcpy(in->externFilename, temp);
+    (void)strcpy(in->externFilename, temp);
     in->externFilename[temp_len] = '\0';
     return (0);
 }
@@ -3785,10 +3785,10 @@ setDefaultValues(struct Input *in, int count)
     in->rank           = 0;
     in->path.count     = 1;
 
-    HDstrcpy(temp, "dataset");
-    HDsnprintf(num, sizeof(num), "%d", count);
-    HDstrcat(temp, num);
-    HDstrcpy(in->path.group[0], temp);
+    strcpy(temp, "dataset");
+    snprintf(num, sizeof(num), "%d", count);
+    strcat(temp, num);
+    strcpy(in->path.group[0], temp);
 
     in->outputArchitecture = 0;  /* NATIVE */
     in->outputByteOrder    = -1; /* use default    */

--- a/tools/src/h5jam/h5jam.c
+++ b/tools/src/h5jam/h5jam.c
@@ -111,13 +111,13 @@ parse_command_line(int argc, const char *const *argv)
     while ((opt = H5_get_option(argc, argv, s_opts, l_opts)) != EOF) {
         switch ((char)opt) {
             case 'o':
-                output_file = HDstrdup(H5_optarg);
+                output_file = strdup(H5_optarg);
                 break;
             case 'i':
-                input_file = HDstrdup(H5_optarg);
+                input_file = strdup(H5_optarg);
                 break;
             case 'u':
-                ub_file = HDstrdup(H5_optarg);
+                ub_file = strdup(H5_optarg);
                 break;
             case 'c':
                 do_clobber = true;

--- a/tools/src/h5jam/h5unjam.c
+++ b/tools/src/h5jam/h5unjam.c
@@ -98,19 +98,19 @@ parse_command_line(int argc, const char *const *argv)
     while ((opt = H5_get_option(argc, argv, s_opts, l_opts)) != EOF) {
         switch ((char)opt) {
             case 'o':
-                output_file = HDstrdup(H5_optarg);
+                output_file = strdup(H5_optarg);
                 if (output_file)
                     h5tools_set_data_output_file(output_file, 1);
                 break;
 
             case 'i':
-                input_file = HDstrdup(H5_optarg);
+                input_file = strdup(H5_optarg);
                 if (input_file)
                     h5tools_set_input_file(input_file, 1);
                 break;
 
             case 'u':
-                ub_file = HDstrdup(H5_optarg);
+                ub_file = strdup(H5_optarg);
                 if (ub_file)
                     h5tools_set_output_file(ub_file, 1);
                 else

--- a/tools/src/h5ls/h5ls.c
+++ b/tools/src/h5ls/h5ls.c
@@ -361,7 +361,7 @@ print_obj_name(h5tools_str_t *buffer, const iter_t *iter, const char *oname, con
     int         n;
 
     if (show_file_name_g)
-        HDsnprintf(fullname, sizeof(fullname), "%s/%s", iter->fname, oname + iter->name_start);
+        snprintf(fullname, sizeof(fullname), "%s/%s", iter->fname, oname + iter->name_start);
     else
         name = oname + iter->name_start;
 
@@ -372,7 +372,7 @@ print_obj_name(h5tools_str_t *buffer, const iter_t *iter, const char *oname, con
         const char *last_sep; /* The location of the last group separator */
 
         /* Find the last component of the path name */
-        if (NULL == (last_sep = HDstrrchr(name, '/')))
+        if (NULL == (last_sep = strrchr(name, '/')))
             last_sep = name;
         else {
             last_sep++;
@@ -1381,9 +1381,9 @@ dump_dataset_values(hid_t dset)
     }
     outputformat.arr_linebreak = 0;
     /* Floating point types should display full precision */
-    HDsnprintf(fmt_float, sizeof(fmt_float), "%%1.%dg", FLT_DIG);
+    snprintf(fmt_float, sizeof(fmt_float), "%%1.%dg", FLT_DIG);
     outputformat.fmt_float = fmt_float;
-    HDsnprintf(fmt_double, sizeof(fmt_double), "%%1.%dg", DBL_DIG);
+    snprintf(fmt_double, sizeof(fmt_double), "%%1.%dg", DBL_DIG);
     outputformat.fmt_double = fmt_double;
 
     if (hexdump_g) {
@@ -1397,7 +1397,7 @@ dump_dataset_values(hid_t dset)
         outputformat.ascii     = true;
         outputformat.elmt_suf1 = "";
         outputformat.elmt_suf2 = "";
-        HDsnprintf(string_prefix, sizeof(string_prefix), "%s\"", outputformat.line_pre);
+        snprintf(string_prefix, sizeof(string_prefix), "%s\"", outputformat.line_pre);
         outputformat.line_pre = string_prefix;
         outputformat.line_suf = "\"";
     }
@@ -1550,9 +1550,9 @@ dump_attribute_values(hid_t attr)
     }
     outputformat.arr_linebreak = 0;
     /* Floating point types should display full precision */
-    HDsnprintf(fmt_float, sizeof(fmt_float), "%%1.%dg", FLT_DIG);
+    snprintf(fmt_float, sizeof(fmt_float), "%%1.%dg", FLT_DIG);
     outputformat.fmt_float = fmt_float;
-    HDsnprintf(fmt_double, sizeof(fmt_double), "%%1.%dg", DBL_DIG);
+    snprintf(fmt_double, sizeof(fmt_double), "%%1.%dg", DBL_DIG);
     outputformat.fmt_double = fmt_double;
 
     if (hexdump_g) {
@@ -1566,7 +1566,7 @@ dump_attribute_values(hid_t attr)
         outputformat.ascii     = true;
         outputformat.elmt_suf1 = "";
         outputformat.elmt_suf2 = "";
-        HDsnprintf(string_prefix, sizeof(string_prefix), "%s\"", outputformat.line_pre);
+        snprintf(string_prefix, sizeof(string_prefix), "%s\"", outputformat.line_pre);
         outputformat.line_pre = string_prefix;
         outputformat.line_suf = "\"";
     }
@@ -1995,7 +1995,7 @@ dataset_list2(hid_t dset, const char H5_ATTR_UNUSED *name)
                 filt_id   = H5Pget_filter2(dcpl, (unsigned)i, &filt_flags, &cd_nelmts, cd_values,
                                            sizeof(f_name), f_name, NULL);
                 f_name[sizeof(f_name) - 1] = '\0';
-                HDsnprintf(s, sizeof(s), "Filter-%d:", i);
+                snprintf(s, sizeof(s), "Filter-%d:", i);
                 h5tools_str_append(&buffer, "    %-10s %s-%u %s {", s, (f_name[0] ? f_name : "method"),
                                    (unsigned)filt_id, ((filt_flags & H5Z_FLAG_OPTIONAL) ? "OPT" : ""));
                 for (cd_num = 0; cd_num < cd_nelmts; cd_num++)
@@ -2182,7 +2182,7 @@ list_obj(const char *name, const H5O_info2_t *oinfo, const char *first_seen, voi
                 else
                     tm = HDlocaltime(&(oinfo->mtime));
                 if (tm) {
-                    HDstrftime(buf, sizeof(buf), "%Y-%m-%d %H:%M:%S %Z", tm);
+                    strftime(buf, sizeof(buf), "%Y-%m-%d %H:%M:%S %Z", tm);
                     h5tools_str_reset(&buffer);
                     h5tools_str_append(&buffer, "    %-10s %s\n", "Modified:", buf);
                     h5tools_render_element(rawoutstream, info, &ctx, &buffer, &curr_pos,
@@ -2700,88 +2700,88 @@ main(int argc, char *argv[])
 
     /* Switches come before non-switch arguments */
     for (argno = 1; argno < argc && '-' == argv[argno][0]; argno++) {
-        if (!HDstrcmp(argv[argno], "--")) {
+        if (!strcmp(argv[argno], "--")) {
             /* Last switch */
             argno++;
             break;
         }
-        else if (!HDstrcmp(argv[argno], "--help")) {
+        else if (!strcmp(argv[argno], "--help")) {
             usage();
             leave(EXIT_SUCCESS);
         }
-        else if (!HDstrcmp(argv[argno], "--address")) {
+        else if (!strcmp(argv[argno], "--address")) {
             address_g = true;
         }
-        else if (!HDstrcmp(argv[argno], "--data")) {
+        else if (!strcmp(argv[argno], "--data")) {
             data_g = true;
         }
-        else if (!HDstrcmp(argv[argno], "--enable-error-stack")) {
+        else if (!strcmp(argv[argno], "--enable-error-stack")) {
             enable_error_stack = 1;
         }
-        else if (!HDstrcmp(argv[argno], "--errors")) {
+        else if (!strcmp(argv[argno], "--errors")) {
             /* deprecated --errors */
             enable_error_stack = 1;
         }
-        else if (!HDstrcmp(argv[argno], "--follow-symlinks")) {
+        else if (!strcmp(argv[argno], "--follow-symlinks")) {
             follow_symlink_g = true;
         }
-        else if (!HDstrcmp(argv[argno], "--no-dangling-links")) {
+        else if (!strcmp(argv[argno], "--no-dangling-links")) {
             no_dangling_link_g = true;
         }
-        else if (!HDstrcmp(argv[argno], "--external")) {
+        else if (!strcmp(argv[argno], "--external")) {
             follow_elink_g = true;
         }
-        else if (!HDstrcmp(argv[argno], "--full")) {
+        else if (!strcmp(argv[argno], "--full")) {
             fullname_g = true;
         }
-        else if (!HDstrcmp(argv[argno], "--group")) {
+        else if (!strcmp(argv[argno], "--group")) {
             grp_literal_g = true;
         }
-        else if (!HDstrcmp(argv[argno], "--label")) {
+        else if (!strcmp(argv[argno], "--label")) {
             label_g = true;
         }
-        else if (!HDstrcmp(argv[argno], "--recursive")) {
+        else if (!strcmp(argv[argno], "--recursive")) {
             recursive_g = true;
             fullname_g  = true;
         }
-        else if (!HDstrcmp(argv[argno], "--simple")) {
+        else if (!strcmp(argv[argno], "--simple")) {
             simple_output_g = true;
         }
-        else if (!HDstrcmp(argv[argno], "--string")) {
+        else if (!strcmp(argv[argno], "--string")) {
             string_g = true;
         }
-        else if (!HDstrncmp(argv[argno], "--vol-value=", (size_t)12)) {
+        else if (!strncmp(argv[argno], "--vol-value=", (size_t)12)) {
             vol_info.type    = VOL_BY_VALUE;
             vol_info.u.value = (H5VL_class_value_t)atoi(argv[argno] + 12);
             custom_vol_fapl  = true;
         }
-        else if (!HDstrncmp(argv[argno], "--vol-name=", (size_t)11)) {
+        else if (!strncmp(argv[argno], "--vol-name=", (size_t)11)) {
             vol_info.type   = VOL_BY_NAME;
             vol_info.u.name = argv[argno] + 11;
             custom_vol_fapl = true;
         }
-        else if (!HDstrncmp(argv[argno], "--vol-info=", (size_t)11)) {
+        else if (!strncmp(argv[argno], "--vol-info=", (size_t)11)) {
             vol_info.info_string = argv[argno] + 11;
         }
-        else if (!HDstrncmp(argv[argno], "--vfd=", (size_t)6)) {
+        else if (!strncmp(argv[argno], "--vfd=", (size_t)6)) {
             vfd_info.type   = VFD_BY_NAME;
             vfd_info.u.name = argv[argno] + 6;
             custom_vfd_fapl = true;
         }
-        else if (!HDstrncmp(argv[argno], "--vfd-value=", (size_t)12)) {
+        else if (!strncmp(argv[argno], "--vfd-value=", (size_t)12)) {
             vfd_info.type    = VFD_BY_VALUE;
             vfd_info.u.value = (H5FD_class_value_t)atoi(argv[argno] + 12);
             custom_vfd_fapl  = true;
         }
-        else if (!HDstrncmp(argv[argno], "--vfd-name=", (size_t)11)) {
+        else if (!strncmp(argv[argno], "--vfd-name=", (size_t)11)) {
             vfd_info.type   = VFD_BY_NAME;
             vfd_info.u.name = argv[argno] + 11;
             custom_vfd_fapl = true;
         }
-        else if (!HDstrncmp(argv[argno], "--vfd-info=", (size_t)11)) {
+        else if (!strncmp(argv[argno], "--vfd-info=", (size_t)11)) {
             vfd_info.info = (const void *)(argv[argno] + 11);
         }
-        else if (!HDstrncmp(argv[argno], "--width=", (size_t)8)) {
+        else if (!strncmp(argv[argno], "--width=", (size_t)8)) {
             width_g = (int)strtol(argv[argno] + 8, &rest, 0);
 
             if (0 == width_g)
@@ -2791,7 +2791,7 @@ main(int argc, char *argv[])
                 leave(EXIT_FAILURE);
             }
         }
-        else if (!HDstrcmp(argv[argno], "--width")) {
+        else if (!strcmp(argv[argno], "--width")) {
             if ((argno + 1) >= argc) {
                 usage();
                 leave(EXIT_FAILURE);
@@ -2805,17 +2805,17 @@ main(int argc, char *argv[])
                 leave(EXIT_FAILURE);
             }
         }
-        else if (!HDstrcmp(argv[argno], "--verbose")) {
+        else if (!strcmp(argv[argno], "--verbose")) {
             verbose_g++;
         }
-        else if (!HDstrcmp(argv[argno], "--version")) {
+        else if (!strcmp(argv[argno], "--version")) {
             print_version(h5tools_getprogname());
             leave(EXIT_SUCCESS);
         }
-        else if (!HDstrcmp(argv[argno], "--hexdump")) {
+        else if (!strcmp(argv[argno], "--hexdump")) {
             hexdump_g = true;
         }
-        else if (!HDstrncmp(argv[argno], "-w", (size_t)2)) {
+        else if (!strncmp(argv[argno], "-w", (size_t)2)) {
             if (argv[argno][2]) {
                 s = argv[argno] + 2;
             }
@@ -2836,7 +2836,7 @@ main(int argc, char *argv[])
                 leave(EXIT_FAILURE);
             }
         }
-        else if (!HDstrncmp(argv[argno], "--s3-cred=", (size_t)10)) {
+        else if (!strncmp(argv[argno], "--s3-cred=", (size_t)10)) {
 #ifdef H5_HAVE_ROS3_VFD
             char const *start = NULL;
 
@@ -2863,7 +2863,7 @@ main(int argc, char *argv[])
             leave(EXIT_FAILURE);
 #endif
         }
-        else if (!HDstrncmp(argv[argno], "--hdfs-attrs=", (size_t)13)) {
+        else if (!strncmp(argv[argno], "--hdfs-attrs=", (size_t)13)) {
 #ifdef H5_HAVE_LIBHDFS
             char const *start = NULL;
 
@@ -2983,13 +2983,13 @@ main(int argc, char *argv[])
     /* Setup a custom fapl for file accesses */
     if (custom_vol_fapl || custom_vfd_fapl) {
 #ifdef H5_HAVE_ROS3_VFD
-        if (custom_vfd_fapl && (0 == HDstrcmp(vfd_info.u.name, drivernames[ROS3_VFD_IDX]))) {
+        if (custom_vfd_fapl && (0 == strcmp(vfd_info.u.name, drivernames[ROS3_VFD_IDX]))) {
             if (!vfd_info.info)
                 vfd_info.info = &ros3_fa;
         }
 #endif
 #ifdef H5_HAVE_LIBHDFS
-        if (custom_vfd_fapl && (0 == HDstrcmp(vfd_info.u.name, drivernames[HDFS_VFD_IDX]))) {
+        if (custom_vfd_fapl && (0 == strcmp(vfd_info.u.name, drivernames[HDFS_VFD_IDX]))) {
             if (!vfd_info.info)
                 vfd_info.info = &hdfs_fa;
         }
@@ -3021,7 +3021,7 @@ main(int argc, char *argv[])
         symlink_trav_t symlink_list;
         size_t         u;
 
-        fname   = HDstrdup(argv[argno++]);
+        fname   = strdup(argv[argno++]);
         oname   = NULL;
         file_id = H5I_INVALID_HID;
 
@@ -3037,7 +3037,7 @@ main(int argc, char *argv[])
 
             /* Shorten the file name; lengthen the object name */
             x     = oname;
-            oname = HDstrrchr(fname, '/');
+            oname = strrchr(fname, '/');
             if (x)
                 *x = '/';
             if (!oname)
@@ -3055,10 +3055,10 @@ main(int argc, char *argv[])
             /* Always use absolute paths to avoid confusion, keep track of where
              * to begin path name output */
             *oname        = '/';
-            iter.base_len = HDstrlen(oname);
+            iter.base_len = strlen(oname);
             iter.base_len -= oname[iter.base_len - 1] == '/';
             x = oname;
-            if (NULL == (oname = HDstrdup(oname))) {
+            if (NULL == (oname = strdup(oname))) {
                 fprintf(rawerrorstream, "memory allocation failed\n");
                 leave(EXIT_FAILURE);
             }
@@ -3090,7 +3090,7 @@ main(int argc, char *argv[])
         symlink_list.objs                        = NULL;
 
         /* Check for root group as object name */
-        if (HDstrcmp(oname, root_name) != 0) {
+        if (strcmp(oname, root_name) != 0) {
             /* Check the type of link given */
             if (H5Lget_info2(file_id, oname, &li, H5P_DEFAULT) < 0) {
                 hsize_t           curr_pos = 0; /* total data element position   */

--- a/tools/src/h5perf/pio_engine.c
+++ b/tools/src/h5perf/pio_engine.c
@@ -278,7 +278,7 @@ do_pio(parameters param)
         /* Open file for write */
         char base_name[256];
 
-        HDsnprintf(base_name, sizeof(base_name), "#pio_tmp_%lu", nf);
+        snprintf(base_name, sizeof(base_name), "#pio_tmp_%lu", nf);
         pio_create_filename(iot, base_name, fname, FILENAME_MAX);
         if (pio_debug_level > 0)
             fprintf(output, "rank %d: data filename=%s\n", pio_mpi_rank_g, fname);
@@ -431,11 +431,11 @@ pio_create_filename(iotype iot, const char *base_name, char *fullname, size_t si
         }
         else {
             /* We didn't append the prefix yet */
-            HDstrncpy(fullname, prefix, size);
+            strncpy(fullname, prefix, size);
             fullname[size - 1] = '\0';
         }
 
-        if ((HDstrlen(fullname) + HDstrlen(base_name) + 1) < size) {
+        if ((strlen(fullname) + strlen(base_name) + 1) < size) {
             /* Append the base_name with a slash first. Multiple slashes are
              * handled below. */
             h5_stat_t buf;
@@ -445,31 +445,31 @@ pio_create_filename(iotype iot, const char *base_name, char *fullname, size_t si
                 if (HDmkdir(fullname, (mode_t)0755) < 0 && errno != EEXIST) {
                     /* We couldn't make the "/tmp/${USER,LOGIN}" subdirectory.
                      * Default to PREFIX's original prefix value. */
-                    HDstrcpy(fullname, prefix);
+                    strcpy(fullname, prefix);
                 }
 
-            HDstrcat(fullname, "/");
-            HDstrcat(fullname, base_name);
+            strcat(fullname, "/");
+            strcat(fullname, base_name);
         }
         else {
             /* Buffer is too small */
             return NULL;
         }
     }
-    else if (HDstrlen(base_name) >= size) {
+    else if (strlen(base_name) >= size) {
         /* Buffer is too small */
         return NULL;
     }
     else {
-        HDstrcpy(fullname, base_name);
+        strcpy(fullname, base_name);
     }
 
     /* Append a suffix */
     if (suffix) {
-        if (HDstrlen(fullname) + HDstrlen(suffix) >= size)
+        if (strlen(fullname) + strlen(suffix) >= size)
             return NULL;
 
-        HDstrcat(fullname, suffix);
+        strcat(fullname, suffix);
     }
 
     /* Remove any double slashes in the filename */
@@ -887,7 +887,7 @@ do_write(results *res, file_descr *fd, parameters *parms, long ndsets, off_t nby
                     }     /* end if */
                 }         /* end else */
 
-                HDsnprintf(dname, sizeof(dname), "Dataset_%ld", ndset);
+                snprintf(dname, sizeof(dname), "Dataset_%ld", ndset);
                 h5ds_id = H5DCREATE(fd->h5fd, dname, ELMT_H5_TYPE, h5dset_space_id, h5dcpl);
 
                 if (h5ds_id < 0) {
@@ -1862,7 +1862,7 @@ do_read(results *res, file_descr *fd, parameters *parms, long ndsets, off_t nbyt
                 break;
 
             case PHDF5:
-                HDsnprintf(dname, sizeof(dname), "Dataset_%ld", ndset);
+                snprintf(dname, sizeof(dname), "Dataset_%ld", ndset);
                 h5ds_id = H5DOPEN(fd->h5fd, dname);
                 if (h5ds_id < 0) {
                     fprintf(stderr, "HDF5 Dataset open failed\n");

--- a/tools/src/h5perf/pio_perf.c
+++ b/tools/src/h5perf/pio_perf.c
@@ -739,7 +739,7 @@ h5_set_info_object(void)
     if ((envp = HDgetenv("HDF5_MPI_INFO")) != NULL) {
         char *next, *valp;
 
-        valp = envp = next = HDstrdup(envp);
+        valp = envp = next = strdup(envp);
 
         if (!valp)
             return 0;
@@ -764,7 +764,7 @@ h5_set_info_object(void)
             if (*next == ';')
                 ++next;
 
-            namep = HDstrncpy(key_val, valp, len);
+            namep = strncpy(key_val, valp, len);
 
             /* pass up any beginning whitespaces */
             while (*namep && (*namep == ' ' || *namep == '\t'))
@@ -774,13 +774,13 @@ h5_set_info_object(void)
                 continue; /* was all white space, so move to next k/v pair */
 
             /* eat up any ending white spaces */
-            endp = &namep[HDstrlen(namep) - 1];
+            endp = &namep[strlen(namep) - 1];
 
             while (endp && (*endp == ' ' || *endp == '\t'))
                 *endp-- = '\0';
 
             /* find the '=' */
-            valp = HDstrchr(namep, '=');
+            valp = strchr(namep, '=');
 
             if (valp != NULL) { /* it's a valid key/value pairing */
                 char *tmp_val = valp + 1;
@@ -1049,7 +1049,7 @@ output_report(const char *fmt, ...)
 
         va_start(ap, fmt);
         H5_GCC_CLANG_DIAG_OFF("format-nonliteral")
-        HDvfprintf(output, fmt, ap);
+        vfprintf(output, fmt, ap);
         H5_GCC_CLANG_DIAG_ON("format-nonliteral")
         va_end(ap);
     }
@@ -1072,7 +1072,7 @@ print_indent(int indent)
         indent *= TAB_SPACE;
 
         for (; indent > 0; --indent)
-            HDfputc(' ', output);
+            fputc(' ', output);
     }
 }
 
@@ -1334,7 +1334,7 @@ parse_command_line(int argc, const char *const *argv)
                         if (isalnum(*end) && i < 10)
                             buf[i++] = *end;
 
-                    if (HDstrlen(buf) > 1 || isdigit(buf[0])) {
+                    if (strlen(buf) > 1 || isdigit(buf[0])) {
                         size_t j;
 
                         for (j = 0; j < 10 && buf[j] != '\0'; ++j)

--- a/tools/src/h5perf/sio_engine.c
+++ b/tools/src/h5perf/sio_engine.c
@@ -197,7 +197,7 @@ do_sio(parameters param, results *res)
      */
     /* Open file for write */
 
-    HDstrcpy(base_name, "#sio_tmp");
+    strcpy(base_name, "#sio_tmp");
     sio_create_filename(iot, base_name, fname, FILENAME_MAX, &param);
 
     if (sio_debug_level > 0)
@@ -339,11 +339,11 @@ sio_create_filename(iotype iot, const char *base_name, char *fullname, size_t si
         }
         else {
             /* We didn't append the prefix yet */
-            HDstrncpy(fullname, prefix, size);
+            strncpy(fullname, prefix, size);
             fullname[size - 1] = '\0';
         }
 
-        if ((HDstrlen(fullname) + HDstrlen(base_name) + 1) < size) {
+        if ((strlen(fullname) + strlen(base_name) + 1) < size) {
             /* Append the base_name with a slash first. Multiple slashes are
              * handled below. */
             h5_stat_t buf;
@@ -353,11 +353,11 @@ sio_create_filename(iotype iot, const char *base_name, char *fullname, size_t si
                 if (HDmkdir(fullname, 0755) < 0 && errno != EEXIST) {
                     /* We couldn't make the "/tmp/${USER,LOGIN}" subdirectory.
                      * Default to PREFIX's original prefix value. */
-                    HDstrcpy(fullname, prefix);
+                    strcpy(fullname, prefix);
                 }
 
-            HDstrcat(fullname, "/");
-            HDstrcat(fullname, base_name);
+            strcat(fullname, "/");
+            strcat(fullname, base_name);
         }
         else {
             /* Buffer is too small */
@@ -369,15 +369,15 @@ sio_create_filename(iotype iot, const char *base_name, char *fullname, size_t si
         return NULL;
     }
     else {
-        HDstrcpy(fullname, base_name);
+        strcpy(fullname, base_name);
     }
 
     /* Append a suffix */
     if (suffix) {
-        if (HDstrlen(fullname) + HDstrlen(suffix) >= size)
+        if (strlen(fullname) + strlen(suffix) >= size)
             return NULL;
 
-        HDstrcat(fullname, suffix);
+        strcat(fullname, suffix);
     }
 
     /* Remove any double slashes in the filename */
@@ -513,7 +513,7 @@ do_write(results *res, file_descr *fd, parameters *parms, void *buffer)
                 } /* end if */
             }     /* end if */
 
-            HDsnprintf(dname, sizeof(dname), "Dataset_%ld", (unsigned long)parms->num_bytes);
+            snprintf(dname, sizeof(dname), "Dataset_%ld", (unsigned long)parms->num_bytes);
             h5ds_id =
                 H5Dcreate2(fd->h5fd, dname, ELMT_H5_TYPE, h5dset_space_id, H5P_DEFAULT, h5dcpl, H5P_DEFAULT);
 
@@ -836,7 +836,7 @@ do_read(results *res, file_descr *fd, parameters *parms, void *buffer)
             break;
 
         case HDF5:
-            HDsnprintf(dname, sizeof(dname), "Dataset_%ld", (long)parms->num_bytes);
+            snprintf(dname, sizeof(dname), "Dataset_%ld", (long)parms->num_bytes);
             h5ds_id = H5Dopen2(fd->h5fd, dname, H5P_DEFAULT);
             if (h5ds_id < 0) {
                 fprintf(stderr, "HDF5 Dataset open failed\n");
@@ -1153,13 +1153,13 @@ set_vfd(parameters *param)
         memset(memb_name, 0, sizeof memb_name);
         memset(memb_addr, 0, sizeof memb_addr);
 
-        assert(HDstrlen(multi_letters) == H5FD_MEM_NTYPES);
+        assert(strlen(multi_letters) == H5FD_MEM_NTYPES);
 
         if (NULL == (sv = calloc(1, sizeof(*sv))))
             return -1;
         for (mt = H5FD_MEM_DEFAULT; mt < H5FD_MEM_NTYPES; mt++) {
             memb_fapl[mt] = H5P_DEFAULT;
-            HDsnprintf(sv->arr[mt], 1024, "%%s-%c.h5", multi_letters[mt]);
+            snprintf(sv->arr[mt], 1024, "%%s-%c.h5", multi_letters[mt]);
             memb_name[mt] = sv->arr[mt];
             memb_addr[mt] = (haddr_t)MAX(mt - 1, 0) * (HADDR_MAX / 10);
         }
@@ -1175,7 +1175,7 @@ set_vfd(parameters *param)
         hsize_t fam_size = 1 * 1024 * 1024; /*100 MB*/
 
         /* Family of files, each 1MB and using the default driver */
-        /* if ((val=HDstrtok(NULL, " \t\n\r")))
+        /* if ((val=strtok(NULL, " \t\n\r")))
             fam_size = (hsize_t)(strtod(val, NULL) * 1024*1024); */
         if (H5Pset_fapl_family(my_fapl, fam_size, H5P_DEFAULT) < 0)
             return -1;
@@ -1274,7 +1274,7 @@ do_cleanupfile(iotype iot, char *filename)
                 if (driver == H5FD_FAMILY) {
                     for (j = 0; /*void*/; j++) {
                         H5_GCC_CLANG_DIAG_OFF("format-nonliteral")
-                        HDsnprintf(temp, temp_sz, filename, j);
+                        snprintf(temp, temp_sz, filename, j);
                         H5_GCC_CLANG_DIAG_ON("format-nonliteral")
 
                         if (HDaccess(temp, F_OK) < 0)
@@ -1294,10 +1294,10 @@ do_cleanupfile(iotype iot, char *filename)
                 }
                 else if (driver == H5FD_MULTI) {
                     H5FD_mem_t mt;
-                    assert(HDstrlen(multi_letters) == H5FD_MEM_NTYPES);
+                    assert(strlen(multi_letters) == H5FD_MEM_NTYPES);
 
                     for (mt = H5FD_MEM_DEFAULT; mt < H5FD_MEM_NTYPES; mt++) {
-                        HDsnprintf(temp, temp_sz, "%s-%c.h5", filename, multi_letters[mt]);
+                        snprintf(temp, temp_sz, "%s-%c.h5", filename, multi_letters[mt]);
                         HDremove(temp); /*don't care if it fails*/
                     }
                 }

--- a/tools/src/h5perf/sio_perf.c
+++ b/tools/src/h5perf/sio_perf.c
@@ -203,7 +203,7 @@ main(int argc, char *argv[])
     if (opts->output_file) {
         if ((output = fopen(opts->output_file, "w")) == NULL) {
             fprintf(stderr, "%s: cannot open output file\n", progname);
-            HDperror(opts->output_file);
+            perror(opts->output_file);
             goto finish;
         }
     }
@@ -627,7 +627,7 @@ output_report(const char *fmt, ...)
 
     va_start(ap, fmt);
     H5_GCC_CLANG_DIAG_OFF("format-nonliteral")
-    HDvfprintf(output, fmt, ap);
+    vfprintf(output, fmt, ap);
     H5_GCC_CLANG_DIAG_ON("format-nonliteral")
     va_end(ap);
 }
@@ -644,7 +644,7 @@ print_indent(int indent)
     indent *= TAB_SPACE;
 
     for (; indent > 0; --indent)
-        HDfputc(' ', output);
+        fputc(' ', output);
 }
 
 static void
@@ -921,7 +921,7 @@ parse_command_line(int argc, const char *const *argv)
                         if (isalnum(*end) && i < 10)
                             buf[i++] = *end;
 
-                    if (HDstrlen(buf) > 1 || isdigit(buf[0])) {
+                    if (strlen(buf) > 1 || isdigit(buf[0])) {
                         size_t j;
 
                         for (j = 0; j < 10 && buf[j] != '\0'; ++j)

--- a/tools/src/h5repack/h5repack_copy.c
+++ b/tools/src/h5repack/h5repack_copy.c
@@ -725,7 +725,7 @@ do_copy_objects(hid_t fidin, hid_t fidout, trav_table_t *travt, pack_opt_t *opti
                      * and copy its attributes using that ID
                      *-------------------------------------------------------------------------
                      */
-                    if (HDstrcmp(travt->objs[i].name, "/") == 0) {
+                    if (strcmp(travt->objs[i].name, "/") == 0) {
                         if ((grp_out = H5Gopen2(fidout, "/", H5P_DEFAULT)) < 0)
                             H5TOOLS_GOTO_ERROR((-1), "H5Gopen2 failed");
                     }
@@ -778,7 +778,7 @@ do_copy_objects(hid_t fidin, hid_t fidout, trav_table_t *travt, pack_opt_t *opti
                     /* check if filters were requested for individual objects */
                     if (options->op_tbl->objs) {
                         for (u = 0; u < options->op_tbl->nelems; u++) {
-                            if (HDstrcmp(travt->objs[i].name, options->op_tbl->objs[u].path) == 0)
+                            if (strcmp(travt->objs[i].name, options->op_tbl->objs[u].path) == 0)
                                 for (ifil = 0; ifil < options->op_tbl->objs[ifil].nfilters; ifil++) {
                                     if (options->op_tbl->objs[u].filter[ifil].filtn > 0)
                                         req_filter = 1;
@@ -1528,7 +1528,7 @@ print_dataset_info(hid_t dcpl_id, char *objname, double ratio, int pr, pack_opt_
     char         f_objname[256]; /* filter objname */
     int          i;
 
-    HDstrcpy(strfilter, "\0");
+    strcpy(strfilter, "\0");
 
     /* get information about input filters */
     if ((nfilters = H5Pget_nfilters(dcpl_id)) < 0)
@@ -1539,65 +1539,65 @@ print_dataset_info(hid_t dcpl_id, char *objname, double ratio, int pr, pack_opt_
 
         if ((filtn = H5Pget_filter2(dcpl_id, (unsigned)i, &filt_flags, &cd_nelmts, cd_values,
                                     sizeof(f_objname), f_objname, NULL)) < 0) {
-            HDstrcat(strfilter, "ERROR ");
+            strcat(strfilter, "ERROR ");
             continue;
         }
 
         switch (filtn) {
             case H5Z_FILTER_NONE:
-                HDstrcat(strfilter, "NONE ");
+                strcat(strfilter, "NONE ");
                 break;
 
             case H5Z_FILTER_DEFLATE:
-                HDstrcat(strfilter, "GZIP ");
+                strcat(strfilter, "GZIP ");
 
 #if defined(PRINT_DEBUG)
                 {
                     unsigned level = cd_values[0];
 
-                    HDsnprintf(temp, sizeof(temp), "(%d)", level);
-                    HDstrcat(strfilter, temp);
+                    snprintf(temp, sizeof(temp), "(%d)", level);
+                    strcat(strfilter, temp);
                 }
 #endif
                 break;
 
             case H5Z_FILTER_SZIP:
-                HDstrcat(strfilter, "SZIP ");
+                strcat(strfilter, "SZIP ");
 
 #if defined(PRINT_DEBUG)
                 {
                     unsigned options_mask = cd_values[0]; /* from dcpl, not filt*/
                     unsigned ppb          = cd_values[1];
 
-                    HDsnprintf(temp, sizeof(temp), "(%d,", ppb);
-                    HDstrcat(strfilter, temp);
+                    snprintf(temp, sizeof(temp), "(%d,", ppb);
+                    strcat(strfilter, temp);
                     if (options_mask & H5_SZIP_EC_OPTION_MASK)
-                        HDstrcpy(temp, "EC) ");
+                        strcpy(temp, "EC) ");
                     else if (options_mask & H5_SZIP_NN_OPTION_MASK)
-                        HDstrcpy(temp, "NN) ");
+                        strcpy(temp, "NN) ");
                 }
-                HDstrcat(strfilter, temp);
+                strcat(strfilter, temp);
 #endif
                 break;
 
             case H5Z_FILTER_SHUFFLE:
-                HDstrcat(strfilter, "SHUF ");
+                strcat(strfilter, "SHUF ");
                 break;
 
             case H5Z_FILTER_FLETCHER32:
-                HDstrcat(strfilter, "FLET ");
+                strcat(strfilter, "FLET ");
                 break;
 
             case H5Z_FILTER_NBIT:
-                HDstrcat(strfilter, "NBIT ");
+                strcat(strfilter, "NBIT ");
                 break;
 
             case H5Z_FILTER_SCALEOFFSET:
-                HDstrcat(strfilter, "SCALEOFFSET ");
+                strcat(strfilter, "SCALEOFFSET ");
                 break;
 
             default:
-                HDstrcat(strfilter, "UD ");
+                strcat(strfilter, "UD ");
                 break;
         } /* end switch */
     }     /* end for each filter */
@@ -1610,10 +1610,10 @@ print_dataset_info(hid_t dcpl_id, char *objname, double ratio, int pr, pack_opt_
     else {
         char str[512], temp[512];
 
-        HDstrcpy(str, "dset     ");
-        HDstrcat(str, strfilter);
-        HDsnprintf(temp, sizeof(temp), "  (%.3f:1)", ratio);
-        HDstrcat(str, temp);
+        strcpy(str, "dset     ");
+        strcat(str, strfilter);
+        snprintf(temp, sizeof(temp), "  (%.3f:1)", ratio);
+        strcat(str, temp);
         if (options->verbose == 2)
             printf(FORMAT_OBJ_TIME, str, read_time, write_time, objname);
         else

--- a/tools/src/h5repack/h5repack_filters.c
+++ b/tools/src/h5repack/h5repack_filters.c
@@ -57,7 +57,7 @@ aux_copy_obj(hid_t        dcpl_id,        /* dataset creation property list */
     }
 
     objout->nfilters = nfilters;
-    HDstrcpy(objout->path, name);
+    strcpy(objout->path, name);
 
     if ((layout = H5Pget_layout(dcpl_id)) < 0)
         H5TOOLS_GOTO_ERROR((-1), "H5Pget_layout failed");
@@ -92,7 +92,7 @@ aux_find_obj(const char  *name,        /* object name from traverse list */
     unsigned int i;
 
     for (i = 0; i < options->op_tbl->nelems; i++) {
-        if (HDstrcmp(options->op_tbl->objs[i].path, name) == 0) {
+        if (strcmp(options->op_tbl->objs[i].path, name) == 0) {
             *obj = options->op_tbl->objs[i];
             return (int)i;
         }
@@ -104,7 +104,7 @@ aux_find_obj(const char  *name,        /* object name from traverse list */
         if (pname[0] == '/')
             pname++;
 
-        if (HDstrcmp(pdest, pname) == 0) {
+        if (strcmp(pdest, pname) == 0) {
             *obj = options->op_tbl->objs[i];
             return (int)i;
         }

--- a/tools/src/h5repack/h5repack_main.c
+++ b/tools/src/h5repack/h5repack_main.c
@@ -401,11 +401,11 @@ read_info(const char *filename, pack_opt_t *options)
 
     /* cycle until end of file reached */
     while (1) {
-        if (EOF == HDfscanf(fp, "%9s", stype))
+        if (EOF == fscanf(fp, "%9s", stype))
             break;
 
         /* Info indicator must be for layout or filter */
-        if (HDstrcmp(stype, "-l") != 0 && HDstrcmp(stype, "-f") != 0) {
+        if (strcmp(stype, "-l") != 0 && strcmp(stype, "-f") != 0) {
             error_msg("bad file format for %s", filename);
             h5tools_setstatus(EXIT_FAILURE);
             ret_value = EXIT_FAILURE;
@@ -416,7 +416,7 @@ read_info(const char *filename, pack_opt_t *options)
         i = 0;
         c = '0';
         while (c != ' ') {
-            if (HDfscanf(fp, "%c", &c) < 0 && ferror(fp)) {
+            if (fscanf(fp, "%c", &c) < 0 && ferror(fp)) {
                 error_msg("fscanf error\n");
                 h5tools_setstatus(EXIT_FAILURE);
                 ret_value = EXIT_FAILURE;
@@ -428,7 +428,7 @@ read_info(const char *filename, pack_opt_t *options)
         c = '0';
         /* go until end */
         while (c != ' ') {
-            if (HDfscanf(fp, "%c", &c) < 0 && ferror(fp)) {
+            if (fscanf(fp, "%c", &c) < 0 && ferror(fp)) {
                 error_msg("fscanf error\n");
                 h5tools_setstatus(EXIT_FAILURE);
                 ret_value = EXIT_FAILURE;
@@ -442,7 +442,7 @@ read_info(const char *filename, pack_opt_t *options)
         }
         comp_info[i - 1] = '\0'; /*cut the last " */
 
-        if (!HDstrcmp(stype, "-l")) {
+        if (!strcmp(stype, "-l")) {
             if (h5repack_addlayout(comp_info, options) == -1) {
                 error_msg("could not add chunk option\n");
                 h5tools_setstatus(EXIT_FAILURE);
@@ -482,9 +482,9 @@ set_sort_by(const char *form)
 {
     H5_index_t idx_type = H5_INDEX_UNKNOWN;
 
-    if (!HDstrcmp(form, "name"))
+    if (!strcmp(form, "name"))
         idx_type = H5_INDEX_NAME;
-    else if (!HDstrcmp(form, "creation_order"))
+    else if (!strcmp(form, "creation_order"))
         idx_type = H5_INDEX_CRT_ORDER;
 
     return idx_type;
@@ -505,9 +505,9 @@ set_sort_order(const char *form)
 {
     H5_iter_order_t iter_order = H5_ITER_UNKNOWN;
 
-    if (!HDstrcmp(form, "ascending"))
+    if (!strcmp(form, "ascending"))
         iter_order = H5_ITER_INC;
-    else if (!HDstrcmp(form, "descending"))
+    else if (!strcmp(form, "descending"))
         iter_order = H5_ITER_DEC;
 
     return iter_order;
@@ -669,7 +669,7 @@ parse_command_line(int argc, const char *const *argv, pack_opt_t *options)
             case 's': {
                 int   idx       = 0;
                 int   ssize     = 0;
-                char *msgPtr    = HDstrchr(H5_optarg, ':');
+                char *msgPtr    = strchr(H5_optarg, ':');
                 options->latest = true; /* must use latest format */
                 if (msgPtr == NULL) {
                     ssize = atoi(H5_optarg);
@@ -679,18 +679,18 @@ parse_command_line(int argc, const char *const *argv, pack_opt_t *options)
                 else {
                     char msgType[10];
 
-                    HDstrcpy(msgType, msgPtr + 1);
+                    strcpy(msgType, msgPtr + 1);
                     msgPtr[0] = '\0';
                     ssize     = atoi(H5_optarg);
-                    if (!HDstrncmp(msgType, "dspace", 6))
+                    if (!strncmp(msgType, "dspace", 6))
                         options->msg_size[0] = ssize;
-                    else if (!HDstrncmp(msgType, "dtype", 5))
+                    else if (!strncmp(msgType, "dtype", 5))
                         options->msg_size[1] = ssize;
-                    else if (!HDstrncmp(msgType, "fill", 4))
+                    else if (!strncmp(msgType, "fill", 4))
                         options->msg_size[2] = ssize;
-                    else if (!HDstrncmp(msgType, "pline", 5))
+                    else if (!strncmp(msgType, "pline", 5))
                         options->msg_size[3] = ssize;
-                    else if (!HDstrncmp(msgType, "attr", 4))
+                    else if (!strncmp(msgType, "attr", 4))
                         options->msg_size[4] = ssize;
                 }
             } break;
@@ -724,14 +724,14 @@ parse_command_line(int argc, const char *const *argv, pack_opt_t *options)
             case 'S': {
                 char strategy[MAX_NC_NAME];
 
-                HDstrcpy(strategy, H5_optarg);
-                if (!HDstrcmp(strategy, "FSM_AGGR"))
+                strcpy(strategy, H5_optarg);
+                if (!strcmp(strategy, "FSM_AGGR"))
                     options->fs_strategy = H5F_FSPACE_STRATEGY_FSM_AGGR;
-                else if (!HDstrcmp(strategy, "PAGE"))
+                else if (!strcmp(strategy, "PAGE"))
                     options->fs_strategy = H5F_FSPACE_STRATEGY_PAGE;
-                else if (!HDstrcmp(strategy, "AGGR"))
+                else if (!strcmp(strategy, "AGGR"))
                     options->fs_strategy = H5F_FSPACE_STRATEGY_AGGR;
-                else if (!HDstrcmp(strategy, "NONE"))
+                else if (!strcmp(strategy, "NONE"))
                     options->fs_strategy = H5F_FSPACE_STRATEGY_NONE;
                 else {
                     error_msg("invalid file space management strategy `%s`\n", H5_optarg);
@@ -865,7 +865,7 @@ parse_command_line(int argc, const char *const *argv, pack_opt_t *options)
             infile  = argv[H5_optind];
             outfile = argv[H5_optind + 1];
 
-            if (!HDstrcmp(infile, outfile)) {
+            if (!strcmp(infile, outfile)) {
                 error_msg("file names cannot be the same\n");
                 usage(h5tools_getprogname());
                 h5tools_setstatus(EXIT_FAILURE);
@@ -887,7 +887,7 @@ parse_command_line(int argc, const char *const *argv, pack_opt_t *options)
     }
 
     /* If the input file uses the onion VFD, get the revision number */
-    if (in_vfd_info.u.name && !HDstrcmp(in_vfd_info.u.name, "onion")) {
+    if (in_vfd_info.u.name && !strcmp(in_vfd_info.u.name, "onion")) {
         if (in_vfd_info.info) {
             errno                      = 0;
             onion_fa_in_g.revision_num = strtoull(in_vfd_info.info, NULL, 10);

--- a/tools/src/h5repack/h5repack_opttable.c
+++ b/tools/src/h5repack/h5repack_opttable.c
@@ -28,7 +28,7 @@ init_packobject(pack_info_t *obj)
 {
     int j, k;
 
-    HDstrcpy(obj->path, "\0");
+    strcpy(obj->path, "\0");
     for (j = 0; j < H5_REPACK_MAX_NFILTERS; j++) {
         obj->filter[j].filtn     = -1;
         obj->filter[j].cd_nelmts = CD_VALUES;
@@ -196,7 +196,7 @@ options_add_layout(obj_list_t *obj_list, unsigned n_objs, pack_info_t *pack, pac
             /* linear table search */
             for (i = 0; i < table->nelems; i++) {
                 /*already on the table */
-                if (HDstrcmp(obj_list[j].obj, table->objs[i].path) == 0) {
+                if (strcmp(obj_list[j].obj, table->objs[i].path) == 0) {
                     /* already chunk info inserted for this one; exit */
                     if (table->objs[i].chunk.rank > 0) {
                         H5TOOLS_INFO("chunk information already inserted for <%s>\n", obj_list[j].obj);
@@ -215,7 +215,7 @@ options_add_layout(obj_list_t *obj_list, unsigned n_objs, pack_info_t *pack, pac
                 /* keep the grow in a temp var */
                 I = table->nelems + added;
                 added++;
-                HDstrcpy(table->objs[I].path, obj_list[j].obj);
+                strcpy(table->objs[I].path, obj_list[j].obj);
                 aux_tblinsert_layout(table, I, pack);
             }
             /* cases where we have an already inserted name but there is a new name also
@@ -223,11 +223,11 @@ options_add_layout(obj_list_t *obj_list, unsigned n_objs, pack_info_t *pack, pac
              -f dset1:GZIP=1 -l dset1,dset2:CHUNK=20x20
              dset1 is already inserted, but dset2 must also be
              */
-            else if (found && HDstrcmp(obj_list[j].obj, table->objs[i].path) != 0) {
+            else if (found && strcmp(obj_list[j].obj, table->objs[i].path) != 0) {
                 /* keep the grow in a temp var */
                 I = table->nelems + added;
                 added++;
-                HDstrcpy(table->objs[I].path, obj_list[j].obj);
+                strcpy(table->objs[I].path, obj_list[j].obj);
                 aux_tblinsert_layout(table, I, pack);
             }
         } /* j */
@@ -238,7 +238,7 @@ options_add_layout(obj_list_t *obj_list, unsigned n_objs, pack_info_t *pack, pac
         for (j = 0; j < n_objs; j++) {
             I = table->nelems + added;
             added++;
-            HDstrcpy(table->objs[I].path, obj_list[j].obj);
+            strcpy(table->objs[I].path, obj_list[j].obj);
             aux_tblinsert_layout(table, I, pack);
         }
     }
@@ -275,7 +275,7 @@ options_add_filter(obj_list_t *obj_list, unsigned n_objs, filter_info_t filt, pa
             /* linear table search */
             for (i = 0; i < table->nelems; i++) {
                 /*already on the table */
-                if (HDstrcmp(obj_list[j].obj, table->objs[i].path) == 0) {
+                if (strcmp(obj_list[j].obj, table->objs[i].path) == 0) {
                     /* insert */
                     aux_tblinsert_filter(table, i, filt);
                     found = true;
@@ -287,7 +287,7 @@ options_add_filter(obj_list_t *obj_list, unsigned n_objs, filter_info_t filt, pa
                 /* keep the grow in a temp var */
                 I = table->nelems + added;
                 added++;
-                HDstrcpy(table->objs[I].path, obj_list[j].obj);
+                strcpy(table->objs[I].path, obj_list[j].obj);
                 aux_tblinsert_filter(table, I, filt);
             }
             /* cases where we have an already inserted name but there is a new name also
@@ -295,11 +295,11 @@ options_add_filter(obj_list_t *obj_list, unsigned n_objs, filter_info_t filt, pa
              -l dset1:CHUNK=20x20 -f dset1,dset2:GZIP=1
              dset1 is already inserted, but dset2 must also be
              */
-            else if (found && HDstrcmp(obj_list[j].obj, table->objs[i].path) != 0) {
+            else if (found && strcmp(obj_list[j].obj, table->objs[i].path) != 0) {
                 /* keep the grow in a temp var */
                 I = table->nelems + added;
                 added++;
-                HDstrcpy(table->objs[I].path, obj_list[j].obj);
+                strcpy(table->objs[I].path, obj_list[j].obj);
                 aux_tblinsert_filter(table, I, filt);
             }
         } /* j */
@@ -311,7 +311,7 @@ options_add_filter(obj_list_t *obj_list, unsigned n_objs, filter_info_t filt, pa
         for (j = 0; j < n_objs; j++) {
             I = table->nelems + added;
             added++;
-            HDstrcpy(table->objs[I].path, obj_list[j].obj);
+            strcpy(table->objs[I].path, obj_list[j].obj);
             aux_tblinsert_filter(table, I, filt);
         }
     }
@@ -338,15 +338,15 @@ options_get_object(const char *path, pack_opttbl_t *table)
 
     for (i = 0; i < table->nelems; i++) {
         /* make full path (start with "/") to compare correctly  */
-        if (HDstrncmp(table->objs[i].path, "/", 1) != 0) {
-            HDstrcpy(tbl_path, "/");
-            HDstrcat(tbl_path, table->objs[i].path);
+        if (strncmp(table->objs[i].path, "/", 1) != 0) {
+            strcpy(tbl_path, "/");
+            strcat(tbl_path, table->objs[i].path);
         }
         else
-            HDstrcpy(tbl_path, table->objs[i].path);
+            strcpy(tbl_path, table->objs[i].path);
 
         /* found it */
-        if (HDstrcmp(tbl_path, path) == 0) {
+        if (strcmp(tbl_path, path) == 0) {
             return (&table->objs[i]);
         }
     }

--- a/tools/src/h5repack/h5repack_parse.c
+++ b/tools/src/h5repack/h5repack_parse.c
@@ -41,7 +41,7 @@ parse_filter(const char *str, unsigned *n_objs, filter_info_t *filt, pack_opt_t 
 {
     size_t      i, m, u;
     char        c;
-    size_t      len = HDstrlen(str);
+    size_t      len = strlen(str);
     int         f, k, l, p, q, end_obj = -1, no_param = 0;
     unsigned    j, n;
     char        sobj[MAX_NC_NAME];
@@ -94,7 +94,7 @@ parse_filter(const char *str, unsigned *n_objs, filter_info_t *filt, pack_opt_t 
                 else
                     sobj[k + 1] = '\0';
 
-                HDstrcpy(obj_list[n].obj, sobj);
+                strcpy(obj_list[n].obj, sobj);
                 memset(sobj, 0, sizeof(sobj));
                 n++;
                 k = -1;
@@ -123,7 +123,7 @@ parse_filter(const char *str, unsigned *n_objs, filter_info_t *filt, pack_opt_t 
                  * example SZIP=8,NN
                  *-------------------------------------------------------------------------
                  */
-                if (HDstrcmp(scomp, "SZIP") == 0) {
+                if (strcmp(scomp, "SZIP") == 0) {
                     l = -1; /* mask index check */
                     for (m = 0, u = i + 1; u < len; u++, m++) {
                         if (str[u] == ',') {
@@ -146,9 +146,9 @@ parse_filter(const char *str, unsigned *n_objs, filter_info_t *filt, pack_opt_t 
                             if (l == 2) {
                                 smask[l] = '\0';
                                 i        = len - 1; /* end */
-                                if (HDstrcmp(smask, "NN") == 0)
+                                if (strcmp(smask, "NN") == 0)
                                     filt->cd_values[j++] = H5_SZIP_NN_OPTION_MASK;
-                                else if (HDstrcmp(smask, "EC") == 0)
+                                else if (strcmp(smask, "EC") == 0)
                                     filt->cd_values[j++] = H5_SZIP_EC_OPTION_MASK;
                                 else {
                                     error_msg("szip mask must be 'NN' or 'EC' \n");
@@ -173,7 +173,7 @@ parse_filter(const char *str, unsigned *n_objs, filter_info_t *filt, pack_opt_t 
                  *  SOFF=3,DF
                  *-------------------------------------------------------------------------
                  */
-                else if (HDstrcmp(scomp, "SOFF") == 0) {
+                else if (strcmp(scomp, "SOFF") == 0) {
                     l = -1; /* mask index check */
                     for (m = 0, u = i + 1; u < len; u++, m++) {
                         if (str[u] == ',') {
@@ -196,9 +196,9 @@ parse_filter(const char *str, unsigned *n_objs, filter_info_t *filt, pack_opt_t 
                             if (l == 2) {
                                 smask[l] = '\0';
                                 i        = len - 1; /* end */
-                                if (HDstrcmp(smask, "IN") == 0)
+                                if (strcmp(smask, "IN") == 0)
                                     filt->cd_values[j++] = H5Z_SO_INT;
-                                else if (HDstrcmp(smask, "DS") == H5Z_SO_FLOAT_DSCALE)
+                                else if (strcmp(smask, "DS") == H5Z_SO_FLOAT_DSCALE)
                                     filt->cd_values[j++] = H5Z_SO_FLOAT_DSCALE;
                                 else {
                                     error_msg("scale type must be 'IN' or 'DS' \n");
@@ -216,7 +216,7 @@ parse_filter(const char *str, unsigned *n_objs, filter_info_t *filt, pack_opt_t 
                  *  UD=307,0,1,9
                  *-------------------------------------------------------------------------
                  */
-                else if (HDstrcmp(scomp, "UD") == 0) {
+                else if (strcmp(scomp, "UD") == 0) {
                     l = -1; /* filter number index check */
                     f = -1; /* filter flag index check */
                     p = -1; /* CD_VAL count check */
@@ -298,7 +298,7 @@ parse_filter(const char *str, unsigned *n_objs, filter_info_t *filt, pack_opt_t 
              * H5Z_FILTER_NONE
              *-------------------------------------------------------------------------
              */
-            if (HDstrcmp(scomp, "NONE") == 0) {
+            if (strcmp(scomp, "NONE") == 0) {
                 filt->filtn     = H5Z_FILTER_NONE;
                 filt->cd_nelmts = 0;
             }
@@ -307,7 +307,7 @@ parse_filter(const char *str, unsigned *n_objs, filter_info_t *filt, pack_opt_t 
              * H5Z_FILTER_DEFLATE
              *-------------------------------------------------------------------------
              */
-            else if (HDstrcmp(scomp, "GZIP") == 0) {
+            else if (strcmp(scomp, "GZIP") == 0) {
                 filt->filtn     = H5Z_FILTER_DEFLATE;
                 filt->cd_nelmts = 1;
                 if (no_param) { /*no more parameters, GZIP must have parameter */
@@ -322,7 +322,7 @@ parse_filter(const char *str, unsigned *n_objs, filter_info_t *filt, pack_opt_t 
              * H5Z_FILTER_SZIP
              *-------------------------------------------------------------------------
              */
-            else if (HDstrcmp(scomp, "SZIP") == 0) {
+            else if (strcmp(scomp, "SZIP") == 0) {
                 filt->filtn     = H5Z_FILTER_SZIP;
                 filt->cd_nelmts = 2;
                 if (no_param) { /*no more parameters, SZIP must have parameter */
@@ -337,7 +337,7 @@ parse_filter(const char *str, unsigned *n_objs, filter_info_t *filt, pack_opt_t 
              * H5Z_FILTER_SHUFFLE
              *-------------------------------------------------------------------------
              */
-            else if (HDstrcmp(scomp, "SHUF") == 0) {
+            else if (strcmp(scomp, "SHUF") == 0) {
                 filt->filtn     = H5Z_FILTER_SHUFFLE;
                 filt->cd_nelmts = 0;
                 if (m > 0) { /*shuffle does not have parameter */
@@ -351,7 +351,7 @@ parse_filter(const char *str, unsigned *n_objs, filter_info_t *filt, pack_opt_t 
              * H5Z_FILTER_FLETCHER32
              *-------------------------------------------------------------------------
              */
-            else if (HDstrcmp(scomp, "FLET") == 0) {
+            else if (strcmp(scomp, "FLET") == 0) {
                 filt->filtn     = H5Z_FILTER_FLETCHER32;
                 filt->cd_nelmts = 0;
                 if (m > 0) { /*shuffle does not have parameter */
@@ -365,7 +365,7 @@ parse_filter(const char *str, unsigned *n_objs, filter_info_t *filt, pack_opt_t 
              * H5Z_FILTER_NBIT
              *-------------------------------------------------------------------------
              */
-            else if (HDstrcmp(scomp, "NBIT") == 0) {
+            else if (strcmp(scomp, "NBIT") == 0) {
                 filt->filtn     = H5Z_FILTER_NBIT;
                 filt->cd_nelmts = 0;
                 if (m > 0) { /*nbit does not have parameter */
@@ -379,7 +379,7 @@ parse_filter(const char *str, unsigned *n_objs, filter_info_t *filt, pack_opt_t 
              * H5Z_FILTER_SCALEOFFSET
              *-------------------------------------------------------------------------
              */
-            else if (HDstrcmp(scomp, "SOFF") == 0) {
+            else if (strcmp(scomp, "SOFF") == 0) {
                 filt->filtn     = H5Z_FILTER_SCALEOFFSET;
                 filt->cd_nelmts = 2;
                 if (no_param) { /*no more parameters, SOFF must have parameter */
@@ -393,7 +393,7 @@ parse_filter(const char *str, unsigned *n_objs, filter_info_t *filt, pack_opt_t 
              * User Defined Filter
              *-------------------------------------------------------------------------
              */
-            else if (HDstrcmp(scomp, "UD") == 0) {
+            else if (strcmp(scomp, "UD") == 0) {
                 /* parameters does not match count */
                 if (filt->cd_nelmts != j) {
                     if (obj_list)
@@ -448,7 +448,7 @@ parse_filter(const char *str, unsigned *n_objs, filter_info_t *filt, pack_opt_t 
                 error_msg("pixels_per_block is too large in <%s>\n", str);
                 exit(EXIT_FAILURE);
             }
-            if ((HDstrcmp(smask, "NN") != 0) && (HDstrcmp(smask, "EC") != 0)) {
+            if ((strcmp(smask, "NN") != 0) && (strcmp(smask, "EC") != 0)) {
                 if (obj_list)
                     free(obj_list);
                 error_msg("szip mask must be 'NN' or 'EC' \n");
@@ -486,7 +486,7 @@ parse_layout(const char *str, unsigned *n_objs, pack_info_t *pack, /* info about
     obj_list_t *obj_list = NULL;
     unsigned    i, j, n;
     char        c;
-    size_t      len = HDstrlen(str);
+    size_t      len = strlen(str);
     int         k, end_obj = -1, c_index;
     char        sobj[MAX_NC_NAME];
     char        sdim[10];
@@ -527,7 +527,7 @@ parse_layout(const char *str, unsigned *n_objs, pack_info_t *pack, /* info about
                     sobj[k] = '\0';
                 else
                     sobj[k + 1] = '\0';
-                HDstrcpy(obj_list[n].obj, sobj);
+                strcpy(obj_list[n].obj, sobj);
                 memset(sobj, 0, sizeof(sobj));
                 n++;
                 k = -1;
@@ -546,11 +546,11 @@ parse_layout(const char *str, unsigned *n_objs, pack_info_t *pack, /* info about
     for (j = (unsigned)(end_obj + 1), n = 0; n <= 5; j++, n++) {
         if (n == 5) {
             slayout[n] = '\0'; /*cut string */
-            if (HDstrcmp(slayout, "COMPA") == 0)
+            if (strcmp(slayout, "COMPA") == 0)
                 pack->layout = H5D_COMPACT;
-            else if (HDstrcmp(slayout, "CONTI") == 0)
+            else if (strcmp(slayout, "CONTI") == 0)
                 pack->layout = H5D_CONTIGUOUS;
-            else if (HDstrcmp(slayout, "CHUNK") == 0)
+            else if (strcmp(slayout, "CHUNK") == 0)
                 pack->layout = H5D_CHUNKED;
             else {
                 error_msg("in parse layout, not a valid layout in <%s>\n", str);
@@ -604,7 +604,7 @@ parse_layout(const char *str, unsigned *n_objs, pack_info_t *pack, /* info about
                 else if (i == len - 1) { /*no more parameters */
                     sdim[k] = '\0';
                     k       = 0;
-                    if (HDstrcmp(sdim, "NONE") == 0) {
+                    if (strcmp(sdim, "NONE") == 0) {
                         pack->chunk.rank = -2;
                     }
                     else {

--- a/tools/src/h5stat/h5stat.c
+++ b/tools/src/h5stat/h5stat.c
@@ -932,7 +932,7 @@ parse_command_line(int argc, const char *const *argv, struct handler_t **hand_re
 
                 /* Store object names */
                 for (u = 0; u < hand->obj_count; u++)
-                    if (NULL == (hand->obj[u] = HDstrdup(H5_optarg))) {
+                    if (NULL == (hand->obj[u] = strdup(H5_optarg))) {
                         error_msg("unable to allocate memory for object name\n");
                         goto error;
                     } /* end if */
@@ -1625,11 +1625,11 @@ main(int argc, char *argv[])
         vfd_info.u.name = drivername;
 
 #ifdef H5_HAVE_ROS3_VFD
-        if (!HDstrcmp(drivername, drivernames[ROS3_VFD_IDX]))
+        if (!strcmp(drivername, drivernames[ROS3_VFD_IDX]))
             vfd_info.info = &ros3_fa;
 #endif
 #ifdef H5_HAVE_LIBHDFS
-        if (!HDstrcmp(drivername, drivernames[HDFS_VFD_IDX]))
+        if (!strcmp(drivername, drivernames[HDFS_VFD_IDX]))
             vfd_info.info = &hdfs_fa;
 #endif
 

--- a/tools/src/misc/h5clear.c
+++ b/tools/src/misc/h5clear.c
@@ -167,7 +167,7 @@ parse_command_line(int argc, const char *const *argv)
         goto error;
     } /* end if */
 
-    fname_g = HDstrdup(argv[H5_optind]);
+    fname_g = strdup(argv[H5_optind]);
 
 done:
     return (0);
@@ -260,7 +260,7 @@ main(int argc, char *argv[])
     }
 
     /* Duplicate the file name */
-    fname = HDstrdup(fname_g);
+    fname = strdup(fname_g);
 
     /* Get a copy of the file access property list */
     if ((fapl = H5Pcreate(H5P_FILE_ACCESS)) < 0) {

--- a/tools/src/misc/h5debug.c
+++ b/tools/src/misc/h5debug.c
@@ -262,7 +262,7 @@ main(int argc, char *argv[])
         exit_value = 1;
         goto done;
     } /* end if */
-    if (HDstrchr(argv[1], '%'))
+    if (strchr(argv[1], '%'))
         if (H5Pset_fapl_family(fapl, (hsize_t)0, H5P_DEFAULT) < 0) {
             fprintf(stderr, "cannot set file access property list\n");
             exit_value = 1;
@@ -772,15 +772,15 @@ main(int argc, char *argv[])
         printf("%-*s ", VCOL, "Signature:");
         for (u = 0; u < sizeof(sig); u++) {
             if (sig[u] > ' ' && sig[u] <= '~' && '\\' != sig[u])
-                HDputchar(sig[u]);
+                putchar(sig[u]);
             else if ('\\' == sig[u]) {
-                HDputchar('\\');
-                HDputchar('\\');
+                putchar('\\');
+                putchar('\\');
             }
             else
                 printf("\\%03o", sig[u]);
         }
-        HDputchar('\n');
+        putchar('\n');
 
         fprintf(stderr, "unknown signature\n");
         exit_value = 4;

--- a/tools/src/misc/h5delete.c
+++ b/tools/src/misc/h5delete.c
@@ -37,7 +37,7 @@ main(int argc, char *argv[])
 
     switch (argc) {
         case 3:
-            if (HDstrcmp(argv[1], "-f") != 0) {
+            if (strcmp(argv[1], "-f") != 0) {
                 usage();
                 return EXIT_FAILURE;
             }

--- a/tools/src/misc/h5mkgrp.c
+++ b/tools/src/misc/h5mkgrp.c
@@ -228,7 +228,7 @@ parse_command_line(int argc, const char *const *argv, mkgrp_opt_t *options)
     }
 
     /* Retrieve file name */
-    options->fname = HDstrdup(argv[H5_optind]);
+    options->fname = strdup(argv[H5_optind]);
     H5_optind++;
 
     /* Check for group(s) to be created */
@@ -245,7 +245,7 @@ parse_command_line(int argc, const char *const *argv, mkgrp_opt_t *options)
     /* Retrieve the group names */
     curr_group = 0;
     while (H5_optind < argc) {
-        options->groups[curr_group] = HDstrdup(argv[H5_optind]);
+        options->groups[curr_group] = strdup(argv[H5_optind]);
         curr_group++;
         H5_optind++;
     }

--- a/tools/src/misc/h5repart.c
+++ b/tools/src/misc/h5repart.c
@@ -177,7 +177,7 @@ main(int argc, char *argv[])
     /*
      * Get the program name from argv[0]. Use only the last component.
      */
-    if ((prog_name = HDstrrchr(argv[0], '/')))
+    if ((prog_name = strrchr(argv[0], '/')))
         prog_name++;
     else
         prog_name = argv[0];
@@ -186,20 +186,20 @@ main(int argc, char *argv[])
      * Parse switches.
      */
     while (argno < argc && '-' == argv[argno][0]) {
-        if (!HDstrcmp(argv[argno], "-v")) {
+        if (!strcmp(argv[argno], "-v")) {
             verbose = true;
             argno++;
         }
-        else if (!HDstrcmp(argv[argno], "-V")) {
+        else if (!strcmp(argv[argno], "-V")) {
             printf("This is %s version %u.%u release %u\n", prog_name, H5_VERS_MAJOR, H5_VERS_MINOR,
                    H5_VERS_RELEASE);
             exit(EXIT_SUCCESS);
         }
-        else if (!HDstrcmp(argv[argno], "-family_to_sec2")) {
+        else if (!strcmp(argv[argno], "-family_to_sec2")) {
             family_to_single = true;
             argno++;
         }
-        else if (!HDstrcmp(argv[argno], "-family_to_single")) {
+        else if (!strcmp(argv[argno], "-family_to_single")) {
             family_to_single = true;
             argno++;
         }
@@ -227,16 +227,16 @@ main(int argc, char *argv[])
     if (argno >= argc)
         usage(prog_name);
     src_gen_name = argv[argno++];
-    HDsnprintf(src_name, NAMELEN, src_gen_name, src_membno);
+    snprintf(src_name, NAMELEN, src_gen_name, src_membno);
     src_is_family = strcmp(src_name, src_gen_name);
 
     if ((src = HDopen(src_name, O_RDONLY)) < 0) {
-        HDperror(src_name);
+        perror(src_name);
         exit(EXIT_FAILURE);
     }
 
     if (HDfstat(src, &sb) < 0) {
-        HDperror("fstat");
+        perror("fstat");
         exit(EXIT_FAILURE);
     }
     src_size = src_act_size = sb.st_size;
@@ -249,11 +249,11 @@ main(int argc, char *argv[])
     if (argno >= argc)
         usage(prog_name);
     dst_gen_name = argv[argno++];
-    HDsnprintf(dst_name, NAMELEN, dst_gen_name, dst_membno);
-    dst_is_family = HDstrcmp(dst_name, dst_gen_name);
+    snprintf(dst_name, NAMELEN, dst_gen_name, dst_membno);
+    dst_is_family = strcmp(dst_name, dst_gen_name);
 
     if ((dst = HDopen(dst_name, O_RDWR | O_CREAT | O_TRUNC, H5_POSIX_CREATE_MODE_RW)) < 0) {
-        HDperror(dst_name);
+        perror(dst_name);
         exit(EXIT_FAILURE);
     }
     if (verbose)
@@ -283,7 +283,7 @@ main(int argc, char *argv[])
         else if (src_offset < src_act_size) {
             n = (size_t)MIN((off_t)n, src_act_size - src_offset);
             if ((nio = HDread(src, buf, n)) < 0) {
-                HDperror("read");
+                perror("read");
                 exit(EXIT_FAILURE);
             }
             else if ((size_t)nio != n) {
@@ -309,11 +309,11 @@ main(int argc, char *argv[])
          */
         if (need_write) {
             if (need_seek && HDlseek(dst, dst_offset, SEEK_SET) < 0) {
-                HDperror("HDlseek");
+                perror("HDlseek");
                 exit(EXIT_FAILURE);
             }
             if ((nio = HDwrite(dst, buf, n)) < 0) {
-                HDperror("write");
+                perror("write");
                 exit(EXIT_FAILURE);
             }
             else if ((size_t)nio != n) {
@@ -341,17 +341,17 @@ main(int argc, char *argv[])
                 dst_offset = dst_offset + (off_t)n;
                 break;
             }
-            HDsnprintf(src_name, NAMELEN, src_gen_name, ++src_membno);
+            snprintf(src_name, NAMELEN, src_gen_name, ++src_membno);
             if ((src = HDopen(src_name, O_RDONLY)) < 0 && ENOENT == errno) {
                 dst_offset = dst_offset + (off_t)n;
                 break;
             }
             else if (src < 0) {
-                HDperror(src_name);
+                perror(src_name);
                 exit(EXIT_FAILURE);
             }
             if (HDfstat(src, &sb) < 0) {
-                HDperror("fstat");
+                perror("fstat");
                 exit(EXIT_FAILURE);
             }
             src_act_size = sb.st_size;
@@ -372,26 +372,26 @@ main(int argc, char *argv[])
         if (dst_is_family && dst_offset == dst_size) {
             if (0 == dst_membno) {
                 if (HDlseek(dst, dst_size - 1, SEEK_SET) < 0) {
-                    HDperror("HDHDlseek");
+                    perror("HDHDlseek");
                     exit(EXIT_FAILURE);
                 }
                 if (HDread(dst, buf, 1) < 0) {
-                    HDperror("read");
+                    perror("read");
                     exit(EXIT_FAILURE);
                 }
                 if (HDlseek(dst, dst_size - 1, SEEK_SET) < 0) {
-                    HDperror("HDlseek");
+                    perror("HDlseek");
                     exit(EXIT_FAILURE);
                 }
                 if (HDwrite(dst, buf, 1) < 0) {
-                    HDperror("write");
+                    perror("write");
                     exit(EXIT_FAILURE);
                 }
             }
             HDclose(dst);
-            HDsnprintf(dst_name, NAMELEN, dst_gen_name, ++dst_membno);
+            snprintf(dst_name, NAMELEN, dst_gen_name, ++dst_membno);
             if ((dst = HDopen(dst_name, O_RDWR | O_CREAT | O_TRUNC, H5_POSIX_CREATE_MODE_RW)) < 0) {
-                HDperror(dst_name);
+                perror(dst_name);
                 exit(EXIT_FAILURE);
             }
             dst_offset = 0;
@@ -408,19 +408,19 @@ main(int argc, char *argv[])
      */
     if (need_seek) {
         if (HDlseek(dst, dst_offset - 1, SEEK_SET) < 0) {
-            HDperror("HDlseek");
+            perror("HDlseek");
             exit(EXIT_FAILURE);
         }
         if (HDread(dst, buf, 1) < 0) {
-            HDperror("read");
+            perror("read");
             exit(EXIT_FAILURE);
         }
         if (HDlseek(dst, dst_offset - 1, SEEK_SET) < 0) {
-            HDperror("HDlseek");
+            perror("HDlseek");
             exit(EXIT_FAILURE);
         }
         if (HDwrite(dst, buf, 1) < 0) {
-            HDperror("write");
+            perror("write");
             exit(EXIT_FAILURE);
         }
     }
@@ -429,7 +429,7 @@ main(int argc, char *argv[])
     /* Modify family driver information saved in superblock through private property.
      * These private properties are for this tool only. */
     if ((fapl = H5Pcreate(H5P_FILE_ACCESS)) < 0) {
-        HDperror("H5Pcreate");
+        perror("H5Pcreate");
         exit(EXIT_FAILURE);
     }
 
@@ -439,7 +439,7 @@ main(int argc, char *argv[])
          * the library to ignore the family driver information saved in the superblock.
          */
         if (H5Pset(fapl, H5F_ACS_FAMILY_TO_SINGLE_NAME, &family_to_single) < 0) {
-            HDperror("H5Pset");
+            perror("H5Pset");
             exit(EXIT_FAILURE);
         }
     }
@@ -448,14 +448,14 @@ main(int argc, char *argv[])
          * library to save the new member size(specified in command line) in superblock.
          * This private property is for this tool only. */
         if (H5Pset_fapl_family(fapl, H5F_FAMILY_DEFAULT, H5P_DEFAULT) < 0) {
-            HDperror("H5Pset_fapl_family");
+            perror("H5Pset_fapl_family");
             exit(EXIT_FAILURE);
         }
 
         /* Set the property of the new member size as hsize_t */
         hdsize = (hsize_t)dst_size;
         if (H5Pset(fapl, H5F_ACS_FAMILY_NEWSIZE_NAME, &hdsize) < 0) {
-            HDperror("H5Pset");
+            perror("H5Pset");
             exit(EXIT_FAILURE);
         }
     }
@@ -476,13 +476,13 @@ main(int argc, char *argv[])
 
     if (file >= 0) {
         if (H5Fclose(file) < 0) {
-            HDperror("H5Fclose");
+            perror("H5Fclose");
             exit(EXIT_FAILURE);
         } /* end if */
     }     /* end if */
 
     if (H5Pclose(fapl) < 0) {
-        HDperror("H5Pclose");
+        perror("H5Pclose");
         exit(EXIT_FAILURE);
     } /* end if */
 

--- a/tools/test/h5diff/h5diffgentest.c
+++ b/tools/test/h5diff/h5diffgentest.c
@@ -333,16 +333,16 @@ onion_filepaths_init(const char *basename)
     if (NULL == (paths = calloc(1, sizeof(struct onion_filepaths))))
         goto error;
 
-    if (NULL == (paths->canon = HDstrdup(basename)))
+    if (NULL == (paths->canon = strdup(basename)))
         goto error;
 
     if (NULL == (paths->onion = malloc(sizeof(char) * ONION_TEST_FIXNAME_SIZE)))
         goto error;
-    HDsnprintf(paths->onion, ONION_TEST_FIXNAME_SIZE, "%s.onion", paths->canon);
+    snprintf(paths->onion, ONION_TEST_FIXNAME_SIZE, "%s.onion", paths->canon);
 
     if (NULL == (paths->recovery = malloc(sizeof(char) * ONION_TEST_FIXNAME_SIZE)))
         goto error;
-    HDsnprintf(paths->recovery, ONION_TEST_FIXNAME_SIZE, "%s.onion.recovery", paths->canon);
+    snprintf(paths->recovery, ONION_TEST_FIXNAME_SIZE, "%s.onion.recovery", paths->canon);
 
     return paths;
 
@@ -4262,35 +4262,35 @@ test_comp_vlen_strings(const char *fname1, const char *grp_name, int is_file_new
     comp9_buf.str_vlen = comp9_buf.str_vlen_repeat = vlen_str_buf;
 
     /* copy fixlen string data to compound buffers */
-    HDstrcpy(comp1_buf.str_fixlen, fixlen_str_buf);
-    HDstrcpy(comp1_buf.str_fixlen_repeat, fixlen_str_buf);
+    strcpy(comp1_buf.str_fixlen, fixlen_str_buf);
+    strcpy(comp1_buf.str_fixlen_repeat, fixlen_str_buf);
 
-    HDstrcpy(comp2_buf.str_fixlen, fixlen_str_buf);
-    HDstrcpy(comp2_buf.str_fixlen_repeat, fixlen_str_buf);
+    strcpy(comp2_buf.str_fixlen, fixlen_str_buf);
+    strcpy(comp2_buf.str_fixlen_repeat, fixlen_str_buf);
 
-    HDstrcpy(comp3_buf.str_fixlen, fixlen_str_buf);
-    HDstrcpy(comp3_buf.str_fixlen_repeat, fixlen_str_buf);
+    strcpy(comp3_buf.str_fixlen, fixlen_str_buf);
+    strcpy(comp3_buf.str_fixlen_repeat, fixlen_str_buf);
 
-    HDstrcpy(comp3_buf.str_fixlen, fixlen_str_buf);
-    HDstrcpy(comp3_buf.str_fixlen_repeat, fixlen_str_buf);
+    strcpy(comp3_buf.str_fixlen, fixlen_str_buf);
+    strcpy(comp3_buf.str_fixlen_repeat, fixlen_str_buf);
 
-    HDstrcpy(comp4_buf.str_fixlen, fixlen_str_buf);
-    HDstrcpy(comp4_buf.str_fixlen_repeat, fixlen_str_buf);
+    strcpy(comp4_buf.str_fixlen, fixlen_str_buf);
+    strcpy(comp4_buf.str_fixlen_repeat, fixlen_str_buf);
 
-    HDstrcpy(comp5_buf.str_fixlen, fixlen_str_buf);
-    HDstrcpy(comp5_buf.str_fixlen_repeat, fixlen_str_buf);
+    strcpy(comp5_buf.str_fixlen, fixlen_str_buf);
+    strcpy(comp5_buf.str_fixlen_repeat, fixlen_str_buf);
 
-    HDstrcpy(comp6_buf.str_fixlen, fixlen_str_buf);
-    HDstrcpy(comp6_buf.str_fixlen_repeat, fixlen_str_buf);
+    strcpy(comp6_buf.str_fixlen, fixlen_str_buf);
+    strcpy(comp6_buf.str_fixlen_repeat, fixlen_str_buf);
 
-    HDstrcpy(comp7_buf.str_fixlen, fixlen_str_buf);
-    HDstrcpy(comp7_buf.str_fixlen_repeat, fixlen_str_buf);
+    strcpy(comp7_buf.str_fixlen, fixlen_str_buf);
+    strcpy(comp7_buf.str_fixlen_repeat, fixlen_str_buf);
 
-    HDstrcpy(comp8_buf.str_fixlen, fixlen_str_buf);
-    HDstrcpy(comp8_buf.str_fixlen_repeat, fixlen_str_buf);
+    strcpy(comp8_buf.str_fixlen, fixlen_str_buf);
+    strcpy(comp8_buf.str_fixlen_repeat, fixlen_str_buf);
 
-    HDstrcpy(comp9_buf.str_fixlen, fixlen_str_buf);
-    HDstrcpy(comp9_buf.str_fixlen_repeat, fixlen_str_buf);
+    strcpy(comp9_buf.str_fixlen, fixlen_str_buf);
+    strcpy(comp9_buf.str_fixlen_repeat, fixlen_str_buf);
 
     /* copy vlen string array data to compound buffers */
     for (i = 0; i < VLEN_STR_ARRY_DIM; i++) {
@@ -4307,32 +4307,32 @@ test_comp_vlen_strings(const char *fname1, const char *grp_name, int is_file_new
 
     /* copy fixlen string attay data to compound buffers */
     for (i = 0; i < FIXLEN_STR_ARRY_DIM; i++) {
-        HDstrcpy(comp1_buf.str_array_fixlen[i], fixlen_str_array_buf[i]);
-        HDstrcpy(comp1_buf.str_fixlen_array_again[i], fixlen_str_array_buf[i]);
+        strcpy(comp1_buf.str_array_fixlen[i], fixlen_str_array_buf[i]);
+        strcpy(comp1_buf.str_fixlen_array_again[i], fixlen_str_array_buf[i]);
 
-        HDstrcpy(comp2_buf.str_array_fixlen[i], fixlen_str_array_buf[i]);
-        HDstrcpy(comp2_buf.str_fixlen_array_again[i], fixlen_str_array_buf[i]);
+        strcpy(comp2_buf.str_array_fixlen[i], fixlen_str_array_buf[i]);
+        strcpy(comp2_buf.str_fixlen_array_again[i], fixlen_str_array_buf[i]);
 
-        HDstrcpy(comp3_buf.str_array_fixlen[i], fixlen_str_array_buf[i]);
-        HDstrcpy(comp3_buf.str_fixlen_array_again[i], fixlen_str_array_buf[i]);
+        strcpy(comp3_buf.str_array_fixlen[i], fixlen_str_array_buf[i]);
+        strcpy(comp3_buf.str_fixlen_array_again[i], fixlen_str_array_buf[i]);
 
-        HDstrcpy(comp4_buf.str_array_fixlen[i], fixlen_str_array_buf[i]);
-        HDstrcpy(comp4_buf.str_fixlen_array_again[i], fixlen_str_array_buf[i]);
+        strcpy(comp4_buf.str_array_fixlen[i], fixlen_str_array_buf[i]);
+        strcpy(comp4_buf.str_fixlen_array_again[i], fixlen_str_array_buf[i]);
 
-        HDstrcpy(comp5_buf.str_array_fixlen[i], fixlen_str_array_buf[i]);
-        HDstrcpy(comp5_buf.str_fixlen_array_again[i], fixlen_str_array_buf[i]);
+        strcpy(comp5_buf.str_array_fixlen[i], fixlen_str_array_buf[i]);
+        strcpy(comp5_buf.str_fixlen_array_again[i], fixlen_str_array_buf[i]);
 
-        HDstrcpy(comp6_buf.str_array_fixlen[i], fixlen_str_array_buf[i]);
-        HDstrcpy(comp6_buf.str_fixlen_array_again[i], fixlen_str_array_buf[i]);
+        strcpy(comp6_buf.str_array_fixlen[i], fixlen_str_array_buf[i]);
+        strcpy(comp6_buf.str_fixlen_array_again[i], fixlen_str_array_buf[i]);
 
-        HDstrcpy(comp7_buf.str_array_fixlen[i], fixlen_str_array_buf[i]);
-        HDstrcpy(comp7_buf.str_fixlen_array_again[i], fixlen_str_array_buf[i]);
+        strcpy(comp7_buf.str_array_fixlen[i], fixlen_str_array_buf[i]);
+        strcpy(comp7_buf.str_fixlen_array_again[i], fixlen_str_array_buf[i]);
 
-        HDstrcpy(comp8_buf.str_array_fixlen[i], fixlen_str_array_buf[i]);
-        HDstrcpy(comp8_buf.str_fixlen_array_again[i], fixlen_str_array_buf[i]);
+        strcpy(comp8_buf.str_array_fixlen[i], fixlen_str_array_buf[i]);
+        strcpy(comp8_buf.str_fixlen_array_again[i], fixlen_str_array_buf[i]);
 
-        HDstrcpy(comp9_buf.str_array_fixlen[i], fixlen_str_array_buf[i]);
-        HDstrcpy(comp9_buf.str_fixlen_array_again[i], fixlen_str_array_buf[i]);
+        strcpy(comp9_buf.str_array_fixlen[i], fixlen_str_array_buf[i]);
+        strcpy(comp9_buf.str_fixlen_array_again[i], fixlen_str_array_buf[i]);
     }
 
     /* int data */

--- a/tools/test/h5dump/h5dumpgentest.c
+++ b/tools/test/h5dump/h5dumpgentest.c
@@ -588,7 +588,7 @@ gent_attribute(void)
     dims[0] = 24;
     space   = H5Screate_simple(1, dims, NULL);
     attr    = H5Acreate2(root, "/attr1", H5T_STD_I8BE, space, H5P_DEFAULT, H5P_DEFAULT);
-    HDsnprintf(buf, sizeof(buf), "attribute of root group");
+    snprintf(buf, sizeof(buf), "attribute of root group");
     H5Awrite(attr, H5T_NATIVE_SCHAR, buf);
     H5Sclose(space);
     H5Aclose(attr);
@@ -963,7 +963,7 @@ gent_udlink(void)
     /* This ud link will dangle, but that's okay */
     fid = H5Fcreate(FILE54, H5F_ACC_TRUNC, H5P_DEFAULT, H5P_DEFAULT);
     H5Lcreate_ud(fid, "udlink1", (H5L_type_t)MY_LINKCLASS, NULL, 0, H5P_DEFAULT, H5P_DEFAULT);
-    HDstrcpy(buf, "foo");
+    strcpy(buf, "foo");
     H5Lcreate_ud(fid, "udlink2", (H5L_type_t)MY_LINKCLASS, buf, 4, H5P_DEFAULT, H5P_DEFAULT);
 
     H5Fclose(fid);
@@ -1386,7 +1386,7 @@ gent_all(void)
     dims[0] = 10;
     space   = H5Screate_simple(1, dims, NULL);
     attr    = H5Acreate2(group, "attr1", H5T_STD_I8BE, space, H5P_DEFAULT, H5P_DEFAULT);
-    HDsnprintf(buf, sizeof(buf), "abcdefghi");
+    snprintf(buf, sizeof(buf), "abcdefghi");
     H5Awrite(attr, H5T_NATIVE_SCHAR, buf);
     H5Sclose(space);
     H5Aclose(attr);
@@ -1422,7 +1422,7 @@ gent_all(void)
     dims[0] = 27;
     space   = H5Screate_simple(1, dims, NULL);
     attr    = H5Acreate2(dataset, "attr1", H5T_STD_I8BE, space, H5P_DEFAULT, H5P_DEFAULT);
-    HDsnprintf(buf, sizeof(buf), "1st attribute of dset1.1.1");
+    snprintf(buf, sizeof(buf), "1st attribute of dset1.1.1");
     H5Awrite(attr, H5T_NATIVE_SCHAR, buf);
     H5Sclose(space);
     H5Aclose(attr);
@@ -1430,7 +1430,7 @@ gent_all(void)
     dims[0] = 27;
     space   = H5Screate_simple(1, dims, NULL);
     attr    = H5Acreate2(dataset, "attr2", H5T_STD_I8BE, space, H5P_DEFAULT, H5P_DEFAULT);
-    HDsnprintf(buf, sizeof(buf), "2nd attribute of dset1.1.1");
+    snprintf(buf, sizeof(buf), "2nd attribute of dset1.1.1");
     H5Awrite(attr, H5T_NATIVE_SCHAR, buf);
     H5Sclose(space);
     H5Aclose(attr);
@@ -1629,7 +1629,7 @@ gent_many(void)
     dims[0] = 10;
     space2  = H5Screate_simple(1, dims, NULL);
     attr    = H5Acreate2(dataset, "attr1", H5T_STD_I8BE, space2, H5P_DEFAULT, H5P_DEFAULT);
-    HDsnprintf(buf, sizeof(buf), "abcdefghi");
+    snprintf(buf, sizeof(buf), "abcdefghi");
     H5Awrite(attr, H5T_NATIVE_CHAR, buf);
     H5Sclose(space2);
     H5Aclose(attr);
@@ -1894,7 +1894,7 @@ gent_str(void)
                 for (l = 0; l < 10; l++)
                     comp1[i][j].a[k][l] = (l + j + k) * (l + j + k);
             for (k = 0; k < 12; k++)
-                HDstrcpy(comp1[i][j].s[k], "abcdefgh12345678abcdefgh12345678");
+                strcpy(comp1[i][j].s[k], "abcdefgh12345678abcdefgh12345678");
         }
 
     dataset = H5Dcreate2(fid, "/comp1", f_type, space, H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT);
@@ -1967,9 +1967,9 @@ gent_str2(void)
     dims[0] = 3;
     space2  = H5Screate_simple(1, dims, NULL);
     attr    = H5Acreate2(dataset, "attr1", fxdlenstr2, space2, H5P_DEFAULT, H5P_DEFAULT);
-    HDsnprintf(&(buf2[0 * LENSTR2]), LENSTR2, "0123456789");
-    HDsnprintf(&(buf2[1 * LENSTR2]), LENSTR2, "abcdefghij");
-    HDsnprintf(&(buf2[2 * LENSTR2]), LENSTR2, "ABCDEFGHIJ");
+    snprintf(&(buf2[0 * LENSTR2]), LENSTR2, "0123456789");
+    snprintf(&(buf2[1 * LENSTR2]), LENSTR2, "abcdefghij");
+    snprintf(&(buf2[2 * LENSTR2]), LENSTR2, "ABCDEFGHIJ");
     H5Awrite(attr, fxdlenstr2, buf2);
     H5Sclose(space2);
     H5Tclose(fxdlenstr2);
@@ -1981,8 +1981,8 @@ gent_str2(void)
 
     for (i = 0; (hsize_t)i < sdim; i++) {
         start[0] = (hsize_t)i;
-        HDsnprintf(buf, sizeof(buf), "This is row %1d of type H5T_STR_NULLTERM of", i);
-        H5Tset_size(memtype, HDstrlen(buf) + 1);
+        snprintf(buf, sizeof(buf), "This is row %1d of type H5T_STR_NULLTERM of", i);
+        H5Tset_size(memtype, strlen(buf) + 1);
         H5Sselect_hyperslab(hyper_space, H5S_SELECT_SET, start, stride, count, block);
         H5Dwrite(dataset, memtype, mem_space, hyper_space, H5P_DEFAULT, buf);
     }
@@ -1994,8 +1994,8 @@ gent_str2(void)
 
     for (i = 0; (hsize_t)i < sdim; i++) {
         start[0] = (hsize_t)i;
-        HDsnprintf(buf, sizeof(buf), "This is row %1d of type H5T_STR_NULLTERM of string array", i);
-        H5Tset_size(memtype, HDstrlen(buf) + 1);
+        snprintf(buf, sizeof(buf), "This is row %1d of type H5T_STR_NULLTERM of string array", i);
+        H5Tset_size(memtype, strlen(buf) + 1);
         H5Sselect_hyperslab(hyper_space, H5S_SELECT_SET, start, stride, count, block);
         H5Dwrite(dataset, memtype, mem_space, hyper_space, H5P_DEFAULT, buf);
     }
@@ -2013,8 +2013,8 @@ gent_str2(void)
 
     for (i = 0; (hsize_t)i < sdim; i++) {
         start[0] = (hsize_t)i;
-        HDsnprintf(buf, sizeof(buf), "This is row %1d of type H5T_STR_NULLPAD of", i);
-        H5Tset_size(memtype, HDstrlen(buf) + 1);
+        snprintf(buf, sizeof(buf), "This is row %1d of type H5T_STR_NULLPAD of", i);
+        H5Tset_size(memtype, strlen(buf) + 1);
         H5Sselect_hyperslab(hyper_space, H5S_SELECT_SET, start, stride, count, block);
         H5Dwrite(dataset, memtype, mem_space, hyper_space, H5P_DEFAULT, buf);
     }
@@ -2026,8 +2026,8 @@ gent_str2(void)
 
     for (i = 0; (hsize_t)i < sdim; i++) {
         start[0] = (hsize_t)i;
-        HDsnprintf(buf, sizeof(buf), "This is row %1d of type H5T_STR_NULLPAD of string array", i);
-        H5Tset_size(memtype, HDstrlen(buf) + 1);
+        snprintf(buf, sizeof(buf), "This is row %1d of type H5T_STR_NULLPAD of string array", i);
+        H5Tset_size(memtype, strlen(buf) + 1);
         H5Sselect_hyperslab(hyper_space, H5S_SELECT_SET, start, stride, count, block);
         H5Dwrite(dataset, memtype, mem_space, hyper_space, H5P_DEFAULT, buf);
     }
@@ -2045,8 +2045,8 @@ gent_str2(void)
 
     for (i = 0; (hsize_t)i < sdim; i++) {
         start[0] = (hsize_t)i;
-        HDsnprintf(buf, sizeof(buf), "This is row %1d of type H5T_STR_SPACEPAD of", i);
-        H5Tset_size(memtype, HDstrlen(buf) + 1);
+        snprintf(buf, sizeof(buf), "This is row %1d of type H5T_STR_SPACEPAD of", i);
+        H5Tset_size(memtype, strlen(buf) + 1);
         H5Sselect_hyperslab(hyper_space, H5S_SELECT_SET, start, stride, count, block);
         H5Dwrite(dataset, memtype, mem_space, hyper_space, H5P_DEFAULT, buf);
     }
@@ -2058,8 +2058,8 @@ gent_str2(void)
 
     for (i = 0; (hsize_t)i < sdim; i++) {
         start[0] = (hsize_t)i;
-        HDsnprintf(buf, sizeof(buf), "This is row %1d of type H5T_STR_SPACEPAD of string array", i);
-        H5Tset_size(memtype, HDstrlen(buf) + 1);
+        snprintf(buf, sizeof(buf), "This is row %1d of type H5T_STR_SPACEPAD of string array", i);
+        H5Tset_size(memtype, strlen(buf) + 1);
         H5Sselect_hyperslab(hyper_space, H5S_SELECT_SET, start, stride, count, block);
         H5Dwrite(dataset, memtype, mem_space, hyper_space, H5P_DEFAULT, buf);
     }
@@ -3790,7 +3790,7 @@ gent_split_file(void)
     root = H5Gopen2(fid, "/", H5P_DEFAULT);
 
     atype = H5Tcopy(H5T_C_S1);
-    H5Tset_size(atype, HDstrlen(meta) + 1);
+    H5Tset_size(atype, strlen(meta) + 1);
     H5Tset_strpad(atype, H5T_STR_NULLTERM);
 
     dims[0] = 1;
@@ -3879,12 +3879,12 @@ gent_multi(void)
     memset(memb_name, 0, sizeof memb_name);
     memset(memb_addr, 0, sizeof memb_addr);
 
-    assert(HDstrlen(multi_letters) == H5FD_MEM_NTYPES);
+    assert(strlen(multi_letters) == H5FD_MEM_NTYPES);
 
     for (mt = H5FD_MEM_DEFAULT; mt < H5FD_MEM_NTYPES; mt++) {
         memb_fapl[mt] = H5P_DEFAULT;
         memb_map[mt]  = mt;
-        HDsprintf(sv[mt], "%%s-%c.h5", multi_letters[mt]);
+        sprintf(sv[mt], "%%s-%c.h5", multi_letters[mt]);
         memb_name[mt] = sv[mt];
         /*printf("memb_name[%d]=%s, memb_map[%d]=%d; ", mt, memb_name[mt], mt, memb_map[mt]);*/
         memb_addr[mt] = (haddr_t)MAX(mt - 1, 0) * (HADDR_MAX / 10);
@@ -3928,7 +3928,7 @@ gent_large_objname(void)
     group = H5Gcreate2(fid, "this_is_a_large_group_name", H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT);
 
     for (i = 0; i < 50; ++i) {
-        HDsnprintf(grp_name, sizeof(grp_name), "this_is_a_large_group_name%d", i);
+        snprintf(grp_name, sizeof(grp_name), "this_is_a_large_group_name%d", i);
         group2 = H5Gcreate2(group, grp_name, H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT);
         H5Gclose(group2);
     }
@@ -3999,7 +3999,7 @@ gent_char(void)
     hid_t       sid1;    /* Dataspace ID     */
     hsize_t     dims1[1];
 
-    dims1[0] = HDstrlen(wdata);
+    dims1[0] = strlen(wdata);
 
     /* Create file */
     fid1 = H5Fcreate(FILE39, H5F_ACC_TRUNC, H5P_DEFAULT, H5P_DEFAULT);
@@ -10877,10 +10877,10 @@ gent_compound_complex2(void)
                     /* Set up first nested compound */
                     buf[i].d.nested_a = (double)i;
 
-                    HDstrcpy(buf[i].d.nested_string, "This is a test string.");
+                    strcpy(buf[i].d.nested_string, "This is a test string.");
 
                     for (j = 0; j < 4; j++)
-                        HDstrcpy(buf[i].d.nested_string_array[j], "String test");
+                        strcpy(buf[i].d.nested_string_array[j], "String test");
 
                     /* Set up multiple nested compound */
                     buf[i].e.a = (float)i;
@@ -10892,9 +10892,9 @@ gent_compound_complex2(void)
                         buf[i].e.b.multiple_nested_d[j] = (long)(j - i * 10);
                     }
 
-                    HDstrcpy(buf[i].e.c.further_nested_string, "1234567890");
+                    strcpy(buf[i].e.c.further_nested_string, "1234567890");
                     for (j = 0; j < 4; j++)
-                        HDstrcpy(buf[i].e.c.further_nested_string_array[j], "STRING ARRAY");
+                        strcpy(buf[i].e.c.further_nested_string_array[j], "STRING ARRAY");
 
                     for (j = 0; j < 10; j++) {
                         buf[i].e.c.deep_nest.deep_nested_short[j]  = (short)(j + i * 10);
@@ -11346,16 +11346,16 @@ onion_filepaths_init(const char *basename)
     if (NULL == (paths = calloc(1, sizeof(struct onion_filepaths))))
         goto error;
 
-    if (NULL == (paths->canon = HDstrdup(basename)))
+    if (NULL == (paths->canon = strdup(basename)))
         goto error;
 
     if (NULL == (paths->onion = malloc(sizeof(char) * ONION_TEST_FIXNAME_SIZE)))
         goto error;
-    HDsnprintf(paths->onion, ONION_TEST_FIXNAME_SIZE, "%s.onion", paths->canon);
+    snprintf(paths->onion, ONION_TEST_FIXNAME_SIZE, "%s.onion", paths->canon);
 
     if (NULL == (paths->recovery = malloc(sizeof(char) * ONION_TEST_FIXNAME_SIZE)))
         goto error;
-    HDsnprintf(paths->recovery, ONION_TEST_FIXNAME_SIZE, "%s.onion.recovery", paths->canon);
+    snprintf(paths->recovery, ONION_TEST_FIXNAME_SIZE, "%s.onion.recovery", paths->canon);
 
     return paths;
 

--- a/tools/test/h5format_convert/h5fc_chk_idx.c
+++ b/tools/test/h5format_convert/h5fc_chk_idx.c
@@ -55,8 +55,8 @@ main(int argc, char *argv[])
     } /* end if */
 
     /* Duplicate the file name  & dataset name */
-    fname = HDstrdup(argv[1]);
-    dname = HDstrdup(argv[2]);
+    fname = strdup(argv[1]);
+    dname = strdup(argv[2]);
 
     /* Try opening the file */
     if ((fid = h5tools_fopen(fname, H5F_ACC_RDONLY, H5P_DEFAULT, false, NULL, (size_t)0)) < 0) {

--- a/tools/test/h5format_convert/h5fc_gentest.c
+++ b/tools/test/h5format_convert/h5fc_gentest.c
@@ -799,8 +799,8 @@ main(void)
 
             memset(filename, 0, sizeof(filename));
             if (!new_format)
-                HDstrcat(filename, "old_");
-            HDstrcat(filename, FILENAME[i]);
+                strcat(filename, "old_");
+            strcat(filename, FILENAME[i]);
 
             gen_ext(filename, new_format, i);
         } /* end for */

--- a/tools/test/h5import/h5importtest.c
+++ b/tools/test/h5import/h5importtest.c
@@ -68,9 +68,9 @@ main(void)
     volatile uint32_t ibyte = 0x01234567;
     /* 0 for big endian, 1 for little endian. */
     if ((*((volatile uint8_t *)(&ibyte))) == 0x67)
-        HDstrcpy(machine_order, "LE");
+        strcpy(machine_order, "LE");
     else
-        HDstrcpy(machine_order, "BE");
+        strcpy(machine_order, "BE");
 
     /*
      * initialize the row, column, and plane vectors

--- a/tools/test/h5jam/getub.c
+++ b/tools/test/h5jam/getub.c
@@ -59,7 +59,7 @@ parse_command_line(int argc, const char *const *argv)
     while ((opt = H5_get_option(argc, argv, s_opts, l_opts)) != EOF) {
         switch ((char)opt) {
             case 'c':
-                nbytes = HDstrdup(H5_optarg);
+                nbytes = strdup(H5_optarg);
                 break;
             case '?':
             default:
@@ -105,10 +105,10 @@ main(int argc, char *argv[])
         goto error;
     } /* end if */
 
-    filename = HDstrdup(argv[H5_optind]);
+    filename = strdup(argv[H5_optind]);
 
     size = 0;
-    if (EOF == (res = HDsscanf(nbytes, "%u", &size))) {
+    if (EOF == (res = sscanf(nbytes, "%u", &size))) {
         /* fail */
         error_msg("missing file name\n");
         usage(h5tools_getprogname());

--- a/tools/test/h5jam/h5jamgentest.c
+++ b/tools/test/h5jam/h5jamgentest.c
@@ -151,7 +151,7 @@ gent_ub(const char *filename, size_t ub_size, size_t ub_fill)
         goto error;
     if ((attr = H5Acreate2(group, "attr1", H5T_STD_I8BE, space, H5P_DEFAULT, H5P_DEFAULT)) < 0)
         goto error;
-    if (HDsnprintf(buf, sizeof(buf), "abcdefghi") < 0)
+    if (snprintf(buf, sizeof(buf), "abcdefghi") < 0)
         goto error;
     if (H5Awrite(attr, H5T_NATIVE_SCHAR, buf) < 0)
         goto error;
@@ -205,7 +205,7 @@ gent_ub(const char *filename, size_t ub_size, size_t ub_fill)
         goto error;
     if ((attr = H5Acreate2(dataset, "attr1", H5T_STD_I8BE, space, H5P_DEFAULT, H5P_DEFAULT)) < 0)
         goto error;
-    if (HDsnprintf(buf, sizeof(buf), "1st attribute of dset1.1.1") < 0)
+    if (snprintf(buf, sizeof(buf), "1st attribute of dset1.1.1") < 0)
         goto error;
     if (H5Awrite(attr, H5T_NATIVE_SCHAR, buf) < 0)
         goto error;
@@ -219,7 +219,7 @@ gent_ub(const char *filename, size_t ub_size, size_t ub_fill)
         goto error;
     if ((attr = H5Acreate2(dataset, "attr2", H5T_STD_I8BE, space, H5P_DEFAULT, H5P_DEFAULT)) < 0)
         goto error;
-    if (HDsnprintf(buf, sizeof(buf), "2nd attribute of dset1.1.1") < 0)
+    if (snprintf(buf, sizeof(buf), "2nd attribute of dset1.1.1") < 0)
         goto error;
     if (H5Awrite(attr, H5T_NATIVE_SCHAR, buf) < 0)
         goto error;
@@ -412,7 +412,7 @@ main(void)
 
     if (gent_ub(FILE7, 0, 0) < 0)
         goto error;
-    if (gent_ub(FILE8, 512, HDstrlen(pattern)) < 0)
+    if (gent_ub(FILE8, 512, strlen(pattern)) < 0)
         goto error;
     if (gent_ub(FILE9, 1024, 513) < 0)
         goto error;

--- a/tools/test/h5jam/tellub.c
+++ b/tools/test/h5jam/tellub.c
@@ -124,7 +124,7 @@ main(int argc, char *argv[])
         goto done;
     }
 
-    ifname = HDstrdup(argv[H5_optind]);
+    ifname = strdup(argv[H5_optind]);
 
     testval = H5Fis_accessible(ifname, H5P_DEFAULT);
 

--- a/tools/test/h5repack/h5repackgentest.c
+++ b/tools/test/h5repack/h5repackgentest.c
@@ -115,7 +115,7 @@ set_dcpl_external_list(hid_t dcpl, const char *filename, unsigned n_elts_per_fil
         return -1;
 
     for (i = 0; i < n_external_files; i++) {
-        if (HDsnprintf(name, MAX_NAME_SIZE, "%s_ex-%u.dat", filename, i) >= MAX_NAME_SIZE)
+        if (snprintf(name, MAX_NAME_SIZE, "%s_ex-%u.dat", filename, i) >= MAX_NAME_SIZE)
             return -1;
 
         if (H5Pset_external(dcpl, name, 0, n_elts_per_file * elt_size) < 0)
@@ -140,7 +140,7 @@ make_file(const char *basename, struct external_def *ext, hid_t type_id, hsize_t
     hid_t space_id  = H5I_INVALID_HID;
     int   ret_value = 0;
 
-    if (HDsnprintf(filename, MAX_NAME_SIZE, "%s%s.h5", basename, (NULL != ext) ? "_ex" : "") >= MAX_NAME_SIZE)
+    if (snprintf(filename, MAX_NAME_SIZE, "%s%s.h5", basename, (NULL != ext) ? "_ex" : "") >= MAX_NAME_SIZE)
         H5REPACKGENTEST_OOPS;
 
     if (NULL != ext) {

--- a/tools/test/h5repack/h5repacktst.c
+++ b/tools/test/h5repack/h5repacktst.c
@@ -3186,7 +3186,7 @@ make_early(void)
             goto out;
         if ((tid = H5Tcopy(H5T_NATIVE_DOUBLE)) < 0)
             goto out;
-        HDsnprintf(name, sizeof(name), "%d", i);
+        snprintf(name, sizeof(name), "%d", i);
         if ((H5Tcommit2(fid, name, tid, H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT)) < 0)
             goto out;
         if (H5Tclose(tid) < 0)
@@ -3210,7 +3210,7 @@ make_early(void)
     for (i = 0; i < iter; i++) {
         if ((tid = H5Tcopy(H5T_NATIVE_DOUBLE)) < 0)
             goto out;
-        HDsnprintf(name, sizeof(name), "%d", i);
+        snprintf(name, sizeof(name), "%d", i);
         if ((H5Tcommit2(fid, name, tid, H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT)) < 0)
             goto out;
         if (H5Tclose(tid) < 0)
@@ -3269,7 +3269,7 @@ make_layout(hid_t loc_id)
      *-------------------------------------------------------------------------
      */
     for (i = 0; i < 4; i++) {
-        HDsnprintf(name, sizeof(name), "dset%d", i + 1);
+        snprintf(name, sizeof(name), "dset%d", i + 1);
         if (write_dset(loc_id, RANK, dims, name, H5T_NATIVE_INT, buf) < 0)
             goto error;
     }

--- a/tools/test/h5stat/h5stat_gentest.c
+++ b/tools/test/h5stat/h5stat_gentest.c
@@ -87,7 +87,7 @@ gen_newgrat_file(const char *fname)
 
     /* Create NUM_GRPS groups in the root group */
     for (i = 1; i <= NUM_GRPS; i++) {
-        HDsnprintf(name, sizeof(name), "%s%d", GROUP_NAME, i);
+        snprintf(name, sizeof(name), "%s%d", GROUP_NAME, i);
         if ((gid = H5Gcreate2(fid, name, H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT)) < 0)
             goto error;
         if (H5Gclose(gid) < 0)
@@ -108,7 +108,7 @@ gen_newgrat_file(const char *fname)
 
     /* Create NUM_ATTRS for the dataset */
     for (i = 1; i <= NUM_ATTRS; i++) {
-        HDsnprintf(attrname, sizeof(attrname), "%s%d", ATTR_NAME, i);
+        snprintf(attrname, sizeof(attrname), "%s%d", ATTR_NAME, i);
         if ((attr_id = H5Acreate2(did, attrname, tid, sid, H5P_DEFAULT, H5P_DEFAULT)) < 0)
             goto error;
         if (H5Aclose(attr_id) < 0)
@@ -210,7 +210,7 @@ gen_threshold_file(const char *fname)
 
     /* Create 11 attributes for the dataset */
     for (i = 1; i <= (THRES_NUM + 1); i++) {
-        HDsnprintf(name, sizeof(name), "%s%d", THRES_ATTR_NAME, i);
+        snprintf(name, sizeof(name), "%s%d", THRES_ATTR_NAME, i);
         if ((attr_id = H5Acreate2(did, name, H5T_NATIVE_INT, sid1, H5P_DEFAULT, H5P_DEFAULT)) < 0)
             goto error;
         if (H5Aclose(attr_id) < 0)
@@ -239,7 +239,7 @@ gen_threshold_file(const char *fname)
 
     /* Create 10 attributes for the 2-D dataset */
     for (i = 1; i <= THRES_NUM; i++) {
-        HDsnprintf(name, sizeof(name), "%s%d", THRES_ATTR_NAME, i);
+        snprintf(name, sizeof(name), "%s%d", THRES_ATTR_NAME, i);
         if ((attr_id = H5Acreate2(did, name, H5T_NATIVE_INT, sid1, H5P_DEFAULT, H5P_DEFAULT)) < 0)
             goto error;
         if (H5Aclose(attr_id) < 0)
@@ -263,7 +263,7 @@ gen_threshold_file(const char *fname)
     /* Create 10 1-D datasets with non-zero dimension size for the group */
     for (i = 1; i <= THRES_NUM; i++) {
         /* set up dataset name */
-        HDsnprintf(name, sizeof(name), "%s%d", THRES_DSET_NAME, i);
+        snprintf(name, sizeof(name), "%s%d", THRES_DSET_NAME, i);
 
         /* Create the dataset */
         if ((did = H5Dcreate2(gid, name, H5T_NATIVE_UCHAR, sid1, H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT)) < 0)
@@ -285,7 +285,7 @@ gen_threshold_file(const char *fname)
     /* Create 25 attributes for the group */
     for (i = 1; i <= THRES_NUM_25; i++) {
         /* Set up attribute name */
-        HDsnprintf(name, sizeof(name), "%s%d", THRES_ATTR_GRP_NAME, i);
+        snprintf(name, sizeof(name), "%s%d", THRES_ATTR_GRP_NAME, i);
 
         /* Create the attribute */
         if ((attr_id = H5Acreate2(gid, name, H5T_NATIVE_INT, sid2, H5P_DEFAULT, H5P_DEFAULT)) < 0)
@@ -307,7 +307,7 @@ gen_threshold_file(const char *fname)
     /* Create 9 1-D datasets with non-zero dimension size for the group */
     for (i = 1; i < THRES_NUM; i++) {
         /* set up dataset name */
-        HDsnprintf(name, sizeof(name), "%s%d", THRES_DSET_NAME, i);
+        snprintf(name, sizeof(name), "%s%d", THRES_DSET_NAME, i);
 
         /* Create the dataset */
         if ((did = H5Dcreate2(gid, name, H5T_NATIVE_UCHAR, sid1, H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT)) < 0)

--- a/tools/test/misc/clear_open_chk.c
+++ b/tools/test/misc/clear_open_chk.c
@@ -47,7 +47,7 @@ main(int argc, char *argv[])
     }
 
     /* Get the file name */
-    fname = HDstrdup(argv[1]);
+    fname = strdup(argv[1]);
 
     /* Try opening the file */
     if ((fid = h5tools_fopen(fname, H5F_ACC_RDONLY, H5P_DEFAULT, false, NULL, (size_t)0)) < 0) {

--- a/tools/test/misc/h5clear_gentest.c
+++ b/tools/test/misc/h5clear_gentest.c
@@ -421,7 +421,7 @@ main(void)
         if ((my_fapl = H5Pcopy(fapl2)) < 0)
             goto error;
         /* Create the file */
-        HDsnprintf(fname, sizeof(fname), "%s%s", new_format ? "latest_" : "", FILENAME[0]);
+        snprintf(fname, sizeof(fname), "%s%s", new_format ? "latest_" : "", FILENAME[0]);
         if ((fid = H5Fcreate(fname, H5F_ACC_TRUNC | (new_format ? 0 : H5F_ACC_SWMR_WRITE), H5P_DEFAULT,
                              my_fapl)) < 0)
             goto error;
@@ -446,7 +446,7 @@ main(void)
             goto error;
 
         /* Create the file */
-        HDsnprintf(fname, sizeof(fname), "%s%s", new_format ? "latest_" : "", FILENAME[1]);
+        snprintf(fname, sizeof(fname), "%s%s", new_format ? "latest_" : "", FILENAME[1]);
         if ((fid = H5Fcreate(fname, H5F_ACC_TRUNC | (new_format ? 0 : H5F_ACC_SWMR_WRITE), H5P_DEFAULT,
                              my_fapl)) < 0)
             goto error;

--- a/tools/test/misc/h5perf_gentest.c
+++ b/tools/test/misc/h5perf_gentest.c
@@ -103,7 +103,7 @@ main(int argc, char *argv[])
     }
 
     if (strlen(fname) <= 0)
-        HDsnprintf(fname, sizeof(fname), FNAME);
+        snprintf(fname, sizeof(fname), FNAME);
 
     create_perf_test_file(fname, ngrps, ndsets, nattrs, (hsize_t)nrows, (hsize_t)dim0, (hsize_t)chunk, vlen,
                           z, l);
@@ -322,7 +322,7 @@ create_perf_test_file(const char *fname, int ngrps, int ndsets, int nattrs, hsiz
         fid = H5Fcreate(fname, H5F_ACC_TRUNC, H5P_DEFAULT, H5P_DEFAULT);
     add_attrs(fid, 0);
 
-    HDsnprintf(name, sizeof(name), "a cmp ds of %d rows", nrows);
+    snprintf(name, sizeof(name), "a cmp ds of %d rows", nrows);
     did = H5Dcreate(fid, name, cmp_tid, sid_large, H5P_DEFAULT, dcpl, H5P_DEFAULT);
     H5Dwrite(did, cmp_tid, H5S_ALL, H5S_ALL, H5P_DEFAULT, buf_comp_large);
     add_attrs(did, 0);
@@ -342,7 +342,7 @@ create_perf_test_file(const char *fname, int ngrps, int ndsets, int nattrs, hsiz
     add_attrs(gid1, 0);
     for (i = 0; i < ngrps; i++) {
         /* create sub groups */
-        HDsnprintf(name, sizeof(name), "g%02d", i);
+        snprintf(name, sizeof(name), "g%02d", i);
         gid2 = H5Gcreate(gid1, name, H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT);
         if (i < 10)
             add_attrs(gid2, 0);
@@ -355,14 +355,14 @@ create_perf_test_file(const char *fname, int ngrps, int ndsets, int nattrs, hsiz
     add_attrs(gid1, 0);
     for (j = 0; j < ndsets; j += 12) {
         /* 1 add a null dataset */
-        HDsnprintf(name, sizeof(name), "%05d null dataset", j);
+        snprintf(name, sizeof(name), "%05d null dataset", j);
         did = H5Dcreate(gid1, name, H5T_STD_I32LE, sid_null, H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT);
         if (!j)
             add_attrs(did, j);
         H5Dclose(did);
 
         /* 2 add scalar int point */
-        HDsnprintf(name, sizeof(name), "%05d scalar int point", j);
+        snprintf(name, sizeof(name), "%05d scalar int point", j);
         did = H5Dcreate(gid1, name, H5T_NATIVE_INT, sid_scalar, H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT);
         H5Dwrite(did, H5T_NATIVE_INT, H5S_ALL, H5S_ALL, H5P_DEFAULT, &j);
         if (!j)
@@ -370,7 +370,7 @@ create_perf_test_file(const char *fname, int ngrps, int ndsets, int nattrs, hsiz
         H5Dclose(did);
 
         /* 3 scalar vlen string */
-        HDsnprintf(name, sizeof(name), "%05d scalar vlen string", j);
+        snprintf(name, sizeof(name), "%05d scalar vlen string", j);
         did = H5Dcreate(gid1, name, tid_vlen_s, sid_scalar, H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT);
         H5Dwrite(did, tid_vlen_s, H5S_ALL, H5S_ALL, H5P_DEFAULT, &buf_vlen_s[0]);
         if (!j)
@@ -378,7 +378,7 @@ create_perf_test_file(const char *fname, int ngrps, int ndsets, int nattrs, hsiz
         H5Dclose(did);
 
         /* 4 add fixed-length float array */
-        HDsnprintf(name, sizeof(name), "%05d fixed-length float array", j);
+        snprintf(name, sizeof(name), "%05d fixed-length float array", j);
         did = H5Dcreate(gid1, name, tid_array_f, sid_1d, H5P_DEFAULT, dcpl, H5P_DEFAULT);
         H5Dwrite(did, tid_array_f, H5S_ALL, H5S_ALL, H5P_DEFAULT, buf_float_a);
         if (!j)
@@ -386,7 +386,7 @@ create_perf_test_file(const char *fname, int ngrps, int ndsets, int nattrs, hsiz
         H5Dclose(did);
 
         /* 5 add fixed-length strings */
-        HDsnprintf(name, sizeof(name), "%05d fixed-length strings", j);
+        snprintf(name, sizeof(name), "%05d fixed-length strings", j);
         did = H5Dcreate(gid1, name, tid_str, sid_1d, H5P_DEFAULT, dcpl, H5P_DEFAULT);
         H5Dwrite(did, tid_str, H5S_ALL, H5S_ALL, H5P_DEFAULT, buf_str);
         if (!j)
@@ -394,7 +394,7 @@ create_perf_test_file(const char *fname, int ngrps, int ndsets, int nattrs, hsiz
         H5Dclose(did);
 
         /* 6 add compound data */
-        HDsnprintf(name, sizeof(name), "%05d compound data", j);
+        snprintf(name, sizeof(name), "%05d compound data", j);
         did = H5Dcreate(gid1, name, cmp_tid, sid_1d, H5P_DEFAULT, dcpl, H5P_DEFAULT);
         H5Dwrite(did, cmp_tid, H5S_ALL, H5S_ALL, H5P_DEFAULT, buf_comp);
         if (!j)
@@ -402,7 +402,7 @@ create_perf_test_file(const char *fname, int ngrps, int ndsets, int nattrs, hsiz
         H5Dclose(did);
 
         /* 7 add 2D double */
-        HDsnprintf(name, sizeof(name), "%05d 2D double", j);
+        snprintf(name, sizeof(name), "%05d 2D double", j);
         strcpy(tmp_name1, name);
         did = H5Dcreate(gid1, name, H5T_NATIVE_DOUBLE, sid_2d, H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT);
         H5Dwrite(did, H5T_NATIVE_DOUBLE, H5S_ALL, H5S_ALL, H5P_DEFAULT, buf_double2d[0]);
@@ -411,7 +411,7 @@ create_perf_test_file(const char *fname, int ngrps, int ndsets, int nattrs, hsiz
         H5Dclose(did);
 
         /* 8 add 1D int array */
-        HDsnprintf(name, sizeof(name), "%05d 1D int array", j);
+        snprintf(name, sizeof(name), "%05d 1D int array", j);
         did = H5Dcreate(gid1, name, H5T_NATIVE_INT, sid_1d, H5P_DEFAULT, dcpl, H5P_DEFAULT);
         H5Dwrite(did, H5T_NATIVE_INT, H5S_ALL, H5S_ALL, H5P_DEFAULT, buf_int);
         if (!j)
@@ -419,7 +419,7 @@ create_perf_test_file(const char *fname, int ngrps, int ndsets, int nattrs, hsiz
         H5Dclose(did);
 
         /* 9 add vlen int array */
-        HDsnprintf(name, sizeof(name), "%05d vlen int array", j);
+        snprintf(name, sizeof(name), "%05d vlen int array", j);
         strcpy(tmp_name2, name);
         did = H5Dcreate(gid1, name, tid_vlen_i, sid_1d, H5P_DEFAULT, dcpl, H5P_DEFAULT);
         H5Dwrite(did, tid_vlen_i, H5S_ALL, H5S_ALL, H5P_DEFAULT, buf_vlen_i);
@@ -428,7 +428,7 @@ create_perf_test_file(const char *fname, int ngrps, int ndsets, int nattrs, hsiz
         H5Dclose(did);
 
         /* 10 add vlen strings */
-        HDsnprintf(name, sizeof(name), "%05d vlen strings", j);
+        snprintf(name, sizeof(name), "%05d vlen strings", j);
         strcpy(tmp_name3, name);
         did = H5Dcreate(gid1, name, tid_vlen_s, sid_1d, H5P_DEFAULT, dcpl, H5P_DEFAULT);
         H5Dwrite(did, tid_vlen_s, H5S_ALL, H5S_ALL, H5P_DEFAULT, buf_vlen_s);
@@ -439,7 +439,7 @@ create_perf_test_file(const char *fname, int ngrps, int ndsets, int nattrs, hsiz
         /* 11 add object refs */
         H5Rcreate(&buf_ref[0], gid1, ".", H5R_OBJECT, (hid_t)-1);
         H5Rcreate(&buf_ref[1], gid1, tmp_name3, H5R_OBJECT, (hid_t)-1);
-        HDsnprintf(name, sizeof(name), "%05d obj refs", j);
+        snprintf(name, sizeof(name), "%05d obj refs", j);
         did = H5Dcreate(gid1, name, H5T_STD_REF_OBJ, sid_2, H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT);
         H5Dwrite(did, H5T_STD_REF_OBJ, H5S_ALL, H5S_ALL, H5P_DEFAULT, buf_ref);
         if (!j)
@@ -454,7 +454,7 @@ create_perf_test_file(const char *fname, int ngrps, int ndsets, int nattrs, hsiz
         H5Sselect_hyperslab(sid_1d, H5S_SELECT_SET, &start, &stride, &count, NULL);
         H5Rcreate(&buf_reg_ref[1], gid1, tmp_name2, H5R_DATASET_REGION, sid_1d);
         H5Sselect_none(sid_1d);
-        HDsnprintf(name, sizeof(name), "%05d region refs", j);
+        snprintf(name, sizeof(name), "%05d region refs", j);
         did = H5Dcreate(gid1, name, H5T_STD_REF_DSETREG, sid_2, H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT);
         H5Dwrite(did, H5T_STD_REF_DSETREG, H5S_ALL, H5S_ALL, H5P_DEFAULT, buf_reg_ref);
         if (!j)
@@ -570,11 +570,11 @@ add_attrs(hid_t oid, int idx)
 
     /* 1 scalar point */
     sid = H5Screate(H5S_SCALAR);
-    HDsnprintf(name, sizeof(name), "%05d scalar int", idx);
+    snprintf(name, sizeof(name), "%05d scalar int", idx);
     nattrs += add_attr(oid, name, H5T_NATIVE_UINT, sid, &i);
-    HDsnprintf(name, sizeof(name), "%05d scalar ulong", idx);
+    snprintf(name, sizeof(name), "%05d scalar ulong", idx);
     nattrs += add_attr(oid, name, H5T_NATIVE_INT64, sid, &l);
-    HDsnprintf(name, sizeof(name), "%05d scalar str", idx);
+    snprintf(name, sizeof(name), "%05d scalar str", idx);
     tid = H5Tcopy(H5T_C_S1);
     H5Tset_size(tid, H5T_VARIABLE);
     nattrs += add_attr(oid, name, tid, sid, &s[2]);
@@ -584,24 +584,24 @@ add_attrs(hid_t oid, int idx)
     /* 4 single point */
     sid = H5Screate_simple(1, dims1, NULL);
     H5Rcreate(&ref, oid, ".", H5R_OBJECT, (hid_t)-1);
-    HDsnprintf(name, sizeof(name), "%05d single float", idx);
+    snprintf(name, sizeof(name), "%05d single float", idx);
     nattrs += add_attr(oid, name, H5T_NATIVE_FLOAT, sid, &f);
-    HDsnprintf(name, sizeof(name), "%05d single double", idx);
+    snprintf(name, sizeof(name), "%05d single double", idx);
     nattrs += add_attr(oid, name, H5T_NATIVE_DOUBLE, sid, &d);
-    HDsnprintf(name, sizeof(name), "%05d single obj_ref", idx);
+    snprintf(name, sizeof(name), "%05d single obj_ref", idx);
     nattrs += add_attr(oid, name, H5T_STD_REF_OBJ, sid, &ref);
     H5Sclose(sid);
 
     /* 7 fixed length 1D array */
     sid = H5Screate_simple(1, dims1, NULL);
     tid = H5Tarray_create(H5T_NATIVE_FLOAT, 1, dims2);
-    HDsnprintf(name, sizeof(name), "%05d array float", idx);
+    snprintf(name, sizeof(name), "%05d array float", idx);
     nattrs += add_attr(oid, name, tid, sid, &f_array[0]);
     H5Tclose(tid);
     tid = H5Tcopy(H5T_C_S1);
     H5Tset_size(tid, strlen(s[0]) + 1);
     tid1 = H5Tarray_create(tid, 1, dims2);
-    HDsnprintf(name, sizeof(name), "%05d array str", idx);
+    snprintf(name, sizeof(name), "%05d array str", idx);
     nattrs += add_attr(oid, name, tid1, sid, s);
     H5Tclose(tid1);
     H5Tclose(tid);
@@ -610,7 +610,7 @@ add_attrs(hid_t oid, int idx)
     /* 9 fixed length 2D int arrays */
     sid = H5Screate_simple(1, dims2, NULL);
     tid = H5Tarray_create(H5T_NATIVE_INT, 2, dims3);
-    HDsnprintf(name, sizeof(name), "%05d array int 2D", idx);
+    snprintf(name, sizeof(name), "%05d array int 2D", idx);
     nattrs += add_attr(oid, name, tid, sid, int3d[0][0]);
     H5Tclose(tid);
     H5Sclose(sid);
@@ -619,12 +619,12 @@ add_attrs(hid_t oid, int idx)
     sid = H5Screate_simple(1, dims2, NULL);
     tid = H5Tcopy(H5T_C_S1);
     H5Tset_size(tid, H5T_VARIABLE);
-    HDsnprintf(name, sizeof(name), "%05d vlen strings", idx);
+    snprintf(name, sizeof(name), "%05d vlen strings", idx);
     nattrs += add_attr(oid, name, tid, sid, s_vlen);
     H5Tclose(tid);
     tid = H5Tvlen_create(H5T_NATIVE_INT);
     ;
-    HDsnprintf(name, sizeof(name), "%05d vlen int array", idx);
+    snprintf(name, sizeof(name), "%05d vlen int array", idx);
     nattrs += add_attr(oid, name, tid, sid, i_vlen);
     H5Tclose(tid);
     H5Sclose(sid);
@@ -638,7 +638,7 @@ add_attrs(hid_t oid, int idx)
     offset += sizeof(H5T_NATIVE_INT);
     H5Tinsert(tid, "City", offset, tid1);
     offset += sizeof(char *);
-    HDsnprintf(name, sizeof(name), "%05d compound data", idx);
+    snprintf(name, sizeof(name), "%05d compound data", idx);
     nattrs += add_attr(oid, name, tid, sid, cmp_data);
     H5Tclose(tid1);
     H5Tclose(tid);

--- a/tools/test/misc/h5repart_gentest.c
+++ b/tools/test/misc/h5repart_gentest.c
@@ -34,11 +34,11 @@ main(void)
 
     /* Set up data array */
     if (NULL == (buf_data = (int *)calloc(FAMILY_NUMBER * FAMILY_SIZE, sizeof(int)))) {
-        HDperror("calloc");
+        perror("calloc");
         exit(EXIT_FAILURE);
     }
     if (NULL == (buf = (int **)calloc(FAMILY_NUMBER, sizeof(buf_data)))) {
-        HDperror("calloc");
+        perror("calloc");
         exit(EXIT_FAILURE);
     }
     for (i = 0; i < FAMILY_NUMBER; i++)
@@ -46,28 +46,28 @@ main(void)
 
     /* Set property list and file name for FAMILY driver */
     if ((fapl = H5Pcreate(H5P_FILE_ACCESS)) < 0) {
-        HDperror("H5Pcreate");
+        perror("H5Pcreate");
         exit(EXIT_FAILURE);
     }
 
     if (H5Pset_fapl_family(fapl, (hsize_t)FAMILY_SIZE, H5P_DEFAULT) < 0) {
-        HDperror("H5Pset_fapl_family");
+        perror("H5Pset_fapl_family");
         exit(EXIT_FAILURE);
     }
 
     if ((file = H5Fcreate(FILENAME, H5F_ACC_TRUNC, H5P_DEFAULT, fapl)) < 0) {
-        HDperror("H5Fcreate");
+        perror("H5Fcreate");
         exit(EXIT_FAILURE);
     }
 
     /* Create and write dataset */
     if ((space = H5Screate_simple(2, dims, NULL)) < 0) {
-        HDperror("H5Screate_simple");
+        perror("H5Screate_simple");
         exit(EXIT_FAILURE);
     }
 
     if ((dset = H5Dcreate2(file, dname, H5T_NATIVE_INT, space, H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT)) < 0) {
-        HDperror("H5Dcreate2");
+        perror("H5Dcreate2");
         exit(EXIT_FAILURE);
     }
 
@@ -76,34 +76,34 @@ main(void)
             buf[i][j] = i * 10000 + j;
 
     if (H5Dwrite(dset, H5T_NATIVE_INT, H5S_ALL, H5S_ALL, H5P_DEFAULT, buf_data) < 0) {
-        HDperror("H5Dwrite");
+        perror("H5Dwrite");
         exit(EXIT_FAILURE);
     }
 
     if (H5Sclose(space) < 0) {
-        HDperror("H5Sclose");
+        perror("H5Sclose");
         exit(EXIT_FAILURE);
     }
 
     if (H5Dclose(dset) < 0) {
-        HDperror("H5Dclose");
+        perror("H5Dclose");
         exit(EXIT_FAILURE);
     }
 
     if (H5Pclose(fapl) < 0) {
-        HDperror("H5Pclose");
+        perror("H5Pclose");
         exit(EXIT_FAILURE);
     }
 
     if (H5Fclose(file) < 0) {
-        HDperror("H5Fclose");
+        perror("H5Fclose");
         exit(EXIT_FAILURE);
     }
 
     free(buf);
     free(buf_data);
 
-    HDputs(" PASSED");
+    puts(" PASSED");
     fflush(stdout);
 
     return EXIT_SUCCESS;

--- a/tools/test/misc/talign.c
+++ b/tools/test/misc/talign.c
@@ -53,12 +53,12 @@ main(void)
 
     printf("%-70s", "Testing alignment in compound datatypes");
 
-    HDstrcpy(string5, "Hi!");
+    strcpy(string5, "Hi!");
     HDunlink(fname);
     fil = H5Fcreate(fname, H5F_ACC_TRUNC, H5P_DEFAULT, H5P_DEFAULT);
 
     if (fil < 0) {
-        HDputs("*FAILED*");
+        puts("*FAILED*");
         return 1;
     }
 
@@ -125,7 +125,7 @@ main(void)
     data = (char *)malloc(H5Tget_size(fix));
 
     if (!data) {
-        HDperror("malloc() failed");
+        perror("malloc() failed");
         HDabort();
     }
 
@@ -138,7 +138,7 @@ main(void)
 out:
     if (error < 0) {
         result = 1;
-        HDputs("*FAILED - HDF5 library error*");
+        puts("*FAILED - HDF5 library error*");
     }
     else if (!(H5_FLT_ABS_EQUAL(fok[0], fptr[0])) || !(H5_FLT_ABS_EQUAL(fok[1], fptr[1])) ||
              !(H5_FLT_ABS_EQUAL(fnok[0], fptr[2])) || !(H5_FLT_ABS_EQUAL(fnok[1], fptr[3]))) {
@@ -179,10 +179,10 @@ out:
                "                    %6f = %f\n",
                (double)fok[0], (double)fptr[0], (double)fok[1], (double)fptr[1], (double)fnok[0],
                (double)fptr[2], (double)fnok[1], (double)fptr[3]);
-        HDputs("*FAILED - compound type alignmnent problem*");
+        puts("*FAILED - compound type alignmnent problem*");
     }
     else {
-        HDputs(" PASSED");
+        puts(" PASSED");
     }
 
     if (data)

--- a/tools/test/perform/iopipe.c
+++ b/tools/test/perform/iopipe.c
@@ -158,7 +158,7 @@ main(void)
     t_start = H5_get_time();
     fprintf(stderr, HEADING, "fill raw");
     for (u = 0; u < nwrite; u++) {
-        HDputc(PROGRESS, stderr);
+        putc(PROGRESS, stderr);
         fflush(stderr);
         memset(the_data, 0xAA, (size_t)(size[0] * size[1]));
     }
@@ -166,7 +166,7 @@ main(void)
     getrusage(RUSAGE_SELF, &r_stop);
 #endif
     t_stop = H5_get_time();
-    HDputc('\n', stderr);
+    putc('\n', stderr);
     print_stats("fill raw",
 #ifdef H5_HAVE_GETRUSAGE
                 &r_start, &r_stop,
@@ -181,7 +181,7 @@ main(void)
     t_start = H5_get_time();
     fprintf(stderr, HEADING, "fill hdf5");
     for (u = 0; u < nread; u++) {
-        HDputc(PROGRESS, stderr);
+        putc(PROGRESS, stderr);
         fflush(stderr);
         status = H5Dread(dset, H5T_NATIVE_UCHAR, file_space, file_space, H5P_DEFAULT, the_data);
         assert(status >= 0);
@@ -190,7 +190,7 @@ main(void)
     getrusage(RUSAGE_SELF, &r_stop);
 #endif
     t_stop = H5_get_time();
-    HDputc('\n', stderr);
+    putc('\n', stderr);
     print_stats("fill hdf5",
 #ifdef H5_HAVE_GETRUSAGE
                 &r_start, &r_stop,
@@ -205,7 +205,7 @@ main(void)
     t_start = H5_get_time();
     fprintf(stderr, HEADING, "out raw");
     for (u = 0; u < nwrite; u++) {
-        HDputc(PROGRESS, stderr);
+        putc(PROGRESS, stderr);
         fflush(stderr);
         offset = HDlseek(fd, (off_t)0, SEEK_SET);
         assert(0 == offset);
@@ -216,7 +216,7 @@ main(void)
     getrusage(RUSAGE_SELF, &r_stop);
 #endif
     t_stop = H5_get_time();
-    HDputc('\n', stderr);
+    putc('\n', stderr);
     print_stats("out raw",
 #ifdef H5_HAVE_GETRUSAGE
                 &r_start, &r_stop,
@@ -231,7 +231,7 @@ main(void)
     t_start = H5_get_time();
     fprintf(stderr, HEADING, "out hdf5");
     for (u = 0; u < nwrite; u++) {
-        HDputc(PROGRESS, stderr);
+        putc(PROGRESS, stderr);
         fflush(stderr);
         status = H5Dwrite(dset, H5T_NATIVE_UCHAR, H5S_ALL, H5S_ALL, H5P_DEFAULT, the_data);
         assert(status >= 0);
@@ -240,7 +240,7 @@ main(void)
     getrusage(RUSAGE_SELF, &r_stop);
 #endif
     t_stop = H5_get_time();
-    HDputc('\n', stderr);
+    putc('\n', stderr);
     print_stats("out hdf5",
 #ifdef H5_HAVE_GETRUSAGE
                 &r_start, &r_stop,
@@ -255,7 +255,7 @@ main(void)
     t_start = H5_get_time();
     fprintf(stderr, HEADING, "in raw");
     for (u = 0; u < nread; u++) {
-        HDputc(PROGRESS, stderr);
+        putc(PROGRESS, stderr);
         fflush(stderr);
         offset = HDlseek(fd, (off_t)0, SEEK_SET);
         assert(0 == offset);
@@ -266,7 +266,7 @@ main(void)
     getrusage(RUSAGE_SELF, &r_stop);
 #endif
     t_stop = H5_get_time();
-    HDputc('\n', stderr);
+    putc('\n', stderr);
     print_stats("in raw",
 #ifdef H5_HAVE_GETRUSAGE
                 &r_start, &r_stop,
@@ -281,7 +281,7 @@ main(void)
     t_start = H5_get_time();
     fprintf(stderr, HEADING, "in hdf5");
     for (u = 0; u < nread; u++) {
-        HDputc(PROGRESS, stderr);
+        putc(PROGRESS, stderr);
         fflush(stderr);
         status = H5Dread(dset, H5T_NATIVE_UCHAR, file_space, file_space, H5P_DEFAULT, the_data);
         assert(status >= 0);
@@ -290,7 +290,7 @@ main(void)
     getrusage(RUSAGE_SELF, &r_stop);
 #endif
     t_stop = H5_get_time();
-    HDputc('\n', stderr);
+    putc('\n', stderr);
     print_stats("in hdf5",
 #ifdef H5_HAVE_GETRUSAGE
                 &r_start, &r_stop,
@@ -310,7 +310,7 @@ main(void)
     t_start = H5_get_time();
     fprintf(stderr, HEADING, "in hdf5 partial");
     for (u = 0; u < nread; u++) {
-        HDputc(PROGRESS, stderr);
+        putc(PROGRESS, stderr);
         fflush(stderr);
         status = H5Dread(dset, H5T_NATIVE_UCHAR, file_space, file_space, H5P_DEFAULT, the_data);
         assert(status >= 0);
@@ -319,7 +319,7 @@ main(void)
     getrusage(RUSAGE_SELF, &r_stop);
 #endif
     t_stop = H5_get_time();
-    HDputc('\n', stderr);
+    putc('\n', stderr);
     print_stats("in hdf5 partial",
 #ifdef H5_HAVE_GETRUSAGE
                 &r_start, &r_stop,

--- a/tools/test/perform/perf_meta.c
+++ b/tools/test/perform/perf_meta.c
@@ -280,7 +280,7 @@ create_dsets(hid_t file)
      * Create a dataset using the default dataset creation properties.
      */
     for (i = 0; i < NUM_DSETS; i++) {
-        HDsnprintf(dset_name, sizeof(dset_name), "dataset %d", i);
+        snprintf(dset_name, sizeof(dset_name), "dataset %d", i);
         if ((dataset = H5Dcreate2(file, dset_name, H5T_NATIVE_DOUBLE, space, H5P_DEFAULT, H5P_DEFAULT,
                                   H5P_DEFAULT)) < 0)
             goto error;
@@ -337,14 +337,14 @@ create_attrs_1(void)
      * Create all(user specifies the number) attributes for each dataset
      */
     for (i = 0; i < NUM_DSETS; i++) {
-        HDsnprintf(dset_name, sizeof(dset_name), "dataset %d", i);
+        snprintf(dset_name, sizeof(dset_name), "dataset %d", i);
         open_t.start = retrieve_time();
         if ((dataset = H5Dopen2(file, dset_name, H5P_DEFAULT)) < 0)
             goto error;
         perf(&open_t, open_t.start, retrieve_time());
 
         for (j = 0; j < NUM_ATTRS; j++) {
-            HDsnprintf(attr_name, sizeof(attr_name), "all attrs for each dset %d", j);
+            snprintf(attr_name, sizeof(attr_name), "all attrs for each dset %d", j);
             attr_t.start = retrieve_time();
             if ((attr = H5Acreate2(dataset, attr_name, H5T_NATIVE_DOUBLE, small_space, H5P_DEFAULT,
                                    H5P_DEFAULT)) < 0)
@@ -433,7 +433,7 @@ create_attrs_2(void)
      * Create all(user specifies the number) attributes for each new dataset
      */
     for (i = 0; i < NUM_DSETS; i++) {
-        HDsnprintf(dset_name, sizeof(dset_name), "dataset %d", i);
+        snprintf(dset_name, sizeof(dset_name), "dataset %d", i);
         create_t.start = retrieve_time();
         if ((dataset = H5Dcreate2(file, dset_name, H5T_NATIVE_DOUBLE, space, H5P_DEFAULT, H5P_DEFAULT,
                                   H5P_DEFAULT)) < 0)
@@ -441,7 +441,7 @@ create_attrs_2(void)
         perf(&create_t, create_t.start, retrieve_time());
 
         for (j = 0; j < NUM_ATTRS; j++) {
-            HDsnprintf(attr_name, sizeof(attr_name), "all attrs for each dset %d", j);
+            snprintf(attr_name, sizeof(attr_name), "all attrs for each dset %d", j);
             attr_t.start = retrieve_time();
             if ((attr = H5Acreate2(dataset, attr_name, H5T_NATIVE_DOUBLE, small_space, H5P_DEFAULT,
                                    H5P_DEFAULT)) < 0)
@@ -539,14 +539,14 @@ create_attrs_3(void)
 
     for (i = 0; i < loop_num; i++) {
         for (j = 0; j < NUM_DSETS; j++) {
-            HDsnprintf(dset_name, sizeof(dset_name), "dataset %d", j);
+            snprintf(dset_name, sizeof(dset_name), "dataset %d", j);
             open_t.start = retrieve_time();
             if ((dataset = H5Dopen2(file, dset_name, H5P_DEFAULT)) < 0)
                 goto error;
             perf(&open_t, open_t.start, retrieve_time());
 
             for (k = 0; k < BATCH_ATTRS; k++) {
-                HDsnprintf(attr_name, sizeof(attr_name), "some attrs for each dset %d %d", i, k);
+                snprintf(attr_name, sizeof(attr_name), "some attrs for each dset %d %d", i, k);
                 attr_t.start = retrieve_time();
                 if ((attr = H5Acreate2(dataset, attr_name, H5T_NATIVE_DOUBLE, small_space, H5P_DEFAULT,
                                        H5P_DEFAULT)) < 0)

--- a/tools/test/perform/zip_perf.c
+++ b/tools/test/perform/zip_perf.c
@@ -85,7 +85,7 @@ error(const char *fmt, ...)
     va_start(ap, fmt);
     fprintf(stderr, "%s: error: ", prog);
     H5_GCC_CLANG_DIAG_OFF("format-nonliteral")
-    HDvfprintf(stderr, fmt, ap);
+    vfprintf(stderr, fmt, ap);
     H5_GCC_CLANG_DIAG_ON("format-nonliteral")
     fprintf(stderr, "\n");
     va_end(ap);
@@ -140,7 +140,7 @@ write_file(Bytef *source, uLongf sourceLen)
         int rc = (int)HDwrite(output, d_ptr, (size_t)d_len);
 
         if (rc == -1)
-            error(HDstrerror(errno));
+            error(strerror(errno));
 
         if (rc == (int)d_len)
             break;
@@ -207,19 +207,19 @@ get_unique_name(void)
 
     if (prefix)
         /* 2 = 1 for '/' + 1 for null terminator */
-        filename = (char *)malloc(HDstrlen(prefix) + HDstrlen(ZIP_PERF_FILE) + 2);
+        filename = (char *)malloc(strlen(prefix) + strlen(ZIP_PERF_FILE) + 2);
     else
-        filename = (char *)malloc(HDstrlen(ZIP_PERF_FILE) + 1);
+        filename = (char *)malloc(strlen(ZIP_PERF_FILE) + 1);
 
     if (!filename)
         error("out of memory");
 
     filename[0] = 0;
     if (prefix) {
-        HDstrcpy(filename, prefix);
-        HDstrcat(filename, "/");
+        strcpy(filename, prefix);
+        strcat(filename, "/");
     }
-    HDstrcat(filename, ZIP_PERF_FILE);
+    strcat(filename, ZIP_PERF_FILE);
 }
 
 /*
@@ -316,13 +316,13 @@ fill_with_random_data(Bytef *src, uLongf src_len)
         fprintf(stdout, "Using /dev/urandom for random data\n");
 
         if (fd < 0)
-            error(HDstrerror(errno));
+            error(strerror(errno));
 
         for (;;) {
             ssize_t rc = HDread(fd, buf, src_len);
 
             if (rc == -1)
-                error(HDstrerror(errno));
+                error(strerror(errno));
 
             if (rc == (ssize_t)len)
                 break;
@@ -391,7 +391,7 @@ do_write_test(unsigned long file_size, unsigned long min_buf_size, unsigned long
         output = HDopen(filename, O_RDWR | O_CREAT, S_IRWXU);
 
         if (output == -1)
-            error(HDstrerror(errno));
+            error(strerror(errno));
 
         for (i = 0; i <= iters; ++i) {
             Bytef *s_ptr = src;
@@ -402,7 +402,7 @@ do_write_test(unsigned long file_size, unsigned long min_buf_size, unsigned long
                 ssize_t rc = HDwrite(output, s_ptr, s_len);
 
                 if (rc == -1)
-                    error(HDstrerror(errno));
+                    error(strerror(errno));
 
                 if (rc == (ssize_t)s_len)
                     break;
@@ -427,7 +427,7 @@ do_write_test(unsigned long file_size, unsigned long min_buf_size, unsigned long
         output = HDopen(filename, O_RDWR | O_CREAT, S_IRWXU);
 
         if (output == -1)
-            error(HDstrerror(errno));
+            error(strerror(errno));
 
         report_once_flag = 1;
         HDgettimeofday(&timer_start, NULL);

--- a/utils/mirror_vfd/mirror_remote.c
+++ b/utils/mirror_vfd/mirror_remote.c
@@ -60,7 +60,7 @@ mirror_log(struct mirror_log_info *info, unsigned int level, const char *format,
         if (format != NULL) {
             va_list args;
             va_start(args, format);
-            HDvfprintf(stream, format, args);
+            vfprintf(stream, format, args);
             va_end(args);
         }
 
@@ -158,7 +158,7 @@ mirror_log_init(char *path, const char *prefix, unsigned int verbosity)
         info->prefix[0] = '\0';
 
         if (prefix && *prefix) {
-            HDstrncpy(info->prefix, prefix, MIRROR_LOG_PREFIX_MAX);
+            strncpy(info->prefix, prefix, MIRROR_LOG_PREFIX_MAX);
         }
 
         if (path && *path) {

--- a/utils/mirror_vfd/mirror_server.c
+++ b/utils/mirror_vfd/mirror_server.c
@@ -187,22 +187,22 @@ parse_args(int argc, char **argv, struct op_args *args_out)
 
     /* Loop over arguments after program name */
     for (int i = 1; i < argc; i++) {
-        if (!HDstrncmp(argv[i], "-h", 3) || !HDstrncmp(argv[i], "--help", 7)) {
+        if (!strncmp(argv[i], "-h", 3) || !strncmp(argv[i], "--help", 7)) {
             mirror_log(NULL, V_INFO, "found help argument");
             args_out->help = 1;
             return 0;
         } /* end if help */
-        else if (!HDstrncmp(argv[i], "--port=", 7)) {
+        else if (!strncmp(argv[i], "--port=", 7)) {
             mirror_log(NULL, V_INFO, "parsing 'main_port' (%s)", argv[i] + 7);
             args_out->main_port = atoi(argv[i] + 7);
         } /* end if port */
-        else if (!HDstrncmp(argv[i], "--verbosity=", 12)) {
+        else if (!strncmp(argv[i], "--verbosity=", 12)) {
             mirror_log(NULL, V_INFO, "parsing 'verbosity' (%s)", argv[i] + 12);
             args_out->verbosity = (unsigned int)atoi(argv[i] + 12);
         } /* end if verbosity */
-        else if (!HDstrncmp(argv[i], "--logpath=", 10)) {
+        else if (!strncmp(argv[i], "--logpath=", 10)) {
             mirror_log(NULL, V_INFO, "parsing 'logpath' (%s)", argv[i] + 10);
-            HDstrncpy(args_out->log_path, argv[i] + 10, PATH_MAX);
+            strncpy(args_out->log_path, argv[i] + 10, PATH_MAX);
         } /* end if logpath */
         else {
             mirror_log(NULL, V_ERR, "unrecognized argument: %s", argv[i]);
@@ -257,7 +257,7 @@ prepare_listening_socket(struct server_run *run)
     mirror_log(run->loginfo, V_INFO, "bind()");
     ret = bind(ret_value, (struct sockaddr *)&server_addr, sizeof(server_addr));
     if (ret < 0) {
-        mirror_log(run->loginfo, V_ERR, "bind() %s", HDstrerror(errno));
+        mirror_log(run->loginfo, V_ERR, "bind() %s", strerror(errno));
         goto error;
     }
 
@@ -517,7 +517,7 @@ handle_requests(struct server_run *run)
         /* Respond to handshake message.
          */
 
-        if (!HDstrncmp("SHUTDOWN", mybuf, 8)) {
+        if (!strncmp("SHUTDOWN", mybuf, 8)) {
             /* Stop operation if told to stop */
             mirror_log(run->loginfo, V_INFO, "received SHUTDOWN!", ret);
 
@@ -533,7 +533,7 @@ handle_requests(struct server_run *run)
             connfd = -1;
             goto done;
         } /* end if explicit "SHUTDOWN" directive */
-        if (!HDstrncmp("CONFIRM", mybuf, 7)) {
+        if (!strncmp("CONFIRM", mybuf, 7)) {
             /* Confirm operation */
             if ((ret = HDwrite(connfd, "ALIVE", 6)) < 0) {
                 mirror_log(run->loginfo, V_ERR, "write:%d", ret);

--- a/utils/mirror_vfd/mirror_server_stop.c
+++ b/utils/mirror_vfd/mirror_server_stop.c
@@ -89,16 +89,16 @@ parse_args(int argc, char **argv, struct mshs_opts *opts)
     opts->magic  = MSHS_OPTS_MAGIC;
     opts->help   = 0;
     opts->portno = MSHS_DEFAULT_PORTNO;
-    HDstrncpy(opts->ip, MSHS_DEFAULT_IP, MSHS_IP_STR_SIZE);
+    strncpy(opts->ip, MSHS_DEFAULT_IP, MSHS_IP_STR_SIZE);
 
     for (i = 1; i < argc; i++) { /* start with first possible option argument */
-        if (!HDstrncmp(argv[i], "-h", 3) || !HDstrncmp(argv[i], "--help", 7)) {
+        if (!strncmp(argv[i], "-h", 3) || !strncmp(argv[i], "--help", 7)) {
             opts->help = 1;
         }
-        else if (!HDstrncmp(argv[i], "--ip=", 5)) {
-            HDstrncpy(opts->ip, argv[i] + 5, MSHS_IP_STR_SIZE);
+        else if (!strncmp(argv[i], "--ip=", 5)) {
+            strncpy(opts->ip, argv[i] + 5, MSHS_IP_STR_SIZE);
         }
-        else if (!HDstrncmp(argv[i], "--port=", 7)) {
+        else if (!strncmp(argv[i], "--port=", 7)) {
             opts->portno = atoi(argv[i] + 7);
         }
         else {
@@ -110,8 +110,8 @@ parse_args(int argc, char **argv, struct mshs_opts *opts)
     } /* end for each argument from command line */
 
     /* auto-replace 'localhost' with numeric IP */
-    if (!HDstrncmp(opts->ip, "localhost", 10)) { /* include null terminator */
-        HDstrncpy(opts->ip, "127.0.0.1", MSHS_IP_STR_SIZE);
+    if (!strncmp(opts->ip, "localhost", 10)) { /* include null terminator */
+        strncpy(opts->ip, "127.0.0.1", MSHS_IP_STR_SIZE);
     }
 
     return 0;
@@ -149,12 +149,12 @@ send_shutdown(struct mshs_opts *opts)
     memset(target_addr.sin_zero, 0, sizeof(target_addr.sin_zero));
 
     if (connect(live_socket, (struct sockaddr *)&target_addr, (socklen_t)sizeof(target_addr)) < 0) {
-        printf("ERROR connect() (%d)\n%s\n", errno, HDstrerror(errno));
+        printf("ERROR connect() (%d)\n%s\n", errno, strerror(errno));
         return -1;
     }
 
     if (HDwrite(live_socket, "SHUTDOWN", 9) == -1) {
-        printf("ERROR write() (%d)\n%s\n", errno, HDstrerror(errno));
+        printf("ERROR write() (%d)\n%s\n", errno, strerror(errno));
         return -1;
     }
 
@@ -163,7 +163,7 @@ send_shutdown(struct mshs_opts *opts)
         printf("ERROR read() can't receive data\n");
         return -1;
     }
-    if (HDstrncmp("CLOSING", mybuf, 8)) {
+    if (strncmp("CLOSING", mybuf, 8)) {
         printf("ERROR read() didn't receive data from server\n");
         return -1;
     }

--- a/utils/mirror_vfd/mirror_writer.c
+++ b/utils/mirror_vfd/mirror_writer.c
@@ -382,7 +382,7 @@ reply_error(struct mirror_session *session, const char *msg)
     mirror_log(session->loginfo, V_ALL, "reply_error(%s)", msg);
 
     reply->status = H5FD_MIRROR_STATUS_ERROR;
-    HDsnprintf(reply->message, H5FD_MIRROR_STATUS_MESSAGE_MAX - 1, "%s", msg);
+    snprintf(reply->message, H5FD_MIRROR_STATUS_MESSAGE_MAX - 1, "%s", msg);
     return _xmit_reply(session);
 } /* end reply_error() */
 
@@ -838,7 +838,7 @@ receive_communique(struct mirror_session *session, struct sock_comm *comm)
     } /* end if hexdump transmissions received */
 
     /* old-fashioned manual kill (for debugging) */
-    if (!HDstrncmp("GOODBYE", comm->raw, 7)) {
+    if (!strncmp("GOODBYE", comm->raw, 7)) {
         mirror_log(session->loginfo, V_INFO, "received GOODBYE");
         comm->recd_die = 1;
         goto done;

--- a/utils/tools/h5dwalk/h5dwalk.c
+++ b/utils/tools/h5dwalk/h5dwalk.c
@@ -97,7 +97,7 @@ static void
 save_command(const char *argv0)
 {
     assert(argv0);
-    user_cmd = HDstrdup(argv0);
+    user_cmd = strdup(argv0);
 }
 
 static void
@@ -328,7 +328,7 @@ distribution_parse(struct distribute_option *option, const char *string)
         return -1;
     }
 
-    str = HDstrdup(string);
+    str = strdup(string);
     /* Parse separators */
     ptr  = str + strlen("size:");
     next = ptr;
@@ -761,9 +761,9 @@ fill_file_list(mfu_flist new_flist, const char *config_filename, int myrank, int
     FILE *config = fopen(config_filename, "r");
     if (config == NULL)
         return -1;
-    while (HDfgets(linebuf, sizeof(linebuf), config) != NULL) {
+    while (fgets(linebuf, sizeof(linebuf), config) != NULL) {
         struct stat statbuf;
-        char       *eol = HDstrchr(linebuf, '\n');
+        char       *eol = strchr(linebuf, '\n');
         if (eol)
             *eol = '\0';
         if (HDstat(linebuf, &statbuf) == 0) {
@@ -835,10 +835,10 @@ copy_args(int argc, const char *argv[], int *mfu_argc, int *copy_len)
     save_command(argv[0]);
 
     for (i = 0; i < argc; i++) {
-        argv_copy[i] = HDstrdup(argv[i]);
+        argv_copy[i] = strdup(argv[i]);
         bytes_copied += (int)(strlen(argv[i]) + 1);
-        argv_copy[i] = HDstrdup(argv[i]);
-        if (check_mfu_args && (HDstrncmp(argv[i], "-T", 2) == 0)) {
+        argv_copy[i] = strdup(argv[i]);
+        if (check_mfu_args && (strncmp(argv[i], "-T", 2) == 0)) {
             check_mfu_args = 0;
             *mfu_argc      = i + 1;
         }
@@ -878,7 +878,7 @@ get_copy_count(char *fname, char *appname)
     hash_index = filehash % NAME_ENTRIES;
     if (filename_cache[hash_index].name == NULL) {
         filename_cache[hash_index].hash      = apphash;
-        filename_cache[hash_index].name      = HDstrdup(fname);
+        filename_cache[hash_index].name      = strdup(fname);
         filename_cache[hash_index].next      = NULL;
         filename_cache[hash_index].nextCount = 1;
         return 0;
@@ -906,7 +906,7 @@ get_copy_count(char *fname, char *appname)
         nextEntry = (hash_entry_t *)malloc(sizeof(hash_entry_t));
         if (nextEntry) {
             lastEntry->next      = nextEntry;
-            nextEntry->name      = HDstrdup(fname);
+            nextEntry->name      = strdup(fname);
             nextEntry->hash      = apphash;
             nextEntry->next      = NULL;
             nextEntry->nextCount = 1;
@@ -929,7 +929,7 @@ run_command(int argc __attribute__((unused)), char **argv, char *cmdline, const 
 #else
 
     /* create a copy of the 1st file passed to the application */
-    HDstrcpy(filepath, fname);
+    strcpy(filepath, fname);
 
     if (log_output_in_single_file || use_stdout) {
         pid_t   pid;
@@ -992,7 +992,7 @@ run_command(int argc __attribute__((unused)), char **argv, char *cmdline, const 
             nbytes    = strlen(cmdline);
             /* Record the command line for the log! */
             if (nbytes < remaining) {
-                HDstrcpy(&buf[offset], cmdline);
+                strcpy(&buf[offset], cmdline);
                 thisbuft->chars += nbytes;
                 thisbuft->count -= nbytes;
                 remaining -= nbytes;
@@ -1014,7 +1014,7 @@ run_command(int argc __attribute__((unused)), char **argv, char *cmdline, const 
                 thisbuft->bufsize = BUFT_SIZE;
                 thisbuft->dt      = MPI_CHAR;
                 /* Copy the remaining cmdline text into the new buffer */
-                HDstrcpy(buf, nextpart);
+                strcpy(buf, nextpart);
                 /* And update our buffer info */
                 // thisbuft->chars = strlen(nextpart) +1;
                 thisbuft->chars = strlen(nextpart);
@@ -1061,8 +1061,8 @@ run_command(int argc __attribute__((unused)), char **argv, char *cmdline, const 
         char   logpath[2048];
         char   logErrors[2048];
         char   current_dir[2048];
-        char  *logbase = HDstrdup(basename(filepath));
-        char  *thisapp = HDstrdup(basename(toolname));
+        char  *logbase = strdup(basename(filepath));
+        char  *thisapp = strdup(basename(toolname));
 
         if (processing_inputfile == 0)
             log_instance = get_copy_count(logbase, thisapp);
@@ -1071,12 +1071,12 @@ run_command(int argc __attribute__((unused)), char **argv, char *cmdline, const 
             if ((log_instance > 0) || processing_inputfile) {
                 if (processing_inputfile)
                     log_instance = current_input_index;
-                HDsnprintf(logpath, sizeof(logpath), "%s/%s_%s.log_%d",
-                           HDgetcwd(current_dir, sizeof(current_dir)), logbase, thisapp, log_instance);
+                snprintf(logpath, sizeof(logpath), "%s/%s_%s.log_%d",
+                         HDgetcwd(current_dir, sizeof(current_dir)), logbase, thisapp, log_instance);
             }
             else {
-                HDsnprintf(logpath, sizeof(logpath), "%s/%s_%s.log",
-                           HDgetcwd(current_dir, sizeof(current_dir)), logbase, thisapp);
+                snprintf(logpath, sizeof(logpath), "%s/%s_%s.log", HDgetcwd(current_dir, sizeof(current_dir)),
+                         logbase, thisapp);
             }
         }
         else {
@@ -1085,17 +1085,17 @@ run_command(int argc __attribute__((unused)), char **argv, char *cmdline, const 
                 if (processing_inputfile)
                     log_instance = current_input_index;
                 if (txtlog[log_len - 1] == '/')
-                    HDsnprintf(logpath, sizeof(logpath), "%s%s_%s.log_%d", txtlog, logbase, thisapp,
-                               log_instance);
+                    snprintf(logpath, sizeof(logpath), "%s%s_%s.log_%d", txtlog, logbase, thisapp,
+                             log_instance);
                 else
-                    HDsnprintf(logpath, sizeof(logpath), "%s/%s_%s.log_%d", txtlog, logbase, thisapp,
-                               log_instance);
+                    snprintf(logpath, sizeof(logpath), "%s/%s_%s.log_%d", txtlog, logbase, thisapp,
+                             log_instance);
             }
             else {
                 if (txtlog[log_len - 1] == '/')
-                    HDsnprintf(logpath, sizeof(logpath), "%s%s_%s.log", txtlog, logbase, thisapp);
+                    snprintf(logpath, sizeof(logpath), "%s%s_%s.log", txtlog, logbase, thisapp);
                 else
-                    HDsnprintf(logpath, sizeof(logpath), "%s/%s_%s.log", txtlog, logbase, thisapp);
+                    snprintf(logpath, sizeof(logpath), "%s/%s_%s.log", txtlog, logbase, thisapp);
             }
         }
 
@@ -1105,8 +1105,8 @@ run_command(int argc __attribute__((unused)), char **argv, char *cmdline, const 
              * copy of the logpath variable.
              */
             log_len = strlen(logpath);
-            HDstrcpy(logErrors, logpath);
-            HDstrcpy(&logErrors[log_len - 3], "err");
+            strcpy(logErrors, logpath);
+            strcpy(&logErrors[log_len - 3], "err");
         }
         if (mfu_debug_level == MFU_LOG_VERBOSE) {
             printf("\tCreating logfile: %s\n", logpath);
@@ -1161,7 +1161,7 @@ MFU_PRED_EXEC(mfu_flist flist, uint64_t idx, void *arg)
     toolname = buf;
 
     /* Get a copy of fname */
-    HDstrcpy(filepath, fname);
+    strcpy(filepath, fname);
 
     /* allocate a char* for each item in the argv array,
      * plus one more for a trailing NULL
@@ -1173,10 +1173,10 @@ MFU_PRED_EXEC(mfu_flist flist, uint64_t idx, void *arg)
     char   cmdline[2048];
     char **argv = (char **)MFU_CALLOC((size_t)(count + 2), sizeof(char *));
 
-    argv[k++] = HDstrdup(toolname);
+    argv[k++] = strdup(toolname);
 
     memset(cmdline, 0, sizeof(cmdline));
-    buf += HDstrlen(toolname) + 1;
+    buf += strlen(toolname) + 1;
     /* Reconstruct the command line that the user provided for the h5tool */
     for (k = 1; k < count; k++) {
         if (buf[0] == '&') {
@@ -1193,26 +1193,26 @@ MFU_PRED_EXEC(mfu_flist flist, uint64_t idx, void *arg)
             if (fname_arg == NULL) {
                 printf("[%d] Warning: Unable to resolve file_substitution %d (idx=%ld)\n", sg_mpi_rank,
                        file_substituted, idx);
-                argv[k] = HDstrdup(fname);
+                argv[k] = strdup(fname);
             }
             else {
-                argv[k] = HDstrdup(fname_arg);
+                argv[k] = strdup(fname_arg);
                 file_substituted++;
             }
         }
         else {
-            argv[k] = HDstrdup(buf);
-            buf += HDstrlen(argv[k]) + 1;
+            argv[k] = strdup(buf);
+            buf += strlen(argv[k]) + 1;
         }
     }
 
-    HDsnprintf(cmdline, sizeof(cmdline), "\n---------\nCommand:");
+    snprintf(cmdline, sizeof(cmdline), "\n---------\nCommand:");
     b_offset = strlen(cmdline);
     for (k = 0; k < count; k++) {
-        HDsprintf(&cmdline[b_offset], " %s", argv[k]);
+        sprintf(&cmdline[b_offset], " %s", argv[k]);
         b_offset = strlen(cmdline);
     }
-    HDsprintf(&cmdline[b_offset], "\n");
+    sprintf(&cmdline[b_offset], "\n");
     run_command(count, argv, cmdline, fname);
 
     mfu_free(argv);
@@ -1244,7 +1244,7 @@ static void
 add_executable(int argc, char **argv, char *cmdstring, int *f_index, int f_count __attribute__((unused)))
 {
     char cmdline[2048];
-    HDsnprintf(cmdline, sizeof(cmdline), "\n---------\nCommand: %s\n", cmdstring);
+    snprintf(cmdline, sizeof(cmdline), "\n---------\nCommand: %s\n", cmdstring);
     argv[argc] = NULL;
     run_command(argc, argv, cmdline, argv[f_index[0]]);
     return;
@@ -1270,7 +1270,7 @@ process_input_file(char *inputname, int myrank, int size)
      */
     processing_inputfile = 1;
 
-    while (HDfgets(linebuf, sizeof(linebuf), config) != NULL) {
+    while (fgets(linebuf, sizeof(linebuf), config) != NULL) {
         const char *delim   = " \n";
         char       *cmdline = NULL;
         char       *cmd     = NULL;
@@ -1285,8 +1285,8 @@ process_input_file(char *inputname, int myrank, int size)
         if (eol) {
             *eol = '\0';
         }
-        cmdline = HDstrdup(linebuf);
-        cmd     = HDstrtok(linebuf, delim);
+        cmdline = strdup(linebuf);
+        cmd     = strtok(linebuf, delim);
         if (cmd) {
             arg = cmd;
             while (arg != NULL) {
@@ -1401,29 +1401,29 @@ main(int argc, char *argv[])
                 h5dwalk_exit(EXIT_FAILURE);
                 break;
             case 'i':
-                inputname    = HDstrdup(H5_optarg);
+                inputname    = strdup(H5_optarg);
                 last_mfu_arg = H5_optind;
                 if (inputname)
                     tool_selected = 1;
                 break;
             case 'o':
-                outputname   = HDstrdup(H5_optarg);
+                outputname   = strdup(H5_optarg);
                 last_mfu_arg = H5_optind;
                 if (outputname) {
                     log_output_in_single_file = 1;
-                    output_log_file           = HDstrdup(H5_optarg);
+                    output_log_file           = strdup(H5_optarg);
                     text                      = 1; /* Format TXT, not HDF5 */
                 }
                 break;
             case 'E':
                 log_errors_in_file = 1;
-                errlog             = HDstrdup(H5_optarg);
+                errlog             = strdup(H5_optarg);
                 last_mfu_arg       = H5_optind;
                 break;
             case 'l':
                 log_stdout_in_file = 1;
                 if (H5_optarg)
-                    txtlog = HDstrdup(H5_optarg);
+                    txtlog = strdup(H5_optarg);
                 break;
             case 'T':
                 /* We need to stop parsing user options at this point.
@@ -1562,7 +1562,7 @@ main(int argc, char *argv[])
         mfu_dst_file = mfu_file_new();
         destpath     = &paths[1];
         path2        = destpath->path;
-        pathlen_total += HDstrlen(path2);
+        pathlen_total += strlen(path2);
         mfu_flist_walk_param_paths(1, destpath, walk_opts, flist2, mfu_dst_file);
     }
 
@@ -1616,8 +1616,8 @@ main(int argc, char *argv[])
                 k++;
             }
             else {
-                HDstrcpy(ptr, argv[i]);
-                ptr += HDstrlen(argv[i]);
+                strcpy(ptr, argv[i]);
+                ptr += strlen(argv[i]);
             }
             *ptr++ = 0;
         }


### PR DESCRIPTION
* HD(f)(put|get)(s|c)
* HDstr*
* HDv*printf
* HD(s)(print|scan)f
* HDperror

But NOT:

* HDstrcase*
* HDvasprintf
* HDstrtok_r
* HDstrndup

As those are not C99 and have portability work-around implementations. They will be handled later.