### PR TITLE
Handle certain empty subfiling environment variables 

### DIFF
--- a/src/H5FDsubfiling/H5FDioc.c
+++ b/src/H5FDsubfiling/H5FDioc.c
@@ -1498,7 +1498,7 @@ H5FD__ioc_del(const char *name, hid_t fapl)
         /* TODO: No support for subfile directory prefix currently */
         /* TODO: Possibly try loading config file prefix from file before deleting */
         snprintf(tmp_filename, PATH_MAX, "%s/" H5FD_SUBFILING_CONFIG_FILENAME_TEMPLATE,
-                 prefix_env ? prefix_env : file_dirname, base_filename, (uint64_t)st.st_ino);
+                 prefix_env && (strlen(prefix_env) > 0) ? prefix_env : file_dirname, base_filename, (uint64_t)st.st_ino);
 
         if (NULL == (config_file = fopen(tmp_filename, "r"))) {
             if (ENOENT == errno) {

--- a/src/H5FDsubfiling/H5FDioc.c
+++ b/src/H5FDsubfiling/H5FDioc.c
@@ -224,7 +224,7 @@ H5FD_ioc_init(void)
 
         /* Check if IOC VFD has been loaded dynamically */
         env_var = getenv(HDF5_DRIVER);
-        if (env_var && !strcmp(env_var, H5FD_IOC_NAME)) {
+        if ((env_var && !strcmp(env_var, H5FD_IOC_NAME) && (strlen(env_value) > 0))) {
             int mpi_initialized = 0;
             int provided        = 0;
 
@@ -1497,8 +1497,10 @@ H5FD__ioc_del(const char *name, hid_t fapl)
 
         /* TODO: No support for subfile directory prefix currently */
         /* TODO: Possibly try loading config file prefix from file before deleting */
-        snprintf(tmp_filename, PATH_MAX, "%s/" H5FD_SUBFILING_CONFIG_FILENAME_TEMPLATE,
+        if (prefix_env && (strlen(prefix_env) > 0)) {
+            snprintf(tmp_filename, PATH_MAX, "%s/" H5FD_SUBFILING_CONFIG_FILENAME_TEMPLATE,
                  prefix_env ? prefix_env : file_dirname, base_filename, (uint64_t)st.st_ino);
+        }
 
         if (NULL == (config_file = fopen(tmp_filename, "r"))) {
             if (ENOENT == errno) {

--- a/src/H5FDsubfiling/H5FDioc.c
+++ b/src/H5FDsubfiling/H5FDioc.c
@@ -1499,7 +1499,7 @@ H5FD__ioc_del(const char *name, hid_t fapl)
         /* TODO: Possibly try loading config file prefix from file before deleting */
         if (prefix_env && (strlen(prefix_env) > 0)) {
             snprintf(tmp_filename, PATH_MAX, "%s/" H5FD_SUBFILING_CONFIG_FILENAME_TEMPLATE,
-                 prefix_env ? prefix_env : file_dirname, base_filename, (uint64_t)st.st_ino);
+                     prefix_env ? prefix_env : file_dirname, base_filename, (uint64_t)st.st_ino);
         }
 
         if (NULL == (config_file = fopen(tmp_filename, "r"))) {

--- a/src/H5FDsubfiling/H5FDioc.c
+++ b/src/H5FDsubfiling/H5FDioc.c
@@ -1498,7 +1498,8 @@ H5FD__ioc_del(const char *name, hid_t fapl)
         /* TODO: No support for subfile directory prefix currently */
         /* TODO: Possibly try loading config file prefix from file before deleting */
         snprintf(tmp_filename, PATH_MAX, "%s/" H5FD_SUBFILING_CONFIG_FILENAME_TEMPLATE,
-                 prefix_env && (strlen(prefix_env) > 0) ? prefix_env : file_dirname, base_filename, (uint64_t)st.st_ino);
+                 prefix_env && (strlen(prefix_env) > 0) ? prefix_env : file_dirname, base_filename,
+                 (uint64_t)st.st_ino);
 
         if (NULL == (config_file = fopen(tmp_filename, "r"))) {
             if (ENOENT == errno) {

--- a/src/H5FDsubfiling/H5FDioc.c
+++ b/src/H5FDsubfiling/H5FDioc.c
@@ -1499,7 +1499,7 @@ H5FD__ioc_del(const char *name, hid_t fapl)
         /* TODO: Possibly try loading config file prefix from file before deleting */
         snprintf(tmp_filename, PATH_MAX, "%s/" H5FD_SUBFILING_CONFIG_FILENAME_TEMPLATE,
                  prefix_env ? prefix_env : file_dirname, base_filename, (uint64_t)st.st_ino);
-        
+
         if (NULL == (config_file = fopen(tmp_filename, "r"))) {
             if (ENOENT == errno) {
 #ifdef H5FD_IOC_DEBUG

--- a/src/H5FDsubfiling/H5FDioc.c
+++ b/src/H5FDsubfiling/H5FDioc.c
@@ -224,7 +224,7 @@ H5FD_ioc_init(void)
 
         /* Check if IOC VFD has been loaded dynamically */
         env_var = getenv(HDF5_DRIVER);
-        if ((env_var && !strcmp(env_var, H5FD_IOC_NAME) && (strlen(env_value) > 0))) {
+        if (env_var && strlen(env_var) > 0 && !strcmp(env_var, H5FD_IOC_NAME)) {
             int mpi_initialized = 0;
             int provided        = 0;
 
@@ -1497,11 +1497,9 @@ H5FD__ioc_del(const char *name, hid_t fapl)
 
         /* TODO: No support for subfile directory prefix currently */
         /* TODO: Possibly try loading config file prefix from file before deleting */
-        if (prefix_env && (strlen(prefix_env) > 0)) {
-            snprintf(tmp_filename, PATH_MAX, "%s/" H5FD_SUBFILING_CONFIG_FILENAME_TEMPLATE,
+        snprintf(tmp_filename, PATH_MAX, "%s/" H5FD_SUBFILING_CONFIG_FILENAME_TEMPLATE,
                  prefix_env ? prefix_env : file_dirname, base_filename, (uint64_t)st.st_ino);
-        }
-
+        
         if (NULL == (config_file = fopen(tmp_filename, "r"))) {
             if (ENOENT == errno) {
 #ifdef H5FD_IOC_DEBUG

--- a/src/H5FDsubfiling/H5subfiling_common.c
+++ b/src/H5FDsubfiling/H5subfiling_common.c
@@ -777,7 +777,7 @@ init_subfiling(const char *base_filename, uint64_t file_id, H5FD_subfiling_param
 
     /* Check if a prefix has been set for the configuration file name */
     prefix_env = getenv(H5FD_SUBFILING_CONFIG_FILE_PREFIX);
-    if (prefix_env && (strlen(prefix_env > 0)) {
+    if (prefix_env && (strlen(prefix_env) > 0)) {
         if (NULL == (new_context->config_file_prefix = strdup(prefix_env)))
             H5_SUBFILING_GOTO_ERROR(H5E_VFL, H5E_CANTCOPY, FAIL, "couldn't copy config file prefix string");
     }

--- a/src/H5FDsubfiling/H5subfiling_common.c
+++ b/src/H5FDsubfiling/H5subfiling_common.c
@@ -777,7 +777,7 @@ init_subfiling(const char *base_filename, uint64_t file_id, H5FD_subfiling_param
 
     /* Check if a prefix has been set for the configuration file name */
     prefix_env = getenv(H5FD_SUBFILING_CONFIG_FILE_PREFIX);
-    if (prefix_env) {
+    if (prefix_env && (strlen(prefix_env > 0)) {
         if (NULL == (new_context->config_file_prefix = strdup(prefix_env)))
             H5_SUBFILING_GOTO_ERROR(H5E_VFL, H5E_CANTCOPY, FAIL, "couldn't copy config file prefix string");
     }
@@ -851,7 +851,8 @@ init_subfiling(const char *base_filename, uint64_t file_id, H5FD_subfiling_param
         char *env_value = NULL;
 
         /* Check for a subfiling stripe size setting from the environment */
-        if ((env_value = getenv(H5FD_SUBFILING_STRIPE_SIZE))) {
+        env_value = getenv(H5FD_SUBFILING_STRIPE_SIZE);
+        if (env_value && (strlen(env_value) > 0)) {
             long long stripe_size = -1;
 
             errno = 0;
@@ -981,7 +982,8 @@ init_app_topology(int64_t sf_context_id, H5FD_subfiling_params_t *subfiling_conf
         case SELECT_IOC_ONE_PER_NODE: {
             if (comm_size > 1) {
                 /* Check for an IOC-per-node value set in the environment */
-                if ((env_value = getenv(H5FD_SUBFILING_IOC_PER_NODE))) {
+                env_value = getenv(H5FD_SUBFILING_IOC_PER_NODE);
+                if (env_value && (strlen(env_value) > 0)) {
                     errno          = 0;
                     ioc_select_val = strtol(env_value, NULL, 0);
                     if ((ERANGE == errno)) {

--- a/src/H5FDsubfiling/H5subfiling_common.c
+++ b/src/H5FDsubfiling/H5subfiling_common.c
@@ -1186,7 +1186,7 @@ get_ioc_selection_criteria_from_env(H5FD_subfiling_ioc_select_t *ioc_selection_t
 
     *ioc_sel_info_str = NULL;
 
-    if (env_value) {
+    if (env_value && (strlen(env_value) > 0)) {
         /*
          * Parse I/O Concentrator selection strategy criteria as
          * either a single value or two colon-separated values of
@@ -1821,7 +1821,8 @@ init_subfiling_context(subfiling_context_t *sf_context, const char *base_filenam
                                 "couldn't allocate space for subfiling filename");
 
     /* Check for a subfile name prefix setting in the environment */
-    if ((env_value = getenv(H5FD_SUBFILING_SUBFILE_PREFIX))) {
+    env_value = getenv(H5FD_SUBFILING_SUBFILE_PREFIX);
+    if (env_value && (strlen(env_value) > 0)) {
         if (NULL == (sf_context->subfile_prefix = strdup(env_value)))
             H5_SUBFILING_GOTO_ERROR(H5E_RESOURCE, H5E_CANTALLOC, FAIL, "couldn't copy subfile prefix value");
     }

--- a/testpar/t_subfiling_vfd.c
+++ b/testpar/t_subfiling_vfd.c
@@ -3237,6 +3237,7 @@ main(int argc, char **argv)
         SKIPPED();
 #endif
 
+#if H5_HAVE_SUBFILING_VFD
     if (MAINPROCESS)
         printf("\nRe-running tests with environment variables set to the empty string\n");
 
@@ -3268,11 +3269,27 @@ main(int argc, char **argv)
     HDunsetenv("H5FD_SUBFILING_IOC_PER_NODE");
     HDunsetenv("H5FD_SUBFILING_STRIPE_SIZE");
     HDunsetenv("H5FD_SUBFILING_CONFIG_FILE_PREFIX");
-    HDsetenv("H5FD_SUBFILING_SUBFILE_PREFIX", subfiling_subfile_prefix_saved, 1);
-    HDsetenv("H5FD_SUBFILING_IOC_SELECTION_CRITERIA", subfiling_ioc_selection_criteria_saved, 1);
-    HDsetenv("H5FD_SUBFILING_IOC_PER_NODE", subfiling_ioc_per_node_saved, 1);
-    HDsetenv("H5FD_SUBFILING_STRIPE_SIZE", subfiling_stripe_size_saved, 1);
-    HDsetenv("H5FD_SUBFILING_CONFIG_FILE_PREFIX", subfiling_config_file_prefix_saved, 1);
+
+    if (subfiling_subfile_prefix_saved) {
+        HDsetenv("H5FD_SUBFILING_SUBFILE_PREFIX", subfiling_subfile_prefix_saved, 1);
+    }
+    if (subfiling_ioc_selection_criteria_saved) {
+        HDsetenv("H5FD_SUBFILING_IOC_SELECTION_CRITERIA", subfiling_ioc_selection_criteria_saved, 1);
+    }
+    if (subfiling_ioc_per_node_saved) {
+        HDsetenv("H5FD_SUBFILING_IOC_PER_NODE", subfiling_ioc_per_node_saved, 1);
+    }
+    if (subfiling_stripe_size_saved) {
+        HDsetenv("H5FD_SUBFILING_STRIPE_SIZE", subfiling_stripe_size_saved, 1);
+    }
+    if(subfiling_config_file_prefix_saved) {
+        HDsetenv("H5FD_SUBFILING_CONFIG_FILE_PREFIX", subfiling_config_file_prefix_saved, 1);
+    }
+
+#else
+    if (MAINPROCESS)
+        SKIPPED();
+#endif
 
     if (nerrors)
         goto exit;

--- a/testpar/t_subfiling_vfd.c
+++ b/testpar/t_subfiling_vfd.c
@@ -3237,6 +3237,43 @@ main(int argc, char **argv)
         SKIPPED();
 #endif
 
+    if (MAINPROCESS)
+        printf("\nRe-running tests with environment variables set to the empty string\n");
+
+    char* subfiling_subfile_prefix_saved = getenv("H5FD_SUBFILING_SUBFILE_PREFIX");
+    char* subfiling_ioc_selection_criteria_saved = getenv("H5FD_SUBFILING_IOC_SELECTION_CRITERIA");
+    char* subfiling_ioc_per_node_saved = getenv("H5FD_SUBFILING_IOC_PER_NODE");
+    char* subfiling_stripe_size_saved = getenv("H5FD_SUBFILING_STRIPE_SIZE");
+    char* subfiling_config_file_prefix_saved = getenv("H5FD_SUBFILING_CONFIG_FILE_PREFIX");
+
+    HDsetenv("H5FD_SUBFILING_SUBFILE_PREFIX", "", 1);
+    HDsetenv("H5FD_SUBFILING_IOC_SELECTION_CRITERIA", "", 1);
+    HDsetenv("H5FD_SUBFILING_IOC_PER_NODE", "", 1);
+    HDsetenv("H5FD_SUBFILING_STRIPE_SIZE", "", 1);
+    HDsetenv("H5FD_SUBFILING_CONFIG_FILE_PREFIX", "", 1);
+
+    for (size_t i = 0; i < ARRAY_SIZE(tests); i++) {
+        if (MPI_SUCCESS == (mpi_code_g = MPI_Barrier(comm_g))) {
+            (*tests[i])();
+        }
+        else {
+            if (MAINPROCESS)
+                MESG("MPI_Barrier failed");
+            nerrors++;
+        }
+    }
+
+    HDunsetenv("H5FD_SUBFILING_SUBFILE_PREFIX");
+    HDunsetenv("H5FD_SUBFILING_IOC_SELECTION_CRITERIA");
+    HDunsetenv("H5FD_SUBFILING_IOC_PER_NODE");
+    HDunsetenv("H5FD_SUBFILING_STRIPE_SIZE");
+    HDunsetenv("H5FD_SUBFILING_CONFIG_FILE_PREFIX");
+    HDsetenv("H5FD_SUBFILING_SUBFILE_PREFIX", subfiling_subfile_prefix_saved, 1);
+    HDsetenv("H5FD_SUBFILING_IOC_SELECTION_CRITERIA", subfiling_ioc_selection_criteria_saved, 1);
+    HDsetenv("H5FD_SUBFILING_IOC_PER_NODE", subfiling_ioc_per_node_saved, 1);
+    HDsetenv("H5FD_SUBFILING_STRIPE_SIZE", subfiling_stripe_size_saved, 1);
+    HDsetenv("H5FD_SUBFILING_CONFIG_FILE_PREFIX", subfiling_config_file_prefix_saved, 1);
+
     if (nerrors)
         goto exit;
 

--- a/testpar/t_subfiling_vfd.c
+++ b/testpar/t_subfiling_vfd.c
@@ -3282,7 +3282,7 @@ main(int argc, char **argv)
     if (subfiling_stripe_size_saved) {
         HDsetenv("H5FD_SUBFILING_STRIPE_SIZE", subfiling_stripe_size_saved, 1);
     }
-    if(subfiling_config_file_prefix_saved) {
+    if (subfiling_config_file_prefix_saved) {
         HDsetenv("H5FD_SUBFILING_CONFIG_FILE_PREFIX", subfiling_config_file_prefix_saved, 1);
     }
 

--- a/testpar/t_subfiling_vfd.c
+++ b/testpar/t_subfiling_vfd.c
@@ -2892,12 +2892,7 @@ main(int argc, char **argv)
     bool     must_unset_config_dir_env       = false;
     int      required                        = MPI_THREAD_MULTIPLE;
     int      provided                        = 0;
-    char    *subfiling_subfile_prefix_saved;
-    char    *subfiling_ioc_selection_criteria_saved;
-    char    *subfiling_ioc_per_node_saved;
-    char    *subfiling_stripe_size_saved;
-    char    *subfiling_config_file_prefix_saved;
-
+    
     HDcompile_assert(SUBFILING_MIN_STRIPE_SIZE <= H5FD_SUBFILING_DEFAULT_STRIPE_SIZE);
 
     /* Initialize MPI */
@@ -3245,12 +3240,6 @@ main(int argc, char **argv)
     if (MAINPROCESS)
         printf("\nRe-running tests with environment variables set to the empty string\n");
 
-    subfiling_subfile_prefix_saved         = getenv("H5FD_SUBFILING_SUBFILE_PREFIX");
-    subfiling_ioc_selection_criteria_saved = getenv("H5FD_SUBFILING_IOC_SELECTION_CRITERIA");
-    subfiling_ioc_per_node_saved           = getenv("H5FD_SUBFILING_IOC_PER_NODE");
-    subfiling_stripe_size_saved            = getenv("H5FD_SUBFILING_STRIPE_SIZE");
-    subfiling_config_file_prefix_saved     = getenv("H5FD_SUBFILING_CONFIG_FILE_PREFIX");
-
     HDsetenv("H5FD_SUBFILING_SUBFILE_PREFIX", "", 1);
     HDsetenv("H5FD_SUBFILING_IOC_SELECTION_CRITERIA", "", 1);
     HDsetenv("H5FD_SUBFILING_IOC_PER_NODE", "", 1);
@@ -3285,22 +3274,6 @@ main(int argc, char **argv)
     HDunsetenv("H5FD_SUBFILING_IOC_PER_NODE");
     HDunsetenv("H5FD_SUBFILING_STRIPE_SIZE");
     HDunsetenv("H5FD_SUBFILING_CONFIG_FILE_PREFIX");
-
-    if (subfiling_subfile_prefix_saved) {
-        HDsetenv("H5FD_SUBFILING_SUBFILE_PREFIX", subfiling_subfile_prefix_saved, 1);
-    }
-    if (subfiling_ioc_selection_criteria_saved) {
-        HDsetenv("H5FD_SUBFILING_IOC_SELECTION_CRITERIA", subfiling_ioc_selection_criteria_saved, 1);
-    }
-    if (subfiling_ioc_per_node_saved) {
-        HDsetenv("H5FD_SUBFILING_IOC_PER_NODE", subfiling_ioc_per_node_saved, 1);
-    }
-    if (subfiling_stripe_size_saved) {
-        HDsetenv("H5FD_SUBFILING_STRIPE_SIZE", subfiling_stripe_size_saved, 1);
-    }
-    if (subfiling_config_file_prefix_saved) {
-        HDsetenv("H5FD_SUBFILING_CONFIG_FILE_PREFIX", subfiling_config_file_prefix_saved, 1);
-    }
 
     if (nerrors)
         goto exit;

--- a/testpar/t_subfiling_vfd.c
+++ b/testpar/t_subfiling_vfd.c
@@ -2892,7 +2892,7 @@ main(int argc, char **argv)
     bool     must_unset_config_dir_env       = false;
     int      required                        = MPI_THREAD_MULTIPLE;
     int      provided                        = 0;
-    
+
     HDcompile_assert(SUBFILING_MIN_STRIPE_SIZE <= H5FD_SUBFILING_DEFAULT_STRIPE_SIZE);
 
     /* Initialize MPI */

--- a/testpar/t_subfiling_vfd.c
+++ b/testpar/t_subfiling_vfd.c
@@ -2892,11 +2892,11 @@ main(int argc, char **argv)
     bool     must_unset_config_dir_env       = false;
     int      required                        = MPI_THREAD_MULTIPLE;
     int      provided                        = 0;
-    char     *subfiling_subfile_prefix_saved;
-    char     *subfiling_ioc_selection_criteria_saved;
-    char     *subfiling_ioc_per_node_saved;
-    char     *subfiling_stripe_size_saved;
-    char     *subfiling_config_file_prefix_saved;
+    char    *subfiling_subfile_prefix_saved;
+    char    *subfiling_ioc_selection_criteria_saved;
+    char    *subfiling_ioc_per_node_saved;
+    char    *subfiling_stripe_size_saved;
+    char    *subfiling_config_file_prefix_saved;
 
     HDcompile_assert(SUBFILING_MIN_STRIPE_SIZE <= H5FD_SUBFILING_DEFAULT_STRIPE_SIZE);
 
@@ -3250,7 +3250,7 @@ main(int argc, char **argv)
     subfiling_ioc_per_node_saved           = getenv("H5FD_SUBFILING_IOC_PER_NODE");
     subfiling_stripe_size_saved            = getenv("H5FD_SUBFILING_STRIPE_SIZE");
     subfiling_config_file_prefix_saved     = getenv("H5FD_SUBFILING_CONFIG_FILE_PREFIX");
-    
+
     HDsetenv("H5FD_SUBFILING_SUBFILE_PREFIX", "", 1);
     HDsetenv("H5FD_SUBFILING_IOC_SELECTION_CRITERIA", "", 1);
     HDsetenv("H5FD_SUBFILING_IOC_PER_NODE", "", 1);

--- a/testpar/t_subfiling_vfd.c
+++ b/testpar/t_subfiling_vfd.c
@@ -3240,11 +3240,11 @@ main(int argc, char **argv)
     if (MAINPROCESS)
         printf("\nRe-running tests with environment variables set to the empty string\n");
 
-    char* subfiling_subfile_prefix_saved = getenv("H5FD_SUBFILING_SUBFILE_PREFIX");
-    char* subfiling_ioc_selection_criteria_saved = getenv("H5FD_SUBFILING_IOC_SELECTION_CRITERIA");
-    char* subfiling_ioc_per_node_saved = getenv("H5FD_SUBFILING_IOC_PER_NODE");
-    char* subfiling_stripe_size_saved = getenv("H5FD_SUBFILING_STRIPE_SIZE");
-    char* subfiling_config_file_prefix_saved = getenv("H5FD_SUBFILING_CONFIG_FILE_PREFIX");
+    char *subfiling_subfile_prefix_saved         = getenv("H5FD_SUBFILING_SUBFILE_PREFIX");
+    char *subfiling_ioc_selection_criteria_saved = getenv("H5FD_SUBFILING_IOC_SELECTION_CRITERIA");
+    char *subfiling_ioc_per_node_saved           = getenv("H5FD_SUBFILING_IOC_PER_NODE");
+    char *subfiling_stripe_size_saved            = getenv("H5FD_SUBFILING_STRIPE_SIZE");
+    char *subfiling_config_file_prefix_saved     = getenv("H5FD_SUBFILING_CONFIG_FILE_PREFIX");
 
     HDsetenv("H5FD_SUBFILING_SUBFILE_PREFIX", "", 1);
     HDsetenv("H5FD_SUBFILING_IOC_SELECTION_CRITERIA", "", 1);

--- a/testpar/t_vfd.c
+++ b/testpar/t_vfd.c
@@ -6185,8 +6185,8 @@ main(int argc, char **argv)
 {
 
 #ifdef H5_HAVE_SUBFILING_VFD
-    int   required                               = MPI_THREAD_MULTIPLE;
-    int   provided                               = 0;
+    int   required = MPI_THREAD_MULTIPLE;
+    int   provided = 0;
     char *subfiling_subfile_prefix_saved;
     char *subfiling_ioc_selection_criteria_saved;
     char *subfiling_ioc_per_node_saved;

--- a/testpar/t_vfd.c
+++ b/testpar/t_vfd.c
@@ -6185,8 +6185,8 @@ main(int argc, char **argv)
 {
 
 #ifdef H5_HAVE_SUBFILING_VFD
-    int required = MPI_THREAD_MULTIPLE;
-    int provided = 0;
+    int   required                               = MPI_THREAD_MULTIPLE;
+    int   provided                               = 0;
     char *subfiling_subfile_prefix_saved         = getenv("H5FD_SUBFILING_SUBFILE_PREFIX");
     char *subfiling_ioc_selection_criteria_saved = getenv("H5FD_SUBFILING_IOC_SELECTION_CRITERIA");
     char *subfiling_ioc_per_node_saved           = getenv("H5FD_SUBFILING_IOC_PER_NODE");
@@ -6196,7 +6196,7 @@ main(int argc, char **argv)
     int mpi_size;
     int mpi_rank = 0;
     int ret;
-    
+
 #ifdef H5_HAVE_SUBFILING_VFD
     if (MPI_SUCCESS != MPI_Init_thread(&argc, &argv, required, &provided)) {
         printf("    MPI doesn't support MPI_Init_thread with MPI_THREAD_MULTIPLE. Exiting\n");
@@ -6257,7 +6257,7 @@ main(int argc, char **argv)
 
     if (mpi_rank == 0)
         printf("\n --- TESTING SUBFILING VFD: environment variables set to empty --- \n");
-    
+
     HDsetenv("H5FD_SUBFILING_SUBFILE_PREFIX", "", 1);
     HDsetenv("H5FD_SUBFILING_IOC_SELECTION_CRITERIA", "", 1);
     HDsetenv("H5FD_SUBFILING_IOC_PER_NODE", "", 1);
@@ -6303,7 +6303,7 @@ main(int argc, char **argv)
     if (subfiling_stripe_size_saved) {
         HDsetenv("H5FD_SUBFILING_STRIPE_SIZE", subfiling_stripe_size_saved, 1);
     }
-    if(subfiling_config_file_prefix_saved) {
+    if (subfiling_config_file_prefix_saved) {
         HDsetenv("H5FD_SUBFILING_CONFIG_FILE_PREFIX", subfiling_config_file_prefix_saved, 1);
     }
 

--- a/testpar/t_vfd.c
+++ b/testpar/t_vfd.c
@@ -6185,8 +6185,8 @@ main(int argc, char **argv)
 {
 
 #ifdef H5_HAVE_SUBFILING_VFD
-    int   required = MPI_THREAD_MULTIPLE;
-    int   provided = 0;
+    int required = MPI_THREAD_MULTIPLE;
+    int provided = 0;
 #endif
     int mpi_size;
     int mpi_rank = 0;

--- a/testpar/t_vfd.c
+++ b/testpar/t_vfd.c
@@ -6187,11 +6187,11 @@ main(int argc, char **argv)
 #ifdef H5_HAVE_SUBFILING_VFD
     int   required                               = MPI_THREAD_MULTIPLE;
     int   provided                               = 0;
-    char *subfiling_subfile_prefix_saved         = getenv("H5FD_SUBFILING_SUBFILE_PREFIX");
-    char *subfiling_ioc_selection_criteria_saved = getenv("H5FD_SUBFILING_IOC_SELECTION_CRITERIA");
-    char *subfiling_ioc_per_node_saved           = getenv("H5FD_SUBFILING_IOC_PER_NODE");
-    char *subfiling_stripe_size_saved            = getenv("H5FD_SUBFILING_STRIPE_SIZE");
-    char *subfiling_config_file_prefix_saved     = getenv("H5FD_SUBFILING_CONFIG_FILE_PREFIX");
+    char *subfiling_subfile_prefix_saved;
+    char *subfiling_ioc_selection_criteria_saved;
+    char *subfiling_ioc_per_node_saved;
+    char *subfiling_stripe_size_saved;
+    char *subfiling_config_file_prefix_saved;
 #endif
     int mpi_size;
     int mpi_rank = 0;
@@ -6255,8 +6255,16 @@ main(int argc, char **argv)
 
     test_vector_io(mpi_rank, mpi_size);
 
+#ifdef H5_HAVE_SUBFILING_VFD
+
     if (mpi_rank == 0)
         printf("\n --- TESTING SUBFILING VFD: environment variables set to empty --- \n");
+
+    subfiling_subfile_prefix_saved         = getenv("H5FD_SUBFILING_SUBFILE_PREFIX");
+    subfiling_ioc_selection_criteria_saved = getenv("H5FD_SUBFILING_IOC_SELECTION_CRITERIA");
+    subfiling_ioc_per_node_saved           = getenv("H5FD_SUBFILING_IOC_PER_NODE");
+    subfiling_stripe_size_saved            = getenv("H5FD_SUBFILING_STRIPE_SIZE");
+    subfiling_config_file_prefix_saved     = getenv("H5FD_SUBFILING_CONFIG_FILE_PREFIX");
 
     HDsetenv("H5FD_SUBFILING_SUBFILE_PREFIX", "", 1);
     HDsetenv("H5FD_SUBFILING_IOC_SELECTION_CRITERIA", "", 1);
@@ -6306,6 +6314,8 @@ main(int argc, char **argv)
     if (subfiling_config_file_prefix_saved) {
         HDsetenv("H5FD_SUBFILING_CONFIG_FILE_PREFIX", subfiling_config_file_prefix_saved, 1);
     }
+
+#endif
 
 finish:
     /* make sure all processes are finished before final report, cleanup

--- a/testpar/t_vfd.c
+++ b/testpar/t_vfd.c
@@ -6187,11 +6187,6 @@ main(int argc, char **argv)
 #ifdef H5_HAVE_SUBFILING_VFD
     int   required = MPI_THREAD_MULTIPLE;
     int   provided = 0;
-    char *subfiling_subfile_prefix_saved;
-    char *subfiling_ioc_selection_criteria_saved;
-    char *subfiling_ioc_per_node_saved;
-    char *subfiling_stripe_size_saved;
-    char *subfiling_config_file_prefix_saved;
 #endif
     int mpi_size;
     int mpi_rank = 0;
@@ -6260,12 +6255,6 @@ main(int argc, char **argv)
     if (mpi_rank == 0)
         printf("\n --- TESTING SUBFILING VFD: environment variables set to empty --- \n");
 
-    subfiling_subfile_prefix_saved         = getenv("H5FD_SUBFILING_SUBFILE_PREFIX");
-    subfiling_ioc_selection_criteria_saved = getenv("H5FD_SUBFILING_IOC_SELECTION_CRITERIA");
-    subfiling_ioc_per_node_saved           = getenv("H5FD_SUBFILING_IOC_PER_NODE");
-    subfiling_stripe_size_saved            = getenv("H5FD_SUBFILING_STRIPE_SIZE");
-    subfiling_config_file_prefix_saved     = getenv("H5FD_SUBFILING_CONFIG_FILE_PREFIX");
-
     HDsetenv("H5FD_SUBFILING_SUBFILE_PREFIX", "", 1);
     HDsetenv("H5FD_SUBFILING_IOC_SELECTION_CRITERIA", "", 1);
     HDsetenv("H5FD_SUBFILING_IOC_PER_NODE", "", 1);
@@ -6298,22 +6287,6 @@ main(int argc, char **argv)
     HDunsetenv("H5FD_SUBFILING_IOC_PER_NODE");
     HDunsetenv("H5FD_SUBFILING_STRIPE_SIZE");
     HDunsetenv("H5FD_SUBFILING_CONFIG_FILE_PREFIX");
-
-    if (subfiling_subfile_prefix_saved) {
-        HDsetenv("H5FD_SUBFILING_SUBFILE_PREFIX", subfiling_subfile_prefix_saved, 1);
-    }
-    if (subfiling_ioc_selection_criteria_saved) {
-        HDsetenv("H5FD_SUBFILING_IOC_SELECTION_CRITERIA", subfiling_ioc_selection_criteria_saved, 1);
-    }
-    if (subfiling_ioc_per_node_saved) {
-        HDsetenv("H5FD_SUBFILING_IOC_PER_NODE", subfiling_ioc_per_node_saved, 1);
-    }
-    if (subfiling_stripe_size_saved) {
-        HDsetenv("H5FD_SUBFILING_STRIPE_SIZE", subfiling_stripe_size_saved, 1);
-    }
-    if (subfiling_config_file_prefix_saved) {
-        HDsetenv("H5FD_SUBFILING_CONFIG_FILE_PREFIX", subfiling_config_file_prefix_saved, 1);
-    }
 
 #endif
 


### PR DESCRIPTION
Handles the case of subfiling environment variables such as H5FD_SUBFILING_IOC_SELECTION_CRITERIA and H5FD_SUBFILING_SUBFILE_PREFIX being set to the empty string, which caused MPI_TEST_t_subfiling_vfd and MPI_TEST_t_vfd to fail.

Fixes #3978.