### PR TITLE
Don't run AOCC parallel tests with -j2

### DIFF
--- a/.github/workflows/aocc-auto.yml
+++ b/.github/workflows/aocc-auto.yml
@@ -86,12 +86,24 @@ jobs:
           make -j3
         working-directory: ${{ runner.workspace }}/build
 
+      # ph5diff tests are in the tools/tests directory so they will get run
+      # here
       - name: Autotools Run Tests
         env:
           NPROCS: 2
         run: |
           export PATH=/home/runner/work/hdf5/hdf5/openmpi-4.1.6-install/bin:/usr/local/bin:$PATH
-          make check -j
+          cd test && make check -j2 && cd ..
+          cd tools && make check -j2 && cd ..
+          cd hl && make check -j2 && cd ..
+        working-directory: ${{ runner.workspace }}/build
+
+      - name: Autotools Run Parallel Tests
+        env:
+          NPROCS: 2
+        run: |
+          export PATH=/home/runner/work/hdf5/hdf5/openmpi-4.1.6-install/bin:/usr/local/bin:$PATH
+          cd testpar && make check && cd ..
         working-directory: ${{ runner.workspace }}/build
 
       - name: Autotools Install

--- a/.github/workflows/aocc-auto.yml
+++ b/.github/workflows/aocc-auto.yml
@@ -85,8 +85,10 @@ jobs:
         working-directory: ${{ runner.workspace }}/build
 
       # ph5diff tests are in the tools/tests directory so they will get run
-      # here
+      # here, so leave NPROCS set here as well
       - name: Autotools Run Tests
+        env:
+          NPROCS: 2
         run: |
           export PATH=/home/runner/work/hdf5/hdf5/openmpi-4.1.6-install/bin:/usr/local/bin:$PATH
           cd test && make check -j2 && cd ..

--- a/.github/workflows/aocc-auto.yml
+++ b/.github/workflows/aocc-auto.yml
@@ -79,8 +79,6 @@ jobs:
 
       - name: Autotools Build
         shell: bash
-        env:
-          NPROCS: 2
         run: |
           export PATH=/home/runner/work/hdf5/hdf5/openmpi-4.1.6-install/bin:/usr/local/bin:$PATH
           make -j3
@@ -89,8 +87,6 @@ jobs:
       # ph5diff tests are in the tools/tests directory so they will get run
       # here
       - name: Autotools Run Tests
-        env:
-          NPROCS: 2
         run: |
           export PATH=/home/runner/work/hdf5/hdf5/openmpi-4.1.6-install/bin:/usr/local/bin:$PATH
           cd test && make check -j2 && cd ..
@@ -107,8 +103,6 @@ jobs:
         working-directory: ${{ runner.workspace }}/build
 
       - name: Autotools Install
-        env:
-          NPROCS: 2
         run: |
           export PATH=/home/runner/work/hdf5/hdf5/openmpi-4.1.6-install/bin:/usr/local/bin:$PATH
           make install

--- a/.github/workflows/aocc-cmake.yml
+++ b/.github/workflows/aocc-cmake.yml
@@ -90,5 +90,10 @@ jobs:
         shell: bash
         run: |
           ctest . -E MPI_TEST --parallel 2 -C ${{ inputs.build_mode }} -V
+        working-directory: ${{ runner.workspace }}/build
+
+      - name: CMake Run Parallel Tests
+        shell: bash
+        run: |
           ctest . -R MPI_TEST -C ${{ inputs.build_mode }} -V
         working-directory: ${{ runner.workspace }}/build

--- a/.github/workflows/aocc-cmake.yml
+++ b/.github/workflows/aocc-cmake.yml
@@ -89,5 +89,6 @@ jobs:
       - name: CMake Run Tests
         shell: bash
         run: |
-          ctest . --parallel 2 -C ${{ inputs.build_mode }} -V
+          ctest . -E MPI_TEST --parallel 2 -C ${{ inputs.build_mode }} -V
+          ctest . -R MPI_TEST -C ${{ inputs.build_mode }} -V
         working-directory: ${{ runner.workspace }}/build


### PR DESCRIPTION
Don't run parallel tests in both Autotools and CMake with multiple processes. ph5diff still runs with -j2 w/ Autotools since the test script is in the tools/test/h5diff directory.