### PR TITLE
Fix nvc warnings for unreachable break

### DIFF
--- a/src/H5trace.c
+++ b/src/H5trace.c
@@ -2411,7 +2411,6 @@ H5_trace_args(H5RS_str_t *rs, const char *type, va_list ap)
                             H5RS_acat(rs, "Reference Region");
                             goto error;
                         } /* end block */
-                        break;
 
                         case 'o': /* hobj_ref_t */
                         {
@@ -2427,7 +2426,6 @@ H5_trace_args(H5RS_str_t *rs, const char *type, va_list ap)
                             H5RS_acat(rs, "Reference Opaque");
                             goto error;
                         } /* end block */
-                        break;
 
                         case 't': /* H5R_type_t */
                         {


### PR DESCRIPTION
```
"/pscratch/sd/l/lrknox/dt-perlm/CI/hdf5-1.15.0/src/H5trace.c", line 2414: warning: statement is unreachable [code_is_unreachable]                           break;                           ^  [CTest: warning matched] Remark: individual 

"/pscratch/sd/l/lrknox/dt-perlm/CI/hdf5-1.15.0/src/H5trace.c", line 2430: warning: statement is unreachable [code_is_unreachable]                           break;                           ^
```