### PR TITLE
Disable EOF checks for SWMR readers in more cases.

### DIFF
--- a/src/H5Fsuper.c
+++ b/src/H5Fsuper.c
@@ -583,13 +583,10 @@ H5F__super_read(H5F_t *f, H5P_genplist_t *fa_plist, bool initial_read)
 
     if (H5F_INTENT(f) & H5F_ACC_SWMR_READ) {
         /*
-         * When the file is opened for SWMR read access, skip the check if:
-         * --the file is already marked for SWMR writing and
-         * --the file has version 3 superblock for SWMR support
+         * When the file is opened for SWMR read access, skip the check if
+         * the file has a version 3 superblock capable of SWMR support
          */
-        if ((sblock->status_flags & H5F_SUPER_SWMR_WRITE_ACCESS) &&
-            (sblock->status_flags & H5F_SUPER_WRITE_ACCESS) &&
-            sblock->super_vers >= HDF5_SUPERBLOCK_VERSION_3)
+        if (sblock->super_vers >= HDF5_SUPERBLOCK_VERSION_3)
             skip_eof_check = true;
     }
     if (!skip_eof_check && initial_read) {


### PR DESCRIPTION
Fixes a race condition where the reader opens the file and sets its EOF from the file's size (from the stat() call in the driver open callback).  Then, before the reader can read the file's superblock, a SWMR writer races in, extends the file, and closes the file, writing an updated superblock with the 'writer' and 'SWMR writer' flags in the superblock off (appropriately).  Then the reader proceeds to read the superblock, and flags the EOF as wrong.  Taking out the check for the 'writer' and 'SWMR writer' flags will cause SWMR readers to avoid flagging the file as incorrect.