### PR TITLE
fix clang ci

### DIFF
--- a/.github/workflows/cmake-analysis.yml
+++ b/.github/workflows/cmake-analysis.yml
@@ -134,7 +134,7 @@ jobs:
         id: setup-clang
         with:
           env: true
-          version: '18'
+          version: '18.1'
 
       - name: Set file base name (Linux_Leak)
         id: set-file-base
@@ -234,7 +234,7 @@ jobs:
         id: setup-clang
         with:
           env: true
-          version: '18'
+          version: '18.1'
 
       - name: Set file base name (Linux_Address)
         id: set-file-base
@@ -334,7 +334,7 @@ jobs:
         id: setup-clang
         with:
           env: true
-          version: '18'
+          version: '18.1'
 
       - name: Set file base name (Linux_UndefinedBehavior)
         id: set-file-base

--- a/.github/workflows/cmake-analysis.yml
+++ b/.github/workflows/cmake-analysis.yml
@@ -127,7 +127,7 @@ jobs:
       - name: Install CMake Dependencies (Linux_Leak)
         run: |
           sudo apt update
-          sudo apt-get install ninja-build doxygen graphviz curl
+          sudo apt-get install ninja-build doxygen graphviz curl libtinfo5
 
       - name: add clang to env
         uses: KyleMayes/install-llvm-action@v2.0.5
@@ -227,7 +227,7 @@ jobs:
       - name: Install CMake Dependencies (Linux_Address)
         run: |
           sudo apt update
-          sudo apt-get install ninja-build doxygen graphviz curl
+          sudo apt-get install ninja-build doxygen graphviz curl libtinfo5
 
       - name: add clang to env
         uses: KyleMayes/install-llvm-action@v2.0.5
@@ -327,7 +327,7 @@ jobs:
       - name: Install CMake Dependencies (Linux_UndefinedBehavior)
         run: |
           sudo apt update
-          sudo apt-get install ninja-build doxygen graphviz curl
+          sudo apt-get install ninja-build doxygen graphviz curl libtinfo5
 
       - name: add clang to env
         uses: KyleMayes/install-llvm-action@v2.0.5

--- a/.github/workflows/cmake-analysis.yml
+++ b/.github/workflows/cmake-analysis.yml
@@ -27,7 +27,7 @@ jobs:
   # Linux (Ubuntu) w/ gcc + coverage
   #
     name: "Ubuntu GCC Coverage"
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
     - name: Install CMake Dependencies (Linux_coverage)
       run: |
@@ -122,12 +122,12 @@ jobs:
   # Linux (Ubuntu) w/ clang + LeakSanitizer
   #
     name: "Ubuntu Clang LeakSanitizer"
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - name: Install CMake Dependencies (Linux_Leak)
         run: |
           sudo apt update
-          sudo apt-get install ninja-build doxygen graphviz curl libtinfo6
+          sudo apt-get install ninja-build doxygen graphviz curl
 
       - name: add clang to env
         uses: KyleMayes/install-llvm-action@v2.0.5
@@ -222,12 +222,12 @@ jobs:
   # Linux (Ubuntu) w/ clang + AddressSanitizer
   #
     name: "Ubuntu Clang AddressSanitizer"
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - name: Install CMake Dependencies (Linux_Address)
         run: |
           sudo apt update
-          sudo apt-get install ninja-build doxygen graphviz curl libtinfo6
+          sudo apt-get install ninja-build doxygen graphviz curl
 
       - name: add clang to env
         uses: KyleMayes/install-llvm-action@v2.0.5
@@ -322,12 +322,12 @@ jobs:
   # Linux (Ubuntu) w/ clang + UndefinedBehaviorSanitizer
   #
     name: "Ubuntu Clang UndefinedBehaviorSanitizer"
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - name: Install CMake Dependencies (Linux_UndefinedBehavior)
         run: |
           sudo apt update
