### PR TITLE
Define __STDC_WANT_IEC_60559_TYPES_EXT__ before including other headers

### DIFF
--- a/src/H5private.h
+++ b/src/H5private.h
@@ -20,6 +20,11 @@
 #ifndef H5private_H
 #define H5private_H
 
+/* Define __STDC_WANT_IEC_60559_TYPES_EXT__ for _FloatN support, if available.
+ * Do that before including any other headers in case they include <float.h>
+ * implicitly. */
+#define __STDC_WANT_IEC_60559_TYPES_EXT__
+
 #include "H5public.h" /* Include Public Definitions    */
 
 #include <assert.h>
@@ -34,8 +39,6 @@
 #include <string.h>
 #include <time.h>
 
-/* Define __STDC_WANT_IEC_60559_TYPES_EXT__ for _FloatN support, if available */
-#define __STDC_WANT_IEC_60559_TYPES_EXT__
 #include <float.h>
 #include <math.h>
 


### PR DESCRIPTION
Some standard headers might implicitly include `float.h`. If that happens before `__STDC_WANT_IEC_60559_TYPES_EXT__` is defined, the macros that are needed for the `_Float16` data type (like `FLT16_MAX`) might not be defined.

That is happening with mingw-w64 headers since the following change: https://github.com/mingw-w64/mingw-w64/commit/b40b6a021dcb6c2396e248e22f682b7bd2599d7a

Define `__STDC_WANT_IEC_60559_TYPES_EXT__` before including other headers in `H5private.h` to make that scenario less likely.