### PR TITLE
Fix CI markdown link check http 500 errors

### DIFF
--- a/.github/workflows/markdown-link-check.yml
+++ b/.github/workflows/markdown-link-check.yml
@@ -14,4 +14,4 @@ jobs:
     - uses: actions/checkout@master
     - uses: gaurav-nelson/github-action-markdown-link-check@v1
       with:
-        config-file: 'markdown_config.json'
+        config-file: '.github/workflows/markdown_config.json'

--- a/.github/workflows/markdown-link-check.yml
+++ b/.github/workflows/markdown-link-check.yml
@@ -6,9 +6,12 @@ on:
   pull_request:
     branches: [ develop ]
 
+# The config file handles things like http 500 errors from sites like GitLab
 jobs:
   markdown-link-check:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@master
     - uses: gaurav-nelson/github-action-markdown-link-check@v1
+      with:
+        config-file: 'markdown_config.json'

--- a/.github/workflows/markdown-link-check.yml
+++ b/.github/workflows/markdown-link-check.yml
@@ -7,6 +7,7 @@ on:
     branches: [ develop ]
 
 # The config file handles things like http 500 errors from sites like GitLab
+# and http 200 responses
 jobs:
   markdown-link-check:
     runs-on: ubuntu-latest

--- a/.github/workflows/markdown_config.json
+++ b/.github/workflows/markdown_config.json
@@ -1,0 +1,3 @@
+{
+    "aliveStatusCodes": [500]
+}

--- a/.github/workflows/markdown_config.json
+++ b/.github/workflows/markdown_config.json
@@ -1,3 +1,3 @@
 {
-    "aliveStatusCodes": [500]
+    "aliveStatusCodes": [200, 500]
 }


### PR DESCRIPTION
Sites like GitLab can have internal problems that return http 500 errors while they fix their problems. This PR adds a config file to the markdown link check so those are considered "passing" and don't break the CI.