### PR TITLE
Remove some Solaris Studio work-arounds

### DIFF
--- a/bin/genparser
+++ b/bin/genparser
@@ -250,8 +250,6 @@ do
     echo '#if ((__GNUC__ * 100) + __GNUC_MINOR__) >= 600                    ' >> tmp.out
     echo '#pragma GCC diagnostic ignored "-Wnull-dereference"               ' >> tmp.out
     echo '#endif                                                            ' >> tmp.out
-    echo '#elif defined __SUNPRO_CC                                         ' >> tmp.out
-    echo '#pragma disable_warn                                              ' >> tmp.out
     echo '#elif defined _MSC_VER                                            ' >> tmp.out
     echo '#pragma warning(push, 1)                                          ' >> tmp.out
     echo '#endif                                                            ' >> tmp.out

--- a/config/cmake/ConfigureChecks.cmake
+++ b/config/cmake/ConfigureChecks.cmake
@@ -29,11 +29,6 @@ if (${CMAKE_SYSTEM_NAME} MATCHES "Darwin")
     set (${HDF_PREFIX}_HAVE_DARWIN 1)
 endif ()
 
-# Check for Solaris
-if (${CMAKE_SYSTEM_NAME} MATCHES "SunOS")
-    set (${HDF_PREFIX}_HAVE_SOLARIS 1)
-endif ()
-
 #-----------------------------------------------------------------------------
 # This MACRO checks IF the symbol exists in the library and IF it
 # does, it appends library to the list.

--- a/hl/src/H5LTanalyze.c
+++ b/hl/src/H5LTanalyze.c
@@ -24,8 +24,6 @@
 #if ((__GNUC__ * 100) + __GNUC_MINOR__) >= 600                    
 #pragma GCC diagnostic ignored "-Wnull-dereference"               
 #endif                                                            
-#elif defined __SUNPRO_CC                                         
-#pragma disable_warn                                              
 #elif defined _MSC_VER                                            
 #pragma warning(push, 1)                                          
 #endif                                                            

--- a/hl/src/H5LTparse.c
+++ b/hl/src/H5LTparse.c
@@ -24,8 +24,6 @@
 #if ((__GNUC__ * 100) + __GNUC_MINOR__) >= 600                    
 #pragma GCC diagnostic ignored "-Wnull-dereference"               
 #endif                                                            
-#elif defined __SUNPRO_CC                                         
-#pragma disable_warn                                              
 #elif defined _MSC_VER                                            
 #pragma warning(push, 1)                                          
 #endif                                                            

--- a/release_docs/RELEASE.txt
+++ b/release_docs/RELEASE.txt
@@ -47,6 +47,12 @@ New Features
 
     Configuration:
     -------------
+    - Dropped some old Solaris Studio work-arounds
+
+      Solaris Studio no longer seems to be maintained and the last version
+      (12.4, circa 2015) doesn't seem to fully support C11. We've removed
+      some hacks that work around things like __attribute__() support.
+
     - Dropped support for the traditional MSVC preprocessor
 
       Visual Studio has recently started using a standards-compliant

--- a/src/H5private.h
+++ b/src/H5private.h
@@ -187,9 +187,6 @@
  * Does the compiler support the __attribute__(()) syntax?  It's no
  * big deal if we don't.
  *
- * Note that Solaris Studio supports attribute, but does not support the
- * attributes we use.
- *
  * When using H5_ATTR_FALLTHROUGH, you should also include a comment that
  * says FALLTHROUGH to reduce warnings on compilers that don't use
  * attributes but do respect fall-through comments.
@@ -199,7 +196,7 @@
  * file). Be sure to update that file if the #ifdefs change here.
  */
 /* clang-format off */
-#if defined(H5_HAVE_ATTRIBUTE) && !defined(__SUNPRO_C)
+#if defined(H5_HAVE_ATTRIBUTE)
 #   define H5_ATTR_FORMAT(X, Y, Z) __attribute__((format(X, Y, Z)))
 #   define H5_ATTR_UNUSED          __attribute__((unused))
 

--- a/tools/test/perform/chunk.c
+++ b/tools/test/perform/chunk.c
@@ -24,8 +24,7 @@
 #include <stdlib.h>
 #include <string.h>
 
-/* Solaris Studio defines attribute, but for the attributes we need */
-#if !defined(H5_HAVE_ATTRIBUTE) || defined __cplusplus || defined(__SUNPRO_C)
+#if !defined(H5_HAVE_ATTRIBUTE) || defined __cplusplus
 #undef __attribute__
 #define __attribute__(X) /*void*/
 #define H5_ATTR_UNUSED   /*void*/

--- a/tools/test/perform/overhead.c
+++ b/tools/test/perform/overhead.c
@@ -30,8 +30,7 @@
 #include <unistd.h>
 #endif
 
-/* Solaris Studio defines attribute, but for the attributes we need */
-#if !defined(H5_HAVE_ATTRIBUTE) || defined __cplusplus || defined(__SUNPRO_C)
+#if !defined(H5_HAVE_ATTRIBUTE) || defined __cplusplus
 #undef __attribute__
 #define __attribute__(X) /*void*/
 #define H5_ATTR_UNUSED   /*void*/


### PR DESCRIPTION
Solaris Studio hasn't been updated in almost a decade and the last version (12.4, circa 2015) doesn't seem to fully support C11.

This PR removes some work-arounds for things like __attribute__() support.