### PR TITLE
Use ubuntu-22.04 for ubuntu clang

### DIFF
--- a/.github/workflows/cmake-script.yml
+++ b/.github/workflows/cmake-script.yml
@@ -669,7 +669,7 @@ jobs:
   # Linux (Ubuntu) w/ clang + CMake
   #
     name: "Ubuntu Clang CMake"
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - name: Install CMake Dependencies (Linux_clang)
         run: |

--- a/.github/workflows/dev-cmake.yml
+++ b/.github/workflows/dev-cmake.yml
@@ -258,7 +258,7 @@ jobs:
     # Linux (Ubuntu) w/ clang + CMake
     #
     name: "Ubuntu Clang CMake"
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - name: Install CMake Dependencies (Linux_clang)
         run: |


### PR DESCRIPTION
ubuntu clang needs libtinfo5 which can only be used on ubuntu-22.04 runners.