### PR TITLE
Minor refactoring of testframe.c testing framework

### DIFF
--- a/c++/test/testhdf5.cpp
+++ b/c++/test/testhdf5.cpp
@@ -32,8 +32,6 @@
         PerformTests() -- Perform requested testing
         GetTestSummary() -- Retrieve Summary request value
         TestSummary() -- Display test summary
-        GetTestCleanup() -- Retrieve Cleanup request value
-        TestCleanup() -- Clean up files from testing
         GetTestNumErrs() -- Retrieve the number of testing errors
 
  ***************************************************************************/
@@ -57,7 +55,7 @@ main(int argc, char *argv[])
         // caused deliberately and expected.
         Exception::dontPrint();
         /* Initialize testing framework */
-        TestInit(argv[0], NULL, NULL, 0);
+        TestInit(argv[0], NULL, NULL, NULL, NULL, 0);
 
         // testing file creation and opening in tfile.cpp
         AddTest("tfile", test_file, NULL, cleanup_file, NULL, 0, "File I/O Operations");
@@ -111,10 +109,6 @@ main(int argc, char *argv[])
     /* Display test summary, if requested */
     if (GetTestSummary())
         TestSummary(stdout);
-
-    /* Clean up test files, if allowed */
-    if (GetTestCleanup() && !getenv(HDF5_NOCLEANUP))
-        TestCleanup();
 
     /* Release test infrastructure */
     TestShutdown();

