### PR TITLE
Add Doxygen documentation for H5FD module and h5tools.

### DIFF
--- a/doxygen/Doxyfile.in
+++ b/doxygen/Doxyfile.in
@@ -693,7 +693,7 @@ FILE_PATTERNS  = H5*public.h H5*module.h H5*develop.h H5FD*.h \
                  H5DxferProp.h H5EnumType.h H5Exception.h H5FaccProp.h H5FcreatProp.h H5File.h \
                  H5FloatType.h H5Group.h H5IdComponent.h H5Include.h H5IntType.h H5LcreatProp.h \
                  H5LaccProp.h H5Library.h H5Location.h H5Object.h H5PredType.h H5PropList.h H5StrType.h \
-                 H5ArrayType.h H5VarLenType.h
+                 H5ArrayType.h H5VarLenType.h h5tools.h h5tools.c
 
 # The RECURSIVE tag can be used to specify whether or not subdirectories should
 # be searched for input files as well.

--- a/doxygen/dox/ReferenceManual.dox
+++ b/doxygen/dox/ReferenceManual.dox
@@ -39,6 +39,10 @@ The functions provided by the HDF5 API are grouped into the following
 </td>
 </tr>
 <tr>
+<th>Files (H5FD)</th><td>@ref H5FD "C"</td><td>"C++"</td><td>"Fortran"</td><td>"Java"</td><td>Manage HDF5 file drivers.
+</td>
+</tr>
+<tr>
 <th>Filters (H5Z)</th><td>@ref H5Z "C"</td><td>"C++"</td><td>@ref FH5Z "Fortran"</td><td>@ref JH5Z "Java"</td><td>Manage HDF5 user-defined filters.
 </td>
 </tr>
@@ -131,6 +135,16 @@ The functions provided by the HDF5 API are grouped into the following
 <tr>
 <td>@ref ERRORS</td><td>The class HDF5Exception returns errors from the Java HDF5 Interface.
 </td>
+</tr>
+</table>
+</td>
+</tr>
+<tr>
+<td>
+<table>
+<caption>HDF5 Tools</caption>
+<tr>
+<td>@ref h5tools</td><td>HDF5 Tools Library</td>
 </tr>
 </table>
 </td>

--- a/src/H5FDmodule.h
+++ b/src/H5FDmodule.h
@@ -25,4 +25,9 @@
 #define H5_MY_PKG     H5FD
 #define H5_MY_PKG_ERR H5E_VFL
 
+/**
+ * \defgroup H5FD File Drivers (H5FD)
+ *
+ * Use the functions in this module to manage HDF5 file drivers.
+ */
 #endif /* H5FDmodule_H */

--- a/tools/lib/h5tools.c
+++ b/tools/lib/h5tools.c
@@ -72,7 +72,10 @@ const char *volnames[] = {
     H5VL_PASSTHRU_NAME,
 };
 
-/* Names of VFDs. These names are always available so that
+/**
+ \ingroup h5tools
+
+ * Names of VFDs. These names are always available so that
  * the tools can emit special messages when a VFD is asked
  * for by name but is not compiled into the library or is
  * somehow otherwise not enabled.
@@ -587,16 +590,8 @@ h5tools_set_fapl_vfd(hid_t fapl_id, h5tools_vfd_info_t *vfd_info)
             }
             else if (!strcmp(vfd_info->u.name, drivernames[SUBFILING_VFD_IDX])) {
 #if defined(H5_HAVE_PARALLEL) && defined(H5_HAVE_SUBFILING_VFD)
-                int mpi_initialized, mpi_finalized;
-
-                /* check if MPI is available. */
-                MPI_Initialized(&mpi_initialized);
-                MPI_Finalized(&mpi_finalized);
-
-                if (mpi_initialized && !mpi_finalized) {
-                    if (H5Pset_fapl_subfiling(fapl_id, (const H5FD_subfiling_config_t *)vfd_info->info) < 0)
-                        H5TOOLS_GOTO_ERROR(FAIL, "H5Pset_fapl_subfiling() failed");
-                }
+                if (H5Pset_fapl_subfiling(fapl_id, (const H5FD_subfiling_config_t *)vfd_info->info) < 0)
+                    H5TOOLS_GOTO_ERROR(FAIL, "H5Pset_fapl_subfiling() failed");
 #else
                 H5TOOLS_GOTO_ERROR(FAIL, "The Subfiling VFD is not enabled");
 #endif
@@ -626,9 +621,20 @@ h5tools_set_fapl_vfd(hid_t fapl_id, h5tools_vfd_info_t *vfd_info)
              *
              * Currently, driver configuration strings are unsupported.
              */
-            if (H5Pset_driver_by_value(fapl_id, vfd_info->u.value, (const char *)vfd_info->info) < 0)
-                H5TOOLS_GOTO_ERROR(FAIL, "can't load VFD plugin by driver value '%ld'",
-                                   (long int)vfd_info->u.value);
+
+            if (vfd_info->u.value == H5_VFD_SUBFILING) {
+#if defined(H5_HAVE_PARALLEL) && defined(H5_HAVE_SUBFILING_VFD)
+                if (H5Pset_fapl_subfiling(fapl_id, (const H5FD_subfiling_config_t *)vfd_info->info) < 0)
+                    H5TOOLS_GOTO_ERROR(FAIL, "H5Pset_fapl_subfiling() failed");
+#else
+                H5TOOLS_GOTO_ERROR(FAIL, "The Subfiling VFD is not enabled");
+#endif
+            }
+            else {
+                if (H5Pset_driver_by_value(fapl_id, vfd_info->u.value, (const char *)vfd_info->info) < 0)
+                    H5TOOLS_GOTO_ERROR(FAIL, "can't load VFD plugin by driver value '%ld'",
+                                       (long int)vfd_info->u.value);
+            }
             break;
 
         default:

--- a/tools/lib/h5tools.h
+++ b/tools/lib/h5tools.h
@@ -10,6 +10,12 @@
  * help@hdfgroup.org.                                                        *
  * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 
+/**
+ * \defgroup h5tools h5tools (h5tools)
+ *
+ * Use the values in this module for command line options.
+ */
+
 /*
  * Purpose:     Support functions for the various tools.
  */
@@ -589,8 +595,11 @@ typedef enum {
     PASS_THROUGH_VOL_IDX,
 } vol_idx;
 
-/* This enum should match the entries in the 'drivernames'
- * array since they are indices into that array. */
+/**
+ \ingroup h5tools
+ This enum should match the entries in the 'drivernames'
+ array since they are indices into that array.
+*/
 typedef enum {
     SEC2_VFD_IDX = 0,
     DIRECT_VFD_IDX,
@@ -717,5 +726,4 @@ H5TOOLS_DLL bool h5tools_render_region_element(FILE *stream, const h5tool_format
 #ifdef __cplusplus
 }
 #endif
-
 #endif /* H5TOOLS_H */


### PR DESCRIPTION
This will help tool users by exposing h5dump VFD options.

![20231222_h5tools_doxygen](https://github.com/HDFGroup/hdf5/assets/4994401/af90822e-9d40-4928-bbb9-bbf933be91e0)

![20231222_h5tools_doxygen_drivernames](https://github.com/HDFGroup/hdf5/assets/4994401/13b12321-7813-4ee3-9255-9e15d177182a)

Once this PR is merged, add the link to https://portal.hdfgroup.org/documentation/hdf5-docs/registered_virtual_file_drivers_vfds.html for #3878.

P.S. H5FD was missing so I added it as well.
