### PR TITLE
Remove dummy comments that repeat function names.

### DIFF
--- a/test/vol.c
+++ b/test/vol.c
@@ -914,11 +914,9 @@ test_basic_file_operation(const char *driver_name)
             TEST_ERROR;
     }
 
-    /* H5Fcreate */
     if ((fid = H5Fcreate(filename, H5F_ACC_TRUNC, H5P_DEFAULT, fapl_id)) < 0)
         TEST_ERROR;
 
-    /* H5Fget_obj_count */
     if ((obj_count = H5Fget_obj_count(fid, H5F_OBJ_FILE)) < 0)
         TEST_ERROR;
     if ((obj_count = H5Fget_obj_count(fid, H5F_OBJ_ALL)) < 0)
@@ -926,7 +924,6 @@ test_basic_file_operation(const char *driver_name)
     if ((obj_count = H5Fget_obj_count((hid_t)H5F_OBJ_ALL, H5F_OBJ_DATASET)) < 0)
         TEST_ERROR;
 
-    /* H5Fget_obj_ids */
     if ((obj_count = H5Fget_obj_ids(fid, H5F_OBJ_ALL, 2, obj_id_list)) < 0)
         TEST_ERROR;
     if ((obj_count = H5Fget_obj_ids((hid_t)H5F_OBJ_ALL, H5F_OBJ_DATASET, 2, obj_id_list)) < 0)
@@ -937,7 +934,6 @@ test_basic_file_operation(const char *driver_name)
                strcmp(driver_name, "family") != 0 && strcmp(driver_name, "direct") != 0 &&
                strcmp(driver_name, "core") != 0 && strcmp(driver_name, "core_paged") != 0 &&
                strcmp(driver_name, "mpio") != 0 && strcmp(driver_name, "splitter") != 0)) {
-        /* H5Fget_access_plist */
         if ((fapl_id2 = H5Fget_access_plist(fid)) < 0)
             TEST_ERROR;
         if (H5Pequal(fapl_id, fapl_id2) != true)
@@ -946,53 +942,42 @@ test_basic_file_operation(const char *driver_name)
             TEST_ERROR;
     } /* end if */
 
-    /* H5Fget_create_plist */
     if ((fcpl_id = H5Fget_create_plist(fid)) < 0)
         TEST_ERROR;
     if (H5Pclose(fcpl_id) < 0)
         TEST_ERROR;
 
-    /* H5Fget_filesize */
     if (H5Fget_filesize(fid, &file_size) < 0)
         TEST_ERROR;
 
     /* Can't retrieve VFD handle for split / multi / family VFDs */
     if ((bool)(strcmp(driver_name, "split") != 0 && strcmp(driver_name, "multi") != 0 &&
                strcmp(driver_name, "family") != 0)) {
-        /* H5Fget_vfd_handle */
         if (H5Fget_vfd_handle(fid, H5P_DEFAULT, &os_file_handle) < 0)
             TEST_ERROR;
     } /* end if */
 
-    /* H5Fget_intent */
     if (H5Fget_intent(fid, &intent) < 0)
         TEST_ERROR;
 
-    /* H5Fget_info2 */
     if (H5Fget_info2(fid, &finfo) < 0)
         TEST_ERROR;
 
-    /* H5Fget_name */
     if (H5Fget_name(fid, name, 32) < 0)
         TEST_ERROR;
 
-    /* H5Fclear_elink_file_cache */
     if (H5Fclear_elink_file_cache(fid) < 0)
         TEST_ERROR;
 
-    /* H5Fflush */
     if (H5Fflush(fid, H5F_SCOPE_GLOBAL) < 0)
         TEST_ERROR;
 
-    /* H5Fclose */
     if (H5Fclose(fid) < 0)
         TEST_ERROR;
 
-    /* H5Fis_accessible */
     if (H5Fis_accessible(filename, fapl_id) < 0)
         TEST_ERROR;
 
