### PR TITLE
Fix potential uninitialized variable

### DIFF
--- a/tools/src/h5perf/sio_engine.c
+++ b/tools/src/h5perf/sio_engine.c
@@ -139,9 +139,7 @@ do_sio(parameters param, results *res)
     /* IO type */
     iot = param.io_type;
 
-    if (NULL == (fname = calloc(FILENAME_MAX, sizeof(char))))
-        GOTOERROR(FAIL);
-
+    /* MUST initialize fd early since we check its file IDs in cleanup code */
     switch (iot) {
         case POSIXIO:
             fd.posixfd  = -1;
@@ -156,6 +154,9 @@ do_sio(parameters param, results *res)
             fprintf(stderr, "Unknown IO type request (%d)\n", (int)iot);
             GOTOERROR(FAIL);
     }
+
+    if (NULL == (fname = calloc(FILENAME_MAX, sizeof(char))))
+        GOTOERROR(FAIL);
 
     linear_buf_size = 1;
 


### PR DESCRIPTION
Moves a union initialization up a bit so it's performed before code that can jump to the cleanup target, where file descriptors could be checked without being initialized.

This could only happen in test code and only in an out-of-memory situation.

Fixes Coverity 1542254