### PR TITLE
Fix windows cpack error in WiX package.

### DIFF
--- a/doxygen/CMakeLists.txt
+++ b/doxygen/CMakeLists.txt
@@ -39,7 +39,7 @@ if (DOXYGEN_FOUND)
   install (
       DIRECTORY ${HDF5_BINARY_DIR}/hdf5lib_docs/html
       DESTINATION ${HDF5_INSTALL_DOC_DIR}
-      COMPONENT Documents
+      COMPONENT hdfdocuments
   )
 
   if (NOT TARGET doxygen)


### PR DESCRIPTION
Packaging fails on Windows because of duplicate IDs. Doxygen install command used a generic name.