### PR TITLE
H5Pf: Use off_t instead HDoff_t

### DIFF
--- a/fortran/src/H5Pf.c
+++ b/fortran/src/H5Pf.c
@@ -1610,7 +1610,7 @@ h5pget_external_c(hid_t_f *prp_id, int_f *idx, size_t_f *name_size, _fcd name, o
     herr_t   status;
     size_t   c_namelen;
     char    *c_name = NULL;
-    off_t  c_offset;
+    off_t    c_offset;
     hsize_t  size;
 
     c_namelen = (size_t)*name_size;

--- a/fortran/src/H5Pf.c
+++ b/fortran/src/H5Pf.c
@@ -1610,7 +1610,7 @@ h5pget_external_c(hid_t_f *prp_id, int_f *idx, size_t_f *name_size, _fcd name, o
     herr_t   status;
     size_t   c_namelen;
     char    *c_name = NULL;
-    HDoff_t  c_offset;
+    off_t  c_offset;
     hsize_t  size;
 
     c_namelen = (size_t)*name_size;


### PR DESCRIPTION
Fixes this error:

H5Pf.c:1630:72: error: passing argument 5 of 'H5Pget_external' from incompatible pointer type [-Wincompatible-pointer-types]

cc @derobins since your PR #5082 maybe be related