### PR TITLE
Add release information to enum constants - Part 4

### DIFF
--- a/src/H5ESpublic.h
+++ b/src/H5ESpublic.h
@@ -26,16 +26,18 @@
 
 /**
  * Default value for "no event set" / synchronous execution. Used in
- * place of a @ref hid_t identifier.
+ * place of a @ref hid_t identifier. \since 1.14.0
  */
 #define H5ES_NONE 0
 
 /* Special "wait" timeout values */
-#define H5ES_WAIT_FOREVER (UINT64_MAX) /**< Wait until all operations complete */
+
+/** Wait until all operations complete \since 1.14.0 */
+#define H5ES_WAIT_FOREVER (UINT64_MAX)
 
 /**
  * Don't wait for operations to complete, just check their status.
- * (This allows @ref H5ESwait to behave like a 'test' operation)
+ * (This allows @ref H5ESwait to behave like a 'test' operation) \since 1.14.0
  */
 #define H5ES_WAIT_NONE (0)
 

--- a/src/H5FDcore.h
+++ b/src/H5FDcore.h
@@ -22,7 +22,7 @@
 /** ID for the core VFD */
 #define H5FD_CORE (H5OPEN H5FD_CORE_id_g)
 
-/** Identifier for the core VFD */
+/** Identifier for the core VFD \since 1.14.0 */
 #define H5FD_CORE_VALUE H5_VFD_CORE
 
 #ifdef __cplusplus

--- a/src/H5FDdirect.h
+++ b/src/H5FDdirect.h
@@ -24,7 +24,7 @@
 /** ID for the direct VFD */
 #define H5FD_DIRECT (H5OPEN H5FD_DIRECT_id_g)
 
-/** Identifier for the direct VFD */
+/** Identifier for the direct VFD \since 1.14.0 */
 #define H5FD_DIRECT_VALUE H5_VFD_DIRECT
 
 #else

--- a/src/H5FDfamily.h
+++ b/src/H5FDfamily.h
@@ -22,7 +22,7 @@
 /** ID for the family VFD */
 #define H5FD_FAMILY (H5OPEN H5FD_FAMILY_id_g)
 
-/** Identifier for the family VFD */
+/** Identifier for the family VFD \since 1.14.0 */
 #define H5FD_FAMILY_VALUE H5_VFD_FAMILY
 
 #ifdef __cplusplus

--- a/src/H5FDhdfs.h
+++ b/src/H5FDhdfs.h
@@ -47,11 +47,11 @@
  */
 #define H5FD__CURR_HDFS_FAPL_T_VERSION 1
 
-/** Max size of the node name \since 1.10.6, backported to 1.8.22 */
+/** Max size of the node name \since 1.10.6, back-ported to 1.8.22 */
 #define H5FD__HDFS_NODE_NAME_SPACE 128
-/** Max size of the user name \since 1.10.6, backported to 1.8.22 */
+/** Max size of the user name \since 1.10.6, back-ported to 1.8.22 */
 #define H5FD__HDFS_USER_NAME_SPACE 128
-/** Max size of the kerberos cache path \since 1.10.6, backported to 1.8.22 */
+/** Max size of the kerberos cache path \since 1.10.6, back-ported to 1.8.22 */
 #define H5FD__HDFS_KERB_CACHE_PATH_SPACE 128
 
 /**

--- a/src/H5FDhdfs.h
+++ b/src/H5FDhdfs.h
@@ -26,7 +26,7 @@
 /** ID for the HDFS VFD */
 #define H5FD_HDFS (H5OPEN H5FD_HDFS_id_g)
 
-/** Identifier for the hdfs VFD */
+/** Identifier for the hdfs VFD \since 1.14.0 */
 #define H5FD_HDFS_VALUE H5_VFD_HDFS
 
 #else
@@ -34,7 +34,7 @@
 /** Initializer for the hdfs VFD (disabled) \since 1.8.22 */
 #define H5FD_HDFS       (H5I_INVALID_HID)
 
-/** Identifier for the hdfs VFD (disabled) */
+/** Identifier for the hdfs VFD (disabled) \since 1.14.0 */
 #define H5FD_HDFS_VALUE H5_VFD_INVALID
 
 #endif /* H5_HAVE_LIBHDFS */
