### PR TITLE
Update AOCC and OpenMPI versions

### DIFF
--- a/.github/workflows/aocc-cmake.yml
+++ b/.github/workflows/aocc-cmake.yml
@@ -16,6 +16,10 @@ jobs:
   aocc_build_and_test:
     name: "aocc ${{ inputs.build_mode }}"
     runs-on: ubuntu-latest
+    env:
+      AOCCVERDOT: "5.0.0"
+      AOCCVERDASH: "5-0"
+
     steps:
       - name: Get Sources
         uses: actions/checkout@v4.1.7
@@ -29,42 +33,42 @@ jobs:
           sudo apt install -y zlib1g-dev libcurl4-openssl-dev libjpeg-dev wget curl bzip2
           sudo apt install -y m4 flex bison cmake libzip-dev openssl build-essential
 
-      - name: Install AOCC 4.2.0
+      - name: Install ${{ env.AOCCVERDOT }} AOCC
         shell: bash
         run: |
-          wget https://download.amd.com/developer/eula/aocc/aocc-4-2/aocc-compiler-4.2.0.tar
-          tar -xvf aocc-compiler-4.2.0.tar
-          cd aocc-compiler-4.2.0
+          wget https://download.amd.com/developer/eula/aocc/aocc-${{ env.AOCCVERDASH }}/aocc-compiler-${{ env.AOCCVERDOT }}.tar
+          tar -xvf aocc-compiler-${{ env.AOCCVERDOT }}.tar
+          cd aocc-compiler-${{ env.AOCCVERDOT }}
           bash install.sh
           source /home/runner/work/hdf5/hdf5/setenv_AOCC.sh
           which clang
           which flang
           clang -v
 
-      - name: Cache OpenMPI 4.1.6 installation
-        id: cache-openmpi-4_1_6
+      - name: Cache OpenMPI installation
+        id: cache-openmpi-5_0_7
         uses: actions/cache@v4
         with:
-          path: /home/runner/work/hdf5/hdf5/openmpi-4.1.6-install
-          key: ${{ runner.os }}-${{ runner.arch }}-openmpi-4_1_6-cache
+          path: /home/runner/work/hdf5/hdf5/openmpi-5.0.7-install
+          key: ${{ runner.os }}-${{ runner.arch }}-openmpi-5_0_7-cache
 
-      - name: Install OpenMPI 4.1.6
-        if: ${{ steps.cache-openmpi-4_1_6.outputs.cache-hit != 'true' }}
+      - name: Install OpenMPI
+        if: ${{ steps.cache-openmpi-5_0_7.outputs.cache-hit != 'true' }}
         run: |
-          export LD_LIBRARY_PATH=/home/runner/work/hdf5/hdf5/aocc-compiler-4.2.0/lib:/usr/local/lib
-          wget https://download.open-mpi.org/release/open-mpi/v4.1/openmpi-4.1.6.tar.gz
-          tar zxvf openmpi-4.1.6.tar.gz
-          cd openmpi-4.1.6
-          ./configure CC=/home/runner/work/hdf5/hdf5/aocc-compiler-4.2.0/bin/clang FC=/home/runner/work/hdf5/hdf5/aocc-compiler-4.2.0/bin/flang --prefix=/home/runner/work/hdf5/hdf5/openmpi-4.1.6-install
+          export LD_LIBRARY_PATH=/home/runner/work/hdf5/hdf5/aocc-compiler-${{ env.AOCCVERDOT }}/lib:/usr/local/lib
+          wget https://download.open-mpi.org/release/open-mpi/v5.0/openmpi-${{ env.AOCCVERDOT }}.tar.gz
+          tar zxvf openmpi-${{ env.AOCCVERDOT }}.tar.gz
+          cd openmpi-${{ env.AOCCVERDOT }}
+          ./configure CC=/home/runner/work/hdf5/hdf5/aocc-compiler-${{ env.AOCCVERDOT }}/bin/clang FC=/home/runner/work/hdf5/hdf5/aocc-compiler-${{ env.AOCCVERDOT }}/bin/flang --prefix=/home/runner/work/hdf5/hdf5/openmpi-${{ env.AOCCVERDOT }}-install
           make
           make install
 
       - name: CMake Configure
         shell: bash
         run: |
-          export LD_LIBRARY_PATH=/home/runner/work/hdf5/hdf5/aocc-compiler-4.2.0/lib:/home/runner/work/hdf5/hdf5/openmpi-4.1.6-install/lib:/usr/local/lib
-          export LD_RUN_PATH=/home/runner/work/hdf5/hdf5/aocc-compiler-4.2.0/lib:/home/runner/work/hdf5/hdf5/openmpi-4.1.6-install/lib:/usr/local/lib
-          export PATH=/home/runner/work/hdf5/hdf5/openmpi-4.1.6-install/bin:/usr/local/bin:$PATH
+          export LD_LIBRARY_PATH=/home/runner/work/hdf5/hdf5/aocc-compiler-${{ env.AOCCVERDOT }}/lib:/home/runner/work/hdf5/hdf5/openmpi-${{ env.AOCCVERDOT }}-install/lib:/usr/local/lib
+          export LD_RUN_PATH=/home/runner/work/hdf5/hdf5/aocc-compiler-${{ env.AOCCVERDOT }}/lib:/home/runner/work/hdf5/hdf5/openmpi-${{ env.AOCCVERDOT }}-install/lib:/usr/local/lib
+          export PATH=/home/runner/work/hdf5/hdf5/openmpi-${{ env.AOCCVERDOT }}-install/bin:/usr/local/bin:$PATH
           mkdir "${{ runner.workspace }}/build"
           cd "${{ runner.workspace }}/build"
           CC=mpicc cmake -C $GITHUB_WORKSPACE/config/cmake/cacheinit.cmake -G Ninja \

