### PR TITLE
Add release information to enum constants - Part 2

### DIFF
--- a/src/H5ACpublic.h
+++ b/src/H5ACpublic.h
@@ -730,7 +730,7 @@ typedef struct H5AC_cache_config_t {
  * cache images
  * \since 1.10.1
  */
-#define H5AC__CACHE_IMAGE__ENTRY_AGEOUT__MAX  100
+#define H5AC__CACHE_IMAGE__ENTRY_AGEOUT__MAX 100
 
 //! <!-- [H5AC_cache_image_config_t_snip] -->
 /**

--- a/src/H5ACpublic.h
+++ b/src/H5ACpublic.h
@@ -719,7 +719,17 @@ typedef struct H5AC_cache_config_t {
 
 #define H5AC__CURR_CACHE_IMAGE_CONFIG_VERSION 1
 
+/**
+ * No limit on number of times a prefetched entry can appear in subsequent
+ * cache images
+ * \since 1.10.1
+ */
 #define H5AC__CACHE_IMAGE__ENTRY_AGEOUT__NONE -1
+/**
+ * Limit on number of times a prefetched entry can appear in subsequent
+ * cache images
+ * \since 1.10.1
+ */
 #define H5AC__CACHE_IMAGE__ENTRY_AGEOUT__MAX  100
 
 //! <!-- [H5AC_cache_image_config_t_snip] -->

--- a/src/H5Dpublic.h
+++ b/src/H5Dpublic.h
@@ -28,9 +28,7 @@
 #define H5D_CHUNK_CACHE_NBYTES_DEFAULT SIZE_MAX
 #define H5D_CHUNK_CACHE_W0_DEFAULT     (-1.0)
 
-/**
- * Bit flags for the H5Pset_chunk_opts() and H5Pget_chunk_opts()
- */
+/** Bit flags for the H5Pset/get_chunk_opts() \since 1.10.0 */
 #define H5D_CHUNK_DONT_FILTER_PARTIAL_CHUNKS (0x0002u)
 
 /*******************/
@@ -1697,7 +1695,7 @@ H5_DLL herr_t H5Dget_chunk_index_type(hid_t did, H5D_chunk_index_t *idx_type);
  */
 #ifndef H5_NO_DEPRECATED_SYMBOLS
 
-/* Macros */
+/** v1 B-tree index \since 1.10.0 */
 #define H5D_CHUNK_BTREE H5D_CHUNK_IDX_BTREE
 
 /* Formerly used to support the H5DOread/write_chunk() API calls.

--- a/src/H5FDdevelop.h
+++ b/src/H5FDdevelop.h
@@ -92,41 +92,49 @@
 /**
  * Extensible array header block; it is mapped to 'ohdr' type file memory to
  * benefit from their similarity.
+ * \since 1.10.0
  */
 #define H5FD_MEM_EARRAY_HDR H5FD_MEM_OHDR
 /**
  * Extensible array index block; it is mapped to 'ohdr' type file memory because
  * these index blocks are similar to extensible array header blocks.
+ * \since 1.10.0
  */
 #define H5FD_MEM_EARRAY_IBLOCK H5FD_MEM_OHDR
 /**
  * Extensible array super block; it is mappend to 'btree' type file memory
  * because the indices are similar enough to B-tree nodes.
+ * \since 1.10.0
  */
 #define H5FD_MEM_EARRAY_SBLOCK H5FD_MEM_BTREE
 /**
  * Extensible array data block; it is mapped to 'lheap' type file memory
  * because it is similar enough to local heap info.
+ * \since 1.10.0
  */
 #define H5FD_MEM_EARRAY_DBLOCK H5FD_MEM_LHEAP
 /**
  * Extensible array data block & page; it is mapped to 'lheap' type file memory
  * because it is similar enough to local heap info.
+ * \since 1.10.0
  */
 #define H5FD_MEM_EARRAY_DBLK_PAGE H5FD_MEM_LHEAP
 /**
  * Fixed array header block; it is mapped to 'ohdr' type file memory to
  * benefit their similarity.
+ * \since 1.10.0
  */
 #define H5FD_MEM_FARRAY_HDR H5FD_MEM_OHDR
 /**
  * Fixed array data block; it is mapped to 'lheap' type file memory
  * because it is similar enough to local heap info.
+ * \since 1.10.0
  */
 #define H5FD_MEM_FARRAY_DBLOCK H5FD_MEM_LHEAP
 /**
  * Fixed array data block & page; it is mapped to 'lheap' type file memory
  * because it is similar enough to local heap info.
+ * \since 1.10.0
  */
 #define H5FD_MEM_FARRAY_DBLK_PAGE H5FD_MEM_LHEAP
 

--- a/src/H5FDhdfs.h
+++ b/src/H5FDhdfs.h
@@ -47,11 +47,11 @@
  */
 #define H5FD__CURR_HDFS_FAPL_T_VERSION 1
 
-/** Max size of the node name \since 1.8.22 */
+/** Max size of the node name \since 1.8.22 1.10.6 */
 #define H5FD__HDFS_NODE_NAME_SPACE 128
-/** Max size of the user name \since 1.8.22 */
+/** Max size of the user name \since 1.8.22 1.10.6 */
 #define H5FD__HDFS_USER_NAME_SPACE 128
-/** Max size of the kerberos cache path \since 1.8.22 */
+/** Max size of the kerberos cache path \since 1.8.22 1.10.6 */
 #define H5FD__HDFS_KERB_CACHE_PATH_SPACE 128
 
 /**

--- a/src/H5FDlog.h
+++ b/src/H5FDlog.h
@@ -31,47 +31,47 @@
 /** Flag for tracking truncate operation \since 1.10.1 */
 #define H5FD_LOG_TRUNCATE 0x00000001
 /** Flag for tracking meta IO operations \since 1.10.1 */
-#define H5FD_LOG_META_IO  (H5FD_LOG_TRUNCATE)
+#define H5FD_LOG_META_IO (H5FD_LOG_TRUNCATE)
 /** Flag for tracking where reads occur \since 1.6.0 */
-#define H5FD_LOG_LOC_READ  0x00000002
+#define H5FD_LOG_LOC_READ 0x00000002
 /** Flag for tracking where writes occur \since 1.6.0 */
 #define H5FD_LOG_LOC_WRITE 0x00000004
 /** Flag for tracking where seeks occur \since 1.6.0 */
-#define H5FD_LOG_LOC_SEEK  0x00000008
+#define H5FD_LOG_LOC_SEEK 0x00000008
 /** Flag for tracking where IO operations occur \since 1.6.0 */
-#define H5FD_LOG_LOC_IO    (H5FD_LOG_LOC_READ | H5FD_LOG_LOC_WRITE | H5FD_LOG_LOC_SEEK)
+#define H5FD_LOG_LOC_IO (H5FD_LOG_LOC_READ | H5FD_LOG_LOC_WRITE | H5FD_LOG_LOC_SEEK)
 /** Flag for tracking number of times each byte is read \since 1.6.0 */
-#define H5FD_LOG_FILE_READ  0x00000010
+#define H5FD_LOG_FILE_READ 0x00000010
 /** Flag for tracking number of times each byte is written \since 1.6.0 */
 #define H5FD_LOG_FILE_WRITE 0x00000020
 /** Flag for tracking number of times each byte is read/written \since 1.6.0 */
-#define H5FD_LOG_FILE_IO    (H5FD_LOG_FILE_READ | H5FD_LOG_FILE_WRITE)
+#define H5FD_LOG_FILE_IO (H5FD_LOG_FILE_READ | H5FD_LOG_FILE_WRITE)
 /** Flag for tracking "flavor" (type) of information stored at each byte \since 1.6.0 */
 #define H5FD_LOG_FLAVOR 0x00000040
 /** Flag for tracking total number of reads \since 1.6.0 */
-#define H5FD_LOG_NUM_READ     0x00000080
+#define H5FD_LOG_NUM_READ 0x00000080
 /** Flag for tracking total number of writes \since 1.6.0 */
-#define H5FD_LOG_NUM_WRITE    0x00000100
+#define H5FD_LOG_NUM_WRITE 0x00000100
 /** Flag for tracking total number of seeks \since 1.6.0 */
-#define H5FD_LOG_NUM_SEEK     0x00000200
+#define H5FD_LOG_NUM_SEEK 0x00000200
 /** Flag for tracking total number of truncates \since 1.8.7 */
 #define H5FD_LOG_NUM_TRUNCATE 0x00000400
 /** Flag for tracking total number of IO operations \since 1.6.0 */
-#define H5FD_LOG_NUM_IO       (H5FD_LOG_NUM_READ | H5FD_LOG_NUM_WRITE | H5FD_LOG_NUM_SEEK | H5FD_LOG_NUM_TRUNCATE)
+#define H5FD_LOG_NUM_IO (H5FD_LOG_NUM_READ | H5FD_LOG_NUM_WRITE | H5FD_LOG_NUM_SEEK | H5FD_LOG_NUM_TRUNCATE)
 /** Flag for tracking time spent in open \since 1.8.7 */
-#define H5FD_LOG_TIME_OPEN     0x00000800
+#define H5FD_LOG_TIME_OPEN 0x00000800
 /** Flag for tracking time spent in stat \since 1.8.7 */
-#define H5FD_LOG_TIME_STAT     0x00001000
+#define H5FD_LOG_TIME_STAT 0x00001000
 /** Flag for tracking time spent in read \since 1.8.7 */
-#define H5FD_LOG_TIME_READ     0x00002000
+#define H5FD_LOG_TIME_READ 0x00002000
 /** Flag for tracking time spent in write \since 1.6.0 */
-#define H5FD_LOG_TIME_WRITE    0x00004000
+#define H5FD_LOG_TIME_WRITE 0x00004000
 /** Flag for tracking time spent in seek \since 1.6.0 */
-#define H5FD_LOG_TIME_SEEK     0x00008000
+#define H5FD_LOG_TIME_SEEK 0x00008000
 /** Flag for tracking time spent in truncate \since 1.10.1 */
 #define H5FD_LOG_TIME_TRUNCATE 0x00010000
 /** Flag for tracking time spent in close \since 1.6.0 */
-#define H5FD_LOG_TIME_CLOSE    0x00020000
+#define H5FD_LOG_TIME_CLOSE 0x00020000
 /** Flag for tracking time spent in IO operations \since 1.6.0 */
 #define H5FD_LOG_TIME_IO                                                                                     \
     (H5FD_LOG_TIME_OPEN | H5FD_LOG_TIME_STAT | H5FD_LOG_TIME_READ | H5FD_LOG_TIME_WRITE |                    \
@@ -79,7 +79,7 @@
 /** Flag for tracking allocation of space in file \since 1.6.0 */
 #define H5FD_LOG_ALLOC 0x00040000
 /** Flag for tracking release of space in file \since 1.10.1 */
-#define H5FD_LOG_FREE  0x00080000
+#define H5FD_LOG_FREE 0x00080000
 /** Flag for tracking all info \since 1.6.0 */
 #define H5FD_LOG_ALL                                                                                         \
     (H5FD_LOG_FREE | H5FD_LOG_ALLOC | H5FD_LOG_TIME_IO | H5FD_LOG_NUM_IO | H5FD_LOG_FLAVOR |                 \

--- a/src/H5FDlog.h
+++ b/src/H5FDlog.h
@@ -27,40 +27,60 @@
 #define H5FD_LOG_VALUE H5_VFD_LOG
 
 /* Flags for H5Pset_fapl_log() */
-/* Flags for tracking 'meta' operations (truncate) */
+
+/** Flag for tracking truncate operation \since 1.10.1 */
 #define H5FD_LOG_TRUNCATE 0x00000001
+/** Flag for tracking meta IO operations \since 1.10.1 */
 #define H5FD_LOG_META_IO  (H5FD_LOG_TRUNCATE)
-/* Flags for tracking where reads/writes/seeks occur */
+/** Flag for tracking where reads occur \since 1.6.0 */
 #define H5FD_LOG_LOC_READ  0x00000002
+/** Flag for tracking where writes occur \since 1.6.0 */
 #define H5FD_LOG_LOC_WRITE 0x00000004
+/** Flag for tracking where seeks occur \since 1.6.0 */
 #define H5FD_LOG_LOC_SEEK  0x00000008
+/** Flag for tracking where IO operations occur \since 1.6.0 */
 #define H5FD_LOG_LOC_IO    (H5FD_LOG_LOC_READ | H5FD_LOG_LOC_WRITE | H5FD_LOG_LOC_SEEK)
-/* Flags for tracking number of times each byte is read/written */
+/** Flag for tracking number of times each byte is read \since 1.6.0 */
 #define H5FD_LOG_FILE_READ  0x00000010
+/** Flag for tracking number of times each byte is written \since 1.6.0 */
 #define H5FD_LOG_FILE_WRITE 0x00000020
+/** Flag for tracking number of times each byte is read/written \since 1.6.0 */
 #define H5FD_LOG_FILE_IO    (H5FD_LOG_FILE_READ | H5FD_LOG_FILE_WRITE)
-/* Flag for tracking "flavor" (type) of information stored at each byte */
+/** Flag for tracking "flavor" (type) of information stored at each byte \since 1.6.0 */
 #define H5FD_LOG_FLAVOR 0x00000040
-/* Flags for tracking total number of reads/writes/seeks/truncates */
+/** Flag for tracking total number of reads \since 1.6.0 */
 #define H5FD_LOG_NUM_READ     0x00000080
+/** Flag for tracking total number of writes \since 1.6.0 */
 #define H5FD_LOG_NUM_WRITE    0x00000100
+/** Flag for tracking total number of seeks \since 1.6.0 */
 #define H5FD_LOG_NUM_SEEK     0x00000200
+/** Flag for tracking total number of truncates \since 1.8.7 */
 #define H5FD_LOG_NUM_TRUNCATE 0x00000400
+/** Flag for tracking total number of IO operations \since 1.6.0 */
 #define H5FD_LOG_NUM_IO       (H5FD_LOG_NUM_READ | H5FD_LOG_NUM_WRITE | H5FD_LOG_NUM_SEEK | H5FD_LOG_NUM_TRUNCATE)
-/* Flags for tracking time spent in open/stat/read/write/seek/truncate/close */
+/** Flag for tracking time spent in open \since 1.8.7 */
 #define H5FD_LOG_TIME_OPEN     0x00000800
+/** Flag for tracking time spent in stat \since 1.8.7 */
 #define H5FD_LOG_TIME_STAT     0x00001000
+/** Flag for tracking time spent in read \since 1.8.7 */
 #define H5FD_LOG_TIME_READ     0x00002000
+/** Flag for tracking time spent in write \since 1.6.0 */
 #define H5FD_LOG_TIME_WRITE    0x00004000
+/** Flag for tracking time spent in seek \since 1.6.0 */
 #define H5FD_LOG_TIME_SEEK     0x00008000
+/** Flag for tracking time spent in truncate \since 1.10.1 */
 #define H5FD_LOG_TIME_TRUNCATE 0x00010000
+/** Flag for tracking time spent in close \since 1.6.0 */
 #define H5FD_LOG_TIME_CLOSE    0x00020000
+/** Flag for tracking time spent in IO operations \since 1.6.0 */
 #define H5FD_LOG_TIME_IO                                                                                     \
     (H5FD_LOG_TIME_OPEN | H5FD_LOG_TIME_STAT | H5FD_LOG_TIME_READ | H5FD_LOG_TIME_WRITE |                    \
      H5FD_LOG_TIME_SEEK | H5FD_LOG_TIME_TRUNCATE | H5FD_LOG_TIME_CLOSE)
-/* Flags for tracking allocation/release of space in file */
+/** Flag for tracking allocation of space in file \since 1.6.0 */
 #define H5FD_LOG_ALLOC 0x00040000
+/** Flag for tracking release of space in file \since 1.10.1 */
 #define H5FD_LOG_FREE  0x00080000
+/** Flag for tracking all info \since 1.6.0 */
 #define H5FD_LOG_ALL                                                                                         \
     (H5FD_LOG_FREE | H5FD_LOG_ALLOC | H5FD_LOG_TIME_IO | H5FD_LOG_NUM_IO | H5FD_LOG_FLAVOR |                 \
      H5FD_LOG_FILE_IO | H5FD_LOG_LOC_IO | H5FD_LOG_META_IO)

--- a/src/H5FDmirror.h
+++ b/src/H5FDmirror.h
@@ -22,7 +22,7 @@
 
 #ifdef H5_HAVE_MIRROR_VFD
 
-/** ID for the mirror VFD */
+/** ID for the mirror VFD \since 1.10.7 */
 #define H5FD_MIRROR (H5OPEN H5FD_MIRROR_id_g)
 
 /** Identifier for the mirror VFD */

--- a/src/H5FDpublic.h
+++ b/src/H5FDpublic.h
@@ -94,11 +94,13 @@
  * from the file when it is flushed/closed, if the file is opened R/W).
  */
 #define H5FD_FEAT_IGNORE_DRVRINFO 0x00000020
-/*
+/**
  * Defining the H5FD_FEAT_DIRTY_DRVRINFO_LOAD for a VFL driver means that
  * the library will mark the driver info dirty when the file is opened
  * R/W.  This will cause the driver info to be re-encoded when the file
  * is flushed/closed.
+ *
+ * \since 1.10.0
  */
 #define H5FD_FEAT_DIRTY_DRVRINFO_LOAD 0x00000040
 /*
@@ -108,13 +110,14 @@
  */
 #define H5FD_FEAT_POSIX_COMPAT_HANDLE 0x00000080
 
-#define H5FD_FEAT_HAS_MPI 0x00000100
-/**< Defining H5FD_FEAT_HAS_MPI for a VFL driver means that
- *   the driver makes use of MPI communication and code may retrieve
- *   communicator/rank information from it
+/**
+ * Defining H5FD_FEAT_HAS_MPI for a VFL driver means that
+ * the driver makes use of MPI communication and code may retrieve
+ * communicator/rank information from it
  *
  * \since 1.8.15
  */
+#define H5FD_FEAT_HAS_MPI 0x00000100
 
 #define H5FD_FEAT_ALLOCATE_EARLY 0x00000200
 /**< Defining the H5FD_FEAT_ALLOCATE_EARLY for a VFL driver will force
@@ -136,31 +139,39 @@
  * image to store in memory.
  */
 #define H5FD_FEAT_CAN_USE_FILE_IMAGE_CALLBACKS 0x00000800
-/*
+/**
  * Defining H5FD_FEAT_SUPPORTS_SWMR_IO for a VFL driver means that the
  * driver supports the single-writer/multiple-readers I/O pattern.
+ *
+ * \since 1.10.0
  */
 #define H5FD_FEAT_SUPPORTS_SWMR_IO 0x00001000
-/*
+/**
  * Defining H5FD_FEAT_USE_ALLOC_SIZE for a VFL driver
  * means that the library will just pass the allocation size to the
  * the driver's allocation callback which will eventually handle alignment.
  * This is specifically used for the multi/split driver.
+ *
+ * \since 1.10.1
  */
 #define H5FD_FEAT_USE_ALLOC_SIZE 0x00002000
-/*
+/**
  * Defining H5FD_FEAT_PAGED_AGGR for a VFL driver
  * means that the driver needs special file space mapping for paged aggregation.
  * This is specifically used for the multi/split driver.
+ *
+ * \since 1.10.1
  */
 #define H5FD_FEAT_PAGED_AGGR 0x00004000
-/*
+/**
  * Defining H5FD_FEAT_DEFAULT_VFD_COMPATIBLE for a VFL driver
  * that creates a file which is compatible with the default VFD.
  * Generally, this means that the VFD creates a single file that follows
  * the canonical HDF5 file format.
  * Regarding the Splitter VFD specifically, only drivers with this flag
  * enabled may be used as the Write-Only (W/O) channel driver.
+ *
+ * \since 1.10.2
  */
 #define H5FD_FEAT_DEFAULT_VFD_COMPATIBLE 0x00008000
 /*

--- a/src/H5FDros3.h
+++ b/src/H5FDros3.h
@@ -47,16 +47,22 @@
 /**
  * \def H5FD_ROS3_MAX_REGION_LEN
  * Maximum string length for specifying the region of the S3 bucket.
+ *
+ * \since 1.10.6
  */
 #define H5FD_ROS3_MAX_REGION_LEN 32
 /**
  * \def H5FD_ROS3_MAX_SECRET_ID_LEN
  * Maximum string length for specifying the security ID.
+ *
+ * \since 1.10.6
  */
 #define H5FD_ROS3_MAX_SECRET_ID_LEN 128
 /**
  * \def H5FD_ROS3_MAX_SECRET_KEY_LEN
  * Maximum string length for specifying the security key.
+ *
+ * \since 1.10.6
  */
 #define H5FD_ROS3_MAX_SECRET_KEY_LEN 128
 /**

--- a/src/H5FDsplitter.h
+++ b/src/H5FDsplitter.h
@@ -31,11 +31,11 @@
 
 /**
  * Maximum length of a filename/path string in the Write-Only channel,
- * including the NULL-terminator.
+ * including the NULL-terminator. \since 1.10.7
  */
 #define H5FD_SPLITTER_PATH_MAX 4096
 
-/** Semi-unique constant used to help identify structure pointers */
+/** Semi-unique constant used to help identify structure pointers \since 1.10.7 */
 #define H5FD_SPLITTER_MAGIC 0x2B916880
 
 //! <!-- [H5FD_splitter_vfd_config_t_snip] -->

--- a/src/H5Fpublic.h
+++ b/src/H5Fpublic.h
@@ -204,6 +204,7 @@ typedef enum H5F_file_space_type_t {
 } H5F_file_space_type_t;
 
 //! <!-- [H5F_retry_info_t_snip] -->
+/** Total number of metadata read retry types \since 1.10.0 */
 #define H5F_NUM_METADATA_READ_RETRY_TYPES 21
 
 /**
@@ -229,11 +230,11 @@ typedef herr_t (*H5F_flush_cb_t)(hid_t object_id, void *udata);
 #define H5F_RFIC_UNUSUAL_NUM_UNUSED_NUMERIC_BITS                                                             \
     (0x0001u) /**< Suppress errors for numeric datatypes with an unusually                                   \
                *   high number of unused bits.  See documentation for                                        \
-               *   H5Pset_relax_file_integrity_checks for details. */
+               *   H5Pset_relax_file_integrity_checks() for details. */
 #define H5F_RFIC_ALL                                                                                         \
     (H5F_RFIC_UNUSUAL_NUM_UNUSED_NUMERIC_BITS) /**< Suppress all format integrity check                      \
                                                 * errors.  See documentation for                             \
-                                                * H5Pset_relax_file_integrity_checks                         \
+                                                * H5Pset_relax_file_integrity_checks()                         \
                                                 * for details. */
 
 /*********************/

--- a/src/H5Fpublic.h
+++ b/src/H5Fpublic.h
@@ -234,7 +234,7 @@ typedef herr_t (*H5F_flush_cb_t)(hid_t object_id, void *udata);
 #define H5F_RFIC_ALL                                                                                         \
     (H5F_RFIC_UNUSUAL_NUM_UNUSED_NUMERIC_BITS) /**< Suppress all format integrity check                      \
                                                 * errors.  See documentation for                             \
-                                                * H5Pset_relax_file_integrity_checks()                         \
+                                                * H5Pset_relax_file_integrity_checks()                       \
                                                 * for details. */
 
 /*********************/

--- a/src/H5Ldevelop.h
+++ b/src/H5Ldevelop.h
@@ -299,7 +299,7 @@ H5_DLL herr_t H5Lunregister(H5L_type_t id);
  */
 #ifndef H5_NO_DEPRECATED_SYMBOLS
 
-/* Previous versions of the H5L_class_t struct */
+/** Previous versions of the H5L_class_t struct \since 1.10.3 */
 #define H5L_LINK_CLASS_T_VERS_0 0
 
 /** Callback during link traversal */

--- a/src/H5Opublic.h
+++ b/src/H5Opublic.h
@@ -78,9 +78,9 @@
  * These flags determine which fields will be filled in the H5O_info_t
  * struct.
  */
-#define H5O_INFO_BASIC     0x0001u /**< Fill in the fileno, addr, type, and rc fields */
-#define H5O_INFO_TIME      0x0002u /**< Fill in the atime, mtime, ctime, and btime fields */
-#define H5O_INFO_NUM_ATTRS 0x0004u /**< Fill in the num_attrs field */
+#define H5O_INFO_BASIC     0x0001u /**< Fill in the fileno, addr, type, and rc fields \since 1.10.3 */
+#define H5O_INFO_TIME      0x0002u /**< Fill in the atime, mtime, ctime, and btime fields \since 1.10.3 */
+#define H5O_INFO_NUM_ATTRS 0x0004u /**< Fill in the num_attrs field \since 1.10.3 */
 #define H5O_INFO_ALL       (H5O_INFO_BASIC | H5O_INFO_TIME | H5O_INFO_NUM_ATTRS)
 
 //! <!-- [H5O_native_info_fields_snip] -->

--- a/src/H5PLpublic.h
+++ b/src/H5PLpublic.h
@@ -23,8 +23,7 @@
 /* Public Typedefs */
 /*******************/
 
-/* Special string to indicate no plugin loading.
- */
+/** Special string to indicate no plugin loading \since 1.10.2 */
 #define H5PL_NO_PLUGIN "::"
 
 //! <!-- [H5PL_type_t_snip] -->

--- a/src/H5public.h
+++ b/src/H5public.h
@@ -328,21 +328,21 @@ typedef off_t HDoff_t;
  */
 typedef int64_t hssize_t;
 /** d print conversion specifier for signed integer type \since 1.10.8 */
-#define PRIdHSIZE          PRId64
+#define PRIdHSIZE PRId64
 /** i print conversion specifier for signed integer type \since 1.10.8 */
-#define PRIiHSIZE          PRIi64
+#define PRIiHSIZE PRIi64
 /** o print conversion specifier for signed integer type \since 1.10.8 */
-#define PRIoHSIZE          PRIo64
+#define PRIoHSIZE PRIo64
 /** u print conversion specifier for signed integer type \since 1.10.8 */
-#define PRIuHSIZE          PRIu64
+#define PRIuHSIZE PRIu64
 /** x print conversion specifier for signed integer type \since 1.10.8 */
-#define PRIxHSIZE          PRIx64
+#define PRIxHSIZE PRIx64
 /** X print conversion specifier for signed integer type \since 1.10.8 */
 #define PRIXHSIZE          PRIX64
 #define H5_SIZEOF_HSIZE_T  8
 #define H5_SIZEOF_HSSIZE_T 8
 /** Represents the largest possible value of uint64_t \since 1.10.0 */
-#define HSIZE_UNDEF        UINT64_MAX
+#define HSIZE_UNDEF UINT64_MAX
 
 /**
  * The address of an object in the file.

--- a/src/H5public.h
+++ b/src/H5public.h
@@ -327,14 +327,21 @@ typedef off_t HDoff_t;
  * should be discouraged in new code.
  */
 typedef int64_t hssize_t;
+/** d print conversion specifier for signed integer type \since 1.10.8 */
 #define PRIdHSIZE          PRId64
+/** i print conversion specifier for signed integer type \since 1.10.8 */
 #define PRIiHSIZE          PRIi64
+/** o print conversion specifier for signed integer type \since 1.10.8 */
 #define PRIoHSIZE          PRIo64
+/** u print conversion specifier for signed integer type \since 1.10.8 */
 #define PRIuHSIZE          PRIu64
+/** x print conversion specifier for signed integer type \since 1.10.8 */
 #define PRIxHSIZE          PRIx64
+/** X print conversion specifier for signed integer type \since 1.10.8 */
 #define PRIXHSIZE          PRIX64
 #define H5_SIZEOF_HSIZE_T  8
 #define H5_SIZEOF_HSSIZE_T 8
+/** Represents the largest possible value of uint64_t \since 1.10.0 */
 #define HSIZE_UNDEF        UINT64_MAX
 
 /**
@@ -343,15 +350,15 @@ typedef int64_t hssize_t;
  * \internal Defined as a (minimum) 64-bit unsigned integer type.
  */
 typedef uint64_t haddr_t;
-/** d print conversion specifier \since 1.8.23 */
+/** d print conversion specifier for unsigned integer type \since 1.8.23 */
 #define PRIdHADDR PRId64
-/** o print conversion specifier \since 1.8.23 */
+/** o print conversion specifier for unsigned integer type \since 1.8.23 */
 #define PRIoHADDR PRIo64
-/** u print conversion specifier \since 1.8.23 */
+/** u print conversion specifier for unsigned integer type \since 1.8.23 */
 #define PRIuHADDR PRIu64
-/** x print conversion specifier \since 1.8.23 */
+/** x print conversion specifier for unsigned integer type \since 1.8.23 */
 #define PRIxHADDR PRIx64
-/** x print conversion specifier \since 1.8.23 */
+/** X print conversion specifier for unsigned integer type \since 1.8.23 */
 #define PRIXHADDR           PRIX64
 #define H5_SIZEOF_HADDR_T   8
 #define HADDR_UNDEF         UINT64_MAX


### PR DESCRIPTION
Added \since to enum constants added in 1.10.x versions

(Partial fix of https://github.com/HDFGroup/hdf5/issues/4408)