### PR TITLE
Add release information to enum constants - Part 3

### DIFF
--- a/src/H5Mpublic.h
+++ b/src/H5Mpublic.h
@@ -32,15 +32,15 @@
 
 /* Macros defining operation IDs for map VOL callbacks (implemented using the
  * "optional" VOL callback) */
-#define H5VL_MAP_CREATE   1 /**< Callback operation ID for map create */
-#define H5VL_MAP_OPEN     2 /**< Callback operation ID for map open */
-#define H5VL_MAP_GET_VAL  3 /**< Callback operation ID for getting an associated value from a map */
-#define H5VL_MAP_EXISTS   4 /**< Callback operation ID for checking if a value exists in a map */
-#define H5VL_MAP_PUT      5 /**< Callback operation ID for putting a key-value pair to a map */
-#define H5VL_MAP_GET      6 /**< Callback operation ID for map get callback */
-#define H5VL_MAP_SPECIFIC 7 /**< Callback operation ID for map specific operation */
-#define H5VL_MAP_OPTIONAL 8 /**< Currently unused */
-#define H5VL_MAP_CLOSE    9 /**< Callback operation ID for terminating access to a map */
+#define H5VL_MAP_CREATE   1 /**< Callback operation ID for map create \since 1.12.0 */
+#define H5VL_MAP_OPEN     2 /**< Callback operation ID for map open \since 1.12.0 */
+#define H5VL_MAP_GET_VAL  3 /**< Callback operation ID for getting an associated value from a map \since 1.12.0 */
+#define H5VL_MAP_EXISTS   4 /**< Callback operation ID for checking if a value exists in a map \since 1.12.0 */
+#define H5VL_MAP_PUT      5 /**< Callback operation ID for putting a key-value pair to a map \since 1.12.0 */
+#define H5VL_MAP_GET      6 /**< Callback operation ID for map get callback \since 1.12.0 */
+#define H5VL_MAP_SPECIFIC 7 /**< Callback operation ID for map specific operation \since 1.12.0 */
+#define H5VL_MAP_OPTIONAL 8 /**< Currently unused \since 1.12.0 */
+#define H5VL_MAP_CLOSE    9 /**< Callback operation ID for terminating access to a map \since 1.12.0 */
 
 /*******************/
 /* Public Typedefs */
@@ -50,19 +50,19 @@
  * Types for map GET callback
  */
 typedef enum H5VL_map_get_t {
-    H5VL_MAP_GET_MAPL,     /**< Callback operation ID for getting map access property list   */
-    H5VL_MAP_GET_MCPL,     /**< Callback operation ID for getting map creation property list */
-    H5VL_MAP_GET_KEY_TYPE, /**< Callback operation ID for getting the key datatype for a map */
-    H5VL_MAP_GET_VAL_TYPE, /**< Callback operation ID for getting the value datatype for a map */
-    H5VL_MAP_GET_COUNT /**< Callback operation ID for getting the number of key-value pairs stored in a map */
+    H5VL_MAP_GET_MAPL,     /**< Callback operation ID for getting map access property list   \since 1.12.0 */
+    H5VL_MAP_GET_MCPL,     /**< Callback operation ID for getting map creation property list \since 1.12.0 */
+    H5VL_MAP_GET_KEY_TYPE, /**< Callback operation ID for getting the key datatype for a map \since 1.12.0 */
+    H5VL_MAP_GET_VAL_TYPE, /**< Callback operation ID for getting the value datatype for a map \since 1.12.0 */
+    H5VL_MAP_GET_COUNT /**< Callback operation ID for getting the number of key-value pairs stored in a map \since 1.12.0 */
 } H5VL_map_get_t;
 
 /**
  * Types for map SPECIFIC callback
  */
 typedef enum H5VL_map_specific_t {
-    H5VL_MAP_ITER,  /**< Callback operation ID for iterating over all key-value pairs stored in the map */
-    H5VL_MAP_DELETE /**< Callback operation ID for deleting a key-value pair stored in the map */
+    H5VL_MAP_ITER,  /**< Callback operation ID for iterating over all key-value pairs stored in the map \since 1.12.0 */
+    H5VL_MAP_DELETE /**< Callback operation ID for deleting a key-value pair stored in the map \since 1.12.0 */
 } H5VL_map_specific_t;
 
 //! <!-- [H5M_iterate_t_snip] -->

--- a/src/H5Mpublic.h
+++ b/src/H5Mpublic.h
@@ -32,10 +32,12 @@
 
 /* Macros defining operation IDs for map VOL callbacks (implemented using the
  * "optional" VOL callback) */
-#define H5VL_MAP_CREATE   1 /**< Callback operation ID for map create \since 1.12.0 */
-#define H5VL_MAP_OPEN     2 /**< Callback operation ID for map open \since 1.12.0 */
-#define H5VL_MAP_GET_VAL  3 /**< Callback operation ID for getting an associated value from a map \since 1.12.0 */
-#define H5VL_MAP_EXISTS   4 /**< Callback operation ID for checking if a value exists in a map \since 1.12.0 */
+#define H5VL_MAP_CREATE 1 /**< Callback operation ID for map create \since 1.12.0 */
+#define H5VL_MAP_OPEN   2 /**< Callback operation ID for map open \since 1.12.0 */
+#define H5VL_MAP_GET_VAL                                                                                     \
+    3 /**< Callback operation ID for getting an associated value from a map \since 1.12.0 */
+#define H5VL_MAP_EXISTS 4   /**< Callback operation ID for checking if a value exists in a map \since 1.12.0 \
+                             */
 #define H5VL_MAP_PUT      5 /**< Callback operation ID for putting a key-value pair to a map \since 1.12.0 */
 #define H5VL_MAP_GET      6 /**< Callback operation ID for map get callback \since 1.12.0 */
 #define H5VL_MAP_SPECIFIC 7 /**< Callback operation ID for map specific operation \since 1.12.0 */
