### PR TITLE
Fix a bug in Subfiling VFD vector I/O setup

### DIFF
--- a/release_docs/RELEASE.txt
+++ b/release_docs/RELEASE.txt
@@ -823,6 +823,24 @@ Bug Fixes since HDF5-1.14.0 release
 ===================================
     Library
     -------
+    - Fixed a bug in the Subfiling VFD that could cause a buffer over-read
+      and memory allocation failures
+
+      When performing vector I/O with the Subfiling VFD, making use of the
+      vector I/O size extension functionality could cause the VFD to read
+      past the end of the "I/O sizes" array that is passed in. When an entry
+      in the "I/O sizes" array has the value 0 and that entry is at an array
+      index greater than 0, this signifies that the value in the preceding
+      array entry should be used for the rest of the I/O vectors, effectively
+      extending the last valid I/O size across the remaining entries. This
+      allows an application to save a bit on memory by passing in a smaller
+      "I/O sizes" array. The Subfiling VFD didn't implement a check for this
+      functionality in the portion of the code that generates I/O vectors,
+      causing it to read past the end of the "I/O sizes" array when it was
+      shorter than expected. This could also result in memory allocation
+      failures, as the nearby memory allocations are based off the values
+      read from that array, which could be uninitialized.
+
     - Fixed H5Rget_attr_name to return the length of the attribute's name
       without the null terminator
 


### PR DESCRIPTION
Fixes a bug where the vector I/O sizes weren't being extended when one of the entries in the array is 0. This caused an overread of the I/O sizes buffer and on some machines would cause a memory allocation failure due to the calculated I/O vector size being too large.