@@ -47,11 +47,11 @@
  */
 #define H5FD__CURR_HDFS_FAPL_T_VERSION 1
 
-/** Max size of the node name \since 1.8.22 1.10.6 */
+/** Max size of the node name \since 1.8.22, 1.10.6 */
 #define H5FD__HDFS_NODE_NAME_SPACE 128
-/** Max size of the user name \since 1.8.22 1.10.6 */
+/** Max size of the user name \since 1.8.22, 1.10.6 */
 #define H5FD__HDFS_USER_NAME_SPACE 128
-/** Max size of the kerberos cache path \since 1.8.22 1.10.6 */
+/** Max size of the kerberos cache path \since 1.8.22, 1.10.6 */
 #define H5FD__HDFS_KERB_CACHE_PATH_SPACE 128
 
 /**

--- a/src/H5FDhdfs.h
+++ b/src/H5FDhdfs.h
@@ -43,15 +43,15 @@
 
 /**
  * The version number of the H5FD_hdfs_fapl_t configuration
- * structure for the #H5FD_HDFS driver
+ * structure for the #H5FD_HDFS driver \since 1.8.22
  */
 #define H5FD__CURR_HDFS_FAPL_T_VERSION 1
 
-/** Max size of the node name \since 1.8.22, 1.10.6 */
+/** Max size of the node name \since 1.10.6, backported to 1.8.22 */
 #define H5FD__HDFS_NODE_NAME_SPACE 128
-/** Max size of the user name \since 1.8.22, 1.10.6 */
+/** Max size of the user name \since 1.10.6, backported to 1.8.22 */
 #define H5FD__HDFS_USER_NAME_SPACE 128
-/** Max size of the kerberos cache path \since 1.8.22, 1.10.6 */
+/** Max size of the kerberos cache path \since 1.10.6, backported to 1.8.22 */
 #define H5FD__HDFS_KERB_CACHE_PATH_SPACE 128
 
 /**

--- a/src/H5FDlog.h
+++ b/src/H5FDlog.h
@@ -23,7 +23,7 @@
 /** ID for the log VFD */
 #define H5FD_LOG (H5OPEN H5FD_LOG_id_g)
 
-/** Identifier for the log VFD */
+/** Identifier for the log VFD \since 1.14.0 */
 #define H5FD_LOG_VALUE H5_VFD_LOG
 
 /* Flags for H5Pset_fapl_log() */

--- a/src/H5FDonion.h
+++ b/src/H5FDonion.h
@@ -22,25 +22,25 @@
 /** ID for the onion VFD */
 #define H5FD_ONION (H5OPEN H5FD_ONION_id_g)
 
-/** Identifier for the onion VFD */
+/** Identifier for the onion VFD \since 1.14.0 */
 #define H5FD_ONION_VALUE H5_VFD_ONION
 
 /** Current version of the onion VFD fapl info struct */
 #define H5FD_ONION_FAPL_INFO_VERSION_CURR 1
 
-#define H5FD_ONION_FAPL_INFO_CREATE_FLAG_ENABLE_PAGE_ALIGNMENT                                               \
-    (0x0001u) /**<                                                                                           \
-               * Onion history metadata will align to page_size.                                             \
-               * Partial pages of unused space will occur in the file,                                       \
-               * but may improve read performance from the backing store                                     \
-               * on some systems.                                                                            \
-               * If disabled (0), padding will not be inserted to align                                      \
-               * to page boundaries.                                                                         \
-               */
+/**
+ * Onion history metadata will align to page_size.
+ * Partial pages of unused space will occur in the file, but may improve read
+ * performance from the backing store on some systems.
+ * If disabled (0), padding will not be inserted to align to page boundaries.
+ * \since 1.14.0
+ */
+#define H5FD_ONION_FAPL_INFO_CREATE_FLAG_ENABLE_PAGE_ALIGNMENT (0x0001u)
 
 /**
  * Max length of a comment.
  * The buffer is defined to be this size + 1 to handle the NUL.
+ * \since 1.14.0
  */
 #define H5FD_ONION_FAPL_INFO_COMMENT_MAX_LEN 255
 

