### PR TITLE
Don't add files and directories with names that begin with ., or that…

### DIFF
--- a/bin/release
+++ b/bin/release
@@ -466,7 +466,7 @@ done
 
 # Create the tar file
 test "$verbose" && echo "   Running tar..." 1>&2
-(cd "$tmpdir" && exec tar -ch --exclude-vcs -f "$HDF5_VERS.tar" "./$HDF5_IN_VERS" || exit 1 )
+(cd "$tmpdir" && exec tar -ch --exclude-vcs --exclude=*autom4te* --exclude=.clang-format --exclude=.codespellrc --exclude=.devcontainer --exclude=.git* --exclude=.h5chkright.ini -f "$HDF5_VERS.tar" "./$HDF5_IN_VERS" || exit 1 )
 
 # Compress
 #SHA256=$HDF5_VERS.sha256

--- a/config/cmake/runTest.cmake
+++ b/config/cmake/runTest.cmake
@@ -137,6 +137,7 @@ file (READ ${TEST_FOLDER}/${TEST_OUTPUT} TEST_STREAM)
 string (FIND TEST_STREAM "_pmi_alps" TEST_FIND_RESULT)
 if (TEST_FIND_RESULT GREATER -1)
   string (REGEX REPLACE "^.*_pmi_alps[^\n]+\n" "" TEST_STREAM "${TEST_STREAM}")
+  string (REGEX REPLACE "^.*ulimit -s.*\n" "" TEST_STREAM "${TEST_STREAM}")
   file (WRITE ${TEST_FOLDER}/${TEST_OUTPUT} ${TEST_STREAM})
 endif ()
 


### PR DESCRIPTION
… match *autom4te* to release tar & zip files.

Fixes #3024

Filter messages with 'ulimit -s' out of test output for runTest.cmake.