### PR TITLE
Clean Autotools files in parallel tests

### DIFF
--- a/fortran/testpar/Makefile.am
+++ b/fortran/testpar/Makefile.am
@@ -36,7 +36,7 @@ TEST_PROG_PARA=parallel_test subfiling_test async_test
 check_PROGRAMS=$(TEST_PROG_PARA)
 
 # Temporary files
-CHECK_CLEANFILES+=parf[12].h5 subf.h5*
+CHECK_CLEANFILES+=parf[12].h5 h5*_tests.h5 subf.h5* test_async_apis.mod
 
 # Test source files
 parallel_test_SOURCES=ptest.F90 hyper.F90 mdset.F90 multidsetrw.F90

--- a/testpar/Makefile.am
+++ b/testpar/Makefile.am
@@ -58,6 +58,7 @@ LDADD = $(LIBH5TEST) $(LIBHDF5)
 # after_mpi_fin.h5 is from t_init_term
 # go is used for debugging. See testphdf5.c.
 CHECK_CLEANFILES+=MPItest.h5 Para*.h5 bigio_test.h5 CacheTestDummy.h5 \
-		  ShapeSameTest.h5 shutdown.h5 pmulti_dset.h5 after_mpi_fin.h5 go
+    ShapeSameTest.h5 shutdown.h5 pmulti_dset.h5 after_mpi_fin.h5 go noflush.h5 \
+	mpio_select_test_file.h5 *.btr
 
 include $(top_srcdir)/config/conclude.am


### PR DESCRIPTION
Adds missing files to `make clean` for parallel, including Fortran.