### PR TITLE
Resolve race around single counter by using two counters

### DIFF
--- a/test/ttsafe_semaphore.c
+++ b/test/ttsafe_semaphore.c
@@ -20,14 +20,15 @@
 
 #if defined(H5_HAVE_THREADS)
 
-#define NUM_PINGPONG     (500 * 1000)
+#define NUM_PINGPONG     (250 * 1000)
 #define NUM_CLIENTSERVER (50 * 1000)
 
 #define NUM_THREADS 16
 
 typedef struct {
     H5TS_semaphore_t   ping_sem, pong_sem;
-    H5TS_atomic_uint_t counter;
+    H5TS_atomic_uint_t ping_counter;
+    H5TS_atomic_uint_t pong_counter;
 } pingpong_t;
 
 typedef struct {
@@ -47,11 +48,11 @@ ping(void *_test_info)
         result = H5TS_semaphore_wait(&test_info->ping_sem);
         CHECK_I(result, "H5TS_semaphore_wait");
 
-        H5TS_atomic_fetch_add_uint(&test_info->counter, (unsigned)1);
+        H5TS_atomic_fetch_add_uint(&test_info->ping_counter, (unsigned)1);
 
         result = H5TS_semaphore_signal(&test_info->pong_sem);
         CHECK_I(result, "H5TS_semaphore_signal");
-    } while (H5TS_atomic_load_uint(&test_info->counter) < NUM_PINGPONG);
+    } while (H5TS_atomic_load_uint(&test_info->ping_counter) < NUM_PINGPONG);
 
     return ret_value;
 }
@@ -67,11 +68,11 @@ pong(void *_test_info)
         result = H5TS_semaphore_wait(&test_info->pong_sem);
         CHECK_I(result, "H5TS_semaphore_wait");
 
-        H5TS_atomic_fetch_add_uint(&test_info->counter, (unsigned)1);
+        H5TS_atomic_fetch_add_uint(&test_info->pong_counter, (unsigned)1);
 
         result = H5TS_semaphore_signal(&test_info->ping_sem);
         CHECK_I(result, "H5TS_semaphore_signal");
-    } while (H5TS_atomic_load_uint(&test_info->counter) < NUM_PINGPONG);
+    } while (H5TS_atomic_load_uint(&test_info->pong_counter) < NUM_PINGPONG);
 
     return ret_value;
 }
@@ -93,7 +94,8 @@ tts_semaphore_pingpong(void)
     CHECK_I(result, "H5TS_semaphore_init");
     result = H5TS_semaphore_init(&test_info.pong_sem, 0);
     CHECK_I(result, "H5TS_semaphore_init");
-    H5TS_atomic_init_uint(&test_info.counter, (unsigned)0);
+    H5TS_atomic_init_uint(&test_info.ping_counter, (unsigned)0);
+    H5TS_atomic_init_uint(&test_info.pong_counter, (unsigned)0);
 
     /* Start ping & pong threads */
     result = H5TS_thread_create(&ping_thread, ping, &test_info);
@@ -111,7 +113,8 @@ tts_semaphore_pingpong(void)
     result = H5TS_thread_join(pong_thread, NULL);
     CHECK_I(result, "H5TS_thread_join");
 
-    VERIFY(H5TS_atomic_load_uint(&test_info.counter), (NUM_PINGPONG + 1), "ping pong");
+    VERIFY(H5TS_atomic_load_uint(&test_info.ping_counter), NUM_PINGPONG, "ping counter");
+    VERIFY(H5TS_atomic_load_uint(&test_info.pong_counter), NUM_PINGPONG, "pong counter");
 
     /* Destroy semaphores, etc. */
     result = H5TS_semaphore_destroy(&test_info.ping_sem);
@@ -119,7 +122,8 @@ tts_semaphore_pingpong(void)
     result = H5TS_semaphore_destroy(&test_info.pong_sem);
     CHECK_I(result, "H5TS_semaphore_destroy");
 
-    H5TS_atomic_destroy_uint(&test_info.counter);
+    H5TS_atomic_destroy_uint(&test_info.ping_counter);
+    H5TS_atomic_destroy_uint(&test_info.pong_counter);
 } /* end tts_semaphore_pingpong() */
 
 static H5TS_THREAD_RETURN_TYPE


### PR DESCRIPTION
Gave this more thought and using a single counter is going to be racey, unless we use thread barriers, which takes away the whole point of the ping+pong semaphores.  So, use two different counters to verify correct operation.