### PR TITLE
Clean the flushrefresh test dir on Autotools

### DIFF
--- a/test/Makefile.am
+++ b/test/Makefile.am
@@ -229,7 +229,7 @@ CHECK_CLEANFILES+=accum.h5 cmpd_dset.h5 mdset.h5 compact_dataset.h5 dataset.h5 d
     splitter*.h5 splitter.log mirror_rw mirror_ro event_set_[0-9].h5 \
     cmpd_dtransform.h5 single_latest.h5 source_file.h5 stdio_file.h5 \
     tfile_is_accessible.h5 tfile_is_accessible_non_hdf5.h5 tverbounds_dtype.h5 \
-    virtual_file1.h5
+    virtual_file1.h5 flushrefresh_test
 
 # Sources for testhdf5 executable
 testhdf5_SOURCES=testhdf5.c tarray.c tattr.c tchecksum.c tconfig.c tfile.c \


### PR DESCRIPTION
The flushrefresh_test directory was not being cleaned up w/ `make clean` under the Autotools