### PR TITLE
Add subfolder argument to gentest scripts

### DIFF
--- a/tools/test/h5copy/CMakeLists.txt
+++ b/tools/test/h5copy/CMakeLists.txt
@@ -23,7 +23,7 @@ if (HDF5_BUILD_GENERATORS)
     clang_format (HDF5_TOOLS_TEST_H5COPY_FORMAT h5copygentest)
   endif ()
 
-  #add_test (NAME h5copygentest COMMAND ${CMAKE_CROSSCOMPILING_EMULATOR} $<TARGET_FILE:h5copygentest>)
+  #add_test (NAME h5copygentest COMMAND ${CMAKE_CROSSCOMPILING_EMULATOR} $<TARGET_FILE:h5copygentest> "testfiles")
 endif ()
 
 #-----------------------------------------------------------------------------

--- a/tools/test/h5copy/h5copygentest.c
+++ b/tools/test/h5copy/h5copygentest.c
@@ -45,6 +45,7 @@
 #define REG_REF_DS1 "Dset_REGREF"
 #define REG_REF_DS2 "Dset2"
 
+#define GENTEST_PATH_MAX_LEN 1024
 /*-------------------------------------------------------------------------
  * Function:    gent_simple
  *
@@ -967,11 +968,35 @@ out:
  */
 
 int
-main(void)
+main(int argc, const char *const argv[])
 {
+    char original_dir[GENTEST_PATH_MAX_LEN];
+
+    if (argc > 2) {
+        fprintf(stderr, "Usage: %s [subfolder]\n", argv[0]);
+        return 1;
+    }
+    else if (argc == 2) {
+        if (getcwd(original_dir, GENTEST_PATH_MAX_LEN) == NULL) {
+            fprintf(stderr, "Failed to get current working directory\n");
+            return 1;
+        }
+        if (chdir(argv[1]) != 0) {
+            fprintf(stderr, "Failed to change directory\n");
+            return 1;
+        }
+    }
+
     Test_Obj_Copy();
     Test_Ref_Copy();
     Test_Extlink_Copy();
+
+    if (original_dir[0] != '\0') {
+        if (chdir(original_dir) != 0) {
+            fprintf(stderr, "Failed to restore directory\n");
+            return 1;
+        }
+    }
 
     return 0;
 }

--- a/tools/test/h5diff/CMakeLists.txt
+++ b/tools/test/h5diff/CMakeLists.txt
@@ -24,7 +24,11 @@ if (HDF5_BUILD_GENERATORS)
     clang_format (HDF5_TOOLS_TEST_H5DIFF_FORMAT h5diffgentest)
   endif ()
 
-  #add_test (NAME h5diffgentest COMMAND ${CMAKE_CROSSCOMPILING_EMULATOR} $<TARGET_FILE:h5diffgentest>)
+  #add_test (NAME h5diffgentest COMMAND ${CMAKE_CROSSCOMPILING_EMULATOR} $<TARGET_FILE:h5diffgentest> "testfiles")
+
+  # if (H5_HAVE_PARALLEL)
+  #   add_test (NAME h5diffgentest COMMAND ${CMAKE_CROSSCOMPILING_EMULATOR} $<TARGET_FILE:h5diffgentest> "PAR/testfiles")
+  # endif ()
 endif ()
 
 #-----------------------------------------------------------------------------

--- a/tools/test/h5diff/h5diffgentest.c
+++ b/tools/test/h5diff/h5diffgentest.c
@@ -123,6 +123,8 @@ size_t H5TOOLS_MALLOCSIZE = (128 * 1024 * 1024);
         goto error;                                                                                          \
     } while (0)
 
