### PR TITLE
Prefix DEFAULT_API_VERSION with HDF5_ in CMake

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -857,9 +857,16 @@ if (HDF5_ENABLE_SUBFILING_VFD)
   endif()
 endif()
 
+# Select the default API version
+set (HDF5_DEFAULT_API_VERSION "v118" CACHE STRING "Enable v1.16 API (v16, v18, v110, v112, v114, v116, v118)")
+set_property (CACHE HDF5_DEFAULT_API_VERSION PROPERTY STRINGS v16 v18 v110 v112 v114 v116 v118)
 
-set (DEFAULT_API_VERSION "v118" CACHE STRING "Enable v1.16 API (v16, v18, v110, v112, v114, v116, v118)")
-set_property (CACHE DEFAULT_API_VERSION PROPERTY STRINGS v16 v18 v110 v112 v114 v116 v118)
+# Most of the configure code uses DEFAULT_API_VERSION, so just set that
+# to be the same value as the HDF5_ option. We can use HDF5_DEFAULT_API_VERSION
+# when the Autotools go away.
+if (HDF5_DEFAULT_API_VERSION)
+  set (DEFAULT_API_VERSION ${HDF5_DEFAULT_API_VERSION})
+endif ()
 #-----------------------------------------------------------------------------
 # Option to use 1.6.x API
 #-----------------------------------------------------------------------------

--- a/release_docs/RELEASE.txt
+++ b/release_docs/RELEASE.txt
@@ -47,6 +47,10 @@ New Features
 
     Configuration:
     -------------
+    - Renamed DEFAULT_API_VERSION to HDF5_DEFAULT_API_VERSION in CMake
+
+      All other HDF5 library CMake options are prefixed with HDF5_
+
     - Dropped support for the traditional MSVC preprocessor
 
       Visual Studio has recently started using a standards-compliant


### PR DESCRIPTION
All other HDF5 library CMake options are prefixed with HDF5_