### PR TITLE
Add h5ls test files to gentest

### DIFF
--- a/tools/test/CMakeLists.txt
+++ b/tools/test/CMakeLists.txt
@@ -9,6 +9,7 @@ set (HDF5_TOOLS
   h5jam
   h5repack
   h5stat
+  h5ls
 )
 
 set (HDF5_TOOLS_MISC
@@ -40,10 +41,10 @@ if (HDF5_BUILD_GENERATORS)
   foreach(tool ${HDF5_TOOLS};${HDF5_TOOLS_MISC})
     if (${tool} IN_LIST HDF5_TOOLS_MISC)
       add_library(${tool}gentest OBJECT ${HDF5_TOOLS_TEST_SOURCE_DIR}/misc/${tool}gentest.c)
-      target_include_directories (${tool}gentest PRIVATE "${HDF5_SRC_INCLUDE_DIRS};${HDF5_TEST_SRC_DIR};${HDF5_TOOLS_TST_DIR};${HDF5_TOOLS_ROOT_DIR}/misc;${HDF5_TOOLS_ROOT_DIR}/lib;${HDF5_SRC_BINARY_DIR};$<$<BOOL:${HDF5_ENABLE_PARALLEL}>:${MPI_C_INCLUDE_DIRS}>")    
+      target_include_directories (${tool}gentest PRIVATE "${HDF5_SRC_INCLUDE_DIRS};${HDF5_TEST_SRC_DIR};${HDF5_TOOLS_TST_DIR};${HDF5_TOOLS_ROOT_DIR}/misc;${HDF5_TOOLS_ROOT_DIR}/lib;${HDF5_SRC_BINARY_DIR};$<$<BOOL:${HDF5_ENABLE_PARALLEL}>:${MPI_C_INCLUDE_DIRS}>")
     else()
       add_library(${tool}gentest OBJECT ${HDF5_TOOLS_TEST_SOURCE_DIR}/${tool}/${tool}gentest.c)
-      target_include_directories (${tool}gentest PRIVATE "${HDF5_SRC_INCLUDE_DIRS};${HDF5_TEST_SRC_DIR};${HDF5_TOOLS_TST_DIR};${HDF5_TOOLS_ROOT_DIR}/lib;${HDF5_SRC_BINARY_DIR};$<$<BOOL:${HDF5_ENABLE_PARALLEL}>:${MPI_C_INCLUDE_DIRS}>")    
+      target_include_directories (${tool}gentest PRIVATE "${HDF5_SRC_INCLUDE_DIRS};${HDF5_TEST_SRC_DIR};${HDF5_TOOLS_TST_DIR};${HDF5_TOOLS_ROOT_DIR}/lib;${HDF5_SRC_BINARY_DIR};$<$<BOOL:${HDF5_ENABLE_PARALLEL}>:${MPI_C_INCLUDE_DIRS}>")
     endif()
 
     if (HDF5_BUILD_STATIC_TOOLS)

--- a/tools/test/h5gentest.c
+++ b/tools/test/h5gentest.c
@@ -428,7 +428,7 @@ gen_h5ls_files(void)
     return nerrors;
 }
 
- /*-------------------------------------------------------------------------
+/*-------------------------------------------------------------------------
  * Function: usage
  *
  * Purpose: Prints a usage message on stdout stream and then returns.
@@ -465,30 +465,23 @@ main(int argc, char *argv[])
 {
     /* command-line options: short and long-named parameters */
     static const char            *s_opts   = "hacdufjrspl";
