### PR TITLE
Change date to data in INSTALL_parallel

### DIFF
--- a/release_docs/INSTALL_parallel
+++ b/release_docs/INSTALL_parallel
@@ -202,7 +202,7 @@ Reference
 1. POSIX Compliant. A good explanation is by Donald Lewin,
     After a write() to a regular file has successfully returned, any
     successful read() from each byte position on the file that was modified
-    by that write() will return the date that was written by the write(). A
+    by that write() will return the data that was written by the write(). A
     subsequent write() to the same byte will overwrite the file data. If a
     read() of a file data can be proven by any means [e.g., MPI_Barrier()]
     to occur after a write() of that data, it must reflect that write(),


### PR DESCRIPTION
`date` does not make sense in the following sentence:

```
After a write() to a regular file has successfully returned, any
    successful read() from each byte position on the file that was modified
    by that write() will return the date that was written by the write(). 
```
