### PR TITLE
Resolve spurious linkchecker timeouts

### DIFF
--- a/.github/workflows/linkchecker.yml
+++ b/.github/workflows/linkchecker.yml
@@ -26,8 +26,6 @@ jobs:
           sudo apt install -y graphviz
           sudo apt install -y --no-install-recommends doxygen
           sudo apt install -y cmake
-          sudo apt install -y texlive-full
-          sudo apt install -y texlive-latex-extra
           pip3 install linkchecker
 
       - name: build

--- a/.github/workflows/linkchecker.yml
+++ b/.github/workflows/linkchecker.yml
@@ -38,6 +38,13 @@ jobs:
       - name: check
         run: |
           cd build/hdf5lib_docs/html
-          linkchecker --no-warnings --ignore-url=/doxygen.css --ignore-url=gnu.org --ignore-url=en.wikipedia.org --ignore-url=help.hdfgroup.org --ignore-url=libpng.org --ignore-url=my.cdash.org --ignore-url=www.oreilly.com --ignore-url=preshing.com --ignore-url=semver.org --ignore-url=sourceforge.net --ignore-url=www.youtube.com --ignore-url=youtu.be --check-extern --threads=2 ./index.html
+          linkchecker --no-warnings --ignore-url=eigen.tuxfamily.org --ignore-url=/doxygen.css \
+          --ignore-url=gnu.org --ignore-url=en.wikipedia.org \
+          --ignore-url=help.hdfgroup.org --ignore-url=libpng.org \
+          --ignore-url=my.cdash.org --ignore-url=www.oreilly.com \
+          --ignore-url=preshing.com --ignore-url=semver.org \
+          --ignore-url=sourceforge.net --ignore-url=www.youtube.com \
+          --ignore-url=youtu.be \
+          --check-extern --threads=2 ./index.html
         #continue-on-error: true
 

--- a/.github/workflows/linkchecker.yml
+++ b/.github/workflows/linkchecker.yml
@@ -22,7 +22,6 @@ jobs:
 
       - name: install
         run: |
-          sudo apt update -y
           sudo apt install -y libunwind-dev
           sudo apt install -y graphviz
           sudo apt install -y --no-install-recommends doxygen

--- a/.github/workflows/linkchecker.yml
+++ b/.github/workflows/linkchecker.yml
@@ -27,7 +27,6 @@ jobs:
           sudo apt install -y --no-install-recommends doxygen
           sudo apt install -y cmake
           sudo apt install -y texlive-full
-          sudo apt install -y texlive-fonts-extra
           sudo apt install -y texlive-latex-extra
           pip3 install linkchecker
 

--- a/.github/workflows/linkchecker.yml
+++ b/.github/workflows/linkchecker.yml
@@ -38,6 +38,6 @@ jobs:
       - name: check
         run: |
           cd build/hdf5lib_docs/html
-          linkchecker --no-warnings --ignore-url=/doxygen.css --ignore-url=gnu.org --ignore-url=en.wikipedia.org --ignore-url=help.hdfgroup.org --ignore-url=libpng.org --ignore-url=my.cdash.org --ignore-url=www.oreilly.com --ignore-url=preshing.com --ignore-url=semver.org --ignore-url=sourceforge.net --ignore-url=www.youtube.com --ignore-url=youtu.be --check-extern --threads=5 ./index.html
+          linkchecker --no-warnings --ignore-url=/doxygen.css --ignore-url=gnu.org --ignore-url=en.wikipedia.org --ignore-url=help.hdfgroup.org --ignore-url=libpng.org --ignore-url=my.cdash.org --ignore-url=www.oreilly.com --ignore-url=preshing.com --ignore-url=semver.org --ignore-url=sourceforge.net --ignore-url=www.youtube.com --ignore-url=youtu.be --check-extern --threads=2 ./index.html
         #continue-on-error: true
 

--- a/.github/workflows/linkchecker.yml
+++ b/.github/workflows/linkchecker.yml
@@ -38,6 +38,6 @@ jobs:
       - name: check
         run: |
           cd build/hdf5lib_docs/html
-          linkchecker --no-warnings --ignore-url=/doxygen.css --ignore-url=gnu.org --ignore-url=en.wikipedia.org --ignore-url=help.hdfgroup.org --ignore-url=libpng.org --ignore-url=my.cdash.org --ignore-url=www.oreilly.com --ignore-url=preshing.com --ignore-url=semver.org --ignore-url=sourceforge.net --ignore-url=www.youtube.com --ignore-url=youtu.be --check-extern ./index.html
+          linkchecker --no-warnings --ignore-url=/doxygen.css --ignore-url=gnu.org --ignore-url=en.wikipedia.org --ignore-url=help.hdfgroup.org --ignore-url=libpng.org --ignore-url=my.cdash.org --ignore-url=www.oreilly.com --ignore-url=preshing.com --ignore-url=semver.org --ignore-url=sourceforge.net --ignore-url=www.youtube.com --ignore-url=youtu.be --check-extern --threads=5 ./index.html
         #continue-on-error: true
 


### PR DESCRIPTION
- Remove unneeded packages from linkchecker installation

The texlive packages constituted over a gigabyte of data to install, but seem to have no impact on the linkchecker workflow. Removing this drops the installation time from ~9 minutes to ~30 seconds. 

- Reduce number of linkchecker threads 
 
The [current linkchecker](https://github.com/linkchecker/linkchecker) often spuriously fails on valid links due to timeouts (see [here](https://github.com/HDFGroup/hdf5/actions/runs/15586347547/job/43893439400), [here](https://github.com/HDFGroup/hdf5/actions/runs/15637693352/job/44057051203), and [here](https://github.com/HDFGroup/hdf5/actions/runs/15353948295/job/43208633948) as examples).

This seems to be due to the target websites rejecting the connection, potentially due to the linkchecker using multiple threads to send many requests to the same domain.

This PR reduces the number of threads the linkchecker uses from the default (10) to 2. This does not substantially impact the time the linkchecker takes to run.

Resolves #5439