### PR TITLE
Fix grammar in VOL guide

### DIFF
--- a/doxygen/dox/VOLConnGuide.dox
+++ b/doxygen/dox/VOLConnGuide.dox
@@ -230,7 +230,7 @@ The initialization and terminate callbacks:
 \endcode
 
 \subsection subsecVOLMap Map Storage to HDF5 File Objects
-The most difficult part of designing a new VOL connector is going to determining how to support HDF5
+The most difficult part of designing a new VOL connector is determining how to support HDF5
 file objects and operations using your storage system. There isn't much specific advice to give here, as each
 connector will have unique needs, but a forthcoming "tutorial" connector will set up a simple connector and
 demonstrate this process.


### PR DESCRIPTION
```
Here's the breakdown of the fix:

Removed "going to" - This phrase is unnecessary and weakens the sentence.
Changed "determining" to a gerund ("determining") - This creates a parallel structure with "designing" and makes the sentence flow better.
```

Credit: Google Gemini
