### PR TITLE
Update the library version matrix for H5Pset_libver_bounds()

### DIFF
--- a/src/H5Ppublic.h
+++ b/src/H5Ppublic.h
@@ -4902,7 +4902,7 @@ H5_DLL herr_t H5Pset_gc_references(hid_t fapl_id, unsigned gc_ref);
  *                 format versions available to library release 1.16.x.
  *                 Since 1.16.x is also #H5F_LIBVER_LATEST, there is no upper
  *                 limit on the format versions to use.  That is, if a
- *                 newer format version is required to support a feature 
+ *                 newer format version is required to support a feature
  *                 in 1.16.x series, this setting will allow the object to be
  *                 created.
  *             \li This is the library default setting and provides the greatest
@@ -4978,7 +4978,7 @@ H5_DLL herr_t H5Pset_gc_references(hid_t fapl_id, unsigned gc_ref);
  *                  format versions available to library release 1.16.x.
  *                  Since 1.16.x is also #H5F_LIBVER_LATEST, there is no upper
  *                  limit on the format versions to use.  That is, if a
- *                  newer format version is required to support a feature 
+ *                  newer format version is required to support a feature
  *                  in 1.16.x series, this setting will allow the object to be
  *                  created.
  *              \li Earlier versions of the library may not be able to access
@@ -5051,8 +5051,8 @@ H5_DLL herr_t H5Pset_gc_references(hid_t fapl_id, unsigned gc_ref);
  *              \li The library will allow objects to be created with the latest
  *                  format versions available to library release 1.16.x.
  *                  Since 1.16.x is also #H5F_LIBVER_LATEST, there is no upper
- *                  limit on the format versions to use.  That is, if a 
- *                  newer format version is required to support a feature 
+ *                  limit on the format versions to use.  That is, if a
+ *                  newer format version is required to support a feature
  *                  in 1.16.x series, this setting will allow the object to be
  *                  created.
  *              \li This setting allows users to take advantage of the latest
@@ -5112,8 +5112,8 @@ H5_DLL herr_t H5Pset_gc_references(hid_t fapl_id, unsigned gc_ref);
  *              \li The library will allow objects to be created with the latest
  *                  format versions available to library release 1.16.x.
  *                  Since 1.16.x is also #H5F_LIBVER_LATEST, there is no upper
- *                  limit on the format versions to use.  That is, if a 
- *                  newer format version is required to support a feature 
+ *                  limit on the format versions to use.  That is, if a
+ *                  newer format version is required to support a feature
  *                  in 1.16.x series, this setting will allow the object to be
  *                  created.
  *              \li This setting allows users to take advantage of the latest
@@ -5155,8 +5155,8 @@ H5_DLL herr_t H5Pset_gc_references(hid_t fapl_id, unsigned gc_ref);
  *              \li The library will allow objects to be created with the latest
  *                  format versions available to library release 1.16.x.
  *                  Since 1.16.x is also #H5F_LIBVER_LATEST, there is no upper
- *                  limit on the format versions to use.  That is, if a 
- *                  newer format version is required to support a feature 
+ *                  limit on the format versions to use.  That is, if a
+ *                  newer format version is required to support a feature
  *                  in 1.16.x series, this setting will allow the object to be
  *                  created.
  *              \li This setting allows users to take advantage of the latest
@@ -5178,8 +5178,8 @@ H5_DLL herr_t H5Pset_gc_references(hid_t fapl_id, unsigned gc_ref);
  *              \li The library will allow objects to be created with the latest
  *                  format versions available to library release 1.16.x.
  *                  Since 1.16.x is also #H5F_LIBVER_LATEST, there is no upper
- *                  limit on the format versions to use.  That is, if a 
- *                  newer format version is required to support a feature 
+ *                  limit on the format versions to use.  That is, if a
+ *                  newer format version is required to support a feature
  *                  in 1.16.x series, this setting will allow the object to be
  *                  created.
  *              \li This setting allows users to take advantage of the latest

--- a/src/H5Ppublic.h
+++ b/src/H5Ppublic.h
@@ -4928,12 +4928,8 @@ H5_DLL herr_t H5Pset_gc_references(hid_t fapl_id, unsigned gc_ref);
  *              \li The library will create objects with the latest format
  *                  versions available to library release 1.8.x.
  *              \li The library will allow objects to be created with the latest