-          sudo apt-get install ninja-build doxygen graphviz curl libtinfo6
+          sudo apt-get install ninja-build doxygen graphviz curl
 
       - name: add clang to env
         uses: KyleMayes/install-llvm-action@v2.0.5

--- a/.github/workflows/cmake-analysis.yml
+++ b/.github/workflows/cmake-analysis.yml
@@ -127,7 +127,7 @@ jobs:
       - name: Install CMake Dependencies (Linux_Leak)
         run: |
           sudo apt update
-          sudo apt-get install ninja-build doxygen graphviz curl libtinfo5
+          sudo apt-get install ninja-build doxygen graphviz curl libtinfo6
 
       - name: add clang to env
         uses: KyleMayes/install-llvm-action@v2.0.5
@@ -227,7 +227,7 @@ jobs:
       - name: Install CMake Dependencies (Linux_Address)
         run: |
           sudo apt update
-          sudo apt-get install ninja-build doxygen graphviz curl libtinfo5
+          sudo apt-get install ninja-build doxygen graphviz curl libtinfo6
 
       - name: add clang to env
         uses: KyleMayes/install-llvm-action@v2.0.5
@@ -327,7 +327,7 @@ jobs:
       - name: Install CMake Dependencies (Linux_UndefinedBehavior)
         run: |
           sudo apt update
-          sudo apt-get install ninja-build doxygen graphviz curl libtinfo5
+          sudo apt-get install ninja-build doxygen graphviz curl libtinfo6
 
       - name: add clang to env
         uses: KyleMayes/install-llvm-action@v2.0.5

--- a/.github/workflows/cmake-ctest.yml
+++ b/.github/workflows/cmake-ctest.yml
@@ -337,7 +337,6 @@ jobs:
         shell: bash
         run: |
           which clang
-          which flang
           clang -v
 
       - name: Install the Apple certificate and provisioning profile

--- a/.github/workflows/cmake-ctest.yml
+++ b/.github/workflows/cmake-ctest.yml
@@ -333,6 +333,13 @@ jobs:
         with:
           version: "1.9.7"
 
+      - name: check clang version
+        shell: bash
+        run: |
+          which clang
+          which flang
+          clang -v
+
       - name: Install the Apple certificate and provisioning profile
         shell: bash
         env:

--- a/.github/workflows/cmake-script.yml
+++ b/.github/workflows/cmake-script.yml
@@ -626,7 +626,7 @@ jobs:
       - name: Install CMake Dependencies (Linux_clang)
         run: |
           sudo apt-get update
-          sudo apt-get install ninja-build doxygen graphviz curl
+          sudo apt-get install ninja-build doxygen graphviz curl libtinfo5
 
       - name: add clang to env
         uses: KyleMayes/install-llvm-action@v2.0.5

--- a/.github/workflows/cmake-script.yml
+++ b/.github/workflows/cmake-script.yml
@@ -621,12 +621,12 @@ jobs:
   # Linux (Ubuntu) w/ clang + CMake
   #
     name: "Ubuntu Clang CMake"
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - name: Install CMake Dependencies (Linux_clang)
         run: |
           sudo apt-get update
-          sudo apt-get install ninja-build doxygen graphviz curl libtinfo6
+          sudo apt-get install ninja-build doxygen graphviz curl
 
       - name: add clang to env
         uses: KyleMayes/install-llvm-action@v2.0.5

--- a/.github/workflows/cmake-script.yml
+++ b/.github/workflows/cmake-script.yml
@@ -234,7 +234,6 @@ jobs:
         shell: bash
         run: |
           which clang
-          which flang
           clang -v
 
       - name: Set up JDK 19
@@ -640,7 +639,6 @@ jobs:
         shell: bash
         run: |
           which clang
-          which flang
           clang -v
 
       - name: Set file base name (Linux_clang)

--- a/.github/workflows/cmake-script.yml
+++ b/.github/workflows/cmake-script.yml
@@ -627,7 +627,14 @@ jobs:
         id: setup-clang
         with:
           env: true
