### PR TITLE
Removed h5test.* from the C++ test

### DIFF
--- a/c++/test/CMakeLists.txt
+++ b/c++/test/CMakeLists.txt
@@ -38,7 +38,7 @@ set (srcdir ${CMAKE_CURRENT_SOURCE_DIR})
 configure_file (${HDF5_CPP_TEST_SOURCE_DIR}/H5srcdir_str.h.in H5srcdir_str.h  @ONLY)
 
 add_executable (cpp_testhdf5 ${CPP_TEST_SOURCES} ${HDF5_CPP_TEST_SOURCE_DIR}/h5cpputil.h)
-target_include_directories (cpp_testhdf5 PRIVATE "${HDF5_SRC_INCLUDE_DIRS};${HDF5_SRC_BINARY_DIR};${H5_TOOLS_LIB_SOURCES};$<$<BOOL:${HDF5_ENABLE_PARALLEL}>:${MPI_C_INCLUDE_DIRS}>")
+target_include_directories (cpp_testhdf5 PRIVATE "${HDF5_SRC_INCLUDE_DIRS};${HDF5_SRC_BINARY_DIR};${HDF5_CPP_TEST_BINARY_DIR};${HDF5_TOOLS_LIB_SOURCE_DIR};$<$<BOOL:${HDF5_ENABLE_PARALLEL}>:${MPI_C_INCLUDE_DIRS}>")
 target_compile_options(cpp_testhdf5 PRIVATE "${HDF5_CMAKE_CXX_FLAGS}")
 target_compile_definitions(cpp_testhdf5
     PRIVATE "$<$<BOOL:${HDF5_ENABLE_PARALLEL}>:MPICH_SKIP_MPICXX;MPICH_IGNORE_CXX_SEEK>"# Parallel/MPI, prevent spurious cpp/cxx warnings
@@ -48,7 +48,7 @@ if (NOT BUILD_SHARED_LIBS)
   target_link_libraries (cpp_testhdf5 PRIVATE ${HDF5_CPP_LIB_TARGET} ${HDF5_LIB_TARGET} ${HDF5_TOOLS_LIB_TARGET})
 else ()
   TARGET_C_PROPERTIES (cpp_testhdf5 SHARED)
-  target_link_libraries (cpp_testhdf5 PRIVATE ${HDF5_CPP_LIBSH_TARGET} ${HDF5_LIBSH_TARGET} ${HDF5_TOOLS_LIB_TARGET})
+  target_link_libraries (cpp_testhdf5 PRIVATE ${HDF5_CPP_LIBSH_TARGET} ${HDF5_LIBSH_TARGET} ${HDF5_TOOLS_LIBSH_TARGET})
   if (MINGW AND HDF5_MINGW_STATIC_GCC_LIBS)
     target_link_options (${HDF5_CPP_LIBSH_TARGET}
         PRIVATE -static-libgcc -static-libstdc++

--- a/c++/test/CMakeLists.txt
+++ b/c++/test/CMakeLists.txt
@@ -38,17 +38,17 @@ set (srcdir ${CMAKE_CURRENT_SOURCE_DIR})
 configure_file (${HDF5_CPP_TEST_SOURCE_DIR}/H5srcdir_str.h.in H5srcdir_str.h  @ONLY)
 
 add_executable (cpp_testhdf5 ${CPP_TEST_SOURCES} ${HDF5_CPP_TEST_SOURCE_DIR}/h5cpputil.h)
-target_include_directories (cpp_testhdf5 PRIVATE "${HDF5_SRC_INCLUDE_DIRS};${HDF5_SRC_BINARY_DIR};${HDF5_TEST_BINARY_DIR};$<$<BOOL:${HDF5_ENABLE_PARALLEL}>:${MPI_C_INCLUDE_DIRS}>")
+target_include_directories (cpp_testhdf5 PRIVATE "${HDF5_SRC_INCLUDE_DIRS};${HDF5_SRC_BINARY_DIR};${H5_TOOLS_LIB_SOURCES};$<$<BOOL:${HDF5_ENABLE_PARALLEL}>:${MPI_C_INCLUDE_DIRS}>")
 target_compile_options(cpp_testhdf5 PRIVATE "${HDF5_CMAKE_CXX_FLAGS}")
 target_compile_definitions(cpp_testhdf5
     PRIVATE "$<$<BOOL:${HDF5_ENABLE_PARALLEL}>:MPICH_SKIP_MPICXX;MPICH_IGNORE_CXX_SEEK>"# Parallel/MPI, prevent spurious cpp/cxx warnings
 )
 if (NOT BUILD_SHARED_LIBS)
   TARGET_C_PROPERTIES (cpp_testhdf5 STATIC)
-  target_link_libraries (cpp_testhdf5 PRIVATE ${HDF5_CPP_LIB_TARGET} ${HDF5_LIB_TARGET} ${HDF5_TEST_LIB_TARGET})
+  target_link_libraries (cpp_testhdf5 PRIVATE ${HDF5_CPP_LIB_TARGET} ${HDF5_LIB_TARGET} ${HDF5_TOOLS_LIB_TARGET})
 else ()
   TARGET_C_PROPERTIES (cpp_testhdf5 SHARED)
-  target_link_libraries (cpp_testhdf5 PRIVATE ${HDF5_CPP_LIBSH_TARGET} ${HDF5_LIBSH_TARGET} ${HDF5_TEST_LIBSH_TARGET})
+  target_link_libraries (cpp_testhdf5 PRIVATE ${HDF5_CPP_LIBSH_TARGET} ${HDF5_LIBSH_TARGET} ${HDF5_TOOLS_LIB_TARGET})
   if (MINGW AND HDF5_MINGW_STATIC_GCC_LIBS)
     target_link_options (${HDF5_CPP_LIBSH_TARGET}
         PRIVATE -static-libgcc -static-libstdc++

--- a/c++/test/Makefile.am
+++ b/c++/test/Makefile.am
@@ -18,7 +18,8 @@
 include $(top_srcdir)/config/commence.am
 
 # Include src, test, and c++/src directories
-AM_CPPFLAGS+=-I$(top_srcdir)/src -I$(top_srcdir)/test -I$(top_srcdir)/c++/src
+# AM_CPPFLAGS+=-I$(top_srcdir)/src -I$(top_srcdir)/tools/lib -I$(top_srcdir)/c++/src
+AM_CPPFLAGS+=-I$(top_srcdir)/tools/lib -I$(top_srcdir)/c++/src -I$(top_srcdir)/src
 
 # These are our main targets.  They should be listed in the order to be
 # executed, generally most specific tests to least specific tests.
@@ -26,7 +27,7 @@ TEST_PROG=testhdf5
 check_PROGRAMS=$(TEST_PROG)
 
 # The tests depend on the hdf5 library, test library, and the c++ library
-LDADD=$(LIBH5TEST) $(LIBH5CPP) $(LIBHDF5)
+LDADD=$(LIBH5TOOLS) $(LIBH5CPP) $(LIBHDF5)
 
 testhdf5_SOURCES=testhdf5.cpp dsets.cpp tattr.cpp tarray.cpp	\
 	tcompound.cpp tdspl.cpp tfile.cpp tfilter.cpp th5s.cpp	\

--- a/c++/test/Makefile.am
+++ b/c++/test/Makefile.am
@@ -18,7 +18,6 @@
 include $(top_srcdir)/config/commence.am
 
 # Include src, test, and c++/src directories
-# AM_CPPFLAGS+=-I$(top_srcdir)/src -I$(top_srcdir)/tools/lib -I$(top_srcdir)/c++/src
 AM_CPPFLAGS+=-I$(top_srcdir)/tools/lib -I$(top_srcdir)/c++/src -I$(top_srcdir)/src
 
 # These are our main targets.  They should be listed in the order to be

--- a/c++/test/dsets.cpp
+++ b/c++/test/dsets.cpp
@@ -112,7 +112,8 @@ test_create(H5File &file)
         // Get and verify the comment from this dataset, using
         // H5std_string getComment(const H5std_string& name, <buf_size=0, by default>)
         H5std_string comment = file.getComment(DSET_DEFAULT_NAME);
-        verify_val(comment.c_str(), "This is a dataset", "DataSet::getComment", __LINE__, __FILE__, "comment");
+        verify_val(comment.c_str(), "This is a dataset", "DataSet::getComment", __LINE__, __FILE__,
+                   "comment");
 
         // Close the dataset when accessing is completed
         delete dataset;
@@ -1093,7 +1094,8 @@ test_getnativeinfo(H5File &file)
         H5O_native_info_t ninfo;
         memset(&ninfo, 0, sizeof(ninfo));
         dataset.getNativeObjinfo(ninfo, H5O_NATIVE_INFO_HDR);
-        verify_val(static_cast<long>(ninfo.hdr.nchunks), 1, "DataSet::getNativeObjinfo", __LINE__, __FILE__, "nchunks");
+        verify_val(static_cast<long>(ninfo.hdr.nchunks), 1, "DataSet::getNativeObjinfo", __LINE__, __FILE__,
+                   "nchunks");
         dataset.close();
 
         // Open the dataset we created above and then close it.  This is one
@@ -1101,7 +1103,8 @@ test_getnativeinfo(H5File &file)
         dataset = file.openDataSet(DSET_DEFAULT_NAME);
         memset(&ninfo, 0, sizeof(ninfo));
         dataset.getNativeObjinfo(ninfo, H5O_NATIVE_INFO_ALL);
-        verify_val(static_cast<long>(ninfo.hdr.nchunks), 1, "DataSet::getNativeObjinfo", __LINE__, __FILE__, "nchunks");
+        verify_val(static_cast<long>(ninfo.hdr.nchunks), 1, "DataSet::getNativeObjinfo", __LINE__, __FILE__,
+                   "nchunks");
         dataset.close();
 
         PASSED();
@@ -1159,7 +1162,8 @@ test_chunk_cache(const FileAccPropList &fapl)
         // Set a link access property on dapl to verify property list inheritance
         dapl.setNumLinks(134);
         size_t nlinks = dapl.getNumLinks();
-        verify_val(static_cast<long>(nlinks), 134, "DSetAccPropList::getNumLinks", __LINE__, __FILE__, "nlinks");
+        verify_val(static_cast<long>(nlinks), 134, "DSetAccPropList::getNumLinks", __LINE__, __FILE__,
+                   "nlinks");
 
         // Make a copy of the external fapl
         FileAccPropList fapl_local(fapl);
@@ -1379,7 +1383,7 @@ test_read_string(H5File &file)
     try {
         const H5std_string  DATASET_NAME("test_read_string");
         const unsigned long NX           = 8;
-        const char          DS_DATA[NX]     = {'a', 0, 0, 0, 0, 0, 0, 'Z'};
+        const char          DS_DATA[NX]  = {'a', 0, 0, 0, 0, 0, 0, 'Z'};
         const H5std_string  EXPECTED_STR = H5std_string(DS_DATA, NX);
         H5std_string        str;
 
@@ -1454,8 +1458,8 @@ extern "C" void
 test_dset()
 {
     hid_t fapl_id;
-    fapl_id = h5tools_get_new_fapl(H5P_DEFAULT); // in tools/lib
-    int nerrors = 0;               // keep track of number of failures occur
+    fapl_id     = h5tools_get_new_fapl(H5P_DEFAULT); // in tools/lib
+    int nerrors = 0;                                 // keep track of number of failures occur
 
     try {
         // Use the file access template id to create a file access prop.

--- a/c++/test/h5cpputil.cpp
+++ b/c++/test/h5cpputil.cpp
@@ -31,10 +31,10 @@ using namespace H5;
 static char srcdir_path[1024];
 static char srcdir_testpath[1024];
 
-bool subst_for_superblock = false;
-size_t   n_tests_passed_g  = 0;
-size_t   n_tests_failed_g  = 0;
-size_t   n_tests_skipped_g  = 0;
+bool   subst_for_superblock = false;
+size_t n_tests_passed_g     = 0;
+size_t n_tests_failed_g     = 0;
+size_t n_tests_skipped_g    = 0;
 
 /*
  * Definitions for the testing structure.
@@ -54,11 +54,11 @@ typedef struct TestStruct {
 /*
  * Variables used by testing framework.
  */
-static int         num_errs                         = 0;         /* Total number of errors during testing */
-static int         Summary                          = 0;         /* Show test summary. Default is no. */
-static int         CleanUp                          = 1;         /* Do cleanup or not. Default is yes. */
-static const char *TestProgName                     = NULL;
-vector<TestStruct> TestList;                                     /* Array of tests */
+static int         num_errs     = 0; /* Total number of errors during testing */
+static int         Summary      = 0; /* Show test summary. Default is no. */
+static int         CleanUp      = 1; /* Do cleanup or not. Default is yes. */
+static const char *TestProgName = NULL;
+vector<TestStruct> TestList; /* Array of tests */
 
 /*-------------------------------------------------------------------------
  * Function:    MESSAGE
@@ -131,8 +131,8 @@ issue_fail_msg(const char *where, int line, const char *file_name, const char *m
 {
     cerr << endl;
     cerr << ">>> FAILED in " << where << " at line " << line << " in " << file_name << " - " << message
-    << endl
-    << endl;
+         << endl
+         << endl;
 }
 
 /*-------------------------------------------------------------------------
@@ -149,9 +149,9 @@ issue_fail_msg(const char *where, int line, const char *file_name, const char *f
 {
     cerr << endl;
     cerr << ">>> FAILED in " << where << ": " << func_name << endl
-             << "    at line " << line << " in " << file_name << endl
-             << "    C library detail: " << message << endl
-             << endl;
+         << "    at line " << line << " in " << file_name << endl
+         << "    C library detail: " << message << endl
+         << endl;
 }
 
 /*-------------------------------------------------------------------------
@@ -213,7 +213,8 @@ check_values(const char *value, const char *msg, int line, const char *file_name
  */
 void
 display_error(const char *msg, const char *where, int line, const char *file_name)
-{                                                                                                   cerr << endl;
+{
+    cerr << endl;
     cerr << "*** ERROR at line " << line << " in " << file_name << "::" << where << "(): " << msg << endl;
     IncTestNumErrs();
     throw TestFailedException(where, "");
@@ -230,13 +231,15 @@ display_error(const char *msg, const char *where, int line, const char *file_nam
  *-------------------------------------------------------------------------
  */
 void
-verify_val(const char *x, const char *value, const char *where, int line, const char *file_name, const char *var)
+verify_val(const char *x, const char *value, const char *where, int line, const char *file_name,
+           const char *var)
 {
-   /* cerr << endl << "this verify_val const char *x and const char *value" << endl;
- */ 
+    /* cerr << endl << "this verify_val const char *x and const char *value" << endl;
+     */
     if (strcmp(x, value) != 0) {
         cerr << endl;
-        cerr << "*** UNEXPECTED VALUE at line " << line << " from " << file_name << "::" << where << "(): " << var << " should be " << value << endl;
+        cerr << "*** UNEXPECTED VALUE at line " << line << " from " << file_name << "::" << where
+             << "(): " << var << " should be " << value << endl;
         // IncTestNumErrs();
         throw TestFailedException(where, "");
     }
@@ -252,10 +255,11 @@ verify_val(const char *x, const char *value, const char *where, int line, const 
  *-------------------------------------------------------------------------
  */
 void
-verify_val(const H5std_string& x, const H5std_string& value, const char *where, int line, const char *file_name, const char *var)
+verify_val(const H5std_string &x, const H5std_string &value, const char *where, int line,
+           const char *file_name, const char *var)
 {
-   /* cerr << endl << "this verify_val const H5std_string& x and const H5std_string& value" << endl;
- */ 
+    /* cerr << endl << "this verify_val const H5std_string& x and const H5std_string& value" << endl;
+     */
     verify_val(x.c_str(), value.c_str(), where, line, file_name, var);
 }
 
@@ -329,7 +333,7 @@ AddTest(const char *TheName, void (*TheCall)(void), void (*Cleanup)(void), const
     }
 
     struct TestStruct aTest;
- 
+
     /* Set up test function */
     strcpy(aTest.Description, TheDescr);
     if (*TheName != '-') {
@@ -340,9 +344,9 @@ AddTest(const char *TheName, void (*TheCall)(void), void (*Cleanup)(void), const
         strcpy(aTest.Name, TheName + 1);
         aTest.SkipFlag = 1;
     }
-    aTest.Call       = TheCall;
-    aTest.Cleanup    = Cleanup;
-    aTest.NumErrors  = -1;
+    aTest.Call      = TheCall;
+    aTest.Cleanup   = Cleanup;
+    aTest.NumErrors = -1;
 
     // Insertion of an element using push_back()
     TestList.push_back(aTest);
@@ -365,9 +369,13 @@ TestUsage(void)
     cerr << "help      print out this information" << endl;
     cerr << endl << endl;
     cerr << "This program currently tests the following:" << endl << endl;
-    cerr << "Name" << "    " << "Description" << endl;
-    cerr << "----" << "    " << "-----------" << endl;
-    for (auto& aTest : TestList)
+    cerr << "Name"
+         << "    "
+         << "Description" << endl;
+    cerr << "----"
+         << "    "
+         << "-----------" << endl;
+    for (auto &aTest : TestList)
         cerr << aTest.Name << " -- " << aTest.Description << endl;
     cerr << endl;
 }
@@ -421,7 +429,7 @@ TestParseCmdLine(int argc, char *argv[])
 void
 PerformTests(void)
 {
-    for (auto& aTest : TestList) {
+    for (auto &aTest : TestList) {
         if (aTest.SkipFlag) {
             MESSAGE("Skipping", aTest.Description, aTest.Name);
         }
@@ -455,7 +463,7 @@ TestSummary(void)
     cerr << "Name of Test     Errors Description of Test" << endl;
     cerr << "---------------- ------ --------------------------------------" << endl;
 
-    for (auto& aTest : TestList) {
+    for (auto &aTest : TestList) {
         if (aTest.NumErrors == -1)
             cerr << aTest.Name << "N/A" << aTest.Description << endl;
         else {
@@ -474,7 +482,7 @@ TestCleanup(void)
     MESSAGE(("\nCleaning Up temp files...\n\n"));
 
     /* call individual cleanup routines in each source module */
-    for (auto& aTest : TestList)
+    for (auto &aTest : TestList)
         if (!aTest.SkipFlag && aTest.Cleanup != NULL)
             aTest.Cleanup();
 }
@@ -593,17 +601,17 @@ h5cpp_fixname(const char *base_name, hid_t fapl, char *fullname, size_t size)
 
     /* Check HDF5_NOCLEANUP environment setting. */
     if (getenv(HDF5_NOCLEANUP))
-            SetTestNoCleanup();
+        SetTestNoCleanup();
 
     /* Check what prefix to use for test files. Process HDF5_PREFIX. */
     /*
      * First use the environment variable, then try the constant
      */
-        prefix = getenv("HDF5_PREFIX");
+    prefix = getenv("HDF5_PREFIX");
 
 #ifdef HDF5_PREFIX
-        if (!prefix)
-            prefix = HDF5_PREFIX;
+    if (!prefix)
+        prefix = HDF5_PREFIX;
 #endif /* HDF5_PREFIX */
 
     /* Prepend the prefix value to the base name */
@@ -625,7 +633,7 @@ h5cpp_fixname(const char *base_name, hid_t fapl, char *fullname, size_t size)
                 memset(&buf, 0, sizeof(h5_stat_t));
                 if (HDstat(fullname, &buf) < 0)
                     /* The directory doesn't exist just yet */
-                    if (HDmkdir(fullname, static_cast<mode_t> (0755)) < 0 && errno != EEXIST)
+                    if (HDmkdir(fullname, static_cast<mode_t>(0755)) < 0 && errno != EEXIST)
                         /*
                          * We couldn't make the "/tmp/${USER,LOGIN}"
                          * subdirectory.  Default to PREFIX's original
@@ -642,7 +650,7 @@ h5cpp_fixname(const char *base_name, hid_t fapl, char *fullname, size_t size)
             }
         }
         else {
-            if (snprintf(fullname, size, "%s/%s", prefix, base_name) == static_cast<int> (size))
+            if (snprintf(fullname, size, "%s/%s", prefix, base_name) == static_cast<int>(size))
                 /* Buffer is too small */
                 return NULL;
         }
@@ -714,10 +722,10 @@ TestAlarmOn(void)
 
     /* Get the alarm value from the environment variable, if set */
     if (env_val != NULL)
-        alarm_sec = static_cast<unsigned> (strtoul(env_val, (char **)NULL, 10));
+        alarm_sec = static_cast<unsigned>(strtoul(env_val, (char **)NULL, 10));
 
     /* Set the number of seconds before alarm goes off */
-    alarm(static_cast<unsigned> (alarm_sec));
+    alarm(static_cast<unsigned>(alarm_sec));
 #endif
 }
 
@@ -789,4 +797,3 @@ h5cpp_get_srcdir_filename(const char *filename)
     /* If not enough space, just return NULL */
     return NULL;
 } /* end h5cpp_get_srcdir_filename() */
-

--- a/c++/test/h5cpputil.cpp
+++ b/c++/test/h5cpputil.cpp
@@ -19,15 +19,75 @@
  ***************************************************************************/
 
 #include <iostream>
-using std::cerr;
-using std::endl;
-
+#include <vector>
 #include <string>
+using namespace std;
+
 #include "H5Cpp.h" // C++ API header file
 using namespace H5;
 
-#include "h5test.h"
 #include "h5cpputil.h" // C++ utilility header file
+#include "H5srcdir_str.h"
+static char srcdir_path[1024];
+static char srcdir_testpath[1024];
+
+bool subst_for_superblock = false;
+size_t   n_tests_passed_g  = 0;
+size_t   n_tests_failed_g  = 0;
+size_t   n_tests_skipped_g  = 0;
+
+/*
+ * Definitions for the testing structure.
+ */
+#define MAXTESTNAME 16
+#define MAXTESTDESC 64
+
+typedef struct TestStruct {
+    int  NumErrors;
+    char Description[MAXTESTDESC];
+    int  SkipFlag;
+    char Name[MAXTESTNAME];
+    void (*Call)(void);
+    void (*Cleanup)(void);
+} TestStruct;
+
+/*
+ * Variables used by testing framework.
+ */
+static int         num_errs                         = 0;         /* Total number of errors during testing */
+static int         Summary                          = 0;         /* Show test summary. Default is no. */
+static int         CleanUp                          = 1;         /* Do cleanup or not. Default is yes. */
+static const char *TestProgName                     = NULL;
+vector<TestStruct> TestList;                                     /* Array of tests */
+
+/*-------------------------------------------------------------------------
+ * Function:    MESSAGE
+ *
+ * Purpose      Prints out the number of errors for the tests indicated
+ *              by 'testname,' if there were any failures occurred.  If
+ *              no failure, MESSAGE prints out the tests passed message.
+ *
+ * Return       if any failure has occurred: 1
+ *
+ *              if no failure occurs: 0
+ *-------------------------------------------------------------------------
+ */
+void
+MESSAGE(int nerrors)
+{
+    cerr << "There were " << nerrors << " errors detected." << endl;
+    cerr << endl;
+}
+void
+MESSAGE(const char *msg)
+{
+    cerr << msg << endl;
+}
+void
+MESSAGE(const char *msg, const char *desc, const char *name)
+{
+    cerr << msg << " -- " << desc << "(" << name << ")" << endl;
+}
 
 /*-------------------------------------------------------------------------
  * Function:    test_report
@@ -69,18 +129,17 @@ test_report(int nerrors, const H5std_string &testname)
 void
 issue_fail_msg(const char *where, int line, const char *file_name, const char *message)
 {
-    if (GetTestVerbosity() >= VERBO_HI) {
-        cerr << endl;
-        cerr << ">>> FAILED in " << where << " at line " << line << " in " << file_name << " - " << message
-             << endl
-             << endl;
-    }
+    cerr << endl;
+    cerr << ">>> FAILED in " << where << " at line " << line << " in " << file_name << " - " << message
+    << endl
+    << endl;
 }
 
 /*-------------------------------------------------------------------------
  * Function:    issue_fail_msg
  *
- * Purpose      Displays that a function has failed with its location.
+ * Purpose      Displays that a function has failed with its location, including
+ *              the function name.
  *
  * Return       None
  *-------------------------------------------------------------------------
@@ -88,13 +147,11 @@ issue_fail_msg(const char *where, int line, const char *file_name, const char *m
 void
 issue_fail_msg(const char *where, int line, const char *file_name, const char *func_name, const char *message)
 {
-    if (GetTestVerbosity() >= VERBO_HI) {
-        cerr << endl;
-        cerr << ">>> FAILED in " << where << ": " << func_name << endl
+    cerr << endl;
+    cerr << ">>> FAILED in " << where << ": " << func_name << endl
              << "    at line " << line << " in " << file_name << endl
              << "    C library detail: " << message << endl
              << endl;
-    }
 }
 
 /*-------------------------------------------------------------------------
@@ -147,32 +204,59 @@ check_values(const char *value, const char *msg, int line, const char *file_name
 }
 
 /*-------------------------------------------------------------------------
+ * Function:    display_error
+ *
+ * Purpose      Displays a error's message and its location.
+ *
+ * Return       None
+ *-------------------------------------------------------------------------
+ */
+void
+display_error(const char *msg, const char *where, int line, const char *file_name)
+{                                                                                                   cerr << endl;
+    cerr << "*** ERROR at line " << line << " in " << file_name << "::" << where << "(): " << msg << endl;
+    IncTestNumErrs();
+    throw TestFailedException(where, "");
+}
+
+/*-------------------------------------------------------------------------
  * Function:    verify_val (const char*, const char*,...)
  *
  * Purpose      Compares two character strings.  If they are
  *              different, the function will print out a message and the
  *              different values.
  *
- * Return       Success: 0
- *
- *              Failure: -1
+ * Return       None
  *-------------------------------------------------------------------------
  */
 void
-verify_val(const char *x, const char *value, const char *where, int line, const char *file_name)
+verify_val(const char *x, const char *value, const char *where, int line, const char *file_name, const char *var)
 {
-    if (GetTestVerbosity() >= VERBO_HI) {
-        cerr << endl;
-        cerr << "   Call to routine: " << where << " at line " << line << " in " << file_name << " had value "
-             << x << endl;
-    }
+   /* cerr << endl << "this verify_val const char *x and const char *value" << endl;
+ */ 
     if (strcmp(x, value) != 0) {
         cerr << endl;
-        cerr << "*** UNEXPECTED VALUE from " << where << " should be " << value << ", but is " << x
-             << " at line " << line << " in " << file_name << endl;
+        cerr << "*** UNEXPECTED VALUE at line " << line << " from " << file_name << "::" << where << "(): " << var << " should be " << value << endl;
         // IncTestNumErrs();
         throw TestFailedException(where, "");
     }
+}
+
+/*-------------------------------------------------------------------------
+ * Function:    verify_val (const string&, const string&,...)
+ *
+ * Purpose      Compares two strings.  If they are different, the
+ *              function will print out a message and the different values.
+ *
+ * Return       None
+ *-------------------------------------------------------------------------
+ */
+void
+verify_val(const H5std_string& x, const H5std_string& value, const char *where, int line, const char *file_name, const char *var)
+{
+   /* cerr << endl << "this verify_val const H5std_string& x and const H5std_string& value" << endl;
+ */ 
+    verify_val(x.c_str(), value.c_str(), where, line, file_name, var);
 }
 
 //--------------------------------------------------------------------------
@@ -218,3 +302,491 @@ TestFailedException::TestFailedException(const H5std_string &func, const H5std_s
     : Exception(func, message)
 {
 }
+
+/*
+ * Setup a test function and add it to the list of tests.
+ *      It must have no parameters and returns void.
+ * TheName--short test name.
+ *    If the name starts with '-', do not run it by default.
+ * TheCall--the test routine.
+ * Cleanup--the cleanup routine for the test.
+ * TheDescr--Long description of the test.
+ *    Since only the pointer is copied, the contents should not change.
+ * Return: Void
+ *    exit EXIT_FAILURE if error is encountered.
+ */
+void
+AddTest(const char *TheName, void (*TheCall)(void), void (*Cleanup)(void), const char *TheDescr)
+{
+    /* Sanity checking */
+    if (strlen(TheDescr) >= MAXTESTDESC) {
+        printf("Test description ('%s') too long, increase MAXTESTDESC(%d).\n", TheDescr, MAXTESTDESC);
+        exit(EXIT_FAILURE);
+    }
+    if (strlen(TheName) >= MAXTESTNAME) {
+        printf("Test name too long, increase MAXTESTNAME(%d).\n", MAXTESTNAME);
+        exit(EXIT_FAILURE);
+    }
+
+    struct TestStruct aTest;
+ 
+    /* Set up test function */
+    strcpy(aTest.Description, TheDescr);
+    if (*TheName != '-') {
+        strcpy(aTest.Name, TheName);
+        aTest.SkipFlag = 0;
+    }
+    else { /* skip test by default */
+        strcpy(aTest.Name, TheName + 1);
+        aTest.SkipFlag = 1;
+    }
+    aTest.Call       = TheCall;
+    aTest.Cleanup    = Cleanup;
+    aTest.NumErrors  = -1;
+
+    // Insertion of an element using push_back()
+    TestList.push_back(aTest);
+}
+
+/*
+ * Print test usage.
+ *    First print the common test options, then the extra options if provided.
+ */
+void
+TestUsage(void)
+{
+    cerr << "Usage: " << TestProgName << endl;
+    cerr << "              [-s[ummary]]" << endl;
+    cerr << "              [-c[leanoff]]" << endl;
+    cerr << "              [-h[elp]]" << endl;
+    cerr << endl << endl;
+    cerr << "summary   prints a summary of test results at the end" << endl;
+    cerr << "cleanoff  does not delete *.h5 files after execution of tests" << endl;
+    cerr << "help      print out this information" << endl;
+    cerr << endl << endl;
+    cerr << "This program currently tests the following:" << endl << endl;
+    cerr << "Name" << "    " << "Description" << endl;
+    cerr << "----" << "    " << "-----------" << endl;
+    for (auto& aTest : TestList)
+        cerr << aTest.Name << " -- " << aTest.Description << endl;
+    cerr << endl;
+}
+
+/*
+ * Print test info.
+ */
+void
+TestInfo(const char *ProgName)
+{
+    unsigned major, minor, release;
+
+    H5get_libversion(&major, &minor, &release);
+
+    cerr << "\nFor help use: " << ProgName << " -help\n" << endl;
+    cerr << "Linked with hdf5 version " << major << "." << minor << " release " << release << endl;
+}
+
+/*
+ * Parse command line information.
+ *      argc, argv: the usual command line argument count and strings
+ * The C++ test only has one argument: -h/-help
+ *
+ * Return: void
+ *    exit EXIT_FAILURE if error is encountered.
+ */
+void
+TestParseCmdLine(int argc, char *argv[])
+{
+    while ((void)argv++, --argc > 0) {
+        if ((strcmp(*argv, "-help") == 0) || (strcmp(*argv, "-h") == 0)) {
+            TestUsage();
+            exit(EXIT_SUCCESS);
+        }
+        else if ((strcmp(*argv, "-summary") == 0) || (strcmp(*argv, "-s") == 0))
+            Summary = 1;
+        else if (strcmp(*argv, "-enable-error-stack") == 0)
+            enable_error_stack = 1;
+        else if ((strcmp(*argv, "-cleanoff") == 0) || (strcmp(*argv, "-c") == 0))
+            SetTestNoCleanup();
+        else {
+            /* non-standard option.  Break out. */
+            break;
+        }
+    }
+}
+
+/*
+ * Perform Tests.
+ */
+void
+PerformTests(void)
+{
+    for (auto& aTest : TestList) {
+        if (aTest.SkipFlag) {
+            MESSAGE("Skipping", aTest.Description, aTest.Name);
+        }
+        else {
+            MESSAGE("Testing", aTest.Description, aTest.Name);
+            MESSAGE(("===============================================\n"));
+            aTest.NumErrors = num_errs;
+            TestAlarmOn();
+            aTest.Call();
+            TestAlarmOff();
+            aTest.NumErrors = num_errs - aTest.NumErrors;
+            MESSAGE(("===============================================\n"));
+            MESSAGE(aTest.NumErrors);
+        }
+    }
+
+    MESSAGE(("\n\n"));
+    if (num_errs)
+        cerr << "!!! " << static_cast<int>(num_errs) << " Error(s) were detected !!!" << endl << endl;
+    else
+        cerr << "All tests were successful." << endl << endl;
+}
+
+/*
+ * Display test summary.
+ */
+void
+TestSummary(void)
+{
+    cerr << "Summary of Test Results:" << endl;
+    cerr << "Name of Test     Errors Description of Test" << endl;
+    cerr << "---------------- ------ --------------------------------------" << endl;
+
+    for (auto& aTest : TestList) {
+        if (aTest.NumErrors == -1)
+            cerr << aTest.Name << "N/A" << aTest.Description << endl;
+        else {
+            cerr << aTest.Name << static_cast<int>(aTest.NumErrors) << aTest.Description << endl;
+        }
+    }
+    cerr << endl << endl;
+}
+
+/*
+ * Cleanup files from testing
+ */
+void
+TestCleanup(void)
+{
+    MESSAGE(("\nCleaning Up temp files...\n\n"));
+
+    /* call individual cleanup routines in each source module */
+    for (auto& aTest : TestList)
+        if (!aTest.SkipFlag && aTest.Cleanup != NULL)
+            aTest.Cleanup();
+}
+
+/*
+ * Retrieve Summary request value.
+ *     0 means no summary, 1 means yes.
+ */
+H5_ATTR_PURE int
+GetTestSummary(void)
+{
+    return (Summary);
+}
+
+/*
+ * Retrieve Cleanup request value.
+ *     0 means no Cleanup, 1 means yes.
+ */
+H5_ATTR_PURE int
+GetTestCleanup(void)
+{
+    return (CleanUp);
+}
+
+/*
+ * Set cleanup to no.
+ * Return previous cleanup value.
+ */
+int
+SetTestNoCleanup(void)
+{
+    int oldval;
+
+    oldval  = CleanUp;
+    CleanUp = 0;
+    return (oldval);
+}
+
+/*
+ * Retrieve the number of testing errors for the testing framework
+ */
+H5_ATTR_PURE int
+GetTestNumErrs(void)
+{
+    return (num_errs);
+}
+
+/*
+ * Increment the number of testing errors
+ */
+void
+IncTestNumErrs(void)
+{
+    num_errs++;
+}
+
+char *
+h5cpp_fixname(const char *base_name, hid_t fapl, char *fullname, size_t size)
+{
+    const char *prefix         = NULL;
+    const char *driver_env_var = NULL; /* HDF5_DRIVER/HDF5_TEST_DRIVER environment variable     */
+    char       *ptr, last = '\0';
+    const char *suffix = ".h5";
+    size_t      i, j;
+    hid_t       driver     = H5I_INVALID_HID;
+    bool        isppdriver = false; /* if the driver is MPI parallel */
+
+    if (!base_name || !fullname || size < 1)
+        return NULL;
+
+    memset(fullname, 0, size);
+
+    /* Determine if driver is set by environment variable. If it is,
+     * only generate a suffix if fixing the filename for the superblock
+     * file. */
+    driver_env_var = h5cpp_get_test_driver_name();
+    if (driver_env_var && (H5P_DEFAULT == fapl) && subst_for_superblock)
+        fapl = H5P_FILE_ACCESS_DEFAULT;
+
+    /* figure out the suffix */
+    if (H5P_DEFAULT != fapl) {
+        if ((driver = H5Pget_driver(fapl)) < 0)
+            return NULL;
+
+        if (suffix) {
+            if (H5FD_FAMILY == driver) {
+                if (subst_for_superblock)
+                    suffix = "-000000.h5";
+                else {
+                    suffix = "-%06d.h5";
+                }
+            }
+            else if (H5FD_MULTI == driver) {
+
+                /* Check the HDF5_DRIVER/HDF5_TEST_DRIVER environment
+                 * variable in case we are using the split driver since
+                 * both of those use the multi VFD under the hood.
+                 */
+                if (driver_env_var && !strcmp(driver_env_var, "split")) {
+                    /* split VFD */
+                    if (subst_for_superblock)
+                        suffix = ".h5.meta";
+                    else
+                        suffix = NULL;
+                }
+                else {
+                    /* multi VFD */
+                    if (subst_for_superblock)
+                        suffix = "-s.h5";
+                    else
+                        suffix = NULL;
+                }
+            }
+        }
+    }
+
+    /* Check HDF5_NOCLEANUP environment setting. */
+    if (getenv(HDF5_NOCLEANUP))
+            SetTestNoCleanup();
+
+    /* Check what prefix to use for test files. Process HDF5_PREFIX. */
+    /*
+     * First use the environment variable, then try the constant
+     */
+        prefix = getenv("HDF5_PREFIX");
+
+#ifdef HDF5_PREFIX
+        if (!prefix)
+            prefix = HDF5_PREFIX;
+#endif /* HDF5_PREFIX */
+
+    /* Prepend the prefix value to the base name */
+    if (prefix && *prefix) {
+        if (isppdriver) {
+            if (!fullname[0]) {
+                /* We didn't append the prefix yet */
+                strncpy(fullname, prefix, size);
+                fullname[size - 1] = '\0';
+            }
+
+            if (strlen(fullname) + strlen(base_name) + 1 < size) {
+                /*
+                 * Append the base_name with a slash first. Multiple
+                 * slashes are handled below.
+                 */
+                h5_stat_t buf;
+
+                memset(&buf, 0, sizeof(h5_stat_t));
+                if (HDstat(fullname, &buf) < 0)
+                    /* The directory doesn't exist just yet */
+                    if (HDmkdir(fullname, static_cast<mode_t> (0755)) < 0 && errno != EEXIST)
+                        /*
+                         * We couldn't make the "/tmp/${USER,LOGIN}"
+                         * subdirectory.  Default to PREFIX's original
+                         * prefix value.
+                         */
+                        strcpy(fullname, prefix);
+
+                strcat(fullname, "/");
+                strcat(fullname, base_name);
+            }
+            else {
+                /* Buffer is too small */
+                return NULL;
+            }
+        }
+        else {
+            if (snprintf(fullname, size, "%s/%s", prefix, base_name) == static_cast<int> (size))
+                /* Buffer is too small */
+                return NULL;
+        }
+    }
+    else if (strlen(base_name) >= size) {
+        /* Buffer is too small */
+        return NULL;
+    }
+    else {
+        strcpy(fullname, base_name);
+    }
+
+    /* Append a suffix */
+    if (suffix) {
+        if (strlen(fullname) + strlen(suffix) >= size)
+            return NULL;
+
+        strcat(fullname, suffix);
+    }
+
+    /* Remove any double slashes in the filename */
+    for (ptr = fullname, i = j = 0; ptr && i < size; i++, ptr++) {
+        if (*ptr != '/' || last != '/')
+            fullname[j++] = *ptr;
+
+        last = *ptr;
+    }
+
+    return fullname;
+}
+
+/*-------------------------------------------------------------------------
+ * Function:    h5cpp_get_test_driver_name
+ *
+ * Purpose:     Checks the HDF5_DRIVER and HDF5_TEST_DRIVER environment
+ *              variables to see if a driver name has been set for testing.
+ *
+ * Return:      Driver name if set/NULL otherwise
+ *
+ *-------------------------------------------------------------------------
+ */
+const char *
+h5cpp_get_test_driver_name(void)
+{
+    char *envval;
+
+    assert(H5_DEFAULT_VFD == H5FD_SEC2);
+
+    if ((envval = getenv(HDF5_DRIVER)))
+        return envval;
+    else if ((envval = getenv("HDF5_TEST_DRIVER")))
+        return envval;
+    else
+        return H5_DEFAULT_VFD_NAME;
+}
+
+/* Enable a test timer that will kill long-running tests, the time is configurable
+ * via an environment variable.
+ *
+ * Only useful on POSIX systems where alarm(2) is present. This does not include
+ * MinGW builds, which will often incorrectly decide that alarm(2) exists.
+ */
+void
+TestAlarmOn(void)
+{
+#ifdef H5_HAVE_ALARM
+    char         *env_val   = getenv("HDF5_ALARM_SECONDS"); /* Alarm environment */
+    unsigned long alarm_sec = H5_ALARM_SEC;                 /* Number of seconds before alarm goes off */
+
+    /* Get the alarm value from the environment variable, if set */
+    if (env_val != NULL)
+        alarm_sec = static_cast<unsigned> (strtoul(env_val, (char **)NULL, 10));
+
+    /* Set the number of seconds before alarm goes off */
+    alarm(static_cast<unsigned> (alarm_sec));
+#endif
+}
+
+/* Disable the test timer */
+void
+TestAlarmOff(void)
+{
+#ifdef H5_HAVE_ALARM
+    /* Set the number of seconds to zero */
+    alarm(0);
+#endif
+}
+
+/*-------------------------------------------------------------------------
+ * Function:    h5cpp_get_srcdir
+ *
+ * Purpose:     Just return the srcdir path
+ *
+ * Return:      The string
+ *
+ *-------------------------------------------------------------------------
+ */
+const char *
+h5cpp_get_srcdir(void)
+{
+    const char *srcdir = getenv("srcdir");
+
+    /* Check for using the srcdir from configure time */
+    if (NULL == srcdir)
+        srcdir = config_srcdir;
+
+    /* Build path to all test files */
+    if ((strlen(srcdir) + 2) < sizeof(srcdir_path)) {
+        snprintf(srcdir_path, sizeof(srcdir_path), "%s/", srcdir);
+        return (srcdir_path);
+    } /* end if */
+    else
+        return (NULL);
+} /* end h5cpp_get_srcdir() */
+
+/*-------------------------------------------------------------------------
+ * Function:    h5cpp_get_srcdir_filename
+ *
+ * Purpose:     Append the test file name to the srcdir path and return the whole string
+ *
+ * Return:      The string or NULL (errors or not enough space)
+ *
+ *-------------------------------------------------------------------------
+ */
+const char *
+h5cpp_get_srcdir_filename(const char *filename)
+{
+    const char *srcdir = h5cpp_get_srcdir();
+
+    /* Check for error */
+    if (NULL == srcdir)
+        return NULL;
+
+    /* Build path to test file. We're checking the length so suppress
+     * the gcc format-truncation warning.
+     */
+    if ((strlen(srcdir) + strlen("testfiles/") + strlen(filename) + 1) < sizeof(srcdir_testpath)) {
+        H5_GCC_DIAG_OFF("format-truncation")
+        snprintf(srcdir_testpath, sizeof(srcdir_testpath), "%s%s", srcdir, filename);
+        H5_GCC_DIAG_ON("format-truncation")
+        return srcdir_testpath;
+    }
+
+    /* If not enough space, just return NULL */
+    return NULL;
+} /* end h5cpp_get_srcdir_filename() */
+

--- a/c++/test/h5cpputil.cpp
+++ b/c++/test/h5cpputil.cpp
@@ -234,8 +234,6 @@ void
 verify_val(const char *x, const char *value, const char *where, int line, const char *file_name,
            const char *var)
 {
-    /* cerr << endl << "this verify_val const char *x and const char *value" << endl;
-     */
     if (strcmp(x, value) != 0) {
         cerr << endl;
         cerr << "*** UNEXPECTED VALUE at line " << line << " from " << file_name << "::" << where
@@ -258,8 +256,6 @@ void
 verify_val(const H5std_string &x, const H5std_string &value, const char *where, int line,
            const char *file_name, const char *var)
 {
-    /* cerr << endl << "this verify_val const H5std_string& x and const H5std_string& value" << endl;
-     */
     verify_val(x.c_str(), value.c_str(), where, line, file_name, var);
 }
 
@@ -491,7 +487,7 @@ TestCleanup(void)
  * Retrieve Summary request value.
  *     0 means no summary, 1 means yes.
  */
-H5_ATTR_PURE int
+int
 GetTestSummary(void)
 {
     return (Summary);
@@ -501,7 +497,7 @@ GetTestSummary(void)
  * Retrieve Cleanup request value.
  *     0 means no Cleanup, 1 means yes.
  */
-H5_ATTR_PURE int
+int
 GetTestCleanup(void)
 {
     return (CleanUp);
@@ -524,7 +520,7 @@ SetTestNoCleanup(void)
 /*
  * Retrieve the number of testing errors for the testing framework
  */
-H5_ATTR_PURE int
+int
 GetTestNumErrs(void)
 {
     return (num_errs);

--- a/c++/test/h5cpputil.h
+++ b/c++/test/h5cpputil.h
@@ -131,6 +131,10 @@ void MESSAGE(int num);
 void MESSAGE(const char *msg);
 void MESSAGE(const char *msg, const char *desc, const char *name);
 
+// Verifies value against expected
+void verify_val(const char *x, const char *value, const char *where, int line, const char *file_name, const char *var);
+void verify_val(const H5std_string& x, const H5std_string& value, const char *where, int line, const char *file_name, const char *var);
+
 template <class Type1, class Type2>
 void
 verify_val(Type1 x, Type2 value, const char *where, int line, const char *file_name, const char *var)

--- a/c++/test/h5cpputil.h
+++ b/c++/test/h5cpputil.h
@@ -27,27 +27,26 @@ using namespace H5;
 using std::cerr;
 using std::endl;
 
-extern size_t   n_tests_passed_g;
-extern size_t   n_tests_failed_g;
-extern size_t   n_tests_skipped_g;
+extern size_t n_tests_passed_g;
+extern size_t n_tests_failed_g;
+extern size_t n_tests_skipped_g;
 
 /* Number of seconds to wait before killing a test (requires alarm(2)) */
 #define H5_ALARM_SEC 1200 /* default is 20 minutes */
 
 /* Routines for operating on the list of tests (for the "all in one" tests) */
-char       *h5cpp_fixname(const char *base_name, hid_t fapl, char *fullname, size_t size);
-void        TestUsage(void);
-void        AddTest(const char *TheName, void (*TheCall)(void), void (*Cleanup)(void),
-                               const char *TheDescr);
-void        TestInfo(const char *ProgName);
-void        TestParseCmdLine(int argc, char *argv[]);
-void        PerformTests(void);
-void        TestSummary(void);
-void        TestCleanup(void);
-void        TestShutdown(void);
- /* void        TestInit(const char *ProgName, void (*private_usage)(void),
-                                int (*private_parser)(int ac, char *av[]));
- */ 
+char *h5cpp_fixname(const char *base_name, hid_t fapl, char *fullname, size_t size);
+void  TestUsage(void);
+void  AddTest(const char *TheName, void (*TheCall)(void), void (*Cleanup)(void), const char *TheDescr);
+void  TestInfo(const char *ProgName);
+void  TestParseCmdLine(int argc, char *argv[]);
+void  PerformTests(void);
+void  TestSummary(void);
+void  TestCleanup(void);
+void  TestShutdown(void);
+/* void        TestInit(const char *ProgName, void (*private_usage)(void),
+                               int (*private_parser)(int ac, char *av[]));
+*/
 int         GetTestSummary(void);
 int         GetTestCleanup(void);
 int         SetTestNoCleanup(void);
@@ -56,7 +55,7 @@ int         SetTestExpress(int newval);
 int         GetTestNumErrs(void);
 void        IncTestNumErrs(void);
 const void *GetTestParameters(void);
-const char    *h5cpp_get_test_driver_name(void);
+const char *h5cpp_get_test_driver_name(void);
 void        TestAlarmOn(void);
 void        TestAlarmOff(void);
 
@@ -177,19 +176,21 @@ void MESSAGE(const char *msg);
 void MESSAGE(const char *msg, const char *desc, const char *name);
 
 // Verifies
-void verify_val(const char *x, const char *value, const char *where, int line, const char *file_name, const char *var);
-void verify_val(const H5std_string& x, const H5std_string& value, const char *where, int line, const char *file_name, const char *var);
+void verify_val(const char *x, const char *value, const char *where, int line, const char *file_name,
+                const char *var);
+void verify_val(const H5std_string &x, const H5std_string &value, const char *where, int line,
+                const char *file_name, const char *var);
 
 template <class Type1, class Type2>
 void
-verify_val(Type1 x, Type2 value, const char *where, int line, const char *file_name, const
- char *var)
+verify_val(Type1 x, Type2 value, const char *where, int line, const char *file_name, const char *var)
 {
-   /* cerr << endl << "verify_val template" << endl;
- */ 
+    /* cerr << endl << "verify_val template" << endl;
+     */
     if (x != value) {
         cerr << endl;
-        cerr << "*** UNEXPECTED VALUE at line " << line << " from" << file_name << "::" << where << "(): " << var << " should be <" << value << ">, but is <" << x << ">" << endl;
+        cerr << "*** UNEXPECTED VALUE at line " << line << " from" << file_name << "::" << where
+             << "(): " << var << " should be <" << value << ">, but is <" << x << ">" << endl;
         IncTestNumErrs();
         throw TestFailedException(where, "");
     }
@@ -201,7 +202,8 @@ verify_val_noteq(Type1 x, Type2 value, const char *where, int line, const char *
 {
     if (x == value) {
         cerr << endl;
-        cerr << "*** UNEXPECTED VALUE at line " << line << " from " << file_name << "::" << where << "(): " << var << " should not be " << value << endl;
+        cerr << "*** UNEXPECTED VALUE at line " << line << " from " << file_name << "::" << where
+             << "(): " << var << " should not be " << value << endl;
         IncTestNumErrs();
         throw TestFailedException(where, "");
     }
@@ -212,7 +214,8 @@ void
 display_difference(Type1 x, Type2 value, const char *where, int line, const char *file_name, const char *var)
 {
     cerr << endl;
-    cerr << "*** UNEXPECTED VALUE at line " << line << " from" << file_name << "::" << where << "(): " << var << " should be " << value << ", but is " << x << endl;
+    cerr << "*** UNEXPECTED VALUE at line " << line << " from" << file_name << "::" << where << "(): " << var
+         << " should be " << value << ", but is " << x << endl;
     IncTestNumErrs();
     throw TestFailedException(where, "");
 }
@@ -289,6 +292,5 @@ void cleanup_array(void);
 void cleanup_genprop(void);
 void cleanup_misc(void);
 */
-
 
 #endif

--- a/c++/test/h5cpputil.h
+++ b/c++/test/h5cpputil.h
@@ -45,9 +45,9 @@ class TestFailedException : public Exception {
  * Some are duplicated from h5test.*
  */
 
-extern size_t   n_tests_passed_g;
-extern size_t   n_tests_failed_g;
-extern size_t   n_tests_skipped_g;
+extern size_t n_tests_passed_g;
+extern size_t n_tests_failed_g;
+extern size_t n_tests_skipped_g;
 
 /* Number of seconds to wait before killing a test (requires alarm(2)) */
 #define H5_ALARM_SEC 1200 /* default is 20 minutes */
@@ -55,27 +55,26 @@ extern size_t   n_tests_skipped_g;
 /*
  * Various functions for operating on the list of tests
  */
-char       *h5cpp_fixname(const char *base_name, hid_t fapl, char *fullname, size_t size);
-void        TestUsage(void);
-void        AddTest(const char *TheName, void (*TheCall)(void), void (*Cleanup)(void),
-                               const char *TheDescr);
-void        TestInfo(const char *ProgName);
-void        TestParseCmdLine(int argc, char *argv[]);
-void        PerformTests(void);
-void        TestSummary(void);
-void        TestCleanup(void);
-int         GetTestSummary(void);
-int         GetTestCleanup(void);
-int         SetTestNoCleanup(void);
-int         GetTestExpress(void);
-int         SetTestExpress(int newval);
-int         GetTestNumErrs(void);
-void        IncTestNumErrs(void);
-void        TestAlarmOn(void);
-void        TestAlarmOff(void);
+char *h5cpp_fixname(const char *base_name, hid_t fapl, char *fullname, size_t size);
+void  TestUsage(void);
+void  AddTest(const char *TheName, void (*TheCall)(void), void (*Cleanup)(void), const char *TheDescr);
+void  TestInfo(const char *ProgName);
+void  TestParseCmdLine(int argc, char *argv[]);
+void  PerformTests(void);
+void  TestSummary(void);
+void  TestCleanup(void);
+int   GetTestSummary(void);
+int   GetTestCleanup(void);
+int   SetTestNoCleanup(void);
+int   GetTestExpress(void);
+int   SetTestExpress(int newval);
+int   GetTestNumErrs(void);
+void  IncTestNumErrs(void);
+void  TestAlarmOn(void);
+void  TestAlarmOff(void);
 
 /* Checks the HDF5_DRIVER and HDF5_TEST_DRIVER environment variables */
-const char    *h5cpp_get_test_driver_name(void);
+const char *h5cpp_get_test_driver_name(void);
 
 /* Return srcdir path */
 const char *h5cpp_get_srcdir(void);

--- a/c++/test/h5cpputil.h
+++ b/c++/test/h5cpputil.h
@@ -131,8 +131,10 @@ void MESSAGE(const char *msg);
 void MESSAGE(const char *msg, const char *desc, const char *name);
 
 // Verifies value against expected
-void verify_val(const char *x, const char *value, const char *where, int line, const char *file_name, const char *var);
-void verify_val(const H5std_string& x, const H5std_string& value, const char *where, int line, const char *file_name, const char *var);
+void verify_val(const char *x, const char *value, const char *where, int line, const char *file_name,
+                const char *var);
+void verify_val(const H5std_string &x, const H5std_string &value, const char *where, int line,
+                const char *file_name, const char *var);
 
 template <class Type1, class Type2>
 void

--- a/c++/test/tarray.cpp
+++ b/c++/test/tarray.cpp
@@ -31,7 +31,7 @@ const int          SPACE1_RANK = 1;
 const int          SPACE1_DIM1 = 4;
 const int          ARRAY1_RANK = 1;
 const int          ARRAY1_DIM1 = 4;
-const int          VAR_LEN = 80;
+const int          VAR_LEN     = 80;
 
 typedef enum flt_t { FLT_FLOAT, FLT_DOUBLE, FLT_LDOUBLE, FLT_OTHER } flt_t;
 
@@ -69,17 +69,17 @@ test_array_compound_array()
     s1_t        rdata[SPACE1_DIM1][ARRAY1_DIM1]; // Information read in
     hsize_t     sdims1[] = {SPACE1_DIM1};
     hsize_t     tdims1[] = {ARRAY1_DIM1};
-    int         nmemb;            // Number of compound members
-    int         i, j, k;          // counting variables
-    H5T_class_t mclass;           // Datatype class for field
+    int         nmemb;   // Number of compound members
+    int         i, j, k; // counting variables
+    H5T_class_t mclass;  // Datatype class for field
 
     // Initialize array data to write
     for (i = 0; i < SPACE1_DIM1; i++)
         for (j = 0; j < ARRAY1_DIM1; j++) {
             wdata[i][j].i = static_cast<int>(i * 10 + j);
             for (k = 0; k < ARRAY1_DIM1; k++) {
-                float temp = static_cast<float>(i) * 10.0F + static_cast<float>(j) * 2.5F +
-                             static_cast<float>(k);
+                float temp =
+                    static_cast<float>(i) * 10.0F + static_cast<float>(j) * 2.5F + static_cast<float>(k);
                 wdata[i][j].f[k] = temp;
             }
         } // end for
@@ -135,7 +135,8 @@ test_array_compound_array()
 
         // Get and verify the type's name
         H5std_string type_name = named_type.getObjName();
-        verify_val(type_name, ARRAYTYPE_NAME, "DataType::getObjName tests constructor", __LINE__, __FILE__, "type_name");
+        verify_val(type_name, ARRAYTYPE_NAME, "DataType::getObjName tests constructor", __LINE__, __FILE__,
+                   "type_name");
         named_type.close();
 
         // Close all
@@ -362,16 +363,16 @@ test_array_info()
     s1_t        wdata[SPACE1_DIM1][ARRAY1_DIM1]; // Information to write
     hsize_t     sdims1[] = {SPACE1_DIM1};
     hsize_t     tdims1[] = {ARRAY1_DIM1};
-    int         i, j, k;   // counting variables
-    H5T_class_t mclass;    // Datatype class for field
+    int         i, j, k; // counting variables
+    H5T_class_t mclass;  // Datatype class for field
 
     // Initialize array data to write
     for (i = 0; i < SPACE1_DIM1; i++)
         for (j = 0; j < ARRAY1_DIM1; j++) {
             wdata[i][j].i = static_cast<int>(i * 10 + j);
             for (k = 0; k < ARRAY1_DIM1; k++) {
-                float temp = static_cast<float>(i) * 10.0F + static_cast<float>(j) * 2.5F +
-                             static_cast<float>(k);
+                float temp =
+                    static_cast<float>(i) * 10.0F + static_cast<float>(j) * 2.5F + static_cast<float>(k);
                 wdata[i][j].f[k] = temp;
             }
         }

--- a/c++/test/tarray.cpp
+++ b/c++/test/tarray.cpp
@@ -23,15 +23,15 @@ using std::endl;
 #include "H5Cpp.h" // C++ API header file
 using namespace H5;
 
-#include "h5test.h"
 #include "h5cpputil.h" // C++ utilility header file
 
 const H5std_string FILENAME("tarray.h5");
 const H5std_string ARRAYTYPE_NAME("/Array type 1");
 const int          SPACE1_RANK = 1;
-const hsize_t      SPACE1_DIM1 = 4;
+const int          SPACE1_DIM1 = 4;
 const int          ARRAY1_RANK = 1;
-const hsize_t      ARRAY1_DIM1 = 4;
+const int          ARRAY1_DIM1 = 4;
+const int          VAR_LEN = 80;
 
 typedef enum flt_t { FLT_FLOAT, FLT_DOUBLE, FLT_LDOUBLE, FLT_OTHER } flt_t;
 
@@ -70,18 +70,17 @@ test_array_compound_array()
     hsize_t     sdims1[] = {SPACE1_DIM1};
     hsize_t     tdims1[] = {ARRAY1_DIM1};
     int         nmemb;            // Number of compound members
-    int         ii;               // counting variables
-    hsize_t     idxi, idxj, idxk; // dimension indicing variables
+    int         i, j, k;          // counting variables
     H5T_class_t mclass;           // Datatype class for field
 
     // Initialize array data to write
-    for (idxi = 0; idxi < SPACE1_DIM1; idxi++)
-        for (idxj = 0; idxj < ARRAY1_DIM1; idxj++) {
-            wdata[idxi][idxj].i = static_cast<int>(idxi * 10 + idxj);
-            for (idxk = 0; idxk < ARRAY1_DIM1; idxk++) {
-                float temp = static_cast<float>(idxi) * 10.0F + static_cast<float>(idxj) * 2.5F +
-                             static_cast<float>(idxk);
-                wdata[idxi][idxj].f[idxk] = temp;
+    for (i = 0; i < SPACE1_DIM1; i++)
+        for (j = 0; j < ARRAY1_DIM1; j++) {
+            wdata[i][j].i = static_cast<int>(i * 10 + j);
+            for (k = 0; k < ARRAY1_DIM1; k++) {
+                float temp = static_cast<float>(i) * 10.0F + static_cast<float>(j) * 2.5F +
+                             static_cast<float>(k);
+                wdata[i][j].f[k] = temp;
             }
         } // end for
 
@@ -136,7 +135,7 @@ test_array_compound_array()
 
         // Get and verify the type's name
         H5std_string type_name = named_type.getObjName();
-        verify_val(type_name, ARRAYTYPE_NAME, "DataType::getObjName tests constructor", __LINE__, __FILE__);
+        verify_val(type_name, ARRAYTYPE_NAME, "DataType::getObjName tests constructor", __LINE__, __FILE__, "type_name");
         named_type.close();
 
         // Close all
@@ -157,7 +156,7 @@ test_array_compound_array()
         // Verify that it is an array of compounds
         DataType dstype = dataset.getDataType();
         mclass          = dstype.getClass();
-        verify_val(mclass == H5T_ARRAY, true, "f2_type.getClass", __LINE__, __FILE__);
+        verify_val(mclass == H5T_ARRAY, true, "f2_type.getClass", __LINE__, __FILE__, "mclass");
 
         dstype.close();
 
@@ -166,39 +165,37 @@ test_array_compound_array()
 
         // Check the array rank
         int ndims = atype_check.getArrayNDims();
-        verify_val(ndims, ARRAY1_RANK, "atype_check.getArrayNDims", __LINE__, __FILE__);
+        verify_val(ndims, ARRAY1_RANK, "atype_check.getArrayNDims", __LINE__, __FILE__, "ndims");
 
         // Get the array dimensions
         hsize_t rdims1[H5S_MAX_RANK];
         atype_check.getArrayDims(rdims1);
 
         // Check the array dimensions
-        for (ii = 0; ii < ndims; ii++)
-            if (rdims1[ii] != tdims1[ii]) {
-                TestErrPrintf("Array dimension information doesn't match!, rdims1[%d]=%" PRIuHSIZE
-                              ", tdims1[%d]=%" PRIuHSIZE "\n",
-                              ii, rdims1[ii], ii, tdims1[ii]);
-                continue;
-            } // end if
+        for (i = 0; i < ndims; i++) {
+            char var[VAR_LEN];
+            sprintf(var, "rdims1[%d]", static_cast<int>(i));
+            verify_val(rdims1[i], tdims1[i], "atype_check.getArrayDims", __LINE__, __FILE__, var);
+            continue;
+        }
 
         // Test ArrayType::ArrayType(const hid_t existing_id)
         ArrayType new_arrtype(atype_check.getId());
 
         // Check the array rank
         ndims = new_arrtype.getArrayNDims();
-        verify_val(ndims, ARRAY1_RANK, "new_arrtype.getArrayNDims", __LINE__, __FILE__);
+        verify_val(ndims, ARRAY1_RANK, "new_arrtype.getArrayNDims", __LINE__, __FILE__, "ndims");
 
         // Get the array dimensions
         new_arrtype.getArrayDims(rdims1);
 
         // Check the array dimensions
-        for (ii = 0; ii < ndims; ii++)
-            if (rdims1[ii] != tdims1[ii]) {
-                TestErrPrintf("Array dimension information doesn't match!, rdims1[%d]=%" PRIuHSIZE
-                              ", tdims1[%d]=%" PRIuHSIZE "\n",
-                              ii, rdims1[ii], ii, tdims1[ii]);
-                continue;
-            } // end if
+        for (i = 0; i < ndims; i++) {
+            char var[VAR_LEN];
+            sprintf(var, "rdims1[%d]", static_cast<int>(i));
+            verify_val(rdims1[i], tdims1[i], "atype_check.getArrayDims", __LINE__, __FILE__, var);
+            continue;
+        }
 
         /*
          * Check the compound datatype and the array of floats datatype
@@ -208,7 +205,7 @@ test_array_compound_array()
         // array datatype atype_check.
         DataType base_type = atype_check.getSuper();
         mclass             = base_type.getClass();
-        verify_val(mclass == H5T_COMPOUND, true, "atype_check.getClass", __LINE__, __FILE__);
+        verify_val(mclass == H5T_COMPOUND, true, "atype_check.getClass", __LINE__, __FILE__, "mclass");
 
         // Verify the compound datatype info
         CompType ctype_check(base_type.getId());
@@ -216,19 +213,18 @@ test_array_compound_array()
 
         // Check the number of members
         nmemb = ctype_check.getNmembers();
-        verify_val(nmemb, 2, "ctype_check.getNmembers", __LINE__, __FILE__);
+        verify_val(nmemb, 2, "ctype_check.getNmembers", __LINE__, __FILE__, "nmemb");
 
         // Check the 2nd field's name
         H5std_string field2_name = ctype_check.getMemberName(1);
-        if (strcmp(field2_name.c_str(), "f") != 0)
-            TestErrPrintf("Compound field name doesn't match!, field2_name=%s\n", field2_name.c_str());
+        verify_val(field2_name.c_str(), "f", "ctype_check.getMemberName", __LINE__, __FILE__, "field2_name");
 
         // Get the 2nd field's datatype
         DataType f2_type = ctype_check.getMemberDataType(1);
 
         // Get the 2nd field's class, this 2nd field should have an array type
         mclass = f2_type.getClass();
-        verify_val(mclass == H5T_ARRAY, true, "f2_type.getClass", __LINE__, __FILE__);
+        verify_val(mclass == H5T_ARRAY, true, "f2_type.getClass", __LINE__, __FILE__, "mclass");
         f2_type.close();
 
         // Get the 2nd field, array of floats datatype, to check
@@ -236,20 +232,19 @@ test_array_compound_array()
 
         // Check the array rank
         ndims = f2_atype_check.getArrayNDims();
-        verify_val(ndims, ARRAY1_RANK, "f2_atype_check.getArrayNDims", __LINE__, __FILE__);
+        verify_val(ndims, ARRAY1_RANK, "f2_atype_check.getArrayNDims", __LINE__, __FILE__, "ndims");
 
         // Get the array dimensions
         memset(rdims1, 0, sizeof(rdims1));
         f2_atype_check.getArrayDims(rdims1);
 
         // Check the array dimensions
-        for (ii = 0; ii < ndims; ii++)
-            if (rdims1[ii] != tdims1[ii]) {
-                TestErrPrintf("Array dimension information doesn't match!, rdims1[%d]=%" PRIuHSIZE
-                              ", tdims1[%d]=%" PRIuHSIZE "\n",
-                              ii, rdims1[ii], ii, tdims1[ii]);
-                continue;
-            } // end if
+        for (i = 0; i < ndims; i++) {
+            char var[VAR_LEN];
+            sprintf(var, "rdims1[%d]", static_cast<int>(i));
+            verify_val(rdims1[i], tdims1[i], "atype_check.getArrayDims", __LINE__, __FILE__, var);
+            continue;
+        }
 
         // Close done datatypes
         f2_atype_check.close();
@@ -259,17 +254,13 @@ test_array_compound_array()
         dataset.read(rdata, atype_check);
 
         // Compare data read in
-        for (idxi = 0; idxi < SPACE1_DIM1; idxi++) {
-            for (idxj = 0; idxj < ARRAY1_DIM1; idxj++) {
-                if (wdata[idxi][idxj].i != rdata[idxi][idxj].i) {
-                    TestErrPrintf("Array data information doesn't match!, wdata[%" PRIuHSIZE "][%" PRIuHSIZE
-                                  "].i=%d, "
-                                  "rdata[%" PRIuHSIZE "][%" PRIuHSIZE "].i=%d\n",
-                                  idxi, idxj, wdata[idxi][idxj].i, idxi, idxj, rdata[idxi][idxj].i);
-                    continue;
-                } // end if
-            }     // end for
-        }         // end for
+        for (i = 0; i < SPACE1_DIM1; i++) {
+            for (j = 0; j < ARRAY1_DIM1; j++) {
+                char var[VAR_LEN];
+                sprintf(var, "rdata[%d][%d]", static_cast<int>(i), static_cast<int>(j));
+                verify_val(rdata[i][j].i, wdata[i][j].i, "dataset.read", __LINE__, __FILE__, var);
+            }
+        }
 
         // Close all
         atype_check.close();
@@ -371,18 +362,17 @@ test_array_info()
     s1_t        wdata[SPACE1_DIM1][ARRAY1_DIM1]; // Information to write
     hsize_t     sdims1[] = {SPACE1_DIM1};
     hsize_t     tdims1[] = {ARRAY1_DIM1};
-    int         ii;               // counting variables
-    hsize_t     idxi, idxj, idxk; // dimension indicing variables
-    H5T_class_t mclass;           // Datatype class for field
+    int         i, j, k;   // counting variables
+    H5T_class_t mclass;    // Datatype class for field
 
     // Initialize array data to write
-    for (idxi = 0; idxi < SPACE1_DIM1; idxi++)
-        for (idxj = 0; idxj < ARRAY1_DIM1; idxj++) {
-            wdata[idxi][idxj].i = static_cast<int>(idxi * 10 + idxj);
-            for (idxk = 0; idxk < ARRAY1_DIM1; idxk++) {
-                float temp = static_cast<float>(idxi) * 10.0F + static_cast<float>(idxj) * 2.5F +
-                             static_cast<float>(idxk);
-                wdata[idxi][idxj].f[idxk] = temp;
+    for (i = 0; i < SPACE1_DIM1; i++)
+        for (j = 0; j < ARRAY1_DIM1; j++) {
+            wdata[i][j].i = static_cast<int>(i * 10 + j);
+            for (k = 0; k < ARRAY1_DIM1; k++) {
+                float temp = static_cast<float>(i) * 10.0F + static_cast<float>(j) * 2.5F +
+                             static_cast<float>(k);
+                wdata[i][j].f[k] = temp;
             }
         }
 
@@ -431,7 +421,7 @@ test_array_info()
         // Verify that it is an array of compounds
         DataType dstype = dataset.getDataType();
         mclass          = dstype.getClass();
-        verify_val(mclass == H5T_ARRAY, true, "f2_type.getClass", __LINE__, __FILE__);
+        verify_val(mclass == H5T_ARRAY, true, "f2_type.getClass", __LINE__, __FILE__, "mclass");
 
         dstype.close();
 
@@ -441,20 +431,19 @@ test_array_info()
 
             // Check the array rank with the const method
             int ndims = atype_check.getArrayNDims();
-            verify_val(ndims, ARRAY1_RANK, "atype_check.getArrayNDims", __LINE__, __FILE__);
+            verify_val(ndims, ARRAY1_RANK, "atype_check.getArrayNDims", __LINE__, __FILE__, "ndims");
 
             // Get the array dimensions with the const method
             hsize_t rdims1[H5S_MAX_RANK];
             atype_check.getArrayDims(rdims1);
 
             // Check the array dimensions
-            for (ii = 0; ii < ndims; ii++)
-                if (rdims1[ii] != tdims1[ii]) {
-                    TestErrPrintf("Array dimension information doesn't match!, rdims1[%d]=%" PRIuHSIZE
-                                  ", tdims1[%d]=%" PRIuHSIZE "\n",
-                                  ii, rdims1[ii], ii, tdims1[ii]);
-                    continue;
-                }
+            for (i = 0; i < ndims; i++) {
+                char var[VAR_LEN];
+                sprintf(var, "rdims1[%d]", static_cast<int>(i));
+                verify_val(rdims1[i], tdims1[i], "atype_check.getArrayDims", __LINE__, __FILE__, var);
+                continue;
+            }
         }
 
         // Close all
@@ -479,9 +468,6 @@ test_array_info()
 extern "C" void
 test_array()
 {
-    // Output message about test being performed
-    MESSAGE(5, ("Testing Array Datatypes\n"));
-
     // Test array of compounds with array field
     test_array_compound_array();
 
@@ -504,5 +490,5 @@ test_array()
 extern "C" void
 cleanup_array()
 {
-    HDremove(FILENAME.c_str());
+    remove(FILENAME.c_str());
 } // cleanup_array

--- a/c++/test/tattr.cpp
+++ b/c++/test/tattr.cpp
@@ -36,13 +36,13 @@ const H5std_string FILE_DTYPE("tattr_dtype.h5");
 const H5std_string ATTR_TMP_NAME("temp_attr_name");
 const H5std_string FATTR_TMP_NAME("temp_fattr_name");
 const size_t       ATTR_MAX_DIMS = 7;
-const int          VAR_LEN = 80; /* Length of variable name */
+const int          VAR_LEN       = 80; /* Length of variable name */
 
 /* 3-D dataset with fixed dimensions */
-const int     SPACE1_RANK = 3;
-const int     SPACE1_DIM1 = 3;
-const int     SPACE1_DIM2 = 15;
-const int     SPACE1_DIM3 = 13;
+const int SPACE1_RANK = 3;
+const int SPACE1_DIM1 = 3;
+const int SPACE1_DIM2 = 15;
+const int SPACE1_DIM3 = 13;
 
 /* Object names */
 const H5std_string DSET1_NAME("Dataset1");
@@ -66,12 +66,12 @@ const int          ATTR2_DIM2          = 2;
 int attr_data2[ATTR2_DIM1][ATTR2_DIM2] = {{7614, -416}, {197814, -3}}; /* Test data for 2nd attribute */
 
 const H5std_string ATTR3_NAME("Attr3");
-const int          ATTR3_RANK          = 3;
-const int          ATTR3_DIM1          = 2;
-const int          ATTR3_DIM2          = 2;
-const int          ATTR3_DIM3          = 2;
+const int          ATTR3_RANK = 3;
+const int          ATTR3_DIM1 = 2;
+const int          ATTR3_DIM2 = 2;
+const int          ATTR3_DIM3 = 2;
 
-double             attr_data3[ATTR3_DIM1][ATTR3_DIM2][ATTR3_DIM3] = {
+double attr_data3[ATTR3_DIM1][ATTR3_DIM2][ATTR3_DIM3] = {
     {{2.3, -26.1}, {0.123, -10.0}}, {{981724.2, -0.91827}, {2.0, 23.0}}}; /* Test data for 3rd attribute */
 
 const H5std_string ATTR4_NAME("Attr4");
@@ -304,8 +304,8 @@ test_attr_getname(FileAccPropList &fapl)
         CHECK(name_size, FAIL, "Attribute::getName", __LINE__, __FILE__);
         verify_val(static_cast<size_t>(name_size), FATTR1_NAME.length(), "Attribute::getName", __LINE__,
                    __FILE__, "name_size");
-        verify_val(const_cast<const char *>(fattr1_name), const_cast<const char *>(FATTR1_NAME.c_str()), "Attribute::getName", __LINE__,
-                   __FILE__, "fattr1_name");
+        verify_val(const_cast<const char *>(fattr1_name), const_cast<const char *>(FATTR1_NAME.c_str()),
+                   "Attribute::getName", __LINE__, __FILE__, "fattr1_name");
         delete[] fattr1_name;
 
         // 2. With arbitrary buf_size that is smaller than the name's length.
@@ -534,7 +534,8 @@ test_attr_basic_read(FileAccPropList &fapl)
         H5O_info2_t oinfo;
         memset(&oinfo, 0, sizeof(oinfo));
         dataset.getObjinfo(oinfo, H5O_INFO_NUM_ATTRS);
-        verify_val(static_cast<long>(oinfo.num_attrs), 3, "DataSet::getObjinfo", __LINE__, __FILE__, "oinfo.num_attrs");
+        verify_val(static_cast<long>(oinfo.num_attrs), 3, "DataSet::getObjinfo", __LINE__, __FILE__,
+                   "oinfo.num_attrs");
 
         // Open an attribute for the dataset
         Attribute ds_attr = dataset.openAttribute(ATTR1_NAME);
@@ -563,7 +564,8 @@ test_attr_basic_read(FileAccPropList &fapl)
         // Verify the correct number of attributes another way
         memset(&oinfo, 0, sizeof(oinfo));
         group.getObjinfo(oinfo, H5O_INFO_NUM_ATTRS);
-        verify_val(static_cast<long>(oinfo.num_attrs), 1, "Group::getObjinfo", __LINE__, __FILE__, "oinfo.num_attrs");
+        verify_val(static_cast<long>(oinfo.num_attrs), 1, "Group::getObjinfo", __LINE__, __FILE__,
+                   "oinfo.num_attrs");
 
         // Open an attribute for the group
         Attribute gr_attr = group.openAttribute(ATTR2_NAME);
@@ -581,7 +583,7 @@ test_attr_basic_read(FileAccPropList &fapl)
                 sprintf(var, "read_data2[%d][%d]", i, j);
                 verify_val(read_data2[i][j], attr_data2[i][j], "Attribute::read", __LINE__, __FILE__, var);
             }
-        }                                                       
+        }
 
         PASSED();
     } // end try block
@@ -689,7 +691,8 @@ test_attr_compound_read(FileAccPropList &fapl)
         H5O_info2_t oinfo;
         memset(&oinfo, 0, sizeof(oinfo));
         dataset.getObjinfo(oinfo, H5O_INFO_NUM_ATTRS);
-        verify_val(static_cast<long>(oinfo.num_attrs), 1, "DataSet::getObjinfo", __LINE__, __FILE__, "oinfo.num_attrs");
+        verify_val(static_cast<long>(oinfo.num_attrs), 1, "DataSet::getObjinfo", __LINE__, __FILE__,
+                   "oinfo.num_attrs");
 
         // Open 1st attribute for the dataset
         Attribute attr = dataset.openAttribute(static_cast<unsigned>(0));
@@ -793,15 +796,18 @@ test_attr_compound_read(FileAccPropList &fapl)
                 if (memcmp(&attr_data4[i][j], &read_data4[i][j], sizeof(struct attr4_struct)) != 0) {
                     char var[VAR_LEN];
                     sprintf(var, "read_data4[%d][%d].%c", i, j, 'i');
-                    verify_val(read_data4[i][j].i, attr_data4[i][j].i, "Attribute::read", __LINE__, __FILE__, var);
+                    verify_val(read_data4[i][j].i, attr_data4[i][j].i, "Attribute::read", __LINE__, __FILE__,
+                               var);
 
                     sprintf(var, "read_data4[%d][%d].%c", i, j, 'd');
                     if (abs(read_data4[i][j].d - attr_data4[i][j].d) > DBL_EPSILON) {
-                        display_difference(read_data4[i][j].d, attr_data4[i][j].d, "DSetAccPropList::getChunkCache", __LINE__, __FILE__, "w0_1");
+                        display_difference(read_data4[i][j].d, attr_data4[i][j].d,
+                                           "DSetAccPropList::getChunkCache", __LINE__, __FILE__, "w0_1");
                     }
 
                     sprintf(var, "read_data4[%d][%d].%c", i, j, 'c');
-                    verify_val(read_data4[i][j].c, attr_data4[i][j].c, "Attribute::read", __LINE__, __FILE__, var);
+                    verify_val(read_data4[i][j].c, attr_data4[i][j].c, "Attribute::read", __LINE__, __FILE__,
+                               var);
                 }
 
         // Verify name
@@ -1031,10 +1037,10 @@ test_attr_mult_write(FileAccPropList &fapl)
 static void
 test_attr_mult_read(FileAccPropList &fapl)
 {
-    int     read_data1[ATTR1_DIM1]                         = {0};     // Buffer for reading 1st attribute
-    int     read_data2[ATTR2_DIM1][ATTR2_DIM2]             = {{0}};   // Buffer for reading 2nd attribute
-    double  read_data3[ATTR3_DIM1][ATTR3_DIM2][ATTR3_DIM3] = {{{0}}}; // Buffer for reading 3rd attribute
-    int     i, j, k;
+    int    read_data1[ATTR1_DIM1]                         = {0};     // Buffer for reading 1st attribute
+    int    read_data2[ATTR2_DIM1][ATTR2_DIM2]             = {{0}};   // Buffer for reading 2nd attribute
+    double read_data3[ATTR3_DIM1][ATTR3_DIM2][ATTR3_DIM3] = {{{0}}}; // Buffer for reading 3rd attribute
+    int    i, j, k;
 
     // Output message about test being performed
     SUBTEST("Multiple Attribute Reading Functions");
@@ -1065,7 +1071,8 @@ test_attr_mult_read(FileAccPropList &fapl)
         // Get the dims of the dataspace and verify them
         hsize_t dims[ATTR_MAX_DIMS]; // Attribute dimensions
         (void)space.getSimpleExtentDims(dims);
-        verify_val(dims[0], static_cast<long unsigned>(ATTR1_DIM1), "DataSpace::getSimpleExtentDims", __LINE__, __FILE__, "dims[0]");
+        verify_val(dims[0], static_cast<long unsigned>(ATTR1_DIM1), "DataSpace::getSimpleExtentDims",
+                   __LINE__, __FILE__, "dims[0]");
 
         /* Verify Datatype */
 
@@ -1179,12 +1186,12 @@ test_attr_mult_read(FileAccPropList &fapl)
 
         // Get the dims of the dataspace and verify them
         (void)space.getSimpleExtentDims(dims);
-        verify_val(static_cast<long>(dims[0]), static_cast<long>(ATTR3_DIM1), "DataSpace::getSimpleExtentDims",
-                   __LINE__, __FILE__, "attribute dimensions");
-        verify_val(static_cast<long>(dims[1]), static_cast<long>(ATTR3_DIM2), "DataSpace::getSimpleExtentDims",
-                   __LINE__, __FILE__, "attribute dimensions");
-        verify_val(static_cast<long>(dims[2]), static_cast<long>(ATTR3_DIM3), "DataSpace::getSimpleExtentDims",
-                   __LINE__, __FILE__, "attribute dimensions");
+        verify_val(static_cast<long>(dims[0]), static_cast<long>(ATTR3_DIM1),
+                   "DataSpace::getSimpleExtentDims", __LINE__, __FILE__, "attribute dimensions");
+        verify_val(static_cast<long>(dims[1]), static_cast<long>(ATTR3_DIM2),
+                   "DataSpace::getSimpleExtentDims", __LINE__, __FILE__, "attribute dimensions");
+        verify_val(static_cast<long>(dims[2]), static_cast<long>(ATTR3_DIM3),
+                   "DataSpace::getSimpleExtentDims", __LINE__, __FILE__, "attribute dimensions");
 
         /* Verify Datatype */
 
@@ -1217,7 +1224,8 @@ test_attr_mult_read(FileAccPropList &fapl)
                     if (abs(attr_data3[i][j][k] - read_data3[i][j][k]) > DBL_EPSILON) {
                         char var[VAR_LEN];
                         sprintf(var, "read_data3[%d][%d][%d]", i, j, k);
-                        display_difference(read_data3[i][j][k], attr_data3[i][j][k], "Attribute::read", __LINE__, __FILE__, var);
+                        display_difference(read_data3[i][j][k], attr_data3[i][j][k], "Attribute::read",
+                                           __LINE__, __FILE__, var);
                     }
                 }
 
@@ -1426,7 +1434,8 @@ test_attr_dtype_shared(FileAccPropList &fapl)
 #ifndef H5_NO_DEPRECATED_SYMBOLS
             // Check reference count on named datatype
             fid1.getObjinfo(TYPE1_NAME, statbuf);
-            verify_val(static_cast<int>(statbuf.nlink), 1, "DataType::getObjinfo", __LINE__, __FILE__, "statbuf.nlink");
+            verify_val(static_cast<int>(statbuf.nlink), 1, "DataType::getObjinfo", __LINE__, __FILE__,
+                       "statbuf.nlink");
 #endif
 
             // Create dataspace for dataset
@@ -1437,7 +1446,8 @@ test_attr_dtype_shared(FileAccPropList &fapl)
 #ifndef H5_NO_DEPRECATED_SYMBOLS
             // Check reference count on named datatype
             fid1.getObjinfo(TYPE1_NAME, statbuf);
-            verify_val(static_cast<int>(statbuf.nlink), 2, "H5File::getObjinfo", __LINE__, __FILE__, "statbuf.nlink");
+            verify_val(static_cast<int>(statbuf.nlink), 2, "H5File::getObjinfo", __LINE__, __FILE__,
+                       "statbuf.nlink");
 #endif
 
             // Create attribute on dataset
@@ -1446,7 +1456,8 @@ test_attr_dtype_shared(FileAccPropList &fapl)
 #ifndef H5_NO_DEPRECATED_SYMBOLS
             // Check reference count on named datatype
             fid1.getObjinfo(TYPE1_NAME, statbuf);
-            verify_val(static_cast<int>(statbuf.nlink), 3, "DataSet::getObjinfo", __LINE__, __FILE__, "statbuf.nlink");
+            verify_val(static_cast<int>(statbuf.nlink), 3, "DataSet::getObjinfo", __LINE__, __FILE__,
+                       "statbuf.nlink");
 #endif
 
             // Close attribute
@@ -1468,7 +1479,8 @@ test_attr_dtype_shared(FileAccPropList &fapl)
 #ifndef H5_NO_DEPRECATED_SYMBOLS
             // Check reference count on named datatype
             fid1.getObjinfo(TYPE1_NAME, statbuf);
-            verify_val(static_cast<int>(statbuf.nlink), 3, "DataSet::createAttribute", __LINE__, __FILE__, "statbuf.nlink");
+            verify_val(static_cast<int>(statbuf.nlink), 3, "DataSet::createAttribute", __LINE__, __FILE__,
+                       "statbuf.nlink");
 #endif
 
             // Write data into the attribute
@@ -1505,7 +1517,8 @@ test_attr_dtype_shared(FileAccPropList &fapl)
 #ifndef H5_NO_DEPRECATED_SYMBOLS
             // Check reference count on named datatype
             fid1.getObjinfo(TYPE1_NAME, statbuf);
-            verify_val(static_cast<int>(statbuf.nlink), 3, "DataSet::openAttribute", __LINE__, __FILE__, "statbuf.nlink");
+            verify_val(static_cast<int>(statbuf.nlink), 3, "DataSet::openAttribute", __LINE__, __FILE__,
+                       "statbuf.nlink");
 #endif
         } // end of second enclosing
 
@@ -1590,7 +1603,9 @@ test_string_attr(FileAccPropList &fapl)
         // Read and verify the attribute string as a string of chars.
         char flstring_att_check[ATTR_LEN];
         gr_flattr1.read(fls_type, flstring_att_check);
-        verify_val(const_cast<const char *>(flstring_att_check), const_cast<const char *>(ATTRSTR_DATA.c_str()), "Attribute::read", __LINE__, __FILE__, "flstring_att_check");
+        verify_val(const_cast<const char *>(flstring_att_check),
+                   const_cast<const char *>(ATTRSTR_DATA.c_str()), "Attribute::read", __LINE__, __FILE__,
+                   "flstring_att_check");
 
         // Read and verify the attribute string as a string of chars; buffer
         // is dynamically allocated.
@@ -1599,7 +1614,9 @@ test_string_attr(FileAccPropList &fapl)
         fl_dyn_string_att_check = new char[attr_size + 1];
         gr_flattr1.read(fls_type, fl_dyn_string_att_check);
 
-        verify_val(const_cast<const char *>(fl_dyn_string_att_check), const_cast<const char *>(ATTRSTR_DATA.c_str()), "Attribute::read", __LINE__, __FILE__, "fl_dyn_string_att_check");
+        verify_val(const_cast<const char *>(fl_dyn_string_att_check),
+                   const_cast<const char *>(ATTRSTR_DATA.c_str()), "Attribute::read", __LINE__, __FILE__,
+                   "fl_dyn_string_att_check");
         delete[] fl_dyn_string_att_check;
 
         /* Test Attribute::read(...,H5std_string& strg) with FL string */
@@ -1607,19 +1624,24 @@ test_string_attr(FileAccPropList &fapl)
         // Read and verify the attribute string as an std::string.
         H5std_string read_flstr1;
         gr_flattr1.read(fls_type, read_flstr1);
-        verify_val(static_cast<const H5std_string>(read_flstr1), static_cast<const H5std_string>(ATTRSTR_DATA), "Attribute::read", __LINE__, __FILE__, "read_flstr1");
+        verify_val(static_cast<const H5std_string>(read_flstr1),
+                   static_cast<const H5std_string>(ATTRSTR_DATA), "Attribute::read", __LINE__, __FILE__,
+                   "read_flstr1");
 
         // Read and verify the attribute string as a string of chars.
         strcpy(flstring_att_check, "");
         gr_flattr2.read(fls_type, flstring_att_check);
-        verify_val(const_cast<const char *>(flstring_att_check), const_cast<const char *>(ATTRSTR_DATA.c_str()), "Attribute::read", __LINE__, __FILE__, "flstring_att_check");
+        verify_val(const_cast<const char *>(flstring_att_check),
+                   const_cast<const char *>(ATTRSTR_DATA.c_str()), "Attribute::read", __LINE__, __FILE__,
+                   "flstring_att_check");
 
         /* Test Attribute::read(...,H5std_string& strg) with FL string */
 
         // Read and verify the attribute string as an std::string.
         H5std_string read_flstr2;
         gr_flattr2.read(fls_type, read_flstr2);
-        verify_val(static_cast<const H5std_string>(read_flstr2), ATTRSTR_DATA, "Attribute::read", __LINE__, __FILE__, "read_flstr2");
+        verify_val(static_cast<const H5std_string>(read_flstr2), ATTRSTR_DATA, "Attribute::read", __LINE__,
+                   __FILE__, "read_flstr2");
 
         //
         // Variable-lenth string attributes
@@ -1637,14 +1659,16 @@ test_string_attr(FileAccPropList &fapl)
         // Read and verify the attribute string as a string of chars.
         char *string_att_check;
         gr_vlattr.read(vls_type, &string_att_check);
-        verify_val(const_cast<const char *>(string_att_check), ATTRSTR_DATA.c_str(), "Attribute::read", __LINE__, __FILE__, "flstring_att_check");
+        verify_val(const_cast<const char *>(string_att_check), ATTRSTR_DATA.c_str(), "Attribute::read",
+                   __LINE__, __FILE__, "flstring_att_check");
         free(string_att_check);
 
         /* Test Attribute::read(...,H5std_string& strg) with VL string */
         // Read and verify the attribute string as an std::string.
         H5std_string read_str;
         gr_vlattr.read(vls_type, read_str);
-        verify_val(static_cast<const H5std_string>(read_str), static_cast<const H5std_string>(ATTRSTR_DATA), "Attribute::read", __LINE__, __FILE__, "read_str");
+        verify_val(static_cast<const H5std_string>(read_str), static_cast<const H5std_string>(ATTRSTR_DATA),
+                   "Attribute::read", __LINE__, __FILE__, "read_str");
 
         PASSED();
     } // end try block
@@ -1752,8 +1776,10 @@ test_attr_dense_create(FileCreatPropList &fcpl, FileAccPropList &fapl)
 
         // Retrieve limits for compact/dense attribute storage
         dcpl.getAttrPhaseChange(max_compact, min_dense);
-        verify_val(max_compact, MAX_COMPACT_DEF, "DSetCreatPropList::getAttrPhaseChange", __LINE__, __FILE__, "max_compact");
-        verify_val(min_dense, MIN_DENSE_DEF, "DSetCreatPropList::getAttrPhaseChange", __LINE__, __FILE__, "min_dense");
+        verify_val(max_compact, MAX_COMPACT_DEF, "DSetCreatPropList::getAttrPhaseChange", __LINE__, __FILE__,
+                   "max_compact");
+        verify_val(min_dense, MIN_DENSE_DEF, "DSetCreatPropList::getAttrPhaseChange", __LINE__, __FILE__,
+                   "min_dense");
 
         // Set new compact/dense attribute storage limits to some random numbers
         dcpl.setAttrPhaseChange(7, 5);

--- a/c++/test/tattr.cpp
+++ b/c++/test/tattr.cpp
@@ -800,7 +800,7 @@ test_attr_compound_read(FileAccPropList &fapl)
                                var);
 
                     sprintf(var, "read_data4[%d][%d].%c", i, j, 'd');
-                    if (abs(read_data4[i][j].d - attr_data4[i][j].d) > DBL_EPSILON) {
+                    if (fabs(read_data4[i][j].d - attr_data4[i][j].d) > DBL_EPSILON) {
                         display_difference(read_data4[i][j].d, attr_data4[i][j].d,
                                            "DSetAccPropList::getChunkCache", __LINE__, __FILE__, "w0_1");
                     }
@@ -929,7 +929,7 @@ test_attr_scalar_read(FileAccPropList &fapl)
         // Read attribute information
         float read_data2 = 0.0; // Buffer for reading 1st attribute
         ds_attr.read(PredType::NATIVE_FLOAT, &read_data2);
-        if (abs(read_data2 - attr_data5) > FLT_EPSILON)
+        if (fabs(read_data2 - attr_data5) > FLT_EPSILON)
             display_difference(read_data2, attr_data5, "Attribute::read", __LINE__, __FILE__, "read_data2");
 
         // Get the dataspace of the attribute
@@ -1221,7 +1221,7 @@ test_attr_mult_read(FileAccPropList &fapl)
         for (i = 0; i < ATTR3_DIM1; i++)
             for (j = 0; j < ATTR3_DIM2; j++)
                 for (k = 0; k < ATTR3_DIM3; k++) {
-                    if (abs(attr_data3[i][j][k] - read_data3[i][j][k]) > DBL_EPSILON) {
+                    if (fabs(attr_data3[i][j][k] - read_data3[i][j][k]) > DBL_EPSILON) {
                         char var[VAR_LEN];
                         sprintf(var, "read_data3[%d][%d][%d]", i, j, k);
                         display_difference(read_data3[i][j][k], attr_data3[i][j][k], "Attribute::read",

--- a/c++/test/tcompound.cpp
+++ b/c++/test/tcompound.cpp
@@ -23,7 +23,6 @@ using std::endl;
 #include "H5Cpp.h" // C++ API header file
 using namespace H5;
 
-#include "h5test.h"
 #include "h5cpputil.h" // C++ utilility header file
 
 /* Number of elements in each test */
@@ -606,13 +605,13 @@ test_compound_7()
         tid1.insertMember("c", HOFFSET(s1_typ_t, c), PredType::NATIVE_LONG);
 
         size_t type_size = tid1.getSize();
-        verify_val(type_size, sizeof(s1_typ_t), "DataType::getSize", __LINE__, __FILE__);
+        verify_val(type_size, sizeof(s1_typ_t), "DataType::getSize", __LINE__, __FILE__, "type_size");
 
         CompType tid2;
         tid2.copy(tid1);
 
         type_size = tid2.getSize();
-        verify_val_noteq(type_size, sizeof(s2_typ_t), "DataType::getSize", __LINE__, __FILE__);
+        verify_val_noteq(type_size, sizeof(s2_typ_t), "DataType::getSize", __LINE__, __FILE__, "type_size");
 
         /* Should not be able to insert field past end of compound datatype */
         try {
@@ -668,7 +667,7 @@ test_compound_set_size()
 
         // Verify that the compound is not packed
         // bool packed = dtype.packed(); // not until C library provides API
-        // verify_val(packed, FALSE, "DataType::packed", __LINE__, __FILE__);
+        // verify_val(packed, FALSE, "DataType::packed", __LINE__, __FILE__, "packed");
 
         dtype.commit(file, "dtype");
 
@@ -687,25 +686,25 @@ test_compound_set_size()
 
         // Verify that the compound is not packed
         // packed = dtype_tmp.packed(); // not until C library provides API
-        // verify_val(packed, FALSE, "DataType::packed", __LINE__, __FILE__);
+        // verify_val(packed, FALSE, "DataType::packed", __LINE__, __FILE__, "packed");
 
         // Expand the type, and verify that it became unpacked
         dtype.setSize(33);
         // packed = dtype.packed(); // not until C library provides API
-        // verify_val(packed, FALSE, "DataType::packed", __LINE__, __FILE__);
+        // verify_val(packed, FALSE, "DataType::packed", __LINE__, __FILE__, "packed");
 
         // Verify setSize() actually set size
         size_t new_size = dtype.getSize();
-        verify_val(static_cast<long>(new_size), 33, "DataType::getSize", __LINE__, __FILE__);
+        verify_val(static_cast<long>(new_size), 33, "DataType::getSize", __LINE__, __FILE__, "new_size");
 
         // Shrink the type, and verify that it became packed
         dtype.setSize(32);
         // packed = dtype.packed(); // not until C library provides API
-        // verify_val(packed, TRUE, "DataType::packed", __LINE__, __FILE__);
+        // verify_val(packed, TRUE, "DataType::packed", __LINE__, __FILE__, "packed");
 
         // Verify setSize() actually set size again
         new_size = dtype.getSize();
-        verify_val(static_cast<long>(new_size), 32, "DataType::getSize", __LINE__, __FILE__);
+        verify_val(static_cast<long>(new_size), 32, "DataType::getSize", __LINE__, __FILE__, "new_size");
 
         /* Close types and file */
         dtype_tmp.close();
@@ -731,9 +730,6 @@ test_compound_set_size()
 extern "C" void
 test_compound()
 {
-    // Output message about test being performed
-    MESSAGE(5, ("Testing Compound Data Type operations\n"));
-
     test_compound_1();        // various things about compound data types
     test_compound_2();        // compound element reordering
     test_compound_3();        // compound datatype subset conversions
@@ -755,5 +751,5 @@ test_compound()
 extern "C" void
 cleanup_compound()
 {
-    HDremove(COMPFILE.c_str());
+    remove(COMPFILE.c_str());
 } // cleanup_file

--- a/c++/test/tdspl.cpp
+++ b/c++/test/tdspl.cpp
@@ -24,7 +24,6 @@ using std::endl;
 #include "H5Cpp.h" // C++ API header file
 using namespace H5;
 
-#include "h5test.h"
 #include "h5cpputil.h" // C++ utilility header file
 
 const H5std_string FILENAME("tdatatransform.h5");
@@ -64,7 +63,7 @@ test_transfplist()
         memset(c_to_f_read, 0, tran_len + 1);
         dxpl_c_to_f_copy.getDataTransform(c_to_f_read, tran_len + 1);
         verify_val(const_cast<const char *>(c_to_f_read), const_cast<const char *>(c_to_f),
-                   "DSetMemXferPropList::getDataTransform", __LINE__, __FILE__);
+                   "DSetMemXferPropList::getDataTransform", __LINE__, __FILE__, "c_to_f_read");
         free(c_to_f_read);
 
         //
@@ -79,14 +78,14 @@ test_transfplist()
         memset(c_to_f_read, 0, tran_len + 1);
         dxpl_c_to_f.getDataTransform(c_to_f_read, tran_len + 1);
         verify_val(const_cast<const char *>(c_to_f_read), const_cast<const char *>(c_to_f),
-                   "DSetMemXferPropList::getDataTransform", __LINE__, __FILE__);
+                   "DSetMemXferPropList::getDataTransform", __LINE__, __FILE__, "c_to_f_read");
         free(c_to_f_read);
 
         // Get and verify the expression with:
         // H5std_string DSetMemXferPropList::getDataTransform()
         H5std_string simple_read = dxpl_simple.getDataTransform();
-        verify_val(const_cast<const char *>(simple_read.c_str()), const_cast<const char *>(simple),
-                   "DSetMemXferPropList::getDataTransform", __LINE__, __FILE__);
+        verify_val(simple_read.c_str(), const_cast<const char *>(simple),
+                   "DSetMemXferPropList::getDataTransform", __LINE__, __FILE__, "simple_read");
 
         // Get and verify the expression with:
         // ssize_t getDataTransform(char* exp, const size_t buf_size)
@@ -95,7 +94,7 @@ test_transfplist()
         memset(utrans_inv_read, 0, tran_len + 1);
         dxpl_utrans_inv.getDataTransform(utrans_inv_read, tran_len + 1);
         verify_val(const_cast<const char *>(utrans_inv_read), const_cast<const char *>(utrans_inv),
-                   "DSetMemXferPropList::getDataTransform", __LINE__, __FILE__);
+                   "DSetMemXferPropList::getDataTransform", __LINE__, __FILE__, "utrans_inv_read");
         free(utrans_inv_read);
 
         PASSED();
@@ -116,9 +115,6 @@ test_transfplist()
 extern "C" void
 test_dsproplist()
 {
-    // Output message about test being performed
-    MESSAGE(5, ("Testing Generic Dataset Property Lists\n"));
-
     test_transfplist(); // test set/getDataTransform()
 
 } // test_dsproplist()
@@ -134,5 +130,5 @@ test_dsproplist()
 extern "C" void
 cleanup_dsproplist()
 {
-    HDremove(FILENAME.c_str());
+    remove(FILENAME.c_str());
 }

--- a/c++/test/testhdf5.cpp
+++ b/c++/test/testhdf5.cpp
@@ -25,7 +25,6 @@
    base functionality testing.
 
    EXTERNAL ROUTINES/VARIABLES:
-        TestInit(...) -- Initialize testing framework
         TestInfo(...) -- Print test info
         AddTest(...)  -- Setup a test function and add it to the list of tests
         TestParseCmdLine(...) -- Parse command line arguments
@@ -45,54 +44,53 @@ using std::endl;
 #include "H5Cpp.h" // C++ API header file
 using namespace H5;
 
-#include "h5test.h"
 #include "h5cpputil.h" // C++ utilility header file
+static const char *TestProgName                     = NULL;
 
 int
 main(int argc, char *argv[])
 {
     try {
-        // Turn of the auto-printing when failure occurs so that we can
-        // handle the errors appropriately since sometime failures are
-        // caused deliberately and expected.
-        Exception::dontPrint();
-        /* Initialize testing framework */
-        TestInit(argv[0], NULL, NULL);
+    /*
+     * Record the program name and private routines if provided.
+     */
+    TestProgName = argv[0];
+ 
 
         // testing file creation and opening in tfile.cpp
-        AddTest("tfile", test_file, cleanup_file, "File I/O Operations", NULL);
+        AddTest("tfile", test_file, cleanup_file, "File I/O Operations");
         // testing dataset functionalities in dset.cpp
-        AddTest("dsets", test_dset, cleanup_dsets, "Dataset I/O Operations", NULL);
+        AddTest("dsets", test_dset, cleanup_dsets, "Dataset I/O Operations");
         // testing dataspace functionalities in th5s.cpp
-        AddTest("th5s", test_h5s, cleanup_h5s, "Dataspaces", NULL);
+        AddTest("th5s", test_h5s, cleanup_h5s, "Dataspaces");
         // testing attribute functionalities in tattr.cpp
-        AddTest("tattr", test_attr, cleanup_attr, "Attributes", NULL);
+        AddTest("tattr", test_attr, cleanup_attr, "Attributes");
         // testing object functionalities in tobject.cpp
-        AddTest("tobject", test_object, cleanup_object, "Objects", NULL);
+        AddTest("tobject", test_object, cleanup_object, "Objects");
         // testing reference functionalities in trefer.cpp
-        AddTest("trefer", test_reference, cleanup_reference, "References", NULL);
+        AddTest("trefer", test_reference, cleanup_reference, "References");
         // testing variable-length strings in tvlstr.cpp
-        AddTest("tvlstr", test_vlstrings, cleanup_vlstrings, "Variable-Length Strings", NULL);
-        AddTest("ttypes", test_types, cleanup_types, "Generic Data Types", NULL);
-        AddTest("tarray", test_array, cleanup_array, "Array Datatypes", NULL);
-        AddTest("tcompound", test_compound, cleanup_compound, "Compound Data Types", NULL);
-        AddTest("tdspl", test_dsproplist, cleanup_dsproplist, "Dataset Property List", NULL);
-        AddTest("tfilter", test_filters, cleanup_filters, "Various Filters", NULL);
-        AddTest("tlinks", test_links, cleanup_links, "Various Links", NULL);
+        AddTest("tvlstr", test_vlstrings, cleanup_vlstrings, "Variable-Length Strings");
+        AddTest("ttypes", test_types, cleanup_types, "Generic Data Types");
+        AddTest("tarray", test_array, cleanup_array, "Array Datatypes");
+        AddTest("tcompound", test_compound, cleanup_compound, "Compound Data Types");
+        AddTest("tdspl", test_dsproplist, cleanup_dsproplist, "Dataset Property List");
+        AddTest("tfilter", test_filters, cleanup_filters, "Various Filters");
+        AddTest("tlinks", test_links, cleanup_links, "Various Links");
         /* Comment out tests that are not done yet. - BMR, Feb 2001
-                AddTest("select", test_select, cleanup_select,  "Selections", NULL);
-                AddTest("time", test_time, cleanup_time,  "Time Datatypes", NULL);
-                AddTest("vltypes", test_vltypes, cleanup_vltypes,  "Variable-Length Datatypes", NULL);
+                AddTest("select", test_select, cleanup_select,  "Selections");
+                AddTest("time", test_time, cleanup_time,  "Time Datatypes");
+                AddTest("vltypes", test_vltypes, cleanup_vltypes,  "Variable-Length Datatypes");
         */
-        AddTest("iterate", test_iterate, cleanup_iterate, "Group & Attribute Iteration", NULL);
+        AddTest("iterate", test_iterate, cleanup_iterate, "Group & Attribute Iteration");
         /*
-                AddTest("genprop", test_genprop, cleanup_genprop,  "Generic Properties", NULL);
-                AddTest("id", test_ids, NULL,  "User-Created Identifiers", NULL);
+                AddTest("genprop", test_genprop, cleanup_genprop,  "Generic Properties");
+                AddTest("id", test_ids, NULL,  "User-Created Identifiers");
 
         Comment out tests that are not done yet */
 
         /* Tentative - BMR 2007/1/12
-                AddTest("enum", test_enum, cleanup_enum,  "Enum Data Types", NULL);
+                AddTest("enum", test_enum, cleanup_enum,  "Enum Data Types");
         */
     }
     catch (Exception &E) {
@@ -105,6 +103,12 @@ main(int argc, char *argv[])
     /* Parse command line arguments */
     TestParseCmdLine(argc, argv);
 
+    // Turn off the auto-printing when failure occurs so that we can
+    // handle the errors appropriately since sometime failures are caused
+    // deliberately and expected, unless it is specifically requested.
+    if (enable_error_stack == 0)
+        Exception::dontPrint();
+
     /* Perform requested testing */
     PerformTests();
 
@@ -115,9 +119,6 @@ main(int argc, char *argv[])
     /* Clean up test files, if allowed */
     if (GetTestCleanup() && !getenv(HDF5_NOCLEANUP))
         TestCleanup();
-
-    /* Release test infrastructure */
-    TestShutdown();
 
     return (GetTestNumErrs());
 }

--- a/c++/test/testhdf5.cpp
+++ b/c++/test/testhdf5.cpp
@@ -45,17 +45,16 @@ using std::endl;
 using namespace H5;
 
 #include "h5cpputil.h" // C++ utilility header file
-static const char *TestProgName                     = NULL;
+static const char *TestProgName = NULL;
 
 int
 main(int argc, char *argv[])
 {
     try {
-    /*
-     * Record the program name and private routines if provided.
-     */
-    TestProgName = argv[0];
- 
+        /*
+         * Record the program name and private routines if provided.
+         */
+        TestProgName = argv[0];
 
         // testing file creation and opening in tfile.cpp
         AddTest("tfile", test_file, cleanup_file, "File I/O Operations");

--- a/c++/test/tfile.cpp
+++ b/c++/test/tfile.cpp
@@ -15,8 +15,8 @@
    tfile.cpp - HDF5 C++ testing the file I/O features
 
    EXTERNAL ROUTINES/VARIABLES:
-     These routines are in the test directory of the C library:
-        h5_fileaccess() -- in h5test.c, returns a file access template
+     These routines are in the tools library:
+        h5tools_get_new_fapl() -- in tools/lib, returns a file access template
 
  ***************************************************************************/
 #include <iostream>
@@ -27,7 +27,6 @@ using std::endl;
 #include "H5Cpp.h" // C++ API header file
 using namespace H5;
 
-#include "h5test.h"
 #include "h5cpputil.h" // C++ utilility header file
 
 const hsize_t      F1_USERBLOCK_SIZE = 0;
@@ -142,17 +141,17 @@ test_file_create()
 
         hsize_t ublock = tmpl1.getUserblock();
         verify_val(static_cast<long>(ublock), static_cast<long>(F1_USERBLOCK_SIZE),
-                   "FileCreatPropList::getUserblock", __LINE__, __FILE__);
+                   "FileCreatPropList::getUserblock", __LINE__, __FILE__, "ublock");
 
         size_t parm1, parm2; // file-creation parameters
         tmpl1.getSizes(parm1, parm2);
-        verify_val(parm1, F1_OFFSET_SIZE, "FileCreatPropList::getSizes", __LINE__, __FILE__);
-        verify_val(parm2, F1_LENGTH_SIZE, "FileCreatPropList::getSizes", __LINE__, __FILE__);
+        verify_val(parm1, F1_OFFSET_SIZE, "FileCreatPropList::getSizes", __LINE__, __FILE__, "parm1");
+        verify_val(parm2, F1_LENGTH_SIZE, "FileCreatPropList::getSizes", __LINE__, __FILE__, "parm2");
 
         unsigned iparm1, iparm2; // file-creation parameters
         tmpl1.getSymk(iparm1, iparm2);
-        verify_val(iparm1, F1_SYM_INTERN_K, "FileCreatPropList::getSymk", __LINE__, __FILE__);
-        verify_val(iparm2, F1_SYM_LEAF_K, "FileCreatPropList::getSymk", __LINE__, __FILE__);
+        verify_val(iparm1, F1_SYM_INTERN_K, "FileCreatPropList::getSymk", __LINE__, __FILE__, "iparm1");
+        verify_val(iparm2, F1_SYM_LEAF_K, "FileCreatPropList::getSymk", __LINE__, __FILE__, "iparm2");
 
         // tmpl1 is automatically closed; if error occurs, it'll be
         // caught in the catch block
@@ -198,17 +197,17 @@ test_file_create()
         // Get the file-creation parameters
         hsize_t ublock = tmpl1->getUserblock();
         verify_val(static_cast<long>(ublock), static_cast<long>(F2_USERBLOCK_SIZE),
-                   "FileCreatPropList::getUserblock", __LINE__, __FILE__);
+                   "FileCreatPropList::getUserblock", __LINE__, __FILE__, "ublock");
 
         size_t parm1, parm2; // file-creation parameters
         tmpl1->getSizes(parm1, parm2);
-        verify_val(parm1, F2_OFFSET_SIZE, "FileCreatPropList::getSizes", __LINE__, __FILE__);
-        verify_val(parm2, F2_LENGTH_SIZE, "FileCreatPropList::getSizes", __LINE__, __FILE__);
+        verify_val(parm1, F2_OFFSET_SIZE, "FileCreatPropList::getSizes", __LINE__, __FILE__, "parm1");
+        verify_val(parm2, F2_LENGTH_SIZE, "FileCreatPropList::getSizes", __LINE__, __FILE__, "parm2");
 
         unsigned iparm1, iparm2; // file-creation parameters
         tmpl1->getSymk(iparm1, iparm2);
-        verify_val(iparm1, F2_SYM_INTERN_K, "FileCreatPropList::getSymk", __LINE__, __FILE__);
-        verify_val(iparm2, F2_SYM_LEAF_K, "FileCreatPropList::getSymk", __LINE__, __FILE__);
+        verify_val(iparm1, F2_SYM_INTERN_K, "FileCreatPropList::getSymk", __LINE__, __FILE__, "iparm1");
+        verify_val(iparm2, F2_SYM_LEAF_K, "FileCreatPropList::getSymk", __LINE__, __FILE__, "iparm2");
 
         // Clone the file-creation template
         FileCreatPropList tmpl2;
@@ -231,15 +230,15 @@ test_file_create()
         // Get the file-creation parameters
         ublock = tmpl1->getUserblock();
         verify_val(static_cast<long>(ublock), static_cast<long>(F3_USERBLOCK_SIZE),
-                   "FileCreatPropList::getUserblock", __LINE__, __FILE__);
+                   "FileCreatPropList::getUserblock", __LINE__, __FILE__, "ublock");
 
         tmpl1->getSizes(parm1, parm2);
-        verify_val(parm1, F3_OFFSET_SIZE, "FileCreatPropList::getSizes", __LINE__, __FILE__);
-        verify_val(parm2, F3_LENGTH_SIZE, "FileCreatPropList::getSizes", __LINE__, __FILE__);
+        verify_val(parm1, F3_OFFSET_SIZE, "FileCreatPropList::getSizes", __LINE__, __FILE__, "parm1");
+        verify_val(parm2, F3_LENGTH_SIZE, "FileCreatPropList::getSizes", __LINE__, __FILE__, "parm2");
 
         tmpl1->getSymk(iparm1, iparm2);
-        verify_val(iparm1, F3_SYM_INTERN_K, "FileCreatPropList::getSymk", __LINE__, __FILE__);
-        verify_val(iparm2, F3_SYM_LEAF_K, "FileCreatPropList::getSymk", __LINE__, __FILE__);
+        verify_val(iparm1, F3_SYM_INTERN_K, "FileCreatPropList::getSymk", __LINE__, __FILE__, "iparm1");
+        verify_val(iparm2, F3_SYM_LEAF_K, "FileCreatPropList::getSymk", __LINE__, __FILE__, "iparm2");
 
         // Release file-creation template
         delete tmpl1;
@@ -278,17 +277,17 @@ test_file_open()
         // Get the file-creation parameters
         hsize_t ublock = tmpl1.getUserblock();
         verify_val(static_cast<long>(ublock), static_cast<long>(F2_USERBLOCK_SIZE),
-                   "FileCreatPropList::getUserblock", __LINE__, __FILE__);
+                   "FileCreatPropList::getUserblock", __LINE__, __FILE__, "ublock");
 
         size_t parm1, parm2; // file-creation parameters
         tmpl1.getSizes(parm1, parm2);
-        verify_val(parm1, F2_OFFSET_SIZE, "FileCreatPropList::getSizes", __LINE__, __FILE__);
-        verify_val(parm2, F2_LENGTH_SIZE, "FileCreatPropList::getSizes", __LINE__, __FILE__);
+        verify_val(parm1, F2_OFFSET_SIZE, "FileCreatPropList::getSizes", __LINE__, __FILE__, "parm1");
+        verify_val(parm2, F2_LENGTH_SIZE, "FileCreatPropList::getSizes", __LINE__, __FILE__, "parm2");
 
         unsigned iparm1, iparm2; // file-creation parameters
         tmpl1.getSymk(iparm1, iparm2);
-        verify_val(iparm1, F2_SYM_INTERN_K, "FileCreatPropList::getSymk", __LINE__, __FILE__);
-        verify_val(iparm2, F2_SYM_LEAF_K, "FileCreatPropList::getSymk", __LINE__, __FILE__);
+        verify_val(iparm1, F2_SYM_INTERN_K, "FileCreatPropList::getSymk", __LINE__, __FILE__, "iparm1");
+        verify_val(iparm2, F2_SYM_LEAF_K, "FileCreatPropList::getSymk", __LINE__, __FILE__, "iparm2");
 
         // Test H5File constructor with existing file id
         H5File file2(file1.getId());
@@ -340,7 +339,7 @@ test_file_size()
     SUBTEST("File Size");
 
     hid_t fapl_id;
-    fapl_id = h5_fileaccess(); // in h5test.c, returns a file access template
+    fapl_id = h5tools_get_new_fapl(H5P_DEFAULT); // in tools/lib
 
     try {
         // Use the file access template id to create a file access prop.
@@ -400,7 +399,7 @@ test_file_num()
     SUBTEST("File Number");
 
     hid_t fapl_id;
-    fapl_id = h5_fileaccess(); // in h5test.c, returns a file access template
+    fapl_id = h5tools_get_new_fapl(H5P_DEFAULT); // in tools/lib
 
     try {
         // Use the file access template id to create a file access prop.
@@ -475,14 +474,14 @@ test_file_name()
 
         // Get file name from the file instance.
         file_name = file4.getFileName();
-        verify_val(file_name, FILE4, "H5File::getFileName", __LINE__, __FILE__);
+        verify_val(file_name, FILE4, "H5File::getFileName", __LINE__, __FILE__, "file_name");
 
         // Create a group in the root group.
         Group group(file4.createGroup(GROUPNAME, 0));
 
         // Get and verify file name via a group.
         file_name = group.getFileName();
-        verify_val(file_name, FILE4, "Group::getFileName", __LINE__, __FILE__);
+        verify_val(file_name, FILE4, "Group::getFileName", __LINE__, __FILE__, "file_name");
 
         // Create the data space.
         hsize_t   dims[RANK] = {NX, NY};
@@ -493,14 +492,14 @@ test_file_name()
 
         // Get and verify file name via a dataset.
         file_name = dataset.getFileName();
-        verify_val(file_name, FILE4, "DataSet::getFileName", __LINE__, __FILE__);
+        verify_val(file_name, FILE4, "DataSet::getFileName", __LINE__, __FILE__, "file_name");
 
         // Create an attribute for the dataset.
         Attribute attr(dataset.createAttribute(DATTRNAME, PredType::NATIVE_INT, space));
 
         // Get and verify file name via an attribute.
         file_name = attr.getFileName();
-        verify_val(file_name, FILE4, "Attribute::getFileName", __LINE__, __FILE__);
+        verify_val(file_name, FILE4, "Attribute::getFileName", __LINE__, __FILE__, "file_name");
 
         // Create a compound datatype.
         CompType comp_type(sizeof(s1_t));
@@ -514,7 +513,7 @@ test_file_name()
 
         // Get and verify file name via a committed datatype.
         comp_type.getFileName();
-        verify_val(file_name, FILE4, "CompType::getFileName", __LINE__, __FILE__);
+        verify_val(file_name, FILE4, "CompType::getFileName", __LINE__, __FILE__, "file_name");
         PASSED();
     } // end of try block
 
@@ -590,40 +589,40 @@ test_file_attribute()
         // Get and verify the number of all objects in the file
         // Current: 1 file, 2 file attr, 1 ds, and 1 ds attr.
         ssize_t num_objs = file5.getObjCount(H5F_OBJ_ALL);
-        verify_val(num_objs, 5, "H5File::getObjCount", __LINE__, __FILE__);
+        verify_val(num_objs, 5, "H5File::getObjCount", __LINE__, __FILE__, "num_objs");
 
         num_objs = file5.getObjCount(H5F_OBJ_GROUP);
-        verify_val(num_objs, 0, "H5File::getObjCount(H5F_OBJ_GROUP)", __LINE__, __FILE__);
+        verify_val(num_objs, 0, "H5File::getObjCount(H5F_OBJ_GROUP)", __LINE__, __FILE__, "num_objs");
         num_objs = file5.getObjCount(H5F_OBJ_DATASET);
-        verify_val(num_objs, 1, "H5File::getObjCount(H5F_OBJ_DATASET)", __LINE__, __FILE__);
+        verify_val(num_objs, 1, "H5File::getObjCount(H5F_OBJ_DATASET)", __LINE__, __FILE__, "num_objs");
         num_objs = file5.getObjCount(H5F_OBJ_ATTR);
-        verify_val(num_objs, 3, "H5File::getObjCount(H5F_OBJ_ATTR)", __LINE__, __FILE__);
+        verify_val(num_objs, 3, "H5File::getObjCount(H5F_OBJ_ATTR)", __LINE__, __FILE__, "num_objs");
         num_objs = file5.getObjCount(H5F_OBJ_DATATYPE);
-        verify_val(num_objs, 0, "H5File::getObjCount(H5F_OBJ_DATATYPE)", __LINE__, __FILE__);
+        verify_val(num_objs, 0, "H5File::getObjCount(H5F_OBJ_DATATYPE)", __LINE__, __FILE__, "num_objs");
         num_objs = file5.getObjCount(H5F_OBJ_FILE);
-        verify_val(num_objs, 1, "H5File::getObjCount(H5F_OBJ_FILE)", __LINE__, __FILE__);
+        verify_val(num_objs, 1, "H5File::getObjCount(H5F_OBJ_FILE)", __LINE__, __FILE__, "num_objs");
 
         // Get the file name using the attributes
         H5std_string fname = fattr1.getFileName();
-        verify_val(fname, FILE5, "H5File::getFileName()", __LINE__, __FILE__);
+        verify_val(fname, FILE5, "H5File::getFileName()", __LINE__, __FILE__, "fname");
 
         fname.clear();
         fname = dattr.getFileName();
-        verify_val(fname, FILE5, "H5File::getFileName()", __LINE__, __FILE__);
+        verify_val(fname, FILE5, "H5File::getFileName()", __LINE__, __FILE__, "fname");
 
         // Get the class of a file attribute's datatype
         H5T_class_t atclass = fattr1.getTypeClass();
         verify_val(static_cast<long>(atclass), static_cast<long>(H5T_FLOAT), "Attribute::getTypeClass()",
-                   __LINE__, __FILE__);
+                   __LINE__, __FILE__, "atclass");
 
         // Get and verify the number of attributes attached to a file
         int n_attrs = file5.getNumAttrs();
-        verify_val(n_attrs, 2, "H5File::getNumAttrs()", __LINE__, __FILE__);
+        verify_val(n_attrs, 2, "H5File::getNumAttrs()", __LINE__, __FILE__, "n_attrs");
 
         // Get and verify the number of attributes attached to a dataset
         n_attrs = 0;
         n_attrs = dataset.getNumAttrs();
-        verify_val(n_attrs, 1, "DataSet::getNumAttrs()", __LINE__, __FILE__);
+        verify_val(n_attrs, 1, "DataSet::getNumAttrs()", __LINE__, __FILE__, "n_attrs");
 
         // Read back attribute's data
         memset(rdata, 0, sizeof(rdata));
@@ -678,13 +677,13 @@ test_libver_bounds_real(H5F_libver_t libver_create, unsigned oh_vers_create, H5F
          * Make sure the root group has the correct object header version
          */
         unsigned obj_version = file.childObjVersion(ROOTGROUP);
-        verify_val(obj_version, oh_vers_create, "H5File::childObjVersion", __LINE__, __FILE__);
+        verify_val(obj_version, oh_vers_create, "H5File::childObjVersion", __LINE__, __FILE__, "obj_version");
 
         // Verify object header version another way
         H5O_native_info_t ninfo;
         memset(&ninfo, 0, sizeof(ninfo));
         file.getNativeObjinfo(ninfo, H5O_NATIVE_INFO_HDR);
-        verify_val(ninfo.hdr.version, oh_vers_create, "H5File::getNativeObjinfo", __LINE__, __FILE__);
+        verify_val(ninfo.hdr.version, oh_vers_create, "H5File::getNativeObjinfo", __LINE__, __FILE__, "ninfo.hdr.version");
 
         /*
          * Reopen the file and make sure the root group still has the correct
@@ -697,7 +696,7 @@ test_libver_bounds_real(H5F_libver_t libver_create, unsigned oh_vers_create, H5F
         file.openFile(FILE6, H5F_ACC_RDWR, fapl);
 
         obj_version = file.childObjVersion(ROOTGROUP);
-        verify_val(obj_version, oh_vers_create, "H5File::childObjVersion", __LINE__, __FILE__);
+        verify_val(obj_version, oh_vers_create, "H5File::childObjVersion", __LINE__, __FILE__, "obj_version");
 
         /*
          * Create a group named "/G1" in the file, and make sure it has the correct
@@ -706,12 +705,12 @@ test_libver_bounds_real(H5F_libver_t libver_create, unsigned oh_vers_create, H5F
         Group group = file.createGroup(GROUP1);
 
         obj_version = group.objVersion();
-        verify_val(obj_version, oh_vers_mod, "Group::objVersion", __LINE__, __FILE__);
+        verify_val(obj_version, oh_vers_mod, "Group::objVersion", __LINE__, __FILE__, "obj_version");
 
         // Verify object header version another way
         memset(&ninfo, 0, sizeof(ninfo));
         group.getNativeObjinfo(ninfo, H5O_NATIVE_INFO_HDR);
-        verify_val(ninfo.hdr.version, oh_vers_mod, "Group::getNativeObjinfo", __LINE__, __FILE__);
+        verify_val(ninfo.hdr.version, oh_vers_mod, "Group::getNativeObjinfo", __LINE__, __FILE__, "ninfo.hdr.version");
 
         group.close(); // close "/G1"
 
@@ -722,7 +721,7 @@ test_libver_bounds_real(H5F_libver_t libver_create, unsigned oh_vers_create, H5F
         group = file.createGroup(SUBGROUP3);
 
         obj_version = group.objVersion();
-        verify_val(obj_version, oh_vers_mod, "Group::objVersion", __LINE__, __FILE__);
+        verify_val(obj_version, oh_vers_mod, "Group::objVersion", __LINE__, __FILE__, "obj_version");
 
         group.close(); // close "/G1/G3"
 
@@ -730,7 +729,7 @@ test_libver_bounds_real(H5F_libver_t libver_create, unsigned oh_vers_create, H5F
          * Make sure the root group still has the correct object header version
          */
         obj_version = file.childObjVersion(ROOTGROUP);
-        verify_val(obj_version, oh_vers_create, "H5File::childObjVersion", __LINE__, __FILE__);
+        verify_val(obj_version, oh_vers_create, "H5File::childObjVersion", __LINE__, __FILE__, "obj_version");
 
         // Everything should be closed as they go out of scope
     } // end of try block
@@ -796,21 +795,21 @@ test_commonfg()
 
         // Get and verify file name via a dataset.
         H5std_string file_name = dataset.getFileName();
-        verify_val(file_name, FILE4, "DataSet::getFileName", __LINE__, __FILE__);
+        verify_val(file_name, FILE4, "DataSet::getFileName", __LINE__, __FILE__, "file_name");
 
         // Create an attribute for the dataset.
         Attribute attr(dataset.createAttribute(DATTRNAME, PredType::NATIVE_INT, space));
 
         // Get and verify file name via an attribute.
         file_name = attr.getFileName();
-        verify_val(file_name, FILE4, "Attribute::getFileName", __LINE__, __FILE__);
+        verify_val(file_name, FILE4, "Attribute::getFileName", __LINE__, __FILE__, "file_name");
 
         // Create an attribute for the file via root group.
         Attribute rootg_attr(rootgroup.createAttribute(FATTRNAME, PredType::NATIVE_INT, space));
 
         // Get and verify file name via an attribute.
         file_name = attr.getFileName();
-        verify_val(file_name, FILE4, "Attribute::getFileName", __LINE__, __FILE__);
+        verify_val(file_name, FILE4, "Attribute::getFileName", __LINE__, __FILE__, "file_name");
 
         PASSED();
     } // end of try block
@@ -853,9 +852,9 @@ test_file_info()
         // Get the file's version information.
         H5F_info2_t finfo;
         tempfile.getFileInfo(finfo);
-        verify_val(static_cast<long>(finfo.super.version), 0, "H5File::getFileInfo", __LINE__, __FILE__);
-        verify_val(static_cast<long>(finfo.free.version), 0, "H5File::getFileInfo", __LINE__, __FILE__);
-        verify_val(static_cast<long>(finfo.sohm.version), 0, "H5File::getFileInfo", __LINE__, __FILE__);
+        verify_val(static_cast<long>(finfo.super.version), 0, "H5File::getFileInfo", __LINE__, __FILE__, "finfo.super.version");
+        verify_val(static_cast<long>(finfo.free.version), 0, "H5File::getFileInfo", __LINE__, __FILE__, "finfo.free.version");
+        verify_val(static_cast<long>(finfo.sohm.version), 0, "H5File::getFileInfo", __LINE__, __FILE__, "finfo.sohm.version");
 
         // Close the file.
         tempfile.close();
@@ -868,14 +867,14 @@ test_file_info()
 
         // Verify file space information.
         verify_val(static_cast<long>(out_strategy), static_cast<long>(H5F_FSPACE_STRATEGY_FSM_AGGR),
-                   "H5File::getFileInfo", __LINE__, __FILE__);
-        verify_val(out_persist, FALSE, "H5File::getFileInfo", __LINE__, __FILE__);
-        verify_val(static_cast<long>(out_threshold), 1, "H5File::getFileInfo", __LINE__, __FILE__);
+                   "H5File::getFileInfo", __LINE__, __FILE__, "out_strategy");
+        verify_val(out_persist, FALSE, "H5File::getFileInfo", __LINE__, __FILE__, "out_persist");
+        verify_val(static_cast<long>(out_threshold), 1, "H5File::getFileInfo", __LINE__, __FILE__, "out_threshold");
 
         /* Retrieve file space page size */
         hsize_t out_fsp_psize = fcpl.getFileSpacePagesize();
         verify_val(out_fsp_psize, FSP_SIZE_DEF, "FileCreatPropList::getFileSpacePagesize", __LINE__,
-                   __FILE__);
+                   __FILE__, "out_fsp_psize");
 
         // Set various file information.
         fcpl.setUserblock(F2_USERBLOCK_SIZE);
@@ -901,9 +900,9 @@ test_file_info()
 
         // Get the file's version information.
         file7.getFileInfo(finfo);
-        verify_val(static_cast<long>(finfo.super.version), 2, "H5File::getFileInfo", __LINE__, __FILE__);
-        verify_val(static_cast<long>(finfo.free.version), 0, "H5File::getFileInfo", __LINE__, __FILE__);
-        verify_val(static_cast<long>(finfo.sohm.version), 0, "H5File::getFileInfo", __LINE__, __FILE__);
+        verify_val(static_cast<long>(finfo.super.version), 2, "H5File::getFileInfo", __LINE__, __FILE__, "finfo.super.version");
+        verify_val(static_cast<long>(finfo.free.version), 0, "H5File::getFileInfo", __LINE__, __FILE__, "finfo.free.version");
+        verify_val(static_cast<long>(finfo.sohm.version), 0, "H5File::getFileInfo", __LINE__, __FILE__, "finfo.sohm.version");
 
         // Close the file.
         file7.close();
@@ -916,26 +915,26 @@ test_file_info()
 
         // Get the file's version information.
         file7.getFileInfo(finfo);
-        verify_val(static_cast<long>(finfo.super.version), 2, "H5File::getFileInfo", __LINE__, __FILE__);
-        verify_val(static_cast<long>(finfo.free.version), 0, "H5File::getFileInfo", __LINE__, __FILE__);
-        verify_val(static_cast<long>(finfo.sohm.version), 0, "H5File::getFileInfo", __LINE__, __FILE__);
+        verify_val(static_cast<long>(finfo.super.version), 2, "H5File::getFileInfo", __LINE__, __FILE__, "finfo.super.version");
+        verify_val(static_cast<long>(finfo.free.version), 0, "H5File::getFileInfo", __LINE__, __FILE__, "finfo.free.version");
+        verify_val(static_cast<long>(finfo.sohm.version), 0, "H5File::getFileInfo", __LINE__, __FILE__, "finfo.sohm.version");
 
         // Retrieve the property values & check them.
         hsize_t userblock = fcpl2.getUserblock();
-        verify_val(userblock, F2_USERBLOCK_SIZE, "FileCreatPropList::getUserblock", __LINE__, __FILE__);
+        verify_val(userblock, F2_USERBLOCK_SIZE, "FileCreatPropList::getUserblock", __LINE__, __FILE__, "userblock");
 
         size_t off_size = 0, len_size = 0;
         fcpl2.getSizes(off_size, len_size);
-        verify_val(off_size, F2_OFFSET_SIZE, "FileCreatPropList::getSizes", __LINE__, __FILE__);
-        verify_val(len_size, F2_LENGTH_SIZE, "FileCreatPropList::getSizes", __LINE__, __FILE__);
+        verify_val(off_size, F2_OFFSET_SIZE, "FileCreatPropList::getSizes", __LINE__, __FILE__, "off_size");
+        verify_val(len_size, F2_LENGTH_SIZE, "FileCreatPropList::getSizes", __LINE__, __FILE__, "len_size");
 
         unsigned sym_ik = 0, sym_lk = 0;
         fcpl2.getSymk(sym_ik, sym_lk);
-        verify_val(sym_ik, F2_SYM_INTERN_K, "FileCreatPropList::getSymk", __LINE__, __FILE__);
-        verify_val(sym_lk, F2_SYM_LEAF_K, "FileCreatPropList::getSymk", __LINE__, __FILE__);
+        verify_val(sym_ik, F2_SYM_INTERN_K, "FileCreatPropList::getSymk", __LINE__, __FILE__, "sym_ik");
+        verify_val(sym_lk, F2_SYM_LEAF_K, "FileCreatPropList::getSymk", __LINE__, __FILE__, "sym_lk");
 
         unsigned istore_ik = fcpl2.getIstorek();
-        verify_val(istore_ik, F2_ISTORE, "FileCreatPropList::getIstorek", __LINE__, __FILE__);
+        verify_val(istore_ik, F2_ISTORE, "FileCreatPropList::getIstorek", __LINE__, __FILE__, "istore_ik");
 
         /*  ret=H5Pget_shared_mesg_nindexes(fcpl2,&nindexes);
         CHECK(ret, FAIL, "H5Pget_shared_mesg_nindexes");
@@ -945,12 +944,12 @@ test_file_info()
         // Get and verify the file space info from the creation property list */
         fcpl2.getFileSpaceStrategy(out_strategy, out_persist, out_threshold);
         verify_val(static_cast<long>(out_strategy), static_cast<long>(strategy),
-                   "FileCreatPropList::getFileSpaceStrategy", __LINE__, __FILE__);
-        verify_val(out_persist, persist, "FileCreatPropList::getFileSpaceStrategy", __LINE__, __FILE__);
-        verify_val(out_threshold, threshold, "FileCreatPropList::getFileSpaceStrategy", __LINE__, __FILE__);
+                   "FileCreatPropList::getFileSpaceStrategy", __LINE__, __FILE__, "out_strategy");
+        verify_val(out_persist, persist, "FileCreatPropList::getFileSpaceStrategy", __LINE__, __FILE__, "out_persist");
+        verify_val(out_threshold, threshold, "FileCreatPropList::getFileSpaceStrategy", __LINE__, __FILE__, "out_threshold");
 
         out_fsp_psize = fcpl2.getFileSpacePagesize();
-        verify_val(out_fsp_psize, FSP_SIZE512, "FileCreatPropList::getFileSpacePagesize", __LINE__, __FILE__);
+        verify_val(out_fsp_psize, FSP_SIZE512, "FileCreatPropList::getFileSpacePagesize", __LINE__, __FILE__, "out_fsp_psize");
 
         PASSED();
     } // end of try block
@@ -970,9 +969,6 @@ test_file_info()
 extern "C" void
 test_file()
 {
-    // Output message about test being performed
-    MESSAGE(5, ("Testing File I/O Operations\n"));
-
     test_file_create();    // Test file creation (also creation templates)
     test_file_open();      // Test file opening
     test_file_size();      // Test file size

--- a/c++/test/tfile.cpp
+++ b/c++/test/tfile.cpp
@@ -683,7 +683,8 @@ test_libver_bounds_real(H5F_libver_t libver_create, unsigned oh_vers_create, H5F
         H5O_native_info_t ninfo;
         memset(&ninfo, 0, sizeof(ninfo));
         file.getNativeObjinfo(ninfo, H5O_NATIVE_INFO_HDR);
-        verify_val(ninfo.hdr.version, oh_vers_create, "H5File::getNativeObjinfo", __LINE__, __FILE__, "ninfo.hdr.version");
+        verify_val(ninfo.hdr.version, oh_vers_create, "H5File::getNativeObjinfo", __LINE__, __FILE__,
+                   "ninfo.hdr.version");
 
         /*
          * Reopen the file and make sure the root group still has the correct
@@ -710,7 +711,8 @@ test_libver_bounds_real(H5F_libver_t libver_create, unsigned oh_vers_create, H5F
         // Verify object header version another way
         memset(&ninfo, 0, sizeof(ninfo));
         group.getNativeObjinfo(ninfo, H5O_NATIVE_INFO_HDR);
-        verify_val(ninfo.hdr.version, oh_vers_mod, "Group::getNativeObjinfo", __LINE__, __FILE__, "ninfo.hdr.version");
+        verify_val(ninfo.hdr.version, oh_vers_mod, "Group::getNativeObjinfo", __LINE__, __FILE__,
+                   "ninfo.hdr.version");
 
         group.close(); // close "/G1"
 
@@ -852,9 +854,12 @@ test_file_info()
         // Get the file's version information.
         H5F_info2_t finfo;
         tempfile.getFileInfo(finfo);
-        verify_val(static_cast<long>(finfo.super.version), 0, "H5File::getFileInfo", __LINE__, __FILE__, "finfo.super.version");
-        verify_val(static_cast<long>(finfo.free.version), 0, "H5File::getFileInfo", __LINE__, __FILE__, "finfo.free.version");
-        verify_val(static_cast<long>(finfo.sohm.version), 0, "H5File::getFileInfo", __LINE__, __FILE__, "finfo.sohm.version");
+        verify_val(static_cast<long>(finfo.super.version), 0, "H5File::getFileInfo", __LINE__, __FILE__,
+                   "finfo.super.version");
+        verify_val(static_cast<long>(finfo.free.version), 0, "H5File::getFileInfo", __LINE__, __FILE__,
+                   "finfo.free.version");
+        verify_val(static_cast<long>(finfo.sohm.version), 0, "H5File::getFileInfo", __LINE__, __FILE__,
+                   "finfo.sohm.version");
 
         // Close the file.
         tempfile.close();
@@ -869,12 +874,13 @@ test_file_info()
         verify_val(static_cast<long>(out_strategy), static_cast<long>(H5F_FSPACE_STRATEGY_FSM_AGGR),
                    "H5File::getFileInfo", __LINE__, __FILE__, "out_strategy");
         verify_val(out_persist, FALSE, "H5File::getFileInfo", __LINE__, __FILE__, "out_persist");
-        verify_val(static_cast<long>(out_threshold), 1, "H5File::getFileInfo", __LINE__, __FILE__, "out_threshold");
+        verify_val(static_cast<long>(out_threshold), 1, "H5File::getFileInfo", __LINE__, __FILE__,
+                   "out_threshold");
 
         /* Retrieve file space page size */
         hsize_t out_fsp_psize = fcpl.getFileSpacePagesize();
-        verify_val(out_fsp_psize, FSP_SIZE_DEF, "FileCreatPropList::getFileSpacePagesize", __LINE__,
-                   __FILE__, "out_fsp_psize");
+        verify_val(out_fsp_psize, FSP_SIZE_DEF, "FileCreatPropList::getFileSpacePagesize", __LINE__, __FILE__,
+                   "out_fsp_psize");
 
         // Set various file information.
         fcpl.setUserblock(F2_USERBLOCK_SIZE);
@@ -900,9 +906,12 @@ test_file_info()
 
         // Get the file's version information.
         file7.getFileInfo(finfo);
-        verify_val(static_cast<long>(finfo.super.version), 2, "H5File::getFileInfo", __LINE__, __FILE__, "finfo.super.version");
-        verify_val(static_cast<long>(finfo.free.version), 0, "H5File::getFileInfo", __LINE__, __FILE__, "finfo.free.version");
-        verify_val(static_cast<long>(finfo.sohm.version), 0, "H5File::getFileInfo", __LINE__, __FILE__, "finfo.sohm.version");
+        verify_val(static_cast<long>(finfo.super.version), 2, "H5File::getFileInfo", __LINE__, __FILE__,
+                   "finfo.super.version");
+        verify_val(static_cast<long>(finfo.free.version), 0, "H5File::getFileInfo", __LINE__, __FILE__,
+                   "finfo.free.version");
+        verify_val(static_cast<long>(finfo.sohm.version), 0, "H5File::getFileInfo", __LINE__, __FILE__,
+                   "finfo.sohm.version");
 
         // Close the file.
         file7.close();
@@ -915,13 +924,17 @@ test_file_info()
 
         // Get the file's version information.
         file7.getFileInfo(finfo);
-        verify_val(static_cast<long>(finfo.super.version), 2, "H5File::getFileInfo", __LINE__, __FILE__, "finfo.super.version");
-        verify_val(static_cast<long>(finfo.free.version), 0, "H5File::getFileInfo", __LINE__, __FILE__, "finfo.free.version");
-        verify_val(static_cast<long>(finfo.sohm.version), 0, "H5File::getFileInfo", __LINE__, __FILE__, "finfo.sohm.version");
+        verify_val(static_cast<long>(finfo.super.version), 2, "H5File::getFileInfo", __LINE__, __FILE__,
+                   "finfo.super.version");
+        verify_val(static_cast<long>(finfo.free.version), 0, "H5File::getFileInfo", __LINE__, __FILE__,
+                   "finfo.free.version");
+        verify_val(static_cast<long>(finfo.sohm.version), 0, "H5File::getFileInfo", __LINE__, __FILE__,
+                   "finfo.sohm.version");
 
         // Retrieve the property values & check them.
         hsize_t userblock = fcpl2.getUserblock();
-        verify_val(userblock, F2_USERBLOCK_SIZE, "FileCreatPropList::getUserblock", __LINE__, __FILE__, "userblock");
+        verify_val(userblock, F2_USERBLOCK_SIZE, "FileCreatPropList::getUserblock", __LINE__, __FILE__,
+                   "userblock");
 
         size_t off_size = 0, len_size = 0;
         fcpl2.getSizes(off_size, len_size);
@@ -945,11 +958,14 @@ test_file_info()
         fcpl2.getFileSpaceStrategy(out_strategy, out_persist, out_threshold);
         verify_val(static_cast<long>(out_strategy), static_cast<long>(strategy),
                    "FileCreatPropList::getFileSpaceStrategy", __LINE__, __FILE__, "out_strategy");
-        verify_val(out_persist, persist, "FileCreatPropList::getFileSpaceStrategy", __LINE__, __FILE__, "out_persist");
-        verify_val(out_threshold, threshold, "FileCreatPropList::getFileSpaceStrategy", __LINE__, __FILE__, "out_threshold");
+        verify_val(out_persist, persist, "FileCreatPropList::getFileSpaceStrategy", __LINE__, __FILE__,
+                   "out_persist");
+        verify_val(out_threshold, threshold, "FileCreatPropList::getFileSpaceStrategy", __LINE__, __FILE__,
+                   "out_threshold");
 
         out_fsp_psize = fcpl2.getFileSpacePagesize();
-        verify_val(out_fsp_psize, FSP_SIZE512, "FileCreatPropList::getFileSpacePagesize", __LINE__, __FILE__, "out_fsp_psize");
+        verify_val(out_fsp_psize, FSP_SIZE512, "FileCreatPropList::getFileSpacePagesize", __LINE__, __FILE__,
+                   "out_fsp_psize");
 
         PASSED();
     } // end of try block

--- a/c++/test/tfilter.cpp
+++ b/c++/test/tfilter.cpp
@@ -23,7 +23,6 @@ using std::endl;
 #include "H5Cpp.h" // C++ API header file
 using namespace H5;
 
-#include "h5test.h"
 #include "h5cpputil.h" // C++ utilility header file
 
 #ifdef H5_HAVE_FILTER_SZIP
@@ -146,7 +145,7 @@ test_szip_filter(H5File &file1)
     // Output message about test being performed
     SUBTEST("szip filter (with encoder)");
 
-    if (h5_szip_can_encode() == 1) {
+    if (h5tools_can_encode(H5Z_FILTER_SZIP) == 1) {
         char *tconv_buf = new char[1000];
         auto  points    = new int[DSET_DIM1][DSET_DIM2];
         auto  check     = new int[DSET_DIM1][DSET_DIM2];
@@ -229,11 +228,8 @@ const H5std_string FILE1("tfilters.h5");
 extern "C" void
 test_filters()
 {
-    // Output message about test being performed
-    MESSAGE(5, ("Testing Various Filters\n"));
-
     hid_t fapl_id;
-    fapl_id = h5_fileaccess(); // in h5test.c, returns a file access template
+    fapl_id = h5tools_get_new_fapl(H5P_DEFAULT); // in tools/lib
 
     try {
         // Use the file access template id to create a file access prop. list

--- a/c++/test/th5s.cpp
+++ b/c++/test/th5s.cpp
@@ -26,9 +26,7 @@ using std::endl;
 #include "H5Cpp.h" // C++ API header file
 using namespace H5;
 
-#include "h5test.h"
 #include "h5cpputil.h" // C++ utilility header file
-#include "H5srcdir.h"  // srcdir querying header file
 
 const H5std_string TESTFILE("th5s.h5");
 const H5std_string DATAFILE("th5s1.h5");
@@ -104,20 +102,20 @@ test_h5s_basic()
         hssize_t n; // Number of dataspace elements
         n = sid1.getSimpleExtentNpoints();
         verify_val(static_cast<long>(n), SPACE1_DIM1 * SPACE1_DIM2 * SPACE1_DIM3,
-                   "DataSpace::getSimpleExtentNpoints", __LINE__, __FILE__);
+                   "DataSpace::getSimpleExtentNpoints", __LINE__, __FILE__, "n");
 
         // Get the logical rank of dataspace sid1 and verify it
         int rank; // Logical rank of dataspace
         rank = sid1.getSimpleExtentNdims();
-        verify_val(rank, SPACE1_RANK, "DataSpace::getSimpleExtentNdims", __LINE__, __FILE__);
+        verify_val(rank, SPACE1_RANK, "DataSpace::getSimpleExtentNdims", __LINE__, __FILE__, "rank");
 
         // Retrieves dimension size of dataspace sid1 and verify it
         int     ndims;    // Number of dimensions
         hsize_t tdims[4]; // Dimension array to test with
         ndims = sid1.getSimpleExtentDims(tdims);
-        verify_val(ndims, SPACE1_RANK, "DataSpace::getSimpleExtentDims", __LINE__, __FILE__);
+        verify_val(ndims, SPACE1_RANK, "DataSpace::getSimpleExtentDims", __LINE__, __FILE__, "ndims");
         verify_val(memcmp(tdims, dims1, SPACE1_RANK * sizeof(unsigned)), 0, "DataSpace::getSimpleExtentDims",
-                   __LINE__, __FILE__);
+                   __LINE__, __FILE__, "tdims");
 
         // Create simple dataspace sid2
         hsize_t   max2[] = {SPACE2_MAX1, SPACE2_MAX2, SPACE2_MAX3, SPACE2_MAX4};
@@ -126,19 +124,19 @@ test_h5s_basic()
         // Get simple extent npoints of dataspace sid2 and verify it
         n = sid2.getSimpleExtentNpoints();
         verify_val(static_cast<long>(n), SPACE2_DIM1 * SPACE2_DIM2 * SPACE2_DIM3 * SPACE2_DIM4,
-                   "DataSpace::getSimpleExtentNpoints", __LINE__, __FILE__);
+                   "DataSpace::getSimpleExtentNpoints", __LINE__, __FILE__, "n");
 
         // Get the logical rank of dataspace sid2 and verify it
         rank = sid2.getSimpleExtentNdims();
-        verify_val(rank, SPACE2_RANK, "DataSpace::getSimpleExtentNdims", __LINE__, __FILE__);
+        verify_val(rank, SPACE2_RANK, "DataSpace::getSimpleExtentNdims", __LINE__, __FILE__, "rank");
 
         // Retrieves dimension size and max size of dataspace sid2 and
         // verify them
         ndims = sid2.getSimpleExtentDims(tdims, tmax);
         verify_val(memcmp(tdims, dims2, SPACE2_RANK * sizeof(unsigned)), 0, "DataSpace::getSimpleExtentDims",
-                   __LINE__, __FILE__);
+                   __LINE__, __FILE__, "tdims");
         verify_val(memcmp(tmax, max2, SPACE2_RANK * sizeof(unsigned)), 0, "DataSpace::getSimpleExtentDims",
-                   __LINE__, __FILE__);
+                   __LINE__, __FILE__, "tmax");
 
         // Check to be sure we can't create a simple data space that has too
         // many dimensions.
@@ -162,7 +160,7 @@ test_h5s_basic()
          */
         char *tmp_str = new char[TESTFILE.length() + 1];
         strcpy(tmp_str, TESTFILE.c_str());
-        const char *testfile = H5_get_srcdir_filename(tmp_str);
+        const char *testfile = h5cpp_get_srcdir_filename(tmp_str);
         delete[] tmp_str;
 
         // Create file
@@ -223,23 +221,23 @@ test_h5s_scalar_write()
         // n = H5Sget_simple_extent_npoints(sid1);
         hssize_t n; // Number of dataspace elements
         n = sid1.getSimpleExtentNpoints();
-        verify_val(static_cast<long>(n), 1, "DataSpace::getSimpleExtentNpoints", __LINE__, __FILE__);
+        verify_val(static_cast<long>(n), 1, "DataSpace::getSimpleExtentNpoints", __LINE__, __FILE__, "n");
 
         int rank; // Logical rank of dataspace
         rank = sid1.getSimpleExtentNdims();
-        verify_val(rank, SPACE3_RANK, "DataSpace::getSimpleExtentNdims", __LINE__, __FILE__);
+        verify_val(rank, SPACE3_RANK, "DataSpace::getSimpleExtentNdims", __LINE__, __FILE__, "rank");
 
         // Retrieves dimension size of dataspace sid1 and verify it
         int     ndims;    // Number of dimensions
         hsize_t tdims[4]; // Dimension array to test with
         ndims = sid1.getSimpleExtentDims(tdims);
-        verify_val(ndims, 0, "DataSpace::getSimpleExtentDims", __LINE__, __FILE__);
+        verify_val(ndims, 0, "DataSpace::getSimpleExtentDims", __LINE__, __FILE__, "ndims");
 
         // Verify extent type
         H5S_class_t ext_type; // Extent type
         ext_type = sid1.getSimpleExtentType();
         verify_val(static_cast<long>(ext_type), static_cast<long>(H5S_SCALAR),
-                   "DataSpace::getSimpleExtentType", __LINE__, __FILE__);
+                   "DataSpace::getSimpleExtentType", __LINE__, __FILE__, "ext_type");
 
         // Create and write a dataset
         DataSet dataset = fid1.createDataSet("Dataset1", PredType::NATIVE_UINT, sid1);
@@ -279,19 +277,19 @@ test_h5s_scalar_read()
 
         // Get the number of dataspace elements
         hssize_t n = sid1.getSimpleExtentNpoints();
-        verify_val(static_cast<long>(n), 1, "DataSpace::getSimpleExtentNpoints", __LINE__, __FILE__);
+        verify_val(static_cast<long>(n), 1, "DataSpace::getSimpleExtentNpoints", __LINE__, __FILE__, "n");
 
         // Get the logical rank of the dataspace
         int ndims = sid1.getSimpleExtentNdims();
-        verify_val(ndims, SPACE3_RANK, "DataSpace::getSimpleExtentNdims", __LINE__, __FILE__);
+        verify_val(ndims, SPACE3_RANK, "DataSpace::getSimpleExtentNdims", __LINE__, __FILE__, "ndims");
 
         ndims = sid1.getSimpleExtentDims(tdims);
-        verify_val(ndims, 0, "DataSpace::getSimpleExtentDims", __LINE__, __FILE__);
+        verify_val(ndims, 0, "DataSpace::getSimpleExtentDims", __LINE__, __FILE__, "ndims");
 
         // Read data back and verify it
         unsigned rdata; // Scalar data read in
         dataset.read(&rdata, PredType::NATIVE_UINT);
-        verify_val(rdata, space3_data, "DataSet::read", __LINE__, __FILE__);
+        verify_val(rdata, space3_data, "DataSet::read", __LINE__, __FILE__, "rdata");
 
         PASSED();
     } // end of try block
@@ -325,7 +323,7 @@ test_h5s_null()
 
         hssize_t n; // Number of dataspace elements
         n = sid1.getSimpleExtentNpoints();
-        verify_val(static_cast<long>(n), 0, "DataSpace::getSimpleExtentNpoints", __LINE__, __FILE__);
+        verify_val(static_cast<long>(n), 0, "DataSpace::getSimpleExtentNpoints", __LINE__, __FILE__, "n");
 
         // Create a dataset
         DataSet dataset = fid1.createDataSet("Dataset1", PredType::NATIVE_UINT, sid1);
@@ -335,7 +333,7 @@ test_h5s_null()
 
         // Read the data.  Make sure no change to the buffer
         dataset.read(&space5_data, PredType::NATIVE_INT);
-        verify_val(space5_data, 7, "DataSet::read", __LINE__, __FILE__);
+        verify_val(space5_data, 7, "DataSet::read", __LINE__, __FILE__, "space5_data");
 
         PASSED();
     } // end of try block
@@ -379,15 +377,15 @@ test_h5s_compound_scalar_write()
 
         // Get the number of dataspace elements
         hssize_t n = sid1.getSimpleExtentNpoints();
-        verify_val(static_cast<long>(n), 1, "DataSpace::getSimpleExtentNpoints", __LINE__, __FILE__);
+        verify_val(static_cast<long>(n), 1, "DataSpace::getSimpleExtentNpoints", __LINE__, __FILE__, "n");
 
         // Get the logical rank of the dataspace
         int ndims = sid1.getSimpleExtentNdims();
-        verify_val(ndims, SPACE3_RANK, "DataSpace::getSimpleExtentNdims", __LINE__, __FILE__);
+        verify_val(ndims, SPACE3_RANK, "DataSpace::getSimpleExtentNdims", __LINE__, __FILE__, "ndims");
 
         hsize_t tdims[4]; // Dimension array to test with
         ndims = sid1.getSimpleExtentDims(tdims);
-        verify_val(ndims, 0, "DataSpace::getSimpleExtentDims", __LINE__, __FILE__);
+        verify_val(ndims, 0, "DataSpace::getSimpleExtentDims", __LINE__, __FILE__, "ndims");
 
         // Create and write a dataset
         DataSet dataset = fid1.createDataSet("Dataset1", tid1, sid1);
@@ -428,14 +426,14 @@ test_h5s_compound_scalar_read()
 
         // Get the number of dataspace elements
         hssize_t n = sid1.getSimpleExtentNpoints();
-        verify_val(static_cast<long>(n), 1, "DataSpace::getSimpleExtentNpoints", __LINE__, __FILE__);
+        verify_val(static_cast<long>(n), 1, "DataSpace::getSimpleExtentNpoints", __LINE__, __FILE__, "n");
 
         // Get the logical rank of the dataspace
         int ndims = sid1.getSimpleExtentNdims();
-        verify_val(ndims, SPACE3_RANK, "DataSpace::getSimpleExtentNdims", __LINE__, __FILE__);
+        verify_val(ndims, SPACE3_RANK, "DataSpace::getSimpleExtentNdims", __LINE__, __FILE__, "ndims");
 
         ndims = sid1.getSimpleExtentDims(tdims);
-        verify_val(ndims, 0, "DataSpace::getSimpleExtentDims", __LINE__, __FILE__);
+        verify_val(ndims, 0, "DataSpace::getSimpleExtentDims", __LINE__, __FILE__, "ndims");
 
         // Get the datatype of this dataset.
         CompType type(dataset);
@@ -445,15 +443,14 @@ test_h5s_compound_scalar_read()
 
         // Verify read data
         if (memcmp(&space4_data, &rdata, sizeof(struct space4_struct)) != 0) {
-            cerr << "scalar data different: space4_data.c1=" << space4_data.c1
-                 << ", read_data4.c1=" << rdata.c1 << endl;
-            cerr << "scalar data different: space4_data.u=" << space4_data.u << ", read_data4.u=" << rdata.u
-                 << endl;
-            cerr << "scalar data different: space4_data.f=" << space4_data.f << ", read_data4.f=" << rdata.f
-                 << endl;
-            TestErrPrintf("scalar data different: space4_data.c1=%c, read_data4.c1=%c\n", space4_data.c1,
-                          rdata.c2);
-        } // end if
+
+            verify_val(rdata.c1, space4_data.c1, "DataSet::read", __LINE__, __FILE__, "rdata.c1");
+            verify_val(rdata.u, space4_data.u, "DataSet::read", __LINE__, __FILE__, "rdata.u");
+            if (abs(rdata.f - space4_data.f) > FLT_EPSILON)
+                display_difference(rdata.f, space4_data.f, "DataSet::read", __LINE__, __FILE__, "rdata.f");
+            verify_val(rdata.c2, space4_data.c2, "DataSet::read", __LINE__, __FILE__, "rdata.c2");
+        }
+
         PASSED();
     } // end of try block
     catch (Exception &E) {
@@ -473,9 +470,6 @@ test_h5s_compound_scalar_read()
 extern "C" void
 test_h5s()
 {
-    // Output message about test being performed
-    MESSAGE(5, ("Testing Dataspaces\n"));
-
     test_h5s_basic();                 // Test basic H5S code
     test_h5s_scalar_write();          // Test scalar H5S writing code
     test_h5s_scalar_read();           // Test scalar H5S reading code

--- a/c++/test/titerate.cpp
+++ b/c++/test/titerate.cpp
@@ -23,7 +23,6 @@ using std::endl;
 #include "H5Cpp.h" // C++ API header file
 using namespace H5;
 
-#include "h5test.h"
 #include "h5cpputil.h" // C++ utilility header file
 
 /* Number of datasets for group iteration test */
@@ -148,7 +147,7 @@ test_iter_group(FileAccPropList &fapl)
         info.command = RET_ZERO;
         idx          = 0;
         ret          = H5Literate2(file.getId(), H5_INDEX_NAME, H5_ITER_INC, &idx, liter_cb, &info);
-        verify_val(ret, SUCCEED, "H5Literate", __LINE__, __FILE__);
+        verify_val(ret, SUCCEED, "H5Literate", __LINE__, __FILE__, "ret");
 
         DataType datatype(PredType::NATIVE_INT);
 
@@ -188,7 +187,7 @@ test_iter_group(FileAccPropList &fapl)
 
         // Get the number of object in the root group
         hsize_t nobjs = root_group.getNumObjs();
-        verify_val(static_cast<long>(nobjs), NDATASETS + 2, "H5Gget_info", __LINE__, __FILE__);
+        verify_val(static_cast<long>(nobjs), NDATASETS + 2, "H5Gget_info", __LINE__, __FILE__, "nobjs");
 
         H5std_string obj_name;
         for (hsize_t i = 0; i < nobjs; i++) {
@@ -281,7 +280,7 @@ test_iter_group(FileAccPropList &fapl)
     info.command = RET_ZERO;
     idx = 0;
     if((ret = H5Literate2(file, H5_INDEX_NAME, H5_ITER_INC, &idx, liter_cb, &info)) > 0)
-        TestErrPrintf("Group iteration function didn't return zero correctly!\n");
+        display_error("Group iteration function didn't return zero correctly!", "test_iter_group", __LINE__, __FILE__);
 
     /* Test all objects in group, when callback always returns 1 */
     /* This also tests the "restarting" ability, because the index changes */
@@ -290,24 +289,21 @@ test_iter_group(FileAccPropList &fapl)
     idx = 0;
     while((ret = H5Literate2(file, H5_INDEX_NAME, H5_ITER_INC, &idx, liter_cb, &info)) > 0) {
         /* Verify return value from iterator gets propagated correctly */
-        verify_val(ret, 2, "H5Literate", __LINE__, __FILE__);
+        verify_val(ret, 2, "H5Literate", __LINE__, __FILE__, "ret");
 
         /* Increment the number of times "2" is returned */
         i++;
 
         /* Verify that the index is the correct value */
-        verify_val(idx, (hsize_t)i, "H5Literate", __LINE__, __FILE__);
+        verify_val(idx, (hsize_t)i, "H5Literate", __LINE__, __FILE__, "idx");
         if(idx > (NDATASETS + 2))
-            TestErrPrintf("Group iteration function walked too far!\n");
+            display_error("Group iteration function walked too far!", "test_iter_group", __LINE__, __FILE__);
 
         /* Verify that the correct name is retrieved */
-        if(strcmp(info.name, lnames[(size_t)(idx - 1)]) != 0)
-            TestErrPrintf("Group iteration function didn't return name correctly for link - lnames[%u] = '%s'!\n", (unsigned)(idx - 1), lnames[(size_t)(idx - 1)]);
+        verify_val(info.name, lnames[(size_t)(idx - 1)], "H5Literate", __LINE__, __FILE__, "info.name");
     } /* end while */
-    verify_val(ret, -1, "H5Literate", __LINE__, __FILE__);
 
-    if(i != (NDATASETS + 2))
-        TestErrPrintf("%u: Group iteration function didn't perform multiple iterations correctly!\n", __LINE__);
+    verify_val(i, NDATASETS + 2, "H5Literate", __LINE__, __FILE__, "i");
 
     /* Test all objects in group, when callback changes return value */
     /* This also tests the "restarting" ability, because the index changes */
@@ -316,24 +312,23 @@ test_iter_group(FileAccPropList &fapl)
     idx = 0;
     while((ret = H5Literate2(file, H5_INDEX_NAME, H5_ITER_INC, &idx, liter_cb, &info)) >= 0) {
         /* Verify return value from iterator gets propagated correctly */
-        verify_val(ret, 1, "H5Literate", __LINE__, __FILE__);
+        verify_val(ret, 1, "H5Literate", __LINE__, __FILE__, "ret");
 
         /* Increment the number of times "1" is returned */
         i++;
 
         /* Verify that the index is the correct value */
-        verify_val(idx, (hsize_t)(i + 10), "H5Literate", __LINE__, __FILE__);
+        verify_val(idx, (hsize_t)(i + 10), "H5Literate", __LINE__, __FILE__, "idx");
         if(idx > (NDATASETS + 2))
-            TestErrPrintf("Group iteration function walked too far!\n");
+            display_error("Group iteration function walked too far!", "test_iter_group", __LINE__, __FILE__);
 
         /* Verify that the correct name is retrieved */
-        if(strcmp(info.name, lnames[(size_t)(idx - 1)]) != 0)
-            TestErrPrintf("Group iteration function didn't return name correctly for link - lnames[%u] = '%s'!\n", (unsigned)(idx - 1), lnames[(size_t)(idx - 1)]);
+        verify_val(info.name, lnames[(size_t)(idx - 1)], "H5Literate", __LINE__, __FILE__, "info.name");
     } /* end while */
-    verify_val(ret, -1, "H5Literate", __LINE__, __FILE__);
+    verify_val(ret, -1, "H5Literate", __LINE__, __FILE__, "ret");
 
     if(i != 42 || idx != 52)
-        TestErrPrintf("%u: Group iteration function didn't perform multiple iterations correctly!\n", __LINE__);
+        display_error("Group iteration function didn't perform multiple iterations correctly!", "test_iter_group", __LINE__, __FILE__);
 
     ret = H5Fclose(file);
     CHECK(ret, FAIL, "H5Fclose");
@@ -367,7 +362,7 @@ printelems(const Group &group, const H5std_string &dsname, const H5std_string &a
         unsigned     idx = 0;
         Attribute    a1(group.openAttribute(idx));
         H5std_string aname = a1.getName();
-        verify_val(aname, atname, "printelems", __LINE__, __FILE__);
+        verify_val(aname, atname, "printelems", __LINE__, __FILE__, "aname");
 
         a1.close();
     }
@@ -442,9 +437,6 @@ test_HDFFV_9920()
 extern "C" void
 test_iterate()
 {
-    // Output message about test being performed
-    MESSAGE(5, ("Testing Iterate Feature\n"));
-
     // Create access property with latest library version.
     FileAccPropList fapl;
     fapl.setLibverBounds(H5F_LIBVER_LATEST, H5F_LIBVER_LATEST);

--- a/c++/test/tlinks.cpp
+++ b/c++/test/tlinks.cpp
@@ -24,7 +24,6 @@ using std::endl;
 #include "H5Cpp.h" // C++ API header file
 using namespace H5;
 
-#include "h5test.h"
 #include "h5cpputil.h" // C++ utilility header file
 
 #define NAME_BUF_SIZE 1024
@@ -71,7 +70,7 @@ test_basic_links(hid_t fapl_id, hbool_t new_format)
         else
             SUBTEST("Link creation");
 
-        h5_fixname(FILENAME[0], fapl_id, filename, sizeof filename);
+        h5cpp_fixname(FILENAME[0], fapl_id, filename, sizeof filename);
         H5File file(filename, H5F_ACC_TRUNC, FileCreatPropList::DEFAULT, fapl);
 
         // Create simple dataspace
@@ -110,13 +109,13 @@ test_basic_links(hid_t fapl_id, hbool_t new_format)
         // Verify link values before closing the file
 
         H5std_string softlink_val = file.getLinkval("grp1/soft");
-        verify_val(softlink_val, "/dset1", "H5File::getLinkval grp1/soft", __LINE__, __FILE__);
+        verify_val(softlink_val, "/dset1", "H5File::getLinkval grp1/soft", __LINE__, __FILE__, "softlink_val");
 
         H5std_string dngllink_val = file.getLinkval("grp1/dangle");
-        verify_val(dngllink_val, "foobar", "H5File::getLinkval grp1/dangle", __LINE__, __FILE__);
+        verify_val(dngllink_val, "foobar", "H5File::getLinkval grp1/dangle", __LINE__, __FILE__, "dngllink_val");
 
         H5std_string reclink_val = file.getLinkval("grp1/recursive");
-        verify_val(reclink_val, "/grp1/recursive", "H5File::getLinkval grp1/recursive", __LINE__, __FILE__);
+        verify_val(reclink_val, "/grp1/recursive", "H5File::getLinkval grp1/recursive", __LINE__, __FILE__, "reclink_val");
 
     } // end of try block
     catch (Exception &E) {
@@ -141,10 +140,10 @@ test_basic_links(hid_t fapl_id, hbool_t new_format)
 
         // Verify link values
         H5std_string softlink_val = file.getLinkval("grp1/soft");
-        verify_val(softlink_val, "/dset1", "H5File::getLinkval grp1/soft", __LINE__, __FILE__);
+        verify_val(softlink_val, "/dset1", "H5File::getLinkval grp1/soft", __LINE__, __FILE__, "softlink_val");
 
         H5std_string reclink_val = file.getLinkval("grp1/recursive");
-        verify_val(reclink_val, "/grp1/recursive", "H5File::getLinkval grp1/recursive", __LINE__, __FILE__);
+        verify_val(reclink_val, "/grp1/recursive", "H5File::getLinkval grp1/recursive", __LINE__, __FILE__, "reclink_val");
 
         PASSED();
     } // end of try block
@@ -182,7 +181,7 @@ test_lcpl(hid_t fapl_id, hbool_t new_format)
         FileAccPropList fapl(fapl_id);
 
         // Create a new file.
-        h5_fixname(FILENAME[0], fapl_id, filename, sizeof filename);
+        h5cpp_fixname(FILENAME[0], fapl_id, filename, sizeof filename);
         H5File file(filename, H5F_ACC_TRUNC, FileCreatPropList::DEFAULT, fapl);
 
         // Create and link a group with the default LCPL.
@@ -202,7 +201,7 @@ test_lcpl(hid_t fapl_id, hbool_t new_format)
         // Check that its character encoding is the default.
         linfo = file.getLinkInfo("/type");
         verify_val(static_cast<long>(linfo.cset), static_cast<long>(H5T_CSET_ASCII),
-                   "Character encoding is not default", __LINE__, __FILE__);
+                   "Character encoding is not default", __LINE__, __FILE__, "linfo.cset");
 
         // Create a simple dataspace.
         dims[0] = H5L_DIM1;
@@ -216,7 +215,7 @@ test_lcpl(hid_t fapl_id, hbool_t new_format)
         // Check that its character encoding is the default.
         linfo = file.getLinkInfo("/dataset");
         verify_val(static_cast<long>(linfo.cset), static_cast<long>(H5T_CSET_ASCII),
-                   "Character encoding is not default", __LINE__, __FILE__);
+                   "Character encoding is not default", __LINE__, __FILE__, "linfo.cset");
 
         // Create a link creation property list with the UTF-8 character encoding.
         LinkCreatPropList lcpl;
@@ -229,7 +228,7 @@ test_lcpl(hid_t fapl_id, hbool_t new_format)
         // Check that its character encoding is UTF-8.
         linfo = file.getLinkInfo(GROUP2NAME);
         verify_val(static_cast<long>(linfo.cset), static_cast<long>(H5T_CSET_UTF8),
-                   "Character encoding is not UTF-8", __LINE__, __FILE__);
+                   "Character encoding is not UTF-8", __LINE__, __FILE__, "linfo.cset");
 
         PASSED();
     } // end of try block
@@ -262,9 +261,9 @@ test_move(hid_t fapl_id, hbool_t new_format)
         FileAccPropList fapl(fapl_id);
 
         // Create two new files
-        h5_fixname(FILENAME[0], fapl_id, filename, sizeof filename);
+        h5cpp_fixname(FILENAME[0], fapl_id, filename, sizeof filename);
         H5File file_a(filename, H5F_ACC_TRUNC, FileCreatPropList::DEFAULT, fapl);
-        h5_fixname(FILENAME[1], fapl_id, filename, sizeof filename);
+        h5cpp_fixname(FILENAME[1], fapl_id, filename, sizeof filename);
         H5File file_b(filename, H5F_ACC_TRUNC, FileCreatPropList::DEFAULT, fapl);
 
         // Create groups in first file
@@ -405,9 +404,9 @@ test_copy(hid_t fapl_id, hbool_t new_format)
 
     try {
         // Create two new files
-        h5_fixname(FILENAME[0], fapl_id, filename, sizeof filename);
+        h5cpp_fixname(FILENAME[0], fapl_id, filename, sizeof filename);
         H5File file_a(filename, H5F_ACC_TRUNC, FileCreatPropList::DEFAULT, fapl_id);
-        h5_fixname(FILENAME[1], fapl_id, filename, sizeof filename);
+        h5cpp_fixname(FILENAME[1], fapl_id, filename, sizeof filename);
         H5File file_b(filename, H5F_ACC_TRUNC, FileCreatPropList::DEFAULT, fapl_id);
 
         // Create groups in first file
@@ -545,7 +544,7 @@ test_num_links(hid_t fapl_id, hbool_t new_format)
         // Use the file access template id to create a file access prop. list.
         FileAccPropList fapl(fapl_id);
 
-        h5_fixname(FILENAME[0], fapl_id, filename, sizeof filename);
+        h5cpp_fixname(FILENAME[0], fapl_id, filename, sizeof filename);
         H5File file(filename, H5F_ACC_RDWR, FileCreatPropList::DEFAULT, fapl);
 
         LinkAccPropList lapl;
@@ -554,7 +553,7 @@ test_num_links(hid_t fapl_id, hbool_t new_format)
 
         // Read it back and verify
         size_t read_nlinks = lapl.getNumLinks();
-        verify_val(read_nlinks, nlinks, "LinkAccPropList::setNumLinks", __LINE__, __FILE__);
+        verify_val(read_nlinks, nlinks, "LinkAccPropList::setNumLinks", __LINE__, __FILE__, "read_nlinks");
 
         PASSED();
     } // end of try block
@@ -631,7 +630,7 @@ test_visit(hid_t fapl_id, hbool_t new_format)
         FileAccPropList fapl(fapl_id);
 
         // Build the hdf5 file name and create the file
-        h5_fixname(FILENAME[3], fapl_id, filename, sizeof filename);
+        h5cpp_fixname(FILENAME[3], fapl_id, filename, sizeof filename);
         H5File *file = new H5File(filename, H5F_ACC_TRUNC, FileCreatPropList::DEFAULT, fapl);
 
         // Create a group
@@ -714,11 +713,8 @@ test_links()
     hid_t    fapl_id, fapl2_id; /* File access property lists */
     unsigned new_format;        /* Whether to use the new format or not */
 
-    if ((fapl_id = h5_fileaccess()) < 0)
-        throw Exception("test_links", "Unable to get file access property list");
+    fapl_id = h5tools_get_new_fapl(H5P_DEFAULT); // in tools/lib
 
-    // Output message about test being performed
-    MESSAGE(5, ("Testing Various Links\n"));
     try {
         /* Copy the file access property list */
         if ((fapl2_id = H5Pcopy(fapl_id)) < 0)
@@ -752,8 +748,7 @@ test_links()
         /* Close 2nd FAPL */
         H5Pclose(fapl2_id);
 
-        h5_delete_all_test_files(FILENAME, fapl_id);
-        H5Pclose(fapl_id);
+        cleanup_links();
     }
     catch (Exception &E) {
         issue_fail_msg("test_links()", __LINE__, __FILE__, E.getCDetailMsg());
@@ -773,4 +768,5 @@ cleanup_links()
 {
     HDremove(FILENAME[0]);
     HDremove(FILENAME[1]);
+    HDremove(FILENAME[3]);
 }

--- a/c++/test/tlinks.cpp
+++ b/c++/test/tlinks.cpp
@@ -109,13 +109,16 @@ test_basic_links(hid_t fapl_id, hbool_t new_format)
         // Verify link values before closing the file
 
         H5std_string softlink_val = file.getLinkval("grp1/soft");
-        verify_val(softlink_val, "/dset1", "H5File::getLinkval grp1/soft", __LINE__, __FILE__, "softlink_val");
+        verify_val(softlink_val, "/dset1", "H5File::getLinkval grp1/soft", __LINE__, __FILE__,
+                   "softlink_val");
 
         H5std_string dngllink_val = file.getLinkval("grp1/dangle");
-        verify_val(dngllink_val, "foobar", "H5File::getLinkval grp1/dangle", __LINE__, __FILE__, "dngllink_val");
+        verify_val(dngllink_val, "foobar", "H5File::getLinkval grp1/dangle", __LINE__, __FILE__,
+                   "dngllink_val");
 
         H5std_string reclink_val = file.getLinkval("grp1/recursive");
-        verify_val(reclink_val, "/grp1/recursive", "H5File::getLinkval grp1/recursive", __LINE__, __FILE__, "reclink_val");
+        verify_val(reclink_val, "/grp1/recursive", "H5File::getLinkval grp1/recursive", __LINE__, __FILE__,
+                   "reclink_val");
 
     } // end of try block
     catch (Exception &E) {
@@ -140,10 +143,12 @@ test_basic_links(hid_t fapl_id, hbool_t new_format)
 
         // Verify link values
         H5std_string softlink_val = file.getLinkval("grp1/soft");
-        verify_val(softlink_val, "/dset1", "H5File::getLinkval grp1/soft", __LINE__, __FILE__, "softlink_val");
+        verify_val(softlink_val, "/dset1", "H5File::getLinkval grp1/soft", __LINE__, __FILE__,
+                   "softlink_val");
 
         H5std_string reclink_val = file.getLinkval("grp1/recursive");
-        verify_val(reclink_val, "/grp1/recursive", "H5File::getLinkval grp1/recursive", __LINE__, __FILE__, "reclink_val");
+        verify_val(reclink_val, "/grp1/recursive", "H5File::getLinkval grp1/recursive", __LINE__, __FILE__,
+                   "reclink_val");
 
         PASSED();
     } // end of try block

--- a/c++/test/tobject.cpp
+++ b/c++/test/tobject.cpp
@@ -21,7 +21,6 @@
 #include "H5Cpp.h" // C++ API header file
 using namespace H5;
 
-#include "h5test.h"
 #include "h5cpputil.h" // C++ utilility header file
 
 const H5std_string FILE_OBJECTS("tobjects.h5");
@@ -83,7 +82,7 @@ test_get_objname()
         if (name_len > 4) {
             char *grp1_name = new char[5];
             name_len        = grp1.getObjName(grp1_name, 5);
-            verify_val(const_cast<const char *>(grp1_name), "/Top", "Group::getObjName", __LINE__, __FILE__);
+            verify_val(const_cast<const char *>(grp1_name), "/Top", "Group::getObjName", __LINE__, __FILE__, "grp1_name");
             delete[] grp1_name;
         }
 
@@ -103,10 +102,10 @@ test_get_objname()
         // H5std_string getObjName() and
         // ssize_t getObjName(H5std_string& obj_name, size_t len = 0)
         H5std_string ds_name = dsinfile.getObjName();
-        verify_val(ds_name, DSET_IN_FILE_PATH, "DataSet::getObjName", __LINE__, __FILE__);
+        verify_val(ds_name, DSET_IN_FILE_PATH, "DataSet::getObjName", __LINE__, __FILE__, "ds_name");
 
         name_len = dsingrp.getObjName(ds_name); // default len
-        verify_val(ds_name, DSET_IN_GRP1_PATH, "DataSet::getObjName", __LINE__, __FILE__);
+        verify_val(ds_name, DSET_IN_GRP1_PATH, "DataSet::getObjName", __LINE__, __FILE__, "ds_name");
 
         // Close dataset
         dsingrp.close();
@@ -117,7 +116,7 @@ test_get_objname()
         // Get and verify the name of the dataset that belongs to subgroup
         // 1.2, using H5std_string getObjName()
         ds_name = dsingrp.getObjName();
-        verify_val(ds_name, DSET_IN_GRP1_2_PATH, "DataSet::getObjName", __LINE__, __FILE__);
+        verify_val(ds_name, DSET_IN_GRP1_2_PATH, "DataSet::getObjName", __LINE__, __FILE__, "ds_name");
 
         // Close dataset
         dsingrp.close();
@@ -126,7 +125,7 @@ test_get_objname()
         // overload: ssize_t getObjName(H5std_string& obj_name, size_t len = 0)
         dsingrp  = grp1_2.openDataSet(DSET_IN_GRP1_2);
         name_len = dsingrp.getObjName(ds_name);
-        verify_val(ds_name, DSET_IN_GRP1_2_PATH, "DataSet::getObjName", __LINE__, __FILE__);
+        verify_val(ds_name, DSET_IN_GRP1_2_PATH, "DataSet::getObjName", __LINE__, __FILE__, "ds_name");
 
         // Everything will be closed as they go out of scope
 
@@ -169,54 +168,54 @@ test_existance()
 
         // Check if GROUP1 exists in the file
         bool exists = file.nameExists(GROUP1);
-        verify_val(exists, TRUE, "Group::nameExists GROUP1_1", __LINE__, __FILE__);
+        verify_val(exists, TRUE, "Group::nameExists GROUP1_1", __LINE__, __FILE__, "exists");
         // Deprecated
         exists = file.exists(GROUP1);
-        verify_val(exists, TRUE, "Group::exists GROUP1_1", __LINE__, __FILE__);
+        verify_val(exists, TRUE, "Group::exists GROUP1_1", __LINE__, __FILE__, "exists");
 
         // Open GROUP1
         Group grp1 = file.openGroup(GROUP1);
 
         // Check if GROUP1_1 and GROUP1_2 exist in GROUP1
         exists = grp1.nameExists(GROUP1_1);
-        verify_val(exists, TRUE, "Group::nameExists GROUP1_1", __LINE__, __FILE__);
+        verify_val(exists, TRUE, "Group::nameExists GROUP1_1", __LINE__, __FILE__, "exists");
         exists = grp1.nameExists(GROUP1_2);
-        verify_val(exists, TRUE, "Group::nameExists GROUP1_2", __LINE__, __FILE__);
+        verify_val(exists, TRUE, "Group::nameExists GROUP1_2", __LINE__, __FILE__, "exists");
         // Deprecated
         exists = grp1.exists(GROUP1_1);
-        verify_val(exists, TRUE, "Group::exists GROUP1_1", __LINE__, __FILE__);
+        verify_val(exists, TRUE, "Group::exists GROUP1_1", __LINE__, __FILE__, "exists");
         exists = grp1.exists(GROUP1_2);
-        verify_val(exists, TRUE, "Group::exists GROUP1_2", __LINE__, __FILE__);
+        verify_val(exists, TRUE, "Group::exists GROUP1_2", __LINE__, __FILE__, "exists");
 
         // Check if DSET_IN_GRP1 exists in GROUP1
         exists = grp1.nameExists(DSET_IN_GRP1);
-        verify_val(exists, TRUE, "Group::nameExists DSET_IN_GRP1", __LINE__, __FILE__);
+        verify_val(exists, TRUE, "Group::nameExists DSET_IN_GRP1", __LINE__, __FILE__, "exists");
         // Deprecated
         exists = grp1.exists(DSET_IN_GRP1);
-        verify_val(exists, TRUE, "Group::exists DSET_IN_GRP1", __LINE__, __FILE__);
+        verify_val(exists, TRUE, "Group::exists DSET_IN_GRP1", __LINE__, __FILE__, "exists");
 
         // Open GROUP1_2
         Group grp1_2 = grp1.openGroup(GROUP1_2);
 
         // Check if DSET_IN_GRP1_2 exists in GROUP1_2
         exists = grp1_2.nameExists(DSET_IN_GRP1_2);
-        verify_val(exists, TRUE, "Group::nameExists DSET_IN_GRP1_2", __LINE__, __FILE__);
+        verify_val(exists, TRUE, "Group::nameExists DSET_IN_GRP1_2", __LINE__, __FILE__, "exists");
         // Deprecated
         exists = grp1_2.exists(DSET_IN_GRP1_2);
-        verify_val(exists, TRUE, "Group::exists DSET_IN_GRP1_2", __LINE__, __FILE__);
+        verify_val(exists, TRUE, "Group::exists DSET_IN_GRP1_2", __LINE__, __FILE__, "exists");
 
         // Check if a dataset exists given dataset as location with full path name
         DataSet dset1 = file.openDataSet(DSET_IN_FILE);
         exists        = dset1.nameExists("/Top Group/Dataset_in_Group_1");
-        verify_val(exists, TRUE, "Group::nameExists given dataset with full path name", __LINE__, __FILE__);
+        verify_val(exists, TRUE, "Group::nameExists given dataset with full path name", __LINE__, __FILE__, "exists");
 
         exists = grp1_2.nameExists(DSET_IN_GRP1);
-        verify_val(exists, FALSE, "Group::nameExists DSET_IN_GRP1", __LINE__, __FILE__);
+        verify_val(exists, FALSE, "Group::nameExists DSET_IN_GRP1", __LINE__, __FILE__, "exists");
         // Deprecated
         exists = dset1.exists("/Top Group/Dataset_in_Group_1");
-        verify_val(exists, TRUE, "Group::exists given dataset with full path name", __LINE__, __FILE__);
+        verify_val(exists, TRUE, "Group::exists given dataset with full path name", __LINE__, __FILE__, "exists");
         exists = grp1_2.exists(DSET_IN_GRP1);
-        verify_val(exists, FALSE, "Group::exists DSET_IN_GRP1", __LINE__, __FILE__);
+        verify_val(exists, FALSE, "Group::exists DSET_IN_GRP1", __LINE__, __FILE__, "exists");
 
         // Everything will be closed as they go out of scope
 
@@ -260,7 +259,7 @@ test_get_objname_ontypes()
 
         // Get and verify its name
         H5std_string inttype_name = inttype.getObjName();
-        verify_val(inttype_name, "/INT type of STD_B8LE", "DataType::getObjName", __LINE__, __FILE__);
+        verify_val(inttype_name, "/INT type of STD_B8LE", "DataType::getObjName", __LINE__, __FILE__, "inttype_name");
 
         // Close the type then open it again to test getting its name, but
         // with the constructor this time
@@ -269,7 +268,7 @@ test_get_objname_ontypes()
 
         // Get and verify its name
         H5std_string std_b8le_name = std_b8le.getObjName();
-        verify_val(std_b8le_name, "/INT type of STD_B8LE", "DataType::getObjName", __LINE__, __FILE__);
+        verify_val(std_b8le_name, "/INT type of STD_B8LE", "DataType::getObjName", __LINE__, __FILE__, "std_b8le_name");
 
         // Make copy of a predefined type and save it
         DataType dtype(PredType::STD_B8LE);
@@ -285,21 +284,21 @@ test_get_objname_ontypes()
 
         // Get and verify its name
         H5std_string type_name = dtype.getObjName();
-        verify_val(type_name, "/STD_B8LE", "DataType::getObjName", __LINE__, __FILE__);
+        verify_val(type_name, "/STD_B8LE", "DataType::getObjName", __LINE__, __FILE__, "type_name");
 
         // Close the type and open it again with the constructor then test
         // getting its name
         dtype.close();
         DataType dtype2(file, "STD_B8LE");
         type_name = dtype2.getObjName();
-        verify_val(type_name, "/STD_B8LE", "DataType::getObjName", __LINE__, __FILE__);
+        verify_val(type_name, "/STD_B8LE", "DataType::getObjName", __LINE__, __FILE__, "type_name");
 
         // Test getting type's name from copied type
         DataType copied_type;
         copied_type.copy(dtype2);
         copied_type.commit(file, "copy of STD_B8LE");
         type_name = copied_type.getObjName();
-        verify_val(type_name, "/copy of STD_B8LE", "DataType::getObjName", __LINE__, __FILE__);
+        verify_val(type_name, "/copy of STD_B8LE", "DataType::getObjName", __LINE__, __FILE__, "type_name");
 
         // Test copying an integer predefined type
         IntType new_int_type(PredType::NATIVE_INT);
@@ -308,8 +307,8 @@ test_get_objname_ontypes()
         new_int_type.commit(grp, "IntType NATIVE_INT");
         ssize_t name_len = new_int_type.getObjName(type_name); // default len
         verify_val(name_len, static_cast<ssize_t>(strlen("/typetests/IntType NATIVE_INT")),
-                   "DataType::getObjName", __LINE__, __FILE__);
-        verify_val(type_name, "/typetests/IntType NATIVE_INT", "DataType::getObjName", __LINE__, __FILE__);
+                   "DataType::getObjName", __LINE__, __FILE__, "name_len");
+        verify_val(type_name, "/typetests/IntType NATIVE_INT", "DataType::getObjName", __LINE__, __FILE__, "type_name");
 
         // Close everything or they can be closed when objects go out of scope
         dtype2.close();
@@ -354,20 +353,20 @@ test_get_objtype()
         // H5O_type_t childObjType(const H5std_string& objname)
         H5O_type_t objtype = file.childObjType(DSET_IN_FILE);
         verify_val(static_cast<long>(objtype), static_cast<long>(H5O_TYPE_DATASET), "DataSet::childObjType",
-                   __LINE__, __FILE__);
+                   __LINE__, __FILE__, "objtype");
 
         // Get and verify object type with
         // H5O_type_t childObjType(const char* objname)
         objtype = grp1.childObjType(GROUP1_1.c_str());
         verify_val(static_cast<long>(objtype), static_cast<long>(H5O_TYPE_GROUP), "DataSet::childObjType",
-                   __LINE__, __FILE__);
+                   __LINE__, __FILE__, "objtype");
 
         // Get and verify object type with
         // H5O_type_t childObjType(hsize_t index, H5_index_t index_type,
         // H5_iter_order_t order, const char* objname=".")
         objtype = grp1.childObjType(1, H5_INDEX_NAME, H5_ITER_INC);
         verify_val(static_cast<long>(objtype), static_cast<long>(H5O_TYPE_NAMED_DATATYPE),
-                   "DataSet::childObjType", __LINE__, __FILE__);
+                   "DataSet::childObjType", __LINE__, __FILE__, "objtype");
 
         // Get and verify object type with
         // H5O_type_t childObjType(hsize_t index,
@@ -375,7 +374,7 @@ test_get_objtype()
         // H5_iter_order_t order=H5_ITER_INC, const char* objname=".")
         objtype = grp1.childObjType(2);
         verify_val(static_cast<long>(objtype), static_cast<long>(H5O_TYPE_GROUP), "DataSet::childObjType",
-                   __LINE__, __FILE__);
+                   __LINE__, __FILE__, "objtype");
 
         // Everything will be closed as they go out of scope
 
@@ -444,19 +443,19 @@ test_open_object_header()
         // Make sure that each is the right kind of ID
         H5I_type_t id_type = IdComponent::getHDFObjType(obj_grp);
         verify_val(static_cast<long>(id_type), static_cast<long>(H5I_GROUP), "H5Iget_type for group ID",
-                   __LINE__, __FILE__);
+                   __LINE__, __FILE__, "id_type");
         id_type = IdComponent::getHDFObjType(obj_dtype);
         verify_val(static_cast<long>(id_type), static_cast<long>(H5I_DATATYPE), "H5Iget_type for datatype ID",
-                   __LINE__, __FILE__);
+                   __LINE__, __FILE__, "id_type");
         id_type = IdComponent::getHDFObjType(obj_dset);
         verify_val(static_cast<long>(id_type), static_cast<long>(H5I_DATASET), "H5Iget_type for dataset ID",
-                   __LINE__, __FILE__);
+                   __LINE__, __FILE__, "id_type");
 
         /* Do something more complex with each of the IDs to make sure */
 
         Group   grp2(obj_grp);
         hsize_t num_objs = grp2.getNumObjs();
-        verify_val(static_cast<long>(num_objs), 1, "H5Gget_info", __LINE__, __FILE__);
+        verify_val(static_cast<long>(num_objs), 1, "H5Gget_info", __LINE__, __FILE__, "num_objs");
         // There should be one object, the datatype
 
         // Close datatype object opened from the file
@@ -465,7 +464,7 @@ test_open_object_header()
         dset.setId(obj_dset);
         dspace         = dset.getSpace();
         bool is_simple = dspace.isSimple();
-        verify_val(is_simple, true, "isSimple", __LINE__, __FILE__);
+        verify_val(is_simple, true, "isSimple", __LINE__, __FILE__, "is_simple");
         dspace.close();
 
         // Open datatype object from the group
@@ -474,7 +473,7 @@ test_open_object_header()
         dtype.setId(obj_dtype);
         H5T_class_t type_class = dtype.getClass();
         verify_val(static_cast<long>(type_class), static_cast<long>(H5T_INTEGER), "H5Tget_class", __LINE__,
-                   __FILE__);
+                   __FILE__, "type_class");
         dtype.close();
 
         // Close datatype object
@@ -485,7 +484,7 @@ test_open_object_header()
 
         // Try doing something with group, the ID should still work
         num_objs = grp2.getNumObjs();
-        verify_val(static_cast<long>(num_objs), 1, "H5Gget_info", __LINE__, __FILE__);
+        verify_val(static_cast<long>(num_objs), 1, "H5Gget_info", __LINE__, __FILE__, "num_objs");
 
         // Close the cloned group
         grp2.close();
@@ -543,7 +542,7 @@ test_getobjectinfo_same_file()
         // file number
         grp1.getObjinfo(oinfo1);
         grp2.getObjinfo(oinfo2);
-        verify_val(oinfo1.fileno, oinfo2.fileno, "file number from getObjinfo", __LINE__, __FILE__);
+        verify_val(oinfo1.fileno, oinfo2.fileno, "file number from getObjinfo", __LINE__, __FILE__, "oinfo1.fileno");
 
         // Close groups and file
         grp1.close();
@@ -566,7 +565,7 @@ test_getobjectinfo_same_file()
         // file number
         grp1.getObjinfo(oinfo1);
         grp2.getObjinfo(oinfo2);
-        verify_val(oinfo1.fileno, oinfo2.fileno, "file number from getObjinfo", __LINE__, __FILE__);
+        verify_val(oinfo1.fileno, oinfo2.fileno, "file number from getObjinfo", __LINE__, __FILE__, "oinfo1.fileno");
 
         // Reset object info
         memset(&oinfo1, 0, sizeof(oinfo1));
@@ -574,7 +573,7 @@ test_getobjectinfo_same_file()
 
         file1.getObjinfo(GROUP1NAME, oinfo1);
         file1.getObjinfo(GROUP2NAME, oinfo2);
-        verify_val(oinfo1.fileno, oinfo2.fileno, "file number from getObjectInfo", __LINE__, __FILE__);
+        verify_val(oinfo1.fileno, oinfo2.fileno, "file number from getObjectInfo", __LINE__, __FILE__, "oinfo1.fileno");
 
         // Close groups and files
         grp1.close();
@@ -631,7 +630,7 @@ test_intermediate_groups()
 
         // Verify value of create missing groups flag
         bool crt_int_grps = lcpl.getCreateIntermediateGroup();
-        verify_val(crt_int_grps, true, "LinkCreatPropList::getCreateIntermediateGroup", __LINE__, __FILE__);
+        verify_val(crt_int_grps, true, "LinkCreatPropList::getCreateIntermediateGroup", __LINE__, __FILE__, "crt_int_grps");
 
         // Create GROUP12NAME with creating missing groups
         Group grp12(file.createGroup(GROUP12NAME, lcpl));
@@ -654,7 +653,7 @@ test_intermediate_groups()
 
         // Verify value of create missing groups flag
         crt_int_grps = lcpl.getCreateIntermediateGroup();
-        verify_val(crt_int_grps, false, "LinkCreatPropList::getCreateIntermediateGroup", __LINE__, __FILE__);
+        verify_val(crt_int_grps, false, "LinkCreatPropList::getCreateIntermediateGroup", __LINE__, __FILE__, "crt_int_grps");
 
         try {
             Group grp14_false(file.createGroup(GROUP14NAME, lcpl));
@@ -665,7 +664,7 @@ test_intermediate_groups()
         // Set the flag to create missing groups set to TRUE
         lcpl.setCreateIntermediateGroup(true);
         crt_int_grps = lcpl.getCreateIntermediateGroup();
-        verify_val(crt_int_grps, true, "LinkCreatPropList::getCreateIntermediateGroup", __LINE__, __FILE__);
+        verify_val(crt_int_grps, true, "LinkCreatPropList::getCreateIntermediateGroup", __LINE__, __FILE__, "crt_int_grps");
 
         // Create GROUP14NAME with the use of link create plist
         Group grp14(file.createGroup(GROUP14NAME, lcpl));
@@ -720,9 +719,6 @@ test_intermediate_groups()
 extern "C" void
 test_object()
 {
-    // Output message about test being performed
-    MESSAGE(5, ("Testing Object Functions\n"));
-
     test_get_objname();             // Test get object name from groups/datasets
     test_existance();               // Test check for object existence
     test_get_objname_ontypes();     // Test get object name from types

--- a/c++/test/tobject.cpp
+++ b/c++/test/tobject.cpp
@@ -82,7 +82,8 @@ test_get_objname()
         if (name_len > 4) {
             char *grp1_name = new char[5];
             name_len        = grp1.getObjName(grp1_name, 5);
-            verify_val(const_cast<const char *>(grp1_name), "/Top", "Group::getObjName", __LINE__, __FILE__, "grp1_name");
+            verify_val(const_cast<const char *>(grp1_name), "/Top", "Group::getObjName", __LINE__, __FILE__,
+                       "grp1_name");
             delete[] grp1_name;
         }
 
@@ -207,13 +208,15 @@ test_existance()
         // Check if a dataset exists given dataset as location with full path name
         DataSet dset1 = file.openDataSet(DSET_IN_FILE);
         exists        = dset1.nameExists("/Top Group/Dataset_in_Group_1");
-        verify_val(exists, TRUE, "Group::nameExists given dataset with full path name", __LINE__, __FILE__, "exists");
+        verify_val(exists, TRUE, "Group::nameExists given dataset with full path name", __LINE__, __FILE__,
+                   "exists");
 
         exists = grp1_2.nameExists(DSET_IN_GRP1);
         verify_val(exists, FALSE, "Group::nameExists DSET_IN_GRP1", __LINE__, __FILE__, "exists");
         // Deprecated
         exists = dset1.exists("/Top Group/Dataset_in_Group_1");
-        verify_val(exists, TRUE, "Group::exists given dataset with full path name", __LINE__, __FILE__, "exists");
+        verify_val(exists, TRUE, "Group::exists given dataset with full path name", __LINE__, __FILE__,
+                   "exists");
         exists = grp1_2.exists(DSET_IN_GRP1);
         verify_val(exists, FALSE, "Group::exists DSET_IN_GRP1", __LINE__, __FILE__, "exists");
 
@@ -259,7 +262,8 @@ test_get_objname_ontypes()
 
         // Get and verify its name
         H5std_string inttype_name = inttype.getObjName();
-        verify_val(inttype_name, "/INT type of STD_B8LE", "DataType::getObjName", __LINE__, __FILE__, "inttype_name");
+        verify_val(inttype_name, "/INT type of STD_B8LE", "DataType::getObjName", __LINE__, __FILE__,
+                   "inttype_name");
 
         // Close the type then open it again to test getting its name, but
         // with the constructor this time
@@ -268,7 +272,8 @@ test_get_objname_ontypes()
 
         // Get and verify its name
         H5std_string std_b8le_name = std_b8le.getObjName();
-        verify_val(std_b8le_name, "/INT type of STD_B8LE", "DataType::getObjName", __LINE__, __FILE__, "std_b8le_name");
+        verify_val(std_b8le_name, "/INT type of STD_B8LE", "DataType::getObjName", __LINE__, __FILE__,
+                   "std_b8le_name");
 
         // Make copy of a predefined type and save it
         DataType dtype(PredType::STD_B8LE);
@@ -308,7 +313,8 @@ test_get_objname_ontypes()
         ssize_t name_len = new_int_type.getObjName(type_name); // default len
         verify_val(name_len, static_cast<ssize_t>(strlen("/typetests/IntType NATIVE_INT")),
                    "DataType::getObjName", __LINE__, __FILE__, "name_len");
-        verify_val(type_name, "/typetests/IntType NATIVE_INT", "DataType::getObjName", __LINE__, __FILE__, "type_name");
+        verify_val(type_name, "/typetests/IntType NATIVE_INT", "DataType::getObjName", __LINE__, __FILE__,
+                   "type_name");
 
         // Close everything or they can be closed when objects go out of scope
         dtype2.close();
@@ -542,7 +548,8 @@ test_getobjectinfo_same_file()
         // file number
         grp1.getObjinfo(oinfo1);
         grp2.getObjinfo(oinfo2);
-        verify_val(oinfo1.fileno, oinfo2.fileno, "file number from getObjinfo", __LINE__, __FILE__, "oinfo1.fileno");
+        verify_val(oinfo1.fileno, oinfo2.fileno, "file number from getObjinfo", __LINE__, __FILE__,
+                   "oinfo1.fileno");
 
         // Close groups and file
         grp1.close();
@@ -565,7 +572,8 @@ test_getobjectinfo_same_file()
         // file number
         grp1.getObjinfo(oinfo1);
         grp2.getObjinfo(oinfo2);
-        verify_val(oinfo1.fileno, oinfo2.fileno, "file number from getObjinfo", __LINE__, __FILE__, "oinfo1.fileno");
+        verify_val(oinfo1.fileno, oinfo2.fileno, "file number from getObjinfo", __LINE__, __FILE__,
+                   "oinfo1.fileno");
 
         // Reset object info
         memset(&oinfo1, 0, sizeof(oinfo1));
@@ -573,7 +581,8 @@ test_getobjectinfo_same_file()
 
         file1.getObjinfo(GROUP1NAME, oinfo1);
         file1.getObjinfo(GROUP2NAME, oinfo2);
-        verify_val(oinfo1.fileno, oinfo2.fileno, "file number from getObjectInfo", __LINE__, __FILE__, "oinfo1.fileno");
+        verify_val(oinfo1.fileno, oinfo2.fileno, "file number from getObjectInfo", __LINE__, __FILE__,
+                   "oinfo1.fileno");
 
         // Close groups and files
         grp1.close();
@@ -630,7 +639,8 @@ test_intermediate_groups()
 
         // Verify value of create missing groups flag
         bool crt_int_grps = lcpl.getCreateIntermediateGroup();
-        verify_val(crt_int_grps, true, "LinkCreatPropList::getCreateIntermediateGroup", __LINE__, __FILE__, "crt_int_grps");
+        verify_val(crt_int_grps, true, "LinkCreatPropList::getCreateIntermediateGroup", __LINE__, __FILE__,
+                   "crt_int_grps");
 
         // Create GROUP12NAME with creating missing groups
         Group grp12(file.createGroup(GROUP12NAME, lcpl));
@@ -653,7 +663,8 @@ test_intermediate_groups()
 
         // Verify value of create missing groups flag
         crt_int_grps = lcpl.getCreateIntermediateGroup();
-        verify_val(crt_int_grps, false, "LinkCreatPropList::getCreateIntermediateGroup", __LINE__, __FILE__, "crt_int_grps");
+        verify_val(crt_int_grps, false, "LinkCreatPropList::getCreateIntermediateGroup", __LINE__, __FILE__,
+                   "crt_int_grps");
 
         try {
             Group grp14_false(file.createGroup(GROUP14NAME, lcpl));
@@ -664,7 +675,8 @@ test_intermediate_groups()
         // Set the flag to create missing groups set to TRUE
         lcpl.setCreateIntermediateGroup(true);
         crt_int_grps = lcpl.getCreateIntermediateGroup();
-        verify_val(crt_int_grps, true, "LinkCreatPropList::getCreateIntermediateGroup", __LINE__, __FILE__, "crt_int_grps");
+        verify_val(crt_int_grps, true, "LinkCreatPropList::getCreateIntermediateGroup", __LINE__, __FILE__,
+                   "crt_int_grps");
 
         // Create GROUP14NAME with the use of link create plist
         Group grp14(file.createGroup(GROUP14NAME, lcpl));

--- a/c++/test/trefer.cpp
+++ b/c++/test/trefer.cpp
@@ -311,7 +311,8 @@ test_reference_obj()
         // Check information in the referenced dataset
         sid1                = dset2.getSpace();
         hssize_t n_elements = sid1.getSimpleExtentNpoints();
-        verify_val(static_cast<long>(n_elements), 4, "DataSpace::getSimpleExtentNpoints", __LINE__, __FILE__, "n_elements");
+        verify_val(static_cast<long>(n_elements), 4, "DataSpace::getSimpleExtentNpoints", __LINE__, __FILE__,
+                   "n_elements");
 
         // Read from disk
         dset2.read(tbuf, PredType::NATIVE_UINT);
@@ -329,11 +330,13 @@ test_reference_obj()
         // Get group's comment using
         // H5std_string getComment(const char* name, <buf_size=0 by default>)
         H5std_string read_comment1 = group.getComment(".", 10);
-        verify_val(read_comment1.c_str(), write_comment, "Group::getComment", __LINE__, __FILE__, "read_comment1");
+        verify_val(read_comment1.c_str(), write_comment, "Group::getComment", __LINE__, __FILE__,
+                   "read_comment1");
 
         // Test with the old default value
         read_comment1 = group.getComment(".", 256);
-        verify_val(read_comment1.c_str(), write_comment, "Group::getComment", __LINE__, __FILE__, "read_comment1");
+        verify_val(read_comment1.c_str(), write_comment, "Group::getComment", __LINE__, __FILE__,
+                   "read_comment1");
 
         // Test that getComment handles failures gracefully, using
         // H5std_string getComment(const char* name, <buf_size=0 by default>)
@@ -669,8 +672,8 @@ test_reference_region_1D()
             // Get dataspace of dset3 the verify number of elements
             sid1  = dset3.getSpace();
             nelms = sid1.getSimpleExtentNpoints();
-            verify_val(static_cast<long>(nelms), 100, "DataSpace::getSimpleExtentNpoints", __LINE__,
-                       __FILE__, "nelms");
+            verify_val(static_cast<long>(nelms), 100, "DataSpace::getSimpleExtentNpoints", __LINE__, __FILE__,
+                       "nelms");
         } // End of test DataSet::dereference
 
         { // Test DataSet constructor -by dereference
@@ -681,8 +684,8 @@ test_reference_region_1D()
             // Get dataspace of newds then verify number of elements
             sid1  = newds.getSpace();
             nelms = sid1.getSimpleExtentNpoints();
-            verify_val(static_cast<long>(nelms), 100, "DataSpace::getSimpleExtentNpoints", __LINE__,
-                       __FILE__, "nelms");
+            verify_val(static_cast<long>(nelms), 100, "DataSpace::getSimpleExtentNpoints", __LINE__, __FILE__,
+                       "nelms");
 
             // Close objects for this mini test
             newds.close();
@@ -693,8 +696,8 @@ test_reference_region_1D()
         dset3.read(drbuf, PredType::STD_U8LE);
 
         for (tu8 = static_cast<uint8_t *>(drbuf), i = 0; i < SPACE3_DIM1; i++, tu8++)
-            verify_val(*tu8, static_cast<uint8_t>(i), "DataSpace::getSimpleExtentNpoints", __LINE__,
-                       __FILE__, "*tu8");
+            verify_val(*tu8, static_cast<uint8_t>(i), "DataSpace::getSimpleExtentNpoints", __LINE__, __FILE__,
+                       "*tu8");
 
         /*
          * Test getting the referenced region
@@ -723,39 +726,66 @@ test_reference_region_1D()
         verify_val(static_cast<long>(coords[1]), 3, "Hyperslab Coordinates", __LINE__, __FILE__, "coords[1]");
         verify_val(static_cast<long>(coords[2]), 7, "Hyperslab Coordinates", __LINE__, __FILE__, "coords[2]");
         verify_val(static_cast<long>(coords[3]), 8, "Hyperslab Coordinates", __LINE__, __FILE__, "coords[3]");
-        verify_val(static_cast<long>(coords[4]), 12, "Hyperslab Coordinates", __LINE__, __FILE__, "coords[4]");
-        verify_val(static_cast<long>(coords[5]), 13, "Hyperslab Coordinates", __LINE__, __FILE__, "coords[5]");
-        verify_val(static_cast<long>(coords[6]), 17, "Hyperslab Coordinates", __LINE__, __FILE__, "coords[6]");
-        verify_val(static_cast<long>(coords[7]), 18, "Hyperslab Coordinates", __LINE__, __FILE__, "coords[7]");
-        verify_val(static_cast<long>(coords[8]), 22, "Hyperslab Coordinates", __LINE__, __FILE__, "coords[8]");
-        verify_val(static_cast<long>(coords[9]), 23, "Hyperslab Coordinates", __LINE__, __FILE__, "coords[9]");
-        verify_val(static_cast<long>(coords[10]), 27, "Hyperslab Coordinates", __LINE__, __FILE__, "coords[10]");
-        verify_val(static_cast<long>(coords[11]), 28, "Hyperslab Coordinates", __LINE__, __FILE__, "coords[11]");
-        verify_val(static_cast<long>(coords[12]), 32, "Hyperslab Coordinates", __LINE__, __FILE__, "coords[12]");
-        verify_val(static_cast<long>(coords[13]), 33, "Hyperslab Coordinates", __LINE__, __FILE__, "coords[13]");
-        verify_val(static_cast<long>(coords[14]), 37, "Hyperslab Coordinates", __LINE__, __FILE__, "coords[14]");
-        verify_val(static_cast<long>(coords[15]), 38, "Hyperslab Coordinates", __LINE__, __FILE__, "coords[15]");
-        verify_val(static_cast<long>(coords[16]), 42, "Hyperslab Coordinates", __LINE__, __FILE__, "coords[16]");
-        verify_val(static_cast<long>(coords[17]), 43, "Hyperslab Coordinates", __LINE__, __FILE__, "coords[17]");
-        verify_val(static_cast<long>(coords[18]), 47, "Hyperslab Coordinates", __LINE__, __FILE__, "coords[18]");
-        verify_val(static_cast<long>(coords[19]), 48, "Hyperslab Coordinates", __LINE__, __FILE__, "coords[19]");
-        verify_val(static_cast<long>(coords[20]), 52, "Hyperslab Coordinates", __LINE__, __FILE__, "coords[20]");
-        verify_val(static_cast<long>(coords[21]), 53, "Hyperslab Coordinates", __LINE__, __FILE__, "coords[21]");
-        verify_val(static_cast<long>(coords[22]), 57, "Hyperslab Coordinates", __LINE__, __FILE__, "coords[22]");
-        verify_val(static_cast<long>(coords[23]), 58, "Hyperslab Coordinates", __LINE__, __FILE__, "coords[23]");
-        verify_val(static_cast<long>(coords[24]), 62, "Hyperslab Coordinates", __LINE__, __FILE__, "coords[24]");
-        verify_val(static_cast<long>(coords[25]), 63, "Hyperslab Coordinates", __LINE__, __FILE__, "coords[25]");
-        verify_val(static_cast<long>(coords[26]), 67, "Hyperslab Coordinates", __LINE__, __FILE__, "coords[26]");
-        verify_val(static_cast<long>(coords[27]), 68, "Hyperslab Coordinates", __LINE__, __FILE__, "coords[27]");
-        verify_val(static_cast<long>(coords[28]), 72, "Hyperslab Coordinates", __LINE__, __FILE__, "coords[28]");
-        verify_val(static_cast<long>(coords[29]), 73, "Hyperslab Coordinates", __LINE__, __FILE__, "coords[29]");
+        verify_val(static_cast<long>(coords[4]), 12, "Hyperslab Coordinates", __LINE__, __FILE__,
+                   "coords[4]");
+        verify_val(static_cast<long>(coords[5]), 13, "Hyperslab Coordinates", __LINE__, __FILE__,
+                   "coords[5]");
+        verify_val(static_cast<long>(coords[6]), 17, "Hyperslab Coordinates", __LINE__, __FILE__,
+                   "coords[6]");
+        verify_val(static_cast<long>(coords[7]), 18, "Hyperslab Coordinates", __LINE__, __FILE__,
+                   "coords[7]");
+        verify_val(static_cast<long>(coords[8]), 22, "Hyperslab Coordinates", __LINE__, __FILE__,
+                   "coords[8]");
+        verify_val(static_cast<long>(coords[9]), 23, "Hyperslab Coordinates", __LINE__, __FILE__,
+                   "coords[9]");
+        verify_val(static_cast<long>(coords[10]), 27, "Hyperslab Coordinates", __LINE__, __FILE__,
+                   "coords[10]");
+        verify_val(static_cast<long>(coords[11]), 28, "Hyperslab Coordinates", __LINE__, __FILE__,
+                   "coords[11]");
+        verify_val(static_cast<long>(coords[12]), 32, "Hyperslab Coordinates", __LINE__, __FILE__,
+                   "coords[12]");
+        verify_val(static_cast<long>(coords[13]), 33, "Hyperslab Coordinates", __LINE__, __FILE__,
+                   "coords[13]");
+        verify_val(static_cast<long>(coords[14]), 37, "Hyperslab Coordinates", __LINE__, __FILE__,
+                   "coords[14]");
+        verify_val(static_cast<long>(coords[15]), 38, "Hyperslab Coordinates", __LINE__, __FILE__,
+                   "coords[15]");
+        verify_val(static_cast<long>(coords[16]), 42, "Hyperslab Coordinates", __LINE__, __FILE__,
+                   "coords[16]");
+        verify_val(static_cast<long>(coords[17]), 43, "Hyperslab Coordinates", __LINE__, __FILE__,
+                   "coords[17]");
+        verify_val(static_cast<long>(coords[18]), 47, "Hyperslab Coordinates", __LINE__, __FILE__,
+                   "coords[18]");
+        verify_val(static_cast<long>(coords[19]), 48, "Hyperslab Coordinates", __LINE__, __FILE__,
+                   "coords[19]");
+        verify_val(static_cast<long>(coords[20]), 52, "Hyperslab Coordinates", __LINE__, __FILE__,
+                   "coords[20]");
+        verify_val(static_cast<long>(coords[21]), 53, "Hyperslab Coordinates", __LINE__, __FILE__,
+                   "coords[21]");
+        verify_val(static_cast<long>(coords[22]), 57, "Hyperslab Coordinates", __LINE__, __FILE__,
+                   "coords[22]");
+        verify_val(static_cast<long>(coords[23]), 58, "Hyperslab Coordinates", __LINE__, __FILE__,
+                   "coords[23]");
+        verify_val(static_cast<long>(coords[24]), 62, "Hyperslab Coordinates", __LINE__, __FILE__,
+                   "coords[24]");
+        verify_val(static_cast<long>(coords[25]), 63, "Hyperslab Coordinates", __LINE__, __FILE__,
+                   "coords[25]");
+        verify_val(static_cast<long>(coords[26]), 67, "Hyperslab Coordinates", __LINE__, __FILE__,
+                   "coords[26]");
+        verify_val(static_cast<long>(coords[27]), 68, "Hyperslab Coordinates", __LINE__, __FILE__,
+                   "coords[27]");
+        verify_val(static_cast<long>(coords[28]), 72, "Hyperslab Coordinates", __LINE__, __FILE__,
+                   "coords[28]");
+        verify_val(static_cast<long>(coords[29]), 73, "Hyperslab Coordinates", __LINE__, __FILE__,
+                   "coords[29]");
 
         free(coords);
 
         // Check boundaries
         reg_sp.getSelectBounds(low, high);
         verify_val(static_cast<long>(low[0]), 2, "DataSpace::getSelectBounds", __LINE__, __FILE__, "low[0]");
-        verify_val(static_cast<long>(high[0]), 73, "DataSpace::getSelectBounds", __LINE__, __FILE__, "high[0]");
+        verify_val(static_cast<long>(high[0]), 73, "DataSpace::getSelectBounds", __LINE__, __FILE__,
+                   "high[0]");
 
         /* Close region space */
         reg_sp.close();
@@ -769,7 +799,8 @@ test_reference_region_1D()
 
         // Get and verify number of element points in the current selection
         hssize_t nelmspts = elm_sp.getSelectElemNpoints();
-        verify_val(static_cast<long>(nelmspts), 10, "DataSpace::getSelectNpoints", __LINE__, __FILE__, "nelmspts");
+        verify_val(static_cast<long>(nelmspts), 10, "DataSpace::getSelectNpoints", __LINE__, __FILE__,
+                   "nelmspts");
 
         /* Allocate space for the hyperslab blocks */
         coords =
@@ -795,7 +826,8 @@ test_reference_region_1D()
         // Check boundaries
         elm_sp.getSelectBounds(low, high);
         verify_val(static_cast<long>(low[0]), 3, "DataSpace::getSelectBounds", __LINE__, __FILE__, "low[0]");
-        verify_val(static_cast<long>(high[0]), 97, "DataSpace::getSelectBounds", __LINE__, __FILE__, "high[0]");
+        verify_val(static_cast<long>(high[0]), 97, "DataSpace::getSelectBounds", __LINE__, __FILE__,
+                   "high[0]");
 
         // Close element space
         elm_sp.close();

--- a/c++/test/trefer.cpp
+++ b/c++/test/trefer.cpp
@@ -24,7 +24,6 @@ using std::endl;
 #include "H5Cpp.h" // C++ API header file
 using namespace H5;
 
-#include "h5test.h"
 #include "h5cpputil.h" // C++ utilility header file
 
 const H5std_string FILE1("trefer1.h5");
@@ -268,25 +267,25 @@ test_reference_obj()
         file1->reference(&wbuf[0], "/Group1/Dataset1");
         H5O_type_t refobj_type = dataset.getRefObjType(&wbuf[0], H5R_OBJECT);
         verify_val(static_cast<long>(refobj_type), static_cast<long>(H5O_TYPE_DATASET),
-                   "DataSet::getRefObjType", __LINE__, __FILE__);
+                   "DataSet::getRefObjType", __LINE__, __FILE__, "refobj_type");
 
         // Create reference to dataset and test getRefObjType
         file1->reference(&wbuf[1], "/Group1/Dataset2");
         refobj_type = dataset.getRefObjType(&wbuf[1], H5R_OBJECT);
         verify_val(static_cast<long>(refobj_type), static_cast<long>(H5O_TYPE_DATASET),
-                   "DataSet::getRefObjType", __LINE__, __FILE__);
+                   "DataSet::getRefObjType", __LINE__, __FILE__, "refobj_type");
 
         // Create reference to group
         file1->reference(&wbuf[2], "/Group1");
         refobj_type = dataset.getRefObjType(&wbuf[2], H5R_OBJECT);
         verify_val(static_cast<long>(refobj_type), static_cast<long>(H5O_TYPE_GROUP),
-                   "DataSet::getRefObjType", __LINE__, __FILE__);
+                   "DataSet::getRefObjType", __LINE__, __FILE__, "refobj_type");
 
         // Create reference to named datatype
         file1->reference(&wbuf[3], "/Group1/Datatype1");
         refobj_type = dataset.getRefObjType(&wbuf[3], H5R_OBJECT);
         verify_val(static_cast<long>(refobj_type), static_cast<long>(H5O_TYPE_NAMED_DATATYPE),
-                   "DataSet::getRefObjType", __LINE__, __FILE__);
+                   "DataSet::getRefObjType", __LINE__, __FILE__, "refobj_type");
 
         // Write selection to disk
         dataset.write(wbuf, PredType::STD_REF_OBJ);
@@ -312,14 +311,14 @@ test_reference_obj()
         // Check information in the referenced dataset
         sid1                = dset2.getSpace();
         hssize_t n_elements = sid1.getSimpleExtentNpoints();
-        verify_val(static_cast<long>(n_elements), 4, "DataSpace::getSimpleExtentNpoints", __LINE__, __FILE__);
+        verify_val(static_cast<long>(n_elements), 4, "DataSpace::getSimpleExtentNpoints", __LINE__, __FILE__, "n_elements");
 
         // Read from disk
         dset2.read(tbuf, PredType::NATIVE_UINT);
 
         for (tu32 = reinterpret_cast<unsigned *>(tbuf), i = 0; i < SPACE1_DIM1; i++, tu32++)
             verify_val(*tu32, static_cast<uint32_t>(i * 3), "DataSpace::getSimpleExtentNpoints", __LINE__,
-                       __FILE__);
+                       __FILE__, "*tu32");
 
         // Close dereferenced dataset
         dset2.close();
