### PR TITLE
Fix broken links and references in INSTALL_Auto.txt

### DIFF
--- a/release_docs/INSTALL_Auto.txt
+++ b/release_docs/INSTALL_Auto.txt
@@ -5,7 +5,7 @@
                      Table of Contents
 
 Section I.    Preconditions
-Section II:   Unix and Mac OSX Configuration and Build
+Section II:   Unix and macOS Configuration and Build
 Section III:  Full installation instructions for source distributions
 Section IV:   Using the Library
 Section V:    Windows Configuration and Build
@@ -34,7 +34,7 @@ Obtaining HDF5 source code
 
 
 ========================================================================
-II. Unix and Mac OSX Configuration and Build
+II. Unix and macOS Configuration and Build
 ========================================================================
 
 See RELEASE.txt in the release_notes/ directory for the list of platforms
@@ -42,7 +42,7 @@ tested for this release.
 
 Before You Start:
 
-   1.  Make sure that the ZLIB library is installed on your system.
+   1.  Make sure that the zlib library is installed on your system.
 
    2.  Optional: Install the Szip version 2.1 library (you may use
        Szip 2.0 binaries). 
@@ -65,14 +65,14 @@ Before You Start:
 
         <more configure_flags> above refers to the configure flags appropriate
         to your installation.  For example, to install HDF5 with the
-        Fortran and C++ interfaces and with SZIP compression, the
+        Fortran and C++ interfaces and with Szip compression, the
         configure line might read as follows:
 
             $ ./configure --prefix=/usr/local/hdf5 --enable-fortran \
                           --enable-cxx --with-szlib=PATH_TO_SZIP
 
         In this case, PATH_TO_SZIP would be replaced with the path to the
-        installed location of the SZIP library.
+        installed location of the Szip library.
 
 ========================================================================
 III. Full installation instructions for source distributions
@@ -87,19 +87,13 @@ III. Full installation instructions for source distributions
 
             $ tar xf hdf5-X.Y.Z.tar
 
-   1.2. Compressed tar archive (*.tar.Z)
-
-            $ uncompress -c < hdf5-X.Y.Z.tar.Z | tar xf -
-            Or
-            $ tar Zxf hdf5-X.Y.Z.tar.Z
-
-   1.3. Gzip'd tar archive (*.tar.gz)
+   1.2. Gzip'd tar archive (*.tar.gz)
 
             $ gunzip < hdf5-X.Y.Z.tar.gz | tar xf -
             Or
             $ tar zxf hdf5-X.Y.Z.tar.gz
 
-   1.4. Bzip'd tar archive (*.tar.bz2)
+   1.3. Bzip'd tar archive (*.tar.bz2)
 
             $ bunzip2 < hdf5-X.Y.Z.tar.bz2 | tar xf -
             Or
@@ -258,11 +252,11 @@ III. Full installation instructions for source distributions
               LDFLAGS=-L/usr/unsup/lib \
               ./configure
 
-        HDF5 includes Szip as a predefined compression method (see 3.2).
+        HDF5 includes Szip as a predefined compression method (see INSTALL 2.2).
         To enable Szip compression, the HDF5 library must be configured
         and built using the Szip library:
 
-            $ ./configure --with-szlib=/Szip_Install_Directory
+            $ ./configure --with-szlib=PATH_TO_SZIP
 
    3.7. Static versus shared linking
         The build process will create static libraries on all systems and
@@ -367,7 +361,7 @@ III. Full installation instructions for source distributions
         source code.  For additional configuration options and other details,
         see "API Compatibility Macros":
 
-            https://portal.hdfgroup.org/display/HDF5/API+Compatibility+Macros
+            https://docs.hdfgroup.org/hdf5/develop/api-compat-macros.html
 
    4. Building
         The library, confidence tests, and programs can be built by


### PR DESCRIPTION
Fix a broken portal links.

3.2 reference is irrelevant. Change it to INSTALL 2.2.

Improve consistency.
- Szip
- macOS
- PATH_TO_SZIP
- zlib

Remove .tar.Z instruction. I don't see it in 1.4.13 release download page.