### PR TITLE
cmake: do not override cmake rpath defines

### DIFF
--- a/HDF5Examples/config/cmake/HDFMacros.cmake
+++ b/HDF5Examples/config/cmake/HDFMacros.cmake
@@ -169,26 +169,6 @@ macro (HDF_DIR_PATHS package_prefix)
   endif ()
   message(STATUS "Final: ${${package_prefix}_INSTALL_DOC_DIR}")
 
-  # Always use full RPATH, i.e. don't skip the full RPATH for the build tree
-  set (CMAKE_SKIP_BUILD_RPATH  OFF)
-  # when building, don't use the install RPATH already
-  # (but later on when installing)
-  set (CMAKE_INSTALL_RPATH_USE_LINK_PATH  OFF)
-  # add the automatically determined parts of the RPATH
-  # which point to directories outside the build tree to the install RPATH
-  set (CMAKE_BUILD_WITH_INSTALL_RPATH ON)
-  if (APPLE)
-    set (CMAKE_INSTALL_NAME_DIR "@rpath")
-    set (CMAKE_INSTALL_RPATH
-        "@executable_path/../${${package_prefix}_INSTALL_LIB_DIR}"
-        "@executable_path/"
-        "@loader_path/../${${package_prefix}_INSTALL_LIB_DIR}"
-        "@loader_path/"
-    )
-  else ()
-    set (CMAKE_INSTALL_RPATH "\$ORIGIN/../${${package_prefix}_INSTALL_LIB_DIR}:\$ORIGIN/")
-  endif ()
-
   if (DEFINED ADDITIONAL_CMAKE_PREFIX_PATH AND EXISTS "${ADDITIONAL_CMAKE_PREFIX_PATH}")
     set (CMAKE_PREFIX_PATH ${ADDITIONAL_CMAKE_PREFIX_PATH} ${CMAKE_PREFIX_PATH})
   endif ()

--- a/config/cmake/HDF5Macros.cmake
+++ b/config/cmake/HDF5Macros.cmake
@@ -35,29 +35,6 @@ macro (H5_SET_LIB_OPTIONS libtarget libname libtype libpackage)
     endif ()
   endif ()
   HDF_SET_LIB_OPTIONS (${libtarget} ${LIB_OUT_NAME} ${libtype})
-
-  #-- Apple Specific install_name for libraries
-  if (APPLE)
-    option (HDF5_BUILD_WITH_INSTALL_NAME "Build with library install_name set to the installation path" OFF)
-    if (HDF5_BUILD_WITH_INSTALL_NAME)
-      set_target_properties (${libtarget} PROPERTIES
-          INSTALL_NAME_DIR "${CMAKE_INSTALL_PREFIX}/lib"
-          BUILD_WITH_INSTALL_RPATH ${HDF5_BUILD_WITH_INSTALL_NAME}
-      )
-    endif ()
-    if (HDF5_BUILD_FRAMEWORKS)
-      if (${libtype} MATCHES "SHARED")
-        # adapt target to build frameworks instead of dylibs
-        set_target_properties(${libtarget} PROPERTIES
-            XCODE_ATTRIBUTE_INSTALL_PATH "@rpath"
-            FRAMEWORK TRUE
-            FRAMEWORK_VERSION ${HDF5_PACKAGE_VERSION_MAJOR}
-            MACOSX_FRAMEWORK_IDENTIFIER org.hdfgroup.${libtarget}
-            MACOSX_FRAMEWORK_SHORT_VERSION_STRING ${HDF5_PACKAGE_VERSION_MAJOR}
-            MACOSX_FRAMEWORK_BUNDLE_VERSION ${HDF5_PACKAGE_VERSION_MAJOR})
-      endif ()
-    endif ()
-  endif ()
 endmacro ()
 
 # Initialize the list of VFDs to be used for testing and create a test folder for each VFD

--- a/config/cmake/HDFMacros.cmake
+++ b/config/cmake/HDFMacros.cmake
@@ -458,26 +458,6 @@ macro (HDF_DIR_PATHS package_prefix)
   endif ()
   message(STATUS "Final: ${${package_prefix}_INSTALL_DOC_DIR}")
 
-  # Always use full RPATH, i.e. don't skip the full RPATH for the build tree
-  set (CMAKE_SKIP_BUILD_RPATH  OFF)
-  # when building, don't use the install RPATH already
-  # (but later on when installing)
-  set (CMAKE_INSTALL_RPATH_USE_LINK_PATH  OFF)
-  # add the automatically determined parts of the RPATH
-  # which point to directories outside the build tree to the install RPATH
-  set (CMAKE_BUILD_WITH_INSTALL_RPATH ON)
-  if (APPLE)
-    set (CMAKE_INSTALL_NAME_DIR "@rpath")
-    set (CMAKE_INSTALL_RPATH
-        "@executable_path/../${${package_prefix}_INSTALL_LIB_DIR}"
-        "@executable_path/"
-        "@loader_path/../${${package_prefix}_INSTALL_LIB_DIR}"
-        "@loader_path/"
-    )
-  else ()
-    set (CMAKE_INSTALL_RPATH "\$ORIGIN/../${${package_prefix}_INSTALL_LIB_DIR}:\$ORIGIN/")
-  endif ()
-
   if (DEFINED ADDITIONAL_CMAKE_PREFIX_PATH AND EXISTS "${ADDITIONAL_CMAKE_PREFIX_PATH}")
     set (CMAKE_PREFIX_PATH ${ADDITIONAL_CMAKE_PREFIX_PATH} ${CMAKE_PREFIX_PATH})
   endif ()