@@ -53,16 +55,20 @@ typedef enum H5VL_map_get_t {
     H5VL_MAP_GET_MAPL,     /**< Callback operation ID for getting map access property list   \since 1.12.0 */
     H5VL_MAP_GET_MCPL,     /**< Callback operation ID for getting map creation property list \since 1.12.0 */
     H5VL_MAP_GET_KEY_TYPE, /**< Callback operation ID for getting the key datatype for a map \since 1.12.0 */
-    H5VL_MAP_GET_VAL_TYPE, /**< Callback operation ID for getting the value datatype for a map \since 1.12.0 */
-    H5VL_MAP_GET_COUNT /**< Callback operation ID for getting the number of key-value pairs stored in a map \since 1.12.0 */
+    H5VL_MAP_GET_VAL_TYPE, /**< Callback operation ID for getting the value datatype for a map \since 1.12.0
+                            */
+    H5VL_MAP_GET_COUNT /**< Callback operation ID for getting the number of key-value pairs stored in a map
+                          \since 1.12.0 */
 } H5VL_map_get_t;
 
 /**
  * Types for map SPECIFIC callback
  */
 typedef enum H5VL_map_specific_t {
-    H5VL_MAP_ITER,  /**< Callback operation ID for iterating over all key-value pairs stored in the map \since 1.12.0 */
-    H5VL_MAP_DELETE /**< Callback operation ID for deleting a key-value pair stored in the map \since 1.12.0 */
+    H5VL_MAP_ITER,  /**< Callback operation ID for iterating over all key-value pairs stored in the map
+                       \since 1.12.0 */
+    H5VL_MAP_DELETE /**< Callback operation ID for deleting a key-value pair stored in the map \since 1.12.0
+                     */
 } H5VL_map_specific_t;
 
 //! <!-- [H5M_iterate_t_snip] -->

--- a/src/H5Opublic.h
+++ b/src/H5Opublic.h
@@ -88,8 +88,8 @@
  * Flags for H5Oget_native_info().  These flags determine which fields will be
  * filled in the \ref H5O_native_info_t struct.
  */
-#define H5O_NATIVE_INFO_HDR       0x0008u /**< Fill in the hdr field */
-#define H5O_NATIVE_INFO_META_SIZE 0x0010u /**< Fill in the meta_size field */
+#define H5O_NATIVE_INFO_HDR       0x0008u /**< Fill in the hdr field \since 1.12.0 */
+#define H5O_NATIVE_INFO_META_SIZE 0x0010u /**< Fill in the meta_size field \since 1.12.0 */
 #define H5O_NATIVE_INFO_ALL       (H5O_NATIVE_INFO_HDR | H5O_NATIVE_INFO_META_SIZE)
 //! <!-- [H5O_native_info_fields_snip] -->
 

--- a/src/H5Rpublic.h
+++ b/src/H5Rpublic.h
@@ -49,13 +49,13 @@
  *           encoded into the datatype message header.
  */
 typedef enum {
-    H5R_BADTYPE         = (-1), /**< Invalid reference type           */
-    H5R_OBJECT1         = 0,    /**< Backward compatibility (object)  */
-    H5R_DATASET_REGION1 = 1,    /**< Backward compatibility (region)  */
-    H5R_OBJECT2         = 2,    /**< Object reference                 */
-    H5R_DATASET_REGION2 = 3,    /**< Region reference                 */
-    H5R_ATTR            = 4,    /**< Attribute Reference              */
-    H5R_MAXTYPE         = 5     /**< Highest type (invalid)           */
+    H5R_BADTYPE         = (-1), /**< Invalid reference type \since 1.0.0           */
+    H5R_OBJECT1         = 0,    /**< Backward compatibility (object) \since 1.12.0 */
+    H5R_DATASET_REGION1 = 1,    /**< Backward compatibility (region) \since 1.12.0 */
+    H5R_OBJECT2         = 2,    /**< Object reference \since 1.12.0                */
+    H5R_DATASET_REGION2 = 3,    /**< Region reference \since 1.12.0                */
+    H5R_ATTR            = 4,    /**< Attribute Reference \since 1.12.0             */
+    H5R_MAXTYPE         = 5     /**< Highest type (invalid) \since 1.0.0           */
 } H5R_type_t;
 //! <!-- [H5R_type_t_snip] -->
 

--- a/src/H5Spublic.h
+++ b/src/H5Spublic.h
@@ -53,38 +53,42 @@
 #define H5S_MAX_RANK 32
 
 /* Flags for selection iterators */
-#define H5S_SEL_ITER_GET_SEQ_LIST_SORTED                                                                     \
-    0x0001 /**< Retrieve elements from iterator in increasing offset order, for                              \
-            * each call to retrieve sequences. Currently, this only applies to                               \
-            * point selections, as hyperslab selections are always returned in                               \
-            * increasing offset order. Note that the order is only increasing                                \
-            * for each call to H5Sget_seq_list(), the next set of sequences                                  \
-            * could start with an earlier offset than the previous one.                                      \
+#define H5S_SEL_ITER_GET_SEQ_LIST_SORTED                                      \
+    0x0001 /**< Retrieve elements from iterator in increasing offset order, for
+            * each call to retrieve sequences. Currently, this only applies to
+            * point selections, as hyperslab selections are always returned in
+            * increasing offset order. Note that the order is only increasing
+            * for each call to H5Sget_seq_list(), the next set of sequences
+            * could start with an earlier offset than the previous one.
+            *
+            * \since 1.12.0
             */
