### PR TITLE
Remove comment about multi VFD duplication

### DIFF
--- a/src/H5warnings.h
+++ b/src/H5warnings.h
@@ -19,10 +19,6 @@
 
 /* Macros for enabling/disabling particular GCC / clang warnings
  *
- * These are duplicated in H5FDmulti.c (we don't want to put them in the
- * public header and the multi VFD can't use private headers). If you make
- * changes here, be sure to update those as well.
- *
  * (see the following web-sites for more info:
  *      http://www.dbp-consulting.com/tutorials/SuppressingGCCWarnings.html
  *      http://gcc.gnu.org/onlinedocs/gcc/Diagnostic-Pragmas.html#Diagnostic-Pragmas


### PR DESCRIPTION
We used to duplicate the warning macros in H5FDmulti.c when they were in
H5private.h. Now that they are in a separate header, we can use them
directly.