### PR TITLE
Fix assertion failure in H5S__copy_pnt_list()

### DIFF
--- a/release_docs/RELEASE.txt
+++ b/release_docs/RELEASE.txt
@@ -514,6 +514,14 @@ Bug Fixes since HDF5-2.0.0 release
 ===================================
     Library
     -------
+    - Fixed an assertion failure in H5S__copy_pnt_list()
+
+      If a dataspace with a point selection in it had its extent reset with
+      the H5Sset_extent_none() function, any copy operations on that dataspace
+      would result in an assertion failure in debug builds of the library
+      due to the dataspace having an extent with a rank value of 0. This has
+      been fixed by converting the assertion failure into a normal error check.
+
     - Fixed an error in H5Ddebug
 
       H5Ddebug would fail for any chunked dataset with a chunk index, due to its

--- a/src/H5Spoint.c
+++ b/src/H5Spoint.c
@@ -800,11 +800,14 @@ H5S__copy_pnt_list(const H5S_pnt_list_t *src, unsigned rank)
 
     /* Sanity checks */
     assert(src);
-    assert(rank > 0);
 
     /* Allocate room for the head of the point list */
     if (NULL == (dst = H5FL_CALLOC(H5S_pnt_list_t)))
         HGOTO_ERROR(H5E_DATASPACE, H5E_CANTALLOC, NULL, "can't allocate point list node");
+
+    /* If source dataspace has no extent, just return new point list node */
+    if (rank == 0)
+        HGOTO_DONE(dst);
 
     curr     = src->head;
     new_tail = NULL;

--- a/test/th5s.c
+++ b/test/th5s.c
@@ -3360,10 +3360,10 @@ test_h5s_bug3(void)
     hid_t   space3   = H5I_INVALID_HID;
 
     space1 = H5Screate_simple(1, dims, NULL);
-    CHECK(space1, FAIL, "H5Screate_simple");
+    CHECK(space1, H5I_INVALID_HID, "H5Screate_simple");
 
     space2 = H5Screate_simple(1, dims, NULL);
-    CHECK(space2, FAIL, "H5Screate_simple");
+    CHECK(space2, H5I_INVALID_HID, "H5Screate_simple");
 
     /* Select a single, different element in each dataspace */
     start[0] = 0;
@@ -3382,7 +3382,7 @@ test_h5s_bug3(void)
      * wasn't a hyperslab.
      */
     space3 = H5Scombine_select(space1, H5S_SELECT_AND, space2);
-    CHECK(space3, FAIL, "H5Scombine_select");
+    CHECK(space3, H5I_INVALID_HID, "H5Scombine_select");
 
     /* Close dataspaces */
     ret = H5Sclose(space1);
@@ -3392,6 +3392,40 @@ test_h5s_bug3(void)
     ret = H5Sclose(space3);
     CHECK(ret, FAIL, "H5Sclose");
 } /* test_h5s_bug3() */
+
+/****************************************************************
+**
+**  test_h5s_bug4(): Test copying a dataspace with a point
+**                   selection after the dataspace's extent has
+**                   been reset with H5Sset_extent_none().
+**
+****************************************************************/
+static void
+test_h5s_bug4(void)
+{
+    hsize_t dims[]        = {10};
+    hsize_t points[]      = {0};
+    herr_t  ret           = SUCCEED;
+    hid_t   space_id      = H5I_INVALID_HID;
+    hid_t   space_copy_id = H5I_INVALID_HID;
+
+    space_id = H5Screate_simple(1, dims, NULL);
+    CHECK(space_id, H5I_INVALID_HID, "H5Screate_simple");
+
+    ret = H5Sselect_elements(space_id, H5S_SELECT_SET, 1, points);
+    CHECK(ret, FAIL, "H5Sselect_elements");
+
+    ret = H5Sset_extent_none(space_id);
+    CHECK(ret, FAIL, "H5Sset_extent_none");
+
+    space_copy_id = H5Scopy(space_id);
+    CHECK(space_id, H5I_INVALID_HID, "H5Scopy");
+
+    ret = H5Sclose(space_copy_id);
+    CHECK(ret, FAIL, "H5Sclose");
+    ret = H5Sclose(space_id);
+    CHECK(ret, FAIL, "H5Sclose");
+} /* test_h5s_bug4() */
 
 /*-------------------------------------------------------------------------
  * Function:    test_versionbounds
@@ -3577,6 +3611,7 @@ test_h5s(void H5_ATTR_UNUSED *params)
     test_h5s_bug1();         /* Test bug in offset initialization */
     test_h5s_bug2();         /* Test bug found in H5S__hyper_update_diminfo() */
     test_h5s_bug3();         /* Test bug found in H5S__combine_select() */
+    test_h5s_bug4();         /* Test bug in point selection copying */
     test_versionbounds();    /* Test version bounds with dataspace */
 } /* test_h5s() */
 


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Fix assertion failure in `H5S__copy_pnt_list()` by adding a zero rank check and update tests.
> 
>   - **Bug Fix**:
>     - Fix assertion failure in `H5S__copy_pnt_list()` in `H5Spoint.c` by adding a check for zero rank and converting the assertion to a normal error check.
>   - **Testing**:
>     - Add `test_h5s_bug4()` in `th5s.c` to test copying a dataspace with a point selection after extent reset with `H5Sset_extent_none()`.
>   - **Documentation**:
>     - Update `RELEASE.txt` to document the fix for the assertion failure in `H5S__copy_pnt_list()`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=HDFGroup%2Fhdf5&utm_source=github&utm_medium=referral)<sup> for d9e20323715e42861baeb8ebf2f23b4de64c6912. You can [customize](https://app.ellipsis.dev/HDFGroup/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->