### PR TITLE
Initialize API context MPI types to MPI_BYTE

### DIFF
--- a/src/H5CX.c
+++ b/src/H5CX.c
@@ -778,6 +778,11 @@ H5CX__push_common(H5CX_node_t *cnode)
     cnode->ctx.tag     = H5AC__INVALID_TAG;
     cnode->ctx.ring    = H5AC_RING_USER;
 
+#ifdef H5_HAVE_PARALLEL
+    cnode->ctx.btype = MPI_BYTE;
+    cnode->ctx.ftype = MPI_BYTE;
+#endif
+
     /* Push context node onto stack */
     cnode->next = *head;
     *head       = cnode;


### PR DESCRIPTION
There is at least one place in the library where the `mtype` and `ftype` fields are retrieved from the API context inside the MPI I/O driver where the library hasn't explicitly set anything with `H5CX_set_mpi_coll_datatypes`. A simple example where collective I/O is requested, but collective metadata writes are NOT requested ran into this with an error of `MPI_ERR_TYPE: invalid datatype`. Initialize the default type to `MPI_BYTE` to avoid these problems.