### PR TITLE
Remove oneapi/clang compiler printf() type warning.

### DIFF
--- a/HDF5Examples/C/H5T/h5ex_t_convert.c
+++ b/HDF5Examples/C/H5T/h5ex_t_convert.c
@@ -120,7 +120,7 @@ main(void)
      * Output the data to the screen.
      */
     for (i = 0; i < DIM0; i++) {
-        printf("sensor[" PRIuHSIZE "]:\n", i);
+        printf("sensor[%" PRIuHSIZE "]:\n", i);
         printf("Serial number   : %d\n", sensor[i].serial_no);
         printf("Location        : %s\n", sensor[i].location);
         printf("Temperature (F) : %f\n", sensor[i].temperature);

--- a/HDF5Examples/C/H5T/h5ex_t_convert.c
+++ b/HDF5Examples/C/H5T/h5ex_t_convert.c
@@ -120,7 +120,7 @@ main(void)
      * Output the data to the screen.
      */
     for (i = 0; i < DIM0; i++) {
-        printf("sensor[%llu]:\n", i);
+        printf("sensor[" PRIuHSIZE "]:\n", i);
         printf("Serial number   : %d\n", sensor[i].serial_no);
         printf("Location        : %s\n", sensor[i].location);
         printf("Temperature (F) : %f\n", sensor[i].temperature);

--- a/HDF5Examples/C/H5T/h5ex_t_convert.c
+++ b/HDF5Examples/C/H5T/h5ex_t_convert.c
@@ -120,7 +120,7 @@ main(void)
      * Output the data to the screen.
      */
     for (i = 0; i < DIM0; i++) {
-        printf("sensor[%d]:\n", i);
+        printf("sensor[%llu]:\n", i);
         printf("Serial number   : %d\n", sensor[i].serial_no);
         printf("Location        : %s\n", sensor[i].location);
         printf("Temperature (F) : %f\n", sensor[i].temperature);

--- a/HDF5Examples/C/H5T/h5ex_t_opaque.c
+++ b/HDF5Examples/C/H5T/h5ex_t_opaque.c
@@ -111,7 +111,7 @@ main(void)
      */
     printf("Datatype tag for %s is: \"%s\"\n", DATASET, tag);
     for (i = 0; i < dims[0]; i++) {
-        printf("%s[%u]: ", DATASET, i);
+        printf("%s[%" PRIuHSIZE "]: ", DATASET, i);
         for (j = 0; j < len; j++)
             printf("%c", rdata[j + i * len]);
         printf("\n");


### PR DESCRIPTION
This PR fixes the following warning:
```
/.../hdfsrc/HDF5Examples/C/H5T/h5ex_t_convert.c:123:33: warning: format specifies type 'int' but the argument has type 'hsize_t' (aka 'unsigned long long') [-Wformat]

        printf("sensor[%d]:\n", i);
                       ~~       ^
                       %llu
1 warning generated.
```