--- a/src/H5FDpublic.h
+++ b/src/H5FDpublic.h
@@ -117,12 +117,12 @@
  */
 #define H5FD_FEAT_HAS_MPI 0x00000100
 
-#define H5FD_FEAT_ALLOCATE_EARLY 0x00000200
-/**< Defining the H5FD_FEAT_ALLOCATE_EARLY for a VFL driver will force
+/** Defining the H5FD_FEAT_ALLOCATE_EARLY for a VFL driver will force
  *   the library to use the H5D_ALLOC_TIME_EARLY on dataset create
  *   instead of the default H5D_ALLOC_TIME_LATE
  * \since 1.8.15
  */
+#define H5FD_FEAT_ALLOCATE_EARLY 0x00000200
 
 /*
  * Defining H5FD_FEAT_ALLOW_FILE_IMAGE for a VFL driver means that

--- a/src/H5FDpublic.h
+++ b/src/H5FDpublic.h
@@ -99,7 +99,6 @@
  * the library will mark the driver info dirty when the file is opened
  * R/W.  This will cause the driver info to be re-encoded when the file
  * is flushed/closed.
- *
  * \since 1.10.0
  */
 #define H5FD_FEAT_DIRTY_DRVRINFO_LOAD 0x00000040
@@ -114,7 +113,6 @@
  * Defining H5FD_FEAT_HAS_MPI for a VFL driver means that
  * the driver makes use of MPI communication and code may retrieve
  * communicator/rank information from it
- *
  * \since 1.8.15
  */
 #define H5FD_FEAT_HAS_MPI 0x00000100
@@ -123,7 +121,6 @@
 /**< Defining the H5FD_FEAT_ALLOCATE_EARLY for a VFL driver will force
  *   the library to use the H5D_ALLOC_TIME_EARLY on dataset create
  *   instead of the default H5D_ALLOC_TIME_LATE
- *
  * \since 1.8.15
  */
 
@@ -142,7 +139,6 @@
 /**
  * Defining H5FD_FEAT_SUPPORTS_SWMR_IO for a VFL driver means that the
  * driver supports the single-writer/multiple-readers I/O pattern.
- *
  * \since 1.10.0
  */
 #define H5FD_FEAT_SUPPORTS_SWMR_IO 0x00001000
@@ -151,7 +147,6 @@
  * means that the library will just pass the allocation size to the
  * the driver's allocation callback which will eventually handle alignment.
  * This is specifically used for the multi/split driver.
- *
  * \since 1.10.1
  */
 #define H5FD_FEAT_USE_ALLOC_SIZE 0x00002000
@@ -159,7 +154,6 @@
  * Defining H5FD_FEAT_PAGED_AGGR for a VFL driver
  * means that the driver needs special file space mapping for paged aggregation.
  * This is specifically used for the multi/split driver.
- *
  * \since 1.10.1
  */
 #define H5FD_FEAT_PAGED_AGGR 0x00004000
@@ -170,7 +164,6 @@
  * the canonical HDF5 file format.
  * Regarding the Splitter VFD specifically, only drivers with this flag
  * enabled may be used as the Write-Only (W/O) channel driver.
- *
  * \since 1.10.2
  */
 #define H5FD_FEAT_DEFAULT_VFD_COMPATIBLE 0x00008000

--- a/src/H5FDros3.h
+++ b/src/H5FDros3.h
@@ -47,21 +47,18 @@
 /**
  * \def H5FD_ROS3_MAX_REGION_LEN
  * Maximum string length for specifying the region of the S3 bucket.
- *
  * \since 1.10.6
  */
 #define H5FD_ROS3_MAX_REGION_LEN 32
 /**
  * \def H5FD_ROS3_MAX_SECRET_ID_LEN
  * Maximum string length for specifying the security ID.
- *
  * \since 1.10.6
  */
 #define H5FD_ROS3_MAX_SECRET_ID_LEN 128
 /**
  * \def H5FD_ROS3_MAX_SECRET_KEY_LEN
  * Maximum string length for specifying the security key.
- *
  * \since 1.10.6
  */
 #define H5FD_ROS3_MAX_SECRET_KEY_LEN 128

