### PR TITLE
Minimize use of abort()

### DIFF
--- a/src/H5.c
+++ b/src/H5.c
@@ -481,10 +481,10 @@ H5_term_library(void)
                 fprintf(stderr, "HDF5: infinite loop closing library\n");
                 fprintf(stderr, "      %s\n", loop);
 #ifndef NDEBUG
-                HDabort();
-#endif        /* NDEBUG */
-            } /* end if */
-        }     /* end if */
+                abort();
+#endif
+            }
+        }
     }
 
     /* Free open debugging streams */
@@ -831,18 +831,18 @@ done:
 /*-------------------------------------------------------------------------
  * Function:    H5check_version
  *
- * Purpose:    Verifies that the arguments match the version numbers
- *        compiled into the library.  This function is intended to be
- *        called from user to verify that the versions of header files
- *        compiled into the application match the version of the hdf5
- *        library.
- *        Within major.minor.release version, the expectation
- *        is that all release versions are compatible, exceptions to
- *        this rule must be added to the VERS_RELEASE_EXCEPTIONS list.
+ * Purpose:     Verifies that the arguments match the version numbers
+ *              compiled into the library.  This function is intended to be
+ *              called from user to verify that the versions of header files
+ *              compiled into the application match the version of the hdf5
+ *              library.
  *
- * Return:    Success:    SUCCEED
+ *              Within major.minor.release version, the expectation
+ *              is that all release versions are compatible, exceptions to
+ *              this rule must be added to the VERS_RELEASE_EXCEPTIONS list.
  *
- *        Failure:    abort()
+ * Return:      Success:    SUCCEED
+ *              Failure:    abort()
  *
  *-------------------------------------------------------------------------
  */
@@ -909,7 +909,7 @@ H5check_version(unsigned majnum, unsigned minnum, unsigned relnum)
 
                 /* Bail out now. */
                 fputs("Bye...\n", stderr);
-                HDabort();
+                abort();
             case 1:
                 /* continue with a warning */
                 /* Note that the warning message is embedded in the format string.*/
@@ -949,7 +949,7 @@ H5check_version(unsigned majnum, unsigned minnum, unsigned relnum)
 
                         /* Bail out now. */
                         fputs("Bye...\n", stderr);
-                        HDabort();
+                        abort();
                     case 1:
                         /* continue with a warning */
                         /* Note that the warning message is embedded in the format string.*/

--- a/src/H5Tbit.c
+++ b/src/H5Tbit.c
@@ -305,7 +305,8 @@ H5T__bit_set_d(uint8_t *buf, size_t offset, size_t size, uint64_t val)
         case H5T_ORDER_NONE:
         case H5T_ORDER_MIXED:
         default:
-            HDabort();
+            /* This function can't return errors */
+            assert(0 && "unknown byte order");
     }
 
     H5T__bit_copy(buf, offset, (uint8_t *)&val, (size_t)0, size);

--- a/src/H5private.h
+++ b/src/H5private.h
@@ -612,14 +612,8 @@ typedef off_t       h5_stat_size_t;
 #define HDoff_t off_t
 #endif
 
-/* Redefine all the POSIX and C functions.  We should never see an
- * undecorated POSIX or C function (or any other non-HDF5 function)
- * in the source.
- */
+/* Redefinions of some POSIX and C functions (mainly to deal with Windows) */
 
-#ifndef HDabort
-#define HDabort() abort()
-#endif
 #ifndef HDaccess
 #define HDaccess(F, M) access(F, M)
 #endif

--- a/test/hyperslab.c
+++ b/test/hyperslab.c
@@ -343,7 +343,7 @@ test_copy(int mode, size_t nx, size_t ny, size_t nz, size_t di, size_t dj, size_
             break;
 
         default:
-            HDabort();
+            FAIL_PUTS_ERROR("Unhandled case");
     } /* end switch */
 
     snprintf(s, sizeof(s), "Testing hyperslab copy %-11s %s", dim, sub);
@@ -406,7 +406,7 @@ test_copy(int mode, size_t nx, size_t ny, size_t nz, size_t di, size_t dj, size_
                                     break;
 
                                 default:
-                                    HDabort();
+                                    FAIL_PUTS_ERROR("Unhandled case");
                             } /* end switch */
 
                             /*

--- a/test/tmisc.c
+++ b/test/tmisc.c
@@ -6118,8 +6118,7 @@ test_misc36_cb1(void *_ctx)
     VERIFY(is_terminating, true, "H5is_library_terminating");
 
     /* Verify correct ordering for 'atclose' callbacks */
-    if (0 != *ctx)
-        HDabort();
+    VERIFY(*ctx, 0, "Wrong context value");
 
     /* Update context value */
     *ctx = 1;
@@ -6139,8 +6138,7 @@ test_misc36_cb2(void *_ctx)
     VERIFY(is_terminating, true, "H5is_library_terminating");
 
     /* Verify correct ordering for 'atclose' callbacks */
-    if (1 != *ctx)
-        HDabort();
+    VERIFY(*ctx, 1, "Wrong context value");
 
     /* Update context value */
     *ctx = 2;

--- a/tools/test/misc/talign.c
+++ b/tools/test/misc/talign.c
@@ -48,8 +48,8 @@ main(void)
 
     char *data = NULL;
 
-    int    result = 0;
-    herr_t error  = 1;
+    int    result = EXIT_SUCCESS;
+    herr_t error  = FAIL;
 
     printf("%-70s", "Testing alignment in compound datatypes");
 
@@ -59,7 +59,7 @@ main(void)
 
     if (fil < 0) {
         puts("*FAILED*");
-        return 1;
+        return EXIT_FAILURE;
     }
 
     H5E_BEGIN_TRY
@@ -123,10 +123,9 @@ main(void)
 
     /* Now open the set, and read it back in */
     data = (char *)malloc(H5Tget_size(fix));
-
     if (!data) {
-        perror("malloc() failed");
-        HDabort();
+        puts("*FAILED*");
+        return EXIT_FAILURE;
     }
 
     set = H5Dopen2(fil, setname, H5P_DEFAULT);
@@ -137,14 +136,14 @@ main(void)
 
 out:
     if (error < 0) {
-        result = 1;
+        result = EXIT_FAILURE;
         puts("*FAILED - HDF5 library error*");
     }
     else if (!(H5_FLT_ABS_EQUAL(fok[0], fptr[0])) || !(H5_FLT_ABS_EQUAL(fok[1], fptr[1])) ||
              !(H5_FLT_ABS_EQUAL(fnok[0], fptr[2])) || !(H5_FLT_ABS_EQUAL(fnok[1], fptr[3]))) {
         char *mname;
 
-        result = 1;
+        result = EXIT_FAILURE;
         mname  = H5Tget_member_name(fix, 0);
         printf("%14s (%2d) %6s = %s\n", mname ? mname : "(null)", (int)H5Tget_member_offset(fix, 0), string5,
                (char *)(data + H5Tget_member_offset(fix, 0)));
@@ -185,8 +184,8 @@ out:
         puts(" PASSED");
     }
 
-    if (data)
-        free(data);
+    free(data);
+
     H5Sclose(spc);
     H5Tclose(cs6);
     H5Tclose(cmp);
@@ -196,7 +195,9 @@ out:
     H5Tclose(cmp3);
     H5Pclose(plist);
     H5Fclose(fil);
+
     HDunlink(fname);
     fflush(stdout);
+
     return result;
 }


### PR DESCRIPTION
The abort() call is used at several places where it probably shouldn't.