### PR TITLE
Remove gmnow() helper fxn from ros3 VFD

### DIFF
--- a/src/H5FDros3.c
+++ b/src/H5FDros3.c
@@ -750,8 +750,8 @@ H5FD__ros3_open(const char *url, unsigned flags, hid_t fapl_id, haddr_t maxaddr)
          *
          * TODO: Find way to reuse/share?
          */
-        now = gmnow();
-        assert(now != NULL);
+        if (NULL == (now = gmtime(time(NULL))))
+            HGOTO_ERROR(H5E_VFL, H5E_BADVALUE, NULL, "gmtime() error");
         if (ISO8601NOW(iso8601now, now) != (ISO8601_SIZE - 1))
             HGOTO_ERROR(H5E_ARGS, H5E_BADVALUE, NULL, "problem while writing iso8601 timestamp");
         if (FAIL == H5FD_s3comms_signing_key(signing_key, (const char *)fa->secret_key,

--- a/src/H5FDs3comms.c
+++ b/src/H5FDs3comms.c
@@ -1211,7 +1211,8 @@ H5FD_s3comms_s3r_read(s3r_t *handle, haddr_t offset, size_t len, void *dest)
         if (request == NULL)
             HGOTO_ERROR(H5E_ARGS, H5E_BADVALUE, FAIL, "could not allocate hrb_t request.");
 
-        now = gmnow();
+        if (NULL == (now = gmtime(time(NULL))))
+            HGOTO_ERROR(H5E_VFL, H5E_BADVALUE, FAIL, "gmtime() error");
         if (ISO8601NOW(iso8601now, now) != (ISO8601_SIZE - 1))
             HGOTO_ERROR(H5E_ARGS, H5E_BADVALUE, FAIL, "could not format ISO8601 time.");
 
@@ -1393,37 +1394,6 @@ done:
 /****************************************************************************
  * MISCELLANEOUS FUNCTIONS
  ****************************************************************************/
-
-/*----------------------------------------------------------------------------
- *
- * Function: gmnow()
- *
- * Purpose:
- *
- *    Get the output of `time.h`'s `gmtime()` call while minimizing setup
- *    clutter where important.
- *
- * Return:
- *
- *    Pointer to resulting `struct tm`,as created by gmtime(time_t * T).
- *
- *----------------------------------------------------------------------------
- */
-struct tm *
-gmnow(void)
-{
-    time_t     now;
-    time_t    *now_ptr   = &now;
-    struct tm *ret_value = NULL;
-
-    /* Doctor assert, checks against error in time() */
-    if ((time_t)(-1) != time(now_ptr))
-        ret_value = gmtime(now_ptr);
-
-    assert(ret_value != NULL);
-
-    return ret_value;
-} /* end gmnow() */
 
 /*----------------------------------------------------------------------------
  *

--- a/src/H5FDs3comms.h
+++ b/src/H5FDs3comms.h
@@ -452,23 +452,23 @@ typedef struct {
 extern "C" {
 #endif
 
-/*******************************************
- * DECLARATION OF HTTP FIELD LIST ROUTINES *
- *******************************************/
+/****************************
+ * HTTP FIELD LIST ROUTINES *
+ ****************************/
 
 H5_DLL herr_t H5FD_s3comms_hrb_node_set(hrb_node_t **L, const char *name, const char *value);
 
-/***********************************************
- * DECLARATION OF HTTP REQUEST BUFFER ROUTINES *
- ***********************************************/
+/********************************
+ * HTTP REQUEST BUFFER ROUTINES *
+ ********************************/
 
 H5_DLL herr_t H5FD_s3comms_hrb_destroy(hrb_t **buf);
 
 H5_DLL hrb_t *H5FD_s3comms_hrb_init_request(const char *verb, const char *resource, const char *host);
 
-/*************************************
- * DECLARATION OF S3REQUEST ROUTINES *
- *************************************/
+/**********************
+ * S3REQUEST ROUTINES *
+ **********************/
 
 H5_DLL herr_t H5FD_s3comms_s3r_close(s3r_t *handle);
 
@@ -479,11 +479,9 @@ H5_DLL s3r_t *H5FD_s3comms_s3r_open(const char url[], const char region[], const
 
 H5_DLL herr_t H5FD_s3comms_s3r_read(s3r_t *handle, haddr_t offset, size_t len, void *dest);
 
-/*********************************
- * DECLARATION OF OTHER ROUTINES *
- *********************************/
-
-H5_DLL struct tm *gmnow(void);
+/******************
+ * OTHER ROUTINES *
+ ******************/
 
 H5_DLL herr_t H5FD_s3comms_aws_canonical_request(char *canonical_request_dest, int cr_size,
                                                  char *signed_headers_dest, int sh_size, hrb_t *http_request);

--- a/test/s3comms.c
+++ b/test/s3comms.c
@@ -1477,7 +1477,7 @@ test_s3r_open(void)
             TEST_ERROR;
     }
 
-    if (NULL == (now = gmnow()))
+    if (NULL == (now = gmtime(time(NULL))))
         TEST_ERROR;
     if (ISO8601NOW(iso8601now, now) != (ISO8601_SIZE - 1))
         TEST_ERROR;


### PR DESCRIPTION
Replace with gmtime(time(NULL))

The unused pointer arg in time() is obsolescent and should be NULL in new code. When the pointer is NULL, the time call cannot fail.