+#define GENTEST_PATH_MAX_LEN 1024
+
 /* A UD link traversal function.  Shouldn't actually be called. */
 static hid_t
 UD_traverse(H5_ATTR_UNUSED const char *link_name, H5_ATTR_UNUSED hid_t cur_group,
@@ -207,8 +209,25 @@ static int    gen_dataset_idx(const char *file, int format);
  */
 
 int
-main(void)
+main(int argc, const char *const argv[])
 {
+    char original_dir[GENTEST_PATH_MAX_LEN];
+
+    if (argc > 2) {
+        fprintf(stderr, "Usage: %s [subfolder]\n", argv[0]);
+        return 1;
+    }
+    else if (argc == 2) {
+        if (getcwd(original_dir, GENTEST_PATH_MAX_LEN) == NULL) {
+            fprintf(stderr, "Failed to get current working directory\n");
+            return 1;
+        }
+        if (chdir(argv[1]) != 0) {
+            fprintf(stderr, "Failed to change directory\n");
+            return 1;
+        }
+    }
+
     test_basic(FILE1, FILE2, FILE11);
 
     test_types(FILE3);
@@ -311,6 +330,13 @@ main(void)
     test_onion_1d_dset(FILE23);
     test_onion_create_delete_objects(FILE24);
     test_onion_dset_extension(FILE25);
+
+    if (original_dir[0] != '\0') {
+        if (chdir(original_dir) != 0) {
+            fprintf(stderr, "Failed to restore directory\n");
+            return 1;
+        }
+    }
 
     return EXIT_SUCCESS;
 }

--- a/tools/test/h5dump/CMakeLists.txt
+++ b/tools/test/h5dump/CMakeLists.txt
@@ -59,7 +59,7 @@ if (HDF5_BUILD_GENERATORS)
     clang_format (HDF5_TOOLS_TEST_H5DUMP_FORMAT h5dumpgentest)
   endif ()
 
-  #add_test (NAME h5dumpgentest COMMAND ${CMAKE_CROSSCOMPILING_EMULATOR} $<TARGET_FILE:h5dumpgentest>)
+  #add_test (NAME h5dumpgentest COMMAND ${CMAKE_CROSSCOMPILING_EMULATOR} $<TARGET_FILE:h5dumpgentest> "testfiles")
 endif ()
 
 if (HDF5_TEST_TOOLS AND HDF5_TEST_SERIAL)

--- a/tools/test/h5dump/h5dumpgentest.c
+++ b/tools/test/h5dump/h5dumpgentest.c
@@ -132,6 +132,8 @@
 #define ONION_TEST_PAGE_SIZE    (uint32_t)32
 #define ONE_DIM_SIZE            16
 
+#define GENTEST_PATH_MAX_LEN 1024
+
 /*-------------------------------------------------------------------------
  * prototypes
  *-------------------------------------------------------------------------
@@ -12754,8 +12756,25 @@ gent_complex_be(void)
 #endif
 
 int
-main(void)
+main(int argc, const char *const argv[])
 {
+    char original_dir[GENTEST_PATH_MAX_LEN];
+
+    if (argc > 2) {
+        fprintf(stderr, "Usage: %s [subfolder]\n", argv[0]);
+        return 1;
+    }
+    else if (argc == 2) {
+        if (getcwd(original_dir, GENTEST_PATH_MAX_LEN) == NULL) {
+            fprintf(stderr, "Failed to get current working directory\n");
+            return 1;
+        }
+        if (chdir(argv[1]) != 0) {
+            fprintf(stderr, "Failed to change directory\n");
+            return 1;
+        }
+    }
+
     gent_group();
     gent_attribute();
     gent_softlink();
@@ -12866,6 +12885,13 @@ main(void)
     gent_complex();
     gent_complex_be();
 #endif
+
+    if (original_dir[0] != '\0') {
+        if (chdir(original_dir) != 0) {
+            fprintf(stderr, "Failed to restore directory\n");
+            return 1;
+        }
+    }
 
     return 0;
 }

--- a/tools/test/h5format_convert/CMakeLists.txt
+++ b/tools/test/h5format_convert/CMakeLists.txt
@@ -41,7 +41,7 @@ if (HDF5_BUILD_GENERATORS)
     clang_format (HDF5_TOOLS_TEST_H5FC_FORMAT h5fc_gentest)
   endif ()
 
-  #add_test (NAME h5fc_gentest COMMAND ${CMAKE_CROSSCOMPILING_EMULATOR} $<TARGET_FILE:h5fc_gentest>)
+  #add_test (NAME h5fc_gentest COMMAND ${CMAKE_CROSSCOMPILING_EMULATOR} $<TARGET_FILE:h5fc_gentest> "testfiles")
 endif ()
 
 if (HDF5_TEST_TOOLS AND HDF5_TEST_SERIAL)

--- a/tools/test/h5format_convert/h5fc_gentest.c
+++ b/tools/test/h5format_convert/h5fc_gentest.c
@@ -59,6 +59,8 @@ static const char *FILENAME[] = {"h5fc_ext1_i.h5",   /* 0 */
 
 #define NUM 500
 
+#define GENTEST_PATH_MAX_LEN 1024
+
 /*
  * Function: gen_non()
  *
@@ -778,9 +780,25 @@ error:
 } /* end gen_ext() */
 
 int
-main(void)
+main(int argc, const char *const argv[])
 {
     unsigned i, new_format;
+    char original_dir[GENTEST_PATH_MAX_LEN];
+
+    if (argc > 2) {
+        fprintf(stderr, "Usage: %s [subfolder]\n", argv[0]);
+        return 1;
+    }
+    else if (argc == 2) {
+        if (getcwd(original_dir, GENTEST_PATH_MAX_LEN) == NULL) {
+            fprintf(stderr, "Failed to get current working directory\n");
+            return 1;
+        }
+        if (chdir(argv[1]) != 0) {
+            fprintf(stderr, "Failed to change directory\n");
+            return 1;
+        }
+    }
 
     /* Generate a non-latest-format file with v3 superblock */
     gen_non(NON_V3_FILE);
@@ -804,6 +822,13 @@ main(void)
             gen_ext(filename, new_format, i);
         } /* end for */
     }     /* end for */
