### PR TITLE
Get the Autotools version number from H5public.h

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-HDF5 version 1.17.0 currently under development
+HDF5 version 2.0.0 currently under development
 
 ![HDF5 Logo](doxygen/img/HDF5.png)
 

--- a/configure.ac
+++ b/configure.ac
@@ -4026,7 +4026,7 @@ fi
 
 ## HDF5 version from H5public.h (3rd field of #define H5_VERS_STR "1.17.0"
 ## w/ sed to remove quotes).
-H5_VERSION="`grep 'H5_VERS_STR' $srcdir/src/H5public.h | sed s/\"//g | cut -d' ' -f3`"
+H5_VERSION=`grep 'H5_VERS_STR' $srcdir/src/H5public.h | sed s/\"//g | cut -d' ' -f3`
 AC_SUBST([H5_VERSION])
 
 ## Configuration date

--- a/configure.ac
+++ b/configure.ac
@@ -4024,8 +4024,9 @@ fi
 ## and installed with the libraries (used to generate libhdf5.settings).
 ##
 
-## HDF5 version from the first line of the README.md file.
-H5_VERSION="`cut -d' ' -f3 $srcdir/README.md | head -1`"
+## HDF5 version from H5public.h (3rd field of #define H5_VERS_STR "1.17.0"
+## w/ sed to remove quotes).
+H5_VERSION="`grep 'H5_VERS_STR' $srcdir/src/H5public.h | sed s/\"//g | cut -d' ' -f3`"
 AC_SUBST([H5_VERSION])
 
 ## Configuration date


### PR DESCRIPTION
The version number in the Autotools is scraped from README.md in configure.ac, which makes README.md count as 'code', which is a problem since changes to markdown files are ignored in CI.

This change scrapes the version number from H5public.h instead of README.md.