### PR TITLE
License update, FLOSS manifest

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -10,6 +10,8 @@ Copyright 1998-2006 by The Board of Trustees of the University of Illinois.
 
 All rights reserved.
 
+This software library and utilities is covered by the 3-clause BSD License.
+
 Redistribution and use in source and binary forms, with or without
 modification, are permitted for any purpose (including commercial purposes)
 provided that the following conditions are met:
@@ -27,11 +29,19 @@ provided that the following conditions are met:
    The HDF Group, the University, or the Contributor, respectively.
 
 DISCLAIMER:
-THIS SOFTWARE IS PROVIDED BY THE HDF GROUP AND THE CONTRIBUTORS
-"AS IS" WITH NO WARRANTY OF ANY KIND, EITHER EXPRESSED OR IMPLIED. IN NO
-EVENT SHALL THE HDF GROUP OR THE CONTRIBUTORS BE LIABLE FOR ANY DAMAGES
-SUFFERED BY THE USERS ARISING OUT OF THE USE OF THIS SOFTWARE, EVEN IF
-ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+“AS IS” AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR
+TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+For further details, please refer to the full license text available
+at https://opensource.org/licenses/bsd-3-clause
 
 You are under no obligation whatsoever to provide any bug fixes, patches, or
 upgrades to the features, functionality or performance of the source code

