### PR TITLE
Remove Windows oneAPI warning for %ld formatting

### DIFF
--- a/tools/src/h5repack/h5repack.c
+++ b/tools/src/h5repack/h5repack.c
@@ -752,7 +752,7 @@ check_options(pack_opt_t *options)
 
     if (options->ublock_filename == NULL && options->ublock_size != 0) {
         if (options->verbose > 0) {
-            printf("Warning: user block file name missing. Reserving a size of %ld...\n",
+            printf("Warning: user block file name missing. Reserving a size of %" PRIuHSIZE "...\n",
                    options->ublock_size);
         }
     }


### PR DESCRIPTION
 ```
  755 |             printf("Warning: user block file name missing. Reserving a size of %ld...\n",
      |                                                                                ~~~
      |                                                                                %llu
  756 |                    options->ublock_size);
      |                    ^~~~~~~~~~~~~~~~~~~~
 ```