### PR TITLE
Fix ifx unused variable hdferr warning.

### DIFF
--- a/fortran/src/H5Aff.F90
+++ b/fortran/src/H5Aff.F90
@@ -1131,6 +1131,9 @@ CONTAINS
     attr_id = INT(H5Aopen_by_idx(loc_id, c_obj_name, INT(idx_type, C_INT), INT(order, C_INT), n, &
          aapl_id_default, lapl_id_default), HID_T)
 
+    hdferr = 0
+    IF(attr_id.LT.0) hdferr = -1
+    
   END SUBROUTINE h5aopen_by_idx_f
 
 !>

--- a/release_docs/RELEASE.txt
+++ b/release_docs/RELEASE.txt
@@ -240,6 +240,10 @@ New Features
 
     Fortran Library:
     ----------------
+
+    - Fixed an uninitialized error return value for hdferr
+      to return the error state of the h5aopen_by_idx_f API.
+
     - Added h5pget_vol_cap_flags_f and related Fortran VOL
       capability definitions.
 


### PR DESCRIPTION
This will remove the following warning:
```
SUBROUTINE h5aopen_by_idx_f(loc_id, obj_name, idx_type, order, n, attr_id, hdferr, aapl_id, lapl_id)
-----------------------------------------------------------------------------^
H5Aff.F90(1091): remark #7712: This variable has not been used.   [HDFERR]
```