### PR TITLE
Fix for issue #4849 that settings in fapl libver bounds causes unexpe…

### DIFF
--- a/c++/test/tfile.cpp
+++ b/c++/test/tfile.cpp
@@ -759,7 +759,7 @@ test_libver_bounds()
 
     /* Run the tests */
     test_libver_bounds_real(H5F_LIBVER_EARLIEST, H5O_VERSION_1, H5F_LIBVER_LATEST, H5O_VERSION_2);
-    test_libver_bounds_real(H5F_LIBVER_LATEST, H5O_VERSION_2, H5F_LIBVER_EARLIEST, H5O_VERSION_2);
+    test_libver_bounds_real(H5F_LIBVER_LATEST, H5O_VERSION_2, H5F_LIBVER_EARLIEST, H5O_VERSION_1);
     PASSED();
 } /* end test_libver_bounds() */
 

--- a/src/H5Fint.c
+++ b/src/H5Fint.c
@@ -3181,7 +3181,8 @@ H5F__set_libver_bounds(H5F_t *f, H5F_libver_t low, H5F_libver_t high)
     assert(f->shared);
 
     /* Set the bounds only if the existing setting is different from the inputs */
-    if (f->shared->low_bound != low || f->shared->high_bound != high) {
+    if ((f->shared->low_bound != low || f->shared->high_bound != high) &&
+        !(H5F_INTENT(f) & H5F_ACC_SWMR_WRITE)) {
         /* Call the flush routine, for this file */
         /* Note: This is done in case the binary format for representing a
          *      metadata entry class changes when the file format low / high
@@ -3704,6 +3705,7 @@ done:
  *                  --only allow datasets and groups without attributes
  *                  --disallow named datatype with/without attributes
  *                  --disallow opened attributes attached to objects
+ *                  --disallow opened objects below 1.10
  *
  * NOTE:        Currently, only opened groups and datasets are allowed
  *              when enabling SWMR via H5Fstart_swmr_write().
@@ -3746,7 +3748,7 @@ H5F__start_swmr_write(H5F_t *f)
     if (f->shared->sblock->super_vers < HDF5_SUPERBLOCK_VERSION_3)
         HGOTO_ERROR(H5E_FILE, H5E_BADVALUE, FAIL, "file superblock version - should be at least 3");
 
-    /* Check for correct file format version */
+    /* Check for correct file format version to start SWMR writing */
     if ((f->shared->low_bound < H5F_LIBVER_V110) || (f->shared->high_bound < H5F_LIBVER_V110))
         HGOTO_ERROR(H5E_FILE, H5E_BADVALUE, FAIL,
                     "file format version does not support SWMR - needs to be 1.10 or greater");
@@ -3783,6 +3785,31 @@ H5F__start_swmr_write(H5F_t *f)
         /* Allocate space for group and object locations */
         if ((obj_ids = (hid_t *)H5MM_malloc(grp_dset_count * sizeof(hid_t))) == NULL)
             HGOTO_ERROR(H5E_FILE, H5E_CANTALLOC, FAIL, "can't allocate buffer for hid_t");
+
+        /* Get the list of opened object ids (groups & datasets) */
+        if (H5F_get_obj_ids(f, H5F_OBJ_GROUP | H5F_OBJ_DATASET, grp_dset_count, obj_ids, false,
+                            &grp_dset_count) < 0)
+            HGOTO_ERROR(H5E_FILE, H5E_CANTGET, FAIL, "H5F_get_obj_ids failed");
+
+        /* Ensure that there's no old-style opened objects */
+        for (u = 0; u < grp_dset_count; u++) {
+            H5O_native_info_t  ninfo;
+            H5O_loc_t *oloc;
+            uint8_t version;
+
+            if (NULL == (oloc = H5O_get_loc(obj_ids[u])))
+                HGOTO_ERROR(H5E_SYM, H5E_NOTFOUND, FAIL, "object not found");
+
+            if (H5O_get_native_info(oloc, &ninfo, H5O_NATIVE_INFO_HDR) < 0)
+                HGOTO_ERROR(H5E_FILE, H5E_CANTGET, FAIL, "H5O_get_native__info failed");
+
+            if (H5O_get_version_bound(f->shared->low_bound, &version) < 0)
+                HGOTO_ERROR(H5E_FILE, H5E_CANTGET, FAIL, "H5O_get_version_bound failed");
+
+            if (ninfo.hdr.version < version)
+                HGOTO_ERROR(H5E_FILE, H5E_BADVALUE, FAIL, "disallow opened objects below 1.10");
+        }
+
         if ((obj_glocs = (H5G_loc_t *)H5MM_malloc(grp_dset_count * sizeof(H5G_loc_t))) == NULL)
             HGOTO_ERROR(H5E_FILE, H5E_CANTALLOC, FAIL, "can't allocate buffer for object group locations");
         if ((obj_olocs = (H5O_loc_t *)H5MM_malloc(grp_dset_count * sizeof(H5O_loc_t))) == NULL)
@@ -3796,11 +3823,6 @@ H5F__start_swmr_write(H5F_t *f)
         if ((obj_apl_ids = (hid_t *)H5MM_calloc(grp_dset_count * sizeof(hid_t))) == NULL)
             HGOTO_ERROR(H5E_FILE, H5E_CANTALLOC, FAIL, "can't allocate buffer for hid_t");
         assert(obj_apl_ids[0] == H5P_DEFAULT);
-
-        /* Get the list of opened object ids (groups & datasets) */
-        if (H5F_get_obj_ids(f, H5F_OBJ_GROUP | H5F_OBJ_DATASET, grp_dset_count, obj_ids, false,
-                            &grp_dset_count) < 0)
-            HGOTO_ERROR(H5E_FILE, H5E_CANTGET, FAIL, "H5F_get_obj_ids failed");
 
         /* Save the VOL connector and the object wrapping context for the refresh step */
         if (grp_dset_count > 0) {
@@ -3923,6 +3945,7 @@ H5F__start_swmr_write(H5F_t *f)
             HGOTO_ERROR(H5E_FILE, H5E_CANTLOCKFILE, FAIL, "unable to lock the file");
         }
     }
+
 
     /* Mark superblock as dirty */
     if (H5F_super_dirty(f) < 0)

--- a/src/H5Fint.c
+++ b/src/H5Fint.c
@@ -3793,9 +3793,9 @@ H5F__start_swmr_write(H5F_t *f)
 
         /* Ensure that there's no old-style opened objects */
         for (u = 0; u < grp_dset_count; u++) {
-            H5O_native_info_t  ninfo;
-            H5O_loc_t *oloc;
-            uint8_t version;
+            H5O_native_info_t ninfo;
+            H5O_loc_t        *oloc;
+            uint8_t           version;
 
             if (NULL == (oloc = H5O_get_loc(obj_ids[u])))
                 HGOTO_ERROR(H5E_SYM, H5E_NOTFOUND, FAIL, "object not found");
@@ -3945,7 +3945,6 @@ H5F__start_swmr_write(H5F_t *f)
             HGOTO_ERROR(H5E_FILE, H5E_CANTLOCKFILE, FAIL, "unable to lock the file");
         }
     }
