### PR TITLE
Avoid attempting to close connector with zero references

### DIFF
--- a/src/H5ES.c
+++ b/src/H5ES.c
@@ -127,20 +127,15 @@ H5ESinsert_request(hid_t es_id, hid_t connector_id, void *request)
     if (NULL == (connector = H5VL_new_connector(connector_id)))
         HGOTO_ERROR(H5E_EVENTSET, H5E_CANTCREATE, FAIL, "can't create VOL connector object");
 
-    /* Increment reference count above 0 so that connector can be closed if VOL object creation fails */
-    connector->nrefs++;
-
     /* Insert request into event set */
     if (H5ES__insert_request(es, connector, request) < 0)
         HGOTO_ERROR(H5E_EVENTSET, H5E_CANTINSERT, FAIL, "can't insert request into event set");
-
-    connector->nrefs--;
 
 done:
     /* Clean up on error */
     if (ret_value < 0)
         /* Release newly created connector.*/
-        if (connector && H5VL_conn_dec_rc(connector) < 0)
+        if (connector && (H5VL_conn_dest(connector) < 0))
             HDONE_ERROR(H5E_EVENTSET, H5E_CANTDEC, FAIL, "unable to decrement ref count on VOL connector");
 
     FUNC_LEAVE_API(ret_value)

--- a/src/H5ES.c
+++ b/src/H5ES.c
@@ -127,14 +127,19 @@ H5ESinsert_request(hid_t es_id, hid_t connector_id, void *request)
     if (NULL == (connector = H5VL_new_connector(connector_id)))
         HGOTO_ERROR(H5E_EVENTSET, H5E_CANTCREATE, FAIL, "can't create VOL connector object");
 
+    /* Increment reference count above 0 so that connector can be closed if VOL object creation fails */
+    connector->nrefs++;
+
     /* Insert request into event set */
     if (H5ES__insert_request(es, connector, request) < 0)
         HGOTO_ERROR(H5E_EVENTSET, H5E_CANTINSERT, FAIL, "can't insert request into event set");
 
+    connector->nrefs--;
+
 done:
     /* Clean up on error */
     if (ret_value < 0)
-        /* Release newly created connector */
+        /* Release newly created connector.*/
         if (connector && H5VL_conn_dec_rc(connector) < 0)
             HDONE_ERROR(H5E_EVENTSET, H5E_CANTDEC, FAIL, "unable to decrement ref count on VOL connector");
 

--- a/src/H5ES.c
+++ b/src/H5ES.c
@@ -141,7 +141,7 @@ done:
     /* Clean up on error */
     if (ret_value < 0)
         /* Release newly created connector.*/
-        if (connector && (H5VL_conn_dest(connector) < 0))
+        if (connector && (H5VL_conn_dec_rc(connector) < 0))
             HDONE_ERROR(H5E_EVENTSET, H5E_CANTDEC, FAIL, "unable to decrement ref count on VOL connector");
 
     FUNC_LEAVE_API(ret_value)

--- a/src/H5ES.c
+++ b/src/H5ES.c
@@ -131,6 +131,12 @@ H5ESinsert_request(hid_t es_id, hid_t connector_id, void *request)
     if (H5ES__insert_request(es, connector, request) < 0)
         HGOTO_ERROR(H5E_EVENTSET, H5E_CANTINSERT, FAIL, "can't insert request into event set");
 
+    /* Remove 'dummy' connector reference */
+    assert(connector->nrefs > 1);
+
+    if (H5VL_conn_dec_rc(connector) < 0)
+        HGOTO_ERROR(H5E_EVENTSET, H5E_CANTDEC, FAIL, "unable to decrement ref count on VOL connector");
+
 done:
     /* Clean up on error */
     if (ret_value < 0)

--- a/src/H5VLint.c
+++ b/src/H5VLint.c
@@ -265,8 +265,8 @@ H5VL_term_package(void)
                 /* Destroy the VOL connector ID group */
                 n += (H5I_dec_type_ref(H5I_VOL) > 0);
             } /* end else */
-        }     /* end else */
-    }         /* end else */
+        } /* end else */
+    } /* end else */
 
     FUNC_LEAVE_NOAPI(n)
 } /* end H5VL_term_package() */
@@ -330,14 +330,14 @@ H5VL__get_connector_cb(void *obj, hid_t id, void *_op_data)
             op_data->found_id = id;
             ret_value         = H5_ITER_STOP;
         } /* end if */