-    static struct h5_long_options l_opts[] = {{"help", no_arg, 'h'},
-                                              {"all", no_arg, 'a'},
-                                              {"h5copy", no_arg, 'c'},
-                                              {"h5diff", no_arg, 'd'},
-                                              {"h5dump", no_arg, 'u'},
-                                              {"h5fc", no_arg, 'f'},
-                                              {"h5jam", no_arg, 'j'},
-                                              {"h5repack", no_arg, 'r'},
-                                              {"h5stat", no_arg, 's'},
-                                              {"h5repart", no_arg, 'p'},
-                                              {"h5ls", no_arg, 'l'},
-                                              {NULL, 0, 0}};
-    int                           i;
-    int                           opt;
-    bool                          run_all      = false;
-    bool                          run_h5copy   = false;
-    bool                          run_h5diff   = false;
-    bool                          run_h5dump   = false;
-    bool                          run_h5fc     = false;
-    bool                          run_h5jam    = false;
-    bool                          run_h5repack = false;
-    bool                          run_h5stat   = false;
-    bool                          run_h5repart = false;
-    bool                          run_h5ls     = false;
+    static struct h5_long_options l_opts[] = {
+        {"help", no_arg, 'h'},     {"all", no_arg, 'a'},      {"h5copy", no_arg, 'c'},
+        {"h5diff", no_arg, 'd'},   {"h5dump", no_arg, 'u'},   {"h5fc", no_arg, 'f'},
+        {"h5jam", no_arg, 'j'},    {"h5repack", no_arg, 'r'}, {"h5stat", no_arg, 's'},
+        {"h5repart", no_arg, 'p'}, {"h5ls", no_arg, 'l'},     {NULL, 0, 0}};
+    int  i;
+    int  opt;
+    bool run_all      = false;
+    bool run_h5copy   = false;
+    bool run_h5diff   = false;
+    bool run_h5dump   = false;
+    bool run_h5fc     = false;
+    bool run_h5jam    = false;
+    bool run_h5repack = false;
+    bool run_h5stat   = false;
+    bool run_h5repart = false;
+    bool run_h5ls     = false;
 
     /* Check for no command line parameters */
     if (argc == 1) {

--- a/tools/test/h5gentest.c
+++ b/tools/test/h5gentest.c
@@ -22,6 +22,7 @@
 #include "h5repackgentest.h"
 #include "h5statgentest.h"
 #include "h5repartgentest.h"
+#include "h5lsgentest.h"
 
 static int
 gen_h5copy_files(void)
@@ -379,7 +380,55 @@ gen_h5repart_files(void)
     return EXIT_SUCCESS;
 }
 
-/*-------------------------------------------------------------------------
+static int
+gen_h5ls_files(void)
+{
+    int nerrors = 0;
+
+    gent_udfilter(H5LS_UDFILTER_FILE);
+
+    gent_all();
+    gent_group();
+    gent_dataset();
+    gent_softlink();
+    gent_softlink2();
+    gent_str();
+
+    gent_vldatatypes();
+    gent_compound_dt();
+    gent_datareg();
+    gent_empty();
+    gent_hardlink();
+    gent_loop();
+    gent_nestcomp();
+
+    gent_group_comments();
+    gent_array1();
+    gent_attr_all();
+    gent_attrreg();
+
+    gent_extlink();
+    gent_extlinks();
+    gent_null_space_group();
+
+    gent_udlink();
+
+#ifdef H5_HAVE__FLOAT_16
+    gent_float16();
+    gent_float16_be();
+#endif
+#ifdef H5_HAVE_COMPLEX_NUMBERS
+    gent_complex();
+    gent_complex_be();
+#endif
+
+    nerrors += (gent_tdset() < 0 ? 1 : 0);
+    gent_dataset_idx();
+
+    return nerrors;
+}
+
+ /*-------------------------------------------------------------------------
  * Function: usage
  *
  * Purpose: Prints a usage message on stdout stream and then returns.
@@ -404,6 +453,7 @@ usage(void)
     printf("  --h5repack      Generate h5repack test files\n");
     printf("  --h5stat        Generate h5stat test files\n");
     printf("  --h5repart      Generate h5repart test files\n");
+    printf("  --h5ls          Generate h5ls test files\n");
     return;
 }
 
@@ -414,7 +464,7 @@ int
 main(int argc, char *argv[])
 {
     /* command-line options: short and long-named parameters */
-    static const char            *s_opts   = "hacdufjrsp";
+    static const char            *s_opts   = "hacdufjrspl";
     static struct h5_long_options l_opts[] = {{"help", no_arg, 'h'},
                                               {"all", no_arg, 'a'},
                                               {"h5copy", no_arg, 'c'},
@@ -425,6 +475,7 @@ main(int argc, char *argv[])
                                               {"h5repack", no_arg, 'r'},
                                               {"h5stat", no_arg, 's'},
                                               {"h5repart", no_arg, 'p'},
+                                              {"h5ls", no_arg, 'l'},
                                               {NULL, 0, 0}};
     int                           i;
     int                           opt;
@@ -437,6 +488,7 @@ main(int argc, char *argv[])
     bool                          run_h5repack = false;
     bool                          run_h5stat   = false;
     bool                          run_h5repart = false;
+    bool                          run_h5ls     = false;
 
     /* Check for no command line parameters */
     if (argc == 1) {
@@ -476,6 +528,8 @@ main(int argc, char *argv[])
                 case 'p':
                     run_h5repart = true;
                     break;
+                case 'l':
+                    run_h5ls = true;
                 default:
                     continue;
             }
