### PR TITLE
Fix h5py GitHub Action

### DIFF
--- a/.github/workflows/h5py.yml
+++ b/.github/workflows/h5py.yml
@@ -3,8 +3,8 @@ name: h5py
 # Triggers the workflow on a schedule or on demand
 on:
   workflow_dispatch:
-  schedule:
-    - cron: "6 0 * * *"
+#  schedule:
+#    - cron: "6 0 * * *"
 
 permissions:
   contents: read
@@ -31,5 +31,5 @@ jobs:
         spack load py-h5py
         spack load py-pytest
         spack load py-ipython
-        pip install pytest-mpi
+        spack load py-pytest-mpi
         python -c "import h5py; h5py.run_tests(); print(h5py.version.info);"

--- a/.github/workflows/h5py.yml
+++ b/.github/workflows/h5py.yml
@@ -3,8 +3,8 @@ name: h5py
 # Triggers the workflow on a schedule or on demand
 on:
   workflow_dispatch:
-#  schedule:
-#    - cron: "6 0 * * *"
+  schedule:
+    - cron: "6 0 * * *"
 
 permissions:
   contents: read

--- a/.github/workflows/h5py.yml
+++ b/.github/workflows/h5py.yml
@@ -28,6 +28,7 @@ jobs:
         ./spack/bin/spack install py-h5py@master+mpi ^hdf5@develop-1.17
         ./spack/bin/spack install py-pytest
         ./spack/bin/spack install py-ipython
+        ./spack/bin/spack install py-pytest-mpi        
         spack load py-h5py
         spack load py-pytest
         spack load py-ipython


### PR DESCRIPTION
Avoid using `pip` on the latest Spack python.

This PR will fix the following error:
```
error: externally-managed-environment
```