### PR TITLE
Replace non-VOL calls with VOL calls - part 2

### DIFF
--- a/src/H5F.c
+++ b/src/H5F.c
@@ -118,7 +118,7 @@ H5Fget_create_plist(hid_t file_id)
     FUNC_ENTER_API(H5I_INVALID_HID)
 
     /* check args */
-    if (NULL == (vol_obj = (H5VL_object_t *)H5I_object_verify(file_id, H5I_FILE)))
+    if (NULL == (vol_obj = H5VL_vol_object_verify(file_id, H5I_FILE)))
         HGOTO_ERROR(H5E_ARGS, H5E_BADTYPE, H5I_INVALID_HID, "invalid file identifier");
 
     /* Set up VOL callback arguments */
@@ -164,7 +164,7 @@ H5Fget_access_plist(hid_t file_id)
     FUNC_ENTER_API(H5I_INVALID_HID)
 
     /* Check args */
-    if (NULL == (vol_obj = (H5VL_object_t *)H5I_object_verify(file_id, H5I_FILE)))
+    if (NULL == (vol_obj = H5VL_vol_object_verify(file_id, H5I_FILE)))
         HGOTO_ERROR(H5E_ARGS, H5E_BADTYPE, H5I_INVALID_HID, "invalid file identifier");
 
     /* Set up VOL callback arguments */
@@ -239,7 +239,7 @@ H5Fget_obj_count(hid_t file_id, unsigned types)
         H5VL_file_get_args_t vol_cb_args; /* Arguments to VOL callback */
 
         /* Get the file object */
-        if (NULL == (vol_obj = (H5VL_object_t *)H5I_object_verify(file_id, H5I_FILE)))
+        if (NULL == (vol_obj = H5VL_vol_object_verify(file_id, H5I_FILE)))
             HGOTO_ERROR(H5E_ARGS, H5E_BADTYPE, (-1), "not a file id");
 
         /* Set up VOL callback arguments */
@@ -358,7 +358,7 @@ H5Fget_obj_ids(hid_t file_id, unsigned types, size_t max_objs, hid_t *oid_list /
         H5VL_file_get_args_t vol_cb_args; /* Arguments to VOL callback */
 
         /* get the file object */
-        if (NULL == (vol_obj = (H5VL_object_t *)H5I_object_verify(file_id, H5I_FILE)))
+        if (NULL == (vol_obj = H5VL_vol_object_verify(file_id, H5I_FILE)))
             HGOTO_ERROR(H5E_ARGS, H5E_BADTYPE, (-1), "invalid file identifier");
 
         /* Set up VOL callback arguments */
@@ -439,7 +439,7 @@ H5Fget_vfd_handle(hid_t file_id, hid_t fapl_id, void **file_handle /*out*/)
         HGOTO_ERROR(H5E_ARGS, H5E_BADVALUE, FAIL, "invalid file handle pointer");
 
     /* Get the file object */
-    if (NULL == (vol_obj = (H5VL_object_t *)H5I_object_verify(file_id, H5I_FILE)))
+    if (NULL == (vol_obj = H5VL_vol_object_verify(file_id, H5I_FILE)))
         HGOTO_ERROR(H5E_ARGS, H5E_BADTYPE, FAIL, "invalid file identifier");
 
     /* Set up VOL callback arguments */
@@ -1226,7 +1226,7 @@ H5Fmount(hid_t loc_id, const char *name, hid_t child_id, hid_t plist_id)
         H5VL_loc_params_t loc_params; /* Location parameters for object access */
 
         /* Get the location object */
-        if (NULL == (vol_obj = (H5VL_object_t *)H5VL_vol_object(loc_id)))
+        if (NULL == (vol_obj = H5VL_vol_object(loc_id)))
             HGOTO_ERROR(H5E_ARGS, H5E_BADTYPE, FAIL, "invalid location identifier");
 
         /* Set location parameters */
@@ -1244,12 +1244,12 @@ H5Fmount(hid_t loc_id, const char *name, hid_t child_id, hid_t plist_id)
     } /* end if */
     else {
         assert(H5I_GROUP == loc_type);
-        if (NULL == (loc_vol_obj = (H5VL_object_t *)H5I_object(loc_id)))
+        if (NULL == (loc_vol_obj = H5VL_vol_object(loc_id)))
             HGOTO_ERROR(H5E_ARGS, H5E_BADTYPE, FAIL, "could not get location object");
     } /* end else */
 
     /* Get the child object */
