### PR TITLE
Disable doxygen as errors for netcdf

### DIFF
--- a/.github/workflows/netcdf.yml
+++ b/.github/workflows/netcdf.yml
@@ -47,7 +47,7 @@ jobs:
       run: |
         cd netcdf-c
         autoreconf -if
-        CFLAGS=${CFLAGS} LDFLAGS=${LDFLAGS} LD_LIBRARY_PATH=${LD_LIBRARY_PATH} ./configure --enable-hdf5 --enable-dap --disable-dap-remote-tests  --enable-doxygen --disable-doxygen-errors --enable-external-server-tests
+        CFLAGS=${CFLAGS} LDFLAGS=${LDFLAGS} LD_LIBRARY_PATH=${LD_LIBRARY_PATH} ./configure --enable-hdf5 --enable-dap --disable-dap-remote-tests --enable-external-server-tests
         cat config.log
         cat libnetcdf.settings
         CFLAGS=${CFLAGS} LDFLAGS=${LDFLAGS} LD_LIBRARY_PATH=${LD_LIBRARY_PATH} make -j

--- a/.github/workflows/netcdf.yml
+++ b/.github/workflows/netcdf.yml
@@ -47,7 +47,7 @@ jobs:
       run: |
         cd netcdf-c
         autoreconf -if
-        CFLAGS=${CFLAGS} LDFLAGS=${LDFLAGS} LD_LIBRARY_PATH=${LD_LIBRARY_PATH} ./configure --enable-hdf5 --enable-dap --disable-dap-remote-tests  --enable-doxygen  --enable-external-server-tests
+        CFLAGS=${CFLAGS} LDFLAGS=${LDFLAGS} LD_LIBRARY_PATH=${LD_LIBRARY_PATH} ./configure --enable-hdf5 --enable-dap --disable-dap-remote-tests  --enable-doxygen --disable-doxygen-errors --enable-external-server-tests
         cat config.log
         cat libnetcdf.settings
         CFLAGS=${CFLAGS} LDFLAGS=${LDFLAGS} LD_LIBRARY_PATH=${LD_LIBRARY_PATH} make -j


### PR DESCRIPTION
Do not build doxygen in CI.  NetCDF doxygen has a doxygen warning treated as error, which causes this particular test to fail.  Not having found an option to disable the error for a warning, we won't enable doxygen in the NetCDF build and leave testing it to NetCDF.