### PR TITLE
Change name of libhdf5hl_fortran installed by autotools 

### DIFF
--- a/config/commence.am
+++ b/config/commence.am
@@ -37,7 +37,7 @@ LIBH5CPP=$(top_builddir)/c++/src/libhdf5_cpp.la
 LIBH5JNI=$(top_builddir)/java/src/jni/libhdf5_java.la
 LIBH5TOOLS=$(top_builddir)/tools/lib/libh5tools.la
 LIBH5_HL=$(top_builddir)/hl/src/libhdf5_hl.la
-LIBH5F_HL=$(top_builddir)/hl/fortran/src/libhdf5hl_fortran.la
+LIBH5F_HL=$(top_builddir)/hl/fortran/src/libhdf5_hl_fortran.la
 LIBH5CPP_HL=$(top_builddir)/hl/c++/src/libhdf5_hl_cpp.la
 
 # Install directories that automake doesn't know about

--- a/fortran/src/h5fc.in
+++ b/fortran/src/h5fc.in
@@ -296,7 +296,7 @@ if test "x$do_link" = "xyes"; then
   shared_link=""
 # conditionally link with the hl library
   if test "X$HL" = "Xhl"; then
-   libraries=" $libraries -lhdf5hl_fortran -lhdf5_hl -lhdf5_fortran -lhdf5 "
+   libraries=" $libraries -lhdf5_hl_fortran -lhdf5_hl -lhdf5_fortran -lhdf5 "
   else
    libraries=" $libraries -lhdf5_fortran -lhdf5 "
   fi

--- a/hl/fortran/src/Makefile.am
+++ b/hl/fortran/src/Makefile.am
@@ -49,21 +49,6 @@ libhdf5_hl_fortran_la_SOURCES=H5DSfc.c H5LTfc.c H5IMfc.c H5IMcc.c H5TBfc.c \
 # HDF5 HL Fortran library depends on HDF5 Library.
 libhdf5_hl_fortran_la_LIBADD=$(LIBH5_HL) $(LIBH5F)
 
-# The name of the lib file doesn't follow the same pattern as the other hl lib
-# files, namely libhdf5_hl_*.  Add a symlink with the compliant name to the
-# actual lib file.
-install-exec-hook:
-	cd $(DESTDIR)$(libdir) && \
-	    if test -f libhdf5_hl_fortran.a -a \
-	    ! -f libhdf5hl_fortran.a; then \
-	        $(LN_S) libhdf5_hl_fortran.a libhdf5hl_fortran.a; \
-	    fi; \
-	    if test -f libhdf5_hl_fortran.so -a \
-	    ! -f libhdf5hl_fortran.so; then \
-	        $(LN_S) libhdf5_hl_fortran.so libhdf5hl_fortran.so; \
-	    fi;
-
-
 # Fortran module files can have different extensions and different names
 # (e.g., different capitalizations) on different platforms.  Write rules
 # for them explicitly rather than trying to teach automake about them.

--- a/hl/fortran/src/Makefile.am
+++ b/hl/fortran/src/Makefile.am
@@ -24,10 +24,10 @@ AM_CPPFLAGS+=-I$(top_srcdir)/src -I$(top_srcdir)/hl/src -I$(top_builddir)/hl/src
 AM_FCFLAGS+=-I$(top_builddir)/fortran/src $(F9XMODFLAG)$(top_builddir)/fortran/src
 
 # Our main target, the high-level fortran library
-lib_LTLIBRARIES=libhdf5hl_fortran.la
+lib_LTLIBRARIES=libhdf5_hl_fortran.la
 
 # Add libtool numbers to the HDF5 HL Fortran library (from config/lt_vers.am)
