### PR TITLE
build: support flang20 on macOS

### DIFF
--- a/config/HDF5Macros.cmake
+++ b/config/HDF5Macros.cmake
@@ -28,7 +28,8 @@ macro (H5_SET_LIB_OPTIONS libtarget libname libtype libpackage)
     else ()
         set_target_properties (${libtarget} PROPERTIES SOVERSION ${LIBHDF_VERSION})
     endif ()
-    if (CMAKE_C_OSX_CURRENT_VERSION_FLAG)
+    # Only set macOS-specific linker flags if not using flang
+    if (CMAKE_C_OSX_CURRENT_VERSION_FLAG AND NOT CMAKE_Fortran_COMPILER_ID STREQUAL "LLVMFlang")
       set_property(TARGET ${libtarget} APPEND PROPERTY
           LINK_FLAGS "${CMAKE_C_OSX_CURRENT_VERSION_FLAG}${PACKAGE_CURRENT} ${CMAKE_C_OSX_COMPATIBILITY_VERSION_FLAG}${PACKAGE_COMPATIBILITY}"
       )

--- a/config/flags/HDFCompilerFortranFlags.cmake
+++ b/config/flags/HDFCompilerFortranFlags.cmake
@@ -49,6 +49,13 @@ if (CMAKE_Fortran_COMPILER_ID MATCHES "Intel")
   include (${HDF_CONFIG_DIR}/flags/HDFIntelFortranFlags.cmake)
 endif ()
 
+if (CMAKE_Fortran_COMPILER_ID STREQUAL "LLVMFlang")
+  # Flang (LLVM Fortran) compiler flags
+  message (STATUS "....Using LLVM Flang Fortran compiler")
+  # Add any flang-specific flags here if needed
+  # For now, flang should work with default flags
+endif ()
+
 #-----------------------------------------------------------------------------
 # HDF5 library compile options - to be made available to all targets
 #-----------------------------------------------------------------------------

--- a/fortran/src/CMakeLists.txt
+++ b/fortran/src/CMakeLists.txt
@@ -397,6 +397,10 @@ if (BUILD_STATIC_LIBS)
       LINKER_LANGUAGE Fortran
       Fortran_MODULE_DIRECTORY ${CMAKE_Fortran_MODULE_DIRECTORY}/static
   )
+  # For flang, use C linker instead of Fortran linker to avoid macOS-specific flags
+  if (CMAKE_Fortran_COMPILER_ID STREQUAL "LLVMFlang")
+    set_target_properties (${HDF5_F90_LIB_TARGET} PROPERTIES LINKER_LANGUAGE C)
+  endif ()
   H5_SET_LIB_OPTIONS (${HDF5_F90_LIB_TARGET} ${HDF5_F90_LIB_NAME} STATIC 0)
   set_global_variable (HDF5_LIBRARIES_TO_EXPORT "${HDF5_LIBRARIES_TO_EXPORT};${HDF5_F90_LIB_TARGET}")
   set (install_targets ${install_targets} ${HDF5_F90_LIB_TARGET})
@@ -433,6 +437,10 @@ if (BUILD_SHARED_LIBS)
       LINKER_LANGUAGE Fortran
       Fortran_MODULE_DIRECTORY ${CMAKE_Fortran_MODULE_DIRECTORY}/shared
   )
+  # For flang, use C linker instead of Fortran linker to avoid macOS-specific flags
+  if (CMAKE_Fortran_COMPILER_ID STREQUAL "LLVMFlang")
+    set_target_properties (${HDF5_F90_LIBSH_TARGET} PROPERTIES LINKER_LANGUAGE C)
+  endif ()
   set_global_variable (HDF5_LIBRARIES_TO_EXPORT "${HDF5_LIBRARIES_TO_EXPORT};${HDF5_F90_LIBSH_TARGET}")
   H5_SET_LIB_OPTIONS (${HDF5_F90_LIBSH_TARGET} ${HDF5_F90_LIB_NAME} SHARED "F")
   set (install_targets ${install_targets} ${HDF5_F90_LIBSH_TARGET})

