### PR TITLE
Restore floating-point suffixes in tests

### DIFF
--- a/hl/test/test_table.c
+++ b/hl/test/test_table.c
@@ -198,7 +198,7 @@ test_table(hid_t fid, int do_write)
     hsize_t    chunk_size   = 10;
     int        compress     = 0;
     int       *fill         = NULL;
-    particle_t fill1[1]     = {{"no data", -1, -99.0, -99.0, -1}};
+    particle_t fill1[1]     = {{"no data", -1, -99.0F, -99.0, -1}};
     int        fill1_new[1] = {-100};
     hsize_t    position;
     char       tname[20];
@@ -226,23 +226,23 @@ test_table(hid_t fid, int do_write)
     particle2_t rbuf2[NRECORDS];
     particle3_t rbuf3[NRECORDS];
     particle_t  rbufc[NRECORDS * 2];
-    particle_t  abuf[2] = {{"eight", 80, 8.0, 80.0, 80}, {"nine", 90, 9.0, 90.0, 90}};
-    particle_t  ibuf[2] = {{"zero", 0, 0.0, 0.0, 0}, {"zero", 0, 0.0, 0.0, 0}};
+    particle_t  abuf[2] = {{"eight", 80, 8.0F, 80.0, 80}, {"nine", 90, 9.0F, 90.0, 90}};
+    particle_t  ibuf[2] = {{"zero", 0, 0.0F, 0.0, 0}, {"zero", 0, 0.0F, 0.0, 0}};
     particle_t  wbufd[NRECORDS];
     particle_t  wbuf[NRECORDS] = {{
                                      "zero",
                                      0,
-                                     0.0,
+                                     0.0F,
                                      0.0,
                                      0,
                                  },
-                                 {"one", 10, 1.0, 10.0, 10},
-                                 {"two", 20, 2.0, 20.0, 20},
-                                 {"three", 30, 3.0, 30.0, 30},
-                                 {"four", 40, 4.0, 40.0, 40},
-                                 {"five", 50, 5.0, 50.0, 50},
-                                 {"six", 60, 6.0, 60.0, 60},
-                                 {"seven", 70, 7.0, 70.0, 70}};
+                                 {"one", 10, 1.0F, 10.0, 10},
+                                 {"two", 20, 2.0F, 20.0, 20},
+                                 {"three", 30, 3.0F, 30.0, 30},
+                                 {"four", 40, 4.0F, 40.0, 40},
+                                 {"five", 50, 5.0F, 50.0, 50},
+                                 {"six", 60, 6.0F, 60.0, 60},
+                                 {"seven", 70, 7.0F, 70.0, 70}};
     /* buffers for the field "Pressure" and "New_field" */
     float pressure_in[NRECORDS] = {0.0F, 1.0F, 2.0F, 3.0F, 4.0F, 5.0F, 6.0F, 7.0F};
     float pressure_out[NRECORDS];

--- a/test/dt_arith.c
+++ b/test/dt_arith.c
@@ -696,7 +696,7 @@ test_particular_fp_integer(void)
 
     /* Print errors */
     if (dst_i != fill_value) {
-        float x = 0.0;
+        float x = 0.0F;
         int   y;
 
         if (0 == fails_this_test++)
@@ -2637,7 +2637,7 @@ my_isnan(dtype_t type, void *val)
     char s[256];
 
     if (FLT_FLOAT == type) {
-        float x = 0.0;
+        float x = 0.0F;
         memcpy(&x, val, sizeof(float));
         retval = isnan(x);
     }
@@ -2663,7 +2663,7 @@ my_isnan(dtype_t type, void *val)
      */
     if (!retval) {
         if (FLT_FLOAT == type) {
-            float x = 0.0;
+            float x = 0.0F;
 
             memcpy(&x, val, sizeof(float));
             snprintf(s, sizeof(s), "%g", (double)x);
@@ -3115,7 +3115,7 @@ test_conv_flt_1(const char *name, int run_test, hid_t src, hid_t dst)
             int    check_expo[2];
 
             if (FLT_FLOAT == dst_type) {
-                float x = 0.0;
+                float x = 0.0F;
                 memcpy(&x, &buf[j * dst_size], sizeof(float));
                 if (underflow && fabsf(x) <= FLT_MIN && fabsf(hw_f) <= FLT_MIN)
                     continue; /* all underflowed, no error */
@@ -3185,7 +3185,7 @@ test_conv_flt_1(const char *name, int run_test, hid_t src, hid_t dst)
             printf(" %02x", saved[j * src_size + ENDIAN(src_size, k, sendian)]);
         printf("%*s", (int)(3 * MAX(0, (ssize_t)dst_size - (ssize_t)src_size)), "");
         if (FLT_FLOAT == src_type) {
-            float x = 0.0;
+            float x = 0.0F;
             memcpy(&x, &saved[j * src_size], sizeof(float));
             printf(" %29.20e\n", (double)x);
         }
@@ -3207,7 +3207,7 @@ test_conv_flt_1(const char *name, int run_test, hid_t src, hid_t dst)
             printf(" %02x", buf[j * dst_size + ENDIAN(dst_size, k, dendian)]);
         printf("%*s", (int)(3 * MAX(0, (ssize_t)src_size - (ssize_t)dst_size)), "");
         if (FLT_FLOAT == dst_type) {
-            float x = 0.0;
+            float x = 0.0F;
             memcpy(&x, &buf[j * dst_size], sizeof(float));
             printf(" %29.20e\n", (double)x);
         }


### PR DESCRIPTION
A prior commit removed too many F suffixes. This restores the suffixes for float variables.