@@ -330,11 +329,11 @@ test_reference_obj()
         // Get group's comment using
         // H5std_string getComment(const char* name, <buf_size=0 by default>)
         H5std_string read_comment1 = group.getComment(".", 10);
-        verify_val(read_comment1.c_str(), write_comment, "Group::getComment", __LINE__, __FILE__);
+        verify_val(read_comment1.c_str(), write_comment, "Group::getComment", __LINE__, __FILE__, "read_comment1");
 
         // Test with the old default value
         read_comment1 = group.getComment(".", 256);
-        verify_val(read_comment1.c_str(), write_comment, "Group::getComment", __LINE__, __FILE__);
+        verify_val(read_comment1.c_str(), write_comment, "Group::getComment", __LINE__, __FILE__, "read_comment1");
 
         // Test that getComment handles failures gracefully, using
         // H5std_string getComment(const char* name, <buf_size=0 by default>)
@@ -358,9 +357,9 @@ test_reference_obj()
 
         tclass = dtype1.getClass();
         verify_val(static_cast<long>(tclass), static_cast<long>(H5T_COMPOUND), "DataType::getClass", __LINE__,
-                   __FILE__);
+                   __FILE__, "tclass");
         int n_members = dtype1.getNmembers();
-        verify_val(n_members, 3, "CompType::getNmembers", __LINE__, __FILE__);
+        verify_val(n_members, 3, "CompType::getNmembers", __LINE__, __FILE__, "n_members");
 
         // Close all objects and file
         dtype1.close();
