### PR TITLE
Remove some H5T_copy calls that are now unnecessary

### DIFF
--- a/src/H5Aint.c
+++ b/src/H5Aint.c
@@ -681,9 +681,7 @@ H5A__read(const H5A_t *attr, const H5T_t *mem_type, void *buf)
     uint8_t    *bkg_buf   = NULL; /* background buffer */
     hssize_t    snelmts;          /* elements in attribute */
     size_t      nelmts;           /* elements in attribute*/
-    H5T_path_t *tpath    = NULL;  /* type conversion info    */
-    H5T_t      *src_type = NULL;  /* temporary datatype */
-    H5T_t      *dst_type = NULL;  /* temporary datatype */
+    H5T_path_t *tpath = NULL;     /* type conversion info    */
     size_t      src_type_size;    /* size of source type     */
     size_t      dst_type_size;    /* size of destination type */
     size_t      buf_size;         /* desired buffer size    */
@@ -723,11 +721,6 @@ H5A__read(const H5A_t *attr, const H5T_t *mem_type, void *buf)
             if (!H5T_path_noop(tpath)) {
                 H5T_bkg_t need_bkg; /* Background buffer type */
 
-                if (NULL == (src_type = H5T_copy(attr->shared->dt, H5T_COPY_ALL)))
-                    HGOTO_ERROR(H5E_ATTR, H5E_CANTCOPY, FAIL, "unable to copy attribute datatype");
-                if (NULL == (dst_type = H5T_copy(mem_type, H5T_COPY_ALL)))
-                    HGOTO_ERROR(H5E_ATTR, H5E_CANTCOPY, FAIL, "unable to copy memory datatype");
-
                 /* Get the maximum buffer size needed and allocate it */
                 buf_size = nelmts * MAX(src_type_size, dst_type_size);
                 if (NULL == (tconv_buf = H5FL_BLK_MALLOC(attr_buf, buf_size)))
@@ -752,8 +745,8 @@ H5A__read(const H5A_t *attr, const H5T_t *mem_type, void *buf)
                 }
 
                 /* Perform datatype conversion.  */
-                if (H5T_convert(tpath, src_type, dst_type, nelmts, (size_t)0, (size_t)0, tconv_buf, bkg_buf) <
-                    0)
+                if (H5T_convert(tpath, attr->shared->dt, mem_type, nelmts, (size_t)0, (size_t)0, tconv_buf,
+                                bkg_buf) < 0)
                     HGOTO_ERROR(H5E_ATTR, H5E_CANTCONVERT, FAIL, "datatype conversion failed");
 
                 /* Copy the converted data into the user's buffer */
@@ -771,10 +764,6 @@ H5A__read(const H5A_t *attr, const H5T_t *mem_type, void *buf)
 
 done:
     /* Release resources */
-    if (src_type && H5T_close(src_type) < 0)
-        HDONE_ERROR(H5E_ATTR, H5E_CANTCLOSEOBJ, FAIL, "unable to close temporary datatype");
-    if (dst_type && H5T_close(dst_type) < 0)
-        HDONE_ERROR(H5E_ATTR, H5E_CANTCLOSEOBJ, FAIL, "unable to close temporary datatype");
     if (tconv_buf)
         tconv_buf = H5FL_BLK_FREE(attr_buf, tconv_buf);
     if (bkg_buf)
@@ -805,9 +794,7 @@ H5A__write(H5A_t *attr, const H5T_t *mem_type, const void *buf)
     uint8_t    *bkg_buf   = NULL; /* temp conversion buffer */
     hssize_t    snelmts;          /* elements in attribute */
     size_t      nelmts;           /* elements in attribute */
-    H5T_path_t *tpath    = NULL;  /* conversion information*/
-    H5T_t      *src_type = NULL;  /* temporary datatype */
-    H5T_t      *dst_type = NULL;  /* temporary datatype */
+    H5T_path_t *tpath = NULL;     /* conversion information*/
     size_t      src_type_size;    /* size of source type    */
     size_t      dst_type_size;    /* size of destination type*/
     size_t      buf_size;         /* desired buffer size    */
@@ -843,11 +830,6 @@ H5A__write(H5A_t *attr, const H5T_t *mem_type, const void *buf)
         if (!H5T_path_noop(tpath)) {
             H5T_bkg_t need_bkg; /* Background buffer type */
 
-            if (NULL == (src_type = H5T_copy(mem_type, H5T_COPY_ALL)))
-                HGOTO_ERROR(H5E_ATTR, H5E_CANTCOPY, FAIL, "unable to copy memory datatype");
-            if (NULL == (dst_type = H5T_copy(attr->shared->dt, H5T_COPY_ALL)))
-                HGOTO_ERROR(H5E_ATTR, H5E_CANTCOPY, FAIL, "unable to copy attribute datatype");
-
             /* Get the maximum buffer size needed and allocate it */
             buf_size = nelmts * MAX(src_type_size, dst_type_size);
             if (NULL == (tconv_buf = H5FL_BLK_MALLOC(attr_buf, buf_size)))
@@ -880,7 +862,8 @@ H5A__write(H5A_t *attr, const H5T_t *mem_type, const void *buf)
             }
 
             /* Perform datatype conversion */
-            if (H5T_convert(tpath, src_type, dst_type, nelmts, (size_t)0, (size_t)0, tconv_buf, bkg_buf) < 0)
+            if (H5T_convert(tpath, mem_type, attr->shared->dt, nelmts, (size_t)0, (size_t)0, tconv_buf,
+                            bkg_buf) < 0)
                 HGOTO_ERROR(H5E_ATTR, H5E_CANTCONVERT, FAIL, "datatype conversion failed");
 
             /* Free the previous attribute data buffer, if there is one */
@@ -911,10 +894,6 @@ H5A__write(H5A_t *attr, const H5T_t *mem_type, const void *buf)
 
 done:
     /* Release resources */
-    if (src_type && H5T_close(src_type) < 0)
-        HDONE_ERROR(H5E_ATTR, H5E_CANTCLOSEOBJ, FAIL, "unable to close temporary datatype");
-    if (dst_type && H5T_close(dst_type) < 0)
-        HDONE_ERROR(H5E_ATTR, H5E_CANTCLOSEOBJ, FAIL, "unable to close temporary datatype");
     if (tconv_buf)
         tconv_buf = H5FL_BLK_FREE(attr_buf, tconv_buf);
     if (bkg_buf)