--- a/src/H5FDsec2.h
+++ b/src/H5FDsec2.h
@@ -23,7 +23,7 @@
 /** ID for the sec2 VFD */
 #define H5FD_SEC2 (H5OPEN H5FD_SEC2_id_g)
 
-/** Identifier for the sec2 VFD */
+/** Identifier for the sec2 VFD \since 1.14.0 */
 #define H5FD_SEC2_VALUE H5_VFD_SEC2
 
 #ifdef __cplusplus

--- a/src/H5FDsplitter.h
+++ b/src/H5FDsplitter.h
@@ -23,7 +23,7 @@
 /** ID for the splitter VFD */
 #define H5FD_SPLITTER (H5OPEN H5FD_SPLITTER_id_g)
 
-/** Identifier for the splitter VFD */
+/** Identifier for the splitter VFD \since 1.14.0 */
 #define H5FD_SPLITTER_VALUE H5_VFD_SPLITTER
 
 /** The version of the H5FD_splitter_vfd_config_t structure used */
@@ -31,7 +31,8 @@
 
 /**
  * Maximum length of a filename/path string in the Write-Only channel,
- * including the NULL-terminator. \since 1.10.7
+ * including the NULL-terminator.
+ * \since 1.10.7
  */
 #define H5FD_SPLITTER_PATH_MAX 4096
 

--- a/src/H5FDsplitter.h
+++ b/src/H5FDsplitter.h
@@ -88,7 +88,7 @@ H5_DLLVAR hid_t H5FD_SPLITTER_id_g;
  *          which is a simplification of the multi VFD and creates separate
  *          files for metadata and data.
  *
- * \since 1.10.7, 1.12.1
+ * \since 1.12.1, back-ported to 1.10.7
  */
 H5_DLL herr_t H5Pset_fapl_splitter(hid_t fapl_id, H5FD_splitter_vfd_config_t *config_ptr);
 