@@ -472,26 +471,26 @@ test_reference_group()
 
         // Check number of objects in the group dereferenced by constructor
         hsize_t nobjs = refgroup.getNumObjs();
-        verify_val(static_cast<long>(nobjs), 3, "H5Group::getNumObjs", __LINE__, __FILE__);
+        verify_val(static_cast<long>(nobjs), 3, "H5Group::getNumObjs", __LINE__, __FILE__, "nobjs");
 
         // Check number of objects in the group dereferenced by ::reference
         nobjs = group.getNumObjs();
-        verify_val(static_cast<long>(nobjs), 3, "H5Group::getNumObjs", __LINE__, __FILE__);
+        verify_val(static_cast<long>(nobjs), 3, "H5Group::getNumObjs", __LINE__, __FILE__, "nobjs");
 
         // Check getting file name given the group dereferenced via constructor
         H5std_string fname = refgroup.getFileName();
-        verify_val(fname, FILE1, "H5Group::getFileName", __LINE__, __FILE__);
+        verify_val(fname, FILE1, "H5Group::getFileName", __LINE__, __FILE__, "fname");
 
         // Check getting file name given the group dereferenced by ::reference
         fname = group.getFileName();
-        verify_val(fname, FILE1, "H5Group::getFileName", __LINE__, __FILE__);
+        verify_val(fname, FILE1, "H5Group::getFileName", __LINE__, __FILE__, "fname");
 
         // Check object type using Group::getObjinfo()
         H5O_info2_t oinfo;
         memset(&oinfo, 0, sizeof(oinfo));
         group.getObjinfo(".", H5_INDEX_NAME, H5_ITER_INC, 0, oinfo);
         verify_val(static_cast<long>(oinfo.type), static_cast<long>(H5O_TYPE_DATASET), "Group::getObjinfo",
-                   __LINE__, __FILE__);
+                   __LINE__, __FILE__, "oinfo.type");
 
         // Check for out of bound query by index
         try {
@@ -507,7 +506,7 @@ test_reference_group()
         // Unlink one of the objects in the dereferenced group, and re-check
         refgroup.unlink(GROUPNAME2);
         nobjs = refgroup.getNumObjs();
-        verify_val(static_cast<long>(nobjs), 2, "H5Group::getNumObjs", __LINE__, __FILE__);
+        verify_val(static_cast<long>(nobjs), 2, "H5Group::getNumObjs", __LINE__, __FILE__, "nobjs");
 
         // Close resources
         group.close();
@@ -605,7 +604,7 @@ test_reference_region_1D()
 
         // Get and verify the number of elements in a dataspace selection
         hssize_t nelms = sid3.getSelectNpoints();
-        verify_val(nelms, 30, "DataSet::getRefObjType", __LINE__, __FILE__);
+        verify_val(nelms, 30, "DataSet::getRefObjType", __LINE__, __FILE__, "nelms");
 
         // Store first dataset region
         file1.reference(&wbuf[0], "/Dataset2", sid3);
@@ -613,7 +612,7 @@ test_reference_region_1D()
         // Get and verify object type
         H5O_type_t obj_type = dset1.getRefObjType(&wbuf[0], H5R_DATASET_REGION);
         verify_val(static_cast<long>(obj_type), static_cast<long>(H5O_TYPE_DATASET), "DataSet::getRefObjType",
-                   __LINE__, __FILE__);
+                   __LINE__, __FILE__, "obj_type");
 
         /* Select sequence of ten points for second reference */
         coord1[0][0] = 16;
