### PR TITLE
Use the current toolchain for examples as default

### DIFF
--- a/CMakeInstallation.cmake
+++ b/CMakeInstallation.cmake
@@ -141,6 +141,10 @@ install (
 #-----------------------------------------------------------------------------
 option (HDF5_PACK_EXAMPLES  "Package the HDF5 Library Examples Compressed File" OFF)
 if (HDF5_PACK_EXAMPLES)
+  if (DEFINED CMAKE_TOOLCHAIN_FILE)
+    get_filename_component(TOOLCHAIN ${CMAKE_TOOLCHAIN_FILE} NAME)
+    set(CTEST_TOOLCHAIN_FILE "\${CTEST_SOURCE_DIRECTORY}/config/toolchain/${TOOLCHAIN}")
+  endif ()
   configure_file (
       ${HDF_RESOURCES_DIR}/examples/HDF5_Examples.cmake.in
       ${HDF5_BINARY_DIR}/HDF5_Examples.cmake @ONLY

--- a/config/cmake/examples/HDF5_Examples.cmake.in
+++ b/config/cmake/examples/HDF5_Examples.cmake.in
@@ -29,6 +29,7 @@ set(CTEST_DASHBOARD_ROOT ${CTEST_SCRIPT_DIRECTORY})
 #INSTALLDIR - HDF5 root folder
 #CTEST_CONFIGURATION_TYPE - Release, Debug, RelWithDebInfo
 #CTEST_SOURCE_NAME - name of source folder; HDF5Examples
+#CTEST_TOOLCHAIN_FILE - name and path in source of toolchain file
 if(DEFINED CTEST_SCRIPT_ARG)
   # transform ctest script arguments of the form
   # script.ctest,var1=value1,var2=value2
@@ -96,6 +97,12 @@ endif()
 ### default HDF5_PLUGIN_PATH to where the filter libraries are located
 set(ENV{HDF5_PLUGIN_PATH} "${INSTALLDIR}/lib/plugin")
 set(ADD_BUILD_OPTIONS "${ADD_BUILD_OPTIONS} -DHDF5_PACKAGE_NAME:STRING=@HDF5_PACKAGE@@HDF_PACKAGE_EXT@")
+### use a toolchain file (supported everywhere)       ####
+if(NOT DEFINED CTEST_TOOLCHAIN_FILE)
+  set(ADD_BUILD_OPTIONS "${ADD_BUILD_OPTIONS} -DCMAKE_TOOLCHAIN_FILE:STRING=@CTEST_TOOLCHAIN_FILE@")
+else()
+  set(ADD_BUILD_OPTIONS "${ADD_BUILD_OPTIONS} -DCMAKE_TOOLCHAIN_FILE:STRING=${CTEST_TOOLCHAIN_FILE}")
+endif()
 
 ###############################################################################################################
 # For any comments please contact cdashhelp@hdfgroup.org

--- a/config/cmake/examples/HDF5_Examples_options.cmake
+++ b/config/cmake/examples/HDF5_Examples_options.cmake
@@ -29,6 +29,19 @@
 #set(ADD_BUILD_OPTIONS "${ADD_BUILD_OPTIONS} -DBUILD_SHARED_LIBS:BOOL=ON")
 
 #############################################################################################
+####      maximum parallel processor count for build and test       ####
+#set(MAX_PROC_COUNT 8)
+
+#############################################################################################
+####      alternate toolsets (Windows usually)        ####
+#set(CMAKE_GENERATOR_TOOLSET "Intel C++ Compiler 17.0")
+
+#############################################################################################
+### use a toolchain file (supported everywhere)       ####
+#set(ADD_BUILD_OPTIONS "${ADD_BUILD_OPTIONS} -DCMAKE_TOOLCHAIN_FILE:STRING=config/toolchain/clang.cmake")
+#set(ADD_BUILD_OPTIONS "${ADD_BUILD_OPTIONS} -DCMAKE_TOOLCHAIN_FILE:STRING=config/toolchain/intel.cmake")
+
+#############################################################################################
 ####      languages       ####
 ### disable C builds
 #set(ADD_BUILD_OPTIONS "${ADD_BUILD_OPTIONS} -DHDF_BUILD_C:BOOL=OFF")

--- a/config/cmake/scripts/HDF5options.cmake
+++ b/config/cmake/scripts/HDF5options.cmake
@@ -26,7 +26,6 @@
 
 #############################################################################################
 ### use a toolchain file (supported everywhere)       ####
-
 #set (ADD_BUILD_OPTIONS "${ADD_BUILD_OPTIONS} -DCMAKE_TOOLCHAIN_FILE:STRING=config/toolchain/intel.cmake")
 
 #############################################################################################


### PR DESCRIPTION
When binaries are created with a certain toolchain this PR will default the examples cmake script to use the same toolchain. However, this can be overridden if using a different hdf5 binary.