### PR TITLE
Fixes test failure for gfortran -O2 and -O3, -fdefault-real-16

### DIFF
--- a/config/cmake/HDFFortranCompilerFlags.cmake
+++ b/config/cmake/HDFFortranCompilerFlags.cmake
@@ -51,6 +51,10 @@ if (CMAKE_Fortran_COMPILER_ID STREQUAL "GNU" AND NOT CMAKE_Fortran_COMPILER_VERS
     set (CMAKE_Fortran_FLAGS "${CMAKE_Fortran_FLAGS} -fdiagnostics-urls=never -fno-diagnostics-color")
   endif ()
 endif ()
+if (CMAKE_Fortran_COMPILER_ID STREQUAL "NAG")
+    message (STATUS "... Select IEEE floating-point mode full")
+    list (APPEND HDF5_CMAKE_Fortran_FLAGS "-ieee=full")
+endif ()
 
 if (CMAKE_Fortran_COMPILER_ID STREQUAL "NAG")
     message (STATUS "... Select IEEE floating-point mode full")

--- a/config/cmake/HDFFortranCompilerFlags.cmake
+++ b/config/cmake/HDFFortranCompilerFlags.cmake
@@ -51,10 +51,6 @@ if (CMAKE_Fortran_COMPILER_ID STREQUAL "GNU" AND NOT CMAKE_Fortran_COMPILER_VERS
     set (CMAKE_Fortran_FLAGS "${CMAKE_Fortran_FLAGS} -fdiagnostics-urls=never -fno-diagnostics-color")
   endif ()
 endif ()
-if (CMAKE_Fortran_COMPILER_ID STREQUAL "NAG")
-    message (STATUS "... Select IEEE floating-point mode full")
-    list (APPEND HDF5_CMAKE_Fortran_FLAGS "-ieee=full")
-endif ()
 
 if (CMAKE_Fortran_COMPILER_ID STREQUAL "NAG")
     message (STATUS "... Select IEEE floating-point mode full")

--- a/fortran/test/tH5P_F03.F90
+++ b/fortran/test/tH5P_F03.F90
@@ -146,7 +146,6 @@ SUBROUTINE test_create(total_error)
   !  Compound datatype test
 
   f_ptr = C_LOC(fill_ctype)
-
   CALL H5Pget_fill_value_f(dcpl, comp_type_id, f_ptr, error)
   CALL check("H5Pget_fill_value_f",error, total_error)
 
@@ -184,6 +183,7 @@ SUBROUTINE test_create(total_error)
   CALL VERIFY("***ERROR: Returned wrong fill value (real)", rfill, 2.0, total_error)
 
   ! For the actual compound type
+  f_ptr = C_LOC(fill_ctype)
   CALL H5Pset_fill_value_f(dcpl, comp_type_id, f_ptr, error)
   CALL check("H5Pget_fill_value_f",error, total_error)
 
@@ -254,7 +254,6 @@ SUBROUTINE test_create(total_error)
   CALL check("H5Dget_create_plist_f", error, total_error)
 
   f_ptr = C_LOC(rd_c)
-
   CALL H5Pget_fill_value_f(dcpl, comp_type_id, f_ptr, error)
   CALL check("H5Pget_fill_value_f", error, total_error)
   CALL verify("***ERROR: Returned wrong fill value", rd_c%a, fill_ctype%a, total_error)

--- a/release_docs/RELEASE.txt
+++ b/release_docs/RELEASE.txt
@@ -880,7 +880,12 @@ Bug Fixes since HDF5-1.14.0 release
       configuration information in the HDF5_VOL_CONNECTOR environment variable and
       would incorrectly report that the specified VOL connector isn't registered
       due to including the configuration information as part of the VOL connector
-      name being checked for registration status. This has now been fixed. 
+      name being checked for registration status. This has now been fixed.
+
+   - Fixed Fortran 2003 test with gfortran-v13, optimization levels O2,O3
+
+     Fixes failing Fortran 2003 test with gfortran, optimization level O2,O3
+     with -fdefault-real-16. Fixes GH #2928.
 
 
 Platforms Tested


### PR DESCRIPTION
Seems higher optimization causes corruption, fixes GH #2928 .