### PR TITLE
Document that ctx VOL property isn't drawn from the FAPL

### DIFF
--- a/src/H5CX.c
+++ b/src/H5CX.c
@@ -349,7 +349,9 @@ typedef struct H5CX_t {
     bool high_bound_valid;        /* Whether high_bound property is valid */
 
     /* Cached VOL settings */
-    H5VL_connector_prop_t vol_connector_prop; /* Property for VOL connector ID & info */
+    H5VL_connector_prop_t vol_connector_prop; /* Property for VOL connector ID & info
+                               This is treated as an independent field with
+                               no relation to the property H5F_ACS_VOL_CONN_NAME stored on the FAPL */
     bool  vol_connector_prop_valid;           /* Whether property for VOL connector ID & info is valid */
     void *vol_wrap_ctx;                       /* VOL connector's "wrap context" for creating IDs */
     bool  vol_wrap_ctx_valid; /* Whether VOL connector's "wrap context" for creating IDs is valid */


### PR DESCRIPTION
Most fields on the context are cached values from an underlying property list that's also stored on the context. `vol_connector_prop`, despite corresponding to the property named `H5F_ACS_VOL_CONN_NAME` from the FAPL, is stored as a field completely independent of any property list. This seems to be because at [the time this field was added](https://github.com/HDFGroup/hdf5/commit/92300f954fec70b3018182defab6933bf6f4bc88), the FAPL was not stored on the context. 

This should probably be changed. If this field is treated like a cached field for a property, then  making property list operations threadsafe would also solve threadsafety problems around the handling of this field. 

For now, just document how this field is treated.