### PR TITLE
Move TestAlarmOn()/TestAlarmOff() back into PerformTests()

### DIFF
--- a/test/testframe.c
+++ b/test/testframe.c
@@ -158,12 +158,6 @@ TestInit(const char *ProgName, void (*TestPrivateUsage)(FILE *stream),
     /* Initialize value for TestExpress functionality */
     h5_get_testexpress();
 
-    /* Enable alarm timer for test program once TestExpress setting
-     * has been determined
-     */
-    if (TestAlarmOn() < 0)
-        MESSAGE(5, ("Couldn't enable test alarm timer\n"));
-
     /* Record the program name and private routines if provided. */
     TestProgName = ProgName;
     if (NULL != TestPrivateUsage)
@@ -456,6 +450,10 @@ done:
 herr_t
 PerformTests(void)
 {
+    /* Enable alarm timer for tests */
+    if (TestAlarmOn() < 0)
+        MESSAGE(5, ("Couldn't enable test alarm timer\n"));
+
     for (unsigned Loop = 0; Loop < TestCount; Loop++) {
         int old_num_errs = TestNumErrs_g;
 
@@ -480,6 +478,8 @@ PerformTests(void)
         MESSAGE(5, ("===============================================\n"));
         MESSAGE(5, ("There were %d errors detected.\n\n", TestArray[Loop].TestNumErrors));
     }
+
+    TestAlarmOff();
 
     MESSAGE(2, ("\n\n"));
     if (TestNumErrs_g)
@@ -572,8 +572,6 @@ TestShutdown(void)
             free(TestArray[Loop].TestParameters);
 
     free(TestArray);
-
-    TestAlarmOff();
 
     return SUCCEED;
 }


### PR DESCRIPTION
Moves call to TestAlarmOn() in testframe framework back into the PerformTests() function due to the timing of when the framework processes command-line arguments