### PR TITLE
Fix broken URLs in documentation

### DIFF
--- a/doc/parallel-compression.md
+++ b/doc/parallel-compression.md
@@ -154,7 +154,7 @@ optimal performance out of the parallel compression feature.
 
 ### Begin with a good chunking strategy
 
-[Starting with a good chunking strategy](https://portal.hdfgroup.org/display/HDF5/Chunking+in+HDF5)
+[Starting with a good chunking strategy](https://portal.hdfgroup.org/documentation/hdf5-docs/chunking_in_hdf5.html)
 will generally have the largest impact on overall application
 performance. The different chunking parameters can be difficult
 to fine-tune, but it is essential to start with a well-performing
@@ -166,7 +166,7 @@ chosen chunk size becomes a very important factor when compression
 is involved, as data chunks have to be completely read and
 re-written to perform partial writes to the chunk.
 
-[Improving I/O performance with HDF5 compressed datasets](https://portal.hdfgroup.org/display/HDF5/Improving+IO+Performance+When+Working+with+HDF5+Compressed+Datasets)
+[Improving I/O performance with HDF5 compressed datasets](https://support.hdfgroup.org/HDF5/doc/TechNotes/TechNote-HDF5-ImprovingIOPerformanceCompressedDatasets.pdf)
 is a useful reference for more information on getting good
 performance when using a chunked dataset layout.
 

--- a/doc/parallel-compression.md
+++ b/doc/parallel-compression.md
@@ -166,7 +166,7 @@ chosen chunk size becomes a very important factor when compression
 is involved, as data chunks have to be completely read and
 re-written to perform partial writes to the chunk.
 
-[Improving I/O performance with HDF5 compressed datasets](https://support.hdfgroup.org/HDF5/doc/TechNotes/TechNote-HDF5-ImprovingIOPerformanceCompressedDatasets.pdf)
+[Improving I/O performance with HDF5 compressed datasets](https://docs.hdfgroup.org/archive/support/HDF5/doc/TechNotes/TechNote-HDF5-ImprovingIOPerformanceCompressedDatasets.pdf)
 is a useful reference for more information on getting good
 performance when using a chunked dataset layout.
 

--- a/doxygen/aliases
+++ b/doxygen/aliases
@@ -234,14 +234,14 @@ ALIASES += sa_metadata_ops="\sa \li H5Pget_all_coll_metadata_ops() \li H5Pget_co
 # References
 ################################################################################
 
-ALIASES += ref_cons_semantics="<a href=\"https://portal.hdfgroup.org/display/HDF5/Enabling+a+Strict+Consistency+Semantics+Model+in+Parallel+HDF5\">Enabling a Strict Consistency Semantics Model in Parallel HDF5</a>"
-ALIASES += ref_file_image_ops="<a href=\"https://portal.hdfgroup.org/display/HDF5/HDF5+File+Image+Operations\">HDF5 File Image Operations</a>"
+ALIASES += ref_cons_semantics="<a href=\"https://docs.hdfgroup.org/hdf5/rfc/RFC%20PHDF5%20Consistency%20Semantics%20MC%20120328.docx.pdf\">Enabling a Strict Consistency Semantics Model in Parallel HDF5</a>"
+ALIASES += ref_file_image_ops="<a href=\"https://docs.hdfgroup.org/hdf5/rfc/HDF5FileImageOperations.pdf\">HDF5 File Image Operations</a>"
 ALIASES += ref_filter_pipe="<a href=\"https://portal.hdfgroup.org/display/HDF5/HDF5+Data+Flow+Pipeline+for+H5Dread\">Data Flow Pipeline for H5Dread()</a>"
-ALIASES += ref_group_impls="<a href=\"https://portal.hdfgroup.org/display/HDF5/Groups\">Group implementations in HDF5</a>"
-ALIASES += ref_h5lib_relver="<a href=\"https://portal.hdfgroup.org/display/HDF5/HDF5+Library+Release+Version+Numbers\">HDF5 Library Release Version Numbers</a>"
+ALIASES += ref_group_impls="<a href=\"https://docs.hdfgroup.org/hdf5/v1_14/group___h5_g.html\">Group implementations in HDF5</a>"
+ALIASES += ref_h5lib_relver="<a href=\"https://docs.hdfgroup.org/archive/support/HDF5/doc/TechNotes/Version.html\">HDF5 Library Release Version Numbers</a>"
 ALIASES += ref_mdc_in_hdf5="<a href=\"https://portal.hdfgroup.org/display/HDF5/Metadata+Caching+in+HDF5\">Metadata Caching in HDF5</a>"
 ALIASES += ref_mdc_logging="<a href=\"https://portal.hdfgroup.org/display/HDF5/H5F_START_MDC_LOGGING\">Metadata Cache Logging</a>"
-ALIASES += ref_news_112="<a href=\"https://portal.hdfgroup.org/display/HDF5/New+Features+in+HDF5+Release+1.12\">New Features in HDF5 Release 1.12</a>"
+ALIASES += ref_news_112="<a href=\"https://portal.hdfgroup.org/documentation/hdf5-docs/release_specifics/new_features_1_12.html\">New Features in HDF5 Release 1.12</a>"
 ALIASES += ref_h5ocopy="<a href=\"https://portal.hdfgroup.org/display/HDF5/Copying+Committed+Datatypes+with+H5Ocopy\">Copying Committed Datatypes with H5Ocopy()</a>"
 ALIASES += ref_sencode_fmt_change="<a href=\"https://portal.hdfgroup.org/pages/viewpage.action?pageId=58100093&preview=/58100093/58100094/encode_format_RFC.pdf\">RFC H5Secnode() / H5Sdecode() Format Change</a>"
 ALIASES += ref_vlen_strings="\Emph{Creating variable-length string datatypes}"

--- a/doxygen/aliases
+++ b/doxygen/aliases
@@ -237,7 +237,7 @@ ALIASES += sa_metadata_ops="\sa \li H5Pget_all_coll_metadata_ops() \li H5Pget_co
 ALIASES += ref_cons_semantics="<a href=\"https://docs.hdfgroup.org/hdf5/rfc/RFC%20PHDF5%20Consistency%20Semantics%20MC%20120328.docx.pdf\">Enabling a Strict Consistency Semantics Model in Parallel HDF5</a>"
 ALIASES += ref_file_image_ops="<a href=\"https://docs.hdfgroup.org/hdf5/rfc/HDF5FileImageOperations.pdf\">HDF5 File Image Operations</a>"
 ALIASES += ref_filter_pipe="<a href=\"https://portal.hdfgroup.org/display/HDF5/HDF5+Data+Flow+Pipeline+for+H5Dread\">Data Flow Pipeline for H5Dread()</a>"
-ALIASES += ref_group_impls="<a href=\"https://docs.hdfgroup.org/hdf5/v1_14/group___h5_g.html\">Group implementations in HDF5</a>"
+ALIASES += ref_group_impls="<a href=\"https://docs.hdfgroup.org/hdf5/develop/group___h5_g.html\">Group implementations in HDF5</a>"
 ALIASES += ref_h5lib_relver="<a href=\"https://docs.hdfgroup.org/archive/support/HDF5/doc/TechNotes/Version.html\">HDF5 Library Release Version Numbers</a>"
 ALIASES += ref_mdc_in_hdf5="<a href=\"https://portal.hdfgroup.org/display/HDF5/Metadata+Caching+in+HDF5\">Metadata Caching in HDF5</a>"
 ALIASES += ref_mdc_logging="<a href=\"https://portal.hdfgroup.org/display/HDF5/H5F_START_MDC_LOGGING\">Metadata Cache Logging</a>"

--- a/doxygen/dox/GettingStarted.dox
+++ b/doxygen/dox/GettingStarted.dox
@@ -42,7 +42,7 @@ Parallel HDF5, and the HDF5-1.10 VDS and SWMR new features:
 <table>
 <tr>
 <td style="background-color:#F5F5F5">
-<a href="https://portal.hdfgroup.org/display/HDF5/Introduction+to+the+HDF5+High+Level+APIs">Using the High Level APIs</a>
+<a href="https://docs.hdfgroup.org/hdf5/develop/high_level.html">Using the High Level APIs</a>
 </td>
 <td>
 \ref H5LT    \ref H5IM    \ref H5TB    \ref H5PT    \ref H5DS
@@ -72,7 +72,7 @@ HDF5-1.10 New Features
 </td>
 <td>
 \li <a href="https://portal.hdfgroup.org/display/HDF5/Introduction+to+the+Virtual+Dataset++-+VDS">Introduction to the Virtual Dataset - VDS</a>
-\li <a href="https://portal.hdfgroup.org/pages/viewpage.action?pageId=48812567">Introduction to Single-Writer/Multiple-Reader (SWMR)</a>
+\li <a href="https://docs.hdfgroup.org/hdf5/v1_14/group___s_w_m_r.html">Introduction to Single-Writer/Multiple-Reader (SWMR)</a>
 </td>
 </tr>
 <tr>

--- a/doxygen/dox/GettingStarted.dox
+++ b/doxygen/dox/GettingStarted.dox
@@ -72,7 +72,7 @@ HDF5-1.10 New Features
 </td>
 <td>
 \li <a href="https://portal.hdfgroup.org/display/HDF5/Introduction+to+the+Virtual+Dataset++-+VDS">Introduction to the Virtual Dataset - VDS</a>
-\li <a href="https://docs.hdfgroup.org/hdf5/v1_14/group___s_w_m_r.html">Introduction to Single-Writer/Multiple-Reader (SWMR)</a>
+\li <a href="https://docs.hdfgroup.org/hdf5/develop/group___s_w_m_r.html">Introduction to Single-Writer/Multiple-Reader (SWMR)</a>
 </td>
 </tr>
 <tr>

--- a/doxygen/dox/IntroHDF5.dox
+++ b/doxygen/dox/IntroHDF5.dox
@@ -608,7 +608,7 @@ on the <a href="http://hdfeos.org/">HDF-EOS Tools and Information Center</a> pag
 \section secHDF5Examples Examples
 \li \ref LBExamples
 \li \ref ExAPI
-\li <a href="https://portal.hdfgroup.org/display/HDF5/Examples+in+the+Source+Code">Examples in the Source Code</a>
+\li <a href="https://github.com/HDFGroup/hdf5/tree/develop/examples">Examples in the Source Code</a>
 \li <a href="https://portal.hdfgroup.org/display/HDF5/Other+Examples">Other Examples</a>
 
 \section secHDF5ExamplesCompile How To Compile

--- a/doxygen/dox/LearnHDFView.dox
+++ b/doxygen/dox/LearnHDFView.dox
@@ -7,7 +7,7 @@ This tutorial enables you to get a feel for HDF5 by using the HDFView browser. I
 any programming experience.
 
 \section sec_learn_hv_install HDFView Installation
-\li Download and install HDFView. It can be downloaded from the <a href="https://portal.hdfgroup.org/display/support/Download+HDFView">Download HDFView</a> page.
+\li Download and install HDFView. It can be downloaded from the <a href="https://portal.hdfgroup.org/downloads/hdfview/hdfview3_3_1.html">Download HDFView</a> page.
 \li Obtain the  <a href="https://support.hdfgroup.org/ftp/HDF5/examples/files/tutorial/storm1.txt">storm1.txt</a> text file, used in the tutorial.
 
 \section sec_learn_hv_begin Begin Tutorial

--- a/doxygen/dox/UsersGuide.dox
+++ b/doxygen/dox/UsersGuide.dox
@@ -374,7 +374,7 @@ These documents provide additional information for the use and tuning of specifi
 </tr>
   <tr style="height: 49.00pt;">
   <td style="width: 234.000pt; border-bottom-style: solid; border-bottom-width: 1px; border-bottom-color: #228a22; vertical-align: top;padding-left: 6.00pt; padding-top: 3.00pt; padding-right: 6.00pt; padding-bottom: 3.00pt;">
-  <p style="font-style: italic; color: #0000ff;"><span><a href="http://www.hdfgroup.org/HDF5/doc/Advanced/DynamicallyLoadedFilters/HDF5DynamicallyLoadedFilters.pdf">HDF5 Dynamically Loaded Filters</a></span></p>
+  <p style="font-style: italic; color: #0000ff;"><span><a href="https://docs.hdfgroup.org/hdf5/rfc/HDF5DynamicallyLoadedFilters.pdf">HDF5 Dynamically Loaded Filters</a></span></p>
 </td>
   <td style="width: 198.000pt; border-bottom-style: solid; border-bottom-width: 1px; border-bottom-color: #228a22; vertical-align: top;padding-left: 6.00pt; padding-top: 3.00pt; padding-right: 6.00pt; padding-bottom: 3.00pt;">
   <p>Describes how an HDF5 application can apply a filter that is not registered with the HDF5 Library.</p>
@@ -382,7 +382,7 @@ These documents provide additional information for the use and tuning of specifi
 </tr>
   <tr style="height: 62.00pt;">
   <td style="width: 234.000pt; border-bottom-style: solid; border-bottom-width: 1px; border-bottom-color: #228a22; vertical-align: top;padding-left: 6.00pt; padding-top: 3.00pt; padding-right: 6.00pt; padding-bottom: 3.00pt;">
-  <p style="font-style: italic; color: #0000ff;"><span><a href="http://www.hdfgroup.org/HDF5/doc/Advanced/FileImageOperations/HDF5FileImageOperations.pdf">HDF5 File Image Operations</a></span></p>
+  <p style="font-style: italic; color: #0000ff;"><span><a href="https://docs.hdfgroup.org/hdf5/rfc/HDF5FileImageOperations.pdf">HDF5 File Image Operations</a></span></p>
 </td>
   <td style="width: 198.000pt; border-bottom-style: solid; border-bottom-width: 1px; border-bottom-color: #228a22; vertical-align: top;padding-left: 6.00pt; padding-top: 3.00pt; padding-right: 6.00pt; padding-bottom: 3.00pt;">
   <p>Describes how to work with HDF5 files in memory. Disk I/O is not required when file images are opened, created, read from, or written to.</p>
@@ -390,7 +390,7 @@ These documents provide additional information for the use and tuning of specifi
 </tr>
   <tr style="height: 62.00pt;">
   <td style="width: 234.000pt; border-bottom-style: solid; border-bottom-width: 1px; border-bottom-color: #228a22; vertical-align: top;padding-left: 6.00pt; padding-top: 3.00pt; padding-right: 6.00pt; padding-bottom: 3.00pt;">
-  <p style="font-style: italic; color: #0000ff;"><span><a href="http://www.hdfgroup.org/HDF5/doc/Advanced/ModifiedRegionWrites/ModifiedRegionWrites.pdf">Modified Region Writes</a></span></p>
+  <p style="font-style: italic; color: #0000ff;"><span><a href="https://docs.hdfgroup.org/archive/support/HDF5/doc/Advanced/ModifiedRegionWrites/ModifiedRegionWrites.pdf">Modified Region Writes</a></span></p>
 </td>
   <td style="width: 198.000pt; border-bottom-style: solid; border-bottom-width: 1px; border-bottom-color: #228a22; vertical-align: top;padding-left: 6.00pt; padding-top: 3.00pt; padding-right: 6.00pt; padding-bottom: 3.00pt;">
   <p>Describes how to set write operations for in-memory files so that only modified regions are written to storage. Available when the Core (Memory) VFD is used.</p>

--- a/doxygen/dox/VOLConnGuide.dox
+++ b/doxygen/dox/VOLConnGuide.dox
@@ -92,7 +92,7 @@ Public header Files you will need to be familiar with include:
 </table>
 
 Many VOL connectors are listed on The HDF Group's VOL plugin registration page, located at:
-<a href="https://portal.hdfgroup.org/display/support/Registered+VOL+Connectors">Registered VOL Connectors</a>.
+<a href="https://portal.hdfgroup.org/documentation/hdf5-docs/registered_vol_connectors.html">Registered VOL Connectors</a>.
 Not all of these VOL connectors are supported by The HDF Group and the level of completeness varies, but the
 connectors found there can serve as examples of working implementations
 
@@ -195,7 +195,7 @@ contact <a href="help@hdfgroup.org">help@hdfgroup.org</a> for help with this. We
 name you've chosen will appear on the registered VOL connectors page.
 
 As noted above, registered VOL connectors will be listed at:
-<a href="https://portal.hdfgroup.org/display/support/Registered+VOL+Connectors">Registered VOL Connectors</a>
+<a href="https://portal.hdfgroup.org/documentation/hdf5-docs/registered_vol_connectors.html">Registered VOL Connectors</a>
 
 A new \b conn_version field has been added to the class struct for 1.13. This field is currently not used by
 the library so its use is determined by the connector author. Best practices for this field will be determined

--- a/doxygen/dox/ViewTools.dox
+++ b/doxygen/dox/ViewTools.dox
@@ -48,7 +48,7 @@ Navigate back: \ref index "Main" / \ref GettingStarted
 
 \section secViewToolsCommandObtain Obtain Tools and Files (Optional)
 Pre-built binaries for Linux and Windows are distributed within the respective HDF5 binary release
-packages, which can be obtained from the <a href="https://portal.hdfgroup.org/display/support/Download+HDF5">Download HDF5</a> page.
+packages, which can be obtained from the <a href="https://portal.hdfgroup.org/downloads/index.html">Download HDF5</a> page.
 
 HDF5 files can be obtained from various places such as \ref HDF5Examples and <a href="http://www.hdfeos.org/">HDF-EOS and Tools and
 Information Center</a>. Specifically, the following examples are used in this tutorial topic:

--- a/src/H5Fmodule.h
+++ b/src/H5Fmodule.h
@@ -235,10 +235,10 @@
  * Note that the root group, indicated above by /, was automatically created when the file was created.
  *
  * h5dump is described on the
- * <a href="https://portal.hdfgroup.org/display/HDF5/h5dump">Tools</a>
+ * <a href="https://docs.hdfgroup.org/hdf5/develop/_view_tools_view.html#subsecViewToolsViewContent_h5dump">Tools</a>
  * page under
- * <a href="https://portal.hdfgroup.org/display/HDF5/Libraries+and+Tools+Reference">
- * Libraries and Tools Reference</a>.
+ * <a href="https://docs.hdfgroup.org/hdf5/develop/_view_tools_command.html">
+ * Command-line Tools</a>.
  * The HDF5 DDL grammar is described in the document \ref DDLBNF114.
  *
  * \subsection subsec_file_summary File Function Summaries
@@ -888,7 +888,7 @@
  *
  * Additional parameters may be added to these functions in the future.
  *
- * @see <a href="https://portal.hdfgroup.org/display/HDF5/HDF5+File+Image+Operations">
+ * @see <a href="https://docs.hdfgroup.org/hdf5/rfc/HDF5FileImageOperations.pdf">
  * HDF5 File Image Operations</a>
  * section for information on more advanced usage of the Memory file driver, and
  * @see <a href="http://www.hdfgroup.org/HDF5/doc/Advanced/ModifiedRegionWrites/ModifiedRegionWrites.pdf">

--- a/src/H5Fmodule.h
+++ b/src/H5Fmodule.h
@@ -888,7 +888,7 @@
  *
  * Additional parameters may be added to these functions in the future.
  *
- * @see <a href="https://docs.hdfgroup.org/hdf5/rfc/HDF5FileImageOperations.pdf">
+ * @see <a href="https://portal.hdfgroup.org/documentation/hdf5-docs/advanced_topics/file_image_ops.html">
  * HDF5 File Image Operations</a>
  * section for information on more advanced usage of the Memory file driver, and
  * @see <a href="http://www.hdfgroup.org/HDF5/doc/Advanced/ModifiedRegionWrites/ModifiedRegionWrites.pdf">

--- a/src/H5Fmodule.h
+++ b/src/H5Fmodule.h
@@ -235,7 +235,8 @@
  * Note that the root group, indicated above by /, was automatically created when the file was created.
  *
  * h5dump is described on the
- * <a href="https://docs.hdfgroup.org/hdf5/develop/_view_tools_view.html#subsecViewToolsViewContent_h5dump">Tools</a>
+ * <a
+ * href="https://docs.hdfgroup.org/hdf5/develop/_view_tools_view.html#subsecViewToolsViewContent_h5dump">Tools</a>
  * page under
  * <a href="https://docs.hdfgroup.org/hdf5/develop/_view_tools_command.html">Command-line Tools</a>.
  * The HDF5 DDL grammar is described in the document \ref DDLBNF114.

--- a/src/H5Fmodule.h
+++ b/src/H5Fmodule.h
@@ -235,8 +235,8 @@
  * Note that the root group, indicated above by /, was automatically created when the file was created.
  *
  * h5dump is described on the
- * <a
- * href="https://docs.hdfgroup.org/hdf5/develop/_view_tools_view.html#subsecViewToolsViewContent_h5dump">Tools</a>
+ * <a href="https://docs.hdfgroup.org/hdf5/develop/_view_tools_view.html#subsecViewToolsViewContent_h5dump">
+ * Tools</a>
  * page under
  * <a href="https://docs.hdfgroup.org/hdf5/develop/_view_tools_command.html">Command-line Tools</a>.
  * The HDF5 DDL grammar is described in the document \ref DDLBNF114.

--- a/src/H5Fmodule.h
+++ b/src/H5Fmodule.h
@@ -235,11 +235,9 @@
  * Note that the root group, indicated above by /, was automatically created when the file was created.
  *
  * h5dump is described on the
- * <a
- * href="https://docs.hdfgroup.org/hdf5/develop/_view_tools_view.html#subsecViewToolsViewContent_h5dump">Tools</a>
+ * <a href="https://docs.hdfgroup.org/hdf5/develop/_view_tools_view.html#subsecViewToolsViewContent_h5dump">Tools</a>
  * page under
- * <a href="https://docs.hdfgroup.org/hdf5/develop/_view_tools_command.html">
- * Command-line Tools</a>.
+ * <a href="https://docs.hdfgroup.org/hdf5/develop/_view_tools_command.html">Command-line Tools</a>.
  * The HDF5 DDL grammar is described in the document \ref DDLBNF114.
  *
  * \subsection subsec_file_summary File Function Summaries

--- a/src/H5Fmodule.h
+++ b/src/H5Fmodule.h
@@ -235,7 +235,8 @@
  * Note that the root group, indicated above by /, was automatically created when the file was created.
  *
  * h5dump is described on the
- * <a href="https://docs.hdfgroup.org/hdf5/develop/_view_tools_view.html#subsecViewToolsViewContent_h5dump">Tools</a>
+ * <a
+ * href="https://docs.hdfgroup.org/hdf5/develop/_view_tools_view.html#subsecViewToolsViewContent_h5dump">Tools</a>
  * page under
  * <a href="https://docs.hdfgroup.org/hdf5/develop/_view_tools_command.html">
  * Command-line Tools</a>.

--- a/src/H5VLmodule.h
+++ b/src/H5VLmodule.h
@@ -83,7 +83,7 @@
  * to be much more common than internal implementations.
  *
  * A list of VOL connectors can be found here:
- * <a href="https://portal.hdfgroup.org/display/support/Registered+VOL+Connectors">
+ * <a href="https://portal.hdfgroup.org/documentation/hdf5-docs/registered_vol_connectors.html">
  * Registered VOL Connectors</a>
  *
  * This list is incomplete and only includes the VOL connectors that have been registered with


### PR DESCRIPTION
Fixes GH-3881 partially.  There are pages that need to be recreated.