-#define H5S_SEL_ITER_SHARE_WITH_DATASPACE                                                                    \
-    0x0002 /**< Don't copy the dataspace selection when creating the selection                               \
-            * iterator. This can improve performance of creating the iterator,                               \
-            * but the dataspace \Bold{MUST NOT} be modified or closed until the                              \
-            * selection iterator is closed or the iterator's behavior will be                                \
-            * undefined.                                                                                     \
+#define H5S_SEL_ITER_SHARE_WITH_DATASPACE                                     \
+    0x0002 /**< Don't copy the dataspace selection when creating the selection
+            * iterator. This can improve performance of creating the iterator,
+            * but the dataspace \Bold{MUST NOT} be modified or closed until the
+            * selection iterator is closed or the iterator's behavior will be
+            * undefined.
+            *
+            * \since 1.12.0
             */
 
 /**
  * Types of dataspaces
  */
 typedef enum H5S_class_t {
-    H5S_NO_CLASS = -1, /**< Error                                      */
-    H5S_SCALAR   = 0,  /**< Singleton (scalar)                         */
-    H5S_SIMPLE   = 1,  /**< Regular grid                               */
-    H5S_NULL     = 2   /**< Empty set                                  */
+    H5S_NO_CLASS = -1, /**< Error \since 1.0.0                         */
+    H5S_SCALAR   = 0,  /**< Singleton (scalar) \since 1.0.0            */
+    H5S_SIMPLE   = 1,  /**< Regular grid \since 1.0.0                  */
+    H5S_NULL     = 2   /**< Empty set \since 1.8.0                     */
 } H5S_class_t;
 
 /**
  * Different ways of combining selections
  */
 typedef enum H5S_seloper_t {
-    H5S_SELECT_NOOP = -1, /**< Error                                     */
-    H5S_SELECT_SET  = 0,  /**< Select "set" operation 		             */
+    H5S_SELECT_NOOP = -1, /**< Error \since 1.0.0                        */
+    H5S_SELECT_SET  = 0,  /**< Select "set" operation \since 1.0.0       */
     H5S_SELECT_OR,        /**< Binary "or" operation for hyperslabs
                            * (add new selection to existing selection)
                            * \code
@@ -92,6 +96,8 @@ typedef enum H5S_seloper_t {
                            * New region:             BBBBBBBBBB
                            * A or B:           CCCCCCCCCCCCCCCC
                            * \endcode
+                           *
+                           * \since 1.0.0
                            */
     H5S_SELECT_AND,       /**< Binary "and" operation for hyperslabs
                            * (only leave overlapped regions in selection)
@@ -100,6 +106,8 @@ typedef enum H5S_seloper_t {
                            * New region:             BBBBBBBBBB
                            * A and B:                CCCC
                            * \endcode
+                           *
+                           * \since 1.6.0
                            */
     H5S_SELECT_XOR,       /**< Binary "xor" operation for hyperslabs
                            * (only leave non-overlapped regions in selection)
@@ -108,6 +116,8 @@ typedef enum H5S_seloper_t {
                            * New region:             BBBBBBBBBB
                            * A xor B:          CCCCCC    CCCCCC
                            * \endcode
+                           *
+                           * \since 1.6.0
                            */
     H5S_SELECT_NOTB,      /**< Binary "not" operation for hyperslabs
                            * (only leave non-overlapped regions in original selection)
@@ -116,6 +126,8 @@ typedef enum H5S_seloper_t {
                            * New region:             BBBBBBBBBB
                            * A not B:          CCCCCC
                            * \endcode
+                           *
+                           * \since 1.6.0
                            */
     H5S_SELECT_NOTA,      /**< Binary "not" operation for hyperslabs
                            * (only leave non-overlapped regions in new selection)
@@ -124,22 +136,24 @@ typedef enum H5S_seloper_t {
                            * New region:             BBBBBBBBBB
                            * B not A:                    CCCCCC
                            * \endcode
+                           *
+                           * \since 1.6.0
                            */
-    H5S_SELECT_APPEND,    /**< Append elements to end of point selection */
-    H5S_SELECT_PREPEND,   /**< Prepend elements to beginning of point selection */
-    H5S_SELECT_INVALID    /**< Invalid upper bound on selection operations */
+    H5S_SELECT_APPEND,    /**< Append elements to end of point selection \since 1.4.0 */
+    H5S_SELECT_PREPEND,   /**< Prepend elements to beginning of point selection \since 1.4.0 */
+    H5S_SELECT_INVALID    /**< Invalid upper bound on selection operations \since 1.0.0 */
 } H5S_seloper_t;
 
 /**
  * Selection type
  */
 typedef enum {
-    H5S_SEL_ERROR      = -1, /**< Error                                 */
-    H5S_SEL_NONE       = 0,  /**< Empty selection                       */
-    H5S_SEL_POINTS     = 1,  /**< Set of points                         */
-    H5S_SEL_HYPERSLABS = 2,  /**< Hyperslab                             */
-    H5S_SEL_ALL        = 3,  /**< Everything	                        */
-    H5S_SEL_N                /**< Sentinel \internal THIS MUST BE LAST	*/
+    H5S_SEL_ERROR      = -1, /**< Error \since 1.0.0                                */
+    H5S_SEL_NONE       = 0,  /**< Empty selection \since 1.0.0                      */
+    H5S_SEL_POINTS     = 1,  /**< Set of points \since 1.0.0                        */
+    H5S_SEL_HYPERSLABS = 2,  /**< Hyperslab \since 1.0.0                            */
+    H5S_SEL_ALL        = 3,  /**< Everything \since 1.0.0                           */
+    H5S_SEL_N                /**< Sentinel \internal THIS MUST BE LAST \since 1.0.0 */
 } H5S_sel_type;
 
 #ifdef __cplusplus

