### PR TITLE
Replace deprecated Fortran 'include mpif.h' with 'USE mpi'

### DIFF
--- a/HDF5Examples/FORTRAN/H5PAR/ph5_f90_hyperslab_by_col.F90
+++ b/HDF5Examples/FORTRAN/H5PAR/ph5_f90_hyperslab_by_col.F90
@@ -4,10 +4,10 @@
      PROGRAM DATASET_BY_COL
 
      USE HDF5 ! This module contains all necessary modules
+     USE mpi
 
      IMPLICIT NONE
 
-     include 'mpif.h'
      CHARACTER(LEN=10), PARAMETER :: filename = "sds_col.h5"  ! File name
      CHARACTER(LEN=8), PARAMETER :: dsetname = "IntArray" ! Dataset name
 

--- a/m4/aclocal_fc.f90
+++ b/m4/aclocal_fc.f90
@@ -154,7 +154,7 @@ END PROGRAM FC_AVAIL_KINDS
 !---- END ----- Determine the available KINDs for REALs and INTEGERs
 
 PROGRAM FC_MPI_CHECK
-  INCLUDE 'mpif.h'
+  USE mpi
   INTEGER :: comm, amode, info, fh, ierror
   CHARACTER(LEN=1) :: filename
   CALL MPI_File_open( comm, filename, amode, info, fh, ierror)

--- a/release_docs/INSTALL_parallel
+++ b/release_docs/INSTALL_parallel
@@ -358,11 +358,9 @@ main(int ac, char **av)
 
      PROGRAM MPIOEXAMPLE
 
-     ! USE MPI
+     USE mpi
 
      IMPLICIT NONE
-
-     INCLUDE 'mpif.h'
         
      CHARACTER(LEN=80), PARAMETER :: filename = "filef.h5" ! File name
      INTEGER     ::   ierror  ! Error flag


### PR DESCRIPTION
With MPI 4.1 the use of the mpif.h include file has been deprecated. Codes should transition to USE mpi or USE mpi_f08.