### PR TITLE
Temporary disable of julia workflow

### DIFF
--- a/.github/workflows/autotools.yml
+++ b/.github/workflows/autotools.yml
@@ -94,11 +94,11 @@ jobs:
         name: "Autotools TestExpress Workflows"
         uses: ./.github/workflows/testxpr-auto.yml
 
-    call-release-auto-julia:
-        name: "Autotools Julia Workflows"
-        uses: ./.github/workflows/julia-auto.yml
-        with:
-          build_mode: "production"
+#    call-release-auto-julia:
+#        name: "Autotools Julia Workflows"
+#        uses: ./.github/workflows/julia-auto.yml
+#        with:
+#          build_mode: "production"
 
 #  workflow-msys2-autotools:
 #    name: "CMake msys2 Workflows"

--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -109,11 +109,11 @@ jobs:
         name: "CMake TestExpress Workflows"
         uses: ./.github/workflows/testxpr-cmake.yml
 
-    call-release-cmake-julia:
-        name: "CMake Julia Workflows"
-        uses: ./.github/workflows/julia-cmake.yml
-        with:
-          build_mode: "Release"
+#    call-release-cmake-julia:
+#        name: "CMake Julia Workflows"
+#        uses: ./.github/workflows/julia-cmake.yml
+#        with:
+#         build_mode: "Release"
 
     call-release-cmake-msys2:
         name: "CMake Msys2 Workflows"


### PR DESCRIPTION
Until the issue is resolved, this workflow may hide other errors unless every main workfloe is inspected.