### PR TITLE
Updated "hdfgroup.github.io" links to "support.hdfgroup.org"

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -121,10 +121,10 @@ Please make sure that you check the items applicable to your pull request:
   * [ ] Does the pull request follow HDF5 best practices (naming conventions, code portability, code structure, etc.)? <<TODO: link to the document>>
   * [ ] Is the pull request applicable to any other branches? If yes, which ones? Please document it in the GitHub issue.
   * [ ] Is the new code sufficiently documented for future maintenance?
-  * [ ] Does the new feature require a change to an existing API? See "API Compatibility Macros" document (https://hdfgroup.github.io/hdf5/develop/d7/d26/api-compat-macros.html)
+  * [ ] Does the new feature require a change to an existing API? See "API Compatibility Macros" document (https://support.hdfgroup.org/documentation/hdf5/latest/api-compat-macros.html)
 * Documentation
   * [ ] Was the change described in the release_docs/RELEASE.txt file?
-  * [ ] Was the new function documented in the corresponding public header file using [Doxygen](https://hdfgroup.github.io/hdf5/develop/d0/dbc/_r_m_t.html)?
+  * [ ] Was the new function documented in the corresponding public header file using [Doxygen](https://support.hdfgroup.org/documentation/hdf5/latest/_r_m_t.html)?
   * [ ] Was new functionality documented for the HDF5 community (the level of documentation depends on the feature; ask us what would be appropriate)
 * Testing
   * [ ] Does the pull request have tests?

--- a/README.md
+++ b/README.md
@@ -42,13 +42,9 @@ Documentation for all HDF software is available at:
 
    https://support.hdfgroup.org/documentation/index.html
 
-Documentation for the current HDF5 library release is available at:
+The latest documentation for the HDF5 library can be found at:
 
-   https://support.hdfgroup.org/releases/hdf5/latest/
-
-The latest Doxygen documentation generated on changes to `develop`, which does **not** correspond to any particular library release, is available at:
-
-   https://hdfgroup.github.io/hdf5/develop 
+   https://support.hdfgroup.org/documentation/hdf5/latest
 
 See the [RELEASE.txt][u1] file in the [release_docs/][u4] directory for information specific
 to the features and updates included in this release of the library.

--- a/doxygen/aliases
+++ b/doxygen/aliases
@@ -16,8 +16,6 @@ ALIASES += DWNURL="\RELURL/downloads/latest"
 # URL for RFCs
 ALIASES += RFCURL="\DOCURL/rfc"
 ALIASES += AEXURL="\HDFURL/archive/support/ftp/HDF5/examples"
-# doxygen subdir (develop, v1_14)
-ALIASES += DOXURL="hdfgroup.github.io/hdf5/develop"
 #branch name (develop, hdf5_1_14)
 ALIASES += SRCURL="github.com/HDFGroup/hdf5/blob/develop"
 #Other projects that contribute to HDF5

--- a/release_docs/INSTALL_CMake.txt
+++ b/release_docs/INSTALL_CMake.txt
@@ -747,7 +747,7 @@ These five steps are described in detail below.
 
         For additional configuration options and other details,
         see "API Compatibility Macros":
-            https://hdfgroup.github.io/hdf5/develop/d7/d26/api-compat-macros.html
+            https://support.hdfgroup.org/documentation/hdf5/latest/api-compat-macros.html
 
    11. Building doxygen
         One can optionally build the doxygen files for the HDF5 C library.

--- a/release_docs/RELEASE_PROCESS.md
+++ b/release_docs/RELEASE_PROCESS.md
@@ -93,15 +93,14 @@ For more information on the HDF5 versioning and backward and forward compatibili
     - `$ bin/h5vers -s X.Y.Z-{SR+1};` 
     - `$ git commit -m "Updated release preparation branch version number to X.Y.Z-{SR+1}"` 
     - `$ git push` 
-7. Replace "hdfgroup.github.io/hdf5/develop" in md files with "support.hdfgroup.org/releases/hdf5/vX.Y/vX.Y.Z/documentation/doxygen"
-8. ** OBSOLETE CURRENTLY **
+7. ** OBSOLETE CURRENTLY **
    Update default configuration mode
     - `$ git checkout hdf5_X_Y_Z;`. 
     - Need to set option `HDF5_GENERATE_HEADERS` to `OFF`, currently in line 996 of [src/CMakeLists.txt][u11].
     - (use `git status --ignored` to see the changes and `git add -f` to add all files. First delete any new files not to be committed, notably `src/H5public.h~`.)
     - `$ git push with commit message listing change steps for creating release branch`
     ** END OBSOLETE CURRENTLY **
-9. E-mail hdf5lib@hdfgroup.org to indicate that the code freeze on the release support branch (i.e. hdf5_X_Y) has been lifted and development on the next maintenance release can resume. The code freeze will remain in place on the release preparation branch (i.e. hdf5_X_Y_Z) indefinitely. 
+8. E-mail hdf5lib@hdfgroup.org to indicate that the code freeze on the release support branch (i.e. hdf5_X_Y) has been lifted and development on the next maintenance release can resume. The code freeze will remain in place on the release preparation branch (i.e. hdf5_X_Y_Z) indefinitely.
 
 ### 7. Perform Release Testing (Test Automation Team | Release Manager | Project Leads)
 1. Verify that source and binary distributions of HDF5 are acceptable on all target operating environments.
@@ -210,6 +209,6 @@ For more information on the HDF5 versioning and backward and forward compatibili
 [u10]: https://github.com/HDFGroup/hdf5/blob/develop/bin/h5vers
 [u11]: https://github.com/HDFGroup/hdf5/blob/develop/src/CMakeLists.txt
 [u12]: https://github.com/HDFGroup/hdf5/blob/develop/configure.ac
-[u13]: https://hdfgroup.github.io/hdf5/develop/d7/d26/api-compat-macros.html
+[u13]: https://support.hdfgroup.org/documentation/hdf5/latest/api-compat-macros.html
 [u14]: https://github.com/HDFGroup/hdf5/releases/tag/snapshot-1.14
 [u15]: https://github.com/HDFGroup/hdf5/releases/tag/snapshot

--- a/test/API/README.md
+++ b/test/API/README.md
@@ -1,7 +1,7 @@
 # HDF5 API Tests
 
 This directory contains several test applications that exercise HDF5's
-public API and serve as regression tests for HDF5 [VOL Connectors](https://hdfgroup.github.io/hdf5/develop/d7/d31/_h5_v_l__u_g.html).
+public API and serve as regression tests for HDF5 [VOL Connectors](https://support.hdfgroup.org/documentation/hdf5/latest/_h5_v_l__u_g.html).
 
 ## Build Process and options
 
@@ -43,12 +43,12 @@ Currently unsupported
 
 These API tests currently only support usage with the native HDF5 VOL connector and HDF5 VOL
 connectors that can be loaded dynamically as a plugin. For information on how to build a VOL
-connector in this manner, refer to section 2.3 of the [HDF5 VOL Connector Author Guide](https://hdfgroup.github.io/hdf5/develop/da/de9/_v_o_l__connector.html).
+connector in this manner, refer to section 2.3 of the [HDF5 VOL Connector Author Guide](https://support.hdfgroup.org/documentation/hdf5/latest/_v_o_l__connector.html).
 
 If an HDF5 VOL connector has been built alongside the library, these API tests can be used
 for testing that VOL connector at the same time that HDF5 is test. For more information on
 how to build a VOL connector alongside the HDF5 library, refer to
-[Building and testing HDF5 VOL connectors with CMake FetchContent](https://hdfgroup.github.io/hdf5/develop/df/d6b/_c_make_vols.html).
+[Building and testing HDF5 VOL connectors with CMake FetchContent](https://support.hdfgroup.org/documentation/hdf5/latest/_c_make_vols.html).
 
 These API tests can also be used to test an HDF5 VOL connector that is external to the library.
 For convenience, the `HDF5_TEST_API_INSTALL` option can be used to install these tests on the


### PR DESCRIPTION
Closes #5526 