--- a/fortran/test/CMakeLists.txt
+++ b/fortran/test/CMakeLists.txt
@@ -156,6 +156,10 @@ if (NOT BUILD_SHARED_LIBS)
       LINKER_LANGUAGE Fortran
       Fortran_MODULE_DIRECTORY ${CMAKE_Fortran_MODULE_DIRECTORY}/static
   )
+  # For flang, use C linker instead of Fortran linker to avoid macOS-specific flags
+  if (CMAKE_Fortran_COMPILER_ID STREQUAL "LLVMFlang")
+    set_target_properties (${HDF5_F90_TEST_LIB_TARGET} PROPERTIES LINKER_LANGUAGE C)
+  endif ()
   H5_SET_LIB_OPTIONS (${HDF5_F90_TEST_LIB_TARGET} ${HDF5_F90_TEST_LIB_NAME} STATIC 0)
   add_dependencies(${HDF5_F90_TEST_LIB_TARGET} H5testgen)
 else ()
@@ -182,6 +186,10 @@ else ()
       LINKER_LANGUAGE Fortran
       Fortran_MODULE_DIRECTORY ${CMAKE_Fortran_MODULE_DIRECTORY}/shared
   )
+  # For flang, use C linker instead of Fortran linker to avoid macOS-specific flags
+  if (CMAKE_Fortran_COMPILER_ID STREQUAL "LLVMFlang")
+    set_target_properties (${HDF5_F90_TEST_LIBSH_TARGET} PROPERTIES LINKER_LANGUAGE C)
+  endif ()
   H5_SET_LIB_OPTIONS (${HDF5_F90_TEST_LIBSH_TARGET} ${HDF5_F90_TEST_LIB_NAME} SHARED "F")
   add_dependencies(${HDF5_F90_TEST_LIBSH_TARGET} H5testgenSH)
 endif ()

--- a/fortran/test/tH5O_F03.F90
+++ b/fortran/test/tH5O_F03.F90
@@ -212,7 +212,7 @@ CONTAINS
 ! A(8) = tm_yday  int   days since January 1       0-365
 ! A(9) = tm_isdst int   Daylight Saving Time flag
 !
-    INTEGER :: len, i
+    INTEGER :: str_len, i
     INTEGER :: idx
     INTEGER :: ierr
 
@@ -221,15 +221,15 @@ CONTAINS
     ! Since the name is generated in C and passed to a Fortran string, it
     ! will be NULL terminated, so we need to find the end of the string.
 
-    DO len = 1, 180
-       IF(name(len) .EQ. C_NULL_CHAR) EXIT
+    DO str_len = 1, 180
+       IF(name(str_len) .EQ. C_NULL_CHAR) EXIT
     ENDDO
 
-    len = len - 1
+    str_len = str_len - 1
 
     ! Check for correct object information
     name2(1:180) = ""
-    DO i = 1, len
+    DO i = 1, str_len
        name2(i:i) = name(i)(1:1)
     ENDDO
 
@@ -237,7 +237,7 @@ CONTAINS
 
        idx = op_data%idx
 
-       DO i = 1, len
+       DO i = 1, str_len
           IF(op_data%info(idx)%path(i)(1:1) .NE. name(i)(1:1))THEN
              visit_obj_cb = -1
              RETURN

--- a/fortran/test/tH5P_F03.F90
+++ b/fortran/test/tH5P_F03.F90
@@ -706,7 +706,7 @@ SUBROUTINE test_vds(total_error)
   INTEGER(size_t) :: i_sz
   INTEGER :: layout                     ! Storage layout
   INTEGER(size_t) :: num_map            ! Number of mappings
-  INTEGER(size_t) :: len                ! Length of the string also a RETURN value
+  INTEGER(size_t) :: str_len            ! Length of the string also a RETURN value
   ! Different sized character buffers
   CHARACTER(len=LEN(SRC_FILE(1))-3)  :: SRC_FILE_LEN_TINY
   CHARACTER(len=LEN(SRC_FILE(1))-1)  :: SRC_FILE_LEN_SMALL

--- a/fortran/test/tH5T.F90
+++ b/fortran/test/tH5T.F90
@@ -97,7 +97,7 @@ CONTAINS
      INTEGER :: class ! Datatype class
      INTEGER :: num_members ! Number of members in the compound datatype
      CHARACTER(LEN=256) :: member_name
