### PR TITLE
Fix a file handle leak in the core VFD

### DIFF
--- a/release_docs/RELEASE.txt
+++ b/release_docs/RELEASE.txt
@@ -404,6 +404,13 @@ Bug Fixes since HDF5-1.14.0 release
 ===================================
     Library
     -------
+    - Fixed a file handle leak in the core VFD
+
+      When opening a file with the core VFD and a file image, if the file
+      already exists, the file check would leak the POSIX file handle.
+
+      Fixes GitHub issue #635
+
     - Fixed some issues with chunk index metadata not getting read
       collectively when collective metadata reads are enabled
 

--- a/src/H5FDcore.c
+++ b/src/H5FDcore.c
@@ -754,8 +754,10 @@ H5FD__core_open(const char *name, unsigned flags, hid_t fapl_id, haddr_t maxaddr
            ((file_image_info.buffer == NULL) && (file_image_info.size == 0)));
     memset(&sb, 0, sizeof(sb));
     if ((file_image_info.buffer != NULL) && !(H5F_ACC_CREAT & flags)) {
-        if (HDopen(name, o_flags, H5_POSIX_CREATE_MODE_RW) >= 0)
+        if ((fd = HDopen(name, o_flags, H5_POSIX_CREATE_MODE_RW)) >= 0) {
+            HDclose(fd);
             HGOTO_ERROR(H5E_FILE, H5E_FILEEXISTS, NULL, "file already exists");
+        }
 
         /* If backing store is requested, create and stat the file
          * Note: We are forcing the O_CREAT flag here, even though this is


### PR DESCRIPTION
When opening a file with the core VFD and a file image, if the file already exists, the file check would leak the POSIX file handle.

Fixes GitHub issue #635