### PR TITLE
Addresses configuration fortran testing flags

### DIFF
--- a/config/cmake/HDF5UseFortran.cmake
+++ b/config/cmake/HDF5UseFortran.cmake
@@ -218,6 +218,11 @@ if (${HAVE_ISO_FORTRAN_ENV})
     string (REGEX REPLACE "," ";" VAR "${pac_validLogicalKinds}")
 
     set(CMAKE_REQUIRED_QUIET TRUE)
+    set(save_CMAKE_Fortran_FLAGS ${CMAKE_Fortran_FLAGS})
+    if (CMAKE_Fortran_COMPILER_ID STREQUAL "Intel")
+       set(CMAKE_Fortran_FLAGS "-warn error")
+    endif ()
+
     foreach (KIND ${VAR})
       unset(MPI_LOGICAL_KIND CACHE)
       set (PROG_SRC
@@ -243,6 +248,7 @@ if (${HAVE_ISO_FORTRAN_ENV})
        message (FATAL_ERROR "Failed to determine LOGICAL KIND for MPI")
     endif ()
     set(CMAKE_REQUIRED_QUIET FALSE)
+    set(CMAKE_Fortran_FLAGS ${save_CMAKE_Fortran_FLAGS})
   endif()
 endif()
 

--- a/fortran/testpar/subfiling.F90
+++ b/fortran/testpar/subfiling.F90
@@ -134,7 +134,7 @@ PROGRAM subfiling_test
         ENDIF
 
         CALL mpi_info_get(info_ret,"foo", 3_MPI_INTEGER_KIND, info_val, flag, mpierror)
-        IF(LOGICAL(flag) .EQV. .TRUE.)THEN
+        IF(LOGICAL(flag) .EQV. LOGICAL(.TRUE.))THEN
            IF(info_val.NE."bar")THEN
               IF(mpi_rank.EQ.0) &
                    WRITE(*,*) "Failed H5Pset_mpi_params_f and H5Pget_mpi_params_f sequence"

--- a/m4/aclocal_fc.m4
+++ b/m4/aclocal_fc.m4
@@ -391,7 +391,12 @@ AC_REQUIRE([PAC_FC_AVAIL_KINDS])
 AC_MSG_CHECKING([default Fortran KIND of LOGICAL in MPI])
 AC_LANG_PUSH([Fortran])
 saved_FCFLAGS=$FCFLAGS
-FCFLAGS=""
+check_Intel="`$FC -V 2>&1 |grep '^Intel'`"
+if test X != "X$check_Intel"; then
+  FCFLAGS="-warn error"
+else
+  FCFLAGS=""
+fi
 for kind in `echo $pac_validLogicalKinds | sed -e 's/,/ /g'`; do
         AC_COMPILE_IFELSE([
                 PROGRAM main


### PR DESCRIPTION
Turns warnings into errors for intel in the Fortran logical configuration test.
Tested on Perlmutter with Intel compilers.