### PR TITLE
Fix target namespace conflicts in CMake

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -286,6 +286,7 @@ set (HDF5_JAVA_LOGGING_SIMPLE_JAR  ${HDF5_SOURCE_DIR}/java/lib/ext/slf4j-simple-
 set (HDF5_DOXYGEN_DIR              ${HDF5_SOURCE_DIR}/doxygen)
 
 set (HDF5_SRC_INCLUDE_DIRS ${HDF5_SRC_DIR})
+set(HDF_PACKAGE_NAMESPACE "hdf5::")
 
 #-----------------------------------------------------------------------------
 # parse the full version number from H5public.h and include in H5_VERS_INFO


### PR DESCRIPTION
`HDF_PACKAGE_NAMESPACE` is a CMake variable used to distinguish HDF cmake targets. It's set when the configuration in `cacheinit.cmake` is used, but is left undefined by default. 

This can cause conflicts between certain build targets when the namespace is expected to distinguish them. I ran into a conflict between the `szaec-static` target defined in `EXTERNAL_SZIP_LIBRARY ` and the one defined in `LIBAEC/CMakeLists.txt:179`, and [users have encountered a similar problem for zlib](https://forum.hdfgroup.org/t/hdf5-cmake-szlib-path/12337/8).