### PR TITLE
Fix the datatype passed to H5*exists_async APIs in tests.

### DIFF
--- a/config/cmake/H5pubconf.h.in
+++ b/config/cmake/H5pubconf.h.in
@@ -53,6 +53,9 @@
 /* Define if Fortran C_LONG_DOUBLE is different from C_DOUBLE */
 #define H5_FORTRAN_C_LONG_DOUBLE_IS_UNIQUE @H5_FORTRAN_C_LONG_DOUBLE_IS_UNIQUE@
 
+/* Define if Fortran C_BOOL is different from default LOGICAL */
+#define H5_FORTRAN_C_BOOL_IS_UNIQUE @H5_FORTRAN_C_BOOL_IS_UNIQUE@
+
 /* Define if we have Fortran C_LONG_DOUBLE */
 #define H5_FORTRAN_HAVE_C_LONG_DOUBLE @H5_FORTRAN_HAVE_C_LONG_DOUBLE@
 

--- a/config/cmake/HDF5UseFortran.cmake
+++ b/config/cmake/HDF5UseFortran.cmake
@@ -101,6 +101,16 @@ else ()
   set (${HDF_PREFIX}_FORTRAN_C_LONG_DOUBLE_IS_UNIQUE 0)
 endif ()
 
+# Check to see C_BOOL is different from default LOGICAL
+
+READ_SOURCE("MODULE l_type_mod" "END PROGRAM PROG_FC_C_BOOL_EQ_LOGICAL" SOURCE_CODE)
+check_fortran_source_compiles (${SOURCE_CODE} FORTRAN_C_BOOL_IS_UNIQUE SRC_EXT f90)
+if (${FORTRAN_C_BOOL_IS_UNIQUE})
+  set (${HDF_PREFIX}_FORTRAN_C_BOOL_IS_UNIQUE 1)
+else ()
+  set (${HDF_PREFIX}_FORTRAN_C_BOOL_IS_UNIQUE 0)
+endif ()
+
 ## Set the sizeof function for use later in the fortran tests
 if (${HDF_PREFIX}_FORTRAN_HAVE_STORAGE_SIZE)
   set (FC_SIZEOF_A "STORAGE_SIZE(a, c_size_t)/STORAGE_SIZE(c_char_'a',c_size_t)")

--- a/configure.ac
+++ b/configure.ac
@@ -710,6 +710,7 @@ if test "X$HDF_FORTRAN" = "Xyes"; then
   AC_SUBST([HAVE_Fortran_INTEGER_SIZEOF_16])
   AC_SUBST([FORTRAN_HAVE_C_LONG_DOUBLE])
   AC_SUBST([FORTRAN_C_LONG_DOUBLE_IS_UNIQUE])
+  AC_SUBST([FORTRAN_C_BOOL_IS_UNIQUE])
   AC_SUBST([H5CONFIG_F_NUM_RKIND])
   AC_SUBST([H5CONFIG_F_RKIND])
   AC_SUBST([H5CONFIG_F_RKIND_SIZEOF])
@@ -759,6 +760,16 @@ if test "X$HDF_FORTRAN" = "Xyes"; then
     else
       FORTRAN_C_LONG_DOUBLE_IS_UNIQUE="0"
     fi
+  fi
+
+  ## Is C_BOOL different from default LOGICAL
+  FORTRAN_C_BOOL_IS_UNIQUE="0"
+  PAC_PROG_FC_C_BOOL_EQ_LOGICAL
+  if test "X$C_BOOL_IS_UNIQUE_FORTRAN" = "Xyes"; then
+    FORTRAN_C_BOOL_IS_UNIQUE="1"
+    AC_DEFINE([FORTRAN_C_BOOL_IS_UNIQUE], [1], [Define if Fortran C_BOOL is different from default LOGICAL])
+  else
+    FORTRAN_C_BOOL_IS_UNIQUE="0"
   fi
 
   FORTRAN_SIZEOF_LONG_DOUBLE=${ac_cv_sizeof_long_double}

--- a/fortran/src/H5config_f.inc.cmake
+++ b/fortran/src/H5config_f.inc.cmake
@@ -73,6 +73,9 @@
 ! Define if Fortran C_LONG_DOUBLE is different from C_DOUBLE
 #define H5_FORTRAN_C_LONG_DOUBLE_IS_UNIQUE @H5_FORTRAN_C_LONG_DOUBLE_IS_UNIQUE@
 
