### PR TITLE
Don't print thread ID when the library isn't multithreaded

### DIFF
--- a/java/test/junit.sh.in
+++ b/java/test/junit.sh.in
@@ -348,7 +348,7 @@ TESTING JUnit-TestH5
 ($RUNSERIAL $JAVAEXE $JAVAEXEFLAGS -Xmx1024M -Dorg.slf4j.simpleLogger.defaultLog=trace -Djava.library.path=$BLDLIBDIR -cp $CLASSPATH -ea org.junit.runner.JUnitCore test.TestH5 > JUnit-TestH5.ext)
 
 # Extract file name, line number, version and thread IDs because they may be different
-sed -e 's/thread [0-9]*/thread (IDs)/' -e 's/: .*\.c /: (file name) /' \
+sed -e 's/ thread [0-9]*//' -e 's/: .*\.c /: (file name) /' \
     -e 's/line [0-9]*/line (number)/' \
     -e 's/Time: [0-9]*[\.,[0-9]*]*/Time:  XXXX/' \
     -e 's/v[1-9]*\.[0-9]*\./version (number)\./' \
@@ -369,7 +369,7 @@ TESTING JUnit-TestH5Eparams
 ($RUNSERIAL $JAVAEXE $JAVAEXEFLAGS -Xmx1024M -Dorg.slf4j.simpleLogger.defaultLog=trace -Djava.library.path=$BLDLIBDIR -cp $CLASSPATH -ea org.junit.runner.JUnitCore test.TestH5Eparams > JUnit-TestH5Eparams.ext)
 
 # Extract file name, line number, version and thread IDs because they may be different
-sed -e 's/thread [0-9]*/thread (IDs)/' -e 's/: .*\.c /: (file name) /' \
+sed -e 's/ thread [0-9]*//' -e 's/: .*\.c /: (file name) /' \
     -e 's/line [0-9]*/line (number)/' \
     -e 's/Time: [0-9]*[\.,[0-9]*]*/Time:  XXXX/' \
     -e 's/v[1-9]*\.[0-9]*\./version (number)\./' \
@@ -390,7 +390,7 @@ TESTING JUnit-TestH5Eregister
 ($RUNSERIAL $JAVAEXE $JAVAEXEFLAGS -Xmx1024M -Dorg.slf4j.simpleLogger.defaultLog=trace -Djava.library.path=$BLDLIBDIR -cp $CLASSPATH -ea org.junit.runner.JUnitCore test.TestH5Eregister > JUnit-TestH5Eregister.ext)
 
 # Extract file name, line number, version and thread IDs because they may be different
-sed -e 's/thread [0-9]*/thread (IDs)/' -e 's/: .*\.c /: (file name) /' \
+sed -e 's/ thread [0-9]*//' -e 's/: .*\.c /: (file name) /' \
     -e 's/line [0-9]*/line (number)/' \
     -e 's/Time: [0-9]*[\.,[0-9]*]*/Time:  XXXX/' \
     -e 's/v[1-9]*\.[0-9]*\./version (number)\./' \
@@ -411,7 +411,7 @@ TESTING JUnit-TestH5Fparams
 ($RUNSERIAL $JAVAEXE $JAVAEXEFLAGS -Xmx1024M -Dorg.slf4j.simpleLogger.defaultLog=trace -Djava.library.path=$BLDLIBDIR -cp $CLASSPATH -ea org.junit.runner.JUnitCore test.TestH5Fparams > JUnit-TestH5Fparams.ext)
 
 # Extract file name, line number, version and thread IDs because they may be different
-sed -e 's/thread [0-9]*/thread (IDs)/' -e 's/: .*\.c /: (file name) /' \
+sed -e 's/ thread [0-9]*//' -e 's/: .*\.c /: (file name) /' \
     -e 's/line [0-9]*/line (number)/' \
     -e 's/Time: [0-9]*[\.,[0-9]*]*/Time:  XXXX/' \
     -e 's/v[1-9]*\.[0-9]*\./version (number)\./' \
@@ -432,7 +432,7 @@ TESTING JUnit-TestH5Fbasic
 ($RUNSERIAL $JAVAEXE $JAVAEXEFLAGS -Xmx1024M -Dorg.slf4j.simpleLogger.defaultLog=trace -Djava.library.path=$BLDLIBDIR -cp $CLASSPATH -ea org.junit.runner.JUnitCore test.TestH5Fbasic > JUnit-TestH5Fbasic.ext)
 
 # Extract file name, line number, version and thread IDs because they may be different
-sed -e 's/thread [0-9]*/thread (IDs)/' -e 's/: .*\.c /: (file name) /' \
+sed -e 's/ thread [0-9]*//' -e 's/: .*\.c /: (file name) /' \
     -e 's/line [0-9]*/line (number)/' \
     -e 's/Time: [0-9]*[\.,[0-9]*]*/Time:  XXXX/' \
     -e 's/v[1-9]*\.[0-9]*\./version (number)\./' \
@@ -453,7 +453,7 @@ TESTING JUnit-TestH5F
 ($RUNSERIAL $JAVAEXE $JAVAEXEFLAGS -Xmx1024M -Dorg.slf4j.simpleLogger.defaultLog=trace -Djava.library.path=$BLDLIBDIR -cp $CLASSPATH -ea org.junit.runner.JUnitCore test.TestH5F > JUnit-TestH5F.ext)
 
 # Extract file name, line number, version and thread IDs because they may be different
-sed -e 's/thread [0-9]*/thread (IDs)/' -e 's/: .*\.c /: (file name) /' \
+sed -e 's/ thread [0-9]*//' -e 's/: .*\.c /: (file name) /' \
     -e 's/line [0-9]*/line (number)/' \
     -e 's/Time: [0-9]*[\.,[0-9]*]*/Time:  XXXX/' \
     -e 's/v[1-9]*\.[0-9]*\./version (number)\./' \
@@ -474,7 +474,7 @@ TESTING JUnit-TestH5Fswmr
 ($RUNSERIAL $JAVAEXE $JAVAEXEFLAGS -Xmx1024M -Dorg.slf4j.simpleLogger.defaultLog=trace -Djava.library.path=$BLDLIBDIR -cp $CLASSPATH -ea org.junit.runner.JUnitCore test.TestH5Fswmr > JUnit-TestH5Fswmr.ext)
 
 # Extract file name, line number, version and thread IDs because they may be different
-sed -e 's/thread [0-9]*/thread (IDs)/' -e 's/: .*\.c /: (file name) /' \
+sed -e 's/ thread [0-9]*//' -e 's/: .*\.c /: (file name) /' \
     -e 's/line [0-9]*/line (number)/' \
     -e 's/Time: [0-9]*[\.,[0-9]*]*/Time:  XXXX/' \
     -e 's/v[1-9]*\.[0-9]*\./version (number)\./' \
@@ -495,7 +495,7 @@ TESTING JUnit-TestH5Gbasic
 ($RUNSERIAL $JAVAEXE $JAVAEXEFLAGS -Xmx1024M -Dorg.slf4j.simpleLogger.defaultLog=trace -Djava.library.path=$BLDLIBDIR -cp $CLASSPATH -ea org.junit.runner.JUnitCore test.TestH5Gbasic > JUnit-TestH5Gbasic.ext)
 
 # Extract file name, line number, version and thread IDs because they may be different
-sed -e 's/thread [0-9]*/thread (IDs)/' -e 's/: .*\.c /: (file name) /' \
+sed -e 's/ thread [0-9]*//' -e 's/: .*\.c /: (file name) /' \
     -e 's/line [0-9]*/line (number)/' \
     -e 's/Time: [0-9]*[\.,[0-9]*]*/Time:  XXXX/' \
     -e 's/v[1-9]*\.[0-9]*\./version (number)\./' \
@@ -516,7 +516,7 @@ TESTING JUnit-TestH5G
 ($RUNSERIAL $JAVAEXE $JAVAEXEFLAGS -Xmx1024M -Dorg.slf4j.simpleLogger.defaultLog=trace -Djava.library.path=$BLDLIBDIR -cp $CLASSPATH -ea org.junit.runner.JUnitCore test.TestH5G > JUnit-TestH5G.ext)
 
 # Extract file name, line number, version and thread IDs because they may be different
-sed -e 's/thread [0-9]*/thread (IDs)/' -e 's/: .*\.c /: (file name) /' \
+sed -e 's/ thread [0-9]*//' -e 's/: .*\.c /: (file name) /' \
     -e 's/line [0-9]*/line (number)/' \
     -e 's/Time: [0-9]*[\.,[0-9]*]*/Time:  XXXX/' \
     -e 's/v[1-9]*\.[0-9]*\./version (number)\./' \
@@ -537,7 +537,7 @@ TESTING JUnit-TestH5Sbasic
 ($RUNSERIAL $JAVAEXE $JAVAEXEFLAGS -Xmx1024M -Dorg.slf4j.simpleLogger.defaultLog=trace -Djava.library.path=$BLDLIBDIR -cp $CLASSPATH -ea org.junit.runner.JUnitCore test.TestH5Sbasic > JUnit-TestH5Sbasic.ext)
 
 # Extract file name, line number, version and thread IDs because they may be different
