### PR TITLE
Replace non-VOL calls with VOL calls - part 3

### DIFF
--- a/src/H5G.c
+++ b/src/H5G.c
@@ -340,7 +340,7 @@ H5Gcreate_anon(hid_t loc_id, hid_t gcpl_id, hid_t gapl_id)
     loc_params.obj_type = H5I_get_type(loc_id);
 
     /* Get the location object */
-    if (NULL == (vol_obj = (H5VL_object_t *)H5I_object(loc_id)))
+    if (NULL == (vol_obj = H5VL_vol_object(loc_id)))
         HGOTO_ERROR(H5E_ARGS, H5E_BADTYPE, H5I_INVALID_HID, "invalid location identifier");
 
     /* Create the group */
@@ -507,7 +507,7 @@ H5Gget_create_plist(hid_t group_id)
     FUNC_ENTER_API(H5I_INVALID_HID)
 
     /* Check args */
-    if (NULL == (vol_obj = (H5VL_object_t *)H5I_object_verify(group_id, H5I_GROUP)))
+    if (NULL == (vol_obj = H5VL_vol_object_verify(group_id, H5I_GROUP)))
         HGOTO_ERROR(H5E_ARGS, H5E_BADTYPE, H5I_INVALID_HID, "not a group ID");
 
     /* Set up VOL callback arguments */
@@ -960,7 +960,7 @@ H5Gflush(hid_t group_id)
     FUNC_ENTER_API(FAIL)
 
     /* Check args */
-    if (NULL == (vol_obj = (H5VL_object_t *)H5I_object_verify(group_id, H5I_GROUP)))
+    if (NULL == (vol_obj = H5VL_vol_object_verify(group_id, H5I_GROUP)))
         HGOTO_ERROR(H5E_ARGS, H5E_BADTYPE, FAIL, "not a group ID");
 
     /* Set up collective metadata if appropriate */
@@ -998,7 +998,7 @@ H5Grefresh(hid_t group_id)
     FUNC_ENTER_API(FAIL)
 
     /* Check args */
-    if (NULL == (vol_obj = (H5VL_object_t *)H5I_object_verify(group_id, H5I_GROUP)))
+    if (NULL == (vol_obj = H5VL_vol_object_verify(group_id, H5I_GROUP)))
         HGOTO_ERROR(H5E_ARGS, H5E_BADTYPE, FAIL, "not a group ID");
 
     /* Set up collective metadata if appropriate */