--- a/src/H5Spublic.h
+++ b/src/H5Spublic.h
@@ -53,24 +53,24 @@
 #define H5S_MAX_RANK 32
 
 /* Flags for selection iterators */
-#define H5S_SEL_ITER_GET_SEQ_LIST_SORTED                                      \
-    0x0001 /**< Retrieve elements from iterator in increasing offset order, for
-            * each call to retrieve sequences. Currently, this only applies to
-            * point selections, as hyperslab selections are always returned in
-            * increasing offset order. Note that the order is only increasing
-            * for each call to H5Sget_seq_list(), the next set of sequences
-            * could start with an earlier offset than the previous one.
-            *
-            * \since 1.12.0
+#define H5S_SEL_ITER_GET_SEQ_LIST_SORTED                                                                     \
+    0x0001 /**< Retrieve elements from iterator in increasing offset order, for                              \
+            * each call to retrieve sequences. Currently, this only applies to                               \
+            * point selections, as hyperslab selections are always returned in                               \
+            * increasing offset order. Note that the order is only increasing                                \
+            * for each call to H5Sget_seq_list(), the next set of sequences                                  \
+            * could start with an earlier offset than the previous one.                                      \
+            *                                                                                                \
+            * \since 1.12.0                                                                                  \
             */
-#define H5S_SEL_ITER_SHARE_WITH_DATASPACE                                     \
-    0x0002 /**< Don't copy the dataspace selection when creating the selection
-            * iterator. This can improve performance of creating the iterator,
-            * but the dataspace \Bold{MUST NOT} be modified or closed until the
-            * selection iterator is closed or the iterator's behavior will be
-            * undefined.
-            *
-            * \since 1.12.0
+#define H5S_SEL_ITER_SHARE_WITH_DATASPACE                                                                    \
+    0x0002 /**< Don't copy the dataspace selection when creating the selection                               \
+            * iterator. This can improve performance of creating the iterator,                               \
+            * but the dataspace \Bold{MUST NOT} be modified or closed until the                              \
+            * selection iterator is closed or the iterator's behavior will be                                \
+            * undefined.                                                                                     \
+            *                                                                                                \
+            * \since 1.12.0                                                                                  \
             */
 
 /**

--- a/src/H5VLpublic.h
+++ b/src/H5VLpublic.h
@@ -38,70 +38,94 @@
 /* VOL connector identifier values
  * These are H5VL_class_value_t values, NOT hid_t values!
  */
-/**
- * \ingroup H5VLDEF
- * Invalid ID for VOL connector ID
- */
+/** Invalid ID for VOL connector ID \since 1.12.0 */
 #define H5_VOL_INVALID (-1)
-/**
- * \ingroup H5VLDEF
- * Native HDF5 file format VOL connector
- */
+/** Native HDF5 file format VOL connector \since 1.12.0 */
 #define H5_VOL_NATIVE 0
-/**
- * \ingroup H5VLDEF
- * VOL connector IDs below this value are reserved for library use
- */
+/** VOL connector IDs below this value are reserved for library use \since 1.12.0 */
 #define H5_VOL_RESERVED 256
-/**
- * \ingroup H5VLDEF
- * Maximum VOL connector ID
- */
+/** Maximum VOL connector ID \since 1.12.0 */
 #define H5_VOL_MAX 65535
 
 /*
  * Capability flags for VOL connectors
  */
