### PR TITLE
Consolidate h5copy add-test macros

### DIFF
--- a/tools/test/h5copy/CMakeTests.cmake
+++ b/tools/test/h5copy/CMakeTests.cmake
@@ -59,7 +59,7 @@ add_custom_target(h5copy_files ALL COMMENT "Copying files needed by h5copy tests
 #
 # Perform h5copy according to passing parameters
 #
-macro (ADD_H5_TEST testname resultcode infile fparam vparam sparam srcname dparam dstname)
+macro (ADD_H5_TEST testname resultcode infile psparam pdparam fparam vparam sparam srcname dparam dstname)
   if (NOT "${fparam}" STREQUAL "")
     set (fparam_flag "-f")
   else()
@@ -72,11 +72,36 @@ macro (ADD_H5_TEST testname resultcode infile fparam vparam sparam srcname dpara
       COMMAND ${CMAKE_COMMAND} -E remove ./testfiles/${testname}.out.h5
   )
 
+  # Optional prefill sub-test, to be done before main test
+  if (NOT "${psparam}" STREQUAL "" OR NOT "${pdparam}" STREQUAL "")
+    if ("${psparam}" STREQUAL "" OR "${pdparam}" STREQUAL "")
+      message(FATAL_ERROR "Prefill test requires prefill src and prefill dest")
+    endif ()
+
+    add_test (
+      NAME H5COPY-${testname}-prefill
+      COMMAND ${CMAKE_CROSSCOMPILING_EMULATOR} $<TARGET_FILE:h5copy> -i ./testfiles/${infile} -o ./testfiles/${testname}.out.h5 -v -s ${psparam} -d ${pdparam}
+    )
+    set_tests_properties (H5COPY-${testname}-prefill PROPERTIES
+      DEPENDS H5COPY-${testname}-clear-objects
+      ENVIRONMENT "${ENV}"
+      WORKING_DIRECTORY "${PROJECT_BINARY_DIR}$<IF:$<STREQUAL:${vol},native>,,/${vol}>"
+      FIXTURES_REQUIRED files
+    )
+    if ("H5COPY-${testname}-prefill" MATCHES "${HDF5_DISABLE_TESTS_REGEX}")
+      set_tests_properties (H5COPY-${testname}-prefill PROPERTIES DISABLED true)
+    endif ()
+
+    set(prefill_dep "H5COPY-${testname}-prefill")
+  endif () # prefill step
+
   add_test (
       NAME H5COPY-${testname}
       COMMAND ${CMAKE_CROSSCOMPILING_EMULATOR} $<TARGET_FILE:h5copy> ${fparam_flag} ${fparam} -i ./testfiles/${infile} -o ./testfiles/${testname}.out.h5 ${vparam} ${sparam} ${srcname} ${dparam} ${dstname} ${ARGN}
   )
-  set_tests_properties (H5COPY-${testname} PROPERTIES DEPENDS H5COPY-${testname}-clear-objects)
+  set_tests_properties (H5COPY-${testname} PROPERTIES DEPENDS 
+    "H5COPY-${testname}-clear-objects;${prefill_dep}"
+  )
   if ("H5COPY-${testname}" MATCHES "${HDF5_DISABLE_TESTS_REGEX}")
     set_tests_properties (H5COPY-${testname} PROPERTIES DISABLED true)
   endif ()
@@ -113,55 +138,6 @@ macro (ADD_SKIP_H5_TEST testname skipresultfile)
         COMMAND ${CMAKE_COMMAND} -E echo "SKIP ${testname}-${skipresultfile} ${ARGN}"
     )
     set_property(TEST H5COPY-${testname}-${skipresultfile} PROPERTY DISABLED true)
-  endif ()
-endmacro ()
-
-macro (ADD_H5_TEST2 testname resultcode infile  psparam pdparam vparam sparam srcname dparam dstname)
-  # Remove any output file left over from previous test run
-  add_test (
-      NAME H5COPY-${testname}-clear-objects
-      COMMAND ${CMAKE_COMMAND} -E remove ./testfiles/${testname}.out.h5
-  )
-
-  add_test (
-      NAME H5COPY-${testname}-prefill
-      COMMAND ${CMAKE_CROSSCOMPILING_EMULATOR} $<TARGET_FILE:h5copy> -i ./testfiles/${infile} -o ./testfiles/${testname}.out.h5 -v -s ${psparam} -d ${pdparam}
-  )
-  set_tests_properties (H5COPY-${testname}-prefill PROPERTIES DEPENDS H5COPY-${testname}-clear-objects)
-  if ("H5COPY-${testname}-prefill" MATCHES "${HDF5_DISABLE_TESTS_REGEX}")
-    set_tests_properties (H5COPY-${testname}-prefill PROPERTIES DISABLED true)
-  endif ()
-
-  add_test (
-      NAME H5COPY-${testname}
-      COMMAND ${CMAKE_CROSSCOMPILING_EMULATOR} $<TARGET_FILE:h5copy> -i ./testfiles/${infile} -o ./testfiles/${testname}.out.h5 ${vparam} ${sparam} ${srcname} ${dparam} ${dstname} ${ARGN}
-  )
-  set_tests_properties (H5COPY-${testname} PROPERTIES DEPENDS H5COPY-${testname}-prefill)
-  if ("H5COPY-${testname}" MATCHES "${HDF5_DISABLE_TESTS_REGEX}")
-    set_tests_properties (H5COPY-${testname} PROPERTIES DISABLED true)
-  endif ()
-  # resultcode=2 will cause the test to skip the diff test
-  if (NOT "${resultcode}" STREQUAL "2")
-    add_test (
-        NAME H5COPY-${testname}-DIFF
-        COMMAND ${CMAKE_CROSSCOMPILING_EMULATOR} $<TARGET_FILE:h5diff> -v ./testfiles/${infile} ./testfiles/${testname}.out.h5 ${srcname} ${dstname}
-    )
-    set_tests_properties (H5COPY-${testname}-DIFF PROPERTIES DEPENDS H5COPY-${testname})
-    if ("${resultcode}" STREQUAL "1")
-      set_tests_properties (H5COPY-${testname}-DIFF PROPERTIES WILL_FAIL "true")
-    endif ()
-    if ("H5COPY-${testname}-DIFF" MATCHES "${HDF5_DISABLE_TESTS_REGEX}")
-      set_tests_properties (H5COPY-${testname}-DIFF PROPERTIES DISABLED true)
-    endif ()
-  endif ()
-  add_test (
-      NAME H5COPY-${testname}-clean-objects
-      COMMAND ${CMAKE_COMMAND} -E remove ./testfiles/${testname}.out.h5
-  )
-  if (NOT "${resultcode}" STREQUAL "2")
-    set_tests_properties (H5COPY-${testname}-clean-objects PROPERTIES DEPENDS H5COPY-${testname}-DIFF)
-  else ()
-    set_tests_properties (H5COPY-${testname}-clean-objects PROPERTIES DEPENDS H5COPY-${testname})
   endif ()
 endmacro ()
 
@@ -462,95 +438,95 @@ ADD_SIMPLE_TEST (h5copy_help1 0 -h)
 ADD_SIMPLE_TEST (h5copy_help2 0 --help)
 
 # "Test copying various forms of datasets"
-ADD_H5_TEST (simple 0 ${HDF_FILE1}.h5 "" -v -s simple -d simple)
-ADD_H5_TEST (chunk 0 ${HDF_FILE1}.h5 "" -v -s chunk -d chunk)
-ADD_H5_TEST (compact 0 ${HDF_FILE1}.h5 "" -v -s compact -d compact)
-ADD_H5_TEST (compound 0 ${HDF_FILE1}.h5 "" -v -s compound -d compound)
+ADD_H5_TEST (simple 0 ${HDF_FILE1}.h5 "" "" "" -v -s simple -d simple)
+ADD_H5_TEST (chunk 0 ${HDF_FILE1}.h5 "" "" "" -v -s chunk -d chunk)
+ADD_H5_TEST (compact 0 ${HDF_FILE1}.h5 "" "" "" -v -s compact -d compact)
+ADD_H5_TEST (compound 0 ${HDF_FILE1}.h5 "" "" "" -v -s compound -d compound)
 
 if (USE_FILTER_DEFLATE)
-  ADD_H5_TEST (compressed 0 ${HDF_FILE1}.h5 "" -v -s compressed -d compressed)
+  ADD_H5_TEST (compressed 0 ${HDF_FILE1}.h5 "" "" "" -v -s compressed -d compressed)
 else ()
-  ADD_H5_TEST (compressed 2 ${HDF_FILE1}.h5 "" -v -s compressed -d compressed)
+  ADD_H5_TEST (compressed 2 ${HDF_FILE1}.h5 "" "" "" -v -s compressed -d compressed)
 endif ()
 
-ADD_H5_TEST (named_vl 0 ${HDF_FILE1}.h5 "" -v -s named_vl -d named_vl)
-ADD_H5_TEST (nested_vl 0 ${HDF_FILE1}.h5 "" -v -s nested_vl -d nested_vl)
-ADD_H5_TEST (dset_attr 0 ${HDF_FILE1}.h5 "" -v -s dset_attr -d dset_attr)
+ADD_H5_TEST (named_vl 0 ${HDF_FILE1}.h5 "" "" "" -v -s named_vl -d named_vl)
+ADD_H5_TEST (nested_vl 0 ${HDF_FILE1}.h5 "" "" "" -v -s nested_vl -d nested_vl)
+ADD_H5_TEST (dset_attr 0 ${HDF_FILE1}.h5 "" "" "" -v -s dset_attr -d dset_attr)
 
 # "Test copying dataset within group in source file to root of destination"
-ADD_H5_TEST (simple_top 0 ${HDF_FILE1}.h5 "" -v -s grp_dsets/simple -d simple_top)
+ADD_H5_TEST (simple_top 0 ${HDF_FILE1}.h5 "" "" "" -v -s grp_dsets/simple -d simple_top)
 
 # "Test copying & renaming dataset"
-ADD_H5_TEST (dsrename 0 ${HDF_FILE1}.h5 "" -v -s compound -d rename)
+ADD_H5_TEST (dsrename 0 ${HDF_FILE1}.h5 "" "" "" -v -s compound -d rename)
 
 # "Test copying empty, 'full' & 'nested' groups"
-ADD_H5_TEST (grp_empty 0 ${HDF_FILE1}.h5 "" -v -s grp_empty -d grp_empty)
+ADD_H5_TEST (grp_empty 0 ${HDF_FILE1}.h5 "" "" "" -v -s grp_empty -d grp_empty)
 if (USE_FILTER_DEFLATE)
-  ADD_H5_TEST (grp_dsets 0 ${HDF_FILE1}.h5 "" -v -s grp_dsets -d grp_dsets)
-  ADD_H5_TEST (grp_nested 0 ${HDF_FILE1}.h5 "" -v -s grp_nested -d grp_nested)
+  ADD_H5_TEST (grp_dsets 0 ${HDF_FILE1}.h5 "" "" "" -v -s grp_dsets -d grp_dsets)
+  ADD_H5_TEST (grp_nested 0 ${HDF_FILE1}.h5 "" "" "" -v -s grp_nested -d grp_nested)
 else ()
-  ADD_H5_TEST (grp_dsets 2 ${HDF_FILE1}.h5 "" -v -s grp_dsets -d grp_dsets)
-  ADD_H5_TEST (grp_nested 2 ${HDF_FILE1}.h5 "" -v -s grp_nested -d grp_nested)
+  ADD_H5_TEST (grp_dsets 2 ${HDF_FILE1}.h5 "" "" "" -v -s grp_dsets -d grp_dsets)
+  ADD_H5_TEST (grp_nested 2 ${HDF_FILE1}.h5 "" "" "" -v -s grp_nested -d grp_nested)
 endif ()
-ADD_H5_TEST (grp_attr 0 ${HDF_FILE1}.h5 "" -v -s grp_attr -d grp_attr)
+ADD_H5_TEST (grp_attr 0 ${HDF_FILE1}.h5 "" "" "" -v -s grp_attr -d grp_attr)
 
 # "Test copying dataset within group in source file to group in destination"
-ADD_H5_TEST2 (simple_group 0 ${HDF_FILE1}.h5 grp_dsets grp_dsets -v -s /grp_dsets/simple -d /grp_dsets/simple_group)
+ADD_H5_TEST (simple_group 0 ${HDF_FILE1}.h5 grp_dsets grp_dsets "" -v -s /grp_dsets/simple -d /grp_dsets/simple_group)
 
 if (USE_FILTER_DEFLATE)
   # "Test copying & renaming group"
-  ADD_H5_TEST (grp_rename 0 ${HDF_FILE1}.h5 "" -v -s grp_dsets -d grp_rename)
+  ADD_H5_TEST (grp_rename 0 ${HDF_FILE1}.h5 "" "" "" -v -s grp_dsets -d grp_rename)
   # "Test copying 'full' group hierarchy into group in destination file"
-  ADD_H5_TEST2 (grp_dsets_rename 0 ${HDF_FILE1}.h5 grp_dsets grp_rename -v -s grp_dsets -d /grp_rename/grp_dsets)
+  ADD_H5_TEST (grp_dsets_rename 0 ${HDF_FILE1}.h5 grp_dsets grp_rename "" -v -s grp_dsets -d /grp_rename/grp_dsets)
 else ()
   # "Test copying & renaming group"
-  ADD_H5_TEST (grp_rename 2 ${HDF_FILE1}.h5 "" -v -s grp_dsets -d grp_rename)
+  ADD_H5_TEST (grp_rename 2 ${HDF_FILE1}.h5 "" "" "" -v -s grp_dsets -d grp_rename)
   # "Test copying 'full' group hierarchy into group in destination file"
-  ADD_H5_TEST2 (grp_dsets_rename 2 ${HDF_FILE1}.h5 grp_dsets grp_rename -v -s grp_dsets -d /grp_rename/grp_dsets)
+  ADD_H5_TEST (grp_dsets_rename 2 ${HDF_FILE1}.h5 grp_dsets grp_rename "" -v -s grp_dsets -d /grp_rename/grp_dsets)
 endif ()
 
 # "Test copying objects into group that doesn't exist yet in destination file"
-ADD_H5_TEST (A_B1_simple 0 ${HDF_FILE1}.h5 "" -vp -s simple -d /A/B1/simple)
-ADD_H5_TEST (A_B2_simple2 0 ${HDF_FILE1}.h5 "" -vp -s simple -d /A/B2/simple2)
-ADD_H5_TEST (C_D_simple 0 ${HDF_FILE1}.h5 "" -vp -s /grp_dsets/simple -d /C/D/simple)
+ADD_H5_TEST (A_B1_simple 0 ${HDF_FILE1}.h5 "" "" "" -vp -s simple -d /A/B1/simple)
+ADD_H5_TEST (A_B2_simple2 0 ${HDF_FILE1}.h5 "" "" "" -vp -s simple -d /A/B2/simple2)
+ADD_H5_TEST (C_D_simple 0 ${HDF_FILE1}.h5 "" "" "" -vp -s /grp_dsets/simple -d /C/D/simple)
 if (USE_FILTER_DEFLATE)
-  ADD_H5_TEST (E_F_grp_dsets 0 ${HDF_FILE1}.h5 "" -vp -s /grp_dsets -d /E/F/grp_dsets)
-  ADD_H5_TEST (G_H_grp_nested 0 ${HDF_FILE1}.h5 "" -vp -s /grp_nested -d /G/H/grp_nested)
+  ADD_H5_TEST (E_F_grp_dsets 0 ${HDF_FILE1}.h5 "" "" "" -vp -s /grp_dsets -d /E/F/grp_dsets)
+  ADD_H5_TEST (G_H_grp_nested 0 ${HDF_FILE1}.h5 "" "" "" -vp -s /grp_nested -d /G/H/grp_nested)
 else ()
