### PR TITLE
Fix h5dump segmentation fault when --vfd-value option is used

### DIFF
--- a/tools/src/h5dump/h5dump.c
+++ b/tools/src/h5dump/h5dump.c
@@ -1234,7 +1234,7 @@ end_collect:
     }
 
     /* If the file uses the onion VFD, get the revision number */
-    if (vfd_info_g.u.name && !strcmp(vfd_info_g.u.name, "onion")) {
+    if (vfd_info_g.type == VFD_BY_NAME && vfd_info_g.u.name && !strcmp(vfd_info_g.u.name, "onion")) {
 
         if (vfd_info_g.info) {
             if (!strcmp(vfd_info_g.info, "revision_count"))


### PR DESCRIPTION
When `--vfd-value=12` option is used, h5dump gives segmentation fault since `vfd_info_g.u.name` becomes invalid.

Thus, the following code triggers the fault:
```
   /* If the file uses the onion VFD, get the revision number */
    if (vfd_info_g.u.name && !strcmp(vfd_info_g.u.name, "onion")) {
   }
 ```