### PR TITLE
Replace sprintf() with snprintf() to remove Xcode/clang warning.

### DIFF
--- a/test/filter_plugin.c
+++ b/test/filter_plugin.c
@@ -849,8 +849,7 @@ test_creating_groups_using_plugins(hid_t fid)
     for (i = 0; i < N_SUBGROUPS; i++) {
         char *sp = subgroup_name;
 
-        sp += snprintf(subgroup_name, sizeof(subgroup_name), SUBGROUP_PREFIX);
-        snprintf(sp, sizeof(sp), "%d", i);
+        sp += snprintf(subgroup_name, sizeof(subgroup_name), SUBGROUP_PREFIX "%d", i);
 
         if ((sub_gid = H5Gcreate2(gid, subgroup_name, H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT)) < 0)
             TEST_ERROR;
@@ -908,8 +907,7 @@ test_opening_groups_using_plugins(hid_t fid)
     for (i = 0; i < N_SUBGROUPS; i++) {
         char *sp = subgroup_name;
 
-        sp += snprintf(subgroup_name, sizeof(subgroup_name), SUBGROUP_PREFIX);
-        snprintf(sp, sizeof(sp), "%d", i);
+        sp += snprintf(subgroup_name, sizeof(subgroup_name), SUBGROUP_PREFIX "%d", i);
 
         if ((sub_gid = H5Gopen2(gid, subgroup_name, H5P_DEFAULT)) < 0)
             TEST_ERROR;

--- a/test/filter_plugin.c
+++ b/test/filter_plugin.c
@@ -850,7 +850,7 @@ test_creating_groups_using_plugins(hid_t fid)
         char *sp = subgroup_name;
 
         sp += snprintf(subgroup_name, sizeof(subgroup_name), SUBGROUP_PREFIX);
-        sprintf(sp, "%d", i);
+        snprintf(sp, sizeof(sp), "%d", i);
 
         if ((sub_gid = H5Gcreate2(gid, subgroup_name, H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT)) < 0)
             TEST_ERROR;
@@ -909,7 +909,7 @@ test_opening_groups_using_plugins(hid_t fid)
         char *sp = subgroup_name;
 
         sp += snprintf(subgroup_name, sizeof(subgroup_name), SUBGROUP_PREFIX);
-        sprintf(sp, "%d", i);
+        snprintf(sp, sizeof(sp), "%d", i);
 
         if ((sub_gid = H5Gopen2(gid, subgroup_name, H5P_DEFAULT)) < 0)
             TEST_ERROR;


### PR DESCRIPTION
Here's a typical warning message:
```
/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX13.1.sdk/usr/include/stdio.h:188:1: note: 'sprintf' has been explicitly marked deprecated here
188 | __deprecated_msg("This function is provided for compatibility reasons only.  Due to security concerns inherent in the design of sprintf(3), it is highly recommended that you use snprintf(3) instead.")
```