### PR TITLE
Add subfiling for h5dump filedriver option help message

### DIFF
--- a/tools/src/h5dump/h5dump.c
+++ b/tools/src/h5dump/h5dump.c
@@ -330,7 +330,7 @@ usage(const char *prog)
     PRINTVALSTREAM(
         rawoutstream,
         "      \"sec2\", \"family\", \"split\", \"multi\", \"direct\", \"stream\", and \"subfiling\".\n");
-    PRINTVALSTREAM(rawoutstream, "      Without the file driver flag, the file will be opened with each driver in\n");    
+    PRINTVALSTREAM(rawoutstream, "      Without the file driver flag, the file will be opened with each driver in\n");
     PRINTVALSTREAM(rawoutstream, "      turn and in the order specified above until one driver succeeds\n");
     PRINTVALSTREAM(rawoutstream, "      in opening the file.\n");
     PRINTVALSTREAM(rawoutstream,

--- a/tools/src/h5dump/h5dump.c
+++ b/tools/src/h5dump/h5dump.c
@@ -326,11 +326,13 @@ usage(const char *prog)
                    "      (Alternate compact form of subsetting is described in the Reference Manual)\n");
     PRINTVALSTREAM(rawoutstream, "\n");
     PRINTVALSTREAM(rawoutstream, "--------------- Option Argument Conventions ---------------\n");
-    PRINTVALSTREAM(rawoutstream,
-                   "  D - is the file driver to use in opening the file. Acceptable values are\n");
     PRINTVALSTREAM(
         rawoutstream,
-        "      \"sec2\", \"family\", \"split\", \"multi\", \"direct\", \"stream\", and \"subfiling\".\n");
+        "  D - is the file driver to use in opening the file. Acceptable values are available from\n");
+    PRINTVALSTREAM(
+        rawoutstream,
+        "      "
+        "https://portal.hdfgroup.org/documentation/hdf5-docs/registered_virtual_file_drivers_vfds.html.\n");    
     PRINTVALSTREAM(rawoutstream,
                    "      Without the file driver flag, the file will be opened with each driver in\n");
     PRINTVALSTREAM(rawoutstream, "      turn and in the order specified above until one driver succeeds\n");

--- a/tools/src/h5dump/h5dump.c
+++ b/tools/src/h5dump/h5dump.c
@@ -326,11 +326,13 @@ usage(const char *prog)
                    "      (Alternate compact form of subsetting is described in the Reference Manual)\n");
     PRINTVALSTREAM(rawoutstream, "\n");
     PRINTVALSTREAM(rawoutstream, "--------------- Option Argument Conventions ---------------\n");
-    PRINTVALSTREAM(rawoutstream, "  D - is the file driver to use in opening the file. Acceptable values are\n");
+    PRINTVALSTREAM(rawoutstream,
+                   "  D - is the file driver to use in opening the file. Acceptable values are\n");
     PRINTVALSTREAM(
         rawoutstream,
         "      \"sec2\", \"family\", \"split\", \"multi\", \"direct\", \"stream\", and \"subfiling\".\n");
-    PRINTVALSTREAM(rawoutstream, "      Without the file driver flag, the file will be opened with each driver in\n");
+    PRINTVALSTREAM(rawoutstream,
+                   "      Without the file driver flag, the file will be opened with each driver in\n");
     PRINTVALSTREAM(rawoutstream, "      turn and in the order specified above until one driver succeeds\n");
     PRINTVALSTREAM(rawoutstream, "      in opening the file.\n");
     PRINTVALSTREAM(rawoutstream,

--- a/tools/src/h5dump/h5dump.c
+++ b/tools/src/h5dump/h5dump.c
@@ -326,11 +326,11 @@ usage(const char *prog)
                    "      (Alternate compact form of subsetting is described in the Reference Manual)\n");
     PRINTVALSTREAM(rawoutstream, "\n");
     PRINTVALSTREAM(rawoutstream, "--------------- Option Argument Conventions ---------------\n");
