### PR TITLE
Remove version number from h5repack test plugin

### DIFF
--- a/tools/test/h5repack/CMakeTests.cmake
+++ b/tools/test/h5repack/CMakeTests.cmake
@@ -1928,7 +1928,7 @@ ADD_H5_DMP_NO_OPT_TEST (tst_onion_objs "TEST" 0 tst_onion_objs.h5 --src-vfd-name
 ###    P L U G I N  T E S T S
 ##############################################################################
 if (BUILD_SHARED_LIBS)
-  ADD_H5_UD_TEST (plugin_version_test 0 h5repack_layout.h5 -v -f UD=260,0,4,9,${H5_VERS_MAJOR},${H5_VERS_MINOR},${H5_VERS_RELEASE})
+  ADD_H5_UD_TEST (plugin_version_test 0 h5repack_layout.h5 -v -f UD=260,0,0)
   ADD_H5_UD_TEST (plugin_test 0 h5repack_layout.h5 -v -f UD=257,0,1,9)
   ADD_H5_UD_TEST (plugin_none 0 h5repack_layout.UD.h5 -v -f NONE)
   # check for no parameters

--- a/tools/test/h5repack/dynlib_vrpk.c
+++ b/tools/test/h5repack/dynlib_vrpk.c
@@ -9,31 +9,34 @@
  * If you do not have access to either file, you may request a copy from     *
  * help@hdfgroup.org.                                                        *
  * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
+
 /*
- * Purpose:    Tests the plugin module (H5PL)
+ * Purpose:	Test group filter plugin for the filter_pluging.c test.
  */
 
 #include <stdlib.h>
 #include <stdio.h>
+#include <string.h>
+
 #include "H5PLextern.h"
 
-#define H5Z_FILTER_DYNLIB4 260
+#define FILTER4_ID   260
+#define SUFFIX_LEN   8
+#define GROUP_SUFFIX ".h5group"
 
-#define PUSH_ERR(func, minor, str)                                                                           \
-    H5Epush2(H5E_DEFAULT, __FILE__, func, __LINE__, H5E_ERR_CLS, H5E_PLUGIN, minor, str)
+static size_t append_to_group_name(unsigned int flags, size_t cd_nelmts, const unsigned int *cd_values,
+                                   size_t nbytes, size_t *buf_size, void **buf);
 
-static size_t H5Z_filter_dynlib4(unsigned int flags, size_t cd_nelmts, const unsigned int *cd_values,
-                                 size_t nbytes, size_t *buf_size, void **buf);
-
-/* This message derives from H5Z */
-const H5Z_class2_t H5Z_DYNLIB4[1] = {{
-    H5Z_CLASS_T_VERS,   /* H5Z_class_t version             */
-    H5Z_FILTER_DYNLIB4, /* Filter id number        */
-    1, 1,               /* Encoding and decoding enabled   */
-    "dynlib4",          /* Filter name for debugging    */
-    NULL,               /* The "can apply" callback        */
-    NULL,               /* The "set local" callback        */
-    H5Z_filter_dynlib4, /* The actual filter function    */
+/* Filter class struct */
+const H5Z_class2_t FILTER_INFO[1] = {{
+    H5Z_CLASS_T_VERS,       /* H5Z_class_t version              */
+    FILTER4_ID,             /* Filter ID number                 */
+    1,                      /* Encoding enabled                 */
+    1,                      /* Decoding enabled                 */
+    "test filter plugin 4", /* Filter name for debugging        */
+    NULL,                   /* The "can apply" callback         */
+    NULL,                   /* The "set local" callback         */
+    append_to_group_name,   /* The actual filter function       */
 }};
 
 H5PL_type_t
@@ -44,66 +47,66 @@ H5PLget_plugin_type(void)
 const void *
 H5PLget_plugin_info(void)
 {
-    return H5Z_DYNLIB4;
+    return FILTER_INFO;
 }
 
 /*-------------------------------------------------------------------------
- * Function:    H5Z_filter_dynlib4
+ * Function:	append_to_group_name
  *
- * Purpose:    A dynlib4 filter method that adds on and subtract from
- *              the original value with another value.  It will be built
- *              as a shared library.  plugin.c test will load and use
- *              this filter library. Designed to call a HDF function.
+ * Purpose:     On write:
+ *                  Appends the suffix ".h5group" to the group name
+ *              On read:
+ *                  Removes the ".h5group" suffix from the group name
  *
- * Return:    Success:    Data chunk size
- *
- *        Failure:    0
+ * Return:      Success:    Data size in bytes
+ *              Failure:    0
  *
  *-------------------------------------------------------------------------
  */
 static size_t
-H5Z_filter_dynlib4(unsigned int flags, size_t cd_nelmts, const unsigned int *cd_values, size_t nbytes,
-                   size_t *buf_size, void **buf)
+append_to_group_name(unsigned int flags, size_t cd_nelmts, const unsigned int *cd_values, size_t nbytes,
+                     size_t *buf_size, void **buf)
 {
-    int     *int_ptr  = (int *)*buf; /* Pointer to the data values */
-    size_t   buf_left = *buf_size;   /* Amount of data buffer left to process */
-    int      add_on   = 0;
-    unsigned ver_info[3];
+    size_t new_name_size = 0; /* Return value */
 
-    /* Check for the library version */
-    if (H5get_libversion(&ver_info[0], &ver_info[1], &ver_info[2]) < 0) {
-        PUSH_ERR("dynlib4", H5E_CALLBACK, "H5get_libversion");
-        return (0);
-    }
     /* Check for the correct number of parameters */
-    if (cd_nelmts == 0)
-        return (0);
+    if (cd_nelmts > 0)
+        return 0;
 
-    /* Check that permanent parameters are set correctly */
-    if (cd_values[0] > 9)
-        return (0);
+    /* Assignment to eliminate unused parameter warning. */
+    (void)cd_values;
 
-    if (ver_info[0] != cd_values[1] || ver_info[1] != cd_values[2]) {
-        PUSH_ERR("dynlib4", H5E_CALLBACK, "H5get_libversion does not match");
-        return (0);
+    if (flags & H5Z_FLAG_REVERSE) {
+        /* READ - Remove the suffix from the group name */
+        new_name_size = *buf_size = nbytes - SUFFIX_LEN;
+    }
+    else {
+        /* WRITE - Append the suffix to the group name */
+        void          *outbuf = NULL; /* Pointer to new buffer                    */
+        unsigned char *dst    = NULL; /* Temporary pointer to destination buffer  */
+
+        /* Get memory for the new, larger string buffer using the
+         * library's memory allocator.
+         */
+        if (NULL == (dst = (unsigned char *)(outbuf = H5allocate_memory(nbytes + SUFFIX_LEN, 0))))
+            return 0;
+
+        /* Copy raw data */
+        memcpy((void *)dst, (const void *)(*buf), nbytes);
+
+        /* Append suffix to raw data for storage */
+        dst += nbytes;
+        memcpy((void *)dst, (const void *)GROUP_SUFFIX, SUFFIX_LEN);
+
+        /* Free the passed-in buffer using the library's allocator */
+        H5free_memory(*buf);
+
+        /* Set return values */
+        *buf_size     = nbytes + SUFFIX_LEN;
+        *buf          = outbuf;
+        outbuf        = NULL;
+        new_name_size = *buf_size;
     }
 
-    add_on = (int)cd_values[0];
-
-    if (flags & H5Z_FLAG_REVERSE) { /*read*/
-        /* Subtract the "add on" value to all the data values */
-        while (buf_left > 0) {
-            *int_ptr++ -= add_on;
-            buf_left -= sizeof(int);
-        }  /* end while */
-    }      /* end if */
-    else { /*write*/
-        /* Add the "add on" value to all the data values */
-        while (buf_left > 0) {
-            *int_ptr++ += add_on;
-            buf_left -= sizeof(int);
-        } /* end while */
-    }     /* end else */
-
-    return nbytes;
-} /* end H5Z_filter_dynlib4() */
+    return new_name_size;
+} /* append_to_group_name() */

--- a/tools/test/h5repack/expected/h5repack_layout.h5-plugin_version_test.ddl
+++ b/tools/test/h5repack/expected/h5repack_layout.h5-plugin_version_test.ddl
@@ -5,13 +5,12 @@ GROUP "/" {
       DATASPACE  SIMPLE { ( 40, 20 ) / ( 40, 20 ) }
       STORAGE_LAYOUT {
          CHUNKED ( 40, 20 )
-         SIZE 3200 (1.000:1 COMPRESSION)
+         SIZE 3208 (0.998:1 COMPRESSION)
       }
       FILTERS {
          USER_DEFINED_FILTER {
             FILTER_ID 260
-            COMMENT dynlib4
-            PARAMS { 9 1 17 0 }
+            COMMENT test filter plugin 4
          }
       }
       FILLVALUE {
@@ -27,13 +26,12 @@ GROUP "/" {
       DATASPACE  SIMPLE { ( 40, 20 ) / ( 40, 20 ) }
       STORAGE_LAYOUT {
          CHUNKED ( 40, 20 )
-         SIZE 3200 (1.000:1 COMPRESSION)
+         SIZE 3208 (0.998:1 COMPRESSION)
       }
       FILTERS {
          USER_DEFINED_FILTER {
             FILTER_ID 260
-            COMMENT dynlib4
-            PARAMS { 9 1 17 0 }
+            COMMENT test filter plugin 4
          }
       }
       FILLVALUE {
@@ -49,13 +47,12 @@ GROUP "/" {
       DATASPACE  SIMPLE { ( 40, 20 ) / ( 40, 20 ) }
       STORAGE_LAYOUT {
          CHUNKED ( 40, 20 )
-         SIZE 3200 (1.000:1 COMPRESSION)
+         SIZE 3208 (0.998:1 COMPRESSION)
       }
       FILTERS {
          USER_DEFINED_FILTER {
             FILTER_ID 260
-            COMMENT dynlib4
-            PARAMS { 9 1 17 0 }
+            COMMENT test filter plugin 4
          }
       }
       FILLVALUE {
@@ -71,13 +68,12 @@ GROUP "/" {
       DATASPACE  SIMPLE { ( 40, 20 ) / ( 40, 20 ) }
       STORAGE_LAYOUT {
          CHUNKED ( 40, 20 )
-         SIZE 3200 (1.000:1 COMPRESSION)
+         SIZE 3208 (0.998:1 COMPRESSION)
       }
       FILTERS {
          USER_DEFINED_FILTER {
             FILTER_ID 260
-            COMMENT dynlib4
-            PARAMS { 9 1 17 0 }
+            COMMENT test filter plugin 4
          }
       }
       FILLVALUE {
@@ -93,13 +89,12 @@ GROUP "/" {
       DATASPACE  SIMPLE { ( 40, 20 ) / ( 40, 20 ) }
       STORAGE_LAYOUT {
          CHUNKED ( 20, 10 )
-         SIZE 3200 (1.000:1 COMPRESSION)
+         SIZE 3232 (0.990:1 COMPRESSION)
       }
       FILTERS {
          USER_DEFINED_FILTER {
             FILTER_ID 260
-            COMMENT dynlib4
-            PARAMS { 9 1 17 0 }
+            COMMENT test filter plugin 4
          }
       }
       FILLVALUE {
@@ -115,13 +110,12 @@ GROUP "/" {
       DATASPACE  SIMPLE { ( 40, 20 ) / ( 40, 20 ) }
       STORAGE_LAYOUT {
          CHUNKED ( 40, 20 )
-         SIZE 3200 (1.000:1 COMPRESSION)
+         SIZE 3208 (0.998:1 COMPRESSION)
       }
       FILTERS {
          USER_DEFINED_FILTER {
             FILTER_ID 260
-            COMMENT dynlib4
-            PARAMS { 9 1 17 0 }
+            COMMENT test filter plugin 4
          }
       }
       FILLVALUE {
@@ -137,13 +131,12 @@ GROUP "/" {
       DATASPACE  SIMPLE { ( 40, 20 ) / ( 40, 20 ) }
       STORAGE_LAYOUT {
          CHUNKED ( 40, 20 )
-         SIZE 3200 (1.000:1 COMPRESSION)
+         SIZE 3208 (0.998:1 COMPRESSION)
       }
       FILTERS {
          USER_DEFINED_FILTER {
             FILTER_ID 260
-            COMMENT dynlib4
-            PARAMS { 9 1 17 0 }
+            COMMENT test filter plugin 4
          }
       }
       FILLVALUE {

--- a/tools/test/h5repack/expected/plugin_version_test.h5repack_layout.h5.tst
+++ b/tools/test/h5repack/expected/plugin_version_test.h5repack_layout.h5.tst
@@ -6,10 +6,10 @@ Making new file ...
  Type     Filter (Compression)     Name
 -----------------------------------------
  group                       /
- dset     UD   (1.000:1)     /dset1
- dset     UD   (1.000:1)     /dset2
- dset     UD   (1.000:1)     /dset3
- dset     UD   (1.000:1)     /dset4
- dset     UD   (1.000:1)     /dset_chunk
- dset     UD   (1.000:1)     /dset_compact
- dset     UD   (1.000:1)     /dset_contiguous
+ dset     UD   (0.998:1)     /dset1
+ dset     UD   (0.998:1)     /dset2
+ dset     UD   (0.998:1)     /dset3
+ dset     UD   (0.998:1)     /dset4
+ dset     UD   (0.990:1)     /dset_chunk
+ dset     UD   (0.998:1)     /dset_compact
+ dset     UD   (0.998:1)     /dset_contiguous

--- a/tools/test/h5repack/h5repack_plugin.sh.in
+++ b/tools/test/h5repack/h5repack_plugin.sh.in
@@ -245,10 +245,9 @@ TOOLTEST_DUMP()
 ##############################################################################
 # prepare for test
 COPY_TESTFILES_TO_TESTDIR
-version_str=`echo @H5_VERSION@ | awk -F"-" '{print $1}' | sed 's/\./,/g'`
 
 # Run the test
-arg="h5repack_layout.h5 -v -f UD=260,0,4,9,$version_str"
+arg="h5repack_layout.h5 -v -f UD=260,0,0"
 TOOLTEST_DUMP plugin_version_test $arg
 
 arg="h5repack_layout.h5 -v -f UD=257,0,1,9"


### PR DESCRIPTION
The h5repack test uses an older copy of a plugin from test that appended the version number to group names. The plugin in test was updated to use a fixed string instead, but the h5repack copy wasn't updated.

We'll remove this copy and just use the plugin from test after the Autotools are removed.