-    if (NULL == (child_vol_obj = (H5VL_object_t *)H5I_object(child_id)))
+    if (NULL == (child_vol_obj = H5VL_vol_object(child_id)))
         HGOTO_ERROR(H5E_ARGS, H5E_BADTYPE, FAIL, "could not get child object");
 
     /* Check if both objects are associated with the same VOL connector */
@@ -1336,7 +1336,7 @@ H5Funmount(hid_t loc_id, const char *name)
         H5VL_loc_params_t loc_params; /* Location parameters for object access */
 
         /* Get the location object */
-        if (NULL == (vol_obj = (H5VL_object_t *)H5VL_vol_object(loc_id)))
+        if (NULL == (vol_obj = H5VL_vol_object(loc_id)))
             HGOTO_ERROR(H5E_ARGS, H5E_BADTYPE, FAIL, "invalid location identifier");
 
         /* Set location parameters */
@@ -1354,7 +1354,7 @@ H5Funmount(hid_t loc_id, const char *name)
     } /* end if */
     else {
         assert(H5I_GROUP == loc_type);
-        if (NULL == (loc_vol_obj = (H5VL_object_t *)H5I_object(loc_id)))
+        if (NULL == (loc_vol_obj = H5VL_vol_object(loc_id)))
             HGOTO_ERROR(H5E_ARGS, H5E_BADTYPE, FAIL, "could not get location object");
     } /* end else */
 
@@ -1404,7 +1404,7 @@ H5F__reopen_api_common(hid_t file_id, void **token_ptr)
     FUNC_ENTER_PACKAGE
 
     /* Get the file object */
-    if (NULL == (vol_obj = (H5VL_object_t *)H5I_object_verify(file_id, H5I_FILE)))
+    if (NULL == (vol_obj = H5VL_vol_object_verify(file_id, H5I_FILE)))
         HGOTO_ERROR(H5E_ARGS, H5E_BADTYPE, H5I_INVALID_HID, "invalid file identifier");
 
     /* Set up VOL callback arguments */
@@ -1555,7 +1555,7 @@ H5Fget_intent(hid_t file_id, unsigned *intent_flags /*out*/)
         H5VL_file_get_args_t vol_cb_args; /* Arguments to VOL callback */
 
         /* Get the internal file structure */
-        if (NULL == (vol_obj = (H5VL_object_t *)H5I_object_verify(file_id, H5I_FILE)))
+        if (NULL == (vol_obj = H5VL_vol_object_verify(file_id, H5I_FILE)))
             HGOTO_ERROR(H5E_ARGS, H5E_BADTYPE, FAIL, "invalid file identifier");
 
         /* Set up VOL callback arguments */
@@ -1594,7 +1594,7 @@ H5Fget_fileno(hid_t file_id, unsigned long *fnumber /*out*/)
         H5VL_file_get_args_t vol_cb_args; /* Arguments to VOL callback */
 
         /* Get the internal file structure */
-        if (NULL == (vol_obj = (H5VL_object_t *)H5I_object_verify(file_id, H5I_FILE)))
+        if (NULL == (vol_obj = H5VL_vol_object_verify(file_id, H5I_FILE)))
             HGOTO_ERROR(H5E_ARGS, H5E_BADTYPE, FAIL, "invalid file identifier");
 
         /* Set up VOL callback arguments */
@@ -1631,7 +1631,7 @@ H5Fget_freespace(hid_t file_id)
     FUNC_ENTER_API((-1))
 
     /* Get the file object */
-    if (NULL == (vol_obj = (H5VL_object_t *)H5I_object_verify(file_id, H5I_FILE)))
+    if (NULL == (vol_obj = H5VL_vol_object_verify(file_id, H5I_FILE)))
         HGOTO_ERROR(H5E_ARGS, H5E_BADTYPE, (-1), "invalid file identifier");
 
     /* Set up VOL callback arguments */
