### PR TITLE
Replace non-VOL calls with VOL calls - part 4

### DIFF
--- a/src/H5Gdeprec.c
+++ b/src/H5Gdeprec.c
@@ -719,8 +719,9 @@ done:
  *
  * Note:	Deprecated in favor of H5Oget_comment/H5Oget_comment_by_name
  *
- * Return:	Success: Number of characters in the comment.  The value
- *                   returned may be larger than the BUFSIZE argument.
+ * Return:	Success: Number of characters in the comment, excluding the
+ *                   NULL terminator character.  The value returned may be
+ *                   larger than the BUFSIZE argument.
  *
  *          Failure: Negative
  *

--- a/src/H5O.c
+++ b/src/H5O.c
@@ -359,7 +359,7 @@ H5Oopen_by_token(hid_t loc_id, H5O_token_t token)
         HGOTO_ERROR(H5E_ARGS, H5E_BADVALUE, H5I_INVALID_HID, "can't open H5O_TOKEN_UNDEF");
 
     /* Get the location object */
-    if (NULL == (vol_obj = (H5VL_object_t *)H5I_object(loc_id)))
+    if (NULL == (vol_obj = H5VL_vol_object(loc_id)))
         HGOTO_ERROR(H5E_ARGS, H5E_BADTYPE, H5I_INVALID_HID, "invalid location identifier");
 
     /* Get object type */
@@ -436,7 +436,7 @@ H5O__copy_api_common(hid_t src_loc_id, const char *src_name, hid_t dst_loc_id, c
         HGOTO_ERROR(H5E_OHDR, H5E_CANTSET, FAIL, "can't set object access arguments");
 
     /* get the object */
-    if (NULL == (*vol_obj_ptr = (H5VL_object_t *)H5I_object(dst_loc_id)))
+    if (NULL == (*vol_obj_ptr = H5VL_vol_object(dst_loc_id)))
         HGOTO_ERROR(H5E_ARGS, H5E_BADTYPE, FAIL, "invalid location identifier");
     loc_params2.type     = H5VL_OBJECT_BY_SELF;
     loc_params2.obj_type = H5I_get_type(dst_loc_id);

--- a/src/H5Odeprec.c
+++ b/src/H5Odeprec.c
@@ -347,7 +347,7 @@ H5Oopen_by_addr(hid_t loc_id, haddr_t addr)
     FUNC_ENTER_API(H5I_INVALID_HID)
 
     /* Get the location object */
-    if (NULL == (vol_obj = (H5VL_object_t *)H5I_object(loc_id)))
+    if (NULL == (vol_obj = H5VL_vol_object(loc_id)))
         HGOTO_ERROR(H5E_ARGS, H5E_BADTYPE, H5I_INVALID_HID, "invalid location identifier");
 
     /* Get object type */

--- a/src/H5Tcommit.c
+++ b/src/H5Tcommit.c
@@ -349,7 +349,7 @@ H5Tcommit_anon(hid_t loc_id, hid_t type_id, hid_t tcpl_id, hid_t tapl_id)
     loc_params.obj_type = H5I_get_type(loc_id);
 
     /* Get the file object */
-    if (NULL == (vol_obj = (H5VL_object_t *)H5I_object(loc_id)))
+    if (NULL == (vol_obj = H5VL_vol_object(loc_id)))
         HGOTO_ERROR(H5E_ARGS, H5E_BADTYPE, FAIL, "invalid file identifier");
 
     /* Commit the datatype */

--- a/src/H5Tdeprec.c
+++ b/src/H5Tdeprec.c
@@ -116,7 +116,7 @@ H5Tcommit1(hid_t loc_id, const char *name, hid_t type_id)
     loc_params.obj_type = H5I_get_type(loc_id);
 
     /* get the object from the loc_id */
-    if (NULL == (vol_obj = (H5VL_object_t *)H5I_object(loc_id)))
+    if (NULL == (vol_obj = H5VL_vol_object(loc_id)))
         HGOTO_ERROR(H5E_ARGS, H5E_BADTYPE, FAIL, "invalid object identifier");
 
     /* Commit the datatype */
@@ -167,7 +167,7 @@ H5Topen1(hid_t loc_id, const char *name)
     loc_params.obj_type = H5I_get_type(loc_id);
 
     /* Get the location object */
-    if (NULL == (vol_obj = (H5VL_object_t *)H5I_object(loc_id)))
+    if (NULL == (vol_obj = H5VL_vol_object(loc_id)))
         HGOTO_ERROR(H5E_ARGS, H5E_BADTYPE, H5I_INVALID_HID, "invalid location identifier");
 
     /* Open the datatype */

--- a/src/H5VLnative.c
+++ b/src/H5VLnative.c
@@ -393,7 +393,7 @@ H5VLnative_addr_to_token(hid_t loc_id, haddr_t addr, H5O_token_t *token)
         bool           is_native_vol_obj;
 
         /* Get the location object */
-        if (NULL == (vol_obj_container = (H5VL_object_t *)H5I_object(loc_id)))
+        if (NULL == (vol_obj_container = H5VL_vol_object(loc_id)))
             HGOTO_ERROR(H5E_ARGS, H5E_BADTYPE, FAIL, "invalid location identifier");
 
         /* Make sure that the VOL object is a native connector object */
@@ -486,7 +486,7 @@ H5VLnative_token_to_addr(hid_t loc_id, H5O_token_t token, haddr_t *addr)
         bool           is_native_vol_obj;
 
         /* Get the location object */
-        if (NULL == (vol_obj_container = (H5VL_object_t *)H5I_object(loc_id)))
+        if (NULL == (vol_obj_container = H5VL_vol_object(loc_id)))
             HGOTO_ERROR(H5E_ARGS, H5E_BADTYPE, FAIL, "invalid location identifier");
 
         /* Make sure that the VOL object is a native connector object */


### PR DESCRIPTION
This PR switches H5I_object() to H5VL_vol_object() in the rest of the APIs (in GH-4730) except H5M.
H5M is left out of this PR because it needs more work in the documentation and there is no test for the H5M API functions.

Fixes GH-4730 partially