### PR TITLE
Call memset before stat calls

### DIFF
--- a/hl/test/test_dset_append.c
+++ b/hl/test/test_dset_append.c
@@ -78,6 +78,7 @@ test_dataset_append_notset(hid_t fid)
     } /* end for */
 
     /* File size when not flushed */
+    memset(&sb1, 0, sizeof(h5_stat_t));
     if (HDstat(FILENAME, &sb1) < 0)
         TEST_ERROR;
 
@@ -86,6 +87,7 @@ test_dataset_append_notset(hid_t fid)
         FAIL_STACK_ERROR;
 
     /* File size after flushing */
+    memset(&sb2, 0, sizeof(h5_stat_t));
     if (HDstat(FILENAME, &sb2) < 0)
         TEST_ERROR;
 

--- a/src/H5FDcore.c
+++ b/src/H5FDcore.c
@@ -766,6 +766,7 @@ H5FD__core_open(const char *name, unsigned flags, hid_t fapl_id, haddr_t maxaddr
         if (fa->backing_store) {
             if ((fd = HDopen(name, o_flags | O_CREAT, H5_POSIX_CREATE_MODE_RW)) < 0)
                 HGOTO_ERROR(H5E_FILE, H5E_CANTOPENFILE, NULL, "unable to create file");
+            memset(&sb, 0, sizeof(h5_stat_t));
             if (HDfstat(fd, &sb) < 0)
                 HSYS_GOTO_ERROR(H5E_FILE, H5E_BADFILE, NULL, "unable to fstat file");
         } /* end if */
@@ -776,6 +777,7 @@ H5FD__core_open(const char *name, unsigned flags, hid_t fapl_id, haddr_t maxaddr
     else if (fa->backing_store || !(H5F_ACC_CREAT & flags)) {
         if ((fd = HDopen(name, o_flags, H5_POSIX_CREATE_MODE_RW)) < 0)
             HGOTO_ERROR(H5E_FILE, H5E_CANTOPENFILE, NULL, "unable to open file");
+        memset(&sb, 0, sizeof(h5_stat_t));
         if (HDfstat(fd, &sb) < 0)
             HSYS_GOTO_ERROR(H5E_FILE, H5E_BADFILE, NULL, "unable to fstat file");
     } /* end if */

--- a/src/H5FDdirect.c
+++ b/src/H5FDdirect.c
@@ -478,6 +478,7 @@ H5FD__direct_open(const char *name, unsigned flags, hid_t fapl_id, haddr_t maxad
     if ((fd = HDopen(name, o_flags, H5_POSIX_CREATE_MODE_RW)) < 0)
         HSYS_GOTO_ERROR(H5E_FILE, H5E_CANTOPENFILE, NULL, "unable to open file");
 
+    memset(&sb, 0, sizeof(h5_stat_t));
     if (HDfstat(fd, &sb) < 0)
         HSYS_GOTO_ERROR(H5E_FILE, H5E_BADFILE, NULL, "unable to fstat file");
 

--- a/src/H5FDlog.c
+++ b/src/H5FDlog.c
@@ -513,6 +513,7 @@ H5FD__log_open(const char *name, unsigned flags, hid_t fapl_id, haddr_t maxaddr)
         H5_timer_start(&stat_timer);
 
     /* Get the file stats */
+    memset(&sb, 0, sizeof(h5_stat_t));
     if (HDfstat(fd, &sb) < 0)
         HSYS_GOTO_ERROR(H5E_FILE, H5E_BADFILE, NULL, "unable to fstat file");
 

--- a/src/H5FDsec2.c
+++ b/src/H5FDsec2.c
@@ -325,6 +325,7 @@ H5FD__sec2_open(const char *name, unsigned flags, hid_t fapl_id, haddr_t maxaddr
             name, myerrno, strerror(myerrno), flags, (unsigned)o_flags);
     } /* end if */
 
+    memset(&sb, 0, sizeof(h5_stat_t));
     if (HDfstat(fd, &sb) < 0)
         HSYS_GOTO_ERROR(H5E_FILE, H5E_BADFILE, NULL, "unable to fstat file");
 

--- a/src/H5FDsubfiling/H5FDioc.c
+++ b/src/H5FDsubfiling/H5FDioc.c
@@ -1479,6 +1479,7 @@ H5FD__ioc_del(const char *name, hid_t fapl)
         char   *prefix_env      = NULL;
         int     num_digits      = 0;
 
+        memset(&st, 0, sizeof(h5_stat_t));
         if (HDstat(name, &st) < 0)
             H5_SUBFILING_SYS_GOTO_ERROR(H5E_FILE, H5E_SYSERRSTR, FAIL, "HDstat failed");
 

--- a/src/H5FDsubfiling/H5FDioc_threads.c
+++ b/src/H5FDsubfiling/H5FDioc_threads.c
@@ -1213,6 +1213,7 @@ ioc_file_report_eof(sf_work_request_t *msg, MPI_Comm comm)
 
     fd = sf_context->sf_fids[subfile_idx];
 
+    memset(&sb, 0, sizeof(h5_stat_t));
     if (HDfstat(fd, &sb) < 0)
         H5_SUBFILING_SYS_GOTO_ERROR(H5E_FILE, H5E_SYSERRSTR, -1, "HDfstat failed");
 

--- a/src/H5FDsubfiling/H5subfiling_common.c
+++ b/src/H5FDsubfiling/H5subfiling_common.c
@@ -565,6 +565,7 @@ H5_open_subfiling_stub_file(const char *name, unsigned flags, MPI_Comm file_comm
         HDcompile_assert(sizeof(uint64_t) >= sizeof(ino_t));
 
         /* Retrieve Inode value for stub file */
+        memset(&st, 0, sizeof(h5_stat_t));
         if (HDstat(name, &st) < 0) {
             stub_file_id = UINT64_MAX;
             H5_SUBFILING_GOTO_ERROR(H5E_VFL, H5E_CANTGET, FAIL,

--- a/src/H5Fint.c
+++ b/src/H5Fint.c
@@ -2783,6 +2783,7 @@ H5F__build_actual_name(const H5F_t *f, const H5P_genplist_t *fapl, const char *n
         h5_stat_t lst; /* Stat info from lstat() call */
 
         /* Call lstat() on the file's name */
+        memset(&lst, 0, sizeof(h5_stat_t));
         if (HDlstat(name, &lst) < 0)
             HGOTO_ERROR(H5E_FILE, H5E_CANTGET, FAIL, "can't retrieve stat info for file");
 
@@ -2825,10 +2826,12 @@ H5F__build_actual_name(const H5F_t *f, const H5P_genplist_t *fapl, const char *n
                 HGOTO_ERROR(H5E_FILE, H5E_CANTGET, FAIL, "can't retrieve POSIX file descriptor");
 
             /* Stat the filename we're resolving */
+            memset(&st, 0, sizeof(h5_stat_t));
             if (HDstat(name, &st) < 0)
                 HSYS_GOTO_ERROR(H5E_FILE, H5E_BADFILE, FAIL, "unable to stat file");
 
             /* Stat the file we opened */
+            memset(&fst, 0, sizeof(h5_stat_t));
             if (HDfstat(*fd, &fst) < 0)
                 HSYS_GOTO_ERROR(H5E_FILE, H5E_BADFILE, FAIL, "unable to fstat file");
 

--- a/src/H5PLpath.c
+++ b/src/H5PLpath.c
@@ -645,6 +645,7 @@ H5PL__path_table_iterate_process_path(const char *plugin_path, H5PL_iterate_type
             snprintf(path, len, "%s/%s", plugin_path, dp->d_name);
 
             /* Get info for directory entry */
+            memset(&my_stat, 0, sizeof(h5_stat_t));
             if (HDstat(path, &my_stat) == -1)
                 HGOTO_ERROR(H5E_FILE, H5E_CANTGET, H5_ITER_ERROR, "can't stat file %s -- error was: %s", path,
                             strerror(errno));
@@ -882,6 +883,7 @@ H5PL__find_plugin_in_path(const H5PL_search_params_t *search_params, bool *found
             snprintf(path, len, "%s/%s", dir, dp->d_name);
 
             /* Get info for directory entry */
+            memset(&my_stat, 0, sizeof(h5_stat_t));
             if (HDstat(path, &my_stat) == -1)
                 HGOTO_ERROR(H5E_FILE, H5E_CANTGET, FAIL, "can't stat file %s -- error was: %s", path,
                             strerror(errno));

--- a/test/big.c
+++ b/test/big.c
@@ -149,6 +149,7 @@ is_sparse(void)
         return 0;
     if (HDclose(fd) < 0)
         return 0;
+    memset(&sb, 0, sizeof(h5_stat_t));
     if (HDstat("x.h5", &sb) < 0)
         return 0;
     if (HDremove("x.h5") < 0)

--- a/test/btree2.c
+++ b/test/btree2.c
@@ -8665,6 +8665,7 @@ fprintf(stderr, "curr_time = %lu\n", (unsigned long)curr_time);
             TEST_ERROR;
 
         /* Retrieve the file's size */
+        memset(&sb, 0, sizeof(h5_stat_t));
         if (HDfstat(fd, &sb) < 0)
             TEST_ERROR;
 

--- a/test/file_image.c
+++ b/test/file_image.c
@@ -628,6 +628,7 @@ test_core(void)
     /* Create file image buffer */
     fd = HDopen(copied_filename, O_RDONLY);
     VERIFY(fd > 0, "open failed");
+    memset(&sb, 0, sizeof(h5_stat_t));
     ret = HDfstat(fd, &sb);
     VERIFY(ret == 0, "fstat failed");
     size       = (size_t)sb.st_size;
@@ -704,6 +705,8 @@ test_get_file_image(const char *test_banner, const int file_name_num, hid_t fapl
     herr_t    ret;
 
     TESTING(test_banner);
+
+    memset(&stat_buf, 0, sizeof(h5_stat_t));
 
     /* set flag if we are dealing with a family file */
     driver = H5Pget_driver(fapl);

--- a/test/h5test.c
+++ b/test/h5test.c
@@ -628,6 +628,7 @@ h5_fixname_real(const char *base_name, hid_t fapl, const char *_suffix, char *fu
                  */
                 h5_stat_t buf;
 
+                memset(&buf, 0, sizeof(h5_stat_t));
                 if (HDstat(fullname, &buf) < 0)
                     /* The directory doesn't exist just yet */
                     if (HDmkdir(fullname, (mode_t)0755) < 0 && errno != EEXIST)
@@ -1067,6 +1068,8 @@ h5_get_file_size(const char *filename, hid_t fapl)
     char      temp[2048]; /* Temporary buffer for file names */
     h5_stat_t sb;         /* Structure for querying file info */
     int       j = 0;
+
+    memset(&sb, 0, sizeof(h5_stat_t));
 
     if (fapl == H5P_DEFAULT) {
         /* Get the file's statistics */

--- a/test/istore.c
+++ b/test/istore.c
@@ -68,6 +68,7 @@ is_sparse(void)
         return 0;
     if (HDclose(fd) < 0)
         return 0;
+    memset(&sb, 0, sizeof(h5_stat_t));
     if (HDstat("x.h5", &sb) < 0)
         return 0;
     if (HDremove("x.h5") < 0)

--- a/test/tfile.c
+++ b/test/tfile.c
@@ -3262,6 +3262,7 @@ cal_chksum(const char *file, uint32_t *chksum)
     CHECK(fdes, FAIL, "HDopen");
 
     /* Retrieve the file's size */
+    memset(&sb, 0, sizeof(h5_stat_t));
     ret = HDfstat(fdes, &sb);
     CHECK(fdes, FAIL, "HDfstat");
 

--- a/testpar/t_shapesame.c
+++ b/testpar/t_shapesame.c
@@ -3985,6 +3985,7 @@ pause_proc(void)
     MPI_Get_processor_name(mpi_name, &mpi_namelen);
 
     if (MAINPROCESS)
+        memset(&statbuf, 0, sizeof(h5_stat_t));
         while ((HDstat(greenlight, &statbuf) == -1) && loops < maxloop) {
             if (!loops++) {
                 printf("Proc %d (%*s, %d): to debug, attach %d\n", mpi_rank, mpi_namelen, mpi_name, pid, pid);
@@ -3992,6 +3993,8 @@ pause_proc(void)
             printf("waiting(%ds) for file %s ...\n", time_int, greenlight);
             fflush(stdout);
             HDsleep(time_int);
+
+            memset(&statbuf, 0, sizeof(h5_stat_t));
         }
     MPI_Barrier(MPI_COMM_WORLD);
 }

--- a/testpar/t_shapesame.c
+++ b/testpar/t_shapesame.c
@@ -3986,16 +3986,16 @@ pause_proc(void)
 
     if (MAINPROCESS)
         memset(&statbuf, 0, sizeof(h5_stat_t));
-        while ((HDstat(greenlight, &statbuf) == -1) && loops < maxloop) {
-            if (!loops++) {
-                printf("Proc %d (%*s, %d): to debug, attach %d\n", mpi_rank, mpi_namelen, mpi_name, pid, pid);
-            }
-            printf("waiting(%ds) for file %s ...\n", time_int, greenlight);
-            fflush(stdout);
-            HDsleep(time_int);
-
-            memset(&statbuf, 0, sizeof(h5_stat_t));
+    while ((HDstat(greenlight, &statbuf) == -1) && loops < maxloop) {
+        if (!loops++) {
+            printf("Proc %d (%*s, %d): to debug, attach %d\n", mpi_rank, mpi_namelen, mpi_name, pid, pid);
         }
+        printf("waiting(%ds) for file %s ...\n", time_int, greenlight);
+        fflush(stdout);
+        HDsleep(time_int);
+
+        memset(&statbuf, 0, sizeof(h5_stat_t));
+    }
     MPI_Barrier(MPI_COMM_WORLD);
 }
 

--- a/testpar/t_shapesame.c
+++ b/testpar/t_shapesame.c
@@ -3984,17 +3984,18 @@ pause_proc(void)
     MPI_Comm_rank(MPI_COMM_WORLD, &mpi_rank);
     MPI_Get_processor_name(mpi_name, &mpi_namelen);
 
-    if (MAINPROCESS)
+    if (MAINPROCESS) {
         memset(&statbuf, 0, sizeof(h5_stat_t));
-    while ((HDstat(greenlight, &statbuf) == -1) && loops < maxloop) {
-        if (!loops++) {
-            printf("Proc %d (%*s, %d): to debug, attach %d\n", mpi_rank, mpi_namelen, mpi_name, pid, pid);
-        }
-        printf("waiting(%ds) for file %s ...\n", time_int, greenlight);
-        fflush(stdout);
-        HDsleep(time_int);
+        while ((HDstat(greenlight, &statbuf) == -1) && loops < maxloop) {
+            if (!loops++) {
+                printf("Proc %d (%*s, %d): to debug, attach %d\n", mpi_rank, mpi_namelen, mpi_name, pid, pid);
+            }
+            printf("waiting(%ds) for file %s ...\n", time_int, greenlight);
+            fflush(stdout);
+            HDsleep(time_int);
 
-        memset(&statbuf, 0, sizeof(h5_stat_t));
+            memset(&statbuf, 0, sizeof(h5_stat_t));
+        }
     }
     MPI_Barrier(MPI_COMM_WORLD);
 }

--- a/testpar/t_subfiling_vfd.c
+++ b/testpar/t_subfiling_vfd.c
@@ -367,6 +367,7 @@ test_config_file(void)
         char      scan_format[256];
         int       num_digits;
 
+        memset(&file_info, 0, sizeof(h5_stat_t));
         VRFY((HDstat(SUBF_FILENAME, &file_info) >= 0), "HDstat succeeded");
 
         config_filename = malloc(PATH_MAX);
@@ -586,6 +587,7 @@ test_stripe_sizes(void)
              * Get the current file size to see where we can safely
              * write to in the file without overwriting the superblock
              */
+            memset(&file_info, 0, sizeof(h5_stat_t));
             VRFY((HDstat(SUBF_FILENAME, &file_info) >= 0), "HDstat succeeded");
             file_size = (h5_stat_size_t)file_info.st_size;
 
@@ -626,6 +628,7 @@ test_stripe_sizes(void)
                 VRFY((fclose(subfile_ptr) >= 0), "fclose on subfile succeeded");
 
                 /* Check file size */
+                memset(&subfile_info, 0, sizeof(h5_stat_t));
                 VRFY((HDstat(tmp_filename, &subfile_info) >= 0), "HDstat succeeded");
                 subfile_size = (h5_stat_size_t)subfile_info.st_size;
 
@@ -672,6 +675,7 @@ test_stripe_sizes(void)
                 VRFY((fclose(subfile_ptr) >= 0), "fclose on subfile succeeded");
 
                 /* Check file size */
+                memset(&subfile_info, 0, sizeof(h5_stat_t));
                 VRFY((HDstat(tmp_filename, &subfile_info) >= 0), "HDstat succeeded");
                 subfile_size = (h5_stat_size_t)subfile_info.st_size;
 
@@ -736,6 +740,7 @@ test_stripe_sizes(void)
          * write to in the file without overwriting the superblock
          */
         if (MAINPROCESS) {
+            memset(&file_info, 0, sizeof(h5_stat_t));
             VRFY((HDstat(SUBF_FILENAME, &file_info) >= 0), "HDstat succeeded");
             file_size = (h5_stat_size_t)file_info.st_size;
 
@@ -792,6 +797,7 @@ test_stripe_sizes(void)
                 VRFY((fclose(subfile_ptr) >= 0), "fclose on subfile succeeded");
 
                 /* Check file size */
+                memset(&subfile_info, 0, sizeof(h5_stat_t));
                 VRFY((HDstat(tmp_filename, &subfile_info) >= 0), "HDstat succeeded");
                 subfile_size = (h5_stat_size_t)subfile_info.st_size;
 
@@ -849,6 +855,7 @@ test_stripe_sizes(void)
                 VRFY((fclose(subfile_ptr) >= 0), "fclose on subfile succeeded");
 
                 /* Check file size */
+                memset(&subfile_info, 0, sizeof(h5_stat_t));
                 VRFY((HDstat(tmp_filename, &subfile_info) >= 0), "HDstat succeeded");
                 subfile_size = (h5_stat_size_t)subfile_info.st_size;
 
@@ -994,6 +1001,7 @@ test_iovec_translation(void)
         VRFY((H5Fclose(file_id) >= 0), "H5Fclose succeeded");
 
         /* Retrieve file info to get the file inode for later use */
+        memset(&file_info, 0, sizeof(h5_stat_t));
         VRFY((HDstat(SUBF_FILENAME, &file_info) >= 0), "HDstat succeeded");
 
         /* Re-open file through H5FDopen for direct writes */
@@ -1044,6 +1052,7 @@ test_iovec_translation(void)
             VRFY((fclose(subfile_ptr) >= 0), "fclose on subfile succeeded");
 
             /* Check file size */
+            memset(&subfile_info, 0, sizeof(h5_stat_t));
             VRFY((HDstat(tmp_filename, &subfile_info) >= 0), "HDstat succeeded");
             subfile_size = (h5_stat_size_t)subfile_info.st_size;
 
@@ -1100,6 +1109,7 @@ test_iovec_translation(void)
         VRFY((H5Fclose(file_id) >= 0), "H5Fclose succeeded");
 
         /* Retrieve file info to get the file inode for later use */
+        memset(&file_info, 0, sizeof(h5_stat_t));
         VRFY((HDstat(SUBF_FILENAME, &file_info) >= 0), "HDstat succeeded");
 
         /* Re-open file through H5FDopen for direct writes */
@@ -1150,6 +1160,7 @@ test_iovec_translation(void)
             VRFY((fclose(subfile_ptr) >= 0), "fclose on subfile succeeded");
 
             /* Check file size */
+            memset(&subfile_info, 0, sizeof(h5_stat_t));
             VRFY((HDstat(tmp_filename, &subfile_info) >= 0), "HDstat succeeded");
             subfile_size = (h5_stat_size_t)subfile_info.st_size;
 
@@ -1196,6 +1207,7 @@ test_iovec_translation(void)
         VRFY((H5Fclose(file_id) >= 0), "H5Fclose succeeded");
 
         /* Retrieve file info to get the file inode for later use */
+        memset(&file_info, 0, sizeof(h5_stat_t));
         VRFY((HDstat(SUBF_FILENAME, &file_info) >= 0), "HDstat succeeded");
 
         /* Re-open file through H5FDopen for direct writes */
@@ -1246,6 +1258,7 @@ test_iovec_translation(void)
             VRFY((fclose(subfile_ptr) >= 0), "fclose on subfile succeeded");
 
             /* Check file size */
+            memset(&subfile_info, 0, sizeof(h5_stat_t));
             VRFY((HDstat(tmp_filename, &subfile_info) >= 0), "HDstat succeeded");
             subfile_size = (h5_stat_size_t)subfile_info.st_size;
 
@@ -1284,6 +1297,7 @@ test_iovec_translation(void)
         VRFY((H5Fclose(file_id) >= 0), "H5Fclose succeeded");
 
         /* Retrieve file info to get the file inode for later use */
+        memset(&file_info, 0, sizeof(h5_stat_t));
         VRFY((HDstat(SUBF_FILENAME, &file_info) >= 0), "HDstat succeeded");
 
         /* Re-open file through H5FDopen for direct writes */
@@ -1334,6 +1348,7 @@ test_iovec_translation(void)
             VRFY((fclose(subfile_ptr) >= 0), "fclose on subfile succeeded");
 
             /* Check file size */
+            memset(&subfile_info, 0, sizeof(h5_stat_t));
             VRFY((HDstat(tmp_filename, &subfile_info) >= 0), "HDstat succeeded");
             subfile_size = (h5_stat_size_t)subfile_info.st_size;
 
@@ -1378,6 +1393,7 @@ test_iovec_translation(void)
         VRFY((H5Fclose(file_id) >= 0), "H5Fclose succeeded");
 
         /* Retrieve file info to get the file inode for later use */
+        memset(&file_info, 0, sizeof(h5_stat_t));
         VRFY((HDstat(SUBF_FILENAME, &file_info) >= 0), "HDstat succeeded");
 
         /* Re-open file through H5FDopen for direct writes */
@@ -1428,6 +1444,7 @@ test_iovec_translation(void)
             VRFY((fclose(subfile_ptr) >= 0), "fclose on subfile succeeded");
 
             /* Check file size */
+            memset(&subfile_info, 0, sizeof(h5_stat_t));
             VRFY((HDstat(tmp_filename, &subfile_info) >= 0), "HDstat succeeded");
             subfile_size = (h5_stat_size_t)subfile_info.st_size;
 
@@ -1471,6 +1488,7 @@ test_iovec_translation(void)
         VRFY((H5Fclose(file_id) >= 0), "H5Fclose succeeded");
 
         /* Retrieve file info to get the file inode for later use */
+        memset(&file_info, 0, sizeof(h5_stat_t));
         VRFY((HDstat(SUBF_FILENAME, &file_info) >= 0), "HDstat succeeded");
 
         /* Re-open file through H5FDopen for direct writes */
@@ -1521,6 +1539,7 @@ test_iovec_translation(void)
             VRFY((fclose(subfile_ptr) >= 0), "fclose on subfile succeeded");
 
             /* Check file size */
+            memset(&subfile_info, 0, sizeof(h5_stat_t));
             VRFY((HDstat(tmp_filename, &subfile_info) >= 0), "HDstat succeeded");
             subfile_size = (h5_stat_size_t)subfile_info.st_size;
 
@@ -1717,6 +1736,7 @@ test_selection_strategies(void)
                     /*
                      * Get the file inode value so we can construct the subfile names
                      */
+                    memset(&file_info, 0, sizeof(h5_stat_t));
                     VRFY((HDstat(SUBF_FILENAME, &file_info) >= 0), "HDstat succeeded");
 
                     num_digits = (int)(log10(expected_num_subfiles) + 1);
@@ -1881,6 +1901,7 @@ test_read_different_stripe_size(void)
         int       num_subfiles = cfg.stripe_count;
         int       num_digits   = (int)(log10(num_subfiles) + 1);
 
+        memset(&file_info, 0, sizeof(h5_stat_t));
         VRFY((HDstat(SUBF_FILENAME, &file_info) >= 0), "HDstat succeeded");
 
         for (int j = 0; j < num_subfiles; j++) {
@@ -1897,6 +1918,7 @@ test_read_different_stripe_size(void)
 
             /* Check file size */
             if (!enable_compression) {
+                memset(&subfile_info, 0, sizeof(h5_stat_t));
                 VRFY((HDstat(tmp_filename, &subfile_info) >= 0), "HDstat succeeded");
                 subfile_size = (h5_stat_size_t)subfile_info.st_size;
 
@@ -1956,6 +1978,7 @@ test_read_different_stripe_size(void)
         int       num_subfiles = cfg.stripe_count;
         int       num_digits   = (int)(log10(num_subfiles / 2) + 1);
 
+        memset(&file_info, 0, sizeof(h5_stat_t));
         VRFY((HDstat(SUBF_FILENAME, &file_info) >= 0), "HDstat succeeded");
 
         for (int j = 0; j < num_subfiles; j++) {
@@ -2104,6 +2127,7 @@ test_subfiling_precreate_rank_0(void)
         num_subfiles = cfg.stripe_count;
         num_digits   = (int)(log10(num_subfiles) + 1);
 
+        memset(&file_info, 0, sizeof(h5_stat_t));
         VRFY((HDstat(SUBF_FILENAME, &file_info) >= 0), "HDstat succeeded");
 
         tmp_filename = malloc(PATH_MAX);
@@ -2122,6 +2146,7 @@ test_subfiling_precreate_rank_0(void)
 
             /* Check file size */
             if (!enable_compression) {
+                memset(&subfile_info, 0, sizeof(h5_stat_t));
                 VRFY((HDstat(tmp_filename, &subfile_info) >= 0), "HDstat succeeded");
                 file_size = (h5_stat_size_t)subfile_info.st_size;
 
@@ -2623,6 +2648,7 @@ test_subfiling_h5fuse(void)
      */
     HDcompile_assert(sizeof(uint64_t) >= sizeof(ino_t));
     if (MAINPROCESS) {
+        memset(&file_info, 0, sizeof(h5_stat_t));
         VRFY((HDstat(SUBF_FILENAME, &file_info) >= 0), "HDstat succeeded");
 
         file_inode = (uint64_t)file_info.st_ino;
@@ -2738,6 +2764,7 @@ test_subfiling_h5fuse(void)
 
         /* Verify the size of the fused file */
         if (!enable_compression) {
+            memset(&file_info, 0, sizeof(h5_stat_t));
             VRFY((HDstat(SUBF_FILENAME, &file_info) >= 0), "HDstat succeeded");
             VRFY(((size_t)file_info.st_size >= target_size), "File size verification succeeded");
         }

--- a/testpar/testphdf5.c
+++ b/testpar/testphdf5.c
@@ -74,6 +74,7 @@ pause_proc(void)
     MPI_Get_processor_name(mpi_name, &mpi_namelen);
 
     if (MAINPROCESS)
+        memset(&statbuf, 0, sizeof(h5_stat_t));
         while ((HDstat(greenlight, &statbuf) == -1) && loops < maxloop) {
             if (!loops++) {
                 printf("Proc %d (%*s, %d): to debug, attach %d\n", mpi_rank, mpi_namelen, mpi_name, pid, pid);
@@ -81,6 +82,8 @@ pause_proc(void)
             printf("waiting(%ds) for file %s ...\n", time_int, greenlight);
             fflush(stdout);
             HDsleep(time_int);
+
+            memset(&statbuf, 0, sizeof(h5_stat_t));
         }
     MPI_Barrier(MPI_COMM_WORLD);
 }

--- a/testpar/testphdf5.c
+++ b/testpar/testphdf5.c
@@ -73,17 +73,18 @@ pause_proc(void)
     MPI_Comm_rank(MPI_COMM_WORLD, &mpi_rank);
     MPI_Get_processor_name(mpi_name, &mpi_namelen);
 
-    if (MAINPROCESS)
+    if (MAINPROCESS) {
         memset(&statbuf, 0, sizeof(h5_stat_t));
-    while ((HDstat(greenlight, &statbuf) == -1) && loops < maxloop) {
-        if (!loops++) {
-            printf("Proc %d (%*s, %d): to debug, attach %d\n", mpi_rank, mpi_namelen, mpi_name, pid, pid);
-        }
-        printf("waiting(%ds) for file %s ...\n", time_int, greenlight);
-        fflush(stdout);
-        HDsleep(time_int);
+        while ((HDstat(greenlight, &statbuf) == -1) && loops < maxloop) {
+            if (!loops++) {
+                printf("Proc %d (%*s, %d): to debug, attach %d\n", mpi_rank, mpi_namelen, mpi_name, pid, pid);
+            }
+            printf("waiting(%ds) for file %s ...\n", time_int, greenlight);
+            fflush(stdout);
+            HDsleep(time_int);
 
-        memset(&statbuf, 0, sizeof(h5_stat_t));
+            memset(&statbuf, 0, sizeof(h5_stat_t));
+        }
     }
     MPI_Barrier(MPI_COMM_WORLD);
 }

--- a/testpar/testphdf5.c
+++ b/testpar/testphdf5.c
@@ -75,16 +75,16 @@ pause_proc(void)
 
     if (MAINPROCESS)
         memset(&statbuf, 0, sizeof(h5_stat_t));
-        while ((HDstat(greenlight, &statbuf) == -1) && loops < maxloop) {
-            if (!loops++) {
-                printf("Proc %d (%*s, %d): to debug, attach %d\n", mpi_rank, mpi_namelen, mpi_name, pid, pid);
-            }
-            printf("waiting(%ds) for file %s ...\n", time_int, greenlight);
-            fflush(stdout);
-            HDsleep(time_int);
-
-            memset(&statbuf, 0, sizeof(h5_stat_t));
+    while ((HDstat(greenlight, &statbuf) == -1) && loops < maxloop) {
+        if (!loops++) {
+            printf("Proc %d (%*s, %d): to debug, attach %d\n", mpi_rank, mpi_namelen, mpi_name, pid, pid);
         }
+        printf("waiting(%ds) for file %s ...\n", time_int, greenlight);
+        fflush(stdout);
+        HDsleep(time_int);
+
+        memset(&statbuf, 0, sizeof(h5_stat_t));
+    }
     MPI_Barrier(MPI_COMM_WORLD);
 }
 

--- a/tools/src/h5jam/h5jam.c
+++ b/tools/src/h5jam/h5jam.c
@@ -245,6 +245,7 @@ main(int argc, char *argv[])
         goto done;
     }
 
+    memset(&sbuf, 0, sizeof(h5_stat_t));
     res = HDfstat(ufid, &sbuf);
     if (res < 0) {
         error_msg("Can't stat file \"%s\"\n", ub_file);
@@ -261,6 +262,7 @@ main(int argc, char *argv[])
         goto done;
     }
 
+    memset(&sbuf2, 0, sizeof(h5_stat_t));
     res = HDfstat(h5fid, &sbuf2);
     if (res < 0) {
         error_msg("Can't stat file \"%s\"\n", input_file);
@@ -392,6 +394,7 @@ copy_some_to_file(int infid, int outfid, hsize_t starting, hsize_t startout, ssi
     } /* end if */
 
     if (limit < 0) {
+        memset(&sbuf, 0, sizeof(h5_stat_t));
         res = HDfstat(infid, &sbuf);
         if (res < 0) {
             error_msg("Can't stat file \n");

--- a/tools/src/h5jam/h5unjam.c
+++ b/tools/src/h5jam/h5unjam.c
@@ -241,6 +241,7 @@ main(int argc, char *argv[])
         goto done;
     }
 
+    memset(&sbuf, 0, sizeof(h5_stat_t));
     res = HDfstat(HDfileno(rawinstream), &sbuf);
     if (res < 0) {
         error_msg("Can't stat file \"%s\"\n", input_file);

--- a/tools/src/h5perf/pio_engine.c
+++ b/tools/src/h5perf/pio_engine.c
@@ -440,6 +440,7 @@ pio_create_filename(iotype iot, const char *base_name, char *fullname, size_t si
              * handled below. */
             h5_stat_t buf;
 
+            memset(&buf, 0, sizeof(h5_stat_t));
             if (HDstat(fullname, &buf) < 0)
                 /* The directory doesn't exist just yet */
                 if (HDmkdir(fullname, (mode_t)0755) < 0 && errno != EEXIST) {

--- a/tools/src/h5perf/sio_engine.c
+++ b/tools/src/h5perf/sio_engine.c
@@ -349,6 +349,7 @@ sio_create_filename(iotype iot, const char *base_name, char *fullname, size_t si
              * handled below. */
             h5_stat_t buf;
 
+            memset(&buf, 0, sizeof(h5_stat_t));
             if (HDstat(fullname, &buf) < 0)
                 /* The directory doesn't exist just yet */
                 if (HDmkdir(fullname, 0755) < 0 && errno != EEXIST) {

--- a/tools/src/misc/h5clear.c
+++ b/tools/src/misc/h5clear.c
@@ -327,6 +327,7 @@ main(int argc, char *argv[])
         haddr_t   eoa; /* The EOA value */
 
         /* Get the file's EOA and EOF */
+        memset(&st, 0, sizeof(h5_stat_t));
         if (H5Fget_eoa(fid, &eoa) < 0 || HDstat(fname, &st) < 0) {
             error_msg("H5Fget_eoa or HDstat\n");
             h5tools_setstatus(EXIT_FAILURE);

--- a/tools/src/misc/h5repart.c
+++ b/tools/src/misc/h5repart.c
@@ -239,6 +239,7 @@ main(int argc, char *argv[])
         exit(EXIT_FAILURE);
     }
 
+    memset(&sb, 0, sizeof(h5_stat_t));
     if (HDfstat(src, &sb) < 0) {
         perror("fstat");
         exit(EXIT_FAILURE);
@@ -358,6 +359,7 @@ main(int argc, char *argv[])
                 perror(src_name);
                 exit(EXIT_FAILURE);
             }
+            memset(&sb, 0, sizeof(h5_stat_t));
             if (HDfstat(src, &sb) < 0) {
                 perror("fstat");
                 exit(EXIT_FAILURE);

--- a/tools/test/h5repack/h5repacktst.c
+++ b/tools/test/h5repack/h5repacktst.c
@@ -1694,6 +1694,7 @@ main(void)
             GOERROR;
         if (h5repack(FNAME4, FNAME4OUT, &pack_options) < 0)
             GOERROR;
+        memset(&file_stat, 0, sizeof(h5_stat_t));
         if (HDstat(FNAME4OUT, &file_stat) < 0)
             GOERROR;
         fsize1 = file_stat.st_size;
@@ -1711,6 +1712,7 @@ main(void)
         if (h5repack_verify(FNAME4, FNAME4OUT, &pack_options) <= 0)
             GOERROR;
         /* record the file size of the output file */
+        memset(&file_stat, 0, sizeof(h5_stat_t));
         if (HDstat(FNAME4OUT, &file_stat) < 0)
             GOERROR;
         fsize2 = file_stat.st_size;

--- a/tools/test/perform/overhead.c
+++ b/tools/test/perform/overhead.c
@@ -231,6 +231,7 @@ test(fill_t fill_style, const double splits[], bool verbose, bool use_rdcc)
         if (verbose) {
             if (H5Fflush(file, H5F_SCOPE_LOCAL) < 0)
                 goto error;
+            memset(&sb, 0, sizeof(h5_stat_t));
             if (HDfstat(fd, &sb) < 0)
                 goto error;
             printf("%4lu %8.3f ***\n", (unsigned long)i,
@@ -276,6 +277,7 @@ test(fill_t fill_style, const double splits[], bool verbose, bool use_rdcc)
                 break;
         }
 
+        memset(&sb, 0, sizeof(h5_stat_t));
         if (HDfstat(fd, &sb) < 0)
             goto error;
         printf("%-7s %8.3f\n", sname,

--- a/tools/test/perform/zip_perf.c
+++ b/tools/test/perform/zip_perf.c
@@ -308,6 +308,7 @@ fill_with_random_data(Bytef *src, uLongf src_len)
     unsigned  u;
     h5_stat_t stat_buf;
 
+    memset(&stat_buf, 0, sizeof(h5_stat_t));
     if (HDstat("/dev/urandom", &stat_buf) == 0) {
         uLongf len = src_len;
         Bytef *buf = src;

--- a/utils/tools/h5dwalk/h5dwalk.c
+++ b/utils/tools/h5dwalk/h5dwalk.c
@@ -766,6 +766,7 @@ fill_file_list(mfu_flist new_flist, const char *config_filename, int myrank, int
         char       *eol = strchr(linebuf, '\n');
         if (eol)
             *eol = '\0';
+        memset(&statbuf, 0, sizeof(h5_stat_t));
         if (HDstat(linebuf, &statbuf) == 0) {
             if (myrank == (index % size)) {
                 mfu_flist_insert_stat((flist_t *)new_flist, linebuf, O_RDONLY, &statbuf);


### PR DESCRIPTION
The buffers passed to stat-like calls are only partially filled in by the call, leaving ununitialized memory areas when the stat buffers are created on the stack.

This change memsets the buffers to 0 before the stat calls, quieting the -fsanitze=memory complaints.