### PR TITLE
Move h5_test_init() calls after MPI_Init

### DIFF
--- a/testpar/t_pmulti_dset.c
+++ b/testpar/t_pmulti_dset.c
@@ -650,12 +650,12 @@ main(int argc, char *argv[])
     unsigned i;
     int      ret;
 
-    h5_test_init();
-
     /* Initialize MPI */
     MPI_Init(&argc, &argv);
     MPI_Comm_size(MPI_COMM_WORLD, &mpi_size);
     MPI_Comm_rank(MPI_COMM_WORLD, &mpi_rank);
+
+    h5_test_init();
 
     /* Generate random number seed, if rank 0 */
     if (MAINPROCESS)

--- a/testpar/t_select_io_dset.c
+++ b/testpar/t_select_io_dset.c
@@ -4086,12 +4086,12 @@ main(int argc, char *argv[])
     unsigned select;
     unsigned mwbuf;
 
-    h5_test_init();
-
     /* Initialize MPI */
     MPI_Init(&argc, &argv);
     MPI_Comm_size(MPI_COMM_WORLD, &mpi_size);
     MPI_Comm_rank(MPI_COMM_WORLD, &mpi_rank);
+
+    h5_test_init();
 
     if ((fapl = H5Pcreate(H5P_FILE_ACCESS)) < 0)
         P_TEST_ERROR;


### PR DESCRIPTION
Parallel HDF5 attempts to create a destructor attribute on the MPI Communicator object
`MPI_COMM_SELF` when the library initializes. This is to ensure that proper shutdown of the
library occurs during calls to `MPI_Finalize()` so that the library doesn't unintentionally make
use of MPI objects after MPI has been finalized. If MPI has not been initialized with a call to
`MPI_Init()` before HDF5 is initialized, the library will be unable to register its destructor attribute
on `MPI_COMM_SELF` and will be unable to properly shut down the library in some cases.