### PR TITLE
Add new -testexpress option to testframe testing framework

### DIFF
--- a/test/btree2.c
+++ b/test/btree2.c
@@ -9928,10 +9928,10 @@ main(void)
     localTestExpress = h5_get_testexpress();
 
     /* For the Direct I/O driver, skip intensive tests due to poor performance */
-    if (localTestExpress < 2 && !strcmp(driver_name, "direct"))
-        localTestExpress = 2;
+    if (localTestExpress < H5_TEST_EXPRESS_QUICK && !strcmp(driver_name, "direct"))
+        localTestExpress = H5_TEST_EXPRESS_QUICK;
 
-    if (localTestExpress > 0)
+    if (localTestExpress > H5_TEST_EXPRESS_EXHAUSTIVE)
         printf("***Express test mode %d.  Some tests may be skipped\n", localTestExpress);
 
     /* Initialize v2 B-tree creation parameters */
@@ -9968,7 +9968,7 @@ main(void)
         nerrors += test_insert_level2_2internal_split(fapl, &cparam, &tparam);
         nerrors += test_insert_level2_3internal_redistrib(fapl, &cparam, &tparam);
         nerrors += test_insert_level2_3internal_split(fapl, &cparam, &tparam);
-        if (localTestExpress > 1)
+        if (localTestExpress > H5_TEST_EXPRESS_FULL)
             printf("***Express test mode on.  test_insert_lots skipped\n");
         else
             nerrors += test_insert_lots(fapl, &cparam, &tparam);
@@ -9982,7 +9982,7 @@ main(void)
         nerrors += test_update_level1_3leaf_redistrib(fapl, &cparam2, &tparam);
         nerrors += test_update_level1_middle_split(fapl, &cparam2, &tparam);
         nerrors += test_update_make_level2(fapl, &cparam2, &tparam);
-        if (localTestExpress > 1)
+        if (localTestExpress > H5_TEST_EXPRESS_FULL)
             printf("***Express test mode on.  test_update_lots skipped\n");
         else
             nerrors += test_update_lots(fapl, &cparam2, &tparam);
@@ -10009,7 +10009,7 @@ main(void)
         nerrors += test_remove_level2_2internal_merge_right(fapl, &cparam, &tparam);
         nerrors += test_remove_level2_3internal_merge(fapl, &cparam, &tparam);
         nerrors += test_remove_level2_collapse_right(fapl, &cparam, &tparam);
-        if (localTestExpress > 1)
+        if (localTestExpress > H5_TEST_EXPRESS_FULL)
             printf("***Express test mode on.  test_remove_lots skipped\n");
         else
             nerrors += test_remove_lots(driver_name, fapl, &cparam);

--- a/test/cache.c
+++ b/test/cache.c
@@ -262,22 +262,22 @@ smoke_check_1(int express_test, unsigned paged)
     else
         TESTING("smoke check #1 -- all clean, ins, dest, ren, 4/2 MB cache");
 
