### PR TITLE
Rework MPI Info FAPL preserve PR to use VFD 'ctl' operations

### DIFF
--- a/src/H5FDmpi.c
+++ b/src/H5FDmpi.c
@@ -143,7 +143,7 @@ done:
 } /* end H5FD_mpi_get_comm() */
 
 /*-------------------------------------------------------------------------
- * Function:    H5FD_mpi_get_comm
+ * Function:    H5FD_mpi_get_info
  *
  * Purpose:     Retrieves the file's MPI_Info info object
  *

--- a/src/H5FDmpi.c
+++ b/src/H5FDmpi.c
@@ -104,13 +104,12 @@ done:
 } /* end H5FD_mpi_get_size() */
 
 /*-------------------------------------------------------------------------
- * Function:	H5FD_mpi_get_comm
+ * Function:    H5FD_mpi_get_comm
  *
- * Purpose:	Retrieves the file's communicator
+ * Purpose:	    Retrieves the file's MPI_Comm communicator object
  *
- * Return:	Success:	The communicator (non-negative)
- *
- *		Failure:	Negative
+ * Return:      Success:    The communicator object
+ *              Failure:    MPI_COMM_NULL
  *
  *-------------------------------------------------------------------------
  */
@@ -142,6 +141,45 @@ H5FD_mpi_get_comm(H5FD_t *file)
 done:
     FUNC_LEAVE_NOAPI(ret_value)
 } /* end H5FD_mpi_get_comm() */
+
+/*-------------------------------------------------------------------------
+ * Function:    H5FD_mpi_get_comm
+ *
+ * Purpose:     Retrieves the file's MPI_Info info object
+ *
+ * Return:      Success:    The info object
+ *              Failure:    MPI_INFO_NULL
+ *
+ *-------------------------------------------------------------------------
+ */
+MPI_Info
+H5FD_mpi_get_info(H5FD_t *file)
+{
+    const H5FD_class_t *cls;
+    uint64_t            flags    = H5FD_CTL_FAIL_IF_UNKNOWN_FLAG | H5FD_CTL_ROUTE_TO_TERMINAL_VFD_FLAG;
+    MPI_Info            info     = MPI_INFO_NULL;
+    void               *info_ptr = (void *)(&info);
+    MPI_Info            ret_value;
+
+    FUNC_ENTER_NOAPI(MPI_INFO_NULL)
+
+    assert(file);
+    cls = (const H5FD_class_t *)(file->cls);
+    assert(cls);
+    assert(cls->ctl); /* All MPI drivers must implement this */
+
+    /* Dispatch to driver */
+    if ((cls->ctl)(file, H5FD_CTL_GET_MPI_INFO_OPCODE, flags, NULL, &info_ptr) < 0)
+        HGOTO_ERROR(H5E_VFL, H5E_CANTGET, MPI_INFO_NULL, "driver get_info request failed");
+
+    if (info == MPI_INFO_NULL)
+        HGOTO_ERROR(H5E_VFL, H5E_CANTGET, MPI_INFO_NULL, "driver get_info request failed -- bad info object");
+
+    ret_value = info;
+
+done:
+    FUNC_LEAVE_NOAPI(ret_value)
+} /* end H5FD_mpi_get_info() */
 
 /*-------------------------------------------------------------------------
  * Function:    H5FD_mpi_MPIOff_to_haddr

--- a/src/H5FDmpio.c
+++ b/src/H5FDmpio.c
@@ -3795,6 +3795,7 @@ done:
  *              At present, the supported op codes are:
  *
  *                  H5FD_CTL_GET_MPI_COMMUNICATOR_OPCODE
+ *                  H5FD_CTL_GET_MPI_INFO_OPCODE
  *                  H5FD_CTL_GET_MPI_RANK_OPCODE
  *                  H5FD_CTL_GET_MPI_SIZE_OPCODE
  *                  H5FD_CTL_GET_MPI_FILE_SYNC_OPCODE
@@ -3825,6 +3826,12 @@ H5FD__mpio_ctl(H5FD_t *_file, uint64_t op_code, uint64_t flags, const void H5_AT
             assert(output);
             assert(*output);
             **((MPI_Comm **)output) = file->comm;
+            break;
+
+        case H5FD_CTL_GET_MPI_INFO_OPCODE:
+            assert(output);
+            assert(*output);
+            **((MPI_Info **)output) = file->info;
             break;
 
         case H5FD_CTL_GET_MPI_RANK_OPCODE:

--- a/src/H5FDprivate.h
+++ b/src/H5FDprivate.h
@@ -214,6 +214,7 @@ H5_DLL herr_t H5FD_get_mpio_atomicity(H5FD_t *file, bool *flag);
 H5_DLL int      H5FD_mpi_get_rank(H5FD_t *file);
 H5_DLL int      H5FD_mpi_get_size(H5FD_t *file);
 H5_DLL MPI_Comm H5FD_mpi_get_comm(H5FD_t *file);
+H5_DLL MPI_Info H5FD_mpi_get_info(H5FD_t *file);
 H5_DLL herr_t   H5FD_mpi_get_file_sync_required(H5FD_t *file, bool *file_sync_required);
 #endif /* H5_HAVE_PARALLEL */
 

