### PR TITLE
Add release information to enum constants - Part 3 cont.

### DIFF
--- a/src/H5Epublic.h
+++ b/src/H5Epublic.h
@@ -21,7 +21,7 @@
 #include "H5public.h"  /* Generic Functions                        */
 #include "H5Ipublic.h" /* Identifiers                              */
 
-/* Value for the default error stack */
+/** Value for the default error stack \since 1.12.2 */
 #define H5E_DEFAULT 0 /* (hid_t) */
 
 /**

--- a/src/H5Fpublic.h
+++ b/src/H5Fpublic.h
@@ -59,7 +59,7 @@
 #define H5F_OBJ_DATATYPE (0x0008u) /**< Datatype objects \since 1.6.0 */
 #define H5F_OBJ_ATTR     (0x0010u) /**< Attribute objects \since 1.6.0 */
 /** All objects \since 1.6.0 */
-#define H5F_OBJ_ALL      (H5F_OBJ_FILE | H5F_OBJ_DATASET | H5F_OBJ_GROUP | H5F_OBJ_DATATYPE | H5F_OBJ_ATTR)
+#define H5F_OBJ_ALL (H5F_OBJ_FILE | H5F_OBJ_DATASET | H5F_OBJ_GROUP | H5F_OBJ_DATATYPE | H5F_OBJ_ATTR)
 
 /**
  * Restrict search to objects opened through current file ID (as opposed to

--- a/src/H5Fpublic.h
+++ b/src/H5Fpublic.h
@@ -44,24 +44,31 @@
                * also open the file with the #H5F_ACC_RDONLY flag.  */
 
 /**
- * Default property list identifier
+ * Default file access
  *
  * \internal Value passed to H5Pset_elink_acc_flags to cause flags to be taken from the parent file.
  * \internal ignore setting on lapl
+ * \since 1.8.3
  */
 #define H5F_ACC_DEFAULT (0xffffu)
 
 /* Flags for H5Fget_obj_count() & H5Fget_obj_ids() calls */
-#define H5F_OBJ_FILE     (0x0001u) /**< File objects */
-#define H5F_OBJ_DATASET  (0x0002u) /**< Dataset objects */
-#define H5F_OBJ_GROUP    (0x0004u) /**< Group objects */
-#define H5F_OBJ_DATATYPE (0x0008u) /**< Datatype objects */
-#define H5F_OBJ_ATTR     (0x0010u) /**< Attribute objects */
+#define H5F_OBJ_FILE     (0x0001u) /**< File objects \since 1.6.0 */
+#define H5F_OBJ_DATASET  (0x0002u) /**< Dataset objects \since 1.6.0 */
+#define H5F_OBJ_GROUP    (0x0004u) /**< Group objects \since 1.6.0 */
+#define H5F_OBJ_DATATYPE (0x0008u) /**< Datatype objects \since 1.6.0 */
+#define H5F_OBJ_ATTR     (0x0010u) /**< Attribute objects \since 1.6.0 */
+/** All objects \since 1.6.0 */
 #define H5F_OBJ_ALL      (H5F_OBJ_FILE | H5F_OBJ_DATASET | H5F_OBJ_GROUP | H5F_OBJ_DATATYPE | H5F_OBJ_ATTR)
-#define H5F_OBJ_LOCAL                                                                                        \
-    (0x0020u) /**< Restrict search to objects opened through current file ID                                 \
-                   (as opposed to objects opened through any file ID accessing this file) */
 
+/**
+ * Restrict search to objects opened through current file ID (as opposed to
+ * objects opened through any file ID accessing this file) \since 1.6.5 */
+#define H5F_OBJ_LOCAL (0x0020u)
+
+/**
+ * Default value to pass into H5Pset_fapl_family() when the size of each file
+ * member is unknown \since 1.8.0 */
 #define H5F_FAMILY_DEFAULT 0 /* (hsize_t) */
 
 #ifdef H5_HAVE_PARALLEL

--- a/src/H5Lpublic.h
+++ b/src/H5Lpublic.h
@@ -30,16 +30,10 @@
 /* Public Macros */
 /*****************/
 
-/**
- * \brief Maximum length of a link's name
- *
- * The maximum length of a link's name is encoded in a 32-bit unsigned integer.
- */
+/** Maximum length of a link's name \since 1.8.0 */
 #define H5L_MAX_LINK_NAME_LEN UINT32_MAX
 
-/**
- * \brief Macro to indicate operation occurs on same location
- */
+/** Macro to indicate operation occurs on same location \since 1.8.0 */
 #define H5L_SAME_LOC 0 /* (hid_t) */
 
 #ifdef __cplusplus
@@ -67,17 +61,12 @@ typedef enum {
     H5L_TYPE_EXTERNAL = 64,   /**< External link id             */
     H5L_TYPE_MAX      = 255   /**< Maximum link type id         */
 } H5L_type_t;
-/**
- * \brief  Maximum value link value for "built-in" link types
- */
+
+/** Maximum value link value for "built-in" link types \since 1.8.0 */
 #define H5L_TYPE_BUILTIN_MAX H5L_TYPE_SOFT
-/**
- * \brief Link ids at or above this value are "user-defined" link types.
- */
+/** Link ids at or above this value are "user-defined" link types. \since 1.8.0 */
 #define H5L_TYPE_UD_MIN H5L_TYPE_EXTERNAL
-/**
- * \brief Maximum link id value for "user-defined" link types.
- */
+/** Maximum link id value for "user-defined" link types. \since 1.12.1 */
 #define H5L_TYPE_UD_MAX H5L_TYPE_MAX
 
 /**

--- a/src/H5Ppublic.h
+++ b/src/H5Ppublic.h
@@ -215,7 +215,7 @@
  */
 #define H5P_CRT_ORDER_INDEXED 0x0002
 /**
- * Default value of type \ref hid_t for all property list classes
+ * Default value of type \ref hid_t for all property list classes \since 1.0.0
  */
 #define H5P_DEFAULT 0 /* (hid_t) */
 


### PR DESCRIPTION
This PR contains the constants in releases 1.12.1-1.12.3 that were missing in the previous Part 3 PR, plus some 1.6 and 1.8 as they were obvious.  (I'm messing up my own PR system for this issue...)

(Partial fix of https://github.com/HDFGroup/hdf5/issues/4408)