### PR TITLE
Add a missing file into Makefile.am for MinGW/MSYS2 Autotools build error.

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -56,7 +56,7 @@ libhdf5_la_SOURCES= H5.c H5build_settings.c H5checksum.c H5dbg.c H5system.c \
         H5FD.c H5FDcore.c H5FDfamily.c H5FDint.c H5FDlog.c H5FDmulti.c \
         H5FDonion.c H5FDonion_header.c H5FDonion_history.c H5FDonion_index.c \
         H5FDperform.c H5FDsec2.c H5FDspace.c \
-        H5FDsplitter.c H5FDstdio.c H5FDtest.c \
+        H5FDsplitter.c H5FDstdio.c H5FDtest.c H5FDwindows.c \
         H5FL.c H5FO.c H5FS.c H5FScache.c H5FSdbg.c H5FSint.c H5FSsection.c \
         H5FSstat.c H5FStest.c \
         H5G.c H5Gbtree2.c H5Gcache.c H5Gcompact.c H5Gdense.c H5Gdeprec.c \


### PR DESCRIPTION
This PR fixes the following error:
```
C:/msys64/mingw64/bin/../lib/gcc/x86_64-w64-mingw32/13.2.0/../../../../x86_64-w64-mingw32/bin/ld.ex\
e: vfd.o:vfd.c:(.text+0xc2ce): undefined reference to `H5Pset_fapl_windows'
collect2.exe: error: ld returned 1 exit status
make[1]: *** [Makefile:2444: vfd.exe] Error 1
make[1]: *** Waiting for unfinished jobs....
make[1]: Leaving directory '/home/JoeLee/hdf5.HDFGroup/test'
make: *** [Makefile:734: all-recursive] Error 1
```