### PR TITLE
Only clear FE_INVALID when that symbol is present on the system

### DIFF
--- a/release_docs/RELEASE.txt
+++ b/release_docs/RELEASE.txt
@@ -132,7 +132,19 @@ Bug Fixes since HDF5-1.16.0 release
 ===================================
     Library
     -------
-    -
+    - Only clear FE_INVALID when that symbol is present on the system
+
+      When we initialize the floating-point types at library startup, it's
+      possible to raise floating-point exceptions when we check which things
+      are supported. Normally, we clear these floating-point exceptions via
+      feclearexcept(FE_INVALID), but FE_INVALID may not be present on all
+      systems. Specifically, this was reported as being a problem when using
+      Emscripten 3.1.68 to compile HDF5 1.14.5 to WebAssembly.
+
+      We've added an #ifdef FE_INVALID block around the exception clearing
+      code to correct this.
+
+      Fixes GitHub issue #4952
 
 
     Java Library

--- a/src/H5Tinit_float.c
+++ b/src/H5Tinit_float.c
@@ -608,9 +608,13 @@ H5T__init_native_float_types(void)
 #endif
 
 done:
-    /* Clear any FE_INVALID exceptions from NaN handling */
+    /* Clear any FE_INVALID exceptions from NaN handling. FE_INVALID is C99/C11,
+     * but may not be present on all systems.
+     */
+#ifdef FE_INVALID
     if (feclearexcept(FE_INVALID) != 0)
         HSYS_GOTO_ERROR(H5E_DATATYPE, H5E_CANTSET, FAIL, "can't clear floating-point exceptions");
+#endif
 
     /* Restore the original environment */
     if (feupdateenv(&saved_fenv) != 0)


### PR DESCRIPTION
When we initialize the floating-point types at library startup, it's possible to raise floating-point exceptions when we check which things are supported. Normally, we clear these floating-point exceptions via feclearexcept(FE_INVALID), but FE_INVALID may not be present on all systems. Specifically, this was reported as being a problem when using Emscripten 3.1.68 to compile HDF5 1.14.5 to WebAssembly.

We've added an #ifdef FE_INVALID block around the exception clearing code to correct this.

Fixes #4952