### PR TITLE
Use cp -rp in test_plugin.sh

### DIFF
--- a/test/test_plugin.sh.in
+++ b/test/test_plugin.sh.in
@@ -18,7 +18,7 @@ TOP_BUILDDIR=@top_builddir@
 EXIT_SUCCESS=0
 EXIT_FAILURE=1
 
-CP="cp -p"    # Use -p to preserve mode,ownership, timestamps
+CP="cp -rp"     # Use -p to preserve mode,ownership, timestamps
 RM="rm -rf"
 
 nerrors=0


### PR DESCRIPTION
When building with debug symbols on MacOS, the cp -p commands in test_plugin.sh will attempt to copy the .dSYM directories with debugging info, which will fail since -r is missing.

Using cp -rp is harmless and allows the test to run

Fixes HDFFV-10542