### PR TITLE
Use HDoff_t with lseek consistently

### DIFF
--- a/src/H5FDcore.c
+++ b/src/H5FDcore.c
@@ -362,7 +362,7 @@ H5FD__core_write_to_bstore(H5FD_core_t *file, haddr_t addr, size_t size)
 
 #ifndef H5_HAVE_PREADWRITE
     /* Seek to the correct location (if we don't have pwrite) */
-    if ((HDoff_t)addr != HDlseek(file->fd, (off_t)addr, SEEK_SET))
+    if ((HDoff_t)addr != HDlseek(file->fd, (HDoff_t)addr, SEEK_SET))
         HGOTO_ERROR(H5E_IO, H5E_SEEKERROR, FAIL, "error seeking in backing store");
 #endif /* H5_HAVE_PREADWRITE */
 

--- a/test/atomic_reader.c
+++ b/test/atomic_reader.c
@@ -114,7 +114,7 @@ verify(int fd, unsigned int k)
     } /* end if */
 
     /* Position the file at the beginning */
-    if (lseek(fd, (off_t)0, SEEK_SET) < 0) {
+    if (lseek(fd, 0, SEEK_SET) < 0) {
         printf("READER: error from lseek\n");
         goto error;
     } /* end if */

--- a/test/atomic_writer.c
+++ b/test/atomic_writer.c
@@ -190,7 +190,7 @@ main(int argc, char *argv[])
                 buf[u] = n;
 
             /* Position the file to the proper location */
-            if (lseek(fd, (off_t)(n * sizeof(unsigned int)), SEEK_SET) < 0) {
+            if (lseek(fd, (n * sizeof(unsigned int)), SEEK_SET) < 0) {
                 printf("WRITER: error from lseek\n");
                 goto error;
             } /* end if */

--- a/test/big.c
+++ b/test/big.c
@@ -143,7 +143,7 @@ is_sparse(void)
 
     if ((fd = HDopen("x.h5", O_RDWR | O_TRUNC | O_CREAT, H5_POSIX_CREATE_MODE_RW)) < 0)
         return 0;
-    if (HDlseek(fd, (off_t)(1024 * 1024), SEEK_SET) != 1024 * 1024)
+    if (HDlseek(fd, (HDoff_t)(1024 * 1024), SEEK_SET) != 1024 * 1024)
         return 0;
     if (5 != HDwrite(fd, "hello", (size_t)5))
         return 0;
@@ -267,7 +267,7 @@ enough_room(hid_t fapl)
         if ((fd[i] = HDopen(name, O_RDWR | O_CREAT | O_TRUNC, H5_POSIX_CREATE_MODE_RW)) < 0) {
             goto done;
         }
-        if ((off_t)size != HDlseek(fd[i], (off_t)size, SEEK_SET)) {
+        if ((HDoff_t)size != HDlseek(fd[i], (HDoff_t)size, SEEK_SET)) {
             goto done;
         }
         if (1 != HDwrite(fd[i], "X", (size_t)1)) {

--- a/test/dsets.c
+++ b/test/dsets.c
@@ -626,7 +626,7 @@ test_simple_io(const char *env_h5_drvr, hid_t fapl)
         file = -1;
 
         f = HDopen(filename, O_RDONLY);
-        HDlseek(f, (off_t)offset, SEEK_SET);
+        HDlseek(f, (HDoff_t)offset, SEEK_SET);
         if (HDread(f, rdata_bytes, sizeof(int) * DSET_DIM1 * DSET_DIM2) < 0)
             goto error;
 
@@ -763,7 +763,7 @@ test_userblock_offset(const char *env_h5_drvr, hid_t fapl, bool new_format)
         file = -1;
 
         f = HDopen(filename, O_RDONLY);
-        HDlseek(f, (off_t)offset, SEEK_SET);
+        HDlseek(f, (HDoff_t)offset, SEEK_SET);
         if (HDread(f, rdata_bytes, sizeof(int) * DSET_DIM1 * DSET_DIM2) < 0)
             goto error;
 

--- a/test/file_image.c
+++ b/test/file_image.c
@@ -871,7 +871,7 @@ test_get_file_image(const char *test_banner, const int file_name_num, hid_t fapl
             HDoff_t off;
 
             /* Position at userblock */
-            off = HDlseek(fd, (off_t)USERBLOCK_SIZE, SEEK_SET);
+            off = HDlseek(fd, (HDoff_t)USERBLOCK_SIZE, SEEK_SET);
             VERIFY(off >= 0, "HDlseek() failed.");
         }
 

--- a/test/istore.c
+++ b/test/istore.c
@@ -62,7 +62,7 @@ is_sparse(void)
 
     if ((fd = HDopen("x.h5", O_RDWR | O_TRUNC | O_CREAT, H5_POSIX_CREATE_MODE_RW)) < 0)
         return 0;
-    if (HDlseek(fd, (off_t)(1024 * 1024), SEEK_SET) != 1024 * 1024)
+    if (HDlseek(fd, (HDoff_t)(1024 * 1024), SEEK_SET) != 1024 * 1024)
         return 0;
     if (5 != HDwrite(fd, "hello", (size_t)5))
         return 0;

--- a/tools/src/h5jam/h5jam.c
+++ b/tools/src/h5jam/h5jam.c
@@ -420,8 +420,8 @@ copy_some_to_file(int infid, int outfid, hsize_t starting, hsize_t startout, ssi
     } /* end if */
 
     while (howmuch > 0) {
-        HDlseek(outfid, (off_t)to, SEEK_SET);
-        HDlseek(infid, (off_t)from, SEEK_SET);
+        HDlseek(outfid, (HDoff_t)to, SEEK_SET);
+        HDlseek(infid, (HDoff_t)from, SEEK_SET);
 
         if (howmuch > 512) {
             nchars = HDread(infid, buf, (unsigned)512);
@@ -499,7 +499,7 @@ write_pad(int ofile, hsize_t old_where, hsize_t *new_where)
 
     buf[0] = '\0';
 
-    HDlseek(ofile, (off_t)old_where, SEEK_SET);
+    HDlseek(ofile, (HDoff_t)old_where, SEEK_SET);
 
     psize = compute_user_block_size(old_where);
     psize -= old_where;

--- a/tools/test/misc/h5clear_gentest.c
+++ b/tools/test/misc/h5clear_gentest.c
@@ -274,7 +274,7 @@ gen_enhance_files(bool user)
         }
 
         /* location of "end of file address" */
-        if (lseek(fd, (off_t)(28 + (user ? USERBLOCK : 0)), SEEK_SET) < 0)
+        if (lseek(fd, (HDoff_t)(28 + (user ? USERBLOCK : 0)), SEEK_SET) < 0)
             goto error;
 
         /* Write the bad eoa value to the file */
@@ -282,7 +282,7 @@ gen_enhance_files(bool user)
             goto error;
 
         /* location of "superblock checksum" */
-        if (lseek(fd, (off_t)(44 + (user ? USERBLOCK : 0)), SEEK_SET) < 0)
+        if (lseek(fd, (HDoff_t)(44 + (user ? USERBLOCK : 0)), SEEK_SET) < 0)
             goto error;
 
         /* Write the chksum value to the file */

--- a/tools/test/perform/iopipe.c
+++ b/tools/test/perform/iopipe.c
@@ -123,7 +123,7 @@ main(void)
     unsigned                       u;
     herr_t H5_ATTR_NDEBUG_UNUSED   status;
     hssize_t H5_ATTR_NDEBUG_UNUSED n;
-    off_t H5_ATTR_NDEBUG_UNUSED    offset;
+    HDoff_t H5_ATTR_NDEBUG_UNUSED  offset;
     hsize_t                        start[2];
     hsize_t                        count[2];
 
@@ -207,7 +207,7 @@ main(void)
     for (u = 0; u < nwrite; u++) {
         putc(PROGRESS, stderr);
         fflush(stderr);
-        offset = HDlseek(fd, (off_t)0, SEEK_SET);
+        offset = HDlseek(fd, 0, SEEK_SET);
         assert(0 == offset);
         n = HDwrite(fd, the_data, (size_t)(size[0] * size[1]));
         assert(n >= 0 && (size_t)n == (size[0] * size[1]));
@@ -257,7 +257,7 @@ main(void)
     for (u = 0; u < nread; u++) {
         putc(PROGRESS, stderr);
         fflush(stderr);
-        offset = HDlseek(fd, (off_t)0, SEEK_SET);
+        offset = HDlseek(fd, 0, SEEK_SET);
         assert(0 == offset);
         n = HDread(fd, the_data, (size_t)(size[0] * size[1]));
         assert(n >= 0 && (size_t)n == (size[0] * size[1]));


### PR DESCRIPTION
lseek on Windows uses __int64 for both the offset and return type instead of off_t like most POSIX systems. This changes ensures we use HDoff_t (which is typdef'd correctly on Windows) w/ lseek.