### PR TITLE
Removed unnecessary call to H5E_clear_stack

### DIFF
--- a/src/H5Dint.c
+++ b/src/H5Dint.c
@@ -1494,9 +1494,6 @@ H5D_open(const H5G_loc_t *loc, hid_t dapl_id)
 
     /* Check if dataset was already open */
     if (NULL == (shared_fo = (H5D_shared_t *)H5FO_opened(dataset->oloc.file, dataset->oloc.addr))) {
-        /* Clear any errors from H5FO_opened() */
-        H5E_clear_stack();
-
         /* Open the dataset object */
         if (H5D__open_oid(dataset, dapl_id) < 0)
             HGOTO_ERROR(H5E_DATASET, H5E_NOTFOUND, NULL, "not found");

--- a/src/H5Gint.c
+++ b/src/H5Gint.c
@@ -437,10 +437,6 @@ H5G_open(const H5G_loc_t *loc)
 
     /* Check if group was already open */
     if ((shared_fo = (H5G_shared_t *)H5FO_opened(grp->oloc.file, grp->oloc.addr)) == NULL) {
-
-        /* Clear any errors from H5FO_opened() */
-        H5E_clear_stack();
-
         /* Open the group object */
         if (H5G__open_oid(grp) < 0)
             HGOTO_ERROR(H5E_SYM, H5E_NOTFOUND, NULL, "not found");

--- a/src/H5Tcommit.c
+++ b/src/H5Tcommit.c
@@ -1036,9 +1036,6 @@ H5T_open(const H5G_loc_t *loc)
 
     /* Check if datatype was already open */
     if (NULL == (shared_fo = (H5T_shared_t *)H5FO_opened(loc->oloc->file, loc->oloc->addr))) {
-        /* Clear any errors from H5FO_opened() */
-        H5E_clear_stack();
-
         /* Open the datatype object */
         if (NULL == (dt = H5T__open_oid(loc)))
             HGOTO_ERROR(H5E_DATATYPE, H5E_NOTFOUND, NULL, "not found");


### PR DESCRIPTION
H5FO_opened and H5SL_search don't push errors on the stack