--- a/funding.jpss
+++ b/funding.jpss
@@ -1,0 +1,117 @@
+{
+  "version": "v1.0.0",
+  "entity": {
+    "type": "organisation",
+    "role": "owner",
+    "name": "The HDF Group",
+    "email": "bizoffice@hdfgroup.org",
+    "phone": "217-531-6100",
+    "description": "The HDF Group is a non-profit organization with the mission of advancing state-of-the-art open-source data management technologies, ensuring long-term access to the data, and supporting our dedicated and diverse user community.",
+    "webpageUrl": {
+      "url": "https://hdfgroup.org",
+      "wellKnown": "https://hdfgroup.org/.well-known/funding-manifest-urls"
+    }
+  },
+  "projects": [
+    {
+      "guid": "hdf5-vfdswmr",
+      "name": "hdf5-vfdswmr",
+      "description": "The primary objective of the Virtual File Driver (VFD) Single-Writer Multiple-Reader (SWMR) is to implement a more modular approach than the current SWMR HDF5 library implementation, thereby reducing maintenance costs and improving overall library efficiency. This allows the HDF5 library to guarantee the maximum time from data writing to reading availability, depending on the underlying file system’s performance and the writer’s frequency of library calls. Additionally, it extends SWMR compatibility to Network File Systems (NFS) and object storage. This proposal outlines the necessary work for supporting the VFD SWMR framework, as well as other VFDs, since the current process of configuring VFD stacks can be complex and time-consuming. The proposed language parser aims to streamline this process by introducing a straightforward configuration language that allows for flexible and structured configuration through the use of name-value pairs. The grammar and structure of the language will define these name-value pairs, specifying the types for the values, which may include integers, floating-point numbers, quoted strings, binary blobs, and lists of name-value pairs. Notably, the grammar will fully support tree-structured VFD stacks, providing a robust and reliable configuration solution. For parsing and implementation, the language will utilize a recursive descent parser. This parser will adeptly handle the configuration language, with functions dedicated to parsing name-value pairs and lists, and will return success or failure based on validation results.",
+      "webpageUrl": {
+        "url": "https://hdfgroup.org",
+        "wellKnown": "https://hdfgroup.org/.well-known/funding-manifest-urls"
+      },
+      "repositoryUrl": {
+        "url": "https://github.com/HDFGroup/hdf5"
+      },
+      "licenses": [
+        "spdx:BSD-3-Clause"
+      ],
+      "tags": [
+        "hdf-5",
+        "hierarchical-data-format",
+        "self-describing",
+        "data-format",
+        "data-management",
+        "data-interoperability",
+        "metadata",
+        "heterogeneous-data"
+      ]
+    },
+    {
+      "guid": "hdf5-utf8",
+      "name": "hdf5-utf8",
+      "description": "Support for UTF-8 in the HDF5 is essential for modern scientific and data-intensive applications. It ensures data integrity, promotes interoperability, and enables the handling of a wide range of information globally. Scientific data is often processed using various tools and programming languages across different operating systems. As the standard for text on the web and in contemporary operating systems, adopting UTF-8 allows HDF5 to facilitate seamless data exchange between platforms and applications, making data sharing easier and more efficient for the scientific community. This project aims to address high-priority issues related to UTF-8 in the HDF5 library, focusing on fixing bugs associated with UTF-8 filenames and variable-length strings, particularly on Windows. Additionally, enhancements will support UTF-8 in HDF5 tools and enable the introspection of UTF-8 strings within functions and variable-length string properties in the HDF5 library. The work also includes the addition of UTF-8 character testing to the existing Continuous Integration (CI) framework of HDF5. These enhancements will validate HDF5's ability to handle international characters in various components of the library, including filenames. While HDF5 has foundational support for UTF-8, this support is not consistently enforced or tested, which can lead to inconsistencies and bugs, especially when data is transferred across different platforms. The work involves creating a new suite of tests designed explicitly for UTF-8. These tests will account for variations in how operating systems, particularly Windows, handle UTF-8 in filenames and command-line interactions. The new tests will be integrated into the existing GitHub Actions to ensure continuous validation of HDF5's internationalization capabilities. This proactive approach will prevent character encoding issues and enhance the HDF5 library's quality for the global scientific community.",
+      "webpageUrl": {
+        "url": "https://hdfgroup.org",
+        "wellKnown": "https://hdfgroup.org/.well-known/funding-manifest-urls"
+      },
+      "repositoryUrl": {
+        "url": "https://github.com/HDFGroup/hdf5"
+      },
+      "licenses": [
+        "spdx:BSD-3-Clause"
+      ],
+      "tags": [
+        "hdf-5",
+        "utf8",
+        "hierarchical-data-format",
+        "self-describing",
+        "data-format",
+        "data-management",
+        "data-interoperability",
+        "metadata",
+        "heterogeneous-data"
+      ]
+    }
+  ],
+  "funding": {
+    "channels": [
+      {
+        "guid": "mybank",
+        "type": "bank",
+        "address": "Will accept direct bank transfers. Please e-mail me for details.",
+        "description": ""
+      }
+    ],
+    "plans": [
+      {
+        "guid": "vfdswmr-developer-compensation",
+        "status": "active",
+        "name": "VFD SWMR Developer Compensation",
+        "description": "This will cover the cost of developers working on the hdf5-vfdswmr project.",
+        "amount": 50000,
+        "currency": "USD",
+        "frequency": "one-time",
+        "channels": [
+          "mybank"
+        ]
+      },
+      {
+        "guid": "utf8-developer-compensation",
+        "status": "active",
+        "name": "UTF8 Developer Compensation",
+        "description": "This will cover the cost of developers working on the hdf5-utf8 project.",
+        "amount": 10000,
+        "currency": "USD",
+        "frequency": "one-time",
+        "channels": [
+          "mybank"
+        ]
+      },
+      {
+        "guid": "flexible-giving",
+        "status": "active",
+        "name": "Flexible Giving",
+        "description": "Support our project with a goodwill contribution of any size you deem fit.",
+        "amount": 0,
+        "currency": "USD",
+        "frequency": "one-time",
+        "channels": [
+          "mybank"
+        ]
+      }
+    ],
+    "history": []
+  }
+}


### PR DESCRIPTION
Added FLOSS manifest for UTF-8 and VFD configure parser proposals. The latter is as outlined in the RFC https://github.com/LifeboatLLC/HDF5-Encryption/blob/main/design_docs/RFC-VFD-Configuration-Language-2024-10-17.pdf

Update the license file to state the license explicitly, and updated the text to match those at https://opensource.org/licenses/bsd-3-clause

