### PR TITLE
Remove Autotools sed hack

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -4285,11 +4285,5 @@ if test "X$HDF_FORTRAN" = "Xyes"; then
   esac
 fi
 
-## HDF5 configure code created by autotools with gcc 4.9.2 is adding problematic
-## linker flags:  -l with no library name; -l <libname>, specifically gfortran or m.
-## This sed script corrects "-l <libname>" first and then "-l " with no library name.
-## If the order is not preserved, all instances of "-l " will be removed.
-sed -e '/^postdeps/ s/-l \([a-zA-Z]\)/-l\1/g' -e '/^postdeps/ s/-l //g' -i libtool
-
 ## show the configure settings
 cat src/libhdf5.settings

--- a/release_docs/RELEASE.txt
+++ b/release_docs/RELEASE.txt
@@ -835,6 +835,16 @@ Bug Fixes since HDF5-1.14.0 release
 
     Configuration
     -------------
+    - Removed an Autotools configure hack that causes problems on MacOS
+
+      A sed line in configure.ac was added in the past to paper over some
+      problems with older versions of the Autotools that would add incorrect
+      linker flags. This hack is not needed with recent versions of the
+      Autotools and the sed line errors on MacOS (though this was a silent
+      error that didn't break the build) so the hack has been removed.
+
+      Fixes GitHub issue #3843
+
     - Fixed an issue where the h5tools_test_utils test program was being
       installed on the system for Autotools builds of HDF5
 


### PR DESCRIPTION
A sed line in configure.ac was added in the past to paper over some
problems with older versions of the Autotools that would add incorrect
linker flags. This hack is not needed with recent versions of the
Autotools and the sed line errors on MacOS (though this was a silent
error that didn't break the build) so the hack has been removed.

Fixes GitHub issue #3843