### PR TITLE
Don't add util subdirs when VFDs are not enabled

### DIFF
--- a/utils/CMakeLists.txt
+++ b/utils/CMakeLists.txt
@@ -7,8 +7,12 @@ endif ()
 
 option (HDF5_BUILD_UTILS  "Build HDF5 Utils" ON)
 if (HDF5_BUILD_UTILS)
-  add_subdirectory (mirror_vfd)
-  add_subdirectory (subfiling_vfd)
+  if (HDF5_ENABLE_MIRROR_VFD)  
+    add_subdirectory (mirror_vfd)
+  endif ()
+  if (HDF5_ENABLE_SUBFILING_VFD)  
+    add_subdirectory (subfiling_vfd)
+  endif ()
 endif ()
 
 #-- Add the h5dwalk and test executables


### PR DESCRIPTION
There's no need to build the helpers in util if the VFD isn't enabled.

Fixes #4984.