### PR TITLE
Remove CANBE_UNUSED() from subfiling VFD

### DIFF
--- a/src/H5FDsubfiling/H5FDioc.c
+++ b/src/H5FDsubfiling/H5FDioc.c
@@ -32,8 +32,6 @@
 #include "H5MMprivate.h"  /* Memory management        */
 #include "H5Pprivate.h"   /* Property lists           */
 
-#define CANBE_UNUSED(X) (void)(X)
-
 /* The driver identification number, initialized at runtime */
 static hid_t H5FD_IOC_g = H5I_INVALID_HID;
 
@@ -1219,13 +1217,14 @@ static herr_t
 H5FD__ioc_read(H5FD_t *_file, H5FD_mem_t H5_ATTR_UNUSED type, hid_t H5_ATTR_UNUSED dxpl_id, haddr_t addr,
                size_t size, void *buf)
 {
-    H5FD_ioc_t *file      = (H5FD_ioc_t *)_file;
-    herr_t      ret_value = SUCCEED;
+#ifndef NDEBUG
+    H5FD_ioc_t *file = (H5FD_ioc_t *)_file;
+#endif
+    herr_t ret_value = SUCCEED;
 
     H5FD_IOC_LOG_CALL(__func__);
 
     assert(file && file->pub.cls);
-    CANBE_UNUSED(file);
     assert(buf);
 
     /* Check for overflow conditions */

--- a/src/H5FDsubfiling/H5FDsubfile_int.c
+++ b/src/H5FDsubfiling/H5FDsubfile_int.c
@@ -343,11 +343,12 @@ H5FD__subfiling__get_real_eof(hid_t context_id, int64_t *logical_eof_ptr)
         H5_SUBFILING_MPI_GOTO_ERROR(FAIL, "MPI_Waitall", mpi_code);
 
     for (int i = 0; i < num_subfiles; i++) {
+#ifndef NDEBUG
         int ioc_rank = (int)recv_msg[3 * i];
+#endif
 
         assert(ioc_rank >= 0);
         assert(ioc_rank < n_io_concentrators);
-        CANBE_UNUSED(ioc_rank);
         assert(sf_eofs[i] == -1);
 
         sf_eofs[i] = recv_msg[(3 * i) + 1];

--- a/src/H5FDsubfiling/H5FDsubfiling_priv.h
+++ b/src/H5FDsubfiling/H5FDsubfiling_priv.h
@@ -63,6 +63,4 @@ H5_DLL herr_t H5FD__subfiling__get_real_eof(hid_t context_id, int64_t *logical_e
 }
 #endif
 
-#define CANBE_UNUSED(X) (void)(X)
-
 #endif /* H5FDsubfiling_priv_H */


### PR DESCRIPTION
This macro was an attempt to quiet warnings about release mode unused variables that only appear in asserts. It resolves to a void cast, which doesn't quiet warnings when an assignment has already taken place.