### PR TITLE
Complete the `if command line option` sentence.

### DIFF
--- a/tools/src/h5dump/h5dump.c
+++ b/tools/src/h5dump/h5dump.c
@@ -1357,7 +1357,7 @@ main(int argc, char *argv[])
         goto done;
     }
 
-    /* enable error reporting if command line option */
+    /* Enable error reporting if -E command line option is specified */
     h5tools_error_report();
 
     /* Initialize indexing options */

--- a/tools/src/h5dump/h5dump.c
+++ b/tools/src/h5dump/h5dump.c
@@ -1357,7 +1357,7 @@ main(int argc, char *argv[])
         goto done;
     }
 
-    /* Enable error reporting if -E command line option is specified */
+    /* Enable error reporting if --enable-error-stack command line option is specified */
     h5tools_error_report();
 
     /* Initialize indexing options */


### PR DESCRIPTION
Make comment clear and consistent.

From:
```
   /* enable error reporting if command line option */
```

To:
```
  /* Enable error reporting if -E command line option is specified */
```