### PR TITLE
Remove the hash_size param from H5Iregister_type()

### DIFF
--- a/bin/make_vers
+++ b/bin/make_vers
@@ -28,6 +28,21 @@ $min_sup_idx = 3;
 # Number of spaces to indent preprocessor commands inside ifdefs
 $indent = 2;
 
+# Global hash of functions ==> # symbol versions parsed from H5vers.txt
+$functions = {};
+
+# Global hash of functions ==> versioned function params parsed from H5vers.txt
+$func_params = {};
+
+# Global hash of typedefs ==> # symbol versions parsed from H5vers.txt
+$typedefs = {};
+
+# Array of {func name ==> symbol version} hashes. One hash per API version.
+@func_vers =  map { {} } 1..($max_idx + 1);
+
+# Array of {type name ==> symbol version} hashes. One hash per API version.
+@type_vers =  map { {} } 1..($max_idx + 1);
+
 #
 # Copyright by The HDF Group.
 # All rights reserved.

--- a/bin/make_vers
+++ b/bin/make_vers
@@ -318,6 +318,58 @@ sub print_endprotect ($$) {
 }
 
 ##############################################################################
+# Validate a line from H5vers.txt
+#
+sub validate_line {
+    my $name      = $_[0];
+    my $params    = $_[1];
+    my $vers      = $_[2];
+
+    my @vers_list;      # Version strings ("v18", etc.)
+    my %sym_versions;   # Versions already seen (for duplicate checks)
+
+    # Check if the name already exists in the list of symbols
+    if(exists($functions{$name}) || exists($typedefs{$name})) {
+        die "duplicated symbol: $name";
+    }
+
+    # Check for no version info given
+    if($vers eq "") {
+        die "no version information: $name";
+    }
+
+    # Separate the versions on commas (produces string elements like "v18")
+    @vers_list = split(/\s*,\s*/, $vers);
+
+    # Check for invalid version data
+    foreach(@vers_list) {
+        # Note:  v111 is allowed because H5O functions were prematurely versioned
+        #        in HDF5 1.10.  Because users were affected by this, the versioning
+        #        was rescinded but the H5O version 2 functions were kept to be
+        #        called directly.  Now that the version macros are added in 1.12,
+        #        along with a 3rd version of the H5O functions, the H5O function
+        #        version for default api=v110 should be version 1 to work correctly
+        #        with 1.10 applications that were using unversioned H5O functions,
+        #        and the H5O function version should be version 3 for default api=v112
+        #        (the default api version for 1.12).  Allowing a v111 entry and
+        #        incrementing its index 13 lines below allows a version 2 that is
+        #        never accessed via the H5O function macros.
+        if(!( $_ =~ /v1[02468]/ || $_ =~ /v11[02468]/ ||  $_ =~ /v111/ || $_ =~ /v200/ )) {
+            die "bad version information: $name";
+        }
+
+        # Make sure we didn't specify duplicate versions on this line
+        if(exists($sym_versions{$_})) {
+            die "duplicate version information: $name";
+        }
+
+        # Store the versions for the function in a local hash table, indexed by the version
+        # (this is only used to check for duplicates)
+        $sym_versions{$_}=$_;
+    }
+}
+
+##############################################################################
 # Parse a meaningful line (not a comment or blank line) into the appropriate
 # data structure
 #