-sed -e 's/thread [0-9]*/thread (IDs)/' -e 's/: .*\.c /: (file name) /' \
+sed -e 's/ thread [0-9]*//' -e 's/: .*\.c /: (file name) /' \
     -e 's/line [0-9]*/line (number)/' \
     -e 's/Time: [0-9]*[\.,[0-9]*]*/Time:  XXXX/' \
     -e 's/v[1-9]*\.[0-9]*\./version (number)\./' \
@@ -558,7 +558,7 @@ TESTING JUnit-TestH5S
 ($RUNSERIAL $JAVAEXE $JAVAEXEFLAGS -Xmx1024M -Dorg.slf4j.simpleLogger.defaultLog=trace -Djava.library.path=$BLDLIBDIR -cp $CLASSPATH -ea org.junit.runner.JUnitCore test.TestH5S > JUnit-TestH5S.ext)
 
 # Extract file name, line number, version and thread IDs because they may be different
-sed -e 's/thread [0-9]*/thread (IDs)/' -e 's/: .*\.c /: (file name) /' \
+sed -e 's/ thread [0-9]*//' -e 's/: .*\.c /: (file name) /' \
     -e 's/line [0-9]*/line (number)/' \
     -e 's/Time: [0-9]*[\.,[0-9]*]*/Time:  XXXX/' \
     -e 's/v[1-9]*\.[0-9]*\./version (number)\./' \
@@ -579,7 +579,7 @@ TESTING JUnit-TestH5Tparams
 ($RUNSERIAL $JAVAEXE $JAVAEXEFLAGS -Xmx1024M -Dorg.slf4j.simpleLogger.defaultLog=trace -Djava.library.path=$BLDLIBDIR -cp $CLASSPATH -ea org.junit.runner.JUnitCore test.TestH5Tparams > JUnit-TestH5Tparams.ext)
 
 # Extract file name, line number, version and thread IDs because they may be different
-sed -e 's/thread [0-9]*/thread (IDs)/' -e 's/: .*\.c /: (file name) /' \
+sed -e 's/ thread [0-9]*//' -e 's/: .*\.c /: (file name) /' \
     -e 's/line [0-9]*/line (number)/' \
     -e 's/Time: [0-9]*[\.,[0-9]*]*/Time:  XXXX/' \
     -e 's/v[1-9]*\.[0-9]*\./version (number)\./' \
@@ -600,7 +600,7 @@ TESTING JUnit-TestH5Tbasic
 ($RUNSERIAL $JAVAEXE $JAVAEXEFLAGS -Xmx1024M -Dorg.slf4j.simpleLogger.defaultLog=trace -Djava.library.path=$BLDLIBDIR -cp $CLASSPATH -ea org.junit.runner.JUnitCore test.TestH5Tbasic > JUnit-TestH5Tbasic.ext)
 
 # Extract file name, line number, version and thread IDs because they may be different
-sed -e 's/thread [0-9]*/thread (IDs)/' -e 's/: .*\.c /: (file name) /' \
+sed -e 's/ thread [0-9]*//' -e 's/: .*\.c /: (file name) /' \
     -e 's/line [0-9]*/line (number)/' \
     -e 's/Time: [0-9]*[\.,[0-9]*]*/Time:  XXXX/' \
     -e 's/v[1-9]*\.[0-9]*\./version (number)\./' \
@@ -621,7 +621,7 @@ TESTING JUnit-TestH5T
 ($RUNSERIAL $JAVAEXE $JAVAEXEFLAGS -Xmx1024M -Dorg.slf4j.simpleLogger.defaultLog=trace -Djava.library.path=$BLDLIBDIR -cp $CLASSPATH -ea org.junit.runner.JUnitCore test.TestH5T > JUnit-TestH5T.ext)
 
 # Extract file name, line number, version and thread IDs because they may be different
-sed -e 's/thread [0-9]*/thread (IDs)/' -e 's/: .*\.c /: (file name) /' \
+sed -e 's/ thread [0-9]*//' -e 's/: .*\.c /: (file name) /' \
     -e 's/line [0-9]*/line (number)/' \
     -e 's/Time: [0-9]*[\.,[0-9]*]*/Time:  XXXX/' \
     -e 's/v[1-9]*\.[0-9]*\./version (number)\./' \
@@ -642,7 +642,7 @@ TESTING JUnit-TestH5Dparams
 ($RUNSERIAL $JAVAEXE $JAVAEXEFLAGS -Xmx1024M -Dorg.slf4j.simpleLogger.defaultLog=trace -Djava.library.path=$BLDLIBDIR -cp $CLASSPATH -ea org.junit.runner.JUnitCore test.TestH5Dparams > JUnit-TestH5Dparams.ext)
 
 # Extract file name, line number, version and thread IDs because they may be different
-sed -e 's/thread [0-9]*/thread (IDs)/' -e 's/: .*\.c /: (file name) /' \
+sed -e 's/ thread [0-9]*//' -e 's/: .*\.c /: (file name) /' \
     -e 's/line [0-9]*/line (number)/' \
     -e 's/Time: [0-9]*[\.,[0-9]*]*/Time:  XXXX/' \
     -e 's/v[1-9]*\.[0-9]*\./version (number)\./' \
@@ -663,7 +663,7 @@ TESTING JUnit-TestH5D
 ($RUNSERIAL $JAVAEXE $JAVAEXEFLAGS -Xmx1024M -Dorg.slf4j.simpleLogger.defaultLog=trace -Djava.library.path=$BLDLIBDIR -cp $CLASSPATH -ea org.junit.runner.JUnitCore test.TestH5D > JUnit-TestH5D.ext)
 
 # Extract file name, line number, version and thread IDs because they may be different
-sed -e 's/thread [0-9]*/thread (IDs)/' -e 's/: .*\.c /: (file name) /' \
+sed -e 's/ thread [0-9]*//' -e 's/: .*\.c /: (file name) /' \
     -e 's/line [0-9]*/line (number)/' \
     -e 's/Time: [0-9]*[\.,[0-9]*]*/Time:  XXXX/' \
     -e 's/v[1-9]*\.[0-9]*\./version (number)\./' \
@@ -684,7 +684,7 @@ TESTING JUnit-TestH5Drw
 ($RUNSERIAL $JAVAEXE $JAVAEXEFLAGS -Xmx1024M -Dorg.slf4j.simpleLogger.defaultLog=trace -Djava.library.path=$BLDLIBDIR -cp $CLASSPATH -ea org.junit.runner.JUnitCore test.TestH5Drw > JUnit-TestH5Drw.ext)
 
 # Extract file name, line number, version and thread IDs because they may be different
-sed -e 's/thread [0-9]*/thread (IDs)/' -e 's/: .*\.c /: (file name) /' \
+sed -e 's/ thread [0-9]*//' -e 's/: .*\.c /: (file name) /' \
     -e 's/line [0-9]*/line (number)/' \
     -e 's/Time: [0-9]*[\.,[0-9]*]*/Time:  XXXX/' \
     -e 's/v[1-9]*\.[0-9]*\./version (number)\./' \
@@ -705,7 +705,7 @@ TESTING JUnit-TestH5Dplist
 ($RUNSERIAL $JAVAEXE $JAVAEXEFLAGS -Xmx1024M -Dorg.slf4j.simpleLogger.defaultLog=trace -Djava.library.path=$BLDLIBDIR -cp $CLASSPATH -ea org.junit.runner.JUnitCore test.TestH5Dplist > JUnit-TestH5Dplist.ext)
 
 # Extract file name, line number, version and thread IDs because they may be different
-sed -e 's/thread [0-9]*/thread (IDs)/' -e 's/: .*\.c /: (file name) /' \
+sed -e 's/ thread [0-9]*//' -e 's/: .*\.c /: (file name) /' \
     -e 's/line [0-9]*/line (number)/' \
     -e 's/Time: [0-9]*[\.,[0-9]*]*/Time:  XXXX/' \
     -e 's/v[1-9]*\.[0-9]*\./version (number)\./' \
@@ -726,7 +726,7 @@ TESTING JUnit-TestH5Lparams
 ($RUNSERIAL $JAVAEXE $JAVAEXEFLAGS -Xmx1024M -Dorg.slf4j.simpleLogger.defaultLog=trace -Djava.library.path=$BLDLIBDIR -cp $CLASSPATH -ea org.junit.runner.JUnitCore test.TestH5Lparams > JUnit-TestH5Lparams.ext)
 
 # Extract file name, line number, version and thread IDs because they may be different
-sed -e 's/thread [0-9]*/thread (IDs)/' -e 's/: .*\.c /: (file name) /' \
+sed -e 's/ thread [0-9]*//' -e 's/: .*\.c /: (file name) /' \
     -e 's/line [0-9]*/line (number)/' \
     -e 's/Time: [0-9]*[\.,[0-9]*]*/Time:  XXXX/' \
     -e 's/v[1-9]*\.[0-9]*\./version (number)\./' \
@@ -747,7 +747,7 @@ TESTING JUnit-TestH5Lbasic
 ($RUNSERIAL $JAVAEXE $JAVAEXEFLAGS -Xmx1024M -Dorg.slf4j.simpleLogger.defaultLog=trace -Djava.library.path=$BLDLIBDIR -cp $CLASSPATH -ea org.junit.runner.JUnitCore test.TestH5Lbasic > JUnit-TestH5Lbasic.ext)
 
 # Extract file name, line number, version and thread IDs because they may be different
