### PR TITLE
Add bounds checking to avoid Out-of-bounds Write for gif2h5

### DIFF
--- a/hl/tools/gif2h5/decompress.c
+++ b/hl/tools/gif2h5/decompress.c
@@ -296,6 +296,10 @@ Decompress(GIFIMAGEDESC *GifImageDesc, GIFHEAD *GifHead)
              * Build the hash table on-the-fly. No table is stored in the
              * file.
              */
+            if (FreeCode >= 4096) {
+                printf("Error: FreeCode out of bounds\n");
+                exit(EXIT_FAILURE);
+            }
             Prefix[FreeCode] = OldCode;
             Suffix[FreeCode] = FinChar;
             OldCode          = InCode;


### PR DESCRIPTION
fix CVE-2022-25972
https://nvd.nist.gov/vuln/detail/CVE-2022-25972