@@ -111,7 +111,7 @@ H5_DLL herr_t H5Pset_fapl_splitter(hid_t fapl_id, H5FD_splitter_vfd_config_t *co
  *          which is a simplification of the multi VFD and creates separate
  *          files for metadata and data.
  *
- * \since 1.10.7, 1.12.1
+ * \since 1.12.1, back-ported to 1.10.7
  */
 H5_DLL herr_t H5Pget_fapl_splitter(hid_t fapl_id, H5FD_splitter_vfd_config_t *config_ptr);
 

--- a/src/H5FDsubfiling/H5FDioc.h
+++ b/src/H5FDsubfiling/H5FDioc.h
@@ -28,6 +28,8 @@
 /**
  * \def H5FD_IOC
  * Macro that returns the identifier for the #H5FD_IOC driver. \hid_t{file driver}
+ *
+ * \since 1.14.0
  */
 #define H5FD_IOC (H5OPEN H5FD_IOC_id_g)
 #else
@@ -37,6 +39,8 @@
 /**
  * \def H5FD_IOC_NAME
  * The canonical name for the #H5FD_IOC driver
+ *
+ * \since 1.14.0
  */
 #define H5FD_IOC_NAME "ioc"
 

--- a/src/H5Ldevelop.h
+++ b/src/H5Ldevelop.h
@@ -26,17 +26,17 @@
 /*****************/
 
 /**
- * \brief Current version of the H5L_class_t struct
+ * \brief Current version of the H5L_class_t struct \since 1.8.0
  */
 #define H5L_LINK_CLASS_T_VERS 1
 
 /**
- * \brief Version of external link format
+ * \brief Version of external link format \since 1.8.0
  */
 #define H5L_EXT_VERSION 0
 
 /**
- * \brief Valid flags for external links
+ * \brief Valid flags for external links \since 1.8.0
  */
 #define H5L_EXT_FLAGS_ALL 0
 

--- a/src/H5Ppublic.h
+++ b/src/H5Ppublic.h
@@ -39,31 +39,31 @@
  */
 
 /**
- * Property list class root, is not user-accessible
+ * Property list class root, is not user-accessible \since 1.8.0
  */
 #define H5P_ROOT (H5OPEN H5P_CLS_ROOT_ID_g)
 /**
- * Object creation property list class, is not user-accessible
+ * Object creation property list class, is not user-accessible \since 1.8.0
  */
 #define H5P_OBJECT_CREATE (H5OPEN H5P_CLS_OBJECT_CREATE_ID_g)
 /**
- * File creation property list class
+ * File creation property list class \since 1.0.0
  */
 #define H5P_FILE_CREATE (H5OPEN H5P_CLS_FILE_CREATE_ID_g)
 /**
- * File access property list class
+ * File access property list class \since 1.0.0
  */
 #define H5P_FILE_ACCESS (H5OPEN H5P_CLS_FILE_ACCESS_ID_g)
 /**
- * Dataset creation property list class
+ * Dataset creation property list class \since 1.0.0
  */
 #define H5P_DATASET_CREATE (H5OPEN H5P_CLS_DATASET_CREATE_ID_g)
 /**
- * Dataset access property list class
+ * Dataset access property list class \since 1.8.0
  */
 #define H5P_DATASET_ACCESS (H5OPEN H5P_CLS_DATASET_ACCESS_ID_g)
 /**
- * Dataset transfer property list class
+ * Dataset transfer property list class \since 1.0.0
  */
 #define H5P_DATASET_XFER (H5OPEN H5P_CLS_DATASET_XFER_ID_g)
 /**
@@ -71,19 +71,19 @@
  */
 #define H5P_FILE_MOUNT (H5OPEN H5P_CLS_FILE_MOUNT_ID_g)
 /**
- * Group creation property list class
+ * Group creation property list class \since 1.8.0
  */
 #define H5P_GROUP_CREATE (H5OPEN H5P_CLS_GROUP_CREATE_ID_g)
 /**
- * Group access property list class
+ * Group access property list class \since 1.8.0
  */
 #define H5P_GROUP_ACCESS (H5OPEN H5P_CLS_GROUP_ACCESS_ID_g)
 /**
- * Datatype creation property list class
+ * Datatype creation property list class \since 1.8.0
  */
 #define H5P_DATATYPE_CREATE (H5OPEN H5P_CLS_DATATYPE_CREATE_ID_g)
 /**
- * Datatype access property list class
+ * Datatype access property list class \since 1.8.0
  */
 #define H5P_DATATYPE_ACCESS (H5OPEN H5P_CLS_DATATYPE_ACCESS_ID_g)
 /**
@@ -99,7 +99,7 @@
  */
 #define H5P_STRING_CREATE (H5OPEN H5P_CLS_STRING_CREATE_ID_g)
 /**
- * Attribute creation property list class
+ * Attribute creation property list class \since 1.8.0
  */
 #define H5P_ATTRIBUTE_CREATE (H5OPEN H5P_CLS_ATTRIBUTE_CREATE_ID_g)
 /**
@@ -143,7 +143,7 @@
  */
 #define H5P_DATASET_CREATE_DEFAULT (H5OPEN H5P_LST_DATASET_CREATE_ID_g)
 /**
- * Dataset access default property list
+ * Dataset access default property list \since 1.8.0
  */
 #define H5P_DATASET_ACCESS_DEFAULT (H5OPEN H5P_LST_DATASET_ACCESS_ID_g)
 /**
@@ -155,19 +155,19 @@
  */
 #define H5P_FILE_MOUNT_DEFAULT (H5OPEN H5P_LST_FILE_MOUNT_ID_g)
 /**
- * Group creation default property list
+ * Group creation default property list \since 1.8.0
  */
 #define H5P_GROUP_CREATE_DEFAULT (H5OPEN H5P_LST_GROUP_CREATE_ID_g)
 /**
- * Group access default property list
+ * Group access default property list \since 1.8.0
  */
 #define H5P_GROUP_ACCESS_DEFAULT (H5OPEN H5P_LST_GROUP_ACCESS_ID_g)
 /**
- * Datytype creation default property list
+ * Datytype creation default property list \since 1.8.0
  */
 #define H5P_DATATYPE_CREATE_DEFAULT (H5OPEN H5P_LST_DATATYPE_CREATE_ID_g)
 /**
- * Datytype access default property list
+ * Datytype access default property list \since 1.8.0
  */
 #define H5P_DATATYPE_ACCESS_DEFAULT (H5OPEN H5P_LST_DATATYPE_ACCESS_ID_g)
 /**
@@ -179,7 +179,7 @@
  */
 #define H5P_MAP_ACCESS_DEFAULT (H5OPEN H5P_LST_MAP_ACCESS_ID_g)
 /**
- * Attribute creation default property list
+ * Attribute creation default property list \since 1.8.0
  */
 #define H5P_ATTRIBUTE_CREATE_DEFAULT (H5OPEN H5P_LST_ATTRIBUTE_CREATE_ID_g)
 /**

--- a/src/H5Spublic.h
+++ b/src/H5Spublic.h
@@ -35,6 +35,7 @@
  * Indicates that the buffer provided in a call to @ref H5Dread or @ref H5Dwrite
  * is a single contiguous block of memory, with the same number of elements
  * as the file dataspace. Used in place of a memory dataspace @ref hid_t value.
+ * \since 1.14.0
  */
 #define H5S_BLOCK 1
 
@@ -42,6 +43,7 @@
  * Used with @ref H5Dread and @ref H5Dwrite to indicate that the file dataspace
  * selection was set via @ref H5Pset_dataset_io_hyperslab_selection calls.
  * Used in place of a file dataspace @ref hid_t value.
+ * \since 1.14.0
  */
 #define H5S_PLIST 2
 

--- a/src/H5VLconnector.h
+++ b/src/H5VLconnector.h
@@ -39,7 +39,7 @@
 /* The maximum size allowed for blobs */
 #define H5VL_MAX_BLOB_ID_SIZE (16) /* Allow for 128-bits blob IDs */
 
-/* # of optional operations reserved for the native VOL connector */
+/** # of optional operations reserved for the native VOL connector \since 1.14.0 */
 #define H5VL_RESERVED_NATIVE_OPTIONAL 1024
 
 /*******************/

--- a/src/H5VLpublic.h
+++ b/src/H5VLpublic.h
@@ -54,77 +54,77 @@
 #define H5VL_CAP_FLAG_NONE 0x0000000000000000
 /** Connector is threadsafe \since 1.12.0 */
 #define H5VL_CAP_FLAG_THREADSAFE 0x0000000000000001
-/** Connector performs operations asynchronously\since 1.12.0 */
+/** Connector performs operations asynchronously\since 1.14.0 */
 #define H5VL_CAP_FLAG_ASYNC 0x0000000000000002
-/** Connector produces native file format \since 1.12.0 */
+/** Connector produces native file format \since 1.14.0 */
 #define H5VL_CAP_FLAG_NATIVE_FILES 0x0000000000000004
-/** H5A create/delete/exists/open/close/read/write \since 1.12.0 */
+/** H5A create/delete/exists/open/close/read/write \since 1.14.0 */
 #define H5VL_CAP_FLAG_ATTR_BASIC 0x0000000000000008
-/** All other H5A API calls \since 1.12.0 */
+/** All other H5A API calls \since 1.14.0 */
 #define H5VL_CAP_FLAG_ATTR_MORE 0x0000000000000010
-/** H5D create/open/close/read/write \since 1.12.0 */
+/** H5D create/open/close/read/write \since 1.14.0 */
 #define H5VL_CAP_FLAG_DATASET_BASIC 0x0000000000000020
-/** All other H5D API calls \since 1.12.0 */
+/** All other H5D API calls \since 1.14.0 */
 #define H5VL_CAP_FLAG_DATASET_MORE 0x0000000000000040
-/** H5F create/open/close/read/write \since 1.12.0 */
+/** H5F create/open/close/read/write \since 1.14.0 */
 #define H5VL_CAP_FLAG_FILE_BASIC 0x0000000000000080
-/** All other H5F API calls \since 1.12.0 */
+/** All other H5F API calls \since 1.14.0 */
 #define H5VL_CAP_FLAG_FILE_MORE 0x0000000000000100
-/** H5G create/open/close \since 1.12.0 */
+/** H5G create/open/close \since 1.14.0 */
 #define H5VL_CAP_FLAG_GROUP_BASIC 0x0000000000000200
-/** All other H5G API calls\since 1.12.0 */
+/** All other H5G API calls\since 1.14.0 */
 #define H5VL_CAP_FLAG_GROUP_MORE 0x0000000000000400
-/** H5L exists/delete \since 1.12.0 */
+/** H5L exists/delete \since 1.14.0 */
 #define H5VL_CAP_FLAG_LINK_BASIC 0x0000000000000800
-/** All other H5L API calls \since 1.12.0 */
+/** All other H5L API calls \since 1.14.0 */
 #define H5VL_CAP_FLAG_LINK_MORE 0x0000000000001000
-/** H5M create/open/close/get*type/get_count/put/get/exists/delete \since 1.12.0 */
+/** H5M create/open/close/get*type/get_count/put/get/exists/delete \since 1.14.0 */
 #define H5VL_CAP_FLAG_MAP_BASIC 0x0000000000002000
-/** All other H5M API calls \since 1.12.0 */
+/** All other H5M API calls \since 1.14.0 */
 #define H5VL_CAP_FLAG_MAP_MORE 0x0000000000004000
-/** H5O open/close/exists \since 1.12.0 */
+/** H5O open/close/exists \since 1.14.0 */
 #define H5VL_CAP_FLAG_OBJECT_BASIC 0x0000000000008000
-/** All other H5O API calls \since 1.12.0 */
+/** All other H5O API calls \since 1.14.0 */
 #define H5VL_CAP_FLAG_OBJECT_MORE 0x0000000000010000
-/** H5Rdestroy \since 1.12.0 */
+/** H5Rdestroy \since 1.14.0 */
 #define H5VL_CAP_FLAG_REF_BASIC 0x0000000000020000
-/** All other H5R API calls \since 1.12.0 */
+/** All other H5R API calls \since 1.14.0 */
 #define H5VL_CAP_FLAG_REF_MORE 0x0000000000040000
-/** Connector supports object references \since 1.12.0 */
+/** Connector supports object references \since 1.14.0 */
 #define H5VL_CAP_FLAG_OBJ_REF 0x0000000000080000
-/** Connector supports regional references \since 1.12.0 */
+/** Connector supports regional references \since 1.14.0 */
 #define H5VL_CAP_FLAG_REG_REF 0x0000000000100000
-/** Connector supports attribute references \since 1.12.0 */
+/** Connector supports attribute references \since 1.14.0 */
 #define H5VL_CAP_FLAG_ATTR_REF 0x0000000000200000
-/** Connector supports stored datatypes \since 1.12.0 */
+/** Connector supports stored datatypes \since 1.14.0 */
 #define H5VL_CAP_FLAG_STORED_DATATYPES 0x0000000000400000
-/** Connector tracks creation order \since 1.12.0 */
+/** Connector tracks creation order \since 1.14.0 */
 #define H5VL_CAP_FLAG_CREATION_ORDER 0x0000000000800000
-/** Connector supports iteration functions \since 1.12.0 */
+/** Connector supports iteration functions \since 1.14.0 */
 #define H5VL_CAP_FLAG_ITERATE 0x0000000001000000
-/** Connector can return a meaningful storage size \since 1.12.0 */
+/** Connector can return a meaningful storage size \since 1.14.0 */
 #define H5VL_CAP_FLAG_STORAGE_SIZE 0x0000000002000000
-/** "by index" API calls are supported \since 1.12.0 */
+/** "by index" API calls are supported \since 1.14.0 */
 #define H5VL_CAP_FLAG_BY_IDX 0x0000000004000000
-/** Connector can return the property lists used to create an object \since 1.12.0 */
+/** Connector can return the property lists used to create an object \since 1.14.0 */
 #define H5VL_CAP_FLAG_GET_PLIST 0x0000000008000000
-/** flush/refresh calls are supported \since 1.12.0 */
+/** flush/refresh calls are supported \since 1.14.0 */
 #define H5VL_CAP_FLAG_FLUSH_REFRESH 0x0000000010000000
-/** External links are supported \since 1.12.0 */
+/** External links are supported \since 1.14.0 */
 #define H5VL_CAP_FLAG_EXTERNAL_LINKS 0x0000000020000000
-/** Hard links are supported \since 1.12.0 */
+/** Hard links are supported \since 1.14.0 */
 #define H5VL_CAP_FLAG_HARD_LINKS 0x0000000040000000
-/** Soft links are supported \since 1.12.0 */
+/** Soft links are supported \since 1.14.0 */
 #define H5VL_CAP_FLAG_SOFT_LINKS 0x0000000080000000
-/** User-defined links are supported \since 1.12.0 */
+/** User-defined links are supported \since 1.14.0 */
 #define H5VL_CAP_FLAG_UD_LINKS 0x0000000100000000
-/** Connector tracks creation, etc. times \since 1.12.0 */
+/** Connector tracks creation, etc. times \since 1.14.0 */
 #define H5VL_CAP_FLAG_TRACK_TIMES 0x0000000200000000
-/** H5Fmount/unmount supported \since 1.12.0 */
+/** H5Fmount/unmount supported \since 1.14.0 */
 #define H5VL_CAP_FLAG_MOUNT 0x0000000400000000
-/** Connector implements a filter pipeline \since 1.12.0 */
+/** Connector implements a filter pipeline \since 1.14.0 */
 #define H5VL_CAP_FLAG_FILTERS 0x0000000800000000
-/** Connector allows fill values to be set \since 1.12.0 */
+/** Connector allows fill values to be set \since 1.14.0 */
 #define H5VL_CAP_FLAG_FILL_VALUES 0x0000001000000000
 
 /**

--- a/src/H5public.h
+++ b/src/H5public.h
@@ -173,16 +173,21 @@
      ((H5_VERS_MAJOR == Maj) && (H5_VERS_MINOR < Min)) || (H5_VERS_MAJOR < Maj))
 
 /* Macros for various environment variables that HDF5 interprets */
+
 /**
  * Used to specify the name of an HDF5 Virtual File Driver to use as
  * the default file driver for file access. Setting this environment
  * variable overrides the default file driver for File Access Property
  * Lists.
+ *
+ * \since 1.14.0
  */
 #define HDF5_DRIVER "HDF5_DRIVER"
 /**
  * Used to specify a configuration string for the HDF5 Virtual File
  * Driver being used for file access.
+ *
+ * \since 1.14.0
  */
 #define HDF5_DRIVER_CONFIG "HDF5_DRIVER_CONFIG"
 /**
@@ -190,12 +195,16 @@
  * to use as the default VOL connector for file access. Setting this
  * environment variable overrides the default VOL connector for File
  * Access Property Lists.
+ *
+ * \since 1.14.0
  */
 #define HDF5_VOL_CONNECTOR "HDF5_VOL_CONNECTOR"
 /**
  * Used to specify a delimiter-separated (currently, ';' for Windows
  * and ':' for other systems) list of paths that HDF5 should search
  * when loading plugins.
+ *
+ * \since 1.14.0
  */
 #define HDF5_PLUGIN_PATH "HDF5_PLUGIN_PATH"
 /**
@@ -204,6 +213,8 @@
  * in H5PLpublic.h as H5PL_NO_PLUGIN), then dynamic loading of any
  * HDF5 plugins will be disabled. No other values are valid for this
  * environment variable.
+ *
+ * \since 1.14.0
  */
 #define HDF5_PLUGIN_PRELOAD "HDF5_PLUGIN_PRELOAD"
 /**
@@ -217,10 +228,14 @@
  *                     that any locking errors caused by file
  *                     locking being disabled on the system
  *                     should be ignored
+ *
+ * \since 1.14.0
  */
 #define HDF5_USE_FILE_LOCKING "HDF5_USE_FILE_LOCKING"
 /**
  * Used to instruct HDF5 not to cleanup files created during testing.
+ *
+ * \since 1.14.0
  */
 #define HDF5_NOCLEANUP "HDF5_NOCLEANUP"
 


### PR DESCRIPTION
Added \since to enum constants added in 1.14.0 version and some of 1.8.0 version.