### PR TITLE
Warning fix

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -13,7 +13,7 @@
 ## ----------------------------------------------------------------------
 ## Initialize configure.
 ##
-AC_PREREQ([2.69])
+AC_PREREQ([2.71])
 
 ## AC_INIT takes the name of the package, the version number, and an
 ## email address to report bugs. AC_CONFIG_SRCDIR takes a unique file

--- a/configure.ac
+++ b/configure.ac
@@ -13,7 +13,7 @@
 ## ----------------------------------------------------------------------
 ## Initialize configure.
 ##
-AC_PREREQ([2.71])
+AC_PREREQ([2.69])
 
 ## AC_INIT takes the name of the package, the version number, and an
 ## email address to report bugs. AC_CONFIG_SRCDIR takes a unique file

--- a/tools/lib/h5diff.c
+++ b/tools/lib/h5diff.c
@@ -1746,7 +1746,7 @@ handle_worker_request(char *worker_tasks, int *n_busy_tasks, diff_opt_t *opts, h
     MPI_Status         status;
     int                task_idx  = 0;
     int                source    = 0;
-    herr_t             ret_value = H5DIFF_NO_ERR;
+    diff_err_t         ret_value = H5DIFF_NO_ERR;
 
     /* Must have at least one busy worker task */
     assert(*n_busy_tasks > 0);


### PR DESCRIPTION
fixes: implicit conversion changes signedness: 'herr_t' (aka 'int') to 'diff_err_t' [-Wsign-conversion]
