### PR TITLE
Report error for h5dump subfiling vfd option if mpi is unavailable

### DIFF
--- a/tools/lib/h5tools.c
+++ b/tools/lib/h5tools.c
@@ -597,6 +597,9 @@ h5tools_set_fapl_vfd(hid_t fapl_id, h5tools_vfd_info_t *vfd_info)
                     if (H5Pset_fapl_subfiling(fapl_id, (const H5FD_subfiling_config_t *)vfd_info->info) < 0)
                         H5TOOLS_GOTO_ERROR(FAIL, "H5Pset_fapl_subfiling() failed");
                 }
+                else {
+                    H5TOOLS_GOTO_ERROR(FAIL, "MPI is not available for Subfiling VFD");
+                }
 #else
                 H5TOOLS_GOTO_ERROR(FAIL, "The Subfiling VFD is not enabled");
 #endif
@@ -626,6 +629,12 @@ h5tools_set_fapl_vfd(hid_t fapl_id, h5tools_vfd_info_t *vfd_info)
              *
              * Currently, driver configuration strings are unsupported.
              */
+#if defined(H5_HAVE_PARALLEL) && defined(H5_HAVE_SUBFILING_VFD)
+            if (vfd_info->u.value == H5_VFD_SUBFILING) {
+                if (H5Pset_fapl_subfiling(fapl_id, (const H5FD_subfiling_config_t *)vfd_info->info) < 0)
+                    H5TOOLS_GOTO_ERROR(FAIL, "H5Pset_fapl_subfiling() failed");
+            }
+#endif
             if (H5Pset_driver_by_value(fapl_id, vfd_info->u.value, (const char *)vfd_info->info) < 0)
                 H5TOOLS_GOTO_ERROR(FAIL, "can't load VFD plugin by driver value '%ld'",
                                    (long int)vfd_info->u.value);

--- a/tools/lib/h5tools.c
+++ b/tools/lib/h5tools.c
@@ -587,19 +587,8 @@ h5tools_set_fapl_vfd(hid_t fapl_id, h5tools_vfd_info_t *vfd_info)
             }
             else if (!strcmp(vfd_info->u.name, drivernames[SUBFILING_VFD_IDX])) {
 #if defined(H5_HAVE_PARALLEL) && defined(H5_HAVE_SUBFILING_VFD)
-                int mpi_initialized, mpi_finalized;
-
-                /* check if MPI is available. */
-                MPI_Initialized(&mpi_initialized);
-                MPI_Finalized(&mpi_finalized);
-
-                if (mpi_initialized && !mpi_finalized) {
-                    if (H5Pset_fapl_subfiling(fapl_id, (const H5FD_subfiling_config_t *)vfd_info->info) < 0)
-                        H5TOOLS_GOTO_ERROR(FAIL, "H5Pset_fapl_subfiling() failed");
-                }
-                else {
-                    H5TOOLS_GOTO_ERROR(FAIL, "MPI is not available for Subfiling VFD");
-                }
+                if (H5Pset_fapl_subfiling(fapl_id, (const H5FD_subfiling_config_t *)vfd_info->info) < 0)
+                    H5TOOLS_GOTO_ERROR(FAIL, "H5Pset_fapl_subfiling() failed");
 #else
                 H5TOOLS_GOTO_ERROR(FAIL, "The Subfiling VFD is not enabled");
 #endif
@@ -629,12 +618,16 @@ h5tools_set_fapl_vfd(hid_t fapl_id, h5tools_vfd_info_t *vfd_info)
              *
              * Currently, driver configuration strings are unsupported.
              */
-#if defined(H5_HAVE_PARALLEL) && defined(H5_HAVE_SUBFILING_VFD)
+
             if (vfd_info->u.value == H5_VFD_SUBFILING) {
+#if defined(H5_HAVE_PARALLEL) && defined(H5_HAVE_SUBFILING_VFD)
                 if (H5Pset_fapl_subfiling(fapl_id, (const H5FD_subfiling_config_t *)vfd_info->info) < 0)
                     H5TOOLS_GOTO_ERROR(FAIL, "H5Pset_fapl_subfiling() failed");
-            }
+#else
+                H5TOOLS_GOTO_ERROR(FAIL, "The Subfiling VFD is not enabled");
 #endif
+            }
+
             if (H5Pset_driver_by_value(fapl_id, vfd_info->u.value, (const char *)vfd_info->info) < 0)
                 H5TOOLS_GOTO_ERROR(FAIL, "can't load VFD plugin by driver value '%ld'",
                                    (long int)vfd_info->u.value);

--- a/tools/lib/h5tools.c
+++ b/tools/lib/h5tools.c
@@ -627,10 +627,11 @@ h5tools_set_fapl_vfd(hid_t fapl_id, h5tools_vfd_info_t *vfd_info)
                 H5TOOLS_GOTO_ERROR(FAIL, "The Subfiling VFD is not enabled");
 #endif
             }
-
-            if (H5Pset_driver_by_value(fapl_id, vfd_info->u.value, (const char *)vfd_info->info) < 0)
-                H5TOOLS_GOTO_ERROR(FAIL, "can't load VFD plugin by driver value '%ld'",
-                                   (long int)vfd_info->u.value);
+            else {
+                if (H5Pset_driver_by_value(fapl_id, vfd_info->u.value, (const char *)vfd_info->info) < 0)
+                    H5TOOLS_GOTO_ERROR(FAIL, "can't load VFD plugin by driver value '%ld'",
+                                       (long int)vfd_info->u.value);
+            }
             break;
 
         default:


### PR DESCRIPTION
This PR will help user to understand why subfiling vfd failed for h5dump.

This PR also allows `--vfd-value=12` option for h5dump. 
12 means subfiling.
