### PR TITLE
Add compression tests for subfiling

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -13,7 +13,7 @@
 ## ----------------------------------------------------------------------
 ## Initialize configure.
 ##
-AC_PREREQ([2.69])
+AC_PREREQ([2.71])
 
 ## AC_INIT takes the name of the package, the version number, and an
 ## email address to report bugs. AC_CONFIG_SRCDIR takes a unique file

--- a/configure.ac
+++ b/configure.ac
@@ -13,7 +13,7 @@
 ## ----------------------------------------------------------------------
 ## Initialize configure.
 ##
-AC_PREREQ([2.71])
+AC_PREREQ([2.69])
 
 ## AC_INIT takes the name of the package, the version number, and an
 ## email address to report bugs. AC_CONFIG_SRCDIR takes a unique file

--- a/testpar/t_subfiling_vfd.c
+++ b/testpar/t_subfiling_vfd.c
@@ -2487,9 +2487,9 @@ main(int argc, char **argv)
     if (num_iocs_g > mpi_size)
         num_iocs_g = mpi_size;
 
-    if (MAINPROCESS) {
+    if (MAINPROCESS)
         printf(" Re-running tests with compression enabled\n");
-    }
+
 #ifdef H5_HAVE_FILTER_DEFLATE
     enable_compression = true;
     for (size_t i = 0; i < ARRAY_SIZE(tests); i++) {

--- a/testpar/t_subfiling_vfd.c
+++ b/testpar/t_subfiling_vfd.c
@@ -2507,10 +2507,8 @@ main(int argc, char **argv)
     if (MAINPROCESS)
         SKIPPED();
 #endif
-    if (MAINPROCESS) {
-        puts("");
-        printf("Re-running tests with environment variables set\n");
-    }
+    if (MAINPROCESS)
+        printf("\nRe-running tests with environment variables set\n");
 
     for (size_t i = 0; i < ARRAY_SIZE(tests); i++) {
         if (MPI_SUCCESS == (mpi_code_g = MPI_Barrier(comm_g))) {
@@ -2523,10 +2521,8 @@ main(int argc, char **argv)
         }
     }
 
-    if (MAINPROCESS) {
-        puts("");
-        printf(" Re-running tests with compression enabled\n");
-    }
+    if (MAINPROCESS)
+        printf("\n Re-running tests with compression enabled\n");
 #ifdef H5_HAVE_FILTER_DEFLATE
     enable_compression = true;
     for (size_t i = 0; i < ARRAY_SIZE(tests); i++) {
@@ -2544,14 +2540,11 @@ main(int argc, char **argv)
     if (MAINPROCESS)
         SKIPPED();
 #endif
-    if (MAINPROCESS)
-        puts("");
-
     if (nerrors)
         goto exit;
 
     if (MAINPROCESS)
-        puts("All Subfiling VFD tests passed\n");
+        puts("\nAll Subfiling VFD tests passed\n");
 
 exit:
     if (must_unset_stripe_size_env)

--- a/testpar/t_subfiling_vfd.c
+++ b/testpar/t_subfiling_vfd.c
@@ -185,7 +185,7 @@ error:
 
     return H5I_INVALID_HID;
 }
- /* ---------------------------------------------------------------------------
+/* ---------------------------------------------------------------------------
  * Function:    create_dcpl_id
  *
  * Purpose:     Creates dataset creation property list identifier with
@@ -206,14 +206,14 @@ create_dcpl_id(int rank, const hsize_t dset_dims[], hid_t dxpl_id)
     if ((ret_value = H5Pcreate(H5P_DATASET_CREATE)) < 0)
         TEST_ERROR;
 
-    if(enable_compression) {
-      if(H5Pset_dxpl_mpio(dxpl_id, H5FD_MPIO_COLLECTIVE) < 0)
-         TEST_ERROR;
-      chunk_dims[0] = dset_dims[0] / 2;
-      if(H5Pset_chunk(ret_value, rank, chunk_dims) < 0)
-         TEST_ERROR;
-      if(H5Pset_deflate(ret_value, 9) < 0)
-         TEST_ERROR;
+    if (enable_compression) {
+        if (H5Pset_dxpl_mpio(dxpl_id, H5FD_MPIO_COLLECTIVE) < 0)
+            TEST_ERROR;
+        chunk_dims[0] = dset_dims[0] / 2;
+        if (H5Pset_chunk(ret_value, rank, chunk_dims) < 0)
+            TEST_ERROR;
+        if (H5Pset_deflate(ret_value, 9) < 0)
+            TEST_ERROR;
     }
 
     return ret_value;
@@ -1383,8 +1383,7 @@ test_subfiling_precreate_rank_0(void)
         dcpl_id = create_dcpl_id(1, dset_dims, dxpl_id);
         VRFY((dcpl_id >= 0), "DCPL creation succeeded");
 
-        dset_id =
-            H5Dcreate2(file_id, "DSET", SUBF_HDF5_TYPE, fspace_id, H5P_DEFAULT, dcpl_id, H5P_DEFAULT);
+        dset_id = H5Dcreate2(file_id, "DSET", SUBF_HDF5_TYPE, fspace_id, H5P_DEFAULT, dcpl_id, H5P_DEFAULT);
         VRFY((dset_id >= 0), "Dataset creation succeeded");
 
         buf = malloc(dset_dims[0] * sizeof(SUBF_C_TYPE));
@@ -1571,7 +1570,7 @@ test_subfiling_write_many_read_one(void)
     fspace_id = H5Screate_simple(1, dset_dims, NULL);
     VRFY((fspace_id >= 0), "H5Screate_simple succeeded");
 
-    dcpl_id = create_dcpl_id(1, dset_dims, dxpl_id );
+    dcpl_id = create_dcpl_id(1, dset_dims, dxpl_id);
     VRFY((dcpl_id >= 0), "DCPL creation succeeded");
 
     dset_id = H5Dcreate2(file_id, "DSET", SUBF_HDF5_TYPE, fspace_id, H5P_DEFAULT, dcpl_id, H5P_DEFAULT);
@@ -2485,18 +2484,18 @@ main(int argc, char **argv)
     if (MAINPROCESS) {
         printf(" Re-running tests with compression enabled\n");
     }
-    enable_compression=true;
+    enable_compression = true;
     for (size_t i = 4; i < ARRAY_SIZE(tests); i++) {
-          if (MPI_SUCCESS == (mpi_code_g = MPI_Barrier(comm_g))) {
-              (*tests[i])();
-          }
-            else   {
-                if (MAINPROCESS)
-                    MESG("MPI_Barrier failed");
-                nerrors++;
-            }
+        if (MPI_SUCCESS == (mpi_code_g = MPI_Barrier(comm_g))) {
+            (*tests[i])();
         }
-    enable_compression=false;
+        else {
+            if (MAINPROCESS)
+                MESG("MPI_Barrier failed");
+            nerrors++;
+        }
+    }
+    enable_compression = false;
 #endif
     if (MAINPROCESS) {
         printf("Re-running tests with environment variables set\n");
@@ -2516,7 +2515,7 @@ main(int argc, char **argv)
     if (MAINPROCESS) {
         printf(" Re-running tests with compression enabled\n");
     }
-    enable_compression=true;
+    enable_compression = true;
     for (size_t i = 5; i < ARRAY_SIZE(tests); i++) {
         if (MPI_SUCCESS == (mpi_code_g = MPI_Barrier(comm_g))) {
             (*tests[i])();
@@ -2527,7 +2526,7 @@ main(int argc, char **argv)
             nerrors++;
         }
     }
-    enable_compression=false;
+    enable_compression = false;
 #endif
     if (MAINPROCESS)
         puts("");

--- a/testpar/t_subfiling_vfd.c
+++ b/testpar/t_subfiling_vfd.c
@@ -2487,12 +2487,12 @@ main(int argc, char **argv)
     if (num_iocs_g > mpi_size)
         num_iocs_g = mpi_size;
 
-#ifdef H5_HAVE_FILTER_DEFLATE
     if (MAINPROCESS) {
         printf(" Re-running tests with compression enabled\n");
     }
+#ifdef H5_HAVE_FILTER_DEFLATE
     enable_compression = true;
-    for (size_t i = 5; i < ARRAY_SIZE(tests); i++) {
+    for (size_t i = 0; i < ARRAY_SIZE(tests); i++) {
         if (MPI_SUCCESS == (mpi_code_g = MPI_Barrier(comm_g))) {
             (*tests[i])();
         }
@@ -2505,7 +2505,6 @@ main(int argc, char **argv)
     enable_compression = false;
 #else
     if (MAINPROCESS) {
-        TESTING_2("re-running tests with compression enabled");
         SKIPPED();
     }
 #endif
@@ -2525,13 +2524,13 @@ main(int argc, char **argv)
         }
     }
 
-#ifdef H5_HAVE_FILTER_DEFLATE
     if (MAINPROCESS) {
         puts("");
         printf(" Re-running tests with compression enabled\n");
     }
+#ifdef H5_HAVE_FILTER_DEFLATE
     enable_compression = true;
-    for (size_t i = 5; i < ARRAY_SIZE(tests); i++) {
+    for (size_t i = 0; i < ARRAY_SIZE(tests); i++) {
         if (MPI_SUCCESS == (mpi_code_g = MPI_Barrier(comm_g))) {
             (*tests[i])();
         }
@@ -2544,8 +2543,6 @@ main(int argc, char **argv)
     enable_compression = false;
 #else
     if (MAINPROCESS) {
-        puts("");
-        TESTING_2("re-running tests with compression enabled");
         SKIPPED();
     }
 #endif

--- a/testpar/t_subfiling_vfd.c
+++ b/testpar/t_subfiling_vfd.c
@@ -40,6 +40,8 @@
 #define PATH_MAX 4096
 #endif
 
+#define DEFAULT_DEFLATE_LEVEL 9
+
 #define ARRAY_SIZE(a) sizeof(a) / sizeof(a[0])
 
 #define CHECK_PASSED()                                                                                       \
@@ -212,7 +214,7 @@ create_dcpl_id(int rank, const hsize_t dset_dims[], hid_t dxpl_id)
         chunk_dims[0] = dset_dims[0] / 2;
         if (H5Pset_chunk(ret_value, rank, chunk_dims) < 0)
             TEST_ERROR;
-        if (H5Pset_deflate(ret_value, 9) < 0)
+        if (H5Pset_deflate(ret_value, DEFAULT_DEFLATE_LEVEL) < 0)
             TEST_ERROR;
     }
 
@@ -2490,7 +2492,7 @@ main(int argc, char **argv)
         printf(" Re-running tests with compression enabled\n");
     }
     enable_compression = true;
-    for (size_t i = 4; i < ARRAY_SIZE(tests); i++) {
+    for (size_t i = 5; i < ARRAY_SIZE(tests); i++) {
         if (MPI_SUCCESS == (mpi_code_g = MPI_Barrier(comm_g))) {
             (*tests[i])();
         }

--- a/testpar/t_subfiling_vfd.c
+++ b/testpar/t_subfiling_vfd.c
@@ -2504,9 +2504,8 @@ main(int argc, char **argv)
     }
     enable_compression = false;
 #else
-    if (MAINPROCESS) {
+    if (MAINPROCESS)
         SKIPPED();
-    }
 #endif
     if (MAINPROCESS) {
         puts("");
@@ -2542,9 +2541,8 @@ main(int argc, char **argv)
     }
     enable_compression = false;
 #else
-    if (MAINPROCESS) {
+    if (MAINPROCESS)
         SKIPPED();
-    }
 #endif
     if (MAINPROCESS)
         puts("");

--- a/testpar/t_subfiling_vfd.c
+++ b/testpar/t_subfiling_vfd.c
@@ -82,12 +82,15 @@ static char *config_dir = NULL;
 int nerrors      = 0;
 int curr_nerrors = 0;
 
+bool enable_compression = false;
+
 /* Function pointer typedef for test functions */
 typedef void (*test_func)(void);
 
 /* Utility functions */
 static hid_t create_subfiling_ioc_fapl(MPI_Comm comm, MPI_Info info, bool custom_config,
                                        H5FD_subfiling_params_t *custom_cfg, int32_t thread_pool_size);
+static hid_t create_dcpl_id(int rank, const hsize_t dims[], hid_t dxpl_id);
 
 /* Test functions */
 static void test_create_and_close(void);
@@ -182,7 +185,47 @@ error:
 
     return H5I_INVALID_HID;
 }
