### PR TITLE
Don't set the rpath when linking statically

### DIFF
--- a/bin/h5cc.in
+++ b/bin/h5cc.in
@@ -327,27 +327,27 @@ if test "x$do_link" = "xyes"; then
   fi
   link_args="$link_args -L${libdir}"
 
-  case "$kind" in
-    gcc|linux*)
-      # MacOS X doesn't support the "-Wl,-rpath -Wl," style of linker flags.
-      # It appears to want none of them specified.
-      case "$host_os" in
-        darwin*)          flag="" ;;
-        *)                flag="-Wl,-rpath -Wl," ;;
-      esac
-      ;;
-    hpux*)                flag="-Wl,+b -Wl," ;;
-    freebsd*|solaris*)    flag="-R" ;;
-    rs6000*|aix*)         flag="-L" ;;
-    sgi)                  flag="-rpath " ;;
-    *)                    flag="" ;;
-  esac
+  if test "x$USE_SHARED_LIB" = "xyes"; then
+    case "$kind" in
+      gcc|linux*)
+        # MacOS X doesn't support the "-Wl,-rpath -Wl," style of linker flags.
+        # It appears to want none of them specified.
+        case "$host_os" in
+          darwin*)          flag="" ;;
+          *)                flag="-Wl,-rpath -Wl," ;;
+        esac
+        ;;
+      hpux*)                flag="-Wl,+b -Wl," ;;
+      freebsd*|solaris*)    flag="-R" ;;
+      rs6000*|aix*)         flag="-L" ;;
+      sgi)                  flag="-rpath " ;;
+      *)                    flag="" ;;
+    esac
 
-  if test -n "$flag"; then
-    shared_link="${flag}${libdir}"
-  fi
-
-  if test "x$USE_SHARED_LIB" != "xyes"; then
+    if test -n "$flag"; then
+      shared_link="${flag}${libdir}"
+    fi
+  else
     # The "-lhdf5" & "-lhdf5_hl" flags are in here already...This is a static
     # compile though, so change it to the static version (.a) of the library.
     new_libraries=""

--- a/c++/src/h5c++.in
+++ b/c++/src/h5c++.in
@@ -314,27 +314,27 @@ if test "x$do_link" = "xyes"; then
   fi
   link_args="$link_args -L${libdir}"
 
-  case "$kind" in
-    gcc|linux*)
-      # MacOS X doesn't support the "-Wl,-rpath -Wl," style of linker flags.
-      # It appears to want none of them specified.
-      case "$host_os" in
-        darwin*)          flag="" ;;
-        *)                flag="-Wl,-rpath -Wl," ;;
-      esac
-      ;;
-    hpux*)                flag="-Wl,+b -Wl," ;;
-    freebsd*|solaris*)    flag="-R" ;;
-    rs6000*|aix*)         flag="-L" ;;
-    sgi)                  flag="-rpath " ;;
-    *)                    flag="" ;;
-  esac
+  if test "x$USE_SHARED_LIB" = "xyes"; then
+    case "$kind" in
+      gcc|linux*)
+        # MacOS X doesn't support the "-Wl,-rpath -Wl," style of linker flags.
+        # It appears to want none of them specified.
+        case "$host_os" in
+          darwin*)          flag="" ;;
+          *)                flag="-Wl,-rpath -Wl," ;;
+        esac
+        ;;
+      hpux*)                flag="-Wl,+b -Wl," ;;
+      freebsd*|solaris*)    flag="-R" ;;
+      rs6000*|aix*)         flag="-L" ;;
+      sgi)                  flag="-rpath " ;;
+      *)                    flag="" ;;
+    esac
 
-  if test -n "$flag"; then
-    shared_link="${flag}${libdir}"
-  fi
-
-  if test "x$USE_SHARED_LIB" != "xyes"; then
+    if test -n "$flag"; then
+      shared_link="${flag}${libdir}"
+    fi
+  else
     # The "-lhdf5" & "-lhdf5_hl" flags are in here already...This is a static
     # compile though, so change it to the static version (.a) of the library.
     new_libraries=""

--- a/fortran/src/h5fc.in
+++ b/fortran/src/h5fc.in
@@ -308,20 +308,20 @@ if test "x$do_link" = "xyes"; then
   fi
   link_args="$link_args -L${libdir}"
 
-  case "$host_os" in
-    linux*)               flag="@fortran_linux_linker_option@-rpath -Wl," ;;
-    hpux*)                flag="-Wl,+b -Wl," ;;
-    freebsd*|solaris*)    flag="-R" ;;
-    rs6000*|aix*)         flag="-L" ;;
-    sgi)                  flag="-rpath " ;;
-    *)                    flag="" ;;
-  esac
+  if test "x$USE_SHARED_LIB" = "xyes"; then
+    case "$host_os" in
+      linux*)               flag="@fortran_linux_linker_option@-rpath -Wl," ;;
+      hpux*)                flag="-Wl,+b -Wl," ;;
+      freebsd*|solaris*)    flag="-R" ;;
+      rs6000*|aix*)         flag="-L" ;;
+      sgi)                  flag="-rpath " ;;
+      *)                    flag="" ;;
+    esac
 
-  if test -n "$flag"; then
-    shared_link="${flag}${libdir}"
-  fi
-
-  if test "x$USE_SHARED_LIB" != "xyes"; then
+    if test -n "$flag"; then
+      shared_link="${flag}${libdir}"
+    fi
+  else
     # The hdf5 library "-l" flags are in here already.  This is a static
     # compile though, so change it to the static versions (.a) of the libraries.
     new_libraries=""


### PR DESCRIPTION
There is no reason for the path to a linked static library to be present as `RPATH` in the dynamic section of a binary. We should only set `-rpath` when linking to a shared library.

We pull the code that sets the `shared_link` variable inside a test for whether we use a shared library. The negation of this test was already present immediately after the now-guarded code, so that code now ends up in the else clause. The only thing that changes is that `shared_link` is populated only in the case of a shared library.