### PR TITLE
Fix oss-fuzz vulns

### DIFF
--- a/src/H5FSsection.c
+++ b/src/H5FSsection.c
@@ -931,7 +931,10 @@ H5FS__sect_link_size(H5FS_sinfo_t *sinfo, const H5FS_section_class_t *cls, H5FS_
 
     /* Determine correct bin which holds items of the section's size */
     bin = H5VM_log2_gen(sect->size);
-    assert(bin < sinfo->nbins);
+    /* Check if the bin index is within bounds */
+    if (bin >= sinfo->nbins)
+        HGOTO_ERROR(H5E_FSPACE, H5E_BADVALUE, FAIL, "bin index out of bounds");
+
     if (sinfo->bins[bin].bin_list == NULL) {
         if (NULL == (sinfo->bins[bin].bin_list = H5SL_create(H5SL_TYPE_HSIZE, NULL)))
             HGOTO_ERROR(H5E_FSPACE, H5E_CANTCREATE, FAIL, "can't create skip list for free space nodes");

--- a/src/H5SM.c
+++ b/src/H5SM.c
@@ -1538,6 +1538,12 @@ H5SM_delete(H5F_t *f, H5O_t *open_oh, H5O_shared_t *sh_mesg)
     assert(H5_addr_defined(H5F_SOHM_ADDR(f)));
     assert(sh_mesg);
 
+    /* Validate the SOHM address */
+    if (!H5_addr_defined(H5F_SOHM_ADDR(f))) {
+        HGOTO_ERROR(H5E_SOHM, H5E_BADVALUE, FAIL,
+                    "SOHM address is invalid or uninitialized");
+    }
+
     /* Get message type */
     type_id = sh_mesg->msg_type_id;
 

--- a/src/H5SM.c
+++ b/src/H5SM.c
@@ -1540,8 +1540,7 @@ H5SM_delete(H5F_t *f, H5O_t *open_oh, H5O_shared_t *sh_mesg)
 
     /* Validate the SOHM address */
     if (!H5_addr_defined(H5F_SOHM_ADDR(f))) {
-        HGOTO_ERROR(H5E_SOHM, H5E_BADVALUE, FAIL,
-                    "SOHM address is invalid or uninitialized");
+        HGOTO_ERROR(H5E_SOHM, H5E_BADVALUE, FAIL, "SOHM address is invalid or uninitialized");
     }
 
     /* Get message type */


### PR DESCRIPTION
commit [c792aa1](https://github.com/aled-ua/hdf5/commit/c792aa1108b5774d548235ba8da5dd873b779bba) Fix

- [OSV-2023-76](https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=61803) - [POC](https://oss-fuzz.com/download?testcase_id=4582680828968960)
Full Sanitizer Report:
```
==13557==ERROR: AddressSanitizer: heap-buffer-overflow on address 0x502000003640 at pc 0x5627fc3fc76d bp 0x7ffcee65e870 sp 0x7ffcee65e868
READ of size 4 at 0x502000003640 thread T0
    #0 0x5627fc3fc76c in H5SM_delete /root/src/H5SM.c:1542:24
    #1 0x5627fc1bef62 in H5O__msg_write_real /root/src/H5Omessage.c:364:13
    #2 0x5627fc1be718 in H5O_msg_write /root/src/H5Omessage.c:246:9
    #3 0x5627fc0163ab in H5G__stab_valid /root/src/H5Gstab.c:1016:13
    #4 0x5627fc00d689 in H5G_mkroot /root/src/H5Groot.c:235:21
    #5 0x5627fbebb4b8 in H5F_open /root/src/H5Fint.c:2134:13
    #6 0x5627fca30d89 in H5VL__native_file_open /root/src/H5VLnative_file.c:127:9
    #7 0x5627fc9dfe16 in H5VL__file_open /root/src/H5VLcallback.c:3714:25
    #8 0x5627fc9df44d in H5VL_file_open /root/src/H5VLcallback.c:3832:30
    #9 0x5627fbe8d874 in H5F__open_api_common /root/src/H5F.c:780:29
    #10 0x5627fbe8ca70 in H5Fopen /root/src/H5F.c:820:22
    #11 0x5627fbc5ab6c in LLVMFuzzerTestOneInput /root/src/h5_extended_fuzzer.c:29:24
    #12 0x5627fbb65f04 in fuzzer::Fuzzer::ExecuteCallback(unsigned char const*, unsigned long) (/root/out/h5_extended_fuzzer+0x188f04) (BuildId: fbd396d65561ef37960c8b3f8a14c0d50bb772c3)
    #13 0x5627fbb4f036 in fuzzer::RunOneTest(fuzzer::Fuzzer*, char const*, unsigned long) (/root/out/h5_extended_fuzzer+0x172036) (BuildId: fbd396d65561ef37960c8b3f8a14c0d50bb772c3)
    #14 0x5627fbb54aea in fuzzer::FuzzerDriver(int*, char***, int (*)(unsigned char const*, unsigned long)) (/root/out/h5_extended_fuzzer+0x177aea) (BuildId: fbd396d65561ef37960c8b3f8a14c0d50bb772c3)
    #15 0x5627fbb7f2a6 in main (/root/out/h5_extended_fuzzer+0x1a22a6) (BuildId: fbd396d65561ef37960c8b3f8a14c0d50bb772c3)
    #16 0x7f0c431461c9 in __libc_start_call_main csu/../sysdeps/nptl/libc_start_call_main.h:58:16
    #17 0x7f0c4314628a in __libc_start_main csu/../csu/libc-start.c:360:3
    #18 0x5627fbb49c04 in _start (/root/out/h5_extended_fuzzer+0x16cc04) (BuildId: fbd396d65561ef37960c8b3f8a14c0d50bb772c3)

0x502000003640 is located 0 bytes after 16-byte region [0x502000003630,0x502000003640)
allocated by thread T0 here:
    #0 0x5627fbc1a033 in malloc (/root/out/h5_extended_fuzzer+0x23d033) (BuildId: fbd396d65561ef37960c8b3f8a14c0d50bb772c3)
    #1 0x5627fbfa7bd9 in H5FL__malloc /root/src/H5FL.c:211:30
    #2 0x5627fbfa775c in H5FL_reg_malloc /root/src/H5FL.c:363:34
    #3 0x5627fbfa7ecc in H5FL_reg_calloc /root/src/H5FL.c:395:30
    #4 0x5627fc1e5d2f in H5O__stab_decode /root/src/H5Ostab.c:97:25
    #...
```
commit [1126b83](https://github.com/aled-ua/hdf5/commit/1126b8362241a31e901f289d2a90cad0fa335e89) Fix

- [OSV-2024-379](https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=67923) - [POC](https://oss-fuzz.com/download?testcase_id=6018839587389440)
Full Sanitizer Report:
```
==10819==ERROR: AddressSanitizer: heap-buffer-overflow on address 0x51d000004480 at pc 0x55cdd6b1b525 bp 0x7ffe35ecefd0 sp 0x7ffe35ecefc8
READ of size 8 at 0x51d000004480 thread T0
    #0 0x55cdd6b1b524 in H5FS__sect_link_size /root/src/H5FSsection.c:935:26
    #1 0x55cdd6b12abc in H5FS__sect_link /root/src/H5FSsection.c:1074:9
    #2 0x55cdd6b10b08 in H5FS_sect_add /root/src/H5FSsection.c:1340:13
    #3 0x55cdd6c39e4e in H5MF__add_sect /root/src/H5MF.c:637:9
    #4 0x55cdd6c3c378 in H5MF__alloc_pagefs /root/src/H5MF.c:906:21
    #5 0x55cdd6c3b766 in H5MF_alloc /root/src/H5MF.c:806:45
    #6 0x55cdd6c3c539 in H5MF__alloc_pagefs /root/src/H5MF.c:923:44
    #7 0x55cdd6c3b766 in H5MF_alloc /root/src/H5MF.c:806:45
    #8 0x55cdd6b19321 in H5FS_vfd_alloc_hdr_and_section_info_if_needed /root/src/H5FSsection.c:2360:48
    #9 0x55cdd6c4b784 in H5MF_settle_meta_data_fsm /root/src/H5MF.c:3192:21
    #10 0x55cdd685045a in H5C_flush_cache /root/src/H5C.c:696:33
    #11 0x55cdd67ea4b0 in H5AC_flush /root/src/H5AC.c:645:9
    #12 0x55cdd6a14cb0 in H5F__flush_phase2 /root/src/H5Fint.c:2341:9
    #13 0x55cdd6a1183a in H5F__dest /root/src/H5Fint.c:1441:17
    #14 0x55cdd6a16ab3 in H5F_try_close /root/src/H5Fint.c:2680:9
    #15 0x55cdd6a157d8 in H5F__close /root/src/H5Fint.c:2482:9
    #16 0x55cdd7583dc0 in H5VL__native_file_close /root/src/H5VLnative_file.c:777:13
    #17 0x55cdd7532a69 in H5VL__file_close /root/src/H5VLcallback.c:4326:25
    #18 0x55cdd75324ca in H5VL_file_close /root/src/H5VLcallback.c:4360:9
    #19 0x55cdd6a20876 in H5F__close_cb /root/src/H5Fint.c:249:9
    #20 0x55cdd6c2468c in H5I__dec_ref /root/src/H5Iint.c:1076:30
    #21 0x55cdd6c24d10 in H5I__dec_app_ref /root/src/H5Iint.c:1156:22
    #22 0x55cdd6c24b8f in H5I_dec_app_ref /root/src/H5Iint.c:1201:22
    #23 0x55cdd69ddd85 in H5Fclose /root/src/H5F.c:1040:9
    #24 0x55cdd67a7bd8 in LLVMFuzzerTestOneInput /root/src/h5_extended_fuzzer.c:39:7
    #25 0x55cdd66b2f04 in fuzzer::Fuzzer::ExecuteCallback(unsigned char const*, unsigned long) (/root/out/h5_extended_fuzzer+0x188f04) (BuildId: 1a2fd423976350948bc250d1471b3ab6317a20b3)
    #26 0x55cdd669c036 in fuzzer::RunOneTest(fuzzer::Fuzzer*, char const*, unsigned long) (/root/out/h5_extended_fuzzer+0x172036) (BuildId: 1a2fd423976350948bc250d1471b3ab6317a20b3)
    #27 0x55cdd66a1aea in fuzzer::FuzzerDriver(int*, char***, int (*)(unsigned char const*, unsigned long)) (/root/out/h5_extended_fuzzer+0x177aea) (BuildId: 1a2fd423976350948bc250d1471b3ab6317a20b3)
    #28 0x55cdd66cc2a6 in main (/root/out/h5_extended_fuzzer+0x1a22a6) (BuildId: 1a2fd423976350948bc250d1471b3ab6317a20b3)
    #29 0x7efeb01931c9 in __libc_start_call_main csu/../sysdeps/nptl/libc_start_call_main.h:58:16
    #30 0x7efeb019328a in __libc_start_main csu/../csu/libc-start.c:360:3
    #31 0x55cdd6696c04 in _start (/root/out/h5_extended_fuzzer+0x16cc04) (BuildId: 1a2fd423976350948bc250d1471b3ab6317a20b3)

0x51d000004480 is located 56 bytes after 1992-byte region [0x51d000003c80,0x51d000004448)
allocated by thread T0 here:
    #0 0x55cdd6767033 in malloc (/root/out/h5_extended_fuzzer+0x23d033) (BuildId: 1a2fd423976350948bc250d1471b3ab6317a20b3)
    #1 0x55cdd6af4bd9 in H5FL__malloc /root/src/H5FL.c:211:30
 ```
- [OSV-2024-575](https://github.com/aled-ua/hdf5/compare/patch-OSV-2024-575) - [POC](https://oss-fuzz.com/download?testcase_id=6018839587389440)
Full Sanitizer Report:
```
==74935==ERROR: AddressSanitizer: heap-buffer-overflow on address 0x51d000003a80 at pc 0x5600a6ae3525 bp 0x7fff0c3d9b50 sp 0x7fff0c3d9b48
READ of size 8 at 0x51d000003a80 thread T0
    #0 0x5600a6ae3524 in H5FS__sect_link_size /root/src/H5FSsection.c:935:26
    #1 0x5600a6adaabc in H5FS__sect_link /root/src/H5FSsection.c:1074:9
    #2 0x5600a6ad8b08 in H5FS_sect_add /root/src/H5FSsection.c:1340:13
    #3 0x5600a6c01e4e in H5MF__add_sect /root/src/H5MF.c:637:9
    #4 0x5600a6c04378 in H5MF__alloc_pagefs /root/src/H5MF.c:906:21
    #5 0x5600a6c03766 in H5MF_alloc /root/src/H5MF.c:806:45
    #6 0x5600a6c04539 in H5MF__alloc_pagefs /root/src/H5MF.c:923:44
    #7 0x5600a6c03766 in H5MF_alloc /root/src/H5MF.c:806:45
    #8 0x5600a774745c in H5O__alloc_chunk /root/src/H5Oalloc.c:883:22
    #9 0x5600a775214c in H5O__alloc_new_chunk /root/src/H5Oalloc.c:1154:9
    #10 0x5600a774d9f8 in H5O__alloc /root/src/H5Oalloc.c:1291:17
    #11 0x5600a6cd27ca in H5O__msg_alloc /root/src/H5Omessage.c:1729:9
    #12 0x5600a6cd1ee4 in H5O__msg_append_real /root/src/H5Omessage.c:191:9
    #13 0x5600a6cd1c17 in H5O_msg_append_oh /root/src/H5Omessage.c:156:9
    #14 0x5600a6cd1718 in H5O_msg_create /root/src/H5Omessage.c:113:9
    #15 0x5600a6a01682 in H5F__super_ext_write_msg /root/src/H5Fsuper.c:1701:13
    #16 0x5600a6c110fd in H5MF_settle_raw_data_fsm /root/src/H5MF.c:2775:17
    #17 0x5600a681831a in H5C_flush_cache /root/src/H5C.c:689:33
    #18 0x5600a67b24b0 in H5AC_flush /root/src/H5AC.c:645:9
    #19 0x5600a69dccb0 in H5F__flush_phase2 /root/src/H5Fint.c:2341:9
    #20 0x5600a69d983a in H5F__dest /root/src/H5Fint.c:1441:17
    #21 0x5600a69deab3 in H5F_try_close /root/src/H5Fint.c:2680:9
    #22 0x5600a69dd7d8 in H5F__close /root/src/H5Fint.c:2482:9
    #23 0x5600a754bdc0 in H5VL__native_file_close /root/src/H5VLnative_file.c:777:13
    #24 0x5600a74faa69 in H5VL__file_close /root/src/H5VLcallback.c:4326:25
    #25 0x5600a74fa4ca in H5VL_file_close /root/src/H5VLcallback.c:4360:9
    #26 0x5600a69e8876 in H5F__close_cb /root/src/H5Fint.c:249:9
    #27 0x5600a6bec68c in H5I__dec_ref /root/src/H5Iint.c:1076:30
    #28 0x5600a6becd10 in H5I__dec_app_ref /root/src/H5Iint.c:1156:22
    #29 0x5600a6becb8f in H5I_dec_app_ref /root/src/H5Iint.c:1201:22
    #30 0x5600a69a5d85 in H5Fclose /root/src/H5F.c:1040:9
    #31 0x5600a676fbd8 in LLVMFuzzerTestOneInput /root/src/h5_extended_fuzzer.c:39:7
```
- [OSV-2024-772](https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=68989) - [POC](https://oss-fuzz.com/download?testcase_id=4558177868775424)
```
==75833==ERROR: AddressSanitizer: heap-buffer-overflow on address 0x51d000004e80 at pc 0x55a9de3a4525 bp 0x7ffc61902a10 sp 0x7ffc61902a08
READ of size 8 at 0x51d000004e80 thread T0
    #0 0x55a9de3a4524 in H5FS__sect_link_size /root/src/H5FSsection.c:935:26
    #1 0x55a9de39babc in H5FS__sect_link /root/src/H5FSsection.c:1074:9
    #2 0x55a9de399b08 in H5FS_sect_add /root/src/H5FSsection.c:1340:13
    #3 0x55a9de4c2e4e in H5MF__add_sect /root/src/H5MF.c:637:9
    #4 0x55a9de4c5378 in H5MF__alloc_pagefs /root/src/H5MF.c:906:21
    #5 0x55a9de4c4766 in H5MF_alloc /root/src/H5MF.c:806:45
    #6 0x55a9de4c5539 in H5MF__alloc_pagefs /root/src/H5MF.c:923:44
    #7 0x55a9de4c4766 in H5MF_alloc /root/src/H5MF.c:806:45
    #8 0x55a9de55efc5 in H5O_apply_ohdr /root/src/H5Oint.c:484:15
    #9 0x55a9de55cf62 in H5O_create /root/src/H5Oint.c:309:9
    #10 0x55a9de2c8acb in H5F__super_ext_create /root/src/H5Fsuper.c:119:13
    #11 0x55a9de2c23b4 in H5F__super_ext_write_msg /root/src/H5Fsuper.c:1683:13
    #12 0x55a9de4d20fd in H5MF_settle_raw_data_fsm /root/src/H5MF.c:2775:17
    #13 0x55a9de0d931a in H5C_flush_cache /root/src/H5C.c:689:33
    #14 0x55a9de0734b0 in H5AC_flush /root/src/H5AC.c:645:9
    #15 0x55a9de29dcb0 in H5F__flush_phase2 /root/src/H5Fint.c:2341:9
    #16 0x55a9de29a83a in H5F__dest /root/src/H5Fint.c:1441:17
    #17 0x55a9de29fab3 in H5F_try_close /root/src/H5Fint.c:2680:9
    #18 0x55a9de29e7d8 in H5F__close /root/src/H5Fint.c:2482:9
    #19 0x55a9dee0cdc0 in H5VL__native_file_close /root/src/H5VLnative_file.c:777:13
    #20 0x55a9dedbba69 in H5VL__file_close /root/src/H5VLcallback.c:4326:25
    #21 0x55a9dedbb4ca in H5VL_file_close /root/src/H5VLcallback.c:4360:9
    #22 0x55a9de2a9876 in H5F__close_cb /root/src/H5Fint.c:249:9
    #23 0x55a9de4ad68c in H5I__dec_ref /root/src/H5Iint.c:1076:30
    #24 0x55a9de4add10 in H5I__dec_app_ref /root/src/H5Iint.c:1156:22
    #25 0x55a9de4adb8f in H5I_dec_app_ref /root/src/H5Iint.c:1201:22
    #26 0x55a9de266d85 in H5Fclose /root/src/H5F.c:1040:9
    #27 0x55a9de030bd8 in LLVMFuzzerTestOneInput /root/src/h5_extended_fuzzer.c:39:7
    #28 0x55a9ddf3bf04 in fuzzer::Fuzzer::ExecuteCallback(unsigned char const*, unsigned long) (/root/out/h5_extended_fuzzer+0x188f04)
    #29 0x55a9ddf25036 in fuzzer::RunOneTest(fuzzer::Fuzzer*, char const*, unsigned long) (/root/out/h5_extended_fuzzer+0x172036)
    #30 0x55a9ddf2aaea in fuzzer::FuzzerDriver(int*, char***, int (*)(unsigned char const*, unsigned long)) (/root/out/h5_extended_fuzzer+0x177aea)
    #31 0x55a9ddf552a6 in main (/root/out/h5_extended_fuzzer+0x1a22a6)
    #32 0x7f79531d71c9 in __libc_start_call_main csu/../sysdeps/nptl/libc_start_call_main.h:58:16
    #33 0x7f79531d728a in __libc_start_main csu/../csu/libc-start.c:360:3
    #34 0x55a9ddf1fc04 in _start (/root/out/h5_extended_fuzzer+0x16cc04)

0x51d000004e80 is located 56 bytes after 1992-byte region [0x51d000004680,0x51d000004e48)
allocated by thread T0 here:
    #0 0x55a9ddff0033 in malloc (/root/out/h5_extended_fuzzer+0x23d033)
    #1 0x55a9de37dbd9 in H5FL__malloc /root/src/H5FL.c:211:30
    #2 0x55a9de37eb03 in H5FL_blk_malloc /root/src/H5FL.c:773:48
    #3 0x55a9de37f394 in H5FL_blk_calloc /root/src/H5FL.c:819:30
    #4 0x55a9de382c46 in H5FL_seq_calloc /root/src/H5FL.c:1651:17
    #5 0x55a9de3966e3 in H5FS__sinfo_new /root/src/H5FSsection.c:142:32
    #6 0x55a9de397afe in H5FS__sinfo_lock /root/src/H5FSsection.c:272:42
    #7 0x55a9de399721 in H5FS_sect_add /root/src/H5FSsection.c:1314:9
    #8 0x55a9de4c2e4e in H5MF__add_sect /root/src/H5MF.c:637:9
    #9 0x55a9de4c5378 in H5MF__alloc_pagefs /root/src/H5MF.c:906:21
    #10 0x55a9de4c4766 in H5MF_alloc /root/src/H5MF.c:806:45
    #11 0x55a9de4c5539 in H5MF__alloc_pagefs /root/src/H5MF.c:923:44
    #12 0x55a9de4c4766 in H5MF_alloc /root/src/H5MF.c:806:45
    #13 0x55a9de55efc5 in H5O_apply_ohdr /root/src/H5Oint.c:484:15
    #14 0x55a9de55cf62 in H5O_create /root/src/H5Oint.c:309:9
    #15 0x55a9de2c8acb in H5F__super_ext_create /root/src/H5Fsuper.c:119:13
    #16 0x55a9de2c23b4 in H5F__super_ext_write_msg /root/src/H5Fsuper.c:1683:13
    #17 0x55a9de4d20fd in H5MF_settle_raw_data_fsm /root/src/H5MF.c:2775:17
    #18 0x55a9de0d931a in H5C_flush_cache /root/src/H5C.c:689:33
    #19 0x55a9de0734b0 in H5AC_flush /root/src/H5AC.c:645:9
    #20 0x55a9de29dcb0 in H5F__flush_phase2 /root/src/H5Fint.c:2341:9
    #21 0x55a9de29a83a in H5F__dest /root/src/H5Fint.c:1441:17
    #22 0x55a9de29fab3 in H5F_try_close /root/src/H5Fint.c:2680:9
    #23 0x55a9de29e7d8 in H5F__close /root/src/H5Fint.c:2482:9
    #24 0x55a9dee0cdc0 in H5VL__native_file_close /root/src/H5VLnative_file.c:777:13
    #25 0x55a9dedbba69 in H5VL__file_close /root/src/H5VLcallback.c:4326:25
    #26 0x55a9dedbb4ca in H5VL_file_close /root/src/H5VLcallback.c:4360:9
    #27 0x55a9de2a9876 in H5F__close_cb /root/src/H5Fint.c:249:9
    #28 0x55a9de4ad68c in H5I__dec_ref /root/src/H5Iint.c:1076:30
    #29 0x55a9de4add10 in H5I__dec_app_ref /root/src/H5Iint.c:1156:22

SUMMARY: AddressSanitizer
```



What these issues have in common is that they should trigger an assert before the vulnerability.

I'm not sure if it should be fixed more completely than just replacing assert with a real error checking.