-
 
     /* Mark superblock as dirty */
     if (H5F_super_dirty(f) < 0)

--- a/src/H5Fint.c
+++ b/src/H5Fint.c
@@ -3798,13 +3798,13 @@ H5F__start_swmr_write(H5F_t *f)
             uint8_t           version;
 
             if (NULL == (oloc = H5O_get_loc(obj_ids[u])))
-                HGOTO_ERROR(H5E_SYM, H5E_NOTFOUND, FAIL, "object not found");
+                HGOTO_ERROR(H5E_FILE, H5E_CANTGET, FAIL, "H5O_get_loc() failed");
 
             if (H5O_get_native_info(oloc, &ninfo, H5O_NATIVE_INFO_HDR) < 0)
-                HGOTO_ERROR(H5E_FILE, H5E_CANTGET, FAIL, "H5O_get_native__info failed");
+                HGOTO_ERROR(H5E_FILE, H5E_CANTGET, FAIL, "H5O_get_native_info() failed");
 
             if (H5O_get_version_bound(f->shared->low_bound, &version) < 0)
-                HGOTO_ERROR(H5E_FILE, H5E_CANTGET, FAIL, "H5O_get_version_bound failed");
+                HGOTO_ERROR(H5E_FILE, H5E_CANTGET, FAIL, "H5O_get_version_bound() failed");
 
             if (ninfo.hdr.version < version)
                 HGOTO_ERROR(H5E_FILE, H5E_BADVALUE, FAIL, "disallow opened objects below 1.10");

--- a/src/H5Oint.c
+++ b/src/H5Oint.c
@@ -2960,7 +2960,6 @@ H5O_has_chksum(const H5O_t *oh)
     FUNC_LEAVE_NOAPI(H5O_SIZEOF_CHKSUM_OH(oh) > 0)
 } /* end H5O_has_chksum() */
 
-
 /*-------------------------------------------------------------------------
  * Function:    H5O_get_version_bound
  *

--- a/src/H5Oint.c
+++ b/src/H5Oint.c
@@ -2959,3 +2959,21 @@ H5O_has_chksum(const H5O_t *oh)
 
     FUNC_LEAVE_NOAPI(H5O_SIZEOF_CHKSUM_OH(oh) > 0)
 } /* end H5O_has_chksum() */
+
+
+/*-------------------------------------------------------------------------
+ * Function:    H5O_get_version_bound
+ *
+ * Purpose:     Retrieve the version for a given bound from object version array
+ *
+ *-------------------------------------------------------------------------
+ */
+herr_t
+H5O_get_version_bound(H5F_libver_t bound, uint8_t *version)
+{
+    FUNC_ENTER_NOAPI_NOINIT_NOERR
+
+    *version = (uint8_t)H5O_obj_ver_bounds[bound];
+
+    FUNC_LEAVE_NOAPI(SUCCEED)
+} /* end H5O_get_version_bound() */

--- a/src/H5Oprivate.h
+++ b/src/H5Oprivate.h
@@ -933,6 +933,7 @@ H5_DLL uint8_t H5O_get_oh_version(const H5O_t *oh);
 H5_DLL herr_t  H5O_get_rc_and_type(const H5O_loc_t *oloc, unsigned *rc, H5O_type_t *otype);
 H5_DLL H5AC_proxy_entry_t *H5O_get_proxy(const H5O_t *oh);
 H5_DLL bool                H5O_has_chksum(const H5O_t *oh);
+H5_DLL herr_t H5O_get_version_bound(H5F_libver_t bound, uint8_t *version);
 
 /* Object header message routines */
 H5_DLL herr_t H5O_msg_create(const H5O_loc_t *loc, unsigned type_id, unsigned mesg_flags,

--- a/src/H5Oprivate.h
+++ b/src/H5Oprivate.h
@@ -933,7 +933,7 @@ H5_DLL uint8_t H5O_get_oh_version(const H5O_t *oh);
 H5_DLL herr_t  H5O_get_rc_and_type(const H5O_loc_t *oloc, unsigned *rc, H5O_type_t *otype);
 H5_DLL H5AC_proxy_entry_t *H5O_get_proxy(const H5O_t *oh);
 H5_DLL bool                H5O_has_chksum(const H5O_t *oh);
-H5_DLL herr_t H5O_get_version_bound(H5F_libver_t bound, uint8_t *version);
+H5_DLL herr_t              H5O_get_version_bound(H5F_libver_t bound, uint8_t *version);
 
 /* Object header message routines */
 H5_DLL herr_t H5O_msg_create(const H5O_loc_t *loc, unsigned type_id, unsigned mesg_flags,

--- a/test/swmr.c
+++ b/test/swmr.c
@@ -1555,7 +1555,7 @@ error:
  *      Close the file
  *
  *  (B) Open the file with write + non-latest-format (earliest, latest)
- *      --file has v3 superblock 
+ *      --file has v3 superblock
  *      Create a group in the file
  *      Create a chunked dataset "dataset2" in the group--keep it open
  *      Verify "dataset2" is using v1 btree indexing
@@ -1736,7 +1736,7 @@ test_start_swmr_write(hid_t in_fapl, bool new_format)
     if (H5Pclose(file_fapl) < 0)
         FAIL_STACK_ERROR;
 
-     /* Create a group */
+    /* Create a group */
     if ((gid = H5Gcreate2(fid, "group", H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT)) < 0)
         FAIL_STACK_ERROR;
 
@@ -1807,7 +1807,6 @@ test_start_swmr_write(hid_t in_fapl, bool new_format)
     if (H5Fclose(fid) < 0)
         TEST_ERROR;
 
-
     /*
      * Case D: when opening a file with (V110, latest)
      */
@@ -1839,7 +1838,6 @@ test_start_swmr_write(hid_t in_fapl, bool new_format)
         TEST_ERROR;
     if (H5Fclose(fid) < 0)
         TEST_ERROR;
-
 
     /*
      * Case E: when opening a file with (V110, latest)
@@ -2218,7 +2216,8 @@ test_err_start_swmr_write(hid_t in_fapl, bool new_format)
     if (new_format) {
         if (ret < 0)
             TEST_ERROR;
-    } else if (ret >= 0)
+    }
+    else if (ret >= 0)
         TEST_ERROR;
 
     /* Should fail for a second call to enable SWMR writing mode */
@@ -2250,9 +2249,10 @@ test_err_start_swmr_write(hid_t in_fapl, bool new_format)
     if (new_format) {
         if (ret < 0)
             TEST_ERROR;
-    } else if (ret >= 0)
+    }
+    else if (ret >= 0)
         TEST_ERROR;
-        
+
     /* Re-open the same file */
     if ((fid2 = H5Freopen(fid)) < 0)
         FAIL_STACK_ERROR;
@@ -2292,7 +2292,8 @@ test_err_start_swmr_write(hid_t in_fapl, bool new_format)
     if (new_format) {
         if (ret < 0)
             TEST_ERROR;
-    } else if (ret >= 0)
+    }
+    else if (ret >= 0)
         TEST_ERROR;
 
     /* Should fail to enable SWMR writing for fid2 */
