### PR TITLE
Fix minor Windows warnings

### DIFF
--- a/src/H5HFhuge.c
+++ b/src/H5HFhuge.c
@@ -192,7 +192,7 @@ H5HF__huge_init(H5HF_hdr_t *hdr)
             hdr->huge_ids_direct = false;
     } /* end if */
     else {
-        if ((hdr->sizeof_addr + hdr->sizeof_size) <= (hdr->id_len - 1)) {
+        if ((unsigned)(hdr->sizeof_addr + hdr->sizeof_size) <= (unsigned)(hdr->id_len - 1)) {
             /* Indicate that v2 B-tree doesn't have to be used to locate object */
             hdr->huge_ids_direct = true;
 

--- a/test/external_common.c
+++ b/test/external_common.c
@@ -82,7 +82,6 @@ reset_raw_data_files(bool is_env)
 
         /* Close this file */
         HDclose(fd);
-
     }
 
     /* The *w files are only pre-filled with the garbage data and are
@@ -109,7 +108,6 @@ reset_raw_data_files(bool is_env)
 
         /* Close this file */
         HDclose(fd);
-
     }
 
     free(garbage);

--- a/test/external_common.c
+++ b/test/external_common.c
@@ -31,12 +31,16 @@ reset_raw_data_files(bool is_env)
 {
     int      fd = 0;          /* external file descriptor             */
     size_t   i, j;            /* iterators                            */
-    hssize_t n;               /* bytes of I/O                         */
     char     filename[1024];  /* file name                            */
     int      data[PART_SIZE]; /* raw data buffer                      */
     uint8_t *garbage = NULL;  /* buffer of garbage data               */
     size_t   garbage_count;   /* size of garbage buffer               */
     size_t   garbage_bytes;   /* # of garbage bytes written to file   */
+
+    h5_posix_io_ret_t n; /* bytes of I/O - use our platform-independent POSIX
+                          * I/O return type to avoid warnings on platforms
+                          * where the return type isn't ssize_t (e.g., Windows)
+                          */
 
     /* Set up garbage buffer */
     garbage_count = N_EXT_FILES * GARBAGE_PER_FILE;
@@ -69,7 +73,7 @@ reset_raw_data_files(bool is_env)
         /* Fill array with data */
         for (j = 0; j < PART_SIZE; j++) {
             data[j] = (int)(i * 25 + j);
-        } /* end for */
+        }
 
         /* Write raw data to the file. */
         n = HDwrite(fd, data, sizeof(data));
@@ -79,7 +83,7 @@ reset_raw_data_files(bool is_env)
         /* Close this file */
         HDclose(fd);
 
-    } /* end for */
+    }
 
     /* The *w files are only pre-filled with the garbage data and are
      * used to verify that write operations work correctly. The individual
@@ -106,7 +110,8 @@ reset_raw_data_files(bool is_env)
         /* Close this file */
         HDclose(fd);
 
-    } /* end for */
+    }
+
     free(garbage);
     return SUCCEED;
 

--- a/test/h5test.c
+++ b/test/h5test.c
@@ -789,7 +789,7 @@ h5_get_vfd_fapl(hid_t fapl)
         /* Multi-file driver, general case of the split driver */
         H5FD_mem_t   memb_map[H5FD_MEM_NTYPES];
         hid_t        memb_fapl[H5FD_MEM_NTYPES];
-        const char  *memb_name[H5FD_MEM_NTYPES];
+        const char  *memb_name[H5FD_MEM_NTYPES] = {0};
         char        *sv[H5FD_MEM_NTYPES];
         haddr_t      memb_addr[H5FD_MEM_NTYPES];
         H5FD_mem_t   mt;
@@ -797,7 +797,6 @@ h5_get_vfd_fapl(hid_t fapl)
 
         memset(memb_map, 0, sizeof(memb_map));
         memset(memb_fapl, 0, sizeof(memb_fapl));
-        memset(memb_name, 0, sizeof(memb_name));
         memset(memb_addr, 0, sizeof(memb_addr));
 
         assert(strlen(multi_letters) == H5FD_MEM_NTYPES);
@@ -808,7 +807,7 @@ h5_get_vfd_fapl(hid_t fapl)
             snprintf(sv[mt], multi_memname_maxlen, "%%s-%c.h5", multi_letters[mt]);
             memb_name[mt] = sv[mt];
             memb_addr[mt] = (haddr_t)MAX(mt - 1, 0) * (HADDR_MAX / 10);
-        } /* end for */
+        }
 
         if (H5Pset_fapl_multi(fapl, memb_map, memb_fapl, memb_name, memb_addr, false) < 0)
             goto error;
@@ -1628,9 +1627,13 @@ int
 h5_make_local_copy(const char *origfilename, const char *local_copy_name)
 {
     int         fd_old = (-1), fd_new = (-1);                    /* File descriptors for copying data */
-    ssize_t     nread;                                           /* Number of bytes read in */
     void       *buf      = NULL;                                 /* Buffer for copying data */
     const char *filename = H5_get_srcdir_filename(origfilename); /* Get the test file name to copy */
+
+    h5_posix_io_ret_t nread; /* bytes of I/O - use our platform-independent POSIX
+                              * I/O return type to avoid warnings on platforms
+                              * where the return type isn't ssize_t (e.g., Windows)
+                              */
 
     if (!filename)
         goto error;
@@ -1646,8 +1649,8 @@ h5_make_local_copy(const char *origfilename, const char *local_copy_name)
         goto error;
 
     /* Copy data */
-    while ((nread = HDread(fd_old, buf, (size_t)READ_BUF_SIZE)) > 0)
-        if (HDwrite(fd_new, buf, (size_t)nread) < 0)
+    while ((nread = HDread(fd_old, buf, (h5_posix_io_t)READ_BUF_SIZE)) > 0)
+        if (HDwrite(fd_new, buf, (h5_posix_io_t)nread) < 0)
             goto error;
 
     /* Close files */

--- a/tools/lib/h5diff.c
+++ b/tools/lib/h5diff.c
@@ -1281,7 +1281,9 @@ diff_match(hid_t file1_id, const char *grp1, trav_info_t *info1, hid_t file2_id,
     }
 #endif /* H5_HAVE_PARALLEL */
 
+#if defined(H5_HAVE_ASPRINTF) || defined(H5_HAVE_PARALLEL)
 done:
+#endif
     free(obj1_fullpath);
     free(obj2_fullpath);
 


### PR DESCRIPTION
* Cast away a signed/unsigned issue in H5HFhuge.c
* Use our platform-independent POSIX types in external_common.c and h5test.c
* Replace a memset() call with a (const) array initializer in h5test.c
* Fix an unused done: target in h5diff