### PR TITLE
Fix Figure 9. table format in HDF5 Groups User Guide

### DIFF
--- a/src/H5Gmodule.h
+++ b/src/H5Gmodule.h
@@ -775,8 +775,8 @@
  * \image html Groups_fig9_aa.gif "c) A link named dset2 to the same dataset is created in /group2."
  * </td>
  * <td>
- * \image html Groups_fig9_bb.gif "d) The link from /group1 to dset1 is removed. The dataset is
- * still in the file, but can be accessed only as /group2/dset2."
+ * \image html Groups_fig9_bb.gif "d) The link from /group1 to dset1 is removed."
+ * The dataset is still in the file, but can be accessed only as /group2/dset2.
  * </td>
  * </tr>
  * </table>
@@ -811,8 +811,7 @@
  * </tr>
  * <tr>
  * <td>
- * \image html Groups_fig10_c.gif "c) dset1 has three names: /group1/dset1, /group2/dset2, and
- * /group1/GXX/dset2."
+ * \image html Groups_fig10_c.gif "c) dset1 has 3 names: /group1/dset1, /group2/dset2, and /group1/GXX/dset2."
  * </td>
  * <td>
  * \image html Groups_fig10_d.gif "d) dset1 has an infinite number of available path names."


### PR DESCRIPTION
Figure 9. in https://docs.hdfgroup.org/hdf5/develop/_h5_g__u_g.html#subsec_group_h5dump

![20240401_doxy_fig9](https://github.com/HDFGroup/hdf5/assets/4994401/6ed299e3-b8d6-46a0-8e28-791c5f2ecfd7)

clang formatter splits a long (>110) caption for Doxygen `\image`.
HTML tag (e.g., `<td>`) becomes invalid.