@@ -2383,7 +2384,6 @@ test_err_start_swmr_write(hid_t in_fapl, bool new_format)
             FAIL_STACK_ERROR;
 
     } /* not new */
-
 
     /* Close the file access property list */
     if (H5Pclose(fapl) < 0)

--- a/test/swmr.c
+++ b/test/swmr.c
@@ -1554,20 +1554,26 @@ error:
  *      Should fail to enable SWMR as the file is already in SWMR writing mode
  *      Close the file
  *
- *  (B) Opening a file
- *      Open the file with write + non-latest-format
- *      --file has v3 superblock and all latest version support enabled
- *      Open dataset "dataset1" 3 times--keep it open
- *    Write to "dataset1"
- *    Create a group in the file
- *      Create a chunked dataset "dataset2" in the group--should be using latest chunk indexing--keep it open
- *      Should succeed in enabling SWMR
- *    Should succeed in reading from multiple opens of "dataset1"
- *      Close multiple opens of "dataset1"
- *    Close "dataset2"
- *      Create "dataset3"--should be using latest chunk indexing
- *      Close "dataset3"
- *      Close the group and file
+ *  (B) Open the file with write + non-latest-format (earliest, latest)
+ *      --file has v3 superblock 
+ *      Create a group in the file
+ *      Create a chunked dataset "dataset2" in the group--keep it open
+ *      Verify "dataset2" is using v1 btree indexing
+ *      Should fail to enable SWMR writing
+ *
+ *  (C) Open a file with write + non-latest format (V110, latest)
+ *      Open the old style group "/group/dataset2" in the file
+ *      Should fail to enable SWMR writing
+ *
+ *  (D) Open a file with write + non-latest format (V110, latest)
+ *      Open the old style group "/group"
+ *      Open the new style group "/dataset1" in the file
+ *      Should fail to enable SWMR writing
+ *
+ *  (E) Open a file with write + non-latest format (V110, latest)
+ *      Open the new style group "/dataset1" in the file
+ *      Should succeed to enable SWMR writing
+ *
  */
 static int
 test_start_swmr_write(hid_t in_fapl, bool new_format)
@@ -1707,11 +1713,11 @@ test_start_swmr_write(hid_t in_fapl, bool new_format)
         FAIL_STACK_ERROR;
 
     /*
-     * Case B: when opening a file
+     * Case B: when opening a file with (earliest, latest)
      */
 
-    /* Open the file again with write + non-latest-format */
-    if ((fid = H5Fopen(filename, H5F_ACC_RDWR, fapl)) < 0)
+    /* Open the file again with write + non-latest-format (earliest, latest) */
+    if ((fid = H5Fopen(filename, H5F_ACC_RDWR, H5P_DEFAULT)) < 0)
         FAIL_STACK_ERROR;
 
     /* Get the file's access_property list */
@@ -1730,24 +1736,7 @@ test_start_swmr_write(hid_t in_fapl, bool new_format)
     if (H5Pclose(file_fapl) < 0)
         FAIL_STACK_ERROR;
 
-    /* open "dataset1", keep it open */
-    if ((did1 = H5Dopen2(fid, "dataset1", H5P_DEFAULT)) < 0)
-        FAIL_STACK_ERROR;
-
-    /* open "dataset1" second time */
-    if ((did1_a = H5Dopen2(fid, "dataset1", H5P_DEFAULT)) < 0)
-        FAIL_STACK_ERROR;
-
-    /* open "dataset1" third time */
-    if ((did1_b = H5Dopen2(fid, "dataset1", H5P_DEFAULT)) < 0)
-        FAIL_STACK_ERROR;
-
-    /* Write to "dataset1" */
-    wdata = 88;
-    if (H5Dwrite(did1, H5T_NATIVE_INT, H5S_ALL, H5S_ALL, H5P_DEFAULT, &wdata) < 0)
-        FAIL_STACK_ERROR;
-
-    /* Create a group */
+     /* Create a group */
     if ((gid = H5Gcreate2(fid, "group", H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT)) < 0)
         FAIL_STACK_ERROR;
 
@@ -1764,99 +1753,114 @@ test_start_swmr_write(hid_t in_fapl, bool new_format)
     /* Get the chunk index type for "dataset2" */
     if (H5D__layout_idx_type_test(did2, &idx_type) < 0)
         FAIL_STACK_ERROR;
