### PR TITLE
ph5diff: remove message that breaks MPI_TEST_H5DIFF-h5diff_601

### DIFF
--- a/tools/src/h5diff/ph5diff_main.c
+++ b/tools/src/h5diff/ph5diff_main.c
@@ -63,8 +63,6 @@ main(int argc, char *argv[])
     g_Parallel    = 1;
 
     if (g_nTasks == 1) {
-        fprintf(stderr, "Only 1 task available...doing serial diff\n");
-
         g_Parallel = 0;
 
         parse_command_line(argc, (const char *const *)argv, &fname1, &fname2, &objname1, &objname2, &opts);


### PR DESCRIPTION
    Start 225: MPI_TEST_H5DIFF-h5diff_601
1/1 Test #225: MPI_TEST_H5DIFF-h5diff_601 .......***Failed    7.82 sec
-- COMMAND:  /usr/lib64/mpi/gcc/openmpi5/bin/mpiexec -n;1;;/home/abuild/rpmbuild/BUILD/hdf5-openmpi5-1.14.6-build/hdf5-1.14.6/build/bin/ph5diff;;h5diff_basic1.h5;h5diff_basic1.h5;nono_obj
-- COMMAND Result: 0
-- COMMAND Error:
Only 1 task available...doing serial diff

CMake Error at /home/abuild/rpmbuild/BUILD/hdf5-openmpi5-1.14.6-build/hdf5-1.14.6/config/cmake/grepTest.cmake:119 (message):
  Failed: The error output of /usr/lib64/mpi/gcc/openmpi5/bin/mpiexec did not
  contain 'Object could not be found'.  Error output was: 'Only 1 task
  available...doing serial diff

  '
