### PR TITLE
Add callable workflows for building OpenMPI and MPICH from source

### DIFF
--- a/.github/workflows/build_mpich_source.yml
+++ b/.github/workflows/build_mpich_source.yml
@@ -1,0 +1,82 @@
+# Build MPICH from source using the latest commit on the
+# 'main' branch and cache the results. The result is installed
+# to (or restored to) '${{ runner.workspace }}/mpich'.
+
+# Triggers the workflow on a call from another workflow
+on:
+  workflow_call:
+    inputs:
+      build_mode:
+        description: "production vs. debug build"
+        required: true
+        type: string
+
+permissions:
+  contents: read
+
+jobs:
+  ubuntu_gcc_build_and_test:
+    name: "Build MPICH ${{ inputs.build_mode }} (GCC)"
+
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Install Linux dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install build-essential libtool libtool-bin
+
+      - name: Get MPICH source
+        uses: actions/checkout@v4.1.7
+        with:
+          repository: 'pmodels/mpich'
+          path: 'mpich'
+          submodules: recursive
+
+      - name: Get MPICH commit hash
+        shell: bash
+        id: get-sha
+        run: |
+          cd $GITHUB_WORKSPACE/mpich
+          export MPICH_SHA=$(git rev-parse HEAD)
+          echo "MPICH_SHA=$MPICH_SHA" >> $GITHUB_ENV
+          echo "sha=$MPICH_SHA" >> $GITHUB_OUTPUT
+          # Output SHA for debugging
+          echo "MPICH_SHA=$MPICH_SHA"
+
+      - name: Cache MPICH (GCC) installation
+        id: cache-mpich-ubuntu-gcc
+        uses: actions/cache@v4
+        with:
+          path: ${{ runner.workspace }}/mpich
+          key: ${{ runner.os }}-${{ runner.arch }}-gcc-mpich-${{ steps.get-sha.outputs.sha }}-${{ inputs.build_mode }}
+
+      # Enable threads=multiple for testing with Subfiling and
+      # VOL connectors that require MPI_THREAD_MULTIPLE
+      - name: Install MPICH (GCC) (Production)
+        if: ${{ steps.cache-mpich-ubuntu-gcc.cache-hit != 'true' && (inputs.build_mode != 'debug') }}
+        run: |
+          cd $GITHUB_WORKSPACE/mpich
+          ./autogen.sh
+          ./configure \
+            CC=gcc \
+            --prefix=${{ runner.workspace }}/mpich \
+            --enable-threads=multiple
+          make -j2
+          make install
+
+      # Enable threads=multiple for testing with Subfiling and
+      # VOL connectors that require MPI_THREAD_MULTIPLE
+      - name: Install MPICH (GCC) (Debug)
+        if: ${{ steps.cache-mpich-ubuntu-gcc.cache-hit != 'true' && (inputs.build_mode == 'debug') }}
+        run: |
+          cd $GITHUB_WORKSPACE/mpich
+          ./autogen.sh
+          ./configure \
+            CC=gcc \
+            --prefix=${{ runner.workspace }}/mpich \
+            --enable-g=most \
+            --enable-debuginfo \
+            --enable-threads=multiple
+          make -j2
+          make install

--- a/.github/workflows/build_openmpi_source.yml
+++ b/.github/workflows/build_openmpi_source.yml
@@ -1,0 +1,75 @@
+# Build OpenMPI from source using the latest commit on the
+# 'main' branch and cache the results. The result is installed
+# to (or restored to) '${{ runner.workspace }}/openmpi'.
+
+# Triggers the workflow on a call from another workflow
+on:
+  workflow_call:
+    inputs:
+      build_mode:
+        description: "production vs. debug build"
+        required: true
+        type: string
+
+permissions:
+  contents: read
+
+jobs:
+  ubuntu_gcc_build_and_test:
+    name: "Build OpenMPI ${{ inputs.build_mode }} (GCC)"
+
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Install Linux dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install build-essential libtool libtool-bin
+
+      - name: Get OpenMPI source
+        uses: actions/checkout@v4.1.7
+        with:
+          repository: 'open-mpi/ompi'
+          path: 'ompi'
+          submodules: recursive
+
+      - name: Get OpenMPI commit hash
+        shell: bash
+        id: get-sha
+        run: |
+          cd $GITHUB_WORKSPACE/ompi
+          export OPENMPI_SHA=$(git rev-parse HEAD)
+          echo "OPENMPI_SHA=$OPENMPI_SHA" >> $GITHUB_ENV
+          echo "sha=$OPENMPI_SHA" >> $GITHUB_OUTPUT
+          # Output SHA for debugging
+          echo "OPENMPI_SHA=$OPENMPI_SHA"
+
+      - name: Cache OpenMPI (GCC) installation
+        id: cache-openmpi-ubuntu-gcc
+        uses: actions/cache@v4
+        with:
+          path: ${{ runner.workspace }}/openmpi
+          key: ${{ runner.os }}-${{ runner.arch }}-gcc-openmpi-${{ steps.get-sha.outputs.sha }}-${{ inputs.build_mode }}
+
+      - name: Install OpenMPI (GCC) (Production)
+        if: ${{ steps.cache-openmpi-ubuntu-gcc.cache-hit != 'true' && (inputs.build_mode != 'debug') }}
+        run: |
+          cd $GITHUB_WORKSPACE/ompi
+          ./autogen.pl
+          ./configure \
+            CC=gcc \
+            --prefix=${{ runner.workspace }}/openmpi
+          make -j2
+          make install
+
+      - name: Install OpenMPI (GCC) (Debug)
+        if: ${{ steps.cache-openmpi-ubuntu-gcc.cache-hit != 'true' && (inputs.build_mode == 'debug') }}
+        run: |
+          cd $GITHUB_WORKSPACE/ompi
+          ./autogen.pl
+          ./configure \
+            CC=gcc \
+            --prefix=${{ runner.workspace }}/openmpi \
+            --enable-debug
+          make -j2
+          make install


### PR DESCRIPTION
These workflows don't do anything alone; they have to be called from another workflow. Each builds (if necessary) their respective MPI implementation and then installs it to (or restores it from cache to) '${{ runner.workspace }}/\<implementation\>' for use in the calling workflow. Primarily created for https://github.com/HDFGroup/hdf5/pull/5032, but made more reusable for future workflows. Currently building is only done on Ubuntu with GCC.