### PR TITLE
Fix issue with H5Fget_file_image() when using newer file formats

### DIFF
--- a/src/H5Fint.c
+++ b/src/H5Fint.c
@@ -3348,7 +3348,8 @@ H5F__get_file_image(H5F_t *file, void *buf_ptr, size_t buf_len, size_t *image_le
             uint32_t chksum; /* Checksum temporary variable      */
             uint8_t *chksum_image_ptr;
 
-            /* When we add new superblock versions make sure this code still works, then modify this assert appropriately */
+            /* When we add new superblock versions make sure this code still works, then modify this assert
+             * appropriately */
             assert(file->shared->sblock->super_vers <= HDF5_SUPERBLOCK_VERSION_3);
 
             /* Offset to checksum */

--- a/src/H5Fint.c
+++ b/src/H5Fint.c
@@ -3322,11 +3322,12 @@ H5F__get_file_image(H5F_t *file, void *buf_ptr, size_t buf_len, size_t *image_le
 
     /* Test to see if a buffer was provided */
     if (buf_ptr != NULL) {
-        unsigned tmp, tmp_size;
+        size_t tmp, tmp_size;
 
         /* Check for buffer too small */
         if ((haddr_t)buf_len < eoa)
             HGOTO_ERROR(H5E_FILE, H5E_BADVALUE, FAIL, "supplied buffer too small");
+        assert(buf_len >= (size_t)H5F_SUPERBLOCK_SIZE(file->shared->sblock));
 
         /* Read in the file image */
         /* (Note compensation for base address addition in internal routine) */
@@ -3341,7 +3342,23 @@ H5F__get_file_image(H5F_t *file, void *buf_ptr, size_t buf_len, size_t *image_le
 
         /* Clear "status_flags" */
         memset((uint8_t *)buf_ptr + tmp, 0, tmp_size);
-    } /* end if */
+
+        /* Check if the version is 2 or greater, if so we need to recalculate the checksum */
+        if (file->shared->sblock->super_vers >= HDF5_SUPERBLOCK_VERSION_2) {
+            uint32_t   chksum;    /* Checksum temporary variable      */
+            uint8_t *chksum_image_ptr;
+
+            /* Offset to checksum */
+            tmp = (size_t)H5F_SUPERBLOCK_SIZE(file->shared->sblock) - H5F_SIZEOF_CHKSUM;
+
+            /* Recompute superblock checksum */
+            chksum = H5_checksum_metadata(buf_ptr, tmp, 0);
+
+            /* Encode checksum into image */
+            chksum_image_ptr = (uint8_t *)buf_ptr + tmp;
+            UINT32ENCODE(chksum_image_ptr, chksum);
+        }
+    }
 
     /* Set *image_len = to EOA */
     *image_len = (size_t)eoa;

--- a/src/H5Fint.c
+++ b/src/H5Fint.c
@@ -3345,7 +3345,7 @@ H5F__get_file_image(H5F_t *file, void *buf_ptr, size_t buf_len, size_t *image_le
 
         /* Check if the version is 2 or greater, if so we need to recalculate the checksum */
         if (file->shared->sblock->super_vers >= HDF5_SUPERBLOCK_VERSION_2) {
-            uint32_t   chksum;    /* Checksum temporary variable      */
+            uint32_t chksum; /* Checksum temporary variable      */
             uint8_t *chksum_image_ptr;
 
             /* Offset to checksum */

--- a/src/H5Fint.c
+++ b/src/H5Fint.c
@@ -3348,6 +3348,9 @@ H5F__get_file_image(H5F_t *file, void *buf_ptr, size_t buf_len, size_t *image_le
             uint32_t chksum; /* Checksum temporary variable      */
             uint8_t *chksum_image_ptr;
 
+            /* When we add new superblock versions make sure this code still works, then modify this assert appropriately */
+            assert(file->shared->sblock->super_vers <= HDF5_SUPERBLOCK_VERSION_3);
+
             /* Offset to checksum */
             tmp = (size_t)H5F_SUPERBLOCK_SIZE(file->shared->sblock) - H5F_SIZEOF_CHKSUM;
 

--- a/test/file_image.c
+++ b/test/file_image.c
@@ -678,7 +678,7 @@ error:
  */
 H5_GCC_CLANG_DIAG_OFF("format-nonliteral")
 static int
-test_get_file_image(const char *test_banner, const int file_name_num, hid_t fapl, bool user)
+test_get_file_image(const char *test_banner, const int file_name_num, hid_t fapl, bool user, H5F_libver_t format)
 {
     char      file_name[1024] = "\0";
     void     *insertion_ptr   = NULL;
@@ -708,6 +708,12 @@ test_get_file_image(const char *test_banner, const int file_name_num, hid_t fapl
     TESTING(test_banner);
 
     memset(&stat_buf, 0, sizeof(h5_stat_t));
+
+    /* Set file format */
+    if (format >= H5F_LIBVER_EARLIEST) {
+        ret = H5Pset_libver_bounds(fapl, format, H5F_LIBVER_LATEST);
+        VERIFY(ret >= 0, "H5Pset_libver_bounds");
+    }
 
     /* set flag if we are dealing with a family file */
     driver = H5Pget_driver(fapl);
@@ -773,130 +779,133 @@ test_get_file_image(const char *test_banner, const int file_name_num, hid_t fapl
     err = H5Fclose(file_id);
     VERIFY(err == SUCCEED, "H5Fclose(file_id) failed.");
 
-    if (is_family_file) {
-        char    member_file_name[1024];
-        ssize_t bytes_to_read;
-        ssize_t member_size;
-        ssize_t size_remaining;
+    /* Only check the byte-exactness for the earliest format, since consistency flags and the checksum can interfere with this */
+    if (format <= H5F_LIBVER_EARLIEST) {
+        if (is_family_file) {
+            char    member_file_name[1024];
+            ssize_t bytes_to_read;
+            ssize_t member_size;
+            ssize_t size_remaining;
 
-        /*
-         * Modifications need to be made to accommodate userblock when
-         * H5Fget_file_image() works for family driver
-         */
-        i         = 0;
-        file_size = 0;
+            /*
+             * Modifications need to be made to accommodate userblock when
+             * H5Fget_file_image() works for family driver
+             */
+            i         = 0;
+            file_size = 0;
 
-        do {
-            snprintf(member_file_name, (size_t)1024, file_name, i);
+            do {
+                snprintf(member_file_name, (size_t)1024, file_name, i);
 
-            /* get the size of the member file */
-            result = HDstat(member_file_name, &stat_buf);
+                /* get the size of the member file */
+                result = HDstat(member_file_name, &stat_buf);
+                VERIFY(result == 0, "HDstat() failed.");
+
+                member_size = (ssize_t)stat_buf.st_size;
+
+                i++;
+                file_size += member_size;
+            } while (member_size > 0);
+
+            /* Since we use the eoa to calculate the image size, the file size
+             * may be larger.  This is OK, as long as (in this specialized instance)
+             * the remainder of the file is all '\0's.
+             */
+            VERIFY(file_size >= image_size, "file size != image size.");
+
+            /* allocate a buffer for the test file image */
+            file_image_ptr = malloc((size_t)file_size);
+            VERIFY(file_image_ptr != NULL, "malloc(2f) failed.");
+
+            size_remaining = image_size;
+            insertion_ptr  = file_image_ptr;
+            i              = 0;
+
+            while (size_remaining > 0) {
+                /* construct the member file name */
+                snprintf(member_file_name, 1024, file_name, i);
+
+                /* open the test file using standard I/O calls */
+                fd = HDopen(member_file_name, O_RDONLY);
+                VERIFY(fd >= 0, "HDopen() failed.");
+
+                if (size_remaining >= FAMILY_SIZE) {
+                    bytes_to_read = FAMILY_SIZE;
+                    size_remaining -= FAMILY_SIZE;
+                }
+                else {
+                    bytes_to_read  = size_remaining;
+                    size_remaining = 0;
+                }
+
+                /* read the member file from disk into the buffer */
+                bytes_read = HDread(fd, insertion_ptr, (size_t)bytes_to_read);
+                VERIFY(bytes_read == bytes_to_read, "HDread() failed.");
+
+                insertion_ptr = (void *)(((char *)insertion_ptr) + bytes_to_read);
+
+                i++;
+
+                /* close the test file */
+                result = HDclose(fd);
+                VERIFY(result == 0, "HDclose() failed.");
+            }
+        }
+        else {
+            /* get the size of the test file */
+            result = HDstat(file_name, &stat_buf);
             VERIFY(result == 0, "HDstat() failed.");
 
-            member_size = (ssize_t)stat_buf.st_size;
+            /* Since we use the eoa to calculate the image size, the file size
+             * may be larger.  This is OK, as long as (in this specialized instance)
+             * the remainder of the file is all '\0's.
+             */
+            file_size = (ssize_t)stat_buf.st_size;
+            if (user) {
+                VERIFY(file_size > USERBLOCK_SIZE, "file size !> userblock size.");
+                file_size -= USERBLOCK_SIZE;
+            }
 
-            i++;
-            file_size += member_size;
-        } while (member_size > 0);
+            /* with latest mods to truncate call in core file drive,
+             * file size should match image size
+             */
+            VERIFY(file_size == image_size, "file size != image size.");
 
-        /* Since we use the eoa to calculate the image size, the file size
-         * may be larger.  This is OK, as long as (in this specialized instance)
-         * the remainder of the file is all '\0's.
-         */
-        VERIFY(file_size >= image_size, "file size != image size.");
-
-        /* allocate a buffer for the test file image */
-        file_image_ptr = malloc((size_t)file_size);
-        VERIFY(file_image_ptr != NULL, "malloc(2f) failed.");
-
-        size_remaining = image_size;
-        insertion_ptr  = file_image_ptr;
-        i              = 0;
-
-        while (size_remaining > 0) {
-            /* construct the member file name */
-            snprintf(member_file_name, 1024, file_name, i);
+            /* allocate a buffer for the test file image */
+            file_image_ptr = malloc((size_t)file_size);
+            VERIFY(file_image_ptr != NULL, "malloc(2) failed.");
 
             /* open the test file using standard I/O calls */
-            fd = HDopen(member_file_name, O_RDONLY);
+            fd = HDopen(file_name, O_RDONLY);
             VERIFY(fd >= 0, "HDopen() failed.");
 
-            if (size_remaining >= FAMILY_SIZE) {
-                bytes_to_read = FAMILY_SIZE;
-                size_remaining -= FAMILY_SIZE;
+            if (user) {
+                HDoff_t off;
+
+                /* Position at userblock */
+                off = HDlseek(fd, USERBLOCK_SIZE, SEEK_SET);
+                VERIFY(off >= 0, "HDlseek() failed.");
             }
-            else {
-                bytes_to_read  = size_remaining;
-                size_remaining = 0;
-            }
 
-            /* read the member file from disk into the buffer */
-            bytes_read = HDread(fd, insertion_ptr, (size_t)bytes_to_read);
-            VERIFY(bytes_read == bytes_to_read, "HDread() failed.");
-
-            insertion_ptr = (void *)(((char *)insertion_ptr) + bytes_to_read);
-
-            i++;
+            /* read the test file from disk into the buffer */
+            bytes_read = HDread(fd, file_image_ptr, (size_t)file_size);
+            VERIFY(bytes_read == file_size, "HDread() failed.");
 
             /* close the test file */
             result = HDclose(fd);
             VERIFY(result == 0, "HDclose() failed.");
         }
-    }
-    else {
-        /* get the size of the test file */
-        result = HDstat(file_name, &stat_buf);
-        VERIFY(result == 0, "HDstat() failed.");
 
-        /* Since we use the eoa to calculate the image size, the file size
-         * may be larger.  This is OK, as long as (in this specialized instance)
-         * the remainder of the file is all '\0's.
-         */
-        file_size = (ssize_t)stat_buf.st_size;
-        if (user) {
-            VERIFY(file_size > USERBLOCK_SIZE, "file size !> userblock size.");
-            file_size -= USERBLOCK_SIZE;
+        /* verify that the file and the image contain the same data */
+        identical = true;
+        i         = 0;
+        while ((i < (int)image_size) && identical) {
+            if (((char *)image_ptr)[i] != ((char *)file_image_ptr)[i])
+                identical = false;
+            i++;
         }
-
-        /* with latest mods to truncate call in core file drive,
-         * file size should match image size
-         */
-        VERIFY(file_size == image_size, "file size != image size.");
-
-        /* allocate a buffer for the test file image */
-        file_image_ptr = malloc((size_t)file_size);
-        VERIFY(file_image_ptr != NULL, "malloc(2) failed.");
-
-        /* open the test file using standard I/O calls */
-        fd = HDopen(file_name, O_RDONLY);
-        VERIFY(fd >= 0, "HDopen() failed.");
-
-        if (user) {
-            HDoff_t off;
-
-            /* Position at userblock */
-            off = HDlseek(fd, USERBLOCK_SIZE, SEEK_SET);
-            VERIFY(off >= 0, "HDlseek() failed.");
-        }
-
-        /* read the test file from disk into the buffer */
-        bytes_read = HDread(fd, file_image_ptr, (size_t)file_size);
-        VERIFY(bytes_read == file_size, "HDread() failed.");
-
-        /* close the test file */
-        result = HDclose(fd);
-        VERIFY(result == 0, "HDclose() failed.");
+        VERIFY(identical, "file and image differ.");
     }
-
-    /* verify that the file and the image contain the same data */
-    identical = true;
-    i         = 0;
-    while ((i < (int)image_size) && identical) {
-        if (((char *)image_ptr)[i] != ((char *)file_image_ptr)[i])
-            identical = false;
-        i++;
-    }
-    VERIFY(identical, "file and image differ.");
 
     /* finally, verify that we can use the core file driver to open the image */
 
@@ -1319,6 +1328,7 @@ main(void)
     hid_t    fapl;
     bool     driver_is_default_compatible;
     unsigned user;
+    H5F_libver_t format;
 
     h5_test_init();
 
@@ -1334,30 +1344,33 @@ main(void)
     }
 
     /* Perform tests with/without user block */
-    for (user = false; user <= true; user++) {
+    for (user = false; user <= true; user++)
 
-        /* test H5Fget_file_image() with sec2 driver */
-        fapl = H5Pcreate(H5P_FILE_ACCESS);
-        if (H5Pset_fapl_sec2(fapl) < 0)
-            errors++;
-        else
-            errors += test_get_file_image("H5Fget_file_image() with sec2 driver", 0, fapl, user);
+        /* Perform tests with different file format versions.  H5F_LIBVER_ERROR causes the test to use the default settings. */
+        for (format = H5F_LIBVER_ERROR; format <= H5F_LIBVER_LATEST; format++) {
 
-        /* test H5Fget_file_image() with stdio driver */
-        fapl = H5Pcreate(H5P_FILE_ACCESS);
-        if (H5Pset_fapl_stdio(fapl) < 0)
-            errors++;
-        else
-            errors += test_get_file_image("H5Fget_file_image() with stdio driver", 1, fapl, user);
+            /* test H5Fget_file_image() with sec2 driver */
+            fapl = H5Pcreate(H5P_FILE_ACCESS);
+            if (H5Pset_fapl_sec2(fapl) < 0)
+                errors++;
+            else
+                errors += test_get_file_image("H5Fget_file_image() with sec2 driver", 0, fapl, user, format);
 
-        /* test H5Fget_file_image() with core driver */
-        fapl = H5Pcreate(H5P_FILE_ACCESS);
-        if (H5Pset_fapl_core(fapl, (size_t)(64 * 1024), true) < 0)
-            errors++;
-        else
-            errors += test_get_file_image("H5Fget_file_image() with core driver", 2, fapl, user);
+            /* test H5Fget_file_image() with stdio driver */
+            fapl = H5Pcreate(H5P_FILE_ACCESS);
+            if (H5Pset_fapl_stdio(fapl) < 0)
+                errors++;
+            else
+                errors += test_get_file_image("H5Fget_file_image() with stdio driver", 1, fapl, user, format);
 
-    } /* end for */
+            /* test H5Fget_file_image() with core driver */
+            fapl = H5Pcreate(H5P_FILE_ACCESS);
+            if (H5Pset_fapl_core(fapl, (size_t)(64 * 1024), true) < 0)
+                errors++;
+            else
+                errors += test_get_file_image("H5Fget_file_image() with core driver", 2, fapl, user, format);
+
+        } /* end for */
 
 #if 0
     /* at present, H5Fget_file_image() rejects files opened with the

--- a/test/file_image.c
+++ b/test/file_image.c
@@ -678,7 +678,8 @@ error:
  */
 H5_GCC_CLANG_DIAG_OFF("format-nonliteral")
 static int
-test_get_file_image(const char *test_banner, const int file_name_num, hid_t fapl, bool user, H5F_libver_t format)
+test_get_file_image(const char *test_banner, const int file_name_num, hid_t fapl, bool user,
+                    H5F_libver_t format)
 {
     char      file_name[1024] = "\0";
     void     *insertion_ptr   = NULL;
@@ -779,7 +780,8 @@ test_get_file_image(const char *test_banner, const int file_name_num, hid_t fapl
     err = H5Fclose(file_id);
     VERIFY(err == SUCCEED, "H5Fclose(file_id) failed.");
 
-    /* Only check the byte-exactness for the earliest format, since consistency flags and the checksum can interfere with this */
+    /* Only check the byte-exactness for the earliest format, since consistency flags and the checksum can
+     * interfere with this */
     if (format <= H5F_LIBVER_EARLIEST) {
         if (is_family_file) {
             char    member_file_name[1024];
@@ -1324,10 +1326,10 @@ error:
 int
 main(void)
 {
-    int      errors = 0;
-    hid_t    fapl;
-    bool     driver_is_default_compatible;
-    unsigned user;
+    int          errors = 0;
+    hid_t        fapl;
+    bool         driver_is_default_compatible;
+    unsigned     user;
     H5F_libver_t format;
 
     h5_test_init();
@@ -1346,7 +1348,8 @@ main(void)
     /* Perform tests with/without user block */
     for (user = false; user <= true; user++)
 
-        /* Perform tests with different file format versions.  H5F_LIBVER_ERROR causes the test to use the default settings. */
+        /* Perform tests with different file format versions.  H5F_LIBVER_ERROR causes the test to use the
+         * default settings. */
         for (format = H5F_LIBVER_ERROR; format <= H5F_LIBVER_LATEST; format++) {
 
             /* test H5Fget_file_image() with sec2 driver */


### PR DESCRIPTION
When H5Fget_file_image() retrieves the image of the file, it clears any file status flags (such as the one indicating it is currently open for writing) to avoid problems when reopening the file image. However, it did not recalculate the superblock checksum , which includes these status flags in the checksummed data, after changing the status flags. This caused the checksum to fail to verify when reopening the file image. This change recalculates the checksum after clearing the status flags and writes it to the correct location in the file image.

resolves #1915 