-    /* H5Fopen */
     if ((fid = H5Fopen(filename, H5F_ACC_RDWR, fapl_id)) < 0)
         TEST_ERROR;
 
@@ -1001,7 +986,6 @@ test_basic_file_operation(const char *driver_name)
                strcmp(driver_name, "family") != 0 && strcmp(driver_name, "direct") != 0 &&
                strcmp(driver_name, "core") != 0 && strcmp(driver_name, "core_paged") != 0 &&
                strcmp(driver_name, "mpio") != 0 && strcmp(driver_name, "splitter") != 0)) {
-        /* H5Fget_access_plist */
         if ((fapl_id2 = H5Fget_access_plist(fid)) < 0)
             TEST_ERROR;
         if (H5Pequal(fapl_id, fapl_id2) != true)
@@ -1018,7 +1002,6 @@ test_basic_file_operation(const char *driver_name)
                strcmp(driver_name, "family") != 0 && strcmp(driver_name, "direct") != 0 &&
                strcmp(driver_name, "core") != 0 && strcmp(driver_name, "core_paged") != 0 &&
                strcmp(driver_name, "mpio") != 0 && strcmp(driver_name, "splitter") != 0)) {
-        /* H5Fget_access_plist */
         if ((fapl_id2 = H5Fget_access_plist(fid_reopen)) < 0)
             TEST_ERROR;
         if (H5Pequal(fapl_id, fapl_id2) != true)
@@ -1034,7 +1017,6 @@ test_basic_file_operation(const char *driver_name)
 
     h5_delete_test_file(FILENAME[0], fapl_id);
 
-    /* H5Pclose */
     if (H5Pclose(fapl_id) < 0)
         TEST_ERROR;
 
@@ -1086,27 +1068,22 @@ test_basic_group_operation(void)
     if ((fid = H5Fcreate(filename, H5F_ACC_TRUNC, H5P_DEFAULT, fapl_id)) < 0)
         TEST_ERROR;
 
-    /* H5Gcreate */
     if ((gid = H5Gcreate2(fid, NATIVE_VOL_TEST_GROUP_NAME, H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT)) < 0)
         TEST_ERROR;
 
-    /* H5Gget_create_plist */
     if ((gcpl_id = H5Gget_create_plist(gid)) < 0)
         TEST_ERROR;
     if (H5Pclose(gcpl_id) < 0)
         TEST_ERROR;
 
-    /* H5Gget_info */
     if (H5Gget_info(gid, &info) < 0)
         TEST_ERROR;
     if (H5Gget_info(fid, &info) < 0)
         TEST_ERROR;
 
-    /* H5Gget_info_by_name */
     if (H5Gget_info_by_name(fid, NATIVE_VOL_TEST_GROUP_NAME, &info, H5P_DEFAULT) < 0)
         TEST_ERROR;
 
-    /* H5Gget_info_by_idx */
     if (H5Gget_info_by_idx(fid, "/", H5_INDEX_NAME, H5_ITER_NATIVE, 0, &info, H5P_DEFAULT) < 0)
         TEST_ERROR;
 
@@ -1117,19 +1094,15 @@ test_basic_group_operation(void)
         if (H5Gflush(gid) < 0)
             TEST_ERROR;
 
-    /* H5Gclose */
     if (H5Gclose(gid) < 0)
         TEST_ERROR;
 
-    /* H5Gopen */
     if ((gid = H5Gopen2(fid, NATIVE_VOL_TEST_GROUP_NAME, H5P_DEFAULT)) < 0)
         TEST_ERROR;
 
-    /* H5Gcreate_anon */
     if ((gid_a = H5Gcreate_anon(fid, H5P_DEFAULT, H5P_DEFAULT)) < 0)
         TEST_ERROR;
 
-    /* H5Grefresh */
     if (H5Grefresh(gid) < 0)
         TEST_ERROR;
 
@@ -1142,7 +1115,6 @@ test_basic_group_operation(void)
 
     h5_delete_test_file(FILENAME[0], fapl_id);
 
-    /* H5Pclose */
     if (H5Pclose(fapl_id) < 0)
         TEST_ERROR;
 
@@ -1213,7 +1185,6 @@ test_basic_dataset_operation(void)
         out_buf[i] = 0;
     }
 