-    }     /* end if */
+    } /* end if */
     else {
         assert(H5VL_GET_CONNECTOR_BY_VALUE == op_data->key.kind);
         if (cls->value == op_data->key.u.value) {
             op_data->found_id = id;
             ret_value         = H5_ITER_STOP;
         } /* end if */
-    }     /* end else */
+    } /* end else */
 
     FUNC_LEAVE_NOAPI(ret_value)
 } /* end H5VL__get_connector_cb() */
@@ -425,7 +425,7 @@ H5VL__set_def_conn(void)
                     0)
                     HGOTO_ERROR(H5E_VOL, H5E_CANTREGISTER, FAIL, "can't register connector");
             } /* end else */
-        }     /* end else */
+        } /* end else */
 
         /* Was there any connector info specified in the environment variable? */
         if (NULL != (tok = HDstrtok_r(NULL, "\n\r", &lasts)))
@@ -627,8 +627,8 @@ H5VL_conn_copy(H5VL_connector_prop_t *connector_prop)
                 /* Set the connector info to the copy */
                 connector_prop->connector_info = new_connector_info;
             } /* end if */
-        }     /* end if */
-    }         /* end if */
+        } /* end if */
+    } /* end if */
 
 done:
     FUNC_LEAVE_NOAPI(ret_value)