+ /* ---------------------------------------------------------------------------
+ * Function:    create_dcpl_id
+ *
+ * Purpose:     Creates dataset creation property list identifier with
+ *              chunking and compression, and enforces the
+ *              required collective IO.
+ *
+ * Return:      Success: HID Dataset creation property list identifier,
+ *                       a non-negative value.
+ *              Failure: H5I_INVALID_HID, a negative value.
+ * ---------------------------------------------------------------------------
+ */
+static hid_t
+create_dcpl_id(int rank, const hsize_t dset_dims[], hid_t dxpl_id)
+{
+    hsize_t chunk_dims[1];
+    hid_t   ret_value = H5I_INVALID_HID;
 
+    if ((ret_value = H5Pcreate(H5P_DATASET_CREATE)) < 0)
+        TEST_ERROR;
+
+    if(enable_compression) {
+      if(H5Pset_dxpl_mpio(dxpl_id, H5FD_MPIO_COLLECTIVE) < 0)
+         TEST_ERROR;
+      chunk_dims[0] = dset_dims[0] / 2;
+      if(H5Pset_chunk(ret_value, rank, chunk_dims) < 0)
+         TEST_ERROR;
+      if(H5Pset_deflate(ret_value, 9) < 0)
+         TEST_ERROR;
+    }
+
+    return ret_value;
+
+error:
+    if ((H5I_INVALID_HID != ret_value) && (H5Pclose(ret_value) < 0)) {
+        H5_FAILED();
+        AT();
+    }
+
+    return H5I_INVALID_HID;
+}
 /*
  * A simple test that creates and closes a file with the
  * subfiling VFD
@@ -1060,6 +1103,7 @@ test_read_different_stripe_size(void)
     hid_t                   fapl_id      = H5I_INVALID_HID;
     hid_t                   dset_id      = H5I_INVALID_HID;
     hid_t                   dxpl_id      = H5I_INVALID_HID;
+    hid_t                   dcpl_id      = H5I_INVALID_HID;
     hid_t                   fspace_id    = H5I_INVALID_HID;
     char                   *tmp_filename = NULL;
     void                   *buf          = NULL;
@@ -1106,7 +1150,10 @@ test_read_different_stripe_size(void)
     fspace_id = H5Screate_simple(1, dset_dims, NULL);
     VRFY((fspace_id >= 0), "H5Screate_simple succeeded");
 
-    dset_id = H5Dcreate2(file_id, "DSET", SUBF_HDF5_TYPE, fspace_id, H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT);
+    dcpl_id = create_dcpl_id(1, dset_dims, dxpl_id);
+    VRFY((dcpl_id >= 0), "DCPL creation succeeded");
+
+    dset_id = H5Dcreate2(file_id, "DSET", SUBF_HDF5_TYPE, fspace_id, H5P_DEFAULT, dcpl_id, H5P_DEFAULT);
     VRFY((dset_id >= 0), "Dataset creation succeeded");
 
     /* Select hyperslab */