-    if (idx_type != H5D_CHUNK_IDX_BT2)
-        FAIL_PUTS_ERROR("should be using v2 B-tree chunk indexing");
+    if (idx_type != H5D_CHUNK_IDX_BTREE)
+        FAIL_PUTS_ERROR("should be using v1 B-tree chunk indexing");
+
+    /* Should fail in enabling SWMR writing since file is opened with (earliest/latest) */
+    H5E_BEGIN_TRY
+    {
+        ret = H5Fstart_swmr_write(fid);
+    }
+    H5E_END_TRY
+    if (ret >= 0)
+        TEST_ERROR;
+
+    if (H5Gclose(gid) < 0)
+        TEST_ERROR;
+    if (H5Dclose(did2) < 0)
+        TEST_ERROR;
+    if (H5Fclose(fid) < 0)
+        TEST_ERROR;
+
+    /*
+     * Case C: when opening a file with (V110, latest)
+     */
+
+    if (H5Pset_libver_bounds(fapl, H5F_LIBVER_V110, H5F_LIBVER_LATEST) < 0)
+        FAIL_STACK_ERROR;
+
+    /* Open the file again with write + non-latest-format (V110, latest) */
+    if ((fid = H5Fopen(filename, H5F_ACC_RDWR, fapl)) < 0)
+        FAIL_STACK_ERROR;
+
+    /* Open the old style dataset: /group/datset2 */
+    if ((did2 = H5Dopen2(fid, "/group/dataset2", H5P_DEFAULT)) < 0)
+        FAIL_STACK_ERROR;
+
+    /* Open the new style dataset */
+    if ((did1 = H5Dopen2(fid, "dataset1", H5P_DEFAULT)) < 0)
+        FAIL_STACK_ERROR;
+
+    /* Should fail in enabling SWMR writing since there are old style objects opened  */
+    H5E_BEGIN_TRY
+    {
+        ret = H5Fstart_swmr_write(fid);
+    }
+    H5E_END_TRY
+    if (ret >= 0)
+        TEST_ERROR;
+
+    if (H5Dclose(did2) < 0)
+        TEST_ERROR;
+    if (H5Dclose(did1) < 0)
+        TEST_ERROR;
+    if (H5Fclose(fid) < 0)
+        TEST_ERROR;
+
+
+    /*
+     * Case D: when opening a file with (V110, latest)
+     */
+
+    /* Open the file again with write + non-latest-format (V110, latest) */
+    if ((fid = H5Fopen(filename, H5F_ACC_RDWR, fapl)) < 0)
+        FAIL_STACK_ERROR;
+
+    /* Open the old style group: /group */
+    if ((gid = H5Gopen2(fid, "group", H5P_DEFAULT)) < 0)
+        FAIL_STACK_ERROR;
+
+    /* Open the new style dataset */
+    if ((did1 = H5Dopen2(fid, "dataset1", H5P_DEFAULT)) < 0)
+        FAIL_STACK_ERROR;
+
+    /* Should fail in enabling SWMR writing since there are old style objects opened  */
+    H5E_BEGIN_TRY
+    {
+        ret = H5Fstart_swmr_write(fid);
+    }
+    H5E_END_TRY
+    if (ret >= 0)
+        TEST_ERROR;
+
+    if (H5Gclose(gid) < 0)
+        TEST_ERROR;
+    if (H5Dclose(did1) < 0)
+        TEST_ERROR;
+    if (H5Fclose(fid) < 0)
+        TEST_ERROR;
+
+
+    /*
+     * Case E: when opening a file with (V110, latest)
+     */
+
+    /* Open the file again with write + non-latest-format (V110, latest) */
+    if ((fid = H5Fopen(filename, H5F_ACC_RDWR, fapl)) < 0)
+        FAIL_STACK_ERROR;
+
+    /* Open the new style dataset */
+    if ((did1 = H5Dopen2(fid, "dataset1", H5P_DEFAULT)) < 0)
+        FAIL_STACK_ERROR;
 
     /* Should succeed in enabling SWMR writing */
     if (H5Fstart_swmr_write(fid) < 0)
-        FAIL_STACK_ERROR;
-
-    /* Get the file's access_property list */
-    if ((file_fapl = H5Fget_access_plist(fid)) < 0)
-        FAIL_STACK_ERROR;
-
-    /* Retrieve the # of read attempts */
-    if (H5Pget_metadata_read_attempts(file_fapl, &attempts) < 0)
-        FAIL_STACK_ERROR;
-
-    /* Should be 100 */
-    if (attempts != H5F_SWMR_METADATA_READ_ATTEMPTS)
         TEST_ERROR;
 
-    /* Close the property list */
-    if (H5Pclose(file_fapl) < 0)
-        FAIL_STACK_ERROR;
-
-    rdata = 0;
-    /* Read from "dataset1" via did1_b (multiple opens) */
-    if (H5Dread(did1_b, H5T_NATIVE_INT, H5S_ALL, H5S_ALL, H5P_DEFAULT, &rdata) < 0)
-        FAIL_STACK_ERROR;
-    if (wdata != rdata)
-        FAIL_STACK_ERROR;
-    if (H5Dclose(did1_b) < 0)
-        FAIL_STACK_ERROR;
-
-    /* Read from "dataset1" */
-    rdata = 0;
-    if (H5Dread(did1, H5T_NATIVE_INT, H5S_ALL, H5S_ALL, H5P_DEFAULT, &rdata) < 0)
-        FAIL_STACK_ERROR;
-    if (wdata != rdata)
-        FAIL_STACK_ERROR;
     if (H5Dclose(did1) < 0)
-        FAIL_STACK_ERROR;
-
-    rdata = 0;
-    /* Read from "dataset1" via did1_a (multiple opens) */
-    if (H5Dread(did1_a, H5T_NATIVE_INT, H5S_ALL, H5S_ALL, H5P_DEFAULT, &rdata) < 0)
-        FAIL_STACK_ERROR;
-    if (wdata != rdata)
-        FAIL_STACK_ERROR;
-    if (H5Dclose(did1_a) < 0)
-        FAIL_STACK_ERROR;
-
-    /* Close "dataset2", dataspace, dataset creation property list */
-    if (H5Dclose(did2) < 0)
-        FAIL_STACK_ERROR;
-    if (H5Sclose(sid2) < 0)
-        FAIL_STACK_ERROR;
-    if (H5Pclose(dcpl) < 0)
-        FAIL_STACK_ERROR;
-
-    /* Create "dataset3" */
-    if ((dcpl = H5Pcreate(H5P_DATASET_CREATE)) < 0)
-        FAIL_STACK_ERROR;
-    if (H5Pset_chunk(dcpl, 2, chunk_dim2) < 0)
-        FAIL_STACK_ERROR;
-    if ((sid3 = H5Screate_simple(2, dim2, max_dim2)) < 0)
-        FAIL_STACK_ERROR;
-    if ((did3 = H5Dcreate2(fid, "dataset3", H5T_NATIVE_INT, sid3, H5P_DEFAULT, dcpl, H5P_DEFAULT)) < 0)
-        FAIL_STACK_ERROR;
-
-    /* Get the chunk index type for "dataset3" */
-    if (H5D__layout_idx_type_test(did3, &idx_type) < 0)
-        FAIL_STACK_ERROR;
-    if (idx_type != H5D_CHUNK_IDX_BT2)
-        FAIL_PUTS_ERROR("should be using v2 B-tree as index");
-
-    /* Close "dataset3", dataspace, dataset creation property list */
-    if (H5Dclose(did3) < 0)
-        FAIL_STACK_ERROR;
-    if (H5Sclose(sid3) < 0)
-        FAIL_STACK_ERROR;
-    if (H5Pclose(dcpl) < 0)
-        FAIL_STACK_ERROR;
-
-    /* Close the group */
-    if (H5Gclose(gid) < 0)
-        FAIL_STACK_ERROR;
-
-    /* Close the file access property list */
-    if (H5Pclose(fapl) < 0)
-        FAIL_STACK_ERROR;
-
-    /* Close the file */
+        TEST_ERROR;
     if (H5Fclose(fid) < 0)