-          version: '18'
+          version: '18.1'
+
+      - name: check clang version
+        shell: bash
+        run: |
+          which clang
+          which flang
+          clang -v
 
       - name: Set file base name (Linux_clang)
         id: set-file-base

--- a/.github/workflows/cmake-script.yml
+++ b/.github/workflows/cmake-script.yml
@@ -626,7 +626,7 @@ jobs:
       - name: Install CMake Dependencies (Linux_clang)
         run: |
           sudo apt-get update
-          sudo apt-get install ninja-build doxygen graphviz curl libtinfo5
+          sudo apt-get install ninja-build doxygen graphviz curl libtinfo6
 
       - name: add clang to env
         uses: KyleMayes/install-llvm-action@v2.0.5

--- a/.github/workflows/cmake-script.yml
+++ b/.github/workflows/cmake-script.yml
@@ -230,6 +230,13 @@ jobs:
         with:
           version: "1.9.7"
 
+      - name: check clang version
+        shell: bash
+        run: |
+          which clang
+          which flang
+          clang -v
+
       - name: Set up JDK 19
         uses: actions/setup-java@v4
         with:

--- a/.github/workflows/main-cmake.yml
+++ b/.github/workflows/main-cmake.yml
@@ -120,7 +120,7 @@ jobs:
       - name: Install CMake Dependencies (Linux)
         run: |
            sudo apt-get update
-           sudo apt-get install ninja-build graphviz libtinfo6
+           sudo apt-get install ninja-build graphviz
            sudo apt install libssl3 libssl-dev libcurl4 libcurl4-openssl-dev
            sudo apt install gcc-12 g++-12 gfortran-12
            echo "CC=gcc-12" >> $GITHUB_ENV

--- a/.github/workflows/main-cmake.yml
+++ b/.github/workflows/main-cmake.yml
@@ -120,7 +120,7 @@ jobs:
       - name: Install CMake Dependencies (Linux)
         run: |
            sudo apt-get update
-           sudo apt-get install ninja-build graphviz libtinfo5
+           sudo apt-get install ninja-build graphviz libtinfo6
            sudo apt install libssl3 libssl-dev libcurl4 libcurl4-openssl-dev
            sudo apt install gcc-12 g++-12 gfortran-12
            echo "CC=gcc-12" >> $GITHUB_ENV

--- a/.github/workflows/main-cmake.yml
+++ b/.github/workflows/main-cmake.yml
@@ -151,6 +151,13 @@ jobs:
           version: '18.1'
         if: ${{ matrix.os == 'macos-latest' }}
 
+      - name: check clang version
+        shell: bash
+        run: |
+          which clang
+          clang -v
+        if: ${{ matrix.os == 'macos-latest' }}
+
       - name: Install Dependencies
         uses: ssciwr/doxygen-install@v1
         with:

--- a/.github/workflows/main-cmake.yml
+++ b/.github/workflows/main-cmake.yml
@@ -143,21 +143,6 @@ jobs:
 #            version: 14
 #        if: ${{ matrix.os == 'macos-latest' }}
 
-#      - name: add clang to env
-#        uses: KyleMayes/install-llvm-action@v2.0.5
-#        id: setup-clang
-#        with:
-#          env: true
-#          version: '18.1'
-#        if: ${{ matrix.os == 'macos-latest' }}
-#
-#      - name: check clang version
-#        shell: bash
-#        run: |
-#          which clang
-#          clang -v
-#        if: ${{ matrix.os == 'macos-latest' }}
-
       - name: Install Dependencies
         uses: ssciwr/doxygen-install@v1
         with:

--- a/.github/workflows/main-cmake.yml
+++ b/.github/workflows/main-cmake.yml
@@ -88,7 +88,7 @@ jobs:
           - name: "MacOS Clang"
             os: macos-latest
             cpp: ON
-            fortran: ON
+            fortran: OFF
             java: ON
             docs: ON
             libaecfc: ON
