### PR TITLE
Fix build error on freebsd

### DIFF
--- a/config/freebsd
+++ b/config/freebsd
@@ -68,7 +68,7 @@ fi
 . $srcdir/config/oneapi-fflags
 
 # Figure out Intel classic FC compiler flags
-. $srcdir/config/classic-fflags
+. $srcdir/config/intel-fflags
 
 # The default C++ compiler
 


### PR DESCRIPTION
Fixes hdf5-1.14.3 build on freebsd

```
checking for config freebsd12.1... no
checking for config freebsd... found
compiler '/home/svcpetsc/petsc-hash-pkgs/39f577/bin/mpicc' is GNU gcc-9.2.0
compiler '/home/svcpetsc/petsc-hash-pkgs/39f577/bin/mpif90' is GNU gfortran-9.2.0
stdout: .: cannot open ./config/classic-fflags: No such file or directory
```

Ref:  https://github.com/HDFGroup/hdf5/pull/3751#discussion_r1412714410