### PR TITLE
Simplify property copying between lists internally

### DIFF
--- a/src/H5P.c
+++ b/src/H5P.c
@@ -1331,8 +1331,8 @@ done:
     property information will be copied from the source class into the
     destination class.
 
-    If a property is copied from one list to another, the property will be
-    first deleted from the destination list (generating a call to the 'close'
+    If a property is copied from one list to another list that already contains the property,
+    the property will be first deleted from the destination list (generating a call to the 'del'
     callback for the property, if one exists) and then the property is copied
     from the source list to the destination list (generating a call to the
     'copy' callback for the property, if one exists).


### PR DESCRIPTION
- Moved duplicated actions (duplicating the property, getting the source property, inserting into destination list) out of the if/else branches.
- Correct some comments (H5P_remove uses the del callback and not the close callback, this operation always inserts into a property list and not a property list class)
- Clarify the description of H5P_copy_prop_plist - it's not exactly equivalent to H5Pinsert2 in the case where the property doesn't exist in the destination, since H5Pinsert2 never invokes the create callback. 