### PR TITLE
Add support for AOCC & Flang w/ the Autotools

### DIFF
--- a/config/clang-cxxflags
+++ b/config/clang-cxxflags
@@ -47,6 +47,7 @@ load_clang_arguments()
     done)
     IFS=' ' echo "$*"
 }
+
 # Get the compiler version in a way that works for clang++
 # unless a compiler version is already known
 #

--- a/config/clang-fflags
+++ b/config/clang-fflags
@@ -1,0 +1,139 @@
+#                            -*- shell-script -*-
+#
+# Copyright by The HDF Group.
+# All rights reserved.
+#
+# This file is part of HDF5.  The full HDF5 copyright notice, including
+# terms governing use, modification, and redistribution, is contained in
+# the COPYING file, which can be found at the root of the source code
+# distribution tree, or in https://www.hdfgroup.org/licenses.
+# If you do not have access to either file, you may request a copy from
+# help@hdfgroup.org.
+
+
+# This file should be sourced into configure if the compiler is the
+# Clang Fortran compiler (flang) or a derivative.  It is careful not to do
+# anything if the compiler is not Clang; otherwise 'cc_flags_set' is set
+# to 'yes'
+#
+
+# Get the compiler version in a way that works for clang
+# unless a compiler version is already known
+#
+#   cc_vendor:    The compiler name: flang
+#   cc_version:   Version number: 6.0.0, 7.3.0, ... 10.0.1
+#
+if test "X-" = "X-$f9x_flags_set"; then
+    # flang -v will return version number following "clang"
+    f9x_version="`$FC $FCFLAGS $H5_FCFLAGS -v 2>&1 |\
+        grep 'clang version' | sed 's/.*clang version \([-a-z0-9\.]*\).*/\1/'`"
+    if test -n "$f9x_version"; then
+        f9x_vendor="flang"
+    fi
+    if test "X-" != "X-$f9x_version"; then
+
+        # Get the compiler version numbers
+        f9x_vers_major=`echo $f9x_version | cut -f1 -d.`
+        f9x_vers_minor=`echo $f9x_version | cut -f2 -d.`
+        f9x_vers_patch=`echo $f9x_version | cut -f3 -d.`
+        test -n "$f9x_vers_major" || f9x_vers_major=0
+        test -n "$f9x_vers_minor" || f9x_vers_minor=0
+        test -n "$f9x_vers_patch" || f9x_vers_patch=0
+    fi
+fi
+
+if test "X-flang" = "X-$f9x_vendor"; then
+
+    echo "compiler '$FC' is $f9x_vendor-$f9x_version"
+
+    FC_BASENAME=flang
+    F9XSUFFIXFLAG=""
+    FSEARCH_DIRS=""
+
+    ###############################
+    # Architecture-specific flags #
+    ###############################
+
+    arch=
+    # Nothing currently. (Uncomment code below and modify to add any)
+    #case "$host_os-$host_cpu" in
+    #    *-i686)
+    #        arch="-march=i686"
+    #        ;;
+    #esac
+
+    H5_FCFLAGS="$H5_FCFLAGS $arch"
+
+    ##############
+    # Production #
+    ##############
+
+    PROD_FCFLAGS=
+
+    #########
+    # Debug #
+    #########
+
+    DEBUG_FCFLAGS=
+
+    ########################
+    # Enhanced Diagnostics #
+    ########################
+
+    NO_DIAGS_FCFLAGS=
+    DIAGS_FCFLAGS=
+
+    ###########
+    # Symbols #
+    ###########
+
+    NO_SYMBOLS_FCFLAGS=
+    SYMBOLS_FCFLAGS=
+
+    #############
+    # Profiling #
+    #############
+
+    PROFILE_FCFLAGS=
+
+    ################
+    # Optimization #
+    ################
+
+    HIGH_OPT_FCFLAGS="-O3"
+    NO_OPT_FCFLAGS="-O0"
+    DEBUG_OPT_FCFLAGS="-O0"
+
+    ############
+    # Warnings #
+    ############
+
+    ###########
+    # General #
+    ###########
+
+    # We don't use OpenMP, so don't link to it
+    H5_FCFLAGS="$H5_FCFLAGS -nomp"
+
+    ######################
+    # Developer warnings #
+    ######################
+
+    NO_DEVELOPER_WARNING_FCFLAGS=
+    DEVELOPER_WARNING_FCFLAGS=
+
+    #############################
+    # Version-specific warnings #
+    #############################
+
+    #################
+    # Flags are set #
+    #################
+    f9x_flags_set=yes
+fi
+
+# Clear f9x info if no flags set
+if test "X$f9x_flags_set" = "X"; then
+    f9x_vendor=
+    f9x_version=
+fi

