### PR TITLE
Move overflow macros from VFDs to H5FDpkg.h

### DIFF
--- a/src/H5FDhdfs.c
+++ b/src/H5FDhdfs.c
@@ -230,19 +230,6 @@ typedef struct H5FD_hdfs_t {
 #endif
 } H5FD_hdfs_t;
 
-/*
- * These macros check for overflow of various quantities.  These macros
- * assume that HDoff_t is signed and haddr_t and size_t are unsigned.
- *
- * ADDR_OVERFLOW:   Checks whether a file address of type `haddr_t'
- *                  is too large to be represented by the second argument
- *                  of the file seek function.
- *                  Only included if HDFS code should compile.
- *
- */
-#define MAXADDR          (((haddr_t)1 << (8 * sizeof(HDoff_t) - 1)) - 1)
-#define ADDR_OVERFLOW(A) (HADDR_UNDEF == (A) || ((A) & ~(haddr_t)MAXADDR))
-
 /* Prototypes */
 static void   *H5FD__hdfs_fapl_get(H5FD_t *_file);
 static void   *H5FD__hdfs_fapl_copy(const void *_old_fa);
@@ -267,7 +254,7 @@ static const H5FD_class_t H5FD_hdfs_g = {
     H5FD_CLASS_VERSION,       /* struct version       */
     H5FD_HDFS_VALUE,          /* value                */
     "hdfs",                   /* name                 */
-    MAXADDR,                  /* maxaddr              */
+    H5FD_MAXADDR,             /* maxaddr              */
     H5F_CLOSE_WEAK,           /* fc_degree            */
     NULL,                     /* terminate            */
     NULL,                     /* sb_size              */
@@ -840,7 +827,7 @@ H5FD__hdfs_open(const char *path, unsigned flags, hid_t fapl_id, haddr_t maxaddr
         HGOTO_ERROR(H5E_ARGS, H5E_BADVALUE, NULL, "invalid file name");
     if (0 == maxaddr || HADDR_UNDEF == maxaddr)
         HGOTO_ERROR(H5E_ARGS, H5E_BADRANGE, NULL, "bogus maxaddr");
-    if (ADDR_OVERFLOW(maxaddr))
+    if (H5FD_ADDR_OVERFLOW(maxaddr))
         HGOTO_ERROR(H5E_ARGS, H5E_OVERFLOW, NULL, "bogus maxaddr");
     if (flags != H5F_ACC_RDONLY)
         HGOTO_ERROR(H5E_ARGS, H5E_UNSUPPORTED, NULL, "only Read-Only access allowed");

--- a/src/H5FDlog.c
+++ b/src/H5FDlog.c
@@ -129,27 +129,6 @@ typedef struct H5FD_log_t {
     H5FD_log_fapl_t    fa;                  /* Driver-specific file access properties           */
 } H5FD_log_t;
 
-/*
- * These macros check for overflow of various quantities.  These macros
- * assume that HDoff_t is signed and haddr_t and size_t are unsigned.
- *
- * ADDR_OVERFLOW:   Checks whether a file address of type `haddr_t'
- *                  is too large to be represented by the second argument
- *                  of the file seek function.
- *
- * SIZE_OVERFLOW:   Checks whether a buffer size of type `hsize_t' is too
- *                  large to be represented by the `size_t' type.
- *
- * REGION_OVERFLOW: Checks whether an address and size pair describe data
- *                  which can be addressed entirely by the second
- *                  argument of the file seek function.
- */
-#define MAXADDR          (((haddr_t)1 << (8 * sizeof(HDoff_t) - 1)) - 1)
-#define ADDR_OVERFLOW(A) (HADDR_UNDEF == (A) || ((A) & ~(haddr_t)MAXADDR))
-#define SIZE_OVERFLOW(Z) ((Z) & ~(hsize_t)MAXADDR)
-#define REGION_OVERFLOW(A, Z)                                                                                \
-    (ADDR_OVERFLOW(A) || SIZE_OVERFLOW(Z) || HADDR_UNDEF == (A) + (Z) || (HDoff_t)((A) + (Z)) < (HDoff_t)(A))
-
 /* Prototypes */
 static void   *H5FD__log_fapl_get(H5FD_t *file);
 static void   *H5FD__log_fapl_copy(const void *_old_fa);
@@ -177,7 +156,7 @@ static const H5FD_class_t H5FD_log_g = {
     H5FD_CLASS_VERSION,      /* struct version      */
     H5FD_LOG_VALUE,          /* value               */
     "log",                   /* name                */
-    MAXADDR,                 /* maxaddr             */
+    H5FD_MAXADDR,            /* maxaddr             */
     H5F_CLOSE_WEAK,          /* fc_degree           */
     NULL,                    /* terminate           */
     NULL,                    /* sb_size             */
@@ -450,7 +429,7 @@ H5FD__log_open(const char *name, unsigned flags, hid_t fapl_id, haddr_t maxaddr)
         HGOTO_ERROR(H5E_ARGS, H5E_BADVALUE, NULL, "invalid file name");
     if (0 == maxaddr || HADDR_UNDEF == maxaddr)
         HGOTO_ERROR(H5E_ARGS, H5E_BADRANGE, NULL, "bogus maxaddr");
-    if (ADDR_OVERFLOW(maxaddr))
+    if (H5FD_ADDR_OVERFLOW(maxaddr))
         HGOTO_ERROR(H5E_ARGS, H5E_OVERFLOW, NULL, "bogus maxaddr");
 
     /* Initialize timers */
@@ -1120,7 +1099,7 @@ H5FD__log_read(H5FD_t *_file, H5FD_mem_t type, hid_t H5_ATTR_UNUSED dxpl_id, had
     /* Check for overflow conditions */
     if (!H5_addr_defined(addr))
         HGOTO_ERROR(H5E_ARGS, H5E_BADVALUE, FAIL, "addr undefined, addr = %llu", (unsigned long long)addr);
-    if (REGION_OVERFLOW(addr, size))
+    if (H5FD_REGION_OVERFLOW(addr, size))
         HGOTO_ERROR(H5E_ARGS, H5E_OVERFLOW, FAIL, "addr overflow, addr = %llu", (unsigned long long)addr);
 
     /* Log the I/O information about the read */
@@ -1344,7 +1323,7 @@ H5FD__log_write(H5FD_t *_file, H5FD_mem_t type, hid_t H5_ATTR_UNUSED dxpl_id, ha
     /* Check for overflow conditions */
     if (!H5_addr_defined(addr))
         HGOTO_ERROR(H5E_ARGS, H5E_BADVALUE, FAIL, "addr undefined, addr = %llu", (unsigned long long)addr);
-    if (REGION_OVERFLOW(addr, size))
+    if (H5FD_REGION_OVERFLOW(addr, size))
         HGOTO_ERROR(H5E_ARGS, H5E_OVERFLOW, FAIL, "addr overflow, addr = %llu, size = %llu",
                     (unsigned long long)addr, (unsigned long long)size);
 

--- a/src/H5FDmirror.c
+++ b/src/H5FDmirror.c
@@ -45,24 +45,6 @@ typedef struct H5FD_mirror_t {
     uint32_t           xmit_i;  /* Counter of transmission sent and rec'd */
 } H5FD_mirror_t;
 
-/*
- * These macros check for overflow of various quantities.  These macros
- * assume that HDoff_t is signed and haddr_t and size_t are unsigned.
- *
- * ADDR_OVERFLOW:   Checks whether a file address of type `haddr_t'
- *                  is too large to be represented by the second argument
- *                  of the file seek function.
- *
- * SIZE_OVERFLOW:   Checks whether a buffer size of type `hsize_t' is too
- *                  large to be represented by the `size_t' type.
- *
- * REGION_OVERFLOW: Checks whether an address and size pair describe data
- *                  which can be addressed entirely by the second
- *                  argument of the file seek function.
- */
-#define MAXADDR          (((haddr_t)1 << (8 * sizeof(HDoff_t) - 1)) - 1)
-#define ADDR_OVERFLOW(A) (HADDR_UNDEF == (A) || ((A) & ~(haddr_t)MAXADDR))
-
 #ifndef BSWAP_64
 #define BSWAP_64(X)                                                                                          \
     (uint64_t)((((X) & 0x00000000000000FF) << 56) | (((X) & 0x000000000000FF00) << 40) |                     \
@@ -162,7 +144,7 @@ static const H5FD_class_t H5FD_mirror_g = {
     H5FD_CLASS_VERSION,     /* struct version       */
     H5FD_MIRROR_VALUE,      /* value                */
     "mirror",               /* name                 */
-    MAXADDR,                /* maxaddr              */
+    H5FD_MAXADDR,           /* maxaddr              */
     H5F_CLOSE_WEAK,         /* fc_degree            */
     NULL,                   /* terminate            */
     NULL,                   /* sb_size              */
@@ -1358,7 +1340,7 @@ H5FD__mirror_open(const char *name, unsigned flags, hid_t fapl_id, haddr_t maxad
         HGOTO_ERROR(H5E_ARGS, H5E_BADVALUE, NULL, "filename is too long");
     if (0 == maxaddr || HADDR_UNDEF == maxaddr)
         HGOTO_ERROR(H5E_ARGS, H5E_BADRANGE, NULL, "bogus maxaddr");
-    if (ADDR_OVERFLOW(maxaddr))
+    if (H5FD_ADDR_OVERFLOW(maxaddr))
         HGOTO_ERROR(H5E_ARGS, H5E_OVERFLOW, NULL, "bogus maxaddr");
 
     if (H5Pget_fapl_mirror(fapl_id, &fa) == FAIL)

--- a/src/H5FDonion.c
+++ b/src/H5FDonion.c
@@ -147,8 +147,6 @@ typedef struct H5FD_onion_t {
 
 H5FL_DEFINE_STATIC(H5FD_onion_t);
 
-#define MAXADDR (((haddr_t)1 << (8 * sizeof(HDoff_t) - 1)) - 1)
-
 #define H5FD_CTL_GET_NUM_REVISIONS 20001
 
 /* Prototypes */
@@ -175,7 +173,7 @@ static const H5FD_class_t H5FD_onion_g = {
     H5FD_CLASS_VERSION,             /* struct version       */
     H5FD_ONION_VALUE,               /* value                */
     "onion",                        /* name                 */
-    MAXADDR,                        /* maxaddr              */
+    H5FD_MAXADDR,                   /* maxaddr              */
     H5F_CLOSE_WEAK,                 /* fc_degree            */
     NULL,                           /* terminate            */
     H5FD__onion_sb_size,            /* sb_size              */

--- a/src/H5FDpkg.h
+++ b/src/H5FDpkg.h
@@ -31,6 +31,30 @@
 /* Package Private Macros */
 /**************************/
 
+/* These macros check for overflow of various quantities. They are suitable
+ * for VFDs that are "file-like" where lseek(2), etc. is used to move around
+ * via HDoff_t units (i.e., most VFDs aside from the core VFD).
+ *
+ * These macros assume that HDoff_t is signed and haddr_t and size_t are unsigned.
+ *
+ * H5FD_ADDR_OVERFLOW:   Checks whether a file address of type `haddr_t'
+ *                       is too large to be represented by the second argument
+ *                       of the file seek function.
+ *
+ * H5FD_SIZE_OVERFLOW:   Checks whether a buffer size of type `hsize_t' is too
+ *                       large to be represented by the `size_t' type.
+ *
+ * H5FD_REGION_OVERFLOW: Checks whether an address and size pair describe data
+ *                       which can be addressed entirely by the second
+ *                       argument of the file seek function.
+ */
+#define H5FD_MAXADDR          (((haddr_t)1 << (8 * sizeof(HDoff_t) - 1)) - 1)
+#define H5FD_ADDR_OVERFLOW(A) (HADDR_UNDEF == (A) || ((A) & ~(haddr_t)H5FD_MAXADDR))
+#define H5FD_SIZE_OVERFLOW(Z) ((Z) & ~(hsize_t)H5FD_MAXADDR)
+#define H5FD_REGION_OVERFLOW(A, Z)                                                                           \
+    (H5FD_ADDR_OVERFLOW(A) || H5FD_SIZE_OVERFLOW(Z) || HADDR_UNDEF == (A) + (Z) ||                           \
+     (HDoff_t)((A) + (Z)) < (HDoff_t)(A))
+
 /****************************/
 /* Package Private Typedefs */
 /****************************/

--- a/src/H5FDros3.c
+++ b/src/H5FDros3.c
@@ -129,18 +129,6 @@ typedef struct H5FD_ros3_t {
 #endif
 } H5FD_ros3_t;
 
-/* These macros check for overflow of various quantities.  These macros
- * assume that HDoff_t is signed and haddr_t and size_t are unsigned.
- *
- * ADDR_OVERFLOW:   Checks whether a file address of type `haddr_t'
- *                  is too large to be represented by the second argument
- *                  of the file seek function.
- *                  Only included if it may be used -- ROS3 VFD is enabled.
- *
- */
-#define MAXADDR          (((haddr_t)1 << (8 * sizeof(HDoff_t) - 1)) - 1)
-#define ADDR_OVERFLOW(A) (HADDR_UNDEF == (A) || ((A) & ~(haddr_t)MAXADDR))
-
 /* Prototypes */
 static void   *H5FD__ros3_fapl_get(H5FD_t *_file);
 static void   *H5FD__ros3_fapl_copy(const void *_old_fa);
@@ -176,7 +164,7 @@ static const H5FD_class_t H5FD_ros3_g = {
     H5FD_CLASS_VERSION,       /* struct version       */
     H5FD_ROS3_VALUE,          /* value                */
     "ros3",                   /* name                 */
-    MAXADDR,                  /* maxaddr              */
+    H5FD_MAXADDR,             /* maxaddr              */
     H5F_CLOSE_WEAK,           /* fc_degree            */
     NULL,                     /* terminate            */
     NULL,                     /* sb_size              */
@@ -725,7 +713,7 @@ H5FD__ros3_open(const char *url, unsigned flags, hid_t fapl_id, haddr_t maxaddr)
         HGOTO_ERROR(H5E_ARGS, H5E_BADVALUE, NULL, "invalid file name");
     if (0 == maxaddr || HADDR_UNDEF == maxaddr)
         HGOTO_ERROR(H5E_ARGS, H5E_BADRANGE, NULL, "bogus maxaddr");
-    if (ADDR_OVERFLOW(maxaddr))
+    if (H5FD_ADDR_OVERFLOW(maxaddr))
         HGOTO_ERROR(H5E_ARGS, H5E_OVERFLOW, NULL, "bogus maxaddr");
     if (flags != H5F_ACC_RDONLY)
         HGOTO_ERROR(H5E_ARGS, H5E_UNSUPPORTED, NULL, "only Read-Only access allowed");

--- a/src/H5FDsplitter.c
+++ b/src/H5FDsplitter.c
@@ -50,27 +50,6 @@ typedef struct H5FD_splitter_t {
     FILE                *logfp;   /* Log file pointer */
 } H5FD_splitter_t;
 
-/*
- * These macros check for overflow of various quantities.  These macros
- * assume that HDoff_t is signed and haddr_t and size_t are unsigned.
- *
- * ADDR_OVERFLOW:   Checks whether a file address of type `haddr_t'
- *                  is too large to be represented by the second argument
- *                  of the file seek function.
- *
- * SIZE_OVERFLOW:   Checks whether a buffer size of type `hsize_t' is too
- *                  large to be represented by the `size_t' type.
- *
- * REGION_OVERFLOW: Checks whether an address and size pair describe data
- *                  which can be addressed entirely by the second
- *                  argument of the file seek function.
- */
-#define MAXADDR          (((haddr_t)1 << (8 * sizeof(HDoff_t) - 1)) - 1)
-#define ADDR_OVERFLOW(A) (HADDR_UNDEF == (A) || ((A) & ~(haddr_t)MAXADDR))
-#define SIZE_OVERFLOW(Z) ((Z) & ~(hsize_t)MAXADDR)
-#define REGION_OVERFLOW(A, Z)                                                                                \
-    (ADDR_OVERFLOW(A) || SIZE_OVERFLOW(Z) || HADDR_UNDEF == (A) + (Z) || (HDoff_t)((A) + (Z)) < (HDoff_t)(A))
-
 /* This macro provides a wrapper for shared fail-log-ignore behavior
  * for errors arising in the splitter's W/O channel.
  * Logs an error entry in a log file, if the file exists.
@@ -139,7 +118,7 @@ static const H5FD_class_t H5FD_splitter_g = {
     H5FD_CLASS_VERSION,           /* struct version       */
     H5FD_SPLITTER_VALUE,          /* value                */
     "splitter",                   /* name                 */
-    MAXADDR,                      /* maxaddr              */
+    H5FD_MAXADDR,                 /* maxaddr              */
     H5F_CLOSE_WEAK,               /* fc_degree            */
     NULL,                         /* terminate            */
     H5FD__splitter_sb_size,       /* sb_size              */
@@ -615,7 +594,7 @@ H5FD__splitter_read(H5FD_t *_file, H5FD_mem_t H5_ATTR_UNUSED type, hid_t H5_ATTR
     /* Check for overflow conditions */
     if (!H5_addr_defined(addr))
         HGOTO_ERROR(H5E_ARGS, H5E_BADVALUE, FAIL, "addr undefined, addr = %llu", (unsigned long long)addr);
-    if (REGION_OVERFLOW(addr, size))
+    if (H5FD_REGION_OVERFLOW(addr, size))
         HGOTO_ERROR(H5E_ARGS, H5E_OVERFLOW, FAIL, "addr overflow, addr = %llu", (unsigned long long)addr);
 
     /* Only read from R/W channel */
@@ -798,7 +777,7 @@ H5FD__splitter_open(const char *name, unsigned flags, hid_t splitter_fapl_id, ha
         HGOTO_ERROR(H5E_ARGS, H5E_BADVALUE, NULL, "invalid file name");
     if (0 == maxaddr || HADDR_UNDEF == maxaddr)
         HGOTO_ERROR(H5E_ARGS, H5E_BADRANGE, NULL, "bogus maxaddr");
-    if (ADDR_OVERFLOW(maxaddr))
+    if (H5FD_ADDR_OVERFLOW(maxaddr))
         HGOTO_ERROR(H5E_ARGS, H5E_OVERFLOW, NULL, "bogus maxaddr");
     if (H5FD_SPLITTER != H5Pget_driver(splitter_fapl_id))
         HGOTO_ERROR(H5E_ARGS, H5E_BADVALUE, NULL, "driver is not splitter");


### PR DESCRIPTION
These are identical in all VFDs except the core VFD, so they've been moved to H5FDpkg.h and renamed:

    * MAXADDR           -->     H5FD_MAXADDR
    * ADDR_OVERFLOW     -->     H5FD_ADDR_OVERFLOW
    * SIZE_OVERFLOW     -->     H5FD_SIZE_OVERFLOW
    * REGION_OVERFLOW   -->     H5FD_REGION_OVERFLOW