### PR TITLE
Some changes to portal links when they could be found on docs.hdfgroup.org, and changed the helpdesk link to help.hdfgroup.org

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,11 +28,11 @@ DOCUMENTATION
 -------------
 This release is fully functional for the API described in the documentation.
 
-   https://portal.hdfgroup.org/display/HDF5/The+HDF5+API
+   https://docs.hdfgroup.org/hdf5/develop/_l_b_a_p_i.html
 
 Full Documentation and Programming Resources for this release can be found at
 
-   https://portal.hdfgroup.org/display/HDF5
+   https://docs.hdfgroup.org/hdf5/develop/index.html
 
 The latest doxygen documentation generated on changes to develop is available at:
 
@@ -55,7 +55,7 @@ HELP AND SUPPORT
 ----------------
 Information regarding Help Desk and Support services is available at
 
-   https://portal.hdfgroup.org/display/support/The+HDF+Help+Desk
+   https://help.hdfgroup.org 
 
 
 
@@ -103,7 +103,7 @@ Periodically development code snapshots are provided at the following URL:
 
 Source packages for current and previous releases are located at:
     
-   https://portal.hdfgroup.org/display/support/Downloads
+   https://portal.hdfgroup.org/Downloads
 
 Development code is available at our Github location:
     

--- a/release_docs/INSTALL_Cygwin.txt
+++ b/release_docs/INSTALL_Cygwin.txt
@@ -266,4 +266,4 @@ Build, Test and Install HDF5 on Cygwin
 -----------------------------------------------------------------------
 
     HDF Forum:     https://forum.hdfgroup.org/
-    HDF Helpdesk:  https://portal.hdfgroup.org/display/support/The+HDF+Help+Desk
+    HDF Helpdesk:  https://help.hdfgroup.org/

--- a/test/API/README.md
+++ b/test/API/README.md
@@ -42,7 +42,7 @@ Currently unsupported
 
 These API tests currently only support usage with the native HDF5 VOL connector and HDF5 VOL
 connectors that can be loaded dynamically as a plugin. For information on how to build a VOL
-connector in this manner, refer to section 2.3 of the [HDF5 VOL Connector Author Guide](https://portal.hdfgroup.org/display/HDF5/HDF5+VOL+Connector+Authors+Guide?preview=/53610813/59903039/vol_connector_author_guide.pdf).
+connector in this manner, refer to section 2.3 of the [HDF5 VOL Connector Author Guide](https://docs.hdfgroup.org/hdf5/develop/_v_o_l__connector.html).
 
 TODO: section on building VOL connectors alongside HDF5 for use with tests
 
@@ -84,4 +84,4 @@ following will appear in the test output:
 
 ### Help and Support
 
-For help with building or using the HDF5 API tests, please contact the [HDF Help Desk](https://portal.hdfgroup.org/display/support/The+HDF+Help+Desk).
+For help with building or using the HDF5 API tests, please contact the [HDF Help Desk](https://help.hdfgroup.org/).


### PR DESCRIPTION
This is not every instance, but ones where the documentation is already on https://docs.hdfgroup.org/hdf5/develop/

Is the develop branch of the doxygen the right place to send people to? 

OK to fix some links we know of now, but not all at this time? 