### PR TITLE
Use tar.gz extension for ABI reports

### DIFF
--- a/.github/workflows/abi-report.yml
+++ b/.github/workflows/abi-report.yml
@@ -170,7 +170,7 @@ jobs:
           cp ${{ inputs.file_base }}-hdf5_cpp_compat_report.html ${{ runner.workspace }}/buildabi/hdf5
           cp ${{ inputs.file_base }}-java_compat_report.html ${{ runner.workspace }}/buildabi/hdf5
           cd "${{ runner.workspace }}/buildabi"
-          tar -zcvf ${{ inputs.file_base }}.html.abi.reports hdf5
+          tar -zcvf ${{ inputs.file_base }}.html.abi.reports.tar.gz hdf5
         shell: bash
 
       - name: Save output as artifact

--- a/.github/workflows/release-files.yml
+++ b/.github/workflows/release-files.yml
@@ -160,7 +160,7 @@ jobs:
           sha256sum ${{ steps.get-file-base.outputs.FILE_BASE }}-win-vs2022_cl.zip >> sha256sums.txt
           sha256sum ${{ steps.get-file-base.outputs.FILE_BASE }}-ubuntu-2204_intel.tar.gz >> sha256sums.txt
           sha256sum ${{ steps.get-file-base.outputs.FILE_BASE }}-win-vs2022_intel.zip >> sha256sums.txt
-          sha256sum ${{ steps.get-file-base.outputs.FILE_BASE }}.html.abi.reports >> sha256sums.txt
+          sha256sum ${{ steps.get-file-base.outputs.FILE_BASE }}.html.abi.reports.tar.gz >> sha256sums.txt
 
       - name: Store snapshot name
         run: |
@@ -197,7 +197,7 @@ jobs:
               ${{ steps.get-file-base.outputs.FILE_BASE }}-win-vs2022_cl.zip
               ${{ steps.get-file-base.outputs.FILE_BASE }}-ubuntu-2204_intel.tar.gz
               ${{ steps.get-file-base.outputs.FILE_BASE }}-win-vs2022_intel.zip
-              ${{ steps.get-file-base.outputs.FILE_BASE }}.html.abi.reports
+              ${{ steps.get-file-base.outputs.FILE_BASE }}.html.abi.reports.tar.gz
               sha256sums.txt
               if-no-files-found: error # 'warn' or 'ignore' are also available, defaults to `warn`
 
@@ -221,7 +221,7 @@ jobs:
               ${{ steps.get-file-base.outputs.FILE_BASE }}-win-vs2022_cl.zip
               ${{ steps.get-file-base.outputs.FILE_BASE }}-ubuntu-2204_intel.tar.gz
               ${{ steps.get-file-base.outputs.FILE_BASE }}-win-vs2022_intel.zip
-              ${{ steps.get-file-base.outputs.FILE_BASE }}.html.abi.reports
+              ${{ steps.get-file-base.outputs.FILE_BASE }}.html.abi.reports.tar.gz
               sha256sums.txt
               if-no-files-found: error # 'warn' or 'ignore' are also available, defaults to `warn`
 

--- a/.github/workflows/remove-files.yml
+++ b/.github/workflows/remove-files.yml
@@ -45,7 +45,7 @@ jobs:
           token: ${{ github.token }}
           tag: "${{ inputs.use_tag }}"
           assets: |
-              ${{ steps.get-file-base.outputs.FILE_BASE }}.html.abi.reports
+              ${{ steps.get-file-base.outputs.FILE_BASE }}.html.abi.reports.tar.gz
               ${{ steps.get-file-base.outputs.FILE_BASE }}.doxygen.zip
               ${{ steps.get-file-base.outputs.FILE_BASE }}.tar.gz
               ${{ steps.get-file-base.outputs.FILE_BASE }}.zip


### PR DESCRIPTION
Users can't open `.reports` file easily without proper file extension after downloading it.