### PR TITLE
Minor adjustments to usage of alarm(2) timer in tests

### DIFF
--- a/test/h5test.h
+++ b/test/h5test.h
@@ -204,7 +204,7 @@ H5TEST_DLLVAR MPI_Info h5_io_info_g; /* MPI INFO object for IO */
 
 /* Macros for the different TestExpress levels for expediting tests */
 #define H5_TEST_EXPRESS_EXHAUSTIVE 0 /** Exhaustive run; tests should take as long as necessary */
-#define H5_TEST_EXPRESS_FULL       1 /** Full run; tests should take no more than 30 minutes    */
+#define H5_TEST_EXPRESS_FULL       1 /** Full run; tests should take no more than 20 minutes    */
 #define H5_TEST_EXPRESS_QUICK      2 /** Quick run; tests should take no more than 10 minutes   */
 #define H5_TEST_EXPRESS_SMOKE_TEST 3 /** Smoke test; tests should take no more than 1 minute    */
 


### PR DESCRIPTION
Make alarm(2) timer per-test program rather than per-subtest

Avoid enabling alarm(2) timer when TestExpress is set to 0