### PR TITLE
Fix the expected DDL output value

### DIFF
--- a/HDF5Examples/C/HL/tfiles/h5ex_table_11.ddl
+++ b/HDF5Examples/C/HL/tfiles/h5ex_table_11.ddl
@@ -178,7 +178,7 @@ GROUP "/" {
          DATATYPE  H5T_IEEE_F64LE
          DATASPACE  SCALAR
          DATA {
-         (0): 0
+         (0): -99
          }
       }
       ATTRIBUTE "FIELD_4_NAME" {


### PR DESCRIPTION
The test source code uses `-99.0`:

`    Particle1   fill_data[1]     = {{"no data", -1, -1, -99.0F, -99.0}};`

I386 Alpine CI test needs this patch to pass all tests.

This change may fail some other 64-bit systems. 
If so, I suspect a bug in the HDF5 library.