@@ -827,9 +827,14 @@ H5VL_register_using_vol_id(H5I_type_t type, void *obj, hid_t connector_id, bool 
     if (NULL == (connector = H5VL_new_connector(connector_id)))
         HGOTO_ERROR(H5E_VOL, H5E_CANTCREATE, H5I_INVALID_HID, "can't create VOL connector object");
 
+    /* Increment reference count above 0 so that connector can be closed if VOL object creation fails */
+    connector->nrefs++;
+
     /* Get an ID for the VOL object */
     if ((ret_value = H5VL_register(type, obj, connector, app_ref)) < 0)
         HGOTO_ERROR(H5E_VOL, H5E_CANTREGISTER, H5I_INVALID_HID, "unable to register object handle");
+
+    connector->nrefs--;
 
 done:
     /* Clean up on error */
@@ -982,12 +987,13 @@ H5VL_conn_dec_rc(H5VL_t *connector)
 
     /* Check arguments */
     assert(connector);
+    assert(connector->nrefs >= 0);
 
     /* Decrement refcount for connector */
     connector->nrefs--;
 
     /* Check for last reference */
-    if (0 >= connector->nrefs) {
+    if (0 == connector->nrefs) {
         if (H5I_dec_ref(connector->id) < 0)
             HGOTO_ERROR(H5E_VOL, H5E_CANTDEC, FAIL, "unable to decrement ref count on VOL connector");
         H5FL_FREE(H5VL_t, connector);

--- a/src/H5VLint.c
+++ b/src/H5VLint.c
@@ -987,7 +987,7 @@ H5VL_conn_dec_rc(H5VL_t *connector)
     connector->nrefs--;
 
     /* Check for last reference */
-    if (0 == connector->nrefs) {
+    if (0 >= connector->nrefs) {
         if (H5I_dec_ref(connector->id) < 0)
             HGOTO_ERROR(H5E_VOL, H5E_CANTDEC, FAIL, "unable to decrement ref count on VOL connector");
         H5FL_FREE(H5VL_t, connector);

--- a/src/H5VLint.c
+++ b/src/H5VLint.c
@@ -853,7 +853,7 @@ done:
     /* Clean up on error */
     if (H5I_INVALID_HID == ret_value)
         /* Release newly created connector */
-        if (connector && (H5VL_conn_dest(connector) < 0))
+        if (connector && (H5VL_conn_dec_rc(connector) < 0))
             HDONE_ERROR(H5E_VOL, H5E_CANTDEC, H5I_INVALID_HID,
                         "unable to decrement ref count on VOL connector")
 
@@ -1007,9 +1007,9 @@ H5VL_conn_dec_rc(H5VL_t *connector)
 
     /* Check for last reference */
     if (0 == connector->nrefs) {
-        if (H5VL_conn_dest(connector) < 0)
-            HGOTO_ERROR(H5E_VOL, H5E_CANTRELEASE, FAIL, "unable to release VOL connector");
-
+        if (H5I_dec_ref(connector->id) < 0)
+            HGOTO_ERROR(H5E_VOL, H5E_CANTDEC, FAIL, "unable to decrement ref count on VOL connector");
+        H5FL_FREE(H5VL_t, connector);
         /* Set return value */
         ret_value = 0;
     } /* end if */
@@ -1020,31 +1020,6 @@ H5VL_conn_dec_rc(H5VL_t *connector)
 done:
     FUNC_LEAVE_NOAPI(ret_value)
 } /* end H5VL_conn_dec_rc() */
-
-/*-------------------------------------------------------------------------
- * Function:    H5VL__conn_dest
- *
- * Purpose:     Destroys a VOL connector struct. This should be used
- *              directly when cleaning up a VOL connector with no references.
- *
- * Return:      SUCCEED/FAIL
- *
- *-------------------------------------------------------------------------
- */
-herr_t
-H5VL_conn_dest(H5VL_t *connector)
-{
-    herr_t ret_value = SUCCEED; /* Return value */
-
-    FUNC_ENTER_NOAPI(FAIL)
-
-    if (H5I_dec_ref(connector->id) < 0)
-        HGOTO_ERROR(H5E_VOL, H5E_CANTDEC, FAIL, "unable to decrement ref count on VOL connector");
-    H5FL_FREE(H5VL_t, connector);
-
-done:
-    FUNC_LEAVE_NOAPI(ret_value)
-} /* end H5VL__conn_dest() */
 
 /*-------------------------------------------------------------------------
  * Function:    H5VL_object_inc_rc

--- a/src/H5VLint.c
+++ b/src/H5VLint.c
@@ -982,7 +982,7 @@ H5VL_conn_dec_rc(H5VL_t *connector)
 
     /* Check arguments */
     assert(connector);
-    assert(connector->nrefs >= 0);
+    assert(connector->nrefs > 0);
 
     /* Decrement refcount for connector */
     connector->nrefs--;
@@ -1023,8 +1023,6 @@ H5VL_conn_dest(H5VL_t *connector)
     if (H5I_dec_ref(connector->id) < 0)
         HGOTO_ERROR(H5E_VOL, H5E_CANTDEC, FAIL, "unable to decrement ref count on VOL connector");
     H5FL_FREE(H5VL_t, connector);
-
-    connector = NULL;
 
 done:
     FUNC_LEAVE_NOAPI(ret_value)

--- a/src/H5VLprivate.h
+++ b/src/H5VLprivate.h
@@ -73,6 +73,7 @@ H5_DLL herr_t  H5VL_cmp_connector_cls(int *cmp_value, const H5VL_class_t *cls1, 
 H5_DLL herr_t  H5VL_conn_copy(H5VL_connector_prop_t *value);
 H5_DLL int64_t H5VL_conn_inc_rc(H5VL_t *connector);
 H5_DLL int64_t H5VL_conn_dec_rc(H5VL_t *connector);
+H5_DLL herr_t  H5VL_conn_dest(H5VL_t *connector);
 H5_DLL herr_t  H5VL_conn_free(const H5VL_connector_prop_t *info);
 H5_DLL herr_t  H5VL_get_cap_flags(const H5VL_connector_prop_t *prop, uint64_t *cap_flags);
 

--- a/src/H5VLprivate.h
+++ b/src/H5VLprivate.h
@@ -73,7 +73,6 @@ H5_DLL herr_t  H5VL_cmp_connector_cls(int *cmp_value, const H5VL_class_t *cls1, 
 H5_DLL herr_t  H5VL_conn_copy(H5VL_connector_prop_t *value);
 H5_DLL int64_t H5VL_conn_inc_rc(H5VL_t *connector);
 H5_DLL int64_t H5VL_conn_dec_rc(H5VL_t *connector);
-H5_DLL herr_t  H5VL_conn_dest(H5VL_t *connector);
 H5_DLL herr_t  H5VL_conn_free(const H5VL_connector_prop_t *info);
 H5_DLL herr_t  H5VL_get_cap_flags(const H5VL_connector_prop_t *prop, uint64_t *cap_flags);
 


### PR DESCRIPTION
Fix for #4634 (H5VL_t not freed properly if closed with no references).

I don't think an assertion would make sense here, since it's possible for regular internal library failures to elicit this issue.