### PR TITLE
Fix a few function names in USAGE comments that don't match the actual

### DIFF
--- a/release_docs/RELEASE_PROCESS.md
+++ b/release_docs/RELEASE_PROCESS.md
@@ -18,7 +18,7 @@ Maintenance releases are always forward compatible with regards to the HDF5 file
 - HDF5 libraries and command line utilities can access files created by future maintenance versions of the library.
 Note that maintenance releases are NOT guaranteed to be interface-compatible, meaning that, on occasion, application source code will need updated and re-compiled against a new maintenance release when the interface changes. Interface changes are only made when absolutely necessary as deemed by the HDF5 product manager(s), and interface compatibility reports are published with each release to inform customers and users of any incompatibilities in the interface.
 
-For more information on the HDF5 versioning and backward and forward compatibility issues, see the [API Compatibility Macros](https://docs.hdfgroup.org/hdf5/v1_14/v1_14_4/api-compat-macros.html) on the public website.
+For more information on the HDF5 versioning and backward and forward compatibility issues, see the [API Compatibility Macros](https://hdfgroup.github.io/hdf5/develop/api-compat-macros.html) on the public website.
 
 ## Participants:
 - Product Manager — The individual responsible for the overall direction and development of a software product at The HDF Group.

--- a/src/H5A.c
+++ b/src/H5A.c
@@ -1880,7 +1880,7 @@ done:
  PURPOSE
     Calls a user's function for each attribute on an object
  USAGE
-    herr_t H5Aiterate2(loc_id, obj_name, idx_type, order, idx, op, op_data, lapl_id)
+    herr_t H5Aiterate_by_name(loc_id, obj_name, idx_type, order, idx, op, op_data, lapl_id)
         hid_t loc_id;           IN: Base location for object
         const char *obj_name;   IN: Name of object relative to location
         H5_index_t idx_type;    IN: Type of index to use

--- a/src/H5FO.c
+++ b/src/H5FO.c
@@ -136,7 +136,7 @@ H5FO_opened(const H5F_t *f, haddr_t addr)
  PURPOSE
     Insert a newly opened object/pointer pair into the opened object info set
  USAGE
-    herr_t H5FO_insert(f,addr,obj)
+    herr_t H5FO_insert(f,addr,obj,delete_flag)
         H5F_t *f;               IN/OUT: File's opened object info set
         haddr_t addr;           IN: Address of object to insert
         void *obj;              IN: Pointer to object to insert
@@ -239,9 +239,10 @@ done:
  PURPOSE
     Mark an object to be deleted when it is closed
  USAGE
-    herr_t H5FO_mark(f,addr)
+    herr_t H5FO_mark(f,addr,deleted)
         const H5F_t *f;         IN: File opened object is in
         haddr_t addr;           IN: Address of object to delete
+        bool deleted;           IN: true for to be deleted
 
  RETURNS
     Returns a non-negative ID for the object on success, negative on failure
@@ -366,7 +367,7 @@ done:
  PURPOSE
     Create the "top" open object count set
  USAGE
-    herr_t H5FO_create(f)
+    herr_t H5FO_top_create(f)
         H5F_t *f;       IN/OUT: File to create opened object count set for
 
  RETURNS
@@ -509,7 +510,7 @@ done:
  PURPOSE
     Return the "top" reference count for an object in a file
  USAGE
-    hsize_t H5FO_top_incr(f, addr)
+    hsize_t H5FO_top_count(f, addr)
         H5F_t *f;               IN/OUT: File's opened object info set
         haddr_t addr;           IN: Address of object to increment
 

--- a/src/H5Sselect.c
+++ b/src/H5Sselect.c
@@ -477,7 +477,7 @@ H5S_select_valid(const H5S_t *space)
     assert(space);
 
     ret_value = (*space->select.type->is_valid)(space);
-]
+
     FUNC_LEAVE_NOAPI(ret_value)
 } /* end H5S_select_valid() */
 

--- a/src/H5Sselect.c
+++ b/src/H5Sselect.c
@@ -413,7 +413,7 @@ H5S_get_select_npoints(const H5S_t *space)
     Check whether the selection fits within the extent, with the current
     offset defined.
  USAGE
-    htri_t H5Sselect_void(dsid)
+    htri_t H5Sselect_valid(dsid)
         hid_t dsid;             IN: Dataspace ID to query
  RETURNS
     true if the selection fits within the extent, false if it does not and
@@ -451,7 +451,7 @@ done:
     Check whether the selection fits within the extent, with the current
     offset defined.
  USAGE
-    htri_t H5S_select_void(space)
+    htri_t H5S_select_valid(space)
         H5S_t *space;           IN: Dataspace to query
  RETURNS
     true if the selection fits within the extent, false if it does not and
@@ -477,7 +477,7 @@ H5S_select_valid(const H5S_t *space)
     assert(space);
 
     ret_value = (*space->select.type->is_valid)(space);
-
+]
     FUNC_LEAVE_NOAPI(ret_value)
 } /* end H5S_select_valid() */
 
@@ -921,7 +921,7 @@ H5S_select_adjust_u(H5S_t *space, const hsize_t *offset)
  PURPOSE
     Adjust a selection by subtracting an offset
  USAGE
-    herr_t H5S_select_adjust_u(space, offset)
+    herr_t H5S_select_adjust_s(space, offset)
         H5S_t *space;           IN/OUT: Pointer to dataspace to adjust
         const hssize_t *offset; IN: Offset to subtract
  RETURNS
@@ -2786,8 +2786,8 @@ done:
  PURPOSE
     Create a dataspace selection iterator for a dataspace's selection
  USAGE
-    hid_t H5Ssel_iter_create(space)
-        hid_t   space;  IN: ID of the dataspace with selection to iterate over
+    hid_t H5Ssel_iter_create(space,elmt_size,flags)
+        hid_t   space;     IN: ID of the dataspace with selection to iterate over
  RETURNS
     Valid dataspace selection iterator ID on success, H5I_INVALID_HID on failure
  DESCRIPTION
@@ -2997,7 +2997,7 @@ done:
  PURPOSE
     Resets a dataspace selection iterator back to an initial state.
  USAGE
-    herr_t H5Ssel_iter_reset(sel_iter_id)
+    herr_t H5Ssel_iter_reset(sel_iter_id,space_id)
         hid_t   sel_iter_id;  IN: ID of the dataspace selection iterator to
                                   reset
         hid_t   space_id;     IN: ID of the dataspace with selection to


### PR DESCRIPTION
function names.
Sometimes parameters and parameter documentation are missing.
Often copy/paste operations with incomplete modification.

I think it is likely there are more, and I'll add a couple of specific questions in the code.  I came across these while reviewing another PR, and thought I would create this one to see if these are something we want to fix.