### PR TITLE
Removed the use of -commons linking option on Darwin (#3581)

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -1070,14 +1070,6 @@ H5_FORTRAN_SHARED="no"
 if test "X${HDF_FORTRAN}" = "Xyes" && test "X${enable_shared}" != "Xno"; then
   AC_MSG_CHECKING([if shared Fortran libraries are supported])
   H5_FORTRAN_SHARED="yes"
-  ## tell libtool to do the right thing with COMMON symbols, this fixes
-  ## corrupt values with COMMON and EQUIVALENCE when building shared
-  ## Fortran libraries on OSX with gnu and Intel compilers (HDFFV-2772).
-  case "`uname`" in
-    Darwin*)
-    H5_LDFLAGS="$H5_LDFLAGS -Wl,-commons,use_dylibs"
-    ;;
-  esac
 
   ## Report results of check(s)
 

--- a/fortran/src/H5_ff.F90
+++ b/fortran/src/H5_ff.F90
@@ -12,8 +12,6 @@
 ! PURPOSE
 !  This module is used to pass C stubs for H5 Fortran APIs. The C stubs are
 !  packed into arrays in H5_f.c and these arrays are then passed to Fortran.
-!  This module then uses EQUIVALENCE to assign elements of the arrays to
-!  Fortran equivalent C stubs.
 !
 ! NOTES
 !  The size of the C arrays in H5_f.c has to match the values of the variables

--- a/release_docs/RELEASE.txt
+++ b/release_docs/RELEASE.txt
@@ -65,6 +65,11 @@ New Features
     -
 
 
+    - Removed "-commons" linking option on Darwin, as COMMON and EQUIVALENCE
+      are no longer used in the Fortran source.
+
+      Fixes GitHub issue #3571
+
     C++ Library:
     ------------
     -


### PR DESCRIPTION
Removed the use of -commons linking option on Darwin as COMMON and EQUIVALENCE is no long used