-#define H5VL_CAP_FLAG_NONE          0x0000000000000000 /**< No special connector capabilities */
-#define H5VL_CAP_FLAG_THREADSAFE    0x0000000000000001 /**< Connector is threadsafe */
-#define H5VL_CAP_FLAG_ASYNC         0x0000000000000002 /**< Connector performs operations asynchronously*/
-#define H5VL_CAP_FLAG_NATIVE_FILES  0x0000000000000004 /**< Connector produces native file format */
-#define H5VL_CAP_FLAG_ATTR_BASIC    0x0000000000000008 /**< H5A create/delete/exists/open/close/read/write */
-#define H5VL_CAP_FLAG_ATTR_MORE     0x0000000000000010 /**< All other H5A API calls */
-#define H5VL_CAP_FLAG_DATASET_BASIC 0x0000000000000020 /**< H5D create/open/close/read/write */
-#define H5VL_CAP_FLAG_DATASET_MORE  0x0000000000000040 /**< All other H5D API calls */
-#define H5VL_CAP_FLAG_FILE_BASIC    0x0000000000000080 /**< H5F create/open/close/read/write */
-#define H5VL_CAP_FLAG_FILE_MORE     0x0000000000000100 /**< All other H5F API calls */
-#define H5VL_CAP_FLAG_GROUP_BASIC   0x0000000000000200 /**< H5G create/open/close */
-#define H5VL_CAP_FLAG_GROUP_MORE    0x0000000000000400 /**< All other H5G API calls*/
-#define H5VL_CAP_FLAG_LINK_BASIC    0x0000000000000800 /**< H5L exists/delete */
-#define H5VL_CAP_FLAG_LINK_MORE     0x0000000000001000 /**< All other H5L API calls */
-#define H5VL_CAP_FLAG_MAP_BASIC                                                                              \
-    0x0000000000002000 /**< H5M create/open/close/get*type/get_count/put/get/exists/delete */
-#define H5VL_CAP_FLAG_MAP_MORE         0x0000000000004000 /**< All other H5M API calls */
-#define H5VL_CAP_FLAG_OBJECT_BASIC     0x0000000000008000 /**< H5O open/close/exists */
-#define H5VL_CAP_FLAG_OBJECT_MORE      0x0000000000010000 /**< All other H5O API calls */
-#define H5VL_CAP_FLAG_REF_BASIC        0x0000000000020000 /**< H5Rdestroy */
-#define H5VL_CAP_FLAG_REF_MORE         0x0000000000040000 /**< All other H5R API calls */
-#define H5VL_CAP_FLAG_OBJ_REF          0x0000000000080000 /**< Connector supports object references */
-#define H5VL_CAP_FLAG_REG_REF          0x0000000000100000 /**< Connector supports regional references */
-#define H5VL_CAP_FLAG_ATTR_REF         0x0000000000200000 /**< Connector supports attribute references */
-#define H5VL_CAP_FLAG_STORED_DATATYPES 0x0000000000400000 /**< Connector supports stored datatypes */
-#define H5VL_CAP_FLAG_CREATION_ORDER   0x0000000000800000 /**< Connector tracks creation order */
-#define H5VL_CAP_FLAG_ITERATE          0x0000000001000000 /**< Connector supports iteration functions */
-#define H5VL_CAP_FLAG_STORAGE_SIZE     0x0000000002000000 /**< Connector can return a meaningful storage size */
-#define H5VL_CAP_FLAG_BY_IDX           0x0000000004000000 /**< "by index" API calls are supported */
-#define H5VL_CAP_FLAG_GET_PLIST                                                                              \
-    0x0000000008000000 /**< Connector can return the property lists used to create an object */
-#define H5VL_CAP_FLAG_FLUSH_REFRESH  0x0000000010000000 /**< flush/refresh calls are supported */
-#define H5VL_CAP_FLAG_EXTERNAL_LINKS 0x0000000020000000 /**< External links are supported */
-#define H5VL_CAP_FLAG_HARD_LINKS     0x0000000040000000 /**< Hard links are supported */
-#define H5VL_CAP_FLAG_SOFT_LINKS     0x0000000080000000 /**< Soft links are supported */
-#define H5VL_CAP_FLAG_UD_LINKS       0x0000000100000000 /**< User-defined links are supported */
-#define H5VL_CAP_FLAG_TRACK_TIMES    0x0000000200000000 /**< Connector tracks creation, etc. times */
-#define H5VL_CAP_FLAG_MOUNT          0x0000000400000000 /**< H5Fmount/unmount supported */
-#define H5VL_CAP_FLAG_FILTERS        0x0000000800000000 /**< Connector implements a filter pipeline */
-#define H5VL_CAP_FLAG_FILL_VALUES    0x0000001000000000 /**< Connector allows fill values to be set */
+/** No special connector capabilities \since 1.12.0 */
+#define H5VL_CAP_FLAG_NONE          0x0000000000000000
+/** Connector is threadsafe \since 1.12.0 */
+#define H5VL_CAP_FLAG_THREADSAFE    0x0000000000000001
+/** Connector performs operations asynchronously\since 1.12.0 */
+#define H5VL_CAP_FLAG_ASYNC         0x0000000000000002
+/** Connector produces native file format \since 1.12.0 */
+#define H5VL_CAP_FLAG_NATIVE_FILES  0x0000000000000004
+/** H5A create/delete/exists/open/close/read/write \since 1.12.0 */
+#define H5VL_CAP_FLAG_ATTR_BASIC    0x0000000000000008
+/** All other H5A API calls \since 1.12.0 */
+#define H5VL_CAP_FLAG_ATTR_MORE     0x0000000000000010
+/** H5D create/open/close/read/write \since 1.12.0 */
+#define H5VL_CAP_FLAG_DATASET_BASIC 0x0000000000000020
+/** All other H5D API calls \since 1.12.0 */
+#define H5VL_CAP_FLAG_DATASET_MORE  0x0000000000000040
+/** H5F create/open/close/read/write \since 1.12.0 */
+#define H5VL_CAP_FLAG_FILE_BASIC    0x0000000000000080
+/** All other H5F API calls \since 1.12.0 */
+#define H5VL_CAP_FLAG_FILE_MORE     0x0000000000000100
+/** H5G create/open/close \since 1.12.0 */
+#define H5VL_CAP_FLAG_GROUP_BASIC   0x0000000000000200
+/** All other H5G API calls\since 1.12.0 */
+#define H5VL_CAP_FLAG_GROUP_MORE    0x0000000000000400
+/** H5L exists/delete \since 1.12.0 */
+#define H5VL_CAP_FLAG_LINK_BASIC    0x0000000000000800
+/** All other H5L API calls \since 1.12.0 */
+#define H5VL_CAP_FLAG_LINK_MORE     0x0000000000001000
+/** H5M create/open/close/get*type/get_count/put/get/exists/delete \since 1.12.0 */
+#define H5VL_CAP_FLAG_MAP_BASIC     0x0000000000002000
+/** All other H5M API calls \since 1.12.0 */
+#define H5VL_CAP_FLAG_MAP_MORE         0x0000000000004000
+/** H5O open/close/exists \since 1.12.0 */
+#define H5VL_CAP_FLAG_OBJECT_BASIC     0x0000000000008000
+/** All other H5O API calls \since 1.12.0 */
+#define H5VL_CAP_FLAG_OBJECT_MORE      0x0000000000010000
+/** H5Rdestroy \since 1.12.0 */
+#define H5VL_CAP_FLAG_REF_BASIC        0x0000000000020000
+/** All other H5R API calls \since 1.12.0 */
+#define H5VL_CAP_FLAG_REF_MORE         0x0000000000040000
+/** Connector supports object references \since 1.12.0 */
+#define H5VL_CAP_FLAG_OBJ_REF          0x0000000000080000
+/** Connector supports regional references \since 1.12.0 */
+#define H5VL_CAP_FLAG_REG_REF          0x0000000000100000
+/** Connector supports attribute references \since 1.12.0 */
+#define H5VL_CAP_FLAG_ATTR_REF         0x0000000000200000
+/** Connector supports stored datatypes \since 1.12.0 */
+#define H5VL_CAP_FLAG_STORED_DATATYPES 0x0000000000400000
+/** Connector tracks creation order \since 1.12.0 */
+#define H5VL_CAP_FLAG_CREATION_ORDER   0x0000000000800000
+/** Connector supports iteration functions \since 1.12.0 */
+#define H5VL_CAP_FLAG_ITERATE          0x0000000001000000
+/** Connector can return a meaningful storage size \since 1.12.0 */
+#define H5VL_CAP_FLAG_STORAGE_SIZE     0x0000000002000000
+/** "by index" API calls are supported \since 1.12.0 */
+#define H5VL_CAP_FLAG_BY_IDX           0x0000000004000000
+/** Connector can return the property lists used to create an object \since 1.12.0 */
+#define H5VL_CAP_FLAG_GET_PLIST        0x0000000008000000
+/** flush/refresh calls are supported \since 1.12.0 */
+#define H5VL_CAP_FLAG_FLUSH_REFRESH  0x0000000010000000
+/** External links are supported \since 1.12.0 */
+#define H5VL_CAP_FLAG_EXTERNAL_LINKS 0x0000000020000000
+/** Hard links are supported \since 1.12.0 */
+#define H5VL_CAP_FLAG_HARD_LINKS     0x0000000040000000
+/** Soft links are supported \since 1.12.0 */
+#define H5VL_CAP_FLAG_SOFT_LINKS     0x0000000080000000
+/** User-defined links are supported \since 1.12.0 */
+#define H5VL_CAP_FLAG_UD_LINKS       0x0000000100000000
+/** Connector tracks creation, etc. times \since 1.12.0 */
+#define H5VL_CAP_FLAG_TRACK_TIMES    0x0000000200000000
+/** H5Fmount/unmount supported \since 1.12.0 */
+#define H5VL_CAP_FLAG_MOUNT          0x0000000400000000
+/** Connector implements a filter pipeline \since 1.12.0 */
+#define H5VL_CAP_FLAG_FILTERS        0x0000000800000000
+/** Connector allows fill values to be set \since 1.12.0 */
+#define H5VL_CAP_FLAG_FILL_VALUES    0x0000001000000000
 
 /**
  * \ingroup H5VLDEF
@@ -116,15 +140,22 @@
  *          the connector that registered it should assume that dataset elements
  *          for _any_ dataset in the file could be written to)
  */
