### PR TITLE
Fix resource leak in Subfiling example programs and tests

### DIFF
--- a/HDF5Examples/C/H5PAR/ph5_subfiling.c
+++ b/HDF5Examples/C/H5PAR/ph5_subfiling.c
@@ -314,6 +314,7 @@ subfiling_write_custom(hid_t fapl_id, int mpi_size, int mpi_rank)
 
     cleanup(EXAMPLE_FILE2, subfiling_fapl);
 
+    H5Pclose(subf_config.ioc_fapl_id);
     H5Pclose(subfiling_fapl);
 }
 
@@ -484,6 +485,7 @@ subfiling_write_precreate(hid_t fapl_id, int mpi_size, int mpi_rank)
 
     cleanup(EXAMPLE_FILE3, subfiling_fapl);
 
+    H5Pclose(subf_config.ioc_fapl_id);
     H5Pclose(subfiling_fapl);
 }
 

--- a/HDF5Examples/FORTRAN/H5PAR/ph5_f90_subfiling.F90
+++ b/HDF5Examples/FORTRAN/H5PAR/ph5_f90_subfiling.F90
@@ -290,6 +290,7 @@ CONTAINS
 
     CALL cleanup(EXAMPLE_FILE, subfiling_fapl)
 
+    CALL H5Pclose_f(subf_config%ioc_fapl_id, status)
     CALL H5Pclose_f(subfiling_fapl, status)
 
   END SUBROUTINE subfiling_write_custom
@@ -457,6 +458,7 @@ CONTAINS
 
     CALL cleanup(EXAMPLE_FILE, subfiling_fapl)
 
+    CALL H5Pclose_f(subf_config%ioc_fapl_id, status)
     CALL H5Pclose_f(subfiling_fapl, status)
 
   END SUBROUTINE subfiling_write_precreate

--- a/src/H5FDsubfiling/H5FDsubfiling.h
+++ b/src/H5FDsubfiling/H5FDsubfiling.h
@@ -396,6 +396,12 @@ H5_DLL herr_t H5Pset_fapl_subfiling(hid_t fapl_id, const H5FD_subfiling_config_t
  *          the default values and then calling H5Pset_fapl_subfiling() with the configured
  *          H5FD_subfiling_config_t structure.
  *
+ *          The `ioc_fapl_id` field of the returned structure will be the ID of a copied or
+ *          newly-created property list which should be closed with H5Pclose() when the
+ *          configuration structure is no longer in use. An application should also be sure to
+ *          close this property list ID first if a different property list ID will be assigned
+ *          to the `ioc_fapl_id` field.
+ *
  * \note H5Pget_fapl_subfiling() returns the #H5FD_SUBFILING driver properties as they
  *       were initially set for the File Access Property List using H5Pset_fapl_subfiling().
  *       Alternatively, the driver properties can be modified at runtime according to values

--- a/testpar/t_subfiling_vfd.c
+++ b/testpar/t_subfiling_vfd.c
@@ -182,6 +182,9 @@ create_subfiling_ioc_fapl(MPI_Comm comm, MPI_Info info, bool custom_config,
 
         if (H5Pset_fapl_subfiling(ret_value, &subfiling_conf) < 0)
             TEST_ERROR;
+
+        if (H5Pclose(subfiling_conf.ioc_fapl_id < 0))
+            TEST_ERROR;
     }
 
     return ret_value;

--- a/testpar/t_vfd.c
+++ b/testpar/t_vfd.c
@@ -477,6 +477,12 @@ setup_vfd_test_file(int file_name_id, char *file_name, int mpi_size, H5FD_mpio_x
             }
 
             /* Assign the IOC fapl as the underlying VPD */
+            if ((pass) && (H5Pclose(subfiling_conf.ioc_fapl_id) == FAIL)) {
+
+                pass         = false;
+                failure_mssg = "Can't close default IOC FAPL.";
+            }
+
             subfiling_conf.ioc_fapl_id = ioc_fapl;
 
             /* Now we can set the SUBFILING fapl before returning. */


### PR DESCRIPTION
Fixes a leak of some property list IDs that causes issues in testing when `MPI_Comm_free()` gets called after `MPI_Finalize()`.