### PR TITLE
Document H5Punregister modifying default properties

### DIFF
--- a/src/H5P.c
+++ b/src/H5P.c
@@ -1397,8 +1397,10 @@ done:
     Returns non-negative on success, negative on failure.
  DESCRIPTION
         Removes a property from a property list class.  Future property lists
-    created of that class will not contain this property.  Existing property
-    lists containing this property are not affected.
+    created of that class will not contain this property. Existing property lists
+    which still use the default value for this property will have this property removed.
+    Existing property lists which have modified this property will not be affected.
+
 
  GLOBAL VARIABLES
  COMMENTS, BUGS, ASSUMPTIONS
@@ -1419,7 +1421,7 @@ H5Punregister(hid_t pclass_id, const char *name)
     if (!name || !*name)
         HGOTO_ERROR(H5E_ARGS, H5E_BADVALUE, FAIL, "invalid property name");
 
-    /* Remove the property list from class */
+    /* Remove the property from property list class */
     if ((ret_value = H5P__unregister(pclass, name)) < 0)
         HGOTO_ERROR(H5E_PLIST, H5E_CANTREGISTER, FAIL, "unable to remove property from class");
 

--- a/src/H5Ppkg.h
+++ b/src/H5Ppkg.h
@@ -108,10 +108,10 @@ struct H5P_genclass_t {
 struct H5P_genplist_t {
     H5P_genclass_t *pclass;     /* Pointer to class info */
     hid_t           plist_id;   /* Copy of the property list ID (for use in close callback) */
-    size_t          nprops;     /* Number of properties in class */
+    size_t          nprops;     /* Number of properties in this list */
     bool            class_init; /* Whether the class initialization callback finished successfully */
     H5SL_t         *del;        /* Skip list containing names of deleted properties */
-    H5SL_t         *props;      /* Skip list containing properties */
+    H5SL_t         *props;      /* Skip list containing properties modified from the parent class */
 };
 
 /* Property list/class iterator callback function pointer */


### PR DESCRIPTION
`H5Punregister()` says that existing property lists are unaffected. However, property lists get default property values from their parent class(es). If list has a property with a default value, then calling `H5Punregister()` to remove that property from the class will also remove it from the list. 

This is probably something we'll want to change eventually, but for now we can at least document the actual behavior. 