### PR TITLE
Add FAPL/DAPL to API Context state

### DIFF
--- a/src/H5CXprivate.h
+++ b/src/H5CXprivate.h
@@ -34,6 +34,7 @@
 
 /* API context state */
 typedef struct H5CX_state_t {
+    hid_t                 fapl_id;            /* FAPL for operation */
     hid_t                 dcpl_id;            /* DCPL for operation */
     hid_t                 dxpl_id;            /* DXPL for operation */
     hid_t                 lapl_id;            /* LAPL for operation */

--- a/src/H5CXprivate.h
+++ b/src/H5CXprivate.h
@@ -35,6 +35,7 @@
 /* API context state */
 typedef struct H5CX_state_t {
     hid_t                 fapl_id;            /* FAPL for operation */
+    hid_t                 dapl_id;            /* DAPL for operation */
     hid_t                 dcpl_id;            /* DCPL for operation */
     hid_t                 dxpl_id;            /* DXPL for operation */
     hid_t                 lapl_id;            /* LAPL for operation */


### PR DESCRIPTION
The API Context state is for use by VOL connectors that might not execute API calls in the order they were provided. It's used to save API Context State (e.g. property lists and a few other fields controlling the operation) and resume it later when the requested operation actually occurs at the VOL layer.

The API Context State is missing two property lists from the API Context - the FAPL and the DAPL. This seems to have occurred by accident because the the API Context State was created before property lists were added to the API Context, and not for any particular design reason. 

Storing the FAPL and DAPL on the Context State is more consistent, and should provide future asynchronous-like VOL Connectors with more flexible control. 

The API Context State struct itself isn't publicly exposed to applications, but VOL connectors use `H5VLretrieve_lib_state()`/`H5Vfree_lib_state()`, which return and free the API Context State in an untyped buffer. This buffer shouldn't be introspected or modified at all by the VOL itself, so this isn't an API change.