@@ -1674,7 +1674,7 @@ H5Fget_filesize(hid_t file_id, hsize_t *size /*out*/)
     /* Check args */
     if (!size)
         HGOTO_ERROR(H5E_ARGS, H5E_BADVALUE, FAIL, "size parameter cannot be NULL");
-    if (NULL == (vol_obj = (H5VL_object_t *)H5I_object_verify(file_id, H5I_FILE)))
+    if (NULL == (vol_obj = H5VL_vol_object_verify(file_id, H5I_FILE)))
         HGOTO_ERROR(H5E_ARGS, H5E_BADVALUE, FAIL, "not a file ID");
 
     /* Set up VOL callback arguments */
@@ -1739,7 +1739,7 @@ H5Fget_file_image(hid_t file_id, void *buf /*out*/, size_t buf_len)
     FUNC_ENTER_API((-1))
 
     /* Check args */
-    if (NULL == (vol_obj = (H5VL_object_t *)H5I_object_verify(file_id, H5I_FILE)))
+    if (NULL == (vol_obj = H5VL_vol_object_verify(file_id, H5I_FILE)))
         HGOTO_ERROR(H5E_ARGS, H5E_BADVALUE, (-1), "not a file ID");
 
     /* Set up VOL callback arguments */
@@ -1789,7 +1789,7 @@ H5Fget_mdc_config(hid_t file_id, H5AC_cache_config_t *config /*out*/)
         HGOTO_ERROR(H5E_ARGS, H5E_BADVALUE, FAIL, "Bad config ptr");
 
     /* Get the file object */
-    if (NULL == (vol_obj = (H5VL_object_t *)H5I_object_verify(file_id, H5I_FILE)))
+    if (NULL == (vol_obj = H5VL_vol_object_verify(file_id, H5I_FILE)))
         HGOTO_ERROR(H5E_ARGS, H5E_BADTYPE, FAIL, "invalid file identifier");
 
     /* Set up VOL callback arguments */
@@ -1827,7 +1827,7 @@ H5Fset_mdc_config(hid_t file_id, const H5AC_cache_config_t *config_ptr)
     FUNC_ENTER_API(FAIL)
 
     /* Get the file object */
-    if (NULL == (vol_obj = (H5VL_object_t *)H5I_object_verify(file_id, H5I_FILE)))
+    if (NULL == (vol_obj = H5VL_vol_object_verify(file_id, H5I_FILE)))
         HGOTO_ERROR(H5E_ARGS, H5E_BADTYPE, FAIL, "invalid file identifier");
 
     /* Set up VOL callback arguments */
@@ -1868,7 +1868,7 @@ H5Fget_mdc_hit_rate(hid_t file_id, double *hit_rate /*out*/)
     /* Check args */
     if (NULL == hit_rate)
         HGOTO_ERROR(H5E_ARGS, H5E_BADVALUE, FAIL, "NULL hit rate pointer");
-    if (NULL == (vol_obj = (H5VL_object_t *)H5I_object_verify(file_id, H5I_FILE)))
+    if (NULL == (vol_obj = H5VL_vol_object_verify(file_id, H5I_FILE)))
         HGOTO_ERROR(H5E_ARGS, H5E_BADVALUE, FAIL, "not a file ID");
 
     /* Set up VOL callback arguments */
