### PR TITLE
Fix incorrect link size for VOL connectors in h5ls/h5diff

### DIFF
--- a/tools/lib/h5diff.c
+++ b/tools/lib/h5diff.c
@@ -521,7 +521,8 @@ trav_grp_symlinks(const char *path, const H5L_info2_t *linfo, void *udata)
                 H5TOOLS_GOTO_DONE(SUCCEED);
             }
 
-            if (H5Lunpack_elink_val(lnk_info.trg_path, linfo->u.val_size, NULL, &ext_fname, &ext_path) < 0)
+            if (H5Lunpack_elink_val(lnk_info.trg_path, lnk_info.linfo.u.val_size, NULL, &ext_fname,
+                                    &ext_path) < 0)
                 H5TOOLS_GOTO_DONE(SUCCEED);
 
             /* check if already visit the target object */

--- a/tools/src/h5ls/h5ls.c
+++ b/tools/src/h5ls/h5ls.c
@@ -2441,7 +2441,7 @@ list_lnk(const char *name, const H5L_info2_t *linfo, void *_iter)
             else if (no_dangling_link_g && ret == 0)
                 iter->symlink_list->dangle_link = true;
 
-            if (H5Lunpack_elink_val(buf, linfo->u.val_size, NULL, &filename, &path) < 0)
+            if (H5Lunpack_elink_val(buf, lnk_info.linfo.u.val_size, NULL, &filename, &path) < 0)
                 goto done;
 
             h5tools_str_append(&buffer, "External Link {");


### PR DESCRIPTION
h5ls and h5diff operate on the value of external links retrieved through the top-level `H5Lget_val()`. In their calls to `H5Lunpack_elink_val()`, these tools provide the size of the external link value as `linfo->u.val_size`, a value passed in from the sub-VOL connector layers of the library.

When using the Native VOL or a VOL connector that doesn't modify external link values, this works fine since the external link size reported by the API agrees with the link size that the sub-Native VOL layers see. 

When using a passthrough connector that changes the external link values,  the link size from outside will reflect the 'internal' link size, and the link value will reflect the externally visible link value, leading to bad memory reads depending on how different the real size is.

This PR changes the tools to use the externally-visible link size  (retrieved via `H5tools_get_symlink_info() -> H5Lget_info2()`) for consistency with the externally-visible link value.