### PR TITLE
Fixes GH#1027 compilation error

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -451,6 +451,12 @@ include (${HDF_RESOURCES_DIR}/ConfigureChecks.cmake)
 set (CMAKE_INCLUDE_CURRENT_DIR_IN_INTERFACE ON)
 
 #-----------------------------------------------------------------------------
+# Include directories in the source or build tree should come before other
+# directories to prioritize headers in the sources over installed ones.
+#-----------------------------------------------------------------------------
+set(CMAKE_INCLUDE_DIRECTORIES_PROJECT_BEFORE ON)
+
+#-----------------------------------------------------------------------------
 # Mac OS X Options
 #-----------------------------------------------------------------------------
 if (HDF5_BUILD_FRAMEWORKS AND NOT BUILD_SHARED_LIBS)

--- a/release_docs/RELEASE.txt
+++ b/release_docs/RELEASE.txt
@@ -682,7 +682,14 @@ Bug Fixes since HDF5-1.14.0 release
       Checks were added to the CMake and Autotools code to verify that CLOCK_MONOTONIC_COARSE,
       PTHREAD_MUTEX_ADAPTIVE_NP and pthread_condattr_setclock() are available before attempting
       to use them in Subfiling VFD-related utility code. Without these checks, attempting
-      to build the Subfiling VFD on macOS would fail. 
+      to build the Subfiling VFD on macOS would fail.
+
+    - Fixes the ordering of INCLUDES when building with CMake
+
+      Include directories in the source or build tree should come before other
+      directories to prioritize headers in the sources over installed ones.
+
+      Fixes GitHub #1027
 
     - The accum test now passes on macOS 12+ (Monterey) w/ CMake
 


### PR DESCRIPTION
Addresses:

Unable to build 1.12.1 when already installed (Error: Symbol ‘h5i_invalid_hid_f’ at (1) has no IMPLICIT type)  
#1027 