### PR TITLE
Make H5F_LIBVER_LATEST a real enum value

### DIFF
--- a/java/src/hdf/hdf5lib/HDF5Constants.java
+++ b/java/src/hdf/hdf5lib/HDF5Constants.java
@@ -575,9 +575,9 @@ public class HDF5Constants {
     /** */
     public static final int H5F_LIBVER_V200 = H5F_LIBVER_V200();
     /** */
-    public static final int H5F_LIBVER_NBOUNDS = H5F_LIBVER_NBOUNDS();
-    /** */
     public static final int H5F_LIBVER_LATEST = H5F_LIBVER_LATEST();
+    /** */
+    public static final int H5F_LIBVER_NBOUNDS = H5F_LIBVER_NBOUNDS();
     /** */
     public static final int H5F_OBJ_ALL = H5F_OBJ_ALL();
     /** */
@@ -2080,9 +2080,9 @@ public class HDF5Constants {
 
     private static native final int H5F_LIBVER_V200();
 
-    private static native final int H5F_LIBVER_NBOUNDS();
-
     private static native final int H5F_LIBVER_LATEST();
+
+    private static native final int H5F_LIBVER_NBOUNDS();
 
     private static native final int H5F_OBJ_ALL();
 

--- a/java/src/jni/h5Constants.c
+++ b/java/src/jni/h5Constants.c
@@ -1309,14 +1309,14 @@ Java_hdf_hdf5lib_HDF5Constants_H5F_1LIBVER_1V200(JNIEnv *env, jclass cls)
     return H5F_LIBVER_V200;
 }
 JNIEXPORT jint JNICALL
-Java_hdf_hdf5lib_HDF5Constants_H5F_1LIBVER_1NBOUNDS(JNIEnv *env, jclass cls)
-{
-    return H5F_LIBVER_NBOUNDS;
-}
-JNIEXPORT jint JNICALL
 Java_hdf_hdf5lib_HDF5Constants_H5F_1LIBVER_1LATEST(JNIEnv *env, jclass cls)
 {
     return H5F_LIBVER_LATEST;
+}
+JNIEXPORT jint JNICALL
+Java_hdf_hdf5lib_HDF5Constants_H5F_1LIBVER_1NBOUNDS(JNIEnv *env, jclass cls)
+{
+    return H5F_LIBVER_NBOUNDS;
 }
 JNIEXPORT jint JNICALL
 Java_hdf_hdf5lib_HDF5Constants_H5F_1OBJ_1ALL(JNIEnv *env, jclass cls)

--- a/release_docs/RELEASE.txt
+++ b/release_docs/RELEASE.txt
@@ -156,6 +156,17 @@ New Features
 
     Library:
     --------
+    - H5F_LIBVER_LATEST is now an enum value
+
+      This was previously #defined to the latest H5F_libver_t API version, but
+      is now an enum value with an integer value equal to the latest H5F_libver_t
+      API version's value. e.g.:
+
+            <snip>
+            H5F_LIBVER_V200     = 5,
+            H5F_LIBVER_LATEST   = 5,
+            </snip>
+
     - Added support for complex number datatypes
 
       Support for the C99 "float _Complex", "double _Complex" and "long double _Complex"

--- a/src/H5Fpublic.h
+++ b/src/H5Fpublic.h
@@ -163,16 +163,15 @@ typedef struct H5F_sect_info_t {
  */
 typedef enum H5F_libver_t {
     H5F_LIBVER_ERROR    = -1,
-    H5F_LIBVER_EARLIEST = 0, /**< Use the earliest possible format for storing objects */
-    H5F_LIBVER_V18      = 1, /**< Use the latest v18 format for storing objects */
-    H5F_LIBVER_V110     = 2, /**< Use the latest v110 format for storing objects */
-    H5F_LIBVER_V112     = 3, /**< Use the latest v112 format for storing objects */
-    H5F_LIBVER_V114     = 4, /**< Use the latest v114 format for storing objects */
-    H5F_LIBVER_V200     = 5, /**< Use the latest v200 format for storing objects */
+    H5F_LIBVER_EARLIEST = 0, /**< Use the earliest possible file format for storing objects */
+    H5F_LIBVER_V18      = 1, /**< Use the 1.8 file format for storing objects */
+    H5F_LIBVER_V110     = 2, /**< Use the 1.10 file format for storing objects */
+    H5F_LIBVER_V112     = 3, /**< Use the 1.12 file format for storing objects */
+    H5F_LIBVER_V114     = 4, /**< Use the 1.14 file format for storing objects */
+    H5F_LIBVER_V200     = 5, /**< Use the 2.0 file format for storing objects */
+    H5F_LIBVER_LATEST   = 5, /**< Use the latest file format for storing objects */
     H5F_LIBVER_NBOUNDS       /**< Sentinel */
 } H5F_libver_t;
-
-#define H5F_LIBVER_LATEST H5F_LIBVER_V200
 
 /**
  * File space handling strategy

--- a/src/H5Ppublic.h
+++ b/src/H5Ppublic.h
@@ -4967,9 +4967,9 @@ H5_DLL herr_t H5Pset_gc_references(hid_t fapl_id, unsigned gc_ref);
  *          enumerated values in the #H5F_libver_t struct, which is
  *          defined in H5Fpublic.h.
  *
- *          The macro #H5F_LIBVER_LATEST is aliased to the highest
- *          enumerated value in #H5F_libver_t, indicating that this is
- *          currently the latest format available.
+ *          #H5F_LIBVER_LATEST is equivalent to the highest explicitly numbered
+ *          API value in #H5F_libver_t, indicating that this is currently the
+ *          latest format available.
  *
  *          The library supports the following pairs of (\p low, \p high)
  *          combinations as derived from the values in #H5F_libver_t:


### PR DESCRIPTION
It was formerly a macro, but is now an enum value with the same value as the latest numbered API.