@@ -2084,10 +2063,10 @@ H5A__attr_copy_file(const H5A_t *attr_src, H5F_t *file_dst, bool *recompute_size
 {
     H5A_t   *attr_dst    = NULL; /* Destination attribute */
     H5T_t   *dt_mem      = NULL; /* Memory datatype */
+    H5S_t   *buf_space   = NULL; /* Dataspace describing buffer */
     void    *buf         = NULL; /* Buffer for copying data */
     void    *reclaim_buf = NULL; /* Buffer for reclaiming data */
     void    *bkg_buf     = NULL; /* Background buffer */
-    hid_t    buf_sid     = -1;   /* ID for buffer dataspace */
     hssize_t sdst_nelmts;        /* # of elements in destination attribute (signed) */
     size_t   dst_nelmts;         /* # of elements in destination attribute */
     size_t   dst_dt_size;        /* Size of destination attribute datatype */
@@ -2200,7 +2179,6 @@ H5A__attr_copy_file(const H5A_t *attr_src, H5F_t *file_dst, bool *recompute_size
             size_t      src_dt_size;                   /* Source datatype size */
             size_t      tmp_dt_size;                   /* Temp. datatype size */
             size_t      max_dt_size;                   /* Max atatype size */
-            H5S_t      *buf_space;                     /* Dataspace describing buffer */
             hsize_t     buf_dim;                       /* Dimension for buffer */
             size_t      nelmts;                        /* Number of elements in buffer */
             size_t      buf_size;                      /* Size of copy buffer */
@@ -2240,12 +2218,6 @@ H5A__attr_copy_file(const H5A_t *attr_src, H5F_t *file_dst, bool *recompute_size
             /* Create the space and set the initial extent */
             if (NULL == (buf_space = H5S_create_simple((unsigned)1, &buf_dim, NULL)))
                 HGOTO_ERROR(H5E_DATASPACE, H5E_CANTCREATE, NULL, "can't create simple dataspace");
-
-            /* Register */
-            if ((buf_sid = H5I_register(H5I_DATASPACE, buf_space, false)) < 0) {
-                H5S_close(buf_space);
-                HGOTO_ERROR(H5E_ID, H5E_CANTREGISTER, NULL, "unable to register dataspace ID");
-            } /* end if */
 
             /* Allocate memory for recclaim buf */
             if (NULL == (reclaim_buf = H5FL_BLK_MALLOC(attr_buf, buf_size)))
@@ -2304,10 +2276,10 @@ H5A__attr_copy_file(const H5A_t *attr_src, H5F_t *file_dst, bool *recompute_size
     ret_value = attr_dst;
 
 done:
-    if (buf_sid > 0 && H5I_dec_ref(buf_sid) < 0)
-        HDONE_ERROR(H5E_ATTR, H5E_CANTFREE, NULL, "can't decrement temporary dataspace ID");
     if (dt_mem && (H5T_close(dt_mem) < 0))
         HDONE_ERROR(H5E_ATTR, H5E_CANTCLOSEOBJ, NULL, "can't close temporary datatype");
+    if (buf_space && H5S_close(buf_space) < 0)
+        HDONE_ERROR(H5E_ATTR, H5E_CANTCLOSEOBJ, NULL, "can't close temporary dataspace");
     if (buf)
         buf = H5FL_BLK_FREE(attr_buf, buf);
     if (reclaim_buf)

--- a/src/H5D.c
+++ b/src/H5D.c
@@ -1853,7 +1853,7 @@ done:
 herr_t
 H5Diterate(void *buf, hid_t type_id, hid_t space_id, H5D_operator_t op, void *operator_data)
 {
-    H5T_t            *type;      /* Datatype */
+    const H5T_t      *type;      /* Datatype */
     H5S_t            *space;     /* Dataspace for iteration */
     H5S_sel_iter_op_t dset_op;   /* Operator for iteration */
     herr_t            ret_value; /* Return value */
@@ -1868,7 +1868,7 @@ H5Diterate(void *buf, hid_t type_id, hid_t space_id, H5D_operator_t op, void *op
         HGOTO_ERROR(H5E_ARGS, H5E_BADVALUE, FAIL, "invalid buffer");
     if (H5I_DATATYPE != H5I_get_type(type_id))
         HGOTO_ERROR(H5E_ARGS, H5E_BADTYPE, FAIL, "invalid datatype");
-    if (NULL == (type = (H5T_t *)H5I_object_verify(type_id, H5I_DATATYPE)))
+    if (NULL == (type = (const H5T_t *)H5I_object_verify(type_id, H5I_DATATYPE)))
         HGOTO_ERROR(H5E_ARGS, H5E_BADTYPE, FAIL, "not an valid base datatype");
     if (NULL == (space = (H5S_t *)H5I_object_verify(space_id, H5I_DATASPACE)))
         HGOTO_ERROR(H5E_ARGS, H5E_BADTYPE, FAIL, "invalid dataspace");

--- a/src/H5Dchunk.c
+++ b/src/H5Dchunk.c
@@ -179,15 +179,15 @@ typedef struct H5D_chunk_it_ud3_t {
     bool                  do_convert;   /* Whether to perform type conversions */
 
     /* needed for converting variable-length data */
-    H5T_t      *dt_src;           /* Source datatype */
-    H5T_t      *dt_dst;           /* Destination datatype */
-    H5T_t      *dt_mem;           /* Memory datatype */
-    H5T_path_t *tpath_src_mem;    /* Datatype conversion path from source file to memory */
-    H5T_path_t *tpath_mem_dst;    /* Datatype conversion path from memory to dest. file */
-    void       *reclaim_buf;      /* Buffer for reclaiming data */
-    size_t      reclaim_buf_size; /* Reclaim buffer size */
-    uint32_t    nelmts;           /* Number of elements in buffer */
-    H5S_t      *buf_space;        /* Dataspace describing buffer */
+    const H5T_t *dt_src;           /* Source datatype */
+    const H5T_t *dt_dst;           /* Destination datatype */
+    const H5T_t *dt_mem;           /* Memory datatype */
+    H5T_path_t  *tpath_src_mem;    /* Datatype conversion path from source file to memory */
+    H5T_path_t  *tpath_mem_dst;    /* Datatype conversion path from memory to dest. file */
+    void        *reclaim_buf;      /* Buffer for reclaiming data */
+    size_t       reclaim_buf_size; /* Reclaim buffer size */
+    uint32_t     nelmts;           /* Number of elements in buffer */
+    H5S_t       *buf_space;        /* Dataspace describing buffer */
 
     /* needed for compressed variable-length data */
     const H5O_pline_t *pline;      /* Filter pipeline */
@@ -296,9 +296,9 @@ static herr_t   H5D__create_piece_file_map_all(H5D_dset_io_info_t *di, H5D_io_in
 static herr_t   H5D__create_piece_file_map_hyper(H5D_dset_io_info_t *di, H5D_io_info_t *io_info);
 static herr_t   H5D__create_piece_mem_map_1d(const H5D_dset_io_info_t *di);
 static herr_t   H5D__create_piece_mem_map_hyper(const H5D_dset_io_info_t *di);
-static herr_t   H5D__piece_file_cb(void *elem, H5T_t *type, unsigned ndims, const hsize_t *coords,
+static herr_t   H5D__piece_file_cb(void *elem, const H5T_t *type, unsigned ndims, const hsize_t *coords,
                                    void *_opdata);
-static herr_t   H5D__piece_mem_cb(void *elem, H5T_t *type, unsigned ndims, const hsize_t *coords,
+static herr_t   H5D__piece_mem_cb(void *elem, const H5T_t *type, unsigned ndims, const hsize_t *coords,
                                   void *_opdata);
 static herr_t   H5D__chunk_may_use_select_io(H5D_io_info_t *io_info, const H5D_dset_io_info_t *dset_info);
 static unsigned H5D__chunk_hash_val(const H5D_shared_t *shared, const hsize_t *scaled);
@@ -1177,7 +1177,6 @@ H5D__chunk_io_init_selections(H5D_io_info_t *io_info, H5D_dset_io_info_t *dinfo)
     const H5D_t       *dataset;            /* Local pointer to dataset info */
     const H5T_t       *mem_type;           /* Local pointer to memory datatype */
     H5S_t             *tmp_mspace = NULL;  /* Temporary memory dataspace */
-    H5T_t             *file_type  = NULL;  /* Temporary copy of file datatype for iteration */
     bool               iter_init  = false; /* Selection iteration info has been initialized */
     char               bogus;              /* "bogus" buffer to pass to selection iterator */
     H5D_io_info_wrap_t io_info_wrap;
@@ -1280,10 +1279,6 @@ H5D__chunk_io_init_selections(H5D_io_info_t *io_info, H5D_dset_io_info_t *dinfo)
         else {
             H5S_sel_iter_op_t iter_op; /* Operator for iteration */
 
-            /* Create temporary datatypes for selection iteration */
-            if (NULL == (file_type = H5T_copy(dataset->shared->type, H5T_COPY_ALL)))
-                HGOTO_ERROR(H5E_DATATYPE, H5E_CANTCOPY, FAIL, "unable to copy file datatype");
-
             /* set opdata for H5D__piece_mem_cb */
             io_info_wrap.io_info = io_info;
             io_info_wrap.dinfo   = dinfo;
@@ -1291,7 +1286,8 @@ H5D__chunk_io_init_selections(H5D_io_info_t *io_info, H5D_dset_io_info_t *dinfo)
             iter_op.u.lib_op     = H5D__piece_file_cb;
 
             /* Spaces might not be the same shape, iterate over the file selection directly */
-            if (H5S_select_iterate(&bogus, file_type, dinfo->file_space, &iter_op, &io_info_wrap) < 0)
+            if (H5S_select_iterate(&bogus, dataset->shared->type, dinfo->file_space, &iter_op,
+                                   &io_info_wrap) < 0)
                 HGOTO_ERROR(H5E_DATASET, H5E_CANTINIT, FAIL, "unable to create file chunk selections");
 
             /* Reset "last piece" info */
@@ -1330,11 +1326,6 @@ H5D__chunk_io_init_selections(H5D_io_info_t *io_info, H5D_dset_io_info_t *dinfo)
             /* Save chunk template information */
             fm->mchunk_tmpl = tmp_mspace;
 
-            /* Create temporary datatypes for selection iteration */
-            if (!file_type)
-                if (NULL == (file_type = H5T_copy(dataset->shared->type, H5T_COPY_ALL)))
-                    HGOTO_ERROR(H5E_DATATYPE, H5E_CANTCOPY, FAIL, "unable to copy file datatype");
-
             /* Create selection iterator for memory selection */
             if (0 == (elmt_size = H5T_get_size(mem_type)))
                 HGOTO_ERROR(H5E_DATATYPE, H5E_BADSIZE, FAIL, "datatype size invalid");
@@ -1349,7 +1340,8 @@ H5D__chunk_io_init_selections(H5D_io_info_t *io_info, H5D_dset_io_info_t *dinfo)
             iter_op.u.lib_op     = H5D__piece_mem_cb;
 
             /* Spaces aren't the same shape, iterate over the memory selection directly */
-            if (H5S_select_iterate(&bogus, file_type, dinfo->file_space, &iter_op, &io_info_wrap) < 0)
+            if (H5S_select_iterate(&bogus, dataset->shared->type, dinfo->file_space, &iter_op,
+                                   &io_info_wrap) < 0)
                 HGOTO_ERROR(H5E_DATASET, H5E_CANTINIT, FAIL, "unable to create memory chunk selections");
         } /* end else */
     }     /* end else */
@@ -1367,8 +1359,6 @@ done:
 
     if (iter_init && H5S_SELECT_ITER_RELEASE(&(fm->mem_iter)) < 0)
         HDONE_ERROR(H5E_DATASPACE, H5E_CANTRELEASE, FAIL, "unable to release selection iterator");
-    if (file_type && (H5T_close_real(file_type) < 0))
-        HDONE_ERROR(H5E_DATATYPE, H5E_CANTFREE, FAIL, "Can't free temporary datatype");
 
     FUNC_LEAVE_NOAPI(ret_value)
 } /* end H5D__chunk_io_init_selections() */
@@ -2232,7 +2222,7 @@ done:
  *-------------------------------------------------------------------------
  */
 static herr_t
-H5D__piece_file_cb(void H5_ATTR_UNUSED *elem, H5T_t H5_ATTR_UNUSED *type, unsigned ndims,
+H5D__piece_file_cb(void H5_ATTR_UNUSED *elem, const H5T_t H5_ATTR_UNUSED *type, unsigned ndims,
                    const hsize_t *coords, void *_opdata)
 {
     H5D_io_info_wrap_t *opdata  = (H5D_io_info_wrap_t *)_opdata;
@@ -2358,7 +2348,7 @@ done:
  *-------------------------------------------------------------------------
  */
 static herr_t
-H5D__piece_mem_cb(void H5_ATTR_UNUSED *elem, H5T_t H5_ATTR_UNUSED *type, unsigned ndims,
+H5D__piece_mem_cb(void H5_ATTR_UNUSED *elem, const H5T_t H5_ATTR_UNUSED *type, unsigned ndims,
                   const hsize_t *coords, void *_opdata)
 {
     H5D_io_info_wrap_t *opdata = (H5D_io_info_wrap_t *)_opdata;
@@ -6573,7 +6563,7 @@ H5D__chunk_copy_cb(const H5D_chunk_rec_t *chunk_rec, void *_udata)
     bool                need_insert = false; /* Whether the chunk needs to be inserted into the index */
 
     /* General information about chunk copy */
-    H5T_t             *dt_src   = udata->dt_src;
+    const H5T_t       *dt_src   = udata->dt_src;
     void              *bkg      = udata->bkg;      /* Background buffer for datatype conversion */
     void              *buf      = udata->buf;      /* Chunk buffer for I/O & datatype conversions */
     size_t             buf_size = udata->buf_size; /* Size of chunk buffer */
@@ -6700,13 +6690,13 @@ H5D__chunk_copy_cb(const H5D_chunk_rec_t *chunk_rec, void *_udata)
 
     /* Perform datatype conversion, if necessary */
     if (is_vlen) {
-        H5T_path_t *tpath_src_mem    = udata->tpath_src_mem;
-        H5T_path_t *tpath_mem_dst    = udata->tpath_mem_dst;
-        H5T_t      *dt_dst           = udata->dt_dst;
-        H5T_t      *dt_mem           = udata->dt_mem;
-        H5S_t      *buf_space        = udata->buf_space;
-        void       *reclaim_buf      = udata->reclaim_buf;
-        size_t      reclaim_buf_size = udata->reclaim_buf_size;
+        H5T_path_t  *tpath_src_mem    = udata->tpath_src_mem;
+        H5T_path_t  *tpath_mem_dst    = udata->tpath_mem_dst;
+        const H5T_t *dt_dst           = udata->dt_dst;
+        const H5T_t *dt_mem           = udata->dt_mem;
+        H5S_t       *buf_space        = udata->buf_space;
+        void        *reclaim_buf      = udata->reclaim_buf;
+        size_t       reclaim_buf_size = udata->reclaim_buf_size;
 
         /* Convert from source file to memory */
         H5_CHECK_OVERFLOW(udata->nelmts, uint32_t, size_t);
@@ -6831,7 +6821,6 @@ H5D__chunk_copy(H5F_t *f_src, H5O_storage_chunk_t *storage_src, H5O_layout_chunk
     void              *bkg             = NULL;      /* Buffer for background during type conversion */
     void              *reclaim_buf     = NULL;      /* Buffer for reclaiming data */
     H5S_t             *buf_space       = NULL;      /* Dataspace describing buffer */
-    hid_t              sid_buf         = -1;        /* ID for buffer dataspace */
     uint32_t           nelmts          = 0;         /* Number of elements in buffer */
     bool               do_convert      = false;     /* Indicate that type conversions should be performed */
     bool               copy_setup_done = false;     /* Indicate that 'copy setup' is done */
@@ -6939,12 +6928,6 @@ H5D__chunk_copy(H5F_t *f_src, H5O_storage_chunk_t *storage_src, H5O_layout_chunk
         if (NULL == (buf_space = H5S_create_simple((unsigned)1, &buf_dim, NULL)))
             HGOTO_ERROR(H5E_DATASPACE, H5E_CANTCREATE, FAIL, "can't create simple dataspace");
 
-        /* Register */
-        if ((sid_buf = H5I_register(H5I_DATASPACE, buf_space, false)) < 0) {
-            (void)H5S_close(buf_space);
-            HGOTO_ERROR(H5E_ID, H5E_CANTREGISTER, FAIL, "unable to register dataspace ID");
-        } /* end if */
-
         /* Set initial buffer sizes */
         buf_size         = nelmts * max_dt_size;
         reclaim_buf_size = nelmts * mem_dt_size;
@@ -7039,8 +7022,6 @@ H5D__chunk_copy(H5F_t *f_src, H5O_storage_chunk_t *storage_src, H5O_layout_chunk
     bkg = udata.bkg;
 
 done:
-    if (sid_buf > 0 && H5I_dec_ref(sid_buf) < 0)
-        HDONE_ERROR(H5E_DATASET, H5E_CANTFREE, FAIL, "can't decrement temporary dataspace ID");
     /* Caller expects that source datatype will be freed */
     if (dt_src && (H5T_close(dt_src) < 0))
         HDONE_ERROR(H5E_DATASET, H5E_CANTCLOSEOBJ, FAIL, "can't close temporary datatype");
@@ -7048,6 +7029,8 @@ done:
         HDONE_ERROR(H5E_DATASET, H5E_CANTCLOSEOBJ, FAIL, "can't close temporary datatype");
     if (dt_mem && (H5T_close(dt_mem) < 0))
         HDONE_ERROR(H5E_DATASET, H5E_CANTCLOSEOBJ, FAIL, "can't close temporary datatype");
+    if (buf_space && H5S_close(buf_space) < 0)
+        HDONE_ERROR(H5E_DATASET, H5E_CANTCLOSEOBJ, FAIL, "can't close temporary dataspace");
     if (buf)
         H5MM_xfree(buf);
     if (bkg)

--- a/src/H5Dcontig.c
+++ b/src/H5Dcontig.c
@@ -1610,7 +1610,6 @@ H5D__contig_copy(H5F_t *f_src, const H5O_storage_contig_t *storage_src, H5F_t *f
     void         *bkg         = NULL;                          /* Temporary buffer for copying data */
     void         *reclaim_buf = NULL;                          /* Buffer for reclaiming data */
     H5S_t        *buf_space   = NULL;                          /* Dataspace describing buffer */
-    hid_t         buf_sid     = -1;                            /* ID for buffer dataspace */
     hsize_t       buf_dim[1]  = {0};                           /* Dimension for buffer */
     bool          is_vlen     = false; /* Flag to indicate that VL type conversion should occur */
     bool          fix_ref     = false; /* Flag to indicate that ref values should be fixed */
@@ -1688,12 +1687,6 @@ H5D__contig_copy(H5F_t *f_src, const H5O_storage_contig_t *storage_src, H5F_t *f
         /* Create the space and set the initial extent */
         if (NULL == (buf_space = H5S_create_simple((unsigned)1, buf_dim, NULL)))
             HGOTO_ERROR(H5E_DATASPACE, H5E_CANTCREATE, FAIL, "can't create simple dataspace");
-
-        /* Register */
-        if ((buf_sid = H5I_register(H5I_DATASPACE, buf_space, false)) < 0) {
-            H5S_close(buf_space);
-            HGOTO_ERROR(H5E_ID, H5E_CANTREGISTER, FAIL, "unable to register dataspace ID");
-        } /* end if */
 
         /* Set flag to do type conversion */
         is_vlen = true;
@@ -1819,8 +1812,6 @@ H5D__contig_copy(H5F_t *f_src, const H5O_storage_contig_t *storage_src, H5F_t *f
     } /* end while */
 
 done:
-    if (buf_sid > 0 && H5I_dec_ref(buf_sid) < 0)
-        HDONE_ERROR(H5E_DATASET, H5E_CANTFREE, FAIL, "can't decrement temporary dataspace ID");
     /* Caller expects that source datatype will be freed */
     if (dt_src && (H5T_close(dt_src) < 0))
         HDONE_ERROR(H5E_DATASET, H5E_CANTCLOSEOBJ, FAIL, "can't close temporary datatype");
@@ -1828,6 +1819,8 @@ done:
         HDONE_ERROR(H5E_DATASET, H5E_CANTCLOSEOBJ, FAIL, "can't close temporary datatype");
     if (dt_mem && (H5T_close(dt_mem) < 0))
         HDONE_ERROR(H5E_DATASET, H5E_CANTCLOSEOBJ, FAIL, "can't close temporary datatype");
+    if (buf_space && H5S_close(buf_space) < 0)
+        HDONE_ERROR(H5E_DATASET, H5E_CANTCLOSEOBJ, FAIL, "can't close temporary dataspace");
     if (buf)
         buf = H5FL_BLK_FREE(type_conv, buf);
     if (reclaim_buf)

--- a/src/H5Ddeprec.c
+++ b/src/H5Ddeprec.c
@@ -306,9 +306,9 @@ done:
 herr_t
 H5Dvlen_reclaim(hid_t type_id, hid_t space_id, hid_t dxpl_id, void *buf)
 {
-    H5T_t *type;
-    H5S_t *space;     /* Dataspace for iteration */
-    herr_t ret_value; /* Return value */
+    const H5T_t *type;
+    H5S_t       *space;     /* Dataspace for iteration */
+    herr_t       ret_value; /* Return value */
 
     FUNC_ENTER_API(FAIL)
     H5TRACE4("e", "iii*x", type_id, space_id, dxpl_id, buf);
@@ -316,7 +316,7 @@ H5Dvlen_reclaim(hid_t type_id, hid_t space_id, hid_t dxpl_id, void *buf)
     /* Check args */
     if (buf == NULL)
         HGOTO_ERROR(H5E_ARGS, H5E_BADVALUE, FAIL, "'buf' pointer is NULL");
-    if (NULL == (type = (H5T_t *)H5I_object_verify(type_id, H5I_DATATYPE)))
+    if (NULL == (type = (const H5T_t *)H5I_object_verify(type_id, H5I_DATATYPE)))
         HGOTO_ERROR(H5E_ARGS, H5E_BADTYPE, FAIL, "invalid datatype");
     if (NULL == (space = (H5S_t *)H5I_object_verify(space_id, H5I_DATASPACE)))
         HGOTO_ERROR(H5E_ARGS, H5E_BADTYPE, FAIL, "invalid dataspace");

--- a/src/H5Dfill.c
+++ b/src/H5Dfill.c
@@ -116,10 +116,8 @@ H5D__fill(const void *fill, const H5T_t *fill_type, void *buf, const H5T_t *buf_
     uint8_t         elem_buf[H5T_ELEM_BUF_SIZE];     /* Buffer for element data */
     H5WB_t         *bkg_elem_wb = NULL;              /* Wrapped buffer for background data */
     uint8_t         bkg_elem_buf[H5T_ELEM_BUF_SIZE]; /* Buffer for background data */
-    uint8_t        *bkg_buf  = NULL;                 /* Background conversion buffer */
-    uint8_t        *tmp_buf  = NULL;                 /* Temp conversion buffer */
-    H5T_t          *src_type = NULL;                 /* Source datatype */
-    H5T_t          *dst_type = NULL;                 /* Destination datatype */
+    uint8_t        *bkg_buf = NULL;                  /* Background conversion buffer */
+    uint8_t        *tmp_buf = NULL;                  /* Temp conversion buffer */
     size_t          dst_type_size;                   /* Size of destination type*/
     herr_t          ret_value = SUCCEED;             /* Return value */
 
@@ -170,15 +168,6 @@ H5D__fill(const void *fill, const H5T_t *fill_type, void *buf, const H5T_t *buf_
             HGOTO_ERROR(H5E_DATASET, H5E_UNSUPPORTED, FAIL,
                         "unable to convert between src and dest datatype");
 
-        /* Construct source & destination datatype IDs, if we will need them */
-        if (!H5T_path_noop(tpath)) {
-            if (NULL == (src_type = H5T_copy(fill_type, H5T_COPY_ALL)))
-                HGOTO_ERROR(H5E_DATASET, H5E_CANTCOPY, FAIL, "unable to copy fill value datatype");
-
-            if (NULL == (dst_type = H5T_copy(buf_type, H5T_COPY_ALL)))
-                HGOTO_ERROR(H5E_DATASET, H5E_CANTCOPY, FAIL, "unable to copy memory datatype");
-        } /* end if */
-
         /* If there's VL type of data, make multiple copies of fill value first,
          * then do conversion on each element so that each of them has a copy
          * of the VL data.
@@ -203,7 +192,7 @@ H5D__fill(const void *fill, const H5T_t *fill_type, void *buf, const H5T_t *buf_
             H5VM_array_fill(tmp_buf, fill, src_type_size, (size_t)nelmts);
 
             /* Convert from file's fill value into memory form */
-            if (H5T_convert(tpath, src_type, dst_type, (size_t)nelmts, (size_t)0, (size_t)0, tmp_buf,
+            if (H5T_convert(tpath, fill_type, buf_type, (size_t)nelmts, (size_t)0, (size_t)0, tmp_buf,
                             bkg_buf) < 0)
                 HGOTO_ERROR(H5E_DATASET, H5E_CANTCONVERT, FAIL, "data type conversion failed");
 
@@ -253,7 +242,7 @@ H5D__fill(const void *fill, const H5T_t *fill_type, void *buf, const H5T_t *buf_
                 } /* end if */
 
                 /* Perform datatype conversion */
-                if (H5T_convert(tpath, src_type, dst_type, (size_t)1, (size_t)0, (size_t)0, elem_ptr,
+                if (H5T_convert(tpath, fill_type, buf_type, (size_t)1, (size_t)0, (size_t)0, elem_ptr,
                                 bkg_ptr) < 0)
                     HGOTO_ERROR(H5E_DATASET, H5E_CANTCONVERT, FAIL, "data type conversion failed");
 
@@ -274,10 +263,6 @@ done:
         HDONE_ERROR(H5E_DATASET, H5E_CANTFREE, FAIL, "Can't release selection iterator");
     if (mem_iter)
         mem_iter = H5FL_FREE(H5S_sel_iter_t, mem_iter);
-    if (src_type && H5T_close(src_type) < 0)
-        HDONE_ERROR(H5E_DATASET, H5E_CANTCLOSEOBJ, FAIL, "unable to close temporary datatype");
-    if (dst_type && H5T_close(dst_type) < 0)
-        HDONE_ERROR(H5E_DATASET, H5E_CANTCLOSEOBJ, FAIL, "unable to close temporary datatype");
     if (tmp_buf)
         tmp_buf = H5FL_BLK_FREE(type_conv, tmp_buf);
     if (elem_wb && H5WB_unwrap(elem_wb) < 0)
@@ -302,7 +287,7 @@ done:
 herr_t
 H5D__fill_init(H5D_fill_buf_info_t *fb_info, void *caller_fill_buf, H5MM_allocate_t alloc_func,
                void *alloc_info, H5MM_free_t free_func, void *free_info, const H5O_fill_t *fill,
-               H5T_t *dset_type, size_t total_nelmts, size_t max_buf_size)
+               const H5T_t *dset_type, size_t total_nelmts, size_t max_buf_size)
 {
     herr_t ret_value = SUCCEED; /* Return value */
 

--- a/src/H5Dint.c
+++ b/src/H5Dint.c
@@ -88,7 +88,7 @@ static herr_t H5D__use_minimized_dset_headers(H5F_t *file, bool *minimize);
 static herr_t H5D__prepare_minimized_oh(H5F_t *file, H5D_t *dset, H5O_loc_t *oloc);
 static size_t H5D__calculate_minimum_header_size(H5F_t *file, H5D_t *dset, H5O_t *ohdr);
 static void  *H5D__vlen_get_buf_size_alloc(size_t size, void *info);
-static herr_t H5D__vlen_get_buf_size_cb(void *elem, H5T_t *type, unsigned ndim, const hsize_t *point,
+static herr_t H5D__vlen_get_buf_size_cb(void *elem, const H5T_t *type, unsigned ndim, const hsize_t *point,
                                         void *op_data);
 static herr_t H5D__vlen_get_buf_size_gen_cb(void *elem, hid_t type_id, unsigned ndim, const hsize_t *point,
                                             void *op_data);
@@ -2624,7 +2624,7 @@ done:
  *-------------------------------------------------------------------------
  */
 static herr_t
-H5D__vlen_get_buf_size_cb(void H5_ATTR_UNUSED *elem, H5T_t *type, unsigned H5_ATTR_UNUSED ndim,
+H5D__vlen_get_buf_size_cb(void H5_ATTR_UNUSED *elem, const H5T_t *type, unsigned H5_ATTR_UNUSED ndim,
                           const hsize_t *point, void *op_data)
 {
     H5D_vlen_bufsize_native_t *vlen_bufsize = (H5D_vlen_bufsize_native_t *)op_data;
@@ -2687,14 +2687,14 @@ H5D__vlen_get_buf_size(H5D_t *dset, hid_t type_id, hid_t space_id, hsize_t *size
     H5S_t                    *mspace       = NULL; /* Memory dataspace */
     char                      bogus;               /* bogus value to pass to H5Diterate() */
     H5S_t                    *space;               /* Dataspace for iteration */
-    H5T_t                    *type;                /* Datatype */
+    const H5T_t              *type;                /* Datatype */
     H5S_sel_iter_op_t         dset_op;             /* Operator for iteration */
     herr_t                    ret_value = FAIL;    /* Return value */
 
     FUNC_ENTER_PACKAGE
 
     /* Check args */
-    if (NULL == (type = (H5T_t *)H5I_object(type_id)))
+    if (NULL == (type = (const H5T_t *)H5I_object(type_id)))
         HGOTO_ERROR(H5E_ARGS, H5E_BADTYPE, FAIL, "not an valid base datatype");
     if (NULL == (space = (H5S_t *)H5I_object(space_id)))
         HGOTO_ERROR(H5E_ARGS, H5E_BADTYPE, FAIL, "invalid dataspace");
@@ -2828,7 +2828,7 @@ H5D__vlen_get_buf_size_gen(H5VL_object_t *vol_obj, hid_t type_id, hid_t space_id
     H5S_t                  *mspace = NULL;       /* Memory dataspace */
     char                    bogus;               /* Bogus value to pass to H5Diterate() */
     H5S_t                  *space;               /* Dataspace for iteration */
-    H5T_t                  *type;                /* Datatype */
+    const H5T_t            *type;                /* Datatype */
     H5S_sel_iter_op_t       dset_op;             /* Operator for iteration */
     H5VL_dataset_get_args_t vol_cb_args;         /* Arguments to VOL callback */
     herr_t                  ret_value = SUCCEED; /* Return value */
@@ -2836,7 +2836,7 @@ H5D__vlen_get_buf_size_gen(H5VL_object_t *vol_obj, hid_t type_id, hid_t space_id
     FUNC_ENTER_PACKAGE
 
     /* Check args */
-    if (NULL == (type = (H5T_t *)H5I_object(type_id)))
+    if (NULL == (type = (const H5T_t *)H5I_object(type_id)))
         HGOTO_ERROR(H5E_DATASET, H5E_BADTYPE, FAIL, "not an valid datatype");
     if (NULL == (space = (H5S_t *)H5I_object(space_id)))
         HGOTO_ERROR(H5E_DATASET, H5E_BADTYPE, FAIL, "invalid dataspace");
@@ -3560,8 +3560,8 @@ H5D_get_create_plist(const H5D_t *dset)
     H5O_layout_t    copied_layout;     /* Layout to tweak */
     H5O_fill_t      copied_fill = {0}; /* Fill value to tweak */
     H5O_efl_t       copied_efl;        /* External file list to tweak */
-    H5T_t          *src_type    = NULL;
     H5T_t          *dst_type    = NULL;
+    H5T_t          *tmp_type    = NULL;
     hid_t           new_dcpl_id = FAIL;
     hid_t           ret_value   = H5I_INVALID_HID; /* Return value */
 
@@ -3650,10 +3650,13 @@ H5D_get_create_plist(const H5D_t *dset)
             uint8_t *bkg_buf = NULL; /* Background conversion buffer */
             size_t   bkg_size;       /* Size of background buffer */
 
-            if (NULL == (src_type = H5T_copy(dset->shared->type, H5T_COPY_ALL)))
-                HGOTO_ERROR(H5E_DATASET, H5E_CANTCOPY, FAIL, "unable to copy dataset's datatype");
-            if (NULL == (dst_type = H5T_copy(copied_fill.type, H5T_COPY_TRANSIENT)))
-                HGOTO_ERROR(H5E_DATASET, H5E_CANTCOPY, FAIL, "unable to copy fill value datatype");
+            dst_type = copied_fill.type;
+            if (H5T_detect_class(dst_type, H5T_VLEN, false) > 0 ||
+                H5T_detect_class(dst_type, H5T_REFERENCE, false) > 0) {
+                if (NULL == (tmp_type = H5T_copy(dst_type, H5T_COPY_TRANSIENT)))
+                    HGOTO_ERROR(H5E_DATASET, H5E_CANTCOPY, FAIL, "unable to copy fill value datatype");
+                dst_type = tmp_type;
+            }
 
             /* Allocate a background buffer */
             bkg_size = MAX(H5T_GET_SIZE(copied_fill.type), H5T_GET_SIZE(dset->shared->type));
@@ -3661,8 +3664,8 @@ H5D_get_create_plist(const H5D_t *dset)
                 HGOTO_ERROR(H5E_DATASET, H5E_CANTALLOC, FAIL, "memory allocation failed");
 
             /* Convert fill value */
-            if (H5T_convert(tpath, src_type, dst_type, (size_t)1, (size_t)0, (size_t)0, copied_fill.buf,
-                            bkg_buf) < 0) {
+            if (H5T_convert(tpath, dset->shared->type, dst_type, (size_t)1, (size_t)0, (size_t)0,
+                            copied_fill.buf, bkg_buf) < 0) {
                 if (bkg_buf)
                     bkg_buf = H5FL_BLK_FREE(type_conv, bkg_buf);
                 HGOTO_ERROR(H5E_DATASET, H5E_CANTCONVERT, FAIL, "datatype conversion failed");
@@ -3699,9 +3702,7 @@ H5D_get_create_plist(const H5D_t *dset)
     ret_value = new_dcpl_id;
 
 done:
-    if (src_type && (H5T_close(src_type) < 0))
-        HDONE_ERROR(H5E_DATASET, H5E_CANTCLOSEOBJ, FAIL, "unable to close temporary datatype");
-    if (dst_type && (H5T_close(dst_type) < 0))
+    if (tmp_type && (H5T_close(tmp_type) < 0))
         HDONE_ERROR(H5E_DATASET, H5E_CANTCLOSEOBJ, FAIL, "unable to close temporary datatype");
 
     if (ret_value < 0) {

--- a/src/H5Dio.c
+++ b/src/H5Dio.c
@@ -46,7 +46,8 @@
 static herr_t H5D__ioinfo_init(size_t count, H5D_io_op_type_t op_type, H5D_dset_io_info_t *dset_info,
                                H5D_io_info_t *io_info);
 static herr_t H5D__dset_ioinfo_init(H5D_t *dset, H5D_dset_io_info_t *dset_info, H5D_storage_t *store);
-static herr_t H5D__typeinfo_init(H5D_io_info_t *io_info, H5D_dset_io_info_t *dset_info, H5T_t *mem_type);
+static herr_t H5D__typeinfo_init(H5D_io_info_t *io_info, H5D_dset_io_info_t *dset_info,
+                                 const H5T_t *mem_type);
 static herr_t H5D__typeinfo_init_phase2(H5D_io_info_t *io_info);
 static herr_t H5D__typeinfo_init_phase3(H5D_io_info_t *io_info);
 #ifdef H5_HAVE_PARALLEL
@@ -1040,7 +1041,7 @@ H5D__dset_ioinfo_init(H5D_t *dset, H5D_dset_io_info_t *dset_info, H5D_storage_t 
  *-------------------------------------------------------------------------
  */
 static herr_t
-H5D__typeinfo_init(H5D_io_info_t *io_info, H5D_dset_io_info_t *dset_info, H5T_t *mem_type)
+H5D__typeinfo_init(H5D_io_info_t *io_info, H5D_dset_io_info_t *dset_info, const H5T_t *mem_type)
 {
     H5D_type_info_t  *type_info;
     const H5D_t      *dset;

--- a/src/H5Dpkg.h
+++ b/src/H5Dpkg.h
@@ -120,8 +120,8 @@ typedef struct H5D_type_info_t {
     /* Initial values */
     const H5T_t *mem_type;  /* Pointer to memory datatype */
     const H5T_t *dset_type; /* Pointer to dataset datatype */
-    H5T_t       *src_type;  /* Pointer to source datatype */
-    H5T_t       *dst_type;  /* Pointer to destination datatype */
+    const H5T_t *src_type;  /* Pointer to source datatype */
+    const H5T_t *dst_type;  /* Pointer to destination datatype */
     H5T_path_t  *tpath;     /* Datatype conversion path */
 
     /* Computed/derived values */
@@ -278,7 +278,7 @@ typedef struct H5D_dset_io_info_t {
         H5D_piece_info_t       *contig_piece_info; /* Piece info for contiguous dataset */
     } layout_io_info;
 
-    H5T_t          *mem_type; /* memory datatype */
+    const H5T_t    *mem_type; /* memory datatype */
     H5D_type_info_t type_info;
     bool            skip_io; /* Whether to skip I/O for this dataset */
 } H5D_dset_io_info_t;
@@ -602,7 +602,7 @@ typedef struct H5D_fill_buf_info_t {
     void             *bkg_buf;                       /* Background conversion buffer */
     size_t            bkg_buf_size;                  /* Size of background buffer */
     H5T_t            *mem_type;                      /* Pointer to memory datatype */
-    H5T_t            *file_type;                     /* Pointer to file datatype */
+    const H5T_t      *file_type;                     /* Pointer to file datatype */
     size_t            mem_elmt_size, file_elmt_size; /* Size of element in memory and on disk */
     size_t            max_elmt_size;                 /* Max. size of memory or file datatype */
     size_t            elmts_per_buf;                 /* # of elements that fit into a buffer */
@@ -784,7 +784,7 @@ H5_DLL herr_t H5D__fill(const void *fill, const H5T_t *fill_type, void *buf, con
                         H5S_t *space);
 H5_DLL herr_t H5D__fill_init(H5D_fill_buf_info_t *fb_info, void *caller_fill_buf, H5MM_allocate_t alloc_func,
                              void *alloc_info, H5MM_free_t free_func, void *free_info, const H5O_fill_t *fill,
-                             H5T_t *dset_type, size_t nelmts, size_t min_buf_size);
+                             const H5T_t *dset_type, size_t nelmts, size_t min_buf_size);
 H5_DLL herr_t H5D__fill_refill_vl(H5D_fill_buf_info_t *fb_info, size_t nelmts);
 H5_DLL herr_t H5D__fill_term(H5D_fill_buf_info_t *fb_info);
 

--- a/src/H5Ocopy_ref.c
+++ b/src/H5Ocopy_ref.c
@@ -64,7 +64,7 @@ static herr_t H5O__copy_expand_ref_object1(H5O_loc_t *src_oloc, const void *buf_
 static herr_t H5O__copy_expand_ref_region1(H5O_loc_t *src_oloc, const void *buf_src, H5O_loc_t *dst_oloc,
                                            H5G_loc_t *dst_root_loc, void *buf_dst, size_t ref_count,
                                            H5O_copy_t *cpy_info);
-static herr_t H5O__copy_expand_ref_object2(H5O_loc_t *src_oloc, H5T_t *dt_src, const void *buf_src,
+static herr_t H5O__copy_expand_ref_object2(H5O_loc_t *src_oloc, const H5T_t *dt_src, const void *buf_src,
                                            size_t nbytes_src, H5O_loc_t *dst_oloc, H5G_loc_t *dst_root_loc,
                                            void *buf_dst, size_t ref_count, H5O_copy_t *cpy_info);
 
@@ -284,7 +284,7 @@ done:
  *-------------------------------------------------------------------------
  */
 static herr_t
-H5O__copy_expand_ref_object2(H5O_loc_t *src_oloc, H5T_t *dt_src, const void *buf_src, size_t nbytes_src,
+H5O__copy_expand_ref_object2(H5O_loc_t *src_oloc, const H5T_t *dt_src, const void *buf_src, size_t nbytes_src,
                              H5O_loc_t *dst_oloc, H5G_loc_t *dst_root_loc, void *buf_dst, size_t ref_count,
                              H5O_copy_t *cpy_info)
 {
@@ -411,7 +411,7 @@ done:
  *-------------------------------------------------------------------------
  */
 herr_t
-H5O_copy_expand_ref(H5F_t *file_src, H5T_t *dt_src, void *buf_src, size_t nbytes_src, H5F_t *file_dst,
+H5O_copy_expand_ref(H5F_t *file_src, const H5T_t *dt_src, void *buf_src, size_t nbytes_src, H5F_t *file_dst,
                     void *buf_dst, H5O_copy_t *cpy_info)
 {
     H5O_loc_t dst_oloc;     /* Copied object object location */

--- a/src/H5Oprivate.h
+++ b/src/H5Oprivate.h
@@ -985,7 +985,7 @@ H5_DLL herr_t H5O_refresh_metadata_reopen(hid_t oid, hid_t apl_id, H5G_loc_t *ob
 /* Object copying routines */
 H5_DLL herr_t H5O_copy_header_map(const H5O_loc_t *oloc_src, H5O_loc_t *oloc_dst /*out */,
                                   H5O_copy_t *cpy_info, bool inc_depth, H5O_type_t *obj_type, void **udata);
-H5_DLL herr_t H5O_copy_expand_ref(H5F_t *file_src, H5T_t *dt_src, void *buf_src, size_t nbytes_src,
+H5_DLL herr_t H5O_copy_expand_ref(H5F_t *file_src, const H5T_t *dt_src, void *buf_src, size_t nbytes_src,
                                   H5F_t *file_dst, void *buf_dst, H5O_copy_t *cpy_info);
 
 /* Debugging routines */

--- a/src/H5Pdcpl.c
+++ b/src/H5Pdcpl.c
@@ -3085,7 +3085,7 @@ H5P_get_fill_value(H5P_genplist_t *plist, const H5T_t *type, void *value /*out*/
     void       *buf       = NULL;    /*conversion buffer	*/
     void       *bkg       = NULL;    /*conversion buffer	*/
     H5T_t      *src_type  = NULL;    /*source datatype      */
-    H5T_t      *dst_type  = NULL;    /*destination datatype */
+    H5T_t      *tmp_type  = NULL;    /*temporary datatype   */
     herr_t      ret_value = SUCCEED; /* Return value */
 
     FUNC_ENTER_NOAPI(FAIL)
@@ -3112,10 +3112,14 @@ H5P_get_fill_value(H5P_genplist_t *plist, const H5T_t *type, void *value /*out*/
      */
     if (NULL == (tpath = H5T_path_find(fill.type, type)))
         HGOTO_ERROR(H5E_PLIST, H5E_CANTINIT, FAIL, "unable to convert between src and dst datatypes");
-    if (NULL == (src_type = H5T_copy(fill.type, H5T_COPY_TRANSIENT)))
-        HGOTO_ERROR(H5E_PLIST, H5E_CANTCOPY, FAIL, "unable to copy fill value datatype");
-    if (NULL == (dst_type = H5T_copy(type, H5T_COPY_ALL)))
-        HGOTO_ERROR(H5E_PLIST, H5E_CANTCOPY, FAIL, "unable to copy memory datatype");
+
+    src_type = fill.type;
+    if (H5T_detect_class(src_type, H5T_VLEN, false) > 0 ||
+        H5T_detect_class(src_type, H5T_REFERENCE, false) > 0) {
+        if (NULL == (tmp_type = H5T_copy(src_type, H5T_COPY_TRANSIENT)))
+            HGOTO_ERROR(H5E_PLIST, H5E_CANTCOPY, FAIL, "unable to copy fill value datatype");
+        src_type = tmp_type;
+    }
 
     /*
      * Data type conversions are always done in place, so we need a buffer
@@ -3136,7 +3140,7 @@ H5P_get_fill_value(H5P_genplist_t *plist, const H5T_t *type, void *value /*out*/
     H5MM_memcpy(buf, fill.buf, H5T_get_size(fill.type));
 
     /* Do the conversion */
-    if (H5T_convert(tpath, src_type, dst_type, (size_t)1, (size_t)0, (size_t)0, buf, bkg) < 0)
+    if (H5T_convert(tpath, src_type, type, (size_t)1, (size_t)0, (size_t)0, buf, bkg) < 0)
         HGOTO_ERROR(H5E_PLIST, H5E_CANTINIT, FAIL, "datatype conversion failed");
     if (buf != value)
         H5MM_memcpy(value, buf, H5T_get_size(type));
@@ -3146,9 +3150,7 @@ done:
         H5MM_xfree(buf);
     if (bkg != value)
         H5MM_xfree(bkg);
-    if (src_type && H5T_close(src_type) < 0)
-        HDONE_ERROR(H5E_PLIST, H5E_CANTCLOSEOBJ, FAIL, "unable to close temporary datatype");
-    if (dst_type && H5T_close(dst_type) < 0)
+    if (tmp_type && H5T_close(tmp_type) < 0)
         HDONE_ERROR(H5E_PLIST, H5E_CANTCLOSEOBJ, FAIL, "unable to close temporary datatype");
 
     FUNC_LEAVE_NOAPI(ret_value)

--- a/src/H5Sprivate.h
+++ b/src/H5Sprivate.h
@@ -106,7 +106,7 @@ typedef struct H5S_sel_iter_t {
 } H5S_sel_iter_t;
 
 /* Selection iteration operator for internal library callbacks */
-typedef herr_t (*H5S_sel_iter_lib_op_t)(void *elem, H5T_t *type, unsigned ndim, const hsize_t *point,
+typedef herr_t (*H5S_sel_iter_lib_op_t)(void *elem, const H5T_t *type, unsigned ndim, const hsize_t *point,
                                         void *op_data);
 
 /* Describe kind of callback to make */
@@ -231,32 +231,32 @@ H5_DLL herr_t  H5S_extent_copy(H5S_t *dst, const H5S_t *src);
 /* Operations on selections */
 H5_DLL herr_t       H5S_select_deserialize(H5S_t **space, const uint8_t **p, const size_t p_size);
 H5_DLL H5S_sel_type H5S_get_select_type(const H5S_t *space);
-H5_DLL herr_t       H5S_select_iterate(void *buf, H5T_t *type, H5S_t *space, const H5S_sel_iter_op_t *op,
-                                       void *op_data);
-H5_DLL herr_t       H5S_select_fill(const void *fill, size_t fill_size, H5S_t *space, void *buf);
-H5_DLL htri_t       H5S_select_valid(const H5S_t *space);
-H5_DLL hsize_t      H5S_get_select_npoints(const H5S_t *space);
-H5_DLL herr_t       H5S_get_select_bounds(const H5S_t *space, hsize_t *start, hsize_t *end);
-H5_DLL herr_t       H5S_get_select_offset(const H5S_t *space, hsize_t *offset);
-H5_DLL int          H5S_get_select_unlim_dim(const H5S_t *space);
-H5_DLL herr_t       H5S_get_select_num_elem_non_unlim(const H5S_t *space, hsize_t *num_elem_non_unlim);
-H5_DLL herr_t       H5S_select_offset(H5S_t *space, const hssize_t *offset);
-H5_DLL herr_t       H5S_select_copy(H5S_t *dst, const H5S_t *src, bool share_selection);
-H5_DLL htri_t       H5S_select_shape_same(H5S_t *space1, H5S_t *space2);
-H5_DLL htri_t       H5S_select_intersect_block(H5S_t *space, const hsize_t *start, const hsize_t *end);
-H5_DLL herr_t       H5S_select_construct_projection(H5S_t *base_space, H5S_t **new_space_ptr,
-                                                    unsigned new_space_rank, hsize_t element_size,
-                                                    ptrdiff_t *buf_adj);
-H5_DLL herr_t       H5S_select_release(H5S_t *ds);
-H5_DLL hssize_t     H5S_select_serial_size(H5S_t *space);
-H5_DLL herr_t       H5S_select_serialize(H5S_t *space, uint8_t **p);
-H5_DLL htri_t       H5S_select_is_contiguous(const H5S_t *space);
-H5_DLL htri_t       H5S_select_is_single(const H5S_t *space);
-H5_DLL htri_t       H5S_select_is_regular(H5S_t *space);
-H5_DLL herr_t       H5S_select_adjust_u(H5S_t *space, const hsize_t *offset);
-H5_DLL herr_t       H5S_select_adjust_s(H5S_t *space, const hssize_t *offset);
-H5_DLL herr_t       H5S_select_project_scalar(const H5S_t *space, hsize_t *offset);
-H5_DLL herr_t       H5S_select_project_simple(const H5S_t *space, H5S_t *new_space, hsize_t *offset);
+H5_DLL herr_t   H5S_select_iterate(void *buf, const H5T_t *type, H5S_t *space, const H5S_sel_iter_op_t *op,
+                                   void *op_data);
+H5_DLL herr_t   H5S_select_fill(const void *fill, size_t fill_size, H5S_t *space, void *buf);
+H5_DLL htri_t   H5S_select_valid(const H5S_t *space);
+H5_DLL hsize_t  H5S_get_select_npoints(const H5S_t *space);
+H5_DLL herr_t   H5S_get_select_bounds(const H5S_t *space, hsize_t *start, hsize_t *end);
+H5_DLL herr_t   H5S_get_select_offset(const H5S_t *space, hsize_t *offset);
+H5_DLL int      H5S_get_select_unlim_dim(const H5S_t *space);
+H5_DLL herr_t   H5S_get_select_num_elem_non_unlim(const H5S_t *space, hsize_t *num_elem_non_unlim);
+H5_DLL herr_t   H5S_select_offset(H5S_t *space, const hssize_t *offset);
+H5_DLL herr_t   H5S_select_copy(H5S_t *dst, const H5S_t *src, bool share_selection);
+H5_DLL htri_t   H5S_select_shape_same(H5S_t *space1, H5S_t *space2);
+H5_DLL htri_t   H5S_select_intersect_block(H5S_t *space, const hsize_t *start, const hsize_t *end);
+H5_DLL herr_t   H5S_select_construct_projection(H5S_t *base_space, H5S_t **new_space_ptr,
+                                                unsigned new_space_rank, hsize_t element_size,
+                                                ptrdiff_t *buf_adj);
+H5_DLL herr_t   H5S_select_release(H5S_t *ds);
+H5_DLL hssize_t H5S_select_serial_size(H5S_t *space);
+H5_DLL herr_t   H5S_select_serialize(H5S_t *space, uint8_t **p);
+H5_DLL htri_t   H5S_select_is_contiguous(const H5S_t *space);
+H5_DLL htri_t   H5S_select_is_single(const H5S_t *space);
+H5_DLL htri_t   H5S_select_is_regular(H5S_t *space);
+H5_DLL herr_t   H5S_select_adjust_u(H5S_t *space, const hsize_t *offset);
+H5_DLL herr_t   H5S_select_adjust_s(H5S_t *space, const hssize_t *offset);
+H5_DLL herr_t   H5S_select_project_scalar(const H5S_t *space, hsize_t *offset);
+H5_DLL herr_t   H5S_select_project_simple(const H5S_t *space, H5S_t *new_space, hsize_t *offset);
 H5_DLL herr_t H5S_select_project_intersection(H5S_t *src_space, H5S_t *dst_space, H5S_t *src_intersect_space,
                                               H5S_t **new_space_ptr, bool share_space);
 H5_DLL herr_t H5S_select_subtract(H5S_t *space, H5S_t *subtract_space);

--- a/src/H5Sselect.c
+++ b/src/H5Sselect.c
@@ -1357,7 +1357,7 @@ H5S_select_iter_release(H5S_sel_iter_t *sel_iter)
         the selection is not modified.
 --------------------------------------------------------------------------*/
 herr_t
-H5S_select_iterate(void *buf, H5T_t *type, H5S_t *space, const H5S_sel_iter_op_t *op, void *op_data)
+H5S_select_iterate(void *buf, const H5T_t *type, H5S_t *space, const H5S_sel_iter_op_t *op, void *op_data)
 {
     H5S_sel_iter_t *iter      = NULL;         /* Selection iteration info */
     bool            iter_init = false;        /* Selection iteration info has been initialized */

--- a/src/H5T.c
+++ b/src/H5T.c
@@ -2442,12 +2442,12 @@ done:
  *
  * Purpose:    Register a hard or soft conversion function for a data type
  *        conversion path.  The path is specified by the source and
- *        destination data types SRC_ID and DST_ID (for soft functions
- *        only the class of these types is important). If FUNC is a
- *        hard function then it replaces any previous path; if it's a
- *        soft function then it replaces all existing paths to which it
- *        applies and is used for any new path to which it applies as
- *        long as that path doesn't have a hard function.
+ *        destination data types SRC and DST (for soft functions only the
+ *        class of these types is important). If FUNC is a hard function
+ *        then it replaces any previous path; if it's a soft function then
+ *        it replaces all existing paths to which it applies and is used
+ *        for any new path to which it applies as long as that path doesn't
+ *        have a hard function.
  *
  * Return:    Non-negative on success/Negative on failure
  *
@@ -2537,14 +2537,14 @@ H5T__register(H5T_pers_t pers, const char *name, H5T_t *src, H5T_t *dst, H5T_con
                 old_path->dst->shared->type != dst->shared->type)
                 continue;
 
-            if (NULL == (tmp_stype = H5T_copy(old_path->src, H5T_COPY_ALL)))
-                HGOTO_ERROR(H5E_DATATYPE, H5E_CANTCOPY, FAIL, "unable to copy src datatype");
-            if (NULL == (tmp_dtype = H5T_copy(old_path->dst, H5T_COPY_ALL)))
-                HGOTO_ERROR(H5E_DATATYPE, H5E_CANTCOPY, FAIL, "unable to copy dst datatype");
-
             memset(&cdata, 0, sizeof cdata);
             cdata.command = H5T_CONV_INIT;
             if (conv->is_app) {
+                if (NULL == (tmp_stype = H5T_copy(old_path->src, H5T_COPY_ALL)))
+                    HGOTO_ERROR(H5E_DATATYPE, H5E_CANTCOPY, FAIL, "unable to copy src datatype");
+                if (NULL == (tmp_dtype = H5T_copy(old_path->dst, H5T_COPY_ALL)))
+                    HGOTO_ERROR(H5E_DATATYPE, H5E_CANTCOPY, FAIL, "unable to copy dst datatype");
+
                 if ((tmp_sid = H5I_register(H5I_DATATYPE, tmp_stype, false)) < 0)
                     HGOTO_ERROR(H5E_DATATYPE, H5E_CANTREGISTER, FAIL,
                                 "unable to register ID for source datatype");
@@ -2566,12 +2566,8 @@ H5T__register(H5T_pers_t pers, const char *name, H5T_t *src, H5T_t *dst, H5T_con
                     continue;
                 } /* end if */
             }     /* end if */
-            else if ((conv->u.lib_func)(tmp_stype, tmp_dtype, &cdata, &tmp_ctx, 0, 0, 0, NULL, NULL) < 0) {
-                if (H5T_close(tmp_stype) < 0)
-                    HGOTO_ERROR(H5E_DATATYPE, H5E_CANTCLOSEOBJ, FAIL, "unable to close temporary datatype");
-                if (H5T_close(tmp_dtype) < 0)
-                    HGOTO_ERROR(H5E_DATATYPE, H5E_CANTCLOSEOBJ, FAIL, "unable to close temporary datatype");
-                tmp_stype = tmp_dtype = NULL;
+            else if ((conv->u.lib_func)(old_path->src, old_path->dst, &cdata, &tmp_ctx, 0, 0, 0, NULL, NULL) <
+                     0) {
                 if (H5E_clear_stack(NULL) < 0)
                     HGOTO_ERROR(H5E_DATATYPE, H5E_CANTRESET, FAIL, "unable to clear current error stack");
                 continue;
@@ -2608,8 +2604,8 @@ H5T__register(H5T_pers_t pers, const char *name, H5T_t *src, H5T_t *dst, H5T_con
 #endif
                 } /* end if */
             }     /* end if */
-            else if ((old_path->conv.u.lib_func)(tmp_stype, tmp_dtype, &(old_path->cdata), NULL, 0, 0, 0,
-                                                 NULL, NULL) < 0) {
+            else if ((old_path->conv.u.lib_func)(old_path->src, old_path->dst, &(old_path->cdata), NULL, 0, 0,
+                                                 0, NULL, NULL) < 0) {
 #ifdef H5T_DEBUG
                 if (H5DEBUG(T))
                     fprintf(H5DEBUG(T),
@@ -2633,20 +2629,10 @@ H5T__register(H5T_pers_t pers, const char *name, H5T_t *src, H5T_t *dst, H5T_con
                 tmp_sid   = H5I_INVALID_HID;
                 tmp_stype = NULL;
             }
-            else if (tmp_stype) {
-                if (H5T_close(tmp_stype) < 0)
-                    HGOTO_ERROR(H5E_DATATYPE, H5E_CANTCLOSEOBJ, FAIL, "can't close temporary datatype");
-                tmp_stype = NULL;
-            }
             if (tmp_did >= 0) {
                 if (H5I_dec_ref(tmp_did) < 0)
                     HGOTO_ERROR(H5E_DATATYPE, H5E_CANTDEC, FAIL, "can't decrement reference on temporary ID");
                 tmp_did   = H5I_INVALID_HID;
-                tmp_dtype = NULL;
-            }
-            else if (tmp_dtype) {
-                if (H5T_close(tmp_dtype) < 0)
-                    HGOTO_ERROR(H5E_DATATYPE, H5E_CANTCLOSEOBJ, FAIL, "can't close temporary datatype");
                 tmp_dtype = NULL;
             }
 
@@ -3039,9 +3025,9 @@ done:
 herr_t
 H5Treclaim(hid_t type_id, hid_t space_id, hid_t dxpl_id, void *buf)
 {
-    H5T_t *type;
-    H5S_t *space;     /* Dataspace for iteration */
-    herr_t ret_value; /* Return value */
+    const H5T_t *type;
+    H5S_t       *space;     /* Dataspace for iteration */
+    herr_t       ret_value; /* Return value */
 
     FUNC_ENTER_API(FAIL)
     H5TRACE4("e", "iii*x", type_id, space_id, dxpl_id, buf);
@@ -3049,7 +3035,7 @@ H5Treclaim(hid_t type_id, hid_t space_id, hid_t dxpl_id, void *buf)
     /* Check args */
     if (buf == NULL)
         HGOTO_ERROR(H5E_ARGS, H5E_BADVALUE, FAIL, "'buf' pointer is NULL");
-    if (NULL == (type = (H5T_t *)H5I_object_verify(type_id, H5I_DATATYPE)))
+    if (NULL == (type = (const H5T_t *)H5I_object_verify(type_id, H5I_DATATYPE)))
         HGOTO_ERROR(H5E_ARGS, H5E_BADTYPE, FAIL, "invalid datatype");
     if (NULL == (space = (H5S_t *)H5I_object_verify(space_id, H5I_DATASPACE)))
         HGOTO_ERROR(H5E_ARGS, H5E_BADTYPE, FAIL, "invalid dataspace");
@@ -4881,11 +4867,11 @@ done:
 /*-------------------------------------------------------------------------
  * Function:    H5T_path_find
  *
- * Purpose:    Library-internal wrapper to find the path which converts type
- *              SRC_ID to type DST_ID.
+ * Purpose:    Library-internal wrapper to find the path which converts
+ *             type SRC to type DST.
  *
- *              If SRC and DST are both null pointers then the special no-op
- *              conversion path is used.
+ *             If SRC and DST are both null pointers then the special no-op
+ *             conversion path is used.
  *
  * Return:    Success:    Pointer to the path, valid until the path
  *                        database is modified.
@@ -4924,17 +4910,17 @@ done:
 /*-------------------------------------------------------------------------
  * Function:    H5T__path_find_real
  *
- * Purpose:    Finds the path which converts type SRC_ID to type DST_ID,
- *        creating a new path if necessary.  If FUNC is non-zero then
- *        it is set as the hard conversion function for that path
- *        regardless of whether the path previously existed. Changing
- *        the conversion function of a path causes statistics to be
- *        reset to zero after printing them.  The NAME is used only
- *        when creating a new path and is just for debugging.
+ * Purpose:    Finds the path which converts type SRC to type DST, creating
+ *             a new path if necessary.  If FUNC is non-zero then it is set
+ *             as the hard conversion function for that path regardless of
+ *             whether the path previously existed. Changing the conversion
+ *             function of a path causes statistics to be reset to zero
+ *             after printing them.  The NAME is used only when creating a
+ *             new path and is just for debugging.
  *
- *        If SRC and DST are both null pointers then the special no-op
- *        conversion path is used.  This path is always stored as the
- *        first path in the path table.
+ *             If SRC and DST are both null pointers then the special no-op
+ *             conversion path is used.  This path is always stored as the
+ *             first path in the path table.
  *
  * Return:    Success:    Pointer to the path, valid until the path
  *                        database is modified.
@@ -5078,13 +5064,18 @@ H5T__path_find_real(const H5T_t *src, const H5T_t *dst, const char *name, H5T_co
         (!table || (table && conv->is_app) || (table && !table->is_hard && !conv->is_app))) {
         assert(path != table);
         assert(NULL == path->conv.u.app_func);
-        if (path->src && (NULL == (tmp_stype = H5T_copy(path->src, H5T_COPY_ALL))))
-            HGOTO_ERROR(H5E_DATATYPE, H5E_CANTCOPY, NULL, "unable to copy source datatype");
-        if (path->dst && (NULL == (tmp_dtype = H5T_copy(path->dst, H5T_COPY_ALL))))
-            HGOTO_ERROR(H5E_DATATYPE, H5E_CANTCOPY, NULL, "unable to copy destination datatype");
 
         path->cdata.command = H5T_CONV_INIT;
         if (conv->is_app) {
+            /* Copy the conversion path's source and destination datatypes and
+             * register an ID for them so we can pass these to the application
+             * conversion function
+             */
+            if (path->src && (NULL == (tmp_stype = H5T_copy(path->src, H5T_COPY_ALL))))
+                HGOTO_ERROR(H5E_DATATYPE, H5E_CANTCOPY, NULL, "unable to copy source datatype");
+            if (path->dst && (NULL == (tmp_dtype = H5T_copy(path->dst, H5T_COPY_ALL))))
+                HGOTO_ERROR(H5E_DATATYPE, H5E_CANTCOPY, NULL, "unable to copy destination datatype");
+
             if (tmp_stype && ((src_id = H5I_register(H5I_DATATYPE, tmp_stype, false)) < 0))
                 HGOTO_ERROR(H5E_DATATYPE, H5E_CANTREGISTER, NULL,
                             "unable to register ID for source datatype");
@@ -5095,7 +5086,7 @@ H5T__path_find_real(const H5T_t *src, const H5T_t *dst, const char *name, H5T_co
             if ((conv->u.app_func)(src_id, dst_id, &(path->cdata), 0, 0, 0, NULL, NULL, H5CX_get_dxpl()) < 0)
                 HGOTO_ERROR(H5E_DATATYPE, H5E_CANTINIT, NULL, "unable to initialize conversion function");
         } /* end if */
-        else if ((conv->u.lib_func)(tmp_stype, tmp_dtype, &(path->cdata), &tmp_ctx, 0, 0, 0, NULL, NULL) < 0)
+        else if ((conv->u.lib_func)(path->src, path->dst, &(path->cdata), &tmp_ctx, 0, 0, 0, NULL, NULL) < 0)
             HGOTO_ERROR(H5E_DATATYPE, H5E_CANTINIT, NULL, "unable to initialize conversion function");
 
         if (src_id >= 0) {
@@ -5104,20 +5095,10 @@ H5T__path_find_real(const H5T_t *src, const H5T_t *dst, const char *name, H5T_co
             src_id    = H5I_INVALID_HID;
             tmp_stype = NULL;
         }
-        else if (tmp_stype) {
-            if (H5T_close(tmp_stype) < 0)
-                HGOTO_ERROR(H5E_DATATYPE, H5E_CANTCLOSEOBJ, NULL, "can't close temporary datatype");
-            tmp_stype = NULL;
-        }
         if (dst_id >= 0) {
             if (H5I_dec_ref(dst_id) < 0)
                 HGOTO_ERROR(H5E_DATATYPE, H5E_CANTDEC, NULL, "can't decrement reference on temporary ID");
             dst_id    = H5I_INVALID_HID;
-            tmp_dtype = NULL;
-        }
-        else if (tmp_dtype) {
-            if (H5T_close(tmp_dtype) < 0)
-                HGOTO_ERROR(H5E_DATATYPE, H5E_CANTCLOSEOBJ, NULL, "can't close temporary datatype");
             tmp_dtype = NULL;
         }
 
@@ -5138,19 +5119,21 @@ H5T__path_find_real(const H5T_t *src, const H5T_t *dst, const char *name, H5T_co
         if (src->shared->type != H5T_g.soft[i].src || dst->shared->type != H5T_g.soft[i].dst)
             continue;
 
-        assert(tmp_stype == NULL);
-        assert(tmp_dtype == NULL);
-
-        if (NULL == (tmp_stype = H5T_copy(path->src, H5T_COPY_ALL)))
-            HGOTO_ERROR(H5E_DATATYPE, H5E_CANTCOPY, NULL, "unable to copy source datatype");
-        if (NULL == (tmp_dtype = H5T_copy(path->dst, H5T_COPY_ALL)))
-            HGOTO_ERROR(H5E_DATATYPE, H5E_CANTCOPY, NULL, "unable to copy destination datatype");
-
         path->cdata.command = H5T_CONV_INIT;
         if (H5T_g.soft[i].conv.is_app) {
+            /* Copy the conversion path's source and destination datatypes and
+             * register an ID for them so we can pass these to the application
+             * conversion function
+             */
+            assert(tmp_stype == NULL);
+            assert(tmp_dtype == NULL);
+            if (NULL == (tmp_stype = H5T_copy(path->src, H5T_COPY_ALL)))
+                HGOTO_ERROR(H5E_DATATYPE, H5E_CANTCOPY, NULL, "unable to copy source datatype");
+            if (NULL == (tmp_dtype = H5T_copy(path->dst, H5T_COPY_ALL)))
+                HGOTO_ERROR(H5E_DATATYPE, H5E_CANTCOPY, NULL, "unable to copy destination datatype");
+
             assert(src_id == H5I_INVALID_HID);
             assert(dst_id == H5I_INVALID_HID);
-
             if ((src_id = H5I_register(H5I_DATATYPE, tmp_stype, false)) < 0)
                 HGOTO_ERROR(H5E_DATATYPE, H5E_CANTREGISTER, NULL,
                             "unable to register ID for source datatype");
@@ -5167,7 +5150,7 @@ H5T__path_find_real(const H5T_t *src, const H5T_t *dst, const char *name, H5T_co
                 path_init_error = true;
             } /* end if */
         }     /* end if */
-        else if ((H5T_g.soft[i].conv.u.lib_func)(tmp_stype, tmp_dtype, &(path->cdata), &tmp_ctx, 0, 0, 0,
+        else if ((H5T_g.soft[i].conv.u.lib_func)(path->src, path->dst, &(path->cdata), &tmp_ctx, 0, 0, 0,
                                                  NULL, NULL) < 0) {
             memset(&(path->cdata), 0, sizeof(H5T_cdata_t));
             /*ignore the error*/
@@ -5190,20 +5173,10 @@ H5T__path_find_real(const H5T_t *src, const H5T_t *dst, const char *name, H5T_co
             src_id    = H5I_INVALID_HID;
             tmp_stype = NULL;
         }
-        else if (tmp_stype) {
-            if (H5T_close(tmp_stype) < 0)
-                HGOTO_ERROR(H5E_DATATYPE, H5E_CANTCLOSEOBJ, NULL, "can't close temporary datatype");
-            tmp_stype = NULL;
-        }
         if (dst_id >= 0) {
             if (H5I_dec_ref(dst_id) < 0)
                 HGOTO_ERROR(H5E_DATATYPE, H5E_CANTDEC, NULL, "can't decrement reference on temporary ID");
             dst_id    = H5I_INVALID_HID;
-            tmp_dtype = NULL;
-        }
-        else if (tmp_dtype) {
-            if (H5T_close(tmp_dtype) < 0)
-                HGOTO_ERROR(H5E_DATATYPE, H5E_CANTCLOSEOBJ, NULL, "can't close temporary datatype");
             tmp_dtype = NULL;
         }
     } /* end for */
@@ -5287,14 +5260,6 @@ H5T__path_find_real(const H5T_t *src, const H5T_t *dst, const char *name, H5T_co
         H5T_g.path[md] = path;
         table          = path;
     } /* end else-if */
-
-    /* Set the flag to indicate both source and destination types are compound types
-     * for the optimization of data reading (in H5Dio.c).
-     * Make sure that path->are_compounds is only true for compound types.
-     */
-    path->are_compounds = false;
-    if (H5T_COMPOUND == H5T_get_class(src, true) && H5T_COMPOUND == H5T_get_class(dst, true))
-        path->are_compounds = true;
 
     /* Set return value */
     ret_value = path;
@@ -5563,7 +5528,7 @@ done:
  *-------------------------------------------------------------------------
  */
 herr_t
-H5T_convert(H5T_path_t *tpath, H5T_t *src_type, H5T_t *dst_type, size_t nelmts, size_t buf_stride,
+H5T_convert(H5T_path_t *tpath, const H5T_t *src_type, const H5T_t *dst_type, size_t nelmts, size_t buf_stride,
             size_t bkg_stride, void *buf, void *bkg)
 {
     H5T_conv_ctx_t conv_ctx = {0};
@@ -5656,8 +5621,9 @@ done:
  *-------------------------------------------------------------------------
  */
 herr_t
-H5T_convert_with_ctx(H5T_path_t *tpath, H5T_t *src_type, H5T_t *dst_type, const H5T_conv_ctx_t *conv_ctx,
-                     size_t nelmts, size_t buf_stride, size_t bkg_stride, void *buf, void *bkg)
+H5T_convert_with_ctx(H5T_path_t *tpath, const H5T_t *src_type, const H5T_t *dst_type,
+                     const H5T_conv_ctx_t *conv_ctx, size_t nelmts, size_t buf_stride, size_t bkg_stride,
+                     void *buf, void *bkg)
 {
     herr_t ret_value = SUCCEED;
 

--- a/src/H5Tenum.c
+++ b/src/H5Tenum.c
@@ -67,15 +67,14 @@ done:
 } /* end H5Tenum_create() */
 
 /*-------------------------------------------------------------------------
- * Function:	H5T__enum_create
+ * Function:    H5T__enum_create
  *
- * Purpose:	Private function for H5Tenum_create.  Create a new
+ * Purpose:     Private function for H5Tenum_create.  Create a new
  *              enumeration data type based on the specified
- *		TYPE, which must be an integer type.
+ *              TYPE, which must be an integer type.
  *
- * Return:	Success:	new enumeration data type
- *
- *		Failure:        NULL
+ * Return:      Success:    new enumeration data type
+ *              Failure:    NULL
  *
  *-------------------------------------------------------------------------
  */
@@ -91,9 +90,11 @@ H5T__enum_create(const H5T_t *parent)
     /* Build new type */
     if (NULL == (ret_value = H5T__alloc()))
         HGOTO_ERROR(H5E_RESOURCE, H5E_NOSPACE, NULL, "memory allocation failed");
-    ret_value->shared->type   = H5T_ENUM;
-    ret_value->shared->parent = H5T_copy(parent, H5T_COPY_ALL);
-    assert(ret_value->shared->parent);
+    ret_value->shared->type = H5T_ENUM;
+
+    if (NULL == (ret_value->shared->parent = H5T_copy(parent, H5T_COPY_ALL)))
+        HGOTO_ERROR(H5E_DATATYPE, H5E_CANTCOPY, NULL, "unable to copy base datatype for enum");
+
     ret_value->shared->size = ret_value->shared->parent->shared->size;
 
 done:

--- a/src/H5Tprivate.h
+++ b/src/H5Tprivate.h
@@ -135,20 +135,20 @@ H5_DLL H5T_bkg_t          H5T_path_bkg(const H5T_path_t *p);
 H5_DLL H5T_subset_info_t *H5T_path_compound_subset(const H5T_path_t *p);
 H5_DLL herr_t             H5T_unregister(H5T_pers_t pers, const char *name, H5T_t *src, H5T_t *dst,
                                          H5VL_object_t *owned_vol_obj, H5T_conv_t func);
-H5_DLL herr_t             H5T_convert(H5T_path_t *tpath, H5T_t *src_type, H5T_t *dst_type, size_t nelmts,
-                                      size_t buf_stride, size_t bkg_stride, void *buf, void *bkg);
-H5_DLL herr_t             H5T_reclaim(H5T_t *type, struct H5S_t *space, void *buf);
-H5_DLL herr_t   H5T_reclaim_cb(void *elem, H5T_t *dt, unsigned ndim, const hsize_t *point, void *op_data);
-H5_DLL herr_t   H5T_vlen_reclaim_elmt(void *elem, H5T_t *dt);
-H5_DLL htri_t   H5T_set_loc(H5T_t *dt, H5VL_object_t *file, H5T_loc_t loc);
-H5_DLL htri_t   H5T_is_sensible(const H5T_t *dt);
-H5_DLL uint32_t H5T_hash(H5F_t *file, const H5T_t *dt);
-H5_DLL herr_t   H5T_set_version(H5F_t *f, H5T_t *dt);
-H5_DLL herr_t   H5T_patch_file(H5T_t *dt, H5F_t *f);
-H5_DLL herr_t   H5T_patch_vlen_file(H5T_t *dt, H5VL_object_t *file);
-H5_DLL herr_t   H5T_own_vol_obj(H5T_t *dt, H5VL_object_t *vol_obj);
-H5_DLL htri_t   H5T_is_variable_str(const H5T_t *dt);
-H5_DLL H5T_t   *H5T_construct_datatype(H5VL_object_t *dt_obj);
+H5_DLL herr_t H5T_convert(H5T_path_t *tpath, const H5T_t *src_type, const H5T_t *dst_type, size_t nelmts,
+                          size_t buf_stride, size_t bkg_stride, void *buf, void *bkg);
+H5_DLL herr_t H5T_reclaim(const H5T_t *type, struct H5S_t *space, void *buf);
+H5_DLL herr_t H5T_reclaim_cb(void *elem, const H5T_t *dt, unsigned ndim, const hsize_t *point, void *op_data);
+H5_DLL herr_t H5T_vlen_reclaim_elmt(void *elem, H5T_t *dt);
+H5_DLL htri_t H5T_set_loc(H5T_t *dt, H5VL_object_t *file, H5T_loc_t loc);
+H5_DLL htri_t H5T_is_sensible(const H5T_t *dt);
+H5_DLL uint32_t       H5T_hash(H5F_t *file, const H5T_t *dt);
+H5_DLL herr_t         H5T_set_version(H5F_t *f, H5T_t *dt);
+H5_DLL herr_t         H5T_patch_file(H5T_t *dt, H5F_t *f);
+H5_DLL herr_t         H5T_patch_vlen_file(H5T_t *dt, H5VL_object_t *file);
+H5_DLL herr_t         H5T_own_vol_obj(H5T_t *dt, H5VL_object_t *vol_obj);
+H5_DLL htri_t         H5T_is_variable_str(const H5T_t *dt);
+H5_DLL H5T_t         *H5T_construct_datatype(H5VL_object_t *dt_obj);
 H5_DLL H5VL_object_t *H5T_get_named_type(const H5T_t *dt);
 H5_DLL H5T_t         *H5T_get_actual_type(H5T_t *dt);
 H5_DLL herr_t         H5T_save_refresh_state(hid_t tid, struct H5O_shared_t *cached_H5O_shared);

--- a/src/H5VLnative_dataset.c
+++ b/src/H5VLnative_dataset.c
@@ -119,7 +119,7 @@ H5VL__native_dataset_io_setup(size_t count, void *obj[], hid_t mem_type_id[], hi
                         "different files detected in multi dataset I/O request");
 
         /* Set up memory type */
-        if (NULL == (dinfo[i].mem_type = (H5T_t *)H5I_object_verify(mem_type_id[i], H5I_DATATYPE)))
+        if (NULL == (dinfo[i].mem_type = (const H5T_t *)H5I_object_verify(mem_type_id[i], H5I_DATATYPE)))
             HGOTO_ERROR(H5E_DATASET, H5E_BADTYPE, FAIL, "invalid datatype");
 
         /* Set up file dataspace */

--- a/test/dtypes.c
+++ b/test/dtypes.c
@@ -7387,6 +7387,107 @@ error:
 } /* end test_set_order_compound() */
 
 /*-------------------------------------------------------------------------
+ * Function:    test_enum_member_order
+ *
+ * Purpose:     Tests that datatype conversions don't perturb the ordering
+ *              of members within an enum datatype due to the way they sort
+ *              the members internally during conversion.
+ *
+ * Return:      Success:    0
+ *              Failure:    number of errors
+ *
+ *-------------------------------------------------------------------------
+ */
+#define NUM_MEMBERS 3
+static int
+test_enum_member_order(void)
+{
+    typedef enum { SOLID, LIQUID, GAS, PLASMA } phase_t;
+
+    const char *enum_names[4]              = {"SOLID", "LIQUID", "GAS", "PLASMA"};
+    phase_t     enum_int_buf[NUM_MEMBERS]  = {LIQUID, GAS, PLASMA};
+    long        enum_long_buf[NUM_MEMBERS] = {0, 0, 0};
+    hid_t       enum_type1                 = H5I_INVALID_HID;
+    hid_t       enum_type2                 = H5I_INVALID_HID;
+    int         val_int                    = -1;
+    long        val_long                   = -1;
+
+    TESTING("stability of enum member ordering after datatype conversion");
+
+    /* Test enum type */
+
+    if ((enum_type1 = H5Tenum_create(H5T_NATIVE_INT)) < 0)
+        TEST_ERROR;
+    if ((enum_type2 = H5Tenum_create(H5T_NATIVE_LONG)) < 0)
+        TEST_ERROR;
+
+    for (size_t i = 0; i < sizeof(enum_names) / sizeof(enum_names[0]); i++) {
+        val_int  = (int)i;
+        val_long = (long)i;
+
+        /* Insert members into enums in order: SOLID, LIQUID, GAS, PLASMA */
+        if (H5Tenum_insert(enum_type1, enum_names[i], &val_int) < 0)
+            TEST_ERROR;
+        if (H5Tenum_insert(enum_type2, enum_names[i], &val_long) < 0)
+            TEST_ERROR;
+    }
+
+    memcpy(enum_long_buf, enum_int_buf, NUM_MEMBERS * sizeof(int));
+
+    /* Convert from int enum type to long enum type */
+    if (H5Tconvert(enum_type1, enum_type2, NUM_MEMBERS, enum_long_buf, NULL, H5P_DEFAULT) < 0)
+        TEST_ERROR;
+
+    /* Sanity check */
+    for (size_t i = 0; i < NUM_MEMBERS; i++) {
+        if (enum_long_buf[i] != (long)enum_int_buf[i]) {
+            H5_FAILED();
+            printf("long enum buf member %zu mismatch after conversion; expected %ld, got %ld\n", i,
+                   (long)enum_int_buf[i], enum_long_buf[i]);
+            goto error;
+        }
+    }
+
+    /* Check that each enum type's members are in the same order we inserted them in */
+    for (size_t i = 0; i < sizeof(enum_names) / sizeof(enum_names[0]); i++) {
+        if (H5Tget_member_value(enum_type1, (unsigned)i, &val_int) < 0)
+            TEST_ERROR;
+        if (val_int != (int)i) {
+            H5_FAILED();
+            printf("int enum member %zu was out of order; expected %d, got %d\n", i, (int)i, val_int);
+            goto error;
+        }
+
+        if (H5Tget_member_value(enum_type2, (unsigned)i, &val_long) < 0)
+            TEST_ERROR;
+        if (val_long != (long)i) {
+            H5_FAILED();
+            printf("long enum member %zu was out of order; expected %ld, got %ld\n", i, (long)i, val_long);
+            goto error;
+        }
+    }
+
+    if (H5Tclose(enum_type1) < 0)
+        TEST_ERROR;
+    if (H5Tclose(enum_type2) < 0)
+        TEST_ERROR;
+
+    PASSED();
+
+    return 0;
+
+error:
+    H5E_BEGIN_TRY
+    {
+        H5Tclose(enum_type1);
+        H5Tclose(enum_type2);
+    }
+    H5E_END_TRY
+
+    return 1;
+}
+
+/*-------------------------------------------------------------------------
  * Function:    test_named_indirect_reopen
  *
  * Purpose:     Tests that open named datatypes can be reopened indirectly
@@ -9126,6 +9227,7 @@ main(void)
     nerrors += test_delete_obj_named(fapl);
     nerrors += test_delete_obj_named_fileid(fapl);
     nerrors += test_set_order_compound(fapl);
+    nerrors += test_enum_member_order();
     nerrors += test_str_create();
 #ifndef H5_NO_DEPRECATED_SYMBOLS
     nerrors += test_deprec(fapl);


### PR DESCRIPTION
Removes some datatype copying calls that are now unnecessary after refactoring the datatype conversion code to use pointers internally rather than IDs

Rewrites the enum conversion function so that it uses cached copies of the source and destination datatypes in order to avoid modifying the datatypes passed in

Adds a 'recursive' field to the datatype conversion context which allows the conversion functions for members of a container datatype to skip unnecessary repetitive conversion setup code

Changes internal datatype conversion callback functions so that the source and destination datatype structure pointers are const

Removes some unused and unnecessary internal IDs registered with H5I_register