### PR TITLE
Re-revert to using autoreconf in autogen.sh

### DIFF
--- a/autogen.sh
+++ b/autogen.sh
@@ -11,12 +11,12 @@
 # help@hdfgroup.org.
 #
 
-# A script to reconfigure autotools for HDF5, and to recreate other
+# A script to reconfigure the Autotools for HDF5, and to recreate other
 # generated files specific to HDF5.
 #
 # IMPORTANT OS X NOTE
 #
-# If you are using OS X, you will probably not have the autotools
+# If you are using OS X, you will probably not have the Autotools
 # installed, even if you have the Xcode command-line tools.
 #
 # The easiest way to fix this is to install everything via Homebrew:
@@ -30,31 +30,7 @@
 #   brew install automake
 #   brew install libtool
 #
-# This only takes a few minutes. Note that libtool and libtoolize will
-# be glibtool and glibtoolize so as not to conflict with Apple's non-gnu
-# tools. This autogen.sh script handles this for you.
-#
 # END IMPORTANT OS X NOTE
-#
-# If you want to use a particular version of the autotools, the paths
-# to each tool can be overridden using the following environment
-# variables:
-#
-#   HDF5_ACLOCAL
-#   HDF5_AUTOHEADER
-#   HDF5_AUTOMAKE
-#   HDF5_AUTOCONF
-#   HDF5_LIBTOOLIZE
-#   HDF5_M4
-#
-# Note that aclocal will attempt to include libtool's share/aclocal
-# directory.
-#
-# Aside from -h for help, this script takes one potential option:
-#
-# -v
-#
-# This emits some extra information, mainly tool versions.
 
 echo
 echo "**************************"
@@ -62,76 +38,9 @@ echo "* HDF5 autogen.sh script *"
 echo "**************************"
 echo
 
-# Default is not verbose output
-verbose=false
-
-optspec=":hpv-"
-while getopts "$optspec" optchar; do
-    case "${optchar}" in
-    h)
-        echo "usage: $0 [OPTIONS]"
-        echo
-        echo "      -h      Print this help message."
-        echo
-        echo "      -v      Show more verbose output."
-        echo
-        echo "  NOTE: Each tool can be set via an environment variable."
-        echo "        These are documented inside this autogen.sh script."
-        echo
-        exit 0
-        ;;
-    v)
-        echo "Setting verbosity: high"
-        echo
-        verbose=true
-        ;;
-    *)
-        if [ "$OPTERR" != 1 ] || case $optspec in :*) ;; *) false; esac; then
-            echo "ERROR: non-option argument: '-${OPTARG}'" >&2
-            echo "Quitting"
-            exit 1
-        fi
-        ;;
-    esac
-done
-
-# If paths to autotools are not specified, use whatever the system
-# has installed as the default. We use 'command -v <tool>' to
-# show exactly what's being used (shellcheck complains that 'which'
-# is non-standard and deprecated).
-if test -z "${HDF5_AUTOCONF}"; then
-    HDF5_AUTOCONF="$(command -v autoconf)"
-fi
-if test -z "${HDF5_AUTOMAKE}"; then
-    HDF5_AUTOMAKE="$(command -v automake)"
-fi
-if test -z "${HDF5_AUTOHEADER}"; then
-    HDF5_AUTOHEADER="$(command -v autoheader)"
-fi
-if test -z "${HDF5_ACLOCAL}"; then
-    HDF5_ACLOCAL="$(command -v aclocal)"
-fi
-if test -z "${HDF5_LIBTOOLIZE}"; then
-    # check for glibtoolize (likely found on MacOS). If not found - check for libtoolize
-    HDF5_LIBTOOLIZE="$(command -v glibtoolize)"
-    if [ ! -f "$HDF5_LIBTOOLIZE" ] ; then
-        HDF5_LIBTOOLIZE="$(command -v libtoolize)"
-    fi
-fi
-if test -z "${HDF5_M4}"; then
-    HDF5_M4="$(command -v m4)"
-fi
-
-
-# Make sure that these versions of the autotools are in the path
-AUTOCONF_DIR=$(dirname "${HDF5_AUTOCONF}")
-LIBTOOL_DIR=$(dirname "${HDF5_LIBTOOLIZE}")
-M4_DIR=$(dirname "${HDF5_M4}")
-PATH=${AUTOCONF_DIR}:${LIBTOOL_DIR}:${M4_DIR}:$PATH
-
 # Run scripts that process source.
 #
