### PR TITLE
Clean up CMake direct VFD handling

### DIFF
--- a/config/cmake/ConfigureChecks.cmake
+++ b/config/cmake/ConfigureChecks.cmake
@@ -661,7 +661,7 @@ if (HDF5_ENABLE_DIRECT_VFD)
   # flag. No other form of direct I/O is supported. This feature also
   # requires posix_memalign().
   CHECK_SYMBOL_EXISTS (O_DIRECT "fcntl.h" HAVE_O_DIRECT)
-  CHECK_FUNCTION_EXISTS (posix_memalign "stdlib.h" HAVE_POSIX_MEMALIGN)
+  CHECK_SYMBOL_EXISTS (posix_memalign "stdlib.h" HAVE_POSIX_MEMALIGN)
 
   if (HAVE_O_DIRECT AND HAVE_POSIX_MEMALIGN)
     set (${HDF_PREFIX}_HAVE_DIRECT 1)

--- a/config/cmake/ConfigureChecks.cmake
+++ b/config/cmake/ConfigureChecks.cmake
@@ -653,38 +653,20 @@ unset (CMAKE_EXTRA_INCLUDE_FILES)
 #-----------------------------------------------------------------------------
 
 #-----------------------------------------------------------------------------
-#  Check if Direct I/O driver works
+# Check whether we can build the direct VFD
 #-----------------------------------------------------------------------------
-if (NOT WINDOWS)
-  option (HDF5_ENABLE_DIRECT_VFD "Build the Direct I/O Virtual File Driver" OFF)
-  if (HDF5_ENABLE_DIRECT_VFD)
-    set (msg "Performing TEST_DIRECT_VFD_WORKS")
-    set (MACRO_CHECK_FUNCTION_DEFINITIONS "-DTEST_DIRECT_VFD_WORKS -D_GNU_SOURCE ${CMAKE_REQUIRED_FLAGS}")
-    TRY_RUN (TEST_DIRECT_VFD_WORKS_RUN   TEST_DIRECT_VFD_WORKS_COMPILE
-        ${CMAKE_BINARY_DIR}
-        ${HDF_RESOURCES_DIR}/HDFTests.c
-        CMAKE_FLAGS -DCOMPILE_DEFINITIONS:STRING=${MACRO_CHECK_FUNCTION_DEFINITIONS}
-        OUTPUT_VARIABLE OUTPUT
-    )
-    if (TEST_DIRECT_VFD_WORKS_COMPILE)
-      if (TEST_DIRECT_VFD_WORKS_RUN EQUAL "0")
-        HDF_FUNCTION_TEST (HAVE_DIRECT)
-        set (CMAKE_REQUIRED_DEFINITIONS "${CMAKE_REQUIRED_DEFINITIONS} -D_GNU_SOURCE")
-        add_definitions ("-D_GNU_SOURCE")
-      else ()
-        set (TEST_DIRECT_VFD_WORKS "" CACHE INTERNAL ${msg})
-        message (VERBOSE "${msg}... no")
-        file (APPEND ${CMAKE_BINARY_DIR}/CMakeFiles/CMakeError.log
-              "Test TEST_DIRECT_VFD_WORKS Run failed with the following output and exit code:\n ${OUTPUT}\n"
-        )
-      endif ()
-    else ()
-      set (TEST_DIRECT_VFD_WORKS "" CACHE INTERNAL ${msg})
-      message (VERBOSE "${msg}... no")
-      file (APPEND ${CMAKE_BINARY_DIR}/CMakeFiles/CMakeError.log
-          "Test TEST_DIRECT_VFD_WORKS Compile failed with the following output:\n ${OUTPUT}\n"
-      )
-    endif ()
+option (HDF5_ENABLE_DIRECT_VFD "Build the Direct I/O Virtual File Driver" OFF)
+if (HDF5_ENABLE_DIRECT_VFD)
+  # The direct VFD is tied to POSIX direct I/O as enabled by the O_DIRECT
+  # flag. No other form of direct I/O is supported. This feature also
+  # requires posix_memalign().
+  check_symbol_exists(O_DIRECT "fcntl.h" HAVE_O_DIRECT)
+  check_symbol_exists(posix_memalign "stdlib.h" HAVE_POSIX_MEMALIGN)
+
+  if (HAVE_O_DIRECT AND HAVE_POSIX_MEMALIGN)
+    set (${HDF_PREFIX}_HAVE_DIRECT 1)
+  else ()
+      message (FATAL_ERROR "The direct VFD was requested but cannot be built.\nIt requires O_DIRECT flag support and posix_memalign()")
   endif ()
 endif ()
 
