### PR TITLE
Disable Julia CI

### DIFF
--- a/.github/workflows/autotools.yml
+++ b/.github/workflows/autotools.yml
@@ -100,11 +100,11 @@ jobs:
         name: "Autotools TestExpress Workflows"
         uses: ./.github/workflows/testxpr-auto.yml
 
-    call-release-auto-julia:
-        name: "Autotools Julia Workflows"
-        uses: ./.github/workflows/julia-auto.yml
-        with:
-          build_mode: "production"
+#    call-release-auto-julia:
+#        name: "Autotools Julia Workflows"
+#        uses: ./.github/workflows/julia-auto.yml
+#        with:
+#          build_mode: "production"
 
 #  workflow-msys2-autotools:
 #    name: "CMake msys2 Workflows"

--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -115,8 +115,8 @@ jobs:
         name: "CMake TestExpress Workflows"
         uses: ./.github/workflows/testxpr-cmake.yml
 
-    call-release-cmake-julia:
-        name: "CMake Julia Workflows"
-        uses: ./.github/workflows/julia-cmake.yml
-        with:
-          build_mode: "Release"      
+#    call-release-cmake-julia:
+#        name: "CMake Julia Workflows"
+#        uses: ./.github/workflows/julia-cmake.yml
+#        with:
+#          build_mode: "Release"      


### PR DESCRIPTION
PR #4968 fixes a bug that causes the Julia CI to fail due to buggy HDF5 behavior. The Julia CI will need to be updated to properly test the fixed feature.