### PR TITLE
add support for aarch64 _Float16 16-bit floating point type

### DIFF
--- a/src/H5private.h
+++ b/src/H5private.h
@@ -589,7 +589,11 @@
  */
 #ifdef H5_HAVE__FLOAT16
 #if defined(__GNUC__)
+#if defined(__aarch64__)
+typedef __fp16 H5__Float16;
+#else
 __extension__ typedef _Float16 H5__Float16;
+#endif
 #else
 typedef _Float16 H5__Float16;
 #endif


### PR DESCRIPTION
_Float16 was supported in commit 330b80a266.

However there is build error report in aarch64, like this: ../../../src/H5private.h:605:23: error: '_Float16' does not name a type; did you mean '_Float64'?
  605 | __extension__ typedef _Float16 H5__Float16;
      |                       ^~~~~~~~
      |                       _Float64
make[2]: *** [Makefile:972: dsets.o] Error 1
make[1]: *** [Makefile:910: all-recursive] Error 1
make: *** [Makefile:739: all-recursive] Error 1

In aarch64, __fp16 type is half-precision (16-bit) floating point