### PR TITLE
Fix caching issue in ROS3 VFD

### DIFF
--- a/release_docs/RELEASE.txt
+++ b/release_docs/RELEASE.txt
@@ -549,6 +549,16 @@ Bug Fixes since HDF5-2.0.0 release
 ===================================
     Library
     -------
+    - Fixed an issue with caching in the ROS3 VFD
+
+      The ROS3 VFD uses a very simple caching mechanism that caches the
+      first 16MiB of a file during file open and serves later reads from
+      that cache if the offset + length falls within the cached range of
+      bytes. Combinations of offset + length that extended exactly to the
+      end of the cached range of bytes (for example, offset=0 and
+      len=16777216) would end up not being served from the cache due to
+      an incorrect range check. This has now been fixed.
+
     - Fixed an error with H5Fget_file_image() with the latest file format
 
       When using H5Fget_file_image() on a file created with the latest file

--- a/src/H5FDros3.c
+++ b/src/H5FDros3.c
@@ -789,8 +789,8 @@ done:
             if (H5FD__s3comms_s3r_close(handle) < 0)
                 HDONE_ERROR(H5E_VFL, H5E_CANTCLOSEFILE, NULL, "unable to close s3 file handle");
         if (file != NULL) {
-            H5MM_xfree(file->cache);
-            file = H5FL_FREE(H5FD_ros3_t, file);
+            file->cache = H5MM_xfree(file->cache);
+            file        = H5FL_FREE(H5FD_ros3_t, file);
         }
         curl_global_cleanup();
     }
@@ -827,8 +827,8 @@ H5FD__ros3_close(H5FD_t H5_ATTR_UNUSED *_file)
         HGOTO_ERROR(H5E_VFL, H5E_CANTCLOSEFILE, FAIL, "unable to close S3 request handle");
 
     /* Release the file info */
-    H5MM_xfree(file->cache);
-    file = H5FL_FREE(H5FD_ros3_t, file);
+    file->cache = H5MM_xfree(file->cache);
+    file        = H5FL_FREE(H5FD_ros3_t, file);
 
 done:
     curl_global_cleanup();
@@ -1097,7 +1097,7 @@ H5FD__ros3_read(H5FD_t *_file, H5FD_mem_t H5_ATTR_UNUSED type, hid_t H5_ATTR_UNU
     /* Copy from the cache when accessing the first N bytes of the file.
      * Saves network I/O operations when opening files.
      */
-    if (addr + size < file->cache_size) {
+    if (addr + size <= file->cache_size) {
         memcpy(buf, file->cache + addr, size);
     }
     else {


### PR DESCRIPTION
Fix an incorrect range check that would prevent reads from being served from the ROS3 VFD's internal cache when the offset + length of the read extends exactly to the end of the cached range of bytes.

Fixes #4700