### PR TITLE
Fix issue with FAPL file locking setting inheriting test

### DIFF
--- a/test/h5test.c
+++ b/test/h5test.c
@@ -2068,6 +2068,49 @@ error:
 } /* end h5_check_if_file_locking_enabled() */
 
 /*-------------------------------------------------------------------------
+ * Function:    h5_check_file_locking_env_var
+ *
+ * Purpose:     Checks if the HDF5_USE_FILE_LOCKING file locking
+ *              environment variable is set and parses its value if so.
+ *
+ *              If the environment variable is not set, both `use_locks`
+ *              and `ignore_disabled_locks` will be set to FAIL to indicate
+ *              this. Otherwise, they will each be set appropriately based
+ *              on the setting for the environment variable.
+ *
+ * Return:      Nothing
+ *
+ *-------------------------------------------------------------------------
+ */
+void
+h5_check_file_locking_env_var(htri_t *use_locks, htri_t *ignore_disabled_locks)
+{
+    char *lock_env_var = NULL;
+
+    assert(use_locks);
+    assert(ignore_disabled_locks);
+
+    lock_env_var = getenv(HDF5_USE_FILE_LOCKING);
+    if (lock_env_var && (!strcmp(lock_env_var, "FALSE") || !strcmp(lock_env_var, "0"))) {
+        *use_locks             = false; /* Override: Never use locks */
+        *ignore_disabled_locks = FAIL;
+    }
+    else if (lock_env_var && !strcmp(lock_env_var, "BEST_EFFORT")) {
+        *use_locks             = true; /* Override: Always use locks */
+        *ignore_disabled_locks = true; /* Override: Ignore disabled locks */
+    }
+    else if (lock_env_var && (!strcmp(lock_env_var, "TRUE") || !strcmp(lock_env_var, "1"))) {
+        *use_locks             = true;  /* Override: Always use locks */
+        *ignore_disabled_locks = false; /* Override: Don't ignore disabled locks */
+    }
+    else {
+        /* Environment variable not set, or not set correctly */
+        *use_locks             = FAIL;
+        *ignore_disabled_locks = FAIL;
+    }
+}
+
+/*-------------------------------------------------------------------------
  * Function:    h5_using_native_vol
  *
  * Purpose:     Checks if the VOL connector being used is (or the VOL

--- a/test/h5test.h
+++ b/test/h5test.h
@@ -290,6 +290,7 @@ H5TEST_DLL const char    *h5_get_version_string(H5F_libver_t libver);
 H5TEST_DLL int            h5_compare_file_bytes(char *fname1, char *fname2);
 H5TEST_DLL int            h5_duplicate_file_by_bytes(const char *orig, const char *dest);
 H5TEST_DLL herr_t         h5_check_if_file_locking_enabled(bool *are_enabled);
+H5TEST_DLL void           h5_check_file_locking_env_var(htri_t *use_locks, htri_t *ignore_disabled_locks);
 H5TEST_DLL herr_t         h5_using_native_vol(hid_t fapl_id, hid_t obj_id, bool *is_native_vol);
 H5TEST_DLL bool           h5_using_default_driver(const char *drv_name);
 H5TEST_DLL herr_t         h5_using_parallel_driver(hid_t fapl_id, bool *driver_is_parallel);


### PR DESCRIPTION
Fixes an issue where the HDF5_USE_FILE_LOCKING environment variable being set can interfere with the file locking setting that the test expects to be returned.