### PR TITLE
Fix h5py CI failure.

### DIFF
--- a/.github/workflows/h5py.yml
+++ b/.github/workflows/h5py.yml
@@ -11,10 +11,11 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-    - name: Install gfortran
-      run: |
-        sudo apt-get update
-        sudo apt-get install -y gfortran-12
+    - name: Install Fortran
+      uses: fortran-lang/setup-fortran@v1
+      with:
+        compiler: gcc
+        version: 13
     - name: Checkout Spack
       uses: actions/checkout@v4
       with:


### PR DESCRIPTION
This PR fixes the following error:

```
==> Fetching https://download.open-mpi.org/release/open-mpi/v4.1/openmpi-4.1.6.tar.bz2
==> No patches needed for openmpi
==> openmpi: Executing phase: 'autoreconf'
==> Error: InstallError: OpenMPI requires both C and Fortran compilers!

/home/runner/work/hdf5/hdf5/spack/var/spack/repos/builtin/packages/openmpi/package.py:907, in die_without_fortran:
        904        # dependencies depends_on('mpi'), require Fortran compiler to
        905        # avoid delayed build errors in dependents.
        906        if (self.compiler.f77 is None) and (self.compiler.fc is None):
  >>    907            raise InstallError(
```