### PR TITLE
Remove ``-lm -ldl`` from hdf5.pc on macOS

### DIFF
--- a/config/cmake/ConfigureChecks.cmake
+++ b/config/cmake/ConfigureChecks.cmake
@@ -148,8 +148,15 @@ endif ()
 #  Check for the math library "m"
 #-----------------------------------------------------------------------------
 if (MINGW OR NOT WINDOWS)
-  CHECK_LIBRARY_EXISTS_CONCAT ("m" ceil     ${HDF_PREFIX}_HAVE_LIBM)
-  CHECK_LIBRARY_EXISTS_CONCAT ("dl" dlopen     ${HDF_PREFIX}_HAVE_LIBDL)
+  if (NOT "${CMAKE_SYSTEM_NAME}" STREQUAL "Darwin")
+    # the m and dl libraries haven't existed on macOS as discrete libraries
+    # for a number of macOS versions. For convenience, CMake seems to provide
+    # some magic that automatically these flags on macOS. This means that
+    # these checks don't give accurate results, which adversely impacts the
+    # contents of the pkg-config files
+    CHECK_LIBRARY_EXISTS_CONCAT ("m" ceil     ${HDF_PREFIX}_HAVE_LIBM)
+    CHECK_LIBRARY_EXISTS_CONCAT ("dl" dlopen     ${HDF_PREFIX}_HAVE_LIBDL)
+  endif()
   CHECK_LIBRARY_EXISTS_CONCAT ("ws2_32" WSAStartup  ${HDF_PREFIX}_HAVE_LIBWS2_32)
   CHECK_LIBRARY_EXISTS_CONCAT ("wsock32" gethostbyname ${HDF_PREFIX}_HAVE_LIBWSOCK32)
 endif ()


### PR DESCRIPTION
Motivation
----------

Prior to this commit, the Libs.private entry within hdf5.pc contain the ``-lm`` and ``-ldl`` flags on macOS. Becuase macOS (for at least a number of recent releases) doesn't specify actually contain these libraries, this means that passing the flags produced by

   ``pkg-config --static --libs hdf5``

will produce linker errors on macOS. The contents of these particular libraries are instead all consolidated within a single system library.

The Solution
------------

It turns out that this issue originates from some "magic" that CMake does to removes these flags from all calls to the linker on macOS. This "magic" seems to cause the built-in logic for checking for the existence of these libraries to falsely report that the libraries exist on macOS. These false positives propagate to the contents of the contents of hdf5.pc. At the same time, this same "magic" seems to prevent linker-errors during the actual compilation of hdf5.

Concerns
--------

I think that much older versions of macOS may have actually provided the "m" and "dl" libraries. If that is the case, then my fix may break builds on these versions of macOS...

I'm not really sure when/if this transition occurred and I don't know how to figure this out. If this is a serious concern, I could try to figure this out. (With that said, I don't have a ton of bandwidth for this. If there isn't an easy answer, we might just need to close this PR)