--- a/config/linux-gnulibc1
+++ b/config/linux-gnulibc1
@@ -122,6 +122,9 @@ fi
 # Figure out Intel FC compiler flags
 . $srcdir/config/intel-fflags
 
+# Figure out Clang FC compiler flags
+. $srcdir/config/clang-fflags
+
 case $FC_BASENAME in
     #
     # Absoft compiler

--- a/configure.ac
+++ b/configure.ac
@@ -4244,14 +4244,17 @@ if test "X$HDF_FORTRAN" = "Xyes"; then
       ;;
   esac
 
-  ### libtool does not pass the correct argument linking (-Wl,-Wl,,) for the NAG Fortran compiler
+  ### libtool does not pass the correct linker options for some Fortran compilers
   ### on Linux (other OSs have not been tested).
-  ### Therefore, detect if we are using the NAG Fortran compiler, and replace the wl="-Wl," for Fortran to
-  ### wl="-Wl,-Wl,," in the libtool file. (HDFFV-10037)
   case "`uname`" in
     Linux*)
+      ### NAG Fortran needs to replace "-Wl," with "-Wl,-Wl,," (HDFFV-10037)
       if test "X$FC_BASENAME" = "Xnagfor"; then
          cat libtool | awk '/BEGIN LIBTOOL TAG CONFIG: FC/{flag=1}flag&&/wl=/{$NF="wl=\"-Wl,-Wl,,\"";flag=0}1' > libtool.tmp && mv -f libtool.tmp libtool && chmod 755 libtool
+      fi
+      ### Flang needs to replace "", with "-Wl," (avoids unknown option: -soname issues)
+      if test "X$FC_BASENAME" = "Xflang"; then
+         cat libtool | awk '/BEGIN LIBTOOL TAG CONFIG: FC/{flag=1}flag&&/wl=/{$NF="wl=\"-Wl,\"";flag=0}1' > libtool.tmp && mv -f libtool.tmp libtool && chmod 755 libtool
       fi
       ;;
   esac

--- a/release_docs/RELEASE.txt
+++ b/release_docs/RELEASE.txt
@@ -47,6 +47,20 @@ New Features
 
     Configuration:
     -------------
+    - Added support for AOCC and classic Flang w/ the Autotools
+
+      * Adds a config/clang-fflags options file to support Flang
+      * Corrects missing "-Wl," from linker options in the libtool wrappers
+        when using Flang, the MPI Fortran compiler wrappers, and building
+        the shared library. This would often result in unrecognized options
+        like -soname.
+      * Enable -nomp w/ Flang to avoid linking to the OpenMPI library.
+
+      CMake can build the parallel, shared library w/ Fortran using AOCC
+      and Flang, so no changes were needed for that build system.
+
+      Fixes GitHub issues #3439, #1588, #366, #280
+
     - Converted the build of libaec and zlib to use FETCH_CONTENT with CMake.
 
       Using the CMake FetchContent module, the external filters can populate


### PR DESCRIPTION
* Adds a config/clang-fflags options file to support Flang
* Corrects missing "-Wl," from linker options in the libtool wrappers when using Flang, the MPI Fortran compiler wrappers, and building the shared library. This would often result in unrecognized options like -soname.
* Enable -nomp w/ Flang to avoid linking to the OpenMPI library.

CMake can build the parallel, shared library w/ Fortran using AOCC and Flang, so no changes were needed for that build system.

Fixes GitHub issues #3458, #3439, #1588, #366, #280