### PR TITLE
Make VOL CI run against current branch

### DIFF
--- a/.github/workflows/vol_adios2.yml
+++ b/.github/workflows/vol_adios2.yml
@@ -28,7 +28,6 @@ jobs:
       - name: Checkout HDF5
         uses: actions/checkout@v4.1.7
         with:
-          repository: HDFGroup/hdf5
           path: hdf5
 
       - name: Configure HDF5

--- a/.github/workflows/vol_async.yml
+++ b/.github/workflows/vol_async.yml
@@ -24,7 +24,6 @@ jobs:
       - name: Checkout HDF5
         uses: actions/checkout@v4.1.7
         with:
-          repository: HDFGroup/hdf5
           path: hdf5
 
       - name: Checkout Argobots

--- a/.github/workflows/vol_cache.yml
+++ b/.github/workflows/vol_cache.yml
@@ -37,7 +37,6 @@ jobs:
       - name: Checkout HDF5
         uses: actions/checkout@v4.1.7
         with:
-          repository: HDFGroup/hdf5
           path: hdf5
 
       - name: Checkout Argobots

--- a/.github/workflows/vol_ext_passthru.yml
+++ b/.github/workflows/vol_ext_passthru.yml
@@ -24,7 +24,6 @@ jobs:
       - name: Checkout HDF5
         uses: actions/checkout@v4.1.7
         with:
-          repository: HDFGroup/hdf5
           path: hdf5
 
       - name: Checkout vol-external-passthrough

--- a/.github/workflows/vol_log.yml
+++ b/.github/workflows/vol_log.yml
@@ -25,7 +25,6 @@ jobs:
       - name: Checkout HDF5
         uses: actions/checkout@v4.1.7
         with:
-          repository: HDFGroup/hdf5
           path: hdf5
 
       # Log-based VOL currently doesn't have CMake support

--- a/.github/workflows/vol_rest.yml
+++ b/.github/workflows/vol_rest.yml
@@ -44,7 +44,6 @@ jobs:
       - name: Checkout HDF5
         uses: actions/checkout@v4.1.7
         with:
-          repository: HDFGroup/hdf5
           path: hdf5
 
       - name: Configure HDF5 with REST VOL connector

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1202,12 +1202,8 @@ endif ()
 # Assuming they don't
 foreach (libs ${LINK_COMP_LIBS})
 #  set (_PKG_CONFIG_REQUIRES_PRIVATE "${_PKG_CONFIG_REQUIRES_PRIVATE} -l${libs}")
-if(TARGET ${libs})
   get_target_property (libname ${libs} OUTPUT_NAME)
   set (_PKG_CONFIG_LIBS_PRIVATE "${_PKG_CONFIG_LIBS_PRIVATE} -l${libname}")
-else ()
-    set (_PKG_CONFIG_LIBS_PRIVATE "${_PKG_CONFIG_LIBS_PRIVATE} -l${libs}")
-endif ()
 endforeach ()
 
 #if (BUILD_STATIC_LIBS)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1202,8 +1202,12 @@ endif ()
 # Assuming they don't
 foreach (libs ${LINK_COMP_LIBS})
 #  set (_PKG_CONFIG_REQUIRES_PRIVATE "${_PKG_CONFIG_REQUIRES_PRIVATE} -l${libs}")
+if(TARGET ${libs})
   get_target_property (libname ${libs} OUTPUT_NAME)
   set (_PKG_CONFIG_LIBS_PRIVATE "${_PKG_CONFIG_LIBS_PRIVATE} -l${libname}")
+else ()
+    set (_PKG_CONFIG_LIBS_PRIVATE "${_PKG_CONFIG_LIBS_PRIVATE} -l${libs}")
+endif ()
 endforeach ()
 
 #if (BUILD_STATIC_LIBS)


### PR DESCRIPTION

This PR also changes the VOL CI to be run against the current HDF branch instead of HDFGroup/develop so that other repos can detect if their changes break CI. This shouldn't change anything about the daily VOL connector CI, since that is run on develop anyway. 
