### PR TITLE
Adds link to h5fuse.sh in testpar for autotools

### DIFF
--- a/.github/workflows/linux-nvhpc.yml
+++ b/.github/workflows/linux-nvhpc.yml
@@ -50,7 +50,7 @@ jobs:
           export OMPI_FC=/opt/nvidia/hpc_sdk/Linux_x86_64/23.7/compilers/bin/nvfortran
           export LD_LIBRARY_PATH=/opt/nvidia/hpc_sdk/Linux_x86_64/23.7/cuda/12.2/lib64:/opt/nvidia/hpc_sdk/Linux_x86_64/23.7/compilers/lib
           export PATH=/opt/nvidia/hpc_sdk/Linux_x86_64/23.7/comm_libs/openmpi4/bin:/opt/nvidia/hpc_sdk/Linux_x86_64/23.7/compilers/bin:$PATH        
-          cmake -B build  -DHDF5_ENABLE_SZIP_SUPPORT:BOOL=OFF -DHDF5_ENABLE_PARALLEL:BOOL=ON -DHDF5_ENABLE_PARALLEL:BOOL=ON -DHDF5_ENABLE_SUBFILING_VFD:BOOL=ON -DHDF5_BUILD_FORTRAN:BOOL=ON
+          cmake -B build  -DHDF5_ENABLE_SZIP_SUPPORT:BOOL=OFF -DHDF5_ENABLE_PARALLEL:BOOL=ON -DHDF5_ENABLE_SUBFILING_VFD:BOOL=ON -DHDF5_BUILD_FORTRAN:BOOL=ON
           cat build/CMakeCache.txt
           cmake --build build
           ctest --test-dir build --output-on-failure        

--- a/.github/workflows/linux-nvhpc.yml
+++ b/.github/workflows/linux-nvhpc.yml
@@ -50,7 +50,7 @@ jobs:
           export OMPI_FC=/opt/nvidia/hpc_sdk/Linux_x86_64/23.7/compilers/bin/nvfortran
           export LD_LIBRARY_PATH=/opt/nvidia/hpc_sdk/Linux_x86_64/23.7/cuda/12.2/lib64:/opt/nvidia/hpc_sdk/Linux_x86_64/23.7/compilers/lib
           export PATH=/opt/nvidia/hpc_sdk/Linux_x86_64/23.7/comm_libs/openmpi4/bin:/opt/nvidia/hpc_sdk/Linux_x86_64/23.7/compilers/bin:$PATH        
-          cmake -B build  -DHDF5_ENABLE_SZIP_SUPPORT:BOOL=OFF -DHDF5_ENABLE_PARALLEL:BOOL=ON -DHDF5_ENABLE_SUBFILING_VFD:BOOL=ON -DHDF5_BUILD_FORTRAN:BOOL=ON
+          cmake -B build  -DHDF5_ENABLE_SZIP_SUPPORT:BOOL=OFF -DHDF5_ENABLE_PARALLEL:BOOL=ON -DHDF5_BUILD_FORTRAN:BOOL=ON
           cat build/CMakeCache.txt
           cmake --build build
           ctest --test-dir build --output-on-failure        

--- a/.github/workflows/linux-nvhpc.yml
+++ b/.github/workflows/linux-nvhpc.yml
@@ -50,7 +50,7 @@ jobs:
           export OMPI_FC=/opt/nvidia/hpc_sdk/Linux_x86_64/23.7/compilers/bin/nvfortran
           export LD_LIBRARY_PATH=/opt/nvidia/hpc_sdk/Linux_x86_64/23.7/cuda/12.2/lib64:/opt/nvidia/hpc_sdk/Linux_x86_64/23.7/compilers/lib
           export PATH=/opt/nvidia/hpc_sdk/Linux_x86_64/23.7/comm_libs/openmpi4/bin:/opt/nvidia/hpc_sdk/Linux_x86_64/23.7/compilers/bin:$PATH        
-          cmake -B build  -DHDF5_ENABLE_SZIP_SUPPORT:BOOL=OFF -DHDF5_ENABLE_PARALLEL:BOOL=ON -DHDF5_BUILD_FORTRAN:BOOL=ON 
+          cmake -B build  -DHDF5_ENABLE_SZIP_SUPPORT:BOOL=OFF -DHDF5_ENABLE_PARALLEL:BOOL=ON -DHDF5_ENABLE_PARALLEL:BOOL=ON -DHDF5_ENABLE_SUBFILING_VFD:BOOL=ON -DHDF5_BUILD_FORTRAN:BOOL=ON
           cat build/CMakeCache.txt
           cmake --build build
           ctest --test-dir build --output-on-failure        