--- a/.github/workflows/aocc-cmake.yml
+++ b/.github/workflows/aocc-cmake.yml
@@ -19,6 +19,8 @@ jobs:
     env:
       AOCCVERDOT: "5.0.0"
       AOCCVERDASH: "5-0"
+      MPIVERDOT: "5.0.7"
+      #MPIVERDASH: See lines below
 
     steps:
       - name: Get Sources
@@ -45,30 +47,30 @@ jobs:
           which flang
           clang -v
 
-      - name: Cache OpenMPI installation
+      - name: Cache OpenMPI ${{ env.MPIVERDOT }} installation
         id: cache-openmpi-5_0_7
         uses: actions/cache@v4
         with:
-          path: /home/runner/work/hdf5/hdf5/openmpi-5.0.7-install
+          path: /home/runner/work/hdf5/hdf5/openmpi-${{ env.MPIVERDOT }}-install
           key: ${{ runner.os }}-${{ runner.arch }}-openmpi-5_0_7-cache
 
-      - name: Install OpenMPI
+      - name: Install OpenMPI ${{ env.MPIVERDOT }}
         if: ${{ steps.cache-openmpi-5_0_7.outputs.cache-hit != 'true' }}
         run: |
           export LD_LIBRARY_PATH=/home/runner/work/hdf5/hdf5/aocc-compiler-${{ env.AOCCVERDOT }}/lib:/usr/local/lib
-          wget https://download.open-mpi.org/release/open-mpi/v5.0/openmpi-${{ env.AOCCVERDOT }}.tar.gz
-          tar zxvf openmpi-${{ env.AOCCVERDOT }}.tar.gz
-          cd openmpi-${{ env.AOCCVERDOT }}
-          ./configure CC=/home/runner/work/hdf5/hdf5/aocc-compiler-${{ env.AOCCVERDOT }}/bin/clang FC=/home/runner/work/hdf5/hdf5/aocc-compiler-${{ env.AOCCVERDOT }}/bin/flang --prefix=/home/runner/work/hdf5/hdf5/openmpi-${{ env.AOCCVERDOT }}-install
+          wget https://download.open-mpi.org/release/open-mpi/v5.0/openmpi-${{ env.MPIVERDOT }}.tar.gz
+          tar zxvf openmpi-${{ env.MPIVERDOT }}.tar.gz
+          cd openmpi-${{ env.MPIVERDOT }}
+          ./configure CC=/home/runner/work/hdf5/hdf5/aocc-compiler-${{ env.AOCCVERDOT }}/bin/clang FC=/home/runner/work/hdf5/hdf5/aocc-compiler-${{ env.AOCCVERDOT }}/bin/flang --prefix=/home/runner/work/hdf5/hdf5/openmpi-${{ env.MPIVERDOT }}-install
           make
           make install
 
       - name: CMake Configure
         shell: bash
         run: |
-          export LD_LIBRARY_PATH=/home/runner/work/hdf5/hdf5/aocc-compiler-${{ env.AOCCVERDOT }}/lib:/home/runner/work/hdf5/hdf5/openmpi-${{ env.AOCCVERDOT }}-install/lib:/usr/local/lib
-          export LD_RUN_PATH=/home/runner/work/hdf5/hdf5/aocc-compiler-${{ env.AOCCVERDOT }}/lib:/home/runner/work/hdf5/hdf5/openmpi-${{ env.AOCCVERDOT }}-install/lib:/usr/local/lib
-          export PATH=/home/runner/work/hdf5/hdf5/openmpi-${{ env.AOCCVERDOT }}-install/bin:/usr/local/bin:$PATH
+          export LD_LIBRARY_PATH=/home/runner/work/hdf5/hdf5/aocc-compiler-${{ env.AOCCVERDOT }}/lib:/home/runner/work/hdf5/hdf5/openmpi-${{ env.MPIVERDOT }}-install/lib:/usr/local/lib
+          export LD_RUN_PATH=/home/runner/work/hdf5/hdf5/aocc-compiler-${{ env.AOCCVERDOT }}/lib:/home/runner/work/hdf5/hdf5/openmpi-${{ env.MPIVERDOT }}-install/lib:/usr/local/lib
+          export PATH=/home/runner/work/hdf5/hdf5/openmpi-${{ env.MPIVERDOT }}-install/bin:/usr/local/bin:$PATH
           mkdir "${{ runner.workspace }}/build"
           cd "${{ runner.workspace }}/build"
           CC=mpicc cmake -C $GITHUB_WORKSPACE/config/cmake/cacheinit.cmake -G Ninja \

--- a/.github/workflows/aocc-cmake.yml
+++ b/.github/workflows/aocc-cmake.yml
@@ -20,7 +20,7 @@ jobs:
       AOCCVERDOT: "5.0.0"
       AOCCVERDASH: "5-0"
       MPIVERDOT: "5.0.7"
-      #MPIVERDASH: See lines below
+      #MPIVERUND: Change is needed in the lines below.
 
     steps:
       - name: Get Sources


### PR DESCRIPTION
Updated both to the latest release, as of 2025/2/28.