### PR TITLE
Remove H5DEBUG() calls from H5Dmpio.c

### DIFF
--- a/src/H5Dmpio.c
+++ b/src/H5Dmpio.c
@@ -614,8 +614,7 @@ H5D__mpio_debug_init(void)
     if (debug_str)
         H5D__mpio_parse_debug_str(debug_str);
 
-    if (H5DEBUG(D))
-        debug_stream = H5DEBUG(D);
+    debug_stream = stdout;
 
     H5D_mpio_debug_inited = true;
 
@@ -1412,7 +1411,7 @@ done:
         fprintf(debug_log_file, "##############\n\n");
         if (EOF == fclose(debug_log_file))
             HDONE_ERROR(H5E_IO, H5E_CLOSEERROR, FAIL, "couldn't close debugging log file");
-        debug_stream = H5DEBUG(D);
+        debug_stream = stdout;
     }
 #endif
 


### PR DESCRIPTION
Just use stdout when a stream is needed.