### PR TITLE
Fix VOL-compatibility issues in External Link API test 

### DIFF
--- a/test/API/H5_api_dataset_test.c
+++ b/test/API/H5_api_dataset_test.c
@@ -1275,10 +1275,10 @@ test_create_dataset_predefined_types(void)
     hid_t  fspace_id                    = H5I_INVALID_HID;
     hid_t  dset_id                      = H5I_INVALID_HID;
     hid_t  predefined_type_test_table[] = {H5T_STD_U8LE,   H5T_STD_U8BE,   H5T_STD_I8LE,   H5T_STD_I8BE,
-                                          H5T_STD_U16LE,  H5T_STD_U16BE,  H5T_STD_I16LE,  H5T_STD_I16BE,
-                                          H5T_STD_U32LE,  H5T_STD_U32BE,  H5T_STD_I32LE,  H5T_STD_I32BE,
-                                          H5T_STD_U64LE,  H5T_STD_U64BE,  H5T_STD_I64LE,  H5T_STD_I64BE,
-                                          H5T_IEEE_F32LE, H5T_IEEE_F32BE, H5T_IEEE_F64LE, H5T_IEEE_F64BE};
+                                           H5T_STD_U16LE,  H5T_STD_U16BE,  H5T_STD_I16LE,  H5T_STD_I16BE,
+                                           H5T_STD_U32LE,  H5T_STD_U32BE,  H5T_STD_I32LE,  H5T_STD_I32BE,
+                                           H5T_STD_U64LE,  H5T_STD_U64BE,  H5T_STD_I64LE,  H5T_STD_I64BE,
+                                           H5T_IEEE_F32LE, H5T_IEEE_F32BE, H5T_IEEE_F64LE, H5T_IEEE_F64BE};
 
     TESTING("dataset creation with predefined datatypes");
 

--- a/test/API/H5_api_dataset_test.c
+++ b/test/API/H5_api_dataset_test.c
@@ -1275,10 +1275,10 @@ test_create_dataset_predefined_types(void)
     hid_t  fspace_id                    = H5I_INVALID_HID;
     hid_t  dset_id                      = H5I_INVALID_HID;
     hid_t  predefined_type_test_table[] = {H5T_STD_U8LE,   H5T_STD_U8BE,   H5T_STD_I8LE,   H5T_STD_I8BE,
-                                           H5T_STD_U16LE,  H5T_STD_U16BE,  H5T_STD_I16LE,  H5T_STD_I16BE,
-                                           H5T_STD_U32LE,  H5T_STD_U32BE,  H5T_STD_I32LE,  H5T_STD_I32BE,
-                                           H5T_STD_U64LE,  H5T_STD_U64BE,  H5T_STD_I64LE,  H5T_STD_I64BE,
-                                           H5T_IEEE_F32LE, H5T_IEEE_F32BE, H5T_IEEE_F64LE, H5T_IEEE_F64BE};
+                                          H5T_STD_U16LE,  H5T_STD_U16BE,  H5T_STD_I16LE,  H5T_STD_I16BE,
+                                          H5T_STD_U32LE,  H5T_STD_U32BE,  H5T_STD_I32LE,  H5T_STD_I32BE,
+                                          H5T_STD_U64LE,  H5T_STD_U64BE,  H5T_STD_I64LE,  H5T_STD_I64BE,
+                                          H5T_IEEE_F32LE, H5T_IEEE_F32BE, H5T_IEEE_F64LE, H5T_IEEE_F64BE};
 
     TESTING("dataset creation with predefined datatypes");
 

