### PR TITLE
Fix Intel oneAPI icc warning

### DIFF
--- a/test/h5test.c
+++ b/test/h5test.c
@@ -480,8 +480,14 @@ h5_fixname_real(const char *base_name, hid_t fapl, const char *_suffix, char *fu
             if (H5FD_FAMILY == driver) {
                 if (subst_for_superblock)
                     suffix = "-000000.h5";
-                else
-                    suffix = nest_printf ? "-%%06d.h5" : "-%06d.h5";
+                else {
+                    if (nest_printf) {
+                        suffix = "-%%06d.h5";
+                    }
+                    else {
+                        suffix = "-%06d.h5";
+                    }
+                }
             }
             else if (H5FD_MULTI == driver) {
 


### PR DESCRIPTION
This fixes the following warning:
```
/home/runner/work/hdf5/hdf5/test/h5test.c(484): warning #3179: deprecated conversion of string literal to char* (should be const char*)
                      suffix = nest_printf ? "-%%06d.h5" : "-%06d.h5";
                                                         ^
```