- *                  format versions available to library release 1.10.x.
- *                  Since 1.10.x is also #H5F_LIBVER_LATEST, there is no upper
- *                  limit on the format versions to use.  For example, if a
- *                  newer format version is required to support a feature e.g.
- *                  virtual dataset, this setting will allow the object to be
- *                  created.
+ *                  format versions available to library release 1.10.x.  Note
+ *                  that 1.10.11 is the last release of the 1.10 series.
  *              \li API calls that create objects or features that are
  *                  available to versions of the library greater than 1.10.x
  *                  release will fail.
@@ -4992,7 +4988,8 @@ H5_DLL herr_t H5Pset_gc_references(hid_t fapl_id, unsigned gc_ref);
  *              \li The library will create objects with the latest format
  *                  versions available to library release 1.10.x.
  *              \li The library will allow objects to be created with the latest
- *                  format versions available to library release 1.10.x.
+ *                  format versions available to library release 1.10.x.  Note
+ *                  that 1.10.11 is the last release of the 1.10 series.
  *              \li The objects written with this setting may be
  *                  accessible to a smaller range of library versions than
  *                  would be the case if low is set to #H5F_LIBVER_EARLIEST.

--- a/src/H5Ppublic.h
+++ b/src/H5Ppublic.h
@@ -4830,9 +4830,8 @@ H5_DLL herr_t H5Pset_gc_references(hid_t fapl_id, unsigned gc_ref);
  *          enumerated value in #H5F_libver_t, indicating that this is
  *          currently the latest format available.
  *
- *          The library supports the following five pairs of
- *          (\p low, \p high) combinations as derived from the values
- *          in #H5F_libver_t:
+ *          The library supports the following pairs of (\p low, \p high)
+ *          combinations as derived from the values in #H5F_libver_t:
  *
  *          <table>
  *           <tr>
@@ -4859,11 +4858,53 @@ H5_DLL herr_t H5Pset_gc_references(hid_t fapl_id, unsigned gc_ref);
  *             \li The library will create objects with the earliest possible
  *                 format versions.
  *             \li The library will allow objects to be created with the latest
- *                 format versions available to library release 1.10.x.
- *                 Since 1.10.x is also #H5F_LIBVER_LATEST, there is no upper
- *                 limit on the format versions to use.  For example, if a newer
- *                 format version is required to support a feature e.g. virtual
- *                 dataset, this setting will allow the object to be created.
+ *                 format versions available to library release 1.10.x.  Note
+ *                 that as 1.10.11 is the last release of the 1.10 series.
+ *             \li API calls that create objects or features that are
+ *                 available to versions of the library greater than 1.10.x
+ *                 release will fail.
+ *            </td>
+ *           </tr>
+ *           <tr>
+ *            <td>\p low=#H5F_LIBVER_EARLIEST<br />
+ *                \p high=#H5F_LIBVER_V112</td>
+ *            <td>
+ *             \li The library will create objects with the earliest possible
+ *                 format versions.
+ *             \li The library will allow objects to be created with the latest
+ *                 format versions available to library release 1.12.x.  Note
+ *                 that as 1.12.3 is the last release of the 1.12 series.
+ *             \li API calls that create objects or features that are
+ *                 available to versions of the library greater than 1.12.x
+ *                 release will fail.
+ *            </td>
+ *           </tr>
+ *           <tr>
+ *            <td>\p low=#H5F_LIBVER_EARLIEST<br />
+ *                \p high=#H5F_LIBVER_V114</td>
+ *            <td>
+ *             \li The library will create objects with the earliest possible
+ *                 format versions.
+ *             \li The library will allow objects to be created with the latest
+ *                 format versions available to library release 1.14.x.
+ *             \li API calls that create objects or features that are
+ *                 available to versions of the library greater than 1.14.x
+ *                 release will fail.
+ *            </td>
+ *           </tr>
+ *           <tr>
+ *            <td>\p low=#H5F_LIBVER_EARLIEST<br />
+ *                \p high=#H5F_LIBVER_V116</td>
+ *            <td>
+ *             \li The library will create objects with the earliest possible
+ *                 format versions.
+ *             \li The library will allow objects to be created with the latest
+ *                 format versions available to library release 1.16.x.
+ *                 Since 1.16.x is also #H5F_LIBVER_LATEST, there is no upper
+ *                 limit on the format versions to use.  That is, if a
+ *                 newer format version is required to support a feature 
+ *                 in 1.16.x series, this setting will allow the object to be
+ *                 created.
  *             \li This is the library default setting and provides the greatest
  *                 format compatibility.
  *            </td>