-#define H5VL_OPT_QUERY_SUPPORTED       0x0001 /**< VOL connector supports this operation */
-#define H5VL_OPT_QUERY_READ_DATA       0x0002 /**< Operation reads data for object */
-#define H5VL_OPT_QUERY_WRITE_DATA      0x0004 /**< Operation writes data for object */
-#define H5VL_OPT_QUERY_QUERY_METADATA  0x0008 /**< Operation reads metadata for object */
-#define H5VL_OPT_QUERY_MODIFY_METADATA 0x0010 /**< Operation modifies metadata for object */
-#define H5VL_OPT_QUERY_COLLECTIVE                                                                            \
-    0x0020 /**< Operation is collective (operations without this flag are assumed to be independent) */
-#define H5VL_OPT_QUERY_NO_ASYNC  0x0040 /**< Operation may NOT be executed asynchronously */
-#define H5VL_OPT_QUERY_MULTI_OBJ 0x0080 /**< Operation involves multiple objects */
+/** VOL connector supports this operation \since 1.14.0 */
+#define H5VL_OPT_QUERY_SUPPORTED       0x0001
+/** Operation reads data for object \since 1.14.0 */
+#define H5VL_OPT_QUERY_READ_DATA       0x0002
+/** Operation writes data for object \since 1.14.0 */
+#define H5VL_OPT_QUERY_WRITE_DATA      0x0004
+/** Operation reads metadata for object \since 1.14.0 */
+#define H5VL_OPT_QUERY_QUERY_METADATA  0x0008
+/** Operation modifies metadata for object \since 1.14.0 */
+#define H5VL_OPT_QUERY_MODIFY_METADATA 0x0010
+/** Operation is collective (operations without this flag are assumed to be independent) \since 1.14.0 */
+#define H5VL_OPT_QUERY_COLLECTIVE      0x0020
+/** Operation may NOT be executed asynchronously \since 1.14.0 */
+#define H5VL_OPT_QUERY_NO_ASYNC        0x0040
+/** Operation involves multiple objects \since 1.14.0 */
+#define H5VL_OPT_QUERY_MULTI_OBJ       0x0080
 
 /*******************/
 /* Public Typedefs */

