### PR TITLE
Add property names to context field docs

### DIFF
--- a/src/H5CX.c
+++ b/src/H5CX.c
@@ -209,15 +209,15 @@ typedef struct H5CX_t {
 #endif                               /* H5_HAVE_PARALLEL */
 
     /* Cached DXPL properties */
-    size_t    max_temp_buf;            /* Maximum temporary buffer size */
+    size_t    max_temp_buf;            /* Maximum temporary buffer size (H5D_XFER_MAX_TEMP_BUF_NAME) .*/
     bool      max_temp_buf_valid;      /* Whether maximum temporary buffer size is valid */
     void     *tconv_buf;               /* Temporary conversion buffer (H5D_XFER_TCONV_BUF_NAME) */
     bool      tconv_buf_valid;         /* Whether temporary conversion buffer is valid */
     void     *bkgr_buf;                /* Background conversion buffer (H5D_XFER_BKGR_BUF_NAME) */
     bool      bkgr_buf_valid;          /* Whether background conversion buffer is valid */
-    H5T_bkg_t bkgr_buf_type;           /* Background buffer type (H5D_XFER_BKGR_BUF_NAME) */
+    H5T_bkg_t bkgr_buf_type;           /* Background buffer type (H5D_XFER_BKGR_BUF_TYPE_NAME) */
     bool      bkgr_buf_type_valid;     /* Whether background buffer type is valid */
-    double    btree_split_ratio[3];    /* B-tree split ratios */
+    double    btree_split_ratio[3];    /* B-tree split ratios (H5D_XFER_BTREE_SPLIT_RATIO_NAME) */
     bool      btree_split_ratio_valid; /* Whether B-tree split ratios are valid */
     size_t    vec_size;                /* Size of hyperslab vector (H5D_XFER_HYPER_VECTOR_SIZE_NAME) */
     bool      vec_size_valid;          /* Whether hyperslab vector is valid */
@@ -247,8 +247,8 @@ typedef struct H5CX_t {
     bool                    dt_conv_cb_valid;     /* Whether datatype conversion struct is valid */
     H5D_selection_io_mode_t selection_io_mode;    /* Selection I/O mode (H5D_XFER_SELECTION_IO_MODE_NAME) */
     bool                    selection_io_mode_valid; /* Whether selection I/O mode is valid */
-    bool                    modify_write_buf;        /* Whether the library can modify write buffers */
-    bool                    modify_write_buf_valid;  /* Whether the modify_write_buf field is valid */
+    bool modify_write_buf; /* Whether the library can modify write buffers (H5D_XFER_MODIFY_WRITE_BUF_NAME)*/
+    bool modify_write_buf_valid; /* Whether the modify_write_buf field is valid */
 
     /* Return-only DXPL properties to return to application */
 #ifdef H5_HAVE_PARALLEL
@@ -305,32 +305,34 @@ typedef struct H5CX_t {
     bool actual_selection_io_mode_valid; /* Whether actual selection I/O mode is valid */
 
     /* Cached LCPL properties */
-    H5T_cset_t encoding;                 /* Link name character encoding */
-    bool       encoding_valid;           /* Whether link name character encoding is valid */
-    unsigned   intermediate_group;       /* Whether to create intermediate groups */
-    bool       intermediate_group_valid; /* Whether create intermediate group flag is valid */
+    H5T_cset_t encoding;         /* Link name character encoding (H5P_STRCRT_CHAR_ENCODING_NAME) */
+    bool       encoding_valid;   /* Whether link name character encoding is valid */
+    unsigned intermediate_group; /* Whether to create intermediate groups (H5L_CRT_INTERMEDIATE_GROUP_NAME) */
+    bool     intermediate_group_valid; /* Whether create intermediate group flag is valid */
 
     /* Cached LAPL properties */
     size_t nlinks;       /* Number of soft / UD links to traverse (H5L_ACS_NLINKS_NAME) */
     bool   nlinks_valid; /* Whether number of soft / UD links to traverse is valid */
 
     /* Cached DCPL properties */
-    bool    do_min_dset_ohdr;       /* Whether to minimize dataset object header */
+    bool    do_min_dset_ohdr; /* Whether to minimize dataset object header (H5D_CRT_MIN_DSET_HDR_SIZE_NAME) */
     bool    do_min_dset_ohdr_valid; /* Whether minimize dataset object header flag is valid */
-    uint8_t ohdr_flags;             /* Object header flags */
+    uint8_t ohdr_flags;             /* Object header flags (H5O_CRT_OHDR_FLAGS_NAME) */
     bool    ohdr_flags_valid;       /* Whether the object headers flags are valid */
 
     /* Cached DAPL properties */
-    const char *extfile_prefix;       /* Prefix for external file                      */
+    const char *extfile_prefix;       /* Prefix for external file (H5D_ACS_EFILE_PREFIX_NAME) */
     bool        extfile_prefix_valid; /* Whether the prefix for external file is valid */
-    const char *vds_prefix;           /* Prefix for VDS                                */
+    const char *vds_prefix;           /* Prefix for VDS (H5D_ACS_VDS_PREFIX_NAME) */
     bool        vds_prefix_valid;     /* Whether the prefix for VDS is valid           */
 
     /* Cached FAPL properties */
-    H5F_libver_t low_bound;        /* low_bound property for H5Pset_libver_bounds() */
-    bool         low_bound_valid;  /* Whether low_bound property is valid */
-    H5F_libver_t high_bound;       /* high_bound property for H5Pset_libver_bounds */
-    bool         high_bound_valid; /* Whether high_bound property is valid */
+    H5F_libver_t low_bound;       /* low_bound property for H5Pset_libver_bounds()
+                                     (H5F_ACS_LIBVER_LOW_BOUND_NAME) */
+    bool         low_bound_valid; /* Whether low_bound property is valid */
+    H5F_libver_t high_bound;      /* high_bound property for H5Pset_libver_bounds
+                                     (H5F_ACS_LIBVER_HIGH_BOUND_NAME) */
+    bool high_bound_valid;        /* Whether high_bound property is valid */
 
     /* Cached VOL settings */
     H5VL_connector_prop_t vol_connector_prop; /* Property for VOL connector ID & info */


### PR DESCRIPTION
Not all of the context fields that map to a property mention the name of the property in their comment. This adds the property names for fields that were missing it, and corrects a few that had the wrong property name listed.