### PR TITLE
Use old requests version in REST VOL workflow

### DIFF
--- a/.github/workflows/vol_rest.yml
+++ b/.github/workflows/vol_rest.yml
@@ -129,6 +129,11 @@ jobs:
       #    path: ${{ runner.workspace }}/hsds-${{ env.HSDS_COMMIT_SHORT }}-install
       #    key: ${{ runner.os }}-${{ runner.arch }}-hsds-${{ env.HSDS_COMMIT }}-${{ inputs.build_mode }}-cache
 
+      # Requests 2.32.0 breaks requests-unixsocket, used by HSDS for socket connections
+      - name: Fix requests version
+        run: |
+          pip install requests==2.31.0
+
       - name: Run HSDS unit tests
         shell: bash
         working-directory: ${{github.workspace}}/hsds


### PR DESCRIPTION
The REST VOL test workflow is failing to due to the 2.32.0 python module `requests` breaking compatibility with the `requests-unixsocket` module, both of which are used by HSDS.