### PR TITLE
Set the C standard to 11

### DIFF
--- a/config/clang-flags
+++ b/config/clang-flags
@@ -116,14 +116,8 @@ if test "X-clang" = "X-$cc_vendor" -o "X-Apple LLVM" = "X-$cc_vendor"; then
     esac
 
     case "$host_os-$host_cpu" in
-        # cygwin needs the "-std=c99" flag removed, so make
-        # a specific case for Cygwin without the flag and a default
-        # case to add the flag everywhere else
-        cygwin-*)
-            ;;
-
         *)
-            H5_CFLAGS="$H5_CFLAGS -std=c99"
+            H5_CFLAGS="$H5_CFLAGS -std=c11"
             ;;
     esac
 

--- a/config/cmake/HDFCompilerFlags.cmake
+++ b/config/cmake/HDFCompilerFlags.cmake
@@ -9,10 +9,10 @@
 # If you do not have access to either file, you may request a copy from
 # help@hdfgroup.org.
 #
-set (CMAKE_C_STANDARD 99)
+set (CMAKE_C_STANDARD 11)
 set (CMAKE_C_STANDARD_REQUIRED TRUE)
 
-set (CMAKE_C_FLAGS "${CMAKE_C99_STANDARD_COMPILE_OPTION} ${CMAKE_C_FLAGS}")
+set (CMAKE_C_FLAGS "${CMAKE_C11_STANDARD_COMPILE_OPTION} ${CMAKE_C_FLAGS}")
 set (CMAKE_C_FLAGS "${CMAKE_C_SANITIZER_FLAGS} ${CMAKE_C_FLAGS}")
 message (VERBOSE "Warnings Configuration: C default: ${CMAKE_C_FLAGS}")
 #-----------------------------------------------------------------------------

--- a/config/gnu-flags
+++ b/config/gnu-flags
@@ -117,18 +117,15 @@ if test "X-gcc" = "X-$cc_vendor"; then
     esac
 
     case "$host_os-$host_cpu" in
-        # Cygwin needs the "-std=c99" flag removed.
-        cygwin-*)
-            ;;
-        # On Solaris, gcc needs the gnu99 standard to pick up certain POSIX
+        # On Solaris, gcc needs the gnu11 standard to pick up certain POSIX
         # things. Do NOT use this as the gcc norm as this encourages the use
         # of non-standard gcc extensions.
         *solaris*)
-            H5_CFLAGS="$H5_CFLAGS -std=gnu99"
+            H5_CFLAGS="$H5_CFLAGS -std=gnu11"
             ;;
-        # Everybody else gets c99 as the standard.
+        # Everybody else gets C11 as the standard.
         *)
-            H5_CFLAGS="$H5_CFLAGS -std=c99"
+            H5_CFLAGS="$H5_CFLAGS -std=c11"
             ;;
     esac
 

--- a/config/nvidia-flags
+++ b/config/nvidia-flags
@@ -68,8 +68,8 @@ if test "X-nvc" = "X-$cc_vendor" -o "X-nvcc" = "X-$cc_vendor"; then
     # General #
     ###########
 
-    # Default to C99 standard.
-    H5_CFLAGS="$H5_CFLAGS $arch -c99 -Minform=warn"
+    # Default to C11 standard.
+    H5_CFLAGS="$H5_CFLAGS $arch -std=c11 -Minform=warn"
 
     ##############
     # Production #

--- a/config/oneapi-flags
+++ b/config/oneapi-flags
@@ -80,8 +80,8 @@ if test "X-icx" = "X-$cc_vendor"; then
     # General #
     ###########
 
-    # Default to C99 standard.
-    H5_CFLAGS="$H5_CFLAGS $arch -std=c99"
+    # Default to C11 standard.
+    H5_CFLAGS="$H5_CFLAGS $arch -std=c11"
 
     ##############
     # Production #

--- a/release_docs/RELEASE.txt
+++ b/release_docs/RELEASE.txt
@@ -47,6 +47,11 @@ New Features
 
     Configuration:
     -------------
+    - The standard for building the library is now C11
+
+      We have updated the build files to set the C standard to C11, though
+      some platforms use gnu11 to get some GNU things to work.
+
     - Added configuration option for internal threading/concurrency support:
 
           CMake:      HDF5_ENABLE_THREADS (ON/OFF) (Default: ON)

--- a/release_docs/RELEASE.txt
+++ b/release_docs/RELEASE.txt
@@ -47,6 +47,16 @@ New Features
 
     Configuration:
     -------------
+    - Dropped support for the traditional MSVC preprocessor
+
+      Visual Studio has recently started using a standards-compliant
+      preprocessor (In VS2019+) and this is the default in C11.
+
+      https://learn.microsoft.com/en-us/cpp/preprocessor/preprocessor-experimental-overview?view=msvc-170
+
+      Because of this, we've dropped support for the traditional
+      MSVC preprocessor.
+
     - The standard for building the library is now C11
 
       We have updated the build files to set the C standard to C11, though

--- a/src/H5win32defs.h
+++ b/src/H5win32defs.h
@@ -43,21 +43,8 @@ struct timezone {
 #define HDlstat(S, B)        _lstati64(S, B)
 #define HDmkdir(S, M)        _mkdir(S)
 
-/* Note that with the traditional MSVC preprocessor, the variadic
- * HDopen macro uses an MSVC-specific extension where the comma
- * is dropped if nothing is passed to the ellipsis.
- *
- * MinGW and the newer, conforming MSVC preprocessor do not exhibit this
- * behavior. The conforming preprocessor is also used by default with
- * C11.
- */
-#if defined(_MSVC_TRADITIONAL)
-/* Using the MSVC traditional preprocessor */
-#define HDopen(S, F, ...) Wopen(S, F, __VA_ARGS__)
-#else
-/* Using a standards conformant preprocessor */
+/* We only support the standards conformant preprocessor */
 #define HDopen(S, F, ...) Wopen(S, F, ##__VA_ARGS__)
-#endif
 
 #define HDremove(S)           Wremove(S)
 #define HDsetenv(N, V, O)     Wsetenv(N, V, O)

--- a/src/H5win32defs.h
+++ b/src/H5win32defs.h
@@ -48,9 +48,10 @@ struct timezone {
  * is dropped if nothing is passed to the ellipsis.
  *
  * MinGW and the newer, conforming MSVC preprocessor do not exhibit this
- * behavior.
+ * behavior. The conforming preprocessor is also used by default with
+ * C11.
  */
-#if (defined(_MSC_VER) && !defined(_MSVC_TRADITIONAL)) || defined(_MSVC_TRADITIONAL)
+#if defined(_MSVC_TRADITIONAL)
 /* Using the MSVC traditional preprocessor */
 #define HDopen(S, F, ...) Wopen(S, F, __VA_ARGS__)
 #else


### PR DESCRIPTION
Ignores some of the older Autotools platform files, since the Autotools will be dropped in the next major release (and we don't have compilers on which to test, anyway).