### PR TITLE
Fix memory leaks in ttsafe tests

### DIFF
--- a/test/ttsafe_attr_vlen.c
+++ b/test/ttsafe_attr_vlen.c
@@ -123,6 +123,7 @@ tts_attr_vlen_thread(void H5_ATTR_UNUSED *client_data)
     hid_t       fid  = H5I_INVALID_HID; /* File ID */
     hid_t       gid  = H5I_INVALID_HID; /* Group ID */
     hid_t       aid  = H5I_INVALID_HID; /* Attribute ID */
+    hid_t       asid = H5I_INVALID_HID; /* Dataspace ID for the attribute */
     hid_t       atid = H5I_INVALID_HID; /* Datatype ID for the attribute */
     char       *string_attr_check;      /* The attribute data being read */
     const char *string_attr = "2.0";    /* The expected attribute data */
@@ -144,6 +145,10 @@ tts_attr_vlen_thread(void H5_ATTR_UNUSED *client_data)
     atid = H5Aget_type(aid);
     CHECK(atid, H5I_INVALID_HID, "H5Aget_type");
 
+    /* Get the dataspace for the attribute */
+    asid = H5Aget_space(aid);
+    CHECK(asid, H5I_INVALID_HID, "H5Aget_space");
+
     /* Read the attribute */
     ret = H5Aread(aid, atid, &string_attr_check);
     CHECK(ret, FAIL, "H5Aclose");
@@ -151,8 +156,15 @@ tts_attr_vlen_thread(void H5_ATTR_UNUSED *client_data)
     /* Verify the attribute data is as expected */
     VERIFY_STR(string_attr_check, string_attr, "H5Aread");
 
+    /* Free the attribute data */
+    ret = H5Dvlen_reclaim(atid, asid, H5P_DEFAULT, &string_attr_check);
+    CHECK(ret, FAIL, "H5Dvlen_reclaim");
+
     /* Close IDs */
     ret = H5Aclose(aid);
+    CHECK(ret, FAIL, "H5Aclose");
+
+    ret = H5Sclose(asid);
     CHECK(ret, FAIL, "H5Aclose");
 
     ret = H5Gclose(gid);


### PR DESCRIPTION
Valgrind still reports possibly lost memory in `tts_error()/tts_dcreate()`:

```
==3035271== 352 bytes in 1 blocks are possibly lost in loss record 2 of 3
==3035271==    at 0x484DA83: calloc (in /usr/libexec/valgrind/vgpreload_memcheck-amd64-linux.so)
==3035271==    by 0x40147D9: calloc (rtld-malloc.h:44)
==3035271==    by 0x40147D9: allocate_dtv (dl-tls.c:375)
==3035271==    by 0x40147D9: _dl_allocate_tls (dl-tls.c:634)
==3035271==    by 0x52A07B4: allocate_stack (allocatestack.c:430)
==3035271==    by 0x52A07B4: pthread_create@@GLIBC_2.34 (pthread_create.c:647)
==3035271==    by 0x4FC9C33: H5TS_thread_create (H5TSthread.c:270)
==3035271==    by 0x1134E0: tts_error (ttsafe_error.c:122)
==3035271==    by 0x4867384: PerformTests (testframe.c:319)
==3035271==    by 0x10C3BF: main (ttsafe.c:178)
```

But I think it's spurious due to something about the order of valgrind's operations and can be ignored. I've verified that all the test threads are joined in each case, so I don't think the thread stack memory is actually leaked.