@@ -632,7 +631,7 @@ test_reference_region_1D()
 
         // Get and verify the number of elements in a dataspace selection
         nelms = sid3.getSelectNpoints();
-        verify_val(nelms, 10, "DataSet::getRefObjType", __LINE__, __FILE__);
+        verify_val(nelms, 10, "DataSet::getRefObjType", __LINE__, __FILE__, "nelms");
 
         // Store first dataset region
         file1.reference(&wbuf[1], "/Dataset2", sid3);
@@ -665,13 +664,13 @@ test_reference_region_1D()
             // Get and verify object type
             obj_type = dset1.getRefObjType(&rbuf[0], H5R_DATASET_REGION);
             verify_val(static_cast<long>(obj_type), static_cast<long>(H5O_TYPE_DATASET),
-                       "DataSet::getRefObjType", __LINE__, __FILE__);
+                       "DataSet::getRefObjType", __LINE__, __FILE__, "obj_type");
 
             // Get dataspace of dset3 the verify number of elements
             sid1  = dset3.getSpace();
             nelms = sid1.getSimpleExtentNpoints();
             verify_val(static_cast<long>(nelms), 100, "DataSpace::getSimpleExtentNpoints", __LINE__,
-                       __FILE__);
+                       __FILE__, "nelms");
         } // End of test DataSet::dereference
 
         { // Test DataSet constructor -by dereference
@@ -683,7 +682,7 @@ test_reference_region_1D()
             sid1  = newds.getSpace();
             nelms = sid1.getSimpleExtentNpoints();
             verify_val(static_cast<long>(nelms), 100, "DataSpace::getSimpleExtentNpoints", __LINE__,
-                       __FILE__);
+                       __FILE__, "nelms");
 
             // Close objects for this mini test
             newds.close();
