### PR TITLE
Add variable called HDF5_VERSION to install config file

### DIFF
--- a/config/install/hdf5-config.cmake.in
+++ b/config/install/hdf5-config.cmake.in
@@ -152,6 +152,7 @@ endif ()
 #-----------------------------------------------------------------------------
 # Version Strings
 #-----------------------------------------------------------------------------
+set (${HDF5_PACKAGE_NAME}_VERSION @HDF5_VERSION_STRING@)
 set (${HDF5_PACKAGE_NAME}_VERSION_STRING @HDF5_VERSION_STRING@)
 set (${HDF5_PACKAGE_NAME}_VERSION_MAJOR  @HDF5_VERSION_MAJOR@)
 set (${HDF5_PACKAGE_NAME}_VERSION_MINOR  @HDF5_VERSION_MINOR@)


### PR DESCRIPTION
Fixes #5164
<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Adds `HDF5_VERSION` variable to `hdf5-config.cmake.in` for version management.
> 
>   - **Configuration**:
>     - Adds `set (${HDF5_PACKAGE_NAME}_VERSION @HDF5_VERSION_STRING@)` to `hdf5-config.cmake.in` for version management.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=HDFGroup%2Fhdf5&utm_source=github&utm_medium=referral)<sup> for c0d4f94daa9a5d7880866b884dc4973f58562c5f. You can [customize](https://app.ellipsis.dev/HDFGroup/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->