### PR TITLE
Check argument for CMake REGEX FCMangle.h.

### DIFF
--- a/config/cmake/HDFUseFortran.cmake
+++ b/config/cmake/HDFUseFortran.cmake
@@ -32,6 +32,9 @@ endif ()
 #-----------------------------------------------------------------------------
 include (FortranCInterface)
 
+#-----------------------------------------------------------------------------
+# Verify that the Fortran and C/C++ compilers work together
+#-----------------------------------------------------------------------------
 FortranCInterface_VERIFY()
 
 FortranCInterface_HEADER (
@@ -41,17 +44,12 @@ FortranCInterface_HEADER (
 )
 
 file (STRINGS ${CMAKE_BINARY_DIR}/FCMangle.h CONTENTS REGEX "H5_FC_GLOBAL\\(.*,.*\\) +(.*)")
-if (CONTENTS)
-  message(${CONTENTS})
-  string (REGEX MATCH "H5_FC_GLOBAL\\(.*,.*\\) +(.*)" RESULT  ${CONTENTS})
-  set (H5_FC_FUNC "H5_FC_FUNC(name,NAME) ${CMAKE_MATCH_1}")
-endif()
+string (REGEX MATCH "H5_FC_GLOBAL\\(.*,.*\\) +(.*)" RESULT  ${CONTENTS})
+set (H5_FC_FUNC "H5_FC_FUNC(name,NAME) ${CMAKE_MATCH_1}")
 
 file (STRINGS ${CMAKE_BINARY_DIR}/FCMangle.h CONTENTS REGEX "H5_FC_GLOBAL_\\(.*,.*\\) +(.*)")
-if (CONTENTS)
-  string (REGEX MATCH "H5_FC_GLOBAL_\\(.*,.*\\) +(.*)" RESULT  ${CONTENTS})
-  set (H5_FC_FUNC_ "H5_FC_FUNC_(name,NAME) ${CMAKE_MATCH_1}")
-endif()
+string (REGEX MATCH "H5_FC_GLOBAL_\\(.*,.*\\) +(.*)" RESULT  ${CONTENTS})
+set (H5_FC_FUNC_ "H5_FC_FUNC_(name,NAME) ${CMAKE_MATCH_1}")
 
 #test code source
 set (SIZEOF_CODE

--- a/config/cmake/HDFUseFortran.cmake
+++ b/config/cmake/HDFUseFortran.cmake
@@ -31,6 +31,9 @@ endif ()
 # Detect name mangling convention used between Fortran and C
 #-----------------------------------------------------------------------------
 include (FortranCInterface)
+
+FortranCInterface_VERIFY()
+
 FortranCInterface_HEADER (
     ${CMAKE_BINARY_DIR}/FCMangle.h
     MACRO_NAMESPACE "H5_FC_"
@@ -38,12 +41,17 @@ FortranCInterface_HEADER (
 )
 
 file (STRINGS ${CMAKE_BINARY_DIR}/FCMangle.h CONTENTS REGEX "H5_FC_GLOBAL\\(.*,.*\\) +(.*)")
-string (REGEX MATCH "H5_FC_GLOBAL\\(.*,.*\\) +(.*)" RESULT ${CONTENTS})
-set (H5_FC_FUNC "H5_FC_FUNC(name,NAME) ${CMAKE_MATCH_1}")
+if (CONTENTS)
+  message(${CONTENTS})
+  string (REGEX MATCH "H5_FC_GLOBAL\\(.*,.*\\) +(.*)" RESULT  ${CONTENTS})
+  set (H5_FC_FUNC "H5_FC_FUNC(name,NAME) ${CMAKE_MATCH_1}")
+endif()
 
 file (STRINGS ${CMAKE_BINARY_DIR}/FCMangle.h CONTENTS REGEX "H5_FC_GLOBAL_\\(.*,.*\\) +(.*)")
-string (REGEX MATCH "H5_FC_GLOBAL_\\(.*,.*\\) +(.*)" RESULT ${CONTENTS})
-set (H5_FC_FUNC_ "H5_FC_FUNC_(name,NAME) ${CMAKE_MATCH_1}")
+if (CONTENTS)
+  string (REGEX MATCH "H5_FC_GLOBAL_\\(.*,.*\\) +(.*)" RESULT  ${CONTENTS})
+  set (H5_FC_FUNC_ "H5_FC_FUNC_(name,NAME) ${CMAKE_MATCH_1}")
+endif()
 
 #test code source
 set (SIZEOF_CODE


### PR DESCRIPTION
 See @imikejackson [forum](https://forum.hdfgroup.org/t/configuring-1-8-18-on-macos-sierra-with-gfortran-6-3-0/3999) message.
 
 Also, prevent using incompatible c/Fortran compiler pairs in advance before it reaches REGEX checking.