--- a/src/H5VLpublic.h
+++ b/src/H5VLpublic.h
@@ -51,81 +51,81 @@
  * Capability flags for VOL connectors
  */
 /** No special connector capabilities \since 1.12.0 */
-#define H5VL_CAP_FLAG_NONE          0x0000000000000000
+#define H5VL_CAP_FLAG_NONE 0x0000000000000000
 /** Connector is threadsafe \since 1.12.0 */
-#define H5VL_CAP_FLAG_THREADSAFE    0x0000000000000001
+#define H5VL_CAP_FLAG_THREADSAFE 0x0000000000000001
 /** Connector performs operations asynchronously\since 1.12.0 */
-#define H5VL_CAP_FLAG_ASYNC         0x0000000000000002
+#define H5VL_CAP_FLAG_ASYNC 0x0000000000000002
 /** Connector produces native file format \since 1.12.0 */
-#define H5VL_CAP_FLAG_NATIVE_FILES  0x0000000000000004
+#define H5VL_CAP_FLAG_NATIVE_FILES 0x0000000000000004
 /** H5A create/delete/exists/open/close/read/write \since 1.12.0 */
-#define H5VL_CAP_FLAG_ATTR_BASIC    0x0000000000000008
+#define H5VL_CAP_FLAG_ATTR_BASIC 0x0000000000000008
 /** All other H5A API calls \since 1.12.0 */
-#define H5VL_CAP_FLAG_ATTR_MORE     0x0000000000000010
+#define H5VL_CAP_FLAG_ATTR_MORE 0x0000000000000010
 /** H5D create/open/close/read/write \since 1.12.0 */
 #define H5VL_CAP_FLAG_DATASET_BASIC 0x0000000000000020
 /** All other H5D API calls \since 1.12.0 */
-#define H5VL_CAP_FLAG_DATASET_MORE  0x0000000000000040
+#define H5VL_CAP_FLAG_DATASET_MORE 0x0000000000000040
 /** H5F create/open/close/read/write \since 1.12.0 */
-#define H5VL_CAP_FLAG_FILE_BASIC    0x0000000000000080
+#define H5VL_CAP_FLAG_FILE_BASIC 0x0000000000000080
 /** All other H5F API calls \since 1.12.0 */
-#define H5VL_CAP_FLAG_FILE_MORE     0x0000000000000100
+#define H5VL_CAP_FLAG_FILE_MORE 0x0000000000000100
 /** H5G create/open/close \since 1.12.0 */
-#define H5VL_CAP_FLAG_GROUP_BASIC   0x0000000000000200
+#define H5VL_CAP_FLAG_GROUP_BASIC 0x0000000000000200
 /** All other H5G API calls\since 1.12.0 */
-#define H5VL_CAP_FLAG_GROUP_MORE    0x0000000000000400
+#define H5VL_CAP_FLAG_GROUP_MORE 0x0000000000000400
 /** H5L exists/delete \since 1.12.0 */
-#define H5VL_CAP_FLAG_LINK_BASIC    0x0000000000000800
+#define H5VL_CAP_FLAG_LINK_BASIC 0x0000000000000800
 /** All other H5L API calls \since 1.12.0 */
-#define H5VL_CAP_FLAG_LINK_MORE     0x0000000000001000
+#define H5VL_CAP_FLAG_LINK_MORE 0x0000000000001000
 /** H5M create/open/close/get*type/get_count/put/get/exists/delete \since 1.12.0 */
-#define H5VL_CAP_FLAG_MAP_BASIC     0x0000000000002000
+#define H5VL_CAP_FLAG_MAP_BASIC 0x0000000000002000
 /** All other H5M API calls \since 1.12.0 */
-#define H5VL_CAP_FLAG_MAP_MORE         0x0000000000004000
+#define H5VL_CAP_FLAG_MAP_MORE 0x0000000000004000
 /** H5O open/close/exists \since 1.12.0 */
-#define H5VL_CAP_FLAG_OBJECT_BASIC     0x0000000000008000
+#define H5VL_CAP_FLAG_OBJECT_BASIC 0x0000000000008000
 /** All other H5O API calls \since 1.12.0 */
-#define H5VL_CAP_FLAG_OBJECT_MORE      0x0000000000010000
+#define H5VL_CAP_FLAG_OBJECT_MORE 0x0000000000010000
 /** H5Rdestroy \since 1.12.0 */
-#define H5VL_CAP_FLAG_REF_BASIC        0x0000000000020000
+#define H5VL_CAP_FLAG_REF_BASIC 0x0000000000020000
 /** All other H5R API calls \since 1.12.0 */
-#define H5VL_CAP_FLAG_REF_MORE         0x0000000000040000
+#define H5VL_CAP_FLAG_REF_MORE 0x0000000000040000
 /** Connector supports object references \since 1.12.0 */
-#define H5VL_CAP_FLAG_OBJ_REF          0x0000000000080000
+#define H5VL_CAP_FLAG_OBJ_REF 0x0000000000080000
 /** Connector supports regional references \since 1.12.0 */
-#define H5VL_CAP_FLAG_REG_REF          0x0000000000100000
+#define H5VL_CAP_FLAG_REG_REF 0x0000000000100000
 /** Connector supports attribute references \since 1.12.0 */
-#define H5VL_CAP_FLAG_ATTR_REF         0x0000000000200000
+#define H5VL_CAP_FLAG_ATTR_REF 0x0000000000200000
 /** Connector supports stored datatypes \since 1.12.0 */
 #define H5VL_CAP_FLAG_STORED_DATATYPES 0x0000000000400000
 /** Connector tracks creation order \since 1.12.0 */