--- a/src/H5L.c
+++ b/src/H5L.c
@@ -468,11 +468,11 @@ H5L__create_hard_api_common(hid_t cur_loc_id, const char *cur_name, hid_t link_l
 
     if (H5L_SAME_LOC != cur_loc_id)
         /* Get the current location object */
-        if (NULL == (curr_vol_obj = (H5VL_object_t *)H5VL_vol_object(cur_loc_id)))
+        if (NULL == (curr_vol_obj = H5VL_vol_object(cur_loc_id)))
             HGOTO_ERROR(H5E_ARGS, H5E_BADTYPE, FAIL, "invalid location identifier");
     if (H5L_SAME_LOC != link_loc_id)
         /* Get the new location object */
-        if (NULL == (link_vol_obj = (H5VL_object_t *)H5VL_vol_object(link_loc_id)))
+        if (NULL == (link_vol_obj = H5VL_vol_object(link_loc_id)))
             HGOTO_ERROR(H5E_ARGS, H5E_BADTYPE, FAIL, "invalid location identifier");
 
     /* Make sure that the VOL connectors are the same */

--- a/src/H5Ldeprec.c
+++ b/src/H5Ldeprec.c
@@ -162,7 +162,7 @@ H5Literate1(hid_t group_id, H5_index_t idx_type, H5_iter_order_t order, hsize_t 
         HGOTO_ERROR(H5E_ARGS, H5E_BADVALUE, FAIL, "no operator specified");
 
     /* Get the location object */
-    if (NULL == (vol_obj = (H5VL_object_t *)H5I_object(group_id)))
+    if (NULL == (vol_obj = H5VL_vol_object(group_id)))
         HGOTO_ERROR(H5E_ARGS, H5E_BADTYPE, FAIL, "invalid location identifier");
 
     /* Check if the VOL object is a native VOL connector object */
@@ -248,7 +248,7 @@ H5Literate_by_name1(hid_t loc_id, const char *group_name, H5_index_t idx_type, H
         HGOTO_ERROR(H5E_LINK, H5E_CANTSET, FAIL, "can't set access property list info");
 
     /* Get the location object */
-    if (NULL == (vol_obj = (H5VL_object_t *)H5I_object(loc_id)))
+    if (NULL == (vol_obj = H5VL_vol_object(loc_id)))
         HGOTO_ERROR(H5E_ARGS, H5E_BADTYPE, FAIL, "invalid location identifier");
 
     /* Check if the VOL object is a native VOL connector object */
@@ -325,7 +325,7 @@ H5Lget_info1(hid_t loc_id, const char *name, H5L_info1_t *linfo /*out*/, hid_t l
     loc_params.loc_data.loc_by_name.lapl_id = lapl_id;
 
     /* Get the location object */
-    if (NULL == (vol_obj = (H5VL_object_t *)H5I_object(loc_id)))
+    if (NULL == (vol_obj = H5VL_vol_object(loc_id)))
         HGOTO_ERROR(H5E_ARGS, H5E_BADTYPE, FAIL, "invalid location identifier");
 
     /* Check if the VOL object is a native VOL connector object */
@@ -416,7 +416,7 @@ H5Lget_info_by_idx1(hid_t loc_id, const char *group_name, H5_index_t idx_type, H
     loc_params.obj_type                     = H5I_get_type(loc_id);
 
     /* Get the location object */
-    if (NULL == (vol_obj = (H5VL_object_t *)H5I_object(loc_id)))
+    if (NULL == (vol_obj = H5VL_vol_object(loc_id)))
         HGOTO_ERROR(H5E_ARGS, H5E_BADTYPE, FAIL, "invalid location identifier");
 
     /* Check if the VOL object is a native VOL connector object */
@@ -515,7 +515,7 @@ H5Lvisit1(hid_t group_id, H5_index_t idx_type, H5_iter_order_t order, H5L_iterat
     loc_params.obj_type = H5I_get_type(group_id);
 
     /* Get the location object */
-    if (NULL == (vol_obj = (H5VL_object_t *)H5I_object(group_id)))
+    if (NULL == (vol_obj = H5VL_vol_object(group_id)))
         HGOTO_ERROR(H5E_ARGS, H5E_BADTYPE, FAIL, "invalid location identifier");
 
     /* Check if the VOL object is a native VOL connector object */
@@ -604,7 +604,7 @@ H5Lvisit_by_name1(hid_t loc_id, const char *group_name, H5_index_t idx_type, H5_
         HGOTO_ERROR(H5E_LINK, H5E_CANTSET, FAIL, "can't set access property list info");
 
     /* get the location object */
-    if (NULL == (vol_obj = (H5VL_object_t *)H5I_object(loc_id)))
+    if (NULL == (vol_obj = H5VL_vol_object(loc_id)))
         HGOTO_ERROR(H5E_ARGS, H5E_BADTYPE, FAIL, "invalid location identifier");
 
     /* Check if the VOL object is a native VOL connector object */

--- a/test/th5o.c
+++ b/test/th5o.c
@@ -752,7 +752,7 @@ test_h5o_plist(void)
     hid_t    grp, dset, dtype, dspace; /* Object identifiers */
     hid_t    fapl;                     /* File access property list */
     hid_t    gcpl, dcpl, tcpl;         /* Object creation properties */
-    hid_t    bad_pl=H5I_INVALID_HID;   /* Invalid property list dues to invalid arg */
+    hid_t    bad_pl = H5I_INVALID_HID; /* Invalid property list dues to invalid arg */
     char     filename[1024];
     unsigned def_max_compact, def_min_dense; /* Default phase change parameters */
     unsigned max_compact, min_dense;         /* Actual phase change parameters */

--- a/test/th5o.c
+++ b/test/th5o.c
@@ -752,6 +752,7 @@ test_h5o_plist(void)
     hid_t    grp, dset, dtype, dspace; /* Object identifiers */
     hid_t    fapl;                     /* File access property list */
     hid_t    gcpl, dcpl, tcpl;         /* Object creation properties */
+    hid_t    bad_pl=H5I_INVALID_HID;   /* Invalid property list dues to invalid arg */
     char     filename[1024];
     unsigned def_max_compact, def_min_dense; /* Default phase change parameters */
     unsigned max_compact, min_dense;         /* Actual phase change parameters */
@@ -853,6 +854,14 @@ test_h5o_plist(void)
     CHECK(tcpl, FAIL, "H5Tget_create_plist");
     dcpl = H5Dget_create_plist(dset);
     CHECK(dcpl, FAIL, "H5Dget_create_plist");
+
+    /* Test passing in a non-group identifier to the H5G API */
+    H5E_BEGIN_TRY
+    {
+        bad_pl = H5Gget_create_plist(dtype);
+    }
+    H5E_END_TRY
+    VERIFY(bad_pl, H5I_INVALID_HID, "H5Gget_create_plist");
 
     /* Retrieve attribute phase change values on each creation property list and verify */
     ret = H5Pget_attr_phase_change(gcpl, &max_compact, &min_dense);


### PR DESCRIPTION
This PR switches H5I_object_verify() to H5VL_vol_object_verify() in the H5G API and removes unnecessary casts.

Fixes GH-4730 partially