### PR TITLE
Remove H5system.c warning on Windows oneAPI.

### DIFF
--- a/src/H5system.c
+++ b/src/H5system.c
@@ -807,13 +807,12 @@ H5_nanosleep(uint64_t nanosec)
 
 #ifdef H5_HAVE_WIN32_API
     DWORD dwMilliseconds = (DWORD)ceil(nanosec / 1.0e6);
-    DWORD ignore;
 
     /* Windows can't sleep at a ns resolution. Best we can do is ~1 ms. We
      * don't care about the return value since the second parameter
      * (bAlertable) is false, so it will always be zero.
      */
-    ignore = SleepEx(dwMilliseconds, false);
+    SleepEx(dwMilliseconds, false);
 
 #else
 


### PR DESCRIPTION
This PR removes the following warning:
```
C:\Users\JoeLee\source\repos\hdf5\src\H5system.c(810,11): warning: variable 'ignore' set but not used [-Wunused-but-set-variable]
    DWORD ignore;
          ^
1 warning generated.
```