-    PRINTVALSTREAM(rawoutstream, "  D - is the file driver to use in opening the file. Acceptable values\n");
+    PRINTVALSTREAM(rawoutstream, "  D - is the file driver to use in opening the file. Acceptable values are\n");
     PRINTVALSTREAM(
         rawoutstream,
-        "      are \"sec2\", \"family\", \"split\", \"multi\", \"direct\", and \"stream\". Without\n");
-    PRINTVALSTREAM(rawoutstream, "      the file driver flag, the file will be opened with each driver in\n");
+        "      \"sec2\", \"family\", \"split\", \"multi\", \"direct\", \"stream\", and \"subfiling\".\n");
+    PRINTVALSTREAM(rawoutstream, "      Without the file driver flag, the file will be opened with each driver in\n");    
     PRINTVALSTREAM(rawoutstream, "      turn and in the order specified above until one driver succeeds\n");
     PRINTVALSTREAM(rawoutstream, "      in opening the file.\n");
     PRINTVALSTREAM(rawoutstream,

--- a/tools/src/h5dump/h5dump.c
+++ b/tools/src/h5dump/h5dump.c
@@ -332,7 +332,7 @@ usage(const char *prog)
     PRINTVALSTREAM(
         rawoutstream,
         "      "
-        "https://portal.hdfgroup.org/documentation/hdf5-docs/registered_virtual_file_drivers_vfds.html.\n");    
+        "https://portal.hdfgroup.org/documentation/hdf5-docs/registered_virtual_file_drivers_vfds.html.\n");
     PRINTVALSTREAM(rawoutstream,
                    "      Without the file driver flag, the file will be opened with each driver in\n");
     PRINTVALSTREAM(rawoutstream, "      turn and in the order specified above until one driver succeeds\n");