--- a/test/testframe.h
+++ b/test/testframe.h
@@ -137,6 +137,11 @@ extern "C" {
  * \param[in]  TestPrivateParser Pointer to a function which parses
  *                               command-line arguments which are specific to
  *                               the test program
+ * \param[in]  TestSetupFunc     Pointer to a function which will be called
+ *                               as part of TestInit()
+ * \param[in]  TestCleanupFunc   Pointer to a function which will be called
+ *                               when the testing framework is being shut
+ *                               down
  * \param[in]  TestProcessID     ID for the process calling TestInit(). Used
  *                               to control printing of output in parallel
  *                               test programs.
@@ -167,6 +172,18 @@ extern "C" {
  *          standard list of arguments it recognizes. \p TestPrivateParser
  *          may be NULL.
  *
+ *          \p TestSetupFunc is a pointer to a function that can be used to
+ *          setup any state needed before tests begin executing. If provided,
+ *          this callback function will be called as part of TestInit() once
+ *          the testing framework has been fully initialized. \p TestSetupFunc
+ *          may be NULL.
+ *
+ *          \p TestCleanupFunc is a pointer to a function that can be used
+ *          to clean up any state after tests have finished executing. If
+ *          provided, this callback function will be called by TestShutdown()
+ *          before the testing framework starts being shut down.
+ *          \p TestCleanupFunc may be NULL.
+ *
  *          \p TestProcessID is an integer value that is used to distinguish
  *          between processes when multiple are involved in running a test
  *          program. This is primarily useful for controlling testing
@@ -180,7 +197,8 @@ extern "C" {
  *
  */
 H5TEST_DLL herr_t TestInit(const char *ProgName, void (*TestPrivateUsage)(FILE *stream),
-                           int (*TestPrivateParser)(int argc, char *argv[]), int TestProcessID);
+                           int (*TestPrivateParser)(int argc, char *argv[]), herr_t (*TestSetupFunc)(void),
+                           herr_t (*TestCleanupFunc)(void), int TestProcessID);
 
 /**
  * --------------------------------------------------------------------------
@@ -188,7 +206,7 @@ H5TEST_DLL herr_t TestInit(const char *ProgName, void (*TestPrivateUsage)(FILE *
  *
  * \brief Shuts down the testing framework
  *
- * \return void
+ * \return \herr_t
  *
  * \details TestShutdown() shuts down the testing framework by tearing down
  *          the internal state needed for running tests and freeing any
@@ -199,7 +217,7 @@ H5TEST_DLL herr_t TestInit(const char *ProgName, void (*TestPrivateUsage)(FILE *
  * \see TestInit()
  *
  */
-H5TEST_DLL void TestShutdown(void);
+H5TEST_DLL herr_t TestShutdown(void);
 
 /**
  * --------------------------------------------------------------------------
@@ -366,7 +384,7 @@ H5TEST_DLL herr_t TestParseCmdLine(int argc, char *argv[]);
  * \brief Executes all tests added by AddTest() that aren't flagged to be
  *        skipped
  *
- * \return void
+ * \return \herr_t
  *
  * \details PerformTests() runs all tests that aren't flagged to be skipped
  *          in the order added by calls to AddTest(). For each test, the
@@ -380,7 +398,7 @@ H5TEST_DLL herr_t TestParseCmdLine(int argc, char *argv[]);
  * \see AddTest(), TestAlarmOn()
  *
  */
-H5TEST_DLL void PerformTests(void);
+H5TEST_DLL herr_t PerformTests(void);
 
 /**
  * --------------------------------------------------------------------------
@@ -403,24 +421,6 @@ H5TEST_DLL void PerformTests(void);
  *
  */
 H5TEST_DLL void TestSummary(FILE *stream);
-
-/**
- * --------------------------------------------------------------------------
- * \ingroup H5TEST
- *
- * \brief Calls the 'cleanup' callback for each test added to the list of
- *        tests
- *
- * \return void
- *
- * \details TestCleanup() performs cleanup by calling the 'cleanup' callback
- *          for each test added to the lists of tests, as long as the test
- *          isn't flagged to be skipped.
- *
- * \see SetTestCleanup()
- *
- */
-H5TEST_DLL void TestCleanup(void);
 
 /**
  * --------------------------------------------------------------------------

--- a/test/testhdf5.c
+++ b/test/testhdf5.c
@@ -47,7 +47,7 @@ main(int argc, char *argv[])
     H5Pclose(fapl_id);
 
     /* Initialize testing framework */
-    if (TestInit(argv[0], NULL, NULL, 0) < 0) {
+    if (TestInit(argv[0], NULL, NULL, NULL, NULL, 0) < 0) {
         fprintf(stderr, "couldn't initialize testing framework\n");
         exit(EXIT_FAILURE);
     }
@@ -90,18 +90,21 @@ main(int argc, char *argv[])
     }
 
     /* Perform requested testing */
-    PerformTests();
+    if (PerformTests() < 0) {
+        fprintf(stderr, "couldn't run tests\n");
+        TestShutdown();
+        exit(EXIT_FAILURE);
+    }
 
     /* Display test summary, if requested */
     if (GetTestSummary())
         TestSummary(stdout);
 
-    /* Clean up test files, if allowed */
-    if (GetTestCleanup() && !getenv(HDF5_NOCLEANUP))
-        TestCleanup();
-
     /* Release test infrastructure */
-    TestShutdown();
+    if (TestShutdown() < 0) {
+        fprintf(stderr, "couldn't shut down testing framework\n");
+        exit(EXIT_FAILURE);
+    }
 
     /* Exit failure if errors encountered; else exit success. */
     /* No need to print anything since PerformTests() already does. */

--- a/test/ttsafe.c
+++ b/test/ttsafe.c
@@ -97,7 +97,7 @@ main(int argc, char *argv[])
 {
 
     /* Initialize testing framework */
-    if (TestInit(argv[0], NULL, NULL, 0) < 0) {
+    if (TestInit(argv[0], NULL, NULL, NULL, NULL, 0) < 0) {
         fprintf(stderr, "couldn't initialize testing framework\n");
         return -1;
     }
@@ -184,18 +184,21 @@ main(int argc, char *argv[])
     }
 
     /* Perform requested testing */
-    PerformTests();
+    if (PerformTests() < 0) {
+        fprintf(stderr, "couldn't run tests\n");
+        TestShutdown();
+        return -1;
+    }
 
     /* Display test summary, if requested */
     if (GetTestSummary())
         TestSummary(stdout);
 
-    /* Clean up test files, if allowed */
-    if (GetTestCleanup() && !getenv(HDF5_NOCLEANUP))
-        TestCleanup();
-
     /* Release test infrastructure */
-    TestShutdown();
+    if (TestShutdown() < 0) {
+        fprintf(stderr, "couldn't shut down testing framework\n");
+        return -1;
+    }
 
     return GetTestNumErrs();
 

--- a/testpar/t_shapesame.c
+++ b/testpar/t_shapesame.c
@@ -4335,7 +4335,7 @@ main(int argc, char **argv)
     }
 
     /* Initialize testing framework */
-    if (TestInit(argv[0], usage, parse_options, mpi_rank) < 0) {
+    if (TestInit(argv[0], usage, parse_options, NULL, NULL, mpi_rank) < 0) {
         if (MAINPROCESS) {
             fprintf(stderr, "couldn't initialize testing framework\n");
             fflush(stderr);
@@ -4388,7 +4388,12 @@ main(int argc, char **argv)
     }
 
     /* Perform requested testing */
-    PerformTests();
+    if (PerformTests() < 0) {
+        if (MAINPROCESS)
+            fprintf(stderr, "couldn't run tests\n");
+        TestShutdown();
+        MPI_Abort(MPI_COMM_WORLD, -1);
+    }
 
     /* make sure all processes are finished before final report, cleanup
      * and exit.
@@ -4430,7 +4435,11 @@ main(int argc, char **argv)
     H5close();
 
     /* Release test infrastructure */
-    TestShutdown();
+    if (TestShutdown() < 0) {
+        if (MAINPROCESS)
+            fprintf(stderr, "couldn't shut down testing framework\n");
+        MPI_Abort(MPI_COMM_WORLD, -1);
+    }
 
     MPI_Finalize();
 


### PR DESCRIPTION
Added setup and cleanup callback parameters to TestInit() to perform setup and cleanup tasks once for whole test program

Removed TestCleanup() function since its functionality is covered by PerformTests()

Added check of the HDF5_NOCLEANUP environment variable in GetTestCleanup()