### PR TITLE
Suppress unhelpful error messages from tentative file opens in h5tools_fopen()

### DIFF
--- a/tools/lib/h5tools.c
+++ b/tools/lib/h5tools.c
@@ -631,12 +631,6 @@ h5tools_set_fapl_vfd(hid_t fapl_id, h5tools_vfd_info_t *vfd_info)
     }
 
 done:
-    if (ret_value < 0) {
-        /* Clear error message unless asked for */
-        if ((H5tools_ERR_STACK_g >= 0) && (enable_error_stack <= 1))
-            H5Epop(H5tools_ERR_STACK_g, 1);
-    }
-
     return ret_value;
 }
 
@@ -728,10 +722,6 @@ done:
     if (ret_value < 0) {
         if (connector_id >= 0 && H5Idec_ref(connector_id) < 0)
             H5TOOLS_ERROR(FAIL, "failed to decrement refcount on VOL connector ID");
-
-        /* Clear error message unless asked for */
-        if ((H5tools_ERR_STACK_g >= 0) && (enable_error_stack <= 1))
-            H5Epop(H5tools_ERR_STACK_g, 1);
     }
 
     return ret_value;
@@ -775,10 +765,6 @@ done:
             H5Pclose(new_fapl_id);
             new_fapl_id = H5I_INVALID_HID;
         }
-
-        /* Clear error message unless asked for */
-        if ((H5tools_ERR_STACK_g >= 0) && (enable_error_stack <= 1))
-            H5Epop(H5tools_ERR_STACK_g, 1);
     }
 
     return ret_value;