@@ -695,7 +694,7 @@ test_reference_region_1D()
 
         for (tu8 = static_cast<uint8_t *>(drbuf), i = 0; i < SPACE3_DIM1; i++, tu8++)
             verify_val(*tu8, static_cast<uint8_t>(i), "DataSpace::getSimpleExtentNpoints", __LINE__,
-                       __FILE__);
+                       __FILE__, "*tu8");
 
         /*
          * Test getting the referenced region
@@ -706,11 +705,11 @@ test_reference_region_1D()
 
         // Get and verify number of elements in a dataspace selection
         nelms = reg_sp.getSelectNpoints();
-        verify_val(static_cast<long>(nelms), 30, "DataSpace::getSelectNpoints", __LINE__, __FILE__);
+        verify_val(static_cast<long>(nelms), 30, "DataSpace::getSelectNpoints", __LINE__, __FILE__, "nelms");
 
         // Get and verify number of hyperslab blocks
         nelms = reg_sp.getSelectHyperNblocks();
-        verify_val(static_cast<long>(nelms), 15, "DataSpace::getSelectNpoints", __LINE__, __FILE__);
+        verify_val(static_cast<long>(nelms), 15, "DataSpace::getSelectNpoints", __LINE__, __FILE__, "nelms");
 
         /* Allocate space for the hyperslab blocks */
         coords =
