### PR TITLE
Avoid  `unable to modify source` output message.

### DIFF
--- a/bin/make_err
+++ b/bin/make_err
@@ -156,8 +156,11 @@ sub create_public ($) {
     my $sect_name;              # Section of minor error messages
     my $sect_desc;              # Description of section
 
-    # Rename previous file
-#    rename "${prefix}${file}", "${prefix}${file}~" or die "unable to make backup";
+    # Remove previous file
+    if (-e "${prefix}${file}")
+    {
+        unlink "${prefix}${file}"
+    }
 
     # Open new header file
     open HEADER, ">${prefix}${file}" or die "unable to modify source";
@@ -224,8 +227,12 @@ sub create_init ($) {
     my $sect_name;              # Section of minor error messages
     my $sect_desc;              # Description of section
 
-    # Rename previous file
-#    rename "${prefix}${file}", "${prefix}${file}~" or die "unable to make backup";
+
+    # Remove previous file
+    if (-e "${prefix}${file}")
+    {
+        unlink "${prefix}${file}"
+    }    
 
     # Open new header file
     open HEADER, ">${prefix}${file}" or die "unable to modify source";
@@ -282,9 +289,13 @@ sub create_term ($) {
     my $sect_name;              # Section of minor error messages
     my $sect_desc;              # Description of section
 
-    # Rename previous file
-#    rename "${prefix}${file}", "${prefix}${file}~" or die "unable to make backup";
 
+    # Remove previous file
+    if (-e "${prefix}${file}")
+    {
+        unlink "${prefix}${file}"
+    }
+    
     # Open new header file
     open HEADER, ">${prefix}${file}" or die "unable to modify source";
 
@@ -330,8 +341,11 @@ sub create_define ($) {
     my $sect_name;              # Section of minor error messages
     my $sect_desc;              # Description of section
 
-    # Rename previous file
-#    rename "${prefix}${file}", "${prefix}${file}~" or die "unable to make backup";
+    # Remove previous file
+    if (-e "${prefix}${file}")
+    {
+        unlink "${prefix}${file}"
+    }
 
     # Open new header file
     open HEADER, ">${prefix}${file}" or die "unable to modify source";

--- a/bin/make_overflow
+++ b/bin/make_overflow
@@ -164,8 +164,11 @@ sub create_public ($) {
     my $file = "H5overflow.h";   # Name of file to generate
     my $name;                   # Name of function
 
-    # Rename previous file
-#    rename "${prefix}${file}", "${prefix}${file}~" or die "unable to make backup";
+    # Remove previous file
+    if (-e "${prefix}${file}")
+    {
+        unlink "${prefix}${file}"
+    }
 
     # Open new header file
     open HEADER, ">${prefix}${file}" or die "unable to modify source";

--- a/bin/make_vers
+++ b/bin/make_vers
@@ -466,7 +466,7 @@ sub create_public ($) {
     }
 
     # Open new header file
-    open HEADER, ">${prefix}${file}"  or die "unable to modify source";
+    open HEADER, ">${prefix}${file}" or die "unable to modify source";
 
     # Create file contents
     print_copyright(*HEADER);

--- a/bin/make_vers
+++ b/bin/make_vers
@@ -459,11 +459,14 @@ sub create_public ($) {
     my $file = "H5version.h";   # Name of file to generate
     my $name;                   # Name of function
 
-    # Rename previous file
-#    rename "${prefix}${file}", "${prefix}${file}~" or die "unable to make backup";
+    # Remove previous file
+    if (-e "${prefix}${file}")
+    {
+        unlink "${prefix}${file}"
+    }
 
     # Open new header file
-    open HEADER, ">${prefix}${file}" or die "unable to modify source";
+    open HEADER, ">${prefix}${file}"  or die "unable to modify source";
 
     # Create file contents
     print_copyright(*HEADER);


### PR DESCRIPTION
I think the `|| die` message should appear only when there's a system error (e.g., disk full).
I think it's better to remove an old header before it's being (re)generated from a text file.