### PR TITLE
Revert "Address code page issues w/ Windows file paths (#4172)"

### DIFF
--- a/src/H5system.c
+++ b/src/H5system.c
@@ -480,21 +480,27 @@ error:
 } /* end H5_get_utf16_str() */
 
 /*-------------------------------------------------------------------------
- * Function:     Wopen
+ * Function:     Wopen_utf8
  *
- * Purpose:      Equivalent of open(2) for use on Windows. Necessary to
- *               handle code pages and Unicode on that platform.
+ * Purpose:      UTF-8 equivalent of open(2) for use on Windows.
+ *               Converts a UTF-8 input path to UTF-16 and then opens the
+ *               file via _wopen() under the hood
  *
  * Return:       Success:    A POSIX file descriptor
  *               Failure:    -1
+ *
  *-------------------------------------------------------------------------
  */
 int
-Wopen(const char *path, int oflag, ...)
+Wopen_utf8(const char *path, int oflag, ...)
 {
     int      fd    = -1;   /* POSIX file descriptor to be returned */
     wchar_t *wpath = NULL; /* UTF-16 version of the path */
     int      pmode = 0;    /* mode (optionally set via variable args) */
+
+    /* Convert the input UTF-8 path to UTF-16 */
+    if (NULL == (wpath = H5_get_utf16_str(path)))
+        goto done;
 
     /* _O_BINARY must be set in Windows to avoid CR-LF <-> LF EOL
      * transformations when performing I/O. Note that this will
@@ -511,83 +517,47 @@ Wopen(const char *path, int oflag, ...)
         va_end(vl);
     }
 
-    /* First try opening the file with the normal POSIX open() call.
-     * This will handle ASCII without additional processing as well as
-     * systems where code pages are being used instead of true Unicode.
-     */
-    if ((fd = open(path, oflag, pmode)) >= 0) {
-        /* If this succeeds, we're done */
-        goto done;
-    }
-
-    if (errno == ENOENT) {
-        /* Not found, reset errno and try with UTF-16 */
-        errno = 0;
-    }
-    else {
-        /* Some other error (like permissions), so just exit */
-        goto done;
-    }
-
-    /* Convert the input UTF-8 path to UTF-16 */
-    if (NULL == (wpath = H5_get_utf16_str(path)))
-        goto done;
-
-    /* Open the file using a UTF-16 path */
+    /* Open the file */
     fd = _wopen(wpath, oflag, pmode);
 
 done:
-    H5MM_xfree(wpath);
+    if (wpath)
+        H5MM_xfree((void *)wpath);
 
     return fd;
-} /* end Wopen() */
+} /* end Wopen_utf8() */
 
 /*-------------------------------------------------------------------------
- * Function:     Wremove
+ * Function:     Wremove_utf8
  *
- * Purpose:      Equivalent of remove(3) for use on Windows. Necessary to
- *               handle code pages and Unicode on that platform.
+ * Purpose:      UTF-8 equivalent of remove(3) for use on Windows.
+ *               Converts a UTF-8 input path to UTF-16 and then opens the
+ *               file via _wremove() under the hood
  *
  * Return:       Success:    0
  *               Failure:    -1
+ *
  *-------------------------------------------------------------------------
  */
 int
-Wremove(const char *path)
+Wremove_utf8(const char *path)
 {
     wchar_t *wpath = NULL; /* UTF-16 version of the path */
     int      ret   = -1;
 
-    /* First try removing the file with the normal POSIX remove() call.
-     * This will handle ASCII without additional processing as well as
-     * systems where code pages are being used instead of true Unicode.
-     */
-    if ((ret = remove(path)) >= 0) {
-        /* If this succeeds, we're done */
-        goto done;
-    }
-
-    if (errno == ENOENT) {
-        /* Not found, reset errno and try with UTF-16 */
-        errno = 0;
-    }
-    else {
-        /* Some other error (like permissions), so just exit */
-        goto done;
-    }
-
     /* Convert the input UTF-8 path to UTF-16 */
     if (NULL == (wpath = H5_get_utf16_str(path)))
         goto done;
 
-    /* Remove the file using a UTF-16 path */
+    /* Open the file */
     ret = _wremove(wpath);
 
 done:
-    H5MM_xfree(wpath);
+    if (wpath)
+        H5MM_xfree((void *)wpath);
 
     return ret;
-} /* end Wremove() */
+} /* end Wremove_utf8() */
 
 #endif /* H5_HAVE_WIN32_API */
 

--- a/src/H5win32defs.h
+++ b/src/H5win32defs.h
@@ -32,7 +32,7 @@ struct timezone {
 };
 #endif
 
-#define HDcreat(S, M)        Wopen(S, O_CREAT | O_TRUNC | O_RDWR, M)
+#define HDcreat(S, M)        Wopen_utf8(S, O_CREAT | O_TRUNC | O_RDWR, M)
 #define HDflock(F, L)        Wflock(F, L)
 #define HDfstat(F, B)        _fstati64(F, B)
 #define HDftell(F)           _ftelli64(F)
@@ -44,9 +44,9 @@ struct timezone {
 #define HDmkdir(S, M)        _mkdir(S)
 
 /* We only support the standards conformant preprocessor */
-#define HDopen(S, F, ...) Wopen(S, F, ##__VA_ARGS__)
+#define HDopen(S, F, ...) Wopen_utf8(S, F, ##__VA_ARGS__)
 
-#define HDremove(S)           Wremove(S)
+#define HDremove(S)           Wremove_utf8(S)
 #define HDsetenv(N, V, O)     Wsetenv(N, V, O)
 #define HDsetvbuf(F, S, M, Z) setvbuf(F, S, M, (Z > 1 ? Z : 2))
 #define HDsleep(S)            Sleep(S * 1000)
@@ -88,8 +88,8 @@ H5_DLL int      Wsetenv(const char *name, const char *value, int overwrite);
 H5_DLL int      Wflock(int fd, int operation);
 H5_DLL herr_t   H5_expand_windows_env_vars(char **env_var);
 H5_DLL wchar_t *H5_get_utf16_str(const char *s);
-H5_DLL int      Wopen(const char *path, int oflag, ...);
-H5_DLL int      Wremove(const char *path);
+H5_DLL int      Wopen_utf8(const char *path, int oflag, ...);
+H5_DLL int      Wremove_utf8(const char *path);
 H5_DLL int      H5_get_win32_times(H5_timevals_t *tvs);
 H5_DLL char    *H5_strndup(const char *s, size_t n);
 H5_DLL char    *Wstrcasestr_wrap(const char *haystack, const char *needle);


### PR DESCRIPTION
This reverts commit eb0351efffe987a9c1882ccc9b03b5b0aec7f2dd.

This isn't a full solution for the problems that arose due to https://github.com/HDFGroup/hdf5/pull/4172 but as expressed by many https://github.com/HDFGroup/hdf5/issues/5037 the concerns for allowing users to "upgrade" past 1.14.3 are real

This ~proves~ provides you all a way to click merge as a way to stop the bleed.

edit: proves -> provides