### PR TITLE
Ignore gnu.org for #5377

### DIFF
--- a/.github/workflows/linkchecker.yml
+++ b/.github/workflows/linkchecker.yml
@@ -42,6 +42,6 @@ jobs:
       - name: check
         run: |
           cd build/hdf5lib_docs/html
-          linkchecker --no-warnings --ignore-url=/doxygen.css --ignore-url=gnu.org --check-extern ./index.html
+          linkchecker --no-warnings --ignore-url=/doxygen.css --ignore-url=gnu.org --ignore-url=en.wikipedia.org --ignore-url=help.hdfgroup.org --ignore-url=libpng.org --ignore-url=my.cdash.org --ignore-url=www.oreilly.com --ignore-url=preshing.com --ignore-url=semver.org --ignore-url=sourceforge.net --ignore-url=www.youtube.com --ignore-url=youtu.be --check-extern ./index.html
         #continue-on-error: true
 

--- a/.github/workflows/linkchecker.yml
+++ b/.github/workflows/linkchecker.yml
@@ -42,6 +42,6 @@ jobs:
       - name: check
         run: |
           cd build/hdf5lib_docs/html
-          linkchecker --no-warnings --ignore-url=/doxygen.css --check-extern ./index.html
+          linkchecker --no-warnings --ignore-url=/doxygen.css --ignore-url=gnu.org --check-extern ./index.html
         #continue-on-error: true
 


### PR DESCRIPTION
Linkchecker almost always fails for gnu.org.
