### PR TITLE
Suppress MPI_Waitall warnings w/ MPICH

### DIFF
--- a/src/H5FDsubfiling/H5FDioc_int.c
+++ b/src/H5FDsubfiling/H5FDioc_int.c
@@ -423,8 +423,14 @@ ioc__async_completion(MPI_Request *mpi_reqs, size_t num_reqs)
     assert(mpi_reqs);
 
     H5_CHECK_OVERFLOW(num_reqs, size_t, int);
+
+    /* Have to supppress gcc warnings regarding MPI_STATUSES_IGNORE
+     * with MPICH (https://github.com/pmodels/mpich/issues/5687)
+     */
+    H5_GCC_DIAG_OFF("stringop-overflow")
     if (MPI_SUCCESS != (mpi_code = MPI_Waitall((int)num_reqs, mpi_reqs, MPI_STATUSES_IGNORE)))
         H5_SUBFILING_MPI_GOTO_ERROR(FAIL, "MPI_Waitall failed", mpi_code);
+    H5_GCC_DIAG_ON("stringop-overflow")
 
 done:
     H5_SUBFILING_FUNC_LEAVE;

--- a/src/H5FDsubfiling/H5FDsubfile_int.c
+++ b/src/H5FDsubfiling/H5FDsubfile_int.c
@@ -143,17 +143,19 @@ H5FD__subfiling__truncate_sub_files(hid_t context_id, int64_t logical_file_eof, 
         }
 
         /* Wait for truncate operations to complete */
+        H5_GCC_DIAG_OFF("stringop-overflow")
         if (MPI_SUCCESS != (mpi_code = MPI_Waitall(num_subfiles_owned, recv_reqs, MPI_STATUSES_IGNORE)))
             H5_SUBFILING_MPI_GOTO_ERROR(FAIL, "MPI_Waitall", mpi_code);
+        H5_GCC_DIAG_ON("stringop-overflow")
 
-            /* sanity check -- compute the file eof using the same mechanism used to
-             * compute the subfile eof.  Assert that the computed value and the
-             * actual value match.
-             *
-             * Do this only for debug builds -- probably delete this before release.
-             *
-             *                                           JRM -- 12/15/21
-             */
+        /* sanity check -- compute the file eof using the same mechanism used to
+         * compute the subfile eof.  Assert that the computed value and the
+         * actual value match.
+         *
+         * Do this only for debug builds -- probably delete this before release.
+         *
+         *                                           JRM -- 12/15/21
+         */
 
 #ifndef NDEBUG
         {
@@ -339,8 +341,10 @@ H5FD__subfiling__get_real_eof(hid_t context_id, int64_t *logical_eof_ptr)
     }
 
     /* Wait for EOF communication to complete */
+    H5_GCC_DIAG_OFF("stringop-overflow")
     if (MPI_SUCCESS != (mpi_code = MPI_Waitall(num_subfiles, recv_reqs, MPI_STATUSES_IGNORE)))
         H5_SUBFILING_MPI_GOTO_ERROR(FAIL, "MPI_Waitall", mpi_code);
+    H5_GCC_DIAG_ON("stringop-overflow")
 
     for (int i = 0; i < num_subfiles; i++) {
         int ioc_rank = (int)recv_msg[3 * i];


### PR DESCRIPTION
MPICH defines MPI_STATUSES_IGNORE (a pointer) to 1, which raises warnings w/ gcc. This is a known issue that the MPICH devs are not going to fix.

See here:
    https://github.com/pmodels/mpich/issues/5687

This fix suppresses those issues w/ gcc