### PR TITLE
Lowercase `Specifies` in File Format Specification

### DIFF
--- a/doxygen/examples/H5.format.html
+++ b/doxygen/examples/H5.format.html
@@ -1432,7 +1432,7 @@
 
 	    <tr>
 	      <td><p>Address of Member File N</p></td>
-	      <td><p>This field Specifies the virtual address at which the member file starts.</p>
+	      <td><p>This field specifies the virtual address at which the member file starts.</p>
 	        <p>N is the number of member files.</p>
 	      </td>
 	    </tr>


### PR DESCRIPTION
`This field Specifies the virtual address at which the member file starts.`
   ->
 `This field specifies the virtual address at which the member file starts.`

in https://portal.hdfgroup.org/hdf5/develop/_f_m_t3.html#Superblock