### PR TITLE
Fix an incorrect returned value by H5LTfind_dataset()

### DIFF
--- a/hl/src/H5LT.c
+++ b/hl/src/H5LT.c
@@ -1228,7 +1228,7 @@ find_dataset(H5_ATTR_UNUSED hid_t loc_id, const char *name, H5_ATTR_UNUSED const
      * cause the iterator to immediately return that positive value,
      * indicating short-circuit success
      */
-    if (strncmp(name, (char *)op_data, strlen((char *)op_data)) == 0)
+    if (strcmp(name, (char *)op_data) == 0)
         ret = 1;
 
     return ret;

--- a/hl/test/test_ds.c
+++ b/hl/test/test_ds.c
@@ -1341,10 +1341,11 @@ out:
 static int
 test_char_attachscales(const char *fileext)
 {
-    hid_t fid = -1;
-    hid_t did = -1;
-    char  dsname[32];
-    char  scalename[32];
+    hid_t  fid = -1;
+    hid_t  did = -1;
+    char   dsname[32];
+    char   scalename[32];
+    herr_t ds_existed = 0;
 
     snprintf(dsname, sizeof(dsname), "%s%s", DATASET_NAME, "ac");
 
@@ -1356,6 +1357,14 @@ test_char_attachscales(const char *fileext)
     /* make a dataset */
     if (create_char_dataset(fid, "ac", 0) < 0)
         goto out;
+
+    /* test finding dataset dsname */
+    if ((ds_existed = H5LTfind_dataset(fid, dsname)) < 0)
+        goto out;
+    if (ds_existed == 0) {
+        printf("Unexpected result: Dataset \"%s\" does exist\n", dsname);
+        goto out;
+    }
 
     if ((did = H5Dopen2(fid, dsname, H5P_DEFAULT)) >= 0) {
         snprintf(scalename, sizeof(scalename), "%s%s", DS_1_NAME, "ac");

--- a/hl/test/test_lite.c
+++ b/hl/test/test_lite.c
@@ -30,7 +30,7 @@
 #define DSET7_NAME "dataset string"
 
 /* Name of a non-existing dataset, do not create a dataset with this name */
-#define NODS_NAME  "dataset"
+#define NODS_NAME "dataset"
 
 #define DIM 6
 
@@ -63,7 +63,7 @@ test_dsets(void)
     hsize_t     dims[2] = {2, 3};
     hid_t       file_id;
     hid_t       dataset_id;
-    herr_t      ds_existed = 0; /* whether searched ds exists */
+    herr_t      ds_existed        = 0; /* whether searched ds exists */
     char        data_char_in[DIM] = {1, 2, 3, 4, 5, 6};
     char        data_char_out[DIM];
     short       data_short_in[DIM] = {1, 2, 3, 4, 5, 6};

--- a/hl/test/test_lite.c
+++ b/hl/test/test_lite.c
@@ -29,6 +29,9 @@
 #define DSET6_NAME "dataset double"
 #define DSET7_NAME "dataset string"
 
+/* Name of a non-existing dataset, do not create a dataset with this name */
+#define NODS_NAME  "dataset"
+
 #define DIM 6
 
 #define ATTR_NAME_SUB "att"
@@ -60,6 +63,7 @@ test_dsets(void)
     hsize_t     dims[2] = {2, 3};
     hid_t       file_id;
     hid_t       dataset_id;
+    herr_t      ds_existed = 0; /* whether searched ds exists */
     char        data_char_in[DIM] = {1, 2, 3, 4, 5, 6};
     char        data_char_out[DIM];
     short       data_short_in[DIM] = {1, 2, 3, 4, 5, 6};
@@ -347,6 +351,23 @@ test_dsets(void)
 
     if (strcmp(data_string_in, data_string_out) != 0)
         goto out;
+
+    PASSED();
+
+    /*-------------------------------------------------------------------------
+     * H5LTfind_dataset test
+     *-------------------------------------------------------------------------
+     */
+
+    HL_TESTING2("H5LTfind_dataset");
+
+    /* Try to find a non-existing ds whose name matches existing datasets partially */
+    if ((ds_existed = H5LTfind_dataset(file_id, NODS_NAME)) < 0)
+        goto out;
+    if (ds_existed > 0) {
+        printf("Dataset \"%s\" does not exist.\n", NODS_NAME);
+        goto out;
+    }
 
     /*-------------------------------------------------------------------------
      * end tests
@@ -1075,7 +1096,7 @@ test_integers(void)
     char  *dt_str;
     size_t str_len;
 
-    HL_TESTING3("\n        text for integer types");
+    HL_TESTING3("        text for integer types");
 
     if ((dtype = H5LTtext_to_dtype("H5T_NATIVE_INT\n", H5LT_DDL)) < 0)
         goto out;
@@ -1881,6 +1902,7 @@ test_text_dtype(void)
 {
     HL_TESTING2("H5LTtext_to_dtype");
 
+    printf("\n");
     if (test_integers() < 0)
         goto out;
 

--- a/release_docs/RELEASE.txt
+++ b/release_docs/RELEASE.txt
@@ -829,6 +829,54 @@ Bug Fixes since HDF5-1.14.0 release
 ===================================
     Library
     -------
+    - Fixed an incorrect returned value by H5LTfind_dataset()
+
+      H5LTfind_dataset() returned true for non-existing datasets because it only
+      compared up to the length of the searched string, such as "Day" vs "DayNight".
+      Applied the user's patch to correct this behavior.
+
+      Fixes GitHub #4780
+
+    - Fixed a segfault by H5Gmove2, extending to H5Lcopy and H5Lmove
+
+      A user's application segfaulted when it passed in an invalid location ID
+      to H5Gmove2.  The src and dst location IDs must be either a file or a group
+      ID.  The fix was also applied to H5Lcopy and H5Lmove.  Now, all these
+      three functions will fail if either the src or dst location ID is not a file
+      or a group ID.
+
+      Fixes GitHub #4737
+
+    - Fixed a segfault by H5Lget_info()
+
+      A user's program generated a segfault when the ID passed into H5Lget_info()
+      was a datatype ID.  This was caused by non-VOL functions being used internally
+      where VOL functions should have been.  This correction was extended to many
+      other functions to prevent potential issue in the future.
+
+      Fixes GitHub #4730
+
+    - Fixed a segfault by H5Fget_intent(), extending to several other functions
+
+      A user's program generated a segfault when the ID passed into H5Fget_intent()
+      was not a file ID.  In addition to H5Fget_intent(), a number of APIs also failed
+      to detect an incorrect ID being passed in, which can potentially cause various
+      failures, including segfault.  The affected functions are listed below and now
+      properly detect incorrect ID parameters:
+
+        H5Fget_intent()
+        H5Fget_fileno()
+        H5Fget_freespace()
+        H5Fget_create_plist()
+        H5Fget_access_plist()
+        H5Fget_vfd_handle()
+        H5Dvlen_get_buf_size()
+        H5Fget_mdc_config()
+        H5Fset_mdc_config()
+        H5Freset_mdc_hit_rate_stats()
+
+      Fixes GitHub #4656 and GitHub #4662
+
     - Fixed a bug with large external datasets
 
       When performing a large I/O on an external dataset, the library would only
@@ -866,8 +914,20 @@ Bug Fixes since HDF5-1.14.0 release
       H5Rget_file_name and H5Rget_obj_name both return the name's length
       without the null terminator.  H5Rget_attr_name now behaves consistently
       with the other two APIs.  Going forward, all the get character string
-      APIs in HDF5 will be modified/written in this manner, regarding the
+      APIs in HDF5 will be modified/written in this manner regarding the
       length of a character string.
+
+      Fixes GitHub #4447
+
+    - Fixed heap-buffer-overflow in h5dump
+
+      h5dump aborted when provided with a malformed input file.  The was because
+      the buffer size for checksum was smaller than H5_SIZEOF_CHKSUM, causing
+      an overflow while calculating the offset to the checksum in the buffer.
+      A check was added so H5F_get_checksums would fail appropriately in all
+      of its occurrences.
+
+      Fixes GitHub #4434
 
     - Fixed library to allow usage of page buffering feature for serial file
       access with parallel builds of HDF5


### PR DESCRIPTION
H5LTfind_dataset() returns true for non-existing datasets because it only compares up to the length of the searched string, such as "Day" vs "DayNight" (issue GH-4780).

This PR applied the user's patch and added missing test for H5LTfind_dataset().