### PR TITLE
Fix bad objcopy test cleanup on failure

### DIFF
--- a/test/objcopy.c
+++ b/test/objcopy.c
@@ -8816,6 +8816,7 @@ error:
         H5Gclose(gid);
         H5Fclose(fid_dst);
         H5Fclose(fid_src);
+        H5Fclose(fid_ext);
     }
     H5E_END_TRY
     return 1;

--- a/test/objcopy.c
+++ b/test/objcopy.c
@@ -17092,6 +17092,8 @@ error:
     {
         H5Dclose(did);
         H5Dclose(did2);
+        H5Dclose(did3);
+        H5Dclose(did4);
         H5Sclose(sid);
         H5Gclose(gid);
         H5Gclose(gid2);


### PR DESCRIPTION
If test_copy_dataset_open() fails after creating and before closing did3 and did4 in the main test body, they will not be closed during error cleanup. This delays the closing of the test file and causes file creation conflicts later on.

The same logic applies to fid_ext in test_copy_ext_link()
