### PR TITLE
Remove unnecessary assignment in test generator

### DIFF
--- a/tools/test/h5format_convert/h5fc_gentest.c
+++ b/tools/test/h5format_convert/h5fc_gentest.c
@@ -136,7 +136,6 @@ gen_non(const char *fname)
      */
 
     /* Create dataspace */
-    max_dims[0] = 10;
     max_dims[0] = H5S_UNLIMITED;
     max_dims[1] = H5S_UNLIMITED;
     if ((sid = H5Screate_simple(2, dims2, max_dims)) < 0)


### PR DESCRIPTION
Fixes what looks like a copy/paste/modify error in the format convert test file generator, where an array element is assigned one value and them immediately overwritten by another value.

Fixes Coverity issue 1542285