### PR TITLE
Remove unnecessary fortran install

### DIFF
--- a/.github/workflows/cmake-bintest.yml
+++ b/.github/workflows/cmake-bintest.yml
@@ -189,12 +189,12 @@ jobs:
               ls ${{ runner.workspace }}
 
       # symlinks the compiler executables to a common location 
-      - name: Setup GNU Fortran
-        uses: fortran-lang/setup-fortran@v1
-        id: setup-fortran
-        with:
-          compiler: gcc
-          version: 12
+      # - name: Setup GNU Fortran
+      #   uses: fortran-lang/setup-fortran@v1
+      #   id: setup-fortran
+      #   with:
+      #     compiler: gcc
+      #     version: 12
 
       - name: Run ctest (MacOS)
         id: run-ctest

--- a/.github/workflows/h5py.yml
+++ b/.github/workflows/h5py.yml
@@ -11,11 +11,6 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-    - name: Install Fortran
-      uses: fortran-lang/setup-fortran@v1
-      with:
-        compiler: gcc
-        version: 13
     - name: Checkout Spack
       uses: actions/checkout@v4.1.1
       with:


### PR DESCRIPTION
Fortran was not enabled for the mac binary, and python test does not need fortran.