-libhdf5hl_fortran_la_LDFLAGS= -version-info $(LT_HL_F_VERS_INTERFACE):$(LT_HL_F_VERS_REVISION):$(LT_HL_F_VERS_AGE) $(AM_LDFLAGS)
+libhdf5_hl_fortran_la_LDFLAGS= -version-info $(LT_HL_F_VERS_INTERFACE):$(LT_HL_F_VERS_REVISION):$(LT_HL_F_VERS_AGE) $(AM_LDFLAGS)
 
 # Some Fortran compilers can't build shared libraries, so sometimes we
 # want to build a shared C library and a static Fortran library.  If so,
@@ -43,24 +43,24 @@ endif
 #endif
 
 # List sources to include in the HDF5 HL Fortran library.
-libhdf5hl_fortran_la_SOURCES=H5DSfc.c H5LTfc.c H5IMfc.c H5IMcc.c H5TBfc.c \
+libhdf5_hl_fortran_la_SOURCES=H5DSfc.c H5LTfc.c H5IMfc.c H5IMcc.c H5TBfc.c \
 	H5DSff.F90 H5LTff.F90 H5TBff.F90 H5IMff.F90 H5DOff.F90 H5LTff_gen.F90 H5TBff_gen.F90
 
 # HDF5 HL Fortran library depends on HDF5 Library.
-libhdf5hl_fortran_la_LIBADD=$(LIBH5_HL) $(LIBH5F)
+libhdf5_hl_fortran_la_LIBADD=$(LIBH5_HL) $(LIBH5F)
 
 # The name of the lib file doesn't follow the same pattern as the other hl lib
 # files, namely libhdf5_hl_*.  Add a symlink with the compliant name to the
 # actual lib file.
 install-exec-hook:
 	cd $(DESTDIR)$(libdir) && \
-	    if test -f libhdf5hl_fortran.a -a \
-	    ! -f libhdf5_hl_fortran.a; then \
-	        $(LN_S) libhdf5hl_fortran.a libhdf5_hl_fortran.a; \
+	    if test -f libhdf_5hl_fortran.a -a \
+	    ! -f libhdf5hl_fortran.a; then \
+	        $(LN_S) libhdf5_hl_fortran.a libhdf5hl_fortran.a; \
 	    fi; \
-	    if test -f libhdf5hl_fortran.so -a \
-	    ! -f libhdf5_hl_fortran.so; then \
-	        $(LN_S) libhdf5hl_fortran.so libhdf5_hl_fortran.so; \
+	    if test -f libhdf5_hl_fortran.so -a \
+	    ! -f libhdf5hl_fortran.so; then \
+	        $(LN_S) libhdf5_hl_fortran.so libhdf5hl_fortran.so; \
 	    fi;
 
 

--- a/hl/fortran/src/Makefile.am
+++ b/hl/fortran/src/Makefile.am
@@ -54,7 +54,7 @@ libhdf5_hl_fortran_la_LIBADD=$(LIBH5_HL) $(LIBH5F)
 # actual lib file.
 install-exec-hook:
 	cd $(DESTDIR)$(libdir) && \
-	    if test -f libhdf_5hl_fortran.a -a \
+	    if test -f libhdf5_hl_fortran.a -a \
 	    ! -f libhdf5hl_fortran.a; then \
 	        $(LN_S) libhdf5_hl_fortran.a libhdf5hl_fortran.a; \
 	    fi; \

--- a/release_docs/RELEASE.txt
+++ b/release_docs/RELEASE.txt
@@ -1767,6 +1767,12 @@ Bug Fixes since HDF5-1.14.0 release
 
     Configuration
     -------------
+    - Changed name of libhdf5hl_fortran installed by autotools to libhdf5_hl_fortran.  The 
+      new name is consistent with the name of the lib when installed by CMake and with the 
+      other hl libs.  
+
+      Fixes GitHub issue #4811
+
     - Fixed usage issue with FindZLIB.cmake module
 
       When building HDF5 with CMake and relying on the FindZLIB.cmake module,


### PR DESCRIPTION
to libhdf5_hl_fortran to be consistent with CMake install and with other hl lib files.  Switched corresponding symlink to libhdf5hl_fortran.

Fixes issue #4684.