### PR TITLE
Fix segfault in vlen io API test

### DIFF
--- a/test/API/H5_api_dataset_test.c
+++ b/test/API/H5_api_dataset_test.c
@@ -9853,6 +9853,9 @@ test_dataset_vlen_io(void)
     hvl_t wbuf[DATASET_VLEN_IO_DSET_DIMS];
     hvl_t rbuf[DATASET_VLEN_IO_DSET_DIMS];
 
+    memset(wbuf, 0, sizeof(hvl_t) * DATASET_VLEN_IO_DSET_DIMS);
+    memset(rbuf, 0, sizeof(hvl_t) * DATASET_VLEN_IO_DSET_DIMS);
+
     TESTING_MULTIPART(
         "verification of dataset data with H5Dwrite and then H5D read with variable length sequence data");
 
@@ -10001,7 +10004,7 @@ test_dataset_vlen_io(void)
             if ((file_id = H5Fopen(H5_api_test_filename, H5F_ACC_RDWR, H5P_DEFAULT)) < 0)
                 PART_TEST_ERROR(rw_all_int);
 
-            if ((container_group = H5Gopen(file_id, DATASET_TEST_GROUP_NAME, H5P_DEFAULT)) < 0)
+            if ((container_group = H5Gopen2(file_id, DATASET_TEST_GROUP_NAME, H5P_DEFAULT)) < 0)
                 PART_TEST_ERROR(rw_all_int);
 
             if ((dset_int = H5Dopen2(container_group, DATASET_VLEN_IO_DSET_NAME "_int", H5P_DEFAULT)) < 0)
@@ -10218,6 +10221,7 @@ test_dataset_vlen_io(void)
 
         PART_BEGIN(rw_point_selection)
         {
+            TESTING_2("write with point selection");
             /* Select even-indexed points */
             for (size_t i = 0; i < DATASET_VLEN_IO_DSET_DIMS / 2; i++)
                 point_coords[i] = i * 2;
@@ -10315,6 +10319,7 @@ test_dataset_vlen_io(void)
 
         PART_BEGIN(rw_hyperslab_selection)
         {
+            TESTING_2("write with hyperslab selection");
             /* Select hyperslab of every 3rd element */
             const hsize_t start[1]  = {0};
             const hsize_t stride[1] = {3};
@@ -10422,6 +10427,7 @@ test_dataset_vlen_io(void)
         TEST_ERROR;
     if (H5Sclose(space_id) < 0)
         TEST_ERROR;
+
     /* In case of memory allocation error, not all hvl_t buffers in array may be allocated.
      * Free one-by-one */
     for (size_t i = 0; i < DATASET_VLEN_IO_DSET_DIMS; i++) {
@@ -10453,9 +10459,12 @@ error:
     {
         H5Fclose(file_id);
         H5Gclose(container_group);
-        H5Dclose(dset_int);
-        H5Dclose(dset_float);
-        H5Dclose(dset_string);
+        if (dset_int != H5I_INVALID_HID)
+            H5Dclose(dset_int);
+        if (dset_float != H5I_INVALID_HID)
+            H5Dclose(dset_float);
+        if (dset_string != H5I_INVALID_HID)
+            H5Dclose(dset_string);
         H5Sclose(space_id);
         for (size_t i = 0; i < DATASET_VLEN_IO_DSET_DIMS; i++) {
             if (wbuf[i].p) {


### PR DESCRIPTION
- Fixed an issue where skipping the test could lead to uninitialized memory in `rbuf`/`wbuf` being freed
- Fixed using `H5Gopen` macro instead of `H5Gopen2`
- Added missing sub-test headers for selections
- If the test fails, only attempt to close datasets if they have valid handles

This should fix the Cache VOL's segfault in the daily CI.