### PR TITLE
Change default dataset chunk cache size to 8 MiB

### DIFF
--- a/java/test/TestH5Pfapl.java
+++ b/java/test/TestH5Pfapl.java
@@ -721,7 +721,7 @@ public class TestH5Pfapl {
         try {
             H5.H5Pget_cache(fapl_id, null, rdcc_nelmts, rdcc_nbytes, rdcc_w0);
             assertTrue("H5P_cache default", rdcc_nelmts[0] == 521);
-            assertTrue("H5P_cache default", rdcc_nbytes[0] == (1024 * 1024));
+            assertTrue("H5P_cache default", rdcc_nbytes[0] == (8 * 1024 * 1024));
             assertTrue("H5P_cache default", rdcc_w0[0] == 0.75);
         }
         catch (Throwable err) {
@@ -749,7 +749,7 @@ public class TestH5Pfapl {
         try {
             H5.H5Pget_chunk_cache(dapl_id, rdcc_nslots, rdcc_nbytes, rdcc_w0);
             assertTrue("H5P_chunk_cache default", rdcc_nslots[0] == 521);
-            assertTrue("H5P_chunk_cache default", rdcc_nbytes[0] == (1024 * 1024));
+            assertTrue("H5P_chunk_cache default", rdcc_nbytes[0] == (8 * 1024 * 1024));
             assertTrue("H5P_chunk_cache default", rdcc_w0[0] == 0.75);
         }
         catch (Throwable err) {

--- a/release_docs/RELEASE.txt
+++ b/release_docs/RELEASE.txt
@@ -214,7 +214,7 @@ New Features
           pkg-config in the CMake wrappers.
 
         * A new -nohl option has been added to avoid building and linking
-          against the high-level HDF5 libraries if desired.  
+          against the high-level HDF5 libraries if desired.
 
         * Similar to the Autotools wrappers, the CMake wrappers now add the
           HDF5 installation library directory to the rpath of the resulting
@@ -240,6 +240,10 @@ New Features
       only have an effect if the file uses paged allocation. Also added the
       H5F_PAGE_BUFFER_SIZE_DEFAULT to allow the user to unset the page buffer
       size in a FAPL so it can be similarly overridden.
+
+    - Default dataset chunk cache size increased
+
+      The default dataset chunk cache size is increased to 8 MiB (8,388,608 bytes).
 
     - The file format has been updated to 4.0
 

--- a/src/H5Pfapl.c
+++ b/src/H5Pfapl.c
@@ -91,7 +91,7 @@
 #define H5F_ACS_DATA_CACHE_NUM_SLOTS_DEC  H5P__decode_size_t
 /* Definition for size of raw data chunk cache(bytes) */
 #define H5F_ACS_DATA_CACHE_BYTE_SIZE_SIZE sizeof(size_t)
-#define H5F_ACS_DATA_CACHE_BYTE_SIZE_DEF  (1024 * 1024)
+#define H5F_ACS_DATA_CACHE_BYTE_SIZE_DEF  (8 * 1024 * 1024)
 #define H5F_ACS_DATA_CACHE_BYTE_SIZE_ENC  H5P__encode_size_t
 #define H5F_ACS_DATA_CACHE_BYTE_SIZE_DEC  H5P__decode_size_t
 /* Definition for preemption read chunks first */

--- a/src/H5Ppublic.h
+++ b/src/H5Ppublic.h
@@ -4243,7 +4243,7 @@ H5_DLL herr_t H5Pset_alignment(hid_t fapl_id, hsize_t threshold, hsize_t alignme
  *                        approximately 100 times that number of chunks.
  *                        The default value is 521.
  * \param[in] rdcc_nbytes Total size of the raw data chunk cache in bytes.
- *                        The default size is 1 MB per dataset.
+ *                        The default size is 8 MiB per dataset.
  * \param[in] rdcc_w0     The chunk preemption policy for all datasets.
  *                        This must be between 0 and 1 inclusive and
  *                        indicates the weighting according to which chunks
@@ -7486,7 +7486,7 @@ H5_DLL herr_t H5Pset_append_flush(hid_t dapl_id, unsigned ndims, const hsize_t b
  *                        this dataset. In most cases increasing this
  *                        number will improve performance, as long as
  *                        you have enough free memory.
- *                        The default size is 1 MB. If the value passed is
+ *                        The default size is 8 MiB. If the value passed is
  *                        #H5D_CHUNK_CACHE_NBYTES_DEFAULT, then the
  *                        property will not be set on \p dapl_id and the
  *                        parameter will come from the file access
@@ -7541,7 +7541,7 @@ H5_DLL herr_t H5Pset_append_flush(hid_t dapl_id, unsigned ndims, const hsize_t b
  *
  *      \b Example \b Usage: The following code sets the chunk cache to
  *       use a hash table with 12421 elements and a maximum size of
- *       16 MB, while using the preemption policy specified for the
+ *       16 MiB, while using the preemption policy specified for the
  *       entire file:
  *       \TText{
  *       H5Pset_chunk_cache(dapl_id, 12421, 16*1024*1024,
@@ -7568,7 +7568,7 @@ H5_DLL herr_t H5Pset_append_flush(hid_t dapl_id, unsigned ndims, const hsize_t b
  *       set by H5Pset_chunk_cache().
  *
  *       In the absence of any cache settings, H5Dopen() will
- *       by default create a 1 MB chunk cache for the opened
+ *       by default create an 8 MiB chunk cache for the opened
  *       dataset. If this size happens to be appropriate, no
  *       call will be needed to either function to set the
  *       chunk cache size.


### PR DESCRIPTION
A draft for now to allow for discussion.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Increase default dataset chunk cache size from 1 MiB to 8 MiB and update related tests and documentation.
> 
>   - **Behavior**:
>     - Default dataset chunk cache size increased from 1 MiB to 8 MiB in `H5Pfapl.c` and `H5Ppublic.h`.
>     - Test assertions updated in `TestH5Pfapl.java` to reflect new default cache size.
>   - **Documentation**:
>     - Updated `RELEASE.txt` to document the new default dataset chunk cache size.
>     - Updated comments in `H5Ppublic.h` to reflect the new default cache size.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=HDFGroup%2Fhdf5&utm_source=github&utm_medium=referral)<sup> for e0ca9ddbbaecc5565b2dd2a1ea1cb411469a46fa. You can [customize](https://app.ellipsis.dev/HDFGroup/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->