-sed -e 's/thread [0-9]*/thread (IDs)/' -e 's/: .*\.c /: (file name) /' \
+sed -e 's/ thread [0-9]*//' -e 's/: .*\.c /: (file name) /' \
     -e 's/line [0-9]*/line (number)/' \
     -e 's/Time: [0-9]*[\.,[0-9]*]*/Time:  XXXX/' \
     -e 's/v[1-9]*\.[0-9]*\./version (number)\./' \
@@ -768,7 +768,7 @@ TESTING JUnit-TestH5Lcreate
 ($RUNSERIAL $JAVAEXE $JAVAEXEFLAGS -Xmx1024M -Dorg.slf4j.simpleLogger.defaultLog=trace -Djava.library.path=$BLDLIBDIR -cp $CLASSPATH -ea org.junit.runner.JUnitCore test.TestH5Lcreate > JUnit-TestH5Lcreate.ext)
 
 # Extract file name, line number, version and thread IDs because they may be different
-sed -e 's/thread [0-9]*/thread (IDs)/' -e 's/: .*\.c /: (file name) /' \
+sed -e 's/ thread [0-9]*//' -e 's/: .*\.c /: (file name) /' \
     -e 's/line [0-9]*/line (number)/' \
     -e 's/Time: [0-9]*[\.,[0-9]*]*/Time:  XXXX/' \
     -e 's/v[1-9]*\.[0-9]*\./version (number)\./' \
@@ -789,7 +789,7 @@ TESTING JUnit-TestH5R
 ($RUNSERIAL $JAVAEXE $JAVAEXEFLAGS -Xmx1024M -Dorg.slf4j.simpleLogger.defaultLog=trace -Djava.library.path=$BLDLIBDIR -cp $CLASSPATH -ea org.junit.runner.JUnitCore test.TestH5R > JUnit-TestH5R.ext)
 
 # Extract file name, line number, version and thread IDs because they may be different
-sed -e 's/thread [0-9]*/thread (IDs)/' -e 's/: .*\.c /: (file name) /' \
+sed -e 's/ thread [0-9]*//' -e 's/: .*\.c /: (file name) /' \
     -e 's/line [0-9]*/line (number)/' \
     -e 's/Time: [0-9]*[\.,[0-9]*]*/Time:  XXXX/' \
     -e 's/v[1-9]*\.[0-9]*\./version (number)\./' \
@@ -810,7 +810,7 @@ TESTING JUnit-TestH5Rref
 ($RUNSERIAL $JAVAEXE $JAVAEXEFLAGS -Xmx1024M -Dorg.slf4j.simpleLogger.defaultLog=trace -Djava.library.path=$BLDLIBDIR -cp $CLASSPATH -ea org.junit.runner.JUnitCore test.TestH5Rref > JUnit-TestH5Rref.ext)
 
 # Extract file name, line number, version and thread IDs because they may be different
-sed -e 's/thread [0-9]*/thread (IDs)/' -e 's/: .*\.c /: (file name) /' \
+sed -e 's/ thread [0-9]*//' -e 's/: .*\.c /: (file name) /' \
     -e 's/line [0-9]*/line (number)/' \
     -e 's/Time: [0-9]*[\.,[0-9]*]*/Time:  XXXX/' \
     -e 's/v[1-9]*\.[0-9]*\./version (number)\./' \
@@ -831,7 +831,7 @@ TESTING JUnit-TestH5P
 ($RUNSERIAL $JAVAEXE $JAVAEXEFLAGS -Xmx1024M -Dorg.slf4j.simpleLogger.defaultLog=trace -Djava.library.path=$BLDLIBDIR -cp $CLASSPATH -ea org.junit.runner.JUnitCore test.TestH5P > JUnit-TestH5P.ext)
 
 # Extract file name, line number, version and thread IDs because they may be different
-sed -e 's/thread [0-9]*/thread (IDs)/' -e 's/: .*\.c /: (file name) /' \
+sed -e 's/ thread [0-9]*//' -e 's/: .*\.c /: (file name) /' \
     -e 's/line [0-9]*/line (number)/' \
     -e 's/Time: [0-9]*[\.,[0-9]*]*/Time:  XXXX/' \
     -e 's/v[1-9]*\.[0-9]*\./version (number)\./' \
@@ -852,7 +852,7 @@ TESTING JUnit-TestH5PData
 ($RUNSERIAL $JAVAEXE $JAVAEXEFLAGS -Xmx1024M -Dorg.slf4j.simpleLogger.defaultLog=trace -Djava.library.path=$BLDLIBDIR -cp $CLASSPATH -ea org.junit.runner.JUnitCore test.TestH5PData > JUnit-TestH5PData.ext)
 
 # Extract file name, line number, version and thread IDs because they may be different
-sed -e 's/thread [0-9]*/thread (IDs)/' -e 's/: .*\.c /: (file name) /' \
+sed -e 's/ thread [0-9]*//' -e 's/: .*\.c /: (file name) /' \
     -e 's/line [0-9]*/line (number)/' \
     -e 's/Time: [0-9]*[\.,[0-9]*]*/Time:  XXXX/' \
     -e 's/v[1-9]*\.[0-9]*\./version (number)\./' \
@@ -873,7 +873,7 @@ TESTING JUnit-TestH5Pfapl
 ($RUNSERIAL $JAVAEXE $JAVAEXEFLAGS -Xmx1024M -Dorg.slf4j.simpleLogger.defaultLog=trace -Djava.library.path=$BLDLIBDIR -cp $CLASSPATH -ea org.junit.runner.JUnitCore test.TestH5Pfapl > JUnit-TestH5Pfapl.ext)
 
 # Extract file name, line number, version and thread IDs because they may be different
-sed -e 's/thread [0-9]*/thread (IDs)/' -e 's/: .*\.c /: (file name) /' \
+sed -e 's/ thread [0-9]*//' -e 's/: .*\.c /: (file name) /' \
     -e 's/line [0-9]*/line (number)/' \
     -e 's/Time: [0-9]*[\.,[0-9]*]*/Time:  XXXX/' \
     -e 's/v[1-9]*\.[0-9]*\./version (number)\./' \
@@ -894,7 +894,7 @@ TESTING JUnit-TestH5Pvirtual
 ($RUNSERIAL $JAVAEXE $JAVAEXEFLAGS -Xmx1024M -Dorg.slf4j.simpleLogger.defaultLog=trace -Djava.library.path=$BLDLIBDIR -cp $CLASSPATH -ea org.junit.runner.JUnitCore test.TestH5Pvirtual > JUnit-TestH5Pvirtual.ext)
 
 # Extract file name, line number, version and thread IDs because they may be different
-sed -e 's/thread [0-9]*/thread (IDs)/' -e 's/: .*\.c /: (file name) /' \
+sed -e 's/ thread [0-9]*//' -e 's/: .*\.c /: (file name) /' \
     -e 's/line [0-9]*/line (number)/' \
     -e 's/Time: [0-9]*[\.,[0-9]*]*/Time:  XXXX/' \
     -e 's/v[1-9]*\.[0-9]*\./version (number)\./' \
@@ -915,7 +915,7 @@ TESTING JUnit-TestH5Plist
 ($RUNSERIAL $JAVAEXE $JAVAEXEFLAGS -Xmx1024M -Dorg.slf4j.simpleLogger.defaultLog=trace -Djava.library.path=$BLDLIBDIR -cp $CLASSPATH -ea org.junit.runner.JUnitCore test.TestH5Plist > JUnit-TestH5Plist.ext)
 
 # Extract file name, line number, version and thread IDs because they may be different
-sed -e 's/thread [0-9]*/thread (IDs)/' -e 's/: .*\.c /: (file name) /' \
+sed -e 's/ thread [0-9]*//' -e 's/: .*\.c /: (file name) /' \
     -e 's/line [0-9]*/line (number)/' \
     -e 's/Time: [0-9]*[\.,[0-9]*]*/Time:  XXXX/' \
     -e 's/v[1-9]*\.[0-9]*\./version (number)\./' \
@@ -936,7 +936,7 @@ TESTING JUnit-TestH5A
 ($RUNSERIAL $JAVAEXE $JAVAEXEFLAGS -Xmx1024M -Dorg.slf4j.simpleLogger.defaultLog=trace -Djava.library.path=$BLDLIBDIR -cp $CLASSPATH -ea org.junit.runner.JUnitCore test.TestH5A > JUnit-TestH5A.ext)
 
 # Extract file name, line number, version and thread IDs because they may be different
-sed -e 's/thread [0-9]*/thread (IDs)/' -e 's/: .*\.c /: (file name) /' \
+sed -e 's/ thread [0-9]*//' -e 's/: .*\.c /: (file name) /' \
     -e 's/line [0-9]*/line (number)/' \
     -e 's/Time: [0-9]*[\.,[0-9]*]*/Time:  XXXX/' \
     -e 's/v[1-9]*\.[0-9]*\./version (number)\./' \
@@ -957,7 +957,7 @@ TESTING JUnit-TestH5Arw
 ($RUNSERIAL $JAVAEXE $JAVAEXEFLAGS -Xmx1024M -Dorg.slf4j.simpleLogger.defaultLog=trace -Djava.library.path=$BLDLIBDIR -cp $CLASSPATH -ea org.junit.runner.JUnitCore test.TestH5Arw > JUnit-TestH5Arw.ext)
 
 # Extract file name, line number, version and thread IDs because they may be different
