### PR TITLE
Change `flang-new` to `flang` in  clang.cmake comment block

### DIFF
--- a/config/toolchain/clang.cmake
+++ b/config/toolchain/clang.cmake
@@ -9,7 +9,7 @@ if(WIN32)
 else()
   set (CMAKE_C_COMPILER clang)
   set (CMAKE_CXX_COMPILER clang++)
-  #set (CMAKE_Fortran_COMPILER flang-new)
+  #set (CMAKE_Fortran_COMPILER flang)
 endif()
 set (CMAKE_EXPORT_COMPILE_COMMANDS ON)
 


### PR DESCRIPTION
Prepare for the new era of the Fortran community.

close #5452