### PR TITLE
Don't install h5tools_test_utils test program on system

### DIFF
--- a/release_docs/RELEASE.txt
+++ b/release_docs/RELEASE.txt
@@ -815,6 +815,16 @@ Bug Fixes since HDF5-1.14.0 release
 
     Configuration
     -------------
+    - Fixed an issue where the h5tools_test_utils test program was being
+      installed on the system for Autotools builds of HDF5
+
+      The h5tools_test_utils test program was mistakenly added to bin_PROGRAMS
+      in its Makefile.am configuration file, causing the executable to be
+      installed on the system. The executable is now added to noinst_PROGRAMS
+      intead and will no longer be installed on the system for Autotools builds
+      of HDF5. The CMake configuration code already avoids installing the
+      executable on the system.
+
     - Fixed a configuration issue that prevented building of the Subfiling VFD on macOS
 
       Checks were added to the CMake and Autotools code to verify that CLOCK_MONOTONIC_COARSE,

--- a/release_docs/RELEASE.txt
+++ b/release_docs/RELEASE.txt
@@ -821,7 +821,7 @@ Bug Fixes since HDF5-1.14.0 release
       The h5tools_test_utils test program was mistakenly added to bin_PROGRAMS
       in its Makefile.am configuration file, causing the executable to be
       installed on the system. The executable is now added to noinst_PROGRAMS
-      intead and will no longer be installed on the system for Autotools builds
+      instead and will no longer be installed on the system for Autotools builds
       of HDF5. The CMake configuration code already avoids installing the
       executable on the system.
 

--- a/tools/libtest/Makefile.am
+++ b/tools/libtest/Makefile.am
@@ -27,7 +27,7 @@ LDADD=$(LIBH5TOOLS) $(LIBH5TEST) $(LIBHDF5)
 
 
 # main target
-bin_PROGRAMS=h5tools_test_utils
+noinst_PROGRAMS=h5tools_test_utils
 # check_PROGRAMS=$(TEST_PROG)
 
 


### PR DESCRIPTION
This is just a test program for some tools utility functions and shouldn't be installed