### PR TITLE
Fix space difference vs expected output for Fortran examples with compression filters

### DIFF
--- a/HDF5Examples/FORTRAN/H5D/h5ex_d_checksum.F90
+++ b/HDF5Examples/FORTRAN/H5D/h5ex_d_checksum.F90
@@ -122,13 +122,13 @@ PROGRAM main
   CALL H5Pget_filter_f(dcpl, 0, flags, nelmts, cd_values, MaxChrLen, name, filter_id, hdferr)
   WRITE(*,'("Filter type is: ")', ADVANCE='NO')
   IF(filter_id.EQ.H5Z_FILTER_DEFLATE_F)THEN
-     WRITE(*,'(T2,"H5Z_FILTER_DEFLATE_F")')
+     WRITE(*,'(" H5Z_FILTER_DEFLATE_F")')
   ELSE IF(filter_id.EQ.H5Z_FILTER_SHUFFLE_F)THEN
-     WRITE(*,'(T2,"H5Z_FILTER_SHUFFLE_F")')
+     WRITE(*,'(" H5Z_FILTER_SHUFFLE_F")')
   ELSE IF(filter_id.EQ.H5Z_FILTER_FLETCHER32_F)THEN
-     WRITE(*,'(T2,"H5Z_FILTER_FLETCHER32_F")')
+     WRITE(*,'(" H5Z_FILTER_FLETCHER32_F")')
   ELSE IF(filter_id.EQ.H5Z_FILTER_SZIP_F)THEN
-     WRITE(*,'(T2,"H5Z_FILTER_SZIP_F")')
+     WRITE(*,'(" H5Z_FILTER_SZIP_F")')
   ENDIF
   !
   ! Read the data using the default properties.

--- a/HDF5Examples/FORTRAN/H5D/h5ex_d_gzip.F90
+++ b/HDF5Examples/FORTRAN/H5D/h5ex_d_gzip.F90
@@ -120,13 +120,13 @@ PROGRAM main
   CALL H5Pget_filter_f(dcpl, 0, flags, nelmts, cd_values, MaxChrLen, name, filter_id, hdferr)
   WRITE(*,'("Filter type is: ")', ADVANCE='NO')
   IF(filter_id.EQ.H5Z_FILTER_DEFLATE_F)THEN
-     WRITE(*,'(T2,"H5Z_FILTER_DEFLATE_F")')
+     WRITE(*,'(" H5Z_FILTER_DEFLATE_F")')
   ELSE IF(filter_id.EQ.H5Z_FILTER_SHUFFLE_F)THEN
-     WRITE(*,'(T2,"H5Z_FILTER_SHUFFLE_F")')
+     WRITE(*,'(" H5Z_FILTER_SHUFFLE_F")')
   ELSE IF(filter_id.EQ.H5Z_FILTER_FLETCHER32_F)THEN
-     WRITE(*,'(T2,"H5Z_FILTER_FLETCHER32_F")')
+     WRITE(*,'(" H5Z_FILTER_FLETCHER32_F")')
   ELSE IF(filter_id.EQ.H5Z_FILTER_SZIP_F)THEN
-     WRITE(*,'(T2,"H5Z_FILTER_SZIP_F")')
+     WRITE(*,'(" H5Z_FILTER_SZIP_F")')
   ENDIF
   !
   ! Read the data using the default properties.

--- a/HDF5Examples/FORTRAN/H5D/h5ex_d_nbit.F90
+++ b/HDF5Examples/FORTRAN/H5D/h5ex_d_nbit.F90
@@ -127,15 +127,15 @@ PROGRAM main
   CALL H5Pget_filter_f(dcpl, 0, flags, nelmts, cd_values, INT(MaxChrLen, SIZE_T), name, filter_id, hdferr)
   WRITE(*,'("Filter type is: ")', ADVANCE='NO')
   IF(filter_id.EQ.H5Z_FILTER_DEFLATE_F)THEN
-     WRITE(*,'(T2,"H5Z_FILTER_DEFLATE_F")')
+     WRITE(*,'(" H5Z_FILTER_DEFLATE_F")')
   ELSE IF(filter_id.EQ.H5Z_FILTER_SHUFFLE_F)THEN
-     WRITE(*,'(T2,"H5Z_FILTER_SHUFFLE_F")')
+     WRITE(*,'(" H5Z_FILTER_SHUFFLE_F")')
   ELSE IF(filter_id.EQ.H5Z_FILTER_FLETCHER32_F)THEN
-     WRITE(*,'(T2,"H5Z_FILTER_FLETCHER32_F")')
+     WRITE(*,'(" H5Z_FILTER_FLETCHER32_F")')
   ELSE IF(filter_id.EQ.H5Z_FILTER_SZIP_F)THEN
-     WRITE(*,'(T2,"H5Z_FILTER_SZIP_F")')
+     WRITE(*,'(" H5Z_FILTER_SZIP_F")')
   ELSE IF(filter_id.EQ.H5Z_FILTER_NBIT_F)THEN
