### PR TITLE
Remove private header from h5tools

### DIFF
--- a/src/H5private.h
+++ b/src/H5private.h
@@ -182,9 +182,9 @@
  * says FALLTHROUGH to reduce warnings on compilers that don't use
  * attributes but do respect fall-through comments.
  *
- * H5_ATTR_CONST is redefined in tools/h5repack/dynlib_rpk.c to quiet
- * gcc warnings (it has to use the public API and can't include this
- * file). Be sure to update that file if the #ifdefs change here.
+ * H5_ATTR_FORMAT and H5_ATTR_UNUSED are redefined in tools/lib/h5tools.h to
+ * avoid using this private header file there. Please be sure to update that
+ * file if the #ifdefs change here.
  */
 /* clang-format off */
 #if defined(H5_HAVE_ATTRIBUTE) && !defined(__SUNPRO_C)

--- a/tools/lib/h5tools.h
+++ b/tools/lib/h5tools.h
@@ -22,8 +22,8 @@
 #define H5_ATTR_FORMAT(X, Y, Z) __attribute__((format(X, Y, Z)))
 #define H5_ATTR_UNUSED          __attribute__((unused))
 #else
-#   define H5_ATTR_FORMAT(X, Y, Z) /*void*/
-#   define H5_ATTR_UNUSED          /*void*/
+#define H5_ATTR_FORMAT(X, Y, Z) /*void*/
+#define H5_ATTR_UNUSED          /*void*/
 #endif
 
 #include "h5tools_error.h"

--- a/tools/lib/h5tools.h
+++ b/tools/lib/h5tools.h
@@ -17,6 +17,12 @@
 #define H5TOOLS_H
 
 #include "hdf5.h"
+
+#if defined(H5_HAVE_ATTRIBUTE) && !defined(__SUNPRO_C)
+#   define H5_ATTR_FORMAT(X, Y, Z) __attribute__((format(X, Y, Z)))
+#   define H5_ATTR_UNUSED          __attribute__((unused))
+#endif
+
 #include "h5tools_error.h"
 
 #define ESCAPE_HTML         1

--- a/tools/lib/h5tools.h
+++ b/tools/lib/h5tools.h
@@ -21,6 +21,9 @@
 #if defined(H5_HAVE_ATTRIBUTE) && !defined(__SUNPRO_C)
 #define H5_ATTR_FORMAT(X, Y, Z) __attribute__((format(X, Y, Z)))
 #define H5_ATTR_UNUSED          __attribute__((unused))
+#else
+#   define H5_ATTR_FORMAT(X, Y, Z) /*void*/
+#   define H5_ATTR_UNUSED          /*void*/
 #endif
 
 #include "h5tools_error.h"

--- a/tools/lib/h5tools.h
+++ b/tools/lib/h5tools.h
@@ -19,8 +19,8 @@
 #include "hdf5.h"
 
 #if defined(H5_HAVE_ATTRIBUTE) && !defined(__SUNPRO_C)
-#   define H5_ATTR_FORMAT(X, Y, Z) __attribute__((format(X, Y, Z)))
-#   define H5_ATTR_UNUSED          __attribute__((unused))
+#define H5_ATTR_FORMAT(X, Y, Z) __attribute__((format(X, Y, Z)))
+#define H5_ATTR_UNUSED          __attribute__((unused))
 #endif
 
 #include "h5tools_error.h"

--- a/tools/lib/h5tools_error.h
+++ b/tools/lib/h5tools_error.h
@@ -17,7 +17,6 @@
 #define H5TOOLS_ERROR_H
 
 #include "H5Epublic.h"
-#include "H5Eprivate.h" /* Error handling       */
 
 /* tools-HDF5 Error variables */
 H5TOOLS_DLLVAR int   H5tools_INDENT_g;


### PR DESCRIPTION
This will allow the C++ tests (PR https://github.com/HDFGroup/hdf5/pull/4629) and other tools/tests to use the h5tools library without involving private header files.

(Issue #4643)