@@ -1129,6 +1176,7 @@ test_read_different_stripe_size(void)
 
     VRFY((H5Sclose(fspace_id) >= 0), "File dataspace close succeeded");
     VRFY((H5Dclose(dset_id) >= 0), "Dataset close succeeded");
+    VRFY((H5Pclose(dcpl_id) >= 0), "DCPL close succeeded");
     VRFY((H5Fclose(file_id) >= 0), "File close succeeded");
 
     /* Ensure all the subfiles are present */
@@ -1271,6 +1319,7 @@ test_subfiling_precreate_rank_0(void)
     hid_t   fapl_id   = H5I_INVALID_HID;
     hid_t   dset_id   = H5I_INVALID_HID;
     hid_t   dxpl_id   = H5I_INVALID_HID;
+    hid_t   dcpl_id   = H5I_INVALID_HID;
     hid_t   fspace_id = H5I_INVALID_HID;
     void   *buf       = NULL;
 
@@ -1331,8 +1380,11 @@ test_subfiling_precreate_rank_0(void)
         fspace_id = H5Screate_simple(1, dset_dims, NULL);
         VRFY((fspace_id >= 0), "H5Screate_simple succeeded");
 
+        dcpl_id = create_dcpl_id(1, dset_dims, dxpl_id);
+        VRFY((dcpl_id >= 0), "DCPL creation succeeded");
+
         dset_id =
