### PR TITLE
Fixes a segfault in h5dump

### DIFF
--- a/src/H5Bcache.c
+++ b/src/H5Bcache.c
@@ -182,7 +182,8 @@ H5B__cache_deserialize(const void *_image, size_t len, void *_udata, bool H5_ATT
     /* Check in case of level is corrupted, it is unreasonable for level to be
        larger than the number of entries */
     if (bt->level > bt->nchildren)
-        HGOTO_ERROR(H5E_BTREE, H5E_BADVALUE, NULL, "level cannot be greater than the number of children, possibly corrupted");
+        HGOTO_ERROR(H5E_BTREE, H5E_BADVALUE, NULL,
+                    "level cannot be greater than the number of children, possibly corrupted");
 
     /* Sibling pointers */
     if (H5_IS_BUFFER_OVERFLOW(image, H5F_sizeof_addr(udata->f), p_end))

--- a/src/H5Bcache.c
+++ b/src/H5Bcache.c
@@ -179,6 +179,11 @@ H5B__cache_deserialize(const void *_image, size_t len, void *_udata, bool H5_ATT
     if (bt->nchildren > shared->two_k)
         HGOTO_ERROR(H5E_BTREE, H5E_BADVALUE, NULL, "number of children is greater than maximum");
 
+    /* Check in case of level is corrupted, it is unreasonable for level to be
+       larger than the number of entries */
+    if (bt->level > bt->nchildren)
+        HGOTO_ERROR(H5E_BTREE, H5E_BADVALUE, NULL, "level cannot be greater than the number of children, possibly corrupted");
+
     /* Sibling pointers */
     if (H5_IS_BUFFER_OVERFLOW(image, H5F_sizeof_addr(udata->f), p_end))
         HGOTO_ERROR(H5E_BTREE, H5E_OVERFLOW, NULL, "ran off end of input buffer while decoding");


### PR DESCRIPTION
h5dump produced a segfault on a mal-formed file because a B-tree node level was corrupted.
This PR adds a check to detect when the node level is greater than the number of entries and to issue an error instead.

Fixes GH-4432