### PR TITLE
Fix an issue where compound datatype member IDs can be leaked during conversion (#4459)

### DIFF
--- a/release_docs/HISTORY-1_14.txt
+++ b/release_docs/HISTORY-1_14.txt
@@ -514,6 +514,23 @@ Bug Fixes since HDF5-1.14.3 release
 
     Library
     -------
+    - Fixed a leak of datatype IDs created internally during datatype conversion
+
+      Fixed an issue where the library could leak IDs that it creates internally
+      for compound datatype members during datatype conversion. When the library's
+      table of datatype conversion functions is modified (such as when a new
+      conversion function is registered with the library from within an application),
+      the compound datatype conversion function has to recalculate data that it
+      has cached. When recalculating that data, the library was registering new
+      IDs for each of the members of the source and destination compound datatypes
+      involved in the conversion process and was overwriting the old cached IDs
+      without first closing them. This would result in use-after-free issues due
+      to multiple IDs pointing to the same internal H5T_t structure, as well as
+      crashes due to the library not gracefully handling partially initialized or
+      partially freed datatypes on library termination.
+
+      Fixes h5py GitHub #2419
+
     - Fixed many (future) CVE issues
 
       A partner organization corrected many potential security issues, which

--- a/release_docs/RELEASE.txt
+++ b/release_docs/RELEASE.txt
@@ -502,7 +502,6 @@ Bug Fixes since HDF5-1.14.4 release
 ===================================
     Library
     -------
-
     - Fixed function H5Requal actually to compare the reference pointers
 
       Fixed an issue with H5Requal always returning true because the

--- a/src/H5T.c
+++ b/src/H5T.c
@@ -1654,12 +1654,11 @@ H5T__unlock_cb(void *_dt, hid_t H5_ATTR_UNUSED id, void *_udata)
     FUNC_ENTER_PACKAGE_NOERR
 
     assert(dt);
-    assert(dt->shared);
 
-    if (H5T_STATE_IMMUTABLE == dt->shared->state) {
+    if (dt->shared && (H5T_STATE_IMMUTABLE == dt->shared->state)) {
         dt->shared->state = H5T_STATE_RDONLY;
         (*n)++;
-    } /* end if */
+    }
 
     FUNC_LEAVE_NOAPI(SUCCEED)
 } /* end H5T__unlock_cb() */
@@ -1873,7 +1872,6 @@ H5T__close_cb(H5T_t *dt, void **request)
 
     /* Sanity check */
     assert(dt);
-    assert(dt->shared);
 
     /* If this datatype is VOL-managed (i.e.: has a VOL object),
      * close it through the VOL connector.
@@ -4153,10 +4151,10 @@ H5T_close_real(H5T_t *dt)
     FUNC_ENTER_NOAPI(FAIL)
 
     /* Sanity check */
-    assert(dt && dt->shared);
+    assert(dt);
 
     /* Clean up resources, depending on shared state */
-    if (dt->shared->state != H5T_STATE_OPEN) {
+    if (dt->shared && (dt->shared->state != H5T_STATE_OPEN)) {
         if (H5T__free(dt) < 0)
             HGOTO_ERROR(H5E_DATATYPE, H5E_CANTFREE, FAIL, "unable to free datatype");
 
@@ -4193,10 +4191,9 @@ H5T_close(H5T_t *dt)
 
     /* Sanity check */
     assert(dt);
-    assert(dt->shared);
 
     /* Named datatype cleanups */
-    if (dt->shared->state == H5T_STATE_OPEN) {
+    if (dt->shared && (dt->shared->state == H5T_STATE_OPEN)) {
         /* Decrement refcount count on open named datatype */
         dt->shared->fo_count--;
 


### PR DESCRIPTION
Also fixes issues with handling of partially initialized datatypes during library shutdown