### PR TITLE
Fix compilation error on clang15/gfortran/macOS-13

### DIFF
--- a/fortran/examples/ph5example.f90
+++ b/fortran/examples/ph5example.f90
@@ -16,10 +16,10 @@
      PROGRAM DATASET
 
      USE HDF5 ! This module contains all necessary modules
-
+     USE MPI
+     
      IMPLICIT NONE
 
-     INCLUDE 'mpif.h'
      CHARACTER(LEN=10), PARAMETER :: default_fname = "sds.h5"  ! Default name
      CHARACTER(LEN=8), PARAMETER :: dsetname = "IntArray" ! Dataset name
 


### PR DESCRIPTION
This PR will fix these errors:

```
Error: GNU Extension: Nonstandard type declaration INTEGER*8 at (1)
mpif.h:534:42:

Error: Symbol 'mpi_displacement_current' at (1) has no IMPLICIT type
mpif.h:551:14:

Error: GNU Extension: Nonstandard type declaration REAL*8 at (1)
mpif.h:552:14:

Error: GNU Extension: Nonstandard type declaration REAL*8 at (1)
/Users/runner/work/hdf5/hdf5/fortran/examples/ph5example.f90:27:33:
```