### PR TITLE
Don't try to load general-19 warnings file for icc

### DIFF
--- a/config/intel-cxxflags
+++ b/config/intel-cxxflags
@@ -166,12 +166,6 @@ if test "X-icpc" = "X-$cxx_vendor"; then
         H5_CXXFLAGS="$H5_CXXFLAGS $(load_intel_arguments classic/18)"
     fi
 
-    # intel <= 19
-    if test $cxx_vers_major -le 19; then
-        # Use the C warnings as CXX warnings are the same
-        H5_CXXFLAGS="$H5_CXXFLAGS $(load_intel_arguments classic/general-19)"
-    fi
-
     #################
     # Flags are set #
     #################

--- a/config/intel-flags
+++ b/config/intel-flags
@@ -161,12 +161,6 @@ if test "X-icc" = "X-$cc_vendor"; then
         H5_CFLAGS="$H5_CFLAGS $(load_intel_arguments classic/18)"
     fi
 
-    # intel <= 19
-    # this file has warnings only available before oneapi versions
-    if test $cc_vers_major -le 19; then
-        H5_CFLAGS="$H5_CFLAGS $(load_intel_arguments classic/general-19)"
-    fi
-
     #################
     # Flags are set #
     #################


### PR DESCRIPTION
The Autools Classic Intel compiler configuration attempts to load a file named `general-19` from the intel-warnings/classic directory, which does not exist.

This removes the attempted load of the file.