--- a/config/cmake/examples/CTestScript.cmake
+++ b/config/cmake/examples/CTestScript.cmake
@@ -73,7 +73,7 @@ if (APPLE)
   set (ENV{CC} "${XCODE_CC}")
   set (ENV{CXX} "${XCODE_CXX}")
 
-  set (BUILD_OPTIONS "${BUILD_OPTIONS} -DCTEST_USE_LAUNCHERS:BOOL=ON -DCMAKE_BUILD_WITH_INSTALL_RPATH:BOOL=OFF")
+  set (BUILD_OPTIONS "${BUILD_OPTIONS} -DCTEST_USE_LAUNCHERS:BOOL=ON")
 endif ()
 
 #-----------------------------------------------------------------------------

--- a/config/cmake/scripts/CTestScript.cmake
+++ b/config/cmake/scripts/CTestScript.cmake
@@ -73,7 +73,7 @@ if (APPLE)
   set (ENV{CC} "${XCODE_CC}")
   set (ENV{CXX} "${XCODE_CXX}")
 
-  set (BUILD_OPTIONS "${BUILD_OPTIONS} -DCTEST_USE_LAUNCHERS:BOOL=ON -DCMAKE_BUILD_WITH_INSTALL_RPATH:BOOL=OFF")
+  set (BUILD_OPTIONS "${BUILD_OPTIONS} -DCTEST_USE_LAUNCHERS:BOOL=ON")
 endif ()
 
 #-----------------------------------------------------------------------------

--- a/release_docs/INSTALL_CMake.txt
+++ b/release_docs/INSTALL_CMake.txt
@@ -380,7 +380,6 @@ IV. Further considerations
           Additional options:
             CMAKE_ANSI_CFLAGS:STRING=-fPIC
             CTEST_USE_LAUNCHERS:BOOL=ON
-            CMAKE_BUILD_WITH_INSTALL_RPATH:BOOL=OFF
 
    5. Windows developers should install NSIS or WiX to create an install image with CPack.
       Visual Studio Express users will not be able to package HDF5 into


### PR DESCRIPTION
## Describe your changes

This removes overriding the values of

- `CMAKE_INSTALL_RPATH_USE_LINK_PATH` Some package managers (e.g. Spack package manager) set this to `ON` to get automatic rpaths to e.g. `libmpi.so` and `libz.so` if they are in non-standard locations.
- `CMAKE_SKIP_BUILD_RPATH` / `CMAKE_BUILD_WITH_INSTALL_RPATH`: they're redundant, just use the defaults to follow the principle of least astonishment. If you ever run a just-built executable during the build, then leaving those to the standard value is better, since you don't really know where the executables/libraries reside during the build.
- `CMAKE_INSTALL_NAME_DIR`: this was a workaround for CMake < 3 on macOS. As of CMake 3, it's the default, see [CMP0042](https://cmake.org/cmake/help/latest/policy/CMP0042.html).
- `CMAKE_INSTALL_RPATH`. Setting this variable overrides what the user passes through `-DCMAKE_INSTALL_RPATH`. This PR results in `$ORIGIN` and `$ORIGIN/../lib` being dropped from install rpaths. These rpaths are not desirable on certain distros where the libs are installed in default search locations, and lookup in the ld.so cache is better. Currently, users cannot opt out of these rpaths. With this change, it's opt-in by passing `-DCMAKE_INSTALL_RPATH=<install prefix>/lib` if they install to non-standard location, like they would already do for every other CMake project out there.*

\* if this project really insists on $ORIGIN type rpaths for locating libraries in hdf5's own install prefix, then I would suggest to make it a target property instead or use `list(APPEND ...)` instead of overriding the user value.
 
The reason for this changes is: the user knows better than the build system whether or not install rpaths are needed and what they should be. The build system does not know whether the install prefix is "non-standard" or if rpaths to dependencies are desirable. The rpath logic of HDF5 is opinionated, and has no opt-out, does not deal with dependencies like zlib / mpi / etc in non-standard directories, and is somewhat outdated w.r.t. macOS.

## Issue ticket number (GitHub or JIRA)

## Checklist before requesting a review
- [ ] My code conforms to the guidelines in CONTRIBUTING.md
- [ ] I made an entry in release_docs/RELEASE.txt (bug fixes, new features)
- [ ] I added a test (bug fixes, new features)
