### PR TITLE
Correct H5T_decode return value description

### DIFF
--- a/src/H5T.c
+++ b/src/H5T.c
@@ -3794,9 +3794,9 @@ done:
  * Purpose:   Private function for H5Tdecode.  Reconstructs a binary
  *            description of datatype and returns a new object handle.
  *
- * Return:    Success:    datatype ID(non-negative)
+ * Return:    Success:    Pointer to the new type.
  *
- *            Failure:    negative
+ *            Failure:    NULL
  *
  *-------------------------------------------------------------------------
  */


### PR DESCRIPTION
The 'return' field in the comment appears to have been copied from `H5Tdecode()`, which has a different return type.