-     INTEGER :: len ! Length of the name of the compound datatype member
+     INTEGER :: str_len ! Length of the name of the compound datatype member
      INTEGER :: member_index ! index of the field
      INTEGER(HSIZE_T), DIMENSION(3) :: array_dims=(/2,3,4/)
      INTEGER :: array_dims_range = 3
@@ -374,11 +374,11 @@ CONTAINS
      !  Also see if name corresponds to the index
      !
      do i = 1, num_members
-        CALL h5tget_member_name_f(dtype_id, i-1, member_name, len, error)
+        CALL h5tget_member_name_f(dtype_id, i-1, member_name, str_len, error)
      CALL check("h5tget_member_name_f", error, total_error)
         CALL h5tget_member_offset_f(dtype_id, i-1, offset_out, error)
      CALL check("h5tget_member_offset_f", error, total_error)
-        CALL h5tget_member_index_f(dtype_id, member_name(1:len), member_index, error)
+        CALL h5tget_member_index_f(dtype_id, member_name(1:str_len), member_index, error)
      CALL check("h5tget_member_index_f", error, total_error)
          if(member_index .ne. i-1) then
             write(*,*) "Index returned is incorrect"
@@ -386,7 +386,7 @@ CONTAINS
             total_error = total_error + 1
             endif
 
-        CHECK_NAME: SELECT CASE (member_name(1:len))
+        CHECK_NAME: SELECT CASE (member_name(1:str_len))
         CASE("char_field")
              if(offset_out .ne. 0) then
                write(*,*) "Offset of the char member is incorrect"

--- a/fortran/test/tH5VL.F90
+++ b/fortran/test/tH5VL.F90
@@ -48,8 +48,8 @@ CONTAINS
 
 
           INTEGER(HSIZE_T), DIMENSION(1) :: dims = (/6/) ! Dataset dimensions
-          INTEGER(SIZE_T), DIMENSION(6) :: len           ! Elements lengths
-          INTEGER(SIZE_T), DIMENSION(6) :: len_out
+          INTEGER(SIZE_T), DIMENSION(6) :: elem_len           ! Elements lengths
+          INTEGER(SIZE_T), DIMENSION(6) :: elem_len_out
           INTEGER     ::   rank = 1                      ! Dataset rank
 
           INTEGER, DIMENSION(5,6) :: vl_int_data ! Data buffers
@@ -77,7 +77,7 @@ CONTAINS
           end do
 
            do i = 1,6
-              len(i) = i-1
+              elem_len(i) = i-1
            end do
 
 
@@ -113,7 +113,7 @@ CONTAINS
           !
           ! Write the dataset.
           !
-          CALL h5dwrite_vl_f(dset_id, vltype_id, vl_int_data, data_dims, len, error)
+          CALL h5dwrite_vl_f(dset_id, vltype_id, vl_int_data, data_dims, elem_len, error)
               CALL check("h5dwrite_int_f", error, total_error)
 
 
@@ -151,17 +151,17 @@ CONTAINS
           !
           ! Read the dataset.
           !