-     WRITE(*,'(T2,"H5Z_FILTER_NBIT_F")')
+     WRITE(*,'(" H5Z_FILTER_NBIT_F")')
   ENDIF
   !
   ! Read the data using the default properties.

--- a/HDF5Examples/FORTRAN/H5D/h5ex_d_soint.F90
+++ b/HDF5Examples/FORTRAN/H5D/h5ex_d_soint.F90
@@ -135,17 +135,17 @@ PROGRAM main
   CALL H5Pget_filter_f(dcpl, 0, flags, nelmts, cd_values, INT(MaxChrLen, SIZE_T), name, filter_id, hdferr)
   WRITE(*,'("Filter type is: ")', ADVANCE='NO')
   IF(filter_id.EQ.H5Z_FILTER_DEFLATE_F)THEN
-     WRITE(*,'(T2,"H5Z_FILTER_DEFLATE_F")')
+     WRITE(*,'(" H5Z_FILTER_DEFLATE_F")')
   ELSE IF(filter_id.EQ.H5Z_FILTER_SHUFFLE_F)THEN
-     WRITE(*,'(T2,"H5Z_FILTER_SHUFFLE_F")')
+     WRITE(*,'(" H5Z_FILTER_SHUFFLE_F")')
   ELSE IF(filter_id.EQ.H5Z_FILTER_FLETCHER32_F)THEN
-     WRITE(*,'(T2,"H5Z_FILTER_FLETCHER32_F")')
+     WRITE(*,'(" H5Z_FILTER_FLETCHER32_F")')
   ELSE IF(filter_id.EQ.H5Z_FILTER_SZIP_F)THEN
-     WRITE(*,'(T2,"H5Z_FILTER_SZIP_F")')
+     WRITE(*,'(" H5Z_FILTER_SZIP_F")')
   ELSE IF(filter_id.EQ.H5Z_FILTER_NBIT_F)THEN
-     WRITE(*,'(T2,"H5Z_FILTER_NBIT_F")')
+     WRITE(*,'(" H5Z_FILTER_NBIT_F")')
   ELSE IF(filter_id.EQ.H5Z_FILTER_SCALEOFFSET_F)THEN
-     WRITE(*,'(T2,"H5Z_FILTER_SCALEOFFSET_F")')
+     WRITE(*,'(" H5Z_FILTER_SCALEOFFSET_F")')
   ENDIF
   !
   ! Read the data using the default properties.

--- a/HDF5Examples/FORTRAN/H5D/h5ex_d_szip.F90
+++ b/HDF5Examples/FORTRAN/H5D/h5ex_d_szip.F90
@@ -121,18 +121,18 @@ PROGRAM main
   CALL H5Pget_filter_f(dcpl, 0, flags, nelmts, cd_values, INT(MaxChrLen,SIZE_T), name, filter_id, hdferr)
   WRITE(*,'("Filter type is: ")', ADVANCE='NO')
   IF(filter_id.EQ.H5Z_FILTER_DEFLATE_F)THEN
-     WRITE(*,'(T2,"H5Z_FILTER_DEFLATE_F")')
+     WRITE(*,'(" H5Z_FILTER_DEFLATE_F")')
   ELSE IF(filter_id.EQ.H5Z_FILTER_SHUFFLE_F)THEN
-     WRITE(*,'(T2,"H5Z_FILTER_SHUFFLE_F")')
+     WRITE(*,'(" H5Z_FILTER_SHUFFLE_F")')
   ELSE IF(filter_id.EQ.H5Z_FILTER_FLETCHER32_F)THEN
-     WRITE(*,'(T2,"H5Z_FILTER_FLETCHER32_F")')
+     WRITE(*,'(" H5Z_FILTER_FLETCHER32_F")')
   ELSE IF(filter_id.EQ.H5Z_FILTER_SZIP_F)THEN
-     WRITE(*,'(T2,"H5Z_FILTER_SZIP_F")')
+     WRITE(*,'(" H5Z_FILTER_SZIP_F")')
 ! DEFINED ONLY IN F2003 hdf5 branch
 !  ELSE IF(filter_id.EQ.H5Z_FILTER_NBIT_F)THEN
-!     WRITE(*,'(T2,"H5Z_FILTER_NBIT_F")')
+!     WRITE(*,'(" H5Z_FILTER_NBIT_F")')
 !  ELSE IF(filter_id.EQ.H5Z_FILTER_SCALEOFFSET_F)THEN
-!     WRITE(*,'(T2,"H5Z_FILTER_SCALEOFFSET_F")')
+!     WRITE(*,'(" H5Z_FILTER_SCALEOFFSET_F")')
   ENDIF
   !
   ! Read the data using the default properties.


### PR DESCRIPTION
Replace 'T2' with ' ' to avoid failure to match expected output due to system tab difference.