### PR TITLE
Add Intel oneAPI and LLVM for Windows Action.

### DIFF
--- a/.github/workflows/win-ninja-icx.yml
+++ b/.github/workflows/win-ninja-icx.yml
@@ -4,7 +4,26 @@ on:
   push:
     branches:
       - develop
+  pull_request:  
+    branches:
+      - develop
+    paths-ignore:
+      - '.github/CODEOWNERS'
+      - '.github/FUNDING.yml'
+      - 'doc/**'
+      - 'release_docs/**'
+      - 'ACKNOWLEDGEMENTS'
+      - 'COPYING**'
+      - '**.md'
 
+# Using concurrency to cancel any in-progress job or run
+concurrency:
+  group: ${{ github.workflow }}-${{ github.sha || github.event.pull_request.number }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+      
 jobs:
   build:
     runs-on: windows-latest

--- a/.github/workflows/win-ninja-icx.yml
+++ b/.github/workflows/win-ninja-icx.yml
@@ -1,0 +1,39 @@
+name: windows ninja icx
+
+on:
+  push:
+    branches:
+      - develop
+
+jobs:
+  build:
+    runs-on: windows-latest
+    steps:
+      - name: Install CMake and Ninja
+        uses: lukka/get-cmake@latest
+        with:
+          cmakeVersion: "3.27.7"
+      - name: Install LLVM and Clang
+        uses: KyleMayes/install-llvm-action@v1
+        with:
+          version: "15"
+      - name: Install Intel OneAPI
+        uses: awvwgk/setup-fortran@main
+        with:
+          compiler: intel
+          version: '2023.2'
+      - name: Checkout HDF5
+        uses: actions/checkout@v4
+      - name: Set oneAPI
+        shell: cmd
+        run: |
+          "C:\Program Files (x86)\Intel\oneAPI\setvars.bat"
+      - name: Configure & Build & Test
+        shell: cmd
+        run: |
+          cd hdf5
+          mkdir build
+          cd build
+          cmake -G Ninja -DCMAKE_C_COMPILER="C:/Program Files (x86)/Intel/oneAPI/compiler/2023.2.0/windows/bin/icx.exe" -DHDF5_ENABLE_SZIP_SUPPORT:BOOL=OFF -DHDF5_ENABLE_Z_LIB_SUPPORT:BOOL=OFF ..
+          ninja
+          ninja test

--- a/tools/test/h5dump/CMakeTests.cmake
+++ b/tools/test/h5dump/CMakeTests.cmake
@@ -426,7 +426,7 @@
     configure_file(${PROJECT_SOURCE_DIR}/exportfiles/tbinregR.exp ${PROJECT_BINARY_DIR}/testfiles/std/tbinregR.exp NEWLINE_STYLE CRLF)
     #file (READ ${PROJECT_SOURCE_DIR}/exportfiles/tbinregR.exp TEST_STREAM)
     #file (WRITE ${PROJECT_BINARY_DIR}/testfiles/std/tbinregR.exp "${TEST_STREAM}")
-    HDFTEST_COPY_FILE("${PROJECT_SOURCE_DIR}/expected/tfloatsattrs.wddl" "${PROJECT_BINARY_DIR}/testfiles/std/tfloatsattrs.ddl" "h5dump_std_files")
+    #HDFTEST_COPY_FILE("${PROJECT_SOURCE_DIR}/expected/tfloatsattrs.wddl" "${PROJECT_BINARY_DIR}/testfiles/std/tfloatsattrs.ddl" "h5dump_std_files")
   else ()
     HDFTEST_COPY_FILE("${PROJECT_SOURCE_DIR}/exportfiles/tbinregR.exp" "${PROJECT_BINARY_DIR}/testfiles/std/tbinregR.exp" "h5dump_std_files")
     HDFTEST_COPY_FILE("${PROJECT_SOURCE_DIR}/expected/tfloatsattrs.ddl" "${PROJECT_BINARY_DIR}/testfiles/std/tfloatsattrs.ddl" "h5dump_std_files")


### PR DESCRIPTION
 This simple action may help Windows users (e.g., #3275 user).

 This action is also good for 1.14.3 release testing as well,
 since it uses the latest CMake 3.27.7 and Intel oneAPI for Windows.

 It has one failure:
```
99% tests passed, 1 tests failed out of 2199

Total Test time (real) = 563.81 sec

The following tests FAILED:
	1731 - H5DUMP-tfloatsattrs (Failed)
```