### PR TITLE
Add OSS-Fuzz badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ HDF5 version 2.0.0 currently under development
 [![HDF5 VOL connectors build status](https://img.shields.io/github/actions/workflow/status/HDFGroup/hdf5/vol.yml?branch=develop&label=HDF5-VOL)](https://github.com/HDFGroup/hdf5/actions/workflows/vol.yml?query=branch%3Adevelop)
 [![HDF5 VFD build status](https://img.shields.io/github/actions/workflow/status/HDFGroup/hdf5/vfd.yml?branch=develop&label=HDF5-VFD)](https://github.com/HDFGroup/hdf5/actions/workflows/vfd.yml?query=branch%3Adevelop)
 [![BSD](https://img.shields.io/badge/License-BSD-blue.svg)](https://github.com/HDFGroup/hdf5/blob/develop/LICENSE)
+[![OSS-Fuzz Status](https://oss-fuzz-build-logs.storage.googleapis.com/badges/hdf5.svg)](https://oss-fuzz-build-logs.storage.googleapis.com/index.html#hdf5)
 
 [HPC configure/build/test results](https://my.cdash.org/index.php?project=HDF5)
 


### PR DESCRIPTION
This badge can boost the confidence for new HDF5 adapters 
when they have doubts in reliability and security.

Developers can check things quickly when there are fuzz issues.
