### PR TITLE
Add citation file to specify how this repository wants to be cited

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -1,0 +1,12 @@
+cff-version: 1.2.0
+title: 'Hierarchical Data Format, version 5'
+message: >-
+  If you use this software, please cite it using the
+  metadata from this file.
+type: software
+authors:
+  - name: The HDF Group
+    website: 'https://www.hdfgroup.org'
+repository-code: 'https://github.com/HDFGroup/hdf5'
+url: 'https://www.hdfgroup.org/HDF5/'
+repository-artifact: 'https://www.hdfgroup.org/downloads/hdf5/'


### PR DESCRIPTION
Hi!

I created a `CITATION.cff` to make it more obvious how this software wants to be cited. The `.cff` format is understood by GitHub (show how to cite on the sidebar of the repo), Zenodo, and Zotero.

The information in that file is based on http://web.archive.org/web/20230610185232/https://portal.hdfgroup.org/display/knowledge/How+do+I+properly+cite+HDF5%2C+HDFView%2C+and+HSDS+in+a+paper which is the lastest source of information I found.
The file itself is created by filling that information into https://citation-file-format.github.io/cff-initializer-javascript/.

Currently, the file contains only the website as a source, which is ok! A lot of scientific software wants to be cited with a specific paper combined. By having this file here anyone who wants to give credit to HDF5 in a publication knows that the preferred way is by linking to the project website.