### PR TITLE
Replace off_t with HDoff_t internally

### DIFF
--- a/hl/tools/gif2h5/gif2hdf.c
+++ b/hl/tools/gif2h5/gif2hdf.c
@@ -26,8 +26,8 @@ main(int argv, char *argc[])
     FILE *fpGif;
 
     /* replacing int32 with long */
-    long i, ImageCount;
-    long filesize;
+    long    i, ImageCount;
+    HDoff_t filesize;
 
     GIFBYTE *MemGif;
     GIFBYTE *StartPos;
@@ -71,7 +71,7 @@ main(int argv, char *argc[])
 
     /* Get the whole file into memory. Mem's much faster than I/O */
     fseek(fpGif, 0L, 2);
-    filesize = ftell(fpGif);
+    filesize = HDftell(fpGif);
     fseek(fpGif, 0L, 0);
 
     if (filesize == 0)

--- a/src/H5Pdcpl.c
+++ b/src/H5Pdcpl.c
@@ -1550,7 +1550,7 @@ H5P__dcrt_ext_file_list_dec(const void **_pp, void *_value)
         enc_size = *(*pp)++;
         assert(enc_size < 256);
         UINT64DECODE_VAR(*pp, enc_value, enc_size);
-        efl->slot[u].offset = (off_t)enc_value;
+        efl->slot[u].offset = (HDoff_t)enc_value;
 
         /* decode size */
         enc_size = *(*pp)++;

--- a/src/H5Ppublic.h
+++ b/src/H5Ppublic.h
@@ -6477,6 +6477,9 @@ H5_DLL herr_t H5Pset_dset_no_attrs_hint(hid_t dcpl_id, hbool_t minimize);
  *         when H5Dwrite() is called to write data to it, the library
  *         will create the file.
  *
+ * \note On Windows, off_t is typically a 32-bit signed long value, which
+ *       limits the valid offset that can be set to 2 GiB.
+ *
  * \since 1.0.0
  *
  */

--- a/src/H5win32defs.h
+++ b/src/H5win32defs.h
@@ -22,7 +22,7 @@
 
 /* off_t exists on Windows, but is always a 32-bit long, even on 64-bit Windows,
  * so we define HDoff_t to be __int64, which is the type of the st_size field
- * of the _stati64 struct.
+ * of the _stati64 struct and what is returned by _ftelli64().
  */
 #define HDoff_t __int64
 
@@ -42,6 +42,7 @@ struct timezone {
 #define HDcreat(S, M)        Wopen_utf8(S, O_CREAT | O_TRUNC | O_RDWR, M)
 #define HDflock(F, L)        Wflock(F, L)
 #define HDfstat(F, B)        _fstati64(F, B)
+#define HDftell(F)           _ftelli64(F)
 #define HDgetdcwd(D, S, Z)   _getdcwd(D, S, Z)
 #define HDgetdrive()         _getdrive()
 #define HDgettimeofday(V, Z) Wgettimeofday(V, Z)

--- a/test/h5test.c
+++ b/test/h5test.c
@@ -1809,7 +1809,7 @@ h5_get_version_string(H5F_libver_t libver)
 /*-------------------------------------------------------------------------
  * Function:    h5_compare_file_bytes()
  *
- * Purpose:     Helper function to compare two files byte-for-byte.
+ * Purpose:     Helper function to compare two files byte-for-byte
  *
  * Return:      Success:  0, if files are identical
  *              Failure: -1, if files differ
@@ -1819,14 +1819,14 @@ h5_get_version_string(H5F_libver_t libver)
 int
 h5_compare_file_bytes(char *f1name, char *f2name)
 {
-    FILE *f1ptr     = NULL; /* two file pointers */
-    FILE *f2ptr     = NULL;
-    off_t f1size    = 0; /* size of the files */
-    off_t f2size    = 0;
-    char  f1char    = 0; /* one char from each file */
-    char  f2char    = 0;
-    off_t ii        = 0;
-    int   ret_value = 0; /* for error handling */
+    FILE   *f1ptr     = NULL; /* two file pointers */
+    FILE   *f2ptr     = NULL;
+    HDoff_t f1size    = 0; /* size of the files */
+    HDoff_t f2size    = 0;
+    char    f1char    = 0; /* one char from each file */
+    char    f2char    = 0;
+    HDoff_t ii        = 0;
+    int     ret_value = 0; /* for error handling */
 
     /* Open files for reading */
     f1ptr = fopen(f1name, "rb");

--- a/testpar/t_subfiling_vfd.c
+++ b/testpar/t_subfiling_vfd.c
@@ -320,7 +320,7 @@ test_config_file(void)
     FILE                   *config_file;
     char                   *config_filename = NULL;
     char                   *config_buf      = NULL;
-    long                    config_file_len;
+    HDoff_t                 config_file_len;
     hid_t                   file_id = H5I_INVALID_HID;
     hid_t                   fapl_id = H5I_INVALID_HID;
     int                     read_stripe_count;


### PR DESCRIPTION
off_t is a 32-bit signed value on Windows, so we should use HDoff_t (which is __int64 on Windows) internally instead.

Also defines HDftell on Windows to be _ftelli64().