### PR TITLE
Remove lseek64 and stat64 symbols from CMake

### DIFF
--- a/config/cmake/ConfigureChecks.cmake
+++ b/config/cmake/ConfigureChecks.cmake
@@ -143,7 +143,6 @@ else ()
 endif ()
 
 if (CYGWIN)
-  set (${HDF_PREFIX}_HAVE_LSEEK64 0)
   set (CMAKE_REQUIRED_DEFINITIONS "${CMAKE_REQUIRED_DEFINITIONS} -D_GNU_SOURCE")
   add_definitions ("-D_GNU_SOURCE")
 endif ()

--- a/config/cmake/H5pubconf.h.in
+++ b/config/cmake/H5pubconf.h.in
@@ -216,9 +216,6 @@
 /* Define to 1 if you have the `z' library (-lz). */
 #cmakedefine H5_HAVE_LIBZ @H5_HAVE_LIBZ@
 
-/* Define to 1 if you have the `lseek64' function. */
-#cmakedefine H5_HAVE_LSEEK64 @H5_HAVE_LSEEK64@
-
 /* Define if the map API (H5M) should be compiled */
 #cmakedefine H5_HAVE_MAP_API @H5_HAVE_MAP_API@
 
@@ -282,9 +279,6 @@
 /* Define whether the Read-Only S3 virtual file driver (VFD) should be
    compiled */
 #cmakedefine H5_HAVE_ROS3_VFD @H5_HAVE_ROS3_VFD@
-
-/* Define to 1 if you have the `stat64' function. */
-#cmakedefine H5_HAVE_STAT64 @H5_HAVE_STAT64@
 
 /* Define if struct stat has the st_blocks field */
 #cmakedefine H5_HAVE_STAT_ST_BLOCKS @H5_HAVE_STAT_ST_BLOCKS@


### PR DESCRIPTION
We don't use these in the library.