### PR TITLE
correct url paths for FLOSS

### DIFF
--- a/.github/.well-known/funding.json
+++ b/.github/.well-known/funding.json
@@ -21,7 +21,7 @@
       },
       "repositoryUrl": {
         "url": "https://github.com/HDFGroup/hdf5",
-        "wellKnown": "https://github.com/HDFGroup/hdf5/blob/main/.github/.well-known/funding-manifest-urls"
+        "wellKnown": "https://github.com/HDFGroup/hdf5/blob/develop/.github/.well-known/funding-manifest-urls"
       },
       "licenses": [
         "spdx:BSD-3-Clause"
@@ -46,7 +46,7 @@
       },
       "repositoryUrl": {
         "url": "https://github.com/hdfgroup/hdf5",
-        "wellKnown": "https://github.com/hdfgroup/hdf5/blob/main/.github/.well-known/funding-manifest-urls"
+        "wellKnown": "https://github.com/hdfgroup/hdf5/blob/develop/.github/.well-known/funding-manifest-urls"
       },
       "licenses": [
         "spdx:BSD-3-Clause"
@@ -72,7 +72,7 @@
       },
       "repositoryUrl": {
         "url": "https://github.com/HDFGroup",
-        "wellKnown": "https://github.com/HDFGroup/hdf5/blob/main/.github/.well-known/funding-manifest-urls"
+        "wellKnown": "https://github.com/HDFGroup/hsds/blob/master/.github/.well-known/funding-manifest-urls"
       },
       "licenses": [
         "spdx:Apache-2.0"


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Corrects `wellKnown` URLs in `funding.json` for FLOSS projects to point to correct branches and repositories.
> 
>   - **URLs Updated**:
>     - Change `wellKnown` URL for `hdf5` project from `main` to `develop` branch.
>     - Change `wellKnown` URL for `hsds` project to point to `master` branch of `hsds` repository.
>   - **Files Affected**:
>     - `.github/.well-known/funding.json`
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=HDFGroup%2Fhdf5&utm_source=github&utm_medium=referral)<sup> for e3f9d872f6236c021453273fa172a5514fdb1ce4. You can [customize](https://app.ellipsis.dev/HDFGroup/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->