### PR TITLE
Remove Windows oneAPI warning for unused function in t_mpi.c

### DIFF
--- a/testpar/t_mpi.c
+++ b/testpar/t_mpi.c
@@ -175,6 +175,8 @@ test_mpio_overlap_writes(char *filename)
 #define GB            1073741824  /* 1024**3 == 2**30 */
 #define TWO_GB_LESS1  2147483647  /* 2**31 - 1 */
 #define FOUR_GB_LESS1 4294967295L /* 2**32 - 1 */
+
+#ifndef H5_HAVE_WIN32_API
 /*
  * Verify that MPI_Offset exceeding 2**31 can be computed correctly.
  * Print any failure as information only, not as an error so that this
@@ -409,6 +411,7 @@ finish:
         free(buf);
     return (nerrs);
 }
+#endif
 
 /*
  * MPI-IO Test: One writes, Many reads.


### PR DESCRIPTION
```
 C:\hdf5\testpar\t_mpi.c(190,1): warning: unused function 'test_mpio_gb_file' [-Wunused-function]
```