### PR TITLE
Remove checks for dev_t being a scalar type

### DIFF
--- a/config/ConfigureChecks.cmake
+++ b/config/ConfigureChecks.cmake
@@ -343,11 +343,6 @@ set (CMAKE_EXTRA_INCLUDE_FILES stdbool.h)
 HDF_CHECK_TYPE_SIZE (_Bool        ${HDF_PREFIX}_SIZEOF_BOOL)
 
 if (MINGW OR NOT WINDOWS)
-  #-----------------------------------------------------------------------------
-  # Check if the dev_t type is a scalar type
-  #-----------------------------------------------------------------------------
-  HDF_FUNCTION_TEST (DEV_T_IS_SCALAR)
-
   # ----------------------------------------------------------------------
   # Check for MONOTONIC_TIMER support (used in clock_gettime).  This has
   # to be done after any POSIX/BSD defines to ensure that the test gets

--- a/config/H5pubconf.h.in
+++ b/config/H5pubconf.h.in
@@ -29,9 +29,6 @@
 /* Define the default plugins path to compile */
 #cmakedefine H5_DEFAULT_PLUGINDIR "@H5_DEFAULT_PLUGINDIR@"
 
-/* Define if dev_t is a scalar */
-#cmakedefine H5_DEV_T_IS_SCALAR @H5_DEV_T_IS_SCALAR@
-
 /* Define if your system is IBM ppc64le and cannot convert some long double
    values correctly. */
 #cmakedefine H5_DISABLE_SOME_LDOUBLE_CONV @H5_DISABLE_SOME_LDOUBLE_CONV@

--- a/config/HDFTests.c
+++ b/config/HDFTests.c
@@ -98,22 +98,6 @@ SIMPLE_TEST(socklen_t foo);
 
 #endif /* HAVE_SOCKLEN_T */
 
-#ifdef DEV_T_IS_SCALAR
-
-#ifdef HAVE_SYS_TYPES_H
-#include <sys/types.h>
-#endif
-
-int main ()
-{
-    dev_t d1, d2;
-    if (d1 == d2)
-        return 0;
-    return 1;
-}
-
-#endif /* DEV_T_IS_SCALAR */
-
 #ifdef HAVE_DEFAULT_SOURCE
 /* Check default source */
 #include <features.h>

--- a/src/H5FDcore.c
+++ b/src/H5FDcore.c
@@ -1053,21 +1053,10 @@ H5FD__core_cmp(const H5FD_t *_f1, const H5FD_t *_f2)
             HGOTO_DONE(1);
 
 #else
-#ifdef H5_DEV_T_IS_SCALAR
         if (f1->device < f2->device)
             HGOTO_DONE(-1);
         if (f1->device > f2->device)
             HGOTO_DONE(1);
-#else  /* H5_DEV_T_IS_SCALAR */
-        /* If dev_t isn't a scalar value on this system, just use memcmp to
-         * determine if the values are the same or not.  The actual return value
-         * shouldn't really matter...
-         */
-        if (memcmp(&(f1->device), &(f2->device), sizeof(dev_t)) < 0)
-            HGOTO_DONE(-1);
-        if (memcmp(&(f1->device), &(f2->device), sizeof(dev_t)) > 0)
-            HGOTO_DONE(1);
-#endif /* H5_DEV_T_IS_SCALAR */
 
         if (f1->inode < f2->inode)
             HGOTO_DONE(-1);

--- a/src/H5FDdirect.c
+++ b/src/H5FDdirect.c
@@ -602,21 +602,10 @@ H5FD__direct_cmp(const H5FD_t *_f1, const H5FD_t *_f2)
         HGOTO_DONE(1);
 
 #else
-#ifdef H5_DEV_T_IS_SCALAR
     if (f1->device < f2->device)
         HGOTO_DONE(-1);
     if (f1->device > f2->device)
         HGOTO_DONE(1);
-#else  /* H5_DEV_T_IS_SCALAR */
-    /* If dev_t isn't a scalar value on this system, just use memcmp to
-     * determine if the values are the same or not.  The actual return value
-     * shouldn't really matter...
-     */
-    if (memcmp(&(f1->device), &(f2->device), sizeof(dev_t)) < 0)
-        HGOTO_DONE(-1);
-    if (memcmp(&(f1->device), &(f2->device), sizeof(dev_t)) > 0)
-        HGOTO_DONE(1);
-#endif /* H5_DEV_T_IS_SCALAR */
 
     if (f1->inode < f2->inode)
         HGOTO_DONE(-1);

--- a/src/H5FDlog.c
+++ b/src/H5FDlog.c
@@ -786,21 +786,10 @@ H5FD__log_cmp(const H5FD_t *_f1, const H5FD_t *_f2)
     if (f1->nFileIndexLow > f2->nFileIndexLow)
         HGOTO_DONE(1);
 #else
