### PR TITLE
Fix h5py CI failure

### DIFF
--- a/.github/workflows/h5py.yml
+++ b/.github/workflows/h5py.yml
@@ -21,7 +21,7 @@ jobs:
 
     - name: Run a multi-line script
       run: |
-        sed -i 's/hdf5@1.10.4:1.14/hdf5@1.10.4:/g' \
+        sed -i 's/hdf5@1.10.6:1.14/hdf5@1.10.6:/g' \
         ./spack/var/spack/repos/builtin/packages/py-h5py/package.py
         . ./spack/share/spack/setup-env.sh
         ./spack/bin/spack spec py-h5py@master+mpi ^hdf5@develop-1.17


### PR DESCRIPTION
Update minimal hdf5 version to 10.6 for Python 3.12,

Ref: https://github.com/spack/spack/pull/47132/files#diff-e14a9be8ba65e358b688fb91ac00a931d029c34c0db4f9384ea5f50cffee8444
