### PR TITLE
Move Glossary to the end of docs navigation menu

### DIFF
--- a/doxygen/hdf5doxy_layout.xml
+++ b/doxygen/hdf5doxy_layout.xml
@@ -6,7 +6,6 @@
     <tab type="user" url="@ref GettingStarted" title="Getting started" />
     <tab type="user" url="@ref UG" title="User Guide" />
     <tab type="user" url="@ref RM" title="Reference Manual" />
-    <tab type="user" url="@ref GLS" title="Glossary" />
     <tab type="user" url="https://portal.hdfgroup.org/display/HDF5/HDF5+Application+Developer%27s+Guide" title="Application Developer's Guide" />
     <tab type="user" url="@ref SPEC" title="Specifications" />
     <tab type="user" url="@ref Cookbook" title="Cookbook" />
@@ -16,6 +15,7 @@
     <tab type="user" url="@ref RFC" title="RFCs" />
     <tab type="user" url="@ref FTS" title="Full-Text Search" />
     <tab type="user" url="@ref About" title="About" />
+    <tab type="user" url="@ref GLS" title="Glossary" />    
   </navindex>
 
   <!-- Layout definition for a class page -->


### PR DESCRIPTION
Glossary is positioned in the middle of left navigation menu.
This will move it to the bottom.