### PR TITLE
Update Windows CI to not install ninja

### DIFF
--- a/.github/workflows/main-cmake.yml
+++ b/.github/workflows/main-cmake.yml
@@ -135,10 +135,6 @@ jobs:
 
       # CMake gets libaec from fetchcontent
 
-      - name: Install Dependencies (Windows)
-        run: choco install ninja
-        if: matrix.os == 'windows-latest'
-
       - name: Install Dependencies (macOS)
         run: brew install ninja
         if: matrix.os == 'macos-13'


### PR DESCRIPTION
We aren't using ninja in the workflow and it's causing CI actions to fail since https://community.chocolatey.org/api/v2/ is currently down. The OneAPI actions do use Ninja however, so those will likely still fail for now.