@@ -4893,6 +4934,53 @@ H5_DLL herr_t H5Pset_gc_references(hid_t fapl_id, unsigned gc_ref);
  *                  newer format version is required to support a feature e.g.
  *                  virtual dataset, this setting will allow the object to be
  *                  created.
+ *              \li API calls that create objects or features that are
+ *                  available to versions of the library greater than 1.10.x
+ *                  release will fail.
+ *              \li Earlier versions of the library may not be able to access
+ *                  objects created with this setting.</td>
+ *           </tr>
+ *           <tr>
+ *            <td>\p low=#H5F_LIBVER_V18<br />
+ *                \p high=#H5F_LIBVER_V112</td>
+ *            <td>
+ *              \li The library will create objects with the latest format
+ *                  versions available to library release 1.8.x.
+ *              \li The library will allow objects to be created with the latest
+ *                  format versions available to library release 1.12.x.
+ *              \li API calls that create objects or features that are
+ *                  available to versions of the library greater than 1.12.x
+ *                  release will fail.
+ *              \li Earlier versions of the library may not be able to access
+ *                  objects created with this setting.</td>
+ *           </tr>
+ *           <tr>
+ *            <td>\p low=#H5F_LIBVER_V18<br />
+ *                \p high=#H5F_LIBVER_V114</td>
+ *            <td>
+ *              \li The library will create objects with the latest format
+ *                  versions available to library release 1.8.x.
+ *              \li The library will allow objects to be created with the latest
+ *                  format versions available to library release 1.14.x.
+ *              \li API calls that create objects or features that are
+ *                  available to versions of the library greater than 1.14.x
+ *                  release will fail.
+ *              \li Earlier versions of the library may not be able to access
+ *                  objects created with this setting.</td>
+ *           </tr>
+ *           <tr>
+ *            <td>\p low=#H5F_LIBVER_V18<br />
+ *                \p high=#H5F_LIBVER_V116</td>
+ *            <td>
+ *              \li The library will create objects with the latest format
+ *                  versions available to library release 1.8.x.
+ *              \li The library will allow objects to be created with the latest
+ *                  format versions available to library release 1.16.x.
+ *                  Since 1.16.x is also #H5F_LIBVER_LATEST, there is no upper
+ *                  limit on the format versions to use.  That is, if a
+ *                  newer format version is required to support a feature 
+ *                  in 1.16.x series, this setting will allow the object to be
+ *                  created.
  *              \li Earlier versions of the library may not be able to access
  *                  objects created with this setting.</td>
  *           </tr>
@@ -4905,10 +4993,67 @@ H5_DLL herr_t H5Pset_gc_references(hid_t fapl_id, unsigned gc_ref);
  *                  versions available to library release 1.10.x.
  *              \li The library will allow objects to be created with the latest
  *                  format versions available to library release 1.10.x.
