### PR TITLE
Add period(.) at the end of the sentence for consistency.

### DIFF
--- a/doxygen/dox/ReferenceManual.dox
+++ b/doxygen/dox/ReferenceManual.dox
@@ -39,7 +39,7 @@ The functions provided by the HDF5 API are grouped into the following
 </td>
 </tr>
 <tr>
-<th>Filters (H5Z)</th><td>@ref H5Z "C"</td><td>"C++"</td><td>@ref FH5Z "Fortran"</td><td>@ref JH5Z "Java"</td><td>Manage HDF5 user-defined filters
+<th>Filters (H5Z)</th><td>@ref H5Z "C"</td><td>"C++"</td><td>@ref FH5Z "Fortran"</td><td>@ref JH5Z "Java"</td><td>Manage HDF5 user-defined filters.
 </td>
 </tr>
 <tr>


### PR DESCRIPTION
H5Z entry in table is missing period.