-sed -e 's/thread [0-9]*/thread (IDs)/' -e 's/: .*\.c /: (file name) /' \
+sed -e 's/ thread [0-9]*//' -e 's/: .*\.c /: (file name) /' \
     -e 's/line [0-9]*/line (number)/' \
     -e 's/Time: [0-9]*[\.,[0-9]*]*/Time:  XXXX/' \
     -e 's/v[1-9]*\.[0-9]*\./version (number)\./' \
@@ -978,7 +978,7 @@ TESTING JUnit-TestH5Oparams
 ($RUNSERIAL $JAVAEXE $JAVAEXEFLAGS -Xmx1024M -Dorg.slf4j.simpleLogger.defaultLog=trace -Djava.library.path=$BLDLIBDIR -cp $CLASSPATH -ea org.junit.runner.JUnitCore test.TestH5Oparams > JUnit-TestH5Oparams.ext)
 
 # Extract file name, line number, version and thread IDs because they may be different
-sed -e 's/thread [0-9]*/thread (IDs)/' -e 's/: .*\.c /: (file name) /' \
+sed -e 's/ thread [0-9]*//' -e 's/: .*\.c /: (file name) /' \
     -e 's/line [0-9]*/line (number)/' \
     -e 's/Time: [0-9]*[\.,[0-9]*]*/Time:  XXXX/' \
     -e 's/v[1-9]*\.[0-9]*\./version (number)\./' \
@@ -999,7 +999,7 @@ TESTING JUnit-TestH5Obasic
 ($RUNSERIAL $JAVAEXE $JAVAEXEFLAGS -Xmx1024M -Dorg.slf4j.simpleLogger.defaultLog=trace -Djava.library.path=$BLDLIBDIR -cp $CLASSPATH -ea org.junit.runner.JUnitCore test.TestH5Obasic > JUnit-TestH5Obasic.ext)
 
 # Extract file name, line number, version and thread IDs because they may be different
-sed -e 's/thread [0-9]*/thread (IDs)/' -e 's/: .*\.c /: (file name) /' \
+sed -e 's/ thread [0-9]*//' -e 's/: .*\.c /: (file name) /' \
     -e 's/line [0-9]*/line (number)/' \
     -e 's/Time: [0-9]*[\.,[0-9]*]*/Time:  XXXX/' \
     -e 's/v[1-9]*\.[0-9]*\./version (number)\./' \
@@ -1020,7 +1020,7 @@ TESTING JUnit-TestH5Ocreate
 ($RUNSERIAL $JAVAEXE $JAVAEXEFLAGS -Xmx1024M -Dorg.slf4j.simpleLogger.defaultLog=trace -Djava.library.path=$BLDLIBDIR -cp $CLASSPATH -ea org.junit.runner.JUnitCore test.TestH5Ocreate > JUnit-TestH5Ocreate.ext)
 
 # Extract file name, line number, version and thread IDs because they may be different
-sed -e 's/thread [0-9]*/thread (IDs)/' -e 's/: .*\.c /: (file name) /' \
+sed -e 's/ thread [0-9]*//' -e 's/: .*\.c /: (file name) /' \
     -e 's/line [0-9]*/line (number)/' \
     -e 's/Time: [0-9]*[\.,[0-9]*]*/Time:  XXXX/' \
     -e 's/v[1-9]*\.[0-9]*\./version (number)\./' \
@@ -1041,7 +1041,7 @@ TESTING JUnit-TestH5OcopyOld
 ($RUNSERIAL $JAVAEXE $JAVAEXEFLAGS -Xmx1024M -Dorg.slf4j.simpleLogger.defaultLog=trace -Djava.library.path=$BLDLIBDIR -cp $CLASSPATH -ea org.junit.runner.JUnitCore test.TestH5OcopyOld > JUnit-TestH5OcopyOld.ext)
 
 # Extract file name, line number, version and thread IDs because they may be different
-sed -e 's/thread [0-9]*/thread (IDs)/' -e 's/: .*\.c /: (file name) /' \
+sed -e 's/ thread [0-9]*//' -e 's/: .*\.c /: (file name) /' \
     -e 's/line [0-9]*/line (number)/' \
     -e 's/Time: [0-9]*[\.,[0-9]*]*/Time:  XXXX/' \
     -e 's/v[1-9]*\.[0-9]*\./version (number)\./' \
@@ -1062,7 +1062,7 @@ TESTING JUnit-TestH5Ocopy
 ($RUNSERIAL $JAVAEXE $JAVAEXEFLAGS -Xmx1024M -Dorg.slf4j.simpleLogger.defaultLog=trace -Djava.library.path=$BLDLIBDIR -cp $CLASSPATH -ea org.junit.runner.JUnitCore test.TestH5Ocopy > JUnit-TestH5Ocopy.ext)
 
 # Extract file name, line number, version and thread IDs because they may be different
-sed -e 's/thread [0-9]*/thread (IDs)/' -e 's/: .*\.c /: (file name) /' \
+sed -e 's/ thread [0-9]*//' -e 's/: .*\.c /: (file name) /' \
     -e 's/line [0-9]*/line (number)/' \
     -e 's/Time: [0-9]*[\.,[0-9]*]*/Time:  XXXX/' \
     -e 's/v[1-9]*\.[0-9]*\./version (number)\./' \
@@ -1083,7 +1083,7 @@ TESTING JUnit-TestH5PL
 ($RUNSERIAL $JAVAEXE $JAVAEXEFLAGS -Xmx1024M -Dorg.slf4j.simpleLogger.defaultLog=trace -Djava.library.path=$BLDLIBDIR -cp $CLASSPATH -ea org.junit.runner.JUnitCore test.TestH5PL > JUnit-TestH5PL.ext)
 
 # Extract file name, line number, version and thread IDs because they may be different
-sed -e 's/thread [0-9]*/thread (IDs)/' -e 's/: .*\.c /: (file name) /' \
+sed -e 's/ thread [0-9]*//' -e 's/: .*\.c /: (file name) /' \
     -e 's/line [0-9]*/line (number)/' \
     -e 's/Time: [0-9]*[\.,[0-9]*]*/Time:  XXXX/' \
     -e 's/v[1-9]*\.[0-9]*\./version (number)\./' \
@@ -1104,7 +1104,7 @@ TESTING JUnit-TestH5VL
 ($RUNSERIAL $JAVAEXE $JAVAEXEFLAGS -Xmx1024M -Dorg.slf4j.simpleLogger.defaultLog=trace -Djava.library.path=$BLDLIBDIR -cp $CLASSPATH -ea org.junit.runner.JUnitCore test.TestH5VL > JUnit-TestH5VL.ext)
 
 # Extract file name, line number, version and thread IDs because they may be different
-sed -e 's/thread [0-9]*/thread (IDs)/' -e 's/: .*\.c /: (file name) /' \
+sed -e 's/ thread [0-9]*//' -e 's/: .*\.c /: (file name) /' \
     -e 's/line [0-9]*/line (number)/' \
     -e 's/Time: [0-9]*[\.,[0-9]*]*/Time:  XXXX/' \
     -e 's/v[1-9]*\.[0-9]*\./version (number)\./' \
@@ -1125,7 +1125,7 @@ TESTING JUnit-TestH5Z
 ($RUNSERIAL $JAVAEXE $JAVAEXEFLAGS -Xmx1024M -Dorg.slf4j.simpleLogger.defaultLog=trace -Djava.library.path=$BLDLIBDIR -cp $CLASSPATH -ea org.junit.runner.JUnitCore test.TestH5Z > JUnit-TestH5Z.ext)
 
 # Extract file name, line number, version and thread IDs because they may be different
-sed -e 's/thread [0-9]*/thread (IDs)/' -e 's/: .*\.c /: (file name) /' \
+sed -e 's/ thread [0-9]*//' -e 's/: .*\.c /: (file name) /' \
     -e 's/line [0-9]*/line (number)/' \
     -e 's/Time: [0-9]*[\.,[0-9]*]*/Time:  XXXX/' \
     -e 's/v[1-9]*\.[0-9]*\./version (number)\./' \
@@ -1146,7 +1146,7 @@ TESTING JUnit-TestH5E
 ($RUNSERIAL $JAVAEXE $JAVAEXEFLAGS -Xmx1024M -Dorg.slf4j.simpleLogger.defaultLog=trace -Djava.library.path=$BLDLIBDIR -cp $CLASSPATH -ea org.junit.runner.JUnitCore test.TestH5E > JUnit-TestH5E.ext)
 
 # Extract file name, line number, version and thread IDs because they may be different
-sed -e 's/thread [0-9]*/thread (IDs)/' -e 's/: .*\.c /: (file name) /' \
+sed -e 's/ thread [0-9]*//' -e 's/: .*\.c /: (file name) /' \
     -e 's/line [0-9]*/line (number)/' \
     -e 's/Time: [0-9]*[\.,[0-9]*]*/Time:  XXXX/' \
     -e 's/v[1-9]*\.[0-9]*\./version (number)\./' \
