### PR TITLE
Don't load toolchain file in CMake workflows

### DIFF
--- a/.github/workflows/main-cmake-spc.yml
+++ b/.github/workflows/main-cmake-spc.yml
@@ -48,7 +48,6 @@ jobs:
           cmake -C $GITHUB_WORKSPACE/config/cmake/cacheinit.cmake \
             -G Ninja \
             -DCMAKE_BUILD_TYPE=Debug \
-            -DCMAKE_TOOLCHAIN_FILE=config/toolchain/gcc.cmake \
             -DBUILD_SHARED_LIBS=ON \
             -DHDF5_ENABLE_ALL_WARNINGS=ON \
             -DHDF5_ENABLE_PARALLEL:BOOL=OFF \
@@ -109,7 +108,6 @@ jobs:
           cmake -C $GITHUB_WORKSPACE/config/cmake/cacheinit.cmake \
             -G Ninja \
             -DCMAKE_BUILD_TYPE=Debug \
-            -DCMAKE_TOOLCHAIN_FILE=config/toolchain/gcc.cmake \
             -DBUILD_SHARED_LIBS=ON \
             -DHDF5_ENABLE_ALL_WARNINGS=ON \
             -DHDF5_ENABLE_PARALLEL:BOOL=OFF \
@@ -170,7 +168,6 @@ jobs:
           cmake -C $GITHUB_WORKSPACE/config/cmake/cacheinit.cmake \
             -G Ninja \
             -DCMAKE_BUILD_TYPE=Debug \
-            -DCMAKE_TOOLCHAIN_FILE=config/toolchain/gcc.cmake \
             -DBUILD_SHARED_LIBS=ON \
             -DHDF5_ENABLE_ALL_WARNINGS=ON \
             -DHDF5_ENABLE_PARALLEL:BOOL=OFF \
@@ -231,7 +228,6 @@ jobs:
           cmake -C $GITHUB_WORKSPACE/config/cmake/cacheinit.cmake \
             -G Ninja \
             -DCMAKE_BUILD_TYPE=Debug \
-            -DCMAKE_TOOLCHAIN_FILE=config/toolchain/gcc.cmake \
             -DBUILD_SHARED_LIBS=ON \
             -DHDF5_ENABLE_ALL_WARNINGS=ON \
             -DHDF5_ENABLE_PARALLEL:BOOL=OFF \

--- a/.github/workflows/main-cmake.yml
+++ b/.github/workflows/main-cmake.yml
@@ -49,7 +49,6 @@ jobs:
           # No Fortran, parallel, or VFDs that rely on POSIX things
           - name: "Windows MSVC"
             os: windows-latest
-            toolchain: ""
             cpp: ON
             fortran: OFF
             java: ON
@@ -83,7 +82,6 @@ jobs:
             mirror_vfd: ON
             direct_vfd: ON
             ros3_vfd: ON
-            toolchain: "-DCMAKE_TOOLCHAIN_FILE=config/toolchain/gcc.cmake"
             generator: "-G Ninja"
             run_tests: true
 
@@ -106,7 +104,6 @@ jobs:
             mirror_vfd: ON
             direct_vfd: OFF
             ros3_vfd: OFF
-            toolchain: "-DCMAKE_TOOLCHAIN_FILE=config/toolchain/clang.cmake"
             generator: "-G Ninja"
             run_tests: true
 
@@ -182,7 +179,6 @@ jobs:
           cmake -C $GITHUB_WORKSPACE/config/cmake/cacheinit.cmake \
             ${{ matrix.generator }} \
             -DCMAKE_BUILD_TYPE=${{ inputs.build_mode }} \
-            ${{ matrix.toolchain }} \
             -DBUILD_SHARED_LIBS=ON \
             -DHDF5_ENABLE_ALL_WARNINGS=ON \
             -DHDF5_ENABLE_DOXY_WARNINGS=ON \
@@ -210,7 +206,6 @@ jobs:
           cmake -C $GITHUB_WORKSPACE/config/cmake/cacheinit.cmake \
             ${{ matrix.generator }} \
             -DCMAKE_BUILD_TYPE=${{ inputs.build_mode }} \
-            ${{ matrix.toolchain }} \
             -DBUILD_SHARED_LIBS=ON \
             -DBUILD_STATIC_LIBS=${{ (matrix.os != 'windows-latest') }} \
             -DHDF5_ENABLE_ALL_WARNINGS=ON \


### PR DESCRIPTION
This was preventing the `echo "CC=gcc-12" >> $GITHUB_ENV` GCC version override in the workflow files from taking place on Ubuntu CMake builds, causing Autotools builds to test GCC 12, while CMake builds were defaulting back to GCC 11.

That said, GCC 12 is not the default on the Ubuntu runners and testing with a non-default compiler seems to defeat part of the purpose of testing on a particular runner, so we may want to consider not overriding the GCC version, or having it as a separate build.