### PR TITLE
H5Dmodule.h: Fix documentation for max number of filters

### DIFF
--- a/src/H5Dmodule.h
+++ b/src/H5Dmodule.h
@@ -817,7 +817,7 @@
  *
  * The HDF5 library distribution includes or employs several optional filters. These are listed in the
  * table below. The filters are applied in the pipeline between the virtual file layer and the file
- * hyperslab operation. See the figure above. The application can use any number of filters in any
+ * hyperslab operation. See the figure above. The application can use any number of filters up to 32, in any
  * order.
  *
  * <table>


### PR DESCRIPTION
* In Dataset user guide via doxygen, change "any number of filters" to a maximum of 32, per dataset.
* Max 32 is in current format spec, also in H5Zpublic.h.
* Currently limited to 32 because of a 32-wide bit field in current use.  (Thanks @vchoi-hdfgroup.)
* Realistically I doubt anyone will ever get even a fraction of the way to this limit.
* If you have better wording, please change it.  I don't care.

Closes #5615.
See discussion on that ticket.