-# These should be run before the autotools so that failures here block
+# These should be run before the Autotools so that failures here block
 # compilation.
 
 # Run trace script
@@ -162,73 +71,20 @@ echo "Running overflow macro generation script:"
 bin/make_overflow src/H5overflow.txt || exit 1
 echo
 
-# Run autotools in order
-#
-# When available, we use the --force option to ensure all files are
-# updated. This prevents the autotools from re-running to fix dependencies
-# during the 'make' step, which can be a problem if environment variables
-# were set on the command line during autogen invocation.
+# Run Autotools
 
-# Some versions of libtoolize will suggest that we add ACLOCAL_AMFLAGS
-# = '-I m4'. This is already done in commence.am, which is included
-# in Makefile.am. You can ignore this suggestion.
-
-# LIBTOOLIZE
-libtoolize_cmd="${HDF5_LIBTOOLIZE} --copy --force"
-echo "${libtoolize_cmd}"
-if [ "$verbose" = true ] ; then
-    ${HDF5_LIBTOOLIZE} --version
-fi
-${libtoolize_cmd} || exit 1
+# The "obsolete" warnings category flags our Java macros as obsolete.
+# Since there is no clear way to upgrade them (Java support in the Autotools
+# is not great) and they work well enough for now, we suppress those warnings.
+echo "Running Autotools"
 echo
 echo "NOTE: You can ignore the warning about adding -I m4."
 echo "      We already do this in an included file."
 echo
-
-# ACLOCAL
-if test -e "${LIBTOOL_DIR}/../share/aclocal" ; then
-    aclocal_include="-I ${LIBTOOL_DIR}/../share/aclocal"
-fi
-aclocal_cmd="${HDF5_ACLOCAL} --force -I m4 ${aclocal_include}"
-echo "${aclocal_cmd}"
-if [ "$verbose" = true ] ; then
-    ${HDF5_ACLOCAL} --version
-fi
-${aclocal_cmd} || exit 1
-echo
-
-# AUTOHEADER
-autoheader_cmd="${HDF5_AUTOHEADER} --force"
-echo "${autoheader_cmd}"
-if [ "$verbose" = true ] ; then
-    ${HDF5_AUTOHEADER} --version
-fi
-${autoheader_cmd} || exit 1
-echo
-
-# AUTOMAKE
-automake_cmd="${HDF5_AUTOMAKE} --copy --add-missing --force-missing"
-echo "${automake_cmd}"
-if [ "$verbose" = true ] ; then
-    ${HDF5_AUTOMAKE} --version
-fi
-${automake_cmd} || exit 1
-echo
-
-# AUTOCONF
-# The "obsolete" warnings category flags our Java macros as obsolete.
-# Since there is no clear way to upgrade them (Java support in the Autotools
-# is not great) and they work well enough for now, we suppress those warnings.
-autoconf_cmd="${HDF5_AUTOCONF} --force --warnings=no-obsolete"
-echo "${autoconf_cmd}"
-if [ "$verbose" = true ] ; then
-    ${HDF5_AUTOCONF} --version
-fi
-${autoconf_cmd} || exit 1
+autoreconf -vif --warnings=no-obsolete || exit 1
 echo
 
 echo "*** SUCCESS ***"
 
 echo
 exit 0
-

--- a/release_docs/RELEASE.txt
+++ b/release_docs/RELEASE.txt
@@ -1724,6 +1724,11 @@ Platforms Tested
 Known Problems
 ==============
 
+    When building with the NAG Fortran compiler using the Autotools and libtool
+    2.4.2 or earlier, the -shared flag will be missing '-Wl,', which will cause
+    compilation to fail. This is due to a bug in libtool that was fixed in 2012
+    and released in 2.4.4 in 2014.
+
     When HDF5 is compiled with NVHPC versions 23.5 - 23.9 (additional versions may
     also be applicable) and with -O2 (or higher) and -DNDEBUG, test failures occur
     in the following tests:


### PR DESCRIPTION
We previously tried removing the per-tool invocation of the Autotools and instead simply invoked autoreconf (PR #1906). This was reverted when it turned out that the NAG Fortran compiler had trouble with an undecorated -shared linker flag.

It turns out that this is due to a bug in libtool 2.4.2 and earlier. Since this version of libtool is over a decade old, we're un-reverting the change. We've added a release note for anyone who has to build from source on elderly platforms.

Fixes #1343