### PR TITLE
Fix linker flag in pkg-config file for system zlib

### DIFF
--- a/CMakeFilters.cmake
+++ b/CMakeFilters.cmake
@@ -108,7 +108,7 @@ if (HDF5_ENABLE_Z_LIB_SUPPORT)
         # on the target. The target returned is: ZLIB::ZLIB
         get_filename_component (libname ${ZLIB_LIBRARIES} NAME_WLE)
         string (REGEX REPLACE "^lib" "" libname ${libname})
-        set_target_properties (ZLIB::ZLIB PROPERTIES OUTPUT_NAME zlib-static)
+        set_target_properties (ZLIB::ZLIB PROPERTIES OUTPUT_NAME ${libname})
         set (LINK_COMP_LIBS ${LINK_COMP_LIBS} ZLIB::ZLIB)
       endif ()
     else ()


### PR DESCRIPTION
Previously was hardcoding `-lzlib-static` which will result in the wrong linker flags when built with system zlib. It looks like there was logic to figure out the library name but the resulting `libname` was never used.

---

I noticed this while debugging issues with HDF5 1.14.5 build over at Homebrew https://github.com/Homebrew/homebrew-core/pull/19328.

Should also be an issue at most repositories/distros as the installed library is `libz` not `libzlib-static`, e.g.
* Alpine - https://pkgs.alpinelinux.org/contents?name=zlib-static&repo=main&branch=edge&arch=x86
* Debian - https://packages.debian.org/sid/amd64/zlib1g-dev/filelist 

Seemed minor fix so no specific GitHub issue but can create one if preferred.

Not sure if any CI run actually tests this combination (CMake using system `zlib`). I think there is a run for Autotools using system `zlib` and CMake using locally fetched libs.

---

From local build, before change (on both 1.14.5 and `develop`):
```pc
Libs.private:   -lzlib-static
```
```console
❯ pkg-config --libs --static hdf5
-L/opt/homebrew/Cellar/hdf5/HEAD-97420ea/lib -lhdf5 -lzlib-static
```

After change:
```pc
Libs.private:   -lz
```
```console
❯ pkg-config --libs --static hdf5
-L/opt/homebrew/Cellar/hdf5/HEAD-97420ea/lib -lhdf5 -lz
```