### PR TITLE
Remove oneapi return value warning.

### DIFF
--- a/test/dt_arith.c
+++ b/test/dt_arith.c
@@ -3307,8 +3307,7 @@ error:
         return MAX((int)fails_all_tests, 1);
     else if (run_test == TEST_DENORM || run_test == TEST_SPECIAL)
         return 1;
-    else
-        return 1;
+    return 1;
 #endif
 }
 

--- a/test/dt_arith.c
+++ b/test/dt_arith.c
@@ -3307,6 +3307,8 @@ error:
         return MAX((int)fails_all_tests, 1);
     else if (run_test == TEST_DENORM || run_test == TEST_SPECIAL)
         return 1;
+    else
+        return 1;
 #endif
 }
 


### PR DESCRIPTION
This PR fixes the following warning on Windows oneapi 2024.0 compiler:
```
[366/3209] Building C object test\CMakeFiles\dt_arith.dir\dt_arith.c.obj
C:\Users\JoeLee\source\repos\hdf5.HDFGroup\test\dt_arith.c(3311,1): warning: non-void function does not return a value in all control paths [-Wreturn-type]
 3311 | }
      | ^
1 warning generated.
```
