### PR TITLE
Add support for the new MSVC preprocessor

### DIFF
--- a/release_docs/RELEASE.txt
+++ b/release_docs/RELEASE.txt
@@ -47,6 +47,21 @@ New Features
 
     Configuration:
     -------------
+    - Added support for the new MSVC preprocessor
+
+      Microsoft added support for a new, standards-conformant preprocessor
+      to MSVC, which can be enabled with the /Zc:preprocessor option. This
+      preprocessor would trip over our HDopen() variadic function-like
+      macro, which uses a feature that only works with the legacy preprocessor.
+
+      ifdefs have been added that select the correct HDopen() form and
+      allow building HDF5 with the /Zc:preprocessor option.
+
+      The HDopen() macro is located in an internal header file and only
+      affects building the HDF5 library from source.
+
+      Fixes GitHub #2515
+
     - Renamed HDF5_ENABLE_USING_MEMCHECKER to HDF5_USING_ANALYSIS_TOOL
 
       The HDF5_USING_ANALYSIS_TOOL is used to indicate to test macros that

--- a/src/H5win32defs.h
+++ b/src/H5win32defs.h
@@ -50,12 +50,18 @@ struct timezone {
 #define HDlstat(S, B)        _lstati64(S, B)
 #define HDmkdir(S, M)        _mkdir(S)
 
-/* Note that the variadic HDopen macro is using a VC++ extension
- * where the comma is dropped if nothing is passed to the ellipsis.
+/* Note that with the traditional MSVC preprocessor, the variadic
+ * HDopen macro uses an MSVC-specific extension where the comma
+ * is dropped if nothing is passed to the ellipsis.
+ *
+ * MinGW and the newer, conforming MSVC preprocessor do not exhibit this
+ * behavior.
  */
-#ifndef H5_HAVE_MINGW
+#if defined(_MSC_VER) && !defined(_MSVC_TRADITIONAL) || _MSVC_TRADITIONAL
+/* Using the MSVC traditional preprocessor */
 #define HDopen(S, F, ...) Wopen_utf8(S, F, __VA_ARGS__)
 #else
+/* Using a standards conformant preprocessor */
 #define HDopen(S, F, ...) Wopen_utf8(S, F, ##__VA_ARGS__)
 #endif
 

--- a/src/H5win32defs.h
+++ b/src/H5win32defs.h
@@ -57,7 +57,7 @@ struct timezone {
  * MinGW and the newer, conforming MSVC preprocessor do not exhibit this
  * behavior.
  */
-#if defined(_MSC_VER) && !defined(_MSVC_TRADITIONAL) || _MSVC_TRADITIONAL
+#if (defined(_MSC_VER) && !defined(_MSVC_TRADITIONAL)) || _MSVC_TRADITIONAL
 /* Using the MSVC traditional preprocessor */
 #define HDopen(S, F, ...) Wopen_utf8(S, F, __VA_ARGS__)
 #else


### PR DESCRIPTION
Microsoft added support for a new, standards-conformant preprocessor
to MSVC, which can be enabled with the /Zc:preprocessor option. This
preprocessor would trip over our HDopen() variadic function-like
macro, which, on Windows w/ MSVC, uses a quirk that only works
with the legacy MSVC preprocessor.

ifdefs have been added that select the correct HDopen() form and
allow building HDF5 with the /Zc:preprocessor option.

Fixes #2515