### PR TITLE
Fix MPI_TEST_H5DIFF-h5diff_601 

### DIFF
--- a/tools/test/h5diff/CMakeTests.cmake
+++ b/tools/test/h5diff/CMakeTests.cmake
@@ -808,7 +808,7 @@ ADD_H5_TEST (h5diff_63 1 -v ${STRINGS1} ${STRINGS2} string4 string4)
 ADD_H5_TEST (h5diff_600 1 ${FILE1})
 
 # 6.1: Check if non-exist object name is specified
-ADD_H5_CMP_TEST (h5diff_601 2 "Object could not be found" ${FILE1} ${FILE1} nono_obj)
+ADD_H5_CMP_TEST (h5diff_601 2 "could not be found" ${FILE1} ${FILE1} nono_obj)
 
 # ##############################################################################
 # # -d


### PR DESCRIPTION
on Dane and Frontier, which occasionally fails when searching for expected output "Object could not be found in <h5diff_basic1.h5>" when the object name </nono_obj> is inserted after "Object".  Search string is reduced to "could not be found".