### PR TITLE
Fix typo in DLS test message

### DIFF
--- a/test/dsets.c
+++ b/test/dsets.c
@@ -14696,7 +14696,7 @@ dls_01_main(void)
     const char *strings[DLS_01_DIMS] = {"String 1", "Test string 2", "Another string", "Final String"};
     char       *buffer               = NULL;
 
-    TESTING("Testing DLS bugfix 1");
+    TESTING("DLS bugfix 1");
 
     if (NULL == h5_fixname(FILENAME[23], H5P_DEFAULT, filename, sizeof(filename)))
         TEST_ERROR;


### PR DESCRIPTION
The TESTING macro already prepends the word "Testing" to the output, so this prints "Testing Testing DLS bugfix 1".