@@ -333,7 +385,6 @@ sub parse_line ($) {
         my @vers_list;      # Version info, as a list
         my @vers_nums;      # Version info, as a numeric list
         my $num_versions;   # Number of versions for function
-        my %sym_versions;   # Versions for a symbol
         my $last_idx;       # The previous version index seen for a function
         my $last_vers;      # The previous version # seen for a function
         my $line_type;      # Type of line we are parsing
@@ -355,15 +406,7 @@ sub parse_line ($) {
 #print "parse_line: line_type='$line_type'\n";
 
 
-        # Check if the name already exists in the list of symbols
-        if(exists($functions{$name}) || exists($typedefs{$name})) {
-            die "duplicated symbol: $name";
-        }
-
-        # Check for no version info given
-        if($vers eq "") {
-            die "no version information: $name";
-        }
+        validate_line($name, $params, $vers);
 
         # Split up version info
         @vers_list = split(/\s*,\s*/, $vers);
@@ -372,28 +415,6 @@ sub parse_line ($) {
         # Parse the version list into numbers, checking for invalid input
         foreach(@vers_list) {
             my $vers_idx;       # Index of version in array
-
-            # Do some validation on the input
-            # Note:  v111 is allowed because H5O functions were prematurely versioned
-            #        in HDF5 1.10.  Because users were affected by this, the versioning
-            #        was rescinded but the H5O version 2 functions were kept to be 
-            #        called directly.  Now that the version macros are added in 1.12,
-            #        along with a 3rd version of the H5O functions, the H5O function
-            #        version for default api=v110 should be version 1 to work correctly
-            #        with 1.10 applications that were using unversioned H5O functions,
-            #        and the H5O function version should be version 3 for default api=v112 
-            #        (the default api version for 1.12).  Allowing a v111 entry and 
-            #        incrementing its index 13 lines below allows a version 2 that is
-            #        never accessed via the H5O function macros.
-            if(!( $_ =~ /v1[02468]/ || $_ =~ /v11[02468]/ ||  $_ =~ /v111/ || $_ =~ /v200/ )) {
-                die "bad version information: $name";
-            }
-            if(exists($sym_versions{$_})) {
-                die "duplicate version information: $name";
-            }
-
-            # Store the versions for the function in a local hash table, indexed by the version
-            $sym_versions{$_}=$_;
 
 #print "parse_line: _=$_\n";
             # Get the index of the version
@@ -411,7 +432,6 @@ sub parse_line ($) {
         }
 #print "parse_line: vers_nums=(@vers_nums)\n";
 
-        # Check for invalid version info given
         $last_idx = -1;
         $last_vers = 1;
         foreach(sort(@vers_nums)) {

--- a/bin/make_vers
+++ b/bin/make_vers
@@ -121,11 +121,12 @@ sub print_checkoptions ($) {
     # Print the #ifdef
     print $fh "#if (";
     $curr_idx = 0;
-    foreach my $api_vers (@versions) {
-        print $fh "defined(H5_USE_", $api_vers, "_API)";
+    for my $i (0 .. $#versions - 1) {
+
+        print $fh "defined(H5_USE_", $versions[$i], "_API)";
 
         $curr_idx++;
-        if ($curr_idx < @versions) {
+        if ($curr_idx < @versions - 1) {
             print $fh " || ";
         }
     }
@@ -137,11 +138,11 @@ sub print_checkoptions ($) {
     # Print the #endif
     print $fh "#endif /* (";
     $curr_idx = 0;
-    foreach my $api_vers (@versions) {
-        print $fh "defined(H5_USE_", $api_vers, "_API)";
+    for my $i (0 .. $#versions - 1) {
+        print $fh "defined(H5_USE_", $versions[$i], "_API)";
 
         $curr_idx++;
-        if ($curr_idx < @versions) {
+        if ($curr_idx < @versions - 1) {
             print $fh " || ";
         }
     }

--- a/bin/make_vers
+++ b/bin/make_vers
@@ -120,7 +120,6 @@ sub print_checkoptions ($) {
     # Print the #ifdef
     print $fh "#if (";
     for my $i (0 .. $#versions - 1) {
-
         print $fh "defined(H5_USE_", $versions[$i], "_API)";
 
         # -2 because we're ignoring the last version in the loop, and the

--- a/bin/make_vers
+++ b/bin/make_vers
@@ -175,7 +175,6 @@ sub print_globalapidefvers ($) {
 #
 sub print_globalapisymbolvers ($) {
     my $fh = shift;             # File handle for output file
-    my $curr_idx;               # Current API version index
 
     # Print the descriptive comment
     print $fh "\n\n/* If a particular \"global\" version of the library's interfaces is chosen,\n";

--- a/bin/make_vers
+++ b/bin/make_vers
@@ -3,27 +3,16 @@ require 5.003;
 use warnings;
 
 # Global settings
-# (The max_idx parameter is the only thing that needs to be changed when adding
-#  support for a new major release.  If support for a prior major release is
-#  added (like support for 1.4, etc), the min_sup_idx parameter will need to
-#  be decremented.)
 
 # Supported version strings. "16" = HDF5 1.6.0, "200" = HDF5 2.0.0, etc.
+#
 # Note that the scheme changed with 2.0.0, when we went to semantic versioning.
 # We use 200 instead of 20 so that HDF5 11.0.0 will get 1100 instead of 110,
 # which would conflict with HDF5 1.10.
+#
+# Also, note that this scheme started at the 1.6/1.8 transition, so earlier
+# versions of the API aren't versioned.
 @versions = ("16", "18", "110", "112", "114", "200");
-
-# Max. library "index" (0 = v1.0, 1 = 1.2, 2 = 1.4, 3 = 1.6, 4 = 1.8, 5 = 1.10, 6 = 1.12, 7 = 1.14, 8 = 2.0, etc)
-$max_idx = 8;
-
-# Last index where we used 1.<major> for the version number (i.e., 1.14). This
-# creates symbols with numbers like "114". After this version, the symbols have
-# numbers like "200" (for v2.0.0).
-$pre200_max_idx = 7;
-
-# Min. supported previous library version "index" (0 = v1.0, 1 = 1.2, etc)
-$min_sup_idx = 3;
 
 # Number of spaces to indent preprocessor commands inside ifdefs
 $indent = 2;
@@ -37,11 +26,25 @@ $func_params = {};
 # Global hash of typedefs ==> # symbol versions parsed from H5vers.txt
 $typedefs = {};
 
-# Array of {func name ==> symbol version} hashes. One hash per API version.
-@func_vers =  map { {} } 1..($max_idx + 1);
+# Hash of API versions to a hash of (API call name --> symbol version)
+#
+# There is one hash for each version in @versions and the (API call name
+# --> symbol version) hash maps an API name like H5Dopen to the symbol version
+# (e.g. H5Dopen --> 1 or 2).
+#
+# So...
+#
+# 200 --> {H5Dopen --> 2, H5Iregister_type --> 2, etc.}
+my %api_vers_to_function_vers;
+foreach my $key (@versions) {
+    $api_vers_to_function_vers{$key} = {};
+}
 
-# Array of {type name ==> symbol version} hashes. One hash per API version.
-@type_vers =  map { {} } 1..($max_idx + 1);
+# Hash of API versions to a hash of (typedef name --> symbol version)
+my %api_vers_to_type_vers;
+foreach my $key (@versions) {
+    $api_vers_to_type_vers{$key} = {};
+}
 
 #
 # Copyright by The HDF Group.
@@ -122,7 +125,7 @@ sub print_checkoptions ($) {
         print $fh "defined(H5_USE_", $api_vers, "_API)";
 
         $curr_idx++;
-        if($curr_idx < @versions) {
+        if ($curr_idx < @versions) {
             print $fh " || ";
         }
     }
@@ -138,7 +141,7 @@ sub print_checkoptions ($) {
         print $fh "defined(H5_USE_", $api_vers, "_API)";
 
         $curr_idx++;
-        if($curr_idx < @versions) {
+        if ($curr_idx < @versions) {
             print $fh " || ";
         }
     }
@@ -183,15 +186,7 @@ sub print_globalapisymbolvers ($) {
     print $fh " */\n";
 
     # Loop over supported older library APIs and define the appropriate macros
-    for $curr_idx ($min_sup_idx .. $max_idx) {
-        # Get the API version string from the index
-        my $api_vers;
-        if ($curr_idx <= $pre200_max_idx) {
-            $api_vers = "1" . ($curr_idx * 2);
-        } else {
-            $api_vers = (1 + $curr_idx - $pre200_max_idx) * 100;
-        }
-
+    foreach my $api_vers (@versions) {
         # Print API version ifdef
         print $fh "\n#ifdef H5_USE_", $api_vers, "_API\n";
 
@@ -200,9 +195,9 @@ sub print_globalapisymbolvers ($) {
         print $fh "\n/*************/\n";
         print $fh "/* Functions */\n";
         print $fh "/*************/\n";
-        for $name (sort keys %{$func_vers[$curr_idx]}) {
+        for $name (sort keys %{$api_vers_to_function_vers{$api_vers}}) {
             print $fh "\n#if !defined(", $name, "_vers)\n";
-            print $fh  " " x $indent, "#define ", $name, "_vers $func_vers[$curr_idx]{$name}\n";
+            print $fh  " " x $indent, "#define ", $name, "_vers $api_vers_to_function_vers{$api_vers}{$name}\n";
             print $fh  "#endif /* !defined(", $name, "_vers) */\n";
         }
 
@@ -211,9 +206,9 @@ sub print_globalapisymbolvers ($) {
         print $fh "\n/************/\n";
         print $fh "/* Typedefs */\n";
         print $fh "/************/\n";
-        for $name (sort keys %{$type_vers[$curr_idx]}) {
+        for $name (sort keys %{$api_vers_to_type_vers{$api_vers}}) {
             print $fh "\n#if !defined(", $name, "_t_vers)\n";
-            print $fh  " " x $indent, "#define ", $name, "_t_vers $type_vers[$curr_idx]{$name}\n";
+            print $fh  " " x $indent, "#define ", $name, "_t_vers $api_vers_to_type_vers{$api_vers}{$name}\n";
             print $fh  "#endif /* !defined(", $name, "_t_vers) */\n";
         }
 
@@ -261,7 +256,7 @@ sub print_defaultapivers ($) {
         print $fh " " x $indent, "#define $curr_name $curr_name$curr_vers\n";
 
         # Print function's dependent parameter types
-        foreach(sort(@param_list)) {
+        foreach (sort (@param_list)) {
             print $fh " " x $indent, "#define ${_}_t $_${curr_vers}_t\n";
         }
 
@@ -272,7 +267,7 @@ sub print_defaultapivers ($) {
             print $fh " " x $indent, "#define $curr_name $curr_name$curr_vers\n";
 
             # Print function's dependent parameter types
-            foreach(sort(@param_list)) {
+            foreach (sort (@param_list)) {
                 print $fh " " x $indent, "#define ${_}_t $_${curr_vers}_t\n";
             }
 
@@ -306,7 +301,7 @@ sub print_defaultapivers ($) {
 
         # Loop to print earlier version name mappings
         $curr_vers--;
-        while($curr_vers > 0) {
+        while ($curr_vers > 0) {
             print $fh "#elif $curr_vers_name == $curr_vers\n";
             print $fh " " x $indent, "#define ${curr_name}_t $curr_name${curr_vers}_t\n";
             $curr_vers--;
@@ -344,20 +339,20 @@ sub validate_line {
     my %sym_versions;   # Versions already seen (for duplicate checks)
 
     # Check if the name already exists in the list of symbols
-    if(exists($functions{$name}) || exists($typedefs{$name})) {
+    if (exists ($functions{$name}) || exists($typedefs{$name})) {
         die "duplicated symbol: $name";
     }
 
     # Check for no version info given
-    if($vers eq "") {
+    if ($vers eq "") {
         die "no version information: $name";
     }
 
     # Separate the versions on commas (produces string elements like "v18")
-    @vers_list = split(/\s*,\s*/, $vers);
+    @vers_list = split (/\s*,\s*/, $vers);
 
     # Check for invalid version data
-    foreach(@vers_list) {
+    foreach (@vers_list) {
         # Note:  v111 is allowed because H5O functions were prematurely versioned
         #        in HDF5 1.10.  Because users were affected by this, the versioning
         #        was rescinded but the H5O version 2 functions were kept to be
@@ -369,12 +364,12 @@ sub validate_line {
         #        (the default api version for 1.12).  Allowing a v111 entry and
         #        incrementing its index 13 lines below allows a version 2 that is
         #        never accessed via the H5O function macros.
-        if(!( $_ =~ /v1[02468]/ || $_ =~ /v11[02468]/ ||  $_ =~ /v111/ || $_ =~ /v200/ )) {
+        if (!( $_ =~ /v1[02468]/ || $_ =~ /v11[02468]/ ||  $_ =~ /v111/ || $_ =~ /v200/ )) {
             die "bad version information: $name";
         }
 
         # Make sure we didn't specify duplicate versions on this line
-        if(exists($sym_versions{$_})) {
+        if (exists($sym_versions{$_})) {
             die "duplicate version information: $name";
         }
 
@@ -393,119 +388,64 @@ sub parse_line ($) {
 
     # Parse API function lines
 #print "line=$line";
-    if($line =~ /^\s*FUNCTION:/ || $line =~ /^\s*TYPEDEF:/) {
+    if ($line =~ /^\s*FUNCTION:/ || $line =~ /^\s*TYPEDEF:/) {
         my $name;           # The name of the function
         my $params;         # Typedefs for function parameters
-        my $vers;           # The version info for the function
-        my @vers_list;      # Version info, as a list
-        my @vers_nums;      # Version info, as a numeric list
-        my $num_versions;   # Number of versions for function
-        my $last_idx;       # The previous version index seen for a function
-        my $last_vers;      # The previous version # seen for a function
+        my $vers_string;    # The version info for the function
+        my @vers_list;      # Version info, as a list (e.g., "112", "200", etc.
         my $line_type;      # Type of line we are parsing
 
         # Determine the type of the line to parse
-        if($line =~ /^\s*FUNCTION:/) {
+        if ($line =~ /^\s*FUNCTION:/) {
             $line_type = 1;
             # Get the function's name & version info
-            ($name, $params, $vers) = ($line =~ /^\s*FUNCTION:\s*(\w*);\s*(.*?)\s*;\s*(.*?)\s*$/);
-#print "parse_line: name='$name', params='$params', vers='$vers'\n";
+            ($name, $params, $vers_string) = ($line =~ /^\s*FUNCTION:\s*(\w*);\s*(.*?)\s*;\s*(.*?)\s*$/);
+#print "parse_line: name='$name', params='$params', vers_string='$vers_string'\n";
         }
-        elsif($line =~ /^\s*TYPEDEF:/) {
+        elsif ($line =~ /^\s*TYPEDEF:/) {
             $line_type = 2;
 
             # Get the typedefs's name & version info
-            ($name, $vers) = ($line =~ /^\s*TYPEDEF:\s*(\w*);\s*(.*?)\s*$/);
-#print "parse_line: name='$name', vers='$vers'\n";
+            ($name, $vers_string) = ($line =~ /^\s*TYPEDEF:\s*(\w*);\s*(.*?)\s*$/);
+#print "parse_line: name='$name', vers_string='$vers_string'\n";
+        } else {
+            die "unknown line type: $line";
         }
 #print "parse_line: line_type='$line_type'\n";
 
+        validate_line($name, $params, $vers_string);
 
-        validate_line($name, $params, $vers);
-
-        # Split up version info
-        @vers_list = split(/\s*,\s*/, $vers);
+        # Split the version info and strip off the leading "v"
+        @vers_list = split(/\s*,\s*/, $vers_string);
+        @vers_list = map { substr($_, 1) } @vers_list;
 #print "parse_line: vers_list=(@vers_list)\n";
 
-        # Parse the version list into numbers, checking for invalid input
-        foreach(@vers_list) {
-            my $vers_idx;       # Index of version in array
-
-#print "parse_line: _=$_\n";
-            # Get the index of the version
-            if (($vers_idx) = ($_ =~ /v1(\d+)/)) {
-                if($vers_idx == 11) {
-                    $vers_idx++;
-                }
-                $vers_idx /= 2;
-            } else {
-                ($vers_idx) = ($_ =~ /v(\d+)/);
-                $vers_idx = ($vers_idx / 100) + ($pre200_max_idx - 1);
-            }
-#print "parse_line: vers_idx='$vers_idx'\n";
-            push(@vers_nums, $vers_idx);
-        }
-#print "parse_line: vers_nums=(@vers_nums)\n";
-
-        $last_idx = -1;
-        $last_vers = 1;
-        foreach(sort(@vers_nums)) {
-#print "parse_line: _=$_ last_idx='$last_idx'\n";
-            # Update intermediate versions of the library that included the API routine
-            if($last_idx >= 0) {
-#print "parse_line: name='$name'\n";
-#print "parse_line: last_vers='$last_vers'\n";
-#print "parse_line: last_idx='$last_idx'\n";
-
-                # Add the function to the list of API routines available in
-                # different versions of the library
-                while($last_idx <= $_) {
-                    if($line_type == 1) {
-                        $func_vers[$last_idx]{$name} = $last_vers;
-                    } elsif($line_type == 2) {
-                        $type_vers[$last_idx]{$name} = $last_vers;
-                    } else {
-                        die "unknown line type: $line";
-                    }
-                    $last_idx++;
-                }
-
-                # Increment the version # of the function
-                $last_vers++;
-            }
-
-            # Keep track of last version index seen
-            $last_idx = $_;
-        }
-
-        # Finish updating versions of the library that included the API routine
-        if($last_idx >= 0) {
-#print "parse_line: max_idx='$max_idx'\n";
-
-            # Add the function to the list of API routines available in
-            # different versions of the library
-            while($last_idx <= $max_idx) {
-                if($line_type == 1) {
-                    $func_vers[$last_idx]{$name} = $last_vers;
-                } elsif($line_type == 2) {
-                    $type_vers[$last_idx]{$name} = $last_vers;
+        # Parse the version list into the hashes of version and type info
+        my $curr_sym_number = 1;
+        foreach my $vers (@vers_list) {
+            foreach my $hash_vers (@versions) {
+                if ($vers > $hash_vers) {
+                    next;
                 } else {
-                    die "unknown line type: $line";
+                    if ($line_type == 1) {
+                        $api_vers_to_function_vers{$hash_vers}{$name} = $curr_sym_number;
+                    } else {
+                        $api_vers_to_type_vers{$hash_vers}{$name} = $curr_sym_number;
+                    }
                 }
-                $last_idx++;
             }
+
+            $curr_sym_number++;
         }
 
         # Store the number of symbol versions in a hash table, indexed by the name
-        if($line_type == 1) {
+        if ($line_type == 1) {
             $functions{$name} = $#vers_list + 1;
 
             # Store the function's parameter types for later
             $func_params{$name} = $params;
-        } elsif($line_type == 2) {
+        } elsif ($line_type == 2) {
             $typedefs{$name} = $#vers_list + 1;
-        } else {
-            die "unknown line type: $line";
         }
 #print "\n";
     }
@@ -552,7 +492,7 @@ for $file (@ARGV) {
 
 #print "file = '$file'\n";
     # Check for directory prefix on input file
-    if($file =~ /\//) {
+    if ($file =~ /\//) {
         ($prefix) = ($file =~ /(^.*\/)/);
     }
     else {
@@ -561,9 +501,9 @@ for $file (@ARGV) {
 #print "prefix = '$prefix'\n";
     # Read in the entire file
     open SOURCE, $file or die "$file: $!\n";
-    while ( defined ($line=<SOURCE>) ) {
+    while ( defined ($line = <SOURCE>) ) {
         # Skip blank lines and those lines whose first character is a '#'
-        if(!($line =~ /(^\s*#.*$)|(^\s*$)/)) {
+        if (!($line =~ /(^\s*#.*$)|(^\s*$)/)) {
             # Construct data structures for later printing
             parse_line($line);
         }
@@ -573,20 +513,5 @@ for $file (@ARGV) {
     # Create header files
     print "Generating 'H5version.h'\n";
     create_public($prefix);
-
-#for $name (sort keys %functions) {
-#    print "functions{$name} = $functions{$name}\n";
-#}
-
-#for $i (0 .. $#func_vers) {
-#    my $vers_name;      # Name of indexed version
-#    $vers_name = "v1." . ($i * 2);
-#    print "$vers_name functions: ";
-#    for $name (sort keys %{$func_vers[$i]}) {
-#        print "$name$func_vers[$i]{$name} ";
-#    }
-#    print "\n";
-#}
-
 }
 

--- a/bin/make_vers
+++ b/bin/make_vers
@@ -112,7 +112,6 @@ sub print_startprotect ($$) {
 #
 sub print_checkoptions ($) {
     my $fh = shift;             # File handle for output file
-    my $curr_idx;               # Current API version index
 
     # Print the option checking
     print $fh "\n\n/* Issue error if contradicting macros have been defined. */\n";
@@ -120,13 +119,13 @@ sub print_checkoptions ($) {
 
     # Print the #ifdef
     print $fh "#if (";
-    $curr_idx = 0;
     for my $i (0 .. $#versions - 1) {
 
         print $fh "defined(H5_USE_", $versions[$i], "_API)";
 
-        $curr_idx++;
-        if ($curr_idx < @versions - 1) {
+        # -2 because we're ignoring the last version in the loop, and the
+        # last version we DO write out can't have an || after it
+        if ($i < @versions - 2) {
             print $fh " || ";
         }
     }
@@ -137,12 +136,10 @@ sub print_checkoptions ($) {
 
     # Print the #endif
     print $fh "#endif /* (";
-    $curr_idx = 0;
     for my $i (0 .. $#versions - 1) {
         print $fh "defined(H5_USE_", $versions[$i], "_API)";
 
-        $curr_idx++;
-        if ($curr_idx < @versions - 1) {
+        if ($i < @versions - 2) {
             print $fh " || ";
         }
     }

--- a/bin/make_vers
+++ b/bin/make_vers
@@ -4,12 +4,23 @@ use warnings;
 
 # Global settings
 # (The max_idx parameter is the only thing that needs to be changed when adding
-#       support for a new major release.  If support for a prior major release
-#       is added (like support for 1.4, etc), the min_sup_idx parameter will
-#       need to be decremented.)
+#  support for a new major release.  If support for a prior major release is
+#  added (like support for 1.4, etc), the min_sup_idx parameter will need to
+#  be decremented.)
+
+# Supported version strings. "16" = HDF5 1.6.0, "200" = HDF5 2.0.0, etc.
+# Note that the scheme changed with 2.0.0, when we went to semantic versioning.
+# We use 200 instead of 20 so that HDF5 11.0.0 will get 1100 instead of 110,
+# which would conflict with HDF5 1.10.
+@versions = ("16", "18", "110", "112", "114", "200");
 
 # Max. library "index" (0 = v1.0, 1 = 1.2, 2 = 1.4, 3 = 1.6, 4 = 1.8, 5 = 1.10, 6 = 1.12, 7 = 1.14, 8 = 2.0, etc)
 $max_idx = 8;
+
+# Last index where we used 1.<major> for the version number (i.e., 1.14). This
+# creates symbols with numbers like "114". After this version, the symbols have
+# numbers like "200" (for v2.0.0).
+$pre200_max_idx = 7;
 
 # Min. supported previous library version "index" (0 = v1.0, 1 = 1.2, etc)
 $min_sup_idx = 3;
@@ -91,9 +102,12 @@ sub print_checkoptions ($) {
 
     # Print the #ifdef
     print $fh "#if (";
-    for $curr_idx ($min_sup_idx .. ($max_idx - 1)) {
-        print $fh "defined(H5_USE_1", ($curr_idx * 2), "_API)";
-        if($curr_idx < ($max_idx - 1)) {
+    $curr_idx = 0;
+    foreach my $api_vers (@versions) {
+        print $fh "defined(H5_USE_", $api_vers, "_API)";
+
+        $curr_idx++;
+        if($curr_idx < @versions) {
             print $fh " || ";
         }
     }
@@ -104,9 +118,12 @@ sub print_checkoptions ($) {
 
     # Print the #endif
     print $fh "#endif /* (";
-    for $curr_idx ($min_sup_idx .. ($max_idx - 1)) {
-        print $fh "defined(H5_USE_1", ($curr_idx * 2), "_API)";
-        if($curr_idx < ($max_idx - 1)) {
+    $curr_idx = 0;
+    foreach my $api_vers (@versions) {
+        print $fh "defined(H5_USE_", $api_vers, "_API)";
+
+        $curr_idx++;
+        if($curr_idx < @versions) {
             print $fh " || ";
         }
     }
@@ -118,7 +135,6 @@ sub print_checkoptions ($) {
 #
 sub print_globalapidefvers ($) {
     my $fh = shift;             # File handle for output file
-    my $curr_idx;               # Current API version index
 
     # Print the descriptive comment
     print $fh "\n\n/* If a particular default \"global\" version of the library's interfaces is\n";
@@ -126,13 +142,13 @@ sub print_globalapidefvers ($) {
     print $fh " *\n";
     print $fh " */\n";
 
-    for $curr_idx ($min_sup_idx .. ($max_idx - 1)) {
+    for my $api_vers (@versions) {
         # Print API version ifdef
-        print $fh "\n#if defined(H5_USE_1", ($curr_idx * 2), "_API_DEFAULT) && !defined(H5_USE_1", ($curr_idx * 2), "_API)\n";
+        print $fh "\n#if defined(H5_USE_", $api_vers, "_API_DEFAULT) && !defined(H5_USE_", $api_vers, "_API)\n";
         # Print API version definition
-        print $fh " " x $indent, "#define H5_USE_1", ($curr_idx * 2), "_API 1\n";
+        print $fh " " x $indent, "#define H5_USE_", $api_vers, "_API 1\n";
         # Print API version endif
-        print $fh "#endif /* H5_USE_1", ($curr_idx * 2), "_API_DEFAULT && !H5_USE_1", ($curr_idx * 2), "_API */\n";
+        print $fh "#endif /* H5_USE_", $api_vers, "_API_DEFAULT && !H5_USE_", $api_vers, "_API */\n";
     }
 }
 
@@ -152,9 +168,17 @@ sub print_globalapisymbolvers ($) {
     print $fh " */\n";
 
     # Loop over supported older library APIs and define the appropriate macros
-    for $curr_idx ($min_sup_idx .. ($max_idx - 1)) {
+    for $curr_idx ($min_sup_idx .. $max_idx) {
+        # Get the API version string from the index
+        my $api_vers;
+        if ($curr_idx <= $pre200_max_idx) {
+            $api_vers = "1" . ($curr_idx * 2);
+        } else {
+            $api_vers = (1 + $curr_idx - $pre200_max_idx) * 100;
+        }
+
         # Print API version ifdef
-        print $fh "\n#ifdef H5_USE_1", ($curr_idx * 2), "_API\n";
+        print $fh "\n#ifdef H5_USE_", $api_vers, "_API\n";
 
         # Print the version macro info for each function that is defined for
         # this API version
@@ -179,7 +203,7 @@ sub print_globalapisymbolvers ($) {
         }
 
         # Print API version endif
-        print $fh "\n#endif /* H5_USE_1", ($curr_idx * 2), "_API */\n";
+        print $fh "\n#endif /* H5_USE_", $api_vers, "_API */\n";
     }
 }
 
@@ -301,7 +325,7 @@ sub parse_line ($) {
     my $line = shift;   # Get the line to parse
 
     # Parse API function lines
-#print "line=$line\n";
+#print "line=$line";
     if($line =~ /^\s*FUNCTION:/ || $line =~ /^\s*TYPEDEF:/) {
         my $name;           # The name of the function
         my $params;         # Typedefs for function parameters
@@ -361,7 +385,7 @@ sub parse_line ($) {
             #        (the default api version for 1.12).  Allowing a v111 entry and 
             #        incrementing its index 13 lines below allows a version 2 that is
             #        never accessed via the H5O function macros.
-            if(!( $_ =~ /v1[02468]/ || $_ =~ /v11[02468]/ ||  $_ =~ /v111/ )) {
+            if(!( $_ =~ /v1[02468]/ || $_ =~ /v11[02468]/ ||  $_ =~ /v111/ || $_ =~ /v200/ )) {
                 die "bad version information: $name";
             }
             if(exists($sym_versions{$_})) {
@@ -373,11 +397,15 @@ sub parse_line ($) {
 
 #print "parse_line: _=$_\n";
             # Get the index of the version
-            ($vers_idx) = ($_ =~ /v1(\d+)/);
-            if($vers_idx == 11) {
-                $vers_idx++;
+            if (($vers_idx) = ($_ =~ /v1(\d+)/)) {
+                if($vers_idx == 11) {
+                    $vers_idx++;
+                }
+                $vers_idx /= 2;
+            } else {
+                ($vers_idx) = ($_ =~ /v(\d+)/);
+                $vers_idx = ($vers_idx / 100) + ($pre200_max_idx - 1);
             }
-            $vers_idx /= 2;
 #print "parse_line: vers_idx='$vers_idx'\n";
             push(@vers_nums, $vers_idx);
         }
@@ -444,6 +472,7 @@ sub parse_line ($) {
         } else {
             die "unknown line type: $line";
         }
+#print "\n";
     }
     # Unknown keyword
     else {

--- a/bin/make_vers
+++ b/bin/make_vers
@@ -122,7 +122,7 @@ sub print_checkoptions ($) {
     for my $i (0 .. $#versions - 1) {
         print $fh "defined(H5_USE_", $versions[$i], "_API)";
 
-        # -2 because we're ignoring the last version in the loop, and the
+        # -2 because we're ignoring the last version in the array, and the
         # last version we DO write out can't have an || after it
         if ($i < @versions - 2) {
             print $fh " || ";

--- a/bin/make_vers
+++ b/bin/make_vers
@@ -357,9 +357,8 @@ sub validate_line {
         #        version for default api=v110 should be version 1 to work correctly
         #        with 1.10 applications that were using unversioned H5O functions,
         #        and the H5O function version should be version 3 for default api=v112
-        #        (the default api version for 1.12).  Allowing a v111 entry and
-        #        incrementing its index 13 lines below allows a version 2 that is
-        #        never accessed via the H5O function macros.
+        #        (the default api version for 1.12).  Allowing a v111 entry allows
+        #        a version 2 that is never accessed via the H5O function macros.
         if (!( $_ =~ /v1[02468]/ || $_ =~ /v11[02468]/ ||  $_ =~ /v111/ || $_ =~ /v200/ )) {
             die "bad version information: $name";
         }

--- a/c++/src/C2Cppfunction_map.htm
+++ b/c++/src/C2Cppfunction_map.htm
@@ -9992,7 +9992,7 @@ normal'><span style='font-size:14.0pt;mso-bidi-font-size:11.0pt;line-height:
   none;mso-border-top-alt:solid windowtext .5pt;mso-border-alt:solid windowtext .5pt;
   padding:0in 5.4pt 0in 5.4pt'>
   <p class=MsoNormal style='margin-bottom:0in;margin-bottom:.0001pt;line-height:
-  normal'>H5Iregister_type</p>
+  normal'>H5Iregister_type2</p>
   </td>
   <td width=474 valign=top style='width:355.2pt;border-top:none;border-left:
   none;border-bottom:solid windowtext 1.0pt;border-right:solid windowtext 1.0pt;

--- a/doxygen/examples/H5I_examples.c
+++ b/doxygen/examples/H5I_examples.c
@@ -133,7 +133,7 @@ fail_dcpl:;
         hid_t      obj_id;
 
         // register a new ID type
-        if ((type = H5Iregister_type(128, 1024, &free_func)) < 0) {
+        if ((type = H5Iregister_type(1024, &free_func)) < 0) {
             ret_val = EXIT_FAILURE;
             goto fail_register;
         }
@@ -167,7 +167,7 @@ fail_register:;
         hsize_t    count;
 
         // register a new ID type
-        if ((type = H5Iregister_type(128, 1024, NULL)) < 0) {
+        if ((type = H5Iregister_type(1024, NULL)) < 0) {
             ret_val = EXIT_FAILURE;
             goto fail_register;
         }
@@ -194,7 +194,7 @@ fail_register:;
         hid_t      obj_id;
 
         // register a new ID type
-        if ((type = H5Iregister_type(128, 1024, NULL)) < 0) {
+        if ((type = H5Iregister_type(1024, NULL)) < 0) {
             ret_val = EXIT_FAILURE;
             goto fail_register;
         }
@@ -224,7 +224,7 @@ fail_register:;
         H5I_type_t type;
 
         // register a new ID type
-        if ((type = H5Iregister_type(128, 1024, NULL)) < 0) {
+        if ((type = H5Iregister_type(1024, NULL)) < 0) {
             ret_val = EXIT_FAILURE;
             goto fail_register;
         }

--- a/doxygen/examples/H5I_examples.c
+++ b/doxygen/examples/H5I_examples.c
@@ -133,7 +133,7 @@ fail_dcpl:;
         hid_t      obj_id;
 
         // register a new ID type
-        if ((type = H5Iregister_type(1024, &free_func)) < 0) {
+        if ((type = H5Iregister_type2(1024, &free_func)) < 0) {
             ret_val = EXIT_FAILURE;
             goto fail_register;
         }
@@ -167,7 +167,7 @@ fail_register:;
         hsize_t    count;
 
         // register a new ID type
-        if ((type = H5Iregister_type(1024, NULL)) < 0) {
+        if ((type = H5Iregister_type2(1024, NULL)) < 0) {
             ret_val = EXIT_FAILURE;
             goto fail_register;
         }
@@ -194,7 +194,7 @@ fail_register:;
         hid_t      obj_id;
 
         // register a new ID type
-        if ((type = H5Iregister_type(1024, NULL)) < 0) {
+        if ((type = H5Iregister_type2(1024, NULL)) < 0) {
             ret_val = EXIT_FAILURE;
             goto fail_register;
         }
@@ -224,7 +224,7 @@ fail_register:;
         H5I_type_t type;
 
         // register a new ID type
-        if ((type = H5Iregister_type(1024, NULL)) < 0) {
+        if ((type = H5Iregister_type2(1024, NULL)) < 0) {
             ret_val = EXIT_FAILURE;
             goto fail_register;
         }

--- a/hl/src/H5PT.c
+++ b/hl/src/H5PT.c
@@ -71,8 +71,7 @@ H5PTcreate(hid_t loc_id, const char *dset_name, hid_t dtype_id, hsize_t chunk_si
 
     /* Register the packet table ID type if this is the first table created */
     if (H5PT_ptable_id_type < 0)
-        if ((H5PT_ptable_id_type =
-                 H5Iregister_type2(0, (H5I_free_t)H5PT_free_id)) < 0)
+        if ((H5PT_ptable_id_type = H5Iregister_type2(0, (H5I_free_t)H5PT_free_id)) < 0)
             goto error;
 
     /* Get memory for the table identifier */
@@ -185,8 +184,7 @@ H5PTcreate_fl(hid_t loc_id, const char *dset_name, hid_t dtype_id, hsize_t chunk
 
     /* Register the packet table ID type if this is the first table created */
     if (H5PT_ptable_id_type < 0)
-        if ((H5PT_ptable_id_type =
-                 H5Iregister_type2(0, (H5I_free_t)H5PT_free_id)) < 0)
+        if ((H5PT_ptable_id_type = H5Iregister_type2(0, (H5I_free_t)H5PT_free_id)) < 0)
             goto error;
 
     /* Get memory for the table identifier */
@@ -285,8 +283,7 @@ H5PTopen(hid_t loc_id, const char *dset_name)
 
     /* Register the packet table ID type if this is the first table created */
     if (H5PT_ptable_id_type < 0)
-        if ((H5PT_ptable_id_type =
-                 H5Iregister_type2(0, (H5I_free_t)H5PT_free_id)) < 0)
+        if ((H5PT_ptable_id_type = H5Iregister_type2(0, (H5I_free_t)H5PT_free_id)) < 0)
             goto error;
 
     table = (htbl_t *)malloc(sizeof(htbl_t));

--- a/hl/src/H5PT.c
+++ b/hl/src/H5PT.c
@@ -72,7 +72,7 @@ H5PTcreate(hid_t loc_id, const char *dset_name, hid_t dtype_id, hsize_t chunk_si
     /* Register the packet table ID type if this is the first table created */
     if (H5PT_ptable_id_type < 0)
         if ((H5PT_ptable_id_type =
-                 H5Iregister_type(0, (H5I_free_t)H5PT_free_id)) < 0)
+                 H5Iregister_type2(0, (H5I_free_t)H5PT_free_id)) < 0)
             goto error;
 
     /* Get memory for the table identifier */
@@ -186,7 +186,7 @@ H5PTcreate_fl(hid_t loc_id, const char *dset_name, hid_t dtype_id, hsize_t chunk
     /* Register the packet table ID type if this is the first table created */
     if (H5PT_ptable_id_type < 0)
         if ((H5PT_ptable_id_type =
-                 H5Iregister_type(0, (H5I_free_t)H5PT_free_id)) < 0)
+                 H5Iregister_type2(0, (H5I_free_t)H5PT_free_id)) < 0)
             goto error;
 
     /* Get memory for the table identifier */
@@ -286,7 +286,7 @@ H5PTopen(hid_t loc_id, const char *dset_name)
     /* Register the packet table ID type if this is the first table created */
     if (H5PT_ptable_id_type < 0)
         if ((H5PT_ptable_id_type =
-                 H5Iregister_type(0, (H5I_free_t)H5PT_free_id)) < 0)
+                 H5Iregister_type2(0, (H5I_free_t)H5PT_free_id)) < 0)
             goto error;
 
     table = (htbl_t *)malloc(sizeof(htbl_t));

--- a/hl/src/H5PT.c
+++ b/hl/src/H5PT.c
@@ -25,8 +25,6 @@ typedef struct {
 static hsize_t    H5PT_ptable_count   = 0;
 static H5I_type_t H5PT_ptable_id_type = H5I_UNINIT;
 
-#define H5PT_HASH_TABLE_SIZE 64
-
 /* Packet Table private functions */
 static herr_t H5PT_free_id(void *id, void **_ctx);
 static herr_t H5PT_close(htbl_t *table);
@@ -74,7 +72,7 @@ H5PTcreate(hid_t loc_id, const char *dset_name, hid_t dtype_id, hsize_t chunk_si
     /* Register the packet table ID type if this is the first table created */
     if (H5PT_ptable_id_type < 0)
         if ((H5PT_ptable_id_type =
-                 H5Iregister_type((size_t)H5PT_HASH_TABLE_SIZE, 0, (H5I_free_t)H5PT_free_id)) < 0)
+                 H5Iregister_type(0, (H5I_free_t)H5PT_free_id)) < 0)
             goto error;
 
     /* Get memory for the table identifier */
@@ -188,7 +186,7 @@ H5PTcreate_fl(hid_t loc_id, const char *dset_name, hid_t dtype_id, hsize_t chunk
     /* Register the packet table ID type if this is the first table created */
     if (H5PT_ptable_id_type < 0)
         if ((H5PT_ptable_id_type =
-                 H5Iregister_type((size_t)H5PT_HASH_TABLE_SIZE, 0, (H5I_free_t)H5PT_free_id)) < 0)
+                 H5Iregister_type(0, (H5I_free_t)H5PT_free_id)) < 0)
             goto error;
 
     /* Get memory for the table identifier */
@@ -288,7 +286,7 @@ H5PTopen(hid_t loc_id, const char *dset_name)
     /* Register the packet table ID type if this is the first table created */
     if (H5PT_ptable_id_type < 0)
         if ((H5PT_ptable_id_type =
-                 H5Iregister_type((size_t)H5PT_HASH_TABLE_SIZE, 0, (H5I_free_t)H5PT_free_id)) < 0)
+                 H5Iregister_type(0, (H5I_free_t)H5PT_free_id)) < 0)
             goto error;
 
     table = (htbl_t *)malloc(sizeof(htbl_t));

--- a/java/src/hdf/hdf5lib/H5.java
+++ b/java/src/hdf/hdf5lib/H5.java
@@ -6306,7 +6306,7 @@ public class H5 implements java.io.Serializable {
     // hid_t H5Iregister(H5I_type_t type, const void *object);
 
     // typedef herr_t (*H5I_free_t)(void *);
-    // H5I_type_t H5Iregister_type(size_t hash_size, unsigned reserved, H5I_free_t free_func);
+    // H5I_type_t H5Iregister_type2(unsigned reserved, H5I_free_t free_func);
 
     // void *H5Iremove_verify(hid_t id, H5I_type_t id_type);
 

--- a/release_docs/RELEASE.txt
+++ b/release_docs/RELEASE.txt
@@ -156,6 +156,24 @@ New Features
 
     Library:
     --------
+    - The H5Iregister_type() signature has changed
+
+      The hash_size parameter has not been used since early versions of HDF5
+      1.8, so it has been removed and the API call has been versioned.
+
+      The old signature has been renamed to H5Iregister_type1() and is considered
+      deprecated:
+
+        H5I_type_t H5Iregister_type1(size_t hash_size, unsigned reserved, H5I_free_t free_func);
+
+      The new signature is H5Iregister_type2(). New code should use this
+      version:
+
+        H5I_type_t H5Iregister_type2(unsigned reserved, H5I_free_t free_func);
+
+      H5Iregister_type() will map to the new signature unless the library is
+      explicitly configured to use an older version of the API.
+
     - H5F_LIBVER_LATEST is now an enum value
 
       This was previously #defined to the latest H5F_libver_t API version, but

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -387,6 +387,7 @@ IDE_GENERATED_PROPERTIES ("H5HL" "${H5HL_HDRS}" "${H5HL_SOURCES}" )
 set (H5I_SOURCES
     ${HDF5_SRC_DIR}/H5I.c
     ${HDF5_SRC_DIR}/H5Idbg.c
+    ${HDF5_SRC_DIR}/H5Ideprec.c
     ${HDF5_SRC_DIR}/H5Iint.c
     ${HDF5_SRC_DIR}/H5Itest.c
 )

--- a/src/H5I.c
+++ b/src/H5I.c
@@ -79,10 +79,9 @@ static int H5I__iterate_pub_cb(void *obj, hid_t id, void *udata);
  *              of ID's to give out.  A specific number (RESERVED) of type
  *              entries may be reserved to enable "constant" values to be handed
  *              out which are valid IDs in the type, but which do not map to any
- *              data structures and are not allocated dynamically later. HASH_SIZE is
- *              the minimum hash table size to use for the type. FREE_FUNC is
- *              called with an object pointer when the object is removed from
- *              the type.
+ *              data structures and are not allocated dynamically later.
+ *              FREE_FUNC is called with an object pointer when the object is
+ *              removed from the type.
  *
  * Return:      Success:    Type ID of the new type
  *              Failure:    H5I_BADID
@@ -92,61 +91,14 @@ static int H5I__iterate_pub_cb(void *obj, hid_t id, void *udata);
 H5I_type_t
 H5Iregister_type2(unsigned reserved, H5I_free_t free_func)
 {
-    H5I_class_t *cls       = NULL;      /* New ID class */
-    H5I_type_t   new_type  = H5I_BADID; /* New ID type value */
-    H5I_type_t   ret_value = H5I_BADID; /* Return value */
+    H5I_type_t ret_value = H5I_BADID;
 
     FUNC_ENTER_API(H5I_BADID)
 
-    /* Generate a new H5I_type_t value */
-
-    /* Increment the number of types */
-    if (H5I_next_type_g < H5I_MAX_NUM_TYPES) {
-        new_type = (H5I_type_t)H5I_next_type_g;
-        H5I_next_type_g++;
-    }
-    else {
-        bool done; /* Indicate that search was successful */
-        int  i;
-
-        /* Look for a free type to give out */
-        done = false;
-        for (i = H5I_NTYPES; i < H5I_MAX_NUM_TYPES && done == false; i++) {
-            if (NULL == H5I_type_info_array_g[i]) {
-                /* Found a free type ID */
-                new_type = (H5I_type_t)i;
-                done     = true;
-            }
-        }
-
-        /* Verify that we found a type to give out */
-        if (done == false)
-            HGOTO_ERROR(H5E_ID, H5E_NOSPACE, H5I_BADID, "Maximum number of ID types exceeded");
-    }
-
-    /* Allocate new ID class */
-    if (NULL == (cls = H5MM_calloc(sizeof(H5I_class_t))))
-        HGOTO_ERROR(H5E_ID, H5E_CANTALLOC, H5I_BADID, "ID class allocation failed");
-
-    /* Initialize class fields */
-    cls->type      = new_type;
-    cls->flags     = H5I_CLASS_IS_APPLICATION;
-    cls->reserved  = reserved;
-    cls->free_func = free_func;
-
-    /* Register the new ID class */
-    if (H5I_register_type(cls) < 0)
+    if (H5I_BADID == (ret_value = H5I__register_type_common(reserved, free_func)))
         HGOTO_ERROR(H5E_ID, H5E_CANTINIT, H5I_BADID, "can't initialize ID class");
 
-    /* Set return value */
-    ret_value = new_type;
-
 done:
-    /* Clean up on error */
-    if (ret_value < 0)
-        if (cls)
-            cls = H5MM_xfree(cls);
-
     FUNC_LEAVE_API(ret_value)
 } /* end H5Iregister_type2() */
 

--- a/src/H5I.c
+++ b/src/H5I.c
@@ -73,9 +73,9 @@ static int H5I__iterate_pub_cb(void *obj, hid_t id, void *udata);
 /*******************/
 
 /*-------------------------------------------------------------------------
- * Function:    H5Iregister_type
+ * Function:    H5Iregister_type2
  *
- * Purpose:     Public interface to H5I_register_type.  Creates a new type
+ * Purpose:     Public interface to H5I_register_type2.  Creates a new type
  *              of ID's to give out.  A specific number (RESERVED) of type
  *              entries may be reserved to enable "constant" values to be handed
  *              out which are valid IDs in the type, but which do not map to any
@@ -90,7 +90,7 @@ static int H5I__iterate_pub_cb(void *obj, hid_t id, void *udata);
  *-------------------------------------------------------------------------
  */
 H5I_type_t
-H5Iregister_type(unsigned reserved, H5I_free_t free_func)
+H5Iregister_type2(unsigned reserved, H5I_free_t free_func)
 {
     H5I_class_t *cls       = NULL;      /* New ID class */
     H5I_type_t   new_type  = H5I_BADID; /* New ID type value */
@@ -148,7 +148,7 @@ done:
             cls = H5MM_xfree(cls);
 
     FUNC_LEAVE_API(ret_value)
-} /* end H5Iregister_type() */
+} /* end H5Iregister_type2() */
 
 /*-------------------------------------------------------------------------
  * Function:    H5Itype_exists

--- a/src/H5I.c
+++ b/src/H5I.c
@@ -90,7 +90,7 @@ static int H5I__iterate_pub_cb(void *obj, hid_t id, void *udata);
  *-------------------------------------------------------------------------
  */
 H5I_type_t
-H5Iregister_type(size_t H5_ATTR_UNUSED hash_size, unsigned reserved, H5I_free_t free_func)
+H5Iregister_type(unsigned reserved, H5I_free_t free_func)
 {
     H5I_class_t *cls       = NULL;      /* New ID class */
     H5I_type_t   new_type  = H5I_BADID; /* New ID type value */

--- a/src/H5Ideprec.c
+++ b/src/H5Ideprec.c
@@ -84,61 +84,14 @@
 H5I_type_t
 H5Iregister_type1(size_t H5_ATTR_UNUSED hash_size, unsigned reserved, H5I_free_t free_func)
 {
-    H5I_class_t *cls       = NULL;      /* New ID class */
-    H5I_type_t   new_type  = H5I_BADID; /* New ID type value */
-    H5I_type_t   ret_value = H5I_BADID; /* Return value */
+    H5I_type_t ret_value = H5I_BADID;
 
     FUNC_ENTER_API(H5I_BADID)
 
-    /* Generate a new H5I_type_t value */
-
-    /* Increment the number of types */
-    if (H5I_next_type_g < H5I_MAX_NUM_TYPES) {
-        new_type = (H5I_type_t)H5I_next_type_g;
-        H5I_next_type_g++;
-    }
-    else {
-        bool done; /* Indicate that search was successful */
-        int  i;
-
-        /* Look for a free type to give out */
-        done = false;
-        for (i = H5I_NTYPES; i < H5I_MAX_NUM_TYPES && done == false; i++) {
-            if (NULL == H5I_type_info_array_g[i]) {
-                /* Found a free type ID */
-                new_type = (H5I_type_t)i;
-                done     = true;
-            }
-        }
-
-        /* Verify that we found a type to give out */
-        if (done == false)
-            HGOTO_ERROR(H5E_ID, H5E_NOSPACE, H5I_BADID, "Maximum number of ID types exceeded");
-    }
-
-    /* Allocate new ID class */
-    if (NULL == (cls = H5MM_calloc(sizeof(H5I_class_t))))
-        HGOTO_ERROR(H5E_ID, H5E_CANTALLOC, H5I_BADID, "ID class allocation failed");
-
-    /* Initialize class fields */
-    cls->type      = new_type;
-    cls->flags     = H5I_CLASS_IS_APPLICATION;
-    cls->reserved  = reserved;
-    cls->free_func = free_func;
-
-    /* Register the new ID class */
-    if (H5I_register_type(cls) < 0)
+    if (H5I_BADID == (ret_value = H5I__register_type_common(reserved, free_func)))
         HGOTO_ERROR(H5E_ID, H5E_CANTINIT, H5I_BADID, "can't initialize ID class");
 
-    /* Set return value */
-    ret_value = new_type;
-
 done:
-    /* Clean up on error */
-    if (ret_value < 0)
-        if (cls)
-            cls = H5MM_xfree(cls);
-
     FUNC_LEAVE_API(ret_value)
 } /* end H5Iregister_type1() */
 #endif /* H5_NO_DEPRECATED_SYMBOLS */

--- a/src/H5Ideprec.c
+++ b/src/H5Ideprec.c
@@ -1,0 +1,144 @@
+/* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * *
+ * Copyright by The HDF Group.                                               *
+ * All rights reserved.                                                      *
+ *                                                                           *
+ * This file is part of HDF5.  The full HDF5 copyright notice, including     *
+ * terms governing use, modification, and redistribution, is contained in    *
+ * the LICENSE file, which can be found at the root of the source code       *
+ * distribution tree, or in https://www.hdfgroup.org/licenses.               *
+ * If you do not have access to either file, you may request a copy from     *
+ * help@hdfgroup.org.                                                        *
+ * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
+
+/*-------------------------------------------------------------------------
+ *
+ * Created:	H5Ideprec.c
+ *
+ * Purpose:	Deprecated functions from the H5I interface.  These
+ *          functions are here for compatibility purposes and may be
+ *          removed in the future.  Applications should switch to the
+ *          newer APIs.
+ *
+ *-------------------------------------------------------------------------
+ */
+
+/****************/
+/* Module Setup */
+/****************/
+
+#include "H5Imodule.h" /* This source code file is part of the H5I module */
+
+/***********/
+/* Headers */
+/***********/
+#include "H5private.h"   /* Generic Functions                        */
+#include "H5Eprivate.h"  /* Error handling                           */
+#include "H5Ipkg.h"      /* File access                              */
+
+/****************/
+/* Local Macros */
+/****************/
+
+/******************/
+/* Local Typedefs */
+/******************/
+
+/********************/
+/* Package Typedefs */
+/********************/
+
+/********************/
+/* Local Prototypes */
+/********************/
+
+/*********************/
+/* Package Variables */
+/*********************/
+
+/*****************************/
+/* Library Private Variables */
+/*****************************/
+
+/*******************/
+/* Local Variables */
+/*******************/
+
+#ifndef H5_NO_DEPRECATED_SYMBOLS
+/*-------------------------------------------------------------------------
+ * Function:    H5Iregister_type1
+ *
+ * Purpose:     Public interface to H5I_register_type.  Creates a new type
+ *              of ID's to give out.  A specific number (RESERVED) of type
+ *              entries may be reserved to enable "constant" values to be handed
+ *              out which are valid IDs in the type, but which do not map to any
+ *              data structures and are not allocated dynamically later. HASH_SIZE is
+ *              the minimum hash table size to use for the type. FREE_FUNC is
+ *              called with an object pointer when the object is removed from
+ *              the type.
+ *
+ * Return:      Success:    Type ID of the new type
+ *              Failure:    H5I_BADID
+ *
+ *-------------------------------------------------------------------------
+ */
+H5I_type_t
+H5Iregister_type1(size_t H5_ATTR_UNUSED hash_size, unsigned reserved, H5I_free_t free_func)
+{
+    H5I_class_t *cls       = NULL;      /* New ID class */
+    H5I_type_t   new_type  = H5I_BADID; /* New ID type value */
+    H5I_type_t   ret_value = H5I_BADID; /* Return value */
+
+    FUNC_ENTER_API(H5I_BADID)
+
+    /* Generate a new H5I_type_t value */
+
+    /* Increment the number of types */
+    if (H5I_next_type_g < H5I_MAX_NUM_TYPES) {
+        new_type = (H5I_type_t)H5I_next_type_g;
+        H5I_next_type_g++;
+    }
+    else {
+        bool done; /* Indicate that search was successful */
+        int  i;
+
+        /* Look for a free type to give out */
+        done = false;
+        for (i = H5I_NTYPES; i < H5I_MAX_NUM_TYPES && done == false; i++) {
+            if (NULL == H5I_type_info_array_g[i]) {
+                /* Found a free type ID */
+                new_type = (H5I_type_t)i;
+                done     = true;
+            }
+        }
+
+        /* Verify that we found a type to give out */
+        if (done == false)
+            HGOTO_ERROR(H5E_ID, H5E_NOSPACE, H5I_BADID, "Maximum number of ID types exceeded");
+    }
+
+    /* Allocate new ID class */
+    if (NULL == (cls = H5MM_calloc(sizeof(H5I_class_t))))
+        HGOTO_ERROR(H5E_ID, H5E_CANTALLOC, H5I_BADID, "ID class allocation failed");
+
+    /* Initialize class fields */
+    cls->type      = new_type;
+    cls->flags     = H5I_CLASS_IS_APPLICATION;
+    cls->reserved  = reserved;
+    cls->free_func = free_func;
+
+    /* Register the new ID class */
+    if (H5I_register_type(cls) < 0)
+        HGOTO_ERROR(H5E_ID, H5E_CANTINIT, H5I_BADID, "can't initialize ID class");
+
+    /* Set return value */
+    ret_value = new_type;
+
+done:
+    /* Clean up on error */
+    if (ret_value < 0)
+        if (cls)
+            cls = H5MM_xfree(cls);
+
+    FUNC_LEAVE_API(ret_value)
+} /* end H5Iregister_type1() */
+#endif /* H5_NO_DEPRECATED_SYMBOLS */

--- a/src/H5Ideprec.c
+++ b/src/H5Ideprec.c
@@ -31,9 +31,9 @@
 /***********/
 /* Headers */
 /***********/
-#include "H5private.h"   /* Generic Functions                        */
-#include "H5Eprivate.h"  /* Error handling                           */
-#include "H5Ipkg.h"      /* File access                              */
+#include "H5private.h"  /* Generic Functions                        */
+#include "H5Eprivate.h" /* Error handling                           */
+#include "H5Ipkg.h"     /* File access                              */
 
 /****************/
 /* Local Macros */

--- a/src/H5Ipkg.h
+++ b/src/H5Ipkg.h
@@ -106,6 +106,7 @@ H5_DLLVAR int H5I_next_type_g;
 
 H5_DLL hid_t          H5I__register(H5I_type_t type, const void *object, bool app_ref,
                                     H5I_future_realize_func_t realize_cb, H5I_future_discard_func_t discard_cb);
+H5_DLL H5I_type_t     H5I__register_type_common(unsigned reserved, H5I_free_t free_func);
 H5_DLL int            H5I__destroy_type(H5I_type_t type);
 H5_DLL void          *H5I__remove_verify(hid_t id, H5I_type_t type);
 H5_DLL int            H5I__inc_type_ref(H5I_type_t type);

--- a/src/H5Ipublic.h
+++ b/src/H5Ipublic.h
@@ -399,7 +399,7 @@ H5_DLL int H5Iget_ref(hid_t id);
  *
  * \return Returns the type identifier on success, negative on failure.
  *
- * \details H5Iregister_type() allocates space for a new ID type and returns an
+ * \details H5Iregister_type2() allocates space for a new ID type and returns an
  *          identifier for it.
  *
  *          The \p reserved parameter indicates the number of IDs in this new
@@ -417,7 +417,7 @@ H5_DLL int H5Iget_ref(hid_t id);
  * \since 2.0.0
  *
  */
-H5_DLL H5I_type_t H5Iregister_type(unsigned reserved, H5I_free_t free_func);
+H5_DLL H5I_type_t H5Iregister_type2(unsigned reserved, H5I_free_t free_func);
 /**
  * \ingroup H5IUD
  *
@@ -695,7 +695,7 @@ H5_DLL htri_t H5Iis_valid(hid_t id);
  *
  * \return Returns the type identifier on success, negative on failure.
  *
- * \details H5Iregister_type() allocates space for a new ID type and returns an
+ * \details H5Iregister_type1() allocates space for a new ID type and returns an
  *          identifier for it.
  *
  *          The \p hash_size parameter indicates the minimum size of the hash

--- a/src/H5Ipublic.h
+++ b/src/H5Ipublic.h
@@ -394,8 +394,6 @@ H5_DLL int H5Iget_ref(hid_t id);
  *
  * \brief Creates and returns a new ID type
  *
- * \param[in] hash_size Minimum hash table size (in entries) used to store IDs
- *                      for the new type (unused in 1.8.13 and later)
  * \param[in] reserved Number of reserved IDs for the new type
  * \param[in] free_func Function used to deallocate space for a single ID
  *
@@ -403,10 +401,6 @@ H5_DLL int H5Iget_ref(hid_t id);
  *
  * \details H5Iregister_type() allocates space for a new ID type and returns an
  *          identifier for it.
- *
- *          The \p hash_size parameter indicates the minimum size of the hash
- *          table used to store IDs in the new type. This parameter is unused
- *          in 1.8.13 and later, when the implementation of ID storage changed.
  *
  *          The \p reserved parameter indicates the number of IDs in this new
  *          type to be reserved. Reserved IDs are valid IDs which are not
@@ -420,10 +414,10 @@ H5_DLL int H5Iget_ref(hid_t id);
  *          pointer which was passed in to the H5Iregister() function. The \p
  *          free_func function should return 0 on success and -1 on failure.
  *
- * \since 1.8.0
+ * \since 2.0.0
  *
  */
-H5_DLL H5I_type_t H5Iregister_type(size_t hash_size, unsigned reserved, H5I_free_t free_func);
+H5_DLL H5I_type_t H5Iregister_type(unsigned reserved, H5I_free_t free_func);
 /**
  * \ingroup H5IUD
  *
@@ -682,6 +676,51 @@ H5_DLL htri_t H5Itype_exists(H5I_type_t type);
  *
  */
 H5_DLL htri_t H5Iis_valid(hid_t id);
+
+/* Symbols defined for compatibility with previous versions of the HDF5 API.
+ *
+ * Use of these symbols is deprecated.
+ */
+#ifndef H5_NO_DEPRECATED_SYMBOLS
+
+/**
+ * \ingroup H5IUD
+ *
+ * \brief Creates and returns a new ID type
+ *
+ * \param[in] hash_size Minimum hash table size (in entries) used to store IDs
+ *                      for the new type (unused in 1.8.13 and later)
+ * \param[in] reserved Number of reserved IDs for the new type
+ * \param[in] free_func Function used to deallocate space for a single ID
+ *
+ * \return Returns the type identifier on success, negative on failure.
+ *
+ * \details H5Iregister_type() allocates space for a new ID type and returns an
+ *          identifier for it.
+ *
+ *          The \p hash_size parameter indicates the minimum size of the hash
+ *          table used to store IDs in the new type. This parameter is unused
+ *          in 1.8.13 and later, when the implementation of ID storage changed.
+ *
+ *          The \p reserved parameter indicates the number of IDs in this new
+ *          type to be reserved. Reserved IDs are valid IDs which are not
+ *          associated with any storage within the library.
+ *
+ *          The \p free_func parameter is a function pointer to a function
+ *          which returns an herr_t and accepts a \c void*. The purpose of this
+ *          function is to deallocate memory for a single ID. It will be called
+ *          by H5Iclear_type() and H5Idestroy_type() on each ID. This function
+ *          is NOT called by H5Iremove_verify(). The \c void* will be the same
+ *          pointer which was passed in to the H5Iregister() function. The \p
+ *          free_func function should return 0 on success and -1 on failure.
+ *
+ * \since 1.8.0
+ * \deprecated 2.0.0 Deprecated in favor of the function H5Iregister_type2()
+ *
+ */
+H5_DLL H5I_type_t H5Iregister_type1(size_t hash_size, unsigned reserved, H5I_free_t free_func);
+
+#endif /* H5_NO_DEPRECATED_SYMBOLS */
 
 #ifdef __cplusplus
 }

--- a/src/H5vers.txt
+++ b/src/H5vers.txt
@@ -39,7 +39,7 @@
 
 # API function names
 # (although not required, it's easier to compare this file with the headers
-#       generated if the list below is in alphanumeric sort order - QAK)
+#       generated if the list below is in alphanumeric sort order)
 FUNCTION: H5Acreate; ; v10, v18
 FUNCTION: H5Aiterate; H5A_operator; v10, v18
 FUNCTION: H5Dcreate; ; v10, v18
@@ -53,6 +53,7 @@ FUNCTION: H5Ewalk; H5E_walk, H5E_error; v10, v18
 FUNCTION: H5Fget_info; H5F_info; v18, v110
 FUNCTION: H5Gcreate; ; v10, v18
 FUNCTION: H5Gopen; ; v10, v18
+FUNCTION: H5Iregister_type; ; v18, v200
 FUNCTION: H5Lget_info; H5L_info; v18, v112
 FUNCTION: H5Lget_info_by_idx; H5L_info; v18, v112
 FUNCTION: H5Literate; H5L_iterate; v18, v112
@@ -88,7 +89,7 @@ FUNCTION: H5Topen; ; v10, v18
 
 # API typedefs
 # (although not required, it's easier to compare this file with the headers
-#       generated if the list below is in alphanumeric sort order - QAK)
+#       generated if the list below is in alphanumeric sort order)
 TYPEDEF: H5E_auto; v10, v18
 TYPEDEF: H5O_info; v18, v112
 TYPEDEF: H5O_iterate; v18, v112

--- a/src/H5version.h
+++ b/src/H5version.h
@@ -50,9 +50,9 @@
 
 /* Issue error if contradicting macros have been defined. */
 /* (Can't use an older (deprecated) API version if deprecated symbols have been disabled) */
-#if (defined(H5_USE_16_API) || defined(H5_USE_18_API) || defined(H5_USE_110_API) || defined(H5_USE_112_API) || defined(H5_USE_114_API) || defined(H5_USE_200_API)) && defined(H5_NO_DEPRECATED_SYMBOLS)
+#if (defined(H5_USE_16_API) || defined(H5_USE_18_API) || defined(H5_USE_110_API) || defined(H5_USE_112_API) || defined(H5_USE_114_API)) && defined(H5_NO_DEPRECATED_SYMBOLS)
   #error "Can't choose old API versions when deprecated APIs are disabled"
-#endif /* (defined(H5_USE_16_API) || defined(H5_USE_18_API) || defined(H5_USE_110_API) || defined(H5_USE_112_API) || defined(H5_USE_114_API) || defined(H5_USE_200_API)) && defined(H5_NO_DEPRECATED_SYMBOLS) */
+#endif /* (defined(H5_USE_16_API) || defined(H5_USE_18_API) || defined(H5_USE_110_API) || defined(H5_USE_112_API) || defined(H5_USE_114_API)) && defined(H5_NO_DEPRECATED_SYMBOLS) */
 
 
 /* If a particular "global" version of the library's interfaces is chosen,

--- a/src/H5version.h
+++ b/src/H5version.h
@@ -43,12 +43,16 @@
   #define H5_USE_114_API 1
 #endif /* H5_USE_114_API_DEFAULT && !H5_USE_114_API */
 
+#if defined(H5_USE_200_API_DEFAULT) && !defined(H5_USE_200_API)
+  #define H5_USE_200_API 1
+#endif /* H5_USE_200_API_DEFAULT && !H5_USE_200_API */
+
 
 /* Issue error if contradicting macros have been defined. */
 /* (Can't use an older (deprecated) API version if deprecated symbols have been disabled) */
-#if (defined(H5_USE_16_API) || defined(H5_USE_18_API) || defined(H5_USE_110_API) || defined(H5_USE_112_API) || defined(H5_USE_114_API)) && defined(H5_NO_DEPRECATED_SYMBOLS)
+#if (defined(H5_USE_16_API) || defined(H5_USE_18_API) || defined(H5_USE_110_API) || defined(H5_USE_112_API) || defined(H5_USE_114_API) || defined(H5_USE_200_API)) && defined(H5_NO_DEPRECATED_SYMBOLS)
   #error "Can't choose old API versions when deprecated APIs are disabled"
-#endif /* (defined(H5_USE_16_API) || defined(H5_USE_18_API) || defined(H5_USE_110_API) || defined(H5_USE_112_API) || defined(H5_USE_114_API)) && defined(H5_NO_DEPRECATED_SYMBOLS) */
+#endif /* (defined(H5_USE_16_API) || defined(H5_USE_18_API) || defined(H5_USE_110_API) || defined(H5_USE_112_API) || defined(H5_USE_114_API) || defined(H5_USE_200_API)) && defined(H5_NO_DEPRECATED_SYMBOLS) */
 
 
 /* If a particular "global" version of the library's interfaces is chosen,
@@ -224,6 +228,10 @@
   #define H5Gopen_vers 2
 #endif /* !defined(H5Gopen_vers) */
 
+#if !defined(H5Iregister_type_vers)
+  #define H5Iregister_type_vers 1
+#endif /* !defined(H5Iregister_type_vers) */
+
 #if !defined(H5Lget_info_vers)
   #define H5Lget_info_vers 1
 #endif /* !defined(H5Lget_info_vers) */
@@ -391,6 +399,10 @@
 #if !defined(H5Gopen_vers)
   #define H5Gopen_vers 2
 #endif /* !defined(H5Gopen_vers) */
+
+#if !defined(H5Iregister_type_vers)
+  #define H5Iregister_type_vers 1
+#endif /* !defined(H5Iregister_type_vers) */
 
 #if !defined(H5Lget_info_vers)
   #define H5Lget_info_vers 1
@@ -564,6 +576,10 @@
   #define H5Gopen_vers 2
 #endif /* !defined(H5Gopen_vers) */
 
+#if !defined(H5Iregister_type_vers)
+  #define H5Iregister_type_vers 1
+#endif /* !defined(H5Iregister_type_vers) */
+
 #if !defined(H5Lget_info_vers)
   #define H5Lget_info_vers 2
 #endif /* !defined(H5Lget_info_vers) */
@@ -736,6 +752,10 @@
   #define H5Gopen_vers 2
 #endif /* !defined(H5Gopen_vers) */
 
+#if !defined(H5Iregister_type_vers)
+  #define H5Iregister_type_vers 1
+#endif /* !defined(H5Iregister_type_vers) */
+
 #if !defined(H5Lget_info_vers)
   #define H5Lget_info_vers 2
 #endif /* !defined(H5Lget_info_vers) */
@@ -849,6 +869,182 @@
 #endif /* !defined(H5Z_class_t_vers) */
 
 #endif /* H5_USE_114_API */
+
+#ifdef H5_USE_200_API
+
+/*************/
+/* Functions */
+/*************/
+
+#if !defined(H5Acreate_vers)
+  #define H5Acreate_vers 2
+#endif /* !defined(H5Acreate_vers) */
+
+#if !defined(H5Aiterate_vers)
+  #define H5Aiterate_vers 2
+#endif /* !defined(H5Aiterate_vers) */
+
+#if !defined(H5Dcreate_vers)
+  #define H5Dcreate_vers 2
+#endif /* !defined(H5Dcreate_vers) */
+
+#if !defined(H5Dopen_vers)
+  #define H5Dopen_vers 2
+#endif /* !defined(H5Dopen_vers) */
+
+#if !defined(H5Eclear_vers)
+  #define H5Eclear_vers 2
+#endif /* !defined(H5Eclear_vers) */
+
+#if !defined(H5Eget_auto_vers)
+  #define H5Eget_auto_vers 2
+#endif /* !defined(H5Eget_auto_vers) */
+
+#if !defined(H5Eprint_vers)
+  #define H5Eprint_vers 2
+#endif /* !defined(H5Eprint_vers) */
+
+#if !defined(H5Epush_vers)
+  #define H5Epush_vers 2
+#endif /* !defined(H5Epush_vers) */
+
+#if !defined(H5Eset_auto_vers)
+  #define H5Eset_auto_vers 2
+#endif /* !defined(H5Eset_auto_vers) */
+
+#if !defined(H5Ewalk_vers)
+  #define H5Ewalk_vers 2
+#endif /* !defined(H5Ewalk_vers) */
+
+#if !defined(H5Fget_info_vers)
+  #define H5Fget_info_vers 2
+#endif /* !defined(H5Fget_info_vers) */
+
+#if !defined(H5Gcreate_vers)
+  #define H5Gcreate_vers 2
+#endif /* !defined(H5Gcreate_vers) */
+
+#if !defined(H5Gopen_vers)
+  #define H5Gopen_vers 2
+#endif /* !defined(H5Gopen_vers) */
+
+#if !defined(H5Iregister_type_vers)
+  #define H5Iregister_type_vers 2
+#endif /* !defined(H5Iregister_type_vers) */
+
+#if !defined(H5Lget_info_vers)
+  #define H5Lget_info_vers 2
+#endif /* !defined(H5Lget_info_vers) */
+
+#if !defined(H5Lget_info_by_idx_vers)
+  #define H5Lget_info_by_idx_vers 2
+#endif /* !defined(H5Lget_info_by_idx_vers) */
+
+#if !defined(H5Literate_vers)
+  #define H5Literate_vers 2
+#endif /* !defined(H5Literate_vers) */
+
+#if !defined(H5Literate_by_name_vers)
+  #define H5Literate_by_name_vers 2
+#endif /* !defined(H5Literate_by_name_vers) */
+
+#if !defined(H5Lvisit_vers)
+  #define H5Lvisit_vers 2
+#endif /* !defined(H5Lvisit_vers) */
+
+#if !defined(H5Lvisit_by_name_vers)
+  #define H5Lvisit_by_name_vers 2
+#endif /* !defined(H5Lvisit_by_name_vers) */
+
+#if !defined(H5Oget_info_vers)
+  #define H5Oget_info_vers 3
+#endif /* !defined(H5Oget_info_vers) */
+
+#if !defined(H5Oget_info_by_idx_vers)
+  #define H5Oget_info_by_idx_vers 3
+#endif /* !defined(H5Oget_info_by_idx_vers) */
+
+#if !defined(H5Oget_info_by_name_vers)
+  #define H5Oget_info_by_name_vers 3
+#endif /* !defined(H5Oget_info_by_name_vers) */
+
+#if !defined(H5Ovisit_vers)
+  #define H5Ovisit_vers 3
+#endif /* !defined(H5Ovisit_vers) */
+
+#if !defined(H5Ovisit_by_name_vers)
+  #define H5Ovisit_by_name_vers 3
+#endif /* !defined(H5Ovisit_by_name_vers) */
+
+#if !defined(H5Pencode_vers)
+  #define H5Pencode_vers 2
+#endif /* !defined(H5Pencode_vers) */
+
+#if !defined(H5Pget_filter_vers)
+  #define H5Pget_filter_vers 2
+#endif /* !defined(H5Pget_filter_vers) */
+
+#if !defined(H5Pget_filter_by_id_vers)
+  #define H5Pget_filter_by_id_vers 2
+#endif /* !defined(H5Pget_filter_by_id_vers) */
+
+#if !defined(H5Pinsert_vers)
+  #define H5Pinsert_vers 2
+#endif /* !defined(H5Pinsert_vers) */
+
+#if !defined(H5Pregister_vers)
+  #define H5Pregister_vers 2
+#endif /* !defined(H5Pregister_vers) */
+
+#if !defined(H5Rdereference_vers)
+  #define H5Rdereference_vers 2
+#endif /* !defined(H5Rdereference_vers) */
+
+#if !defined(H5Rget_obj_type_vers)
+  #define H5Rget_obj_type_vers 2
+#endif /* !defined(H5Rget_obj_type_vers) */
+
+#if !defined(H5Sencode_vers)
+  #define H5Sencode_vers 2
+#endif /* !defined(H5Sencode_vers) */
+
+#if !defined(H5Tarray_create_vers)
+  #define H5Tarray_create_vers 2
+#endif /* !defined(H5Tarray_create_vers) */
+
+#if !defined(H5Tcommit_vers)
+  #define H5Tcommit_vers 2
+#endif /* !defined(H5Tcommit_vers) */
+
+#if !defined(H5Tget_array_dims_vers)
+  #define H5Tget_array_dims_vers 2
+#endif /* !defined(H5Tget_array_dims_vers) */
+
+#if !defined(H5Topen_vers)
+  #define H5Topen_vers 2
+#endif /* !defined(H5Topen_vers) */
+
+/************/
+/* Typedefs */
+/************/
+
+#if !defined(H5E_auto_t_vers)
+  #define H5E_auto_t_vers 2
+#endif /* !defined(H5E_auto_t_vers) */
+
+#if !defined(H5O_info_t_vers)
+  #define H5O_info_t_vers 2
+#endif /* !defined(H5O_info_t_vers) */
+
+#if !defined(H5O_iterate_t_vers)
+  #define H5O_iterate_t_vers 2
+#endif /* !defined(H5O_iterate_t_vers) */
+
+#if !defined(H5Z_class_t_vers)
+  #define H5Z_class_t_vers 2
+#endif /* !defined(H5Z_class_t_vers) */
+
+#endif /* H5_USE_200_API */
 
 
 /* Choose the correct version of each API symbol, defaulting to the latest
@@ -1011,6 +1207,17 @@
 #else /* H5Gopen_vers */
   #error "H5Gopen_vers set to invalid value"
 #endif /* H5Gopen_vers */
+
+#if !defined(H5Iregister_type_vers) || H5Iregister_type_vers == 2
+  #ifndef H5Iregister_type_vers
+    #define H5Iregister_type_vers 2
+  #endif /* H5Iregister_type_vers */
+  #define H5Iregister_type H5Iregister_type2
+#elif H5Iregister_type_vers == 1
+  #define H5Iregister_type H5Iregister_type1
+#else /* H5Iregister_type_vers */
+  #error "H5Iregister_type_vers set to invalid value"
+#endif /* H5Iregister_type_vers */
 
 #if !defined(H5Lget_info_vers) || H5Lget_info_vers == 2
   #ifndef H5Lget_info_vers

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -67,7 +67,7 @@ libhdf5_la_SOURCES= H5.c H5build_settings.c H5checksum.c H5dbg.c H5system.c \
         H5HFspace.c H5HFstat.c H5HFtest.c H5HFtiny.c \
         H5HG.c H5HGcache.c H5HGdbg.c H5HGquery.c \
         H5HL.c H5HLcache.c H5HLdbg.c H5HLint.c H5HLprfx.c H5HLdblk.c \
-        H5I.c H5Idbg.c H5Iint.c H5Itest.c \
+        H5I.c H5Idbg.c H5Ideprec.c H5Iint.c H5Itest.c \
         H5L.c H5Ldeprec.c H5Lexternal.c H5Lint.c \
         H5M.c \
         H5MF.c H5MFaggr.c H5MFdbg.c H5MFsection.c \

--- a/test/tid.c
+++ b/test/tid.c
@@ -79,7 +79,7 @@ basic_id_test(void)
         goto out;
 
     /* Register a type */
-    myType = H5Iregister_type((size_t)64, 0, free_wrapper);
+    myType = H5Iregister_type(0, free_wrapper);
 
     CHECK(myType, H5I_BADID, "H5Iregister_type");
     if (myType == H5I_BADID)
@@ -173,7 +173,7 @@ basic_id_test(void)
     H5E_END_TRY
 
     /* Register another type and another object in that type */
-    myType = H5Iregister_type((size_t)64, 0, free_wrapper);
+    myType = H5Iregister_type(0, free_wrapper);
 
     CHECK(myType, H5I_BADID, "H5Iregister_type");
     if (myType == H5I_BADID)
@@ -245,6 +245,225 @@ out:
 
     return -1;
 }
+
+#ifndef H5_NO_DEPRECATED_SYMBOLS
+/* Test that H5Iregister_type1() works correctly (just a copy of the basic test) */
+static int
+H5Iregister_type1_test(void)
+{
+    H5I_type_t myType  = H5I_BADID;
+    hid_t      arrayID = H5I_INVALID_HID;
+    void      *testObj = NULL;
+    void      *testPtr = NULL;
+    char       nameString[10];
+    hid_t      testID;
+    ssize_t    testSize = -1;
+    herr_t     err;
+    int        num_ref;
+    hsize_t    num_members;
+
+    /* Try to register an ID with fictitious types */
+    H5E_BEGIN_TRY
+    arrayID = H5Iregister((H5I_type_t)420, testObj);
+    H5E_END_TRY
+
+    VERIFY(arrayID, H5I_INVALID_HID, "H5Iregister");
+    if (arrayID != H5I_INVALID_HID)
+        goto out;
+
+    H5E_BEGIN_TRY
+    arrayID = H5Iregister((H5I_type_t)-1, testObj);
+    H5E_END_TRY
+
+    VERIFY(arrayID, H5I_INVALID_HID, "H5Iregister");
+    if (arrayID != H5I_INVALID_HID)
+        goto out;
+
+    /* Try to access IDs with fictitious types */
+    H5E_BEGIN_TRY
+    testPtr = H5Iobject_verify((hid_t)100, (H5I_type_t)0);
+    H5E_END_TRY
+
+    CHECK_PTR_NULL(testPtr, "H5Iobject_verify");
+    if (testPtr != NULL)
+        goto out;
+
+    H5E_BEGIN_TRY
+    testPtr = H5Iobject_verify((hid_t)700, (H5I_type_t)700);
+    H5E_END_TRY
+
+    CHECK_PTR_NULL(testPtr, "H5Iobject_verify");
+    if (testPtr != NULL)
+        goto out;
+
+    /* Register a type */
+    myType = H5Iregister_type1(64, 0, free_wrapper);
+
+    CHECK(myType, H5I_BADID, "H5Iregister_type1");
+    if (myType == H5I_BADID)
+        goto out;
+
+    /* Register an ID and retrieve the object it points to.
+     * Once the ID has been registered, testObj will be freed when
+     * its ID type is destroyed.
+     */
+    testObj = malloc(7 * sizeof(int));
+    arrayID = H5Iregister(myType, testObj);
+
+    CHECK(arrayID, H5I_INVALID_HID, "H5Iregister");
+    if (arrayID == H5I_INVALID_HID) {
+        free(testObj);
+        goto out;
+    }
+
+    testPtr = (int *)H5Iobject_verify(arrayID, myType);
+
+    CHECK_PTR_EQ(testPtr, testObj, "H5Iobject_verify");
+    if (testPtr != testObj)
+        goto out;
+
+    /* Ensure that H5Iget_file_id and H5Iget_name() fail, since this
+     * is an hid_t for the wrong kind of object
+     */
+    H5E_BEGIN_TRY
+    testID = H5Iget_file_id(arrayID);
+    H5E_END_TRY
+
+    VERIFY(testID, H5I_INVALID_HID, "H5Iget_file_id");
+    if (testID != H5I_INVALID_HID)
+        goto out;
+
+    H5E_BEGIN_TRY
+    testSize = H5Iget_name(arrayID, nameString, (size_t)9);
+    H5E_END_TRY
+
+    VERIFY(testSize, -1, "H5Iget_name");
+    if (testSize != -1)
+        goto out;
+
+    /* Make sure H5Iremove_verify catches objects of the wrong type */
+    H5E_BEGIN_TRY
+    testPtr = (int *)H5Iremove_verify(arrayID, (H5I_type_t)0);
+    H5E_END_TRY
+
+    CHECK_PTR_NULL(testPtr, "H5Iremove_verify");
+    if (testPtr != NULL)
+        goto out;
+
+    H5E_BEGIN_TRY
+    testPtr = (int *)H5Iremove_verify(arrayID, (H5I_type_t)((int)myType - 1));
+    H5E_END_TRY
+
+    CHECK_PTR_NULL(testPtr, "H5Iremove_verify");
+    if (testPtr != NULL)
+        goto out;
+
+    /* Remove an ID and make sure we can't access it */
+    testPtr = (int *)H5Iremove_verify(arrayID, myType);
+
+    CHECK_PTR(testPtr, "H5Iremove_verify");
+    if (testPtr == NULL)
+        goto out;
+
+    H5E_BEGIN_TRY
+    testPtr = (int *)H5Iobject_verify(arrayID, myType);
+    H5E_END_TRY
+
+    CHECK_PTR_NULL(testPtr, "H5Iobject_verify");
+    if (testPtr != NULL)
+        goto out;
+
+    /* Delete the type and make sure we can't access objects within it */
+    arrayID = H5Iregister(myType, testObj);
+
+    err = H5Idestroy_type(myType);
+    VERIFY(err, 0, "H5Idestroy_type");
+    if (err != 0)
+        goto out;
+    VERIFY(H5Itype_exists(myType), 0, "H5Itype_exists");
+    if (H5Itype_exists(myType) != 0)
+        goto out;
+
+    H5E_BEGIN_TRY
+    VERIFY(H5Inmembers(myType, NULL), -1, "H5Inmembers");
+    if (H5Inmembers(myType, NULL) != -1)
+        goto out;
+    H5E_END_TRY
+
+    /* Register another type and another object in that type */
+    myType = H5Iregister_type1(64, 0, free_wrapper);
+
+    CHECK(myType, H5I_BADID, "H5Iregister_type1");
+    if (myType == H5I_BADID)
+        goto out;
+
+    /* The memory that testObj pointed to should already have been
+     * freed when the previous type was destroyed.  Allocate new
+     * memory for it.
+     */
+    testObj = malloc(7 * sizeof(int));
+    arrayID = H5Iregister(myType, testObj);
+
+    CHECK(arrayID, H5I_INVALID_HID, "H5Iregister");
+    if (arrayID == H5I_INVALID_HID) {
+        free(testObj);
+        goto out;
+    }
+
+    err = H5Inmembers(myType, &num_members);
+    CHECK(err, -1, "H5Inmembers");
+    if (err < 0)
+        goto out;
+    VERIFY(num_members, 1, "H5Inmembers");
+    if (num_members != 1)
+        goto out;
+
+    /* Increment references to type and ensure that dec_type_ref
+     * doesn't destroy the type
+     */
+    num_ref = H5Iinc_type_ref(myType);
+    VERIFY(num_ref, 2, "H5Iinc_type_ref");
+    if (num_ref != 2)
+        goto out;
+    num_ref = H5Idec_type_ref(myType);
+    VERIFY(num_ref, 1, "H5Idec_type_ref");
+    if (num_ref != 1)
+        goto out;
+    err = H5Inmembers(myType, &num_members);
+    CHECK(err, -1, "H5Inmembers");
+    if (err < 0)
+        goto out;
+    VERIFY(num_members, 1, "H5Inmembers");
+    if (num_members != 1)
+        goto out;
+
+    /* This call to dec_type_ref should destroy the type */
+    num_ref = H5Idec_type_ref(myType);
+    VERIFY(num_ref, 0, "H5Idec_type_ref");
+    if (num_ref != 0)
+        goto out;
+    VERIFY(H5Itype_exists(myType), 0, "H5Itype_exists");
+    if (H5Itype_exists(myType) != 0)
+        goto out;
+
+    H5E_BEGIN_TRY
+    err = H5Inmembers(myType, &num_members);
+    if (err >= 0)
+        goto out;
+    H5E_END_TRY
+
+    return 0;
+
+out:
+    /* Clean up type if it has been allocated and free memory used
+     * by testObj
+     */
+    if (myType >= 0)
+        H5Idestroy_type(myType);
+
+    return -1;
+}
+#endif /* H5_NO_DEPRECATED_SYMBOLS */
 
 /* A dummy search function for the next test */
 static int
@@ -508,7 +727,7 @@ test_id_type_list(void)
     H5I_type_t testType;
     int        i; /* Just a counter variable */
 
-    startType = H5Iregister_type((size_t)8, 0, free_wrapper);
+    startType = H5Iregister_type(0, free_wrapper);
     CHECK(startType, H5I_BADID, "H5Iregister_type");
     if (startType == H5I_BADID)
         goto out;
@@ -521,7 +740,7 @@ test_id_type_list(void)
     }
     /* Create types up to H5I_MAX_NUM_TYPES */
     for (i = startType + 1; i < H5I_MAX_NUM_TYPES; i++) {
-        currentType = H5Iregister_type((size_t)8, 0, free_wrapper);
+        currentType = H5Iregister_type(0, free_wrapper);
         CHECK(currentType, H5I_BADID, "H5Iregister_type");
         if (currentType == H5I_BADID)
             goto out;
@@ -529,7 +748,7 @@ test_id_type_list(void)
 
     /* Wrap around to low type ID numbers */
     for (i = H5I_NTYPES; i < startType; i++) {
-        currentType = H5Iregister_type((size_t)8, 0, free_wrapper);
+        currentType = H5Iregister_type(0, free_wrapper);
         CHECK(currentType, H5I_BADID, "H5Iregister_type");
         if (currentType == H5I_BADID)
             goto out;
@@ -537,7 +756,7 @@ test_id_type_list(void)
 
     /* There should be no room at the inn for a new ID type*/
     H5E_BEGIN_TRY
-    testType = H5Iregister_type((size_t)8, 0, free_wrapper);
+    testType = H5Iregister_type(0, free_wrapper);
     H5E_END_TRY
 
     VERIFY(testType, H5I_BADID, "H5Iregister_type");
@@ -546,7 +765,7 @@ test_id_type_list(void)
 
     /* Now delete a type and try to insert again */
     H5Idestroy_type(H5I_NTYPES);
-    testType = H5Iregister_type((size_t)8, 0, free_wrapper);
+    testType = H5Iregister_type(0, free_wrapper);
 
     VERIFY(testType, H5I_NTYPES, "H5Iregister_type");
     if (testType != H5I_NTYPES)
@@ -700,7 +919,7 @@ test_remove_clear_type(void)
     herr_t         ret; /* return value */
 
     /* Register a user-defined type with our custom ID-deleting callback */
-    obj_type = H5Iregister_type((size_t)8, 0, rct_free_cb);
+    obj_type = H5Iregister_type(0, rct_free_cb);
     CHECK(obj_type, H5I_BADID, "H5Iregister_type");
     if (obj_type == H5I_BADID)
         goto error;
@@ -994,7 +1213,7 @@ test_future_ids(void)
     herr_t        ret;             /* Return value */
 
     /* Register a user-defined type with our custom ID-deleting callback */
-    obj_type = H5Iregister_type((size_t)15, 0, free_actual_object);
+    obj_type = H5Iregister_type(0, free_actual_object);
     CHECK(obj_type, H5I_BADID, "H5Iregister_type");
     if (H5I_BADID == obj_type)
         goto error;
@@ -1054,7 +1273,7 @@ test_future_ids(void)
         goto error;
 
     /* Re-register a user-defined type with our custom ID-deleting callback */
-    obj_type = H5Iregister_type((size_t)15, 0, free_actual_object);
+    obj_type = H5Iregister_type(0, free_actual_object);
     CHECK(obj_type, H5I_BADID, "H5Iregister_type");
     if (H5I_BADID == obj_type)
         goto error;
@@ -1094,7 +1313,7 @@ test_future_ids(void)
         goto error;
 
     /* Re-register a user-defined type with our custom ID-deleting callback */
-    obj_type = H5Iregister_type((size_t)15, 0, free_actual_object);
+    obj_type = H5Iregister_type(0, free_actual_object);
     CHECK(obj_type, H5I_BADID, "H5Iregister_type");
     if (H5I_BADID == obj_type)
         goto error;
@@ -1502,6 +1721,10 @@ test_ids(const void H5_ATTR_UNUSED *params)
 
     if (basic_id_test() < 0)
         TestErrPrintf("Basic ID test failed\n");
+#ifndef H5_NO_DEPRECATED_SYMBOLS
+    if (H5Iregister_type1_test() < 0)
+        TestErrPrintf("H5Iregister_type1() test failed\n");
+#endif /* H5_NO_DEPRECATED_SYMBOLS */
     if (id_predefined_test() < 0)
         TestErrPrintf("Predefined ID type test failed\n");
     if (test_is_valid() < 0)

--- a/test/tid.c
+++ b/test/tid.c
@@ -79,9 +79,9 @@ basic_id_test(void)
         goto out;
 
     /* Register a type */
-    myType = H5Iregister_type(0, free_wrapper);
+    myType = H5Iregister_type2(0, free_wrapper);
 
-    CHECK(myType, H5I_BADID, "H5Iregister_type");
+    CHECK(myType, H5I_BADID, "H5Iregister_type2");
     if (myType == H5I_BADID)
         goto out;
 
@@ -173,9 +173,9 @@ basic_id_test(void)
     H5E_END_TRY
 
     /* Register another type and another object in that type */
-    myType = H5Iregister_type(0, free_wrapper);
+    myType = H5Iregister_type2(0, free_wrapper);
 
-    CHECK(myType, H5I_BADID, "H5Iregister_type");
+    CHECK(myType, H5I_BADID, "H5Iregister_type2");
     if (myType == H5I_BADID)
         goto out;
 
@@ -727,47 +727,47 @@ test_id_type_list(void)
     H5I_type_t testType;
     int        i; /* Just a counter variable */
 
-    startType = H5Iregister_type(0, free_wrapper);
-    CHECK(startType, H5I_BADID, "H5Iregister_type");
+    startType = H5Iregister_type2(0, free_wrapper);
+    CHECK(startType, H5I_BADID, "H5Iregister_type2");
     if (startType == H5I_BADID)
         goto out;
 
     /* Sanity check */
     if ((int)startType >= H5I_MAX_NUM_TYPES || startType < H5I_NTYPES) {
         /* Error condition, throw an error */
-        ERROR("H5Iregister_type");
+        ERROR("H5Iregister_type2");
         goto out;
     }
     /* Create types up to H5I_MAX_NUM_TYPES */
     for (i = startType + 1; i < H5I_MAX_NUM_TYPES; i++) {
-        currentType = H5Iregister_type(0, free_wrapper);
-        CHECK(currentType, H5I_BADID, "H5Iregister_type");
+        currentType = H5Iregister_type2(0, free_wrapper);
+        CHECK(currentType, H5I_BADID, "H5Iregister_type2");
         if (currentType == H5I_BADID)
             goto out;
     }
 
     /* Wrap around to low type ID numbers */
     for (i = H5I_NTYPES; i < startType; i++) {
-        currentType = H5Iregister_type(0, free_wrapper);
-        CHECK(currentType, H5I_BADID, "H5Iregister_type");
+        currentType = H5Iregister_type2(0, free_wrapper);
+        CHECK(currentType, H5I_BADID, "H5Iregister_type2");
         if (currentType == H5I_BADID)
             goto out;
     }
 
     /* There should be no room at the inn for a new ID type*/
     H5E_BEGIN_TRY
-    testType = H5Iregister_type(0, free_wrapper);
+    testType = H5Iregister_type2(0, free_wrapper);
     H5E_END_TRY
 
-    VERIFY(testType, H5I_BADID, "H5Iregister_type");
+    VERIFY(testType, H5I_BADID, "H5Iregister_type2");
     if (testType != H5I_BADID)
         goto out;
 
     /* Now delete a type and try to insert again */
     H5Idestroy_type(H5I_NTYPES);
-    testType = H5Iregister_type(0, free_wrapper);
+    testType = H5Iregister_type2(0, free_wrapper);
 
-    VERIFY(testType, H5I_NTYPES, "H5Iregister_type");
+    VERIFY(testType, H5I_NTYPES, "H5Iregister_type2");
     if (testType != H5I_NTYPES)
         goto out;
 
@@ -919,8 +919,8 @@ test_remove_clear_type(void)
     herr_t         ret; /* return value */
 
     /* Register a user-defined type with our custom ID-deleting callback */
-    obj_type = H5Iregister_type(0, rct_free_cb);
-    CHECK(obj_type, H5I_BADID, "H5Iregister_type");
+    obj_type = H5Iregister_type2(0, rct_free_cb);
+    CHECK(obj_type, H5I_BADID, "H5Iregister_type2");
     if (obj_type == H5I_BADID)
         goto error;
 
@@ -1213,8 +1213,8 @@ test_future_ids(void)
     herr_t        ret;             /* Return value */
 
     /* Register a user-defined type with our custom ID-deleting callback */
-    obj_type = H5Iregister_type(0, free_actual_object);
-    CHECK(obj_type, H5I_BADID, "H5Iregister_type");
+    obj_type = H5Iregister_type2(0, free_actual_object);
+    CHECK(obj_type, H5I_BADID, "H5Iregister_type2");
     if (H5I_BADID == obj_type)
         goto error;
 
@@ -1273,8 +1273,8 @@ test_future_ids(void)
         goto error;
 
     /* Re-register a user-defined type with our custom ID-deleting callback */
-    obj_type = H5Iregister_type(0, free_actual_object);
-    CHECK(obj_type, H5I_BADID, "H5Iregister_type");
+    obj_type = H5Iregister_type2(0, free_actual_object);
+    CHECK(obj_type, H5I_BADID, "H5Iregister_type2");
     if (H5I_BADID == obj_type)
         goto error;
 
@@ -1313,8 +1313,8 @@ test_future_ids(void)
         goto error;
 
     /* Re-register a user-defined type with our custom ID-deleting callback */
-    obj_type = H5Iregister_type(0, free_actual_object);
-    CHECK(obj_type, H5I_BADID, "H5Iregister_type");
+    obj_type = H5Iregister_type2(0, free_actual_object);
+    CHECK(obj_type, H5I_BADID, "H5Iregister_type2");
     if (H5I_BADID == obj_type)
         goto error;
 


### PR DESCRIPTION
The hash_size parameter of H5Iregister_type() hasn't been used since 1.8.
It's been removed and the API call has been versioned.

This PR also updates the make_vers script to handle v2.0.0.

Fixes #4344