@@ -1167,7 +1167,7 @@ TESTING JUnit-TestH5Edefault
 ($RUNSERIAL $JAVAEXE $JAVAEXEFLAGS -Xmx1024M -Dorg.slf4j.simpleLogger.defaultLog=trace -Djava.library.path=$BLDLIBDIR -cp $CLASSPATH -ea org.junit.runner.JUnitCore test.TestH5Edefault > JUnit-TestH5Edefault.ext)
 
 # Extract file name, line number, version and thread IDs because they may be different
-sed -e 's/thread [0-9]*/thread (IDs)/' -e 's/: .*\.c /: (file name) /' \
+sed -e 's/ thread [0-9]*//' -e 's/: .*\.c /: (file name) /' \
     -e 's/line [0-9]*/line (number)/' \
     -e 's/Time: [0-9]*[\.,[0-9]*]*/Time:  XXXX/' \
     -e 's/v[1-9]*\.[0-9]*\./version (number)\./' \
@@ -1189,7 +1189,7 @@ if test $USE_FILTER_SZIP = "yes"; then
     ($RUNSERIAL $JAVAEXE $JAVAEXEFLAGS -Xmx1024M -Dorg.slf4j.simpleLogger.defaultLog=trace -Djava.library.path=$BLDLIBDIR -cp $CLASSPATH -ea org.junit.runner.JUnitCore test.TestH5Giterate > JUnit-TestH5Giterate.ext)
 
     # Extract file name, line number, version and thread IDs because they may be different
-    sed -e 's/thread [0-9]*/thread (IDs)/' -e 's/: .*\.c /: (file name) /' \
+    sed -e 's/ thread [0-9]*//' -e 's/: .*\.c /: (file name) /' \
         -e 's/line [0-9]*/line (number)/' \
         -e 's/Time: [0-9]*[\.,[0-9]*]*/Time:  XXXX/' \
         -e 's/v[1-9]*\.[0-9]*\./version (number)\./' \
@@ -1211,7 +1211,7 @@ if test "X$ROS3_VFD" = "Xyes"; then
     ($RUNSERIAL $JAVAEXE $JAVAEXEFLAGS -Xmx1024M -Dorg.slf4j.simpleLogger.defaultLog=trace -Djava.library.path=$BLDLIBDIR -cp $CLASSPATH -ea org.junit.runner.JUnitCore test.TestH5Pfapls3 > JUnit-TestH5Pfapls3.ext)
 
     # Extract file name, line number, version and thread IDs because they may be different
-    sed -e 's/thread [0-9]*/thread (IDs)/' -e 's/: .*\.c /: (file name) /' \
+    sed -e 's/ thread [0-9]*//' -e 's/: .*\.c /: (file name) /' \
         -e 's/line [0-9]*/line (number)/' \
         -e 's/Time: [0-9]*\.,[0-9]*/Time:  XXXX/' \
         -e 's/v[1-9]*\.[0-9]*\./version (number)\./' \
@@ -1233,7 +1233,7 @@ if test "X$HAVE_LIBHDFS" = "Xyes"; then
     ($RUNSERIAL $JAVAEXE $JAVAEXEFLAGS -Xmx1024M -Dorg.slf4j.simpleLogger.defaultLog=trace -Djava.library.path=$BLDLIBDIR -cp $CLASSPATH -ea org.junit.runner.JUnitCore test.TestH5Pfaplhdfs > JUnit-TestH5Pfaplhdfs.ext)
 
     # Extract file name, line number, version and thread IDs because they may be different
-    sed -e 's/thread [0-9]*/thread (IDs)/' -e 's/: .*\.c /: (file name) /' \
+    sed -e 's/ thread [0-9]*//' -e 's/: .*\.c /: (file name) /' \
         -e 's/line [0-9]*/line (number)/' \
         -e 's/Time: [0-9]*\.,[0-9]*/Time:  XXXX/' \
         -e 's/v[1-9]*\.[0-9]*\./version (number)\./' \

--- a/src/H5CS.c
+++ b/src/H5CS.c
@@ -134,9 +134,11 @@ H5CS_print_stack(const H5CS_t *fstack, FILE *stream)
     if (!stream)
         stream = stderr;
 
-    fprintf(stream, "HDF5-DIAG: Function stack from %s ", H5_lib_vers_info_g);
+    fprintf(stream, "HDF5-DIAG: Function stack from %s", H5_lib_vers_info_g);
     /* try show the process or thread id in multiple processes cases*/
-    fprintf(stream, "thread %" PRIu64 ".", H5TS_thread_id());
+#ifdef H5_HAVE_THREADSAFE
+    fprintf(stream, " thread %" PRIu64 ".", H5TS_thread_id());
+#endif
     if (fstack && fstack->nused > 0)
         fprintf(stream, "  Back trace follows.");
     fputc('\n', stream);

--- a/src/H5Eint.c
+++ b/src/H5Eint.c
@@ -218,7 +218,7 @@ H5E__walk1_cb(int n, H5E_error1_t *err_desc, void *client_data)
         if (cls_ptr->lib_vers)
             eprint->cls.lib_vers = cls_ptr->lib_vers;
 
-        fprintf(stream, "%s-DIAG: Error detected in %s (%s) ",
+        fprintf(stream, "%s-DIAG: Error detected in %s (%s)",
                 (cls_ptr->cls_name ? cls_ptr->cls_name : "(null)"),
                 (cls_ptr->lib_name ? cls_ptr->lib_name : "(null)"),
                 (cls_ptr->lib_vers ? cls_ptr->lib_vers : "(null)"));
@@ -233,13 +233,17 @@ H5E__walk1_cb(int n, H5E_error1_t *err_desc, void *client_data)
 
             if (mpi_initialized && !mpi_finalized) {
                 MPI_Comm_rank(MPI_COMM_WORLD, &mpi_rank);
-                fprintf(stream, "MPI-process %d", mpi_rank);
+                fprintf(stream, " MPI-process %d", mpi_rank);
             } /* end if */
+#ifdef H5_HAVE_THREADSAFE
             else
-                fprintf(stream, "thread 0");
+                fprintf(stream, " thread %" PRIu64, H5TS_thread_id());
+#endif
         } /* end block */
 #else
-        fprintf(stream, "thread %" PRIu64, H5TS_thread_id());
+#ifdef H5_HAVE_THREADSAFE
+        fprintf(stream, " thread %" PRIu64, H5TS_thread_id());
+#endif
 #endif
         fprintf(stream, ":\n");
     } /* end if */
@@ -342,7 +346,7 @@ H5E__walk2_cb(unsigned n, const H5E_error2_t *err_desc, void *client_data)
         if (cls_ptr->lib_vers)
             eprint->cls.lib_vers = cls_ptr->lib_vers;
 
-        fprintf(stream, "%s-DIAG: Error detected in %s (%s) ",
+        fprintf(stream, "%s-DIAG: Error detected in %s (%s)",
                 (cls_ptr->cls_name ? cls_ptr->cls_name : "(null)"),
                 (cls_ptr->lib_name ? cls_ptr->lib_name : "(null)"),
                 (cls_ptr->lib_vers ? cls_ptr->lib_vers : "(null)"));
@@ -357,13 +361,17 @@ H5E__walk2_cb(unsigned n, const H5E_error2_t *err_desc, void *client_data)
 
             if (mpi_initialized && !mpi_finalized) {
                 MPI_Comm_rank(MPI_COMM_WORLD, &mpi_rank);
-                fprintf(stream, "MPI-process %d", mpi_rank);
+                fprintf(stream, " MPI-process %d", mpi_rank);
             } /* end if */
+#ifdef H5_HAVE_THREADSAFE
             else
-                fprintf(stream, "thread 0");
+                fprintf(stream, " thread %" PRIu64, H5TS_thread_id());
+#endif
         } /* end block */
 #else
-        fprintf(stream, "thread %" PRIu64, H5TS_thread_id());
+#ifdef H5_HAVE_THREADSAFE
+        fprintf(stream, " thread %" PRIu64, H5TS_thread_id());
+#endif
 #endif
         fprintf(stream, ":\n");
     } /* end if */

--- a/test/h5test.c
+++ b/test/h5test.c
@@ -1117,10 +1117,14 @@ h5_show_hostname(void)
         MPI_Comm_rank(MPI_COMM_WORLD, &mpi_rank);
         printf("MPI-process %d.", mpi_rank);
     }
+#ifdef H5_HAVE_THREADSAFE
     else
-        printf("thread 0.");
+        printf("thread %" PRIu64 ".", H5TS_thread_id());
+#endif
 #else
+#ifdef H5_HAVE_THREADSAFE
     printf("thread %" PRIu64 ".", H5TS_thread_id());
+#endif
 #endif
 #ifdef H5_HAVE_WIN32_API
 