--- a/tools/src/h5dump/h5dump.c
+++ b/tools/src/h5dump/h5dump.c
@@ -1473,7 +1473,7 @@ main(int argc, char *argv[])
                                 xml_dtd_uri_g);
                 }
                 else {
-                    /*  TO DO: make -url option work in this case (may need new option) */
+                    /*  TODO: make -url option work in this case (may need new option) */
                     char *ns;
                     char *indx;
 

--- a/tools/test/h5dump/expected/h5dump-help.txt
+++ b/tools/test/h5dump/expected/h5dump-help.txt
@@ -103,9 +103,9 @@ usage: h5dump [OPTIONS] files
       (Alternate compact form of subsetting is described in the Reference Manual)
 
 --------------- Option Argument Conventions ---------------
-  D - is the file driver to use in opening the file. Acceptable values
-      are "sec2", "family", "split", "multi", "direct", and "stream". Without
-      the file driver flag, the file will be opened with each driver in
+  D - is the file driver to use in opening the file. Acceptable values are
+      "sec2", "family", "split", "multi", "direct", "stream", and "subfiling".
+      Without the file driver flag, the file will be opened with each driver in
       turn and in the order specified above until one driver succeeds
       in opening the file.
       See examples below for family, split, and multi driver special file name usage.

--- a/tools/test/h5dump/expected/h5dump-help.txt
+++ b/tools/test/h5dump/expected/h5dump-help.txt
@@ -103,8 +103,8 @@ usage: h5dump [OPTIONS] files
       (Alternate compact form of subsetting is described in the Reference Manual)
 
 --------------- Option Argument Conventions ---------------
-  D - is the file driver to use in opening the file. Acceptable values are
-      "sec2", "family", "split", "multi", "direct", "stream", and "subfiling".
+  D - is the file driver to use in opening the file. Acceptable values are available from
+      https://portal.hdfgroup.org/documentation/hdf5-docs/registered_virtual_file_drivers_vfds.html.
       Without the file driver flag, the file will be opened with each driver in
       turn and in the order specified above until one driver succeeds
       in opening the file.

--- a/tools/test/h5dump/expected/pbits/tnofilename-with-packed-bits.ddl
+++ b/tools/test/h5dump/expected/pbits/tnofilename-with-packed-bits.ddl
@@ -103,9 +103,9 @@ usage: h5dump [OPTIONS] files
       (Alternate compact form of subsetting is described in the Reference Manual)
 
 --------------- Option Argument Conventions ---------------
-  D - is the file driver to use in opening the file. Acceptable values
-      are "sec2", "family", "split", "multi", "direct", and "stream". Without
-      the file driver flag, the file will be opened with each driver in
+  D - is the file driver to use in opening the file. Acceptable values are
+      "sec2", "family", "split", "multi", "direct", "stream", and "subfiling".
+      Without the file driver flag, the file will be opened with each driver in
       turn and in the order specified above until one driver succeeds
       in opening the file.
       See examples below for family, split, and multi driver special file name usage.

--- a/tools/test/h5dump/expected/pbits/tnofilename-with-packed-bits.ddl
+++ b/tools/test/h5dump/expected/pbits/tnofilename-with-packed-bits.ddl
@@ -103,8 +103,8 @@ usage: h5dump [OPTIONS] files
       (Alternate compact form of subsetting is described in the Reference Manual)
 
 --------------- Option Argument Conventions ---------------
-  D - is the file driver to use in opening the file. Acceptable values are
-      "sec2", "family", "split", "multi", "direct", "stream", and "subfiling".
+  D - is the file driver to use in opening the file. Acceptable values are available from
+      https://portal.hdfgroup.org/documentation/hdf5-docs/registered_virtual_file_drivers_vfds.html.
       Without the file driver flag, the file will be opened with each driver in
       turn and in the order specified above until one driver succeeds
       in opening the file.

--- a/tools/test/h5dump/expected/pbits/tpbitsIncomplete.ddl
+++ b/tools/test/h5dump/expected/pbits/tpbitsIncomplete.ddl
@@ -103,9 +103,9 @@ usage: h5dump [OPTIONS] files
       (Alternate compact form of subsetting is described in the Reference Manual)
 
 --------------- Option Argument Conventions ---------------
-  D - is the file driver to use in opening the file. Acceptable values
-      are "sec2", "family", "split", "multi", "direct", and "stream". Without
-      the file driver flag, the file will be opened with each driver in
+  D - is the file driver to use in opening the file. Acceptable values are
+      "sec2", "family", "split", "multi", "direct", "stream", and "subfiling".
+      Without the file driver flag, the file will be opened with each driver in
       turn and in the order specified above until one driver succeeds
       in opening the file.
       See examples below for family, split, and multi driver special file name usage.

--- a/tools/test/h5dump/expected/pbits/tpbitsIncomplete.ddl
+++ b/tools/test/h5dump/expected/pbits/tpbitsIncomplete.ddl
@@ -103,8 +103,8 @@ usage: h5dump [OPTIONS] files
       (Alternate compact form of subsetting is described in the Reference Manual)
 
 --------------- Option Argument Conventions ---------------
-  D - is the file driver to use in opening the file. Acceptable values are
-      "sec2", "family", "split", "multi", "direct", "stream", and "subfiling".
+  D - is the file driver to use in opening the file. Acceptable values are available from
+      https://portal.hdfgroup.org/documentation/hdf5-docs/registered_virtual_file_drivers_vfds.html.
       Without the file driver flag, the file will be opened with each driver in
       turn and in the order specified above until one driver succeeds
       in opening the file.

--- a/tools/test/h5dump/expected/pbits/tpbitsLengthExceeded.ddl
+++ b/tools/test/h5dump/expected/pbits/tpbitsLengthExceeded.ddl
@@ -103,9 +103,9 @@ usage: h5dump [OPTIONS] files
       (Alternate compact form of subsetting is described in the Reference Manual)
 
 --------------- Option Argument Conventions ---------------
-  D - is the file driver to use in opening the file. Acceptable values
-      are "sec2", "family", "split", "multi", "direct", and "stream". Without
-      the file driver flag, the file will be opened with each driver in
+  D - is the file driver to use in opening the file. Acceptable values are
+      "sec2", "family", "split", "multi", "direct", "stream", and "subfiling".
+      Without the file driver flag, the file will be opened with each driver in
       turn and in the order specified above until one driver succeeds
       in opening the file.
       See examples below for family, split, and multi driver special file name usage.

--- a/tools/test/h5dump/expected/pbits/tpbitsLengthExceeded.ddl
+++ b/tools/test/h5dump/expected/pbits/tpbitsLengthExceeded.ddl
@@ -103,8 +103,8 @@ usage: h5dump [OPTIONS] files
       (Alternate compact form of subsetting is described in the Reference Manual)
 
 --------------- Option Argument Conventions ---------------
-  D - is the file driver to use in opening the file. Acceptable values are
-      "sec2", "family", "split", "multi", "direct", "stream", and "subfiling".
+  D - is the file driver to use in opening the file. Acceptable values are available from
+      https://portal.hdfgroup.org/documentation/hdf5-docs/registered_virtual_file_drivers_vfds.html.
       Without the file driver flag, the file will be opened with each driver in
       turn and in the order specified above until one driver succeeds
       in opening the file.

--- a/tools/test/h5dump/expected/pbits/tpbitsLengthPositive.ddl
+++ b/tools/test/h5dump/expected/pbits/tpbitsLengthPositive.ddl
@@ -103,9 +103,9 @@ usage: h5dump [OPTIONS] files
       (Alternate compact form of subsetting is described in the Reference Manual)
 
 --------------- Option Argument Conventions ---------------
-  D - is the file driver to use in opening the file. Acceptable values
-      are "sec2", "family", "split", "multi", "direct", and "stream". Without
-      the file driver flag, the file will be opened with each driver in
+  D - is the file driver to use in opening the file. Acceptable values are
+      "sec2", "family", "split", "multi", "direct", "stream", and "subfiling".
+      Without the file driver flag, the file will be opened with each driver in
       turn and in the order specified above until one driver succeeds
       in opening the file.
       See examples below for family, split, and multi driver special file name usage.

--- a/tools/test/h5dump/expected/pbits/tpbitsLengthPositive.ddl
+++ b/tools/test/h5dump/expected/pbits/tpbitsLengthPositive.ddl
@@ -103,8 +103,8 @@ usage: h5dump [OPTIONS] files
       (Alternate compact form of subsetting is described in the Reference Manual)
 
 --------------- Option Argument Conventions ---------------
-  D - is the file driver to use in opening the file. Acceptable values are
-      "sec2", "family", "split", "multi", "direct", "stream", and "subfiling".
+  D - is the file driver to use in opening the file. Acceptable values are available from
+      https://portal.hdfgroup.org/documentation/hdf5-docs/registered_virtual_file_drivers_vfds.html.
       Without the file driver flag, the file will be opened with each driver in
       turn and in the order specified above until one driver succeeds
       in opening the file.

--- a/tools/test/h5dump/expected/pbits/tpbitsMaxExceeded.ddl
+++ b/tools/test/h5dump/expected/pbits/tpbitsMaxExceeded.ddl
@@ -103,9 +103,9 @@ usage: h5dump [OPTIONS] files
       (Alternate compact form of subsetting is described in the Reference Manual)
 
 --------------- Option Argument Conventions ---------------
-  D - is the file driver to use in opening the file. Acceptable values
-      are "sec2", "family", "split", "multi", "direct", and "stream". Without
-      the file driver flag, the file will be opened with each driver in
+  D - is the file driver to use in opening the file. Acceptable values are
+      "sec2", "family", "split", "multi", "direct", "stream", and "subfiling".
+      Without the file driver flag, the file will be opened with each driver in
       turn and in the order specified above until one driver succeeds
       in opening the file.
       See examples below for family, split, and multi driver special file name usage.

--- a/tools/test/h5dump/expected/pbits/tpbitsMaxExceeded.ddl
+++ b/tools/test/h5dump/expected/pbits/tpbitsMaxExceeded.ddl
@@ -103,8 +103,8 @@ usage: h5dump [OPTIONS] files
       (Alternate compact form of subsetting is described in the Reference Manual)
 
 --------------- Option Argument Conventions ---------------
-  D - is the file driver to use in opening the file. Acceptable values are
-      "sec2", "family", "split", "multi", "direct", "stream", and "subfiling".
+  D - is the file driver to use in opening the file. Acceptable values are available from
+      https://portal.hdfgroup.org/documentation/hdf5-docs/registered_virtual_file_drivers_vfds.html.
       Without the file driver flag, the file will be opened with each driver in
       turn and in the order specified above until one driver succeeds
       in opening the file.

--- a/tools/test/h5dump/expected/pbits/tpbitsOffsetExceeded.ddl
+++ b/tools/test/h5dump/expected/pbits/tpbitsOffsetExceeded.ddl
@@ -103,9 +103,9 @@ usage: h5dump [OPTIONS] files
       (Alternate compact form of subsetting is described in the Reference Manual)
 
 --------------- Option Argument Conventions ---------------
-  D - is the file driver to use in opening the file. Acceptable values
-      are "sec2", "family", "split", "multi", "direct", and "stream". Without
-      the file driver flag, the file will be opened with each driver in
+  D - is the file driver to use in opening the file. Acceptable values are
+      "sec2", "family", "split", "multi", "direct", "stream", and "subfiling".
+      Without the file driver flag, the file will be opened with each driver in
       turn and in the order specified above until one driver succeeds
       in opening the file.
       See examples below for family, split, and multi driver special file name usage.

--- a/tools/test/h5dump/expected/pbits/tpbitsOffsetExceeded.ddl
+++ b/tools/test/h5dump/expected/pbits/tpbitsOffsetExceeded.ddl
@@ -103,8 +103,8 @@ usage: h5dump [OPTIONS] files
       (Alternate compact form of subsetting is described in the Reference Manual)
 
 --------------- Option Argument Conventions ---------------
-  D - is the file driver to use in opening the file. Acceptable values are
-      "sec2", "family", "split", "multi", "direct", "stream", and "subfiling".
+  D - is the file driver to use in opening the file. Acceptable values are available from
+      https://portal.hdfgroup.org/documentation/hdf5-docs/registered_virtual_file_drivers_vfds.html.
       Without the file driver flag, the file will be opened with each driver in
       turn and in the order specified above until one driver succeeds
       in opening the file.

--- a/tools/test/h5dump/expected/pbits/tpbitsOffsetNegative.ddl
+++ b/tools/test/h5dump/expected/pbits/tpbitsOffsetNegative.ddl
@@ -103,9 +103,9 @@ usage: h5dump [OPTIONS] files
       (Alternate compact form of subsetting is described in the Reference Manual)
 
 --------------- Option Argument Conventions ---------------
-  D - is the file driver to use in opening the file. Acceptable values
-      are "sec2", "family", "split", "multi", "direct", and "stream". Without
-      the file driver flag, the file will be opened with each driver in
+  D - is the file driver to use in opening the file. Acceptable values are
+      "sec2", "family", "split", "multi", "direct", "stream", and "subfiling".
+      Without the file driver flag, the file will be opened with each driver in
       turn and in the order specified above until one driver succeeds
       in opening the file.
       See examples below for family, split, and multi driver special file name usage.

--- a/tools/test/h5dump/expected/pbits/tpbitsOffsetNegative.ddl
+++ b/tools/test/h5dump/expected/pbits/tpbitsOffsetNegative.ddl
@@ -103,8 +103,8 @@ usage: h5dump [OPTIONS] files
       (Alternate compact form of subsetting is described in the Reference Manual)
 
 --------------- Option Argument Conventions ---------------
-  D - is the file driver to use in opening the file. Acceptable values are
-      "sec2", "family", "split", "multi", "direct", "stream", and "subfiling".
+  D - is the file driver to use in opening the file. Acceptable values are available from
+      https://portal.hdfgroup.org/documentation/hdf5-docs/registered_virtual_file_drivers_vfds.html.
       Without the file driver flag, the file will be opened with each driver in
       turn and in the order specified above until one driver succeeds
       in opening the file.


### PR DESCRIPTION
`subfiling` is missing in h5dump help message as an available option value.
This PR will fix it.