### PR TITLE
Fixed allocation-size-too-big error in H5MM.c

### DIFF
--- a/src/H5Centry.c
+++ b/src/H5Centry.c
@@ -954,7 +954,8 @@ H5C__verify_len_eoa(H5F_t *f, const H5C_class_t *type, haddr_t addr, size_t *len
         } /* end if */
     }
     else {
-        HGOTO_ERROR(H5E_CACHE, H5E_BADVALUE, FAIL, "total of addr and len exceeds max possible value (potential corrupted data)");
+        HGOTO_ERROR(H5E_CACHE, H5E_BADVALUE, FAIL,
+                    "total of addr and len exceeds max possible value (potential corrupted data)");
     }
 
     if (*len <= 0)

--- a/src/H5Centry.c
+++ b/src/H5Centry.c
@@ -954,7 +954,7 @@ H5C__verify_len_eoa(H5F_t *f, const H5C_class_t *type, haddr_t addr, size_t *len
             if (*len <= 0)
                 HGOTO_ERROR(H5E_CACHE, H5E_BADVALUE, FAIL, "len not positive after adjustment for EOA");
         } /* end else */
-    } /* end if */
+    }     /* end if */
 
 done:
     FUNC_LEAVE_NOAPI(ret_value)

--- a/src/H5Centry.c
+++ b/src/H5Centry.c
@@ -944,13 +944,18 @@ H5C__verify_len_eoa(H5F_t *f, const H5C_class_t *type, haddr_t addr, size_t *len
         HGOTO_ERROR(H5E_CACHE, H5E_BADVALUE, FAIL, "address of object past end of allocation");
 
     /* Check if the amount of data to read will be past the EOA */
-    if (H5_addr_gt((addr + *len), eoa)) {
-        if (actual)
-            HGOTO_ERROR(H5E_CACHE, H5E_BADVALUE, FAIL, "actual len exceeds EOA");
-        else
-            /* Trim down the length of the metadata */
-            *len = (size_t)(eoa - addr);
-    } /* end if */
+    if ((ULONG_MAX - *len) >= addr) {
+        if (H5_addr_gt((addr + *len), eoa)) {
+            if (actual)
+                HGOTO_ERROR(H5E_CACHE, H5E_BADVALUE, FAIL, "actual len exceeds EOA");
+            else
+                /* Trim down the length of the metadata */
+                *len = (size_t)(eoa - addr);
+        } /* end if */
+    }
+    else {
+        HGOTO_ERROR(H5E_CACHE, H5E_BADVALUE, FAIL, "total of addr and len exceeds max possible value (potential corrupted data)");
+    }
 
     if (*len <= 0)
         HGOTO_ERROR(H5E_CACHE, H5E_BADVALUE, FAIL, "len not positive after adjustment for EOA");

--- a/src/H5Centry.c
+++ b/src/H5Centry.c
@@ -943,23 +943,18 @@ H5C__verify_len_eoa(H5F_t *f, const H5C_class_t *type, haddr_t addr, size_t *len
     if (H5_addr_gt(addr, eoa))
         HGOTO_ERROR(H5E_CACHE, H5E_BADVALUE, FAIL, "address of object past end of allocation");
 
-    /* Check if the amount of data to read will be past the EOA */
-    if ((ULONG_MAX - *len) >= addr) {
-        if (H5_addr_gt((addr + *len), eoa)) {
-            if (actual)
-                HGOTO_ERROR(H5E_CACHE, H5E_BADVALUE, FAIL, "actual len exceeds EOA");
-            else
-                /* Trim down the length of the metadata */
-                *len = (size_t)(eoa - addr);
-        } /* end if */
-    }
-    else {
-        HGOTO_ERROR(H5E_CACHE, H5E_BADVALUE, FAIL,
-                    "total of addr and len exceeds max possible value (potential corrupted data)");
-    }
+    /* Check if the amount of data to read will be past the EOA, or wraps around */
+    if (H5_addr_lt((addr + *len), addr) || H5_addr_gt((addr + *len), eoa)) {
+        if (actual)
+            HGOTO_ERROR(H5E_CACHE, H5E_BADVALUE, FAIL, "actual len exceeds EOA");
+        else {
+            /* Trim down the length of the metadata */
+            *len = (size_t)(eoa - addr);
 
-    if (*len <= 0)
-        HGOTO_ERROR(H5E_CACHE, H5E_BADVALUE, FAIL, "len not positive after adjustment for EOA");
+            if (*len <= 0)
+                HGOTO_ERROR(H5E_CACHE, H5E_BADVALUE, FAIL, "len not positive after adjustment for EOA");
+        } /* end else */
+    } /* end if */
 
 done:
     FUNC_LEAVE_NOAPI(ret_value)


### PR DESCRIPTION
A decoded length appeared to be corrupted and had a very large value.
This PR added a check to detect such potential data corruption.

The [fuzzer file](https://github.com/HDFGroup/cve_hdf5/blob/main/fuzzerfiles/gh-4431-poc-03.h5) is in the cve_hdf5 repo.

Fixes GH-4431