### PR TITLE
switched from \returns to more commonly used \return

### DIFF
--- a/src/H5Apublic.h
+++ b/src/H5Apublic.h
@@ -42,7 +42,7 @@ typedef struct {
  * \param[in] ainfo The attribute's info struct
  * \param[in,out] op_data A pointer to the operator data passed into
  *                H5Aiterate2() or H5Aiterate_by_name()
- * \returns The return values from an operator are:
+ * \return The return values from an operator are:
  *          \li Zero causes the iterator to continue, returning zero when
  *              all attributes have been processed.
  *          \li Positive causes the iterator to immediately return that
@@ -1098,7 +1098,7 @@ H5_DLL herr_t H5Arename_by_name(hid_t loc_id, const char *obj_name, const char *
  * \param[in] attr_name The name of the current object attribute
  * \param[in,out] operator_data A pointer to the operator data passed into
  *                H5Aiterate1()
- * \returns The return values from an operator are:
+ * \return The return values from an operator are:
  *          \li Zero causes the iterator to continue, returning zero when
  *              all attributes have been processed.
  *          \li Positive causes the iterator to immediately return that

--- a/src/H5Dpublic.h
+++ b/src/H5Dpublic.h
@@ -204,7 +204,7 @@ typedef herr_t (*H5D_scatter_func_t)(const void **src_buf /*out*/, size_t *src_b
  * \param[in,out] op_data User-defined pointer to data required by the callback
  *                        function; a pass-through of the \p op_data pointer
  *                        provided with the H5Dgather() function call.
- * \returns \herr_t
+ * \return \herr_t
  *
  * \details The callback function should process, store, or otherwise make use
  *          of the data returned in dst_buf before it returns, because the
@@ -228,7 +228,7 @@ typedef herr_t (*H5D_gather_func_t)(const void *dst_buf, size_t dst_buf_bytes_us
  * \param[in]     size        Chunk size in bytes, 0 if the chunk does not exist
  * \param[in,out] op_data     Pointer to any user-defined data associated with
  *                            the operation.
- * \returns \li Zero (#H5_ITER_CONT) causes the iterator to continue, returning
+ * \return \li Zero (#H5_ITER_CONT) causes the iterator to continue, returning
  *              zero when all elements have been processed.
  *          \li A positive value (#H5_ITER_STOP) causes the iterator to
  *              immediately return that value, indicating short-circuit success.

--- a/src/H5ESpublic.h
+++ b/src/H5ESpublic.h
@@ -150,7 +150,7 @@ extern "C" {
  *
  * \brief Creates an event set
  *
- * \returns \hid_t{event set}
+ * \return \hid_t{event set}
  *
  * \details H5EScreate() creates a new event set and returns a corresponding
  *          event set identifier.
@@ -170,7 +170,7 @@ H5_DLL hid_t H5EScreate(void);
  *            the event set to complete
  * \param[out] num_in_progress The number of operations still in progress
  * \param[out] err_occurred Flag if an operation in the event set failed
- * \returns \herr_t
+ * \return \herr_t
  *
  * \details H5ESwait() waits for operations in an event set \p es_id to wait
  *          with \p timeout.
@@ -201,7 +201,7 @@ H5_DLL herr_t H5ESwait(hid_t es_id, uint64_t timeout, size_t *num_in_progress, h
  * \es_id
  * \param[out] num_not_canceled The number of events not canceled
  * \param[out] err_occurred Status indicating if error is present in the event set
- * \returns \herr_t
+ * \return \herr_t
  *
  * \details H5EScancel() attempts to cancel operations in an event set specified
  *          by \p es_id. H5ES_NONE is a valid value for \p es_id, but functions as a no-op.
@@ -218,7 +218,7 @@ H5_DLL herr_t H5EScancel(hid_t es_id, size_t *num_not_canceled, hbool_t *err_occ
  *
  * \es_id
  * \param[out] count The number of events in the event set
- * \returns \herr_t
+ * \return \herr_t
  *
  * \details H5ESget_count() retrieves number of events in an event set specified
  *          by \p es_id.
@@ -235,7 +235,7 @@ H5_DLL herr_t H5ESget_count(hid_t es_id, size_t *count);
  *
  * \es_id
  * \param[out] counter The accumulative counter value for an event set
- * \returns \herr_t
+ * \return \herr_t
  *
  * \details H5ESget_op_counter() retrieves the current accumulative count of
  *          event set operations since the event set creation of \p es_id.
@@ -257,7 +257,7 @@ H5_DLL herr_t H5ESget_op_counter(hid_t es_id, uint64_t *counter);
  * \es_id
  * \param[out] err_occurred Status indicating if error is present in the event
  *             set
- * \returns \herr_t
+ * \return \herr_t
  *
  * \details H5ESget_err_status() checks if event set specified by es_id has
  *          failed operations.
@@ -274,7 +274,7 @@ H5_DLL herr_t H5ESget_err_status(hid_t es_id, hbool_t *err_occurred);
  *
  * \es_id
  * \param[out] num_errs Number of errors
- * \returns \herr_t
+ * \return \herr_t
  *
  * \details H5ESget_err_count() retrieves the number of failed operations in an
  *          event set specified by \p es_id.
@@ -296,7 +296,7 @@ H5_DLL herr_t H5ESget_err_count(hid_t es_id, size_t *num_errs);
  * \param[in] num_err_info The number of elements in \p err_info array
  * \param[out] err_info Array of structures
  * \param[out] err_cleared Number of cleared errors
- * \returns \herr_t
+ * \return \herr_t
  *
  * \details H5ESget_err_info() retrieves information about failed operations in
  *          an event set specified by \p es_id.  The strings retrieved for each
@@ -318,7 +318,7 @@ H5_DLL herr_t H5ESget_err_info(hid_t es_id, size_t num_err_info, H5ES_err_info_t
  *
  * \param[in] num_err_info The number of elements in \p err_info array
  * \param[in] err_info Array of structures
- * \returns \herr_t
+ * \return \herr_t
  *
  * \since 1.14.0
  *
@@ -334,7 +334,7 @@ H5_DLL herr_t H5ESfree_err_info(size_t num_err_info, H5ES_err_info_t err_info[])
  * \es_id
  * \param[in] func The insert function to register
  * \param[in] ctx User-specified information (context) to pass to \p func
- * \returns \herr_t
+ * \return \herr_t
  *
  * \details Only one insert callback can be registered for each event set.
  *          Registering a new callback will replace the existing one.
@@ -354,7 +354,7 @@ H5_DLL herr_t H5ESregister_insert_func(hid_t es_id, H5ES_event_insert_func_t fun
  * \es_id
  * \param[in] func The completion function to register
  * \param[in] ctx User-specified information (context) to pass to \p func
- * \returns \herr_t
+ * \return \herr_t
  *
  * \details Only one complete callback can be registered for each event set.
  *          Registering a new callback will replace the existing one.
@@ -371,7 +371,7 @@ H5_DLL herr_t H5ESregister_complete_func(hid_t es_id, H5ES_event_complete_func_t
  * \brief Terminates access to an event set
  *
  * \es_id
- * \returns \herr_t
+ * \return \herr_t
  *
  * \details H5ESclose() terminates access to an event set specified by \p es_id.
  *

--- a/src/H5Fpublic.h
+++ b/src/H5Fpublic.h
@@ -1142,7 +1142,7 @@ H5_DLL herr_t H5Fget_mdc_hit_rate(hid_t file_id, double *hit_rate_ptr);
  *                          or NULL if that datum is not desired
  * \param[out] cur_num_entries_ptr Pointer to the location in which the current number of entries in
  *                                 the cache is to be returned, or NULL if that datum is not desired
- * \returns \herr_t
+ * \return \herr_t
  *
  * \details H5Fget_mdc_size()  queries the metadata cache of the target file for the desired size
  *          information, and returns this information in the locations indicated by the pointer
@@ -1168,7 +1168,7 @@ H5_DLL herr_t H5Fget_mdc_size(hid_t file_id, size_t *max_size_ptr, size_t *min_c
  * \brief Resets hit rate statistics counters for the target file
  *
  * \file_id
- * \returns \herr_t
+ * \return \herr_t
  *
  * \details
  * \parblock
@@ -1683,7 +1683,7 @@ H5_DLL herr_t H5Fget_page_buffering_stats(hid_t file_id, unsigned accesses[2], u
  * \file_id
  * \param[out] image_addr Offset of the cache image if it exists, or #HADDR_UNDEF if it does not
  * \param[out] image_size Length of the cache image if it exists, or 0 if it does not
- * \returns \herr_t
+ * \return \herr_t
  *
  * \details
  * \parblock
@@ -1771,7 +1771,7 @@ H5_DLL herr_t H5Fset_dset_no_attrs_hint(hid_t file_id, hbool_t minimize);
  * \param[in] flag Logical flag for atomicity setting. Valid values are:
  *                 \li \c 1 -- Sets MPI file access to atomic mode.
  *                 \li \c 0 -- Sets MPI file access to nonatomic mode.
- * \returns \herr_t
+ * \return \herr_t
  *
  * \par Motivation
  * H5Fset_mpi_atomicity() is applicable only in parallel environments using MPI I/O.
@@ -1836,7 +1836,7 @@ H5_DLL herr_t H5Fset_mpi_atomicity(hid_t file_id, hbool_t flag);
  * \param[out] flag Logical flag for atomicity setting. Valid values are:
  *                  \li 1 -- MPI file access is set to atomic mode.
  *                  \li 0 -- MPI file access is set to nonatomic mode.
- * \returns \herr_t
+ * \return \herr_t
  *
  * \details H5Fget_mpi_atomicity() retrieves the current consistency semantics mode for
  *          data access for the file \p file_id.

--- a/src/H5Mpublic.h
+++ b/src/H5Mpublic.h
@@ -214,7 +214,7 @@ extern "C" {
  * \lcpl_id
  * \mcpl_id
  * \mapl_id
- * \returns \hid_t{map object}
+ * \return \hid_t{map object}
  *
  * \details H5Mcreate() creates a new map object for storing key-value
  *          pairs. The in-file datatype for keys is defined by \p key_type_id
@@ -262,7 +262,7 @@ H5_DLL hid_t H5Mcreate_anon(hid_t loc_id, hid_t key_type_id, hid_t val_type_id, 
  * \fgdta_loc_id{loc_id}
  * \param[in] name Map object name relative to \p loc_id
  * \mapl_id
- * \returns \hid_t{map object}
+ * \return \hid_t{map object}
  *
  * \details H5Mopen() finds a map object specified by \p name under the location
  *          specified by \p loc_id. The map object should be close with
@@ -291,7 +291,7 @@ H5_DLL hid_t  H5Mopen_async(hid_t loc_id, const char *name, hid_t mapl_id, hid_t
  * \brief Terminates access to a map object
  *
  * \map_id
- * \returns \herr_t
+ * \return \herr_t
  *
  * \details H5Mclose() closes access to a map object specified by \p map_id and
  *          releases resources used by it.
@@ -321,7 +321,7 @@ H5_DLL herr_t H5Mclose_async(hid_t map_id, hid_t es_id);
  * \brief Gets key datatype for a map object
  *
  * \map_id
- * \returns \hid_t{datatype}
+ * \return \hid_t{datatype}
  *
  * \details H5Mget_key_type() retrieves key datatype as stored in the file for a
  *          map object specified by \p map_id and returns identifier for the
@@ -338,7 +338,7 @@ H5_DLL hid_t H5Mget_key_type(hid_t map_id);
  * \brief Gets value datatype for a map object
  *
  * \map_id
- * \returns \hid_t{datatype}
+ * \return \hid_t{datatype}
  *
  * \details H5Mget_val_type() retrieves value datatype as stored in the file for
  *          a map object specified by \p map_id and returns identifier for the
@@ -355,7 +355,7 @@ H5_DLL hid_t H5Mget_val_type(hid_t map_id);
  * \brief Gets creation property list for a map object
  *
  * \map_id
- * \returns \hid_t{map creation property list}
+ * \return \hid_t{map creation property list}
  *
  * \details H5Mget_create_plist() returns an identifier for a copy of the
  *          creation property list for a map object specified by \p map_id.
@@ -374,7 +374,7 @@ H5_DLL hid_t H5Mget_create_plist(hid_t map_id);
  * \brief Gets access property list for a map object
  *
  * \map_id
- * \returns \hid_t{map access property list}
+ * \return \hid_t{map access property list}
  *
  * \details H5Mget_access_plist() returns an identifier for a copy of the access
  *          property list for a map object specified by \p map_id.
@@ -392,7 +392,7 @@ H5_DLL hid_t H5Mget_access_plist(hid_t map_id);
  * \map_id
  * \param[out] count The number of key-value pairs stored in the map object
  * \dxpl_id
- * \returns \herr_t
+ * \return \herr_t
  *
  * \details H5Mget_count() retrieves the number of key-value pairs stored in a
  *          map specified by map_id.
@@ -413,7 +413,7 @@ H5_DLL herr_t H5Mget_count(hid_t map_id, hsize_t *count, hid_t dxpl_id);
  * \type_id{val_mem_type_id}
  * \param[in] value Pointer to value buffer
  * \dxpl_id
- * \returns \herr_t
+ * \return \herr_t
  *
  * \details H5Mput() adds a key-value pair to a map object specified by \p
  *          map_id, or updates the value for the specified key if one was set
@@ -457,7 +457,7 @@ H5_DLL herr_t H5Mput_async(hid_t map_id, hid_t key_mem_type_id, const void *key,
  * \type_id{val_mem_type_id}
  * \param[out] value Pointer to value buffer
  * \dxpl_id
- * \returns \herr_t
+ * \return \herr_t
  *
  * \details H5Mget() retrieves from a map object specified by \p map_id, the
  *          value associated with the provided key \p key. \p key_mem_type_id
@@ -502,7 +502,7 @@ H5_DLL herr_t H5Mget_async(hid_t map_id, hid_t key_mem_type_id, const void *key,
  * \param[in] key Pointer to key buffer
  * \param[out] exists Pointer to a buffer to return the existence status
  * \dxpl_id
- * \returns \herr_t
+ * \return \herr_t
  *
  * \details H5Mexists() checks if the provided key is stored in the map object
  *          specified by \p map_id. If \p key_mem_type_id is different from that
@@ -528,7 +528,7 @@ H5_DLL herr_t H5Mexists(hid_t map_id, hid_t key_mem_type_id, const void *key, hb
  * \param[in] op User-defined iterator function
  * \op_data
  * \dxpl_id
- * \returns \herr_t
+ * \return \herr_t
  *
  * \details H5Miterate() iterates over all key-value pairs stored in the map
  *          object specified by \p map_id, making the callback specified by \p
@@ -572,7 +572,7 @@ H5_DLL herr_t H5Miterate(hid_t map_id, hsize_t *idx, hid_t key_mem_type_id, H5M_
  * \op_data
  * \dxpl_id
  * \lapl_id
- * \returns \herr_t
+ * \return \herr_t
  *
  * \details H5Miterate_by_name() iterates over all key-value pairs stored in the
  *          map object specified by \p map_id, making the callback specified by
@@ -612,7 +612,7 @@ H5_DLL herr_t H5Miterate_by_name(hid_t loc_id, const char *map_name, hsize_t *id
  * \type_id{key_mem_type_id}
  * \param[in] key Pointer to key buffer
  * \dxpl_id
- * \returns \herr_t
+ * \return \herr_t
  *
  * \details H5Mdelete() deletes a key-value pair from the map object specified
  *          by \p map_id. \p key_mem_type_id specifies the datatype for the

--- a/src/H5Tpublic.h
+++ b/src/H5Tpublic.h
@@ -227,7 +227,7 @@ extern "C" {
  * \param[in] src_buf Source data buffer
  * \param[in,out] dst_buf Destination data buffer
  * \param[in,out] user_data Callback context
- * \returns Valid callback function return values are #H5T_CONV_ABORT,
+ * \return Valid callback function return values are #H5T_CONV_ABORT,
  *          #H5T_CONV_UNHANDLED and #H5T_CONV_HANDLED.
  *
  * \details If an exception like overflow happens during conversion, this

--- a/src/H5public.h
+++ b/src/H5public.h
@@ -103,7 +103,7 @@
  * \param[in] Maj Major version number - A non-negative integer value
  * \param[in] Min Minor version number - A non-negative integer value
  * \param[in] Rel Release version number - A non-negative integer value
- * \returns A value of 1 is returned if the library version is greater than
+ * \return A value of 1 is returned if the library version is greater than
  *          or equal to the version number specified.\n
  *          A value of 0 is returned if the library version is less than the
  *          version number specified.\n
@@ -139,7 +139,7 @@
  * \param[in] Maj Major version number - A non-negative integer value
  * \param[in] Min Minor version number - A non-negative integer value
  * \param[in] Rel Release version number - A non-negative integer value
- * \returns A value of 1 is returned if the library version is less than
+ * \return A value of 1 is returned if the library version is less than
  *          or equal to the version number specified.\n
  *          A value of 0 is returned if the library version is greater than the
  *          version number specified.\n


### PR DESCRIPTION
Switched to the \return convention instead of having a mix of the two.