### PR TITLE
Fix vuln OSV-2024-390

### DIFF
--- a/src/H5Ocache.c
+++ b/src/H5Ocache.c
@@ -781,6 +781,10 @@ H5O__cache_chk_serialize(const H5F_t *f, void *image, size_t len, void *_thing)
     /* copy the chunk into the image -- this is potentially expensive.
      * Can we rework things so that the chunk and the cache share a buffer?
      */
+    /* Ensure len does not exceed the size of the source buffer */
+    if (len > chk_proxy->oh->chunk[chk_proxy->chunkno].size)
+        HGOTO_ERROR(H5E_OHDR, H5E_OVERFLOW, FAIL, "buffer overflow detected");
+
     H5MM_memcpy(image, chk_proxy->oh->chunk[chk_proxy->chunkno].image, len);
 
 done:


### PR DESCRIPTION
[Warning] This PR is generated by AI
### PR Title: Fix for Heap-Buffer-Overflow Vulnerability in HDF5 - OSV-2024-390

---

### PR Description:
- **Bug Type**: Heap-Buffer-Overflow
- **Summary**: A vulnerability was identified in the HDF5 library where the program attempted to copy data exceeding the size of the allocated heap buffer. This led to a heap-buffer-overflow error, compromising the program's memory safety.
- **Fix Summary**: The patch introduces a bounds check before performing a memory copy operation (`H5MM_memcpy`) in the `H5O__cache_chk_serialize` function. If the requested length exceeds the size of the source buffer, the function will exit with an error, preventing the overflow. This fix improves the security and stability of the program by ensuring memory operations are safely bounded.

---

### Sanitizer Report Summary:
The sanitizer detected a heap-buffer-overflow error. The program attempted to access memory beyond the allocated buffer size of 8 bytes by trying to read 64 bytes at an offset of 8. The issue was identified in the `H5O__cache_chk_serialize` function, which is part of the object header cache serialization logic.

---

### Full Sanitizer Report:
```
==23213==ERROR: AddressSanitizer: heap-buffer-overflow on address 0x5020000036d8 at pc 0x5590d44b5ee6 bp 0x7ffd098e3240 sp 0x7ffd098e2a00
READ of size 64 at 0x5020000036d8 thread T0
    #0 0x5590d44b5ee5 in __asan_memcpy (/root/out/h5_extended_fuzzer+0x23aee5) (BuildId: 4dfb8b243953a293082050c5d44a381ad23ff76a)
    #1 0x5590d49c8a94 in H5O__cache_chk_serialize /root/src/H5Ocache.c:784:5
    #2 0x5590d45b8877 in H5C__generate_image /root/src/H5Centry.c:374:9
    #3 0x5590d45afbf7 in H5C__flush_single_entry /root/src/H5Centry.c:553:17
    #4 0x5590d45fce96 in H5C__flush_ring /root/src/H5Cint.c:1748:25
    #5 0x5590d45a1608 in H5C_flush_cache /root/src/H5C.c:710:17
    #6 0x5590d461e3ca in H5C_flush_tagged_entries /root/src/H5Ctag.c:654:9
    #7 0x5590d4544ae6 in H5AC_flush_tagged_metadata /root/src/H5AC.c:2208:9
    #8 0x5590d477580e in H5F_flush_tagged_metadata /root/src/H5Fio.c:421:9
    #9 0x5590d475ab92 in H5F_open /root/src/H5Fint.c:2211:17
    #10 0x5590d52ced89 in H5VL__native_file_open /root/src/H5VLnative_file.c:127:9
    #11 0x5590d527de16 in H5VL__file_open /root/src/H5VLcallback.c:3714:25
    #12 0x5590d527d44d in H5VL_file_open /root/src/H5VLcallback.c:3832:30
    #13 0x5590d472b874 in H5F__open_api_common /root/src/H5F.c:780:29
    #14 0x5590d472aa70 in H5Fopen /root/src/H5F.c:820:22
    #15 0x5590d44f8b6c in LLVMFuzzerTestOneInput /root/src/h5_extended_fuzzer.c:29:24
    #16 0x5590d4403f04 in fuzzer::Fuzzer::ExecuteCallback(unsigned char const*, unsigned long) (/root/out/h5_extended_fuzzer+0x188f04) (BuildId: 4dfb8b243953a293082050c5d44a381ad23ff76a)
    #17 0x5590d43ed036 in fuzzer::RunOneTest(fuzzer::Fuzzer*, char const*, unsigned long) (/root/out/h5_extended_fuzzer+0x172036) (BuildId: 4dfb8b243953a293082050c5d44a381ad23ff76a)
    #18 0x5590d43f2aea in fuzzer::FuzzerDriver(int*, char***, int (*)(unsigned char const*, unsigned long)) (/root/out/h5_extended_fuzzer+0x177aea) (BuildId: 4dfb8b243953a293082050c5d44a381ad23ff76a)
    #19 0x5590d441d2a6 in main (/root/out/h5_extended_fuzzer+0x1a22a6) (BuildId: 4dfb8b243953a293082050c5d44a381ad23ff76a)
    #20 0x7f0edfc721c9 in __libc_start_call_main csu/../sysdeps/nptl/libc_start_call_main.h:58:16
    #21 0x7f0edfc7228a in __libc_start_main csu/../csu/libc-start.c:360:3
    #22 0x5590d43e7c04 in _start (/root/out/h5_extended_fuzzer+0x16cc04) (BuildId: 4dfb8b243953a293082050c5d44a381ad23ff76a)

0x5020000036d8 is located 0 bytes after 8-byte region [0x5020000036d0,0x5020000036d8)
allocated by thread T0 here:
    #0 0x5590d44b8033 in malloc (/root/out/h5_extended_fuzzer+0x23d033) (BuildId: 4dfb8b243953a293082050c5d44a381ad23ff76a)
    ...
SUMMARY: AddressSanitizer
```

---

### Files Modified:
- `src/H5Ocache.c`

```diff
diff --git a/src/H5Ocache.c b/src/H5Ocache.c
index a5bf35aa7b..8d06f28207 100644
--- a/src/H5Ocache.c
+++ b/src/H5Ocache.c
@@ -781,6 +781,10 @@ H5O__cache_chk_serialize(const H5F_t *f, void *image, size_t len, void *_thing)
     /* copy the chunk into the image -- this is potentially expensive.
      * Can we rework things so that the chunk and the cache share a buffer?
      */
+    /* Ensure len does not exceed the size of the source buffer */
+    if (len > chk_proxy->oh->chunk[chk_proxy->chunkno].size)
+        HGOTO_ERROR(H5E_OHDR, H5E_OVERFLOW, FAIL, "buffer overflow detected");
+
     H5MM_memcpy(image, chk_proxy->oh->chunk[chk_proxy->chunkno].image, len);
 
 done:
```

---

### Patch Validation:
The patch has been validated and confirmed to resolve the heap-buffer-overflow vulnerability identified in the sanitizer report. No new bugs or regressions were introduced during testing.

---

### Links:
- [Original Vulnerability Report](https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=67889)
- [Proof of Concept (PoC)](https://oss-fuzz.com/download?testcase_id=6465395046285312)