### PR TITLE
Remove clang warnings

### DIFF
--- a/src/H5FDsubfiling/H5FDsubfiling.c
+++ b/src/H5FDsubfiling/H5FDsubfiling.c
@@ -1556,7 +1556,7 @@ H5FD__subfiling_read(H5FD_t *_file, H5FD_mem_t type, hid_t H5_ATTR_UNUSED dxpl_i
         H5_SUBFILING_GOTO_ERROR(H5E_ARGS, H5E_BADVALUE, FAIL, "addr undefined, addr = %" PRIuHADDR, addr);
     if (REGION_OVERFLOW(addr, size))
         H5_SUBFILING_GOTO_ERROR(H5E_ARGS, H5E_OVERFLOW, FAIL,
-                                "addr overflow, addr = %" PRIuHADDR ", size = %lu", addr, size);
+                                "addr overflow, addr = %" PRIuHADDR ", size = %zu", addr, size);
 
     /* Temporarily reject collective I/O until support is implemented (unless types are simple MPI_BYTE) */
     {
@@ -1789,7 +1789,7 @@ H5FD__subfiling_write(H5FD_t *_file, H5FD_mem_t type, hid_t H5_ATTR_UNUSED dxpl_
         H5_SUBFILING_GOTO_ERROR(H5E_ARGS, H5E_BADVALUE, FAIL, "addr undefined, addr = %" PRIuHADDR, addr);
     if (REGION_OVERFLOW(addr, size))
         H5_SUBFILING_GOTO_ERROR(H5E_ARGS, H5E_OVERFLOW, FAIL,
-                                "addr overflow, addr = %" PRIuHADDR ", size = %lu", addr, size);
+                                "addr overflow, addr = %" PRIuHADDR ", size = %zu", addr, size);
 
     /* Temporarily reject collective I/O until support is implemented (unless types are simple MPI_BYTE) */
     {

--- a/src/H5FDsubfiling/H5FDsubfiling.c
+++ b/src/H5FDsubfiling/H5FDsubfiling.c
@@ -1556,7 +1556,7 @@ H5FD__subfiling_read(H5FD_t *_file, H5FD_mem_t type, hid_t H5_ATTR_UNUSED dxpl_i
         H5_SUBFILING_GOTO_ERROR(H5E_ARGS, H5E_BADVALUE, FAIL, "addr undefined, addr = %" PRIuHADDR, addr);
     if (REGION_OVERFLOW(addr, size))
         H5_SUBFILING_GOTO_ERROR(H5E_ARGS, H5E_OVERFLOW, FAIL,
-                                "addr overflow, addr = %" PRIuHADDR ", size = %" PRIuHADDR, addr, size);
+                                "addr overflow, addr = %" PRIuHADDR ", size = %lu", addr, size);
 
     /* Temporarily reject collective I/O until support is implemented (unless types are simple MPI_BYTE) */
     {
@@ -1789,7 +1789,7 @@ H5FD__subfiling_write(H5FD_t *_file, H5FD_mem_t type, hid_t H5_ATTR_UNUSED dxpl_
         H5_SUBFILING_GOTO_ERROR(H5E_ARGS, H5E_BADVALUE, FAIL, "addr undefined, addr = %" PRIuHADDR, addr);
     if (REGION_OVERFLOW(addr, size))
         H5_SUBFILING_GOTO_ERROR(H5E_ARGS, H5E_OVERFLOW, FAIL,
-                                "addr overflow, addr = %" PRIuHADDR ", size = %" PRIuHADDR, addr, size);
+                                "addr overflow, addr = %" PRIuHADDR ", size = %lu", addr, size);
 
     /* Temporarily reject collective I/O until support is implemented (unless types are simple MPI_BYTE) */
     {


### PR DESCRIPTION
This PR will remove 2 clang15 warnings on macOS-13.

```
[146/4042] Building C object src/CMakeFiles/hdf5-static.dir/H5FDsubfiling/H5FDsubfiling.c.o
/Users/runner/work/hdf5/hdf5/src/H5FDsubfiling/H5FDsubfiling.c:[155](https://github.com/hyoklee/hdf5/actions/runs/6475183334/job/17581689545#step:6:156)9:99: warning: format specifies type 'unsigned long long' but the argument has type 'size_t' (aka 'unsigned long') [-Wformat]
                                "addr overflow, addr = %" PRIuHADDR ", size = %" PRIuHADDR, addr, size);
                                ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^~~~~
/Users/runner/work/hdf5/hdf5/src/H5FDsubfiling/H5subfiling_err.h:135:33: note: expanded from macro 'H5_SUBFILING_GOTO_ERROR'
                fprintf(stderr, __VA_ARGS__);                                                                \
                                ^~~~~~~~~~~
/Users/runner/work/hdf5/hdf5/src/H5FDsubfiling/H5FDsubfiling.c:1792:99: warning: format specifies type 'unsigned long long' but the argument has type 'size_t' (aka 'unsigned long') [-Wformat]
                                "addr overflow, addr = %" PRIuHADDR ", size = %" PRIuHADDR, addr, size);
                                ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^~~~~
/Users/runner/work/hdf5/hdf5/src/H5FDsubfiling/H5subfiling_err.h:135:33: note: expanded from macro 'H5_SUBFILING_GOTO_ERROR'
                fprintf(stderr, __VA_ARGS__);                                                                \
                                ^~~~~~~~~~~
2 warnings generated.
```