@@ -720,43 +719,43 @@ test_reference_region_1D()
         reg_sp.getSelectHyperBlocklist(0, static_cast<hsize_t>(nelms), coords);
 
         // Verify values in the list
-        verify_val(static_cast<long>(coords[0]), 2, "Hyperslab Coordinates", __LINE__, __FILE__);
-        verify_val(static_cast<long>(coords[1]), 3, "Hyperslab Coordinates", __LINE__, __FILE__);
-        verify_val(static_cast<long>(coords[2]), 7, "Hyperslab Coordinates", __LINE__, __FILE__);
-        verify_val(static_cast<long>(coords[3]), 8, "Hyperslab Coordinates", __LINE__, __FILE__);
-        verify_val(static_cast<long>(coords[4]), 12, "Hyperslab Coordinates", __LINE__, __FILE__);
-        verify_val(static_cast<long>(coords[5]), 13, "Hyperslab Coordinates", __LINE__, __FILE__);
-        verify_val(static_cast<long>(coords[6]), 17, "Hyperslab Coordinates", __LINE__, __FILE__);
-        verify_val(static_cast<long>(coords[7]), 18, "Hyperslab Coordinates", __LINE__, __FILE__);
-        verify_val(static_cast<long>(coords[8]), 22, "Hyperslab Coordinates", __LINE__, __FILE__);
-        verify_val(static_cast<long>(coords[9]), 23, "Hyperslab Coordinates", __LINE__, __FILE__);
-        verify_val(static_cast<long>(coords[10]), 27, "Hyperslab Coordinates", __LINE__, __FILE__);
-        verify_val(static_cast<long>(coords[11]), 28, "Hyperslab Coordinates", __LINE__, __FILE__);
-        verify_val(static_cast<long>(coords[12]), 32, "Hyperslab Coordinates", __LINE__, __FILE__);
-        verify_val(static_cast<long>(coords[13]), 33, "Hyperslab Coordinates", __LINE__, __FILE__);
-        verify_val(static_cast<long>(coords[14]), 37, "Hyperslab Coordinates", __LINE__, __FILE__);
-        verify_val(static_cast<long>(coords[15]), 38, "Hyperslab Coordinates", __LINE__, __FILE__);
-        verify_val(static_cast<long>(coords[16]), 42, "Hyperslab Coordinates", __LINE__, __FILE__);
-        verify_val(static_cast<long>(coords[17]), 43, "Hyperslab Coordinates", __LINE__, __FILE__);
-        verify_val(static_cast<long>(coords[18]), 47, "Hyperslab Coordinates", __LINE__, __FILE__);
-        verify_val(static_cast<long>(coords[19]), 48, "Hyperslab Coordinates", __LINE__, __FILE__);
-        verify_val(static_cast<long>(coords[20]), 52, "Hyperslab Coordinates", __LINE__, __FILE__);
-        verify_val(static_cast<long>(coords[21]), 53, "Hyperslab Coordinates", __LINE__, __FILE__);
-        verify_val(static_cast<long>(coords[22]), 57, "Hyperslab Coordinates", __LINE__, __FILE__);
-        verify_val(static_cast<long>(coords[23]), 58, "Hyperslab Coordinates", __LINE__, __FILE__);
-        verify_val(static_cast<long>(coords[24]), 62, "Hyperslab Coordinates", __LINE__, __FILE__);
-        verify_val(static_cast<long>(coords[25]), 63, "Hyperslab Coordinates", __LINE__, __FILE__);
-        verify_val(static_cast<long>(coords[26]), 67, "Hyperslab Coordinates", __LINE__, __FILE__);
-        verify_val(static_cast<long>(coords[27]), 68, "Hyperslab Coordinates", __LINE__, __FILE__);
-        verify_val(static_cast<long>(coords[28]), 72, "Hyperslab Coordinates", __LINE__, __FILE__);
-        verify_val(static_cast<long>(coords[29]), 73, "Hyperslab Coordinates", __LINE__, __FILE__);
+        verify_val(static_cast<long>(coords[0]), 2, "Hyperslab Coordinates", __LINE__, __FILE__, "coords[0]");
+        verify_val(static_cast<long>(coords[1]), 3, "Hyperslab Coordinates", __LINE__, __FILE__, "coords[1]");
+        verify_val(static_cast<long>(coords[2]), 7, "Hyperslab Coordinates", __LINE__, __FILE__, "coords[2]");
+        verify_val(static_cast<long>(coords[3]), 8, "Hyperslab Coordinates", __LINE__, __FILE__, "coords[3]");
+        verify_val(static_cast<long>(coords[4]), 12, "Hyperslab Coordinates", __LINE__, __FILE__, "coords[4]");
+        verify_val(static_cast<long>(coords[5]), 13, "Hyperslab Coordinates", __LINE__, __FILE__, "coords[5]");
+        verify_val(static_cast<long>(coords[6]), 17, "Hyperslab Coordinates", __LINE__, __FILE__, "coords[6]");
+        verify_val(static_cast<long>(coords[7]), 18, "Hyperslab Coordinates", __LINE__, __FILE__, "coords[7]");
+        verify_val(static_cast<long>(coords[8]), 22, "Hyperslab Coordinates", __LINE__, __FILE__, "coords[8]");
+        verify_val(static_cast<long>(coords[9]), 23, "Hyperslab Coordinates", __LINE__, __FILE__, "coords[9]");
+        verify_val(static_cast<long>(coords[10]), 27, "Hyperslab Coordinates", __LINE__, __FILE__, "coords[10]");
+        verify_val(static_cast<long>(coords[11]), 28, "Hyperslab Coordinates", __LINE__, __FILE__, "coords[11]");
+        verify_val(static_cast<long>(coords[12]), 32, "Hyperslab Coordinates", __LINE__, __FILE__, "coords[12]");
+        verify_val(static_cast<long>(coords[13]), 33, "Hyperslab Coordinates", __LINE__, __FILE__, "coords[13]");
+        verify_val(static_cast<long>(coords[14]), 37, "Hyperslab Coordinates", __LINE__, __FILE__, "coords[14]");
+        verify_val(static_cast<long>(coords[15]), 38, "Hyperslab Coordinates", __LINE__, __FILE__, "coords[15]");
+        verify_val(static_cast<long>(coords[16]), 42, "Hyperslab Coordinates", __LINE__, __FILE__, "coords[16]");
+        verify_val(static_cast<long>(coords[17]), 43, "Hyperslab Coordinates", __LINE__, __FILE__, "coords[17]");
+        verify_val(static_cast<long>(coords[18]), 47, "Hyperslab Coordinates", __LINE__, __FILE__, "coords[18]");
+        verify_val(static_cast<long>(coords[19]), 48, "Hyperslab Coordinates", __LINE__, __FILE__, "coords[19]");
+        verify_val(static_cast<long>(coords[20]), 52, "Hyperslab Coordinates", __LINE__, __FILE__, "coords[20]");
+        verify_val(static_cast<long>(coords[21]), 53, "Hyperslab Coordinates", __LINE__, __FILE__, "coords[21]");
+        verify_val(static_cast<long>(coords[22]), 57, "Hyperslab Coordinates", __LINE__, __FILE__, "coords[22]");
+        verify_val(static_cast<long>(coords[23]), 58, "Hyperslab Coordinates", __LINE__, __FILE__, "coords[23]");
+        verify_val(static_cast<long>(coords[24]), 62, "Hyperslab Coordinates", __LINE__, __FILE__, "coords[24]");
+        verify_val(static_cast<long>(coords[25]), 63, "Hyperslab Coordinates", __LINE__, __FILE__, "coords[25]");
+        verify_val(static_cast<long>(coords[26]), 67, "Hyperslab Coordinates", __LINE__, __FILE__, "coords[26]");
+        verify_val(static_cast<long>(coords[27]), 68, "Hyperslab Coordinates", __LINE__, __FILE__, "coords[27]");
+        verify_val(static_cast<long>(coords[28]), 72, "Hyperslab Coordinates", __LINE__, __FILE__, "coords[28]");
+        verify_val(static_cast<long>(coords[29]), 73, "Hyperslab Coordinates", __LINE__, __FILE__, "coords[29]");
 
         free(coords);
 
         // Check boundaries
         reg_sp.getSelectBounds(low, high);
