### PR TITLE
Remove 1 hour timeout limit for objcopy test

### DIFF
--- a/test/CMakeTests.cmake
+++ b/test/CMakeTests.cmake
@@ -432,7 +432,7 @@ endforeach ()
 set_tests_properties (H5TESTXPR-fheap PROPERTIES TIMEOUT ${CTEST_VERY_LONG_TIMEOUT})
 set_tests_properties (H5TEST-big PROPERTIES TIMEOUT ${CTEST_VERY_LONG_TIMEOUT})
 set_tests_properties (H5TESTXPR-btree2 PROPERTIES TIMEOUT ${CTEST_VERY_LONG_TIMEOUT})
-set_tests_properties (H5TESTXPR-objcopy PROPERTIES TIMEOUT ${CTEST_VERY_LONG_TIMEOUT})
+
 
 #-- Adding test for cache
 if (NOT CYGWIN)


### PR DESCRIPTION
close #5629