### PR TITLE
Remove HDF from Fortran 2003 configuration check message.

### DIFF
--- a/m4/aclocal_fc.m4
+++ b/m4/aclocal_fc.m4
@@ -159,7 +159,7 @@ dnl disable Fortran 2003 if it does not.
 
 AC_DEFUN([PAC_PROG_FC_HAVE_F2003_REQUIREMENTS],[
    HAVE_F2003_REQUIREMENTS="no"
-   AC_MSG_CHECKING([if Fortran compiler version compatible with Fortran 2003 HDF])
+   AC_MSG_CHECKING([if Fortran compiler version compatible with Fortran 2003])
    TEST_SRC="`sed -n '/PROG_FC_HAVE_F2003_REQUIREMENTS/,/END PROGRAM PROG_FC_HAVE_F2003_REQUIREMENTS/p' $srcdir/m4/aclocal_fc.f90`"
    AC_COMPILE_IFELSE([$TEST_SRC], [AC_MSG_RESULT([yes])
             HAVE_F2003_REQUIREMENTS="yes"],


### PR DESCRIPTION
When I tested lfortran support with Autotools, I got this error output:

```
checking how /Users/runner/miniconda3/bin/lfortran finds modules... -I
checking if Fortran compiler version compatible with Fortran 2003 HDF... no
configure: error: Fortran compiler lacks required Fortran 2003 features; unsupported Fortran 2003 compiler, remove --enable-fortran
```

I think `HDF` is not necessary. 

Q: What Fortran 2003 feature is missing in lfortran to build HDF5?

See Also: https://github.com/lfortran/lfortran/issues/3321

