### PR TITLE
Updates for release_docs/NEWSLETTER.txt.

### DIFF
--- a/bin/release
+++ b/bin/release
@@ -455,7 +455,7 @@ cp -p Makefile.dist Makefile
 
 # Update README.md and release_docs/RELEASE.txt with release information in
 # line 1.
-for f in README.md release_docs/RELEASE.txt; do
+for f in README.md release_docs/RELEASE.txt release_docs/NEWSLETTER.txt; do
     echo "HDF5 version $VERS released on $release_date" >$f.x
     sed -e 1d $f >>$f.x
     mv $f.x $f

--- a/release_docs/NEWSLETTER.txt
+++ b/release_docs/NEWSLETTER.txt
@@ -1,18 +1,9 @@
-Release of HDF5 1.14.4 Library and Tools is now available from the HDF5 Releases page.
+HDF5 version 1.15.0 currently under development
 
-This is a maintenance release with a few changes and updates:
+Features included for the next major release:
 ----------------------------------------------------------------------------
 
-* Added support for _Float16 16-bit floating-point datatype
-
-  Support for the 16-bit floating-point _Float16 C type has been added to
-  HDF5. On platforms where this type is available, this can enable more
-  efficient storage of floating-point data when an application doesn't
-  need the precision of larger floating-point datatypes. It can also allow
-  for improved performance when converting between 16-bit floating-point
-  data and data of another HDF5 datatype.
-
-  (GitHub #4065, #2154)
+*
 
 ----------------------------------------------------------------------------
 Please see the full release notes for detailed information regarding this release,


### PR DESCRIPTION
1st line of NEWSLETTER.txt had a reference to the 1.14.4 release.  The first line has been changed to include the current branch version and the release date when that occurs.  The release date will be inserted by bin/release in place of "currently under development" as is done for README.md and RELEASE.txt.  bin/h5vers sets the version in the 1st line of these files.