--- a/test/test_error.sh.in
+++ b/test/test_error.sh.in
@@ -70,7 +70,7 @@ TEST() {
    fi
 
    # Extract file name, line number, version and thread IDs because they may be different
-   sed -e 's/thread [0-9]*/thread (IDs)/' -e 's/: .*\.c /: (file name) /' \
+   sed -e 's/ thread [0-9]*//' -e 's/: .*\.c /: (file name) /' \
 	-e 's/line [0-9]*/line (number)/' \
         -e 's/v[1-9]*\.[0-9]*\./version (number)\./' \
 	-e 's/[1-9]*\.[0-9]*\.[0-9]*[^)]*/version (number)/' \

--- a/test/testfiles/err_compat_1
+++ b/test/testfiles/err_compat_1
@@ -3,7 +3,7 @@ Testing error API based on data I/O
 All error API tests passed.
    This program tests the Error API compatible with HDF5 version (number).  There are supposed to be some error messages
 ********* Print error stack in HDF5 default way *********
-HDF5-DIAG: Error detected in HDF5 (version (number)) thread (IDs):
+HDF5-DIAG: Error detected in HDF5 (version (number)):
   #000: (file name) line (number) in main(): fake error message 1
     major: Error API
     minor: Bad value
@@ -12,7 +12,7 @@ HDF5-DIAG: Error detected in HDF5 (version (number)) thread (IDs):
     error #000: (file name) in main(): line (number)
         major: Error API
         minor: Bad value
-HDF5-DIAG: Error detected in HDF5 (version (number)) thread (IDs):
+HDF5-DIAG: Error detected in HDF5 (version (number)):
   #000: (file name) line (number) in H5Dcreate2(): unable to synchronously create dataset
     major: Dataset
     minor: Unable to create file
@@ -70,7 +70,7 @@ HDF5-DIAG: Error detected in HDF5 (version (number)) thread (IDs):
     error #003: (file name) in H5Dcreate2(): line (number)
         major: Dataset
         minor: Unable to create file
-HDF5-DIAG: Error detected in HDF5 (version (number)) thread (IDs):
+HDF5-DIAG: Error detected in HDF5 (version (number)):
   #000: (file name) line (number) in H5Dcreate2(): unable to synchronously create dataset
     major: Dataset
     minor: Unable to create file
@@ -83,7 +83,7 @@ HDF5-DIAG: Error detected in HDF5 (version (number)) thread (IDs):
   #003: (file name) line (number) in H5VL_vol_object(): invalid identifier type to function
     major: Invalid arguments to routine
     minor: Inappropriate type
-HDF5-DIAG: Error detected in HDF5 (version (number)) thread (IDs):
+HDF5-DIAG: Error detected in HDF5 (version (number)):
   #000: (file name) line (number) in main(): fake error message 2
     major: Error API
     minor: Unrecognized message

--- a/test/testfiles/error_test_1
+++ b/test/testfiles/error_test_1
@@ -1,10 +1,10 @@
    This program tests the Error API.  There're supposed to be some error messages
 ********* Print error stack in HDF5 default way *********
-Second Test-DIAG: Error detected in Second Program (1.0) thread (IDs):
+Second Test-DIAG: Error detected in Second Program (1.0):
   #000: (file name) line (number) in main(): Error stack test failed
     major: Error in test
     minor: Error in error stack
-Error Test-DIAG: Error detected in Error Program (1.0) thread (IDs):
+Error Test-DIAG: Error detected in Error Program (1.0):
   #001: (file name) line (number) in error_stack(): Get number test failed, returned 0
     major: Error in API
     minor: Error in H5Eget_num
@@ -20,21 +20,21 @@ Error Test-DIAG: Error detected in Error Program (1.0) thread (IDs):
         minor: Error in error stack
 
 Testing error API based on data I/O
-HDF5-DIAG: Error detected in HDF5 (version (number)) thread (IDs):
+HDF5-DIAG: Error detected in HDF5 (version (number)):
   #000: (file name) line (number) in H5Dwrite(): can't synchronously write data
     major: Dataset
     minor: Write failed
   #001: (file name) line (number) in H5D__write_api_common(): dset_id is not a dataset ID
     major: Invalid arguments to routine
     minor: Inappropriate type
-Error Test-DIAG: Error detected in Error Program (1.0) thread (IDs):
+Error Test-DIAG: Error detected in Error Program (1.0):
   #000: (file name) line (number) in main(): Error test failed, it's wrong
     major: Error in test
     minor: Error in subroutine
   #001: (file name) line (number) in test_error(): H5Dwrite failed as supposed to
     major: Error in IO
     minor: Error in H5Dwrite
-HDF5-DIAG: Error detected in HDF5 (version (number)) thread (IDs):
+HDF5-DIAG: Error detected in HDF5 (version (number)):
   #002: (file name) line (number) in H5Dwrite(): can't synchronously write data
     major: Dataset
     minor: Write failed
@@ -43,7 +43,7 @@ HDF5-DIAG: Error detected in HDF5 (version (number)) thread (IDs):
     minor: Inappropriate type
 
 Testing error message during data reading when filter isn't registered
-HDF5-DIAG: Error detected in HDF5 (version (number)) thread (IDs):
+HDF5-DIAG: Error detected in HDF5 (version (number)):
   #000: (file name) line (number) in H5Dread(): can't synchronously read data
     major: Dataset
     minor: Read failed

--- a/tools/test/h5dump/errfiles/tall-1.err
+++ b/tools/test/h5dump/errfiles/tall-1.err
@@ -1,4 +1,4 @@
-HDF5-DIAG: Error detected in HDF5 (version (number)) thread (IDs):
+HDF5-DIAG: Error detected in HDF5 (version (number)):
   #000: (file name) line (number) in H5Oopen(): unable to synchronously open object
     major: Object header
     minor: Can't open object

--- a/tools/test/h5dump/errfiles/tall-2A.err
+++ b/tools/test/h5dump/errfiles/tall-2A.err
@@ -1,4 +1,4 @@
-HDF5-DIAG: Error detected in HDF5 (version (number)) thread (IDs):
+HDF5-DIAG: Error detected in HDF5 (version (number)):
   #000: (file name) line (number) in H5Oopen(): unable to synchronously open object
     major: Object header
     minor: Can't open object

--- a/tools/test/h5dump/errfiles/tall-2A0.err
+++ b/tools/test/h5dump/errfiles/tall-2A0.err
@@ -1,4 +1,4 @@
-HDF5-DIAG: Error detected in HDF5 (version (number)) thread (IDs):
+HDF5-DIAG: Error detected in HDF5 (version (number)):
   #000: (file name) line (number) in H5Oopen(): unable to synchronously open object
     major: Object header
     minor: Can't open object

--- a/tools/test/h5dump/errfiles/tall-2B.err
+++ b/tools/test/h5dump/errfiles/tall-2B.err
@@ -1,4 +1,4 @@
-HDF5-DIAG: Error detected in HDF5 (version (number)) thread (IDs):
+HDF5-DIAG: Error detected in HDF5 (version (number)):
   #000: (file name) line (number) in H5Oopen(): unable to synchronously open object
     major: Object header
     minor: Can't open object

--- a/tools/test/h5dump/errfiles/tarray1_big.err
+++ b/tools/test/h5dump/errfiles/tarray1_big.err
@@ -1,25 +1,25 @@
-HDF5-DIAG: Error detected in HDF5 (version (number)) thread (IDs):
+HDF5-DIAG: Error detected in HDF5 (version (number)):
   #000: (file name) line (number) in H5Rget_obj_type3(): unable to get object token
     major: References
     minor: Can't get value
   #001: (file name) line (number) in H5R__get_obj_token(): NULL token size
     major: References
     minor: Unable to copy object
-HDF5-DIAG: Error detected in HDF5 (version (number)) thread (IDs):
+HDF5-DIAG: Error detected in HDF5 (version (number)):
   #000: (file name) line (number) in H5Rget_obj_type3(): unable to get object token
     major: References
     minor: Can't get value
   #001: (file name) line (number) in H5R__get_obj_token(): NULL token size
     major: References
     minor: Unable to copy object
-HDF5-DIAG: Error detected in HDF5 (version (number)) thread (IDs):
+HDF5-DIAG: Error detected in HDF5 (version (number)):
   #000: (file name) line (number) in H5Rget_obj_type3(): unable to get object token
     major: References
     minor: Can't get value
   #001: (file name) line (number) in H5R__get_obj_token(): NULL token size
     major: References
     minor: Unable to copy object
-H5tools-DIAG: Error detected in HDF5:tools (version (number)) thread (IDs):
+H5tools-DIAG: Error detected in HDF5:tools (version (number)):
   #000: (file name) line (number) in h5tools_dump_data(): H5Rget_obj_type3 H5R_OBJECT1 failed
     major: Failure in tools library
     minor: error in function

--- a/tools/test/h5dump/errfiles/tattr-3.err
+++ b/tools/test/h5dump/errfiles/tattr-3.err
@@ -1,4 +1,4 @@
-HDF5-DIAG: Error detected in HDF5 (version (number)) thread (IDs):
+HDF5-DIAG: Error detected in HDF5 (version (number)):
   #000: (file name) line (number) in H5Aopen(): unable to synchronously open attribute
     major: Attribute
     minor: Unable to create file

--- a/tools/test/h5dump/errfiles/tattrregR.err
+++ b/tools/test/h5dump/errfiles/tattrregR.err
@@ -1,18 +1,18 @@
-HDF5-DIAG: Error detected in HDF5 (version (number)) thread (IDs):
+HDF5-DIAG: Error detected in HDF5 (version (number)):
   #000: (file name) line (number) in H5Rget_obj_type3(): unable to get object token
     major: References
     minor: Can't get value
   #001: (file name) line (number) in H5R__get_obj_token(): NULL token size
     major: References
     minor: Unable to copy object
-HDF5-DIAG: Error detected in HDF5 (version (number)) thread (IDs):
+HDF5-DIAG: Error detected in HDF5 (version (number)):
   #000: (file name) line (number) in H5Rget_obj_type3(): unable to get object token
     major: References
     minor: Can't get value
   #001: (file name) line (number) in H5R__get_obj_token(): NULL token size
     major: References
     minor: Unable to copy object
-H5tools-DIAG: Error detected in HDF5:tools (version (number)) thread (IDs):
+H5tools-DIAG: Error detected in HDF5:tools (version (number)):
   #000: (file name) line (number) in h5tools_dump_data(): H5Rget_obj_type3 H5R_OBJECT1 failed
     major: Failure in tools library
     minor: error in function

--- a/tools/test/h5dump/errfiles/tcomp-3.err
+++ b/tools/test/h5dump/errfiles/tcomp-3.err
@@ -1,4 +1,4 @@
-HDF5-DIAG: Error detected in HDF5 (version (number)) thread (IDs):
+HDF5-DIAG: Error detected in HDF5 (version (number)):
   #000: (file name) line (number) in H5Topen2(): unable to open named datatype synchronously
     major: Datatype
     minor: Can't open object

--- a/tools/test/h5dump/errfiles/tdataregR.err
+++ b/tools/test/h5dump/errfiles/tdataregR.err
@@ -1,18 +1,18 @@
-HDF5-DIAG: Error detected in HDF5 (version (number)) thread (IDs):
+HDF5-DIAG: Error detected in HDF5 (version (number)):
   #000: (file name) line (number) in H5Rget_obj_type3(): unable to get object token
     major: References
     minor: Can't get value
   #001: (file name) line (number) in H5R__get_obj_token(): NULL token size
     major: References
     minor: Unable to copy object
-HDF5-DIAG: Error detected in HDF5 (version (number)) thread (IDs):
+HDF5-DIAG: Error detected in HDF5 (version (number)):
   #000: (file name) line (number) in H5Rget_obj_type3(): unable to get object token
     major: References
     minor: Can't get value
   #001: (file name) line (number) in H5R__get_obj_token(): NULL token size
     major: References
     minor: Unable to copy object
-H5tools-DIAG: Error detected in HDF5:tools (version (number)) thread (IDs):
+H5tools-DIAG: Error detected in HDF5:tools (version (number)):
   #000: (file name) line (number) in h5tools_dump_data(): H5Rget_obj_type3 H5R_OBJECT1 failed
     major: Failure in tools library
     minor: error in function

--- a/tools/test/h5dump/errfiles/tdset-2.err
+++ b/tools/test/h5dump/errfiles/tdset-2.err
@@ -1,4 +1,4 @@
-HDF5-DIAG: Error detected in HDF5 (version (number)) thread (IDs):
+HDF5-DIAG: Error detected in HDF5 (version (number)):
   #000: (file name) line (number) in H5Dopen2(): unable to synchronously open dataset
     major: Dataset
     minor: Can't open object
@@ -29,7 +29,7 @@ HDF5-DIAG: Error detected in HDF5 (version (number)) thread (IDs):
   #009: (file name) line (number) in H5G__loc_find_cb(): object 'dset3' doesn't exist
     major: Symbol table
     minor: Object not found
-HDF5-DIAG: Error detected in HDF5 (version (number)) thread (IDs):
+HDF5-DIAG: Error detected in HDF5 (version (number)):
   #000: (file name) line (number) in H5Lget_info2(): unable to get link info
     major: Links
     minor: Can't get value

--- a/tools/test/h5dump/errfiles/textlink.err
+++ b/tools/test/h5dump/errfiles/textlink.err
@@ -1,4 +1,4 @@
-HDF5-DIAG: Error detected in HDF5 (version (number)) thread (IDs):
+HDF5-DIAG: Error detected in HDF5 (version (number)):
   #000: (file name) line (number) in H5Oopen(): unable to synchronously open object
     major: Object header
     minor: Can't open object
@@ -35,7 +35,7 @@ HDF5-DIAG: Error detected in HDF5 (version (number)) thread (IDs):
   #011: (file name) line (number) in H5L__extern_traverse(): unable to open external file, external link file name = 'filename'
     major: Links
     minor: Unable to open file
-HDF5-DIAG: Error detected in HDF5 (version (number)) thread (IDs):
+HDF5-DIAG: Error detected in HDF5 (version (number)):
   #000: (file name) line (number) in H5Oopen(): unable to synchronously open object
     major: Object header
     minor: Can't open object

--- a/tools/test/h5dump/errfiles/textlinkfar.err
+++ b/tools/test/h5dump/errfiles/textlinkfar.err
@@ -1,4 +1,4 @@
-HDF5-DIAG: Error detected in HDF5 (version (number)) thread (IDs):
+HDF5-DIAG: Error detected in HDF5 (version (number)):
   #000: (file name) line (number) in H5Oopen(): unable to synchronously open object
     major: Object header
     minor: Can't open object
@@ -59,7 +59,7 @@ HDF5-DIAG: Error detected in HDF5 (version (number)) thread (IDs):
   #019: (file name) line (number) in H5G__traverse_slink_cb(): component not found
     major: Symbol table
     minor: Object not found
-HDF5-DIAG: Error detected in HDF5 (version (number)) thread (IDs):
+HDF5-DIAG: Error detected in HDF5 (version (number)):
   #000: (file name) line (number) in H5G_loc_find(): can't find object
     major: Symbol table
     minor: Object not found
@@ -156,7 +156,7 @@ HDF5-DIAG: Error detected in HDF5 (version (number)) thread (IDs):
   #031: (file name) line (number) in H5G__traverse_special(): too many links
     major: Links
     minor: Too many soft links in path
-HDF5-DIAG: Error detected in HDF5 (version (number)) thread (IDs):
+HDF5-DIAG: Error detected in HDF5 (version (number)):
   #000: (file name) line (number) in H5G_loc_find(): can't find object
     major: Symbol table
     minor: Object not found

--- a/tools/test/h5dump/errfiles/textlinksrc.err
+++ b/tools/test/h5dump/errfiles/textlinksrc.err
@@ -1,4 +1,4 @@
-HDF5-DIAG: Error detected in HDF5 (version (number)) thread (IDs):
+HDF5-DIAG: Error detected in HDF5 (version (number)):
   #000: (file name) line (number) in H5Oopen(): unable to synchronously open object
     major: Object header
     minor: Can't open object
@@ -59,7 +59,7 @@ HDF5-DIAG: Error detected in HDF5 (version (number)) thread (IDs):
   #019: (file name) line (number) in H5G__traverse_slink_cb(): component not found
     major: Symbol table
     minor: Object not found
-HDF5-DIAG: Error detected in HDF5 (version (number)) thread (IDs):
+HDF5-DIAG: Error detected in HDF5 (version (number)):
   #000: (file name) line (number) in H5G_loc_find(): can't find object
     major: Symbol table
     minor: Object not found
@@ -156,7 +156,7 @@ HDF5-DIAG: Error detected in HDF5 (version (number)) thread (IDs):
   #031: (file name) line (number) in H5G__traverse_special(): too many links
     major: Links
     minor: Too many soft links in path
-HDF5-DIAG: Error detected in HDF5 (version (number)) thread (IDs):
+HDF5-DIAG: Error detected in HDF5 (version (number)):
   #000: (file name) line (number) in H5G_loc_find(): can't find object
     major: Symbol table
     minor: Object not found

--- a/tools/test/h5dump/errfiles/tgroup-2.err
+++ b/tools/test/h5dump/errfiles/tgroup-2.err
@@ -1,4 +1,4 @@
-HDF5-DIAG: Error detected in HDF5 (version (number)) thread (IDs):
+HDF5-DIAG: Error detected in HDF5 (version (number)):
   #000: (file name) line (number) in H5Gopen2(): unable to synchronously open group
     major: Symbol table
     minor: Unable to create file

--- a/tools/test/h5dump/errfiles/torderlinks1.err
+++ b/tools/test/h5dump/errfiles/torderlinks1.err
@@ -1,4 +1,4 @@
-HDF5-DIAG: Error detected in HDF5 (version (number)) thread (IDs):
+HDF5-DIAG: Error detected in HDF5 (version (number)):
   #000: (file name) line (number) in H5Oopen(): unable to synchronously open object
     major: Object header
     minor: Can't open object

--- a/tools/test/h5dump/errfiles/torderlinks2.err
+++ b/tools/test/h5dump/errfiles/torderlinks2.err
@@ -1,4 +1,4 @@
-HDF5-DIAG: Error detected in HDF5 (version (number)) thread (IDs):
+HDF5-DIAG: Error detected in HDF5 (version (number)):
   #000: (file name) line (number) in H5Oopen(): unable to synchronously open object
     major: Object header
     minor: Can't open object

--- a/tools/test/h5dump/errfiles/tperror.err
+++ b/tools/test/h5dump/errfiles/tperror.err
@@ -1,4 +1,4 @@
-HDF5-DIAG: Error detected in HDF5 (version (number)) thread (IDs):
+HDF5-DIAG: Error detected in HDF5 (version (number)):
   #000: (file name) line (number) in H5Dopen2(): unable to synchronously open dataset
     major: Dataset
     minor: Can't open object
@@ -29,7 +29,7 @@ HDF5-DIAG: Error detected in HDF5 (version (number)) thread (IDs):
   #009: (file name) line (number) in H5G__loc_find_cb(): object 'bogus' doesn't exist
     major: Symbol table
     minor: Object not found
-HDF5-DIAG: Error detected in HDF5 (version (number)) thread (IDs):
+HDF5-DIAG: Error detected in HDF5 (version (number)):
   #000: (file name) line (number) in H5Lget_info2(): unable to get link info
     major: Links
     minor: Can't get value

--- a/tools/test/h5dump/errfiles/tqmarkfile.err
+++ b/tools/test/h5dump/errfiles/tqmarkfile.err
@@ -1,4 +1,4 @@
-HDF5-DIAG: Error detected in HDF5 (version (number)) thread (IDs):
+HDF5-DIAG: Error detected in HDF5 (version (number)):
   #000: (file name) line (number) in H5Dopen2(): not found
     major: Dataset
     minor: Object not found
@@ -14,7 +14,7 @@ HDF5-DIAG: Error detected in HDF5 (version (number)) thread (IDs):
   #004: (file name) line (number) in H5G_loc_find_cb(): object 'Dataset1' doesn't exist
     major: Symbol table
     minor: Object not found
-HDF5-DIAG: Error detected in HDF5 (version (number)) thread (IDs):
+HDF5-DIAG: Error detected in HDF5 (version (number)):
   #000: (file name) line (number) in H5Lget_info2(): unable to get link info
     major: Symbol table
     minor: Object not found

--- a/tools/test/h5dump/errfiles/tslink-D.err
+++ b/tools/test/h5dump/errfiles/tslink-D.err
@@ -1,4 +1,4 @@
-HDF5-DIAG: Error detected in HDF5 (version (number)) thread (IDs):
+HDF5-DIAG: Error detected in HDF5 (version (number)):
   #000: (file name) line (number) in H5Dopen2(): unable to synchronously open dataset
     major: Dataset
     minor: Can't open object

--- a/tools/test/h5dump/testh5dump.sh.in
+++ b/tools/test/h5dump/testh5dump.sh.in
@@ -796,7 +796,7 @@ TOOLTEST3() {
     STDERR_FILTER $actual_err
 
     # Extract file name, line number, version and thread IDs because they may be different
-    sed -e 's/thread [0-9]*/thread (IDs)/' -e 's/: .*\.c /: (file name) /' \
+    sed -e 's/ thread [0-9]*//' -e 's/: .*\.c /: (file name) /' \
         -e 's/line [0-9]*/line (number)/' \
         -e 's/v[1-9]*\.[0-9]*\./version (number)\./' \
         -e 's/[1-9]*\.[0-9]*\.[0-9]*[^)]*/version (number)/' \
@@ -854,7 +854,7 @@ TOOLTEST4() {
     STDERR_FILTER $actual_err
 
     # Extract file name, line number, version and thread IDs because they may be different
-    sed -e 's/thread [0-9]*/thread (IDs)/' -e 's/: .*\.c /: (file name) /' \
+    sed -e 's/ thread [0-9]*//' -e 's/: .*\.c /: (file name) /' \
         -e 's/line [0-9]*/line (number)/' \
         -e 's/v[1-9]*\.[0-9]*\./version (number)\./' \
         -e 's/[1-9]*\.[0-9]*\.[0-9]*[^)]*/version (number)/' \
@@ -919,7 +919,7 @@ TOOLTEST5() {
     STDERR_FILTER $actual_err
 
     # Extract file name, line number, version and thread IDs because they may be different
-    sed -e 's/thread [0-9]*/thread (IDs)/' -e 's/: .*\.c /: (file name) /' \
+    sed -e 's/ thread [0-9]*//' -e 's/: .*\.c /: (file name) /' \
         -e 's/line [0-9]*/line (number)/' \
         -e 's/v[1-9]*\.[0-9]*\./version (number)\./' \
         -e 's/[1-9]*\.[0-9]*\.[0-9]*[^)]*/version (number)/' \

--- a/tools/test/h5dump/testh5dumppbits.sh.in
+++ b/tools/test/h5dump/testh5dumppbits.sh.in
@@ -337,7 +337,7 @@ TOOLTEST3() {
     STDERR_FILTER $actual_err
 
     # Extract file name, line number, version and thread IDs because they may be different
-    sed -e 's/thread [0-9]*/thread (IDs)/' -e 's/: .*\.c /: (file name) /' \
+    sed -e 's/ thread [0-9]*//' -e 's/: .*\.c /: (file name) /' \
         -e 's/line [0-9]*/line (number)/' \
         -e 's/v[1-9]*\.[0-9]*\./version (number)\./' \
         -e 's/[1-9]*\.[0-9]*\.[0-9]*[^)]*/version (number)/' \
@@ -394,7 +394,7 @@ TOOLTEST4() {
     STDERR_FILTER $actual_err
 
     # Extract file name, line number, version and thread IDs because they may be different
-    sed -e 's/thread [0-9]*/thread (IDs)/' -e 's/: .*\.c /: (file name) /' \
+    sed -e 's/ thread [0-9]*//' -e 's/: .*\.c /: (file name) /' \
         -e 's/line [0-9]*/line (number)/' \
         -e 's/v[1-9]*\.[0-9]*\./version (number)\./' \
         -e 's/[1-9]*\.[0-9]*\.[0-9]*[^)]*/version (number)/' \

--- a/tools/test/h5dump/testh5dumpvds.sh.in
+++ b/tools/test/h5dump/testh5dumpvds.sh.in
@@ -318,7 +318,7 @@ TOOLTEST3() {
     STDERR_FILTER $actual_err
 
     # Extract file name, line number, version and thread IDs because they may be different
-    sed -e 's/thread [0-9]*/thread (IDs)/' -e 's/: .*\.c /: (file name) /' \
+    sed -e 's/ thread [0-9]*//' -e 's/: .*\.c /: (file name) /' \
         -e 's/line [0-9]*/line (number)/' \
         -e 's/v[1-9]*\.[0-9]*\./version (number)\./' \
         -e 's/[1-9]*\.[0-9]*\.[0-9]*[^)]*/version (number)/' \
@@ -376,7 +376,7 @@ TOOLTEST4() {
     STDERR_FILTER $actual_err
 
     # Extract file name, line number, version and thread IDs because they may be different
-    sed -e 's/thread [0-9]*/thread (IDs)/' -e 's/: .*\.c /: (file name) /' \
+    sed -e 's/ thread [0-9]*//' -e 's/: .*\.c /: (file name) /' \
         -e 's/line [0-9]*/line (number)/' \
         -e 's/v[1-9]*\.[0-9]*\./version (number)\./' \
         -e 's/[1-9]*\.[0-9]*\.[0-9]*[^)]*/version (number)/' \

--- a/tools/test/h5format_convert/testh5fc.sh.in
+++ b/tools/test/h5format_convert/testh5fc.sh.in
@@ -283,7 +283,7 @@ TOOLTEST_MASK_OUT() {
     STDERR_FILTER $actual_err
 
     # Extract file name, line number, version and thread IDs because they may be different
-    sed -e 's/thread [0-9]*/thread (IDs)/' -e 's/: .*\.c /: (file name) /' \
+    sed -e 's/ thread [0-9]*//' -e 's/: .*\.c /: (file name) /' \
         -e 's/line [0-9]*/line (number)/' \
         -e 's/v[1-9]*\.[0-9]*\./version (number)\./' \
         -e 's/[1-9]*\.[0-9]*\.[0-9]*[^)]*/version (number)/' \

--- a/tools/test/h5repack/expected/h5repack_layout.h5-dset2_chunk_20x10-errstk.tst
+++ b/tools/test/h5repack/expected/h5repack_layout.h5-dset2_chunk_20x10-errstk.tst
@@ -1,4 +1,4 @@
-HDF5-DIAG: Error detected in HDF5 (version (number)) thread (IDs):
+HDF5-DIAG: Error detected in HDF5 (version (number)):
   #000: (file name) line (number) in H5Dcreate2(): unable to synchronously create dataset
     major: Dataset
     minor: Unable to create file
@@ -44,7 +44,7 @@ HDF5-DIAG: Error detected in HDF5 (version (number)) thread (IDs):
   #014: (file name) line (number) in H5D__chunk_construct(): dimensionality of chunks doesn't match the dataspace
     major: Dataset
     minor: Bad value
-H5tools-DIAG: Error detected in HDF5:tools (version (number)) thread (IDs):
+H5tools-DIAG: Error detected in HDF5:tools (version (number)):
   #000: (file name) line (number) in do_copy_objects(): H5Dcreate2 failed
     major: Failure in tools library
     minor: function info

--- a/tools/test/h5repack/h5repack.sh.in
+++ b/tools/test/h5repack/h5repack.sh.in
@@ -1061,7 +1061,7 @@ TOOLTESTM() {
     cp $actual_err $actual_err_sav
 
     # Extract file name, line number, version and thread IDs because they may be different
-    sed -e 's/thread [0-9]*/thread (IDs)/' -e 's/: .*\.c /: (file name) /' \
+    sed -e 's/ thread [0-9]*//' -e 's/: .*\.c /: (file name) /' \
         -e 's/line [0-9]*/line (number)/' \
         -e 's/v[1-9]*\.[0-9]*\./version (number)\./' \
         -e 's/[1-9]*\.[0-9]*\.[0-9]*[^)]*/version (number)/' \


### PR DESCRIPTION
Corresponding changes to make error output for regression tests agnostic to thread setting.