### PR TITLE
Fix daily build S3 testing

### DIFF
--- a/.github/workflows/cmake-ctest.yml
+++ b/.github/workflows/cmake-ctest.yml
@@ -578,13 +578,31 @@ jobs:
       - name: Install CMake Dependencies (Linux S3)
         run: |
           sudo apt-get update
-          sudo apt-get install ninja-build doxygen graphviz
-          sudo apt install libssl3 libssl-dev libcurl4 libcurl4-openssl-dev
+          sudo apt-get install ninja-build doxygen
 
       - name: Install CMake
         uses: jwlawson/actions-setup-cmake@v2
         with:
           cmake-version: '3.31.6'
+
+      - name: Install aws-c-s3 (Cached installation)
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
+        with:
+          name: libaws-c-s3-Release
+
+      - name: Untar libaws-c-s3 installation
+        run: |
+          tar xvf libaws-c-s3.tar -C ${{ runner.workspace }}
+
+      - name: List contents of libaws-c-s3 installation
+        run: |
+          ls -lR ${{ runner.workspace }}/aws-c-s3-build
+
+      - name: Setup environment
+        shell: bash
+        run: |
+          echo "LD_LIBRARY_PATH=${{ runner.workspace }}/aws-c-s3-build/lib:$LD_LIBRARY_PATH" >> $GITHUB_ENV
+          echo "CMAKE_PREFIX_PATH=${{ runner.workspace }}/aws-c-s3-build" >> $GITHUB_ENV
 
       - name: Set file base name (Linux S3)
         id: set-file-base

--- a/.github/workflows/cmake-script.yml
+++ b/.github/workflows/cmake-script.yml
@@ -365,13 +365,31 @@ jobs:
       - name: Install CMake Dependencies (Linux S3)
         run: |
           sudo apt-get update
-          sudo apt-get install ninja-build doxygen graphviz curl
-          sudo apt install libssl3 libssl-dev libcurl4 libcurl4-openssl-dev
+          sudo apt-get install ninja-build doxygen
 
       - name: Install CMake
         uses: jwlawson/actions-setup-cmake@v2
         with:
           cmake-version: '3.31.6'
+
+      - name: Install aws-c-s3 (Cached installation)
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
+        with:
+          name: libaws-c-s3-Release
+
+      - name: Untar libaws-c-s3 installation
+        run: |
+          tar xvf libaws-c-s3.tar -C ${{ runner.workspace }}
+
+      - name: List contents of libaws-c-s3 installation
+        run: |
+          ls -laR ${{ runner.workspace }}/aws-c-s3-build
+
+      - name: Setup environment
+        shell: bash
+        run: |
+          echo "LD_LIBRARY_PATH=${{ runner.workspace }}/aws-c-s3-build/lib:$LD_LIBRARY_PATH" >> $GITHUB_ENV
+          echo "CMAKE_PREFIX_PATH=${{ runner.workspace }}/aws-c-s3-build" >> $GITHUB_ENV
 
       - name: Set file base name (Linux S3)
         id: set-file-base

--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -33,6 +33,7 @@ jobs:
       uses: ./.github/workflows/vfd-ros3.yml
       with:
         build_mode: "Release"
+        build_aws_c_s3_only: false
         aws_c_s3_build_type: "package"
         # Use latest release for building from source on Ubuntu
         # until a package is available to install 

--- a/.github/workflows/daily-build.yml
+++ b/.github/workflows/daily-build.yml
@@ -66,6 +66,19 @@ jobs:
       use_tag: snapshot
       use_environ: snapshots
 
+  call-aws-c-s3-build:
+    needs: call-workflow-tarball
+    name: "Build aws-c-s3 library"
+    uses: ./.github/workflows/vfd-ros3.yml
+    with:
+      build_mode: "Release"
+      build_aws_c_s3_only: true
+      aws_c_s3_build_type: "source"
+      # Use latest release for building from source on Ubuntu
+      # until a package is available to install 
+      aws_c_s3_tag: "v0.8.0"
+    if: ${{ ((needs.call-workflow-tarball.outputs.has_changes == 'true') || (needs.get-old-names.outputs.run-ignore == 'ignore')) }}
+
   call-release-cmake-cygwin:
     needs: [get-old-names, call-workflow-tarball]
     name: "CMake Cygwin Workflows"
@@ -76,7 +89,7 @@ jobs:
     if: ${{ ((needs.call-workflow-tarball.outputs.has_changes == 'true') || (needs.get-old-names.outputs.run-ignore == 'ignore')) }}
 
   call-workflow-c-script:
-    needs: [get-old-names, call-workflow-tarball]
+    needs: [get-old-names, call-workflow-tarball, call-aws-c-s3-build]
     uses: ./.github/workflows/cmake-script.yml
     with:
       file_base: ${{ needs.call-workflow-tarball.outputs.file_base }}
@@ -118,7 +131,7 @@ jobs:
     if: ${{ ((needs.call-workflow-tarball.outputs.has_changes == 'true') || (needs.get-old-names.outputs.run-ignore == 'ignore')) }}
 
   call-workflow-ctest:
-    needs: [get-old-names, call-workflow-tarball]
+    needs: [get-old-names, call-workflow-tarball, call-aws-c-s3-build]
     uses: ./.github/workflows/cmake-ctest.yml
     with:
       preset_name: ci-StdShar

--- a/.github/workflows/vfd-main.yml
+++ b/.github/workflows/vfd-main.yml
@@ -41,6 +41,7 @@ jobs:
     uses: ./.github/workflows/vfd-ros3.yml
     with:
       build_mode: "${{ inputs.build_mode }}"
+      build_aws_c_s3_only: false
       aws_c_s3_build_type: "source"
       aws_c_s3_tag: "main"
 

--- a/.github/workflows/vfd-ros3.yml
+++ b/.github/workflows/vfd-ros3.yml
@@ -7,6 +7,10 @@ on:
         description: "CMake build type (CMAKE_BUILD_TYPE)"
         required: true
         type: string
+      build_aws_c_s3_only:
+        description: "Only build the aws-c-s3 library without performing other actions"
+        required: true
+        type: boolean
       aws_c_s3_build_type:
         description: "Install aws-c-s3 from a package manager ('package') or build from source ('source')"
         required: true
@@ -240,7 +244,7 @@ jobs:
           if-no-files-found: error # 'warn' or 'ignore' are also available, defaults to `warn`
 
   build_from_package_managers:
-    if: ${{ inputs.aws_c_s3_build_type == 'package' }}
+    if: ${{ inputs.aws_c_s3_build_type == 'package' && ! inputs.build_aws_c_s3_only }}
 
     # Ubuntu doesn't have a package for aws-c-s3 yet, so use a
     # built from source version until then
@@ -382,7 +386,7 @@ jobs:
   # Build and test the ROS3 VFD using aws-c-s3 built from source,
   # currently only on Ubuntu.
   build_and_test_vfd:
-    if: ${{ inputs.aws_c_s3_build_type == 'source' }}
+    if: ${{ inputs.aws_c_s3_build_type == 'source' && ! inputs.build_aws_c_s3_only }}
 
     needs: build_aws_c_s3
 


### PR DESCRIPTION
Switches over the daily-build workflow jobs for S3 testing to use aws-c-s3 instead of trying to use libcurl.