-#define H5VL_CAP_FLAG_CREATION_ORDER   0x0000000000800000
+#define H5VL_CAP_FLAG_CREATION_ORDER 0x0000000000800000
 /** Connector supports iteration functions \since 1.12.0 */
-#define H5VL_CAP_FLAG_ITERATE          0x0000000001000000
+#define H5VL_CAP_FLAG_ITERATE 0x0000000001000000
 /** Connector can return a meaningful storage size \since 1.12.0 */
-#define H5VL_CAP_FLAG_STORAGE_SIZE     0x0000000002000000
+#define H5VL_CAP_FLAG_STORAGE_SIZE 0x0000000002000000
 /** "by index" API calls are supported \since 1.12.0 */
-#define H5VL_CAP_FLAG_BY_IDX           0x0000000004000000
+#define H5VL_CAP_FLAG_BY_IDX 0x0000000004000000
 /** Connector can return the property lists used to create an object \since 1.12.0 */
-#define H5VL_CAP_FLAG_GET_PLIST        0x0000000008000000
+#define H5VL_CAP_FLAG_GET_PLIST 0x0000000008000000
 /** flush/refresh calls are supported \since 1.12.0 */
-#define H5VL_CAP_FLAG_FLUSH_REFRESH  0x0000000010000000
+#define H5VL_CAP_FLAG_FLUSH_REFRESH 0x0000000010000000
 /** External links are supported \since 1.12.0 */
 #define H5VL_CAP_FLAG_EXTERNAL_LINKS 0x0000000020000000
 /** Hard links are supported \since 1.12.0 */
-#define H5VL_CAP_FLAG_HARD_LINKS     0x0000000040000000
+#define H5VL_CAP_FLAG_HARD_LINKS 0x0000000040000000
 /** Soft links are supported \since 1.12.0 */
-#define H5VL_CAP_FLAG_SOFT_LINKS     0x0000000080000000
+#define H5VL_CAP_FLAG_SOFT_LINKS 0x0000000080000000
 /** User-defined links are supported \since 1.12.0 */
-#define H5VL_CAP_FLAG_UD_LINKS       0x0000000100000000
+#define H5VL_CAP_FLAG_UD_LINKS 0x0000000100000000
 /** Connector tracks creation, etc. times \since 1.12.0 */
-#define H5VL_CAP_FLAG_TRACK_TIMES    0x0000000200000000
+#define H5VL_CAP_FLAG_TRACK_TIMES 0x0000000200000000
 /** H5Fmount/unmount supported \since 1.12.0 */
-#define H5VL_CAP_FLAG_MOUNT          0x0000000400000000
+#define H5VL_CAP_FLAG_MOUNT 0x0000000400000000
 /** Connector implements a filter pipeline \since 1.12.0 */
-#define H5VL_CAP_FLAG_FILTERS        0x0000000800000000
+#define H5VL_CAP_FLAG_FILTERS 0x0000000800000000
 /** Connector allows fill values to be set \since 1.12.0 */
-#define H5VL_CAP_FLAG_FILL_VALUES    0x0000001000000000
+#define H5VL_CAP_FLAG_FILL_VALUES 0x0000001000000000
 
 /**
  * \ingroup H5VLDEF
@@ -141,21 +141,21 @@
  *          for _any_ dataset in the file could be written to)
  */
 /** VOL connector supports this operation \since 1.14.0 */
-#define H5VL_OPT_QUERY_SUPPORTED       0x0001
+#define H5VL_OPT_QUERY_SUPPORTED 0x0001
 /** Operation reads data for object \since 1.14.0 */
-#define H5VL_OPT_QUERY_READ_DATA       0x0002
+#define H5VL_OPT_QUERY_READ_DATA 0x0002
 /** Operation writes data for object \since 1.14.0 */
-#define H5VL_OPT_QUERY_WRITE_DATA      0x0004
+#define H5VL_OPT_QUERY_WRITE_DATA 0x0004
 /** Operation reads metadata for object \since 1.14.0 */
-#define H5VL_OPT_QUERY_QUERY_METADATA  0x0008
+#define H5VL_OPT_QUERY_QUERY_METADATA 0x0008
 /** Operation modifies metadata for object \since 1.14.0 */
 #define H5VL_OPT_QUERY_MODIFY_METADATA 0x0010
 /** Operation is collective (operations without this flag are assumed to be independent) \since 1.14.0 */
-#define H5VL_OPT_QUERY_COLLECTIVE      0x0020
+#define H5VL_OPT_QUERY_COLLECTIVE 0x0020
 /** Operation may NOT be executed asynchronously \since 1.14.0 */
-#define H5VL_OPT_QUERY_NO_ASYNC        0x0040
+#define H5VL_OPT_QUERY_NO_ASYNC 0x0040
 /** Operation involves multiple objects \since 1.14.0 */
-#define H5VL_OPT_QUERY_MULTI_OBJ       0x0080
+#define H5VL_OPT_QUERY_MULTI_OBJ 0x0080
 
 /*******************/
 /* Public Typedefs */

--- a/src/H5public.h
+++ b/src/H5public.h
@@ -419,6 +419,8 @@ typedef struct H5_ih_info_t {
  * \details Tokens are unique and permanent identifiers that are
  *          used to reference HDF5 objects in a container. This allows
  *          for 128-bit tokens
+ *
+ * \since 1.12.0
  */
 #define H5O_MAX_TOKEN_SIZE (16)
 


### PR DESCRIPTION
- Added \since to enum constants added in 1.12.x versions
- Removed unnecessary continuation backslashes in doxygen comments

(Partial fix of GH-4408)