### PR TITLE
Prototype Version Zero Support for the SCC

### DIFF
--- a/src/H5Dfarray.c
+++ b/src/H5Dfarray.c
@@ -80,8 +80,9 @@ typedef struct H5D_farray_ctx_ud_t {
 /* For structured chunk */
 typedef struct H5D_farray_stc_ctx_ud_t {
     const H5F_t *f;           /* Pointer to file info */
+    uint64_t chunk_size;      /* Size of chunk (bytes)*/
     unsigned     nsects;      /* # of sections */
-    unsigned     offset_size; /* Offset size to encode/decode chunk size */
+    unsigned     offset_size; /* ?? Offset size to encode/decode chunk size */
 } H5D_farray_stc_ctx_ud_t;
 
 /* Fixed array callback context */
@@ -92,9 +93,10 @@ typedef struct H5D_farray_ctx_t {
 
 /* For structured chunk */
 typedef struct H5D_farray_stc_ctx_t {
-    size_t   file_addr_len; /* Size of addresses in the file (bytes) */
+    size_t   file_addr_len;  /* Size of addresses in the file (bytes) */
+    size_t chunk_size_len;  /* Size of chunk sizes in the file (bytes) */
     unsigned nsects;        /* # of sections */
-    unsigned offset_size;   /* Offset size to encode/decode chunk size */
+    unsigned offset_size;   /* ??? Offset size to encode/decode chunk size */
 } H5D_farray_stc_ctx_t;
 
 /* Fixed Array callback info for iteration over chunks */
@@ -1991,6 +1993,7 @@ H5D__farray_stc_idx_create(const H5D_chk_idx_info_t *idx_info)
 
     /* Set up the user data */
     udata.f           = idx_info->f;
+    udata.chunk_size =  layout->size;
     udata.nsects      = storage->nsects;
     udata.offset_size = storage->offset_size;
 
@@ -2951,6 +2954,13 @@ H5D__farray_stc_crt_context(void *_udata)
 
     /* Initialize the context */
     ctx->file_addr_len = H5F_SIZEOF_ADDR(udata->f);
+
+    ctx->chunk_size_len = 1 + ((H5VM_log2_gen((uint64_t)udata->chunk_size) + H5O_STRUCT_CHUNK_OFFSET_SIZE) /
+                          H5O_STRUCT_CHUNK_OFFSET_SIZE);
+    if (ctx->chunk_size_len > H5O_STRUCT_CHUNK_OFFSET_SIZE)
+        ctx->chunk_size_len = H5O_STRUCT_CHUNK_OFFSET_SIZE;
+
+
     ctx->nsects        = udata->nsects;
     ctx->offset_size   = udata->offset_size;
 
@@ -3075,7 +3085,7 @@ H5D__farray_stc_encode(void *raw, const void *_elmt, size_t nelmts, void *_ctx)
         H5F_addr_encode_len(ctx->file_addr_len, (uint8_t **)&raw, elmt->addr);
 
         /* Chunk size */
-        UINT64ENCODE_VAR(raw, elmt->nbytes, ctx->offset_size);
+        UINT64ENCODE_VAR(raw, elmt->nbytes, ctx->chunk_size_len);
 
         /* Offsets for (n-1) sections: no need to encode offset for section 0 */
         for (unsigned u = 1; u < ctx->nsects; u++)
@@ -3126,7 +3136,7 @@ H5D__farray_stc_filt_encode(void *_raw, const void *_elmt, size_t nelmts, void *
         H5F_addr_encode_len(ctx->file_addr_len, &raw, elmt->addr);
 
         /* Chunk size */
-        UINT64ENCODE_VAR(raw, elmt->nbytes, ctx->offset_size);
+        UINT64ENCODE_VAR(raw, elmt->nbytes, ctx->chunk_size_len);
 
         /* Offsets for (n-1) sections: no need to encode offset for section 0 */
         for (unsigned u = 1; u < ctx->nsects; u++)
@@ -3183,7 +3193,7 @@ H5D__farray_stc_decode(const void *_raw, void *_elmt, size_t nelmts, void *_ctx)
         H5F_addr_decode_len(ctx->file_addr_len, &raw, &elmt->addr);
 
         /* Chunk size */
-        UINT64DECODE_VAR(raw, elmt->nbytes, ctx->offset_size);
+        UINT64DECODE_VAR(raw, elmt->nbytes, ctx->chunk_size_len);
 
         /* Offset for (n-1) sections: no need to decode offset for section 0 */
         elmt->offset[0] = 0; /* Filler */

--- a/src/H5Dfarray.c
+++ b/src/H5Dfarray.c
@@ -80,7 +80,7 @@ typedef struct H5D_farray_ctx_ud_t {
 /* For structured chunk */
 typedef struct H5D_farray_stc_ctx_ud_t {
     const H5F_t *f;           /* Pointer to file info */
-    uint64_t chunk_size;      /* Size of chunk (bytes)*/
+    uint64_t     chunk_size;  /* Size of chunk (bytes)*/
     unsigned     nsects;      /* # of sections */
     unsigned     offset_size; /* ?? Offset size to encode/decode chunk size */
 } H5D_farray_stc_ctx_ud_t;
@@ -94,9 +94,9 @@ typedef struct H5D_farray_ctx_t {
 /* For structured chunk */
 typedef struct H5D_farray_stc_ctx_t {
     size_t   file_addr_len;  /* Size of addresses in the file (bytes) */
-    size_t chunk_size_len;  /* Size of chunk sizes in the file (bytes) */
-    unsigned nsects;        /* # of sections */
-    unsigned offset_size;   /* ??? Offset size to encode/decode chunk size */
+    size_t   chunk_size_len; /* Size of chunk sizes in the file (bytes) */
+    unsigned nsects;         /* # of sections */
+    unsigned offset_size;    /* ??? Offset size to encode/decode chunk size */
 } H5D_farray_stc_ctx_t;
 
 /* Fixed Array callback info for iteration over chunks */
@@ -1993,7 +1993,7 @@ H5D__farray_stc_idx_create(const H5D_chk_idx_info_t *idx_info)
 
     /* Set up the user data */
     udata.f           = idx_info->f;
-    udata.chunk_size =  layout->size;
+    udata.chunk_size  = layout->size;
     udata.nsects      = storage->nsects;
     udata.offset_size = storage->offset_size;
 
@@ -2956,13 +2956,12 @@ H5D__farray_stc_crt_context(void *_udata)
     ctx->file_addr_len = H5F_SIZEOF_ADDR(udata->f);
 
     ctx->chunk_size_len = 1 + ((H5VM_log2_gen((uint64_t)udata->chunk_size) + H5O_STRUCT_CHUNK_OFFSET_SIZE) /
-                          H5O_STRUCT_CHUNK_OFFSET_SIZE);
+                               H5O_STRUCT_CHUNK_OFFSET_SIZE);
     if (ctx->chunk_size_len > H5O_STRUCT_CHUNK_OFFSET_SIZE)
         ctx->chunk_size_len = H5O_STRUCT_CHUNK_OFFSET_SIZE;
 
-
-    ctx->nsects        = udata->nsects;
-    ctx->offset_size   = udata->offset_size;
+    ctx->nsects      = udata->nsects;
+    ctx->offset_size = udata->offset_size;
 
     /* Set return value */
     ret_value = ctx;

--- a/src/H5Dio.c
+++ b/src/H5Dio.c
@@ -864,7 +864,7 @@ H5D__write(size_t count, H5D_dset_io_info_t *dset_info)
             if (!dset_info[i].dset->shared->layout.sc_ops) {
                 /* Set metadata tagging with dset oheader addr */
                 H5AC_tag(dset_info->dset->oloc.addr, &prev_tag);
-                
+
                 /* Invoke correct "high level" I/O routine */
                 if ((*dset_info[i].io_ops.multi_write)(&io_info, &dset_info[i]) < 0)
                     HGOTO_ERROR(H5E_DATASET, H5E_WRITEERROR, FAIL, "can't write data");
@@ -918,7 +918,7 @@ H5D__write(size_t count, H5D_dset_io_info_t *dset_info)
     /* Make shared chunk cache write call if appropriate */
     if (any_scc) {
         assert(H5F_SHARED_CACHE(dset_info[0].dset->oloc.file));
-        
+
         if (H5SC_write(H5F_SHARED_CACHE(dset_info[0].dset->oloc.file), count, dset_info) < 0)
             HGOTO_ERROR(H5E_DATASET, H5E_WRITEERROR, FAIL, "write through shared chunk cache failed");
 
@@ -932,7 +932,7 @@ done:
     for (i = 0; i < io_op_init; i++) {
         assert(!dset_info[i].skip_io);
         if (!dset_info[i].dset->shared->layout.sc_ops && dset_info[i].layout_ops.io_term &&
-        // if (!dset_info[i].layout->sc_ops && dset_info[i].layout_ops.io_term &&
+            // if (!dset_info[i].layout->sc_ops && dset_info[i].layout_ops.io_term &&
             (*dset_info[i].layout_ops.io_term)(&io_info, &(dset_info[i])) < 0)
             HDONE_ERROR(H5E_DATASET, H5E_CANTCLOSEOBJ, FAIL, "unable to shut down I/O op info");
     }
@@ -1058,8 +1058,8 @@ H5D__dset_ioinfo_init(H5D_t *dset, H5D_dset_io_info_t *dset_info, H5D_storage_t 
     assert(dset_info->type_info.tpath);
 
     /* Set up "normal" I/O fields */
-    dset_info->dset  = dset;
-    dset_info->store = store;
+    dset_info->dset   = dset;
+    dset_info->store  = store;
     dset_info->layout = &dset->shared->layout;
 
     /* Only set layout ops if weŕe not using the shared chunk cache */

--- a/src/H5Dio.c
+++ b/src/H5Dio.c
@@ -290,7 +290,7 @@ H5D__read(size_t count, H5D_dset_io_info_t *dset_info)
         }
 
         /* Check for shared chunk cache support */
-        if (dset_info[i].layout->sc_ops)
+        if (dset_info[i].dset->shared->layout.sc_ops)
             /* Note that there is at least one dataset that supports shared chunk cache */
             any_scc = true;
         else {
@@ -404,7 +404,7 @@ H5D__read(size_t count, H5D_dset_io_info_t *dset_info)
         /* Loop with serial & single-dset read IO path */
         for (i = 0; i < count; i++)
             /* Only call the legacy I/O code if weŕe not using the shared chunk cache */
-            if (!dset_info[i].layout->sc_ops) {
+            if (!dset_info[i].dset->shared->layout.sc_ops) {
                 /* Check for skipped I/O */
                 if (dset_info[i].skip_io)
                     continue;
@@ -475,7 +475,7 @@ H5D__read(size_t count, H5D_dset_io_info_t *dset_info)
 done:
     /* Shut down the I/O op information */
     for (i = 0; i < io_op_init; i++)
-        if (!dset_info[i].layout->sc_ops && dset_info[i].layout_ops.io_term &&
+        if (!dset_info[i].dset->shared->layout.sc_ops && dset_info[i].layout_ops.io_term &&
             (*dset_info[i].layout_ops.io_term)(&io_info, &(dset_info[i])) < 0)
             HDONE_ERROR(H5E_DATASET, H5E_CANTCLOSEOBJ, FAIL, "unable to shut down I/O op info");
 
@@ -753,7 +753,7 @@ H5D__write(size_t count, H5D_dset_io_info_t *dset_info)
         dset_info[i].skip_io = false;
 
         /* Check for shared chunk cache support */
-        if (dset_info[i].layout->sc_ops)
+        if (dset_info[i].dset->shared->layout.sc_ops)
             /* Note that there is at least one dataset that supports shared chunk cache */
             any_scc = true;
         else {
@@ -861,10 +861,10 @@ H5D__write(size_t count, H5D_dset_io_info_t *dset_info)
             assert(!dset_info[i].skip_io);
 
             /* Only call the legacy I/O code if weŕe not using the shared chunk cache */
-            if (!dset_info[i].layout->sc_ops) {
+            if (!dset_info[i].dset->shared->layout.sc_ops) {
                 /* Set metadata tagging with dset oheader addr */
                 H5AC_tag(dset_info->dset->oloc.addr, &prev_tag);
-
+                
                 /* Invoke correct "high level" I/O routine */
                 if ((*dset_info[i].io_ops.multi_write)(&io_info, &dset_info[i]) < 0)
                     HGOTO_ERROR(H5E_DATASET, H5E_WRITEERROR, FAIL, "can't write data");
@@ -918,15 +918,21 @@ H5D__write(size_t count, H5D_dset_io_info_t *dset_info)
     /* Make shared chunk cache write call if appropriate */
     if (any_scc) {
         assert(H5F_SHARED_CACHE(dset_info[0].dset->oloc.file));
+        
         if (H5SC_write(H5F_SHARED_CACHE(dset_info[0].dset->oloc.file), count, dset_info) < 0)
             HGOTO_ERROR(H5E_DATASET, H5E_WRITEERROR, FAIL, "write through shared chunk cache failed");
+
+        if (orig_mem_space) {
+            orig_mem_space = NULL;
+        }
     }
 
 done:
     /* Shut down the I/O op information */
     for (i = 0; i < io_op_init; i++) {
         assert(!dset_info[i].skip_io);
-        if (!dset_info[i].layout->sc_ops && dset_info[i].layout_ops.io_term &&
+        if (!dset_info[i].dset->shared->layout.sc_ops && dset_info[i].layout_ops.io_term &&
+        // if (!dset_info[i].layout->sc_ops && dset_info[i].layout_ops.io_term &&
             (*dset_info[i].layout_ops.io_term)(&io_info, &(dset_info[i])) < 0)
             HDONE_ERROR(H5E_DATASET, H5E_CANTCLOSEOBJ, FAIL, "unable to shut down I/O op info");
     }
@@ -1054,6 +1060,7 @@ H5D__dset_ioinfo_init(H5D_t *dset, H5D_dset_io_info_t *dset_info, H5D_storage_t 
     /* Set up "normal" I/O fields */
     dset_info->dset  = dset;
     dset_info->store = store;
+    dset_info->layout = &dset->shared->layout;
 
     /* Only set layout ops if weŕe not using the shared chunk cache */
     if (!dset->shared->layout.sc_ops) {

--- a/src/H5Dstruct_chunk.c
+++ b/src/H5Dstruct_chunk.c
@@ -1245,8 +1245,11 @@ done:
  */
 static herr_t
 H5D__struct_chunk_lookup(H5D_t *dset, size_t count, const hsize_t *scaled[] /*in*/, haddr_t *addr[] /*out*/,
+                        
                          hsize_t *size[] /*out*/, hsize_t *defined_values_size[] /*out*/,
+                        
                          size_t *size_hint[] /*out*/, size_t *defined_values_size_hint[] /*out*/,
+                        
                          void **_udata[] /*out*/)
 {
     H5D_chunk_ud_t             *udata;
@@ -1254,7 +1257,7 @@ H5D__struct_chunk_lookup(H5D_t *dset, size_t count, const hsize_t *scaled[] /*in
     H5O_layout_struct_chunk_t  *layout  = &dset->shared->layout.u.struct_chunk;
     H5D_chk_idx_info_t          idx_info; /* Chunked index info */
     H5O_pline_t                *pline;    /* I/O pipeline info */
-    hbool_t                     filtered        = false;
+    hbool_t                     filtered = false;
     size_t                      tot_unfilt_size = 0;
     size_t                      i;
     herr_t                      ret_value = SUCCEED; /* Return value */
@@ -1305,14 +1308,14 @@ H5D__struct_chunk_lookup(H5D_t *dset, size_t count, const hsize_t *scaled[] /*in
             tot_unfilt_size = udata->unfilt_size[0] + udata->unfilt_size[1];
 
         if (size_hint[i])
-            size_hint[i] = filtered ? tot_unfilt_size : size[i];
+            *size_hint[i] = filtered ? tot_unfilt_size : *size[i];
 
         /* Size of defined values */
         if (defined_values_size[i])
-            defined_values_size[i] = filtered ? udata->unfilt_size[0] : udata->offset[1];
+            *defined_values_size[i] = filtered ? udata->unfilt_size[0] : udata->offset[1];
 
         if (defined_values_size_hint[i])
-            defined_values_size_hint[i] = filtered ? udata->unfilt_size[0] : defined_values_size[i];
+            *defined_values_size_hint[i] = filtered ? udata->unfilt_size[0] : *defined_values_size[i];
 
         _udata[i] = (void *)udata;
 
@@ -1343,7 +1346,7 @@ done:
  *              If the dataset reported partial_bound_chunks_different_encoding as false,
  *              the setting of partial_bound is undefined.
  *
- * Return:    Non-negative on success/Negative on failure
+  Return:    Non-negative on success/Negative on failure
  *
  * NOTE: On entry: [chunk] is the pointer to the on disk file format chunk buffer
  *       On exit: [chunk] is the pointer to the chunk intermediate struct
@@ -1365,6 +1368,8 @@ H5D__struct_chunk_decode(H5D_t *dset, size_t *nbytes /*in,out*/, size_t *alloc_s
     H5Z_cb_t               filter_cb;           /* I/O filter callback function */
     uint32_t               stored_chksum;       /* Stored metadata checksum value */
     uint32_t               computed_chksum;     /* Computed metadata checksum value */
+    void *tmp;
+    const unsigned char *sel_p;
     herr_t                 ret_value = SUCCEED; /* Return value */
 
     FUNC_ENTER_PACKAGE
@@ -1398,14 +1403,14 @@ H5D__struct_chunk_decode(H5D_t *dset, size_t *nbytes /*in,out*/, size_t *alloc_s
     chk->sel_alloc_size -= H5_SIZEOF_CHKSUM;
 
     /* Allocate a buffer for the encoded selection */
-    if (NULL == (chk->sel_buf = H5D__chunk_mem_alloc(chk->sel_alloc_size, pline)))
+    if (NULL == (chk->sel_buf = H5MM_malloc(chk->sel_alloc_size)))
         HGOTO_ERROR(H5E_RESOURCE, H5E_NOSPACE, FAIL, "memory allocation failed for encoded selection buffer");
 
     /* Copy over the encoded selection */
     H5MM_memcpy(chk->sel_buf, *chunk, chk->sel_nbytes);
 
     /* Allocate a buffer for the data values */
-    if (NULL == (chk->data_buf = H5D__chunk_mem_alloc(chk->data_alloc_size, pline)))
+    if (NULL == (chk->data_buf = H5MM_malloc(chk->data_alloc_size)))
         HGOTO_ERROR(H5E_RESOURCE, H5E_NOSPACE, FAIL, "memory allocation failed for data buffer");
 
     /* Copy over the data values */
@@ -1431,14 +1436,19 @@ H5D__struct_chunk_decode(H5D_t *dset, size_t *nbytes /*in,out*/, size_t *alloc_s
             HGOTO_ERROR(H5E_DATASET, H5E_CANTFILTER, FAIL, "data pipeline read failed");
     }
 
+    sel_p = chk->sel_buf;
+
     /* Decode the encoded selection to dataspace sel_space */
-    if (NULL == (chk->sel_space = H5S_decode((const unsigned char **)&chk->sel_buf)))
+    if (NULL == (chk->sel_space = H5S_decode(&sel_p)))
         HGOTO_ERROR(H5E_DATASET, H5E_CANTDECODE, FAIL, "unable to decode dataspace");
 
     /* Return values on exit */
-    *nbytes += chk->sel_nbytes + chk->data_nbytes;
-    *alloc_size += *nbytes;
+    *nbytes = (chk->sel_nbytes + chk->data_nbytes);
+    *alloc_size = *nbytes;
+
+    tmp = *chunk;
     *chunk = chk;
+    tmp = H5MM_xfree(tmp);
 
 done:
     FUNC_LEAVE_NOAPI(ret_value)
@@ -1502,7 +1512,7 @@ H5D__struct_chunk_decode_defined_values(H5D_t *dset, size_t *nbytes /*in,out*/, 
     chk->sel_alloc_size -= H5_SIZEOF_CHKSUM;
 
     /* Allocate a buffer for the encoded selection */
-    if (NULL == (chk->sel_buf = H5D__chunk_mem_alloc(chk->sel_alloc_size, pline)))
+    if (NULL == (chk->sel_buf = H5MM_malloc(chk->sel_alloc_size)))
         HGOTO_ERROR(H5E_RESOURCE, H5E_NOSPACE, FAIL, "memory allocation failed for encoded selection buffer");
 
     /* Copy over the encoded selection */
@@ -1568,7 +1578,7 @@ H5D__struct_chunk_new_chunk(H5D_t *dset, bool fill, size_t *nbytes /*out*/, size
     /* Sanity checks */
     assert(dset);
     assert(dset->shared->layout.u.struct_chunk.stc_type == H5D_SPARSE_CHUNK);
-    assert(!fill); // Why not fill?
+    assert(!fill);
 
     /* Allocate the chunk's intermediate struct */
     if (NULL == (chk = H5MM_malloc(sizeof(H5D_chunk_cache_mem_t))))
@@ -1632,10 +1642,9 @@ H5D__struct_chunk_condense(H5D_t *dset, size_t *nbytes /*in, out*/, void **chunk
     if ((chk->sel_alloc_size + chk->data_alloc_size) == (chk->sel_nbytes + chk->data_nbytes))
         /* Nothing to condense */
         HGOTO_DONE(SUCCEED);
-
-    if (NULL == (chk->sel_buf = H5D__chunk_mem_realloc(chk->sel_buf, chk->sel_nbytes, pline)))
+    if (NULL == (chk->sel_buf = H5MM_realloc(chk->sel_buf, chk->sel_nbytes)))
         HGOTO_ERROR(H5E_RESOURCE, H5E_NOSPACE, FAIL, "memory reallocation failed for raw data chunk");
-    if (NULL == (chk->data_buf = H5D__chunk_mem_realloc(chk->data_buf, chk->data_nbytes, pline)))
+    if (NULL == (chk->data_buf = H5MM_realloc(chk->data_buf, chk->data_nbytes)))
         HGOTO_ERROR(H5E_RESOURCE, H5E_NOSPACE, FAIL, "memory reallocation failed for raw data chunk");
 
     chk->sel_alloc_size  = chk->sel_nbytes;
@@ -1674,6 +1683,7 @@ done:
  * NOTE: Only handle two sections for now
  *-------------------------------------------------------------------------
  */
+#ifdef out
 static herr_t
 H5D__struct_chunk_encode(H5D_t *dset, hsize_t *write_size /*out*/, hsize_t *write_buf_alloc /*out*/,
                          bool H5_ATTR_UNUSED partial_bound, const void *chunk, void *_udata,
@@ -1684,9 +1694,159 @@ H5D__struct_chunk_encode(H5D_t *dset, hsize_t *write_size /*out*/, hsize_t *writ
     void                        *sel_buf;
     void                        *data_buf;
     uint8_t                     *p = NULL;
+    unsigned char               *sel_p = NULL;
     size_t                       sel_nbytes, sel_alloc_size;
     size_t                       data_nbytes, data_alloc_size;
+    H5O_pline_t                 *pline    = NULL; /* I/O pipeline info */
+    void                        *tot_buf  = NULL;
+    hsize_t                      nelmts;
+    size_t                       type_size;
+    uint32_t                     metadata_chksum;
+    herr_t                       ret_value = SUCCEED; /* Return value */
+
+    FUNC_ENTER_PACKAGE
+
+    /* Sanity checks */
+    assert(dset);
+
+    pline = &(dset->shared->dcpl_cache.pline);
+
+    /* Determine size of selection dataspace */
+    if (H5S_encode(chk->sel_space, &sel_p, &sel_nbytes) < 0)
+        HGOTO_ERROR(H5E_DATASET, H5E_CANTGET, FAIL, "unable to get encoded dataspace size");
+
+    /* Allocate buffer for selection */
+    sel_alloc_size = sel_nbytes;
+#ifdef out
+    if (NULL == (sel_buf = H5D__chunk_mem_alloc(sel_alloc_size, pline)))
+        HGOTO_ERROR(H5E_RESOURCE, H5E_NOSPACE, FAIL, "memory allocation failed for the chunk");
+#endif
+    if (NULL == (sel_buf = H5MM_malloc(sel_alloc_size)))
+        HGOTO_ERROR(H5E_RESOURCE, H5E_NOSPACE, FAIL, "memory allocation failed for the chunk");
+
+    sel_p = sel_buf;
+
+    /* Encode the selection */
+    if (H5S_encode(chk->sel_space, &sel_p, &sel_nbytes) < 0)
+        HGOTO_ERROR(H5E_DATASET, H5E_CANTGET, FAIL, "unable to encode dataspace");
+
+    /* Get the number of elements in the selection */
+    nelmts    = H5S_GET_SELECT_NPOINTS(chk->sel_space);
+    type_size = H5T_GET_SIZE(dset->shared->type);
+
+    assert(nelmts * type_size == chk->data_nbytes);
+
+    /* Compression */
+    if (pline && pline->tot_filt_nsects) {
+        H5Z_EDC_t err_detect; /* Error detection info */
+        H5Z_cb_t  filter_cb;  /* I/O filter callback function */
+        unsigned i;
+        H5Z_stc_filter_sect_t *filt_sect;
+        size_t *nbytes;
+        size_t *buf_size;
+        void **buf;
+        unsigned *filt_mask;
+
+        udata->unfilt_size[0] = chk->sel_nbytes;
+        udata->unfilt_size[1] = chk->data_nbytes;
+
+        /* Retrieve filter settings from API context */
+        if (H5CX_get_err_detect(&err_detect) < 0)
+            HGOTO_ERROR(H5E_DATASET, H5E_CANTGET, FAIL, "can't get error detection info");
+         if (H5CX_get_filter_cb(&filter_cb) < 0)
+            HGOTO_ERROR(H5E_DATASET, H5E_CANTGET, FAIL, "can't get I/O filter callback function");
+
+        for (i = 0, filt_sect = &pline->filt_sects[0]; i < pline->tot_filt_nsects; i++, filt_sect++) {
+    
+            if (filt_sect->nused) {
+                switch(filt_sect->seq_sect) {
+                    case H5_SECTION_SELECTION:
+                        filt_mask = &udata->filt_mask[0];
+                        nbytes = &sel_nbytes;
+                        buf_size = &sel_alloc_size;
+                        buf = &sel_buf;
+                        break;
+
+                    case H5_SECTION_FIXED:
+                        filt_mask = &udata->filt_mask[1];
+                        nbytes = &data_nbytes;
+                        buf_size = &data_alloc_size;
+                        buf = &data_buf;
+                        break;
+
+                    case H5_SECTION_VL:
+                    case H5_SECTION_NUM:
+                    default:
+                        assert(0 && "Unknown action?!?");
+                }
+                if (H5Z_apply_pipeline(pline->version, filt_sect->nused, filt_sect->filter, 0, filt_mask, 
+                                       err_detect, filter_cb, nbytes, buf_size, buf) < 0)
+                    HGOTO_ERROR(H5E_DATASET, H5E_CANTFILTER, FAIL, "output pipeline failed");
+            } /* end if nused */
+    
+        } /* end for */
+
+    } /* end if pline */
+
+    /* Allocate write_buf for selection + data */
+#ifdef out
+    if (NULL ==
+        (tot_buf = H5D__chunk_mem_alloc(sel_alloc_size + H5_SIZEOF_CHKSUM + chk->data_alloc_size, pline)))
+        HGOTO_ERROR(H5E_RESOURCE, H5E_NOSPACE, FAIL, "memory allocation failed for the chunk");
+#endif
+    if (NULL ==
+        (tot_buf = H5MM_malloc(sel_alloc_size + H5_SIZEOF_CHKSUM + chk->data_alloc_size)))
+        HGOTO_ERROR(H5E_RESOURCE, H5E_NOSPACE, FAIL, "memory allocation failed for the chunk");
+
+    /* Copy selection to tot_buf */
+    H5MM_memcpy(tot_buf, sel_buf, sel_nbytes);
+
+    /* Compute metadata checksum */
+    metadata_chksum = H5_checksum_metadata(sel_buf, (size_t)sel_nbytes, 0);
+
+    p = (uint8_t *)tot_buf + sel_nbytes;
+    /* Encode metadata checksum for the selection */
+    UINT32ENCODE(p, metadata_chksum);
+
+    sel_nbytes += H5_SIZEOF_CHKSUM;
+    sel_alloc_size += H5_SIZEOF_CHKSUM;
+
+    /* Copy data to tot_buf */
+    H5MM_memcpy((uint8_t *)tot_buf + sel_nbytes, chk->data_buf, chk->data_nbytes);
+
+    udata->offset[0] = 0; /* Filler */
+    udata->offset[1] = sel_nbytes;
+
+    *write_size      = sel_nbytes + chk->data_nbytes;
+    *write_buf_alloc = sel_alloc_size + chk->data_alloc_size;
+    *write_buf       = tot_buf;
+
+done:
+#ifdef out
+    if (sel_buf)
+        sel_buf = (uint8_t *)H5D__chunk_mem_xfree(sel_buf, pline);
+#endif
+    if (sel_buf)
+        sel_buf = H5MM_xfree(sel_buf);
+
+    FUNC_LEAVE_NOAPI(ret_value)
+} /* H5D__struct_chunk_encode() */
+#endif
+
+
+static herr_t
+H5D__struct_chunk_encode(H5D_t *dset, hsize_t *write_size /*out*/, hsize_t *write_buf_alloc /*out*/,
+                         bool H5_ATTR_UNUSED partial_bound, const void *chunk, void *_udata,
+                         void **write_buf /*out*/)
+{
+    const H5D_chunk_cache_mem_t *chk   = (const H5D_chunk_cache_mem_t *)chunk; /* Chunk memory cache info */
+    H5D_chunk_ud_t              *udata = (H5D_chunk_ud_t *)_udata;
+    void                        *sel_buf;
+    void                        *data_buf;
+    uint8_t                     *p = NULL;
     unsigned char               *sel_p    = NULL;
+    size_t                       sel_nbytes, sel_alloc_size;
+    size_t                       data_nbytes, data_alloc_size;
     H5O_pline_t                 *pline    = NULL; /* I/O pipeline info */
     hbool_t                      filtered = false;
     void                        *tot_buf  = NULL;
@@ -1710,7 +1870,7 @@ H5D__struct_chunk_encode(H5D_t *dset, hsize_t *write_size /*out*/, hsize_t *writ
 
     /* Allocate buffer for selection */
     sel_alloc_size = sel_nbytes;
-    if (NULL == (sel_buf = H5D__chunk_mem_alloc(sel_alloc_size, pline)))
+    if (NULL == (sel_buf = H5MM_malloc(sel_alloc_size)))
         HGOTO_ERROR(H5E_RESOURCE, H5E_NOSPACE, FAIL, "memory allocation failed for the chunk");
 
     sel_p = sel_buf;
@@ -1736,7 +1896,7 @@ H5D__struct_chunk_encode(H5D_t *dset, hsize_t *write_size /*out*/, hsize_t *writ
         /* Retrieve filter settings from API context */
         if (H5CX_get_err_detect(&err_detect) < 0)
             HGOTO_ERROR(H5E_DATASET, H5E_CANTGET, FAIL, "can't get error detection info");
-        if (H5CX_get_filter_cb(&filter_cb) < 0)
+         if (H5CX_get_filter_cb(&filter_cb) < 0)
             HGOTO_ERROR(H5E_DATASET, H5E_CANTGET, FAIL, "can't get I/O filter callback function");
 
         /* Process sel_space and data through the filter pipeline */
@@ -1747,11 +1907,12 @@ H5D__struct_chunk_encode(H5D_t *dset, hsize_t *write_size /*out*/, hsize_t *writ
         if (H5Z_pipeline(pline, 0, &udata->filt_mask[1], err_detect, filter_cb, &data_nbytes,
                          &data_alloc_size, &data_buf) < 0)
             HGOTO_ERROR(H5E_DATASET, H5E_CANTFILTER, FAIL, "output pipeline failed");
+
     }
 
     /* Allocate write_buf for selection + data */
     if (NULL ==
-        (tot_buf = H5D__chunk_mem_alloc(sel_alloc_size + H5_SIZEOF_CHKSUM + chk->data_alloc_size, pline)))
+        (tot_buf = H5MM_malloc(sel_alloc_size + H5_SIZEOF_CHKSUM + chk->data_alloc_size)))
         HGOTO_ERROR(H5E_RESOURCE, H5E_NOSPACE, FAIL, "memory allocation failed for the chunk");
 
     /* Copy selection to tot_buf */
@@ -1779,7 +1940,7 @@ H5D__struct_chunk_encode(H5D_t *dset, hsize_t *write_size /*out*/, hsize_t *writ
 
 done:
     if (sel_buf)
-        sel_buf = (uint8_t *)H5D__chunk_mem_xfree(sel_buf, pline);
+        sel_buf = H5MM_xfree(sel_buf);
 
     FUNC_LEAVE_NOAPI(ret_value)
 } /* H5D__struct_chunk_encode() */
@@ -1814,9 +1975,10 @@ H5D__struct_chunk_encode_in_place(H5D_t *dset, size_t *write_size /*out*/, bool 
     hbool_t                filtered = false;
     uint32_t               metadata_chksum;
     uint8_t               *p;
+    unsigned char          *sel_p = NULL;
+    H5D_chunk_cache_mem_t *tmp;
     hsize_t                nelmts;
     size_t                 type_size;
-    unsigned char         *sel_p     = NULL;
     herr_t                 ret_value = SUCCEED; /* Return value */
 
     FUNC_ENTER_PACKAGE
@@ -1834,9 +1996,9 @@ H5D__struct_chunk_encode_in_place(H5D_t *dset, size_t *write_size /*out*/, bool 
 
     chk->sel_alloc_size = chk->sel_nbytes;
 
-    if (NULL ==
-        (chk->sel_buf = H5D__chunk_mem_realloc(chk->sel_buf, chk->sel_alloc_size + H5_SIZEOF_CHKSUM, pline)))
-        HGOTO_ERROR(H5E_RESOURCE, H5E_NOSPACE, FAIL, "memory allocation failed for the chunk");
+    if (NULL == (chk->sel_buf = H5MM_realloc(chk->sel_buf, chk->sel_alloc_size + H5_SIZEOF_CHKSUM)))
+        HGOTO_ERROR(H5E_RESOURCE, H5E_CANTALLOC, FAIL,
+                    "memory allocation failed for intermediate chunk struct");
 
     sel_p = chk->sel_buf;
 
@@ -1885,29 +2047,29 @@ H5D__struct_chunk_encode_in_place(H5D_t *dset, size_t *write_size /*out*/, bool 
     }
 
     /* Realloc chk->data_buf to provide space for encoded selection and data */
-    if (NULL ==
-        (chk->data_buf = H5D__chunk_mem_realloc(chk->data_buf, (chk->sel_nbytes + chk->data_nbytes), pline)))
+    if (NULL == (chk->data_buf = H5MM_realloc(chk->data_buf, chk->sel_nbytes + chk->data_nbytes)))
         HGOTO_ERROR(H5E_RESOURCE, H5E_NOSPACE, FAIL, "memory reallocation failed for data chunk");
 
-    // Why is this shift necessary????
     /* Shift data values to the right to provide space for encoded selection */
     memmove((uint8_t *)(chk->data_buf) + chk->sel_nbytes, chk->data_buf, chk->data_nbytes);
 
-    H5MM_memcpy(chk->data_buf, chk->sel_buf, chk->sel_nbytes); // Move selection to the front
+    H5MM_memcpy(chk->data_buf, chk->sel_buf, chk->sel_nbytes);
 
-    *chunk      = chk->data_buf;                        // Returned data buffer
-    *write_size = (chk->sel_nbytes + chk->data_nbytes); // Returned size
+    tmp = chk;
 
-    udata->offset[0] = 0;               /* Filler */
-    udata->offset[1] = chk->sel_nbytes; // When writing to disk, offset (of each section) is required
+    *chunk           = chk->data_buf;
+    *write_size      = (chk->sel_nbytes + chk->data_nbytes);
+    udata->offset[1] = chk->sel_nbytes;
 
     /* Free chk->sel_buf */
-    chk->sel_buf    = (uint8_t *)H5D__chunk_mem_xfree(chk->sel_buf, pline);
+    chk->sel_buf    = H5MM_xfree(chk->sel_buf);
     chk->sel_nbytes = chk->sel_alloc_size = 0;
 
     /* Close chk->sel_space */
     if (chk->sel_space && H5S_close(chk->sel_space) < 0)
         HGOTO_ERROR(H5E_DATASET, H5E_CANTRELEASE, FAIL, "can't release dataspace for encoded selection");
+
+    tmp = H5MM_xfree(tmp);
 
 done:
     FUNC_LEAVE_NOAPI(ret_value)
@@ -1925,7 +2087,7 @@ done:
  *-------------------------------------------------------------------------
  */
 static herr_t
-H5D__struct_chunk_evict(H5D_t *dset, void *chunk, void H5_ATTR_UNUSED *udata)
+H5D__struct_chunk_evict(H5D_t *dset, void *chunk, void *udata)
 {
     H5D_chunk_cache_mem_t *chk = (H5D_chunk_cache_mem_t *)chunk; /* Chunk memory cache info */
     H5O_pline_t           *pline;                                /* I/O pipeline info */
@@ -1936,11 +2098,9 @@ H5D__struct_chunk_evict(H5D_t *dset, void *chunk, void H5_ATTR_UNUSED *udata)
     /* Sanity checks */
     assert(dset);
 
-    pline = &(dset->shared->dcpl_cache.pline);
-
     /* Free the sel_buf + data_buffer */
-    chk->sel_buf  = (uint8_t *)H5D__chunk_mem_xfree(chk->sel_buf, pline);
-    chk->data_buf = (uint8_t *)H5D__chunk_mem_xfree(chk->data_buf, pline);
+    chk->sel_buf  = H5MM_xfree(chk->sel_buf);
+    chk->data_buf = H5MM_xfree(chk->data_buf);
 
     /* Close the encoded dataspace */
     if (chk->sel_space && H5S_close(chk->sel_space) < 0)
@@ -1948,6 +2108,8 @@ H5D__struct_chunk_evict(H5D_t *dset, void *chunk, void H5_ATTR_UNUSED *udata)
 
     /* Free the chunk memory cache info structure */
     chk = H5MM_xfree(chk);
+
+    udata = H5MM_xfree(udata);
 
 done:
     FUNC_LEAVE_NOAPI(ret_value)
@@ -2506,8 +2668,7 @@ H5D__struct_chunk_scatter_mem(H5D_dset_io_info_t *dset_info, H5D_io_type_info_t 
     buf = dset_info->buf.vp;
 
     /* Allocate the data_scat_buf: chunk size * element size */
-    // scat_buf_size = dset_info->layout->u.struct_chunk.size * file_type_size;
-    scat_buf_size = dset_info->dset->shared->layout.u.struct_chunk.size;
+    scat_buf_size = dset_info->layout->u.struct_chunk.size;
     if (NULL == (data_scat_buf = H5FL_BLK_MALLOC(scat_buf, scat_buf_size)))
         HGOTO_ERROR(H5E_RESOURCE, H5E_NOSPACE, FAIL, "memory allocation failed for scattered data buffer");
     memset(data_scat_buf, 0, scat_buf_size);
@@ -2803,13 +2964,11 @@ H5D__struct_chunk_gather_mem(H5D_dset_io_info_t *dset_info, H5D_io_type_info_t *
 
         /* Allocate the data_scat_buf: chunk size * element size */
         scat_buf_size = dset_info->layout->u.struct_chunk.size;
-        // scat_buf_size = dset_info->dset->shared->layout.u.struct_chunk.size * file_type_size;
         if (NULL == (data_scat_buf = H5FL_BLK_MALLOC(scat_buf, scat_buf_size)))
             HGOTO_ERROR(H5E_RESOURCE, H5E_NOSPACE, FAIL,
                         "memory allocation failed for scattered data buffer");
         memset(data_scat_buf, 0, scat_buf_size);
 
-        // If the chunk is not new, proceed
         if (chk->sel_space != NULL) {
             /* Get the number of elements in the selection */
             sel_nelmts = H5S_GET_SELECT_NPOINTS(chk->sel_space);
@@ -3032,8 +3191,7 @@ H5D__struct_chunk_gather_mem(H5D_dset_io_info_t *dset_info, H5D_io_type_info_t *
         chk->data_nbytes     = sel_nelmts * file_type_size;
         chk->data_alloc_size = chk->data_nbytes;
 
-        if (NULL == (chk->data_buf = H5D__chunk_mem_realloc(chk->data_buf, chk->data_alloc_size,
-                                                            &dset_info->dset->shared->dcpl_cache.pline)))
+        if (NULL == (chk->data_buf = H5MM_realloc(chk->data_buf, chk->data_alloc_size)))
             HGOTO_ERROR(H5E_RESOURCE, H5E_NOSPACE, FAIL, "memory allocation failed for the chunk");
 
         /* Gather elements to chk->data_buf */
@@ -3052,9 +3210,9 @@ H5D__struct_chunk_gather_mem(H5D_dset_io_info_t *dset_info, H5D_io_type_info_t *
             data_scat_buf = H5FL_BLK_FREE(scat_buf, data_scat_buf);
     }
 
-    nbytes += chk->data_nbytes;
-    alloc_size += chk->data_alloc_size;
-    alloc_size_total += (*nbytes + *alloc_size);
+    *nbytes += chk->sel_nbytes + chk->data_nbytes;
+    *alloc_size += chk->sel_alloc_size + chk->data_alloc_size;
+    *alloc_size_total += (*nbytes + *alloc_size);
 
 done:
     /* Release selection iterators */
@@ -3455,7 +3613,7 @@ H5D__struct_chunk_evict_values(H5D_t *dset, size_t *nbytes /*in,out*/, size_t *a
 
     pline = &(dset->shared->dcpl_cache.pline);
 
-    chk->data_buf = (uint8_t *)H5D__chunk_mem_xfree(chk->data_buf, pline);
+    chk->data_buf = H5MM_xfree(chk->data_buf);
 
     chk->data_nbytes     = 0;
     chk->data_alloc_size = 0;

--- a/src/H5Dstruct_chunk.c
+++ b/src/H5Dstruct_chunk.c
@@ -1245,11 +1245,11 @@ done:
  */
 static herr_t
 H5D__struct_chunk_lookup(H5D_t *dset, size_t count, const hsize_t *scaled[] /*in*/, haddr_t *addr[] /*out*/,
-                        
+
                          hsize_t *size[] /*out*/, hsize_t *defined_values_size[] /*out*/,
-                        
+
                          size_t *size_hint[] /*out*/, size_t *defined_values_size_hint[] /*out*/,
-                        
+
                          void **_udata[] /*out*/)
 {
     H5D_chunk_ud_t             *udata;
@@ -1257,7 +1257,7 @@ H5D__struct_chunk_lookup(H5D_t *dset, size_t count, const hsize_t *scaled[] /*in
     H5O_layout_struct_chunk_t  *layout  = &dset->shared->layout.u.struct_chunk;
     H5D_chk_idx_info_t          idx_info; /* Chunked index info */
     H5O_pline_t                *pline;    /* I/O pipeline info */
-    hbool_t                     filtered = false;
+    hbool_t                     filtered        = false;
     size_t                      tot_unfilt_size = 0;
     size_t                      i;
     herr_t                      ret_value = SUCCEED; /* Return value */
@@ -1364,12 +1364,12 @@ H5D__struct_chunk_decode(H5D_t *dset, size_t *nbytes /*in,out*/, size_t *alloc_s
     H5D_chunk_cache_mem_t *chk;   /* Chunk's intermediate struct */
     H5O_pline_t           *pline; /* I/O pipeline info */
     hbool_t                filtered = false;
-    H5Z_EDC_t              err_detect;          /* Error detection info */
-    H5Z_cb_t               filter_cb;           /* I/O filter callback function */
-    uint32_t               stored_chksum;       /* Stored metadata checksum value */
-    uint32_t               computed_chksum;     /* Computed metadata checksum value */
-    void *tmp;
-    const unsigned char *sel_p;
+    H5Z_EDC_t              err_detect;      /* Error detection info */
+    H5Z_cb_t               filter_cb;       /* I/O filter callback function */
+    uint32_t               stored_chksum;   /* Stored metadata checksum value */
+    uint32_t               computed_chksum; /* Computed metadata checksum value */
+    void                  *tmp;
+    const unsigned char   *sel_p;
     herr_t                 ret_value = SUCCEED; /* Return value */
 
     FUNC_ENTER_PACKAGE
@@ -1443,12 +1443,12 @@ H5D__struct_chunk_decode(H5D_t *dset, size_t *nbytes /*in,out*/, size_t *alloc_s
         HGOTO_ERROR(H5E_DATASET, H5E_CANTDECODE, FAIL, "unable to decode dataspace");
 
     /* Return values on exit */
-    *nbytes = (chk->sel_nbytes + chk->data_nbytes);
+    *nbytes     = (chk->sel_nbytes + chk->data_nbytes);
     *alloc_size = *nbytes;
 
-    tmp = *chunk;
+    tmp    = *chunk;
     *chunk = chk;
-    tmp = H5MM_xfree(tmp);
+    tmp    = H5MM_xfree(tmp);
 
 done:
     FUNC_LEAVE_NOAPI(ret_value)
@@ -1693,12 +1693,12 @@ H5D__struct_chunk_encode(H5D_t *dset, hsize_t *write_size /*out*/, hsize_t *writ
     H5D_chunk_ud_t              *udata = (H5D_chunk_ud_t *)_udata;
     void                        *sel_buf;
     void                        *data_buf;
-    uint8_t                     *p = NULL;
+    uint8_t                     *p     = NULL;
     unsigned char               *sel_p = NULL;
     size_t                       sel_nbytes, sel_alloc_size;
     size_t                       data_nbytes, data_alloc_size;
-    H5O_pline_t                 *pline    = NULL; /* I/O pipeline info */
-    void                        *tot_buf  = NULL;
+    H5O_pline_t                 *pline   = NULL; /* I/O pipeline info */
+    void                        *tot_buf = NULL;
     hsize_t                      nelmts;
     size_t                       type_size;
     uint32_t                     metadata_chksum;
@@ -1738,14 +1738,14 @@ H5D__struct_chunk_encode(H5D_t *dset, hsize_t *write_size /*out*/, hsize_t *writ
 
     /* Compression */
     if (pline && pline->tot_filt_nsects) {
-        H5Z_EDC_t err_detect; /* Error detection info */
-        H5Z_cb_t  filter_cb;  /* I/O filter callback function */
-        unsigned i;
+        H5Z_EDC_t              err_detect; /* Error detection info */
+        H5Z_cb_t               filter_cb;  /* I/O filter callback function */
+        unsigned               i;
         H5Z_stc_filter_sect_t *filt_sect;
-        size_t *nbytes;
-        size_t *buf_size;
-        void **buf;
-        unsigned *filt_mask;
+        size_t                *nbytes;
+        size_t                *buf_size;
+        void                 **buf;
+        unsigned              *filt_mask;
 
         udata->unfilt_size[0] = chk->sel_nbytes;
         udata->unfilt_size[1] = chk->data_nbytes;
@@ -1753,25 +1753,25 @@ H5D__struct_chunk_encode(H5D_t *dset, hsize_t *write_size /*out*/, hsize_t *writ
         /* Retrieve filter settings from API context */
         if (H5CX_get_err_detect(&err_detect) < 0)
             HGOTO_ERROR(H5E_DATASET, H5E_CANTGET, FAIL, "can't get error detection info");
-         if (H5CX_get_filter_cb(&filter_cb) < 0)
+        if (H5CX_get_filter_cb(&filter_cb) < 0)
             HGOTO_ERROR(H5E_DATASET, H5E_CANTGET, FAIL, "can't get I/O filter callback function");
 
         for (i = 0, filt_sect = &pline->filt_sects[0]; i < pline->tot_filt_nsects; i++, filt_sect++) {
-    
+
             if (filt_sect->nused) {
-                switch(filt_sect->seq_sect) {
+                switch (filt_sect->seq_sect) {
                     case H5_SECTION_SELECTION:
                         filt_mask = &udata->filt_mask[0];
-                        nbytes = &sel_nbytes;
-                        buf_size = &sel_alloc_size;
-                        buf = &sel_buf;
+                        nbytes    = &sel_nbytes;
+                        buf_size  = &sel_alloc_size;
+                        buf       = &sel_buf;
                         break;
 
                     case H5_SECTION_FIXED:
                         filt_mask = &udata->filt_mask[1];
-                        nbytes = &data_nbytes;
-                        buf_size = &data_alloc_size;
-                        buf = &data_buf;
+                        nbytes    = &data_nbytes;
+                        buf_size  = &data_alloc_size;
+                        buf       = &data_buf;
                         break;
 
                     case H5_SECTION_VL:
@@ -1779,11 +1779,11 @@ H5D__struct_chunk_encode(H5D_t *dset, hsize_t *write_size /*out*/, hsize_t *writ
                     default:
                         assert(0 && "Unknown action?!?");
                 }
-                if (H5Z_apply_pipeline(pline->version, filt_sect->nused, filt_sect->filter, 0, filt_mask, 
+                if (H5Z_apply_pipeline(pline->version, filt_sect->nused, filt_sect->filter, 0, filt_mask,
                                        err_detect, filter_cb, nbytes, buf_size, buf) < 0)
                     HGOTO_ERROR(H5E_DATASET, H5E_CANTFILTER, FAIL, "output pipeline failed");
             } /* end if nused */
-    
+
         } /* end for */
 
     } /* end if pline */
@@ -1794,8 +1794,7 @@ H5D__struct_chunk_encode(H5D_t *dset, hsize_t *write_size /*out*/, hsize_t *writ
         (tot_buf = H5D__chunk_mem_alloc(sel_alloc_size + H5_SIZEOF_CHKSUM + chk->data_alloc_size, pline)))
         HGOTO_ERROR(H5E_RESOURCE, H5E_NOSPACE, FAIL, "memory allocation failed for the chunk");
 #endif
-    if (NULL ==
-        (tot_buf = H5MM_malloc(sel_alloc_size + H5_SIZEOF_CHKSUM + chk->data_alloc_size)))
+    if (NULL == (tot_buf = H5MM_malloc(sel_alloc_size + H5_SIZEOF_CHKSUM + chk->data_alloc_size)))
         HGOTO_ERROR(H5E_RESOURCE, H5E_NOSPACE, FAIL, "memory allocation failed for the chunk");
 
     /* Copy selection to tot_buf */
@@ -1833,7 +1832,6 @@ done:
 } /* H5D__struct_chunk_encode() */
 #endif
 
-
 static herr_t
 H5D__struct_chunk_encode(H5D_t *dset, hsize_t *write_size /*out*/, hsize_t *write_buf_alloc /*out*/,
                          bool H5_ATTR_UNUSED partial_bound, const void *chunk, void *_udata,
@@ -1843,8 +1841,8 @@ H5D__struct_chunk_encode(H5D_t *dset, hsize_t *write_size /*out*/, hsize_t *writ
     H5D_chunk_ud_t              *udata = (H5D_chunk_ud_t *)_udata;
     void                        *sel_buf;
     void                        *data_buf;
-    uint8_t                     *p = NULL;
-    unsigned char               *sel_p    = NULL;
+    uint8_t                     *p     = NULL;
+    unsigned char               *sel_p = NULL;
     size_t                       sel_nbytes, sel_alloc_size;
     size_t                       data_nbytes, data_alloc_size;
     H5O_pline_t                 *pline    = NULL; /* I/O pipeline info */
@@ -1896,7 +1894,7 @@ H5D__struct_chunk_encode(H5D_t *dset, hsize_t *write_size /*out*/, hsize_t *writ
         /* Retrieve filter settings from API context */
         if (H5CX_get_err_detect(&err_detect) < 0)
             HGOTO_ERROR(H5E_DATASET, H5E_CANTGET, FAIL, "can't get error detection info");
-         if (H5CX_get_filter_cb(&filter_cb) < 0)
+        if (H5CX_get_filter_cb(&filter_cb) < 0)
             HGOTO_ERROR(H5E_DATASET, H5E_CANTGET, FAIL, "can't get I/O filter callback function");
 
         /* Process sel_space and data through the filter pipeline */
@@ -1907,12 +1905,10 @@ H5D__struct_chunk_encode(H5D_t *dset, hsize_t *write_size /*out*/, hsize_t *writ
         if (H5Z_pipeline(pline, 0, &udata->filt_mask[1], err_detect, filter_cb, &data_nbytes,
                          &data_alloc_size, &data_buf) < 0)
             HGOTO_ERROR(H5E_DATASET, H5E_CANTFILTER, FAIL, "output pipeline failed");
-
     }
 
     /* Allocate write_buf for selection + data */
-    if (NULL ==
-        (tot_buf = H5MM_malloc(sel_alloc_size + H5_SIZEOF_CHKSUM + chk->data_alloc_size)))
+    if (NULL == (tot_buf = H5MM_malloc(sel_alloc_size + H5_SIZEOF_CHKSUM + chk->data_alloc_size)))
         HGOTO_ERROR(H5E_RESOURCE, H5E_NOSPACE, FAIL, "memory allocation failed for the chunk");
 
     /* Copy selection to tot_buf */
@@ -1975,7 +1971,7 @@ H5D__struct_chunk_encode_in_place(H5D_t *dset, size_t *write_size /*out*/, bool 
     hbool_t                filtered = false;
     uint32_t               metadata_chksum;
     uint8_t               *p;
-    unsigned char          *sel_p = NULL;
+    unsigned char         *sel_p = NULL;
     H5D_chunk_cache_mem_t *tmp;
     hsize_t                nelmts;
     size_t                 type_size;

--- a/src/H5Dstruct_chunk.c
+++ b/src/H5Dstruct_chunk.c
@@ -1244,10 +1244,7 @@ done:
  *-------------------------------------------------------------------------
  */
 static herr_t
-H5D__struct_chunk_lookup(H5D_t *dset, size_t count, const hsize_t *scaled[] /*in*/, haddr_t *addr[] /*out*/,
-                         hsize_t *size[] /*out*/, hsize_t *defined_values_size[] /*out*/,
-                         size_t *size_hint[] /*out*/, size_t *defined_values_size_hint[] /*out*/,
-                         void **_udata[] /*out*/)
+H5D__struct_chunk_lookup(H5D_t *dset, size_t count, const hsize_t *scaled[] /*in*/, haddr_t *addr[] /*out*/, hsize_t *size[] /*out*/, hsize_t *defined_values_size[] /*out*/, size_t *size_hint[] /*out*/, size_t *defined_values_size_hint[] /*out*/, void **_udata[] /*out*/)
 {
     H5D_chunk_ud_t             *udata;
     H5O_storage_struct_chunk_t *storage = &(dset->shared->layout.storage.u.struct_chunk);
@@ -1305,16 +1302,16 @@ H5D__struct_chunk_lookup(H5D_t *dset, size_t count, const hsize_t *scaled[] /*in
             tot_unfilt_size = udata->unfilt_size[0] + udata->unfilt_size[1];
 
         if (size_hint[i])
-            *size_hint[i] = filtered ? tot_unfilt_size : *size[i];
+            size_hint[i] = filtered ? tot_unfilt_size : size[i];
 
         /* Size of defined values */
         if (defined_values_size[i])
-            *defined_values_size[i] = filtered ? udata->unfilt_size[0] : udata->offset[1];
+            defined_values_size[i] = filtered ? udata->unfilt_size[0] : udata->offset[1];
 
         if (defined_values_size_hint[i])
-            *defined_values_size_hint[i] = filtered ? udata->unfilt_size[0] : *defined_values_size[i];
+            defined_values_size_hint[i] = filtered ? udata->unfilt_size[0] : defined_values_size[i];
 
-        _udata[i] = (void **)&udata;
+        _udata[i] = (void *)udata;
 
     } /* end count */
 
@@ -1354,9 +1351,7 @@ done:
  *-------------------------------------------------------------------------
  */
 static herr_t
-H5D__struct_chunk_decode(H5D_t *dset, size_t *nbytes /*in,out*/, size_t *alloc_size /*in,out*/,
-                         bool H5_ATTR_UNUSED partial_bound, void **chunk /*in,out*/, void *_udata)
-{
+H5D__struct_chunk_decode(H5D_t *dset, size_t *nbytes /*in,out*/, size_t *alloc_size /*in,out*/, bool H5_ATTR_UNUSED partial_bound, void **chunk /*in,out*/, void *_udata) {
     H5D_chunk_ud_t        *udata = (H5D_chunk_ud_t *)_udata;
     H5D_chunk_cache_mem_t *chk;   /* Chunk's intermediate struct */
     H5O_pline_t           *pline; /* I/O pipeline info */
@@ -1461,10 +1456,7 @@ done:
  *-------------------------------------------------------------------------
  */
 static herr_t
-H5D__struct_chunk_decode_defined_values(H5D_t *dset, size_t *nbytes /*in,out*/, size_t *alloc_size /*in,out*/,
-                                        bool H5_ATTR_UNUSED partial_bound, void **chunk /*in,out*/,
-                                        void *_udata)
-{
+H5D__struct_chunk_decode_defined_values(H5D_t *dset, size_t *nbytes /*in,out*/, size_t *alloc_size /*in,out*/, bool H5_ATTR_UNUSED partial_bound, void **chunk /*in,out*/, void *_udata) {
     H5D_chunk_ud_t        *udata = (H5D_chunk_ud_t *)_udata;
     H5D_chunk_cache_mem_t *chk;             /* Chunk's intermediate struct */
     uint32_t               stored_chksum;   /* Stored metadata checksum value */
@@ -1555,9 +1547,7 @@ done:
  *-------------------------------------------------------------------------
  */
 static herr_t
-H5D__struct_chunk_new_chunk(H5D_t *dset, bool fill, size_t *nbytes /*out*/, size_t *buf_size /*out*/,
-                            void **chunk /*out*/, void **udata /*out*/)
-{
+H5D__struct_chunk_new_chunk(H5D_t *dset, bool fill, size_t *nbytes /*out*/, size_t *buf_size /*out*/, void **chunk /*out*/, void **udata /*out*/) {
     H5D_chunk_cache_mem_t *chk; /* Chunk's intermediate struct */
     H5D_chunk_ud_t        *uptr;
 
@@ -1568,7 +1558,7 @@ H5D__struct_chunk_new_chunk(H5D_t *dset, bool fill, size_t *nbytes /*out*/, size
     /* Sanity checks */
     assert(dset);
     assert(dset->shared->layout.u.struct_chunk.stc_type == H5D_SPARSE_CHUNK);
-    assert(!fill);
+    assert(!fill); // Why not fill?
 
     /* Allocate the chunk's intermediate struct */
     if (NULL == (chk = H5MM_malloc(sizeof(H5D_chunk_cache_mem_t))))
@@ -1594,7 +1584,7 @@ H5D__struct_chunk_new_chunk(H5D_t *dset, bool fill, size_t *nbytes /*out*/, size
 
     memset(uptr, 0, sizeof(H5D_chunk_ud_t));
 
-    *udata = &uptr;
+    *udata = uptr;
 
 done:
     FUNC_LEAVE_NOAPI(ret_value)
@@ -1615,9 +1605,7 @@ done:
  *-------------------------------------------------------------------------
  */
 static herr_t
-H5D__struct_chunk_condense(H5D_t *dset, size_t *nbytes /*in, out*/, void **chunk /*in, out*/,
-                           void H5_ATTR_UNUSED *udata)
-{
+H5D__struct_chunk_condense(H5D_t *dset, size_t *nbytes /*in, out*/, void **chunk /*in, out*/, void H5_ATTR_UNUSED *udata) {
     H5O_pline_t           *pline;                                       /* I/O pipeline info  */
     H5D_chunk_cache_mem_t *chk       = (H5D_chunk_cache_mem_t *)*chunk; /* Chunk's memory cache info */
     herr_t                 ret_value = SUCCEED;                         /* Return value */
@@ -1675,17 +1663,15 @@ done:
  *-------------------------------------------------------------------------
  */
 static herr_t
-H5D__struct_chunk_encode(H5D_t *dset, hsize_t *write_size /*out*/, hsize_t *write_buf_alloc /*out*/,
-                         bool H5_ATTR_UNUSED partial_bound, const void *chunk, void *_udata,
-                         void **write_buf /*out*/)
-{
+H5D__struct_chunk_encode(H5D_t *dset, hsize_t *write_size /*out*/, hsize_t *write_buf_alloc /*out*/, bool H5_ATTR_UNUSED partial_bound, const void *chunk, void *_udata, void **write_buf /*out*/) {
     const H5D_chunk_cache_mem_t *chk   = (const H5D_chunk_cache_mem_t *)chunk; /* Chunk memory cache info */
     H5D_chunk_ud_t              *udata = (H5D_chunk_ud_t *)_udata;
     void                        *sel_buf;
     void                        *data_buf;
-    uint8_t                     *p = (uint8_t *)sel_buf;
+    uint8_t                     *p = NULL;
     size_t                       sel_nbytes, sel_alloc_size;
     size_t                       data_nbytes, data_alloc_size;
+    unsigned char               *sel_p = NULL;
     H5O_pline_t                 *pline    = NULL; /* I/O pipeline info */
     hbool_t                      filtered = false;
     void                        *tot_buf  = NULL;
@@ -1704,7 +1690,7 @@ H5D__struct_chunk_encode(H5D_t *dset, hsize_t *write_size /*out*/, hsize_t *writ
         filtered = true;
 
     /* Determine size of selection dataspace */
-    if (H5S_encode(chk->sel_space, NULL, &sel_nbytes) < 0)
+    if (H5S_encode(chk->sel_space, &sel_p, &sel_nbytes) < 0)
         HGOTO_ERROR(H5E_DATASET, H5E_CANTGET, FAIL, "unable to get encoded dataspace size");
 
     /* Allocate buffer for selection */
@@ -1712,8 +1698,10 @@ H5D__struct_chunk_encode(H5D_t *dset, hsize_t *write_size /*out*/, hsize_t *writ
     if (NULL == (sel_buf = H5D__chunk_mem_alloc(sel_alloc_size, pline)))
         HGOTO_ERROR(H5E_RESOURCE, H5E_NOSPACE, FAIL, "memory allocation failed for the chunk");
 
+    sel_p = sel_buf;
+
     /* Encode the selection */
-    if (H5S_encode(chk->sel_space, (unsigned char **)&sel_buf, &sel_nbytes) < 0)
+    if (H5S_encode(chk->sel_space, &sel_p, &sel_nbytes) < 0)
         HGOTO_ERROR(H5E_DATASET, H5E_CANTGET, FAIL, "unable to encode dataspace");
 
     /* Get the number of elements in the selection */
@@ -1802,9 +1790,7 @@ done:
  *-------------------------------------------------------------------------
  */
 static herr_t
-H5D__struct_chunk_encode_in_place(H5D_t *dset, size_t *write_size /*out*/, bool H5_ATTR_UNUSED partial_bound,
-                                  void **chunk /*in,out*/, void *_udata)
-{
+H5D__struct_chunk_encode_in_place(H5D_t *dset, size_t *write_size /*out*/, bool H5_ATTR_UNUSED partial_bound, void **chunk /*in,out*/, void *_udata) {
     H5D_chunk_cache_mem_t *chk   = (H5D_chunk_cache_mem_t *)*chunk; /* Chunk memory cache info */
     H5D_chunk_ud_t        *udata = (H5D_chunk_ud_t *)_udata;
     H5O_pline_t           *pline; /* I/O pipeline info */
@@ -1813,6 +1799,7 @@ H5D__struct_chunk_encode_in_place(H5D_t *dset, size_t *write_size /*out*/, bool 
     uint8_t               *p;
     hsize_t                nelmts;
     size_t                 type_size;
+    unsigned char          *sel_p = NULL;
     herr_t                 ret_value = SUCCEED; /* Return value */
 
     FUNC_ENTER_PACKAGE
@@ -1825,7 +1812,7 @@ H5D__struct_chunk_encode_in_place(H5D_t *dset, size_t *write_size /*out*/, bool 
         filtered = true;
 
     /* Determine size of selection dataspace */
-    if (H5S_encode(chk->sel_space, NULL, &chk->sel_nbytes) < 0)
+    if (H5S_encode(chk->sel_space, &sel_p, &chk->sel_nbytes) < 0)
         HGOTO_ERROR(H5E_DATASET, H5E_CANTGET, FAIL, "unable to get encoded dataspace size");
 
     chk->sel_alloc_size = chk->sel_nbytes;
@@ -1834,8 +1821,10 @@ H5D__struct_chunk_encode_in_place(H5D_t *dset, size_t *write_size /*out*/, bool 
         (chk->sel_buf = H5D__chunk_mem_realloc(chk->sel_buf, chk->sel_alloc_size + H5_SIZEOF_CHKSUM, pline)))
         HGOTO_ERROR(H5E_RESOURCE, H5E_NOSPACE, FAIL, "memory allocation failed for the chunk");
 
+    sel_p = chk->sel_buf;
+
     /* Encode the selection */
-    if (H5S_encode(chk->sel_space, (unsigned char **)&chk->sel_buf, &chk->sel_nbytes) < 0)
+    if (H5S_encode(chk->sel_space, &sel_p, &chk->sel_nbytes) < 0)
         HGOTO_ERROR(H5E_DATASET, H5E_CANTGET, FAIL, "unable to encode dataspace");
 
     /* Compute metadata checksum for chk->sel_space into chk->data_buf */
@@ -1847,6 +1836,7 @@ H5D__struct_chunk_encode_in_place(H5D_t *dset, size_t *write_size /*out*/, bool 
 
     chk->sel_nbytes += H5_SIZEOF_CHKSUM;
     chk->sel_alloc_size += H5_SIZEOF_CHKSUM;
+
 
     /* Get the number of elements in the selection */
     nelmts    = H5S_GET_SELECT_NPOINTS(chk->sel_space);
@@ -1883,14 +1873,17 @@ H5D__struct_chunk_encode_in_place(H5D_t *dset, size_t *write_size /*out*/, bool 
         (chk->data_buf = H5D__chunk_mem_realloc(chk->data_buf, (chk->sel_nbytes + chk->data_nbytes), pline)))
         HGOTO_ERROR(H5E_RESOURCE, H5E_NOSPACE, FAIL, "memory reallocation failed for data chunk");
 
+    // Why is this shift necessary????
     /* Shift data values to the right to provide space for encoded selection */
     memmove((uint8_t *)(chk->data_buf) + chk->sel_nbytes, chk->data_buf, chk->data_nbytes);
 
-    H5MM_memcpy(chk->data_buf, chk->sel_buf, chk->sel_nbytes);
+    H5MM_memcpy(chk->data_buf, chk->sel_buf, chk->sel_nbytes); // Move selection to the front
 
-    *chunk           = chk->data_buf;
-    *write_size      = (chk->sel_nbytes + chk->data_nbytes);
-    udata->offset[1] = chk->sel_nbytes;
+    *chunk           = chk->data_buf; // Returned data buffer
+    *write_size      = (chk->sel_nbytes + chk->data_nbytes); // Returned size
+
+    udata->offset[0] = 0; /* Filler */
+    udata->offset[1] = chk->sel_nbytes; // When writing to disk, offset (of each section) is required
 
     /* Free chk->sel_buf */
     chk->sel_buf    = (uint8_t *)H5D__chunk_mem_xfree(chk->sel_buf, pline);
@@ -2066,12 +2059,7 @@ done:
  *-------------------------------------------------------------------------
  */
 static herr_t
-H5D__struct_chunk_vector_read(H5D_t *dset, haddr_t addr, const H5S_t *file_space_in,
-                              bool H5_ATTR_UNUSED partial_bound, void *chunk /*in*/,
-                              size_t *vec_count /*out*/, haddr_t **offsets /*out*/, size_t **sizes /*out*/,
-                              bool *vector_possible /*out*/, bool *require_values /*out*/,
-                              void H5_ATTR_UNUSED *udata)
-{
+H5D__struct_chunk_vector_read(H5D_t *dset, haddr_t addr, const H5S_t *file_space_in, bool H5_ATTR_UNUSED partial_bound, void *chunk /*in*/, size_t *vec_count /*out*/, haddr_t **offsets /*out*/, size_t **sizes /*out*/, bool *vector_possible /*out*/, bool *require_values /*out*/, void H5_ATTR_UNUSED *udata) {
     H5D_chunk_cache_mem_t  *chk = (H5D_chunk_cache_mem_t *)chunk; /* Chunk memory cache info */
     H5O_pline_t            *pline;                                /* I/O pipeline info */
     size_t                  elmt_size = 0;
@@ -2260,12 +2248,7 @@ done:
  *-------------------------------------------------------------------------
  */
 static herr_t
-H5D__struct_chunk_vector_write(H5D_t *dset, haddr_t addr, const H5S_t *file_space_in,
-                               bool H5_ATTR_UNUSED partial_bound, void *chunk /*in*/,
-                               size_t *vec_count /*out*/, haddr_t **offsets /*out*/, size_t **sizes /*out*/,
-                               bool *vector_possible /*out*/, bool *require_values /*out*/,
-                               void H5_ATTR_UNUSED *udata)
-{
+H5D__struct_chunk_vector_write(H5D_t *dset, haddr_t addr, const H5S_t *file_space_in, bool H5_ATTR_UNUSED partial_bound, void *chunk /*in*/, size_t *vec_count /*out*/, haddr_t **offsets /*out*/, size_t **sizes /*out*/, bool *vector_possible /*out*/, bool *require_values /*out*/, void H5_ATTR_UNUSED *udata) {
     H5D_chunk_cache_mem_t  *chk       = (H5D_chunk_cache_mem_t *)chunk; /* Chunk memory cache info */
     size_t                  elmt_size = 0;
     haddr_t                *vec_addrs = NULL;
@@ -2441,10 +2424,7 @@ done:
  *-------------------------------------------------------------------------
  */
 static herr_t
-H5D__struct_chunk_scatter_mem(H5D_dset_io_info_t *dset_info, H5D_io_type_info_t *io_type_info,
-                              const H5S_t *mem_space, const H5S_t *file_space, const void *chunk,
-                              void H5_ATTR_UNUSED *udata)
-{
+H5D__struct_chunk_scatter_mem(H5D_dset_io_info_t *dset_info, H5D_io_type_info_t *io_type_info, const H5S_t *mem_space, const H5S_t *file_space, const void *chunk, void H5_ATTR_UNUSED *udata) {
     void           *buf;                    /* Local pointer to application buffer */
     void           *tmp_buf;                /* Buffer to use for type conversion */
     H5S_sel_iter_t *file_iter      = NULL;  /* Memory selection iteration info*/
@@ -2497,7 +2477,8 @@ H5D__struct_chunk_scatter_mem(H5D_dset_io_info_t *dset_info, H5D_io_type_info_t 
     buf = dset_info->buf.vp;
 
     /* Allocate the data_scat_buf: chunk size * element size */
-    scat_buf_size = dset_info->layout->u.struct_chunk.size * file_type_size;
+    // scat_buf_size = dset_info->layout->u.struct_chunk.size * file_type_size;
+    scat_buf_size = dset_info->dset->shared->layout.u.struct_chunk.size;
     if (NULL == (data_scat_buf = H5FL_BLK_MALLOC(scat_buf, scat_buf_size)))
         HGOTO_ERROR(H5E_RESOURCE, H5E_NOSPACE, FAIL, "memory allocation failed for scattered data buffer");
     memset(data_scat_buf, 0, scat_buf_size);
@@ -2726,11 +2707,7 @@ done:
  *-------------------------------------------------------------------------
  */
 static herr_t
-H5D__struct_chunk_gather_mem(H5D_dset_io_info_t *dset_info, H5D_io_type_info_t *io_type_info,
-                             const H5S_t *mem_space, const H5S_t *file_space, size_t *nbytes /*in,out*/,
-                             size_t *alloc_size /*in,out*/, size_t *alloc_size_total /*in,out*/, void *chunk,
-                             void H5_ATTR_UNUSED *udata)
-{
+H5D__struct_chunk_gather_mem(H5D_dset_io_info_t *dset_info, H5D_io_type_info_t *io_type_info, const H5S_t *mem_space, const H5S_t *file_space, size_t *nbytes /*in,out*/, size_t *alloc_size /*in,out*/, size_t *alloc_size_total /*in,out*/, void *chunk, void H5_ATTR_UNUSED *udata) {
 
     const void             *buf;                    /* Local pointer to application buffer */
     void                   *tmp_buf;                /* Buffer to use for type conversion */
@@ -2792,12 +2769,14 @@ H5D__struct_chunk_gather_mem(H5D_dset_io_info_t *dset_info, H5D_io_type_info_t *
         hsize_t sel_nelmts;
 
         /* Allocate the data_scat_buf: chunk size * element size */
-        scat_buf_size = dset_info->layout->u.struct_chunk.size * file_type_size;
+        scat_buf_size = dset_info->layout->u.struct_chunk.size;
+        // scat_buf_size = dset_info->dset->shared->layout.u.struct_chunk.size * file_type_size;
         if (NULL == (data_scat_buf = H5FL_BLK_MALLOC(scat_buf, scat_buf_size)))
             HGOTO_ERROR(H5E_RESOURCE, H5E_NOSPACE, FAIL,
                         "memory allocation failed for scattered data buffer");
         memset(data_scat_buf, 0, scat_buf_size);
 
+        // If the chunk is not new, proceed
         if (chk->sel_space != NULL) {
             /* Get the number of elements in the selection */
             sel_nelmts = H5S_GET_SELECT_NPOINTS(chk->sel_space);
@@ -2983,13 +2962,21 @@ H5D__struct_chunk_gather_mem(H5D_dset_io_info_t *dset_info, H5D_io_type_info_t *
      *  Gather data in data_scat_buf to chk->data_buf according to chk->sel_space
      */
     {
+        H5S_t *sel_space;
         hsize_t sel_nelmts;
         hsize_t n;
 
         /* Combine selections */
         if (chk->sel_space) {
-            if (NULL == (chk->sel_space = H5S__combine_select(chk->sel_space, H5S_SELECT_OR, flex_fspace.vp)))
+            if (NULL == (sel_space = H5S__combine_select(chk->sel_space, H5S_SELECT_OR, flex_fspace.vp)))
                 HGOTO_ERROR(H5E_DATASET, H5E_CANTINIT, FAIL, "unable to get dataspace");
+            if (H5S_close(chk->sel_space) < 0)
+                HGOTO_ERROR(H5E_DATASET, H5E_CANTRELEASE, FAIL, "can't release dataspace");
+
+            if (NULL == (chk->sel_space = H5S_copy(sel_space, false, true)))
+                HGOTO_ERROR(H5E_DATASET, H5E_CANTINIT, FAIL, "unable to get dataspace");
+            if (H5S_close(sel_space) < 0)
+                HGOTO_ERROR(H5E_DATASET, H5E_CANTRELEASE, FAIL, "can't release dataspace");
         }
         else {
             if (NULL == (chk->sel_space = H5S_copy(file_space, false, true)))
@@ -3032,9 +3019,9 @@ H5D__struct_chunk_gather_mem(H5D_dset_io_info_t *dset_info, H5D_io_type_info_t *
             data_scat_buf = H5FL_BLK_FREE(scat_buf, data_scat_buf);
     }
 
-    *nbytes += chk->sel_nbytes + chk->data_nbytes;
-    *alloc_size += chk->sel_alloc_size + chk->data_alloc_size;
-    *alloc_size_total += (*nbytes + *alloc_size);
+    nbytes += chk->data_nbytes;
+    alloc_size += chk->data_alloc_size;
+    alloc_size_total += (*nbytes + *alloc_size);
 
 done:
     /* Release selection iterators */
@@ -3082,10 +3069,7 @@ done:
  *-------------------------------------------------------------------------
  */
 static herr_t
-H5D__struct_chunk_fill(H5D_dset_io_info_t *dset_info, H5D_io_type_info_t H5_ATTR_UNUSED *io_type_info,
-                       H5S_t *space, size_t *nbytes /*in,out*/, size_t *alloc_size /*in,out*/,
-                       size_t *alloc_size_total /*in,out*/, void *chunk, void H5_ATTR_UNUSED *udata)
-{
+H5D__struct_chunk_fill(H5D_dset_io_info_t *dset_info, H5D_io_type_info_t H5_ATTR_UNUSED *io_type_info, H5S_t *space, size_t *nbytes /*in,out*/, size_t *alloc_size /*in,out*/, size_t *alloc_size_total /*in,out*/, void *chunk, void H5_ATTR_UNUSED *udata) {
     const H5O_fill_t      *fill = &(dset_info->dset->shared->dcpl_cache.fill); /* Fill value info */
     H5D_chunk_cache_mem_t *chk  = (H5D_chunk_cache_mem_t *)chunk;              /* Chunk's memory cache info */
     uint8_t                elmt_buf[H5T_ELEM_BUF_SIZE];                        /* Buffer for element data */
@@ -3178,9 +3162,7 @@ done:
  *-------------------------------------------------------------------------
  */
 static herr_t
-H5D__struct_chunk_defined_values(H5D_t *dset, const H5S_t *selection, void *chunk,
-                                 H5S_t **defined_values /*out*/, void H5_ATTR_UNUSED *udata)
-{
+H5D__struct_chunk_defined_values(H5D_t *dset, const H5S_t *selection, void *chunk, H5S_t **defined_values /*out*/, void H5_ATTR_UNUSED *udata) {
 
     H5D_chunk_cache_mem_t  *chk = (H5D_chunk_cache_mem_t *)chunk; /* Chunk's memory cache info */
     H5_flexible_const_ptr_t flex_sel;
@@ -3229,10 +3211,7 @@ done:
  *-------------------------------------------------------------------------
  */
 static herr_t
-H5D__struct_chunk_erase_values(H5D_t *dset, const H5S_t *selection, size_t *nbytes /*in,out*/,
-                               size_t H5_ATTR_UNUSED *alloc_size /*in,out*/, void *chunk,
-                               bool *delete_chunk /*out*/, void H5_ATTR_UNUSED *udata)
-{
+H5D__struct_chunk_erase_values(H5D_t *dset, const H5S_t *selection, size_t *nbytes /*in,out*/, size_t H5_ATTR_UNUSED *alloc_size /*in,out*/, void *chunk, bool *delete_chunk /*out*/, void H5_ATTR_UNUSED *udata) {
     H5D_chunk_cache_mem_t  *chk = (H5D_chunk_cache_mem_t *)chunk; /* Chunk memory cache info */
     void                   *buf = chk->data_buf;
     H5S_t                  *serial_values_space = NULL;

--- a/src/H5Dstruct_chunk.c
+++ b/src/H5Dstruct_chunk.c
@@ -1244,7 +1244,10 @@ done:
  *-------------------------------------------------------------------------
  */
 static herr_t
-H5D__struct_chunk_lookup(H5D_t *dset, size_t count, const hsize_t *scaled[] /*in*/, haddr_t *addr[] /*out*/, hsize_t *size[] /*out*/, hsize_t *defined_values_size[] /*out*/, size_t *size_hint[] /*out*/, size_t *defined_values_size_hint[] /*out*/, void **_udata[] /*out*/)
+H5D__struct_chunk_lookup(H5D_t *dset, size_t count, const hsize_t *scaled[] /*in*/, haddr_t *addr[] /*out*/,
+                         hsize_t *size[] /*out*/, hsize_t *defined_values_size[] /*out*/,
+                         size_t *size_hint[] /*out*/, size_t *defined_values_size_hint[] /*out*/,
+                         void **_udata[] /*out*/)
 {
     H5D_chunk_ud_t             *udata;
     H5O_storage_struct_chunk_t *storage = &(dset->shared->layout.storage.u.struct_chunk);
@@ -1351,7 +1354,9 @@ done:
  *-------------------------------------------------------------------------
  */
 static herr_t
-H5D__struct_chunk_decode(H5D_t *dset, size_t *nbytes /*in,out*/, size_t *alloc_size /*in,out*/, bool H5_ATTR_UNUSED partial_bound, void **chunk /*in,out*/, void *_udata) {
+H5D__struct_chunk_decode(H5D_t *dset, size_t *nbytes /*in,out*/, size_t *alloc_size /*in,out*/,
+                         bool H5_ATTR_UNUSED partial_bound, void **chunk /*in,out*/, void *_udata)
+{
     H5D_chunk_ud_t        *udata = (H5D_chunk_ud_t *)_udata;
     H5D_chunk_cache_mem_t *chk;   /* Chunk's intermediate struct */
     H5O_pline_t           *pline; /* I/O pipeline info */
@@ -1456,7 +1461,10 @@ done:
  *-------------------------------------------------------------------------
  */
 static herr_t
-H5D__struct_chunk_decode_defined_values(H5D_t *dset, size_t *nbytes /*in,out*/, size_t *alloc_size /*in,out*/, bool H5_ATTR_UNUSED partial_bound, void **chunk /*in,out*/, void *_udata) {
+H5D__struct_chunk_decode_defined_values(H5D_t *dset, size_t *nbytes /*in,out*/, size_t *alloc_size /*in,out*/,
+                                        bool H5_ATTR_UNUSED partial_bound, void **chunk /*in,out*/,
+                                        void *_udata)
+{
     H5D_chunk_ud_t        *udata = (H5D_chunk_ud_t *)_udata;
     H5D_chunk_cache_mem_t *chk;             /* Chunk's intermediate struct */
     uint32_t               stored_chksum;   /* Stored metadata checksum value */
@@ -1547,7 +1555,9 @@ done:
  *-------------------------------------------------------------------------
  */
 static herr_t
-H5D__struct_chunk_new_chunk(H5D_t *dset, bool fill, size_t *nbytes /*out*/, size_t *buf_size /*out*/, void **chunk /*out*/, void **udata /*out*/) {
+H5D__struct_chunk_new_chunk(H5D_t *dset, bool fill, size_t *nbytes /*out*/, size_t *buf_size /*out*/,
+                            void **chunk /*out*/, void **udata /*out*/)
+{
     H5D_chunk_cache_mem_t *chk; /* Chunk's intermediate struct */
     H5D_chunk_ud_t        *uptr;
 
@@ -1605,7 +1615,9 @@ done:
  *-------------------------------------------------------------------------
  */
 static herr_t
-H5D__struct_chunk_condense(H5D_t *dset, size_t *nbytes /*in, out*/, void **chunk /*in, out*/, void H5_ATTR_UNUSED *udata) {
+H5D__struct_chunk_condense(H5D_t *dset, size_t *nbytes /*in, out*/, void **chunk /*in, out*/,
+                           void H5_ATTR_UNUSED *udata)
+{
     H5O_pline_t           *pline;                                       /* I/O pipeline info  */
     H5D_chunk_cache_mem_t *chk       = (H5D_chunk_cache_mem_t *)*chunk; /* Chunk's memory cache info */
     herr_t                 ret_value = SUCCEED;                         /* Return value */
@@ -1663,7 +1675,10 @@ done:
  *-------------------------------------------------------------------------
  */
 static herr_t
-H5D__struct_chunk_encode(H5D_t *dset, hsize_t *write_size /*out*/, hsize_t *write_buf_alloc /*out*/, bool H5_ATTR_UNUSED partial_bound, const void *chunk, void *_udata, void **write_buf /*out*/) {
+H5D__struct_chunk_encode(H5D_t *dset, hsize_t *write_size /*out*/, hsize_t *write_buf_alloc /*out*/,
+                         bool H5_ATTR_UNUSED partial_bound, const void *chunk, void *_udata,
+                         void **write_buf /*out*/)
+{
     const H5D_chunk_cache_mem_t *chk   = (const H5D_chunk_cache_mem_t *)chunk; /* Chunk memory cache info */
     H5D_chunk_ud_t              *udata = (H5D_chunk_ud_t *)_udata;
     void                        *sel_buf;
@@ -1671,7 +1686,7 @@ H5D__struct_chunk_encode(H5D_t *dset, hsize_t *write_size /*out*/, hsize_t *writ
     uint8_t                     *p = NULL;
     size_t                       sel_nbytes, sel_alloc_size;
     size_t                       data_nbytes, data_alloc_size;
-    unsigned char               *sel_p = NULL;
+    unsigned char               *sel_p    = NULL;
     H5O_pline_t                 *pline    = NULL; /* I/O pipeline info */
     hbool_t                      filtered = false;
     void                        *tot_buf  = NULL;
@@ -1790,7 +1805,9 @@ done:
  *-------------------------------------------------------------------------
  */
 static herr_t
-H5D__struct_chunk_encode_in_place(H5D_t *dset, size_t *write_size /*out*/, bool H5_ATTR_UNUSED partial_bound, void **chunk /*in,out*/, void *_udata) {
+H5D__struct_chunk_encode_in_place(H5D_t *dset, size_t *write_size /*out*/, bool H5_ATTR_UNUSED partial_bound,
+                                  void **chunk /*in,out*/, void *_udata)
+{
     H5D_chunk_cache_mem_t *chk   = (H5D_chunk_cache_mem_t *)*chunk; /* Chunk memory cache info */
     H5D_chunk_ud_t        *udata = (H5D_chunk_ud_t *)_udata;
     H5O_pline_t           *pline; /* I/O pipeline info */
@@ -1799,7 +1816,7 @@ H5D__struct_chunk_encode_in_place(H5D_t *dset, size_t *write_size /*out*/, bool 
     uint8_t               *p;
     hsize_t                nelmts;
     size_t                 type_size;
-    unsigned char          *sel_p = NULL;
+    unsigned char         *sel_p     = NULL;
     herr_t                 ret_value = SUCCEED; /* Return value */
 
     FUNC_ENTER_PACKAGE
@@ -1836,7 +1853,6 @@ H5D__struct_chunk_encode_in_place(H5D_t *dset, size_t *write_size /*out*/, bool 
 
     chk->sel_nbytes += H5_SIZEOF_CHKSUM;
     chk->sel_alloc_size += H5_SIZEOF_CHKSUM;
-
 
     /* Get the number of elements in the selection */
     nelmts    = H5S_GET_SELECT_NPOINTS(chk->sel_space);
@@ -1879,10 +1895,10 @@ H5D__struct_chunk_encode_in_place(H5D_t *dset, size_t *write_size /*out*/, bool 
 
     H5MM_memcpy(chk->data_buf, chk->sel_buf, chk->sel_nbytes); // Move selection to the front
 
-    *chunk           = chk->data_buf; // Returned data buffer
-    *write_size      = (chk->sel_nbytes + chk->data_nbytes); // Returned size
+    *chunk      = chk->data_buf;                        // Returned data buffer
+    *write_size = (chk->sel_nbytes + chk->data_nbytes); // Returned size
 
-    udata->offset[0] = 0; /* Filler */
+    udata->offset[0] = 0;               /* Filler */
     udata->offset[1] = chk->sel_nbytes; // When writing to disk, offset (of each section) is required
 
     /* Free chk->sel_buf */
@@ -2059,7 +2075,12 @@ done:
  *-------------------------------------------------------------------------
  */
 static herr_t
-H5D__struct_chunk_vector_read(H5D_t *dset, haddr_t addr, const H5S_t *file_space_in, bool H5_ATTR_UNUSED partial_bound, void *chunk /*in*/, size_t *vec_count /*out*/, haddr_t **offsets /*out*/, size_t **sizes /*out*/, bool *vector_possible /*out*/, bool *require_values /*out*/, void H5_ATTR_UNUSED *udata) {
+H5D__struct_chunk_vector_read(H5D_t *dset, haddr_t addr, const H5S_t *file_space_in,
+                              bool H5_ATTR_UNUSED partial_bound, void *chunk /*in*/,
+                              size_t *vec_count /*out*/, haddr_t **offsets /*out*/, size_t **sizes /*out*/,
+                              bool *vector_possible /*out*/, bool *require_values /*out*/,
+                              void H5_ATTR_UNUSED *udata)
+{
     H5D_chunk_cache_mem_t  *chk = (H5D_chunk_cache_mem_t *)chunk; /* Chunk memory cache info */
     H5O_pline_t            *pline;                                /* I/O pipeline info */
     size_t                  elmt_size = 0;
@@ -2248,7 +2269,12 @@ done:
  *-------------------------------------------------------------------------
  */
 static herr_t
-H5D__struct_chunk_vector_write(H5D_t *dset, haddr_t addr, const H5S_t *file_space_in, bool H5_ATTR_UNUSED partial_bound, void *chunk /*in*/, size_t *vec_count /*out*/, haddr_t **offsets /*out*/, size_t **sizes /*out*/, bool *vector_possible /*out*/, bool *require_values /*out*/, void H5_ATTR_UNUSED *udata) {
+H5D__struct_chunk_vector_write(H5D_t *dset, haddr_t addr, const H5S_t *file_space_in,
+                               bool H5_ATTR_UNUSED partial_bound, void *chunk /*in*/,
+                               size_t *vec_count /*out*/, haddr_t **offsets /*out*/, size_t **sizes /*out*/,
+                               bool *vector_possible /*out*/, bool *require_values /*out*/,
+                               void H5_ATTR_UNUSED *udata)
+{
     H5D_chunk_cache_mem_t  *chk       = (H5D_chunk_cache_mem_t *)chunk; /* Chunk memory cache info */
     size_t                  elmt_size = 0;
     haddr_t                *vec_addrs = NULL;
@@ -2424,7 +2450,10 @@ done:
  *-------------------------------------------------------------------------
  */
 static herr_t
-H5D__struct_chunk_scatter_mem(H5D_dset_io_info_t *dset_info, H5D_io_type_info_t *io_type_info, const H5S_t *mem_space, const H5S_t *file_space, const void *chunk, void H5_ATTR_UNUSED *udata) {
+H5D__struct_chunk_scatter_mem(H5D_dset_io_info_t *dset_info, H5D_io_type_info_t *io_type_info,
+                              const H5S_t *mem_space, const H5S_t *file_space, const void *chunk,
+                              void H5_ATTR_UNUSED *udata)
+{
     void           *buf;                    /* Local pointer to application buffer */
     void           *tmp_buf;                /* Buffer to use for type conversion */
     H5S_sel_iter_t *file_iter      = NULL;  /* Memory selection iteration info*/
@@ -2707,7 +2736,11 @@ done:
  *-------------------------------------------------------------------------
  */
 static herr_t
-H5D__struct_chunk_gather_mem(H5D_dset_io_info_t *dset_info, H5D_io_type_info_t *io_type_info, const H5S_t *mem_space, const H5S_t *file_space, size_t *nbytes /*in,out*/, size_t *alloc_size /*in,out*/, size_t *alloc_size_total /*in,out*/, void *chunk, void H5_ATTR_UNUSED *udata) {
+H5D__struct_chunk_gather_mem(H5D_dset_io_info_t *dset_info, H5D_io_type_info_t *io_type_info,
+                             const H5S_t *mem_space, const H5S_t *file_space, size_t *nbytes /*in,out*/,
+                             size_t *alloc_size /*in,out*/, size_t *alloc_size_total /*in,out*/, void *chunk,
+                             void H5_ATTR_UNUSED *udata)
+{
 
     const void             *buf;                    /* Local pointer to application buffer */
     void                   *tmp_buf;                /* Buffer to use for type conversion */
@@ -2962,7 +2995,7 @@ H5D__struct_chunk_gather_mem(H5D_dset_io_info_t *dset_info, H5D_io_type_info_t *
      *  Gather data in data_scat_buf to chk->data_buf according to chk->sel_space
      */
     {
-        H5S_t *sel_space;
+        H5S_t  *sel_space;
         hsize_t sel_nelmts;
         hsize_t n;
 
@@ -3069,7 +3102,10 @@ done:
  *-------------------------------------------------------------------------
  */
 static herr_t
-H5D__struct_chunk_fill(H5D_dset_io_info_t *dset_info, H5D_io_type_info_t H5_ATTR_UNUSED *io_type_info, H5S_t *space, size_t *nbytes /*in,out*/, size_t *alloc_size /*in,out*/, size_t *alloc_size_total /*in,out*/, void *chunk, void H5_ATTR_UNUSED *udata) {
+H5D__struct_chunk_fill(H5D_dset_io_info_t *dset_info, H5D_io_type_info_t H5_ATTR_UNUSED *io_type_info,
+                       H5S_t *space, size_t *nbytes /*in,out*/, size_t *alloc_size /*in,out*/,
+                       size_t *alloc_size_total /*in,out*/, void *chunk, void H5_ATTR_UNUSED *udata)
+{
     const H5O_fill_t      *fill = &(dset_info->dset->shared->dcpl_cache.fill); /* Fill value info */
     H5D_chunk_cache_mem_t *chk  = (H5D_chunk_cache_mem_t *)chunk;              /* Chunk's memory cache info */
     uint8_t                elmt_buf[H5T_ELEM_BUF_SIZE];                        /* Buffer for element data */
@@ -3162,7 +3198,9 @@ done:
  *-------------------------------------------------------------------------
  */
 static herr_t
-H5D__struct_chunk_defined_values(H5D_t *dset, const H5S_t *selection, void *chunk, H5S_t **defined_values /*out*/, void H5_ATTR_UNUSED *udata) {
+H5D__struct_chunk_defined_values(H5D_t *dset, const H5S_t *selection, void *chunk,
+                                 H5S_t **defined_values /*out*/, void H5_ATTR_UNUSED *udata)
+{
 
     H5D_chunk_cache_mem_t  *chk = (H5D_chunk_cache_mem_t *)chunk; /* Chunk's memory cache info */
     H5_flexible_const_ptr_t flex_sel;
@@ -3211,7 +3249,10 @@ done:
  *-------------------------------------------------------------------------
  */
 static herr_t
-H5D__struct_chunk_erase_values(H5D_t *dset, const H5S_t *selection, size_t *nbytes /*in,out*/, size_t H5_ATTR_UNUSED *alloc_size /*in,out*/, void *chunk, bool *delete_chunk /*out*/, void H5_ATTR_UNUSED *udata) {
+H5D__struct_chunk_erase_values(H5D_t *dset, const H5S_t *selection, size_t *nbytes /*in,out*/,
+                               size_t H5_ATTR_UNUSED *alloc_size /*in,out*/, void *chunk,
+                               bool *delete_chunk /*out*/, void H5_ATTR_UNUSED *udata)
+{
     H5D_chunk_cache_mem_t  *chk = (H5D_chunk_cache_mem_t *)chunk; /* Chunk memory cache info */
     void                   *buf = chk->data_buf;
     H5S_t                  *serial_values_space = NULL;

--- a/src/H5SC.c
+++ b/src/H5SC.c
@@ -268,7 +268,7 @@ H5SC__io_info_init(H5SC_t H5_ATTR_NDEBUG_UNUSED *cache, H5SC_io_info_t *sc_io_in
         unsigned     num_partial_dims;
         hsize_t      curr_partial_clip[H5S_MAX_RANK]; /* Current partial dimension sizes to clip against */
         hsize_t      partial_dim_size[H5S_MAX_RANK];  /* Size of a partial dimension */
-        bool         is_partial_dim[H5S_MAX_RANK];    /* Whether a dimension is currently a partial chunk */
+        bool         is_partial_dim[H5S_MAX_RANK] = {false};    /* Whether a dimension is currently a partial chunk */
         int          curr_dim;                        /* Current dimension to increment */
         hssize_t adjust[H5S_MAX_RANK]; /* Adjustment to make to all file chunks (for shape same algorithm) */
         hsize_t  zeros[H5S_MAX_RANK];  /* All zero vector (for start parameter to setting hyperslab on partial
@@ -287,8 +287,6 @@ H5SC__io_info_init(H5SC_t H5_ATTR_NDEBUG_UNUSED *cache, H5SC_io_info_t *sc_io_in
         dset_sel_chunks = 0;
 
         /* Get chunk dimensions */
-        // assert(dset_info[i].layout->sc_ops->layout_query);
-        // if (dset_info[i].layout->sc_ops->layout_query(dset_info[i].dset, chunk_dims, NULL, NULL) < 0)
         assert(dset_info[i].dset->shared->layout.sc_ops->layout_query);
         if (dset_info[i].dset->shared->layout.sc_ops->layout_query(dset_info[i].dset, chunk_dims, NULL,
                                                                    NULL) < 0)
@@ -396,10 +394,9 @@ H5SC__io_info_init(H5SC_t H5_ATTR_NDEBUG_UNUSED *cache, H5SC_io_info_t *sc_io_in
             }
 
             /* Get memory dataspace dimensions */
-            // This sets mem_dims[i] correctly, the error message is not being reported correctly
-            if (H5S_get_simple_extent_dims(dset_info[i].mem_space, mem_dims, NULL) < 0) {
-                assert(0); // Added to illustrate the strange GDB nonsense...
-                HGOTO_ERROR(H5E_DATASPACE, H5E_CANTGET, FAIL, "can't get memory dataspace dimensions");
+            if (H5S_get_simple_extent_dims(dset_info[i].mem_space, mem_dims, NULL) < 0){
+                   HGOTO_ERROR(H5E_DATASPACE, H5E_CANTGET, FAIL, "can't get memory dataspace dimensions");
+
             }
         }
         else
@@ -666,7 +663,7 @@ H5SC__io_info_init(H5SC_t H5_ATTR_NDEBUG_UNUSED *cache, H5SC_io_info_t *sc_io_in
         if (tmp_dset_space && H5S_close(tmp_dset_space) < 0)
             HGOTO_ERROR(H5E_DATASET, H5E_CANTRELEASE, FAIL, "can't release temporary file dataspace");
         tmp_dset_space = NULL;
-        if (tmp_dset_space && H5S_close(single_chunk_space) < 0)
+        if (single_chunk_space && H5S_close(single_chunk_space) < 0)
             HGOTO_ERROR(H5E_DATASET, H5E_CANTRELEASE, FAIL, "can't release temporary file dataspace");
         single_chunk_space = NULL;
     }
@@ -744,22 +741,23 @@ H5SC__io_info_term(H5SC_io_info_t *sc_io_info)
 herr_t
 H5SC_read(H5SC_t *cache, size_t count, H5D_dset_io_info_t *dset_info)
 {
-    H5SC_io_info_t    sc_io_info;
-    herr_t            ret_value = SUCCEED;
-    volatile hsize_t *scaled[H5S_MAX_RANK];                   // First used in the lookup callback
-    volatile haddr_t *addr[H5S_MAX_RANK];                     // First used in the lookup callback
-    volatile haddr_t  addr0;                                  // Instanced addr_t
-    volatile hsize_t *size[H5S_MAX_RANK];                     // First used in the lookup callback
-    volatile hsize_t  size0;                                  // Instanced hsize_t
-    volatile hsize_t *defined_values_size[H5S_MAX_RANK];      // First used in the lookup callback
-    volatile size_t  *size_hint[H5S_MAX_RANK];                // First used in the lookup callback
-    volatile size_t  *defined_values_size_hint[H5S_MAX_RANK]; // First used in the lookup callback
-    volatile void    *udata_arr[H5S_MAX_RANK];                // First used in the lookup callback
-    volatile void *chunk = NULL; // First used in block read; eventually becomes the chunk intermediate struct
-    volatile H5D_io_type_info_t my_io_type_info;    // First used in the scatter_mem callback
-    volatile const H5S_t       *scatter_mem_space;  // Used in the scatter_mem callback
-    volatile const H5S_t       *scatter_file_space; // Used in the scatter_mem callback
-    haddr_t                     md_tag = HADDR_UNDEF;
+    H5SC_io_info_t sc_io_info;
+    herr_t         ret_value = SUCCEED;
+    hsize_t *scaled[H5S_MAX_RANK]; /* First used in the lookup callback */
+    haddr_t *addr[H5S_MAX_RANK]; /* First used in the lookup callback */
+    haddr_t  addr0; /* Instanced addr_t */
+    hsize_t *size[H5S_MAX_RANK]; /* First used in the lookup callback */
+    hsize_t size0; /* Instanced hsize_t */
+    hsize_t *defined_values_size[H5S_MAX_RANK]; /* First used in the lookup callback */
+    size_t *size_hint[H5S_MAX_RANK]; /* First used in the lookup callback*/
+    size_t *defined_values_size_hint[H5S_MAX_RANK]; /* First used in the lookup callback */
+    void *udata_arr[H5S_MAX_RANK]; /* First used in the lookup callback */
+    void *chunk = NULL; /* First used in block read; eventually becomes the chunk intermediate struct */
+    H5D_io_type_info_t my_io_type_info; /* First used in the scatter_mem callback */
+    const H5S_t *scatter_mem_space; /* Used in the scatter_mem callback */
+    const H5S_t *scatter_file_space; /* Used in the scatter_mem callback */
+    haddr_t md_tag = HADDR_UNDEF;
+
 
     FUNC_ENTER_NOAPI(FAIL)
 
@@ -794,34 +792,52 @@ H5SC_read(H5SC_t *cache, size_t count, H5D_dset_io_info_t *dset_info)
         HGOTO_ERROR(H5E_DATASET, H5E_CANTINIT, FAIL, "can't initialize selections for I/O");
     }
 
-    /*Loop through the datasets*/
+    /* Loop through the datasets */
     for (int i = 0; i < count; i++) {
 
-        /*Set metadata tagging for this dataset*/
+        /* Set metadata tagging for this dataset */
         H5AC_tag(dset_info[i].dset->oloc.addr, &md_tag);
 
         size_t chunk_count = sc_io_info.num_sel_chunks;
 
-        /*Chunk lookup (in file)*/
+        /* Chunk lookup (in file) */
         assert(dset_info[i].dset->shared->layout.sc_ops->lookup);
 
-        scaled[0] = sc_io_info.sel_chunks[0].scaled;
-        addr[0]   = &addr0;
-        size[0]   = &size0;
+
+        for (int j = 0; j < chunk_count; j++) {
+            /* Setup scaled for the jth chunk */
+            scaled[j] = sc_io_info.sel_chunks[j].scaled;
+
+            /* Setup the initial address with a unique pointer */
+            haddr_t *tmp_addr = malloc(sizeof(haddr_t));
+            addr[j] = tmp_addr;
+
+            /* Setup the initial size with a unique pointer */
+            hsize_t *tmp_size = malloc(sizeof(hsize_t));
+            size[j] = tmp_size;
+
+            hsize_t *tmp_def_val_size = malloc(sizeof(hsize_t));
+            defined_values_size[j] = tmp_def_val_size;
+
+            size_t *tmp_size_hint = malloc(sizeof(size_t));
+            *tmp_size_hint = 0;
+            size_hint[j] = tmp_size_hint;
+
+            size_t *tmp_def_val_size_hint = malloc(sizeof(size_t));
+            defined_values_size_hint[j] = tmp_def_val_size_hint;
+        }
 
         if (dset_info[i].dset->shared->layout.sc_ops->lookup(
-                dset_info[i].dset,   /*INPUT: Pointer to the dataset (in file)*/
-                chunk_count,         /*INPUT: The number of chunks in this datasets*/
-                scaled,              /*INPUT: Scaled coordinate(s) of the chunk*/
-                addr,                /*OUTPUT: Address of the chunk (on disk)*/
-                size,                /*OUTPUT: Chunk size (on disk)*/
-                defined_values_size, /*OUTPUT: The number of bytes to read (if the list of defined values is
-                                        needed)*/
-                size_hint,           /*OUTPUT: The suggested allocation size for the chunk (pre-decode)*/
-                defined_values_size_hint, /*OUTPUT: Suggested allocation size (if the list of defined values
-                                             is needed)*/
-                &udata_arr /*OUTPUT: Buffer to be passed through to H5D__struct_chunk_decode(_in_place)*/
-                ) < 0) {
+                                                            dset_info[i].dset,       /* INPUT: Pointer to the dataset (in file) */
+                                                            chunk_count,             /* INPUT: The number of chunks in this datasets */
+                                                            scaled,                  /* INPUT: Scaled coordinate(s) of the chunk */
+                                                            addr,                    /* OUTPUT: Address of the chunk (on disk) */
+                                                            size,                    /* OUTPUT: Chunk size (on disk) */
+                                                            defined_values_size,      /* OUTPUT: The number of bytes to read (if the list of defined values is needed) */
+                                                            size_hint,               /* OUTPUT: The suggested allocation size for the chunk (pre-decode) */
+                                                            defined_values_size_hint, /* OUTPUT: Suggested allocation size (if the list of defined values is needed) */
+                                                            &udata_arr               /* OUTPUT: Buffer to be passed through to H5D__struct_chunk_decode(_in_place) */
+                                                            ) < 0) {
             HGOTO_ERROR(H5E_DATASET, H5E_CANTGET, FAIL, "unable to lookup chunk (SCC)");
         }
 
@@ -829,72 +845,84 @@ H5SC_read(H5SC_t *cache, size_t count, H5D_dset_io_info_t *dset_info)
          * ***Read the data from file (disk)***
          */
 
-        /* Allocate buffer for the chunk data*/
-        if (NULL == (chunk = H5MM_malloc(*size_hint[0]))) {
-            HGOTO_ERROR(H5E_RESOURCE, H5E_NOSPACE, H5_ITER_ERROR,
-                        "memory allocation failed for raw data chunk (SCC)");
+        void *chunk_arr[chunk_count];
+
+        for (int j = 0; j < chunk_count; j++) {
+        /* Allocate buffer for the chunk data */
+            if (NULL == (chunk_arr[j] = H5MM_malloc(*size_hint[j]))) {
+                HGOTO_ERROR(H5E_RESOURCE, H5E_NOSPACE, H5_ITER_ERROR, "memory allocation failed for raw data chunk (SCC)");
+            }
+
+            if (H5F_block_read(
+                        dset_info[i].dset->oloc.file, /* INPUT: Current file ID*/
+                        H5FD_MEM_DRAW,               /* INPUT: Set based on the definitions in the H5F_mem_t type */
+                        *addr[j],                    /* INPUT: Address returned from the lookup callback */
+                        *size[j],                    /* INPUT: Size returned from the lookup callback */
+                        chunk_arr[j]                 /* INPUT/OUTPUT: Chunk buffer (which will be transitioned into the intermediate format) */
+                        ) < 0 ) {
+                HGOTO_ERROR(H5E_DATASET, H5E_READERROR, FAIL, "unable to block read from file (SCC)");
+            }
+
+            assert(dset_info[i].dset->shared->layout.sc_ops->decode);
+
+            size_t nbytes = *size[j]; /*Prior to decode, this is the number of bytes used in the chunk buffer*/
+            size_t alloc_size = *size_hint[j]; /*Prior to decode, this is the size of the chunk buffer*/
+
+            if (dset_info[i].dset->shared->layout.sc_ops->decode(
+                                                            dset_info[i].dset, /* INPUT: Pointer to the dataset in memory*/
+                                                            &nbytes,           /* INPUT/OUTPUT: nbytes; entry: number of bytes used in the chunk buffer; exit: total number of bytes used */
+                                                            &alloc_size,       /* INPUT/OUTPUT: alloc_size*/
+                                                            false,             /* UNUSED*/
+                                                            &chunk_arr[j],     /* INPUT/OUTPUT: chunk; On entry: the pointer tot he on disk formatted chunk buffer; On exit: the pointer to the chunk intermediate struct */
+                                                            udata_arr[j]       /* INPUT: Used to store some chunk properties*/
+                                                            ) < 0) {
+                HGOTO_ERROR(H5E_DATASET, H5E_CANTGET, FAIL, "unable to decode chunk in place (SCC)");
+            }
+            assert(dset_info[i].dset->shared->layout.sc_ops->scatter_mem);
+
+            size_t src_type_size = 0; /* Manually taken from `*dset_info->type_info`, looking at the contents of the `layout_io_info` section */
+            size_t dst_type_size = 0; /* Manually taken from `*dset_info->type_info`, looking at the contents of the `layout_io_info` section */
+            my_io_type_info.tconv_buf = NULL; /* Datatype conv buffer (pointer) */
+            my_io_type_info.tconv_buf_size = src_type_size; /* Size of type conversion buffer */
+            my_io_type_info.bkg_buf = NULL; /* Pointer to background buffer */
+            my_io_type_info.bkg_buf_size = dst_type_size; /* Size of the background buffer */
+
+            /* There is also a need to set the mem/file spaces */
+            scatter_mem_space = sc_io_info.sel_chunks[j].mem_space; /* Pointer to the memory space ID for the chunk (derived from sc_io_info) */
+            scatter_file_space = sc_io_info.sel_chunks[j].file_space; /* Pointer to the file space ID for the chunk (derived from sc_io_info) */
+
+            if (dset_info[i].dset->shared->layout.sc_ops->scatter_mem(
+                                                                    &dset_info[i],     /* INPUT: Pointer to the dataset in memory */
+                                                                    &my_io_type_info,  /* INPUT: Localized version of H5D_io_type_info_t; derived from information available in the sc_io_info struct */
+                                                                    scatter_mem_space, /* INPUT: Pointer to the appropriate memory space ID */
+                                                                    scatter_file_space, /* INPUT: Pointer to the appropriate file space space ID */
+                                                                    chunk_arr[j],      /* INPUT/OUTPUT: Memory-formatted chunk buffer */
+                                                                    udata_arr[j]       /* UNUSED: Udata, which is modified by previous callbacks */
+                                                                    ) < 0) {
+                HGOTO_ERROR(H5E_DATASET, H5E_CANTGET, FAIL, "unable to scatter mem for read chunk (SCC)");
+            }
+
+            /* Free the buffers via callback after scattering data to user buffer */
+            if (dset_info[i].dset->shared->layout.sc_ops->evict(dset_info[i].dset,
+                                                                chunk_arr[j],
+                                                                udata_arr[j]
+            ) < 0) {
+                HGOTO_ERROR(H5E_DATASET, H5E_CANTGET, FAIL, "unable to evict the chunk (SCC)");
+            }
+
+        }/* Chunk Processing Loop End */
+
+        /* Free the allocated components prior to processing the next dataset */
+        for (int j = 0; j < chunk_count; j++) {
+            free(addr[j]);
+            free(size[j]);
+            free(defined_values_size[j]);
+            free(size_hint[j]);
+            free(defined_values_size_hint[j]);
         }
 
-        if (H5F_block_read(
-                dset_info[i].dset->oloc.file, /*INPUT: Current file ID*/
-                H5FD_MEM_DRAW,                /*INPUT: Set based on the definitions in the H5F_mem_t type*/
-                *addr[0],                     /*INPUT: Address returned from the lookup callback */
-                *size[0],                     /*INPUT: Size returned from the lookup callback*/
-                chunk /*INPUT/OUTPUT: Chunk buffer (which will be transitioned into the intermediate format)*/
-                ) < 0) {
-            HGOTO_ERROR(H5E_DATASET, H5E_READERROR, FAIL, "unable to block read from file (SCC)");
-        }
-
-        assert(dset_info[i].dset->shared->layout.sc_ops->decode);
-
-        size_t nbytes = *size[0]; /*Prior to decode, this is the number of bytes used in the chunk buffer*/
-        size_t alloc_size = *size_hint[0]; /*Prior to decode, this is the size of the chunk buffer*/
-
-        if (dset_info[i].dset->shared->layout.sc_ops->decode(
-                dset_info[i].dset, /*INPUT: Pointer to the dataset in memory*/
-                &nbytes, /*INPUT/OUTPUT: nbytes; entry: number of bytes used in the chunk buffer; exit: total
-                            number of bytes used (not allocated)  (this may not be *size[0]...)*/
-                &alloc_size, /*INPUT/OUTPUT: alloc_size*/
-                false,       /*UNUSED*/
-                &chunk, /*INPUT/OUTPUT: chunk; On entry: the pointer tot he on disk formatted chunk buffer; On
-                           exit: the pointer to the chunk intermediate struct*/
-                udata_arr[0] /*INPUT: Used to store some chunk properties*/
-                ) < 0) {
-            HGOTO_ERROR(H5E_DATASET, H5E_CANTGET, FAIL, "unable to decode chunk in place (SCC)");
-        }
-        assert(dset_info[i].dset->shared->layout.sc_ops->scatter_mem);
-
-        size_t src_type_size = 0; /*Manually taken from `*dset_info->type_info`, looking at the contents of
-                                     the `layout_io_info` section*/
-        size_t dst_type_size = 0; /*Manually taken from `*dset_info->type_info`, looking at the contents of
-                                     the `layout_io_info` section*/
-        my_io_type_info.tconv_buf      = NULL;          /*Datatype conv buffer (pointer)*/
-        my_io_type_info.tconv_buf_size = src_type_size; /*Size of type conversion buffer*/
-        my_io_type_info.bkg_buf        = NULL;          /*Pointer to background buffer*/
-        my_io_type_info.bkg_buf_size   = dst_type_size; /*Size of the background buffer*/
-
-        // There is also a need to set the mem/file spaces
-        scatter_mem_space =
-            sc_io_info.sel_chunks[0]
-                .mem_space; /* Pointer to the memory space ID for the chunk (derived from sc_io_info)*/
-        scatter_file_space =
-            sc_io_info.sel_chunks[0]
-                .file_space; /* Pointer to the file space ID for the chunk (derived from sc_io_info)*/
-
-        if (dset_info[i].dset->shared->layout.sc_ops->scatter_mem(
-                &dset_info[i],      /*INPUT: Pointer to the dataset in memory*/
-                &my_io_type_info,   /*INPUT: Localized version of H5D_io_type_info_t; derived from information
-                                       available in the sc_io_info struct*/
-                scatter_mem_space,  /*INPUT: Pointer to the appropriate memory space ID*/
-                scatter_file_space, /*INPUT: Pointer to the appropriate file space space ID*/
-                chunk,              /*INPUT/OUTPUT: Memory-formatted chunk buffer*/
-                udata_arr[0]        /*UNUSED: Udata, which is modified by previous callbacks*/
-                ) < 0) {
-            HGOTO_ERROR(H5E_DATASET, H5E_CANTGET, FAIL, "unable to scatter mem for read chunk (SCC)");
-        }
-        assert(chunk);
-        H5AC_tag(md_tag, NULL); /*Reset the metadata tag for the next dataset*/
-    }                           /*Dataset Loop End*/
+        H5AC_tag(md_tag, NULL); /* Reset the metadata tag for the next dataset */
+    }/* Dataset Loop End */
 
 done:
     /* Terminate sc_io_info */
@@ -917,28 +945,28 @@ done:
 herr_t
 H5SC_write(H5SC_t *cache, size_t count, H5D_dset_io_info_t *dset_info)
 {
-    H5SC_io_info_t              sc_io_info;
-    herr_t                      ret_value = SUCCEED;
-    volatile size_t             nbytes;   // Used in the new chunk callback
-    volatile size_t             buf_size; // Used in the new chunk callback
-    volatile void              *chunk;
-    volatile size_t             alloc_size;
-    volatile size_t             alloc_size_total;
-    volatile size_t             write_size;
-    volatile hsize_t           *scaled[H5S_MAX_RANK]; // Initializing to 0 doesn't have any effect
-    volatile H5D_io_type_info_t my_io_type_info;      // Used in gather_mem callback
-    volatile const H5S_t       *gather_mem_space;
-    volatile const H5S_t       *gather_file_space;
-    volatile haddr_t           *addr[H5S_MAX_RANK];
-    volatile haddr_t            addr0;
-    volatile hsize_t           *size[H5S_MAX_RANK];
-    volatile hsize_t            size0;
-    volatile hsize_t           *defined_values_size[H5S_MAX_RANK];
-    volatile size_t            *size_hint[H5S_MAX_RANK];
-    volatile size_t            *defined_values_size_hint[H5S_MAX_RANK];
-    volatile void              *udata_arr[H5S_MAX_RANK];
-    volatile hsize_t            new_disk_size[H5S_MAX_RANK];
-    haddr_t                     md_tag = HADDR_UNDEF;
+    H5SC_io_info_t sc_io_info;
+    herr_t         ret_value = SUCCEED;
+    size_t nbytes; /* Used in the new chunk callback */
+    size_t buf_size; /* Used in the new chunk callback */
+    void *chunk;
+    size_t alloc_size;
+    size_t alloc_size_total;
+    size_t write_size;
+    hsize_t *scaled[H5S_MAX_RANK];
+    H5D_io_type_info_t my_io_type_info; /* Used in gather_mem callback */
+    const H5S_t *gather_mem_space;
+    const H5S_t *gather_file_space;
+    haddr_t *addr[H5S_MAX_RANK];
+    haddr_t addr0;
+    hsize_t *size[H5S_MAX_RANK];
+    hsize_t size0;
+    hsize_t *defined_values_size[H5S_MAX_RANK];
+    size_t *size_hint[H5S_MAX_RANK]; 
+    size_t *defined_values_size_hint[H5S_MAX_RANK]; 
+    void *udata_arr[H5S_MAX_RANK];
+    hsize_t write_size_arr[H5S_MAX_RANK];
+    haddr_t md_tag = HADDR_UNDEF;
 
     FUNC_ENTER_NOAPI(FAIL)
 
@@ -971,148 +999,196 @@ H5SC_write(H5SC_t *cache, size_t count, H5D_dset_io_info_t *dset_info)
     if (H5SC__io_info_init(cache, &sc_io_info, count, dset_info) < 0)
         HGOTO_ERROR(H5E_DATASET, H5E_CANTINIT, FAIL, "can't initialize selections for I/O");
 
-    // Loop through the datasets
+    /* Loop through the datasets */
     for (int i = 0; i < count; i++) {
         /*
          * To avoid issues with metadata tagging while doing multi-dataset I/O,
          * we need to handle tagging within the SCC
          */
-        H5AC_tag(dset_info[i].dset->oloc.addr,
-                 &md_tag); // Set the metadata tag (Does this need to be for the ith dataset?)
+        H5AC_tag(dset_info[i].dset->oloc.addr, &md_tag); /* Set the metadata tag */
 
-        // Throw an error if no chunks were selected
-        if (sc_io_info.num_sel_chunks == 0) //{
-            HDONE_ERROR(H5E_DATASET, H5E_CANTGETSIZE, FAIL,
-                        "The number of structured chunks should be non-zero");
+        /* Throw an error if no chunks were selected */
+        if (sc_io_info.num_sel_chunks == 0)
+            HDONE_ERROR(H5E_DATASET, H5E_CANTGETSIZE, FAIL, 
+                "The number of selected structured chunks should be non-zero (SCC)");
 
         size_t chunk_count = sc_io_info.num_sel_chunks;
 
         /*
          * Begin the write process (cache emulation)
-         *Look up the chunk in file (for now, simply assert that the callback is present)
+         * Look up the chunk in file (for now, simply assert that the callback is present)
          */
         assert(dset_info[i].dset->shared->layout.sc_ops->lookup);
 
-        scaled[0] = sc_io_info.sel_chunks[0].scaled;
-        addr[0]   = &addr0; // Should this be buf from the sel_chunks struct?
-        size[0]   = &size0;
+        /* Loop to initialize the components necessary for the SCC */
+        for (int j = 0; j < chunk_count; j++) {
+            /* Set up scaled for the jth chunk */
+            scaled[j] = sc_io_info.sel_chunks[j].scaled;
+
+            /* Setup the address with a unique pointer (will need to be freed after looping through the dataset) */
+            haddr_t *tmp_addr = malloc(sizeof(haddr_t));
+            *tmp_addr = HADDR_UNDEF;
+            addr[j] = tmp_addr;
+
+            /* Setup the size with a unique pointer (will need to be freed after looping through the dataset) */
+            hsize_t *tmp_size = malloc(sizeof(size_t));
+            size[j] = tmp_size;
+
+            hsize_t *tmp_def_val_size = malloc(sizeof(hsize_t));
+            defined_values_size[j] = tmp_def_val_size;
+
+            size_t *tmp_size_hint = malloc(sizeof(size_t));
+            size_hint[j] = tmp_size_hint;
+
+            size_t *tmp_def_val_size_hint = malloc(sizeof(size_t));
+            defined_values_size_hint[j] = tmp_def_val_size_hint;
+
+        }
+
+        /* Pointers up to this point (with n=2 chunks) have been verified to be unique */
 
         if (dset_info[i].dset->shared->layout.sc_ops->lookup(
-                dset_info[i].dset,   /*INPUT: Pointer to the dataset in memory*/
-                chunk_count,         /*INPUT: The number of chunks in the dataset being processed*/
-                scaled,              /*INPUT: Scaled coordinate(s) for the chunk*/
-                addr,                /*OUTPUT: Address of the chunk (on disk)*/
-                size,                /*OUTPUT: Chunk size (on disk)*/
-                defined_values_size, /*OUTPUT: The number of bytes to read (if the list of defined values is
-                                        needed)*/
-                size_hint,           /*OUTPUT: The suggested allocation size for the chunk (pre-encode)*/
-                defined_values_size_hint, /*OUTPUT: Suggested allocation size (if on the list of defined
-                                             values is needed)*/
-                &udata_arr /*OUTPUT: Buffer to be passed through to H5__struct_chunk_encode(_in_place())*/
-                ) < 0)
+                                                            dset_info[i].dset,       /* INPUT: Pointer to the dataset in memory */
+                                                            chunk_count,             /* INPUT: The number of chunks in the dataset being processed */
+                                                            scaled,                  /* INPUT: Scaled coordinate(s) for the chunk */
+                                                            addr,                    /* OUTPUT: Address of the chunk (on disk) */
+                                                            size,                    /* OUTPUT: Chunk size (on disk) */
+                                                            defined_values_size,      /* OUTPUT: The number of bytes to read (if the list of defined values is needed) */
+                                                            size_hint,               /* OUTPUT: The suggested allocation size for the chunk (pre-encode) */
+                                                            defined_values_size_hint, /* OUTPUT: Suggested allocation size (if on the list of defined values is needed) */
+                                                            &udata_arr               /* OUTPUT: Buffer to be passed through to H5__struct_chunk_encode(_in_place()) */
+                                                            ) < 0)
             HGOTO_ERROR(H5E_DATASET, H5E_CANTGET, FAIL, "unable to lookup chunk (SCC)");
+        
+            /* Free udata since the chunks do not exist (decode will not be called) */
+            for (int j = 0; j < chunk_count; j++) {
+                udata_arr[j] = H5MM_xfree(udata_arr[j]);
+            }
 
-        /*Create a new (empty) chunk (not inserted into the disk chunk index)*/
+        /* Create a new (empty) chunk (not inserted into the disk chunk index) */
         assert(dset_info[i].dset->shared->layout.sc_ops->new_chunk);
 
-        if (dset_info[i].dset->shared->layout.sc_ops->new_chunk(
-                dset_info[i].dset, /*INPUT: Pointer to the dataset in memory NOTE: 5/7 This isn the wrong
-                                      dataset info struct...*/
-                false,     /*INPUT: Bool to set whether to write the fill value to the chunk (unless this is a
-                              sparse chunk)*/
-                &nbytes,   /*OUTPUT: Number of bytes used (initialized to zero if chunk isn't found, yeah?)*/
-                &buf_size, /*OUTPUT: Size of the chunk buffer*/
-                &chunk,    /*OUTPUT: Pointer to the chunk intermediate struct*/
-                &udata_arr[0] /*OUTPUT: Udata initialization*/
-                ) < 0)
-            HGOTO_ERROR(H5E_DATASET, H5E_CANTGET, FAIL, "unable to create new chunk (SCC)");
-
         /*
-         * Set the io_type_info struct parameters.
-         * NOTE: Since vlen_buf_info isn't required for the v0, we simply avoind
-         * initialize it (passing NULL causes an error and should be avoided)
+         * The `new_chunk` callback will need to loop through each chunk here; 
+         * we will need to have an array of chunk pointers. It *should* be sufficient
+         * to simply create an array of void pointers, pass in the elements one-by-one,
+         * and then ensure that in the future (when `chunk` is uses), the proper chunk
+         * is being iterated on. As with the previous callback, we'll start by simply doing
+         * one loop through with the array input and go from there.
          */
-        size_t src_type_size = 0; /*Manually taken from `*dset_info->type_info`, looking at the contents of
-                                     the `layout_io_info` section*/
-        size_t dst_type_size = 0; /*Manually taken from `*dset_info->type_info`, looking at the contents of
-                                     the `layout_io_info` section*/
-        my_io_type_info.tconv_buf              = NULL;          /*Datatype conv buffer (pointer)*/
-        my_io_type_info.tconv_buf_size         = src_type_size; /*Size of type conversion buffer*/
-        my_io_type_info.bkg_buf                = NULL;          /*Pointer to background buffer*/
-        my_io_type_info.bkg_buf_size           = dst_type_size; /*Size of the background buffer*/
-        my_io_type_info.may_use_in_place_tconv = true;          /*Use in-place if possible*/
 
-        /*The gather_mem callback is used to collect data from the memory buffer into the chunk buffer*/
+        void *chunk_arr[chunk_count];
+
+        for (int j = 0; j < chunk_count; j++) {
+
+            if (dset_info[i].dset->shared->layout.sc_ops->new_chunk(
+                                                                    dset_info[i].dset, /* INPUT: Pointer to the dataset in memory */ 
+                                                                    false,             /* INPUT: Bool to set whether to write the fill value to the chunk */
+                                                                    &nbytes,           /* OUTPUT: Number of bytes used */
+                                                                    &buf_size,         /* OUTPUT: Size of the chunk buffer */
+                                                                    &chunk_arr[j],     /* OUTPUT: Pointer to the chunk intermediate struct */
+                                                                    &udata_arr[j]      /* OUTPUT: Udata initialization */
+                                                                    ) < 0) {
+                HGOTO_ERROR(H5E_DATASET, H5E_CANTGET, FAIL, "unable to create new chunk (SCC)");
+            }
+        }
+        
+
+        /* The gather_mem callback is used to collect data from the memory buffer into the chunk buffer */
         assert(dset_info[i].dset->shared->layout.sc_ops->gather_mem);
+        
+        for (int j = 0; j < chunk_count; j++) {
 
-        gather_mem_space =
-            sc_io_info.sel_chunks[0].mem_space; /*Pointer to the memory space ID, derived from sc_io_info*/
-        gather_file_space =
-            sc_io_info.sel_chunks[0].file_space; /*Pointer to the file space ID, derived from sc_io_info*/
+            /* 
+             * Set the io_type_info struct parameters.
+             * NOTE: Since vlen_buf_info isn't required for the v0, we simply avoided
+             * initialize it (passing NULL causes an error and should be avoided)
+             */
+            size_t src_type_size = 0; /* Manually taken from `*dset_info->type_info`, looking at the contents of the `layout_io_info` section */
+            size_t dst_type_size = 0; /* Manually taken from `*dset_info->type_info`, looking at the contents of the `layout_io_info` section */
+            my_io_type_info.tconv_buf = NULL; /* Datatype conv buffer (pointer) */
+            my_io_type_info.tconv_buf_size = src_type_size; /* Size of type conversion buffer */
+            my_io_type_info.bkg_buf = NULL; /* Pointer to background buffer */
+            my_io_type_info.bkg_buf_size = dst_type_size; /* Size of the background buffer */
+            my_io_type_info.may_use_in_place_tconv = true; /* Use in-place if possible */
 
-        if (dset_info[i].dset->shared->layout.sc_ops->gather_mem(
-                &dset_info[i],     /*INPUT: Pointer to the dataset in memory*/
-                &my_io_type_info,  /*INPUT: Localized version of the H5D_io_type_info_t; derived from
-                                      information available in the sc_io_info struct*/
-                gather_mem_space,  /*INPUT: Pointer to the appropriate memory space ID*/
-                gather_file_space, /*INPUT: Pointer to the appropriate file space ID*/
-                &nbytes, /*INPUT/OUTPUT Size of the chunk; will be reallocated in this callback and returned*/
-                &alloc_size,       /*INPUT/OUTPUT: Allocated size of the chunk buffer (?)*/
-                &alloc_size_total, /*INPUT/OUTPUT: Size of nbytes + alloc_size*/
-                chunk,             /*INPUT/OUTPUT: Intermediate chunk structure*/
-                udata_arr[0]       /*UNUSED*/
-                ) < 0)
-            HGOTO_ERROR(H5E_DATASET, H5E_CANTGET, FAIL, "unable to gather mem for new chunk (SCC)");
+            gather_mem_space = sc_io_info.sel_chunks[j].mem_space; /* Pointer to the memory space ID, derived from sc_io_info */
+            gather_file_space = sc_io_info.sel_chunks[j].file_space; /* Pointer to the file space ID, derived from sc_io_info */
 
+            /* nbytes, alloc_size, and alloc_size_total are embedded in the chunk intermediate struct and don't need to be adjusted/corrected for each chunk that is looped over */
+            if (dset_info[i].dset->shared->layout.sc_ops->gather_mem(
+                                                            &dset_info[i],     /* INPUT: Pointer to the dataset in memory*/
+                                                            &my_io_type_info,  /* INPUT: Localized version of the H5D_io_type_info_t; derived from information available in the sc_io_info struct */
+                                                            gather_mem_space,  /* INPUT: Pointer to the appropriate memory space ID */
+                                                            gather_file_space,  /* INPUT: Pointer to the appropriate file space ID */
+                                                            &nbytes,           /* INPUT/OUTPUT Size of the chunk; will be reallocated in this callback and returned */
+                                                            &alloc_size,       /* INPUT/OUTPUT: Allocated size of the chunk buffer */
+                                                            &alloc_size_total, /* INPUT/OUTPUT: Size of nbytes + alloc_size */
+                                                            chunk_arr[j],      /*INPUT/OUTPUT: Intermediate chunk structure */
+                                                            udata_arr[j]       /* UNUSED */
+                                                            ) < 0) {
+                HGOTO_ERROR(H5E_DATASET, H5E_CANTGET, FAIL, "unable to gather mem for new chunk (SCC)");
+                }
+        }
         /*
          * Start the "eviction" process
          * First, we encode in place (chunk becomes disk formatted chunk buffer)
          */
         assert(dset_info[i].dset->shared->layout.sc_ops->encode_in_place);
-        if (dset_info[i].dset->shared->layout.sc_ops->encode_in_place(
-                dset_info[i].dset, /*INPUT: Pointer to the dataset in memory*/
-                &write_size,       /*OUTPUT: Sum of the size of the selected bytes and the data bytes*/
-                false,  /*UNUSED; indicate used to specify if a chunk has a partial boundary (unsupported in
-                           v0)*/
-                &chunk, /*INPUT/OUTPUT On entry, points to the chunk intermediate struct; on exit, points to
-                           the on disk file format chunk buffer*/
-                udata_arr[0] /*INPUT/OUTPUT Udata, which has been utilized by previous callbacks*/
-                ) < 0) {
-            HGOTO_ERROR(H5E_DATASET, H5E_CANTGET, FAIL, "unable to encode chunk in place (SCC)");
+        
+        for (int j = 0; j < chunk_count; j++) {
+
+            if (dset_info[i].dset->shared->layout.sc_ops->encode_in_place(
+                                                                    dset_info[i].dset, /* INPUT: Pointer to the dataset in memory */
+                                                                    &write_size,       /* OUTPUT: Sum of the size of the selected bytes and the data bytes */
+                                                                    false,             /* UNUSED; indicate used to specify if a chunk has a partial boundary (unsupported in v0) */
+                                                                    &chunk_arr[j],     /* INPUT/OUTPUT On entry, points to the chunk intermediate struct; on exit, points to the on disk file format chunk buffer */
+                                                                    udata_arr[j]       /* INPUT/OUTPUT Udata, which has been utilized by previous callbacks */
+                                                                    ) < 0) { 
+                HGOTO_ERROR(H5E_DATASET, H5E_CANTGET, FAIL, "unable to encode chunk in place (SCC)");
+            }
+
+            /* Add the computed write size to the appropriate array */
+            write_size_arr[j] = write_size;
         }
-
-        /*Add the computed write size to the appropriate array*/
-        new_disk_size[0] = write_size;
-
-        /*Insert the chunk into the chunk index within the file*/
+        /* Insert the chunk into the chunk index within the file */
         assert(dset_info[i].dset->shared->layout.sc_ops->insert);
 
         if (dset_info[i].dset->shared->layout.sc_ops->insert(
-                dset_info[i].dset, /*INPUT: Pointer to the dataset in memory*/
-                chunk_count,       /*INPUT: Number of chunks in the I/O request*/
-                &scaled,           /*INPUT: Scaled coordinate for the chunk; derived from `sc_io_info`*/
-                addr,              /*INPUT/OUTPUT: Array of addrs*/
-                NULL, /*INPUT: Old disk size array; likely derived from the insert callback (if chunk is on
-                         disk)*/
-                new_disk_size, /*INPUT: Write size, computed from the encode callback*/
-                chunk,         /*UNUSED: Intermediate chunk structure (on-disk formatted); full array*/
-                udata_arr      /*INPUT: Array of udata (which are modified by previous callbacks)*/
-                ) < 0)
+                                                dset_info[i].dset, /* INPUT: Pointer to the dataset in memory */
+                                                chunk_count,       /* INPUT: Number of chunks in the I/O request */
+                                                &scaled,           /* INPUT: Scaled coordinate for the chunk; derived from `sc_io_info` */
+                                                addr,              /* INPUT/OUTPUT: Array of addrs */
+                                                NULL,              /* INPUT: Old disk size array; likely derived from the insert callback (if chunk is on disk) */
+                                                write_size_arr,    /* INPUT: Write size, computed from the encode callback */
+                                                chunk_arr,         /* UNUSED: Intermediate chunk structure (on-disk formatted); full array */
+                                                udata_arr          /* INPUT: Array of udata (which are modified by previous callbacks) */
+                                                ) < 0)
             HGOTO_ERROR(H5E_DATASET, H5E_CANTINSERT, FAIL, "unable to insert chunk into file (SCC)");
 
-        /*Write the chunk to file using H5F_block_write*/
-        if (H5F_block_write(dset_info[i].dset->oloc.file, /*INPUT: Current file ID*/
-                            H5FD_MEM_DRAW, /*INPUT: Based on the definitions in H5F_mem_t, this option seemed
-                                              the most appropriate*/
-                            *addr[0], /*INPUT: This is the address in the file where data will be written; set
-                                         by the insert callback*/
-                            write_size, /*INPUT: Encoded write size from the `encode_in_place` callback*/
-                            chunk /*INPUT: Should be the data buffer (encode last modified the chunk buffer)*/
+        for (int j = 0; j < chunk_count; j++) {
+        /* Write the chunk to file using H5F_block_write */
+            if (H5F_block_write(
+                            dset_info[i].dset->oloc.file, /* INPUT: Current file ID */
+                            H5FD_MEM_DRAW,               /* INPUT: Based on the definitions in H5F_mem_t, this option seemed the most appropriate */
+                            *addr[j],                    /* INPUT: This is the address in the file where data will be written; set by the insert callback */
+                            write_size_arr[j],           /* INPUT: Encoded write size from the `encode_in_place` callback */
+                            chunk_arr[j]                 /* INPUT: Should be the data buffer (encode last modified the chunk buffer) */
                             ) < 0) {
-            HGOTO_ERROR(H5E_DATASET, H5E_WRITEERROR, FAIL, "unable to block write to file(SCC)");
+                HGOTO_ERROR(H5E_DATASET, H5E_WRITEERROR, FAIL, "unable to block write to file(SCC)");
+            }
+
+            chunk_arr[j] = H5MM_xfree(chunk_arr[j]);
+            udata_arr[j] = H5MM_xfree(udata_arr[j]);
+
+            free(addr[j]);
+            free(size[j]);
+            free(defined_values_size[j]);
+            free(size_hint[j]);
+            free(defined_values_size_hint[j]);
         }
-        H5AC_tag(md_tag, NULL); /*Reset the metadata tag for the next dataset*/
-    }                           /*Dataset Loop*/
+        H5AC_tag(md_tag, NULL); /* Reset the metadata tag for the next dataset */
+    }/* End Dataset Loop */
 done:
     /* Terminate sc_io_info */
     if (H5SC__io_info_term(&sc_io_info) < 0)

--- a/src/H5SC.c
+++ b/src/H5SC.c
@@ -268,8 +268,8 @@ H5SC__io_info_init(H5SC_t H5_ATTR_NDEBUG_UNUSED *cache, H5SC_io_info_t *sc_io_in
         unsigned     num_partial_dims;
         hsize_t      curr_partial_clip[H5S_MAX_RANK]; /* Current partial dimension sizes to clip against */
         hsize_t      partial_dim_size[H5S_MAX_RANK];  /* Size of a partial dimension */
-        bool         is_partial_dim[H5S_MAX_RANK] = {false};    /* Whether a dimension is currently a partial chunk */
-        int          curr_dim;                        /* Current dimension to increment */
+        bool is_partial_dim[H5S_MAX_RANK] = {false};  /* Whether a dimension is currently a partial chunk */
+        int  curr_dim;                                /* Current dimension to increment */
         hssize_t adjust[H5S_MAX_RANK]; /* Adjustment to make to all file chunks (for shape same algorithm) */
         hsize_t  zeros[H5S_MAX_RANK];  /* All zero vector (for start parameter to setting hyperslab on partial
                                           chunks for "all" selection) */
@@ -394,9 +394,8 @@ H5SC__io_info_init(H5SC_t H5_ATTR_NDEBUG_UNUSED *cache, H5SC_io_info_t *sc_io_in
             }
 
             /* Get memory dataspace dimensions */
-            if (H5S_get_simple_extent_dims(dset_info[i].mem_space, mem_dims, NULL) < 0){
-                   HGOTO_ERROR(H5E_DATASPACE, H5E_CANTGET, FAIL, "can't get memory dataspace dimensions");
-
+            if (H5S_get_simple_extent_dims(dset_info[i].mem_space, mem_dims, NULL) < 0) {
+                HGOTO_ERROR(H5E_DATASPACE, H5E_CANTGET, FAIL, "can't get memory dataspace dimensions");
             }
         }
         else
@@ -743,21 +742,20 @@ H5SC_read(H5SC_t *cache, size_t count, H5D_dset_io_info_t *dset_info)
 {
     H5SC_io_info_t sc_io_info;
     herr_t         ret_value = SUCCEED;
-    hsize_t *scaled[H5S_MAX_RANK]; /* First used in the lookup callback */
-    haddr_t *addr[H5S_MAX_RANK]; /* First used in the lookup callback */
-    haddr_t  addr0; /* Instanced addr_t */
-    hsize_t *size[H5S_MAX_RANK]; /* First used in the lookup callback */
-    hsize_t size0; /* Instanced hsize_t */
-    hsize_t *defined_values_size[H5S_MAX_RANK]; /* First used in the lookup callback */
-    size_t *size_hint[H5S_MAX_RANK]; /* First used in the lookup callback*/
-    size_t *defined_values_size_hint[H5S_MAX_RANK]; /* First used in the lookup callback */
-    void *udata_arr[H5S_MAX_RANK]; /* First used in the lookup callback */
+    hsize_t       *scaled[H5S_MAX_RANK];                   /* First used in the lookup callback */
+    haddr_t       *addr[H5S_MAX_RANK];                     /* First used in the lookup callback */
+    haddr_t        addr0;                                  /* Instanced addr_t */
+    hsize_t       *size[H5S_MAX_RANK];                     /* First used in the lookup callback */
+    hsize_t        size0;                                  /* Instanced hsize_t */
+    hsize_t       *defined_values_size[H5S_MAX_RANK];      /* First used in the lookup callback */
+    size_t        *size_hint[H5S_MAX_RANK];                /* First used in the lookup callback*/
+    size_t        *defined_values_size_hint[H5S_MAX_RANK]; /* First used in the lookup callback */
+    void          *udata_arr[H5S_MAX_RANK];                /* First used in the lookup callback */
     void *chunk = NULL; /* First used in block read; eventually becomes the chunk intermediate struct */
-    H5D_io_type_info_t my_io_type_info; /* First used in the scatter_mem callback */
-    const H5S_t *scatter_mem_space; /* Used in the scatter_mem callback */
-    const H5S_t *scatter_file_space; /* Used in the scatter_mem callback */
-    haddr_t md_tag = HADDR_UNDEF;
-
+    H5D_io_type_info_t my_io_type_info;    /* First used in the scatter_mem callback */
+    const H5S_t       *scatter_mem_space;  /* Used in the scatter_mem callback */
+    const H5S_t       *scatter_file_space; /* Used in the scatter_mem callback */
+    haddr_t            md_tag = HADDR_UNDEF;
 
     FUNC_ENTER_NOAPI(FAIL)
 
@@ -803,41 +801,42 @@ H5SC_read(H5SC_t *cache, size_t count, H5D_dset_io_info_t *dset_info)
         /* Chunk lookup (in file) */
         assert(dset_info[i].dset->shared->layout.sc_ops->lookup);
 
-
         for (int j = 0; j < chunk_count; j++) {
             /* Setup scaled for the jth chunk */
             scaled[j] = sc_io_info.sel_chunks[j].scaled;
 
             /* Setup the initial address with a unique pointer */
             haddr_t *tmp_addr = malloc(sizeof(haddr_t));
-            addr[j] = tmp_addr;
+            addr[j]           = tmp_addr;
 
             /* Setup the initial size with a unique pointer */
             hsize_t *tmp_size = malloc(sizeof(hsize_t));
-            size[j] = tmp_size;
+            size[j]           = tmp_size;
 
             hsize_t *tmp_def_val_size = malloc(sizeof(hsize_t));
-            defined_values_size[j] = tmp_def_val_size;
+            defined_values_size[j]    = tmp_def_val_size;
 
             size_t *tmp_size_hint = malloc(sizeof(size_t));
-            *tmp_size_hint = 0;
-            size_hint[j] = tmp_size_hint;
+            *tmp_size_hint        = 0;
+            size_hint[j]          = tmp_size_hint;
 
             size_t *tmp_def_val_size_hint = malloc(sizeof(size_t));
-            defined_values_size_hint[j] = tmp_def_val_size_hint;
+            defined_values_size_hint[j]   = tmp_def_val_size_hint;
         }
 
         if (dset_info[i].dset->shared->layout.sc_ops->lookup(
-                                                            dset_info[i].dset,       /* INPUT: Pointer to the dataset (in file) */
-                                                            chunk_count,             /* INPUT: The number of chunks in this datasets */
-                                                            scaled,                  /* INPUT: Scaled coordinate(s) of the chunk */
-                                                            addr,                    /* OUTPUT: Address of the chunk (on disk) */
-                                                            size,                    /* OUTPUT: Chunk size (on disk) */
-                                                            defined_values_size,      /* OUTPUT: The number of bytes to read (if the list of defined values is needed) */
-                                                            size_hint,               /* OUTPUT: The suggested allocation size for the chunk (pre-decode) */
-                                                            defined_values_size_hint, /* OUTPUT: Suggested allocation size (if the list of defined values is needed) */
-                                                            &udata_arr               /* OUTPUT: Buffer to be passed through to H5D__struct_chunk_decode(_in_place) */
-                                                            ) < 0) {
+                dset_info[i].dset,   /* INPUT: Pointer to the dataset (in file) */
+                chunk_count,         /* INPUT: The number of chunks in this datasets */
+                scaled,              /* INPUT: Scaled coordinate(s) of the chunk */
+                addr,                /* OUTPUT: Address of the chunk (on disk) */
+                size,                /* OUTPUT: Chunk size (on disk) */
+                defined_values_size, /* OUTPUT: The number of bytes to read (if the list of defined values is
+                                        needed) */
+                size_hint,           /* OUTPUT: The suggested allocation size for the chunk (pre-decode) */
+                defined_values_size_hint, /* OUTPUT: Suggested allocation size (if the list of defined values
+                                             is needed) */
+                &udata_arr /* OUTPUT: Buffer to be passed through to H5D__struct_chunk_decode(_in_place) */
+                ) < 0) {
             HGOTO_ERROR(H5E_DATASET, H5E_CANTGET, FAIL, "unable to lookup chunk (SCC)");
         }
 
@@ -848,69 +847,78 @@ H5SC_read(H5SC_t *cache, size_t count, H5D_dset_io_info_t *dset_info)
         void *chunk_arr[chunk_count];
 
         for (int j = 0; j < chunk_count; j++) {
-        /* Allocate buffer for the chunk data */
+            /* Allocate buffer for the chunk data */
             if (NULL == (chunk_arr[j] = H5MM_malloc(*size_hint[j]))) {
-                HGOTO_ERROR(H5E_RESOURCE, H5E_NOSPACE, H5_ITER_ERROR, "memory allocation failed for raw data chunk (SCC)");
+                HGOTO_ERROR(H5E_RESOURCE, H5E_NOSPACE, H5_ITER_ERROR,
+                            "memory allocation failed for raw data chunk (SCC)");
             }
 
-            if (H5F_block_read(
-                        dset_info[i].dset->oloc.file, /* INPUT: Current file ID*/
-                        H5FD_MEM_DRAW,               /* INPUT: Set based on the definitions in the H5F_mem_t type */
-                        *addr[j],                    /* INPUT: Address returned from the lookup callback */
-                        *size[j],                    /* INPUT: Size returned from the lookup callback */
-                        chunk_arr[j]                 /* INPUT/OUTPUT: Chunk buffer (which will be transitioned into the intermediate format) */
-                        ) < 0 ) {
+            if (H5F_block_read(dset_info[i].dset->oloc.file, /* INPUT: Current file ID*/
+                               H5FD_MEM_DRAW, /* INPUT: Set based on the definitions in the H5F_mem_t type */
+                               *addr[j],      /* INPUT: Address returned from the lookup callback */
+                               *size[j],      /* INPUT: Size returned from the lookup callback */
+                               chunk_arr[j] /* INPUT/OUTPUT: Chunk buffer (which will be transitioned into the
+                                               intermediate format) */
+                               ) < 0) {
                 HGOTO_ERROR(H5E_DATASET, H5E_READERROR, FAIL, "unable to block read from file (SCC)");
             }
 
             assert(dset_info[i].dset->shared->layout.sc_ops->decode);
 
-            size_t nbytes = *size[j]; /*Prior to decode, this is the number of bytes used in the chunk buffer*/
+            size_t nbytes =
+                *size[j]; /*Prior to decode, this is the number of bytes used in the chunk buffer*/
             size_t alloc_size = *size_hint[j]; /*Prior to decode, this is the size of the chunk buffer*/
 
             if (dset_info[i].dset->shared->layout.sc_ops->decode(
-                                                            dset_info[i].dset, /* INPUT: Pointer to the dataset in memory*/
-                                                            &nbytes,           /* INPUT/OUTPUT: nbytes; entry: number of bytes used in the chunk buffer; exit: total number of bytes used */
-                                                            &alloc_size,       /* INPUT/OUTPUT: alloc_size*/
-                                                            false,             /* UNUSED*/
-                                                            &chunk_arr[j],     /* INPUT/OUTPUT: chunk; On entry: the pointer tot he on disk formatted chunk buffer; On exit: the pointer to the chunk intermediate struct */
-                                                            udata_arr[j]       /* INPUT: Used to store some chunk properties*/
-                                                            ) < 0) {
+                    dset_info[i].dset, /* INPUT: Pointer to the dataset in memory*/
+                    &nbytes, /* INPUT/OUTPUT: nbytes; entry: number of bytes used in the chunk buffer; exit:
+                                total number of bytes used */
+                    &alloc_size,   /* INPUT/OUTPUT: alloc_size*/
+                    false,         /* UNUSED*/
+                    &chunk_arr[j], /* INPUT/OUTPUT: chunk; On entry: the pointer tot he on disk formatted
+                                      chunk buffer; On exit: the pointer to the chunk intermediate struct */
+                    udata_arr[j]   /* INPUT: Used to store some chunk properties*/
+                    ) < 0) {
                 HGOTO_ERROR(H5E_DATASET, H5E_CANTGET, FAIL, "unable to decode chunk in place (SCC)");
             }
             assert(dset_info[i].dset->shared->layout.sc_ops->scatter_mem);
 
-            size_t src_type_size = 0; /* Manually taken from `*dset_info->type_info`, looking at the contents of the `layout_io_info` section */
-            size_t dst_type_size = 0; /* Manually taken from `*dset_info->type_info`, looking at the contents of the `layout_io_info` section */
-            my_io_type_info.tconv_buf = NULL; /* Datatype conv buffer (pointer) */
+            size_t src_type_size = 0; /* Manually taken from `*dset_info->type_info`, looking at the contents
+                                         of the `layout_io_info` section */
+            size_t dst_type_size = 0; /* Manually taken from `*dset_info->type_info`, looking at the contents
+                                         of the `layout_io_info` section */
+            my_io_type_info.tconv_buf      = NULL;          /* Datatype conv buffer (pointer) */
             my_io_type_info.tconv_buf_size = src_type_size; /* Size of type conversion buffer */
-            my_io_type_info.bkg_buf = NULL; /* Pointer to background buffer */
-            my_io_type_info.bkg_buf_size = dst_type_size; /* Size of the background buffer */
+            my_io_type_info.bkg_buf        = NULL;          /* Pointer to background buffer */
+            my_io_type_info.bkg_buf_size   = dst_type_size; /* Size of the background buffer */
 
             /* There is also a need to set the mem/file spaces */
-            scatter_mem_space = sc_io_info.sel_chunks[j].mem_space; /* Pointer to the memory space ID for the chunk (derived from sc_io_info) */
-            scatter_file_space = sc_io_info.sel_chunks[j].file_space; /* Pointer to the file space ID for the chunk (derived from sc_io_info) */
+            scatter_mem_space =
+                sc_io_info.sel_chunks[j]
+                    .mem_space; /* Pointer to the memory space ID for the chunk (derived from sc_io_info) */
+            scatter_file_space =
+                sc_io_info.sel_chunks[j]
+                    .file_space; /* Pointer to the file space ID for the chunk (derived from sc_io_info) */
 
             if (dset_info[i].dset->shared->layout.sc_ops->scatter_mem(
-                                                                    &dset_info[i],     /* INPUT: Pointer to the dataset in memory */
-                                                                    &my_io_type_info,  /* INPUT: Localized version of H5D_io_type_info_t; derived from information available in the sc_io_info struct */
-                                                                    scatter_mem_space, /* INPUT: Pointer to the appropriate memory space ID */
-                                                                    scatter_file_space, /* INPUT: Pointer to the appropriate file space space ID */
-                                                                    chunk_arr[j],      /* INPUT/OUTPUT: Memory-formatted chunk buffer */
-                                                                    udata_arr[j]       /* UNUSED: Udata, which is modified by previous callbacks */
-                                                                    ) < 0) {
+                    &dset_info[i],      /* INPUT: Pointer to the dataset in memory */
+                    &my_io_type_info,   /* INPUT: Localized version of H5D_io_type_info_t; derived from
+                                           information available in the sc_io_info struct */
+                    scatter_mem_space,  /* INPUT: Pointer to the appropriate memory space ID */
+                    scatter_file_space, /* INPUT: Pointer to the appropriate file space space ID */
+                    chunk_arr[j],       /* INPUT/OUTPUT: Memory-formatted chunk buffer */
+                    udata_arr[j]        /* UNUSED: Udata, which is modified by previous callbacks */
+                    ) < 0) {
                 HGOTO_ERROR(H5E_DATASET, H5E_CANTGET, FAIL, "unable to scatter mem for read chunk (SCC)");
             }
 
             /* Free the buffers via callback after scattering data to user buffer */
-            if (dset_info[i].dset->shared->layout.sc_ops->evict(dset_info[i].dset,
-                                                                chunk_arr[j],
-                                                                udata_arr[j]
-            ) < 0) {
+            if (dset_info[i].dset->shared->layout.sc_ops->evict(dset_info[i].dset, chunk_arr[j],
+                                                                udata_arr[j]) < 0) {
                 HGOTO_ERROR(H5E_DATASET, H5E_CANTGET, FAIL, "unable to evict the chunk (SCC)");
             }
 
-        }/* Chunk Processing Loop End */
+        } /* Chunk Processing Loop End */
 
         /* Free the allocated components prior to processing the next dataset */
         for (int j = 0; j < chunk_count; j++) {
@@ -922,7 +930,7 @@ H5SC_read(H5SC_t *cache, size_t count, H5D_dset_io_info_t *dset_info)
         }
 
         H5AC_tag(md_tag, NULL); /* Reset the metadata tag for the next dataset */
-    }/* Dataset Loop End */
+    }                           /* Dataset Loop End */
 
 done:
     /* Terminate sc_io_info */
@@ -945,28 +953,28 @@ done:
 herr_t
 H5SC_write(H5SC_t *cache, size_t count, H5D_dset_io_info_t *dset_info)
 {
-    H5SC_io_info_t sc_io_info;
-    herr_t         ret_value = SUCCEED;
-    size_t nbytes; /* Used in the new chunk callback */
-    size_t buf_size; /* Used in the new chunk callback */
-    void *chunk;
-    size_t alloc_size;
-    size_t alloc_size_total;
-    size_t write_size;
-    hsize_t *scaled[H5S_MAX_RANK];
+    H5SC_io_info_t     sc_io_info;
+    herr_t             ret_value = SUCCEED;
+    size_t             nbytes;   /* Used in the new chunk callback */
+    size_t             buf_size; /* Used in the new chunk callback */
+    void              *chunk;
+    size_t             alloc_size;
+    size_t             alloc_size_total;
+    size_t             write_size;
+    hsize_t           *scaled[H5S_MAX_RANK];
     H5D_io_type_info_t my_io_type_info; /* Used in gather_mem callback */
-    const H5S_t *gather_mem_space;
-    const H5S_t *gather_file_space;
-    haddr_t *addr[H5S_MAX_RANK];
-    haddr_t addr0;
-    hsize_t *size[H5S_MAX_RANK];
-    hsize_t size0;
-    hsize_t *defined_values_size[H5S_MAX_RANK];
-    size_t *size_hint[H5S_MAX_RANK]; 
-    size_t *defined_values_size_hint[H5S_MAX_RANK]; 
-    void *udata_arr[H5S_MAX_RANK];
-    hsize_t write_size_arr[H5S_MAX_RANK];
-    haddr_t md_tag = HADDR_UNDEF;
+    const H5S_t       *gather_mem_space;
+    const H5S_t       *gather_file_space;
+    haddr_t           *addr[H5S_MAX_RANK];
+    haddr_t            addr0;
+    hsize_t           *size[H5S_MAX_RANK];
+    hsize_t            size0;
+    hsize_t           *defined_values_size[H5S_MAX_RANK];
+    size_t            *size_hint[H5S_MAX_RANK];
+    size_t            *defined_values_size_hint[H5S_MAX_RANK];
+    void              *udata_arr[H5S_MAX_RANK];
+    hsize_t            write_size_arr[H5S_MAX_RANK];
+    haddr_t            md_tag = HADDR_UNDEF;
 
     FUNC_ENTER_NOAPI(FAIL)
 
@@ -1009,8 +1017,8 @@ H5SC_write(H5SC_t *cache, size_t count, H5D_dset_io_info_t *dset_info)
 
         /* Throw an error if no chunks were selected */
         if (sc_io_info.num_sel_chunks == 0)
-            HDONE_ERROR(H5E_DATASET, H5E_CANTGETSIZE, FAIL, 
-                "The number of selected structured chunks should be non-zero (SCC)");
+            HDONE_ERROR(H5E_DATASET, H5E_CANTGETSIZE, FAIL,
+                        "The number of selected structured chunks should be non-zero (SCC)");
 
         size_t chunk_count = sc_io_info.num_sel_chunks;
 
@@ -1025,51 +1033,54 @@ H5SC_write(H5SC_t *cache, size_t count, H5D_dset_io_info_t *dset_info)
             /* Set up scaled for the jth chunk */
             scaled[j] = sc_io_info.sel_chunks[j].scaled;
 
-            /* Setup the address with a unique pointer (will need to be freed after looping through the dataset) */
+            /* Setup the address with a unique pointer (will need to be freed after looping through the
+             * dataset) */
             haddr_t *tmp_addr = malloc(sizeof(haddr_t));
-            *tmp_addr = HADDR_UNDEF;
-            addr[j] = tmp_addr;
+            *tmp_addr         = HADDR_UNDEF;
+            addr[j]           = tmp_addr;
 
-            /* Setup the size with a unique pointer (will need to be freed after looping through the dataset) */
+            /* Setup the size with a unique pointer (will need to be freed after looping through the dataset)
+             */
             hsize_t *tmp_size = malloc(sizeof(size_t));
-            size[j] = tmp_size;
+            size[j]           = tmp_size;
 
             hsize_t *tmp_def_val_size = malloc(sizeof(hsize_t));
-            defined_values_size[j] = tmp_def_val_size;
+            defined_values_size[j]    = tmp_def_val_size;
 
             size_t *tmp_size_hint = malloc(sizeof(size_t));
-            size_hint[j] = tmp_size_hint;
+            size_hint[j]          = tmp_size_hint;
 
             size_t *tmp_def_val_size_hint = malloc(sizeof(size_t));
-            defined_values_size_hint[j] = tmp_def_val_size_hint;
-
+            defined_values_size_hint[j]   = tmp_def_val_size_hint;
         }
 
         /* Pointers up to this point (with n=2 chunks) have been verified to be unique */
 
         if (dset_info[i].dset->shared->layout.sc_ops->lookup(
-                                                            dset_info[i].dset,       /* INPUT: Pointer to the dataset in memory */
-                                                            chunk_count,             /* INPUT: The number of chunks in the dataset being processed */
-                                                            scaled,                  /* INPUT: Scaled coordinate(s) for the chunk */
-                                                            addr,                    /* OUTPUT: Address of the chunk (on disk) */
-                                                            size,                    /* OUTPUT: Chunk size (on disk) */
-                                                            defined_values_size,      /* OUTPUT: The number of bytes to read (if the list of defined values is needed) */
-                                                            size_hint,               /* OUTPUT: The suggested allocation size for the chunk (pre-encode) */
-                                                            defined_values_size_hint, /* OUTPUT: Suggested allocation size (if on the list of defined values is needed) */
-                                                            &udata_arr               /* OUTPUT: Buffer to be passed through to H5__struct_chunk_encode(_in_place()) */
-                                                            ) < 0)
+                dset_info[i].dset,   /* INPUT: Pointer to the dataset in memory */
+                chunk_count,         /* INPUT: The number of chunks in the dataset being processed */
+                scaled,              /* INPUT: Scaled coordinate(s) for the chunk */
+                addr,                /* OUTPUT: Address of the chunk (on disk) */
+                size,                /* OUTPUT: Chunk size (on disk) */
+                defined_values_size, /* OUTPUT: The number of bytes to read (if the list of defined values is
+                                        needed) */
+                size_hint,           /* OUTPUT: The suggested allocation size for the chunk (pre-encode) */
+                defined_values_size_hint, /* OUTPUT: Suggested allocation size (if on the list of defined
+                                             values is needed) */
+                &udata_arr /* OUTPUT: Buffer to be passed through to H5__struct_chunk_encode(_in_place()) */
+                ) < 0)
             HGOTO_ERROR(H5E_DATASET, H5E_CANTGET, FAIL, "unable to lookup chunk (SCC)");
-        
-            /* Free udata since the chunks do not exist (decode will not be called) */
-            for (int j = 0; j < chunk_count; j++) {
-                udata_arr[j] = H5MM_xfree(udata_arr[j]);
-            }
+
+        /* Free udata since the chunks do not exist (decode will not be called) */
+        for (int j = 0; j < chunk_count; j++) {
+            udata_arr[j] = H5MM_xfree(udata_arr[j]);
+        }
 
         /* Create a new (empty) chunk (not inserted into the disk chunk index) */
         assert(dset_info[i].dset->shared->layout.sc_ops->new_chunk);
 
         /*
-         * The `new_chunk` callback will need to loop through each chunk here; 
+         * The `new_chunk` callback will need to loop through each chunk here;
          * we will need to have an array of chunk pointers. It *should* be sufficient
          * to simply create an array of void pointers, pass in the elements one-by-one,
          * and then ensure that in the future (when `chunk` is uses), the proper chunk
@@ -1082,69 +1093,77 @@ H5SC_write(H5SC_t *cache, size_t count, H5D_dset_io_info_t *dset_info)
         for (int j = 0; j < chunk_count; j++) {
 
             if (dset_info[i].dset->shared->layout.sc_ops->new_chunk(
-                                                                    dset_info[i].dset, /* INPUT: Pointer to the dataset in memory */ 
-                                                                    false,             /* INPUT: Bool to set whether to write the fill value to the chunk */
-                                                                    &nbytes,           /* OUTPUT: Number of bytes used */
-                                                                    &buf_size,         /* OUTPUT: Size of the chunk buffer */
-                                                                    &chunk_arr[j],     /* OUTPUT: Pointer to the chunk intermediate struct */
-                                                                    &udata_arr[j]      /* OUTPUT: Udata initialization */
-                                                                    ) < 0) {
+                    dset_info[i].dset, /* INPUT: Pointer to the dataset in memory */
+                    false,             /* INPUT: Bool to set whether to write the fill value to the chunk */
+                    &nbytes,           /* OUTPUT: Number of bytes used */
+                    &buf_size,         /* OUTPUT: Size of the chunk buffer */
+                    &chunk_arr[j],     /* OUTPUT: Pointer to the chunk intermediate struct */
+                    &udata_arr[j]      /* OUTPUT: Udata initialization */
+                    ) < 0) {
                 HGOTO_ERROR(H5E_DATASET, H5E_CANTGET, FAIL, "unable to create new chunk (SCC)");
             }
         }
-        
 
         /* The gather_mem callback is used to collect data from the memory buffer into the chunk buffer */
         assert(dset_info[i].dset->shared->layout.sc_ops->gather_mem);
-        
+
         for (int j = 0; j < chunk_count; j++) {
 
-            /* 
+            /*
              * Set the io_type_info struct parameters.
              * NOTE: Since vlen_buf_info isn't required for the v0, we simply avoided
              * initialize it (passing NULL causes an error and should be avoided)
              */
-            size_t src_type_size = 0; /* Manually taken from `*dset_info->type_info`, looking at the contents of the `layout_io_info` section */
-            size_t dst_type_size = 0; /* Manually taken from `*dset_info->type_info`, looking at the contents of the `layout_io_info` section */
-            my_io_type_info.tconv_buf = NULL; /* Datatype conv buffer (pointer) */
-            my_io_type_info.tconv_buf_size = src_type_size; /* Size of type conversion buffer */
-            my_io_type_info.bkg_buf = NULL; /* Pointer to background buffer */
-            my_io_type_info.bkg_buf_size = dst_type_size; /* Size of the background buffer */
-            my_io_type_info.may_use_in_place_tconv = true; /* Use in-place if possible */
+            size_t src_type_size = 0; /* Manually taken from `*dset_info->type_info`, looking at the contents
+                                         of the `layout_io_info` section */
+            size_t dst_type_size = 0; /* Manually taken from `*dset_info->type_info`, looking at the contents
+                                         of the `layout_io_info` section */
+            my_io_type_info.tconv_buf              = NULL;          /* Datatype conv buffer (pointer) */
+            my_io_type_info.tconv_buf_size         = src_type_size; /* Size of type conversion buffer */
+            my_io_type_info.bkg_buf                = NULL;          /* Pointer to background buffer */
+            my_io_type_info.bkg_buf_size           = dst_type_size; /* Size of the background buffer */
+            my_io_type_info.may_use_in_place_tconv = true;          /* Use in-place if possible */
 
-            gather_mem_space = sc_io_info.sel_chunks[j].mem_space; /* Pointer to the memory space ID, derived from sc_io_info */
-            gather_file_space = sc_io_info.sel_chunks[j].file_space; /* Pointer to the file space ID, derived from sc_io_info */
+            gather_mem_space = sc_io_info.sel_chunks[j]
+                                   .mem_space; /* Pointer to the memory space ID, derived from sc_io_info */
+            gather_file_space = sc_io_info.sel_chunks[j]
+                                    .file_space; /* Pointer to the file space ID, derived from sc_io_info */
 
-            /* nbytes, alloc_size, and alloc_size_total are embedded in the chunk intermediate struct and don't need to be adjusted/corrected for each chunk that is looped over */
+            /* nbytes, alloc_size, and alloc_size_total are embedded in the chunk intermediate struct and
+             * don't need to be adjusted/corrected for each chunk that is looped over */
             if (dset_info[i].dset->shared->layout.sc_ops->gather_mem(
-                                                            &dset_info[i],     /* INPUT: Pointer to the dataset in memory*/
-                                                            &my_io_type_info,  /* INPUT: Localized version of the H5D_io_type_info_t; derived from information available in the sc_io_info struct */
-                                                            gather_mem_space,  /* INPUT: Pointer to the appropriate memory space ID */
-                                                            gather_file_space,  /* INPUT: Pointer to the appropriate file space ID */
-                                                            &nbytes,           /* INPUT/OUTPUT Size of the chunk; will be reallocated in this callback and returned */
-                                                            &alloc_size,       /* INPUT/OUTPUT: Allocated size of the chunk buffer */
-                                                            &alloc_size_total, /* INPUT/OUTPUT: Size of nbytes + alloc_size */
-                                                            chunk_arr[j],      /*INPUT/OUTPUT: Intermediate chunk structure */
-                                                            udata_arr[j]       /* UNUSED */
-                                                            ) < 0) {
+                    &dset_info[i],     /* INPUT: Pointer to the dataset in memory*/
+                    &my_io_type_info,  /* INPUT: Localized version of the H5D_io_type_info_t; derived from
+                                          information available in the sc_io_info struct */
+                    gather_mem_space,  /* INPUT: Pointer to the appropriate memory space ID */
+                    gather_file_space, /* INPUT: Pointer to the appropriate file space ID */
+                    &nbytes,     /* INPUT/OUTPUT Size of the chunk; will be reallocated in this callback and
+                                    returned */
+                    &alloc_size, /* INPUT/OUTPUT: Allocated size of the chunk buffer */
+                    &alloc_size_total, /* INPUT/OUTPUT: Size of nbytes + alloc_size */
+                    chunk_arr[j],      /*INPUT/OUTPUT: Intermediate chunk structure */
+                    udata_arr[j]       /* UNUSED */
+                    ) < 0) {
                 HGOTO_ERROR(H5E_DATASET, H5E_CANTGET, FAIL, "unable to gather mem for new chunk (SCC)");
-                }
+            }
         }
         /*
          * Start the "eviction" process
          * First, we encode in place (chunk becomes disk formatted chunk buffer)
          */
         assert(dset_info[i].dset->shared->layout.sc_ops->encode_in_place);
-        
+
         for (int j = 0; j < chunk_count; j++) {
 
             if (dset_info[i].dset->shared->layout.sc_ops->encode_in_place(
-                                                                    dset_info[i].dset, /* INPUT: Pointer to the dataset in memory */
-                                                                    &write_size,       /* OUTPUT: Sum of the size of the selected bytes and the data bytes */
-                                                                    false,             /* UNUSED; indicate used to specify if a chunk has a partial boundary (unsupported in v0) */
-                                                                    &chunk_arr[j],     /* INPUT/OUTPUT On entry, points to the chunk intermediate struct; on exit, points to the on disk file format chunk buffer */
-                                                                    udata_arr[j]       /* INPUT/OUTPUT Udata, which has been utilized by previous callbacks */
-                                                                    ) < 0) { 
+                    dset_info[i].dset, /* INPUT: Pointer to the dataset in memory */
+                    &write_size,       /* OUTPUT: Sum of the size of the selected bytes and the data bytes */
+                    false, /* UNUSED; indicate used to specify if a chunk has a partial boundary (unsupported
+                              in v0) */
+                    &chunk_arr[j], /* INPUT/OUTPUT On entry, points to the chunk intermediate struct; on exit,
+                                      points to the on disk file format chunk buffer */
+                    udata_arr[j]   /* INPUT/OUTPUT Udata, which has been utilized by previous callbacks */
+                    ) < 0) {
                 HGOTO_ERROR(H5E_DATASET, H5E_CANTGET, FAIL, "unable to encode chunk in place (SCC)");
             }
 
@@ -1155,26 +1174,30 @@ H5SC_write(H5SC_t *cache, size_t count, H5D_dset_io_info_t *dset_info)
         assert(dset_info[i].dset->shared->layout.sc_ops->insert);
 
         if (dset_info[i].dset->shared->layout.sc_ops->insert(
-                                                dset_info[i].dset, /* INPUT: Pointer to the dataset in memory */
-                                                chunk_count,       /* INPUT: Number of chunks in the I/O request */
-                                                &scaled,           /* INPUT: Scaled coordinate for the chunk; derived from `sc_io_info` */
-                                                addr,              /* INPUT/OUTPUT: Array of addrs */
-                                                NULL,              /* INPUT: Old disk size array; likely derived from the insert callback (if chunk is on disk) */
-                                                write_size_arr,    /* INPUT: Write size, computed from the encode callback */
-                                                chunk_arr,         /* UNUSED: Intermediate chunk structure (on-disk formatted); full array */
-                                                udata_arr          /* INPUT: Array of udata (which are modified by previous callbacks) */
-                                                ) < 0)
+                dset_info[i].dset, /* INPUT: Pointer to the dataset in memory */
+                chunk_count,       /* INPUT: Number of chunks in the I/O request */
+                &scaled,           /* INPUT: Scaled coordinate for the chunk; derived from `sc_io_info` */
+                addr,              /* INPUT/OUTPUT: Array of addrs */
+                NULL, /* INPUT: Old disk size array; likely derived from the insert callback (if chunk is on
+                         disk) */
+                write_size_arr, /* INPUT: Write size, computed from the encode callback */
+                chunk_arr,      /* UNUSED: Intermediate chunk structure (on-disk formatted); full array */
+                udata_arr       /* INPUT: Array of udata (which are modified by previous callbacks) */
+                ) < 0)
             HGOTO_ERROR(H5E_DATASET, H5E_CANTINSERT, FAIL, "unable to insert chunk into file (SCC)");
 
         for (int j = 0; j < chunk_count; j++) {
-        /* Write the chunk to file using H5F_block_write */
+            /* Write the chunk to file using H5F_block_write */
             if (H5F_block_write(
-                            dset_info[i].dset->oloc.file, /* INPUT: Current file ID */
-                            H5FD_MEM_DRAW,               /* INPUT: Based on the definitions in H5F_mem_t, this option seemed the most appropriate */
-                            *addr[j],                    /* INPUT: This is the address in the file where data will be written; set by the insert callback */
-                            write_size_arr[j],           /* INPUT: Encoded write size from the `encode_in_place` callback */
-                            chunk_arr[j]                 /* INPUT: Should be the data buffer (encode last modified the chunk buffer) */
-                            ) < 0) {
+                    dset_info[i].dset->oloc.file, /* INPUT: Current file ID */
+                    H5FD_MEM_DRAW, /* INPUT: Based on the definitions in H5F_mem_t, this option seemed the
+                                      most appropriate */
+                    *addr[j], /* INPUT: This is the address in the file where data will be written; set by the
+                                 insert callback */
+                    write_size_arr[j], /* INPUT: Encoded write size from the `encode_in_place` callback */
+                    chunk_arr[j] /* INPUT: Should be the data buffer (encode last modified the chunk buffer)
+                                  */
+                    ) < 0) {
                 HGOTO_ERROR(H5E_DATASET, H5E_WRITEERROR, FAIL, "unable to block write to file(SCC)");
             }
 
@@ -1188,7 +1211,7 @@ H5SC_write(H5SC_t *cache, size_t count, H5D_dset_io_info_t *dset_info)
             free(defined_values_size_hint[j]);
         }
         H5AC_tag(md_tag, NULL); /* Reset the metadata tag for the next dataset */
-    }/* End Dataset Loop */
+    }                           /* End Dataset Loop */
 done:
     /* Terminate sc_io_info */
     if (H5SC__io_info_term(&sc_io_info) < 0)

--- a/src/H5SC.c
+++ b/src/H5SC.c
@@ -21,6 +21,7 @@
 /* Headers */
 /***********/
 #include "H5private.h"   /* Generic Functions            */
+#include "H5ACprivate.h" /* Metadata Cache*/
 #include "H5Dpkg.h"      /* Datasets                     */
 #include "H5Eprivate.h"  /* Error handling               */
 #include "H5Fprivate.h"  /* Files                        */
@@ -228,9 +229,7 @@ done:
  *-------------------------------------------------------------------------
  */
 static herr_t
-H5SC__io_info_init(H5SC_t H5_ATTR_NDEBUG_UNUSED *cache, H5SC_io_info_t *sc_io_info, size_t count,
-                   H5D_dset_io_info_t *dset_info)
-{
+H5SC__io_info_init(H5SC_t H5_ATTR_NDEBUG_UNUSED *cache, H5SC_io_info_t *sc_io_info, size_t count, H5D_dset_io_info_t *dset_info) {
     H5S_t *tmp_dset_space     = NULL;
     H5S_t *single_chunk_space = NULL;
     size_t i;
@@ -280,19 +279,23 @@ H5SC__io_info_init(H5SC_t H5_ATTR_NDEBUG_UNUSED *cache, H5SC_io_info_t *sc_io_in
         sel_points = dset_info[i].nelmts;
 
         /* Nothing to do if no points selected, I/O is skipped, or no shared chunk cache client */
-        if (sel_points == 0 || dset_info[i].skip_io || !dset_info[i].layout->sc_ops)
+        if (sel_points == 0 || dset_info[i].skip_io || !dset_info[i].dset->shared->layout.sc_ops)
             continue;
 
         dset_sel_chunks = 0;
 
         /* Get chunk dimensions */
-        assert(dset_info[i].layout->sc_ops->layout_query);
-        if (dset_info[i].layout->sc_ops->layout_query(dset_info[i].dset, chunk_dims, NULL, NULL) < 0)
+        // assert(dset_info[i].layout->sc_ops->layout_query);
+        // if (dset_info[i].layout->sc_ops->layout_query(dset_info[i].dset, chunk_dims, NULL, NULL) < 0)
+        assert(dset_info[i].dset->shared->layout.sc_ops->layout_query);
+        if (dset_info[i].dset->shared->layout.sc_ops->layout_query(dset_info[i].dset, chunk_dims, NULL, NULL) < 0)
+        
             HGOTO_ERROR(H5E_DATASET, H5E_CANTGET, FAIL, "unable to query chunk dimensions");
 
-        /* Get dataspace ranks */
+        /* Get dataspace ranks */    
         file_ndims = (unsigned)H5S_GET_EXTENT_NDIMS(dset_info[i].file_space);
         mem_ndims  = (unsigned)H5S_GET_EXTENT_NDIMS(dset_info[i].mem_space);
+    
 
         /* Get the file and memory selection types */
         if ((file_sel_type = H5S_GET_SELECT_TYPE(dset_info[i].file_space)) < H5S_SEL_NONE)
@@ -391,8 +394,12 @@ H5SC__io_info_init(H5SC_t H5_ATTR_NDEBUG_UNUSED *cache, H5SC_io_info_t *sc_io_in
             }
 
             /* Get memory dataspace dimensions */
-            if (H5S_get_simple_extent_dims(dset_info[i].mem_space, mem_dims, NULL) < 0)
-                HGOTO_ERROR(H5E_DATASPACE, H5E_CANTGET, FAIL, "can't get memory dataspace dimensions");
+            // This sets mem_dims[i] correctly, the error message is not being reported correctly
+            if (H5S_get_simple_extent_dims(dset_info[i].mem_space, mem_dims, NULL) < 0){
+                   assert(0); // Added to illustrate the strange GDB nonsense...
+                   HGOTO_ERROR(H5E_DATASPACE, H5E_CANTGET, FAIL, "can't get memory dataspace dimensions");
+
+            }
         }
         else
             /* Create a dataspace with the same extent as the file dataspace */
@@ -738,15 +745,144 @@ H5SC_read(H5SC_t *cache, size_t count, H5D_dset_io_info_t *dset_info)
 {
     H5SC_io_info_t sc_io_info;
     herr_t         ret_value = SUCCEED;
+    volatile hsize_t *scaled[H5S_MAX_RANK]; // First used in the lookup callback
+    volatile haddr_t *addr[H5S_MAX_RANK]; // First used in the lookup callback
+    volatile haddr_t addr0; // Instanced addr_t
+    volatile hsize_t *size[H5S_MAX_RANK]; // First used in the lookup callback
+    volatile hsize_t size0; // Instanced hsize_t
+    volatile hsize_t *defined_values_size[H5S_MAX_RANK]; // First used in the lookup callback
+    volatile size_t *size_hint[H5S_MAX_RANK]; // First used in the lookup callback
+    volatile size_t *defined_values_size_hint[H5S_MAX_RANK]; // First used in the lookup callback
+    volatile void *udata_arr[H5S_MAX_RANK]; // First used in the lookup callback
+    volatile void *chunk = NULL; // First used in block read; eventually becomes the chunk intermediate struct
+    volatile H5D_io_type_info_t my_io_type_info; // First used in the scatter_mem callback
+    volatile const H5S_t *scatter_mem_space; // Used in the scatter_mem callback
+    volatile const H5S_t *scatter_file_space; // Used in the scatter_mem callback
+    haddr_t md_tag = HADDR_UNDEF;
+
 
     FUNC_ENTER_NOAPI(FAIL)
 
     assert(cache);
     assert(count == 0 || dset_info);
 
+    /* 
+     * *** VO: Pass the I/O request (for a single chunk) "through" the cache ***
+     * Since the cache isn't implemented yet, we'll simulate this using the following
+     * process:
+     * 0. Perform initial setup (completed by `H5SC_io_info_init`)
+     * For each chunk in `sc_io_info`:
+     * 
+     * 1. Cache emulation for Raw Data Read
+     *  - Check if the chunk is in cache (it won't be at this point);
+     *    if not, look up the chunk with `H5D__struct_chunk_lookup()`
+     *  - If the chunk is found on disk, initiate a chunk read from disk
+     *    In the initial version, we know the chunk is on disk, so this
+     *    callback will return the address and size of the chunk.
+     *  
+     * 2. Read the chunk into memory 
+     *  - Use `H5F_block_read()` to read with the address/size previously
+     *    returned from the lookup callback
+     *  - Afterward, use `H5D__struct_chunk_decode()` to decode the chunk
+     *    (from on disk memory to in cache memory)
+     *  - The chunk data then needs to be scattered into the user buffer
+     *    using `H5D__struct_chunk_scatter_mem()`
+     */
+
     /* Set up selections in sc_io_info */
-    if (H5SC__io_info_init(cache, &sc_io_info, count, dset_info) < 0)
+    if (H5SC__io_info_init(cache, &sc_io_info, count, dset_info) < 0) {
         HGOTO_ERROR(H5E_DATASET, H5E_CANTINIT, FAIL, "can't initialize selections for I/O");
+    }
+
+    /*Loop through the datasets*/
+    for (int i = 0; i < count; i++) {
+
+        /*Set metadata tagging for this dataset*/
+        H5AC_tag(dset_info[i].dset->oloc.addr, &md_tag);
+
+        size_t chunk_count = sc_io_info.num_sel_chunks;
+
+        /*Chunk lookup (in file)*/
+        assert(dset_info[i].dset->shared->layout.sc_ops->lookup);
+
+        scaled[0] = sc_io_info.sel_chunks[0].scaled;
+        addr[0] = &addr0;
+        size[0] = &size0;
+
+        if (dset_info[i].dset->shared->layout.sc_ops->lookup(
+                                                            dset_info[i].dset,       /*INPUT: Pointer to the dataset (in file)*/
+                                                            chunk_count,             /*INPUT: The number of chunks in this datasets*/
+                                                            scaled,                  /*INPUT: Scaled coordinate(s) of the chunk*/
+                                                            addr,                    /*OUTPUT: Address of the chunk (on disk)*/
+                                                            size,                    /*OUTPUT: Chunk size (on disk)*/
+                                                            defined_values_size,      /*OUTPUT: The number of bytes to read (if the list of defined values is needed)*/
+                                                            size_hint,               /*OUTPUT: The suggested allocation size for the chunk (pre-decode)*/
+                                                            defined_values_size_hint, /*OUTPUT: Suggested allocation size (if the list of defined values is needed)*/
+                                                            &udata_arr               /*OUTPUT: Buffer to be passed through to H5D__struct_chunk_decode(_in_place)*/
+                                                            ) < 0) {
+            HGOTO_ERROR(H5E_DATASET, H5E_CANTGET, FAIL, "unable to lookup chunk (SCC)");
+        }
+
+        /*
+         * ***Read the data from file (disk)***
+         */
+
+        /* Allocate buffer for the chunk data*/
+        if (NULL == (chunk = H5MM_malloc(*size_hint[0]))) {
+            HGOTO_ERROR(H5E_RESOURCE, H5E_NOSPACE, H5_ITER_ERROR, "memory allocation failed for raw data chunk (SCC)");
+        }
+
+        if (H5F_block_read(
+                    dset_info[i].dset->oloc.file, /*INPUT: Current file ID*/
+                    H5FD_MEM_DRAW,               /*INPUT: Set based on the definitions in the H5F_mem_t type*/
+                    *addr[0],                    /*INPUT: Address returned from the lookup callback */
+                    *size[0],                    /*INPUT: Size returned from the lookup callback*/
+                    chunk                        /*INPUT/OUTPUT: Chunk buffer (which will be transitioned into the intermediate format)*/
+                    ) < 0 ) {
+            HGOTO_ERROR(H5E_DATASET, H5E_READERROR, FAIL, "unable to block read from file (SCC)");
+        }
+
+        assert(dset_info[i].dset->shared->layout.sc_ops->decode);
+
+        size_t nbytes = *size[0]; /*Prior to decode, this is the number of bytes used in the chunk buffer*/
+        size_t alloc_size = *size_hint[0]; /*Prior to decode, this is the size of the chunk buffer*/
+
+        if (dset_info[i].dset->shared->layout.sc_ops->decode(
+                                                        dset_info[i].dset, /*INPUT: Pointer to the dataset in memory*/
+                                                        &nbytes,           /*INPUT/OUTPUT: nbytes; entry: number of bytes used in the chunk buffer; exit: total number of bytes used (not allocated)  (this may not be *size[0]...)*/
+                                                        &alloc_size,       /*INPUT/OUTPUT: alloc_size*/
+                                                        false,             /*UNUSED*/
+                                                        &chunk,            /*INPUT/OUTPUT: chunk; On entry: the pointer tot he on disk formatted chunk buffer; On exit: the pointer to the chunk intermediate struct*/
+                                                        udata_arr[0]       /*INPUT: Used to store some chunk properties*/
+                                                        ) < 0) {
+            HGOTO_ERROR(H5E_DATASET, H5E_CANTGET, FAIL, "unable to decode chunk in place (SCC)");
+        }
+        assert(dset_info[i].dset->shared->layout.sc_ops->scatter_mem);
+
+        size_t src_type_size = 0; /*Manually taken from `*dset_info->type_info`, looking at the contents of the `layout_io_info` section*/
+        size_t dst_type_size = 0; /*Manually taken from `*dset_info->type_info`, looking at the contents of the `layout_io_info` section*/
+        my_io_type_info.tconv_buf = NULL; /*Datatype conv buffer (pointer)*/
+        my_io_type_info.tconv_buf_size = src_type_size; /*Size of type conversion buffer*/
+        my_io_type_info.bkg_buf = NULL; /*Pointer to background buffer*/
+        my_io_type_info.bkg_buf_size = dst_type_size; /*Size of the background buffer*/
+
+        // There is also a need to set the mem/file spaces
+        scatter_mem_space = sc_io_info.sel_chunks[0].mem_space; /* Pointer to the memory space ID for the chunk (derived from sc_io_info)*/
+        scatter_file_space = sc_io_info.sel_chunks[0].file_space; /* Pointer to the file space ID for the chunk (derived from sc_io_info)*/
+
+        if (dset_info[i].dset->shared->layout.sc_ops->scatter_mem(
+                                                                &dset_info[i],     /*INPUT: Pointer to the dataset in memory*/
+                                                                &my_io_type_info,  /*INPUT: Localized version of H5D_io_type_info_t; derived from information available in the sc_io_info struct*/
+                                                                scatter_mem_space, /*INPUT: Pointer to the appropriate memory space ID*/
+                                                                scatter_file_space, /*INPUT: Pointer to the appropriate file space space ID*/
+                                                                chunk,             /*INPUT/OUTPUT: Memory-formatted chunk buffer*/
+                                                                udata_arr[0]       /*UNUSED: Udata, which is modified by previous callbacks*/
+                                                                ) < 0) {
+            HGOTO_ERROR(H5E_DATASET, H5E_CANTGET, FAIL, "unable to scatter mem for read chunk (SCC)");
+        }
+        assert(chunk);
+        H5AC_tag(md_tag, NULL); /*Reset the metadata tag for the next dataset*/
+    }/*Dataset Loop End*/
 
 done:
     /* Terminate sc_io_info */
@@ -771,16 +907,186 @@ H5SC_write(H5SC_t *cache, size_t count, H5D_dset_io_info_t *dset_info)
 {
     H5SC_io_info_t sc_io_info;
     herr_t         ret_value = SUCCEED;
+    volatile size_t nbytes; // Used in the new chunk callback
+    volatile size_t buf_size; // Used in the new chunk callback
+    volatile void *chunk;
+    volatile size_t alloc_size;
+    volatile size_t alloc_size_total;
+    volatile size_t write_size;
+    volatile hsize_t *scaled[H5S_MAX_RANK]; // Initializing to 0 doesn't have any effect
+    volatile H5D_io_type_info_t my_io_type_info; // Used in gather_mem callback
+    volatile const H5S_t *gather_mem_space;
+    volatile const H5S_t *gather_file_space;
+    volatile haddr_t *addr[H5S_MAX_RANK];
+    volatile haddr_t addr0;
+    volatile hsize_t *size[H5S_MAX_RANK];
+    volatile hsize_t size0;
+    volatile hsize_t *defined_values_size[H5S_MAX_RANK];
+    volatile size_t *size_hint[H5S_MAX_RANK]; 
+    volatile size_t *defined_values_size_hint[H5S_MAX_RANK]; 
+    volatile void *udata_arr[H5S_MAX_RANK];
+    volatile hsize_t new_disk_size[H5S_MAX_RANK];
+    haddr_t md_tag = HADDR_UNDEF;
 
     FUNC_ENTER_NOAPI(FAIL)
 
     assert(cache);
     assert(count == 0 || dset_info);
 
+    /* 
+     * *** V0: Pass the I/O request (for a single chunk) "through" the cache ***
+     * Since the cache isn't implemented yet, we'll simulate this using the following
+     * process:
+     * For each chunk in `sc_io_info`:
+     * 
+     * 1. Cache emulation for Raw Data Write
+     *  - Look up the chunk (expected failure to find; no cache to search)
+     *  - The chunk is not yet written to file (assumed for version 0 prototype),
+     *    so it should be fully overwritten
+     *  - Call `H5SC_new_chunk_t` to create a new chunk (fill = true)
+     *  - Call H5SC_chunk_gather_mem_t
+     *  
+     * 2. Immediately evict the chunk from the "cache"
+     *  - The chunk will be dirty (new chunk not in file)
+     *  - The chunk is not encoded; encode (diagram says in-place, 
+     *    need to look at encode as well)
+     *  - Call H5SC_chunk_insert_t to insert the chunk into the file indexing
+     *  - Call H5F_block_write (in H5Fio.c) to write the chunk (single buffer) to the file
+     *  - Free the chunk from the "cache"
+     */
+
     /* Set up selections in sc_io_info */
     if (H5SC__io_info_init(cache, &sc_io_info, count, dset_info) < 0)
         HGOTO_ERROR(H5E_DATASET, H5E_CANTINIT, FAIL, "can't initialize selections for I/O");
 
+    // Loop through the datasets
+    for (int i = 0; i < count; i++) {
+        /* 
+         * To avoid issues with metadata tagging while doing multi-dataset I/O,
+         * we need to handle tagging within the SCC
+         */
+        H5AC_tag(dset_info[i].dset->oloc.addr, &md_tag); // Set the metadata tag (Does this need to be for the ith dataset?)
+
+        // Throw an error if no chunks were selected
+        if (sc_io_info.num_sel_chunks == 0) //{
+            HDONE_ERROR(H5E_DATASET, H5E_CANTGETSIZE, FAIL, 
+                "The number of structured chunks should be non-zero");
+
+        size_t chunk_count = sc_io_info.num_sel_chunks;
+
+        /*
+         * Begin the write process (cache emulation)
+         *Look up the chunk in file (for now, simply assert that the callback is present)
+         */
+        assert(dset_info[i].dset->shared->layout.sc_ops->lookup);
+
+        scaled[0] = sc_io_info.sel_chunks[0].scaled;
+        addr[0] = &addr0; // Should this be buf from the sel_chunks struct?
+        size[0] = &size0;
+
+        if (dset_info[i].dset->shared->layout.sc_ops->lookup(
+                                                            dset_info[i].dset,       /*INPUT: Pointer to the dataset in memory*/
+                                                            chunk_count,             /*INPUT: The number of chunks in the dataset being processed*/
+                                                            scaled,                  /*INPUT: Scaled coordinate(s) for the chunk*/
+                                                            addr,                    /*OUTPUT: Address of the chunk (on disk)*/
+                                                            size,                    /*OUTPUT: Chunk size (on disk)*/
+                                                            defined_values_size,      /*OUTPUT: The number of bytes to read (if the list of defined values is needed)*/
+                                                            size_hint,               /*OUTPUT: The suggested allocation size for the chunk (pre-encode)*/
+                                                            defined_values_size_hint, /*OUTPUT: Suggested allocation size (if on the list of defined values is needed)*/
+                                                            &udata_arr               /*OUTPUT: Buffer to be passed through to H5__struct_chunk_encode(_in_place())*/
+                                                            ) < 0)
+            HGOTO_ERROR(H5E_DATASET, H5E_CANTGET, FAIL, "unable to lookup chunk (SCC)");
+
+        /*Create a new (empty) chunk (not inserted into the disk chunk index)*/
+        assert(dset_info[i].dset->shared->layout.sc_ops->new_chunk);
+
+        if (dset_info[i].dset->shared->layout.sc_ops->new_chunk(
+                                                                dset_info[i].dset, /*INPUT: Pointer to the dataset in memory NOTE: 5/7 This isn the wrong dataset info struct...*/ 
+                                                                false,             /*INPUT: Bool to set whether to write the fill value to the chunk (unless this is a sparse chunk)*/
+                                                                &nbytes,           /*OUTPUT: Number of bytes used (initialized to zero if chunk isn't found, yeah?)*/
+                                                                &buf_size,         /*OUTPUT: Size of the chunk buffer*/
+                                                                &chunk,            /*OUTPUT: Pointer to the chunk intermediate struct*/
+                                                                &udata_arr[0]      /*OUTPUT: Udata initialization*/
+                                                                ) < 0)
+            HGOTO_ERROR(H5E_DATASET, H5E_CANTGET, FAIL, "unable to create new chunk (SCC)");
+
+        /* 
+         * Set the io_type_info struct parameters.
+         * NOTE: Since vlen_buf_info isn't required for the v0, we simply avoind
+         * initialize it (passing NULL causes an error and should be avoided)
+         */
+        size_t src_type_size = 0; /*Manually taken from `*dset_info->type_info`, looking at the contents of the `layout_io_info` section*/
+        size_t dst_type_size = 0; /*Manually taken from `*dset_info->type_info`, looking at the contents of the `layout_io_info` section*/
+        my_io_type_info.tconv_buf = NULL; /*Datatype conv buffer (pointer)*/
+        my_io_type_info.tconv_buf_size = src_type_size; /*Size of type conversion buffer*/
+        my_io_type_info.bkg_buf = NULL; /*Pointer to background buffer*/
+        my_io_type_info.bkg_buf_size = dst_type_size; /*Size of the background buffer*/
+        my_io_type_info.may_use_in_place_tconv = true; /*Use in-place if possible*/
+
+        /*The gather_mem callback is used to collect data from the memory buffer into the chunk buffer*/
+        assert(dset_info[i].dset->shared->layout.sc_ops->gather_mem);
+        
+        gather_mem_space = sc_io_info.sel_chunks[0].mem_space; /*Pointer to the memory space ID, derived from sc_io_info*/
+        gather_file_space = sc_io_info.sel_chunks[0].file_space; /*Pointer to the file space ID, derived from sc_io_info*/
+
+        if (dset_info[i].dset->shared->layout.sc_ops->gather_mem(
+                                                        &dset_info[i],     /*INPUT: Pointer to the dataset in memory*/
+                                                        &my_io_type_info,  /*INPUT: Localized version of the H5D_io_type_info_t; derived from information available in the sc_io_info struct*/
+                                                        gather_mem_space,  /*INPUT: Pointer to the appropriate memory space ID*/
+                                                        gather_file_space,  /*INPUT: Pointer to the appropriate file space ID*/
+                                                        &nbytes,           /*INPUT/OUTPUT Size of the chunk; will be reallocated in this callback and returned*/
+                                                        &alloc_size,       /*INPUT/OUTPUT: Allocated size of the chunk buffer (?)*/
+                                                        &alloc_size_total, /*INPUT/OUTPUT: Size of nbytes + alloc_size*/
+                                                        chunk,             /*INPUT/OUTPUT: Intermediate chunk structure*/
+                                                        udata_arr[0]       /*UNUSED*/
+                                                        ) < 0)
+            HGOTO_ERROR(H5E_DATASET, H5E_CANTGET, FAIL, "unable to gather mem for new chunk (SCC)");
+
+        /*
+         * Start the "eviction" process
+         * First, we encode in place (chunk becomes disk formatted chunk buffer)
+         */
+        assert(dset_info[i].dset->shared->layout.sc_ops->encode_in_place);
+        if (dset_info[i].dset->shared->layout.sc_ops->encode_in_place(
+                                                                dset_info[i].dset, /*INPUT: Pointer to the dataset in memory*/
+                                                                &write_size,       /*OUTPUT: Sum of the size of the selected bytes and the data bytes*/
+                                                                false,             /*UNUSED; indicate used to specify if a chunk has a partial boundary (unsupported in v0)*/
+                                                                &chunk,            /*INPUT/OUTPUT On entry, points to the chunk intermediate struct; on exit, points to the on disk file format chunk buffer*/
+                                                                udata_arr[0]       /*INPUT/OUTPUT Udata, which has been utilized by previous callbacks*/
+                                                                ) < 0) { 
+            HGOTO_ERROR(H5E_DATASET, H5E_CANTGET, FAIL, "unable to encode chunk in place (SCC)");
+        }
+
+        /*Add the computed write size to the appropriate array*/
+        new_disk_size[0] = write_size;
+
+        /*Insert the chunk into the chunk index within the file*/
+        assert(dset_info[i].dset->shared->layout.sc_ops->insert);
+        
+        if (dset_info[i].dset->shared->layout.sc_ops->insert(
+                                                dset_info[i].dset, /*INPUT: Pointer to the dataset in memory*/
+                                                chunk_count,       /*INPUT: Number of chunks in the I/O request*/
+                                                &scaled,           /*INPUT: Scaled coordinate for the chunk; derived from `sc_io_info`*/
+                                                addr,              /*INPUT/OUTPUT: Array of addrs*/
+                                                NULL,              /*INPUT: Old disk size array; likely derived from the insert callback (if chunk is on disk)*/
+                                                new_disk_size,     /*INPUT: Write size, computed from the encode callback*/
+                                                chunk,             /*UNUSED: Intermediate chunk structure (on-disk formatted); full array*/
+                                                udata_arr          /*INPUT: Array of udata (which are modified by previous callbacks)*/
+                                                ) < 0)
+            HGOTO_ERROR(H5E_DATASET, H5E_CANTINSERT, FAIL, "unable to insert chunk into file (SCC)");
+
+        /*Write the chunk to file using H5F_block_write*/
+        if (H5F_block_write(
+                        dset_info[i].dset->oloc.file, /*INPUT: Current file ID*/
+                        H5FD_MEM_DRAW,               /*INPUT: Based on the definitions in H5F_mem_t, this option seemed the most appropriate*/
+                        *addr[0],                    /*INPUT: This is the address in the file where data will be written; set by the insert callback*/
+                        write_size,                  /*INPUT: Encoded write size from the `encode_in_place` callback*/
+                        chunk                        /*INPUT: Should be the data buffer (encode last modified the chunk buffer)*/
+                        ) < 0) {
+            HGOTO_ERROR(H5E_DATASET, H5E_WRITEERROR, FAIL, "unable to block write to file(SCC)");
+        }
+        H5AC_tag(md_tag, NULL); /*Reset the metadata tag for the next dataset*/
+    }/*Dataset Loop*/
 done:
     /* Terminate sc_io_info */
     if (H5SC__io_info_term(&sc_io_info) < 0)

--- a/src/H5SC.c
+++ b/src/H5SC.c
@@ -229,7 +229,9 @@ done:
  *-------------------------------------------------------------------------
  */
 static herr_t
-H5SC__io_info_init(H5SC_t H5_ATTR_NDEBUG_UNUSED *cache, H5SC_io_info_t *sc_io_info, size_t count, H5D_dset_io_info_t *dset_info) {
+H5SC__io_info_init(H5SC_t H5_ATTR_NDEBUG_UNUSED *cache, H5SC_io_info_t *sc_io_info, size_t count,
+                   H5D_dset_io_info_t *dset_info)
+{
     H5S_t *tmp_dset_space     = NULL;
     H5S_t *single_chunk_space = NULL;
     size_t i;
@@ -288,14 +290,14 @@ H5SC__io_info_init(H5SC_t H5_ATTR_NDEBUG_UNUSED *cache, H5SC_io_info_t *sc_io_in
         // assert(dset_info[i].layout->sc_ops->layout_query);
         // if (dset_info[i].layout->sc_ops->layout_query(dset_info[i].dset, chunk_dims, NULL, NULL) < 0)
         assert(dset_info[i].dset->shared->layout.sc_ops->layout_query);
-        if (dset_info[i].dset->shared->layout.sc_ops->layout_query(dset_info[i].dset, chunk_dims, NULL, NULL) < 0)
-        
+        if (dset_info[i].dset->shared->layout.sc_ops->layout_query(dset_info[i].dset, chunk_dims, NULL,
+                                                                   NULL) < 0)
+
             HGOTO_ERROR(H5E_DATASET, H5E_CANTGET, FAIL, "unable to query chunk dimensions");
 
-        /* Get dataspace ranks */    
+        /* Get dataspace ranks */
         file_ndims = (unsigned)H5S_GET_EXTENT_NDIMS(dset_info[i].file_space);
         mem_ndims  = (unsigned)H5S_GET_EXTENT_NDIMS(dset_info[i].mem_space);
-    
 
         /* Get the file and memory selection types */
         if ((file_sel_type = H5S_GET_SELECT_TYPE(dset_info[i].file_space)) < H5S_SEL_NONE)
@@ -395,10 +397,9 @@ H5SC__io_info_init(H5SC_t H5_ATTR_NDEBUG_UNUSED *cache, H5SC_io_info_t *sc_io_in
 
             /* Get memory dataspace dimensions */
             // This sets mem_dims[i] correctly, the error message is not being reported correctly
-            if (H5S_get_simple_extent_dims(dset_info[i].mem_space, mem_dims, NULL) < 0){
-                   assert(0); // Added to illustrate the strange GDB nonsense...
-                   HGOTO_ERROR(H5E_DATASPACE, H5E_CANTGET, FAIL, "can't get memory dataspace dimensions");
-
+            if (H5S_get_simple_extent_dims(dset_info[i].mem_space, mem_dims, NULL) < 0) {
+                assert(0); // Added to illustrate the strange GDB nonsense...
+                HGOTO_ERROR(H5E_DATASPACE, H5E_CANTGET, FAIL, "can't get memory dataspace dimensions");
             }
         }
         else
@@ -743,44 +744,43 @@ H5SC__io_info_term(H5SC_io_info_t *sc_io_info)
 herr_t
 H5SC_read(H5SC_t *cache, size_t count, H5D_dset_io_info_t *dset_info)
 {
-    H5SC_io_info_t sc_io_info;
-    herr_t         ret_value = SUCCEED;
-    volatile hsize_t *scaled[H5S_MAX_RANK]; // First used in the lookup callback
-    volatile haddr_t *addr[H5S_MAX_RANK]; // First used in the lookup callback
-    volatile haddr_t addr0; // Instanced addr_t
-    volatile hsize_t *size[H5S_MAX_RANK]; // First used in the lookup callback
-    volatile hsize_t size0; // Instanced hsize_t
-    volatile hsize_t *defined_values_size[H5S_MAX_RANK]; // First used in the lookup callback
-    volatile size_t *size_hint[H5S_MAX_RANK]; // First used in the lookup callback
-    volatile size_t *defined_values_size_hint[H5S_MAX_RANK]; // First used in the lookup callback
-    volatile void *udata_arr[H5S_MAX_RANK]; // First used in the lookup callback
+    H5SC_io_info_t    sc_io_info;
+    herr_t            ret_value = SUCCEED;
+    volatile hsize_t *scaled[H5S_MAX_RANK];                   // First used in the lookup callback
+    volatile haddr_t *addr[H5S_MAX_RANK];                     // First used in the lookup callback
+    volatile haddr_t  addr0;                                  // Instanced addr_t
+    volatile hsize_t *size[H5S_MAX_RANK];                     // First used in the lookup callback
+    volatile hsize_t  size0;                                  // Instanced hsize_t
+    volatile hsize_t *defined_values_size[H5S_MAX_RANK];      // First used in the lookup callback
+    volatile size_t  *size_hint[H5S_MAX_RANK];                // First used in the lookup callback
+    volatile size_t  *defined_values_size_hint[H5S_MAX_RANK]; // First used in the lookup callback
+    volatile void    *udata_arr[H5S_MAX_RANK];                // First used in the lookup callback
     volatile void *chunk = NULL; // First used in block read; eventually becomes the chunk intermediate struct
-    volatile H5D_io_type_info_t my_io_type_info; // First used in the scatter_mem callback
-    volatile const H5S_t *scatter_mem_space; // Used in the scatter_mem callback
-    volatile const H5S_t *scatter_file_space; // Used in the scatter_mem callback
-    haddr_t md_tag = HADDR_UNDEF;
-
+    volatile H5D_io_type_info_t my_io_type_info;    // First used in the scatter_mem callback
+    volatile const H5S_t       *scatter_mem_space;  // Used in the scatter_mem callback
+    volatile const H5S_t       *scatter_file_space; // Used in the scatter_mem callback
+    haddr_t                     md_tag = HADDR_UNDEF;
 
     FUNC_ENTER_NOAPI(FAIL)
 
     assert(cache);
     assert(count == 0 || dset_info);
 
-    /* 
+    /*
      * *** VO: Pass the I/O request (for a single chunk) "through" the cache ***
      * Since the cache isn't implemented yet, we'll simulate this using the following
      * process:
      * 0. Perform initial setup (completed by `H5SC_io_info_init`)
      * For each chunk in `sc_io_info`:
-     * 
+     *
      * 1. Cache emulation for Raw Data Read
      *  - Check if the chunk is in cache (it won't be at this point);
      *    if not, look up the chunk with `H5D__struct_chunk_lookup()`
      *  - If the chunk is found on disk, initiate a chunk read from disk
      *    In the initial version, we know the chunk is on disk, so this
      *    callback will return the address and size of the chunk.
-     *  
-     * 2. Read the chunk into memory 
+     *
+     * 2. Read the chunk into memory
      *  - Use `H5F_block_read()` to read with the address/size previously
      *    returned from the lookup callback
      *  - Afterward, use `H5D__struct_chunk_decode()` to decode the chunk
@@ -806,20 +806,22 @@ H5SC_read(H5SC_t *cache, size_t count, H5D_dset_io_info_t *dset_info)
         assert(dset_info[i].dset->shared->layout.sc_ops->lookup);
 
         scaled[0] = sc_io_info.sel_chunks[0].scaled;
-        addr[0] = &addr0;
-        size[0] = &size0;
+        addr[0]   = &addr0;
+        size[0]   = &size0;
 
         if (dset_info[i].dset->shared->layout.sc_ops->lookup(
-                                                            dset_info[i].dset,       /*INPUT: Pointer to the dataset (in file)*/
-                                                            chunk_count,             /*INPUT: The number of chunks in this datasets*/
-                                                            scaled,                  /*INPUT: Scaled coordinate(s) of the chunk*/
-                                                            addr,                    /*OUTPUT: Address of the chunk (on disk)*/
-                                                            size,                    /*OUTPUT: Chunk size (on disk)*/
-                                                            defined_values_size,      /*OUTPUT: The number of bytes to read (if the list of defined values is needed)*/
-                                                            size_hint,               /*OUTPUT: The suggested allocation size for the chunk (pre-decode)*/
-                                                            defined_values_size_hint, /*OUTPUT: Suggested allocation size (if the list of defined values is needed)*/
-                                                            &udata_arr               /*OUTPUT: Buffer to be passed through to H5D__struct_chunk_decode(_in_place)*/
-                                                            ) < 0) {
+                dset_info[i].dset,   /*INPUT: Pointer to the dataset (in file)*/
+                chunk_count,         /*INPUT: The number of chunks in this datasets*/
+                scaled,              /*INPUT: Scaled coordinate(s) of the chunk*/
+                addr,                /*OUTPUT: Address of the chunk (on disk)*/
+                size,                /*OUTPUT: Chunk size (on disk)*/
+                defined_values_size, /*OUTPUT: The number of bytes to read (if the list of defined values is
+                                        needed)*/
+                size_hint,           /*OUTPUT: The suggested allocation size for the chunk (pre-decode)*/
+                defined_values_size_hint, /*OUTPUT: Suggested allocation size (if the list of defined values
+                                             is needed)*/
+                &udata_arr /*OUTPUT: Buffer to be passed through to H5D__struct_chunk_decode(_in_place)*/
+                ) < 0) {
             HGOTO_ERROR(H5E_DATASET, H5E_CANTGET, FAIL, "unable to lookup chunk (SCC)");
         }
 
@@ -829,16 +831,17 @@ H5SC_read(H5SC_t *cache, size_t count, H5D_dset_io_info_t *dset_info)
 
         /* Allocate buffer for the chunk data*/
         if (NULL == (chunk = H5MM_malloc(*size_hint[0]))) {
-            HGOTO_ERROR(H5E_RESOURCE, H5E_NOSPACE, H5_ITER_ERROR, "memory allocation failed for raw data chunk (SCC)");
+            HGOTO_ERROR(H5E_RESOURCE, H5E_NOSPACE, H5_ITER_ERROR,
+                        "memory allocation failed for raw data chunk (SCC)");
         }
 
         if (H5F_block_read(
-                    dset_info[i].dset->oloc.file, /*INPUT: Current file ID*/
-                    H5FD_MEM_DRAW,               /*INPUT: Set based on the definitions in the H5F_mem_t type*/
-                    *addr[0],                    /*INPUT: Address returned from the lookup callback */
-                    *size[0],                    /*INPUT: Size returned from the lookup callback*/
-                    chunk                        /*INPUT/OUTPUT: Chunk buffer (which will be transitioned into the intermediate format)*/
-                    ) < 0 ) {
+                dset_info[i].dset->oloc.file, /*INPUT: Current file ID*/
+                H5FD_MEM_DRAW,                /*INPUT: Set based on the definitions in the H5F_mem_t type*/
+                *addr[0],                     /*INPUT: Address returned from the lookup callback */
+                *size[0],                     /*INPUT: Size returned from the lookup callback*/
+                chunk /*INPUT/OUTPUT: Chunk buffer (which will be transitioned into the intermediate format)*/
+                ) < 0) {
             HGOTO_ERROR(H5E_DATASET, H5E_READERROR, FAIL, "unable to block read from file (SCC)");
         }
 
@@ -848,41 +851,50 @@ H5SC_read(H5SC_t *cache, size_t count, H5D_dset_io_info_t *dset_info)
         size_t alloc_size = *size_hint[0]; /*Prior to decode, this is the size of the chunk buffer*/
 
         if (dset_info[i].dset->shared->layout.sc_ops->decode(
-                                                        dset_info[i].dset, /*INPUT: Pointer to the dataset in memory*/
-                                                        &nbytes,           /*INPUT/OUTPUT: nbytes; entry: number of bytes used in the chunk buffer; exit: total number of bytes used (not allocated)  (this may not be *size[0]...)*/
-                                                        &alloc_size,       /*INPUT/OUTPUT: alloc_size*/
-                                                        false,             /*UNUSED*/
-                                                        &chunk,            /*INPUT/OUTPUT: chunk; On entry: the pointer tot he on disk formatted chunk buffer; On exit: the pointer to the chunk intermediate struct*/
-                                                        udata_arr[0]       /*INPUT: Used to store some chunk properties*/
-                                                        ) < 0) {
+                dset_info[i].dset, /*INPUT: Pointer to the dataset in memory*/
+                &nbytes, /*INPUT/OUTPUT: nbytes; entry: number of bytes used in the chunk buffer; exit: total
+                            number of bytes used (not allocated)  (this may not be *size[0]...)*/
+                &alloc_size, /*INPUT/OUTPUT: alloc_size*/
+                false,       /*UNUSED*/
+                &chunk, /*INPUT/OUTPUT: chunk; On entry: the pointer tot he on disk formatted chunk buffer; On
+                           exit: the pointer to the chunk intermediate struct*/
+                udata_arr[0] /*INPUT: Used to store some chunk properties*/
+                ) < 0) {
             HGOTO_ERROR(H5E_DATASET, H5E_CANTGET, FAIL, "unable to decode chunk in place (SCC)");
         }
         assert(dset_info[i].dset->shared->layout.sc_ops->scatter_mem);
 
-        size_t src_type_size = 0; /*Manually taken from `*dset_info->type_info`, looking at the contents of the `layout_io_info` section*/
-        size_t dst_type_size = 0; /*Manually taken from `*dset_info->type_info`, looking at the contents of the `layout_io_info` section*/
-        my_io_type_info.tconv_buf = NULL; /*Datatype conv buffer (pointer)*/
+        size_t src_type_size = 0; /*Manually taken from `*dset_info->type_info`, looking at the contents of
+                                     the `layout_io_info` section*/
+        size_t dst_type_size = 0; /*Manually taken from `*dset_info->type_info`, looking at the contents of
+                                     the `layout_io_info` section*/
+        my_io_type_info.tconv_buf      = NULL;          /*Datatype conv buffer (pointer)*/
         my_io_type_info.tconv_buf_size = src_type_size; /*Size of type conversion buffer*/
-        my_io_type_info.bkg_buf = NULL; /*Pointer to background buffer*/
-        my_io_type_info.bkg_buf_size = dst_type_size; /*Size of the background buffer*/
+        my_io_type_info.bkg_buf        = NULL;          /*Pointer to background buffer*/
+        my_io_type_info.bkg_buf_size   = dst_type_size; /*Size of the background buffer*/
 
         // There is also a need to set the mem/file spaces
-        scatter_mem_space = sc_io_info.sel_chunks[0].mem_space; /* Pointer to the memory space ID for the chunk (derived from sc_io_info)*/
-        scatter_file_space = sc_io_info.sel_chunks[0].file_space; /* Pointer to the file space ID for the chunk (derived from sc_io_info)*/
+        scatter_mem_space =
+            sc_io_info.sel_chunks[0]
+                .mem_space; /* Pointer to the memory space ID for the chunk (derived from sc_io_info)*/
+        scatter_file_space =
+            sc_io_info.sel_chunks[0]
+                .file_space; /* Pointer to the file space ID for the chunk (derived from sc_io_info)*/
 
         if (dset_info[i].dset->shared->layout.sc_ops->scatter_mem(
-                                                                &dset_info[i],     /*INPUT: Pointer to the dataset in memory*/
-                                                                &my_io_type_info,  /*INPUT: Localized version of H5D_io_type_info_t; derived from information available in the sc_io_info struct*/
-                                                                scatter_mem_space, /*INPUT: Pointer to the appropriate memory space ID*/
-                                                                scatter_file_space, /*INPUT: Pointer to the appropriate file space space ID*/
-                                                                chunk,             /*INPUT/OUTPUT: Memory-formatted chunk buffer*/
-                                                                udata_arr[0]       /*UNUSED: Udata, which is modified by previous callbacks*/
-                                                                ) < 0) {
+                &dset_info[i],      /*INPUT: Pointer to the dataset in memory*/
+                &my_io_type_info,   /*INPUT: Localized version of H5D_io_type_info_t; derived from information
+                                       available in the sc_io_info struct*/
+                scatter_mem_space,  /*INPUT: Pointer to the appropriate memory space ID*/
+                scatter_file_space, /*INPUT: Pointer to the appropriate file space space ID*/
+                chunk,              /*INPUT/OUTPUT: Memory-formatted chunk buffer*/
+                udata_arr[0]        /*UNUSED: Udata, which is modified by previous callbacks*/
+                ) < 0) {
             HGOTO_ERROR(H5E_DATASET, H5E_CANTGET, FAIL, "unable to scatter mem for read chunk (SCC)");
         }
         assert(chunk);
         H5AC_tag(md_tag, NULL); /*Reset the metadata tag for the next dataset*/
-    }/*Dataset Loop End*/
+    }                           /*Dataset Loop End*/
 
 done:
     /* Terminate sc_io_info */
@@ -905,50 +917,50 @@ done:
 herr_t
 H5SC_write(H5SC_t *cache, size_t count, H5D_dset_io_info_t *dset_info)
 {
-    H5SC_io_info_t sc_io_info;
-    herr_t         ret_value = SUCCEED;
-    volatile size_t nbytes; // Used in the new chunk callback
-    volatile size_t buf_size; // Used in the new chunk callback
-    volatile void *chunk;
-    volatile size_t alloc_size;
-    volatile size_t alloc_size_total;
-    volatile size_t write_size;
-    volatile hsize_t *scaled[H5S_MAX_RANK]; // Initializing to 0 doesn't have any effect
-    volatile H5D_io_type_info_t my_io_type_info; // Used in gather_mem callback
-    volatile const H5S_t *gather_mem_space;
-    volatile const H5S_t *gather_file_space;
-    volatile haddr_t *addr[H5S_MAX_RANK];
-    volatile haddr_t addr0;
-    volatile hsize_t *size[H5S_MAX_RANK];
-    volatile hsize_t size0;
-    volatile hsize_t *defined_values_size[H5S_MAX_RANK];
-    volatile size_t *size_hint[H5S_MAX_RANK]; 
-    volatile size_t *defined_values_size_hint[H5S_MAX_RANK]; 
-    volatile void *udata_arr[H5S_MAX_RANK];
-    volatile hsize_t new_disk_size[H5S_MAX_RANK];
-    haddr_t md_tag = HADDR_UNDEF;
+    H5SC_io_info_t              sc_io_info;
+    herr_t                      ret_value = SUCCEED;
+    volatile size_t             nbytes;   // Used in the new chunk callback
+    volatile size_t             buf_size; // Used in the new chunk callback
+    volatile void              *chunk;
+    volatile size_t             alloc_size;
+    volatile size_t             alloc_size_total;
+    volatile size_t             write_size;
+    volatile hsize_t           *scaled[H5S_MAX_RANK]; // Initializing to 0 doesn't have any effect
+    volatile H5D_io_type_info_t my_io_type_info;      // Used in gather_mem callback
+    volatile const H5S_t       *gather_mem_space;
+    volatile const H5S_t       *gather_file_space;
+    volatile haddr_t           *addr[H5S_MAX_RANK];
+    volatile haddr_t            addr0;
+    volatile hsize_t           *size[H5S_MAX_RANK];
+    volatile hsize_t            size0;
+    volatile hsize_t           *defined_values_size[H5S_MAX_RANK];
+    volatile size_t            *size_hint[H5S_MAX_RANK];
+    volatile size_t            *defined_values_size_hint[H5S_MAX_RANK];
+    volatile void              *udata_arr[H5S_MAX_RANK];
+    volatile hsize_t            new_disk_size[H5S_MAX_RANK];
+    haddr_t                     md_tag = HADDR_UNDEF;
 
     FUNC_ENTER_NOAPI(FAIL)
 
     assert(cache);
     assert(count == 0 || dset_info);
 
-    /* 
+    /*
      * *** V0: Pass the I/O request (for a single chunk) "through" the cache ***
      * Since the cache isn't implemented yet, we'll simulate this using the following
      * process:
      * For each chunk in `sc_io_info`:
-     * 
+     *
      * 1. Cache emulation for Raw Data Write
      *  - Look up the chunk (expected failure to find; no cache to search)
      *  - The chunk is not yet written to file (assumed for version 0 prototype),
      *    so it should be fully overwritten
      *  - Call `H5SC_new_chunk_t` to create a new chunk (fill = true)
      *  - Call H5SC_chunk_gather_mem_t
-     *  
+     *
      * 2. Immediately evict the chunk from the "cache"
      *  - The chunk will be dirty (new chunk not in file)
-     *  - The chunk is not encoded; encode (diagram says in-place, 
+     *  - The chunk is not encoded; encode (diagram says in-place,
      *    need to look at encode as well)
      *  - Call H5SC_chunk_insert_t to insert the chunk into the file indexing
      *  - Call H5F_block_write (in H5Fio.c) to write the chunk (single buffer) to the file
@@ -961,16 +973,17 @@ H5SC_write(H5SC_t *cache, size_t count, H5D_dset_io_info_t *dset_info)
 
     // Loop through the datasets
     for (int i = 0; i < count; i++) {
-        /* 
+        /*
          * To avoid issues with metadata tagging while doing multi-dataset I/O,
          * we need to handle tagging within the SCC
          */
-        H5AC_tag(dset_info[i].dset->oloc.addr, &md_tag); // Set the metadata tag (Does this need to be for the ith dataset?)
+        H5AC_tag(dset_info[i].dset->oloc.addr,
+                 &md_tag); // Set the metadata tag (Does this need to be for the ith dataset?)
 
         // Throw an error if no chunks were selected
         if (sc_io_info.num_sel_chunks == 0) //{
-            HDONE_ERROR(H5E_DATASET, H5E_CANTGETSIZE, FAIL, 
-                "The number of structured chunks should be non-zero");
+            HDONE_ERROR(H5E_DATASET, H5E_CANTGETSIZE, FAIL,
+                        "The number of structured chunks should be non-zero");
 
         size_t chunk_count = sc_io_info.num_sel_chunks;
 
@@ -981,65 +994,74 @@ H5SC_write(H5SC_t *cache, size_t count, H5D_dset_io_info_t *dset_info)
         assert(dset_info[i].dset->shared->layout.sc_ops->lookup);
 
         scaled[0] = sc_io_info.sel_chunks[0].scaled;
-        addr[0] = &addr0; // Should this be buf from the sel_chunks struct?
-        size[0] = &size0;
+        addr[0]   = &addr0; // Should this be buf from the sel_chunks struct?
+        size[0]   = &size0;
 
         if (dset_info[i].dset->shared->layout.sc_ops->lookup(
-                                                            dset_info[i].dset,       /*INPUT: Pointer to the dataset in memory*/
-                                                            chunk_count,             /*INPUT: The number of chunks in the dataset being processed*/
-                                                            scaled,                  /*INPUT: Scaled coordinate(s) for the chunk*/
-                                                            addr,                    /*OUTPUT: Address of the chunk (on disk)*/
-                                                            size,                    /*OUTPUT: Chunk size (on disk)*/
-                                                            defined_values_size,      /*OUTPUT: The number of bytes to read (if the list of defined values is needed)*/
-                                                            size_hint,               /*OUTPUT: The suggested allocation size for the chunk (pre-encode)*/
-                                                            defined_values_size_hint, /*OUTPUT: Suggested allocation size (if on the list of defined values is needed)*/
-                                                            &udata_arr               /*OUTPUT: Buffer to be passed through to H5__struct_chunk_encode(_in_place())*/
-                                                            ) < 0)
+                dset_info[i].dset,   /*INPUT: Pointer to the dataset in memory*/
+                chunk_count,         /*INPUT: The number of chunks in the dataset being processed*/
+                scaled,              /*INPUT: Scaled coordinate(s) for the chunk*/
+                addr,                /*OUTPUT: Address of the chunk (on disk)*/
+                size,                /*OUTPUT: Chunk size (on disk)*/
+                defined_values_size, /*OUTPUT: The number of bytes to read (if the list of defined values is
+                                        needed)*/
+                size_hint,           /*OUTPUT: The suggested allocation size for the chunk (pre-encode)*/
+                defined_values_size_hint, /*OUTPUT: Suggested allocation size (if on the list of defined
+                                             values is needed)*/
+                &udata_arr /*OUTPUT: Buffer to be passed through to H5__struct_chunk_encode(_in_place())*/
+                ) < 0)
             HGOTO_ERROR(H5E_DATASET, H5E_CANTGET, FAIL, "unable to lookup chunk (SCC)");
 
         /*Create a new (empty) chunk (not inserted into the disk chunk index)*/
         assert(dset_info[i].dset->shared->layout.sc_ops->new_chunk);
 
         if (dset_info[i].dset->shared->layout.sc_ops->new_chunk(
-                                                                dset_info[i].dset, /*INPUT: Pointer to the dataset in memory NOTE: 5/7 This isn the wrong dataset info struct...*/ 
-                                                                false,             /*INPUT: Bool to set whether to write the fill value to the chunk (unless this is a sparse chunk)*/
-                                                                &nbytes,           /*OUTPUT: Number of bytes used (initialized to zero if chunk isn't found, yeah?)*/
-                                                                &buf_size,         /*OUTPUT: Size of the chunk buffer*/
-                                                                &chunk,            /*OUTPUT: Pointer to the chunk intermediate struct*/
-                                                                &udata_arr[0]      /*OUTPUT: Udata initialization*/
-                                                                ) < 0)
+                dset_info[i].dset, /*INPUT: Pointer to the dataset in memory NOTE: 5/7 This isn the wrong
+                                      dataset info struct...*/
+                false,     /*INPUT: Bool to set whether to write the fill value to the chunk (unless this is a
+                              sparse chunk)*/
+                &nbytes,   /*OUTPUT: Number of bytes used (initialized to zero if chunk isn't found, yeah?)*/
+                &buf_size, /*OUTPUT: Size of the chunk buffer*/
+                &chunk,    /*OUTPUT: Pointer to the chunk intermediate struct*/
+                &udata_arr[0] /*OUTPUT: Udata initialization*/
+                ) < 0)
             HGOTO_ERROR(H5E_DATASET, H5E_CANTGET, FAIL, "unable to create new chunk (SCC)");
 
-        /* 
+        /*
          * Set the io_type_info struct parameters.
          * NOTE: Since vlen_buf_info isn't required for the v0, we simply avoind
          * initialize it (passing NULL causes an error and should be avoided)
          */
-        size_t src_type_size = 0; /*Manually taken from `*dset_info->type_info`, looking at the contents of the `layout_io_info` section*/
-        size_t dst_type_size = 0; /*Manually taken from `*dset_info->type_info`, looking at the contents of the `layout_io_info` section*/
-        my_io_type_info.tconv_buf = NULL; /*Datatype conv buffer (pointer)*/
-        my_io_type_info.tconv_buf_size = src_type_size; /*Size of type conversion buffer*/
-        my_io_type_info.bkg_buf = NULL; /*Pointer to background buffer*/
-        my_io_type_info.bkg_buf_size = dst_type_size; /*Size of the background buffer*/
-        my_io_type_info.may_use_in_place_tconv = true; /*Use in-place if possible*/
+        size_t src_type_size = 0; /*Manually taken from `*dset_info->type_info`, looking at the contents of
+                                     the `layout_io_info` section*/
+        size_t dst_type_size = 0; /*Manually taken from `*dset_info->type_info`, looking at the contents of
+                                     the `layout_io_info` section*/
+        my_io_type_info.tconv_buf              = NULL;          /*Datatype conv buffer (pointer)*/
+        my_io_type_info.tconv_buf_size         = src_type_size; /*Size of type conversion buffer*/
+        my_io_type_info.bkg_buf                = NULL;          /*Pointer to background buffer*/
+        my_io_type_info.bkg_buf_size           = dst_type_size; /*Size of the background buffer*/
+        my_io_type_info.may_use_in_place_tconv = true;          /*Use in-place if possible*/
 
         /*The gather_mem callback is used to collect data from the memory buffer into the chunk buffer*/
         assert(dset_info[i].dset->shared->layout.sc_ops->gather_mem);
-        
-        gather_mem_space = sc_io_info.sel_chunks[0].mem_space; /*Pointer to the memory space ID, derived from sc_io_info*/
-        gather_file_space = sc_io_info.sel_chunks[0].file_space; /*Pointer to the file space ID, derived from sc_io_info*/
+
+        gather_mem_space =
+            sc_io_info.sel_chunks[0].mem_space; /*Pointer to the memory space ID, derived from sc_io_info*/
+        gather_file_space =
+            sc_io_info.sel_chunks[0].file_space; /*Pointer to the file space ID, derived from sc_io_info*/
 
         if (dset_info[i].dset->shared->layout.sc_ops->gather_mem(
-                                                        &dset_info[i],     /*INPUT: Pointer to the dataset in memory*/
-                                                        &my_io_type_info,  /*INPUT: Localized version of the H5D_io_type_info_t; derived from information available in the sc_io_info struct*/
-                                                        gather_mem_space,  /*INPUT: Pointer to the appropriate memory space ID*/
-                                                        gather_file_space,  /*INPUT: Pointer to the appropriate file space ID*/
-                                                        &nbytes,           /*INPUT/OUTPUT Size of the chunk; will be reallocated in this callback and returned*/
-                                                        &alloc_size,       /*INPUT/OUTPUT: Allocated size of the chunk buffer (?)*/
-                                                        &alloc_size_total, /*INPUT/OUTPUT: Size of nbytes + alloc_size*/
-                                                        chunk,             /*INPUT/OUTPUT: Intermediate chunk structure*/
-                                                        udata_arr[0]       /*UNUSED*/
-                                                        ) < 0)
+                &dset_info[i],     /*INPUT: Pointer to the dataset in memory*/
+                &my_io_type_info,  /*INPUT: Localized version of the H5D_io_type_info_t; derived from
+                                      information available in the sc_io_info struct*/
+                gather_mem_space,  /*INPUT: Pointer to the appropriate memory space ID*/
+                gather_file_space, /*INPUT: Pointer to the appropriate file space ID*/
+                &nbytes, /*INPUT/OUTPUT Size of the chunk; will be reallocated in this callback and returned*/
+                &alloc_size,       /*INPUT/OUTPUT: Allocated size of the chunk buffer (?)*/
+                &alloc_size_total, /*INPUT/OUTPUT: Size of nbytes + alloc_size*/
+                chunk,             /*INPUT/OUTPUT: Intermediate chunk structure*/
+                udata_arr[0]       /*UNUSED*/
+                ) < 0)
             HGOTO_ERROR(H5E_DATASET, H5E_CANTGET, FAIL, "unable to gather mem for new chunk (SCC)");
 
         /*
@@ -1048,12 +1070,14 @@ H5SC_write(H5SC_t *cache, size_t count, H5D_dset_io_info_t *dset_info)
          */
         assert(dset_info[i].dset->shared->layout.sc_ops->encode_in_place);
         if (dset_info[i].dset->shared->layout.sc_ops->encode_in_place(
-                                                                dset_info[i].dset, /*INPUT: Pointer to the dataset in memory*/
-                                                                &write_size,       /*OUTPUT: Sum of the size of the selected bytes and the data bytes*/
-                                                                false,             /*UNUSED; indicate used to specify if a chunk has a partial boundary (unsupported in v0)*/
-                                                                &chunk,            /*INPUT/OUTPUT On entry, points to the chunk intermediate struct; on exit, points to the on disk file format chunk buffer*/
-                                                                udata_arr[0]       /*INPUT/OUTPUT Udata, which has been utilized by previous callbacks*/
-                                                                ) < 0) { 
+                dset_info[i].dset, /*INPUT: Pointer to the dataset in memory*/
+                &write_size,       /*OUTPUT: Sum of the size of the selected bytes and the data bytes*/
+                false,  /*UNUSED; indicate used to specify if a chunk has a partial boundary (unsupported in
+                           v0)*/
+                &chunk, /*INPUT/OUTPUT On entry, points to the chunk intermediate struct; on exit, points to
+                           the on disk file format chunk buffer*/
+                udata_arr[0] /*INPUT/OUTPUT Udata, which has been utilized by previous callbacks*/
+                ) < 0) {
             HGOTO_ERROR(H5E_DATASET, H5E_CANTGET, FAIL, "unable to encode chunk in place (SCC)");
         }
 
@@ -1062,31 +1086,33 @@ H5SC_write(H5SC_t *cache, size_t count, H5D_dset_io_info_t *dset_info)
 
         /*Insert the chunk into the chunk index within the file*/
         assert(dset_info[i].dset->shared->layout.sc_ops->insert);
-        
+
         if (dset_info[i].dset->shared->layout.sc_ops->insert(
-                                                dset_info[i].dset, /*INPUT: Pointer to the dataset in memory*/
-                                                chunk_count,       /*INPUT: Number of chunks in the I/O request*/
-                                                &scaled,           /*INPUT: Scaled coordinate for the chunk; derived from `sc_io_info`*/
-                                                addr,              /*INPUT/OUTPUT: Array of addrs*/
-                                                NULL,              /*INPUT: Old disk size array; likely derived from the insert callback (if chunk is on disk)*/
-                                                new_disk_size,     /*INPUT: Write size, computed from the encode callback*/
-                                                chunk,             /*UNUSED: Intermediate chunk structure (on-disk formatted); full array*/
-                                                udata_arr          /*INPUT: Array of udata (which are modified by previous callbacks)*/
-                                                ) < 0)
+                dset_info[i].dset, /*INPUT: Pointer to the dataset in memory*/
+                chunk_count,       /*INPUT: Number of chunks in the I/O request*/
+                &scaled,           /*INPUT: Scaled coordinate for the chunk; derived from `sc_io_info`*/
+                addr,              /*INPUT/OUTPUT: Array of addrs*/
+                NULL, /*INPUT: Old disk size array; likely derived from the insert callback (if chunk is on
+                         disk)*/
+                new_disk_size, /*INPUT: Write size, computed from the encode callback*/
+                chunk,         /*UNUSED: Intermediate chunk structure (on-disk formatted); full array*/
+                udata_arr      /*INPUT: Array of udata (which are modified by previous callbacks)*/
+                ) < 0)
             HGOTO_ERROR(H5E_DATASET, H5E_CANTINSERT, FAIL, "unable to insert chunk into file (SCC)");
 
         /*Write the chunk to file using H5F_block_write*/
-        if (H5F_block_write(
-                        dset_info[i].dset->oloc.file, /*INPUT: Current file ID*/
-                        H5FD_MEM_DRAW,               /*INPUT: Based on the definitions in H5F_mem_t, this option seemed the most appropriate*/
-                        *addr[0],                    /*INPUT: This is the address in the file where data will be written; set by the insert callback*/
-                        write_size,                  /*INPUT: Encoded write size from the `encode_in_place` callback*/
-                        chunk                        /*INPUT: Should be the data buffer (encode last modified the chunk buffer)*/
-                        ) < 0) {
+        if (H5F_block_write(dset_info[i].dset->oloc.file, /*INPUT: Current file ID*/
+                            H5FD_MEM_DRAW, /*INPUT: Based on the definitions in H5F_mem_t, this option seemed
+                                              the most appropriate*/
+                            *addr[0], /*INPUT: This is the address in the file where data will be written; set
+                                         by the insert callback*/
+                            write_size, /*INPUT: Encoded write size from the `encode_in_place` callback*/
+                            chunk /*INPUT: Should be the data buffer (encode last modified the chunk buffer)*/
+                            ) < 0) {
             HGOTO_ERROR(H5E_DATASET, H5E_WRITEERROR, FAIL, "unable to block write to file(SCC)");
         }
         H5AC_tag(md_tag, NULL); /*Reset the metadata tag for the next dataset*/
-    }/*Dataset Loop*/
+    }                           /*Dataset Loop*/
 done:
     /* Terminate sc_io_info */
     if (H5SC__io_info_term(&sc_io_info) < 0)


### PR DESCRIPTION
Changes to internal library routines to support a minimal, pass-through-based version zero of the Shared Chunk Cache. This includes support for writing and reading structured chunk data through attaching the high-level API layers to the relevant callback functions.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Prototype version zero of Shared Chunk Cache (SCC) with basic read/write operations and chunk management in HDF5.
> 
>   - **Behavior**:
>     - Introduces prototype for version zero of Shared Chunk Cache (SCC) with basic pass-through functionality.
>     - Implements `H5SC_read` and `H5SC_write` in `H5SC.c` for reading and writing chunk data through SCC.
>     - Adds chunk handling functions in `H5Dstruct_chunk.c` for encoding, decoding, and managing chunk data.
>   - **Functions**:
>     - Adds `H5SC_create`, `H5SC_destroy`, `H5SC_flush`, and `H5SC_flush_dset` in `H5SC.c` for managing SCC lifecycle.
>     - Implements `H5SC__io_info_init` and `H5SC__io_info_term` in `H5SC.c` for initializing and terminating I/O operations.
>     - Adds `H5D__struct_chunk_lookup`, `H5D__struct_chunk_decode`, `H5D__struct_chunk_encode`, and other chunk operations in `H5Dstruct_chunk.c`.
>   - **Misc**:
>     - Updates `H5Dio.c` to integrate SCC operations with existing dataset I/O processes.
>     - Modifies `H5Dfarray.c` to support structured chunk context updates.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=HDFGroup%2Fhdf5&utm_source=github&utm_medium=referral)<sup> for 7c5e9be14a9a8e55f5e2affc6d31ffaa0db79af2. You can [customize](https://app.ellipsis.dev/HDFGroup/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->