### PR TITLE
Remove leading / from relative path.

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,10 +38,10 @@ The latest doxygen documentation generated on changes to develop is available at
 
    https://hdfgroup.github.io/hdf5/
 
-See the [RELEASE.txt](/release_docs/RELEASE.txt) file in the [release_docs/](/release_docs/) directory for information specific
+See the [RELEASE.txt](release_docs/RELEASE.txt) file in the [release_docs/](release_docs/) directory for information specific
 to the features and updates included in this release of the library.
 
-Several more files are located within the [release_docs/](/release_docs/) directory with specific
+Several more files are located within the [release_docs/](release_docs/) directory with specific
 details for several common platforms and configurations.
 
     INSTALL - Start Here. General instructions for compiling and installing the library


### PR DESCRIPTION
`/` is not necessary in markdown. Links work well without it.