-        FAIL_STACK_ERROR;
+        TEST_ERROR;
 
     PASSED();
 
@@ -1915,12 +1919,12 @@ error:
  *      --Enable SWMR writing mode twice
  *      --First time succeed, second time fail
  *      --Close the file
-        (2) --Open the file with write + with/without latest format
+ *      (2) --Open the file with write + with/without latest format
  *      --Succeed to enable SWMR writing mode
  *      --Reopen the same file
  *          --fail to enable SWMR writing mode for the reopened file
  *      --Close the file
-        (3) --Open the file with write + with/without latest format
+ *      (3) --Open the file with write + with/without latest format
  *      --Open the same file again
  *          --succeed to enable SWMR for the first opened file
  *          --fail to enable SWMR for the second opened file
@@ -1931,7 +1935,6 @@ error:
  *              --fail to open due to superblock version not 3
  *          (2) Open the file with SWMR write+non-latest-format
  *              --fail to open due to superblock version not 3
-
  *          (3) Open the file with write+latest format
  *              --fail to enable SWMR due to superblock version not 3
  *          (4) Open the file with write+non-latest-format
@@ -2164,8 +2167,18 @@ test_err_start_swmr_write(hid_t in_fapl, bool new_format)
     if (H5Aclose(aid) < 0)
         FAIL_STACK_ERROR;
 
-    /* Should succeed in enabling SWMR writing */
-    if (H5Fstart_swmr_write(fid) < 0)
+    /* Should succeed in enabling SWMR writing when new_format */
+    /* Should fail in enabling SWMR writing when !new_format */
+    H5E_BEGIN_TRY
+    {
+        ret = H5Fstart_swmr_write(fid);
+    }
+    H5E_END_TRY
+    if (new_format) {
+        if (ret < 0)
+            TEST_ERROR;
+    }
+    else if (ret >= 0)
         TEST_ERROR;
 
     /* Close the dataspace */
@@ -2195,8 +2208,17 @@ test_err_start_swmr_write(hid_t in_fapl, bool new_format)
     if ((fid = H5Fopen(filename, H5F_ACC_RDWR, fapl)) < 0)
         FAIL_STACK_ERROR;
 
-    /* Should succeed in enabling SWMR writing mode */
-    if (H5Fstart_swmr_write(fid) < 0)
+    /* Should succeed when new_format */
+    /* Should fail when !new_format */
+    H5E_BEGIN_TRY
+    {
+        ret = H5Fstart_swmr_write(fid);
+    }
+    H5E_END_TRY
+    if (new_format) {
+        if (ret < 0)
+            TEST_ERROR;
+    } else if (ret >= 0)
         TEST_ERROR;
 
     /* Should fail for a second call to enable SWMR writing mode */
@@ -2218,10 +2240,19 @@ test_err_start_swmr_write(hid_t in_fapl, bool new_format)
     if ((fid = H5Fopen(filename, H5F_ACC_RDWR, fapl)) < 0)
         FAIL_STACK_ERROR;
 
-    /* Should succeed in enabling SWMR writing mode */
-    if (H5Fstart_swmr_write(fid) < 0)
+    /* Should succeed when new_format */
+    /* Should fail when !new_format */
+    H5E_BEGIN_TRY
+    {
+        ret = H5Fstart_swmr_write(fid);
+    }
+    H5E_END_TRY
+    if (new_format) {
+        if (ret < 0)
+            TEST_ERROR;
+    } else if (ret >= 0)
         TEST_ERROR;
-
+        
     /* Re-open the same file */
     if ((fid2 = H5Freopen(fid)) < 0)
         FAIL_STACK_ERROR;
@@ -2251,8 +2282,17 @@ test_err_start_swmr_write(hid_t in_fapl, bool new_format)
     if ((fid2 = H5Fopen(filename, H5F_ACC_RDWR, fapl)) < 0)
         FAIL_STACK_ERROR;
 
-    /* Should succeed in enabling SWMR writing for fid */
-    if (H5Fstart_swmr_write(fid) < 0)
+    /* Should succeed when new_format */
+    /* Should fail when !new_format */
+    H5E_BEGIN_TRY
+    {
+        ret = H5Fstart_swmr_write(fid);
+    }
+    H5E_END_TRY
+    if (new_format) {
+        if (ret < 0)
+            TEST_ERROR;
+    } else if (ret >= 0)
         TEST_ERROR;
 
     /* Should fail to enable SWMR writing for fid2 */
@@ -2343,6 +2383,7 @@ test_err_start_swmr_write(hid_t in_fapl, bool new_format)
             FAIL_STACK_ERROR;
 
     } /* not new */
+
 
     /* Close the file access property list */
     if (H5Pclose(fapl) < 0)
@@ -2499,6 +2540,11 @@ test_start_swmr_write_concur(hid_t in_fapl, bool new_format)
      *  Verify concurrent file open with H5F_ACC_RDONLY|H5F_ACC_SWMR_READ
      *  will fail without H5Fstart_swmr_write()
      */
+
+    if (!new_format) {
+        if (H5Pset_libver_bounds(fapl, H5F_LIBVER_V110, H5F_LIBVER_LATEST) < 0)
+            FAIL_STACK_ERROR;
+    }
 
     /* Fork child process */
     if ((childpid = fork()) < 0)
@@ -7428,6 +7474,11 @@ test_multiple_same(hid_t in_fapl, bool new_format)
 
     if ((fapl = H5Pcopy(in_fapl)) < 0)
         FAIL_STACK_ERROR;
