### PR TITLE
Point to HDFGroup repository for testing vol-log-based

### DIFF
--- a/.github/workflows/vol_log.yml
+++ b/.github/workflows/vol_log.yml
@@ -58,7 +58,7 @@ jobs:
       - name: Checkout Log-based VOL
         uses: actions/checkout@v4.1.1
         with:
-          repository: DataLib-ECP/vol-log-based
+          repository: HDFGroup/vol-log-based
           path: vol-log-based
 
       - name: Build HDF5 Log-based VOL connector and test with external tests 


### PR DESCRIPTION
Updates the location to the new HDFGroup repository, which was now the primary location of the repository.