### PR TITLE
Fix LOG VOL CI not including Zlib

### DIFF
--- a/.github/workflows/vol_log.yml
+++ b/.github/workflows/vol_log.yml
@@ -41,7 +41,7 @@ jobs:
             -DHDF5_ENABLE_PARALLEL:BOOL=ON \
             -DHDF5_ENABLE_THREADSAFE:BOOL=ON \
             -DHDF5_ALLOW_UNSUPPORTED:BOOL=ON \
-            -DHDF5_ENABLE_ZLIB_SUPPORT:BOOL=OFF \
+            -DHDF5_ENABLE_ZLIB_SUPPORT:BOOL=ON \
             -DHDF5_ENABLE_SZIP_SUPPORT:BOOL=OFF \
             ${{ github.workspace }}/hdf5
           cat src/libhdf5.settings


### PR DESCRIPTION
#5085 changed the default for zlip support to 'off', so the CI should now specifically turn this one. The LOG VOL CI is currently failing two compression tests due to this issue.