### PR TITLE
Adjust h5repack userblock option to allow reserve size

### DIFF
--- a/release_docs/RELEASE.txt
+++ b/release_docs/RELEASE.txt
@@ -734,7 +734,10 @@ New Features
 
     Tools:
     ------
-    -
+    - Allow h5repack to reserve space for a user block without a file
+
+      This is useful for users who want to reserve space
+      in the file for future use without requiring a file to copy.
 
 
     High-Level APIs:

--- a/tools/src/h5repack/h5repack.c
+++ b/tools/src/h5repack/h5repack.c
@@ -748,7 +748,7 @@ check_options(pack_opt_t *options)
 
     if (options->ublock_filename == NULL && options->ublock_size != 0) {
         if (options->verbose > 0) {
-            printf("Warning: user block file name missing. Reserving a size of %d...\n",
+            printf("Warning: user block file name missing. Reserving a size of %ld...\n",
                    options->ublock_size);
         }
     }

--- a/tools/src/h5repack/h5repack.c
+++ b/tools/src/h5repack/h5repack.c
@@ -746,8 +746,12 @@ check_options(pack_opt_t *options)
         }
     }
 
-    if (options->ublock_filename == NULL && options->ublock_size != 0)
-        H5TOOLS_GOTO_ERROR((-1), "file name missing for user block");
+    if (options->ublock_filename == NULL && options->ublock_size != 0) {
+        if (options->verbose > 0) {
+            printf("Warning: user block file name missing. Reserving a size of %d...\n",
+                   options->ublock_size);
+        }
+    }
 
     /*------------------------------------------------------------------------
      * Verify alignment options; threshold is zero default but alignment not

--- a/tools/src/h5repack/h5repack_copy.c
+++ b/tools/src/h5repack/h5repack_copy.c
@@ -368,7 +368,7 @@ copy_objects(const char *fnamein, const char *fnameout, pack_opt_t *options)
      *-------------------------------------------------------------------------
      */
 
-    if (options->ublock_size > 0) {
+    if (options->ublock_filename != NULL && options->ublock_size > 0) {
         if (copy_user_block(options->ublock_filename, fnameout, options->ublock_size) < 0)
             H5TOOLS_GOTO_ERROR((-1), "Could not copy user block. Exiting...");
     }

--- a/tools/test/h5repack/CMakeTests.cmake
+++ b/tools/test/h5repack/CMakeTests.cmake
@@ -979,6 +979,51 @@
       )
   endmacro ()
 
+  macro (ADD_H5_VERIFY_USERBLOCK testname userblocksize testfile)
+    if (NOT HDF5_USING_ANALYSIS_TOOL)
+      add_test (
+          NAME H5REPACK_VERIFY_USERBLOCK-${testname}-clear-objects
+          COMMAND ${CMAKE_COMMAND} -E remove testfiles/out-${testname}.${testfile}
+      )
+      add_test (
+          NAME H5REPACK_VERIFY_USERBLOCK-${testname}
+          COMMAND ${CMAKE_CROSSCOMPILING_EMULATOR} $<TARGET_FILE:h5repack> --enable-error-stack ${ARGN} ${PROJECT_BINARY_DIR}/testfiles/${testfile} ${PROJECT_BINARY_DIR}/testfiles/out-${testname}.${testfile}
+      )
+      set_tests_properties (H5REPACK_VERIFY_USERBLOCK-${testname} PROPERTIES
+          DEPENDS H5REPACK_VERIFY_USERBLOCK-${testname}-clear-objects
+      )
+      if ("H5REPACK_VERIFY_USERBLOCK-${testname}" MATCHES "${HDF5_DISABLE_TESTS_REGEX}")
+        set_tests_properties (H5REPACK_VERIFY_USERBLOCK-${testname} PROPERTIES DISABLED true)
+      endif ()
+      add_test (
+          NAME H5REPACK_VERIFY_USERBLOCK-${testname}_DMP
+          COMMAND "${CMAKE_COMMAND}"
+              -D "TEST_EMULATOR=${CMAKE_CROSSCOMPILING_EMULATOR}"
+              -D "TEST_PROGRAM=$<TARGET_FILE:h5dump>"
+              -D "TEST_ARGS:STRING=-H;-B;out-${testname}.${testfile}"
+              -D "TEST_FOLDER=${PROJECT_BINARY_DIR}/testfiles"
+              -D "TEST_OUTPUT=${testfile}-${testname}-v.out"
+              -D "TEST_EXPECT=${resultcode}"
+              -D "TEST_FILTER:STRING=USERBLOCK_SIZE ${userblocksize}"
+              -D "TEST_REFERENCE=USERBLOCK_SIZE ${userblocksize}"
+              -P "${HDF_RESOURCES_DIR}/grepTest.cmake"
+      )
+      set_tests_properties (H5REPACK_VERIFY_USERBLOCK-${testname}_DMP PROPERTIES
+          DEPENDS H5REPACK_VERIFY_USERBLOCK-${testname}
+      )
+      if ("H5REPACK_VERIFY_USERBLOCK-${testname}_DMP" MATCHES "${HDF5_DISABLE_TESTS_REGEX}")
+        set_tests_properties (H5REPACK_VERIFY_USERBLOCK-${testname}_DMP PROPERTIES DISABLED true)
+      endif ()
+      add_test (
+          NAME H5REPACK_VERIFY_USERBLOCK-${testname}-clean-objects
+          COMMAND ${CMAKE_COMMAND} -E remove testfiles/out-${testname}.${testfile}
+      )
+      set_tests_properties (H5REPACK_VERIFY_USERBLOCK-${testname}-clean-objects PROPERTIES
+          DEPENDS H5REPACK_VERIFY_USERBLOCK-${testname}_DMP
+      )
+    endif ()
+  endmacro ()
+
   macro (ADD_H5_TEST_META testname testfile)
       # Remove any output file left over from previous test run
       add_test (
@@ -1718,6 +1763,9 @@
 # add a userblock to file
   set (arg ${FILE1} -u ${PROJECT_BINARY_DIR}/testfiles/ublock.bin -b 2048)
   ADD_H5_TEST (add_userblock "TEST" ${arg})
+
+# add a userblock reserve to file
+  ADD_H5_VERIFY_USERBLOCK (reserve_userblock 2048 ${FILE1} -b 2048)
 
 # add alignment
   set (arg ${FILE1} -t 1 -a 1)

--- a/tools/test/h5repack/h5repack.sh.in
+++ b/tools/test/h5repack/h5repack.sh.in
@@ -1805,6 +1805,10 @@ fi
 arg="h5repack_objs.h5 -u ublock.bin -b 2048"
 TOOLTEST add_userblock $arg
 
+# reserve a userblock to file
+arg="h5repack_objs.h5 -b 2048"
+TOOLTEST reserve_userblock $arg
+
 # add alignment
 arg="h5repack_objs.h5 -t 1 -a 1 "
 TOOLTEST add_alignment $arg


### PR DESCRIPTION
Removed the failure for a missing userblock file to allow a userblock size to reserve space without requiring a file.