### PR TITLE
The h5(p)*c parser retains escaped whitespace character

### DIFF
--- a/bin/h5cc.in
+++ b/bin/h5cc.in
@@ -263,6 +263,10 @@ for arg in $@ ; do
       qarg='"'"$arg"'"'
       qargs="$qargs $qarg"
       ;;
+    *\ *)
+      qarg=$arg
+      qargs="$qargs $qarg"
+      ;;
     *)
       if test -s "$arg"; then
         ext=`expr "$arg" : '.*\(\..*\)'`

--- a/c++/src/h5c++.in
+++ b/c++/src/h5c++.in
@@ -253,6 +253,10 @@ for arg in $@ ; do
       qarg='"'"$arg"'"'
       qargs="$qargs $qarg"
       ;;
+    *\ *)
+      qarg=$arg
+      qargs="$qargs $qarg"
+      ;;
     *)
       if [ -s "$arg" ] ; then
 	ext=`expr "$arg" : '.*\(\..*\)'`

--- a/fortran/src/H5Sff.F90
+++ b/fortran/src/H5Sff.F90
@@ -893,6 +893,10 @@ CONTAINS
 !! \param operator Flag, valid values are:
 !!                 \li H5S_SELECT_SET_F
 !!                 \li H5S_SELECT_OR_F
+!!                 \li H5S_SELECT_AND_F
+!!                 \li H5S_SELECT_XOR_F
+!!                 \li H5S_SELECT_NOTB_F
+!!                 \li H5S_SELECT_NOTA_F
 !! \param start    Array with hyperslab offsets, \Bold{0-based indices}.
 !! \param count    Number of blocks included in the hyperslab.
 !! \param hdferr   \fortran_error
@@ -1000,8 +1004,6 @@ CONTAINS
 !                          H5S_SELECT_XOR_F
 !                          H5S_SELECT_NOTB_F
 !                          H5S_SELECT_NOTA_F
-!                          H5S_SELECT_APPEND_F
-!                          H5S_SELECT_PREPEND_F
 !            start            - array with hyperslab offsets
 !            count            - number of blocks included in the
 !                          hyperslab

--- a/fortran/src/H5Sff.F90
+++ b/fortran/src/H5Sff.F90
@@ -893,10 +893,6 @@ CONTAINS
 !! \param operator Flag, valid values are:
 !!                 \li H5S_SELECT_SET_F
 !!                 \li H5S_SELECT_OR_F
-!!                 \li H5S_SELECT_AND_F
-!!                 \li H5S_SELECT_XOR_F
-!!                 \li H5S_SELECT_NOTB_F
-!!                 \li H5S_SELECT_NOTA_F
 !! \param start    Array with hyperslab offsets, \Bold{0-based indices}.
 !! \param count    Number of blocks included in the hyperslab.
 !! \param hdferr   \fortran_error
@@ -1004,6 +1000,8 @@ CONTAINS
 !                          H5S_SELECT_XOR_F
 !                          H5S_SELECT_NOTB_F
 !                          H5S_SELECT_NOTA_F
+!                          H5S_SELECT_APPEND_F
+!                          H5S_SELECT_PREPEND_F
 !            start            - array with hyperslab offsets
 !            count            - number of blocks included in the
 !                          hyperslab

--- a/fortran/src/h5fc.in
+++ b/fortran/src/h5fc.in
@@ -237,6 +237,10 @@ for arg in $@ ; do
       qarg='"'"$arg"'"'
       qargs="$qargs $qarg"
       ;;
+    *\ *)
+      qarg=$arg
+      qargs="$qargs $qarg"
+      ;;
     *)
       if [ -s "$arg" ] ; then
         ext=`expr "$arg" : '.*\(\..*\)'`


### PR DESCRIPTION
Addresses #4964 