--- a/tools/lib/h5tools.c
+++ b/tools/lib/h5tools.c
@@ -935,7 +935,9 @@ h5tools_fopen(const char *fname, unsigned flags, hid_t fapl_id, bool use_specifi
     hid_t    tmp_fapl_id  = H5I_INVALID_HID;
     hid_t    used_fapl_id = H5I_INVALID_HID;
     unsigned volnum, drivernum;
-    hid_t    ret_value = H5I_INVALID_HID;
+    bool     lib_errors_paused   = false;
+    bool     tools_errors_paused = false;
+    hid_t    ret_value           = H5I_INVALID_HID;
 
     /*
      * First try to open the file using just the given FAPL. If the
@@ -971,6 +973,17 @@ h5tools_fopen(const char *fname, unsigned flags, hid_t fapl_id, bool use_specifi
      */
     if (use_specific_driver)
         H5TOOLS_GOTO_ERROR(H5I_INVALID_HID, "failed to open file using specified FAPL");
+
+    /*
+     * Pause errors on the library and tools error stacks to prevent a
+     * flood of unhelpful error messages from the section below.
+     */
+    if (H5Epause_stack(H5tools_ERR_STACK_g) < 0)
+        H5TOOLS_GOTO_ERROR(H5I_INVALID_HID, "failed to pause errors for tools error stack");
+    tools_errors_paused = true;
+    if (H5Epause_stack(H5E_DEFAULT) < 0)
+        H5TOOLS_GOTO_ERROR(H5I_INVALID_HID, "failed to pause errors for library error stack");
+    lib_errors_paused = true;
 
     /*
      * As a final resort, try to open the file using each of the available
@@ -1026,11 +1039,7 @@ h5tools_fopen(const char *fname, unsigned flags, hid_t fapl_id, bool use_specifi
                 }
 
                 /* Can we open the file with this combo? */
-                H5E_BEGIN_TRY
-                {
-                    fid = h5tools_fopen(fname, flags, tmp_fapl_id, true, drivername, drivername_size);
-                }
-                H5E_END_TRY
+                fid = h5tools_fopen(fname, flags, tmp_fapl_id, true, drivername, drivername_size);
 
                 if (fid >= 0) {
                     used_fapl_id = tmp_fapl_id;
@@ -1074,6 +1083,11 @@ h5tools_fopen(const char *fname, unsigned flags, hid_t fapl_id, bool use_specifi
     ret_value = H5I_INVALID_HID;
 
 done:
+    if (lib_errors_paused && H5Eresume_stack(H5E_DEFAULT) < 0)
+        H5TOOLS_ERROR(H5I_INVALID_HID, "failed to unpause errors for library error stack");
+    if (tools_errors_paused && H5Eresume_stack(H5tools_ERR_STACK_g) < 0)
+        H5TOOLS_ERROR(H5I_INVALID_HID, "failed to unpause errors for tools error stack");
+
     /* Save the driver name if using a native-terminal VOL connector */
     if (drivername && drivername_size && ret_value >= 0)
         if (used_fapl_id >= 0 &&
@@ -1082,12 +1096,6 @@ done:
 
     if (tmp_fapl_id >= 0)
         H5Pclose(tmp_fapl_id);
-
-    /* Clear error message unless asked for */
-    if (ret_value < 0) {
-        if ((H5tools_ERR_STACK_g >= 0) && (enable_error_stack <= 1))
-            H5Epop(H5tools_ERR_STACK_g, 1);
-    }
 
     return ret_value;
 }


### PR DESCRIPTION
When developing the DAOS VOL connector, it was requested that the library/tools try to fallback to opening a file with what's available in terms of VOLs/VFDs when the file can't be opened by the default setup, which is usually native+sec2. While I'm now thinking this feature was misguided and should be reworked, it's currently polluting the error stack from at least `h5dump` in a very unhelpful way. The new pause/resume feature for error stacks allows cleaning up of these messages to put the error stacks back to how they used to be years ago. Compare the current (snipped a bit due to length):

```bash
h5dump --enable-error-stack=2 bogus.h5
```

```bash
HDF5-DIAG: Error detected in HDF5 (2.0.0):
  #000: H5F.c line 821 in H5Fopen(): unable to synchronously open file
    major: File accessibility
    minor: Unable to open file
  #001: H5F.c line 782 in H5F__open_api_common(): unable to open file
    major: File accessibility
    minor: Unable to open file
  #002: H5VLcallback.c line 3869 in H5VL_file_open(): open failed
    major: Virtual Object Layer
    minor: Can't open object
  #003: H5VLcallback.c line 3718 in H5VL__file_open(): open failed
    major: Virtual Object Layer
    minor: Can't open object
  #004: H5VLnative_file.c line 128 in H5VL__native_file_open(): unable to open file
    major: File accessibility
    minor: Unable to open file
  #005: H5Fint.c line 1924 in H5F_open(): can't try opening file
    major: File accessibility
    minor: Unable to open file
  #006: H5FD.c line 966 in H5FD_open(): can't open file
    major: Virtual File Layer
    minor: Unable to open file
  #007: H5FDsec2.c line 285 in H5FD__sec2_open(): unable to open file: name = 'bogus.h5', errno = 2, error message = 'No such file or directory', flags = 0, o_flags = 0
    major: File accessibility
    minor: Unable to open file
... (repeat of the above)
...
  #007: H5FDstdio.c line 348 in H5FD_stdio_open(): file doesn't exist and CREAT wasn't specified
    major: Low-level I/O
    minor: Unable to open file
...
  #007: H5FDcore.c line 759 in H5FD__core_open(): unable to open file
    major: File accessibility
    minor: Unable to open file
...
  #007: H5FDfamily.c line 745 in H5FD__family_open(): file names not unique
    major: Virtual File Layer
    minor: File already exists
...
...
HDF5-DIAG: Error detected in HDF5 (2.0.0):
  #000: H5Pfapl.c line 1310 in H5Pset_driver_by_name(): can't set driver info
    major: Property lists
    minor: Can't set value
  #001: H5Pfapl.c line 1260 in H5P_set_driver_by_name(): unable to register VFD
    major: Virtual File Layer
    minor: Unable to register new ID
  #002: H5FDint.c line 3202 in H5FD_register_driver_by_name(): unable to load VFD
    major: Virtual File Layer
    minor: Unable to initialize object
  #003: H5PLint.c line 274 in H5PL_load(): can't find plugin. Check either HDF5_VOL_CONNECTOR, HDF5_PLUGIN_PATH, default location, or path set by H5PLxxx functions
    major: Plugin for dynamically loaded library
    minor: Object not found
  #004: H5PLpath.c line 805 in H5PL__find_plugin_in_path_table(): search in path /usr/local/hdf5/lib/plugin encountered an error
    major: Plugin for dynamically loaded library
    minor: Can't get value
  #005: H5PLpath.c line 857 in H5PL__find_plugin_in_path(): can't open directory (/usr/local/hdf5/lib/plugin). Please verify its existence
    major: Plugin for dynamically loaded library
    minor: Can't open directory or file
  #006: H5PLpath.c line 805 in H5PL__find_plugin_in_path_table(): search in path /usr/local/HDF_Group/HDF5/2.0.0/lib/plugin encountered an error
    major: Plugin for dynamically loaded library
    minor: Can't get value
  #007: H5PLpath.c line 857 in H5PL__find_plugin_in_path(): can't open directory (/usr/local/HDF_Group/HDF5/2.0.0/lib/plugin). Please verify its existence
    major: Plugin for dynamically loaded library
    minor: Can't open directory or file
...
  #007: H5FDsplitter.c line 835 in H5FD__splitter_open(): unable to open R/W file
    major: Virtual File Layer
    minor: Unable to open file
  #008: H5FD.c line 966 in H5FD_open(): can't open file
    major: Virtual File Layer
    minor: Unable to open file
  #009: H5FDsec2.c line 285 in H5FD__sec2_open(): unable to open file: name = 'bogus.h5', errno = 2, error message = 'No such file or directory', flags = 0, o_flags = 0
    major: File accessibility
    minor: Unable to open file
...
h5dump error: unable to open file "bogus.h5"
H5tools-DIAG: Error detected in HDF5:tools (2.0.0):
  #000: h5tools.c line 975 in h5tools_fopen(): failed to open file using specified FAPL
    major: Failure in tools library
    minor: error in function
  #001: h5tools.c line 591 in h5tools_set_fapl_vfd(): Onion VFD info is invalid
    major: Failure in tools library
    minor: error in function
  #002: h5tools.c line 585 in h5tools_set_fapl_vfd(): The Subfiling VFD is not enabled
    major: Failure in tools library
    minor: error in function
  #003: h5tools.c line 577 in h5tools_set_fapl_vfd(): The HDFS VFD is not enabled
    major: Failure in tools library
    minor: error in function
  #004: h5tools.c line 567 in h5tools_set_fapl_vfd(): Read-only S3 VFD is not enabled
    major: Failure in tools library
    minor: error in function
  #005: h5tools.c line 975 in h5tools_fopen(): failed to open file using specified FAPL
    major: Failure in tools library
    minor: error in function
  #006: h5tools.c line 602 in h5tools_set_fapl_vfd(): can't load VFD plugin by driver name 'mirror'
    major: Failure in tools library
    minor: error in function
  #007: h5tools.c line 553 in h5tools_set_fapl_vfd(): MPI-I/O VFD is not enabled
    major: Failure in tools library
    minor: error in function
  #008: h5tools.c line 975 in h5tools_fopen(): failed to open file using specified FAPL
    major: Failure in tools library
    minor: error in function
  #009: h5tools.c line 975 in h5tools_fopen(): failed to open file using specified FAPL
    major: Failure in tools library
    minor: error in function
  #010: h5tools.c line 975 in h5tools_fopen(): failed to open file using specified FAPL
    major: Failure in tools library
    minor: error in function
  #011: h5tools.c line 975 in h5tools_fopen(): failed to open file using specified FAPL
    major: Failure in tools library
    minor: error in function
  #012: h5tools.c line 975 in h5tools_fopen(): failed to open file using specified FAPL
    major: Failure in tools library
    minor: error in function
  #013: h5tools.c line 507 in h5tools_set_fapl_vfd(): Windows VFD is not enabled
    major: Failure in tools library
    minor: error in function
  #014: h5tools.c line 491 in h5tools_set_fapl_vfd(): Direct VFD is not enabled
    major: Failure in tools library
    minor: error in function
  #015: h5tools.c line 975 in h5tools_fopen(): failed to open file using specified FAPL
    major: Failure in tools library
    minor: error in function
```

Against these changes:

```bash
h5dump --enable-error-stack=2 bogus.h5
```

```bash
HDF5-DIAG: Error detected in HDF5 (2.0.0):
  #000: H5F.c line 821 in H5Fopen(): unable to synchronously open file
    major: File accessibility
    minor: Unable to open file
  #001: H5F.c line 782 in H5F__open_api_common(): unable to open file
    major: File accessibility
    minor: Unable to open file
  #002: H5VLcallback.c line 3869 in H5VL_file_open(): open failed
    major: Virtual Object Layer
    minor: Can't open object
  #003: H5VLcallback.c line 3718 in H5VL__file_open(): open failed
    major: Virtual Object Layer
    minor: Can't open object
  #004: H5VLnative_file.c line 128 in H5VL__native_file_open(): unable to open file
    major: File accessibility
    minor: Unable to open file
  #005: H5Fint.c line 1924 in H5F_open(): can't try opening file
    major: File accessibility
    minor: Unable to open file
  #006: H5FD.c line 966 in H5FD_open(): can't open file
    major: Virtual File Layer
    minor: Unable to open file
  #007: H5FDsec2.c line 285 in H5FD__sec2_open(): unable to open file: name = 'bogus.h5', errno = 2, error message = 'No such file or directory', flags = 0, o_flags = 0
    major: File accessibility
    minor: Unable to open file
h5dump error: unable to open file "bogus.h5"
```