- *                  Since 1.10.x is also #H5F_LIBVER_LATEST, there is no upper
- *                  limit on the format versions to use. For example, if a
- *                  newer format version is required to support a feature e.g.
- *                  virtual dataset, this setting will allow the object to be
+ *              \li The objects written with this setting may be
+ *                  accessible to a smaller range of library versions than
+ *                  would be the case if low is set to #H5F_LIBVER_EARLIEST.
+ *              \li API calls that create objects or features that are available
+ *                  to versions of the library greater than 1.10.x release will
+ *                  fail.
+ *              \li Earlier versions of the library may not be able to access
+ *                  objects created with this setting.</td>
+ *            </td>
+ *           </tr>
+ *           <tr>
+ *            <td>\p low=#H5F_LIBVER_V110<br />
+ *                \p high=#H5F_LIBVER_V112
+ *             </td>
+ *             <td>
+ *              \li The library will create objects with the latest format
+ *                  versions available to library release 1.10.x.
+ *              \li The library will allow objects to be created with the latest
+ *                  format versions available to library release 1.12.x.
+ *              \li The objects written with this setting may be
+ *                  accessible to a smaller range of library versions than
+ *                  would be the case if low is set to #H5F_LIBVER_EARLIEST.
+ *              \li API calls that create objects or features that are available
+ *                  to versions of the library greater than 1.12.x release will
+ *                  fail.
+ *              \li Earlier versions of the library may not be able to access
+ *                  objects created with this setting.</td>
+ *            </td>
+ *           </tr>
+ *           <tr>
+ *            <td>\p low=#H5F_LIBVER_V110<br />
+ *                \p high=#H5F_LIBVER_V114
+ *             </td>
+ *             <td>
+ *              \li The library will create objects with the latest format
+ *                  versions available to library release 1.10.x.
+ *              \li The library will allow objects to be created with the latest
+ *                  format versions available to library release 1.14.x.
+ *              \li The objects written with this setting may be
+ *                  accessible to a smaller range of library versions than
+ *                  would be the case if low is set to #H5F_LIBVER_EARLIEST.
+ *              \li API calls that create objects or features that are available
+ *                  to versions of the library greater than 1.14.x release will
+ *                  fail.
+ *              \li Earlier versions of the library may not be able to access
+ *                  objects created with this setting.</td>
+ *            </td>
+ *           </tr>
+ *           <tr>
+ *            <td>\p low=#H5F_LIBVER_V110<br />
+ *                \p high=#H5F_LIBVER_V116
+ *             </td>
+ *             <td>
+ *              \li The library will create objects with the latest format
+ *                  versions available to library release 1.10.x.
+ *              \li The library will allow objects to be created with the latest
+ *                  format versions available to library release 1.16.x.
+ *                  Since 1.16.x is also #H5F_LIBVER_LATEST, there is no upper
+ *                  limit on the format versions to use.  That is, if a 
+ *                  newer format version is required to support a feature 
+ *                  in 1.16.x series, this setting will allow the object to be
  *                  created.
  *              \li This setting allows users to take advantage of the latest
  *                  features and performance enhancements in the library.
@@ -4916,8 +5061,134 @@ H5_DLL herr_t H5Pset_gc_references(hid_t fapl_id, unsigned gc_ref);
  *                  accessible to a smaller range of library versions than
  *                  would be the case if low is set to #H5F_LIBVER_EARLIEST.
  *              \li Earlier versions of the library may not be able to access
