### PR TITLE
Add note about H5Iregister_type hash_table param

### DIFF
--- a/src/H5Ipublic.h
+++ b/src/H5Ipublic.h
@@ -399,7 +399,7 @@ H5_DLL int H5Iget_ref(hid_t id);
  * \brief Creates and returns a new ID type
  *
  * \param[in] hash_size Minimum hash table size (in entries) used to store IDs
- *                      for the new type
+ *                      for the new type (unused in 1.8.13 and later)
  * \param[in] reserved Number of reserved IDs for the new type
  * \param[in] free_func Function used to deallocate space for a single ID
  *
@@ -409,7 +409,8 @@ H5_DLL int H5Iget_ref(hid_t id);
  *          identifier for it.
  *
  *          The \p hash_size parameter indicates the minimum size of the hash
- *          table used to store IDs in the new type.
+ *          table used to store IDs in the new type. This field is unused in
+ *          1.8.13 and later, when the implementation of ID storage changed.
  *
  *          The \p reserved parameter indicates the number of IDs in this new
  *          type to be reserved. Reserved IDs are valid IDs which are not

--- a/src/H5Ipublic.h
+++ b/src/H5Ipublic.h
@@ -409,8 +409,8 @@ H5_DLL int H5Iget_ref(hid_t id);
  *          identifier for it.
  *
  *          The \p hash_size parameter indicates the minimum size of the hash
- *          table used to store IDs in the new type. This field is unused in
- *          1.8.13 and later, when the implementation of ID storage changed.
+ *          table used to store IDs in the new type. This parameter is unused
+ *          in 1.8.13 and later, when the implementation of ID storage changed.
  *
  *          The \p reserved parameter indicates the number of IDs in this new
  *          type to be reserved. Reserved IDs are valid IDs which are not


### PR DESCRIPTION
The `hash_table` parameter is unused in HDF5 1.8.13 and later, when we moved from using hash tables to skip lists for storing IDs. The current hash table implementation does not use this parameter.