### PR TITLE
Remove incorrect include of sz header (#3939)

### DIFF
--- a/testpar/t_filter_read.c
+++ b/testpar/t_filter_read.c
@@ -18,10 +18,6 @@
 
 #include "testphdf5.h"
 
-#ifdef H5_HAVE_SZLIB_H
-#include "szlib.h"
-#endif
-
 static int mpi_size, mpi_rank;
 
 /* Chunk sizes */


### PR DESCRIPTION
Will fix compile errors on HPC machines due to include of non-existent szlib.h.