--- a/src/H5FDpublic.h
+++ b/src/H5FDpublic.h
@@ -179,6 +179,7 @@
 #define H5FD_CTL_INVALID_OPCODE              0
 #define H5FD_CTL_TEST_OPCODE                 1
 #define H5FD_CTL_GET_MPI_COMMUNICATOR_OPCODE 2
+#define H5FD_CTL_GET_MPI_INFO_OPCODE         9
 #define H5FD_CTL_GET_MPI_RANK_OPCODE         3
 #define H5FD_CTL_GET_MPI_SIZE_OPCODE         4
 #define H5FD_CTL_MEM_ALLOC                   5

--- a/src/H5FDsubfiling/H5FDsubfiling.c
+++ b/src/H5FDsubfiling/H5FDsubfiling.c
@@ -2551,6 +2551,12 @@ H5FD__subfiling_ctl(H5FD_t *_file, uint64_t op_code, uint64_t flags, const void 
             **((MPI_Comm **)output) = file->ext_comm;
             break;
 
+        case H5FD_CTL_GET_MPI_INFO_OPCODE:
+            assert(output);
+            assert(*output);
+            **((MPI_Info **)output) = file->info;
+            break;
+
         case H5FD_CTL_GET_MPI_RANK_OPCODE:
             assert(output);
             assert(*output);

--- a/src/H5Fmpi.c
+++ b/src/H5Fmpi.c
@@ -97,11 +97,10 @@ done:
 /*-------------------------------------------------------------------------
  * Function:    H5F_mpi_get_comm
  *
- * Purpose:     Retrieves the file's communicator
+ * Purpose:     Retrieves the file's MPI_Comm communicator object
  *
- * Return:      Success:    The communicator (non-negative)
- *
- *              Failure:    Negative
+ * Return:      Success:    The communicator object
+ *              Failure:    MPI_COMM_NULL
  *
  *-------------------------------------------------------------------------
  */
@@ -121,6 +120,33 @@ H5F_mpi_get_comm(const H5F_t *f)
 done:
     FUNC_LEAVE_NOAPI(ret_value)
 } /* end H5F_mpi_get_comm() */
+
+/*-------------------------------------------------------------------------
+ * Function:    H5F_mpi_get_info
+ *
+ * Purpose:     Retrieves the file's MPI_Info info object
+ *
+ * Return:      Success:    The info object
+ *              Failure:    MPI_INFO_NULL
+ *
+ *-------------------------------------------------------------------------
+ */
+MPI_Info
+H5F_mpi_get_info(const H5F_t *f)
+{
+    MPI_Info ret_value = MPI_INFO_NULL;
+
+    FUNC_ENTER_NOAPI(MPI_INFO_NULL)
+
+    assert(f && f->shared);
+
+    /* Dispatch to driver */
+    if ((ret_value = H5FD_mpi_get_info(f->shared->lf)) == MPI_INFO_NULL)
+        HGOTO_ERROR(H5E_FILE, H5E_CANTGET, MPI_INFO_NULL, "driver get_info request failed");
+
+done:
+    FUNC_LEAVE_NOAPI(ret_value)
+} /* end H5F_mpi_get_info() */
 
 /*-------------------------------------------------------------------------
  * Function:    H5F_shared_mpi_get_size

--- a/src/H5Fpkg.h
+++ b/src/H5Fpkg.h
@@ -359,7 +359,6 @@ struct H5F_shared_t {
 #ifdef H5_HAVE_PARALLEL
     H5P_coll_md_read_flag_t coll_md_read;  /* Do all metadata reads collectively */
     bool                    coll_md_write; /* Do all metadata writes collectively */
-    MPI_Info                mpi_info;      /* MPI info */
 #endif                                     /* H5_HAVE_PARALLEL */
 };
 

--- a/src/H5Fprivate.h
+++ b/src/H5Fprivate.h
@@ -640,6 +640,7 @@ H5_DLL herr_t H5F_eoa_dirty(H5F_t *f);
 #ifdef H5_HAVE_PARALLEL
 H5_DLL int      H5F_mpi_get_rank(const H5F_t *f);
 H5_DLL MPI_Comm H5F_mpi_get_comm(const H5F_t *f);
+H5_DLL MPI_Info H5F_mpi_get_info(const H5F_t *f);
 H5_DLL int      H5F_shared_mpi_get_size(const H5F_shared_t *f_sh);
 H5_DLL int      H5F_mpi_get_size(const H5F_t *f);
 H5_DLL herr_t   H5F_mpi_retrieve_comm(hid_t loc_id, hid_t acspl_id, MPI_Comm *mpi_comm);


### PR DESCRIPTION
This doesn't fix the test failure with nvhpc and intel classic, but brings the changes more in line with how we retrieve the MPI_Comm object currently by using the VFD 'ctl' callback. The test failure with nvhpc goes away with an optimization level of -O1 or lower, so I still suspect that's due to an nvhpc problem and not something in the library. It appears that Nvidia also does or was building HDF5 with -O1 from https://forums.developer.nvidia.com/t/help-configuring-hdf5-with-nvhpc-no-version-information-available/183413.