### PR TITLE
Fix buffer size calculation in the deflate filter

### DIFF
--- a/src/H5Zdeflate.c
+++ b/src/H5Zdeflate.c
@@ -42,8 +42,6 @@ const H5Z_class2_t H5Z_DEFLATE[1] = {{
     H5Z__filter_deflate, /* The actual filter function	*/
 }};
 
-#define H5Z_DEFLATE_SIZE_ADJUST(s) (ceil(((double)(s)) * 1.001) + 12)
-
 /*-------------------------------------------------------------------------
  * Function:	H5Z__filter_deflate
  *
@@ -149,7 +147,7 @@ H5Z__filter_deflate(unsigned flags, size_t cd_nelmts, const unsigned cd_values[]
          */
         const Bytef *z_src = (const Bytef *)(*buf);
         Bytef       *z_dst; /*destination buffer		*/
-        uLongf       z_dst_nbytes = (uLongf)H5Z_DEFLATE_SIZE_ADJUST(nbytes);
+        uLongf       z_dst_nbytes = (uLongf)compressBound(nbytes);
         uLong        z_src_nbytes = (uLong)nbytes;
         int          aggression; /* Compression aggression setting */
 


### PR DESCRIPTION
The heuristic that is currently used to calculate the size of the output buffer for the `compress2` operation in the `deflate` filter might produce a number that is too small for some implementations of `zlib` API. For example, [`zlib-ng`](https://github.com/zlib-ng/zlib-ng)  built with the new strategies enabled ([`-DWITH_NEW_STRATEGIES=ON`](https://github.com/zlib-ng/zlib-ng/blob/af8169a724bd607e4e8c7de2a705ab17206217d6/CMakeLists.txt#L86C8-L86C27)) requires more than `ceil(((double)(400)) * 1.001) + 12 = 413` bytes for the following chunk:
```c
char z_src[400] = {
  0, 0, 0,   0,  255, 15,  192, 63, 0, 0, 64,  64, 255, 15,  144, 64,
  0, 0, 192, 64, 255, 15,  240, 64, 0, 0, 16,  65, 255, 15,  40,  65,
  0, 0, 64,  65, 255, 15,  88,  65, 0, 0, 112, 65, 255, 15,  132, 65,
  0, 0, 144, 65, 255, 15,  156, 65, 0, 0, 168, 65, 255, 15,  180, 65,
  0, 0, 192, 65, 255, 15,  204, 65, 0, 0, 216, 65, 255, 15,  228, 65,
  0, 0, 240, 65, 255, 15,  252, 65, 0, 0, 4,   66, 255, 15,  10,  66,
  0, 0, 16,  66, 255, 15,  22,  66, 0, 0, 28,  66, 255, 15,  34,  66,
  0, 0, 40,  66, 255, 15,  46,  66, 0, 0, 52,  66, 255, 15,  58,  66,
  0, 0, 64,  66, 255, 15,  70,  66, 0, 0, 76,  66, 255, 15,  82,  66,
  0, 0, 88,  66, 255, 15,  94,  66, 0, 0, 100, 66, 255, 15,  106, 66,
  0, 0, 112, 66, 255, 15,  118, 66, 0, 0, 124, 66, 255, 15,  129, 66,
  0, 0, 132, 66, 255, 15,  135, 66, 0, 0, 138, 66, 255, 15,  141, 66,
  0, 0, 144, 66, 255, 15,  147, 66, 0, 0, 150, 66, 255, 15,  153, 66,
  0, 0, 156, 66, 255, 15,  159, 66, 0, 0, 162, 66, 255, 15,  165, 66,
  0, 0, 168, 66, 255, 15,  171, 66, 0, 0, 174, 66, 255, 15,  177, 66,
  0, 0, 180, 66, 255, 15,  183, 66, 0, 0, 186, 66, 255, 15,  189, 66,
  0, 0, 192, 66, 255, 15,  195, 66, 0, 0, 198, 66, 255, 15,  201, 66,
  0, 0, 204, 66, 255, 15,  207, 66, 0, 0, 210, 66, 255, 15,  213, 66,
  0, 0, 216, 66, 255, 15,  219, 66, 0, 0, 222, 66, 255, 15,  225, 66,
  0, 0, 228, 66, 255, 15,  231, 66, 0, 0, 234, 66, 255, 15,  237, 66,
  0, 0, 240, 66, 255, 15,  243, 66, 0, 0, 246, 66, 255, 15,  249, 66,
  0, 0, 252, 66, 255, 15,  255, 66, 0, 0, 1,   67, 255, 143, 2,   67,
  0, 0, 4,   67, 255, 143, 5,   67, 0, 0, 7,   67, 255, 143, 8,   67,
  0, 0, 10,  67, 255, 143, 11,  67, 0, 0, 13,  67, 255, 143, 14,  67,
  0, 0, 16,  67, 255, 143, 17,  67, 0, 0, 19,  67, 255, 143, 20,  67};
```
The minimal size required for that is `420`. It looks like, instead of adjusting the heuristic, it makes sense to use the [`compressBound`](https://refspecs.linuxbase.org/LSB_3.0.0/LSB-Core-generic/LSB-Core-generic/zlib-compressbound-1.html) function, which for the chunk above returns `474`. This PR does exactly that.