### PR TITLE
Patch Julia CI

### DIFF
--- a/.github/workflows/julia-auto.yml
+++ b/.github/workflows/julia-auto.yml
@@ -16,8 +16,16 @@ jobs:
     name: "julia ${{ inputs.build_mode }}"
     runs-on: ubuntu-latest
     steps:
-      - name: Get Sources
+      - name: Get HDF5 source
         uses: actions/checkout@v4.1.7
+
+        # Checking out the Julia HDF5 wrappers will clobber the HDF5 checkout
+        # NOTE: Remove this when the Julia wrappers have been patched
+      - name: Save the Julia patch file
+        shell: bash
+        run: |
+          mkdir "${{ runner.workspace }}/julia_patch"
+          cp .github/workflows/julia_ci.patch "${{ runner.workspace }}/julia_patch"
 
       - name: Install Dependencies
         shell: bash
@@ -64,6 +72,11 @@ jobs:
         with:
           repository: JuliaIO/HDF5.jl
           path: .
+
+        # NOTE: Remove this when the Julia wrappers have been patched
+      - name: Patch Julia CI
+        run:  |
+          git apply "${{ runner.workspace }}/julia_patch/julia_ci.patch" -v
 
       - name: Generate LocalPreferences
         run: |

--- a/.github/workflows/julia-cmake.yml
+++ b/.github/workflows/julia-cmake.yml
@@ -16,8 +16,16 @@ jobs:
     name: "julia ${{ inputs.build_mode }}"
     runs-on: ubuntu-latest
     steps:
-      - name: Get Sources
+      - name: Get HDF5 source
         uses: actions/checkout@v4.1.7
+
+        # Checking out the Julia HDF5 wrappers will clobber the HDF5 checkout
+        # NOTE: Remove this when the Julia wrappers have been patched
+      - name: Save the Julia patch file
+        shell: bash
+        run: |
+          mkdir "${{ runner.workspace }}/julia_patch"
+          cp .github/workflows/julia_ci.patch "${{ runner.workspace }}/julia_patch"
 
       - name: Install Dependencies
         shell: bash
@@ -67,6 +75,11 @@ jobs:
         with:
           repository: JuliaIO/HDF5.jl
           path: .
+
+        # NOTE: Remove this when the Julia wrappers have been patched
+      - name: Patch Julia CI
+        run:  |
+          git apply "${{ runner.workspace }}/julia_patch/julia_ci.patch" -v
 
       - name: Generate LocalPreferences
         run: |

--- a/.github/workflows/julia_ci.patch
+++ b/.github/workflows/julia_ci.patch
@@ -1,0 +1,19 @@
+diff --git a/test/objects.jl b/test/objects.jl
+index d68dd749..0541e91a 100644
+--- a/test/objects.jl
++++ b/test/objects.jl
+@@ -16,7 +16,13 @@ using HDF5.API
+     h5open(fn, "r") do h5f
+         @test API.h5o_exists_by_name(h5f, "data")
+         @test API.h5o_exists_by_name(h5f, "lore")
+-        @test_throws API.H5Error API.h5o_exists_by_name(h5f, "noonian")
++        @static if HDF5.API.h5_get_libversion() <= v"1.14.5"
++            # Buggy behavior in earlier versions of HDF5 returns FAIL (-1)
++            @test_throws API.H5Error API.h5o_exists_by_name(h5f, "noonian")
++        else
++            # The correct behavior is to return false (0)
++            @test API.h5o_exists_by_name(h5f, "noonian") == 0
++        end
+ 
+         loc_id = API.h5o_open(h5f, "data", API.H5P_DEFAULT)
+         try


### PR DESCRIPTION
A recent bugfix to the library changed the return value of an API call and a Julia CI action expects the incorrect result. This patch papers over this until the upstream Julia wrapper CI can be fixed.