### PR TITLE
Skip unseekable file test on Cygwin

### DIFF
--- a/test/h5test.c
+++ b/test/h5test.c
@@ -2564,6 +2564,31 @@ h5_driver_uses_multiple_files(const char *drv_name, unsigned flags)
     return ret_val;
 }
 
+/*-------------------------------------------------------------------------
+ * Function:    h5_on_cygwin
+
+ *
+ * Purpose:     Determine whether tests are running on Cygwin
+ *
+ * Return:      True if running on Cygwin, false otherwise.
+ *
+ *-------------------------------------------------------------------------
+ */
+bool
+h5_on_cygwin(void)
+{
+    bool  ret_value = false;
+    FILE *fp        = NULL;
+
+    /* If /cygdrive/ exists and is readable, assume HDF5 is running on Cygwin */
+    if ((fp = fopen("/cygdrive", "r")) != NULL) {
+        fclose(fp);
+        ret_value = true;
+    }
+
+    return ret_value;
+}
+
 /* Deterministic random number functions that don't modify the underlying
  * C/POSIX library rand/random state, as this can cause spurious test failures.
  *

--- a/test/h5test.h
+++ b/test/h5test.h
@@ -318,7 +318,7 @@ H5TEST_DLL bool           h5_using_default_driver(const char *drv_name);
 H5TEST_DLL herr_t         h5_using_parallel_driver(hid_t fapl_id, bool *driver_is_parallel);
 H5TEST_DLL herr_t         h5_driver_is_default_vfd_compatible(hid_t fapl_id, bool *default_vfd_compatible);
 H5TEST_DLL bool           h5_driver_uses_multiple_files(const char *drv_name, unsigned flags);
-
+H5TEST_DLL bool           h5_on_cygwin(void);
 /* Random number functions that don't modify the underlying rand/random state.
  * These use rand_r with a state pointer under the hood. The state is always
  * initialized to the same value so that each process in the parallel tests

--- a/test/tfile.c
+++ b/test/tfile.c
@@ -8116,6 +8116,12 @@ test_unseekable_file(void)
     /* Flush message in case this test segfaults */
     fflush(stdout);
 
+/* Segfault still occurs on Cygwin - see hdf5#4797 */
+#if defined(__CYGWIN__)
+    MESSAGE(5, (" -- SKIPPED --\n"));
+    return;
+#endif
+
     /* Creation */
 #ifdef H5_HAVE_WIN32_API
     H5Fcreate("NUL", H5F_ACC_TRUNC, H5P_DEFAULT, H5P_DEFAULT);

--- a/test/tfile.c
+++ b/test/tfile.c
@@ -8116,11 +8116,11 @@ test_unseekable_file(void)
     /* Flush message in case this test segfaults */
     fflush(stdout);
 
-/* Segfault still occurs on Cygwin - see hdf5#4797 */
-#if defined(__CYGWIN__)
-    MESSAGE(5, (" -- SKIPPED --\n"));
-    return;
-#endif
+    /* Segfault still occurs on Cygwin - see hdf5#4797 */
+    if (h5_on_cygwin()) {
+        MESSAGE(5, (" -- SKIPPED --\n"));
+        return;
+    }
 
     /* Creation */
 #ifdef H5_HAVE_WIN32_API


### PR DESCRIPTION
Different implementation of hdf5#4797. Ideally the root issue will be fixed eventually, but for now we should avoid a known segfault during testing.

The metadata cache assertion that triggers an error in debug builds hasn't been converted to a regular error because it uses a debug-build-exclusive routine.