+! Define if Fortran C_BOOL is different from default LOGICAL
+#define H5_FORTRAN_C_BOOL_IS_UNIQUE @H5_FORTRAN_C_BOOL_IS_UNIQUE@
+
 ! Define if the intrinsic module ISO_FORTRAN_ENV exists
 #define H5_HAVE_ISO_FORTRAN_ENV @H5_HAVE_ISO_FORTRAN_ENV@
 

--- a/fortran/src/H5config_f.inc.in
+++ b/fortran/src/H5config_f.inc.in
@@ -41,6 +41,9 @@
 ! Define if Fortran C_LONG_DOUBLE is different from C_DOUBLE
 #undef FORTRAN_C_LONG_DOUBLE_IS_UNIQUE
 
+! Define if Fortran C_BOOL is different from default LOGICAL
+#undef FORTRAN_C_BOOL_IS_UNIQUE
+
 ! Define if the intrinsic module ISO_FORTRAN_ENV exists
 #undef HAVE_ISO_FORTRAN_ENV
 

--- a/fortran/test/H5_test_buildiface.F90
+++ b/fortran/test/H5_test_buildiface.F90
@@ -106,6 +106,9 @@ PROGRAM H5_test_buildiface
   END DO
   WRITE(11,'(A)') "     MODULE PROCEDURE verify_character"
   WRITE(11,'(A)') "     MODULE PROCEDURE verify_logical"
+#ifdef H5_FORTRAN_C_BOOL_IS_UNIQUE
+  WRITE(11,'(A)') "     MODULE PROCEDURE verify_c_bool"
+#endif
   WRITE(11,'(A)') "  END INTERFACE"
 
   WRITE(11,'(A)') '  INTERFACE check_real_eq'
@@ -299,6 +302,35 @@ PROGRAM H5_test_buildiface
   WRITE(11,'(A)') '      ENDIF'
   WRITE(11,'(A)') '    ENDIF'
   WRITE(11,'(A)') '  END SUBROUTINE verify_logical'
+
+#ifdef H5_FORTRAN_C_BOOL_IS_UNIQUE
+! DLL definitions for windows
+  WRITE(11,'(A)') '!DEC$if defined(BUILD_HDF5_TEST_DLL)'
+  WRITE(11,'(A)') '!DEC$attributes dllexport :: verify_c_bool'
+  WRITE(11,'(A)') '!DEC$endif'
+! Subroutine API
+  WRITE(11,'(A)') '  SUBROUTINE verify_c_bool(string,value,correct_value,total_error,chck_eq)'
+  WRITE(11,'(A)') '    IMPLICIT NONE'
+  WRITE(11,'(A)') '    CHARACTER(LEN=*) :: string'
+  WRITE(11,'(A)') '    LOGICAL(C_BOOL) :: value, correct_value'
+  WRITE(11,'(A)') '    INTEGER :: total_error'
+  WRITE(11,'(A)') '    LOGICAL, OPTIONAL :: chck_eq'
+  WRITE(11,'(A)') '    LOGICAL :: chck_eq_opt'
+  WRITE(11,'(A)') '    chck_eq_opt = .TRUE.'
+  WRITE(11,'(A)') '    IF(PRESENT(chck_eq)) chck_eq_opt = chck_eq'
+  WRITE(11,'(A)') '    IF(chck_eq_opt .EQV. .TRUE.)THEN'
+  WRITE(11,'(A)') '      IF (value .NEQV. correct_value) THEN'
+  WRITE(11,'(A)') '         total_error = total_error + 1'
+  WRITE(11,'(A)') '         WRITE(*,*) "ERROR: INCORRECT VALIDATION ", string'
+  WRITE(11,'(A)') '      ENDIF'
+  WRITE(11,'(A)') '    ELSE'
+  WRITE(11,'(A)') '      IF (value .EQV. correct_value) THEN'
+  WRITE(11,'(A)') '         total_error = total_error + 1'
+  WRITE(11,'(A)') '         WRITE(*,*) "ERROR: INCORRECT VALIDATION ", string'
+  WRITE(11,'(A)') '      ENDIF'
+  WRITE(11,'(A)') '    ENDIF'
+  WRITE(11,'(A)') '  END SUBROUTINE verify_c_bool'
+#endif
 
   WRITE(11,'(A)') "END MODULE TH5_MISC_gen"
 

--- a/fortran/testpar/async.F90
+++ b/fortran/testpar/async.F90
@@ -26,9 +26,8 @@ MODULE test_async_APIs
   LOGICAL :: async_enabled = .TRUE.
   LOGICAL :: mpi_thread_mult = .TRUE.
 