-    if (paged && (express_test > 0)) {
+    if (paged && (express_test > H5_TEST_EXPRESS_EXHAUSTIVE)) {
 
         SKIPPED();
         return (0);
     }
 
     switch (express_test) {
-        case 0:
+        case H5_TEST_EXPRESS_EXHAUSTIVE:
             max_index = (10 * 1024) - 1;
             break;
 
-        case 1:
+        case H5_TEST_EXPRESS_FULL:
             max_index = (1 * 1024) - 1;
             break;
 
-        case 2:
+        case H5_TEST_EXPRESS_QUICK:
             max_index = (512) - 1;
             break;
 
@@ -457,22 +457,22 @@ smoke_check_2(int express_test, unsigned paged)
     else
         TESTING("smoke check #2 -- ~1/2 dirty, ins, dest, ren, 4/2 MB cache");
 
-    if (paged && (express_test > 0)) {
+    if (paged && (express_test > H5_TEST_EXPRESS_EXHAUSTIVE)) {
 
         SKIPPED();
         return (0);
     }
 
     switch (express_test) {
-        case 0:
+        case H5_TEST_EXPRESS_EXHAUSTIVE:
             max_index = (10 * 1024) - 1;
             break;
 
-        case 1:
+        case H5_TEST_EXPRESS_FULL:
             max_index = (1 * 1024) - 1;
             break;
 
-        case 2:
+        case H5_TEST_EXPRESS_QUICK:
             max_index = (512) - 1;
             break;
 
@@ -651,22 +651,22 @@ smoke_check_3(int express_test, unsigned paged)
     else
         TESTING("smoke check #3 -- all clean, ins, dest, ren, 2/1 KB cache");
 
-    if (paged && (express_test > 0)) {
+    if (paged && (express_test > H5_TEST_EXPRESS_EXHAUSTIVE)) {
 
         SKIPPED();
         return (0);
     }
 
     switch (express_test) {
-        case 0:
+        case H5_TEST_EXPRESS_EXHAUSTIVE:
             max_index = (10 * 1024) - 1;
             break;
 
-        case 1:
+        case H5_TEST_EXPRESS_FULL:
             max_index = (1 * 1024) - 1;
             break;
 
-        case 2:
+        case H5_TEST_EXPRESS_QUICK:
             max_index = (512) - 1;
             break;
 
@@ -846,22 +846,22 @@ smoke_check_4(int express_test, unsigned paged)
     else
         TESTING("smoke check #4 -- ~1/2 dirty, ins, dest, ren, 2/1 KB cache");
 
-    if (paged && (express_test > 0)) {
+    if (paged && (express_test > H5_TEST_EXPRESS_EXHAUSTIVE)) {
 
         SKIPPED();
         return (0);
     }
 
     switch (express_test) {
-        case 0:
+        case H5_TEST_EXPRESS_EXHAUSTIVE:
             max_index = (10 * 1024) - 1;
             break;
 
-        case 1:
+        case H5_TEST_EXPRESS_FULL:
             max_index = (1 * 1024) - 1;
             break;
 
-        case 2:
+        case H5_TEST_EXPRESS_QUICK:
             max_index = (512) - 1;
             break;
 
@@ -1081,22 +1081,22 @@ smoke_check_5(int express_test, unsigned paged)
     else
         TESTING("smoke check #5 -- all clean, ins, prot, unprot, AR cache 1");
 
-    if (paged && (express_test > 0)) {
+    if (paged && (express_test > H5_TEST_EXPRESS_EXHAUSTIVE)) {
 
         SKIPPED();
         return (0);
     }
 
     switch (express_test) {
-        case 0:
+        case H5_TEST_EXPRESS_EXHAUSTIVE:
             max_index = (10 * 1024) - 1;
             break;
 
-        case 1:
+        case H5_TEST_EXPRESS_FULL:
             max_index = (1 * 1024) - 1;
             break;
 
-        case 2:
+        case H5_TEST_EXPRESS_QUICK:
             max_index = (512) - 1;
             break;
 
@@ -1305,7 +1305,7 @@ smoke_check_6(int express_test, unsigned paged)
     else
         TESTING("smoke check #6 -- ~1/2 dirty, ins, prot, unprot, AR cache 1");
 
-    if (paged && (express_test > 0)) {
+    if (paged && (express_test > H5_TEST_EXPRESS_EXHAUSTIVE)) {
 
         SKIPPED();
         return (0);
@@ -1314,15 +1314,15 @@ smoke_check_6(int express_test, unsigned paged)
     pass = true;
 
     switch (express_test) {
-        case 0:
+        case H5_TEST_EXPRESS_EXHAUSTIVE:
             max_index = (10 * 1024) - 1;
             break;
 
-        case 1:
+        case H5_TEST_EXPRESS_FULL:
             max_index = (1 * 1024) - 1;
             break;
 
-        case 2:
+        case H5_TEST_EXPRESS_QUICK:
             max_index = (512) - 1;
             break;
 
@@ -1530,22 +1530,22 @@ smoke_check_7(int express_test, unsigned paged)
     else
         TESTING("smoke check #7 -- all clean, ins, prot, unprot, AR cache 2");
 
-    if (paged && (express_test > 0)) {
+    if (paged && (express_test > H5_TEST_EXPRESS_EXHAUSTIVE)) {
 
         SKIPPED();
         return (0);
     }
 
     switch (express_test) {
-        case 0:
+        case H5_TEST_EXPRESS_EXHAUSTIVE:
             max_index = (10 * 1024) - 1;
             break;
 
-        case 1:
+        case H5_TEST_EXPRESS_FULL:
             max_index = (1 * 1024) - 1;
             break;
 
-        case 2:
+        case H5_TEST_EXPRESS_QUICK:
             max_index = (512) - 1;
             break;
 
@@ -1755,22 +1755,22 @@ smoke_check_8(int express_test, unsigned paged)
     else
         TESTING("smoke check #8 -- ~1/2 dirty, ins, prot, unprot, AR cache 2");
 
-    if (paged && (express_test > 0)) {
+    if (paged && (express_test > H5_TEST_EXPRESS_EXHAUSTIVE)) {
 
         SKIPPED();
         return (0);
     }
 
     switch (express_test) {
-        case 0:
+        case H5_TEST_EXPRESS_EXHAUSTIVE:
             max_index = (10 * 1024) - 1;
             break;
 
-        case 1:
+        case H5_TEST_EXPRESS_FULL:
             max_index = (1 * 1024) - 1;
             break;
 
-        case 2:
+        case H5_TEST_EXPRESS_QUICK:
             max_index = (512) - 1;
             break;
 
@@ -1945,22 +1945,22 @@ smoke_check_9(int express_test, unsigned paged)
     else
         TESTING("smoke check #9 -- all clean, ins, dest, ren, 4/2 MB, corked");
 
-    if (paged && (express_test > 0)) {
+    if (paged && (express_test > H5_TEST_EXPRESS_EXHAUSTIVE)) {
 
         SKIPPED();
         return (0);
     }
 
     switch (express_test) {
-        case 0:
+        case H5_TEST_EXPRESS_EXHAUSTIVE:
             max_index = (10 * 1024) - 1;
             break;
 
-        case 1:
+        case H5_TEST_EXPRESS_FULL:
             max_index = (1 * 1024) - 1;
             break;
 
-        case 2:
+        case H5_TEST_EXPRESS_QUICK:
             max_index = (512) - 1;
             break;
 
@@ -2249,22 +2249,22 @@ smoke_check_10(int express_test, unsigned paged)
     else
         TESTING("smoke check #10 -- ~1/2 dirty, ins, dest, ren, 4/2 MB, corked");
 
-    if (paged && (express_test > 0)) {
+    if (paged && (express_test > H5_TEST_EXPRESS_EXHAUSTIVE)) {
 
         SKIPPED();
         return (0);
     }
 
     switch (express_test) {
-        case 0:
+        case H5_TEST_EXPRESS_EXHAUSTIVE:
             max_index = (10 * 1024) - 1;
             break;
 
-        case 1:
+        case H5_TEST_EXPRESS_FULL:
             max_index = (1 * 1024) - 1;
             break;
 
-        case 2:
+        case H5_TEST_EXPRESS_QUICK:
             max_index = (512) - 1;
             break;
 
@@ -2554,15 +2554,15 @@ write_permitted_check(int
 #if H5C_MAINTAIN_CLEAN_AND_DIRTY_LRU_LISTS
 
     switch (express_test) {
-        case 0:
+        case H5_TEST_EXPRESS_EXHAUSTIVE:
             max_index = (10 * 1024) - 1;
             break;
 
-        case 1:
+        case H5_TEST_EXPRESS_FULL:
             max_index = (1 * 1024) - 1;
             break;
 
-        case 2:
+        case H5_TEST_EXPRESS_QUICK:
             max_index = (512) - 1;
             break;
 
@@ -32427,7 +32427,7 @@ main(void)
 
             fprintf(stdout, "\n\nRe-running tests with paged aggregation:\n");
 
-            if (express_test > 0)
+            if (express_test > H5_TEST_EXPRESS_EXHAUSTIVE)
                 fprintf(stdout, "    Skipping smoke checks.\n");
 
             fprintf(stdout, "\n");

--- a/test/cache_api.c
+++ b/test/cache_api.c
@@ -949,7 +949,7 @@ mdc_api_call_smoke_check(int express_test, unsigned paged, hid_t fcpl_id)
 
     pass = true;
 
-    if (express_test > 0) {
+    if (express_test > H5_TEST_EXPRESS_EXHAUSTIVE) {
 
         SKIPPED();
 

--- a/test/fheap.c
+++ b/test/fheap.c
@@ -15985,9 +15985,9 @@ main(void)
      *      in the future for parallel build.
      */
     test_express = h5_get_testexpress();
-    if (test_express > 0)
+    if (test_express > H5_TEST_EXPRESS_EXHAUSTIVE)
         printf("***Express test mode %d.  Some tests may be skipped\n", test_express);
-    else if (test_express == 0) {
+    else if (test_express == H5_TEST_EXPRESS_EXHAUSTIVE) {
 #ifdef H5_HAVE_PARALLEL
         num_pb_fs = NUM_PB_FS - 2;
 #else
@@ -16203,7 +16203,7 @@ main(void)
                     /* If this test fails, uncomment the tests above, which build up to this
                      * level of complexity gradually. -QAK
                      */
-                    if (test_express > 1)
+                    if (test_express > H5_TEST_EXPRESS_FULL)
                         printf(
                             "***Express test mode on.  test_man_start_5th_recursive_indirect is skipped\n");
                     else
@@ -16251,7 +16251,7 @@ main(void)
                                 nerrors += test_man_remove_first_row(fapl, &small_cparam, &tparam);
                                 nerrors += test_man_remove_first_two_rows(fapl, &small_cparam, &tparam);
                                 nerrors += test_man_remove_first_four_rows(fapl, &small_cparam, &tparam);
-                                if (test_express > 1)
+                                if (test_express > H5_TEST_EXPRESS_FULL)
                                     printf("***Express test mode on.  Some tests skipped\n");
                                 else {
                                     nerrors += test_man_remove_all_root_direct(fapl, &small_cparam, &tparam);
@@ -16301,7 +16301,7 @@ main(void)
                                 nerrors +=
                                     test_man_fill_1st_row_3rd_direct_fill_2nd_direct_less_one_wrap_start_block_add_skipped(
                                         fapl, &small_cparam, &tparam);
-                                if (test_express > 1)
+                                if (test_express > H5_TEST_EXPRESS_FULL)
                                     printf("***Express test mode on.  Some tests skipped\n");
                                 else {
                                     nerrors +=
@@ -16431,7 +16431,7 @@ main(void)
             }     /* end block */
 
             /* Random object insertion & deletion */
-            if (test_express > 1)
+            if (test_express > H5_TEST_EXPRESS_FULL)
                 printf("***Express test mode on.  Some tests skipped\n");
             else {
                 /* Random tests using "small" heap creation parameters */

--- a/test/h5test.c
+++ b/test/h5test.c
@@ -890,16 +890,16 @@ h5_get_testexpress(void)
 
     /* TestExpress_g is uninitialized if it has a negative value */
     if (express_val < 0) {
-        /* Default to level 1 if not overridden */
-        express_val = 1;
+        /* Default to full run of tests if not overridden */
+        express_val = H5_TEST_EXPRESS_FULL;
 
         /* Check if a default test express level is defined (e.g., by build system) */
 #ifdef H5_TEST_EXPRESS_LEVEL_DEFAULT
         express_val = H5_TEST_EXPRESS_LEVEL_DEFAULT;
         if (express_val < 0)
-            express_val = 1; /* Reset to default */
-        else if (express_val > 3)
-            express_val = 3;
+            express_val = H5_TEST_EXPRESS_FULL; /* Reset to default */
+        else if (express_val > H5_TEST_EXPRESS_SMOKE_TEST)
+            express_val = H5_TEST_EXPRESS_SMOKE_TEST;
 #endif
     }
 
@@ -909,13 +909,13 @@ h5_get_testexpress(void)
     env_val = getenv("HDF5TestExpress");
     if (env_val) {
         if (strcmp(env_val, "0") == 0)
-            express_val = 0;
+            express_val = H5_TEST_EXPRESS_EXHAUSTIVE;
         else if (strcmp(env_val, "1") == 0)
-            express_val = 1;
+            express_val = H5_TEST_EXPRESS_FULL;
         else if (strcmp(env_val, "2") == 0)
-            express_val = 2;
+            express_val = H5_TEST_EXPRESS_QUICK;
         else
-            express_val = 3;
+            express_val = H5_TEST_EXPRESS_SMOKE_TEST;
     }
 
     return express_val;
@@ -928,9 +928,9 @@ void
 h5_set_testexpress(int new_val)
 {
     if (new_val < 0)
-        new_val = 1; /* Reset to default */
-    else if (new_val > 3)
-        new_val = 3;
+        new_val = H5_TEST_EXPRESS_FULL; /* Reset to default */
+    else if (new_val > H5_TEST_EXPRESS_SMOKE_TEST)
+        new_val = H5_TEST_EXPRESS_SMOKE_TEST;
 
     TestExpress_g = new_val;
 }

--- a/test/h5test.h
+++ b/test/h5test.h
@@ -202,6 +202,12 @@ H5TEST_DLLVAR MPI_Info h5_io_info_g; /* MPI INFO object for IO */
             }                                                                                                \
     } while (0)
 
+/* Macros for the different TestExpress levels for expediting tests */
+#define H5_TEST_EXPRESS_EXHAUSTIVE 0 /** Exhaustive run; tests should take as long as necessary */
+#define H5_TEST_EXPRESS_FULL       1 /** Full run; tests should take no more than 30 minutes    */
+#define H5_TEST_EXPRESS_QUICK      2 /** Quick run; tests should take no more than 10 minutes   */
+#define H5_TEST_EXPRESS_SMOKE_TEST 3 /** Smoke test; tests should take no more than 1 minute    */
+
 #ifdef __cplusplus
 extern "C" {
 #endif
@@ -270,10 +276,14 @@ H5TEST_DLL void h5_restore_err(void);
  *          (currently level 1, unless overridden at configuration time). The
  *          different TestExpress level settings have the following meanings:
  *
- *          + 0             - Tests should take as long as necessary
- *          + 1             - Tests should take no more than 30 minutes
- *          + 2             - Tests should take no more than 10 minutes
- *          + 3 (or higher) - Tests should take no more than 1 minute
+ *          + 0 / #H5_TEST_EXPRESS_EXHAUSTIVE - Tests should take as long as
+ *                                              necessary
+ *          + 1 / #H5_TEST_EXPRESS_FULL       - Tests should take no more
+ *                                              than 30 minutes
+ *          + 2 / #H5_TEST_EXPRESS_QUICK      - Tests should take no more
+ *                                              than 10 minutes
+ *          + 3 / #H5_TEST_EXPRESS_SMOKE_TEST - Tests should take no more
+ *                                              than 1 minute
  *
  *          If the TestExpress level setting is not yet initialized, this
  *          function will first set a local variable to the value of the
@@ -281,9 +291,17 @@ H5TEST_DLL void h5_restore_err(void);
  *          the environment variable "HDF5TestExpress" is defined, its value
  *          will override the local variable's value. Acceptable values for
  *          the environment variable are the strings "0", "1" and "2"; any
- *          other string will cause the variable to be set to the value 3.
- *          Once the value for the local variable has been determined,
- *          h5_get_testexpress() returns that value.
+ *          other string will cause the variable to be set to the value
+ *          3 / H5_TEST_EXPRESS_SMOKE_TEST. Once the value for the local
+ *          variable has been determined, h5_get_testexpress() returns that
+ *          value.
+ *
+ *          The limitation imposed by the TestExpress functionality applies
+ *          to the total runtime of a test executable, even if it contains
+ *          multiple sub-tests.
+ *
+ *          The standard system for test times is a Linux machine running in
+ *          NFS space (to catch tests that involve a great deal of disk I/O).
  *
  * \see h5_set_testexpress()
  *

--- a/test/testframe.h
+++ b/test/testframe.h
@@ -513,17 +513,18 @@ H5TEST_DLL herr_t ParseTestVerbosity(char *argv);
  *          expedited. The variable may be set to one of the following
  *          values:
  *
- *          0: Exhaustive run
- *             Tests should take as long as necessary
- *          1: Full run. Default value if H5_TEST_EXPRESS_LEVEL_DEFAULT
- *             and the HDF5TestExpress environment variable are not defined
- *             Tests should take no more than 30 minutes
- *          2: Quick run
- *             Tests should take no more than 10 minutes
- *          3: Smoke test.
+ *          0 / H5_TEST_EXPRESS_EXHAUSTIVE: Exhaustive run
+ *             Tests should take as long as necessary.
+ *          1 / H5_TEST_EXPRESS_FULL: Full run
+ *             Default value if H5_TEST_EXPRESS_LEVEL_DEFAULT and the
+ *             HDF5TestExpress environment variable are not defined.
+ *             Tests should take no more than 30 minutes.
+ *          2 / H5_TEST_EXPRESS_QUICK: Quick run
+ *             Tests should take no more than 10 minutes.
+ *          3 / H5_TEST_EXPRESS_SMOKE_TEST: Smoke test
  *             Default if the HDF5TestExpress environment variable is set to
- *             a value other than 0-3
- *             Tests should take less than 1 minute
+ *             a value other than 0-3.
+ *             Tests should take less than 1 minute.
  *
  *          The macro H5_TEST_EXPRESS_LEVEL_DEFAULT may be defined to one
  *          of these values at library configuration time in order to

--- a/test/tsohm.c
+++ b/test/tsohm.c
@@ -615,7 +615,7 @@ size1_helper(hid_t file, const char *filename, hid_t fapl_id, bool test_file_clo
     /* Closing and re-opening the file takes a long time on systems without
      * local disks.  Don't close and reopen if express testing is enabled.
      */
-    if (h5_get_testexpress() > 1)
+    if (h5_get_testexpress() > H5_TEST_EXPRESS_FULL)
         test_file_closing = false;
 
     /* Initialize wdata */
@@ -1553,7 +1553,7 @@ size2_helper(hid_t fcpl_id, int test_file_closing, size2_helper_struct *ret_size
     /* Closing and re-opening the file takes a long time on systems without
      * local disks.  Don't close and reopen if express testing is enabled.
      */
-    if (h5_get_testexpress() > 1)
+    if (h5_get_testexpress() > H5_TEST_EXPRESS_FULL)
         test_file_closing = 0;
 
     /* Create a file and get its size */

--- a/test/ttsafe_rec_rwlock.c
+++ b/test/ttsafe_rec_rwlock.c
@@ -582,15 +582,15 @@ tts_rec_rwlock_smoke_check_2(void H5_ATTR_UNUSED *params)
 
     /* Reduce # of threads and test cycles for higher levels of express testing */
     express_test = GetTestExpress();
-    if (express_test >= 1) {
+    if (express_test >= H5_TEST_EXPRESS_FULL) {
         num_threads /= 2;
         lock_cycles /= 10;
     }
-    if (express_test >= 2) {
+    if (express_test >= H5_TEST_EXPRESS_QUICK) {
         num_threads /= 2;
         lock_cycles /= 10;
     }
-    if (express_test >= 3) {
+    if (express_test >= H5_TEST_EXPRESS_SMOKE_TEST) {
         num_threads /= 2;
         lock_cycles /= 10;
     }
@@ -788,15 +788,15 @@ tts_rec_rwlock_smoke_check_3(void H5_ATTR_UNUSED *params)
 
     /* Reduce # of threads and test cycles for higher levels of express testing */
     express_test = GetTestExpress();
-    if (express_test >= 1) {
+    if (express_test >= H5_TEST_EXPRESS_FULL) {
         num_threads /= 2;
         lock_cycles /= 10;
     }
-    if (express_test >= 2) {
+    if (express_test >= H5_TEST_EXPRESS_QUICK) {
         num_threads /= 2;
         lock_cycles /= 10;
     }
-    if (express_test >= 3) {
+    if (express_test >= H5_TEST_EXPRESS_SMOKE_TEST) {
         num_threads /= 2;
         lock_cycles /= 10;
     }
@@ -994,15 +994,15 @@ tts_rec_rwlock_smoke_check_4(void H5_ATTR_UNUSED *params)
 
     /* Reduce # of threads and test cycles for higher levels of express testing */
     express_test = GetTestExpress();
-    if (express_test >= 1) {
+    if (express_test >= H5_TEST_EXPRESS_FULL) {
         num_threads /= 2;
         lock_cycles /= 10;
     }
-    if (express_test >= 2) {
+    if (express_test >= H5_TEST_EXPRESS_QUICK) {
         num_threads /= 2;
         lock_cycles /= 10;
     }
-    if (express_test >= 3) {
+    if (express_test >= H5_TEST_EXPRESS_SMOKE_TEST) {
         num_threads /= 2;
         lock_cycles /= 10;
     }

--- a/testpar/t_2Gio.c
+++ b/testpar/t_2Gio.c
@@ -2594,7 +2594,7 @@ main(int argc, char **argv)
     H5_mpi_set_bigio_count(oldsize);
 
     express_test = GetTestExpress();
-    if ((express_test == 0) && (mpi_rank < 2)) {
+    if ((express_test == H5_TEST_EXPRESS_EXHAUSTIVE) && (mpi_rank < 2)) {
         MpioTest2G(test_comm);
     }
 

--- a/testpar/t_filters_parallel.c
+++ b/testpar/t_filters_parallel.c
@@ -10000,7 +10000,7 @@ main(int argc, char **argv)
      * Get the TestExpress level setting
      */
     test_express_level_g = h5_get_testexpress();
-    if ((test_express_level_g >= 1) && MAINPROCESS) {
+    if ((test_express_level_g >= H5_TEST_EXPRESS_FULL) && MAINPROCESS) {
         printf("** Some tests will be skipped due to TestExpress setting.\n");
         printf("** Exhaustive tests will only be performed for the first available filter.\n");
         printf("** Set the HDF5TestExpress environment variable to 0 to perform exhaustive testing for all "
@@ -10197,7 +10197,7 @@ main(int argc, char **argv)
                          * as the 'USE_MULTIPLE_DATASETS' and 'USE_MULTIPLE_DATASETS_MIXED_FILTERED'
                          * cases are more stressful on the file system.
                          */
-                        if (test_express_level_g > 1) {
+                        if (test_express_level_g > H5_TEST_EXPRESS_FULL) {
                             if (((test_mode == USE_MULTIPLE_DATASETS) ||
                                  (test_mode == USE_MULTIPLE_DATASETS_MIXED_FILTERED)) &&
                                 (chunk_opt != H5FD_MPIO_CHUNK_ONE_IO))
@@ -10301,7 +10301,7 @@ main(int argc, char **argv)
          * If the TestExpress level setting isn't set for exhaustive
          * testing, run smoke checks for the other filters
          */
-        if (!expedite_testing && (test_express_level_g >= 1))
+        if (!expedite_testing && (test_express_level_g >= H5_TEST_EXPRESS_FULL))
             expedite_testing = true;
     }
 

--- a/testpar/t_shapesame.c
+++ b/testpar/t_shapesame.c
@@ -1954,7 +1954,7 @@ contig_hs_dr_pio_test(const void *params, ShapeSameTestMethods sstest_type)
     if (local_express_test < 0) {
         max_skips = max_skips_tbl[0];
     }
-    else if (local_express_test > 3) {
+    else if (local_express_test > H5_TEST_EXPRESS_SMOKE_TEST) {
         max_skips = max_skips_tbl[3];
     }
     else {
@@ -3873,7 +3873,7 @@ ckrbrd_hs_dr_pio_test(const void *params, ShapeSameTestMethods sstest_type)
     if (local_express_test < 0) {
         max_skips = max_skips_tbl[0];
     }
-    else if (local_express_test > 3) {
+    else if (local_express_test > H5_TEST_EXPRESS_SMOKE_TEST) {
         max_skips = max_skips_tbl[3];
     }
     else {


### PR DESCRIPTION
Adds new -testexpress command-line option to the testframe testing framework to allow setting or overriding of the TestExpress level at runtime

Adds macros for the different currently defined TestExpress levels