### PR TITLE
Remove VS ptable error from Known Problems

### DIFF
--- a/release_docs/RELEASE.txt
+++ b/release_docs/RELEASE.txt
@@ -1537,6 +1537,8 @@ Bug Fixes since HDF5-1.14.0 release
     Tools
     -----
 
+    - Fixed h5dump to support subfiling VFD via command line options
+    
     - Renamed h5fuse.sh to h5fuse
 
       Addresses Discussion #3791
@@ -1849,9 +1851,6 @@ Known Problems
     applications.  Parallel applications can read files with metadata cache
     images, but since this is a collective operation, a deadlock is possible
     if one or more processes do not participate.
-
-    CPP ptable test fails on both VS2017 and VS2019 with Intel compiler, JIRA
-    issue: HDFFV-10628.  This test will pass with VS2015 with Intel compiler.
 
     The subsetting option in ph5diff currently will fail and should be avoided.
     The subsetting option works correctly in serial h5diff.

--- a/release_docs/RELEASE.txt
+++ b/release_docs/RELEASE.txt
@@ -1537,8 +1537,6 @@ Bug Fixes since HDF5-1.14.0 release
     Tools
     -----
 
-    - Fixed h5dump to support subfiling VFD via command line options
-    
     - Renamed h5fuse.sh to h5fuse
 
       Addresses Discussion #3791


### PR DESCRIPTION
Test passes for VS2019: https://cdash.hdfgroup.org/test/86066263

Microsoft ended VS2017 support in 2022.

