### PR TITLE
MPI type correction

### DIFF
--- a/fortran/src/H5Pf.c
+++ b/fortran/src/H5Pf.c
@@ -4606,8 +4606,8 @@ h5pset_fapl_mpio_c(hid_t_f *prp_id, void *comm, void *info)
     herr_t   ret;
     MPI_Comm c_comm;
     MPI_Info c_info;
-    c_comm = MPI_Comm_f2c(*((int *)comm));
-    c_info = MPI_Info_f2c(*((int *)info));
+    c_comm = MPI_Comm_f2c(*((MPI_Fint *)comm));
+    c_info = MPI_Info_f2c(*((MPI_Fint *)info));
 
     /*
      * Call H5Pset_mpi function.
@@ -4677,8 +4677,8 @@ h5pset_mpi_params_c(hid_t_f *prp_id, void *comm, void *info)
     herr_t   ret;
     MPI_Comm c_comm;
     MPI_Info c_info;
-    c_comm = MPI_Comm_f2c(*((int *)comm));
-    c_info = MPI_Info_f2c(*((int *)info));
+    c_comm = MPI_Comm_f2c(*((MPI_Fint *)comm));
+    c_info = MPI_Info_f2c(*((MPI_Fint *)info));
 
     /*
      * Call H5Pset_mpi_params.

--- a/fortran/test/tH5P_F03.F90
+++ b/fortran/test/tH5P_F03.F90
@@ -47,7 +47,7 @@ MODULE test_genprop_cls_cb1_mod
 
 CONTAINS
 
-  INTEGER FUNCTION test_genprop_cls_cb1_f(list_id, create_data ) bind(C)
+  INTEGER(KIND=C_INT) FUNCTION test_genprop_cls_cb1_f(list_id, create_data ) bind(C)
 
     IMPLICIT NONE
 

--- a/m4/aclocal_fc.m4
+++ b/m4/aclocal_fc.m4
@@ -390,7 +390,8 @@ AC_DEFUN([PAC_FIND_MPI_LOGICAL_KIND],[
 AC_REQUIRE([PAC_FC_AVAIL_KINDS])
 AC_MSG_CHECKING([default Fortran KIND of LOGICAL in MPI])
 AC_LANG_PUSH([Fortran])
-
+saved_FCFLAGS=$FCFLAGS
+FCFLAGS=""
 for kind in `echo $pac_validLogicalKinds | sed -e 's/,/ /g'`; do
         AC_COMPILE_IFELSE([
                 PROGRAM main
@@ -411,6 +412,7 @@ else
   AC_DEFINE_UNQUOTED([MPI_LOGICAL_KIND], [$PAC_MPI_LOGICAL_KIND], [Define MPI Fortran KIND of LOGICAL])
   AC_MSG_RESULT([$PAC_MPI_LOGICAL_KIND])
 fi
+FCFLAGS=$saved_FCFLAGS
 AC_LANG_POP([Fortran])
 ])
 

--- a/release_docs/RELEASE.txt
+++ b/release_docs/RELEASE.txt
@@ -1770,6 +1770,9 @@ Known Problems
     implemented: (1) derived type argument passed by value (H5VLff.F90),
     and (2) support for REAL with KIND = 2 in intrinsic SPACING used in testing.
 
+    Fortran tests HDF5_1_8.F90 and HDF5_F03.F90 will fail with Cray compilers greater than
+    version 16.0 due to a compiler bug. The latest version verified as failing was version 17.0.
+
     Several tests currently fail on certain platforms:
         MPI_TEST-t_bigio fails with spectrum-mpi on ppc64le platforms.
 


### PR DESCRIPTION
Addresses Jordan's comments.

I added to known issues and made minor corrections to the return type for the callback function.