### PR TITLE
Disable complex dtypes in API tests for now

### DIFF
--- a/test/API/H5_api_test_util.c
+++ b/test/API/H5_api_test_util.c
@@ -89,7 +89,7 @@ static hid_t generate_random_datatype_compound(H5T_class_t parent_class, bool is
 static hid_t generate_random_datatype_reference(H5T_class_t parent_class, bool is_compact);
 static hid_t generate_random_datatype_enum(H5T_class_t parent_class, bool is_compact);
 static hid_t generate_random_datatype_array(H5T_class_t parent_class, bool is_compact);
-static hid_t generate_random_datatype_complex(H5T_class_t parent_class, bool is_compact);
+// static hid_t generate_random_datatype_complex(H5T_class_t parent_class, bool is_compact);
 
 /*
  * Helper function to generate a random HDF5 datatype in order to thoroughly
@@ -172,8 +172,12 @@ roll_datatype:
             gen_func = generate_random_datatype_array;
             break;
         case H5T_COMPLEX:
-            gen_func = generate_random_datatype_complex;
+            // gen_func = generate_random_datatype_complex;
+
+            /* Temporarily disable generation of complex datatypes */
+            goto roll_datatype;
             break;
+            
         default:
             printf("    invalid datatype class\n");
             goto done;
@@ -608,6 +612,7 @@ done:
     return ret_value;
 }
 
+/*
 static hid_t
 generate_random_datatype_complex(H5T_class_t H5_ATTR_UNUSED parent_class, bool H5_ATTR_UNUSED is_compact)
 {
@@ -654,6 +659,7 @@ done:
 
     return ret_value;
 }
+*/
 
 /*
  * Helper function to generate a random HDF5 dataspace in order to thoroughly


### PR DESCRIPTION
The REST VOL CI is failing because the REST VOL/HSDS don't currently support complex datatypes. Since none of the other VOLs in CI do anything particular with complex datatypes, it should be fine to disable this until the REST VOL/HSDS are updated.