### PR TITLE
Switch HDoff_t from __int64 to int64_t on Windows

### DIFF
--- a/release_docs/RELEASE.txt
+++ b/release_docs/RELEASE.txt
@@ -69,7 +69,7 @@ New Features
       POSIX large-file support (LFS). On Windows, however, off_t is defined
       as a 32-bit type, even on 64-bit Windows.
 
-      HDoff_t has been added to H5public.h and is defined to be __int64 on
+      HDoff_t has been added to H5public.h and is defined to be int64_t on
       Windows and the library has been updated to use HDoff_t in place of
       off_t throughout. The H5Pset_external() offset parameter has also been
       updated to be HDoff_t.

--- a/src/H5public.h
+++ b/src/H5public.h
@@ -301,14 +301,14 @@ typedef long long ssize_t;
 typedef uint64_t hsize_t;
 
 /* off_t exists on Windows, but is always a 32-bit long, even on 64-bit Windows,
- * so on Windows we define HDoff_t to be __int64, which is the type of the
- * st_size field of the _stati64 struct.
+ * so on Windows we define HDoff_t to be int64_t, which is equivalent to __int64,
+ * the type of the st_size field of the _stati64 struct.
  */
 #ifdef H5_HAVE_WIN32_API
 /**
  * Platform-independent offset
  */
-typedef __int64 HDoff_t;
+typedef int64_t HDoff_t;
 #else
 /**
  * Platform-independent offset


### PR DESCRIPTION
__int64 raises warnings when building with clang