@@ -483,7 +537,7 @@ main(int argc, char *argv[])
     }
 
     if (!run_all && !run_h5copy && !run_h5diff && !run_h5dump && !run_h5fc && !run_h5jam && !run_h5repack &&
-        !run_h5stat && !run_h5repart) {
+        !run_h5stat && !run_h5repart && !run_h5ls) {
         usage();
         return EXIT_FAILURE;
     }
@@ -498,6 +552,7 @@ main(int argc, char *argv[])
         gen_h5repack_files();
         gen_h5stat_files();
         gen_h5repart_files();
+        gen_h5ls_files();
     }
     else {
         if (run_h5copy) {
@@ -523,6 +578,9 @@ main(int argc, char *argv[])
         }
         if (run_h5repart) {
             gen_h5repart_files();
+        }
+        if (run_h5ls) {
+            gen_h5ls_files();
         }
     }
 

--- a/tools/test/h5ls/h5lsgentest.c
+++ b/tools/test/h5ls/h5lsgentest.c
@@ -1,0 +1,104 @@
+/* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * *
+ * Copyright by The HDF Group.                                               *
+ * All rights reserved.                                                      *
+ *                                                                           *
+ * This file is part of HDF5.  The full HDF5 copyright notice, including     *
+ * terms governing use, modification, and redistribution, is contained in    *
+ * the LICENSE file, which can be found at the root of the source code       *
+ * distribution tree, or in https://www.hdfgroup.org/licenses.               *
+ * If you do not have access to either file, you may request a copy from     *
+ * help@hdfgroup.org.                                                        *
+ * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
+
+#include "hdf5.h"
+#include "H5private.h"
+#include "h5lsgentest.h"
+
+#define TDSET_FILENAME "tdset2.h5"
+
+herr_t
+gent_tdset(void)
+{
+    hid_t       file_id, dataset1_id, dataset2_id;
+    hid_t       dataspace1_id, dataspace2_id;
+    hid_t       datatype1_id, datatype2_id;
+    hid_t       plist_id;
+    hsize_t     dims1[2] = {10, 20};
+    hsize_t     maxdims1[2] = {H5S_UNLIMITED, 20};
+    hsize_t     dims2[2] = {30, 10};
+    hsize_t     maxdims2[2] = {30, H5S_UNLIMITED};
+    hsize_t     chunk_dims[2] = {5, 5};
+    int         i, j;
+    int         data1[10][20];
+    double      data2[30][10];
+    herr_t      status = SUCCEED;
+
+    /* Initialize data for dataset 1 */
+    for (i = 0; i < 10; i++) {
+        for (j = 0; j < 20; j++) {
+            data1[i][j] = j;
+        }
+    }
+
+    /* Initialize data for dataset 2 */
+    for (i = 0; i < 30; i++) {
+        for (j = 0; j < 10; j++) {
+            data2[i][j] = (double)j;
+        }
+    }
+
+    /* Create a new file using default properties */
+    file_id = H5Fcreate(TDSET_FILENAME, H5F_ACC_TRUNC, H5P_DEFAULT, H5P_DEFAULT);
+
+    /* Create the data space for the first dataset */
+    dataspace1_id = H5Screate_simple(2, dims1, maxdims1);
+
+    /* Create the data space for the second dataset */
+    dataspace2_id = H5Screate_simple(2, dims2, maxdims2);
+
+    /* Create the dataset creation property list */
+    plist_id = H5Pcreate(H5P_DATASET_CREATE);
+
+    /* Set the chunk size */
+    status = H5Pset_chunk(plist_id, 2, chunk_dims);
+
+    /* Create the datatype for the first dataset (32-bit big-endian integer) */
+    datatype1_id = H5Tcopy(H5T_STD_I32BE);
+
+    /* Create the datatype for the second dataset (64-bit big-endian float) */
+    datatype2_id = H5Tcopy(H5T_IEEE_F64BE);
+
+    /* Create the first dataset */
+    dataset1_id = H5Dcreate2(file_id, "dset1", datatype1_id, dataspace1_id,
+                            H5P_DEFAULT, plist_id, H5P_DEFAULT);
+
+    /* Write the first dataset */
+    status = H5Dwrite(dataset1_id, H5T_NATIVE_INT, H5S_ALL, H5S_ALL, H5P_DEFAULT, data1);
+
+    /* Create the second dataset */
+    dataset2_id = H5Dcreate2(file_id, "dset2", datatype2_id, dataspace2_id,
+                            H5P_DEFAULT, plist_id, H5P_DEFAULT);
+
+    /* Write the second dataset */
+    status = H5Dwrite(dataset2_id, H5T_NATIVE_DOUBLE, H5S_ALL, H5S_ALL, H5P_DEFAULT, data2);
+
+    /* Close the datasets */
+    status = H5Dclose(dataset1_id);
+    status = H5Dclose(dataset2_id);
+
+    /* Close the datatypes */
+    status = H5Tclose(datatype1_id);
+    status = H5Tclose(datatype2_id);
+
+    /* Close the dataspaces */
+    status = H5Sclose(dataspace1_id);
+    status = H5Sclose(dataspace2_id);
+
+    /* Close the property list */
+    status = H5Pclose(plist_id);
+
+    /* Close the file */
+    status = H5Fclose(file_id);
+
+    return status;
+}