- *                  objects created with this
- * setting.
+ *                  objects created with this setting.
+ *            </td>
+ *           <tr>
+ *            <td>\p low=#H5F_LIBVER_V112<br />
+ *                \p high=#H5F_LIBVER_V112
+ *             </td>
+ *             <td>
+ *              \li The library will create objects with the latest format
+ *                  versions available to library release 1.12.x.
+ *              \li The library will allow objects to be created with the latest
+ *                  format versions available to library release 1.12.x.
+ *              \li The objects written with this setting may be
+ *                  accessible to a smaller range of library versions than
+ *                  would be the case if low is set to #H5F_LIBVER_EARLIEST.
+ *              \li API calls that create objects or features that are available
+ *                  to versions of the library greater than 1.12.x release will
+ *                  fail.
+ *              \li Earlier versions of the library may not be able to access
+ *                  objects created with this setting.</td>
+ *            </td>
+ *           </tr>
+ *           <tr>
+ *            <td>\p low=#H5F_LIBVER_V112<br />
+ *                \p high=#H5F_LIBVER_V114
+ *             </td>
+ *             <td>
+ *              \li The library will create objects with the latest format
+ *                  versions available to library release 1.12.x.
+ *              \li The library will allow objects to be created with the latest
+ *                  format versions available to library release 1.14.x.
+ *              \li The objects written with this setting may be
+ *                  accessible to a smaller range of library versions than
+ *                  would be the case if low is set to #H5F_LIBVER_EARLIEST.
+ *              \li API calls that create objects or features that are available
+ *                  to versions of the library greater than 1.14.x release will
+ *                  fail.
+ *              \li Earlier versions of the library may not be able to access
+ *                  objects created with this setting.</td>
+ *            </td>
+ *           </tr>
+ *           </tr>
+ *           <tr>
+ *            <td>\p low=#H5F_LIBVER_V112<br />
+ *                \p high=#H5F_LIBVER_V116
+ *             </td>
+ *             <td>
+ *              \li The library will create objects with the latest format
+ *                  versions available to library release 1.12.x.
+ *              \li The library will allow objects to be created with the latest
+ *                  format versions available to library release 1.16.x.
+ *                  Since 1.16.x is also #H5F_LIBVER_LATEST, there is no upper
+ *                  limit on the format versions to use.  That is, if a 
+ *                  newer format version is required to support a feature 
+ *                  in 1.16.x series, this setting will allow the object to be
+ *                  created.
+ *              \li This setting allows users to take advantage of the latest
+ *                  features and performance enhancements in the library.
+ *                  However, objects written with this setting may be
+ *                  accessible to a smaller range of library versions than
+ *                  would be the case if low is set to #H5F_LIBVER_EARLIEST.
+ *              \li Earlier versions of the library may not be able to access
+ *                  objects created with this setting.
+ *            </td>
+ *           </tr>
+ *           <tr>
+ *            <td>\p low=#H5F_LIBVER_V114<br />
+ *                \p high=#H5F_LIBVER_V114
+ *             </td>
+ *             <td>
+ *              \li The library will create objects with the latest format
+ *                  versions available to library release 1.14.x.
+ *              \li The library will allow objects to be created with the latest
+ *                  format versions available to library release 1.14.x.
+ *              \li The objects written with this setting may be
+ *                  accessible to a smaller range of library versions than
+ *                  would be the case if low is set to #H5F_LIBVER_EARLIEST.
+ *              \li API calls that create objects or features that are available
+ *                  to versions of the library greater than 1.14.x release will
+ *                  fail.
+ *              \li Earlier versions of the library may not be able to access
+ *                  objects created with this setting.</td>
+ *            </td>
+ *           </tr>
+ *           </tr>
+ *           <tr>
+ *            <td>\p low=#H5F_LIBVER_V114<br />
+ *                \p high=#H5F_LIBVER_V116
+ *             </td>
+ *             <td>
+ *              \li The library will create objects with the latest format
+ *                  versions available to library release 1.14.x.
+ *              \li The library will allow objects to be created with the latest
+ *                  format versions available to library release 1.16.x.
+ *                  Since 1.16.x is also #H5F_LIBVER_LATEST, there is no upper
+ *                  limit on the format versions to use.  That is, if a 
+ *                  newer format version is required to support a feature 
+ *                  in 1.16.x series, this setting will allow the object to be
+ *                  created.
+ *              \li This setting allows users to take advantage of the latest
+ *                  features and performance enhancements in the library.
+ *                  However, objects written with this setting may be
+ *                  accessible to a smaller range of library versions than
+ *                  would be the case if low is set to #H5F_LIBVER_EARLIEST.
+ *              \li Earlier versions of the library may not be able to access
+ *                  objects created with this setting.
+ *            </td>
+ *           </tr>
+ *           <tr>
+ *            <td>\p low=#H5F_LIBVER_V116<br />
+ *                \p high=#H5F_LIBVER_V116
+ *             </td>
+ *             <td>
+ *              \li The library will create objects with the latest format
+ *                  versions available to library release 1.16.x.
+ *              \li The library will allow objects to be created with the latest
+ *                  format versions available to library release 1.16.x.
+ *                  Since 1.16.x is also #H5F_LIBVER_LATEST, there is no upper
+ *                  limit on the format versions to use.  That is, if a 
+ *                  newer format version is required to support a feature 
+ *                  in 1.16.x series, this setting will allow the object to be
+ *                  created.
+ *              \li This setting allows users to take advantage of the latest
+ *                  features and performance enhancements in the library.
+ *                  However, objects written with this setting may be
+ *                  accessible to a smaller range of library versions than
+ *                  would be the case if low is set to #H5F_LIBVER_EARLIEST.
+ *              \li Earlier versions of the library may not be able to access
+ *                  objects created with this setting.
  *            </td>
  *           </tr>
  *          </table>


### PR DESCRIPTION
Added 1.12, 1.14, and 1.16 to the table for libver bounds in the H5Pset_libver_bounds docs.

Note: The table can be made smaller if some of the similar notes in all the rows be combined as
common notes outside of the table.  Please let me know if that is a preferred way.

Fixes GitHub #3524