### PR TITLE
Refactor datatype conversion code to use pointers rather than IDs

### DIFF
--- a/src/H5Aint.c
+++ b/src/H5Aint.c
@@ -677,15 +677,16 @@ done:
 herr_t
 H5A__read(const H5A_t *attr, const H5T_t *mem_type, void *buf)
 {
-    uint8_t    *tconv_buf = NULL;         /* datatype conv buffer*/
-    uint8_t    *bkg_buf   = NULL;         /* background buffer */
-    hssize_t    snelmts;                  /* elements in attribute */
-    size_t      nelmts;                   /* elements in attribute*/
-    H5T_path_t *tpath  = NULL;            /* type conversion info    */
-    hid_t       src_id = -1, dst_id = -1; /* temporary type IDs*/
-    size_t      src_type_size;            /* size of source type     */
-    size_t      dst_type_size;            /* size of destination type */
-    size_t      buf_size;                 /* desired buffer size    */
+    uint8_t    *tconv_buf = NULL; /* datatype conv buffer*/
+    uint8_t    *bkg_buf   = NULL; /* background buffer */
+    hssize_t    snelmts;          /* elements in attribute */
+    size_t      nelmts;           /* elements in attribute*/
+    H5T_path_t *tpath    = NULL;  /* type conversion info    */
+    H5T_t      *src_type = NULL;  /* temporary datatype */
+    H5T_t      *dst_type = NULL;  /* temporary datatype */
+    size_t      src_type_size;    /* size of source type     */
+    size_t      dst_type_size;    /* size of destination type */
+    size_t      buf_size;         /* desired buffer size    */
     herr_t      ret_value = SUCCEED;
 
     FUNC_ENTER_PACKAGE_TAG(attr->oloc.addr)
@@ -722,10 +723,10 @@ H5A__read(const H5A_t *attr, const H5T_t *mem_type, void *buf)
             if (!H5T_path_noop(tpath)) {
                 H5T_bkg_t need_bkg; /* Background buffer type */
 
-                if ((src_id = H5I_register(H5I_DATATYPE, H5T_copy(attr->shared->dt, H5T_COPY_ALL), false)) <
-                        0 ||
-                    (dst_id = H5I_register(H5I_DATATYPE, H5T_copy(mem_type, H5T_COPY_ALL), false)) < 0)
-                    HGOTO_ERROR(H5E_ATTR, H5E_CANTREGISTER, FAIL, "unable to register types for conversion");
+                if (NULL == (src_type = H5T_copy(attr->shared->dt, H5T_COPY_ALL)))
+                    HGOTO_ERROR(H5E_ATTR, H5E_CANTCOPY, FAIL, "unable to copy attribute datatype");
+                if (NULL == (dst_type = H5T_copy(mem_type, H5T_COPY_ALL)))
+                    HGOTO_ERROR(H5E_ATTR, H5E_CANTCOPY, FAIL, "unable to copy memory datatype");
 
                 /* Get the maximum buffer size needed and allocate it */
                 buf_size = nelmts * MAX(src_type_size, dst_type_size);
@@ -751,8 +752,9 @@ H5A__read(const H5A_t *attr, const H5T_t *mem_type, void *buf)
                 }
 
                 /* Perform datatype conversion.  */
-                if (H5T_convert(tpath, src_id, dst_id, nelmts, (size_t)0, (size_t)0, tconv_buf, bkg_buf) < 0)
-                    HGOTO_ERROR(H5E_ATTR, H5E_CANTENCODE, FAIL, "datatype conversion failed");
+                if (H5T_convert(tpath, src_type, dst_type, nelmts, (size_t)0, (size_t)0, tconv_buf, bkg_buf) <
+                    0)
+                    HGOTO_ERROR(H5E_ATTR, H5E_CANTCONVERT, FAIL, "datatype conversion failed");
 
                 /* Copy the converted data into the user's buffer */
                 H5MM_memcpy(buf, tconv_buf, (dst_type_size * nelmts));
@@ -769,10 +771,10 @@ H5A__read(const H5A_t *attr, const H5T_t *mem_type, void *buf)
 
 done:
     /* Release resources */
-    if (src_id >= 0 && H5I_dec_ref(src_id) < 0)
-        HDONE_ERROR(H5E_ATTR, H5E_CANTDEC, FAIL, "unable to close temporary object");
-    if (dst_id >= 0 && H5I_dec_ref(dst_id) < 0)
-        HDONE_ERROR(H5E_ATTR, H5E_CANTDEC, FAIL, "unable to close temporary object");
+    if (src_type && H5T_close(src_type) < 0)
+        HDONE_ERROR(H5E_ATTR, H5E_CANTCLOSEOBJ, FAIL, "unable to close temporary datatype");
+    if (dst_type && H5T_close(dst_type) < 0)
+        HDONE_ERROR(H5E_ATTR, H5E_CANTCLOSEOBJ, FAIL, "unable to close temporary datatype");
     if (tconv_buf)
         tconv_buf = H5FL_BLK_FREE(attr_buf, tconv_buf);
     if (bkg_buf)
@@ -799,15 +801,16 @@ done:
 herr_t
 H5A__write(H5A_t *attr, const H5T_t *mem_type, const void *buf)
 {
-    uint8_t    *tconv_buf = NULL;         /* datatype conv buffer */
-    uint8_t    *bkg_buf   = NULL;         /* temp conversion buffer */
-    hssize_t    snelmts;                  /* elements in attribute */
-    size_t      nelmts;                   /* elements in attribute */
-    H5T_path_t *tpath  = NULL;            /* conversion information*/
-    hid_t       src_id = -1, dst_id = -1; /* temporary type IDs */
-    size_t      src_type_size;            /* size of source type    */
-    size_t      dst_type_size;            /* size of destination type*/
-    size_t      buf_size;                 /* desired buffer size    */
+    uint8_t    *tconv_buf = NULL; /* datatype conv buffer */
+    uint8_t    *bkg_buf   = NULL; /* temp conversion buffer */
+    hssize_t    snelmts;          /* elements in attribute */
+    size_t      nelmts;           /* elements in attribute */
+    H5T_path_t *tpath    = NULL;  /* conversion information*/
+    H5T_t      *src_type = NULL;  /* temporary datatype */
+    H5T_t      *dst_type = NULL;  /* temporary datatype */
+    size_t      src_type_size;    /* size of source type    */
+    size_t      dst_type_size;    /* size of destination type*/
+    size_t      buf_size;         /* desired buffer size    */
     herr_t      ret_value = SUCCEED;
 
     FUNC_ENTER_PACKAGE_TAG(attr->oloc.addr)
@@ -840,9 +843,10 @@ H5A__write(H5A_t *attr, const H5T_t *mem_type, const void *buf)
         if (!H5T_path_noop(tpath)) {
             H5T_bkg_t need_bkg; /* Background buffer type */
 
-            if ((src_id = H5I_register(H5I_DATATYPE, H5T_copy(mem_type, H5T_COPY_ALL), false)) < 0 ||
-                (dst_id = H5I_register(H5I_DATATYPE, H5T_copy(attr->shared->dt, H5T_COPY_ALL), false)) < 0)
-                HGOTO_ERROR(H5E_ATTR, H5E_CANTREGISTER, FAIL, "unable to register types for conversion");
+            if (NULL == (src_type = H5T_copy(mem_type, H5T_COPY_ALL)))
+                HGOTO_ERROR(H5E_ATTR, H5E_CANTCOPY, FAIL, "unable to copy memory datatype");
+            if (NULL == (dst_type = H5T_copy(attr->shared->dt, H5T_COPY_ALL)))
+                HGOTO_ERROR(H5E_ATTR, H5E_CANTCOPY, FAIL, "unable to copy attribute datatype");
 
             /* Get the maximum buffer size needed and allocate it */
             buf_size = nelmts * MAX(src_type_size, dst_type_size);
@@ -876,8 +880,8 @@ H5A__write(H5A_t *attr, const H5T_t *mem_type, const void *buf)
             }
 
             /* Perform datatype conversion */
-            if (H5T_convert(tpath, src_id, dst_id, nelmts, (size_t)0, (size_t)0, tconv_buf, bkg_buf) < 0)
-                HGOTO_ERROR(H5E_ATTR, H5E_CANTENCODE, FAIL, "datatype conversion failed");
+            if (H5T_convert(tpath, src_type, dst_type, nelmts, (size_t)0, (size_t)0, tconv_buf, bkg_buf) < 0)
+                HGOTO_ERROR(H5E_ATTR, H5E_CANTCONVERT, FAIL, "datatype conversion failed");
 
             /* Free the previous attribute data buffer, if there is one */
             if (attr->shared->data)
@@ -907,10 +911,10 @@ H5A__write(H5A_t *attr, const H5T_t *mem_type, const void *buf)
 
 done:
     /* Release resources */
-    if (src_id >= 0 && H5I_dec_ref(src_id) < 0)
-        HDONE_ERROR(H5E_ATTR, H5E_CANTDEC, FAIL, "unable to close temporary object");
-    if (dst_id >= 0 && H5I_dec_ref(dst_id) < 0)
-        HDONE_ERROR(H5E_ATTR, H5E_CANTDEC, FAIL, "unable to close temporary object");
+    if (src_type && H5T_close(src_type) < 0)
+        HDONE_ERROR(H5E_ATTR, H5E_CANTCLOSEOBJ, FAIL, "unable to close temporary datatype");
+    if (dst_type && H5T_close(dst_type) < 0)
+        HDONE_ERROR(H5E_ATTR, H5E_CANTCLOSEOBJ, FAIL, "unable to close temporary datatype");
     if (tconv_buf)
         tconv_buf = H5FL_BLK_FREE(attr_buf, tconv_buf);
     if (bkg_buf)
@@ -2079,9 +2083,7 @@ H5A__attr_copy_file(const H5A_t *attr_src, H5F_t *file_dst, bool *recompute_size
                     H5O_copy_t H5_ATTR_NDEBUG_UNUSED *cpy_info)
 {
     H5A_t   *attr_dst    = NULL; /* Destination attribute */
-    hid_t    tid_src     = -1;   /* Datatype ID for source datatype */
-    hid_t    tid_dst     = -1;   /* Datatype ID for destination datatype */
-    hid_t    tid_mem     = -1;   /* Datatype ID for memory datatype */
+    H5T_t   *dt_mem      = NULL; /* Memory datatype */
     void    *buf         = NULL; /* Buffer for copying data */
     void    *reclaim_buf = NULL; /* Buffer for reclaiming data */
     void    *bkg_buf     = NULL; /* Background buffer */
@@ -2195,7 +2197,6 @@ H5A__attr_copy_file(const H5A_t *attr_src, H5F_t *file_dst, bool *recompute_size
         /* Check if we need to convert data */
         if (H5T_detect_class(attr_src->shared->dt, H5T_VLEN, false) > 0) {
             H5T_path_t *tpath_src_mem, *tpath_mem_dst; /* Datatype conversion paths */
-            H5T_t      *dt_mem;                        /* Memory datatype */
             size_t      src_dt_size;                   /* Source datatype size */
             size_t      tmp_dt_size;                   /* Temp. datatype size */
             size_t      max_dt_size;                   /* Max atatype size */
@@ -2204,20 +2205,9 @@ H5A__attr_copy_file(const H5A_t *attr_src, H5F_t *file_dst, bool *recompute_size
             size_t      nelmts;                        /* Number of elements in buffer */
             size_t      buf_size;                      /* Size of copy buffer */
 
-            /* Create datatype ID for src datatype */
-            if ((tid_src = H5I_register(H5I_DATATYPE, attr_src->shared->dt, false)) < 0)
-                HGOTO_ERROR(H5E_DATATYPE, H5E_CANTREGISTER, NULL, "unable to register source file datatype");
-
             /* create a memory copy of the variable-length datatype */
             if (NULL == (dt_mem = H5T_copy(attr_src->shared->dt, H5T_COPY_TRANSIENT)))
                 HGOTO_ERROR(H5E_DATATYPE, H5E_CANTINIT, NULL, "unable to copy");
-            if ((tid_mem = H5I_register(H5I_DATATYPE, dt_mem, false)) < 0)
-                HGOTO_ERROR(H5E_DATATYPE, H5E_CANTREGISTER, NULL, "unable to register memory datatype");
-
-            /* create variable-length datatype at the destination file */
-            if ((tid_dst = H5I_register(H5I_DATATYPE, attr_dst->shared->dt, false)) < 0)
-                HGOTO_ERROR(H5E_DATATYPE, H5E_CANTREGISTER, NULL,
-                            "unable to register destination file datatype");
 
             /* Set up the conversion functions */
             if (NULL == (tpath_src_mem = H5T_path_find(attr_src->shared->dt, dt_mem)))
@@ -2273,7 +2263,8 @@ H5A__attr_copy_file(const H5A_t *attr_src, H5F_t *file_dst, bool *recompute_size
                     HGOTO_ERROR(H5E_ATTR, H5E_CANTALLOC, NULL, "memory allocation failed");
 
             /* Convert from source file to memory */
-            if (H5T_convert(tpath_src_mem, tid_src, tid_mem, nelmts, (size_t)0, (size_t)0, buf, bkg_buf) < 0)
+            if (H5T_convert(tpath_src_mem, attr_src->shared->dt, dt_mem, nelmts, (size_t)0, (size_t)0, buf,
+                            bkg_buf) < 0)
                 HGOTO_ERROR(H5E_DATATYPE, H5E_CANTINIT, NULL, "datatype conversion NULLed");
 
             H5MM_memcpy(reclaim_buf, buf, buf_size);
@@ -2283,12 +2274,13 @@ H5A__attr_copy_file(const H5A_t *attr_src, H5F_t *file_dst, bool *recompute_size
                 memset(bkg_buf, 0, buf_size);
 
             /* Convert from memory to destination file */
-            if (H5T_convert(tpath_mem_dst, tid_mem, tid_dst, nelmts, (size_t)0, (size_t)0, buf, bkg_buf) < 0)
+            if (H5T_convert(tpath_mem_dst, dt_mem, attr_dst->shared->dt, nelmts, (size_t)0, (size_t)0, buf,
+                            bkg_buf) < 0)
                 HGOTO_ERROR(H5E_DATATYPE, H5E_CANTINIT, NULL, "datatype conversion NULLed");
 
             H5MM_memcpy(attr_dst->shared->data, buf, attr_dst->shared->data_size);
 
-            if (H5T_reclaim(tid_mem, buf_space, reclaim_buf) < 0)
+            if (H5T_reclaim(dt_mem, buf_space, reclaim_buf) < 0)
                 HGOTO_ERROR(H5E_DATASET, H5E_BADITER, NULL, "unable to reclaim variable-length data");
         } /* end if */
         else {
@@ -2313,19 +2305,9 @@ H5A__attr_copy_file(const H5A_t *attr_src, H5F_t *file_dst, bool *recompute_size
 
 done:
     if (buf_sid > 0 && H5I_dec_ref(buf_sid) < 0)
-        HDONE_ERROR(H5E_ATTR, H5E_CANTFREE, NULL, "Can't decrement temporary dataspace ID");
-    if (tid_src > 0)
-        /* Don't decrement ID, we want to keep underlying datatype */
-        if (NULL == H5I_remove(tid_src))
-            HDONE_ERROR(H5E_ATTR, H5E_CANTFREE, NULL, "Can't decrement temporary datatype ID");
-    if (tid_dst > 0)
-        /* Don't decrement ID, we want to keep underlying datatype */
-        if (NULL == H5I_remove(tid_dst))
-            HDONE_ERROR(H5E_ATTR, H5E_CANTFREE, NULL, "Can't decrement temporary datatype ID");
-    if (tid_mem > 0)
-        /* Decrement the memory datatype ID, it's transient */
-        if (H5I_dec_ref(tid_mem) < 0)
-            HDONE_ERROR(H5E_ATTR, H5E_CANTFREE, NULL, "Can't decrement temporary datatype ID");
+        HDONE_ERROR(H5E_ATTR, H5E_CANTFREE, NULL, "can't decrement temporary dataspace ID");
+    if (dt_mem && (H5T_close(dt_mem) < 0))
+        HDONE_ERROR(H5E_ATTR, H5E_CANTCLOSEOBJ, NULL, "can't close temporary datatype");
     if (buf)
         buf = H5FL_BLK_FREE(attr_buf, buf);
     if (reclaim_buf)
@@ -2416,7 +2398,7 @@ H5A__attr_post_copy_file(const H5O_loc_t *src_oloc, const H5A_t *attr_src, H5O_l
         /* Check for expanding references */
         if (cpy_info->expand_ref) {
             /* Copy objects referenced in source buffer to destination file and set destination elements */
-            if (H5O_copy_expand_ref(file_src, H5I_INVALID_HID, attr_src->shared->dt, attr_src->shared->data,
+            if (H5O_copy_expand_ref(file_src, attr_src->shared->dt, attr_src->shared->data,
                                     attr_src->shared->data_size, file_dst, attr_dst->shared->data,
                                     cpy_info) < 0)
                 HGOTO_ERROR(H5E_ATTR, H5E_CANTCOPY, FAIL, "unable to copy reference attribute");

--- a/src/H5Dchunk.c
+++ b/src/H5Dchunk.c
@@ -179,16 +179,15 @@ typedef struct H5D_chunk_it_ud3_t {
     bool                  do_convert;   /* Whether to perform type conversions */
 
     /* needed for converting variable-length data */
-    hid_t        tid_src;          /* Datatype ID for source datatype */
-    hid_t        tid_dst;          /* Datatype ID for destination datatype */
-    hid_t        tid_mem;          /* Datatype ID for memory datatype */
-    const H5T_t *dt_src;           /* Source datatype */
-    H5T_path_t  *tpath_src_mem;    /* Datatype conversion path from source file to memory */
-    H5T_path_t  *tpath_mem_dst;    /* Datatype conversion path from memory to dest. file */
-    void        *reclaim_buf;      /* Buffer for reclaiming data */
-    size_t       reclaim_buf_size; /* Reclaim buffer size */
-    uint32_t     nelmts;           /* Number of elements in buffer */
-    H5S_t       *buf_space;        /* Dataspace describing buffer */
+    H5T_t      *dt_src;           /* Source datatype */
+    H5T_t      *dt_dst;           /* Destination datatype */
+    H5T_t      *dt_mem;           /* Memory datatype */
+    H5T_path_t *tpath_src_mem;    /* Datatype conversion path from source file to memory */
+    H5T_path_t *tpath_mem_dst;    /* Datatype conversion path from memory to dest. file */
+    void       *reclaim_buf;      /* Buffer for reclaiming data */
+    size_t      reclaim_buf_size; /* Reclaim buffer size */
+    uint32_t    nelmts;           /* Number of elements in buffer */
+    H5S_t      *buf_space;        /* Dataspace describing buffer */
 
     /* needed for compressed variable-length data */
     const H5O_pline_t *pline;      /* Filter pipeline */
@@ -297,9 +296,9 @@ static herr_t   H5D__create_piece_file_map_all(H5D_dset_io_info_t *di, H5D_io_in
 static herr_t   H5D__create_piece_file_map_hyper(H5D_dset_io_info_t *di, H5D_io_info_t *io_info);
 static herr_t   H5D__create_piece_mem_map_1d(const H5D_dset_io_info_t *di);
 static herr_t   H5D__create_piece_mem_map_hyper(const H5D_dset_io_info_t *di);
-static herr_t   H5D__piece_file_cb(void *elem, const H5T_t *type, unsigned ndims, const hsize_t *coords,
+static herr_t   H5D__piece_file_cb(void *elem, H5T_t *type, unsigned ndims, const hsize_t *coords,
                                    void *_opdata);
-static herr_t   H5D__piece_mem_cb(void *elem, const H5T_t *type, unsigned ndims, const hsize_t *coords,
+static herr_t   H5D__piece_mem_cb(void *elem, H5T_t *type, unsigned ndims, const hsize_t *coords,
                                   void *_opdata);
 static herr_t   H5D__chunk_may_use_select_io(H5D_io_info_t *io_info, const H5D_dset_io_info_t *dset_info);
 static unsigned H5D__chunk_hash_val(const H5D_shared_t *shared, const hsize_t *scaled);
@@ -2234,7 +2233,7 @@ done:
  *-------------------------------------------------------------------------
  */
 static herr_t
-H5D__piece_file_cb(void H5_ATTR_UNUSED *elem, const H5T_t H5_ATTR_UNUSED *type, unsigned ndims,
+H5D__piece_file_cb(void H5_ATTR_UNUSED *elem, H5T_t H5_ATTR_UNUSED *type, unsigned ndims,
                    const hsize_t *coords, void *_opdata)
 {
     H5D_io_info_wrap_t *opdata  = (H5D_io_info_wrap_t *)_opdata;
@@ -2360,7 +2359,7 @@ done:
  *-------------------------------------------------------------------------
  */
 static herr_t
-H5D__piece_mem_cb(void H5_ATTR_UNUSED *elem, const H5T_t H5_ATTR_UNUSED *type, unsigned ndims,
+H5D__piece_mem_cb(void H5_ATTR_UNUSED *elem, H5T_t H5_ATTR_UNUSED *type, unsigned ndims,
                   const hsize_t *coords, void *_opdata)
 {
     H5D_io_info_wrap_t *opdata = (H5D_io_info_wrap_t *)_opdata;
@@ -4590,8 +4589,8 @@ H5D__chunk_lock(const H5D_io_info_t H5_ATTR_NDEBUG_UNUSED *io_info, const H5D_ds
                     /* Initialize the fill value buffer */
                     /* (use the compact dataset storage buffer as the fill value buffer) */
                     if (H5D__fill_init(&fb_info, chunk, NULL, NULL, NULL, NULL,
-                                       &dset->shared->dcpl_cache.fill, dset->shared->type,
-                                       dset->shared->type_id, (size_t)0, chunk_size) < 0)
+                                       &dset->shared->dcpl_cache.fill, dset->shared->type, (size_t)0,
+                                       chunk_size) < 0)
                         HGOTO_ERROR(H5E_DATASET, H5E_CANTINIT, NULL, "can't initialize fill buffer info");
                     fb_info_init = true;
 
@@ -5020,8 +5019,8 @@ H5D__chunk_allocate(const H5D_t *dset, bool full_overwrite, const hsize_t old_di
         /* Initialize the fill value buffer */
         /* (delay allocating fill buffer for VL datatypes until refilling) */
         if (H5D__fill_init(&fb_info, NULL, H5D__chunk_mem_alloc, pline, H5D__chunk_mem_free, pline,
-                           &dset->shared->dcpl_cache.fill, dset->shared->type, dset->shared->type_id,
-                           (size_t)0, orig_chunk_size) < 0)
+                           &dset->shared->dcpl_cache.fill, dset->shared->type, (size_t)0,
+                           orig_chunk_size) < 0)
             HGOTO_ERROR(H5E_DATASET, H5E_CANTINIT, FAIL, "can't initialize fill buffer info");
         fb_info_init = true;
 
@@ -5793,8 +5792,7 @@ H5D__chunk_prune_fill(H5D_chunk_it_ud1_t *udata, bool new_unfilt_chunk)
     if (!udata->fb_info_init) {
         H5_CHECK_OVERFLOW(udata->elmts_per_chunk, uint32_t, size_t);
         if (H5D__fill_init(&udata->fb_info, NULL, NULL, NULL, NULL, NULL, &dset->shared->dcpl_cache.fill,
-                           dset->shared->type, dset->shared->type_id, (size_t)udata->elmts_per_chunk,
-                           chunk_size) < 0)
+                           dset->shared->type, (size_t)udata->elmts_per_chunk, chunk_size) < 0)
             HGOTO_ERROR(H5E_DATASET, H5E_CANTINIT, FAIL, "can't initialize fill buffer info");
         udata->fb_info_init = true;
     } /* end if */
@@ -6576,6 +6574,7 @@ H5D__chunk_copy_cb(const H5D_chunk_rec_t *chunk_rec, void *_udata)
     bool                need_insert = false; /* Whether the chunk needs to be inserted into the index */
 
     /* General information about chunk copy */
+    H5T_t             *dt_src   = udata->dt_src;
     void              *bkg      = udata->bkg;      /* Background buffer for datatype conversion */
     void              *buf      = udata->buf;      /* Chunk buffer for I/O & datatype conversions */
     size_t             buf_size = udata->buf_size; /* Size of chunk buffer */
@@ -6608,9 +6607,9 @@ H5D__chunk_copy_cb(const H5D_chunk_rec_t *chunk_rec, void *_udata)
 
     /* Check parameter for type conversion */
     if (udata->do_convert) {
-        if (H5T_detect_class(udata->dt_src, H5T_VLEN, false) > 0)
+        if (H5T_detect_class(dt_src, H5T_VLEN, false) > 0)
             is_vlen = true;
-        else if ((H5T_get_class(udata->dt_src, false) == H5T_REFERENCE) &&
+        else if ((H5T_get_class(dt_src, false) == H5T_REFERENCE) &&
                  (udata->file_src != udata->idx_info_dst->f))
             fix_ref = true;
         else
@@ -6704,18 +6703,17 @@ H5D__chunk_copy_cb(const H5D_chunk_rec_t *chunk_rec, void *_udata)
     if (is_vlen) {
         H5T_path_t *tpath_src_mem    = udata->tpath_src_mem;
         H5T_path_t *tpath_mem_dst    = udata->tpath_mem_dst;
+        H5T_t      *dt_dst           = udata->dt_dst;
+        H5T_t      *dt_mem           = udata->dt_mem;
         H5S_t      *buf_space        = udata->buf_space;
-        hid_t       tid_src          = udata->tid_src;
-        hid_t       tid_dst          = udata->tid_dst;
-        hid_t       tid_mem          = udata->tid_mem;
         void       *reclaim_buf      = udata->reclaim_buf;
         size_t      reclaim_buf_size = udata->reclaim_buf_size;
 
         /* Convert from source file to memory */
         H5_CHECK_OVERFLOW(udata->nelmts, uint32_t, size_t);
-        if (H5T_convert(tpath_src_mem, tid_src, tid_mem, (size_t)udata->nelmts, (size_t)0, (size_t)0, buf,
+        if (H5T_convert(tpath_src_mem, dt_src, dt_mem, (size_t)udata->nelmts, (size_t)0, (size_t)0, buf,
                         bkg) < 0)
-            HGOTO_ERROR(H5E_DATATYPE, H5E_CANTINIT, H5_ITER_ERROR, "datatype conversion failed");
+            HGOTO_ERROR(H5E_DATATYPE, H5E_CANTCONVERT, H5_ITER_ERROR, "datatype conversion failed");
 
         /* Copy into another buffer, to reclaim memory later */
         H5MM_memcpy(reclaim_buf, buf, reclaim_buf_size);
@@ -6724,20 +6722,20 @@ H5D__chunk_copy_cb(const H5D_chunk_rec_t *chunk_rec, void *_udata)
         memset(bkg, 0, buf_size);
 
         /* Convert from memory to destination file */
-        if (H5T_convert(tpath_mem_dst, tid_mem, tid_dst, udata->nelmts, (size_t)0, (size_t)0, buf, bkg) < 0)
-            HGOTO_ERROR(H5E_DATATYPE, H5E_CANTINIT, H5_ITER_ERROR, "datatype conversion failed");
+        if (H5T_convert(tpath_mem_dst, dt_mem, dt_dst, udata->nelmts, (size_t)0, (size_t)0, buf, bkg) < 0)
+            HGOTO_ERROR(H5E_DATATYPE, H5E_CANTCONVERT, H5_ITER_ERROR, "datatype conversion failed");
 
         /* Reclaim space from variable length data */
-        if (H5T_reclaim(tid_mem, buf_space, reclaim_buf) < 0)
-            HGOTO_ERROR(H5E_DATASET, H5E_BADITER, H5_ITER_ERROR, "unable to reclaim variable-length data");
+        if (H5T_reclaim(dt_mem, buf_space, reclaim_buf) < 0)
+            HGOTO_ERROR(H5E_DATASET, H5E_CANTFREE, H5_ITER_ERROR, "unable to reclaim variable-length data");
     } /* end if */
     else if (fix_ref) {
         /* Check for expanding references */
         /* (background buffer has already been zeroed out, if not expanding) */
         if (udata->cpy_info->expand_ref) {
             /* Copy the reference elements */
-            if (H5O_copy_expand_ref(udata->file_src, udata->tid_src, udata->dt_src, buf, nbytes,
-                                    udata->idx_info_dst->f, bkg, udata->cpy_info) < 0)
+            if (H5O_copy_expand_ref(udata->file_src, dt_src, buf, nbytes, udata->idx_info_dst->f, bkg,
+                                    udata->cpy_info) < 0)
                 HGOTO_ERROR(H5E_DATASET, H5E_CANTCOPY, H5_ITER_ERROR, "unable to copy reference attribute");
         } /* end if */
 
@@ -6813,32 +6811,32 @@ done:
  */
 herr_t
 H5D__chunk_copy(H5F_t *f_src, H5O_storage_chunk_t *storage_src, H5O_layout_chunk_t *layout_src, H5F_t *f_dst,
-                H5O_storage_chunk_t *storage_dst, const H5S_extent_t *ds_extent_src, const H5T_t *dt_src,
+                H5O_storage_chunk_t *storage_dst, const H5S_extent_t *ds_extent_src, H5T_t *dt_src,
                 const H5O_pline_t *pline_src, H5O_copy_t *cpy_info)
 {
-    H5D_chunk_it_ud3_t udata;                                       /* User data for iteration callback */
-    H5D_chk_idx_info_t idx_info_dst;                                /* Dest. chunked index info */
-    H5D_chk_idx_info_t idx_info_src;                                /* Source chunked index info */
-    int                sndims;                                      /* Rank of dataspace */
-    hsize_t            curr_dims[H5O_LAYOUT_NDIMS];                 /* Curr. size of dataset dimensions */
-    hsize_t            max_dims[H5O_LAYOUT_NDIMS];                  /* Curr. size of dataset dimensions */
-    H5O_pline_t        _pline;                                      /* Temporary pipeline info */
-    const H5O_pline_t *pline;                                       /* Pointer to pipeline info to use */
-    H5T_path_t        *tpath_src_mem = NULL, *tpath_mem_dst = NULL; /* Datatype conversion paths */
-    hid_t              tid_src = -1;                                /* Datatype ID for source datatype */
-    hid_t              tid_dst = -1;                                /* Datatype ID for destination datatype */
-    hid_t              tid_mem = -1;                                /* Datatype ID for memory datatype */
-    size_t             buf_size;                                    /* Size of copy buffer */
-    size_t             reclaim_buf_size;                            /* Size of reclaim buffer */
-    void              *buf             = NULL;                      /* Buffer for copying data */
-    void              *bkg             = NULL;    /* Buffer for background during type conversion */
-    void              *reclaim_buf     = NULL;    /* Buffer for reclaiming data */
-    H5S_t             *buf_space       = NULL;    /* Dataspace describing buffer */
-    hid_t              sid_buf         = -1;      /* ID for buffer dataspace */
-    uint32_t           nelmts          = 0;       /* Number of elements in buffer */
-    bool               do_convert      = false;   /* Indicate that type conversions should be performed */
-    bool               copy_setup_done = false;   /* Indicate that 'copy setup' is done */
-    herr_t             ret_value       = SUCCEED; /* Return value */
+    H5D_chunk_it_ud3_t udata;                       /* User data for iteration callback */
+    H5D_chk_idx_info_t idx_info_dst;                /* Dest. chunked index info */
+    H5D_chk_idx_info_t idx_info_src;                /* Source chunked index info */
+    int                sndims;                      /* Rank of dataspace */
+    hsize_t            curr_dims[H5O_LAYOUT_NDIMS]; /* Curr. size of dataset dimensions */
+    hsize_t            max_dims[H5O_LAYOUT_NDIMS];  /* Curr. size of dataset dimensions */
+    H5O_pline_t        _pline;                      /* Temporary pipeline info */
+    const H5O_pline_t *pline;                       /* Pointer to pipeline info to use */
+    H5T_path_t        *tpath_src_mem = NULL;        /* Source datatype conversion path */
+    H5T_path_t        *tpath_mem_dst = NULL;        /* Memory datatype conversion path */
+    H5T_t             *dt_dst        = NULL;        /* Destination datatype */
+    H5T_t             *dt_mem        = NULL;        /* Memory datatype */
+    size_t             buf_size;                    /* Size of copy buffer */
+    size_t             reclaim_buf_size;            /* Size of reclaim buffer */
+    void              *buf             = NULL;      /* Buffer for copying data */
+    void              *bkg             = NULL;      /* Buffer for background during type conversion */
+    void              *reclaim_buf     = NULL;      /* Buffer for reclaiming data */
+    H5S_t             *buf_space       = NULL;      /* Dataspace describing buffer */
+    hid_t              sid_buf         = -1;        /* ID for buffer dataspace */
+    uint32_t           nelmts          = 0;         /* Number of elements in buffer */
+    bool               do_convert      = false;     /* Indicate that type conversions should be performed */
+    bool               copy_setup_done = false;     /* Indicate that 'copy setup' is done */
+    herr_t             ret_value       = SUCCEED;   /* Return value */
 
     FUNC_ENTER_PACKAGE
 
@@ -6896,14 +6894,8 @@ H5D__chunk_copy(H5F_t *f_src, H5O_storage_chunk_t *storage_src, H5O_layout_chunk
                     "unable to set up index-specific chunk copying information");
     copy_setup_done = true;
 
-    /* Create datatype ID for src datatype */
-    if ((tid_src = H5I_register(H5I_DATATYPE, dt_src, false)) < 0)
-        HGOTO_ERROR(H5E_DATATYPE, H5E_CANTREGISTER, FAIL, "unable to register source file datatype");
-
     /* If there's a VLEN source datatype, set up type conversion information */
     if (H5T_detect_class(dt_src, H5T_VLEN, false) > 0) {
-        H5T_t   *dt_dst;      /* Destination datatype */
-        H5T_t   *dt_mem;      /* Memory datatype */
         size_t   mem_dt_size; /* Memory datatype size */
         size_t   tmp_dt_size; /* Temp. datatype size */
         size_t   max_dt_size; /* Max atatype size */
@@ -6913,10 +6905,6 @@ H5D__chunk_copy(H5F_t *f_src, H5O_storage_chunk_t *storage_src, H5O_layout_chunk
         /* create a memory copy of the variable-length datatype */
         if (NULL == (dt_mem = H5T_copy(dt_src, H5T_COPY_TRANSIENT)))
             HGOTO_ERROR(H5E_DATATYPE, H5E_CANTINIT, FAIL, "unable to copy");
-        if ((tid_mem = H5I_register(H5I_DATATYPE, dt_mem, false)) < 0) {
-            (void)H5T_close_real(dt_mem);
-            HGOTO_ERROR(H5E_DATATYPE, H5E_CANTREGISTER, FAIL, "unable to register memory datatype");
-        } /* end if */
 
         /* create variable-length datatype at the destination file */
         if (NULL == (dt_dst = H5T_copy(dt_src, H5T_COPY_TRANSIENT)))
@@ -6924,10 +6912,6 @@ H5D__chunk_copy(H5F_t *f_src, H5O_storage_chunk_t *storage_src, H5O_layout_chunk
         if (H5T_set_loc(dt_dst, H5F_VOL_OBJ(f_dst), H5T_LOC_DISK) < 0) {
             (void)H5T_close_real(dt_dst);
             HGOTO_ERROR(H5E_DATATYPE, H5E_CANTINIT, FAIL, "cannot mark datatype on disk");
-        } /* end if */
-        if ((tid_dst = H5I_register(H5I_DATATYPE, dt_dst, false)) < 0) {
-            (void)H5T_close_real(dt_dst);
-            HGOTO_ERROR(H5E_DATATYPE, H5E_CANTREGISTER, FAIL, "unable to register destination file datatype");
         } /* end if */
 
         /* Set up the conversion functions */
@@ -7008,10 +6992,9 @@ H5D__chunk_copy(H5F_t *f_src, H5O_storage_chunk_t *storage_src, H5O_layout_chunk
     udata.buf              = buf;
     udata.bkg              = bkg;
     udata.buf_size         = buf_size;
-    udata.tid_src          = tid_src;
-    udata.tid_mem          = tid_mem;
-    udata.tid_dst          = tid_dst;
     udata.dt_src           = dt_src;
+    udata.dt_dst           = dt_dst;
+    udata.dt_mem           = dt_mem;
     udata.do_convert       = do_convert;
     udata.tpath_src_mem    = tpath_src_mem;
     udata.tpath_mem_dst    = tpath_mem_dst;
@@ -7059,12 +7042,13 @@ H5D__chunk_copy(H5F_t *f_src, H5O_storage_chunk_t *storage_src, H5O_layout_chunk
 done:
     if (sid_buf > 0 && H5I_dec_ref(sid_buf) < 0)
         HDONE_ERROR(H5E_DATASET, H5E_CANTFREE, FAIL, "can't decrement temporary dataspace ID");
-    if (tid_src > 0 && H5I_dec_ref(tid_src) < 0)
-        HDONE_ERROR(H5E_DATASET, H5E_CANTFREE, FAIL, "Can't decrement temporary datatype ID");
-    if (tid_dst > 0 && H5I_dec_ref(tid_dst) < 0)
-        HDONE_ERROR(H5E_DATASET, H5E_CANTFREE, FAIL, "Can't decrement temporary datatype ID");
-    if (tid_mem > 0 && H5I_dec_ref(tid_mem) < 0)
-        HDONE_ERROR(H5E_DATASET, H5E_CANTFREE, FAIL, "Can't decrement temporary datatype ID");
+    /* Caller expects that source datatype will be freed */
+    if (dt_src && (H5T_close(dt_src) < 0))
+        HDONE_ERROR(H5E_DATASET, H5E_CANTCLOSEOBJ, FAIL, "can't close temporary datatype");
+    if (dt_dst && (H5T_close(dt_dst) < 0))
+        HDONE_ERROR(H5E_DATASET, H5E_CANTCLOSEOBJ, FAIL, "can't close temporary datatype");
+    if (dt_mem && (H5T_close(dt_mem) < 0))
+        HDONE_ERROR(H5E_DATASET, H5E_CANTCLOSEOBJ, FAIL, "can't close temporary datatype");
     if (buf)
         H5MM_xfree(buf);
     if (bkg)
@@ -7342,8 +7326,7 @@ H5D__nonexistent_readvv_cb(hsize_t H5_ATTR_UNUSED dst_off, hsize_t src_off, size
 
     /* Initialize the fill value buffer */
     if (H5D__fill_init(&fb_info, (udata->rbuf + src_off), NULL, NULL, NULL, NULL,
-                       &udata->dset->shared->dcpl_cache.fill, udata->dset->shared->type,
-                       udata->dset->shared->type_id, (size_t)0, len) < 0)
+                       &udata->dset->shared->dcpl_cache.fill, udata->dset->shared->type, (size_t)0, len) < 0)
         HGOTO_ERROR(H5E_DATASET, H5E_CANTINIT, FAIL, "can't initialize fill buffer info");
     fb_info_init = true;
 

--- a/src/H5Dcompact.c
+++ b/src/H5Dcompact.c
@@ -127,7 +127,7 @@ H5D__compact_fill(const H5D_t *dset)
     /* Initialize the fill value buffer */
     /* (use the compact dataset storage buffer as the fill value buffer) */
     if (H5D__fill_init(&fb_info, dset->shared->layout.storage.u.compact.buf, NULL, NULL, NULL, NULL,
-                       &dset->shared->dcpl_cache.fill, dset->shared->type, dset->shared->type_id, (size_t)0,
+                       &dset->shared->dcpl_cache.fill, dset->shared->type, (size_t)0,
                        dset->shared->layout.storage.u.compact.size) < 0)
         HGOTO_ERROR(H5E_DATASET, H5E_CANTINIT, FAIL, "can't initialize fill buffer info");
     fb_info_init = true;
@@ -470,9 +470,8 @@ herr_t
 H5D__compact_copy(H5F_t *f_src, H5O_storage_compact_t *_storage_src, H5F_t *f_dst,
                   H5O_storage_compact_t *storage_dst, H5T_t *dt_src, H5O_copy_t *cpy_info)
 {
-    hid_t         tid_src     = -1;   /* Datatype ID for source datatype */
-    hid_t         tid_dst     = -1;   /* Datatype ID for destination datatype */
-    hid_t         tid_mem     = -1;   /* Datatype ID for memory datatype */
+    H5T_t        *dt_mem      = NULL; /* Memory datatype */
+    H5T_t        *dt_dst      = NULL; /* Destination datatype */
     void         *buf         = NULL; /* Buffer for copying data */
     void         *bkg         = NULL; /* Temporary buffer for copying data */
     void         *reclaim_buf = NULL; /* Buffer for reclaiming data */
@@ -496,15 +495,9 @@ H5D__compact_copy(H5F_t *f_src, H5O_storage_compact_t *_storage_src, H5F_t *f_ds
     if (shared_fo != NULL)
         storage_src = &(shared_fo->layout.storage.u.compact);
 
-    /* Create datatype ID for src datatype, so it gets freed */
-    if ((tid_src = H5I_register(H5I_DATATYPE, dt_src, false)) < 0)
-        HGOTO_ERROR(H5E_DATASET, H5E_CANTREGISTER, FAIL, "unable to register source file datatype");
-
     /* If there's a VLEN source datatype, do type conversion information */
     if (H5T_detect_class(dt_src, H5T_VLEN, false) > 0) {
         H5T_path_t *tpath_src_mem, *tpath_mem_dst; /* Datatype conversion paths */
-        H5T_t      *dt_dst;                        /* Destination datatype */
-        H5T_t      *dt_mem;                        /* Memory datatype */
         H5S_t      *buf_space;                     /* Dataspace describing buffer */
         size_t      buf_size;                      /* Size of copy buffer */
         size_t      nelmts;                        /* Number of elements in buffer */
@@ -516,10 +509,6 @@ H5D__compact_copy(H5F_t *f_src, H5O_storage_compact_t *_storage_src, H5F_t *f_ds
         /* create a memory copy of the variable-length datatype */
         if (NULL == (dt_mem = H5T_copy(dt_src, H5T_COPY_TRANSIENT)))
             HGOTO_ERROR(H5E_DATATYPE, H5E_CANTINIT, FAIL, "unable to copy");
-        if ((tid_mem = H5I_register(H5I_DATATYPE, dt_mem, false)) < 0) {
-            (void)H5T_close_real(dt_mem);
-            HGOTO_ERROR(H5E_DATATYPE, H5E_CANTREGISTER, FAIL, "unable to register memory datatype");
-        } /* end if */
 
         /* create variable-length datatype at the destination file */
         if (NULL == (dt_dst = H5T_copy(dt_src, H5T_COPY_TRANSIENT)))
@@ -527,10 +516,6 @@ H5D__compact_copy(H5F_t *f_src, H5O_storage_compact_t *_storage_src, H5F_t *f_ds
         if (H5T_set_loc(dt_dst, H5F_VOL_OBJ(f_dst), H5T_LOC_DISK) < 0) {
             (void)H5T_close_real(dt_dst);
             HGOTO_ERROR(H5E_DATATYPE, H5E_CANTINIT, FAIL, "cannot mark datatype on disk");
-        } /* end if */
-        if ((tid_dst = H5I_register(H5I_DATATYPE, dt_dst, false)) < 0) {
-            (void)H5T_close_real(dt_dst);
-            HGOTO_ERROR(H5E_DATATYPE, H5E_CANTREGISTER, FAIL, "unable to register destination file datatype");
         } /* end if */
 
         /* Set up the conversion functions */
@@ -584,8 +569,8 @@ H5D__compact_copy(H5F_t *f_src, H5O_storage_compact_t *_storage_src, H5F_t *f_ds
             HGOTO_ERROR(H5E_RESOURCE, H5E_NOSPACE, FAIL, "memory allocation failed");
 
         /* Convert from source file to memory */
-        if (H5T_convert(tpath_src_mem, tid_src, tid_mem, nelmts, (size_t)0, (size_t)0, buf, bkg) < 0)
-            HGOTO_ERROR(H5E_DATATYPE, H5E_CANTINIT, FAIL, "datatype conversion failed");
+        if (H5T_convert(tpath_src_mem, dt_src, dt_mem, nelmts, (size_t)0, (size_t)0, buf, bkg) < 0)
+            HGOTO_ERROR(H5E_DATATYPE, H5E_CANTCONVERT, FAIL, "datatype conversion failed");
 
         /* Copy into another buffer, to reclaim memory later */
         H5MM_memcpy(reclaim_buf, buf, buf_size);
@@ -594,13 +579,13 @@ H5D__compact_copy(H5F_t *f_src, H5O_storage_compact_t *_storage_src, H5F_t *f_ds
         memset(bkg, 0, buf_size);
 
         /* Convert from memory to destination file */
-        if (H5T_convert(tpath_mem_dst, tid_mem, tid_dst, nelmts, (size_t)0, (size_t)0, buf, bkg) < 0)
-            HGOTO_ERROR(H5E_DATATYPE, H5E_CANTINIT, FAIL, "datatype conversion failed");
+        if (H5T_convert(tpath_mem_dst, dt_mem, dt_dst, nelmts, (size_t)0, (size_t)0, buf, bkg) < 0)
+            HGOTO_ERROR(H5E_DATATYPE, H5E_CANTCONVERT, FAIL, "datatype conversion failed");
 
         H5MM_memcpy(storage_dst->buf, buf, storage_dst->size);
 
-        if (H5T_reclaim(tid_mem, buf_space, reclaim_buf) < 0)
-            HGOTO_ERROR(H5E_DATASET, H5E_BADITER, FAIL, "unable to reclaim variable-length data");
+        if (H5T_reclaim(dt_mem, buf_space, reclaim_buf) < 0)
+            HGOTO_ERROR(H5E_DATASET, H5E_CANTFREE, FAIL, "unable to reclaim variable-length data");
     } /* end if */
     else if (H5T_get_class(dt_src, false) == H5T_REFERENCE) {
         if (f_src != f_dst) {
@@ -608,7 +593,7 @@ H5D__compact_copy(H5F_t *f_src, H5O_storage_compact_t *_storage_src, H5F_t *f_ds
             if (cpy_info->expand_ref) {
                 /* Copy objects referenced in source buffer to destination file and set destination elements
                  */
-                if (H5O_copy_expand_ref(f_src, tid_src, dt_src, storage_src->buf, storage_src->size, f_dst,
+                if (H5O_copy_expand_ref(f_src, dt_src, storage_src->buf, storage_src->size, f_dst,
                                         storage_dst->buf, cpy_info) < 0)
                     HGOTO_ERROR(H5E_DATASET, H5E_CANTCOPY, FAIL, "unable to copy reference attribute");
             } /* end if */
@@ -630,12 +615,13 @@ H5D__compact_copy(H5F_t *f_src, H5O_storage_compact_t *_storage_src, H5F_t *f_ds
 done:
     if (buf_sid > 0 && H5I_dec_ref(buf_sid) < 0)
         HDONE_ERROR(H5E_DATASET, H5E_CANTFREE, FAIL, "can't decrement temporary dataspace ID");
-    if (tid_src > 0 && H5I_dec_ref(tid_src) < 0)
-        HDONE_ERROR(H5E_DATASET, H5E_CANTFREE, FAIL, "Can't decrement temporary datatype ID");
-    if (tid_dst > 0 && H5I_dec_ref(tid_dst) < 0)
-        HDONE_ERROR(H5E_DATASET, H5E_CANTFREE, FAIL, "Can't decrement temporary datatype ID");
-    if (tid_mem > 0 && H5I_dec_ref(tid_mem) < 0)
-        HDONE_ERROR(H5E_DATASET, H5E_CANTFREE, FAIL, "Can't decrement temporary datatype ID");
+    /* Caller expects that source datatype will be freed */
+    if (dt_src && (H5T_close(dt_src) < 0))
+        HDONE_ERROR(H5E_DATASET, H5E_CANTCLOSEOBJ, FAIL, "can't close temporary datatype");
+    if (dt_dst && (H5T_close(dt_dst) < 0))
+        HDONE_ERROR(H5E_DATASET, H5E_CANTCLOSEOBJ, FAIL, "can't close temporary datatype");
+    if (dt_mem && (H5T_close(dt_mem) < 0))
+        HDONE_ERROR(H5E_DATASET, H5E_CANTCLOSEOBJ, FAIL, "can't close temporary datatype");
     if (buf)
         buf = H5FL_BLK_FREE(type_conv, buf);
     if (reclaim_buf)

--- a/src/H5Dcontig.c
+++ b/src/H5Dcontig.c
@@ -239,7 +239,7 @@ H5D__contig_fill(H5D_t *dset)
 
     /* Initialize the fill value buffer */
     if (H5D__fill_init(&fb_info, NULL, NULL, NULL, NULL, NULL, &dset->shared->dcpl_cache.fill,
-                       dset->shared->type, dset->shared->type_id, npoints, max_temp_buf) < 0)
+                       dset->shared->type, npoints, max_temp_buf) < 0)
         HGOTO_ERROR(H5E_DATASET, H5E_CANTINIT, FAIL, "can't initialize fill buffer info");
     fb_info_init = true;
 
@@ -1596,9 +1596,6 @@ H5D__contig_copy(H5F_t *f_src, const H5O_storage_contig_t *storage_src, H5F_t *f
     H5T_path_t   *tpath_src_mem = NULL, *tpath_mem_dst = NULL; /* Datatype conversion paths */
     H5T_t        *dt_dst      = NULL;                          /* Destination datatype */
     H5T_t        *dt_mem      = NULL;                          /* Memory datatype */
-    hid_t         tid_src     = -1;                            /* Datatype ID for source datatype */
-    hid_t         tid_dst     = -1;                            /* Datatype ID for destination datatype */
-    hid_t         tid_mem     = -1;                            /* Datatype ID for memory datatype */
     size_t        src_dt_size = 0;                             /* Source datatype size */
     size_t        mem_dt_size = 0;                             /* Memory datatype size */
     size_t        dst_dt_size = 0;                             /* Destination datatype size */
@@ -1643,21 +1640,11 @@ H5D__contig_copy(H5F_t *f_src, const H5O_storage_contig_t *storage_src, H5F_t *f
     H5_CHECK_OVERFLOW(total_src_nbytes, hsize_t, size_t);
     buf_size = MIN(H5D_TEMP_BUF_SIZE, (size_t)total_src_nbytes);
 
-    /* Create datatype ID for src datatype.  We may or may not use this ID,
-     * but this ensures that the src datatype will be freed.
-     */
-    if ((tid_src = H5I_register(H5I_DATATYPE, dt_src, false)) < 0)
-        HGOTO_ERROR(H5E_DATATYPE, H5E_CANTREGISTER, FAIL, "unable to register source file datatype");
-
     /* If there's a VLEN source datatype, set up type conversion information */
     if (H5T_detect_class(dt_src, H5T_VLEN, false) > 0) {
         /* create a memory copy of the variable-length datatype */
         if (NULL == (dt_mem = H5T_copy(dt_src, H5T_COPY_TRANSIENT)))
             HGOTO_ERROR(H5E_DATATYPE, H5E_CANTINIT, FAIL, "unable to copy");
-        if ((tid_mem = H5I_register(H5I_DATATYPE, dt_mem, false)) < 0) {
-            (void)H5T_close_real(dt_mem);
-            HGOTO_ERROR(H5E_DATASET, H5E_CANTREGISTER, FAIL, "unable to register memory datatype");
-        } /* end if */
 
         /* create variable-length datatype at the destination file */
         if (NULL == (dt_dst = H5T_copy(dt_src, H5T_COPY_TRANSIENT)))
@@ -1665,10 +1652,6 @@ H5D__contig_copy(H5F_t *f_src, const H5O_storage_contig_t *storage_src, H5F_t *f
         if (H5T_set_loc(dt_dst, H5F_VOL_OBJ(f_dst), H5T_LOC_DISK) < 0) {
             (void)H5T_close_real(dt_dst);
             HGOTO_ERROR(H5E_DATASET, H5E_CANTINIT, FAIL, "cannot mark datatype on disk");
-        } /* end if */
-        if ((tid_dst = H5I_register(H5I_DATATYPE, dt_dst, false)) < 0) {
-            (void)H5T_close_real(dt_dst);
-            HGOTO_ERROR(H5E_DATASET, H5E_CANTREGISTER, FAIL, "unable to register destination file datatype");
         } /* end if */
 
         /* Set up the conversion functions */
@@ -1793,8 +1776,8 @@ H5D__contig_copy(H5F_t *f_src, const H5O_storage_contig_t *storage_src, H5F_t *f
         /* Perform datatype conversion, if necessary */
         if (is_vlen) {
             /* Convert from source file to memory */
-            if (H5T_convert(tpath_src_mem, tid_src, tid_mem, nelmts, (size_t)0, (size_t)0, buf, bkg) < 0)
-                HGOTO_ERROR(H5E_DATATYPE, H5E_CANTINIT, FAIL, "datatype conversion failed");
+            if (H5T_convert(tpath_src_mem, dt_src, dt_mem, nelmts, (size_t)0, (size_t)0, buf, bkg) < 0)
+                HGOTO_ERROR(H5E_DATATYPE, H5E_CANTCONVERT, FAIL, "datatype conversion failed");
 
             /* Copy into another buffer, to reclaim memory later */
             H5MM_memcpy(reclaim_buf, buf, mem_nbytes);
@@ -1803,18 +1786,18 @@ H5D__contig_copy(H5F_t *f_src, const H5O_storage_contig_t *storage_src, H5F_t *f
             memset(bkg, 0, buf_size);
 
             /* Convert from memory to destination file */
-            if (H5T_convert(tpath_mem_dst, tid_mem, tid_dst, nelmts, (size_t)0, (size_t)0, buf, bkg) < 0)
-                HGOTO_ERROR(H5E_DATATYPE, H5E_CANTINIT, FAIL, "datatype conversion failed");
+            if (H5T_convert(tpath_mem_dst, dt_mem, dt_dst, nelmts, (size_t)0, (size_t)0, buf, bkg) < 0)
+                HGOTO_ERROR(H5E_DATATYPE, H5E_CANTCONVERT, FAIL, "datatype conversion failed");
 
             /* Reclaim space from variable length data */
-            if (H5T_reclaim(tid_mem, buf_space, reclaim_buf) < 0)
-                HGOTO_ERROR(H5E_DATASET, H5E_BADITER, FAIL, "unable to reclaim variable-length data");
+            if (H5T_reclaim(dt_mem, buf_space, reclaim_buf) < 0)
+                HGOTO_ERROR(H5E_DATASET, H5E_CANTFREE, FAIL, "unable to reclaim variable-length data");
         } /* end if */
         else if (fix_ref) {
             /* Check for expanding references */
             if (cpy_info->expand_ref) {
                 /* Copy the reference elements */
-                if (H5O_copy_expand_ref(f_src, tid_src, dt_src, buf, buf_size, f_dst, bkg, cpy_info) < 0)
+                if (H5O_copy_expand_ref(f_src, dt_src, buf, buf_size, f_dst, bkg, cpy_info) < 0)
                     HGOTO_ERROR(H5E_DATASET, H5E_CANTCOPY, FAIL, "unable to copy reference attribute");
 
                 /* After fix ref, copy the new reference elements to the buffer to write out */
@@ -1838,12 +1821,13 @@ H5D__contig_copy(H5F_t *f_src, const H5O_storage_contig_t *storage_src, H5F_t *f
 done:
     if (buf_sid > 0 && H5I_dec_ref(buf_sid) < 0)
         HDONE_ERROR(H5E_DATASET, H5E_CANTFREE, FAIL, "can't decrement temporary dataspace ID");
-    if (tid_src > 0 && H5I_dec_ref(tid_src) < 0)
-        HDONE_ERROR(H5E_DATASET, H5E_CANTFREE, FAIL, "Can't decrement temporary datatype ID");
-    if (tid_dst > 0 && H5I_dec_ref(tid_dst) < 0)
-        HDONE_ERROR(H5E_DATASET, H5E_CANTFREE, FAIL, "Can't decrement temporary datatype ID");
-    if (tid_mem > 0 && H5I_dec_ref(tid_mem) < 0)
-        HDONE_ERROR(H5E_DATASET, H5E_CANTFREE, FAIL, "Can't decrement temporary datatype ID");
+    /* Caller expects that source datatype will be freed */
+    if (dt_src && (H5T_close(dt_src) < 0))
+        HDONE_ERROR(H5E_DATASET, H5E_CANTCLOSEOBJ, FAIL, "can't close temporary datatype");
+    if (dt_dst && (H5T_close(dt_dst) < 0))
+        HDONE_ERROR(H5E_DATASET, H5E_CANTCLOSEOBJ, FAIL, "can't close temporary datatype");
+    if (dt_mem && (H5T_close(dt_mem) < 0))
+        HDONE_ERROR(H5E_DATASET, H5E_CANTCLOSEOBJ, FAIL, "can't close temporary datatype");
     if (buf)
         buf = H5FL_BLK_FREE(type_conv, buf);
     if (reclaim_buf)

--- a/src/H5Ddeprec.c
+++ b/src/H5Ddeprec.c
@@ -306,6 +306,7 @@ done:
 herr_t
 H5Dvlen_reclaim(hid_t type_id, hid_t space_id, hid_t dxpl_id, void *buf)
 {
+    H5T_t *type;
     H5S_t *space;     /* Dataspace for iteration */
     herr_t ret_value; /* Return value */
 
@@ -313,8 +314,10 @@ H5Dvlen_reclaim(hid_t type_id, hid_t space_id, hid_t dxpl_id, void *buf)
     H5TRACE4("e", "iii*x", type_id, space_id, dxpl_id, buf);
 
     /* Check args */
-    if (H5I_DATATYPE != H5I_get_type(type_id) || buf == NULL)
-        HGOTO_ERROR(H5E_ARGS, H5E_BADVALUE, FAIL, "invalid argument");
+    if (buf == NULL)
+        HGOTO_ERROR(H5E_ARGS, H5E_BADVALUE, FAIL, "'buf' pointer is NULL");
+    if (NULL == (type = (H5T_t *)H5I_object_verify(type_id, H5I_DATATYPE)))
+        HGOTO_ERROR(H5E_ARGS, H5E_BADTYPE, FAIL, "invalid datatype");
     if (NULL == (space = (H5S_t *)H5I_object_verify(space_id, H5I_DATASPACE)))
         HGOTO_ERROR(H5E_ARGS, H5E_BADTYPE, FAIL, "invalid dataspace");
     if (!(H5S_has_extent(space)))
@@ -330,7 +333,7 @@ H5Dvlen_reclaim(hid_t type_id, hid_t space_id, hid_t dxpl_id, void *buf)
     H5CX_set_dxpl(dxpl_id);
 
     /* Call internal routine */
-    ret_value = H5T_reclaim(type_id, space, buf);
+    ret_value = H5T_reclaim(type, space, buf);
 
 done:
     FUNC_LEAVE_API(ret_value)

--- a/src/H5Dfill.c
+++ b/src/H5Dfill.c
@@ -116,9 +116,10 @@ H5D__fill(const void *fill, const H5T_t *fill_type, void *buf, const H5T_t *buf_
     uint8_t         elem_buf[H5T_ELEM_BUF_SIZE];     /* Buffer for element data */
     H5WB_t         *bkg_elem_wb = NULL;              /* Wrapped buffer for background data */
     uint8_t         bkg_elem_buf[H5T_ELEM_BUF_SIZE]; /* Buffer for background data */
-    uint8_t        *bkg_buf = NULL;                  /* Background conversion buffer */
-    uint8_t        *tmp_buf = NULL;                  /* Temp conversion buffer */
-    hid_t           src_id = -1, dst_id = -1;        /* Temporary type IDs */
+    uint8_t        *bkg_buf  = NULL;                 /* Background conversion buffer */
+    uint8_t        *tmp_buf  = NULL;                 /* Temp conversion buffer */
+    H5T_t          *src_type = NULL;                 /* Source datatype */
+    H5T_t          *dst_type = NULL;                 /* Destination datatype */
     size_t          dst_type_size;                   /* Size of destination type*/
     herr_t          ret_value = SUCCEED;             /* Return value */
 
@@ -171,11 +172,11 @@ H5D__fill(const void *fill, const H5T_t *fill_type, void *buf, const H5T_t *buf_
 
         /* Construct source & destination datatype IDs, if we will need them */
         if (!H5T_path_noop(tpath)) {
-            if ((src_id = H5I_register(H5I_DATATYPE, H5T_copy(fill_type, H5T_COPY_ALL), false)) < 0)
-                HGOTO_ERROR(H5E_DATASET, H5E_CANTREGISTER, FAIL, "unable to register types for conversion");
+            if (NULL == (src_type = H5T_copy(fill_type, H5T_COPY_ALL)))
+                HGOTO_ERROR(H5E_DATASET, H5E_CANTCOPY, FAIL, "unable to copy fill value datatype");
 
-            if ((dst_id = H5I_register(H5I_DATATYPE, H5T_copy(buf_type, H5T_COPY_ALL), false)) < 0)
-                HGOTO_ERROR(H5E_DATASET, H5E_CANTREGISTER, FAIL, "unable to register types for conversion");
+            if (NULL == (dst_type = H5T_copy(buf_type, H5T_COPY_ALL)))
+                HGOTO_ERROR(H5E_DATASET, H5E_CANTCOPY, FAIL, "unable to copy memory datatype");
         } /* end if */
 
         /* If there's VL type of data, make multiple copies of fill value first,
@@ -202,8 +203,8 @@ H5D__fill(const void *fill, const H5T_t *fill_type, void *buf, const H5T_t *buf_
             H5VM_array_fill(tmp_buf, fill, src_type_size, (size_t)nelmts);
 
             /* Convert from file's fill value into memory form */
-            if (H5T_convert(tpath, src_id, dst_id, (size_t)nelmts, (size_t)0, (size_t)0, tmp_buf, bkg_buf) <
-                0)
+            if (H5T_convert(tpath, src_type, dst_type, (size_t)nelmts, (size_t)0, (size_t)0, tmp_buf,
+                            bkg_buf) < 0)
                 HGOTO_ERROR(H5E_DATASET, H5E_CANTCONVERT, FAIL, "data type conversion failed");
 
             /* Allocate the chunk selection iterator */
@@ -252,8 +253,8 @@ H5D__fill(const void *fill, const H5T_t *fill_type, void *buf, const H5T_t *buf_
                 } /* end if */
 
                 /* Perform datatype conversion */
-                if (H5T_convert(tpath, src_id, dst_id, (size_t)1, (size_t)0, (size_t)0, elem_ptr, bkg_ptr) <
-                    0)
+                if (H5T_convert(tpath, src_type, dst_type, (size_t)1, (size_t)0, (size_t)0, elem_ptr,
+                                bkg_ptr) < 0)
                     HGOTO_ERROR(H5E_DATASET, H5E_CANTCONVERT, FAIL, "data type conversion failed");
 
                 /* Point at element buffer */
@@ -273,10 +274,10 @@ done:
         HDONE_ERROR(H5E_DATASET, H5E_CANTFREE, FAIL, "Can't release selection iterator");
     if (mem_iter)
         mem_iter = H5FL_FREE(H5S_sel_iter_t, mem_iter);
-    if (src_id != (-1) && H5I_dec_ref(src_id) < 0)
-        HDONE_ERROR(H5E_DATASET, H5E_CANTFREE, FAIL, "Can't decrement temporary datatype ID");
-    if (dst_id != (-1) && H5I_dec_ref(dst_id) < 0)
-        HDONE_ERROR(H5E_DATASET, H5E_CANTFREE, FAIL, "Can't decrement temporary datatype ID");
+    if (src_type && H5T_close(src_type) < 0)
+        HDONE_ERROR(H5E_DATASET, H5E_CANTCLOSEOBJ, FAIL, "unable to close temporary datatype");
+    if (dst_type && H5T_close(dst_type) < 0)
+        HDONE_ERROR(H5E_DATASET, H5E_CANTCLOSEOBJ, FAIL, "unable to close temporary datatype");
     if (tmp_buf)
         tmp_buf = H5FL_BLK_FREE(type_conv, tmp_buf);
     if (elem_wb && H5WB_unwrap(elem_wb) < 0)
@@ -301,7 +302,7 @@ done:
 herr_t
 H5D__fill_init(H5D_fill_buf_info_t *fb_info, void *caller_fill_buf, H5MM_allocate_t alloc_func,
                void *alloc_info, H5MM_free_t free_func, void *free_info, const H5O_fill_t *fill,
-               const H5T_t *dset_type, hid_t dset_type_id, size_t total_nelmts, size_t max_buf_size)
+               H5T_t *dset_type, size_t total_nelmts, size_t max_buf_size)
 {
     herr_t ret_value = SUCCEED; /* Return value */
 
@@ -311,7 +312,6 @@ H5D__fill_init(H5D_fill_buf_info_t *fb_info, void *caller_fill_buf, H5MM_allocat
     assert(fb_info);
     assert(fill);
     assert(dset_type);
-    assert(dset_type_id > 0);
 
     /* Reset fill buffer information */
     memset(fb_info, 0, sizeof(*fb_info));
@@ -319,7 +319,6 @@ H5D__fill_init(H5D_fill_buf_info_t *fb_info, void *caller_fill_buf, H5MM_allocat
     /* Cache constant information from the dataset */
     fb_info->fill            = fill;
     fb_info->file_type       = dset_type;
-    fb_info->file_tid        = dset_type_id;
     fb_info->fill_alloc_func = alloc_func;
     fb_info->fill_alloc_info = alloc_info;
     fb_info->fill_free_func  = free_func;
@@ -339,8 +338,6 @@ H5D__fill_init(H5D_fill_buf_info_t *fb_info, void *caller_fill_buf, H5MM_allocat
             /* Create temporary datatype for conversion operation */
             if (NULL == (fb_info->mem_type = H5T_copy(dset_type, H5T_COPY_TRANSIENT)))
                 HGOTO_ERROR(H5E_DATASET, H5E_CANTCOPY, FAIL, "unable to copy file datatype");
-            if ((fb_info->mem_tid = H5I_register(H5I_DATATYPE, fb_info->mem_type, false)) < 0)
-                HGOTO_ERROR(H5E_DATATYPE, H5E_CANTREGISTER, FAIL, "unable to register memory datatype");
 
             /* Retrieve sizes of memory & file datatypes */
             fb_info->mem_elmt_size = H5T_get_size(fb_info->mem_type);
@@ -516,7 +513,7 @@ H5D__fill_refill_vl(H5D_fill_buf_info_t *fb_info, size_t nelmts)
         memset(fb_info->bkg_buf, 0, fb_info->max_elmt_size);
 
     /* Type convert the dataset buffer, to copy any VL components */
-    if (H5T_convert(fb_info->fill_to_mem_tpath, fb_info->file_tid, fb_info->mem_tid, (size_t)1, (size_t)0,
+    if (H5T_convert(fb_info->fill_to_mem_tpath, fb_info->file_type, fb_info->mem_type, (size_t)1, (size_t)0,
                     (size_t)0, fb_info->fill_buf, fb_info->bkg_buf) < 0)
         HGOTO_ERROR(H5E_DATASET, H5E_CANTCONVERT, FAIL, "data type conversion failed");
 
@@ -540,7 +537,7 @@ H5D__fill_refill_vl(H5D_fill_buf_info_t *fb_info, size_t nelmts)
     H5MM_memcpy(buf, fb_info->fill_buf, fb_info->fill_buf_size);
 
     /* Type convert the dataset buffer, to copy any VL components */
-    if (H5T_convert(fb_info->mem_to_dset_tpath, fb_info->mem_tid, fb_info->file_tid, nelmts, (size_t)0,
+    if (H5T_convert(fb_info->mem_to_dset_tpath, fb_info->mem_type, fb_info->file_type, nelmts, (size_t)0,
                     (size_t)0, fb_info->fill_buf, fb_info->bkg_buf) < 0)
         HGOTO_ERROR(H5E_DATASET, H5E_CANTCONVERT, FAIL, "data type conversion failed");
 
@@ -622,9 +619,7 @@ H5D__fill_term(H5D_fill_buf_info_t *fb_info)
 
     /* Free other resources for vlen fill values */
     if (fb_info->has_vlen_fill_type) {
-        if (fb_info->mem_tid > 0)
-            H5I_dec_ref(fb_info->mem_tid);
-        else if (fb_info->mem_type)
+        if (fb_info->mem_type)
             (void)H5T_close_real(fb_info->mem_type);
         if (fb_info->bkg_buf)
             fb_info->bkg_buf = H5FL_BLK_FREE(type_conv, fb_info->bkg_buf);

--- a/src/H5Dint.c
+++ b/src/H5Dint.c
@@ -88,7 +88,7 @@ static herr_t H5D__use_minimized_dset_headers(H5F_t *file, bool *minimize);
 static herr_t H5D__prepare_minimized_oh(H5F_t *file, H5D_t *dset, H5O_loc_t *oloc);
 static size_t H5D__calculate_minimum_header_size(H5F_t *file, H5D_t *dset, H5O_t *ohdr);
 static void  *H5D__vlen_get_buf_size_alloc(size_t size, void *info);
-static herr_t H5D__vlen_get_buf_size_cb(void *elem, hid_t type_id, unsigned ndim, const hsize_t *point,
+static herr_t H5D__vlen_get_buf_size_cb(void *elem, H5T_t *type, unsigned ndim, const hsize_t *point,
                                         void *op_data);
 static herr_t H5D__vlen_get_buf_size_gen_cb(void *elem, hid_t type_id, unsigned ndim, const hsize_t *point,
                                             void *op_data);
@@ -2624,7 +2624,7 @@ done:
  *-------------------------------------------------------------------------
  */
 static herr_t
-H5D__vlen_get_buf_size_cb(void H5_ATTR_UNUSED *elem, hid_t type_id, unsigned H5_ATTR_UNUSED ndim,
+H5D__vlen_get_buf_size_cb(void H5_ATTR_UNUSED *elem, H5T_t *type, unsigned H5_ATTR_UNUSED ndim,
                           const hsize_t *point, void *op_data)
 {
     H5D_vlen_bufsize_native_t *vlen_bufsize = (H5D_vlen_bufsize_native_t *)op_data;
@@ -2634,7 +2634,7 @@ H5D__vlen_get_buf_size_cb(void H5_ATTR_UNUSED *elem, hid_t type_id, unsigned H5_
     FUNC_ENTER_PACKAGE
 
     /* Sanity check */
-    assert(H5I_DATATYPE == H5I_get_type(type_id));
+    assert(type);
     assert(point);
     assert(op_data);
 
@@ -2643,11 +2643,11 @@ H5D__vlen_get_buf_size_cb(void H5_ATTR_UNUSED *elem, hid_t type_id, unsigned H5_
         HGOTO_ERROR(H5E_DATASET, H5E_CANTCREATE, H5_ITER_ERROR, "can't select point");
 
     {
-        dset_info.dset        = vlen_bufsize->dset;
-        dset_info.mem_space   = vlen_bufsize->mspace;
-        dset_info.file_space  = vlen_bufsize->fspace;
-        dset_info.buf.vp      = vlen_bufsize->common.fl_tbuf;
-        dset_info.mem_type_id = type_id;
+        dset_info.dset       = vlen_bufsize->dset;
+        dset_info.mem_space  = vlen_bufsize->mspace;
+        dset_info.file_space = vlen_bufsize->fspace;
+        dset_info.buf.vp     = vlen_bufsize->common.fl_tbuf;
+        dset_info.mem_type   = type;
 
         /* Read in the point (with the custom VL memory allocator) */
         if (H5D__read(1, &dset_info) < 0)
@@ -2729,9 +2729,8 @@ H5D__vlen_get_buf_size(H5D_t *dset, hid_t type_id, hid_t space_id, hsize_t *size
     vlen_bufsize.common.size = 0;
 
     /* Call H5S_select_iterate with args, etc. */
-    dset_op.op_type          = H5S_SEL_ITER_OP_APP;
-    dset_op.u.app_op.op      = H5D__vlen_get_buf_size_cb;
-    dset_op.u.app_op.type_id = type_id;
+    dset_op.op_type  = H5S_SEL_ITER_OP_LIB;
+    dset_op.u.lib_op = H5D__vlen_get_buf_size_cb;
 
     ret_value = H5S_select_iterate(&bogus, type, space, &dset_op, &vlen_bufsize);
 
@@ -3561,6 +3560,8 @@ H5D_get_create_plist(const H5D_t *dset)
     H5O_layout_t    copied_layout;     /* Layout to tweak */
     H5O_fill_t      copied_fill = {0}; /* Fill value to tweak */
     H5O_efl_t       copied_efl;        /* External file list to tweak */
+    H5T_t          *src_type    = NULL;
+    H5T_t          *dst_type    = NULL;
     hid_t           new_dcpl_id = FAIL;
     hid_t           ret_value   = H5I_INVALID_HID; /* Return value */
 
@@ -3646,43 +3647,28 @@ H5D_get_create_plist(const H5D_t *dset)
 
         /* Convert disk form of fill value into memory form */
         if (!H5T_path_noop(tpath)) {
-            hid_t    dst_id, src_id; /* Source & destination datatypes for type conversion */
             uint8_t *bkg_buf = NULL; /* Background conversion buffer */
             size_t   bkg_size;       /* Size of background buffer */
 
-            /* Wrap copies of types to convert */
-            dst_id = H5I_register(H5I_DATATYPE, H5T_copy(copied_fill.type, H5T_COPY_TRANSIENT), false);
-            if (dst_id < 0)
-                HGOTO_ERROR(H5E_DATATYPE, H5E_CANTINIT, FAIL, "unable to copy/register datatype");
-            src_id = H5I_register(H5I_DATATYPE, H5T_copy(dset->shared->type, H5T_COPY_ALL), false);
-            if (src_id < 0) {
-                H5I_dec_ref(dst_id);
-                HGOTO_ERROR(H5E_DATASET, H5E_CANTINIT, FAIL, "unable to copy/register datatype");
-            } /* end if */
+            if (NULL == (src_type = H5T_copy(dset->shared->type, H5T_COPY_ALL)))
+                HGOTO_ERROR(H5E_DATASET, H5E_CANTCOPY, FAIL, "unable to copy dataset's datatype");
+            if (NULL == (dst_type = H5T_copy(copied_fill.type, H5T_COPY_TRANSIENT)))
+                HGOTO_ERROR(H5E_DATASET, H5E_CANTCOPY, FAIL, "unable to copy fill value datatype");
 
             /* Allocate a background buffer */
             bkg_size = MAX(H5T_GET_SIZE(copied_fill.type), H5T_GET_SIZE(dset->shared->type));
-            if (H5T_path_bkg(tpath) && NULL == (bkg_buf = H5FL_BLK_CALLOC(type_conv, bkg_size))) {
-                H5I_dec_ref(src_id);
-                H5I_dec_ref(dst_id);
+            if (H5T_path_bkg(tpath) && NULL == (bkg_buf = H5FL_BLK_CALLOC(type_conv, bkg_size)))
                 HGOTO_ERROR(H5E_DATASET, H5E_CANTALLOC, FAIL, "memory allocation failed");
-            } /* end if */
 
             /* Convert fill value */
-            if (H5T_convert(tpath, src_id, dst_id, (size_t)1, (size_t)0, (size_t)0, copied_fill.buf,
+            if (H5T_convert(tpath, src_type, dst_type, (size_t)1, (size_t)0, (size_t)0, copied_fill.buf,
                             bkg_buf) < 0) {
-                H5I_dec_ref(src_id);
-                H5I_dec_ref(dst_id);
                 if (bkg_buf)
                     bkg_buf = H5FL_BLK_FREE(type_conv, bkg_buf);
                 HGOTO_ERROR(H5E_DATASET, H5E_CANTCONVERT, FAIL, "datatype conversion failed");
             } /* end if */
 
             /* Release local resources */
-            if (H5I_dec_ref(src_id) < 0)
-                HGOTO_ERROR(H5E_DATASET, H5E_CANTDEC, FAIL, "unable to close temporary object");
-            if (H5I_dec_ref(dst_id) < 0)
-                HGOTO_ERROR(H5E_DATASET, H5E_CANTDEC, FAIL, "unable to close temporary object");
             if (bkg_buf)
                 bkg_buf = H5FL_BLK_FREE(type_conv, bkg_buf);
         } /* end if */
@@ -3713,6 +3699,11 @@ H5D_get_create_plist(const H5D_t *dset)
     ret_value = new_dcpl_id;
 
 done:
+    if (src_type && (H5T_close(src_type) < 0))
+        HDONE_ERROR(H5E_DATASET, H5E_CANTCLOSEOBJ, FAIL, "unable to close temporary datatype");
+    if (dst_type && (H5T_close(dst_type) < 0))
+        HDONE_ERROR(H5E_DATASET, H5E_CANTCLOSEOBJ, FAIL, "unable to close temporary datatype");
+
     if (ret_value < 0) {
         if (new_dcpl_id > 0)
             if (H5I_dec_app_ref(new_dcpl_id) < 0)

--- a/src/H5Dio.c
+++ b/src/H5Dio.c
@@ -46,7 +46,7 @@
 static herr_t H5D__ioinfo_init(size_t count, H5D_io_op_type_t op_type, H5D_dset_io_info_t *dset_info,
                                H5D_io_info_t *io_info);
 static herr_t H5D__dset_ioinfo_init(H5D_t *dset, H5D_dset_io_info_t *dset_info, H5D_storage_t *store);
-static herr_t H5D__typeinfo_init(H5D_io_info_t *io_info, H5D_dset_io_info_t *dset_info, hid_t mem_type_id);
+static herr_t H5D__typeinfo_init(H5D_io_info_t *io_info, H5D_dset_io_info_t *dset_info, H5T_t *mem_type);
 static herr_t H5D__typeinfo_init_phase2(H5D_io_info_t *io_info);
 static herr_t H5D__typeinfo_init_phase3(H5D_io_info_t *io_info);
 #ifdef H5_HAVE_PARALLEL
@@ -157,7 +157,7 @@ H5D__read(size_t count, H5D_dset_io_info_t *dset_info)
         H5AC_tag(dset_info[i].dset->oloc.addr, &prev_tag);
 
         /* Set up datatype info for operation */
-        if (H5D__typeinfo_init(&io_info, &(dset_info[i]), dset_info[i].mem_type_id) < 0)
+        if (H5D__typeinfo_init(&io_info, &(dset_info[i]), dset_info[i].mem_type) < 0)
             HGOTO_ERROR(H5E_DATASET, H5E_CANTINIT, FAIL, "unable to set up type info");
 
         /* Make certain that the number of elements in each selection is the same, and cache nelmts in
@@ -577,7 +577,7 @@ H5D__write(size_t count, H5D_dset_io_info_t *dset_info)
             HGOTO_ERROR(H5E_DATASET, H5E_WRITEERROR, FAIL, "no write intent on file");
 
         /* Set up datatype info for operation */
-        if (H5D__typeinfo_init(&io_info, &(dset_info[i]), dset_info[i].mem_type_id) < 0)
+        if (H5D__typeinfo_init(&io_info, &(dset_info[i]), dset_info[i].mem_type) < 0)
             HGOTO_ERROR(H5E_DATASET, H5E_CANTINIT, FAIL, "unable to set up type info");
 
             /* Various MPI based checks */
@@ -1040,12 +1040,10 @@ H5D__dset_ioinfo_init(H5D_t *dset, H5D_dset_io_info_t *dset_info, H5D_storage_t 
  *-------------------------------------------------------------------------
  */
 static herr_t
-H5D__typeinfo_init(H5D_io_info_t *io_info, H5D_dset_io_info_t *dset_info, hid_t mem_type_id)
+H5D__typeinfo_init(H5D_io_info_t *io_info, H5D_dset_io_info_t *dset_info, H5T_t *mem_type)
 {
     H5D_type_info_t  *type_info;
     const H5D_t      *dset;
-    const H5T_t      *src_type;            /* Source datatype */
-    const H5T_t      *dst_type;            /* Destination datatype */
     H5Z_data_xform_t *data_transform;      /* Data transform info */
     herr_t            ret_value = SUCCEED; /* Return value	*/
 
@@ -1054,6 +1052,7 @@ H5D__typeinfo_init(H5D_io_info_t *io_info, H5D_dset_io_info_t *dset_info, hid_t 
     /* Check args */
     assert(io_info);
     assert(dset_info);
+    assert(mem_type);
 
     /* Set convenience pointers */
     type_info = &dset_info->type_info;
@@ -1068,21 +1067,16 @@ H5D__typeinfo_init(H5D_io_info_t *io_info, H5D_dset_io_info_t *dset_info, hid_t 
     memset(type_info, 0, sizeof(*type_info));
 
     /* Get the memory & dataset datatypes */
-    if (NULL == (type_info->mem_type = (const H5T_t *)H5I_object_verify(mem_type_id, H5I_DATATYPE)))
-        HGOTO_ERROR(H5E_ARGS, H5E_BADTYPE, FAIL, "not a datatype");
+    type_info->mem_type  = mem_type;
     type_info->dset_type = dset->shared->type;
 
     if (io_info->op_type == H5D_IO_OP_WRITE) {
-        src_type               = type_info->mem_type;
-        dst_type               = dset->shared->type;
-        type_info->src_type_id = mem_type_id;
-        type_info->dst_type_id = dset->shared->type_id;
+        type_info->src_type = mem_type;
+        type_info->dst_type = dset->shared->type;
     } /* end if */
     else {
-        src_type               = dset->shared->type;
-        dst_type               = type_info->mem_type;
-        type_info->src_type_id = dset->shared->type_id;
-        type_info->dst_type_id = mem_type_id;
+        type_info->src_type = dset->shared->type;
+        type_info->dst_type = mem_type;
     } /* end else */
 
     /* Locate the type conversion function and dataspace conversion
@@ -1092,7 +1086,7 @@ H5D__typeinfo_init(H5D_io_info_t *io_info, H5D_dset_io_info_t *dset_info, hid_t 
      * enough value in xfer_parms since turning off datatype conversion also
      * turns off background preservation.
      */
-    if (NULL == (type_info->tpath = H5T_path_find(src_type, dst_type)))
+    if (NULL == (type_info->tpath = H5T_path_find(type_info->src_type, type_info->dst_type)))
         HGOTO_ERROR(H5E_DATASET, H5E_UNSUPPORTED, FAIL, "unable to convert between src and dest datatype");
 
     /* Retrieve info from API context */
@@ -1100,8 +1094,8 @@ H5D__typeinfo_init(H5D_io_info_t *io_info, H5D_dset_io_info_t *dset_info, hid_t 
         HGOTO_ERROR(H5E_DATASET, H5E_CANTGET, FAIL, "can't get data transform info");
 
     /* Precompute some useful information */
-    type_info->src_type_size = H5T_get_size(src_type);
-    type_info->dst_type_size = H5T_get_size(dst_type);
+    type_info->src_type_size = H5T_get_size(type_info->src_type);
+    type_info->dst_type_size = H5T_get_size(type_info->dst_type);
     type_info->is_conv_noop  = H5T_path_noop(type_info->tpath);
     type_info->is_xform_noop = H5Z_xform_noop(data_transform);
     if (type_info->is_xform_noop && type_info->is_conv_noop) {

--- a/src/H5Dmpio.c
+++ b/src/H5Dmpio.c
@@ -3279,7 +3279,7 @@ H5D__mpio_collective_filtered_chunk_io_setup(const H5D_io_info_t *io_info, const
                                (H5MM_free_t)H5D__chunk_mem_free,
                                (void *)&di[dset_idx].dset->shared->dcpl_cache.pline,
                                &di[dset_idx].dset->shared->dcpl_cache.fill, di[dset_idx].dset->shared->type,
-                               di[dset_idx].dset->shared->type_id, 0, curr_dset_info->file_chunk_size) < 0)
+                               0, curr_dset_info->file_chunk_size) < 0)
                 HGOTO_ERROR(H5E_DATASET, H5E_CANTINIT, FAIL, "can't initialize fill value buffer");
 
             curr_dset_info->fb_info_init = true;

--- a/src/H5Dpkg.h
+++ b/src/H5Dpkg.h
@@ -118,11 +118,11 @@
 /* Typedef for datatype information for raw data I/O operation */
 typedef struct H5D_type_info_t {
     /* Initial values */
-    const H5T_t *mem_type;    /* Pointer to memory datatype */
-    const H5T_t *dset_type;   /* Pointer to dataset datatype */
-    H5T_path_t  *tpath;       /* Datatype conversion path */
-    hid_t        src_type_id; /* Source datatype ID */
-    hid_t        dst_type_id; /* Destination datatype ID */
+    const H5T_t *mem_type;  /* Pointer to memory datatype */
+    const H5T_t *dset_type; /* Pointer to dataset datatype */
+    H5T_t       *src_type;  /* Pointer to source datatype */
+    H5T_t       *dst_type;  /* Pointer to destination datatype */
+    H5T_path_t  *tpath;     /* Datatype conversion path */
 
     /* Computed/derived values */
     size_t                   src_type_size;  /* Size of source type */
@@ -278,7 +278,7 @@ typedef struct H5D_dset_io_info_t {
         H5D_piece_info_t       *contig_piece_info; /* Piece info for contiguous dataset */
     } layout_io_info;
 
-    hid_t           mem_type_id; /* memory datatype ID */
+    H5T_t          *mem_type; /* memory datatype */
     H5D_type_info_t type_info;
     bool            skip_io; /* Whether to skip I/O for this dataset */
 } H5D_dset_io_info_t;
@@ -602,9 +602,7 @@ typedef struct H5D_fill_buf_info_t {
     void             *bkg_buf;                       /* Background conversion buffer */
     size_t            bkg_buf_size;                  /* Size of background buffer */
     H5T_t            *mem_type;                      /* Pointer to memory datatype */
-    const H5T_t      *file_type;                     /* Pointer to file datatype */
-    hid_t             mem_tid;                       /* ID for memory version of disk datatype */
-    hid_t             file_tid;                      /* ID for disk datatype */
+    H5T_t            *file_type;                     /* Pointer to file datatype */
     size_t            mem_elmt_size, file_elmt_size; /* Size of element in memory and on disk */
     size_t            max_elmt_size;                 /* Max. size of memory or file datatype */
     size_t            elmts_per_buf;                 /* # of elements that fit into a buffer */
@@ -742,8 +740,8 @@ H5_DLL herr_t H5D__chunk_addrmap(const H5D_t *dset, haddr_t chunk_addr[]);
 H5_DLL herr_t H5D__chunk_update_cache(H5D_t *dset);
 H5_DLL herr_t H5D__chunk_copy(H5F_t *f_src, H5O_storage_chunk_t *storage_src, H5O_layout_chunk_t *layout_src,
                               H5F_t *f_dst, H5O_storage_chunk_t *storage_dst,
-                              const H5S_extent_t *ds_extent_src, const H5T_t *dt_src,
-                              const H5O_pline_t *pline_src, H5O_copy_t *cpy_info);
+                              const H5S_extent_t *ds_extent_src, H5T_t *dt_src, const H5O_pline_t *pline_src,
+                              H5O_copy_t *cpy_info);
 H5_DLL herr_t H5D__chunk_bh_info(const H5O_loc_t *loc, H5O_t *oh, H5O_layout_t *layout, hsize_t *btree_size);
 H5_DLL herr_t H5D__chunk_dump_index(H5D_t *dset, FILE *stream);
 H5_DLL herr_t H5D__chunk_delete(H5F_t *f, H5O_t *oh, H5O_storage_t *store);
@@ -786,7 +784,7 @@ H5_DLL herr_t H5D__fill(const void *fill, const H5T_t *fill_type, void *buf, con
                         H5S_t *space);
 H5_DLL herr_t H5D__fill_init(H5D_fill_buf_info_t *fb_info, void *caller_fill_buf, H5MM_allocate_t alloc_func,
                              void *alloc_info, H5MM_free_t free_func, void *free_info, const H5O_fill_t *fill,
-                             const H5T_t *dset_type, hid_t dset_type_id, size_t nelmts, size_t min_buf_size);
+                             H5T_t *dset_type, size_t nelmts, size_t min_buf_size);
 H5_DLL herr_t H5D__fill_refill_vl(H5D_fill_buf_info_t *fb_info, size_t nelmts);
 H5_DLL herr_t H5D__fill_term(H5D_fill_buf_info_t *fb_info);
 

--- a/src/H5Dscatgath.c
+++ b/src/H5Dscatgath.c
@@ -576,8 +576,8 @@ H5D__scatgath_read(const H5D_io_info_t *io_info, const H5D_dset_io_info_t *dset_
             /*
              * Perform datatype conversion.
              */
-            if (H5T_convert(dset_info->type_info.tpath, dset_info->type_info.src_type_id,
-                            dset_info->type_info.dst_type_id, smine_nelmts, (size_t)0, (size_t)0, tmp_buf,
+            if (H5T_convert(dset_info->type_info.tpath, dset_info->type_info.src_type,
+                            dset_info->type_info.dst_type, smine_nelmts, (size_t)0, (size_t)0, tmp_buf,
                             io_info->bkg_buf) < 0)
                 HGOTO_ERROR(H5E_DATASET, H5E_CANTCONVERT, FAIL, "datatype conversion failed");
 
@@ -772,8 +772,8 @@ H5D__scatgath_write(const H5D_io_info_t *io_info, const H5D_dset_io_info_t *dset
             /*
              * Perform datatype conversion.
              */
-            if (H5T_convert(dset_info->type_info.tpath, dset_info->type_info.src_type_id,
-                            dset_info->type_info.dst_type_id, smine_nelmts, (size_t)0, (size_t)0, tmp_buf,
+            if (H5T_convert(dset_info->type_info.tpath, dset_info->type_info.src_type,
+                            dset_info->type_info.dst_type, smine_nelmts, (size_t)0, (size_t)0, tmp_buf,
                             io_info->bkg_buf) < 0)
                 HGOTO_ERROR(H5E_DATASET, H5E_CANTCONVERT, FAIL, "datatype conversion failed");
         } /* end else */
@@ -975,10 +975,9 @@ H5D__scatgath_read_select(H5D_io_info_t *io_info)
                 /*
                  * Perform datatype conversion.
                  */
-                if (H5T_convert(dset_info->type_info.tpath, dset_info->type_info.src_type_id,
-                                dset_info->type_info.dst_type_id,
-                                (size_t)io_info->sel_pieces[i]->piece_points, (size_t)0, (size_t)0,
-                                tmp_bufs[i], tmp_bkg_buf) < 0)
+                if (H5T_convert(dset_info->type_info.tpath, dset_info->type_info.src_type,
+                                dset_info->type_info.dst_type, (size_t)io_info->sel_pieces[i]->piece_points,
+                                (size_t)0, (size_t)0, tmp_bufs[i], tmp_bkg_buf) < 0)
                     HGOTO_ERROR(H5E_DATASET, H5E_CANTCONVERT, FAIL, "datatype conversion failed");
 
                 /* Do the data transform after the conversion (since we're using type mem_type) */
@@ -1232,8 +1231,8 @@ H5D__scatgath_write_select(H5D_io_info_t *io_info)
                     /*
                      * Perform datatype conversion.
                      */
-                    if (H5T_convert(dset_info->type_info.tpath, dset_info->type_info.src_type_id,
-                                    dset_info->type_info.dst_type_id,
+                    if (H5T_convert(dset_info->type_info.tpath, dset_info->type_info.src_type,
+                                    dset_info->type_info.dst_type,
                                     (size_t)io_info->sel_pieces[i]->piece_points, (size_t)0, (size_t)0,
                                     tmp_write_buf, tmp_bkg_buf) < 0)
                         HGOTO_ERROR(H5E_DATASET, H5E_CANTCONVERT, FAIL, "datatype conversion failed");
@@ -1292,10 +1291,9 @@ H5D__scatgath_write_select(H5D_io_info_t *io_info)
                  * Perform datatype conversion.
                  */
                 assert(j < bkg_pieces);
-                if (H5T_convert(dset_info->type_info.tpath, dset_info->type_info.src_type_id,
-                                dset_info->type_info.dst_type_id,
-                                (size_t)io_info->sel_pieces[i]->piece_points, (size_t)0, (size_t)0,
-                                tmp_write_buf, bkg_bufs[j]) < 0)
+                if (H5T_convert(dset_info->type_info.tpath, dset_info->type_info.src_type,
+                                dset_info->type_info.dst_type, (size_t)io_info->sel_pieces[i]->piece_points,
+                                (size_t)0, (size_t)0, tmp_write_buf, bkg_bufs[j]) < 0)
                     HGOTO_ERROR(H5E_DATASET, H5E_CANTCONVERT, FAIL, "datatype conversion failed");
 
                 /* Advance to next background buffer */

--- a/src/H5Dvirtual.c
+++ b/src/H5Dvirtual.c
@@ -2678,11 +2678,11 @@ H5D__virtual_read_one(H5D_dset_io_info_t *dset_info, H5O_storage_virtual_srcdset
 
         {
             /* Initialize source_dinfo */
-            source_dinfo.dset        = source_dset->dset;
-            source_dinfo.mem_space   = source_dset->projected_mem_space;
-            source_dinfo.file_space  = projected_src_space;
-            source_dinfo.buf.vp      = dset_info->buf.vp;
-            source_dinfo.mem_type_id = dset_info->type_info.dst_type_id;
+            source_dinfo.dset       = source_dset->dset;
+            source_dinfo.mem_space  = source_dset->projected_mem_space;
+            source_dinfo.file_space = projected_src_space;
+            source_dinfo.buf.vp     = dset_info->buf.vp;
+            source_dinfo.mem_type   = dset_info->type_info.dst_type;
 
             /* Read in the point (with the custom VL memory allocator) */
             if (H5D__read(1, &source_dinfo) < 0)
@@ -2875,11 +2875,11 @@ H5D__virtual_write_one(H5D_dset_io_info_t *dset_info, H5O_storage_virtual_srcdse
 
         {
             /* Initialize source_dinfo */
-            source_dinfo.dset        = source_dset->dset;
-            source_dinfo.mem_space   = source_dset->projected_mem_space;
-            source_dinfo.file_space  = projected_src_space;
-            source_dinfo.buf.cvp     = dset_info->buf.cvp;
-            source_dinfo.mem_type_id = dset_info->type_info.dst_type_id;
+            source_dinfo.dset       = source_dset->dset;
+            source_dinfo.mem_space  = source_dset->projected_mem_space;
+            source_dinfo.file_space = projected_src_space;
+            source_dinfo.buf.cvp    = dset_info->buf.cvp;
+            source_dinfo.mem_type   = dset_info->type_info.dst_type;
 
             /* Read in the point (with the custom VL memory allocator) */
             if (H5D__write(1, &source_dinfo) < 0)

--- a/src/H5Ocopy_ref.c
+++ b/src/H5Ocopy_ref.c
@@ -64,10 +64,9 @@ static herr_t H5O__copy_expand_ref_object1(H5O_loc_t *src_oloc, const void *buf_
 static herr_t H5O__copy_expand_ref_region1(H5O_loc_t *src_oloc, const void *buf_src, H5O_loc_t *dst_oloc,
                                            H5G_loc_t *dst_root_loc, void *buf_dst, size_t ref_count,
                                            H5O_copy_t *cpy_info);
-static herr_t H5O__copy_expand_ref_object2(H5O_loc_t *src_oloc, hid_t tid_src, const H5T_t *dt_src,
-                                           const void *buf_src, size_t nbytes_src, H5O_loc_t *dst_oloc,
-                                           H5G_loc_t *dst_root_loc, void *buf_dst, size_t ref_count,
-                                           H5O_copy_t *cpy_info);
+static herr_t H5O__copy_expand_ref_object2(H5O_loc_t *src_oloc, H5T_t *dt_src, const void *buf_src,
+                                           size_t nbytes_src, H5O_loc_t *dst_oloc, H5G_loc_t *dst_root_loc,
+                                           void *buf_dst, size_t ref_count, H5O_copy_t *cpy_info);
 
 /*********************/
 /* Package Variables */
@@ -285,17 +284,14 @@ done:
  *-------------------------------------------------------------------------
  */
 static herr_t
-H5O__copy_expand_ref_object2(H5O_loc_t *src_oloc, hid_t tid_src, const H5T_t *dt_src, const void *buf_src,
-                             size_t nbytes_src, H5O_loc_t *dst_oloc, H5G_loc_t *dst_root_loc, void *buf_dst,
-                             size_t ref_count, H5O_copy_t *cpy_info)
+H5O__copy_expand_ref_object2(H5O_loc_t *src_oloc, H5T_t *dt_src, const void *buf_src, size_t nbytes_src,
+                             H5O_loc_t *dst_oloc, H5G_loc_t *dst_root_loc, void *buf_dst, size_t ref_count,
+                             H5O_copy_t *cpy_info)
 {
     H5T_t              *dt_mem        = NULL;                        /* Memory datatype */
     H5T_t              *dt_dst        = NULL;                        /* Destination datatype */
-    hid_t               tid_mem       = H5I_INVALID_HID;             /* Datatype ID for memory datatype */
-    hid_t               tid_dst       = H5I_INVALID_HID;             /* Datatype ID for memory datatype */
     H5T_path_t         *tpath_src_mem = NULL, *tpath_mem_dst = NULL; /* Datatype conversion paths */
     size_t              i;                                           /* Local index variable */
-    bool                reg_tid_src             = (tid_src == H5I_INVALID_HID);
     hid_t               dst_loc_id              = H5I_INVALID_HID;
     void               *conv_buf                = NULL;        /* Buffer for converting data */
     size_t              conv_buf_size           = 0;           /* Buffer size */
@@ -308,17 +304,9 @@ H5O__copy_expand_ref_object2(H5O_loc_t *src_oloc, hid_t tid_src, const H5T_t *dt
 
     FUNC_ENTER_PACKAGE
 
-    /* Create datatype ID for src datatype. */
-    if ((tid_src == H5I_INVALID_HID) && (tid_src = H5I_register(H5I_DATATYPE, dt_src, false)) < 0)
-        HGOTO_ERROR(H5E_OHDR, H5E_CANTREGISTER, FAIL, "unable to register source file datatype");
-
     /* create a memory copy of the reference datatype */
     if (NULL == (dt_mem = H5T_copy(dt_src, H5T_COPY_TRANSIENT)))
         HGOTO_ERROR(H5E_OHDR, H5E_CANTINIT, FAIL, "unable to copy");
-    if ((tid_mem = H5I_register(H5I_DATATYPE, dt_mem, false)) < 0) {
-        (void)H5T_close_real(dt_mem);
-        HGOTO_ERROR(H5E_OHDR, H5E_CANTREGISTER, FAIL, "unable to register memory datatype");
-    } /* end if */
 
     /* create reference datatype at the destination file */
     if (NULL == (dt_dst = H5T_copy(dt_src, H5T_COPY_TRANSIENT)))
@@ -326,10 +314,6 @@ H5O__copy_expand_ref_object2(H5O_loc_t *src_oloc, hid_t tid_src, const H5T_t *dt
     if (H5T_set_loc(dt_dst, H5F_VOL_OBJ(dst_oloc->file), H5T_LOC_DISK) < 0) {
         (void)H5T_close_real(dt_dst);
         HGOTO_ERROR(H5E_OHDR, H5E_CANTINIT, FAIL, "cannot mark datatype on disk");
-    } /* end if */
-    if ((tid_dst = H5I_register(H5I_DATATYPE, dt_dst, false)) < 0) {
-        (void)H5T_close_real(dt_dst);
-        HGOTO_ERROR(H5E_OHDR, H5E_CANTREGISTER, FAIL, "unable to register destination file datatype");
     } /* end if */
 
     /* Set up the conversion functions */
@@ -346,7 +330,7 @@ H5O__copy_expand_ref_object2(H5O_loc_t *src_oloc, hid_t tid_src, const H5T_t *dt
     H5MM_memcpy(conv_buf, buf_src, nbytes_src);
 
     /* Convert from source file to memory */
-    if (H5T_convert(tpath_src_mem, tid_src, tid_mem, ref_count, (size_t)0, (size_t)0, conv_buf, NULL) < 0)
+    if (H5T_convert(tpath_src_mem, dt_src, dt_mem, ref_count, (size_t)0, (size_t)0, conv_buf, NULL) < 0)
         HGOTO_ERROR(H5E_OHDR, H5E_CANTCONVERT, FAIL, "datatype conversion failed");
 
     /* Retrieve loc ID */
@@ -392,24 +376,21 @@ H5O__copy_expand_ref_object2(H5O_loc_t *src_oloc, hid_t tid_src, const H5T_t *dt
         HGOTO_ERROR(H5E_OHDR, H5E_CANTCREATE, FAIL, "can't create simple dataspace");
 
     /* Convert from memory to destination file */
-    if (H5T_convert(tpath_mem_dst, tid_mem, tid_dst, ref_count, (size_t)0, (size_t)0, conv_buf, NULL) < 0)
+    if (H5T_convert(tpath_mem_dst, dt_mem, dt_dst, ref_count, (size_t)0, (size_t)0, conv_buf, NULL) < 0)
         HGOTO_ERROR(H5E_OHDR, H5E_CANTCONVERT, FAIL, "datatype conversion failed");
     H5MM_memcpy(buf_dst, conv_buf, nbytes_src);
 
     /* Reclaim space from reference data */
-    if (H5T_reclaim(tid_mem, buf_space, reclaim_buf) < 0)
+    if (H5T_reclaim(dt_mem, buf_space, reclaim_buf) < 0)
         HGOTO_ERROR(H5E_OHDR, H5E_BADITER, FAIL, "unable to reclaim reference data");
 
 done:
     if (buf_space && (H5S_close(buf_space) < 0))
-        HDONE_ERROR(H5E_OHDR, H5E_CANTFREE, FAIL, "Can't close dataspace");
-    /* Don't decrement ID, we want to keep underlying datatype */
-    if (reg_tid_src && (tid_src > 0) && (NULL == H5I_remove(tid_src)))
-        HDONE_ERROR(H5E_OHDR, H5E_CANTFREE, FAIL, "Can't decrement temporary datatype ID");
-    if ((tid_mem > 0) && H5I_dec_ref(tid_mem) < 0)
-        HDONE_ERROR(H5E_OHDR, H5E_CANTFREE, FAIL, "Can't decrement temporary datatype ID");
-    if ((tid_dst > 0) && H5I_dec_ref(tid_dst) < 0)
-        HDONE_ERROR(H5E_OHDR, H5E_CANTFREE, FAIL, "Can't decrement temporary datatype ID");
+        HDONE_ERROR(H5E_OHDR, H5E_CANTFREE, FAIL, "can't close dataspace");
+    if (dt_mem && (H5T_close(dt_mem) < 0))
+        HDONE_ERROR(H5E_OHDR, H5E_CANTCLOSEOBJ, FAIL, "can't close temporary datatype");
+    if (dt_dst && (H5T_close(dt_dst) < 0))
+        HDONE_ERROR(H5E_OHDR, H5E_CANTCLOSEOBJ, FAIL, "can't close temporary datatype");
     if (reclaim_buf)
         reclaim_buf = H5FL_BLK_FREE(type_conv, reclaim_buf);
     if (conv_buf)
@@ -430,8 +411,8 @@ done:
  *-------------------------------------------------------------------------
  */
 herr_t
-H5O_copy_expand_ref(H5F_t *file_src, hid_t tid_src, const H5T_t *dt_src, void *buf_src, size_t nbytes_src,
-                    H5F_t *file_dst, void *buf_dst, H5O_copy_t *cpy_info)
+H5O_copy_expand_ref(H5F_t *file_src, H5T_t *dt_src, void *buf_src, size_t nbytes_src, H5F_t *file_dst,
+                    void *buf_dst, H5O_copy_t *cpy_info)
 {
     H5O_loc_t dst_oloc;     /* Copied object object location */
     H5O_loc_t src_oloc;     /* Temporary object location for source object */
@@ -479,8 +460,8 @@ H5O_copy_expand_ref(H5F_t *file_src, hid_t tid_src, const H5T_t *dt_src, void *b
         case H5R_DATASET_REGION2:
         case H5R_ATTR:
         case H5R_OBJECT2:
-            if (H5O__copy_expand_ref_object2(&src_oloc, tid_src, dt_src, buf_src, nbytes_src, &dst_oloc,
-                                             &dst_root_loc, buf_dst, ref_count, cpy_info) < 0)
+            if (H5O__copy_expand_ref_object2(&src_oloc, dt_src, buf_src, nbytes_src, &dst_oloc, &dst_root_loc,
+                                             buf_dst, ref_count, cpy_info) < 0)
                 HGOTO_ERROR(H5E_OHDR, H5E_BADVALUE, FAIL, "unable to expand reference");
             break;
         case H5R_BADTYPE:

--- a/src/H5Ofill.c
+++ b/src/H5Ofill.c
@@ -534,6 +534,8 @@ H5O__fill_copy(const void *_src, void *_dst)
 {
     const H5O_fill_t *src       = (const H5O_fill_t *)_src;
     H5O_fill_t       *dst       = (H5O_fill_t *)_dst;
+    H5T_t            *src_type  = NULL;
+    H5T_t            *dst_type  = NULL;
     void             *ret_value = NULL; /* Return value */
 
     FUNC_ENTER_PACKAGE
@@ -572,41 +574,28 @@ H5O__fill_copy(const void *_src, void *_dst)
 
             /* If necessary, convert fill value datatypes (which copies VL components, etc.) */
             if (!H5T_path_noop(tpath)) {
-                hid_t    dst_id, src_id; /* Source & destination datatypes for type conversion */
                 uint8_t *bkg_buf = NULL; /* Background conversion buffer */
                 size_t   bkg_size;       /* Size of background buffer */
 
-                /* Wrap copies of types to convert */
-                dst_id = H5I_register(H5I_DATATYPE, H5T_copy(dst->type, H5T_COPY_TRANSIENT), false);
-                if (dst_id < 0)
-                    HGOTO_ERROR(H5E_OHDR, H5E_CANTINIT, NULL, "unable to copy/register datatype");
-                src_id = H5I_register(H5I_DATATYPE, H5T_copy(src->type, H5T_COPY_ALL), false);
-                if (src_id < 0) {
-                    H5I_dec_ref(dst_id);
-                    HGOTO_ERROR(H5E_OHDR, H5E_CANTINIT, NULL, "unable to copy/register datatype");
-                } /* end if */
+                if (NULL == (src_type = H5T_copy(src->type, H5T_COPY_ALL)))
+                    HGOTO_ERROR(H5E_OHDR, H5E_CANTCOPY, NULL, "unable to copy source datatype");
+                if (NULL == (dst_type = H5T_copy(dst->type, H5T_COPY_TRANSIENT)))
+                    HGOTO_ERROR(H5E_OHDR, H5E_CANTCOPY, NULL, "unable to copy destination datatype");
 
                 /* Allocate a background buffer */
                 bkg_size = MAX(H5T_get_size(dst->type), H5T_get_size(src->type));
-                if (H5T_path_bkg(tpath) && NULL == (bkg_buf = H5FL_BLK_CALLOC(type_conv, bkg_size))) {
-                    H5I_dec_ref(src_id);
-                    H5I_dec_ref(dst_id);
+                if (H5T_path_bkg(tpath) && NULL == (bkg_buf = H5FL_BLK_CALLOC(type_conv, bkg_size)))
                     HGOTO_ERROR(H5E_RESOURCE, H5E_NOSPACE, NULL, "memory allocation failed");
-                } /* end if */
 
                 /* Convert fill value */
-                if (H5T_convert(tpath, src_id, dst_id, (size_t)1, (size_t)0, (size_t)0, dst->buf, bkg_buf) <
-                    0) {
-                    H5I_dec_ref(src_id);
-                    H5I_dec_ref(dst_id);
+                if (H5T_convert(tpath, src_type, dst_type, (size_t)1, (size_t)0, (size_t)0, dst->buf,
+                                bkg_buf) < 0) {
                     if (bkg_buf)
                         bkg_buf = H5FL_BLK_FREE(type_conv, bkg_buf);
                     HGOTO_ERROR(H5E_OHDR, H5E_CANTCONVERT, NULL, "datatype conversion failed");
                 } /* end if */
 
                 /* Release the background buffer */
-                H5I_dec_ref(src_id);
-                H5I_dec_ref(dst_id);
                 if (bkg_buf)
                     bkg_buf = H5FL_BLK_FREE(type_conv, bkg_buf);
             } /* end if */
@@ -619,6 +608,11 @@ H5O__fill_copy(const void *_src, void *_dst)
     ret_value = dst;
 
 done:
+    if (src_type && (H5T_close(src_type) < 0))
+        HDONE_ERROR(H5E_OHDR, H5E_CANTCLOSEOBJ, NULL, "unable to close temporary datatype");
+    if (dst_type && (H5T_close(dst_type) < 0))
+        HDONE_ERROR(H5E_OHDR, H5E_CANTCLOSEOBJ, NULL, "unable to close temporary datatype");
+
     if (!ret_value && dst) {
         if (dst->buf)
             H5MM_xfree(dst->buf);
@@ -713,8 +707,7 @@ H5O__fill_old_size(const H5F_t H5_ATTR_UNUSED *f, const void *_fill)
 herr_t
 H5O_fill_reset_dyn(H5O_fill_t *fill)
 {
-    hid_t  fill_type_id = -1;      /* Datatype ID for fill value datatype when reclaiming VL fill values */
-    herr_t ret_value    = SUCCEED; /* Return value */
+    herr_t ret_value = SUCCEED; /* Return value */
 
     FUNC_ENTER_NOAPI(FAIL)
 
@@ -722,23 +715,14 @@ H5O_fill_reset_dyn(H5O_fill_t *fill)
 
     if (fill->buf) {
         if (fill->type && H5T_detect_class(fill->type, H5T_VLEN, false) > 0) {
-            H5T_t *fill_type;  /* Copy of fill value datatype */
             H5S_t *fill_space; /* Scalar dataspace for fill value element */
-
-            /* Copy the fill value datatype and get an ID for it */
-            if (NULL == (fill_type = H5T_copy(fill->type, H5T_COPY_TRANSIENT)))
-                HGOTO_ERROR(H5E_OHDR, H5E_CANTINIT, FAIL, "unable to copy fill value datatype");
-            if ((fill_type_id = H5I_register(H5I_DATATYPE, fill_type, false)) < 0) {
-                (void)H5T_close_real(fill_type);
-                HGOTO_ERROR(H5E_OHDR, H5E_CANTREGISTER, FAIL, "unable to register fill value datatype");
-            } /* end if */
 
             /* Create a scalar dataspace for the fill value element */
             if (NULL == (fill_space = H5S_create(H5S_SCALAR)))
                 HGOTO_ERROR(H5E_OHDR, H5E_CANTCREATE, FAIL, "can't create scalar dataspace");
 
             /* Reclaim any variable length components of the fill value */
-            if (H5T_reclaim(fill_type_id, fill_space, fill->buf) < 0) {
+            if (H5T_reclaim(fill->type, fill_space, fill->buf) < 0) {
                 H5S_close(fill_space);
                 HGOTO_ERROR(H5E_OHDR, H5E_BADITER, FAIL, "unable to reclaim variable-length fill value data");
             } /* end if */
@@ -757,9 +741,6 @@ H5O_fill_reset_dyn(H5O_fill_t *fill)
     } /* end if */
 
 done:
-    if (fill_type_id > 0 && H5I_dec_ref(fill_type_id) < 0)
-        HDONE_ERROR(H5E_OHDR, H5E_CANTDEC, FAIL, "unable to decrement ref count for temp ID");
-
     FUNC_LEAVE_NOAPI(ret_value)
 } /* end H5O_fill_reset_dyn() */
 
@@ -957,10 +938,11 @@ H5O__fill_debug(H5F_t H5_ATTR_UNUSED *f, const void *_fill, FILE *stream, int in
 herr_t
 H5O_fill_convert(H5O_fill_t *fill, H5T_t *dset_type, bool *fill_changed)
 {
-    H5T_path_t *tpath;                    /* Type conversion info    */
-    void       *buf = NULL, *bkg = NULL;  /* Conversion buffers    */
-    hid_t       src_id = -1, dst_id = -1; /* Datatype identifiers    */
-    herr_t      ret_value = SUCCEED;      /* Return value */
+    H5T_path_t *tpath;                   /* Type conversion info    */
+    void       *buf = NULL, *bkg = NULL; /* Conversion buffers    */
+    H5T_t      *src_type  = NULL;
+    H5T_t      *dst_type  = NULL;
+    herr_t      ret_value = SUCCEED; /* Return value */
 
     FUNC_ENTER_NOAPI(FAIL)
 
@@ -991,9 +973,10 @@ H5O_fill_convert(H5O_fill_t *fill, H5T_t *dset_type, bool *fill_changed)
     if (!H5T_path_noop(tpath)) {
         size_t fill_type_size;
 
-        if ((src_id = H5I_register(H5I_DATATYPE, H5T_copy(fill->type, H5T_COPY_ALL), false)) < 0 ||
-            (dst_id = H5I_register(H5I_DATATYPE, H5T_copy(dset_type, H5T_COPY_ALL), false)) < 0)
-            HGOTO_ERROR(H5E_OHDR, H5E_CANTINIT, FAIL, "unable to copy/register data type");
+        if (NULL == (src_type = H5T_copy(fill->type, H5T_COPY_ALL)))
+            HGOTO_ERROR(H5E_OHDR, H5E_CANTCOPY, FAIL, "unable to copy fill value datatype");
+        if (NULL == (dst_type = H5T_copy(dset_type, H5T_COPY_ALL)))
+            HGOTO_ERROR(H5E_OHDR, H5E_CANTCOPY, FAIL, "unable to copy dataset's datatype");
 
         /*
          * Datatype conversions are always done in place, so we need a buffer
@@ -1011,7 +994,7 @@ H5O_fill_convert(H5O_fill_t *fill, H5T_t *dset_type, bool *fill_changed)
             HGOTO_ERROR(H5E_RESOURCE, H5E_NOSPACE, FAIL, "memory allocation failed for type conversion");
 
         /* Do the conversion */
-        if (H5T_convert(tpath, src_id, dst_id, (size_t)1, (size_t)0, (size_t)0, buf, bkg) < 0)
+        if (H5T_convert(tpath, src_type, dst_type, (size_t)1, (size_t)0, (size_t)0, buf, bkg) < 0)
             HGOTO_ERROR(H5E_OHDR, H5E_CANTINIT, FAIL, "datatype conversion failed");
 
         /* Update the fill message */
@@ -1028,10 +1011,10 @@ H5O_fill_convert(H5O_fill_t *fill, H5T_t *dset_type, bool *fill_changed)
     } /* end if */
 
 done:
-    if (src_id >= 0 && H5I_dec_ref(src_id) < 0)
-        HDONE_ERROR(H5E_OHDR, H5E_CANTDEC, FAIL, "unable to decrement ref count for temp ID");
-    if (dst_id >= 0 && H5I_dec_ref(dst_id) < 0)
-        HDONE_ERROR(H5E_OHDR, H5E_CANTDEC, FAIL, "unable to decrement ref count for temp ID");
+    if (src_type && (H5T_close(src_type) < 0))
+        HDONE_ERROR(H5E_OHDR, H5E_CANTCLOSEOBJ, FAIL, "unable to close temporary datatype");
+    if (dst_type && (H5T_close(dst_type) < 0))
+        HDONE_ERROR(H5E_OHDR, H5E_CANTCLOSEOBJ, FAIL, "unable to close temporary datatype");
     if (bkg)
         H5MM_xfree(bkg);
 

--- a/src/H5Oprivate.h
+++ b/src/H5Oprivate.h
@@ -985,8 +985,8 @@ H5_DLL herr_t H5O_refresh_metadata_reopen(hid_t oid, hid_t apl_id, H5G_loc_t *ob
 /* Object copying routines */
 H5_DLL herr_t H5O_copy_header_map(const H5O_loc_t *oloc_src, H5O_loc_t *oloc_dst /*out */,
                                   H5O_copy_t *cpy_info, bool inc_depth, H5O_type_t *obj_type, void **udata);
-H5_DLL herr_t H5O_copy_expand_ref(H5F_t *file_src, hid_t tid_src, const H5T_t *dt_src, void *buf_src,
-                                  size_t nbytes_src, H5F_t *file_dst, void *buf_dst, H5O_copy_t *cpy_info);
+H5_DLL herr_t H5O_copy_expand_ref(H5F_t *file_src, H5T_t *dt_src, void *buf_src, size_t nbytes_src,
+                                  H5F_t *file_dst, void *buf_dst, H5O_copy_t *cpy_info);
 
 /* Debugging routines */
 H5_DLL herr_t H5O_debug_id(unsigned type_id, H5F_t *f, const void *mesg, FILE *stream, int indent,

--- a/src/H5Pdcpl.c
+++ b/src/H5Pdcpl.c
@@ -3042,8 +3042,7 @@ H5Pset_fill_value(hid_t plist_id, hid_t type_id, const void *value)
                 HGOTO_ERROR(H5E_RESOURCE, H5E_NOSPACE, FAIL, "memory allocation failed");
 
             /* Convert the fill value */
-            if (H5T_convert(tpath, type_id, type_id, (size_t)1, (size_t)0, (size_t)0, fill.buf, bkg_buf) <
-                0) {
+            if (H5T_convert(tpath, type, type, (size_t)1, (size_t)0, (size_t)0, fill.buf, bkg_buf) < 0) {
                 if (bkg_buf)
                     bkg_buf = H5FL_BLK_FREE(type_conv, bkg_buf);
                 HGOTO_ERROR(H5E_DATASET, H5E_CANTCONVERT, FAIL, "datatype conversion failed");
@@ -3085,8 +3084,8 @@ H5P_get_fill_value(H5P_genplist_t *plist, const H5T_t *type, void *value /*out*/
     H5T_path_t *tpath;               /*type conversion info	*/
     void       *buf       = NULL;    /*conversion buffer	*/
     void       *bkg       = NULL;    /*conversion buffer	*/
-    hid_t       src_id    = -1;      /*source datatype id	*/
-    hid_t       dst_id    = -1;      /*destination datatype id	*/
+    H5T_t      *src_type  = NULL;    /*source datatype      */
+    H5T_t      *dst_type  = NULL;    /*destination datatype */
     herr_t      ret_value = SUCCEED; /* Return value */
 
     FUNC_ENTER_NOAPI(FAIL)
@@ -3113,8 +3112,10 @@ H5P_get_fill_value(H5P_genplist_t *plist, const H5T_t *type, void *value /*out*/
      */
     if (NULL == (tpath = H5T_path_find(fill.type, type)))
         HGOTO_ERROR(H5E_PLIST, H5E_CANTINIT, FAIL, "unable to convert between src and dst datatypes");
-    if ((src_id = H5I_register(H5I_DATATYPE, H5T_copy(fill.type, H5T_COPY_TRANSIENT), false)) < 0)
-        HGOTO_ERROR(H5E_PLIST, H5E_CANTINIT, FAIL, "unable to copy/register datatype");
+    if (NULL == (src_type = H5T_copy(fill.type, H5T_COPY_TRANSIENT)))
+        HGOTO_ERROR(H5E_PLIST, H5E_CANTCOPY, FAIL, "unable to copy fill value datatype");
+    if (NULL == (dst_type = H5T_copy(type, H5T_COPY_ALL)))
+        HGOTO_ERROR(H5E_PLIST, H5E_CANTCOPY, FAIL, "unable to copy memory datatype");
 
     /*
      * Data type conversions are always done in place, so we need a buffer
@@ -3135,9 +3136,7 @@ H5P_get_fill_value(H5P_genplist_t *plist, const H5T_t *type, void *value /*out*/
     H5MM_memcpy(buf, fill.buf, H5T_get_size(fill.type));
 
     /* Do the conversion */
-    if ((dst_id = H5I_register(H5I_DATATYPE, H5T_copy(type, H5T_COPY_ALL), false)) < 0)
-        HGOTO_ERROR(H5E_PLIST, H5E_CANTINIT, FAIL, "unable to copy/register datatype");
-    if (H5T_convert(tpath, src_id, dst_id, (size_t)1, (size_t)0, (size_t)0, buf, bkg) < 0)
+    if (H5T_convert(tpath, src_type, dst_type, (size_t)1, (size_t)0, (size_t)0, buf, bkg) < 0)
         HGOTO_ERROR(H5E_PLIST, H5E_CANTINIT, FAIL, "datatype conversion failed");
     if (buf != value)
         H5MM_memcpy(value, buf, H5T_get_size(type));
@@ -3147,10 +3146,10 @@ done:
         H5MM_xfree(buf);
     if (bkg != value)
         H5MM_xfree(bkg);
-    if (src_id >= 0 && H5I_dec_ref(src_id) < 0)
-        HDONE_ERROR(H5E_PLIST, H5E_CANTDEC, FAIL, "can't decrement ref count of temp ID");
-    if (dst_id >= 0 && H5I_dec_ref(dst_id) < 0)
-        HDONE_ERROR(H5E_PLIST, H5E_CANTDEC, FAIL, "can't decrement ref count of temp ID");
+    if (src_type && H5T_close(src_type) < 0)
+        HDONE_ERROR(H5E_PLIST, H5E_CANTCLOSEOBJ, FAIL, "unable to close temporary datatype");
+    if (dst_type && H5T_close(dst_type) < 0)
+        HDONE_ERROR(H5E_PLIST, H5E_CANTCLOSEOBJ, FAIL, "unable to close temporary datatype");
 
     FUNC_LEAVE_NOAPI(ret_value)
 } /* end H5P_get_fill_value() */

--- a/src/H5Sprivate.h
+++ b/src/H5Sprivate.h
@@ -106,7 +106,7 @@ typedef struct H5S_sel_iter_t {
 } H5S_sel_iter_t;
 
 /* Selection iteration operator for internal library callbacks */
-typedef herr_t (*H5S_sel_iter_lib_op_t)(void *elem, const H5T_t *type, unsigned ndim, const hsize_t *point,
+typedef herr_t (*H5S_sel_iter_lib_op_t)(void *elem, H5T_t *type, unsigned ndim, const hsize_t *point,
                                         void *op_data);
 
 /* Describe kind of callback to make */
@@ -231,32 +231,32 @@ H5_DLL herr_t  H5S_extent_copy(H5S_t *dst, const H5S_t *src);
 /* Operations on selections */
 H5_DLL herr_t       H5S_select_deserialize(H5S_t **space, const uint8_t **p, const size_t p_size);
 H5_DLL H5S_sel_type H5S_get_select_type(const H5S_t *space);
-H5_DLL herr_t   H5S_select_iterate(void *buf, const H5T_t *type, H5S_t *space, const H5S_sel_iter_op_t *op,
-                                   void *op_data);
-H5_DLL herr_t   H5S_select_fill(const void *fill, size_t fill_size, H5S_t *space, void *buf);
-H5_DLL htri_t   H5S_select_valid(const H5S_t *space);
-H5_DLL hsize_t  H5S_get_select_npoints(const H5S_t *space);
-H5_DLL herr_t   H5S_get_select_bounds(const H5S_t *space, hsize_t *start, hsize_t *end);
-H5_DLL herr_t   H5S_get_select_offset(const H5S_t *space, hsize_t *offset);
-H5_DLL int      H5S_get_select_unlim_dim(const H5S_t *space);
-H5_DLL herr_t   H5S_get_select_num_elem_non_unlim(const H5S_t *space, hsize_t *num_elem_non_unlim);
-H5_DLL herr_t   H5S_select_offset(H5S_t *space, const hssize_t *offset);
-H5_DLL herr_t   H5S_select_copy(H5S_t *dst, const H5S_t *src, bool share_selection);
-H5_DLL htri_t   H5S_select_shape_same(H5S_t *space1, H5S_t *space2);
-H5_DLL htri_t   H5S_select_intersect_block(H5S_t *space, const hsize_t *start, const hsize_t *end);
-H5_DLL herr_t   H5S_select_construct_projection(H5S_t *base_space, H5S_t **new_space_ptr,
-                                                unsigned new_space_rank, hsize_t element_size,
-                                                ptrdiff_t *buf_adj);
-H5_DLL herr_t   H5S_select_release(H5S_t *ds);
-H5_DLL hssize_t H5S_select_serial_size(H5S_t *space);
-H5_DLL herr_t   H5S_select_serialize(H5S_t *space, uint8_t **p);
-H5_DLL htri_t   H5S_select_is_contiguous(const H5S_t *space);
-H5_DLL htri_t   H5S_select_is_single(const H5S_t *space);
-H5_DLL htri_t   H5S_select_is_regular(H5S_t *space);
-H5_DLL herr_t   H5S_select_adjust_u(H5S_t *space, const hsize_t *offset);
-H5_DLL herr_t   H5S_select_adjust_s(H5S_t *space, const hssize_t *offset);
-H5_DLL herr_t   H5S_select_project_scalar(const H5S_t *space, hsize_t *offset);
-H5_DLL herr_t   H5S_select_project_simple(const H5S_t *space, H5S_t *new_space, hsize_t *offset);
+H5_DLL herr_t       H5S_select_iterate(void *buf, H5T_t *type, H5S_t *space, const H5S_sel_iter_op_t *op,
+                                       void *op_data);
+H5_DLL herr_t       H5S_select_fill(const void *fill, size_t fill_size, H5S_t *space, void *buf);
+H5_DLL htri_t       H5S_select_valid(const H5S_t *space);
+H5_DLL hsize_t      H5S_get_select_npoints(const H5S_t *space);
+H5_DLL herr_t       H5S_get_select_bounds(const H5S_t *space, hsize_t *start, hsize_t *end);
+H5_DLL herr_t       H5S_get_select_offset(const H5S_t *space, hsize_t *offset);
+H5_DLL int          H5S_get_select_unlim_dim(const H5S_t *space);
+H5_DLL herr_t       H5S_get_select_num_elem_non_unlim(const H5S_t *space, hsize_t *num_elem_non_unlim);
+H5_DLL herr_t       H5S_select_offset(H5S_t *space, const hssize_t *offset);
+H5_DLL herr_t       H5S_select_copy(H5S_t *dst, const H5S_t *src, bool share_selection);
+H5_DLL htri_t       H5S_select_shape_same(H5S_t *space1, H5S_t *space2);
+H5_DLL htri_t       H5S_select_intersect_block(H5S_t *space, const hsize_t *start, const hsize_t *end);
+H5_DLL herr_t       H5S_select_construct_projection(H5S_t *base_space, H5S_t **new_space_ptr,
+                                                    unsigned new_space_rank, hsize_t element_size,
+                                                    ptrdiff_t *buf_adj);
+H5_DLL herr_t       H5S_select_release(H5S_t *ds);
+H5_DLL hssize_t     H5S_select_serial_size(H5S_t *space);
+H5_DLL herr_t       H5S_select_serialize(H5S_t *space, uint8_t **p);
+H5_DLL htri_t       H5S_select_is_contiguous(const H5S_t *space);
+H5_DLL htri_t       H5S_select_is_single(const H5S_t *space);
+H5_DLL htri_t       H5S_select_is_regular(H5S_t *space);
+H5_DLL herr_t       H5S_select_adjust_u(H5S_t *space, const hsize_t *offset);
+H5_DLL herr_t       H5S_select_adjust_s(H5S_t *space, const hssize_t *offset);
+H5_DLL herr_t       H5S_select_project_scalar(const H5S_t *space, hsize_t *offset);
+H5_DLL herr_t       H5S_select_project_simple(const H5S_t *space, H5S_t *new_space, hsize_t *offset);
 H5_DLL herr_t H5S_select_project_intersection(H5S_t *src_space, H5S_t *dst_space, H5S_t *src_intersect_space,
                                               H5S_t **new_space_ptr, bool share_space);
 H5_DLL herr_t H5S_select_subtract(H5S_t *space, H5S_t *subtract_space);

--- a/src/H5Sselect.c
+++ b/src/H5Sselect.c
@@ -1357,7 +1357,7 @@ H5S_select_iter_release(H5S_sel_iter_t *sel_iter)
         the selection is not modified.
 --------------------------------------------------------------------------*/
 herr_t
-H5S_select_iterate(void *buf, const H5T_t *type, H5S_t *space, const H5S_sel_iter_op_t *op, void *op_data)
+H5S_select_iterate(void *buf, H5T_t *type, H5S_t *space, const H5S_sel_iter_op_t *op, void *op_data)
 {
     H5S_sel_iter_t *iter      = NULL;         /* Selection iteration info */
     bool            iter_init = false;        /* Selection iteration info has been initialized */

--- a/src/H5T.c
+++ b/src/H5T.c
@@ -1498,8 +1498,8 @@ H5T_top_term_package(void)
                     }                          /* end if */
                 }                              /* end if */
                 else {
-                    if ((path->conv.u.lib_func)((hid_t)FAIL, (hid_t)FAIL, &(path->cdata), (size_t)0,
-                                                (size_t)0, (size_t)0, NULL, NULL) < 0) {
+                    if ((path->conv.u.lib_func)(NULL, NULL, &(path->cdata), NULL, (size_t)0, (size_t)0,
+                                                (size_t)0, NULL, NULL) < 0) {
 #ifdef H5T_DEBUG
                         if (H5DEBUG(T)) {
                             fprintf(H5DEBUG(T),
@@ -2456,13 +2456,16 @@ done:
 static herr_t
 H5T__register(H5T_pers_t pers, const char *name, H5T_t *src, H5T_t *dst, H5T_conv_func_t *conv)
 {
-    hid_t       tmp_sid = -1, tmp_did = -1; /*temporary data type IDs    */
-    H5T_path_t *old_path = NULL;            /*existing conversion path   */
-    H5T_path_t *new_path = NULL;            /*new conversion path        */
-    H5T_cdata_t cdata;                      /*temporary conversion data  */
-    int         nprint = 0;                 /*number of paths shut down  */
-    int         i;                          /*counter                    */
-    herr_t      ret_value = SUCCEED;        /*return value               */
+    H5T_path_t *old_path = NULL;             /*existing conversion path   */
+    H5T_path_t *new_path = NULL;             /*new conversion path        */
+    H5T_cdata_t cdata;                       /*temporary conversion data  */
+    H5T_t      *tmp_stype = NULL;            /*temporary source datatype */
+    H5T_t      *tmp_dtype = NULL;            /*temporary destination datatype */
+    hid_t       tmp_sid   = H5I_INVALID_HID; /*temporary datatype ID */
+    hid_t       tmp_did   = H5I_INVALID_HID; /*temporary datatype ID */
+    int         nprint    = 0;               /*number of paths shut down  */
+    int         i;                           /*counter                    */
+    herr_t      ret_value = SUCCEED;         /*return value               */
 
     FUNC_ENTER_PACKAGE
 
@@ -2523,27 +2526,36 @@ H5T__register(H5T_pers_t pers, const char *name, H5T_t *src, H5T_t *dst, H5T_con
                 old_path->dst->shared->type != dst->shared->type)
                 continue;
 
-            if ((tmp_sid = H5I_register(H5I_DATATYPE, H5T_copy(old_path->src, H5T_COPY_ALL), false)) < 0 ||
-                (tmp_did = H5I_register(H5I_DATATYPE, H5T_copy(old_path->dst, H5T_COPY_ALL), false)) < 0)
-                HGOTO_ERROR(H5E_DATATYPE, H5E_CANTREGISTER, FAIL,
-                            "unable to register data types for conv query");
+            if (NULL == (tmp_stype = H5T_copy(old_path->src, H5T_COPY_ALL)))
+                HGOTO_ERROR(H5E_DATATYPE, H5E_CANTCOPY, FAIL, "unable to copy src datatype");
+            if (NULL == (tmp_dtype = H5T_copy(old_path->dst, H5T_COPY_ALL)))
+                HGOTO_ERROR(H5E_DATATYPE, H5E_CANTCOPY, FAIL, "unable to copy dst datatype");
+
             memset(&cdata, 0, sizeof cdata);
             cdata.command = H5T_CONV_INIT;
             if (conv->is_app) {
+                if ((tmp_sid = H5I_register(H5I_DATATYPE, tmp_stype, false)) < 0)
+                    HGOTO_ERROR(H5E_DATATYPE, H5E_CANTREGISTER, FAIL,
+                                "unable to register ID for source datatype");
+                if ((tmp_did = H5I_register(H5I_DATATYPE, tmp_dtype, false)) < 0)
+                    HGOTO_ERROR(H5E_DATATYPE, H5E_CANTREGISTER, FAIL,
+                                "unable to register ID for destination datatype");
+
                 if ((conv->u.app_func)(tmp_sid, tmp_did, &cdata, (size_t)0, (size_t)0, (size_t)0, NULL, NULL,
                                        H5CX_get_dxpl()) < 0) {
                     H5I_dec_ref(tmp_sid);
                     H5I_dec_ref(tmp_did);
-                    tmp_sid = tmp_did = -1;
+                    tmp_sid = tmp_did = H5I_INVALID_HID;
+                    tmp_stype = tmp_dtype = NULL;
                     H5E_clear_stack(NULL);
                     continue;
                 } /* end if */
             }     /* end if */
-            else if ((conv->u.lib_func)(tmp_sid, tmp_did, &cdata, (size_t)0, (size_t)0, (size_t)0, NULL,
-                                        NULL) < 0) {
-                H5I_dec_ref(tmp_sid);
-                H5I_dec_ref(tmp_did);
-                tmp_sid = tmp_did = -1;
+            else if ((conv->u.lib_func)(tmp_stype, tmp_dtype, &cdata, NULL, (size_t)0, (size_t)0, (size_t)0,
+                                        NULL, NULL) < 0) {
+                H5T_close(tmp_stype);
+                H5T_close(tmp_dtype);
+                tmp_stype = tmp_dtype = NULL;
                 H5E_clear_stack(NULL);
                 continue;
             } /* end if */
@@ -2579,8 +2591,8 @@ H5T__register(H5T_pers_t pers, const char *name, H5T_t *src, H5T_t *dst, H5T_con
 #endif
                 } /* end if */
             }     /* end if */
-            else if ((old_path->conv.u.lib_func)(tmp_sid, tmp_did, &(old_path->cdata), (size_t)0, (size_t)0,
-                                                 (size_t)0, NULL, NULL) < 0) {
+            else if ((old_path->conv.u.lib_func)(tmp_stype, tmp_dtype, &(old_path->cdata), NULL, (size_t)0,
+                                                 (size_t)0, (size_t)0, NULL, NULL) < 0) {
 #ifdef H5T_DEBUG
                 if (H5DEBUG(T))
                     fprintf(H5DEBUG(T),
@@ -2594,9 +2606,28 @@ H5T__register(H5T_pers_t pers, const char *name, H5T_t *src, H5T_t *dst, H5T_con
             old_path = H5FL_FREE(H5T_path_t, old_path);
 
             /* Release temporary atoms */
-            H5I_dec_ref(tmp_sid);
-            H5I_dec_ref(tmp_did);
-            tmp_sid = tmp_did = -1;
+            if (tmp_sid >= 0) {
+                if (H5I_dec_ref(tmp_sid) < 0)
+                    HGOTO_ERROR(H5E_DATATYPE, H5E_CANTDEC, FAIL, "can't decrement reference on temporary ID");
+                tmp_sid   = H5I_INVALID_HID;
+                tmp_stype = NULL;
+            }
+            else if (tmp_stype) {
+                if (H5T_close(tmp_stype) < 0)
+                    HGOTO_ERROR(H5E_DATATYPE, H5E_CANTCLOSEOBJ, FAIL, "can't close temporary datatype");
+                tmp_stype = NULL;
+            }
+            if (tmp_did >= 0) {
+                if (H5I_dec_ref(tmp_did) < 0)
+                    HGOTO_ERROR(H5E_DATATYPE, H5E_CANTDEC, FAIL, "can't decrement reference on temporary ID");
+                tmp_did   = H5I_INVALID_HID;
+                tmp_dtype = NULL;
+            }
+            else if (tmp_dtype) {
+                if (H5T_close(tmp_dtype) < 0)
+                    HGOTO_ERROR(H5E_DATATYPE, H5E_CANTCLOSEOBJ, FAIL, "can't close temporary datatype");
+                tmp_dtype = NULL;
+            }
 
             /* We don't care about any failures during the freeing process */
             H5E_clear_stack(NULL);
@@ -2612,11 +2643,24 @@ done:
                 (void)H5T_close_real(new_path->dst);
             new_path = H5FL_FREE(H5T_path_t, new_path);
         } /* end if */
-        if (tmp_sid >= 0)
-            H5I_dec_ref(tmp_sid);
-        if (tmp_did >= 0)
-            H5I_dec_ref(tmp_did);
-    } /* end if */
+    }     /* end if */
+
+    if (tmp_sid >= 0) {
+        if (H5I_dec_ref(tmp_sid) < 0)
+            HDONE_ERROR(H5E_DATATYPE, H5E_CANTDEC, FAIL, "can't decrement reference on temporary ID");
+    }
+    else if (tmp_stype) {
+        if (H5T_close(tmp_stype) < 0)
+            HDONE_ERROR(H5E_DATATYPE, H5E_CANTCLOSEOBJ, FAIL, "can't close temporary datatype");
+    }
+    if (tmp_did >= 0) {
+        if (H5I_dec_ref(tmp_did) < 0)
+            HDONE_ERROR(H5E_DATATYPE, H5E_CANTDEC, FAIL, "can't decrement reference on temporary ID");
+    }
+    else if (tmp_dtype) {
+        if (H5T_close(tmp_dtype) < 0)
+            HDONE_ERROR(H5E_DATATYPE, H5E_CANTCLOSEOBJ, FAIL, "can't close temporary datatype");
+    }
 
     FUNC_LEAVE_NOAPI(ret_value)
 } /* end H5T__register() */
@@ -2769,7 +2813,7 @@ H5T_unregister(H5T_pers_t pers, const char *name, H5T_t *src, H5T_t *dst, H5VL_o
 #endif
                 } /* end if */
             }     /* end if */
-            else if ((path->conv.u.lib_func)((hid_t)FAIL, (hid_t)FAIL, &(path->cdata), (size_t)0, (size_t)0,
+            else if ((path->conv.u.lib_func)(NULL, NULL, &(path->cdata), NULL, (size_t)0, (size_t)0,
                                              (size_t)0, NULL, NULL) < 0) {
 #ifdef H5T_DEBUG
                 if (H5DEBUG(T))
@@ -2952,7 +2996,7 @@ H5Tconvert(hid_t src_id, hid_t dst_id, size_t nelmts, void *buf, void *backgroun
     if (NULL == (tpath = H5T_path_find(src, dst)))
         HGOTO_ERROR(H5E_DATATYPE, H5E_CANTINIT, FAIL, "unable to convert between src and dst data types");
 
-    if (H5T_convert(tpath, src_id, dst_id, nelmts, (size_t)0, (size_t)0, buf, background) < 0)
+    if (H5T_convert(tpath, src, dst, nelmts, (size_t)0, (size_t)0, buf, background) < 0)
         HGOTO_ERROR(H5E_DATATYPE, H5E_CANTINIT, FAIL, "data type conversion failed");
 
 done:
@@ -2974,6 +3018,7 @@ done:
 herr_t
 H5Treclaim(hid_t type_id, hid_t space_id, hid_t dxpl_id, void *buf)
 {
+    H5T_t *type;
     H5S_t *space;     /* Dataspace for iteration */
     herr_t ret_value; /* Return value */
 
@@ -2981,8 +3026,10 @@ H5Treclaim(hid_t type_id, hid_t space_id, hid_t dxpl_id, void *buf)
     H5TRACE4("e", "iii*x", type_id, space_id, dxpl_id, buf);
 
     /* Check args */
-    if (H5I_DATATYPE != H5I_get_type(type_id) || buf == NULL)
-        HGOTO_ERROR(H5E_ARGS, H5E_BADVALUE, FAIL, "invalid argument");
+    if (buf == NULL)
+        HGOTO_ERROR(H5E_ARGS, H5E_BADVALUE, FAIL, "'buf' pointer is NULL");
+    if (NULL == (type = (H5T_t *)H5I_object_verify(type_id, H5I_DATATYPE)))
+        HGOTO_ERROR(H5E_ARGS, H5E_BADTYPE, FAIL, "invalid datatype");
     if (NULL == (space = (H5S_t *)H5I_object_verify(space_id, H5I_DATASPACE)))
         HGOTO_ERROR(H5E_ARGS, H5E_BADTYPE, FAIL, "invalid dataspace");
     if (!(H5S_has_extent(space)))
@@ -2998,7 +3045,7 @@ H5Treclaim(hid_t type_id, hid_t space_id, hid_t dxpl_id, void *buf)
     H5CX_set_dxpl(dxpl_id);
 
     /* Call internal routine */
-    ret_value = H5T_reclaim(type_id, space, buf);
+    ret_value = H5T_reclaim(type, space, buf);
 
 done:
     FUNC_LEAVE_API(ret_value)
@@ -4876,16 +4923,19 @@ done:
 static H5T_path_t *
 H5T__path_find_real(const H5T_t *src, const H5T_t *dst, const char *name, H5T_conv_func_t *conv)
 {
-    int         lt, rt;                   /* left and right edges */
-    int         md;                       /* middle */
-    int         cmp;                      /* comparison result  */
-    int         old_npaths;               /* Previous number of paths in table */
-    H5T_path_t *table  = NULL;            /* path existing in the table */
-    H5T_path_t *path   = NULL;            /* new path */
-    hid_t       src_id = -1, dst_id = -1; /* src and dst type identifiers */
-    int         i;                        /* counter */
-    int         nprint    = 0;            /* lines of output printed */
-    H5T_path_t *ret_value = NULL;         /* Return value */
+    int         lt, rt;                      /* left and right edges */
+    int         md;                          /* middle */
+    int         cmp;                         /* comparison result  */
+    int         old_npaths;                  /* Previous number of paths in table */
+    H5T_path_t *table     = NULL;            /* path existing in the table */
+    H5T_path_t *path      = NULL;            /* new path */
+    H5T_t      *tmp_stype = NULL;            /* temporary source datatype */
+    H5T_t      *tmp_dtype = NULL;            /* temporary destination datatype */
+    hid_t       src_id    = H5I_INVALID_HID; /* source datatype identifier */
+    hid_t       dst_id    = H5I_INVALID_HID; /* destination datatype identifier */
+    int         i;                           /* counter */
+    int         nprint    = 0;               /* lines of output printed */
+    H5T_path_t *ret_value = NULL;            /* Return value */
 
     FUNC_ENTER_PACKAGE
 
@@ -4910,8 +4960,8 @@ H5T__path_find_real(const H5T_t *src, const H5T_t *dst, const char *name, H5T_co
         H5T_g.path[0]->conv.is_app     = false;
         H5T_g.path[0]->conv.u.lib_func = H5T__conv_noop;
         H5T_g.path[0]->cdata.command   = H5T_CONV_INIT;
-        if (H5T__conv_noop((hid_t)FAIL, (hid_t)FAIL, &(H5T_g.path[0]->cdata), (size_t)0, (size_t)0, (size_t)0,
-                           NULL, NULL) < 0) {
+        if (H5T__conv_noop(NULL, NULL, &(H5T_g.path[0]->cdata), NULL, (size_t)0, (size_t)0, (size_t)0, NULL,
+                           NULL) < 0) {
 #ifdef H5T_DEBUG
             if (H5DEBUG(T))
                 fprintf(H5DEBUG(T), "H5T: unable to initialize no-op conversion function (ignored)\n");
@@ -4993,28 +5043,53 @@ H5T__path_find_real(const H5T_t *src, const H5T_t *dst, const char *name, H5T_co
         (!table || (table && conv->is_app) || (table && !table->is_hard && !conv->is_app))) {
         assert(path != table);
         assert(NULL == path->conv.u.app_func);
-        if (path->src && (src_id = H5I_register(H5I_DATATYPE, H5T_copy(path->src, H5T_COPY_ALL), false)) < 0)
-            HGOTO_ERROR(H5E_DATATYPE, H5E_CANTREGISTER, NULL,
-                        "unable to register source conversion type for query");
-        if (path->dst && (dst_id = H5I_register(H5I_DATATYPE, H5T_copy(path->dst, H5T_COPY_ALL), false)) < 0)
-            HGOTO_ERROR(H5E_DATATYPE, H5E_CANTREGISTER, NULL,
-                        "unable to register destination conversion type for query");
+        if (path->src && (NULL == (tmp_stype = H5T_copy(path->src, H5T_COPY_ALL))))
+            HGOTO_ERROR(H5E_DATATYPE, H5E_CANTCOPY, NULL, "unable to copy source datatype");
+        if (path->dst && (NULL == (tmp_dtype = H5T_copy(path->dst, H5T_COPY_ALL))))
+            HGOTO_ERROR(H5E_DATATYPE, H5E_CANTCOPY, NULL, "unable to copy destination datatype");
+
         path->cdata.command = H5T_CONV_INIT;
         if (conv->is_app) {
+            if (tmp_stype && ((src_id = H5I_register(H5I_DATATYPE, tmp_stype, false)) < 0))
+                HGOTO_ERROR(H5E_DATATYPE, H5E_CANTREGISTER, NULL,
+                            "unable to register ID for source datatype");
+            if (tmp_dtype && ((dst_id = H5I_register(H5I_DATATYPE, tmp_dtype, false)) < 0))
+                HGOTO_ERROR(H5E_DATATYPE, H5E_CANTREGISTER, NULL,
+                            "unable to register ID for destination datatype");
+
             if ((conv->u.app_func)(src_id, dst_id, &(path->cdata), (size_t)0, (size_t)0, (size_t)0, NULL,
                                    NULL, H5CX_get_dxpl()) < 0)
                 HGOTO_ERROR(H5E_DATATYPE, H5E_CANTINIT, NULL, "unable to initialize conversion function");
         } /* end if */
-        else if ((conv->u.lib_func)(src_id, dst_id, &(path->cdata), (size_t)0, (size_t)0, (size_t)0, NULL,
-                                    NULL) < 0)
+        else if ((conv->u.lib_func)(tmp_stype, tmp_dtype, &(path->cdata), NULL, (size_t)0, (size_t)0,
+                                    (size_t)0, NULL, NULL) < 0)
             HGOTO_ERROR(H5E_DATATYPE, H5E_CANTINIT, NULL, "unable to initialize conversion function");
-        if (src_id >= 0)
-            H5I_dec_ref(src_id);
-        if (dst_id >= 0)
-            H5I_dec_ref(dst_id);
-        src_id = dst_id = -1;
-        path->conv      = *conv;
-        path->is_hard   = true;
+
+        if (src_id >= 0) {
+            if (H5I_dec_ref(src_id) < 0)
+                HGOTO_ERROR(H5E_DATATYPE, H5E_CANTDEC, NULL, "can't decrement reference on temporary ID");
+            src_id    = H5I_INVALID_HID;
+            tmp_stype = NULL;
+        }
+        else if (tmp_stype) {
+            if (H5T_close(tmp_stype) < 0)
+                HGOTO_ERROR(H5E_DATATYPE, H5E_CANTCLOSEOBJ, NULL, "can't close temporary datatype");
+            tmp_stype = NULL;
+        }
+        if (dst_id >= 0) {
+            if (H5I_dec_ref(dst_id) < 0)
+                HGOTO_ERROR(H5E_DATATYPE, H5E_CANTDEC, NULL, "can't decrement reference on temporary ID");
+            dst_id    = H5I_INVALID_HID;
+            tmp_dtype = NULL;
+        }
+        else if (tmp_dtype) {
+            if (H5T_close(tmp_dtype) < 0)
+                HGOTO_ERROR(H5E_DATATYPE, H5E_CANTCLOSEOBJ, NULL, "can't close temporary datatype");
+            tmp_dtype = NULL;
+        }
+
+        path->conv    = *conv;
+        path->is_hard = true;
     } /* end if */
 
     /*
@@ -5029,14 +5104,27 @@ H5T__path_find_real(const H5T_t *src, const H5T_t *dst, const char *name, H5T_co
 
         if (src->shared->type != H5T_g.soft[i].src || dst->shared->type != H5T_g.soft[i].dst)
             continue;
-        if ((src_id = H5I_register(H5I_DATATYPE, H5T_copy(path->src, H5T_COPY_ALL), false)) < 0)
-            HGOTO_ERROR(H5E_DATATYPE, H5E_CANTREGISTER, NULL,
-                        "unable to register src conversion type for query");
-        if ((dst_id = H5I_register(H5I_DATATYPE, H5T_copy(path->dst, H5T_COPY_ALL), false)) < 0)
-            HGOTO_ERROR(H5E_DATATYPE, H5E_CANTREGISTER, NULL,
-                        "unable to register dst conversion type for query");
+
+        assert(tmp_stype == NULL);
+        assert(tmp_dtype == NULL);
+
+        if (NULL == (tmp_stype = H5T_copy(path->src, H5T_COPY_ALL)))
+            HGOTO_ERROR(H5E_DATATYPE, H5E_CANTCOPY, NULL, "unable to copy source datatype");
+        if (NULL == (tmp_dtype = H5T_copy(path->dst, H5T_COPY_ALL)))
+            HGOTO_ERROR(H5E_DATATYPE, H5E_CANTCOPY, NULL, "unable to copy destination datatype");
+
         path->cdata.command = H5T_CONV_INIT;
         if (H5T_g.soft[i].conv.is_app) {
+            assert(src_id == H5I_INVALID_HID);
+            assert(dst_id == H5I_INVALID_HID);
+
+            if ((src_id = H5I_register(H5I_DATATYPE, tmp_stype, false)) < 0)
+                HGOTO_ERROR(H5E_DATATYPE, H5E_CANTREGISTER, NULL,
+                            "unable to register ID for source datatype");
+            if ((dst_id = H5I_register(H5I_DATATYPE, tmp_dtype, false)) < 0)
+                HGOTO_ERROR(H5E_DATATYPE, H5E_CANTREGISTER, NULL,
+                            "unable to register ID for destination datatype");
+
             if ((H5T_g.soft[i].conv.u.app_func)(src_id, dst_id, &(path->cdata), (size_t)0, (size_t)0,
                                                 (size_t)0, NULL, NULL, H5CX_get_dxpl()) < 0) {
                 memset(&(path->cdata), 0, sizeof(H5T_cdata_t));
@@ -5044,8 +5132,8 @@ H5T__path_find_real(const H5T_t *src, const H5T_t *dst, const char *name, H5T_co
                 path_init_error = true;
             } /* end if */
         }     /* end if */
-        else if ((H5T_g.soft[i].conv.u.lib_func)(src_id, dst_id, &(path->cdata), (size_t)0, (size_t)0,
-                                                 (size_t)0, NULL, NULL) < 0) {
+        else if ((H5T_g.soft[i].conv.u.lib_func)(tmp_stype, tmp_dtype, &(path->cdata), NULL, (size_t)0,
+                                                 (size_t)0, (size_t)0, NULL, NULL) < 0) {
             memset(&(path->cdata), 0, sizeof(H5T_cdata_t));
             H5E_clear_stack(NULL); /*ignore the error*/
             path_init_error = true;
@@ -5058,9 +5146,29 @@ H5T__path_find_real(const H5T_t *src, const H5T_t *dst, const char *name, H5T_co
             path->conv                  = H5T_g.soft[i].conv;
             path->is_hard               = false;
         } /* end else */
-        H5I_dec_ref(src_id);
-        H5I_dec_ref(dst_id);
-        src_id = dst_id = -1;
+
+        if (src_id >= 0) {
+            if (H5I_dec_ref(src_id) < 0)
+                HGOTO_ERROR(H5E_DATATYPE, H5E_CANTDEC, NULL, "can't decrement reference on temporary ID");
+            src_id    = H5I_INVALID_HID;
+            tmp_stype = NULL;
+        }
+        else if (tmp_stype) {
+            if (H5T_close(tmp_stype) < 0)
+                HGOTO_ERROR(H5E_DATATYPE, H5E_CANTCLOSEOBJ, NULL, "can't close temporary datatype");
+            tmp_stype = NULL;
+        }
+        if (dst_id >= 0) {
+            if (H5I_dec_ref(dst_id) < 0)
+                HGOTO_ERROR(H5E_DATATYPE, H5E_CANTDEC, NULL, "can't decrement reference on temporary ID");
+            dst_id    = H5I_INVALID_HID;
+            tmp_dtype = NULL;
+        }
+        else if (tmp_dtype) {
+            if (H5T_close(tmp_dtype) < 0)
+                HGOTO_ERROR(H5E_DATATYPE, H5E_CANTCLOSEOBJ, NULL, "can't close temporary datatype");
+            tmp_dtype = NULL;
+        }
     } /* end for */
     if (!path->conv.u.app_func)
         HGOTO_ERROR(H5E_DATATYPE, H5E_CANTINIT, NULL, "no appropriate function for conversion path");
@@ -5104,8 +5212,8 @@ H5T__path_find_real(const H5T_t *src, const H5T_t *dst, const char *name, H5T_co
                 H5E_clear_stack(NULL); /*ignore the failure*/
             }                          /* end if */
         }                              /* end if */
-        else if ((table->conv.u.lib_func)((hid_t)FAIL, (hid_t)FAIL, &(table->cdata), (size_t)0, (size_t)0,
-                                          (size_t)0, NULL, NULL) < 0) {
+        else if ((table->conv.u.lib_func)(NULL, NULL, &(table->cdata), NULL, (size_t)0, (size_t)0, (size_t)0,
+                                          NULL, NULL) < 0) {
 #ifdef H5T_DEBUG
             if (H5DEBUG(T))
                 fprintf(H5DEBUG(T), "H5T: conversion function 0x%016zx free failed for %s (ignored)\n",
@@ -5159,10 +5267,23 @@ done:
             (void)H5T_close_real(path->dst);
         path = H5FL_FREE(H5T_path_t, path);
     } /* end if */
-    if (src_id >= 0)
-        H5I_dec_ref(src_id);
-    if (dst_id >= 0)
-        H5I_dec_ref(dst_id);
+
+    if (src_id >= 0) {
+        if (H5I_dec_ref(src_id) < 0)
+            HDONE_ERROR(H5E_DATATYPE, H5E_CANTDEC, NULL, "can't decrement reference on temporary ID");
+    }
+    else if (tmp_stype) {
+        if (H5T_close(tmp_stype) < 0)
+            HDONE_ERROR(H5E_DATATYPE, H5E_CANTCLOSEOBJ, NULL, "can't close temporary datatype");
+    }
+    if (dst_id >= 0) {
+        if (H5I_dec_ref(dst_id) < 0)
+            HDONE_ERROR(H5E_DATATYPE, H5E_CANTDEC, NULL, "can't decrement reference on temporary ID");
+    }
+    else if (tmp_dtype) {
+        if (H5T_close(tmp_dtype) < 0)
+            HDONE_ERROR(H5E_DATATYPE, H5E_CANTCLOSEOBJ, NULL, "can't close temporary datatype");
+    }
 
     FUNC_LEAVE_NOAPI(ret_value)
 } /* end H5T__path_find_real() */
@@ -5337,13 +5458,16 @@ done:
  *-------------------------------------------------------------------------
  */
 herr_t
-H5T_convert(H5T_path_t *tpath, hid_t src_id, hid_t dst_id, size_t nelmts, size_t buf_stride,
+H5T_convert(H5T_path_t *tpath, H5T_t *src_type, H5T_t *dst_type, size_t nelmts, size_t buf_stride,
             size_t bkg_stride, void *buf, void *bkg)
 {
+    H5T_conv_ctx_t conv_ctx = {0};
 #ifdef H5T_DEBUG
-    H5_timer_t timer; /* Timer for conversion */
+    H5_timer_t timer = {0}; /* Timer for conversion */
 #endif
-    herr_t ret_value = SUCCEED; /* Return value */
+    hid_t  src_type_id = H5I_INVALID_HID;
+    hid_t  dst_type_id = H5I_INVALID_HID;
+    herr_t ret_value   = SUCCEED;
 
     FUNC_ENTER_NOAPI(FAIL)
 
@@ -5355,16 +5479,42 @@ H5T_convert(H5T_path_t *tpath, hid_t src_id, hid_t dst_id, size_t nelmts, size_t
     } /* end if */
 #endif
 
-    /* Call the appropriate conversion callback */
-    tpath->cdata.command = H5T_CONV_CONV;
-    if (tpath->conv.is_app) {
-        if ((tpath->conv.u.app_func)(src_id, dst_id, &(tpath->cdata), nelmts, buf_stride, bkg_stride, buf,
-                                     bkg, H5CX_get_dxpl()) < 0)
-            HGOTO_ERROR(H5E_DATATYPE, H5E_CANTCONVERT, FAIL, "datatype conversion failed");
-    } /* end if */
-    else if ((tpath->conv.u.lib_func)(src_id, dst_id, &(tpath->cdata), nelmts, buf_stride, bkg_stride, buf,
-                                      bkg) < 0)
+    /* Get the datatype conversion exception callback structure from the API context */
+    if (H5CX_get_dt_conv_cb(&conv_ctx.cb_struct) < 0)
+        HGOTO_ERROR(H5E_DATATYPE, H5E_CANTGET, FAIL, "unable to get conversion exception callback");
+
+    /*
+     * If this is an application conversion function or an exception callback
+     * function was supplied, register IDs for the datatypes so we can pass
+     * those as appropriate. Also grab the DXPL if necessary so we can pass
+     * that to the app conversion function.
+     */
+    if (tpath->conv.is_app || conv_ctx.cb_struct.func) {
+        if ((src_type_id = H5I_register(H5I_DATATYPE, src_type, false)) < 0)
+            HGOTO_ERROR(H5E_DATATYPE, H5E_CANTREGISTER, FAIL, "unable to register ID for source datatype");
+        if ((dst_type_id = H5I_register(H5I_DATATYPE, dst_type, false)) < 0)
+            HGOTO_ERROR(H5E_DATATYPE, H5E_CANTREGISTER, FAIL,
+                        "unable to register ID for destination datatype");
+
+        if (tpath->conv.is_app)
+            conv_ctx.dxpl_id = H5CX_get_dxpl();
+    }
+    conv_ctx.src_type_id = src_type_id;
+    conv_ctx.dst_type_id = dst_type_id;
+
+    if (H5T_convert_with_ctx(tpath, src_type, dst_type, &conv_ctx, nelmts, buf_stride, bkg_stride, buf, bkg) <
+        0)
         HGOTO_ERROR(H5E_DATATYPE, H5E_CANTCONVERT, FAIL, "datatype conversion failed");
+
+done:
+    /* Remove IDs, but don't decrement their reference counts, as they
+     * could have been registered for datatypes that weren't copied
+     */
+    if ((src_type_id >= 0) && (NULL == H5I_remove(src_type_id)))
+        HDONE_ERROR(H5E_DATATYPE, H5E_CANTFREE, FAIL, "can't decrement temporary datatype ID");
+    if ((dst_type_id >= 0) && (NULL == H5I_remove(dst_type_id)))
+        HDONE_ERROR(H5E_DATATYPE, H5E_CANTFREE, FAIL, "can't decrement temporary datatype ID");
+
 #ifdef H5T_DEBUG
     if (H5DEBUG(T)) {
         /* Stop timer */
@@ -5379,9 +5529,49 @@ H5T_convert(H5T_path_t *tpath, hid_t src_id, hid_t dst_id, size_t nelmts, size_t
     } /* end if */
 #endif
 
-done:
     FUNC_LEAVE_NOAPI(ret_value)
 } /* end H5T_convert() */
+
+/*-------------------------------------------------------------------------
+ * Function:  H5T_convert_with_ctx
+ *
+ * Purpose:   Helper routine for H5T_convert that accepts a pointer to a
+ *            H5T_conv_ctx_t conversion context structure. Useful for
+ *            conversion routines involving container datatypes, such as
+ *            compounds, where the conversion context structure that was
+ *            setup during the initial H5T_convert call can be reused.
+ *            This avoids the expensive and unnecessary overhead of
+ *            recreating this structure and possibly re-registering IDs for
+ *            the source and destination datatypes for every single member
+ *            of the container datatype and every single element being
+ *            converted that consists of that container datatype.
+ *
+ * Return:    Non-negative on success/Negative on failure
+ *
+ *-------------------------------------------------------------------------
+ */
+herr_t
+H5T_convert_with_ctx(H5T_path_t *tpath, H5T_t *src_type, H5T_t *dst_type, const H5T_conv_ctx_t *conv_ctx,
+                     size_t nelmts, size_t buf_stride, size_t bkg_stride, void *buf, void *bkg)
+{
+    herr_t ret_value = SUCCEED;
+
+    FUNC_ENTER_NOAPI(FAIL)
+
+    /* Call the appropriate conversion callback */
+    tpath->cdata.command = H5T_CONV_CONV;
+    if (tpath->conv.is_app) {
+        if ((tpath->conv.u.app_func)(conv_ctx->src_type_id, conv_ctx->dst_type_id, &(tpath->cdata), nelmts,
+                                     buf_stride, bkg_stride, buf, bkg, conv_ctx->dxpl_id) < 0)
+            HGOTO_ERROR(H5E_DATATYPE, H5E_CANTCONVERT, FAIL, "datatype conversion failed");
+    } /* end if */
+    else if ((tpath->conv.u.lib_func)(src_type, dst_type, &(tpath->cdata), conv_ctx, nelmts, buf_stride,
+                                      bkg_stride, buf, bkg) < 0)
+        HGOTO_ERROR(H5E_DATATYPE, H5E_CANTCONVERT, FAIL, "datatype conversion failed");
+
+done:
+    FUNC_LEAVE_NOAPI(ret_value)
+} /* end H5T_convert_with_ctx() */
 
 /*-------------------------------------------------------------------------
  * Function:  H5T_oloc

--- a/src/H5Tconv.c
+++ b/src/H5Tconv.c
@@ -186,7 +186,8 @@
     {                                                                                                        \
         if (*(S) > (ST)(D_MAX)) {                                                                            \
             H5T_conv_ret_t except_ret =                                                                      \
-                (cb_struct.func)(H5T_CONV_EXCEPT_RANGE_HI, src_id, dst_id, S, D, cb_struct.user_data);       \
+                (conv_ctx->cb_struct.func)(H5T_CONV_EXCEPT_RANGE_HI, conv_ctx->src_type_id,                  \
+                                           conv_ctx->dst_type_id, S, D, conv_ctx->cb_struct.user_data);      \
             if (except_ret == H5T_CONV_UNHANDLED)                                                            \
                 /* Let compiler convert if case is ignored by user handler*/                                 \
                 *(D) = (DT)(D_MAX);                                                                          \
@@ -196,7 +197,8 @@
         }                                                                                                    \
         else if (*(S) < (ST)(D_MIN)) {                                                                       \
             H5T_conv_ret_t except_ret =                                                                      \
-                (cb_struct.func)(H5T_CONV_EXCEPT_RANGE_LOW, src_id, dst_id, S, D, cb_struct.user_data);      \
+                (conv_ctx->cb_struct.func)(H5T_CONV_EXCEPT_RANGE_LOW, conv_ctx->src_type_id,                 \
+                                           conv_ctx->dst_type_id, S, D, conv_ctx->cb_struct.user_data);      \
             if (except_ret == H5T_CONV_UNHANDLED)                                                            \
                 /* Let compiler convert if case is ignored by user handler*/                                 \
                 *(D) = (DT)(D_MIN);                                                                          \
@@ -223,7 +225,8 @@
     {                                                                                                        \
         if (*(S) > (ST)(D_MAX)) {                                                                            \
             H5T_conv_ret_t except_ret =                                                                      \
-                (cb_struct.func)(H5T_CONV_EXCEPT_RANGE_HI, src_id, dst_id, S, D, cb_struct.user_data);       \
+                (conv_ctx->cb_struct.func)(H5T_CONV_EXCEPT_RANGE_HI, conv_ctx->src_type_id,                  \
+                                           conv_ctx->dst_type_id, S, D, conv_ctx->cb_struct.user_data);      \
             if (except_ret == H5T_CONV_UNHANDLED)                                                            \
                 /* Let compiler convert if case is ignored by user handler*/                                 \
                 *(D) = (DT)(D_MAX);                                                                          \
@@ -253,7 +256,8 @@
     {                                                                                                        \
         if (*(S) < 0) {                                                                                      \
             H5T_conv_ret_t except_ret =                                                                      \
-                (cb_struct.func)(H5T_CONV_EXCEPT_RANGE_LOW, src_id, dst_id, S, D, cb_struct.user_data);      \
+                (conv_ctx->cb_struct.func)(H5T_CONV_EXCEPT_RANGE_LOW, conv_ctx->src_type_id,                 \
+                                           conv_ctx->dst_type_id, S, D, conv_ctx->cb_struct.user_data);      \
             if (except_ret == H5T_CONV_UNHANDLED)                                                            \
                 /* Let compiler convert if case is ignored by user handler*/                                 \
                 *(D) = 0;                                                                                    \
@@ -314,7 +318,8 @@
 #define H5T_CONV_uS_CORE_1(S, D, ST, DT, D_MIN, D_MAX)                                                       \
     if (*(S) > (DT)(D_MAX)) {                                                                                \
         H5T_conv_ret_t except_ret =                                                                          \
-            (cb_struct.func)(H5T_CONV_EXCEPT_RANGE_HI, src_id, dst_id, S, D, cb_struct.user_data);           \
+            (conv_ctx->cb_struct.func)(H5T_CONV_EXCEPT_RANGE_HI, conv_ctx->src_type_id,                      \
+                                       conv_ctx->dst_type_id, S, D, conv_ctx->cb_struct.user_data);          \
         if (except_ret == H5T_CONV_UNHANDLED)                                                                \
             /* Let compiler convert if case is ignored by user handler */                                    \
             *(D) = (DT)(D_MAX);                                                                              \
@@ -376,7 +381,8 @@
     {                                                                                                        \
         if (*(S) < 0) {                                                                                      \
             H5T_conv_ret_t except_ret =                                                                      \
-                (cb_struct.func)(H5T_CONV_EXCEPT_RANGE_LOW, src_id, dst_id, S, D, cb_struct.user_data);      \
+                (conv_ctx->cb_struct.func)(H5T_CONV_EXCEPT_RANGE_LOW, conv_ctx->src_type_id,                 \
+                                           conv_ctx->dst_type_id, S, D, conv_ctx->cb_struct.user_data);      \
             if (except_ret == H5T_CONV_UNHANDLED)                                                            \
                 /* Let compiler convert if case is ignored by user handler*/                                 \
                 *(D) = 0;                                                                                    \
@@ -386,7 +392,8 @@
         }                                                                                                    \
         else if (sizeof(ST) > sizeof(DT) && *(S) > (ST)(D_MAX)) {                                            \
             H5T_conv_ret_t except_ret =                                                                      \
-                (cb_struct.func)(H5T_CONV_EXCEPT_RANGE_HI, src_id, dst_id, S, D, cb_struct.user_data);       \
+                (conv_ctx->cb_struct.func)(H5T_CONV_EXCEPT_RANGE_HI, conv_ctx->src_type_id,                  \
+                                           conv_ctx->dst_type_id, S, D, conv_ctx->cb_struct.user_data);      \
             if (except_ret == H5T_CONV_UNHANDLED)                                                            \
                 /* Let compiler convert if case is ignored by user handler*/                                 \
                 *(D) = (DT)(D_MAX);                                                                          \
@@ -430,7 +437,8 @@
         /* Assumes memory format of unsigned & signed integers is same */                                    \
         if (*(S) < 0) {                                                                                      \
             H5T_conv_ret_t except_ret =                                                                      \
-                (cb_struct.func)(H5T_CONV_EXCEPT_RANGE_LOW, src_id, dst_id, S, D, cb_struct.user_data);      \
+                (conv_ctx->cb_struct.func)(H5T_CONV_EXCEPT_RANGE_LOW, conv_ctx->src_type_id,                 \
+                                           conv_ctx->dst_type_id, S, D, conv_ctx->cb_struct.user_data);      \
             if (except_ret == H5T_CONV_UNHANDLED)                                                            \
                 /* Let compiler convert if case is ignored by user handler*/                                 \
                 *(D) = 0;                                                                                    \
@@ -461,7 +469,8 @@
         /* Assumes memory format of unsigned & signed integers is same */                                    \
         if (*(S) > (ST)(D_MAX)) {                                                                            \
             H5T_conv_ret_t except_ret =                                                                      \
-                (cb_struct.func)(H5T_CONV_EXCEPT_RANGE_HI, src_id, dst_id, S, D, cb_struct.user_data);       \
+                (conv_ctx->cb_struct.func)(H5T_CONV_EXCEPT_RANGE_HI, conv_ctx->src_type_id,                  \
+                                           conv_ctx->dst_type_id, S, D, conv_ctx->cb_struct.user_data);      \
             if (except_ret == H5T_CONV_UNHANDLED)                                                            \
                 /* Let compiler convert if case is ignored by user handler*/                                 \
                 *(D) = (DT)(D_MAX);                                                                          \
@@ -500,7 +509,8 @@
     {                                                                                                        \
         if (*(S) > (ST)(D_MAX)) {                                                                            \
             H5T_conv_ret_t except_ret =                                                                      \
-                (cb_struct.func)(H5T_CONV_EXCEPT_RANGE_HI, src_id, dst_id, S, D, cb_struct.user_data);       \
+                (conv_ctx->cb_struct.func)(H5T_CONV_EXCEPT_RANGE_HI, conv_ctx->src_type_id,                  \
+                                           conv_ctx->dst_type_id, S, D, conv_ctx->cb_struct.user_data);      \
             if (except_ret == H5T_CONV_UNHANDLED)                                                            \
                 /* Let compiler convert if case is ignored by user handler*/                                 \
                 *(D) = H5_GLUE3(H5T_NATIVE_, DTYPE, _POS_INF_g);                                             \
@@ -510,7 +520,8 @@
         }                                                                                                    \
         else if (*(S) < (ST)(D_MIN)) {                                                                       \
             H5T_conv_ret_t except_ret =                                                                      \
-                (cb_struct.func)(H5T_CONV_EXCEPT_RANGE_LOW, src_id, dst_id, S, D, cb_struct.user_data);      \
+                (conv_ctx->cb_struct.func)(H5T_CONV_EXCEPT_RANGE_LOW, conv_ctx->src_type_id,                 \
+                                           conv_ctx->dst_type_id, S, D, conv_ctx->cb_struct.user_data);      \
             if (except_ret == H5T_CONV_UNHANDLED)                                                            \
                 /* Let compiler convert if case is ignored by user handler*/                                 \
                 *(D) = H5_GLUE3(H5T_NATIVE_, DTYPE, _NEG_INF_g);                                             \
@@ -608,7 +619,8 @@
             /* Check for more bits of precision in src than available in dst */                              \
             if ((high_bit_pos - low_bit_pos) >= dprec) {                                                     \
                 H5T_conv_ret_t except_ret =                                                                  \
-                    (cb_struct.func)(H5T_CONV_EXCEPT_PRECISION, src_id, dst_id, S, D, cb_struct.user_data);  \
+                    (conv_ctx->cb_struct.func)(H5T_CONV_EXCEPT_PRECISION, conv_ctx->src_type_id,             \
+                                               conv_ctx->dst_type_id, S, D, conv_ctx->cb_struct.user_data);  \
                 if (except_ret == H5T_CONV_UNHANDLED)                                                        \
                     /* Let compiler convert if case is ignored by user handler*/                             \
                     *(D) = (DT)(*(S));                                                                       \
@@ -644,7 +656,8 @@
     {                                                                                                        \
         if (*(S) > (ST)(D_MAX) || (sprec < dprec && *(S) == (ST)(D_MAX))) {                                  \
             H5T_conv_ret_t except_ret =                                                                      \
-                (cb_struct.func)(H5T_CONV_EXCEPT_RANGE_HI, src_id, dst_id, S, D, cb_struct.user_data);       \
+                (conv_ctx->cb_struct.func)(H5T_CONV_EXCEPT_RANGE_HI, conv_ctx->src_type_id,                  \
+                                           conv_ctx->dst_type_id, S, D, conv_ctx->cb_struct.user_data);      \
             if (except_ret == H5T_CONV_UNHANDLED)                                                            \
                 /* Let compiler convert if case is ignored by user handler*/                                 \
                 *(D) = (DT)(D_MAX);                                                                          \
@@ -654,7 +667,8 @@
         }                                                                                                    \
         else if (*(S) < (ST)(D_MIN)) {                                                                       \
             H5T_conv_ret_t except_ret =                                                                      \
-                (cb_struct.func)(H5T_CONV_EXCEPT_RANGE_LOW, src_id, dst_id, S, D, cb_struct.user_data);      \
+                (conv_ctx->cb_struct.func)(H5T_CONV_EXCEPT_RANGE_LOW, conv_ctx->src_type_id,                 \
+                                           conv_ctx->dst_type_id, S, D, conv_ctx->cb_struct.user_data);      \
             if (except_ret == H5T_CONV_UNHANDLED)                                                            \
                 /* Let compiler convert if case is ignored by user handler*/                                 \
                 *(D) = (DT)(D_MIN);                                                                          \
@@ -664,7 +678,8 @@
         }                                                                                                    \
         else if (*(S) != (ST)((DT)(*(S)))) {                                                                 \
             H5T_conv_ret_t except_ret =                                                                      \
-                (cb_struct.func)(H5T_CONV_EXCEPT_TRUNCATE, src_id, dst_id, S, D, cb_struct.user_data);       \
+                (conv_ctx->cb_struct.func)(H5T_CONV_EXCEPT_TRUNCATE, conv_ctx->src_type_id,                  \
+                                           conv_ctx->dst_type_id, S, D, conv_ctx->cb_struct.user_data);      \
             if (except_ret == H5T_CONV_UNHANDLED)                                                            \
                 /* Let compiler convert if case is ignored by user handler*/                                 \
                 *(D) = (DT)(*(S));                                                                           \
@@ -709,28 +724,24 @@
         FUNC_ENTER_PACKAGE                                                                                   \
                                                                                                              \
         {                                                                                                    \
-            size_t elmtno;                    /*element number        */                                     \
-            H5T_CONV_DECL_PREC(PREC)          /*declare precision variables, or not */                       \
-            void         *src_buf;            /*'raw' source buffer        */                                \
-            void         *dst_buf;            /*'raw' destination buffer    */                               \
-            ST           *src, *s;            /*source buffer            */                                  \
-            DT           *dst, *d;            /*destination buffer        */                                 \
-            H5T_t        *st, *dt;            /*datatype descriptors        */                               \
-            ST            src_aligned;        /*source aligned type        */                                \
-            DT            dst_aligned;        /*destination aligned type    */                               \
-            bool          s_mv, d_mv;         /*move data to align it?    */                                 \
-            ssize_t       s_stride, d_stride; /*src and dst strides        */                                \
-            size_t        safe;               /*how many elements are safe to process in each pass */        \
-            H5T_conv_cb_t cb_struct;          /*conversion callback structure */                             \
+            size_t elmtno;              /*element number        */                                           \
+            H5T_CONV_DECL_PREC(PREC)    /*declare precision variables, or not */                             \
+            void   *src_buf;            /*'raw' source buffer        */                                      \
+            void   *dst_buf;            /*'raw' destination buffer    */                                     \
+            ST     *src, *s;            /*source buffer            */                                        \
+            DT     *dst, *d;            /*destination buffer        */                                       \
+            ST      src_aligned;        /*source aligned type        */                                      \
+            DT      dst_aligned;        /*destination aligned type    */                                     \
+            bool    s_mv, d_mv;         /*move data to align it?    */                                       \
+            ssize_t s_stride, d_stride; /*src and dst strides        */                                      \
+            size_t  safe;               /*how many elements are safe to process in each pass */              \
                                                                                                              \
             switch (cdata->command) {                                                                        \
                 case H5T_CONV_INIT:                                                                          \
                     /* Sanity check and initialize statistics */                                             \
                     cdata->need_bkg = H5T_BKG_NO;                                                            \
-                    if (NULL == (st = (H5T_t *)H5I_object(src_id)) ||                                        \
-                        NULL == (dt = (H5T_t *)H5I_object(dst_id)))                                          \
-                        HGOTO_ERROR(H5E_DATATYPE, H5E_CANTINIT, FAIL,                                        \
-                                    "unable to dereference datatype object ID");                             \
+                    if (NULL == st || NULL == dt)                                                            \
+                        HGOTO_ERROR(H5E_DATATYPE, H5E_CANTINIT, FAIL, "invalid datatype");                   \
                     if (st->shared->size != sizeof(ST) || dt->shared->size != sizeof(DT))                    \
                         HGOTO_ERROR(H5E_DATATYPE, H5E_CANTINIT, FAIL, "disagreement about datatype size");   \
                     CI_ALLOC_PRIV                                                                            \
@@ -743,6 +754,12 @@
                     break;                                                                                   \
                                                                                                              \
                 case H5T_CONV_CONV:                                                                          \
+                    if (NULL == st || NULL == dt)                                                            \
+                        HGOTO_ERROR(H5E_DATATYPE, H5E_CANTINIT, FAIL, "invalid datatype");                   \
+                    if (NULL == conv_ctx)                                                                    \
+                        HGOTO_ERROR(H5E_DATATYPE, H5E_CANTINIT, FAIL,                                        \
+                                    "invalid datatype conversion context pointer");                          \
+                                                                                                             \
                     /* Initialize source & destination strides */                                            \
                     if (buf_stride) {                                                                        \
                         assert(buf_stride >= sizeof(ST));                                                    \
@@ -765,17 +782,6 @@
                             (size_t)d_stride % H5T_NATIVE_##DTYPE##_ALIGN_g);                                \
                     CI_INC_SRC(s_mv)                                                                         \
                     CI_INC_DST(d_mv)                                                                         \
-                                                                                                             \
-                    /* Get conversion exception callback property */                                         \
-                    if (H5CX_get_dt_conv_cb(&cb_struct) < 0)                                                 \
-                        HGOTO_ERROR(H5E_DATATYPE, H5E_CANTGET, FAIL,                                         \
-                                    "unable to get conversion exception callback");                          \
-                                                                                                             \
-                    /* Get source and destination datatypes */                                               \
-                    if (NULL == (st = (H5T_t *)H5I_object(src_id)) ||                                        \
-                        NULL == (dt = (H5T_t *)H5I_object(dst_id)))                                          \
-                        HGOTO_ERROR(H5E_DATATYPE, H5E_CANTINIT, FAIL,                                        \
-                                    "unable to dereference datatype object ID");                             \
                                                                                                              \
                     H5T_CONV_SET_PREC(PREC) /*init precision variables, or not */                            \
                                                                                                              \
@@ -950,7 +956,7 @@ done:                                                                           
 /* The outer wrapper for the type conversion loop, to check for an exception handling routine */
 #define H5T_CONV_LOOP_OUTER(PRE_SALIGN_GUTS, PRE_DALIGN_GUTS, POST_SALIGN_GUTS, POST_DALIGN_GUTS, GUTS,      \
                             STYPE, DTYPE, S, D, ST, DT, D_MIN, D_MAX)                                        \
-    if (cb_struct.func) {                                                                                    \
+    if (conv_ctx->cb_struct.func) {                                                                          \
         H5T_CONV_LOOP(PRE_SALIGN_GUTS, PRE_DALIGN_GUTS, POST_SALIGN_GUTS, POST_DALIGN_GUTS, GUTS, STYPE,     \
                       DTYPE, S, D, ST, DT, D_MIN, D_MAX)                                                     \
     }                                                                                                        \
@@ -1058,7 +1064,9 @@ done:                                                                           
 /* Conversion data for H5T__conv_struct() */
 typedef struct H5T_conv_struct_t {
     int              *src2dst;     /*mapping from src to dst member num */
-    hid_t            *src_memb_id; /*source member type ID's         */
+    H5T_t           **src_memb;    /*source member datatypes */
+    H5T_t           **dst_memb;    /*destination member datatypes */
+    hid_t            *src_memb_id; /*source member type ID's */
     hid_t            *dst_memb_id; /*destination member type ID's         */
     H5T_path_t      **memb_path;   /*conversion path for each member    */
     H5T_subset_info_t subset_info; /*info related to compound subsets   */
@@ -1124,9 +1132,10 @@ H5FL_BLK_DEFINE_STATIC(ref_seq);
  *-------------------------------------------------------------------------
  */
 herr_t
-H5T__conv_noop(hid_t H5_ATTR_UNUSED src_id, hid_t H5_ATTR_UNUSED dst_id, H5T_cdata_t *cdata,
-               size_t H5_ATTR_UNUSED nelmts, size_t H5_ATTR_UNUSED buf_stride,
-               size_t H5_ATTR_UNUSED bkg_stride, void H5_ATTR_UNUSED *buf, void H5_ATTR_UNUSED *background)
+H5T__conv_noop(H5T_t H5_ATTR_UNUSED *src, H5T_t H5_ATTR_UNUSED *dst, H5T_cdata_t *cdata,
+               const H5T_conv_ctx_t H5_ATTR_UNUSED *conv_ctx, size_t H5_ATTR_UNUSED nelmts,
+               size_t H5_ATTR_UNUSED buf_stride, size_t H5_ATTR_UNUSED bkg_stride, void H5_ATTR_UNUSED *buf,
+               void H5_ATTR_UNUSED *background)
 {
     herr_t ret_value = SUCCEED; /* Return value */
 
@@ -1166,12 +1175,11 @@ done:
  *-------------------------------------------------------------------------
  */
 herr_t
-H5T__conv_order_opt(hid_t src_id, hid_t dst_id, H5T_cdata_t *cdata, size_t nelmts, size_t buf_stride,
-                    size_t H5_ATTR_UNUSED bkg_stride, void *_buf, void H5_ATTR_UNUSED *background)
+H5T__conv_order_opt(H5T_t *src, H5T_t *dst, H5T_cdata_t *cdata, const H5T_conv_ctx_t H5_ATTR_UNUSED *conv_ctx,
+                    size_t nelmts, size_t buf_stride, size_t H5_ATTR_UNUSED bkg_stride, void *_buf,
+                    void H5_ATTR_UNUSED *background)
 {
     uint8_t *buf = (uint8_t *)_buf;
-    H5T_t   *src = NULL;
-    H5T_t   *dst = NULL;
     size_t   i;
     herr_t   ret_value = SUCCEED; /* Return value */
 
@@ -1180,7 +1188,7 @@ H5T__conv_order_opt(hid_t src_id, hid_t dst_id, H5T_cdata_t *cdata, size_t nelmt
     switch (cdata->command) {
         case H5T_CONV_INIT:
             /* Capability query */
-            if (NULL == (src = (H5T_t *)H5I_object(src_id)) || NULL == (dst = (H5T_t *)H5I_object(dst_id)))
+            if (NULL == src || NULL == dst)
                 HGOTO_ERROR(H5E_ARGS, H5E_BADTYPE, FAIL, "not a datatype");
             if (src->shared->size != dst->shared->size || 0 != src->shared->u.atomic.offset ||
                 0 != dst->shared->u.atomic.offset)
@@ -1232,7 +1240,7 @@ H5T__conv_order_opt(hid_t src_id, hid_t dst_id, H5T_cdata_t *cdata, size_t nelmt
 
         case H5T_CONV_CONV:
             /* The conversion */
-            if (NULL == (src = (H5T_t *)H5I_object(src_id)) || NULL == (dst = (H5T_t *)H5I_object(dst_id)))
+            if (NULL == src || NULL == dst)
                 HGOTO_ERROR(H5E_ARGS, H5E_BADTYPE, FAIL, "not a datatype");
 
             /* Check for "no op" reference conversion */
@@ -1572,12 +1580,11 @@ done:
  *-------------------------------------------------------------------------
  */
 herr_t
-H5T__conv_order(hid_t src_id, hid_t dst_id, H5T_cdata_t *cdata, size_t nelmts, size_t buf_stride,
-                size_t H5_ATTR_UNUSED bkg_stride, void *_buf, void H5_ATTR_UNUSED *background)
+H5T__conv_order(H5T_t *src, H5T_t *dst, H5T_cdata_t *cdata, const H5T_conv_ctx_t H5_ATTR_UNUSED *conv_ctx,
+                size_t nelmts, size_t buf_stride, size_t H5_ATTR_UNUSED bkg_stride, void *_buf,
+                void H5_ATTR_UNUSED *background)
 {
     uint8_t *buf = (uint8_t *)_buf;
-    H5T_t   *src = NULL;
-    H5T_t   *dst = NULL;
     size_t   i;
     size_t   j, md;
     herr_t   ret_value = SUCCEED; /* Return value */
@@ -1587,7 +1594,7 @@ H5T__conv_order(hid_t src_id, hid_t dst_id, H5T_cdata_t *cdata, size_t nelmts, s
     switch (cdata->command) {
         case H5T_CONV_INIT:
             /* Capability query */
-            if (NULL == (src = (H5T_t *)H5I_object(src_id)) || NULL == (dst = (H5T_t *)H5I_object(dst_id)))
+            if (NULL == src || NULL == dst)
                 HGOTO_ERROR(H5E_ARGS, H5E_BADTYPE, FAIL, "not a datatype");
             if (src->shared->size != dst->shared->size || 0 != src->shared->u.atomic.offset ||
                 0 != dst->shared->u.atomic.offset ||
@@ -1633,7 +1640,7 @@ H5T__conv_order(hid_t src_id, hid_t dst_id, H5T_cdata_t *cdata, size_t nelmts, s
 
         case H5T_CONV_CONV:
             /* The conversion */
-            if (NULL == (src = (H5T_t *)H5I_object(src_id)))
+            if (NULL == src)
                 HGOTO_ERROR(H5E_ARGS, H5E_BADTYPE, FAIL, "not a datatype");
 
             buf_stride = buf_stride ? buf_stride : src->shared->size;
@@ -1665,31 +1672,30 @@ done:
  *-------------------------------------------------------------------------
  */
 herr_t
-H5T__conv_b_b(hid_t src_id, hid_t dst_id, H5T_cdata_t *cdata, size_t nelmts, size_t buf_stride,
-              size_t H5_ATTR_UNUSED bkg_stride, void *_buf, void H5_ATTR_UNUSED *background)
+H5T__conv_b_b(H5T_t *src, H5T_t *dst, H5T_cdata_t *cdata, const H5T_conv_ctx_t *conv_ctx, size_t nelmts,
+              size_t buf_stride, size_t H5_ATTR_UNUSED bkg_stride, void *_buf,
+              void H5_ATTR_UNUSED *background)
 {
     uint8_t       *buf = (uint8_t *)_buf;
-    H5T_t         *src = NULL, *dst = NULL; /*source and dest datatypes    */
-    ssize_t        direction;               /*direction of traversal    */
-    size_t         elmtno;                  /*element number        */
-    size_t         olap;                    /*num overlapping elements    */
-    size_t         half_size;               /*1/2 of total size for swapping*/
-    uint8_t       *s, *sp, *d, *dp;         /*source and dest traversal ptrs*/
-    uint8_t        dbuf[256] = {0};         /*temp destination buffer    */
-    size_t         msb_pad_offset;          /*offset for dest MSB padding    */
+    ssize_t        direction;       /*direction of traversal    */
+    size_t         elmtno;          /*element number        */
+    size_t         olap;            /*num overlapping elements    */
+    size_t         half_size;       /*1/2 of total size for swapping*/
+    uint8_t       *s, *sp, *d, *dp; /*source and dest traversal ptrs*/
+    uint8_t        dbuf[256] = {0}; /*temp destination buffer    */
+    size_t         msb_pad_offset;  /*offset for dest MSB padding    */
     size_t         i;
-    uint8_t       *src_rev   = NULL;         /*order-reversed source buffer  */
-    H5T_conv_cb_t  cb_struct = {NULL, NULL}; /*conversion callback structure */
-    H5T_conv_ret_t except_ret;               /*return of callback function   */
-    bool           reverse;                  /*if reverse the order of destination        */
-    herr_t         ret_value = SUCCEED;      /* Return value */
+    uint8_t       *src_rev = NULL;      /*order-reversed source buffer  */
+    H5T_conv_ret_t except_ret;          /*return of callback function   */
+    bool           reverse;             /*if reverse the order of destination        */
+    herr_t         ret_value = SUCCEED; /* Return value */
 
     FUNC_ENTER_PACKAGE
 
     switch (cdata->command) {
         case H5T_CONV_INIT:
             /* Capability query */
-            if (NULL == (src = (H5T_t *)H5I_object(src_id)) || NULL == (dst = (H5T_t *)H5I_object(dst_id)))
+            if (NULL == src || NULL == dst)
                 HGOTO_ERROR(H5E_ARGS, H5E_BADTYPE, FAIL, "not a datatype");
             if (H5T_ORDER_LE != src->shared->u.atomic.order && H5T_ORDER_BE != src->shared->u.atomic.order)
                 HGOTO_ERROR(H5E_DATATYPE, H5E_UNSUPPORTED, FAIL, "unsupported byte order");
@@ -1702,9 +1708,10 @@ H5T__conv_b_b(hid_t src_id, hid_t dst_id, H5T_cdata_t *cdata, size_t nelmts, siz
             break;
 
         case H5T_CONV_CONV:
-            /* Get the datatypes */
-            if (NULL == (src = (H5T_t *)H5I_object(src_id)) || NULL == (dst = (H5T_t *)H5I_object(dst_id)))
+            if (NULL == src || NULL == dst)
                 HGOTO_ERROR(H5E_ARGS, H5E_BADTYPE, FAIL, "not a datatype");
+            if (NULL == conv_ctx)
+                HGOTO_ERROR(H5E_ARGS, H5E_BADVALUE, FAIL, "invalid datatype conversion context pointer");
 
             /*
              * Do we process the values from beginning to end or vice versa? Also,
@@ -1732,10 +1739,6 @@ H5T__conv_b_b(hid_t src_id, hid_t dst_id, H5T_cdata_t *cdata, size_t nelmts, siz
                 dp        = (uint8_t *)buf + (nelmts - 1) * dst->shared->size;
                 direction = -1;
             }
-
-            /* Get conversion exception callback property */
-            if (H5CX_get_dt_conv_cb(&cb_struct) < 0)
-                HGOTO_ERROR(H5E_DATATYPE, H5E_CANTGET, FAIL, "unable to get conversion exception callback");
 
             /* Allocate space for order-reversed source buffer */
             src_rev = (uint8_t *)H5MM_calloc(src->shared->size);
@@ -1793,11 +1796,12 @@ H5T__conv_b_b(hid_t src_id, hid_t dst_id, H5T_cdata_t *cdata, size_t nelmts, siz
                  */
                 if (src->shared->u.atomic.prec > dst->shared->u.atomic.prec) {
                     /*overflow*/
-                    if (cb_struct.func) { /*If user's exception handler is present, use it*/
+                    if (conv_ctx->cb_struct.func) { /*If user's exception handler is present, use it*/
                         H5T__reverse_order(src_rev, s, src->shared->size,
                                            src->shared->u.atomic.order); /*reverse order first*/
-                        except_ret = (cb_struct.func)(H5T_CONV_EXCEPT_RANGE_HI, src_id, dst_id, src_rev, d,
-                                                      cb_struct.user_data);
+                        except_ret = (conv_ctx->cb_struct.func)(H5T_CONV_EXCEPT_RANGE_HI,
+                                                                conv_ctx->src_type_id, conv_ctx->dst_type_id,
+                                                                src_rev, d, conv_ctx->cb_struct.user_data);
                     } /* end if */
 
                     if (except_ret == H5T_CONV_UNHANDLED) {
@@ -1912,13 +1916,15 @@ done:
 static H5T_conv_struct_t *
 H5T__conv_struct_free(H5T_conv_struct_t *priv)
 {
-    int     *src2dst     = priv->src2dst;
-    hid_t   *src_memb_id = priv->src_memb_id, *dst_memb_id = priv->dst_memb_id;
-    unsigned i;
+    int    *src2dst     = priv->src2dst;
+    H5T_t **src_memb    = priv->src_memb;
+    H5T_t **dst_memb    = priv->dst_memb;
+    hid_t  *src_memb_id = priv->src_memb_id;
+    hid_t  *dst_memb_id = priv->dst_memb_id;
 
     FUNC_ENTER_PACKAGE_NOERR
 
-    for (i = 0; i < priv->src_nmembs; i++)
+    for (unsigned i = 0; i < priv->src_nmembs; i++)
         if (src2dst[i] >= 0) {
             int H5_ATTR_NDEBUG_UNUSED status;
 
@@ -1929,6 +1935,8 @@ H5T__conv_struct_free(H5T_conv_struct_t *priv)
         } /* end if */
 
     H5MM_xfree(src2dst);
+    H5MM_xfree(src_memb);
+    H5MM_xfree(dst_memb);
     H5MM_xfree(src_memb_id);
     H5MM_xfree(dst_memb_id);
     H5MM_xfree(priv->memb_path);
@@ -1999,6 +2007,8 @@ H5T__conv_struct_init(H5T_t *src, H5T_t *dst, H5T_cdata_t *cdata)
          */
         if (NULL == (priv = (H5T_conv_struct_t *)(cdata->priv = H5MM_calloc(sizeof(H5T_conv_struct_t)))) ||
             NULL == (priv->src2dst = (int *)H5MM_malloc(src_nmembs * sizeof(int))) ||
+            NULL == (priv->src_memb = (H5T_t **)H5MM_malloc(src_nmembs * sizeof(H5T_t *))) ||
+            NULL == (priv->dst_memb = (H5T_t **)H5MM_malloc(dst_nmembs * sizeof(H5T_t *))) ||
             NULL == (priv->src_memb_id = (hid_t *)H5MM_malloc(src_nmembs * sizeof(hid_t))) ||
             NULL == (priv->dst_memb_id = (hid_t *)H5MM_malloc(dst_nmembs * sizeof(hid_t))))
             HGOTO_ERROR(H5E_RESOURCE, H5E_NOSPACE, FAIL, "memory allocation failed");
@@ -2032,17 +2042,27 @@ H5T__conv_struct_init(H5T_t *src, H5T_t *dst, H5T_cdata_t *cdata)
                 } /* end if */
             }     /* end for */
             if (src2dst[i] >= 0) {
-                hid_t  tid;
                 H5T_t *type;
+                hid_t  tid;
 
-                type = H5T_copy(src->shared->u.compnd.memb[i].type, H5T_COPY_ALL);
-                tid  = H5I_register(H5I_DATATYPE, type, false);
-                assert(tid >= 0);
+                if (NULL == (type = H5T_copy(src->shared->u.compnd.memb[i].type, H5T_COPY_ALL)))
+                    HGOTO_ERROR(H5E_DATATYPE, H5E_CANTCOPY, FAIL,
+                                "can't copy source compound member datatype");
+                priv->src_memb[i] = type;
+
+                if ((tid = H5I_register(H5I_DATATYPE, type, false)) < 0)
+                    HGOTO_ERROR(H5E_DATATYPE, H5E_CANTREGISTER, FAIL,
+                                "can't register ID for source compound member datatype");
                 priv->src_memb_id[i] = tid;
 
-                type = H5T_copy(dst->shared->u.compnd.memb[src2dst[i]].type, H5T_COPY_ALL);
-                tid  = H5I_register(H5I_DATATYPE, type, false);
-                assert(tid >= 0);
+                if (NULL == (type = H5T_copy(dst->shared->u.compnd.memb[src2dst[i]].type, H5T_COPY_ALL)))
+                    HGOTO_ERROR(H5E_DATATYPE, H5E_CANTCOPY, FAIL,
+                                "can't copy destination compound member datatype");
+                priv->dst_memb[src2dst[i]] = type;
+
+                if ((tid = H5I_register(H5I_DATATYPE, type, false)) < 0)
+                    HGOTO_ERROR(H5E_DATATYPE, H5E_CANTREGISTER, FAIL,
+                                "can't register ID for source compound member datatype");
                 priv->dst_memb_id[src2dst[i]] = tid;
             } /* end if */
         }     /* end for */
@@ -2192,14 +2212,12 @@ H5T__conv_struct_subset(const H5T_cdata_t *cdata)
  *-------------------------------------------------------------------------
  */
 herr_t
-H5T__conv_struct(hid_t src_id, hid_t dst_id, H5T_cdata_t *cdata, size_t nelmts, size_t buf_stride,
-                 size_t bkg_stride, void *_buf, void *_bkg)
+H5T__conv_struct(H5T_t *src, H5T_t *dst, H5T_cdata_t *cdata, const H5T_conv_ctx_t *conv_ctx, size_t nelmts,
+                 size_t buf_stride, size_t bkg_stride, void *_buf, void *_bkg)
 {
     uint8_t           *buf  = (uint8_t *)_buf;  /*cast for pointer arithmetic    */
     uint8_t           *bkg  = (uint8_t *)_bkg;  /*background pointer arithmetic    */
     uint8_t           *xbuf = buf, *xbkg = bkg; /*temp pointers into buf and bkg*/
-    H5T_t             *src      = NULL;         /*source datatype        */
-    H5T_t             *dst      = NULL;         /*destination datatype        */
     int               *src2dst  = NULL;         /*maps src member to dst member    */
     H5T_cmemb_t       *src_memb = NULL;         /*source struct member descript.*/
     H5T_cmemb_t       *dst_memb = NULL;         /*destination struct memb desc.    */
@@ -2207,10 +2225,10 @@ H5T__conv_struct(hid_t src_id, hid_t dst_id, H5T_cdata_t *cdata, size_t nelmts, 
     ssize_t            src_delta;               /*source stride    */
     ssize_t            bkg_delta;               /*background stride    */
     size_t             elmtno;
-    unsigned           u; /*counters            */
-    int                i; /*counters            */
-    H5T_conv_struct_t *priv      = (H5T_conv_struct_t *)(cdata->priv);
-    herr_t             ret_value = SUCCEED; /* Return value */
+    unsigned           u; /*counters */
+    H5T_conv_struct_t *priv         = (H5T_conv_struct_t *)(cdata->priv);
+    H5T_conv_ctx_t     tmp_conv_ctx = {0};
+    herr_t             ret_value    = SUCCEED; /* Return value */
 
     FUNC_ENTER_PACKAGE
 
@@ -2218,11 +2236,11 @@ H5T__conv_struct(hid_t src_id, hid_t dst_id, H5T_cdata_t *cdata, size_t nelmts, 
         case H5T_CONV_INIT:
             /*
              * First, determine if this conversion function applies to the
-             * conversion path SRC_ID-->DST_ID.  If not, return failure;
+             * conversion path SRC-->DST.  If not, return failure;
              * otherwise initialize the `priv' field of `cdata' with information
              * that remains (almost) constant for this conversion path.
              */
-            if (NULL == (src = (H5T_t *)H5I_object(src_id)) || NULL == (dst = (H5T_t *)H5I_object(dst_id)))
+            if (NULL == src || NULL == dst)
                 HGOTO_ERROR(H5E_DATATYPE, H5E_BADTYPE, FAIL, "not a datatype");
             if (H5T_COMPOUND != src->shared->type)
                 HGOTO_ERROR(H5E_DATATYPE, H5E_BADTYPE, FAIL, "not a H5T_COMPOUND datatype");
@@ -2244,10 +2262,15 @@ H5T__conv_struct(hid_t src_id, hid_t dst_id, H5T_cdata_t *cdata, size_t nelmts, 
             /*
              * Conversion.
              */
-            if (NULL == (src = (H5T_t *)H5I_object(src_id)) || NULL == (dst = (H5T_t *)H5I_object(dst_id)))
+            if (NULL == src || NULL == dst)
                 HGOTO_ERROR(H5E_DATATYPE, H5E_BADTYPE, FAIL, "not a datatype");
+            if (NULL == conv_ctx)
+                HGOTO_ERROR(H5E_DATATYPE, H5E_BADVALUE, FAIL, "invalid datatype conversion context pointer");
             assert(priv);
             assert(bkg && cdata->need_bkg);
+
+            /* Initialize temporary conversion context */
+            tmp_conv_ctx = *conv_ctx;
 
             if (cdata->recalc && H5T__conv_struct_init(src, dst, cdata) < 0)
                 HGOTO_ERROR(H5E_DATATYPE, H5E_CANTINIT, FAIL, "unable to initialize conversion data");
@@ -2300,12 +2323,17 @@ H5T__conv_struct(hid_t src_id, hid_t dst_id, H5T_cdata_t *cdata, size_t nelmts, 
                     dst_memb = dst->shared->u.compnd.memb + src2dst[u];
 
                     if (dst_memb->size <= src_memb->size) {
-                        if (H5T_convert(priv->memb_path[u], priv->src_memb_id[u],
-                                        priv->dst_memb_id[src2dst[u]], (size_t)1, (size_t)0,
-                                        (size_t)0, /*no striding (packed array)*/
-                                        xbuf + src_memb->offset, xbkg + dst_memb->offset) < 0)
-                            HGOTO_ERROR(H5E_DATATYPE, H5E_CANTINIT, FAIL,
+                        /* Update IDs in conversion context */
+                        tmp_conv_ctx.src_type_id = priv->src_memb_id[u];
+                        tmp_conv_ctx.dst_type_id = priv->dst_memb_id[src2dst[u]];
+
+                        if (H5T_convert_with_ctx(priv->memb_path[u], priv->src_memb[u],
+                                                 priv->dst_memb[src2dst[u]], &tmp_conv_ctx, (size_t)1,
+                                                 (size_t)0, (size_t)0, /*no striding (packed array)*/
+                                                 xbuf + src_memb->offset, xbkg + dst_memb->offset) < 0)
+                            HGOTO_ERROR(H5E_DATATYPE, H5E_CANTCONVERT, FAIL,
                                         "unable to convert compound datatype member");
+
                         memmove(xbuf + offset, xbuf + src_memb->offset, dst_memb->size);
                         offset += dst_memb->size;
                     } /* end if */
@@ -2323,19 +2351,23 @@ H5T__conv_struct(hid_t src_id, hid_t dst_id, H5T_cdata_t *cdata, size_t nelmts, 
                  * background buffer.
                  */
                 H5_CHECK_OVERFLOW(src->shared->u.compnd.nmembs, size_t, int);
-                for (i = (int)src->shared->u.compnd.nmembs - 1; i >= 0; --i) {
+                for (int i = (int)src->shared->u.compnd.nmembs - 1; i >= 0; --i) {
                     if (src2dst[i] < 0)
                         continue; /*subsetting*/
                     src_memb = src->shared->u.compnd.memb + i;
                     dst_memb = dst->shared->u.compnd.memb + src2dst[i];
 
                     if (dst_memb->size > src_memb->size) {
+                        /* Update IDs in conversion context */
+                        tmp_conv_ctx.src_type_id = priv->src_memb_id[i];
+                        tmp_conv_ctx.dst_type_id = priv->dst_memb_id[src2dst[i]];
+
                         offset -= src_memb->size;
-                        if (H5T_convert(priv->memb_path[i], priv->src_memb_id[i],
-                                        priv->dst_memb_id[src2dst[i]], (size_t)1, (size_t)0,
-                                        (size_t)0, /*no striding (packed array)*/
-                                        xbuf + offset, xbkg + dst_memb->offset) < 0)
-                            HGOTO_ERROR(H5E_DATATYPE, H5E_CANTINIT, FAIL,
+                        if (H5T_convert_with_ctx(priv->memb_path[i], priv->src_memb[i],
+                                                 priv->dst_memb[src2dst[i]], &tmp_conv_ctx, (size_t)1,
+                                                 (size_t)0, (size_t)0, /*no striding (packed array)*/
+                                                 xbuf + offset, xbkg + dst_memb->offset) < 0)
+                            HGOTO_ERROR(H5E_DATATYPE, H5E_CANTCONVERT, FAIL,
                                         "unable to convert compound datatype member");
                     } /* end if */
                     else
@@ -2416,25 +2448,23 @@ done:
  *-------------------------------------------------------------------------
  */
 herr_t
-H5T__conv_struct_opt(hid_t src_id, hid_t dst_id, H5T_cdata_t *cdata, size_t nelmts, size_t buf_stride,
-                     size_t bkg_stride, void *_buf, void *_bkg)
+H5T__conv_struct_opt(H5T_t *src, H5T_t *dst, H5T_cdata_t *cdata, const H5T_conv_ctx_t *conv_ctx,
+                     size_t nelmts, size_t buf_stride, size_t bkg_stride, void *_buf, void *_bkg)
 {
     uint8_t           *buf      = (uint8_t *)_buf; /*cast for pointer arithmetic    */
     uint8_t           *bkg      = (uint8_t *)_bkg; /*background pointer arithmetic    */
     uint8_t           *xbuf     = NULL;            /*temporary pointer into `buf'    */
     uint8_t           *xbkg     = NULL;            /*temporary pointer into `bkg'    */
-    H5T_t             *src      = NULL;            /*source datatype        */
-    H5T_t             *dst      = NULL;            /*destination datatype        */
     int               *src2dst  = NULL;            /*maps src member to dst member    */
     H5T_cmemb_t       *src_memb = NULL;            /*source struct member descript.*/
     H5T_cmemb_t       *dst_memb = NULL;            /*destination struct memb desc.    */
     size_t             offset;                     /*byte offset wrt struct    */
     size_t             elmtno;                     /*element counter        */
     size_t             copy_size;                  /*size of element for copying   */
-    H5T_conv_struct_t *priv      = NULL;           /*private data            */
-    bool               no_stride = false;          /*flag to indicate no stride    */
-    unsigned           u;                          /*counters            */
-    int                i;                          /*counters            */
+    H5T_conv_struct_t *priv         = NULL;        /*private data            */
+    H5T_conv_ctx_t     tmp_conv_ctx = {0};         /*temporary conversion context */
+    bool               no_stride    = false;       /*flag to indicate no stride    */
+    unsigned           u;                          /*counters */
     herr_t             ret_value = SUCCEED;        /* Return value */
 
     FUNC_ENTER_PACKAGE
@@ -2443,11 +2473,11 @@ H5T__conv_struct_opt(hid_t src_id, hid_t dst_id, H5T_cdata_t *cdata, size_t nelm
         case H5T_CONV_INIT:
             /*
              * First, determine if this conversion function applies to the
-             * conversion path SRC_ID-->DST_ID.  If not, return failure;
+             * conversion path SRC-->DST.  If not, return failure;
              * otherwise initialize the `priv' field of `cdata' with information
              * that remains (almost) constant for this conversion path.
              */
-            if (NULL == (src = (H5T_t *)H5I_object(src_id)) || NULL == (dst = (H5T_t *)H5I_object(dst_id)))
+            if (NULL == src || NULL == dst)
                 HGOTO_ERROR(H5E_ARGS, H5E_BADTYPE, FAIL, "not a datatype");
             if (H5T_COMPOUND != src->shared->type)
                 HGOTO_ERROR(H5E_DATATYPE, H5E_BADTYPE, FAIL, "not a H5T_COMPOUND datatype");
@@ -2480,7 +2510,7 @@ H5T__conv_struct_opt(hid_t src_id, hid_t dst_id, H5T_cdata_t *cdata, size_t nelm
                         offset += src_memb->size;
                 } /* end for */
                 H5_CHECK_OVERFLOW(src->shared->u.compnd.nmembs, size_t, int);
-                for (i = (int)src->shared->u.compnd.nmembs - 1; i >= 0; --i) {
+                for (int i = (int)src->shared->u.compnd.nmembs - 1; i >= 0; --i) {
                     if (src2dst[i] < 0)
                         continue;
                     src_memb = src->shared->u.compnd.memb + i;
@@ -2508,8 +2538,13 @@ H5T__conv_struct_opt(hid_t src_id, hid_t dst_id, H5T_cdata_t *cdata, size_t nelm
             /*
              * Conversion.
              */
-            if (NULL == (src = (H5T_t *)H5I_object(src_id)) || NULL == (dst = (H5T_t *)H5I_object(dst_id)))
+            if (NULL == src || NULL == dst)
                 HGOTO_ERROR(H5E_ARGS, H5E_BADTYPE, FAIL, "not a datatype");
+            if (NULL == conv_ctx)
+                HGOTO_ERROR(H5E_DATATYPE, H5E_BADVALUE, FAIL, "invalid datatype conversion context pointer");
+
+            /* Initialize temporary conversion context */
+            tmp_conv_ctx = *conv_ctx;
 
             /* Update cached data if necessary */
             if (cdata->recalc && H5T__conv_struct_init(src, dst, cdata) < 0)
@@ -2573,13 +2608,18 @@ H5T__conv_struct_opt(hid_t src_id, hid_t dst_id, H5T_cdata_t *cdata, size_t nelm
                     dst_memb = dst->shared->u.compnd.memb + src2dst[u];
 
                     if (dst_memb->size <= src_memb->size) {
+                        /* Update IDs in conversion context */
+                        tmp_conv_ctx.src_type_id = priv->src_memb_id[u];
+                        tmp_conv_ctx.dst_type_id = priv->dst_memb_id[src2dst[u]];
+
                         xbuf = buf + src_memb->offset;
                         xbkg = bkg + dst_memb->offset;
-                        if (H5T_convert(priv->memb_path[u], priv->src_memb_id[u],
-                                        priv->dst_memb_id[src2dst[u]], nelmts, buf_stride, bkg_stride, xbuf,
-                                        xbkg) < 0)
-                            HGOTO_ERROR(H5E_DATATYPE, H5E_CANTINIT, FAIL,
+                        if (H5T_convert_with_ctx(priv->memb_path[u], priv->src_memb[u],
+                                                 priv->dst_memb[src2dst[u]], &tmp_conv_ctx, nelmts,
+                                                 buf_stride, bkg_stride, xbuf, xbkg) < 0)
+                            HGOTO_ERROR(H5E_DATATYPE, H5E_CANTCONVERT, FAIL,
                                         "unable to convert compound datatype member");
+
                         for (elmtno = 0; elmtno < nelmts; elmtno++) {
                             memmove(xbkg, xbuf, dst_memb->size);
                             xbuf += buf_stride;
@@ -2602,20 +2642,24 @@ H5T__conv_struct_opt(hid_t src_id, hid_t dst_id, H5T_cdata_t *cdata, size_t nelm
                  * bkg buffer.
                  */
                 H5_CHECK_OVERFLOW(src->shared->u.compnd.nmembs, size_t, int);
-                for (i = (int)src->shared->u.compnd.nmembs - 1; i >= 0; --i) {
+                for (int i = (int)src->shared->u.compnd.nmembs - 1; i >= 0; --i) {
                     if (src2dst[i] < 0)
                         continue;
                     src_memb = src->shared->u.compnd.memb + i;
                     dst_memb = dst->shared->u.compnd.memb + src2dst[i];
 
                     if (dst_memb->size > src_memb->size) {
+                        /* Update IDs in conversion context */
+                        tmp_conv_ctx.src_type_id = priv->src_memb_id[i];
+                        tmp_conv_ctx.dst_type_id = priv->dst_memb_id[src2dst[i]];
+
                         offset -= src_memb->size;
                         xbuf = buf + offset;
                         xbkg = bkg + dst_memb->offset;
-                        if (H5T_convert(priv->memb_path[i], priv->src_memb_id[i],
-                                        priv->dst_memb_id[src2dst[i]], nelmts, buf_stride, bkg_stride, xbuf,
-                                        xbkg) < 0)
-                            HGOTO_ERROR(H5E_DATATYPE, H5E_CANTINIT, FAIL,
+                        if (H5T_convert_with_ctx(priv->memb_path[i], priv->src_memb[i],
+                                                 priv->dst_memb[src2dst[i]], &tmp_conv_ctx, nelmts,
+                                                 buf_stride, bkg_stride, xbuf, xbkg) < 0)
+                            HGOTO_ERROR(H5E_DATATYPE, H5E_CANTCONVERT, FAIL,
                                         "unable to convert compound datatype member");
                         for (elmtno = 0; elmtno < nelmts; elmtno++) {
                             memmove(xbkg, xbuf, dst_memb->size);
@@ -2798,16 +2842,14 @@ done:
  *-------------------------------------------------------------------------
  */
 herr_t
-H5T__conv_enum(hid_t src_id, hid_t dst_id, H5T_cdata_t *cdata, size_t nelmts, size_t buf_stride,
-               size_t H5_ATTR_UNUSED bkg_stride, void *_buf, void H5_ATTR_UNUSED *bkg)
+H5T__conv_enum(H5T_t *src, H5T_t *dst, H5T_cdata_t *cdata, const H5T_conv_ctx_t *conv_ctx, size_t nelmts,
+               size_t buf_stride, size_t H5_ATTR_UNUSED bkg_stride, void *_buf, void H5_ATTR_UNUSED *bkg)
 {
-    uint8_t           *buf = (uint8_t *)_buf;   /*cast for pointer arithmetic    */
-    H5T_t             *src = NULL, *dst = NULL; /*src and dst datatypes    */
-    uint8_t           *s = NULL, *d = NULL;     /*src and dst BUF pointers    */
-    ssize_t            src_delta, dst_delta;    /*conversion strides        */
-    int                n;                       /*src value cast as native int    */
+    uint8_t           *buf = (uint8_t *)_buf; /*cast for pointer arithmetic    */
+    uint8_t           *s = NULL, *d = NULL;   /*src and dst BUF pointers    */
+    ssize_t            src_delta, dst_delta;  /*conversion strides        */
+    int                n;                     /*src value cast as native int    */
     H5T_enum_struct_t *priv = (H5T_enum_struct_t *)(cdata->priv);
-    H5T_conv_cb_t      cb_struct;           /*conversion callback structure */
     H5T_conv_ret_t     except_ret;          /*return of callback function   */
     size_t             i;                   /*counters            */
     herr_t             ret_value = SUCCEED; /* Return value                 */
@@ -2818,11 +2860,11 @@ H5T__conv_enum(hid_t src_id, hid_t dst_id, H5T_cdata_t *cdata, size_t nelmts, si
         case H5T_CONV_INIT:
             /*
              * Determine if this conversion function applies to the conversion
-             * path SRC_ID->DST_ID.  If not return failure; otherwise initialize
+             * path SRC->DST.  If not return failure; otherwise initialize
              * the `priv' field of `cdata' with information about the underlying
              * integer conversion.
              */
-            if (NULL == (src = (H5T_t *)H5I_object(src_id)) || NULL == (dst = (H5T_t *)H5I_object(dst_id)))
+            if (NULL == src || NULL == dst)
                 HGOTO_ERROR(H5E_DATATYPE, H5E_BADTYPE, FAIL, "not a datatype");
             if (H5T_ENUM != src->shared->type)
                 HGOTO_ERROR(H5E_DATATYPE, H5E_BADTYPE, FAIL, "not a H5T_ENUM datatype");
@@ -2848,8 +2890,10 @@ H5T__conv_enum(hid_t src_id, hid_t dst_id, H5T_cdata_t *cdata, size_t nelmts, si
             break;
 
         case H5T_CONV_CONV:
-            if (NULL == (src = (H5T_t *)H5I_object(src_id)) || NULL == (dst = (H5T_t *)H5I_object(dst_id)))
+            if (NULL == src || NULL == dst)
                 HGOTO_ERROR(H5E_ARGS, H5E_BADTYPE, FAIL, "not a datatype");
+            if (NULL == conv_ctx)
+                HGOTO_ERROR(H5E_ARGS, H5E_BADVALUE, FAIL, "invalid datatype conversion context pointer");
             if (H5T_ENUM != src->shared->type)
                 HGOTO_ERROR(H5E_DATATYPE, H5E_BADTYPE, FAIL, "not a H5T_ENUM datatype");
             if (H5T_ENUM != dst->shared->type)
@@ -2885,10 +2929,6 @@ H5T__conv_enum(hid_t src_id, hid_t dst_id, H5T_cdata_t *cdata, size_t nelmts, si
                 d         = buf + (nelmts - 1) * dst->shared->size;
             }
 
-            /* Get conversion exception callback property */
-            if (H5CX_get_dt_conv_cb(&cb_struct) < 0)
-                HGOTO_ERROR(H5E_DATATYPE, H5E_CANTGET, FAIL, "unable to get conversion exception callback");
-
             for (i = 0; i < nelmts; i++, s += src_delta, d += dst_delta) {
                 if (priv->length) {
                     /* Use O(1) lookup */
@@ -2909,9 +2949,10 @@ H5T__conv_enum(hid_t src_id, hid_t dst_id, H5T_cdata_t *cdata, size_t nelmts, si
                         /*overflow*/
                         except_ret = H5T_CONV_UNHANDLED;
                         /*If user's exception handler is present, use it*/
-                        if (cb_struct.func)
-                            except_ret = (cb_struct.func)(H5T_CONV_EXCEPT_RANGE_HI, src_id, dst_id, s, d,
-                                                          cb_struct.user_data);
+                        if (conv_ctx->cb_struct.func)
+                            except_ret = (conv_ctx->cb_struct.func)(
+                                H5T_CONV_EXCEPT_RANGE_HI, conv_ctx->src_type_id, conv_ctx->dst_type_id, s, d,
+                                conv_ctx->cb_struct.user_data);
 
                         if (except_ret == H5T_CONV_UNHANDLED)
                             memset(d, 0xff, dst->shared->size);
@@ -2946,9 +2987,10 @@ H5T__conv_enum(hid_t src_id, hid_t dst_id, H5T_cdata_t *cdata, size_t nelmts, si
                     if (lt >= rt) {
                         except_ret = H5T_CONV_UNHANDLED;
                         /*If user's exception handler is present, use it*/
-                        if (cb_struct.func)
-                            except_ret = (cb_struct.func)(H5T_CONV_EXCEPT_RANGE_HI, src_id, dst_id, src, d,
-                                                          cb_struct.user_data);
+                        if (conv_ctx->cb_struct.func)
+                            except_ret = (conv_ctx->cb_struct.func)(
+                                H5T_CONV_EXCEPT_RANGE_HI, conv_ctx->src_type_id, conv_ctx->dst_type_id, s, d,
+                                conv_ctx->cb_struct.user_data);
 
                         if (except_ret == H5T_CONV_UNHANDLED)
                             memset(d, 0xff, dst->shared->size);
@@ -2992,13 +3034,13 @@ done:
  *-------------------------------------------------------------------------
  */
 herr_t
-H5T__conv_enum_numeric(hid_t src_id, hid_t dst_id, H5T_cdata_t *cdata, size_t nelmts,
+H5T__conv_enum_numeric(H5T_t *src, H5T_t *dst, H5T_cdata_t *cdata,
+                       const H5T_conv_ctx_t H5_ATTR_UNUSED *conv_ctx, size_t nelmts,
                        size_t H5_ATTR_UNUSED buf_stride, size_t H5_ATTR_UNUSED bkg_stride, void *_buf,
                        void H5_ATTR_UNUSED *bkg)
 {
-    H5T_t      *src, *dst;           /*src and dst datatypes    */
     H5T_t      *src_parent;          /*parent type for src           */
-    hid_t       src_parent_id = -1;  /*ID for parent of the source   */
+    H5T_t      *tmp_type = NULL;     /*temporary datatype for parent type */
     H5T_path_t *tpath;               /* Conversion information       */
     herr_t      ret_value = SUCCEED; /* Return value                 */
 
@@ -3008,9 +3050,9 @@ H5T__conv_enum_numeric(hid_t src_id, hid_t dst_id, H5T_cdata_t *cdata, size_t ne
         case H5T_CONV_INIT:
             /*
              * Determine if this conversion function applies to the conversion
-             * path SRC_ID->DST_ID.  If not, return failure.
+             * path SRC->DST.  If not, return failure.
              */
-            if (NULL == (src = (H5T_t *)H5I_object(src_id)) || NULL == (dst = (H5T_t *)H5I_object(dst_id)))
+            if (NULL == src || NULL == dst)
                 HGOTO_ERROR(H5E_DATATYPE, H5E_BADTYPE, FAIL, "not a datatype");
             if (H5T_ENUM != src->shared->type)
                 HGOTO_ERROR(H5E_DATATYPE, H5E_BADTYPE, FAIL, "source type is not a H5T_ENUM datatype");
@@ -3024,23 +3066,21 @@ H5T__conv_enum_numeric(hid_t src_id, hid_t dst_id, H5T_cdata_t *cdata, size_t ne
             break;
 
         case H5T_CONV_CONV:
-            if (NULL == (src = (H5T_t *)H5I_object(src_id)) || NULL == (dst = (H5T_t *)H5I_object(dst_id)))
+            if (NULL == src || NULL == dst)
                 HGOTO_ERROR(H5E_ARGS, H5E_BADTYPE, FAIL, "not a datatype");
 
             src_parent = src->shared->parent;
 
             if (NULL == (tpath = H5T_path_find(src_parent, dst))) {
-                HGOTO_ERROR(H5E_DATASET, H5E_UNSUPPORTED, FAIL,
+                HGOTO_ERROR(H5E_DATATYPE, H5E_UNSUPPORTED, FAIL,
                             "unable to convert between src and dest datatype");
             }
             else if (!H5T_path_noop(tpath)) {
-                if ((src_parent_id = H5I_register(H5I_DATATYPE, H5T_copy(src_parent, H5T_COPY_ALL), false)) <
-                    0)
-                    HGOTO_ERROR(H5E_DATASET, H5E_CANTREGISTER, FAIL,
-                                "unable to register types for conversion");
+                if (NULL == (tmp_type = H5T_copy(src_parent, H5T_COPY_ALL)))
+                    HGOTO_ERROR(H5E_DATATYPE, H5E_CANTCOPY, FAIL, "can't copy parent datatype");
 
                 /* Convert the data */
-                if (H5T_convert(tpath, src_parent_id, dst_id, nelmts, buf_stride, bkg_stride, _buf, bkg) < 0)
+                if (H5T_convert(tpath, tmp_type, dst, nelmts, buf_stride, bkg_stride, _buf, bkg) < 0)
                     HGOTO_ERROR(H5E_DATATYPE, H5E_CANTINIT, FAIL, "datatype conversion failed");
             }
             break;
@@ -3051,9 +3091,9 @@ H5T__conv_enum_numeric(hid_t src_id, hid_t dst_id, H5T_cdata_t *cdata, size_t ne
     } /* end switch */
 
 done:
-    /* Release the temporary datatype IDs used */
-    if (src_parent_id >= 0)
-        H5I_dec_ref(src_parent_id);
+    /* Release the temporary datatype used */
+    if (tmp_type && (H5T_close(tmp_type) < 0))
+        HDONE_ERROR(H5E_DATATYPE, H5E_CANTCLOSEOBJ, FAIL, "can't close temporary datatype");
 
     FUNC_LEAVE_NOAPI(ret_value)
 } /* end H5T__conv_enum_numeric() */
@@ -3080,32 +3120,35 @@ done:
  *-------------------------------------------------------------------------
  */
 herr_t
-H5T__conv_vlen(hid_t src_id, hid_t dst_id, H5T_cdata_t *cdata, size_t nelmts, size_t buf_stride,
-               size_t bkg_stride, void *buf, void *bkg)
+H5T__conv_vlen(H5T_t *src, H5T_t *dst, H5T_cdata_t *cdata, const H5T_conv_ctx_t *conv_ctx, size_t nelmts,
+               size_t buf_stride, size_t bkg_stride, void *buf, void *bkg)
 {
-    H5T_vlen_alloc_info_t vl_alloc_info;              /* VL allocation info */
-    H5T_path_t           *tpath         = NULL;       /* Type conversion path             */
-    bool                  noop_conv     = false;      /* Flag to indicate a noop conversion */
-    bool                  write_to_file = false;      /* Flag to indicate writing to file */
-    htri_t                parent_is_vlen;             /* Flag to indicate parent is vlen datatype */
-    size_t                bg_seq_len = 0;             /* The number of elements in the background sequence */
-    hid_t                 tsrc_id = -1, tdst_id = -1; /*temporary type atoms         */
-    H5T_t                *src = NULL;                 /*source datatype             */
-    H5T_t                *dst = NULL;                 /*destination datatype             */
-    uint8_t              *s   = NULL;                 /*source buffer            */
-    uint8_t              *d   = NULL;                 /*destination buffer        */
-    uint8_t              *b   = NULL;                 /*background buffer        */
-    ssize_t               s_stride, d_stride;         /*src and dst strides        */
-    ssize_t               b_stride;                   /*bkg stride            */
-    size_t                safe;                       /*how many elements are safe to process in each pass */
-    size_t                src_base_size, dst_base_size; /*source & destination base size*/
-    void                 *conv_buf      = NULL;         /*temporary conversion buffer          */
-    size_t                conv_buf_size = 0;            /*size of conversion buffer in bytes */
-    void                 *tmp_buf       = NULL;         /*temporary background buffer          */
-    size_t                tmp_buf_size  = 0;            /*size of temporary bkg buffer         */
-    bool                  nested        = false;        /*flag of nested VL case             */
-    size_t                elmtno;                       /*element number counter         */
-    herr_t                ret_value = SUCCEED;          /* Return value */
+    H5T_vlen_alloc_info_t vl_alloc_info;         /* VL allocation info */
+    H5T_conv_ctx_t        tmp_conv_ctx  = {0};   /* Temporary conversion context */
+    H5T_path_t           *tpath         = NULL;  /* Type conversion path             */
+    bool                  noop_conv     = false; /* Flag to indicate a noop conversion */
+    bool                  write_to_file = false; /* Flag to indicate writing to file */
+    htri_t                parent_is_vlen;        /* Flag to indicate parent is vlen datatype */
+    size_t                bg_seq_len = 0;        /* The number of elements in the background sequence */
+    H5T_t                *tsrc_cpy   = NULL;     /*temporary copy of source base datatype */
+    H5T_t                *tdst_cpy   = NULL;     /*temporary copy of destination base datatype */
+    hid_t                 tsrc_id    = H5I_INVALID_HID; /*temporary type atom */
+    hid_t                 tdst_id    = H5I_INVALID_HID; /*temporary type atom */
+    uint8_t              *s          = NULL;            /*source buffer            */
+    uint8_t              *d          = NULL;            /*destination buffer        */
+    uint8_t              *b          = NULL;            /*background buffer        */
+    ssize_t               s_stride, d_stride;           /*src and dst strides        */
+    ssize_t               b_stride;                     /*bkg stride            */
+    size_t                safe;                  /*how many elements are safe to process in each pass */
+    size_t                src_base_size;         /*source base size*/
+    size_t                dst_base_size;         /*destination base size*/
+    void                 *conv_buf      = NULL;  /*temporary conversion buffer          */
+    size_t                conv_buf_size = 0;     /*size of conversion buffer in bytes */
+    void                 *tmp_buf       = NULL;  /*temporary background buffer          */
+    size_t                tmp_buf_size  = 0;     /*size of temporary bkg buffer         */
+    bool                  nested        = false; /*flag of nested VL case             */
+    size_t                elmtno;                /*element number counter         */
+    herr_t                ret_value = SUCCEED;   /* Return value */
 
     FUNC_ENTER_PACKAGE
 
@@ -3118,7 +3161,7 @@ H5T__conv_vlen(hid_t src_id, hid_t dst_id, H5T_cdata_t *cdata, size_t nelmts, si
              * information that remains (almost) constant for this
              * conversion path.
              */
-            if (NULL == (src = (H5T_t *)H5I_object(src_id)) || NULL == (dst = (H5T_t *)H5I_object(dst_id)))
+            if (NULL == src || NULL == dst)
                 HGOTO_ERROR(H5E_DATATYPE, H5E_BADTYPE, FAIL, "not a datatype");
             if (H5T_VLEN != src->shared->type)
                 HGOTO_ERROR(H5E_DATATYPE, H5E_BADTYPE, FAIL, "not a H5T_VLEN datatype");
@@ -3145,8 +3188,13 @@ H5T__conv_vlen(hid_t src_id, hid_t dst_id, H5T_cdata_t *cdata, size_t nelmts, si
             /*
              * Conversion.
              */
-            if (NULL == (src = (H5T_t *)H5I_object(src_id)) || NULL == (dst = (H5T_t *)H5I_object(dst_id)))
+            if (NULL == src || NULL == dst)
                 HGOTO_ERROR(H5E_ARGS, H5E_BADTYPE, FAIL, "not a datatype");
+            if (NULL == conv_ctx)
+                HGOTO_ERROR(H5E_DATATYPE, H5E_BADVALUE, FAIL, "invalid datatype conversion context pointer");
+
+            /* Initialize temporary conversion context */
+            tmp_conv_ctx = *conv_ctx;
 
             /* Initialize source & destination strides */
             if (buf_stride) {
@@ -3179,26 +3227,33 @@ H5T__conv_vlen(hid_t src_id, hid_t dst_id, H5T_cdata_t *cdata, size_t nelmts, si
                 HGOTO_ERROR(H5E_DATATYPE, H5E_UNSUPPORTED, FAIL,
                             "unable to convert between src and dest datatypes");
             else if (!H5T_path_noop(tpath)) {
-                H5T_t *tsrc_cpy = NULL, *tdst_cpy = NULL;
-
                 if (NULL == (tsrc_cpy = H5T_copy(src->shared->parent, H5T_COPY_ALL)))
-                    HGOTO_ERROR(H5E_DATATYPE, H5E_CANTCOPY, FAIL, "unable to copy src type for conversion");
+                    HGOTO_ERROR(H5E_DATATYPE, H5E_CANTCOPY, FAIL,
+                                "unable to copy src base type for conversion");
                 /* References need to know about the src file */
                 if (tsrc_cpy->shared->type == H5T_REFERENCE)
                     if (H5T_set_loc(tsrc_cpy, src->shared->u.vlen.file, src->shared->u.vlen.loc) < 0)
                         HGOTO_ERROR(H5E_DATATYPE, H5E_CANTSET, FAIL, "can't set datatype location");
 
+                if ((tsrc_id = H5I_register(H5I_DATATYPE, tsrc_cpy, false)) < 0)
+                    HGOTO_ERROR(H5E_DATATYPE, H5E_CANTREGISTER, FAIL,
+                                "unable to register ID for source base datatype");
+
                 if (NULL == (tdst_cpy = H5T_copy(dst->shared->parent, H5T_COPY_ALL)))
-                    HGOTO_ERROR(H5E_DATATYPE, H5E_CANTCOPY, FAIL, "unable to copy dst type for conversion");
+                    HGOTO_ERROR(H5E_DATATYPE, H5E_CANTCOPY, FAIL,
+                                "unable to copy dst base type for conversion");
                 /* References need to know about the dst file */
                 if (tdst_cpy->shared->type == H5T_REFERENCE)
                     if (H5T_set_loc(tdst_cpy, dst->shared->u.vlen.file, dst->shared->u.vlen.loc) < 0)
                         HGOTO_ERROR(H5E_DATATYPE, H5E_CANTSET, FAIL, "can't set datatype location");
 
-                if (((tsrc_id = H5I_register(H5I_DATATYPE, tsrc_cpy, false)) < 0) ||
-                    ((tdst_id = H5I_register(H5I_DATATYPE, tdst_cpy, false)) < 0))
-                    HGOTO_ERROR(H5E_DATASET, H5E_CANTREGISTER, FAIL,
-                                "unable to register types for conversion");
+                if ((tdst_id = H5I_register(H5I_DATATYPE, tdst_cpy, false)) < 0)
+                    HGOTO_ERROR(H5E_DATATYPE, H5E_CANTREGISTER, FAIL,
+                                "unable to register ID for destination base datatype");
+
+                /* Update IDs in conversion context */
+                tmp_conv_ctx.src_type_id = tsrc_id;
+                tmp_conv_ctx.dst_type_id = tdst_id;
             } /* end else-if */
             else
                 noop_conv = true;
@@ -3374,9 +3429,10 @@ H5T__conv_vlen(hid_t src_id, hid_t dst_id, H5T_cdata_t *cdata, size_t nelmts, si
                             } /* end if */
 
                             /* Convert VL sequence */
-                            if (H5T_convert(tpath, tsrc_id, tdst_id, seq_len, (size_t)0, (size_t)0, conv_buf,
-                                            tmp_buf) < 0)
-                                HGOTO_ERROR(H5E_DATATYPE, H5E_CANTINIT, FAIL, "datatype conversion failed");
+                            if (H5T_convert_with_ctx(tpath, tsrc_cpy, tdst_cpy, &tmp_conv_ctx, seq_len,
+                                                     (size_t)0, (size_t)0, conv_buf, tmp_buf) < 0)
+                                HGOTO_ERROR(H5E_DATATYPE, H5E_CANTCONVERT, FAIL,
+                                            "datatype conversion failed");
                         } /* end if */
 
                         /* Write sequence to destination location */
@@ -3417,11 +3473,6 @@ H5T__conv_vlen(hid_t src_id, hid_t dst_id, H5T_cdata_t *cdata, size_t nelmts, si
                 nelmts -= safe;
             } /* end while */
 
-            /* Release the temporary datatype IDs used */
-            if (tsrc_id >= 0)
-                H5I_dec_ref(tsrc_id);
-            if (tdst_id >= 0)
-                H5I_dec_ref(tdst_id);
             break;
 
         default: /* Some other command we don't know about yet.*/
@@ -3429,6 +3480,23 @@ H5T__conv_vlen(hid_t src_id, hid_t dst_id, H5T_cdata_t *cdata, size_t nelmts, si
     } /* end switch */
 
 done:
+    if (tsrc_id >= 0) {
+        if (H5I_dec_ref(tsrc_id) < 0)
+            HDONE_ERROR(H5E_DATATYPE, H5E_CANTDEC, FAIL, "can't decrement reference on temporary ID");
+    }
+    else if (tsrc_cpy) {
+        if (H5T_close(tsrc_cpy) < 0)
+            HDONE_ERROR(H5E_DATATYPE, H5E_CANTCLOSEOBJ, FAIL, "can't close temporary datatype");
+    }
+    if (tdst_id >= 0) {
+        if (H5I_dec_ref(tdst_id) < 0)
+            HDONE_ERROR(H5E_DATATYPE, H5E_CANTDEC, FAIL, "can't decrement reference on temporary ID");
+    }
+    else if (tdst_cpy) {
+        if (H5T_close(tdst_cpy) < 0)
+            HDONE_ERROR(H5E_DATATYPE, H5E_CANTCLOSEOBJ, FAIL, "can't close temporary datatype");
+    }
+
     /* If the conversion buffer doesn't need to be freed, reset its pointer */
     if (write_to_file && noop_conv)
         conv_buf = NULL;
@@ -3453,20 +3521,20 @@ done:
  *-------------------------------------------------------------------------
  */
 herr_t
-H5T__conv_array(hid_t src_id, hid_t dst_id, H5T_cdata_t *cdata, size_t nelmts, size_t buf_stride,
-                size_t bkg_stride, void *_buf, void H5_ATTR_UNUSED *_bkg)
+H5T__conv_array(H5T_t *src, H5T_t *dst, H5T_cdata_t *cdata, const H5T_conv_ctx_t H5_ATTR_UNUSED *conv_ctx,
+                size_t nelmts, size_t buf_stride, size_t bkg_stride, void *_buf, void H5_ATTR_UNUSED *_bkg)
 {
-    H5T_path_t *tpath;                      /* Type conversion path             */
-    hid_t       tsrc_id = -1, tdst_id = -1; /*temporary type atoms         */
-    H5T_t      *src = NULL;                 /*source datatype             */
-    H5T_t      *dst = NULL;                 /*destination datatype             */
-    uint8_t    *sp, *dp;                    /*source and dest traversal ptrs     */
-    ssize_t     src_delta, dst_delta;       /*source & destination stride         */
-    int         direction;                  /*direction of traversal         */
-    size_t      elmtno;                     /*element number counter         */
-    unsigned    u;                          /* local index variable */
-    void       *bkg_buf   = NULL;           /*temporary background buffer          */
-    herr_t      ret_value = SUCCEED;        /* Return value */
+    H5T_conv_ctx_t tmp_conv_ctx = {0};         /* Temporary conversion context */
+    H5T_path_t    *tpath;                      /* Type conversion path             */
+    H5T_t         *tsrc_cpy = NULL;            /*temporary copy of source base datatype */
+    H5T_t         *tdst_cpy = NULL;            /*temporary copy of destination base datatype */
+    hid_t          tsrc_id  = H5I_INVALID_HID; /*temporary type atom */
+    hid_t          tdst_id  = H5I_INVALID_HID; /*temporary type atom */
+    uint8_t       *sp, *dp;                    /*source and dest traversal ptrs     */
+    ssize_t        src_delta, dst_delta;       /*source & destination stride         */
+    int            direction;                  /*direction of traversal         */
+    void          *bkg_buf   = NULL;           /*temporary background buffer          */
+    herr_t         ret_value = SUCCEED;        /* Return value */
 
     FUNC_ENTER_PACKAGE
 
@@ -3474,12 +3542,12 @@ H5T__conv_array(hid_t src_id, hid_t dst_id, H5T_cdata_t *cdata, size_t nelmts, s
         case H5T_CONV_INIT:
             /*
              * First, determine if this conversion function applies to the
-             * conversion path SRC_ID-->DST_ID.  If not, return failure;
+             * conversion path SRC-->DST.  If not, return failure;
              * otherwise initialize the `priv' field of `cdata' with
              * information that remains (almost) constant for this
              * conversion path.
              */
-            if (NULL == (src = (H5T_t *)H5I_object(src_id)) || NULL == (dst = (H5T_t *)H5I_object(dst_id)))
+            if (NULL == src || NULL == dst)
                 HGOTO_ERROR(H5E_ARGS, H5E_BADTYPE, FAIL, "not a datatype");
             assert(H5T_ARRAY == src->shared->type);
             assert(H5T_ARRAY == dst->shared->type);
@@ -3488,7 +3556,7 @@ H5T__conv_array(hid_t src_id, hid_t dst_id, H5T_cdata_t *cdata, size_t nelmts, s
             if (src->shared->u.array.ndims != dst->shared->u.array.ndims)
                 HGOTO_ERROR(H5E_DATATYPE, H5E_UNSUPPORTED, FAIL,
                             "array datatypes do not have the same number of dimensions");
-            for (u = 0; u < src->shared->u.array.ndims; u++)
+            for (unsigned u = 0; u < src->shared->u.array.ndims; u++)
                 if (src->shared->u.array.dim[u] != dst->shared->u.array.dim[u])
                     HGOTO_ERROR(H5E_DATATYPE, H5E_UNSUPPORTED, FAIL,
                                 "array datatypes do not have the same sizes of dimensions");
@@ -3506,8 +3574,13 @@ H5T__conv_array(hid_t src_id, hid_t dst_id, H5T_cdata_t *cdata, size_t nelmts, s
             /*
              * Conversion.
              */
-            if (NULL == (src = (H5T_t *)H5I_object(src_id)) || NULL == (dst = (H5T_t *)H5I_object(dst_id)))
+            if (NULL == src || NULL == dst)
                 HGOTO_ERROR(H5E_ARGS, H5E_BADTYPE, FAIL, "not a datatype");
+            if (NULL == conv_ctx)
+                HGOTO_ERROR(H5E_DATATYPE, H5E_BADVALUE, FAIL, "invalid datatype conversion context pointer");
+
+            /* Initialize temporary conversion context */
+            tmp_conv_ctx = *conv_ctx;
 
             /*
              * Do we process the values from beginning to end or vice
@@ -3539,12 +3612,23 @@ H5T__conv_array(hid_t src_id, hid_t dst_id, H5T_cdata_t *cdata, size_t nelmts, s
                             "unable to convert between src and dest datatypes");
             }
             else if (!H5T_path_noop(tpath)) {
-                if ((tsrc_id = H5I_register(H5I_DATATYPE, H5T_copy(src->shared->parent, H5T_COPY_ALL),
-                                            false)) < 0 ||
-                    (tdst_id =
-                         H5I_register(H5I_DATATYPE, H5T_copy(dst->shared->parent, H5T_COPY_ALL), false)) < 0)
-                    HGOTO_ERROR(H5E_DATASET, H5E_CANTREGISTER, FAIL,
-                                "unable to register types for conversion");
+                if (NULL == (tsrc_cpy = H5T_copy(src->shared->parent, H5T_COPY_ALL)))
+                    HGOTO_ERROR(H5E_DATATYPE, H5E_CANTCOPY, FAIL,
+                                "unable to copy src base type for conversion");
+                if ((tsrc_id = H5I_register(H5I_DATATYPE, tsrc_cpy, false)) < 0)
+                    HGOTO_ERROR(H5E_DATATYPE, H5E_CANTREGISTER, FAIL,
+                                "unable to register ID for source base datatype");
+
+                if (NULL == (tdst_cpy = H5T_copy(dst->shared->parent, H5T_COPY_ALL)))
+                    HGOTO_ERROR(H5E_DATATYPE, H5E_CANTCOPY, FAIL,
+                                "unable to copy dst base type for conversion");
+                if ((tdst_id = H5I_register(H5I_DATATYPE, tdst_cpy, false)) < 0)
+                    HGOTO_ERROR(H5E_DATATYPE, H5E_CANTREGISTER, FAIL,
+                                "unable to register ID for destination base datatype");
+
+                /* Update IDs in conversion context */
+                tmp_conv_ctx.src_type_id = tsrc_id;
+                tmp_conv_ctx.dst_type_id = tdst_id;
             }
 
             /* Check if we need a background buffer for this conversion */
@@ -3559,25 +3643,20 @@ H5T__conv_array(hid_t src_id, hid_t dst_id, H5T_cdata_t *cdata, size_t nelmts, s
             } /* end if */
 
             /* Perform the actual conversion */
-            for (elmtno = 0; elmtno < nelmts; elmtno++) {
+            for (size_t elmtno = 0; elmtno < nelmts; elmtno++) {
                 /* Copy the source array into the correct location for the destination */
                 memmove(dp, sp, src->shared->size);
 
                 /* Convert array */
-                if (H5T_convert(tpath, tsrc_id, tdst_id, src->shared->u.array.nelem, (size_t)0, bkg_stride,
-                                dp, bkg_buf) < 0)
-                    HGOTO_ERROR(H5E_DATATYPE, H5E_CANTINIT, FAIL, "datatype conversion failed");
+                if (H5T_convert_with_ctx(tpath, tsrc_cpy, tdst_cpy, &tmp_conv_ctx, src->shared->u.array.nelem,
+                                         (size_t)0, bkg_stride, dp, bkg_buf) < 0)
+                    HGOTO_ERROR(H5E_DATATYPE, H5E_CANTCONVERT, FAIL, "datatype conversion failed");
 
                 /* Advance the source & destination pointers */
                 sp += src_delta;
                 dp += dst_delta;
             } /* end for */
 
-            /* Release the temporary datatype IDs used */
-            if (tsrc_id >= 0)
-                H5I_dec_ref(tsrc_id);
-            if (tdst_id >= 0)
-                H5I_dec_ref(tdst_id);
             break;
 
         default: /* Some other command we don't know about yet.*/
@@ -3585,6 +3664,23 @@ H5T__conv_array(hid_t src_id, hid_t dst_id, H5T_cdata_t *cdata, size_t nelmts, s
     } /* end switch */
 
 done:
+    if (tsrc_id >= 0) {
+        if (H5I_dec_ref(tsrc_id) < 0)
+            HDONE_ERROR(H5E_DATATYPE, H5E_CANTDEC, FAIL, "can't decrement reference on temporary ID");
+    }
+    else if (tsrc_cpy) {
+        if (H5T_close(tsrc_cpy) < 0)
+            HDONE_ERROR(H5E_DATATYPE, H5E_CANTCLOSEOBJ, FAIL, "can't close temporary datatype");
+    }
+    if (tdst_id >= 0) {
+        if (H5I_dec_ref(tdst_id) < 0)
+            HDONE_ERROR(H5E_DATATYPE, H5E_CANTDEC, FAIL, "can't decrement reference on temporary ID");
+    }
+    else if (tdst_cpy) {
+        if (H5T_close(tdst_cpy) < 0)
+            HDONE_ERROR(H5E_DATATYPE, H5E_CANTCLOSEOBJ, FAIL, "can't close temporary datatype");
+    }
+
     /* Release the background buffer, if we have one */
     if (bkg_buf)
         bkg_buf = H5FL_BLK_FREE(array_seq, bkg_buf);
@@ -3603,14 +3699,12 @@ done:
  *-------------------------------------------------------------------------
  */
 herr_t
-H5T__conv_ref(hid_t src_id, hid_t dst_id, H5T_cdata_t *cdata, size_t nelmts, size_t buf_stride,
-              size_t bkg_stride, void *buf, void *bkg)
+H5T__conv_ref(H5T_t *src, H5T_t *dst, H5T_cdata_t *cdata, const H5T_conv_ctx_t H5_ATTR_UNUSED *conv_ctx,
+              size_t nelmts, size_t buf_stride, size_t bkg_stride, void *buf, void *bkg)
 {
-    H5T_t   *src = NULL;           /* source datatype                      */
-    H5T_t   *dst = NULL;           /* destination datatype                 */
-    uint8_t *s   = NULL;           /* source buffer                        */
-    uint8_t *d   = NULL;           /* destination buffer                   */
-    uint8_t *b   = NULL;           /* background buffer                    */
+    uint8_t *s = NULL;             /* source buffer                        */
+    uint8_t *d = NULL;             /* destination buffer                   */
+    uint8_t *b = NULL;             /* background buffer                    */
     ssize_t  s_stride, d_stride;   /* src and dst strides                  */
     ssize_t  b_stride;             /* bkg stride                           */
     size_t   safe;                 /* how many elements are safe to process in each pass */
@@ -3625,12 +3719,12 @@ H5T__conv_ref(hid_t src_id, hid_t dst_id, H5T_cdata_t *cdata, size_t nelmts, siz
         case H5T_CONV_INIT:
             /*
              * First, determine if this conversion function applies to the
-             * conversion path SRC_ID-->DST_ID.  If not, return failure;
+             * conversion path SRC-->DST.  If not, return failure;
              * otherwise initialize the `priv' field of `cdata' with
              * information that remains (almost) constant for this
              * conversion path.
              */
-            if (NULL == (src = (H5T_t *)H5I_object(src_id)) || NULL == (dst = (H5T_t *)H5I_object(dst_id)))
+            if (NULL == src || NULL == dst)
                 HGOTO_ERROR(H5E_DATATYPE, H5E_BADTYPE, FAIL, "not a datatype");
             if (H5T_REFERENCE != src->shared->type)
                 HGOTO_ERROR(H5E_DATATYPE, H5E_BADTYPE, FAIL, "not a H5T_REFERENCE datatype");
@@ -3651,7 +3745,7 @@ H5T__conv_ref(hid_t src_id, hid_t dst_id, H5T_cdata_t *cdata, size_t nelmts, siz
             /*
              * Conversion.
              */
-            if (NULL == (src = (H5T_t *)H5I_object(src_id)) || NULL == (dst = (H5T_t *)H5I_object(dst_id)))
+            if (NULL == src || NULL == dst)
                 HGOTO_ERROR(H5E_ARGS, H5E_BADTYPE, FAIL, "not a datatype");
 
             assert(src->shared->u.atomic.u.r.cls);
@@ -3815,11 +3909,9 @@ done:
  *-------------------------------------------------------------------------
  */
 herr_t
-H5T__conv_i_i(hid_t src_id, hid_t dst_id, H5T_cdata_t *cdata, size_t nelmts, size_t buf_stride,
-              size_t H5_ATTR_UNUSED bkg_stride, void *buf, void H5_ATTR_UNUSED *bkg)
+H5T__conv_i_i(H5T_t *src, H5T_t *dst, H5T_cdata_t *cdata, const H5T_conv_ctx_t *conv_ctx, size_t nelmts,
+              size_t buf_stride, size_t H5_ATTR_UNUSED bkg_stride, void *buf, void H5_ATTR_UNUSED *bkg)
 {
-    H5T_t         *src = NULL;           /*source datatype        */
-    H5T_t         *dst = NULL;           /*destination datatype        */
     ssize_t        src_delta, dst_delta; /*source & destination stride    */
     int            direction;            /*direction of traversal    */
     size_t         elmtno;               /*element number        */
@@ -3829,18 +3921,17 @@ H5T__conv_i_i(hid_t src_id, hid_t dst_id, H5T_cdata_t *cdata, size_t nelmts, siz
     uint8_t       *src_rev  = NULL;      /*order-reversed source buffer  */
     uint8_t        dbuf[64] = {0};       /*temp destination buffer    */
     size_t         first;
-    ssize_t        sfirst;                   /*a signed version of `first'    */
-    size_t         i;                        /*Local index variables         */
-    H5T_conv_cb_t  cb_struct = {NULL, NULL}; /*conversion callback structure */
-    H5T_conv_ret_t except_ret;               /*return of callback function   */
-    bool           reverse;                  /*if reverse the order of destination        */
-    herr_t         ret_value = SUCCEED;      /* Return value */
+    ssize_t        sfirst;              /*a signed version of `first'    */
+    size_t         i;                   /*Local index variables         */
+    H5T_conv_ret_t except_ret;          /*return of callback function   */
+    bool           reverse;             /*if reverse the order of destination        */
+    herr_t         ret_value = SUCCEED; /* Return value */
 
     FUNC_ENTER_PACKAGE
 
     switch (cdata->command) {
         case H5T_CONV_INIT:
-            if (NULL == (src = (H5T_t *)H5I_object(src_id)) || NULL == (dst = (H5T_t *)H5I_object(dst_id)))
+            if (NULL == src || NULL == dst)
                 HGOTO_ERROR(H5E_ARGS, H5E_BADTYPE, FAIL, "not a datatype");
             if (H5T_ORDER_LE != src->shared->u.atomic.order && H5T_ORDER_BE != src->shared->u.atomic.order)
                 HGOTO_ERROR(H5E_DATATYPE, H5E_UNSUPPORTED, FAIL, "unsupported byte order");
@@ -3855,9 +3946,10 @@ H5T__conv_i_i(hid_t src_id, hid_t dst_id, H5T_cdata_t *cdata, size_t nelmts, siz
             break;
 
         case H5T_CONV_CONV:
-            /* Get the datatypes */
-            if (NULL == (src = (H5T_t *)H5I_object(src_id)) || NULL == (dst = (H5T_t *)H5I_object(dst_id)))
+            if (NULL == src || NULL == dst)
                 HGOTO_ERROR(H5E_ARGS, H5E_BADTYPE, FAIL, "not a datatype");
+            if (NULL == conv_ctx)
+                HGOTO_ERROR(H5E_ARGS, H5E_BADVALUE, FAIL, "invalid datatype conversion context pointer");
 
             /*
              * Do we process the values from beginning to end or vice versa? Also,
@@ -3894,10 +3986,6 @@ H5T__conv_i_i(hid_t src_id, hid_t dst_id, H5T_cdata_t *cdata, size_t nelmts, siz
             H5_CHECK_OVERFLOW(dst->shared->size, size_t, ssize_t);
             src_delta = (ssize_t)direction * (ssize_t)(buf_stride ? buf_stride : src->shared->size);
             dst_delta = (ssize_t)direction * (ssize_t)(buf_stride ? buf_stride : dst->shared->size);
-
-            /* Get conversion exception callback property */
-            if (H5CX_get_dt_conv_cb(&cb_struct) < 0)
-                HGOTO_ERROR(H5E_DATATYPE, H5E_CANTGET, FAIL, "unable to get conversion exception callback");
 
             /* Allocate space for order-reversed source buffer */
             src_rev = (uint8_t *)H5MM_calloc(src->shared->size);
@@ -3978,11 +4066,12 @@ H5T__conv_i_i(hid_t src_id, hid_t dst_id, H5T_cdata_t *cdata, size_t nelmts, siz
                     }
                     else if (first >= dst->shared->u.atomic.prec) {
                         /*overflow*/
-                        if (cb_struct.func) { /*If user's exception handler is present, use it*/
+                        if (conv_ctx->cb_struct.func) { /*If user's exception handler is present, use it*/
                             H5T__reverse_order(src_rev, s, src->shared->size,
                                                src->shared->u.atomic.order); /*reverse order first*/
-                            except_ret = (cb_struct.func)(H5T_CONV_EXCEPT_RANGE_HI, src_id, dst_id, src_rev,
-                                                          d, cb_struct.user_data);
+                            except_ret = (conv_ctx->cb_struct.func)(
+                                H5T_CONV_EXCEPT_RANGE_HI, conv_ctx->src_type_id, conv_ctx->dst_type_id,
+                                src_rev, d, conv_ctx->cb_struct.user_data);
                         }
 
                         if (except_ret == H5T_CONV_UNHANDLED) {
@@ -4011,11 +4100,12 @@ H5T__conv_i_i(hid_t src_id, hid_t dst_id, H5T_cdata_t *cdata, size_t nelmts, siz
                      */
                     if (first + 1 == src->shared->u.atomic.prec) {
                         /*overflow - source is negative*/
-                        if (cb_struct.func) { /*If user's exception handler is present, use it*/
+                        if (conv_ctx->cb_struct.func) { /*If user's exception handler is present, use it*/
                             H5T__reverse_order(src_rev, s, src->shared->size,
                                                src->shared->u.atomic.order); /*reverse order first*/
-                            except_ret = (cb_struct.func)(H5T_CONV_EXCEPT_RANGE_LOW, src_id, dst_id, src_rev,
-                                                          d, cb_struct.user_data);
+                            except_ret = (conv_ctx->cb_struct.func)(
+                                H5T_CONV_EXCEPT_RANGE_LOW, conv_ctx->src_type_id, conv_ctx->dst_type_id,
+                                src_rev, d, conv_ctx->cb_struct.user_data);
                         }
 
                         if (except_ret == H5T_CONV_UNHANDLED) {
@@ -4036,11 +4126,12 @@ H5T__conv_i_i(hid_t src_id, hid_t dst_id, H5T_cdata_t *cdata, size_t nelmts, siz
                     }
                     else if (first >= dst->shared->u.atomic.prec) {
                         /*overflow - source is positive*/
-                        if (cb_struct.func) { /*If user's exception handler is present, use it*/
+                        if (conv_ctx->cb_struct.func) { /*If user's exception handler is present, use it*/
                             H5T__reverse_order(src_rev, s, src->shared->size,
                                                src->shared->u.atomic.order); /*reverse order first*/
-                            except_ret = (cb_struct.func)(H5T_CONV_EXCEPT_RANGE_HI, src_id, dst_id, src_rev,
-                                                          d, cb_struct.user_data);
+                            except_ret = (conv_ctx->cb_struct.func)(
+                                H5T_CONV_EXCEPT_RANGE_HI, conv_ctx->src_type_id, conv_ctx->dst_type_id,
+                                src_rev, d, conv_ctx->cb_struct.user_data);
                         }
 
                         if (except_ret == H5T_CONV_UNHANDLED)
@@ -4066,11 +4157,12 @@ H5T__conv_i_i(hid_t src_id, hid_t dst_id, H5T_cdata_t *cdata, size_t nelmts, siz
                      */
                     if (first + 1 >= dst->shared->u.atomic.prec) {
                         /*overflow*/
-                        if (cb_struct.func) { /*If user's exception handler is present, use it*/
+                        if (conv_ctx->cb_struct.func) { /*If user's exception handler is present, use it*/
                             H5T__reverse_order(src_rev, s, src->shared->size,
                                                src->shared->u.atomic.order); /*reverse order first*/
-                            except_ret = (cb_struct.func)(H5T_CONV_EXCEPT_RANGE_HI, src_id, dst_id, src_rev,
-                                                          d, cb_struct.user_data);
+                            except_ret = (conv_ctx->cb_struct.func)(
+                                H5T_CONV_EXCEPT_RANGE_HI, conv_ctx->src_type_id, conv_ctx->dst_type_id,
+                                src_rev, d, conv_ctx->cb_struct.user_data);
                         }
 
                         if (except_ret == H5T_CONV_UNHANDLED) {
@@ -4111,11 +4203,12 @@ H5T__conv_i_i(hid_t src_id, hid_t dst_id, H5T_cdata_t *cdata, size_t nelmts, siz
 
                     if (sfz >= 0 && fz + 1 >= dst->shared->u.atomic.prec) {
                         /*overflow*/
-                        if (cb_struct.func) { /*If user's exception handler is present, use it*/
+                        if (conv_ctx->cb_struct.func) { /*If user's exception handler is present, use it*/
                             H5T__reverse_order(src_rev, s, src->shared->size,
                                                src->shared->u.atomic.order); /*reverse order first*/
-                            except_ret = (cb_struct.func)(H5T_CONV_EXCEPT_RANGE_LOW, src_id, dst_id, src_rev,
-                                                          d, cb_struct.user_data);
+                            except_ret = (conv_ctx->cb_struct.func)(
+                                H5T_CONV_EXCEPT_RANGE_LOW, conv_ctx->src_type_id, conv_ctx->dst_type_id,
+                                src_rev, d, conv_ctx->cb_struct.user_data);
                         }
 
                         if (except_ret == H5T_CONV_UNHANDLED) {
@@ -4151,11 +4244,12 @@ H5T__conv_i_i(hid_t src_id, hid_t dst_id, H5T_cdata_t *cdata, size_t nelmts, siz
                      */
                     if (first + 1 >= dst->shared->u.atomic.prec) {
                         /*overflow*/
-                        if (cb_struct.func) { /*If user's exception handler is present, use it*/
+                        if (conv_ctx->cb_struct.func) { /*If user's exception handler is present, use it*/
                             H5T__reverse_order(src_rev, s, src->shared->size,
                                                src->shared->u.atomic.order); /*reverse order first*/
-                            except_ret = (cb_struct.func)(H5T_CONV_EXCEPT_RANGE_HI, src_id, dst_id, src_rev,
-                                                          d, cb_struct.user_data);
+                            except_ret = (conv_ctx->cb_struct.func)(
+                                H5T_CONV_EXCEPT_RANGE_HI, conv_ctx->src_type_id, conv_ctx->dst_type_id,
+                                src_rev, d, conv_ctx->cb_struct.user_data);
                         }
 
                         if (except_ret == H5T_CONV_UNHANDLED) {
@@ -4250,12 +4344,10 @@ done:
  *-------------------------------------------------------------------------
  */
 herr_t
-H5T__conv_f_f(hid_t src_id, hid_t dst_id, H5T_cdata_t *cdata, size_t nelmts, size_t buf_stride,
-              size_t H5_ATTR_UNUSED bkg_stride, void *buf, void H5_ATTR_UNUSED *bkg)
+H5T__conv_f_f(H5T_t *src_p, H5T_t *dst_p, H5T_cdata_t *cdata, const H5T_conv_ctx_t *conv_ctx, size_t nelmts,
+              size_t buf_stride, size_t H5_ATTR_UNUSED bkg_stride, void *buf, void H5_ATTR_UNUSED *bkg)
 {
     /* Traversal-related variables */
-    H5T_t       *src_p;                /*source datatype        */
-    H5T_t       *dst_p;                /*destination datatype        */
     H5T_atomic_t src;                  /*atomic source info        */
     H5T_atomic_t dst;                  /*atomic destination info    */
     ssize_t      src_delta, dst_delta; /*source & destination stride    */
@@ -4271,27 +4363,25 @@ H5T__conv_f_f(hid_t src_id, hid_t dst_id, H5T_cdata_t *cdata, size_t nelmts, siz
     uint8_t      tmp1, tmp2;           /*temp variables for swapping bytes*/
 
     /* Conversion-related variables */
-    int64_t        expo;                        /*exponent            */
-    hssize_t       expo_max;                    /*maximum possible dst exponent    */
-    size_t         msize = 0;                   /*useful size of mantissa in src*/
-    size_t         mpos;                        /*offset to useful mant is src    */
-    uint64_t       sign;                        /*source sign bit value         */
-    size_t         mrsh;                        /*amount to right shift mantissa*/
-    bool           carry = false;               /*carry after rounding mantissa    */
-    size_t         i;                           /*miscellaneous counters    */
-    size_t         implied;                     /*destination implied bits    */
-    bool           denormalized = false;        /*is either source or destination denormalized?*/
-    H5T_conv_cb_t  cb_struct    = {NULL, NULL}; /*conversion callback structure */
-    H5T_conv_ret_t except_ret;                  /*return of callback function   */
-    bool           reverse;                     /*if reverse the order of destination        */
-    herr_t         ret_value = SUCCEED;         /*return value                 */
+    int64_t        expo;                 /*exponent            */
+    hssize_t       expo_max;             /*maximum possible dst exponent    */
+    size_t         msize = 0;            /*useful size of mantissa in src*/
+    size_t         mpos;                 /*offset to useful mant is src    */
+    uint64_t       sign;                 /*source sign bit value         */
+    size_t         mrsh;                 /*amount to right shift mantissa*/
+    bool           carry = false;        /*carry after rounding mantissa    */
+    size_t         i;                    /*miscellaneous counters    */
+    size_t         implied;              /*destination implied bits    */
+    bool           denormalized = false; /*is either source or destination denormalized?*/
+    H5T_conv_ret_t except_ret;           /*return of callback function   */
+    bool           reverse;              /*if reverse the order of destination        */
+    herr_t         ret_value = SUCCEED;  /*return value                 */
 
     FUNC_ENTER_PACKAGE
 
     switch (cdata->command) {
         case H5T_CONV_INIT:
-            if (NULL == (src_p = (H5T_t *)H5I_object(src_id)) ||
-                NULL == (dst_p = (H5T_t *)H5I_object(dst_id)))
+            if (NULL == src_p || NULL == dst_p)
                 HGOTO_ERROR(H5E_ARGS, H5E_BADTYPE, FAIL, "not a datatype");
             src = src_p->shared->u.atomic;
             dst = dst_p->shared->u.atomic;
@@ -4310,10 +4400,11 @@ H5T__conv_f_f(hid_t src_id, hid_t dst_id, H5T_cdata_t *cdata, size_t nelmts, siz
             break;
 
         case H5T_CONV_CONV:
-            /* Get the datatypes */
-            if (NULL == (src_p = (H5T_t *)H5I_object(src_id)) ||
-                NULL == (dst_p = (H5T_t *)H5I_object(dst_id)))
+            if (NULL == src_p || NULL == dst_p)
                 HGOTO_ERROR(H5E_ARGS, H5E_BADTYPE, FAIL, "not a datatype");
+            if (NULL == conv_ctx)
+                HGOTO_ERROR(H5E_ARGS, H5E_BADVALUE, FAIL, "invalid datatype conversion context pointer");
+
             src      = src_p->shared->u.atomic;
             dst      = dst_p->shared->u.atomic;
             expo_max = ((hssize_t)1 << dst.u.f.esize) - 1;
@@ -4352,10 +4443,6 @@ H5T__conv_f_f(hid_t src_id, hid_t dst_id, H5T_cdata_t *cdata, size_t nelmts, siz
             H5_CHECK_OVERFLOW(dst_p->shared->size, size_t, ssize_t);
             src_delta = (ssize_t)direction * (ssize_t)(buf_stride ? buf_stride : src_p->shared->size);
             dst_delta = (ssize_t)direction * (ssize_t)(buf_stride ? buf_stride : dst_p->shared->size);
-
-            /* Get conversion exception callback property */
-            if (H5CX_get_dt_conv_cb(&cb_struct) < 0)
-                HGOTO_ERROR(H5E_DATATYPE, H5E_CANTGET, FAIL, "unable to get conversion exception callback");
 
             /* Allocate space for order-reversed source buffer */
             src_rev = (uint8_t *)H5MM_calloc(src_p->shared->size);
@@ -4437,16 +4524,18 @@ H5T__conv_f_f(hid_t src_id, hid_t dst_id, H5T_cdata_t *cdata, size_t nelmts, siz
                     }
                     else if (H5T__bit_find(s, src.u.f.epos, src.u.f.esize, H5T_BIT_LSB, false) < 0) {
                         /* +Inf or -Inf */
-                        if (cb_struct.func) { /*If user's exception handler is present, use it*/
+                        if (conv_ctx->cb_struct.func) { /*If user's exception handler is present, use it*/
                             /*reverse order first*/
                             H5T__reverse_order(src_rev, s, src_p->shared->size,
                                                src_p->shared->u.atomic.order);
                             if (sign)
-                                except_ret = (cb_struct.func)(H5T_CONV_EXCEPT_NINF, src_id, dst_id, src_rev,
-                                                              d, cb_struct.user_data);
+                                except_ret = (conv_ctx->cb_struct.func)(
+                                    H5T_CONV_EXCEPT_NINF, conv_ctx->src_type_id, conv_ctx->dst_type_id,
+                                    src_rev, d, conv_ctx->cb_struct.user_data);
                             else
-                                except_ret = (cb_struct.func)(H5T_CONV_EXCEPT_PINF, src_id, dst_id, src_rev,
-                                                              d, cb_struct.user_data);
+                                except_ret = (conv_ctx->cb_struct.func)(
+                                    H5T_CONV_EXCEPT_PINF, conv_ctx->src_type_id, conv_ctx->dst_type_id,
+                                    src_rev, d, conv_ctx->cb_struct.user_data);
                         }
 
                         if (except_ret == H5T_CONV_UNHANDLED) {
@@ -4478,15 +4567,17 @@ H5T__conv_f_f(hid_t src_id, hid_t dst_id, H5T_cdata_t *cdata, size_t nelmts, siz
                      *If the exponent bits are all 1s and only the 1st bit of mantissa
                      *is set to 1.  It's infinity. The Intel-Linux "long double" is this case.*/
                     /* +Inf or -Inf */
-                    if (cb_struct.func) { /*If user's exception handler is present, use it*/
+                    if (conv_ctx->cb_struct.func) { /*If user's exception handler is present, use it*/
                         /*reverse order first*/
                         H5T__reverse_order(src_rev, s, src_p->shared->size, src_p->shared->u.atomic.order);
                         if (sign)
-                            except_ret = (cb_struct.func)(H5T_CONV_EXCEPT_NINF, src_id, dst_id, src_rev, d,
-                                                          cb_struct.user_data);
+                            except_ret = (conv_ctx->cb_struct.func)(
+                                H5T_CONV_EXCEPT_NINF, conv_ctx->src_type_id, conv_ctx->dst_type_id, src_rev,
+                                d, conv_ctx->cb_struct.user_data);
                         else
-                            except_ret = (cb_struct.func)(H5T_CONV_EXCEPT_PINF, src_id, dst_id, src_rev, d,
-                                                          cb_struct.user_data);
+                            except_ret = (conv_ctx->cb_struct.func)(
+                                H5T_CONV_EXCEPT_PINF, conv_ctx->src_type_id, conv_ctx->dst_type_id, src_rev,
+                                d, conv_ctx->cb_struct.user_data);
                     }
 
                     if (except_ret == H5T_CONV_UNHANDLED) {
@@ -4516,11 +4607,12 @@ H5T__conv_f_f(hid_t src_id, hid_t dst_id, H5T_cdata_t *cdata, size_t nelmts, siz
                 }
                 else if (H5T__bit_find(s, src.u.f.epos, src.u.f.esize, H5T_BIT_LSB, false) < 0) {
                     /* NaN */
-                    if (cb_struct.func) { /*If user's exception handler is present, use it*/
+                    if (conv_ctx->cb_struct.func) { /*If user's exception handler is present, use it*/
                         /*reverse order first*/
                         H5T__reverse_order(src_rev, s, src_p->shared->size, src_p->shared->u.atomic.order);
-                        except_ret = (cb_struct.func)(H5T_CONV_EXCEPT_NAN, src_id, dst_id, src_rev, d,
-                                                      cb_struct.user_data);
+                        except_ret = (conv_ctx->cb_struct.func)(H5T_CONV_EXCEPT_NAN, conv_ctx->src_type_id,
+                                                                conv_ctx->dst_type_id, src_rev, d,
+                                                                conv_ctx->cb_struct.user_data);
                     }
 
                     if (except_ret == H5T_CONV_UNHANDLED) {
@@ -4637,11 +4729,12 @@ H5T__conv_f_f(hid_t src_id, hid_t dst_id, H5T_cdata_t *cdata, size_t nelmts, siz
                      * handler make sure the source buffer we hand it is in the
                      * original byte order.
                      */
-                    if (cb_struct.func) { /*If user's exception handler is present, use it*/
+                    if (conv_ctx->cb_struct.func) { /*If user's exception handler is present, use it*/
                         /*reverse order first*/
                         H5T__reverse_order(src_rev, s, src_p->shared->size, src_p->shared->u.atomic.order);
-                        except_ret = (cb_struct.func)(H5T_CONV_EXCEPT_RANGE_HI, src_id, dst_id, src_rev, d,
-                                                      cb_struct.user_data);
+                        except_ret = (conv_ctx->cb_struct.func)(H5T_CONV_EXCEPT_RANGE_HI,
+                                                                conv_ctx->src_type_id, conv_ctx->dst_type_id,
+                                                                src_rev, d, conv_ctx->cb_struct.user_data);
                     }
 
                     if (except_ret == H5T_CONV_UNHANDLED) {
@@ -4727,12 +4820,13 @@ H5T__conv_f_f(hid_t src_id, hid_t dst_id, H5T_cdata_t *cdata, size_t nelmts, siz
                          * calling the overflow handler make sure the source
                          * buffer we hand it is in the original byte order.
                          */
-                        if (cb_struct.func) { /*If user's exception handler is present, use it*/
+                        if (conv_ctx->cb_struct.func) { /*If user's exception handler is present, use it*/
                             /*reverse order first*/
                             H5T__reverse_order(src_rev, s, src_p->shared->size,
                                                src_p->shared->u.atomic.order);
-                            except_ret = (cb_struct.func)(H5T_CONV_EXCEPT_RANGE_HI, src_id, dst_id, src_rev,
-                                                          d, cb_struct.user_data);
+                            except_ret = (conv_ctx->cb_struct.func)(
+                                H5T_CONV_EXCEPT_RANGE_HI, conv_ctx->src_type_id, conv_ctx->dst_type_id,
+                                src_rev, d, conv_ctx->cb_struct.user_data);
                         }
 
                         if (except_ret == H5T_CONV_UNHANDLED) {
@@ -4833,11 +4927,10 @@ done:
  *-------------------------------------------------------------------------
  */
 herr_t
-H5T__conv_s_s(hid_t src_id, hid_t dst_id, H5T_cdata_t *cdata, size_t nelmts, size_t buf_stride,
-              size_t H5_ATTR_UNUSED bkg_stride, void *buf, void H5_ATTR_UNUSED *bkg)
+H5T__conv_s_s(H5T_t *src, H5T_t *dst, H5T_cdata_t *cdata, const H5T_conv_ctx_t H5_ATTR_UNUSED *conv_ctx,
+              size_t nelmts, size_t buf_stride, size_t H5_ATTR_UNUSED bkg_stride, void *buf,
+              void H5_ATTR_UNUSED *bkg)
 {
-    H5T_t   *src = NULL;           /*source datatype        */
-    H5T_t   *dst = NULL;           /*destination datatype        */
     ssize_t  src_delta, dst_delta; /*source & destination stride    */
     int      direction;            /*direction of traversal    */
     size_t   elmtno;               /*element number        */
@@ -4851,7 +4944,7 @@ H5T__conv_s_s(hid_t src_id, hid_t dst_id, H5T_cdata_t *cdata, size_t nelmts, siz
 
     switch (cdata->command) {
         case H5T_CONV_INIT:
-            if (NULL == (src = (H5T_t *)H5I_object(src_id)) || NULL == (dst = (H5T_t *)H5I_object(dst_id)))
+            if (NULL == src || NULL == dst)
                 HGOTO_ERROR(H5E_ARGS, H5E_BADTYPE, FAIL, "not a datatype");
             if (8 * src->shared->size != src->shared->u.atomic.prec ||
                 8 * dst->shared->size != dst->shared->u.atomic.prec)
@@ -4881,7 +4974,7 @@ H5T__conv_s_s(hid_t src_id, hid_t dst_id, H5T_cdata_t *cdata, size_t nelmts, siz
 
         case H5T_CONV_CONV:
             /* Get the datatypes */
-            if (NULL == (src = (H5T_t *)H5I_object(src_id)) || NULL == (dst = (H5T_t *)H5I_object(dst_id)))
+            if (NULL == src || NULL == dst)
                 HGOTO_ERROR(H5E_ARGS, H5E_BADTYPE, FAIL, "not a datatype");
 
             /*
@@ -5076,8 +5169,9 @@ done:
  *-------------------------------------------------------------------------
  */
 herr_t
-H5T__conv_schar_uchar(hid_t src_id, hid_t dst_id, H5T_cdata_t *cdata, size_t nelmts, size_t buf_stride,
-                      size_t H5_ATTR_UNUSED bkg_stride, void *buf, void H5_ATTR_UNUSED *bkg)
+H5T__conv_schar_uchar(H5T_t *st, H5T_t *dt, H5T_cdata_t *cdata, const H5T_conv_ctx_t *conv_ctx, size_t nelmts,
+                      size_t buf_stride, size_t H5_ATTR_UNUSED bkg_stride, void *buf,
+                      void H5_ATTR_UNUSED *bkg)
 {
     H5T_CONV_su(SCHAR, UCHAR, signed char, unsigned char, -, -);
 }
@@ -5094,8 +5188,9 @@ H5T__conv_schar_uchar(hid_t src_id, hid_t dst_id, H5T_cdata_t *cdata, size_t nel
  *-------------------------------------------------------------------------
  */
 herr_t
-H5T__conv_uchar_schar(hid_t src_id, hid_t dst_id, H5T_cdata_t *cdata, size_t nelmts, size_t buf_stride,
-                      size_t H5_ATTR_UNUSED bkg_stride, void *buf, void H5_ATTR_UNUSED *bkg)
+H5T__conv_uchar_schar(H5T_t *st, H5T_t *dt, H5T_cdata_t *cdata, const H5T_conv_ctx_t *conv_ctx, size_t nelmts,
+                      size_t buf_stride, size_t H5_ATTR_UNUSED bkg_stride, void *buf,
+                      void H5_ATTR_UNUSED *bkg)
 {
     H5T_CONV_us(UCHAR, SCHAR, unsigned char, signed char, -, SCHAR_MAX);
 }
@@ -5112,8 +5207,9 @@ H5T__conv_uchar_schar(hid_t src_id, hid_t dst_id, H5T_cdata_t *cdata, size_t nel
  *-------------------------------------------------------------------------
  */
 herr_t
-H5T__conv_schar_short(hid_t src_id, hid_t dst_id, H5T_cdata_t *cdata, size_t nelmts, size_t buf_stride,
-                      size_t H5_ATTR_UNUSED bkg_stride, void *buf, void H5_ATTR_UNUSED *bkg)
+H5T__conv_schar_short(H5T_t *st, H5T_t *dt, H5T_cdata_t *cdata, const H5T_conv_ctx_t *conv_ctx, size_t nelmts,
+                      size_t buf_stride, size_t H5_ATTR_UNUSED bkg_stride, void *buf,
+                      void H5_ATTR_UNUSED *bkg)
 {
     H5T_CONV_sS(SCHAR, SHORT, signed char, short, -, -);
 }
@@ -5130,8 +5226,9 @@ H5T__conv_schar_short(hid_t src_id, hid_t dst_id, H5T_cdata_t *cdata, size_t nel
  *-------------------------------------------------------------------------
  */
 herr_t
-H5T__conv_schar_ushort(hid_t src_id, hid_t dst_id, H5T_cdata_t *cdata, size_t nelmts, size_t buf_stride,
-                       size_t H5_ATTR_UNUSED bkg_stride, void *buf, void H5_ATTR_UNUSED *bkg)
+H5T__conv_schar_ushort(H5T_t *st, H5T_t *dt, H5T_cdata_t *cdata, const H5T_conv_ctx_t *conv_ctx,
+                       size_t nelmts, size_t buf_stride, size_t H5_ATTR_UNUSED bkg_stride, void *buf,
+                       void H5_ATTR_UNUSED *bkg)
 {
     H5T_CONV_sU(SCHAR, USHORT, signed char, unsigned short, -, -);
 }
@@ -5148,8 +5245,9 @@ H5T__conv_schar_ushort(hid_t src_id, hid_t dst_id, H5T_cdata_t *cdata, size_t ne
  *-------------------------------------------------------------------------
  */
 herr_t
-H5T__conv_uchar_short(hid_t src_id, hid_t dst_id, H5T_cdata_t *cdata, size_t nelmts, size_t buf_stride,
-                      size_t H5_ATTR_UNUSED bkg_stride, void *buf, void H5_ATTR_UNUSED *bkg)
+H5T__conv_uchar_short(H5T_t *st, H5T_t *dt, H5T_cdata_t *cdata, const H5T_conv_ctx_t *conv_ctx, size_t nelmts,
+                      size_t buf_stride, size_t H5_ATTR_UNUSED bkg_stride, void *buf,
+                      void H5_ATTR_UNUSED *bkg)
 {
     H5T_CONV_uS(UCHAR, SHORT, unsigned char, short, -, SHRT_MAX);
 }
@@ -5166,8 +5264,9 @@ H5T__conv_uchar_short(hid_t src_id, hid_t dst_id, H5T_cdata_t *cdata, size_t nel
  *-------------------------------------------------------------------------
  */
 herr_t
-H5T__conv_uchar_ushort(hid_t src_id, hid_t dst_id, H5T_cdata_t *cdata, size_t nelmts, size_t buf_stride,
-                       size_t H5_ATTR_UNUSED bkg_stride, void *buf, void H5_ATTR_UNUSED *bkg)
+H5T__conv_uchar_ushort(H5T_t *st, H5T_t *dt, H5T_cdata_t *cdata, const H5T_conv_ctx_t *conv_ctx,
+                       size_t nelmts, size_t buf_stride, size_t H5_ATTR_UNUSED bkg_stride, void *buf,
+                       void H5_ATTR_UNUSED *bkg)
 {
     H5T_CONV_uU(UCHAR, USHORT, unsigned char, unsigned short, -, -);
 }
@@ -5184,8 +5283,8 @@ H5T__conv_uchar_ushort(hid_t src_id, hid_t dst_id, H5T_cdata_t *cdata, size_t ne
  *-------------------------------------------------------------------------
  */
 herr_t
-H5T__conv_schar_int(hid_t src_id, hid_t dst_id, H5T_cdata_t *cdata, size_t nelmts, size_t buf_stride,
-                    size_t H5_ATTR_UNUSED bkg_stride, void *buf, void H5_ATTR_UNUSED *bkg)
+H5T__conv_schar_int(H5T_t *st, H5T_t *dt, H5T_cdata_t *cdata, const H5T_conv_ctx_t *conv_ctx, size_t nelmts,
+                    size_t buf_stride, size_t H5_ATTR_UNUSED bkg_stride, void *buf, void H5_ATTR_UNUSED *bkg)
 {
     H5T_CONV_sS(SCHAR, INT, signed char, int, -, -);
 }
@@ -5202,8 +5301,8 @@ H5T__conv_schar_int(hid_t src_id, hid_t dst_id, H5T_cdata_t *cdata, size_t nelmt
  *-------------------------------------------------------------------------
  */
 herr_t
-H5T__conv_schar_uint(hid_t src_id, hid_t dst_id, H5T_cdata_t *cdata, size_t nelmts, size_t buf_stride,
-                     size_t H5_ATTR_UNUSED bkg_stride, void *buf, void H5_ATTR_UNUSED *bkg)
+H5T__conv_schar_uint(H5T_t *st, H5T_t *dt, H5T_cdata_t *cdata, const H5T_conv_ctx_t *conv_ctx, size_t nelmts,
+                     size_t buf_stride, size_t H5_ATTR_UNUSED bkg_stride, void *buf, void H5_ATTR_UNUSED *bkg)
 {
     H5T_CONV_sU(SCHAR, UINT, signed char, unsigned, -, -);
 }
@@ -5220,8 +5319,8 @@ H5T__conv_schar_uint(hid_t src_id, hid_t dst_id, H5T_cdata_t *cdata, size_t nelm
  *-------------------------------------------------------------------------
  */
 herr_t
-H5T__conv_uchar_int(hid_t src_id, hid_t dst_id, H5T_cdata_t *cdata, size_t nelmts, size_t buf_stride,
-                    size_t H5_ATTR_UNUSED bkg_stride, void *buf, void H5_ATTR_UNUSED *bkg)
+H5T__conv_uchar_int(H5T_t *st, H5T_t *dt, H5T_cdata_t *cdata, const H5T_conv_ctx_t *conv_ctx, size_t nelmts,
+                    size_t buf_stride, size_t H5_ATTR_UNUSED bkg_stride, void *buf, void H5_ATTR_UNUSED *bkg)
 {
     H5T_CONV_uS(UCHAR, INT, unsigned char, int, -, INT_MAX);
 }
@@ -5238,8 +5337,8 @@ H5T__conv_uchar_int(hid_t src_id, hid_t dst_id, H5T_cdata_t *cdata, size_t nelmt
  *-------------------------------------------------------------------------
  */
 herr_t
-H5T__conv_uchar_uint(hid_t src_id, hid_t dst_id, H5T_cdata_t *cdata, size_t nelmts, size_t buf_stride,
-                     size_t H5_ATTR_UNUSED bkg_stride, void *buf, void H5_ATTR_UNUSED *bkg)
+H5T__conv_uchar_uint(H5T_t *st, H5T_t *dt, H5T_cdata_t *cdata, const H5T_conv_ctx_t *conv_ctx, size_t nelmts,
+                     size_t buf_stride, size_t H5_ATTR_UNUSED bkg_stride, void *buf, void H5_ATTR_UNUSED *bkg)
 {
     H5T_CONV_uU(UCHAR, UINT, unsigned char, unsigned, -, -);
 }
@@ -5256,8 +5355,8 @@ H5T__conv_uchar_uint(hid_t src_id, hid_t dst_id, H5T_cdata_t *cdata, size_t nelm
  *-------------------------------------------------------------------------
  */
 herr_t
-H5T__conv_schar_long(hid_t src_id, hid_t dst_id, H5T_cdata_t *cdata, size_t nelmts, size_t buf_stride,
-                     size_t H5_ATTR_UNUSED bkg_stride, void *buf, void H5_ATTR_UNUSED *bkg)
+H5T__conv_schar_long(H5T_t *st, H5T_t *dt, H5T_cdata_t *cdata, const H5T_conv_ctx_t *conv_ctx, size_t nelmts,
+                     size_t buf_stride, size_t H5_ATTR_UNUSED bkg_stride, void *buf, void H5_ATTR_UNUSED *bkg)
 {
     H5T_CONV_sS(SCHAR, LONG, signed char, long, -, -);
 }
@@ -5274,8 +5373,9 @@ H5T__conv_schar_long(hid_t src_id, hid_t dst_id, H5T_cdata_t *cdata, size_t nelm
  *-------------------------------------------------------------------------
  */
 herr_t
-H5T__conv_schar_ulong(hid_t src_id, hid_t dst_id, H5T_cdata_t *cdata, size_t nelmts, size_t buf_stride,
-                      size_t H5_ATTR_UNUSED bkg_stride, void *buf, void H5_ATTR_UNUSED *bkg)
+H5T__conv_schar_ulong(H5T_t *st, H5T_t *dt, H5T_cdata_t *cdata, const H5T_conv_ctx_t *conv_ctx, size_t nelmts,
+                      size_t buf_stride, size_t H5_ATTR_UNUSED bkg_stride, void *buf,
+                      void H5_ATTR_UNUSED *bkg)
 {
     H5T_CONV_sU(SCHAR, ULONG, signed char, unsigned long, -, -);
 }
@@ -5292,8 +5392,8 @@ H5T__conv_schar_ulong(hid_t src_id, hid_t dst_id, H5T_cdata_t *cdata, size_t nel
  *-------------------------------------------------------------------------
  */
 herr_t
-H5T__conv_uchar_long(hid_t src_id, hid_t dst_id, H5T_cdata_t *cdata, size_t nelmts, size_t buf_stride,
-                     size_t H5_ATTR_UNUSED bkg_stride, void *buf, void H5_ATTR_UNUSED *bkg)
+H5T__conv_uchar_long(H5T_t *st, H5T_t *dt, H5T_cdata_t *cdata, const H5T_conv_ctx_t *conv_ctx, size_t nelmts,
+                     size_t buf_stride, size_t H5_ATTR_UNUSED bkg_stride, void *buf, void H5_ATTR_UNUSED *bkg)
 {
     H5T_CONV_uS(UCHAR, LONG, unsigned char, long, -, LONG_MAX);
 }
@@ -5310,8 +5410,9 @@ H5T__conv_uchar_long(hid_t src_id, hid_t dst_id, H5T_cdata_t *cdata, size_t nelm
  *-------------------------------------------------------------------------
  */
 herr_t
-H5T__conv_uchar_ulong(hid_t src_id, hid_t dst_id, H5T_cdata_t *cdata, size_t nelmts, size_t buf_stride,
-                      size_t H5_ATTR_UNUSED bkg_stride, void *buf, void H5_ATTR_UNUSED *bkg)
+H5T__conv_uchar_ulong(H5T_t *st, H5T_t *dt, H5T_cdata_t *cdata, const H5T_conv_ctx_t *conv_ctx, size_t nelmts,
+                      size_t buf_stride, size_t H5_ATTR_UNUSED bkg_stride, void *buf,
+                      void H5_ATTR_UNUSED *bkg)
 {
     H5T_CONV_uU(UCHAR, ULONG, unsigned char, unsigned long, -, -);
 }
@@ -5328,8 +5429,9 @@ H5T__conv_uchar_ulong(hid_t src_id, hid_t dst_id, H5T_cdata_t *cdata, size_t nel
  *-------------------------------------------------------------------------
  */
 herr_t
-H5T__conv_schar_llong(hid_t src_id, hid_t dst_id, H5T_cdata_t *cdata, size_t nelmts, size_t buf_stride,
-                      size_t H5_ATTR_UNUSED bkg_stride, void *buf, void H5_ATTR_UNUSED *bkg)
+H5T__conv_schar_llong(H5T_t *st, H5T_t *dt, H5T_cdata_t *cdata, const H5T_conv_ctx_t *conv_ctx, size_t nelmts,
+                      size_t buf_stride, size_t H5_ATTR_UNUSED bkg_stride, void *buf,
+                      void H5_ATTR_UNUSED *bkg)
 {
     H5T_CONV_sS(SCHAR, LLONG, signed char, long long, -, -);
 }
@@ -5346,8 +5448,9 @@ H5T__conv_schar_llong(hid_t src_id, hid_t dst_id, H5T_cdata_t *cdata, size_t nel
  *-------------------------------------------------------------------------
  */
 herr_t
-H5T__conv_schar_ullong(hid_t src_id, hid_t dst_id, H5T_cdata_t *cdata, size_t nelmts, size_t buf_stride,
-                       size_t H5_ATTR_UNUSED bkg_stride, void *buf, void H5_ATTR_UNUSED *bkg)
+H5T__conv_schar_ullong(H5T_t *st, H5T_t *dt, H5T_cdata_t *cdata, const H5T_conv_ctx_t *conv_ctx,
+                       size_t nelmts, size_t buf_stride, size_t H5_ATTR_UNUSED bkg_stride, void *buf,
+                       void H5_ATTR_UNUSED *bkg)
 {
     H5T_CONV_sU(SCHAR, ULLONG, signed char, unsigned long long, -, -);
 }
@@ -5364,8 +5467,9 @@ H5T__conv_schar_ullong(hid_t src_id, hid_t dst_id, H5T_cdata_t *cdata, size_t ne
  *-------------------------------------------------------------------------
  */
 herr_t
-H5T__conv_uchar_llong(hid_t src_id, hid_t dst_id, H5T_cdata_t *cdata, size_t nelmts, size_t buf_stride,
-                      size_t H5_ATTR_UNUSED bkg_stride, void *buf, void H5_ATTR_UNUSED *bkg)
+H5T__conv_uchar_llong(H5T_t *st, H5T_t *dt, H5T_cdata_t *cdata, const H5T_conv_ctx_t *conv_ctx, size_t nelmts,
+                      size_t buf_stride, size_t H5_ATTR_UNUSED bkg_stride, void *buf,
+                      void H5_ATTR_UNUSED *bkg)
 {
     H5T_CONV_uS(UCHAR, LLONG, unsigned char, long long, -, LLONG_MAX);
 }
@@ -5382,8 +5486,9 @@ H5T__conv_uchar_llong(hid_t src_id, hid_t dst_id, H5T_cdata_t *cdata, size_t nel
  *-------------------------------------------------------------------------
  */
 herr_t
-H5T__conv_uchar_ullong(hid_t src_id, hid_t dst_id, H5T_cdata_t *cdata, size_t nelmts, size_t buf_stride,
-                       size_t H5_ATTR_UNUSED bkg_stride, void *buf, void H5_ATTR_UNUSED *bkg)
+H5T__conv_uchar_ullong(H5T_t *st, H5T_t *dt, H5T_cdata_t *cdata, const H5T_conv_ctx_t *conv_ctx,
+                       size_t nelmts, size_t buf_stride, size_t H5_ATTR_UNUSED bkg_stride, void *buf,
+                       void H5_ATTR_UNUSED *bkg)
 {
     H5T_CONV_uU(UCHAR, ULLONG, unsigned char, unsigned long long, -, -);
 }
@@ -5400,8 +5505,9 @@ H5T__conv_uchar_ullong(hid_t src_id, hid_t dst_id, H5T_cdata_t *cdata, size_t ne
  *-------------------------------------------------------------------------
  */
 herr_t
-H5T__conv_short_schar(hid_t src_id, hid_t dst_id, H5T_cdata_t *cdata, size_t nelmts, size_t buf_stride,
-                      size_t H5_ATTR_UNUSED bkg_stride, void *buf, void H5_ATTR_UNUSED *bkg)
+H5T__conv_short_schar(H5T_t *st, H5T_t *dt, H5T_cdata_t *cdata, const H5T_conv_ctx_t *conv_ctx, size_t nelmts,
+                      size_t buf_stride, size_t H5_ATTR_UNUSED bkg_stride, void *buf,
+                      void H5_ATTR_UNUSED *bkg)
 {
     H5T_CONV_Ss(SHORT, SCHAR, short, signed char, SCHAR_MIN, SCHAR_MAX);
 }
@@ -5418,8 +5524,9 @@ H5T__conv_short_schar(hid_t src_id, hid_t dst_id, H5T_cdata_t *cdata, size_t nel
  *-------------------------------------------------------------------------
  */
 herr_t
-H5T__conv_short_uchar(hid_t src_id, hid_t dst_id, H5T_cdata_t *cdata, size_t nelmts, size_t buf_stride,
-                      size_t H5_ATTR_UNUSED bkg_stride, void *buf, void H5_ATTR_UNUSED *bkg)
+H5T__conv_short_uchar(H5T_t *st, H5T_t *dt, H5T_cdata_t *cdata, const H5T_conv_ctx_t *conv_ctx, size_t nelmts,
+                      size_t buf_stride, size_t H5_ATTR_UNUSED bkg_stride, void *buf,
+                      void H5_ATTR_UNUSED *bkg)
 {
     H5T_CONV_Su(SHORT, UCHAR, short, unsigned char, -, UCHAR_MAX);
 }
@@ -5436,8 +5543,9 @@ H5T__conv_short_uchar(hid_t src_id, hid_t dst_id, H5T_cdata_t *cdata, size_t nel
  *-------------------------------------------------------------------------
  */
 herr_t
-H5T__conv_ushort_schar(hid_t src_id, hid_t dst_id, H5T_cdata_t *cdata, size_t nelmts, size_t buf_stride,
-                       size_t H5_ATTR_UNUSED bkg_stride, void *buf, void H5_ATTR_UNUSED *bkg)
+H5T__conv_ushort_schar(H5T_t *st, H5T_t *dt, H5T_cdata_t *cdata, const H5T_conv_ctx_t *conv_ctx,
+                       size_t nelmts, size_t buf_stride, size_t H5_ATTR_UNUSED bkg_stride, void *buf,
+                       void H5_ATTR_UNUSED *bkg)
 {
     H5T_CONV_Us(USHORT, SCHAR, unsigned short, signed char, -, SCHAR_MAX);
 }
@@ -5454,8 +5562,9 @@ H5T__conv_ushort_schar(hid_t src_id, hid_t dst_id, H5T_cdata_t *cdata, size_t ne
  *-------------------------------------------------------------------------
  */
 herr_t
-H5T__conv_ushort_uchar(hid_t src_id, hid_t dst_id, H5T_cdata_t *cdata, size_t nelmts, size_t buf_stride,
-                       size_t H5_ATTR_UNUSED bkg_stride, void *buf, void H5_ATTR_UNUSED *bkg)
+H5T__conv_ushort_uchar(H5T_t *st, H5T_t *dt, H5T_cdata_t *cdata, const H5T_conv_ctx_t *conv_ctx,
+                       size_t nelmts, size_t buf_stride, size_t H5_ATTR_UNUSED bkg_stride, void *buf,
+                       void H5_ATTR_UNUSED *bkg)
 {
     H5T_CONV_Uu(USHORT, UCHAR, unsigned short, unsigned char, -, UCHAR_MAX);
 }
@@ -5472,8 +5581,9 @@ H5T__conv_ushort_uchar(hid_t src_id, hid_t dst_id, H5T_cdata_t *cdata, size_t ne
  *-------------------------------------------------------------------------
  */
 herr_t
-H5T__conv_short_ushort(hid_t src_id, hid_t dst_id, H5T_cdata_t *cdata, size_t nelmts, size_t buf_stride,
-                       size_t H5_ATTR_UNUSED bkg_stride, void *buf, void H5_ATTR_UNUSED *bkg)
+H5T__conv_short_ushort(H5T_t *st, H5T_t *dt, H5T_cdata_t *cdata, const H5T_conv_ctx_t *conv_ctx,
+                       size_t nelmts, size_t buf_stride, size_t H5_ATTR_UNUSED bkg_stride, void *buf,
+                       void H5_ATTR_UNUSED *bkg)
 {
     H5T_CONV_su(SHORT, USHORT, short, unsigned short, -, -);
 }
@@ -5490,8 +5600,9 @@ H5T__conv_short_ushort(hid_t src_id, hid_t dst_id, H5T_cdata_t *cdata, size_t ne
  *-------------------------------------------------------------------------
  */
 herr_t
-H5T__conv_ushort_short(hid_t src_id, hid_t dst_id, H5T_cdata_t *cdata, size_t nelmts, size_t buf_stride,
-                       size_t H5_ATTR_UNUSED bkg_stride, void *buf, void H5_ATTR_UNUSED *bkg)
+H5T__conv_ushort_short(H5T_t *st, H5T_t *dt, H5T_cdata_t *cdata, const H5T_conv_ctx_t *conv_ctx,
+                       size_t nelmts, size_t buf_stride, size_t H5_ATTR_UNUSED bkg_stride, void *buf,
+                       void H5_ATTR_UNUSED *bkg)
 {
     H5T_CONV_us(USHORT, SHORT, unsigned short, short, -, SHRT_MAX);
 }
@@ -5508,8 +5619,8 @@ H5T__conv_ushort_short(hid_t src_id, hid_t dst_id, H5T_cdata_t *cdata, size_t ne
  *-------------------------------------------------------------------------
  */
 herr_t
-H5T__conv_short_int(hid_t src_id, hid_t dst_id, H5T_cdata_t *cdata, size_t nelmts, size_t buf_stride,
-                    size_t H5_ATTR_UNUSED bkg_stride, void *buf, void H5_ATTR_UNUSED *bkg)
+H5T__conv_short_int(H5T_t *st, H5T_t *dt, H5T_cdata_t *cdata, const H5T_conv_ctx_t *conv_ctx, size_t nelmts,
+                    size_t buf_stride, size_t H5_ATTR_UNUSED bkg_stride, void *buf, void H5_ATTR_UNUSED *bkg)
 {
     H5T_CONV_sS(SHORT, INT, short, int, -, -);
 }
@@ -5526,8 +5637,8 @@ H5T__conv_short_int(hid_t src_id, hid_t dst_id, H5T_cdata_t *cdata, size_t nelmt
  *-------------------------------------------------------------------------
  */
 herr_t
-H5T__conv_short_uint(hid_t src_id, hid_t dst_id, H5T_cdata_t *cdata, size_t nelmts, size_t buf_stride,
-                     size_t H5_ATTR_UNUSED bkg_stride, void *buf, void H5_ATTR_UNUSED *bkg)
+H5T__conv_short_uint(H5T_t *st, H5T_t *dt, H5T_cdata_t *cdata, const H5T_conv_ctx_t *conv_ctx, size_t nelmts,
+                     size_t buf_stride, size_t H5_ATTR_UNUSED bkg_stride, void *buf, void H5_ATTR_UNUSED *bkg)
 {
     H5T_CONV_sU(SHORT, UINT, short, unsigned, -, -);
 }
@@ -5544,8 +5655,8 @@ H5T__conv_short_uint(hid_t src_id, hid_t dst_id, H5T_cdata_t *cdata, size_t nelm
  *-------------------------------------------------------------------------
  */
 herr_t
-H5T__conv_ushort_int(hid_t src_id, hid_t dst_id, H5T_cdata_t *cdata, size_t nelmts, size_t buf_stride,
-                     size_t H5_ATTR_UNUSED bkg_stride, void *buf, void H5_ATTR_UNUSED *bkg)
+H5T__conv_ushort_int(H5T_t *st, H5T_t *dt, H5T_cdata_t *cdata, const H5T_conv_ctx_t *conv_ctx, size_t nelmts,
+                     size_t buf_stride, size_t H5_ATTR_UNUSED bkg_stride, void *buf, void H5_ATTR_UNUSED *bkg)
 {
     H5T_CONV_uS(USHORT, INT, unsigned short, int, -, INT_MAX);
 }
@@ -5562,8 +5673,9 @@ H5T__conv_ushort_int(hid_t src_id, hid_t dst_id, H5T_cdata_t *cdata, size_t nelm
  *-------------------------------------------------------------------------
  */
 herr_t
-H5T__conv_ushort_uint(hid_t src_id, hid_t dst_id, H5T_cdata_t *cdata, size_t nelmts, size_t buf_stride,
-                      size_t H5_ATTR_UNUSED bkg_stride, void *buf, void H5_ATTR_UNUSED *bkg)
+H5T__conv_ushort_uint(H5T_t *st, H5T_t *dt, H5T_cdata_t *cdata, const H5T_conv_ctx_t *conv_ctx, size_t nelmts,
+                      size_t buf_stride, size_t H5_ATTR_UNUSED bkg_stride, void *buf,
+                      void H5_ATTR_UNUSED *bkg)
 {
     H5T_CONV_uU(USHORT, UINT, unsigned short, unsigned, -, -);
 }
@@ -5580,8 +5692,8 @@ H5T__conv_ushort_uint(hid_t src_id, hid_t dst_id, H5T_cdata_t *cdata, size_t nel
  *-------------------------------------------------------------------------
  */
 herr_t
-H5T__conv_short_long(hid_t src_id, hid_t dst_id, H5T_cdata_t *cdata, size_t nelmts, size_t buf_stride,
-                     size_t H5_ATTR_UNUSED bkg_stride, void *buf, void H5_ATTR_UNUSED *bkg)
+H5T__conv_short_long(H5T_t *st, H5T_t *dt, H5T_cdata_t *cdata, const H5T_conv_ctx_t *conv_ctx, size_t nelmts,
+                     size_t buf_stride, size_t H5_ATTR_UNUSED bkg_stride, void *buf, void H5_ATTR_UNUSED *bkg)
 {
     H5T_CONV_sS(SHORT, LONG, short, long, -, -);
 }
@@ -5598,8 +5710,9 @@ H5T__conv_short_long(hid_t src_id, hid_t dst_id, H5T_cdata_t *cdata, size_t nelm
  *-------------------------------------------------------------------------
  */
 herr_t
-H5T__conv_short_ulong(hid_t src_id, hid_t dst_id, H5T_cdata_t *cdata, size_t nelmts, size_t buf_stride,
-                      size_t H5_ATTR_UNUSED bkg_stride, void *buf, void H5_ATTR_UNUSED *bkg)
+H5T__conv_short_ulong(H5T_t *st, H5T_t *dt, H5T_cdata_t *cdata, const H5T_conv_ctx_t *conv_ctx, size_t nelmts,
+                      size_t buf_stride, size_t H5_ATTR_UNUSED bkg_stride, void *buf,
+                      void H5_ATTR_UNUSED *bkg)
 {
     H5T_CONV_sU(SHORT, ULONG, short, unsigned long, -, -);
 }
@@ -5616,8 +5729,9 @@ H5T__conv_short_ulong(hid_t src_id, hid_t dst_id, H5T_cdata_t *cdata, size_t nel
  *-------------------------------------------------------------------------
  */
 herr_t
-H5T__conv_ushort_long(hid_t src_id, hid_t dst_id, H5T_cdata_t *cdata, size_t nelmts, size_t buf_stride,
-                      size_t H5_ATTR_UNUSED bkg_stride, void *buf, void H5_ATTR_UNUSED *bkg)
+H5T__conv_ushort_long(H5T_t *st, H5T_t *dt, H5T_cdata_t *cdata, const H5T_conv_ctx_t *conv_ctx, size_t nelmts,
+                      size_t buf_stride, size_t H5_ATTR_UNUSED bkg_stride, void *buf,
+                      void H5_ATTR_UNUSED *bkg)
 {
     H5T_CONV_uS(USHORT, LONG, unsigned short, long, -, LONG_MAX);
 }
@@ -5634,8 +5748,9 @@ H5T__conv_ushort_long(hid_t src_id, hid_t dst_id, H5T_cdata_t *cdata, size_t nel
  *-------------------------------------------------------------------------
  */
 herr_t
-H5T__conv_ushort_ulong(hid_t src_id, hid_t dst_id, H5T_cdata_t *cdata, size_t nelmts, size_t buf_stride,
-                       size_t H5_ATTR_UNUSED bkg_stride, void *buf, void H5_ATTR_UNUSED *bkg)
+H5T__conv_ushort_ulong(H5T_t *st, H5T_t *dt, H5T_cdata_t *cdata, const H5T_conv_ctx_t *conv_ctx,
+                       size_t nelmts, size_t buf_stride, size_t H5_ATTR_UNUSED bkg_stride, void *buf,
+                       void H5_ATTR_UNUSED *bkg)
 {
     H5T_CONV_uU(USHORT, ULONG, unsigned short, unsigned long, -, -);
 }
@@ -5652,8 +5767,9 @@ H5T__conv_ushort_ulong(hid_t src_id, hid_t dst_id, H5T_cdata_t *cdata, size_t ne
  *-------------------------------------------------------------------------
  */
 herr_t
-H5T__conv_short_llong(hid_t src_id, hid_t dst_id, H5T_cdata_t *cdata, size_t nelmts, size_t buf_stride,
-                      size_t H5_ATTR_UNUSED bkg_stride, void *buf, void H5_ATTR_UNUSED *bkg)
+H5T__conv_short_llong(H5T_t *st, H5T_t *dt, H5T_cdata_t *cdata, const H5T_conv_ctx_t *conv_ctx, size_t nelmts,
+                      size_t buf_stride, size_t H5_ATTR_UNUSED bkg_stride, void *buf,
+                      void H5_ATTR_UNUSED *bkg)
 {
     H5T_CONV_sS(SHORT, LLONG, short, long long, -, -);
 }
@@ -5670,8 +5786,9 @@ H5T__conv_short_llong(hid_t src_id, hid_t dst_id, H5T_cdata_t *cdata, size_t nel
  *-------------------------------------------------------------------------
  */
 herr_t
-H5T__conv_short_ullong(hid_t src_id, hid_t dst_id, H5T_cdata_t *cdata, size_t nelmts, size_t buf_stride,
-                       size_t H5_ATTR_UNUSED bkg_stride, void *buf, void H5_ATTR_UNUSED *bkg)
+H5T__conv_short_ullong(H5T_t *st, H5T_t *dt, H5T_cdata_t *cdata, const H5T_conv_ctx_t *conv_ctx,
+                       size_t nelmts, size_t buf_stride, size_t H5_ATTR_UNUSED bkg_stride, void *buf,
+                       void H5_ATTR_UNUSED *bkg)
 {
     H5T_CONV_sU(SHORT, ULLONG, short, unsigned long long, -, -);
 }
@@ -5688,8 +5805,9 @@ H5T__conv_short_ullong(hid_t src_id, hid_t dst_id, H5T_cdata_t *cdata, size_t ne
  *-------------------------------------------------------------------------
  */
 herr_t
-H5T__conv_ushort_llong(hid_t src_id, hid_t dst_id, H5T_cdata_t *cdata, size_t nelmts, size_t buf_stride,
-                       size_t H5_ATTR_UNUSED bkg_stride, void *buf, void H5_ATTR_UNUSED *bkg)
+H5T__conv_ushort_llong(H5T_t *st, H5T_t *dt, H5T_cdata_t *cdata, const H5T_conv_ctx_t *conv_ctx,
+                       size_t nelmts, size_t buf_stride, size_t H5_ATTR_UNUSED bkg_stride, void *buf,
+                       void H5_ATTR_UNUSED *bkg)
 {
     H5T_CONV_uS(USHORT, LLONG, unsigned short, long long, -, LLONG_MAX);
 }
@@ -5706,8 +5824,9 @@ H5T__conv_ushort_llong(hid_t src_id, hid_t dst_id, H5T_cdata_t *cdata, size_t ne
  *-------------------------------------------------------------------------
  */
 herr_t
-H5T__conv_ushort_ullong(hid_t src_id, hid_t dst_id, H5T_cdata_t *cdata, size_t nelmts, size_t buf_stride,
-                        size_t H5_ATTR_UNUSED bkg_stride, void *buf, void H5_ATTR_UNUSED *bkg)
+H5T__conv_ushort_ullong(H5T_t *st, H5T_t *dt, H5T_cdata_t *cdata, const H5T_conv_ctx_t *conv_ctx,
+                        size_t nelmts, size_t buf_stride, size_t H5_ATTR_UNUSED bkg_stride, void *buf,
+                        void H5_ATTR_UNUSED *bkg)
 {
     H5T_CONV_uU(USHORT, ULLONG, unsigned short, unsigned long long, -, -);
 }
@@ -5724,8 +5843,8 @@ H5T__conv_ushort_ullong(hid_t src_id, hid_t dst_id, H5T_cdata_t *cdata, size_t n
  *-------------------------------------------------------------------------
  */
 herr_t
-H5T__conv_int_schar(hid_t src_id, hid_t dst_id, H5T_cdata_t *cdata, size_t nelmts, size_t buf_stride,
-                    size_t H5_ATTR_UNUSED bkg_stride, void *buf, void H5_ATTR_UNUSED *bkg)
+H5T__conv_int_schar(H5T_t *st, H5T_t *dt, H5T_cdata_t *cdata, const H5T_conv_ctx_t *conv_ctx, size_t nelmts,
+                    size_t buf_stride, size_t H5_ATTR_UNUSED bkg_stride, void *buf, void H5_ATTR_UNUSED *bkg)
 {
     H5T_CONV_Ss(INT, SCHAR, int, signed char, SCHAR_MIN, SCHAR_MAX);
 }
@@ -5742,8 +5861,8 @@ H5T__conv_int_schar(hid_t src_id, hid_t dst_id, H5T_cdata_t *cdata, size_t nelmt
  *-------------------------------------------------------------------------
  */
 herr_t
-H5T__conv_int_uchar(hid_t src_id, hid_t dst_id, H5T_cdata_t *cdata, size_t nelmts, size_t buf_stride,
-                    size_t H5_ATTR_UNUSED bkg_stride, void *buf, void H5_ATTR_UNUSED *bkg)
+H5T__conv_int_uchar(H5T_t *st, H5T_t *dt, H5T_cdata_t *cdata, const H5T_conv_ctx_t *conv_ctx, size_t nelmts,
+                    size_t buf_stride, size_t H5_ATTR_UNUSED bkg_stride, void *buf, void H5_ATTR_UNUSED *bkg)
 {
     H5T_CONV_Su(INT, UCHAR, int, unsigned char, -, UCHAR_MAX);
 }
@@ -5760,8 +5879,8 @@ H5T__conv_int_uchar(hid_t src_id, hid_t dst_id, H5T_cdata_t *cdata, size_t nelmt
  *-------------------------------------------------------------------------
  */
 herr_t
-H5T__conv_uint_schar(hid_t src_id, hid_t dst_id, H5T_cdata_t *cdata, size_t nelmts, size_t buf_stride,
-                     size_t H5_ATTR_UNUSED bkg_stride, void *buf, void H5_ATTR_UNUSED *bkg)
+H5T__conv_uint_schar(H5T_t *st, H5T_t *dt, H5T_cdata_t *cdata, const H5T_conv_ctx_t *conv_ctx, size_t nelmts,
+                     size_t buf_stride, size_t H5_ATTR_UNUSED bkg_stride, void *buf, void H5_ATTR_UNUSED *bkg)
 {
     H5T_CONV_Us(UINT, SCHAR, unsigned, signed char, -, SCHAR_MAX);
 }
@@ -5778,8 +5897,8 @@ H5T__conv_uint_schar(hid_t src_id, hid_t dst_id, H5T_cdata_t *cdata, size_t nelm
  *-------------------------------------------------------------------------
  */
 herr_t
-H5T__conv_uint_uchar(hid_t src_id, hid_t dst_id, H5T_cdata_t *cdata, size_t nelmts, size_t buf_stride,
-                     size_t H5_ATTR_UNUSED bkg_stride, void *buf, void H5_ATTR_UNUSED *bkg)
+H5T__conv_uint_uchar(H5T_t *st, H5T_t *dt, H5T_cdata_t *cdata, const H5T_conv_ctx_t *conv_ctx, size_t nelmts,
+                     size_t buf_stride, size_t H5_ATTR_UNUSED bkg_stride, void *buf, void H5_ATTR_UNUSED *bkg)
 {
     H5T_CONV_Uu(UINT, UCHAR, unsigned, unsigned char, -, UCHAR_MAX);
 }
@@ -5796,8 +5915,8 @@ H5T__conv_uint_uchar(hid_t src_id, hid_t dst_id, H5T_cdata_t *cdata, size_t nelm
  *-------------------------------------------------------------------------
  */
 herr_t
-H5T__conv_int_short(hid_t src_id, hid_t dst_id, H5T_cdata_t *cdata, size_t nelmts, size_t buf_stride,
-                    size_t H5_ATTR_UNUSED bkg_stride, void *buf, void H5_ATTR_UNUSED *bkg)
+H5T__conv_int_short(H5T_t *st, H5T_t *dt, H5T_cdata_t *cdata, const H5T_conv_ctx_t *conv_ctx, size_t nelmts,
+                    size_t buf_stride, size_t H5_ATTR_UNUSED bkg_stride, void *buf, void H5_ATTR_UNUSED *bkg)
 {
     H5T_CONV_Ss(INT, SHORT, int, short, SHRT_MIN, SHRT_MAX);
 }
@@ -5814,8 +5933,8 @@ H5T__conv_int_short(hid_t src_id, hid_t dst_id, H5T_cdata_t *cdata, size_t nelmt
  *-------------------------------------------------------------------------
  */
 herr_t
-H5T__conv_int_ushort(hid_t src_id, hid_t dst_id, H5T_cdata_t *cdata, size_t nelmts, size_t buf_stride,
-                     size_t H5_ATTR_UNUSED bkg_stride, void *buf, void H5_ATTR_UNUSED *bkg)
+H5T__conv_int_ushort(H5T_t *st, H5T_t *dt, H5T_cdata_t *cdata, const H5T_conv_ctx_t *conv_ctx, size_t nelmts,
+                     size_t buf_stride, size_t H5_ATTR_UNUSED bkg_stride, void *buf, void H5_ATTR_UNUSED *bkg)
 {
     H5T_CONV_Su(INT, USHORT, int, unsigned short, -, USHRT_MAX);
 }
@@ -5832,8 +5951,8 @@ H5T__conv_int_ushort(hid_t src_id, hid_t dst_id, H5T_cdata_t *cdata, size_t nelm
  *-------------------------------------------------------------------------
  */
 herr_t
-H5T__conv_uint_short(hid_t src_id, hid_t dst_id, H5T_cdata_t *cdata, size_t nelmts, size_t buf_stride,
-                     size_t H5_ATTR_UNUSED bkg_stride, void *buf, void H5_ATTR_UNUSED *bkg)
+H5T__conv_uint_short(H5T_t *st, H5T_t *dt, H5T_cdata_t *cdata, const H5T_conv_ctx_t *conv_ctx, size_t nelmts,
+                     size_t buf_stride, size_t H5_ATTR_UNUSED bkg_stride, void *buf, void H5_ATTR_UNUSED *bkg)
 {
     H5T_CONV_Us(UINT, SHORT, unsigned, short, -, SHRT_MAX);
 }
@@ -5850,8 +5969,9 @@ H5T__conv_uint_short(hid_t src_id, hid_t dst_id, H5T_cdata_t *cdata, size_t nelm
  *-------------------------------------------------------------------------
  */
 herr_t
-H5T__conv_uint_ushort(hid_t src_id, hid_t dst_id, H5T_cdata_t *cdata, size_t nelmts, size_t buf_stride,
-                      size_t H5_ATTR_UNUSED bkg_stride, void *buf, void H5_ATTR_UNUSED *bkg)
+H5T__conv_uint_ushort(H5T_t *st, H5T_t *dt, H5T_cdata_t *cdata, const H5T_conv_ctx_t *conv_ctx, size_t nelmts,
+                      size_t buf_stride, size_t H5_ATTR_UNUSED bkg_stride, void *buf,
+                      void H5_ATTR_UNUSED *bkg)
 {
     H5T_CONV_Uu(UINT, USHORT, unsigned, unsigned short, -, USHRT_MAX);
 }
@@ -5868,8 +5988,8 @@ H5T__conv_uint_ushort(hid_t src_id, hid_t dst_id, H5T_cdata_t *cdata, size_t nel
  *-------------------------------------------------------------------------
  */
 herr_t
-H5T__conv_int_uint(hid_t src_id, hid_t dst_id, H5T_cdata_t *cdata, size_t nelmts, size_t buf_stride,
-                   size_t H5_ATTR_UNUSED bkg_stride, void *buf, void H5_ATTR_UNUSED *bkg)
+H5T__conv_int_uint(H5T_t *st, H5T_t *dt, H5T_cdata_t *cdata, const H5T_conv_ctx_t *conv_ctx, size_t nelmts,
+                   size_t buf_stride, size_t H5_ATTR_UNUSED bkg_stride, void *buf, void H5_ATTR_UNUSED *bkg)
 {
     H5T_CONV_su(INT, UINT, int, unsigned, -, -);
 }
@@ -5886,8 +6006,8 @@ H5T__conv_int_uint(hid_t src_id, hid_t dst_id, H5T_cdata_t *cdata, size_t nelmts
  *-------------------------------------------------------------------------
  */
 herr_t
-H5T__conv_uint_int(hid_t src_id, hid_t dst_id, H5T_cdata_t *cdata, size_t nelmts, size_t buf_stride,
-                   size_t H5_ATTR_UNUSED bkg_stride, void *buf, void H5_ATTR_UNUSED *bkg)
+H5T__conv_uint_int(H5T_t *st, H5T_t *dt, H5T_cdata_t *cdata, const H5T_conv_ctx_t *conv_ctx, size_t nelmts,
+                   size_t buf_stride, size_t H5_ATTR_UNUSED bkg_stride, void *buf, void H5_ATTR_UNUSED *bkg)
 {
     H5T_CONV_us(UINT, INT, unsigned, int, -, INT_MAX);
 }
@@ -5904,8 +6024,8 @@ H5T__conv_uint_int(hid_t src_id, hid_t dst_id, H5T_cdata_t *cdata, size_t nelmts
  *-------------------------------------------------------------------------
  */
 herr_t
-H5T__conv_int_long(hid_t src_id, hid_t dst_id, H5T_cdata_t *cdata, size_t nelmts, size_t buf_stride,
-                   size_t H5_ATTR_UNUSED bkg_stride, void *buf, void H5_ATTR_UNUSED *bkg)
+H5T__conv_int_long(H5T_t *st, H5T_t *dt, H5T_cdata_t *cdata, const H5T_conv_ctx_t *conv_ctx, size_t nelmts,
+                   size_t buf_stride, size_t H5_ATTR_UNUSED bkg_stride, void *buf, void H5_ATTR_UNUSED *bkg)
 {
     H5T_CONV_sS(INT, LONG, int, long, -, -);
 }
@@ -5922,8 +6042,8 @@ H5T__conv_int_long(hid_t src_id, hid_t dst_id, H5T_cdata_t *cdata, size_t nelmts
  *-------------------------------------------------------------------------
  */
 herr_t
-H5T__conv_int_ulong(hid_t src_id, hid_t dst_id, H5T_cdata_t *cdata, size_t nelmts, size_t buf_stride,
-                    size_t H5_ATTR_UNUSED bkg_stride, void *buf, void H5_ATTR_UNUSED *bkg)
+H5T__conv_int_ulong(H5T_t *st, H5T_t *dt, H5T_cdata_t *cdata, const H5T_conv_ctx_t *conv_ctx, size_t nelmts,
+                    size_t buf_stride, size_t H5_ATTR_UNUSED bkg_stride, void *buf, void H5_ATTR_UNUSED *bkg)
 {
     H5T_CONV_sU(INT, LONG, int, unsigned long, -, -);
 }
@@ -5940,8 +6060,8 @@ H5T__conv_int_ulong(hid_t src_id, hid_t dst_id, H5T_cdata_t *cdata, size_t nelmt
  *-------------------------------------------------------------------------
  */
 herr_t
-H5T__conv_uint_long(hid_t src_id, hid_t dst_id, H5T_cdata_t *cdata, size_t nelmts, size_t buf_stride,
-                    size_t H5_ATTR_UNUSED bkg_stride, void *buf, void H5_ATTR_UNUSED *bkg)
+H5T__conv_uint_long(H5T_t *st, H5T_t *dt, H5T_cdata_t *cdata, const H5T_conv_ctx_t *conv_ctx, size_t nelmts,
+                    size_t buf_stride, size_t H5_ATTR_UNUSED bkg_stride, void *buf, void H5_ATTR_UNUSED *bkg)
 {
     H5T_CONV_uS(UINT, LONG, unsigned, long, -, LONG_MAX);
 }
@@ -5958,8 +6078,8 @@ H5T__conv_uint_long(hid_t src_id, hid_t dst_id, H5T_cdata_t *cdata, size_t nelmt
  *-------------------------------------------------------------------------
  */
 herr_t
-H5T__conv_uint_ulong(hid_t src_id, hid_t dst_id, H5T_cdata_t *cdata, size_t nelmts, size_t buf_stride,
-                     size_t H5_ATTR_UNUSED bkg_stride, void *buf, void H5_ATTR_UNUSED *bkg)
+H5T__conv_uint_ulong(H5T_t *st, H5T_t *dt, H5T_cdata_t *cdata, const H5T_conv_ctx_t *conv_ctx, size_t nelmts,
+                     size_t buf_stride, size_t H5_ATTR_UNUSED bkg_stride, void *buf, void H5_ATTR_UNUSED *bkg)
 {
     H5T_CONV_uU(UINT, ULONG, unsigned, unsigned long, -, -);
 }
@@ -5976,8 +6096,8 @@ H5T__conv_uint_ulong(hid_t src_id, hid_t dst_id, H5T_cdata_t *cdata, size_t nelm
  *-------------------------------------------------------------------------
  */
 herr_t
-H5T__conv_int_llong(hid_t src_id, hid_t dst_id, H5T_cdata_t *cdata, size_t nelmts, size_t buf_stride,
-                    size_t H5_ATTR_UNUSED bkg_stride, void *buf, void H5_ATTR_UNUSED *bkg)
+H5T__conv_int_llong(H5T_t *st, H5T_t *dt, H5T_cdata_t *cdata, const H5T_conv_ctx_t *conv_ctx, size_t nelmts,
+                    size_t buf_stride, size_t H5_ATTR_UNUSED bkg_stride, void *buf, void H5_ATTR_UNUSED *bkg)
 {
     H5T_CONV_sS(INT, LLONG, int, long long, -, -);
 }
@@ -5994,8 +6114,8 @@ H5T__conv_int_llong(hid_t src_id, hid_t dst_id, H5T_cdata_t *cdata, size_t nelmt
  *-------------------------------------------------------------------------
  */
 herr_t
-H5T__conv_int_ullong(hid_t src_id, hid_t dst_id, H5T_cdata_t *cdata, size_t nelmts, size_t buf_stride,
-                     size_t H5_ATTR_UNUSED bkg_stride, void *buf, void H5_ATTR_UNUSED *bkg)
+H5T__conv_int_ullong(H5T_t *st, H5T_t *dt, H5T_cdata_t *cdata, const H5T_conv_ctx_t *conv_ctx, size_t nelmts,
+                     size_t buf_stride, size_t H5_ATTR_UNUSED bkg_stride, void *buf, void H5_ATTR_UNUSED *bkg)
 {
     H5T_CONV_sU(INT, ULLONG, int, unsigned long long, -, -);
 }
@@ -6012,8 +6132,8 @@ H5T__conv_int_ullong(hid_t src_id, hid_t dst_id, H5T_cdata_t *cdata, size_t nelm
  *-------------------------------------------------------------------------
  */
 herr_t
-H5T__conv_uint_llong(hid_t src_id, hid_t dst_id, H5T_cdata_t *cdata, size_t nelmts, size_t buf_stride,
-                     size_t H5_ATTR_UNUSED bkg_stride, void *buf, void H5_ATTR_UNUSED *bkg)
+H5T__conv_uint_llong(H5T_t *st, H5T_t *dt, H5T_cdata_t *cdata, const H5T_conv_ctx_t *conv_ctx, size_t nelmts,
+                     size_t buf_stride, size_t H5_ATTR_UNUSED bkg_stride, void *buf, void H5_ATTR_UNUSED *bkg)
 {
     H5T_CONV_uS(UINT, LLONG, unsigned, long long, -, LLONG_MAX);
 }
@@ -6030,8 +6150,9 @@ H5T__conv_uint_llong(hid_t src_id, hid_t dst_id, H5T_cdata_t *cdata, size_t nelm
  *-------------------------------------------------------------------------
  */
 herr_t
-H5T__conv_uint_ullong(hid_t src_id, hid_t dst_id, H5T_cdata_t *cdata, size_t nelmts, size_t buf_stride,
-                      size_t H5_ATTR_UNUSED bkg_stride, void *buf, void H5_ATTR_UNUSED *bkg)
+H5T__conv_uint_ullong(H5T_t *st, H5T_t *dt, H5T_cdata_t *cdata, const H5T_conv_ctx_t *conv_ctx, size_t nelmts,
+                      size_t buf_stride, size_t H5_ATTR_UNUSED bkg_stride, void *buf,
+                      void H5_ATTR_UNUSED *bkg)
 {
     H5T_CONV_uU(UINT, ULLONG, unsigned, unsigned long long, -, -);
 }
@@ -6048,8 +6169,8 @@ H5T__conv_uint_ullong(hid_t src_id, hid_t dst_id, H5T_cdata_t *cdata, size_t nel
  *-------------------------------------------------------------------------
  */
 herr_t
-H5T__conv_long_schar(hid_t src_id, hid_t dst_id, H5T_cdata_t *cdata, size_t nelmts, size_t buf_stride,
-                     size_t H5_ATTR_UNUSED bkg_stride, void *buf, void H5_ATTR_UNUSED *bkg)
+H5T__conv_long_schar(H5T_t *st, H5T_t *dt, H5T_cdata_t *cdata, const H5T_conv_ctx_t *conv_ctx, size_t nelmts,
+                     size_t buf_stride, size_t H5_ATTR_UNUSED bkg_stride, void *buf, void H5_ATTR_UNUSED *bkg)
 {
     H5T_CONV_Ss(LONG, SCHAR, long, signed char, SCHAR_MIN, SCHAR_MAX);
 }
@@ -6066,8 +6187,8 @@ H5T__conv_long_schar(hid_t src_id, hid_t dst_id, H5T_cdata_t *cdata, size_t nelm
  *-------------------------------------------------------------------------
  */
 herr_t
-H5T__conv_long_uchar(hid_t src_id, hid_t dst_id, H5T_cdata_t *cdata, size_t nelmts, size_t buf_stride,
-                     size_t H5_ATTR_UNUSED bkg_stride, void *buf, void H5_ATTR_UNUSED *bkg)
+H5T__conv_long_uchar(H5T_t *st, H5T_t *dt, H5T_cdata_t *cdata, const H5T_conv_ctx_t *conv_ctx, size_t nelmts,
+                     size_t buf_stride, size_t H5_ATTR_UNUSED bkg_stride, void *buf, void H5_ATTR_UNUSED *bkg)
 {
     H5T_CONV_Su(LONG, UCHAR, long, unsigned char, -, UCHAR_MAX);
 }
@@ -6084,8 +6205,9 @@ H5T__conv_long_uchar(hid_t src_id, hid_t dst_id, H5T_cdata_t *cdata, size_t nelm
  *-------------------------------------------------------------------------
  */
 herr_t
-H5T__conv_ulong_schar(hid_t src_id, hid_t dst_id, H5T_cdata_t *cdata, size_t nelmts, size_t buf_stride,
-                      size_t H5_ATTR_UNUSED bkg_stride, void *buf, void H5_ATTR_UNUSED *bkg)
+H5T__conv_ulong_schar(H5T_t *st, H5T_t *dt, H5T_cdata_t *cdata, const H5T_conv_ctx_t *conv_ctx, size_t nelmts,
+                      size_t buf_stride, size_t H5_ATTR_UNUSED bkg_stride, void *buf,
+                      void H5_ATTR_UNUSED *bkg)
 {
     H5T_CONV_Us(ULONG, SCHAR, unsigned long, signed char, -, SCHAR_MAX);
 }
@@ -6102,8 +6224,9 @@ H5T__conv_ulong_schar(hid_t src_id, hid_t dst_id, H5T_cdata_t *cdata, size_t nel
  *-------------------------------------------------------------------------
  */
 herr_t
-H5T__conv_ulong_uchar(hid_t src_id, hid_t dst_id, H5T_cdata_t *cdata, size_t nelmts, size_t buf_stride,
-                      size_t H5_ATTR_UNUSED bkg_stride, void *buf, void H5_ATTR_UNUSED *bkg)
+H5T__conv_ulong_uchar(H5T_t *st, H5T_t *dt, H5T_cdata_t *cdata, const H5T_conv_ctx_t *conv_ctx, size_t nelmts,
+                      size_t buf_stride, size_t H5_ATTR_UNUSED bkg_stride, void *buf,
+                      void H5_ATTR_UNUSED *bkg)
 {
     H5T_CONV_Uu(ULONG, UCHAR, unsigned long, unsigned char, -, UCHAR_MAX);
 }
@@ -6120,8 +6243,8 @@ H5T__conv_ulong_uchar(hid_t src_id, hid_t dst_id, H5T_cdata_t *cdata, size_t nel
  *-------------------------------------------------------------------------
  */
 herr_t
-H5T__conv_long_short(hid_t src_id, hid_t dst_id, H5T_cdata_t *cdata, size_t nelmts, size_t buf_stride,
-                     size_t H5_ATTR_UNUSED bkg_stride, void *buf, void H5_ATTR_UNUSED *bkg)
+H5T__conv_long_short(H5T_t *st, H5T_t *dt, H5T_cdata_t *cdata, const H5T_conv_ctx_t *conv_ctx, size_t nelmts,
+                     size_t buf_stride, size_t H5_ATTR_UNUSED bkg_stride, void *buf, void H5_ATTR_UNUSED *bkg)
 {
     H5T_CONV_Ss(LONG, SHORT, long, short, SHRT_MIN, SHRT_MAX);
 }
@@ -6138,8 +6261,9 @@ H5T__conv_long_short(hid_t src_id, hid_t dst_id, H5T_cdata_t *cdata, size_t nelm
  *-------------------------------------------------------------------------
  */
 herr_t
-H5T__conv_long_ushort(hid_t src_id, hid_t dst_id, H5T_cdata_t *cdata, size_t nelmts, size_t buf_stride,
-                      size_t H5_ATTR_UNUSED bkg_stride, void *buf, void H5_ATTR_UNUSED *bkg)
+H5T__conv_long_ushort(H5T_t *st, H5T_t *dt, H5T_cdata_t *cdata, const H5T_conv_ctx_t *conv_ctx, size_t nelmts,
+                      size_t buf_stride, size_t H5_ATTR_UNUSED bkg_stride, void *buf,
+                      void H5_ATTR_UNUSED *bkg)
 {
     H5T_CONV_Su(LONG, USHORT, long, unsigned short, -, USHRT_MAX);
 }
@@ -6156,8 +6280,9 @@ H5T__conv_long_ushort(hid_t src_id, hid_t dst_id, H5T_cdata_t *cdata, size_t nel
  *-------------------------------------------------------------------------
  */
 herr_t
-H5T__conv_ulong_short(hid_t src_id, hid_t dst_id, H5T_cdata_t *cdata, size_t nelmts, size_t buf_stride,
-                      size_t H5_ATTR_UNUSED bkg_stride, void *buf, void H5_ATTR_UNUSED *bkg)
+H5T__conv_ulong_short(H5T_t *st, H5T_t *dt, H5T_cdata_t *cdata, const H5T_conv_ctx_t *conv_ctx, size_t nelmts,
+                      size_t buf_stride, size_t H5_ATTR_UNUSED bkg_stride, void *buf,
+                      void H5_ATTR_UNUSED *bkg)
 {
     H5T_CONV_Us(ULONG, SHORT, unsigned long, short, -, SHRT_MAX);
 }
@@ -6174,8 +6299,9 @@ H5T__conv_ulong_short(hid_t src_id, hid_t dst_id, H5T_cdata_t *cdata, size_t nel
  *-------------------------------------------------------------------------
  */
 herr_t
-H5T__conv_ulong_ushort(hid_t src_id, hid_t dst_id, H5T_cdata_t *cdata, size_t nelmts, size_t buf_stride,
-                       size_t H5_ATTR_UNUSED bkg_stride, void *buf, void H5_ATTR_UNUSED *bkg)
+H5T__conv_ulong_ushort(H5T_t *st, H5T_t *dt, H5T_cdata_t *cdata, const H5T_conv_ctx_t *conv_ctx,
+                       size_t nelmts, size_t buf_stride, size_t H5_ATTR_UNUSED bkg_stride, void *buf,
+                       void H5_ATTR_UNUSED *bkg)
 {
     H5T_CONV_Uu(ULONG, USHORT, unsigned long, unsigned short, -, USHRT_MAX);
 }
@@ -6192,8 +6318,8 @@ H5T__conv_ulong_ushort(hid_t src_id, hid_t dst_id, H5T_cdata_t *cdata, size_t ne
  *-------------------------------------------------------------------------
  */
 herr_t
-H5T__conv_long_int(hid_t src_id, hid_t dst_id, H5T_cdata_t *cdata, size_t nelmts, size_t buf_stride,
-                   size_t H5_ATTR_UNUSED bkg_stride, void *buf, void H5_ATTR_UNUSED *bkg)
+H5T__conv_long_int(H5T_t *st, H5T_t *dt, H5T_cdata_t *cdata, const H5T_conv_ctx_t *conv_ctx, size_t nelmts,
+                   size_t buf_stride, size_t H5_ATTR_UNUSED bkg_stride, void *buf, void H5_ATTR_UNUSED *bkg)
 {
     H5T_CONV_Ss(LONG, INT, long, int, INT_MIN, INT_MAX);
 }
@@ -6210,8 +6336,8 @@ H5T__conv_long_int(hid_t src_id, hid_t dst_id, H5T_cdata_t *cdata, size_t nelmts
  *-------------------------------------------------------------------------
  */
 herr_t
-H5T__conv_long_uint(hid_t src_id, hid_t dst_id, H5T_cdata_t *cdata, size_t nelmts, size_t buf_stride,
-                    size_t H5_ATTR_UNUSED bkg_stride, void *buf, void H5_ATTR_UNUSED *bkg)
+H5T__conv_long_uint(H5T_t *st, H5T_t *dt, H5T_cdata_t *cdata, const H5T_conv_ctx_t *conv_ctx, size_t nelmts,
+                    size_t buf_stride, size_t H5_ATTR_UNUSED bkg_stride, void *buf, void H5_ATTR_UNUSED *bkg)
 {
     H5T_CONV_Su(LONG, UINT, long, unsigned, -, UINT_MAX);
 }
@@ -6228,8 +6354,8 @@ H5T__conv_long_uint(hid_t src_id, hid_t dst_id, H5T_cdata_t *cdata, size_t nelmt
  *-------------------------------------------------------------------------
  */
 herr_t
-H5T__conv_ulong_int(hid_t src_id, hid_t dst_id, H5T_cdata_t *cdata, size_t nelmts, size_t buf_stride,
-                    size_t H5_ATTR_UNUSED bkg_stride, void *buf, void H5_ATTR_UNUSED *bkg)
+H5T__conv_ulong_int(H5T_t *st, H5T_t *dt, H5T_cdata_t *cdata, const H5T_conv_ctx_t *conv_ctx, size_t nelmts,
+                    size_t buf_stride, size_t H5_ATTR_UNUSED bkg_stride, void *buf, void H5_ATTR_UNUSED *bkg)
 {
     H5T_CONV_Us(ULONG, INT, unsigned long, int, -, INT_MAX);
 }
@@ -6246,8 +6372,8 @@ H5T__conv_ulong_int(hid_t src_id, hid_t dst_id, H5T_cdata_t *cdata, size_t nelmt
  *-------------------------------------------------------------------------
  */
 herr_t
-H5T__conv_ulong_uint(hid_t src_id, hid_t dst_id, H5T_cdata_t *cdata, size_t nelmts, size_t buf_stride,
-                     size_t H5_ATTR_UNUSED bkg_stride, void *buf, void H5_ATTR_UNUSED *bkg)
+H5T__conv_ulong_uint(H5T_t *st, H5T_t *dt, H5T_cdata_t *cdata, const H5T_conv_ctx_t *conv_ctx, size_t nelmts,
+                     size_t buf_stride, size_t H5_ATTR_UNUSED bkg_stride, void *buf, void H5_ATTR_UNUSED *bkg)
 {
     H5T_CONV_Uu(ULONG, UINT, unsigned long, unsigned, -, UINT_MAX);
 }
@@ -6264,8 +6390,8 @@ H5T__conv_ulong_uint(hid_t src_id, hid_t dst_id, H5T_cdata_t *cdata, size_t nelm
  *-------------------------------------------------------------------------
  */
 herr_t
-H5T__conv_long_ulong(hid_t src_id, hid_t dst_id, H5T_cdata_t *cdata, size_t nelmts, size_t buf_stride,
-                     size_t H5_ATTR_UNUSED bkg_stride, void *buf, void H5_ATTR_UNUSED *bkg)
+H5T__conv_long_ulong(H5T_t *st, H5T_t *dt, H5T_cdata_t *cdata, const H5T_conv_ctx_t *conv_ctx, size_t nelmts,
+                     size_t buf_stride, size_t H5_ATTR_UNUSED bkg_stride, void *buf, void H5_ATTR_UNUSED *bkg)
 {
     H5T_CONV_su(LONG, ULONG, long, unsigned long, -, -);
 }
@@ -6282,8 +6408,8 @@ H5T__conv_long_ulong(hid_t src_id, hid_t dst_id, H5T_cdata_t *cdata, size_t nelm
  *-------------------------------------------------------------------------
  */
 herr_t
-H5T__conv_ulong_long(hid_t src_id, hid_t dst_id, H5T_cdata_t *cdata, size_t nelmts, size_t buf_stride,
-                     size_t H5_ATTR_UNUSED bkg_stride, void *buf, void H5_ATTR_UNUSED *bkg)
+H5T__conv_ulong_long(H5T_t *st, H5T_t *dt, H5T_cdata_t *cdata, const H5T_conv_ctx_t *conv_ctx, size_t nelmts,
+                     size_t buf_stride, size_t H5_ATTR_UNUSED bkg_stride, void *buf, void H5_ATTR_UNUSED *bkg)
 {
     H5T_CONV_us(ULONG, LONG, unsigned long, long, -, LONG_MAX);
 }
@@ -6300,8 +6426,8 @@ H5T__conv_ulong_long(hid_t src_id, hid_t dst_id, H5T_cdata_t *cdata, size_t nelm
  *-------------------------------------------------------------------------
  */
 herr_t
-H5T__conv_long_llong(hid_t src_id, hid_t dst_id, H5T_cdata_t *cdata, size_t nelmts, size_t buf_stride,
-                     size_t H5_ATTR_UNUSED bkg_stride, void *buf, void H5_ATTR_UNUSED *bkg)
+H5T__conv_long_llong(H5T_t *st, H5T_t *dt, H5T_cdata_t *cdata, const H5T_conv_ctx_t *conv_ctx, size_t nelmts,
+                     size_t buf_stride, size_t H5_ATTR_UNUSED bkg_stride, void *buf, void H5_ATTR_UNUSED *bkg)
 {
     H5T_CONV_sS(LONG, LLONG, long, long long, -, -);
 }
@@ -6318,8 +6444,9 @@ H5T__conv_long_llong(hid_t src_id, hid_t dst_id, H5T_cdata_t *cdata, size_t nelm
  *-------------------------------------------------------------------------
  */
 herr_t
-H5T__conv_long_ullong(hid_t src_id, hid_t dst_id, H5T_cdata_t *cdata, size_t nelmts, size_t buf_stride,
-                      size_t H5_ATTR_UNUSED bkg_stride, void *buf, void H5_ATTR_UNUSED *bkg)
+H5T__conv_long_ullong(H5T_t *st, H5T_t *dt, H5T_cdata_t *cdata, const H5T_conv_ctx_t *conv_ctx, size_t nelmts,
+                      size_t buf_stride, size_t H5_ATTR_UNUSED bkg_stride, void *buf,
+                      void H5_ATTR_UNUSED *bkg)
 {
     H5T_CONV_sU(LONG, ULLONG, long, unsigned long long, -, -);
 }
@@ -6336,8 +6463,9 @@ H5T__conv_long_ullong(hid_t src_id, hid_t dst_id, H5T_cdata_t *cdata, size_t nel
  *-------------------------------------------------------------------------
  */
 herr_t
-H5T__conv_ulong_llong(hid_t src_id, hid_t dst_id, H5T_cdata_t *cdata, size_t nelmts, size_t buf_stride,
-                      size_t H5_ATTR_UNUSED bkg_stride, void *buf, void H5_ATTR_UNUSED *bkg)
+H5T__conv_ulong_llong(H5T_t *st, H5T_t *dt, H5T_cdata_t *cdata, const H5T_conv_ctx_t *conv_ctx, size_t nelmts,
+                      size_t buf_stride, size_t H5_ATTR_UNUSED bkg_stride, void *buf,
+                      void H5_ATTR_UNUSED *bkg)
 {
     H5T_CONV_uS(ULONG, LLONG, unsigned long, long long, -, LLONG_MAX);
 }
@@ -6354,8 +6482,9 @@ H5T__conv_ulong_llong(hid_t src_id, hid_t dst_id, H5T_cdata_t *cdata, size_t nel
  *-------------------------------------------------------------------------
  */
 herr_t
-H5T__conv_ulong_ullong(hid_t src_id, hid_t dst_id, H5T_cdata_t *cdata, size_t nelmts, size_t buf_stride,
-                       size_t H5_ATTR_UNUSED bkg_stride, void *buf, void H5_ATTR_UNUSED *bkg)
+H5T__conv_ulong_ullong(H5T_t *st, H5T_t *dt, H5T_cdata_t *cdata, const H5T_conv_ctx_t *conv_ctx,
+                       size_t nelmts, size_t buf_stride, size_t H5_ATTR_UNUSED bkg_stride, void *buf,
+                       void H5_ATTR_UNUSED *bkg)
 {
     H5T_CONV_uU(ULONG, ULLONG, unsigned long, unsigned long long, -, -);
 }
@@ -6372,8 +6501,9 @@ H5T__conv_ulong_ullong(hid_t src_id, hid_t dst_id, H5T_cdata_t *cdata, size_t ne
  *-------------------------------------------------------------------------
  */
 herr_t
-H5T__conv_llong_schar(hid_t src_id, hid_t dst_id, H5T_cdata_t *cdata, size_t nelmts, size_t buf_stride,
-                      size_t H5_ATTR_UNUSED bkg_stride, void *buf, void H5_ATTR_UNUSED *bkg)
+H5T__conv_llong_schar(H5T_t *st, H5T_t *dt, H5T_cdata_t *cdata, const H5T_conv_ctx_t *conv_ctx, size_t nelmts,
+                      size_t buf_stride, size_t H5_ATTR_UNUSED bkg_stride, void *buf,
+                      void H5_ATTR_UNUSED *bkg)
 {
     H5T_CONV_Ss(LLONG, SCHAR, long long, signed char, SCHAR_MIN, SCHAR_MAX);
 }
@@ -6390,8 +6520,9 @@ H5T__conv_llong_schar(hid_t src_id, hid_t dst_id, H5T_cdata_t *cdata, size_t nel
  *-------------------------------------------------------------------------
  */
 herr_t
-H5T__conv_llong_uchar(hid_t src_id, hid_t dst_id, H5T_cdata_t *cdata, size_t nelmts, size_t buf_stride,
-                      size_t H5_ATTR_UNUSED bkg_stride, void *buf, void H5_ATTR_UNUSED *bkg)
+H5T__conv_llong_uchar(H5T_t *st, H5T_t *dt, H5T_cdata_t *cdata, const H5T_conv_ctx_t *conv_ctx, size_t nelmts,
+                      size_t buf_stride, size_t H5_ATTR_UNUSED bkg_stride, void *buf,
+                      void H5_ATTR_UNUSED *bkg)
 {
     H5T_CONV_Su(LLONG, UCHAR, long long, unsigned char, -, UCHAR_MAX);
 }
@@ -6408,8 +6539,9 @@ H5T__conv_llong_uchar(hid_t src_id, hid_t dst_id, H5T_cdata_t *cdata, size_t nel
  *-------------------------------------------------------------------------
  */
 herr_t
-H5T__conv_ullong_schar(hid_t src_id, hid_t dst_id, H5T_cdata_t *cdata, size_t nelmts, size_t buf_stride,
-                       size_t H5_ATTR_UNUSED bkg_stride, void *buf, void H5_ATTR_UNUSED *bkg)
+H5T__conv_ullong_schar(H5T_t *st, H5T_t *dt, H5T_cdata_t *cdata, const H5T_conv_ctx_t *conv_ctx,
+                       size_t nelmts, size_t buf_stride, size_t H5_ATTR_UNUSED bkg_stride, void *buf,
+                       void H5_ATTR_UNUSED *bkg)
 {
     H5T_CONV_Us(ULLONG, SCHAR, unsigned long long, signed char, -, SCHAR_MAX);
 }
@@ -6426,8 +6558,9 @@ H5T__conv_ullong_schar(hid_t src_id, hid_t dst_id, H5T_cdata_t *cdata, size_t ne
  *-------------------------------------------------------------------------
  */
 herr_t
-H5T__conv_ullong_uchar(hid_t src_id, hid_t dst_id, H5T_cdata_t *cdata, size_t nelmts, size_t buf_stride,
-                       size_t H5_ATTR_UNUSED bkg_stride, void *buf, void H5_ATTR_UNUSED *bkg)
+H5T__conv_ullong_uchar(H5T_t *st, H5T_t *dt, H5T_cdata_t *cdata, const H5T_conv_ctx_t *conv_ctx,
+                       size_t nelmts, size_t buf_stride, size_t H5_ATTR_UNUSED bkg_stride, void *buf,
+                       void H5_ATTR_UNUSED *bkg)
 {
     H5T_CONV_Uu(ULLONG, UCHAR, unsigned long long, unsigned char, -, UCHAR_MAX);
 }
@@ -6444,8 +6577,9 @@ H5T__conv_ullong_uchar(hid_t src_id, hid_t dst_id, H5T_cdata_t *cdata, size_t ne
  *-------------------------------------------------------------------------
  */
 herr_t
-H5T__conv_llong_short(hid_t src_id, hid_t dst_id, H5T_cdata_t *cdata, size_t nelmts, size_t buf_stride,
-                      size_t H5_ATTR_UNUSED bkg_stride, void *buf, void H5_ATTR_UNUSED *bkg)
+H5T__conv_llong_short(H5T_t *st, H5T_t *dt, H5T_cdata_t *cdata, const H5T_conv_ctx_t *conv_ctx, size_t nelmts,
+                      size_t buf_stride, size_t H5_ATTR_UNUSED bkg_stride, void *buf,
+                      void H5_ATTR_UNUSED *bkg)
 {
     H5T_CONV_Ss(LLONG, SHORT, long long, short, SHRT_MIN, SHRT_MAX);
 }
@@ -6462,8 +6596,9 @@ H5T__conv_llong_short(hid_t src_id, hid_t dst_id, H5T_cdata_t *cdata, size_t nel
  *-------------------------------------------------------------------------
  */
 herr_t
-H5T__conv_llong_ushort(hid_t src_id, hid_t dst_id, H5T_cdata_t *cdata, size_t nelmts, size_t buf_stride,
-                       size_t H5_ATTR_UNUSED bkg_stride, void *buf, void H5_ATTR_UNUSED *bkg)
+H5T__conv_llong_ushort(H5T_t *st, H5T_t *dt, H5T_cdata_t *cdata, const H5T_conv_ctx_t *conv_ctx,
+                       size_t nelmts, size_t buf_stride, size_t H5_ATTR_UNUSED bkg_stride, void *buf,
+                       void H5_ATTR_UNUSED *bkg)
 {
     H5T_CONV_Su(LLONG, USHORT, long long, unsigned short, -, USHRT_MAX);
 }
@@ -6480,8 +6615,9 @@ H5T__conv_llong_ushort(hid_t src_id, hid_t dst_id, H5T_cdata_t *cdata, size_t ne
  *-------------------------------------------------------------------------
  */
 herr_t
-H5T__conv_ullong_short(hid_t src_id, hid_t dst_id, H5T_cdata_t *cdata, size_t nelmts, size_t buf_stride,
-                       size_t H5_ATTR_UNUSED bkg_stride, void *buf, void H5_ATTR_UNUSED *bkg)
+H5T__conv_ullong_short(H5T_t *st, H5T_t *dt, H5T_cdata_t *cdata, const H5T_conv_ctx_t *conv_ctx,
+                       size_t nelmts, size_t buf_stride, size_t H5_ATTR_UNUSED bkg_stride, void *buf,
+                       void H5_ATTR_UNUSED *bkg)
 {
     H5T_CONV_Us(ULLONG, SHORT, unsigned long long, short, -, SHRT_MAX);
 }
@@ -6498,8 +6634,9 @@ H5T__conv_ullong_short(hid_t src_id, hid_t dst_id, H5T_cdata_t *cdata, size_t ne
  *-------------------------------------------------------------------------
  */
 herr_t
-H5T__conv_ullong_ushort(hid_t src_id, hid_t dst_id, H5T_cdata_t *cdata, size_t nelmts, size_t buf_stride,
-                        size_t H5_ATTR_UNUSED bkg_stride, void *buf, void H5_ATTR_UNUSED *bkg)
+H5T__conv_ullong_ushort(H5T_t *st, H5T_t *dt, H5T_cdata_t *cdata, const H5T_conv_ctx_t *conv_ctx,
+                        size_t nelmts, size_t buf_stride, size_t H5_ATTR_UNUSED bkg_stride, void *buf,
+                        void H5_ATTR_UNUSED *bkg)
 {
     H5T_CONV_Uu(ULLONG, USHORT, unsigned long long, unsigned short, -, USHRT_MAX);
 }
@@ -6516,8 +6653,8 @@ H5T__conv_ullong_ushort(hid_t src_id, hid_t dst_id, H5T_cdata_t *cdata, size_t n
  *-------------------------------------------------------------------------
  */
 herr_t
-H5T__conv_llong_int(hid_t src_id, hid_t dst_id, H5T_cdata_t *cdata, size_t nelmts, size_t buf_stride,
-                    size_t H5_ATTR_UNUSED bkg_stride, void *buf, void H5_ATTR_UNUSED *bkg)
+H5T__conv_llong_int(H5T_t *st, H5T_t *dt, H5T_cdata_t *cdata, const H5T_conv_ctx_t *conv_ctx, size_t nelmts,
+                    size_t buf_stride, size_t H5_ATTR_UNUSED bkg_stride, void *buf, void H5_ATTR_UNUSED *bkg)
 {
     H5T_CONV_Ss(LLONG, INT, long long, int, INT_MIN, INT_MAX);
 }
@@ -6534,8 +6671,8 @@ H5T__conv_llong_int(hid_t src_id, hid_t dst_id, H5T_cdata_t *cdata, size_t nelmt
  *-------------------------------------------------------------------------
  */
 herr_t
-H5T__conv_llong_uint(hid_t src_id, hid_t dst_id, H5T_cdata_t *cdata, size_t nelmts, size_t buf_stride,
-                     size_t H5_ATTR_UNUSED bkg_stride, void *buf, void H5_ATTR_UNUSED *bkg)
+H5T__conv_llong_uint(H5T_t *st, H5T_t *dt, H5T_cdata_t *cdata, const H5T_conv_ctx_t *conv_ctx, size_t nelmts,
+                     size_t buf_stride, size_t H5_ATTR_UNUSED bkg_stride, void *buf, void H5_ATTR_UNUSED *bkg)
 {
     H5T_CONV_Su(LLONG, UINT, long long, unsigned, -, UINT_MAX);
 }
@@ -6552,8 +6689,8 @@ H5T__conv_llong_uint(hid_t src_id, hid_t dst_id, H5T_cdata_t *cdata, size_t nelm
  *-------------------------------------------------------------------------
  */
 herr_t
-H5T__conv_ullong_int(hid_t src_id, hid_t dst_id, H5T_cdata_t *cdata, size_t nelmts, size_t buf_stride,
-                     size_t H5_ATTR_UNUSED bkg_stride, void *buf, void H5_ATTR_UNUSED *bkg)
+H5T__conv_ullong_int(H5T_t *st, H5T_t *dt, H5T_cdata_t *cdata, const H5T_conv_ctx_t *conv_ctx, size_t nelmts,
+                     size_t buf_stride, size_t H5_ATTR_UNUSED bkg_stride, void *buf, void H5_ATTR_UNUSED *bkg)
 {
     H5T_CONV_Us(ULLONG, INT, unsigned long long, int, -, INT_MAX);
 }
@@ -6570,8 +6707,9 @@ H5T__conv_ullong_int(hid_t src_id, hid_t dst_id, H5T_cdata_t *cdata, size_t nelm
  *-------------------------------------------------------------------------
  */
 herr_t
-H5T__conv_ullong_uint(hid_t src_id, hid_t dst_id, H5T_cdata_t *cdata, size_t nelmts, size_t buf_stride,
-                      size_t H5_ATTR_UNUSED bkg_stride, void *buf, void H5_ATTR_UNUSED *bkg)
+H5T__conv_ullong_uint(H5T_t *st, H5T_t *dt, H5T_cdata_t *cdata, const H5T_conv_ctx_t *conv_ctx, size_t nelmts,
+                      size_t buf_stride, size_t H5_ATTR_UNUSED bkg_stride, void *buf,
+                      void H5_ATTR_UNUSED *bkg)
 {
     H5T_CONV_Uu(ULLONG, UINT, unsigned long long, unsigned, -, UINT_MAX);
 }
@@ -6588,8 +6726,8 @@ H5T__conv_ullong_uint(hid_t src_id, hid_t dst_id, H5T_cdata_t *cdata, size_t nel
  *-------------------------------------------------------------------------
  */
 herr_t
-H5T__conv_llong_long(hid_t src_id, hid_t dst_id, H5T_cdata_t *cdata, size_t nelmts, size_t buf_stride,
-                     size_t H5_ATTR_UNUSED bkg_stride, void *buf, void H5_ATTR_UNUSED *bkg)
+H5T__conv_llong_long(H5T_t *st, H5T_t *dt, H5T_cdata_t *cdata, const H5T_conv_ctx_t *conv_ctx, size_t nelmts,
+                     size_t buf_stride, size_t H5_ATTR_UNUSED bkg_stride, void *buf, void H5_ATTR_UNUSED *bkg)
 {
     H5T_CONV_Ss(LLONG, LONG, long long, long, LONG_MIN, LONG_MAX);
 }
@@ -6606,8 +6744,9 @@ H5T__conv_llong_long(hid_t src_id, hid_t dst_id, H5T_cdata_t *cdata, size_t nelm
  *-------------------------------------------------------------------------
  */
 herr_t
-H5T__conv_llong_ulong(hid_t src_id, hid_t dst_id, H5T_cdata_t *cdata, size_t nelmts, size_t buf_stride,
-                      size_t H5_ATTR_UNUSED bkg_stride, void *buf, void H5_ATTR_UNUSED *bkg)
+H5T__conv_llong_ulong(H5T_t *st, H5T_t *dt, H5T_cdata_t *cdata, const H5T_conv_ctx_t *conv_ctx, size_t nelmts,
+                      size_t buf_stride, size_t H5_ATTR_UNUSED bkg_stride, void *buf,
+                      void H5_ATTR_UNUSED *bkg)
 {
     H5T_CONV_Su(LLONG, ULONG, long long, unsigned long, -, ULONG_MAX);
 }
@@ -6624,8 +6763,9 @@ H5T__conv_llong_ulong(hid_t src_id, hid_t dst_id, H5T_cdata_t *cdata, size_t nel
  *-------------------------------------------------------------------------
  */
 herr_t
-H5T__conv_ullong_long(hid_t src_id, hid_t dst_id, H5T_cdata_t *cdata, size_t nelmts, size_t buf_stride,
-                      size_t H5_ATTR_UNUSED bkg_stride, void *buf, void H5_ATTR_UNUSED *bkg)
+H5T__conv_ullong_long(H5T_t *st, H5T_t *dt, H5T_cdata_t *cdata, const H5T_conv_ctx_t *conv_ctx, size_t nelmts,
+                      size_t buf_stride, size_t H5_ATTR_UNUSED bkg_stride, void *buf,
+                      void H5_ATTR_UNUSED *bkg)
 {
     H5T_CONV_Us(ULLONG, LONG, unsigned long long, long, -, LONG_MAX);
 }
@@ -6642,8 +6782,9 @@ H5T__conv_ullong_long(hid_t src_id, hid_t dst_id, H5T_cdata_t *cdata, size_t nel
  *-------------------------------------------------------------------------
  */
 herr_t
-H5T__conv_ullong_ulong(hid_t src_id, hid_t dst_id, H5T_cdata_t *cdata, size_t nelmts, size_t buf_stride,
-                       size_t H5_ATTR_UNUSED bkg_stride, void *buf, void H5_ATTR_UNUSED *bkg)
+H5T__conv_ullong_ulong(H5T_t *st, H5T_t *dt, H5T_cdata_t *cdata, const H5T_conv_ctx_t *conv_ctx,
+                       size_t nelmts, size_t buf_stride, size_t H5_ATTR_UNUSED bkg_stride, void *buf,
+                       void H5_ATTR_UNUSED *bkg)
 {
     H5T_CONV_Uu(ULLONG, ULONG, unsigned long long, unsigned long, -, ULONG_MAX);
 }
@@ -6660,8 +6801,9 @@ H5T__conv_ullong_ulong(hid_t src_id, hid_t dst_id, H5T_cdata_t *cdata, size_t ne
  *-------------------------------------------------------------------------
  */
 herr_t
-H5T__conv_llong_ullong(hid_t src_id, hid_t dst_id, H5T_cdata_t *cdata, size_t nelmts, size_t buf_stride,
-                       size_t H5_ATTR_UNUSED bkg_stride, void *buf, void H5_ATTR_UNUSED *bkg)
+H5T__conv_llong_ullong(H5T_t *st, H5T_t *dt, H5T_cdata_t *cdata, const H5T_conv_ctx_t *conv_ctx,
+                       size_t nelmts, size_t buf_stride, size_t H5_ATTR_UNUSED bkg_stride, void *buf,
+                       void H5_ATTR_UNUSED *bkg)
 {
     H5T_CONV_su(LLONG, ULLONG, long long, unsigned long long, -, -);
 }
@@ -6678,8 +6820,9 @@ H5T__conv_llong_ullong(hid_t src_id, hid_t dst_id, H5T_cdata_t *cdata, size_t ne
  *-------------------------------------------------------------------------
  */
 herr_t
-H5T__conv_ullong_llong(hid_t src_id, hid_t dst_id, H5T_cdata_t *cdata, size_t nelmts, size_t buf_stride,
-                       size_t H5_ATTR_UNUSED bkg_stride, void *buf, void H5_ATTR_UNUSED *bkg)
+H5T__conv_ullong_llong(H5T_t *st, H5T_t *dt, H5T_cdata_t *cdata, const H5T_conv_ctx_t *conv_ctx,
+                       size_t nelmts, size_t buf_stride, size_t H5_ATTR_UNUSED bkg_stride, void *buf,
+                       void H5_ATTR_UNUSED *bkg)
 {
     H5T_CONV_us(ULLONG, LLONG, unsigned long long, long long, -, LLONG_MAX);
 }
@@ -6695,8 +6838,9 @@ H5T__conv_ullong_llong(hid_t src_id, hid_t dst_id, H5T_cdata_t *cdata, size_t ne
  *-------------------------------------------------------------------------
  */
 herr_t
-H5T__conv_float_double(hid_t src_id, hid_t dst_id, H5T_cdata_t *cdata, size_t nelmts, size_t buf_stride,
-                       size_t H5_ATTR_UNUSED bkg_stride, void *buf, void H5_ATTR_UNUSED *bkg)
+H5T__conv_float_double(H5T_t *st, H5T_t *dt, H5T_cdata_t *cdata, const H5T_conv_ctx_t *conv_ctx,
+                       size_t nelmts, size_t buf_stride, size_t H5_ATTR_UNUSED bkg_stride, void *buf,
+                       void H5_ATTR_UNUSED *bkg)
 {
     H5T_CONV_fF(FLOAT, DOUBLE, float, double, -, -);
 }
@@ -6712,8 +6856,9 @@ H5T__conv_float_double(hid_t src_id, hid_t dst_id, H5T_cdata_t *cdata, size_t ne
  *-------------------------------------------------------------------------
  */
 herr_t
-H5T__conv_float_ldouble(hid_t src_id, hid_t dst_id, H5T_cdata_t *cdata, size_t nelmts, size_t buf_stride,
-                        size_t H5_ATTR_UNUSED bkg_stride, void *buf, void H5_ATTR_UNUSED *bkg)
+H5T__conv_float_ldouble(H5T_t *st, H5T_t *dt, H5T_cdata_t *cdata, const H5T_conv_ctx_t *conv_ctx,
+                        size_t nelmts, size_t buf_stride, size_t H5_ATTR_UNUSED bkg_stride, void *buf,
+                        void H5_ATTR_UNUSED *bkg)
 {
     H5T_CONV_fF(FLOAT, LDOUBLE, float, long double, -, -);
 }
@@ -6729,8 +6874,9 @@ H5T__conv_float_ldouble(hid_t src_id, hid_t dst_id, H5T_cdata_t *cdata, size_t n
  *-------------------------------------------------------------------------
  */
 herr_t
-H5T__conv_double_float(hid_t src_id, hid_t dst_id, H5T_cdata_t *cdata, size_t nelmts, size_t buf_stride,
-                       size_t H5_ATTR_UNUSED bkg_stride, void *buf, void H5_ATTR_UNUSED *bkg)
+H5T__conv_double_float(H5T_t *st, H5T_t *dt, H5T_cdata_t *cdata, const H5T_conv_ctx_t *conv_ctx,
+                       size_t nelmts, size_t buf_stride, size_t H5_ATTR_UNUSED bkg_stride, void *buf,
+                       void H5_ATTR_UNUSED *bkg)
 {
     H5T_CONV_Ff(DOUBLE, FLOAT, double, float, -FLT_MAX, FLT_MAX);
 }
@@ -6746,8 +6892,9 @@ H5T__conv_double_float(hid_t src_id, hid_t dst_id, H5T_cdata_t *cdata, size_t ne
  *-------------------------------------------------------------------------
  */
 herr_t
-H5T__conv_double_ldouble(hid_t src_id, hid_t dst_id, H5T_cdata_t *cdata, size_t nelmts, size_t buf_stride,
-                         size_t H5_ATTR_UNUSED bkg_stride, void *buf, void H5_ATTR_UNUSED *bkg)
+H5T__conv_double_ldouble(H5T_t *st, H5T_t *dt, H5T_cdata_t *cdata, const H5T_conv_ctx_t *conv_ctx,
+                         size_t nelmts, size_t buf_stride, size_t H5_ATTR_UNUSED bkg_stride, void *buf,
+                         void H5_ATTR_UNUSED *bkg)
 {
     H5T_CONV_fF(DOUBLE, LDOUBLE, double, long double, -, -);
 }
@@ -6763,8 +6910,9 @@ H5T__conv_double_ldouble(hid_t src_id, hid_t dst_id, H5T_cdata_t *cdata, size_t 
  *-------------------------------------------------------------------------
  */
 herr_t
-H5T__conv_ldouble_float(hid_t src_id, hid_t dst_id, H5T_cdata_t *cdata, size_t nelmts, size_t buf_stride,
-                        size_t H5_ATTR_UNUSED bkg_stride, void *buf, void H5_ATTR_UNUSED *bkg)
+H5T__conv_ldouble_float(H5T_t *st, H5T_t *dt, H5T_cdata_t *cdata, const H5T_conv_ctx_t *conv_ctx,
+                        size_t nelmts, size_t buf_stride, size_t H5_ATTR_UNUSED bkg_stride, void *buf,
+                        void H5_ATTR_UNUSED *bkg)
 {
     H5T_CONV_Ff(LDOUBLE, FLOAT, long double, float, -FLT_MAX, FLT_MAX);
 }
@@ -6780,8 +6928,9 @@ H5T__conv_ldouble_float(hid_t src_id, hid_t dst_id, H5T_cdata_t *cdata, size_t n
  *-------------------------------------------------------------------------
  */
 herr_t
-H5T__conv_ldouble_double(hid_t src_id, hid_t dst_id, H5T_cdata_t *cdata, size_t nelmts, size_t buf_stride,
-                         size_t H5_ATTR_UNUSED bkg_stride, void *buf, void H5_ATTR_UNUSED *bkg)
+H5T__conv_ldouble_double(H5T_t *st, H5T_t *dt, H5T_cdata_t *cdata, const H5T_conv_ctx_t *conv_ctx,
+                         size_t nelmts, size_t buf_stride, size_t H5_ATTR_UNUSED bkg_stride, void *buf,
+                         void H5_ATTR_UNUSED *bkg)
 {
     H5T_CONV_Ff(LDOUBLE, DOUBLE, long double, double, -DBL_MAX, DBL_MAX);
 }
@@ -6797,8 +6946,9 @@ H5T__conv_ldouble_double(hid_t src_id, hid_t dst_id, H5T_cdata_t *cdata, size_t 
  *-------------------------------------------------------------------------
  */
 herr_t
-H5T__conv_schar_float(hid_t src_id, hid_t dst_id, H5T_cdata_t *cdata, size_t nelmts, size_t buf_stride,
-                      size_t H5_ATTR_UNUSED bkg_stride, void *buf, void H5_ATTR_UNUSED *bkg)
+H5T__conv_schar_float(H5T_t *st, H5T_t *dt, H5T_cdata_t *cdata, const H5T_conv_ctx_t *conv_ctx, size_t nelmts,
+                      size_t buf_stride, size_t H5_ATTR_UNUSED bkg_stride, void *buf,
+                      void H5_ATTR_UNUSED *bkg)
 {
     H5T_CONV_xF(SCHAR, FLOAT, signed char, float, -, -);
 }
@@ -6814,8 +6964,9 @@ H5T__conv_schar_float(hid_t src_id, hid_t dst_id, H5T_cdata_t *cdata, size_t nel
  *-------------------------------------------------------------------------
  */
 herr_t
-H5T__conv_schar_double(hid_t src_id, hid_t dst_id, H5T_cdata_t *cdata, size_t nelmts, size_t buf_stride,
-                       size_t H5_ATTR_UNUSED bkg_stride, void *buf, void H5_ATTR_UNUSED *bkg)
+H5T__conv_schar_double(H5T_t *st, H5T_t *dt, H5T_cdata_t *cdata, const H5T_conv_ctx_t *conv_ctx,
+                       size_t nelmts, size_t buf_stride, size_t H5_ATTR_UNUSED bkg_stride, void *buf,
+                       void H5_ATTR_UNUSED *bkg)
 {
     H5T_CONV_xF(SCHAR, DOUBLE, signed char, double, -, -);
 }
@@ -6831,8 +6982,9 @@ H5T__conv_schar_double(hid_t src_id, hid_t dst_id, H5T_cdata_t *cdata, size_t ne
  *-------------------------------------------------------------------------
  */
 herr_t
-H5T__conv_schar_ldouble(hid_t src_id, hid_t dst_id, H5T_cdata_t *cdata, size_t nelmts, size_t buf_stride,
-                        size_t H5_ATTR_UNUSED bkg_stride, void *buf, void H5_ATTR_UNUSED *bkg)
+H5T__conv_schar_ldouble(H5T_t *st, H5T_t *dt, H5T_cdata_t *cdata, const H5T_conv_ctx_t *conv_ctx,
+                        size_t nelmts, size_t buf_stride, size_t H5_ATTR_UNUSED bkg_stride, void *buf,
+                        void H5_ATTR_UNUSED *bkg)
 {
     H5T_CONV_xF(SCHAR, LDOUBLE, signed char, long double, -, -);
 }
@@ -6848,8 +7000,9 @@ H5T__conv_schar_ldouble(hid_t src_id, hid_t dst_id, H5T_cdata_t *cdata, size_t n
  *-------------------------------------------------------------------------
  */
 herr_t
-H5T__conv_uchar_float(hid_t src_id, hid_t dst_id, H5T_cdata_t *cdata, size_t nelmts, size_t buf_stride,
-                      size_t H5_ATTR_UNUSED bkg_stride, void *buf, void H5_ATTR_UNUSED *bkg)
+H5T__conv_uchar_float(H5T_t *st, H5T_t *dt, H5T_cdata_t *cdata, const H5T_conv_ctx_t *conv_ctx, size_t nelmts,
+                      size_t buf_stride, size_t H5_ATTR_UNUSED bkg_stride, void *buf,
+                      void H5_ATTR_UNUSED *bkg)
 {
     H5T_CONV_xF(UCHAR, FLOAT, unsigned char, float, -, -);
 }
@@ -6865,8 +7018,9 @@ H5T__conv_uchar_float(hid_t src_id, hid_t dst_id, H5T_cdata_t *cdata, size_t nel
  *-------------------------------------------------------------------------
  */
 herr_t
-H5T__conv_uchar_double(hid_t src_id, hid_t dst_id, H5T_cdata_t *cdata, size_t nelmts, size_t buf_stride,
-                       size_t H5_ATTR_UNUSED bkg_stride, void *buf, void H5_ATTR_UNUSED *bkg)
+H5T__conv_uchar_double(H5T_t *st, H5T_t *dt, H5T_cdata_t *cdata, const H5T_conv_ctx_t *conv_ctx,
+                       size_t nelmts, size_t buf_stride, size_t H5_ATTR_UNUSED bkg_stride, void *buf,
+                       void H5_ATTR_UNUSED *bkg)
 {
     H5T_CONV_xF(UCHAR, DOUBLE, unsigned char, double, -, -);
 }
@@ -6882,8 +7036,9 @@ H5T__conv_uchar_double(hid_t src_id, hid_t dst_id, H5T_cdata_t *cdata, size_t ne
  *-------------------------------------------------------------------------
  */
 herr_t
-H5T__conv_uchar_ldouble(hid_t src_id, hid_t dst_id, H5T_cdata_t *cdata, size_t nelmts, size_t buf_stride,
-                        size_t H5_ATTR_UNUSED bkg_stride, void *buf, void H5_ATTR_UNUSED *bkg)
+H5T__conv_uchar_ldouble(H5T_t *st, H5T_t *dt, H5T_cdata_t *cdata, const H5T_conv_ctx_t *conv_ctx,
+                        size_t nelmts, size_t buf_stride, size_t H5_ATTR_UNUSED bkg_stride, void *buf,
+                        void H5_ATTR_UNUSED *bkg)
 {
     H5T_CONV_xF(UCHAR, LDOUBLE, unsigned char, long double, -, -);
 }
@@ -6899,8 +7054,9 @@ H5T__conv_uchar_ldouble(hid_t src_id, hid_t dst_id, H5T_cdata_t *cdata, size_t n
  *-------------------------------------------------------------------------
  */
 herr_t
-H5T__conv_short_float(hid_t src_id, hid_t dst_id, H5T_cdata_t *cdata, size_t nelmts, size_t buf_stride,
-                      size_t H5_ATTR_UNUSED bkg_stride, void *buf, void H5_ATTR_UNUSED *bkg)
+H5T__conv_short_float(H5T_t *st, H5T_t *dt, H5T_cdata_t *cdata, const H5T_conv_ctx_t *conv_ctx, size_t nelmts,
+                      size_t buf_stride, size_t H5_ATTR_UNUSED bkg_stride, void *buf,
+                      void H5_ATTR_UNUSED *bkg)
 {
     H5T_CONV_xF(SHORT, FLOAT, short, float, -, -);
 }
@@ -6916,8 +7072,9 @@ H5T__conv_short_float(hid_t src_id, hid_t dst_id, H5T_cdata_t *cdata, size_t nel
  *-------------------------------------------------------------------------
  */
 herr_t
-H5T__conv_short_double(hid_t src_id, hid_t dst_id, H5T_cdata_t *cdata, size_t nelmts, size_t buf_stride,
-                       size_t H5_ATTR_UNUSED bkg_stride, void *buf, void H5_ATTR_UNUSED *bkg)
+H5T__conv_short_double(H5T_t *st, H5T_t *dt, H5T_cdata_t *cdata, const H5T_conv_ctx_t *conv_ctx,
+                       size_t nelmts, size_t buf_stride, size_t H5_ATTR_UNUSED bkg_stride, void *buf,
+                       void H5_ATTR_UNUSED *bkg)
 {
     H5T_CONV_xF(SHORT, DOUBLE, short, double, -, -);
 }
@@ -6933,8 +7090,9 @@ H5T__conv_short_double(hid_t src_id, hid_t dst_id, H5T_cdata_t *cdata, size_t ne
  *-------------------------------------------------------------------------
  */
 herr_t
-H5T__conv_short_ldouble(hid_t src_id, hid_t dst_id, H5T_cdata_t *cdata, size_t nelmts, size_t buf_stride,
-                        size_t H5_ATTR_UNUSED bkg_stride, void *buf, void H5_ATTR_UNUSED *bkg)
+H5T__conv_short_ldouble(H5T_t *st, H5T_t *dt, H5T_cdata_t *cdata, const H5T_conv_ctx_t *conv_ctx,
+                        size_t nelmts, size_t buf_stride, size_t H5_ATTR_UNUSED bkg_stride, void *buf,
+                        void H5_ATTR_UNUSED *bkg)
 {
     H5T_CONV_xF(SHORT, LDOUBLE, short, long double, -, -);
 }
@@ -6950,8 +7108,9 @@ H5T__conv_short_ldouble(hid_t src_id, hid_t dst_id, H5T_cdata_t *cdata, size_t n
  *-------------------------------------------------------------------------
  */
 herr_t
-H5T__conv_ushort_float(hid_t src_id, hid_t dst_id, H5T_cdata_t *cdata, size_t nelmts, size_t buf_stride,
-                       size_t H5_ATTR_UNUSED bkg_stride, void *buf, void H5_ATTR_UNUSED *bkg)
+H5T__conv_ushort_float(H5T_t *st, H5T_t *dt, H5T_cdata_t *cdata, const H5T_conv_ctx_t *conv_ctx,
+                       size_t nelmts, size_t buf_stride, size_t H5_ATTR_UNUSED bkg_stride, void *buf,
+                       void H5_ATTR_UNUSED *bkg)
 {
     H5T_CONV_xF(USHORT, FLOAT, unsigned short, float, -, -);
 }
@@ -6967,8 +7126,9 @@ H5T__conv_ushort_float(hid_t src_id, hid_t dst_id, H5T_cdata_t *cdata, size_t ne
  *-------------------------------------------------------------------------
  */
 herr_t
-H5T__conv_ushort_double(hid_t src_id, hid_t dst_id, H5T_cdata_t *cdata, size_t nelmts, size_t buf_stride,
-                        size_t H5_ATTR_UNUSED bkg_stride, void *buf, void H5_ATTR_UNUSED *bkg)
+H5T__conv_ushort_double(H5T_t *st, H5T_t *dt, H5T_cdata_t *cdata, const H5T_conv_ctx_t *conv_ctx,
+                        size_t nelmts, size_t buf_stride, size_t H5_ATTR_UNUSED bkg_stride, void *buf,
+                        void H5_ATTR_UNUSED *bkg)
 {
     H5T_CONV_xF(USHORT, DOUBLE, unsigned short, double, -, -);
 }
@@ -6984,8 +7144,9 @@ H5T__conv_ushort_double(hid_t src_id, hid_t dst_id, H5T_cdata_t *cdata, size_t n
  *-------------------------------------------------------------------------
  */
 herr_t
-H5T__conv_ushort_ldouble(hid_t src_id, hid_t dst_id, H5T_cdata_t *cdata, size_t nelmts, size_t buf_stride,
-                         size_t H5_ATTR_UNUSED bkg_stride, void *buf, void H5_ATTR_UNUSED *bkg)
+H5T__conv_ushort_ldouble(H5T_t *st, H5T_t *dt, H5T_cdata_t *cdata, const H5T_conv_ctx_t *conv_ctx,
+                         size_t nelmts, size_t buf_stride, size_t H5_ATTR_UNUSED bkg_stride, void *buf,
+                         void H5_ATTR_UNUSED *bkg)
 {
     H5T_CONV_xF(USHORT, LDOUBLE, unsigned short, long double, -, -);
 }
@@ -7001,8 +7162,8 @@ H5T__conv_ushort_ldouble(hid_t src_id, hid_t dst_id, H5T_cdata_t *cdata, size_t 
  *-------------------------------------------------------------------------
  */
 herr_t
-H5T__conv_int_float(hid_t src_id, hid_t dst_id, H5T_cdata_t *cdata, size_t nelmts, size_t buf_stride,
-                    size_t H5_ATTR_UNUSED bkg_stride, void *buf, void H5_ATTR_UNUSED *bkg)
+H5T__conv_int_float(H5T_t *st, H5T_t *dt, H5T_cdata_t *cdata, const H5T_conv_ctx_t *conv_ctx, size_t nelmts,
+                    size_t buf_stride, size_t H5_ATTR_UNUSED bkg_stride, void *buf, void H5_ATTR_UNUSED *bkg)
 {
     H5T_CONV_xF(INT, FLOAT, int, float, -, -);
 }
@@ -7018,8 +7179,8 @@ H5T__conv_int_float(hid_t src_id, hid_t dst_id, H5T_cdata_t *cdata, size_t nelmt
  *-------------------------------------------------------------------------
  */
 herr_t
-H5T__conv_int_double(hid_t src_id, hid_t dst_id, H5T_cdata_t *cdata, size_t nelmts, size_t buf_stride,
-                     size_t H5_ATTR_UNUSED bkg_stride, void *buf, void H5_ATTR_UNUSED *bkg)
+H5T__conv_int_double(H5T_t *st, H5T_t *dt, H5T_cdata_t *cdata, const H5T_conv_ctx_t *conv_ctx, size_t nelmts,
+                     size_t buf_stride, size_t H5_ATTR_UNUSED bkg_stride, void *buf, void H5_ATTR_UNUSED *bkg)
 {
     H5T_CONV_xF(INT, DOUBLE, int, double, -, -);
 }
@@ -7035,8 +7196,9 @@ H5T__conv_int_double(hid_t src_id, hid_t dst_id, H5T_cdata_t *cdata, size_t nelm
  *-------------------------------------------------------------------------
  */
 herr_t
-H5T__conv_int_ldouble(hid_t src_id, hid_t dst_id, H5T_cdata_t *cdata, size_t nelmts, size_t buf_stride,
-                      size_t H5_ATTR_UNUSED bkg_stride, void *buf, void H5_ATTR_UNUSED *bkg)
+H5T__conv_int_ldouble(H5T_t *st, H5T_t *dt, H5T_cdata_t *cdata, const H5T_conv_ctx_t *conv_ctx, size_t nelmts,
+                      size_t buf_stride, size_t H5_ATTR_UNUSED bkg_stride, void *buf,
+                      void H5_ATTR_UNUSED *bkg)
 {
     H5T_CONV_xF(INT, LDOUBLE, int, long double, -, -);
 }
@@ -7052,8 +7214,8 @@ H5T__conv_int_ldouble(hid_t src_id, hid_t dst_id, H5T_cdata_t *cdata, size_t nel
  *-------------------------------------------------------------------------
  */
 herr_t
-H5T__conv_uint_float(hid_t src_id, hid_t dst_id, H5T_cdata_t *cdata, size_t nelmts, size_t buf_stride,
-                     size_t H5_ATTR_UNUSED bkg_stride, void *buf, void H5_ATTR_UNUSED *bkg)
+H5T__conv_uint_float(H5T_t *st, H5T_t *dt, H5T_cdata_t *cdata, const H5T_conv_ctx_t *conv_ctx, size_t nelmts,
+                     size_t buf_stride, size_t H5_ATTR_UNUSED bkg_stride, void *buf, void H5_ATTR_UNUSED *bkg)
 {
     H5T_CONV_xF(UINT, FLOAT, unsigned int, float, -, -);
 }
@@ -7069,8 +7231,9 @@ H5T__conv_uint_float(hid_t src_id, hid_t dst_id, H5T_cdata_t *cdata, size_t nelm
  *-------------------------------------------------------------------------
  */
 herr_t
-H5T__conv_uint_double(hid_t src_id, hid_t dst_id, H5T_cdata_t *cdata, size_t nelmts, size_t buf_stride,
-                      size_t H5_ATTR_UNUSED bkg_stride, void *buf, void H5_ATTR_UNUSED *bkg)
+H5T__conv_uint_double(H5T_t *st, H5T_t *dt, H5T_cdata_t *cdata, const H5T_conv_ctx_t *conv_ctx, size_t nelmts,
+                      size_t buf_stride, size_t H5_ATTR_UNUSED bkg_stride, void *buf,
+                      void H5_ATTR_UNUSED *bkg)
 {
     H5T_CONV_xF(UINT, DOUBLE, unsigned int, double, -, -);
 }
@@ -7086,8 +7249,9 @@ H5T__conv_uint_double(hid_t src_id, hid_t dst_id, H5T_cdata_t *cdata, size_t nel
  *-------------------------------------------------------------------------
  */
 herr_t
-H5T__conv_uint_ldouble(hid_t src_id, hid_t dst_id, H5T_cdata_t *cdata, size_t nelmts, size_t buf_stride,
-                       size_t H5_ATTR_UNUSED bkg_stride, void *buf, void H5_ATTR_UNUSED *bkg)
+H5T__conv_uint_ldouble(H5T_t *st, H5T_t *dt, H5T_cdata_t *cdata, const H5T_conv_ctx_t *conv_ctx,
+                       size_t nelmts, size_t buf_stride, size_t H5_ATTR_UNUSED bkg_stride, void *buf,
+                       void H5_ATTR_UNUSED *bkg)
 {
     H5T_CONV_xF(UINT, LDOUBLE, unsigned int, long double, -, -);
 }
@@ -7103,8 +7267,8 @@ H5T__conv_uint_ldouble(hid_t src_id, hid_t dst_id, H5T_cdata_t *cdata, size_t ne
  *-------------------------------------------------------------------------
  */
 herr_t
-H5T__conv_long_float(hid_t src_id, hid_t dst_id, H5T_cdata_t *cdata, size_t nelmts, size_t buf_stride,
-                     size_t H5_ATTR_UNUSED bkg_stride, void *buf, void H5_ATTR_UNUSED *bkg)
+H5T__conv_long_float(H5T_t *st, H5T_t *dt, H5T_cdata_t *cdata, const H5T_conv_ctx_t *conv_ctx, size_t nelmts,
+                     size_t buf_stride, size_t H5_ATTR_UNUSED bkg_stride, void *buf, void H5_ATTR_UNUSED *bkg)
 {
     H5T_CONV_xF(LONG, FLOAT, long, float, -, -);
 }
@@ -7120,8 +7284,9 @@ H5T__conv_long_float(hid_t src_id, hid_t dst_id, H5T_cdata_t *cdata, size_t nelm
  *-------------------------------------------------------------------------
  */
 herr_t
-H5T__conv_long_double(hid_t src_id, hid_t dst_id, H5T_cdata_t *cdata, size_t nelmts, size_t buf_stride,
-                      size_t H5_ATTR_UNUSED bkg_stride, void *buf, void H5_ATTR_UNUSED *bkg)
+H5T__conv_long_double(H5T_t *st, H5T_t *dt, H5T_cdata_t *cdata, const H5T_conv_ctx_t *conv_ctx, size_t nelmts,
+                      size_t buf_stride, size_t H5_ATTR_UNUSED bkg_stride, void *buf,
+                      void H5_ATTR_UNUSED *bkg)
 {
     H5T_CONV_xF(LONG, DOUBLE, long, double, -, -);
 }
@@ -7137,8 +7302,9 @@ H5T__conv_long_double(hid_t src_id, hid_t dst_id, H5T_cdata_t *cdata, size_t nel
  *-------------------------------------------------------------------------
  */
 herr_t
-H5T__conv_long_ldouble(hid_t src_id, hid_t dst_id, H5T_cdata_t *cdata, size_t nelmts, size_t buf_stride,
-                       size_t H5_ATTR_UNUSED bkg_stride, void *buf, void H5_ATTR_UNUSED *bkg)
+H5T__conv_long_ldouble(H5T_t *st, H5T_t *dt, H5T_cdata_t *cdata, const H5T_conv_ctx_t *conv_ctx,
+                       size_t nelmts, size_t buf_stride, size_t H5_ATTR_UNUSED bkg_stride, void *buf,
+                       void H5_ATTR_UNUSED *bkg)
 {
     H5T_CONV_xF(LONG, LDOUBLE, long, long double, -, -);
 }
@@ -7154,8 +7320,9 @@ H5T__conv_long_ldouble(hid_t src_id, hid_t dst_id, H5T_cdata_t *cdata, size_t ne
  *-------------------------------------------------------------------------
  */
 herr_t
-H5T__conv_ulong_float(hid_t src_id, hid_t dst_id, H5T_cdata_t *cdata, size_t nelmts, size_t buf_stride,
-                      size_t H5_ATTR_UNUSED bkg_stride, void *buf, void H5_ATTR_UNUSED *bkg)
+H5T__conv_ulong_float(H5T_t *st, H5T_t *dt, H5T_cdata_t *cdata, const H5T_conv_ctx_t *conv_ctx, size_t nelmts,
+                      size_t buf_stride, size_t H5_ATTR_UNUSED bkg_stride, void *buf,
+                      void H5_ATTR_UNUSED *bkg)
 {
     H5T_CONV_xF(ULONG, FLOAT, unsigned long, float, -, -);
 }
@@ -7171,8 +7338,9 @@ H5T__conv_ulong_float(hid_t src_id, hid_t dst_id, H5T_cdata_t *cdata, size_t nel
  *-------------------------------------------------------------------------
  */
 herr_t
-H5T__conv_ulong_double(hid_t src_id, hid_t dst_id, H5T_cdata_t *cdata, size_t nelmts, size_t buf_stride,
-                       size_t H5_ATTR_UNUSED bkg_stride, void *buf, void H5_ATTR_UNUSED *bkg)
+H5T__conv_ulong_double(H5T_t *st, H5T_t *dt, H5T_cdata_t *cdata, const H5T_conv_ctx_t *conv_ctx,
+                       size_t nelmts, size_t buf_stride, size_t H5_ATTR_UNUSED bkg_stride, void *buf,
+                       void H5_ATTR_UNUSED *bkg)
 {
     H5T_CONV_xF(ULONG, DOUBLE, unsigned long, double, -, -);
 }
@@ -7188,8 +7356,9 @@ H5T__conv_ulong_double(hid_t src_id, hid_t dst_id, H5T_cdata_t *cdata, size_t ne
  *-------------------------------------------------------------------------
  */
 herr_t
-H5T__conv_ulong_ldouble(hid_t src_id, hid_t dst_id, H5T_cdata_t *cdata, size_t nelmts, size_t buf_stride,
-                        size_t H5_ATTR_UNUSED bkg_stride, void *buf, void H5_ATTR_UNUSED *bkg)
+H5T__conv_ulong_ldouble(H5T_t *st, H5T_t *dt, H5T_cdata_t *cdata, const H5T_conv_ctx_t *conv_ctx,
+                        size_t nelmts, size_t buf_stride, size_t H5_ATTR_UNUSED bkg_stride, void *buf,
+                        void H5_ATTR_UNUSED *bkg)
 {
     H5T_CONV_xF(ULONG, LDOUBLE, unsigned long, long double, -, -);
 }
@@ -7205,8 +7374,9 @@ H5T__conv_ulong_ldouble(hid_t src_id, hid_t dst_id, H5T_cdata_t *cdata, size_t n
  *-------------------------------------------------------------------------
  */
 herr_t
-H5T__conv_llong_float(hid_t src_id, hid_t dst_id, H5T_cdata_t *cdata, size_t nelmts, size_t buf_stride,
-                      size_t H5_ATTR_UNUSED bkg_stride, void *buf, void H5_ATTR_UNUSED *bkg)
+H5T__conv_llong_float(H5T_t *st, H5T_t *dt, H5T_cdata_t *cdata, const H5T_conv_ctx_t *conv_ctx, size_t nelmts,
+                      size_t buf_stride, size_t H5_ATTR_UNUSED bkg_stride, void *buf,
+                      void H5_ATTR_UNUSED *bkg)
 {
     H5T_CONV_xF(LLONG, FLOAT, long long, float, -, -);
 }
@@ -7222,8 +7392,9 @@ H5T__conv_llong_float(hid_t src_id, hid_t dst_id, H5T_cdata_t *cdata, size_t nel
  *-------------------------------------------------------------------------
  */
 herr_t
-H5T__conv_llong_double(hid_t src_id, hid_t dst_id, H5T_cdata_t *cdata, size_t nelmts, size_t buf_stride,
-                       size_t H5_ATTR_UNUSED bkg_stride, void *buf, void H5_ATTR_UNUSED *bkg)
+H5T__conv_llong_double(H5T_t *st, H5T_t *dt, H5T_cdata_t *cdata, const H5T_conv_ctx_t *conv_ctx,
+                       size_t nelmts, size_t buf_stride, size_t H5_ATTR_UNUSED bkg_stride, void *buf,
+                       void H5_ATTR_UNUSED *bkg)
 {
     H5T_CONV_xF(LLONG, DOUBLE, long long, double, -, -);
 }
@@ -7240,8 +7411,9 @@ H5T__conv_llong_double(hid_t src_id, hid_t dst_id, H5T_cdata_t *cdata, size_t ne
  */
 #ifdef H5T_CONV_INTERNAL_LLONG_LDOUBLE
 herr_t
-H5T__conv_llong_ldouble(hid_t src_id, hid_t dst_id, H5T_cdata_t *cdata, size_t nelmts, size_t buf_stride,
-                        size_t H5_ATTR_UNUSED bkg_stride, void *buf, void H5_ATTR_UNUSED *bkg)
+H5T__conv_llong_ldouble(H5T_t *st, H5T_t *dt, H5T_cdata_t *cdata, const H5T_conv_ctx_t *conv_ctx,
+                        size_t nelmts, size_t buf_stride, size_t H5_ATTR_UNUSED bkg_stride, void *buf,
+                        void H5_ATTR_UNUSED *bkg)
 {
     H5T_CONV_xF(LLONG, LDOUBLE, long long, long double, -, -);
 }
@@ -7258,8 +7430,9 @@ H5T__conv_llong_ldouble(hid_t src_id, hid_t dst_id, H5T_cdata_t *cdata, size_t n
  *-------------------------------------------------------------------------
  */
 herr_t
-H5T__conv_ullong_float(hid_t src_id, hid_t dst_id, H5T_cdata_t *cdata, size_t nelmts, size_t buf_stride,
-                       size_t H5_ATTR_UNUSED bkg_stride, void *buf, void H5_ATTR_UNUSED *bkg)
+H5T__conv_ullong_float(H5T_t *st, H5T_t *dt, H5T_cdata_t *cdata, const H5T_conv_ctx_t *conv_ctx,
+                       size_t nelmts, size_t buf_stride, size_t H5_ATTR_UNUSED bkg_stride, void *buf,
+                       void H5_ATTR_UNUSED *bkg)
 {
     H5T_CONV_xF(ULLONG, FLOAT, unsigned long long, float, -, -);
 }
@@ -7275,8 +7448,9 @@ H5T__conv_ullong_float(hid_t src_id, hid_t dst_id, H5T_cdata_t *cdata, size_t ne
  *-------------------------------------------------------------------------
  */
 herr_t
-H5T__conv_ullong_double(hid_t src_id, hid_t dst_id, H5T_cdata_t *cdata, size_t nelmts, size_t buf_stride,
-                        size_t H5_ATTR_UNUSED bkg_stride, void *buf, void H5_ATTR_UNUSED *bkg)
+H5T__conv_ullong_double(H5T_t *st, H5T_t *dt, H5T_cdata_t *cdata, const H5T_conv_ctx_t *conv_ctx,
+                        size_t nelmts, size_t buf_stride, size_t H5_ATTR_UNUSED bkg_stride, void *buf,
+                        void H5_ATTR_UNUSED *bkg)
 {
     H5T_CONV_xF(ULLONG, DOUBLE, unsigned long long, double, -, -);
 }
@@ -7293,8 +7467,9 @@ H5T__conv_ullong_double(hid_t src_id, hid_t dst_id, H5T_cdata_t *cdata, size_t n
  */
 #ifdef H5T_CONV_INTERNAL_ULLONG_LDOUBLE
 herr_t
-H5T__conv_ullong_ldouble(hid_t src_id, hid_t dst_id, H5T_cdata_t *cdata, size_t nelmts, size_t buf_stride,
-                         size_t H5_ATTR_UNUSED bkg_stride, void *buf, void H5_ATTR_UNUSED *bkg)
+H5T__conv_ullong_ldouble(H5T_t *st, H5T_t *dt, H5T_cdata_t *cdata, const H5T_conv_ctx_t *conv_ctx,
+                         size_t nelmts, size_t buf_stride, size_t H5_ATTR_UNUSED bkg_stride, void *buf,
+                         void H5_ATTR_UNUSED *bkg)
 {
     H5T_CONV_xF(ULLONG, LDOUBLE, unsigned long long, long double, -, -);
 }
@@ -7311,8 +7486,9 @@ H5T__conv_ullong_ldouble(hid_t src_id, hid_t dst_id, H5T_cdata_t *cdata, size_t 
  *-------------------------------------------------------------------------
  */
 herr_t
-H5T__conv_float_schar(hid_t src_id, hid_t dst_id, H5T_cdata_t *cdata, size_t nelmts, size_t buf_stride,
-                      size_t H5_ATTR_UNUSED bkg_stride, void *buf, void H5_ATTR_UNUSED *bkg)
+H5T__conv_float_schar(H5T_t *st, H5T_t *dt, H5T_cdata_t *cdata, const H5T_conv_ctx_t *conv_ctx, size_t nelmts,
+                      size_t buf_stride, size_t H5_ATTR_UNUSED bkg_stride, void *buf,
+                      void H5_ATTR_UNUSED *bkg)
 {
     H5_GCC_CLANG_DIAG_OFF("float-equal")
     H5T_CONV_Fx(FLOAT, SCHAR, float, signed char, SCHAR_MIN, SCHAR_MAX);
@@ -7330,8 +7506,9 @@ H5T__conv_float_schar(hid_t src_id, hid_t dst_id, H5T_cdata_t *cdata, size_t nel
  *-------------------------------------------------------------------------
  */
 herr_t
-H5T__conv_float_uchar(hid_t src_id, hid_t dst_id, H5T_cdata_t *cdata, size_t nelmts, size_t buf_stride,
-                      size_t H5_ATTR_UNUSED bkg_stride, void *buf, void H5_ATTR_UNUSED *bkg)
+H5T__conv_float_uchar(H5T_t *st, H5T_t *dt, H5T_cdata_t *cdata, const H5T_conv_ctx_t *conv_ctx, size_t nelmts,
+                      size_t buf_stride, size_t H5_ATTR_UNUSED bkg_stride, void *buf,
+                      void H5_ATTR_UNUSED *bkg)
 {
     H5_GCC_CLANG_DIAG_OFF("float-equal")
     H5T_CONV_Fx(FLOAT, UCHAR, float, unsigned char, 0, UCHAR_MAX);
@@ -7349,8 +7526,9 @@ H5T__conv_float_uchar(hid_t src_id, hid_t dst_id, H5T_cdata_t *cdata, size_t nel
  *-------------------------------------------------------------------------
  */
 herr_t
-H5T__conv_double_schar(hid_t src_id, hid_t dst_id, H5T_cdata_t *cdata, size_t nelmts, size_t buf_stride,
-                       size_t H5_ATTR_UNUSED bkg_stride, void *buf, void H5_ATTR_UNUSED *bkg)
+H5T__conv_double_schar(H5T_t *st, H5T_t *dt, H5T_cdata_t *cdata, const H5T_conv_ctx_t *conv_ctx,
+                       size_t nelmts, size_t buf_stride, size_t H5_ATTR_UNUSED bkg_stride, void *buf,
+                       void H5_ATTR_UNUSED *bkg)
 {
     H5_GCC_CLANG_DIAG_OFF("float-equal")
     H5T_CONV_Fx(DOUBLE, SCHAR, double, signed char, SCHAR_MIN, SCHAR_MAX);
@@ -7368,8 +7546,9 @@ H5T__conv_double_schar(hid_t src_id, hid_t dst_id, H5T_cdata_t *cdata, size_t ne
  *-------------------------------------------------------------------------
  */
 herr_t
-H5T__conv_double_uchar(hid_t src_id, hid_t dst_id, H5T_cdata_t *cdata, size_t nelmts, size_t buf_stride,
-                       size_t H5_ATTR_UNUSED bkg_stride, void *buf, void H5_ATTR_UNUSED *bkg)
+H5T__conv_double_uchar(H5T_t *st, H5T_t *dt, H5T_cdata_t *cdata, const H5T_conv_ctx_t *conv_ctx,
+                       size_t nelmts, size_t buf_stride, size_t H5_ATTR_UNUSED bkg_stride, void *buf,
+                       void H5_ATTR_UNUSED *bkg)
 {
     H5_GCC_CLANG_DIAG_OFF("float-equal")
     H5T_CONV_Fx(DOUBLE, UCHAR, double, unsigned char, 0, UCHAR_MAX);
@@ -7387,8 +7566,9 @@ H5T__conv_double_uchar(hid_t src_id, hid_t dst_id, H5T_cdata_t *cdata, size_t ne
  *-------------------------------------------------------------------------
  */
 herr_t
-H5T__conv_ldouble_schar(hid_t src_id, hid_t dst_id, H5T_cdata_t *cdata, size_t nelmts, size_t buf_stride,
-                        size_t H5_ATTR_UNUSED bkg_stride, void *buf, void H5_ATTR_UNUSED *bkg)
+H5T__conv_ldouble_schar(H5T_t *st, H5T_t *dt, H5T_cdata_t *cdata, const H5T_conv_ctx_t *conv_ctx,
+                        size_t nelmts, size_t buf_stride, size_t H5_ATTR_UNUSED bkg_stride, void *buf,
+                        void H5_ATTR_UNUSED *bkg)
 {
     H5_GCC_CLANG_DIAG_OFF("float-equal")
     H5T_CONV_Fx(LDOUBLE, SCHAR, long double, signed char, SCHAR_MIN, SCHAR_MAX);
@@ -7406,8 +7586,9 @@ H5T__conv_ldouble_schar(hid_t src_id, hid_t dst_id, H5T_cdata_t *cdata, size_t n
  *-------------------------------------------------------------------------
  */
 herr_t
-H5T__conv_ldouble_uchar(hid_t src_id, hid_t dst_id, H5T_cdata_t *cdata, size_t nelmts, size_t buf_stride,
-                        size_t H5_ATTR_UNUSED bkg_stride, void *buf, void H5_ATTR_UNUSED *bkg)
+H5T__conv_ldouble_uchar(H5T_t *st, H5T_t *dt, H5T_cdata_t *cdata, const H5T_conv_ctx_t *conv_ctx,
+                        size_t nelmts, size_t buf_stride, size_t H5_ATTR_UNUSED bkg_stride, void *buf,
+                        void H5_ATTR_UNUSED *bkg)
 {
     H5_GCC_CLANG_DIAG_OFF("float-equal")
     H5T_CONV_Fx(LDOUBLE, UCHAR, long double, unsigned char, 0, UCHAR_MAX);
@@ -7425,8 +7606,9 @@ H5T__conv_ldouble_uchar(hid_t src_id, hid_t dst_id, H5T_cdata_t *cdata, size_t n
  *-------------------------------------------------------------------------
  */
 herr_t
-H5T__conv_float_short(hid_t src_id, hid_t dst_id, H5T_cdata_t *cdata, size_t nelmts, size_t buf_stride,
-                      size_t H5_ATTR_UNUSED bkg_stride, void *buf, void H5_ATTR_UNUSED *bkg)
+H5T__conv_float_short(H5T_t *st, H5T_t *dt, H5T_cdata_t *cdata, const H5T_conv_ctx_t *conv_ctx, size_t nelmts,
+                      size_t buf_stride, size_t H5_ATTR_UNUSED bkg_stride, void *buf,
+                      void H5_ATTR_UNUSED *bkg)
 {
     H5_GCC_CLANG_DIAG_OFF("float-equal")
     H5T_CONV_Fx(FLOAT, SHORT, float, short, SHRT_MIN, SHRT_MAX);
@@ -7444,8 +7626,9 @@ H5T__conv_float_short(hid_t src_id, hid_t dst_id, H5T_cdata_t *cdata, size_t nel
  *-------------------------------------------------------------------------
  */
 herr_t
-H5T__conv_float_ushort(hid_t src_id, hid_t dst_id, H5T_cdata_t *cdata, size_t nelmts, size_t buf_stride,
-                       size_t H5_ATTR_UNUSED bkg_stride, void *buf, void H5_ATTR_UNUSED *bkg)
+H5T__conv_float_ushort(H5T_t *st, H5T_t *dt, H5T_cdata_t *cdata, const H5T_conv_ctx_t *conv_ctx,
+                       size_t nelmts, size_t buf_stride, size_t H5_ATTR_UNUSED bkg_stride, void *buf,
+                       void H5_ATTR_UNUSED *bkg)
 {
     H5_GCC_CLANG_DIAG_OFF("float-equal")
     H5T_CONV_Fx(FLOAT, USHORT, float, unsigned short, 0, USHRT_MAX);
@@ -7463,8 +7646,9 @@ H5T__conv_float_ushort(hid_t src_id, hid_t dst_id, H5T_cdata_t *cdata, size_t ne
  *-------------------------------------------------------------------------
  */
 herr_t
-H5T__conv_double_short(hid_t src_id, hid_t dst_id, H5T_cdata_t *cdata, size_t nelmts, size_t buf_stride,
-                       size_t H5_ATTR_UNUSED bkg_stride, void *buf, void H5_ATTR_UNUSED *bkg)
+H5T__conv_double_short(H5T_t *st, H5T_t *dt, H5T_cdata_t *cdata, const H5T_conv_ctx_t *conv_ctx,
+                       size_t nelmts, size_t buf_stride, size_t H5_ATTR_UNUSED bkg_stride, void *buf,
+                       void H5_ATTR_UNUSED *bkg)
 {
     H5_GCC_CLANG_DIAG_OFF("float-equal")
     H5T_CONV_Fx(DOUBLE, SHORT, double, short, SHRT_MIN, SHRT_MAX);
@@ -7482,8 +7666,9 @@ H5T__conv_double_short(hid_t src_id, hid_t dst_id, H5T_cdata_t *cdata, size_t ne
  *-------------------------------------------------------------------------
  */
 herr_t
-H5T__conv_double_ushort(hid_t src_id, hid_t dst_id, H5T_cdata_t *cdata, size_t nelmts, size_t buf_stride,
-                        size_t H5_ATTR_UNUSED bkg_stride, void *buf, void H5_ATTR_UNUSED *bkg)
+H5T__conv_double_ushort(H5T_t *st, H5T_t *dt, H5T_cdata_t *cdata, const H5T_conv_ctx_t *conv_ctx,
+                        size_t nelmts, size_t buf_stride, size_t H5_ATTR_UNUSED bkg_stride, void *buf,
+                        void H5_ATTR_UNUSED *bkg)
 {
     H5_GCC_CLANG_DIAG_OFF("float-equal")
     H5T_CONV_Fx(DOUBLE, USHORT, double, unsigned short, 0, USHRT_MAX);
@@ -7501,8 +7686,9 @@ H5T__conv_double_ushort(hid_t src_id, hid_t dst_id, H5T_cdata_t *cdata, size_t n
  *-------------------------------------------------------------------------
  */
 herr_t
-H5T__conv_ldouble_short(hid_t src_id, hid_t dst_id, H5T_cdata_t *cdata, size_t nelmts, size_t buf_stride,
-                        size_t H5_ATTR_UNUSED bkg_stride, void *buf, void H5_ATTR_UNUSED *bkg)
+H5T__conv_ldouble_short(H5T_t *st, H5T_t *dt, H5T_cdata_t *cdata, const H5T_conv_ctx_t *conv_ctx,
+                        size_t nelmts, size_t buf_stride, size_t H5_ATTR_UNUSED bkg_stride, void *buf,
+                        void H5_ATTR_UNUSED *bkg)
 {
     H5_GCC_CLANG_DIAG_OFF("float-equal")
     H5T_CONV_Fx(LDOUBLE, SHORT, long double, short, SHRT_MIN, SHRT_MAX);
@@ -7520,8 +7706,9 @@ H5T__conv_ldouble_short(hid_t src_id, hid_t dst_id, H5T_cdata_t *cdata, size_t n
  *-------------------------------------------------------------------------
  */
 herr_t
-H5T__conv_ldouble_ushort(hid_t src_id, hid_t dst_id, H5T_cdata_t *cdata, size_t nelmts, size_t buf_stride,
-                         size_t H5_ATTR_UNUSED bkg_stride, void *buf, void H5_ATTR_UNUSED *bkg)
+H5T__conv_ldouble_ushort(H5T_t *st, H5T_t *dt, H5T_cdata_t *cdata, const H5T_conv_ctx_t *conv_ctx,
+                         size_t nelmts, size_t buf_stride, size_t H5_ATTR_UNUSED bkg_stride, void *buf,
+                         void H5_ATTR_UNUSED *bkg)
 {
     H5_GCC_CLANG_DIAG_OFF("float-equal")
     H5T_CONV_Fx(LDOUBLE, USHORT, long double, unsigned short, 0, USHRT_MAX);
@@ -7539,8 +7726,8 @@ H5T__conv_ldouble_ushort(hid_t src_id, hid_t dst_id, H5T_cdata_t *cdata, size_t 
  *-------------------------------------------------------------------------
  */
 herr_t
-H5T__conv_float_int(hid_t src_id, hid_t dst_id, H5T_cdata_t *cdata, size_t nelmts, size_t buf_stride,
-                    size_t H5_ATTR_UNUSED bkg_stride, void *buf, void H5_ATTR_UNUSED *bkg)
+H5T__conv_float_int(H5T_t *st, H5T_t *dt, H5T_cdata_t *cdata, const H5T_conv_ctx_t *conv_ctx, size_t nelmts,
+                    size_t buf_stride, size_t H5_ATTR_UNUSED bkg_stride, void *buf, void H5_ATTR_UNUSED *bkg)
 {
     H5_GCC_CLANG_DIAG_OFF("float-equal")
     H5T_CONV_Fx(FLOAT, INT, float, int, INT_MIN, INT_MAX);
@@ -7558,8 +7745,8 @@ H5T__conv_float_int(hid_t src_id, hid_t dst_id, H5T_cdata_t *cdata, size_t nelmt
  *-------------------------------------------------------------------------
  */
 herr_t
-H5T__conv_float_uint(hid_t src_id, hid_t dst_id, H5T_cdata_t *cdata, size_t nelmts, size_t buf_stride,
-                     size_t H5_ATTR_UNUSED bkg_stride, void *buf, void H5_ATTR_UNUSED *bkg)
+H5T__conv_float_uint(H5T_t *st, H5T_t *dt, H5T_cdata_t *cdata, const H5T_conv_ctx_t *conv_ctx, size_t nelmts,
+                     size_t buf_stride, size_t H5_ATTR_UNUSED bkg_stride, void *buf, void H5_ATTR_UNUSED *bkg)
 {
     H5_GCC_CLANG_DIAG_OFF("float-equal")
     H5T_CONV_Fx(FLOAT, UINT, float, unsigned int, 0, UINT_MAX);
@@ -7577,8 +7764,8 @@ H5T__conv_float_uint(hid_t src_id, hid_t dst_id, H5T_cdata_t *cdata, size_t nelm
  *-------------------------------------------------------------------------
  */
 herr_t
-H5T__conv_double_int(hid_t src_id, hid_t dst_id, H5T_cdata_t *cdata, size_t nelmts, size_t buf_stride,
-                     size_t H5_ATTR_UNUSED bkg_stride, void *buf, void H5_ATTR_UNUSED *bkg)
+H5T__conv_double_int(H5T_t *st, H5T_t *dt, H5T_cdata_t *cdata, const H5T_conv_ctx_t *conv_ctx, size_t nelmts,
+                     size_t buf_stride, size_t H5_ATTR_UNUSED bkg_stride, void *buf, void H5_ATTR_UNUSED *bkg)
 {
     H5_GCC_CLANG_DIAG_OFF("float-equal")
     H5T_CONV_Fx(DOUBLE, INT, double, int, INT_MIN, INT_MAX);
@@ -7596,8 +7783,9 @@ H5T__conv_double_int(hid_t src_id, hid_t dst_id, H5T_cdata_t *cdata, size_t nelm
  *-------------------------------------------------------------------------
  */
 herr_t
-H5T__conv_double_uint(hid_t src_id, hid_t dst_id, H5T_cdata_t *cdata, size_t nelmts, size_t buf_stride,
-                      size_t H5_ATTR_UNUSED bkg_stride, void *buf, void H5_ATTR_UNUSED *bkg)
+H5T__conv_double_uint(H5T_t *st, H5T_t *dt, H5T_cdata_t *cdata, const H5T_conv_ctx_t *conv_ctx, size_t nelmts,
+                      size_t buf_stride, size_t H5_ATTR_UNUSED bkg_stride, void *buf,
+                      void H5_ATTR_UNUSED *bkg)
 {
     H5_GCC_CLANG_DIAG_OFF("float-equal")
     H5T_CONV_Fx(DOUBLE, UINT, double, unsigned int, 0, UINT_MAX);
@@ -7615,8 +7803,9 @@ H5T__conv_double_uint(hid_t src_id, hid_t dst_id, H5T_cdata_t *cdata, size_t nel
  *-------------------------------------------------------------------------
  */
 herr_t
-H5T__conv_ldouble_int(hid_t src_id, hid_t dst_id, H5T_cdata_t *cdata, size_t nelmts, size_t buf_stride,
-                      size_t H5_ATTR_UNUSED bkg_stride, void *buf, void H5_ATTR_UNUSED *bkg)
+H5T__conv_ldouble_int(H5T_t *st, H5T_t *dt, H5T_cdata_t *cdata, const H5T_conv_ctx_t *conv_ctx, size_t nelmts,
+                      size_t buf_stride, size_t H5_ATTR_UNUSED bkg_stride, void *buf,
+                      void H5_ATTR_UNUSED *bkg)
 {
     H5_GCC_CLANG_DIAG_OFF("float-equal")
     H5T_CONV_Fx(LDOUBLE, INT, long double, int, INT_MIN, INT_MAX);
@@ -7634,8 +7823,9 @@ H5T__conv_ldouble_int(hid_t src_id, hid_t dst_id, H5T_cdata_t *cdata, size_t nel
  *-------------------------------------------------------------------------
  */
 herr_t
-H5T__conv_ldouble_uint(hid_t src_id, hid_t dst_id, H5T_cdata_t *cdata, size_t nelmts, size_t buf_stride,
-                       size_t H5_ATTR_UNUSED bkg_stride, void *buf, void H5_ATTR_UNUSED *bkg)
+H5T__conv_ldouble_uint(H5T_t *st, H5T_t *dt, H5T_cdata_t *cdata, const H5T_conv_ctx_t *conv_ctx,
+                       size_t nelmts, size_t buf_stride, size_t H5_ATTR_UNUSED bkg_stride, void *buf,
+                       void H5_ATTR_UNUSED *bkg)
 {
     H5_GCC_CLANG_DIAG_OFF("float-equal")
     H5T_CONV_Fx(LDOUBLE, UINT, long double, unsigned int, 0, UINT_MAX);
@@ -7653,8 +7843,8 @@ H5T__conv_ldouble_uint(hid_t src_id, hid_t dst_id, H5T_cdata_t *cdata, size_t ne
  *-------------------------------------------------------------------------
  */
 herr_t
-H5T__conv_float_long(hid_t src_id, hid_t dst_id, H5T_cdata_t *cdata, size_t nelmts, size_t buf_stride,
-                     size_t H5_ATTR_UNUSED bkg_stride, void *buf, void H5_ATTR_UNUSED *bkg)
+H5T__conv_float_long(H5T_t *st, H5T_t *dt, H5T_cdata_t *cdata, const H5T_conv_ctx_t *conv_ctx, size_t nelmts,
+                     size_t buf_stride, size_t H5_ATTR_UNUSED bkg_stride, void *buf, void H5_ATTR_UNUSED *bkg)
 {
     H5_GCC_CLANG_DIAG_OFF("float-equal")
     H5T_CONV_Fx(FLOAT, LONG, float, long, LONG_MIN, LONG_MAX);
@@ -7672,8 +7862,9 @@ H5T__conv_float_long(hid_t src_id, hid_t dst_id, H5T_cdata_t *cdata, size_t nelm
  *-------------------------------------------------------------------------
  */
 herr_t
-H5T__conv_float_ulong(hid_t src_id, hid_t dst_id, H5T_cdata_t *cdata, size_t nelmts, size_t buf_stride,
-                      size_t H5_ATTR_UNUSED bkg_stride, void *buf, void H5_ATTR_UNUSED *bkg)
+H5T__conv_float_ulong(H5T_t *st, H5T_t *dt, H5T_cdata_t *cdata, const H5T_conv_ctx_t *conv_ctx, size_t nelmts,
+                      size_t buf_stride, size_t H5_ATTR_UNUSED bkg_stride, void *buf,
+                      void H5_ATTR_UNUSED *bkg)
 {
     H5_GCC_CLANG_DIAG_OFF("float-equal")
     H5T_CONV_Fx(FLOAT, ULONG, float, unsigned long, 0, ULONG_MAX);
@@ -7691,8 +7882,9 @@ H5T__conv_float_ulong(hid_t src_id, hid_t dst_id, H5T_cdata_t *cdata, size_t nel
  *-------------------------------------------------------------------------
  */
 herr_t
-H5T__conv_double_long(hid_t src_id, hid_t dst_id, H5T_cdata_t *cdata, size_t nelmts, size_t buf_stride,
-                      size_t H5_ATTR_UNUSED bkg_stride, void *buf, void H5_ATTR_UNUSED *bkg)
+H5T__conv_double_long(H5T_t *st, H5T_t *dt, H5T_cdata_t *cdata, const H5T_conv_ctx_t *conv_ctx, size_t nelmts,
+                      size_t buf_stride, size_t H5_ATTR_UNUSED bkg_stride, void *buf,
+                      void H5_ATTR_UNUSED *bkg)
 {
     H5_GCC_CLANG_DIAG_OFF("float-equal")
     H5T_CONV_Fx(DOUBLE, LONG, double, long, LONG_MIN, LONG_MAX);
@@ -7710,8 +7902,9 @@ H5T__conv_double_long(hid_t src_id, hid_t dst_id, H5T_cdata_t *cdata, size_t nel
  *-------------------------------------------------------------------------
  */
 herr_t
-H5T__conv_double_ulong(hid_t src_id, hid_t dst_id, H5T_cdata_t *cdata, size_t nelmts, size_t buf_stride,
-                       size_t H5_ATTR_UNUSED bkg_stride, void *buf, void H5_ATTR_UNUSED *bkg)
+H5T__conv_double_ulong(H5T_t *st, H5T_t *dt, H5T_cdata_t *cdata, const H5T_conv_ctx_t *conv_ctx,
+                       size_t nelmts, size_t buf_stride, size_t H5_ATTR_UNUSED bkg_stride, void *buf,
+                       void H5_ATTR_UNUSED *bkg)
 {
     H5_GCC_CLANG_DIAG_OFF("float-equal")
     H5T_CONV_Fx(DOUBLE, ULONG, double, unsigned long, 0, ULONG_MAX);
@@ -7729,8 +7922,9 @@ H5T__conv_double_ulong(hid_t src_id, hid_t dst_id, H5T_cdata_t *cdata, size_t ne
  *-------------------------------------------------------------------------
  */
 herr_t
-H5T__conv_ldouble_long(hid_t src_id, hid_t dst_id, H5T_cdata_t *cdata, size_t nelmts, size_t buf_stride,
-                       size_t H5_ATTR_UNUSED bkg_stride, void *buf, void H5_ATTR_UNUSED *bkg)
+H5T__conv_ldouble_long(H5T_t *st, H5T_t *dt, H5T_cdata_t *cdata, const H5T_conv_ctx_t *conv_ctx,
+                       size_t nelmts, size_t buf_stride, size_t H5_ATTR_UNUSED bkg_stride, void *buf,
+                       void H5_ATTR_UNUSED *bkg)
 {
     H5_GCC_CLANG_DIAG_OFF("float-equal")
     H5T_CONV_Fx(LDOUBLE, LONG, long double, long, LONG_MIN, LONG_MAX);
@@ -7748,8 +7942,9 @@ H5T__conv_ldouble_long(hid_t src_id, hid_t dst_id, H5T_cdata_t *cdata, size_t ne
  *-------------------------------------------------------------------------
  */
 herr_t
-H5T__conv_ldouble_ulong(hid_t src_id, hid_t dst_id, H5T_cdata_t *cdata, size_t nelmts, size_t buf_stride,
-                        size_t H5_ATTR_UNUSED bkg_stride, void *buf, void H5_ATTR_UNUSED *bkg)
+H5T__conv_ldouble_ulong(H5T_t *st, H5T_t *dt, H5T_cdata_t *cdata, const H5T_conv_ctx_t *conv_ctx,
+                        size_t nelmts, size_t buf_stride, size_t H5_ATTR_UNUSED bkg_stride, void *buf,
+                        void H5_ATTR_UNUSED *bkg)
 {
     H5_GCC_CLANG_DIAG_OFF("float-equal")
     H5T_CONV_Fx(LDOUBLE, ULONG, long double, unsigned long, 0, ULONG_MAX);
@@ -7767,8 +7962,9 @@ H5T__conv_ldouble_ulong(hid_t src_id, hid_t dst_id, H5T_cdata_t *cdata, size_t n
  *-------------------------------------------------------------------------
  */
 herr_t
-H5T__conv_float_llong(hid_t src_id, hid_t dst_id, H5T_cdata_t *cdata, size_t nelmts, size_t buf_stride,
-                      size_t H5_ATTR_UNUSED bkg_stride, void *buf, void H5_ATTR_UNUSED *bkg)
+H5T__conv_float_llong(H5T_t *st, H5T_t *dt, H5T_cdata_t *cdata, const H5T_conv_ctx_t *conv_ctx, size_t nelmts,
+                      size_t buf_stride, size_t H5_ATTR_UNUSED bkg_stride, void *buf,
+                      void H5_ATTR_UNUSED *bkg)
 {
     H5_GCC_CLANG_DIAG_OFF("float-equal")
     H5T_CONV_Fx(FLOAT, LLONG, float, long long, LLONG_MIN, LLONG_MAX);
@@ -7786,8 +7982,9 @@ H5T__conv_float_llong(hid_t src_id, hid_t dst_id, H5T_cdata_t *cdata, size_t nel
  *-------------------------------------------------------------------------
  */
 herr_t
-H5T__conv_float_ullong(hid_t src_id, hid_t dst_id, H5T_cdata_t *cdata, size_t nelmts, size_t buf_stride,
-                       size_t H5_ATTR_UNUSED bkg_stride, void *buf, void H5_ATTR_UNUSED *bkg)
+H5T__conv_float_ullong(H5T_t *st, H5T_t *dt, H5T_cdata_t *cdata, const H5T_conv_ctx_t *conv_ctx,
+                       size_t nelmts, size_t buf_stride, size_t H5_ATTR_UNUSED bkg_stride, void *buf,
+                       void H5_ATTR_UNUSED *bkg)
 {
     H5_GCC_CLANG_DIAG_OFF("float-equal")
     H5T_CONV_Fx(FLOAT, ULLONG, float, unsigned long long, 0, ULLONG_MAX);
@@ -7805,8 +8002,9 @@ H5T__conv_float_ullong(hid_t src_id, hid_t dst_id, H5T_cdata_t *cdata, size_t ne
  *-------------------------------------------------------------------------
  */
 herr_t
-H5T__conv_double_llong(hid_t src_id, hid_t dst_id, H5T_cdata_t *cdata, size_t nelmts, size_t buf_stride,
-                       size_t H5_ATTR_UNUSED bkg_stride, void *buf, void H5_ATTR_UNUSED *bkg)
+H5T__conv_double_llong(H5T_t *st, H5T_t *dt, H5T_cdata_t *cdata, const H5T_conv_ctx_t *conv_ctx,
+                       size_t nelmts, size_t buf_stride, size_t H5_ATTR_UNUSED bkg_stride, void *buf,
+                       void H5_ATTR_UNUSED *bkg)
 {
     H5_GCC_CLANG_DIAG_OFF("float-equal")
     H5T_CONV_Fx(DOUBLE, LLONG, double, long long, LLONG_MIN, LLONG_MAX);
@@ -7824,8 +8022,9 @@ H5T__conv_double_llong(hid_t src_id, hid_t dst_id, H5T_cdata_t *cdata, size_t ne
  *-------------------------------------------------------------------------
  */
 herr_t
-H5T__conv_double_ullong(hid_t src_id, hid_t dst_id, H5T_cdata_t *cdata, size_t nelmts, size_t buf_stride,
-                        size_t H5_ATTR_UNUSED bkg_stride, void *buf, void H5_ATTR_UNUSED *bkg)
+H5T__conv_double_ullong(H5T_t *st, H5T_t *dt, H5T_cdata_t *cdata, const H5T_conv_ctx_t *conv_ctx,
+                        size_t nelmts, size_t buf_stride, size_t H5_ATTR_UNUSED bkg_stride, void *buf,
+                        void H5_ATTR_UNUSED *bkg)
 {
     H5_GCC_CLANG_DIAG_OFF("float-equal")
     H5T_CONV_Fx(DOUBLE, ULLONG, double, unsigned long long, 0, ULLONG_MAX);
@@ -7844,8 +8043,9 @@ H5T__conv_double_ullong(hid_t src_id, hid_t dst_id, H5T_cdata_t *cdata, size_t n
  */
 #ifdef H5T_CONV_INTERNAL_LDOUBLE_LLONG
 herr_t
-H5T__conv_ldouble_llong(hid_t src_id, hid_t dst_id, H5T_cdata_t *cdata, size_t nelmts, size_t buf_stride,
-                        size_t H5_ATTR_UNUSED bkg_stride, void *buf, void H5_ATTR_UNUSED *bkg)
+H5T__conv_ldouble_llong(H5T_t *st, H5T_t *dt, H5T_cdata_t *cdata, const H5T_conv_ctx_t *conv_ctx,
+                        size_t nelmts, size_t buf_stride, size_t H5_ATTR_UNUSED bkg_stride, void *buf,
+                        void H5_ATTR_UNUSED *bkg)
 {
     H5_GCC_CLANG_DIAG_OFF("float-equal")
     H5T_CONV_Fx(LDOUBLE, LLONG, long double, long long, LLONG_MIN, LLONG_MAX);
@@ -7865,8 +8065,9 @@ H5T__conv_ldouble_llong(hid_t src_id, hid_t dst_id, H5T_cdata_t *cdata, size_t n
  */
 #ifdef H5T_CONV_INTERNAL_LDOUBLE_ULLONG
 herr_t
-H5T__conv_ldouble_ullong(hid_t src_id, hid_t dst_id, H5T_cdata_t *cdata, size_t nelmts, size_t buf_stride,
-                         size_t H5_ATTR_UNUSED bkg_stride, void *buf, void H5_ATTR_UNUSED *bkg)
+H5T__conv_ldouble_ullong(H5T_t *st, H5T_t *dt, H5T_cdata_t *cdata, const H5T_conv_ctx_t *conv_ctx,
+                         size_t nelmts, size_t buf_stride, size_t H5_ATTR_UNUSED bkg_stride, void *buf,
+                         void H5_ATTR_UNUSED *bkg)
 {
     H5_GCC_CLANG_DIAG_OFF("float-equal")
     H5T_CONV_Fx(LDOUBLE, ULLONG, long double, unsigned long long, 0, ULLONG_MAX);
@@ -7886,12 +8087,10 @@ H5T__conv_ldouble_ullong(hid_t src_id, hid_t dst_id, H5T_cdata_t *cdata, size_t 
  *-------------------------------------------------------------------------
  */
 herr_t
-H5T__conv_f_i(hid_t src_id, hid_t dst_id, H5T_cdata_t *cdata, size_t nelmts, size_t buf_stride,
-              size_t H5_ATTR_UNUSED bkg_stride, void *buf, void H5_ATTR_UNUSED *bkg)
+H5T__conv_f_i(H5T_t *src_p, H5T_t *dst_p, H5T_cdata_t *cdata, const H5T_conv_ctx_t *conv_ctx, size_t nelmts,
+              size_t buf_stride, size_t H5_ATTR_UNUSED bkg_stride, void *buf, void H5_ATTR_UNUSED *bkg)
 {
     /* Traversal-related variables */
-    H5T_t       *src_p;           /*source datatype        */
-    H5T_t       *dst_p;           /*destination datatype        */
     H5T_atomic_t src;             /*atomic source info        */
     H5T_atomic_t dst;             /*atomic destination info    */
     int          direction;       /*forward or backward traversal    */
@@ -7905,25 +8104,23 @@ H5T__conv_f_i(hid_t src_id, hid_t dst_id, H5T_cdata_t *cdata, size_t nelmts, siz
     uint8_t      tmp1, tmp2;      /*temp variables for swapping bytes*/
 
     /* Conversion-related variables */
-    hssize_t       expo;                     /*source exponent        */
-    hssize_t       sign;                     /*source sign bit value         */
-    uint8_t       *int_buf = NULL;           /*buffer for temporary value    */
-    size_t         buf_size;                 /*buffer size for temporary value */
-    size_t         i;                        /*miscellaneous counters    */
-    size_t         first;                    /*first bit(MSB) in an integer  */
-    ssize_t        sfirst;                   /*a signed version of `first'    */
-    H5T_conv_cb_t  cb_struct = {NULL, NULL}; /*conversion callback structure */
-    bool           truncated;                /*if fraction value is dropped  */
-    bool           reverse;                  /*if reverse order of destination at the end */
-    H5T_conv_ret_t except_ret;               /*return of callback function   */
-    herr_t         ret_value = SUCCEED;      /* Return value                 */
+    hssize_t       expo;                /*source exponent        */
+    hssize_t       sign;                /*source sign bit value         */
+    uint8_t       *int_buf = NULL;      /*buffer for temporary value    */
+    size_t         buf_size;            /*buffer size for temporary value */
+    size_t         i;                   /*miscellaneous counters    */
+    size_t         first;               /*first bit(MSB) in an integer  */
+    ssize_t        sfirst;              /*a signed version of `first'    */
+    bool           truncated;           /*if fraction value is dropped  */
+    bool           reverse;             /*if reverse order of destination at the end */
+    H5T_conv_ret_t except_ret;          /*return of callback function   */
+    herr_t         ret_value = SUCCEED; /* Return value                 */
 
     FUNC_ENTER_PACKAGE
 
     switch (cdata->command) {
         case H5T_CONV_INIT:
-            if (NULL == (src_p = (H5T_t *)H5I_object(src_id)) ||
-                NULL == (dst_p = (H5T_t *)H5I_object(dst_id)))
+            if (NULL == src_p || NULL == dst_p)
                 HGOTO_ERROR(H5E_ARGS, H5E_BADTYPE, FAIL, "not a datatype");
             src = src_p->shared->u.atomic;
             dst = dst_p->shared->u.atomic;
@@ -7940,10 +8137,11 @@ H5T__conv_f_i(hid_t src_id, hid_t dst_id, H5T_cdata_t *cdata, size_t nelmts, siz
             break;
 
         case H5T_CONV_CONV:
-            /* Get the datatypes */
-            if (NULL == (src_p = (H5T_t *)H5I_object(src_id)) ||
-                NULL == (dst_p = (H5T_t *)H5I_object(dst_id)))
+            if (NULL == src_p || NULL == dst_p)
                 HGOTO_ERROR(H5E_ARGS, H5E_BADTYPE, FAIL, "not a datatype");
+            if (NULL == conv_ctx)
+                HGOTO_ERROR(H5E_ARGS, H5E_BADVALUE, FAIL, "invalid datatype conversion context pointer");
+
             src = src_p->shared->u.atomic;
             dst = dst_p->shared->u.atomic;
 
@@ -7978,10 +8176,6 @@ H5T__conv_f_i(hid_t src_id, hid_t dst_id, H5T_cdata_t *cdata, size_t nelmts, siz
              */
             buf_size = (size_t)(pow(2.0, (double)src.u.f.esize) / 8 + 1);
             int_buf  = (uint8_t *)H5MM_calloc(buf_size);
-
-            /* Get conversion exception callback property */
-            if (H5CX_get_dt_conv_cb(&cb_struct) < 0)
-                HGOTO_ERROR(H5E_DATATYPE, H5E_CANTGET, FAIL, "unable to get conversion exception callback");
 
             /* Allocate space for order-reversed source buffer */
             src_rev = (uint8_t *)H5MM_calloc(src_p->shared->size);
@@ -8064,13 +8258,14 @@ H5T__conv_f_i(hid_t src_id, hid_t dst_id, H5T_cdata_t *cdata, size_t nelmts, siz
                     }
                     else if (H5T__bit_find(s, src.u.f.epos, src.u.f.esize, H5T_BIT_LSB, false) < 0) {
                         /* +Infinity or -Infinity */
-                        if (sign) {               /* -Infinity */
-                            if (cb_struct.func) { /*If user's exception handler is present, use it*/
+                        if (sign) {                         /* -Infinity */
+                            if (conv_ctx->cb_struct.func) { /*If user's exception handler is present, use it*/
                                 /*reverse order first*/
                                 H5T__reverse_order(src_rev, s, src_p->shared->size,
                                                    src_p->shared->u.atomic.order);
-                                except_ret = (cb_struct.func)(H5T_CONV_EXCEPT_NINF, src_id, dst_id, src_rev,
-                                                              d, cb_struct.user_data);
+                                except_ret = (conv_ctx->cb_struct.func)(
+                                    H5T_CONV_EXCEPT_NINF, conv_ctx->src_type_id, conv_ctx->dst_type_id,
+                                    src_rev, d, conv_ctx->cb_struct.user_data);
                             }
 
                             if (except_ret == H5T_CONV_UNHANDLED) {
@@ -8086,13 +8281,14 @@ H5T__conv_f_i(hid_t src_id, hid_t dst_id, H5T_cdata_t *cdata, size_t nelmts, siz
                                 HGOTO_ERROR(H5E_DATATYPE, H5E_CANTCONVERT, FAIL,
                                             "can't handle conversion exception");
                         }
-                        else {                    /* +Infinity */
-                            if (cb_struct.func) { /*If user's exception handler is present, use it*/
+                        else {                              /* +Infinity */
+                            if (conv_ctx->cb_struct.func) { /*If user's exception handler is present, use it*/
                                 /*reverse order first*/
                                 H5T__reverse_order(src_rev, s, src_p->shared->size,
                                                    src_p->shared->u.atomic.order);
-                                except_ret = (cb_struct.func)(H5T_CONV_EXCEPT_PINF, src_id, dst_id, src_rev,
-                                                              d, cb_struct.user_data);
+                                except_ret = (conv_ctx->cb_struct.func)(
+                                    H5T_CONV_EXCEPT_PINF, conv_ctx->src_type_id, conv_ctx->dst_type_id,
+                                    src_rev, d, conv_ctx->cb_struct.user_data);
                             }
 
                             if (except_ret == H5T_CONV_UNHANDLED) {
@@ -8120,13 +8316,14 @@ H5T__conv_f_i(hid_t src_id, hid_t dst_id, H5T_cdata_t *cdata, size_t nelmts, siz
                      *If the exponent bits are all 1s and only the 1st bit of mantissa
                      *is set to 1.  It's infinity. The Intel-Linux "long double" is this case.*/
                     /* +Infinity or -Infinity */
-                    if (sign) {               /* -Infinity */
-                        if (cb_struct.func) { /*If user's exception handler is present, use it*/
+                    if (sign) {                         /* -Infinity */
+                        if (conv_ctx->cb_struct.func) { /*If user's exception handler is present, use it*/
                             /*reverse order first*/
                             H5T__reverse_order(src_rev, s, src_p->shared->size,
                                                src_p->shared->u.atomic.order);
-                            except_ret = (cb_struct.func)(H5T_CONV_EXCEPT_NINF, src_id, dst_id, src_rev, d,
-                                                          cb_struct.user_data);
+                            except_ret = (conv_ctx->cb_struct.func)(
+                                H5T_CONV_EXCEPT_NINF, conv_ctx->src_type_id, conv_ctx->dst_type_id, src_rev,
+                                d, conv_ctx->cb_struct.user_data);
                         }
 
                         if (except_ret == H5T_CONV_UNHANDLED) {
@@ -8142,13 +8339,14 @@ H5T__conv_f_i(hid_t src_id, hid_t dst_id, H5T_cdata_t *cdata, size_t nelmts, siz
                             HGOTO_ERROR(H5E_DATATYPE, H5E_CANTCONVERT, FAIL,
                                         "can't handle conversion exception");
                     }
-                    else {                    /* +Infinity */
-                        if (cb_struct.func) { /*If user's exception handler is present, use it*/
+                    else {                              /* +Infinity */
+                        if (conv_ctx->cb_struct.func) { /*If user's exception handler is present, use it*/
                             /*reverse order first*/
                             H5T__reverse_order(src_rev, s, src_p->shared->size,
                                                src_p->shared->u.atomic.order);
-                            except_ret = (cb_struct.func)(H5T_CONV_EXCEPT_PINF, src_id, dst_id, src_rev, d,
-                                                          cb_struct.user_data);
+                            except_ret = (conv_ctx->cb_struct.func)(
+                                H5T_CONV_EXCEPT_PINF, conv_ctx->src_type_id, conv_ctx->dst_type_id, src_rev,
+                                d, conv_ctx->cb_struct.user_data);
                         }
 
                         if (except_ret == H5T_CONV_UNHANDLED) {
@@ -8170,11 +8368,12 @@ H5T__conv_f_i(hid_t src_id, hid_t dst_id, H5T_cdata_t *cdata, size_t nelmts, siz
                 }
                 else if (H5T__bit_find(s, src.u.f.epos, src.u.f.esize, H5T_BIT_LSB, false) < 0) {
                     /* NaN */
-                    if (cb_struct.func) { /*If user's exception handler is present, use it*/
+                    if (conv_ctx->cb_struct.func) { /*If user's exception handler is present, use it*/
                         /*reverse order first*/
                         H5T__reverse_order(src_rev, s, src_p->shared->size, src_p->shared->u.atomic.order);
-                        except_ret = (cb_struct.func)(H5T_CONV_EXCEPT_NAN, src_id, dst_id, src_rev, d,
-                                                      cb_struct.user_data);
+                        except_ret = (conv_ctx->cb_struct.func)(H5T_CONV_EXCEPT_NAN, conv_ctx->src_type_id,
+                                                                conv_ctx->dst_type_id, src_rev, d,
+                                                                conv_ctx->cb_struct.user_data);
                     }
 
                     if (except_ret == H5T_CONV_UNHANDLED) {
@@ -8245,7 +8444,7 @@ H5T__conv_f_i(hid_t src_id, hid_t dst_id, H5T_cdata_t *cdata, size_t nelmts, siz
                  * If expo is less than mantissa size, the frantional value is dropped off
                  * during conversion.  Set exception type to be "truncate"
                  */
-                if ((size_t)expo < src.u.f.msize && cb_struct.func)
+                if ((size_t)expo < src.u.f.msize && conv_ctx->cb_struct.func)
                     truncated = true;
 
                 /*
@@ -8271,13 +8470,14 @@ H5T__conv_f_i(hid_t src_id, hid_t dst_id, H5T_cdata_t *cdata, size_t nelmts, siz
                      * zero(do nothing).  If user's exception handler is set, call it and
                      * let user handle it.
                      */
-                    if (sign) {               /*source is negative*/
-                        if (cb_struct.func) { /*If user's exception handler is present, use it*/
+                    if (sign) {                         /*source is negative*/
+                        if (conv_ctx->cb_struct.func) { /*If user's exception handler is present, use it*/
                             /*reverse order first*/
                             H5T__reverse_order(src_rev, s, src_p->shared->size,
                                                src_p->shared->u.atomic.order);
-                            except_ret = (cb_struct.func)(H5T_CONV_EXCEPT_RANGE_LOW, src_id, dst_id, src_rev,
-                                                          d, cb_struct.user_data);
+                            except_ret = (conv_ctx->cb_struct.func)(
+                                H5T_CONV_EXCEPT_RANGE_LOW, conv_ctx->src_type_id, conv_ctx->dst_type_id,
+                                src_rev, d, conv_ctx->cb_struct.user_data);
                             if (except_ret == H5T_CONV_ABORT)
                                 HGOTO_ERROR(H5E_DATATYPE, H5E_CANTCONVERT, FAIL,
                                             "can't handle conversion exception");
@@ -8291,12 +8491,13 @@ H5T__conv_f_i(hid_t src_id, hid_t dst_id, H5T_cdata_t *cdata, size_t nelmts, siz
                     else { /*source is positive*/
                         if (first >= dst.prec) {
                             /*overflow*/
-                            if (cb_struct.func) { /*If user's exception handler is present, use it*/
+                            if (conv_ctx->cb_struct.func) { /*If user's exception handler is present, use it*/
                                 /*reverse order first*/
                                 H5T__reverse_order(src_rev, s, src_p->shared->size,
                                                    src_p->shared->u.atomic.order);
-                                except_ret = (cb_struct.func)(H5T_CONV_EXCEPT_RANGE_HI, src_id, dst_id,
-                                                              src_rev, d, cb_struct.user_data);
+                                except_ret = (conv_ctx->cb_struct.func)(
+                                    H5T_CONV_EXCEPT_RANGE_HI, conv_ctx->src_type_id, conv_ctx->dst_type_id,
+                                    src_rev, d, conv_ctx->cb_struct.user_data);
                             }
 
                             if (except_ret == H5T_CONV_UNHANDLED)
@@ -8312,12 +8513,13 @@ H5T__conv_f_i(hid_t src_id, hid_t dst_id, H5T_cdata_t *cdata, size_t nelmts, siz
                         }
                         else if (first < dst.prec) {
                             if (truncated &&
-                                cb_struct.func) { /*If user's exception handler is present, use it*/
+                                conv_ctx->cb_struct.func) { /*If user's exception handler is present, use it*/
                                 /*reverse order first*/
                                 H5T__reverse_order(src_rev, s, src_p->shared->size,
                                                    src_p->shared->u.atomic.order);
-                                except_ret = (cb_struct.func)(H5T_CONV_EXCEPT_TRUNCATE, src_id, dst_id,
-                                                              src_rev, d, cb_struct.user_data);
+                                except_ret = (conv_ctx->cb_struct.func)(
+                                    H5T_CONV_EXCEPT_TRUNCATE, conv_ctx->src_type_id, conv_ctx->dst_type_id,
+                                    src_rev, d, conv_ctx->cb_struct.user_data);
                             }
 
                             if (except_ret == H5T_CONV_UNHANDLED)
@@ -8338,12 +8540,13 @@ H5T__conv_f_i(hid_t src_id, hid_t dst_id, H5T_cdata_t *cdata, size_t nelmts, siz
                     if (sign) {                       /*source is negative*/
                         if (first < dst.prec - 1) {
                             if (truncated &&
-                                cb_struct.func) { /*If user's exception handler is present, use it*/
+                                conv_ctx->cb_struct.func) { /*If user's exception handler is present, use it*/
                                 /*reverse order first*/
                                 H5T__reverse_order(src_rev, s, src_p->shared->size,
                                                    src_p->shared->u.atomic.order);
-                                except_ret = (cb_struct.func)(H5T_CONV_EXCEPT_TRUNCATE, src_id, dst_id,
-                                                              src_rev, d, cb_struct.user_data);
+                                except_ret = (conv_ctx->cb_struct.func)(
+                                    H5T_CONV_EXCEPT_TRUNCATE, conv_ctx->src_type_id, conv_ctx->dst_type_id,
+                                    src_rev, d, conv_ctx->cb_struct.user_data);
                             }
 
                             if (except_ret == H5T_CONV_UNHANDLED) { /*If this case ignored by user handler*/
@@ -8368,12 +8571,13 @@ H5T__conv_f_i(hid_t src_id, hid_t dst_id, H5T_cdata_t *cdata, size_t nelmts, siz
                             /* if underflows and no callback, do nothing except turn on
                              * the sign bit because 0x80...00 is the biggest negative value.
                              */
-                            if (cb_struct.func) { /*If user's exception handler is present, use it*/
+                            if (conv_ctx->cb_struct.func) { /*If user's exception handler is present, use it*/
                                 /*reverse order first*/
                                 H5T__reverse_order(src_rev, s, src_p->shared->size,
                                                    src_p->shared->u.atomic.order);
-                                except_ret = (cb_struct.func)(H5T_CONV_EXCEPT_RANGE_LOW, src_id, dst_id,
-                                                              src_rev, d, cb_struct.user_data);
+                                except_ret = (conv_ctx->cb_struct.func)(
+                                    H5T_CONV_EXCEPT_RANGE_LOW, conv_ctx->src_type_id, conv_ctx->dst_type_id,
+                                    src_rev, d, conv_ctx->cb_struct.user_data);
                             }
 
                             if (except_ret == H5T_CONV_UNHANDLED)
@@ -8391,12 +8595,13 @@ H5T__conv_f_i(hid_t src_id, hid_t dst_id, H5T_cdata_t *cdata, size_t nelmts, siz
                     else { /*source is positive*/
                         if (first >= dst.prec - 1) {
                             /*overflow*/
-                            if (cb_struct.func) { /*If user's exception handler is present, use it*/
+                            if (conv_ctx->cb_struct.func) { /*If user's exception handler is present, use it*/
                                 /*reverse order first*/
                                 H5T__reverse_order(src_rev, s, src_p->shared->size,
                                                    src_p->shared->u.atomic.order);
-                                except_ret = (cb_struct.func)(H5T_CONV_EXCEPT_RANGE_HI, src_id, dst_id,
-                                                              src_rev, d, cb_struct.user_data);
+                                except_ret = (conv_ctx->cb_struct.func)(
+                                    H5T_CONV_EXCEPT_RANGE_HI, conv_ctx->src_type_id, conv_ctx->dst_type_id,
+                                    src_rev, d, conv_ctx->cb_struct.user_data);
                             }
 
                             if (except_ret == H5T_CONV_UNHANDLED)
@@ -8412,12 +8617,13 @@ H5T__conv_f_i(hid_t src_id, hid_t dst_id, H5T_cdata_t *cdata, size_t nelmts, siz
                         }
                         else if (first < dst.prec - 1) {
                             if (truncated &&
-                                cb_struct.func) { /*If user's exception handler is present, use it*/
+                                conv_ctx->cb_struct.func) { /*If user's exception handler is present, use it*/
                                 /*reverse order first*/
                                 H5T__reverse_order(src_rev, s, src_p->shared->size,
                                                    src_p->shared->u.atomic.order);
-                                except_ret = (cb_struct.func)(H5T_CONV_EXCEPT_TRUNCATE, src_id, dst_id,
-                                                              src_rev, d, cb_struct.user_data);
+                                except_ret = (conv_ctx->cb_struct.func)(
+                                    H5T_CONV_EXCEPT_TRUNCATE, conv_ctx->src_type_id, conv_ctx->dst_type_id,
+                                    src_rev, d, conv_ctx->cb_struct.user_data);
                             }
 
                             if (except_ret == H5T_CONV_UNHANDLED) {
@@ -8509,12 +8715,10 @@ done:
  *-------------------------------------------------------------------------
  */
 herr_t
-H5T__conv_i_f(hid_t src_id, hid_t dst_id, H5T_cdata_t *cdata, size_t nelmts, size_t buf_stride,
-              size_t H5_ATTR_UNUSED bkg_stride, void *buf, void H5_ATTR_UNUSED *bkg)
+H5T__conv_i_f(H5T_t *src_p, H5T_t *dst_p, H5T_cdata_t *cdata, const H5T_conv_ctx_t *conv_ctx, size_t nelmts,
+              size_t buf_stride, size_t H5_ATTR_UNUSED bkg_stride, void *buf, void H5_ATTR_UNUSED *bkg)
 {
     /* Traversal-related variables */
-    H5T_t       *src_p;           /*source datatype        */
-    H5T_t       *dst_p;           /*destination datatype        */
     H5T_atomic_t src;             /*atomic source info        */
     H5T_atomic_t dst;             /*atomic destination info    */
     int          direction;       /*forward or backward traversal    */
@@ -8528,27 +8732,25 @@ H5T__conv_i_f(hid_t src_id, hid_t dst_id, H5T_cdata_t *cdata, size_t nelmts, siz
     uint8_t      tmp1, tmp2;      /*temp variables for swapping bytes*/
 
     /* Conversion-related variables */
-    hsize_t        expo;                     /*destination exponent        */
-    hsize_t        expo_max;                 /*maximal possible exponent value       */
-    size_t         sign;                     /*source sign bit value         */
-    bool           is_max_neg;               /*source is maximal negative value*/
-    bool           do_round;                 /*whether there is roundup      */
-    uint8_t       *int_buf = NULL;           /*buffer for temporary value    */
-    size_t         buf_size;                 /*buffer size for temporary value */
-    size_t         i;                        /*miscellaneous counters    */
-    size_t         first;                    /*first bit(MSB) in an integer  */
-    ssize_t        sfirst;                   /*a signed version of `first'    */
-    H5T_conv_cb_t  cb_struct = {NULL, NULL}; /*conversion callback structure */
-    H5T_conv_ret_t except_ret;               /*return of callback function   */
-    bool           reverse;                  /*if reverse the order of destination   */
-    herr_t         ret_value = SUCCEED;      /* Return value */
+    hsize_t        expo;                /*destination exponent        */
+    hsize_t        expo_max;            /*maximal possible exponent value       */
+    size_t         sign;                /*source sign bit value         */
+    bool           is_max_neg;          /*source is maximal negative value*/
+    bool           do_round;            /*whether there is roundup      */
+    uint8_t       *int_buf = NULL;      /*buffer for temporary value    */
+    size_t         buf_size;            /*buffer size for temporary value */
+    size_t         i;                   /*miscellaneous counters    */
+    size_t         first;               /*first bit(MSB) in an integer  */
+    ssize_t        sfirst;              /*a signed version of `first'    */
+    H5T_conv_ret_t except_ret;          /*return of callback function   */
+    bool           reverse;             /*if reverse the order of destination   */
+    herr_t         ret_value = SUCCEED; /* Return value */
 
     FUNC_ENTER_PACKAGE
 
     switch (cdata->command) {
         case H5T_CONV_INIT:
-            if (NULL == (src_p = (H5T_t *)H5I_object(src_id)) ||
-                NULL == (dst_p = (H5T_t *)H5I_object(dst_id)))
+            if (NULL == src_p || NULL == dst_p)
                 HGOTO_ERROR(H5E_ARGS, H5E_BADTYPE, FAIL, "not a datatype");
             src = src_p->shared->u.atomic;
             dst = dst_p->shared->u.atomic;
@@ -8565,10 +8767,11 @@ H5T__conv_i_f(hid_t src_id, hid_t dst_id, H5T_cdata_t *cdata, size_t nelmts, siz
             break;
 
         case H5T_CONV_CONV:
-            /* Get the datatypes */
-            if (NULL == (src_p = (H5T_t *)H5I_object(src_id)) ||
-                NULL == (dst_p = (H5T_t *)H5I_object(dst_id)))
+            if (NULL == src_p || NULL == dst_p)
                 HGOTO_ERROR(H5E_ARGS, H5E_BADTYPE, FAIL, "not a datatype");
+            if (NULL == conv_ctx)
+                HGOTO_ERROR(H5E_ARGS, H5E_BADVALUE, FAIL, "invalid datatype conversion context pointer");
+
             src = src_p->shared->u.atomic;
             dst = dst_p->shared->u.atomic;
 
@@ -8603,10 +8806,6 @@ H5T__conv_i_f(hid_t src_id, hid_t dst_id, H5T_cdata_t *cdata, size_t nelmts, siz
              */
             buf_size = (src.prec > dst.u.f.msize ? src.prec : dst.u.f.msize) / 8 + 1;
             int_buf  = (uint8_t *)H5MM_calloc(buf_size);
-
-            /* Get conversion exception callback property */
-            if (H5CX_get_dt_conv_cb(&cb_struct) < 0)
-                HGOTO_ERROR(H5E_DATATYPE, H5E_CANTGET, FAIL, "unable to get conversion exception callback");
 
             /* Allocate space for order-reversed source buffer */
             src_rev = (uint8_t *)H5MM_calloc(src_p->shared->size);
@@ -8743,11 +8942,12 @@ H5T__conv_i_f(hid_t src_id, hid_t dst_id, H5T_cdata_t *cdata, size_t nelmts, siz
                     /* If the bit sequence is bigger than the mantissa part, there'll be some
                      * precision loss.  Let user's handler deal with the case if it's present
                      */
-                    if (cb_struct.func) {
+                    if (conv_ctx->cb_struct.func) {
                         H5T__reverse_order(src_rev, s, src_p->shared->size,
                                            src_p->shared->u.atomic.order); /*reverse order first*/
-                        except_ret = (cb_struct.func)(H5T_CONV_EXCEPT_PRECISION, src_id, dst_id, src_rev, d,
-                                                      cb_struct.user_data);
+                        except_ret = (conv_ctx->cb_struct.func)(H5T_CONV_EXCEPT_PRECISION,
+                                                                conv_ctx->src_type_id, conv_ctx->dst_type_id,
+                                                                src_rev, d, conv_ctx->cb_struct.user_data);
                     }
 
                     if (except_ret == H5T_CONV_HANDLED) {
@@ -8813,12 +9013,13 @@ H5T__conv_i_f(hid_t src_id, hid_t dst_id, H5T_cdata_t *cdata, size_t nelmts, siz
                 /* Check if the exponent is too big */
                 expo_max = (hsize_t)(pow(2.0, (double)dst.u.f.esize) - 1);
 
-                if (expo > expo_max) {    /*overflows*/
-                    if (cb_struct.func) { /*user's exception handler.  Reverse back source order*/
+                if (expo > expo_max) {              /*overflows*/
+                    if (conv_ctx->cb_struct.func) { /*user's exception handler.  Reverse back source order*/
                         H5T__reverse_order(src_rev, s, src_p->shared->size,
                                            src_p->shared->u.atomic.order); /*reverse order first*/
-                        except_ret = (cb_struct.func)(H5T_CONV_EXCEPT_RANGE_HI, src_id, dst_id, src_rev, d,
-                                                      cb_struct.user_data);
+                        except_ret = (conv_ctx->cb_struct.func)(H5T_CONV_EXCEPT_RANGE_HI,
+                                                                conv_ctx->src_type_id, conv_ctx->dst_type_id,
+                                                                src_rev, d, conv_ctx->cb_struct.user_data);
 
                         if (except_ret == H5T_CONV_ABORT)
                             HGOTO_ERROR(H5E_DATATYPE, H5E_CANTCONVERT, FAIL,
@@ -8973,9 +9174,8 @@ H5T__reverse_order(uint8_t *rev, uint8_t *s, size_t size, H5T_order_t order)
  *-------------------------------------------------------------------------
  */
 herr_t
-H5T_reclaim(hid_t type_id, H5S_t *space, void *buf)
+H5T_reclaim(H5T_t *type, H5S_t *space, void *buf)
 {
-    H5T_t                *type;             /* Datatype */
     H5S_sel_iter_op_t     dset_op;          /* Operator for iteration */
     H5T_vlen_alloc_info_t vl_alloc_info;    /* VL allocation info */
     herr_t                ret_value = FAIL; /* Return value */
@@ -8983,12 +9183,9 @@ H5T_reclaim(hid_t type_id, H5S_t *space, void *buf)
     FUNC_ENTER_NOAPI_NOINIT
 
     /* Check args */
-    assert(H5I_DATATYPE == H5I_get_type(type_id));
+    assert(type);
     assert(space);
     assert(buf);
-
-    if (NULL == (type = (H5T_t *)H5I_object_verify(type_id, H5I_DATATYPE)))
-        HGOTO_ERROR(H5E_ARGS, H5E_BADTYPE, FAIL, "not an valid base datatype");
 
     /* Get the allocation info */
     if (H5CX_get_vlen_alloc_info(&vl_alloc_info) < 0)
@@ -9015,7 +9212,7 @@ done:
  *-------------------------------------------------------------------------
  */
 herr_t
-H5T_reclaim_cb(void *elem, const H5T_t *dt, unsigned H5_ATTR_UNUSED ndim, const hsize_t H5_ATTR_UNUSED *point,
+H5T_reclaim_cb(void *elem, H5T_t *dt, unsigned H5_ATTR_UNUSED ndim, const hsize_t H5_ATTR_UNUSED *point,
                void *op_data)
 {
     herr_t ret_value = SUCCEED; /* Return value */

--- a/src/H5Tnative.c
+++ b/src/H5Tnative.c
@@ -332,7 +332,6 @@ H5T__get_native_type(H5T_t *dtype, H5T_direction_t direction, size_t *struct_ali
 
         case H5T_ENUM: {
             H5T_path_t *tpath; /* Type conversion info    */
-            hid_t       super_type_id, nat_super_type_id;
 
             /* Don't need to do anything special for alignment, offset since the ENUM type usually is integer.
              */
@@ -343,11 +342,6 @@ H5T__get_native_type(H5T_t *dtype, H5T_direction_t direction, size_t *struct_ali
             if (NULL == (nat_super_type =
                              H5T__get_native_type(super_type, direction, struct_align, offset, comp_size)))
                 HGOTO_ERROR(H5E_ARGS, H5E_BADTYPE, NULL, "base native type retrieval failed");
-
-            if ((super_type_id = H5I_register(H5I_DATATYPE, super_type, false)) < 0)
-                HGOTO_ERROR(H5E_ARGS, H5E_BADTYPE, NULL, "cannot register datatype");
-            if ((nat_super_type_id = H5I_register(H5I_DATATYPE, nat_super_type, false)) < 0)
-                HGOTO_ERROR(H5E_ARGS, H5E_BADTYPE, NULL, "cannot register datatype");
 
             /* Allocate room for the enum values */
             if (NULL == (tmp_memb_value = H5MM_calloc(H5T_get_size(super_type))))
@@ -375,7 +369,7 @@ H5T__get_native_type(H5T_t *dtype, H5T_direction_t direction, size_t *struct_ali
                     HGOTO_ERROR(H5E_ARGS, H5E_BADTYPE, NULL, "cannot get member value");
                 H5MM_memcpy(memb_value, tmp_memb_value, H5T_get_size(super_type));
 
-                if (H5T_convert(tpath, super_type_id, nat_super_type_id, (size_t)1, (size_t)0, (size_t)0,
+                if (H5T_convert(tpath, super_type, nat_super_type, (size_t)1, (size_t)0, (size_t)0,
                                 memb_value, NULL) < 0)
                     HGOTO_ERROR(H5E_ARGS, H5E_BADTYPE, NULL, "cannot get member value");
 
@@ -386,12 +380,10 @@ H5T__get_native_type(H5T_t *dtype, H5T_direction_t direction, size_t *struct_ali
             memb_value     = H5MM_xfree(memb_value);
             tmp_memb_value = H5MM_xfree(tmp_memb_value);
 
-            /* Close base type */
-            if (H5I_dec_app_ref(nat_super_type_id) < 0)
-                HGOTO_ERROR(H5E_ARGS, H5E_BADTYPE, NULL, "cannot close datatype");
-            /* Close super type */
-            if (H5I_dec_app_ref(super_type_id) < 0)
-                HGOTO_ERROR(H5E_ARGS, H5E_BADTYPE, NULL, "cannot close datatype");
+            if (H5T_close(nat_super_type) < 0)
+                HGOTO_ERROR(H5E_DATATYPE, H5E_CANTCLOSEOBJ, NULL, "can't close datatype");
+            if (H5T_close(super_type) < 0)
+                HGOTO_ERROR(H5E_DATATYPE, H5E_CANTCLOSEOBJ, NULL, "can't close datatype");
 
             ret_value = new_type;
         } /* end case */

--- a/src/H5Tpkg.h
+++ b/src/H5Tpkg.h
@@ -150,9 +150,17 @@ struct H5T_stats_t {
     H5_timevals_t times;  /*total time for conversion	     */
 };
 
+/* Context struct for information used during datatype conversions */
+typedef struct H5T_conv_ctx_t {
+    H5T_conv_cb_t cb_struct;
+    hid_t         dxpl_id;
+    hid_t         src_type_id;
+    hid_t         dst_type_id;
+} H5T_conv_ctx_t;
+
 /* Library internal datatype conversion functions are... */
-typedef herr_t (*H5T_lib_conv_t)(hid_t src_id, hid_t dst_id, H5T_cdata_t *cdata, size_t nelmts,
-                                 size_t buf_stride, size_t bkg_stride, void *buf, void *bkg);
+typedef herr_t (*H5T_lib_conv_t)(H5T_t *src, H5T_t *dst, H5T_cdata_t *cdata, const H5T_conv_ctx_t *conv_ctx,
+                                 size_t nelmts, size_t buf_stride, size_t bkg_stride, void *buf, void *bkg);
 
 /* Conversion callbacks (library internal ones don't need DXPL) */
 typedef struct H5T_conv_func_t {
@@ -479,357 +487,472 @@ H5_DLL herr_t H5T__commit_named(const H5G_loc_t *loc, const char *name, H5T_t *d
 H5_DLL H5T_t *H5T__open_name(const H5G_loc_t *loc, const char *name);
 H5_DLL hid_t  H5T__get_create_plist(const H5T_t *type);
 
+/* Helper function for H5T_convert that accepts a pointer to a H5T_conv_ctx_t structure */
+H5_DLL herr_t H5T_convert_with_ctx(H5T_path_t *tpath, H5T_t *src_type, H5T_t *dst_type,
+                                   const H5T_conv_ctx_t *conv_ctx, size_t nelmts, size_t buf_stride,
+                                   size_t bkg_stride, void *buf, void *bkg);
+
 /* Conversion functions */
-H5_DLL herr_t H5T__conv_noop(hid_t src_id, hid_t dst_id, H5T_cdata_t *cdata, size_t nelmts, size_t buf_stride,
-                             size_t bkg_stride, void *buf, void *bkg);
+H5_DLL herr_t H5T__conv_noop(H5T_t *src, H5T_t *dst, H5T_cdata_t *cdata, const H5T_conv_ctx_t *conv_ctx,
+                             size_t nelmts, size_t buf_stride, size_t bkg_stride, void *_buf, void *bkg);
 
-H5_DLL herr_t H5T__conv_order(hid_t src_id, hid_t dst_id, H5T_cdata_t *cdata, size_t nelmts,
-                              size_t buf_stride, size_t bkg_stride, void *_buf, void *bkg);
-H5_DLL herr_t H5T__conv_order_opt(hid_t src_id, hid_t dst_id, H5T_cdata_t *cdata, size_t nelmts,
-                                  size_t buf_stride, size_t bkg_stride, void *_buf, void *bkg);
-H5_DLL herr_t H5T__conv_struct(hid_t src_id, hid_t dst_id, H5T_cdata_t *cdata, size_t nelmts,
-                               size_t buf_stride, size_t bkg_stride, void *_buf, void *bkg);
-H5_DLL herr_t H5T__conv_struct_opt(hid_t src_id, hid_t dst_id, H5T_cdata_t *cdata, size_t nelmts,
-                                   size_t buf_stride, size_t bkg_stride, void *_buf, void *bkg);
-H5_DLL herr_t H5T__conv_enum(hid_t src_id, hid_t dst_id, H5T_cdata_t *cdata, size_t nelmts, size_t buf_stride,
-                             size_t bkg_stride, void *buf, void *bkg);
-H5_DLL herr_t H5T__conv_enum_numeric(hid_t src_id, hid_t dst_id, H5T_cdata_t *cdata, size_t nelmts,
-                                     size_t buf_stride, size_t bkg_stride, void *buf, void *bkg);
-H5_DLL herr_t H5T__conv_vlen(hid_t src_id, hid_t dst_id, H5T_cdata_t *cdata, size_t nelmts, size_t buf_stride,
-                             size_t bkg_stride, void *buf, void *bkg);
-H5_DLL herr_t H5T__conv_array(hid_t src_id, hid_t dst_id, H5T_cdata_t *cdata, size_t nelmts,
-                              size_t buf_stride, size_t bkg_stride, void *buf, void *bkg);
-H5_DLL herr_t H5T__conv_ref(hid_t src_id, hid_t dst_id, H5T_cdata_t *cdata, size_t nelmts, size_t buf_stride,
-                            size_t bkg_stride, void *buf, void *bkg);
-H5_DLL herr_t H5T__conv_i_i(hid_t src_id, hid_t dst_id, H5T_cdata_t *cdata, size_t nelmts, size_t buf_stride,
-                            size_t bkg_stride, void *_buf, void *bkg);
-H5_DLL herr_t H5T__conv_f_f(hid_t src_id, hid_t dst_id, H5T_cdata_t *cdata, size_t nelmts, size_t buf_stride,
-                            size_t bkg_stride, void *_buf, void *bkg);
-H5_DLL herr_t H5T__conv_f_i(hid_t src_id, hid_t dst_id, H5T_cdata_t *cdata, size_t nelmts, size_t buf_stride,
-                            size_t bkg_stride, void *_buf, void *bkg);
-H5_DLL herr_t H5T__conv_i_f(hid_t src_id, hid_t dst_id, H5T_cdata_t *cdata, size_t nelmts, size_t buf_stride,
-                            size_t bkg_stride, void *_buf, void *bkg);
-H5_DLL herr_t H5T__conv_s_s(hid_t src_id, hid_t dst_id, H5T_cdata_t *cdata, size_t nelmts, size_t buf_stride,
-                            size_t bkg_stride, void *_buf, void *bkg);
-H5_DLL herr_t H5T__conv_b_b(hid_t src_id, hid_t dst_id, H5T_cdata_t *cdata, size_t nelmts, size_t buf_stride,
-                            size_t bkg_stride, void *_buf, void *bkg);
+H5_DLL herr_t H5T__conv_order(H5T_t *src, H5T_t *dst, H5T_cdata_t *cdata, const H5T_conv_ctx_t *conv_ctx,
+                              size_t nelmts, size_t buf_stride, size_t bkg_stride, void *_buf, void *bkg);
+H5_DLL herr_t H5T__conv_order_opt(H5T_t *src, H5T_t *dst, H5T_cdata_t *cdata, const H5T_conv_ctx_t *conv_ctx,
+                                  size_t nelmts, size_t buf_stride, size_t bkg_stride, void *_buf, void *bkg);
+H5_DLL herr_t H5T__conv_struct(H5T_t *src, H5T_t *dst, H5T_cdata_t *cdata, const H5T_conv_ctx_t *conv_ctx,
+                               size_t nelmts, size_t buf_stride, size_t bkg_stride, void *_buf, void *bkg);
+H5_DLL herr_t H5T__conv_struct_opt(H5T_t *src, H5T_t *dst, H5T_cdata_t *cdata, const H5T_conv_ctx_t *conv_ctx,
+                                   size_t nelmts, size_t buf_stride, size_t bkg_stride, void *_buf,
+                                   void *bkg);
+H5_DLL herr_t H5T__conv_enum(H5T_t *src, H5T_t *dst, H5T_cdata_t *cdata, const H5T_conv_ctx_t *conv_ctx,
+                             size_t nelmts, size_t buf_stride, size_t bkg_stride, void *buf, void *bkg);
+H5_DLL herr_t H5T__conv_enum_numeric(H5T_t *src, H5T_t *dst, H5T_cdata_t *cdata,
+                                     const H5T_conv_ctx_t *conv_ctx, size_t nelmts, size_t buf_stride,
+                                     size_t bkg_stride, void *buf, void *bkg);
+H5_DLL herr_t H5T__conv_vlen(H5T_t *src, H5T_t *dst, H5T_cdata_t *cdata, const H5T_conv_ctx_t *conv_ctx,
+                             size_t nelmts, size_t buf_stride, size_t bkg_stride, void *buf, void *bkg);
+H5_DLL herr_t H5T__conv_array(H5T_t *src, H5T_t *dst, H5T_cdata_t *cdata, const H5T_conv_ctx_t *conv_ctx,
+                              size_t nelmts, size_t buf_stride, size_t bkg_stride, void *buf, void *bkg);
+H5_DLL herr_t H5T__conv_ref(H5T_t *src, H5T_t *dst, H5T_cdata_t *cdata, const H5T_conv_ctx_t *conv_ctx,
+                            size_t nelmts, size_t buf_stride, size_t bkg_stride, void *buf, void *bkg);
+H5_DLL herr_t H5T__conv_i_i(H5T_t *src, H5T_t *dst, H5T_cdata_t *cdata, const H5T_conv_ctx_t *conv_ctx,
+                            size_t nelmts, size_t buf_stride, size_t bkg_stride, void *_buf, void *bkg);
+H5_DLL herr_t H5T__conv_f_f(H5T_t *src, H5T_t *dst, H5T_cdata_t *cdata, const H5T_conv_ctx_t *conv_ctx,
+                            size_t nelmts, size_t buf_stride, size_t bkg_stride, void *_buf, void *bkg);
+H5_DLL herr_t H5T__conv_f_i(H5T_t *src, H5T_t *dst, H5T_cdata_t *cdata, const H5T_conv_ctx_t *conv_ctx,
+                            size_t nelmts, size_t buf_stride, size_t bkg_stride, void *_buf, void *bkg);
+H5_DLL herr_t H5T__conv_i_f(H5T_t *src, H5T_t *dst, H5T_cdata_t *cdata, const H5T_conv_ctx_t *conv_ctx,
+                            size_t nelmts, size_t buf_stride, size_t bkg_stride, void *_buf, void *bkg);
+H5_DLL herr_t H5T__conv_s_s(H5T_t *src, H5T_t *dst, H5T_cdata_t *cdata, const H5T_conv_ctx_t *conv_ctx,
+                            size_t nelmts, size_t buf_stride, size_t bkg_stride, void *_buf, void *bkg);
+H5_DLL herr_t H5T__conv_b_b(H5T_t *src, H5T_t *dst, H5T_cdata_t *cdata, const H5T_conv_ctx_t *conv_ctx,
+                            size_t nelmts, size_t buf_stride, size_t bkg_stride, void *_buf, void *bkg);
 
-H5_DLL herr_t H5T__conv_schar_uchar(hid_t src_id, hid_t dst_id, H5T_cdata_t *cdata, size_t nelmts,
-                                    size_t buf_stride, size_t bkg_stride, void *buf, void *bkg);
-H5_DLL herr_t H5T__conv_uchar_schar(hid_t src_id, hid_t dst_id, H5T_cdata_t *cdata, size_t nelmts,
-                                    size_t buf_stride, size_t bkg_stride, void *buf, void *bkg);
-H5_DLL herr_t H5T__conv_schar_short(hid_t src_id, hid_t dst_id, H5T_cdata_t *cdata, size_t nelmts,
-                                    size_t buf_stride, size_t bkg_stride, void *buf, void *bkg);
-H5_DLL herr_t H5T__conv_schar_ushort(hid_t src_id, hid_t dst_id, H5T_cdata_t *cdata, size_t nelmts,
-                                     size_t buf_stride, size_t bkg_stride, void *buf, void *bkg);
-H5_DLL herr_t H5T__conv_uchar_short(hid_t src_id, hid_t dst_id, H5T_cdata_t *cdata, size_t nelmts,
-                                    size_t buf_stride, size_t bkg_stride, void *buf, void *bkg);
-H5_DLL herr_t H5T__conv_uchar_ushort(hid_t src_id, hid_t dst_id, H5T_cdata_t *cdata, size_t nelmts,
-                                     size_t buf_stride, size_t bkg_stride, void *buf, void *bkg);
-H5_DLL herr_t H5T__conv_schar_int(hid_t src_id, hid_t dst_id, H5T_cdata_t *cdata, size_t nelmts,
-                                  size_t buf_stride, size_t bkg_stride, void *buf, void *bkg);
-H5_DLL herr_t H5T__conv_schar_uint(hid_t src_id, hid_t dst_id, H5T_cdata_t *cdata, size_t nelmts,
-                                   size_t buf_stride, size_t bkg_stride, void *buf, void *bkg);
-H5_DLL herr_t H5T__conv_uchar_int(hid_t src_id, hid_t dst_id, H5T_cdata_t *cdata, size_t nelmts,
-                                  size_t buf_stride, size_t bkg_stride, void *buf, void *bkg);
-H5_DLL herr_t H5T__conv_uchar_uint(hid_t src_id, hid_t dst_id, H5T_cdata_t *cdata, size_t nelmts,
-                                   size_t buf_stride, size_t bkg_stride, void *buf, void *bkg);
-H5_DLL herr_t H5T__conv_schar_long(hid_t src_id, hid_t dst_id, H5T_cdata_t *cdata, size_t nelmts,
-                                   size_t buf_stride, size_t bkg_stride, void *buf, void *bkg);
-H5_DLL herr_t H5T__conv_schar_ulong(hid_t src_id, hid_t dst_id, H5T_cdata_t *cdata, size_t nelmts,
-                                    size_t buf_stride, size_t bkg_stride, void *buf, void *bkg);
-H5_DLL herr_t H5T__conv_uchar_long(hid_t src_id, hid_t dst_id, H5T_cdata_t *cdata, size_t nelmts,
-                                   size_t buf_stride, size_t bkg_stride, void *buf, void *bkg);
-H5_DLL herr_t H5T__conv_uchar_ulong(hid_t src_id, hid_t dst_id, H5T_cdata_t *cdata, size_t nelmts,
-                                    size_t buf_stride, size_t bkg_stride, void *buf, void *bkg);
-H5_DLL herr_t H5T__conv_schar_llong(hid_t src_id, hid_t dst_id, H5T_cdata_t *cdata, size_t nelmts,
-                                    size_t buf_stride, size_t bkg_stride, void *buf, void *bkg);
-H5_DLL herr_t H5T__conv_schar_ullong(hid_t src_id, hid_t dst_id, H5T_cdata_t *cdata, size_t nelmts,
-                                     size_t buf_stride, size_t bkg_stride, void *buf, void *bkg);
-H5_DLL herr_t H5T__conv_uchar_llong(hid_t src_id, hid_t dst_id, H5T_cdata_t *cdata, size_t nelmts,
-                                    size_t buf_stride, size_t bkg_stride, void *buf, void *bkg);
-H5_DLL herr_t H5T__conv_uchar_ullong(hid_t src_id, hid_t dst_id, H5T_cdata_t *cdata, size_t nelmts,
-                                     size_t buf_stride, size_t bkg_stride, void *buf, void *bkg);
+H5_DLL herr_t H5T__conv_schar_uchar(H5T_t *src, H5T_t *dst, H5T_cdata_t *cdata,
+                                    const H5T_conv_ctx_t *conv_ctx, size_t nelmts, size_t buf_stride,
+                                    size_t bkg_stride, void *buf, void *bkg);
+H5_DLL herr_t H5T__conv_uchar_schar(H5T_t *src, H5T_t *dst, H5T_cdata_t *cdata,
+                                    const H5T_conv_ctx_t *conv_ctx, size_t nelmts, size_t buf_stride,
+                                    size_t bkg_stride, void *buf, void *bkg);
+H5_DLL herr_t H5T__conv_schar_short(H5T_t *src, H5T_t *dst, H5T_cdata_t *cdata,
+                                    const H5T_conv_ctx_t *conv_ctx, size_t nelmts, size_t buf_stride,
+                                    size_t bkg_stride, void *buf, void *bkg);
+H5_DLL herr_t H5T__conv_schar_ushort(H5T_t *src, H5T_t *dst, H5T_cdata_t *cdata,
+                                     const H5T_conv_ctx_t *conv_ctx, size_t nelmts, size_t buf_stride,
+                                     size_t bkg_stride, void *buf, void *bkg);
+H5_DLL herr_t H5T__conv_uchar_short(H5T_t *src, H5T_t *dst, H5T_cdata_t *cdata,
+                                    const H5T_conv_ctx_t *conv_ctx, size_t nelmts, size_t buf_stride,
+                                    size_t bkg_stride, void *buf, void *bkg);
+H5_DLL herr_t H5T__conv_uchar_ushort(H5T_t *src, H5T_t *dst, H5T_cdata_t *cdata,
+                                     const H5T_conv_ctx_t *conv_ctx, size_t nelmts, size_t buf_stride,
+                                     size_t bkg_stride, void *buf, void *bkg);
+H5_DLL herr_t H5T__conv_schar_int(H5T_t *src, H5T_t *dst, H5T_cdata_t *cdata, const H5T_conv_ctx_t *conv_ctx,
+                                  size_t nelmts, size_t buf_stride, size_t bkg_stride, void *buf, void *bkg);
+H5_DLL herr_t H5T__conv_schar_uint(H5T_t *src, H5T_t *dst, H5T_cdata_t *cdata, const H5T_conv_ctx_t *conv_ctx,
+                                   size_t nelmts, size_t buf_stride, size_t bkg_stride, void *buf, void *bkg);
+H5_DLL herr_t H5T__conv_uchar_int(H5T_t *src, H5T_t *dst, H5T_cdata_t *cdata, const H5T_conv_ctx_t *conv_ctx,
+                                  size_t nelmts, size_t buf_stride, size_t bkg_stride, void *buf, void *bkg);
+H5_DLL herr_t H5T__conv_uchar_uint(H5T_t *src, H5T_t *dst, H5T_cdata_t *cdata, const H5T_conv_ctx_t *conv_ctx,
+                                   size_t nelmts, size_t buf_stride, size_t bkg_stride, void *buf, void *bkg);
+H5_DLL herr_t H5T__conv_schar_long(H5T_t *src, H5T_t *dst, H5T_cdata_t *cdata, const H5T_conv_ctx_t *conv_ctx,
+                                   size_t nelmts, size_t buf_stride, size_t bkg_stride, void *buf, void *bkg);
+H5_DLL herr_t H5T__conv_schar_ulong(H5T_t *src, H5T_t *dst, H5T_cdata_t *cdata,
+                                    const H5T_conv_ctx_t *conv_ctx, size_t nelmts, size_t buf_stride,
+                                    size_t bkg_stride, void *buf, void *bkg);
+H5_DLL herr_t H5T__conv_uchar_long(H5T_t *src, H5T_t *dst, H5T_cdata_t *cdata, const H5T_conv_ctx_t *conv_ctx,
+                                   size_t nelmts, size_t buf_stride, size_t bkg_stride, void *buf, void *bkg);
+H5_DLL herr_t H5T__conv_uchar_ulong(H5T_t *src, H5T_t *dst, H5T_cdata_t *cdata,
+                                    const H5T_conv_ctx_t *conv_ctx, size_t nelmts, size_t buf_stride,
+                                    size_t bkg_stride, void *buf, void *bkg);
+H5_DLL herr_t H5T__conv_schar_llong(H5T_t *src, H5T_t *dst, H5T_cdata_t *cdata,
+                                    const H5T_conv_ctx_t *conv_ctx, size_t nelmts, size_t buf_stride,
+                                    size_t bkg_stride, void *buf, void *bkg);
+H5_DLL herr_t H5T__conv_schar_ullong(H5T_t *src, H5T_t *dst, H5T_cdata_t *cdata,
+                                     const H5T_conv_ctx_t *conv_ctx, size_t nelmts, size_t buf_stride,
+                                     size_t bkg_stride, void *buf, void *bkg);
+H5_DLL herr_t H5T__conv_uchar_llong(H5T_t *src, H5T_t *dst, H5T_cdata_t *cdata,
+                                    const H5T_conv_ctx_t *conv_ctx, size_t nelmts, size_t buf_stride,
+                                    size_t bkg_stride, void *buf, void *bkg);
+H5_DLL herr_t H5T__conv_uchar_ullong(H5T_t *src, H5T_t *dst, H5T_cdata_t *cdata,
+                                     const H5T_conv_ctx_t *conv_ctx, size_t nelmts, size_t buf_stride,
+                                     size_t bkg_stride, void *buf, void *bkg);
 
-H5_DLL herr_t H5T__conv_short_schar(hid_t src_id, hid_t dst_id, H5T_cdata_t *cdata, size_t nelmts,
-                                    size_t buf_stride, size_t bkg_stride, void *buf, void *bkg);
-H5_DLL herr_t H5T__conv_short_uchar(hid_t src_id, hid_t dst_id, H5T_cdata_t *cdata, size_t nelmts,
-                                    size_t buf_stride, size_t bkg_stride, void *buf, void *bkg);
-H5_DLL herr_t H5T__conv_ushort_schar(hid_t src_id, hid_t dst_id, H5T_cdata_t *cdata, size_t nelmts,
-                                     size_t buf_stride, size_t bkg_stride, void *buf, void *bkg);
-H5_DLL herr_t H5T__conv_ushort_uchar(hid_t src_id, hid_t dst_id, H5T_cdata_t *cdata, size_t nelmts,
-                                     size_t buf_stride, size_t bkg_stride, void *buf, void *bkg);
-H5_DLL herr_t H5T__conv_short_ushort(hid_t src_id, hid_t dst_id, H5T_cdata_t *cdata, size_t nelmts,
-                                     size_t buf_stride, size_t bkg_stride, void *buf, void *bkg);
-H5_DLL herr_t H5T__conv_ushort_short(hid_t src_id, hid_t dst_id, H5T_cdata_t *cdata, size_t nelmts,
-                                     size_t buf_stride, size_t bkg_stride, void *buf, void *bkg);
-H5_DLL herr_t H5T__conv_short_int(hid_t src_id, hid_t dst_id, H5T_cdata_t *cdata, size_t nelmts,
-                                  size_t buf_stride, size_t bkg_stride, void *buf, void *bkg);
-H5_DLL herr_t H5T__conv_short_uint(hid_t src_id, hid_t dst_id, H5T_cdata_t *cdata, size_t nelmts,
-                                   size_t buf_stride, size_t bkg_stride, void *buf, void *bkg);
-H5_DLL herr_t H5T__conv_ushort_int(hid_t src_id, hid_t dst_id, H5T_cdata_t *cdata, size_t nelmts,
-                                   size_t buf_stride, size_t bkg_stride, void *buf, void *bkg);
-H5_DLL herr_t H5T__conv_ushort_uint(hid_t src_id, hid_t dst_id, H5T_cdata_t *cdata, size_t nelmts,
-                                    size_t buf_stride, size_t bkg_stride, void *buf, void *bkg);
-H5_DLL herr_t H5T__conv_short_long(hid_t src_id, hid_t dst_id, H5T_cdata_t *cdata, size_t nelmts,
-                                   size_t buf_stride, size_t bkg_stride, void *buf, void *bkg);
-H5_DLL herr_t H5T__conv_short_ulong(hid_t src_id, hid_t dst_id, H5T_cdata_t *cdata, size_t nelmts,
-                                    size_t buf_stride, size_t bkg_stride, void *buf, void *bkg);
-H5_DLL herr_t H5T__conv_ushort_long(hid_t src_id, hid_t dst_id, H5T_cdata_t *cdata, size_t nelmts,
-                                    size_t buf_stride, size_t bkg_stride, void *buf, void *bkg);
-H5_DLL herr_t H5T__conv_ushort_ulong(hid_t src_id, hid_t dst_id, H5T_cdata_t *cdata, size_t nelmts,
-                                     size_t buf_stride, size_t bkg_stride, void *buf, void *bkg);
-H5_DLL herr_t H5T__conv_short_llong(hid_t src_id, hid_t dst_id, H5T_cdata_t *cdata, size_t nelmts,
-                                    size_t buf_stride, size_t bkg_stride, void *buf, void *bkg);
-H5_DLL herr_t H5T__conv_short_ullong(hid_t src_id, hid_t dst_id, H5T_cdata_t *cdata, size_t nelmts,
-                                     size_t buf_stride, size_t bkg_stride, void *buf, void *bkg);
-H5_DLL herr_t H5T__conv_ushort_llong(hid_t src_id, hid_t dst_id, H5T_cdata_t *cdata, size_t nelmts,
-                                     size_t buf_stride, size_t bkg_stride, void *buf, void *bkg);
-H5_DLL herr_t H5T__conv_ushort_ullong(hid_t src_id, hid_t dst_id, H5T_cdata_t *cdata, size_t nelmts,
-                                      size_t buf_stride, size_t bkg_stride, void *buf, void *bkg);
+H5_DLL herr_t H5T__conv_short_schar(H5T_t *src, H5T_t *dst, H5T_cdata_t *cdata,
+                                    const H5T_conv_ctx_t *conv_ctx, size_t nelmts, size_t buf_stride,
+                                    size_t bkg_stride, void *buf, void *bkg);
+H5_DLL herr_t H5T__conv_short_uchar(H5T_t *src, H5T_t *dst, H5T_cdata_t *cdata,
+                                    const H5T_conv_ctx_t *conv_ctx, size_t nelmts, size_t buf_stride,
+                                    size_t bkg_stride, void *buf, void *bkg);
+H5_DLL herr_t H5T__conv_ushort_schar(H5T_t *src, H5T_t *dst, H5T_cdata_t *cdata,
+                                     const H5T_conv_ctx_t *conv_ctx, size_t nelmts, size_t buf_stride,
+                                     size_t bkg_stride, void *buf, void *bkg);
+H5_DLL herr_t H5T__conv_ushort_uchar(H5T_t *src, H5T_t *dst, H5T_cdata_t *cdata,
+                                     const H5T_conv_ctx_t *conv_ctx, size_t nelmts, size_t buf_stride,
+                                     size_t bkg_stride, void *buf, void *bkg);
+H5_DLL herr_t H5T__conv_short_ushort(H5T_t *src, H5T_t *dst, H5T_cdata_t *cdata,
+                                     const H5T_conv_ctx_t *conv_ctx, size_t nelmts, size_t buf_stride,
+                                     size_t bkg_stride, void *buf, void *bkg);
+H5_DLL herr_t H5T__conv_ushort_short(H5T_t *src, H5T_t *dst, H5T_cdata_t *cdata,
+                                     const H5T_conv_ctx_t *conv_ctx, size_t nelmts, size_t buf_stride,
+                                     size_t bkg_stride, void *buf, void *bkg);
+H5_DLL herr_t H5T__conv_short_int(H5T_t *src, H5T_t *dst, H5T_cdata_t *cdata, const H5T_conv_ctx_t *conv_ctx,
+                                  size_t nelmts, size_t buf_stride, size_t bkg_stride, void *buf, void *bkg);
+H5_DLL herr_t H5T__conv_short_uint(H5T_t *src, H5T_t *dst, H5T_cdata_t *cdata, const H5T_conv_ctx_t *conv_ctx,
+                                   size_t nelmts, size_t buf_stride, size_t bkg_stride, void *buf, void *bkg);
+H5_DLL herr_t H5T__conv_ushort_int(H5T_t *src, H5T_t *dst, H5T_cdata_t *cdata, const H5T_conv_ctx_t *conv_ctx,
+                                   size_t nelmts, size_t buf_stride, size_t bkg_stride, void *buf, void *bkg);
+H5_DLL herr_t H5T__conv_ushort_uint(H5T_t *src, H5T_t *dst, H5T_cdata_t *cdata,
+                                    const H5T_conv_ctx_t *conv_ctx, size_t nelmts, size_t buf_stride,
+                                    size_t bkg_stride, void *buf, void *bkg);
+H5_DLL herr_t H5T__conv_short_long(H5T_t *src, H5T_t *dst, H5T_cdata_t *cdata, const H5T_conv_ctx_t *conv_ctx,
+                                   size_t nelmts, size_t buf_stride, size_t bkg_stride, void *buf, void *bkg);
+H5_DLL herr_t H5T__conv_short_ulong(H5T_t *src, H5T_t *dst, H5T_cdata_t *cdata,
+                                    const H5T_conv_ctx_t *conv_ctx, size_t nelmts, size_t buf_stride,
+                                    size_t bkg_stride, void *buf, void *bkg);
+H5_DLL herr_t H5T__conv_ushort_long(H5T_t *src, H5T_t *dst, H5T_cdata_t *cdata,
+                                    const H5T_conv_ctx_t *conv_ctx, size_t nelmts, size_t buf_stride,
+                                    size_t bkg_stride, void *buf, void *bkg);
+H5_DLL herr_t H5T__conv_ushort_ulong(H5T_t *src, H5T_t *dst, H5T_cdata_t *cdata,
+                                     const H5T_conv_ctx_t *conv_ctx, size_t nelmts, size_t buf_stride,
+                                     size_t bkg_stride, void *buf, void *bkg);
+H5_DLL herr_t H5T__conv_short_llong(H5T_t *src, H5T_t *dst, H5T_cdata_t *cdata,
+                                    const H5T_conv_ctx_t *conv_ctx, size_t nelmts, size_t buf_stride,
+                                    size_t bkg_stride, void *buf, void *bkg);
+H5_DLL herr_t H5T__conv_short_ullong(H5T_t *src, H5T_t *dst, H5T_cdata_t *cdata,
+                                     const H5T_conv_ctx_t *conv_ctx, size_t nelmts, size_t buf_stride,
+                                     size_t bkg_stride, void *buf, void *bkg);
+H5_DLL herr_t H5T__conv_ushort_llong(H5T_t *src, H5T_t *dst, H5T_cdata_t *cdata,
+                                     const H5T_conv_ctx_t *conv_ctx, size_t nelmts, size_t buf_stride,
+                                     size_t bkg_stride, void *buf, void *bkg);
+H5_DLL herr_t H5T__conv_ushort_ullong(H5T_t *src, H5T_t *dst, H5T_cdata_t *cdata,
+                                      const H5T_conv_ctx_t *conv_ctx, size_t nelmts, size_t buf_stride,
+                                      size_t bkg_stride, void *buf, void *bkg);
 
-H5_DLL herr_t H5T__conv_int_schar(hid_t src_id, hid_t dst_id, H5T_cdata_t *cdata, size_t nelmts,
-                                  size_t buf_stride, size_t bkg_stride, void *buf, void *bkg);
-H5_DLL herr_t H5T__conv_int_uchar(hid_t src_id, hid_t dst_id, H5T_cdata_t *cdata, size_t nelmts,
-                                  size_t buf_stride, size_t bkg_stride, void *buf, void *bkg);
-H5_DLL herr_t H5T__conv_uint_schar(hid_t src_id, hid_t dst_id, H5T_cdata_t *cdata, size_t nelmts,
-                                   size_t buf_stride, size_t bkg_stride, void *buf, void *bkg);
-H5_DLL herr_t H5T__conv_uint_uchar(hid_t src_id, hid_t dst_id, H5T_cdata_t *cdata, size_t nelmts,
-                                   size_t buf_stride, size_t bkg_stride, void *buf, void *bkg);
-H5_DLL herr_t H5T__conv_int_short(hid_t src_id, hid_t dst_id, H5T_cdata_t *cdata, size_t nelmts,
-                                  size_t buf_stride, size_t bkg_stride, void *buf, void *bkg);
-H5_DLL herr_t H5T__conv_int_ushort(hid_t src_id, hid_t dst_id, H5T_cdata_t *cdata, size_t nelmts,
-                                   size_t buf_stride, size_t bkg_stride, void *buf, void *bkg);
-H5_DLL herr_t H5T__conv_uint_short(hid_t src_id, hid_t dst_id, H5T_cdata_t *cdata, size_t nelmts,
-                                   size_t buf_stride, size_t bkg_stride, void *buf, void *bkg);
-H5_DLL herr_t H5T__conv_uint_ushort(hid_t src_id, hid_t dst_id, H5T_cdata_t *cdata, size_t nelmts,
-                                    size_t buf_stride, size_t bkg_stride, void *buf, void *bkg);
-H5_DLL herr_t H5T__conv_int_uint(hid_t src_id, hid_t dst_id, H5T_cdata_t *cdata, size_t nelmts,
-                                 size_t buf_stride, size_t bkg_stride, void *buf, void *bkg);
-H5_DLL herr_t H5T__conv_uint_int(hid_t src_id, hid_t dst_id, H5T_cdata_t *cdata, size_t nelmts,
-                                 size_t buf_stride, size_t bkg_stride, void *buf, void *bkg);
-H5_DLL herr_t H5T__conv_int_long(hid_t src_id, hid_t dst_id, H5T_cdata_t *cdata, size_t nelmts,
-                                 size_t buf_stride, size_t bkg_stride, void *buf, void *bkg);
-H5_DLL herr_t H5T__conv_int_ulong(hid_t src_id, hid_t dst_id, H5T_cdata_t *cdata, size_t nelmts,
-                                  size_t buf_stride, size_t bkg_stride, void *buf, void *bkg);
-H5_DLL herr_t H5T__conv_uint_long(hid_t src_id, hid_t dst_id, H5T_cdata_t *cdata, size_t nelmts,
-                                  size_t buf_stride, size_t bkg_stride, void *buf, void *bkg);
-H5_DLL herr_t H5T__conv_uint_ulong(hid_t src_id, hid_t dst_id, H5T_cdata_t *cdata, size_t nelmts,
-                                   size_t buf_stride, size_t bkg_stride, void *buf, void *bkg);
-H5_DLL herr_t H5T__conv_int_llong(hid_t src_id, hid_t dst_id, H5T_cdata_t *cdata, size_t nelmts,
-                                  size_t buf_stride, size_t bkg_stride, void *buf, void *bkg);
-H5_DLL herr_t H5T__conv_int_ullong(hid_t src_id, hid_t dst_id, H5T_cdata_t *cdata, size_t nelmts,
-                                   size_t buf_stride, size_t bkg_stride, void *buf, void *bkg);
-H5_DLL herr_t H5T__conv_uint_llong(hid_t src_id, hid_t dst_id, H5T_cdata_t *cdata, size_t nelmts,
-                                   size_t buf_stride, size_t bkg_stride, void *buf, void *bkg);
-H5_DLL herr_t H5T__conv_uint_ullong(hid_t src_id, hid_t dst_id, H5T_cdata_t *cdata, size_t nelmts,
-                                    size_t buf_stride, size_t bkg_stride, void *buf, void *bkg);
+H5_DLL herr_t H5T__conv_int_schar(H5T_t *src, H5T_t *dst, H5T_cdata_t *cdata, const H5T_conv_ctx_t *conv_ctx,
+                                  size_t nelmts, size_t buf_stride, size_t bkg_stride, void *buf, void *bkg);
+H5_DLL herr_t H5T__conv_int_uchar(H5T_t *src, H5T_t *dst, H5T_cdata_t *cdata, const H5T_conv_ctx_t *conv_ctx,
+                                  size_t nelmts, size_t buf_stride, size_t bkg_stride, void *buf, void *bkg);
+H5_DLL herr_t H5T__conv_uint_schar(H5T_t *src, H5T_t *dst, H5T_cdata_t *cdata, const H5T_conv_ctx_t *conv_ctx,
+                                   size_t nelmts, size_t buf_stride, size_t bkg_stride, void *buf, void *bkg);
+H5_DLL herr_t H5T__conv_uint_uchar(H5T_t *src, H5T_t *dst, H5T_cdata_t *cdata, const H5T_conv_ctx_t *conv_ctx,
+                                   size_t nelmts, size_t buf_stride, size_t bkg_stride, void *buf, void *bkg);
+H5_DLL herr_t H5T__conv_int_short(H5T_t *src, H5T_t *dst, H5T_cdata_t *cdata, const H5T_conv_ctx_t *conv_ctx,
+                                  size_t nelmts, size_t buf_stride, size_t bkg_stride, void *buf, void *bkg);
+H5_DLL herr_t H5T__conv_int_ushort(H5T_t *src, H5T_t *dst, H5T_cdata_t *cdata, const H5T_conv_ctx_t *conv_ctx,
+                                   size_t nelmts, size_t buf_stride, size_t bkg_stride, void *buf, void *bkg);
+H5_DLL herr_t H5T__conv_uint_short(H5T_t *src, H5T_t *dst, H5T_cdata_t *cdata, const H5T_conv_ctx_t *conv_ctx,
+                                   size_t nelmts, size_t buf_stride, size_t bkg_stride, void *buf, void *bkg);
+H5_DLL herr_t H5T__conv_uint_ushort(H5T_t *src, H5T_t *dst, H5T_cdata_t *cdata,
+                                    const H5T_conv_ctx_t *conv_ctx, size_t nelmts, size_t buf_stride,
+                                    size_t bkg_stride, void *buf, void *bkg);
+H5_DLL herr_t H5T__conv_int_uint(H5T_t *src, H5T_t *dst, H5T_cdata_t *cdata, const H5T_conv_ctx_t *conv_ctx,
+                                 size_t nelmts, size_t buf_stride, size_t bkg_stride, void *buf, void *bkg);
+H5_DLL herr_t H5T__conv_uint_int(H5T_t *src, H5T_t *dst, H5T_cdata_t *cdata, const H5T_conv_ctx_t *conv_ctx,
+                                 size_t nelmts, size_t buf_stride, size_t bkg_stride, void *buf, void *bkg);
+H5_DLL herr_t H5T__conv_int_long(H5T_t *src, H5T_t *dst, H5T_cdata_t *cdata, const H5T_conv_ctx_t *conv_ctx,
+                                 size_t nelmts, size_t buf_stride, size_t bkg_stride, void *buf, void *bkg);
+H5_DLL herr_t H5T__conv_int_ulong(H5T_t *src, H5T_t *dst, H5T_cdata_t *cdata, const H5T_conv_ctx_t *conv_ctx,
+                                  size_t nelmts, size_t buf_stride, size_t bkg_stride, void *buf, void *bkg);
+H5_DLL herr_t H5T__conv_uint_long(H5T_t *src, H5T_t *dst, H5T_cdata_t *cdata, const H5T_conv_ctx_t *conv_ctx,
+                                  size_t nelmts, size_t buf_stride, size_t bkg_stride, void *buf, void *bkg);
+H5_DLL herr_t H5T__conv_uint_ulong(H5T_t *src, H5T_t *dst, H5T_cdata_t *cdata, const H5T_conv_ctx_t *conv_ctx,
+                                   size_t nelmts, size_t buf_stride, size_t bkg_stride, void *buf, void *bkg);
+H5_DLL herr_t H5T__conv_int_llong(H5T_t *src, H5T_t *dst, H5T_cdata_t *cdata, const H5T_conv_ctx_t *conv_ctx,
+                                  size_t nelmts, size_t buf_stride, size_t bkg_stride, void *buf, void *bkg);
+H5_DLL herr_t H5T__conv_int_ullong(H5T_t *src, H5T_t *dst, H5T_cdata_t *cdata, const H5T_conv_ctx_t *conv_ctx,
+                                   size_t nelmts, size_t buf_stride, size_t bkg_stride, void *buf, void *bkg);
+H5_DLL herr_t H5T__conv_uint_llong(H5T_t *src, H5T_t *dst, H5T_cdata_t *cdata, const H5T_conv_ctx_t *conv_ctx,
+                                   size_t nelmts, size_t buf_stride, size_t bkg_stride, void *buf, void *bkg);
+H5_DLL herr_t H5T__conv_uint_ullong(H5T_t *src, H5T_t *dst, H5T_cdata_t *cdata,
+                                    const H5T_conv_ctx_t *conv_ctx, size_t nelmts, size_t buf_stride,
+                                    size_t bkg_stride, void *buf, void *bkg);
 
-H5_DLL herr_t H5T__conv_long_schar(hid_t src_id, hid_t dst_id, H5T_cdata_t *cdata, size_t nelmts,
-                                   size_t buf_stride, size_t bkg_stride, void *buf, void *bkg);
-H5_DLL herr_t H5T__conv_long_uchar(hid_t src_id, hid_t dst_id, H5T_cdata_t *cdata, size_t nelmts,
-                                   size_t buf_stride, size_t bkg_stride, void *buf, void *bkg);
-H5_DLL herr_t H5T__conv_ulong_schar(hid_t src_id, hid_t dst_id, H5T_cdata_t *cdata, size_t nelmts,
-                                    size_t buf_stride, size_t bkg_stride, void *buf, void *bkg);
-H5_DLL herr_t H5T__conv_ulong_uchar(hid_t src_id, hid_t dst_id, H5T_cdata_t *cdata, size_t nelmts,
-                                    size_t buf_stride, size_t bkg_stride, void *buf, void *bkg);
-H5_DLL herr_t H5T__conv_long_short(hid_t src_id, hid_t dst_id, H5T_cdata_t *cdata, size_t nelmts,
-                                   size_t buf_stride, size_t bkg_stride, void *buf, void *bkg);
-H5_DLL herr_t H5T__conv_long_ushort(hid_t src_id, hid_t dst_id, H5T_cdata_t *cdata, size_t nelmts,
-                                    size_t buf_stride, size_t bkg_stride, void *buf, void *bkg);
-H5_DLL herr_t H5T__conv_ulong_short(hid_t src_id, hid_t dst_id, H5T_cdata_t *cdata, size_t nelmts,
-                                    size_t buf_stride, size_t bkg_stride, void *buf, void *bkg);
-H5_DLL herr_t H5T__conv_ulong_ushort(hid_t src_id, hid_t dst_id, H5T_cdata_t *cdata, size_t nelmts,
-                                     size_t buf_stride, size_t bkg_stride, void *buf, void *bkg);
-H5_DLL herr_t H5T__conv_long_int(hid_t src_id, hid_t dst_id, H5T_cdata_t *cdata, size_t nelmts,
-                                 size_t buf_stride, size_t bkg_stride, void *buf, void *bkg);
-H5_DLL herr_t H5T__conv_long_uint(hid_t src_id, hid_t dst_id, H5T_cdata_t *cdata, size_t nelmts,
-                                  size_t buf_stride, size_t bkg_stride, void *buf, void *bkg);
-H5_DLL herr_t H5T__conv_ulong_int(hid_t src_id, hid_t dst_id, H5T_cdata_t *cdata, size_t nelmts,
-                                  size_t buf_stride, size_t bkg_stride, void *buf, void *bkg);
-H5_DLL herr_t H5T__conv_ulong_uint(hid_t src_id, hid_t dst_id, H5T_cdata_t *cdata, size_t nelmts,
-                                   size_t buf_stride, size_t bkg_stride, void *buf, void *bkg);
-H5_DLL herr_t H5T__conv_long_ulong(hid_t src_id, hid_t dst_id, H5T_cdata_t *cdata, size_t nelmts,
-                                   size_t buf_stride, size_t bkg_stride, void *buf, void *bkg);
-H5_DLL herr_t H5T__conv_ulong_long(hid_t src_id, hid_t dst_id, H5T_cdata_t *cdata, size_t nelmts,
-                                   size_t buf_stride, size_t bkg_stride, void *buf, void *bkg);
-H5_DLL herr_t H5T__conv_long_llong(hid_t src_id, hid_t dst_id, H5T_cdata_t *cdata, size_t nelmts,
-                                   size_t buf_stride, size_t bkg_stride, void *buf, void *bkg);
-H5_DLL herr_t H5T__conv_long_ullong(hid_t src_id, hid_t dst_id, H5T_cdata_t *cdata, size_t nelmts,
-                                    size_t buf_stride, size_t bkg_stride, void *buf, void *bkg);
-H5_DLL herr_t H5T__conv_ulong_llong(hid_t src_id, hid_t dst_id, H5T_cdata_t *cdata, size_t nelmts,
-                                    size_t buf_stride, size_t bkg_stride, void *buf, void *bkg);
-H5_DLL herr_t H5T__conv_ulong_ullong(hid_t src_id, hid_t dst_id, H5T_cdata_t *cdata, size_t nelmts,
-                                     size_t buf_stride, size_t bkg_stride, void *buf, void *bkg);
+H5_DLL herr_t H5T__conv_long_schar(H5T_t *src, H5T_t *dst, H5T_cdata_t *cdata, const H5T_conv_ctx_t *conv_ctx,
+                                   size_t nelmts, size_t buf_stride, size_t bkg_stride, void *buf, void *bkg);
+H5_DLL herr_t H5T__conv_long_uchar(H5T_t *src, H5T_t *dst, H5T_cdata_t *cdata, const H5T_conv_ctx_t *conv_ctx,
+                                   size_t nelmts, size_t buf_stride, size_t bkg_stride, void *buf, void *bkg);
+H5_DLL herr_t H5T__conv_ulong_schar(H5T_t *src, H5T_t *dst, H5T_cdata_t *cdata,
+                                    const H5T_conv_ctx_t *conv_ctx, size_t nelmts, size_t buf_stride,
+                                    size_t bkg_stride, void *buf, void *bkg);
+H5_DLL herr_t H5T__conv_ulong_uchar(H5T_t *src, H5T_t *dst, H5T_cdata_t *cdata,
+                                    const H5T_conv_ctx_t *conv_ctx, size_t nelmts, size_t buf_stride,
+                                    size_t bkg_stride, void *buf, void *bkg);
+H5_DLL herr_t H5T__conv_long_short(H5T_t *src, H5T_t *dst, H5T_cdata_t *cdata, const H5T_conv_ctx_t *conv_ctx,
+                                   size_t nelmts, size_t buf_stride, size_t bkg_stride, void *buf, void *bkg);
+H5_DLL herr_t H5T__conv_long_ushort(H5T_t *src, H5T_t *dst, H5T_cdata_t *cdata,
+                                    const H5T_conv_ctx_t *conv_ctx, size_t nelmts, size_t buf_stride,
+                                    size_t bkg_stride, void *buf, void *bkg);
+H5_DLL herr_t H5T__conv_ulong_short(H5T_t *src, H5T_t *dst, H5T_cdata_t *cdata,
+                                    const H5T_conv_ctx_t *conv_ctx, size_t nelmts, size_t buf_stride,
+                                    size_t bkg_stride, void *buf, void *bkg);
+H5_DLL herr_t H5T__conv_ulong_ushort(H5T_t *src, H5T_t *dst, H5T_cdata_t *cdata,
+                                     const H5T_conv_ctx_t *conv_ctx, size_t nelmts, size_t buf_stride,
+                                     size_t bkg_stride, void *buf, void *bkg);
+H5_DLL herr_t H5T__conv_long_int(H5T_t *src, H5T_t *dst, H5T_cdata_t *cdata, const H5T_conv_ctx_t *conv_ctx,
+                                 size_t nelmts, size_t buf_stride, size_t bkg_stride, void *buf, void *bkg);
+H5_DLL herr_t H5T__conv_long_uint(H5T_t *src, H5T_t *dst, H5T_cdata_t *cdata, const H5T_conv_ctx_t *conv_ctx,
+                                  size_t nelmts, size_t buf_stride, size_t bkg_stride, void *buf, void *bkg);
+H5_DLL herr_t H5T__conv_ulong_int(H5T_t *src, H5T_t *dst, H5T_cdata_t *cdata, const H5T_conv_ctx_t *conv_ctx,
+                                  size_t nelmts, size_t buf_stride, size_t bkg_stride, void *buf, void *bkg);
+H5_DLL herr_t H5T__conv_ulong_uint(H5T_t *src, H5T_t *dst, H5T_cdata_t *cdata, const H5T_conv_ctx_t *conv_ctx,
+                                   size_t nelmts, size_t buf_stride, size_t bkg_stride, void *buf, void *bkg);
+H5_DLL herr_t H5T__conv_long_ulong(H5T_t *src, H5T_t *dst, H5T_cdata_t *cdata, const H5T_conv_ctx_t *conv_ctx,
+                                   size_t nelmts, size_t buf_stride, size_t bkg_stride, void *buf, void *bkg);
+H5_DLL herr_t H5T__conv_ulong_long(H5T_t *src, H5T_t *dst, H5T_cdata_t *cdata, const H5T_conv_ctx_t *conv_ctx,
+                                   size_t nelmts, size_t buf_stride, size_t bkg_stride, void *buf, void *bkg);
+H5_DLL herr_t H5T__conv_long_llong(H5T_t *src, H5T_t *dst, H5T_cdata_t *cdata, const H5T_conv_ctx_t *conv_ctx,
+                                   size_t nelmts, size_t buf_stride, size_t bkg_stride, void *buf, void *bkg);
+H5_DLL herr_t H5T__conv_long_ullong(H5T_t *src, H5T_t *dst, H5T_cdata_t *cdata,
+                                    const H5T_conv_ctx_t *conv_ctx, size_t nelmts, size_t buf_stride,
+                                    size_t bkg_stride, void *buf, void *bkg);
+H5_DLL herr_t H5T__conv_ulong_llong(H5T_t *src, H5T_t *dst, H5T_cdata_t *cdata,
+                                    const H5T_conv_ctx_t *conv_ctx, size_t nelmts, size_t buf_stride,
+                                    size_t bkg_stride, void *buf, void *bkg);
+H5_DLL herr_t H5T__conv_ulong_ullong(H5T_t *src, H5T_t *dst, H5T_cdata_t *cdata,
+                                     const H5T_conv_ctx_t *conv_ctx, size_t nelmts, size_t buf_stride,
+                                     size_t bkg_stride, void *buf, void *bkg);
 
-H5_DLL herr_t H5T__conv_llong_schar(hid_t src_id, hid_t dst_id, H5T_cdata_t *cdata, size_t nelmts,
-                                    size_t buf_stride, size_t bkg_stride, void *buf, void *bkg);
-H5_DLL herr_t H5T__conv_llong_uchar(hid_t src_id, hid_t dst_id, H5T_cdata_t *cdata, size_t nelmts,
-                                    size_t buf_stride, size_t bkg_stride, void *buf, void *bkg);
-H5_DLL herr_t H5T__conv_ullong_schar(hid_t src_id, hid_t dst_id, H5T_cdata_t *cdata, size_t nelmts,
-                                     size_t buf_stride, size_t bkg_stride, void *buf, void *bkg);
-H5_DLL herr_t H5T__conv_ullong_uchar(hid_t src_id, hid_t dst_id, H5T_cdata_t *cdata, size_t nelmts,
-                                     size_t buf_stride, size_t bkg_stride, void *buf, void *bkg);
-H5_DLL herr_t H5T__conv_llong_short(hid_t src_id, hid_t dst_id, H5T_cdata_t *cdata, size_t nelmts,
-                                    size_t buf_stride, size_t bkg_stride, void *buf, void *bkg);
-H5_DLL herr_t H5T__conv_llong_ushort(hid_t src_id, hid_t dst_id, H5T_cdata_t *cdata, size_t nelmts,
-                                     size_t buf_stride, size_t bkg_stride, void *buf, void *bkg);
-H5_DLL herr_t H5T__conv_ullong_short(hid_t src_id, hid_t dst_id, H5T_cdata_t *cdata, size_t nelmts,
-                                     size_t buf_stride, size_t bkg_stride, void *buf, void *bkg);
-H5_DLL herr_t H5T__conv_ullong_ushort(hid_t src_id, hid_t dst_id, H5T_cdata_t *cdata, size_t nelmts,
-                                      size_t buf_stride, size_t bkg_stride, void *buf, void *bkg);
-H5_DLL herr_t H5T__conv_llong_int(hid_t src_id, hid_t dst_id, H5T_cdata_t *cdata, size_t nelmts,
-                                  size_t buf_stride, size_t bkg_stride, void *buf, void *bkg);
-H5_DLL herr_t H5T__conv_llong_uint(hid_t src_id, hid_t dst_id, H5T_cdata_t *cdata, size_t nelmts,
-                                   size_t buf_stride, size_t bkg_stride, void *buf, void *bkg);
-H5_DLL herr_t H5T__conv_ullong_int(hid_t src_id, hid_t dst_id, H5T_cdata_t *cdata, size_t nelmts,
-                                   size_t buf_stride, size_t bkg_stride, void *buf, void *bkg);
-H5_DLL herr_t H5T__conv_ullong_uint(hid_t src_id, hid_t dst_id, H5T_cdata_t *cdata, size_t nelmts,
-                                    size_t buf_stride, size_t bkg_stride, void *buf, void *bkg);
-H5_DLL herr_t H5T__conv_llong_long(hid_t src_id, hid_t dst_id, H5T_cdata_t *cdata, size_t nelmts,
-                                   size_t buf_stride, size_t bkg_stride, void *buf, void *bkg);
-H5_DLL herr_t H5T__conv_llong_ulong(hid_t src_id, hid_t dst_id, H5T_cdata_t *cdata, size_t nelmts,
-                                    size_t buf_stride, size_t bkg_stride, void *buf, void *bkg);
-H5_DLL herr_t H5T__conv_ullong_long(hid_t src_id, hid_t dst_id, H5T_cdata_t *cdata, size_t nelmts,
-                                    size_t buf_stride, size_t bkg_stride, void *buf, void *bkg);
-H5_DLL herr_t H5T__conv_ullong_ulong(hid_t src_id, hid_t dst_id, H5T_cdata_t *cdata, size_t nelmts,
-                                     size_t buf_stride, size_t bkg_stride, void *buf, void *bkg);
-H5_DLL herr_t H5T__conv_llong_ullong(hid_t src_id, hid_t dst_id, H5T_cdata_t *cdata, size_t nelmts,
-                                     size_t buf_stride, size_t bkg_stride, void *buf, void *bkg);
-H5_DLL herr_t H5T__conv_ullong_llong(hid_t src_id, hid_t dst_id, H5T_cdata_t *cdata, size_t nelmts,
-                                     size_t buf_stride, size_t bkg_stride, void *buf, void *bkg);
-H5_DLL herr_t H5T__conv_float_double(hid_t src_id, hid_t dst_id, H5T_cdata_t *cdata, size_t nelmts,
-                                     size_t buf_stride, size_t bkg_stride, void *buf, void *bkg);
-H5_DLL herr_t H5T__conv_float_ldouble(hid_t src_id, hid_t dst_id, H5T_cdata_t *cdata, size_t nelmts,
-                                      size_t buf_stride, size_t bkg_stride, void *buf, void *bkg);
-H5_DLL herr_t H5T__conv_double_float(hid_t src_id, hid_t dst_id, H5T_cdata_t *cdata, size_t nelmts,
-                                     size_t buf_stride, size_t bkg_stride, void *buf, void *bkg);
-H5_DLL herr_t H5T__conv_double_ldouble(hid_t src_id, hid_t dst_id, H5T_cdata_t *cdata, size_t nelmts,
-                                       size_t buf_stride, size_t bkg_stride, void *buf, void *bkg);
-H5_DLL herr_t H5T__conv_ldouble_float(hid_t src_id, hid_t dst_id, H5T_cdata_t *cdata, size_t nelmts,
-                                      size_t buf_stride, size_t bkg_stride, void *buf, void *bkg);
-H5_DLL herr_t H5T__conv_ldouble_double(hid_t src_id, hid_t dst_id, H5T_cdata_t *cdata, size_t nelmts,
-                                       size_t buf_stride, size_t bkg_stride, void *buf, void *bkg);
-H5_DLL herr_t H5T__conv_schar_float(hid_t src_id, hid_t dst_id, H5T_cdata_t *cdata, size_t nelmts,
-                                    size_t buf_stride, size_t bkg_stride, void *buf, void *bkg);
-H5_DLL herr_t H5T__conv_schar_double(hid_t src_id, hid_t dst_id, H5T_cdata_t *cdata, size_t nelmts,
-                                     size_t buf_stride, size_t bkg_stride, void *buf, void *bkg);
-H5_DLL herr_t H5T__conv_schar_ldouble(hid_t src_id, hid_t dst_id, H5T_cdata_t *cdata, size_t nelmts,
-                                      size_t buf_stride, size_t bkg_stride, void *buf, void *bkg);
-H5_DLL herr_t H5T__conv_uchar_float(hid_t src_id, hid_t dst_id, H5T_cdata_t *cdata, size_t nelmts,
-                                    size_t buf_stride, size_t bkg_stride, void *buf, void *bkg);
-H5_DLL herr_t H5T__conv_uchar_double(hid_t src_id, hid_t dst_id, H5T_cdata_t *cdata, size_t nelmts,
-                                     size_t buf_stride, size_t bkg_stride, void *buf, void *bkg);
-H5_DLL herr_t H5T__conv_uchar_ldouble(hid_t src_id, hid_t dst_id, H5T_cdata_t *cdata, size_t nelmts,
-                                      size_t buf_stride, size_t bkg_stride, void *buf, void *bkg);
-H5_DLL herr_t H5T__conv_short_float(hid_t src_id, hid_t dst_id, H5T_cdata_t *cdata, size_t nelmts,
-                                    size_t buf_stride, size_t bkg_stride, void *buf, void *bkg);
-H5_DLL herr_t H5T__conv_short_double(hid_t src_id, hid_t dst_id, H5T_cdata_t *cdata, size_t nelmts,
-                                     size_t buf_stride, size_t bkg_stride, void *buf, void *bkg);
-H5_DLL herr_t H5T__conv_short_ldouble(hid_t src_id, hid_t dst_id, H5T_cdata_t *cdata, size_t nelmts,
-                                      size_t buf_stride, size_t bkg_stride, void *buf, void *bkg);
-H5_DLL herr_t H5T__conv_ushort_float(hid_t src_id, hid_t dst_id, H5T_cdata_t *cdata, size_t nelmts,
-                                     size_t buf_stride, size_t bkg_stride, void *buf, void *bkg);
-H5_DLL herr_t H5T__conv_ushort_double(hid_t src_id, hid_t dst_id, H5T_cdata_t *cdata, size_t nelmts,
-                                      size_t buf_stride, size_t bkg_stride, void *buf, void *bkg);
-H5_DLL herr_t H5T__conv_ushort_ldouble(hid_t src_id, hid_t dst_id, H5T_cdata_t *cdata, size_t nelmts,
-                                       size_t buf_stride, size_t bkg_stride, void *buf, void *bkg);
-H5_DLL herr_t H5T__conv_int_float(hid_t src_id, hid_t dst_id, H5T_cdata_t *cdata, size_t nelmts,
-                                  size_t buf_stride, size_t bkg_stride, void *buf, void *bkg);
-H5_DLL herr_t H5T__conv_int_double(hid_t src_id, hid_t dst_id, H5T_cdata_t *cdata, size_t nelmts,
-                                   size_t buf_stride, size_t bkg_stride, void *buf, void *bkg);
-H5_DLL herr_t H5T__conv_int_ldouble(hid_t src_id, hid_t dst_id, H5T_cdata_t *cdata, size_t nelmts,
-                                    size_t buf_stride, size_t bkg_stride, void *buf, void *bkg);
-H5_DLL herr_t H5T__conv_uint_float(hid_t src_id, hid_t dst_id, H5T_cdata_t *cdata, size_t nelmts,
-                                   size_t buf_stride, size_t bkg_stride, void *buf, void *bkg);
-H5_DLL herr_t H5T__conv_uint_double(hid_t src_id, hid_t dst_id, H5T_cdata_t *cdata, size_t nelmts,
-                                    size_t buf_stride, size_t bkg_stride, void *buf, void *bkg);
-H5_DLL herr_t H5T__conv_uint_ldouble(hid_t src_id, hid_t dst_id, H5T_cdata_t *cdata, size_t nelmts,
-                                     size_t buf_stride, size_t bkg_stride, void *buf, void *bkg);
-H5_DLL herr_t H5T__conv_long_float(hid_t src_id, hid_t dst_id, H5T_cdata_t *cdata, size_t nelmts,
-                                   size_t buf_stride, size_t bkg_stride, void *buf, void *bkg);
-H5_DLL herr_t H5T__conv_long_double(hid_t src_id, hid_t dst_id, H5T_cdata_t *cdata, size_t nelmts,
-                                    size_t buf_stride, size_t bkg_stride, void *buf, void *bkg);
-H5_DLL herr_t H5T__conv_long_ldouble(hid_t src_id, hid_t dst_id, H5T_cdata_t *cdata, size_t nelmts,
-                                     size_t buf_stride, size_t bkg_stride, void *buf, void *bkg);
-H5_DLL herr_t H5T__conv_ulong_float(hid_t src_id, hid_t dst_id, H5T_cdata_t *cdata, size_t nelmts,
-                                    size_t buf_stride, size_t bkg_stride, void *buf, void *bkg);
-H5_DLL herr_t H5T__conv_ulong_double(hid_t src_id, hid_t dst_id, H5T_cdata_t *cdata, size_t nelmts,
-                                     size_t buf_stride, size_t bkg_stride, void *buf, void *bkg);
-H5_DLL herr_t H5T__conv_ulong_ldouble(hid_t src_id, hid_t dst_id, H5T_cdata_t *cdata, size_t nelmts,
-                                      size_t buf_stride, size_t bkg_stride, void *buf, void *bkg);
-H5_DLL herr_t H5T__conv_llong_float(hid_t src_id, hid_t dst_id, H5T_cdata_t *cdata, size_t nelmts,
-                                    size_t buf_stride, size_t bkg_stride, void *buf, void *bkg);
-H5_DLL herr_t H5T__conv_llong_double(hid_t src_id, hid_t dst_id, H5T_cdata_t *cdata, size_t nelmts,
-                                     size_t buf_stride, size_t bkg_stride, void *buf, void *bkg);
-H5_DLL herr_t H5T__conv_llong_ldouble(hid_t src_id, hid_t dst_id, H5T_cdata_t *cdata, size_t nelmts,
-                                      size_t buf_stride, size_t bkg_stride, void *buf, void *bkg);
-H5_DLL herr_t H5T__conv_ullong_float(hid_t src_id, hid_t dst_id, H5T_cdata_t *cdata, size_t nelmts,
-                                     size_t buf_stride, size_t bkg_stride, void *buf, void *bkg);
-H5_DLL herr_t H5T__conv_ullong_double(hid_t src_id, hid_t dst_id, H5T_cdata_t *cdata, size_t nelmts,
-                                      size_t buf_stride, size_t bkg_stride, void *buf, void *bkg);
-H5_DLL herr_t H5T__conv_ullong_ldouble(hid_t src_id, hid_t dst_id, H5T_cdata_t *cdata, size_t nelmts,
-                                       size_t buf_stride, size_t bkg_stride, void *buf, void *bkg);
-H5_DLL herr_t H5T__conv_float_schar(hid_t src_id, hid_t dst_id, H5T_cdata_t *cdata, size_t nelmts,
-                                    size_t buf_stride, size_t bkg_stride, void *buf, void *bkg);
-H5_DLL herr_t H5T__conv_float_uchar(hid_t src_id, hid_t dst_id, H5T_cdata_t *cdata, size_t nelmts,
-                                    size_t buf_stride, size_t bkg_stride, void *buf, void *bkg);
-H5_DLL herr_t H5T__conv_float_short(hid_t src_id, hid_t dst_id, H5T_cdata_t *cdata, size_t nelmts,
-                                    size_t buf_stride, size_t bkg_stride, void *buf, void *bkg);
-H5_DLL herr_t H5T__conv_float_ushort(hid_t src_id, hid_t dst_id, H5T_cdata_t *cdata, size_t nelmts,
-                                     size_t buf_stride, size_t bkg_stride, void *buf, void *bkg);
-H5_DLL herr_t H5T__conv_float_int(hid_t src_id, hid_t dst_id, H5T_cdata_t *cdata, size_t nelmts,
-                                  size_t buf_stride, size_t bkg_stride, void *buf, void *bkg);
-H5_DLL herr_t H5T__conv_float_uint(hid_t src_id, hid_t dst_id, H5T_cdata_t *cdata, size_t nelmts,
-                                   size_t buf_stride, size_t bkg_stride, void *buf, void *bkg);
-H5_DLL herr_t H5T__conv_float_long(hid_t src_id, hid_t dst_id, H5T_cdata_t *cdata, size_t nelmts,
-                                   size_t buf_stride, size_t bkg_stride, void *buf, void *bkg);
-H5_DLL herr_t H5T__conv_float_ulong(hid_t src_id, hid_t dst_id, H5T_cdata_t *cdata, size_t nelmts,
-                                    size_t buf_stride, size_t bkg_stride, void *buf, void *bkg);
-H5_DLL herr_t H5T__conv_float_llong(hid_t src_id, hid_t dst_id, H5T_cdata_t *cdata, size_t nelmts,
-                                    size_t buf_stride, size_t bkg_stride, void *buf, void *bkg);
-H5_DLL herr_t H5T__conv_float_ullong(hid_t src_id, hid_t dst_id, H5T_cdata_t *cdata, size_t nelmts,
-                                     size_t buf_stride, size_t bkg_stride, void *buf, void *bkg);
-H5_DLL herr_t H5T__conv_double_schar(hid_t src_id, hid_t dst_id, H5T_cdata_t *cdata, size_t nelmts,
-                                     size_t buf_stride, size_t bkg_stride, void *buf, void *bkg);
-H5_DLL herr_t H5T__conv_double_uchar(hid_t src_id, hid_t dst_id, H5T_cdata_t *cdata, size_t nelmts,
-                                     size_t buf_stride, size_t bkg_stride, void *buf, void *bkg);
-H5_DLL herr_t H5T__conv_double_short(hid_t src_id, hid_t dst_id, H5T_cdata_t *cdata, size_t nelmts,
-                                     size_t buf_stride, size_t bkg_stride, void *buf, void *bkg);
-H5_DLL herr_t H5T__conv_double_ushort(hid_t src_id, hid_t dst_id, H5T_cdata_t *cdata, size_t nelmts,
-                                      size_t buf_stride, size_t bkg_stride, void *buf, void *bkg);
-H5_DLL herr_t H5T__conv_double_int(hid_t src_id, hid_t dst_id, H5T_cdata_t *cdata, size_t nelmts,
-                                   size_t buf_stride, size_t bkg_stride, void *buf, void *bkg);
-H5_DLL herr_t H5T__conv_double_uint(hid_t src_id, hid_t dst_id, H5T_cdata_t *cdata, size_t nelmts,
-                                    size_t buf_stride, size_t bkg_stride, void *buf, void *bkg);
-H5_DLL herr_t H5T__conv_double_long(hid_t src_id, hid_t dst_id, H5T_cdata_t *cdata, size_t nelmts,
-                                    size_t buf_stride, size_t bkg_stride, void *buf, void *bkg);
-H5_DLL herr_t H5T__conv_double_ulong(hid_t src_id, hid_t dst_id, H5T_cdata_t *cdata, size_t nelmts,
-                                     size_t buf_stride, size_t bkg_stride, void *buf, void *bkg);
-H5_DLL herr_t H5T__conv_double_llong(hid_t src_id, hid_t dst_id, H5T_cdata_t *cdata, size_t nelmts,
-                                     size_t buf_stride, size_t bkg_stride, void *buf, void *bkg);
-H5_DLL herr_t H5T__conv_double_ullong(hid_t src_id, hid_t dst_id, H5T_cdata_t *cdata, size_t nelmts,
-                                      size_t buf_stride, size_t bkg_stride, void *buf, void *bkg);
-H5_DLL herr_t H5T__conv_ldouble_schar(hid_t src_id, hid_t dst_id, H5T_cdata_t *cdata, size_t nelmts,
-                                      size_t buf_stride, size_t bkg_stride, void *buf, void *bkg);
-H5_DLL herr_t H5T__conv_ldouble_uchar(hid_t src_id, hid_t dst_id, H5T_cdata_t *cdata, size_t nelmts,
-                                      size_t buf_stride, size_t bkg_stride, void *buf, void *bkg);
-H5_DLL herr_t H5T__conv_ldouble_short(hid_t src_id, hid_t dst_id, H5T_cdata_t *cdata, size_t nelmts,
-                                      size_t buf_stride, size_t bkg_stride, void *buf, void *bkg);
-H5_DLL herr_t H5T__conv_ldouble_ushort(hid_t src_id, hid_t dst_id, H5T_cdata_t *cdata, size_t nelmts,
-                                       size_t buf_stride, size_t bkg_stride, void *buf, void *bkg);
-H5_DLL herr_t H5T__conv_ldouble_int(hid_t src_id, hid_t dst_id, H5T_cdata_t *cdata, size_t nelmts,
-                                    size_t buf_stride, size_t bkg_stride, void *buf, void *bkg);
-H5_DLL herr_t H5T__conv_ldouble_uint(hid_t src_id, hid_t dst_id, H5T_cdata_t *cdata, size_t nelmts,
-                                     size_t buf_stride, size_t bkg_stride, void *buf, void *bkg);
-H5_DLL herr_t H5T__conv_ldouble_long(hid_t src_id, hid_t dst_id, H5T_cdata_t *cdata, size_t nelmts,
-                                     size_t buf_stride, size_t bkg_stride, void *buf, void *bkg);
-H5_DLL herr_t H5T__conv_ldouble_ulong(hid_t src_id, hid_t dst_id, H5T_cdata_t *cdata, size_t nelmts,
-                                      size_t buf_stride, size_t bkg_stride, void *buf, void *bkg);
-H5_DLL herr_t H5T__conv_ldouble_llong(hid_t src_id, hid_t dst_id, H5T_cdata_t *cdata, size_t nelmts,
-                                      size_t buf_stride, size_t bkg_stride, void *buf, void *bkg);
-H5_DLL herr_t H5T__conv_ldouble_ullong(hid_t src_id, hid_t dst_id, H5T_cdata_t *cdata, size_t nelmts,
-                                       size_t buf_stride, size_t bkg_stride, void *buf, void *bkg);
+H5_DLL herr_t H5T__conv_llong_schar(H5T_t *src, H5T_t *dst, H5T_cdata_t *cdata,
+                                    const H5T_conv_ctx_t *conv_ctx, size_t nelmts, size_t buf_stride,
+                                    size_t bkg_stride, void *buf, void *bkg);
+H5_DLL herr_t H5T__conv_llong_uchar(H5T_t *src, H5T_t *dst, H5T_cdata_t *cdata,
+                                    const H5T_conv_ctx_t *conv_ctx, size_t nelmts, size_t buf_stride,
+                                    size_t bkg_stride, void *buf, void *bkg);
+H5_DLL herr_t H5T__conv_ullong_schar(H5T_t *src, H5T_t *dst, H5T_cdata_t *cdata,
+                                     const H5T_conv_ctx_t *conv_ctx, size_t nelmts, size_t buf_stride,
+                                     size_t bkg_stride, void *buf, void *bkg);
+H5_DLL herr_t H5T__conv_ullong_uchar(H5T_t *src, H5T_t *dst, H5T_cdata_t *cdata,
+                                     const H5T_conv_ctx_t *conv_ctx, size_t nelmts, size_t buf_stride,
+                                     size_t bkg_stride, void *buf, void *bkg);
+H5_DLL herr_t H5T__conv_llong_short(H5T_t *src, H5T_t *dst, H5T_cdata_t *cdata,
+                                    const H5T_conv_ctx_t *conv_ctx, size_t nelmts, size_t buf_stride,
+                                    size_t bkg_stride, void *buf, void *bkg);
+H5_DLL herr_t H5T__conv_llong_ushort(H5T_t *src, H5T_t *dst, H5T_cdata_t *cdata,
+                                     const H5T_conv_ctx_t *conv_ctx, size_t nelmts, size_t buf_stride,
+                                     size_t bkg_stride, void *buf, void *bkg);
+H5_DLL herr_t H5T__conv_ullong_short(H5T_t *src, H5T_t *dst, H5T_cdata_t *cdata,
+                                     const H5T_conv_ctx_t *conv_ctx, size_t nelmts, size_t buf_stride,
+                                     size_t bkg_stride, void *buf, void *bkg);
+H5_DLL herr_t H5T__conv_ullong_ushort(H5T_t *src, H5T_t *dst, H5T_cdata_t *cdata,
+                                      const H5T_conv_ctx_t *conv_ctx, size_t nelmts, size_t buf_stride,
+                                      size_t bkg_stride, void *buf, void *bkg);
+H5_DLL herr_t H5T__conv_llong_int(H5T_t *src, H5T_t *dst, H5T_cdata_t *cdata, const H5T_conv_ctx_t *conv_ctx,
+                                  size_t nelmts, size_t buf_stride, size_t bkg_stride, void *buf, void *bkg);
+H5_DLL herr_t H5T__conv_llong_uint(H5T_t *src, H5T_t *dst, H5T_cdata_t *cdata, const H5T_conv_ctx_t *conv_ctx,
+                                   size_t nelmts, size_t buf_stride, size_t bkg_stride, void *buf, void *bkg);
+H5_DLL herr_t H5T__conv_ullong_int(H5T_t *src, H5T_t *dst, H5T_cdata_t *cdata, const H5T_conv_ctx_t *conv_ctx,
+                                   size_t nelmts, size_t buf_stride, size_t bkg_stride, void *buf, void *bkg);
+H5_DLL herr_t H5T__conv_ullong_uint(H5T_t *src, H5T_t *dst, H5T_cdata_t *cdata,
+                                    const H5T_conv_ctx_t *conv_ctx, size_t nelmts, size_t buf_stride,
+                                    size_t bkg_stride, void *buf, void *bkg);
+H5_DLL herr_t H5T__conv_llong_long(H5T_t *src, H5T_t *dst, H5T_cdata_t *cdata, const H5T_conv_ctx_t *conv_ctx,
+                                   size_t nelmts, size_t buf_stride, size_t bkg_stride, void *buf, void *bkg);
+H5_DLL herr_t H5T__conv_llong_ulong(H5T_t *src, H5T_t *dst, H5T_cdata_t *cdata,
+                                    const H5T_conv_ctx_t *conv_ctx, size_t nelmts, size_t buf_stride,
+                                    size_t bkg_stride, void *buf, void *bkg);
+H5_DLL herr_t H5T__conv_ullong_long(H5T_t *src, H5T_t *dst, H5T_cdata_t *cdata,
+                                    const H5T_conv_ctx_t *conv_ctx, size_t nelmts, size_t buf_stride,
+                                    size_t bkg_stride, void *buf, void *bkg);
+H5_DLL herr_t H5T__conv_ullong_ulong(H5T_t *src, H5T_t *dst, H5T_cdata_t *cdata,
+                                     const H5T_conv_ctx_t *conv_ctx, size_t nelmts, size_t buf_stride,
+                                     size_t bkg_stride, void *buf, void *bkg);
+H5_DLL herr_t H5T__conv_llong_ullong(H5T_t *src, H5T_t *dst, H5T_cdata_t *cdata,
+                                     const H5T_conv_ctx_t *conv_ctx, size_t nelmts, size_t buf_stride,
+                                     size_t bkg_stride, void *buf, void *bkg);
+H5_DLL herr_t H5T__conv_ullong_llong(H5T_t *src, H5T_t *dst, H5T_cdata_t *cdata,
+                                     const H5T_conv_ctx_t *conv_ctx, size_t nelmts, size_t buf_stride,
+                                     size_t bkg_stride, void *buf, void *bkg);
+H5_DLL herr_t H5T__conv_float_double(H5T_t *src, H5T_t *dst, H5T_cdata_t *cdata,
+                                     const H5T_conv_ctx_t *conv_ctx, size_t nelmts, size_t buf_stride,
+                                     size_t bkg_stride, void *buf, void *bkg);
+H5_DLL herr_t H5T__conv_float_ldouble(H5T_t *src, H5T_t *dst, H5T_cdata_t *cdata,
+                                      const H5T_conv_ctx_t *conv_ctx, size_t nelmts, size_t buf_stride,
+                                      size_t bkg_stride, void *buf, void *bkg);
+H5_DLL herr_t H5T__conv_double_float(H5T_t *src, H5T_t *dst, H5T_cdata_t *cdata,
+                                     const H5T_conv_ctx_t *conv_ctx, size_t nelmts, size_t buf_stride,
+                                     size_t bkg_stride, void *buf, void *bkg);
+H5_DLL herr_t H5T__conv_double_ldouble(H5T_t *src, H5T_t *dst, H5T_cdata_t *cdata,
+                                       const H5T_conv_ctx_t *conv_ctx, size_t nelmts, size_t buf_stride,
+                                       size_t bkg_stride, void *buf, void *bkg);
+H5_DLL herr_t H5T__conv_ldouble_float(H5T_t *src, H5T_t *dst, H5T_cdata_t *cdata,
+                                      const H5T_conv_ctx_t *conv_ctx, size_t nelmts, size_t buf_stride,
+                                      size_t bkg_stride, void *buf, void *bkg);
+H5_DLL herr_t H5T__conv_ldouble_double(H5T_t *src, H5T_t *dst, H5T_cdata_t *cdata,
+                                       const H5T_conv_ctx_t *conv_ctx, size_t nelmts, size_t buf_stride,
+                                       size_t bkg_stride, void *buf, void *bkg);
+H5_DLL herr_t H5T__conv_schar_float(H5T_t *src, H5T_t *dst, H5T_cdata_t *cdata,
+                                    const H5T_conv_ctx_t *conv_ctx, size_t nelmts, size_t buf_stride,
+                                    size_t bkg_stride, void *buf, void *bkg);
+H5_DLL herr_t H5T__conv_schar_double(H5T_t *src, H5T_t *dst, H5T_cdata_t *cdata,
+                                     const H5T_conv_ctx_t *conv_ctx, size_t nelmts, size_t buf_stride,
+                                     size_t bkg_stride, void *buf, void *bkg);
+H5_DLL herr_t H5T__conv_schar_ldouble(H5T_t *src, H5T_t *dst, H5T_cdata_t *cdata,
+                                      const H5T_conv_ctx_t *conv_ctx, size_t nelmts, size_t buf_stride,
+                                      size_t bkg_stride, void *buf, void *bkg);
+H5_DLL herr_t H5T__conv_uchar_float(H5T_t *src, H5T_t *dst, H5T_cdata_t *cdata,
+                                    const H5T_conv_ctx_t *conv_ctx, size_t nelmts, size_t buf_stride,
+                                    size_t bkg_stride, void *buf, void *bkg);
+H5_DLL herr_t H5T__conv_uchar_double(H5T_t *src, H5T_t *dst, H5T_cdata_t *cdata,
+                                     const H5T_conv_ctx_t *conv_ctx, size_t nelmts, size_t buf_stride,
+                                     size_t bkg_stride, void *buf, void *bkg);
+H5_DLL herr_t H5T__conv_uchar_ldouble(H5T_t *src, H5T_t *dst, H5T_cdata_t *cdata,
+                                      const H5T_conv_ctx_t *conv_ctx, size_t nelmts, size_t buf_stride,
+                                      size_t bkg_stride, void *buf, void *bkg);
+H5_DLL herr_t H5T__conv_short_float(H5T_t *src, H5T_t *dst, H5T_cdata_t *cdata,
+                                    const H5T_conv_ctx_t *conv_ctx, size_t nelmts, size_t buf_stride,
+                                    size_t bkg_stride, void *buf, void *bkg);
+H5_DLL herr_t H5T__conv_short_double(H5T_t *src, H5T_t *dst, H5T_cdata_t *cdata,
+                                     const H5T_conv_ctx_t *conv_ctx, size_t nelmts, size_t buf_stride,
+                                     size_t bkg_stride, void *buf, void *bkg);
+H5_DLL herr_t H5T__conv_short_ldouble(H5T_t *src, H5T_t *dst, H5T_cdata_t *cdata,
+                                      const H5T_conv_ctx_t *conv_ctx, size_t nelmts, size_t buf_stride,
+                                      size_t bkg_stride, void *buf, void *bkg);
+H5_DLL herr_t H5T__conv_ushort_float(H5T_t *src, H5T_t *dst, H5T_cdata_t *cdata,
+                                     const H5T_conv_ctx_t *conv_ctx, size_t nelmts, size_t buf_stride,
+                                     size_t bkg_stride, void *buf, void *bkg);
+H5_DLL herr_t H5T__conv_ushort_double(H5T_t *src, H5T_t *dst, H5T_cdata_t *cdata,
+                                      const H5T_conv_ctx_t *conv_ctx, size_t nelmts, size_t buf_stride,
+                                      size_t bkg_stride, void *buf, void *bkg);
+H5_DLL herr_t H5T__conv_ushort_ldouble(H5T_t *src, H5T_t *dst, H5T_cdata_t *cdata,
+                                       const H5T_conv_ctx_t *conv_ctx, size_t nelmts, size_t buf_stride,
+                                       size_t bkg_stride, void *buf, void *bkg);
+H5_DLL herr_t H5T__conv_int_float(H5T_t *src, H5T_t *dst, H5T_cdata_t *cdata, const H5T_conv_ctx_t *conv_ctx,
+                                  size_t nelmts, size_t buf_stride, size_t bkg_stride, void *buf, void *bkg);
+H5_DLL herr_t H5T__conv_int_double(H5T_t *src, H5T_t *dst, H5T_cdata_t *cdata, const H5T_conv_ctx_t *conv_ctx,
+                                   size_t nelmts, size_t buf_stride, size_t bkg_stride, void *buf, void *bkg);
+H5_DLL herr_t H5T__conv_int_ldouble(H5T_t *src, H5T_t *dst, H5T_cdata_t *cdata,
+                                    const H5T_conv_ctx_t *conv_ctx, size_t nelmts, size_t buf_stride,
+                                    size_t bkg_stride, void *buf, void *bkg);
+H5_DLL herr_t H5T__conv_uint_float(H5T_t *src, H5T_t *dst, H5T_cdata_t *cdata, const H5T_conv_ctx_t *conv_ctx,
+                                   size_t nelmts, size_t buf_stride, size_t bkg_stride, void *buf, void *bkg);
+H5_DLL herr_t H5T__conv_uint_double(H5T_t *src, H5T_t *dst, H5T_cdata_t *cdata,
+                                    const H5T_conv_ctx_t *conv_ctx, size_t nelmts, size_t buf_stride,
+                                    size_t bkg_stride, void *buf, void *bkg);
+H5_DLL herr_t H5T__conv_uint_ldouble(H5T_t *src, H5T_t *dst, H5T_cdata_t *cdata,
+                                     const H5T_conv_ctx_t *conv_ctx, size_t nelmts, size_t buf_stride,
+                                     size_t bkg_stride, void *buf, void *bkg);
+H5_DLL herr_t H5T__conv_long_float(H5T_t *src, H5T_t *dst, H5T_cdata_t *cdata, const H5T_conv_ctx_t *conv_ctx,
+                                   size_t nelmts, size_t buf_stride, size_t bkg_stride, void *buf, void *bkg);
+H5_DLL herr_t H5T__conv_long_double(H5T_t *src, H5T_t *dst, H5T_cdata_t *cdata,
+                                    const H5T_conv_ctx_t *conv_ctx, size_t nelmts, size_t buf_stride,
+                                    size_t bkg_stride, void *buf, void *bkg);
+H5_DLL herr_t H5T__conv_long_ldouble(H5T_t *src, H5T_t *dst, H5T_cdata_t *cdata,
+                                     const H5T_conv_ctx_t *conv_ctx, size_t nelmts, size_t buf_stride,
+                                     size_t bkg_stride, void *buf, void *bkg);
+H5_DLL herr_t H5T__conv_ulong_float(H5T_t *src, H5T_t *dst, H5T_cdata_t *cdata,
+                                    const H5T_conv_ctx_t *conv_ctx, size_t nelmts, size_t buf_stride,
+                                    size_t bkg_stride, void *buf, void *bkg);
+H5_DLL herr_t H5T__conv_ulong_double(H5T_t *src, H5T_t *dst, H5T_cdata_t *cdata,
+                                     const H5T_conv_ctx_t *conv_ctx, size_t nelmts, size_t buf_stride,
+                                     size_t bkg_stride, void *buf, void *bkg);
+H5_DLL herr_t H5T__conv_ulong_ldouble(H5T_t *src, H5T_t *dst, H5T_cdata_t *cdata,
+                                      const H5T_conv_ctx_t *conv_ctx, size_t nelmts, size_t buf_stride,
+                                      size_t bkg_stride, void *buf, void *bkg);
+H5_DLL herr_t H5T__conv_llong_float(H5T_t *src, H5T_t *dst, H5T_cdata_t *cdata,
+                                    const H5T_conv_ctx_t *conv_ctx, size_t nelmts, size_t buf_stride,
+                                    size_t bkg_stride, void *buf, void *bkg);
+H5_DLL herr_t H5T__conv_llong_double(H5T_t *src, H5T_t *dst, H5T_cdata_t *cdata,
+                                     const H5T_conv_ctx_t *conv_ctx, size_t nelmts, size_t buf_stride,
+                                     size_t bkg_stride, void *buf, void *bkg);
+H5_DLL herr_t H5T__conv_llong_ldouble(H5T_t *src, H5T_t *dst, H5T_cdata_t *cdata,
+                                      const H5T_conv_ctx_t *conv_ctx, size_t nelmts, size_t buf_stride,
+                                      size_t bkg_stride, void *buf, void *bkg);
+H5_DLL herr_t H5T__conv_ullong_float(H5T_t *src, H5T_t *dst, H5T_cdata_t *cdata,
+                                     const H5T_conv_ctx_t *conv_ctx, size_t nelmts, size_t buf_stride,
+                                     size_t bkg_stride, void *buf, void *bkg);
+H5_DLL herr_t H5T__conv_ullong_double(H5T_t *src, H5T_t *dst, H5T_cdata_t *cdata,
+                                      const H5T_conv_ctx_t *conv_ctx, size_t nelmts, size_t buf_stride,
+                                      size_t bkg_stride, void *buf, void *bkg);
+H5_DLL herr_t H5T__conv_ullong_ldouble(H5T_t *src, H5T_t *dst, H5T_cdata_t *cdata,
+                                       const H5T_conv_ctx_t *conv_ctx, size_t nelmts, size_t buf_stride,
+                                       size_t bkg_stride, void *buf, void *bkg);
+H5_DLL herr_t H5T__conv_float_schar(H5T_t *src, H5T_t *dst, H5T_cdata_t *cdata,
+                                    const H5T_conv_ctx_t *conv_ctx, size_t nelmts, size_t buf_stride,
+                                    size_t bkg_stride, void *buf, void *bkg);
+H5_DLL herr_t H5T__conv_float_uchar(H5T_t *src, H5T_t *dst, H5T_cdata_t *cdata,
+                                    const H5T_conv_ctx_t *conv_ctx, size_t nelmts, size_t buf_stride,
+                                    size_t bkg_stride, void *buf, void *bkg);
+H5_DLL herr_t H5T__conv_float_short(H5T_t *src, H5T_t *dst, H5T_cdata_t *cdata,
+                                    const H5T_conv_ctx_t *conv_ctx, size_t nelmts, size_t buf_stride,
+                                    size_t bkg_stride, void *buf, void *bkg);
+H5_DLL herr_t H5T__conv_float_ushort(H5T_t *src, H5T_t *dst, H5T_cdata_t *cdata,
+                                     const H5T_conv_ctx_t *conv_ctx, size_t nelmts, size_t buf_stride,
+                                     size_t bkg_stride, void *buf, void *bkg);
+H5_DLL herr_t H5T__conv_float_int(H5T_t *src, H5T_t *dst, H5T_cdata_t *cdata, const H5T_conv_ctx_t *conv_ctx,
+                                  size_t nelmts, size_t buf_stride, size_t bkg_stride, void *buf, void *bkg);
+H5_DLL herr_t H5T__conv_float_uint(H5T_t *src, H5T_t *dst, H5T_cdata_t *cdata, const H5T_conv_ctx_t *conv_ctx,
+                                   size_t nelmts, size_t buf_stride, size_t bkg_stride, void *buf, void *bkg);
+H5_DLL herr_t H5T__conv_float_long(H5T_t *src, H5T_t *dst, H5T_cdata_t *cdata, const H5T_conv_ctx_t *conv_ctx,
+                                   size_t nelmts, size_t buf_stride, size_t bkg_stride, void *buf, void *bkg);
+H5_DLL herr_t H5T__conv_float_ulong(H5T_t *src, H5T_t *dst, H5T_cdata_t *cdata,
+                                    const H5T_conv_ctx_t *conv_ctx, size_t nelmts, size_t buf_stride,
+                                    size_t bkg_stride, void *buf, void *bkg);
+H5_DLL herr_t H5T__conv_float_llong(H5T_t *src, H5T_t *dst, H5T_cdata_t *cdata,
+                                    const H5T_conv_ctx_t *conv_ctx, size_t nelmts, size_t buf_stride,
+                                    size_t bkg_stride, void *buf, void *bkg);
+H5_DLL herr_t H5T__conv_float_ullong(H5T_t *src, H5T_t *dst, H5T_cdata_t *cdata,
+                                     const H5T_conv_ctx_t *conv_ctx, size_t nelmts, size_t buf_stride,
+                                     size_t bkg_stride, void *buf, void *bkg);
+H5_DLL herr_t H5T__conv_double_schar(H5T_t *src, H5T_t *dst, H5T_cdata_t *cdata,
+                                     const H5T_conv_ctx_t *conv_ctx, size_t nelmts, size_t buf_stride,
+                                     size_t bkg_stride, void *buf, void *bkg);
+H5_DLL herr_t H5T__conv_double_uchar(H5T_t *src, H5T_t *dst, H5T_cdata_t *cdata,
+                                     const H5T_conv_ctx_t *conv_ctx, size_t nelmts, size_t buf_stride,
+                                     size_t bkg_stride, void *buf, void *bkg);
+H5_DLL herr_t H5T__conv_double_short(H5T_t *src, H5T_t *dst, H5T_cdata_t *cdata,
+                                     const H5T_conv_ctx_t *conv_ctx, size_t nelmts, size_t buf_stride,
+                                     size_t bkg_stride, void *buf, void *bkg);
+H5_DLL herr_t H5T__conv_double_ushort(H5T_t *src, H5T_t *dst, H5T_cdata_t *cdata,
+                                      const H5T_conv_ctx_t *conv_ctx, size_t nelmts, size_t buf_stride,
+                                      size_t bkg_stride, void *buf, void *bkg);
+H5_DLL herr_t H5T__conv_double_int(H5T_t *src, H5T_t *dst, H5T_cdata_t *cdata, const H5T_conv_ctx_t *conv_ctx,
+                                   size_t nelmts, size_t buf_stride, size_t bkg_stride, void *buf, void *bkg);
+H5_DLL herr_t H5T__conv_double_uint(H5T_t *src, H5T_t *dst, H5T_cdata_t *cdata,
+                                    const H5T_conv_ctx_t *conv_ctx, size_t nelmts, size_t buf_stride,
+                                    size_t bkg_stride, void *buf, void *bkg);
+H5_DLL herr_t H5T__conv_double_long(H5T_t *src, H5T_t *dst, H5T_cdata_t *cdata,
+                                    const H5T_conv_ctx_t *conv_ctx, size_t nelmts, size_t buf_stride,
+                                    size_t bkg_stride, void *buf, void *bkg);
+H5_DLL herr_t H5T__conv_double_ulong(H5T_t *src, H5T_t *dst, H5T_cdata_t *cdata,
+                                     const H5T_conv_ctx_t *conv_ctx, size_t nelmts, size_t buf_stride,
+                                     size_t bkg_stride, void *buf, void *bkg);
+H5_DLL herr_t H5T__conv_double_llong(H5T_t *src, H5T_t *dst, H5T_cdata_t *cdata,
+                                     const H5T_conv_ctx_t *conv_ctx, size_t nelmts, size_t buf_stride,
+                                     size_t bkg_stride, void *buf, void *bkg);
+H5_DLL herr_t H5T__conv_double_ullong(H5T_t *src, H5T_t *dst, H5T_cdata_t *cdata,
+                                      const H5T_conv_ctx_t *conv_ctx, size_t nelmts, size_t buf_stride,
+                                      size_t bkg_stride, void *buf, void *bkg);
+H5_DLL herr_t H5T__conv_ldouble_schar(H5T_t *src, H5T_t *dst, H5T_cdata_t *cdata,
+                                      const H5T_conv_ctx_t *conv_ctx, size_t nelmts, size_t buf_stride,
+                                      size_t bkg_stride, void *buf, void *bkg);
+H5_DLL herr_t H5T__conv_ldouble_uchar(H5T_t *src, H5T_t *dst, H5T_cdata_t *cdata,
+                                      const H5T_conv_ctx_t *conv_ctx, size_t nelmts, size_t buf_stride,
+                                      size_t bkg_stride, void *buf, void *bkg);
+H5_DLL herr_t H5T__conv_ldouble_short(H5T_t *src, H5T_t *dst, H5T_cdata_t *cdata,
+                                      const H5T_conv_ctx_t *conv_ctx, size_t nelmts, size_t buf_stride,
+                                      size_t bkg_stride, void *buf, void *bkg);
+H5_DLL herr_t H5T__conv_ldouble_ushort(H5T_t *src, H5T_t *dst, H5T_cdata_t *cdata,
+                                       const H5T_conv_ctx_t *conv_ctx, size_t nelmts, size_t buf_stride,
+                                       size_t bkg_stride, void *buf, void *bkg);
+H5_DLL herr_t H5T__conv_ldouble_int(H5T_t *src, H5T_t *dst, H5T_cdata_t *cdata,
+                                    const H5T_conv_ctx_t *conv_ctx, size_t nelmts, size_t buf_stride,
+                                    size_t bkg_stride, void *buf, void *bkg);
+H5_DLL herr_t H5T__conv_ldouble_uint(H5T_t *src, H5T_t *dst, H5T_cdata_t *cdata,
+                                     const H5T_conv_ctx_t *conv_ctx, size_t nelmts, size_t buf_stride,
+                                     size_t bkg_stride, void *buf, void *bkg);
+H5_DLL herr_t H5T__conv_ldouble_long(H5T_t *src, H5T_t *dst, H5T_cdata_t *cdata,
+                                     const H5T_conv_ctx_t *conv_ctx, size_t nelmts, size_t buf_stride,
+                                     size_t bkg_stride, void *buf, void *bkg);
+H5_DLL herr_t H5T__conv_ldouble_ulong(H5T_t *src, H5T_t *dst, H5T_cdata_t *cdata,
+                                      const H5T_conv_ctx_t *conv_ctx, size_t nelmts, size_t buf_stride,
+                                      size_t bkg_stride, void *buf, void *bkg);
+H5_DLL herr_t H5T__conv_ldouble_llong(H5T_t *src, H5T_t *dst, H5T_cdata_t *cdata,
+                                      const H5T_conv_ctx_t *conv_ctx, size_t nelmts, size_t buf_stride,
+                                      size_t bkg_stride, void *buf, void *bkg);
+H5_DLL herr_t H5T__conv_ldouble_ullong(H5T_t *src, H5T_t *dst, H5T_cdata_t *cdata,
+                                       const H5T_conv_ctx_t *conv_ctx, size_t nelmts, size_t buf_stride,
+                                       size_t bkg_stride, void *buf, void *bkg);
 
 /* Bit twiddling functions */
 H5_DLL void     H5T__bit_copy(uint8_t *dst, size_t dst_offset, const uint8_t *src, size_t src_offset,

--- a/src/H5Tprivate.h
+++ b/src/H5Tprivate.h
@@ -135,20 +135,20 @@ H5_DLL H5T_bkg_t          H5T_path_bkg(const H5T_path_t *p);
 H5_DLL H5T_subset_info_t *H5T_path_compound_subset(const H5T_path_t *p);
 H5_DLL herr_t             H5T_unregister(H5T_pers_t pers, const char *name, H5T_t *src, H5T_t *dst,
                                          H5VL_object_t *owned_vol_obj, H5T_conv_t func);
-H5_DLL herr_t H5T_convert(H5T_path_t *tpath, hid_t src_id, hid_t dst_id, size_t nelmts, size_t buf_stride,
-                          size_t bkg_stride, void *buf, void *bkg);
-H5_DLL herr_t H5T_reclaim(hid_t type_id, struct H5S_t *space, void *buf);
-H5_DLL herr_t H5T_reclaim_cb(void *elem, const H5T_t *dt, unsigned ndim, const hsize_t *point, void *op_data);
-H5_DLL herr_t H5T_vlen_reclaim_elmt(void *elem, H5T_t *dt);
-H5_DLL htri_t H5T_set_loc(H5T_t *dt, H5VL_object_t *file, H5T_loc_t loc);
-H5_DLL htri_t H5T_is_sensible(const H5T_t *dt);
-H5_DLL uint32_t       H5T_hash(H5F_t *file, const H5T_t *dt);
-H5_DLL herr_t         H5T_set_version(H5F_t *f, H5T_t *dt);
-H5_DLL herr_t         H5T_patch_file(H5T_t *dt, H5F_t *f);
-H5_DLL herr_t         H5T_patch_vlen_file(H5T_t *dt, H5VL_object_t *file);
-H5_DLL herr_t         H5T_own_vol_obj(H5T_t *dt, H5VL_object_t *vol_obj);
-H5_DLL htri_t         H5T_is_variable_str(const H5T_t *dt);
-H5_DLL H5T_t         *H5T_construct_datatype(H5VL_object_t *dt_obj);
+H5_DLL herr_t             H5T_convert(H5T_path_t *tpath, H5T_t *src_type, H5T_t *dst_type, size_t nelmts,
+                                      size_t buf_stride, size_t bkg_stride, void *buf, void *bkg);
+H5_DLL herr_t             H5T_reclaim(H5T_t *type, struct H5S_t *space, void *buf);
+H5_DLL herr_t   H5T_reclaim_cb(void *elem, H5T_t *dt, unsigned ndim, const hsize_t *point, void *op_data);
+H5_DLL herr_t   H5T_vlen_reclaim_elmt(void *elem, H5T_t *dt);
+H5_DLL htri_t   H5T_set_loc(H5T_t *dt, H5VL_object_t *file, H5T_loc_t loc);
+H5_DLL htri_t   H5T_is_sensible(const H5T_t *dt);
+H5_DLL uint32_t H5T_hash(H5F_t *file, const H5T_t *dt);
+H5_DLL herr_t   H5T_set_version(H5F_t *f, H5T_t *dt);
+H5_DLL herr_t   H5T_patch_file(H5T_t *dt, H5F_t *f);
+H5_DLL herr_t   H5T_patch_vlen_file(H5T_t *dt, H5VL_object_t *file);
+H5_DLL herr_t   H5T_own_vol_obj(H5T_t *dt, H5VL_object_t *vol_obj);
+H5_DLL htri_t   H5T_is_variable_str(const H5T_t *dt);
+H5_DLL H5T_t   *H5T_construct_datatype(H5VL_object_t *dt_obj);
 H5_DLL H5VL_object_t *H5T_get_named_type(const H5T_t *dt);
 H5_DLL H5T_t         *H5T_get_actual_type(H5T_t *dt);
 H5_DLL herr_t         H5T_save_refresh_state(hid_t tid, struct H5O_shared_t *cached_H5O_shared);

--- a/src/H5VLnative_dataset.c
+++ b/src/H5VLnative_dataset.c
@@ -119,7 +119,8 @@ H5VL__native_dataset_io_setup(size_t count, void *obj[], hid_t mem_type_id[], hi
                         "different files detected in multi dataset I/O request");
 
         /* Set up memory type */
-        dinfo[i].mem_type_id = mem_type_id[i];
+        if (NULL == (dinfo[i].mem_type = (H5T_t *)H5I_object_verify(mem_type_id[i], H5I_DATATYPE)))
+            HGOTO_ERROR(H5E_DATASET, H5E_BADTYPE, FAIL, "invalid datatype");
 
         /* Set up file dataspace */
         if (H5S_ALL == file_space_id[i])

--- a/test/dt_arith.c
+++ b/test/dt_arith.c
@@ -487,6 +487,16 @@ except_func(H5T_conv_except_t except_type, hid_t H5_ATTR_UNUSED src_id, hid_t H5
     return ret;
 }
 
+static herr_t
+my_conv_int_float_func(hid_t H5_ATTR_UNUSED src_id, hid_t H5_ATTR_UNUSED dst_id,
+                       H5T_cdata_t H5_ATTR_UNUSED *cdata, size_t H5_ATTR_UNUSED nelmts,
+                       size_t H5_ATTR_UNUSED buf_stride, size_t H5_ATTR_UNUSED bkg_stride,
+                       void H5_ATTR_UNUSED *buf, void H5_ATTR_UNUSED *bkg,
+                       hid_t H5_ATTR_UNUSED dset_xfer_plist)
+{
+    return SUCCEED;
+}
+
 /*-------------------------------------------------------------------------
  * Function:    test_hard_query
  *
@@ -511,20 +521,21 @@ test_hard_query(void)
         goto error;
     }
 
-    /* Unregister the hard conversion from int to float.  Verify the conversion
-     * is a soft conversion. */
-    H5Tunregister(H5T_PERS_HARD, NULL, H5T_NATIVE_INT, H5T_NATIVE_FLOAT,
-                  (H5T_conv_t)((void (*)(void))H5T__conv_int_float));
+    /* Unregister all hard conversion paths */
+    H5Tunregister(H5T_PERS_HARD, NULL, H5I_INVALID_HID, H5I_INVALID_HID, NULL);
+
+    /* Verify the conversion is now a soft conversion */
     if (H5Tcompiler_conv(H5T_NATIVE_INT, H5T_NATIVE_FLOAT) != false) {
         H5_FAILED();
         printf("Can't query conversion function\n");
         goto error;
     }
 
-    /* Register the hard conversion from int to float.  Verify the conversion
-     * is a hard conversion. */
+    /* Register our custom int to float conversion function */
     H5Tregister(H5T_PERS_HARD, "int_flt", H5T_NATIVE_INT, H5T_NATIVE_FLOAT,
-                (H5T_conv_t)((void (*)(void))H5T__conv_int_float));
+                (H5T_conv_t)((void (*)(void))my_conv_int_float_func));
+
+    /* Verify the conversion is now a hard conversion */
     if (H5Tcompiler_conv(H5T_NATIVE_INT, H5T_NATIVE_FLOAT) != true) {
         H5_FAILED();
         printf("Can't query conversion function\n");

--- a/tools/test/h5format_convert/h5fc_chk_idx.c
+++ b/tools/test/h5format_convert/h5fc_chk_idx.c
@@ -61,39 +61,47 @@ main(int argc, char *argv[])
     /* Try opening the file */
     if ((fid = h5tools_fopen(fname, H5F_ACC_RDONLY, H5P_DEFAULT, false, NULL, (size_t)0)) < 0) {
         fprintf(stderr, "h5fc_chk_idx: unable to open the file\n");
-        exit(EXIT_FAILURE);
+        goto error;
     } /* end if */
 
     /* Open the dataset */
     if ((did = H5Dopen2(fid, dname, H5P_DEFAULT)) < 0) {
         fprintf(stderr, "h5fc_chk_idx: unable to open the dataset\n");
-        exit(EXIT_FAILURE);
+        goto error;
     } /* end if */
 
     /* Get the dataset's chunk indexing type */
     if (H5Dget_chunk_index_type(did, &idx_type) < 0) {
         fprintf(stderr, "h5fc_chk_idx: unable to get chunk index type for the dataset\n");
-        exit(EXIT_FAILURE);
+        goto error;
     } /* end if */
 
     /* Close the dataset */
     if (H5Dclose(did) < 0) {
         fprintf(stderr, "h5fc_chk_idx: unable to close the dataset\n");
-        exit(EXIT_FAILURE);
+        goto error;
     } /* end if */
 
     /* Close the file */
     if (H5Fclose(fid) < 0) {
         fprintf(stderr, "h5fc_chk_idx_type: cannot close the file\n");
-        exit(EXIT_FAILURE);
+        goto error;
     } /* end if */
 
     /* Return success when the chunk indexing type is version 1 B-tree */
-    if (idx_type == H5D_CHUNK_IDX_BTREE)
-        exit(EXIT_SUCCESS);
-    else {
+    if (idx_type != H5D_CHUNK_IDX_BTREE) {
         fprintf(stderr, "Error: chunk indexing type is %d\n", idx_type);
-        exit(EXIT_FAILURE);
+        goto error;
     } /* end if */
 
+    free(fname);
+    free(dname);
+
+    exit(EXIT_SUCCESS);
+
+error:
+    free(fname);
+    free(dname);
+
+    exit(EXIT_FAILURE);
 } /* main() */


### PR DESCRIPTION
The datatype conversion code previously used IDs for the source and destination datatypes rather than pointers to the internal structures for those datatypes. This was mostly due to the need for an ID for these datatypes that can be passed to an application-registered datatype conversion function or datatype conversion exception function. However, using IDs internally caused a lot of unnecessary ID lookups and hurt performance of datatype conversions in general. This was especially problematic for compound datatype conversions, where the ID lookups were occuring on every member of every compound element of a dataset. The code has now been refactored to use pointers internally and only create IDs for datatypes when necessary.

Fixed a test issue in dt_arith where a library datatype conversion function was being cast to an application conversion function. Since the two have different prototypes, this started failing after the parameters for a library conversion function changed from hid_t to H5T_t * and an extra parameter was added. This appears to have worked coincidentally in the past since the only different between a library conversion function and application conversion function was an extra DXPL parameter at the end of an application conversion function.

Fixed an issue where memory wasn't being freed in the h5fc_chk_idx test program. Even though the program exits quickly after allocating the memory, it still causes failures when testing with -fsanitize=address.