### PR TITLE
Remove trailing extra whitespace in hyperlink

### DIFF
--- a/doxygen/dox/Overview.dox
+++ b/doxygen/dox/Overview.dox
@@ -9,13 +9,13 @@ the entire HDF5 ecosystem in one place, and you should also consult the document
 sets of the many outstanding community projects.
 
 For a first contact with HDF5, the best place is to have a look at the \link
-GettingStarted getting started \endlink page that shows you how to write and
+GettingStarted getting started\endlink page that shows you how to write and
 compile your first program with HDF5.
 
 The \b main \b documentation is organized by documentation flavor. Most
 technical documentation consists to varying degrees of information related to
 <em>tasks</em>, <em>concepts</em>, or <em>reference</em> material. As its title
-suggests, the \link RM Reference Manual \endlink is 100% reference material,
+suggests, the \link RM Reference Manual\endlink is 100% reference material,
 while the \link Cookbook \endlink is focused on tasks. The different guide-type
 documents cover a mix of tasks, concepts, and reference, to help a specific
 <em>audience</em> succeed.


### PR DESCRIPTION
The hyperlink blue line goes beyond the reference text.

<img width="165" alt="Screen Shot 2024-05-21 at 10 37 05 AM" src="https://github.com/HDFGroup/hdf5/assets/4994401/8d52058f-e089-4bc2-99c0-b7bd29fe2483">