+
+    if (!new_format) {
+        if (H5Pset_libver_bounds(fapl, H5F_LIBVER_V110, H5F_LIBVER_LATEST) < 0)
+            FAIL_STACK_ERROR;
+    }
 
     /* Set the filename to use for this test (dependent on fapl) */
     h5_fixname(FILENAME[0], fapl, filename, sizeof(filename));

--- a/test/tfile.c
+++ b/test/tfile.c
@@ -5649,7 +5649,7 @@ test_libver_bounds_real(H5F_libver_t libver_create, unsigned oh_vers_create, H5F
  *
  *-------------------------------------------------------------------------
  */
-#define VERBFNAME   "tverbounds_dspace.h5"
+#define VFNAME   "verbounds.h5"
 #define VERBDSNAME  "dataset 1"
 #define SPACE1_DIM1 3
 static void
@@ -5659,7 +5659,6 @@ test_libver_bounds_open(void)
     hid_t        space    = H5I_INVALID_HID;   /* Dataspace ID */
     hid_t        dset     = H5I_INVALID_HID;   /* Dataset ID */
     hid_t        fapl     = H5I_INVALID_HID;   /* File access property list ID */
-    hid_t        new_fapl = H5I_INVALID_HID;   /* File access property list ID for reopened file */
     hid_t        dcpl     = H5I_INVALID_HID;   /* Dataset creation property list ID */
     hsize_t      dim[1]   = {SPACE1_DIM1};     /* Dataset dimensions */
     H5F_libver_t low, high;                    /* File format bounds */
@@ -5707,7 +5706,7 @@ test_libver_bounds_open(void)
     CHECK(ret, FAIL, "H5Pset_libver_bounds");
 
     /* Create the file */
-    file = H5Fcreate(VERBFNAME, H5F_ACC_TRUNC, H5P_DEFAULT, fapl);
+    file = H5Fcreate(VFNAME, H5F_ACC_TRUNC, H5P_DEFAULT, fapl);
     CHECK(file, FAIL, "H5Fcreate");
 
     /* Create dataset */
@@ -5720,49 +5719,36 @@ test_libver_bounds_open(void)
     ret = H5Fclose(file);
     CHECK(ret, FAIL, "H5Fclose");
 
-    /* Attempt to open latest file with (earliest, v18), should fail */
+    /* Attempt to open latest file with (earliest, v18) should succeed */
     ret = H5Pset_libver_bounds(fapl, H5F_LIBVER_EARLIEST, H5F_LIBVER_V18);
-    H5E_BEGIN_TRY
-    {
-        file = H5Fopen(VERBFNAME, H5F_ACC_RDONLY, fapl);
-    }
-    H5E_END_TRY
-    VERIFY(file, FAIL, "Attempted to open latest file with earliest version");
+    CHECK(ret, FAIL, "H5Pset_libver_bounds");
+
+    if ((file = H5Fopen(VFNAME, H5F_ACC_RDONLY, fapl)) < 0)
+    VERIFY((file >= 0), true, "Attempt to open latest file with earliest version should succeed");
+    ret = H5Fclose(file);
+    CHECK(ret, FAIL, "H5Fclose");
 
     /* Attempt to open latest file with (v18, v18), should fail */
     ret = H5Pset_libver_bounds(fapl, H5F_LIBVER_V18, H5F_LIBVER_V18);
-    H5E_BEGIN_TRY
-    {
-        file = H5Fopen(VERBFNAME, H5F_ACC_RDONLY, fapl);
-    }
-    H5E_END_TRY
-    VERIFY(file, FAIL, "Attempted to open latest file with v18 bounds");
+    CHECK(ret, FAIL, "H5Pset_libver_bounds");
 
-    /* Opening VERBFNAME in these combination should succeed.
-       For each low bound, verify that it is upgraded properly */
+    file = H5Fopen(VFNAME, H5F_ACC_RDONLY, fapl);
+    VERIFY((file >= 0), true, "Attempt to open latest file with v18 bounds should succeed");
+    ret = H5Fclose(file);
+    CHECK(ret, FAIL, "H5Fclose");
+
+    /* Opening VERBFNAME in these combination should succeed */
     high = H5F_LIBVER_LATEST;
     for (low = H5F_LIBVER_EARLIEST; low < H5F_LIBVER_NBOUNDS; low++) {
-        H5F_libver_t new_low = H5F_LIBVER_EARLIEST;
 
         /* Set version bounds for opening file */
         ret = H5Pset_libver_bounds(fapl, low, high);
         CHECK(ret, FAIL, "H5Pset_libver_bounds");
 
         /* Open the file */
-        file = H5Fopen(VERBFNAME, H5F_ACC_RDONLY, fapl);
-        CHECK(file, FAIL, "H5Fopen");
+        file = H5Fopen(VFNAME, H5F_ACC_RDONLY, fapl);
+        VERIFY(file >=0, true, "H5Fopen should succeed");
 
-        /* Get the new file access property */
-        new_fapl = H5Fget_access_plist(file);
-        CHECK(new_fapl, FAIL, "H5Fget_access_plist");
-
-        /* Get new low bound and verify that it has been upgraded properly */
-        ret = H5Pget_libver_bounds(new_fapl, &new_low, NULL);
-        CHECK(ret, FAIL, "H5Pget_libver_bounds");
-        VERIFY(new_low >= H5F_LIBVER_V110, true, "Low bound should be upgraded to at least H5F_LIBVER_V110");
-
-        ret = H5Pclose(new_fapl);
-        CHECK(ret, FAIL, "H5Pclose");
         ret = H5Fclose(file);
         CHECK(ret, FAIL, "H5Fclose");
     } /* for low */
@@ -5886,9 +5872,10 @@ test_libver_bounds(void)
 
     /* Run the tests */
     test_libver_bounds_real(H5F_LIBVER_EARLIEST, 1, H5F_LIBVER_LATEST, 2);
-    test_libver_bounds_real(H5F_LIBVER_LATEST, 2, H5F_LIBVER_EARLIEST, 2);
+    test_libver_bounds_real(H5F_LIBVER_LATEST, 2, H5F_LIBVER_EARLIEST, 1);
     test_libver_bounds_open();
     test_libver_bounds_copy();
+
 } /* end test_libver_bounds() */
 
 /**************************************************************************************
@@ -6251,7 +6238,7 @@ test_libver_bounds_super_create(hid_t fapl, hid_t fcpl, htri_t is_swmr, htri_t n
 **
 **                      (A) Opening a file with write access
 **
-**                                              Superblock version 0, 1
+**                                              Superblock version 0, 1, 2, 3
 **                  --------------------------------------------------------------------------------
 **                  | (earliest, v18) | (earliest, v110) | (v18, v18) | (v18, v110) | (v110, v110) |
 **                  |______________________________________________________________________________|
@@ -6259,26 +6246,6 @@ test_libver_bounds_super_create(hid_t fapl, hid_t fcpl, htri_t is_swmr, htri_t n
 **                  |------------------------------------------------------------------------------|
 ** File open        |                               succeed                                        |
 **                  |______________________________________________________________________________|
-**
-**
-**                                              Superblock version 2
-**                  --------------------------------------------------------------------------------
-**                  | (earliest, v18) | (earliest, v110) | (v18, v18) | (v18, v110) | (v110, v110) |
-**                  |______________________________________________________________________________|
-** File's low bound |               -->v18               |               no change                 |
-**                  |------------------------------------------------------------------------------|
-** File open        |                               succeed                                        |
-**                  |______________________________________________________________________________|
-**
-**                                              Superblock version 3
-**                  --------------------------------------------------------------------------------
-**                  | (earliest, v18) | (earliest, v110) | (v18, v18) | (v18, v110) | (v110, v110) |
-**                  |______________________________________________________________________________|
-** File's low bound | --              | -->v110          | --         | -->v110     | no change    |
-**                  |------------------------------------------------------------------------------|
-** File open        | fail            | succeed          | fail       | succeed     | succeed      |
-**                  |______________________________________________________________________________|
-**
 **
 **
 **                     (B) Opening a file with SWMR-write access
@@ -6316,9 +6283,7 @@ static void
 test_libver_bounds_super_open(hid_t fapl, hid_t fcpl, htri_t is_swmr, htri_t non_def_fsm)
 {
     hid_t        fid      = H5I_INVALID_HID; /* File ID */