-        verify_val(static_cast<long>(low[0]), 2, "DataSpace::getSelectBounds", __LINE__, __FILE__);
-        verify_val(static_cast<long>(high[0]), 73, "DataSpace::getSelectBounds", __LINE__, __FILE__);
+        verify_val(static_cast<long>(low[0]), 2, "DataSpace::getSelectBounds", __LINE__, __FILE__, "low[0]");
+        verify_val(static_cast<long>(high[0]), 73, "DataSpace::getSelectBounds", __LINE__, __FILE__, "high[0]");
 
         /* Close region space */
         reg_sp.close();
@@ -770,7 +769,7 @@ test_reference_region_1D()
 
         // Get and verify number of element points in the current selection
         hssize_t nelmspts = elm_sp.getSelectElemNpoints();
-        verify_val(static_cast<long>(nelmspts), 10, "DataSpace::getSelectNpoints", __LINE__, __FILE__);
+        verify_val(static_cast<long>(nelmspts), 10, "DataSpace::getSelectNpoints", __LINE__, __FILE__, "nelmspts");
 
         /* Allocate space for the hyperslab blocks */
         coords =
@@ -780,23 +779,23 @@ test_reference_region_1D()
         elm_sp.getSelectElemPointlist(0, static_cast<hsize_t>(nelmspts), coords);
 
         // Verify points
-        verify_val(coords[0], coord1[0][0], "Element Coordinates", __LINE__, __FILE__);
-        verify_val(coords[1], coord1[1][0], "Element Coordinates", __LINE__, __FILE__);
-        verify_val(coords[2], coord1[2][0], "Element Coordinates", __LINE__, __FILE__);
-        verify_val(coords[3], coord1[3][0], "Element Coordinates", __LINE__, __FILE__);
-        verify_val(coords[4], coord1[4][0], "Element Coordinates", __LINE__, __FILE__);
-        verify_val(coords[5], coord1[5][0], "Element Coordinates", __LINE__, __FILE__);
-        verify_val(coords[6], coord1[6][0], "Element Coordinates", __LINE__, __FILE__);
-        verify_val(coords[7], coord1[7][0], "Element Coordinates", __LINE__, __FILE__);
-        verify_val(coords[8], coord1[8][0], "Element Coordinates", __LINE__, __FILE__);
-        verify_val(coords[9], coord1[9][0], "Element Coordinates", __LINE__, __FILE__);
+        verify_val(coords[0], coord1[0][0], "Element Coordinates", __LINE__, __FILE__, "coords[0]");
+        verify_val(coords[1], coord1[1][0], "Element Coordinates", __LINE__, __FILE__, "coords[1]");
+        verify_val(coords[2], coord1[2][0], "Element Coordinates", __LINE__, __FILE__, "coords[2]");
+        verify_val(coords[3], coord1[3][0], "Element Coordinates", __LINE__, __FILE__, "coords[3]");
+        verify_val(coords[4], coord1[4][0], "Element Coordinates", __LINE__, __FILE__, "coords[4]");
+        verify_val(coords[5], coord1[5][0], "Element Coordinates", __LINE__, __FILE__, "coords[5]");
+        verify_val(coords[6], coord1[6][0], "Element Coordinates", __LINE__, __FILE__, "coords[6]");
+        verify_val(coords[7], coord1[7][0], "Element Coordinates", __LINE__, __FILE__, "coords[7]");
+        verify_val(coords[8], coord1[8][0], "Element Coordinates", __LINE__, __FILE__, "coords[8]");
+        verify_val(coords[9], coord1[9][0], "Element Coordinates", __LINE__, __FILE__, "coords[9]");
 
         free(coords);
 
         // Check boundaries
         elm_sp.getSelectBounds(low, high);
-        verify_val(static_cast<long>(low[0]), 3, "DataSpace::getSelectBounds", __LINE__, __FILE__);
-        verify_val(static_cast<long>(high[0]), 97, "DataSpace::getSelectBounds", __LINE__, __FILE__);
+        verify_val(static_cast<long>(low[0]), 3, "DataSpace::getSelectBounds", __LINE__, __FILE__, "low[0]");
+        verify_val(static_cast<long>(high[0]), 97, "DataSpace::getSelectBounds", __LINE__, __FILE__, "high[0]");
 
         // Close element space
         elm_sp.close();