-            H5Dcreate2(file_id, "DSET", SUBF_HDF5_TYPE, fspace_id, H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT);
+            H5Dcreate2(file_id, "DSET", SUBF_HDF5_TYPE, fspace_id, H5P_DEFAULT, dcpl_id, H5P_DEFAULT);
         VRFY((dset_id >= 0), "Dataset creation succeeded");
 
         buf = malloc(dset_dims[0] * sizeof(SUBF_C_TYPE));
@@ -1350,6 +1402,7 @@ test_subfiling_precreate_rank_0(void)
         VRFY((H5Sclose(fspace_id) >= 0), "File dataspace close succeeded");
         VRFY((H5Dclose(dset_id) >= 0), "Dataset close succeeded");
         VRFY((H5Pclose(fapl_id) >= 0), "FAPL close succeeded");
+        VRFY((H5Pclose(dcpl_id) >= 0), "DCPL close succeeded");
         VRFY((H5Fclose(file_id) >= 0), "H5Fclose succeeded");
 
         /*
@@ -1470,6 +1523,7 @@ test_subfiling_write_many_read_one(void)
     hid_t   fapl_id   = H5I_INVALID_HID;
     hid_t   dset_id   = H5I_INVALID_HID;
     hid_t   dxpl_id   = H5I_INVALID_HID;
+    hid_t   dcpl_id   = H5I_INVALID_HID;
     hid_t   fspace_id = H5I_INVALID_HID;
     void   *buf       = NULL;
 
@@ -1517,7 +1571,10 @@ test_subfiling_write_many_read_one(void)
     fspace_id = H5Screate_simple(1, dset_dims, NULL);
     VRFY((fspace_id >= 0), "H5Screate_simple succeeded");
 
-    dset_id = H5Dcreate2(file_id, "DSET", SUBF_HDF5_TYPE, fspace_id, H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT);
+    dcpl_id = create_dcpl_id(1, dset_dims, dxpl_id );
+    VRFY((dcpl_id >= 0), "DCPL creation succeeded");
+
+    dset_id = H5Dcreate2(file_id, "DSET", SUBF_HDF5_TYPE, fspace_id, H5P_DEFAULT, dcpl_id, H5P_DEFAULT);
     VRFY((dset_id >= 0), "Dataset creation succeeded");
 
     /* Select hyperslab */