-  ADD_H5_TEST (E_F_grp_dsets 2 ${HDF_FILE1}.h5 "" -vp -s /grp_dsets -d /E/F/grp_dsets)
-  ADD_H5_TEST (G_H_grp_nested 2 ${HDF_FILE1}.h5 "" -vp -s /grp_nested -d /G/H/grp_nested)
+  ADD_H5_TEST (E_F_grp_dsets 2 ${HDF_FILE1}.h5 "" "" "" -vp -s /grp_dsets -d /E/F/grp_dsets)
+  ADD_H5_TEST (G_H_grp_nested 2 ${HDF_FILE1}.h5 "" "" "" -vp -s /grp_nested -d /G/H/grp_nested)
 endif ()
 
 ############# COPY REFERENCES ##############
 
 # "Test copying object and region references"
-ADD_H5_TEST (region_ref 2 ${HDF_FILE2}.h5 ref -v -s / -d /COPY)
+ADD_H5_TEST (region_ref 2 ${HDF_FILE2}.h5 "" "" ref -v -s / -d /COPY)
 
 ############# COPY EXT LINKS ##############
 
 # "Test copying external link directly without -f ext"
-ADD_H5_TEST (ext_link 2 ${HDF_EXT_SRC_FILE}.h5 "" -v -s /group_ext/extlink_dset -d /copy1_dset)
+ADD_H5_TEST (ext_link 2 ${HDF_EXT_SRC_FILE}.h5 "" "" "" -v -s /group_ext/extlink_dset -d /copy1_dset)
 
 # "Test copying external link directly with -f ext"
-ADD_H5_TEST (ext_link_f 2 ${HDF_EXT_SRC_FILE}.h5 ext -v -s /group_ext/extlink_dset -d /copy2_dset)
+ADD_H5_TEST (ext_link_f 2 ${HDF_EXT_SRC_FILE}.h5 "" "" ext -v -s /group_ext/extlink_dset -d /copy2_dset)
 
 # "Test copying dangling external link (no obj) directly without -f ext"
-ADD_H5_TEST (ext_dangle_noobj 2 ${HDF_EXT_SRC_FILE}.h5 "" -v -s /group_ext/extlink_notyet1 -d /copy_dangle1_1)
+ADD_H5_TEST (ext_dangle_noobj 2 ${HDF_EXT_SRC_FILE}.h5 "" "" "" -v -s /group_ext/extlink_notyet1 -d /copy_dangle1_1)
 
 # "Test copying dangling external link (no obj) directly with -f ext"
-ADD_H5_TEST (ext_dangle_noobj_f 2 ${HDF_EXT_SRC_FILE}.h5 ext -v -s /group_ext/extlink_notyet1 -d /copy_dangle1_2)
+ADD_H5_TEST (ext_dangle_noobj_f 2 ${HDF_EXT_SRC_FILE}.h5 "" "" ext -v -s /group_ext/extlink_notyet1 -d /copy_dangle1_2)
 
 # "Test copying dangling external link (no file) directly without -f ext"
-ADD_H5_TEST (ext_dangle_nofile 2 ${HDF_EXT_SRC_FILE}.h5 "" -v -s /group_ext/extlink_notyet2 -d /copy_dangle2_1)
+ADD_H5_TEST (ext_dangle_nofile 2 ${HDF_EXT_SRC_FILE}.h5 "" "" "" -v -s /group_ext/extlink_notyet2 -d /copy_dangle2_1)
 
 # "Test copying dangling external link (no file) directly with -f ext"
-ADD_H5_TEST (ext_dangle_nofile_f 2 ${HDF_EXT_SRC_FILE}.h5 ext -v -s /group_ext/extlink_notyet2 -d /copy_dangle2_2)
+ADD_H5_TEST (ext_dangle_nofile_f 2 ${HDF_EXT_SRC_FILE}.h5 "" "" ext -v -s /group_ext/extlink_notyet2 -d /copy_dangle2_2)
 
 # "Test copying a group contains external links without -f ext"
-ADD_H5_TEST (ext_link_group 2 ${HDF_EXT_SRC_FILE}.h5 "" -v -s /group_ext -d /copy1_group)
+ADD_H5_TEST (ext_link_group 2 ${HDF_EXT_SRC_FILE}.h5 "" "" "" -v -s /group_ext -d /copy1_group)
 
 # "Test copying a group contains external links with -f ext"
-ADD_H5_TEST (ext_link_group_f 2 ${HDF_EXT_SRC_FILE}.h5 ext -v -s /group_ext -d /copy2_group)
+ADD_H5_TEST (ext_link_group_f 2 ${HDF_EXT_SRC_FILE}.h5 "" "" ext -v -s /group_ext -d /copy2_group)
 
 ############# Test misc. ##############
 

