### PR TITLE
Remove HD from last non-win32 C89 functions

### DIFF
--- a/hl/tools/h5watch/h5watch.c
+++ b/hl/tools/h5watch/h5watch.c
@@ -785,13 +785,13 @@ main(int argc, char *argv[])
     h5tools_init();
 
     /* To exit from h5watch for SIGTERM signal */
-    if (HDsignal(SIGTERM, catch_signal) == SIG_ERR) {
+    if (signal(SIGTERM, catch_signal) == SIG_ERR) {
         error_msg("An error occurred while setting a signal handler.\n");
         leave(EXIT_FAILURE);
     }
 
     /* To exit from h5watch for SIGINT signal */
-    if (HDsignal(SIGINT, catch_signal) == SIG_ERR) {
+    if (signal(SIGINT, catch_signal) == SIG_ERR) {
         error_msg("An error occurred while setting a signal handler.\n");
         leave(EXIT_FAILURE);
     }

--- a/src/H5Clog_json.c
+++ b/src/H5Clog_json.c
@@ -245,7 +245,7 @@ H5C__log_json_set_up(H5C_log_info_t *log_info, const char log_location[], int mp
     /* Open log file and set it to be unbuffered */
     if (NULL == (json_udata->outfile = fopen(file_name, "w")))
         HGOTO_ERROR(H5E_CACHE, H5E_LOGGING, FAIL, "can't create mdc log file");
-    HDsetbuf(json_udata->outfile, NULL);
+    setbuf(json_udata->outfile, NULL);
 
 done:
     if (file_name)

--- a/src/H5Clog_trace.c
+++ b/src/H5Clog_trace.c
@@ -240,7 +240,7 @@ H5C__log_trace_set_up(H5C_log_info_t *log_info, const char log_location[], int m
     /* Open log file and set it to be unbuffered */
     if (NULL == (trace_udata->outfile = fopen(file_name, "w")))
         HGOTO_ERROR(H5E_CACHE, H5E_LOGGING, FAIL, "can't create mdc log file");
-    HDsetbuf(trace_udata->outfile, NULL);
+    setbuf(trace_udata->outfile, NULL);
 
     /* Write the header */
     fprintf(trace_udata->outfile, "### HDF5 metadata cache trace file version 1 ###\n");

--- a/src/H5private.h
+++ b/src/H5private.h
@@ -798,17 +798,8 @@ H5_DLL H5_ATTR_CONST int Nflock(int fd, int operation);
 #ifndef HDremove
 #define HDremove(S) remove(S)
 #endif
-#ifndef HDrename
-#define HDrename(OLD, NEW) rename(OLD, NEW)
-#endif
-#ifndef HDrewind
-#define HDrewind(F) rewind(F)
-#endif
 #ifndef HDrmdir
 #define HDrmdir(S) rmdir(S)
-#endif
-#ifndef HDsetbuf
-#define HDsetbuf(F, S) setbuf(F, S)
 #endif
 #ifndef HDsetenv
 #define HDsetenv(N, V, O) setenv(N, V, O)
@@ -824,9 +815,6 @@ H5_DLL H5_ATTR_CONST int Nflock(int fd, int operation);
 #endif
 #ifndef HDsigemptyset
 #define HDsigemptyset(S) sigemptyset(S)
-#endif
-#ifndef HDsignal
-#define HDsignal(N, F) signal(N, F)
 #endif
 #ifndef HDsleep
 #define HDsleep(N) sleep(N)
@@ -849,9 +837,6 @@ H5_DLL H5_ATTR_CONST int Nflock(int fd, int operation);
 #endif
 #ifndef HDstrtok_r
 #define HDstrtok_r(X, Y, Z) strtok_r(X, Y, Z)
-#endif
-#ifndef HDtmpfile
-#define HDtmpfile() tmpfile()
 #endif
 #ifndef HDunlink
 #define HDunlink(S) unlink(S)

--- a/test/app_ref.c
+++ b/test/app_ref.c
@@ -172,7 +172,7 @@ main(void)
 
     RAND_INC(T_ESTACK);
 
-    HDsignal(SIGABRT, &Abrt_Handler);
+    signal(SIGABRT, &Abrt_Handler);
 
     if (H5close() < 0)
         TEST_ERROR;

--- a/test/del_many_dense_attrs.c
+++ b/test/del_many_dense_attrs.c
@@ -69,7 +69,7 @@ main(void)
     h5_reset();
 
     /* To exit from the file for SIGABRT signal */
-    if (HDsignal(SIGABRT, catch_signal) == SIG_ERR)
+    if (signal(SIGABRT, catch_signal) == SIG_ERR)
         TEST_ERROR;
 
     fapl = h5_fileaccess();

--- a/test/dt_arith.c
+++ b/test/dt_arith.c
@@ -3261,7 +3261,7 @@ test_conv_flt_1(const char *name, int run_test, hid_t src, hid_t dst)
      * The remainder of this function is executed only by the child if
      * HANDLE_SIGFPE is defined.
      */
-    HDsignal(SIGFPE, fpe_handler);
+    signal(SIGFPE, fpe_handler);
 
     /* What are the names of the source and destination types */
     if (H5Tequal(src, H5T_NATIVE_FLOAT)) {

--- a/test/filenotclosed.c
+++ b/test/filenotclosed.c
@@ -80,7 +80,7 @@ main(void)
     h5_reset();
 
     /* To exit from the file for SIGABRT signal */
-    if (HDsignal(SIGABRT, catch_signal) == SIG_ERR)
+    if (signal(SIGABRT, catch_signal) == SIG_ERR)
         TEST_ERROR;
 
     fapl = h5_fileaccess();

--- a/test/h5test.c
+++ b/test/h5test.c
@@ -1784,7 +1784,7 @@ h5_send_message(const char *send, const char *arg1, const char *arg2)
 
     fclose(signalfile);
 
-    HDrename(TMP_SIGNAL_FILE, send);
+    rename(TMP_SIGNAL_FILE, send);
 } /* h5_send_message() */
 
 /*-------------------------------------------------------------------------
@@ -2099,8 +2099,8 @@ h5_compare_file_bytes(char *f1name, char *f2name)
     }
 
     /* Compare each byte and fail if a difference is found */
-    HDrewind(f1ptr);
-    HDrewind(f2ptr);
+    rewind(f1ptr);
+    rewind(f2ptr);
     for (ii = 0; ii < f1size; ii++) {
         if (fread(&f1char, 1, 1, f1ptr) != 1) {
             ret_value = -1;
@@ -2216,7 +2216,7 @@ h5_duplicate_file_by_bytes(const char *orig, const char *dest)
 
     HDfseek(orig_ptr, 0, SEEK_END);
     fsize = (size_t)HDftell(orig_ptr);
-    HDrewind(orig_ptr);
+    rewind(orig_ptr);
 
     dest_ptr = fopen(dest, "wb");
     if (NULL == dest_ptr) {

--- a/test/tcheck_version.c
+++ b/test/tcheck_version.c
@@ -126,9 +126,9 @@ main(int ac, char **av)
     (void)_CrtSetReportHook2(_CRT_RPTHOOK_INSTALL, handle_crt_abort);
 #endif
     parse(ac, av);
-    HDsignal(SIGABRT, &abort_intercept);
+    signal(SIGABRT, &abort_intercept);
     H5check_version(major, minor, release);
-    HDsignal(SIGABRT, SIG_DFL);
+    signal(SIGABRT, SIG_DFL);
 #ifdef H5_HAVE_WIN32_API
     (void)_CrtSetReportHook2(_CRT_RPTHOOK_REMOVE, handle_crt_abort);
 #endif

--- a/testpar/t_2Gio.c
+++ b/testpar/t_2Gio.c
@@ -4270,8 +4270,8 @@ main(int argc, char **argv)
 
 #ifndef H5_HAVE_WIN32_API
     /* Un-buffer the stdout and stderr */
-    HDsetbuf(stderr, NULL);
-    HDsetbuf(stdout, NULL);
+    setbuf(stderr, NULL);
+    setbuf(stdout, NULL);
 #endif
 
     MPI_Init(&argc, &argv);

--- a/testpar/t_shapesame.c
+++ b/testpar/t_shapesame.c
@@ -4283,8 +4283,8 @@ main(int argc, char **argv)
 
 #ifndef H5_HAVE_WIN32_API
     /* Un-buffer the stdout and stderr */
-    HDsetbuf(stderr, NULL);
-    HDsetbuf(stdout, NULL);
+    setbuf(stderr, NULL);
+    setbuf(stdout, NULL);
 #endif
 
 #ifdef H5_HAVE_TEST_API

--- a/testpar/testphdf5.c
+++ b/testpar/testphdf5.c
@@ -317,8 +317,8 @@ main(int argc, char **argv)
 
 #ifndef H5_HAVE_WIN32_API
     /* Un-buffer the stdout and stderr */
-    HDsetbuf(stderr, NULL);
-    HDsetbuf(stdout, NULL);
+    setbuf(stderr, NULL);
+    setbuf(stdout, NULL);
 #endif
 
 #ifdef H5_HAVE_TEST_API

--- a/tools/lib/h5tools_utils.c
+++ b/tools/lib/h5tools_utils.c
@@ -79,7 +79,7 @@ parallel_print(const char *format, ...)
                 /* Terminate the outbuff at the end of the previous output */
                 outBuff[outBuffOffset] = '\0';
 
-                overflow_file = HDtmpfile();
+                overflow_file = tmpfile();
                 if (overflow_file == NULL)
                     fprintf(rawerrorstream,
                             "warning: could not create overflow file.  Output may be truncated.\n");


### PR DESCRIPTION
Removes the HD prefix from the last C89 functions with no special Windows equilvalent:

* rename
* rewind
* setbuf
* signal
* tmpfile