### PR TITLE
Reverts AC_SYS_LARGEFILE change

### DIFF
--- a/acsite.m4
+++ b/acsite.m4
@@ -1,0 +1,53 @@
+dnl -------------------------------------------------------------------------
+dnl -------------------------------------------------------------------------
+dnl
+dnl Copyright by The HDF Group.
+dnl All rights reserved.
+dnl
+dnl This file is part of HDF5.  The full HDF5 copyright notice, including
+dnl terms governing use, modification, and redistribution, is contained in
+dnl the COPYING file, which can be found at the root of the source code
+dnl dnl distribution tree, or in https://www.hdfgroup.org/licenses.
+dnl dnl If you do not have access to either file, you may request a copy from
+dnl dnl help@hdfgroup.org.
+dnl
+dnl Macros for HDF5 Fortran
+dnl
+dnl -------------------------------------------------------------------------
+dnl -------------------------------------------------------------------------
+
+dnl -------------------------------------------------------------------------
+dnl _AC_SYS_LARGEFILE_MACRO_VALUE
+dnl
+dnl The following macro overrides the autoconf macro of the same name
+dnl with this custom definition. This macro performs the same checks as
+dnl autoconf's native _AC_SYS_LARGEFILE_MACRO_VALUE, but will also set
+dnl AM_CPPFLAGS with the appropriate -D defines so additional configure
+dnl sizeof checks do not fail.
+dnl
+# _AC_SYS_LARGEFILE_MACRO_VALUE(C-MACRO, VALUE,
+#               CACHE-VAR,
+#               DESCRIPTION,
+#               PROLOGUE, [FUNCTION-BODY])
+# ----------------------------------------------------------
+m4_define([_AC_SYS_LARGEFILE_MACRO_VALUE],
+[AC_CACHE_CHECK([for $1 value needed for large files], [$3],
+[while :; do
+  m4_ifval([$6], [AC_LINK_IFELSE], [AC_COMPILE_IFELSE])(
+    [AC_LANG_PROGRAM([$5], [$6])],
+    [$3=no; break])
+  m4_ifval([$6], [AC_LINK_IFELSE], [AC_COMPILE_IFELSE])(
+    [AC_LANG_PROGRAM([@%:@define $1 $2
+$5], [$6])],
+    [$3=$2; break])
+  $3=unknown
+  break
+done])
+case $$3 in #(
+  no | unknown) ;;
+  *) AC_DEFINE_UNQUOTED([$1], [$$3], [$4])
+     AM_CPPFLAGS="-D$1=$$3 $AM_CPPFLAGS";;
+esac
+rm -rf conftest*[]dnl
+])# _AC_SYS_LARGEFILE_MACRO_VALUE
+

--- a/configure.ac
+++ b/configure.ac
@@ -1576,9 +1576,33 @@ if test "X${enable_shared}" = "Xyes"; then
 fi
 
 ## ----------------------------------------------------------------------
-## Set up large file support
+## Use the macro _AC_SYS_LARGEFILE_MACRO_VALUE to test defines
+## that might need to be set for largefile support to behave
+## correctly. This macro is defined in acsite.m4 and overrides
+## the version provided by Autoconf (as of v2.65). The custom
+## macro additionally adds the appropriate defines to AM_CPPFLAGS
+## so that later configure checks have them visible.
+##
+## NOTE: AC_SYS_LARGEFILE is buggy on some platforms and will
+##       NOT set the defines, even though it correctly detects
+##       the necessary values. These macro hacks are annoying
+##       but unfortunately will be necessary until we decide
+##       to drop support for platforms that don't have 64-bit
+##       off_t defaults.
 
-AC_SYS_LARGEFILE
+## Check for _FILE_OFFSET_BITS
+_AC_SYS_LARGEFILE_MACRO_VALUE([_FILE_OFFSET_BITS], [64],
+  [ac_cv_sys_file_offset_bits],
+  [Number of bits in a file offset, on hosts where this is settable.],
+  [_AC_SYS_LARGEFILE_TEST_INCLUDES])
+
+## Check for _LARGE_FILES
+if test "$ac_cv_sys_file_offset_bits" = unknown; then
+  _AC_SYS_LARGEFILE_MACRO_VALUE([_LARGE_FILES], [1],
+    [ac_cv_sys_large_files],
+    [Define for large files, on AIX-style hosts.],
+    [_AC_SYS_LARGEFILE_TEST_INCLUDES])
+fi
 
 ## ----------------------------------------------------------------------
 ## Add necessary defines for Linux Systems.


### PR DESCRIPTION
We previously replaced local macros with AC_SYS_LARGEFILE, which is unfortunately buggy on some systems and does not correctly set the necessary defines, despite successfully detecting them.

This restores the previous macro hacks to acsite.m4