-    /* H5Dcreate */
     curr_dims = 0;
     if ((sid = H5Screate_simple(1, &curr_dims, &max_dims)) < 0)
         TEST_ERROR;
@@ -1226,7 +1197,6 @@ test_basic_dataset_operation(void)
                           H5P_DEFAULT)) < 0)
         TEST_ERROR;
 
-    /* H5Dcreate_anon */
     if ((did_a = H5Dcreate_anon(fid, H5T_NATIVE_INT, sid, dcpl_id, H5P_DEFAULT)) < 0)
         TEST_ERROR;
 
@@ -1235,7 +1205,6 @@ test_basic_dataset_operation(void)
     if (H5Pclose(dcpl_id) < 0)
         TEST_ERROR;
 
-    /* H5Dset_extent */
     curr_dims = N_ELEMENTS;
     if (H5Dset_extent(did, &curr_dims) < 0)
         TEST_ERROR;
@@ -1247,35 +1216,28 @@ test_basic_dataset_operation(void)
         if (H5Dflush(did) < 0)
             TEST_ERROR;
 
-    /* H5Dwrite */
     if (H5Dwrite(did, H5T_NATIVE_INT, H5S_ALL, H5S_ALL, H5P_DEFAULT, in_buf) < 0)
         TEST_ERROR;
 
-    /* H5Drefresh */
     if (H5Drefresh(did) < 0)
         TEST_ERROR;
 
-    /* H5Dclose */
     if (H5Dclose(did) < 0)
         TEST_ERROR;
     if (H5Dclose(did_a) < 0)
         TEST_ERROR;
 
-    /* H5Dopen */
     if ((did = H5Dopen2(fid, NATIVE_VOL_TEST_DATASET_NAME, H5P_DEFAULT)) < 0)
         TEST_ERROR;
 
-    /* H5Dget_space */
     if ((sid = H5Dget_space(did)) < 0)
         TEST_ERROR;
     if (H5Sclose(sid) < 0)
         TEST_ERROR;
 
-    /* H5Dget_space_status */
     if (H5Dget_space_status(did, &status) < 0)
         TEST_ERROR;
 
-    /* H5Dget_type */
     if ((tid = H5Dget_type(did)) < 0)
         TEST_ERROR;
     if (H5Tclose(tid) < 0)
@@ -1287,13 +1249,11 @@ test_basic_dataset_operation(void)
     if (H5Tclose(tid) < 0)
         TEST_ERROR;
 
-    /* H5Dget_create_plist */
     if ((dcpl_id = H5Dget_create_plist(did)) < 0)
         TEST_ERROR;
     if (H5Pclose(dcpl_id) < 0)
         TEST_ERROR;
 
-    /* H5Dget_access_plist */
     if ((dapl_id = H5Dget_access_plist(did)) < 0)
         TEST_ERROR;
     if (H5Pclose(dapl_id) < 0)
@@ -1311,7 +1271,6 @@ test_basic_dataset_operation(void)
     if (HADDR_UNDEF != (offset = H5Dget_offset(did)))
         TEST_ERROR;
 
-    /* H5Dread */
     if (H5Dread(did, H5T_NATIVE_INT, H5S_ALL, H5S_ALL, H5P_DEFAULT, out_buf) < 0)
         TEST_ERROR;
 
@@ -1326,7 +1285,6 @@ test_basic_dataset_operation(void)
 
     h5_delete_test_file(FILENAME[0], fapl_id);
 
-    /* H5Pclose */
     if (H5Pclose(fapl_id) < 0)
         TEST_ERROR;
 