@@ -1539,6 +1596,7 @@ test_subfiling_write_many_read_one(void)
     buf = NULL;
 
     VRFY((H5Dclose(dset_id) >= 0), "Dataset close succeeded");
+    VRFY((H5Pclose(dcpl_id) >= 0), "DCPL close succeeded");
     VRFY((H5Fclose(file_id) >= 0), "File close succeeded");
 
     mpi_code_g = MPI_Barrier(comm_g);
@@ -1616,6 +1674,7 @@ test_subfiling_write_many_read_few(void)
     hid_t    fapl_id   = H5I_INVALID_HID;
     hid_t    dset_id   = H5I_INVALID_HID;
     hid_t    dxpl_id   = H5I_INVALID_HID;
+    hid_t    dcpl_id   = H5I_INVALID_HID;
     hid_t    fspace_id = H5I_INVALID_HID;
     void    *buf       = NULL;
 
@@ -1673,7 +1732,10 @@ test_subfiling_write_many_read_few(void)
     fspace_id = H5Screate_simple(1, dset_dims, NULL);
     VRFY((fspace_id >= 0), "H5Screate_simple succeeded");
 
-    dset_id = H5Dcreate2(file_id, "DSET", SUBF_HDF5_TYPE, fspace_id, H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT);
+    dcpl_id = create_dcpl_id(1, dset_dims, dxpl_id);
+    VRFY((dcpl_id >= 0), "DCPL creation succeeded");
+
+    dset_id = H5Dcreate2(file_id, "DSET", SUBF_HDF5_TYPE, fspace_id, H5P_DEFAULT, dcpl_id, H5P_DEFAULT);
     VRFY((dset_id >= 0), "Dataset creation succeeded");
 
     /* Select hyperslab */