@@ -135,13 +135,13 @@ jobs:
         if: ${{ matrix.os == 'macos-latest' }}
 
         # symlinks the compiler executables to a common location 
-      - name: Install GNU Fortran (macOS)
-        uses: fortran-lang/setup-fortran@v1
-        id: setup-fortran
-        with:
-            compiler: gcc
-            version: 14
-        if: ${{ matrix.os == 'macos-latest' }}
+#      - name: Install GNU Fortran (macOS)
+#        uses: fortran-lang/setup-fortran@v1
+#        id: setup-fortran
+#        with:
+#            compiler: gcc
+#            version: 14
+#        if: ${{ matrix.os == 'macos-latest' }}
 
       - name: add clang to env
         uses: KyleMayes/install-llvm-action@v2.0.5

--- a/.github/workflows/main-cmake.yml
+++ b/.github/workflows/main-cmake.yml
@@ -66,8 +66,6 @@ jobs:
 
           # Linux (Ubuntu) w/ gcc + CMake
           #
-          # We might think about adding Clang, but MacOS already tests that
-          # so it's not critical
           - name: "Ubuntu gcc"
             os: ubuntu-latest
             cpp: ON
@@ -87,8 +85,6 @@ jobs:
 
           # MacOS w/ Clang + CMake
           #
-          # We could also build with the Autotools via brew installing them,
-          # but that seems unnecessary
           - name: "MacOS Clang"
             os: macos-latest
             cpp: ON
@@ -124,7 +120,7 @@ jobs:
       - name: Install CMake Dependencies (Linux)
         run: |
            sudo apt-get update
-           sudo apt-get install ninja-build graphviz
+           sudo apt-get install ninja-build graphviz libtinfo5
            sudo apt install libssl3 libssl-dev libcurl4 libcurl4-openssl-dev
            sudo apt install gcc-12 g++-12 gfortran-12
            echo "CC=gcc-12" >> $GITHUB_ENV

--- a/.github/workflows/main-cmake.yml
+++ b/.github/workflows/main-cmake.yml
@@ -143,6 +143,14 @@ jobs:
             version: 14
         if: ${{ matrix.os == 'macos-latest' }}
 
+      - name: add clang to env
+        uses: KyleMayes/install-llvm-action@v2.0.5
+        id: setup-clang
+        with:
+          env: true
+          version: '18.1'
+        if: ${{ matrix.os == 'macos-latest' }}
+
       - name: Install Dependencies
         uses: ssciwr/doxygen-install@v1
         with:

--- a/.github/workflows/main-cmake.yml
+++ b/.github/workflows/main-cmake.yml
@@ -143,20 +143,20 @@ jobs:
 #            version: 14
 #        if: ${{ matrix.os == 'macos-latest' }}
 
-      - name: add clang to env
-        uses: KyleMayes/install-llvm-action@v2.0.5
-        id: setup-clang
-        with:
-          env: true
-          version: '18.1'
-        if: ${{ matrix.os == 'macos-latest' }}
-
-      - name: check clang version
-        shell: bash
-        run: |
-          which clang
-          clang -v
-        if: ${{ matrix.os == 'macos-latest' }}
+#      - name: add clang to env
+#        uses: KyleMayes/install-llvm-action@v2.0.5
+#        id: setup-clang
+#        with:
+#          env: true
+#          version: '18.1'
+#        if: ${{ matrix.os == 'macos-latest' }}
+#
+#      - name: check clang version
+#        shell: bash
+#        run: |
+#          which clang
+#          clang -v
+#        if: ${{ matrix.os == 'macos-latest' }}
 
       - name: Install Dependencies
         uses: ssciwr/doxygen-install@v1


### PR DESCRIPTION
Disable installing fortran on macs because it also installs gcc.
Revert linux clang builds to ubuntu 22 and install libtinfo5 - clang install needs version 5 and ubuntu has version 6.