### PR TITLE
Include vector.c from libaec sources to prevent linker errors during HDF5 build

### DIFF
--- a/config/cmake/LIBAEC/CMakeLists.txt
+++ b/config/cmake/LIBAEC/CMakeLists.txt
@@ -157,6 +157,7 @@ set(LIBAEC_SRCS
     ${LIBAEC_SRC_DIR}/encode.c
     ${LIBAEC_SRC_DIR}/encode_accessors.c
     ${LIBAEC_SRC_DIR}/decode.c
+    ${LIBAEC_SRC_DIR}/vector.c
 )
 
 set (LIBAEC_PUBLIC_HEADERS


### PR DESCRIPTION
Problem Statement:
libaec source now has additional file vector.c. If we are building HDF5 using GIT URL of libaec, then not including the vector.c causes linker errors in HDF5 build

```
     [exec] C:\hdf5-1.14.3-39_spk\depot\Third_Party\hdf5\1.14.3\dist\src\H5Ztrans.c(1032): warning C4028: formal parameter 3 different from declaration [C:\hdf5-1.14.3-39_spk\depot\Third_Party\hdf5\1.14.3\x64\src\hdf5-shared.vcxproj]
     [exec]   Generating Code...
     [exec]      Creating library C:/hdf5-1.14.3-39_spk/depot/Third_Party/hdf5/1.14.3/x64/bin/Debug/hdf5_D.lib and object C:/hdf5-1.14.3-39_spk/depot/Third_Party/hdf5/1.14.3/x64/bin/Debug/hdf5_D.exp
     [exec] libaec_D.lib(encode.obj) : error LNK2019: unresolved external symbol vector_create referenced in function aec_encode_enable_offsets [C:\hdf5-1.14.3-39_spk\depot\Third_Party\hdf5\1.14.3\x64\src\hdf5-shared.vcxproj]
     [exec] libaec_D.lib(decode.obj) : error LNK2001: unresolved external symbol vector_create [C:\hdf5-1.14.3-39_spk\depot\Third_Party\hdf5\1.14.3\x64\src\hdf5-shared.vcxproj]
     [exec] libaec_D.lib(encode.obj) : error LNK2019: unresolved external symbol vector_destroy referenced in function aec_encode_end [C:\hdf5-1.14.3-39_spk\depot\Third_Party\hdf5\1.14.3\x64\src\hdf5-shared.vcxproj]
     [exec] libaec_D.lib(decode.obj) : error LNK2001: unresolved external symbol vector_destroy [C:\hdf5-1.14.3-39_spk\depot\Third_Party\hdf5\1.14.3\x64\src\hdf5-shared.vcxproj]
     [exec] libaec_D.lib(encode.obj) : error LNK2019: unresolved external symbol vector_size referenced in function aec_encode_count_offsets [C:\hdf5-1.14.3-39_spk\depot\Third_Party\hdf5\1.14.3\x64\src\hdf5-shared.vcxproj]
     [exec] libaec_D.lib(decode.obj) : error LNK2001: unresolved external symbol vector_size [C:\hdf5-1.14.3-39_spk\depot\Third_Party\hdf5\1.14.3\x64\src\hdf5-shared.vcxproj]
     [exec] libaec_D.lib(encode.obj) : error LNK2019: unresolved external symbol vector_push_back referenced in function aec_encode_enable_offsets [C:\hdf5-1.14.3-39_spk\depot\Third_Party\hdf5\1.14.3\x64\src\hdf5-shared.vcxproj]
     [exec] libaec_D.lib(decode.obj) : error LNK2001: unresolved external symbol vector_push_back [C:\hdf5-1.14.3-39_spk\depot\Third_Party\hdf5\1.14.3\x64\src\hdf5-shared.vcxproj]
     [exec] libaec_D.lib(encode.obj) : error LNK2019: unresolved external symbol vector_data referenced in function aec_encode_get_offsets [C:\hdf5-1.14.3-39_spk\depot\Third_Party\hdf5\1.14.3\x64\src\hdf5-shared.vcxproj]
     [exec] libaec_D.lib(decode.obj) : error LNK2001: unresolved external symbol vector_data [C:\hdf5-1.14.3-39_spk\depot\Third_Party\hdf5\1.14.3\x64\src\hdf5-shared.vcxproj]
     [exec] C:\hdf5-1.14.3-39_spk\depot\Third_Party\hdf5\1.14.3\x64\bin\Debug\hdf5_D.dll : fatal error LNK1120: 5 unresolved externals [C:\hdf5-1.14.3-39_spk\depot\Third_Party\hdf5\1.14.3\x64\src\hdf5-shared.vcxproj]
```

