### PR TITLE
Correct usage of H5_HAVE__FLOAT16 macro

### DIFF
--- a/tools/test/h5gentest.c
+++ b/tools/test/h5gentest.c
@@ -424,7 +424,7 @@ gen_h5ls_files(void)
 
     gent_udlink();
 
-#ifdef H5_HAVE__FLOAT_16
+#ifdef H5_HAVE__FLOAT16
     gent_float16();
     gent_float16_be();
 #endif


### PR DESCRIPTION
When merged into the current tools test file generator program, an extra space was added in the usage of the `H5_HAVE__FLOAT16` macro.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Corrects macro usage from `H5_HAVE__FLOAT_16` to `H5_HAVE__FLOAT16` in `h5gentest.c`, affecting conditional compilation of `gent_float16()` and `gent_float16_be()`.
> 
>   - **Macro Correction**:
>     - Corrects macro usage from `H5_HAVE__FLOAT_16` to `H5_HAVE__FLOAT16` in `h5gentest.c`.
>     - Affects conditional compilation of `gent_float16()` and `gent_float16_be()` functions.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=HDFGroup%2Fhdf5&utm_source=github&utm_medium=referral)<sup> for d765c78bfaffd894c795096b80f099cc6c8339b6. You can [customize](https://app.ellipsis.dev/HDFGroup/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->