### PR TITLE
Update NVHPC optimization settings

### DIFF
--- a/config/cmake/HDFCompilerFlags.cmake
+++ b/config/cmake/HDFCompilerFlags.cmake
@@ -54,46 +54,8 @@ if (CMAKE_C_COMPILER_ID STREQUAL "NVHPC" )
       set (CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -s")
     endif ()
   else ()
-    set (CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Mbounds -g")
+    set (CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Mbounds -gopt")
   endif ()
-
-  # With at least NVHPC 23.5 - 23.9, compiling with -O2 or higher and -DNDEBUG
-  # appears to have issues that manifest in the tests as incorrect metadata
-  # checksums being read or memory being corrupted. Compiling without -DNDEBUG
-  # does not appear to have these issues, but is not ideal due to compiling in
-  # asserts and other library debug code. Compiling with -O1 also does not appear
-  # to have these issues, so set maximum optimization level to -O1 for now until
-  # it can be determined whether these issues are compiler-specific or issues
-  # in the library.
-  set (cmake_c_flags_minsizerel_edited "${CMAKE_C_FLAGS_MINSIZEREL}")
-  string (REPLACE "-O2" "" cmake_c_flags_minsizerel_edited "${cmake_c_flags_minsizerel_edited}")
-  string (REPLACE "-O3" "" cmake_c_flags_minsizerel_edited "${cmake_c_flags_minsizerel_edited}")
-  string (REPLACE "-O4" "" cmake_c_flags_minsizerel_edited "${cmake_c_flags_minsizerel_edited}")
-  string (REPLACE "-Ofast" "" cmake_c_flags_minsizerel_edited "${cmake_c_flags_minsizerel_edited}")
-  string (REPLACE "-fast" "" cmake_c_flags_minsizerel_edited "${cmake_c_flags_minsizerel_edited}")
-  string (STRIP "${cmake_c_flags_minsizerel_edited}" cmake_c_flags_minsizerel_edited)
-  string (PREPEND cmake_c_flags_minsizerel_edited "-O1 ")
-  set (CMAKE_C_FLAGS_MINSIZEREL "${cmake_c_flags_minsizerel_edited}")
-
-  set (cmake_c_flags_release_edited "${CMAKE_C_FLAGS_RELEASE}")
-  string (REPLACE "-O2" "" cmake_c_flags_release_edited "${cmake_c_flags_release_edited}")
-  string (REPLACE "-O3" "" cmake_c_flags_release_edited "${cmake_c_flags_release_edited}")
-  string (REPLACE "-O4" "" cmake_c_flags_release_edited "${cmake_c_flags_release_edited}")
-  string (REPLACE "-Ofast" "" cmake_c_flags_release_edited "${cmake_c_flags_release_edited}")
-  string (REPLACE "-fast" "" cmake_c_flags_release_edited "${cmake_c_flags_release_edited}")
-  string (STRIP "${cmake_c_flags_release_edited}" cmake_c_flags_release_edited)
-  string (PREPEND cmake_c_flags_release_edited "-O1 ")
-  set (CMAKE_C_FLAGS_RELEASE "${cmake_c_flags_release_edited}")
-
-  set (cmake_c_flags_relwithdebinfo_edited "${CMAKE_C_FLAGS_RELWITHDEBINFO}")
-  string (REPLACE "-O2" "" cmake_c_flags_relwithdebinfo_edited "${cmake_c_flags_relwithdebinfo_edited}")
-  string (REPLACE "-O3" "" cmake_c_flags_relwithdebinfo_edited "${cmake_c_flags_relwithdebinfo_edited}")
-  string (REPLACE "-O4" "" cmake_c_flags_relwithdebinfo_edited "${cmake_c_flags_relwithdebinfo_edited}")
-  string (REPLACE "-Ofast" "" cmake_c_flags_relwithdebinfo_edited "${cmake_c_flags_relwithdebinfo_edited}")
-  string (REPLACE "-fast" "" cmake_c_flags_relwithdebinfo_edited "${cmake_c_flags_relwithdebinfo_edited}")
-  string (STRIP "${cmake_c_flags_relwithdebinfo_edited}" cmake_c_flags_relwithdebinfo_edited)
-  string (PREPEND cmake_c_flags_relwithdebinfo_edited "-O1 ")
-  set (CMAKE_C_FLAGS_RELWITHDEBINFO "${cmake_c_flags_relwithdebinfo_edited}")
 endif ()
 
 if (CMAKE_C_COMPILER_ID STREQUAL "GNU")

--- a/config/nvidia-flags
+++ b/config/nvidia-flags
@@ -92,7 +92,7 @@ if test "X-nvc" = "X-$cc_vendor" -o "X-nvcc" = "X-$cc_vendor"; then
     ###########
 
     NO_SYMBOLS_CFLAGS="-s"
-    SYMBOLS_CFLAGS="-g"
+    SYMBOLS_CFLAGS="-gopt"
 
     #############
     # Profiling #
@@ -106,9 +106,8 @@ if test "X-nvc" = "X-$cc_vendor" -o "X-nvcc" = "X-$cc_vendor"; then
     # Optimization #
     ################
 
-    HIGH_OPT_CFLAGS="-O1"         # -O2+ currently has test failures.
-    #DEBUG_OPT_CFLAGS="-gopt -O2"
-    DEBUG_OPT_CFLAGS="-gopt -O1"  # -O2+ currently has test failures.
+    HIGH_OPT_CFLAGS="-O3"
+    DEBUG_OPT_CFLAGS="-O1"  # -O0 can be very slow
     NO_OPT_CFLAGS="-O0"
 
     #################


### PR DESCRIPTION
* Use -gopt in Autotools/CMake instead of -g
* Autotools uses -O3 for release, -O1 for debug
* CMake uses whatever the defaults are for the configuration
* Remove CMake optimization flag removal hack