-          CALL h5dread_vl_f(dset_id, vltype_id, vl_int_data_out, data_dims, len_out, &
+          CALL h5dread_vl_f(dset_id, vltype_id, vl_int_data_out, data_dims, elem_len_out, &
                             error, mem_space_id = dspace_id, file_space_id = dspace_id)
               CALL check("h5dread_int_f", error, total_error)
               do ih = 1, data_dims(2)
-              do jh = 1, len_out(ih)
+              do jh = 1, elem_len_out(ih)
               if(vl_int_data(jh,ih) .ne. vl_int_data_out(jh,ih))  then
                   total_error = total_error + 1
                   write(*,*) "h5dread_vl_f returned incorrect data"
               endif
               enddo
-               if (len(ih) .ne. len_out(ih)) then
+               if (elem_len(ih) .ne. elem_len_out(ih)) then
                   total_error = total_error + 1
                   write(*,*) "h5dread_vl_f returned incorrect data"
               endif
@@ -208,8 +208,8 @@ CONTAINS
 
 
           INTEGER(HSIZE_T), DIMENSION(1) :: dims = (/6/) ! Dataset dimensions
-          INTEGER(SIZE_T), DIMENSION(6) :: len           ! Elements lengths
-          INTEGER(SIZE_T), DIMENSION(6) :: len_out
+          INTEGER(SIZE_T), DIMENSION(6) :: elem_len           ! Elements lengths
+          INTEGER(SIZE_T), DIMENSION(6) :: elem_len_out
           INTEGER     ::   rank = 1                      ! Dataset rank
 
           REAL, DIMENSION(5,6) :: vl_real_data ! Data buffers
@@ -239,7 +239,7 @@ CONTAINS
           end do
 
            do i = 1,6
-              len(i) = i-1
+              elem_len(i) = i-1
            end do
 
 
@@ -284,7 +284,7 @@ CONTAINS
           !
           ! Write the dataset.
           !
-          CALL h5dwrite_vl_f(dset_id, vltype_id, vl_real_data, data_dims, len, error)
+          CALL h5dwrite_vl_f(dset_id, vltype_id, vl_real_data, data_dims, elem_len, error)
               CALL check("h5dwrite_vl_real_f", error, total_error)
 
 
@@ -321,14 +321,14 @@ CONTAINS
           !
           ! Read the dataset.
           !
-          CALL h5dread_vl_f(dset_id, vltype_id, vl_real_data_out, data_dims, len_out, &
+          CALL h5dread_vl_f(dset_id, vltype_id, vl_real_data_out, data_dims, elem_len_out, &
                             error, mem_space_id = dspace_id, file_space_id = dspace_id)
               CALL check("h5dread_real_f", error, total_error)
               DO ih = 1, data_dims(2)
-              DO jh = 1, len_out(ih)
+              DO jh = 1, elem_len_out(ih)
                  CALL VERIFY("h5dread_vl_f returned incorrect data",vl_real_data(jh,ih),vl_real_data_out(jh,ih), total_error)
               ENDDO
-              IF (LEN(ih) .NE. len_out(ih)) THEN
+              IF (elem_len(ih) .NE. elem_len_out(ih)) THEN
                  total_error = total_error + 1
                  WRITE(*,*) "h5dread_vl_f returned incorrect data"
               ENDIF

--- a/fortran/test/tf.F90
+++ b/fortran/test/tf.F90
@@ -70,14 +70,14 @@ CONTAINS
     CHARACTER(LEN=*), INTENT(IN) :: title_header ! test name
     INTEGER, PARAMETER :: width = TAB_SPACE+10
     CHARACTER(LEN=2*width) ::title_centered
-    INTEGER :: len, i
+    INTEGER :: str_len, i
 
     title_centered(:) = " "
 
-    len=LEN_TRIM(title_header)
-    title_centered(1:3) ="| |"
-    title_centered((width-len)/2:(width-len)/2+len) = TRIM(title_header)
-    title_centered(width-1:width+2) ="| |"
+    str_len = LEN_TRIM(title_header)
+    title_centered(1:3) = "| |"
+    title_centered((width - str_len)/2:(width - str_len)/2 + str_len) = TRIM(title_header)
+    title_centered(width - 1:width + 2) = "| |"
 
     WRITE(*,'(1X)', ADVANCE="NO")
     DO i = 1, width-1

--- a/fortran/test/vol_connector.F90
+++ b/fortran/test/vol_connector.F90
@@ -244,7 +244,7 @@ PROGRAM vol_connector
   INTEGER :: ret_total_error
   LOGICAL :: cleanup, status
   CHARACTER(LEN=32) :: VOL_CONNECTOR_ENV
-  INTEGER :: LEN = 0
+  INTEGER :: STR_LEN = 0
   INTEGER :: CONN_NAME_LEN
 
   CALL h5open_f(error)
@@ -259,9 +259,9 @@ PROGRAM vol_connector
   WRITE(*,'(A)') "Testing VOL connector plugin functionality."
 
   ! Check to see if the VOL connector was set with an env variable
-  CALL GET_ENVIRONMENT_VARIABLE("HDF5_VOL_CONNECTOR", VOL_CONNECTOR_ENV, LEN)
+  CALL GET_ENVIRONMENT_VARIABLE("HDF5_VOL_CONNECTOR", VOL_CONNECTOR_ENV, STR_LEN)
   CONN_NAME_LEN = INDEX(VOL_CONNECTOR_ENV, ' ')
-  IF(LEN.NE.0)THEN
+  IF(STR_LEN.NE.0)THEN
      NATIVE_VOL_CONNECTOR_NAME = TRIM(VOL_CONNECTOR_ENV(1:CONN_NAME_LEN))
   ELSE
      NATIVE_VOL_CONNECTOR_NAME = "native"

--- a/hl/fortran/src/CMakeLists.txt
+++ b/hl/fortran/src/CMakeLists.txt
@@ -189,6 +189,10 @@ if (BUILD_STATIC_LIBS)
       LINKER_LANGUAGE Fortran
       Fortran_MODULE_DIRECTORY ${CMAKE_Fortran_MODULE_DIRECTORY}/static
   )
+  # For flang, use C linker instead of Fortran linker to avoid macOS-specific flags
+  if (CMAKE_Fortran_COMPILER_ID STREQUAL "LLVMFlang")
+    set_target_properties (${HDF5_HL_F90_LIB_TARGET} PROPERTIES LINKER_LANGUAGE C)
+  endif ()
   H5_SET_LIB_OPTIONS (${HDF5_HL_F90_LIB_TARGET} ${HDF5_HL_F90_LIB_NAME} STATIC 0)
   set_global_variable (HDF5_LIBRARIES_TO_EXPORT "${HDF5_LIBRARIES_TO_EXPORT};${HDF5_HL_F90_LIB_TARGET}")
   set (install_targets ${install_targets} ${HDF5_HL_F90_LIB_TARGET})
@@ -228,6 +232,10 @@ if (BUILD_SHARED_LIBS)
       LINKER_LANGUAGE Fortran
       Fortran_MODULE_DIRECTORY ${CMAKE_Fortran_MODULE_DIRECTORY}/shared
   )