--- a/.github/workflows/main-auto-par.yml
+++ b/.github/workflows/main-auto-par.yml
@@ -54,6 +54,7 @@ jobs:
             --with-default-api-version=v114 \
             --enable-shared \
             --enable-parallel \
+            --enable-subfiling-vfd \
             --disable-cxx \
             --disable-fortran \
             --disable-java \
@@ -111,6 +112,7 @@ jobs:
             --with-default-api-version=v114 \
             --enable-shared \
             --enable-parallel \
+            --enable-subfiling-vfd \
             --disable-cxx \
             --disable-fortran \
             --disable-java \

--- a/configure.ac
+++ b/configure.ac
@@ -4206,6 +4206,11 @@ AC_CONFIG_FILES([Makefile
                  hl/fortran/examples/run-hlfortran-ex.sh])
 
 AC_CONFIG_FILES([utils/subfiling_vfd/h5fuse.sh], [chmod +x utils/subfiling_vfd/h5fuse.sh])
+if test -n "$TESTPARALLEL"; then
+  if test "X$SUBFILING_VFD" = "Xyes"; then
+    AC_CONFIG_LINKS([testpar/h5fuse.sh:utils/subfiling_vfd/h5fuse.sh])
+  fi
+fi
 
 AC_CONFIG_COMMANDS([.classes], [], [$MKDIR_P java/src/.classes;
                 $MKDIR_P java/test/.classes;

--- a/src/H5FDsubfiling/H5FDioc.c
+++ b/src/H5FDsubfiling/H5FDioc.c
@@ -32,6 +32,8 @@
 #include "H5MMprivate.h"  /* Memory management        */
 #include "H5Pprivate.h"   /* Property lists           */
 
+#define CANBE_UNUSED(X) (void)(X)
+
 /* The driver identification number, initialized at runtime */
 static hid_t H5FD_IOC_g = H5I_INVALID_HID;
 
@@ -1223,6 +1225,7 @@ H5FD__ioc_read(H5FD_t *_file, H5FD_mem_t H5_ATTR_UNUSED type, hid_t H5_ATTR_UNUS
     H5FD_IOC_LOG_CALL(__func__);
 
     assert(file && file->pub.cls);
+    CANBE_UNUSED(file);
     assert(buf);
 
     /* Check for overflow conditions */

--- a/src/H5FDsubfiling/H5FDsubfile_int.c
+++ b/src/H5FDsubfiling/H5FDsubfile_int.c
@@ -347,6 +347,7 @@ H5FD__subfiling__get_real_eof(hid_t context_id, int64_t *logical_eof_ptr)
 
         assert(ioc_rank >= 0);
         assert(ioc_rank < n_io_concentrators);
+        CANBE_UNUSED(ioc_rank);
         assert(sf_eofs[i] == -1);
 
         sf_eofs[i] = recv_msg[(3 * i) + 1];

--- a/src/H5FDsubfiling/H5FDsubfiling_priv.h
+++ b/src/H5FDsubfiling/H5FDsubfiling_priv.h
@@ -63,4 +63,6 @@ H5_DLL herr_t H5FD__subfiling__get_real_eof(hid_t context_id, int64_t *logical_e
 }
 #endif
 
+#define CANBE_UNUSED(X) (void)(X)
+
 #endif /* H5FDsubfiling_priv_H */

--- a/src/H5FDsubfiling/H5subfiling_common.c
+++ b/src/H5FDsubfiling/H5subfiling_common.c
@@ -1365,7 +1365,8 @@ init_app_layout(sf_topology_t *app_topology, MPI_Comm comm, MPI_Comm node_comm)
         if (app_layout->layout[i].node_local_rank == 0)
             app_layout->node_count++;
 
-    assert(app_layout->node_count > 0);
+    if (app_layout->node_count <= 0)
+        H5_SUBFILING_GOTO_ERROR(H5E_VFL, H5E_CANTGET, FAIL, "node count less than or equal to zero");
 
     if (NULL ==
         (app_layout->node_ranks = malloc((size_t)app_layout->node_count * sizeof(*app_layout->node_ranks))))


### PR DESCRIPTION
Make the h5fuse.sh utility available to parallel subfiling tests so h5fuse related testing is not skipped for autotools builds.