-    H5F_t       *f        = NULL;            /* Internal file pointer */
     hid_t        new_fapl = H5I_INVALID_HID; /* File access property list */
-    unsigned     super_vers;                 /* Superblock version */
     H5F_libver_t low, high;                  /* Low and high bounds */
     herr_t       ret;                        /* Return value */
 
@@ -6338,13 +6303,6 @@ test_libver_bounds_super_open(hid_t fapl, hid_t fcpl, htri_t is_swmr, htri_t non
     }
     else {
         VERIFY(fid >= 0, true, "H5Fcreate");
-
-        /* Get the internal file pointer */
-        f = (H5F_t *)H5VL_object(fid);
-        CHECK_PTR(f, "H5VL_object");
-
-        /* The file's superblock version */
-        super_vers = f->shared->sblock->super_vers;
 
         /* Close the file */
         ret = H5Fclose(fid);
@@ -6374,64 +6332,16 @@ test_libver_bounds_super_open(hid_t fapl, hid_t fcpl, htri_t is_swmr, htri_t non
                 }
                 H5E_END_TRY
 
-                if (non_def_fsm && high < H5F_LIBVER_V110) {
-                    VERIFY(fid, H5I_INVALID_HID, "H5Fopen");
-                    continue;
-                }
-
                 /* Get the internal file pointer if the open succeeds */
                 if (fid >= 0) {
-                    f = (H5F_t *)H5VL_object(fid);
-                    CHECK_PTR(f, "H5VL_object");
+                     ret = H5Fclose(fid);
+                     CHECK(ret, FAIL, "H5Fclose");
+
+                } else {
+
+                    VERIFY((is_swmr || (non_def_fsm && (high < H5F_LIBVER_V110))), true, "H5Fopen");
                 }
 
-                /* Verify the file open succeeds or fails */
-                switch (super_vers) {
-                    case 3:
-                        if (high >= H5F_LIBVER_V110) {
-                            /* Should succeed */
-                            VERIFY(fid >= 0, true, "H5Fopen");
-                            VERIFY(f->shared->low_bound >= H5F_LIBVER_V110, true,
-                                   "HDF5_superblock_ver_bounds");
-
-                            /* Close the file */
-                            ret = H5Fclose(fid);
-                            CHECK(ret, FAIL, "H5Fclose");
-                        }
-                        else /* Should fail */
-                            VERIFY(fid >= 0, false, "H5Fopen");
-                        break;
-
-                    case 2:
-                        if (is_swmr) /* Should fail */
-                            VERIFY(fid >= 0, false, "H5Fopen");
-                        else { /* Should succeed */
-                            VERIFY(fid >= 0, true, "H5Fopen");
-                            VERIFY(f->shared->low_bound >= H5F_LIBVER_V18, true,
-                                   "HDF5_superblock_ver_bounds");
-
-                            /* Close the file */
-                            ret = H5Fclose(fid);
-                            CHECK(ret, FAIL, "H5Fclose");
-                        }
-                        break;
-
-                    case 1:
-                    case 0:
-                        if (is_swmr) /* Should fail */
-                            VERIFY(fid >= 0, false, "H5Fopen");
-                        else { /* Should succeed */
-                            VERIFY(fid >= 0, true, "H5Fopen");
-                            VERIFY(f->shared->low_bound, low, "HDF5_superblock_ver_bounds");
-
-                            ret = H5Fclose(fid);
-                            CHECK(ret, FAIL, "H5Fclose");
-                        }
-                        break;
-
-                    default:
-                        break;
-                } /* end switch */
             }     /* end for */
         }         /* end for */
 
@@ -6555,6 +6465,7 @@ test_libver_bounds_obj(hid_t fapl)
                 fid = H5Fopen(FILE8, H5F_ACC_RDWR, new_fapl);
             }
             H5E_END_TRY
+            VERIFY((fid >= 0), true, "File open should succeed");
 
             if (fid >= 0) { /* The file open succeeds */
 
@@ -6773,6 +6684,7 @@ test_libver_bounds_dataset(hid_t fapl)
                 fid = H5Fopen(FILE8, H5F_ACC_RDWR, new_fapl);
             }
             H5E_END_TRY
+            VERIFY((fid >= 0), true, "File open should succeed");
 
             if (fid >= 0) { /* The file open succeeds */
 
@@ -7002,6 +6914,7 @@ test_libver_bounds_dataspace(hid_t fapl)
                 fid = H5Fopen(FILE8, H5F_ACC_RDWR, new_fapl);
             }
             H5E_END_TRY
