### PR TITLE
Check if DECIMAL_DIG is defined during CMake configuration

### DIFF
--- a/config/cmake/ConfigureChecks.cmake
+++ b/config/cmake/ConfigureChecks.cmake
@@ -745,7 +745,11 @@ if (HDF5_BUILD_FORTRAN)
 #else\n\
 #  define C_FLT128_DIG 0\n\
 #endif\n\
-#define C_LDBL_DIG DECIMAL_DIG\n\
+#ifdef DECIMAL_DIG\n\
+#  define C_LDBL_DIG DECIMAL_DIG\n\
+#else\n\
+#  define C_LDBL_DIG 0\n\
+#endif\n\
 \n\
 int main(void) {\nprintf(\"\\%d\\\;\\%d\\\;\", C_LDBL_DIG, C_FLT128_DIG)\\\;\n\nreturn 0\\\;\n}\n
         "


### PR DESCRIPTION
This PR will fix the following error on Echidna:

```
 CMake Error at config/cmake/ConfigureChecks.cmake:729 (message):
  Compilation of C maximum decimal precision for C - Failed
Call Stack (most recent call first):
  config/cmake/ConfigureChecks.cmake:754 (C_RUN)
  CMakeLists.txt:496 (include)
```