### PR TITLE
Fix bad ref counting in async object close with empty event set

### DIFF
--- a/src/H5A.c
+++ b/src/H5A.c
@@ -2244,8 +2244,9 @@ H5Aclose_async(const char *app_file, const char *app_func, unsigned app_line, hi
             HGOTO_ERROR(H5E_ATTR, H5E_CANTINSERT, FAIL, "can't insert token into event set");
 
 done:
-    if (connector && H5VL_conn_dec_rc(connector) < 0)
-        HDONE_ERROR(H5E_ATTR, H5E_CANTDEC, FAIL, "can't decrement ref count on connector");
+    if (connector && (H5ES_NONE != es_id))
+        if (H5VL_conn_dec_rc(connector) < 0)
+            HDONE_ERROR(H5E_ATTR, H5E_CANTDEC, FAIL, "can't decrement ref count on connector");
 
     FUNC_LEAVE_API(ret_value)
 } /* H5Aclose_async() */

--- a/src/H5D.c
+++ b/src/H5D.c
@@ -531,8 +531,9 @@ H5Dclose_async(const char *app_file, const char *app_func, unsigned app_line, hi
             HGOTO_ERROR(H5E_DATASET, H5E_CANTINSERT, FAIL, "can't insert token into event set");
 
 done:
-    if (connector && H5VL_conn_dec_rc(connector) < 0)
-        HDONE_ERROR(H5E_DATASET, H5E_CANTDEC, FAIL, "can't decrement ref count on connector");
+    if (connector && (H5ES_NONE != es_id))
+        if (H5VL_conn_dec_rc(connector) < 0)
+            HDONE_ERROR(H5E_DATASET, H5E_CANTDEC, FAIL, "can't decrement ref count on connector");
 
     FUNC_LEAVE_API(ret_value)
 } /* end H5Dclose_async() */

--- a/src/H5F.c
+++ b/src/H5F.c
@@ -1104,8 +1104,9 @@ H5Fclose_async(const char *app_file, const char *app_func, unsigned app_line, hi
             HGOTO_ERROR(H5E_FILE, H5E_CANTINSERT, FAIL, "can't insert token into event set");
 
 done:
-    if (connector && H5VL_conn_dec_rc(connector) < 0)
-        HDONE_ERROR(H5E_FILE, H5E_CANTDEC, FAIL, "can't decrement ref count on connector");
+    if (connector && (H5ES_NONE != es_id))
+        if (H5VL_conn_dec_rc(connector) < 0)
+            HDONE_ERROR(H5E_FILE, H5E_CANTDEC, FAIL, "can't decrement ref count on connector");
 
     FUNC_LEAVE_API(ret_value)
 } /* end H5Fclose_async() */

--- a/src/H5G.c
+++ b/src/H5G.c
@@ -935,8 +935,9 @@ H5Gclose_async(const char *app_file, const char *app_func, unsigned app_line, hi
             HGOTO_ERROR(H5E_SYM, H5E_CANTINSERT, FAIL, "can't insert token into event set");
 
 done:
-    if (connector && H5VL_conn_dec_rc(connector) < 0)
-        HDONE_ERROR(H5E_SYM, H5E_CANTDEC, FAIL, "can't decrement ref count on connector");
+    if (connector && (H5ES_NONE != es_id))
+        if (H5VL_conn_dec_rc(connector) < 0)
+            HDONE_ERROR(H5E_SYM, H5E_CANTDEC, FAIL, "can't decrement ref count on connector");
 
     FUNC_LEAVE_API(ret_value)
 } /* end H5Gclose_async() */

--- a/src/H5M.c
+++ b/src/H5M.c
@@ -663,8 +663,9 @@ H5Mclose_async(const char *app_file, const char *app_func, unsigned app_line, hi
             HGOTO_ERROR(H5E_MAP, H5E_CANTINSERT, FAIL, "can't insert token into event set");
 
 done:
-    if (connector && H5VL_conn_dec_rc(connector) < 0)
-        HDONE_ERROR(H5E_MAP, H5E_CANTDEC, FAIL, "can't decrement ref count on connector");
+    if (connector && (H5ES_NONE != es_id))
+        if (H5VL_conn_dec_rc(connector) < 0)
+            HDONE_ERROR(H5E_MAP, H5E_CANTDEC, FAIL, "can't decrement ref count on connector");
 
     FUNC_LEAVE_API(ret_value)
 } /* end H5Mclose_async() */

--- a/src/H5O.c
+++ b/src/H5O.c
@@ -1967,8 +1967,9 @@ H5Oclose_async(const char *app_file, const char *app_func, unsigned app_line, hi
             HGOTO_ERROR(H5E_OHDR, H5E_CANTINSERT, FAIL, "can't insert token into event set");
 
 done:
-    if (connector && H5VL_conn_dec_rc(connector) < 0)
-        HDONE_ERROR(H5E_OHDR, H5E_CANTDEC, FAIL, "can't decrement ref count on connector");
+    if (connector && (H5ES_NONE != es_id))
+        if (H5VL_conn_dec_rc(connector) < 0)
+            HDONE_ERROR(H5E_OHDR, H5E_CANTDEC, FAIL, "can't decrement ref count on connector");
 
     FUNC_LEAVE_API(ret_value)
 } /* end H5Oclose_async() */

--- a/src/H5T.c
+++ b/src/H5T.c
@@ -2127,8 +2127,9 @@ H5Tclose_async(const char *app_file, const char *app_func, unsigned app_line, hi
             HGOTO_ERROR(H5E_DATATYPE, H5E_CANTINSERT, FAIL, "can't insert token into event set");
 
 done:
-    if (connector && H5VL_conn_dec_rc(connector) < 0)
-        HDONE_ERROR(H5E_DATATYPE, H5E_CANTDEC, FAIL, "can't decrement ref count on connector");
+    if (connector && (H5ES_NONE != es_id))
+        if (H5VL_conn_dec_rc(connector) < 0)
+            HDONE_ERROR(H5E_DATATYPE, H5E_CANTDEC, FAIL, "can't decrement ref count on connector");
 
     FUNC_LEAVE_API(ret_value)
 } /* end H5Tclose_async() */


### PR DESCRIPTION
If the event set is not none, the async object close functions increment the reference count of the VOL connector to prevent it from being closed if the object closure results in the entire file being closed. 

The end of the close routines always decrement the connector ref count, presumably in order to undo this earlier addition. (This decrement shouldn't correspond to the closing of the target object, since that is not guaranteed to occur if the target object has a reference count above 1.)

If these routines are invoked with an empty event set, then the earlier ref count increment never occurs and the decrement at the end of the function might result in the connector object being unexpectedly freed. 

This PR changes the decrement at the end to be controlled by the same condition that triggers the earlier increment (`H5ES_NONE != es_id`). `H5ES_insert()` shouldn't be able to take the event set from from a non-none value to a none value, so this should decrement the reference count in exactly the cases where it is incremented. 