@@ -1910,7 +1910,7 @@ H5Fget_mdc_size(hid_t file_id, size_t *max_size /*out*/, size_t *min_clean_size 
     FUNC_ENTER_API(FAIL)
 
     /* Check args */
-    if (NULL == (vol_obj = (H5VL_object_t *)H5I_object_verify(file_id, H5I_FILE)))
+    if (NULL == (vol_obj = H5VL_vol_object_verify(file_id, H5I_FILE)))
         HGOTO_ERROR(H5E_ARGS, H5E_BADVALUE, FAIL, "not a file ID");
 
     /* Set up VOL callback arguments */
@@ -1959,7 +1959,7 @@ H5Freset_mdc_hit_rate_stats(hid_t file_id)
     FUNC_ENTER_API(FAIL)
 
     /* Get the file object */
-    if (NULL == (vol_obj = (H5VL_object_t *)H5I_object_verify(file_id, H5I_FILE)))
+    if (NULL == (vol_obj = H5VL_vol_object_verify(file_id, H5I_FILE)))
         HGOTO_ERROR(H5E_ARGS, H5E_BADTYPE, FAIL, "invalid file identifier");
 
     /* Set up VOL callback arguments */
@@ -2109,7 +2109,7 @@ H5Fget_metadata_read_retry_info(hid_t file_id, H5F_retry_info_t *info /*out*/)
         HGOTO_ERROR(H5E_ARGS, H5E_BADVALUE, FAIL, "no info struct");
 
     /* Get the file pointer */
-    if (NULL == (vol_obj = (H5VL_object_t *)H5I_object_verify(file_id, H5I_FILE)))
+    if (NULL == (vol_obj = H5VL_vol_object_verify(file_id, H5I_FILE)))
         HGOTO_ERROR(H5E_ARGS, H5E_BADVALUE, FAIL, "not a file ID");
 
     /* Set up VOL callback arguments */
@@ -2149,7 +2149,7 @@ H5Fget_free_sections(hid_t file_id, H5F_mem_t type, size_t nsects, H5F_sect_info
     FUNC_ENTER_API((-1))
 
     /* Check args */
-    if (NULL == (vol_obj = (H5VL_object_t *)H5I_object_verify(file_id, H5I_FILE)))
+    if (NULL == (vol_obj = H5VL_vol_object_verify(file_id, H5I_FILE)))
         HGOTO_ERROR(H5E_ARGS, H5E_BADTYPE, (-1), "invalid file identifier");
     if (sect_info && nsects == 0)
         HGOTO_ERROR(H5E_ARGS, H5E_BADVALUE, (-1), "nsects must be > 0");
@@ -2194,7 +2194,7 @@ H5Fclear_elink_file_cache(hid_t file_id)
     FUNC_ENTER_API(FAIL)
 
     /* Check args */
-    if (NULL == (vol_obj = (H5VL_object_t *)H5I_object_verify(file_id, H5I_FILE)))
+    if (NULL == (vol_obj = H5VL_vol_object_verify(file_id, H5I_FILE)))
         HGOTO_ERROR(H5E_ARGS, H5E_BADVALUE, FAIL, "not a file ID");
 
     /* Set up VOL callback arguments */
@@ -2253,7 +2253,7 @@ H5Fstart_swmr_write(hid_t file_id)
     FUNC_ENTER_API(FAIL)
 
     /* Check args */
-    if (NULL == (vol_obj = (H5VL_object_t *)H5I_object_verify(file_id, H5I_FILE)))
+    if (NULL == (vol_obj = H5VL_vol_object_verify(file_id, H5I_FILE)))
         HGOTO_ERROR(H5E_ARGS, H5E_BADTYPE, FAIL, "hid_t identifier is not a file ID");
 
     /* Set up collective metadata if appropriate */
@@ -2292,7 +2292,7 @@ H5Fstart_mdc_logging(hid_t file_id)
     FUNC_ENTER_API(FAIL)
 
     /* Sanity check */
-    if (NULL == (vol_obj = (H5VL_object_t *)H5I_object_verify(file_id, H5I_FILE)))
+    if (NULL == (vol_obj = H5VL_vol_object_verify(file_id, H5I_FILE)))
         HGOTO_ERROR(H5E_ARGS, H5E_BADTYPE, FAIL, "hid_t identifier is not a file ID");
 
     /* Set up VOL callback arguments */
@@ -2328,7 +2328,7 @@ H5Fstop_mdc_logging(hid_t file_id)
     FUNC_ENTER_API(FAIL)
 
     /* Sanity check */
-    if (NULL == (vol_obj = (H5VL_object_t *)H5I_object_verify(file_id, H5I_FILE)))
+    if (NULL == (vol_obj = H5VL_vol_object_verify(file_id, H5I_FILE)))
         HGOTO_ERROR(H5E_ARGS, H5E_BADTYPE, FAIL, "hid_t identifier is not a file ID");
 
     /* Set up VOL callback arguments */
@@ -2365,7 +2365,7 @@ H5Fget_mdc_logging_status(hid_t file_id, hbool_t *is_enabled /*out*/, hbool_t *i
     FUNC_ENTER_API(FAIL)
 
     /* Sanity check */
-    if (NULL == (vol_obj = (H5VL_object_t *)H5I_object_verify(file_id, H5I_FILE)))
+    if (NULL == (vol_obj = H5VL_vol_object_verify(file_id, H5I_FILE)))
         HGOTO_ERROR(H5E_ARGS, H5E_BADTYPE, FAIL, "hid_t identifier is not a file ID");
 
     /* Set up VOL callback arguments */
@@ -2405,7 +2405,7 @@ H5Fset_libver_bounds(hid_t file_id, H5F_libver_t low, H5F_libver_t high)
     FUNC_ENTER_API(FAIL)
 
     /* Check args */
-    if (NULL == (vol_obj = (H5VL_object_t *)H5I_object_verify(file_id, H5I_FILE)))
+    if (NULL == (vol_obj = H5VL_vol_object_verify(file_id, H5I_FILE)))
         HGOTO_ERROR(H5E_FILE, H5E_BADVALUE, FAIL, "not a file ID");
 
     /* Set up collective metadata if appropriate */
@@ -2447,7 +2447,7 @@ H5Fformat_convert(hid_t file_id)
     FUNC_ENTER_API(FAIL)
 
     /* Check args */
-    if (NULL == (vol_obj = (H5VL_object_t *)H5I_object_verify(file_id, H5I_FILE)))
+    if (NULL == (vol_obj = H5VL_vol_object_verify(file_id, H5I_FILE)))
         HGOTO_ERROR(H5E_ARGS, H5E_BADTYPE, FAIL, "file_id parameter is not a valid file identifier");
 
     /* Set up collective metadata if appropriate */
@@ -2485,7 +2485,7 @@ H5Freset_page_buffering_stats(hid_t file_id)
     FUNC_ENTER_API(FAIL)
 
     /* Check args */
-    if (NULL == (vol_obj = (H5VL_object_t *)H5I_object_verify(file_id, H5I_FILE)))
+    if (NULL == (vol_obj = H5VL_vol_object_verify(file_id, H5I_FILE)))
         HGOTO_ERROR(H5E_ARGS, H5E_BADTYPE, FAIL, "invalid file identifier");
 
     /* Set up VOL callback arguments */
@@ -2522,7 +2522,7 @@ H5Fget_page_buffering_stats(hid_t file_id, unsigned accesses[2] /*out*/, unsigne
     FUNC_ENTER_API(FAIL)
 
     /* Check args */
-    if (NULL == (vol_obj = (H5VL_object_t *)H5I_object_verify(file_id, H5I_FILE)))
+    if (NULL == (vol_obj = H5VL_vol_object_verify(file_id, H5I_FILE)))
         HGOTO_ERROR(H5E_ARGS, H5E_BADVALUE, FAIL, "not a file ID");
     if (NULL == accesses || NULL == hits || NULL == misses || NULL == evictions || NULL == bypasses)
         HGOTO_ERROR(H5E_ARGS, H5E_BADVALUE, FAIL, "NULL input parameters for stats");
@@ -2568,7 +2568,7 @@ H5Fget_mdc_image_info(hid_t file_id, haddr_t *image_addr /*out*/, hsize_t *image
     FUNC_ENTER_API(FAIL)
 
     /* Check args */
-    if (NULL == (vol_obj = (H5VL_object_t *)H5I_object_verify(file_id, H5I_FILE)))
+    if (NULL == (vol_obj = H5VL_vol_object_verify(file_id, H5I_FILE)))
         HGOTO_ERROR(H5E_ARGS, H5E_BADTYPE, FAIL, "hid_t identifier is not a file ID");
 
     /* Set up VOL callback arguments */
@@ -2605,7 +2605,7 @@ H5Fget_eoa(hid_t file_id, haddr_t *eoa /*out*/)
     FUNC_ENTER_API(FAIL)
 
     /* Check args */
-    if (NULL == (vol_obj = (H5VL_object_t *)H5I_object_verify(file_id, H5I_FILE)))
+    if (NULL == (vol_obj = H5VL_vol_object_verify(file_id, H5I_FILE)))
         HGOTO_ERROR(H5E_ARGS, H5E_BADTYPE, FAIL, "hid_t identifier is not a file ID");
 
     /* Only do work if valid pointer to fill in */
@@ -2647,7 +2647,7 @@ H5Fincrement_filesize(hid_t file_id, hsize_t increment)
     FUNC_ENTER_API(FAIL)
 
     /* Check args */
-    if (NULL == (vol_obj = (H5VL_object_t *)H5I_object_verify(file_id, H5I_FILE)))
+    if (NULL == (vol_obj = H5VL_vol_object_verify(file_id, H5I_FILE)))
         HGOTO_ERROR(H5E_ARGS, H5E_BADTYPE, FAIL, "hid_t identifier is not a file ID");
 
     /* Set up VOL callback arguments */
@@ -2686,7 +2686,7 @@ H5Fget_dset_no_attrs_hint(hid_t file_id, hbool_t *minimize /*out*/)
     /* Check args */
     if (NULL == minimize)
         HGOTO_ERROR(H5E_ARGS, H5E_BADVALUE, FAIL, "out pointer 'minimize' cannot be NULL");
-    if (NULL == (vol_obj = (H5VL_object_t *)H5I_object_verify(file_id, H5I_FILE)))
+    if (NULL == (vol_obj = H5VL_vol_object_verify(file_id, H5I_FILE)))
         HGOTO_ERROR(H5E_ARGS, H5E_BADTYPE, FAIL, "invalid file identifier");
 
     /* Set up VOL callback arguments */
@@ -2723,7 +2723,7 @@ H5Fset_dset_no_attrs_hint(hid_t file_id, hbool_t minimize)
     FUNC_ENTER_API(FAIL)
 
     /* Check args */
-    if (NULL == (vol_obj = (H5VL_object_t *)H5I_object_verify(file_id, H5I_FILE)))
+    if (NULL == (vol_obj = H5VL_vol_object_verify(file_id, H5I_FILE)))
         HGOTO_ERROR(H5E_ARGS, H5E_BADTYPE, FAIL, "invalid file identifier");
 
     /* Set up VOL callback arguments */

--- a/src/H5Fdeprec.c
+++ b/src/H5Fdeprec.c
@@ -214,7 +214,7 @@ H5Fset_latest_format(hid_t file_id, hbool_t latest_format)
     FUNC_ENTER_API(FAIL)
 
     /* Check args */
-    if (NULL == (vol_obj = (H5VL_object_t *)H5I_object_verify(file_id, H5I_FILE)))
+    if (NULL == (vol_obj = H5VL_vol_object_verify(file_id, H5I_FILE)))
         HGOTO_ERROR(H5E_FILE, H5E_BADVALUE, FAIL, "not a file ID");
 
     /* Set up collective metadata if appropriate */

--- a/src/H5Fpublic.h
+++ b/src/H5Fpublic.h
@@ -874,7 +874,7 @@ H5_DLL herr_t H5Fget_vfd_handle(hid_t file_id, hid_t fapl, void **file_handle);
  *
  * \brief Mounts an HDF5 file
  *
- * \loc_id{loc}
+ * \fg_loc_id{loc_id}
  * \param[in] name Name of the group onto which the file specified by \p child
  *                 is to be mounted
  * \file_id{child}
@@ -898,13 +898,13 @@ H5_DLL herr_t H5Fget_vfd_handle(hid_t file_id, hid_t fapl, void **file_handle);
  * \since 1.0.0
  *
  */
-H5_DLL herr_t H5Fmount(hid_t loc, const char *name, hid_t child, hid_t plist);
+H5_DLL herr_t H5Fmount(hid_t loc_id, const char *name, hid_t child, hid_t plist);
 /**
  * \ingroup H5F
  *
- * \brief Unounts an HDF5 file
+ * \brief Un-mounts an HDF5 file
  *
- * \loc_id{loc}
+ * \fg_loc_id{loc_id}
  * \param[in] name Name of the mount point
  *
  * \return \herr_t
@@ -922,7 +922,7 @@ H5_DLL herr_t H5Fmount(hid_t loc, const char *name, hid_t child, hid_t plist);
  * \since 1.0.0
  *
  */
-H5_DLL herr_t H5Funmount(hid_t loc, const char *name);
+H5_DLL herr_t H5Funmount(hid_t loc_id, const char *name);
 /**
  * \ingroup H5F
  *

--- a/test/mount.c
+++ b/test/mount.c
@@ -164,6 +164,7 @@ test_illegal(hid_t fapl)
 {
     hid_t file1 = H5I_INVALID_HID, file1b = H5I_INVALID_HID, file2 = H5I_INVALID_HID, file3 = H5I_INVALID_HID,
           file3b = H5I_INVALID_HID, mnt = H5I_INVALID_HID;
+    hid_t dtype = H5I_INVALID_HID;  /* To test invalid ID */
     char   filename1[1024], filename2[1024], filename3[1024];
     herr_t status;
 
@@ -258,6 +259,30 @@ test_illegal(hid_t fapl)
     } /* end if */
     if (H5Funmount(file1, "/mnt1") < 0)
         FAIL_STACK_ERROR;
+
+    /* Try passing in IDs that are not a file or group ID */
+    if ((dtype = H5Tcopy(H5T_C_S1)) < 0)
+        FAIL_STACK_ERROR;
+    H5E_BEGIN_TRY
+    {
+        status = H5Fmount(dtype, "/mnt1", file1b, H5P_DEFAULT);
+    }
+    H5E_END_TRY
+    if (status >= 0) {
+        H5_FAILED();
+        puts("    Passing in an ID other than file or group ID should have failed.");
+        TEST_ERROR;
+    } /* end if */
+    H5E_BEGIN_TRY
+    {
+        status = H5Funmount(dtype, "/mnt1");
+    }
+    H5E_END_TRY
+    if (status >= 0) {
+        H5_FAILED();
+        puts("    Passing in an ID other than file or group ID should have failed.");
+        TEST_ERROR;
+    } /* end if */
 
     /* Close everything and return */
     if (H5Fclose(file1) < 0)

--- a/test/mount.c
+++ b/test/mount.c
@@ -164,7 +164,7 @@ test_illegal(hid_t fapl)
 {
     hid_t file1 = H5I_INVALID_HID, file1b = H5I_INVALID_HID, file2 = H5I_INVALID_HID, file3 = H5I_INVALID_HID,
           file3b = H5I_INVALID_HID, mnt = H5I_INVALID_HID;
-    hid_t dtype = H5I_INVALID_HID;  /* To test invalid ID */
+    hid_t  dtype = H5I_INVALID_HID; /* To test invalid ID */
     char   filename1[1024], filename2[1024], filename3[1024];
     herr_t status;
 

--- a/test/tfile.c
+++ b/test/tfile.c
@@ -8197,6 +8197,14 @@ test_deprec(const char *driver_name)
     fcpl = H5Fget_create_plist(file);
     CHECK(fcpl, FAIL, "H5Fget_create_plist");
 
+    /* Test passing in an ID that is not a file ID, should fail */
+    H5E_BEGIN_TRY
+    {
+        ret = H5Fset_latest_format(fcpl, true);
+    }
+    H5E_END_TRY
+    VERIFY(ret, FAIL, "H5Fset_latest_format");
+
     /* Get the file's version information */
     ret = H5Pget_version(fcpl, &super, &freelist, &stab, &shhdr);
     CHECK(ret, FAIL, "H5Pget_version");


### PR DESCRIPTION
This PR switches H5I_object_verify() to H5VL_vol_object_verify() in the H5F API and fixes documentation of H5Fmount and H5Funmount.

Fixes GH-4730 partially