--- a/tools/test/h5copy/CMakeTests.cmake
+++ b/tools/test/h5copy/CMakeTests.cmake
@@ -76,7 +76,7 @@ macro (ADD_H5_TEST testname resultcode result_errcheck infile sameflag psparam p
   if (NOT "${fparam}" STREQUAL "")
     set (fparam_flag "-f")
   else()
-    set (fparam_flag "")  
+    set (fparam_flag "")
   endif ()
 
   if (${sameflag})
@@ -103,9 +103,6 @@ macro (ADD_H5_TEST testname resultcode result_errcheck infile sameflag psparam p
     )
     set_tests_properties (H5COPY-${testname}-prefill PROPERTIES
       DEPENDS H5COPY-${testname}-clear-objects
-      ENVIRONMENT "${ENV}"
-      WORKING_DIRECTORY "${PROJECT_BINARY_DIR}$<IF:$<STREQUAL:${vol},native>,,/${vol}>"
-      FIXTURES_REQUIRED files
     )
     if ("H5COPY-${testname}-prefill" MATCHES "${HDF5_DISABLE_TESTS_REGEX}")
       set_tests_properties (H5COPY-${testname}-prefill PROPERTIES DISABLED true)
@@ -139,7 +136,7 @@ macro (ADD_H5_TEST testname resultcode result_errcheck infile sameflag psparam p
       )
   endif ()
 
-  set_tests_properties (H5COPY-${testname} PROPERTIES DEPENDS 
+  set_tests_properties (H5COPY-${testname} PROPERTIES DEPENDS
     "H5COPY-${testname}-clear-objects;${prefill_dep}"
   )
   if ("H5COPY-${testname}" MATCHES "${HDF5_DISABLE_TESTS_REGEX}")

--- a/tools/test/h5copy/CMakeTests.cmake
+++ b/tools/test/h5copy/CMakeTests.cmake
@@ -60,6 +60,7 @@ add_custom_target(h5copy_files ALL COMMENT "Copying files needed by h5copy tests
 # Perform h5copy according to passing parameters
 # testname - name of test to add
 # resultcode - expected resultcode after test execution
+# result_errcheck - if provided, compare the error output of the test to the file with this name
 # infile - name of input file
 # sameflag - flag indicating whether the input/output file should be the same for the main test. TRUE or FALSE.
 # psparam - source file for optional prefill test. must be paired with nonempty pdparam.
@@ -71,7 +72,7 @@ add_custom_target(h5copy_files ALL COMMENT "Copying files needed by h5copy tests
 # dparam - "dest" argument to h5copy. should always be "-d"
 # dstname - name of dest for h5copy
 #
-macro (ADD_H5_TEST testname resultcode infile sameflag psparam pdparam fparam vparam sparam srcname dparam dstname)
+macro (ADD_H5_TEST testname resultcode result_errcheck infile sameflag psparam pdparam fparam vparam sparam srcname dparam dstname)
   if (NOT "${fparam}" STREQUAL "")
     set (fparam_flag "-f")
   else()
@@ -113,10 +114,31 @@ macro (ADD_H5_TEST testname resultcode infile sameflag psparam pdparam fparam vp
     set(prefill_dep "H5COPY-${testname}-prefill")
   endif () # prefill step
 
-  add_test (
+  # No error check
+  # Force this behavior if memchecker enabled
+  if ("${result_errcheck}" STREQUAL "" OR HDF5_ENABLE_USING_MEMCHECKER)
+    add_test (
+        NAME H5COPY-${testname}
+        COMMAND ${CMAKE_CROSSCOMPILING_EMULATOR} $<TARGET_FILE:h5copy> ${fparam_flag} ${fparam} -i ./testfiles/${main_infile} -o ./testfiles/${testname}.out.h5 ${vparam} ${sparam} ${srcname} ${dparam} ${dstname} ${ARGN}
+    )
+  else() # Perform the same test with error checking
+    add_test (
       NAME H5COPY-${testname}
-      COMMAND ${CMAKE_CROSSCOMPILING_EMULATOR} $<TARGET_FILE:h5copy> ${fparam_flag} ${fparam} -i ./testfiles/${main_infile} -o ./testfiles/${testname}.out.h5 ${vparam} ${sparam} ${srcname} ${dparam} ${dstname} ${ARGN}
-  )
+      COMMAND "${CMAKE_COMMAND}"
+          -D "TEST_EMULATOR=${CMAKE_CROSSCOMPILING_EMULATOR}"
+          -D "TEST_PROGRAM=$<TARGET_FILE:h5copy>"
+          -D "TEST_ARGS=${fparam_flag};${fparam};-i;./testfiles/${main_infile};-o;./testfiles/${testname}.out.h5;${vparam};${sparam};${srcname};${dparam};${dstname}"
+          -D "TEST_FOLDER=${PROJECT_BINARY_DIR}"
+          -D "TEST_OUTPUT=./testfiles/${testname}.out.out"
+          -D "TEST_EXPECT=${resultcode}"
+          -D "TEST_REFERENCE=./testfiles/${testname}.out"
+          -D "TEST_ERRREF=${result_errcheck}"
+          -D "TEST_MASK_STORE=true"
+          -D "TEST_GREP_COMPARE=TRUE"
+          -P "${HDF_RESOURCES_DIR}/runTest.cmake"
+      )
+  endif ()
+
   set_tests_properties (H5COPY-${testname} PROPERTIES DEPENDS 
     "H5COPY-${testname}-clear-objects;${prefill_dep}"
   )
@@ -147,49 +169,6 @@ macro (ADD_H5_TEST testname resultcode infile sameflag psparam pdparam fparam vp
   else ()
     set_tests_properties (H5COPY-${testname}-clean-objects PROPERTIES DEPENDS H5COPY-${testname})
   endif ()
-endmacro ()
-
-#
-# Similar to ADD_H5_TEST macro. Compare to outputs from source & target
-# files instead of checking with h5ls.
-#
-macro (ADD_H5_CMP_TEST testname resultcode result_errcheck infile vparam sparam srcname dparam dstname)
-  # Remove any output file left over from previous test run
-  add_test (
-      NAME H5COPY-CMP-${testname}-clear-objects
-      COMMAND ${CMAKE_COMMAND} -E remove ./testfiles/${testname}.out.h5
-  )
-  # If using memchecker add tests without using scripts
-  if (HDF5_ENABLE_USING_MEMCHECKER)
-    add_test (NAME H5COPY-CMP-${testname} COMMAND ${CMAKE_CROSSCOMPILING_EMULATOR} $<TARGET_FILE:h5copy> -i ./testfiles/${infile} -o ./testfiles/${testname}.out.h5 ${vparam} ${sparam} ${srcname} ${dparam} ${dstname} ${ARGN})
-    if ("${resultcode}" STREQUAL "1")
-      set_tests_properties (H5COPY-CMP-${testname} PROPERTIES WILL_FAIL "true")
-    endif ()
-  else ()
-    add_test (
-        NAME H5COPY-CMP-${testname}
-        COMMAND "${CMAKE_COMMAND}"
-            -D "TEST_EMULATOR=${CMAKE_CROSSCOMPILING_EMULATOR}"
-            -D "TEST_PROGRAM=$<TARGET_FILE:h5copy>"
-            -D "TEST_ARGS=-i;./testfiles/${infile};-o;./testfiles/${testname}.out.h5;${vparam};${sparam};${srcname};${dparam};${dstname}"
-            -D "TEST_FOLDER=${PROJECT_BINARY_DIR}"
-            -D "TEST_OUTPUT=./testfiles/${testname}.out.out"
-            -D "TEST_EXPECT=${resultcode}"
-            -D "TEST_REFERENCE=./testfiles/${testname}.out"
-            -D "TEST_ERRREF=${result_errcheck}"
-            -D "TEST_GREP_COMPARE=TRUE"
-            -P "${HDF_RESOURCES_DIR}/runTest.cmake"
-    )
-  endif ()
-  set_tests_properties (H5COPY-CMP-${testname} PROPERTIES DEPENDS H5COPY-CMP-${testname}-clear-objects)
-  if ("H5COPY-CMP-${testname}" MATCHES "${HDF5_DISABLE_TESTS_REGEX}")
-    set_tests_properties (H5COPY-CMP-${testname} PROPERTIES DISABLED true)
-  endif ()
-  add_test (
-      NAME H5COPY-CMP-${testname}-clean-objects
-      COMMAND ${CMAKE_COMMAND} -E remove ./testfiles/${testname}.out.h5
-  )
-  set_tests_properties (H5COPY-CMP-${testname}-clean-objects PROPERTIES DEPENDS H5COPY-CMP-${testname})
 endmacro ()
 
 macro (ADD_H5_UD_TEST testname resultcode infile sparam srcname dparam dstname cmpfile)
@@ -397,113 +376,113 @@ ADD_SIMPLE_TEST (h5copy_help1 0 -h)
 ADD_SIMPLE_TEST (h5copy_help2 0 --help)
 
 # "Test copying various forms of datasets"
-ADD_H5_TEST (simple 0 ${HDF_FILE1}.h5 FALSE "" "" "" -v -s simple -d simple)
-ADD_H5_TEST (chunk 0 ${HDF_FILE1}.h5 FALSE "" "" "" -v -s chunk -d chunk)
-ADD_H5_TEST (compact 0 ${HDF_FILE1}.h5 FALSE "" "" "" -v -s compact -d compact)
-ADD_H5_TEST (compound 0 ${HDF_FILE1}.h5 FALSE "" "" "" -v -s compound -d compound)
+ADD_H5_TEST (simple 0 "" ${HDF_FILE1}.h5 FALSE "" "" "" -v -s simple -d simple)
+ADD_H5_TEST (chunk 0 "" ${HDF_FILE1}.h5 FALSE "" "" "" -v -s chunk -d chunk)
+ADD_H5_TEST (compact 0 "" ${HDF_FILE1}.h5 FALSE "" "" "" -v -s compact -d compact)
+ADD_H5_TEST (compound 0 "" ${HDF_FILE1}.h5 FALSE "" "" "" -v -s compound -d compound)
 
 if (USE_FILTER_DEFLATE)
-  ADD_H5_TEST (compressed 0 ${HDF_FILE1}.h5 FALSE "" "" "" -v -s compressed -d compressed)
+  ADD_H5_TEST (compressed 0 "" ${HDF_FILE1}.h5 FALSE "" "" "" -v -s compressed -d compressed)
 else ()
-  ADD_H5_TEST (compressed 2 ${HDF_FILE1}.h5 FALSE "" "" "" -v -s compressed -d compressed)
+  ADD_H5_TEST (compressed 2 "" ${HDF_FILE1}.h5 FALSE "" "" "" -v -s compressed -d compressed)
 endif ()
 
-ADD_H5_TEST (named_vl 0 ${HDF_FILE1}.h5 FALSE "" "" "" -v -s named_vl -d named_vl)
-ADD_H5_TEST (nested_vl 0 ${HDF_FILE1}.h5 FALSE "" "" "" -v -s nested_vl -d nested_vl)
-ADD_H5_TEST (dset_attr 0 ${HDF_FILE1}.h5 FALSE "" "" "" -v -s dset_attr -d dset_attr)
+ADD_H5_TEST (named_vl 0 "" ${HDF_FILE1}.h5 FALSE "" "" "" -v -s named_vl -d named_vl)
+ADD_H5_TEST (nested_vl 0 "" ${HDF_FILE1}.h5 FALSE "" "" "" -v -s nested_vl -d nested_vl)
+ADD_H5_TEST (dset_attr 0 "" ${HDF_FILE1}.h5 FALSE "" "" "" -v -s dset_attr -d dset_attr)
 
 # "Test copying dataset within group in source file to root of destination"
-ADD_H5_TEST (simple_top 0 ${HDF_FILE1}.h5 FALSE "" "" "" -v -s grp_dsets/simple -d simple_top)
+ADD_H5_TEST (simple_top 0 "" ${HDF_FILE1}.h5 FALSE "" "" "" -v -s grp_dsets/simple -d simple_top)
 
 # "Test copying & renaming dataset"
-ADD_H5_TEST (dsrename 0 ${HDF_FILE1}.h5 FALSE "" "" "" -v -s compound -d rename)
+ADD_H5_TEST (dsrename 0 "" ${HDF_FILE1}.h5 FALSE "" "" "" -v -s compound -d rename)
 
 # "Test copying empty, 'full' & 'nested' groups"
-ADD_H5_TEST (grp_empty 0 ${HDF_FILE1}.h5 FALSE "" "" "" -v -s grp_empty -d grp_empty)
+ADD_H5_TEST (grp_empty 0 "" ${HDF_FILE1}.h5 FALSE "" "" "" -v -s grp_empty -d grp_empty)
 if (USE_FILTER_DEFLATE)
-  ADD_H5_TEST (grp_dsets 0 ${HDF_FILE1}.h5 FALSE "" "" "" -v -s grp_dsets -d grp_dsets)
-  ADD_H5_TEST (grp_nested 0 ${HDF_FILE1}.h5 FALSE "" "" "" -v -s grp_nested -d grp_nested)
+  ADD_H5_TEST (grp_dsets 0 "" ${HDF_FILE1}.h5 FALSE "" "" "" -v -s grp_dsets -d grp_dsets)
+  ADD_H5_TEST (grp_nested 0 "" ${HDF_FILE1}.h5 FALSE "" "" "" -v -s grp_nested -d grp_nested)
 else ()
-  ADD_H5_TEST (grp_dsets 2 ${HDF_FILE1}.h5 FALSE "" "" "" -v -s grp_dsets -d grp_dsets)
-  ADD_H5_TEST (grp_nested 2 ${HDF_FILE1}.h5 FALSE "" "" "" -v -s grp_nested -d grp_nested)
+  ADD_H5_TEST (grp_dsets 2 "" ${HDF_FILE1}.h5 FALSE "" "" "" -v -s grp_dsets -d grp_dsets)
+  ADD_H5_TEST (grp_nested 2 "" ${HDF_FILE1}.h5 FALSE "" "" "" -v -s grp_nested -d grp_nested)
 endif ()
-ADD_H5_TEST (grp_attr 0 ${HDF_FILE1}.h5 FALSE "" "" "" -v -s grp_attr -d grp_attr)
+ADD_H5_TEST (grp_attr 0 "" ${HDF_FILE1}.h5 FALSE "" "" "" -v -s grp_attr -d grp_attr)
 
 # "Test copying dataset within group in source file to group in destination"
-ADD_H5_TEST (simple_group 0 ${HDF_FILE1}.h5 FALSE grp_dsets grp_dsets "" -v -s /grp_dsets/simple -d /grp_dsets/simple_group)
+ADD_H5_TEST (simple_group 0 "" ${HDF_FILE1}.h5 FALSE grp_dsets grp_dsets "" -v -s /grp_dsets/simple -d /grp_dsets/simple_group)
 
 if (USE_FILTER_DEFLATE)
   # "Test copying & renaming group"
-  ADD_H5_TEST (grp_rename 0 ${HDF_FILE1}.h5 FALSE "" "" "" -v -s grp_dsets -d grp_rename)
+  ADD_H5_TEST (grp_rename 0 "" ${HDF_FILE1}.h5 FALSE "" "" "" -v -s grp_dsets -d grp_rename)
   # "Test copying 'full' group hierarchy into group in destination file"
-  ADD_H5_TEST (grp_dsets_rename 0 ${HDF_FILE1}.h5 FALSE grp_dsets grp_rename "" -v -s grp_dsets -d /grp_rename/grp_dsets)
+  ADD_H5_TEST (grp_dsets_rename 0 "" ${HDF_FILE1}.h5 FALSE grp_dsets grp_rename "" -v -s grp_dsets -d /grp_rename/grp_dsets)
 else ()
   # "Test copying & renaming group"
-  ADD_H5_TEST (grp_rename 2 ${HDF_FILE1}.h5 FALSE "" "" "" -v -s grp_dsets -d grp_rename)
+  ADD_H5_TEST (grp_rename 2 "" ${HDF_FILE1}.h5 FALSE "" "" "" -v -s grp_dsets -d grp_rename)
   # "Test copying 'full' group hierarchy into group in destination file"
-  ADD_H5_TEST (grp_dsets_rename 2 ${HDF_FILE1}.h5 FALSE grp_dsets grp_rename "" -v -s grp_dsets -d /grp_rename/grp_dsets)
+  ADD_H5_TEST (grp_dsets_rename 2 "" ${HDF_FILE1}.h5 FALSE grp_dsets grp_rename "" -v -s grp_dsets -d /grp_rename/grp_dsets)
 endif ()
 
 # "Test copying objects into group that doesn't exist yet in destination file"
-ADD_H5_TEST (A_B1_simple 0 ${HDF_FILE1}.h5 FALSE "" "" "" -vp -s simple -d /A/B1/simple)
-ADD_H5_TEST (A_B2_simple2 0 ${HDF_FILE1}.h5 FALSE "" "" "" -vp -s simple -d /A/B2/simple2)
-ADD_H5_TEST (C_D_simple 0 ${HDF_FILE1}.h5 FALSE "" "" "" -vp -s /grp_dsets/simple -d /C/D/simple)
+ADD_H5_TEST (A_B1_simple 0 "" ${HDF_FILE1}.h5 FALSE "" "" "" -vp -s simple -d /A/B1/simple)
+ADD_H5_TEST (A_B2_simple2 0 "" ${HDF_FILE1}.h5 FALSE "" "" "" -vp -s simple -d /A/B2/simple2)
+ADD_H5_TEST (C_D_simple 0 "" ${HDF_FILE1}.h5 FALSE "" "" "" -vp -s /grp_dsets/simple -d /C/D/simple)
 if (USE_FILTER_DEFLATE)
-  ADD_H5_TEST (E_F_grp_dsets 0 ${HDF_FILE1}.h5 FALSE "" "" "" -vp -s /grp_dsets -d /E/F/grp_dsets)
-  ADD_H5_TEST (G_H_grp_nested 0 ${HDF_FILE1}.h5 FALSE "" "" "" -vp -s /grp_nested -d /G/H/grp_nested)
+  ADD_H5_TEST (E_F_grp_dsets 0 "" ${HDF_FILE1}.h5 FALSE "" "" "" -vp -s /grp_dsets -d /E/F/grp_dsets)
+  ADD_H5_TEST (G_H_grp_nested 0 "" ${HDF_FILE1}.h5 FALSE "" "" "" -vp -s /grp_nested -d /G/H/grp_nested)
 else ()
-  ADD_H5_TEST (E_F_grp_dsets 2 ${HDF_FILE1}.h5 FALSE "" "" "" -vp -s /grp_dsets -d /E/F/grp_dsets)
-  ADD_H5_TEST (G_H_grp_nested 2 ${HDF_FILE1}.h5 FALSE "" "" "" -vp -s /grp_nested -d /G/H/grp_nested)
+  ADD_H5_TEST (E_F_grp_dsets 2 "" ${HDF_FILE1}.h5 FALSE "" "" "" -vp -s /grp_dsets -d /E/F/grp_dsets)
+  ADD_H5_TEST (G_H_grp_nested 2 "" ${HDF_FILE1}.h5 FALSE "" "" "" -vp -s /grp_nested -d /G/H/grp_nested)
 endif ()
 
 ############# COPY REFERENCES ##############
 
 # "Test copying object and region references"
-ADD_H5_TEST (region_ref 2 ${HDF_FILE2}.h5 FALSE "" "" ref -v -s / -d /COPY)
+ADD_H5_TEST (region_ref 2 "" ${HDF_FILE2}.h5 FALSE "" "" ref -v -s / -d /COPY)
 
 ############# COPY EXT LINKS ##############
 
 # "Test copying external link directly without -f ext"
-ADD_H5_TEST (ext_link 2 ${HDF_EXT_SRC_FILE}.h5 FALSE "" "" "" -v -s /group_ext/extlink_dset -d /copy1_dset)
+ADD_H5_TEST (ext_link 2 "" ${HDF_EXT_SRC_FILE}.h5 FALSE "" "" "" -v -s /group_ext/extlink_dset -d /copy1_dset)
 
 # "Test copying external link directly with -f ext"
-ADD_H5_TEST (ext_link_f 2 ${HDF_EXT_SRC_FILE}.h5 FALSE "" "" ext -v -s /group_ext/extlink_dset -d /copy2_dset)
+ADD_H5_TEST (ext_link_f 2 "" ${HDF_EXT_SRC_FILE}.h5 FALSE "" "" ext -v -s /group_ext/extlink_dset -d /copy2_dset)
 
 # "Test copying dangling external link (no obj) directly without -f ext"
-ADD_H5_TEST (ext_dangle_noobj 2 ${HDF_EXT_SRC_FILE}.h5 FALSE "" "" "" -v -s /group_ext/extlink_notyet1 -d /copy_dangle1_1)
+ADD_H5_TEST (ext_dangle_noobj 2 "" ${HDF_EXT_SRC_FILE}.h5 FALSE "" "" "" -v -s /group_ext/extlink_notyet1 -d /copy_dangle1_1)
 
 # "Test copying dangling external link (no obj) directly with -f ext"
-ADD_H5_TEST (ext_dangle_noobj_f 2 ${HDF_EXT_SRC_FILE}.h5 FALSE "" "" ext -v -s /group_ext/extlink_notyet1 -d /copy_dangle1_2)
+ADD_H5_TEST (ext_dangle_noobj_f 2 "" ${HDF_EXT_SRC_FILE}.h5 FALSE "" "" ext -v -s /group_ext/extlink_notyet1 -d /copy_dangle1_2)
 
 # "Test copying dangling external link (no file) directly without -f ext"
-ADD_H5_TEST (ext_dangle_nofile 2 ${HDF_EXT_SRC_FILE}.h5 FALSE "" "" "" -v -s /group_ext/extlink_notyet2 -d /copy_dangle2_1)
+ADD_H5_TEST (ext_dangle_nofile 2 "" ${HDF_EXT_SRC_FILE}.h5 FALSE "" "" "" -v -s /group_ext/extlink_notyet2 -d /copy_dangle2_1)
 
 # "Test copying dangling external link (no file) directly with -f ext"
-ADD_H5_TEST (ext_dangle_nofile_f 2 ${HDF_EXT_SRC_FILE}.h5 FALSE "" "" ext -v -s /group_ext/extlink_notyet2 -d /copy_dangle2_2)
+ADD_H5_TEST (ext_dangle_nofile_f 2 "" ${HDF_EXT_SRC_FILE}.h5 FALSE "" "" ext -v -s /group_ext/extlink_notyet2 -d /copy_dangle2_2)
 
 # "Test copying a group contains external links without -f ext"
-ADD_H5_TEST (ext_link_group 2 ${HDF_EXT_SRC_FILE}.h5 FALSE "" "" "" -v -s /group_ext -d /copy1_group)
+ADD_H5_TEST (ext_link_group 2 "" ${HDF_EXT_SRC_FILE}.h5 FALSE "" "" "" -v -s /group_ext -d /copy1_group)
 
 # "Test copying a group contains external links with -f ext"
-ADD_H5_TEST (ext_link_group_f 2 ${HDF_EXT_SRC_FILE}.h5 FALSE "" "" ext -v -s /group_ext -d /copy2_group)
+ADD_H5_TEST (ext_link_group_f 2 "" ${HDF_EXT_SRC_FILE}.h5 FALSE "" "" ext -v -s /group_ext -d /copy2_group)
 
 ############# Test misc. ##############
 
 #-----------------------------------------------------------------
 # "Test copying object into group which doesn't exist, without -p"
 #
-ADD_H5_CMP_TEST (h5copy_misc1 1 "h5copy error" ${HDF_FILE1}.h5 -v -s /simple -d /g1/g2/simple)
+ADD_H5_TEST (h5copy_misc1 1 "h5copy error" ${HDF_FILE1}.h5 FALSE "" "" "" -v -s /simple -d /g1/g2/simple)
 
 #-------------------------------------------
 # "Test copying objects to the same file "
 #
 # - dataset
-ADD_H5_TEST (samefile1 0 ${HDF_FILE1}.h5 TRUE /simple /simple "" -v -s /simple -d /simple_cp)
+ADD_H5_TEST (samefile1 0 "" ${HDF_FILE1}.h5 TRUE /simple /simple "" -v -s /simple -d /simple_cp)
 # - group with some datasets
 if (USE_FILTER_DEFLATE)
-  ADD_H5_TEST (samefile2 0 ${HDF_FILE1}.h5 TRUE /grp_dsets /grp_dsets "" -v -s /grp_dsets -d /grp_dsets_cp)
+  ADD_H5_TEST (samefile2 0 "" ${HDF_FILE1}.h5 TRUE /grp_dsets /grp_dsets "" -v -s /grp_dsets -d /grp_dsets_cp)
 else ()
-  ADD_H5_TEST (samefile2 2 ${HDF_FILE1}.h5 TRUE /grp_dsets /grp_dsets "" -v -s /grp_dsets -d /grp_dsets_cp)
+  ADD_H5_TEST (samefile2 2 "" ${HDF_FILE1}.h5 TRUE /grp_dsets /grp_dsets "" -v -s /grp_dsets -d /grp_dsets_cp)
 endif ()
 
 ##############################################################################

--- a/tools/test/h5copy/CMakeTests.cmake
+++ b/tools/test/h5copy/CMakeTests.cmake
@@ -179,38 +179,29 @@ macro (ADD_H5_UD_TEST testname resultcode infile sparam srcname dparam dstname c
         COMMAND ${CMAKE_COMMAND} -E remove testfiles/${testname}.out.h5
     )
     if ("${resultcode}" STREQUAL "2")
-      add_test (
-          NAME H5COPY_UD-${testname}
-          COMMAND "${CMAKE_COMMAND}"
-              -D "TEST_EMULATOR=${CMAKE_CROSSCOMPILING_EMULATOR}"
-              -D "TEST_PROGRAM=$<TARGET_FILE:h5copy>"
-              -D "TEST_ARGS:STRING=-v;-i;./testfiles/${infile};-o;./testfiles/${testname}.out.h5;${sparam};${srcname};${dparam};${dstname}"
-              -D "TEST_FOLDER=${PROJECT_BINARY_DIR}"
-              -D "TEST_OUTPUT=./testfiles/${infile}.out"
-              -D "TEST_EXPECT=${resultcode}"
-              -D "TEST_REFERENCE=./testfiles/${infile}.txt"
-              -D "TEST_ENV_VAR=HDF5_PLUGIN_PATH"
-              -D "TEST_ENV_VALUE=${CMAKE_BINARY_DIR}"
-              -D "TEST_LIBRARY_DIRECTORY=${CMAKE_TEST_OUTPUT_DIRECTORY}"
-              -P "${HDF_RESOURCES_DIR}/runTest.cmake"
-      )
-    else ()
-      add_test (
-          NAME H5COPY_UD-${testname}
-          COMMAND "${CMAKE_COMMAND}"
-              -D "TEST_EMULATOR=${CMAKE_CROSSCOMPILING_EMULATOR}"
-              -D "TEST_PROGRAM=$<TARGET_FILE:h5copy>"
-              -D "TEST_ARGS:STRING=-v;-i;./testfiles/${infile};-o;./testfiles/${testname}.out.h5;${sparam};${srcname};${dparam};${dstname}"
-              -D "TEST_FOLDER=${PROJECT_BINARY_DIR}"
-              -D "TEST_OUTPUT=./testfiles/${infile}.out"
-              -D "TEST_EXPECT=${resultcode}"
-              -D "TEST_REFERENCE=./testfiles/${infile}.txt"
-              -D "TEST_ENV_VAR=HDF5_PLUGIN_PATH"
-              -D "TEST_ENV_VALUE=${CMAKE_BINARY_DIR}/plugins"
-              -D "TEST_LIBRARY_DIRECTORY=${CMAKE_TEST_OUTPUT_DIRECTORY}"
-              -P "${HDF_RESOURCES_DIR}/runTest.cmake"
-      )
+      # force a plugin not found error
+      set (ud_search_path ${CMAKE_BINARY_DIR})
+    else()
+      # use correct search path
+      set (ud_search_path ${CMAKE_BINARY_DIR}/plugins)
     endif ()
+
+    add_test (
+      NAME H5COPY_UD-${testname}
+      COMMAND "${CMAKE_COMMAND}"
+          -D "TEST_EMULATOR=${CMAKE_CROSSCOMPILING_EMULATOR}"
+          -D "TEST_PROGRAM=$<TARGET_FILE:h5copy>"
+          -D "TEST_ARGS:STRING=-v;-i;./testfiles/${infile};-o;./testfiles/${testname}.out.h5;${sparam};${srcname};${dparam};${dstname}"
+          -D "TEST_FOLDER=${PROJECT_BINARY_DIR}"
+          -D "TEST_OUTPUT=./testfiles/${infile}.out"
+          -D "TEST_EXPECT=${resultcode}"
+          -D "TEST_REFERENCE=./testfiles/${infile}.txt"
+          -D "TEST_ENV_VAR=HDF5_PLUGIN_PATH"
+          -D "TEST_ENV_VALUE=${ud_search_path}"
+          -D "TEST_LIBRARY_DIRECTORY=${CMAKE_TEST_OUTPUT_DIRECTORY}"
+          -P "${HDF_RESOURCES_DIR}/runTest.cmake"
+    )
+
     set_tests_properties (H5COPY_UD-${testname} PROPERTIES DEPENDS H5COPY_UD-${testname}-clear-objects)
     if ("H5COPY_UD-${testname}" MATCHES "${HDF5_DISABLE_TESTS_REGEX}")
       set_tests_properties (H5COPY_UD-${testname} PROPERTIES DISABLED true)
@@ -250,40 +241,32 @@ macro (ADD_H5_UD_ERR_TEST testname resultcode infile sparam srcname dparam dstna
         COMMAND ${CMAKE_COMMAND} -E remove testfiles/${testname}_ERR.out.h5
     )
     if ("${resultcode}" STREQUAL "2")
-      add_test (
-          NAME H5COPY_UD_ERR-${testname}
-          COMMAND "${CMAKE_COMMAND}"
-              -D "TEST_EMULATOR=${CMAKE_CROSSCOMPILING_EMULATOR}"
-              -D "TEST_PROGRAM=$<TARGET_FILE:h5copy>"
-              -D "TEST_ARGS:STRING=-v;--enable-error-stack;-i;./testfiles/${infile};-o;./testfiles/${testname}_ERR.out.h5;${sparam};${srcname};${dparam};${dstname}"
-              -D "TEST_FOLDER=${PROJECT_BINARY_DIR}"
-              -D "TEST_OUTPUT=./testfiles/${infile}_ERR.out"
-              -D "TEST_EXPECT=0"
-              -D "TEST_REFERENCE=./testfiles/${infile}_ERR.txt"
-              -D "TEST_MASK_ERROR=true"
-              -D "TEST_ENV_VAR=HDF5_PLUGIN_PATH"
-              -D "TEST_ENV_VALUE=${CMAKE_BINARY_DIR}"
-              -D "TEST_LIBRARY_DIRECTORY=${CMAKE_TEST_OUTPUT_DIRECTORY}"
-              -P "${HDF_RESOURCES_DIR}/runTest.cmake"
-      )
+      # force a plugin not found error
+      set (ud_search_path ${CMAKE_BINARY_DIR})
+      set (expected_result "0")
     else ()
-      add_test (
-          NAME H5COPY_UD_ERR-${testname}
-          COMMAND "${CMAKE_COMMAND}"
-              -D "TEST_EMULATOR=${CMAKE_CROSSCOMPILING_EMULATOR}"
-              -D "TEST_PROGRAM=$<TARGET_FILE:h5copy>"
-              -D "TEST_ARGS:STRING=-v;--enable-error-stack;-i;./testfiles/${infile};-o;./testfiles/${testname}_ERR.out.h5;${sparam};${srcname};${dparam};${dstname}"
-              -D "TEST_FOLDER=${PROJECT_BINARY_DIR}"
-              -D "TEST_OUTPUT=./testfiles/${infile}_ERR.out"
-              -D "TEST_EXPECT=${resultcode}"
-              -D "TEST_REFERENCE=./testfiles/${infile}_ERR.txt"
-              -D "TEST_MASK_ERROR=true"
-              -D "TEST_ENV_VAR=HDF5_PLUGIN_PATH"
-              -D "TEST_ENV_VALUE=${CMAKE_BINARY_DIR}/plugins"
-              -D "TEST_LIBRARY_DIRECTORY=${CMAKE_TEST_OUTPUT_DIRECTORY}"
-              -P "${HDF_RESOURCES_DIR}/runTest.cmake"
-      )
+      # use correct search path
+      set (ud_search_path ${CMAKE_BINARY_DIR}/plugins)
+      set (expected_result "${resultcode}")
     endif ()
+
+    add_test (
+      NAME H5COPY_UD_ERR-${testname}
+      COMMAND "${CMAKE_COMMAND}"
+          -D "TEST_EMULATOR=${CMAKE_CROSSCOMPILING_EMULATOR}"
+          -D "TEST_PROGRAM=$<TARGET_FILE:h5copy>"
+          -D "TEST_ARGS:STRING=-v;--enable-error-stack;-i;./testfiles/${infile};-o;./testfiles/${testname}_ERR.out.h5;${sparam};${srcname};${dparam};${dstname}"
+          -D "TEST_FOLDER=${PROJECT_BINARY_DIR}"
+          -D "TEST_OUTPUT=./testfiles/${infile}_ERR.out"
+          -D "TEST_EXPECT=${expected_result}"
+          -D "TEST_REFERENCE=./testfiles/${infile}_ERR.txt"
+          -D "TEST_MASK_ERROR=true"
+          -D "TEST_ENV_VAR=HDF5_PLUGIN_PATH"
+          -D "TEST_ENV_VALUE=${ud_search_path}"
+          -D "TEST_LIBRARY_DIRECTORY=${CMAKE_TEST_OUTPUT_DIRECTORY}"
+          -P "${HDF_RESOURCES_DIR}/runTest.cmake"
+    )
+
     set_tests_properties (H5COPY_UD_ERR-${testname} PROPERTIES DEPENDS H5COPY_UD_ERR-${testname}-clear-objects)
     if ("H5COPY_UD_ERR-${testname}" MATCHES "${HDF5_DISABLE_TESTS_REGEX}")
       set_tests_properties (H5COPY_UD_ERR-${testname} PROPERTIES DISABLED true)

--- a/tools/test/h5copy/CMakeTests.cmake
+++ b/tools/test/h5copy/CMakeTests.cmake
@@ -58,13 +58,31 @@ add_custom_target(h5copy_files ALL COMMENT "Copying files needed by h5copy tests
 
 #
 # Perform h5copy according to passing parameters
+# testname - name of test to add
+# resultcode - expected resultcode after test execution
+# infile - name of input file
+# sameflag - flag indicating whether the input/output file should be the same for the main test. TRUE or FALSE.
+# psparam - source file for optional prefill test. must be paired with nonempty pdparam.
+# pdparam - dest file for optional prefill test. must be paired with nonempty psparam.
+# fparam - optional value to pass to h5copy's "-f" argument. "" for no flag.
+# vparam - optional verbose argument to h5copy. "-v" or ""
+# sparam - "source" argument to h5copy. should always be "-s"
+# srcname - name of src for h5copy
+# dparam - "dest" argument to h5copy. should always be "-d"
+# dstname - name of dest for h5copy
 #
-macro (ADD_H5_TEST testname resultcode infile psparam pdparam fparam vparam sparam srcname dparam dstname)
+macro (ADD_H5_TEST testname resultcode infile sameflag psparam pdparam fparam vparam sparam srcname dparam dstname)
   if (NOT "${fparam}" STREQUAL "")
     set (fparam_flag "-f")
   else()
     set (fparam_flag "")  
   endif ()
+
+  if (${sameflag})
+    set (main_infile "${testname}.out.h5")
+  else()
+    set (main_infile "${infile}")
+  endif()
 
   # Remove any output file left over from previous test run
   add_test (
@@ -97,7 +115,7 @@ macro (ADD_H5_TEST testname resultcode infile psparam pdparam fparam vparam spar
 
   add_test (
       NAME H5COPY-${testname}
-      COMMAND ${CMAKE_CROSSCOMPILING_EMULATOR} $<TARGET_FILE:h5copy> ${fparam_flag} ${fparam} -i ./testfiles/${infile} -o ./testfiles/${testname}.out.h5 ${vparam} ${sparam} ${srcname} ${dparam} ${dstname} ${ARGN}
+      COMMAND ${CMAKE_CROSSCOMPILING_EMULATOR} $<TARGET_FILE:h5copy> ${fparam_flag} ${fparam} -i ./testfiles/${main_infile} -o ./testfiles/${testname}.out.h5 ${vparam} ${sparam} ${srcname} ${dparam} ${dstname} ${ARGN}
   )
   set_tests_properties (H5COPY-${testname} PROPERTIES DEPENDS 
     "H5COPY-${testname}-clear-objects;${prefill_dep}"
@@ -110,7 +128,7 @@ macro (ADD_H5_TEST testname resultcode infile psparam pdparam fparam vparam spar
   if (NOT "${resultcode}" STREQUAL "2")
     add_test (
         NAME H5COPY-${testname}-DIFF
-        COMMAND ${CMAKE_CROSSCOMPILING_EMULATOR} $<TARGET_FILE:h5diff> -v ./testfiles/${infile} ./testfiles/${testname}.out.h5 ${srcname} ${dstname}
+        COMMAND ${CMAKE_CROSSCOMPILING_EMULATOR} $<TARGET_FILE:h5diff> -v ./testfiles/${main_infile} ./testfiles/${testname}.out.h5 ${srcname} ${dstname}
     )
     set_tests_properties (H5COPY-${testname}-DIFF PROPERTIES DEPENDS H5COPY-${testname})
     if ("${resultcode}" STREQUAL "1")
@@ -128,55 +146,6 @@ macro (ADD_H5_TEST testname resultcode infile psparam pdparam fparam vparam spar
     set_tests_properties (H5COPY-${testname}-clean-objects PROPERTIES DEPENDS H5COPY-${testname}-DIFF)
   else ()
     set_tests_properties (H5COPY-${testname}-clean-objects PROPERTIES DEPENDS H5COPY-${testname})
-  endif ()
-endmacro ()
-
-macro (ADD_H5_TEST_SAME testname resultcode pfile psparam pdparam vparam sparam srcname dparam dstname)
-  # Remove any output file left over from previous test run
-  add_test (
-      NAME H5COPY_SAME-${testname}-clear-objects
-      COMMAND ${CMAKE_COMMAND} -E remove ./testfiles/${testname}.out.h5
-  )
-
-  add_test (
-      NAME H5COPY_SAME-${testname}-prefill
-      COMMAND ${CMAKE_CROSSCOMPILING_EMULATOR} $<TARGET_FILE:h5copy> -i ./testfiles/${pfile} -o ./testfiles/${testname}.out.h5 -v -s ${psparam} -d ${pdparam}
-  )
-  set_tests_properties (H5COPY_SAME-${testname}-prefill PROPERTIES DEPENDS H5COPY_SAME-${testname}-clear-objects)
-  if ("H5COPY_SAME-${testname}-prefill" MATCHES "${HDF5_DISABLE_TESTS_REGEX}")
-    set_tests_properties (H5COPY_SAME-${testname}-prefill PROPERTIES DISABLED true)
-  endif ()
-
-  add_test (
-      NAME H5COPY_SAME-${testname}
-      COMMAND ${CMAKE_CROSSCOMPILING_EMULATOR} $<TARGET_FILE:h5copy> -i ./testfiles/${testname}.out.h5 -o ./testfiles/${testname}.out.h5 ${vparam} ${sparam} ${srcname} ${dparam} ${dstname} ${ARGN}
-  )
-  set_tests_properties (H5COPY_SAME-${testname} PROPERTIES DEPENDS H5COPY_SAME-${testname}-prefill)
-  if ("H5COPY_SAME-${testname}" MATCHES "${HDF5_DISABLE_TESTS_REGEX}")
-    set_tests_properties (H5COPY_SAME-${testname} PROPERTIES DISABLED true)
-  endif ()
-  # resultcode=2 will cause the test to skip the diff test
-  if (NOT "${resultcode}" STREQUAL "2")
-    add_test (
-        NAME H5COPY_SAME-${testname}-DIFF
-        COMMAND ${CMAKE_CROSSCOMPILING_EMULATOR} $<TARGET_FILE:h5diff> -v ./testfiles/${testname}.out.h5 ./testfiles/${testname}.out.h5 ${srcname} ${dstname}
-    )
-    set_tests_properties (H5COPY_SAME-${testname}-DIFF PROPERTIES DEPENDS H5COPY_SAME-${testname})
-    if ("${resultcode}" STREQUAL "1")
-      set_tests_properties (H5COPY_SAME-${testname}-DIFF PROPERTIES WILL_FAIL "true")
-    endif ()
-    if ("H5COPY_SAME-${testname}-DIFF" MATCHES "${HDF5_DISABLE_TESTS_REGEX}")
-      set_tests_properties (H5COPY_SAME-${testname}-DIFF PROPERTIES DISABLED true)
-    endif ()
-  endif ()
-  add_test (
-      NAME H5COPY_SAME-${testname}-clean-objects
-      COMMAND ${CMAKE_COMMAND} -E remove ./testfiles/${testname}.out.h5
-  )
-  if (NOT "${resultcode}" STREQUAL "2")
-    set_tests_properties (H5COPY_SAME-${testname}-clean-objects PROPERTIES DEPENDS H5COPY_SAME-${testname}-DIFF)
-  else ()
-    set_tests_properties (H5COPY_SAME-${testname}-clean-objects PROPERTIES DEPENDS H5COPY_SAME-${testname})
   endif ()
 endmacro ()
 
@@ -428,95 +397,95 @@ ADD_SIMPLE_TEST (h5copy_help1 0 -h)
 ADD_SIMPLE_TEST (h5copy_help2 0 --help)
 
 # "Test copying various forms of datasets"
-ADD_H5_TEST (simple 0 ${HDF_FILE1}.h5 "" "" "" -v -s simple -d simple)
-ADD_H5_TEST (chunk 0 ${HDF_FILE1}.h5 "" "" "" -v -s chunk -d chunk)
-ADD_H5_TEST (compact 0 ${HDF_FILE1}.h5 "" "" "" -v -s compact -d compact)
-ADD_H5_TEST (compound 0 ${HDF_FILE1}.h5 "" "" "" -v -s compound -d compound)
+ADD_H5_TEST (simple 0 ${HDF_FILE1}.h5 FALSE "" "" "" -v -s simple -d simple)
+ADD_H5_TEST (chunk 0 ${HDF_FILE1}.h5 FALSE "" "" "" -v -s chunk -d chunk)
+ADD_H5_TEST (compact 0 ${HDF_FILE1}.h5 FALSE "" "" "" -v -s compact -d compact)
+ADD_H5_TEST (compound 0 ${HDF_FILE1}.h5 FALSE "" "" "" -v -s compound -d compound)
 
 if (USE_FILTER_DEFLATE)
-  ADD_H5_TEST (compressed 0 ${HDF_FILE1}.h5 "" "" "" -v -s compressed -d compressed)
+  ADD_H5_TEST (compressed 0 ${HDF_FILE1}.h5 FALSE "" "" "" -v -s compressed -d compressed)
 else ()
-  ADD_H5_TEST (compressed 2 ${HDF_FILE1}.h5 "" "" "" -v -s compressed -d compressed)
+  ADD_H5_TEST (compressed 2 ${HDF_FILE1}.h5 FALSE "" "" "" -v -s compressed -d compressed)
 endif ()
 
-ADD_H5_TEST (named_vl 0 ${HDF_FILE1}.h5 "" "" "" -v -s named_vl -d named_vl)
-ADD_H5_TEST (nested_vl 0 ${HDF_FILE1}.h5 "" "" "" -v -s nested_vl -d nested_vl)
-ADD_H5_TEST (dset_attr 0 ${HDF_FILE1}.h5 "" "" "" -v -s dset_attr -d dset_attr)
+ADD_H5_TEST (named_vl 0 ${HDF_FILE1}.h5 FALSE "" "" "" -v -s named_vl -d named_vl)
+ADD_H5_TEST (nested_vl 0 ${HDF_FILE1}.h5 FALSE "" "" "" -v -s nested_vl -d nested_vl)
+ADD_H5_TEST (dset_attr 0 ${HDF_FILE1}.h5 FALSE "" "" "" -v -s dset_attr -d dset_attr)
 
 # "Test copying dataset within group in source file to root of destination"
-ADD_H5_TEST (simple_top 0 ${HDF_FILE1}.h5 "" "" "" -v -s grp_dsets/simple -d simple_top)
+ADD_H5_TEST (simple_top 0 ${HDF_FILE1}.h5 FALSE "" "" "" -v -s grp_dsets/simple -d simple_top)
 
 # "Test copying & renaming dataset"
-ADD_H5_TEST (dsrename 0 ${HDF_FILE1}.h5 "" "" "" -v -s compound -d rename)
+ADD_H5_TEST (dsrename 0 ${HDF_FILE1}.h5 FALSE "" "" "" -v -s compound -d rename)
 
 # "Test copying empty, 'full' & 'nested' groups"
-ADD_H5_TEST (grp_empty 0 ${HDF_FILE1}.h5 "" "" "" -v -s grp_empty -d grp_empty)
+ADD_H5_TEST (grp_empty 0 ${HDF_FILE1}.h5 FALSE "" "" "" -v -s grp_empty -d grp_empty)
 if (USE_FILTER_DEFLATE)
-  ADD_H5_TEST (grp_dsets 0 ${HDF_FILE1}.h5 "" "" "" -v -s grp_dsets -d grp_dsets)
-  ADD_H5_TEST (grp_nested 0 ${HDF_FILE1}.h5 "" "" "" -v -s grp_nested -d grp_nested)
+  ADD_H5_TEST (grp_dsets 0 ${HDF_FILE1}.h5 FALSE "" "" "" -v -s grp_dsets -d grp_dsets)
+  ADD_H5_TEST (grp_nested 0 ${HDF_FILE1}.h5 FALSE "" "" "" -v -s grp_nested -d grp_nested)
 else ()
-  ADD_H5_TEST (grp_dsets 2 ${HDF_FILE1}.h5 "" "" "" -v -s grp_dsets -d grp_dsets)
-  ADD_H5_TEST (grp_nested 2 ${HDF_FILE1}.h5 "" "" "" -v -s grp_nested -d grp_nested)
+  ADD_H5_TEST (grp_dsets 2 ${HDF_FILE1}.h5 FALSE "" "" "" -v -s grp_dsets -d grp_dsets)
+  ADD_H5_TEST (grp_nested 2 ${HDF_FILE1}.h5 FALSE "" "" "" -v -s grp_nested -d grp_nested)
 endif ()
-ADD_H5_TEST (grp_attr 0 ${HDF_FILE1}.h5 "" "" "" -v -s grp_attr -d grp_attr)
+ADD_H5_TEST (grp_attr 0 ${HDF_FILE1}.h5 FALSE "" "" "" -v -s grp_attr -d grp_attr)
 
 # "Test copying dataset within group in source file to group in destination"
-ADD_H5_TEST (simple_group 0 ${HDF_FILE1}.h5 grp_dsets grp_dsets "" -v -s /grp_dsets/simple -d /grp_dsets/simple_group)
+ADD_H5_TEST (simple_group 0 ${HDF_FILE1}.h5 FALSE grp_dsets grp_dsets "" -v -s /grp_dsets/simple -d /grp_dsets/simple_group)
 
 if (USE_FILTER_DEFLATE)
   # "Test copying & renaming group"
-  ADD_H5_TEST (grp_rename 0 ${HDF_FILE1}.h5 "" "" "" -v -s grp_dsets -d grp_rename)
+  ADD_H5_TEST (grp_rename 0 ${HDF_FILE1}.h5 FALSE "" "" "" -v -s grp_dsets -d grp_rename)
   # "Test copying 'full' group hierarchy into group in destination file"
-  ADD_H5_TEST (grp_dsets_rename 0 ${HDF_FILE1}.h5 grp_dsets grp_rename "" -v -s grp_dsets -d /grp_rename/grp_dsets)
+  ADD_H5_TEST (grp_dsets_rename 0 ${HDF_FILE1}.h5 FALSE grp_dsets grp_rename "" -v -s grp_dsets -d /grp_rename/grp_dsets)
 else ()
   # "Test copying & renaming group"
-  ADD_H5_TEST (grp_rename 2 ${HDF_FILE1}.h5 "" "" "" -v -s grp_dsets -d grp_rename)
+  ADD_H5_TEST (grp_rename 2 ${HDF_FILE1}.h5 FALSE "" "" "" -v -s grp_dsets -d grp_rename)
   # "Test copying 'full' group hierarchy into group in destination file"
-  ADD_H5_TEST (grp_dsets_rename 2 ${HDF_FILE1}.h5 grp_dsets grp_rename "" -v -s grp_dsets -d /grp_rename/grp_dsets)
+  ADD_H5_TEST (grp_dsets_rename 2 ${HDF_FILE1}.h5 FALSE grp_dsets grp_rename "" -v -s grp_dsets -d /grp_rename/grp_dsets)
 endif ()
 
 # "Test copying objects into group that doesn't exist yet in destination file"
-ADD_H5_TEST (A_B1_simple 0 ${HDF_FILE1}.h5 "" "" "" -vp -s simple -d /A/B1/simple)
-ADD_H5_TEST (A_B2_simple2 0 ${HDF_FILE1}.h5 "" "" "" -vp -s simple -d /A/B2/simple2)
-ADD_H5_TEST (C_D_simple 0 ${HDF_FILE1}.h5 "" "" "" -vp -s /grp_dsets/simple -d /C/D/simple)
+ADD_H5_TEST (A_B1_simple 0 ${HDF_FILE1}.h5 FALSE "" "" "" -vp -s simple -d /A/B1/simple)
+ADD_H5_TEST (A_B2_simple2 0 ${HDF_FILE1}.h5 FALSE "" "" "" -vp -s simple -d /A/B2/simple2)
+ADD_H5_TEST (C_D_simple 0 ${HDF_FILE1}.h5 FALSE "" "" "" -vp -s /grp_dsets/simple -d /C/D/simple)
 if (USE_FILTER_DEFLATE)
-  ADD_H5_TEST (E_F_grp_dsets 0 ${HDF_FILE1}.h5 "" "" "" -vp -s /grp_dsets -d /E/F/grp_dsets)
-  ADD_H5_TEST (G_H_grp_nested 0 ${HDF_FILE1}.h5 "" "" "" -vp -s /grp_nested -d /G/H/grp_nested)
+  ADD_H5_TEST (E_F_grp_dsets 0 ${HDF_FILE1}.h5 FALSE "" "" "" -vp -s /grp_dsets -d /E/F/grp_dsets)
+  ADD_H5_TEST (G_H_grp_nested 0 ${HDF_FILE1}.h5 FALSE "" "" "" -vp -s /grp_nested -d /G/H/grp_nested)
 else ()
-  ADD_H5_TEST (E_F_grp_dsets 2 ${HDF_FILE1}.h5 "" "" "" -vp -s /grp_dsets -d /E/F/grp_dsets)
-  ADD_H5_TEST (G_H_grp_nested 2 ${HDF_FILE1}.h5 "" "" "" -vp -s /grp_nested -d /G/H/grp_nested)
+  ADD_H5_TEST (E_F_grp_dsets 2 ${HDF_FILE1}.h5 FALSE "" "" "" -vp -s /grp_dsets -d /E/F/grp_dsets)
+  ADD_H5_TEST (G_H_grp_nested 2 ${HDF_FILE1}.h5 FALSE "" "" "" -vp -s /grp_nested -d /G/H/grp_nested)
 endif ()
 
 ############# COPY REFERENCES ##############
 
 # "Test copying object and region references"
-ADD_H5_TEST (region_ref 2 ${HDF_FILE2}.h5 "" "" ref -v -s / -d /COPY)
+ADD_H5_TEST (region_ref 2 ${HDF_FILE2}.h5 FALSE "" "" ref -v -s / -d /COPY)
 
 ############# COPY EXT LINKS ##############
 
 # "Test copying external link directly without -f ext"
-ADD_H5_TEST (ext_link 2 ${HDF_EXT_SRC_FILE}.h5 "" "" "" -v -s /group_ext/extlink_dset -d /copy1_dset)
+ADD_H5_TEST (ext_link 2 ${HDF_EXT_SRC_FILE}.h5 FALSE "" "" "" -v -s /group_ext/extlink_dset -d /copy1_dset)
 
 # "Test copying external link directly with -f ext"
-ADD_H5_TEST (ext_link_f 2 ${HDF_EXT_SRC_FILE}.h5 "" "" ext -v -s /group_ext/extlink_dset -d /copy2_dset)
+ADD_H5_TEST (ext_link_f 2 ${HDF_EXT_SRC_FILE}.h5 FALSE "" "" ext -v -s /group_ext/extlink_dset -d /copy2_dset)
 
 # "Test copying dangling external link (no obj) directly without -f ext"
-ADD_H5_TEST (ext_dangle_noobj 2 ${HDF_EXT_SRC_FILE}.h5 "" "" "" -v -s /group_ext/extlink_notyet1 -d /copy_dangle1_1)
+ADD_H5_TEST (ext_dangle_noobj 2 ${HDF_EXT_SRC_FILE}.h5 FALSE "" "" "" -v -s /group_ext/extlink_notyet1 -d /copy_dangle1_1)
 
 # "Test copying dangling external link (no obj) directly with -f ext"
-ADD_H5_TEST (ext_dangle_noobj_f 2 ${HDF_EXT_SRC_FILE}.h5 "" "" ext -v -s /group_ext/extlink_notyet1 -d /copy_dangle1_2)
+ADD_H5_TEST (ext_dangle_noobj_f 2 ${HDF_EXT_SRC_FILE}.h5 FALSE "" "" ext -v -s /group_ext/extlink_notyet1 -d /copy_dangle1_2)
 
 # "Test copying dangling external link (no file) directly without -f ext"
-ADD_H5_TEST (ext_dangle_nofile 2 ${HDF_EXT_SRC_FILE}.h5 "" "" "" -v -s /group_ext/extlink_notyet2 -d /copy_dangle2_1)
+ADD_H5_TEST (ext_dangle_nofile 2 ${HDF_EXT_SRC_FILE}.h5 FALSE "" "" "" -v -s /group_ext/extlink_notyet2 -d /copy_dangle2_1)
 
 # "Test copying dangling external link (no file) directly with -f ext"
-ADD_H5_TEST (ext_dangle_nofile_f 2 ${HDF_EXT_SRC_FILE}.h5 "" "" ext -v -s /group_ext/extlink_notyet2 -d /copy_dangle2_2)
+ADD_H5_TEST (ext_dangle_nofile_f 2 ${HDF_EXT_SRC_FILE}.h5 FALSE "" "" ext -v -s /group_ext/extlink_notyet2 -d /copy_dangle2_2)
 
 # "Test copying a group contains external links without -f ext"
-ADD_H5_TEST (ext_link_group 2 ${HDF_EXT_SRC_FILE}.h5 "" "" "" -v -s /group_ext -d /copy1_group)
+ADD_H5_TEST (ext_link_group 2 ${HDF_EXT_SRC_FILE}.h5 FALSE "" "" "" -v -s /group_ext -d /copy1_group)
 
 # "Test copying a group contains external links with -f ext"
-ADD_H5_TEST (ext_link_group_f 2 ${HDF_EXT_SRC_FILE}.h5 "" "" ext -v -s /group_ext -d /copy2_group)
+ADD_H5_TEST (ext_link_group_f 2 ${HDF_EXT_SRC_FILE}.h5 FALSE "" "" ext -v -s /group_ext -d /copy2_group)
 
 ############# Test misc. ##############
 
@@ -529,12 +498,12 @@ ADD_H5_CMP_TEST (h5copy_misc1 1 "h5copy error" ${HDF_FILE1}.h5 -v -s /simple -d 
 # "Test copying objects to the same file "
 #
 # - dataset
-ADD_H5_TEST_SAME (samefile1 0 ${HDF_FILE1}.h5 /simple /simple -v -s /simple -d /simple_cp)
+ADD_H5_TEST (samefile1 0 ${HDF_FILE1}.h5 TRUE /simple /simple "" -v -s /simple -d /simple_cp)
 # - group with some datasets
 if (USE_FILTER_DEFLATE)
-  ADD_H5_TEST_SAME (samefile2 0 ${HDF_FILE1}.h5 /grp_dsets /grp_dsets -v -s /grp_dsets -d /grp_dsets_cp)
+  ADD_H5_TEST (samefile2 0 ${HDF_FILE1}.h5 TRUE /grp_dsets /grp_dsets "" -v -s /grp_dsets -d /grp_dsets_cp)
 else ()
-  ADD_H5_TEST_SAME (samefile2 2 ${HDF_FILE1}.h5 /grp_dsets /grp_dsets -v -s /grp_dsets -d /grp_dsets_cp)
+  ADD_H5_TEST (samefile2 2 ${HDF_FILE1}.h5 TRUE /grp_dsets /grp_dsets "" -v -s /grp_dsets -d /grp_dsets_cp)
 endif ()
 
 ##############################################################################

--- a/tools/test/h5copy/CMakeTests.cmake
+++ b/tools/test/h5copy/CMakeTests.cmake
@@ -58,31 +58,76 @@ add_custom_target(h5copy_files ALL COMMENT "Copying files needed by h5copy tests
 
 #
 # Perform h5copy according to passing parameters
-# testname - name of test to add
-# resultcode - expected resultcode after test execution
-# result_errcheck - if provided, compare the error output of the test to the file with this name
-# infile - name of input file
-# sameflag - flag indicating whether the input/output file should be the same for the main test. TRUE or FALSE.
-# psparam - source file for optional prefill test. must be paired with nonempty pdparam.
-# pdparam - dest file for optional prefill test. must be paired with nonempty psparam.
-# fparam - optional value to pass to h5copy's "-f" argument. "" for no flag.
-# vparam - optional verbose argument to h5copy. "-v" or ""
-# sparam - "source" argument to h5copy. should always be "-s"
-# srcname - name of src for h5copy
-# dparam - "dest" argument to h5copy. should always be "-d"
-# dstname - name of dest for h5copy
 #
-macro (ADD_H5_TEST testname resultcode result_errcheck infile sameflag psparam pdparam fparam vparam sparam srcname dparam dstname)
-  if (NOT "${fparam}" STREQUAL "")
-    set (fparam_flag "-f")
-  else()
-    set (fparam_flag "")
+# Usage: ADD_H5_TEST(<testname> <required_args> [optional_args] [flags])
+#
+# REQUIRED POSITIONAL ARGUMENT:
+#   testname - name of test to add
+#
+# REQUIRED KEYWORD ARGUMENTS (must specify value):
+#   RESULT_CODE <code>    - expected return code after test execution (0, 1, or 2)
+#   INPUT_FILE <file>     - name of input HDF5 file
+#   SOURCE_NAME <name>    - source object name/path for h5copy
+#   DEST_NAME <name>      - destination object name/path for h5copy
+#
+# OPTIONAL KEYWORD ARGUMENTS (must specify value):
+#   ERROR_CHECK <file>    - if provided, compare error output to this reference file
+#   FORCE_FLAG <value>    - value to pass to h5copy's "-f" argument (e.g., "ref", "ext")
+#   PREFILL_SRC <name>    - source object for optional prefill test (requires PREFILL_DEST)
+#   PREFILL_DEST <name>   - destination object for optional prefill test (requires PREFILL_SRC)
+#
+# OPTIONAL FLAGS (no value, presence indicates true):
+#   SAME_FILE            - use output file as input for main test (for same-file operations)
+#   VERBOSE              - add "-v" verbose flag to h5copy command
+#
+# NOTES:
+#   - PREFILL_SRC and PREFILL_DEST must be used together or not at all
+#   - RESULT_CODE=2 will skip the diff verification test
+#   - Additional arguments can be passed after all keywords (e.g., "-p" flag)
+#
+macro (ADD_H5_TEST testname)
+  cmake_parse_arguments(ARG
+    "SAME_FILE;VERBOSE"
+    "RESULT_CODE;ERROR_CHECK;INPUT_FILE;FORCE_FLAG;PREFILL_SRC;PREFILL_DEST;SOURCE_NAME;DEST_NAME"
+    ""
+    ${ARGN}
+  )
+  
+  # Validate required parameters
+  if (NOT DEFINED ARG_RESULT_CODE)
+    message(FATAL_ERROR "ADD_H5_TEST: RESULT_CODE is required")
+  endif ()
+  if (NOT DEFINED ARG_INPUT_FILE)
+    message(FATAL_ERROR "ADD_H5_TEST: INPUT_FILE is required")
+  endif ()
+  if (NOT DEFINED ARG_SOURCE_NAME)
+    message(FATAL_ERROR "ADD_H5_TEST: SOURCE_NAME is required")
+  endif ()
+  if (NOT DEFINED ARG_DEST_NAME)
+    message(FATAL_ERROR "ADD_H5_TEST: DEST_NAME is required")
   endif ()
 
-  if (${sameflag})
+  # Set up force flag
+  if (DEFINED ARG_FORCE_FLAG AND NOT "${ARG_FORCE_FLAG}" STREQUAL "")
+    set (fparam_flag "-f")
+    set (fparam "${ARG_FORCE_FLAG}")
+  else()
+    set (fparam_flag "")
+    set (fparam "")
+  endif ()
+
+  # Set up verbose flag
+  if (ARG_VERBOSE)
+    set (vparam "-v")
+  else()
+    set (vparam "")
+  endif ()
+
+  # Determine input file for main test
+  if (ARG_SAME_FILE)
     set (main_infile "${testname}.out.h5")
   else()
-    set (main_infile "${infile}")
+    set (main_infile "${ARG_INPUT_FILE}")
   endif()
 
   # Remove any output file left over from previous test run
@@ -92,14 +137,14 @@ macro (ADD_H5_TEST testname resultcode result_errcheck infile sameflag psparam p
   )
 
   # Optional prefill sub-test, to be done before main test
-  if (NOT "${psparam}" STREQUAL "" OR NOT "${pdparam}" STREQUAL "")
-    if ("${psparam}" STREQUAL "" OR "${pdparam}" STREQUAL "")
-      message(FATAL_ERROR "Prefill test requires prefill src and prefill dest")
+  if (DEFINED ARG_PREFILL_SRC OR DEFINED ARG_PREFILL_DEST)
+    if (NOT DEFINED ARG_PREFILL_SRC OR NOT DEFINED ARG_PREFILL_DEST)
+      message(FATAL_ERROR "Prefill test requires both PREFILL_SRC and PREFILL_DEST")
     endif ()
 
     add_test (
       NAME H5COPY-${testname}-prefill
-      COMMAND ${CMAKE_CROSSCOMPILING_EMULATOR} $<TARGET_FILE:h5copy> -i ./testfiles/${infile} -o ./testfiles/${testname}.out.h5 -v -s ${psparam} -d ${pdparam}
+      COMMAND ${CMAKE_CROSSCOMPILING_EMULATOR} $<TARGET_FILE:h5copy> -i ./testfiles/${ARG_INPUT_FILE} -o ./testfiles/${testname}.out.h5 -v -s ${ARG_PREFILL_SRC} -d ${ARG_PREFILL_DEST}
     )
     set_tests_properties (H5COPY-${testname}-prefill PROPERTIES
       DEPENDS H5COPY-${testname}-clear-objects
@@ -113,10 +158,10 @@ macro (ADD_H5_TEST testname resultcode result_errcheck infile sameflag psparam p
 
   # No error check
   # Force this behavior if memchecker enabled
-  if ("${result_errcheck}" STREQUAL "" OR HDF5_ENABLE_USING_MEMCHECKER)
+  if (NOT DEFINED ARG_ERROR_CHECK OR "${ARG_ERROR_CHECK}" STREQUAL "" OR HDF5_ENABLE_USING_MEMCHECKER)
     add_test (
         NAME H5COPY-${testname}
-        COMMAND ${CMAKE_CROSSCOMPILING_EMULATOR} $<TARGET_FILE:h5copy> ${fparam_flag} ${fparam} -i ./testfiles/${main_infile} -o ./testfiles/${testname}.out.h5 ${vparam} ${sparam} ${srcname} ${dparam} ${dstname} ${ARGN}
+        COMMAND ${CMAKE_CROSSCOMPILING_EMULATOR} $<TARGET_FILE:h5copy> ${fparam_flag} ${fparam} -i ./testfiles/${main_infile} -o ./testfiles/${testname}.out.h5 ${vparam} -s ${ARG_SOURCE_NAME} -d ${ARG_DEST_NAME} ${ARG_UNPARSED_ARGUMENTS}
     )
   else() # Perform the same test with error checking
     add_test (
@@ -124,12 +169,12 @@ macro (ADD_H5_TEST testname resultcode result_errcheck infile sameflag psparam p
       COMMAND "${CMAKE_COMMAND}"
           -D "TEST_EMULATOR=${CMAKE_CROSSCOMPILING_EMULATOR}"
           -D "TEST_PROGRAM=$<TARGET_FILE:h5copy>"
-          -D "TEST_ARGS=${fparam_flag};${fparam};-i;./testfiles/${main_infile};-o;./testfiles/${testname}.out.h5;${vparam};${sparam};${srcname};${dparam};${dstname}"
+          -D "TEST_ARGS=${fparam_flag};${fparam};-i;./testfiles/${main_infile};-o;./testfiles/${testname}.out.h5;${vparam};-s;${ARG_SOURCE_NAME};-d;${ARG_DEST_NAME}"
           -D "TEST_FOLDER=${PROJECT_BINARY_DIR}"
           -D "TEST_OUTPUT=./testfiles/${testname}.out.out"
-          -D "TEST_EXPECT=${resultcode}"
+          -D "TEST_EXPECT=${ARG_RESULT_CODE}"
           -D "TEST_REFERENCE=./testfiles/${testname}.out"
-          -D "TEST_ERRREF=${result_errcheck}"
+          -D "TEST_ERRREF=${ARG_ERROR_CHECK}"
           -D "TEST_MASK_STORE=true"
           -D "TEST_GREP_COMPARE=TRUE"
           -P "${HDF_RESOURCES_DIR}/runTest.cmake"
@@ -143,14 +188,14 @@ macro (ADD_H5_TEST testname resultcode result_errcheck infile sameflag psparam p
     set_tests_properties (H5COPY-${testname} PROPERTIES DISABLED true)
   endif ()
 
-  # resultcode=2 will cause the test to skip the diff test
-  if (NOT "${resultcode}" STREQUAL "2")
+  # Skip diff test if result code is 2
+  if (NOT "${ARG_RESULT_CODE}" STREQUAL "2")
     add_test (
         NAME H5COPY-${testname}-DIFF
-        COMMAND ${CMAKE_CROSSCOMPILING_EMULATOR} $<TARGET_FILE:h5diff> -v ./testfiles/${main_infile} ./testfiles/${testname}.out.h5 ${srcname} ${dstname}
+        COMMAND ${CMAKE_CROSSCOMPILING_EMULATOR} $<TARGET_FILE:h5diff> -v ./testfiles/${main_infile} ./testfiles/${testname}.out.h5 ${ARG_SOURCE_NAME} ${ARG_DEST_NAME}
     )
     set_tests_properties (H5COPY-${testname}-DIFF PROPERTIES DEPENDS H5COPY-${testname})
-    if ("${resultcode}" STREQUAL "1")
+    if ("${ARG_RESULT_CODE}" STREQUAL "1")
       set_tests_properties (H5COPY-${testname}-DIFF PROPERTIES WILL_FAIL "true")
     endif ()
     if ("H5COPY-${testname}-DIFF" MATCHES "${HDF5_DISABLE_TESTS_REGEX}")
@@ -161,7 +206,7 @@ macro (ADD_H5_TEST testname resultcode result_errcheck infile sameflag psparam p
       NAME H5COPY-${testname}-clean-objects
       COMMAND ${CMAKE_COMMAND} -E remove ./testfiles/${testname}.out.h5
   )
-  if (NOT "${resultcode}" STREQUAL "2")
+  if (NOT "${ARG_RESULT_CODE}" STREQUAL "2")
     set_tests_properties (H5COPY-${testname}-clean-objects PROPERTIES DEPENDS H5COPY-${testname}-DIFF)
   else ()
     set_tests_properties (H5COPY-${testname}-clean-objects PROPERTIES DEPENDS H5COPY-${testname})
@@ -356,113 +401,113 @@ ADD_SIMPLE_TEST (h5copy_help1 0 -h)
 ADD_SIMPLE_TEST (h5copy_help2 0 --help)
 
 # "Test copying various forms of datasets"
-ADD_H5_TEST (simple 0 "" ${HDF_FILE1}.h5 FALSE "" "" "" -v -s simple -d simple)
-ADD_H5_TEST (chunk 0 "" ${HDF_FILE1}.h5 FALSE "" "" "" -v -s chunk -d chunk)
-ADD_H5_TEST (compact 0 "" ${HDF_FILE1}.h5 FALSE "" "" "" -v -s compact -d compact)
-ADD_H5_TEST (compound 0 "" ${HDF_FILE1}.h5 FALSE "" "" "" -v -s compound -d compound)
+ADD_H5_TEST (simple RESULT_CODE 0 INPUT_FILE ${HDF_FILE1}.h5 VERBOSE SOURCE_NAME simple DEST_NAME simple)
+ADD_H5_TEST (chunk RESULT_CODE 0 INPUT_FILE ${HDF_FILE1}.h5 VERBOSE SOURCE_NAME chunk DEST_NAME chunk)
+ADD_H5_TEST (compact RESULT_CODE 0 INPUT_FILE ${HDF_FILE1}.h5 VERBOSE SOURCE_NAME compact DEST_NAME compact)
+ADD_H5_TEST (compound RESULT_CODE 0 INPUT_FILE ${HDF_FILE1}.h5 VERBOSE SOURCE_NAME compound DEST_NAME compound)
 
 if (USE_FILTER_DEFLATE)
-  ADD_H5_TEST (compressed 0 "" ${HDF_FILE1}.h5 FALSE "" "" "" -v -s compressed -d compressed)
+  ADD_H5_TEST (compressed RESULT_CODE 0 INPUT_FILE ${HDF_FILE1}.h5 VERBOSE SOURCE_NAME compressed DEST_NAME compressed)
 else ()
-  ADD_H5_TEST (compressed 2 "" ${HDF_FILE1}.h5 FALSE "" "" "" -v -s compressed -d compressed)
+  ADD_H5_TEST (compressed RESULT_CODE 2 INPUT_FILE ${HDF_FILE1}.h5 VERBOSE SOURCE_NAME compressed DEST_NAME compressed)
 endif ()
 
-ADD_H5_TEST (named_vl 0 "" ${HDF_FILE1}.h5 FALSE "" "" "" -v -s named_vl -d named_vl)
-ADD_H5_TEST (nested_vl 0 "" ${HDF_FILE1}.h5 FALSE "" "" "" -v -s nested_vl -d nested_vl)
-ADD_H5_TEST (dset_attr 0 "" ${HDF_FILE1}.h5 FALSE "" "" "" -v -s dset_attr -d dset_attr)
+ADD_H5_TEST (named_vl RESULT_CODE 0 INPUT_FILE ${HDF_FILE1}.h5 VERBOSE SOURCE_NAME named_vl DEST_NAME named_vl)
+ADD_H5_TEST (nested_vl RESULT_CODE 0 INPUT_FILE ${HDF_FILE1}.h5 VERBOSE SOURCE_NAME nested_vl DEST_NAME nested_vl)
+ADD_H5_TEST (dset_attr RESULT_CODE 0 INPUT_FILE ${HDF_FILE1}.h5 VERBOSE SOURCE_NAME dset_attr DEST_NAME dset_attr)
 
 # "Test copying dataset within group in source file to root of destination"
-ADD_H5_TEST (simple_top 0 "" ${HDF_FILE1}.h5 FALSE "" "" "" -v -s grp_dsets/simple -d simple_top)
+ADD_H5_TEST (simple_top RESULT_CODE 0 INPUT_FILE ${HDF_FILE1}.h5 VERBOSE SOURCE_NAME grp_dsets/simple DEST_NAME simple_top)
 
 # "Test copying & renaming dataset"
-ADD_H5_TEST (dsrename 0 "" ${HDF_FILE1}.h5 FALSE "" "" "" -v -s compound -d rename)
+ADD_H5_TEST (dsrename RESULT_CODE 0 INPUT_FILE ${HDF_FILE1}.h5 VERBOSE SOURCE_NAME compound DEST_NAME rename)
 
 # "Test copying empty, 'full' & 'nested' groups"
-ADD_H5_TEST (grp_empty 0 "" ${HDF_FILE1}.h5 FALSE "" "" "" -v -s grp_empty -d grp_empty)
+ADD_H5_TEST (grp_empty RESULT_CODE 0 INPUT_FILE ${HDF_FILE1}.h5 VERBOSE SOURCE_NAME grp_empty DEST_NAME grp_empty)
 if (USE_FILTER_DEFLATE)
-  ADD_H5_TEST (grp_dsets 0 "" ${HDF_FILE1}.h5 FALSE "" "" "" -v -s grp_dsets -d grp_dsets)
-  ADD_H5_TEST (grp_nested 0 "" ${HDF_FILE1}.h5 FALSE "" "" "" -v -s grp_nested -d grp_nested)
+  ADD_H5_TEST (grp_dsets RESULT_CODE 0 INPUT_FILE ${HDF_FILE1}.h5 VERBOSE SOURCE_NAME grp_dsets DEST_NAME grp_dsets)
+  ADD_H5_TEST (grp_nested RESULT_CODE 0 INPUT_FILE ${HDF_FILE1}.h5 VERBOSE SOURCE_NAME grp_nested DEST_NAME grp_nested)
 else ()
-  ADD_H5_TEST (grp_dsets 2 "" ${HDF_FILE1}.h5 FALSE "" "" "" -v -s grp_dsets -d grp_dsets)
-  ADD_H5_TEST (grp_nested 2 "" ${HDF_FILE1}.h5 FALSE "" "" "" -v -s grp_nested -d grp_nested)
+  ADD_H5_TEST (grp_dsets RESULT_CODE 2 INPUT_FILE ${HDF_FILE1}.h5 VERBOSE SOURCE_NAME grp_dsets DEST_NAME grp_dsets)
+  ADD_H5_TEST (grp_nested RESULT_CODE 2 INPUT_FILE ${HDF_FILE1}.h5 VERBOSE SOURCE_NAME grp_nested DEST_NAME grp_nested)
 endif ()
-ADD_H5_TEST (grp_attr 0 "" ${HDF_FILE1}.h5 FALSE "" "" "" -v -s grp_attr -d grp_attr)
+ADD_H5_TEST (grp_attr RESULT_CODE 0 INPUT_FILE ${HDF_FILE1}.h5 VERBOSE SOURCE_NAME grp_attr DEST_NAME grp_attr)
 
 # "Test copying dataset within group in source file to group in destination"
-ADD_H5_TEST (simple_group 0 "" ${HDF_FILE1}.h5 FALSE grp_dsets grp_dsets "" -v -s /grp_dsets/simple -d /grp_dsets/simple_group)
+ADD_H5_TEST (simple_group RESULT_CODE 0 INPUT_FILE ${HDF_FILE1}.h5 PREFILL_SRC grp_dsets PREFILL_DEST grp_dsets VERBOSE SOURCE_NAME /grp_dsets/simple DEST_NAME /grp_dsets/simple_group)
 
 if (USE_FILTER_DEFLATE)
   # "Test copying & renaming group"
-  ADD_H5_TEST (grp_rename 0 "" ${HDF_FILE1}.h5 FALSE "" "" "" -v -s grp_dsets -d grp_rename)
+  ADD_H5_TEST (grp_rename RESULT_CODE 0 INPUT_FILE ${HDF_FILE1}.h5 VERBOSE SOURCE_NAME grp_dsets DEST_NAME grp_rename)
   # "Test copying 'full' group hierarchy into group in destination file"
-  ADD_H5_TEST (grp_dsets_rename 0 "" ${HDF_FILE1}.h5 FALSE grp_dsets grp_rename "" -v -s grp_dsets -d /grp_rename/grp_dsets)
+  ADD_H5_TEST (grp_dsets_rename RESULT_CODE 0 INPUT_FILE ${HDF_FILE1}.h5 PREFILL_SRC grp_dsets PREFILL_DEST grp_rename VERBOSE SOURCE_NAME grp_dsets DEST_NAME /grp_rename/grp_dsets)
 else ()
   # "Test copying & renaming group"
-  ADD_H5_TEST (grp_rename 2 "" ${HDF_FILE1}.h5 FALSE "" "" "" -v -s grp_dsets -d grp_rename)
+  ADD_H5_TEST (grp_rename RESULT_CODE 2 INPUT_FILE ${HDF_FILE1}.h5 VERBOSE SOURCE_NAME grp_dsets DEST_NAME grp_rename)
   # "Test copying 'full' group hierarchy into group in destination file"
-  ADD_H5_TEST (grp_dsets_rename 2 "" ${HDF_FILE1}.h5 FALSE grp_dsets grp_rename "" -v -s grp_dsets -d /grp_rename/grp_dsets)
+  ADD_H5_TEST (grp_dsets_rename RESULT_CODE 2 INPUT_FILE ${HDF_FILE1}.h5 PREFILL_SRC grp_dsets PREFILL_DEST grp_rename VERBOSE SOURCE_NAME grp_dsets DEST_NAME /grp_rename/grp_dsets)
 endif ()
 
 # "Test copying objects into group that doesn't exist yet in destination file"
-ADD_H5_TEST (A_B1_simple 0 "" ${HDF_FILE1}.h5 FALSE "" "" "" -vp -s simple -d /A/B1/simple)
-ADD_H5_TEST (A_B2_simple2 0 "" ${HDF_FILE1}.h5 FALSE "" "" "" -vp -s simple -d /A/B2/simple2)
-ADD_H5_TEST (C_D_simple 0 "" ${HDF_FILE1}.h5 FALSE "" "" "" -vp -s /grp_dsets/simple -d /C/D/simple)
+ADD_H5_TEST (A_B1_simple RESULT_CODE 0 INPUT_FILE ${HDF_FILE1}.h5 VERBOSE SOURCE_NAME simple DEST_NAME /A/B1/simple -p)
+ADD_H5_TEST (A_B2_simple2 RESULT_CODE 0 INPUT_FILE ${HDF_FILE1}.h5 VERBOSE SOURCE_NAME simple DEST_NAME /A/B2/simple2 -p)
+ADD_H5_TEST (C_D_simple RESULT_CODE 0 INPUT_FILE ${HDF_FILE1}.h5 VERBOSE SOURCE_NAME /grp_dsets/simple DEST_NAME /C/D/simple -p)
 if (USE_FILTER_DEFLATE)
-  ADD_H5_TEST (E_F_grp_dsets 0 "" ${HDF_FILE1}.h5 FALSE "" "" "" -vp -s /grp_dsets -d /E/F/grp_dsets)
-  ADD_H5_TEST (G_H_grp_nested 0 "" ${HDF_FILE1}.h5 FALSE "" "" "" -vp -s /grp_nested -d /G/H/grp_nested)
+  ADD_H5_TEST (E_F_grp_dsets RESULT_CODE 0 INPUT_FILE ${HDF_FILE1}.h5 VERBOSE SOURCE_NAME /grp_dsets DEST_NAME /E/F/grp_dsets -p)
+  ADD_H5_TEST (G_H_grp_nested RESULT_CODE 0 INPUT_FILE ${HDF_FILE1}.h5 VERBOSE SOURCE_NAME /grp_nested DEST_NAME /G/H/grp_nested -p)
 else ()
-  ADD_H5_TEST (E_F_grp_dsets 2 "" ${HDF_FILE1}.h5 FALSE "" "" "" -vp -s /grp_dsets -d /E/F/grp_dsets)
-  ADD_H5_TEST (G_H_grp_nested 2 "" ${HDF_FILE1}.h5 FALSE "" "" "" -vp -s /grp_nested -d /G/H/grp_nested)
+  ADD_H5_TEST (E_F_grp_dsets RESULT_CODE 2 INPUT_FILE ${HDF_FILE1}.h5 VERBOSE SOURCE_NAME /grp_dsets DEST_NAME /E/F/grp_dsets -p)
+  ADD_H5_TEST (G_H_grp_nested RESULT_CODE 2 INPUT_FILE ${HDF_FILE1}.h5 VERBOSE SOURCE_NAME /grp_nested DEST_NAME /G/H/grp_nested -p)
 endif ()
 
 ############# COPY REFERENCES ##############
 
 # "Test copying object and region references"
-ADD_H5_TEST (region_ref 2 "" ${HDF_FILE2}.h5 FALSE "" "" ref -v -s / -d /COPY)
+ADD_H5_TEST (region_ref RESULT_CODE 2 INPUT_FILE ${HDF_FILE2}.h5 FORCE_FLAG ref VERBOSE SOURCE_NAME / DEST_NAME /COPY)
 
 ############# COPY EXT LINKS ##############
 
 # "Test copying external link directly without -f ext"
-ADD_H5_TEST (ext_link 2 "" ${HDF_EXT_SRC_FILE}.h5 FALSE "" "" "" -v -s /group_ext/extlink_dset -d /copy1_dset)
+ADD_H5_TEST (ext_link RESULT_CODE 2 INPUT_FILE ${HDF_EXT_SRC_FILE}.h5 VERBOSE SOURCE_NAME /group_ext/extlink_dset DEST_NAME /copy1_dset)
 
 # "Test copying external link directly with -f ext"
-ADD_H5_TEST (ext_link_f 2 "" ${HDF_EXT_SRC_FILE}.h5 FALSE "" "" ext -v -s /group_ext/extlink_dset -d /copy2_dset)
+ADD_H5_TEST (ext_link_f RESULT_CODE 2 INPUT_FILE ${HDF_EXT_SRC_FILE}.h5 FORCE_FLAG ext VERBOSE SOURCE_NAME /group_ext/extlink_dset DEST_NAME /copy2_dset)
 
 # "Test copying dangling external link (no obj) directly without -f ext"
-ADD_H5_TEST (ext_dangle_noobj 2 "" ${HDF_EXT_SRC_FILE}.h5 FALSE "" "" "" -v -s /group_ext/extlink_notyet1 -d /copy_dangle1_1)
+ADD_H5_TEST (ext_dangle_noobj RESULT_CODE 2 INPUT_FILE ${HDF_EXT_SRC_FILE}.h5 VERBOSE SOURCE_NAME /group_ext/extlink_notyet1 DEST_NAME /copy_dangle1_1)
 
 # "Test copying dangling external link (no obj) directly with -f ext"
-ADD_H5_TEST (ext_dangle_noobj_f 2 "" ${HDF_EXT_SRC_FILE}.h5 FALSE "" "" ext -v -s /group_ext/extlink_notyet1 -d /copy_dangle1_2)
+ADD_H5_TEST (ext_dangle_noobj_f RESULT_CODE 2 INPUT_FILE ${HDF_EXT_SRC_FILE}.h5 FORCE_FLAG ext VERBOSE SOURCE_NAME /group_ext/extlink_notyet1 DEST_NAME /copy_dangle1_2)
 
 # "Test copying dangling external link (no file) directly without -f ext"
-ADD_H5_TEST (ext_dangle_nofile 2 "" ${HDF_EXT_SRC_FILE}.h5 FALSE "" "" "" -v -s /group_ext/extlink_notyet2 -d /copy_dangle2_1)
+ADD_H5_TEST (ext_dangle_nofile RESULT_CODE 2 INPUT_FILE ${HDF_EXT_SRC_FILE}.h5 VERBOSE SOURCE_NAME /group_ext/extlink_notyet2 DEST_NAME /copy_dangle2_1)
 
 # "Test copying dangling external link (no file) directly with -f ext"
-ADD_H5_TEST (ext_dangle_nofile_f 2 "" ${HDF_EXT_SRC_FILE}.h5 FALSE "" "" ext -v -s /group_ext/extlink_notyet2 -d /copy_dangle2_2)
+ADD_H5_TEST (ext_dangle_nofile_f RESULT_CODE 2 INPUT_FILE ${HDF_EXT_SRC_FILE}.h5 FORCE_FLAG ext VERBOSE SOURCE_NAME /group_ext/extlink_notyet2 DEST_NAME /copy_dangle2_2)
 
 # "Test copying a group contains external links without -f ext"
-ADD_H5_TEST (ext_link_group 2 "" ${HDF_EXT_SRC_FILE}.h5 FALSE "" "" "" -v -s /group_ext -d /copy1_group)
+ADD_H5_TEST (ext_link_group RESULT_CODE 2 INPUT_FILE ${HDF_EXT_SRC_FILE}.h5 VERBOSE SOURCE_NAME /group_ext DEST_NAME /copy1_group)
 
 # "Test copying a group contains external links with -f ext"
-ADD_H5_TEST (ext_link_group_f 2 "" ${HDF_EXT_SRC_FILE}.h5 FALSE "" "" ext -v -s /group_ext -d /copy2_group)
+ADD_H5_TEST (ext_link_group_f RESULT_CODE 2 INPUT_FILE ${HDF_EXT_SRC_FILE}.h5 FORCE_FLAG ext VERBOSE SOURCE_NAME /group_ext DEST_NAME /copy2_group)
 
 ############# Test misc. ##############
 
 #-----------------------------------------------------------------
 # "Test copying object into group which doesn't exist, without -p"
 #
-ADD_H5_TEST (h5copy_misc1 1 "h5copy error" ${HDF_FILE1}.h5 FALSE "" "" "" -v -s /simple -d /g1/g2/simple)
+ADD_H5_TEST (h5copy_misc1 RESULT_CODE 1 ERROR_CHECK "h5copy error" INPUT_FILE ${HDF_FILE1}.h5 VERBOSE SOURCE_NAME /simple DEST_NAME /g1/g2/simple)
 
 #-------------------------------------------
 # "Test copying objects to the same file "
 #
 # - dataset
-ADD_H5_TEST (samefile1 0 "" ${HDF_FILE1}.h5 TRUE /simple /simple "" -v -s /simple -d /simple_cp)
+ADD_H5_TEST (samefile1 RESULT_CODE 0 INPUT_FILE ${HDF_FILE1}.h5 SAME_FILE PREFILL_SRC /simple PREFILL_DEST /simple VERBOSE SOURCE_NAME /simple DEST_NAME /simple_cp)
 # - group with some datasets
 if (USE_FILTER_DEFLATE)
-  ADD_H5_TEST (samefile2 0 "" ${HDF_FILE1}.h5 TRUE /grp_dsets /grp_dsets "" -v -s /grp_dsets -d /grp_dsets_cp)
+  ADD_H5_TEST (samefile2 RESULT_CODE 0 INPUT_FILE ${HDF_FILE1}.h5 SAME_FILE PREFILL_SRC /grp_dsets PREFILL_DEST /grp_dsets VERBOSE SOURCE_NAME /grp_dsets DEST_NAME /grp_dsets_cp)
 else ()
-  ADD_H5_TEST (samefile2 2 "" ${HDF_FILE1}.h5 TRUE /grp_dsets /grp_dsets "" -v -s /grp_dsets -d /grp_dsets_cp)
+  ADD_H5_TEST (samefile2 RESULT_CODE 2 INPUT_FILE ${HDF_FILE1}.h5 SAME_FILE PREFILL_SRC /grp_dsets PREFILL_DEST /grp_dsets VERBOSE SOURCE_NAME /grp_dsets DEST_NAME /grp_dsets_cp)
 endif ()
 
 ##############################################################################

--- a/tools/test/h5copy/CMakeTests.cmake
+++ b/tools/test/h5copy/CMakeTests.cmake
@@ -131,16 +131,6 @@ macro (ADD_H5_TEST testname resultcode infile psparam pdparam fparam vparam spar
   endif ()
 endmacro ()
 
-macro (ADD_SKIP_H5_TEST testname skipresultfile)
-  if (NOT HDF5_USING_ANALYSIS_TOOL)
-    add_test (
-        NAME H5COPY-${testname}-${skipresultfile}
-        COMMAND ${CMAKE_COMMAND} -E echo "SKIP ${testname}-${skipresultfile} ${ARGN}"
-    )
-    set_property(TEST H5COPY-${testname}-${skipresultfile} PROPERTY DISABLED true)
-  endif ()
-endmacro ()
-
 macro (ADD_H5_TEST_SAME testname resultcode pfile psparam pdparam vparam sparam srcname dparam dstname)
   # Remove any output file left over from previous test run
   add_test (

--- a/tools/test/h5copy/CMakeTests.cmake
+++ b/tools/test/h5copy/CMakeTests.cmake
@@ -59,48 +59,13 @@ add_custom_target(h5copy_files ALL COMMENT "Copying files needed by h5copy tests
 #
 # Perform h5copy according to passing parameters
 #
-macro (ADD_H5_F_TEST testname resultcode infile fparam vparam sparam srcname dparam dstname)
-  # Remove any output file left over from previous test run
-  add_test (
-      NAME H5COPY_F-${testname}-clear-objects
-      COMMAND ${CMAKE_COMMAND} -E remove ./testfiles/${testname}.out.h5
-  )
-
-  add_test (
-      NAME H5COPY_F-${testname}
-      COMMAND ${CMAKE_CROSSCOMPILING_EMULATOR} $<TARGET_FILE:h5copy> -f ${fparam} -i ./testfiles/${infile} -o ./testfiles/${testname}.out.h5 ${vparam} ${sparam} ${srcname} ${dparam} ${dstname} ${ARGN}
-  )
-  set_tests_properties (H5COPY_F-${testname} PROPERTIES DEPENDS H5COPY_F-${testname}-clear-objects)
-  if ("H5COPY_F-${testname}" MATCHES "${HDF5_DISABLE_TESTS_REGEX}")
-    set_tests_properties (H5COPY_F-${testname} PROPERTIES DISABLED true)
+macro (ADD_H5_TEST testname resultcode infile fparam vparam sparam srcname dparam dstname)
+  if (NOT "${fparam}" STREQUAL "")
+    set (fparam_flag "-f")
+  else()
+    set (fparam_flag "")  
   endif ()
 
-  # resultcode=2 will cause the test to skip the diff test
-  if (NOT "${resultcode}" STREQUAL "2")
-    add_test (
-        NAME H5COPY_F-${testname}-DIFF
-        COMMAND ${CMAKE_CROSSCOMPILING_EMULATOR} $<TARGET_FILE:h5diff> -v ./testfiles/${infile} ./testfiles/${testname}.out.h5 ${srcname} ${dstname}
-    )
-    set_tests_properties (H5COPY_F-${testname}-DIFF PROPERTIES DEPENDS H5COPY_F-${testname})
-    if ("${resultcode}" STREQUAL "1")
-      set_tests_properties (H5COPY_F-${testname}-DIFF PROPERTIES WILL_FAIL "true")
-    endif ()
-    if ("H5COPY_F-${testname}-DIFF" MATCHES "${HDF5_DISABLE_TESTS_REGEX}")
-      set_tests_properties (H5COPY_F-${testname}-DIFF PROPERTIES DISABLED true)
-    endif ()
-  endif ()
-  add_test (
-      NAME H5COPY_F-${testname}-clean-objects
-      COMMAND ${CMAKE_COMMAND} -E remove ./testfiles/${testname}.out.h5
-  )
-  if (NOT "${resultcode}" STREQUAL "2")
-    set_tests_properties (H5COPY_F-${testname}-clean-objects PROPERTIES DEPENDS H5COPY_F-${testname}-DIFF)
-  else ()
-    set_tests_properties (H5COPY_F-${testname}-clean-objects PROPERTIES DEPENDS H5COPY_F-${testname})
-  endif ()
-endmacro ()
-
-macro (ADD_H5_TEST testname resultcode infile vparam sparam srcname dparam dstname)
   # Remove any output file left over from previous test run
   add_test (
       NAME H5COPY-${testname}-clear-objects
@@ -109,7 +74,7 @@ macro (ADD_H5_TEST testname resultcode infile vparam sparam srcname dparam dstna
 
   add_test (
       NAME H5COPY-${testname}
-      COMMAND ${CMAKE_CROSSCOMPILING_EMULATOR} $<TARGET_FILE:h5copy> -i ./testfiles/${infile} -o ./testfiles/${testname}.out.h5 ${vparam} ${sparam} ${srcname} ${dparam} ${dstname} ${ARGN}
+      COMMAND ${CMAKE_CROSSCOMPILING_EMULATOR} $<TARGET_FILE:h5copy> ${fparam_flag} ${fparam} -i ./testfiles/${infile} -o ./testfiles/${testname}.out.h5 ${vparam} ${sparam} ${srcname} ${dparam} ${dstname} ${ARGN}
   )
   set_tests_properties (H5COPY-${testname} PROPERTIES DEPENDS H5COPY-${testname}-clear-objects)
   if ("H5COPY-${testname}" MATCHES "${HDF5_DISABLE_TESTS_REGEX}")
@@ -497,95 +462,95 @@ ADD_SIMPLE_TEST (h5copy_help1 0 -h)
 ADD_SIMPLE_TEST (h5copy_help2 0 --help)
 
 # "Test copying various forms of datasets"
-ADD_H5_TEST (simple 0 ${HDF_FILE1}.h5 -v -s simple -d simple)
-ADD_H5_TEST (chunk 0 ${HDF_FILE1}.h5 -v -s chunk -d chunk)
-ADD_H5_TEST (compact 0 ${HDF_FILE1}.h5 -v -s compact -d compact)
-ADD_H5_TEST (compound 0 ${HDF_FILE1}.h5 -v -s compound -d compound)
+ADD_H5_TEST (simple 0 ${HDF_FILE1}.h5 "" -v -s simple -d simple)
+ADD_H5_TEST (chunk 0 ${HDF_FILE1}.h5 "" -v -s chunk -d chunk)
+ADD_H5_TEST (compact 0 ${HDF_FILE1}.h5 "" -v -s compact -d compact)
+ADD_H5_TEST (compound 0 ${HDF_FILE1}.h5 "" -v -s compound -d compound)
 
 if (USE_FILTER_DEFLATE)
-  ADD_H5_TEST (compressed 0 ${HDF_FILE1}.h5 -v -s compressed -d compressed)
+  ADD_H5_TEST (compressed 0 ${HDF_FILE1}.h5 "" -v -s compressed -d compressed)
 else ()
-  ADD_H5_TEST (compressed 2 ${HDF_FILE1}.h5 -v -s compressed -d compressed)
+  ADD_H5_TEST (compressed 2 ${HDF_FILE1}.h5 "" -v -s compressed -d compressed)
 endif ()
 
-ADD_H5_TEST (named_vl 0 ${HDF_FILE1}.h5 -v -s named_vl -d named_vl)
-ADD_H5_TEST (nested_vl 0 ${HDF_FILE1}.h5 -v -s nested_vl -d nested_vl)
-ADD_H5_TEST (dset_attr 0 ${HDF_FILE1}.h5 -v -s dset_attr -d dset_attr)
+ADD_H5_TEST (named_vl 0 ${HDF_FILE1}.h5 "" -v -s named_vl -d named_vl)
+ADD_H5_TEST (nested_vl 0 ${HDF_FILE1}.h5 "" -v -s nested_vl -d nested_vl)
+ADD_H5_TEST (dset_attr 0 ${HDF_FILE1}.h5 "" -v -s dset_attr -d dset_attr)
 
 # "Test copying dataset within group in source file to root of destination"
-ADD_H5_TEST (simple_top 0 ${HDF_FILE1}.h5 -v -s grp_dsets/simple -d simple_top)
+ADD_H5_TEST (simple_top 0 ${HDF_FILE1}.h5 "" -v -s grp_dsets/simple -d simple_top)
 
 # "Test copying & renaming dataset"
-ADD_H5_TEST (dsrename 0 ${HDF_FILE1}.h5 -v -s compound -d rename)
+ADD_H5_TEST (dsrename 0 ${HDF_FILE1}.h5 "" -v -s compound -d rename)
 
 # "Test copying empty, 'full' & 'nested' groups"
-ADD_H5_TEST (grp_empty 0 ${HDF_FILE1}.h5 -v -s grp_empty -d grp_empty)
+ADD_H5_TEST (grp_empty 0 ${HDF_FILE1}.h5 "" -v -s grp_empty -d grp_empty)
 if (USE_FILTER_DEFLATE)
-  ADD_H5_TEST (grp_dsets 0 ${HDF_FILE1}.h5 -v -s grp_dsets -d grp_dsets)
-  ADD_H5_TEST (grp_nested 0 ${HDF_FILE1}.h5 -v -s grp_nested -d grp_nested)
+  ADD_H5_TEST (grp_dsets 0 ${HDF_FILE1}.h5 "" -v -s grp_dsets -d grp_dsets)
+  ADD_H5_TEST (grp_nested 0 ${HDF_FILE1}.h5 "" -v -s grp_nested -d grp_nested)
 else ()
-  ADD_H5_TEST (grp_dsets 2 ${HDF_FILE1}.h5 -v -s grp_dsets -d grp_dsets)
-  ADD_H5_TEST (grp_nested 2 ${HDF_FILE1}.h5 -v -s grp_nested -d grp_nested)
+  ADD_H5_TEST (grp_dsets 2 ${HDF_FILE1}.h5 "" -v -s grp_dsets -d grp_dsets)
+  ADD_H5_TEST (grp_nested 2 ${HDF_FILE1}.h5 "" -v -s grp_nested -d grp_nested)
 endif ()
-ADD_H5_TEST (grp_attr 0 ${HDF_FILE1}.h5 -v -s grp_attr -d grp_attr)
+ADD_H5_TEST (grp_attr 0 ${HDF_FILE1}.h5 "" -v -s grp_attr -d grp_attr)
 
 # "Test copying dataset within group in source file to group in destination"
 ADD_H5_TEST2 (simple_group 0 ${HDF_FILE1}.h5 grp_dsets grp_dsets -v -s /grp_dsets/simple -d /grp_dsets/simple_group)
 
 if (USE_FILTER_DEFLATE)
   # "Test copying & renaming group"
-  ADD_H5_TEST (grp_rename 0 ${HDF_FILE1}.h5 -v -s grp_dsets -d grp_rename)
+  ADD_H5_TEST (grp_rename 0 ${HDF_FILE1}.h5 "" -v -s grp_dsets -d grp_rename)
   # "Test copying 'full' group hierarchy into group in destination file"
   ADD_H5_TEST2 (grp_dsets_rename 0 ${HDF_FILE1}.h5 grp_dsets grp_rename -v -s grp_dsets -d /grp_rename/grp_dsets)
 else ()
   # "Test copying & renaming group"
-  ADD_H5_TEST (grp_rename 2 ${HDF_FILE1}.h5 -v -s grp_dsets -d grp_rename)
+  ADD_H5_TEST (grp_rename 2 ${HDF_FILE1}.h5 "" -v -s grp_dsets -d grp_rename)
   # "Test copying 'full' group hierarchy into group in destination file"
   ADD_H5_TEST2 (grp_dsets_rename 2 ${HDF_FILE1}.h5 grp_dsets grp_rename -v -s grp_dsets -d /grp_rename/grp_dsets)
 endif ()
 
 # "Test copying objects into group that doesn't exist yet in destination file"
-ADD_H5_TEST (A_B1_simple 0 ${HDF_FILE1}.h5 -vp -s simple -d /A/B1/simple)
-ADD_H5_TEST (A_B2_simple2 0 ${HDF_FILE1}.h5 -vp -s simple -d /A/B2/simple2)
-ADD_H5_TEST (C_D_simple 0 ${HDF_FILE1}.h5 -vp -s /grp_dsets/simple -d /C/D/simple)
+ADD_H5_TEST (A_B1_simple 0 ${HDF_FILE1}.h5 "" -vp -s simple -d /A/B1/simple)
+ADD_H5_TEST (A_B2_simple2 0 ${HDF_FILE1}.h5 "" -vp -s simple -d /A/B2/simple2)
+ADD_H5_TEST (C_D_simple 0 ${HDF_FILE1}.h5 "" -vp -s /grp_dsets/simple -d /C/D/simple)
 if (USE_FILTER_DEFLATE)
-  ADD_H5_TEST (E_F_grp_dsets 0 ${HDF_FILE1}.h5 -vp -s /grp_dsets -d /E/F/grp_dsets)
-  ADD_H5_TEST (G_H_grp_nested 0 ${HDF_FILE1}.h5 -vp -s /grp_nested -d /G/H/grp_nested)
+  ADD_H5_TEST (E_F_grp_dsets 0 ${HDF_FILE1}.h5 "" -vp -s /grp_dsets -d /E/F/grp_dsets)
+  ADD_H5_TEST (G_H_grp_nested 0 ${HDF_FILE1}.h5 "" -vp -s /grp_nested -d /G/H/grp_nested)
 else ()
-  ADD_H5_TEST (E_F_grp_dsets 2 ${HDF_FILE1}.h5 -vp -s /grp_dsets -d /E/F/grp_dsets)
-  ADD_H5_TEST (G_H_grp_nested 2 ${HDF_FILE1}.h5 -vp -s /grp_nested -d /G/H/grp_nested)
+  ADD_H5_TEST (E_F_grp_dsets 2 ${HDF_FILE1}.h5 "" -vp -s /grp_dsets -d /E/F/grp_dsets)
+  ADD_H5_TEST (G_H_grp_nested 2 ${HDF_FILE1}.h5 "" -vp -s /grp_nested -d /G/H/grp_nested)
 endif ()
 
 ############# COPY REFERENCES ##############
 
 # "Test copying object and region references"
-ADD_H5_F_TEST (region_ref 2 ${HDF_FILE2}.h5 ref -v -s / -d /COPY)
+ADD_H5_TEST (region_ref 2 ${HDF_FILE2}.h5 ref -v -s / -d /COPY)
 
 ############# COPY EXT LINKS ##############
 
 # "Test copying external link directly without -f ext"
-ADD_H5_TEST (ext_link 2 ${HDF_EXT_SRC_FILE}.h5 -v -s /group_ext/extlink_dset -d /copy1_dset)
+ADD_H5_TEST (ext_link 2 ${HDF_EXT_SRC_FILE}.h5 "" -v -s /group_ext/extlink_dset -d /copy1_dset)
 
 # "Test copying external link directly with -f ext"
-ADD_H5_F_TEST (ext_link_f 2 ${HDF_EXT_SRC_FILE}.h5 ext -v -s /group_ext/extlink_dset -d /copy2_dset)
+ADD_H5_TEST (ext_link_f 2 ${HDF_EXT_SRC_FILE}.h5 ext -v -s /group_ext/extlink_dset -d /copy2_dset)
 
 # "Test copying dangling external link (no obj) directly without -f ext"
-ADD_H5_TEST (ext_dangle_noobj 2 ${HDF_EXT_SRC_FILE}.h5 -v -s /group_ext/extlink_notyet1 -d /copy_dangle1_1)
+ADD_H5_TEST (ext_dangle_noobj 2 ${HDF_EXT_SRC_FILE}.h5 "" -v -s /group_ext/extlink_notyet1 -d /copy_dangle1_1)
 
 # "Test copying dangling external link (no obj) directly with -f ext"
-ADD_H5_F_TEST (ext_dangle_noobj_f 2 ${HDF_EXT_SRC_FILE}.h5 ext -v -s /group_ext/extlink_notyet1 -d /copy_dangle1_2)
+ADD_H5_TEST (ext_dangle_noobj_f 2 ${HDF_EXT_SRC_FILE}.h5 ext -v -s /group_ext/extlink_notyet1 -d /copy_dangle1_2)
 
 # "Test copying dangling external link (no file) directly without -f ext"
-ADD_H5_TEST (ext_dangle_nofile 2 ${HDF_EXT_SRC_FILE}.h5 -v -s /group_ext/extlink_notyet2 -d /copy_dangle2_1)
+ADD_H5_TEST (ext_dangle_nofile 2 ${HDF_EXT_SRC_FILE}.h5 "" -v -s /group_ext/extlink_notyet2 -d /copy_dangle2_1)
 
 # "Test copying dangling external link (no file) directly with -f ext"
-ADD_H5_F_TEST (ext_dangle_nofile_f 2 ${HDF_EXT_SRC_FILE}.h5 ext -v -s /group_ext/extlink_notyet2 -d /copy_dangle2_2)
+ADD_H5_TEST (ext_dangle_nofile_f 2 ${HDF_EXT_SRC_FILE}.h5 ext -v -s /group_ext/extlink_notyet2 -d /copy_dangle2_2)
 
 # "Test copying a group contains external links without -f ext"
-ADD_H5_TEST (ext_link_group 2 ${HDF_EXT_SRC_FILE}.h5 -v -s /group_ext -d /copy1_group)
+ADD_H5_TEST (ext_link_group 2 ${HDF_EXT_SRC_FILE}.h5 "" -v -s /group_ext -d /copy1_group)
 
 # "Test copying a group contains external links with -f ext"
-ADD_H5_F_TEST (ext_link_group_f 2 ${HDF_EXT_SRC_FILE}.h5 ext -v -s /group_ext -d /copy2_group)
+ADD_H5_TEST (ext_link_group_f 2 ${HDF_EXT_SRC_FILE}.h5 ext -v -s /group_ext -d /copy2_group)
 
 ############# Test misc. ##############
 


### PR DESCRIPTION
- Merged several macros together that were minor variants of `ADD_H5_TEST`.
- Reworked the argument handling of `ADD_H5_TEST` to use `cmake_parse_arguments()`
- Simplify portions of the UD macros
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Consolidated multiple test macros into `ADD_H5_TEST` in `CMakeTests.cmake`, simplifying test setup and argument handling for `h5copy`.
> 
>   - **Macros**:
>     - Consolidated multiple test macros into `ADD_H5_TEST` in `CMakeTests.cmake`.
>     - Removed redundant macros like `ADD_H5_F_TEST`, `ADD_H5_TEST2`, `ADD_H5_TEST_SAME`, `ADD_H5_CMP_TEST`, and `ADD_SKIP_H5_TEST`.
>   - **Argument Handling**:
>     - Reworked `ADD_H5_TEST` to use `cmake_parse_arguments()` for better argument parsing.
>     - Added support for keyword arguments and flags in `ADD_H5_TEST`.
>   - **Simplification**:
>     - Simplified portions of user-defined (UD) test macros by removing redundant code and using shared logic.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=HDFGroup%2Fhdf5&utm_source=github&utm_medium=referral)<sup> for cf71ffe55700d3520494b32719eba594b3c7086c. You can [customize](https://app.ellipsis.dev/HDFGroup/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->