### PR TITLE
Fix fatal error C1083: Cannot open include file

### DIFF
--- a/src/H5Zdeflate.c
+++ b/src/H5Zdeflate.c
@@ -23,7 +23,7 @@
 #define H5_ZLIB_HEADER "zlib.h"
 #endif
 #if defined(H5_ZLIB_HEADER)
-#include H5_ZLIB_HEADER /* "zlib.h" */
+#include H5_ZLIB_HEADER "zlib.h"
 #endif
 
 /* Local function prototypes */


### PR DESCRIPTION
See https://cdash.hdfgroup.org/viewBuildError.php?buildid=125323