### PR TITLE
Update URLs in RELEASE.txt

### DIFF
--- a/release_docs/RELEASE.txt
+++ b/release_docs/RELEASE.txt
@@ -13,13 +13,13 @@ HDF5 source.
 Note that documentation in the links below will be updated at the time of each
 final release.
 
-Links to HDF5 documentation can be found on The HDF5 web page:
+Links to HDF5 documentation can be found on:
 
-     https://portal.hdfgroup.org/display/HDF5/HDF5
+     https://portal.hdfgroup.org/documentation/
 
 The official HDF5 releases can be obtained from:
 
-     https://www.hdfgroup.org/downloads/hdf5/
+     https://portal.hdfgroup.org/downloads/index.html
 
 Changes from Release to Release and New Features in the HDF5-1.16.x release series
 can be found at:

--- a/release_docs/RELEASE.txt
+++ b/release_docs/RELEASE.txt
@@ -19,7 +19,7 @@ Links to HDF5 documentation can be found on:
 
 The official HDF5 releases can be obtained from:
 
-     https://portal.hdfgroup.org/downloads/index.html
+     https://www.hdfgroup.org/downloads/hdf5/
 
 Changes from Release to Release and New Features in the HDF5-1.16.x release series
 can be found at:


### PR DESCRIPTION
Note that https://portal.hdfgroup.org/display/HDF5/Release+Specific+Information is still not available yet.