### PR TITLE
Remove NVHPC [set_but_not_used] warning.

### DIFF
--- a/testpar/t_subfiling_vfd.c
+++ b/testpar/t_subfiling_vfd.c
@@ -2347,7 +2347,8 @@ main(int argc, char **argv)
         must_unset_ioc_thread_count_env = true;
     }
 
-    if (!(env_value = HDgetenv(H5FD_SUBFILING_CONFIG_FILE_PREFIX))) {
+    env_value = HDgetenv(H5FD_SUBFILING_CONFIG_FILE_PREFIX);
+    if (NULL != env_value) {
         int rand_value = 0;
 
         if (MAINPROCESS)


### PR DESCRIPTION
This PR will remove the following NVHPC warning:

```
warning: variable "env_value" was set but never used [set_but_not_used]
```