### PR TITLE
Added macOS support statement

### DIFF
--- a/release_docs/RELEASE.txt
+++ b/release_docs/RELEASE.txt
@@ -1288,6 +1288,12 @@ Bug Fixes since HDF5-1.14.0 release
 Platforms Tested
 ===================
 
+    - HDF5 supports the latest macOS versions, including the current and two
+      preceding releases. As new major macOS versions become available, HDF5
+      will discontinue  support for the  oldest  version and add  the latest
+      version to its list of compatible systems, along with the previous two
+      releases.
+
     Linux 5.16.14-200.fc35           GNU gcc (GCC) 11.2.1 20220127 (Red Hat 11.2.1-9)
     #1 SMP x86_64  GNU/Linux         GNU Fortran (GCC) 11.2.1 20220127 (Red Hat 11.2.1-9)
     Fedora35                         clang version 13.0.0 (Fedora 13.0.0-3.fc35)


### PR DESCRIPTION
This would mean we test starting with macOS 12 (Monterey), released October 25, 2021. The best estimates have older versions accounting for less than 3% of the install versions.

Also, do you know if the list of platform testing is correct, and is this maintainable going forward with all the different testing going on between GitHub, BB, and daily tests?