@@ -705,7 +687,7 @@ option (HDF5_ENABLE_ROS3_VFD "Build the ROS3 Virtual File Driver" OFF)
 endif ()
 
 # ----------------------------------------------------------------------
-# Check whether we can build the Mirror VFD
+# Check whether we can build the mirror VFD
 # ----------------------------------------------------------------------
 option (HDF5_ENABLE_MIRROR_VFD "Build the Mirror Virtual File Driver" OFF)
 if (HDF5_ENABLE_MIRROR_VFD)

--- a/config/cmake/ConfigureChecks.cmake
+++ b/config/cmake/ConfigureChecks.cmake
@@ -660,8 +660,8 @@ if (HDF5_ENABLE_DIRECT_VFD)
   # The direct VFD is tied to POSIX direct I/O as enabled by the O_DIRECT
   # flag. No other form of direct I/O is supported. This feature also
   # requires posix_memalign().
-  check_symbol_exists(O_DIRECT "fcntl.h" HAVE_O_DIRECT)
-  check_symbol_exists(posix_memalign "stdlib.h" HAVE_POSIX_MEMALIGN)
+  CHECK_SYMBOL_EXISTS (O_DIRECT "fcntl.h" HAVE_O_DIRECT)
+  CHECK_FUNCTION_EXISTS (posix_memalign "stdlib.h" HAVE_POSIX_MEMALIGN)
 
   if (HAVE_O_DIRECT AND HAVE_POSIX_MEMALIGN)
     set (${HDF_PREFIX}_HAVE_DIRECT 1)

--- a/config/cmake/ConfigureChecks.cmake
+++ b/config/cmake/ConfigureChecks.cmake
@@ -666,7 +666,7 @@ if (HDF5_ENABLE_DIRECT_VFD)
   if (HAVE_O_DIRECT AND HAVE_POSIX_MEMALIGN)
     set (${HDF_PREFIX}_HAVE_DIRECT 1)
   else ()
-      message (FATAL_ERROR "The direct VFD was requested but cannot be built.\nIt requires O_DIRECT flag support and posix_memalign()")
+    message (FATAL_ERROR "The direct VFD was requested but cannot be built.\nIt requires O_DIRECT flag support and posix_memalign()")
   endif ()
 endif ()
 

--- a/config/cmake/HDFTests.c
+++ b/config/cmake/HDFTests.c
@@ -89,29 +89,6 @@ int main ()
 
 #endif /* DEV_T_IS_SCALAR */
 
-#ifdef TEST_DIRECT_VFD_WORKS
-
-#include <sys/types.h>
-#include <sys/stat.h>
-#include <fcntl.h>
-
-int main(void)
-{
-    int fid;
-
-    if ((fid = open("tst_file", O_CREAT | O_TRUNC | O_DIRECT, 0755)) < 0)
-        return 1;
-    close(fid);
-    remove("tst_file");
-
-    return 0;
-}
-#endif
-
-#ifdef HAVE_DIRECT
-       SIMPLE_TEST(posix_memalign());
-#endif
-
 #ifdef HAVE_DEFAULT_SOURCE
 /* Check default source */
 #include <features.h>

--- a/config/cmake/libhdf5.settings.cmake.in
+++ b/config/cmake/libhdf5.settings.cmake.in
@@ -79,7 +79,7 @@ Dimension scales w/ new references: @DIMENSION_SCALES_WITH_NEW_REF@
     With deprecated public symbols: @HDF5_ENABLE_DEPRECATED_SYMBOLS@
             I/O filters (external): @EXTERNAL_FILTERS@
                      Map (H5M) API: @H5_HAVE_MAP_API@
-                        Direct VFD: @H5_HAVE_DIRECT@
+                        Direct VFD: @HDF5_ENABLE_DIRECT_VFD@
                         Mirror VFD: @H5_HAVE_MIRROR_VFD@
                      Subfiling VFD: @H5_HAVE_SUBFILING_VFD@
                 (Read-Only) S3 VFD: @H5_HAVE_ROS3_VFD@


### PR DESCRIPTION
There's no need to build and run programs, or even check the operating system. We just need to check for O_DIRECT and posix_memalign().