### PR TITLE
Fix bin/trace script w/ out params

### DIFF
--- a/bin/trace
+++ b/bin/trace
@@ -318,7 +318,7 @@ sub rewrite_func ($$$$$) {
     $args =~ s/\/\*\s*in\s*\*\///g;  # Get rid of /*in*/
     $args =~ s/\/\*\s*out\s*\*\///g; # Get rid of /*out*/
     $args =~ s/\/\*\s*in,\s*out\s*\*\///g; # Get rid of /*in,out*/
-    $args =~ s/\/\*\s*in_out\s*\*\///g; # Get rid of /*in,out*/
+    $args =~ s/\/\*\s*in_out\s*\*\///g; # Get rid of /*in_out*/
     $args =~ s/H5FL_TRACK_PARAMS//g; # Remove free list macro
     $args =~ s/\n#.*?\n/\n/g;        # Remove lines beginning with '#'
     my @args = split /,[\s\n]*/, $args;

--- a/bin/trace
+++ b/bin/trace
@@ -75,6 +75,7 @@ $Source = "";
                "H5F_file_space_type_t"      => "Ft",
                "H5F_libver_t"               => "Fv",
                "H5G_iterate_t"              => "Gi",
+               "H5G_info_t"                 => "GI",
                "H5G_obj_t"                  => "Go",
                "H5G_stat_t"                 => "Gs",
                "hsize_t"                    => "h",

--- a/bin/trace
+++ b/bin/trace
@@ -31,6 +31,7 @@ $Source = "";
                "H5A_operator1_t"            => "Ao",
                "H5A_operator2_t"            => "AO",
                "hbool_t"                    => "b",
+               "bool"                       => "b",
                "H5AC_cache_config_t"        => "Cc",
                "H5AC_cache_image_config_t"  => "CC",
                "double"                     => "d",

--- a/bin/trace
+++ b/bin/trace
@@ -199,7 +199,7 @@ $Source = "";
                "H5FD_t"                     => "#",
                "H5FD_hdfs_fapl_t"           => "#",
                "H5FD_mirror_fapl_t"         => "#",
-               "H5FD_onion_fapl_t"         => "#",
+               "H5FD_onion_fapl_t"          => "#",
                "H5FD_ros3_fapl_t"           => "#",
                "H5FD_splitter_vfd_config_t" => "#",
                "H5L_class_t"                => "#",
@@ -305,10 +305,18 @@ sub rewrite_func ($$$$$) {
     $trace = "H5TRACE0(\"$rettype\", \"\");\n";
     $argtrace = "H5ARG_TRACE0(\"\")";
   } else {
-    # Split arguments.  First convert `/*in,out*/' to get rid of the
-    # comma and remove lines beginning with a '#', then split the arguments
-    # on commas.
-    $args =~ s/(\/\*\s*in),\s*(out\s*\*\/)/$1_$2/g;     # Get rid of comma in 'in,out'
+    # Split arguments
+    #
+    # First remove:
+    #   * /*in*/, /*out*/, /*in_out*/, and /*in,out*/ comments
+    #   * preprocessor lines that start with #
+    #   * H5FL_TRACKING_PARAMS macros (free list code only)
+    #
+    # then split the function arguments on commas
+    $args =~ s/\/\*\s*in\s*\*\///g;  # Get rid of /*in*/
+    $args =~ s/\/\*\s*out\s*\*\///g; # Get rid of /*out*/
+    $args =~ s/\/\*\s*in,\s*out\s*\*\///g; # Get rid of /*in,out*/
+    $args =~ s/\/\*\s*in_out\s*\*\///g; # Get rid of /*in,out*/
     $args =~ s/H5FL_TRACK_PARAMS//g; # Remove free list macro
     $args =~ s/\n#.*?\n/\n/g;        # Remove lines beginning with '#'
     my @args = split /,[\s\n]*/, $args;
@@ -320,8 +328,7 @@ sub rewrite_func ($$$$$) {
         next;
       }
       unless ($arg=~/^((\s*[a-z_A-Z](\w|\*)*\s+)+(\s*\*\s*|\s*const\s*|\s*volatile\s*)*)
-              ([a-z_A-Z]\w*)(\[.*?\])?
-              (\s*\/\*\s*(in|out|in_out)\s*\*\/)?\s*$/x) {
+              ([a-z_A-Z]\w*)(\[.*?\])?\s*$/x) {
         errmesg $file, $name, "unable to parse \`$arg\'";
         goto error;
       } else {

--- a/src/H5.c
+++ b/src/H5.c
@@ -1216,7 +1216,7 @@ H5is_library_threadsafe(bool *is_ts /*out*/)
     herr_t ret_value = SUCCEED; /* Return value */
 
     FUNC_ENTER_API_NOINIT
-    H5TRACE1("e", "*!", is_ts);
+    H5TRACE1("e", "*b", is_ts);
 
     if (is_ts) {
 #ifdef H5_HAVE_THREADSAFE
@@ -1251,7 +1251,7 @@ H5is_library_terminating(bool *is_terminating /*out*/)
     herr_t ret_value = SUCCEED; /* Return value */
 
     FUNC_ENTER_API_NOINIT
-    H5TRACE1("e", "*!", is_terminating);
+    H5TRACE1("e", "*b", is_terminating);
 
     assert(is_terminating);
 

--- a/src/H5.c
+++ b/src/H5.c
@@ -654,7 +654,7 @@ H5get_free_list_sizes(size_t *reg_size /*out*/, size_t *arr_size /*out*/, size_t
     herr_t ret_value = SUCCEED; /* Return value */
 
     FUNC_ENTER_API(FAIL)
-    H5TRACE4("e", "xxxx", reg_size, arr_size, blk_size, fac_size);
+    H5TRACE4("e", "*z*z*z*z", reg_size, arr_size, blk_size, fac_size);
 
     /* Call the free list function to actually get the sizes */
     if (H5FL_get_free_list_sizes(reg_size, arr_size, blk_size, fac_size) < 0)
@@ -814,7 +814,7 @@ H5get_libversion(unsigned *majnum /*out*/, unsigned *minnum /*out*/, unsigned *r
     herr_t ret_value = SUCCEED;
 
     FUNC_ENTER_API(FAIL)
-    H5TRACE3("e", "xxx", majnum, minnum, relnum);
+    H5TRACE3("e", "*Iu*Iu*Iu", majnum, minnum, relnum);
 
     /* Set the version information */
     if (majnum)
@@ -1216,7 +1216,7 @@ H5is_library_threadsafe(bool *is_ts /*out*/)
     herr_t ret_value = SUCCEED; /* Return value */
 
     FUNC_ENTER_API_NOINIT
-    H5TRACE1("e", "x", is_ts);
+    H5TRACE1("e", "*!", is_ts);
 
     if (is_ts) {
 #ifdef H5_HAVE_THREADSAFE
@@ -1251,7 +1251,7 @@ H5is_library_terminating(bool *is_terminating /*out*/)
     herr_t ret_value = SUCCEED; /* Return value */
 
     FUNC_ENTER_API_NOINIT
-    H5TRACE1("e", "x", is_terminating);
+    H5TRACE1("e", "*!", is_terminating);
 
     assert(is_terminating);
 

--- a/src/H5A.c
+++ b/src/H5A.c
@@ -1036,7 +1036,7 @@ H5Aread(hid_t attr_id, hid_t dtype_id, void *buf /*out*/)
     herr_t ret_value = SUCCEED; /* Return value */
 
     FUNC_ENTER_API(FAIL)
-    H5TRACE3("e", "iix", attr_id, dtype_id, buf);
+    H5TRACE3("e", "ii*x", attr_id, dtype_id, buf);
 
     /* Synchronously read the data */
     if (H5A__read_api_common(attr_id, dtype_id, buf, NULL, NULL) < 0)
@@ -1064,7 +1064,7 @@ H5Aread_async(const char *app_file, const char *app_func, unsigned app_line, hid
     herr_t         ret_value = SUCCEED;         /* Return value */
 
     FUNC_ENTER_API(FAIL)
-    H5TRACE7("e", "*s*sIuiixi", app_file, app_func, app_line, attr_id, dtype_id, buf, es_id);
+    H5TRACE7("e", "*s*sIuii*xi", app_file, app_func, app_line, attr_id, dtype_id, buf, es_id);
 
     /* Set up request token pointer for asynchronous operation */
     if (H5ES_NONE != es_id)
@@ -1078,7 +1078,7 @@ H5Aread_async(const char *app_file, const char *app_func, unsigned app_line, hid
     if (NULL != token)
         /* clang-format off */
         if (H5ES_insert(es_id, vol_obj->connector, token,
-                        H5ARG_TRACE7(__func__, "*s*sIuiixi", app_file, app_func, app_line, attr_id, dtype_id, buf, es_id)) < 0)
+                        H5ARG_TRACE7(__func__, "*s*sIuii*xi", app_file, app_func, app_line, attr_id, dtype_id, buf, es_id)) < 0)
             /* clang-format on */
             HGOTO_ERROR(H5E_ATTR, H5E_CANTINSERT, FAIL, "can't insert token into event set");
 
@@ -1257,7 +1257,7 @@ H5Aget_name(hid_t attr_id, size_t buf_size, char *buf /*out*/)
     ssize_t              ret_value     = -1; /* Return value */
 
     FUNC_ENTER_API((-1))
-    H5TRACE3("Zs", "izx", attr_id, buf_size, buf);
+    H5TRACE3("Zs", "iz*s", attr_id, buf_size, buf);
 
     /* check arguments */
     if (NULL == (vol_obj = (H5VL_object_t *)H5I_object_verify(attr_id, H5I_ATTR)))
@@ -1308,7 +1308,7 @@ H5Aget_name_by_idx(hid_t loc_id, const char *obj_name, H5_index_t idx_type, H5_i
     ssize_t              ret_value;         /* Return value */
 
     FUNC_ENTER_API(FAIL)
-    H5TRACE8("Zs", "i*sIiIohxzi", loc_id, obj_name, idx_type, order, n, name, size, lapl_id);
+    H5TRACE8("Zs", "i*sIiIoh*szi", loc_id, obj_name, idx_type, order, n, name, size, lapl_id);
 
     /* Check args */
     if (H5I_ATTR == H5I_get_type(loc_id))
@@ -1416,7 +1416,7 @@ H5Aget_info(hid_t attr_id, H5A_info_t *ainfo /*out*/)
     herr_t               ret_value = SUCCEED; /* Return value */
 
     FUNC_ENTER_API(FAIL)
-    H5TRACE2("e", "ix", attr_id, ainfo);
+    H5TRACE2("e", "i*Ai", attr_id, ainfo);
 
     /* Check args */
     if (NULL == (vol_obj = (H5VL_object_t *)H5I_object_verify(attr_id, H5I_ATTR)))
@@ -1458,7 +1458,7 @@ H5Aget_info_by_name(hid_t loc_id, const char *obj_name, const char *attr_name, H
     herr_t               ret_value = SUCCEED; /* Return value */
 
     FUNC_ENTER_API(FAIL)
-    H5TRACE5("e", "i*s*sxi", loc_id, obj_name, attr_name, ainfo, lapl_id);
+    H5TRACE5("e", "i*s*s*Aii", loc_id, obj_name, attr_name, ainfo, lapl_id);
 
     /* Check args */
     if (H5I_ATTR == H5I_get_type(loc_id))
@@ -1515,7 +1515,7 @@ H5Aget_info_by_idx(hid_t loc_id, const char *obj_name, H5_index_t idx_type, H5_i
     herr_t               ret_value = SUCCEED; /* Return value */
 
     FUNC_ENTER_API(FAIL)
-    H5TRACE7("e", "i*sIiIohxi", loc_id, obj_name, idx_type, order, n, ainfo, lapl_id);
+    H5TRACE7("e", "i*sIiIoh*Aii", loc_id, obj_name, idx_type, order, n, ainfo, lapl_id);
 
     /* Check args */
     if (H5I_ATTR == H5I_get_type(loc_id))

--- a/src/H5D.c
+++ b/src/H5D.c
@@ -679,7 +679,7 @@ H5Dget_space_status(hid_t dset_id, H5D_space_status_t *allocation /*out*/)
     herr_t                  ret_value = SUCCEED; /* Return value         */
 
     FUNC_ENTER_API(FAIL)
-    H5TRACE2("e", "ix", dset_id, allocation);
+    H5TRACE2("e", "i*Ds", dset_id, allocation);
 
     /* Check args */
     if (NULL == (vol_obj = (H5VL_object_t *)H5I_object_verify(dset_id, H5I_DATASET)))
@@ -1053,7 +1053,7 @@ H5Dread(hid_t dset_id, hid_t mem_type_id, hid_t mem_space_id, hid_t file_space_i
     herr_t ret_value = SUCCEED; /* Return value */
 
     FUNC_ENTER_API(FAIL)
-    H5TRACE6("e", "iiiiix", dset_id, mem_type_id, mem_space_id, file_space_id, dxpl_id, buf);
+    H5TRACE6("e", "iiiii*x", dset_id, mem_type_id, mem_space_id, file_space_id, dxpl_id, buf);
 
     /* Read the data */
     if (H5D__read_api_common(1, &dset_id, &mem_type_id, &mem_space_id, &file_space_id, dxpl_id, &buf, NULL,
@@ -1083,7 +1083,7 @@ H5Dread_async(const char *app_file, const char *app_func, unsigned app_line, hid
     herr_t         ret_value = SUCCEED;         /* Return value */
 
     FUNC_ENTER_API(FAIL)
-    H5TRACE10("e", "*s*sIuiiiiixi", app_file, app_func, app_line, dset_id, mem_type_id, mem_space_id,
+    H5TRACE10("e", "*s*sIuiiiii*xi", app_file, app_func, app_line, dset_id, mem_type_id, mem_space_id,
               file_space_id, dxpl_id, buf, es_id);
 
     /* Set up request token pointer for asynchronous operation */
@@ -1099,7 +1099,7 @@ H5Dread_async(const char *app_file, const char *app_func, unsigned app_line, hid
     if (NULL != token)
         /* clang-format off */
         if (H5ES_insert(es_id, vol_obj->connector, token,
-                        H5ARG_TRACE10(__func__, "*s*sIuiiiiixi", app_file, app_func, app_line, dset_id, mem_type_id, mem_space_id, file_space_id, dxpl_id, buf, es_id)) < 0)
+                        H5ARG_TRACE10(__func__, "*s*sIuiiiii*xi", app_file, app_func, app_line, dset_id, mem_type_id, mem_space_id, file_space_id, dxpl_id, buf, es_id)) < 0)
             /* clang-format on */
             HGOTO_ERROR(H5E_DATASET, H5E_CANTINSERT, FAIL, "can't insert token into event set");
 
@@ -1124,7 +1124,7 @@ H5Dread_multi(size_t count, hid_t dset_id[], hid_t mem_type_id[], hid_t mem_spac
     herr_t ret_value = SUCCEED; /* Return value */
 
     FUNC_ENTER_API(FAIL)
-    H5TRACE7("e", "z*i*i*i*iix", count, dset_id, mem_type_id, mem_space_id, file_space_id, dxpl_id, buf);
+    H5TRACE7("e", "z*i*i*i*ii**x", count, dset_id, mem_type_id, mem_space_id, file_space_id, dxpl_id, buf);
 
     if (count == 0)
         HGOTO_DONE(SUCCEED);
@@ -1159,7 +1159,7 @@ H5Dread_multi_async(const char *app_file, const char *app_func, unsigned app_lin
     herr_t         ret_value = SUCCEED;         /* Return value */
 
     FUNC_ENTER_API(FAIL)
-    H5TRACE11("e", "*s*sIuz*i*i*i*iixi", app_file, app_func, app_line, count, dset_id, mem_type_id,
+    H5TRACE11("e", "*s*sIuz*i*i*i*ii**xi", app_file, app_func, app_line, count, dset_id, mem_type_id,
               mem_space_id, file_space_id, dxpl_id, buf, es_id);
 
     /* Set up request token pointer for asynchronous operation */
@@ -1175,7 +1175,7 @@ H5Dread_multi_async(const char *app_file, const char *app_func, unsigned app_lin
     if (NULL != token)
         /* clang-format off */
         if (H5ES_insert(es_id, vol_obj->connector, token,
-                        H5ARG_TRACE11(__func__, "*s*sIuz*i*i*i*iixi", app_file, app_func, app_line, count, dset_id, mem_type_id, mem_space_id, file_space_id, dxpl_id, buf, es_id)) < 0)
+                        H5ARG_TRACE11(__func__, "*s*sIuz*i*i*i*ii**xi", app_file, app_func, app_line, count, dset_id, mem_type_id, mem_space_id, file_space_id, dxpl_id, buf, es_id)) < 0)
             /* clang-format on */
             HGOTO_ERROR(H5E_DATASET, H5E_CANTINSERT, FAIL, "can't insert token into event set");
 
@@ -1201,7 +1201,7 @@ H5Dread_chunk(hid_t dset_id, hid_t dxpl_id, const hsize_t *offset, uint32_t *fil
     herr_t                              ret_value = SUCCEED; /* Return value */
 
     FUNC_ENTER_API(FAIL)
-    H5TRACE5("e", "ii*h*Iux", dset_id, dxpl_id, offset, filters, buf);
+    H5TRACE5("e", "ii*h*Iu*x", dset_id, dxpl_id, offset, filters, buf);
 
     /* Check arguments */
     if (NULL == (vol_obj = (H5VL_object_t *)H5I_object_verify(dset_id, H5I_DATASET)))
@@ -1581,7 +1581,7 @@ H5Dscatter(H5D_scatter_func_t op, void *op_data, hid_t type_id, hid_t dst_space_
     herr_t          ret_value      = SUCCEED; /* Return value */
 
     FUNC_ENTER_API(FAIL)
-    H5TRACE5("e", "DS*xiix", op, op_data, type_id, dst_space_id, dst_buf);
+    H5TRACE5("e", "DS*xii*x", op, op_data, type_id, dst_space_id, dst_buf);
 
     /* Check args */
     if (op == NULL)
@@ -1674,7 +1674,7 @@ H5Dgather(hid_t src_space_id, const void *src_buf, hid_t type_id, size_t dst_buf
     herr_t          ret_value = SUCCEED; /* Return value */
 
     FUNC_ENTER_API(FAIL)
-    H5TRACE7("e", "i*xizxDg*x", src_space_id, src_buf, type_id, dst_buf_size, dst_buf, op, op_data);
+    H5TRACE7("e", "i*xiz*xDg*x", src_space_id, src_buf, type_id, dst_buf_size, dst_buf, op, op_data);
 
     /* Check args */
     if (NULL == (src_space = (H5S_t *)H5I_object_verify(src_space_id, H5I_DATASPACE)))
@@ -1906,7 +1906,7 @@ H5Dvlen_get_buf_size(hid_t dataset_id, hid_t type_id, hid_t space_id, hsize_t *s
     herr_t         ret_value = SUCCEED; /* Return value */
 
     FUNC_ENTER_API(FAIL)
-    H5TRACE4("e", "iiix", dataset_id, type_id, space_id, size);
+    H5TRACE4("e", "iii*h", dataset_id, type_id, space_id, size);
 
     /* Check args */
     if (NULL == (vol_obj = (H5VL_object_t *)H5I_object(dataset_id)))
@@ -2201,7 +2201,7 @@ H5Dget_chunk_index_type(hid_t dset_id, H5D_chunk_index_t *idx_type /*out*/)
     herr_t                              ret_value = SUCCEED; /* Return value                 */
 
     FUNC_ENTER_API(FAIL)
-    H5TRACE2("e", "ix", dset_id, idx_type);
+    H5TRACE2("e", "i*Dk", dset_id, idx_type);
 
     /* Check args */
     if (NULL == (vol_obj = (H5VL_object_t *)H5I_object_verify(dset_id, H5I_DATASET)))
@@ -2243,7 +2243,7 @@ H5Dget_chunk_storage_size(hid_t dset_id, const hsize_t *offset, hsize_t *chunk_n
     herr_t                              ret_value = SUCCEED; /* Return value                 */
 
     FUNC_ENTER_API(FAIL)
-    H5TRACE3("e", "i*hx", dset_id, offset, chunk_nbytes);
+    H5TRACE3("e", "i*h*h", dset_id, offset, chunk_nbytes);
 
     /* Check arguments */
     if (NULL == (vol_obj = (H5VL_object_t *)H5I_object_verify(dset_id, H5I_DATASET)))
@@ -2294,7 +2294,7 @@ H5Dget_num_chunks(hid_t dset_id, hid_t fspace_id, hsize_t *nchunks /*out*/)
     herr_t                              ret_value = SUCCEED;
 
     FUNC_ENTER_API(FAIL)
-    H5TRACE3("e", "iix", dset_id, fspace_id, nchunks);
+    H5TRACE3("e", "ii*h", dset_id, fspace_id, nchunks);
 
     /* Check arguments */
     if (NULL == (vol_obj = (H5VL_object_t *)H5I_object_verify(dset_id, H5I_DATASET)))
@@ -2346,7 +2346,7 @@ H5Dget_chunk_info(hid_t dset_id, hid_t fspace_id, hsize_t chk_index, hsize_t *of
     herr_t                              ret_value = SUCCEED;
 
     FUNC_ENTER_API(FAIL)
-    H5TRACE7("e", "iihxxxx", dset_id, fspace_id, chk_index, offset, filter_mask, addr, size);
+    H5TRACE7("e", "iih*h*Iu*a*h", dset_id, fspace_id, chk_index, offset, filter_mask, addr, size);
 
     /* Check arguments */
     if (NULL == offset && NULL == filter_mask && NULL == addr && NULL == size)
@@ -2415,7 +2415,7 @@ H5Dget_chunk_info_by_coord(hid_t dset_id, const hsize_t *offset, unsigned *filte
     herr_t                              ret_value = SUCCEED;
 
     FUNC_ENTER_API(FAIL)
-    H5TRACE5("e", "i*hxxx", dset_id, offset, filter_mask, addr, size);
+    H5TRACE5("e", "i*h*Iu*a*h", dset_id, offset, filter_mask, addr, size);
 
     /* Check arguments */
     if (NULL == (vol_obj = (H5VL_object_t *)H5I_object_verify(dset_id, H5I_DATASET)))

--- a/src/H5E.c
+++ b/src/H5E.c
@@ -534,7 +534,7 @@ H5Eget_class_name(hid_t class_id, char *name /*out*/, size_t size)
     ssize_t    ret_value = -1; /* Return value */
 
     FUNC_ENTER_API((-1))
-    H5TRACE3("Zs", "ixz", class_id, name, size);
+    H5TRACE3("Zs", "i*sz", class_id, name, size);
 
     /* Get the error class */
     if (NULL == (cls = (H5E_cls_t *)H5I_object_verify(class_id, H5I_ERROR_CLASS)))
@@ -774,7 +774,7 @@ H5Eget_msg(hid_t msg_id, H5E_type_t *type /*out*/, char *msg_str /*out*/, size_t
     ssize_t    ret_value = -1; /* Return value */
 
     FUNC_ENTER_API_NOCLEAR((-1))
-    H5TRACE4("Zs", "ixxz", msg_id, type, msg_str, size);
+    H5TRACE4("Zs", "i*Et*sz", msg_id, type, msg_str, size);
 
     /* Get the message object */
     if (NULL == (msg = (H5E_msg_t *)H5I_object_verify(msg_id, H5I_ERROR_MSG)))
@@ -1446,7 +1446,7 @@ H5Eget_auto2(hid_t estack_id, H5E_auto2_t *func /*out*/, void **client_data /*ou
 
     /* Don't clear the error stack! :-) */
     FUNC_ENTER_API_NOCLEAR(FAIL)
-    H5TRACE3("e", "ixx", estack_id, func, client_data);
+    H5TRACE3("e", "i*EA**x", estack_id, func, client_data);
 
     if (estack_id == H5E_DEFAULT) {
         if (NULL == (estack = H5E__get_my_stack())) /*lint !e506 !e774 Make lint 'constant value Boolean' in

--- a/src/H5ES.c
+++ b/src/H5ES.c
@@ -161,7 +161,7 @@ H5ESget_count(hid_t es_id, size_t *count /*out*/)
     herr_t ret_value = SUCCEED; /* Return value */
 
     FUNC_ENTER_API(FAIL)
-    H5TRACE2("e", "ix", es_id, count);
+    H5TRACE2("e", "i*z", es_id, count);
 
     /* Passing H5ES_NONE is valid, but a no-op */
     if (H5ES_NONE != es_id) {
@@ -202,7 +202,7 @@ H5ESget_op_counter(hid_t es_id, uint64_t *op_counter /*out*/)
     herr_t ret_value = SUCCEED; /* Return value */
 
     FUNC_ENTER_API(FAIL)
-    H5TRACE2("e", "ix", es_id, op_counter);
+    H5TRACE2("e", "i*UL", es_id, op_counter);
 
     /* Passing H5ES_NONE is valid, but a no-op */
     if (H5ES_NONE != es_id) {
@@ -252,7 +252,7 @@ H5ESget_requests(hid_t es_id, H5_iter_order_t order, hid_t *connector_ids, void 
     herr_t  ret_value = SUCCEED; /* Return value */
 
     FUNC_ENTER_API(FAIL)
-    H5TRACE6("e", "iIo*i**xzx", es_id, order, connector_ids, requests, array_len, count);
+    H5TRACE6("e", "iIo*i**xz*z", es_id, order, connector_ids, requests, array_len, count);
 
     /* Check arguments */
     if (NULL == (es = H5I_object_verify(es_id, H5I_EVENTSET)))
@@ -304,7 +304,7 @@ H5ESwait(hid_t es_id, uint64_t timeout, size_t *num_in_progress /*out*/, hbool_t
     herr_t ret_value = SUCCEED; /* Return value */
 
     FUNC_ENTER_API(FAIL)
-    H5TRACE4("e", "iULxx", es_id, timeout, num_in_progress, op_failed);
+    H5TRACE4("e", "iUL*z*b", es_id, timeout, num_in_progress, op_failed);
 
     /* Passing H5ES_NONE is valid, but a no-op */
     if (H5ES_NONE != es_id) {
@@ -344,7 +344,7 @@ H5EScancel(hid_t es_id, size_t *num_not_canceled /*out*/, hbool_t *op_failed /*o
     herr_t ret_value = SUCCEED; /* Return value */
 
     FUNC_ENTER_API(FAIL)
-    H5TRACE3("e", "ixx", es_id, num_not_canceled, op_failed);
+    H5TRACE3("e", "i*z*b", es_id, num_not_canceled, op_failed);
 
     /* Passing H5ES_NONE is valid, but a no-op */
     if (H5ES_NONE != es_id) {
@@ -384,7 +384,7 @@ H5ESget_err_status(hid_t es_id, hbool_t *err_status /*out*/)
     herr_t ret_value = SUCCEED; /* Return value */
 
     FUNC_ENTER_API(FAIL)
-    H5TRACE2("e", "ix", es_id, err_status);
+    H5TRACE2("e", "i*b", es_id, err_status);
 
     /* Passing H5ES_NONE is valid, but a no-op */
     if (H5ES_NONE != es_id) {
@@ -423,7 +423,7 @@ H5ESget_err_count(hid_t es_id, size_t *num_errs /*out*/)
     herr_t ret_value = SUCCEED; /* Return value */
 
     FUNC_ENTER_API(FAIL)
-    H5TRACE2("e", "ix", es_id, num_errs);
+    H5TRACE2("e", "i*z", es_id, num_errs);
 
     /* Passing H5ES_NONE is valid, but a no-op */
     if (H5ES_NONE != es_id) {
@@ -467,7 +467,7 @@ H5ESget_err_info(hid_t es_id, size_t num_err_info, H5ES_err_info_t err_info[] /*
     herr_t ret_value = SUCCEED; /* Return value */
 
     FUNC_ENTER_API(FAIL)
-    H5TRACE4("e", "izxx", es_id, num_err_info, err_info, num_cleared);
+    H5TRACE4("e", "iz*#*z", es_id, num_err_info, err_info, num_cleared);
 
     /* Passing H5ES_NONE is valid, but a no-op */
     if (H5ES_NONE != es_id) {

--- a/src/H5Edeprec.c
+++ b/src/H5Edeprec.c
@@ -317,7 +317,7 @@ H5Eget_auto1(H5E_auto1_t *func /*out*/, void **client_data /*out*/)
     herr_t        ret_value = SUCCEED; /* Return value */
 
     FUNC_ENTER_API(FAIL)
-    H5TRACE2("e", "xx", func, client_data);
+    H5TRACE2("e", "*Ea**x", func, client_data);
 
     /* Retrieve default error stack */
     if (NULL == (estack = H5E__get_my_stack())) /*lint !e506 !e774 Make lint 'constant value Boolean' in

--- a/src/H5F.c
+++ b/src/H5F.c
@@ -344,7 +344,7 @@ H5Fget_obj_ids(hid_t file_id, unsigned types, size_t max_objs, hid_t *oid_list /
     ssize_t ret_value = 0; /* Return value */
 
     FUNC_ENTER_API((-1))
-    H5TRACE4("Zs", "iIuzx", file_id, types, max_objs, oid_list);
+    H5TRACE4("Zs", "iIuz*i", file_id, types, max_objs, oid_list);
 
     /* Check arguments */
     if (0 == (types & H5F_OBJ_ALL))
@@ -437,7 +437,7 @@ H5Fget_vfd_handle(hid_t file_id, hid_t fapl_id, void **file_handle /*out*/)
     herr_t                           ret_value = SUCCEED; /* Return value */
 
     FUNC_ENTER_API(FAIL)
-    H5TRACE3("e", "iix", file_id, fapl_id, file_handle);
+    H5TRACE3("e", "ii**x", file_id, fapl_id, file_handle);
 
     /* Check args */
     if (!file_handle)
@@ -1567,7 +1567,7 @@ H5Fget_intent(hid_t file_id, unsigned *intent_flags /*out*/)
     herr_t ret_value = SUCCEED;
 
     FUNC_ENTER_API(FAIL)
-    H5TRACE2("e", "ix", file_id, intent_flags);
+    H5TRACE2("e", "i*Iu", file_id, intent_flags);
 
     /* If no intent flags were passed in, exit quietly */
     if (intent_flags) {
@@ -1607,7 +1607,7 @@ H5Fget_fileno(hid_t file_id, unsigned long *fnumber /*out*/)
     herr_t ret_value = SUCCEED;
 
     FUNC_ENTER_API(FAIL)
-    H5TRACE2("e", "ix", file_id, fnumber);
+    H5TRACE2("e", "i*Ul", file_id, fnumber);
 
     /* If no fnumber pointer was passed in, exit quietly */
     if (fnumber) {
@@ -1692,7 +1692,7 @@ H5Fget_filesize(hid_t file_id, hsize_t *size /*out*/)
     herr_t                           ret_value = SUCCEED; /* Return value */
 
     FUNC_ENTER_API(FAIL)
-    H5TRACE2("e", "ix", file_id, size);
+    H5TRACE2("e", "i*h", file_id, size);
 
     /* Check args */
     if (!size)
@@ -1760,7 +1760,7 @@ H5Fget_file_image(hid_t file_id, void *buf /*out*/, size_t buf_len)
     ssize_t                          ret_value;     /* Return value             */
 
     FUNC_ENTER_API((-1))
-    H5TRACE3("Zs", "ixz", file_id, buf, buf_len);
+    H5TRACE3("Zs", "i*xz", file_id, buf, buf_len);
 
     /* Check args */
     if (NULL == (vol_obj = (H5VL_object_t *)H5I_object_verify(file_id, H5I_FILE)))
@@ -1807,7 +1807,7 @@ H5Fget_mdc_config(hid_t file_id, H5AC_cache_config_t *config /*out*/)
     herr_t                           ret_value = SUCCEED; /* Return value */
 
     FUNC_ENTER_API(FAIL)
-    H5TRACE2("e", "ix", file_id, config);
+    H5TRACE2("e", "i*Cc", file_id, config);
 
     /* Check args */
     if ((NULL == config) || (config->version != H5AC__CURR_CACHE_CONFIG_VERSION))
@@ -1890,7 +1890,7 @@ H5Fget_mdc_hit_rate(hid_t file_id, double *hit_rate /*out*/)
     herr_t                           ret_value = SUCCEED; /* Return value */
 
     FUNC_ENTER_API(FAIL)
-    H5TRACE2("e", "ix", file_id, hit_rate);
+    H5TRACE2("e", "i*d", file_id, hit_rate);
 
     /* Check args */
     if (NULL == hit_rate)
@@ -1935,7 +1935,7 @@ H5Fget_mdc_size(hid_t file_id, size_t *max_size /*out*/, size_t *min_clean_size 
     herr_t                           ret_value = SUCCEED; /* Return value */
 
     FUNC_ENTER_API(FAIL)
-    H5TRACE5("e", "ixxxx", file_id, max_size, min_clean_size, cur_size, cur_num_entries);
+    H5TRACE5("e", "i*z*z*z*Is", file_id, max_size, min_clean_size, cur_size, cur_num_entries);
 
     /* Check args */
     if (NULL == (vol_obj = (H5VL_object_t *)H5I_object_verify(file_id, H5I_FILE)))
@@ -2032,7 +2032,7 @@ H5Fget_name(hid_t obj_id, char *name /*out*/, size_t size)
     ssize_t              ret_value     = -1; /* Return value */
 
     FUNC_ENTER_API((-1))
-    H5TRACE3("Zs", "ixz", obj_id, name, size);
+    H5TRACE3("Zs", "i*sz", obj_id, name, size);
 
     /* Check the type */
     type = H5I_get_type(obj_id);
@@ -2085,7 +2085,7 @@ H5Fget_info2(hid_t obj_id, H5F_info2_t *finfo /*out*/)
     herr_t                           ret_value = SUCCEED; /* Return value */
 
     FUNC_ENTER_API(FAIL)
-    H5TRACE2("e", "ix", obj_id, finfo);
+    H5TRACE2("e", "i*FI", obj_id, finfo);
 
     /* Check args */
     if (!finfo)
@@ -2134,7 +2134,7 @@ H5Fget_metadata_read_retry_info(hid_t file_id, H5F_retry_info_t *info /*out*/)
     herr_t                           ret_value = SUCCEED; /* Return value */
 
     FUNC_ENTER_API(FAIL)
-    H5TRACE2("e", "ix", file_id, info);
+    H5TRACE2("e", "i*!", file_id, info);
 
     /* Check args */
     if (!info)
@@ -2179,7 +2179,7 @@ H5Fget_free_sections(hid_t file_id, H5F_mem_t type, size_t nsects, H5F_sect_info
     ssize_t                          ret_value  = -1; /* Return value */
 
     FUNC_ENTER_API((-1))
-    H5TRACE4("Zs", "iFmzx", file_id, type, nsects, sect_info);
+    H5TRACE4("Zs", "iFmz*!", file_id, type, nsects, sect_info);
 
     /* Check args */
     if (NULL == (vol_obj = (H5VL_object_t *)H5I_object_verify(file_id, H5I_FILE)))
@@ -2400,7 +2400,7 @@ H5Fget_mdc_logging_status(hid_t file_id, hbool_t *is_enabled /*out*/, hbool_t *i
     herr_t                           ret_value = SUCCEED; /* Return value */
 
     FUNC_ENTER_API(FAIL)
-    H5TRACE3("e", "ixx", file_id, is_enabled, is_currently_logging);
+    H5TRACE3("e", "i*b*b", file_id, is_enabled, is_currently_logging);
 
     /* Sanity check */
     if (NULL == (vol_obj = (H5VL_object_t *)H5I_object_verify(file_id, H5I_FILE)))
@@ -2561,7 +2561,7 @@ H5Fget_page_buffering_stats(hid_t file_id, unsigned accesses[2] /*out*/, unsigne
     herr_t                           ret_value = SUCCEED; /* Return value */
 
     FUNC_ENTER_API(FAIL)
-    H5TRACE6("e", "ixxxxx", file_id, accesses, hits, misses, evictions, bypasses);
+    H5TRACE6("e", "i*Iu*Iu*Iu*Iu*Iu", file_id, accesses, hits, misses, evictions, bypasses);
 
     /* Check args */
     if (NULL == (vol_obj = (H5VL_object_t *)H5I_object_verify(file_id, H5I_FILE)))
@@ -2608,7 +2608,7 @@ H5Fget_mdc_image_info(hid_t file_id, haddr_t *image_addr /*out*/, hsize_t *image
     herr_t                           ret_value = SUCCEED; /* Return value */
 
     FUNC_ENTER_API(FAIL)
-    H5TRACE3("e", "ixx", file_id, image_addr, image_len);
+    H5TRACE3("e", "i*a*h", file_id, image_addr, image_len);
 
     /* Check args */
     if (NULL == (vol_obj = (H5VL_object_t *)H5I_object_verify(file_id, H5I_FILE)))
@@ -2646,7 +2646,7 @@ H5Fget_eoa(hid_t file_id, haddr_t *eoa /*out*/)
     herr_t         ret_value = SUCCEED; /* Return value */
 
     FUNC_ENTER_API(FAIL)
-    H5TRACE2("e", "ix", file_id, eoa);
+    H5TRACE2("e", "i*a", file_id, eoa);
 
     /* Check args */
     if (NULL == (vol_obj = (H5VL_object_t *)H5I_object_verify(file_id, H5I_FILE)))
@@ -2727,7 +2727,7 @@ H5Fget_dset_no_attrs_hint(hid_t file_id, hbool_t *minimize /*out*/)
     herr_t                           ret_value = SUCCEED; /* Return value */
 
     FUNC_ENTER_API(FAIL)
-    H5TRACE2("e", "ix", file_id, minimize);
+    H5TRACE2("e", "i*b", file_id, minimize);
 
     /* Check args */
     if (NULL == minimize)

--- a/src/H5FD.c
+++ b/src/H5FD.c
@@ -974,7 +974,7 @@ H5FDquery(const H5FD_t *file, unsigned long *flags /*out*/)
     int ret_value = 0;
 
     FUNC_ENTER_API((-1))
-    H5TRACE2("Is", "*#x", file, flags);
+    H5TRACE2("Is", "*#*Ul", file, flags);
 
     /* Check arguments */
     if (!file)
@@ -1406,7 +1406,7 @@ H5FDread(H5FD_t *file, H5FD_mem_t type, hid_t dxpl_id, haddr_t addr, size_t size
     herr_t ret_value = SUCCEED; /* Return value             */
 
     FUNC_ENTER_API(FAIL)
-    H5TRACE6("e", "*#Mtiazx", file, type, dxpl_id, addr, size, buf);
+    H5TRACE6("e", "*#Mtiaz*x", file, type, dxpl_id, addr, size, buf);
 
     /* Check arguments */
     if (!file)
@@ -1508,7 +1508,7 @@ H5FDread_vector(H5FD_t *file, hid_t dxpl_id, uint32_t count, H5FD_mem_t types[],
     herr_t ret_value = SUCCEED; /* Return value             */
 
     FUNC_ENTER_API(FAIL)
-    H5TRACE7("e", "*#iIu*Mt*a*zx", file, dxpl_id, count, types, addrs, sizes, bufs);
+    H5TRACE7("e", "*#iIu*Mt*a*z**x", file, dxpl_id, count, types, addrs, sizes, bufs);
 
     /* Check arguments */
     if (!file)
@@ -1677,7 +1677,7 @@ H5FDread_selection(H5FD_t *file, H5FD_mem_t type, hid_t dxpl_id, uint32_t count,
     herr_t ret_value = SUCCEED; /* Return value             */
 
     FUNC_ENTER_API(FAIL)
-    H5TRACE9("e", "*#MtiIu*i*i*a*zx", file, type, dxpl_id, count, mem_space_ids, file_space_ids, offsets,
+    H5TRACE9("e", "*#MtiIu*i*i*a*z**x", file, type, dxpl_id, count, mem_space_ids, file_space_ids, offsets,
              element_sizes, bufs);
 
     /* Check arguments */
@@ -1878,7 +1878,7 @@ H5FDread_vector_from_selection(H5FD_t *file, H5FD_mem_t type, hid_t dxpl_id, uin
     herr_t ret_value = SUCCEED; /* Return value             */
 
     FUNC_ENTER_API(FAIL)
-    H5TRACE9("e", "*#MtiIu*i*i*a*zx", file, type, dxpl_id, count, mem_space_ids, file_space_ids, offsets,
+    H5TRACE9("e", "*#MtiIu*i*i*a*z**x", file, type, dxpl_id, count, mem_space_ids, file_space_ids, offsets,
              element_sizes, bufs);
 
     /* Check arguments */
@@ -2617,7 +2617,7 @@ H5FDget_vfd_handle(H5FD_t *file, hid_t fapl_id, void **file_handle /*out*/)
     herr_t ret_value = SUCCEED;
 
     FUNC_ENTER_API(FAIL)
-    H5TRACE3("e", "*#ix", file, fapl_id, file_handle);
+    H5TRACE3("e", "*#i**x", file, fapl_id, file_handle);
 
     /* Check arguments */
     if (!file)
@@ -2761,7 +2761,7 @@ H5FDdriver_query(hid_t driver_id, unsigned long *flags /*out*/)
     herr_t        ret_value = SUCCEED; /* Return value                 */
 
     FUNC_ENTER_API(FAIL)
-    H5TRACE2("e", "ix", driver_id, flags);
+    H5TRACE2("e", "i*Ul", driver_id, flags);
 
     /* Check arguments */
     if (NULL == flags)

--- a/src/H5FDcore.c
+++ b/src/H5FDcore.c
@@ -565,7 +565,7 @@ H5Pget_core_write_tracking(hid_t plist_id, hbool_t *is_enabled /*out*/, size_t *
     herr_t                  ret_value = SUCCEED; /* Return value */
 
     FUNC_ENTER_API(FAIL)
-    H5TRACE3("e", "ixx", plist_id, is_enabled, page_size);
+    H5TRACE3("e", "i*b*z", plist_id, is_enabled, page_size);
 
     /* Get the plist structure */
     if (NULL == (plist = H5P_object_verify(plist_id, H5P_FILE_ACCESS)))
@@ -642,7 +642,7 @@ H5Pget_fapl_core(hid_t fapl_id, size_t *increment /*out*/, hbool_t *backing_stor
     herr_t                  ret_value = SUCCEED; /* Return value */
 
     FUNC_ENTER_API(FAIL)
-    H5TRACE3("e", "ixx", fapl_id, increment, backing_store);
+    H5TRACE3("e", "i*z*b", fapl_id, increment, backing_store);
 
     if (NULL == (plist = H5P_object_verify(fapl_id, H5P_FILE_ACCESS)))
         HGOTO_ERROR(H5E_ARGS, H5E_BADTYPE, FAIL, "not a file access property list");

--- a/src/H5FDdirect.c
+++ b/src/H5FDdirect.c
@@ -298,7 +298,7 @@ H5Pget_fapl_direct(hid_t fapl_id, size_t *boundary /*out*/, size_t *block_size /
     herr_t                    ret_value = SUCCEED; /* Return value */
 
     FUNC_ENTER_API(FAIL)
-    H5TRACE4("e", "ixxx", fapl_id, boundary, block_size, cbuf_size);
+    H5TRACE4("e", "i*z*z*z", fapl_id, boundary, block_size, cbuf_size);
 
     if (NULL == (plist = H5P_object_verify(fapl_id, H5P_FILE_ACCESS)))
         HGOTO_ERROR(H5E_ARGS, H5E_BADTYPE, FAIL, "not a file access list");

--- a/src/H5FDfamily.c
+++ b/src/H5FDfamily.c
@@ -383,7 +383,7 @@ H5Pget_fapl_family(hid_t fapl_id, hsize_t *msize /*out*/, hid_t *memb_fapl_id /*
     herr_t                    ret_value = SUCCEED; /* Return value */
 
     FUNC_ENTER_API(FAIL)
-    H5TRACE3("e", "ixx", fapl_id, msize, memb_fapl_id);
+    H5TRACE3("e", "i*h*i", fapl_id, msize, memb_fapl_id);
 
     if (NULL == (plist = H5P_object_verify(fapl_id, H5P_FILE_ACCESS)))
         HGOTO_ERROR(H5E_ARGS, H5E_BADTYPE, FAIL, "not a file access list");

--- a/src/H5FDhdfs.c
+++ b/src/H5FDhdfs.c
@@ -600,7 +600,7 @@ H5Pget_fapl_hdfs(hid_t fapl_id, H5FD_hdfs_fapl_t *fa_dst /*out*/)
     herr_t                  ret_value = SUCCEED;
 
     FUNC_ENTER_API(FAIL)
-    H5TRACE2("e", "ix", fapl_id, fa_dst);
+    H5TRACE2("e", "i*#", fapl_id, fa_dst);
 
 #if HDFS_DEBUG
     fprintf(stdout, "called %s.\n", __func__);

--- a/src/H5FDmirror.c
+++ b/src/H5FDmirror.c
@@ -1263,7 +1263,7 @@ H5Pget_fapl_mirror(hid_t fapl_id, H5FD_mirror_fapl_t *fa_dst /*out*/)
     herr_t                    ret_value = SUCCEED;
 
     FUNC_ENTER_API(FAIL)
-    H5TRACE2("e", "ix", fapl_id, fa_dst);
+    H5TRACE2("e", "i*#", fapl_id, fa_dst);
 
     LOG_OP_CALL(__func__);
 

--- a/src/H5FDmpio.c
+++ b/src/H5FDmpio.c
@@ -439,7 +439,7 @@ H5Pget_fapl_mpio(hid_t fapl_id, MPI_Comm *comm /*out*/, MPI_Info *info /*out*/)
     herr_t          ret_value = SUCCEED; /* Return value */
 
     FUNC_ENTER_API(FAIL)
-    H5TRACE3("e", "ixx", fapl_id, comm, info);
+    H5TRACE3("e", "i*Mc*Mi", fapl_id, comm, info);
 
     /* Set comm and info in case we have problems */
     if (comm)
@@ -541,7 +541,7 @@ H5Pget_dxpl_mpio(hid_t dxpl_id, H5FD_mpio_xfer_t *xfer_mode /*out*/)
     herr_t          ret_value = SUCCEED; /* Return value */
 
     FUNC_ENTER_API(FAIL)
-    H5TRACE2("e", "ix", dxpl_id, xfer_mode);
+    H5TRACE2("e", "i*Dt", dxpl_id, xfer_mode);
 
     /* Check arguments */
     if (NULL == (plist = H5P_object_verify(dxpl_id, H5P_DATASET_XFER)))

--- a/src/H5FDonion.c
+++ b/src/H5FDonion.c
@@ -1667,7 +1667,7 @@ H5FDonion_get_revision_count(const char *filename, hid_t fapl_id, uint64_t *revi
     herr_t          ret_value = SUCCEED;
 
     FUNC_ENTER_API(FAIL)
-    H5TRACE3("e", "*six", filename, fapl_id, revision_count);
+    H5TRACE3("e", "*si*UL", filename, fapl_id, revision_count);
 
     /* Check args */
     if (!filename || !strcmp(filename, ""))

--- a/src/H5FDros3.c
+++ b/src/H5FDros3.c
@@ -456,7 +456,7 @@ H5Pget_fapl_ros3(hid_t fapl_id, H5FD_ros3_fapl_t *fa_dst /*out*/)
     herr_t                  ret_value = SUCCEED;
 
     FUNC_ENTER_API(FAIL)
-    H5TRACE2("e", "ix", fapl_id, fa_dst);
+    H5TRACE2("e", "i*#", fapl_id, fa_dst);
 
 #if ROS3_DEBUG
     fprintf(stdout, "H5Pget_fapl_ros3() called.\n");
@@ -605,7 +605,7 @@ H5Pget_fapl_ros3_token(hid_t fapl_id, size_t size, char *token_dst /*out*/)
     herr_t          ret_value = SUCCEED;
 
     FUNC_ENTER_API(FAIL)
-    H5TRACE3("e", "izx", fapl_id, size, token_dst);
+    H5TRACE3("e", "iz*s", fapl_id, size, token_dst);
 
 #if ROS3_DEBUG
     fprintf(stdout, "H5Pget_fapl_ros3_token() called.\n");

--- a/src/H5FDsplitter.c
+++ b/src/H5FDsplitter.c
@@ -335,7 +335,7 @@ H5Pget_fapl_splitter(hid_t fapl_id, H5FD_splitter_vfd_config_t *config /*out*/)
     herr_t                      ret_value    = SUCCEED;
 
     FUNC_ENTER_API(FAIL)
-    H5TRACE2("e", "ix", fapl_id, config);
+    H5TRACE2("e", "i*#", fapl_id, config);
 
     H5FD_SPLITTER_LOG_CALL(__func__);
 

--- a/src/H5Fdeprec.c
+++ b/src/H5Fdeprec.c
@@ -94,7 +94,7 @@ H5Fget_info1(hid_t obj_id, H5F_info1_t *finfo /*out*/)
     herr_t                           ret_value = SUCCEED; /* Return value */
 
     FUNC_ENTER_API(FAIL)
-    H5TRACE2("e", "ix", obj_id, finfo);
+    H5TRACE2("e", "i*!", obj_id, finfo);
 
     /* Check args */
     if (!finfo)

--- a/src/H5Fmpi.c
+++ b/src/H5Fmpi.c
@@ -326,7 +326,7 @@ H5Fget_mpi_atomicity(hid_t file_id, bool *flag /*out*/)
     herr_t                           ret_value = SUCCEED; /* Return value */
 
     FUNC_ENTER_API(FAIL)
-    H5TRACE2("e", "ix", file_id, flag);
+    H5TRACE2("e", "i*!", file_id, flag);
 
     /* Get the file object */
     if (NULL == (vol_obj = (H5VL_object_t *)H5I_object_verify(file_id, H5I_FILE)))

--- a/src/H5Fmpi.c
+++ b/src/H5Fmpi.c
@@ -326,7 +326,7 @@ H5Fget_mpi_atomicity(hid_t file_id, bool *flag /*out*/)
     herr_t                           ret_value = SUCCEED; /* Return value */
 
     FUNC_ENTER_API(FAIL)
-    H5TRACE2("e", "i*!", file_id, flag);
+    H5TRACE2("e", "i*b", file_id, flag);
 
     /* Get the file object */
     if (NULL == (vol_obj = (H5VL_object_t *)H5I_object_verify(file_id, H5I_FILE)))

--- a/src/H5G.c
+++ b/src/H5G.c
@@ -591,7 +591,7 @@ H5Gget_info(hid_t loc_id, H5G_info_t *group_info /*out*/)
     herr_t ret_value = SUCCEED; /* Return value */
 
     FUNC_ENTER_API(FAIL)
-    H5TRACE2("e", "i*!", loc_id, group_info);
+    H5TRACE2("e", "i*GI", loc_id, group_info);
 
     /* Retrieve group information synchronously */
     if (H5G__get_info_api_common(loc_id, group_info, NULL, NULL) < 0)
@@ -620,7 +620,7 @@ H5Gget_info_async(const char *app_file, const char *app_func, unsigned app_line,
     herr_t         ret_value = SUCCEED;         /* Return value */
 
     FUNC_ENTER_API(FAIL)
-    H5TRACE6("e", "*s*sIui*!i", app_file, app_func, app_line, loc_id, group_info, es_id);
+    H5TRACE6("e", "*s*sIui*GIi", app_file, app_func, app_line, loc_id, group_info, es_id);
 
     /* Set up request token pointer for asynchronous operation */
     if (H5ES_NONE != es_id)
@@ -634,7 +634,7 @@ H5Gget_info_async(const char *app_file, const char *app_func, unsigned app_line,
     if (NULL != token)
         /* clang-format off */
         if (H5ES_insert(es_id, vol_obj->connector, token,
-                H5ARG_TRACE6(__func__, "*s*sIui*!i", app_file, app_func, app_line, loc_id, group_info, es_id)) < 0)
+                H5ARG_TRACE6(__func__, "*s*sIui*GIi", app_file, app_func, app_line, loc_id, group_info, es_id)) < 0)
             /* clang-format on */
             HGOTO_ERROR(H5E_SYM, H5E_CANTINSERT, FAIL, "can't insert token into event set");
 
@@ -699,7 +699,7 @@ H5Gget_info_by_name(hid_t loc_id, const char *name, H5G_info_t *group_info /*out
     herr_t ret_value = SUCCEED; /* Return value */
 
     FUNC_ENTER_API(FAIL)
-    H5TRACE4("e", "i*s*!i", loc_id, name, group_info, lapl_id);
+    H5TRACE4("e", "i*s*GIi", loc_id, name, group_info, lapl_id);
 
     /* Retrieve group information synchronously */
     if (H5G__get_info_by_name_api_common(loc_id, name, group_info, lapl_id, NULL, NULL) < 0)
@@ -728,7 +728,7 @@ H5Gget_info_by_name_async(const char *app_file, const char *app_func, unsigned a
     herr_t         ret_value = SUCCEED;         /* Return value */
 
     FUNC_ENTER_API(FAIL)
-    H5TRACE8("e", "*s*sIui*s*!ii", app_file, app_func, app_line, loc_id, name, group_info, lapl_id, es_id);
+    H5TRACE8("e", "*s*sIui*s*GIii", app_file, app_func, app_line, loc_id, name, group_info, lapl_id, es_id);
 
     /* Set up request token pointer for asynchronous operation */
     if (H5ES_NONE != es_id)
@@ -742,7 +742,7 @@ H5Gget_info_by_name_async(const char *app_file, const char *app_func, unsigned a
     if (NULL != token)
         /* clang-format off */
         if (H5ES_insert(es_id, vol_obj->connector, token,
-                        H5ARG_TRACE8(__func__, "*s*sIui*s*!ii", app_file, app_func, app_line, loc_id, name, group_info, lapl_id, es_id)) < 0)
+                        H5ARG_TRACE8(__func__, "*s*sIui*s*GIii", app_file, app_func, app_line, loc_id, name, group_info, lapl_id, es_id)) < 0)
             /* clang-format on */
             HGOTO_ERROR(H5E_SYM, H5E_CANTINSERT, FAIL, "can't insert token into event set");
 
@@ -809,7 +809,7 @@ H5Gget_info_by_idx(hid_t loc_id, const char *group_name, H5_index_t idx_type, H5
     herr_t ret_value = SUCCEED; /* Return value */
 
     FUNC_ENTER_API(FAIL)
-    H5TRACE7("e", "i*sIiIoh*!i", loc_id, group_name, idx_type, order, n, group_info, lapl_id);
+    H5TRACE7("e", "i*sIiIoh*GIi", loc_id, group_name, idx_type, order, n, group_info, lapl_id);
 
     /* Retrieve group information synchronously */
     if (H5G__get_info_by_idx_api_common(loc_id, group_name, idx_type, order, n, group_info, lapl_id, NULL,
@@ -840,8 +840,8 @@ H5Gget_info_by_idx_async(const char *app_file, const char *app_func, unsigned ap
     herr_t         ret_value = SUCCEED;         /* Return value */
 
     FUNC_ENTER_API(FAIL)
-    H5TRACE11("e", "*s*sIui*sIiIoh*!ii", app_file, app_func, app_line, loc_id, group_name, idx_type, order, n,
-              group_info, lapl_id, es_id);
+    H5TRACE11("e", "*s*sIui*sIiIoh*GIii", app_file, app_func, app_line, loc_id, group_name, idx_type, order,
+              n, group_info, lapl_id, es_id);
 
     /* Set up request token pointer for asynchronous operation */
     if (H5ES_NONE != es_id)
@@ -856,7 +856,7 @@ H5Gget_info_by_idx_async(const char *app_file, const char *app_func, unsigned ap
     if (NULL != token)
         /* clang-format off */
         if (H5ES_insert(es_id, vol_obj->connector, token,
-                        H5ARG_TRACE11(__func__, "*s*sIui*sIiIoh*!ii", app_file, app_func, app_line, loc_id, group_name, idx_type, order, n, group_info, lapl_id, es_id)) < 0)
+                        H5ARG_TRACE11(__func__, "*s*sIui*sIiIoh*GIii", app_file, app_func, app_line, loc_id, group_name, idx_type, order, n, group_info, lapl_id, es_id)) < 0)
             /* clang-format on */
             HGOTO_ERROR(H5E_SYM, H5E_CANTINSERT, FAIL, "can't insert token into event set");
 

--- a/src/H5G.c
+++ b/src/H5G.c
@@ -591,7 +591,7 @@ H5Gget_info(hid_t loc_id, H5G_info_t *group_info /*out*/)
     herr_t ret_value = SUCCEED; /* Return value */
 
     FUNC_ENTER_API(FAIL)
-    H5TRACE2("e", "ix", loc_id, group_info);
+    H5TRACE2("e", "i*!", loc_id, group_info);
 
     /* Retrieve group information synchronously */
     if (H5G__get_info_api_common(loc_id, group_info, NULL, NULL) < 0)
@@ -620,7 +620,7 @@ H5Gget_info_async(const char *app_file, const char *app_func, unsigned app_line,
     herr_t         ret_value = SUCCEED;         /* Return value */
 
     FUNC_ENTER_API(FAIL)
-    H5TRACE6("e", "*s*sIuixi", app_file, app_func, app_line, loc_id, group_info, es_id);
+    H5TRACE6("e", "*s*sIui*!i", app_file, app_func, app_line, loc_id, group_info, es_id);
 
     /* Set up request token pointer for asynchronous operation */
     if (H5ES_NONE != es_id)
@@ -634,7 +634,7 @@ H5Gget_info_async(const char *app_file, const char *app_func, unsigned app_line,
     if (NULL != token)
         /* clang-format off */
         if (H5ES_insert(es_id, vol_obj->connector, token,
-                H5ARG_TRACE6(__func__, "*s*sIuixi", app_file, app_func, app_line, loc_id, group_info, es_id)) < 0)
+                H5ARG_TRACE6(__func__, "*s*sIui*!i", app_file, app_func, app_line, loc_id, group_info, es_id)) < 0)
             /* clang-format on */
             HGOTO_ERROR(H5E_SYM, H5E_CANTINSERT, FAIL, "can't insert token into event set");
 
@@ -699,7 +699,7 @@ H5Gget_info_by_name(hid_t loc_id, const char *name, H5G_info_t *group_info /*out
     herr_t ret_value = SUCCEED; /* Return value */
 
     FUNC_ENTER_API(FAIL)
-    H5TRACE4("e", "i*sxi", loc_id, name, group_info, lapl_id);
+    H5TRACE4("e", "i*s*!i", loc_id, name, group_info, lapl_id);
 
     /* Retrieve group information synchronously */
     if (H5G__get_info_by_name_api_common(loc_id, name, group_info, lapl_id, NULL, NULL) < 0)
@@ -728,7 +728,7 @@ H5Gget_info_by_name_async(const char *app_file, const char *app_func, unsigned a
     herr_t         ret_value = SUCCEED;         /* Return value */
 
     FUNC_ENTER_API(FAIL)
-    H5TRACE8("e", "*s*sIui*sxii", app_file, app_func, app_line, loc_id, name, group_info, lapl_id, es_id);
+    H5TRACE8("e", "*s*sIui*s*!ii", app_file, app_func, app_line, loc_id, name, group_info, lapl_id, es_id);
 
     /* Set up request token pointer for asynchronous operation */
     if (H5ES_NONE != es_id)
@@ -742,7 +742,7 @@ H5Gget_info_by_name_async(const char *app_file, const char *app_func, unsigned a
     if (NULL != token)
         /* clang-format off */
         if (H5ES_insert(es_id, vol_obj->connector, token,
-                        H5ARG_TRACE8(__func__, "*s*sIui*sxii", app_file, app_func, app_line, loc_id, name, group_info, lapl_id, es_id)) < 0)
+                        H5ARG_TRACE8(__func__, "*s*sIui*s*!ii", app_file, app_func, app_line, loc_id, name, group_info, lapl_id, es_id)) < 0)
             /* clang-format on */
             HGOTO_ERROR(H5E_SYM, H5E_CANTINSERT, FAIL, "can't insert token into event set");
 
@@ -809,7 +809,7 @@ H5Gget_info_by_idx(hid_t loc_id, const char *group_name, H5_index_t idx_type, H5
     herr_t ret_value = SUCCEED; /* Return value */
 
     FUNC_ENTER_API(FAIL)
-    H5TRACE7("e", "i*sIiIohxi", loc_id, group_name, idx_type, order, n, group_info, lapl_id);
+    H5TRACE7("e", "i*sIiIoh*!i", loc_id, group_name, idx_type, order, n, group_info, lapl_id);
 
     /* Retrieve group information synchronously */
     if (H5G__get_info_by_idx_api_common(loc_id, group_name, idx_type, order, n, group_info, lapl_id, NULL,
@@ -840,7 +840,7 @@ H5Gget_info_by_idx_async(const char *app_file, const char *app_func, unsigned ap
     herr_t         ret_value = SUCCEED;         /* Return value */
 
     FUNC_ENTER_API(FAIL)
-    H5TRACE11("e", "*s*sIui*sIiIohxii", app_file, app_func, app_line, loc_id, group_name, idx_type, order, n,
+    H5TRACE11("e", "*s*sIui*sIiIoh*!ii", app_file, app_func, app_line, loc_id, group_name, idx_type, order, n,
               group_info, lapl_id, es_id);
 
     /* Set up request token pointer for asynchronous operation */
@@ -856,7 +856,7 @@ H5Gget_info_by_idx_async(const char *app_file, const char *app_func, unsigned ap
     if (NULL != token)
         /* clang-format off */
         if (H5ES_insert(es_id, vol_obj->connector, token,
-                        H5ARG_TRACE11(__func__, "*s*sIui*sIiIohxii", app_file, app_func, app_line, loc_id, group_name, idx_type, order, n, group_info, lapl_id, es_id)) < 0)
+                        H5ARG_TRACE11(__func__, "*s*sIui*sIiIoh*!ii", app_file, app_func, app_line, loc_id, group_name, idx_type, order, n, group_info, lapl_id, es_id)) < 0)
             /* clang-format on */
             HGOTO_ERROR(H5E_SYM, H5E_CANTINSERT, FAIL, "can't insert token into event set");
 

--- a/src/H5Gdeprec.c
+++ b/src/H5Gdeprec.c
@@ -627,7 +627,7 @@ H5Gget_linkval(hid_t loc_id, const char *name, size_t size, char *buf /*out*/)
     herr_t               ret_value = SUCCEED; /* Return value */
 
     FUNC_ENTER_API(FAIL)
-    H5TRACE4("e", "i*szx", loc_id, name, size, buf);
+    H5TRACE4("e", "i*sz*s", loc_id, name, size, buf);
 
     /* Check arguments */
     if (!name || !*name)
@@ -748,7 +748,7 @@ H5Gget_comment(hid_t loc_id, const char *name, size_t bufsize, char *buf /*out*/
     int                                ret_value;       /* Return value */
 
     FUNC_ENTER_API(-1)
-    H5TRACE4("Is", "i*szx", loc_id, name, bufsize, buf);
+    H5TRACE4("Is", "i*sz*s", loc_id, name, bufsize, buf);
 
     if (!name || !*name)
         HGOTO_ERROR(H5E_ARGS, H5E_BADVALUE, -1, "no name specified");
@@ -884,7 +884,7 @@ H5Gget_num_objs(hid_t loc_id, hsize_t *num_objs /*out*/)
     herr_t                ret_value = SUCCEED; /* Return value */
 
     FUNC_ENTER_API(FAIL)
-    H5TRACE2("e", "ix", loc_id, num_objs);
+    H5TRACE2("e", "i*h", loc_id, num_objs);
 
     /* Check args */
     id_type = H5I_get_type(loc_id);
@@ -933,7 +933,7 @@ H5Gget_objinfo(hid_t loc_id, const char *name, hbool_t follow_link, H5G_stat_t *
     herr_t                            ret_value = SUCCEED; /* Return value */
 
     FUNC_ENTER_API(FAIL)
-    H5TRACE4("e", "i*sbx", loc_id, name, follow_link, statbuf);
+    H5TRACE4("e", "i*sb*Gs", loc_id, name, follow_link, statbuf);
 
     /* Check arguments */
     if (!name || !*name)
@@ -1148,7 +1148,7 @@ H5Gget_objname_by_idx(hid_t loc_id, hsize_t idx, char *name /*out*/, size_t size
     ssize_t              ret_value;    /* Return value */
 
     FUNC_ENTER_API(FAIL)
-    H5TRACE4("Zs", "ihxz", loc_id, idx, name, size);
+    H5TRACE4("Zs", "ih*sz", loc_id, idx, name, size);
 
     /* Set up collective metadata if appropriate */
     if (H5CX_set_loc(loc_id) < 0)

--- a/src/H5I.c
+++ b/src/H5I.c
@@ -908,7 +908,7 @@ H5Iget_name(hid_t id, char *name /*out*/, size_t size)
     ssize_t                ret_value    = -1; /* Return value */
 
     FUNC_ENTER_API((-1))
-    H5TRACE3("Zs", "ixz", id, name, size);
+    H5TRACE3("Zs", "i*sz", id, name, size);
 
     /* Get the object pointer */
     if (NULL == (vol_obj = H5VL_vol_object(id)))

--- a/src/H5L.c
+++ b/src/H5L.c
@@ -1042,7 +1042,7 @@ H5Lget_val(hid_t loc_id, const char *name, void *buf /*out*/, size_t size, hid_t
     herr_t               ret_value = SUCCEED; /* Return value */
 
     FUNC_ENTER_API(FAIL)
-    H5TRACE5("e", "i*sxzi", loc_id, name, buf, size, lapl_id);
+    H5TRACE5("e", "i*s*xzi", loc_id, name, buf, size, lapl_id);
 
     /* Check arguments */
     if (!name || !*name)
@@ -1100,7 +1100,7 @@ H5Lget_val_by_idx(hid_t loc_id, const char *group_name, H5_index_t idx_type, H5_
     herr_t               ret_value = SUCCEED; /* Return value */
 
     FUNC_ENTER_API(FAIL)
-    H5TRACE8("e", "i*sIiIohxzi", loc_id, group_name, idx_type, order, n, buf, size, lapl_id);
+    H5TRACE8("e", "i*sIiIoh*xzi", loc_id, group_name, idx_type, order, n, buf, size, lapl_id);
 
     /* Check arguments */
     if (!group_name || !*group_name)
@@ -1272,7 +1272,7 @@ H5Lget_info2(hid_t loc_id, const char *name, H5L_info2_t *linfo /*out*/, hid_t l
     herr_t               ret_value = SUCCEED; /* Return value */
 
     FUNC_ENTER_API(FAIL)
-    H5TRACE4("e", "i*sxi", loc_id, name, linfo, lapl_id);
+    H5TRACE4("e", "i*s*!i", loc_id, name, linfo, lapl_id);
 
     /* Check arguments */
     if (!name || !*name)
@@ -1325,7 +1325,7 @@ H5Lget_info_by_idx2(hid_t loc_id, const char *group_name, H5_index_t idx_type, H
     herr_t               ret_value = SUCCEED; /* Return value */
 
     FUNC_ENTER_API(FAIL)
-    H5TRACE7("e", "i*sIiIohxi", loc_id, group_name, idx_type, order, n, linfo, lapl_id);
+    H5TRACE7("e", "i*sIiIoh*!i", loc_id, group_name, idx_type, order, n, linfo, lapl_id);
 
     /* Check arguments */
     if (!group_name || !*group_name)
@@ -1515,7 +1515,7 @@ H5Lget_name_by_idx(hid_t loc_id, const char *group_name, H5_index_t idx_type, H5
     ssize_t              ret_value     = -1; /* Return value */
 
     FUNC_ENTER_API((-1))
-    H5TRACE8("Zs", "i*sIiIohxzi", loc_id, group_name, idx_type, order, n, name, size, lapl_id);
+    H5TRACE8("Zs", "i*sIiIoh*szi", loc_id, group_name, idx_type, order, n, name, size, lapl_id);
 
     /* Check arguments */
     if (!group_name || !*group_name)

--- a/src/H5Ldeprec.c
+++ b/src/H5Ldeprec.c
@@ -311,7 +311,7 @@ H5Lget_info1(hid_t loc_id, const char *name, H5L_info1_t *linfo /*out*/, hid_t l
     herr_t               ret_value = SUCCEED; /* Return value */
 
     FUNC_ENTER_API(FAIL)
-    H5TRACE4("e", "i*sxi", loc_id, name, linfo, lapl_id);
+    H5TRACE4("e", "i*s*!i", loc_id, name, linfo, lapl_id);
 
     /* Check arguments */
     if (!name || !*name)
@@ -396,7 +396,7 @@ H5Lget_info_by_idx1(hid_t loc_id, const char *group_name, H5_index_t idx_type, H
     herr_t               ret_value = SUCCEED; /* Return value */
 
     FUNC_ENTER_API(FAIL)
-    H5TRACE7("e", "i*sIiIohxi", loc_id, group_name, idx_type, order, n, linfo, lapl_id);
+    H5TRACE7("e", "i*sIiIoh*!i", loc_id, group_name, idx_type, order, n, linfo, lapl_id);
 
     /* Check arguments */
     if (!group_name || !*group_name)

--- a/src/H5M.c
+++ b/src/H5M.c
@@ -881,7 +881,7 @@ H5Mget_count(hid_t map_id, hsize_t *count /*out*/, hid_t dxpl_id)
     herr_t               ret_value = SUCCEED; /* Return value         */
 
     FUNC_ENTER_API(H5I_INVALID_HID)
-    H5TRACE3("e", "ixi", map_id, count, dxpl_id);
+    H5TRACE3("e", "i*hi", map_id, count, dxpl_id);
 
     /* Check args */
     if (NULL == (vol_obj = (H5VL_object_t *)H5I_object_verify(map_id, H5I_MAP)))

--- a/src/H5O.c
+++ b/src/H5O.c
@@ -1079,7 +1079,7 @@ H5Oget_info3(hid_t loc_id, H5O_info2_t *oinfo /*out*/, unsigned fields)
     herr_t                 ret_value = SUCCEED; /* Return value */
 
     FUNC_ENTER_API(FAIL)
-    H5TRACE3("e", "ixIu", loc_id, oinfo, fields);
+    H5TRACE3("e", "i*!Iu", loc_id, oinfo, fields);
 
     /* Check args */
     if (!oinfo)
@@ -1171,7 +1171,7 @@ H5Oget_info_by_name3(hid_t loc_id, const char *name, H5O_info2_t *oinfo /*out*/,
     herr_t ret_value = SUCCEED; /* Return value */
 
     FUNC_ENTER_API(FAIL)
-    H5TRACE5("e", "i*sxIui", loc_id, name, oinfo, fields, lapl_id);
+    H5TRACE5("e", "i*s*!Iui", loc_id, name, oinfo, fields, lapl_id);
 
     /* Retrieve object information synchronously */
     if (H5O__get_info_by_name_api_common(loc_id, name, oinfo, fields, lapl_id, NULL, NULL) < 0)
@@ -1201,7 +1201,7 @@ H5Oget_info_by_name_async(const char *app_file, const char *app_func, unsigned a
     herr_t         ret_value = SUCCEED;         /* Return value */
 
     FUNC_ENTER_API(FAIL)
-    H5TRACE9("e", "*s*sIui*sxIuii", app_file, app_func, app_line, loc_id, name, oinfo, fields, lapl_id,
+    H5TRACE9("e", "*s*sIui*s*!Iuii", app_file, app_func, app_line, loc_id, name, oinfo, fields, lapl_id,
              es_id);
 
     /* Set up request token pointer for asynchronous operation */
@@ -1216,7 +1216,7 @@ H5Oget_info_by_name_async(const char *app_file, const char *app_func, unsigned a
     if (NULL != token)
         /* clang-format off */
         if (H5ES_insert(es_id, vol_obj->connector, token,
-                        H5ARG_TRACE9(__func__, "*s*sIui*sxIuii", app_file, app_func, app_line, loc_id, name, oinfo, fields, lapl_id, es_id)) < 0)
+                        H5ARG_TRACE9(__func__, "*s*sIui*s*!Iuii", app_file, app_func, app_line, loc_id, name, oinfo, fields, lapl_id, es_id)) < 0)
             /* clang-format on */
             HGOTO_ERROR(H5E_OHDR, H5E_CANTINSERT, FAIL, "can't insert token into event set");
 
@@ -1245,7 +1245,7 @@ H5Oget_info_by_idx3(hid_t loc_id, const char *group_name, H5_index_t idx_type, H
     herr_t                 ret_value = SUCCEED; /* Return value */
 
     FUNC_ENTER_API(FAIL)
-    H5TRACE8("e", "i*sIiIohxIui", loc_id, group_name, idx_type, order, n, oinfo, fields, lapl_id);
+    H5TRACE8("e", "i*sIiIoh*!Iui", loc_id, group_name, idx_type, order, n, oinfo, fields, lapl_id);
 
     /* Check args */
     if (!group_name || !*group_name)
@@ -1308,7 +1308,7 @@ H5Oget_native_info(hid_t loc_id, H5O_native_info_t *oinfo /*out*/, unsigned fiel
     herr_t                             ret_value = SUCCEED; /* Return value */
 
     FUNC_ENTER_API(FAIL)
-    H5TRACE3("e", "ixIu", loc_id, oinfo, fields);
+    H5TRACE3("e", "i*!Iu", loc_id, oinfo, fields);
 
     /* Check args */
     if (!oinfo)
@@ -1359,7 +1359,7 @@ H5Oget_native_info_by_name(hid_t loc_id, const char *name, H5O_native_info_t *oi
     herr_t                             ret_value = SUCCEED; /* Return value */
 
     FUNC_ENTER_API(FAIL)
-    H5TRACE5("e", "i*sxIui", loc_id, name, oinfo, fields, lapl_id);
+    H5TRACE5("e", "i*s*!Iui", loc_id, name, oinfo, fields, lapl_id);
 
     /* Check args */
     if (!name)
@@ -1422,7 +1422,7 @@ H5Oget_native_info_by_idx(hid_t loc_id, const char *group_name, H5_index_t idx_t
     herr_t                             ret_value = SUCCEED; /* Return value */
 
     FUNC_ENTER_API(FAIL)
-    H5TRACE8("e", "i*sIiIohxIui", loc_id, group_name, idx_type, order, n, oinfo, fields, lapl_id);
+    H5TRACE8("e", "i*sIiIoh*!Iui", loc_id, group_name, idx_type, order, n, oinfo, fields, lapl_id);
 
     /* Check args */
     if (!group_name || !*group_name)
@@ -1602,7 +1602,7 @@ H5Oget_comment(hid_t obj_id, char *comment /*out*/, size_t bufsize)
     ssize_t                            ret_value   = -1; /* Return value */
 
     FUNC_ENTER_API((-1))
-    H5TRACE3("Zs", "ixz", obj_id, comment, bufsize);
+    H5TRACE3("Zs", "i*sz", obj_id, comment, bufsize);
 
     /* Get the object */
     if (NULL == (vol_obj = H5VL_vol_object(obj_id)))
@@ -1655,7 +1655,7 @@ H5Oget_comment_by_name(hid_t loc_id, const char *name, char *comment /*out*/, si
     ssize_t                            ret_value   = -1; /* Return value */
 
     FUNC_ENTER_API((-1))
-    H5TRACE5("Zs", "i*sxzi", loc_id, name, comment, bufsize, lapl_id);
+    H5TRACE5("Zs", "i*s*szi", loc_id, name, comment, bufsize, lapl_id);
 
     /* Check args */
     if (!name || !*name)

--- a/src/H5O.c
+++ b/src/H5O.c
@@ -2196,7 +2196,7 @@ H5Oare_mdc_flushes_disabled(hid_t object_id, bool *are_disabled)
     herr_t                             ret_value = SUCCEED; /* Return value */
 
     FUNC_ENTER_API(FAIL)
-    H5TRACE2("e", "i*!", object_id, are_disabled);
+    H5TRACE2("e", "i*b", object_id, are_disabled);
 
     /* Sanity check */
     if (!are_disabled)

--- a/src/H5Odeprec.c
+++ b/src/H5Odeprec.c
@@ -405,7 +405,7 @@ H5Oget_info1(hid_t loc_id, H5O_info1_t *oinfo /*out*/)
     herr_t            ret_value         = SUCCEED; /* Return value */
 
     FUNC_ENTER_API(FAIL)
-    H5TRACE2("e", "ix", loc_id, oinfo);
+    H5TRACE2("e", "i*!", loc_id, oinfo);
 
     /* Check args */
     if (!oinfo)
@@ -455,7 +455,7 @@ H5Oget_info_by_name1(hid_t loc_id, const char *name, H5O_info1_t *oinfo /*out*/,
     herr_t            ret_value         = SUCCEED; /* Return value */
 
     FUNC_ENTER_API(FAIL)
-    H5TRACE4("e", "i*sxi", loc_id, name, oinfo, lapl_id);
+    H5TRACE4("e", "i*s*!i", loc_id, name, oinfo, lapl_id);
 
     /* Check args */
     if (!name)
@@ -517,7 +517,7 @@ H5Oget_info_by_idx1(hid_t loc_id, const char *group_name, H5_index_t idx_type, H
     herr_t            ret_value         = SUCCEED; /* Return value */
 
     FUNC_ENTER_API(FAIL)
-    H5TRACE7("e", "i*sIiIohxi", loc_id, group_name, idx_type, order, n, oinfo, lapl_id);
+    H5TRACE7("e", "i*sIiIoh*!i", loc_id, group_name, idx_type, order, n, oinfo, lapl_id);
 
     /* Check args */
     if (!group_name || !*group_name)
@@ -582,7 +582,7 @@ H5Oget_info2(hid_t loc_id, H5O_info1_t *oinfo /*out*/, unsigned fields)
     herr_t            ret_value = SUCCEED; /* Return value */
 
     FUNC_ENTER_API(FAIL)
-    H5TRACE3("e", "ixIu", loc_id, oinfo, fields);
+    H5TRACE3("e", "i*!Iu", loc_id, oinfo, fields);
 
     /* Check args */
     if (!oinfo)
@@ -635,7 +635,7 @@ H5Oget_info_by_name2(hid_t loc_id, const char *name, H5O_info1_t *oinfo /*out*/,
     herr_t            ret_value = SUCCEED; /* Return value */
 
     FUNC_ENTER_API(FAIL)
-    H5TRACE5("e", "i*sxIui", loc_id, name, oinfo, fields, lapl_id);
+    H5TRACE5("e", "i*s*!Iui", loc_id, name, oinfo, fields, lapl_id);
 
     /* Check args */
     if (!name)
@@ -700,7 +700,7 @@ H5Oget_info_by_idx2(hid_t loc_id, const char *group_name, H5_index_t idx_type, H
     herr_t            ret_value = SUCCEED; /* Return value */
 
     FUNC_ENTER_API(FAIL)
-    H5TRACE8("e", "i*sIiIohxIui", loc_id, group_name, idx_type, order, n, oinfo, fields, lapl_id);
+    H5TRACE8("e", "i*sIiIoh*!Iui", loc_id, group_name, idx_type, order, n, oinfo, fields, lapl_id);
 
     /* Check args */
     if (!group_name || !*group_name)

--- a/src/H5P.c
+++ b/src/H5P.c
@@ -758,7 +758,7 @@ H5Pget_size(hid_t id, const char *name, size_t *size /*out*/)
     herr_t          ret_value; /* return value */
 
     FUNC_ENTER_API(FAIL)
-    H5TRACE3("e", "i*sx", id, name, size);
+    H5TRACE3("e", "i*s*z", id, name, size);
 
     /* Check arguments. */
     if (H5I_GENPROP_LST != H5I_get_type(id) && H5I_GENPROP_CLS != H5I_get_type(id))
@@ -963,7 +963,7 @@ H5Pget_nprops(hid_t id, size_t *nprops /*out*/)
     herr_t          ret_value = SUCCEED; /* return value */
 
     FUNC_ENTER_API(FAIL)
-    H5TRACE2("e", "ix", id, nprops);
+    H5TRACE2("e", "i*z", id, nprops);
 
     /* Check arguments. */
     if (H5I_GENPROP_LST != H5I_get_type(id) && H5I_GENPROP_CLS != H5I_get_type(id))
@@ -1263,7 +1263,7 @@ H5Pget(hid_t plist_id, const char *name, void *value /*out*/)
     herr_t          ret_value = SUCCEED; /* return value */
 
     FUNC_ENTER_API(FAIL)
-    H5TRACE3("e", "i*sx", plist_id, name, value);
+    H5TRACE3("e", "i*s*x", plist_id, name, value);
 
     /* Check arguments. */
     if (NULL == (plist = (H5P_genplist_t *)H5I_object_verify(plist_id, H5I_GENPROP_LST)))

--- a/src/H5PL.c
+++ b/src/H5PL.c
@@ -109,7 +109,7 @@ H5PLget_loading_state(unsigned *plugin_control_mask /*out*/)
     herr_t ret_value = SUCCEED; /* Return value */
 
     FUNC_ENTER_API(FAIL)
-    H5TRACE1("e", "x", plugin_control_mask);
+    H5TRACE1("e", "*Iu", plugin_control_mask);
 
     if (NULL == plugin_control_mask)
         HGOTO_ERROR(H5E_ARGS, H5E_BADVALUE, FAIL, "plugin_control_mask parameter cannot be NULL");

--- a/src/H5Pdapl.c
+++ b/src/H5Pdapl.c
@@ -810,7 +810,7 @@ H5Pget_chunk_cache(hid_t dapl_id, size_t *rdcc_nslots /*out*/, size_t *rdcc_nbyt
     herr_t          ret_value = SUCCEED; /* return value */
 
     FUNC_ENTER_API(FAIL)
-    H5TRACE4("e", "ixxx", dapl_id, rdcc_nslots, rdcc_nbytes, rdcc_w0);
+    H5TRACE4("e", "i*z*z*d", dapl_id, rdcc_nslots, rdcc_nbytes, rdcc_w0);
 
     /* Get the plist structure */
     if (NULL == (plist = H5P_object_verify(dapl_id, H5P_DATASET_ACCESS)))
@@ -1108,7 +1108,7 @@ H5Pget_virtual_view(hid_t plist_id, H5D_vds_view_t *view /*out*/)
     herr_t          ret_value = SUCCEED; /* Return value */
 
     FUNC_ENTER_API(FAIL)
-    H5TRACE2("e", "ix", plist_id, view);
+    H5TRACE2("e", "i*Dv", plist_id, view);
 
     /* Get the plist structure */
     if (NULL == (plist = H5P_object_verify(plist_id, H5P_DATASET_ACCESS)))
@@ -1251,7 +1251,7 @@ H5Pget_virtual_printf_gap(hid_t plist_id, hsize_t *gap_size /*out*/)
     herr_t          ret_value = SUCCEED; /* Return value */
 
     FUNC_ENTER_API(FAIL)
-    H5TRACE2("e", "ix", plist_id, gap_size);
+    H5TRACE2("e", "i*h", plist_id, gap_size);
 
     /* Get the plist structure */
     if (NULL == (plist = H5P_object_verify(plist_id, H5P_DATASET_ACCESS)))
@@ -1353,7 +1353,7 @@ H5Pget_append_flush(hid_t plist_id, unsigned ndims, hsize_t boundary[], H5D_appe
     herr_t             ret_value = SUCCEED; /* return value */
 
     FUNC_ENTER_API(FAIL)
-    H5TRACE5("e", "iIu*hxx", plist_id, ndims, boundary, func, udata);
+    H5TRACE5("e", "iIu*h*DA**x", plist_id, ndims, boundary, func, udata);
 
     /* Get the plist structure */
     if (NULL == (plist = H5P_object_verify(plist_id, H5P_DATASET_ACCESS)))
@@ -1436,7 +1436,7 @@ H5Pget_efile_prefix(hid_t plist_id, char *prefix /*out*/, size_t size)
     ssize_t         ret_value; /* Return value */
 
     FUNC_ENTER_API(FAIL)
-    H5TRACE3("Zs", "ixz", plist_id, prefix, size);
+    H5TRACE3("Zs", "i*sz", plist_id, prefix, size);
 
     /* Get the plist structure */
     if (NULL == (plist = H5P_object_verify(plist_id, H5P_DATASET_ACCESS)))
@@ -1526,7 +1526,7 @@ H5Pget_virtual_prefix(hid_t plist_id, char *prefix /*out*/, size_t size)
     ssize_t         ret_value; /* Return value */
 
     FUNC_ENTER_API(FAIL)
-    H5TRACE3("Zs", "ixz", plist_id, prefix, size);
+    H5TRACE3("Zs", "i*sz", plist_id, prefix, size);
 
     /* Get the plist structure */
     if (NULL == (plist = H5P_object_verify(plist_id, H5P_DATASET_ACCESS)))

--- a/src/H5Pdcpl.c
+++ b/src/H5Pdcpl.c
@@ -1980,7 +1980,7 @@ H5Pget_chunk(hid_t plist_id, int max_ndims, hsize_t dim[] /*out*/)
     int             ret_value; /* Return value */
 
     FUNC_ENTER_API(FAIL)
-    H5TRACE3("Is", "iIsx", plist_id, max_ndims, dim);
+    H5TRACE3("Is", "iIs*h", plist_id, max_ndims, dim);
 
     /* Get the plist structure */
     if (NULL == (plist = H5P_object_verify(plist_id, H5P_DATASET_CREATE)))
@@ -2203,7 +2203,7 @@ H5Pget_virtual_count(hid_t dcpl_id, size_t *count /*out*/)
     herr_t          ret_value = SUCCEED; /* Return value */
 
     FUNC_ENTER_API(FAIL)
-    H5TRACE2("e", "ix", dcpl_id, count);
+    H5TRACE2("e", "i*z", dcpl_id, count);
 
     if (count) {
         /* Get the plist structure */
@@ -2400,7 +2400,7 @@ H5Pget_virtual_filename(hid_t dcpl_id, size_t idx, char *name /*out*/, size_t si
     ssize_t         ret_value; /* Return value */
 
     FUNC_ENTER_API(FAIL)
-    H5TRACE4("Zs", "izxz", dcpl_id, idx, name, size);
+    H5TRACE4("Zs", "iz*sz", dcpl_id, idx, name, size);
 
     /* Get the plist structure */
     if (NULL == (plist = H5P_object_verify(dcpl_id, H5P_DATASET_CREATE)))
@@ -2458,7 +2458,7 @@ H5Pget_virtual_dsetname(hid_t dcpl_id, size_t idx, char *name /*out*/, size_t si
     ssize_t         ret_value; /* Return value */
 
     FUNC_ENTER_API(FAIL)
-    H5TRACE4("Zs", "izxz", dcpl_id, idx, name, size);
+    H5TRACE4("Zs", "iz*sz", dcpl_id, idx, name, size);
 
     /* Get the plist structure */
     if (NULL == (plist = H5P_object_verify(dcpl_id, H5P_DATASET_CREATE)))
@@ -2554,7 +2554,7 @@ H5Pget_chunk_opts(hid_t plist_id, unsigned *options /*out*/)
     herr_t          ret_value = SUCCEED; /* Return value */
 
     FUNC_ENTER_API(FAIL)
-    H5TRACE2("e", "ix", plist_id, options);
+    H5TRACE2("e", "i*Iu", plist_id, options);
 
     /* Get the plist structure */
     if (NULL == (plist = H5P_object_verify(plist_id, H5P_DATASET_CREATE)))
@@ -2723,7 +2723,7 @@ H5Pget_external(hid_t plist_id, unsigned idx, size_t name_size, char *name /*out
     herr_t          ret_value = SUCCEED; /* return value */
 
     FUNC_ENTER_API(FAIL)
-    H5TRACE6("e", "iIuzxxx", plist_id, idx, name_size, name, offset, size);
+    H5TRACE6("e", "iIuz*s*o*h", plist_id, idx, name_size, name, offset, size);
 
     /* Get the plist structure */
     if (NULL == (plist = H5P_object_verify(plist_id, H5P_DATASET_CREATE)))
@@ -3176,7 +3176,7 @@ H5Pget_fill_value(hid_t plist_id, hid_t type_id, void *value /*out*/)
     herr_t          ret_value = SUCCEED; /* Return value */
 
     FUNC_ENTER_API(FAIL)
-    H5TRACE3("e", "iix", plist_id, type_id, value);
+    H5TRACE3("e", "ii*x", plist_id, type_id, value);
 
     /* Check arguments */
     if (NULL == (type = (H5T_t *)H5I_object_verify(type_id, H5I_DATATYPE)))
@@ -3399,7 +3399,7 @@ H5Pget_alloc_time(hid_t plist_id, H5D_alloc_time_t *alloc_time /*out*/)
     herr_t ret_value = SUCCEED; /* return value          */
 
     FUNC_ENTER_API(FAIL)
-    H5TRACE2("e", "ix", plist_id, alloc_time);
+    H5TRACE2("e", "i*Da", plist_id, alloc_time);
 
     /* Get values */
     if (alloc_time) {
@@ -3481,7 +3481,7 @@ H5Pget_fill_time(hid_t plist_id, H5D_fill_time_t *fill_time /*out*/)
     herr_t ret_value = SUCCEED; /* return value          */
 
     FUNC_ENTER_API(FAIL)
-    H5TRACE2("e", "ix", plist_id, fill_time);
+    H5TRACE2("e", "i*Df", plist_id, fill_time);
 
     /* Set values */
     if (fill_time) {
@@ -3527,7 +3527,7 @@ H5Pget_dset_no_attrs_hint(hid_t dcpl_id, hbool_t *minimize /*out*/)
     herr_t          ret_value = SUCCEED;
 
     FUNC_ENTER_API(FAIL)
-    H5TRACE2("e", "ix", dcpl_id, minimize);
+    H5TRACE2("e", "i*b", dcpl_id, minimize);
 
     if (NULL == minimize)
         HGOTO_ERROR(H5E_ARGS, H5E_BADVALUE, FAIL, "receiving pointer cannot be NULL");

--- a/src/H5Pdeprec.c
+++ b/src/H5Pdeprec.c
@@ -449,7 +449,7 @@ H5Pget_version(hid_t plist_id, unsigned *super /*out*/, unsigned *freelist /*out
     herr_t          ret_value = SUCCEED; /* Return value */
 
     FUNC_ENTER_API(FAIL)
-    H5TRACE5("e", "ixxxx", plist_id, super, freelist, stab, shhdr);
+    H5TRACE5("e", "i*Iu*Iu*Iu*Iu", plist_id, super, freelist, stab, shhdr);
 
     /* Get the plist structure */
     if (NULL == (plist = H5P_object_verify(plist_id, H5P_FILE_CREATE)))
@@ -605,7 +605,7 @@ H5Pget_file_space(hid_t plist_id, H5F_file_space_type_t *strategy /*out*/, hsize
     herr_t                ret_value = SUCCEED; /* Return value */
 
     FUNC_ENTER_API(FAIL)
-    H5TRACE3("e", "ixx", plist_id, strategy, threshold);
+    H5TRACE3("e", "i*Ft*h", plist_id, strategy, threshold);
 
     /* Get current file space info */
     if (H5Pget_file_space_strategy(plist_id, &new_strategy, &new_persist, &new_threshold) < 0)

--- a/src/H5Pdxpl.c
+++ b/src/H5Pdxpl.c
@@ -1033,7 +1033,7 @@ H5Pget_data_transform(hid_t plist_id, char *expression /*out*/, size_t size)
     ssize_t           ret_value; /* return value */
 
     FUNC_ENTER_API(FAIL)
-    H5TRACE3("Zs", "ixz", plist_id, expression, size);
+    H5TRACE3("Zs", "i*sz", plist_id, expression, size);
 
     /* Get the plist structure */
     if (NULL == (plist = H5P_object_verify(plist_id, H5P_DATASET_XFER)))
@@ -1129,7 +1129,7 @@ H5Pget_buffer(hid_t plist_id, void **tconv /*out*/, void **bkg /*out*/)
     size_t          ret_value; /* Return value */
 
     FUNC_ENTER_API(0)
-    H5TRACE3("z", "ixx", plist_id, tconv, bkg);
+    H5TRACE3("z", "i**x**x", plist_id, tconv, bkg);
 
     /* Get the plist structure */
     if (NULL == (plist = H5P_object_verify(plist_id, H5P_DATASET_XFER)))
@@ -1387,7 +1387,7 @@ H5Pget_type_conv_cb(hid_t plist_id, H5T_conv_except_func_t *op /*out*/, void **o
     herr_t          ret_value = SUCCEED; /* return value */
 
     FUNC_ENTER_API(FAIL)
-    H5TRACE3("e", "ixx", plist_id, op, operate_data);
+    H5TRACE3("e", "i*TE**x", plist_id, op, operate_data);
 
     /* Get the plist structure */
     if (NULL == (plist = H5P_object_verify(plist_id, H5P_DATASET_XFER)))
@@ -1425,7 +1425,7 @@ H5Pget_btree_ratios(hid_t plist_id, double *left /*out*/, double *middle /*out*/
     herr_t          ret_value = SUCCEED;  /* Return value */
 
     FUNC_ENTER_API(FAIL)
-    H5TRACE4("e", "ixxx", plist_id, left, middle, right);
+    H5TRACE4("e", "i*d*d*d", plist_id, left, middle, right);
 
     /* Get the plist structure */
     if (NULL == (plist = H5P_object_verify(plist_id, H5P_DATASET_XFER)))
@@ -1590,7 +1590,7 @@ H5Pget_vlen_mem_manager(hid_t plist_id, H5MM_allocate_t *alloc_func /*out*/, voi
     herr_t          ret_value = SUCCEED; /* Return value */
 
     FUNC_ENTER_API(FAIL)
-    H5TRACE5("e", "ixxxx", plist_id, alloc_func, alloc_info, free_func, free_info);
+    H5TRACE5("e", "i*Ma**x*Mf**x", plist_id, alloc_func, alloc_info, free_func, free_info);
 
     /* Get the plist structure */
     if (NULL == (plist = H5P_object_verify(plist_id, H5P_DATASET_XFER)))
@@ -1672,7 +1672,7 @@ H5Pget_hyper_vector_size(hid_t plist_id, size_t *vector_size /*out*/)
     herr_t          ret_value = SUCCEED; /* Return value */
 
     FUNC_ENTER_API(FAIL)
-    H5TRACE2("e", "ix", plist_id, vector_size);
+    H5TRACE2("e", "i*z", plist_id, vector_size);
 
     /* Get the plist structure */
     if (NULL == (plist = H5P_object_verify(plist_id, H5P_DATASET_XFER)))
@@ -1904,7 +1904,7 @@ H5Pget_mpio_actual_chunk_opt_mode(hid_t                             plist_id,
     herr_t          ret_value = SUCCEED; /* return value */
 
     FUNC_ENTER_API(FAIL)
-    H5TRACE2("e", "ix", plist_id, actual_chunk_opt_mode);
+    H5TRACE2("e", "i*Do", plist_id, actual_chunk_opt_mode);
 
     /* Get the plist structure */
     if (NULL == (plist = H5P_object_verify(plist_id, H5P_DATASET_XFER)))
@@ -1936,7 +1936,7 @@ H5Pget_mpio_actual_io_mode(hid_t plist_id, H5D_mpio_actual_io_mode_t *actual_io_
     herr_t          ret_value = SUCCEED; /* return value */
 
     FUNC_ENTER_API(FAIL)
-    H5TRACE2("e", "ix", plist_id, actual_io_mode);
+    H5TRACE2("e", "i*Di", plist_id, actual_io_mode);
 
     /* Get the plist structure */
     if (NULL == (plist = H5P_object_verify(plist_id, H5P_DATASET_XFER)))
@@ -1968,7 +1968,7 @@ H5Pget_mpio_no_collective_cause(hid_t plist_id, uint32_t *local_no_collective_ca
     herr_t          ret_value = SUCCEED; /* return value */
 
     FUNC_ENTER_API(FAIL)
-    H5TRACE3("e", "ixx", plist_id, local_no_collective_cause, global_no_collective_cause);
+    H5TRACE3("e", "i*Iu*Iu", plist_id, local_no_collective_cause, global_no_collective_cause);
 
     /* Get the plist structure */
     if (NULL == (plist = H5P_object_verify(plist_id, H5P_DATASET_XFER)))
@@ -2421,7 +2421,7 @@ H5Pget_selection_io(hid_t plist_id, H5D_selection_io_mode_t *selection_io_mode /
     herr_t          ret_value = SUCCEED; /* Return value */
 
     FUNC_ENTER_API(FAIL)
-    H5TRACE2("e", "ix", plist_id, selection_io_mode);
+    H5TRACE2("e", "i*DC", plist_id, selection_io_mode);
 
     /* Check arguments */
     if (NULL == (plist = H5P_object_verify(plist_id, H5P_DATASET_XFER)))
@@ -2452,7 +2452,7 @@ H5Pget_no_selection_io_cause(hid_t plist_id, uint32_t *no_selection_io_cause /*o
     herr_t          ret_value = SUCCEED; /* return value */
 
     FUNC_ENTER_API(FAIL)
-    H5TRACE2("e", "ix", plist_id, no_selection_io_cause);
+    H5TRACE2("e", "i*Iu", plist_id, no_selection_io_cause);
 
     /* Get the plist structure */
     if (NULL == (plist = H5P_object_verify(plist_id, H5P_DATASET_XFER)))
@@ -2485,7 +2485,7 @@ H5Pget_actual_selection_io_mode(hid_t plist_id, uint32_t *actual_selection_io_mo
     herr_t          ret_value = SUCCEED; /* return value */
 
     FUNC_ENTER_API(FAIL)
-    H5TRACE2("e", "ix", plist_id, actual_selection_io_mode);
+    H5TRACE2("e", "i*Iu", plist_id, actual_selection_io_mode);
 
     /* Get the plist structure */
     if (NULL == (plist = H5P_object_verify(plist_id, H5P_DATASET_XFER)))
@@ -2617,7 +2617,7 @@ H5Pget_modify_write_buf(hid_t plist_id, hbool_t *modify_write_buf /*out*/)
     herr_t          ret_value = SUCCEED; /* Return value */
 
     FUNC_ENTER_API(FAIL)
-    H5TRACE2("e", "ix", plist_id, modify_write_buf);
+    H5TRACE2("e", "i*b", plist_id, modify_write_buf);
 
     /* Check arguments */
     if (NULL == (plist = H5P_object_verify(plist_id, H5P_DATASET_XFER)))

--- a/src/H5Pfapl.c
+++ b/src/H5Pfapl.c
@@ -1106,7 +1106,7 @@ H5Pget_alignment(hid_t fapl_id, hsize_t *threshold /*out*/, hsize_t *alignment /
     herr_t          ret_value = SUCCEED; /* Return value */
 
     FUNC_ENTER_API(FAIL)
-    H5TRACE3("e", "ixx", fapl_id, threshold, alignment);
+    H5TRACE3("e", "i*h*h", fapl_id, threshold, alignment);
 
     /* Get the plist structure */
     if (NULL == (plist = H5P_object_verify(fapl_id, H5P_FILE_ACCESS)))
@@ -2028,7 +2028,7 @@ H5Pget_family_offset(hid_t fapl_id, hsize_t *offset /*out*/)
     herr_t          ret_value = SUCCEED; /* Return value */
 
     FUNC_ENTER_API(FAIL)
-    H5TRACE2("e", "ix", fapl_id, offset);
+    H5TRACE2("e", "i*h", fapl_id, offset);
 
     /* Get the plist structure */
     if (H5P_DEFAULT == fapl_id)
@@ -2100,7 +2100,7 @@ H5Pget_multi_type(hid_t fapl_id, H5FD_mem_t *type /*out*/)
     herr_t          ret_value = SUCCEED; /* Return value */
 
     FUNC_ENTER_API(FAIL)
-    H5TRACE2("e", "ix", fapl_id, type);
+    H5TRACE2("e", "i*Mt", fapl_id, type);
 
     /* Get the plist structure */
     if (H5P_DEFAULT == fapl_id)
@@ -2189,7 +2189,7 @@ H5Pget_cache(hid_t plist_id, int *mdc_nelmts, size_t *rdcc_nslots /*out*/, size_
     herr_t          ret_value = SUCCEED; /* return value */
 
     FUNC_ENTER_API(FAIL)
-    H5TRACE5("e", "i*Isxxx", plist_id, mdc_nelmts, rdcc_nslots, rdcc_nbytes, rdcc_w0);
+    H5TRACE5("e", "i*Is*z*z*d", plist_id, mdc_nelmts, rdcc_nslots, rdcc_nbytes, rdcc_w0);
 
     /* Get the plist structure */
     if (NULL == (plist = H5P_object_verify(plist_id, H5P_FILE_ACCESS)))
@@ -2276,7 +2276,7 @@ H5Pget_mdc_image_config(hid_t plist_id, H5AC_cache_image_config_t *config /*out*
     herr_t          ret_value = SUCCEED; /* return value */
 
     FUNC_ENTER_API(FAIL)
-    H5TRACE2("e", "ix", plist_id, config);
+    H5TRACE2("e", "i*CC", plist_id, config);
 
     /* Get the plist structure */
     if (NULL == (plist = H5P_object_verify(plist_id, H5P_FILE_ACCESS)))
@@ -2362,7 +2362,7 @@ H5Pget_mdc_config(hid_t plist_id, H5AC_cache_config_t *config /*out*/)
     herr_t          ret_value = SUCCEED; /* return value */
 
     FUNC_ENTER_API(FAIL)
-    H5TRACE2("e", "ix", plist_id, config);
+    H5TRACE2("e", "i*Cc", plist_id, config);
 
     /* Get the plist structure */
     if (NULL == (plist = H5P_object_verify(plist_id, H5P_FILE_ACCESS)))
@@ -2446,7 +2446,7 @@ H5Pget_gc_references(hid_t plist_id, unsigned *gc_ref /*out*/)
     herr_t          ret_value = SUCCEED; /* return value */
 
     FUNC_ENTER_API(FAIL)
-    H5TRACE2("e", "ix", plist_id, gc_ref);
+    H5TRACE2("e", "i*Iu", plist_id, gc_ref);
 
     /* Get the plist structure */
     if (NULL == (plist = H5P_object_verify(plist_id, H5P_FILE_ACCESS)))
@@ -2507,7 +2507,7 @@ H5Pget_fclose_degree(hid_t plist_id, H5F_close_degree_t *degree /*out*/)
     herr_t          ret_value = SUCCEED; /* return value */
 
     FUNC_ENTER_API(FAIL)
-    H5TRACE2("e", "ix", plist_id, degree);
+    H5TRACE2("e", "i*Fd", plist_id, degree);
 
     /* Get the plist structure */
     if (NULL == (plist = H5P_object_verify(plist_id, H5P_FILE_ACCESS)))
@@ -2577,7 +2577,7 @@ H5Pget_meta_block_size(hid_t plist_id, hsize_t *size /*out*/)
     herr_t          ret_value = SUCCEED; /* return value */
 
     FUNC_ENTER_API(FAIL)
-    H5TRACE2("e", "ix", plist_id, size);
+    H5TRACE2("e", "i*h", plist_id, size);
 
     /* Get the plist structure */
     if (NULL == (plist = H5P_object_verify(plist_id, H5P_FILE_ACCESS)))
@@ -2650,7 +2650,7 @@ H5Pget_sieve_buf_size(hid_t plist_id, size_t *size /*out*/)
     herr_t          ret_value = SUCCEED; /* return value */
 
     FUNC_ENTER_API(FAIL)
-    H5TRACE2("e", "ix", plist_id, size);
+    H5TRACE2("e", "i*z", plist_id, size);
 
     /* Get the plist structure */
     if (NULL == (plist = H5P_object_verify(plist_id, H5P_FILE_ACCESS)))
@@ -2722,7 +2722,7 @@ H5Pget_small_data_block_size(hid_t plist_id, hsize_t *size /*out*/)
     herr_t          ret_value = SUCCEED; /* return value */
 
     FUNC_ENTER_API(FAIL)
-    H5TRACE2("e", "ix", plist_id, size);
+    H5TRACE2("e", "i*h", plist_id, size);
 
     /* Get the plist structure */
     if (NULL == (plist = H5P_object_verify(plist_id, H5P_FILE_ACCESS)))
@@ -2892,7 +2892,7 @@ H5Pget_libver_bounds(hid_t plist_id, H5F_libver_t *low /*out*/, H5F_libver_t *hi
     herr_t          ret_value = SUCCEED; /* return value */
 
     FUNC_ENTER_API(FAIL)
-    H5TRACE3("e", "ixx", plist_id, low, high);
+    H5TRACE3("e", "i*Fv*Fv", plist_id, low, high);
 
     /* Get the plist structure */
     if (NULL == (plist = H5P_object_verify(plist_id, H5P_FILE_ACCESS)))
@@ -2965,7 +2965,7 @@ H5Pget_elink_file_cache_size(hid_t plist_id, unsigned *efc_size /*out*/)
     herr_t          ret_value = SUCCEED; /* return value */
 
     FUNC_ENTER_API(FAIL)
-    H5TRACE2("e", "ix", plist_id, efc_size);
+    H5TRACE2("e", "i*Iu", plist_id, efc_size);
 
     /* Get the plist structure */
     if (NULL == (plist = H5P_object_verify(plist_id, H5P_FILE_ACCESS)))
@@ -3092,7 +3092,7 @@ H5Pget_file_image(hid_t fapl_id, void **buf /*out*/, size_t *buf_len /*out*/)
     herr_t                 ret_value = SUCCEED; /* Return value */
 
     FUNC_ENTER_API(FAIL)
-    H5TRACE3("e", "ixx", fapl_id, buf, buf_len);
+    H5TRACE3("e", "i**x*z", fapl_id, buf, buf_len);
 
     /* Get the plist structure */
     if (NULL == (fapl = H5P_object_verify(fapl_id, H5P_FILE_ACCESS)))
@@ -3245,7 +3245,7 @@ H5Pget_file_image_callbacks(hid_t fapl_id, H5FD_file_image_callbacks_t *callback
     herr_t                 ret_value = SUCCEED; /* Return value */
 
     FUNC_ENTER_API(FAIL)
-    H5TRACE2("e", "ix", fapl_id, callbacks);
+    H5TRACE2("e", "i*DI", fapl_id, callbacks);
 
     /* Get the plist structure */
     if (NULL == (fapl = H5P_object_verify(fapl_id, H5P_FILE_ACCESS)))
@@ -4439,7 +4439,7 @@ H5Pget_metadata_read_attempts(hid_t plist_id, unsigned *attempts /*out*/)
     herr_t ret_value = SUCCEED; /* Return value */
 
     FUNC_ENTER_API(FAIL)
-    H5TRACE2("e", "ix", plist_id, attempts);
+    H5TRACE2("e", "i*Iu", plist_id, attempts);
 
     /* Get values */
     if (attempts) {
@@ -4521,7 +4521,7 @@ H5Pget_object_flush_cb(hid_t plist_id, H5F_flush_cb_t *func /*out*/, void **udat
     herr_t             ret_value = SUCCEED; /* return value */
 
     FUNC_ENTER_API(FAIL)
-    H5TRACE3("e", "ixx", plist_id, func, udata);
+    H5TRACE3("e", "i*FF**x", plist_id, func, udata);
 
     /* Get the plist structure */
     if (NULL == (plist = H5P_object_verify(plist_id, H5P_FILE_ACCESS)))
@@ -4604,7 +4604,7 @@ H5Pget_mdc_log_options(hid_t plist_id, hbool_t *is_enabled /*out*/, char *locati
     herr_t          ret_value    = SUCCEED; /* Return value */
 
     FUNC_ENTER_API(FAIL)
-    H5TRACE5("e", "ixxxx", plist_id, is_enabled, location, location_size, start_on_access);
+    H5TRACE5("e", "i*b*s*z*b", plist_id, is_enabled, location, location_size, start_on_access);
 
     /* Get the property list structure */
     if (NULL == (plist = H5P_object_verify(plist_id, H5P_FILE_ACCESS)))
@@ -4902,7 +4902,7 @@ H5Pget_evict_on_close(hid_t fapl_id, hbool_t *evict_on_close /*out*/)
     herr_t          ret_value = SUCCEED; /* return value */
 
     FUNC_ENTER_API(FAIL)
-    H5TRACE2("e", "ix", fapl_id, evict_on_close);
+    H5TRACE2("e", "i*b", fapl_id, evict_on_close);
 
     /* Compare the property list's class against the other class */
     if (true != H5P_isa_class(fapl_id, H5P_FILE_ACCESS))
@@ -4983,7 +4983,7 @@ H5Pget_file_locking(hid_t fapl_id, hbool_t *use_file_locking /*out*/, hbool_t *i
     herr_t          ret_value = SUCCEED; /* return value */
 
     FUNC_ENTER_API(FAIL)
-    H5TRACE3("e", "ixx", fapl_id, use_file_locking, ignore_when_disabled);
+    H5TRACE3("e", "i*b*b", fapl_id, use_file_locking, ignore_when_disabled);
 
     /* Make sure this is a fapl */
     if (H5P_DEFAULT == fapl_id)
@@ -5143,7 +5143,7 @@ H5Pget_all_coll_metadata_ops(hid_t plist_id, hbool_t *is_collective /*out*/)
     herr_t ret_value = SUCCEED; /* return value */
 
     FUNC_ENTER_API(FAIL)
-    H5TRACE2("e", "ix", plist_id, is_collective);
+    H5TRACE2("e", "i*b", plist_id, is_collective);
 
     /* Compare the property list's class against the other class */
     /* (Dataset, group, attribute, and named datatype access property lists
@@ -5226,7 +5226,7 @@ H5Pget_mpi_params(hid_t plist_id, MPI_Comm *comm /*out*/, MPI_Info *info /*out*/
     herr_t          ret_value = SUCCEED; /* return value */
 
     FUNC_ENTER_API(FAIL)
-    H5TRACE3("e", "ixx", plist_id, comm, info);
+    H5TRACE3("e", "i*Mc*Mi", plist_id, comm, info);
 
     /* Make sure that the property list is a fapl */
     if (true != H5P_isa_class(plist_id, H5P_FILE_ACCESS))
@@ -5670,7 +5670,7 @@ H5Pget_coll_metadata_write(hid_t plist_id, hbool_t *is_collective /*out*/)
     herr_t          ret_value = SUCCEED; /* return value */
 
     FUNC_ENTER_API(FAIL)
-    H5TRACE2("e", "ix", plist_id, is_collective);
+    H5TRACE2("e", "i*b", plist_id, is_collective);
 
     /* Compare the property list's class against the other class */
     if (true != H5P_isa_class(plist_id, H5P_FILE_ACCESS))
@@ -5752,7 +5752,7 @@ H5Pget_page_buffer_size(hid_t plist_id, size_t *buf_size /*out*/, unsigned *min_
     herr_t          ret_value = SUCCEED; /* return value */
 
     FUNC_ENTER_API(FAIL)
-    H5TRACE4("e", "ixxx", plist_id, buf_size, min_meta_perc, min_raw_perc);
+    H5TRACE4("e", "i*z*Iu*Iu", plist_id, buf_size, min_meta_perc, min_raw_perc);
 
     /* Get the plist structure */
     if (NULL == (plist = H5P_object_verify(plist_id, H5P_FILE_ACCESS)))
@@ -5899,7 +5899,7 @@ H5Pget_vol_id(hid_t plist_id, hid_t *vol_id /*out*/)
     herr_t          ret_value = SUCCEED; /* Return value */
 
     FUNC_ENTER_API(FAIL)
-    H5TRACE2("e", "ix", plist_id, vol_id);
+    H5TRACE2("e", "i*i", plist_id, vol_id);
 
     if (H5P_DEFAULT == plist_id)
         plist_id = H5P_FILE_ACCESS_DEFAULT;
@@ -5948,7 +5948,7 @@ H5Pget_vol_info(hid_t plist_id, void **vol_info /*out*/)
     herr_t          ret_value = SUCCEED; /* Return value */
 
     FUNC_ENTER_API(FAIL)
-    H5TRACE2("e", "ix", plist_id, vol_info);
+    H5TRACE2("e", "i**x", plist_id, vol_info);
 
     /* Get property list for ID */
     if (NULL == (plist = (H5P_genplist_t *)H5I_object_verify(plist_id, H5I_GENPROP_LST)))

--- a/src/H5Pfcpl.c
+++ b/src/H5Pfcpl.c
@@ -361,7 +361,7 @@ H5Pget_userblock(hid_t plist_id, hsize_t *size /*out*/)
     herr_t          ret_value = SUCCEED; /* return value */
 
     FUNC_ENTER_API(FAIL)
-    H5TRACE2("e", "ix", plist_id, size);
+    H5TRACE2("e", "i*h", plist_id, size);
 
     /* Get the plist structure */
     if (NULL == (plist = H5P_object_verify(plist_id, H5P_FILE_CREATE)))
@@ -447,7 +447,7 @@ H5Pget_sizes(hid_t plist_id, size_t *sizeof_addr /*out*/, size_t *sizeof_size /*
     herr_t          ret_value = SUCCEED; /* return value */
 
     FUNC_ENTER_API(FAIL)
-    H5TRACE3("e", "ixx", plist_id, sizeof_addr, sizeof_size);
+    H5TRACE3("e", "i*z*z", plist_id, sizeof_addr, sizeof_size);
 
     /* Get the plist structure */
     if (NULL == (plist = H5P_object_verify(plist_id, H5P_FILE_CREATE)))
@@ -548,7 +548,7 @@ H5Pget_sym_k(hid_t plist_id, unsigned *ik /*out*/, unsigned *lk /*out*/)
     herr_t          ret_value = SUCCEED; /* Return value */
 
     FUNC_ENTER_API(FAIL)
-    H5TRACE3("e", "ixx", plist_id, ik, lk);
+    H5TRACE3("e", "i*Iu*Iu", plist_id, ik, lk);
 
     /* Get the plist structure */
     if (NULL == (plist = H5P_object_verify(plist_id, H5P_FILE_CREATE)))
@@ -632,7 +632,7 @@ H5Pget_istore_k(hid_t plist_id, unsigned *ik /*out*/)
     herr_t          ret_value = SUCCEED; /* Return value */
 
     FUNC_ENTER_API(FAIL)
-    H5TRACE2("e", "ix", plist_id, ik);
+    H5TRACE2("e", "i*Iu", plist_id, ik);
 
     /* Get the plist structure */
     if (NULL == (plist = H5P_object_verify(plist_id, H5P_FILE_CREATE)))
@@ -790,7 +790,7 @@ H5Pget_shared_mesg_nindexes(hid_t plist_id, unsigned *nindexes /*out*/)
     herr_t          ret_value = SUCCEED; /* Return value */
 
     FUNC_ENTER_API(FAIL)
-    H5TRACE2("e", "ix", plist_id, nindexes);
+    H5TRACE2("e", "i*Iu", plist_id, nindexes);
 
     /* Get the plist structure */
     if (NULL == (plist = H5P_object_verify(plist_id, H5P_FILE_CREATE)))
@@ -887,7 +887,7 @@ H5Pget_shared_mesg_index(hid_t plist_id, unsigned index_num, unsigned *mesg_type
     herr_t          ret_value = SUCCEED;                 /* Return value */
 
     FUNC_ENTER_API(FAIL)
-    H5TRACE4("e", "iIuxx", plist_id, index_num, mesg_type_flags, min_mesg_size);
+    H5TRACE4("e", "iIu*Iu*Iu", plist_id, index_num, mesg_type_flags, min_mesg_size);
 
     /* Get the plist structure */
     if (NULL == (plist = H5P_object_verify(plist_id, H5P_FILE_CREATE)))
@@ -1160,7 +1160,7 @@ H5Pget_shared_mesg_phase_change(hid_t plist_id, unsigned *max_list /*out*/, unsi
     herr_t          ret_value = SUCCEED; /* Return value */
 
     FUNC_ENTER_API(FAIL)
-    H5TRACE3("e", "ixx", plist_id, max_list, min_btree);
+    H5TRACE3("e", "i*Iu*Iu", plist_id, max_list, min_btree);
 
     /* Get the plist structure */
     if (NULL == (plist = H5P_object_verify(plist_id, H5P_FILE_CREATE)))
@@ -1242,7 +1242,7 @@ H5Pget_file_space_strategy(hid_t plist_id, H5F_fspace_strategy_t *strategy /*out
     herr_t          ret_value = SUCCEED; /* Return value */
 
     FUNC_ENTER_API(FAIL)
-    H5TRACE4("e", "ixxx", plist_id, strategy, persist, threshold);
+    H5TRACE4("e", "i*Ff*b*h", plist_id, strategy, persist, threshold);
 
     /* Get the plist structure */
     if (NULL == (plist = H5P_object_verify(plist_id, H5P_FILE_CREATE)))
@@ -1382,7 +1382,7 @@ H5Pget_file_space_page_size(hid_t plist_id, hsize_t *fsp_size /*out*/)
     herr_t          ret_value = SUCCEED; /* Return value */
 
     FUNC_ENTER_API(FAIL)
-    H5TRACE2("e", "ix", plist_id, fsp_size);
+    H5TRACE2("e", "i*h", plist_id, fsp_size);
 
     /* Get the plist structure */
     if (NULL == (plist = H5P_object_verify(plist_id, H5P_FILE_CREATE)))

--- a/src/H5Pgcpl.c
+++ b/src/H5Pgcpl.c
@@ -187,7 +187,7 @@ H5Pget_local_heap_size_hint(hid_t plist_id, size_t *size_hint /*out*/)
     herr_t ret_value = SUCCEED; /* return value */
 
     FUNC_ENTER_API(FAIL)
-    H5TRACE2("e", "ix", plist_id, size_hint);
+    H5TRACE2("e", "i*z", plist_id, size_hint);
 
     if (size_hint) {
         H5P_genplist_t *plist; /* Property list pointer */
@@ -282,7 +282,7 @@ H5Pget_link_phase_change(hid_t plist_id, unsigned *max_compact /*out*/, unsigned
     herr_t ret_value = SUCCEED; /* return value */
 
     FUNC_ENTER_API(FAIL)
-    H5TRACE3("e", "ixx", plist_id, max_compact, min_dense);
+    H5TRACE3("e", "i*Iu*Iu", plist_id, max_compact, min_dense);
 
     /* Get values */
     if (max_compact || min_dense) {
@@ -380,7 +380,7 @@ H5Pget_est_link_info(hid_t plist_id, unsigned *est_num_entries /*out*/, unsigned
     herr_t ret_value = SUCCEED; /* return value */
 
     FUNC_ENTER_API(FAIL)
-    H5TRACE3("e", "ixx", plist_id, est_num_entries, est_name_len);
+    H5TRACE3("e", "i*Iu*Iu", plist_id, est_num_entries, est_name_len);
 
     /* Get values */
     if (est_num_entries || est_name_len) {
@@ -464,7 +464,7 @@ H5Pget_link_creation_order(hid_t plist_id, unsigned *crt_order_flags /*out*/)
     herr_t ret_value = SUCCEED; /* return value */
 
     FUNC_ENTER_API(FAIL)
-    H5TRACE2("e", "ix", plist_id, crt_order_flags);
+    H5TRACE2("e", "i*Iu", plist_id, crt_order_flags);
 
     /* Get values */
     if (crt_order_flags) {

--- a/src/H5Plapl.c
+++ b/src/H5Plapl.c
@@ -893,7 +893,7 @@ H5Pget_nlinks(hid_t plist_id, size_t *nlinks /*out*/)
     herr_t          ret_value = SUCCEED; /* Return value */
 
     FUNC_ENTER_API(FAIL)
-    H5TRACE2("e", "ix", plist_id, nlinks);
+    H5TRACE2("e", "i*z", plist_id, nlinks);
 
     if (!nlinks)
         HGOTO_ERROR(H5E_ARGS, H5E_BADVALUE, FAIL, "invalid pointer passed in");
@@ -964,7 +964,7 @@ H5Pget_elink_prefix(hid_t plist_id, char *prefix /*out*/, size_t size)
     ssize_t         ret_value; /* Return value */
 
     FUNC_ENTER_API(FAIL)
-    H5TRACE3("Zs", "ixz", plist_id, prefix, size);
+    H5TRACE3("Zs", "i*sz", plist_id, prefix, size);
 
     /* Get the plist structure */
     if (NULL == (plist = H5P_object_verify(plist_id, H5P_LINK_ACCESS)))
@@ -1109,7 +1109,7 @@ H5Pget_elink_acc_flags(hid_t lapl_id, unsigned *flags /*out*/)
     herr_t          ret_value = SUCCEED; /* Return value */
 
     FUNC_ENTER_API(FAIL)
-    H5TRACE2("e", "ix", lapl_id, flags);
+    H5TRACE2("e", "i*Iu", lapl_id, flags);
 
     /* Get the plist structure */
     if (NULL == (plist = H5P_object_verify(lapl_id, H5P_LINK_ACCESS)))
@@ -1184,7 +1184,7 @@ H5Pget_elink_cb(hid_t lapl_id, H5L_elink_traverse_t *func /*out*/, void **op_dat
     herr_t          ret_value = SUCCEED; /* Return value */
 
     FUNC_ENTER_API(FAIL)
-    H5TRACE3("e", "ixx", lapl_id, func, op_data);
+    H5TRACE3("e", "i*Lt**x", lapl_id, func, op_data);
 
     /* Get the plist structure */
     if (NULL == (plist = H5P_object_verify(lapl_id, H5P_LINK_ACCESS)))

--- a/src/H5Plcpl.c
+++ b/src/H5Plcpl.c
@@ -172,7 +172,7 @@ H5Pget_create_intermediate_group(hid_t plist_id, unsigned *crt_intmd_group /*out
     herr_t          ret_value = SUCCEED; /* return value */
 
     FUNC_ENTER_API(FAIL)
-    H5TRACE2("e", "ix", plist_id, crt_intmd_group);
+    H5TRACE2("e", "i*Iu", plist_id, crt_intmd_group);
 
     /* Get the plist structure */
     if (NULL == (plist = H5P_object_verify(plist_id, H5P_LINK_CREATE)))

--- a/src/H5Pmapl.c
+++ b/src/H5Pmapl.c
@@ -187,7 +187,7 @@ H5Pget_map_iterate_hints(hid_t mapl_id, size_t *key_prefetch_size /*out*/, size_
     herr_t          ret_value = SUCCEED; /* return value */
 
     FUNC_ENTER_API(FAIL)
-    H5TRACE3("e", "ixx", mapl_id, key_prefetch_size, key_alloc_size);
+    H5TRACE3("e", "i*z*z", mapl_id, key_prefetch_size, key_alloc_size);
 
     /* Get the plist structure */
     if (NULL == (plist = H5P_object_verify(mapl_id, H5P_MAP_ACCESS)))

--- a/src/H5Pocpl.c
+++ b/src/H5Pocpl.c
@@ -246,7 +246,7 @@ H5Pget_attr_phase_change(hid_t plist_id, unsigned *max_compact /*out*/, unsigned
     herr_t          ret_value = SUCCEED; /* Return value */
 
     FUNC_ENTER_API(FAIL)
-    H5TRACE3("e", "ixx", plist_id, max_compact, min_dense);
+    H5TRACE3("e", "i*Iu*Iu", plist_id, max_compact, min_dense);
 
     /* Get the plist structure */
     if (NULL == (plist = H5P_object_verify(plist_id, H5P_OBJECT_CREATE)))
@@ -330,7 +330,7 @@ H5Pget_attr_creation_order(hid_t plist_id, unsigned *crt_order_flags /*out*/)
     herr_t ret_value = SUCCEED; /* return value */
 
     FUNC_ENTER_API(FAIL)
-    H5TRACE2("e", "ix", plist_id, crt_order_flags);
+    H5TRACE2("e", "i*Iu", plist_id, crt_order_flags);
 
     /* Get values */
     if (crt_order_flags) {
@@ -427,7 +427,7 @@ H5Pget_obj_track_times(hid_t plist_id, hbool_t *track_times /*out*/)
     herr_t ret_value = SUCCEED; /* return value */
 
     FUNC_ENTER_API(FAIL)
-    H5TRACE2("e", "ix", plist_id, track_times);
+    H5TRACE2("e", "i*b", plist_id, track_times);
 
     /* Get values */
     if (track_times) {
@@ -756,7 +756,7 @@ done:
  *-------------------------------------------------------------------------
  */
 H5Z_filter_t
-H5Pget_filter2(hid_t plist_id, unsigned idx, unsigned int *flags /*out*/, size_t *cd_nelmts /*in_out*/,
+H5Pget_filter2(hid_t plist_id, unsigned idx, unsigned int *flags /*out*/, size_t *cd_nelmts /*in,out*/,
                unsigned cd_values[] /*out*/, size_t namelen, char name[] /*out*/,
                unsigned *filter_config /*out*/)
 {
@@ -766,7 +766,8 @@ H5Pget_filter2(hid_t plist_id, unsigned idx, unsigned int *flags /*out*/, size_t
     H5Z_filter_t             ret_value; /* return value */
 
     FUNC_ENTER_API(H5Z_FILTER_ERROR)
-    H5TRACE8("Zf", "iIux*zxzxx", plist_id, idx, flags, cd_nelmts, cd_values, namelen, name, filter_config);
+    H5TRACE8("Zf", "iIu*Iu*z*Iuz*s*Iu", plist_id, idx, flags, cd_nelmts, cd_values, namelen, name,
+             filter_config);
 
     /* Check args */
     if (cd_nelmts || cd_values) {
@@ -837,7 +838,7 @@ done:
  */
 herr_t
 H5P_get_filter_by_id(H5P_genplist_t *plist, H5Z_filter_t id, unsigned int *flags /*out*/,
-                     size_t *cd_nelmts /*in_out*/, unsigned cd_values[] /*out*/, size_t namelen,
+                     size_t *cd_nelmts /*in,out*/, unsigned cd_values[] /*out*/, size_t namelen,
                      char name[] /*out*/, unsigned *filter_config)
 {
     H5O_pline_t        pline;               /* Filter pipeline */
@@ -883,14 +884,15 @@ done:
  */
 herr_t
 H5Pget_filter_by_id2(hid_t plist_id, H5Z_filter_t id, unsigned int *flags /*out*/,
-                     size_t *cd_nelmts /*in_out*/, unsigned cd_values[] /*out*/, size_t namelen,
+                     size_t *cd_nelmts /*in,out*/, unsigned cd_values[] /*out*/, size_t namelen,
                      char name[] /*out*/, unsigned *filter_config /*out*/)
 {
     H5P_genplist_t *plist;               /* Property list */
     herr_t          ret_value = SUCCEED; /* Return value */
 
     FUNC_ENTER_API(FAIL)
-    H5TRACE8("e", "iZfx*zxzxx", plist_id, id, flags, cd_nelmts, cd_values, namelen, name, filter_config);
+    H5TRACE8("e", "iZf*Iu*z*Iuz*s*Iu", plist_id, id, flags, cd_nelmts, cd_values, namelen, name,
+             filter_config);
 
     /* Check args */
     if (id < 0 || id > H5Z_FILTER_MAX)
@@ -1139,7 +1141,7 @@ done:
  *-------------------------------------------------------------------------
  */
 herr_t
-H5P__get_filter(const H5Z_filter_info_t *filter, unsigned int *flags /*out*/, size_t *cd_nelmts /*in_out*/,
+H5P__get_filter(const H5Z_filter_info_t *filter, unsigned int *flags /*out*/, size_t *cd_nelmts /*in,out*/,
                 unsigned cd_values[] /*out*/, size_t namelen, char name[] /*out*/,
                 unsigned *filter_config /*out*/)
 {
@@ -1656,7 +1658,7 @@ done:
  *-------------------------------------------------------------------------
  */
 H5Z_filter_t
-H5Pget_filter1(hid_t plist_id, unsigned idx, unsigned int *flags /*out*/, size_t *cd_nelmts /*in_out*/,
+H5Pget_filter1(hid_t plist_id, unsigned idx, unsigned int *flags /*out*/, size_t *cd_nelmts /*in,out*/,
                unsigned cd_values[] /*out*/, size_t namelen, char name[] /*out*/)
 {
     H5O_pline_t              pline;     /* Filter pipeline */
@@ -1665,7 +1667,7 @@ H5Pget_filter1(hid_t plist_id, unsigned idx, unsigned int *flags /*out*/, size_t
     H5Z_filter_t             ret_value; /* return value */
 
     FUNC_ENTER_API(H5Z_FILTER_ERROR)
-    H5TRACE7("Zf", "iIux*zxzx", plist_id, idx, flags, cd_nelmts, cd_values, namelen, name);
+    H5TRACE7("Zf", "iIu*Iu*z*Iuz*s", plist_id, idx, flags, cd_nelmts, cd_values, namelen, name);
 
     /* Check args */
     if (cd_nelmts || cd_values) {
@@ -1735,14 +1737,14 @@ done:
  */
 herr_t
 H5Pget_filter_by_id1(hid_t plist_id, H5Z_filter_t id, unsigned int *flags /*out*/,
-                     size_t *cd_nelmts /*in_out*/, unsigned cd_values[] /*out*/, size_t namelen,
+                     size_t *cd_nelmts /*in,out*/, unsigned cd_values[] /*out*/, size_t namelen,
                      char name[] /*out*/)
 {
     H5P_genplist_t *plist;               /* Property list pointer */
     herr_t          ret_value = SUCCEED; /* Return value */
 
     FUNC_ENTER_API(FAIL)
-    H5TRACE7("e", "iZfx*zxzx", plist_id, id, flags, cd_nelmts, cd_values, namelen, name);
+    H5TRACE7("e", "iZf*Iu*z*Iuz*s", plist_id, id, flags, cd_nelmts, cd_values, namelen, name);
 
     /* Check args */
     if (id < 0 || id > H5Z_FILTER_MAX)

--- a/src/H5Pocpypl.c
+++ b/src/H5Pocpypl.c
@@ -646,7 +646,7 @@ H5Pget_copy_object(hid_t plist_id, unsigned *cpy_option /*out*/)
     herr_t          ret_value = SUCCEED; /* return value */
 
     FUNC_ENTER_API(FAIL)
-    H5TRACE2("e", "ix", plist_id, cpy_option);
+    H5TRACE2("e", "i*Iu", plist_id, cpy_option);
 
     /* Get the plist structure */
     if (NULL == (plist = H5P_object_verify(plist_id, H5P_OBJECT_COPY)))
@@ -839,7 +839,7 @@ H5Pget_mcdt_search_cb(hid_t plist_id, H5O_mcdt_search_cb_t *func /*out*/, void *
     herr_t             ret_value = SUCCEED; /* Return value */
 
     FUNC_ENTER_API(FAIL)
-    H5TRACE3("e", "ixx", plist_id, func, op_data);
+    H5TRACE3("e", "i*Os**x", plist_id, func, op_data);
 
     /* Get the plist structure */
     if (NULL == (plist = H5P_object_verify(plist_id, H5P_OBJECT_COPY)))

--- a/src/H5Pstrcpl.c
+++ b/src/H5Pstrcpl.c
@@ -175,7 +175,7 @@ H5Pget_char_encoding(hid_t plist_id, H5T_cset_t *encoding /*out*/)
     herr_t          ret_value = SUCCEED; /* return value */
 
     FUNC_ENTER_API(FAIL)
-    H5TRACE2("e", "ix", plist_id, encoding);
+    H5TRACE2("e", "i*Tc", plist_id, encoding);
 
     /* Get the plist structure */
     if (NULL == (plist = H5P_object_verify(plist_id, H5P_STRING_CREATE)))

--- a/src/H5R.c
+++ b/src/H5R.c
@@ -980,7 +980,7 @@ H5Rget_obj_type3(H5R_ref_t *ref_ptr, hid_t rapl_id, H5O_type_t *obj_type /*out*/
     herr_t                 ret_value = SUCCEED; /* Return value */
 
     FUNC_ENTER_API(FAIL)
-    H5TRACE3("e", "*Rrix", ref_ptr, rapl_id, obj_type);
+    H5TRACE3("e", "*Rri*Ot", ref_ptr, rapl_id, obj_type);
 
     /* Check args */
     if (ref_ptr == NULL)
@@ -1039,7 +1039,7 @@ H5Rget_file_name(const H5R_ref_t *ref_ptr, char *buf /*out*/, size_t size)
     ssize_t ret_value; /* Return value */
 
     FUNC_ENTER_API((-1))
-    H5TRACE3("Zs", "*Rrxz", ref_ptr, buf, size);
+    H5TRACE3("Zs", "*Rr*sz", ref_ptr, buf, size);
 
     /* Check args */
     if (ref_ptr == NULL)
@@ -1105,7 +1105,7 @@ H5Rget_obj_name(H5R_ref_t *ref_ptr, hid_t rapl_id, char *buf /*out*/, size_t siz
     ssize_t                ret_value    = 0;   /* Return value */
 
     FUNC_ENTER_API((-1))
-    H5TRACE4("Zs", "*Rrixz", ref_ptr, rapl_id, buf, size);
+    H5TRACE4("Zs", "*Rri*sz", ref_ptr, rapl_id, buf, size);
 
     /* Check args */
     if (ref_ptr == NULL)
@@ -1167,7 +1167,7 @@ H5Rget_attr_name(const H5R_ref_t *ref_ptr, char *buf /*out*/, size_t size)
     ssize_t ret_value; /* Return value */
 
     FUNC_ENTER_API((-1))
-    H5TRACE3("Zs", "*Rrxz", ref_ptr, buf, size);
+    H5TRACE3("Zs", "*Rr*sz", ref_ptr, buf, size);
 
     /* Check args */
     if (ref_ptr == NULL)

--- a/src/H5Rdeprec.c
+++ b/src/H5Rdeprec.c
@@ -528,7 +528,7 @@ H5Rget_obj_type2(hid_t id, H5R_type_t ref_type, const void *ref, H5O_type_t *obj
     herr_t                 ret_value         = SUCCEED; /* Return value */
 
     FUNC_ENTER_API(FAIL)
-    H5TRACE4("e", "iRt*xx", id, ref_type, ref, obj_type);
+    H5TRACE4("e", "iRt*x*Ot", id, ref_type, ref, obj_type);
 
     /* Check args */
     if (buf == NULL)
@@ -766,7 +766,7 @@ H5Rget_name(hid_t id, H5R_type_t ref_type, const void *ref, char *name /*out*/, 
     ssize_t                ret_value    = -1;                         /* Return value */
 
     FUNC_ENTER_API((-1))
-    H5TRACE5("Zs", "iRt*xxz", id, ref_type, ref, name, size);
+    H5TRACE5("Zs", "iRt*x*sz", id, ref_type, ref, name, size);
 
     /* Check args */
     if (buf == NULL)

--- a/src/H5S.c
+++ b/src/H5S.c
@@ -877,7 +877,7 @@ H5Sget_simple_extent_dims(hid_t space_id, hsize_t dims[] /*out*/, hsize_t maxdim
     int    ret_value = -1;
 
     FUNC_ENTER_API((-1))
-    H5TRACE3("Is", "ixx", space_id, dims, maxdims);
+    H5TRACE3("Is", "i*h*h", space_id, dims, maxdims);
 
     /* Check args */
     if (NULL == (ds = (H5S_t *)H5I_object_verify(space_id, H5I_DATASPACE)))

--- a/src/H5Shyper.c
+++ b/src/H5Shyper.c
@@ -4821,7 +4821,7 @@ H5Sget_select_hyper_blocklist(hid_t spaceid, hsize_t startblock, hsize_t numbloc
     herr_t ret_value; /* return value */
 
     FUNC_ENTER_API(FAIL)
-    H5TRACE4("e", "ihhx", spaceid, startblock, numblocks, buf);
+    H5TRACE4("e", "ihh*[a2]h", spaceid, startblock, numblocks, buf);
 
     /* Check args */
     if (buf == NULL)
@@ -12431,7 +12431,7 @@ H5Sget_regular_hyperslab(hid_t spaceid, hsize_t start[] /*out*/, hsize_t stride[
     herr_t   ret_value = SUCCEED; /* Return value */
 
     FUNC_ENTER_API(FAIL)
-    H5TRACE5("e", "ixxxx", spaceid, start, stride, count, block);
+    H5TRACE5("e", "i*h*h*h*h", spaceid, start, stride, count, block);
 
     /* Check args */
     if (NULL == (space = (H5S_t *)H5I_object_verify(spaceid, H5I_DATASPACE)))

--- a/src/H5Spoint.c
+++ b/src/H5Spoint.c
@@ -1625,7 +1625,7 @@ H5Sget_select_elem_pointlist(hid_t spaceid, hsize_t startpoint, hsize_t numpoint
     herr_t ret_value; /* return value */
 
     FUNC_ENTER_API(FAIL)
-    H5TRACE4("e", "ihhx", spaceid, startpoint, numpoints, buf);
+    H5TRACE4("e", "ihh*[a2]h", spaceid, startpoint, numpoints, buf);
 
     /* Check args */
     if (NULL == buf)

--- a/src/H5Sselect.c
+++ b/src/H5Sselect.c
@@ -596,7 +596,7 @@ H5Sget_select_bounds(hid_t spaceid, hsize_t start[] /*out*/, hsize_t end[] /*out
     herr_t ret_value; /* return value */
 
     FUNC_ENTER_API(FAIL)
-    H5TRACE3("e", "ixx", spaceid, start, end);
+    H5TRACE3("e", "i*h*h", spaceid, start, end);
 
     /* Check args */
     if (start == NULL || end == NULL)
@@ -2901,7 +2901,7 @@ H5Ssel_iter_get_seq_list(hid_t sel_iter_id, size_t maxseq, size_t maxelmts, size
     herr_t          ret_value = SUCCEED; /* Return value */
 
     FUNC_ENTER_API(FAIL)
-    H5TRACE7("e", "izzxxxx", sel_iter_id, maxseq, maxelmts, nseq, nelmts, off, len);
+    H5TRACE7("e", "izz*z*z*h*z", sel_iter_id, maxseq, maxelmts, nseq, nelmts, off, len);
 
     /* Check args */
     if (NULL == (sel_iter = (H5S_sel_iter_t *)H5I_object_verify(sel_iter_id, H5I_SPACE_SEL_ITER)))

--- a/src/H5T.c
+++ b/src/H5T.c
@@ -2847,7 +2847,7 @@ H5Tfind(hid_t src_id, hid_t dst_id, H5T_cdata_t **pcdata /*out*/)
     H5T_conv_t  ret_value; /* Return value */
 
     FUNC_ENTER_API(NULL)
-    H5TRACE3("TC", "iix", src_id, dst_id, pcdata);
+    H5TRACE3("TC", "ii**!", src_id, dst_id, pcdata);
 
     /* Check args */
     if (NULL == (src = (H5T_t *)H5I_object_verify(src_id, H5I_DATATYPE)) ||

--- a/src/H5Tarray.c
+++ b/src/H5Tarray.c
@@ -245,7 +245,7 @@ H5Tget_array_dims2(hid_t type_id, hsize_t dims[] /*out*/)
     int    ret_value; /* return value			*/
 
     FUNC_ENTER_API(FAIL)
-    H5TRACE2("Is", "ix", type_id, dims);
+    H5TRACE2("Is", "i*h", type_id, dims);
 
     /* Check args */
     if (NULL == (dt = (H5T_t *)H5I_object_verify(type_id, H5I_DATATYPE)))
@@ -364,7 +364,7 @@ H5Tget_array_dims1(hid_t type_id, hsize_t dims[] /*out*/, int H5_ATTR_UNUSED per
     int    ret_value; /* return value			*/
 
     FUNC_ENTER_API(FAIL)
-    H5TRACE3("Is", "ixx", type_id, dims, perm);
+    H5TRACE3("Is", "i*h*Is", type_id, dims, perm);
 
     /* Check args */
     if (NULL == (dt = (H5T_t *)H5I_object_verify(type_id, H5I_DATATYPE)))

--- a/src/H5Tenum.c
+++ b/src/H5Tenum.c
@@ -222,7 +222,7 @@ H5Tget_member_value(hid_t type, unsigned membno, void *value /*out*/)
     herr_t ret_value = SUCCEED; /* Return value */
 
     FUNC_ENTER_API(FAIL)
-    H5TRACE3("e", "iIux", type, membno, value);
+    H5TRACE3("e", "iIu*x", type, membno, value);
 
     if (NULL == (dt = (H5T_t *)H5I_object_verify(type, H5I_DATATYPE)))
         HGOTO_ERROR(H5E_ARGS, H5E_BADTYPE, FAIL, "not a data type");
@@ -289,7 +289,7 @@ H5Tenum_nameof(hid_t type, const void *value, char *name /*out*/, size_t size)
     herr_t ret_value = SUCCEED; /* Return value */
 
     FUNC_ENTER_API(FAIL)
-    H5TRACE4("e", "i*xxz", type, value, name, size);
+    H5TRACE4("e", "i*x*sz", type, value, name, size);
 
     /* Check args */
     if (NULL == (dt = (H5T_t *)H5I_object_verify(type, H5I_DATATYPE)))
@@ -420,7 +420,7 @@ H5Tenum_valueof(hid_t type, const char *name, void *value /*out*/)
     herr_t ret_value = SUCCEED; /* Return value */
 
     FUNC_ENTER_API(FAIL)
-    H5TRACE3("e", "i*sx", type, name, value);
+    H5TRACE3("e", "i*s*x", type, name, value);
 
     /* Check args */
     if (NULL == (dt = (H5T_t *)H5I_object_verify(type, H5I_DATATYPE)))

--- a/src/H5Tfloat.c
+++ b/src/H5Tfloat.c
@@ -47,7 +47,7 @@ H5Tget_fields(hid_t type_id, size_t *spos /*out*/, size_t *epos /*out*/, size_t 
     herr_t ret_value = SUCCEED; /* Return value */
 
     FUNC_ENTER_API(FAIL)
-    H5TRACE6("e", "ixxxxx", type_id, spos, epos, esize, mpos, msize);
+    H5TRACE6("e", "i*z*z*z*z*z", type_id, spos, epos, esize, mpos, msize);
 
     /* Check args */
     if (NULL == (dt = (H5T_t *)H5I_object_verify(type_id, H5I_DATATYPE)))

--- a/src/H5Tpad.c
+++ b/src/H5Tpad.c
@@ -40,7 +40,7 @@ H5Tget_pad(hid_t type_id, H5T_pad_t *lsb /*out*/, H5T_pad_t *msb /*out*/)
     herr_t ret_value = SUCCEED; /* Return value */
 
     FUNC_ENTER_API(FAIL)
-    H5TRACE3("e", "ixx", type_id, lsb, msb);
+    H5TRACE3("e", "i*Tp*Tp", type_id, lsb, msb);
 
     /* Check args */
     if (NULL == (dt = (H5T_t *)H5I_object_verify(type_id, H5I_DATATYPE)))

--- a/src/H5VL.c
+++ b/src/H5VL.c
@@ -420,7 +420,7 @@ H5VLget_connector_name(hid_t obj_id, char *name /*out*/, size_t size)
     ssize_t ret_value = -1;
 
     FUNC_ENTER_API(FAIL)
-    H5TRACE3("Zs", "ixz", obj_id, name, size);
+    H5TRACE3("Zs", "i*sz", obj_id, name, size);
 
     /* Call internal routine */
     if ((ret_value = H5VL__get_connector_name(obj_id, name, size)) < 0)
@@ -770,7 +770,7 @@ H5VLretrieve_lib_state(void **state /*out*/)
 
     /* Must use this, to avoid modifying the API context stack in FUNC_ENTER */
     FUNC_ENTER_API_NOINIT
-    H5TRACE1("e", "x", state);
+    H5TRACE1("e", "**x", state);
 
     /* Check args */
     if (NULL == state)
@@ -938,7 +938,7 @@ H5VLquery_optional(hid_t obj_id, H5VL_subclass_t subcls, int opt_type, uint64_t 
     herr_t         ret_value = SUCCEED; /* Return value */
 
     FUNC_ENTER_API(FAIL)
-    H5TRACE4("e", "iVSIsx", obj_id, subcls, opt_type, flags);
+    H5TRACE4("e", "iVSIs*UL", obj_id, subcls, opt_type, flags);
 
     /* Check args */
     if (NULL == flags)
@@ -989,7 +989,7 @@ H5VLregister_opt_operation(H5VL_subclass_t subcls, const char *op_name, int *op_
     herr_t ret_value = SUCCEED; /* Return value */
 
     FUNC_ENTER_API(FAIL)
-    H5TRACE3("e", "VS*sx", subcls, op_name, op_val);
+    H5TRACE3("e", "VS*s*Is", subcls, op_name, op_val);
 
     /* Check args */
     if (NULL == op_val)
@@ -1028,7 +1028,7 @@ H5VLfind_opt_operation(H5VL_subclass_t subcls, const char *op_name, int *op_val 
     herr_t ret_value = SUCCEED; /* Return value */
 
     FUNC_ENTER_API(FAIL)
-    H5TRACE3("e", "VS*sx", subcls, op_name, op_val);
+    H5TRACE3("e", "VS*s*Is", subcls, op_name, op_val);
 
     /* Check args */
     if (NULL == op_val)

--- a/src/H5VLcallback.c
+++ b/src/H5VLcallback.c
@@ -284,7 +284,7 @@ H5VLget_cap_flags(hid_t connector_id, uint64_t *cap_flags /*out*/)
     herr_t        ret_value = SUCCEED; /* Return value */
 
     FUNC_ENTER_API_NOINIT
-    H5TRACE2("e", "ix", connector_id, cap_flags);
+    H5TRACE2("e", "i*UL", connector_id, cap_flags);
 
     /* Check args */
     if (NULL == (cls = (H5VL_class_t *)H5I_object_verify(connector_id, H5I_VOL)))
@@ -315,7 +315,7 @@ H5VLget_value(hid_t connector_id, H5VL_class_value_t *value /*out*/)
     herr_t        ret_value = SUCCEED; /* Return value */
 
     FUNC_ENTER_API_NOINIT
-    H5TRACE2("e", "ix", connector_id, value);
+    H5TRACE2("e", "i*VC", connector_id, value);
 
     /* Check args */
     if (NULL == (cls = (H5VL_class_t *)H5I_object_verify(connector_id, H5I_VOL)))
@@ -663,7 +663,7 @@ H5VLconnector_str_to_info(const char *str, hid_t connector_id, void **info /*out
     herr_t ret_value = SUCCEED; /* Return value */
 
     FUNC_ENTER_API_NOINIT
-    H5TRACE3("e", "*six", str, connector_id, info);
+    H5TRACE3("e", "*si**x", str, connector_id, info);
 
     /* Call internal routine */
     if (H5VL__connector_str_to_info(str, connector_id, info) < 0)
@@ -763,7 +763,7 @@ H5VLget_wrap_ctx(void *obj, hid_t connector_id, void **wrap_ctx /*out*/)
     herr_t        ret_value = SUCCEED; /* Return value */
 
     FUNC_ENTER_API_NOINIT
-    H5TRACE3("e", "*xix", obj, connector_id, wrap_ctx);
+    H5TRACE3("e", "*xi**x", obj, connector_id, wrap_ctx);
 
     /* Check args and get class pointer */
     if (NULL == (cls = (H5VL_class_t *)H5I_object_verify(connector_id, H5I_VOL)))
@@ -1060,8 +1060,8 @@ H5VLattr_create(void *obj, const H5VL_loc_params_t *loc_params, hid_t connector_
     void         *ret_value = NULL; /* Return value */
 
     FUNC_ENTER_API_NOINIT
-    H5TRACE10("*x", "*x*#i*siiiiix", obj, loc_params, connector_id, name, type_id, space_id, acpl_id, aapl_id,
-              dxpl_id, req);
+    H5TRACE10("*x", "*x*#i*siiiii**x", obj, loc_params, connector_id, name, type_id, space_id, acpl_id,
+              aapl_id, dxpl_id, req);
 
     /* Check args and get class pointer */
     if (NULL == obj)
@@ -1163,7 +1163,7 @@ H5VLattr_open(void *obj, const H5VL_loc_params_t *loc_params, hid_t connector_id
     void         *ret_value = NULL; /* Return value */
 
     FUNC_ENTER_API_NOINIT
-    H5TRACE7("*x", "*x*#i*siix", obj, loc_params, connector_id, name, aapl_id, dxpl_id, req);
+    H5TRACE7("*x", "*x*#i*sii**x", obj, loc_params, connector_id, name, aapl_id, dxpl_id, req);
 
     /* Check args and get class pointer */
     if (NULL == obj)
@@ -1260,7 +1260,7 @@ H5VLattr_read(void *obj, hid_t connector_id, hid_t mem_type_id, void *buf, hid_t
     herr_t        ret_value = SUCCEED; /* Return value */
 
     FUNC_ENTER_API_NOINIT
-    H5TRACE6("e", "*xii*xix", obj, connector_id, mem_type_id, buf, dxpl_id, req);
+    H5TRACE6("e", "*xii*xi**x", obj, connector_id, mem_type_id, buf, dxpl_id, req);
 
     /* Check args and get class pointer */
     if (NULL == obj)
@@ -1359,7 +1359,7 @@ H5VLattr_write(void *obj, hid_t connector_id, hid_t mem_type_id, const void *buf
     herr_t        ret_value = SUCCEED; /* Return value */
 
     FUNC_ENTER_API_NOINIT
-    H5TRACE6("e", "*xii*xix", obj, connector_id, mem_type_id, buf, dxpl_id, req);
+    H5TRACE6("e", "*xii*xi**x", obj, connector_id, mem_type_id, buf, dxpl_id, req);
 
     /* Check args and get class pointer */
     if (NULL == obj)
@@ -1456,7 +1456,7 @@ H5VLattr_get(void *obj, hid_t connector_id, H5VL_attr_get_args_t *args, hid_t dx
     herr_t        ret_value = SUCCEED; /* Return value */
 
     FUNC_ENTER_API_NOINIT
-    H5TRACE5("e", "*xi*!ix", obj, connector_id, args, dxpl_id, req);
+    H5TRACE5("e", "*xi*!i**x", obj, connector_id, args, dxpl_id, req);
 
     /* Check args and get class pointer */
     if (NULL == obj)
@@ -1561,7 +1561,7 @@ H5VLattr_specific(void *obj, const H5VL_loc_params_t *loc_params, hid_t connecto
     herr_t        ret_value = SUCCEED; /* Return value */
 
     FUNC_ENTER_API_NOINIT
-    H5TRACE6("e", "*x*#i*!ix", obj, loc_params, connector_id, args, dxpl_id, req);
+    H5TRACE6("e", "*x*#i*!i**x", obj, loc_params, connector_id, args, dxpl_id, req);
 
     /* Check args and get class pointer */
     if (NULL == obj)
@@ -1662,7 +1662,7 @@ H5VLattr_optional(void *obj, hid_t connector_id, H5VL_optional_args_t *args, hid
     herr_t        ret_value = SUCCEED; /* Return value */
 
     FUNC_ENTER_API_NOINIT
-    H5TRACE5("e", "*xi*!ix", obj, connector_id, args, dxpl_id, req);
+    H5TRACE5("e", "*xi*!i**x", obj, connector_id, args, dxpl_id, req);
 
     /* Check args and get class pointer */
     if (NULL == obj)
@@ -1796,7 +1796,7 @@ H5VLattr_close(void *obj, hid_t connector_id, hid_t dxpl_id, void **req /*out*/)
     herr_t        ret_value = SUCCEED; /* Return value */
 
     FUNC_ENTER_API_NOINIT
-    H5TRACE4("e", "*xiix", obj, connector_id, dxpl_id, req);
+    H5TRACE4("e", "*xii**x", obj, connector_id, dxpl_id, req);
 
     /* Check args and get class pointer */
     if (NULL == obj)
@@ -1902,7 +1902,7 @@ H5VLdataset_create(void *obj, const H5VL_loc_params_t *loc_params, hid_t connect
     void         *ret_value = NULL; /* Return value */
 
     FUNC_ENTER_API_NOINIT
-    H5TRACE11("*x", "*x*#i*siiiiiix", obj, loc_params, connector_id, name, lcpl_id, type_id, space_id,
+    H5TRACE11("*x", "*x*#i*siiiiii**x", obj, loc_params, connector_id, name, lcpl_id, type_id, space_id,
               dcpl_id, dapl_id, dxpl_id, req);
 
     /* Check args and get class pointer */
@@ -2005,7 +2005,7 @@ H5VLdataset_open(void *obj, const H5VL_loc_params_t *loc_params, hid_t connector
     void         *ret_value = NULL; /* Return value */
 
     FUNC_ENTER_API_NOINIT
-    H5TRACE7("*x", "*x*#i*siix", obj, loc_params, connector_id, name, dapl_id, dxpl_id, req);
+    H5TRACE7("*x", "*x*#i*sii**x", obj, loc_params, connector_id, name, dapl_id, dxpl_id, req);
 
     /* Check args and get class pointer */
     if (NULL == obj)
@@ -2182,7 +2182,7 @@ H5VLdataset_read(size_t count, void *obj[], hid_t connector_id, hid_t mem_type_i
     herr_t        ret_value = SUCCEED; /* Return value */
 
     FUNC_ENTER_API_NOINIT
-    H5TRACE9("e", "z**xi*i*i*ii**xx", count, obj, connector_id, mem_type_id, mem_space_id, file_space_id,
+    H5TRACE9("e", "z**xi*i*i*ii**x**x", count, obj, connector_id, mem_type_id, mem_space_id, file_space_id,
              dxpl_id, buf, req);
 
     /* Check args and get class pointer */
@@ -2372,7 +2372,7 @@ H5VLdataset_write(size_t count, void *obj[], hid_t connector_id, hid_t mem_type_
     herr_t        ret_value = SUCCEED; /* Return value */
 
     FUNC_ENTER_API_NOINIT
-    H5TRACE9("e", "z**xi*i*i*ii**xx", count, obj, connector_id, mem_type_id, mem_space_id, file_space_id,
+    H5TRACE9("e", "z**xi*i*i*ii**x**x", count, obj, connector_id, mem_type_id, mem_space_id, file_space_id,
              dxpl_id, buf, req);
 
     /* Check args and get class pointer */
@@ -2483,7 +2483,7 @@ H5VLdataset_get(void *obj, hid_t connector_id, H5VL_dataset_get_args_t *args, hi
     herr_t        ret_value = SUCCEED; /* Return value */
 
     FUNC_ENTER_API_NOINIT
-    H5TRACE5("e", "*xi*!ix", obj, connector_id, args, dxpl_id, req);
+    H5TRACE5("e", "*xi*!i**x", obj, connector_id, args, dxpl_id, req);
 
     /* Check args and get class pointer */
     if (NULL == obj)
@@ -2583,7 +2583,7 @@ H5VLdataset_specific(void *obj, hid_t connector_id, H5VL_dataset_specific_args_t
     herr_t        ret_value = SUCCEED; /* Return value */
 
     FUNC_ENTER_API_NOINIT
-    H5TRACE5("e", "*xi*!ix", obj, connector_id, args, dxpl_id, req);
+    H5TRACE5("e", "*xi*!i**x", obj, connector_id, args, dxpl_id, req);
 
     /* Check args and get class pointer */
     if (NULL == obj)
@@ -2682,7 +2682,7 @@ H5VLdataset_optional(void *obj, hid_t connector_id, H5VL_optional_args_t *args, 
     herr_t        ret_value = SUCCEED; /* Return value */
 
     FUNC_ENTER_API_NOINIT
-    H5TRACE5("e", "*xi*!ix", obj, connector_id, args, dxpl_id, req);
+    H5TRACE5("e", "*xi*!i**x", obj, connector_id, args, dxpl_id, req);
 
     /* Check args and get class pointer */
     if (NULL == obj)
@@ -2832,7 +2832,7 @@ H5VLdataset_close(void *obj, hid_t connector_id, hid_t dxpl_id, void **req /*out
     herr_t        ret_value = SUCCEED; /* Return value */
 
     FUNC_ENTER_API_NOINIT
-    H5TRACE4("e", "*xiix", obj, connector_id, dxpl_id, req);
+    H5TRACE4("e", "*xii**x", obj, connector_id, dxpl_id, req);
 
     /* Check args and get class pointer */
     if (NULL == obj)
@@ -2936,8 +2936,8 @@ H5VLdatatype_commit(void *obj, const H5VL_loc_params_t *loc_params, hid_t connec
     void         *ret_value = NULL; /* Return value */
 
     FUNC_ENTER_API_NOINIT
-    H5TRACE10("*x", "*x*#i*siiiiix", obj, loc_params, connector_id, name, type_id, lcpl_id, tcpl_id, tapl_id,
-              dxpl_id, req);
+    H5TRACE10("*x", "*x*#i*siiiii**x", obj, loc_params, connector_id, name, type_id, lcpl_id, tcpl_id,
+              tapl_id, dxpl_id, req);
 
     /* Check args and get class pointer */
     if (NULL == obj)
@@ -3039,7 +3039,7 @@ H5VLdatatype_open(void *obj, const H5VL_loc_params_t *loc_params, hid_t connecto
     void         *ret_value = NULL; /* Return value */
 
     FUNC_ENTER_API_NOINIT
-    H5TRACE7("*x", "*x*#i*siix", obj, loc_params, connector_id, name, tapl_id, dxpl_id, req);
+    H5TRACE7("*x", "*x*#i*sii**x", obj, loc_params, connector_id, name, tapl_id, dxpl_id, req);
 
     /* Check args and get class pointer */
     if (NULL == obj)
@@ -3138,7 +3138,7 @@ H5VLdatatype_get(void *obj, hid_t connector_id, H5VL_datatype_get_args_t *args, 
     herr_t        ret_value = SUCCEED; /* Return value */
 
     FUNC_ENTER_API_NOINIT
-    H5TRACE5("e", "*xi*!ix", obj, connector_id, args, dxpl_id, req);
+    H5TRACE5("e", "*xi*!i**x", obj, connector_id, args, dxpl_id, req);
 
     /* Check args and get class pointer */
     if (NULL == obj)
@@ -3238,7 +3238,7 @@ H5VLdatatype_specific(void *obj, hid_t connector_id, H5VL_datatype_specific_args
     herr_t        ret_value = SUCCEED; /* Return value */
 
     FUNC_ENTER_API_NOINIT
-    H5TRACE5("e", "*xi*!ix", obj, connector_id, args, dxpl_id, req);
+    H5TRACE5("e", "*xi*!i**x", obj, connector_id, args, dxpl_id, req);
 
     /* Check args and get class pointer */
     if (NULL == obj)
@@ -3381,7 +3381,7 @@ H5VLdatatype_optional(void *obj, hid_t connector_id, H5VL_optional_args_t *args,
     herr_t        ret_value = SUCCEED; /* Return value */
 
     FUNC_ENTER_API_NOINIT
-    H5TRACE5("e", "*xi*!ix", obj, connector_id, args, dxpl_id, req);
+    H5TRACE5("e", "*xi*!i**x", obj, connector_id, args, dxpl_id, req);
 
     /* Check args and get class pointer */
     if (NULL == obj)
@@ -3525,7 +3525,7 @@ H5VLdatatype_close(void *obj, hid_t connector_id, hid_t dxpl_id, void **req /*ou
     herr_t        ret_value = SUCCEED; /* Return value */
 
     FUNC_ENTER_API_NOINIT
-    H5TRACE4("e", "*xiix", obj, connector_id, dxpl_id, req);
+    H5TRACE4("e", "*xii**x", obj, connector_id, dxpl_id, req);
 
     /* Check args and get class pointer */
     if (NULL == obj)
@@ -3628,7 +3628,7 @@ H5VLfile_create(const char *name, unsigned flags, hid_t fcpl_id, hid_t fapl_id, 
     void                 *ret_value = NULL; /* Return value */
 
     FUNC_ENTER_API_NOINIT
-    H5TRACE6("*x", "*sIuiiix", name, flags, fcpl_id, fapl_id, dxpl_id, req);
+    H5TRACE6("*x", "*sIuiii**x", name, flags, fcpl_id, fapl_id, dxpl_id, req);
 
     /* Get the VOL info from the fapl */
     if (NULL == (plist = (H5P_genplist_t *)H5I_object(fapl_id)))
@@ -3889,7 +3889,7 @@ H5VLfile_open(const char *name, unsigned flags, hid_t fapl_id, hid_t dxpl_id, vo
     void                 *ret_value = NULL; /* Return value */
 
     FUNC_ENTER_API_NOINIT
-    H5TRACE5("*x", "*sIuiix", name, flags, fapl_id, dxpl_id, req);
+    H5TRACE5("*x", "*sIuii**x", name, flags, fapl_id, dxpl_id, req);
 
     /* Get the VOL info from the fapl */
     if (NULL == (plist = (H5P_genplist_t *)H5I_object(fapl_id)))
@@ -3990,7 +3990,7 @@ H5VLfile_get(void *obj, hid_t connector_id, H5VL_file_get_args_t *args, hid_t dx
     herr_t        ret_value = SUCCEED; /* Return value */
 
     FUNC_ENTER_API_NOINIT
-    H5TRACE5("e", "*xi*!ix", obj, connector_id, args, dxpl_id, req);
+    H5TRACE5("e", "*xi*!i**x", obj, connector_id, args, dxpl_id, req);
 
     /* Check args and get class pointer */
     if (NULL == obj)
@@ -4125,7 +4125,7 @@ H5VLfile_specific(void *obj, hid_t connector_id, H5VL_file_specific_args_t *args
     herr_t        ret_value = SUCCEED; /* Return value */
 
     FUNC_ENTER_API_NOINIT
-    H5TRACE5("e", "*xi*!ix", obj, connector_id, args, dxpl_id, req);
+    H5TRACE5("e", "*xi*!i**x", obj, connector_id, args, dxpl_id, req);
 
     /* Check args and get class pointer */
     if (NULL == (cls = (H5VL_class_t *)H5I_object_verify(connector_id, H5I_VOL)))
@@ -4221,7 +4221,7 @@ H5VLfile_optional(void *obj, hid_t connector_id, H5VL_optional_args_t *args, hid
     herr_t        ret_value = SUCCEED; /* Return value */
 
     FUNC_ENTER_API_NOINIT
-    H5TRACE5("e", "*xi*!ix", obj, connector_id, args, dxpl_id, req);
+    H5TRACE5("e", "*xi*!i**x", obj, connector_id, args, dxpl_id, req);
 
     /* Check args and get class pointer */
     if (NULL == obj)
@@ -4365,7 +4365,7 @@ H5VLfile_close(void *obj, hid_t connector_id, hid_t dxpl_id, void **req /*out*/)
     herr_t        ret_value = SUCCEED; /* Return value */
 
     FUNC_ENTER_API_NOINIT
-    H5TRACE4("e", "*xiix", obj, connector_id, dxpl_id, req);
+    H5TRACE4("e", "*xii**x", obj, connector_id, dxpl_id, req);
 
     /* Check args and get class pointer */
     if (NULL == obj)
@@ -4467,7 +4467,7 @@ H5VLgroup_create(void *obj, const H5VL_loc_params_t *loc_params, hid_t connector
     void         *ret_value = NULL; /* Return value */
 
     FUNC_ENTER_API_NOINIT
-    H5TRACE9("*x", "*x*#i*siiiix", obj, loc_params, connector_id, name, lcpl_id, gcpl_id, gapl_id, dxpl_id,
+    H5TRACE9("*x", "*x*#i*siiii**x", obj, loc_params, connector_id, name, lcpl_id, gcpl_id, gapl_id, dxpl_id,
              req);
 
     /* Check args and get class pointer */
@@ -4570,7 +4570,7 @@ H5VLgroup_open(void *obj, const H5VL_loc_params_t *loc_params, hid_t connector_i
     void         *ret_value = NULL; /* Return value */
 
     FUNC_ENTER_API_NOINIT
-    H5TRACE7("*x", "*x*#i*siix", obj, loc_params, connector_id, name, gapl_id, dxpl_id, req);
+    H5TRACE7("*x", "*x*#i*sii**x", obj, loc_params, connector_id, name, gapl_id, dxpl_id, req);
 
     /* Check args and get class pointer */
     if (NULL == obj)
@@ -4667,7 +4667,7 @@ H5VLgroup_get(void *obj, hid_t connector_id, H5VL_group_get_args_t *args, hid_t 
     herr_t        ret_value = SUCCEED; /* Return value */
 
     FUNC_ENTER_API_NOINIT
-    H5TRACE5("e", "*xi*!ix", obj, connector_id, args, dxpl_id, req);
+    H5TRACE5("e", "*xi*!i**x", obj, connector_id, args, dxpl_id, req);
 
     /* Check args and get class pointer */
     if (NULL == obj)
@@ -4766,7 +4766,7 @@ H5VLgroup_specific(void *obj, hid_t connector_id, H5VL_group_specific_args_t *ar
     herr_t        ret_value = SUCCEED; /* Return value */
 
     FUNC_ENTER_API_NOINIT
-    H5TRACE5("e", "*xi*!ix", obj, connector_id, args, dxpl_id, req);
+    H5TRACE5("e", "*xi*!i**x", obj, connector_id, args, dxpl_id, req);
 
     /* Check args and get class pointer */
     if (NULL == obj)
@@ -4867,7 +4867,7 @@ H5VLgroup_optional(void *obj, hid_t connector_id, H5VL_optional_args_t *args, hi
     herr_t        ret_value = SUCCEED; /* Return value */
 
     FUNC_ENTER_API_NOINIT
-    H5TRACE5("e", "*xi*!ix", obj, connector_id, args, dxpl_id, req);
+    H5TRACE5("e", "*xi*!i**x", obj, connector_id, args, dxpl_id, req);
 
     /* Check args and get class pointer */
     if (NULL == obj)
@@ -5012,7 +5012,7 @@ H5VLgroup_close(void *obj, hid_t connector_id, hid_t dxpl_id, void **req /*out*/
     herr_t        ret_value = SUCCEED; /* Return value */
 
     FUNC_ENTER_API_NOINIT
-    H5TRACE4("e", "*xiix", obj, connector_id, dxpl_id, req);
+    H5TRACE4("e", "*xii**x", obj, connector_id, dxpl_id, req);
 
     /* Check args and get class pointer */
     if (NULL == obj)
@@ -5127,7 +5127,7 @@ H5VLlink_create(H5VL_link_create_args_t *args, void *obj, const H5VL_loc_params_
     herr_t        ret_value = SUCCEED; /* Return value */
 
     FUNC_ENTER_API_NOINIT
-    H5TRACE8("e", "*!*x*#iiiix", args, obj, loc_params, connector_id, lcpl_id, lapl_id, dxpl_id, req);
+    H5TRACE8("e", "*!*x*#iiii**x", args, obj, loc_params, connector_id, lcpl_id, lapl_id, dxpl_id, req);
 
     /* Get class pointer */
     if (NULL == (cls = (H5VL_class_t *)H5I_object_verify(connector_id, H5I_VOL)))
@@ -5233,8 +5233,8 @@ H5VLlink_copy(void *src_obj, const H5VL_loc_params_t *loc_params1, void *dst_obj
     herr_t        ret_value = SUCCEED; /* Return value */
 
     FUNC_ENTER_API_NOINIT
-    H5TRACE9("e", "*x*#*x*#iiiix", src_obj, loc_params1, dst_obj, loc_params2, connector_id, lcpl_id, lapl_id,
-             dxpl_id, req);
+    H5TRACE9("e", "*x*#*x*#iiii**x", src_obj, loc_params1, dst_obj, loc_params2, connector_id, lcpl_id,
+             lapl_id, dxpl_id, req);
 
     /* Get class pointer */
     if (NULL == (cls = (H5VL_class_t *)H5I_object_verify(connector_id, H5I_VOL)))
@@ -5340,8 +5340,8 @@ H5VLlink_move(void *src_obj, const H5VL_loc_params_t *loc_params1, void *dst_obj
     herr_t        ret_value = SUCCEED; /* Return value */
 
     FUNC_ENTER_API_NOINIT
-    H5TRACE9("e", "*x*#*x*#iiiix", src_obj, loc_params1, dst_obj, loc_params2, connector_id, lcpl_id, lapl_id,
-             dxpl_id, req);
+    H5TRACE9("e", "*x*#*x*#iiii**x", src_obj, loc_params1, dst_obj, loc_params2, connector_id, lcpl_id,
+             lapl_id, dxpl_id, req);
 
     /* Get class pointer */
     if (NULL == (cls = (H5VL_class_t *)H5I_object_verify(connector_id, H5I_VOL)))
@@ -5439,7 +5439,7 @@ H5VLlink_get(void *obj, const H5VL_loc_params_t *loc_params, hid_t connector_id,
     herr_t        ret_value = SUCCEED; /* Return value */
 
     FUNC_ENTER_API_NOINIT
-    H5TRACE6("e", "*x*#i*!ix", obj, loc_params, connector_id, args, dxpl_id, req);
+    H5TRACE6("e", "*x*#i*!i**x", obj, loc_params, connector_id, args, dxpl_id, req);
 
     /* Check args and get class pointer */
     if (NULL == obj)
@@ -5542,7 +5542,7 @@ H5VLlink_specific(void *obj, const H5VL_loc_params_t *loc_params, hid_t connecto
     herr_t        ret_value = SUCCEED; /* Return value */
 
     FUNC_ENTER_API_NOINIT
-    H5TRACE6("e", "*x*#i*!ix", obj, loc_params, connector_id, args, dxpl_id, req);
+    H5TRACE6("e", "*x*#i*!i**x", obj, loc_params, connector_id, args, dxpl_id, req);
 
     /* Check args and get class pointer */
     if (NULL == obj)
@@ -5643,7 +5643,7 @@ H5VLlink_optional(void *obj, const H5VL_loc_params_t *loc_params, hid_t connecto
     herr_t        ret_value = SUCCEED; /* Return value */
 
     FUNC_ENTER_API_NOINIT
-    H5TRACE6("e", "*x*#i*!ix", obj, loc_params, connector_id, args, dxpl_id, req);
+    H5TRACE6("e", "*x*#i*!i**x", obj, loc_params, connector_id, args, dxpl_id, req);
 
     /* Check args and get class pointer */
     if (NULL == obj)
@@ -5805,7 +5805,7 @@ H5VLobject_open(void *obj, const H5VL_loc_params_t *params, hid_t connector_id, 
     void         *ret_value = NULL; /* Return value */
 
     FUNC_ENTER_API_NOINIT
-    H5TRACE6("*x", "*x*#i*Itix", obj, params, connector_id, opened_type, dxpl_id, req);
+    H5TRACE6("*x", "*x*#i*Iti**x", obj, params, connector_id, opened_type, dxpl_id, req);
 
     /* Check args and get class pointer */
     if (NULL == obj)
@@ -5915,8 +5915,8 @@ H5VLobject_copy(void *src_obj, const H5VL_loc_params_t *src_loc_params, const ch
     herr_t        ret_value = SUCCEED; /* Return value */
 
     FUNC_ENTER_API_NOINIT
-    H5TRACE11("e", "*x*#*s*x*#*siiiix", src_obj, src_loc_params, src_name, dst_obj, dst_loc_params, dst_name,
-              connector_id, ocpypl_id, lcpl_id, dxpl_id, req);
+    H5TRACE11("e", "*x*#*s*x*#*siiii**x", src_obj, src_loc_params, src_name, dst_obj, dst_loc_params,
+              dst_name, connector_id, ocpypl_id, lcpl_id, dxpl_id, req);
 
     /* Check args and get class pointers */
     if (NULL == src_obj || NULL == dst_obj)
@@ -6017,7 +6017,7 @@ H5VLobject_get(void *obj, const H5VL_loc_params_t *loc_params, hid_t connector_i
     herr_t        ret_value = SUCCEED; /* Return value */
 
     FUNC_ENTER_API_NOINIT
-    H5TRACE6("e", "*x*#i*!ix", obj, loc_params, connector_id, args, dxpl_id, req);
+    H5TRACE6("e", "*x*#i*!i**x", obj, loc_params, connector_id, args, dxpl_id, req);
 
     /* Check args and get class pointer */
     if (NULL == obj)
@@ -6120,7 +6120,7 @@ H5VLobject_specific(void *obj, const H5VL_loc_params_t *loc_params, hid_t connec
     herr_t        ret_value = SUCCEED; /* Return value */
 
     FUNC_ENTER_API_NOINIT
-    H5TRACE6("e", "*x*#i*!ix", obj, loc_params, connector_id, args, dxpl_id, req);
+    H5TRACE6("e", "*x*#i*!i**x", obj, loc_params, connector_id, args, dxpl_id, req);
 
     /* Check args and get class pointer */
     if (NULL == obj)
@@ -6221,7 +6221,7 @@ H5VLobject_optional(void *obj, const H5VL_loc_params_t *loc_params, hid_t connec
     herr_t        ret_value = SUCCEED; /* Return value */
 
     FUNC_ENTER_API_NOINIT
-    H5TRACE6("e", "*x*#i*!ix", obj, loc_params, connector_id, args, dxpl_id, req);
+    H5TRACE6("e", "*x*#i*!i**x", obj, loc_params, connector_id, args, dxpl_id, req);
 
     /* Check args and get class pointer */
     if (NULL == obj)
@@ -6392,7 +6392,7 @@ H5VLintrospect_get_conn_cls(void *obj, hid_t connector_id, H5VL_get_conn_lvl_t l
     herr_t        ret_value = SUCCEED; /* Return value */
 
     FUNC_ENTER_API_NOINIT
-    H5TRACE4("e", "*xiVLx", obj, connector_id, lvl, conn_cls);
+    H5TRACE4("e", "*xiVL**#", obj, connector_id, lvl, conn_cls);
 
     /* Check args */
     if (NULL == obj)
@@ -6464,7 +6464,7 @@ H5VLintrospect_get_cap_flags(const void *info, hid_t connector_id, uint64_t *cap
     herr_t        ret_value = SUCCEED; /* Return value */
 
     FUNC_ENTER_API_NOINIT
-    H5TRACE3("e", "*xix", info, connector_id, cap_flags);
+    H5TRACE3("e", "*xi*UL", info, connector_id, cap_flags);
 
     /* Check args */
     if (NULL == cap_flags)
@@ -6568,7 +6568,7 @@ H5VLintrospect_opt_query(void *obj, hid_t connector_id, H5VL_subclass_t subcls, 
     herr_t        ret_value = SUCCEED; /* Return value */
 
     FUNC_ENTER_API_NOINIT
-    H5TRACE5("e", "*xiVSIsx", obj, connector_id, subcls, opt_type, flags);
+    H5TRACE5("e", "*xiVSIs*UL", obj, connector_id, subcls, opt_type, flags);
 
     /* Get class pointer */
     if (NULL == (cls = (H5VL_class_t *)H5I_object_verify(connector_id, H5I_VOL)))
@@ -6671,7 +6671,7 @@ H5VLrequest_wait(void *req, hid_t connector_id, uint64_t timeout, H5VL_request_s
     herr_t        ret_value = SUCCEED; /* Return value */
 
     FUNC_ENTER_API_NOINIT
-    H5TRACE4("e", "*xiULx", req, connector_id, timeout, status);
+    H5TRACE4("e", "*xiUL*#", req, connector_id, timeout, status);
 
     /* Get class pointer */
     if (NULL == (cls = (H5VL_class_t *)H5I_object_verify(connector_id, H5I_VOL)))
@@ -6878,7 +6878,7 @@ H5VLrequest_cancel(void *req, hid_t connector_id, H5VL_request_status_t *status 
     herr_t        ret_value = SUCCEED; /* Return value */
 
     FUNC_ENTER_API_NOINIT
-    H5TRACE3("e", "*xix", req, connector_id, status);
+    H5TRACE3("e", "*xi*#", req, connector_id, status);
 
     /* Get class pointer */
     if (NULL == (cls = (H5VL_class_t *)H5I_object_verify(connector_id, H5I_VOL)))
@@ -7415,7 +7415,7 @@ H5VLblob_get(void *obj, hid_t connector_id, const void *blob_id, void *buf /*out
     herr_t        ret_value = SUCCEED; /* Return value */
 
     FUNC_ENTER_API_NOINIT
-    H5TRACE6("e", "*xi*xxz*x", obj, connector_id, blob_id, buf, size, ctx);
+    H5TRACE6("e", "*xi*x*xz*x", obj, connector_id, blob_id, buf, size, ctx);
 
     /* Get class pointer */
     if (NULL == obj)
@@ -8038,7 +8038,7 @@ H5VLoptional(void *obj, hid_t connector_id, H5VL_optional_args_t *args, hid_t dx
     herr_t        ret_value = SUCCEED; /* Return value */
 
     FUNC_ENTER_API_NOINIT
-    H5TRACE5("e", "*xi*!ix", obj, connector_id, args, dxpl_id, req);
+    H5TRACE5("e", "*xi*!i**x", obj, connector_id, args, dxpl_id, req);
 
     /* Check args and get class pointer */
     if (NULL == obj)

--- a/src/H5Z.c
+++ b/src/H5Z.c
@@ -1713,7 +1713,7 @@ H5Zget_filter_info(H5Z_filter_t filter, unsigned *filter_config_flags /*out*/)
     herr_t ret_value = SUCCEED;
 
     FUNC_ENTER_API(FAIL)
-    H5TRACE2("e", "Zfx", filter, filter_config_flags);
+    H5TRACE2("e", "Zf*Iu", filter, filter_config_flags);
 
     /* Get the filter info */
     if (H5Z_get_filter_info(filter, filter_config_flags) < 0)

--- a/src/H5trace.c
+++ b/src/H5trace.c
@@ -23,7 +23,7 @@
 /* Module Setup */
 /****************/
 #include "H5module.h" /* This source code file is part of the H5 module */
-#define H5I_FRIEND    /*suppress error about including H5Ipkg      */
+#define H5I_FRIEND    /* Suppress error about including H5Ipkg */
 
 /***********/
 /* Headers */
@@ -40,7 +40,7 @@
 #include "H5VLprivate.h" /* Virtual Object Layer                     */
 
 #ifdef H5_HAVE_PARALLEL
-/* datatypes of predefined drivers needed by H5_trace() */
+/* Datatypes of predefined drivers needed by H5_trace() */
 #include "H5FDmpio.h"
 #endif /* H5_HAVE_PARALLEL */
 
@@ -79,7 +79,7 @@ static herr_t H5_trace_args_close_degree(H5RS_str_t *rs, H5F_close_degree_t degr
  * Function:    H5_trace_args_bool
  *
  * Purpose:     This routine formats an bool and adds the output to
- *		the refcounted string (RS) argument.
+ *              the refcounted string (RS) argument.
  *
  * Return:      SUCCEED / FAIL
  *
@@ -104,7 +104,7 @@ H5_trace_args_bool(H5RS_str_t *rs, bool val)
  * Function:    H5_trace_args_cset
  *
  * Purpose:     This routine formats an H5T_cset_t and adds the output to
- *		the refcounted string (RS) argument.
+ *              the refcounted string (RS) argument.
  *
  * Return:      SUCCEED / FAIL
  *
@@ -148,7 +148,7 @@ H5_trace_args_cset(H5RS_str_t *rs, H5T_cset_t cset)
         default:
             H5RS_asprintf_cat(rs, "%ld", (long)cset);
             break;
-    } /* end switch */
+    }
 
     return SUCCEED;
 } /* end H5_trace_args_cset() */
@@ -197,14 +197,14 @@ H5_trace_args_close_degree(H5RS_str_t *rs, H5F_close_degree_t degree)
  * Function:    H5_trace_args
  *
  * Purpose:     This routine formats a set of function arguments, placing the
- *		resulting string in the refcounted string (RS) argument.
+ *              resulting string in the refcounted string (RS) argument.
  *
- *		The TYPE argument is a string which gives the type of each of
+ *              The TYPE argument is a string which gives the type of each of
  *              the following argument pairs.  Each type begins with zero or
- *		more asterisks (one for each level of indirection, although
- *		some types have one level of indirection already implied)
- *		followed by either one letter (lower case) or two letters
- *		(first one uppercase).
+ *              more asterisks (one for each level of indirection, although
+ *              some types have one level of indirection already implied)
+ *              followed by either one letter (lower case) or two letters
+ *              (first one uppercase).
  *
  *              The variable argument list consists of pairs of values. Each
  *              pair is a string which is the formal argument name in the

--- a/src/H5trace.c
+++ b/src/H5trace.c
@@ -1480,8 +1480,40 @@ H5_trace_args(H5RS_str_t *rs, const char *type, va_list ap)
                             H5G_iterate_t git = (H5G_iterate_t)va_arg(ap, H5G_iterate_t);
 
                             H5RS_asprintf_cat(rs, "%p", (void *)(uintptr_t)git);
-                        } /* end block */
-                        break;
+                        } break;
+
+                        case 'I': /* H5G_info_t */
+                        {
+                            H5G_info_t ginfo = va_arg(ap, H5G_info_t);
+
+                            H5RS_acat(rs, "{");
+                            switch (ginfo.storage_type) {
+                                case H5G_STORAGE_TYPE_UNKNOWN:
+                                    H5RS_asprintf_cat(rs, "H5G_STORAGE_TYPE_UNKNOWN");
+                                    break;
+
+                                case H5G_STORAGE_TYPE_SYMBOL_TABLE:
+                                    H5RS_asprintf_cat(rs, "H5G_STORAGE_TYPE_SYMBOL_TABLE");
+                                    break;
+
+                                case H5G_STORAGE_TYPE_COMPACT:
+                                    H5RS_asprintf_cat(rs, "H5G_STORAGE_TYPE_COMPACT");
+                                    break;
+
+                                case H5G_STORAGE_TYPE_DENSE:
+                                    H5RS_asprintf_cat(rs, "H5G_STORAGE_TYPE_DENSE");
+                                    break;
+
+                                default:
+                                    H5RS_asprintf_cat(rs, "%ld", (long)ginfo.storage_type);
+                                    break;
+                            }
+                            H5RS_asprintf_cat(rs, ", ");
+                            H5RS_asprintf_cat(rs, "%" PRIuHSIZE ", ", ginfo.nlinks);
+                            H5RS_asprintf_cat(rs, "%" PRId64 ", ", ginfo.max_corder);
+                            H5_trace_args_bool(rs, ginfo.mounted);
+                            H5RS_asprintf_cat(rs, "}");
+                        } break;
 
                         case 'o': /* H5G_obj_t */
                         {


### PR DESCRIPTION
The bin/trace script adds TRACE macros to public API calls in the main C library. This script had a parsing bug that caused functions that were annotated with /*out*/, etc. to be labeled as void pointers instead of typed pointers.

This is mainly a developer feature and not visible to consumers of the public API.

The bin/trace script now annotates public API calls properly.

Fixes GH #3733