### PR TITLE
h5cc: Allow overriding the compilers written into the file

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1058,7 +1058,7 @@ else ()
 endif ()
 
 #-----------------------------------------------------------------------------
-# Option to override the compiler for pkg-config & h5cc
+# Option to override the compiler for h5cc
 #-----------------------------------------------------------------------------
 if (HDF5_ENABLE_PARALLEL AND MPI_C_FOUND)
   set (_HDF5_H5CC_C_COMPILER ${MPI_C_COMPILER})
@@ -1230,13 +1230,6 @@ if (EXISTS "${HDF5_SOURCE_DIR}/fortran" AND IS_DIRECTORY "${HDF5_SOURCE_DIR}/for
       endif ()
     endif ()
 
-    if (HDF5_ENABLE_PARALLEL AND MPI_Fortran_FOUND)
-      set (_HDF5_H5CC_Fortran_COMPILER ${MPI_Fortran_COMPILER})
-    else ()
-      set (_HDF5_H5CC_Fortran_COMPILER ${CMAKE_Fortran_COMPILER})
-    endif ()
-    set (HDF5_H5CC_Fortran_COMPILER ${_HDF5_H5CC_Fortran_COMPILER} CACHE STRING "Fortran compiler to use in h5cc")
-
     add_subdirectory (fortran)
     if (HDF5_BUILD_HL_LIB)
       if (EXISTS "${HDF5_SOURCE_DIR}/hl/fortran" AND IS_DIRECTORY "${HDF5_SOURCE_DIR}/hl/fortran")
@@ -1263,13 +1256,6 @@ if (EXISTS "${HDF5_SOURCE_DIR}/c++" AND IS_DIRECTORY "${HDF5_SOURCE_DIR}/c++")
     endif ()
 
     include (${HDF_RESOURCES_DIR}/HDFCompilerCXXFlags.cmake)
-
-    if (HDF5_ENABLE_PARALLEL AND MPI_CXX_FOUND)
-      set (_HDF5_H5CC_CXX_COMPILER ${MPI_CXX_COMPILER})
-    else ()
-      set (_HDF5_H5CC_CXX_COMPILER ${CMAKE_CXX_COMPILER})
-    endif ()
-    set (HDF5_H5CC_CXX_COMPILER ${_HDF5_H5CC_CXX_COMPILER} CACHE STRING "C++ compiler to use in h5cc")
 
     add_subdirectory (c++)
     if (HDF5_BUILD_HL_LIB)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1058,6 +1058,16 @@ else ()
 endif ()
 
 #-----------------------------------------------------------------------------
+# Option to override the compiler for pkg-config & h5cc
+#-----------------------------------------------------------------------------
+if (HDF5_ENABLE_PARALLEL AND MPI_C_FOUND)
+  set (_PKG_CONFIG_C_COMPILER ${MPI_C_COMPILER})
+else ()
+  set (_PKG_CONFIG_C_COMPILER ${CMAKE_C_COMPILER})
+endif ()
+set (PKG_CONFIG_C_COMPILER ${_PKG_CONFIG_C_COMPILER} CACHE STRING "C compiler to use in h5cc")
+
+#-----------------------------------------------------------------------------
 # Add the HDF5 Library Target to the build
 #-----------------------------------------------------------------------------
 add_subdirectory (src)
@@ -1220,6 +1230,13 @@ if (EXISTS "${HDF5_SOURCE_DIR}/fortran" AND IS_DIRECTORY "${HDF5_SOURCE_DIR}/for
       endif ()
     endif ()
 
+    if (HDF5_ENABLE_PARALLEL AND MPI_Fortran_FOUND)
+      set (_PKG_CONFIG_Fortran_COMPILER ${MPI_Fortran_COMPILER})
+    else ()
+      set (_PKG_CONFIG_Fortran_COMPILER ${CMAKE_Fortran_COMPILER})
+    endif ()
+    set (PKG_CONFIG_Fortran_COMPILER ${_PKG_CONFIG_Fortran_COMPILER} CACHE STRING "Fortran compiler to use in h5cc")
+
     add_subdirectory (fortran)
     if (HDF5_BUILD_HL_LIB)
       if (EXISTS "${HDF5_SOURCE_DIR}/hl/fortran" AND IS_DIRECTORY "${HDF5_SOURCE_DIR}/hl/fortran")
@@ -1246,6 +1263,13 @@ if (EXISTS "${HDF5_SOURCE_DIR}/c++" AND IS_DIRECTORY "${HDF5_SOURCE_DIR}/c++")
     endif ()
 
     include (${HDF_RESOURCES_DIR}/HDFCompilerCXXFlags.cmake)
+
+    if (HDF5_ENABLE_PARALLEL AND MPI_CXX_FOUND)
+      set (_PKG_CONFIG_CXX_COMPILER ${MPI_CXX_COMPILER})
+    else ()
+      set (_PKG_CONFIG_CXX_COMPILER ${CMAKE_CXX_COMPILER})
+    endif ()
+    set (PKG_CONFIG_CXX_COMPILER ${_PKG_CONFIG_CXX_COMPILER} CACHE STRING "C++ compiler to use in h5cc")
 
     add_subdirectory (c++)
     if (HDF5_BUILD_HL_LIB)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1061,11 +1061,11 @@ endif ()
 # Option to override the compiler for pkg-config & h5cc
 #-----------------------------------------------------------------------------
 if (HDF5_ENABLE_PARALLEL AND MPI_C_FOUND)
-  set (_PKG_CONFIG_C_COMPILER ${MPI_C_COMPILER})
+  set (_HDF5_H5CC_C_COMPILER ${MPI_C_COMPILER})
 else ()
-  set (_PKG_CONFIG_C_COMPILER ${CMAKE_C_COMPILER})
+  set (_HDF5_H5CC_C_COMPILER ${CMAKE_C_COMPILER})
 endif ()
-set (PKG_CONFIG_C_COMPILER ${_PKG_CONFIG_C_COMPILER} CACHE STRING "C compiler to use in h5cc")
+set (HDF5_H5CC_C_COMPILER ${_HDF5_H5CC_C_COMPILER} CACHE STRING "C compiler to use in h5cc")
 
 #-----------------------------------------------------------------------------
 # Add the HDF5 Library Target to the build
@@ -1231,11 +1231,11 @@ if (EXISTS "${HDF5_SOURCE_DIR}/fortran" AND IS_DIRECTORY "${HDF5_SOURCE_DIR}/for
     endif ()
 
     if (HDF5_ENABLE_PARALLEL AND MPI_Fortran_FOUND)
-      set (_PKG_CONFIG_Fortran_COMPILER ${MPI_Fortran_COMPILER})
+      set (_HDF5_H5CC_Fortran_COMPILER ${MPI_Fortran_COMPILER})
     else ()
-      set (_PKG_CONFIG_Fortran_COMPILER ${CMAKE_Fortran_COMPILER})
+      set (_HDF5_H5CC_Fortran_COMPILER ${CMAKE_Fortran_COMPILER})
     endif ()
-    set (PKG_CONFIG_Fortran_COMPILER ${_PKG_CONFIG_Fortran_COMPILER} CACHE STRING "Fortran compiler to use in h5cc")
+    set (HDF5_H5CC_Fortran_COMPILER ${_HDF5_H5CC_Fortran_COMPILER} CACHE STRING "Fortran compiler to use in h5cc")
 
     add_subdirectory (fortran)
     if (HDF5_BUILD_HL_LIB)
@@ -1265,11 +1265,11 @@ if (EXISTS "${HDF5_SOURCE_DIR}/c++" AND IS_DIRECTORY "${HDF5_SOURCE_DIR}/c++")
     include (${HDF_RESOURCES_DIR}/HDFCompilerCXXFlags.cmake)
 
     if (HDF5_ENABLE_PARALLEL AND MPI_CXX_FOUND)
-      set (_PKG_CONFIG_CXX_COMPILER ${MPI_CXX_COMPILER})
+      set (_HDF5_H5CC_CXX_COMPILER ${MPI_CXX_COMPILER})
     else ()
-      set (_PKG_CONFIG_CXX_COMPILER ${CMAKE_CXX_COMPILER})
+      set (_HDF5_H5CC_CXX_COMPILER ${CMAKE_CXX_COMPILER})
     endif ()
-    set (PKG_CONFIG_CXX_COMPILER ${_PKG_CONFIG_CXX_COMPILER} CACHE STRING "C++ compiler to use in h5cc")
+    set (HDF5_H5CC_CXX_COMPILER ${_HDF5_H5CC_CXX_COMPILER} CACHE STRING "C++ compiler to use in h5cc")
 
     add_subdirectory (c++)
     if (HDF5_BUILD_HL_LIB)

--- a/c++/src/CMakeLists.txt
+++ b/c++/src/CMakeLists.txt
@@ -206,11 +206,7 @@ install (
 )
 
 if (NOT WIN32 AND NOT MINGW)
-  if (HDF5_ENABLE_PARALLEL AND MPI_CXX_FOUND)
-    set (_PKG_CONFIG_COMPILER ${MPI_CXX_COMPILER})
-  else ()
-    set (_PKG_CONFIG_COMPILER ${CMAKE_CXX_COMPILER})
-  endif ()
+  set (_PKG_CONFIG_COMPILER ${PKG_CONFIG_CXX_COMPILER})
   configure_file (
       ${HDF_RESOURCES_DIR}/libh5cc.in
       ${HDF5_BINARY_DIR}/CMakeFiles/h5c++

--- a/c++/src/CMakeLists.txt
+++ b/c++/src/CMakeLists.txt
@@ -206,7 +206,7 @@ install (
 )
 
 if (NOT WIN32 AND NOT MINGW)
-  set (_PKG_CONFIG_COMPILER ${PKG_CONFIG_CXX_COMPILER})
+  set (_PKG_CONFIG_COMPILER ${HDF5_H5CC_CXX_COMPILER})
   configure_file (
       ${HDF_RESOURCES_DIR}/libh5cc.in
       ${HDF5_BINARY_DIR}/CMakeFiles/h5c++

--- a/config/cmake/HDFCompilerCXXFlags.cmake
+++ b/config/cmake/HDFCompilerCXXFlags.cmake
@@ -140,6 +140,16 @@ if (CMAKE_CXX_COMPILER_LOADED)
   if (HDF5_ENABLE_OPTIMIZATION)
     list (APPEND HDF5_CMAKE_CXX_FLAGS "${OPTIMIZE_CXXFLAGS}")
   endif ()
+
+  #-----------------------------------------------------------------------------
+  # Option to override the compiler for h5c++
+  #-----------------------------------------------------------------------------
+  if (HDF5_ENABLE_PARALLEL AND MPI_CXX_FOUND)
+    set (_HDF5_H5CC_CXX_COMPILER ${MPI_CXX_COMPILER})
+  else ()
+    set (_HDF5_H5CC_CXX_COMPILER ${CMAKE_CXX_COMPILER})
+  endif ()
+  set (HDF5_H5CC_CXX_COMPILER ${_HDF5_H5CC_CXX_COMPILER} CACHE STRING "C++ compiler to use in h5c++")
 endif ()
 
 #-----------------------------------------------------------------------------

--- a/config/cmake/HDFCompilerFortranFlags.cmake
+++ b/config/cmake/HDFCompilerFortranFlags.cmake
@@ -66,6 +66,16 @@ if (NOT MSVC AND NOT MINGW)
 endif ()
 
 #-----------------------------------------------------------------------------
+# Option to override the compiler for h5fc
+#-----------------------------------------------------------------------------
+if (HDF5_ENABLE_PARALLEL AND MPI_Fortran_FOUND)
+  set (_HDF5_H5CC_Fortran_COMPILER ${MPI_Fortran_COMPILER})
+else ()
+  set (_HDF5_H5CC_Fortran_COMPILER ${CMAKE_Fortran_COMPILER})
+endif ()
+set (HDF5_H5CC_Fortran_COMPILER ${_HDF5_H5CC_Fortran_COMPILER} CACHE STRING "Fortran compiler to use in h5fc")
+
+#-----------------------------------------------------------------------------
 # The build mode flags are not added to CMAKE_Fortran_FLAGS, so create a separate
 # variable for them so they can be written out to libhdf5.settings and
 # H5build_settings.c

--- a/fortran/src/CMakeLists.txt
+++ b/fortran/src/CMakeLists.txt
@@ -614,7 +614,7 @@ install (
 )
 
 if (NOT WIN32 AND NOT MINGW)
-  set (_PKG_CONFIG_COMPILER ${PKG_CONFIG_Fortran_COMPILER})
+  set (_PKG_CONFIG_COMPILER ${HDF5_H5CC_Fortran_COMPILER})
   configure_file (
       ${HDF_RESOURCES_DIR}/libh5cc.in
       ${HDF5_BINARY_DIR}/CMakeFiles/h5fc

--- a/fortran/src/CMakeLists.txt
+++ b/fortran/src/CMakeLists.txt
@@ -614,11 +614,7 @@ install (
 )
 
 if (NOT WIN32 AND NOT MINGW)
-  if (HDF5_ENABLE_PARALLEL AND MPI_Fortran_FOUND)
-    set (_PKG_CONFIG_COMPILER ${MPI_Fortran_COMPILER})
-  else ()
-    set (_PKG_CONFIG_COMPILER ${CMAKE_Fortran_COMPILER})
-  endif ()
+  set (_PKG_CONFIG_COMPILER ${PKG_CONFIG_Fortran_COMPILER})
   configure_file (
       ${HDF_RESOURCES_DIR}/libh5cc.in
       ${HDF5_BINARY_DIR}/CMakeFiles/h5fc

--- a/hl/c++/src/CMakeLists.txt
+++ b/hl/c++/src/CMakeLists.txt
@@ -124,11 +124,7 @@ install (
 )
 
 if (NOT WIN32 AND NOT MINGW)
-  if (HDF5_ENABLE_PARALLEL AND MPI_CXX_FOUND)
-    set (_PKG_CONFIG_COMPILER ${MPI_CXX_COMPILER})
-  else ()
-    set (_PKG_CONFIG_COMPILER ${CMAKE_CXX_COMPILER})
-  endif ()
+  set (_PKG_CONFIG_COMPILER ${PKG_CONFIG_CXX_COMPILER})
   configure_file (
       ${HDF_RESOURCES_DIR}/libh5cc.in
       ${HDF5_BINARY_DIR}/CMakeFiles/h5hlc++

--- a/hl/c++/src/CMakeLists.txt
+++ b/hl/c++/src/CMakeLists.txt
@@ -124,7 +124,7 @@ install (
 )
 
 if (NOT WIN32 AND NOT MINGW)
-  set (_PKG_CONFIG_COMPILER ${PKG_CONFIG_CXX_COMPILER})
+  set (_PKG_CONFIG_COMPILER ${HDF5_H5CC_CXX_COMPILER})
   configure_file (
       ${HDF_RESOURCES_DIR}/libh5cc.in
       ${HDF5_BINARY_DIR}/CMakeFiles/h5hlc++

--- a/hl/fortran/src/CMakeLists.txt
+++ b/hl/fortran/src/CMakeLists.txt
@@ -359,7 +359,7 @@ install (
 )
 
 if (NOT WIN32 AND NOT MINGW)
-  set (_PKG_CONFIG_COMPILER ${PKG_CONFIG_Fortran_COMPILER})
+  set (_PKG_CONFIG_COMPILER ${HDF5_H5CC_Fortran_COMPILER})
   configure_file (
       ${HDF_RESOURCES_DIR}/libh5cc.in
       ${HDF5_BINARY_DIR}/CMakeFiles/h5hlfc

--- a/hl/fortran/src/CMakeLists.txt
+++ b/hl/fortran/src/CMakeLists.txt
@@ -359,11 +359,7 @@ install (
 )
 
 if (NOT WIN32 AND NOT MINGW)
-  if (HDF5_ENABLE_PARALLEL AND MPI_Fortran_FOUND)
-    set (_PKG_CONFIG_COMPILER ${MPI_Fortran_COMPILER})
-  else ()
-    set (_PKG_CONFIG_COMPILER ${CMAKE_Fortran_COMPILER})
-  endif ()
+  set (_PKG_CONFIG_COMPILER ${PKG_CONFIG_Fortran_COMPILER})
   configure_file (
       ${HDF_RESOURCES_DIR}/libh5cc.in
       ${HDF5_BINARY_DIR}/CMakeFiles/h5hlfc

--- a/hl/src/CMakeLists.txt
+++ b/hl/src/CMakeLists.txt
@@ -156,7 +156,7 @@ install (
 )
 
 if (NOT WIN32 AND NOT MINGW)
-  set (_PKG_CONFIG_COMPILER ${PKG_CONFIG_C_COMPILER})
+  set (_PKG_CONFIG_COMPILER ${HDF5_H5CC_C_COMPILER})
   configure_file (
       ${HDF_RESOURCES_DIR}/libh5cc.in
       ${HDF5_BINARY_DIR}/CMakeFiles/h5hlcc

--- a/hl/src/CMakeLists.txt
+++ b/hl/src/CMakeLists.txt
@@ -156,11 +156,7 @@ install (
 )
 
 if (NOT WIN32 AND NOT MINGW)
-  if (HDF5_ENABLE_PARALLEL AND MPI_C_FOUND)
-    set (_PKG_CONFIG_COMPILER ${MPI_C_COMPILER})
-  else ()
-    set (_PKG_CONFIG_COMPILER ${CMAKE_C_COMPILER})
-  endif ()
+  set (_PKG_CONFIG_COMPILER ${PKG_CONFIG_C_COMPILER})
   configure_file (
       ${HDF_RESOURCES_DIR}/libh5cc.in
       ${HDF5_BINARY_DIR}/CMakeFiles/h5hlcc

--- a/release_docs/INSTALL_CMake.txt
+++ b/release_docs/INSTALL_CMake.txt
@@ -861,9 +861,9 @@ HDF5_ENABLE_FORMATTERS         "format source files"                            
 HDF5_BUILD_DOC                 "Build documentation"                                OFF
 HDF5_ENABLE_DOXY_WARNINGS      "Enable fail if doxygen parsing has warnings."       OFF
 
-PKG_CONFIG_C_COMPILER          "C compiler to use in h5cc"                          ${CMAKE_C_COMPILER}
-PKG_CONFIG_CXX_COMPILER        "C++ compiler to use in h5cc"                        ${CMAKE_CXX_COMPILER}
-PKG_CONFIG_Fortran_COMPILER    "Fortran compiler to use in h5cc"                    ${CMAKE_Fortran_COMPILER}
+HDF5_H5CC_C_COMPILER           "C compiler to use in h5cc"                          ${CMAKE_C_COMPILER}
+HDF5_H5CC_CXX_COMPILER         "C++ compiler to use in h5cc"                        ${CMAKE_CXX_COMPILER}
+HDF5_H5CC_Fortran_COMPILER     "Fortran compiler to use in h5cc"                    ${CMAKE_Fortran_COMPILER}
 
 ---------------- HDF5 VFD Options ---------------------
 HDF5_ENABLE_DIRECT_VFD         "Build the Direct I/O Virtual File Driver"           OFF

--- a/release_docs/INSTALL_CMake.txt
+++ b/release_docs/INSTALL_CMake.txt
@@ -861,6 +861,10 @@ HDF5_ENABLE_FORMATTERS         "format source files"                            
 HDF5_BUILD_DOC                 "Build documentation"                                OFF
 HDF5_ENABLE_DOXY_WARNINGS      "Enable fail if doxygen parsing has warnings."       OFF
 
+PKG_CONFIG_C_COMPILER          "C compiler to use in h5cc"                          ${CMAKE_C_COMPILER}
+PKG_CONFIG_CXX_COMPILER        "C++ compiler to use in h5cc"                        ${CMAKE_CXX_COMPILER}
+PKG_CONFIG_Fortran_COMPILER    "Fortran compiler to use in h5cc"                    ${CMAKE_Fortran_COMPILER}
+
 ---------------- HDF5 VFD Options ---------------------
 HDF5_ENABLE_DIRECT_VFD         "Build the Direct I/O Virtual File Driver"           OFF
 HDF5_ENABLE_MIRROR_VFD         "Build the Mirror Virtual File Driver"               OFF

--- a/release_docs/RELEASE.txt
+++ b/release_docs/RELEASE.txt
@@ -54,7 +54,7 @@ New Features
           HDF5_H5CC_Fortran_COMPILER for the Fortran compiler
 
       These default to the currently used compiler, preserving the current
-      behavior. However, they can be overriden by users who need to use
+      behavior. However, they can be overridden by users who need to use
       a different compiler at runtime, for example when they build via ccache.
 
     - Added CMAKE_INSTALL_PREFIX to the default plugin path

--- a/release_docs/RELEASE.txt
+++ b/release_docs/RELEASE.txt
@@ -47,6 +47,16 @@ New Features
 
     Configuration:
     -------------
+    - Added CMake configuration options to override compilers in h5cc:
+
+          HDF5_H5CC_C_COMPILER       for the C compiler
+          HDF5_H5CC_CXX_COMPILER     for the C++ compiler
+          HDF5_H5CC_Fortran_COMPILER for the Fortran compiler
+
+      These default to the currently used compiler, preserving the current
+      behavior. However, they can be overriden by users who need to use
+      a different compiler at runtime, for example when they build via ccache.
+
     - Added CMAKE_INSTALL_PREFIX to the default plugin path
 
       To help users find their plugins, the default plugin path has been 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1253,11 +1253,7 @@ install (
 )
 
 if (NOT WIN32)
-  if (HDF5_ENABLE_PARALLEL AND MPI_C_FOUND)
-    set (_PKG_CONFIG_COMPILER ${MPI_C_COMPILER})
-  else ()
-    set (_PKG_CONFIG_COMPILER ${CMAKE_C_COMPILER})
-  endif ()
+  set (_PKG_CONFIG_COMPILER ${PKG_CONFIG_C_COMPILER})
   configure_file (
       ${HDF_RESOURCES_DIR}/libh5cc.in
       ${HDF5_BINARY_DIR}/CMakeFiles/h5cc

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1253,7 +1253,7 @@ install (
 )
 
 if (NOT WIN32)
-  set (_PKG_CONFIG_COMPILER ${PKG_CONFIG_C_COMPILER})
+  set (_PKG_CONFIG_COMPILER ${HDF5_H5CC_C_COMPILER})
   configure_file (
       ${HDF_RESOURCES_DIR}/libh5cc.in
       ${HDF5_BINARY_DIR}/CMakeFiles/h5cc


### PR DESCRIPTION
Add a set of `HDF5_H5CC_C_COMPILER`, `HDF5_H5CC_CXX_COMPILER` and `HDF5_H5CC_Fortran_COMPILER` variables that can be used to override the compiler string written into `h5cc`, `h5c++`, etc.  This is particularly useful when e.g. using ccache during the build, as the ccache path otherwise ends up in `h5cc`.