+
+    if (original_dir[0] != '\0') {
+        if (chdir(original_dir) != 0) {
+            fprintf(stderr, "Failed to restore directory\n");
+            return 1;
+        }
+    }
 
     return 0;
 } /* end main */

--- a/tools/test/h5format_convert/h5fc_gentest.c
+++ b/tools/test/h5format_convert/h5fc_gentest.c
@@ -783,7 +783,7 @@ int
 main(int argc, const char *const argv[])
 {
     unsigned i, new_format;
-    char original_dir[GENTEST_PATH_MAX_LEN];
+    char     original_dir[GENTEST_PATH_MAX_LEN];
 
     if (argc > 2) {
         fprintf(stderr, "Usage: %s [subfolder]\n", argv[0]);

--- a/tools/test/h5jam/CMakeLists.txt
+++ b/tools/test/h5jam/CMakeLists.txt
@@ -23,7 +23,7 @@ if (HDF5_BUILD_GENERATORS)
     clang_format (HDF5_TOOLS_TEST_H5JAM_FORMAT h5jamgentest)
   endif ()
 
-  #add_test (NAME h5jamgentest COMMAND ${CMAKE_CROSSCOMPILING_EMULATOR} $<TARGET_FILE:h5jamgentest>)
+  #add_test (NAME h5jamgentest COMMAND ${CMAKE_CROSSCOMPILING_EMULATOR} $<TARGET_FILE:h5jamgentest> "testfiles")
 endif ()
 
 add_executable (getub ${HDF5_TOOLS_TEST_H5JAM_SOURCE_DIR}/getub.c)

--- a/tools/test/h5jam/h5jamgentest.c
+++ b/tools/test/h5jam/h5jamgentest.c
@@ -36,6 +36,8 @@
 #define FILE8 "twithub.h5"
 #define FILE9 "twithub513.h5"
 
+#define GENTEST_PATH_MAX_LEN 1024
+
 /*
  * This pattern is used to fill text files
  */
@@ -399,8 +401,25 @@ error:
  *-------------------------------------------------------------------------
  */
 int
-main(void)
+main(int argc, const char *const argv[])
 {
+    char original_dir[GENTEST_PATH_MAX_LEN];
+
+    if (argc > 2) {
+        fprintf(stderr, "Usage: %s [subfolder]\n", argv[0]);
+        return 1;
+    }
+    else if (argc == 2) {
+        if (getcwd(original_dir, GENTEST_PATH_MAX_LEN) == NULL) {
+            fprintf(stderr, "Failed to get current working directory\n");
+            return 1;
+        }
+        if (chdir(argv[1]) != 0) {
+            fprintf(stderr, "Failed to change directory\n");
+            return 1;
+        }
+    }
+
     if (create_textfile(UBTXT2, 10) < 0)
         goto error;
     if (create_textfile(UBTXT3, 511) < 0)
@@ -417,9 +436,19 @@ main(void)
     if (gent_ub(FILE9, 1024, 513) < 0)
         goto error;
 
+    if (original_dir[0] != '\0') {
+        if (chdir(original_dir) != 0) {
+            fprintf(stderr, "Failed to restore directory\n");
+            return 1;
+        }
+    }
+
     return EXIT_SUCCESS;
 
 error:
+    /* Try to restore original directory */
+    chdir(original_dir);
+
     fprintf(stderr, "h5jam test generator FAILED\n");
     return EXIT_FAILURE;
 }

--- a/tools/test/h5repack/CMakeLists.txt
+++ b/tools/test/h5repack/CMakeLists.txt
@@ -116,7 +116,7 @@ if (HDF5_BUILD_GENERATORS)
     clang_format (HDF5_TOOLS_TEST_H5REPACK_FORMAT h5repackgentest)
   endif ()
 
-  #add_test (NAME h5repackgentest COMMAND ${CMAKE_CROSSCOMPILING_EMULATOR} $<TARGET_FILE:h5repackgentest>)
+  #add_test (NAME h5repackgentest COMMAND ${CMAKE_CROSSCOMPILING_EMULATOR} $<TARGET_FILE:h5repackgentest> "testfiles")
 endif ()
 
 if (HDF5_TEST_TOOLS AND HDF5_TEST_SERIAL)

--- a/tools/test/h5repack/h5repackgentest.c
+++ b/tools/test/h5repack/h5repackgentest.c
@@ -326,7 +326,7 @@ generate_f32le(bool external)
 int
 main(int argc, const char *const argv[])
 {
-    int i = 0;
+    int  i = 0;
     char original_dir[GENTEST_PATH_MAX_LEN];
 
     if (argc > 2) {

--- a/tools/test/h5repack/h5repackgentest.c
+++ b/tools/test/h5repack/h5repackgentest.c
@@ -41,6 +41,8 @@
 #define FILE_UINT8BE   "h5repack_uint8be"
 #define FILE_F32LE     "h5repack_f32le"
 
+#define GENTEST_PATH_MAX_LEN 1024
+
 #define H5REPACKGENTEST_OOPS                                                                                 \
     {                                                                                                        \
         ret_value = -1;                                                                                      \
@@ -322,9 +324,25 @@ generate_f32le(bool external)
  * Return 0 on success, nonzero on failure.
  */
 int
-main(void)
+main(int argc, const char *const argv[])
 {
     int i = 0;
+    char original_dir[GENTEST_PATH_MAX_LEN];
+
+    if (argc > 2) {
+        fprintf(stderr, "Usage: %s [subfolder]\n", argv[0]);
+        return 1;
+    }
+    else if (argc == 2) {
+        if (getcwd(original_dir, GENTEST_PATH_MAX_LEN) == NULL) {
+            fprintf(stderr, "Failed to get current working directory\n");
+            return 1;
+        }
+        if (chdir(argv[1]) != 0) {
+            fprintf(stderr, "Failed to change directory\n");
+            return 1;
+        }
+    }
 
     for (i = 0; i < 2; i++) {
         bool external = (i & 1) ? true : false;
@@ -344,6 +362,13 @@ main(void)
             printf("A generate_f32le failed!\n");
 
     } /* end for external data storage or not */
+
+    if (original_dir[0] != '\0') {
+        if (chdir(original_dir) != 0) {
+            fprintf(stderr, "Failed to restore directory\n");
+            return 1;
+        }
+    }
 
     return EXIT_SUCCESS;
 } /* end main() */

--- a/tools/test/h5stat/CMakeLists.txt
+++ b/tools/test/h5stat/CMakeLists.txt
@@ -23,7 +23,7 @@ if (HDF5_BUILD_GENERATORS)
     clang_format (HDF5_TOOLS_TEST_H5STAT_FORMAT h5stat_gentest)
   endif ()
 
-  #add_test (NAME h5stat_gentest COMMAND ${CMAKE_CROSSCOMPILING_EMULATOR} $<TARGET_FILE:h5stat_gentest>)
+  #add_test (NAME h5stat_gentest COMMAND ${CMAKE_CROSSCOMPILING_EMULATOR} $<TARGET_FILE:h5stat_gentest> "testfiles")
 endif ()
 
 if (HDF5_TEST_TOOLS AND HDF5_TEST_SERIAL)

--- a/tools/test/h5stat/h5stat_gentest.c
+++ b/tools/test/h5stat/h5stat_gentest.c
@@ -46,6 +46,8 @@
 /* For gen_err_refcount() */
 #define ERR_REFCOUNT_FILE "h5stat_err_refcount.h5"
 
+#define GENTEST_PATH_MAX_LEN 1024
+
 /*
  * Generate HDF5 file with latest format with
  * NUM_GRPS groups and NUM_ATTRS attributes for the dataset
@@ -608,8 +610,25 @@ error:
  */
 
 int
-main(void)
+main(int argc, const char *const argv[])
 {
+    char original_dir[GENTEST_PATH_MAX_LEN];
+
+    if (argc > 2) {
+        fprintf(stderr, "Usage: %s [subfolder]\n", argv[0]);
+        return 1;
+    }
+    else if (argc == 2) {
+        if (getcwd(original_dir, GENTEST_PATH_MAX_LEN) == NULL) {
+            fprintf(stderr, "Failed to get current working directory\n");
+            return 1;
+        }
+        if (chdir(argv[1]) != 0) {
+            fprintf(stderr, "Failed to change directory\n");
+            return 1;
+        }
+    }
+
     if (gen_newgrat_file(NEWGRAT_FILE) < 0)
         goto error;
     if (gen_threshold_file(THRESHOLD_FILE) < 0)
@@ -623,9 +642,19 @@ main(void)
     if (gen_err_refcount(ERR_REFCOUNT_FILE) < 0)
         goto error;
 
+    if (original_dir[0] != '\0') {
+        if (chdir(original_dir) != 0) {
+            fprintf(stderr, "Failed to restore directory\n");
+            return 1;
+        }
+    }
+
     return EXIT_SUCCESS;
 
 error:
+    /* Try to restore original directory */
+    chdir(original_dir);
+
     fprintf(stderr, "h5stat test generator FAILED\n");
     return EXIT_FAILURE;
 }

--- a/tools/test/misc/CMakeLists.txt
+++ b/tools/test/misc/CMakeLists.txt
@@ -34,7 +34,7 @@ if (HDF5_BUILD_GENERATORS)
     target_link_libraries (h5clear_gentest PRIVATE ${HDF5_TOOLS_LIBSH_TARGET} ${HDF5_TEST_LIBSH_TARGET})
   endif ()
   set_target_properties (h5clear_gentest PROPERTIES FOLDER tools)
-  #add_test (NAME H5CLEAR-h5clear_gentest COMMAND ${CMAKE_CROSSCOMPILING_EMULATOR} $<TARGET_FILE:h5clear_gentest>)
+  #add_test (NAME H5CLEAR-h5clear_gentest COMMAND ${CMAKE_CROSSCOMPILING_EMULATOR} $<TARGET_FILE:h5clear_gentest> "testfiles")
 
   #-----------------------------------------------------------------------------
   # Add Target to clang-format

--- a/tools/test/misc/CMakeLists.txt
+++ b/tools/test/misc/CMakeLists.txt
@@ -15,7 +15,7 @@ if (HDF5_BUILD_GENERATORS)
     target_link_libraries (h5repart_gentest PRIVATE ${HDF5_TOOLS_LIBSH_TARGET} ${HDF5_TEST_LIBSH_TARGET})
   endif ()
   set_target_properties (h5repart_gentest PROPERTIES FOLDER generator/tools)
-  #add_test (NAME h5repart_gentest COMMAND ${CMAKE_CROSSCOMPILING_EMULATOR} $<TARGET_FILE:h5repart_gentest>)
+  #add_test (NAME h5repart_gentest COMMAND ${CMAKE_CROSSCOMPILING_EMULATOR} $<TARGET_FILE:h5repart_gentest> "testfiles")
 
   #-----------------------------------------------------------------------------
   # Add Target to clang-format

--- a/tools/test/misc/h5clear_gentest.c
+++ b/tools/test/misc/h5clear_gentest.c
@@ -39,6 +39,7 @@ const char *FILENAME_ENHANCE[] = {
 #define DATASET          "dset"
 #define NUM_ELMTS        100
 #define USERBLOCK        512
+#define GENTEST_PATH_MAX_LEN 1024
 
 /*-------------------------------------------------------------------------
  * Function:    gen_cache_image_file
@@ -365,7 +366,7 @@ error:
  *-------------------------------------------------------------------------
  */
 int
-main(void)
+main(int argc, const char *const argv[])
 {
     hid_t    fid  = H5I_INVALID_HID;                /* File ID */
     hid_t    fcpl = H5I_INVALID_HID;                /* File creation property list */
@@ -377,6 +378,22 @@ main(void)
     hsize_t  dim[1];                                /* Dimension sizes */
     int      data[NUM_ELMTS];                       /* Buffer for data */
     int      i;                                     /* Local index variables */
+    char     original_dir[1024];
+
+    if (argc > 2) {
+        fprintf(stderr, "Usage: %s [subfolder]\n", argv[0]);
+        return 1;
+    }
+    else if (argc == 2) {
+        if (getcwd(original_dir, 1024) == NULL) {
+            fprintf(stderr, "Failed to get current working directory\n");
+            return 1;
+        }
+        if (chdir(argv[1]) != 0) {
+            fprintf(stderr, "Failed to change directory\n");
+            return 1;
+        }
+    }
 
     /* Generate a file with cache image feature enabled */
     if (gen_cache_image_file(CACHE_IMAGE_FILE) < 0)
@@ -588,6 +605,13 @@ main(void)
     if (H5Pclose(fcpl) < 0)
         goto error;
 
+    if (original_dir[0] != '\0') {
+        if (chdir(original_dir) != 0) {
+            fprintf(stderr, "Failed to restore directory\n");
+            return 1;
+        }
+    }
+
     /* Does not flush and does not close the file */
 
     fflush(stdout);
@@ -597,6 +621,8 @@ main(void)
     _exit(0);
 
 error:
+    /* Try to restore original directory */
+    chdir(original_dir);
 
     /* Exit with failure */
     _exit(1);

--- a/tools/test/misc/h5clear_gentest.c
+++ b/tools/test/misc/h5clear_gentest.c
@@ -34,11 +34,11 @@ const char *FILENAME_ENHANCE[] = {
 
 #define KB 1024U
 
-#define CACHE_IMAGE_FILE "h5clear_mdc_image.h5"
-#define DSET             "DSET"
-#define DATASET          "dset"
-#define NUM_ELMTS        100
-#define USERBLOCK        512
+#define CACHE_IMAGE_FILE     "h5clear_mdc_image.h5"
+#define DSET                 "DSET"
+#define DATASET              "dset"
+#define NUM_ELMTS            100
+#define USERBLOCK            512
 #define GENTEST_PATH_MAX_LEN 1024
 
 /*-------------------------------------------------------------------------

--- a/tools/test/misc/h5repart_gentest.c
+++ b/tools/test/misc/h5repart_gentest.c
@@ -21,16 +21,33 @@
 #define FAMILY_SIZE   1024
 #define FILENAME      "family_file%05d.h5"
 
+#define GENTEST_PATH_MAX_LEN 1024
+
 int **buf      = NULL;
 int  *buf_data = NULL;
 
 int
-main(void)
+main(int argc, const char *const argv[])
 {
     hid_t   file = (-1), fapl, space = (-1), dset = (-1);
     char    dname[] = "dataset";
     int     i, j;
     hsize_t dims[2] = {FAMILY_NUMBER, FAMILY_SIZE};
+    char original_dir[GENTEST_PATH_MAX_LEN];
+
+    if (argc > 2) {
+        fprintf(stderr, "Usage: %s [subfolder]\n", argv[0]);
+        return 1;
+    } else if (argc == 2) {
+        if (getcwd(original_dir, GENTEST_PATH_MAX_LEN) == NULL) {
+            fprintf(stderr, "Failed to get current working directory\n");
+            return 1;
+        }
+        if (chdir(argv[1]) != 0) {
+            fprintf(stderr, "Failed to change directory\n");
+            return 1;
+        }
+    }
 
     /* Set up data array */
     if (NULL == (buf_data = (int *)calloc(FAMILY_NUMBER * FAMILY_SIZE, sizeof(int)))) {
@@ -98,6 +115,13 @@ main(void)
     if (H5Fclose(file) < 0) {
         perror("H5Fclose");
         exit(EXIT_FAILURE);
+    }
+
+    if (original_dir[0] != '\0') {
+        if (chdir(original_dir) != 0) {
+            fprintf(stderr, "Failed to restore directory\n");
+            return 1;
+        }
     }
 
     free(buf);

--- a/tools/test/misc/h5repart_gentest.c
+++ b/tools/test/misc/h5repart_gentest.c
@@ -33,12 +33,13 @@ main(int argc, const char *const argv[])
     char    dname[] = "dataset";
     int     i, j;
     hsize_t dims[2] = {FAMILY_NUMBER, FAMILY_SIZE};
-    char original_dir[GENTEST_PATH_MAX_LEN];
+    char    original_dir[GENTEST_PATH_MAX_LEN];
 
     if (argc > 2) {
         fprintf(stderr, "Usage: %s [subfolder]\n", argv[0]);
         return 1;
-    } else if (argc == 2) {
+    }
+    else if (argc == 2) {
         if (getcwd(original_dir, GENTEST_PATH_MAX_LEN) == NULL) {
             fprintf(stderr, "Failed to get current working directory\n");
             return 1;


### PR DESCRIPTION
Part of a project to re-integrate the gentest scripts with VOL tools testing. This makes it simple to have the gentest scripts match the current expected behavior where test files end up in the `testfiles` directory.

`h5perf_gentest.c` is excluded from these changes since it already takes in filenames which can have a subfolder prepended to them.