+  # For flang, use C linker instead of Fortran linker to avoid macOS-specific flags
+  if (CMAKE_Fortran_COMPILER_ID STREQUAL "LLVMFlang")
+    set_target_properties (${HDF5_HL_F90_LIBSH_TARGET} PROPERTIES LINKER_LANGUAGE C)
+  endif ()
   H5_SET_LIB_OPTIONS (${HDF5_HL_F90_LIBSH_TARGET} ${HDF5_HL_F90_LIB_NAME} SHARED "HL_F")
   set_global_variable (HDF5_LIBRARIES_TO_EXPORT "${HDF5_LIBRARIES_TO_EXPORT};${HDF5_HL_F90_LIBSH_TARGET}")
   set (install_targets ${install_targets} ${HDF5_HL_F90_LIBSH_TARGET})


### PR DESCRIPTION
Proof: https://my.cdash.org/builds/2992283

close #5662

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Add support for Flang Fortran compiler on macOS by adjusting linker settings and handling Flang-specific cases in build configuration.
> 
>   - **Build Configuration**:
>     - In `HDF5Macros.cmake`, avoid setting macOS-specific linker flags when using Flang by checking `CMAKE_Fortran_COMPILER_ID`.
>     - In `HDFCompilerFortranFlags.cmake`, add a section for Flang to log its usage and note that default flags are sufficient.
>     - In `fortran/src/CMakeLists.txt`, `fortran/test/CMakeLists.txt`, and `hl/fortran/src/CMakeLists.txt`, set `LINKER_LANGUAGE` to C for Flang to avoid macOS-specific flags.
>   - **Code Changes**:
>     - Rename `len` to `str_len` in `tH5O_F03.F90`, `tH5P_F03.F90`, `tH5T.F90`, `tH5VL.F90`, `tf.F90`, and `vol_connector.F90` to improve clarity and avoid conflicts.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=HDFGroup%2Fhdf5&utm_source=github&utm_medium=referral)<sup> for b31f4a16f6ab07ffc3faaa7c619816ef9adfdc6d. You can [customize](https://app.ellipsis.dev/HDFGroup/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->