### PR TITLE
Avoid attempted use of NULL pointer in parallel compression code

### DIFF
--- a/src/H5Dmpio.c
+++ b/src/H5Dmpio.c
@@ -3782,6 +3782,10 @@ H5D__mpio_redistribute_shared_chunks_int(H5D_filtered_collective_io_info_t *chun
         counts_disps_array = H5MM_xfree(counts_disps_array);
     }
 
+    /* No useful work to do - exit */
+    if (coll_chunk_list_num_entries == 0)
+        HGOTO_DONE(SUCCEED);
+
     /*
      * Phase 2 - Involved ranks now redistribute any shared chunks to new
      * owners as necessary.


### PR DESCRIPTION
The parallel compression test code tests for the case where all MPI ranks have no selection in a dataset when writing to it. Add an early exit to the code to avoid attempting to use a NULL pointer due to there being no work to do.