### PR TITLE
Switched from UNTESTED to UNT

### DIFF
--- a/CVE_list_1_14.md
+++ b/CVE_list_1_14.md
@@ -1,13 +1,13 @@
 | CVE issue number                                                                         | 1.14.0   | 1.14.1   | 1.14.2   | 1.14.3   |
 | :-------------------------------------------------------------------------               | :-----   | :-----   | :-----   | :-----   |
-| [CVE-2022-26061](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2022-26061)          | UNTESTED (3) | UNTESTED (3) | UNTESTED (3) | UNTESTED (3) |
-| [CVE-2022-25972](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2022-25972)          | UNTESTED (3) | UNTESTED (3) | UNTESTED (3) | UNTESTED (3) |
-| [CVE-2022-25942](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2022-25942)          | UNTESTED (3) | UNTESTED (3) | UNTESTED (3) | UNTESTED (3) |
+| [CVE-2022-26061](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2022-26061)          | UNT (3) | UNT (3) | UNT (3) | UNT (3) |
+| [CVE-2022-25972](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2022-25972)          | UNT (3) | UNT (3) | UNT (3) | UNT (3) |
+| [CVE-2022-25942](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2022-25942)          | UNT (3) | UNT (3) | UNT (3) | UNT (3) |
 | [CVE-2021-46244](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2021-46244)          | ✅       | ✅       | ✅       | ✅       |
 | [CVE-2021-46243](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2021-46243)          | ✅       | ✅       | ✅       | ✅       |
 | [CVE-2021-46242](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2021-46242)          | ✅       | ✅       | ✅       | ✅       |
 | [CVE-2021-45833](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2021-45833)          | ✅       | ✅       | ✅       | ✅       |
-| [CVE-2021-45832](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2021-45832)          | UNTESTED (1) | UNTESTED (1) | UNTESTED (1) | UNTESTED (1)|
+| [CVE-2021-45832](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2021-45832)          | UNT (1) | UNT (1) | UNT (1) | UNT (1)|
 | [CVE-2021-45830](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2021-45830)          | ✅       | ✅       | ✅       | ✅       |
 | [CVE-2021-45829](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2021-45829)          | ✅       | ✅       | ✅       | ✅       |
 | [CVE-2021-37501](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2021-37501)          | ❌       | ✅       | ✅       | ✅       |
@@ -69,6 +69,7 @@
 | [CVE-2016-4330](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2016-4330)            | ✅       | ✅       | ✅       | ✅       |
 
 ## NOTES
+* "UNT" denotes "UNTESTED"
 1. CVE-2021-45832 has no known proof of vulnerability file. The H5E code that could produce an infinite loop has been reworked, but without a vulnerable file or test program it's difficult to tell if this issue has been fixed. The stack trace provided with the CVE only contains part of the trace, so we don't even know the entry point into the library.
 2. CVE-2021-31009 is not a specific vulnerability against HDF5.
 3. CVE-2022-25942, CVE-2022-25972, and CVE-2022-26061 are not tested. Those vulnerabilities involve the high-level GIF tools and can be avoided by disabling those tools at build time.


### PR DESCRIPTION
This makes the lines shorter to keep CVE numbers on one line instead of breaking them into three lines.