### PR TITLE
Fix grammar

### DIFF
--- a/src/H5overflow.txt
+++ b/src/H5overflow.txt
@@ -9,7 +9,7 @@
 # help@hdfgroup.org.
 #
 
-# This file is used to generate the headers that is needed for detecting
+# This file is used to generate the header that is needed for detecting
 # overflows between types at run-time
 #
 # The bin/make_overflow script reads in this file and creates the appropriate


### PR DESCRIPTION
It generates 1 header file, `H5overflow.h`.