### PR TITLE
Clean up API decorations in H5api_adpt.h

### DIFF
--- a/c++/src/H5AbstractDs.h
+++ b/c++/src/H5AbstractDs.h
@@ -32,7 +32,7 @@ class DataSpace;
     It provides a collection of services that are common to both Attribute
     and DataSet.
 */
-class H5_DLLCPP AbstractDs {
+class H5CPP_DLL AbstractDs {
   public:
     // Gets a copy the datatype of that this abstract dataset uses.
     // Note that this datatype is a generic one and can only be accessed

--- a/c++/src/H5ArrayType.h
+++ b/c++/src/H5ArrayType.h
@@ -21,7 +21,7 @@ namespace H5 {
      the HDF5's Array Datatypes.
 */
 // Inheritance: DataType -> H5Object -> H5Location -> IdComponent
-class H5_DLLCPP ArrayType : public DataType {
+class H5CPP_DLL ArrayType : public DataType {
   public:
     // Constructor that creates a new array data type based on the
     // specified base type.

--- a/c++/src/H5AtomType.h
+++ b/c++/src/H5AtomType.h
@@ -24,7 +24,7 @@ namespace H5 {
     from DataType.
 */
 // Inheritance: DataType -> H5Object -> H5Location -> IdComponent
-class H5_DLLCPP AtomType : public DataType {
+class H5CPP_DLL AtomType : public DataType {
   public:
     // Returns the byte order of an atomic datatype.
     H5T_order_t getOrder() const;

--- a/c++/src/H5Attribute.h
+++ b/c++/src/H5Attribute.h
@@ -25,7 +25,7 @@ namespace H5 {
     a location.
 */
 //  Inheritance: multiple H5Location/AbstractDs -> IdComponent
-class H5_DLLCPP Attribute : public AbstractDs, public H5Location {
+class H5CPP_DLL Attribute : public AbstractDs, public H5Location {
   public:
     // Copy constructor: same as the original Attribute.
     Attribute(const Attribute &original);

--- a/c++/src/H5CommonFG.h
+++ b/c++/src/H5CommonFG.h
@@ -26,7 +26,7 @@ class VarLenType;
     \brief \a CommonFG is an abstract base class of H5Group.
 */
 /* Note: This class is being deprecated gradually. */
-class H5_DLLCPP CommonFG {
+class H5CPP_DLL CommonFG {
   public:
     // Opens a generic named datatype in this location.
     DataType openDataType(const char *name) const;

--- a/c++/src/H5CompType.h
+++ b/c++/src/H5CompType.h
@@ -21,7 +21,7 @@ namespace H5 {
     compound datatypes.
 */
 //  Inheritance: DataType -> H5Object -> H5Location -> IdComponent
-class H5_DLLCPP CompType : public DataType {
+class H5CPP_DLL CompType : public DataType {
   public:
     // Default constructor
     CompType();

--- a/c++/src/H5DaccProp.h
+++ b/c++/src/H5DaccProp.h
@@ -21,7 +21,7 @@ namespace H5 {
     wrappers for the HDF5 dataset access property functions.
 */
 //  Inheritance: LinkAccPropList -> PropList -> IdComponent
-class H5_DLLCPP DSetAccPropList : public LinkAccPropList {
+class H5CPP_DLL DSetAccPropList : public LinkAccPropList {
   public:
     ///\brief Default dataset creation property list.
     static const DSetAccPropList &DEFAULT;

--- a/c++/src/H5DataSet.h
+++ b/c++/src/H5DataSet.h
@@ -24,7 +24,7 @@ namespace H5 {
     inherits from H5Object because a dataset is an HDF5 object.
 */
 //  Inheritance: multiple H5Object/AbstractDs -> H5Location -> IdComponent
-class H5_DLLCPP DataSet : public H5Object, public AbstractDs {
+class H5CPP_DLL DataSet : public H5Object, public AbstractDs {
   public:
     // Close this dataset.
     virtual void close() override;

--- a/c++/src/H5DataSpace.h
+++ b/c++/src/H5DataSpace.h
@@ -21,7 +21,7 @@ namespace H5 {
      the HDF5's dataspaces.
 */
 //  Inheritance: IdComponent
-class H5_DLLCPP DataSpace : public IdComponent {
+class H5CPP_DLL DataSpace : public IdComponent {
   public:
     ///\brief Default DataSpace objects
     static const DataSpace &ALL;

--- a/c++/src/H5DataType.h
+++ b/c++/src/H5DataType.h
@@ -24,7 +24,7 @@ namespace H5 {
     and VarLenType.
 */
 //  Inheritance: DataType -> H5Object -> H5Location -> IdComponent
-class H5_DLLCPP DataType : public H5Object {
+class H5CPP_DLL DataType : public H5Object {
   public:
     // Creates a datatype given its class and size
     DataType(const H5T_class_t type_class, size_t size);

--- a/c++/src/H5DcreatProp.h
+++ b/c++/src/H5DcreatProp.h
@@ -25,7 +25,7 @@ class DataSpace;
     wrappers for the HDF5 dataset creation property functions.
 */
 //  Inheritance: ObjCreatPropList -> PropList -> IdComponent
-class H5_DLLCPP DSetCreatPropList : public ObjCreatPropList {
+class H5CPP_DLL DSetCreatPropList : public ObjCreatPropList {
   public:
     ///\brief Default dataset creation property list.
     static const DSetCreatPropList &DEFAULT;

--- a/c++/src/H5DxferProp.h
+++ b/c++/src/H5DxferProp.h
@@ -21,7 +21,7 @@ namespace H5 {
     wrappers for the HDF5 dataset memory and transfer property list.
 */
 //  Inheritance: PropList -> IdComponent
-class H5_DLLCPP DSetMemXferPropList : public PropList {
+class H5CPP_DLL DSetMemXferPropList : public PropList {
   public:
     ///\brief Default dataset memory and transfer property list.
     static const DSetMemXferPropList &DEFAULT;

--- a/c++/src/H5EnumType.h
+++ b/c++/src/H5EnumType.h
@@ -21,7 +21,7 @@ namespace H5 {
     enum datatypes.
 */
 //  Inheritance: DataType -> H5Object -> H5Location -> IdComponent
-class H5_DLLCPP EnumType : public DataType {
+class H5CPP_DLL EnumType : public DataType {
 
   public:
     // Creates an empty enumeration datatype based on a native signed

--- a/c++/src/H5Exception.h
+++ b/c++/src/H5Exception.h
@@ -24,7 +24,7 @@ namespace H5 {
 
     Many classes are derived from Exception for specific HDF5 C interfaces.
 */
-class H5_DLLCPP Exception {
+class H5CPP_DLL Exception {
   public:
     // Creates an exception with a function name where the failure occurs
     // and an optional detailed message
@@ -85,84 +85,84 @@ class H5_DLLCPP Exception {
     H5std_string func_name;
 };
 
-class H5_DLLCPP FileIException : public Exception {
+class H5CPP_DLL FileIException : public Exception {
   public:
     FileIException(const H5std_string &func_name, const H5std_string &message = DEFAULT_MSG);
     FileIException();
     virtual ~FileIException() override = default;
 };
 
-class H5_DLLCPP GroupIException : public Exception {
+class H5CPP_DLL GroupIException : public Exception {
   public:
     GroupIException(const H5std_string &func_name, const H5std_string &message = DEFAULT_MSG);
     GroupIException();
     virtual ~GroupIException() override = default;
 };
 
-class H5_DLLCPP DataSpaceIException : public Exception {
+class H5CPP_DLL DataSpaceIException : public Exception {
   public:
     DataSpaceIException(const H5std_string &func_name, const H5std_string &message = DEFAULT_MSG);
     DataSpaceIException();
     virtual ~DataSpaceIException() override = default;
 };
 
-class H5_DLLCPP DataTypeIException : public Exception {
+class H5CPP_DLL DataTypeIException : public Exception {
   public:
     DataTypeIException(const H5std_string &func_name, const H5std_string &message = DEFAULT_MSG);
     DataTypeIException();
     virtual ~DataTypeIException() override = default;
 };
 
-class H5_DLLCPP ObjHeaderIException : public Exception {
+class H5CPP_DLL ObjHeaderIException : public Exception {
   public:
     ObjHeaderIException(const H5std_string &func_name, const H5std_string &message = DEFAULT_MSG);
     ObjHeaderIException();
     virtual ~ObjHeaderIException() override = default;
 };
 
-class H5_DLLCPP PropListIException : public Exception {
+class H5CPP_DLL PropListIException : public Exception {
   public:
     PropListIException(const H5std_string &func_name, const H5std_string &message = DEFAULT_MSG);
     PropListIException();
     virtual ~PropListIException() override = default;
 };
 
-class H5_DLLCPP DataSetIException : public Exception {
+class H5CPP_DLL DataSetIException : public Exception {
   public:
     DataSetIException(const H5std_string &func_name, const H5std_string &message = DEFAULT_MSG);
     DataSetIException();
     virtual ~DataSetIException() override = default;
 };
 
-class H5_DLLCPP AttributeIException : public Exception {
+class H5CPP_DLL AttributeIException : public Exception {
   public:
     AttributeIException(const H5std_string &func_name, const H5std_string &message = DEFAULT_MSG);
     AttributeIException();
     virtual ~AttributeIException() override = default;
 };
 
-class H5_DLLCPP ReferenceException : public Exception {
+class H5CPP_DLL ReferenceException : public Exception {
   public:
     ReferenceException(const H5std_string &func_name, const H5std_string &message = DEFAULT_MSG);
     ReferenceException();
     virtual ~ReferenceException() override = default;
 };
 
-class H5_DLLCPP LibraryIException : public Exception {
+class H5CPP_DLL LibraryIException : public Exception {
   public:
     LibraryIException(const H5std_string &func_name, const H5std_string &message = DEFAULT_MSG);
     LibraryIException();
     virtual ~LibraryIException() override = default;
 };
 
-class H5_DLLCPP LocationException : public Exception {
+class H5CPP_DLL LocationException : public Exception {
   public:
     LocationException(const H5std_string &func_name, const H5std_string &message = DEFAULT_MSG);
     LocationException();
     virtual ~LocationException() override = default;
 };
 
-class H5_DLLCPP IdComponentException : public Exception {
+class H5CPP_DLL IdComponentException : public Exception {
   public:
     IdComponentException(const H5std_string &func_name, const H5std_string &message = DEFAULT_MSG);
     IdComponentException();

--- a/c++/src/H5FaccProp.h
+++ b/c++/src/H5FaccProp.h
@@ -21,7 +21,7 @@ namespace H5 {
     wrappers for the HDF5 file access property list.
 */
 //  Inheritance: PropList -> IdComponent
-class H5_DLLCPP FileAccPropList : public PropList {
+class H5CPP_DLL FileAccPropList : public PropList {
   public:
     ///\brief Default file access property list.
     static const FileAccPropList &DEFAULT;

--- a/c++/src/H5FcreatProp.h
+++ b/c++/src/H5FcreatProp.h
@@ -21,7 +21,7 @@ namespace H5 {
     wrappers for the HDF5 file create property list.
 */
 //  Inheritance: PropList -> IdComponent
-class H5_DLLCPP FileCreatPropList : public PropList {
+class H5CPP_DLL FileCreatPropList : public PropList {
   public:
     ///\brief Default file creation property list.
     static const FileCreatPropList &DEFAULT;

--- a/c++/src/H5File.h
+++ b/c++/src/H5File.h
@@ -21,7 +21,7 @@ namespace H5 {
     as file is a root group.
 */
 //  Inheritance: Group -> CommonFG/H5Object -> H5Location -> IdComponent
-class H5_DLLCPP H5File : public Group {
+class H5CPP_DLL H5File : public Group {
   public:
     // Creates or opens an HDF5 file.
     H5File(const char *name, unsigned int flags,

--- a/c++/src/H5FloatType.h
+++ b/c++/src/H5FloatType.h
@@ -21,7 +21,7 @@ namespace H5 {
     floating point datatype.
 */
 //  Inheritance: AtomType -> DataType -> H5Object -> H5Location -> IdComponent
-class H5_DLLCPP FloatType : public AtomType {
+class H5CPP_DLL FloatType : public AtomType {
   public:
     // Creates a floating-point type using a predefined type.
     FloatType(const PredType &pred_type);

--- a/c++/src/H5Group.h
+++ b/c++/src/H5Group.h
@@ -20,7 +20,7 @@ namespace H5 {
     \brief Class Group represents an HDF5 group.
 */
 //  Inheritance: CommonFG/H5Object -> H5Location -> IdComponent
-class H5_DLLCPP Group : public H5Object, public CommonFG {
+class H5CPP_DLL Group : public H5Object, public CommonFG {
   public:
     // Close this group.
     virtual void close() override;

--- a/c++/src/H5IdComponent.h
+++ b/c++/src/H5IdComponent.h
@@ -23,7 +23,7 @@ namespace H5 {
     In most cases, the C library handles these operations and an application
     rarely needs them.
 */
-class H5_DLLCPP IdComponent {
+class H5CPP_DLL IdComponent {
   public:
     // Increment reference counter.
     void incRefCount(const hid_t obj_id) const;

--- a/c++/src/H5IntType.h
+++ b/c++/src/H5IntType.h
@@ -21,7 +21,7 @@ namespace H5 {
     integer datatype.
 */
 //  Inheritance: AtomType -> DataType -> H5Object -> H5Location -> IdComponent
-class H5_DLLCPP IntType : public AtomType {
+class H5CPP_DLL IntType : public AtomType {
   public:
     // Creates an integer type using a predefined type
     IntType(const PredType &pred_type);

--- a/c++/src/H5LaccProp.h
+++ b/c++/src/H5LaccProp.h
@@ -21,7 +21,7 @@ namespace H5 {
     wrappers for the HDF5 link access property list.
 */
 // Inheritance: PropList -> IdComponent
-class H5_DLLCPP LinkAccPropList : public PropList {
+class H5CPP_DLL LinkAccPropList : public PropList {
   public:
     ///\brief Default link access property list.
     static const LinkAccPropList &DEFAULT;

--- a/c++/src/H5LcreatProp.h
+++ b/c++/src/H5LcreatProp.h
@@ -21,7 +21,7 @@ namespace H5 {
     wrappers for the HDF5 link creation property list.
 */
 // Inheritance: PropList -> IdComponent
-class H5_DLLCPP LinkCreatPropList : public PropList {
+class H5CPP_DLL LinkCreatPropList : public PropList {
   public:
     ///\brief Default link creation property list.
     static const LinkCreatPropList &DEFAULT;

--- a/c++/src/H5Library.h
+++ b/c++/src/H5Library.h
@@ -22,7 +22,7 @@ namespace H5 {
     It is not necessary to construct an instance of H5Library to use the
     methods.
 */
-class H5_DLLCPP H5Library {
+class H5CPP_DLL H5Library {
   public:
     // Initializes the HDF5 library.
     static void open();

--- a/c++/src/H5Location.h
+++ b/c++/src/H5Location.h
@@ -27,7 +27,7 @@ namespace H5 {
     Wrappers for H5A functions stay in H5Object.
 */
 // Inheritance: IdComponent
-class H5_DLLCPP H5Location : public IdComponent {
+class H5CPP_DLL H5Location : public IdComponent {
   public:
     // Checks if a link of a given name exists in a location
     bool nameExists(const char *name, const LinkAccPropList &lapl = LinkAccPropList::DEFAULT) const;

--- a/c++/src/H5Object.h
+++ b/c++/src/H5Object.h
@@ -61,7 +61,7 @@ class UserData4Visit {
     H5Object        *obj;
 };
 
-class H5_DLLCPP H5Object : public H5Location {
+class H5CPP_DLL H5Object : public H5Location {
   public:
     // Creates an attribute for the specified object
     // PropList is currently not used, so always be default.

--- a/c++/src/H5OcreatProp.h
+++ b/c++/src/H5OcreatProp.h
@@ -21,7 +21,7 @@ namespace H5 {
     wrappers for the HDF5 object create property list.
 */
 //  Inheritance: PropList -> IdComponent
-class H5_DLLCPP ObjCreatPropList : public PropList {
+class H5CPP_DLL ObjCreatPropList : public PropList {
   public:
     ///\brief Default object creation property list.
     static const ObjCreatPropList &DEFAULT;

--- a/c++/src/H5PredType.h
+++ b/c++/src/H5PredType.h
@@ -24,7 +24,7 @@ namespace H5 {
     closed by H5Tclose.  They are treated as constants.
 */
 //  Inheritance: AtomType -> DataType -> H5Object -> H5Location -> IdComponent
-class H5_DLLCPP PredType : public AtomType {
+class H5CPP_DLL PredType : public AtomType {
   public:
     ///\brief Returns this class name.
     virtual H5std_string

--- a/c++/src/H5PropList.h
+++ b/c++/src/H5PropList.h
@@ -21,7 +21,7 @@ namespace H5 {
     the HDF5 generic property list.
 */
 //  Inheritance: IdComponent
-class H5_DLLCPP PropList : public IdComponent {
+class H5CPP_DLL PropList : public IdComponent {
   public:
     ///\brief Default property list
     static const PropList &DEFAULT;

--- a/c++/src/H5StrType.h
+++ b/c++/src/H5StrType.h
@@ -21,7 +21,7 @@ namespace H5 {
     string datatype.
 */
 //  Inheritance: AtomType -> DataType -> H5Object -> H5Location -> IdComponent
-class H5_DLLCPP StrType : public AtomType {
+class H5CPP_DLL StrType : public AtomType {
   public:
     // Creates a string type using a predefined type
     StrType(const PredType &pred_type);

--- a/c++/src/H5VarLenType.h
+++ b/c++/src/H5VarLenType.h
@@ -21,7 +21,7 @@ namespace H5 {
     Variable-length Datatypes.
 */
 //  Inheritance: DataType -> H5Object -> H5Location -> IdComponent
-class H5_DLLCPP VarLenType : public DataType {
+class H5CPP_DLL VarLenType : public DataType {
   public:
     // Constructor that creates a variable-length datatype based
     // on the specified base type.

--- a/fortran/src/H5f90proto.h
+++ b/fortran/src/H5f90proto.h
@@ -16,8 +16,8 @@
 #include "H5public.h"
 #include "H5f90.h"
 
-H5_FCDLL char *HD5f2cstring(_fcd fdesc, size_t len);
-H5_FCDLL void  HD5packFstring(char *src, char *dest, size_t len);
+H5FC_DLL char *HD5f2cstring(_fcd fdesc, size_t len);
+H5FC_DLL void  HD5packFstring(char *src, char *dest, size_t len);
 
 /*
  * Storage info struct used by H5O_info_t and H5F_info_t
@@ -77,142 +77,142 @@ typedef struct H5O_native_info_t_f {
 /*
  *  Functions from H5Ff.c
  */
-H5_FCDLL int_f h5fcreate_c(_fcd name, int_f *namelen, int_f *access_flags, hid_t_f *crt_prp, hid_t_f *acc_prp,
+H5FC_DLL int_f h5fcreate_c(_fcd name, int_f *namelen, int_f *access_flags, hid_t_f *crt_prp, hid_t_f *acc_prp,
                            hid_t_f *file_id);
-H5_FCDLL int_f h5fopen_c(_fcd name, int_f *namelen, int_f *access_flags, hid_t_f *acc_prp, hid_t_f *file_id);
-H5_FCDLL int_f h5fclose_c(hid_t_f *file_id);
-H5_FCDLL int_f h5fmount_c(hid_t_f *loc_id, _fcd dsetname, int_f *namelen, hid_t_f *file_id, hid_t_f *acc_prp);
-H5_FCDLL int_f h5funmount_c(hid_t_f *loc_id, _fcd dsetname, int_f *namelen);
-H5_FCDLL int_f h5freopen_c(hid_t_f *file_id1, hid_t_f *file_id2);
-H5_FCDLL int_f h5fget_create_plist_c(hid_t_f *file_id, hid_t_f *prop_id);
-H5_FCDLL int_f h5fget_access_plist_c(hid_t_f *file_id, hid_t_f *access_id);
-H5_FCDLL int_f h5fget_obj_count_c(hid_t_f *file_id, int_f *obj_type, size_t_f *obj_count);
-H5_FCDLL int_f h5fget_obj_ids_c(hid_t_f *file_id, int_f *obj_type, size_t_f *max_objs, hid_t_f *obj_ids,
+H5FC_DLL int_f h5fopen_c(_fcd name, int_f *namelen, int_f *access_flags, hid_t_f *acc_prp, hid_t_f *file_id);
+H5FC_DLL int_f h5fclose_c(hid_t_f *file_id);
+H5FC_DLL int_f h5fmount_c(hid_t_f *loc_id, _fcd dsetname, int_f *namelen, hid_t_f *file_id, hid_t_f *acc_prp);
+H5FC_DLL int_f h5funmount_c(hid_t_f *loc_id, _fcd dsetname, int_f *namelen);
+H5FC_DLL int_f h5freopen_c(hid_t_f *file_id1, hid_t_f *file_id2);
+H5FC_DLL int_f h5fget_create_plist_c(hid_t_f *file_id, hid_t_f *prop_id);
+H5FC_DLL int_f h5fget_access_plist_c(hid_t_f *file_id, hid_t_f *access_id);
+H5FC_DLL int_f h5fget_obj_count_c(hid_t_f *file_id, int_f *obj_type, size_t_f *obj_count);
+H5FC_DLL int_f h5fget_obj_ids_c(hid_t_f *file_id, int_f *obj_type, size_t_f *max_objs, hid_t_f *obj_ids,
                                 size_t_f *num_objs);
-H5_FCDLL int_f h5fget_freespace_c(hid_t_f *file_id, hssize_t_f *free_space);
-H5_FCDLL int_f h5fget_file_image_c(hid_t_f *file_id, void *buf_ptr, size_t_f *buf_len, size_t_f *buf_req);
-H5_FCDLL int_f h5fflush_c(hid_t_f *obj_id, int_f *scope);
-H5_FCDLL int_f h5fget_name_c(hid_t_f *obj_id, size_t_f *size, _fcd buf, size_t_f *buflen);
-H5_FCDLL int_f h5fget_filesize_c(hid_t_f *file_id, hsize_t_f *size);
-H5_FCDLL int_f h5fget_fileno_c(hid_t_f *file_id, int_f *fileno);
+H5FC_DLL int_f h5fget_freespace_c(hid_t_f *file_id, hssize_t_f *free_space);
+H5FC_DLL int_f h5fget_file_image_c(hid_t_f *file_id, void *buf_ptr, size_t_f *buf_len, size_t_f *buf_req);
+H5FC_DLL int_f h5fflush_c(hid_t_f *obj_id, int_f *scope);
+H5FC_DLL int_f h5fget_name_c(hid_t_f *obj_id, size_t_f *size, _fcd buf, size_t_f *buflen);
+H5FC_DLL int_f h5fget_filesize_c(hid_t_f *file_id, hsize_t_f *size);
+H5FC_DLL int_f h5fget_fileno_c(hid_t_f *file_id, int_f *fileno);
 
 /*
  * Functions from H5Sf.c
  */
-H5_FCDLL int_f h5screate_simple_c(int_f *rank, hsize_t_f *dims, hsize_t_f *maxdims, hid_t_f *space_id);
-H5_FCDLL int_f h5sclose_c(hid_t_f *space_id);
-H5_FCDLL int_f h5screate_c(int_f *classtype, hid_t_f *space_id);
-H5_FCDLL int_f h5scopy_c(hid_t_f *space_id, hid_t_f *new_space_id);
-H5_FCDLL int_f h5sget_select_hyper_nblocks_c(hid_t_f *space_id, hssize_t_f *num_blocks);
-H5_FCDLL int_f h5sget_select_hyper_blocklist_c(hid_t_f *space_id, hsize_t_f *startblock,
+H5FC_DLL int_f h5screate_simple_c(int_f *rank, hsize_t_f *dims, hsize_t_f *maxdims, hid_t_f *space_id);
+H5FC_DLL int_f h5sclose_c(hid_t_f *space_id);
+H5FC_DLL int_f h5screate_c(int_f *classtype, hid_t_f *space_id);
+H5FC_DLL int_f h5scopy_c(hid_t_f *space_id, hid_t_f *new_space_id);
+H5FC_DLL int_f h5sget_select_hyper_nblocks_c(hid_t_f *space_id, hssize_t_f *num_blocks);
+H5FC_DLL int_f h5sget_select_hyper_blocklist_c(hid_t_f *space_id, hsize_t_f *startblock,
                                                hsize_t_f *num_blocks, hsize_t_f *buf);
-H5_FCDLL int_f h5sget_select_bounds_c(hid_t_f *space_id, hsize_t_f *start, hsize_t_f *end);
-H5_FCDLL int_f h5sget_select_elem_npoints_c(hid_t_f *space_id, hssize_t_f *num_points);
-H5_FCDLL int_f h5sget_select_elem_pointlist_c(hid_t_f *space_id, hsize_t_f *startpoint, hsize_t_f *numpoints,
+H5FC_DLL int_f h5sget_select_bounds_c(hid_t_f *space_id, hsize_t_f *start, hsize_t_f *end);
+H5FC_DLL int_f h5sget_select_elem_npoints_c(hid_t_f *space_id, hssize_t_f *num_points);
+H5FC_DLL int_f h5sget_select_elem_pointlist_c(hid_t_f *space_id, hsize_t_f *startpoint, hsize_t_f *numpoints,
                                               hsize_t_f *buf);
-H5_FCDLL int_f h5sselect_all_c(hid_t_f *space_id);
-H5_FCDLL int_f h5sselect_none_c(hid_t_f *space_id);
-H5_FCDLL int_f h5sselect_valid_c(hid_t_f *space_id, int_f *flag);
-H5_FCDLL int_f h5sget_simple_extent_npoints_c(hid_t_f *space_id, hsize_t_f *npoints);
-H5_FCDLL int_f h5sget_select_npoints_c(hid_t_f *space_id, hssize_t_f *npoints);
-H5_FCDLL int_f h5sget_simple_extent_ndims_c(hid_t_f *space_id, int_f *ndims);
-H5_FCDLL int_f h5sget_simple_extent_type_c(hid_t_f *space_id, int_f *classtype);
-H5_FCDLL int_f h5soffset_simple_c(hid_t_f *space_id, hssize_t_f *offset);
-H5_FCDLL int_f h5sset_extent_simple_c(hid_t_f *space_id, int_f *rank, hsize_t_f *current_size,
+H5FC_DLL int_f h5sselect_all_c(hid_t_f *space_id);
+H5FC_DLL int_f h5sselect_none_c(hid_t_f *space_id);
+H5FC_DLL int_f h5sselect_valid_c(hid_t_f *space_id, int_f *flag);
+H5FC_DLL int_f h5sget_simple_extent_npoints_c(hid_t_f *space_id, hsize_t_f *npoints);
+H5FC_DLL int_f h5sget_select_npoints_c(hid_t_f *space_id, hssize_t_f *npoints);
+H5FC_DLL int_f h5sget_simple_extent_ndims_c(hid_t_f *space_id, int_f *ndims);
+H5FC_DLL int_f h5sget_simple_extent_type_c(hid_t_f *space_id, int_f *classtype);
+H5FC_DLL int_f h5soffset_simple_c(hid_t_f *space_id, hssize_t_f *offset);
+H5FC_DLL int_f h5sset_extent_simple_c(hid_t_f *space_id, int_f *rank, hsize_t_f *current_size,
                                       hsize_t_f *maximum_size);
-H5_FCDLL int_f h5sis_simple_c(hid_t_f *space_id, int_f *flag);
-H5_FCDLL int_f h5sget_simple_extent_dims_c(hid_t_f *space_id, hsize_t_f *dims, hsize_t_f *maxdims);
-H5_FCDLL int_f h5sextent_copy_c(hid_t_f *dest_space_id, hid_t_f *source_space_id);
-H5_FCDLL int_f h5sset_extent_none_c(hid_t_f *space_id);
-H5_FCDLL int_f h5sselect_hyperslab_c(hid_t_f *space_id, int_f *op, hsize_t_f *start, hsize_t_f *count,
+H5FC_DLL int_f h5sis_simple_c(hid_t_f *space_id, int_f *flag);
+H5FC_DLL int_f h5sget_simple_extent_dims_c(hid_t_f *space_id, hsize_t_f *dims, hsize_t_f *maxdims);
+H5FC_DLL int_f h5sextent_copy_c(hid_t_f *dest_space_id, hid_t_f *source_space_id);
+H5FC_DLL int_f h5sset_extent_none_c(hid_t_f *space_id);
+H5FC_DLL int_f h5sselect_hyperslab_c(hid_t_f *space_id, int_f *op, hsize_t_f *start, hsize_t_f *count,
                                      hsize_t_f *stride, hsize_t_f *block);
-H5_FCDLL int_f h5sget_select_type_c(hid_t_f *space_id, int_f *op);
-H5_FCDLL int_f h5sselect_elements_c(hid_t_f *space_id, int_f *op, size_t_f *nelements, hsize_t_f *coord);
-H5_FCDLL int_f h5scombine_hyperslab_c(hid_t_f *space_id, int_f *op, hsize_t_f *start, hsize_t_f *count,
+H5FC_DLL int_f h5sget_select_type_c(hid_t_f *space_id, int_f *op);
+H5FC_DLL int_f h5sselect_elements_c(hid_t_f *space_id, int_f *op, size_t_f *nelements, hsize_t_f *coord);
+H5FC_DLL int_f h5scombine_hyperslab_c(hid_t_f *space_id, int_f *op, hsize_t_f *start, hsize_t_f *count,
                                       hsize_t_f *stride, hsize_t_f *block, hid_t_f *hyper_id);
-H5_FCDLL int_f h5scombine_select_c(hid_t_f *space1_id, int_f *op, hid_t_f *space2_id, hid_t_f *ds_id);
-H5_FCDLL int_f h5smodify_select_c(hid_t_f *space1_id, int_f *op, hid_t_f *space2_id);
-H5_FCDLL int_f h5sdecode_c(_fcd buf, hid_t_f *obj_id);
-H5_FCDLL int_f h5sencode_c(_fcd buf, hid_t_f *obj_id, size_t_f *nalloc, hid_t_f *fapl_id);
-H5_FCDLL int_f h5sextent_equal_c(hid_t_f *space1_id, hid_t_f *space2_id, hid_t_f *c_equal);
+H5FC_DLL int_f h5scombine_select_c(hid_t_f *space1_id, int_f *op, hid_t_f *space2_id, hid_t_f *ds_id);
+H5FC_DLL int_f h5smodify_select_c(hid_t_f *space1_id, int_f *op, hid_t_f *space2_id);
+H5FC_DLL int_f h5sdecode_c(_fcd buf, hid_t_f *obj_id);
+H5FC_DLL int_f h5sencode_c(_fcd buf, hid_t_f *obj_id, size_t_f *nalloc, hid_t_f *fapl_id);
+H5FC_DLL int_f h5sextent_equal_c(hid_t_f *space1_id, hid_t_f *space2_id, hid_t_f *c_equal);
 
 /*
  * Functions from H5Df.c
  */
 
-H5_FCDLL int_f h5dcreate_c(hid_t_f *loc_id, _fcd name, int_f *namelen, hid_t_f *type_id, hid_t_f *space_id,
+H5FC_DLL int_f h5dcreate_c(hid_t_f *loc_id, _fcd name, int_f *namelen, hid_t_f *type_id, hid_t_f *space_id,
                            hid_t_f *lcpl_id, hid_t_f *dcpl_id, hid_t_f *dapl_id, hid_t_f *dset_id);
-H5_FCDLL int_f h5dopen_c(hid_t_f *loc_id, _fcd name, int_f *namelen, hid_t_f *dapl_id, hid_t_f *dset_id);
-H5_FCDLL int_f h5dclose_c(hid_t_f *dset_id);
+H5FC_DLL int_f h5dopen_c(hid_t_f *loc_id, _fcd name, int_f *namelen, hid_t_f *dapl_id, hid_t_f *dset_id);
+H5FC_DLL int_f h5dclose_c(hid_t_f *dset_id);
 
-H5_FCDLL int_f h5dwrite_vl_integer_c(hid_t_f *dset_id, hid_t_f *mem_type_id, hid_t_f *mem_space_id,
+H5FC_DLL int_f h5dwrite_vl_integer_c(hid_t_f *dset_id, hid_t_f *mem_type_id, hid_t_f *mem_space_id,
                                      hid_t_f *file_space_id, hid_t_f *xfer_prp, int_f *buf, hsize_t_f *dims,
                                      size_t_f *len);
-H5_FCDLL int_f h5dwrite_vl_real_c(hid_t_f *dset_id, hid_t_f *mem_type_id, hid_t_f *mem_space_id,
+H5FC_DLL int_f h5dwrite_vl_real_c(hid_t_f *dset_id, hid_t_f *mem_type_id, hid_t_f *mem_space_id,
                                   hid_t_f *file_space_id, hid_t_f *xfer_prp, real_f *buf, hsize_t_f *dims,
                                   size_t_f *len);
-H5_FCDLL int_f h5dwrite_vl_string_c(hid_t_f *dset_id, hid_t_f *mem_type_id, hid_t_f *mem_space_id,
+H5FC_DLL int_f h5dwrite_vl_string_c(hid_t_f *dset_id, hid_t_f *mem_type_id, hid_t_f *mem_space_id,
                                     hid_t_f *file_space_id, hid_t_f *xfer_prp, _fcd buf, hsize_t_f *dims,
                                     size_t_f *len);
-H5_FCDLL int_f h5dwrite_ref_reg_c(hid_t_f *dset_id, hid_t_f *mem_type_id, hid_t_f *mem_space_id,
+H5FC_DLL int_f h5dwrite_ref_reg_c(hid_t_f *dset_id, hid_t_f *mem_type_id, hid_t_f *mem_space_id,
                                   hid_t_f *file_space_id, hid_t_f *xfer_prp, int_f *buf, hsize_t_f *dims);
-H5_FCDLL int_f h5dread_vl_integer_c(hid_t_f *dset_id, hid_t_f *mem_type_id, hid_t_f *mem_space_id,
+H5FC_DLL int_f h5dread_vl_integer_c(hid_t_f *dset_id, hid_t_f *mem_type_id, hid_t_f *mem_space_id,
                                     hid_t_f *file_space_id, hid_t_f *xfer_prp, int_f *buf, hsize_t_f *dims,
                                     size_t_f *len);
-H5_FCDLL int_f h5dread_vl_real_c(hid_t_f *dset_id, hid_t_f *mem_type_id, hid_t_f *mem_space_id,
+H5FC_DLL int_f h5dread_vl_real_c(hid_t_f *dset_id, hid_t_f *mem_type_id, hid_t_f *mem_space_id,
                                  hid_t_f *file_space_id, hid_t_f *xfer_prp, real_f *buf, hsize_t_f *dims,
                                  size_t_f *len);
-H5_FCDLL int_f h5dread_vl_string_c(hid_t_f *dset_id, hid_t_f *mem_type_id, hid_t_f *mem_space_id,
+H5FC_DLL int_f h5dread_vl_string_c(hid_t_f *dset_id, hid_t_f *mem_type_id, hid_t_f *mem_space_id,
                                    hid_t_f *file_space_id, hid_t_f *xfer_prp, _fcd buf, hsize_t_f *dims,
                                    size_t_f *len);
-H5_FCDLL int_f h5dread_ref_reg_c(hid_t_f *dset_id, hid_t_f *mem_type_id, hid_t_f *mem_space_id,
+H5FC_DLL int_f h5dread_ref_reg_c(hid_t_f *dset_id, hid_t_f *mem_type_id, hid_t_f *mem_space_id,
                                  hid_t_f *file_space_id, hid_t_f *xfer_prp, int_f *buf, hsize_t_f *dims);
-H5_FCDLL int_f h5dget_access_plist_c(hid_t_f *dset_id, hid_t_f *plist_id);
-H5_FCDLL int_f h5dget_space_c(hid_t_f *dset_id, hid_t_f *space_id);
-H5_FCDLL int_f h5dget_type_c(hid_t_f *dset_id, hid_t_f *type_id);
-H5_FCDLL int_f h5dget_create_plist_c(hid_t_f *dset_id, hid_t_f *plist_id);
-H5_FCDLL int_f h5dset_extent_c(hid_t_f *dset_id, hsize_t_f *dims);
-H5_FCDLL int_f h5dvlen_get_max_len_c(hid_t_f *dataset_id, hid_t_f *type_id, hid_t_f *space_id, size_t_f *len);
-H5_FCDLL int_f h5dget_storage_size_c(hid_t_f *dataset_id, hsize_t_f *size);
-H5_FCDLL int_f h5dget_space_status_c(hid_t_f *dset_id, int_f *flag);
-H5_FCDLL int_f h5dcreate_anon_c(hid_t_f *loc_id, hid_t_f *type_id, hid_t_f *space_id, hid_t_f *dcpl_id,
+H5FC_DLL int_f h5dget_access_plist_c(hid_t_f *dset_id, hid_t_f *plist_id);
+H5FC_DLL int_f h5dget_space_c(hid_t_f *dset_id, hid_t_f *space_id);
+H5FC_DLL int_f h5dget_type_c(hid_t_f *dset_id, hid_t_f *type_id);
+H5FC_DLL int_f h5dget_create_plist_c(hid_t_f *dset_id, hid_t_f *plist_id);
+H5FC_DLL int_f h5dset_extent_c(hid_t_f *dset_id, hsize_t_f *dims);
+H5FC_DLL int_f h5dvlen_get_max_len_c(hid_t_f *dataset_id, hid_t_f *type_id, hid_t_f *space_id, size_t_f *len);
+H5FC_DLL int_f h5dget_storage_size_c(hid_t_f *dataset_id, hsize_t_f *size);
+H5FC_DLL int_f h5dget_space_status_c(hid_t_f *dset_id, int_f *flag);
+H5FC_DLL int_f h5dcreate_anon_c(hid_t_f *loc_id, hid_t_f *type_id, hid_t_f *space_id, hid_t_f *dcpl_id,
                                 hid_t_f *dapl_id, hid_t_f *dset_id);
-H5_FCDLL int_f h5dwrite_f_c(hid_t_f *dset_id, hid_t_f *mem_type_id, hid_t_f *mem_space_id,
+H5FC_DLL int_f h5dwrite_f_c(hid_t_f *dset_id, hid_t_f *mem_type_id, hid_t_f *mem_space_id,
                             hid_t_f *file_space_id, hid_t_f *xfer_prp, void *buf);
-H5_FCDLL int_f h5dread_f_c(hid_t_f *dset_id, hid_t_f *mem_type_id, hid_t_f *mem_space_id,
+H5FC_DLL int_f h5dread_f_c(hid_t_f *dset_id, hid_t_f *mem_type_id, hid_t_f *mem_space_id,
                            hid_t_f *file_space_id, hid_t_f *xfer_prp, void *buf);
-H5_FCDLL int_f h5dvlen_reclaim_c(hid_t_f *type_id, hid_t_f *space_id, hid_t_f *plist_id, void *buf);
+H5FC_DLL int_f h5dvlen_reclaim_c(hid_t_f *type_id, hid_t_f *space_id, hid_t_f *plist_id, void *buf);
 
 /*
  * Functions from H5Gf.c
  */
-H5_FCDLL int_f h5gcreate_c(hid_t_f *loc_id, _fcd name, int_f *namelen, size_t_f *size_hint, hid_t_f *grp_id,
+H5FC_DLL int_f h5gcreate_c(hid_t_f *loc_id, _fcd name, int_f *namelen, size_t_f *size_hint, hid_t_f *grp_id,
                            hid_t_f *lcpl_id, hid_t_f *gcpl_id, hid_t_f *gapl_id);
-H5_FCDLL int_f h5gopen_c(hid_t_f *loc_id, _fcd name, int_f *namelen, hid_t_f *gapl_id, hid_t_f *grp_id);
-H5_FCDLL int_f h5gclose_c(hid_t_f *grp_id);
-H5_FCDLL int_f h5gget_obj_info_idx_c(hid_t_f *loc_id, _fcd name, int_f *namelen, int_f *idx, _fcd obj_name,
+H5FC_DLL int_f h5gopen_c(hid_t_f *loc_id, _fcd name, int_f *namelen, hid_t_f *gapl_id, hid_t_f *grp_id);
+H5FC_DLL int_f h5gclose_c(hid_t_f *grp_id);
+H5FC_DLL int_f h5gget_obj_info_idx_c(hid_t_f *loc_id, _fcd name, int_f *namelen, int_f *idx, _fcd obj_name,
                                      int_f *obj_namelen, int_f *obj_type);
-H5_FCDLL int_f h5gn_members_c(hid_t_f *loc_id, _fcd name, int_f *namelen, int_f *nmembers);
-H5_FCDLL int_f h5glink_c(hid_t_f *loc_id, int_f *link_type, _fcd current_name, int_f *current_namelen,
+H5FC_DLL int_f h5gn_members_c(hid_t_f *loc_id, _fcd name, int_f *namelen, int_f *nmembers);
+H5FC_DLL int_f h5glink_c(hid_t_f *loc_id, int_f *link_type, _fcd current_name, int_f *current_namelen,
                          _fcd new_name, int_f *new_namelen);
-H5_FCDLL int_f h5glink2_c(hid_t_f *cur_loc_id, _fcd cur_name, int_f *cur_namelen, int_f *link_type,
+H5FC_DLL int_f h5glink2_c(hid_t_f *cur_loc_id, _fcd cur_name, int_f *cur_namelen, int_f *link_type,
                           hid_t_f *new_loc_id, _fcd new_name, int_f *new_namelen);
-H5_FCDLL int_f h5gunlink_c(hid_t_f *loc_id, _fcd name, int_f *namelen);
-H5_FCDLL int_f h5gmove_c(hid_t_f *loc_id, _fcd src_name, int_f *src_namelen, _fcd dst_name,
+H5FC_DLL int_f h5gunlink_c(hid_t_f *loc_id, _fcd name, int_f *namelen);
+H5FC_DLL int_f h5gmove_c(hid_t_f *loc_id, _fcd src_name, int_f *src_namelen, _fcd dst_name,
                          int_f *dst_namelen);
-H5_FCDLL int_f h5gmove2_c(hid_t_f *src_loc_id, _fcd src_name, int_f *src_namelen, hid_t_f *dst_loc_id,
+H5FC_DLL int_f h5gmove2_c(hid_t_f *src_loc_id, _fcd src_name, int_f *src_namelen, hid_t_f *dst_loc_id,
                           _fcd dst_name, int_f *dst_namelen);
-H5_FCDLL int_f h5gget_linkval_c(hid_t_f *loc_id, _fcd name, int_f *namelen, size_t_f *size, _fcd value);
-H5_FCDLL int_f h5gset_comment_c(hid_t_f *loc_id, _fcd name, int_f *namelen, _fcd comment, int_f *commentlen);
-H5_FCDLL int_f h5gget_comment_c(hid_t_f *loc_id, _fcd name, int_f *namelen, size_t_f *bufsize, _fcd comment);
-H5_FCDLL int_f h5gcreate_anon_c(hid_t_f *loc_id, hid_t_f *gcpl_id, hid_t_f *gapl_id, hid_t_f *grp_id);
-H5_FCDLL int_f h5gget_create_plist_c(hid_t_f *grp_id, hid_t_f *gcpl_id);
-H5_FCDLL int_f h5gget_info_c(hid_t_f *group_id, int_f *storage_type, int_f *nlinks, int_f *max_corder,
+H5FC_DLL int_f h5gget_linkval_c(hid_t_f *loc_id, _fcd name, int_f *namelen, size_t_f *size, _fcd value);
+H5FC_DLL int_f h5gset_comment_c(hid_t_f *loc_id, _fcd name, int_f *namelen, _fcd comment, int_f *commentlen);
+H5FC_DLL int_f h5gget_comment_c(hid_t_f *loc_id, _fcd name, int_f *namelen, size_t_f *bufsize, _fcd comment);
+H5FC_DLL int_f h5gcreate_anon_c(hid_t_f *loc_id, hid_t_f *gcpl_id, hid_t_f *gapl_id, hid_t_f *grp_id);
+H5FC_DLL int_f h5gget_create_plist_c(hid_t_f *grp_id, hid_t_f *gcpl_id);
+H5FC_DLL int_f h5gget_info_c(hid_t_f *group_id, int_f *storage_type, int_f *nlinks, int_f *max_corder,
                              int_f *mounted);
-H5_FCDLL int_f h5gget_info_by_idx_c(hid_t_f *loc_id, _fcd group_name, size_t_f *group_namelen,
+H5FC_DLL int_f h5gget_info_by_idx_c(hid_t_f *loc_id, _fcd group_name, size_t_f *group_namelen,
                                     int_f *index_type, int_f *order, hsize_t_f *n, hid_t_f *lapl_id,
                                     int_f *storage_type, int_f *nlinks, int_f *max_corder, int_f *mounted);
-H5_FCDLL int_f h5gget_info_by_name_c(hid_t_f *loc_id, _fcd group_name, size_t_f *group_namelen,
+H5FC_DLL int_f h5gget_info_by_name_c(hid_t_f *loc_id, _fcd group_name, size_t_f *group_namelen,
                                      hid_t_f *lapl_id, int_f *storage_type, int_f *nlinks, int_f *max_corder,
                                      int_f *mounted);
 
@@ -220,341 +220,341 @@ H5_FCDLL int_f h5gget_info_by_name_c(hid_t_f *loc_id, _fcd group_name, size_t_f 
  * Functions from H5Af.c
  */
 
-H5_FCDLL int_f h5awrite_f_c(hid_t_f *attr_id, hid_t_f *mem_type_id, void *buf);
-H5_FCDLL int_f h5aread_f_c(hid_t_f *attr_id, hid_t_f *mem_type_id, void *buf);
-H5_FCDLL int_f h5acreate_c(hid_t_f *obj_id, _fcd name, size_t_f *namelen, hid_t_f *type_id, hid_t_f *space_id,
+H5FC_DLL int_f h5awrite_f_c(hid_t_f *attr_id, hid_t_f *mem_type_id, void *buf);
+H5FC_DLL int_f h5aread_f_c(hid_t_f *attr_id, hid_t_f *mem_type_id, void *buf);
+H5FC_DLL int_f h5acreate_c(hid_t_f *obj_id, _fcd name, size_t_f *namelen, hid_t_f *type_id, hid_t_f *space_id,
                            hid_t_f *crt_prp, hid_t_f *aapl, hid_t_f *attr_id);
-H5_FCDLL int_f h5adelete_c(hid_t_f *obj_id, _fcd name, size_t_f *namelen);
-H5_FCDLL int_f h5aget_num_attrs_c(hid_t_f *obj_id, int_f *attr_num);
-H5_FCDLL int_f h5aget_name_c(hid_t_f *attr_id, size_t_f *size, _fcd buf);
-H5_FCDLL int_f h5arename_by_name_c(hid_t_f *loc_id, _fcd obj_name, size_t_f *obj_namelen, _fcd old_attr_name,
+H5FC_DLL int_f h5adelete_c(hid_t_f *obj_id, _fcd name, size_t_f *namelen);
+H5FC_DLL int_f h5aget_num_attrs_c(hid_t_f *obj_id, int_f *attr_num);
+H5FC_DLL int_f h5aget_name_c(hid_t_f *attr_id, size_t_f *size, _fcd buf);
+H5FC_DLL int_f h5arename_by_name_c(hid_t_f *loc_id, _fcd obj_name, size_t_f *obj_namelen, _fcd old_attr_name,
                                    size_t_f *old_attr_namelen, _fcd new_attr_name, size_t_f *new_attr_namelen,
                                    hid_t_f *lapl_id);
-H5_FCDLL int_f h5aopen_c(hid_t_f *obj_id, _fcd attr_name, size_t_f *attr_namelen, hid_t_f *aapl_id,
+H5FC_DLL int_f h5aopen_c(hid_t_f *obj_id, _fcd attr_name, size_t_f *attr_namelen, hid_t_f *aapl_id,
                          hid_t_f *attr_id);
-H5_FCDLL int_f h5adelete_by_name_c(hid_t_f *loc_id, _fcd obj_name, size_t_f *obj_namelen, _fcd attr_name,
+H5FC_DLL int_f h5adelete_by_name_c(hid_t_f *loc_id, _fcd obj_name, size_t_f *obj_namelen, _fcd attr_name,
                                    size_t_f *attr_namelen, hid_t_f *lapl_id);
-H5_FCDLL int_f h5adelete_by_idx_c(hid_t_f *loc_id, _fcd obj_name, size_t_f *obj_namelen, int_f *idx_type,
+H5FC_DLL int_f h5adelete_by_idx_c(hid_t_f *loc_id, _fcd obj_name, size_t_f *obj_namelen, int_f *idx_type,
                                   int_f *order, hsize_t_f *n, hid_t_f *lapl_id);
-H5_FCDLL int_f h5aget_name_by_idx_c(hid_t_f *loc_id, _fcd obj_name, size_t_f *obj_namelen, int_f *idx_type,
+H5FC_DLL int_f h5aget_name_by_idx_c(hid_t_f *loc_id, _fcd obj_name, size_t_f *obj_namelen, int_f *idx_type,
                                     int_f *order, hsize_t_f *n, _fcd name, size_t_f *size, hid_t_f *lapl_id);
-H5_FCDLL int_f h5aopen_by_idx_c(hid_t_f *loc_id, _fcd obj_name, size_t_f *obj_namelen, int_f *idx_type,
+H5FC_DLL int_f h5aopen_by_idx_c(hid_t_f *loc_id, _fcd obj_name, size_t_f *obj_namelen, int_f *idx_type,
                                 int_f *order, hsize_t_f *n, hid_t_f *aapl_id, hid_t_f *lapl_id,
                                 hid_t_f *attr_id);
-H5_FCDLL int_f h5aget_info_c(hid_t_f *loc_id, int_f *corder_valid, int_f *corder, int_f *cset,
+H5FC_DLL int_f h5aget_info_c(hid_t_f *loc_id, int_f *corder_valid, int_f *corder, int_f *cset,
                              hsize_t_f *data_size);
-H5_FCDLL int_f h5aget_info_by_idx_c(hid_t_f *loc_id, _fcd obj_name, size_t_f *obj_namelen, int_f *idx_type,
+H5FC_DLL int_f h5aget_info_by_idx_c(hid_t_f *loc_id, _fcd obj_name, size_t_f *obj_namelen, int_f *idx_type,
                                     int_f *order, hsize_t_f *n, hid_t_f *lapl_id, int_f *corder_valid,
                                     int_f *corder, int_f *cset, hsize_t_f *data_size);
-H5_FCDLL int_f h5aget_info_by_name_c(hid_t_f *loc_id, _fcd obj_name, size_t_f *obj_namelen, _fcd attr_name,
+H5FC_DLL int_f h5aget_info_by_name_c(hid_t_f *loc_id, _fcd obj_name, size_t_f *obj_namelen, _fcd attr_name,
                                      size_t_f *attr_namelen, hid_t_f *lapl_id, int_f *corder_valid,
                                      int_f *corder, int_f *cset, hsize_t_f *data_size);
-H5_FCDLL int_f h5acreate_by_name_c(hid_t_f *loc_id, _fcd obj_name, size_t_f *obj_namelen, _fcd attr_name,
+H5FC_DLL int_f h5acreate_by_name_c(hid_t_f *loc_id, _fcd obj_name, size_t_f *obj_namelen, _fcd attr_name,
                                    size_t_f *attr_namelen, hid_t_f *type_id, hid_t_f *space_id,
                                    hid_t_f *acpl_id, hid_t_f *aapl_id, hid_t_f *lapl_id, hid_t_f *attr_id);
-H5_FCDLL int_f h5aexists_c(hid_t_f *obj_id, _fcd name, size_t_f *namelen, hid_t_f *attr_exists);
-H5_FCDLL int_f h5aexists_by_name_c(hid_t_f *loc_id, _fcd obj_name, size_t_f *obj_namelen, _fcd attr_name,
+H5FC_DLL int_f h5aexists_c(hid_t_f *obj_id, _fcd name, size_t_f *namelen, hid_t_f *attr_exists);
+H5FC_DLL int_f h5aexists_by_name_c(hid_t_f *loc_id, _fcd obj_name, size_t_f *obj_namelen, _fcd attr_name,
                                    size_t_f *attr_namelen, hid_t_f *lapl_id, int_f *attr_exists);
-H5_FCDLL int_f h5aopen_by_name_c(hid_t_f *loc_id, _fcd obj_name, size_t_f *obj_namelen, _fcd attr_name,
+H5FC_DLL int_f h5aopen_by_name_c(hid_t_f *loc_id, _fcd obj_name, size_t_f *obj_namelen, _fcd attr_name,
                                  size_t_f *attr_namelen, hid_t_f *aapl_id, hid_t_f *lapl_id,
                                  hid_t_f *attr_id);
-H5_FCDLL int_f h5arename_c(hid_t_f *loc_id, _fcd old_attr_name, size_t_f *old_attr_namelen,
+H5FC_DLL int_f h5arename_c(hid_t_f *loc_id, _fcd old_attr_name, size_t_f *old_attr_namelen,
                            _fcd new_attr_name, size_t_f *new_attr_namelen);
 
 /*
  * Functions form H5Tf.c file
  */
 
-H5_FCDLL int_f h5tcreate_c(int_f *cls, size_t_f *size, hid_t_f *type_id);
-H5_FCDLL int_f h5topen_c(hid_t_f *loc_id, _fcd name, int_f *namelen, hid_t_f *type_id, hid_t_f *tapl_id);
-H5_FCDLL int_f h5tcommit_c(hid_t_f *loc_id, _fcd name, int_f *namelen, hid_t_f *type_id, hid_t_f *lcpl_id,
+H5FC_DLL int_f h5tcreate_c(int_f *cls, size_t_f *size, hid_t_f *type_id);
+H5FC_DLL int_f h5topen_c(hid_t_f *loc_id, _fcd name, int_f *namelen, hid_t_f *type_id, hid_t_f *tapl_id);
+H5FC_DLL int_f h5tcommit_c(hid_t_f *loc_id, _fcd name, int_f *namelen, hid_t_f *type_id, hid_t_f *lcpl_id,
                            hid_t_f *tcpl_id, hid_t_f *tapl_id);
-H5_FCDLL int_f h5tclose_c(hid_t_f *type_id);
-H5_FCDLL int_f h5tequal_c(hid_t_f *type1_id, hid_t_f *type2_id, int_f *c_flag);
-H5_FCDLL int_f h5tcopy_c(hid_t_f *type_id, hid_t_f *new_type_id);
-H5_FCDLL int_f h5tget_class_c(hid_t_f *type_id, int_f *classtype);
-H5_FCDLL int_f h5tget_order_c(hid_t_f *type_id, int_f *order);
-H5_FCDLL int_f h5tset_order_c(hid_t_f *type_id, int_f *order);
-H5_FCDLL int_f h5tget_size_c(hid_t_f *type_id, size_t_f *size);
-H5_FCDLL int_f h5tset_size_c(hid_t_f *type_id, size_t_f *size);
-H5_FCDLL int_f h5tcommitted_c(hid_t_f *dtype_id);
-H5_FCDLL int_f h5tget_precision_c(hid_t_f *type_id, size_t_f *precision);
-H5_FCDLL int_f h5tset_precision_c(hid_t_f *type_id, size_t_f *precision);
-H5_FCDLL int_f h5tget_offset_c(hid_t_f *type_id, size_t_f *offset);
-H5_FCDLL int_f h5tset_offset_c(hid_t_f *type_id, size_t_f *offset);
-H5_FCDLL int_f h5tget_pad_c(hid_t_f *type_id, int_f *lsbpad, int_f *msbpad);
-H5_FCDLL int_f h5tset_pad_c(hid_t_f *type_id, int_f *lsbpad, int_f *msbpad);
-H5_FCDLL int_f h5tget_sign_c(hid_t_f *type_id, int_f *sign);
-H5_FCDLL int_f h5tset_sign_c(hid_t_f *type_id, int_f *sign);
-H5_FCDLL int_f h5tget_fields_c(hid_t_f *type_id, size_t_f *spos, size_t_f *epos, size_t_f *esize,
+H5FC_DLL int_f h5tclose_c(hid_t_f *type_id);
+H5FC_DLL int_f h5tequal_c(hid_t_f *type1_id, hid_t_f *type2_id, int_f *c_flag);
+H5FC_DLL int_f h5tcopy_c(hid_t_f *type_id, hid_t_f *new_type_id);
+H5FC_DLL int_f h5tget_class_c(hid_t_f *type_id, int_f *classtype);
+H5FC_DLL int_f h5tget_order_c(hid_t_f *type_id, int_f *order);
+H5FC_DLL int_f h5tset_order_c(hid_t_f *type_id, int_f *order);
+H5FC_DLL int_f h5tget_size_c(hid_t_f *type_id, size_t_f *size);
+H5FC_DLL int_f h5tset_size_c(hid_t_f *type_id, size_t_f *size);
+H5FC_DLL int_f h5tcommitted_c(hid_t_f *dtype_id);
+H5FC_DLL int_f h5tget_precision_c(hid_t_f *type_id, size_t_f *precision);
+H5FC_DLL int_f h5tset_precision_c(hid_t_f *type_id, size_t_f *precision);
+H5FC_DLL int_f h5tget_offset_c(hid_t_f *type_id, size_t_f *offset);
+H5FC_DLL int_f h5tset_offset_c(hid_t_f *type_id, size_t_f *offset);
+H5FC_DLL int_f h5tget_pad_c(hid_t_f *type_id, int_f *lsbpad, int_f *msbpad);
+H5FC_DLL int_f h5tset_pad_c(hid_t_f *type_id, int_f *lsbpad, int_f *msbpad);
+H5FC_DLL int_f h5tget_sign_c(hid_t_f *type_id, int_f *sign);
+H5FC_DLL int_f h5tset_sign_c(hid_t_f *type_id, int_f *sign);
+H5FC_DLL int_f h5tget_fields_c(hid_t_f *type_id, size_t_f *spos, size_t_f *epos, size_t_f *esize,
                                size_t_f *mpos, size_t_f *msize);
-H5_FCDLL int_f h5tset_fields_c(hid_t_f *type_id, size_t_f *spos, size_t_f *epos, size_t_f *esize,
+H5FC_DLL int_f h5tset_fields_c(hid_t_f *type_id, size_t_f *spos, size_t_f *epos, size_t_f *esize,
                                size_t_f *mpos, size_t_f *msize);
-H5_FCDLL int_f h5tget_ebias_c(hid_t_f *type_id, size_t_f *ebias);
-H5_FCDLL int_f h5tset_ebias_c(hid_t_f *type_id, size_t_f *ebias);
-H5_FCDLL int_f h5tget_norm_c(hid_t_f *type_id, int_f *norm);
-H5_FCDLL int_f h5tset_norm_c(hid_t_f *type_id, int_f *norm);
-H5_FCDLL int_f h5tget_inpad_c(hid_t_f *type_id, int_f *padtype);
-H5_FCDLL int_f h5tset_inpad_c(hid_t_f *type_id, int_f *padtype);
-H5_FCDLL int_f h5tget_cset_c(hid_t_f *type_id, int_f *cset);
-H5_FCDLL int_f h5tset_cset_c(hid_t_f *type_id, int_f *cset);
-H5_FCDLL int_f h5tget_strpad_c(hid_t_f *type_id, int_f *strpad);
-H5_FCDLL int_f h5tset_strpad_c(hid_t_f *type_id, int_f *strpad);
-H5_FCDLL int_f h5tget_nmembers_c(hid_t_f *type_id, int_f *num_members);
-H5_FCDLL int_f h5tget_member_name_c(hid_t_f *type_id, int_f *idx, _fcd member_name, int_f *namelen);
-H5_FCDLL int_f h5tget_member_offset_c(hid_t_f *type_id, int_f *member_no, size_t_f *offset);
-H5_FCDLL int_f h5tget_member_type_c(hid_t_f *type_id, int_f *field_idx, hid_t_f *datatype);
-H5_FCDLL int_f h5tget_member_index_c(hid_t_f *type_id, _fcd name, int_f *namelen, int_f *idx);
-H5_FCDLL int_f h5tinsert_c(hid_t_f *type_id, _fcd name, int_f *namelen, size_t_f *offset, hid_t_f *field_id);
-H5_FCDLL int_f h5tpack_c(hid_t_f *type_id);
-H5_FCDLL int_f h5tinsert_array_c(hid_t_f *parent_id, _fcd name, int_f *namelen, size_t_f *offset,
+H5FC_DLL int_f h5tget_ebias_c(hid_t_f *type_id, size_t_f *ebias);
+H5FC_DLL int_f h5tset_ebias_c(hid_t_f *type_id, size_t_f *ebias);
+H5FC_DLL int_f h5tget_norm_c(hid_t_f *type_id, int_f *norm);
+H5FC_DLL int_f h5tset_norm_c(hid_t_f *type_id, int_f *norm);
+H5FC_DLL int_f h5tget_inpad_c(hid_t_f *type_id, int_f *padtype);
+H5FC_DLL int_f h5tset_inpad_c(hid_t_f *type_id, int_f *padtype);
+H5FC_DLL int_f h5tget_cset_c(hid_t_f *type_id, int_f *cset);
+H5FC_DLL int_f h5tset_cset_c(hid_t_f *type_id, int_f *cset);
+H5FC_DLL int_f h5tget_strpad_c(hid_t_f *type_id, int_f *strpad);
+H5FC_DLL int_f h5tset_strpad_c(hid_t_f *type_id, int_f *strpad);
+H5FC_DLL int_f h5tget_nmembers_c(hid_t_f *type_id, int_f *num_members);
+H5FC_DLL int_f h5tget_member_name_c(hid_t_f *type_id, int_f *idx, _fcd member_name, int_f *namelen);
+H5FC_DLL int_f h5tget_member_offset_c(hid_t_f *type_id, int_f *member_no, size_t_f *offset);
+H5FC_DLL int_f h5tget_member_type_c(hid_t_f *type_id, int_f *field_idx, hid_t_f *datatype);
+H5FC_DLL int_f h5tget_member_index_c(hid_t_f *type_id, _fcd name, int_f *namelen, int_f *idx);
+H5FC_DLL int_f h5tinsert_c(hid_t_f *type_id, _fcd name, int_f *namelen, size_t_f *offset, hid_t_f *field_id);
+H5FC_DLL int_f h5tpack_c(hid_t_f *type_id);
+H5FC_DLL int_f h5tinsert_array_c(hid_t_f *parent_id, _fcd name, int_f *namelen, size_t_f *offset,
                                  int_f *ndims, size_t_f *dims, hid_t_f *member_id, int_f *perm);
-H5_FCDLL int_f h5tinsert_array_c2(hid_t_f *parent_id, _fcd name, int_f *namelen, size_t_f *offset,
+H5FC_DLL int_f h5tinsert_array_c2(hid_t_f *parent_id, _fcd name, int_f *namelen, size_t_f *offset,
                                   int_f *ndims, size_t_f *dims, hid_t_f *member_id);
-H5_FCDLL int_f h5tenum_create_c(hid_t_f *parent_id, hid_t_f *new_type_id);
-H5_FCDLL int_f h5tenum_insert_c(hid_t_f *type_id, _fcd name, int_f *namelen, int_f *value);
-H5_FCDLL int_f h5tenum_insert_ptr_c(hid_t_f *type_id, _fcd name, int_f *namelen, void *value);
-H5_FCDLL int_f h5tenum_nameof_c(hid_t_f *type_id, int_f *value, _fcd name, size_t_f *namelen);
-H5_FCDLL int_f h5tenum_valueof_c(hid_t_f *type_id, _fcd name, int_f *namelen, int_f *value);
-H5_FCDLL int_f h5tget_member_value_c(hid_t_f *type_id, int_f *member_no, int_f *value);
-H5_FCDLL int_f h5tset_tag_c(hid_t_f *type_id, _fcd tag, int_f *namelen);
-H5_FCDLL int_f h5tget_tag_c(hid_t_f *type_id, _fcd tag, size_t_f *tag_size, int_f *namelen);
-H5_FCDLL int_f h5tarray_create_c(hid_t_f *base_id, int_f *rank, hsize_t_f *dims, hid_t_f *type_id);
-H5_FCDLL int_f h5tget_array_dims_c(hid_t_f *type_id, hsize_t_f *dims);
-H5_FCDLL int_f h5tget_array_ndims_c(hid_t_f *type_id, int_f *ndims);
-H5_FCDLL int_f h5tget_super_c(hid_t_f *type_id, hid_t_f *base_type_id);
-H5_FCDLL int_f h5tvlen_create_c(hid_t_f *type_id, hid_t_f *vltype_id);
-H5_FCDLL int_f h5tis_variable_str_c(hid_t_f *type_id, int_f *flag);
-H5_FCDLL int_f h5tget_member_class_c(hid_t_f *type_id, int_f *member_no, int_f *cls);
-H5_FCDLL int_f h5tcommit_anon_c(hid_t_f *loc_id, hid_t_f *dtype_id, hid_t_f *tcpl_id, hid_t_f *tapl_id);
-H5_FCDLL int_f h5tencode_c(_fcd buf, hid_t_f *obj_id, size_t_f *nalloc);
-H5_FCDLL int_f h5tget_create_plist_c(hid_t_f *dtype_id, hid_t_f *dtpl_id);
-H5_FCDLL int_f h5tcompiler_conv_c(hid_t_f *src_id, hid_t_f *dst_id, int_f *c_flag);
-H5_FCDLL int_f h5tget_native_type_c(hid_t_f *dtype_id, int_f *direction, hid_t_f *native_dtype_id);
-H5_FCDLL int_f h5tconvert_c(hid_t_f *src_id, hid_t_f *dst_id, size_t_f *nelmts, void *buf, void *background,
+H5FC_DLL int_f h5tenum_create_c(hid_t_f *parent_id, hid_t_f *new_type_id);
+H5FC_DLL int_f h5tenum_insert_c(hid_t_f *type_id, _fcd name, int_f *namelen, int_f *value);
+H5FC_DLL int_f h5tenum_insert_ptr_c(hid_t_f *type_id, _fcd name, int_f *namelen, void *value);
+H5FC_DLL int_f h5tenum_nameof_c(hid_t_f *type_id, int_f *value, _fcd name, size_t_f *namelen);
+H5FC_DLL int_f h5tenum_valueof_c(hid_t_f *type_id, _fcd name, int_f *namelen, int_f *value);
+H5FC_DLL int_f h5tget_member_value_c(hid_t_f *type_id, int_f *member_no, int_f *value);
+H5FC_DLL int_f h5tset_tag_c(hid_t_f *type_id, _fcd tag, int_f *namelen);
+H5FC_DLL int_f h5tget_tag_c(hid_t_f *type_id, _fcd tag, size_t_f *tag_size, int_f *namelen);
+H5FC_DLL int_f h5tarray_create_c(hid_t_f *base_id, int_f *rank, hsize_t_f *dims, hid_t_f *type_id);
+H5FC_DLL int_f h5tget_array_dims_c(hid_t_f *type_id, hsize_t_f *dims);
+H5FC_DLL int_f h5tget_array_ndims_c(hid_t_f *type_id, int_f *ndims);
+H5FC_DLL int_f h5tget_super_c(hid_t_f *type_id, hid_t_f *base_type_id);
+H5FC_DLL int_f h5tvlen_create_c(hid_t_f *type_id, hid_t_f *vltype_id);
+H5FC_DLL int_f h5tis_variable_str_c(hid_t_f *type_id, int_f *flag);
+H5FC_DLL int_f h5tget_member_class_c(hid_t_f *type_id, int_f *member_no, int_f *cls);
+H5FC_DLL int_f h5tcommit_anon_c(hid_t_f *loc_id, hid_t_f *dtype_id, hid_t_f *tcpl_id, hid_t_f *tapl_id);
+H5FC_DLL int_f h5tencode_c(_fcd buf, hid_t_f *obj_id, size_t_f *nalloc);
+H5FC_DLL int_f h5tget_create_plist_c(hid_t_f *dtype_id, hid_t_f *dtpl_id);
+H5FC_DLL int_f h5tcompiler_conv_c(hid_t_f *src_id, hid_t_f *dst_id, int_f *c_flag);
+H5FC_DLL int_f h5tget_native_type_c(hid_t_f *dtype_id, int_f *direction, hid_t_f *native_dtype_id);
+H5FC_DLL int_f h5tconvert_c(hid_t_f *src_id, hid_t_f *dst_id, size_t_f *nelmts, void *buf, void *background,
                             hid_t_f *plist_id);
 
 /*
  * Functions from H5Of.c
  */
 
-H5_FCDLL int_f h5oopen_c(hid_t_f *loc_id, _fcd name, size_t_f *namelen, hid_t_f *lapl_id, hid_t_f *obj_id);
-H5_FCDLL int_f h5oclose_c(hid_t_f *object_id);
-H5_FCDLL int_f h5oopen_by_token_c(hid_t_f *loc_id, H5O_token_t *token, hid_t_f *obj_id);
-H5_FCDLL int_f h5olink_c(hid_t_f *object_id, hid_t_f *new_loc_id, _fcd name, size_t_f *namelen,
+H5FC_DLL int_f h5oopen_c(hid_t_f *loc_id, _fcd name, size_t_f *namelen, hid_t_f *lapl_id, hid_t_f *obj_id);
+H5FC_DLL int_f h5oclose_c(hid_t_f *object_id);
+H5FC_DLL int_f h5oopen_by_token_c(hid_t_f *loc_id, H5O_token_t *token, hid_t_f *obj_id);
+H5FC_DLL int_f h5olink_c(hid_t_f *object_id, hid_t_f *new_loc_id, _fcd name, size_t_f *namelen,
                          hid_t_f *lcpl_id, hid_t_f *lapl_id);
-H5_FCDLL int_f h5oget_info_c(hid_t_f *object_id, H5O_info_t_f *object_info, int_f *fields);
-H5_FCDLL int_f h5oget_info_by_idx_c(hid_t_f *loc_id, _fcd group_name, size_t_f *namelen, int_f *index_field,
+H5FC_DLL int_f h5oget_info_c(hid_t_f *object_id, H5O_info_t_f *object_info, int_f *fields);
+H5FC_DLL int_f h5oget_info_by_idx_c(hid_t_f *loc_id, _fcd group_name, size_t_f *namelen, int_f *index_field,
                                     int_f *order, hsize_t_f *n, hid_t_f *lapl_id, H5O_info_t_f *object_info,
                                     int_f *fields);
-H5_FCDLL int_f h5oget_info_by_name_c(hid_t_f *loc_id, char *name, hid_t_f *lapl_id, H5O_info_t_f *object_info,
+H5FC_DLL int_f h5oget_info_by_name_c(hid_t_f *loc_id, char *name, hid_t_f *lapl_id, H5O_info_t_f *object_info,
                                      int_f *fields, hid_t_f *es_id, char *file, char *func, int_f *line);
-H5_FCDLL int_f h5ocopy_c(hid_t_f *src_loc_id, _fcd src_name, size_t_f *src_name_len, hid_t_f *dst_loc_id,
+H5FC_DLL int_f h5ocopy_c(hid_t_f *src_loc_id, _fcd src_name, size_t_f *src_name_len, hid_t_f *dst_loc_id,
                          _fcd dst_name, size_t_f *dst_name_len, hid_t_f *ocpypl_id, hid_t_f *lcpl_id);
-H5_FCDLL int_f h5odecr_refcount_c(hid_t_f *object_id);
-H5_FCDLL int_f h5oincr_refcount_c(hid_t_f *object_id);
-H5_FCDLL int_f h5oexists_by_name_c(hid_t_f *loc_id, _fcd name, size_t_f *namelen, hid_t_f *lapl_id);
-H5_FCDLL int_f h5oset_comment_c(hid_t_f *object_id, _fcd comment, size_t_f *commentlen);
-H5_FCDLL int_f h5oset_comment_by_name_c(hid_t_f *object_id, _fcd name, size_t_f *namelen, _fcd comment,
+H5FC_DLL int_f h5odecr_refcount_c(hid_t_f *object_id);
+H5FC_DLL int_f h5oincr_refcount_c(hid_t_f *object_id);
+H5FC_DLL int_f h5oexists_by_name_c(hid_t_f *loc_id, _fcd name, size_t_f *namelen, hid_t_f *lapl_id);
+H5FC_DLL int_f h5oset_comment_c(hid_t_f *object_id, _fcd comment, size_t_f *commentlen);
+H5FC_DLL int_f h5oset_comment_by_name_c(hid_t_f *object_id, _fcd name, size_t_f *namelen, _fcd comment,
                                         size_t_f *commentlen, hid_t_f *lapl_id);
-H5_FCDLL int_f h5oopen_by_idx_c(hid_t_f *loc_id, _fcd group_name, size_t_f *group_namelen, int_f *index_type,
+H5FC_DLL int_f h5oopen_by_idx_c(hid_t_f *loc_id, _fcd group_name, size_t_f *group_namelen, int_f *index_type,
                                 int_f *order, hsize_t_f *n, hid_t_f *obj_id, hid_t_f *lapl_id);
-H5_FCDLL int_f h5oget_comment_c(hid_t_f *object_id, _fcd comment, size_t_f *commentsize, hssize_t_f *bufsize);
-H5_FCDLL int_f h5oget_comment_by_name_c(hid_t_f *loc_id, _fcd name, size_t_f *name_size, _fcd comment,
+H5FC_DLL int_f h5oget_comment_c(hid_t_f *object_id, _fcd comment, size_t_f *commentsize, hssize_t_f *bufsize);
+H5FC_DLL int_f h5oget_comment_by_name_c(hid_t_f *loc_id, _fcd name, size_t_f *name_size, _fcd comment,
                                         size_t_f *commentsize, size_t_f *bufsize, hid_t_f *lapl_id);
-H5_FCDLL int_f h5otoken_cmp_c(hid_t_f *loc_id, H5O_token_t *token1, H5O_token_t *token2, int_f *cmp_value);
+H5FC_DLL int_f h5otoken_cmp_c(hid_t_f *loc_id, H5O_token_t *token1, H5O_token_t *token2, int_f *cmp_value);
 /*
  * Functions from H5Pf.c
  */
-H5_FCDLL int_f h5pcreate_c(hid_t_f *cls, hid_t_f *prp_id);
-H5_FCDLL int_f h5pcopy_c(hid_t_f *prp_id, hid_t_f *new_prp_id);
-H5_FCDLL int_f h5pequal_c(hid_t_f *plist1_id, hid_t_f *plist2_id, int_f *c_flag);
-H5_FCDLL int_f h5pget_class_c(hid_t_f *prp_id, hid_t_f *classtype);
-H5_FCDLL int_f h5pset_deflate_c(hid_t_f *prp_id, int_f *level);
-H5_FCDLL int_f h5pset_chunk_c(hid_t_f *prp_id, int_f *rank, hsize_t_f *dims);
-H5_FCDLL int_f h5pget_chunk_c(hid_t_f *prp_id, int_f *max_rank, hsize_t_f *dims);
-H5_FCDLL int_f h5pset_file_image_c(hid_t_f *fapl_id, void *buf_ptr, size_t_f *buf_len);
-H5_FCDLL int_f h5pget_file_image_c(hid_t_f *fapl_id, void **buf_ptr, size_t_f *buf_len);
-H5_FCDLL int_f h5pset_preserve_c(hid_t_f *prp_id, int_f *flag);
-H5_FCDLL int_f h5pget_preserve_c(hid_t_f *prp_id, int_f *flag);
-H5_FCDLL int_f h5pget_version_c(hid_t_f *prp_id, int_f *boot, int_f *freelist, int_f *stab, int_f *shhdr);
-H5_FCDLL int_f h5pset_userblock_c(hid_t_f *prp_id, hsize_t_f *size);
-H5_FCDLL int_f h5pget_userblock_c(hid_t_f *prp_id, hsize_t_f *size);
-H5_FCDLL int_f h5pget_sizes_c(hid_t_f *prp_id, size_t_f *sizeof_addr, size_t_f *sizeof_size);
-H5_FCDLL int_f h5pset_sizes_c(hid_t_f *prp_id, size_t_f *sizeof_addr, size_t_f *sizeof_size);
-H5_FCDLL int_f h5pset_sym_k_c(hid_t_f *prp_id, int_f *ik, int_f *lk);
-H5_FCDLL int_f h5pget_sym_k_c(hid_t_f *prp_id, int_f *ik, int_f *lk);
-H5_FCDLL int_f h5pset_istore_k_c(hid_t_f *prp_id, int_f *ik);
-H5_FCDLL int_f h5pget_istore_k_c(hid_t_f *prp_id, int_f *ik);
-H5_FCDLL int_f h5pget_driver_c(hid_t_f *prp_id, hid_t_f *driver);
-H5_FCDLL int_f h5pset_fapl_stdio_c(hid_t_f *prp_id);
+H5FC_DLL int_f h5pcreate_c(hid_t_f *cls, hid_t_f *prp_id);
+H5FC_DLL int_f h5pcopy_c(hid_t_f *prp_id, hid_t_f *new_prp_id);
+H5FC_DLL int_f h5pequal_c(hid_t_f *plist1_id, hid_t_f *plist2_id, int_f *c_flag);
+H5FC_DLL int_f h5pget_class_c(hid_t_f *prp_id, hid_t_f *classtype);
+H5FC_DLL int_f h5pset_deflate_c(hid_t_f *prp_id, int_f *level);
+H5FC_DLL int_f h5pset_chunk_c(hid_t_f *prp_id, int_f *rank, hsize_t_f *dims);
+H5FC_DLL int_f h5pget_chunk_c(hid_t_f *prp_id, int_f *max_rank, hsize_t_f *dims);
+H5FC_DLL int_f h5pset_file_image_c(hid_t_f *fapl_id, void *buf_ptr, size_t_f *buf_len);
+H5FC_DLL int_f h5pget_file_image_c(hid_t_f *fapl_id, void **buf_ptr, size_t_f *buf_len);
+H5FC_DLL int_f h5pset_preserve_c(hid_t_f *prp_id, int_f *flag);
+H5FC_DLL int_f h5pget_preserve_c(hid_t_f *prp_id, int_f *flag);
+H5FC_DLL int_f h5pget_version_c(hid_t_f *prp_id, int_f *boot, int_f *freelist, int_f *stab, int_f *shhdr);
+H5FC_DLL int_f h5pset_userblock_c(hid_t_f *prp_id, hsize_t_f *size);
+H5FC_DLL int_f h5pget_userblock_c(hid_t_f *prp_id, hsize_t_f *size);
+H5FC_DLL int_f h5pget_sizes_c(hid_t_f *prp_id, size_t_f *sizeof_addr, size_t_f *sizeof_size);
+H5FC_DLL int_f h5pset_sizes_c(hid_t_f *prp_id, size_t_f *sizeof_addr, size_t_f *sizeof_size);
+H5FC_DLL int_f h5pset_sym_k_c(hid_t_f *prp_id, int_f *ik, int_f *lk);
+H5FC_DLL int_f h5pget_sym_k_c(hid_t_f *prp_id, int_f *ik, int_f *lk);
+H5FC_DLL int_f h5pset_istore_k_c(hid_t_f *prp_id, int_f *ik);
+H5FC_DLL int_f h5pget_istore_k_c(hid_t_f *prp_id, int_f *ik);
+H5FC_DLL int_f h5pget_driver_c(hid_t_f *prp_id, hid_t_f *driver);
+H5FC_DLL int_f h5pset_fapl_stdio_c(hid_t_f *prp_id);
 #ifdef NO_SUCH_F90_FUNCTION
-H5_FCDLL int_f h5pget_fapl_stdio_c(hid_t_f *prp_id, int_f *io);
+H5FC_DLL int_f h5pget_fapl_stdio_c(hid_t_f *prp_id, int_f *io);
 #endif
-H5_FCDLL int_f h5pset_fapl_sec2_c(hid_t_f *prp_id);
+H5FC_DLL int_f h5pset_fapl_sec2_c(hid_t_f *prp_id);
 #ifdef NO_SUCH_F90_FUNCTION
-H5_FCDLL int_f h5pget_fapl_sec2_c(hid_t_f *prp_id, int_f *sec2);
+H5FC_DLL int_f h5pget_fapl_sec2_c(hid_t_f *prp_id, int_f *sec2);
 #endif
-H5_FCDLL int_f h5pset_alignment_c(hid_t_f *prp_id, hsize_t_f *threshold, hsize_t_f *alignment);
-H5_FCDLL int_f h5pget_alignment_c(hid_t_f *prp_id, hsize_t_f *threshold, hsize_t_f *alignment);
-H5_FCDLL int_f h5pget_fapl_core_c(hid_t_f *prp_id, size_t_f *increment, int_f *flag);
-H5_FCDLL int_f h5pset_fapl_core_c(hid_t_f *prp_id, size_t_f *increment, int_f *flag);
-H5_FCDLL int_f h5pset_fapl_family_c(hid_t_f *prp_id, hsize_t_f *memb_size, hid_t_f *memb_plist);
-H5_FCDLL int_f h5pget_fapl_family_c(hid_t_f *prp_id, hsize_t_f *memb_size, hid_t_f *memb_plist);
-H5_FCDLL int_f h5pset_cache_c(hid_t_f *prp_id, int_f *mdc_nelmts, size_t_f *rdcc_nelmts,
+H5FC_DLL int_f h5pset_alignment_c(hid_t_f *prp_id, hsize_t_f *threshold, hsize_t_f *alignment);
+H5FC_DLL int_f h5pget_alignment_c(hid_t_f *prp_id, hsize_t_f *threshold, hsize_t_f *alignment);
+H5FC_DLL int_f h5pget_fapl_core_c(hid_t_f *prp_id, size_t_f *increment, int_f *flag);
+H5FC_DLL int_f h5pset_fapl_core_c(hid_t_f *prp_id, size_t_f *increment, int_f *flag);
+H5FC_DLL int_f h5pset_fapl_family_c(hid_t_f *prp_id, hsize_t_f *memb_size, hid_t_f *memb_plist);
+H5FC_DLL int_f h5pget_fapl_family_c(hid_t_f *prp_id, hsize_t_f *memb_size, hid_t_f *memb_plist);
+H5FC_DLL int_f h5pset_cache_c(hid_t_f *prp_id, int_f *mdc_nelmts, size_t_f *rdcc_nelmts,
                               size_t_f *rdcc_nbytes, real_f *rdcc_w0);
-H5_FCDLL int_f h5pget_cache_c(hid_t_f *prp_id, int_f *mdc_nelmts, size_t_f *rdcc_nelmts,
+H5FC_DLL int_f h5pget_cache_c(hid_t_f *prp_id, int_f *mdc_nelmts, size_t_f *rdcc_nelmts,
                               size_t_f *rdcc_nbytes, real_f *rdcc_w0);
 #ifdef NO_SUCH_F90_FUNCTION
-H5_FCDLL int_f h5pget_fapl_split_c(hid_t_f *prp_id, size_t_f *meta_ext_size, _fcd meta_ext,
+H5FC_DLL int_f h5pget_fapl_split_c(hid_t_f *prp_id, size_t_f *meta_ext_size, _fcd meta_ext,
                                    hid_t_f *meta_plist, size_t_f *raw_ext_size, _fcd raw_ext,
                                    hid_t_f *raw_plist);
 #endif
-H5_FCDLL int_f h5pset_fapl_split_c(hid_t_f *prp_id, int_f *meta_len, _fcd meta_ext, hid_t_f *meta_plist,
+H5FC_DLL int_f h5pset_fapl_split_c(hid_t_f *prp_id, int_f *meta_len, _fcd meta_ext, hid_t_f *meta_plist,
                                    int_f *raw_len, _fcd raw_ext, hid_t_f *raw_plist);
-H5_FCDLL int_f h5pset_gc_references_c(hid_t_f *prp_id, int_f *gc_references);
-H5_FCDLL int_f h5pget_gc_references_c(hid_t_f *prp_id, int_f *gc_references);
-H5_FCDLL int_f h5pset_layout_c(hid_t_f *prp_id, int_f *layout);
-H5_FCDLL int_f h5pget_layout_c(hid_t_f *prp_id, int_f *layout);
-H5_FCDLL int_f h5pset_filter_c(hid_t_f *prp_id, int_f *filter, int_f *flags, size_t_f *cd_nelmts,
+H5FC_DLL int_f h5pset_gc_references_c(hid_t_f *prp_id, int_f *gc_references);
+H5FC_DLL int_f h5pget_gc_references_c(hid_t_f *prp_id, int_f *gc_references);
+H5FC_DLL int_f h5pset_layout_c(hid_t_f *prp_id, int_f *layout);
+H5FC_DLL int_f h5pget_layout_c(hid_t_f *prp_id, int_f *layout);
+H5FC_DLL int_f h5pset_filter_c(hid_t_f *prp_id, int_f *filter, int_f *flags, size_t_f *cd_nelmts,
                                int_f *cd_values);
-H5_FCDLL int_f h5premove_filter_c(hid_t_f *prp_id, int_f *filter);
-H5_FCDLL int_f h5pmodify_filter_c(hid_t_f *prp_id, int_f *filter, int_f *flags, size_t_f *cd_nelmts,
+H5FC_DLL int_f h5premove_filter_c(hid_t_f *prp_id, int_f *filter);
+H5FC_DLL int_f h5pmodify_filter_c(hid_t_f *prp_id, int_f *filter, int_f *flags, size_t_f *cd_nelmts,
                                   int_f *cd_values);
-H5_FCDLL int_f h5pget_nfilters_c(hid_t_f *prp_id, int_f *nfilters);
-H5_FCDLL int_f h5pget_filter_c(hid_t_f *prp_id, int_f *filter_number, int_f *flags, size_t_f *cd_nelmts,
+H5FC_DLL int_f h5pget_nfilters_c(hid_t_f *prp_id, int_f *nfilters);
+H5FC_DLL int_f h5pget_filter_c(hid_t_f *prp_id, int_f *filter_number, int_f *flags, size_t_f *cd_nelmts,
                                int_f *cd_values, size_t_f *namelen, _fcd name, int_f *filter_id);
-H5_FCDLL int_f h5pget_filter_by_id_c(hid_t_f *prp_id, int_f *filter_id, int_f *flags, size_t_f *cd_nelmts,
+H5FC_DLL int_f h5pget_filter_by_id_c(hid_t_f *prp_id, int_f *filter_id, int_f *flags, size_t_f *cd_nelmts,
                                      int_f *cd_values, size_t_f *namelen, _fcd name);
-H5_FCDLL int_f h5pset_external_c(hid_t_f *prp_id, _fcd name, int_f *namelen, off_t_f *offset,
+H5FC_DLL int_f h5pset_external_c(hid_t_f *prp_id, _fcd name, int_f *namelen, off_t_f *offset,
                                  hsize_t_f *bytes);
-H5_FCDLL int_f h5pget_external_count_c(hid_t_f *prp_id, int_f *count);
-H5_FCDLL int_f h5pget_external_c(hid_t_f *prp_id, int_f *idx, size_t_f *name_size, _fcd name, off_t_f *offset,
+H5FC_DLL int_f h5pget_external_count_c(hid_t_f *prp_id, int_f *count);
+H5FC_DLL int_f h5pget_external_c(hid_t_f *prp_id, int_f *idx, size_t_f *name_size, _fcd name, off_t_f *offset,
                                  hsize_t_f *bytes);
-H5_FCDLL int_f h5pget_btree_ratios_c(hid_t_f *prp_id, real_f *left, real_f *middle, real_f *right);
-H5_FCDLL int_f h5pset_btree_ratios_c(hid_t_f *prp_id, real_f *left, real_f *middle, real_f *right);
-H5_FCDLL int_f h5pset_fclose_degree_c(hid_t_f *fapl, int_f *degree);
-H5_FCDLL int_f h5pget_fclose_degree_c(hid_t_f *fapl, int_f *degree);
-H5_FCDLL int_f h5pget_buffer_c(hid_t_f *plist, hsize_t_f *size);
-H5_FCDLL int_f h5pset_buffer_c(hid_t_f *plist, hsize_t_f *size);
-H5_FCDLL int_f h5pset_alloc_time_c(hid_t_f *plist, int_f *flag);
-H5_FCDLL int_f h5pget_alloc_time_c(hid_t_f *plist, int_f *flag);
-H5_FCDLL int_f h5pset_fill_time_c(hid_t_f *plist, int_f *flag);
-H5_FCDLL int_f h5pget_fill_time_c(hid_t_f *plist, int_f *flag);
-H5_FCDLL int_f h5pset_meta_block_size_c(hid_t_f *plist, hsize_t_f *size);
-H5_FCDLL int_f h5pget_meta_block_size_c(hid_t_f *plist, hsize_t_f *size);
-H5_FCDLL int_f h5pset_sieve_buf_size_c(hid_t_f *plist, size_t_f *size);
-H5_FCDLL int_f h5pget_sieve_buf_size_c(hid_t_f *plist, size_t_f *size);
-H5_FCDLL int_f h5pset_small_data_block_size_c(hid_t_f *plist, hsize_t_f *size);
-H5_FCDLL int_f h5pget_small_data_block_size_c(hid_t_f *plist, hsize_t_f *size);
-H5_FCDLL int_f h5pset_hyper_vector_size_c(hid_t_f *plist, size_t_f *size);
-H5_FCDLL int_f h5pget_hyper_vector_size_c(hid_t_f *plist, size_t_f *size);
-H5_FCDLL int_f h5pregister_c(hid_t_f *cls, _fcd name, int_f *name_len, size_t_f *size, void *value);
-H5_FCDLL int_f h5pinsert_c(hid_t_f *plist, _fcd name, int_f *name_len, size_t_f *size, void *value);
-H5_FCDLL int_f h5pset_c(hid_t_f *prp_id, _fcd name, int_f *name_len, void *value);
-H5_FCDLL int_f h5pget_c(hid_t_f *prp_id, _fcd name, int_f *name_len, void *value);
-H5_FCDLL int_f h5pexist_c(hid_t_f *prp_id, _fcd name, int_f *name_len);
-H5_FCDLL int_f h5pget_size_c(hid_t_f *prp_id, _fcd name, int_f *name_len, size_t_f *size);
-H5_FCDLL int_f h5pget_nprops_c(hid_t_f *prp_id, size_t_f *nprops);
-H5_FCDLL int_f h5pget_class_parent_c(hid_t_f *prp_id, hid_t_f *parent_id);
-H5_FCDLL int_f h5pisa_class_c(hid_t_f *plist, hid_t_f *pclass);
-H5_FCDLL int_f h5pcopy_prop_c(hid_t_f *dst_id, hid_t_f *src_id, _fcd name, int_f *name_len);
-H5_FCDLL int_f h5premove_c(hid_t_f *plid, _fcd name, int_f *name_len);
-H5_FCDLL int_f h5punregister_c(hid_t_f *cls, _fcd name, int_f *name_len);
-H5_FCDLL int_f h5pclose_class_c(hid_t_f *cls);
-H5_FCDLL int_f h5pget_class_name_c(hid_t_f *prp_id, _fcd name, int_f *name_len);
-H5_FCDLL int_f h5pset_shuffle_c(hid_t_f *prp_id);
-H5_FCDLL int_f h5pset_fletcher32_c(hid_t_f *prp_id);
-H5_FCDLL int_f h5pset_edc_check_c(hid_t_f *prp_id, int_f *flag);
-H5_FCDLL int_f h5pget_edc_check_c(hid_t_f *prp_id, int_f *flag);
-H5_FCDLL int_f h5pset_family_offset_c(hid_t_f *prp_id, hsize_t_f *offset);
-H5_FCDLL int_f h5pget_fapl_multi_c(hid_t_f *prp_id, int_f *mem_map, hid_t_f *memb_fapl, _fcd memb_name,
+H5FC_DLL int_f h5pget_btree_ratios_c(hid_t_f *prp_id, real_f *left, real_f *middle, real_f *right);
+H5FC_DLL int_f h5pset_btree_ratios_c(hid_t_f *prp_id, real_f *left, real_f *middle, real_f *right);
+H5FC_DLL int_f h5pset_fclose_degree_c(hid_t_f *fapl, int_f *degree);
+H5FC_DLL int_f h5pget_fclose_degree_c(hid_t_f *fapl, int_f *degree);
+H5FC_DLL int_f h5pget_buffer_c(hid_t_f *plist, hsize_t_f *size);
+H5FC_DLL int_f h5pset_buffer_c(hid_t_f *plist, hsize_t_f *size);
+H5FC_DLL int_f h5pset_alloc_time_c(hid_t_f *plist, int_f *flag);
+H5FC_DLL int_f h5pget_alloc_time_c(hid_t_f *plist, int_f *flag);
+H5FC_DLL int_f h5pset_fill_time_c(hid_t_f *plist, int_f *flag);
+H5FC_DLL int_f h5pget_fill_time_c(hid_t_f *plist, int_f *flag);
+H5FC_DLL int_f h5pset_meta_block_size_c(hid_t_f *plist, hsize_t_f *size);
+H5FC_DLL int_f h5pget_meta_block_size_c(hid_t_f *plist, hsize_t_f *size);
+H5FC_DLL int_f h5pset_sieve_buf_size_c(hid_t_f *plist, size_t_f *size);
+H5FC_DLL int_f h5pget_sieve_buf_size_c(hid_t_f *plist, size_t_f *size);
+H5FC_DLL int_f h5pset_small_data_block_size_c(hid_t_f *plist, hsize_t_f *size);
+H5FC_DLL int_f h5pget_small_data_block_size_c(hid_t_f *plist, hsize_t_f *size);
+H5FC_DLL int_f h5pset_hyper_vector_size_c(hid_t_f *plist, size_t_f *size);
+H5FC_DLL int_f h5pget_hyper_vector_size_c(hid_t_f *plist, size_t_f *size);
+H5FC_DLL int_f h5pregister_c(hid_t_f *cls, _fcd name, int_f *name_len, size_t_f *size, void *value);
+H5FC_DLL int_f h5pinsert_c(hid_t_f *plist, _fcd name, int_f *name_len, size_t_f *size, void *value);
+H5FC_DLL int_f h5pset_c(hid_t_f *prp_id, _fcd name, int_f *name_len, void *value);
+H5FC_DLL int_f h5pget_c(hid_t_f *prp_id, _fcd name, int_f *name_len, void *value);
+H5FC_DLL int_f h5pexist_c(hid_t_f *prp_id, _fcd name, int_f *name_len);
+H5FC_DLL int_f h5pget_size_c(hid_t_f *prp_id, _fcd name, int_f *name_len, size_t_f *size);
+H5FC_DLL int_f h5pget_nprops_c(hid_t_f *prp_id, size_t_f *nprops);
+H5FC_DLL int_f h5pget_class_parent_c(hid_t_f *prp_id, hid_t_f *parent_id);
+H5FC_DLL int_f h5pisa_class_c(hid_t_f *plist, hid_t_f *pclass);
+H5FC_DLL int_f h5pcopy_prop_c(hid_t_f *dst_id, hid_t_f *src_id, _fcd name, int_f *name_len);
+H5FC_DLL int_f h5premove_c(hid_t_f *plid, _fcd name, int_f *name_len);
+H5FC_DLL int_f h5punregister_c(hid_t_f *cls, _fcd name, int_f *name_len);
+H5FC_DLL int_f h5pclose_class_c(hid_t_f *cls);
+H5FC_DLL int_f h5pget_class_name_c(hid_t_f *prp_id, _fcd name, int_f *name_len);
+H5FC_DLL int_f h5pset_shuffle_c(hid_t_f *prp_id);
+H5FC_DLL int_f h5pset_fletcher32_c(hid_t_f *prp_id);
+H5FC_DLL int_f h5pset_edc_check_c(hid_t_f *prp_id, int_f *flag);
+H5FC_DLL int_f h5pget_edc_check_c(hid_t_f *prp_id, int_f *flag);
+H5FC_DLL int_f h5pset_family_offset_c(hid_t_f *prp_id, hsize_t_f *offset);
+H5FC_DLL int_f h5pget_fapl_multi_c(hid_t_f *prp_id, int_f *mem_map, hid_t_f *memb_fapl, _fcd memb_name,
                                    int_f *len, int_f *lenmax, real_f *memb_addr, int_f *flag,
                                    int_f *maxlen_out);
-H5_FCDLL int_f h5pset_fapl_multi_c(hid_t_f *prp_id, int_f *mem_map, hid_t_f *memb_fapl, _fcd memb_name,
+H5FC_DLL int_f h5pset_fapl_multi_c(hid_t_f *prp_id, int_f *mem_map, hid_t_f *memb_fapl, _fcd memb_name,
                                    int_f *len, int_f *lenmax, real_f *memb_addr, int_f *flag);
-H5_FCDLL int_f h5pset_fapl_multi_sc(hid_t_f *prp_id, int_f *flag);
-H5_FCDLL int_f h5pset_szip_c(hid_t_f *prp_id, int_f *options_mask, int_f *pixels_per_block);
-H5_FCDLL int_f h5pall_filters_avail_c(hid_t_f *prp_id, int_f *status);
-H5_FCDLL int_f h5pfill_value_defined_c(hid_t_f *prp_id, int_f *flag);
-H5_FCDLL int_f h5pget_attr_phase_change_c(hid_t_f *ocpl_id, int_f *max_compact, int_f *min_dense);
-H5_FCDLL int_f h5pset_attr_creation_order_c(hid_t_f *ocpl_id, int_f *crt_order_flags);
-H5_FCDLL int_f h5pset_shared_mesg_nindexes_c(hid_t_f *plist_id, int_f *nindexes);
-H5_FCDLL int_f h5pset_shared_mesg_index_c(hid_t_f *fcpl_id, int_f *index_num, int_f *mesg_type_flags,
+H5FC_DLL int_f h5pset_fapl_multi_sc(hid_t_f *prp_id, int_f *flag);
+H5FC_DLL int_f h5pset_szip_c(hid_t_f *prp_id, int_f *options_mask, int_f *pixels_per_block);
+H5FC_DLL int_f h5pall_filters_avail_c(hid_t_f *prp_id, int_f *status);
+H5FC_DLL int_f h5pfill_value_defined_c(hid_t_f *prp_id, int_f *flag);
+H5FC_DLL int_f h5pget_attr_phase_change_c(hid_t_f *ocpl_id, int_f *max_compact, int_f *min_dense);
+H5FC_DLL int_f h5pset_attr_creation_order_c(hid_t_f *ocpl_id, int_f *crt_order_flags);
+H5FC_DLL int_f h5pset_shared_mesg_nindexes_c(hid_t_f *plist_id, int_f *nindexes);
+H5FC_DLL int_f h5pset_shared_mesg_index_c(hid_t_f *fcpl_id, int_f *index_num, int_f *mesg_type_flags,
                                           int_f *min_mesg_size);
-H5_FCDLL int_f h5pget_attr_creation_order_c(hid_t_f *ocpl_id, int_f *crt_order_flags);
-H5_FCDLL int_f h5pset_link_creation_order_c(hid_t_f *gcpl_id, int_f *crt_order_flags);
-H5_FCDLL int_f h5pget_link_phase_change_c(hid_t_f *gcpl_id, int_f *max_compact, int_f *min_dense);
-H5_FCDLL int_f h5pget_obj_track_times_c(hid_t_f *plist_id, int_f *flag);
-H5_FCDLL int_f h5pset_obj_track_times_c(hid_t_f *plist_id, int_f *flag);
-H5_FCDLL int_f h5pset_create_inter_group_c(hid_t_f *lcpl_id, int_f *crt_intermed_group);
-H5_FCDLL int_f h5pget_create_inter_group_c(hid_t_f *lcpl_id, int_f *crt_intermed_group);
-H5_FCDLL int_f h5pget_link_creation_order_c(hid_t_f *gcpl_id, int_f *crt_order_flags);
-H5_FCDLL int_f h5pset_char_encoding_c(hid_t_f *plist_id, int_f *encoding);
-H5_FCDLL int_f h5pget_char_encoding_c(hid_t_f *plist_id, int_f *encoding);
-H5_FCDLL int_f h5pset_copy_object_c(hid_t_f *ocp_plist_id, int_f *copy_options);
-H5_FCDLL int_f h5pget_copy_object_c(hid_t_f *ocp_plist_id, int_f *copy_options);
-H5_FCDLL int_f h5pget_data_transform_c(hid_t_f *plist_id, _fcd expression, int_f *expression_len,
+H5FC_DLL int_f h5pget_attr_creation_order_c(hid_t_f *ocpl_id, int_f *crt_order_flags);
+H5FC_DLL int_f h5pset_link_creation_order_c(hid_t_f *gcpl_id, int_f *crt_order_flags);
+H5FC_DLL int_f h5pget_link_phase_change_c(hid_t_f *gcpl_id, int_f *max_compact, int_f *min_dense);
+H5FC_DLL int_f h5pget_obj_track_times_c(hid_t_f *plist_id, int_f *flag);
+H5FC_DLL int_f h5pset_obj_track_times_c(hid_t_f *plist_id, int_f *flag);
+H5FC_DLL int_f h5pset_create_inter_group_c(hid_t_f *lcpl_id, int_f *crt_intermed_group);
+H5FC_DLL int_f h5pget_create_inter_group_c(hid_t_f *lcpl_id, int_f *crt_intermed_group);
+H5FC_DLL int_f h5pget_link_creation_order_c(hid_t_f *gcpl_id, int_f *crt_order_flags);
+H5FC_DLL int_f h5pset_char_encoding_c(hid_t_f *plist_id, int_f *encoding);
+H5FC_DLL int_f h5pget_char_encoding_c(hid_t_f *plist_id, int_f *encoding);
+H5FC_DLL int_f h5pset_copy_object_c(hid_t_f *ocp_plist_id, int_f *copy_options);
+H5FC_DLL int_f h5pget_copy_object_c(hid_t_f *ocp_plist_id, int_f *copy_options);
+H5FC_DLL int_f h5pget_data_transform_c(hid_t_f *plist_id, _fcd expression, int_f *expression_len,
                                        size_t_f *size);
-H5_FCDLL int_f h5pset_data_transform_c(hid_t_f *plist_id, _fcd expression, int_f *expression_len);
-H5_FCDLL int_f h5pget_local_heap_size_hint_c(hid_t_f *gcpl_id, size_t_f *size_hint);
-H5_FCDLL int_f h5pget_est_link_info_c(hid_t_f *gcpl_id, int_f *est_num_entries, int_f *est_name_len);
-H5_FCDLL int_f h5pset_local_heap_size_hint_c(hid_t_f *gcpl_id, size_t_f *size_hint);
-H5_FCDLL int_f h5pset_est_link_info_c(hid_t_f *gcpl_id, int_f *est_num_entries, int_f *est_name_len);
-H5_FCDLL int_f h5pset_link_phase_change_c(hid_t_f *gcpl_id, int_f *max_compact, int_f *min_dense);
-H5_FCDLL int_f h5pset_fapl_direct_c(hid_t_f *fapl_id, size_t_f *alignment, size_t_f *block_size,
+H5FC_DLL int_f h5pset_data_transform_c(hid_t_f *plist_id, _fcd expression, int_f *expression_len);
+H5FC_DLL int_f h5pget_local_heap_size_hint_c(hid_t_f *gcpl_id, size_t_f *size_hint);
+H5FC_DLL int_f h5pget_est_link_info_c(hid_t_f *gcpl_id, int_f *est_num_entries, int_f *est_name_len);
+H5FC_DLL int_f h5pset_local_heap_size_hint_c(hid_t_f *gcpl_id, size_t_f *size_hint);
+H5FC_DLL int_f h5pset_est_link_info_c(hid_t_f *gcpl_id, int_f *est_num_entries, int_f *est_name_len);
+H5FC_DLL int_f h5pset_link_phase_change_c(hid_t_f *gcpl_id, int_f *max_compact, int_f *min_dense);
+H5FC_DLL int_f h5pset_fapl_direct_c(hid_t_f *fapl_id, size_t_f *alignment, size_t_f *block_size,
                                     size_t_f *cbuf_size);
-H5_FCDLL int_f h5pget_fapl_direct_c(hid_t_f *fapl_id, size_t_f *alignment, size_t_f *block_size,
+H5FC_DLL int_f h5pget_fapl_direct_c(hid_t_f *fapl_id, size_t_f *alignment, size_t_f *block_size,
                                     size_t_f *cbuf_size);
-H5_FCDLL int_f h5pset_attr_phase_change_c(hid_t_f *ocpl_id, int_f *max_compact, int_f *min_dense);
-H5_FCDLL int_f h5pset_nbit_c(hid_t_f *plist_id);
-H5_FCDLL int_f h5pset_scaleoffset_c(hid_t_f *plist_id, int_f *scale_type, int_f *scale_factor);
-H5_FCDLL int_f h5pset_nlinks_c(hid_t_f *lapl_id, size_t_f *nlinks);
-H5_FCDLL int_f h5pget_nlinks_c(hid_t_f *lapl_id, size_t_f *nlinks);
-H5_FCDLL int_f h5pset_chunk_cache_c(hid_t_f *dapl_id, size_t_f *rdcc_nslots, size_t_f *rdcc_nbytes,
+H5FC_DLL int_f h5pset_attr_phase_change_c(hid_t_f *ocpl_id, int_f *max_compact, int_f *min_dense);
+H5FC_DLL int_f h5pset_nbit_c(hid_t_f *plist_id);
+H5FC_DLL int_f h5pset_scaleoffset_c(hid_t_f *plist_id, int_f *scale_type, int_f *scale_factor);
+H5FC_DLL int_f h5pset_nlinks_c(hid_t_f *lapl_id, size_t_f *nlinks);
+H5FC_DLL int_f h5pget_nlinks_c(hid_t_f *lapl_id, size_t_f *nlinks);
+H5FC_DLL int_f h5pset_chunk_cache_c(hid_t_f *dapl_id, size_t_f *rdcc_nslots, size_t_f *rdcc_nbytes,
                                     real_f *rdcc_w0);
-H5_FCDLL int_f h5pget_chunk_cache_c(hid_t_f *dapl_id, size_t_f *rdcc_nslots, size_t_f *rdcc_nbytes,
+H5FC_DLL int_f h5pget_chunk_cache_c(hid_t_f *dapl_id, size_t_f *rdcc_nslots, size_t_f *rdcc_nbytes,
                                     real_f *rdcc_w0);
 #ifdef H5_HAVE_PARALLEL
-H5_FCDLL int_f h5pget_mpio_actual_io_mode_c(hid_t_f *dxpl_id, int_f *actual_io_mode);
-H5_FCDLL int_f h5pget_fapl_mpio_c(hid_t_f *prp_id, int *comm, int *info);
-H5_FCDLL int_f h5pset_fapl_mpio_c(hid_t_f *prp_id, void *comm, void *info);
-H5_FCDLL int_f h5pget_mpi_params_c(hid_t_f *prp_id, int *comm, int *info);
-H5_FCDLL int_f h5pset_mpi_params_c(hid_t_f *prp_id, void *comm, void *info);
-H5_FCDLL int_f h5pget_dxpl_mpio_c(hid_t_f *prp_id, int_f *data_xfer_mode);
-H5_FCDLL int_f h5pset_dxpl_mpio_c(hid_t_f *prp_id, int_f *data_xfer_mode);
+H5FC_DLL int_f h5pget_mpio_actual_io_mode_c(hid_t_f *dxpl_id, int_f *actual_io_mode);
+H5FC_DLL int_f h5pget_fapl_mpio_c(hid_t_f *prp_id, int *comm, int *info);
+H5FC_DLL int_f h5pset_fapl_mpio_c(hid_t_f *prp_id, void *comm, void *info);
+H5FC_DLL int_f h5pget_mpi_params_c(hid_t_f *prp_id, int *comm, int *info);
+H5FC_DLL int_f h5pset_mpi_params_c(hid_t_f *prp_id, void *comm, void *info);
+H5FC_DLL int_f h5pget_dxpl_mpio_c(hid_t_f *prp_id, int_f *data_xfer_mode);
+H5FC_DLL int_f h5pset_dxpl_mpio_c(hid_t_f *prp_id, int_f *data_xfer_mode);
 #endif
 /*
  * Functions from H5Rf.c
  */
-H5_FCDLL int_f h5rcreate_region_c(int_f *ref, hid_t_f *loc_id, _fcd name, int_f *namelen, hid_t_f *space_id);
-H5_FCDLL int_f h5rcreate_ptr_c(void *ref, hid_t_f *loc_id, _fcd name, int_f *namelen, int_f *ref_type,
+H5FC_DLL int_f h5rcreate_region_c(int_f *ref, hid_t_f *loc_id, _fcd name, int_f *namelen, hid_t_f *space_id);
+H5FC_DLL int_f h5rcreate_ptr_c(void *ref, hid_t_f *loc_id, _fcd name, int_f *namelen, int_f *ref_type,
                                hid_t_f *space_id);
-H5_FCDLL int_f h5rdereference_ptr_c(hid_t_f *obj_id, int_f *ref_type, void *ref, hid_t_f *ref_obj_id);
-H5_FCDLL int_f h5rget_region_region_c(hid_t_f *dset_id, int_f *ref, hid_t_f *space_id);
-H5_FCDLL int_f h5rget_region_ptr_c(hid_t_f *dset_id, void *ref, hid_t_f *space_id);
-H5_FCDLL int_f h5rget_object_type_obj_c(hid_t_f *dset_id, haddr_t_f *ref, int_f *obj_type);
-H5_FCDLL int_f h5rget_name_ptr_c(hid_t_f *loc_id, int_f *ref_type, void *ref, _fcd name, size_t_f *name_len,
+H5FC_DLL int_f h5rdereference_ptr_c(hid_t_f *obj_id, int_f *ref_type, void *ref, hid_t_f *ref_obj_id);
+H5FC_DLL int_f h5rget_region_region_c(hid_t_f *dset_id, int_f *ref, hid_t_f *space_id);
+H5FC_DLL int_f h5rget_region_ptr_c(hid_t_f *dset_id, void *ref, hid_t_f *space_id);
+H5FC_DLL int_f h5rget_object_type_obj_c(hid_t_f *dset_id, haddr_t_f *ref, int_f *obj_type);
+H5FC_DLL int_f h5rget_name_ptr_c(hid_t_f *loc_id, int_f *ref_type, void *ref, _fcd name, size_t_f *name_len,
                                  size_t_f *size_default);
-H5_FCDLL int_f h5rget_obj_type_c(hid_t_f *loc_id, int_f *ref_type, void *ref, int_f *obj_type);
+H5FC_DLL int_f h5rget_obj_type_c(hid_t_f *loc_id, int_f *ref_type, void *ref, int_f *obj_type);
 /*
  * Functions from H5If.c
  */
-H5_FCDLL int_f h5iget_type_c(hid_t_f *obj_id, int_f *type);
-H5_FCDLL int_f h5iget_name_c(hid_t_f *obj_id, _fcd buf, size_t_f *buf_size, size_t_f *name_size);
-H5_FCDLL int_f h5iinc_ref_c(hid_t_f *obj_id, int_f *ref_count);
-H5_FCDLL int_f h5idec_ref_c(hid_t_f *obj_id, int_f *ref_count);
-H5_FCDLL int_f h5iget_ref_c(hid_t_f *obj_id, int_f *ref_count);
-H5_FCDLL int_f h5iget_file_id_c(hid_t_f *obj_id, hid_t_f *file_id);
-H5_FCDLL int_f h5iis_valid_c(hid_t_f *obj_id, int_f *c_valid);
+H5FC_DLL int_f h5iget_type_c(hid_t_f *obj_id, int_f *type);
+H5FC_DLL int_f h5iget_name_c(hid_t_f *obj_id, _fcd buf, size_t_f *buf_size, size_t_f *name_size);
+H5FC_DLL int_f h5iinc_ref_c(hid_t_f *obj_id, int_f *ref_count);
+H5FC_DLL int_f h5idec_ref_c(hid_t_f *obj_id, int_f *ref_count);
+H5FC_DLL int_f h5iget_ref_c(hid_t_f *obj_id, int_f *ref_count);
+H5FC_DLL int_f h5iget_file_id_c(hid_t_f *obj_id, hid_t_f *file_id);
+H5FC_DLL int_f h5iis_valid_c(hid_t_f *obj_id, int_f *c_valid);
 
 /*
  * Functions from H5Ef.c
  */
 
-H5_FCDLL int_f h5eprint_c(hid_t_f *err_stack, _fcd name, size_t_f *namelen);
-H5_FCDLL int_f h5eset_auto2_c(int_f *printflag, hid_t_f *estack_id, H5E_auto2_t func, void *client_data);
-H5_FCDLL int_f h5epush_c(hid_t_f *err_stack, _fcd file, int_f *file_len, _fcd func, int_f *func_len, int line,
+H5FC_DLL int_f h5eprint_c(hid_t_f *err_stack, _fcd name, size_t_f *namelen);
+H5FC_DLL int_f h5eset_auto2_c(int_f *printflag, hid_t_f *estack_id, H5E_auto2_t func, void *client_data);
+H5FC_DLL int_f h5epush_c(hid_t_f *err_stack, _fcd file, int_f *file_len, _fcd func, int_f *func_len, int line,
                          hid_t_f *cls_id, hid_t_f *maj_id, hid_t_f *min_id, _fcd msg, int_f *msg_len,
                          const char *arg1, const char *arg2, const char *arg3, const char *arg4,
                          const char *arg5, const char *arg6, const char *arg7, const char *arg8,
@@ -565,12 +565,12 @@ H5_FCDLL int_f h5epush_c(hid_t_f *err_stack, _fcd file, int_f *file_len, _fcd fu
 /*
  * Functions from H5f.c
  */
-H5_FCDLL int_f h5open_c(void);
-H5_FCDLL int_f h5close_c(void);
-H5_FCDLL int_f h5init_types_c(hid_t_f *types, hid_t_f *floatingtypes, hid_t_f *integertypes);
-H5_FCDLL int_f h5close_types_c(hid_t_f *types, int_f *lentypes, hid_t_f *floatingtypes, int_f *floatinglen,
+H5FC_DLL int_f h5open_c(void);
+H5FC_DLL int_f h5close_c(void);
+H5FC_DLL int_f h5init_types_c(hid_t_f *types, hid_t_f *floatingtypes, hid_t_f *integertypes);
+H5FC_DLL int_f h5close_types_c(hid_t_f *types, int_f *lentypes, hid_t_f *floatingtypes, int_f *floatinglen,
                                hid_t_f *integertypes, int_f *integerlen);
-H5_FCDLL int_f h5init_flags_c(int_f *h5d_flags, size_t_f *h5d_size_flags, int_f *h5e_flags,
+H5FC_DLL int_f h5init_flags_c(int_f *h5d_flags, size_t_f *h5d_size_flags, int_f *h5e_flags,
                               hid_t_f *h5e_hid_flags, H5ES_status_t *h5es_flags, hid_t_f *h5es_hid_flags,
                               int_f *h5f_flags, int_f *h5fd_flags, hid_t_f *h5fd_hid_flags, int_f *h5g_flags,
                               int_f *h5i_flags, int_f *h5l_flags, int_f *h5o_flags, hid_t_f *h5p_flags,
@@ -578,57 +578,57 @@ H5_FCDLL int_f h5init_flags_c(int_f *h5d_flags, size_t_f *h5d_size_flags, int_f 
                               hid_t_f *h5s_hid_flags, hsize_t_f *h5s_hsize_flags, int_f *h5t_flags,
                               int_f *h5vl_flags, uint64_t *h5vl_int64_flags, int_f *h5z_flags,
                               int_f *h5_generic_flags, haddr_t_f *h5_haddr_generic_flags);
-H5_FCDLL int_f h5init1_flags_c(int_f *h5lib_flags);
-H5_FCDLL int_f h5get_libversion_c(int_f *majnum, int_f *minnum, int_f *relnum);
-H5_FCDLL int_f h5check_version_c(int_f *majnum, int_f *minnum, int_f *relnum);
-H5_FCDLL int_f h5garbage_collect_c(void);
-H5_FCDLL int_f h5dont_atexit_c(void);
+H5FC_DLL int_f h5init1_flags_c(int_f *h5lib_flags);
+H5FC_DLL int_f h5get_libversion_c(int_f *majnum, int_f *minnum, int_f *relnum);
+H5FC_DLL int_f h5check_version_c(int_f *majnum, int_f *minnum, int_f *relnum);
+H5FC_DLL int_f h5garbage_collect_c(void);
+H5FC_DLL int_f h5dont_atexit_c(void);
 
 /*
  * Functions from H5Zf.c
  */
-H5_FCDLL int_f h5zunregister_c(int_f *filter);
-H5_FCDLL int_f h5zfilter_avail_c(int_f *filter, int_f *flag);
-H5_FCDLL int_f h5zget_filter_info_c(int_f *filter, int_f *flag);
+H5FC_DLL int_f h5zunregister_c(int_f *filter);
+H5FC_DLL int_f h5zfilter_avail_c(int_f *filter, int_f *flag);
+H5FC_DLL int_f h5zget_filter_info_c(int_f *filter, int_f *flag);
 
 /*
  * Functions from H5Lf.c
  */
 
-H5_FCDLL int_f h5lcopy_c(hid_t_f *src_loc_id, _fcd src_name, size_t_f *src_namelen, hid_t_f *dest_loc_id,
+H5FC_DLL int_f h5lcopy_c(hid_t_f *src_loc_id, _fcd src_name, size_t_f *src_namelen, hid_t_f *dest_loc_id,
                          _fcd dest_name, size_t_f *dest_namelen, hid_t_f *lcpl_id, hid_t_f *lapl_id);
-H5_FCDLL int_f h5lcreate_external_c(_fcd file_name, size_t_f *file_namelen, _fcd obj_name,
+H5FC_DLL int_f h5lcreate_external_c(_fcd file_name, size_t_f *file_namelen, _fcd obj_name,
                                     size_t_f *obj_namelen, hid_t_f *link_loc_id, _fcd link_name,
                                     size_t_f *link_namelen, hid_t_f *lcpl_id, hid_t_f *lapl_id);
-H5_FCDLL int_f h5lcreate_hard_c(hid_t_f *obj_loc_id, _fcd obj_name, size_t_f *obj_namelen,
+H5FC_DLL int_f h5lcreate_hard_c(hid_t_f *obj_loc_id, _fcd obj_name, size_t_f *obj_namelen,
                                 hid_t_f *link_loc_id, _fcd link_name, size_t_f *link_namelen,
                                 hid_t_f *lcpl_id, hid_t_f *lapl_id);
-H5_FCDLL int_f h5lcreate_soft_c(_fcd target_path, size_t_f *target_path_len, hid_t_f *link_loc_id,
+H5FC_DLL int_f h5lcreate_soft_c(_fcd target_path, size_t_f *target_path_len, hid_t_f *link_loc_id,
                                 _fcd link_name, size_t_f *link_name_len, hid_t_f *lcpl_id, hid_t_f *lapl_id);
-H5_FCDLL int_f h5ldelete_c(hid_t_f *loc_id, _fcd name, size_t_f *namelen, hid_t_f *lapl_id);
-H5_FCDLL int_f h5ldelete_by_idx_c(hid_t_f *loc_id, _fcd group_name, size_t_f *group_namelen,
+H5FC_DLL int_f h5ldelete_c(hid_t_f *loc_id, _fcd name, size_t_f *namelen, hid_t_f *lapl_id);
+H5FC_DLL int_f h5ldelete_by_idx_c(hid_t_f *loc_id, _fcd group_name, size_t_f *group_namelen,
                                   int_f *index_field, int_f *order, hsize_t_f *n, hid_t_f *lapl_id);
-H5_FCDLL int_f h5lexists_c(hid_t_f *loc_id, _fcd name, size_t_f *namelen, hid_t_f *lapl_id,
+H5FC_DLL int_f h5lexists_c(hid_t_f *loc_id, _fcd name, size_t_f *namelen, hid_t_f *lapl_id,
                            int_f *link_exists);
-H5_FCDLL int_f h5lget_info_c(hid_t_f *link_loc_id, _fcd link_name, size_t_f *link_namelen, int_f *cset,
+H5FC_DLL int_f h5lget_info_c(hid_t_f *link_loc_id, _fcd link_name, size_t_f *link_namelen, int_f *cset,
                              int_f *corder, int_f *corder_valid, int_f *link_type, H5O_token_t *token,
                              size_t_f *val_size, hid_t_f *lapl_id);
-H5_FCDLL int_f h5lget_info_by_idx_c(hid_t_f *loc_id, _fcd group_name, size_t_f *group_namelen,
+H5FC_DLL int_f h5lget_info_by_idx_c(hid_t_f *loc_id, _fcd group_name, size_t_f *group_namelen,
                                     int_f *index_field, int_f *order, hsize_t_f *n, int_f *link_type,
                                     int_f *corder_valid, int_f *corder, int_f *cset, H5O_token_t *token,
                                     size_t_f *val_size, hid_t_f *lapl_id);
-H5_FCDLL int_f h5lis_registered_c(int_f *link_cls_id);
-H5_FCDLL int_f h5lmove_c(hid_t_f *src_loc_id, _fcd src_name, size_t_f *src_namelen, hid_t_f *dest_loc_id,
+H5FC_DLL int_f h5lis_registered_c(int_f *link_cls_id);
+H5FC_DLL int_f h5lmove_c(hid_t_f *src_loc_id, _fcd src_name, size_t_f *src_namelen, hid_t_f *dest_loc_id,
                          _fcd dest_name, size_t_f *dest_namelen, hid_t_f *lcpl_id, hid_t_f *lapl_id);
-H5_FCDLL int_f h5lget_name_by_idx_c(hid_t_f *loc_id, _fcd group_name, size_t_f *group_namelen,
+H5FC_DLL int_f h5lget_name_by_idx_c(hid_t_f *loc_id, _fcd group_name, size_t_f *group_namelen,
                                     int_f *index_field, int_f *order, hsize_t_f *n, size_t_f *size, _fcd name,
                                     hid_t_f *lapl_id);
-H5_FCDLL int_f h5lget_val_c(hid_t_f *link_loc_id, _fcd link_name, size_t_f *link_namelen, size_t_f *size,
+H5FC_DLL int_f h5lget_val_c(hid_t_f *link_loc_id, _fcd link_name, size_t_f *link_namelen, size_t_f *size,
                             void *linkval_buff, hid_t_f *lapl_id);
 
-H5_FCDLL int_f h5literate_c(hid_t_f *group_id, int_f *index_type, int_f *order, hsize_t_f *idx,
+H5FC_DLL int_f h5literate_c(hid_t_f *group_id, int_f *index_type, int_f *order, hsize_t_f *idx,
                             H5L_iterate2_t op, void *op_data);
-H5_FCDLL int_f h5literate_by_name_c(hid_t_f *loc_id, _fcd name, size_t_f *namelen, int_f *index_type,
+H5FC_DLL int_f h5literate_by_name_c(hid_t_f *loc_id, _fcd name, size_t_f *namelen, int_f *index_type,
                                     int_f *order, hsize_t_f *idx, H5L_iterate2_t op, void *op_data,
                                     hid_t_f *lapl_id);
 

--- a/fortran/test/t.h
+++ b/fortran/test/t.h
@@ -25,11 +25,11 @@ char *h5_fixname(const char *base_name, hid_t fapl, char *fullname, size_t size)
 #define nh5_exit_c          H5_FC_FUNC_(h5_exit_c, H5_EXIT_C)
 #define nh5_env_nocleanup_c H5_FC_FUNC_(h5_env_nocleanup_c, H5_ENV_NOCLEANUP_C)
 
-H5_FCTESTDLL int_f nh5_fixname_c(_fcd base_name, size_t_f *base_namelen, hid_t_f *fapl, _fcd full_name,
-                                 size_t_f *full_namelen);
+H5FC_TEST_DLL int_f nh5_fixname_c(_fcd base_name, size_t_f *base_namelen, hid_t_f *fapl, _fcd full_name,
+                                  size_t_f *full_namelen);
 
-H5_FCTESTDLL int_f nh5_cleanup_c(_fcd base_name, size_t_f *base_namelen, hid_t_f *fapl);
+H5FC_TEST_DLL int_f nh5_cleanup_c(_fcd base_name, size_t_f *base_namelen, hid_t_f *fapl);
 
-H5_FCTESTDLL H5_ATTR_NORETURN void nh5_exit_c(int_f *status);
+H5FC_TEST_DLL H5_ATTR_NORETURN void nh5_exit_c(int_f *status);
 
-H5_FCTESTDLL void nh5_env_nocleanup_c(int_f *status);
+H5FC_TEST_DLL void nh5_env_nocleanup_c(int_f *status);

--- a/hl/c++/src/H5PacketTable.h
+++ b/hl/c++/src/H5PacketTable.h
@@ -27,7 +27,7 @@
 #include "H5PTpublic.h"
 #include "H5api_adpt.h"
 
-class H5_HLCPPDLL PacketTable {
+class H5CPP_HL_DLL PacketTable {
   public:
     /* Null constructor
      * Sets table_id to H5I_INVALID_HID
@@ -127,7 +127,7 @@ class H5_HLCPPDLL PacketTable {
     hid_t table_id;
 };
 
-class H5_HLCPPDLL FL_PacketTable : virtual public PacketTable {
+class H5CPP_HL_DLL FL_PacketTable : virtual public PacketTable {
   public:
     /* Constructor
      * Creates a packet table to store either fixed- or variable-length packets.

--- a/hl/fortran/src/H5LTf90proto.h
+++ b/hl/fortran/src/H5LTf90proto.h
@@ -20,128 +20,128 @@
 
 /* These definitions should match those in fortran/src/H5f90kit.c */
 
-H5_FCDLL char *HD5f2cstring(_fcd fdesc, size_t len);
-H5_FCDLL void  HD5packFstring(char *src, char *dest, size_t len);
+H5FC_DLL char *HD5f2cstring(_fcd fdesc, size_t len);
+H5FC_DLL void  HD5packFstring(char *src, char *dest, size_t len);
 
 /*
  *  Functions from H5DSfc.c
  */
-HDF5_HL_F90CSTUBDLL
+H5FC_HL_DLL
 int_f h5dsset_scale_c(hid_t_f *dsid, _fcd dimname, size_t_f *dimnamelen);
 
-HDF5_HL_F90CSTUBDLL
+H5FC_HL_DLL
 int_f h5dsattach_scale_c(hid_t_f *did, hid_t_f *dsid, int_f *idx);
 
-HDF5_HL_F90CSTUBDLL
+H5FC_HL_DLL
 int_f h5dsdetach_scale_c(hid_t_f *did, hid_t_f *dsid, int_f *idx);
 
-HDF5_HL_F90CSTUBDLL
+H5FC_HL_DLL
 int_f h5dsis_attached_c(hid_t_f *did, hid_t_f *dsid, int_f *idx, int_f *c_is_attached);
 
-HDF5_HL_F90CSTUBDLL
+H5FC_HL_DLL
 int_f h5dsis_scale_c(hid_t_f *did, int_f *is_scale);
 
-HDF5_HL_F90CSTUBDLL
+H5FC_HL_DLL
 int_f h5dsset_label_c(hid_t_f *did, int_f *idx, _fcd label, size_t_f *labellen);
 
-HDF5_HL_F90CSTUBDLL
+H5FC_HL_DLL
 int_f h5dsget_label_c(hid_t_f *did, int_f *idx, _fcd label, size_t_f *size);
 
-HDF5_HL_F90CSTUBDLL
+H5FC_HL_DLL
 int_f h5dsget_scale_name_c(hid_t_f *did, _fcd label, size_t_f *size);
 
-HDF5_HL_F90CSTUBDLL
+H5FC_HL_DLL
 int_f h5dsget_num_scales_c(hid_t_f *did, int_f *idx, int_f *num_scales);
 
 /*
  *  Functions from H5LTfc.c
  */
 
-HDF5_HL_F90CSTUBDLL
+H5FC_HL_DLL
 int_f h5ltmake_dataset_c(hid_t_f *loc_id, size_t_f *namelen, _fcd name, int_f *rank, hsize_t_f *dims,
                          hid_t_f *type_id, void *buf);
 
-HDF5_HL_F90CSTUBDLL
+H5FC_HL_DLL
 int_f h5ltread_dataset_c(hid_t_f *loc_id, size_t_f *namelen, _fcd name, hid_t_f *type_id, void *buf);
 
-HDF5_HL_F90CSTUBDLL
+H5FC_HL_DLL
 int_f h5ltset_attribute_c(hid_t_f *loc_id, size_t_f *namelen, _fcd dsetname, size_t_f *attrnamelen,
                           _fcd attrname, size_t_f *size, void *buf, char *dtype, size_t_f *sizeof_val);
 
-HDF5_HL_F90CSTUBDLL
+H5FC_HL_DLL
 int_f h5ltget_attribute_c(hid_t_f *loc_id, size_t_f *namelen, _fcd dsetname, size_t_f *attrnamelen,
                           _fcd attrname, void *buf, char *dtype, size_t_f *sizeof_val);
 
-HDF5_HL_F90CSTUBDLL
+H5FC_HL_DLL
 int_f h5ltget_attribute_string_c(hid_t_f *loc_id, size_t_f *namelen, _fcd dsetname, size_t_f *attrnamelen,
                                  _fcd attrname, _fcd buf, size_t_f *buf_size);
 
-HDF5_HL_F90CSTUBDLL
+H5FC_HL_DLL
 int_f h5ltget_dataset_ndims_c(hid_t_f *loc_id, size_t_f *namelen, _fcd name, int_f *rank);
 
-HDF5_HL_F90CSTUBDLL
+H5FC_HL_DLL
 int_f h5ltfind_dataset_c(hid_t_f *loc_id, size_t_f *namelen, _fcd name);
 
-HDF5_HL_F90CSTUBDLL
+H5FC_HL_DLL
 int_f h5ltget_dataset_info_c(hid_t_f *loc_id, size_t_f *namelen, _fcd name, hsize_t_f *dims,
                              int_f *type_class, size_t_f *type_size);
 
-HDF5_HL_F90CSTUBDLL
+H5FC_HL_DLL
 int_f h5ltget_attribute_ndims_c(hid_t_f *loc_id, size_t_f *namelen, _fcd dsetname, size_t_f *attrnamelen,
                                 _fcd attrname, int_f *rank);
-HDF5_HL_F90CSTUBDLL
+H5FC_HL_DLL
 int_f h5ltget_attribute_info_c(hid_t_f *loc_id, size_t_f *namelen, _fcd name, size_t_f *attrnamelen,
                                _fcd attrname, hsize_t_f *dims, int_f *type_class, size_t_f *type_size);
 
-HDF5_HL_F90CSTUBDLL
+H5FC_HL_DLL
 int_f h5ltmake_dataset_string_c(hid_t_f *loc_id, size_t_f *namelen, _fcd name, size_t_f *buflen, char *buf);
 
-HDF5_HL_F90CSTUBDLL
+H5FC_HL_DLL
 int_f h5ltread_dataset_string_c(hid_t_f *loc_id, size_t_f *namelen, _fcd name, char *buf);
 
-HDF5_HL_F90CSTUBDLL
+H5FC_HL_DLL
 int_f h5ltpath_valid_c(hid_t_f *loc_id, _fcd path, size_t_f *pathlen, int_f *check_object_valid_c);
 
 /*-------------------------------------------------------------------------
  * Image
  *-------------------------------------------------------------------------
  */
-HDF5_HL_F90CSTUBDLL
+H5FC_HL_DLL
 int_f h5immake_image_8bit_c(hid_t_f *loc_id, size_t_f *namelen, _fcd name, hsize_t_f *width,
                             hsize_t_f *height, int_f *buf);
-HDF5_HL_F90CSTUBDLL
+H5FC_HL_DLL
 int_f h5imread_image_c(hid_t_f *loc_id, size_t_f *namelen, _fcd name, int_f *buf);
 
-HDF5_HL_F90CSTUBDLL
+H5FC_HL_DLL
 int_f h5immake_image_24bit_c(hid_t_f *loc_id, size_t_f *namelen, _fcd name, size_t_f *ilen, _fcd il,
                              hsize_t_f *width, hsize_t_f *height, void *buf);
-HDF5_HL_F90CSTUBDLL
+H5FC_HL_DLL
 int_f h5imget_image_info_c(hid_t_f *loc_id, size_t_f *namelen, _fcd name, hsize_t_f *width, hsize_t_f *height,
                            hsize_t_f *planes, hsize_t_f *npals, size_t_f *ilen, _fcd interlace);
 
-HDF5_HL_F90CSTUBDLL
+H5FC_HL_DLL
 int_f h5imis_image_c(hid_t_f *loc_id, size_t_f *namelen, _fcd name);
 
-HDF5_HL_F90CSTUBDLL
+H5FC_HL_DLL
 int_f h5immake_palette_c(hid_t_f *loc_id, size_t_f *namelen, _fcd name, hsize_t_f *dims, void *buf);
 
-HDF5_HL_F90CSTUBDLL
+H5FC_HL_DLL
 int_f h5imlink_palette_c(hid_t_f *loc_id, size_t_f *namelen, _fcd name, size_t_f *ilen, _fcd pal_name);
 
-HDF5_HL_F90CSTUBDLL
+H5FC_HL_DLL
 int_f h5imunlink_palette_c(hid_t_f *loc_id, size_t_f *namelen, _fcd name, size_t_f *ilen, _fcd pal_name);
 
-HDF5_HL_F90CSTUBDLL
+H5FC_HL_DLL
 int_f h5imget_npalettes_c(hid_t_f *loc_id, size_t_f *namelen, _fcd name, hsize_t_f *npals);
 
-HDF5_HL_F90CSTUBDLL
+H5FC_HL_DLL
 int_f h5imget_palette_info_c(hid_t_f *loc_id, size_t_f *namelen, _fcd name, int_f *pal_number,
                              hsize_t_f *dims);
 
-HDF5_HL_F90CSTUBDLL
+H5FC_HL_DLL
 int_f h5imget_palette_c(hid_t_f *loc_id, size_t_f *namelen, _fcd name, int_f *pal_number, void *buf);
 
-HDF5_HL_F90CSTUBDLL
+H5FC_HL_DLL
 int_f h5imis_palette_c(hid_t_f *loc_id, size_t_f *namelen, _fcd name);
 
 /*-------------------------------------------------------------------------
@@ -149,7 +149,7 @@ int_f h5imis_palette_c(hid_t_f *loc_id, size_t_f *namelen, _fcd name);
  *-------------------------------------------------------------------------
  */
 
-HDF5_HL_F90CSTUBDLL
+H5FC_HL_DLL
 int_f h5tbmake_table_c(size_t_f *namelen1, _fcd name1, hid_t_f *loc_id, size_t_f *namelen, _fcd name,
                        hsize_t_f *nfields, hsize_t_f *nrecords, size_t_f *type_size, size_t_f *field_offset,
                        hid_t_f *field_types, hsize_t_f *chunk_size, int_f *compress,
@@ -157,11 +157,11 @@ int_f h5tbmake_table_c(size_t_f *namelen1, _fcd name1, hid_t_f *loc_id, size_t_f
                        size_t_f *max_char_size_field_names, /* char len of fields */
                        _fcd      buf);                           /* field_names */
 
-HDF5_HL_F90CSTUBDLL
+H5FC_HL_DLL
 int_f h5tbread_table_c(hid_t_f *loc_id, _fcd name, size_t_f *namelen, hsize_t_f *nfields, size_t_f *dst_size,
                        size_t_f *dst_offset, size_t_f *dst_sizes, void *dst_buf);
 
-HDF5_HL_F90CSTUBDLL
+H5FC_HL_DLL
 int_f h5tbmake_table_ptr_c(size_t_f *namelen1, _fcd name1, hid_t_f *loc_id, size_t_f *namelen, _fcd name,
                            hsize_t_f *nfields, hsize_t_f *nrecords, size_t_f *type_size,
                            size_t_f *field_offset, hid_t_f *field_types, hsize_t_f *chunk_size,
@@ -171,36 +171,36 @@ int_f h5tbmake_table_ptr_c(size_t_f *namelen1, _fcd name1, hid_t_f *loc_id, size
                            char     *field_names,               /* field_names */
                            void     *data);
 
-HDF5_HL_F90CSTUBDLL
+H5FC_HL_DLL
 int_f h5tbwrite_field_name_c(hid_t_f *loc_id, size_t_f *namelen, _fcd name, size_t_f *namelen1,
                              _fcd field_name, hsize_t_f *start, hsize_t_f *nrecords, size_t_f *type_size,
                              void *buf);
 
-HDF5_HL_F90CSTUBDLL
+H5FC_HL_DLL
 int_f h5tbread_field_name_c(hid_t_f *loc_id, size_t_f *namelen, _fcd name, size_t_f *namelen1,
                             _fcd field_name, hsize_t_f *start, hsize_t_f *nrecords, size_t_f *type_size,
                             void *buf);
 
-HDF5_HL_F90CSTUBDLL
+H5FC_HL_DLL
 int_f h5tbwrite_field_index_c(hid_t_f *loc_id, size_t_f *namelen, _fcd name, int_f *field_index,
                               hsize_t_f *start, hsize_t_f *nrecords, size_t_f *type_size, void *buf);
 
-HDF5_HL_F90CSTUBDLL
+H5FC_HL_DLL
 int_f h5tbread_field_index_c(hid_t_f *loc_id, size_t_f *namelen, _fcd name, int_f *field_index,
                              hsize_t_f *start, hsize_t_f *nrecords, size_t_f *type_size, void *buf);
 
-HDF5_HL_F90CSTUBDLL
+H5FC_HL_DLL
 int_f h5tbinsert_field_c(hid_t_f *loc_id, size_t_f *namelen, _fcd name, size_t_f *namelen1, _fcd field_name,
                          hid_t_f *field_type, int_f *position, void *buf);
 
-HDF5_HL_F90CSTUBDLL
+H5FC_HL_DLL
 int_f h5tbdelete_field_c(hid_t_f *loc_id, size_t_f *namelen, _fcd name, size_t_f *namelen1, _fcd field_name);
 
-HDF5_HL_F90CSTUBDLL
+H5FC_HL_DLL
 int_f h5tbget_table_info_c(hid_t_f *loc_id, size_t_f *namelen, _fcd name, hsize_t_f *nfields,
                            hsize_t_f *nrecords);
 
-HDF5_HL_F90CSTUBDLL
+H5FC_HL_DLL
 int_f h5tbget_field_info_c(hid_t_f *loc_id, size_t_f *namelen, _fcd name, hsize_t_f *nfields,
                            size_t_f *field_sizes, size_t_f *field_offsets, size_t_f *type_size,
                            size_t_f *namelen2, size_t_f *lenmax, _fcd field_names, size_t_f *maxlen_out);

--- a/hl/src/H5DOpublic.h
+++ b/hl/src/H5DOpublic.h
@@ -310,7 +310,7 @@ extern "C" {
  * \since   1.10.0
  *
  */
-H5_HLDLL herr_t H5DOappend(hid_t dset_id, hid_t dxpl_id, unsigned axis, size_t extension, hid_t memtype,
+H5HL_DLL herr_t H5DOappend(hid_t dset_id, hid_t dxpl_id, unsigned axis, size_t extension, hid_t memtype,
                            const void *buf);
 
 /* Symbols defined for compatibility with previous versions of the HDF5 API.
@@ -393,7 +393,7 @@ H5_HLDLL herr_t H5DOappend(hid_t dset_id, hid_t dxpl_id, unsigned axis, size_t e
  *
  * \since   1.8.11
  */
-H5_HLDLL herr_t H5DOwrite_chunk(hid_t dset_id, hid_t dxpl_id, uint32_t filters, const hsize_t *offset,
+H5HL_DLL herr_t H5DOwrite_chunk(hid_t dset_id, hid_t dxpl_id, uint32_t filters, const hsize_t *offset,
                                 size_t data_size, const void *buf);
 
 /**
@@ -454,7 +454,7 @@ H5_HLDLL herr_t H5DOwrite_chunk(hid_t dset_id, hid_t dxpl_id, uint32_t filters, 
  *
  * \since   1.10.2, 1.8.19
  */
-H5_HLDLL herr_t H5DOread_chunk(hid_t dset_id, hid_t dxpl_id, const hsize_t *offset, uint32_t *filters /*out*/,
+H5HL_DLL herr_t H5DOread_chunk(hid_t dset_id, hid_t dxpl_id, const hsize_t *offset, uint32_t *filters /*out*/,
                                void *buf /*out*/);
 
 #endif /* H5_NO_DEPRECATED_SYMBOLS */

--- a/hl/src/H5DSpublic.h
+++ b/hl/src/H5DSpublic.h
@@ -825,7 +825,7 @@ extern "C" {
  *           via configure option.
  *
  */
-H5_HLDLL herr_t H5DSwith_new_ref(hid_t obj_id, hbool_t *with_new_ref);
+H5HL_DLL herr_t H5DSwith_new_ref(hid_t obj_id, hbool_t *with_new_ref);
 
 /**
  * --------------------------------------------------------------------------
@@ -856,7 +856,7 @@ H5_HLDLL herr_t H5DSwith_new_ref(hid_t obj_id, hbool_t *with_new_ref);
  * \note The Dimension Scale \p dsid can be attached to the
  *       same dimension more than once, which has no effect.
  */
-H5_HLDLL herr_t H5DSattach_scale(hid_t did, hid_t dsid, unsigned int idx);
+H5HL_DLL herr_t H5DSattach_scale(hid_t did, hid_t dsid, unsigned int idx);
 
 /**
  * --------------------------------------------------------------------------
@@ -887,7 +887,7 @@ H5_HLDLL herr_t H5DSattach_scale(hid_t did, hid_t dsid, unsigned int idx);
  *       of the associations, for \p did.
  *
  */
-H5_HLDLL herr_t H5DSdetach_scale(hid_t did, hid_t dsid, unsigned int idx);
+H5HL_DLL herr_t H5DSdetach_scale(hid_t did, hid_t dsid, unsigned int idx);
 
 /**
  * --------------------------------------------------------------------------
@@ -922,7 +922,7 @@ H5_HLDLL herr_t H5DSdetach_scale(hid_t did, hid_t dsid, unsigned int idx);
  *
  * \todo what is [9] after Palette interface?
  */
-H5_HLDLL herr_t H5DSset_scale(hid_t dsid, const char *dimname);
+H5HL_DLL herr_t H5DSset_scale(hid_t dsid, const char *dimname);
 
 /**
  * --------------------------------------------------------------------------
@@ -943,7 +943,7 @@ H5_HLDLL herr_t H5DSset_scale(hid_t dsid, const char *dimname);
  *          dataset \p did.
  *
  */
-H5_HLDLL int H5DSget_num_scales(hid_t did, unsigned int idx);
+H5HL_DLL int H5DSget_num_scales(hid_t did, unsigned int idx);
 
 /**
  * --------------------------------------------------------------------------
@@ -966,7 +966,7 @@ H5_HLDLL int H5DSget_num_scales(hid_t did, unsigned int idx);
  *          - Bad arguments
  *
  */
-H5_HLDLL herr_t H5DSset_label(hid_t did, unsigned int idx, const char *label);
+H5HL_DLL herr_t H5DSset_label(hid_t did, unsigned int idx, const char *label);
 
 /**
  * --------------------------------------------------------------------------
@@ -996,7 +996,7 @@ H5_HLDLL herr_t H5DSset_label(hid_t did, unsigned int idx, const char *label);
  *          - Bad arguments
  *
  */
-H5_HLDLL ssize_t H5DSget_label(hid_t did, unsigned int idx, char *label, size_t size);
+H5HL_DLL ssize_t H5DSget_label(hid_t did, unsigned int idx, char *label, size_t size);
 
 /**
  * --------------------------------------------------------------------------
@@ -1030,7 +1030,7 @@ H5_HLDLL ssize_t H5DSget_label(hid_t did, unsigned int idx, char *label, size_t 
  *          passed back will contain the null terminator and the last character
  *          will be missing from the name passed back to the calling application.)
  */
-H5_HLDLL ssize_t H5DSget_scale_name(hid_t did, char *name, size_t size);
+H5HL_DLL ssize_t H5DSget_scale_name(hid_t did, char *name, size_t size);
 
 /**
  * --------------------------------------------------------------------------
@@ -1046,7 +1046,7 @@ H5_HLDLL ssize_t H5DSget_scale_name(hid_t did, char *name, size_t size);
  *          i.e., has class="DIMENSION_SCALE").
  *
  */
-H5_HLDLL htri_t H5DSis_scale(hid_t did);
+H5HL_DLL htri_t H5DSis_scale(hid_t did);
 
 /**
  * --------------------------------------------------------------------------
@@ -1102,7 +1102,7 @@ H5_HLDLL htri_t H5DSis_scale(hid_t did);
  *          the iteration. If the membership changes during the iteration,
  *          the function's behavior is undefined.
  */
-H5_HLDLL herr_t H5DSiterate_scales(hid_t did, unsigned int dim, int *idx, H5DS_iterate_t visitor,
+H5HL_DLL herr_t H5DSiterate_scales(hid_t did, unsigned int dim, int *idx, H5DS_iterate_t visitor,
                                    void *visitor_data);
 
 /**
@@ -1128,7 +1128,7 @@ H5_HLDLL herr_t H5DSiterate_scales(hid_t did, unsigned int dim, int *idx, H5DS_i
  *          - If \p did is a Dimension Scale (A Dimension Scale cannot have scales.)
  *
  */
-H5_HLDLL htri_t H5DSis_attached(hid_t did, hid_t dsid, unsigned int idx);
+H5HL_DLL htri_t H5DSis_attached(hid_t did, hid_t dsid, unsigned int idx);
 
 #ifdef __cplusplus
 }

--- a/hl/src/H5IMprivate.h
+++ b/hl/src/H5IMprivate.h
@@ -29,6 +29,6 @@
  * Private functions
  *-------------------------------------------------------------------------
  */
-H5_HLDLL herr_t H5IM_find_palette(hid_t loc_id);
+H5HL_DLL herr_t H5IM_find_palette(hid_t loc_id);
 
 #endif

--- a/hl/src/H5IMpublic.h
+++ b/hl/src/H5IMpublic.h
@@ -105,7 +105,7 @@ extern "C" {
  *          table palette.
  *
  */
-H5_HLDLL herr_t H5IMmake_image_8bit(hid_t loc_id, const char *dset_name, hsize_t width, hsize_t height,
+H5HL_DLL herr_t H5IMmake_image_8bit(hid_t loc_id, const char *dset_name, hsize_t width, hsize_t height,
                                     const unsigned char *buffer);
 
 /**
@@ -145,7 +145,7 @@ H5_HLDLL herr_t H5IMmake_image_8bit(hid_t loc_id, const char *dset_name, hsize_t
  *          or INTERLACE_PLANE.
  *
  */
-H5_HLDLL herr_t H5IMmake_image_24bit(hid_t loc_id, const char *dset_name, hsize_t width, hsize_t height,
+H5HL_DLL herr_t H5IMmake_image_24bit(hid_t loc_id, const char *dset_name, hsize_t width, hsize_t height,
                                      const char *interlace, const unsigned char *buffer);
 
 /**
@@ -170,7 +170,7 @@ H5_HLDLL herr_t H5IMmake_image_24bit(hid_t loc_id, const char *dset_name, hsize_
  *          by the identifier \p loc_id.
  *
  */
-H5_HLDLL herr_t H5IMget_image_info(hid_t loc_id, const char *dset_name, hsize_t *width, hsize_t *height,
+H5HL_DLL herr_t H5IMget_image_info(hid_t loc_id, const char *dset_name, hsize_t *width, hsize_t *height,
                                    hsize_t *planes, char *interlace, hssize_t *npals);
 
 /**
@@ -190,7 +190,7 @@ H5_HLDLL herr_t H5IMget_image_info(hid_t loc_id, const char *dset_name, hsize_t 
  *          identifier \p loc_id.
  *
  */
-H5_HLDLL herr_t H5IMread_image(hid_t loc_id, const char *dset_name, unsigned char *buffer);
+H5HL_DLL herr_t H5IMread_image(hid_t loc_id, const char *dset_name, unsigned char *buffer);
 
 /**
  * --------------------------------------------------------------------------
@@ -212,7 +212,7 @@ H5_HLDLL herr_t H5IMread_image(hid_t loc_id, const char *dset_name, unsigned cha
  *          type #H5T_NATIVE_UCHAR.
  *
  */
-H5_HLDLL herr_t H5IMmake_palette(hid_t loc_id, const char *pal_name, const hsize_t *pal_dims,
+H5HL_DLL herr_t H5IMmake_palette(hid_t loc_id, const char *pal_name, const hsize_t *pal_dims,
                                  const unsigned char *pal_data);
 
 /**
@@ -234,7 +234,7 @@ H5_HLDLL herr_t H5IMmake_palette(hid_t loc_id, const char *pal_name, const hsize
  *          to the new palette.
  *
  */
-H5_HLDLL herr_t H5IMlink_palette(hid_t loc_id, const char *image_name, const char *pal_name);
+H5HL_DLL herr_t H5IMlink_palette(hid_t loc_id, const char *image_name, const char *pal_name);
 
 /**
  * --------------------------------------------------------------------------
@@ -252,7 +252,7 @@ H5_HLDLL herr_t H5IMlink_palette(hid_t loc_id, const char *image_name, const cha
  *          specified by \p image_name.
  *
  */
-H5_HLDLL herr_t H5IMunlink_palette(hid_t loc_id, const char *image_name, const char *pal_name);
+H5HL_DLL herr_t H5IMunlink_palette(hid_t loc_id, const char *image_name, const char *pal_name);
 
 /**
  * --------------------------------------------------------------------------
@@ -270,7 +270,7 @@ H5_HLDLL herr_t H5IMunlink_palette(hid_t loc_id, const char *image_name, const c
  *          an image specified by \p image_name.
  *
  */
-H5_HLDLL herr_t H5IMget_npalettes(hid_t loc_id, const char *image_name, hssize_t *npals);
+H5HL_DLL herr_t H5IMget_npalettes(hid_t loc_id, const char *image_name, hssize_t *npals);
 
 /**
  * --------------------------------------------------------------------------
@@ -291,7 +291,7 @@ H5_HLDLL herr_t H5IMget_npalettes(hid_t loc_id, const char *image_name, hssize_t
  *          associated to an image specified by \p image_name.
  *
  */
-H5_HLDLL herr_t H5IMget_palette_info(hid_t loc_id, const char *image_name, int pal_number, hsize_t *pal_dims);
+H5HL_DLL herr_t H5IMget_palette_info(hid_t loc_id, const char *image_name, int pal_number, hsize_t *pal_dims);
 
 /**
  * --------------------------------------------------------------------------
@@ -312,7 +312,7 @@ H5_HLDLL herr_t H5IMget_palette_info(hid_t loc_id, const char *image_name, int p
  *          image specified by \p image_name.
  *
  */
-H5_HLDLL herr_t H5IMget_palette(hid_t loc_id, const char *image_name, int pal_number,
+H5HL_DLL herr_t H5IMget_palette(hid_t loc_id, const char *image_name, int pal_number,
                                 unsigned char *pal_data);
 
 /**
@@ -332,7 +332,7 @@ H5_HLDLL herr_t H5IMget_palette(hid_t loc_id, const char *image_name, int pal_nu
  *          Specification.
  *
  */
-H5_HLDLL herr_t H5IMis_image(hid_t loc_id, const char *dset_name);
+H5HL_DLL herr_t H5IMis_image(hid_t loc_id, const char *dset_name);
 
 /**
  * --------------------------------------------------------------------------
@@ -351,7 +351,7 @@ H5_HLDLL herr_t H5IMis_image(hid_t loc_id, const char *dset_name);
  *          Image and Palette Specification.
  *
  */
-H5_HLDLL herr_t H5IMis_palette(hid_t loc_id, const char *dset_name);
+H5HL_DLL herr_t H5IMis_palette(hid_t loc_id, const char *dset_name);
 
 #ifdef __cplusplus
 }

--- a/hl/src/H5LDprivate.h
+++ b/hl/src/H5LDprivate.h
@@ -42,8 +42,8 @@ extern "C" {
  * #2: these two routines are too specific to be made as public routines
  * Decide to do #3 at this point of time after some discussion.
  */
-H5_HLDLL void H5LD_clean_vector(H5LD_memb_t *listv[]);
-H5_HLDLL int  H5LD_construct_vector(char *fields, H5LD_memb_t *listv[], hid_t par_tid);
+H5HL_DLL void H5LD_clean_vector(H5LD_memb_t *listv[]);
+H5HL_DLL int  H5LD_construct_vector(char *fields, H5LD_memb_t *listv[], hid_t par_tid);
 
 #ifdef __cplusplus
 }

--- a/hl/src/H5LDpublic.h
+++ b/hl/src/H5LDpublic.h
@@ -44,7 +44,7 @@ extern "C" {
  * \since 1.10.0
  *
  */
-H5_HLDLL herr_t H5LDget_dset_dims(hid_t did, hsize_t *cur_dims);
+H5HL_DLL herr_t H5LDget_dset_dims(hid_t did, hsize_t *cur_dims);
 
 /**
  *-------------------------------------------------------------------------
@@ -81,7 +81,7 @@ H5_HLDLL herr_t H5LDget_dset_dims(hid_t did, hsize_t *cur_dims);
  * \since 1.10.0
  *
  */
-H5_HLDLL size_t H5LDget_dset_type_size(hid_t did, const char *fields);
+H5HL_DLL size_t H5LDget_dset_type_size(hid_t did, const char *fields);
 
 /**
  *-------------------------------------------------------------------------
@@ -157,7 +157,7 @@ H5_HLDLL size_t H5LDget_dset_type_size(hid_t did, const char *fields);
  * \since 1.10.0
  *
  */
-H5_HLDLL herr_t H5LDget_dset_elmts(hid_t did, const hsize_t *prev_dims, const hsize_t *cur_dims,
+H5HL_DLL herr_t H5LDget_dset_elmts(hid_t did, const hsize_t *prev_dims, const hsize_t *cur_dims,
                                    const char *fields, void *buf);
 
 #ifdef __cplusplus

--- a/hl/src/H5LTprivate.h
+++ b/hl/src/H5LTprivate.h
@@ -19,12 +19,12 @@
 /* public LT prototypes			*/
 #include "H5LTpublic.h"
 
-H5_HLDLL herr_t H5LT_get_attribute_disk(hid_t obj_id, const char *attr_name, void *data);
-H5_HLDLL herr_t H5LT_set_attribute_numerical(hid_t loc_id, const char *obj_name, const char *attr_name,
+H5HL_DLL herr_t H5LT_get_attribute_disk(hid_t obj_id, const char *attr_name, void *data);
+H5HL_DLL herr_t H5LT_set_attribute_numerical(hid_t loc_id, const char *obj_name, const char *attr_name,
                                              size_t size, hid_t type_id, const void *data);
-H5_HLDLL herr_t H5LT_set_attribute_string(hid_t dset_id, const char *name, const char *buf);
-H5_HLDLL char  *H5LT_dtype_to_text(hid_t dtype, char *dt_str, H5LT_lang_t lang, size_t *slen,
+H5HL_DLL herr_t H5LT_set_attribute_string(hid_t dset_id, const char *name, const char *buf);
+H5HL_DLL char  *H5LT_dtype_to_text(hid_t dtype, char *dt_str, H5LT_lang_t lang, size_t *slen,
                                    bool no_user_buf);
-H5_HLDLL hid_t  H5LTyyparse(void);
+H5HL_DLL hid_t  H5LTyyparse(void);
 
 #endif

--- a/hl/src/H5LTpublic.h
+++ b/hl/src/H5LTpublic.h
@@ -198,7 +198,7 @@ extern "C" {
  *                with more than three dimensions.
  *
  */
-H5_HLDLL herr_t H5LTmake_dataset(hid_t loc_id, const char *dset_name, int rank, const hsize_t *dims,
+H5HL_DLL herr_t H5LTmake_dataset(hid_t loc_id, const char *dset_name, int rank, const hsize_t *dims,
                                  hid_t type_id, const void *buffer);
 
 /**
@@ -222,7 +222,7 @@ H5_HLDLL herr_t H5LTmake_dataset(hid_t loc_id, const char *dset_name, int rank, 
  *          The dataset's datatype will be \e character, #H5T_NATIVE_CHAR.
  *
  */
-H5_HLDLL herr_t H5LTmake_dataset_char(hid_t loc_id, const char *dset_name, int rank, const hsize_t *dims,
+H5HL_DLL herr_t H5LTmake_dataset_char(hid_t loc_id, const char *dset_name, int rank, const hsize_t *dims,
                                       const char *buffer);
 
 /**
@@ -247,7 +247,7 @@ H5_HLDLL herr_t H5LTmake_dataset_char(hid_t loc_id, const char *dset_name, int r
  *          #H5T_NATIVE_SHORT.
  *
  */
-H5_HLDLL herr_t H5LTmake_dataset_short(hid_t loc_id, const char *dset_name, int rank, const hsize_t *dims,
+H5HL_DLL herr_t H5LTmake_dataset_short(hid_t loc_id, const char *dset_name, int rank, const hsize_t *dims,
                                        const short *buffer);
 
 /**
@@ -275,7 +275,7 @@ H5_HLDLL herr_t H5LTmake_dataset_short(hid_t loc_id, const char *dset_name, int 
  *          arrays with more than three dimensions.
  *
  */
-H5_HLDLL herr_t H5LTmake_dataset_int(hid_t loc_id, const char *dset_name, int rank, const hsize_t *dims,
+H5HL_DLL herr_t H5LTmake_dataset_int(hid_t loc_id, const char *dset_name, int rank, const hsize_t *dims,
                                      const int *buffer);
 
 /**
@@ -300,7 +300,7 @@ H5_HLDLL herr_t H5LTmake_dataset_int(hid_t loc_id, const char *dset_name, int ra
  *          #H5T_NATIVE_LONG.
  *
  */
-H5_HLDLL herr_t H5LTmake_dataset_long(hid_t loc_id, const char *dset_name, int rank, const hsize_t *dims,
+H5HL_DLL herr_t H5LTmake_dataset_long(hid_t loc_id, const char *dset_name, int rank, const hsize_t *dims,
                                       const long *buffer);
 
 /**
@@ -328,7 +328,7 @@ H5_HLDLL herr_t H5LTmake_dataset_long(hid_t loc_id, const char *dset_name, int r
  *                arrays with more than three dimensions.
  *
  */
-H5_HLDLL herr_t H5LTmake_dataset_float(hid_t loc_id, const char *dset_name, int rank, const hsize_t *dims,
+H5HL_DLL herr_t H5LTmake_dataset_float(hid_t loc_id, const char *dset_name, int rank, const hsize_t *dims,
                                        const float *buffer);
 
 /**
@@ -356,7 +356,7 @@ H5_HLDLL herr_t H5LTmake_dataset_float(hid_t loc_id, const char *dset_name, int 
  *                arrays with more than three dimensions.
  *
  */
-H5_HLDLL herr_t H5LTmake_dataset_double(hid_t loc_id, const char *dset_name, int rank, const hsize_t *dims,
+H5HL_DLL herr_t H5LTmake_dataset_double(hid_t loc_id, const char *dset_name, int rank, const hsize_t *dims,
                                         const double *buffer);
 
 /**
@@ -378,7 +378,7 @@ H5_HLDLL herr_t H5LTmake_dataset_double(hid_t loc_id, const char *dset_name, int
  *          The dataset's datatype will be <em>C string</em>, #H5T_C_S1.
  *
  */
-H5_HLDLL herr_t H5LTmake_dataset_string(hid_t loc_id, const char *dset_name, const char *buf);
+H5HL_DLL herr_t H5LTmake_dataset_string(hid_t loc_id, const char *dset_name, const char *buf);
 
 /*-------------------------------------------------------------------------
  *
@@ -410,7 +410,7 @@ H5_HLDLL herr_t H5LTmake_dataset_string(hid_t loc_id, const char *dset_name, con
  *                  accommodate arrays with more than three dimensions.
  *
  */
-H5_HLDLL herr_t H5LTread_dataset(hid_t loc_id, const char *dset_name, hid_t type_id, void *buffer);
+H5HL_DLL herr_t H5LTread_dataset(hid_t loc_id, const char *dset_name, hid_t type_id, void *buffer);
 
 /**
  *-------------------------------------------------------------------------
@@ -429,7 +429,7 @@ H5_HLDLL herr_t H5LTread_dataset(hid_t loc_id, const char *dset_name, hid_t type
  *          The HDF5 datatype is #H5T_NATIVE_CHAR.
  *
  */
-H5_HLDLL herr_t H5LTread_dataset_char(hid_t loc_id, const char *dset_name, char *buffer);
+H5HL_DLL herr_t H5LTread_dataset_char(hid_t loc_id, const char *dset_name, char *buffer);
 
 /**
  *-------------------------------------------------------------------------
@@ -448,7 +448,7 @@ H5_HLDLL herr_t H5LTread_dataset_char(hid_t loc_id, const char *dset_name, char 
  *          The HDF5 datatype is #H5T_NATIVE_SHORT.
  *
  */
-H5_HLDLL herr_t H5LTread_dataset_short(hid_t loc_id, const char *dset_name, short *buffer);
+H5HL_DLL herr_t H5LTread_dataset_short(hid_t loc_id, const char *dset_name, short *buffer);
 
 /**
  *-------------------------------------------------------------------------
@@ -470,7 +470,7 @@ H5_HLDLL herr_t H5LTread_dataset_short(hid_t loc_id, const char *dset_name, shor
  *                accommodate arrays with more than three dimensions.
  *
  */
-H5_HLDLL herr_t H5LTread_dataset_int(hid_t loc_id, const char *dset_name, int *buffer);
+H5HL_DLL herr_t H5LTread_dataset_int(hid_t loc_id, const char *dset_name, int *buffer);
 
 /**
  *-------------------------------------------------------------------------
@@ -489,7 +489,7 @@ H5_HLDLL herr_t H5LTread_dataset_int(hid_t loc_id, const char *dset_name, int *b
  *          The HDF5 datatype is #H5T_NATIVE_LONG.
  *
  */
-H5_HLDLL herr_t H5LTread_dataset_long(hid_t loc_id, const char *dset_name, long *buffer);
+H5HL_DLL herr_t H5LTread_dataset_long(hid_t loc_id, const char *dset_name, long *buffer);
 
 /**
  *-------------------------------------------------------------------------
@@ -510,7 +510,7 @@ H5_HLDLL herr_t H5LTread_dataset_long(hid_t loc_id, const char *dset_name, long 
  * \version 1.8.7 Fortran subroutine modified in this release to
  *                accommodate arrays with more than three dimensions.
  */
-H5_HLDLL herr_t H5LTread_dataset_float(hid_t loc_id, const char *dset_name, float *buffer);
+H5HL_DLL herr_t H5LTread_dataset_float(hid_t loc_id, const char *dset_name, float *buffer);
 
 /**
  *-------------------------------------------------------------------------
@@ -531,7 +531,7 @@ H5_HLDLL herr_t H5LTread_dataset_float(hid_t loc_id, const char *dset_name, floa
  * \version 1.8.7 Fortran subroutine modified in this release to
  *                accommodate arrays with more than three dimensions.
  */
-H5_HLDLL herr_t H5LTread_dataset_double(hid_t loc_id, const char *dset_name, double *buffer);
+H5HL_DLL herr_t H5LTread_dataset_double(hid_t loc_id, const char *dset_name, double *buffer);
 
 /**
  *-------------------------------------------------------------------------
@@ -550,7 +550,7 @@ H5_HLDLL herr_t H5LTread_dataset_double(hid_t loc_id, const char *dset_name, dou
  *          The HDF5 datatype is #H5T_C_S1.
  *
  */
-H5_HLDLL herr_t H5LTread_dataset_string(hid_t loc_id, const char *dset_name, char *buf);
+H5HL_DLL herr_t H5LTread_dataset_string(hid_t loc_id, const char *dset_name, char *buf);
 
 /*-------------------------------------------------------------------------
  *
@@ -576,7 +576,7 @@ H5_HLDLL herr_t H5LTread_dataset_string(hid_t loc_id, const char *dset_name, cha
  *          named \p dset_name exists attached to the object \p loc_id.
  *
  */
-H5_HLDLL herr_t H5LTget_dataset_ndims(hid_t loc_id, const char *dset_name, int *rank);
+H5HL_DLL herr_t H5LTget_dataset_ndims(hid_t loc_id, const char *dset_name, int *rank);
 
 /**
  *-------------------------------------------------------------------------
@@ -599,7 +599,7 @@ H5_HLDLL herr_t H5LTget_dataset_ndims(hid_t loc_id, const char *dset_name, int *
  *          named \p dset_name attached to the object \p loc_id.
  *
  */
-H5_HLDLL herr_t H5LTget_dataset_info(hid_t loc_id, const char *dset_name, hsize_t *dims,
+H5HL_DLL herr_t H5LTget_dataset_info(hid_t loc_id, const char *dset_name, hsize_t *dims,
                                      H5T_class_t *type_class, size_t *type_size);
 
 /**
@@ -620,7 +620,7 @@ H5_HLDLL herr_t H5LTget_dataset_info(hid_t loc_id, const char *dset_name, hsize_
  *          specify a dataset that is a member of that group.
  *
  */
-H5_HLDLL herr_t H5LTfind_dataset(hid_t loc_id, const char *name);
+H5HL_DLL herr_t H5LTfind_dataset(hid_t loc_id, const char *name);
 
 /*-------------------------------------------------------------------------
  *
@@ -649,7 +649,7 @@ H5_HLDLL herr_t H5LTfind_dataset(hid_t loc_id, const char *name);
  *          it is overwritten.
  *
  */
-H5_HLDLL herr_t H5LTset_attribute_string(hid_t loc_id, const char *obj_name, const char *attr_name,
+H5HL_DLL herr_t H5LTset_attribute_string(hid_t loc_id, const char *obj_name, const char *attr_name,
                                          const char *attr_data);
 
 /**
@@ -675,7 +675,7 @@ H5_HLDLL herr_t H5LTset_attribute_string(hid_t loc_id, const char *obj_name, con
  *          The HDF5 datatype of the attribute is #H5T_NATIVE_CHAR.
  *
  */
-H5_HLDLL herr_t H5LTset_attribute_char(hid_t loc_id, const char *obj_name, const char *attr_name,
+H5HL_DLL herr_t H5LTset_attribute_char(hid_t loc_id, const char *obj_name, const char *attr_name,
                                        const char *buffer, size_t size);
 
 /**
@@ -701,7 +701,7 @@ H5_HLDLL herr_t H5LTset_attribute_char(hid_t loc_id, const char *obj_name, const
  *          The HDF5 datatype of the attribute is #H5T_NATIVE_UCHAR.
  *
  */
-H5_HLDLL herr_t H5LTset_attribute_uchar(hid_t loc_id, const char *obj_name, const char *attr_name,
+H5HL_DLL herr_t H5LTset_attribute_uchar(hid_t loc_id, const char *obj_name, const char *attr_name,
                                         const unsigned char *buffer, size_t size);
 
 /**
@@ -727,7 +727,7 @@ H5_HLDLL herr_t H5LTset_attribute_uchar(hid_t loc_id, const char *obj_name, cons
  *          The HDF5 datatype of the attribute is #H5T_NATIVE_SHORT.
  *
  */
-H5_HLDLL herr_t H5LTset_attribute_short(hid_t loc_id, const char *obj_name, const char *attr_name,
+H5HL_DLL herr_t H5LTset_attribute_short(hid_t loc_id, const char *obj_name, const char *attr_name,
                                         const short *buffer, size_t size);
 
 /**
@@ -753,7 +753,7 @@ H5_HLDLL herr_t H5LTset_attribute_short(hid_t loc_id, const char *obj_name, cons
  *          The HDF5 datatype of the attribute is #H5T_NATIVE_USHORT.
  *
  */
-H5_HLDLL herr_t H5LTset_attribute_ushort(hid_t loc_id, const char *obj_name, const char *attr_name,
+H5HL_DLL herr_t H5LTset_attribute_ushort(hid_t loc_id, const char *obj_name, const char *attr_name,
                                          const unsigned short *buffer, size_t size);
 
 /**
@@ -780,7 +780,7 @@ H5_HLDLL herr_t H5LTset_attribute_ushort(hid_t loc_id, const char *obj_name, con
  *          is #H5T_NATIVE_INT.
  *
  */
-H5_HLDLL herr_t H5LTset_attribute_int(hid_t loc_id, const char *obj_name, const char *attr_name,
+H5HL_DLL herr_t H5LTset_attribute_int(hid_t loc_id, const char *obj_name, const char *attr_name,
                                       const int *buffer, size_t size);
 
 /**
@@ -806,7 +806,7 @@ H5_HLDLL herr_t H5LTset_attribute_int(hid_t loc_id, const char *obj_name, const 
  *          The HDF5 datatype of the attribute is #H5T_NATIVE_UINT.
  *
  */
-H5_HLDLL herr_t H5LTset_attribute_uint(hid_t loc_id, const char *obj_name, const char *attr_name,
+H5HL_DLL herr_t H5LTset_attribute_uint(hid_t loc_id, const char *obj_name, const char *attr_name,
                                        const unsigned int *buffer, size_t size);
 
 /**
@@ -833,7 +833,7 @@ H5_HLDLL herr_t H5LTset_attribute_uint(hid_t loc_id, const char *obj_name, const
  *          is #H5T_NATIVE_LONG.
  *
  */
-H5_HLDLL herr_t H5LTset_attribute_long(hid_t loc_id, const char *obj_name, const char *attr_name,
+H5HL_DLL herr_t H5LTset_attribute_long(hid_t loc_id, const char *obj_name, const char *attr_name,
                                        const long *buffer, size_t size);
 
 /**
@@ -859,7 +859,7 @@ H5_HLDLL herr_t H5LTset_attribute_long(hid_t loc_id, const char *obj_name, const
  *          is #H5T_NATIVE_LLONG.
  *
  */
-H5_HLDLL herr_t H5LTset_attribute_long_long(hid_t loc_id, const char *obj_name, const char *attr_name,
+H5HL_DLL herr_t H5LTset_attribute_long_long(hid_t loc_id, const char *obj_name, const char *attr_name,
                                             const long long *buffer, size_t size);
 
 /**
@@ -886,7 +886,7 @@ H5_HLDLL herr_t H5LTset_attribute_long_long(hid_t loc_id, const char *obj_name, 
  *          is #H5T_NATIVE_ULONG.
  *
  */
-H5_HLDLL herr_t H5LTset_attribute_ulong(hid_t loc_id, const char *obj_name, const char *attr_name,
+H5HL_DLL herr_t H5LTset_attribute_ulong(hid_t loc_id, const char *obj_name, const char *attr_name,
                                         const unsigned long *buffer, size_t size);
 
 /**
@@ -912,7 +912,7 @@ H5_HLDLL herr_t H5LTset_attribute_ulong(hid_t loc_id, const char *obj_name, cons
  *          is #H5T_NATIVE_ULLONG.
  *
  */
-H5_HLDLL herr_t H5LTset_attribute_ullong(hid_t loc_id, const char *obj_name, const char *attr_name,
+H5HL_DLL herr_t H5LTset_attribute_ullong(hid_t loc_id, const char *obj_name, const char *attr_name,
                                          const unsigned long long *buffer, size_t size);
 
 /**
@@ -939,7 +939,7 @@ H5_HLDLL herr_t H5LTset_attribute_ullong(hid_t loc_id, const char *obj_name, con
  *          of the attribute is #H5T_NATIVE_FLOAT.
  *
  */
-H5_HLDLL herr_t H5LTset_attribute_float(hid_t loc_id, const char *obj_name, const char *attr_name,
+H5HL_DLL herr_t H5LTset_attribute_float(hid_t loc_id, const char *obj_name, const char *attr_name,
                                         const float *buffer, size_t size);
 
 /**
@@ -966,7 +966,7 @@ H5_HLDLL herr_t H5LTset_attribute_float(hid_t loc_id, const char *obj_name, cons
  *          of the attribute is #H5T_NATIVE_DOUBLE.
  *
  */
-H5_HLDLL herr_t H5LTset_attribute_double(hid_t loc_id, const char *obj_name, const char *attr_name,
+H5HL_DLL herr_t H5LTset_attribute_double(hid_t loc_id, const char *obj_name, const char *attr_name,
                                          const double *buffer, size_t size);
 
 /*-------------------------------------------------------------------------
@@ -996,7 +996,7 @@ H5_HLDLL herr_t H5LTset_attribute_double(hid_t loc_id, const char *obj_name, con
  *          \p attr_name with the memory type \p mem_type_id.
  *
  */
-H5_HLDLL herr_t H5LTget_attribute(hid_t loc_id, const char *obj_name, const char *attr_name,
+H5HL_DLL herr_t H5LTget_attribute(hid_t loc_id, const char *obj_name, const char *attr_name,
                                   hid_t mem_type_id, void *data);
 
 /**
@@ -1025,7 +1025,7 @@ H5_HLDLL herr_t H5LTget_attribute(hid_t loc_id, const char *obj_name, const char
  *                padding; this buffer was previously returned with a C NULL terminator.
  *
  */
-H5_HLDLL herr_t H5LTget_attribute_string(hid_t loc_id, const char *obj_name, const char *attr_name,
+H5HL_DLL herr_t H5LTget_attribute_string(hid_t loc_id, const char *obj_name, const char *attr_name,
                                          char *data);
 
 /**
@@ -1049,7 +1049,7 @@ H5_HLDLL herr_t H5LTget_attribute_string(hid_t loc_id, const char *obj_name, con
  *          is #H5T_NATIVE_CHAR.
  *
  */
-H5_HLDLL herr_t H5LTget_attribute_char(hid_t loc_id, const char *obj_name, const char *attr_name, char *data);
+H5HL_DLL herr_t H5LTget_attribute_char(hid_t loc_id, const char *obj_name, const char *attr_name, char *data);
 
 /**
  *-------------------------------------------------------------------------
@@ -1072,7 +1072,7 @@ H5_HLDLL herr_t H5LTget_attribute_char(hid_t loc_id, const char *obj_name, const
  *          attribute is #H5T_NATIVE_UCHAR
  *
  */
-H5_HLDLL herr_t H5LTget_attribute_uchar(hid_t loc_id, const char *obj_name, const char *attr_name,
+H5HL_DLL herr_t H5LTget_attribute_uchar(hid_t loc_id, const char *obj_name, const char *attr_name,
                                         unsigned char *data);
 
 /**
@@ -1096,7 +1096,7 @@ H5_HLDLL herr_t H5LTget_attribute_uchar(hid_t loc_id, const char *obj_name, cons
  *          attribute is #H5T_NATIVE_SHORT
  *
  */
-H5_HLDLL herr_t H5LTget_attribute_short(hid_t loc_id, const char *obj_name, const char *attr_name,
+H5HL_DLL herr_t H5LTget_attribute_short(hid_t loc_id, const char *obj_name, const char *attr_name,
                                         short *data);
 
 /**
@@ -1120,7 +1120,7 @@ H5_HLDLL herr_t H5LTget_attribute_short(hid_t loc_id, const char *obj_name, cons
  *          attribute is #H5T_NATIVE_USHORT.
  *
  */
-H5_HLDLL herr_t H5LTget_attribute_ushort(hid_t loc_id, const char *obj_name, const char *attr_name,
+H5HL_DLL herr_t H5LTget_attribute_ushort(hid_t loc_id, const char *obj_name, const char *attr_name,
                                          unsigned short *data);
 
 /**
@@ -1144,7 +1144,7 @@ H5_HLDLL herr_t H5LTget_attribute_ushort(hid_t loc_id, const char *obj_name, con
  *          attribute is #H5T_NATIVE_INT.
  *
  */
-H5_HLDLL herr_t H5LTget_attribute_int(hid_t loc_id, const char *obj_name, const char *attr_name, int *data);
+H5HL_DLL herr_t H5LTget_attribute_int(hid_t loc_id, const char *obj_name, const char *attr_name, int *data);
 
 /**
  *-------------------------------------------------------------------------
@@ -1167,7 +1167,7 @@ H5_HLDLL herr_t H5LTget_attribute_int(hid_t loc_id, const char *obj_name, const 
  *          attribute is #H5T_NATIVE_INT.
  *
  */
-H5_HLDLL herr_t H5LTget_attribute_uint(hid_t loc_id, const char *obj_name, const char *attr_name,
+H5HL_DLL herr_t H5LTget_attribute_uint(hid_t loc_id, const char *obj_name, const char *attr_name,
                                        unsigned int *data);
 
 /**
@@ -1191,7 +1191,7 @@ H5_HLDLL herr_t H5LTget_attribute_uint(hid_t loc_id, const char *obj_name, const
  *          attribute is #H5T_NATIVE_LONG.
  *
  */
-H5_HLDLL herr_t H5LTget_attribute_long(hid_t loc_id, const char *obj_name, const char *attr_name, long *data);
+H5HL_DLL herr_t H5LTget_attribute_long(hid_t loc_id, const char *obj_name, const char *attr_name, long *data);
 
 /**
  *-------------------------------------------------------------------------
@@ -1211,7 +1211,7 @@ H5_HLDLL herr_t H5LTget_attribute_long(hid_t loc_id, const char *obj_name, const
  *          specified by \p loc_id and \p obj_name.
  *
  */
-H5_HLDLL herr_t H5LTget_attribute_long_long(hid_t loc_id, const char *obj_name, const char *attr_name,
+H5HL_DLL herr_t H5LTget_attribute_long_long(hid_t loc_id, const char *obj_name, const char *attr_name,
                                             long long *data);
 
 /**
@@ -1235,7 +1235,7 @@ H5_HLDLL herr_t H5LTget_attribute_long_long(hid_t loc_id, const char *obj_name, 
  *          attribute is #H5T_NATIVE_ULONG.
  *
  */
-H5_HLDLL herr_t H5LTget_attribute_ulong(hid_t loc_id, const char *obj_name, const char *attr_name,
+H5HL_DLL herr_t H5LTget_attribute_ulong(hid_t loc_id, const char *obj_name, const char *attr_name,
                                         unsigned long *data);
 
 /**
@@ -1259,7 +1259,7 @@ H5_HLDLL herr_t H5LTget_attribute_ulong(hid_t loc_id, const char *obj_name, cons
  *          attribute is #H5T_NATIVE_ULLONG.
  *
  */
-H5_HLDLL herr_t H5LTget_attribute_ullong(hid_t loc_id, const char *obj_name, const char *attr_name,
+H5HL_DLL herr_t H5LTget_attribute_ullong(hid_t loc_id, const char *obj_name, const char *attr_name,
                                          unsigned long long *data);
 
 /**
@@ -1283,7 +1283,7 @@ H5_HLDLL herr_t H5LTget_attribute_ullong(hid_t loc_id, const char *obj_name, con
  *          attribute is #H5T_NATIVE_FLOAT.
  *
  */
-H5_HLDLL herr_t H5LTget_attribute_float(hid_t loc_id, const char *obj_name, const char *attr_name,
+H5HL_DLL herr_t H5LTget_attribute_float(hid_t loc_id, const char *obj_name, const char *attr_name,
                                         float *data);
 
 /**
@@ -1307,7 +1307,7 @@ H5_HLDLL herr_t H5LTget_attribute_float(hid_t loc_id, const char *obj_name, cons
  *          attribute is #H5T_NATIVE_DOUBLE.
  *
  */
-H5_HLDLL herr_t H5LTget_attribute_double(hid_t loc_id, const char *obj_name, const char *attr_name,
+H5HL_DLL herr_t H5LTget_attribute_double(hid_t loc_id, const char *obj_name, const char *attr_name,
                                          double *data);
 
 /*-------------------------------------------------------------------------
@@ -1337,7 +1337,7 @@ H5_HLDLL herr_t H5LTget_attribute_double(hid_t loc_id, const char *obj_name, con
  *          by the name \p obj_name.
  *
  */
-H5_HLDLL herr_t H5LTget_attribute_ndims(hid_t loc_id, const char *obj_name, const char *attr_name, int *rank);
+H5HL_DLL herr_t H5LTget_attribute_ndims(hid_t loc_id, const char *obj_name, const char *attr_name, int *rank);
 
 /**
  *-------------------------------------------------------------------------
@@ -1366,7 +1366,7 @@ H5_HLDLL herr_t H5LTget_attribute_ndims(hid_t loc_id, const char *obj_name, cons
  * \snippet H5LT_examples.c get_attribute_info
  *
  */
-H5_HLDLL herr_t H5LTget_attribute_info(hid_t loc_id, const char *obj_name, const char *attr_name,
+H5HL_DLL herr_t H5LTget_attribute_info(hid_t loc_id, const char *obj_name, const char *attr_name,
                                        hsize_t *dims, H5T_class_t *type_class, size_t *type_size);
 
 /*-------------------------------------------------------------------------
@@ -1405,7 +1405,7 @@ H5_HLDLL herr_t H5LTget_attribute_info(hid_t loc_id, const char *obj_name, const
  * \snippet H5LT_examples.c enum
  *
  */
-H5_HLDLL hid_t H5LTtext_to_dtype(const char *text, H5LT_lang_t lang_type);
+H5HL_DLL hid_t H5LTtext_to_dtype(const char *text, H5LT_lang_t lang_type);
 
 /**
  *-------------------------------------------------------------------------
@@ -1442,7 +1442,7 @@ H5_HLDLL hid_t H5LTtext_to_dtype(const char *text, H5LT_lang_t lang_type);
  * \snippet H5LT_examples.c enum
  *
  */
-H5_HLDLL herr_t H5LTdtype_to_text(hid_t dtype, char *str, H5LT_lang_t lang_type, size_t *len);
+H5HL_DLL herr_t H5LTdtype_to_text(hid_t dtype, char *str, H5LT_lang_t lang_type, size_t *len);
 
 /*-------------------------------------------------------------------------
  *
@@ -1472,7 +1472,7 @@ H5_HLDLL herr_t H5LTdtype_to_text(hid_t dtype, char *str, H5LT_lang_t lang_type,
  *          to that object.
  *
  */
-H5_HLDLL herr_t H5LTfind_attribute(hid_t loc_id, const char *name);
+H5HL_DLL herr_t H5LTfind_attribute(hid_t loc_id, const char *name);
 
 /**
  *-------------------------------------------------------------------------
@@ -1560,7 +1560,7 @@ H5_HLDLL herr_t H5LTfind_attribute(hid_t loc_id, const char *name);
  *                 See the “Note on Behavior Change” section above.
  *
  */
-H5_HLDLL htri_t H5LTpath_valid(hid_t loc_id, const char *path, hbool_t check_object_valid);
+H5HL_DLL htri_t H5LTpath_valid(hid_t loc_id, const char *path, hbool_t check_object_valid);
 
 /*-------------------------------------------------------------------------
  *
@@ -1642,7 +1642,7 @@ H5_HLDLL htri_t H5LTpath_valid(hid_t loc_id, const char *path, hbool_t check_obj
  *
  * \since 1.8.9
  */
-H5_HLDLL hid_t H5LTopen_file_image(void *buf_ptr, size_t buf_size, unsigned flags);
+H5HL_DLL hid_t H5LTopen_file_image(void *buf_ptr, size_t buf_size, unsigned flags);
 
 #ifdef __cplusplus
 }

--- a/hl/src/H5PTpublic.h
+++ b/hl/src/H5PTpublic.h
@@ -143,7 +143,7 @@ extern "C" {
  * \since   1.10.0 and 1.8.17
  *
  */
-H5_HLDLL hid_t H5PTcreate(hid_t loc_id, const char *dset_name, hid_t dtype_id, hsize_t chunk_size,
+H5HL_DLL hid_t H5PTcreate(hid_t loc_id, const char *dset_name, hid_t dtype_id, hsize_t chunk_size,
                           hid_t plist_id);
 
 /**
@@ -166,7 +166,7 @@ H5_HLDLL hid_t H5PTcreate(hid_t loc_id, const char *dset_name, hid_t dtype_id, h
  *          H5PTclose().
  *
  */
-H5_HLDLL hid_t H5PTopen(hid_t loc_id, const char *dset_name);
+H5HL_DLL hid_t H5PTopen(hid_t loc_id, const char *dset_name);
 
 /**
  * --------------------------------------------------------------------------
@@ -182,7 +182,7 @@ H5_HLDLL hid_t H5PTopen(hid_t loc_id, const char *dset_name);
  *          by \p table_id.
  *
  */
-H5_HLDLL herr_t H5PTclose(hid_t table_id);
+H5HL_DLL herr_t H5PTclose(hid_t table_id);
 
 /**
  * --------------------------------------------------------------------------
@@ -227,7 +227,7 @@ H5_HLDLL herr_t H5PTclose(hid_t table_id);
  *
  */
 /* This function may be removed from the packet table in release 1.8.19. */
-H5_HLDLL hid_t H5PTcreate_fl(hid_t loc_id, const char *dset_name, hid_t dtype_id, hsize_t chunk_size,
+H5HL_DLL hid_t H5PTcreate_fl(hid_t loc_id, const char *dset_name, hid_t dtype_id, hsize_t chunk_size,
                              int compression);
 
 /*-------------------------------------------------------------------------
@@ -255,7 +255,7 @@ H5_HLDLL hid_t H5PTcreate_fl(hid_t loc_id, const char *dset_name, hid_t dtype_id
  *          the data should be in the form of #hvl_t structs.
  *
  */
-H5_HLDLL herr_t H5PTappend(hid_t table_id, size_t nrecords, const void *data);
+H5HL_DLL herr_t H5PTappend(hid_t table_id, size_t nrecords, const void *data);
 
 /*-------------------------------------------------------------------------
  * Read functions
@@ -285,7 +285,7 @@ H5_HLDLL herr_t H5PTappend(hid_t table_id, size_t nrecords, const void *data);
  *          The memory used by this data must be freed using H5PTfree_vlen_buff().
  *
  */
-H5_HLDLL herr_t H5PTget_next(hid_t table_id, size_t nrecords, void *data);
+H5HL_DLL herr_t H5PTget_next(hid_t table_id, size_t nrecords, void *data);
 
 /**
  * --------------------------------------------------------------------------
@@ -312,7 +312,7 @@ H5_HLDLL herr_t H5PTget_next(hid_t table_id, size_t nrecords, void *data);
  *          H5PTfree_vlen_buff().
  *
  */
-H5_HLDLL herr_t H5PTread_packets(hid_t table_id, hsize_t start, size_t nrecords, void *data);
+H5HL_DLL herr_t H5PTread_packets(hid_t table_id, hsize_t start, size_t nrecords, void *data);
 
 /*-------------------------------------------------------------------------
  * Inquiry functions
@@ -334,7 +334,7 @@ H5_HLDLL herr_t H5PTread_packets(hid_t table_id, hsize_t start, size_t nrecords,
  *          of packets in a packet table specified by \p table_id.
  *
  */
-H5_HLDLL herr_t H5PTget_num_packets(hid_t table_id, hsize_t *nrecords);
+H5HL_DLL herr_t H5PTget_num_packets(hid_t table_id, hsize_t *nrecords);
 
 /**
  * --------------------------------------------------------------------------
@@ -352,7 +352,7 @@ H5_HLDLL herr_t H5PTget_num_packets(hid_t table_id, hsize_t *nrecords);
  *          and returns a negative value otherwise.
  *
  */
-H5_HLDLL herr_t H5PTis_valid(hid_t table_id);
+H5HL_DLL herr_t H5PTis_valid(hid_t table_id);
 
 /**
  * --------------------------------------------------------------------------
@@ -376,7 +376,7 @@ H5_HLDLL herr_t H5PTis_valid(hid_t table_id);
  *                            Function had been removed in 1.8.3.
  *
  */
-H5_HLDLL herr_t H5PTis_varlen(hid_t table_id);
+H5HL_DLL herr_t H5PTis_varlen(hid_t table_id);
 
 /*-------------------------------------------------------------------------
  *
@@ -402,7 +402,7 @@ H5_HLDLL herr_t H5PTis_varlen(hid_t table_id);
  * \since 1.10.0 and 1.8.17
  *
  */
-H5_HLDLL hid_t H5PTget_dataset(hid_t table_id);
+H5HL_DLL hid_t H5PTget_dataset(hid_t table_id);
 
 /**
  * --------------------------------------------------------------------------
@@ -421,7 +421,7 @@ H5_HLDLL hid_t H5PTget_dataset(hid_t table_id);
  * \since 1.10.0 and 1.8.17
  *
  */
-H5_HLDLL hid_t H5PTget_type(hid_t table_id);
+H5HL_DLL hid_t H5PTget_type(hid_t table_id);
 
 /*-------------------------------------------------------------------------
  *
@@ -449,7 +449,7 @@ H5_HLDLL hid_t H5PTget_type(hid_t table_id);
  *          this information is lost when the packet table is closed.
  *
  */
-H5_HLDLL herr_t H5PTcreate_index(hid_t table_id);
+H5HL_DLL herr_t H5PTcreate_index(hid_t table_id);
 
 /**
  * --------------------------------------------------------------------------
@@ -468,7 +468,7 @@ H5_HLDLL herr_t H5PTcreate_index(hid_t table_id);
  *          packet (the packets are zero-indexed).
  *
  */
-H5_HLDLL herr_t H5PTset_index(hid_t table_id, hsize_t pt_index);
+H5HL_DLL herr_t H5PTset_index(hid_t table_id, hsize_t pt_index);
 
 /**
  * --------------------------------------------------------------------------
@@ -487,7 +487,7 @@ H5_HLDLL herr_t H5PTset_index(hid_t table_id, hsize_t pt_index);
  * \since 1.8.0
  *
  */
-H5_HLDLL herr_t H5PTget_index(hid_t table_id, hsize_t *pt_index);
+H5HL_DLL herr_t H5PTget_index(hid_t table_id, hsize_t *pt_index);
 
 /*-------------------------------------------------------------------------
  *
@@ -519,7 +519,7 @@ H5_HLDLL herr_t H5PTget_index(hid_t table_id, hsize_t *pt_index);
  *                            Function had been removed in 1.8.3.
  *
  */
-H5_HLDLL herr_t H5PTfree_vlen_buff(hid_t table_id, size_t bufflen, void *buff);
+H5HL_DLL herr_t H5PTfree_vlen_buff(hid_t table_id, size_t bufflen, void *buff);
 
 #ifdef __cplusplus
 }

--- a/hl/src/H5TBpublic.h
+++ b/hl/src/H5TBpublic.h
@@ -135,7 +135,7 @@ extern "C" {
  *          identifier loc_id.
  *
  */
-H5_HLDLL herr_t H5TBmake_table(const char *table_title, hid_t loc_id, const char *dset_name, hsize_t nfields,
+H5HL_DLL herr_t H5TBmake_table(const char *table_title, hid_t loc_id, const char *dset_name, hsize_t nfields,
                                hsize_t nrecords, size_t type_size, const char *field_names[],
                                const size_t *field_offset, const hid_t *field_types, hsize_t chunk_size,
                                void *fill_data, int compress, const void *buf);
@@ -173,7 +173,7 @@ H5_HLDLL herr_t H5TBmake_table(const char *table_title, hid_t loc_id, const char
  *          new records.
  *
  */
-H5_HLDLL herr_t H5TBappend_records(hid_t loc_id, const char *dset_name, hsize_t nrecords, size_t type_size,
+H5HL_DLL herr_t H5TBappend_records(hid_t loc_id, const char *dset_name, hsize_t nrecords, size_t type_size,
                                    const size_t *field_offset, const size_t *dst_sizes, const void *buf);
 
 /**
@@ -202,7 +202,7 @@ H5_HLDLL herr_t H5TBappend_records(hid_t loc_id, const char *dset_name, hsize_t 
  *          to the object specified by the identifier \p loc_id.
  *
  */
-H5_HLDLL herr_t H5TBwrite_records(hid_t loc_id, const char *dset_name, hsize_t start, hsize_t nrecords,
+H5HL_DLL herr_t H5TBwrite_records(hid_t loc_id, const char *dset_name, hsize_t start, hsize_t nrecords,
                                   size_t type_size, const size_t *field_offset, const size_t *dst_sizes,
                                   const void *buf);
 
@@ -234,7 +234,7 @@ H5_HLDLL herr_t H5TBwrite_records(hid_t loc_id, const char *dset_name, hsize_t s
  *          by the identifier \p loc_id.
  *
  */
-H5_HLDLL herr_t H5TBwrite_fields_name(hid_t loc_id, const char *dset_name, const char *field_names,
+H5HL_DLL herr_t H5TBwrite_fields_name(hid_t loc_id, const char *dset_name, const char *field_names,
                                       hsize_t start, hsize_t nrecords, size_t type_size,
                                       const size_t *field_offset, const size_t *dst_sizes, const void *buf);
 
@@ -269,7 +269,7 @@ H5_HLDLL herr_t H5TBwrite_fields_name(hid_t loc_id, const char *dset_name, const
  *          specified by the identifier \p loc_id.
  *
  */
-H5_HLDLL herr_t H5TBwrite_fields_index(hid_t loc_id, const char *dset_name, hsize_t nfields,
+H5HL_DLL herr_t H5TBwrite_fields_index(hid_t loc_id, const char *dset_name, hsize_t nfields,
                                        const int *field_index, hsize_t start, hsize_t nrecords,
                                        size_t type_size, const size_t *field_offset, const size_t *dst_sizes,
                                        const void *buf);
@@ -306,7 +306,7 @@ H5_HLDLL herr_t H5TBwrite_fields_index(hid_t loc_id, const char *dset_name, hsiz
  *          the identifier \p loc_id.
  *
  */
-H5_HLDLL herr_t H5TBread_table(hid_t loc_id, const char *dset_name, size_t dst_size, const size_t *dst_offset,
+H5HL_DLL herr_t H5TBread_table(hid_t loc_id, const char *dset_name, size_t dst_size, const size_t *dst_offset,
                                const size_t *dst_sizes, void *dst_buf);
 
 /**
@@ -336,7 +336,7 @@ H5_HLDLL herr_t H5TBread_table(hid_t loc_id, const char *dset_name, size_t dst_s
  *          attached to the object specified by the identifier \p loc_id.
  *
  */
-H5_HLDLL herr_t H5TBread_fields_name(hid_t loc_id, const char *dset_name, const char *field_names,
+H5HL_DLL herr_t H5TBread_fields_name(hid_t loc_id, const char *dset_name, const char *field_names,
                                      hsize_t start, hsize_t nrecords, size_t type_size,
                                      const size_t *field_offset, const size_t *dst_sizes, void *buf);
 
@@ -371,7 +371,7 @@ H5_HLDLL herr_t H5TBread_fields_name(hid_t loc_id, const char *dset_name, const 
  *          to the object specified by the identifier \p loc_id.
  *
  */
-H5_HLDLL herr_t H5TBread_fields_index(hid_t loc_id, const char *dset_name, hsize_t nfields,
+H5HL_DLL herr_t H5TBread_fields_index(hid_t loc_id, const char *dset_name, hsize_t nfields,
                                       const int *field_index, hsize_t start, hsize_t nrecords,
                                       size_t type_size, const size_t *field_offset, const size_t *dst_sizes,
                                       void *buf);
@@ -403,7 +403,7 @@ H5_HLDLL herr_t H5TBread_fields_index(hid_t loc_id, const char *dset_name, hsize
  *          identifier \p loc_id.
  *
  */
-H5_HLDLL herr_t H5TBread_records(hid_t loc_id, const char *dset_name, hsize_t start, hsize_t nrecords,
+H5HL_DLL herr_t H5TBread_records(hid_t loc_id, const char *dset_name, hsize_t start, hsize_t nrecords,
                                  size_t type_size, const size_t *dst_offset, const size_t *dst_sizes,
                                  void *buf);
 
@@ -433,7 +433,7 @@ H5_HLDLL herr_t H5TBread_records(hid_t loc_id, const char *dset_name, hsize_t st
  *          by the identifier \p loc_id.
  *
  */
-H5_HLDLL herr_t H5TBget_table_info(hid_t loc_id, const char *dset_name, hsize_t *nfields, hsize_t *nrecords);
+H5HL_DLL herr_t H5TBget_table_info(hid_t loc_id, const char *dset_name, hsize_t *nfields, hsize_t *nrecords);
 
 /**
  * --------------------------------------------------------------------------
@@ -460,7 +460,7 @@ H5_HLDLL herr_t H5TBget_table_info(hid_t loc_id, const char *dset_name, hsize_t 
  *          by the identifier \p loc_id.
  *
  */
-H5_HLDLL herr_t H5TBget_field_info(hid_t loc_id, const char *dset_name, char *field_names[],
+H5HL_DLL herr_t H5TBget_field_info(hid_t loc_id, const char *dset_name, char *field_names[],
                                    size_t *field_sizes, size_t *field_offsets, size_t *type_size);
 
 /*-------------------------------------------------------------------------
@@ -489,7 +489,7 @@ H5_HLDLL herr_t H5TBget_field_info(hid_t loc_id, const char *dset_name, char *fi
  *          ("pulling up" all the records after it).
  *
  */
-H5_HLDLL herr_t H5TBdelete_record(hid_t loc_id, const char *dset_name, hsize_t start, hsize_t nrecords);
+H5HL_DLL herr_t H5TBdelete_record(hid_t loc_id, const char *dset_name, hsize_t start, hsize_t nrecords);
 
 /**
  * --------------------------------------------------------------------------
@@ -516,7 +516,7 @@ H5_HLDLL herr_t H5TBdelete_record(hid_t loc_id, const char *dset_name, hsize_t s
  *          ("pushing down" all the records after it)
  *
  */
-H5_HLDLL herr_t H5TBinsert_record(hid_t loc_id, const char *dset_name, hsize_t start, hsize_t nrecords,
+H5HL_DLL herr_t H5TBinsert_record(hid_t loc_id, const char *dset_name, hsize_t start, hsize_t nrecords,
                                   size_t dst_size, const size_t *dst_offset, const size_t *dst_sizes,
                                   void *buf);
 
@@ -544,7 +544,7 @@ H5_HLDLL herr_t H5TBinsert_record(hid_t loc_id, const char *dset_name, hsize_t s
  *          are attached to the object specified by the identifier loc_id.
  *
  */
-H5_HLDLL herr_t H5TBadd_records_from(hid_t loc_id, const char *dset_name1, hsize_t start1, hsize_t nrecords,
+H5HL_DLL herr_t H5TBadd_records_from(hid_t loc_id, const char *dset_name1, hsize_t start1, hsize_t nrecords,
                                      const char *dset_name2, hsize_t start2);
 
 /**
@@ -574,7 +574,7 @@ H5_HLDLL herr_t H5TBadd_records_from(hid_t loc_id, const char *dset_name1, hsize
  *          table is written in the first file.
  *
  */
-H5_HLDLL herr_t H5TBcombine_tables(hid_t loc_id1, const char *dset_name1, hid_t loc_id2,
+H5HL_DLL herr_t H5TBcombine_tables(hid_t loc_id1, const char *dset_name1, hid_t loc_id2,
                                    const char *dset_name2, const char *dset_name3);
 
 /**
@@ -603,7 +603,7 @@ H5_HLDLL herr_t H5TBcombine_tables(hid_t loc_id1, const char *dset_name1, hid_t 
  *          time if the table is large.
  *
  */
-H5_HLDLL herr_t H5TBinsert_field(hid_t loc_id, const char *dset_name, const char *field_name,
+H5HL_DLL herr_t H5TBinsert_field(hid_t loc_id, const char *dset_name, const char *field_name,
                                  hid_t field_type, hsize_t position, const void *fill_data, const void *buf);
 
 /**
@@ -626,7 +626,7 @@ H5_HLDLL herr_t H5TBinsert_field(hid_t loc_id, const char *dset_name, const char
  *          time if the table is large.
  *
  */
-H5_HLDLL herr_t H5TBdelete_field(hid_t loc_id, const char *dset_name, const char *field_name);
+H5HL_DLL herr_t H5TBdelete_field(hid_t loc_id, const char *dset_name, const char *field_name);
 
 /*-------------------------------------------------------------------------
  *
@@ -651,7 +651,7 @@ H5_HLDLL herr_t H5TBdelete_field(hid_t loc_id, const char *dset_name, const char
  *          by \p loc_id in a buffer \p table_title.
  *
  */
-H5_HLDLL herr_t H5TBAget_title(hid_t loc_id, char *table_title);
+H5HL_DLL herr_t H5TBAget_title(hid_t loc_id, char *table_title);
 
 /**
  * --------------------------------------------------------------------------
@@ -678,7 +678,7 @@ H5_HLDLL herr_t H5TBAget_title(hid_t loc_id, char *table_title);
  * \include H5TBAget_fill.c
  *
  */
-H5_HLDLL htri_t H5TBAget_fill(hid_t loc_id, const char *dset_name, hid_t dset_id, unsigned char *dst_buf);
+H5HL_DLL htri_t H5TBAget_fill(hid_t loc_id, const char *dset_name, hid_t dset_id, unsigned char *dst_buf);
 
 #ifdef __cplusplus
 }

--- a/release_docs/RELEASE.txt
+++ b/release_docs/RELEASE.txt
@@ -193,9 +193,6 @@ New Features
         H5_FCTESTDLL(VAR)        --> H5FC_TEST_DLL(VAR)
         HDF5_HL_F90CSTUBDLL(VAR) --> H5FC_HL_DLL(VAR)
 
-      The shared library decorations are also now used when building static
-      libraries (where they are meaningless and ignored).
-
     - The ROS3 VFD now includes the HTTP status code and a generic message
       in the HDF5 error stack when a 400 or 500 error occurs
 

--- a/release_docs/RELEASE.txt
+++ b/release_docs/RELEASE.txt
@@ -181,6 +181,21 @@ New Features
 
     Library:
     --------
+    - Renamed some API decorations
+
+      Some API decorations (used to hide __declspec on Windows, among other
+      things) have been renamed:
+
+        H5_DLLCPP(VAR)           --> H5CPP_DLL(VAR)
+        H5_HLDLL(VAR)            --> H5HL_DLL(VAR)
+        H5_HLCPPDLL(VAR)         --> H5CPP_HL_DLL(VAR)
+        H5_FCDLL(VAR)            --> H5FC_DLL(VAR)
+        H5_FCTESTDLL(VAR)        --> H5FC_TEST_DLL(VAR)
+        HDF5_HL_F90CSTUBDLL(VAR) --> H5FC_HL_DLL(VAR)
+
+      The shared library decorations are also now used when building static
+      libraries (where they are meaningless and ignored).
+
     - The ROS3 VFD now includes the HTTP status code and a generic message
       in the HDF5 error stack when a 400 or 500 error occurs
 

--- a/src/H5api_adpt.h
+++ b/src/H5api_adpt.h
@@ -30,6 +30,8 @@
 #ifndef H5API_ADPT_H
 #define H5API_ADPT_H
 
+#ifdef H5_BUILT_AS_DYNAMIC_LIB
+
 /* clang-format off */
 
 /* When building with MSVC, we need to decorate the functions with
@@ -153,5 +155,31 @@
 #define H5FC_HL_DLL    H5_API_IMPORT
 #define H5FC_HL_DLLVAR H5_VAR_IMPORT
 #endif
+
+#else
+
+/* Static library decorations */
+#define H5_DLL
+#define H5_DLLVAR extern
+#define H5TEST_DLL
+#define H5TEST_DLLVAR extern
+#define H5TESTPAR_DLL
+#define H5TESTPAR_DLLVAR extern
+#define H5TOOLS_DLL
+#define H5TOOLS_DLLVAR extern
+#define H5CPP_DLL
+#define H5CPP_DLLVAR extern
+#define H5HL_DLL
+#define H5HL_DLLVAR extern
+#define H5CPP_HL_DLL
+#define H5CPP_HL_DLLVAR extern
+#define H5FC_DLL
+#define H5FC_DLLVAR extern
+#define H5FC_TEST_DLL
+#define H5FC_TEST_DLLVAR extern
+#define H5FC_HL_DLL
+#define H5FC_HL_DLLVAR extern
+
+#endif /* H5_BUILT_AS_DYNAMIC_LIB */
 
 #endif /* H5API_ADPT_H */

--- a/src/H5api_adpt.h
+++ b/src/H5api_adpt.h
@@ -102,56 +102,56 @@
 
 /* C++ library */
 #if defined(hdf5_cpp_shared_EXPORTS)
-#define H5_DLLCPP    H5_API_EXPORT
-#define H5_DLLCPPVAR H5_VAR_EXPORT
+#define H5CPP_DLL    H5_API_EXPORT
+#define H5CPP_DLLVAR H5_VAR_EXPORT
 #else
-#define H5_DLLCPP    H5_API_IMPORT
-#define H5_DLLCPPVAR H5_VAR_IMPORT
+#define H5CPP_DLL    H5_API_IMPORT
+#define H5CPP_DLLVAR H5_VAR_IMPORT
 #endif
 
 /* High-level library */
 #if defined(hdf5_hl_shared_EXPORTS)
-#define H5_HLDLL    H5_API_EXPORT
-#define H5_HLDLLVAR H5_VAR_EXPORT
+#define H5HL_DLL    H5_API_EXPORT
+#define H5HL_DLLVAR H5_VAR_EXPORT
 #else
-#define H5_HLDLL    H5_API_IMPORT
-#define H5_HLDLLVAR H5_VAR_IMPORT
+#define H5HL_DLL    H5_API_IMPORT
+#define H5HL_DLLVAR H5_VAR_IMPORT
 #endif
 
 /* High-level C++ library */
 #if defined(hdf5_hl_cpp_shared_EXPORTS)
-#define H5_HLCPPDLL    H5_API_EXPORT
-#define H5_HLCPPDLLVAR H5_VAR_EXPORT
+#define H5CPP_HL_DLL    H5_API_EXPORT
+#define H5CPP_HL_DLLVAR H5_VAR_EXPORT
 #else
-#define H5_HLCPPDLL    H5_API_IMPORT
-#define H5_HLCPPDLLVAR H5_VAR_IMPORT
+#define H5CPP_HL_DLL    H5_API_IMPORT
+#define H5CPP_HL_DLLVAR H5_VAR_IMPORT
 #endif
 
 /* Fortran library C stubs */
 #if defined(hdf5_f90cstub_shared_EXPORTS)
-#define H5_FCDLL    H5_API_EXPORT
-#define H5_FCDLLVAR H5_VAR_EXPORT
+#define H5FC_DLL    H5_API_EXPORT
+#define H5FC_DLLVAR H5_VAR_EXPORT
 #else
-#define H5_FCDLL    H5_API_IMPORT
-#define H5_FCDLLVAR H5_VAR_IMPORT
+#define H5FC_DLL    H5_API_IMPORT
+#define H5FC_DLLVAR H5_VAR_IMPORT
 #endif
 
 /* Fortran test library C stubs */
 #if defined(hdf5_test_f90cstub_shared_EXPORTS)
-#define H5_FCTESTDLL    H5_API_EXPORT
-#define H5_FCTESTDLLVAR H5_VAR_EXPORT
+#define H5FC_TEST_DLL    H5_API_EXPORT
+#define H5FC_TEST_DLLVAR H5_VAR_EXPORT
 #else
-#define H5_FCTESTDLL    H5_API_IMPORT
-#define H5_FCTESTDLLVAR H5_VAR_IMPORT
+#define H5FC_TEST_DLL    H5_API_IMPORT
+#define H5FC_TEST_DLLVAR H5_VAR_IMPORT
 #endif
 
 /* High-level Fortran library C stubs */
 #if defined(hdf5_hl_f90cstub_shared_EXPORTS)
-#define HDF5_HL_F90CSTUBDLL    H5_API_EXPORT
-#define HDF5_HL_F90CSTUBDLLVAR H5_VAR_EXPORT
+#define H5FC_HL_DLL    H5_API_EXPORT
+#define H5FC_HL_DLLVAR H5_VAR_EXPORT
 #else
-#define HDF5_HL_F90CSTUBDLL    H5_API_IMPORT
-#define HDF5_HL_F90CSTUBDLLVAR H5_VAR_IMPORT
+#define H5FC_HL_DLL    H5_API_IMPORT
+#define H5FC_HL_DLLVAR H5_VAR_IMPORT
 #endif
 
 #endif /* H5API_ADPT_H */

--- a/src/H5api_adpt.h
+++ b/src/H5api_adpt.h
@@ -23,7 +23,7 @@
  * markup is ignored when building static libraries.
  *
  * Each library needs a different set of named macros or Windows will
- * incorrectly use dllexport with importend library when it should be using
+ * incorrectly use dllexport with imported library when it should be using
  * dllimport.
  */
 

--- a/src/H5api_adpt.h
+++ b/src/H5api_adpt.h
@@ -12,265 +12,146 @@
 
 /*
  * H5api_adpt.h
- * Used for the HDF5 dll project
+ *
+ * API decorations for exported symbols
+ *
+ * These decorations are mostly for Windows, which has to use __declspec(dllexport)
+ * when linking a library together and __declspec(dllimport) when consuming
+ * a previously-built library.
+ *
+ * We use the same macros everywhere, both shared and static, as the shared
+ * markup is ignored when building static libraries.
+ *
+ * Each library needs a different set of named macros or Windows will
+ * incorrectly use dllexport with importend library when it should be using
+ * dllimport.
  */
+
 #ifndef H5API_ADPT_H
 #define H5API_ADPT_H
 
-/* This will only be defined if HDF5 was built with CMake */
-#ifdef H5_BUILT_AS_DYNAMIC_LIB
+/* clang-format off */
 
+/* When building with MSVC, we need to decorate the functions with
+ * __declspec()
+ *
+ * NOTE that _MSC_VER is also defined by clang + Visual Studio
+ */
+#if defined(_MSC_VER)
+    #define H5_API_EXPORT        __declspec(dllexport)
+    #define H5_VAR_EXPORT extern __declspec(dllexport)
+    #define H5_API_IMPORT        __declspec(dllimport)
+    #define H5_VAR_IMPORT extern __declspec(dllimport)
+
+/* Compilers that support GNU extensions (gcc, clang, etc.) support API
+ * visibility attributes.
+ */
+#elif defined(__GNUC__)
+    #define H5_API_EXPORT        __attribute__((visibility("default")))
+    #define H5_VAR_EXPORT extern __attribute__((visibility("default")))
+    #define H5_API_IMPORT        __attribute__((visibility("default")))
+    #define H5_VAR_IMPORT extern __attribute__((visibility("default")))
+
+/* API decorations for anything not covered above */
+#else
+    #define H5_API_EXPORT
+    #define H5_VAR_EXPORT extern
+    #define H5_API_IMPORT
+    #define H5_VAR_IMPORT extern
+#endif
+
+/* clang-fomat on */
+
+/* CMake defines <project>_shared_EXPORTS when building a shared library */
+
+/* C library */
 #if defined(hdf5_shared_EXPORTS)
-#if defined(_MSC_VER) /* MSVC Compiler Case */
-#define H5_DLL    __declspec(dllexport)
-#define H5_DLLVAR extern __declspec(dllexport)
-#elif (__GNUC__ >= 4) /* GCC 4.x has support for visibility options */
-#define H5_DLL    __attribute__((visibility("default")))
-#define H5_DLLVAR extern __attribute__((visibility("default")))
-#endif
+#define H5_DLL    H5_API_EXPORT
+#define H5_DLLVAR H5_VAR_EXPORT
 #else
-#if defined(_MSC_VER) /* MSVC Compiler Case */
-#define H5_DLL    __declspec(dllimport)
-#define H5_DLLVAR __declspec(dllimport)
-#elif (__GNUC__ >= 4) /* GCC 4.x has support for visibility options */
-#define H5_DLL    __attribute__((visibility("default")))
-#define H5_DLLVAR extern __attribute__((visibility("default")))
-#endif
+#define H5_DLL    H5_API_IMPORT
+#define H5_DLLVAR H5_VAR_IMPORT
 #endif
 
-#ifndef H5_DLL
-#define H5_DLL
-#define H5_DLLVAR extern
-#endif /* _HDF5DLL_ */
-
+/* Test library */
 #if defined(hdf5_test_shared_EXPORTS)
-#if defined(_MSC_VER) /* MSVC Compiler Case */
-#define H5TEST_DLL    __declspec(dllexport)
-#define H5TEST_DLLVAR extern __declspec(dllexport)
-#elif (__GNUC__ >= 4) /* GCC 4.x has support for visibility options */
-#define H5TEST_DLL    __attribute__((visibility("default")))
-#define H5TEST_DLLVAR extern __attribute__((visibility("default")))
-#endif
+#define H5TEST_DLL    H5_API_EXPORT
+#define H5TEST_DLLVAR H5_VAR_EXPORT
 #else
-#if defined(_MSC_VER) /* MSVC Compiler Case */
-#define H5TEST_DLL    __declspec(dllimport)
-#define H5TEST_DLLVAR __declspec(dllimport)
-#elif (__GNUC__ >= 4) /* GCC 4.x has support for visibility options */
-#define H5TEST_DLL    __attribute__((visibility("default")))
-#define H5TEST_DLLVAR extern __attribute__((visibility("default")))
-#endif
+#define H5TEST_DLL    H5_API_IMPORT
+#define H5TEST_DLLVAR H5_VAR_IMPORT
 #endif
 
-#ifndef H5TEST_DLL
-#define H5TEST_DLL
-#define H5TEST_DLLVAR extern
-#endif /* H5TEST_DLL */
-
+/* Parallel test library */
 #if defined(hdf5_testpar_shared_EXPORTS)
-#if defined(_MSC_VER) /* MSVC Compiler Case */
-#define H5TESTPAR_DLL    __declspec(dllexport)
-#define H5TESTPAR_DLLVAR extern __declspec(dllexport)
-#elif (__GNUC__ >= 4) /* GCC 4.x has support for visibility options */
-#define H5TESTPAR_DLL    __attribute__((visibility("default")))
-#define H5TESTPAR_DLLVAR extern __attribute__((visibility("default")))
-#endif
+#define H5TESTPAR_DLL    H5_API_EXPORT
+#define H5TESTPAR_DLLVAR H5_VAR_EXPORT
 #else
-#if defined(_MSC_VER) /* MSVC Compiler Case */
-#define H5TESTPAR_DLL    __declspec(dllimport)
-#define H5TESTPAR_DLLVAR __declspec(dllimport)
-#elif (__GNUC__ >= 4) /* GCC 4.x has support for visibility options */
-#define H5TESTPAR_DLL    __attribute__((visibility("default")))
-#define H5TESTPAR_DLLVAR extern __attribute__((visibility("default")))
-#endif
+#define H5TESTPAR_DLL    H5_API_IMPORT
+#define H5TESTPAR_DLLVAR H5_VAR_IMPORT
 #endif
 
-#ifndef H5TESTPAR_DLL
-#define H5TESTPAR_DLL
-#define H5TESTPAR_DLLVAR extern
-#endif /* H5TESTPAR_DLL */
-
+/* Tools library */
 #if defined(hdf5_tools_shared_EXPORTS)
-#if defined(_MSC_VER) /* MSVC Compiler Case */
-#define H5TOOLS_DLL    __declspec(dllexport)
-#define H5TOOLS_DLLVAR extern __declspec(dllexport)
-#elif (__GNUC__ >= 4) /* GCC 4.x has support for visibility options */
-#define H5TOOLS_DLL    __attribute__((visibility("default")))
-#define H5TOOLS_DLLVAR extern __attribute__((visibility("default")))
-#endif
+#define H5TOOLS_DLL    H5_API_EXPORT
+#define H5TOOLS_DLLVAR H5_VAR_EXPORT
 #else
-#if defined(_MSC_VER) /* MSVC Compiler Case */
-#define H5TOOLS_DLL    __declspec(dllimport)
-#define H5TOOLS_DLLVAR __declspec(dllimport)
-#elif (__GNUC__ >= 4) /* GCC 4.x has support for visibility options */
-#define H5TOOLS_DLL    __attribute__((visibility("default")))
-#define H5TOOLS_DLLVAR extern __attribute__((visibility("default")))
-#endif
+#define H5TOOLS_DLL    H5_API_IMPORT
+#define H5TOOLS_DLLVAR H5_VAR_IMPORT
 #endif
 
-#ifndef H5TOOLS_DLL
-#define H5TOOLS_DLL
-#define H5TOOLS_DLLVAR extern
-#endif /* H5TOOLS_DLL */
-
+/* C++ library */
 #if defined(hdf5_cpp_shared_EXPORTS)
-#if defined(_MSC_VER) /* MSVC Compiler Case */
-#define H5_DLLCPP    __declspec(dllexport)
-#define H5_DLLCPPVAR extern __declspec(dllexport)
-#elif (__GNUC__ >= 4) /* GCC 4.x has support for visibility options */
-#define H5_DLLCPP    __attribute__((visibility("default")))
-#define H5_DLLCPPVAR extern __attribute__((visibility("default")))
-#endif
+#define H5_DLLCPP    H5_API_EXPORT
+#define H5_DLLCPPVAR H5_VAR_EXPORT
 #else
-#if defined(_MSC_VER) /* MSVC Compiler Case */
-#define H5_DLLCPP    __declspec(dllimport)
-#define H5_DLLCPPVAR __declspec(dllimport)
-#elif (__GNUC__ >= 4) /* GCC 4.x has support for visibility options */
-#define H5_DLLCPP    __attribute__((visibility("default")))
-#define H5_DLLCPPVAR extern __attribute__((visibility("default")))
-#endif
+#define H5_DLLCPP    H5_API_IMPORT
+#define H5_DLLCPPVAR H5_VAR_IMPORT
 #endif
 
-#ifndef H5_DLLCPP
-#define H5_DLLCPP
-#define H5_DLLCPPVAR extern
-#endif /* H5_DLLCPP */
-
+/* High-level library */
 #if defined(hdf5_hl_shared_EXPORTS)
-#if defined(_MSC_VER) /* MSVC Compiler Case */
-#define H5_HLDLL    __declspec(dllexport)
-#define H5_HLDLLVAR extern __declspec(dllexport)
-#elif (__GNUC__ >= 4) /* GCC 4.x has support for visibility options */
-#define H5_HLDLL    __attribute__((visibility("default")))
-#define H5_HLDLLVAR extern __attribute__((visibility("default")))
-#endif
+#define H5_HLDLL    H5_API_EXPORT
+#define H5_HLDLLVAR H5_VAR_EXPORT
 #else
-#if defined(_MSC_VER) /* MSVC Compiler Case */
-#define H5_HLDLL    __declspec(dllimport)
-#define H5_HLDLLVAR __declspec(dllimport)
-#elif (__GNUC__ >= 4) /* GCC 4.x has support for visibility options */
-#define H5_HLDLL    __attribute__((visibility("default")))
-#define H5_HLDLLVAR extern __attribute__((visibility("default")))
-#endif
+#define H5_HLDLL    H5_API_IMPORT
+#define H5_HLDLLVAR H5_VAR_IMPORT
 #endif
 
-#ifndef H5_HLDLL
-#define H5_HLDLL
-#define H5_HLDLLVAR extern
-#endif /* H5_HLDLL */
-
+/* High-level C++ library */
 #if defined(hdf5_hl_cpp_shared_EXPORTS)
-#if defined(_MSC_VER) /* MSVC Compiler Case */
-#define H5_HLCPPDLL    __declspec(dllexport)
-#define H5_HLCPPDLLVAR extern __declspec(dllexport)
-#elif (__GNUC__ >= 4) /* GCC 4.x has support for visibility options */
-#define H5_HLCPPDLL    __attribute__((visibility("default")))
-#define H5_HLCPPDLLVAR extern __attribute__((visibility("default")))
-#endif
+#define H5_HLCPPDLL    H5_API_EXPORT
+#define H5_HLCPPDLLVAR H5_VAR_EXPORT
 #else
-#if defined(_MSC_VER) /* MSVC Compiler Case */
-#define H5_HLCPPDLL    __declspec(dllimport)
-#define H5_HLCPPDLLVAR __declspec(dllimport)
-#elif (__GNUC__ >= 4) /* GCC 4.x has support for visibility options */
-#define H5_HLCPPDLL    __attribute__((visibility("default")))
-#define H5_HLCPPDLLVAR extern __attribute__((visibility("default")))
-#endif
+#define H5_HLCPPDLL    H5_API_IMPORT
+#define H5_HLCPPDLLVAR H5_VAR_IMPORT
 #endif
 
-#ifndef H5_HLCPPDLL
-#define H5_HLCPPDLL
-#define H5_HLCPPDLLVAR extern
-#endif /* H5_HLCPPDLL */
-
+/* Fortran library C stubs */
 #if defined(hdf5_f90cstub_shared_EXPORTS)
-#if defined(_MSC_VER) /* MSVC Compiler Case */
-#define H5_FCDLL    __declspec(dllexport)
-#define H5_FCDLLVAR extern __declspec(dllexport)
-#elif (__GNUC__ >= 4) /* GCC 4.x has support for visibility options */
-#define H5_FCDLL    __attribute__((visibility("default")))
-#define H5_FCDLLVAR extern __attribute__((visibility("default")))
-#endif
+#define H5_FCDLL    H5_API_EXPORT
+#define H5_FCDLLVAR H5_VAR_EXPORT
 #else
-#if defined(_MSC_VER) /* MSVC Compiler Case */
-#define H5_FCDLL    __declspec(dllimport)
-#define H5_FCDLLVAR __declspec(dllimport)
-#elif (__GNUC__ >= 4) /* GCC 4.x has support for visibility options */
-#define H5_FCDLL    __attribute__((visibility("default")))
-#define H5_FCDLLVAR extern __attribute__((visibility("default")))
-#endif
+#define H5_FCDLL    H5_API_IMPORT
+#define H5_FCDLLVAR H5_VAR_IMPORT
 #endif
 
-#ifndef H5_FCDLL
-#define H5_FCDLL
-#define H5_FCDLLVAR extern
-#endif /* H5_FCDLL */
-
+/* Fortran test library C stubs */
 #if defined(hdf5_test_f90cstub_shared_EXPORTS)
-#if defined(_MSC_VER) /* MSVC Compiler Case */
-#define H5_FCTESTDLL    __declspec(dllexport)
-#define H5_FCTESTDLLVAR extern __declspec(dllexport)
-#elif (__GNUC__ >= 4) /* GCC 4.x has support for visibility options */
-#define H5_FCTESTDLL    __attribute__((visibility("default")))
-#define H5_FCTESTDLLVAR extern __attribute__((visibility("default")))
-#endif
+#define H5_FCTESTDLL    H5_API_EXPORT
+#define H5_FCTESTDLLVAR H5_VAR_EXPORT
 #else
-#if defined(_MSC_VER) /* MSVC Compiler Case */
-#define H5_FCTESTDLL    __declspec(dllimport)
-#define H5_FCTESTDLLVAR __declspec(dllimport)
-#elif (__GNUC__ >= 4) /* GCC 4.x has support for visibility options */
-#define H5_FCTESTDLL    __attribute__((visibility("default")))
-#define H5_FCTESTDLLVAR extern __attribute__((visibility("default")))
-#endif
+#define H5_FCTESTDLL    H5_API_IMPORT
+#define H5_FCTESTDLLVAR H5_VAR_IMPORT
 #endif
 
-#ifndef H5_FCTESTDLL
-#define H5_FCTESTDLL
-#define H5_FCTESTDLLVAR extern
-#endif /* H5_FCTESTDLL */
-
+/* High-level Fortran library C stubs */
 #if defined(hdf5_hl_f90cstub_shared_EXPORTS)
-#if defined(_MSC_VER) /* MSVC Compiler Case */
-#define HDF5_HL_F90CSTUBDLL    __declspec(dllexport)
-#define HDF5_HL_F90CSTUBDLLVAR extern __declspec(dllexport)
-#elif (__GNUC__ >= 4) /* GCC 4.x has support for visibility options */
-#define HDF5_HL_F90CSTUBDLL    __attribute__((visibility("default")))
-#define HDF5_HL_F90CSTUBDLLVAR extern __attribute__((visibility("default")))
-#endif
+#define HDF5_HL_F90CSTUBDLL    H5_API_EXPORT
+#define HDF5_HL_F90CSTUBDLLVAR H5_VAR_EXPORT
 #else
-#if defined(_MSC_VER) /* MSVC Compiler Case */
-#define HDF5_HL_F90CSTUBDLL    __declspec(dllimport)
-#define HDF5_HL_F90CSTUBDLLVAR __declspec(dllimport)
-#elif (__GNUC__ >= 4) /* GCC 4.x has support for visibility options */
-#define HDF5_HL_F90CSTUBDLL    __attribute__((visibility("default")))
-#define HDF5_HL_F90CSTUBDLLVAR extern __attribute__((visibility("default")))
+#define HDF5_HL_F90CSTUBDLL    H5_API_IMPORT
+#define HDF5_HL_F90CSTUBDLLVAR H5_VAR_IMPORT
 #endif
-#endif
-
-#ifndef HDF5_HL_F90CSTUBDLL
-#define HDF5_HL_F90CSTUBDLL
-#define HDF5_HL_F90CSTUBDLLVAR extern
-#endif /* HDF5_HL_F90CSTUBDLL */
-
-#else
-#define H5_DLL
-#define H5_DLLVAR extern
-#define H5TEST_DLL
-#define H5TEST_DLLVAR extern
-#define H5TESTPAR_DLL
-#define H5TESTPAR_DLLVAR extern
-#define H5TOOLS_DLL
-#define H5TOOLS_DLLVAR extern
-#define H5_DLLCPP
-#define H5_DLLCPPVAR extern
-#define H5_HLDLL
-#define H5_HLDLLVAR extern
-#define H5_HLCPPDLL
-#define H5_HLCPPDLLVAR extern
-#define H5_FCDLL
-#define H5_FCDLLVAR extern
-#define H5_FCTESTDLL
-#define H5_FCTESTDLLVAR extern
-#define HDF5_HL_F90CSTUBDLL
-#define HDF5_HL_F90CSTUBDLLVAR extern
-#endif /* H5_BUILT_AS_DYNAMIC_LIB */
 
 #endif /* H5API_ADPT_H */


### PR DESCRIPTION
Reduces duplication in H5api_adpt.h

Some API decorations (used to hide __declspec on Windows, among other
things) have been renamed to be consistent and easier to read:

    H5_DLLCPP(VAR)           --> H5CPP_DLL(VAR)
    H5_HLDLL(VAR)            --> H5HL_DLL(VAR)
    H5_HLCPPDLL(VAR)         --> H5CPP_HL_DLL(VAR)
    H5_FCDLL(VAR)            --> H5FC_DLL(VAR)
    H5_FCTESTDLL(VAR)        --> H5FC_TEST_DLL(VAR)
    HDF5_HL_F90CSTUBDLL(VAR) --> H5FC_HL_DLL(VAR)

Fixes #5509