### PR TITLE
Fix objects not being closed on objcopy test failure

### DIFF
--- a/test/objcopy.c
+++ b/test/objcopy.c
@@ -1508,10 +1508,12 @@ error:
 static int
 compare_groups(hid_t gid, hid_t gid2, hid_t pid, int depth, unsigned copy_flags)
 {
-    H5G_info_t ginfo;     /* Group info struct */
-    H5G_info_t ginfo2;    /* Group info struct */
-    hsize_t    idx;       /* Index over the objects in group */
-    unsigned   cpy_flags; /* Object copy flags */
+    H5G_info_t ginfo;                  /* Group info struct */
+    H5G_info_t ginfo2;                 /* Group info struct */
+    hsize_t    idx;                    /* Index over the objects in group */
+    unsigned   cpy_flags;              /* Object copy flags */
+    hid_t      oid  = H5I_INVALID_HID; /* IDs of objects within group */
+    hid_t      oid2 = H5I_INVALID_HID;
 
     /* Retrieve the object copy flags from the property list, if it's non-DEFAULT */
     if (pid != H5P_DEFAULT) {
@@ -1564,7 +1566,6 @@ compare_groups(hid_t gid, hid_t gid2, hid_t pid, int depth, unsigned copy_flags)
 
             /* Extra checks for "real" objects */
             if (linfo.type == H5L_TYPE_HARD) {
-                hid_t             oid, oid2;     /* IDs of objects within group */
                 H5O_info2_t       oinfo, oinfo2; /* Data model object info */
                 H5O_native_info_t ninfo, ninfo2; /* Native file format object info */
 
@@ -1649,8 +1650,11 @@ compare_groups(hid_t gid, hid_t gid2, hid_t pid, int depth, unsigned copy_flags)
                 /* Close objects */
                 if (H5Oclose(oid) < 0)
                     TEST_ERROR;
+                oid = H5I_INVALID_HID;
+
                 if (H5Oclose(oid2) < 0)
                     TEST_ERROR;
+                oid2 = H5I_INVALID_HID;
             } /* end if */
             else {
                 /* Check that both links are the same size */
@@ -1691,6 +1695,8 @@ compare_groups(hid_t gid, hid_t gid2, hid_t pid, int depth, unsigned copy_flags)
 error:
     H5E_BEGIN_TRY
     {
+        H5Oclose(oid);
+        H5Oclose(oid2);
     }
     H5E_END_TRY
     return false;


### PR DESCRIPTION
If the call to `compare_datasets` returns a test failure, then `oid` and `oid2` won't be cleaned up properly, which can propagate failures in some cases due to delaying file closes.