--- a/test/API/H5_api_link_test.c
+++ b/test/API/H5_api_link_test.c
@@ -900,7 +900,7 @@ test_create_hard_link_invalid_params(void)
         {
             TESTING_2("H5Lcreate_hard across files");
 
-            snprintf(ext_link_filename, H5_API_TEST_FILENAME_MAX_LENGTH, "%s", EXTERNAL_LINK_TEST_FILE_NAME);
+            snprintf(ext_link_filename, H5_API_TEST_FILENAME_MAX_LENGTH, "%s%s", test_path_prefix, EXTERNAL_LINK_TEST_FILE_NAME);
 
             if ((ext_file_id = H5Fcreate(ext_link_filename, H5F_ACC_TRUNC, H5P_DEFAULT, H5P_DEFAULT)) < 0) {
                 H5_FAILED();
@@ -1999,7 +1999,7 @@ test_create_external_link(void)
         return 0;
     }
 
-    snprintf(ext_link_filename, H5_API_TEST_FILENAME_MAX_LENGTH, "%s", EXTERNAL_LINK_TEST_FILE_NAME);
+    snprintf(ext_link_filename, H5_API_TEST_FILENAME_MAX_LENGTH, "%s%s", test_path_prefix, EXTERNAL_LINK_TEST_FILE_NAME);
 
     if ((file_id = H5Fcreate(ext_link_filename, H5F_ACC_TRUNC, H5P_DEFAULT, H5P_DEFAULT)) < 0) {
         H5_FAILED();
@@ -2107,7 +2107,7 @@ test_create_external_link_dangling(void)
         return 0;
     }
 
-    snprintf(ext_link_filename, H5_API_TEST_FILENAME_MAX_LENGTH, "%s", EXTERNAL_LINK_TEST_FILE_NAME);
+    snprintf(ext_link_filename, H5_API_TEST_FILENAME_MAX_LENGTH, "%s%s", test_path_prefix, EXTERNAL_LINK_TEST_FILE_NAME);
 
     if ((ext_file_id = H5Fcreate(ext_link_filename, H5F_ACC_TRUNC, H5P_DEFAULT, H5P_DEFAULT)) < 0) {
         H5_FAILED();
@@ -2248,7 +2248,7 @@ test_create_external_link_multi(void)
         {
             TESTING_2("Create the first external file to be pointed to");
 
-            snprintf(ext_link_filename1, H5_API_TEST_FILENAME_MAX_LENGTH, "%s", EXTERNAL_LINK_TEST_FILE_NAME);
+            snprintf(ext_link_filename1, H5_API_TEST_FILENAME_MAX_LENGTH, "%s%s", test_path_prefix, EXTERNAL_LINK_TEST_FILE_NAME);
 
             if ((file_id = H5Fcreate(ext_link_filename1, H5F_ACC_TRUNC, H5P_DEFAULT, H5P_DEFAULT)) < 0) {
                 H5_FAILED();
@@ -2308,8 +2308,8 @@ test_create_external_link_multi(void)
         {
             TESTING_2("Create the second external file to be pointed to");
 
-            snprintf(ext_link_filename2, H5_API_TEST_FILENAME_MAX_LENGTH, "%s",
-                     EXTERNAL_LINK_TEST_FILE_NAME2);
+            snprintf(ext_link_filename2, H5_API_TEST_FILENAME_MAX_LENGTH, "%s%s",
+                     test_path_prefix, EXTERNAL_LINK_TEST_FILE_NAME2);
 
             if ((file_id = H5Fcreate(ext_link_filename2, H5F_ACC_TRUNC, H5P_DEFAULT, H5P_DEFAULT)) < 0) {
                 H5_FAILED();
@@ -2365,8 +2365,8 @@ test_create_external_link_multi(void)
         {
             TESTING_2("Create the third external file to be pointed to");
 
-            snprintf(ext_link_filename3, H5_API_TEST_FILENAME_MAX_LENGTH, "%s",
-                     EXTERNAL_LINK_TEST_FILE_NAME3);
+            snprintf(ext_link_filename3, H5_API_TEST_FILENAME_MAX_LENGTH, "%s%s",
+                     test_path_prefix, EXTERNAL_LINK_TEST_FILE_NAME3);
 
             if ((file_id = H5Fcreate(ext_link_filename3, H5F_ACC_TRUNC, H5P_DEFAULT, H5P_DEFAULT)) < 0) {
                 H5_FAILED();
@@ -2605,8 +2605,8 @@ test_create_external_link_ping_pong(void)
         return 0;
     }
 
-    snprintf(ext_link_filename1, H5_API_TEST_FILENAME_MAX_LENGTH, "%s", EXTERNAL_LINK_TEST_PING_PONG_NAME1);
-    snprintf(ext_link_filename2, H5_API_TEST_FILENAME_MAX_LENGTH, "%s", EXTERNAL_LINK_TEST_PING_PONG_NAME2);
+    snprintf(ext_link_filename1, H5_API_TEST_FILENAME_MAX_LENGTH, "%s%s", test_path_prefix, EXTERNAL_LINK_TEST_PING_PONG_NAME1);
+    snprintf(ext_link_filename2, H5_API_TEST_FILENAME_MAX_LENGTH, "%s%s", test_path_prefix, EXTERNAL_LINK_TEST_PING_PONG_NAME2);
 
     BEGIN_MULTIPART
     {
@@ -2860,8 +2860,8 @@ test_create_external_link_invalid_params(void)
 
     TESTING_2("test setup");
 
-    snprintf(ext_link_filename, H5_API_TEST_FILENAME_MAX_LENGTH, "%s",
-             EXTERNAL_LINK_INVALID_PARAMS_TEST_FILE_NAME);
+    snprintf(ext_link_filename, H5_API_TEST_FILENAME_MAX_LENGTH, "%s%s",
+             test_path_prefix, EXTERNAL_LINK_INVALID_PARAMS_TEST_FILE_NAME);
 
     if ((file_id = H5Fcreate(ext_link_filename, H5F_ACC_TRUNC, H5P_DEFAULT, H5P_DEFAULT)) < 0) {
         H5_FAILED();
@@ -3751,7 +3751,7 @@ test_delete_link(void)
         {
             TESTING_2("H5Ldelete on external link");
 
-            snprintf(ext_link_filename, H5_API_TEST_FILENAME_MAX_LENGTH, "%s", EXTERNAL_LINK_TEST_FILE_NAME);
+            snprintf(ext_link_filename, H5_API_TEST_FILENAME_MAX_LENGTH, "%s%s", test_path_prefix, EXTERNAL_LINK_TEST_FILE_NAME);
 
             if ((ext_file_id = H5Fcreate(ext_link_filename, H5F_ACC_TRUNC, H5P_DEFAULT, H5P_DEFAULT)) < 0) {
                 H5_FAILED();
@@ -5714,7 +5714,7 @@ test_delete_link(void)
             }
 
             /* Create file for external link to reference */
-            snprintf(ext_link_filename, H5_API_TEST_FILENAME_MAX_LENGTH, "%s", EXTERNAL_LINK_TEST_FILE_NAME);
+            snprintf(ext_link_filename, H5_API_TEST_FILENAME_MAX_LENGTH, "%s%s", test_path_prefix, EXTERNAL_LINK_TEST_FILE_NAME);
 
             if ((ext_file_id = H5Fcreate(ext_link_filename, H5F_ACC_TRUNC, H5P_DEFAULT, H5P_DEFAULT)) < 0) {
                 H5_FAILED();
@@ -5995,7 +5995,7 @@ test_delete_link(void)
             }
 
             /* Create file for external link to reference */
-            snprintf(ext_link_filename, H5_API_TEST_FILENAME_MAX_LENGTH, "%s", EXTERNAL_LINK_TEST_FILE_NAME);
+            snprintf(ext_link_filename, H5_API_TEST_FILENAME_MAX_LENGTH, "%s%s", test_path_prefix, EXTERNAL_LINK_TEST_FILE_NAME);
 
             if ((ext_file_id = H5Fcreate(ext_link_filename, H5F_ACC_TRUNC, H5P_DEFAULT, H5P_DEFAULT)) < 0) {
                 H5_FAILED();
@@ -6270,7 +6270,7 @@ test_delete_link(void)
             TESTING_2("H5Ldelete_by_idx on external link by alphabetical order in increasing order");
 
             /* Create file for external link to reference */
-            snprintf(ext_link_filename, H5_API_TEST_FILENAME_MAX_LENGTH, "%s", EXTERNAL_LINK_TEST_FILE_NAME);
+            snprintf(ext_link_filename, H5_API_TEST_FILENAME_MAX_LENGTH, "%s%s", test_path_prefix, EXTERNAL_LINK_TEST_FILE_NAME);
 
             if ((ext_file_id = H5Fcreate(ext_link_filename, H5F_ACC_TRUNC, H5P_DEFAULT, H5P_DEFAULT)) < 0) {
                 H5_FAILED();
@@ -6545,7 +6545,7 @@ test_delete_link(void)
             TESTING_2("H5Ldelete_by_idx on external link by alphabetical order in decreasing order");
 
             /* Create file for external link to reference */
-            snprintf(ext_link_filename, H5_API_TEST_FILENAME_MAX_LENGTH, "%s", EXTERNAL_LINK_TEST_FILE_NAME);
+            snprintf(ext_link_filename, H5_API_TEST_FILENAME_MAX_LENGTH, "%s%s", test_path_prefix, EXTERNAL_LINK_TEST_FILE_NAME);
 
             if ((ext_file_id = H5Fcreate(ext_link_filename, H5F_ACC_TRUNC, H5P_DEFAULT, H5P_DEFAULT)) < 0) {
                 H5_FAILED();
@@ -8253,7 +8253,7 @@ test_copy_link(void)
         {
             TESTING_2("H5Lcopy on external link (copied link's properties not checked)");
 
-            snprintf(ext_link_filename, H5_API_TEST_FILENAME_MAX_LENGTH, "%s", EXTERNAL_LINK_TEST_FILE_NAME);
+            snprintf(ext_link_filename, H5_API_TEST_FILENAME_MAX_LENGTH, "%s%s", test_path_prefix, EXTERNAL_LINK_TEST_FILE_NAME);
 
             if ((ext_file_id = H5Fcreate(ext_link_filename, H5F_ACC_TRUNC, H5P_DEFAULT, H5P_DEFAULT)) < 0) {
                 H5_FAILED();
@@ -8361,7 +8361,7 @@ test_copy_link(void)
 
             TESTING_2("H5Lcopy on external link (copied link's properties checked)");
 
-            snprintf(ext_link_filename, H5_API_TEST_FILENAME_MAX_LENGTH, "%s", EXTERNAL_LINK_TEST_FILE_NAME);
+            snprintf(ext_link_filename, H5_API_TEST_FILENAME_MAX_LENGTH, "%s%s", test_path_prefix, EXTERNAL_LINK_TEST_FILE_NAME);
 
             if ((ext_file_id = H5Fcreate(ext_link_filename, H5F_ACC_TRUNC, H5P_DEFAULT, H5P_DEFAULT)) < 0) {
                 H5_FAILED();
@@ -8564,7 +8564,7 @@ test_copy_link(void)
         {
             TESTING_2("H5Lcopy on external link using H5L_SAME_LOC");
 
-            snprintf(ext_link_filename, H5_API_TEST_FILENAME_MAX_LENGTH, "%s", EXTERNAL_LINK_TEST_FILE_NAME);
+            snprintf(ext_link_filename, H5_API_TEST_FILENAME_MAX_LENGTH, "%s%s", test_path_prefix, EXTERNAL_LINK_TEST_FILE_NAME);
 
             if ((ext_file_id = H5Fcreate(ext_link_filename, H5F_ACC_TRUNC, H5P_DEFAULT, H5P_DEFAULT)) < 0) {
                 H5_FAILED();
@@ -9081,7 +9081,7 @@ test_copy_link_invalid_params(void)
         {
             TESTING_2("H5Lcopy invalid across files");
 
-            snprintf(ext_link_filename, H5_API_TEST_FILENAME_MAX_LENGTH, "%s", EXTERNAL_LINK_TEST_FILE_NAME);
+            snprintf(ext_link_filename, H5_API_TEST_FILENAME_MAX_LENGTH, "%s%s", test_path_prefix, EXTERNAL_LINK_TEST_FILE_NAME);
 
             if ((ext_file_id = H5Fcreate(ext_link_filename, H5F_ACC_TRUNC, H5P_DEFAULT, H5P_DEFAULT)) < 0) {
                 H5_FAILED();
@@ -9175,7 +9175,7 @@ test_move_link(void)
 
     TESTING_2("test setup");
 
-    snprintf(ext_link_filename, H5_API_TEST_FILENAME_MAX_LENGTH, "%s", EXTERNAL_LINK_TEST_FILE_NAME);
+    snprintf(ext_link_filename, H5_API_TEST_FILENAME_MAX_LENGTH, "%s%s", test_path_prefix, EXTERNAL_LINK_TEST_FILE_NAME);
 
     if ((file_id = H5Fopen(H5_api_test_filename, H5F_ACC_RDWR, H5P_DEFAULT)) < 0) {
         H5_FAILED();
@@ -10056,7 +10056,7 @@ test_move_link(void)
         {
             TESTING_2("H5Lmove on external link (moved link's properties not checked)");
 
-            snprintf(ext_link_filename, H5_API_TEST_FILENAME_MAX_LENGTH, "%s", EXTERNAL_LINK_TEST_FILE_NAME);
+            snprintf(ext_link_filename, H5_API_TEST_FILENAME_MAX_LENGTH, "%s%s", test_path_prefix, EXTERNAL_LINK_TEST_FILE_NAME);
 
             if ((ext_file_id = H5Fcreate(ext_link_filename, H5F_ACC_TRUNC, H5P_DEFAULT, H5P_DEFAULT)) < 0) {
                 H5_FAILED();
@@ -10164,7 +10164,7 @@ test_move_link(void)
 
             TESTING_2("H5Lmove on external link (moved link's properties checked)");
 
-            snprintf(ext_link_filename, H5_API_TEST_FILENAME_MAX_LENGTH, "%s", EXTERNAL_LINK_TEST_FILE_NAME);
+            snprintf(ext_link_filename, H5_API_TEST_FILENAME_MAX_LENGTH, "%s%s", test_path_prefix, EXTERNAL_LINK_TEST_FILE_NAME);
 
             if ((ext_file_id = H5Fcreate(ext_link_filename, H5F_ACC_TRUNC, H5P_DEFAULT, H5P_DEFAULT)) < 0) {
                 H5_FAILED();
@@ -10367,7 +10367,7 @@ test_move_link(void)
         {
             TESTING_2("H5Lmove on external link using H5L_SAME_LOC");
 
-            snprintf(ext_link_filename, H5_API_TEST_FILENAME_MAX_LENGTH, "%s", EXTERNAL_LINK_TEST_FILE_NAME);
+            snprintf(ext_link_filename, H5_API_TEST_FILENAME_MAX_LENGTH, "%s%s", test_path_prefix, EXTERNAL_LINK_TEST_FILE_NAME);
 
             if ((ext_file_id = H5Fcreate(ext_link_filename, H5F_ACC_TRUNC, H5P_DEFAULT, H5P_DEFAULT)) < 0) {
                 H5_FAILED();
@@ -10505,7 +10505,7 @@ test_move_link(void)
         {
             TESTING_2("H5Lmove to rename external link without moving it");
 
-            snprintf(ext_link_filename, H5_API_TEST_FILENAME_MAX_LENGTH, "%s", EXTERNAL_LINK_TEST_FILE_NAME);
+            snprintf(ext_link_filename, H5_API_TEST_FILENAME_MAX_LENGTH, "%s%s", test_path_prefix, EXTERNAL_LINK_TEST_FILE_NAME);
 
             if ((ext_file_id = H5Fcreate(ext_link_filename, H5F_ACC_TRUNC, H5P_DEFAULT, H5P_DEFAULT)) < 0) {
                 H5_FAILED();
@@ -11389,7 +11389,7 @@ test_move_link_invalid_params(void)
         {
             TESTING_2("H5Lmove into another file");
 
-            snprintf(ext_link_filename, H5_API_TEST_FILENAME_MAX_LENGTH, "%s", EXTERNAL_LINK_TEST_FILE_NAME);
+            snprintf(ext_link_filename, H5_API_TEST_FILENAME_MAX_LENGTH, "%s%s", test_path_prefix, EXTERNAL_LINK_TEST_FILE_NAME);
 
             if ((ext_file_id = H5Fcreate(ext_link_filename, H5F_ACC_TRUNC, H5P_DEFAULT, H5P_DEFAULT)) < 0) {
                 H5_FAILED();
@@ -11628,7 +11628,7 @@ test_get_link_val(void)
 
             memset(&link_info, 0, sizeof(link_info));
 
-            snprintf(ext_link_filename, H5_API_TEST_FILENAME_MAX_LENGTH, "%s", EXTERNAL_LINK_TEST_FILE_NAME);
+            snprintf(ext_link_filename, H5_API_TEST_FILENAME_MAX_LENGTH, "%s%s", test_path_prefix, EXTERNAL_LINK_TEST_FILE_NAME);
 
             if ((ext_file_id = H5Fcreate(ext_link_filename, H5F_ACC_TRUNC, H5P_DEFAULT, H5P_DEFAULT)) < 0) {
                 H5_FAILED();
@@ -12526,7 +12526,7 @@ test_get_link_val(void)
                 PART_EMPTY(H5Lget_val_by_idx_external_crt_order_increasing);
             }
 
-            snprintf(ext_link_filename, H5_API_TEST_FILENAME_MAX_LENGTH, "%s", EXTERNAL_LINK_TEST_FILE_NAME);
+            snprintf(ext_link_filename, H5_API_TEST_FILENAME_MAX_LENGTH, "%s%s", test_path_prefix, EXTERNAL_LINK_TEST_FILE_NAME);
 
             if ((ext_file_id = H5Fcreate(ext_link_filename, H5F_ACC_TRUNC, H5P_DEFAULT, H5P_DEFAULT)) < 0) {
                 H5_FAILED();
@@ -12775,7 +12775,7 @@ test_get_link_val(void)
                 PART_EMPTY(H5Lget_val_by_idx_external_crt_order_decreasing);
             }
 
-            snprintf(ext_link_filename, H5_API_TEST_FILENAME_MAX_LENGTH, "%s", EXTERNAL_LINK_TEST_FILE_NAME);
+            snprintf(ext_link_filename, H5_API_TEST_FILENAME_MAX_LENGTH, "%s%s", test_path_prefix, EXTERNAL_LINK_TEST_FILE_NAME);
 
             if ((ext_file_id = H5Fcreate(ext_link_filename, H5F_ACC_TRUNC, H5P_DEFAULT, H5P_DEFAULT)) < 0) {
                 H5_FAILED();
@@ -13018,7 +13018,7 @@ test_get_link_val(void)
 
             TESTING_2("H5Lget_val_by_idx on external link by alphabetical order in increasing order");
 
-            snprintf(ext_link_filename, H5_API_TEST_FILENAME_MAX_LENGTH, "%s", EXTERNAL_LINK_TEST_FILE_NAME);
+            snprintf(ext_link_filename, H5_API_TEST_FILENAME_MAX_LENGTH, "%s%s", test_path_prefix, EXTERNAL_LINK_TEST_FILE_NAME);
 
             if ((ext_file_id = H5Fcreate(ext_link_filename, H5F_ACC_TRUNC, H5P_DEFAULT, H5P_DEFAULT)) < 0) {
                 H5_FAILED();
@@ -13261,7 +13261,7 @@ test_get_link_val(void)
 
             TESTING_2("H5Lget_val_by_idx on external link by alphabetical order in decreasing order");
 
-            snprintf(ext_link_filename, H5_API_TEST_FILENAME_MAX_LENGTH, "%s", EXTERNAL_LINK_TEST_FILE_NAME);
+            snprintf(ext_link_filename, H5_API_TEST_FILENAME_MAX_LENGTH, "%s%s", test_path_prefix, EXTERNAL_LINK_TEST_FILE_NAME);
 
             if ((ext_file_id = H5Fcreate(ext_link_filename, H5F_ACC_TRUNC, H5P_DEFAULT, H5P_DEFAULT)) < 0) {
                 H5_FAILED();
@@ -14168,7 +14168,7 @@ test_get_link_info(void)
 
             memset(&link_info, 0, sizeof(link_info));
 
-            snprintf(ext_link_filename, H5_API_TEST_FILENAME_MAX_LENGTH, "%s", EXTERNAL_LINK_TEST_FILE_NAME);
+            snprintf(ext_link_filename, H5_API_TEST_FILENAME_MAX_LENGTH, "%s%s", test_path_prefix, EXTERNAL_LINK_TEST_FILE_NAME);
 
             if ((ext_file_id = H5Fcreate(ext_link_filename, H5F_ACC_TRUNC, H5P_DEFAULT, H5P_DEFAULT)) < 0) {
                 H5_FAILED();
@@ -15733,7 +15733,7 @@ test_get_link_info(void)
                 PART_EMPTY(H5Lget_info_by_idx_external_crt_order_increasing);
             }
 
-            snprintf(ext_link_filename, H5_API_TEST_FILENAME_MAX_LENGTH, "%s", EXTERNAL_LINK_TEST_FILE_NAME);
+            snprintf(ext_link_filename, H5_API_TEST_FILENAME_MAX_LENGTH, "%s%s", test_path_prefix, EXTERNAL_LINK_TEST_FILE_NAME);
 
             if ((ext_file_id = H5Fcreate(ext_link_filename, H5F_ACC_TRUNC, H5P_DEFAULT, H5P_DEFAULT)) < 0) {
                 H5_FAILED();
@@ -15936,7 +15936,7 @@ test_get_link_info(void)
                 PART_EMPTY(H5Lget_info_by_idx_external_crt_order_decreasing);
             }
 
-            snprintf(ext_link_filename, H5_API_TEST_FILENAME_MAX_LENGTH, "%s", EXTERNAL_LINK_TEST_FILE_NAME);
+            snprintf(ext_link_filename, H5_API_TEST_FILENAME_MAX_LENGTH, "%s%s", test_path_prefix, EXTERNAL_LINK_TEST_FILE_NAME);
 
             if ((ext_file_id = H5Fcreate(ext_link_filename, H5F_ACC_TRUNC, H5P_DEFAULT, H5P_DEFAULT)) < 0) {
                 H5_FAILED();
@@ -16133,7 +16133,7 @@ test_get_link_info(void)
         {
             TESTING_2("H5Lget_info_by_idx2 on external link by alphabetical order in increasing order");
 
-            snprintf(ext_link_filename, H5_API_TEST_FILENAME_MAX_LENGTH, "%s", EXTERNAL_LINK_TEST_FILE_NAME);
+            snprintf(ext_link_filename, H5_API_TEST_FILENAME_MAX_LENGTH, "%s%s", test_path_prefix, EXTERNAL_LINK_TEST_FILE_NAME);
 
             if ((ext_file_id = H5Fcreate(ext_link_filename, H5F_ACC_TRUNC, H5P_DEFAULT, H5P_DEFAULT)) < 0) {
                 H5_FAILED();
@@ -16336,7 +16336,7 @@ test_get_link_info(void)
         {
             TESTING_2("H5Lget_info_by_idx2 on external link by alphabetical order in decreasing order");
 
-            snprintf(ext_link_filename, H5_API_TEST_FILENAME_MAX_LENGTH, "%s", EXTERNAL_LINK_TEST_FILE_NAME);
+            snprintf(ext_link_filename, H5_API_TEST_FILENAME_MAX_LENGTH, "%s%s", test_path_prefix, EXTERNAL_LINK_TEST_FILE_NAME);
 
             if ((ext_file_id = H5Fcreate(ext_link_filename, H5F_ACC_TRUNC, H5P_DEFAULT, H5P_DEFAULT)) < 0) {
                 H5_FAILED();
@@ -18362,7 +18362,7 @@ test_get_link_name(void)
             }
 
             /* Create file for external link to reference */
-            snprintf(ext_link_filename, H5_API_TEST_FILENAME_MAX_LENGTH, "%s", EXTERNAL_LINK_TEST_FILE_NAME);
+            snprintf(ext_link_filename, H5_API_TEST_FILENAME_MAX_LENGTH, "%s%s", test_path_prefix, EXTERNAL_LINK_TEST_FILE_NAME);
 
             if ((ext_file_id = H5Fcreate(ext_link_filename, H5F_ACC_TRUNC, H5P_DEFAULT, H5P_DEFAULT)) < 0) {
                 H5_FAILED();
@@ -18550,7 +18550,7 @@ test_get_link_name(void)
             }
 
             /* Create file for external link to reference */
-            snprintf(ext_link_filename, H5_API_TEST_FILENAME_MAX_LENGTH, "%s", EXTERNAL_LINK_TEST_FILE_NAME);
+            snprintf(ext_link_filename, H5_API_TEST_FILENAME_MAX_LENGTH, "%s%s", test_path_prefix, EXTERNAL_LINK_TEST_FILE_NAME);
 
             if ((ext_file_id = H5Fcreate(ext_link_filename, H5F_ACC_TRUNC, H5P_DEFAULT, H5P_DEFAULT)) < 0) {
                 H5_FAILED();
@@ -18732,7 +18732,7 @@ test_get_link_name(void)
             TESTING_2("H5Lget_name_by_idx on external link by alphabetical order in increasing order");
 
             /* Create file for external link to reference */
-            snprintf(ext_link_filename, H5_API_TEST_FILENAME_MAX_LENGTH, "%s", EXTERNAL_LINK_TEST_FILE_NAME);
+            snprintf(ext_link_filename, H5_API_TEST_FILENAME_MAX_LENGTH, "%s%s", test_path_prefix, EXTERNAL_LINK_TEST_FILE_NAME);
 
             if ((ext_file_id = H5Fcreate(ext_link_filename, H5F_ACC_TRUNC, H5P_DEFAULT, H5P_DEFAULT)) < 0) {
                 H5_FAILED();
@@ -18914,7 +18914,7 @@ test_get_link_name(void)
             TESTING_2("H5Lget_name_by_idx on external link by alphabetical order in decreasing order");
 
             /* Create file for external link to reference */
-            snprintf(ext_link_filename, H5_API_TEST_FILENAME_MAX_LENGTH, "%s", EXTERNAL_LINK_TEST_FILE_NAME);
+            snprintf(ext_link_filename, H5_API_TEST_FILENAME_MAX_LENGTH, "%s%s", test_path_prefix, EXTERNAL_LINK_TEST_FILE_NAME);
 
             if ((ext_file_id = H5Fcreate(ext_link_filename, H5F_ACC_TRUNC, H5P_DEFAULT, H5P_DEFAULT)) < 0) {
                 H5_FAILED();
@@ -20215,7 +20215,7 @@ test_link_iterate_external_links(void)
 
     TESTING_2("test setup");
 
-    snprintf(ext_link_filename, H5_API_TEST_FILENAME_MAX_LENGTH, "%s", EXTERNAL_LINK_TEST_FILE_NAME);
+    snprintf(ext_link_filename, H5_API_TEST_FILENAME_MAX_LENGTH, "%s%s", test_path_prefix, EXTERNAL_LINK_TEST_FILE_NAME);
 
     if ((file_id = H5Fcreate(ext_link_filename, H5F_ACC_TRUNC, H5P_DEFAULT, H5P_DEFAULT)) < 0) {
         H5_FAILED();
@@ -20612,7 +20612,7 @@ test_link_iterate_mixed_links(void)
 
     TESTING_2("test setup");
 
-    snprintf(ext_link_filename, H5_API_TEST_FILENAME_MAX_LENGTH, "%s", EXTERNAL_LINK_TEST_FILE_NAME);
+    snprintf(ext_link_filename, H5_API_TEST_FILENAME_MAX_LENGTH, "%s%s", test_path_prefix, EXTERNAL_LINK_TEST_FILE_NAME);
 
     if ((file_id = H5Fcreate(ext_link_filename, H5F_ACC_TRUNC, H5P_DEFAULT, H5P_DEFAULT)) < 0) {
         H5_FAILED();
@@ -21098,7 +21098,7 @@ test_link_iterate_invalid_params(void)
 
     TESTING_2("test setup");
 
-    snprintf(ext_link_filename, H5_API_TEST_FILENAME_MAX_LENGTH, "%s", EXTERNAL_LINK_TEST_FILE_NAME);
+    snprintf(ext_link_filename, H5_API_TEST_FILENAME_MAX_LENGTH, "%s%s", test_path_prefix, EXTERNAL_LINK_TEST_FILE_NAME);
 
     if ((file_id = H5Fcreate(ext_link_filename, H5F_ACC_TRUNC, H5P_DEFAULT, H5P_DEFAULT)) < 0) {
         H5_FAILED();
@@ -22525,7 +22525,7 @@ test_link_visit_external_links_no_cycles(void)
 
     TESTING_2("test setup");
 
-    snprintf(ext_link_filename, H5_API_TEST_FILENAME_MAX_LENGTH, "%s", EXTERNAL_LINK_TEST_FILE_NAME);
+    snprintf(ext_link_filename, H5_API_TEST_FILENAME_MAX_LENGTH, "%s%s", test_path_prefix, EXTERNAL_LINK_TEST_FILE_NAME);
 
     if ((file_id = H5Fcreate(ext_link_filename, H5F_ACC_TRUNC, H5P_DEFAULT, H5P_DEFAULT)) < 0) {
         H5_FAILED();
@@ -22953,7 +22953,7 @@ test_link_visit_mixed_links_no_cycles(void)
 
     TESTING_2("test setup");
 
-    snprintf(ext_link_filename, H5_API_TEST_FILENAME_MAX_LENGTH, "%s", EXTERNAL_LINK_TEST_FILE_NAME);
+    snprintf(ext_link_filename, H5_API_TEST_FILENAME_MAX_LENGTH, "%s%s", test_path_prefix, EXTERNAL_LINK_TEST_FILE_NAME);
 
     if ((file_id = H5Fcreate(ext_link_filename, H5F_ACC_TRUNC, H5P_DEFAULT, H5P_DEFAULT)) < 0) {
         H5_FAILED();
@@ -24593,7 +24593,7 @@ test_link_visit_mixed_links_cycles(void)
 
     TESTING_2("test setup");
 
-    snprintf(ext_link_filename, H5_API_TEST_FILENAME_MAX_LENGTH, "%s", EXTERNAL_LINK_TEST_FILE_NAME);
+    snprintf(ext_link_filename, H5_API_TEST_FILENAME_MAX_LENGTH, "%s%s", test_path_prefix, EXTERNAL_LINK_TEST_FILE_NAME);
 
     if ((file_id = H5Fcreate(ext_link_filename, H5F_ACC_TRUNC, H5P_DEFAULT, H5P_DEFAULT)) < 0) {
         H5_FAILED();
@@ -25030,7 +25030,7 @@ test_link_visit_invalid_params(void)
 
     TESTING_2("test setup");
 
-    snprintf(ext_link_filename, H5_API_TEST_FILENAME_MAX_LENGTH, "%s", EXTERNAL_LINK_TEST_FILE_NAME);
+    snprintf(ext_link_filename, H5_API_TEST_FILENAME_MAX_LENGTH, "%s%s", test_path_prefix, EXTERNAL_LINK_TEST_FILE_NAME);
 
     if ((file_id = H5Fcreate(ext_link_filename, H5F_ACC_TRUNC, H5P_DEFAULT, H5P_DEFAULT)) < 0) {
         H5_FAILED();

--- a/test/API/H5_api_link_test.c
+++ b/test/API/H5_api_link_test.c
@@ -21001,8 +21001,8 @@ test_link_iterate_mixed_links(void)
         {
             TESTING_2("H5Literate_by_name2 by link name in increasing order");
 
-            if (!(vol_cap_flags_g & H5VL_CAP_FLAG_EXTERNAL_LINKS) || 
-                !(vol_cap_flags_g & H5VL_CAP_FLAG_UD_LINKS) ) {
+            if (!(vol_cap_flags_g & H5VL_CAP_FLAG_EXTERNAL_LINKS) ||
+                !(vol_cap_flags_g & H5VL_CAP_FLAG_UD_LINKS)) {
                 SKIPPED();
                 printf("    external links or user-defined links aren't supported with this VOL connector\n");
                 PART_EMPTY(H5Literate_by_name_link_name_increasing);
@@ -21032,8 +21032,8 @@ test_link_iterate_mixed_links(void)
         {
             TESTING_2("H5Literate_by_name2 by link name in decreasing order");
 
-            if (!(vol_cap_flags_g & H5VL_CAP_FLAG_EXTERNAL_LINKS) || 
-                !(vol_cap_flags_g & H5VL_CAP_FLAG_UD_LINKS) ) {
+            if (!(vol_cap_flags_g & H5VL_CAP_FLAG_EXTERNAL_LINKS) ||
+                !(vol_cap_flags_g & H5VL_CAP_FLAG_UD_LINKS)) {
                 SKIPPED();
                 printf("    external links or user-defined links aren't supported with this VOL connector\n");
                 PART_EMPTY(H5Literate_by_name_link_name_decreasing);

--- a/test/API/H5_api_link_test.c
+++ b/test/API/H5_api_link_test.c
@@ -19679,6 +19679,14 @@ test_link_iterate_hard_links(void)
         {
             TESTING_2("H5Literate2 by link name in increasing order");
 
+            if (!(vol_cap_flags_g & H5VL_CAP_FLAG_EXTERNAL_LINKS) ||
+                !(vol_cap_flags_g & H5VL_CAP_FLAG_UD_LINKS)) {
+                SKIPPED();
+                printf("    API functions for external or user-defined link aren't supported with this "
+                         "connector\n");
+                PART_EMPTY(H5Literate_link_name_increasing);
+            }
+
             i = 0;
 
             /* Test basic link iteration capability using both index types and both index orders */
@@ -20401,6 +20409,12 @@ test_link_iterate_external_links(void)
         {
             TESTING_2("H5Literate2 by link name in increasing order");
 
+            if (!(vol_cap_flags_g & H5VL_CAP_FLAG_CREATION_ORDER) || !(vol_cap_flags_g & H5VL_CAP_FLAG_EXTERNAL_LINKS)) {
+                SKIPPED();
+                printf("    creation order tracking or the external link API aren't supported with this VOL connector\n");
+                PART_EMPTY(H5Literate_link_name_increasing);
+            }
+
             i = 0;
 
             /* Test basic link iteration capability using both index types and both index orders */
@@ -20424,6 +20438,12 @@ test_link_iterate_external_links(void)
         PART_BEGIN(H5Literate_link_name_decreasing)
         {
             TESTING_2("H5Literate2 by link name in decreasing order");
+
+            if (!(vol_cap_flags_g & H5VL_CAP_FLAG_CREATION_ORDER) || !(vol_cap_flags_g & H5VL_CAP_FLAG_EXTERNAL_LINKS)) {
+                SKIPPED();
+                printf("    creation order tracking or the external link API aren't supported with this VOL connector\n");
+                PART_EMPTY(H5Literate_link_name_decreasing);
+            }
 
             /* Reset the counter to the appropriate value for the next test */
             i = LINK_ITER_EXT_LINKS_TEST_NUM_LINKS;
@@ -20449,9 +20469,9 @@ test_link_iterate_external_links(void)
         {
             TESTING_2("H5Literate2 by creation order in increasing order");
 
-            if (!(vol_cap_flags_g & H5VL_CAP_FLAG_CREATION_ORDER)) {
+            if (!(vol_cap_flags_g & H5VL_CAP_FLAG_CREATION_ORDER) || !(vol_cap_flags_g & H5VL_CAP_FLAG_EXTERNAL_LINKS)) {
                 SKIPPED();
-                printf("    creation order tracking isn't supported with this VOL connector\n");
+                printf("    creation order tracking or the external link API aren't supported with this VOL connector\n");
                 PART_EMPTY(H5Literate_link_creation_increasing);
             }
 
@@ -20479,9 +20499,9 @@ test_link_iterate_external_links(void)
         {
             TESTING_2("H5Literate2 by creation order in decreasing order");
 
-            if (!(vol_cap_flags_g & H5VL_CAP_FLAG_CREATION_ORDER)) {
+            if (!(vol_cap_flags_g & H5VL_CAP_FLAG_CREATION_ORDER) || !(vol_cap_flags_g & H5VL_CAP_FLAG_EXTERNAL_LINKS)) {
                 SKIPPED();
-                printf("    creation order tracking isn't supported with this VOL connector\n");
+                printf("    creation order tracking or the external link API aren't supported with this VOL connector\n");
                 PART_EMPTY(H5Literate_link_creation_decreasing);
             }
 
@@ -20509,6 +20529,12 @@ test_link_iterate_external_links(void)
         {
             TESTING_2("H5Literate_by_name2 by link name in increasing order");
 
+            if (!(vol_cap_flags_g & H5VL_CAP_FLAG_CREATION_ORDER) || !(vol_cap_flags_g & H5VL_CAP_FLAG_EXTERNAL_LINKS)) {
+                SKIPPED();
+                printf("    creation order tracking or the external link API aren't supported with this VOL connector\n");
+                PART_EMPTY(H5Literate_by_name_link_name_increasing);
+            }
+
             /* Reset the counter to the appropriate value for the next test */
             i = 0;
 
@@ -20533,6 +20559,12 @@ test_link_iterate_external_links(void)
         PART_BEGIN(H5Literate_by_name_link_name_decreasing)
         {
             TESTING_2("H5Literate_by_name2 by link name in decreasing order");
+
+            if (!(vol_cap_flags_g & H5VL_CAP_FLAG_EXTERNAL_LINKS)) {
+                SKIPPED();
+                printf("    creation order tracking or the external link API aren't supported with this VOL connector\n");
+                PART_EMPTY(H5Literate_by_name_creation_decreasing);
+            }
 
             /* Reset the counter to the appropriate value for the next test */
             i = LINK_ITER_EXT_LINKS_TEST_NUM_LINKS;
@@ -20559,9 +20591,9 @@ test_link_iterate_external_links(void)
         {
             TESTING_2("H5Literate_by_name2 by creation order in increasing order");
 
-            if (!(vol_cap_flags_g & H5VL_CAP_FLAG_CREATION_ORDER)) {
+            if (!(vol_cap_flags_g & H5VL_CAP_FLAG_CREATION_ORDER) || !(vol_cap_flags_g & H5VL_CAP_FLAG_EXTERNAL_LINKS)) {
                 SKIPPED();
-                printf("    creation order tracking isn't supported with this VOL connector\n");
+                printf("    creation order tracking or the external link API aren't supported with this VOL connector\n");
                 PART_EMPTY(H5Literate_by_name_creation_increasing);
             }
 
@@ -20591,9 +20623,9 @@ test_link_iterate_external_links(void)
         {
             TESTING_2("H5Literate_by_name2 by creation order in decreasing order");
 
-            if (!(vol_cap_flags_g & H5VL_CAP_FLAG_CREATION_ORDER)) {
+            if (!(vol_cap_flags_g & H5VL_CAP_FLAG_CREATION_ORDER) || !(vol_cap_flags_g & H5VL_CAP_FLAG_EXTERNAL_LINKS)) {
                 SKIPPED();
-                printf("    creation order tracking isn't supported with this VOL connector\n");
+                printf("    creation order tracking or the external link API are not supported with this VOL connector\n");
                 PART_EMPTY(H5Literate_by_name_creation_decreasing);
             }
 
@@ -20838,6 +20870,13 @@ test_link_iterate_mixed_links(void)
         {
             TESTING_2("H5Literate2 by link name in increasing order");
 
+            if (!(vol_cap_flags_g & H5VL_CAP_FLAG_EXTERNAL_LINKS) || 
+                !(vol_cap_flags_g & H5VL_CAP_FLAG_UD_LINKS) ) {
+                SKIPPED();
+                printf("    creation order tracking, external links, or user-defined links aren't supported with this VOL connector\n");
+                PART_EMPTY(H5Literate_link_name_increasing);
+            }
+
             i = 0;
 
             /* Test basic link iteration capability using both index types and both index orders */
@@ -20860,6 +20899,13 @@ test_link_iterate_mixed_links(void)
         PART_BEGIN(H5Literate_link_name_decreasing)
         {
             TESTING_2("H5Literate2 by link name in decreasing order");
+
+            if (!(vol_cap_flags_g & H5VL_CAP_FLAG_EXTERNAL_LINKS) || 
+                !(vol_cap_flags_g & H5VL_CAP_FLAG_UD_LINKS) ) {
+                SKIPPED();
+                printf("    creation order tracking, external links, or user-defined links aren't supported with this VOL connector\n");
+                PART_EMPTY(H5Literate_link_name_decreasing);
+            }
 
             /* Reset the counter to the appropriate value for the next test */
             i = LINK_ITER_MIXED_LINKS_TEST_NUM_LINKS;
@@ -20884,9 +20930,11 @@ test_link_iterate_mixed_links(void)
         {
             TESTING_2("H5Literate2 by creation order in increasing order");
 
-            if (!(vol_cap_flags_g & H5VL_CAP_FLAG_CREATION_ORDER)) {
+            if (!(vol_cap_flags_g & H5VL_CAP_FLAG_CREATION_ORDER) || 
+                !(vol_cap_flags_g & H5VL_CAP_FLAG_EXTERNAL_LINKS) || 
+                !(vol_cap_flags_g & H5VL_CAP_FLAG_UD_LINKS)) {
                 SKIPPED();
-                printf("    creation order tracking isn't supported with this VOL connector\n");
+                printf("    creation order tracking, external links, or user-defined links aren't supported with this VOL connector\n");
                 PART_EMPTY(H5Literate_link_creation_increasing);
             }
 
@@ -20914,9 +20962,11 @@ test_link_iterate_mixed_links(void)
         {
             TESTING_2("H5Literate2 by creation order in decreasing order");
 
-            if (!(vol_cap_flags_g & H5VL_CAP_FLAG_CREATION_ORDER)) {
+            if (!(vol_cap_flags_g & H5VL_CAP_FLAG_CREATION_ORDER) || 
+                !(vol_cap_flags_g & H5VL_CAP_FLAG_EXTERNAL_LINKS) || 
+                !(vol_cap_flags_g & H5VL_CAP_FLAG_UD_LINKS)) {
                 SKIPPED();
-                printf("    creation order tracking isn't supported with this VOL connector\n");
+                printf("    creation order tracking, external links, or user-defined links aren't supported with this VOL connector\n");
                 PART_EMPTY(H5Literate_link_creation_decreasing);
             }
 
@@ -20944,6 +20994,14 @@ test_link_iterate_mixed_links(void)
         {
             TESTING_2("H5Literate_by_name2 by link name in increasing order");
 
+            if (!(vol_cap_flags_g & H5VL_CAP_FLAG_CREATION_ORDER) ||
+                !(vol_cap_flags_g & H5VL_CAP_FLAG_EXTERNAL_LINKS) || 
+                !(vol_cap_flags_g & H5VL_CAP_FLAG_UD_LINKS) ) {
+                SKIPPED();
+                printf("    creation order tracking, external links, or user-defined links aren't supported with this VOL connector\n");
+                PART_EMPTY(H5Literate_by_name_link_name_increasing);
+            }
+
             i = 0;
 
             if (H5Literate_by_name2(
@@ -20967,6 +21025,14 @@ test_link_iterate_mixed_links(void)
         PART_BEGIN(H5Literate_by_name_link_name_decreasing)
         {
             TESTING_2("H5Literate_by_name2 by link name in decreasing order");
+
+            if (!(vol_cap_flags_g & H5VL_CAP_FLAG_CREATION_ORDER) ||
+                !(vol_cap_flags_g & H5VL_CAP_FLAG_EXTERNAL_LINKS) || 
+                !(vol_cap_flags_g & H5VL_CAP_FLAG_UD_LINKS) ) {
+                SKIPPED();
+                printf("    creation order tracking, external links, or user-defined links aren't supported with this VOL connector\n");
+                PART_EMPTY(H5Literate_by_name_link_name_decreasing);
+            }
 
             /* Reset the counter to the appropriate value for the next test */
             i = LINK_ITER_MIXED_LINKS_TEST_NUM_LINKS;
@@ -20993,9 +21059,11 @@ test_link_iterate_mixed_links(void)
         {
             TESTING_2("H5Literate_by_name2 by creation order in increasing order");
 
-            if (!(vol_cap_flags_g & H5VL_CAP_FLAG_CREATION_ORDER)) {
+            if (!(vol_cap_flags_g & H5VL_CAP_FLAG_CREATION_ORDER) ||
+                !(vol_cap_flags_g & H5VL_CAP_FLAG_EXTERNAL_LINKS) || 
+                !(vol_cap_flags_g & H5VL_CAP_FLAG_UD_LINKS) ) {
                 SKIPPED();
-                printf("    creation order tracking isn't supported with this VOL connector\n");
+                printf("    creation order tracking, external links, or user-defined links aren't supported with this VOL connector\n");
                 PART_EMPTY(H5Literate_by_name_creation_increasing);
             }
 
@@ -21024,9 +21092,11 @@ test_link_iterate_mixed_links(void)
         {
             TESTING_2("H5Literate_by_name2 by creation order in decreasing order");
 
-            if (!(vol_cap_flags_g & H5VL_CAP_FLAG_CREATION_ORDER)) {
+            if (!(vol_cap_flags_g & H5VL_CAP_FLAG_CREATION_ORDER) || 
+                !(vol_cap_flags_g & H5VL_CAP_FLAG_EXTERNAL_LINKS) || 
+                !(vol_cap_flags_g & H5VL_CAP_FLAG_UD_LINKS)) {
                 SKIPPED();
-                printf("    creation order tracking isn't supported with this VOL connector\n");
+                printf("    creation order tracking, external links, or user-defined links aren't supported with this VOL connector\n");
                 PART_EMPTY(H5Literate_by_name_creation_decreasing);
             }
 
@@ -21055,9 +21125,11 @@ test_link_iterate_mixed_links(void)
         {
             TESTING_2("H5Literate2 index-saving capabilities in increasing order");
 
-            if (!(vol_cap_flags_g & H5VL_CAP_FLAG_CREATION_ORDER)) {
+            if (!(vol_cap_flags_g & H5VL_CAP_FLAG_CREATION_ORDER) ||
+                !(vol_cap_flags_g & H5VL_CAP_FLAG_EXTERNAL_LINKS) ||
+                !(vol_cap_flags_g & H5VL_CAP_FLAG_UD_LINKS)) {
                 SKIPPED();
-                printf("    creation order tracking isn't supported with this VOL connector\n");
+                printf("    creation order tracking, external links, or user-defined links aren't supported with this VOL connector\n");
                 PART_EMPTY(H5Literate_index_saving_increasing);
             }
 
@@ -21093,9 +21165,11 @@ test_link_iterate_mixed_links(void)
         {
             TESTING_2("H5Literate2 index-saving capabilities in decreasing order");
 
-            if (!(vol_cap_flags_g & H5VL_CAP_FLAG_CREATION_ORDER)) {
+            if (!(vol_cap_flags_g & H5VL_CAP_FLAG_CREATION_ORDER) ||
+                !(vol_cap_flags_g & H5VL_CAP_FLAG_EXTERNAL_LINKS) || 
+                !(vol_cap_flags_g & H5VL_CAP_FLAG_UD_LINKS)) {
                 SKIPPED();
-                printf("    creation order tracking isn't supported with this VOL connector\n");
+                printf("    creation order tracking, external links, or user-defined links aren't supported with this VOL connector\n");
                 PART_EMPTY(H5Literate_index_saving_decreasing);
             }
 
@@ -25935,7 +26009,6 @@ link_iter_external_links_cb(hid_t group_id, const char *name, const H5L_info2_t 
     herr_t  ret_val = H5_ITER_CONT;
 
     if (!(vol_cap_flags_g & H5VL_CAP_FLAG_EXTERNAL_LINKS)) {
-        SKIPPED();
         printf("    API functions for external links aren't supported with this "
                "connector\n");
         return 1;
@@ -26000,7 +26073,6 @@ link_iter_mixed_links_cb(hid_t group_id, const char *name, const H5L_info2_t *in
     herr_t  ret_val     = 0;
 
     if (!(vol_cap_flags_g & H5VL_CAP_FLAG_EXTERNAL_LINKS) || !(vol_cap_flags_g & H5VL_CAP_FLAG_UD_LINKS)) {
-        SKIPPED();
         printf("    API functions for external or user-defined link aren't supported with this "
                "connector\n");
         return 1;
@@ -26089,7 +26161,6 @@ link_iter_idx_saving_cb(hid_t group_id, const char *name, const H5L_info2_t *inf
     int *broken = (int *)op_data;
 
     if (!(vol_cap_flags_g & H5VL_CAP_FLAG_EXTERNAL_LINKS) || !(vol_cap_flags_g & H5VL_CAP_FLAG_UD_LINKS)) {
-        SKIPPED();
         printf("    API functions for external or user-defined link aren't supported with this "
                "connector\n");
         return 1;

--- a/test/API/H5_api_link_test.c
+++ b/test/API/H5_api_link_test.c
@@ -514,18 +514,17 @@ test_create_hard_link_many(void)
         goto error;
     }
 
-    for (size_t i = 1; i < HARD_LINK_TEST_GROUP_MANY_NUM_HARD_LINKS + 1; i++) {
+    for (size_t i = 1; (i < HARD_LINK_TEST_GROUP_MANY_NUM_HARD_LINKS + 1 && !valid_name_matched); i++) {
         char name_possibility[H5_API_TEST_FILENAME_MAX_LENGTH];
 
         snprintf(name_possibility, H5_API_TEST_FILENAME_MAX_LENGTH, "%s%zu",
                  "/" LINK_TEST_GROUP_NAME "/" HARD_LINK_TEST_GROUP_MANY_NAME "/hard", i);
 
-        valid_name_matched = !strcmp(objname, name_possibility) || valid_name_matched;
+        valid_name_matched |= !strcmp(objname, name_possibility);
     }
 
-    valid_name_matched = !strcmp(objname, "/" LINK_TEST_GROUP_NAME "/" HARD_LINK_TEST_GROUP_MANY_NAME
-                                          "/" HARD_LINK_TEST_GROUP_MANY_FINAL_NAME) ||
-                         valid_name_matched;
+    valid_name_matched |= !strcmp(objname, "/" LINK_TEST_GROUP_NAME "/" HARD_LINK_TEST_GROUP_MANY_NAME
+                                           "/" HARD_LINK_TEST_GROUP_MANY_FINAL_NAME);
 
     if (!valid_name_matched) {
         H5_FAILED();
@@ -1728,18 +1727,17 @@ test_create_soft_link_many(void)
         goto error;
     }
 
-    for (size_t i = 1; i < SOFT_LINK_TEST_GROUP_MANY_NAME_SOFT_LINK_COUNT + 1; i++) {
+    for (size_t i = 1; (i < SOFT_LINK_TEST_GROUP_MANY_NAME_SOFT_LINK_COUNT + 1 && !valid_name_matched); i++) {
         char name_possibility[H5_API_TEST_FILENAME_MAX_LENGTH];
 
         snprintf(name_possibility, H5_API_TEST_FILENAME_MAX_LENGTH, "%s%zu",
                  "/" LINK_TEST_GROUP_NAME "/" SOFT_LINK_TEST_GROUP_MANY_NAME "/soft", i);
 
-        valid_name_matched = !strcmp(objname, name_possibility) || valid_name_matched;
+        valid_name_matched |= !strcmp(objname, name_possibility);
     }
 
-    valid_name_matched = !strcmp(objname, "/" LINK_TEST_GROUP_NAME "/" SOFT_LINK_TEST_GROUP_MANY_NAME
-                                          "/" SOFT_LINK_TEST_GROUP_MANY_FINAL_NAME) ||
-                         valid_name_matched;
+    valid_name_matched |= !strcmp(objname, "/" LINK_TEST_GROUP_NAME "/" SOFT_LINK_TEST_GROUP_MANY_NAME
+                                           "/" SOFT_LINK_TEST_GROUP_MANY_FINAL_NAME);
 
     if (!valid_name_matched) {
         H5_FAILED();
@@ -19683,7 +19681,7 @@ test_link_iterate_hard_links(void)
                 !(vol_cap_flags_g & H5VL_CAP_FLAG_UD_LINKS)) {
                 SKIPPED();
                 printf("    API functions for external or user-defined link aren't supported with this "
-                         "connector\n");
+                       "connector\n");
                 PART_EMPTY(H5Literate_link_name_increasing);
             }
 
@@ -20409,9 +20407,11 @@ test_link_iterate_external_links(void)
         {
             TESTING_2("H5Literate2 by link name in increasing order");
 
-            if (!(vol_cap_flags_g & H5VL_CAP_FLAG_CREATION_ORDER) || !(vol_cap_flags_g & H5VL_CAP_FLAG_EXTERNAL_LINKS)) {
+            if (!(vol_cap_flags_g & H5VL_CAP_FLAG_CREATION_ORDER) ||
+                !(vol_cap_flags_g & H5VL_CAP_FLAG_EXTERNAL_LINKS)) {
                 SKIPPED();
-                printf("    creation order tracking or the external link API aren't supported with this VOL connector\n");
+                printf("    creation order tracking or the external link API aren't supported with this VOL "
+                       "connector\n");
                 PART_EMPTY(H5Literate_link_name_increasing);
             }
 
@@ -20439,9 +20439,11 @@ test_link_iterate_external_links(void)
         {
             TESTING_2("H5Literate2 by link name in decreasing order");
 
-            if (!(vol_cap_flags_g & H5VL_CAP_FLAG_CREATION_ORDER) || !(vol_cap_flags_g & H5VL_CAP_FLAG_EXTERNAL_LINKS)) {
+            if (!(vol_cap_flags_g & H5VL_CAP_FLAG_CREATION_ORDER) ||
+                !(vol_cap_flags_g & H5VL_CAP_FLAG_EXTERNAL_LINKS)) {
                 SKIPPED();
-                printf("    creation order tracking or the external link API aren't supported with this VOL connector\n");
+                printf("    creation order tracking or the external link API aren't supported with this VOL "
+                       "connector\n");
                 PART_EMPTY(H5Literate_link_name_decreasing);
             }
 
@@ -20469,9 +20471,11 @@ test_link_iterate_external_links(void)
         {
             TESTING_2("H5Literate2 by creation order in increasing order");
 
-            if (!(vol_cap_flags_g & H5VL_CAP_FLAG_CREATION_ORDER) || !(vol_cap_flags_g & H5VL_CAP_FLAG_EXTERNAL_LINKS)) {
+            if (!(vol_cap_flags_g & H5VL_CAP_FLAG_CREATION_ORDER) ||
+                !(vol_cap_flags_g & H5VL_CAP_FLAG_EXTERNAL_LINKS)) {
                 SKIPPED();
-                printf("    creation order tracking or the external link API aren't supported with this VOL connector\n");
+                printf("    creation order tracking or the external link API aren't supported with this VOL "
+                       "connector\n");
                 PART_EMPTY(H5Literate_link_creation_increasing);
             }
 
@@ -20499,9 +20503,11 @@ test_link_iterate_external_links(void)
         {
             TESTING_2("H5Literate2 by creation order in decreasing order");
 
-            if (!(vol_cap_flags_g & H5VL_CAP_FLAG_CREATION_ORDER) || !(vol_cap_flags_g & H5VL_CAP_FLAG_EXTERNAL_LINKS)) {
+            if (!(vol_cap_flags_g & H5VL_CAP_FLAG_CREATION_ORDER) ||
+                !(vol_cap_flags_g & H5VL_CAP_FLAG_EXTERNAL_LINKS)) {
                 SKIPPED();
-                printf("    creation order tracking or the external link API aren't supported with this VOL connector\n");
+                printf("    creation order tracking or the external link API aren't supported with this VOL "
+                       "connector\n");
                 PART_EMPTY(H5Literate_link_creation_decreasing);
             }
 
@@ -20529,9 +20535,11 @@ test_link_iterate_external_links(void)
         {
             TESTING_2("H5Literate_by_name2 by link name in increasing order");
 
-            if (!(vol_cap_flags_g & H5VL_CAP_FLAG_CREATION_ORDER) || !(vol_cap_flags_g & H5VL_CAP_FLAG_EXTERNAL_LINKS)) {
+            if (!(vol_cap_flags_g & H5VL_CAP_FLAG_CREATION_ORDER) ||
+                !(vol_cap_flags_g & H5VL_CAP_FLAG_EXTERNAL_LINKS)) {
                 SKIPPED();
-                printf("    creation order tracking or the external link API aren't supported with this VOL connector\n");
+                printf("    creation order tracking or the external link API aren't supported with this VOL "
+                       "connector\n");
                 PART_EMPTY(H5Literate_by_name_link_name_increasing);
             }
 
@@ -20562,7 +20570,8 @@ test_link_iterate_external_links(void)
 
             if (!(vol_cap_flags_g & H5VL_CAP_FLAG_EXTERNAL_LINKS)) {
                 SKIPPED();
-                printf("    creation order tracking or the external link API aren't supported with this VOL connector\n");
+                printf("    creation order tracking or the external link API aren't supported with this VOL "
+                       "connector\n");
                 PART_EMPTY(H5Literate_by_name_creation_decreasing);
             }
 
@@ -20591,9 +20600,11 @@ test_link_iterate_external_links(void)
         {
             TESTING_2("H5Literate_by_name2 by creation order in increasing order");
 
-            if (!(vol_cap_flags_g & H5VL_CAP_FLAG_CREATION_ORDER) || !(vol_cap_flags_g & H5VL_CAP_FLAG_EXTERNAL_LINKS)) {
+            if (!(vol_cap_flags_g & H5VL_CAP_FLAG_CREATION_ORDER) ||
+                !(vol_cap_flags_g & H5VL_CAP_FLAG_EXTERNAL_LINKS)) {
                 SKIPPED();
-                printf("    creation order tracking or the external link API aren't supported with this VOL connector\n");
+                printf("    creation order tracking or the external link API aren't supported with this VOL "
+                       "connector\n");
                 PART_EMPTY(H5Literate_by_name_creation_increasing);
             }
 
@@ -20623,9 +20634,11 @@ test_link_iterate_external_links(void)
         {
             TESTING_2("H5Literate_by_name2 by creation order in decreasing order");
 
-            if (!(vol_cap_flags_g & H5VL_CAP_FLAG_CREATION_ORDER) || !(vol_cap_flags_g & H5VL_CAP_FLAG_EXTERNAL_LINKS)) {
+            if (!(vol_cap_flags_g & H5VL_CAP_FLAG_CREATION_ORDER) ||
+                !(vol_cap_flags_g & H5VL_CAP_FLAG_EXTERNAL_LINKS)) {
                 SKIPPED();
-                printf("    creation order tracking or the external link API are not supported with this VOL connector\n");
+                printf("    creation order tracking or the external link API are not supported with this VOL "
+                       "connector\n");
                 PART_EMPTY(H5Literate_by_name_creation_decreasing);
             }
 
@@ -20870,10 +20883,11 @@ test_link_iterate_mixed_links(void)
         {
             TESTING_2("H5Literate2 by link name in increasing order");
 
-            if (!(vol_cap_flags_g & H5VL_CAP_FLAG_EXTERNAL_LINKS) || 
-                !(vol_cap_flags_g & H5VL_CAP_FLAG_UD_LINKS) ) {
+            if (!(vol_cap_flags_g & H5VL_CAP_FLAG_EXTERNAL_LINKS) ||
+                !(vol_cap_flags_g & H5VL_CAP_FLAG_UD_LINKS)) {
                 SKIPPED();
-                printf("    creation order tracking, external links, or user-defined links aren't supported with this VOL connector\n");
+                printf("    creation order tracking, external links, or user-defined links aren't supported "
+                       "with this VOL connector\n");
                 PART_EMPTY(H5Literate_link_name_increasing);
             }
 
@@ -20900,10 +20914,11 @@ test_link_iterate_mixed_links(void)
         {
             TESTING_2("H5Literate2 by link name in decreasing order");
 
-            if (!(vol_cap_flags_g & H5VL_CAP_FLAG_EXTERNAL_LINKS) || 
-                !(vol_cap_flags_g & H5VL_CAP_FLAG_UD_LINKS) ) {
+            if (!(vol_cap_flags_g & H5VL_CAP_FLAG_EXTERNAL_LINKS) ||
+                !(vol_cap_flags_g & H5VL_CAP_FLAG_UD_LINKS)) {
                 SKIPPED();
-                printf("    creation order tracking, external links, or user-defined links aren't supported with this VOL connector\n");
+                printf("    creation order tracking, external links, or user-defined links aren't supported "
+                       "with this VOL connector\n");
                 PART_EMPTY(H5Literate_link_name_decreasing);
             }
 
@@ -20930,11 +20945,12 @@ test_link_iterate_mixed_links(void)
         {
             TESTING_2("H5Literate2 by creation order in increasing order");
 
-            if (!(vol_cap_flags_g & H5VL_CAP_FLAG_CREATION_ORDER) || 
-                !(vol_cap_flags_g & H5VL_CAP_FLAG_EXTERNAL_LINKS) || 
+            if (!(vol_cap_flags_g & H5VL_CAP_FLAG_CREATION_ORDER) ||
+                !(vol_cap_flags_g & H5VL_CAP_FLAG_EXTERNAL_LINKS) ||
                 !(vol_cap_flags_g & H5VL_CAP_FLAG_UD_LINKS)) {
                 SKIPPED();
-                printf("    creation order tracking, external links, or user-defined links aren't supported with this VOL connector\n");
+                printf("    creation order tracking, external links, or user-defined links aren't supported "
+                       "with this VOL connector\n");
                 PART_EMPTY(H5Literate_link_creation_increasing);
             }
 
@@ -20962,11 +20978,12 @@ test_link_iterate_mixed_links(void)
         {
             TESTING_2("H5Literate2 by creation order in decreasing order");
 
-            if (!(vol_cap_flags_g & H5VL_CAP_FLAG_CREATION_ORDER) || 
-                !(vol_cap_flags_g & H5VL_CAP_FLAG_EXTERNAL_LINKS) || 
+            if (!(vol_cap_flags_g & H5VL_CAP_FLAG_CREATION_ORDER) ||
+                !(vol_cap_flags_g & H5VL_CAP_FLAG_EXTERNAL_LINKS) ||
                 !(vol_cap_flags_g & H5VL_CAP_FLAG_UD_LINKS)) {
                 SKIPPED();
-                printf("    creation order tracking, external links, or user-defined links aren't supported with this VOL connector\n");
+                printf("    creation order tracking, external links, or user-defined links aren't supported "
+                       "with this VOL connector\n");
                 PART_EMPTY(H5Literate_link_creation_decreasing);
             }
 
@@ -20995,10 +21012,11 @@ test_link_iterate_mixed_links(void)
             TESTING_2("H5Literate_by_name2 by link name in increasing order");
 
             if (!(vol_cap_flags_g & H5VL_CAP_FLAG_CREATION_ORDER) ||
-                !(vol_cap_flags_g & H5VL_CAP_FLAG_EXTERNAL_LINKS) || 
-                !(vol_cap_flags_g & H5VL_CAP_FLAG_UD_LINKS) ) {
+                !(vol_cap_flags_g & H5VL_CAP_FLAG_EXTERNAL_LINKS) ||
+                !(vol_cap_flags_g & H5VL_CAP_FLAG_UD_LINKS)) {
                 SKIPPED();
-                printf("    creation order tracking, external links, or user-defined links aren't supported with this VOL connector\n");
+                printf("    creation order tracking, external links, or user-defined links aren't supported "
+                       "with this VOL connector\n");
                 PART_EMPTY(H5Literate_by_name_link_name_increasing);
             }
 
@@ -21027,10 +21045,11 @@ test_link_iterate_mixed_links(void)
             TESTING_2("H5Literate_by_name2 by link name in decreasing order");
 
             if (!(vol_cap_flags_g & H5VL_CAP_FLAG_CREATION_ORDER) ||
-                !(vol_cap_flags_g & H5VL_CAP_FLAG_EXTERNAL_LINKS) || 
-                !(vol_cap_flags_g & H5VL_CAP_FLAG_UD_LINKS) ) {
+                !(vol_cap_flags_g & H5VL_CAP_FLAG_EXTERNAL_LINKS) ||
+                !(vol_cap_flags_g & H5VL_CAP_FLAG_UD_LINKS)) {
                 SKIPPED();
-                printf("    creation order tracking, external links, or user-defined links aren't supported with this VOL connector\n");
+                printf("    creation order tracking, external links, or user-defined links aren't supported "
+                       "with this VOL connector\n");
                 PART_EMPTY(H5Literate_by_name_link_name_decreasing);
             }
 
@@ -21060,10 +21079,11 @@ test_link_iterate_mixed_links(void)
             TESTING_2("H5Literate_by_name2 by creation order in increasing order");
 
             if (!(vol_cap_flags_g & H5VL_CAP_FLAG_CREATION_ORDER) ||
-                !(vol_cap_flags_g & H5VL_CAP_FLAG_EXTERNAL_LINKS) || 
-                !(vol_cap_flags_g & H5VL_CAP_FLAG_UD_LINKS) ) {
+                !(vol_cap_flags_g & H5VL_CAP_FLAG_EXTERNAL_LINKS) ||
+                !(vol_cap_flags_g & H5VL_CAP_FLAG_UD_LINKS)) {
                 SKIPPED();
-                printf("    creation order tracking, external links, or user-defined links aren't supported with this VOL connector\n");
+                printf("    creation order tracking, external links, or user-defined links aren't supported "
+                       "with this VOL connector\n");
                 PART_EMPTY(H5Literate_by_name_creation_increasing);
             }
 
@@ -21092,11 +21112,12 @@ test_link_iterate_mixed_links(void)
         {
             TESTING_2("H5Literate_by_name2 by creation order in decreasing order");
 
-            if (!(vol_cap_flags_g & H5VL_CAP_FLAG_CREATION_ORDER) || 
-                !(vol_cap_flags_g & H5VL_CAP_FLAG_EXTERNAL_LINKS) || 
+            if (!(vol_cap_flags_g & H5VL_CAP_FLAG_CREATION_ORDER) ||
+                !(vol_cap_flags_g & H5VL_CAP_FLAG_EXTERNAL_LINKS) ||
                 !(vol_cap_flags_g & H5VL_CAP_FLAG_UD_LINKS)) {
                 SKIPPED();
-                printf("    creation order tracking, external links, or user-defined links aren't supported with this VOL connector\n");
+                printf("    creation order tracking, external links, or user-defined links aren't supported "
+                       "with this VOL connector\n");
                 PART_EMPTY(H5Literate_by_name_creation_decreasing);
             }
 
@@ -21129,7 +21150,8 @@ test_link_iterate_mixed_links(void)
                 !(vol_cap_flags_g & H5VL_CAP_FLAG_EXTERNAL_LINKS) ||
                 !(vol_cap_flags_g & H5VL_CAP_FLAG_UD_LINKS)) {
                 SKIPPED();
-                printf("    creation order tracking, external links, or user-defined links aren't supported with this VOL connector\n");
+                printf("    creation order tracking, external links, or user-defined links aren't supported "
+                       "with this VOL connector\n");
                 PART_EMPTY(H5Literate_index_saving_increasing);
             }
 
@@ -21166,10 +21188,11 @@ test_link_iterate_mixed_links(void)
             TESTING_2("H5Literate2 index-saving capabilities in decreasing order");
 
             if (!(vol_cap_flags_g & H5VL_CAP_FLAG_CREATION_ORDER) ||
-                !(vol_cap_flags_g & H5VL_CAP_FLAG_EXTERNAL_LINKS) || 
+                !(vol_cap_flags_g & H5VL_CAP_FLAG_EXTERNAL_LINKS) ||
                 !(vol_cap_flags_g & H5VL_CAP_FLAG_UD_LINKS)) {
                 SKIPPED();
-                printf("    creation order tracking, external links, or user-defined links aren't supported with this VOL connector\n");
+                printf("    creation order tracking, external links, or user-defined links aren't supported "
+                       "with this VOL connector\n");
                 PART_EMPTY(H5Literate_index_saving_decreasing);
             }
 

--- a/test/API/H5_api_link_test.c
+++ b/test/API/H5_api_link_test.c
@@ -374,6 +374,7 @@ test_create_hard_link_many(void)
     hid_t  file_id         = H5I_INVALID_HID;
     hid_t  container_group = H5I_INVALID_HID;
     hid_t  group_id = H5I_INVALID_HID, group_id2 = H5I_INVALID_HID;
+    bool   valid_name_matched = FALSE;
     char   objname[HARD_LINK_TEST_GROUP_MANY_NAME_BUF_SIZE]; /* Object name */
 
     TESTING("hard link creation of many links");
@@ -505,6 +506,7 @@ test_create_hard_link_many(void)
                HARD_LINK_TEST_GROUP_MANY_FINAL_NAME);
         goto error;
     }
+
     /* Check name */
     if (H5Iget_name(group_id2, objname, (size_t)HARD_LINK_TEST_GROUP_MANY_NAME_BUF_SIZE) < 0) {
         H5_FAILED();
@@ -512,9 +514,24 @@ test_create_hard_link_many(void)
         goto error;
     }
 
-    if (strcmp(objname, "/" LINK_TEST_GROUP_NAME "/" HARD_LINK_TEST_GROUP_MANY_NAME "/hard21")) {
+    for (size_t i = 1; i < HARD_LINK_TEST_GROUP_MANY_NUM_HARD_LINKS + 1; i++) {
+        char name_possibility[H5_API_TEST_FILENAME_MAX_LENGTH];
+
+        snprintf(name_possibility, H5_API_TEST_FILENAME_MAX_LENGTH, "%s%zu",
+                 "/" LINK_TEST_GROUP_NAME "/" HARD_LINK_TEST_GROUP_MANY_NAME "/hard", i);
+
+        valid_name_matched = !strcmp(objname, name_possibility) || valid_name_matched;
+    }
+
+    valid_name_matched = !strcmp(objname, "/" LINK_TEST_GROUP_NAME "/" HARD_LINK_TEST_GROUP_MANY_NAME
+                                          "/" HARD_LINK_TEST_GROUP_MANY_FINAL_NAME) ||
+                         valid_name_matched;
+
+    if (!valid_name_matched) {
         H5_FAILED();
-        printf("    wrong name of the object '%s'\n", objname);
+        printf("    H5Iget_name failed to retrieve a valid name for '%s'\n",
+               HARD_LINK_TEST_GROUP_MANY_FINAL_NAME);
+
         goto error;
     }
 
@@ -900,7 +917,8 @@ test_create_hard_link_invalid_params(void)
         {
             TESTING_2("H5Lcreate_hard across files");
 
-            snprintf(ext_link_filename, H5_API_TEST_FILENAME_MAX_LENGTH, "%s%s", test_path_prefix, EXTERNAL_LINK_TEST_FILE_NAME);
+            snprintf(ext_link_filename, H5_API_TEST_FILENAME_MAX_LENGTH, "%s%s", test_path_prefix,
+                     EXTERNAL_LINK_TEST_FILE_NAME);
 
             if ((ext_file_id = H5Fcreate(ext_link_filename, H5F_ACC_TRUNC, H5P_DEFAULT, H5P_DEFAULT)) < 0) {
                 H5_FAILED();
@@ -1555,11 +1573,12 @@ error:
 static int
 test_create_soft_link_many(void)
 {
-    htri_t link_exists;
-    hid_t  file_id         = H5I_INVALID_HID;
-    hid_t  container_group = H5I_INVALID_HID;
-    hid_t  group_id        = H5I_INVALID_HID;
-    hid_t  object_id       = H5I_INVALID_HID;
+    htri_t link_exists        = FAIL;
+    bool   valid_name_matched = FALSE;
+    hid_t  file_id            = H5I_INVALID_HID;
+    hid_t  container_group    = H5I_INVALID_HID;
+    hid_t  group_id           = H5I_INVALID_HID;
+    hid_t  object_id          = H5I_INVALID_HID;
     char   objname[SOFT_LINK_TEST_GROUP_MANY_NAME_BUF_SIZE]; /* Object name */
 
     TESTING("soft link creation of many links");
@@ -1709,9 +1728,24 @@ test_create_soft_link_many(void)
         goto error;
     }
 
-    if (strcmp(objname, "/" LINK_TEST_GROUP_NAME "/" SOFT_LINK_TEST_GROUP_MANY_NAME "/soft16")) {
+    for (size_t i = 1; i < SOFT_LINK_TEST_GROUP_MANY_NAME_SOFT_LINK_COUNT + 1; i++) {
+        char name_possibility[H5_API_TEST_FILENAME_MAX_LENGTH];
+
+        snprintf(name_possibility, H5_API_TEST_FILENAME_MAX_LENGTH, "%s%zu",
+                 "/" LINK_TEST_GROUP_NAME "/" SOFT_LINK_TEST_GROUP_MANY_NAME "/soft", i);
+
+        valid_name_matched = !strcmp(objname, name_possibility) || valid_name_matched;
+    }
+
+    valid_name_matched = !strcmp(objname, "/" LINK_TEST_GROUP_NAME "/" SOFT_LINK_TEST_GROUP_MANY_NAME
+                                          "/" SOFT_LINK_TEST_GROUP_MANY_FINAL_NAME) ||
+                         valid_name_matched;
+
+    if (!valid_name_matched) {
         H5_FAILED();
-        printf("    wrong name of the object '%s'\n", objname);
+        printf("    H5Iget_name failed to retrieve a valid name for '%s'\n",
+               "/" LINK_TEST_GROUP_NAME "/" SOFT_LINK_TEST_GROUP_MANY_NAME
+               "/" SOFT_LINK_TEST_GROUP_MANY_FINAL_NAME);
         goto error;
     }
 
@@ -1999,7 +2033,8 @@ test_create_external_link(void)
         return 0;
     }
 
-    snprintf(ext_link_filename, H5_API_TEST_FILENAME_MAX_LENGTH, "%s%s", test_path_prefix, EXTERNAL_LINK_TEST_FILE_NAME);
+    snprintf(ext_link_filename, H5_API_TEST_FILENAME_MAX_LENGTH, "%s%s", test_path_prefix,
+             EXTERNAL_LINK_TEST_FILE_NAME);
 
     if ((file_id = H5Fcreate(ext_link_filename, H5F_ACC_TRUNC, H5P_DEFAULT, H5P_DEFAULT)) < 0) {
         H5_FAILED();
@@ -2107,7 +2142,8 @@ test_create_external_link_dangling(void)
         return 0;
     }
 
-    snprintf(ext_link_filename, H5_API_TEST_FILENAME_MAX_LENGTH, "%s%s", test_path_prefix, EXTERNAL_LINK_TEST_FILE_NAME);
+    snprintf(ext_link_filename, H5_API_TEST_FILENAME_MAX_LENGTH, "%s%s", test_path_prefix,
+             EXTERNAL_LINK_TEST_FILE_NAME);
 
     if ((ext_file_id = H5Fcreate(ext_link_filename, H5F_ACC_TRUNC, H5P_DEFAULT, H5P_DEFAULT)) < 0) {
         H5_FAILED();
@@ -2248,7 +2284,8 @@ test_create_external_link_multi(void)
         {
             TESTING_2("Create the first external file to be pointed to");
 
-            snprintf(ext_link_filename1, H5_API_TEST_FILENAME_MAX_LENGTH, "%s%s", test_path_prefix, EXTERNAL_LINK_TEST_FILE_NAME);
+            snprintf(ext_link_filename1, H5_API_TEST_FILENAME_MAX_LENGTH, "%s%s", test_path_prefix,
+                     EXTERNAL_LINK_TEST_FILE_NAME);
 
             if ((file_id = H5Fcreate(ext_link_filename1, H5F_ACC_TRUNC, H5P_DEFAULT, H5P_DEFAULT)) < 0) {
                 H5_FAILED();
@@ -2308,8 +2345,8 @@ test_create_external_link_multi(void)
         {
             TESTING_2("Create the second external file to be pointed to");
 
-            snprintf(ext_link_filename2, H5_API_TEST_FILENAME_MAX_LENGTH, "%s%s",
-                     test_path_prefix, EXTERNAL_LINK_TEST_FILE_NAME2);
+            snprintf(ext_link_filename2, H5_API_TEST_FILENAME_MAX_LENGTH, "%s%s", test_path_prefix,
+                     EXTERNAL_LINK_TEST_FILE_NAME2);
 
             if ((file_id = H5Fcreate(ext_link_filename2, H5F_ACC_TRUNC, H5P_DEFAULT, H5P_DEFAULT)) < 0) {
                 H5_FAILED();
@@ -2365,8 +2402,8 @@ test_create_external_link_multi(void)
         {
             TESTING_2("Create the third external file to be pointed to");
 
-            snprintf(ext_link_filename3, H5_API_TEST_FILENAME_MAX_LENGTH, "%s%s",
-                     test_path_prefix, EXTERNAL_LINK_TEST_FILE_NAME3);
+            snprintf(ext_link_filename3, H5_API_TEST_FILENAME_MAX_LENGTH, "%s%s", test_path_prefix,
+                     EXTERNAL_LINK_TEST_FILE_NAME3);
 
             if ((file_id = H5Fcreate(ext_link_filename3, H5F_ACC_TRUNC, H5P_DEFAULT, H5P_DEFAULT)) < 0) {
                 H5_FAILED();
@@ -2462,9 +2499,10 @@ test_create_external_link_multi(void)
                 PART_ERROR(H5Lcreate_external_final_file);
             }
 
-            if (strcmp(objname, "/A/B/C")) {
+            if (strcmp(objname, "/A/B/C") && strcmp(objname, "/D/E/F") && strcmp(objname, "/G/H/I") &&
+                strcmp(objname, "/" LINK_TEST_GROUP_NAME "/" EXTERNAL_LINK_TEST_MULTI_NAME "/ext_link")) {
                 H5_FAILED();
-                printf("    wrong name of the object '%s'\n", objname);
+                printf("    H5Iget_name failed to retrieve a valid name for the object '%s'\n", "/A/B/C");
                 PART_ERROR(H5Lcreate_external_final_file);
             }
 
@@ -2532,9 +2570,13 @@ test_create_external_link_multi(void)
                 PART_ERROR(H5Lcreate_external_object_created);
             }
 
-            if (strcmp(objname, "/A/B/C/new_group")) {
+            if (strcmp(objname, "/A/B/C/new_group") && strcmp(objname, "/D/E/F/new_group") &&
+                strcmp(objname, "/G/H/I/new_group") &&
+                strcmp(objname,
+                       "/" LINK_TEST_GROUP_NAME "/" EXTERNAL_LINK_TEST_MULTI_NAME "/ext_link/new_group")) {
                 H5_FAILED();
-                printf("    wrong name of the object '%s'\n", objname);
+                printf("    H5Iget_name was unable to retrieve a valid name for the object '%s'\n",
+                       "/A/B/C/new_group");
                 PART_ERROR(H5Lcreate_external_object_created);
             }
 
@@ -2587,9 +2629,10 @@ error:
 static int
 test_create_external_link_ping_pong(void)
 {
-    hid_t file_id   = H5I_INVALID_HID;
-    hid_t group_id  = H5I_INVALID_HID;
-    hid_t group_id2 = H5I_INVALID_HID;
+    hid_t file_id            = H5I_INVALID_HID;
+    hid_t group_id           = H5I_INVALID_HID;
+    hid_t group_id2          = H5I_INVALID_HID;
+    bool  valid_name_matched = false;
     char  ext_link_filename1[H5_API_TEST_FILENAME_MAX_LENGTH];
     char  ext_link_filename2[H5_API_TEST_FILENAME_MAX_LENGTH];
     char  objname[EXTERNAL_LINK_TEST_MULTI_NAME_BUF_SIZE];
@@ -2605,8 +2648,10 @@ test_create_external_link_ping_pong(void)
         return 0;
     }
 
-    snprintf(ext_link_filename1, H5_API_TEST_FILENAME_MAX_LENGTH, "%s%s", test_path_prefix, EXTERNAL_LINK_TEST_PING_PONG_NAME1);
-    snprintf(ext_link_filename2, H5_API_TEST_FILENAME_MAX_LENGTH, "%s%s", test_path_prefix, EXTERNAL_LINK_TEST_PING_PONG_NAME2);
+    snprintf(ext_link_filename1, H5_API_TEST_FILENAME_MAX_LENGTH, "%s%s", test_path_prefix,
+             EXTERNAL_LINK_TEST_PING_PONG_NAME1);
+    snprintf(ext_link_filename2, H5_API_TEST_FILENAME_MAX_LENGTH, "%s%s", test_path_prefix,
+             EXTERNAL_LINK_TEST_PING_PONG_NAME2);
 
     BEGIN_MULTIPART
     {
@@ -2735,9 +2780,23 @@ test_create_external_link_ping_pong(void)
                 PART_ERROR(H5Lcreate_external_verify);
             }
 
-            if (strcmp(objname, "/final")) {
+            for (size_t i = 1; i < EXTERNAL_LINK_TEST_PING_PONG_NUM_LINKS + 1; i++) {
+                char name_possibility[H5_API_TEST_FILENAME_MAX_LENGTH];
+
+                snprintf(name_possibility, H5_API_TEST_FILENAME_MAX_LENGTH, "%s%zu", "/link", i);
+
+                if (!strcmp(name_possibility, objname)) {
+                    valid_name_matched = true;
+                    break;
+                }
+            }
+
+            if (!strcmp(objname, "/final"))
+                valid_name_matched = true;
+
+            if (!valid_name_matched) {
                 H5_FAILED();
-                printf("    wrong name of the object '%s'\n", objname);
+                printf("    H5Iget_name was unable to retrieve a valid name for the object '%s'\n", "/final");
                 PART_ERROR(H5Lcreate_external_verify);
             }
 
@@ -2795,9 +2854,20 @@ test_create_external_link_ping_pong(void)
                 PART_ERROR(H5Lcreate_external_verify_again);
             }
 
-            if (strcmp(objname, "/final/new_group")) {
+            for (size_t i = 1; i < EXTERNAL_LINK_TEST_PING_PONG_NUM_LINKS + 1; i++) {
+                char name_possibility[H5_API_TEST_FILENAME_MAX_LENGTH];
+
+                snprintf(name_possibility, H5_API_TEST_FILENAME_MAX_LENGTH, "%s%zu%s", "/link", i,
+                         "/new_group");
+
+                valid_name_matched = !strcmp(objname, name_possibility) || valid_name_matched;
+            }
+
+            valid_name_matched = !strcmp(objname, "/final/new_group") || valid_name_matched;
+
+            if (!valid_name_matched) {
                 H5_FAILED();
-                printf("    wrong name of the object '%s'\n", objname);
+                printf("    H5Iget_name was unable to find a valid name for '%s'\n", "/final/new_group");
                 PART_ERROR(H5Lcreate_external_verify_again);
             }
 
@@ -2860,8 +2930,8 @@ test_create_external_link_invalid_params(void)
 
     TESTING_2("test setup");
 
-    snprintf(ext_link_filename, H5_API_TEST_FILENAME_MAX_LENGTH, "%s%s",
-             test_path_prefix, EXTERNAL_LINK_INVALID_PARAMS_TEST_FILE_NAME);
+    snprintf(ext_link_filename, H5_API_TEST_FILENAME_MAX_LENGTH, "%s%s", test_path_prefix,
+             EXTERNAL_LINK_INVALID_PARAMS_TEST_FILE_NAME);
 
     if ((file_id = H5Fcreate(ext_link_filename, H5F_ACC_TRUNC, H5P_DEFAULT, H5P_DEFAULT)) < 0) {
         H5_FAILED();
@@ -3751,7 +3821,8 @@ test_delete_link(void)
         {
             TESTING_2("H5Ldelete on external link");
 
-            snprintf(ext_link_filename, H5_API_TEST_FILENAME_MAX_LENGTH, "%s%s", test_path_prefix, EXTERNAL_LINK_TEST_FILE_NAME);
+            snprintf(ext_link_filename, H5_API_TEST_FILENAME_MAX_LENGTH, "%s%s", test_path_prefix,
+                     EXTERNAL_LINK_TEST_FILE_NAME);
 
             if ((ext_file_id = H5Fcreate(ext_link_filename, H5F_ACC_TRUNC, H5P_DEFAULT, H5P_DEFAULT)) < 0) {
                 H5_FAILED();
@@ -5714,7 +5785,8 @@ test_delete_link(void)
             }
 
             /* Create file for external link to reference */
-            snprintf(ext_link_filename, H5_API_TEST_FILENAME_MAX_LENGTH, "%s%s", test_path_prefix, EXTERNAL_LINK_TEST_FILE_NAME);
+            snprintf(ext_link_filename, H5_API_TEST_FILENAME_MAX_LENGTH, "%s%s", test_path_prefix,
+                     EXTERNAL_LINK_TEST_FILE_NAME);
 
             if ((ext_file_id = H5Fcreate(ext_link_filename, H5F_ACC_TRUNC, H5P_DEFAULT, H5P_DEFAULT)) < 0) {
                 H5_FAILED();
@@ -5995,7 +6067,8 @@ test_delete_link(void)
             }
 
             /* Create file for external link to reference */
-            snprintf(ext_link_filename, H5_API_TEST_FILENAME_MAX_LENGTH, "%s%s", test_path_prefix, EXTERNAL_LINK_TEST_FILE_NAME);
+            snprintf(ext_link_filename, H5_API_TEST_FILENAME_MAX_LENGTH, "%s%s", test_path_prefix,
+                     EXTERNAL_LINK_TEST_FILE_NAME);
 
             if ((ext_file_id = H5Fcreate(ext_link_filename, H5F_ACC_TRUNC, H5P_DEFAULT, H5P_DEFAULT)) < 0) {
                 H5_FAILED();
@@ -6270,7 +6343,8 @@ test_delete_link(void)
             TESTING_2("H5Ldelete_by_idx on external link by alphabetical order in increasing order");
 
             /* Create file for external link to reference */
-            snprintf(ext_link_filename, H5_API_TEST_FILENAME_MAX_LENGTH, "%s%s", test_path_prefix, EXTERNAL_LINK_TEST_FILE_NAME);
+            snprintf(ext_link_filename, H5_API_TEST_FILENAME_MAX_LENGTH, "%s%s", test_path_prefix,
+                     EXTERNAL_LINK_TEST_FILE_NAME);
 
             if ((ext_file_id = H5Fcreate(ext_link_filename, H5F_ACC_TRUNC, H5P_DEFAULT, H5P_DEFAULT)) < 0) {
                 H5_FAILED();
@@ -6545,7 +6619,8 @@ test_delete_link(void)
             TESTING_2("H5Ldelete_by_idx on external link by alphabetical order in decreasing order");
 
             /* Create file for external link to reference */
-            snprintf(ext_link_filename, H5_API_TEST_FILENAME_MAX_LENGTH, "%s%s", test_path_prefix, EXTERNAL_LINK_TEST_FILE_NAME);
+            snprintf(ext_link_filename, H5_API_TEST_FILENAME_MAX_LENGTH, "%s%s", test_path_prefix,
+                     EXTERNAL_LINK_TEST_FILE_NAME);
 
             if ((ext_file_id = H5Fcreate(ext_link_filename, H5F_ACC_TRUNC, H5P_DEFAULT, H5P_DEFAULT)) < 0) {
                 H5_FAILED();
@@ -8253,7 +8328,8 @@ test_copy_link(void)
         {
             TESTING_2("H5Lcopy on external link (copied link's properties not checked)");
 
-            snprintf(ext_link_filename, H5_API_TEST_FILENAME_MAX_LENGTH, "%s%s", test_path_prefix, EXTERNAL_LINK_TEST_FILE_NAME);
+            snprintf(ext_link_filename, H5_API_TEST_FILENAME_MAX_LENGTH, "%s%s", test_path_prefix,
+                     EXTERNAL_LINK_TEST_FILE_NAME);
 
             if ((ext_file_id = H5Fcreate(ext_link_filename, H5F_ACC_TRUNC, H5P_DEFAULT, H5P_DEFAULT)) < 0) {
                 H5_FAILED();
@@ -8361,7 +8437,8 @@ test_copy_link(void)
 
             TESTING_2("H5Lcopy on external link (copied link's properties checked)");
 
-            snprintf(ext_link_filename, H5_API_TEST_FILENAME_MAX_LENGTH, "%s%s", test_path_prefix, EXTERNAL_LINK_TEST_FILE_NAME);
+            snprintf(ext_link_filename, H5_API_TEST_FILENAME_MAX_LENGTH, "%s%s", test_path_prefix,
+                     EXTERNAL_LINK_TEST_FILE_NAME);
 
             if ((ext_file_id = H5Fcreate(ext_link_filename, H5F_ACC_TRUNC, H5P_DEFAULT, H5P_DEFAULT)) < 0) {
                 H5_FAILED();
@@ -8564,7 +8641,8 @@ test_copy_link(void)
         {
             TESTING_2("H5Lcopy on external link using H5L_SAME_LOC");
 
-            snprintf(ext_link_filename, H5_API_TEST_FILENAME_MAX_LENGTH, "%s%s", test_path_prefix, EXTERNAL_LINK_TEST_FILE_NAME);
+            snprintf(ext_link_filename, H5_API_TEST_FILENAME_MAX_LENGTH, "%s%s", test_path_prefix,
+                     EXTERNAL_LINK_TEST_FILE_NAME);
 
             if ((ext_file_id = H5Fcreate(ext_link_filename, H5F_ACC_TRUNC, H5P_DEFAULT, H5P_DEFAULT)) < 0) {
                 H5_FAILED();
@@ -9081,7 +9159,8 @@ test_copy_link_invalid_params(void)
         {
             TESTING_2("H5Lcopy invalid across files");
 
-            snprintf(ext_link_filename, H5_API_TEST_FILENAME_MAX_LENGTH, "%s%s", test_path_prefix, EXTERNAL_LINK_TEST_FILE_NAME);
+            snprintf(ext_link_filename, H5_API_TEST_FILENAME_MAX_LENGTH, "%s%s", test_path_prefix,
+                     EXTERNAL_LINK_TEST_FILE_NAME);
 
             if ((ext_file_id = H5Fcreate(ext_link_filename, H5F_ACC_TRUNC, H5P_DEFAULT, H5P_DEFAULT)) < 0) {
                 H5_FAILED();
@@ -9175,7 +9254,8 @@ test_move_link(void)
 
     TESTING_2("test setup");
 
-    snprintf(ext_link_filename, H5_API_TEST_FILENAME_MAX_LENGTH, "%s%s", test_path_prefix, EXTERNAL_LINK_TEST_FILE_NAME);
+    snprintf(ext_link_filename, H5_API_TEST_FILENAME_MAX_LENGTH, "%s%s", test_path_prefix,
+             EXTERNAL_LINK_TEST_FILE_NAME);
 
     if ((file_id = H5Fopen(H5_api_test_filename, H5F_ACC_RDWR, H5P_DEFAULT)) < 0) {
         H5_FAILED();
@@ -10056,7 +10136,8 @@ test_move_link(void)
         {
             TESTING_2("H5Lmove on external link (moved link's properties not checked)");
 
-            snprintf(ext_link_filename, H5_API_TEST_FILENAME_MAX_LENGTH, "%s%s", test_path_prefix, EXTERNAL_LINK_TEST_FILE_NAME);
+            snprintf(ext_link_filename, H5_API_TEST_FILENAME_MAX_LENGTH, "%s%s", test_path_prefix,
+                     EXTERNAL_LINK_TEST_FILE_NAME);
 
             if ((ext_file_id = H5Fcreate(ext_link_filename, H5F_ACC_TRUNC, H5P_DEFAULT, H5P_DEFAULT)) < 0) {
                 H5_FAILED();
@@ -10164,7 +10245,8 @@ test_move_link(void)
 
             TESTING_2("H5Lmove on external link (moved link's properties checked)");
 
-            snprintf(ext_link_filename, H5_API_TEST_FILENAME_MAX_LENGTH, "%s%s", test_path_prefix, EXTERNAL_LINK_TEST_FILE_NAME);
+            snprintf(ext_link_filename, H5_API_TEST_FILENAME_MAX_LENGTH, "%s%s", test_path_prefix,
+                     EXTERNAL_LINK_TEST_FILE_NAME);
 
             if ((ext_file_id = H5Fcreate(ext_link_filename, H5F_ACC_TRUNC, H5P_DEFAULT, H5P_DEFAULT)) < 0) {
                 H5_FAILED();
@@ -10367,7 +10449,8 @@ test_move_link(void)
         {
             TESTING_2("H5Lmove on external link using H5L_SAME_LOC");
 
-            snprintf(ext_link_filename, H5_API_TEST_FILENAME_MAX_LENGTH, "%s%s", test_path_prefix, EXTERNAL_LINK_TEST_FILE_NAME);
+            snprintf(ext_link_filename, H5_API_TEST_FILENAME_MAX_LENGTH, "%s%s", test_path_prefix,
+                     EXTERNAL_LINK_TEST_FILE_NAME);
 
             if ((ext_file_id = H5Fcreate(ext_link_filename, H5F_ACC_TRUNC, H5P_DEFAULT, H5P_DEFAULT)) < 0) {
                 H5_FAILED();
@@ -10505,7 +10588,8 @@ test_move_link(void)
         {
             TESTING_2("H5Lmove to rename external link without moving it");
 
-            snprintf(ext_link_filename, H5_API_TEST_FILENAME_MAX_LENGTH, "%s%s", test_path_prefix, EXTERNAL_LINK_TEST_FILE_NAME);
+            snprintf(ext_link_filename, H5_API_TEST_FILENAME_MAX_LENGTH, "%s%s", test_path_prefix,
+                     EXTERNAL_LINK_TEST_FILE_NAME);
 
             if ((ext_file_id = H5Fcreate(ext_link_filename, H5F_ACC_TRUNC, H5P_DEFAULT, H5P_DEFAULT)) < 0) {
                 H5_FAILED();
@@ -11389,7 +11473,8 @@ test_move_link_invalid_params(void)
         {
             TESTING_2("H5Lmove into another file");
 
-            snprintf(ext_link_filename, H5_API_TEST_FILENAME_MAX_LENGTH, "%s%s", test_path_prefix, EXTERNAL_LINK_TEST_FILE_NAME);
+            snprintf(ext_link_filename, H5_API_TEST_FILENAME_MAX_LENGTH, "%s%s", test_path_prefix,
+                     EXTERNAL_LINK_TEST_FILE_NAME);
 
             if ((ext_file_id = H5Fcreate(ext_link_filename, H5F_ACC_TRUNC, H5P_DEFAULT, H5P_DEFAULT)) < 0) {
                 H5_FAILED();
@@ -11628,7 +11713,8 @@ test_get_link_val(void)
 
             memset(&link_info, 0, sizeof(link_info));
 
-            snprintf(ext_link_filename, H5_API_TEST_FILENAME_MAX_LENGTH, "%s%s", test_path_prefix, EXTERNAL_LINK_TEST_FILE_NAME);
+            snprintf(ext_link_filename, H5_API_TEST_FILENAME_MAX_LENGTH, "%s%s", test_path_prefix,
+                     EXTERNAL_LINK_TEST_FILE_NAME);
 
             if ((ext_file_id = H5Fcreate(ext_link_filename, H5F_ACC_TRUNC, H5P_DEFAULT, H5P_DEFAULT)) < 0) {
                 H5_FAILED();
@@ -12526,7 +12612,8 @@ test_get_link_val(void)
                 PART_EMPTY(H5Lget_val_by_idx_external_crt_order_increasing);
             }
 
-            snprintf(ext_link_filename, H5_API_TEST_FILENAME_MAX_LENGTH, "%s%s", test_path_prefix, EXTERNAL_LINK_TEST_FILE_NAME);
+            snprintf(ext_link_filename, H5_API_TEST_FILENAME_MAX_LENGTH, "%s%s", test_path_prefix,
+                     EXTERNAL_LINK_TEST_FILE_NAME);
 
             if ((ext_file_id = H5Fcreate(ext_link_filename, H5F_ACC_TRUNC, H5P_DEFAULT, H5P_DEFAULT)) < 0) {
                 H5_FAILED();
@@ -12775,7 +12862,8 @@ test_get_link_val(void)
                 PART_EMPTY(H5Lget_val_by_idx_external_crt_order_decreasing);
             }
 
-            snprintf(ext_link_filename, H5_API_TEST_FILENAME_MAX_LENGTH, "%s%s", test_path_prefix, EXTERNAL_LINK_TEST_FILE_NAME);
+            snprintf(ext_link_filename, H5_API_TEST_FILENAME_MAX_LENGTH, "%s%s", test_path_prefix,
+                     EXTERNAL_LINK_TEST_FILE_NAME);
 
             if ((ext_file_id = H5Fcreate(ext_link_filename, H5F_ACC_TRUNC, H5P_DEFAULT, H5P_DEFAULT)) < 0) {
                 H5_FAILED();
@@ -13018,7 +13106,8 @@ test_get_link_val(void)
 
             TESTING_2("H5Lget_val_by_idx on external link by alphabetical order in increasing order");
 
-            snprintf(ext_link_filename, H5_API_TEST_FILENAME_MAX_LENGTH, "%s%s", test_path_prefix, EXTERNAL_LINK_TEST_FILE_NAME);
+            snprintf(ext_link_filename, H5_API_TEST_FILENAME_MAX_LENGTH, "%s%s", test_path_prefix,
+                     EXTERNAL_LINK_TEST_FILE_NAME);
 
             if ((ext_file_id = H5Fcreate(ext_link_filename, H5F_ACC_TRUNC, H5P_DEFAULT, H5P_DEFAULT)) < 0) {
                 H5_FAILED();
@@ -13261,7 +13350,8 @@ test_get_link_val(void)
 
             TESTING_2("H5Lget_val_by_idx on external link by alphabetical order in decreasing order");
 
-            snprintf(ext_link_filename, H5_API_TEST_FILENAME_MAX_LENGTH, "%s%s", test_path_prefix, EXTERNAL_LINK_TEST_FILE_NAME);
+            snprintf(ext_link_filename, H5_API_TEST_FILENAME_MAX_LENGTH, "%s%s", test_path_prefix,
+                     EXTERNAL_LINK_TEST_FILE_NAME);
 
             if ((ext_file_id = H5Fcreate(ext_link_filename, H5F_ACC_TRUNC, H5P_DEFAULT, H5P_DEFAULT)) < 0) {
                 H5_FAILED();
@@ -14168,7 +14258,8 @@ test_get_link_info(void)
 
             memset(&link_info, 0, sizeof(link_info));
 
-            snprintf(ext_link_filename, H5_API_TEST_FILENAME_MAX_LENGTH, "%s%s", test_path_prefix, EXTERNAL_LINK_TEST_FILE_NAME);
+            snprintf(ext_link_filename, H5_API_TEST_FILENAME_MAX_LENGTH, "%s%s", test_path_prefix,
+                     EXTERNAL_LINK_TEST_FILE_NAME);
 
             if ((ext_file_id = H5Fcreate(ext_link_filename, H5F_ACC_TRUNC, H5P_DEFAULT, H5P_DEFAULT)) < 0) {
                 H5_FAILED();
@@ -15733,7 +15824,8 @@ test_get_link_info(void)
                 PART_EMPTY(H5Lget_info_by_idx_external_crt_order_increasing);
             }
 
-            snprintf(ext_link_filename, H5_API_TEST_FILENAME_MAX_LENGTH, "%s%s", test_path_prefix, EXTERNAL_LINK_TEST_FILE_NAME);
+            snprintf(ext_link_filename, H5_API_TEST_FILENAME_MAX_LENGTH, "%s%s", test_path_prefix,
+                     EXTERNAL_LINK_TEST_FILE_NAME);
 
             if ((ext_file_id = H5Fcreate(ext_link_filename, H5F_ACC_TRUNC, H5P_DEFAULT, H5P_DEFAULT)) < 0) {
                 H5_FAILED();
@@ -15936,7 +16028,8 @@ test_get_link_info(void)
                 PART_EMPTY(H5Lget_info_by_idx_external_crt_order_decreasing);
             }
 
-            snprintf(ext_link_filename, H5_API_TEST_FILENAME_MAX_LENGTH, "%s%s", test_path_prefix, EXTERNAL_LINK_TEST_FILE_NAME);
+            snprintf(ext_link_filename, H5_API_TEST_FILENAME_MAX_LENGTH, "%s%s", test_path_prefix,
+                     EXTERNAL_LINK_TEST_FILE_NAME);
 
             if ((ext_file_id = H5Fcreate(ext_link_filename, H5F_ACC_TRUNC, H5P_DEFAULT, H5P_DEFAULT)) < 0) {
                 H5_FAILED();
@@ -16133,7 +16226,8 @@ test_get_link_info(void)
         {
             TESTING_2("H5Lget_info_by_idx2 on external link by alphabetical order in increasing order");
 
-            snprintf(ext_link_filename, H5_API_TEST_FILENAME_MAX_LENGTH, "%s%s", test_path_prefix, EXTERNAL_LINK_TEST_FILE_NAME);
+            snprintf(ext_link_filename, H5_API_TEST_FILENAME_MAX_LENGTH, "%s%s", test_path_prefix,
+                     EXTERNAL_LINK_TEST_FILE_NAME);
 
             if ((ext_file_id = H5Fcreate(ext_link_filename, H5F_ACC_TRUNC, H5P_DEFAULT, H5P_DEFAULT)) < 0) {
                 H5_FAILED();
@@ -16336,7 +16430,8 @@ test_get_link_info(void)
         {
             TESTING_2("H5Lget_info_by_idx2 on external link by alphabetical order in decreasing order");
 
-            snprintf(ext_link_filename, H5_API_TEST_FILENAME_MAX_LENGTH, "%s%s", test_path_prefix, EXTERNAL_LINK_TEST_FILE_NAME);
+            snprintf(ext_link_filename, H5_API_TEST_FILENAME_MAX_LENGTH, "%s%s", test_path_prefix,
+                     EXTERNAL_LINK_TEST_FILE_NAME);
 
             if ((ext_file_id = H5Fcreate(ext_link_filename, H5F_ACC_TRUNC, H5P_DEFAULT, H5P_DEFAULT)) < 0) {
                 H5_FAILED();
@@ -18362,7 +18457,8 @@ test_get_link_name(void)
             }
 
             /* Create file for external link to reference */
-            snprintf(ext_link_filename, H5_API_TEST_FILENAME_MAX_LENGTH, "%s%s", test_path_prefix, EXTERNAL_LINK_TEST_FILE_NAME);
+            snprintf(ext_link_filename, H5_API_TEST_FILENAME_MAX_LENGTH, "%s%s", test_path_prefix,
+                     EXTERNAL_LINK_TEST_FILE_NAME);
 
             if ((ext_file_id = H5Fcreate(ext_link_filename, H5F_ACC_TRUNC, H5P_DEFAULT, H5P_DEFAULT)) < 0) {
                 H5_FAILED();
@@ -18550,7 +18646,8 @@ test_get_link_name(void)
             }
 
             /* Create file for external link to reference */
-            snprintf(ext_link_filename, H5_API_TEST_FILENAME_MAX_LENGTH, "%s%s", test_path_prefix, EXTERNAL_LINK_TEST_FILE_NAME);
+            snprintf(ext_link_filename, H5_API_TEST_FILENAME_MAX_LENGTH, "%s%s", test_path_prefix,
+                     EXTERNAL_LINK_TEST_FILE_NAME);
 
             if ((ext_file_id = H5Fcreate(ext_link_filename, H5F_ACC_TRUNC, H5P_DEFAULT, H5P_DEFAULT)) < 0) {
                 H5_FAILED();
@@ -18732,7 +18829,8 @@ test_get_link_name(void)
             TESTING_2("H5Lget_name_by_idx on external link by alphabetical order in increasing order");
 
             /* Create file for external link to reference */
-            snprintf(ext_link_filename, H5_API_TEST_FILENAME_MAX_LENGTH, "%s%s", test_path_prefix, EXTERNAL_LINK_TEST_FILE_NAME);
+            snprintf(ext_link_filename, H5_API_TEST_FILENAME_MAX_LENGTH, "%s%s", test_path_prefix,
+                     EXTERNAL_LINK_TEST_FILE_NAME);
 
             if ((ext_file_id = H5Fcreate(ext_link_filename, H5F_ACC_TRUNC, H5P_DEFAULT, H5P_DEFAULT)) < 0) {
                 H5_FAILED();
@@ -18914,7 +19012,8 @@ test_get_link_name(void)
             TESTING_2("H5Lget_name_by_idx on external link by alphabetical order in decreasing order");
 
             /* Create file for external link to reference */
-            snprintf(ext_link_filename, H5_API_TEST_FILENAME_MAX_LENGTH, "%s%s", test_path_prefix, EXTERNAL_LINK_TEST_FILE_NAME);
+            snprintf(ext_link_filename, H5_API_TEST_FILENAME_MAX_LENGTH, "%s%s", test_path_prefix,
+                     EXTERNAL_LINK_TEST_FILE_NAME);
 
             if ((ext_file_id = H5Fcreate(ext_link_filename, H5F_ACC_TRUNC, H5P_DEFAULT, H5P_DEFAULT)) < 0) {
                 H5_FAILED();
@@ -20215,7 +20314,8 @@ test_link_iterate_external_links(void)
 
     TESTING_2("test setup");
 
-    snprintf(ext_link_filename, H5_API_TEST_FILENAME_MAX_LENGTH, "%s%s", test_path_prefix, EXTERNAL_LINK_TEST_FILE_NAME);
+    snprintf(ext_link_filename, H5_API_TEST_FILENAME_MAX_LENGTH, "%s%s", test_path_prefix,
+             EXTERNAL_LINK_TEST_FILE_NAME);
 
     if ((file_id = H5Fcreate(ext_link_filename, H5F_ACC_TRUNC, H5P_DEFAULT, H5P_DEFAULT)) < 0) {
         H5_FAILED();
@@ -20612,7 +20712,8 @@ test_link_iterate_mixed_links(void)
 
     TESTING_2("test setup");
 
-    snprintf(ext_link_filename, H5_API_TEST_FILENAME_MAX_LENGTH, "%s%s", test_path_prefix, EXTERNAL_LINK_TEST_FILE_NAME);
+    snprintf(ext_link_filename, H5_API_TEST_FILENAME_MAX_LENGTH, "%s%s", test_path_prefix,
+             EXTERNAL_LINK_TEST_FILE_NAME);
 
     if ((file_id = H5Fcreate(ext_link_filename, H5F_ACC_TRUNC, H5P_DEFAULT, H5P_DEFAULT)) < 0) {
         H5_FAILED();
@@ -21098,7 +21199,8 @@ test_link_iterate_invalid_params(void)
 
     TESTING_2("test setup");
 
-    snprintf(ext_link_filename, H5_API_TEST_FILENAME_MAX_LENGTH, "%s%s", test_path_prefix, EXTERNAL_LINK_TEST_FILE_NAME);
+    snprintf(ext_link_filename, H5_API_TEST_FILENAME_MAX_LENGTH, "%s%s", test_path_prefix,
+             EXTERNAL_LINK_TEST_FILE_NAME);
 
     if ((file_id = H5Fcreate(ext_link_filename, H5F_ACC_TRUNC, H5P_DEFAULT, H5P_DEFAULT)) < 0) {
         H5_FAILED();
@@ -22525,7 +22627,8 @@ test_link_visit_external_links_no_cycles(void)
 
     TESTING_2("test setup");
 
-    snprintf(ext_link_filename, H5_API_TEST_FILENAME_MAX_LENGTH, "%s%s", test_path_prefix, EXTERNAL_LINK_TEST_FILE_NAME);
+    snprintf(ext_link_filename, H5_API_TEST_FILENAME_MAX_LENGTH, "%s%s", test_path_prefix,
+             EXTERNAL_LINK_TEST_FILE_NAME);
 
     if ((file_id = H5Fcreate(ext_link_filename, H5F_ACC_TRUNC, H5P_DEFAULT, H5P_DEFAULT)) < 0) {
         H5_FAILED();
@@ -22953,7 +23056,8 @@ test_link_visit_mixed_links_no_cycles(void)
 
     TESTING_2("test setup");
 
-    snprintf(ext_link_filename, H5_API_TEST_FILENAME_MAX_LENGTH, "%s%s", test_path_prefix, EXTERNAL_LINK_TEST_FILE_NAME);
+    snprintf(ext_link_filename, H5_API_TEST_FILENAME_MAX_LENGTH, "%s%s", test_path_prefix,
+             EXTERNAL_LINK_TEST_FILE_NAME);
 
     if ((file_id = H5Fcreate(ext_link_filename, H5F_ACC_TRUNC, H5P_DEFAULT, H5P_DEFAULT)) < 0) {
         H5_FAILED();
@@ -24593,7 +24697,8 @@ test_link_visit_mixed_links_cycles(void)
 
     TESTING_2("test setup");
 
-    snprintf(ext_link_filename, H5_API_TEST_FILENAME_MAX_LENGTH, "%s%s", test_path_prefix, EXTERNAL_LINK_TEST_FILE_NAME);
+    snprintf(ext_link_filename, H5_API_TEST_FILENAME_MAX_LENGTH, "%s%s", test_path_prefix,
+             EXTERNAL_LINK_TEST_FILE_NAME);
 
     if ((file_id = H5Fcreate(ext_link_filename, H5F_ACC_TRUNC, H5P_DEFAULT, H5P_DEFAULT)) < 0) {
         H5_FAILED();
@@ -25030,7 +25135,8 @@ test_link_visit_invalid_params(void)
 
     TESTING_2("test setup");
 
-    snprintf(ext_link_filename, H5_API_TEST_FILENAME_MAX_LENGTH, "%s%s", test_path_prefix, EXTERNAL_LINK_TEST_FILE_NAME);
+    snprintf(ext_link_filename, H5_API_TEST_FILENAME_MAX_LENGTH, "%s%s", test_path_prefix,
+             EXTERNAL_LINK_TEST_FILE_NAME);
 
     if ((file_id = H5Fcreate(ext_link_filename, H5F_ACC_TRUNC, H5P_DEFAULT, H5P_DEFAULT)) < 0) {
         H5_FAILED();

--- a/test/API/H5_api_link_test.c
+++ b/test/API/H5_api_link_test.c
@@ -2778,19 +2778,15 @@ test_create_external_link_ping_pong(void)
                 PART_ERROR(H5Lcreate_external_verify);
             }
 
-            for (size_t i = 1; i < EXTERNAL_LINK_TEST_PING_PONG_NUM_LINKS + 1; i++) {
+            for (size_t i = 1; i < EXTERNAL_LINK_TEST_PING_PONG_NUM_LINKS + 1 && !valid_name_matched; i++) {
                 char name_possibility[H5_API_TEST_FILENAME_MAX_LENGTH];
 
                 snprintf(name_possibility, H5_API_TEST_FILENAME_MAX_LENGTH, "%s%zu", "/link", i);
 
-                if (!strcmp(name_possibility, objname)) {
-                    valid_name_matched = true;
-                    break;
-                }
+                valid_name_matched |= !strcmp(name_possibility, objname);
             }
 
-            if (!strcmp(objname, "/final"))
-                valid_name_matched = true;
+            valid_name_matched |= !strcmp(objname, "/final");
 
             if (!valid_name_matched) {
                 H5_FAILED();
@@ -2852,16 +2848,16 @@ test_create_external_link_ping_pong(void)
                 PART_ERROR(H5Lcreate_external_verify_again);
             }
 
-            for (size_t i = 1; i < EXTERNAL_LINK_TEST_PING_PONG_NUM_LINKS + 1; i++) {
+            for (size_t i = 1; i < EXTERNAL_LINK_TEST_PING_PONG_NUM_LINKS + 1 && !valid_name_matched; i++) {
                 char name_possibility[H5_API_TEST_FILENAME_MAX_LENGTH];
 
                 snprintf(name_possibility, H5_API_TEST_FILENAME_MAX_LENGTH, "%s%zu%s", "/link", i,
                          "/new_group");
 
-                valid_name_matched = !strcmp(objname, name_possibility) || valid_name_matched;
+                valid_name_matched |= !strcmp(objname, name_possibility);
             }
 
-            valid_name_matched = !strcmp(objname, "/final/new_group") || valid_name_matched;
+            valid_name_matched |= !strcmp(objname, "/final/new_group");
 
             if (!valid_name_matched) {
                 H5_FAILED();
@@ -20407,11 +20403,9 @@ test_link_iterate_external_links(void)
         {
             TESTING_2("H5Literate2 by link name in increasing order");
 
-            if (!(vol_cap_flags_g & H5VL_CAP_FLAG_CREATION_ORDER) ||
-                !(vol_cap_flags_g & H5VL_CAP_FLAG_EXTERNAL_LINKS)) {
+            if (!(vol_cap_flags_g & H5VL_CAP_FLAG_EXTERNAL_LINKS)) {
                 SKIPPED();
-                printf("    creation order tracking or the external link API aren't supported with this VOL "
-                       "connector\n");
+                printf("    external link API is not supported with this VOL connector\n");
                 PART_EMPTY(H5Literate_link_name_increasing);
             }
 
@@ -20439,11 +20433,9 @@ test_link_iterate_external_links(void)
         {
             TESTING_2("H5Literate2 by link name in decreasing order");
 
-            if (!(vol_cap_flags_g & H5VL_CAP_FLAG_CREATION_ORDER) ||
-                !(vol_cap_flags_g & H5VL_CAP_FLAG_EXTERNAL_LINKS)) {
+            if (!(vol_cap_flags_g & H5VL_CAP_FLAG_EXTERNAL_LINKS)) {
                 SKIPPED();
-                printf("    creation order tracking or the external link API aren't supported with this VOL "
-                       "connector\n");
+                printf("    external link API is not supported with this VOL connector\n");
                 PART_EMPTY(H5Literate_link_name_decreasing);
             }
 
@@ -20535,11 +20527,9 @@ test_link_iterate_external_links(void)
         {
             TESTING_2("H5Literate_by_name2 by link name in increasing order");
 
-            if (!(vol_cap_flags_g & H5VL_CAP_FLAG_CREATION_ORDER) ||
-                !(vol_cap_flags_g & H5VL_CAP_FLAG_EXTERNAL_LINKS)) {
+            if (!(vol_cap_flags_g & H5VL_CAP_FLAG_EXTERNAL_LINKS)) {
                 SKIPPED();
-                printf("    creation order tracking or the external link API aren't supported with this VOL "
-                       "connector\n");
+                printf("    the external link API is not supported with this VOL connector\n");
                 PART_EMPTY(H5Literate_by_name_link_name_increasing);
             }
 
@@ -21011,12 +21001,10 @@ test_link_iterate_mixed_links(void)
         {
             TESTING_2("H5Literate_by_name2 by link name in increasing order");
 
-            if (!(vol_cap_flags_g & H5VL_CAP_FLAG_CREATION_ORDER) ||
-                !(vol_cap_flags_g & H5VL_CAP_FLAG_EXTERNAL_LINKS) ||
-                !(vol_cap_flags_g & H5VL_CAP_FLAG_UD_LINKS)) {
+            if (!(vol_cap_flags_g & H5VL_CAP_FLAG_EXTERNAL_LINKS) || 
+                !(vol_cap_flags_g & H5VL_CAP_FLAG_UD_LINKS) ) {
                 SKIPPED();
-                printf("    creation order tracking, external links, or user-defined links aren't supported "
-                       "with this VOL connector\n");
+                printf("    external links or user-defined links aren't supported with this VOL connector\n");
                 PART_EMPTY(H5Literate_by_name_link_name_increasing);
             }
 
@@ -21044,12 +21032,10 @@ test_link_iterate_mixed_links(void)
         {
             TESTING_2("H5Literate_by_name2 by link name in decreasing order");
 
-            if (!(vol_cap_flags_g & H5VL_CAP_FLAG_CREATION_ORDER) ||
-                !(vol_cap_flags_g & H5VL_CAP_FLAG_EXTERNAL_LINKS) ||
-                !(vol_cap_flags_g & H5VL_CAP_FLAG_UD_LINKS)) {
+            if (!(vol_cap_flags_g & H5VL_CAP_FLAG_EXTERNAL_LINKS) || 
+                !(vol_cap_flags_g & H5VL_CAP_FLAG_UD_LINKS) ) {
                 SKIPPED();
-                printf("    creation order tracking, external links, or user-defined links aren't supported "
-                       "with this VOL connector\n");
+                printf("    external links or user-defined links aren't supported with this VOL connector\n");
                 PART_EMPTY(H5Literate_by_name_link_name_decreasing);
             }
 

--- a/test/API/H5_api_link_test.h
+++ b/test/API/H5_api_link_test.h
@@ -29,9 +29,10 @@ int H5_api_link_test(void);
 #define HARD_LINK_TEST_GROUP_LONG_NAME "hard_link_long_name"
 #define MAX_NAME_LEN                   ((64 * 1024) + 1024)
 
-#define HARD_LINK_TEST_GROUP_MANY_NAME          "hard_link_many_name"
-#define HARD_LINK_TEST_GROUP_MANY_FINAL_NAME    "hard_link_final"
-#define HARD_LINK_TEST_GROUP_MANY_NAME_BUF_SIZE 1024
+#define HARD_LINK_TEST_GROUP_MANY_NAME           "hard_link_many_name"
+#define HARD_LINK_TEST_GROUP_MANY_FINAL_NAME     "hard_link_final"
+#define HARD_LINK_TEST_GROUP_MANY_NAME_BUF_SIZE  1024
+#define HARD_LINK_TEST_GROUP_MANY_NUM_HARD_LINKS 21
 
 #define H5L_SAME_LOC_TEST_GROUP_NAME "h5l_same_loc_test_group"
 #define H5L_SAME_LOC_TEST_LINK_NAME1 "h5l_same_loc_test_link1"
@@ -58,9 +59,10 @@ int H5_api_link_test(void);
 #define SOFT_LINK_TEST_GROUP_LONG_NAME  "soft_link_long_name"
 #define SOFT_LINK_TEST_LONG_OBJECT_NAME "soft_link_object_name"
 
-#define SOFT_LINK_TEST_GROUP_MANY_NAME          "soft_link_many_name"
-#define SOFT_LINK_TEST_GROUP_MANY_FINAL_NAME    "soft_link_final"
-#define SOFT_LINK_TEST_GROUP_MANY_NAME_BUF_SIZE 1024
+#define SOFT_LINK_TEST_GROUP_MANY_NAME                 "soft_link_many_name"
+#define SOFT_LINK_TEST_GROUP_MANY_FINAL_NAME           "soft_link_final"
+#define SOFT_LINK_TEST_GROUP_MANY_NAME_BUF_SIZE        1024
+#define SOFT_LINK_TEST_GROUP_MANY_NAME_SOFT_LINK_COUNT 16
 
 #define SOFT_LINK_INVALID_PARAMS_TEST_GROUP_NAME "soft_link_creation_invalid_params_test"
 #define SOFT_LINK_INVALID_PARAMS_TEST_LINK_NAME  "soft_link_to_root"
@@ -82,6 +84,7 @@ int H5_api_link_test(void);
 #define EXTERNAL_LINK_TEST_PING_PONG_NAME1         "ext_link_file_ping_pong_1.h5"
 #define EXTERNAL_LINK_TEST_PING_PONG_NAME2         "ext_link_file_ping_pong_2.h5"
 #define EXTERNAL_LINK_TEST_PING_PONG_NAME_BUF_SIZE 1024
+#define EXTERNAL_LINK_TEST_PING_PONG_NUM_LINKS     6
 
 #define EXTERNAL_LINK_INVALID_PARAMS_TEST_GROUP_NAME "external_link_creation_invalid_params_test"
 #define EXTERNAL_LINK_INVALID_PARAMS_TEST_FILE_NAME  "ext_link_invalid_params_file.h5"


### PR DESCRIPTION
* Fixed some external link tests not prepending the API  test prefix to the filename.
* Modified link tests that use `H5Iget_name` to accept any of the valid names for the target object, since [the API](https://docs.hdfgroup.org/hdf5/develop/group___h5_i.html#title6) does not specify which of an object's possible names will be returned.
* Fixed link iteration test counting skips as failures due to doing the capability flag checks from within the link callbacks. Now, the capability flags are checked before the link iteration is performed. 