+            VERIFY((fid >= 0), true, "File open should succeed");
 
             if (fid >= 0) { /* The file open succeeds */
 
@@ -7338,6 +7251,7 @@ test_libver_bounds_datatype_check(hid_t fapl, hid_t tid)
                 fid = H5Fopen(FILE8, H5F_ACC_RDWR, new_fapl);
             }
             H5E_END_TRY
+            VERIFY((fid >= 0), true, "File open should succeed");
 
             if (fid >= 0) { /* The file open succeeds */
 
@@ -7666,6 +7580,7 @@ test_libver_bounds_attributes(hid_t fapl)
                 fid = H5Fopen(FILE8, H5F_ACC_RDWR, new_fapl);
             }
             H5E_END_TRY
+            VERIFY((fid >= 0), true, "File open should succeed");
 
             if (fid >= 0) { /* The file open succeeds */
 
@@ -7686,8 +7601,8 @@ test_libver_bounds_attributes(hid_t fapl)
                 CHECK_PTR(attr, "H5VL_object");
 
                 /* Verify the attribute message version */
-                VERIFY(attr->shared->version, H5O_attr_ver_bounds[f->shared->low_bound],
-                       "H5O_attr_ver_bounds");
+                VERIFY(attr->shared->version >= H5O_attr_ver_bounds[f->shared->low_bound],
+                       true, "H5O_attr_ver_bounds");
 
                 /* Close the attribute */
                 ret = H5Aclose(aid);

--- a/test/tfile.c
+++ b/test/tfile.c
@@ -5649,18 +5649,18 @@ test_libver_bounds_real(H5F_libver_t libver_create, unsigned oh_vers_create, H5F
  *
  *-------------------------------------------------------------------------
  */
-#define VFNAME   "verbounds.h5"
+#define VFNAME      "verbounds.h5"
 #define VERBDSNAME  "dataset 1"
 #define SPACE1_DIM1 3
 static void
 test_libver_bounds_open(void)
 {
-    hid_t        file     = H5I_INVALID_HID;   /* File ID */
-    hid_t        space    = H5I_INVALID_HID;   /* Dataspace ID */
-    hid_t        dset     = H5I_INVALID_HID;   /* Dataset ID */
-    hid_t        fapl     = H5I_INVALID_HID;   /* File access property list ID */
-    hid_t        dcpl     = H5I_INVALID_HID;   /* Dataset creation property list ID */
-    hsize_t      dim[1]   = {SPACE1_DIM1};     /* Dataset dimensions */
+    hid_t        file   = H5I_INVALID_HID;     /* File ID */
+    hid_t        space  = H5I_INVALID_HID;     /* Dataspace ID */
+    hid_t        dset   = H5I_INVALID_HID;     /* Dataset ID */
+    hid_t        fapl   = H5I_INVALID_HID;     /* File access property list ID */
+    hid_t        dcpl   = H5I_INVALID_HID;     /* Dataset creation property list ID */
+    hsize_t      dim[1] = {SPACE1_DIM1};       /* Dataset dimensions */
     H5F_libver_t low, high;                    /* File format bounds */
     hsize_t      chunk_dim[1] = {SPACE1_DIM1}; /* Chunk dimensions */
     bool         vol_is_native;
@@ -5724,7 +5724,7 @@ test_libver_bounds_open(void)
     CHECK(ret, FAIL, "H5Pset_libver_bounds");
 
     if ((file = H5Fopen(VFNAME, H5F_ACC_RDONLY, fapl)) < 0)
-    VERIFY((file >= 0), true, "Attempt to open latest file with earliest version should succeed");
+        VERIFY((file >= 0), true, "Attempt to open latest file with earliest version should succeed");
     ret = H5Fclose(file);
     CHECK(ret, FAIL, "H5Fclose");
 
@@ -5747,7 +5747,7 @@ test_libver_bounds_open(void)
 
         /* Open the file */
         file = H5Fopen(VFNAME, H5F_ACC_RDONLY, fapl);
-        VERIFY(file >=0, true, "H5Fopen should succeed");
+        VERIFY(file >= 0, true, "H5Fopen should succeed");
 
         ret = H5Fclose(file);
         CHECK(ret, FAIL, "H5Fclose");
@@ -6334,16 +6334,16 @@ test_libver_bounds_super_open(hid_t fapl, hid_t fcpl, htri_t is_swmr, htri_t non
 
                 /* Get the internal file pointer if the open succeeds */
                 if (fid >= 0) {
-                     ret = H5Fclose(fid);
-                     CHECK(ret, FAIL, "H5Fclose");
-
-                } else {
+                    ret = H5Fclose(fid);
+                    CHECK(ret, FAIL, "H5Fclose");
+                }
+                else {
 
                     VERIFY((is_swmr || (non_def_fsm && (high < H5F_LIBVER_V110))), true, "H5Fopen");
                 }
 
-            }     /* end for */
-        }         /* end for */
+            } /* end for */
+        }     /* end for */
 
         /* Close the file access property list */
         ret = H5Pclose(new_fapl);
@@ -7601,8 +7601,8 @@ test_libver_bounds_attributes(hid_t fapl)
                 CHECK_PTR(attr, "H5VL_object");
 
                 /* Verify the attribute message version */
-                VERIFY(attr->shared->version >= H5O_attr_ver_bounds[f->shared->low_bound],
-                       true, "H5O_attr_ver_bounds");
+                VERIFY(attr->shared->version >= H5O_attr_ver_bounds[f->shared->low_bound], true,
+                       "H5O_attr_ver_bounds");
 
                 /* Close the attribute */
                 ret = H5Aclose(aid);

--- a/test/tmisc.c
+++ b/test/tmisc.c
@@ -6868,7 +6868,7 @@ test_misc40(void)
     CHECK(ret, FAIL, "H5Fclose");
 
     /* Re-open the file */
-    fid = H5Fopen(MISC25C_FILE, H5F_ACC_RDWR, H5P_DEFAULT);
+    fid = H5Fopen(MISC25C_FILE, H5F_ACC_RDWR, fapl);
     CHECK(fid, H5I_INVALID_HID, "H5Fopen");
 
     /* Set the compact/dense value high, to see if we can trick the


### PR DESCRIPTION
…cted H5Fopen failures.

File with non-SWMR-write access can now be opened without regard for superblock version. Due to the fix, H5Fstart_swmr_write() also needs to be modified as well as the tests for libver bounds. The "RFC: Setting Bounds for Object Creation in HDF5 1.10.0" is also updated to reflect the changes.