### PR TITLE
Automatically turn on Subfiling VFD if parallel is enabled in build options

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -723,6 +723,9 @@ if (HDF5_ENABLE_PARALLEL)
                Reading/Writing >2GB of data in a single parallel I/O operation will be disabled.")
       set (LARGE_PARALLEL_IO OFF)
     endif ()
+
+    #Turn on Subfiling VFD
+    set (HDF5_ENABLE_SUBFILING_VFD ON CACHE BOOL "Build Parallel HDF5 Subfiling VFD" FORCE)
   else ()
     message (FATAL_ERROR "Parallel libraries not found")
   endif ()

--- a/configure.ac
+++ b/configure.ac
@@ -3139,6 +3139,10 @@ AC_ARG_ENABLE([subfiling-vfd],
                                [default=no]])],
               [SUBFILING_VFD=$enableval], [SUBFILING_VFD=no])
 
+if test "X${PARALLEL}" == "Xyes"; then
+    SUBFILING_VFD=yes
+fi
+
 if test "X$SUBFILING_VFD" = "Xyes"; then
     AC_MSG_RESULT([yes])
     AC_DEFINE([HAVE_SUBFILING_VFD], [1],


### PR DESCRIPTION
Automatically turn on Subfiling VFD if parallel is enabled in build options in both Autotools and CMake. 

Addresses #3985.