--- a/tools/test/h5ls/h5lsgentest.c
+++ b/tools/test/h5ls/h5lsgentest.c
@@ -19,19 +19,19 @@
 herr_t
 gent_tdset(void)
 {
-    hid_t       file_id, dataset1_id, dataset2_id;
-    hid_t       dataspace1_id, dataspace2_id;
-    hid_t       datatype1_id, datatype2_id;
-    hid_t       plist_id;
-    hsize_t     dims1[2] = {10, 20};
-    hsize_t     maxdims1[2] = {H5S_UNLIMITED, 20};
-    hsize_t     dims2[2] = {30, 10};
-    hsize_t     maxdims2[2] = {30, H5S_UNLIMITED};
-    hsize_t     chunk_dims[2] = {5, 5};
-    int         i, j;
-    int         data1[10][20];
-    double      data2[30][10];
-    herr_t      status = SUCCEED;
+    hid_t   file_id, dataset1_id, dataset2_id;
+    hid_t   dataspace1_id, dataspace2_id;
+    hid_t   datatype1_id, datatype2_id;
+    hid_t   plist_id;
+    hsize_t dims1[2]      = {10, 20};
+    hsize_t maxdims1[2]   = {H5S_UNLIMITED, 20};
+    hsize_t dims2[2]      = {30, 10};
+    hsize_t maxdims2[2]   = {30, H5S_UNLIMITED};
+    hsize_t chunk_dims[2] = {5, 5};
+    int     i, j;
+    int     data1[10][20];
+    double  data2[30][10];
+    herr_t  status = SUCCEED;
 
     /* Initialize data for dataset 1 */
     for (i = 0; i < 10; i++) {
@@ -69,15 +69,15 @@ gent_tdset(void)
     datatype2_id = H5Tcopy(H5T_IEEE_F64BE);
 
     /* Create the first dataset */
-    dataset1_id = H5Dcreate2(file_id, "dset1", datatype1_id, dataspace1_id,
-                            H5P_DEFAULT, plist_id, H5P_DEFAULT);
+    dataset1_id =
+        H5Dcreate2(file_id, "dset1", datatype1_id, dataspace1_id, H5P_DEFAULT, plist_id, H5P_DEFAULT);
 
     /* Write the first dataset */
     status = H5Dwrite(dataset1_id, H5T_NATIVE_INT, H5S_ALL, H5S_ALL, H5P_DEFAULT, data1);
 
     /* Create the second dataset */
-    dataset2_id = H5Dcreate2(file_id, "dset2", datatype2_id, dataspace2_id,
-                            H5P_DEFAULT, plist_id, H5P_DEFAULT);
+    dataset2_id =
+        H5Dcreate2(file_id, "dset2", datatype2_id, dataspace2_id, H5P_DEFAULT, plist_id, H5P_DEFAULT);
 
     /* Write the second dataset */
     status = H5Dwrite(dataset2_id, H5T_NATIVE_DOUBLE, H5S_ALL, H5S_ALL, H5P_DEFAULT, data2);

--- a/tools/test/h5ls/h5lsgentest.h
+++ b/tools/test/h5ls/h5lsgentest.h
@@ -1,0 +1,22 @@
+/* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * *
+ * Copyright by The HDF Group.                                               *
+ * All rights reserved.                                                      *
+ *                                                                           *
+ * This file is part of HDF5.  The full HDF5 copyright notice, including     *
+ * terms governing use, modification, and redistribution, is contained in    *
+ * the LICENSE file, which can be found at the root of the source code       *
+ * distribution tree, or in https://www.hdfgroup.org/licenses.               *
+ * If you do not have access to either file, you may request a copy from     *
+ * help@hdfgroup.org.                                                        *
+ * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
+
+#ifndef H5LS_GENTEST_H
+#define H5LS_GENTEST_H
+
+#include "hdf5.h"
+
+#define H5LS_UDFILTER_FILE "tudfilter.h5"
+
+herr_t gent_tdset(void);
+
+#endif /* H5LS_GENTEST_H */


### PR DESCRIPTION
h5ls currently has no script to generate the test files it uses on the fly. This adds support for h5ls test file generation to the gentest script.