@@ -1391,44 +1349,35 @@ test_basic_attribute_operation(void)
     if ((sid = H5Screate_simple(1, &dims, &dims)) < 0)
         TEST_ERROR;
 
-    /* H5Acreate */
     if ((aid = H5Acreate2(fid, NATIVE_VOL_TEST_ATTRIBUTE_NAME, H5T_NATIVE_INT, sid, H5P_DEFAULT,
                           H5P_DEFAULT)) < 0)
         TEST_ERROR;
 
-    /* H5Awrite */
     if (H5Awrite(aid, H5T_NATIVE_INT, &data_in) < 0)
         TEST_ERROR;
 
-    /* H5Aread */
     if (H5Aread(aid, H5T_NATIVE_INT, &data_out) < 0)
         TEST_ERROR;
     if (data_in != data_out)
         TEST_ERROR;
 
-    /* H5Aclose */
     if (H5Aclose(aid) < 0)
         TEST_ERROR;
 
-    /* H5Aopen */
     if ((aid = H5Aopen(fid, NATIVE_VOL_TEST_ATTRIBUTE_NAME, H5P_DEFAULT)) < 0)
         TEST_ERROR;
     if (H5Aclose(aid) < 0)
         TEST_ERROR;
 
-    /* H5Adelete */
     if (H5Adelete(fid, NATIVE_VOL_TEST_ATTRIBUTE_NAME) < 0)
         TEST_ERROR;
 
-    /* H5Acreate_by_name */
     if ((aid_name = H5Acreate_by_name(fid, NATIVE_VOL_TEST_GROUP_NAME, NATIVE_VOL_TEST_ATTRIBUTE_NAME,
                                       H5T_NATIVE_INT, sid, H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT)) < 0)
         TEST_ERROR;
-    /* H5Aclose */
     if (H5Aclose(aid_name) < 0)
         TEST_ERROR;
 
-    /* H5Adelete_by_name */
     if (H5Adelete_by_name(fid, NATIVE_VOL_TEST_GROUP_NAME, NATIVE_VOL_TEST_ATTRIBUTE_NAME, H5P_DEFAULT) < 0)
         TEST_ERROR;
 
@@ -1441,7 +1390,6 @@ test_basic_attribute_operation(void)
 
     h5_delete_test_file(FILENAME[0], fapl_id);
 
-    /* H5Pclose */
     if (H5Pclose(fapl_id) < 0)
         TEST_ERROR;
 
@@ -1495,23 +1443,19 @@ test_basic_object_operation(void)
     if ((gid = H5Gcreate2(fid, NATIVE_VOL_TEST_GROUP_NAME, H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT)) < 0)
         TEST_ERROR;
 
-    /* H5Oget_info */
     if (H5Oget_info3(fid, &object_info, H5O_INFO_ALL) < 0)
         TEST_ERROR;
 
     //! [H5Oget_info_by_name3_snip]
 
-    /* H5Oget_info_by_name */
     if (H5Oget_info_by_name3(fid, NATIVE_VOL_TEST_GROUP_NAME, &object_info, H5O_INFO_ALL, H5P_DEFAULT) < 0)
         TEST_ERROR;
 
     //! [H5Oget_info_by_name3_snip]
 
-    /* H5Oexists_by_name */
     if (H5Oexists_by_name(fid, NATIVE_VOL_TEST_GROUP_NAME, H5P_DEFAULT) != true)
         TEST_ERROR;
 
-    /* H5Oopen/close */
     if ((oid = H5Oopen(fid, NATIVE_VOL_TEST_GROUP_NAME, H5P_DEFAULT)) < 0)
         TEST_ERROR;
     if (H5Oclose(oid) < 0)
@@ -1524,7 +1468,6 @@ test_basic_object_operation(void)
 
     h5_delete_test_file(FILENAME[0], fapl_id);
 