-  INTEGER(C_INT), PARAMETER :: logical_true = 1
-  INTEGER(C_INT), PARAMETER :: logical_false = 0
-  
+  LOGICAL(C_BOOL), PARAMETER :: logical_true = .TRUE.
+  LOGICAL(C_BOOL), PARAMETER :: logical_false = .FALSE.
 
   ! Custom group iteration callback data
   TYPE, bind(c) ::  iter_info
@@ -178,7 +177,7 @@ CONTAINS
     INTEGER(HID_T) :: space_id
     INTEGER(HID_T) :: attr_id0, attr_id1, attr_id2
     LOGICAL :: exists
-    INTEGER(C_INT), TARGET :: exists0=logical_false, exists1=logical_false, exists2=logical_false, exists3=logical_false
+    LOGICAL(C_BOOL), TARGET :: exists0=logical_false, exists1=logical_false, exists2=logical_false, exists3=logical_false
     TYPE(C_PTR) :: f_ptr, f_ptr1, f_ptr2
 
     CALL H5EScreate_f(es_id, hdferror)
@@ -788,7 +787,7 @@ CONTAINS
     INTEGER(hid_t)  :: sid = -1  ! Dataspace ID
     CHARACTER(LEN=12), PARAMETER :: CORDER_GROUP_NAME  = "corder_group"
     CHARACTER(LEN=12), PARAMETER :: CORDER_GROUP_NAME2 = "corder_grp00"
-    INTEGER(C_INT), TARGET :: exists1, exists2
+    LOGICAL(C_BOOL), TARGET :: exists1, exists2
     LOGICAL :: exists
     TYPE(C_PTR) :: f_ptr
 

--- a/m4/aclocal_fc.f90
+++ b/m4/aclocal_fc.f90
@@ -55,6 +55,31 @@ PROGRAM PROG_FC_HAVE_F2003_REQUIREMENTS
   ptr = C_LOC(ichr(1:1))
 END PROGRAM PROG_FC_HAVE_F2003_REQUIREMENTS
 
+!---- START ----- Check to see C_BOOL is different from LOGICAL
+MODULE l_type_mod
+  USE ISO_C_BINDING
+  INTERFACE h5t
+     MODULE PROCEDURE h5t_c_bool
+     MODULE PROCEDURE h5t_logical
+  END INTERFACE
+CONTAINS
+  SUBROUTINE h5t_c_bool(lcb)
+    LOGICAL(KIND=C_BOOL) :: lcb
+  END SUBROUTINE h5t_c_bool
+  SUBROUTINE h5t_logical(l)
+    LOGICAL :: l
+  END SUBROUTINE h5t_logical
+END MODULE l_type_mod
+PROGRAM PROG_FC_C_BOOL_EQ_LOGICAL
+  USE ISO_C_BINDING
+  USE l_type_mod
+  LOGICAL(KIND=C_BOOL) :: lcb
+  LOGICAL              :: l
+  CALL h5t(lcb)
+  CALL h5t(l)
+END PROGRAM PROG_FC_C_BOOL_EQ_LOGICAL
+!---- END ------- Check to see C_BOOL is different from LOGICAL
+
 !---- START ----- Check to see C_LONG_DOUBLE is different from C_DOUBLE
 MODULE type_mod
   USE ISO_C_BINDING

--- a/m4/aclocal_fc.m4
+++ b/m4/aclocal_fc.m4
@@ -131,6 +131,17 @@ AC_DEFUN([PAC_PROG_FC_C_LONG_DOUBLE_EQ_C_DOUBLE],[
 ])
 fi
 
+dnl Check if C_BOOL is different from default LOGICAL
+
+AC_DEFUN([PAC_PROG_FC_C_BOOL_EQ_LOGICAL],[
+  C_BOOL_IS_UNIQUE_FORTRAN="no"
+  AC_MSG_CHECKING([if Fortran C_BOOL is different from default LOGICAL])
+  TEST_SRC="`sed -n '/MODULE l_type_mod/,/END PROGRAM PROG_FC_C_BOOL_EQ_LOGICAL/p' $srcdir/m4/aclocal_fc.f90`"
+  AC_COMPILE_IFELSE([$TEST_SRC], [AC_MSG_RESULT([yes])
+            C_BOOL_IS_UNIQUE_FORTRAN="yes"],
+         [AC_MSG_RESULT([no])])
+])
+
 dnl Checking if the compiler supports the required Fortran 2003 features and
 dnl disable Fortran 2003 if it does not.
 


### PR DESCRIPTION
Fix the datatype passed to H5*exists_async APIs in tests.
Add a new testing function to verify C_BOOL values.