### PR TITLE
Properly clean up cache when failing to load an object header

### DIFF
--- a/src/H5Gint.c
+++ b/src/H5Gint.c
@@ -506,6 +506,7 @@ static herr_t
 H5G__open_oid(H5G_t *grp)
 {
     bool   obj_opened = false;
+    htri_t msg_exists;
     herr_t ret_value  = SUCCEED;
 
     FUNC_ENTER_PACKAGE
@@ -523,8 +524,14 @@ H5G__open_oid(H5G_t *grp)
     obj_opened = true;
 
     /* Check if this object has the right message(s) to be treated as a group */
-    if ((H5O_msg_exists(&(grp->oloc), H5O_STAB_ID) <= 0) && (H5O_msg_exists(&(grp->oloc), H5O_LINFO_ID) <= 0))
-        HGOTO_ERROR(H5E_SYM, H5E_CANTOPENOBJ, FAIL, "not a group");
+    if ((msg_exists = H5O_msg_exists(&(grp->oloc), H5O_STAB_ID)) < 0)
+        HGOTO_ERROR(H5E_SYM, H5E_CANTGET, FAIL, "can't check if symbol table message exists");
+    if (!msg_exists) {
+        if ((msg_exists = H5O_msg_exists(&(grp->oloc), H5O_LINFO_ID)) < 0)
+            HGOTO_ERROR(H5E_SYM, H5E_CANTGET, FAIL, "can't check if link info message exists");
+        if (!msg_exists)
+            HGOTO_ERROR(H5E_SYM, H5E_CANTOPENOBJ, FAIL, "not a group");
+    }
 
 done:
     if (ret_value < 0) {

--- a/src/H5Gint.c
+++ b/src/H5Gint.c
@@ -507,7 +507,7 @@ H5G__open_oid(H5G_t *grp)
 {
     bool   obj_opened = false;
     htri_t msg_exists;
-    herr_t ret_value  = SUCCEED;
+    herr_t ret_value = SUCCEED;
 
     FUNC_ENTER_PACKAGE
 

--- a/src/H5Odbg.c
+++ b/src/H5Odbg.c
@@ -87,6 +87,10 @@ H5O__assert(const H5O_t *oh)
 
     FUNC_ENTER_PACKAGE_NOERR
 
+    assert(oh);
+    assert(oh->chunk || oh->nchunks == 0);
+    assert(oh->mesg || oh->nmesgs == 0);
+
     /* Initialize the tracking variables */
     hdr_size   = 0;
     meta_space = (size_t)H5O_SIZEOF_HDR(oh) + (size_t)(H5O_SIZEOF_CHKHDR_OH(oh) * (oh->nchunks - 1));
@@ -139,6 +143,8 @@ H5O__assert(const H5O_t *oh)
     for (u = 0, curr_msg = &oh->mesg[0]; u < oh->nmesgs; u++, curr_msg++) {
         uint8_t H5_ATTR_NDEBUG_UNUSED *curr_hdr;      /* Start of current message header */
         size_t                         curr_tot_size; /* Total size of current message (including header) */
+
+        assert(curr_msg->type);
 
         curr_hdr      = curr_msg->raw - H5O_SIZEOF_MSGHDR_OH(oh);
         curr_tot_size = curr_msg->raw_size + (size_t)H5O_SIZEOF_MSGHDR_OH(oh);

--- a/src/H5Oint.c
+++ b/src/H5Oint.c
@@ -1113,7 +1113,8 @@ done:
         if (cont_msg_info.msgs)
             cont_msg_info.msgs = (H5O_cont_t *)H5FL_SEQ_FREE(H5O_cont_t, cont_msg_info.msgs);
 
-        if (H5O_unprotect(loc, oh, H5AC__NO_FLAGS_SET) < 0)
+        /* Unprotect the ohdr and delete it from cache since if we failed to load it it's in an inconsistent state */
+        if (H5O_unprotect(loc, oh, H5AC__DELETED_FLAG) < 0)
             HDONE_ERROR(H5E_OHDR, H5E_CANTUNPROTECT, NULL, "unable to release object header");
     }
 
@@ -1234,8 +1235,19 @@ H5O_unprotect(const H5O_loc_t *loc, H5O_t *oh, unsigned oh_flags)
             } /* end if */
         }     /* end for */
 
-        /* Reet the flag from the unprotect */
+        /* Reset the flag from the unprotect */
         oh->chunks_pinned = false;
+    } /* end if */
+
+    /* Remove the other chunks if we're removing the ohdr (due to a failure) */
+    if (oh_flags & H5AC__DELETED_FLAG) {
+        unsigned u; /* Local index variable */
+
+        /* Iterate over chunks > 0 */
+        for (u = 1; u < oh->nchunks; u++)
+            /* Expunge chunk proxy from cache */
+            if (H5AC_expunge_entry(loc->file, H5AC_OHDR_CHK, oh->chunk[u].addr, H5AC__NO_FLAGS_SET) < 0)
+                HGOTO_ERROR(H5E_OHDR, H5E_CANTUNPIN, FAIL, "unable to expunge object header chunk");
     } /* end if */
 
     /* Unprotect the object header */

--- a/src/H5Oint.c
+++ b/src/H5Oint.c
@@ -1113,7 +1113,8 @@ done:
         if (cont_msg_info.msgs)
             cont_msg_info.msgs = (H5O_cont_t *)H5FL_SEQ_FREE(H5O_cont_t, cont_msg_info.msgs);
 
-        /* Unprotect the ohdr and delete it from cache since if we failed to load it it's in an inconsistent state */
+        /* Unprotect the ohdr and delete it from cache since if we failed to load it it's in an inconsistent
+         * state */
         if (H5O_unprotect(loc, oh, H5AC__DELETED_FLAG) < 0)
             HDONE_ERROR(H5E_OHDR, H5E_CANTUNPROTECT, NULL, "unable to release object header");
     }


### PR DESCRIPTION
Addresses #4433 

Since an object header is split into multiple cache objects but treated as a single object in the object header code, it is possible, if the cache load of the object header fails, for some of the object header objects to remain in cache pointing to an incomplete/inconsistent H5O_t struct. Modified H5O_protect to expunge all chunks and delete the main object header chunk if it fails for any reason. Also modified H5G__open_oid() to avoid the second call to H5O_msg_exists() if the first returns an error.