### PR TITLE
H5Group: Fix operator=

### DIFF
--- a/c++/src/H5Attribute.cpp
+++ b/c++/src/H5Attribute.cpp
@@ -610,9 +610,7 @@ Attribute::~Attribute()
 Attribute &
 Attribute::operator=(const Attribute &original)
 {
-    if (&original != this) {
-        setId(original.id);
-    }
+    IdComponent::operator=(original);
 
     return *this;
 }

--- a/c++/src/H5Group.cpp
+++ b/c++/src/H5Group.cpp
@@ -279,9 +279,7 @@ Group::~Group()
 Group &
 Group::operator=(const Group &original)
 {
-    if (&original != this) {
-        setId(original.id);
-    }
+    IdComponent::operator=(original);
 
     return *this;
 }


### PR DESCRIPTION
Using the parent class operator else exceptions are not handled

Closes #4472 

/cc @seanm @derobins @bmribler 