### PR TITLE
Add testing of Subfiling VFD with zlib compression

### DIFF
--- a/testpar/t_subfiling_vfd.c
+++ b/testpar/t_subfiling_vfd.c
@@ -100,9 +100,7 @@ static void test_subfiling_precreate_rank_0(void);
 static void test_subfiling_write_many_read_one(void);
 static void test_subfiling_write_many_read_few(void);
 static void test_subfiling_h5fuse(void);
-#ifdef H5_HAVE_FILTER_DEFLATE
 static void t_zlib(void);
-#endif
 
 static test_func tests[] = {test_create_and_close,
                             test_ioc_only_fail,
@@ -113,12 +111,8 @@ static test_func tests[] = {test_create_and_close,
                             test_subfiling_precreate_rank_0,
                             test_subfiling_write_many_read_one,
                             test_subfiling_write_many_read_few,
-                            test_subfiling_h5fuse
-#ifdef H5_HAVE_FILTER_DEFLATE
-                            ,
-                            t_zlib
-#endif
-};
+                            test_subfiling_h5fuse,
+                            t_zlib};
 
 /* ---------------------------------------------------------------------------
  * Function:    create_subfiling_ioc_fapl
@@ -2121,7 +2115,6 @@ parse_subfiling_env_vars(void)
     }
 }
 
-#ifdef H5_HAVE_FILTER_DEFLATE
 /*
  * Test zlib.
  */
@@ -2131,6 +2124,10 @@ parse_subfiling_env_vars(void)
 static void
 t_zlib(void)
 {
+    if (MAINPROCESS)
+        TESTING_2("write zlib & read w/ single MPI rank");
+
+#ifdef H5_HAVE_FILTER_DEFLATE
     hsize_t start[1];
     hsize_t count[1];
     hsize_t dset_dims[1];
@@ -2152,9 +2149,6 @@ t_zlib(void)
 
     /* Set selection I/O mode on DXPL */
     VRFY((H5Pset_selection_io(dxpl_id, H5D_SELECTION_IO_MODE_ON) >= 0), "H5Pset_selection_io succeeded");
-
-    if (MAINPROCESS)
-        TESTING_2("write zlib & read w/ single MPI rank");
 
     /* Get a default Subfiling FAPL */
     fapl_id = create_subfiling_ioc_fapl(comm_g, info_g, false, NULL, 0);
@@ -2268,11 +2262,14 @@ t_zlib(void)
     VRFY((H5Pclose(dxpl_id) >= 0), "DXPL close succeeded");
 
     CHECK_PASSED();
+#else
+    if (MAINPROCESS)
+        SKIPPED();
+#endif
 }
 #undef SUBF_FILENAME
 #undef SUBF_HDF5_TYPE
 #undef SUBF_C_TYPE
-#endif
 
 int
 main(int argc, char **argv)

--- a/testpar/t_subfiling_vfd.c
+++ b/testpar/t_subfiling_vfd.c
@@ -100,7 +100,8 @@ static void test_subfiling_precreate_rank_0(void);
 static void test_subfiling_write_many_read_one(void);
 static void test_subfiling_write_many_read_few(void);
 static void test_subfiling_h5fuse(void);