@@ -1695,6 +1757,7 @@ test_subfiling_write_many_read_few(void)
     buf = NULL;
 
     VRFY((H5Dclose(dset_id) >= 0), "Dataset close succeeded");
+    VRFY((H5Pclose(dcpl_id) >= 0), "DCPL close succeeded");
     VRFY((H5Fclose(file_id) >= 0), "File close succeeded");
 
     /*
@@ -1808,6 +1871,7 @@ test_subfiling_h5fuse(void)
     hid_t     fapl_id   = H5I_INVALID_HID;
     hid_t     dset_id   = H5I_INVALID_HID;
     hid_t     dxpl_id   = H5I_INVALID_HID;
+    hid_t     dcpl_id   = H5I_INVALID_HID;
     hid_t     fspace_id = H5I_INVALID_HID;
     void     *buf       = NULL;
     int       skip_test = 0;
@@ -1898,7 +1962,10 @@ test_subfiling_h5fuse(void)
     fspace_id = H5Screate_simple(1, dset_dims, NULL);
     VRFY((fspace_id >= 0), "H5Screate_simple succeeded");
 
-    dset_id = H5Dcreate2(file_id, "DSET", SUBF_HDF5_TYPE, fspace_id, H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT);
+    dcpl_id = create_dcpl_id(1, dset_dims, dxpl_id);
+    VRFY((dcpl_id >= 0), "DCPL creation succeeded");
+
+    dset_id = H5Dcreate2(file_id, "DSET", SUBF_HDF5_TYPE, fspace_id, H5P_DEFAULT, dcpl_id, H5P_DEFAULT);
     VRFY((dset_id >= 0), "Dataset creation succeeded");
 
     /* Select hyperslab */
@@ -1921,6 +1988,7 @@ test_subfiling_h5fuse(void)
 
     VRFY((H5Sclose(fspace_id) >= 0), "File dataspace close succeeded");
     VRFY((H5Dclose(dset_id) >= 0), "Dataset close succeeded");
+    VRFY((H5Pclose(dcpl_id) >= 0), "DCPL close succeeded");
     VRFY((H5Fclose(file_id) >= 0), "File close succeeded");
 
     if (MAINPROCESS) {
@@ -2413,7 +2481,23 @@ main(int argc, char **argv)
     num_iocs_g = (ioc_per_node_g > 0) ? (int)ioc_per_node_g * num_nodes_g : num_nodes_g;
     if (num_iocs_g > mpi_size)
         num_iocs_g = mpi_size;
-
+#ifdef H5_HAVE_FILTER_DEFLATE
+    if (MAINPROCESS) {
+        printf(" Re-running tests with compression enabled\n");
+    }
+    enable_compression=true;
+    for (size_t i = 4; i < ARRAY_SIZE(tests); i++) {
+          if (MPI_SUCCESS == (mpi_code_g = MPI_Barrier(comm_g))) {
+              (*tests[i])();
+          }
+            else   {
+                if (MAINPROCESS)
+                    MESG("MPI_Barrier failed");
+                nerrors++;
+            }
+        }
+    enable_compression=false;
+#endif
     if (MAINPROCESS) {
         printf("Re-running tests with environment variables set\n");
     }
@@ -2428,7 +2512,23 @@ main(int argc, char **argv)
             nerrors++;
         }
     }
-
+#ifdef H5_HAVE_FILTER_DEFLATE
+    if (MAINPROCESS) {
+        printf(" Re-running tests with compression enabled\n");
+    }
+    enable_compression=true;
+    for (size_t i = 5; i < ARRAY_SIZE(tests); i++) {
+        if (MPI_SUCCESS == (mpi_code_g = MPI_Barrier(comm_g))) {
+            (*tests[i])();
+        }
+        else {
+            if (MAINPROCESS)
+                MESG("MPI_Barrier failed");
+            nerrors++;
+        }
+    }
+    enable_compression=false;
+#endif
     if (MAINPROCESS)
         puts("");
 


### PR DESCRIPTION
Tests compression as part of the subfiling tests, skips the compression part if compression is not available.