-    /* H5Pclose */
     if (H5Pclose(fapl_id) < 0)
         TEST_ERROR;
 
@@ -1572,7 +1515,6 @@ test_basic_link_operation(void)
     if ((gid = H5Gcreate2(fid, NATIVE_VOL_TEST_GROUP_NAME, H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT)) < 0)
         TEST_ERROR;
 
-    /* H5Lcreate_hard */
     if (H5Lcreate_hard(fid, "/", gid, NATIVE_VOL_TEST_HARD_LINK_NAME, H5P_DEFAULT, H5P_DEFAULT) < 0)
         TEST_ERROR;
 
@@ -1580,18 +1522,15 @@ test_basic_link_operation(void)
     if (H5Lcreate_soft("/", fid, NATIVE_VOL_TEST_SOFT_LINK_NAME, H5P_DEFAULT, H5P_DEFAULT) < 0)
         TEST_ERROR;
 
-    /* H5Lexists */
     if (H5Lexists(gid, NATIVE_VOL_TEST_HARD_LINK_NAME, H5P_DEFAULT) < 0)
         TEST_ERROR;
     if (H5Lexists(fid, NATIVE_VOL_TEST_SOFT_LINK_NAME, H5P_DEFAULT) < 0)
         TEST_ERROR;
 
-    /* H5Lcopy */
     if (H5Lcopy(gid, NATIVE_VOL_TEST_HARD_LINK_NAME, fid, NATIVE_VOL_TEST_COPY_LINK_NAME, H5P_DEFAULT,
                 H5P_DEFAULT) < 0)
         TEST_ERROR;
 
-    /* H5Lmove */
     if (H5Lmove(fid, NATIVE_VOL_TEST_COPY_LINK_NAME, gid, NATIVE_VOL_TEST_MOVE_LINK_NAME, H5P_DEFAULT,
                 H5P_DEFAULT) < 0)
         TEST_ERROR;
@@ -1603,7 +1542,6 @@ test_basic_link_operation(void)
 
     h5_delete_test_file(FILENAME[0], fapl_id);
 
-    /* H5Pclose */
     if (H5Pclose(fapl_id) < 0)
         TEST_ERROR;
 
@@ -1654,7 +1592,6 @@ test_basic_datatype_operation(void)
     if ((tid = H5Tcopy(H5T_NATIVE_INT)) < 0)
         TEST_ERROR;
 
-    /* H5Tcommit */
     if (H5Tcommit2(fid, NATIVE_VOL_TEST_DATATYPE_NAME, tid, H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT) < 0)
         TEST_ERROR;
 
@@ -1665,23 +1602,18 @@ test_basic_datatype_operation(void)
         if (H5Tflush(tid) < 0)
             TEST_ERROR;
 
-    /* H5Trefresh */
     if (H5Trefresh(tid) < 0)
         TEST_ERROR;
 
-    /* H5Tclose */
     if (H5Tclose(tid) < 0)
         TEST_ERROR;
 
-    /* H5Topen */
     if ((tid = H5Topen2(fid, NATIVE_VOL_TEST_DATATYPE_NAME, H5P_DEFAULT)) < 0)
         TEST_ERROR;
 
-    /* H5Tget_create_plist */
     if ((tcpl_id = H5Tget_create_plist(tid)) < 0)
         TEST_ERROR;
 
-    /* H5Tcommit_anon */
     if ((tid_anon = H5Tcopy(H5T_NATIVE_INT)) < 0)
         TEST_ERROR;
     if (H5Tcommit_anon(fid, tid_anon, H5P_DEFAULT, H5P_DEFAULT) < 0)
@@ -1698,7 +1630,6 @@ test_basic_datatype_operation(void)
 
     h5_delete_test_file(FILENAME[0], fapl_id);
 
-    /* H5Pclose */
     if (H5Pclose(fapl_id) < 0)
         TEST_ERROR;
 


### PR DESCRIPTION
Some comments even do not match function names.