@@ -829,9 +828,6 @@ test_reference_region_1D()
 extern "C" void
 test_reference()
 {
-    // Output message about test being performed
-    MESSAGE(5, ("Testing References\n"));
-
     test_reference_params();    // Test basic parameters of reference functionality
     test_reference_obj();       // Test basic object reference functionality
     test_reference_group();     // Test group reference functionality

--- a/c++/test/ttypes.cpp
+++ b/c++/test/ttypes.cpp
@@ -191,7 +191,8 @@ test_detect_type_class()
 
         // Native integers should be in the integer class
         in_class = DataType::detectClass(PredType::NATIVE_INT, H5T_INTEGER);
-        verify_val(in_class, true, "DataType::detectClass() with H5T_INTEGER", __LINE__, __FILE__, "in_class");
+        verify_val(in_class, true, "DataType::detectClass() with H5T_INTEGER", __LINE__, __FILE__,
+                   "in_class");
 
         // Native integers should _not_ be in other classes
         in_class = DataType::detectClass(PredType::NATIVE_INT, H5T_FLOAT);
@@ -215,10 +216,12 @@ test_detect_type_class()
 
         // Make certain that atom_cmpd is a compound type,
         in_class = atom_cmpd.detectClass(H5T_COMPOUND);
-        verify_val(in_class, true, "CompType::detectClass() with H5T_COMPOUND", __LINE__, __FILE__, "in_class");
+        verify_val(in_class, true, "CompType::detectClass() with H5T_COMPOUND", __LINE__, __FILE__,
+                   "in_class");
         // and that it contains a field of type integer
         in_class = atom_cmpd.detectClass(H5T_INTEGER);
-        verify_val(in_class, true, "CompType::detectClass() with H5T_INTEGER", __LINE__, __FILE__, "in_class");
+        verify_val(in_class, true, "CompType::detectClass() with H5T_INTEGER", __LINE__, __FILE__,
+                   "in_class");
         // and a field of type float,
         in_class = atom_cmpd.detectClass(H5T_FLOAT);
         verify_val(in_class, true, "CompType::detectClass() with H5T_FLOAT", __LINE__, __FILE__, "in_class");
@@ -239,7 +242,8 @@ test_detect_type_class()
         in_class = atom_arr.detectClass(H5T_ARRAY);
         verify_val(in_class, true, "CompType::detectClass() with H5T_ARRAY", __LINE__, __FILE__, "in_class");
         in_class = atom_arr.detectClass(H5T_REFERENCE);
-        verify_val(in_class, true, "CompType::detectClass() with H5T_REFERENCE", __LINE__, __FILE__, "in_class");
+        verify_val(in_class, true, "CompType::detectClass() with H5T_REFERENCE", __LINE__, __FILE__,
+                   "in_class");
 
         // Make certain that an incorrect class is not detected
         in_class = atom_arr.detectClass(H5T_VLEN);
@@ -247,7 +251,8 @@ test_detect_type_class()
         in_class = atom_arr.detectClass(H5T_FLOAT);
         verify_val(in_class, false, "CompType::detectClass() with H5T_FLOAT", __LINE__, __FILE__, "in_class");
         in_class = atom_arr.detectClass(H5T_INTEGER);
-        verify_val(in_class, false, "CompType::detectClass() with H5T_INTEGER", __LINE__, __FILE__, "in_class");
+        verify_val(in_class, false, "CompType::detectClass() with H5T_INTEGER", __LINE__, __FILE__,
+                   "in_class");
 
         /*
          *  Test class of VL datatype
@@ -264,9 +269,11 @@ test_detect_type_class()
 
         // Make certain that an incorrect class is not detected
         in_class = atom_vlf.detectClass(H5T_COMPOUND);
-        verify_val(in_class, false, "CompType::detectClass() with H5T_COMPOUND", __LINE__, __FILE__, "in_class");
+        verify_val(in_class, false, "CompType::detectClass() with H5T_COMPOUND", __LINE__, __FILE__,
+                   "in_class");
         in_class = atom_vlf.detectClass(H5T_INTEGER);
-        verify_val(in_class, false, "CompType::detectClass() with H5T_INTEGER", __LINE__, __FILE__, "in_class");
+        verify_val(in_class, false, "CompType::detectClass() with H5T_INTEGER", __LINE__, __FILE__,
+                   "in_class");
 
         /*
          *  Test class of VL datatype
@@ -280,11 +287,13 @@ test_detect_type_class()
         in_class = atom_vlc.detectClass(H5T_VLEN);
         verify_val(in_class, true, "CompType::detectClass() with H5T_VLEN", __LINE__, __FILE__, "in_class");
         in_class = atom_vlc.detectClass(H5T_INTEGER);
-        verify_val(in_class, true, "CompType::detectClass() with H5T_INTEGER", __LINE__, __FILE__, "in_class");
+        verify_val(in_class, true, "CompType::detectClass() with H5T_INTEGER", __LINE__, __FILE__,
+                   "in_class");
 
         // Make certain that an incorrect class is not detected
         in_class = atom_vlc.detectClass(H5T_STRING);
-        verify_val(in_class, false, "CompType::detectClass() with H5T_STRING", __LINE__, __FILE__, "in_class");
+        verify_val(in_class, false, "CompType::detectClass() with H5T_STRING", __LINE__, __FILE__,
+                   "in_class");
 
         /*
          *  Test class of VL string datatype
@@ -316,13 +325,16 @@ test_detect_type_class()
 
         // Make certain that the correct classes can be detected
         in_class = cplx_cmpd.detectClass(H5T_COMPOUND);
-        verify_val(in_class, true, "CompType::detectClass() with H5T_COMPOUND", __LINE__, __FILE__, "in_class");
+        verify_val(in_class, true, "CompType::detectClass() with H5T_COMPOUND", __LINE__, __FILE__,
+                   "in_class");
         in_class = cplx_cmpd.detectClass(H5T_ARRAY);
         verify_val(in_class, true, "CompType::detectClass() with H5T_ARRAY", __LINE__, __FILE__, "in_class");
         in_class = cplx_cmpd.detectClass(H5T_REFERENCE);
-        verify_val(in_class, true, "CompType::detectClass() with H5T_REFERENCE", __LINE__, __FILE__, "in_class");
+        verify_val(in_class, true, "CompType::detectClass() with H5T_REFERENCE", __LINE__, __FILE__,
+                   "in_class");
         in_class = cplx_cmpd.detectClass(H5T_INTEGER);
-        verify_val(in_class, true, "CompType::detectClass() with H5T_INTEGER", __LINE__, __FILE__, "in_class");
+        verify_val(in_class, true, "CompType::detectClass() with H5T_INTEGER", __LINE__, __FILE__,
+                   "in_class");
         in_class = cplx_cmpd.detectClass(H5T_FLOAT);
         verify_val(in_class, true, "CompType::detectClass() with H5T_FLOAT", __LINE__, __FILE__, "in_class");
         in_class = cplx_cmpd.detectClass(H5T_STRING);
@@ -362,7 +374,8 @@ test_vltype()
         bool in_class = vltype.detectClass(H5T_VLEN);
         verify_val(in_class, true, "VarLenType::detectClass() with H5T_VLEN", __LINE__, __FILE__, "in_class");
         in_class = vltype.detectClass(H5T_INTEGER);
-        verify_val(in_class, true, "VarLenType::detectClass() with H5T_INTEGER", __LINE__, __FILE__, "in_class");
+        verify_val(in_class, true, "VarLenType::detectClass() with H5T_INTEGER", __LINE__, __FILE__,
+                   "in_class");
 
         // Test copy constructor
         VarLenType vltype2(vltype);
@@ -372,11 +385,14 @@ test_vltype()
         verify_val(is_valid, true, "isValid on vltype2", __LINE__, __FILE__, "in_class");
 
         in_class = vltype2.detectClass(H5T_VLEN);
-        verify_val(in_class, true, "VarLenType::detectClass() with H5T_VLEN for vltype2", __LINE__, __FILE__, "in_class");
+        verify_val(in_class, true, "VarLenType::detectClass() with H5T_VLEN for vltype2", __LINE__, __FILE__,
+                   "in_class");
         in_class = vltype2.detectClass(H5T_INTEGER);
-        verify_val(in_class, true, "VarLenType::detectClass() with H5T_INTEGER for vltype2", __LINE__, __FILE__, "in_class");
+        verify_val(in_class, true, "VarLenType::detectClass() with H5T_INTEGER for vltype2", __LINE__,
+                   __FILE__, "in_class");
         in_class = vltype2.detectClass(H5T_FLOAT);
-        verify_val(in_class, false, "VarLenType::detectClass() with H5T_FLOAT for vltype2", __LINE__, __FILE__, "in_class");
+        verify_val(in_class, false, "VarLenType::detectClass() with H5T_FLOAT for vltype2", __LINE__,
+                   __FILE__, "in_class");
 
         // Create a new file to use in this test
         H5File file(FILENAME[3], H5F_ACC_TRUNC);
@@ -399,9 +415,11 @@ test_vltype()
         // Trying to detect H5T_VLEN and H5T_FLOAT classes on this type,
         // should both be true
         in_class = vltype2.detectClass(H5T_VLEN);
-        verify_val(in_class, true, "VarLenType::detectClass() with H5T_VLEN for vltype2", __LINE__, __FILE__, "in_class");
+        verify_val(in_class, true, "VarLenType::detectClass() with H5T_VLEN for vltype2", __LINE__, __FILE__,
+                   "in_class");
         in_class = first_vlt_again.detectClass(H5T_FLOAT);
-        verify_val(in_class, true, "VarLenType::detectClass() with H5T_FLOAT for first_vlt_again", __LINE__, __FILE__, "in_class");
+        verify_val(in_class, true, "VarLenType::detectClass() with H5T_FLOAT for first_vlt_again", __LINE__,
+                   __FILE__, "in_class");
 
         PASSED();
     } // end of try block
@@ -818,14 +836,18 @@ test_encode_decode()
         verify_val(cmptyp == *decoded_cmp_ptr, true, "DataType::decode", __LINE__, __FILE__, "cmptyp");
 
         // Verify again via querying member number and member index by name.
-        verify_val(decoded_cmp_ptr->getNmembers(), 4, "DataType::decode", __LINE__, __FILE__, "decoded_cmp_ptr's number of members");
-        verify_val(decoded_cmp_ptr->getMemberIndex("c"), 2, "DataType::decode", __LINE__, __FILE__, "Member index of 'c'");
+        verify_val(decoded_cmp_ptr->getNmembers(), 4, "DataType::decode", __LINE__, __FILE__,
+                   "decoded_cmp_ptr's number of members");
+        verify_val(decoded_cmp_ptr->getMemberIndex("c"), 2, "DataType::decode", __LINE__, __FILE__,
+                   "Member index of 'c'");
 
         // Create a CompType instance from the pointer and verify it
         CompType cmptyp_clone(*decoded_cmp_ptr);
         verify_val(cmptyp == cmptyp_clone, true, "DataType::decode", __LINE__, __FILE__, "cmptyp");
-        verify_val(cmptyp_clone.getNmembers(), 4, "DataType::decode", __LINE__, __FILE__, "(cmptyp_clone's number of members");
-        verify_val(cmptyp_clone.getMemberIndex("c"), 2, "DataType::decode", __LINE__, __FILE__, "Member index of 'c'");
+        verify_val(cmptyp_clone.getNmembers(), 4, "DataType::decode", __LINE__, __FILE__,
+                   "(cmptyp_clone's number of members");
+        verify_val(cmptyp_clone.getMemberIndex("c"), 2, "DataType::decode", __LINE__, __FILE__,
+                   "Member index of 'c'");
 
         delete decoded_cmp_ptr;
 
@@ -860,14 +882,18 @@ test_encode_decode()
         verify_val(enumtyp == *decoded_enum_ptr, true, "DataType::decode", __LINE__, __FILE__, "enumtyp");
 
         // Verify again via querying member number and member index by name.
-        verify_val(decoded_enum_ptr->getNmembers(), 5, "DataType::decode", __LINE__, __FILE__, "decoded_enum_ptr's number of members");
-        verify_val(decoded_enum_ptr->getMemberIndex("GREEN"), 1, "DataType::decode", __LINE__, __FILE__, "Member index of GREEN");
+        verify_val(decoded_enum_ptr->getNmembers(), 5, "DataType::decode", __LINE__, __FILE__,
+                   "decoded_enum_ptr's number of members");
+        verify_val(decoded_enum_ptr->getMemberIndex("GREEN"), 1, "DataType::decode", __LINE__, __FILE__,
+                   "Member index of GREEN");
 
         // Create a EnumType instance from the pointer and verify it
         EnumType enumtyp_clone(*decoded_enum_ptr);
         verify_val(enumtyp == enumtyp_clone, true, "DataType::decode", __LINE__, __FILE__, "enumtyp");
-        verify_val(enumtyp_clone.getNmembers(), 5, "DataType::decode", __LINE__, __FILE__, "enumtyp_clone's number of members");
-        verify_val(enumtyp_clone.getMemberIndex("GREEN"), 1, "DataType::decode", __LINE__, __FILE__, "Member index of GREEN");
+        verify_val(enumtyp_clone.getNmembers(), 5, "DataType::decode", __LINE__, __FILE__,
+                   "enumtyp_clone's number of members");
+        verify_val(enumtyp_clone.getMemberIndex("GREEN"), 1, "DataType::decode", __LINE__, __FILE__,
+                   "Member index of GREEN");
 
         delete decoded_enum_ptr;
 
@@ -889,7 +915,8 @@ test_encode_decode()
         StrType *decoded_str_ptr(static_cast<StrType *>(vlsttyp.decode()));
 
         verify_val(vlsttyp == *decoded_str_ptr, true, "DataType::decode", __LINE__, __FILE__, "vlsttyp");
-        verify_val(decoded_str_ptr->isVariableStr(), true, "DataType::decode", __LINE__, __FILE__, "decoded_str_ptr being variable-len string");
+        verify_val(decoded_str_ptr->isVariableStr(), true, "DataType::decode", __LINE__, __FILE__,
+                   "decoded_str_ptr being variable-len string");
 
         delete decoded_str_ptr;
 
@@ -901,7 +928,8 @@ test_encode_decode()
         // Create a StrType instance from the DataType object and verify it
         StrType decoded_vlsttyp(decoded_vlstr_ptr->getId());
         verify_val(vlsttyp == decoded_vlsttyp, true, "DataType::decode", __LINE__, __FILE__, "vlsttyp");
-        verify_val(decoded_vlsttyp.isVariableStr(), true, "DataType::decode", __LINE__, __FILE__, "decoded_vlsttyp being variable-len string");
+        verify_val(decoded_vlsttyp.isVariableStr(), true, "DataType::decode", __LINE__, __FILE__,
+                   "decoded_vlsttyp being variable-len string");
 
         delete decoded_vlstr_ptr;
 
@@ -935,7 +963,8 @@ test_encode_decode()
         // Create a ArrayType instance from the decoded pointer and verify it
         ArrayType decoded_arrtyp(decoded_dt_ptr->getId());
         verify_val(arrtyp == decoded_arrtyp, true, "DataType::decode", __LINE__, __FILE__, "arrtyp");
-        verify_val(decoded_arrtyp.getArrayNDims(), ARRAY1_RANK, "DataType::decode", __LINE__, __FILE__, "decoded_arrtyp's number of dimensions");
+        verify_val(decoded_arrtyp.getArrayNDims(), ARRAY1_RANK, "DataType::decode", __LINE__, __FILE__,
+                   "decoded_arrtyp's number of dimensions");
 
         delete decoded_dt_ptr;
 
@@ -983,7 +1012,8 @@ test_encode_decode()
 
         // H5std_string norm_string;
         // H5T_norm_t mant_norm = decoded_flttyp.getNorm(norm_string);
-        // verify_val(decoded_flttyp.isVariableStr(), true, "DataType::decode", __LINE__, __FILE__, "decoded_flttyp being variable-len string");
+        // verify_val(decoded_flttyp.isVariableStr(), true, "DataType::decode", __LINE__, __FILE__,
+        // "decoded_flttyp being variable-len string");
 
         delete decoded_flt_ptr;
 

--- a/c++/test/ttypes.cpp
+++ b/c++/test/ttypes.cpp
@@ -23,7 +23,6 @@ using std::endl;
 #include "H5Cpp.h" // C++ API header file
 using namespace H5;
 
-#include "h5test.h"
 #include "h5cpputil.h" // C++ utilility header file
 
 /*
@@ -95,7 +94,7 @@ test_classes()
         tcls = PredType::NATIVE_DOUBLE.getClass();
         if (H5T_FLOAT != tcls) {
             verify_val(static_cast<long>(tcls), static_cast<long>(H5T_FLOAT),
-                       "test_class: invalid type class for NATIVE_DOUBLE -", __LINE__, __FILE__);
+                       "test_class: invalid type class for NATIVE_DOUBLE -", __LINE__, __FILE__, "tcls");
         }
         PASSED();
     } // end of try block
@@ -192,15 +191,15 @@ test_detect_type_class()
 
         // Native integers should be in the integer class
         in_class = DataType::detectClass(PredType::NATIVE_INT, H5T_INTEGER);
-        verify_val(in_class, true, "DataType::detectClass() with H5T_INTEGER", __LINE__, __FILE__);
+        verify_val(in_class, true, "DataType::detectClass() with H5T_INTEGER", __LINE__, __FILE__, "in_class");
 
         // Native integers should _not_ be in other classes
         in_class = DataType::detectClass(PredType::NATIVE_INT, H5T_FLOAT);
-        verify_val(in_class, false, "DataType::detectClass() with H5T_FLOAT", __LINE__, __FILE__);
+        verify_val(in_class, false, "DataType::detectClass() with H5T_FLOAT", __LINE__, __FILE__, "in_class");
         in_class = DataType::detectClass(PredType::NATIVE_INT, H5T_ARRAY);
-        verify_val(in_class, false, "DataType::detectClass() with H5T_ARRAY", __LINE__, __FILE__);
+        verify_val(in_class, false, "DataType::detectClass() with H5T_ARRAY", __LINE__, __FILE__, "in_class");
         in_class = DataType::detectClass(PredType::NATIVE_INT, H5T_ENUM);
-        verify_val(in_class, false, "DataType::detectClass() with H5T_ENUM", __LINE__, __FILE__);
+        verify_val(in_class, false, "DataType::detectClass() with H5T_ENUM", __LINE__, __FILE__, "in_class");
 
         /*
          *  Test class of a compound type with some atomic types as fields.
@@ -216,16 +215,16 @@ test_detect_type_class()
 
         // Make certain that atom_cmpd is a compound type,
         in_class = atom_cmpd.detectClass(H5T_COMPOUND);
-        verify_val(in_class, true, "CompType::detectClass() with H5T_COMPOUND", __LINE__, __FILE__);
+        verify_val(in_class, true, "CompType::detectClass() with H5T_COMPOUND", __LINE__, __FILE__, "in_class");
         // and that it contains a field of type integer
         in_class = atom_cmpd.detectClass(H5T_INTEGER);
-        verify_val(in_class, true, "CompType::detectClass() with H5T_INTEGER", __LINE__, __FILE__);
+        verify_val(in_class, true, "CompType::detectClass() with H5T_INTEGER", __LINE__, __FILE__, "in_class");
         // and a field of type float,
         in_class = atom_cmpd.detectClass(H5T_FLOAT);
-        verify_val(in_class, true, "CompType::detectClass() with H5T_FLOAT", __LINE__, __FILE__);
+        verify_val(in_class, true, "CompType::detectClass() with H5T_FLOAT", __LINE__, __FILE__, "in_class");
         // and that it doesn't contain any field of variable-length
         in_class = atom_cmpd.detectClass(H5T_VLEN);
-        verify_val(in_class, false, "CompType::detectClass() with H5T_VLEN", __LINE__, __FILE__);
+        verify_val(in_class, false, "CompType::detectClass() with H5T_VLEN", __LINE__, __FILE__, "in_class");
 
         /*
          *  Test class of array datatype
@@ -238,17 +237,17 @@ test_detect_type_class()
 
         // Make certain that the correct classes can be detected
         in_class = atom_arr.detectClass(H5T_ARRAY);
-        verify_val(in_class, true, "CompType::detectClass() with H5T_ARRAY", __LINE__, __FILE__);
+        verify_val(in_class, true, "CompType::detectClass() with H5T_ARRAY", __LINE__, __FILE__, "in_class");
         in_class = atom_arr.detectClass(H5T_REFERENCE);
-        verify_val(in_class, true, "CompType::detectClass() with H5T_REFERENCE", __LINE__, __FILE__);
+        verify_val(in_class, true, "CompType::detectClass() with H5T_REFERENCE", __LINE__, __FILE__, "in_class");
 
         // Make certain that an incorrect class is not detected
         in_class = atom_arr.detectClass(H5T_VLEN);
-        verify_val(in_class, false, "CompType::detectClass() with H5T_VLEN", __LINE__, __FILE__);
+        verify_val(in_class, false, "CompType::detectClass() with H5T_VLEN", __LINE__, __FILE__, "in_class");
         in_class = atom_arr.detectClass(H5T_FLOAT);
-        verify_val(in_class, false, "CompType::detectClass() with H5T_FLOAT", __LINE__, __FILE__);
+        verify_val(in_class, false, "CompType::detectClass() with H5T_FLOAT", __LINE__, __FILE__, "in_class");
         in_class = atom_arr.detectClass(H5T_INTEGER);
-        verify_val(in_class, false, "CompType::detectClass() with H5T_INTEGER", __LINE__, __FILE__);
+        verify_val(in_class, false, "CompType::detectClass() with H5T_INTEGER", __LINE__, __FILE__, "in_class");
 
         /*
          *  Test class of VL datatype
@@ -259,15 +258,15 @@ test_detect_type_class()
 
         // Make certain that the correct classes can be detected
         in_class = atom_vlf.detectClass(H5T_VLEN);
-        verify_val(in_class, true, "CompType::detectClass() with H5T_VLEN", __LINE__, __FILE__);
+        verify_val(in_class, true, "CompType::detectClass() with H5T_VLEN", __LINE__, __FILE__, "in_class");
         in_class = atom_vlf.detectClass(H5T_FLOAT);
-        verify_val(in_class, true, "CompType::detectClass() with H5T_FLOAT", __LINE__, __FILE__);
+        verify_val(in_class, true, "CompType::detectClass() with H5T_FLOAT", __LINE__, __FILE__, "in_class");
 
         // Make certain that an incorrect class is not detected
         in_class = atom_vlf.detectClass(H5T_COMPOUND);
-        verify_val(in_class, false, "CompType::detectClass() with H5T_COMPOUND", __LINE__, __FILE__);
+        verify_val(in_class, false, "CompType::detectClass() with H5T_COMPOUND", __LINE__, __FILE__, "in_class");
         in_class = atom_vlf.detectClass(H5T_INTEGER);
-        verify_val(in_class, false, "CompType::detectClass() with H5T_INTEGER", __LINE__, __FILE__);
+        verify_val(in_class, false, "CompType::detectClass() with H5T_INTEGER", __LINE__, __FILE__, "in_class");
 
         /*
          *  Test class of VL datatype
@@ -279,13 +278,13 @@ test_detect_type_class()
 
         // Make certain that the correct classes can be detected
         in_class = atom_vlc.detectClass(H5T_VLEN);
-        verify_val(in_class, true, "CompType::detectClass() with H5T_VLEN", __LINE__, __FILE__);
+        verify_val(in_class, true, "CompType::detectClass() with H5T_VLEN", __LINE__, __FILE__, "in_class");
         in_class = atom_vlc.detectClass(H5T_INTEGER);
-        verify_val(in_class, true, "CompType::detectClass() with H5T_INTEGER", __LINE__, __FILE__);
+        verify_val(in_class, true, "CompType::detectClass() with H5T_INTEGER", __LINE__, __FILE__, "in_class");
 
         // Make certain that an incorrect class is not detected
         in_class = atom_vlc.detectClass(H5T_STRING);
-        verify_val(in_class, false, "CompType::detectClass() with H5T_STRING", __LINE__, __FILE__);
+        verify_val(in_class, false, "CompType::detectClass() with H5T_STRING", __LINE__, __FILE__, "in_class");
 
         /*
          *  Test class of VL string datatype
@@ -296,11 +295,11 @@ test_detect_type_class()
 
         // Make certain that the correct classes can be detected
         in_class = atom_vls.detectClass(H5T_STRING);
-        verify_val(in_class, true, "CompType::detectClass() with H5T_STRING", __LINE__, __FILE__);
+        verify_val(in_class, true, "CompType::detectClass() with H5T_STRING", __LINE__, __FILE__, "in_class");
 
         // Make certain that an incorrect class is not detected
         in_class = atom_vls.detectClass(H5T_VLEN);
-        verify_val(in_class, false, "CompType::detectClass() with H5T_VLEN", __LINE__, __FILE__);
+        verify_val(in_class, false, "CompType::detectClass() with H5T_VLEN", __LINE__, __FILE__, "in_class");
 
         /*
          *  Test class of a compound type with some complex types as fields.
@@ -317,25 +316,25 @@ test_detect_type_class()
 
         // Make certain that the correct classes can be detected
         in_class = cplx_cmpd.detectClass(H5T_COMPOUND);
-        verify_val(in_class, true, "CompType::detectClass() with H5T_COMPOUND", __LINE__, __FILE__);
+        verify_val(in_class, true, "CompType::detectClass() with H5T_COMPOUND", __LINE__, __FILE__, "in_class");
         in_class = cplx_cmpd.detectClass(H5T_ARRAY);
-        verify_val(in_class, true, "CompType::detectClass() with H5T_ARRAY", __LINE__, __FILE__);
+        verify_val(in_class, true, "CompType::detectClass() with H5T_ARRAY", __LINE__, __FILE__, "in_class");
         in_class = cplx_cmpd.detectClass(H5T_REFERENCE);
-        verify_val(in_class, true, "CompType::detectClass() with H5T_REFERENCE", __LINE__, __FILE__);
+        verify_val(in_class, true, "CompType::detectClass() with H5T_REFERENCE", __LINE__, __FILE__, "in_class");
         in_class = cplx_cmpd.detectClass(H5T_INTEGER);
-        verify_val(in_class, true, "CompType::detectClass() with H5T_INTEGER", __LINE__, __FILE__);
+        verify_val(in_class, true, "CompType::detectClass() with H5T_INTEGER", __LINE__, __FILE__, "in_class");
         in_class = cplx_cmpd.detectClass(H5T_FLOAT);
-        verify_val(in_class, true, "CompType::detectClass() with H5T_FLOAT", __LINE__, __FILE__);
+        verify_val(in_class, true, "CompType::detectClass() with H5T_FLOAT", __LINE__, __FILE__, "in_class");
         in_class = cplx_cmpd.detectClass(H5T_STRING);
-        verify_val(in_class, true, "CompType::detectClass() with H5T_STRING", __LINE__, __FILE__);
+        verify_val(in_class, true, "CompType::detectClass() with H5T_STRING", __LINE__, __FILE__, "in_class");
         in_class = cplx_cmpd.detectClass(H5T_VLEN);
-        verify_val(in_class, true, "CompType::detectClass() with H5T_VLEN", __LINE__, __FILE__);
+        verify_val(in_class, true, "CompType::detectClass() with H5T_VLEN", __LINE__, __FILE__, "in_class");
 
         // Make certain that an incorrect class is not detected
         in_class = cplx_cmpd.detectClass(H5T_TIME);
-        verify_val(in_class, false, "CompType::detectClass() with H5T_TIME", __LINE__, __FILE__);
+        verify_val(in_class, false, "CompType::detectClass() with H5T_TIME", __LINE__, __FILE__, "in_class");
         in_class = cplx_cmpd.detectClass(H5T_ENUM);
-        verify_val(in_class, false, "CompType::detectClass() with H5T_ENUM", __LINE__, __FILE__);
+        verify_val(in_class, false, "CompType::detectClass() with H5T_ENUM", __LINE__, __FILE__, "in_class");
 
         PASSED();
     }
@@ -361,25 +360,23 @@ test_vltype()
         VarLenType vltype(PredType::NATIVE_INT);
 
         bool in_class = vltype.detectClass(H5T_VLEN);
-        verify_val(in_class, true, "VarLenType::detectClass() with H5T_VLEN", __LINE__, __FILE__);
+        verify_val(in_class, true, "VarLenType::detectClass() with H5T_VLEN", __LINE__, __FILE__, "in_class");
         in_class = vltype.detectClass(H5T_INTEGER);
-        verify_val(in_class, true, "VarLenType::detectClass() with H5T_INTEGER", __LINE__, __FILE__);
+        verify_val(in_class, true, "VarLenType::detectClass() with H5T_INTEGER", __LINE__, __FILE__, "in_class");
 
         // Test copy constructor
         VarLenType vltype2(vltype);
 
         // Verify that the copied type has a valid id
         bool is_valid = IdComponent::isValid(vltype2.getId());
-        verify_val(is_valid, true, "isValid on vltype2", __LINE__, __FILE__);
+        verify_val(is_valid, true, "isValid on vltype2", __LINE__, __FILE__, "in_class");
 
         in_class = vltype2.detectClass(H5T_VLEN);
-        verify_val(in_class, true, "VarLenType::detectClass() with H5T_VLEN for vltype2", __LINE__, __FILE__);
+        verify_val(in_class, true, "VarLenType::detectClass() with H5T_VLEN for vltype2", __LINE__, __FILE__, "in_class");
         in_class = vltype2.detectClass(H5T_INTEGER);
-        verify_val(in_class, true, "VarLenType::detectClass() with H5T_INTEGER for vltype2", __LINE__,
-                   __FILE__);
+        verify_val(in_class, true, "VarLenType::detectClass() with H5T_INTEGER for vltype2", __LINE__, __FILE__, "in_class");
         in_class = vltype2.detectClass(H5T_FLOAT);
-        verify_val(in_class, false, "VarLenType::detectClass() with H5T_FLOAT for vltype2", __LINE__,
-                   __FILE__);
+        verify_val(in_class, false, "VarLenType::detectClass() with H5T_FLOAT for vltype2", __LINE__, __FILE__, "in_class");
 
         // Create a new file to use in this test
         H5File file(FILENAME[3], H5F_ACC_TRUNC);
@@ -402,10 +399,9 @@ test_vltype()
         // Trying to detect H5T_VLEN and H5T_FLOAT classes on this type,
         // should both be true
         in_class = vltype2.detectClass(H5T_VLEN);
-        verify_val(in_class, true, "VarLenType::detectClass() with H5T_VLEN for vltype2", __LINE__, __FILE__);
+        verify_val(in_class, true, "VarLenType::detectClass() with H5T_VLEN for vltype2", __LINE__, __FILE__, "in_class");
         in_class = first_vlt_again.detectClass(H5T_FLOAT);
-        verify_val(in_class, true, "VarLenType::detectClass() with H5T_FLOAT for first_vlt_again", __LINE__,
-                   __FILE__);
+        verify_val(in_class, true, "VarLenType::detectClass() with H5T_FLOAT for first_vlt_again", __LINE__, __FILE__, "in_class");
 
         PASSED();
     } // end of try block
@@ -460,17 +456,17 @@ test_query()
 
         // Query member number and member index by name, for compound type
         int nmembs = tid1.getNmembers();
-        verify_val(nmembs, 4, "CompType::getNmembers()", __LINE__, __FILE__);
+        verify_val(nmembs, 4, "CompType::getNmembers()", __LINE__, __FILE__, "nmembs");
 
         int index = tid1.getMemberIndex("c");
-        verify_val(index, 2, "CompType::getMemberIndex()", __LINE__, __FILE__);
+        verify_val(index, 2, "CompType::getMemberIndex()", __LINE__, __FILE__, "index");
 
         // Query member number and member index by name, for enumeration type.
         nmembs = tid2.getNmembers();
-        verify_val(nmembs, 5, "EnumType::getNmembers()", __LINE__, __FILE__);
+        verify_val(nmembs, 5, "EnumType::getNmembers()", __LINE__, __FILE__, "nmembs");
 
         index = tid2.getMemberIndex("ORANGE");
-        verify_val(index, 3, "EnumType::getMemberIndex()", __LINE__, __FILE__);
+        verify_val(index, 3, "EnumType::getMemberIndex()", __LINE__, __FILE__, "index");
 
         // Commit compound datatype, and test getting the datatype creation
         // prop list, then close it
@@ -508,15 +504,15 @@ test_query()
 
         // Query member number and member index by name, for compound type
         nmembs = comptype.getNmembers();
-        verify_val(nmembs, 4, "CompType::getNmembers()", __LINE__, __FILE__);
+        verify_val(nmembs, 4, "CompType::getNmembers()", __LINE__, __FILE__, "nmembs");
         index = comptype.getMemberIndex("c");
-        verify_val(index, 2, "CompType::getMemberIndex()", __LINE__, __FILE__);
+        verify_val(index, 2, "CompType::getMemberIndex()", __LINE__, __FILE__, "index");
 
         // Query member number and member index by name, for enumeration type
         nmembs = enumtype.getNmembers();
-        verify_val(nmembs, 5, "EnumType::getNmembers()", __LINE__, __FILE__);
+        verify_val(nmembs, 5, "EnumType::getNmembers()", __LINE__, __FILE__, "nmembs");
         index = enumtype.getMemberIndex("ORANGE");
-        verify_val(index, 3, "EnumType::getMemberIndex()", __LINE__, __FILE__);
+        verify_val(index, 3, "EnumType::getMemberIndex()", __LINE__, __FILE__, "index");
 
         // Close datatypes and file
         comptype.close();
@@ -709,7 +705,7 @@ test_named()
         bool iscommitted = trans_type.committed();
         verify_val(iscommitted, 0,
                    "DataType::committed() - Copying a named type should result in a transient type!",
-                   __LINE__, __FILE__);
+                   __LINE__, __FILE__, "iscommitted");
         trans_type.setPrecision(256);
         trans_type.close();
 
@@ -813,23 +809,23 @@ test_encode_decode()
         cmptyp.encode();
 
         // Verify that encoding had been done
-        verify_val(cmptyp.hasBinaryDesc(), true, "DataType::encode", __LINE__, __FILE__);
+        verify_val(cmptyp.hasBinaryDesc(), true, "DataType::encode", __LINE__, __FILE__, "cmptyp encoding");
 
         // Decode compound type's buffer to a new CompType
         CompType *decoded_cmp_ptr(static_cast<CompType *>(cmptyp.decode()));
 
         // Verify that the datatype was copied exactly via encoding/decoding
-        verify_val(cmptyp == *decoded_cmp_ptr, true, "DataType::decode", __LINE__, __FILE__);
+        verify_val(cmptyp == *decoded_cmp_ptr, true, "DataType::decode", __LINE__, __FILE__, "cmptyp");
 
         // Verify again via querying member number and member index by name.
-        verify_val(decoded_cmp_ptr->getNmembers(), 4, "DataType::decode", __LINE__, __FILE__);
-        verify_val(decoded_cmp_ptr->getMemberIndex("c"), 2, "DataType::decode", __LINE__, __FILE__);
+        verify_val(decoded_cmp_ptr->getNmembers(), 4, "DataType::decode", __LINE__, __FILE__, "decoded_cmp_ptr's number of members");
+        verify_val(decoded_cmp_ptr->getMemberIndex("c"), 2, "DataType::decode", __LINE__, __FILE__, "Member index of 'c'");
 
         // Create a CompType instance from the pointer and verify it
         CompType cmptyp_clone(*decoded_cmp_ptr);
-        verify_val(cmptyp == cmptyp_clone, true, "DataType::decode", __LINE__, __FILE__);
-        verify_val(cmptyp_clone.getNmembers(), 4, "DataType::decode", __LINE__, __FILE__);
-        verify_val(cmptyp_clone.getMemberIndex("c"), 2, "DataType::decode", __LINE__, __FILE__);
+        verify_val(cmptyp == cmptyp_clone, true, "DataType::decode", __LINE__, __FILE__, "cmptyp");
+        verify_val(cmptyp_clone.getNmembers(), 4, "DataType::decode", __LINE__, __FILE__, "(cmptyp_clone's number of members");
+        verify_val(cmptyp_clone.getMemberIndex("c"), 2, "DataType::decode", __LINE__, __FILE__, "Member index of 'c'");
 
         delete decoded_cmp_ptr;
 
@@ -855,23 +851,23 @@ test_encode_decode()
         enumtyp.encode();
 
         // Verify that encoding had been done
-        verify_val(enumtyp.hasBinaryDesc(), true, "DataType::encode", __LINE__, __FILE__);
+        verify_val(enumtyp.hasBinaryDesc(), true, "DataType::encode", __LINE__, __FILE__, "enumtyp encoding");
 
         // Decode enumeration type's buffer to a new EnumType
         EnumType *decoded_enum_ptr(static_cast<EnumType *>(enumtyp.decode()));
 
         // Verify that the datatype was copied exactly via encoding/decoding
-        verify_val(enumtyp == *decoded_enum_ptr, true, "DataType::decode", __LINE__, __FILE__);
+        verify_val(enumtyp == *decoded_enum_ptr, true, "DataType::decode", __LINE__, __FILE__, "enumtyp");
 
         // Verify again via querying member number and member index by name.
-        verify_val(decoded_enum_ptr->getNmembers(), 5, "DataType::decode", __LINE__, __FILE__);
-        verify_val(decoded_enum_ptr->getMemberIndex("GREEN"), 1, "DataType::decode", __LINE__, __FILE__);
+        verify_val(decoded_enum_ptr->getNmembers(), 5, "DataType::decode", __LINE__, __FILE__, "decoded_enum_ptr's number of members");
+        verify_val(decoded_enum_ptr->getMemberIndex("GREEN"), 1, "DataType::decode", __LINE__, __FILE__, "Member index of GREEN");
 
         // Create a EnumType instance from the pointer and verify it
         EnumType enumtyp_clone(*decoded_enum_ptr);
-        verify_val(enumtyp == enumtyp_clone, true, "DataType::decode", __LINE__, __FILE__);
-        verify_val(enumtyp_clone.getNmembers(), 5, "DataType::decode", __LINE__, __FILE__);
-        verify_val(enumtyp_clone.getMemberIndex("GREEN"), 1, "DataType::decode", __LINE__, __FILE__);
+        verify_val(enumtyp == enumtyp_clone, true, "DataType::decode", __LINE__, __FILE__, "enumtyp");
+        verify_val(enumtyp_clone.getNmembers(), 5, "DataType::decode", __LINE__, __FILE__, "enumtyp_clone's number of members");
+        verify_val(enumtyp_clone.getMemberIndex("GREEN"), 1, "DataType::decode", __LINE__, __FILE__, "Member index of GREEN");
 
         delete decoded_enum_ptr;
 
@@ -887,13 +883,13 @@ test_encode_decode()
         vlsttyp.encode();
 
         // Verify that encoding had been done
-        verify_val(vlsttyp.hasBinaryDesc(), true, "DataType::encode", __LINE__, __FILE__);
+        verify_val(vlsttyp.hasBinaryDesc(), true, "DataType::encode", __LINE__, __FILE__, "vlsttyp encoding");
 
         // Decode the variable-length type's buffer to a new StrType
         StrType *decoded_str_ptr(static_cast<StrType *>(vlsttyp.decode()));
 
-        verify_val(vlsttyp == *decoded_str_ptr, true, "DataType::decode", __LINE__, __FILE__);
-        verify_val(decoded_str_ptr->isVariableStr(), true, "DataType::decode", __LINE__, __FILE__);
+        verify_val(vlsttyp == *decoded_str_ptr, true, "DataType::decode", __LINE__, __FILE__, "vlsttyp");
+        verify_val(decoded_str_ptr->isVariableStr(), true, "DataType::decode", __LINE__, __FILE__, "decoded_str_ptr being variable-len string");
 
         delete decoded_str_ptr;
 
@@ -904,8 +900,8 @@ test_encode_decode()
 
         // Create a StrType instance from the DataType object and verify it
         StrType decoded_vlsttyp(decoded_vlstr_ptr->getId());
-        verify_val(vlsttyp == decoded_vlsttyp, true, "DataType::decode", __LINE__, __FILE__);
-        verify_val(decoded_vlsttyp.isVariableStr(), true, "DataType::decode", __LINE__, __FILE__);
+        verify_val(vlsttyp == decoded_vlsttyp, true, "DataType::decode", __LINE__, __FILE__, "vlsttyp");
+        verify_val(decoded_vlsttyp.isVariableStr(), true, "DataType::decode", __LINE__, __FILE__, "decoded_vlsttyp being variable-len string");
 
         delete decoded_vlstr_ptr;
 
@@ -922,12 +918,12 @@ test_encode_decode()
         arrtyp.encode();
 
         // Verify that encoding had been done
-        verify_val(arrtyp.hasBinaryDesc(), true, "DataType::encode", __LINE__, __FILE__);
+        verify_val(arrtyp.hasBinaryDesc(), true, "DataType::encode", __LINE__, __FILE__, "arrtyp encoding");
 
         // Create an ArrayType instance from the decoded pointer and verify it
         ArrayType *decoded_arr_ptr(static_cast<ArrayType *>(arrtyp.decode()));
 
-        verify_val(arrtyp == *decoded_arr_ptr, true, "DataType::decode", __LINE__, __FILE__);
+        verify_val(arrtyp == *decoded_arr_ptr, true, "DataType::decode", __LINE__, __FILE__, "arrtyp");
 
         delete decoded_arr_ptr;
 
@@ -938,8 +934,8 @@ test_encode_decode()
 
         // Create a ArrayType instance from the decoded pointer and verify it
         ArrayType decoded_arrtyp(decoded_dt_ptr->getId());
-        verify_val(arrtyp == decoded_arrtyp, true, "DataType::decode", __LINE__, __FILE__);
-        verify_val(decoded_arrtyp.getArrayNDims(), ARRAY1_RANK, "DataType::decode", __LINE__, __FILE__);
+        verify_val(arrtyp == decoded_arrtyp, true, "DataType::decode", __LINE__, __FILE__, "arrtyp");
+        verify_val(decoded_arrtyp.getArrayNDims(), ARRAY1_RANK, "DataType::decode", __LINE__, __FILE__, "decoded_arrtyp's number of dimensions");
 
         delete decoded_dt_ptr;
 
@@ -954,14 +950,14 @@ test_encode_decode()
         inttyp.encode();
 
         // Verify that encoding had been done
-        verify_val(inttyp.hasBinaryDesc(), true, "DataType::encode", __LINE__, __FILE__);
+        verify_val(inttyp.hasBinaryDesc(), true, "DataType::encode", __LINE__, __FILE__, "inttyp encoding");
 
         // Create an IntType instance from the decoded pointer and verify it
         IntType   *decoded_int_ptr(static_cast<IntType *>(inttyp.decode()));
         H5T_sign_t int_sign = decoded_int_ptr->getSign();
         verify_val(static_cast<long>(int_sign), static_cast<long>(H5T_SGN_NONE), "DataType::decode", __LINE__,
-                   __FILE__);
-        verify_val(inttyp == *decoded_int_ptr, true, "DataType::decode", __LINE__, __FILE__);
+                   __FILE__, "int_sign");
+        verify_val(inttyp == *decoded_int_ptr, true, "DataType::decode", __LINE__, __FILE__, "inttyp");
 
         delete decoded_int_ptr;
 
@@ -976,18 +972,18 @@ test_encode_decode()
         flttyp.encode();
 
         // Verify that encoding had been done
-        verify_val(flttyp.hasBinaryDesc(), true, "DataType::encode", __LINE__, __FILE__);
+        verify_val(flttyp.hasBinaryDesc(), true, "DataType::encode", __LINE__, __FILE__, "flttyp encoding");
 
         // Decode the array type's buffer
         DataType *decoded_flt_ptr(flttyp.decode());
 
         // Create a IntType instance from the decoded pointer and verify it
         FloatType decoded_flttyp(decoded_flt_ptr->getId());
-        verify_val(flttyp == decoded_flttyp, true, "DataType::decode", __LINE__, __FILE__);
+        verify_val(flttyp == decoded_flttyp, true, "DataType::decode", __LINE__, __FILE__, "flttyp");
 
         // H5std_string norm_string;
         // H5T_norm_t mant_norm = decoded_flttyp.getNorm(norm_string);
-        // verify_val(decoded_flttyp.isVariableStr(), true, "DataType::decode", __LINE__, __FILE__);
+        // verify_val(decoded_flttyp.isVariableStr(), true, "DataType::decode", __LINE__, __FILE__, "decoded_flttyp being variable-len string");
 
         delete decoded_flt_ptr;
 
@@ -1033,8 +1029,8 @@ test_operators()
         CompType clone_cmptyp(cmptyp);
 
         // Verify that operator== and operator!= work properly
-        verify_val(cmptyp == clone_cmptyp, true, "DataType::operator==", __LINE__, __FILE__);
-        verify_val(cmptyp != clone_cmptyp, false, "DataType::operator!=", __LINE__, __FILE__);
+        verify_val(cmptyp == clone_cmptyp, true, "DataType::operator==", __LINE__, __FILE__, "cmptyp");
+        verify_val(cmptyp != clone_cmptyp, false, "DataType::operator!=", __LINE__, __FILE__, "cmptyp");
 
         //
         // Test with EnumType
@@ -1051,8 +1047,8 @@ test_operators()
         enumtyp.insert("BLUE", &enum_val);
 
         // Verify that operator== and operator!= work properly
-        verify_val(cmptyp == enumtyp, false, "DataType::operator==", __LINE__, __FILE__);
-        verify_val(cmptyp != enumtyp, true, "DataType::operator!=", __LINE__, __FILE__);
+        verify_val(cmptyp == enumtyp, false, "DataType::operator==", __LINE__, __FILE__, "cmptyp");
+        verify_val(cmptyp != enumtyp, true, "DataType::operator!=", __LINE__, __FILE__, "cmptyp");
 
         //
         // Test with compound datatype's member
@@ -1066,16 +1062,16 @@ test_operators()
         IntType member_inttyp = cmptyp.getMemberIntType(0);
 
         // Test various combinations
-        verify_val(inttyp == member_inttyp, true, "DataType::operator==", __LINE__, __FILE__);
-        verify_val(flttyp == member_inttyp, false, "DataType::operator==", __LINE__, __FILE__);
-        verify_val(flttyp != member_inttyp, true, "DataType::operator==", __LINE__, __FILE__);
+        verify_val(inttyp == member_inttyp, true, "DataType::operator==", __LINE__, __FILE__, "inttyp");
+        verify_val(flttyp == member_inttyp, false, "DataType::operator==", __LINE__, __FILE__, "flttyp");
+        verify_val(flttyp != member_inttyp, true, "DataType::operator==", __LINE__, __FILE__, "flttyp");
 
         // Get the NATIVE_FLOAT member from the compound datatype above
-        IntType member_flttyp = cmptyp.getMemberIntType(1);
+        FloatType member_flttyp = cmptyp.getMemberFloatType(1);
 
         // Test various combinations
-        verify_val(inttyp == member_flttyp, false, "DataType::operator==", __LINE__, __FILE__);
-        verify_val(flttyp != member_flttyp, false, "DataType::operator==", __LINE__, __FILE__);
+        verify_val(inttyp == member_flttyp, false, "DataType::operator==", __LINE__, __FILE__, "inttyp");
+        verify_val(flttyp != member_flttyp, false, "DataType::operator==", __LINE__, __FILE__, "flttyp");
 
         PASSED();
     }
@@ -1095,9 +1091,6 @@ test_operators()
 extern "C" void
 test_types()
 {
-    // Output message about test being performed
-    MESSAGE(5, ("Testing Generic Data Types\n"));
-
     // Test basic datatypes
     test_classes();
     test_copy();

--- a/c++/test/tvlstr.cpp
+++ b/c++/test/tvlstr.cpp
@@ -78,7 +78,8 @@ test_vlstring_dataset()
 
         // Read and verify the dataset string as a string of chars.
         dset1.read(&string_ds_check, vlst);
-        verify_val(const_cast<const char *>(string_ds_check), DSET1_DATA.c_str(), "DataSet::read", __LINE__, __FILE__, "string_ds_check");
+        verify_val(const_cast<const char *>(string_ds_check), DSET1_DATA.c_str(), "DataSet::read", __LINE__,
+                   __FILE__, "string_ds_check");
 
         free(string_ds_check); // note: no need for std::string test
         string_ds_check = NULL;
@@ -102,10 +103,14 @@ test_vlstring_dataset()
         dset1.read(&string_ds_check, vlst);
 
         // Verify data read.
-        verify_val(const_cast<const char *>(string_ds_check), const_cast<const char *>(dynstring_ds_write), "DataSet::read", __LINE__, __FILE__, "string_ds_check");
-        verify_val(static_cast<const H5std_string>(string_ds_check), static_cast<const H5std_string>(dynstring_ds_write), "DataSet::read", __LINE__, __FILE__, "string_ds_check");
-         /* verify_val(static_cast<const H5std_string&>(string_ds_check), static_cast<const H5std_string&>(dynstring_ds_write), "DataSet::read", __LINE__, __FILE__, "string_ds_check");
- */ 
+        verify_val(const_cast<const char *>(string_ds_check), const_cast<const char *>(dynstring_ds_write),
+                   "DataSet::read", __LINE__, __FILE__, "string_ds_check");
+        verify_val(static_cast<const H5std_string>(string_ds_check),
+                   static_cast<const H5std_string>(dynstring_ds_write), "DataSet::read", __LINE__, __FILE__,
+                   "string_ds_check");
+        /* verify_val(static_cast<const H5std_string&>(string_ds_check), static_cast<const
+         * H5std_string&>(dynstring_ds_write), "DataSet::read", __LINE__, __FILE__, "string_ds_check");
+         */
         free(string_ds_check);
         string_ds_check = NULL;
         dset1.close();
@@ -174,7 +179,8 @@ test_vlstring_array_dataset()
         for (int i = 0; i < SPACE1_DIM1; i++) {
             char var[VAR_LEN];
             sprintf(var, "string_ds_check[%d]", i);
-            verify_val(const_cast<const char *>(string_ds_check[i]), string_ds_array[i], "DataSet::read", __LINE__, __FILE__, var);
+            verify_val(const_cast<const char *>(string_ds_check[i]), string_ds_array[i], "DataSet::read",
+                       __LINE__, __FILE__, var);
             free(string_ds_check[i]);
         }
 
@@ -197,7 +203,8 @@ test_vlstring_array_dataset()
 
         char *rdata2;
         dataset2.read(&rdata2, vlst);
-        verify_val(const_cast<const char *>(rdata2), const_cast<const char *>(wdata2), "DataSet::read", __LINE__, __FILE__, "rdata2");
+        verify_val(const_cast<const char *>(rdata2), const_cast<const char *>(wdata2), "DataSet::read",
+                   __LINE__, __FILE__, "rdata2");
 
         // Release resources from second dataset operation.
         scalar_space.close();
@@ -258,8 +265,7 @@ test_vlstrings_special()
         dataset.read(rdata, vlst);
 
         // Check data read in.
-        for (int i = 0; i < SPACE1_DIM1; i++)
-        {
+        for (int i = 0; i < SPACE1_DIM1; i++) {
             char var[VAR_LEN];
             sprintf(var, "rdata[%d]", i);
             verify_val(rdata[i], static_cast<void *>(NULL), "DataSet::read", __LINE__, __FILE__, var);
@@ -309,12 +315,12 @@ test_vlstrings_special()
         dataset.read(rdata, vlst);
 
         // Check data read in.
-         /* for (int i = 0; i < SPACE1_DIM1; i++) {
-            char var[VAR_LEN];
-            sprintf(var, "rdata[%d]", i);
-            verify_val(rdata[i], NULL, "DataSet::read", __LINE__, __FILE__, var);
-        }
- */ 
+        /* for (int i = 0; i < SPACE1_DIM1; i++) {
+           char var[VAR_LEN];
+           sprintf(var, "rdata[%d]", i);
+           verify_val(rdata[i], NULL, "DataSet::read", __LINE__, __FILE__, var);
+       }
+*/
 
         // Try to write nil strings to disk.
         dataset.write(wdata2, vlst);
@@ -323,12 +329,12 @@ test_vlstrings_special()
         dataset.read(rdata, vlst);
 
         // Check data read in.
-         /* for (int i = 0; i < SPACE1_DIM1; i++) {
-            char var[VAR_LEN];
-            sprintf(var, "rdata[%d]", i);
-            verify_val(rdata[i], NULL, "DataSet::read", __LINE__, __FILE__, var);
-        }
- */ 
+        /* for (int i = 0; i < SPACE1_DIM1; i++) {
+           char var[VAR_LEN];
+           sprintf(var, "rdata[%d]", i);
+           verify_val(rdata[i], NULL, "DataSet::read", __LINE__, __FILE__, var);
+       }
+*/
 
         // Close objects and file.
         dataset.close();
@@ -372,7 +378,8 @@ test_vlstring_type()
         // Change padding and verify it.
         vlst.setStrpad(H5T_STR_NULLPAD);
         H5T_str_t pad = vlst.getStrpad();
-        verify_val(static_cast<long>(pad), static_cast<long>(H5T_STR_NULLPAD), "StrType::getStrpad", __LINE__, __FILE__, "pad");
+        verify_val(static_cast<long>(pad), static_cast<long>(H5T_STR_NULLPAD), "StrType::getStrpad", __LINE__,
+                   __FILE__, "pad");
 
         // Convert to variable-length string.
         vlst.setSize(H5T_VARIABLE);
@@ -386,9 +393,11 @@ test_vlstring_type()
 
         // Check default character set and padding.
         H5T_cset_t cset = vlst.getCset();
-        verify_val(static_cast<long>(cset), static_cast<long>(H5T_CSET_ASCII), "StrType::getCset", __LINE__, __FILE__, "cset");
+        verify_val(static_cast<long>(cset), static_cast<long>(H5T_CSET_ASCII), "StrType::getCset", __LINE__,
+                   __FILE__, "cset");
         pad = vlst.getStrpad();
-        verify_val(static_cast<long>(pad), static_cast<long>(H5T_STR_NULLPAD), "StrType::getStrpad", __LINE__, __FILE__, "pad");
+        verify_val(static_cast<long>(pad), static_cast<long>(H5T_STR_NULLPAD), "StrType::getStrpad", __LINE__,
+                   __FILE__, "pad");
 
         // Commit variable-length string datatype to storage.
         vlst.commit(*file1, VLSTR_TYPE);
@@ -416,9 +425,11 @@ test_vlstring_type()
 
         // Verify character set and padding
         cset = vlst2.getCset();
-        verify_val(static_cast<long>(cset), static_cast<long>(H5T_CSET_ASCII), "StrType::getCset", __LINE__, __FILE__, "cset");
+        verify_val(static_cast<long>(cset), static_cast<long>(H5T_CSET_ASCII), "StrType::getCset", __LINE__,
+                   __FILE__, "cset");
         pad = vlst2.getStrpad();
-        verify_val(static_cast<long>(pad), static_cast<long>(H5T_STR_NULLPAD), "StrType::getStrpad", __LINE__, __FILE__, "pad");
+        verify_val(static_cast<long>(pad), static_cast<long>(H5T_STR_NULLPAD), "StrType::getStrpad", __LINE__,
+                   __FILE__, "pad");
 
         // Close datatype and file
         vlst2.close();
@@ -479,7 +490,8 @@ test_compact_vlstring()
         for (int i = 0; i < SPACE1_DIM1; i++) {
             char var[VAR_LEN];
             sprintf(var, "rdata[%d]", i);
-            verify_val(static_cast<const char *>(rdata[i]), static_cast<const char *>(wdata[i]), "DataSet::read", __LINE__, __FILE__, var);
+            verify_val(static_cast<const char *>(rdata[i]), static_cast<const char *>(wdata[i]),
+                       "DataSet::read", __LINE__, __FILE__, var);
         }
 
         // Reclaim the read VL data
@@ -541,7 +553,8 @@ test_vlstring_attribute()
         // Read and verify the attribute string as a string of chars.
         char *string_att_check;
         gr_attr.read(vlst, &string_att_check);
-        verify_val(const_cast<const char *>(string_att_check), ATTRSTR_DATA.c_str(), "Attribute::read", __LINE__, __FILE__, "string_att_check");
+        verify_val(const_cast<const char *>(string_att_check), ATTRSTR_DATA.c_str(), "Attribute::read",
+                   __LINE__, __FILE__, "string_att_check");
         free(string_att_check); // note: no need for std::string test
 
         // Read and verify the attribute string as an std::string.
@@ -563,7 +576,8 @@ test_vlstring_attribute()
         gr_attr.read(vlst, &string_att_check);
 
         // Verify data read.
-        verify_val(static_cast<const char *>(string_att_check), static_cast<const char *>(string_att_write), "Attribute::read", __LINE__, __FILE__, "string_att_check");
+        verify_val(static_cast<const char *>(string_att_check), static_cast<const char *>(string_att_write),
+                   "Attribute::read", __LINE__, __FILE__, "string_att_check");
 
         // Release resources.
         free(string_att_check);
@@ -587,7 +601,8 @@ test_vlstring_attribute()
  * Return       None
  *-------------------------------------------------------------------------
  */
-static void test_read_vl_string_attribute()
+static void
+test_read_vl_string_attribute()
 {
 
     // Output message about test being performed
@@ -601,22 +616,24 @@ static void test_read_vl_string_attribute()
         StrType vlst(0, H5T_VARIABLE);
 
         // Open the root group and its attribute named ATTRSTR_NAME.
-        Group root = file1.openGroup("/");
-        Attribute att = root.openAttribute(ATTRSTR_NAME);
+        Group     root = file1.openGroup("/");
+        Attribute att  = root.openAttribute(ATTRSTR_NAME);
 
         // Test reading "normal" sized string attribute
         char *string_att_check;
         att.read(vlst, &string_att_check);
-        verify_val(const_cast<const char *>(string_att_check), ATTRSTR_DATA.c_str(), "Attribute::read", __LINE__, __FILE__, "string_att_check");
+        verify_val(const_cast<const char *>(string_att_check), ATTRSTR_DATA.c_str(), "Attribute::read",
+                   __LINE__, __FILE__, "string_att_check");
         free(string_att_check);
         att.close();
 
         // Test reading "large" sized string attribute
         att = root.openAttribute("test_scalar_large");
         att.read(vlst, &string_att_check);
-        verify_val(static_cast<const char *>(string_att_check), static_cast<const char *>(string_att_write), "Attribute::read", __LINE__, __FILE__, "string_att_check");
+        verify_val(static_cast<const char *>(string_att_check), static_cast<const char *>(string_att_write),
+                   "Attribute::read", __LINE__, __FILE__, "string_att_check");
         free(string_att_check);
-        free(string_att_write);   // Free string allocated in test_write_vl_string_attribute
+        free(string_att_write); // Free string allocated in test_write_vl_string_attribute
 
         // Close objects and file.
         att.close();
@@ -628,8 +645,7 @@ static void test_read_vl_string_attribute()
     } // end try
 
     // Catch all exceptions.
-    catch (Exception& E)
-    {
+    catch (Exception &E) {
         issue_fail_msg("test_read_vl_string_attribute()", __LINE__, __FILE__, E.getCDetailMsg());
     }
 } // test_read_vl_string_attribute
@@ -681,7 +697,9 @@ test_vlstring_array_attribute()
         for (int i = 0; i < SPACE1_DIM1; i++) {
             char var[VAR_LEN];
             sprintf(var, "string_att_check[%d]", i);
-            verify_val(static_cast<const char *>(string_att_check[i]), static_cast<const char *>(string_att_array[i]), "DataSet::read", __LINE__, __FILE__, var);
+            verify_val(static_cast<const char *>(string_att_check[i]),
+                       static_cast<const char *>(string_att_array[i]), "DataSet::read", __LINE__, __FILE__,
+                       var);
 
             free(string_att_check[i]); // note: no need for std::string test
         }
@@ -728,7 +746,8 @@ read_scalar_dset(H5File &file, DataType &type, DataSpace &space, char *name, cha
         dset.read(&data_read, type, space, space);
         dset.close();
 
-        verify_val(static_cast<const char *>(data), static_cast<const char *>(data_read), "DataSet::read", __LINE__, __FILE__, "data");
+        verify_val(static_cast<const char *>(data), static_cast<const char *>(data_read), "DataSet::read",
+                   __LINE__, __FILE__, "data");
         free(data_read);
     } // end try
     catch (FileIException &ferr) {


### PR DESCRIPTION
Revised the C++ tests to eliminate the use of private header files. The solution is to use some functions in the tools library and duplicate some functions from h5test.*.  Some of these duplicated functions can be added to the tools library at a later time, however.

Also, there are many small changes to improve the overall outputs of the tests.

Note: The changes to c++/test/Makefile.am will be committed soon.

(Issue GH-4517)