### PR TITLE
Fix H5S_MAX_RANK doc

### DIFF
--- a/src/H5Spublic.h
+++ b/src/H5Spublic.h
@@ -50,7 +50,7 @@
 #define H5S_UNLIMITED HSIZE_UNDEF /**< Value for 'unlimited' dimensions */
 
 /**
- * The maximum dataspace rank or number of dimensions
+ * The maximum number of dimensions in a dataspace or array datatype
  */
 #define H5S_MAX_RANK 32
 


### PR DESCRIPTION
The H5S_MAX_RANK is the maximum number of dimensions in a dataset or an array datatype.