### PR TITLE
Remove unnecessary step from REST VOL workflow

### DIFF
--- a/.github/workflows/vol_rest.yml
+++ b/.github/workflows/vol_rest.yml
@@ -188,8 +188,3 @@ jobs:
           ROOT_DIR=${{github.workspace}}/hsdsdata \
           BUCKET_NAME=hsdstest \
           ctest --build-config ${{ inputs.build_mode }} -VV -R "h5_api" .
-
-      - name: Stop HSDS
-        working-directory: ${{github.workspace}}/hsds
-        run: |
-          ./stopall.sh


### PR DESCRIPTION
HSDS isn't run through docker in this test, so `stopall.sh` isn't doing anything. It's also causing the workflow to fail now that docker-compose v1 isn't part of the runners by default anymore.

Successful run of the workflow without this step can be seen [here](https://github.com/mattjala/hdf5/actions/runs/8561628536/job/23463236190)