### PR TITLE
h5cc shell portability fixes

### DIFF
--- a/config/cmake/libh5cc.in
+++ b/config/cmake/libh5cc.in
@@ -66,7 +66,8 @@ for arg in $@ ; do
       exit $status
       ;;
     -show)
-      echo @_PKG_CONFIG_COMPILER@ ${@:2} `pkg-config $pc_args --define-variable=prefix=$dir --cflags --libs @_PKG_CONFIG_LIBNAME@`
+      shift
+      echo @_PKG_CONFIG_COMPILER@ $@ `pkg-config $pc_args --define-variable=prefix=$dir --cflags --libs @_PKG_CONFIG_LIBNAME@`
       exit $status
       ;;
     -help)

--- a/config/cmake/libh5cc.in
+++ b/config/cmake/libh5cc.in
@@ -67,7 +67,7 @@ for arg in $@ ; do
       ;;
     -show)
       shift
-      echo @_PKG_CONFIG_COMPILER@ $@ `pkg-config $pc_args --define-variable=prefix=$dir --cflags --libs @_PKG_CONFIG_LIBNAME@`
+      echo @_PKG_CONFIG_COMPILER@ "$@" `pkg-config $pc_args --define-variable=prefix=$dir --cflags --libs @_PKG_CONFIG_LIBNAME@`
       exit $status
       ;;
     -help)
@@ -79,7 +79,7 @@ for arg in $@ ; do
       pc_args="$pc_args $arg"
       ;;
     *)
-      @_PKG_CONFIG_COMPILER@ $@ `pkg-config $pc_args --define-variable=prefix=$dir --cflags --libs @_PKG_CONFIG_LIBNAME@`
+      @_PKG_CONFIG_COMPILER@ "$@" `pkg-config $pc_args --define-variable=prefix=$dir --cflags --libs @_PKG_CONFIG_LIBNAME@`
       status=$?
       exit $status
       ;;


### PR DESCRIPTION
Two related changes to the CMake `h5cc.in` file:

1. Replace the `${@:2}` construct that is specific to bash shell with a more portable approach based on `shift`, in order to restore compatibility with more strict POSIX shells.  This fixes a regression introduced in #5361.
2. Pass arguments to subprocesses via quoted `"$@"` rather than plain `$@`, in order to prevent the shell from applying word splitting, filename expansion, etc., and therefore ensure that they are passed through to the compiler process unchanged.