### PR TITLE
Determine MPI LOGICAL during build, used in tests.

### DIFF
--- a/config/cmake/HDF5UseFortran.cmake
+++ b/config/cmake/HDF5UseFortran.cmake
@@ -152,8 +152,12 @@ endif ()
 #-----------------------------------------------------------------------------
 # Determine the available KINDs for REALs and INTEGERs
 #-----------------------------------------------------------------------------
+if (${HAVE_ISO_FORTRAN_ENV})
+  READ_SOURCE ("PROGRAM FC08_AVAIL_KINDS" "END PROGRAM FC08_AVAIL_KINDS" SOURCE_CODE)
+else ()
+  READ_SOURCE ("PROGRAM FC_AVAIL_KINDS" "END PROGRAM FC_AVAIL_KINDS" SOURCE_CODE)
+endif ()
 
-READ_SOURCE ("PROGRAM FC_AVAIL_KINDS" "END PROGRAM FC_AVAIL_KINDS" SOURCE_CODE)
 FORTRAN_RUN ("REAL and INTEGER KINDs"
     "${SOURCE_CODE}"
     XX
@@ -167,6 +171,9 @@ FORTRAN_RUN ("REAL and INTEGER KINDs"
 # dnl    -- LINE 3 --  max decimal precision for reals
 # dnl    -- LINE 4 --  number of valid integer kinds
 # dnl    -- LINE 5 --  number of valid real kinds
+# dnl    -- LINE 6 --  number of valid logical kinds
+# dnl    -- LINE 7 --  valid logical kinds (comma separated list)
+
 #
 # Convert the string to a list of strings by replacing the carriage return with a semicolon
 string (REGEX REPLACE "[\r\n]+" ";" PROG_OUTPUT "${PROG_OUTPUT}")
@@ -201,6 +208,56 @@ message (STATUS "....NUMBER OF INTEGER KINDS FOUND ${PAC_FORTRAN_NUM_INTEGER_KIN
 message (STATUS "....REAL KINDS FOUND ${PAC_FC_ALL_REAL_KINDS}")
 message (STATUS "....INTEGER KINDS FOUND ${PAC_FC_ALL_INTEGER_KINDS}")
 message (STATUS "....MAX DECIMAL PRECISION ${${HDF_PREFIX}_PAC_FC_MAX_REAL_PRECISION}")
+
+if (${HAVE_ISO_FORTRAN_ENV})
+
+  list (GET PROG_OUTPUT 5 NUM_LKIND)
+  set (PAC_FORTRAN_NUM_LOGICAL_KINDS "${NUM_LKIND}")
+
+  list (GET PROG_OUTPUT 6 pac_validLogicalKinds)
+  # If the list is empty then something went wrong.
+  if (NOT pac_validLogicalKinds)
+      message (FATAL_ERROR "Failed to find available LOGICAL KINDs for Fortran")
+  endif ()
+
+  set (PAC_FC_ALL_LOGICAL_KINDS "\{${pac_validLogicalKinds}\}")
+  message (STATUS "....LOGICAL KINDS FOUND ${PAC_FC_ALL_LOGICAL_KINDS}")
+
+
+# ********************
+# LOGICAL KIND FOR MPI
+# ********************
+  if (HDF5_ENABLE_PARALLEL AND BUILD_TESTING)
+    string (REGEX REPLACE "," ";" VAR "${pac_validLogicalKinds}")
+
+    set(CMAKE_REQUIRED_QUIET TRUE)
+    foreach (KIND ${VAR})
+      unset(MPI_LOGICAL_KIND CACHE)
+      set (PROG_SRC
+      "
+          PROGRAM main
+             USE MPI
+             IMPLICIT NONE
+             LOGICAL(KIND=${KIND}) :: flag
+             INTEGER(KIND=MPI_INTEGER_KIND) :: info_ret, mpierror
+             CHARACTER(LEN=3) :: info_val
+             CALL mpi_info_get(info_ret,\"foo\", 3_MPI_INTEGER_KIND, info_val, flag, mpierror)
+          END
+       "
+      )
+      check_fortran_source_compiles (${PROG_SRC} MPI_LOGICAL_KIND SRC_EXT f90)
+
+      if (${MPI_LOGICAL_KIND} MATCHES "1")
+        set (${HDF_PREFIX}_MPI_LOGICAL_KIND ${KIND})
+        message (STATUS "....FORTRAN LOGICAL KIND for MPI is ${KIND}")
+      endif ()
+    endforeach ()
+    if (${HDF_PREFIX}_MPI_LOGICAL_KIND STREQUAL "")
+       message (FATAL_ERROR "Failed to determine LOGICAL KIND for MPI")
+    endif ()
+    set(CMAKE_REQUIRED_QUIET FALSE)
+  endif()
+endif()
 
 #-----------------------------------------------------------------------------
 # Determine the available KINDs for REALs and INTEGERs

--- a/config/cmake/HDF5UseFortran.cmake
+++ b/config/cmake/HDF5UseFortran.cmake
@@ -223,7 +223,6 @@ if (${HAVE_ISO_FORTRAN_ENV})
   set (PAC_FC_ALL_LOGICAL_KINDS "\{${pac_validLogicalKinds}\}")
   message (STATUS "....LOGICAL KINDS FOUND ${PAC_FC_ALL_LOGICAL_KINDS}")
 
-
 # ********************
 # LOGICAL KIND FOR MPI
 # ********************
@@ -247,7 +246,7 @@ if (${HAVE_ISO_FORTRAN_ENV})
       )
       check_fortran_source_compiles (${PROG_SRC} MPI_LOGICAL_KIND SRC_EXT f90)
 
-      if (${MPI_LOGICAL_KIND} MATCHES "1")
+      if (MPI_LOGICAL_KIND)
         set (${HDF_PREFIX}_MPI_LOGICAL_KIND ${KIND})
         message (STATUS "....FORTRAN LOGICAL KIND for MPI is ${KIND}")
       endif ()
@@ -406,7 +405,6 @@ endif ()
 if (NOT PAC_FORTRAN_NATIVE_DOUBLE_KIND)
    message (FATAL_ERROR "Failed to find KIND of NATIVE DOUBLE for Fortran")
 endif ()
-
 
 set (${HDF_PREFIX}_FORTRAN_SIZEOF_LONG_DOUBLE ${${HDF_PREFIX}_SIZEOF_LONG_DOUBLE})
 

--- a/configure.ac
+++ b/configure.ac
@@ -830,8 +830,13 @@ if test "X$HDF_FORTRAN" = "Xyes"; then
   PAC_FC_NATIVE_INTEGER
 
   ## Find all available KINDs
-  PAC_FC_AVAIL_KINDS
-  ## Find all sizeofs for available KINDs
+  if test "X$HAVE_ISO_FORTRAN_ENV" = "X1";then
+    PAC_FC_AVAIL_KINDS_F08
+  else
+    PAC_FC_AVAIL_KINDS
+  fi
+
+  ## Find all SIZEOFs for available KINDs
   PAC_FC_SIZEOF_INT_KINDS
   PAC_FC_SIZEOF_REAL_KINDS
 
@@ -3055,6 +3060,16 @@ if test -n "$PARALLEL"; then
                 [AC_MSG_RESULT([no])]
     )
     AC_LANG_POP(Fortran)
+
+    if test "X$HDF5_TESTS" = "Xyes"; then
+        AC_SUBST([MPI_LOGICAL_KIND])
+        PAC_FIND_MPI_LOGICAL_KIND
+        if test "X$" = "Xyes"; then
+          HAVE_ISO_FORTRAN_ENV="1"
+          AC_DEFINE([HAVE_ISO_FORTRAN_ENV], [1], [Define if Fortran supports ISO_FORTRAN_ENV (F08)])
+        fi
+    fi
+
   fi
 
   ## ----------------------------------------------------------------------

--- a/fortran/src/CMakeLists.txt
+++ b/fortran/src/CMakeLists.txt
@@ -79,6 +79,11 @@ if (H5_FORTRAN_HAVE_CHAR_ALLOC)
   set (CMAKE_H5_FORTRAN_HAVE_CHAR_ALLOC 1)
 endif ()
 
+set (CMAKE_H5_MPI_LOGICAL_KIND 0)
+if (H5_MPI_LOGICAL_KIND)
+  set (CMAKE_H5_MPI_LOGICAL_KIND 1)
+endif ()
+
 configure_file (${HDF5_F90_SRC_SOURCE_DIR}/H5config_f.inc.cmake ${HDF5_F90_BINARY_DIR}/H5config_f.inc @ONLY)
 configure_file (${HDF5_F90_SRC_SOURCE_DIR}/H5fort_type_defines.h.cmake ${HDF5_F90_BINARY_DIR}/H5fort_type_defines.h @ONLY)
 

--- a/fortran/src/H5config_f.inc.cmake
+++ b/fortran/src/H5config_f.inc.cmake
@@ -79,6 +79,14 @@
 ! Define if Fortran C_BOOL is different from default LOGICAL
 #define H5_FORTRAN_C_BOOL_IS_UNIQUE @H5_FORTRAN_C_BOOL_IS_UNIQUE@
 
+! Define  MPI Fortran KIND of LOGICAL
+#cmakedefine01 CMAKE_H5_MPI_LOGICAL_KIND
+#if CMAKE_H5_MPI_LOGICAL_KIND == 0
+#undef H5_MPI_LOGICAL_KIND
+#else
+#define H5_MPI_LOGICAL_KIND @H5_MPI_LOGICAL_KIND@
+#endif
+
 ! Define if Fortran supports ISO_FORTRAN_ENV (F08)
 #cmakedefine01 CMAKE_H5_HAVE_ISO_FORTRAN_ENV
 #if CMAKE_H5_HAVE_ISO_FORTRAN_ENV == 0

--- a/fortran/src/H5config_f.inc.in
+++ b/fortran/src/H5config_f.inc.in
@@ -50,6 +50,9 @@
 ! Define if Fortran supports ISO_FORTRAN_ENV (F08)
 #undef HAVE_ISO_FORTRAN_ENV
 
+! Define MPI Fortran KIND of LOGICAL
+#undef MPI_LOGICAL_KIND
+
 ! Define the size of C's double
 #undef SIZEOF_DOUBLE
 

--- a/fortran/testpar/mpi_param.F90
+++ b/fortran/testpar/mpi_param.F90
@@ -18,9 +18,6 @@
 
 SUBROUTINE mpi_param_03(nerrors)
 
-#ifdef H5_HAVE_ISO_FORTRAN_ENV
-  USE, INTRINSIC :: iso_fortran_env, ONLY : atomic_logical_kind
-#endif
   USE MPI
   USE HDF5
   USE TH5_MISC
@@ -39,8 +36,8 @@ SUBROUTINE mpi_param_03(nerrors)
   INTEGER(KIND=MPI_INTEGER_KIND) :: info, info_ret
   INTEGER(KIND=MPI_INTEGER_KIND) :: comm, comm_ret
   INTEGER(KIND=MPI_INTEGER_KIND) :: nkeys
-#ifdef H5_HAVE_ISO_FORTRAN_ENV
-  LOGICAL(KIND=atomic_logical_kind) :: flag
+#ifdef H5_MPI_LOGICAL_KIND
+  LOGICAL(KIND=H5_MPI_LOGICAL_KIND) :: flag
 #else
   LOGICAL(KIND=MPI_INTEGER_KIND) :: flag
 #endif
@@ -178,10 +175,6 @@ END SUBROUTINE mpi_param_03
 SUBROUTINE mpi_param_08(nerrors)
 
 #ifdef H5_HAVE_MPI_F08
-
-#ifdef H5_HAVE_ISO_FORTRAN_ENV
-  USE, INTRINSIC :: iso_fortran_env, ONLY : atomic_logical_kind
-#endif
   USE MPI_F08
   USE HDF5
   USE TH5_MISC
@@ -199,8 +192,8 @@ SUBROUTINE mpi_param_08(nerrors)
   TYPE(MPI_INFO) :: info, info_ret
   TYPE(MPI_COMM) :: comm, comm_ret
   INTEGER(KIND=MPI_INTEGER_KIND) :: nkeys
-#ifdef H5_HAVE_ISO_FORTRAN_ENV
-  LOGICAL(KIND=atomic_logical_kind) :: flag
+#ifdef H5_MPI_LOGICAL_KIND
+  LOGICAL(KIND=H5_MPI_LOGICAL_KIND) :: flag
 #else
   LOGICAL(KIND=MPI_INTEGER_KIND) :: flag
 #endif

--- a/fortran/testpar/ptest.F90
+++ b/fortran/testpar/ptest.F90
@@ -37,6 +37,52 @@ PROGRAM parallel_test
   CHARACTER(LEN=10), DIMENSION(1:2) :: chr_chunk =(/"contiguous", "chunk     "/)
   INTEGER(KIND=MPI_INTEGER_KIND) :: mpi_int_type
 
+  INTERFACE
+
+    SUBROUTINE mpi_param_03(ret_total_error)
+      IMPLICIT NONE
+      INTEGER, INTENT(inout) :: ret_total_error
+    END SUBROUTINE mpi_param_03
+
+    SUBROUTINE mpi_param_08(ret_total_error)
+      IMPLICIT NONE
+      INTEGER, INTENT(inout) :: ret_total_error
+    END SUBROUTINE mpi_param_08
+
+    SUBROUTINE hyper(length,do_collective,do_chunk, mpi_size, mpi_rank, nerrors)
+       USE MPI
+       IMPLICIT NONE
+       INTEGER, INTENT(in) :: length
+       LOGICAL, INTENT(in) :: do_collective
+       LOGICAL, INTENT(in) :: do_chunk
+       INTEGER(KIND=MPI_INTEGER_KIND), INTENT(in) :: mpi_size
+       INTEGER(KIND=MPI_INTEGER_KIND), INTENT(in) :: mpi_rank
+       INTEGER, INTENT(inout) :: nerrors
+     END SUBROUTINE hyper
+
+     SUBROUTINE pmultiple_dset_hyper_rw(do_collective, do_chunk, mpi_size, mpi_rank, nerrors)
+       USE MPI
+       IMPLICIT NONE
+       LOGICAL, INTENT(in) :: do_collective
+       LOGICAL, INTENT(in) :: do_chunk
+       INTEGER(KIND=MPI_INTEGER_KIND), INTENT(in) :: mpi_size
+       INTEGER(KIND=MPI_INTEGER_KIND), INTENT(in) :: mpi_rank
+       INTEGER, INTENT(inout) :: nerrors
+     END SUBROUTINE pmultiple_dset_hyper_rw
+
+     SUBROUTINE multiple_dset_write(length, do_collective, do_chunk, mpi_size, mpi_rank, nerrors)
+       USE MPI
+       IMPLICIT NONE
+       INTEGER, INTENT(in) :: length
+       LOGICAL, INTENT(in) :: do_collective
+       LOGICAL, INTENT(in) :: do_chunk
+       INTEGER(KIND=MPI_INTEGER_KIND), INTENT(in) :: mpi_size
+       INTEGER(KIND=MPI_INTEGER_KIND), INTENT(in) :: mpi_rank
+       INTEGER, INTENT(inout) :: nerrors
+     END SUBROUTINE multiple_dset_write
+
+  END INTERFACE
+
   !
   ! initialize MPI
   !

--- a/fortran/testpar/subfiling.F90
+++ b/fortran/testpar/subfiling.F90
@@ -18,9 +18,6 @@
 
 PROGRAM subfiling_test
   USE, INTRINSIC :: ISO_C_BINDING, ONLY : C_INT64_T
-#ifdef H5_HAVE_ISO_FORTRAN_ENV
-  USE, INTRINSIC :: iso_fortran_env, ONLY : atomic_logical_kind
-#endif
   USE HDF5
   USE MPI
   USE TH5_MISC
@@ -50,8 +47,8 @@ PROGRAM subfiling_test
   INTEGER(C_INT64_T) inode
   TYPE(H5FD_subfiling_config_t) :: vfd_config
   TYPE(H5FD_ioc_config_t)       :: vfd_config_ioc
-#ifdef H5_HAVE_ISO_FORTRAN_ENV
-  LOGICAL(KIND=atomic_logical_kind) :: flag
+#ifdef H5_MPI_LOGICAL_KIND
+  LOGICAL(KIND=H5_MPI_LOGICAL_KIND) :: flag
 #else
   LOGICAL(KIND=MPI_INTEGER_KIND) :: flag
 #endif

--- a/m4/aclocal_fc.f90
+++ b/m4/aclocal_fc.f90
@@ -21,8 +21,7 @@
 !
 
 PROGRAM PROG_FC_ISO_FORTRAN_ENV
-  USE, INTRINSIC :: ISO_FORTRAN_ENV, ONLY : atomic_logical_kind
-  LOGICAL(KIND=atomic_logical_kind) :: state
+  USE, INTRINSIC :: ISO_FORTRAN_ENV, ONLY : logical_kinds
 END PROGRAM PROG_FC_ISO_FORTRAN_ENV
 
 PROGRAM PROG_FC_SIZEOF
@@ -182,6 +181,70 @@ PROGRAM FC_AVAIL_KINDS
      WRITE(stdout,'(I0)') num_rkinds
 END PROGRAM FC_AVAIL_KINDS
 !---- END ----- Determine the available KINDs for REALs and INTEGERs
+
+!---- START ----- Determine the available KINDs for REALs, INTEGERs and LOGICALs -- ISO_FORTRAN_ENV (F08)
+PROGRAM FC08_AVAIL_KINDS
+      USE, INTRINSIC :: ISO_FORTRAN_ENV, ONLY : stdout=>OUTPUT_UNIT, integer_kinds, real_kinds, logical_kinds
+      IMPLICIT NONE
+      INTEGER :: ik, jk, k, max_decimal_prec
+      INTEGER :: num_rkinds, num_ikinds, num_lkinds
+
+      ! Find integer KINDs
+
+      num_ikinds = SIZE(integer_kinds)
+
+      DO k = 1, num_ikinds
+         WRITE(stdout,'(I0)', ADVANCE='NO') integer_kinds(k)
+         IF(k.NE.num_ikinds)THEN
+            WRITE(stdout,'(A)',ADVANCE='NO') ','
+         ELSE
+            WRITE(stdout,'()')
+         ENDIF
+      ENDDO
+
+      ! Find real KINDs
+
+      num_rkinds = SIZE(real_kinds)
+
+      max_decimal_prec = 1
+
+      prec: DO ik = 2, 36
+         exp: DO jk = 1, 700
+            k = SELECTED_REAL_KIND(ik,jk)
+            IF(k.LT.0) EXIT exp
+            max_decimal_prec = ik
+         ENDDO exp
+      ENDDO prec
+
+      DO k = 1, num_rkinds
+         WRITE(stdout,'(I0)', ADVANCE='NO') real_kinds(k)
+         IF(k.NE.num_rkinds)THEN
+            WRITE(stdout,'(A)',ADVANCE='NO') ','
+         ELSE
+            WRITE(stdout,'()')
+         ENDIF
+      ENDDO
+
+     WRITE(stdout,'(I0)') max_decimal_prec
+     WRITE(stdout,'(I0)') num_ikinds
+     WRITE(stdout,'(I0)') num_rkinds
+
+     ! Find logical KINDs
+
+     num_lkinds = SIZE(logical_kinds)
+     WRITE(stdout,'(I0)') num_lkinds
+
+     DO k = 1, num_lkinds
+        WRITE(stdout,'(I0)', ADVANCE='NO') logical_kinds(k)
+        IF(k.NE.num_lkinds)THEN
+           WRITE(stdout,'(A)',ADVANCE='NO') ','
+        ELSE
+           WRITE(stdout,'()')
+        ENDIF
+     ENDDO
+
+END PROGRAM FC08_AVAIL_KINDS
+!---- END ----- Determine the available KINDs for REALs, INTEGERs and LOGICALs -- ISO_FORTRAN_ENV (F08)
 
 PROGRAM FC_MPI_CHECK
   USE mpi

--- a/m4/aclocal_fc.m4
+++ b/m4/aclocal_fc.m4
@@ -323,6 +323,97 @@ AC_RUN_IFELSE([$TEST_SRC],
 
 AC_LANG_POP([Fortran])
 ])
+
+dnl --------------------------------------------------------------
+dnl Determine the available KINDs for REALs, INTEGERs and LOGICALS
+dnl --------------------------------------------------------------
+dnl
+dnl This is a runtime test.
+dnl
+AC_DEFUN([PAC_FC_AVAIL_KINDS_F08],[
+AC_LANG_PUSH([Fortran])
+TEST_SRC="`sed -n '/PROGRAM FC08_AVAIL_KINDS/,/END PROGRAM FC08_AVAIL_KINDS/p' $srcdir/m4/aclocal_fc.f90`"
+AC_RUN_IFELSE([$TEST_SRC],
+ [
+        dnl The output from the above program will be:
+        dnl    -- LINE 1 --  valid integer kinds (comma separated list)
+        dnl    -- LINE 2 --  valid real kinds (comma separated list)
+        dnl    -- LINE 3 --  max decimal precision for reals
+        dnl    -- LINE 4 --  number of valid integer kinds
+        dnl    -- LINE 5 --  number of valid real kinds
+        dnl    -- LINE 6 --  number of valid logical kinds
+        dnl    -- LINE 7 --  valid logical kinds (comma separated list)
+
+        pac_validIntKinds=$(./conftest$EXEEXT 2>&1 | sed -n '1p')
+        pac_validRealKinds=$(./conftest$EXEEXT 2>&1 | sed -n '2p')
+        PAC_FC_MAX_REAL_PRECISION=$(./conftest$EXEEXT 2>&1 | sed -n '3p')
+        AC_DEFINE_UNQUOTED([PAC_FC_MAX_REAL_PRECISION], $PAC_FC_MAX_REAL_PRECISION, [Define Fortran Maximum Real Decimal Precision])
+
+        PAC_FC_ALL_INTEGER_KINDS="{`echo $pac_validIntKinds`}"
+        PAC_FC_ALL_REAL_KINDS="{`echo $pac_validRealKinds`}"
+
+        PAC_FORTRAN_NUM_INTEGER_KINDS=$(./conftest$EXEEXT 2>&1 | sed -n '4p')
+        H5CONFIG_F_NUM_IKIND="INTEGER, PARAMETER :: num_ikinds = `echo $PAC_FORTRAN_NUM_INTEGER_KINDS`"
+        H5CONFIG_F_IKIND="INTEGER, DIMENSION(1:num_ikinds) :: ikind = (/`echo $pac_validIntKinds`/)"
+        H5CONFIG_F_NUM_RKIND="INTEGER, PARAMETER :: num_rkinds = $(./conftest$EXEEXT 2>&1 | sed -n '5p')"
+        H5CONFIG_F_RKIND="INTEGER, DIMENSION(1:num_rkinds) :: rkind = (/`echo $pac_validRealKinds`/)"
+
+        AC_DEFINE_UNQUOTED([H5CONFIG_F_NUM_RKIND], $H5CONFIG_F_NUM_RKIND, [Define number of valid Fortran REAL KINDs])
+        AC_DEFINE_UNQUOTED([H5CONFIG_F_NUM_IKIND], $H5CONFIG_F_NUM_IKIND, [Define number of valid Fortran INTEGER KINDs])
+        AC_DEFINE_UNQUOTED([H5CONFIG_F_RKIND], $H5CONFIG_F_RKIND, [Define valid Fortran REAL KINDs])
+        AC_DEFINE_UNQUOTED([H5CONFIG_F_IKIND], $H5CONFIG_F_IKIND, [Define valid Fortran INTEGER KINDs])
+
+        PAC_FORTRAN_NUM_LOGICAL_KINDS=$(./conftest$EXEEXT 2>&1 | sed -n '6p')
+        pac_validLogicalKinds=$(./conftest$EXEEXT 2>&1 | sed -n '7p')
+        PAC_FC_ALL_LOGICAL_KINDS="{`echo $pac_validLogicalKinds`}"
+
+        AC_MSG_CHECKING([for Number of Fortran INTEGER KINDs])
+        AC_MSG_RESULT([$PAC_FORTRAN_NUM_INTEGER_KINDS])
+        AC_MSG_CHECKING([for Fortran INTEGER KINDs])
+        AC_MSG_RESULT([$PAC_FC_ALL_INTEGER_KINDS])
+        AC_MSG_CHECKING([for Fortran REAL KINDs])
+        AC_MSG_RESULT([$PAC_FC_ALL_REAL_KINDS])
+        AC_MSG_CHECKING([for Fortran REALs maximum decimal precision])
+        AC_MSG_RESULT([$PAC_FC_MAX_REAL_PRECISION])
+        AC_MSG_CHECKING([for Number of Fortran LOGICAL KINDs])
+        AC_MSG_RESULT([$PAC_FORTRAN_NUM_LOGICAL_KINDS])
+        AC_MSG_CHECKING([for Fortran LOGICAL KINDs])
+        AC_MSG_RESULT([$PAC_FC_ALL_LOGICAL_KINDS])
+],[
+    AC_MSG_RESULT([Error])
+    AC_MSG_ERROR([Failed to run Fortran program to determine available KINDs])
+],[])
+AC_LANG_POP([Fortran])
+])
+
+AC_DEFUN([PAC_FIND_MPI_LOGICAL_KIND],[
+AC_REQUIRE([PAC_FC_AVAIL_KINDS])
+AC_MSG_CHECKING([default Fortran KIND of LOGICAL in MPI])
+AC_LANG_PUSH([Fortran])
+
+for kind in `echo $pac_validLogicalKinds | sed -e 's/,/ /g'`; do
+        AC_COMPILE_IFELSE([
+                PROGRAM main
+                 USE MPI
+                 IMPLICIT NONE
+                 LOGICAL(KIND=$kind) :: flag
+                 INTEGER(KIND=MPI_INTEGER_KIND) :: info_ret, mpierror
+                 CHARACTER(LEN=3) :: info_val
+                 CALL mpi_info_get(info_ret,"foo", 3_MPI_INTEGER_KIND, info_val, flag, mpierror)
+                END],
+         [AC_SUBST([PAC_MPI_LOGICAL_KIND]) PAC_MPI_LOGICAL_KIND=$kind],
+         []
+        )
+done
+if test "X$PAC_MPI_LOGICAL_KIND" = "X"; then
+  AC_MSG_ERROR([Failed to find Fortran KIND of LOGICAL in MPI])
+else
+  AC_DEFINE_UNQUOTED([MPI_LOGICAL_KIND], [$PAC_MPI_LOGICAL_KIND], [Define MPI Fortran KIND of LOGICAL])
+  AC_MSG_RESULT([$PAC_MPI_LOGICAL_KIND])
+fi
+AC_LANG_POP([Fortran])
+])
+
 AC_DEFUN([PAC_FC_SIZEOF_INT_KINDS],[
 AC_REQUIRE([PAC_FC_AVAIL_KINDS])
 AC_MSG_CHECKING([sizeof of available INTEGER KINDs])


### PR DESCRIPTION
Should address remaining build failures on Perlmutter.