### PR TITLE
Initialize selection type in both if/else sections

### DIFF
--- a/src/H5Dchunk.c
+++ b/src/H5Dchunk.c
@@ -1206,8 +1206,8 @@ H5D__chunk_io_init_selections(H5D_io_info_t *io_info, H5D_dset_io_info_t *dinfo)
         fm->use_single = true;
 
         /* Initialize selection type in memory and file */
-	fm->msel_type = H5S_SEL_NONE;
-	fm->fsel_type = H5S_SEL_NONE;
+        fm->msel_type = H5S_SEL_NONE;
+        fm->fsel_type = H5S_SEL_NONE;
 
         /* Initialize single chunk dataspace */
         if (NULL == dataset->shared->cache.chunk.single_space) {

--- a/src/H5Dchunk.c
+++ b/src/H5Dchunk.c
@@ -1062,8 +1062,8 @@ H5D__chunk_io_init(H5D_io_info_t *io_info, H5D_dset_io_info_t *dinfo)
     fm->single_piece_info = NULL;
 
     /* Initialize selection type in memory and file */
-    fm->msel_type         = H5S_SEL_ERROR;
-    fm->fsel_type         = H5S_SEL_ERROR;
+    fm->msel_type = H5S_SEL_ERROR;
+    fm->fsel_type = H5S_SEL_ERROR;
 
     /* Check if the memory space is scalar & make equivalent memory space */
     if ((sm_ndims = H5S_GET_EXTENT_NDIMS(dinfo->mem_space)) < 0)

--- a/src/H5Dchunk.c
+++ b/src/H5Dchunk.c
@@ -1205,6 +1205,10 @@ H5D__chunk_io_init_selections(H5D_io_info_t *io_info, H5D_dset_io_info_t *dinfo)
         /* Initialize skip list for chunk selections */
         fm->use_single = true;
 
+        /* Initialize selection type in memory and file */
+	fm->msel_type = H5S_SEL_NONE;
+	fm->fsel_type = H5S_SEL_NONE;
+
         /* Initialize single chunk dataspace */
         if (NULL == dataset->shared->cache.chunk.single_space) {
             /* Make a copy of the dataspace for the dataset */

--- a/src/H5Dchunk.c
+++ b/src/H5Dchunk.c
@@ -1061,6 +1061,10 @@ H5D__chunk_io_init(H5D_io_info_t *io_info, H5D_dset_io_info_t *dinfo)
     fm->single_space      = NULL;
     fm->single_piece_info = NULL;
 
+    /* Initialize selection type in memory and file */
+    fm->msel_type         = H5S_SEL_ERROR;
+    fm->fsel_type         = H5S_SEL_ERROR;
+
     /* Check if the memory space is scalar & make equivalent memory space */
     if ((sm_ndims = H5S_GET_EXTENT_NDIMS(dinfo->mem_space)) < 0)
         HGOTO_ERROR(H5E_DATASPACE, H5E_CANTGET, FAIL, "unable to get dimension number");
@@ -1204,10 +1208,6 @@ H5D__chunk_io_init_selections(H5D_io_info_t *io_info, H5D_dset_io_info_t *dinfo)
         && H5S_SEL_ALL != H5S_GET_SELECT_TYPE(dinfo->file_space)) {
         /* Initialize skip list for chunk selections */
         fm->use_single = true;
-
-        /* Initialize selection type in memory and file */
-        fm->msel_type = H5S_SEL_NONE;
-        fm->fsel_type = H5S_SEL_NONE;
 
         /* Initialize single chunk dataspace */
         if (NULL == dataset->shared->cache.chunk.single_space) {


### PR DESCRIPTION
The field fsel_type was never initialized in the if section of the if/else initialization code. 

Fixes #3969.