-#ifdef H5_DEV_T_IS_SCALAR
     if (f1->device < f2->device)
         HGOTO_DONE(-1);
     if (f1->device > f2->device)
         HGOTO_DONE(1);
-#else  /* H5_DEV_T_IS_SCALAR */
-    /* If dev_t isn't a scalar value on this system, just use memcmp to
-     * determine if the values are the same or not.  The actual return value
-     * shouldn't really matter...
-     */
-    if (memcmp(&(f1->device), &(f2->device), sizeof(dev_t)) < 0)
-        HGOTO_DONE(-1);
-    if (memcmp(&(f1->device), &(f2->device), sizeof(dev_t)) > 0)
-        HGOTO_DONE(1);
-#endif /* H5_DEV_T_IS_SCALAR */
 
     if (f1->inode < f2->inode)
         HGOTO_DONE(-1);

--- a/src/H5FDsec2.c
+++ b/src/H5FDsec2.c
@@ -432,21 +432,11 @@ H5FD__sec2_cmp(const H5FD_t *_f1, const H5FD_t *_f2)
     if (f1->nFileIndexLow > f2->nFileIndexLow)
         HGOTO_DONE(1);
 #else /* H5_HAVE_WIN32_API */
-#ifdef H5_DEV_T_IS_SCALAR
     if (f1->device < f2->device)
         HGOTO_DONE(-1);
     if (f1->device > f2->device)
         HGOTO_DONE(1);
-#else  /* H5_DEV_T_IS_SCALAR */
-    /* If dev_t isn't a scalar value on this system, just use memcmp to
-     * determine if the values are the same or not.  The actual return value
-     * shouldn't really matter...
-     */
-    if (memcmp(&(f1->device), &(f2->device), sizeof(dev_t)) < 0)
-        HGOTO_DONE(-1);
-    if (memcmp(&(f1->device), &(f2->device), sizeof(dev_t)) > 0)
-        HGOTO_DONE(1);
-#endif /* H5_DEV_T_IS_SCALAR */
+
     if (f1->inode < f2->inode)
         HGOTO_DONE(-1);
     if (f1->inode > f2->inode)

--- a/src/H5FDsec2.c
+++ b/src/H5FDsec2.c
@@ -431,7 +431,7 @@ H5FD__sec2_cmp(const H5FD_t *_f1, const H5FD_t *_f2)
         HGOTO_DONE(-1);
     if (f1->nFileIndexLow > f2->nFileIndexLow)
         HGOTO_DONE(1);
-#else /* H5_HAVE_WIN32_API */
+#else  /* H5_HAVE_WIN32_API */
     if (f1->device < f2->device)
         HGOTO_DONE(-1);
     if (f1->device > f2->device)

--- a/src/H5FDstdio.c
+++ b/src/H5FDstdio.c
@@ -509,7 +509,7 @@ H5FD_stdio_cmp(const H5FD_t *_f1, const H5FD_t *_f2)
         return -1;
     if (f1->nFileIndexLow > f2->nFileIndexLow)
         return 1;
-#else /* H5_HAVE_WIN32_API */
+#else  /* H5_HAVE_WIN32_API */
     if (f1->device < f2->device)
         return -1;
     if (f1->device > f2->device)

--- a/src/H5FDstdio.c
+++ b/src/H5FDstdio.c
@@ -510,21 +510,11 @@ H5FD_stdio_cmp(const H5FD_t *_f1, const H5FD_t *_f2)
     if (f1->nFileIndexLow > f2->nFileIndexLow)
         return 1;
 #else /* H5_HAVE_WIN32_API */
-#ifdef H5_DEV_T_IS_SCALAR
     if (f1->device < f2->device)
         return -1;
     if (f1->device > f2->device)
         return 1;
-#else  /* H5_DEV_T_IS_SCALAR */
-    /* If dev_t isn't a scalar value on this system, just use memcmp to
-     * determine if the values are the same or not.  The actual return value
-     * shouldn't really matter...
-     */
-    if (memcmp(&(f1->device), &(f2->device), sizeof(dev_t)) < 0)
-        return -1;
-    if (memcmp(&(f1->device), &(f2->device), sizeof(dev_t)) > 0)
-        return 1;
-#endif /* H5_DEV_T_IS_SCALAR */
+
     if (f1->inode < f2->inode)
         return -1;
     if (f1->inode > f2->inode)


### PR DESCRIPTION
POSIX has defined dev_t as an integral type since 2001.

These are only used in the cmp() callbacks of the POSIX-y VFDs.

Fixes #5566 