### PR TITLE
Document 'return-and-read' fields in API context

### DIFF
--- a/src/H5CX.c
+++ b/src/H5CX.c
@@ -156,10 +156,10 @@
  *      application's (non-default) property list.  Getting / setting these
  *      properties within the library does _not_ affect the application's
  *      property list.  Note that the naming of these fields, <foo> and
- *      <foo>_valid, is important for the H5CX_RETRIEVE_PROP_VALID ahd
- *      H5CX_RETRIEVE_PROP_VALID_SET macros to work properly.
+ *      <foo>_valid, is important for the H5CX_RETRIEVE_PROP_VALID
+ *      macro to work properly.
  *
- * - "Return-only"" properties that are returned to the application, mainly
+ * - "Return-only" properties that are returned to the application, mainly
  *      for sending out "introspection" information ("Why did collective I/O
  *      get broken for this operation?", "Which filters are set on the chunk I
  *      just directly read in?", etc) Setting these fields will cause the
@@ -167,6 +167,19 @@
  *      context is popped, when returning from the API routine.  Note that the
  *      naming of these fields, <foo> and <foo>_set, is important for the
  *      H5CX_TEST_SET_PROP and H5CX_SET_PROP macros to work properly.
+ *
+ * - "Return-and-read" properties that are returned to the application to send out introspection information,
+ *      but are also queried by the library internally. Internal queries always retrieve the original value
+ *      from the property list, and update the context's value to match. These properties have both a 'valid'
+ *      and 'set' flag. <foo>_valid is true if the field has ever been populated from its underlying property
+ *      list. <foo>_set flag is true if this field has ever been set on the context for application
+ *      introspection. The naming of these fields is important for the H5CX_RETRIEVE_PROP_VALID_SET macro to
+ *      work properly.
+ *
+ *      Note that if a set operation is followed by an internal read, it is possible for <foo>_set to be true
+ *      while the value in the context matches the underlying property list, resulting in a redundant write to
+ *      the property list when the context is popped. Similarly, if a field has been set on the context but
+ *      never read internally, <foo>_valid will be false despite the context containing a meaningful value.
  */
 typedef struct H5CX_t {
     /* DXPL */
@@ -1082,7 +1095,7 @@ H5CX_restore_state(const H5CX_state_t *api_state)
 /*-------------------------------------------------------------------------
  * Function:    H5CX_free_state
  *
- * Purpose:     Free a previously retrievedAPI context state
+ * Purpose:     Free a previously retrieved API context state
  *
  * Return:      Non-negative on success / Negative on failure
  *


### PR DESCRIPTION
The documentation for API contexts states there are four types of fields:
- property lists
- internal fields
- cached fields with a `<field>_valid` flag that do not cause their underlying property list to be modified
-  return-only properties with a `<field>_set` flag that cause the underlying property list to be modified when the API context is popped, but are never queried internally by the library

However, there are several fields that contain both a `<field>_valid` and `<field>_set` flag. These fields can cause the input property list to be modified,  may be queried internally by the library by functions of the form `H5CX\_get\_<field>()`, and can use cached values for  reads similarly to cached fields. The specific fields are:
- `actual_selection_io_mode`
- `mpio_local_no_coll_cause`
- `mpio_global_no_coll_cause`
- `no_selection_io_cause`

This PR coins the term 'return-and-read fields' for these cases and documents them in the `H5CX_t` documentation, as well as pointing out some potentially unintuitive facts about them:
- the `<field>_set` flag only indicates whether the context has _ever_  performed a set operation on this field. Later reads from the property list which overwrite the value stored on the context do not modify the set flag. As such, if a set operation is followed by an internal query, the modification of the property list at API context pop time will be redundant (since the value in the context will already match the property list's value).
 
- the `<field>_valid` flag only indicates whether the context has _ever_ been populated with a value from the original property list. The `H5CX_set_<field>` routines don't interact with this flag at all, and so both of the following are possible:
    - the field is never read, and is only written by `H5CX_set_<field>`. The context then contains a meaningful value, but `<field>_valid` is false.
    - the field is read, but is overwritten on the context by `H5CX_set_<field>`. The context contains  a value that is not from the underlying property list, but `<field>_valid` is true.
  
