### PR TITLE
Fix typo in H5T_order_t enum

### DIFF
--- a/src/H5Tpublic.h
+++ b/src/H5Tpublic.h
@@ -52,7 +52,7 @@ typedef enum H5T_class_t {
 typedef enum H5T_order_t {
     H5T_ORDER_ERROR = -1, /**< error                                   */
     H5T_ORDER_LE    = 0,  /**< little endian                           */
-    H5T_ORDER_BE    = 1,  /**< bit endian                              */
+    H5T_ORDER_BE    = 1,  /**< big endian                              */
     H5T_ORDER_VAX   = 2,  /**< VAX mixed endian                        */
     H5T_ORDER_MIXED = 3,  /**< Compound type with mixed member orders  */
     H5T_ORDER_NONE  = 4   /**< no particular order (strings, bits,..)  */


### PR DESCRIPTION
'bit endian' --> 'big endian'