-static void t_zlib(void);
+static void test_zlib(void);
+static void test_zlib_r(void);
 
 static test_func tests[] = {test_create_and_close,
                             test_ioc_only_fail,
@@ -112,7 +113,8 @@ static test_func tests[] = {test_create_and_close,
                             test_subfiling_write_many_read_one,
                             test_subfiling_write_many_read_few,
                             test_subfiling_h5fuse,
-                            t_zlib};
+                            test_zlib,
+                            test_zlib_r};
 
 /* ---------------------------------------------------------------------------
  * Function:    create_subfiling_ioc_fapl
@@ -2122,7 +2124,7 @@ parse_subfiling_env_vars(void)
 #define SUBF_HDF5_TYPE H5T_NATIVE_INT
 #define SUBF_C_TYPE    int
 static void
-t_zlib(void)
+test_zlib(void)
 {
     if (MAINPROCESS)
         TESTING_2("write zlib & read w/ single MPI rank");
@@ -2251,8 +2253,212 @@ t_zlib(void)
             H5Fdelete(SUBF_FILENAME, fapl_id);
         }
         H5E_END_TRY
+        VRFY((H5Pclose(fapl_id) >= 0), "FAPL close succeeded");
+    }
+
+    /* Read from all ranks. */
+
+    mpi_code_g = MPI_Barrier(comm_g);
+    VRFY((mpi_code_g == MPI_SUCCESS), "MPI_Barrier succeeded");
+
+    VRFY((H5Sclose(fspace_id) >= 0), "File dataspace close succeeded");
+    VRFY((H5Pclose(dxpl_id) >= 0), "DXPL close succeeded");
+
+    CHECK_PASSED();
+#else
+    if (MAINPROCESS)
+        SKIPPED();
+#endif
+}
+#undef SUBF_FILENAME
+#undef SUBF_HDF5_TYPE
+#undef SUBF_C_TYPE
+
+/*
+ * Test writing zlib file and reading it with some MPI ranks.
+ */
+#define SUBF_FILENAME  "t_zlib_r.h5"
+#define SUBF_HDF5_TYPE H5T_NATIVE_INT
+#define SUBF_C_TYPE    int
+static void
+test_zlib_r(void)
+{
+    if (MAINPROCESS)
+        TESTING_2("write zlib & read w/ some MPI ranks");
+
+#ifdef H5_HAVE_FILTER_DEFLATE
+    MPI_Comm sub_comm = MPI_COMM_NULL;
+    hsize_t  start[1];
+    hsize_t  count[1];
+    hsize_t  dset_dims[1];
+    hsize_t  chunk_dims[1];
+    bool     reading_file = false;
+    size_t   target_size;
+    hid_t    file_id   = H5I_INVALID_HID;
+    hid_t    fapl_id   = H5I_INVALID_HID;
+    hid_t    dset_id   = H5I_INVALID_HID;
+    hid_t    dxpl_id   = H5I_INVALID_HID;
+    hid_t    fspace_id = H5I_INVALID_HID;
+    hid_t    plist_id  = H5I_INVALID_HID;
+    void    *buf       = NULL;
+
+    curr_nerrors = nerrors;
+
+    dxpl_id = H5Pcreate(H5P_DATASET_XFER);
+    VRFY((dxpl_id >= 0), "DXPL creation succeeded");
+    VRFY((H5Pset_dxpl_mpio(dxpl_id, H5FD_MPIO_COLLECTIVE) >= 0), "H5Pset_dxpl_mpio() succeeded");
+
+    /* Set selection I/O mode on DXPL */
+    VRFY((H5Pset_selection_io(dxpl_id, H5D_SELECTION_IO_MODE_ON) >= 0), "H5Pset_selection_io succeeded");
+
+    /*
+     * Skip this test for an MPI communicator size of 1,
+     * as the test wouldn't really be meaningful
+     */
+    if (mpi_size == 1) {
+        if (MAINPROCESS)
+            SKIPPED();
+        return;
+    }
+
+    /* Get a default Subfiling FAPL */
+    fapl_id = create_subfiling_ioc_fapl(comm_g, info_g, false, NULL, 0);
+    VRFY((fapl_id >= 0), "FAPL creation succeeded");
+
+    /* Create file on all ranks */
+    file_id = H5Fcreate(SUBF_FILENAME, H5F_ACC_TRUNC, H5P_DEFAULT, fapl_id);
+    VRFY((file_id >= 0), "H5Fcreate succeeded");
+
+    VRFY((H5Pclose(fapl_id) >= 0), "FAPL close succeeded");
+
+    /* Calculate target size for dataset to stripe it across available IOCs */
+    target_size = (stripe_size_g > 0) ? (size_t)stripe_size_g : H5FD_SUBFILING_DEFAULT_STRIPE_SIZE;
+
+    /* Nudge stripe size to be multiple of C type size */
+    if ((target_size % sizeof(SUBF_C_TYPE)) != 0)
+        target_size += sizeof(SUBF_C_TYPE) - (target_size % sizeof(SUBF_C_TYPE));
+
+    target_size *= (size_t)mpi_size;
+
+    VRFY(((target_size % sizeof(SUBF_C_TYPE)) == 0), "target size check succeeded");
+
+    if (stripe_size_g > 0) {
+        VRFY((target_size >= (size_t)stripe_size_g), "target size check succeeded");
+    }
+    else {
+        VRFY((target_size >= H5FD_SUBFILING_DEFAULT_STRIPE_SIZE), "target size check succeeded");
+    }
+
+    dset_dims[0] = (hsize_t)(target_size / sizeof(SUBF_C_TYPE));
+
+    fspace_id = H5Screate_simple(1, dset_dims, NULL);
+    VRFY((fspace_id >= 0), "H5Screate_simple succeeded");
+
+    plist_id = H5Pcreate(H5P_DATASET_CREATE);
+    VRFY((plist_id >= 0), "H5Pcreate() succeeded");
+    chunk_dims[0] = dset_dims[0] / 4;
+    VRFY((H5Pset_chunk(plist_id, 1, chunk_dims) >= 0), "H5Pset_chunk() succeeded");
+    VRFY((H5Pset_deflate(plist_id, 1) >= 0), "H5Pset_deflate() succeeded");
+
+    dset_id = H5Dcreate2(file_id, "DSET", SUBF_HDF5_TYPE, fspace_id, H5P_DEFAULT, plist_id, H5P_DEFAULT);
+    VRFY((dset_id >= 0), "H5Dcreate2() succeeded");
+
+    /* Select hyperslab */
+    count[0] = dset_dims[0] / (hsize_t)mpi_size;
+    start[0] = (hsize_t)mpi_rank * count[0];
+    VRFY((H5Sselect_hyperslab(fspace_id, H5S_SELECT_SET, start, NULL, count, NULL) >= 0),
+         "H5Sselect_hyperslab succeeded");
+
+    buf = malloc(count[0] * sizeof(SUBF_C_TYPE));
+    VRFY(buf, "malloc succeeded");
+
+    for (size_t i = 0; i < count[0]; i++)
+        ((SUBF_C_TYPE *)buf)[i] = (SUBF_C_TYPE)((size_t)mpi_rank + i);
+
+    VRFY((H5Dwrite(dset_id, SUBF_HDF5_TYPE, H5S_BLOCK, fspace_id, dxpl_id, buf) >= 0),
+         "Dataset write succeeded");
+
+    free(buf);
+    buf = NULL;
+
+    VRFY((H5Dclose(dset_id) >= 0), "Dataset close succeeded");
+    VRFY((H5Fclose(file_id) >= 0), "File close succeeded");
+
+    /*
+     * If only using 1 node, read file back with a
+     * few ranks from that node. Otherwise, read file
+     * back with 1 MPI rank per node
+     */
+    if (num_nodes_g == 1) {
+        int color;
+
+        if (mpi_size < 2) {
+            color = 1;
+        }
+        else if (mpi_size < 4) {
+            color = (mpi_rank < (mpi_size / 2));
+        }
+        else {
+            color = (mpi_rank < (mpi_size / 4));
+        }
+
+        if (mpi_size > 1) {
+            mpi_code_g = MPI_Comm_split(comm_g, color, mpi_rank, &sub_comm);
+            VRFY((mpi_code_g == MPI_SUCCESS), "MPI_Comm_split succeeded");
+        }
+
+        if (color)
+            reading_file = true;
+    }
+    else {
+        if (node_local_rank == 0) {
+            sub_comm     = ioc_comm;
+            reading_file = true;
+        }
+    }
+
+    if (reading_file) {
+        fapl_id = create_subfiling_ioc_fapl(sub_comm, MPI_INFO_NULL, false, NULL, 0);
+        VRFY((fapl_id >= 0), "FAPL creation succeeded");
+
+        file_id = H5Fopen(SUBF_FILENAME, H5F_ACC_RDONLY, fapl_id);
+        VRFY((file_id >= 0), "H5Fopen succeeded");
+
+        dset_id = H5Dopen2(file_id, "DSET", H5P_DEFAULT);
+        VRFY((dset_id >= 0), "Dataset open succeeded");
+
+        buf = calloc(1, target_size);
+        VRFY(buf, "calloc succeeded");
+
+        VRFY((H5Dread(dset_id, SUBF_HDF5_TYPE, H5S_BLOCK, H5S_ALL, dxpl_id, buf) >= 0),
+             "Dataset read succeeded");
+
+        for (size_t i = 0; i < (size_t)mpi_size; i++) {
+            for (size_t j = 0; j < count[0]; j++) {
+                SUBF_C_TYPE buf_value = ((SUBF_C_TYPE *)buf)[(i * count[0]) + j];
+
+                VRFY((buf_value == (SUBF_C_TYPE)(j + i)), "data verification succeeded");
+            }
+        }
+
+        free(buf);
+        buf = NULL;
+
+        VRFY((H5Dclose(dset_id) >= 0), "Dataset close succeeded");
+        VRFY((H5Fclose(file_id) >= 0), "File close succeeded");
+
+        H5E_BEGIN_TRY
+        {
+            H5Fdelete(SUBF_FILENAME, fapl_id);
+        }
+        H5E_END_TRY
 
         VRFY((H5Pclose(fapl_id) >= 0), "FAPL close succeeded");
+    }
+
+    if ((sub_comm != MPI_COMM_NULL) && (num_nodes_g == 1)) {
+        mpi_code_g = MPI_Comm_free(&sub_comm);
+        VRFY((mpi_code_g == MPI_SUCCESS), "MPI_Comm_free succeeded");
     }
 
     mpi_code_g = MPI_Barrier(comm_g);


### PR DESCRIPTION
1. Help user to find the directory when test fails.
2. Test zlib compression (OESS-388).

Fixes OESS-388