### PR TITLE
Cancel running GitHub workflows on push to same PR

### DIFF
--- a/.github/workflows/cve.yml
+++ b/.github/workflows/cve.yml
@@ -16,7 +16,7 @@ on:
 
 # Using concurrency to cancel any in-progress job or run
 concurrency:
-  group: ${{ github.workflow }}-${{ github.sha || github.event.pull_request.number || github.ref }}
+  group: ${{ github.workflow }}-${{ github.head_ref && github.ref || github.run_id }}
   cancel-in-progress: true
 
 permissions:

--- a/.github/workflows/cve.yml
+++ b/.github/workflows/cve.yml
@@ -16,7 +16,7 @@ on:
 
 # Using concurrency to cancel any in-progress job or run
 concurrency:
-  group: ${{ github.workflow }}-${{ github.sha || github.event.pull_request.number }}
+  group: ${{ github.workflow }}-${{ github.sha || github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
 
 permissions:

--- a/.github/workflows/hdfeos5.yml
+++ b/.github/workflows/hdfeos5.yml
@@ -16,7 +16,7 @@ on:
 
 # Using concurrency to cancel any in-progress job or run
 concurrency:
-  group: ${{ github.workflow }}-${{ github.sha || github.event.pull_request.number || github.ref }}
+  group: ${{ github.workflow }}-${{ github.head_ref && github.ref || github.run_id }}
   cancel-in-progress: true
 
 permissions:

--- a/.github/workflows/hdfeos5.yml
+++ b/.github/workflows/hdfeos5.yml
@@ -16,7 +16,7 @@ on:
 
 # Using concurrency to cancel any in-progress job or run
 concurrency:
-  group: ${{ github.workflow }}-${{ github.sha || github.event.pull_request.number }}
+  group: ${{ github.workflow }}-${{ github.sha || github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
 
 permissions:

--- a/.github/workflows/linux-auto-aocc-ompi.yml
+++ b/.github/workflows/linux-auto-aocc-ompi.yml
@@ -16,7 +16,7 @@ on:
 
 # Using concurrency to cancel any in-progress job or run
 concurrency:
-  group: ${{ github.workflow }}-${{ github.sha || github.event.pull_request.number || github.ref }}
+  group: ${{ github.workflow }}-${{ github.head_ref && github.ref || github.run_id }}
   cancel-in-progress: true
 
 permissions:

--- a/.github/workflows/linux-auto-aocc-ompi.yml
+++ b/.github/workflows/linux-auto-aocc-ompi.yml
@@ -16,7 +16,7 @@ on:
 
 # Using concurrency to cancel any in-progress job or run
 concurrency:
-  group: ${{ github.workflow }}-${{ github.sha || github.event.pull_request.number }}
+  group: ${{ github.workflow }}-${{ github.sha || github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
 
 permissions:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -17,7 +17,7 @@ on:
 
 # Using concurrency to cancel any in-progress job or run
 concurrency:
-  group: ${{ github.workflow }}-${{ github.sha || github.event.pull_request.number }}
+  group: ${{ github.workflow }}-${{ github.sha || github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
 
 permissions:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -17,7 +17,7 @@ on:
 
 # Using concurrency to cancel any in-progress job or run
 concurrency:
-  group: ${{ github.workflow }}-${{ github.sha || github.event.pull_request.number || github.ref }}
+  group: ${{ github.workflow }}-${{ github.head_ref && github.ref || github.run_id }}
   cancel-in-progress: true
 
 permissions:

--- a/.github/workflows/netcdf.yml
+++ b/.github/workflows/netcdf.yml
@@ -19,7 +19,7 @@ permissions:
 
 # Using concurrency to cancel any in-progress job or run
 concurrency:
-  group: ${{ github.workflow }}-${{ github.sha || github.event.pull_request.number }}
+  group: ${{ github.workflow }}-${{ github.sha || github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/netcdf.yml
+++ b/.github/workflows/netcdf.yml
@@ -19,7 +19,7 @@ permissions:
 
 # Using concurrency to cancel any in-progress job or run
 concurrency:
-  group: ${{ github.workflow }}-${{ github.sha || github.event.pull_request.number || github.ref }}
+  group: ${{ github.workflow }}-${{ github.head_ref && github.ref || github.run_id }}
   cancel-in-progress: true
 
 jobs:


### PR DESCRIPTION
Uses github.ref for the concurrency group for workflows when run as part of a PR (github.head_ref is available) so that previously-triggered workflows are cancelled when a new commit is pushed to a PR. Otherwise, uses github.run_id when commits are pushed to develop so that this shouldn't cancel things when multiple commits are merged to develop at close times.