### PR TITLE
Remove cached datatype conversion path table entries on file close

### DIFF
--- a/src/H5T.c
+++ b/src/H5T.c
@@ -348,6 +348,8 @@ static herr_t H5T__set_size(H5T_t *dt, size_t size);
 static herr_t H5T__close_cb(H5T_t *dt, void **request);
 static H5T_path_t *H5T__path_find_real(const H5T_t *src, const H5T_t *dst, const char *name,
                                        H5T_conv_func_t *conv);
+static bool        H5T_path_match(H5T_path_t *path, H5T_pers_t pers, const char *name, H5T_t *src, H5T_t *dst,
+                                  H5VL_object_t *owned_vol_obj, H5T_conv_t func);
 static bool        H5T__detect_vlen_ref(const H5T_t *dt);
 static H5T_t      *H5T__initiate_copy(const H5T_t *old_dt);
 static H5T_t      *H5T__copy_transient(H5T_t *old_dt);
@@ -2693,8 +2695,22 @@ H5T_unregister(H5T_pers_t pers, const char *name, H5T_t *src, H5T_t *dst, H5VL_o
 
     FUNC_ENTER_NOAPI_NOERR
 
-    /* Remove matching entries from the soft list */
-    if (H5T_PERS_DONTCARE == pers || H5T_PERS_SOFT == pers) {
+    /*
+     * Remove matching entries from the soft list if:
+     *
+     *  - The caller didn't specify a particular type (soft or hard)
+     *    of conversion path to match against or specified that soft
+     *    conversion paths should be matched against
+     *
+     *  AND
+     *
+     *  - The caller didn't provide the `owned_vol_obj` parameter;
+     *    if this parameter is provided, we want to leave the soft
+     *    list untouched and only remove cached conversion paths
+     *    below where the file VOL object associated with the path's
+     *    source or destination types matches the given VOL object.
+     */
+    if ((H5T_PERS_DONTCARE == pers || H5T_PERS_SOFT == pers) && !owned_vol_obj) {
         for (i = H5T_g.nsoft - 1; i >= 0; --i) {
             soft = H5T_g.soft + i;
             assert(soft);
@@ -2703,8 +2719,6 @@ H5T_unregister(H5T_pers_t pers, const char *name, H5T_t *src, H5T_t *dst, H5VL_o
             if (src && src->shared->type != soft->src)
                 continue;
             if (dst && dst->shared->type != soft->dst)
-                continue;
-            if (owned_vol_obj)
                 continue;
             if (func && func != soft->conv.u.app_func)
                 continue;
@@ -2721,12 +2735,7 @@ H5T_unregister(H5T_pers_t pers, const char *name, H5T_t *src, H5T_t *dst, H5VL_o
         path = H5T_g.path[i];
         assert(path);
 
-        nomatch = ((H5T_PERS_SOFT == pers && path->is_hard) || (H5T_PERS_HARD == pers && !path->is_hard)) ||
-                  (name && *name && strcmp(name, path->name) != 0) ||
-                  (src && H5T_cmp(src, path->src, false)) || (dst && H5T_cmp(dst, path->dst, false)) ||
-                  (owned_vol_obj && (owned_vol_obj != path->src->shared->owned_vol_obj) &&
-                   (owned_vol_obj != path->dst->shared->owned_vol_obj)) ||
-                  (func && func != path->conv.u.app_func);
+        nomatch = !H5T_path_match(path, pers, name, src, dst, owned_vol_obj, func);
 
         /* Not a match */
         if (nomatch) {
@@ -5157,6 +5166,53 @@ done:
 
     FUNC_LEAVE_NOAPI(ret_value)
 } /* end H5T__path_find_real() */
+
+/*-------------------------------------------------------------------------
+ * Function:  H5T_path_match
+ *
+ * Purpose:   Helper function to determine whether a datatype conversion
+ *            path object matches against a given set of criteria.
+ *
+ * Return:    true/false (can't fail)
+ *
+ *-------------------------------------------------------------------------
+ */
+static bool
+H5T_path_match(H5T_path_t *path, H5T_pers_t pers, const char *name, H5T_t *src, H5T_t *dst,
+               H5VL_object_t *owned_vol_obj, H5T_conv_t func)
+{
+    bool ret_value = true;
+
+    assert(path);
+
+    FUNC_ENTER_NOAPI_NOINIT_NOERR
+
+    if (
+        /* Check that the specified conversion function persistence matches */
+        ((H5T_PERS_SOFT == pers && path->is_hard) || (H5T_PERS_HARD == pers && !path->is_hard)) ||
+
+        /* Check that the specified conversion path name matches */
+        (name && *name && strcmp(name, path->name) != 0) ||
+
+        /*
+         * Check that the specified source and destination datatypes match
+         * the source and destination datatypes in the conversion path
+         */
+        (src && H5T_cmp(src, path->src, false)) || (dst && H5T_cmp(dst, path->dst, false)) ||
+
+        /*
+         * Check that the specified VOL object matches the VOL object
+         * in the conversion path
+         */
+        (owned_vol_obj && (owned_vol_obj != path->src->shared->owned_vol_obj) &&
+         (owned_vol_obj != path->dst->shared->owned_vol_obj)) ||
+
+        /* Check that the specified conversion function matches */
+        (func && func != path->conv.u.app_func))
+        ret_value = false;
+
+    FUNC_LEAVE_NOAPI(ret_value)
+} /* H5T_path_match() */
 
 /*-------------------------------------------------------------------------
  * Function:  H5T_path_noop

--- a/src/H5Tpkg.h
+++ b/src/H5Tpkg.h
@@ -877,4 +877,7 @@ H5_DLL herr_t H5T__sort_name(const H5T_t *dt, int *map);
 /* Debugging functions */
 H5_DLL herr_t H5T__print_stats(H5T_path_t *path, int *nprint /*in,out*/);
 
+/* Testing functions */
+H5_DLL int H5T__get_path_table_npaths(void);
+
 #endif /* H5Tpkg_H */

--- a/src/H5Tprivate.h
+++ b/src/H5Tprivate.h
@@ -133,6 +133,8 @@ H5_DLL H5T_path_t        *H5T_path_find(const H5T_t *src, const H5T_t *dst);
 H5_DLL bool               H5T_path_noop(const H5T_path_t *p);
 H5_DLL H5T_bkg_t          H5T_path_bkg(const H5T_path_t *p);
 H5_DLL H5T_subset_info_t *H5T_path_compound_subset(const H5T_path_t *p);
+H5_DLL herr_t             H5T_unregister(H5T_pers_t pers, const char *name, H5T_t *src, H5T_t *dst,
+                                         H5VL_object_t *owned_vol_obj, H5T_conv_t func);
 H5_DLL herr_t H5T_convert(H5T_path_t *tpath, hid_t src_id, hid_t dst_id, size_t nelmts, size_t buf_stride,
                           size_t bkg_stride, void *buf, void *bkg);
 H5_DLL herr_t H5T_reclaim(hid_t type_id, struct H5S_t *space, void *buf);


### PR DESCRIPTION
When performing datatype conversions during I/O, the library checks to see whether it can re-use a cached datatype conversion pathway by performing comparisons between the source and destination datatypes of the current operation and the source and destination datatypes associated with each cached datatype conversion pathway. For variable-length and reference datatypes, a comparison is made between the VOL object for the file associated with these datatypes, which may change as a file is closed and reopened. In workflows involving a loop that opens a file, performs I/O on an object with a variable-length or reference datatype and then closes the file, this can lead to constant memory usage growth as the library compares the file VOL objects between the datatypes as different and adds a new cached conversion pathway entry on each iteration during I/O. This is now fixed by clearing out any cached conversion pathway entries for variable-length or reference datatypes associated with a particular file when that file is closed.