### PR TITLE
Remove printf() format warning on Windows oneAPI.

### DIFF
--- a/test/accum.c
+++ b/test/accum.c
@@ -2194,7 +2194,7 @@ test_swmr_write_big(bool newest_format)
         ZeroMemory(&pi, sizeof(pi));
 
         if (0 == CreateProcess(NULL, SWMR_READER, NULL, NULL, false, 0, NULL, NULL, &si, &pi)) {
-            printf("CreateProcess failed (%d).\n", GetLastError());
+            printf("CreateProcess failed (%lu).\n", GetLastError());
             FAIL_STACK_ERROR;
         }
 


### PR DESCRIPTION
```
C:\Users\JoeLee\source\repos\hdf5\test\accum.c(2197,52): warning: format specifies type 'int' but the argument has type 'DWORD' (aka 'unsigned long') [-Wformat]
            printf("CreateProcess failed (%d).\n", GetLastError());
                                          ~~       ^~~~~~~~~~~~~~
                                          %lu
1 warning generated.
```