### PR TITLE
Fix `HDopen macro redefined` warnings

### DIFF
--- a/tools/src/h5perf/pio_engine.c
+++ b/tools/src/h5perf/pio_engine.c
@@ -72,12 +72,6 @@
     } while (0)
 
 /* POSIX I/O macros */
-#ifdef H5_HAVE_WIN32_API
-/* Can't link against the library, so this test will use the older, non-Unicode
- * _open() call on Windows.
- */
-#define HDopen(S, F, ...) _open(S, F | _O_BINARY, __VA_ARGS__)
-#endif /* H5_HAVE_WIN32_API */
 #define POSIXCREATE(fn)     HDopen(fn, O_CREAT | O_TRUNC | O_RDWR, 0600)
 #define POSIXOPEN(fn, F)    HDopen(fn, F, 0600)
 #define POSIXCLOSE(F)       HDclose(F)

--- a/tools/src/h5perf/sio_engine.c
+++ b/tools/src/h5perf/sio_engine.c
@@ -53,12 +53,6 @@
     } while (0)
 
 /* POSIX I/O macros */
-#ifdef H5_HAVE_WIN32_API
-/* Can't link against the library, so this test will use the older, non-Unicode
- * _open() call on Windows.
- */
-#define HDopen(S, F, ...) _open(S, F | _O_BINARY, __VA_ARGS__)
-#endif /* H5_HAVE_WIN32_API */
 #define POSIXCREATE(fn)     HDopen(fn, O_CREAT | O_TRUNC | O_RDWR, 0600)
 #define POSIXOPEN(fn, F)    HDopen(fn, F, 0600)
 #define POSIXCLOSE(F)       HDclose(F)


### PR DESCRIPTION
This PR will remove the following warnings on Windows+ oneAPI 24.2:
```
D:\a\actions\actions\hdf5\tools\src\h5perf\sio_engine.c(60,9): warning: 'HDopen' macro redefined [-Wmacro-redefined]
D:\a\actions\actions\hdf5\tools\src\h5perf\pio_engine.c(79,9): warning: 'HDopen' macro redefined [-Wmacro-redefined]
```