### PR TITLE
Modifications for adding structured chunk filter support.

### DIFF
--- a/doxygen/examples/H5P_struct_chunk_examples.c
+++ b/doxygen/examples/H5P_struct_chunk_examples.c
@@ -46,8 +46,7 @@ main(void)
         }
 
         // Adds a filter to section 0
-        if (H5Pset_filter2(dcpl, H5_SECTION_SELECTION, H5Z_FILTER_SHUFFLE, H5Z_FLAG_MANDATORY, 0, NULL) <
-            0) {
+        if (H5Pset_filter2(dcpl, H5_SECTION_SELECTION, H5Z_FILTER_SHUFFLE, H5Z_FLAG_MANDATORY, 0, NULL) < 0) {
             ret_val = EXIT_FAILURE;
             goto fail_set_filter2;
         }
@@ -117,14 +116,14 @@ fail_file:;
             goto fail_pget_filter3;
         }
 
-        if (H5Pmodify_filter2(dcpl, H5_SECTION_SELECTION, H5Z_FILTER_SHUFFLE, H5Z_FLAG_OPTIONAL, 0,
-                              NULL) < 0) {
+        if (H5Pmodify_filter2(dcpl, H5_SECTION_SELECTION, H5Z_FILTER_SHUFFLE, H5Z_FLAG_OPTIONAL, 0, NULL) <
+            0) {
             ret_val = EXIT_FAILURE;
             goto fail_pmod_filter2;
         }
 
-        if (H5Pget_filter_by_id3(dcpl, H5_SECTION_SELECTION, H5Z_FILTER_SHUFFLE, &flags, NULL, NULL, 0,
-                                 NULL, NULL) < 0) {
+        if (H5Pget_filter_by_id3(dcpl, H5_SECTION_SELECTION, H5Z_FILTER_SHUFFLE, &flags, NULL, NULL, 0, NULL,
+                                 NULL) < 0) {
 
             ret_val = EXIT_FAILURE;
             goto fail_pget_filter_id3;

--- a/doxygen/examples/H5P_struct_chunk_examples.c
+++ b/doxygen/examples/H5P_struct_chunk_examples.c
@@ -46,7 +46,7 @@ main(void)
         }
 
         // Adds a filter to section 0
-        if (H5Pset_filter2(dcpl, H5Z_FLAG_SPARSE_SELECTION, H5Z_FILTER_DEFLATE, H5Z_FLAG_MANDATORY, 0, NULL) <
+        if (H5Pset_filter2(dcpl, H5_SECTION_SELECTION, H5Z_FILTER_SHUFFLE, H5Z_FLAG_MANDATORY, 0, NULL) <
             0) {
             ret_val = EXIT_FAILURE;
             goto fail_set_filter2;
@@ -60,7 +60,11 @@ main(void)
         }
 
         // Verify the number of filters is correct
-        if ((nfilters = H5Pget_nfilters2(dcpl, H5Z_FLAG_SPARSE_SELECTION)) != 1)
+        if (H5Pget_nfilters2(dcpl, H5_SECTION_SELECTION, &num_filters) < 0) {
+            ret_val = EXIT_FAILURE;
+            goto fail_get_nfilters2;
+        }
+        if (num_filters != 1)
             ret_val = EXIT_FAILURE;
 
         H5Dclose(did);
@@ -69,6 +73,7 @@ fail_dcreate:
 fail_set_layout:
 fail_set_chunk:
 fail_set_filter2:
+fail_get_nfilters2:
         H5Pclose(dcpl);
 
 fail_dcpl:
@@ -106,19 +111,19 @@ fail_file:;
             goto fail_dget_plist;
         }
 
-        filtn = H5Pget_filter3(dcpl, H5Z_FLAG_SPARSE_SELECTION, 0, &flags, NULL, NULL, (size_t)0, NULL, NULL);
-        if (filtn != H5Z_FILTER_DEFLATE && flags != H5Z_FLAG_MANDATORY) {
+        filtn = H5Pget_filter3(dcpl, H5_SECTION_SELECTION, 0, &flags, NULL, NULL, (size_t)0, NULL, NULL);
+        if (filtn != H5Z_FILTER_SHUFFLE && flags != H5Z_FLAG_MANDATORY) {
             ret_val = EXIT_FAILURE;
             goto fail_pget_filter3;
         }
 
-        if (H5Pmodify_filter2(dcpl, H5Z_FLAG_SPARSE_SELECTION, H5Z_FILTER_DEFLATE, H5Z_FLAG_OPTIONAL, 0,
+        if (H5Pmodify_filter2(dcpl, H5_SECTION_SELECTION, H5Z_FILTER_SHUFFLE, H5Z_FLAG_OPTIONAL, 0,
                               NULL) < 0) {
             ret_val = EXIT_FAILURE;
             goto fail_pmod_filter2;
         }
 
-        if (H5Pget_filter_by_id3(dcpl, H5Z_FLAG_SPARSE_SELECTION, H5Z_FILTER_DEFLATE, &flags, NULL, NULL, 0,
+        if (H5Pget_filter_by_id3(dcpl, H5_SECTION_SELECTION, H5Z_FILTER_SHUFFLE, &flags, NULL, NULL, 0,
                                  NULL, NULL) < 0) {
 
             ret_val = EXIT_FAILURE;
@@ -130,12 +135,12 @@ fail_file:;
             goto fail_pget_filter_id3;
         }
 
-        if (H5Premove_filter2(dcpl, H5Z_FLAG_SPARSE_SELECTION, H5Z_FILTER_DEFLATE) < 0) {
+        if (H5Premove_filter2(dcpl, H5_SECTION_SELECTION, H5Z_FILTER_SHUFFLE) < 0) {
             ret_val = EXIT_FAILURE;
             goto fail_remove_filter2;
         }
 
-        filtn = H5Pget_filter3(dcpl, H5Z_FLAG_SPARSE_SELECTION, 0, NULL, NULL, NULL, (size_t)0, NULL, NULL);
+        filtn = H5Pget_filter3(dcpl, H5_SECTION_SELECTION, 0, NULL, NULL, NULL, (size_t)0, NULL, NULL);
         if (filtn != H5Z_FILTER_NONE)
             ret_val = EXIT_FAILURE;
 

--- a/src/H5Dfarray.c
+++ b/src/H5Dfarray.c
@@ -80,9 +80,9 @@ typedef struct H5D_farray_ctx_ud_t {
 /* For structured chunk */
 typedef struct H5D_farray_stc_ctx_ud_t {
     const H5F_t *f;           /* Pointer to file info */
-    uint64_t     chunk_size;  /* Size of chunk (bytes)*/
+    uint64_t     chunk_size; /* Size of chunk (bytes) */
     unsigned     nsects;      /* # of sections */
-    unsigned     offset_size; /* ?? Offset size to encode/decode chunk size */
+    unsigned     offset_size; /* TBD: Offset size to encode/decode chunk size */
 } H5D_farray_stc_ctx_ud_t;
 
 /* Fixed array callback context */
@@ -93,10 +93,10 @@ typedef struct H5D_farray_ctx_t {
 
 /* For structured chunk */
 typedef struct H5D_farray_stc_ctx_t {
-    size_t   file_addr_len;  /* Size of addresses in the file (bytes) */
-    size_t   chunk_size_len; /* Size of chunk sizes in the file (bytes) */
-    unsigned nsects;         /* # of sections */
-    unsigned offset_size;    /* ??? Offset size to encode/decode chunk size */
+    size_t   file_addr_len; /* Size of addresses in the file (bytes) */
+    size_t   chunk_size_len;  /* Size of chunk sizes in the file (bytes) */
+    unsigned nsects;        /* # of sections */
+    unsigned offset_size;   /* TBD: Offset size to encode/decode chunk size */
 } H5D_farray_stc_ctx_t;
 
 /* Fixed Array callback info for iteration over chunks */
@@ -1960,7 +1960,7 @@ H5D__farray_stc_idx_create(const H5D_chk_idx_info_t *idx_info)
         chunk_size_len = H5O_STRUCT_CHUNK_OFFSET_SIZE;
 
     /* General parameters */
-    if (idx_info->pline->nused > 0) {
+    if (idx_info->pline->tot_filt_nsects > 0) {
 
         cparam.cls = H5FA_CLS_FILT_STRUCT_CHUNK;
 
@@ -2187,11 +2187,11 @@ H5D__farray_stc_idx_insert(const H5D_chk_idx_info_t *idx_info, H5D_chunk_ud_t *u
         HGOTO_ERROR(H5E_ARGS, H5E_BADRANGE, FAIL, "chunk index must be less than 2^32");
 
     /* Check for filters on chunks */
-    if (idx_info->pline->nused > 0) {
+    if (idx_info->pline->tot_filt_nsects > 0) {
         H5D_farray_stc_filt_elmt_t elmt; /* Fixed array element */
 
         elmt.addr = udata->chunk_block.offset;
-        H5_CHECKED_ASSIGN(elmt.nbytes, uint32_t, udata->chunk_block.length, hsize_t);
+        H5_CHECKED_ASSIGN(elmt.nbytes, uint64_t, udata->chunk_block.length, hsize_t);
 
         for (unsigned u = 0; u < idx_info->stc_storage->nsects; u++) {
             elmt.offset[u] = udata->offset[u]; /* Filler: offset[0] will not be encoded in stc_encode() */
@@ -2207,7 +2207,7 @@ H5D__farray_stc_idx_insert(const H5D_chk_idx_info_t *idx_info, H5D_chunk_ud_t *u
         H5D_farray_stc_elmt_t elmt; /* Fixed array element */
 
         elmt.addr = udata->chunk_block.offset;
-        H5_CHECKED_ASSIGN(elmt.nbytes, uint32_t, udata->chunk_block.length, hsize_t);
+        H5_CHECKED_ASSIGN(elmt.nbytes, uint64_t, udata->chunk_block.length, hsize_t);
 
         for (unsigned u = 0; u < idx_info->stc_storage->nsects; u++)
             elmt.offset[u] = udata->offset[u]; /* offset[0] will not be encoded in stc_encode() */
@@ -2269,7 +2269,7 @@ H5D__farray_stc_idx_get_addr(const H5D_chk_idx_info_t *idx_info, H5D_chunk_ud_t 
     udata->chunk_idx = idx;
 
     /* Check for filters on chunks */
-    if (idx_info->pline->nused > 0) {
+    if (idx_info->pline->tot_filt_nsects > 0) {
         H5D_farray_stc_filt_elmt_t elmt; /* Fixed array element */
 
         /* Get the information for the chunk */
@@ -2486,7 +2486,7 @@ H5D__farray_stc_idx_iterate(const H5D_chk_idx_info_t *idx_info, H5D_chunk_cb_fun
         udata.common.stc_layout  = idx_info->stc_layout;
         udata.common.stc_storage = idx_info->stc_storage;
         memset(&udata.chunk_rec, 0, sizeof(udata.chunk_rec));
-        udata.filtered   = (idx_info->pline->nused > 0);
+        udata.filtered   = (idx_info->pline->tot_filt_nsects > 0);
         udata.stc_nsects = idx_info->stc_storage->nsects;
         udata.cb         = chunk_cb;
         udata.udata      = chunk_udata;
@@ -2545,7 +2545,7 @@ H5D__farray_stc_idx_remove(const H5D_chk_idx_info_t *idx_info, H5D_chunk_common_
                                 udata->scaled);
 
     /* Check for filters on chunks */
-    if (idx_info->pline->nused > 0) {
+    if (idx_info->pline->tot_filt_nsects > 0) {
         H5D_farray_stc_filt_elmt_t elmt; /* Fixed array element */
 
         /* Get the info about the chunk for the index */
@@ -2946,7 +2946,6 @@ H5D__farray_stc_crt_context(void *_udata)
     /* Sanity checks */
     assert(udata);
     assert(udata->f);
-    assert(udata->offset_size > 0);
 
     /* Allocate new context structure */
     if (NULL == (ctx = H5FL_MALLOC(H5D_farray_stc_ctx_t)))
@@ -2956,12 +2955,13 @@ H5D__farray_stc_crt_context(void *_udata)
     ctx->file_addr_len = H5F_SIZEOF_ADDR(udata->f);
 
     ctx->chunk_size_len = 1 + ((H5VM_log2_gen((uint64_t)udata->chunk_size) + H5O_STRUCT_CHUNK_OFFSET_SIZE) /
-                               H5O_STRUCT_CHUNK_OFFSET_SIZE);
+                          H5O_STRUCT_CHUNK_OFFSET_SIZE);
     if (ctx->chunk_size_len > H5O_STRUCT_CHUNK_OFFSET_SIZE)
         ctx->chunk_size_len = H5O_STRUCT_CHUNK_OFFSET_SIZE;
 
-    ctx->nsects      = udata->nsects;
-    ctx->offset_size = udata->offset_size;
+ 
+    ctx->nsects        = udata->nsects;
+    ctx->offset_size   = udata->offset_size;
 
     /* Set return value */
     ret_value = ctx;
@@ -3243,7 +3243,7 @@ H5D__farray_stc_filt_decode(const void *_raw, void *_elmt, size_t nelmts, void *
         H5F_addr_decode_len(ctx->file_addr_len, &raw, &elmt->addr);
 
         /* Chunk size */
-        UINT64DECODE_VAR(raw, elmt->nbytes, ctx->offset_size);
+        UINT64DECODE_VAR(raw, elmt->nbytes, ctx->chunk_size_len);
 
         /* Offset for (n-1) sections: no need to decode offset for section 0 */
         for (unsigned u = 1; u < ctx->nsects; u++)

--- a/src/H5Dfarray.c
+++ b/src/H5Dfarray.c
@@ -80,7 +80,7 @@ typedef struct H5D_farray_ctx_ud_t {
 /* For structured chunk */
 typedef struct H5D_farray_stc_ctx_ud_t {
     const H5F_t *f;           /* Pointer to file info */
-    uint64_t     chunk_size; /* Size of chunk (bytes) */
+    uint64_t     chunk_size;  /* Size of chunk (bytes) */
     unsigned     nsects;      /* # of sections */
     unsigned     offset_size; /* TBD: Offset size to encode/decode chunk size */
 } H5D_farray_stc_ctx_ud_t;
@@ -93,10 +93,10 @@ typedef struct H5D_farray_ctx_t {
 
 /* For structured chunk */
 typedef struct H5D_farray_stc_ctx_t {
-    size_t   file_addr_len; /* Size of addresses in the file (bytes) */
-    size_t   chunk_size_len;  /* Size of chunk sizes in the file (bytes) */
-    unsigned nsects;        /* # of sections */
-    unsigned offset_size;   /* TBD: Offset size to encode/decode chunk size */
+    size_t   file_addr_len;  /* Size of addresses in the file (bytes) */
+    size_t   chunk_size_len; /* Size of chunk sizes in the file (bytes) */
+    unsigned nsects;         /* # of sections */
+    unsigned offset_size;    /* TBD: Offset size to encode/decode chunk size */
 } H5D_farray_stc_ctx_t;
 
 /* Fixed Array callback info for iteration over chunks */
@@ -2955,13 +2955,12 @@ H5D__farray_stc_crt_context(void *_udata)
     ctx->file_addr_len = H5F_SIZEOF_ADDR(udata->f);
 
     ctx->chunk_size_len = 1 + ((H5VM_log2_gen((uint64_t)udata->chunk_size) + H5O_STRUCT_CHUNK_OFFSET_SIZE) /
-                          H5O_STRUCT_CHUNK_OFFSET_SIZE);
+                               H5O_STRUCT_CHUNK_OFFSET_SIZE);
     if (ctx->chunk_size_len > H5O_STRUCT_CHUNK_OFFSET_SIZE)
         ctx->chunk_size_len = H5O_STRUCT_CHUNK_OFFSET_SIZE;
 
- 
-    ctx->nsects        = udata->nsects;
-    ctx->offset_size   = udata->offset_size;
+    ctx->nsects      = udata->nsects;
+    ctx->offset_size = udata->offset_size;
 
     /* Set return value */
     ret_value = ctx;

--- a/src/H5Dint.c
+++ b/src/H5Dint.c
@@ -799,9 +799,9 @@ H5D__calculate_minimum_header_size(H5F_t *file, H5D_t *dset, H5O_t *ohdr)
     }
 
     /* Filter/Pipeline message size */
-    if (H5D_CHUNKED == dset->shared->layout.type) {
+    if (H5D_CHUNKED == dset->shared->layout.type || H5D_STRUCT_CHUNK == dset->shared->layout.type) {
         H5O_pline_t *pline = &dset->shared->dcpl_cache.pline;
-        if (pline->nused > 0) {
+        if (pline->nused > 0 || pline->tot_filt_nsects > 0) {
             get_value = H5O_msg_size_oh(file, ohdr, H5O_PLINE_ID, pline, 0);
             if (get_value == 0)
                 HGOTO_ERROR(H5E_DATASET, H5E_CANTGET, 0, "can't get size of filter message");
@@ -1298,6 +1298,8 @@ H5D__create(H5F_t *file, hid_t type_id, const H5S_t *space, hid_t dcpl_id, hid_t
             /* Check that chunked layout is used if filters are enabled */
             if (pline->nused > 0 && H5D_CHUNKED != layout->type)
                 HGOTO_ERROR(H5E_DATASET, H5E_BADVALUE, NULL, "filters can only be used with chunked layout");
+            if (pline->tot_filt_nsects > 0 && H5D_STRUCT_CHUNK != layout->type)
+                HGOTO_ERROR(H5E_DATASET, H5E_BADVALUE, NULL, "filters can only be used with structured chunked layout");
         }
 
         /* Check if the alloc_time is the default and error out */
@@ -1309,9 +1311,22 @@ H5D__create(H5F_t *file, hid_t type_id, const H5S_t *space, hid_t dcpl_id, hid_t
             HGOTO_ERROR(H5E_DATASET, H5E_BADVALUE, NULL, "compact dataset must have early space allocation");
     } /* end if */
 
-    /* Set the version for the I/O pipeline message */
-    if (H5O_pline_set_version(file, &new_dset->shared->dcpl_cache.pline) < 0)
-        HGOTO_ERROR(H5E_DATASET, H5E_CANTSET, NULL, "can't set latest version of I/O filter pipeline");
+    if (new_dset->shared->layout.type == H5D_STRUCT_CHUNK) {
+
+        /* Version 3 of pipeline message is introduced to support structured chunk layout */
+        /* but as of now this version does not support other layout types yet. */
+        /* Make sure that the file's high bound is latest to allow version 3 for structured chunk */
+        /* because H5Pset_filter2() will set pipeline message to version 3 */
+        if (H5F_HIGH_BOUND(file) != H5F_LIBVER_LATEST)
+            HGOTO_ERROR(H5E_DATASET, H5E_CANTSET, NULL, "need to use latest format for version 3 of filter pipeline message");
+
+    } else {
+
+        /* H5O_PLINE_VERSION_LATEST is still version 2 because version 3 of pipeline message */
+        /* does not support other layout types yet */
+        if (H5O_pline_set_version(file, &new_dset->shared->dcpl_cache.pline) < 0)
+            HGOTO_ERROR(H5E_DATASET, H5E_CANTSET, NULL, "can't set latest version of I/O filter pipeline");
+    }
 
     /* Set the version for the fill message */
     if (H5O_fill_set_version(file, &new_dset->shared->dcpl_cache.fill) < 0)
@@ -1338,7 +1353,9 @@ H5D__create(H5F_t *file, hid_t type_id, const H5S_t *space, hid_t dcpl_id, hid_t
      * so we don't need to force early space allocation. Otherwise, we force early space
      * allocation to facilitate independent raw data operations.
      */
-    if (H5F_HAS_FEATURE(file, H5FD_FEAT_HAS_MPI) && (new_dset->shared->dcpl_cache.pline.nused == 0))
+    if (H5F_HAS_FEATURE(file, H5FD_FEAT_HAS_MPI) && 
+        (new_dset->shared->dcpl_cache.pline.nused == 0) &&
+        (new_dset->shared->dcpl_cache.pline.tot_filt_nsects == 0))
         new_dset->shared->dcpl_cache.fill.alloc_time = H5D_ALLOC_TIME_EARLY;
 
     /* Set the dataset's I/O operations */
@@ -1807,6 +1824,7 @@ H5D__open_oid(H5D_t *dataset, hid_t dapl_id)
                     break;
 
                 case H5D_CHUNKED:
+                case H5D_STRUCT_CHUNK:
                     fill_prop->alloc_time = H5D_ALLOC_TIME_INCR;
                     break;
 
@@ -1829,6 +1847,7 @@ H5D__open_oid(H5D_t *dataset, hid_t dapl_id)
     if ((dataset->shared->layout.type == H5D_COMPACT && fill_prop->alloc_time == H5D_ALLOC_TIME_EARLY) ||
         (dataset->shared->layout.type == H5D_CONTIGUOUS && fill_prop->alloc_time == H5D_ALLOC_TIME_LATE) ||
         (dataset->shared->layout.type == H5D_CHUNKED && fill_prop->alloc_time == H5D_ALLOC_TIME_INCR) ||
+        (dataset->shared->layout.type == H5D_STRUCT_CHUNK && fill_prop->alloc_time == H5D_ALLOC_TIME_INCR) ||
         (dataset->shared->layout.type == H5D_VIRTUAL && fill_prop->alloc_time == H5D_ALLOC_TIME_INCR))
         alloc_time_state = 1;
 
@@ -1885,7 +1904,8 @@ H5D__open_oid(H5D_t *dataset, hid_t dapl_id)
                         !(*dataset->shared->layout.ops->is_space_alloc)(&dataset->shared->layout.storage);
     must_init_storage = must_init_storage && (H5F_HAS_FEATURE(dataset->oloc.file, H5FD_FEAT_ALLOCATE_EARLY) ||
                                               (H5F_HAS_FEATURE(dataset->oloc.file, H5FD_FEAT_HAS_MPI) &&
-                                               dataset->shared->dcpl_cache.pline.nused == 0));
+                                               dataset->shared->dcpl_cache.pline.nused == 0 &&
+                                               dataset->shared->dcpl_cache.pline.tot_filt_nsects == 0));
 
     if (must_init_storage && (H5D__alloc_storage(dataset, H5D_ALLOC_OPEN, false, NULL) < 0))
         HGOTO_ERROR(H5E_DATASET, H5E_CANTINIT, FAIL, "unable to initialize file storage");
@@ -3275,6 +3295,7 @@ H5D__set_extent(H5D_t *dset, const hsize_t *size)
 
             /* Update chunks that are no longer edge chunks as a result of
              * expansion */
+            /* TBD: check to modify here when H5Dset_extent is implemented for structured chunk */
             if (expand &&
                 (dset->shared->layout.u.chunk.flags & H5O_LAYOUT_CHUNK_DONT_FILTER_PARTIAL_BOUND_CHUNKS) &&
                 (dset->shared->dcpl_cache.pline.nused > 0))

--- a/src/H5Dint.c
+++ b/src/H5Dint.c
@@ -1299,7 +1299,8 @@ H5D__create(H5F_t *file, hid_t type_id, const H5S_t *space, hid_t dcpl_id, hid_t
             if (pline->nused > 0 && H5D_CHUNKED != layout->type)
                 HGOTO_ERROR(H5E_DATASET, H5E_BADVALUE, NULL, "filters can only be used with chunked layout");
             if (pline->tot_filt_nsects > 0 && H5D_STRUCT_CHUNK != layout->type)
-                HGOTO_ERROR(H5E_DATASET, H5E_BADVALUE, NULL, "filters can only be used with structured chunked layout");
+                HGOTO_ERROR(H5E_DATASET, H5E_BADVALUE, NULL,
+                            "filters can only be used with structured chunked layout");
         }
 
         /* Check if the alloc_time is the default and error out */
@@ -1318,9 +1319,10 @@ H5D__create(H5F_t *file, hid_t type_id, const H5S_t *space, hid_t dcpl_id, hid_t
         /* Make sure that the file's high bound is latest to allow version 3 for structured chunk */
         /* because H5Pset_filter2() will set pipeline message to version 3 */
         if (H5F_HIGH_BOUND(file) != H5F_LIBVER_LATEST)
-            HGOTO_ERROR(H5E_DATASET, H5E_CANTSET, NULL, "need to use latest format for version 3 of filter pipeline message");
-
-    } else {
+            HGOTO_ERROR(H5E_DATASET, H5E_CANTSET, NULL,
+                        "need to use latest format for version 3 of filter pipeline message");
+    }
+    else {
 
         /* H5O_PLINE_VERSION_LATEST is still version 2 because version 3 of pipeline message */
         /* does not support other layout types yet */
@@ -1353,8 +1355,7 @@ H5D__create(H5F_t *file, hid_t type_id, const H5S_t *space, hid_t dcpl_id, hid_t
      * so we don't need to force early space allocation. Otherwise, we force early space
      * allocation to facilitate independent raw data operations.
      */
-    if (H5F_HAS_FEATURE(file, H5FD_FEAT_HAS_MPI) && 
-        (new_dset->shared->dcpl_cache.pline.nused == 0) &&
+    if (H5F_HAS_FEATURE(file, H5FD_FEAT_HAS_MPI) && (new_dset->shared->dcpl_cache.pline.nused == 0) &&
         (new_dset->shared->dcpl_cache.pline.tot_filt_nsects == 0))
         new_dset->shared->dcpl_cache.fill.alloc_time = H5D_ALLOC_TIME_EARLY;
 

--- a/src/H5Dio.c
+++ b/src/H5Dio.c
@@ -290,7 +290,7 @@ H5D__read(size_t count, H5D_dset_io_info_t *dset_info)
         }
 
         /* Check for shared chunk cache support */
-        if (dset_info[i].dset->shared->layout.sc_ops)
+        if (dset_info[i].layout->sc_ops)
             /* Note that there is at least one dataset that supports shared chunk cache */
             any_scc = true;
         else {
@@ -404,7 +404,7 @@ H5D__read(size_t count, H5D_dset_io_info_t *dset_info)
         /* Loop with serial & single-dset read IO path */
         for (i = 0; i < count; i++)
             /* Only call the legacy I/O code if weŕe not using the shared chunk cache */
-            if (!dset_info[i].dset->shared->layout.sc_ops) {
+            if (!dset_info[i].layout->sc_ops) {
                 /* Check for skipped I/O */
                 if (dset_info[i].skip_io)
                     continue;
@@ -475,7 +475,7 @@ H5D__read(size_t count, H5D_dset_io_info_t *dset_info)
 done:
     /* Shut down the I/O op information */
     for (i = 0; i < io_op_init; i++)
-        if (!dset_info[i].dset->shared->layout.sc_ops && dset_info[i].layout_ops.io_term &&
+        if (!dset_info[i].layout->sc_ops && dset_info[i].layout_ops.io_term &&
             (*dset_info[i].layout_ops.io_term)(&io_info, &(dset_info[i])) < 0)
             HDONE_ERROR(H5E_DATASET, H5E_CANTCLOSEOBJ, FAIL, "unable to shut down I/O op info");
 
@@ -753,7 +753,7 @@ H5D__write(size_t count, H5D_dset_io_info_t *dset_info)
         dset_info[i].skip_io = false;
 
         /* Check for shared chunk cache support */
-        if (dset_info[i].dset->shared->layout.sc_ops)
+        if (dset_info[i].layout->sc_ops)
             /* Note that there is at least one dataset that supports shared chunk cache */
             any_scc = true;
         else {
@@ -861,7 +861,7 @@ H5D__write(size_t count, H5D_dset_io_info_t *dset_info)
             assert(!dset_info[i].skip_io);
 
             /* Only call the legacy I/O code if weŕe not using the shared chunk cache */
-            if (!dset_info[i].dset->shared->layout.sc_ops) {
+            if (!dset_info[i].layout->sc_ops) {
                 /* Set metadata tagging with dset oheader addr */
                 H5AC_tag(dset_info->dset->oloc.addr, &prev_tag);
 
@@ -931,8 +931,7 @@ done:
     /* Shut down the I/O op information */
     for (i = 0; i < io_op_init; i++) {
         assert(!dset_info[i].skip_io);
-        if (!dset_info[i].dset->shared->layout.sc_ops && dset_info[i].layout_ops.io_term &&
-            // if (!dset_info[i].layout->sc_ops && dset_info[i].layout_ops.io_term &&
+        if (!dset_info[i].layout->sc_ops && dset_info[i].layout_ops.io_term &&
             (*dset_info[i].layout_ops.io_term)(&io_info, &(dset_info[i])) < 0)
             HDONE_ERROR(H5E_DATASET, H5E_CANTCLOSEOBJ, FAIL, "unable to shut down I/O op info");
     }

--- a/src/H5Dlayout.c
+++ b/src/H5Dlayout.c
@@ -648,14 +648,25 @@ H5D__layout_oh_create(H5F_t *file, H5O_t *oh, H5D_t *dset, hid_t dapl_id)
     fill_prop = &dset->shared->dcpl_cache.fill;
 
     /* Update the filters message, if this is a chunked dataset */
-    if (layout->type == H5D_CHUNKED) {
+    if (layout->type == H5D_CHUNKED || layout->type == H5D_STRUCT_CHUNK) {
         H5O_pline_t *pline; /* Dataset's I/O pipeline information */
 
         pline = &dset->shared->dcpl_cache.pline;
-        if (pline->nused > 0 &&
+        if ((pline->nused > 0 || pline->tot_filt_nsects > 0) &&
             H5O_msg_append_oh(file, oh, H5O_PLINE_ID, H5O_MSG_FLAG_CONSTANT, 0, pline) < 0)
             HGOTO_ERROR(H5E_DATASET, H5E_CANTINIT, FAIL, "unable to update filter header message");
     } /* end if */
+
+#ifdef out
+    if (layout->type == H5D_STRUCT_CHUNK) {
+        H5O_pline_t *pline; /* Dataset's I/O pipeline information */
+
+        pline = &dset->shared->dcpl_cache.pline;
+        if (pline->tot_filt_nsects > 0 &&
+            H5O_msg_append_oh(file, oh, H5O_PLINE_ID, H5O_MSG_FLAG_CONSTANT, 0, pline) < 0)
+            HGOTO_ERROR(H5E_DATASET, H5E_CANTINIT, FAIL, "unable to update filter header message");
+    } /* end if */
+#endif
 
     /* Initialize the layout information for the new dataset */
     if (dset->shared->layout.ops->init && (dset->shared->layout.ops->init)(file, dset, dapl_id) < 0)
@@ -724,7 +735,8 @@ H5D__layout_oh_create(H5F_t *file, H5O_t *oh, H5D_t *dset, hid_t dapl_id)
      *  non-filtered and has >0 elements, since space may not be allocated -QAK) */
     /* (Note: this is relying on H5D__alloc_storage not calling H5O_msg_write during dataset creation) */
     if (fill_prop->alloc_time == H5D_ALLOC_TIME_EARLY && H5D_COMPACT != layout->type &&
-        !dset->shared->dcpl_cache.pline.nused && (0 != H5S_GET_EXTENT_NPOINTS(dset->shared->space)))
+        !dset->shared->dcpl_cache.pline.nused && !dset->shared->dcpl_cache.pline.tot_filt_nsects && 
+        (0 != H5S_GET_EXTENT_NPOINTS(dset->shared->space)))
         layout_mesg_flags = H5O_MSG_FLAG_CONSTANT;
     else
         layout_mesg_flags = 0;

--- a/src/H5Dlayout.c
+++ b/src/H5Dlayout.c
@@ -735,7 +735,7 @@ H5D__layout_oh_create(H5F_t *file, H5O_t *oh, H5D_t *dset, hid_t dapl_id)
      *  non-filtered and has >0 elements, since space may not be allocated -QAK) */
     /* (Note: this is relying on H5D__alloc_storage not calling H5O_msg_write during dataset creation) */
     if (fill_prop->alloc_time == H5D_ALLOC_TIME_EARLY && H5D_COMPACT != layout->type &&
-        !dset->shared->dcpl_cache.pline.nused && !dset->shared->dcpl_cache.pline.tot_filt_nsects && 
+        !dset->shared->dcpl_cache.pline.nused && !dset->shared->dcpl_cache.pline.tot_filt_nsects &&
         (0 != H5S_GET_EXTENT_NPOINTS(dset->shared->space)))
         layout_mesg_flags = H5O_MSG_FLAG_CONSTANT;
     else

--- a/src/H5Dpkg.h
+++ b/src/H5Dpkg.h
@@ -495,8 +495,8 @@ typedef struct H5D_chunk_ud_t {
     hsize_t     chunk_idx;                    /* Chunk index for EA, FA indexing */
                                               /* Structured chunk */
     uint64_t offset[H5O_MAX_STC_NSECTS];      /* Array of offsets for n sections */
-    uint64_t unfilt_size[H5O_MAX_STC_NSECTS]; /* Array of offsets for n sections */
-    unsigned filt_mask[H5O_MAX_STC_NSECTS];   /* Array of offsets for n sections */
+    uint64_t unfilt_size[H5O_MAX_STC_NSECTS]; /* Array of unfilt_size for n sections */
+    uint32_t filt_mask[H5O_MAX_STC_NSECTS];   /* Array of filt_mask for n sections */
 } H5D_chunk_ud_t;
 
 /* Typedef for "generic" chunk callbacks */

--- a/src/H5Dstruct_chunk.c
+++ b/src/H5Dstruct_chunk.c
@@ -1257,7 +1257,7 @@ H5D__struct_chunk_lookup(H5D_t *dset, size_t count, const hsize_t *scaled[] /*in
     H5O_layout_struct_chunk_t  *layout  = &dset->shared->layout.u.struct_chunk;
     H5D_chk_idx_info_t          idx_info; /* Chunked index info */
     H5O_pline_t                *pline;    /* I/O pipeline info */
-    hbool_t                     filtered = false;
+    hbool_t                     filtered        = false;
     size_t                      tot_unfilt_size = 0;
     size_t                      i;
     herr_t                      ret_value = SUCCEED; /* Return value */
@@ -1300,8 +1300,8 @@ H5D__struct_chunk_lookup(H5D_t *dset, size_t count, const hsize_t *scaled[] /*in
 
         if (!H5_addr_defined(*addr[i])) {
             udata = H5MM_xfree(udata);
-
-        } else {
+        }
+        else {
 
             if (addr[i])
                 *addr[i] = udata->chunk_block.offset;
@@ -1323,7 +1323,7 @@ H5D__struct_chunk_lookup(H5D_t *dset, size_t count, const hsize_t *scaled[] /*in
                 *defined_values_size_hint[i] = filtered ? udata->unfilt_size[0] : *defined_values_size[i];
 
             _udata[i] = (void *)udata;
-        } 
+        }
 
         _udata[i] = (void *)udata;
 
@@ -1371,11 +1371,11 @@ H5D__struct_chunk_decode(H5D_t *dset, size_t *nbytes /*in,out*/, size_t *alloc_s
     H5D_chunk_ud_t        *udata = (H5D_chunk_ud_t *)_udata;
     H5D_chunk_cache_mem_t *chk;   /* Chunk's intermediate struct */
     H5O_pline_t           *pline; /* I/O pipeline info */
-    hbool_t                filtered  = false;
-    uint32_t               stored_chksum;       /* Stored metadata checksum value */
-    uint32_t               computed_chksum;     /* Computed metadata checksum value */
-    void *tmp;
-    const unsigned char *sel_p;
+    hbool_t                filtered = false;
+    uint32_t               stored_chksum;   /* Stored metadata checksum value */
+    uint32_t               computed_chksum; /* Computed metadata checksum value */
+    void                  *tmp;
+    const unsigned char   *sel_p;
     herr_t                 ret_value = SUCCEED; /* Return value */
 
     FUNC_ENTER_PACKAGE
@@ -1399,7 +1399,6 @@ H5D__struct_chunk_decode(H5D_t *dset, size_t *nbytes /*in,out*/, size_t *alloc_s
     chk->data_nbytes     = *nbytes - chk->sel_nbytes;
     chk->data_alloc_size = *alloc_size - chk->sel_alloc_size;
 
-
     /* Allocate a buffer for the encoded selection */
     if (NULL == (chk->sel_buf = H5MM_malloc(chk->sel_alloc_size)))
         HGOTO_ERROR(H5E_RESOURCE, H5E_NOSPACE, FAIL, "memory allocation failed for encoded selection buffer");
@@ -1416,30 +1415,32 @@ H5D__struct_chunk_decode(H5D_t *dset, size_t *nbytes /*in,out*/, size_t *alloc_s
 
     /* Decompress the encoded selection  & data values */
     if (filtered) {
-        H5Z_EDC_t err_detect; /* Error detection info */
-        H5Z_cb_t  filter_cb;  /* I/O filter callback function */
-        unsigned i;
+        H5Z_EDC_t              err_detect; /* Error detection info */
+        H5Z_cb_t               filter_cb;  /* I/O filter callback function */
+        unsigned               i;
         H5Z_stc_filter_sect_t *filt_sect;
 
         /* Retrieve filter settings from API context */
         if (H5CX_get_err_detect(&err_detect) < 0)
             HGOTO_ERROR(H5E_DATASET, H5E_CANTGET, FAIL, "can't get error detection info");
-         if (H5CX_get_filter_cb(&filter_cb) < 0)
+        if (H5CX_get_filter_cb(&filter_cb) < 0)
             HGOTO_ERROR(H5E_DATASET, H5E_CANTGET, FAIL, "can't get I/O filter callback function");
 
         for (i = 0, filt_sect = &pline->filt_sects[0]; i < pline->tot_filt_nsects; i++, filt_sect++) {
-    
+
             if (filt_sect->nused) {
-                switch(filt_sect->seq_sect) {
+                switch (filt_sect->seq_sect) {
                     case H5_SECTION_SELECTION:
-                        if (H5Z_apply_filters(filt_sect->nused, filt_sect->filter, H5Z_FLAG_REVERSE, &udata->filt_mask[0], 
-                                               err_detect, filter_cb, &chk->sel_nbytes, &chk->sel_alloc_size, &chk->sel_buf) < 0)
+                        if (H5Z_apply_filters(filt_sect->nused, filt_sect->filter, H5Z_FLAG_REVERSE,
+                                              &udata->filt_mask[0], err_detect, filter_cb, &chk->sel_nbytes,
+                                              &chk->sel_alloc_size, &chk->sel_buf) < 0)
                             HGOTO_ERROR(H5E_DATASET, H5E_CANTFILTER, FAIL, "output pipeline failed");
                         break;
 
                     case H5_SECTION_FIXED:
-                        if (H5Z_apply_filters(filt_sect->nused, filt_sect->filter, H5Z_FLAG_REVERSE, &udata->filt_mask[1], 
-                                               err_detect, filter_cb, &chk->data_nbytes, &chk->data_alloc_size, &chk->data_buf) < 0)
+                        if (H5Z_apply_filters(filt_sect->nused, filt_sect->filter, H5Z_FLAG_REVERSE,
+                                              &udata->filt_mask[1], err_detect, filter_cb, &chk->data_nbytes,
+                                              &chk->data_alloc_size, &chk->data_buf) < 0)
                             HGOTO_ERROR(H5E_DATASET, H5E_CANTFILTER, FAIL, "output pipeline failed");
                         break;
 
@@ -1449,9 +1450,8 @@ H5D__struct_chunk_decode(H5D_t *dset, size_t *nbytes /*in,out*/, size_t *alloc_s
                         assert(0 && "Unknown action?!?");
                 }
             } /* end if nused */
-    
-        } /* end for */
 
+        } /* end for */
     }
     /* Get stored and computed checksums */
     if (H5F_get_checksums(chk->sel_buf, chk->sel_nbytes, &stored_chksum, &computed_chksum) < 0)
@@ -1503,13 +1503,13 @@ H5D__struct_chunk_decode_defined_values(H5D_t *dset, size_t *nbytes /*in,out*/, 
                                         void *_udata)
 {
     H5D_chunk_ud_t        *udata = (H5D_chunk_ud_t *)_udata;
-    H5D_chunk_cache_mem_t *chk;             /* Chunk's intermediate struct */
-    H5O_pline_t           *pline;           /* I/O pipeline info */
-    hbool_t                filtered  = false;
+    H5D_chunk_cache_mem_t *chk;   /* Chunk's intermediate struct */
+    H5O_pline_t           *pline; /* I/O pipeline info */
+    hbool_t                filtered = false;
     uint32_t               stored_chksum;   /* Stored metadata checksum value */
     uint32_t               computed_chksum; /* Computed metadata checksum value */
-    void *tmp;
-    const unsigned char *sel_p;
+    void                  *tmp;
+    const unsigned char   *sel_p;
     herr_t                 ret_value = SUCCEED; /* Return value */
 
     FUNC_ENTER_PACKAGE
@@ -1538,9 +1538,9 @@ H5D__struct_chunk_decode_defined_values(H5D_t *dset, size_t *nbytes /*in,out*/, 
 
     /* Decompress the encoded selection */
     if (filtered) {
-        H5Z_EDC_t              err_detect;      /* Error detection info */
-        H5Z_cb_t               filter_cb;       /* I/O filter callback function */
-        unsigned i;
+        H5Z_EDC_t              err_detect; /* Error detection info */
+        H5Z_cb_t               filter_cb;  /* I/O filter callback function */
+        unsigned               i;
         H5Z_stc_filter_sect_t *filt_sect;
 
         /* Retrieve filter settings from API context */
@@ -1550,12 +1550,13 @@ H5D__struct_chunk_decode_defined_values(H5D_t *dset, size_t *nbytes /*in,out*/, 
             HGOTO_ERROR(H5E_DATASET, H5E_CANTGET, FAIL, "can't get I/O filter callback function");
 
         for (i = 0, filt_sect = &pline->filt_sects[0]; i < pline->tot_filt_nsects; i++, filt_sect++) {
-    
+
             if (filt_sect->nused) {
-                switch(filt_sect->seq_sect) {
+                switch (filt_sect->seq_sect) {
                     case H5_SECTION_SELECTION:
-                        if (H5Z_apply_filters(filt_sect->nused, filt_sect->filter, H5Z_FLAG_REVERSE, &udata->filt_mask[0], 
-                                               err_detect, filter_cb, &chk->sel_nbytes, &chk->sel_alloc_size, &chk->sel_buf) < 0)
+                        if (H5Z_apply_filters(filt_sect->nused, filt_sect->filter, H5Z_FLAG_REVERSE,
+                                              &udata->filt_mask[0], err_detect, filter_cb, &chk->sel_nbytes,
+                                              &chk->sel_alloc_size, &chk->sel_buf) < 0)
                             HGOTO_ERROR(H5E_DATASET, H5E_CANTFILTER, FAIL, "output pipeline failed");
                         break;
 
@@ -1568,9 +1569,8 @@ H5D__struct_chunk_decode_defined_values(H5D_t *dset, size_t *nbytes /*in,out*/, 
                         assert(0 && "Unknown action?!?");
                 }
             } /* end if nused */
-    
-        } /* end for */
 
+        } /* end for */
     }
 
     /* Get stored and computed checksums */
@@ -1589,12 +1589,12 @@ H5D__struct_chunk_decode_defined_values(H5D_t *dset, size_t *nbytes /*in,out*/, 
         HGOTO_ERROR(H5E_DATASET, H5E_CANTDECODE, FAIL, "unable to decode dataspace");
 
     /* Return values on exit */
-    *nbytes = chk->sel_nbytes;
+    *nbytes     = chk->sel_nbytes;
     *alloc_size = *nbytes;
 
-    tmp = *chunk;
+    tmp    = *chunk;
     *chunk = chk;
-    tmp = H5MM_xfree(tmp);
+    tmp    = H5MM_xfree(tmp);
 
 done:
     FUNC_LEAVE_NOAPI(ret_value)
@@ -1742,7 +1742,7 @@ H5D__struct_chunk_encode(H5D_t *dset, hsize_t *write_size /*out*/, hsize_t *writ
     const H5D_chunk_cache_mem_t *chk   = (const H5D_chunk_cache_mem_t *)chunk; /* Chunk memory cache info */
     H5D_chunk_ud_t              *udata = (H5D_chunk_ud_t *)_udata;
     void                        *data_buf;
-    uint8_t                     *p = NULL;
+    uint8_t                     *p     = NULL;
     unsigned char               *sel_p = NULL;
     size_t                       sel_nbytes, sel_alloc_size;
     size_t                       data_nbytes, data_alloc_size;
@@ -1795,19 +1795,19 @@ H5D__struct_chunk_encode(H5D_t *dset, hsize_t *write_size /*out*/, hsize_t *writ
     assert(nelmts * type_size == chk->data_nbytes);
     assert(chk->data_alloc_size >= chk->data_nbytes);
 
-    data_nbytes = chk->data_nbytes;
+    data_nbytes     = chk->data_nbytes;
     data_alloc_size = chk->data_alloc_size;
 
     if (NULL == (data_buf = H5MM_malloc(data_alloc_size)))
         HGOTO_ERROR(H5E_RESOURCE, H5E_NOSPACE, FAIL, "memory allocation failed for the chunk");
 
     H5MM_memcpy(data_buf, chk->data_buf, chk->data_nbytes);
-    
+
     /* Compression */
     if (filtered) {
-        H5Z_EDC_t err_detect; /* Error detection info */
-        H5Z_cb_t  filter_cb;  /* I/O filter callback function */
-        unsigned i;
+        H5Z_EDC_t              err_detect; /* Error detection info */
+        H5Z_cb_t               filter_cb;  /* I/O filter callback function */
+        unsigned               i;
         H5Z_stc_filter_sect_t *filt_sect;
 
         udata->unfilt_size[0] = sel_nbytes;
@@ -1822,16 +1822,18 @@ H5D__struct_chunk_encode(H5D_t *dset, hsize_t *write_size /*out*/, hsize_t *writ
         for (i = 0, filt_sect = &pline->filt_sects[0]; i < pline->tot_filt_nsects; i++, filt_sect++) {
 
             if (filt_sect->nused) {
-                switch(filt_sect->seq_sect) {
+                switch (filt_sect->seq_sect) {
                     case H5_SECTION_SELECTION:
                         if (H5Z_apply_filters(filt_sect->nused, filt_sect->filter, 0, &udata->filt_mask[0],
-                                               err_detect, filter_cb, &sel_nbytes, &sel_alloc_size, &tot_buf) < 0)
+                                              err_detect, filter_cb, &sel_nbytes, &sel_alloc_size,
+                                              &tot_buf) < 0)
                             HGOTO_ERROR(H5E_DATASET, H5E_CANTFILTER, FAIL, "output pipeline failed");
                         break;
 
                     case H5_SECTION_FIXED:
                         if (H5Z_apply_filters(filt_sect->nused, filt_sect->filter, 0, &udata->filt_mask[1],
-                                               err_detect, filter_cb, &data_nbytes, &data_alloc_size, &data_buf) < 0)
+                                              err_detect, filter_cb, &data_nbytes, &data_alloc_size,
+                                              &data_buf) < 0)
                             HGOTO_ERROR(H5E_DATASET, H5E_CANTFILTER, FAIL, "output pipeline failed");
                         break;
 
@@ -1842,13 +1844,11 @@ H5D__struct_chunk_encode(H5D_t *dset, hsize_t *write_size /*out*/, hsize_t *writ
                 }
             } /* end if nused */
 
-        } /* end for */ 
-
+        } /* end for */
     }
 
     /* Re-allocate write_buf to include + data */
-    if (NULL ==
-        (tot_buf = H5MM_realloc(tot_buf, sel_alloc_size + data_alloc_size)))
+    if (NULL == (tot_buf = H5MM_realloc(tot_buf, sel_alloc_size + data_alloc_size)))
         HGOTO_ERROR(H5E_RESOURCE, H5E_NOSPACE, FAIL, "memory allocation failed for the chunk");
 
     /* Copy data to tot_buf */
@@ -1895,10 +1895,10 @@ H5D__struct_chunk_encode_in_place(H5D_t *dset, size_t *write_size /*out*/, bool 
     H5D_chunk_cache_mem_t *chk   = (H5D_chunk_cache_mem_t *)*chunk; /* Chunk memory cache info */
     H5D_chunk_ud_t        *udata = (H5D_chunk_ud_t *)_udata;
     H5O_pline_t           *pline; /* I/O pipeline info */
-    hbool_t               filtered = false;
+    hbool_t                filtered = false;
     uint32_t               metadata_chksum;
     uint8_t               *p;
-    unsigned char          *sel_p = NULL;
+    unsigned char         *sel_p = NULL;
     H5D_chunk_cache_mem_t *tmp;
     hsize_t                nelmts;
     size_t                 type_size;
@@ -1950,9 +1950,9 @@ H5D__struct_chunk_encode_in_place(H5D_t *dset, size_t *write_size /*out*/, bool 
 
     /* Compression */
     if (filtered) {
-        H5Z_EDC_t err_detect; /* Error detection info */
-        H5Z_cb_t  filter_cb;  /* I/O filter callback function */
-        unsigned i;
+        H5Z_EDC_t              err_detect; /* Error detection info */
+        H5Z_cb_t               filter_cb;  /* I/O filter callback function */
+        unsigned               i;
         H5Z_stc_filter_sect_t *filt_sect;
 
         udata->unfilt_size[0] = chk->sel_nbytes;
@@ -1961,22 +1961,24 @@ H5D__struct_chunk_encode_in_place(H5D_t *dset, size_t *write_size /*out*/, bool 
         /* Retrieve filter settings from API context */
         if (H5CX_get_err_detect(&err_detect) < 0)
             HGOTO_ERROR(H5E_DATASET, H5E_CANTGET, FAIL, "can't get error detection info");
-         if (H5CX_get_filter_cb(&filter_cb) < 0)
+        if (H5CX_get_filter_cb(&filter_cb) < 0)
             HGOTO_ERROR(H5E_DATASET, H5E_CANTGET, FAIL, "can't get I/O filter callback function");
 
         for (i = 0, filt_sect = &pline->filt_sects[0]; i < pline->tot_filt_nsects; i++, filt_sect++) {
-    
+
             if (filt_sect->nused) {
-                switch(filt_sect->seq_sect) {
+                switch (filt_sect->seq_sect) {
                     case H5_SECTION_SELECTION:
-                        if (H5Z_apply_filters(filt_sect->nused, filt_sect->filter, 0, &udata->filt_mask[0], 
-                                               err_detect, filter_cb, &chk->sel_nbytes, &chk->sel_alloc_size, &chk->sel_buf) < 0)
+                        if (H5Z_apply_filters(filt_sect->nused, filt_sect->filter, 0, &udata->filt_mask[0],
+                                              err_detect, filter_cb, &chk->sel_nbytes, &chk->sel_alloc_size,
+                                              &chk->sel_buf) < 0)
                             HGOTO_ERROR(H5E_DATASET, H5E_CANTFILTER, FAIL, "output pipeline failed");
                         break;
 
                     case H5_SECTION_FIXED:
-                        if (H5Z_apply_filters(filt_sect->nused, filt_sect->filter, 0, &udata->filt_mask[1], 
-                                               err_detect, filter_cb, &chk->data_nbytes, &chk->data_alloc_size, &chk->data_buf) < 0)
+                        if (H5Z_apply_filters(filt_sect->nused, filt_sect->filter, 0, &udata->filt_mask[1],
+                                              err_detect, filter_cb, &chk->data_nbytes, &chk->data_alloc_size,
+                                              &chk->data_buf) < 0)
                             HGOTO_ERROR(H5E_DATASET, H5E_CANTFILTER, FAIL, "output pipeline failed");
                         break;
 
@@ -1986,9 +1988,8 @@ H5D__struct_chunk_encode_in_place(H5D_t *dset, size_t *write_size /*out*/, bool 
                         assert(0 && "Unknown action?!?");
                 }
             } /* end if nused */
-    
-        } /* end for */
 
+        } /* end for */
     }
 
     /* Realloc chk->data_buf to provide space for encoded selection and data */
@@ -2034,8 +2035,8 @@ done:
 static herr_t
 H5D__struct_chunk_evict(H5D_t *dset, void *chunk, void *udata)
 {
-    H5D_chunk_cache_mem_t *chk = (H5D_chunk_cache_mem_t *)chunk; /* Chunk memory cache info */
-    herr_t                 ret_value = SUCCEED;                  /* Return value */
+    H5D_chunk_cache_mem_t *chk       = (H5D_chunk_cache_mem_t *)chunk; /* Chunk memory cache info */
+    herr_t                 ret_value = SUCCEED;                        /* Return value */
 
     FUNC_ENTER_PACKAGE
 
@@ -3588,8 +3589,8 @@ static herr_t
 H5D__struct_chunk_layout_query(H5D_t *dset, hsize_t *chunk_dims, bool *encode_decode_necessary,
                                bool *partial_bound_chunks_different_encoding)
 {
-    H5O_pline_t            *pline; /* I/O pipeline info */
-    herr_t ret_value = SUCCEED; /* Return value		*/
+    H5O_pline_t *pline;               /* I/O pipeline info */
+    herr_t       ret_value = SUCCEED; /* Return value		*/
 
     FUNC_ENTER_PACKAGE
 

--- a/src/H5Dstruct_chunk.c
+++ b/src/H5Dstruct_chunk.c
@@ -1257,7 +1257,7 @@ H5D__struct_chunk_lookup(H5D_t *dset, size_t count, const hsize_t *scaled[] /*in
     H5O_layout_struct_chunk_t  *layout  = &dset->shared->layout.u.struct_chunk;
     H5D_chk_idx_info_t          idx_info; /* Chunked index info */
     H5O_pline_t                *pline;    /* I/O pipeline info */
-    hbool_t                     filtered        = false;
+    hbool_t                     filtered = false;
     size_t                      tot_unfilt_size = 0;
     size_t                      i;
     herr_t                      ret_value = SUCCEED; /* Return value */
@@ -1269,7 +1269,7 @@ H5D__struct_chunk_lookup(H5D_t *dset, size_t count, const hsize_t *scaled[] /*in
     assert(dset->shared->layout.type == H5D_STRUCT_CHUNK);
 
     pline = &(dset->shared->dcpl_cache.pline);
-    if (pline && pline->nused)
+    if (pline && pline->tot_filt_nsects)
         filtered = true;
 
     /* Compose chunked index info struct */
@@ -1298,24 +1298,32 @@ H5D__struct_chunk_lookup(H5D_t *dset, size_t count, const hsize_t *scaled[] /*in
         if ((storage->ops->get_addr)(&idx_info, udata) < 0)
             HGOTO_ERROR(H5E_DATASET, H5E_CANTGET, FAIL, "can't query chunk address");
 
-        if (addr[i])
-            *addr[i] = udata->chunk_block.offset;
-        if (size[i])
-            *size[i] = udata->chunk_block.length;
+        if (!H5_addr_defined(*addr[i])) {
+            udata = H5MM_xfree(udata);
 
-        if (filtered)
-            /* For now: assume two sections for fixed data */
-            tot_unfilt_size = udata->unfilt_size[0] + udata->unfilt_size[1];
+        } else {
 
-        if (size_hint[i])
-            *size_hint[i] = filtered ? tot_unfilt_size : *size[i];
+            if (addr[i])
+                *addr[i] = udata->chunk_block.offset;
+            if (size[i])
+                *size[i] = udata->chunk_block.length;
 
-        /* Size of defined values */
-        if (defined_values_size[i])
-            *defined_values_size[i] = filtered ? udata->unfilt_size[0] : udata->offset[1];
+            if (filtered)
+                /* For now: assume two sections for fixed data */
+                tot_unfilt_size = udata->unfilt_size[0] + udata->unfilt_size[1];
 
-        if (defined_values_size_hint[i])
-            *defined_values_size_hint[i] = filtered ? udata->unfilt_size[0] : *defined_values_size[i];
+            if (size_hint[i])
+                *size_hint[i] = filtered ? tot_unfilt_size : *size[i];
+
+            /* Size of defined values */
+            if (defined_values_size[i])
+                *defined_values_size[i] = filtered ? udata->unfilt_size[0] : udata->offset[1];
+
+            if (defined_values_size_hint[i])
+                *defined_values_size_hint[i] = filtered ? udata->unfilt_size[0] : *defined_values_size[i];
+
+            _udata[i] = (void *)udata;
+        } 
 
         _udata[i] = (void *)udata;
 
@@ -1363,13 +1371,11 @@ H5D__struct_chunk_decode(H5D_t *dset, size_t *nbytes /*in,out*/, size_t *alloc_s
     H5D_chunk_ud_t        *udata = (H5D_chunk_ud_t *)_udata;
     H5D_chunk_cache_mem_t *chk;   /* Chunk's intermediate struct */
     H5O_pline_t           *pline; /* I/O pipeline info */
-    hbool_t                filtered = false;
-    H5Z_EDC_t              err_detect;      /* Error detection info */
-    H5Z_cb_t               filter_cb;       /* I/O filter callback function */
-    uint32_t               stored_chksum;   /* Stored metadata checksum value */
-    uint32_t               computed_chksum; /* Computed metadata checksum value */
-    void                  *tmp;
-    const unsigned char   *sel_p;
+    hbool_t                filtered  = false;
+    uint32_t               stored_chksum;       /* Stored metadata checksum value */
+    uint32_t               computed_chksum;     /* Computed metadata checksum value */
+    void *tmp;
+    const unsigned char *sel_p;
     herr_t                 ret_value = SUCCEED; /* Return value */
 
     FUNC_ENTER_PACKAGE
@@ -1378,7 +1384,7 @@ H5D__struct_chunk_decode(H5D_t *dset, size_t *nbytes /*in,out*/, size_t *alloc_s
     assert(dset);
 
     pline = &(dset->shared->dcpl_cache.pline);
-    if (pline && pline->nused)
+    if (pline && pline->tot_filt_nsects)
         filtered = true;
 
     /* Allocate the chunk intermediate struct */
@@ -1393,14 +1399,6 @@ H5D__struct_chunk_decode(H5D_t *dset, size_t *nbytes /*in,out*/, size_t *alloc_s
     chk->data_nbytes     = *nbytes - chk->sel_nbytes;
     chk->data_alloc_size = *alloc_size - chk->sel_alloc_size;
 
-    /* Get stored and computed checksums */
-    if (H5F_get_checksums(*chunk, chk->sel_nbytes, &stored_chksum, &computed_chksum) < 0)
-        HGOTO_ERROR(H5E_DATASET, H5E_CANTGET, FAIL, "can't get checksums");
-    if (stored_chksum != computed_chksum)
-        HGOTO_ERROR(H5E_DATASET, H5E_CANTGET, FAIL, "checksums verification failed");
-
-    chk->sel_nbytes -= H5_SIZEOF_CHKSUM;
-    chk->sel_alloc_size -= H5_SIZEOF_CHKSUM;
 
     /* Allocate a buffer for the encoded selection */
     if (NULL == (chk->sel_buf = H5MM_malloc(chk->sel_alloc_size)))
@@ -1414,27 +1412,57 @@ H5D__struct_chunk_decode(H5D_t *dset, size_t *nbytes /*in,out*/, size_t *alloc_s
         HGOTO_ERROR(H5E_RESOURCE, H5E_NOSPACE, FAIL, "memory allocation failed for data buffer");
 
     /* Copy over the data values */
-    H5MM_memcpy(chk->data_buf, (uint8_t *)(*chunk) + chk->sel_nbytes + H5_SIZEOF_CHKSUM, chk->data_nbytes);
+    H5MM_memcpy(chk->data_buf, (uint8_t *)(*chunk) + chk->sel_nbytes, chk->data_nbytes);
 
     /* Decompress the encoded selection  & data values */
     if (filtered) {
+        H5Z_EDC_t err_detect; /* Error detection info */
+        H5Z_cb_t  filter_cb;  /* I/O filter callback function */
+        unsigned i;
+        H5Z_stc_filter_sect_t *filt_sect;
 
         /* Retrieve filter settings from API context */
         if (H5CX_get_err_detect(&err_detect) < 0)
             HGOTO_ERROR(H5E_DATASET, H5E_CANTGET, FAIL, "can't get error detection info");
-        if (H5CX_get_filter_cb(&filter_cb) < 0)
+         if (H5CX_get_filter_cb(&filter_cb) < 0)
             HGOTO_ERROR(H5E_DATASET, H5E_CANTGET, FAIL, "can't get I/O filter callback function");
 
-        /* Decompress the encoded selection */
-        if (H5Z_pipeline(pline, H5Z_FLAG_REVERSE, &(udata->filt_mask[0]), err_detect, filter_cb,
-                         &chk->sel_nbytes, &chk->sel_alloc_size, &chk->sel_buf) < 0)
-            HGOTO_ERROR(H5E_DATASET, H5E_CANTFILTER, FAIL, "data pipeline read failed");
+        for (i = 0, filt_sect = &pline->filt_sects[0]; i < pline->tot_filt_nsects; i++, filt_sect++) {
+    
+            if (filt_sect->nused) {
+                switch(filt_sect->seq_sect) {
+                    case H5_SECTION_SELECTION:
+                        if (H5Z_apply_filters(filt_sect->nused, filt_sect->filter, H5Z_FLAG_REVERSE, &udata->filt_mask[0], 
+                                               err_detect, filter_cb, &chk->sel_nbytes, &chk->sel_alloc_size, &chk->sel_buf) < 0)
+                            HGOTO_ERROR(H5E_DATASET, H5E_CANTFILTER, FAIL, "output pipeline failed");
+                        break;
 
-        /* Decompress the data values */
-        if (H5Z_pipeline(pline, H5Z_FLAG_REVERSE, &(udata->filt_mask[1]), err_detect, filter_cb,
-                         &chk->data_nbytes, &chk->data_alloc_size, &chk->data_buf) < 0)
-            HGOTO_ERROR(H5E_DATASET, H5E_CANTFILTER, FAIL, "data pipeline read failed");
+                    case H5_SECTION_FIXED:
+                        if (H5Z_apply_filters(filt_sect->nused, filt_sect->filter, H5Z_FLAG_REVERSE, &udata->filt_mask[1], 
+                                               err_detect, filter_cb, &chk->data_nbytes, &chk->data_alloc_size, &chk->data_buf) < 0)
+                            HGOTO_ERROR(H5E_DATASET, H5E_CANTFILTER, FAIL, "output pipeline failed");
+                        break;
+
+                    case H5_SECTION_VL:
+                    case H5_SECTION_NUM:
+                    default:
+                        assert(0 && "Unknown action?!?");
+                }
+            } /* end if nused */
+    
+        } /* end for */
+
     }
+    /* Get stored and computed checksums */
+    if (H5F_get_checksums(chk->sel_buf, chk->sel_nbytes, &stored_chksum, &computed_chksum) < 0)
+        HGOTO_ERROR(H5E_DATASET, H5E_CANTGET, FAIL, "can't get checksums");
+    if (stored_chksum != computed_chksum)
+        HGOTO_ERROR(H5E_DATASET, H5E_CANTGET, FAIL, "checksums verification failed");
+
+    chk->sel_nbytes -= H5_SIZEOF_CHKSUM;
+    chk->sel_alloc_size -= H5_SIZEOF_CHKSUM;
+
+    sel_p = chk->sel_buf;
 
     sel_p = chk->sel_buf;
 
@@ -1461,7 +1489,6 @@ done:
  * Purpose:     The same as H5SC_chunk_decode_t but only decodes the defined values.
  *
  *              Optional, if not present, all values are defined.
- *
  * Return:    Non-negative on success/Negative on failure
  *
  * NOTE: On entry: [chunk] is the pointer to the on disk file format chunk buffer
@@ -1477,12 +1504,12 @@ H5D__struct_chunk_decode_defined_values(H5D_t *dset, size_t *nbytes /*in,out*/, 
 {
     H5D_chunk_ud_t        *udata = (H5D_chunk_ud_t *)_udata;
     H5D_chunk_cache_mem_t *chk;             /* Chunk's intermediate struct */
+    H5O_pline_t           *pline;           /* I/O pipeline info */
+    hbool_t                filtered  = false;
     uint32_t               stored_chksum;   /* Stored metadata checksum value */
     uint32_t               computed_chksum; /* Computed metadata checksum value */
-    H5O_pline_t           *pline;           /* I/O pipeline info */
-    H5Z_EDC_t              err_detect;      /* Error detection info */
-    H5Z_cb_t               filter_cb;       /* I/O filter callback function */
-    hbool_t                filtered  = false;
+    void *tmp;
+    const unsigned char *sel_p;
     herr_t                 ret_value = SUCCEED; /* Return value */
 
     FUNC_ENTER_PACKAGE
@@ -1491,7 +1518,7 @@ H5D__struct_chunk_decode_defined_values(H5D_t *dset, size_t *nbytes /*in,out*/, 
     assert(dset);
 
     pline = &(dset->shared->dcpl_cache.pline);
-    if (pline && pline->nused)
+    if (pline && pline->tot_filt_nsects)
         filtered = true;
 
     /* Allocate the chunk intermediate struct */
@@ -1502,6 +1529,50 @@ H5D__struct_chunk_decode_defined_values(H5D_t *dset, size_t *nbytes /*in,out*/, 
     /* nbytes and alloc_size for encoded selection */
     chk->sel_nbytes = chk->sel_alloc_size = udata->offset[1];
 
+    /* Allocate a buffer for the encoded selection */
+    if (NULL == (chk->sel_buf = H5MM_malloc(chk->sel_alloc_size)))
+        HGOTO_ERROR(H5E_RESOURCE, H5E_NOSPACE, FAIL, "memory allocation failed for encoded selection buffer");
+
+    /* Copy over the encoded selection */
+    H5MM_memcpy(chk->sel_buf, *chunk, chk->sel_nbytes);
+
+    /* Decompress the encoded selection */
+    if (filtered) {
+        H5Z_EDC_t              err_detect;      /* Error detection info */
+        H5Z_cb_t               filter_cb;       /* I/O filter callback function */
+        unsigned i;
+        H5Z_stc_filter_sect_t *filt_sect;
+
+        /* Retrieve filter settings from API context */
+        if (H5CX_get_err_detect(&err_detect) < 0)
+            HGOTO_ERROR(H5E_DATASET, H5E_CANTGET, FAIL, "can't get error detection info");
+        if (H5CX_get_filter_cb(&filter_cb) < 0)
+            HGOTO_ERROR(H5E_DATASET, H5E_CANTGET, FAIL, "can't get I/O filter callback function");
+
+        for (i = 0, filt_sect = &pline->filt_sects[0]; i < pline->tot_filt_nsects; i++, filt_sect++) {
+    
+            if (filt_sect->nused) {
+                switch(filt_sect->seq_sect) {
+                    case H5_SECTION_SELECTION:
+                        if (H5Z_apply_filters(filt_sect->nused, filt_sect->filter, H5Z_FLAG_REVERSE, &udata->filt_mask[0], 
+                                               err_detect, filter_cb, &chk->sel_nbytes, &chk->sel_alloc_size, &chk->sel_buf) < 0)
+                            HGOTO_ERROR(H5E_DATASET, H5E_CANTFILTER, FAIL, "output pipeline failed");
+                        break;
+
+                    case H5_SECTION_FIXED:
+                        break;
+
+                    case H5_SECTION_VL:
+                    case H5_SECTION_NUM:
+                    default:
+                        assert(0 && "Unknown action?!?");
+                }
+            } /* end if nused */
+    
+        } /* end for */
+
+    }
+
     /* Get stored and computed checksums */
     if (H5F_get_checksums(*chunk, chk->sel_nbytes, &stored_chksum, &computed_chksum) < 0)
         HGOTO_ERROR(H5E_DATASET, H5E_CANTGET, FAIL, "can't get checksums");
@@ -1511,36 +1582,19 @@ H5D__struct_chunk_decode_defined_values(H5D_t *dset, size_t *nbytes /*in,out*/, 
     chk->sel_nbytes -= H5_SIZEOF_CHKSUM;
     chk->sel_alloc_size -= H5_SIZEOF_CHKSUM;
 
-    /* Allocate a buffer for the encoded selection */
-    if (NULL == (chk->sel_buf = H5MM_malloc(chk->sel_alloc_size)))
-        HGOTO_ERROR(H5E_RESOURCE, H5E_NOSPACE, FAIL, "memory allocation failed for encoded selection buffer");
-
-    /* Copy over the encoded selection */
-    H5MM_memcpy(chk->sel_buf, *chunk, chk->sel_nbytes);
-
-    /* Decompress the encoded selection  & data values */
-    if (filtered) {
-
-        /* Retrieve filter settings from API context */
-        if (H5CX_get_err_detect(&err_detect) < 0)
-            HGOTO_ERROR(H5E_DATASET, H5E_CANTGET, FAIL, "can't get error detection info");
-        if (H5CX_get_filter_cb(&filter_cb) < 0)
-            HGOTO_ERROR(H5E_DATASET, H5E_CANTGET, FAIL, "can't get I/O filter callback function");
-
-        /* Decompress the encoded selection */
-        if (H5Z_pipeline(pline, H5Z_FLAG_REVERSE, &(udata->filt_mask[0]), err_detect, filter_cb,
-                         &chk->sel_nbytes, &chk->sel_alloc_size, &chk->sel_buf) < 0)
-            HGOTO_ERROR(H5E_DATASET, H5E_CANTFILTER, FAIL, "data pipeline read failed");
-    }
+    sel_p = chk->sel_buf;
 
     /* Decode the encoded selection to dataspace sel_space */
-    if (NULL == (chk->sel_space = H5S_decode((const unsigned char **)&chk->sel_buf)))
+    if (NULL == (chk->sel_space = H5S_decode(&sel_p)))
         HGOTO_ERROR(H5E_DATASET, H5E_CANTDECODE, FAIL, "unable to decode dataspace");
 
     /* Return values on exit */
-    *nbytes += chk->sel_nbytes;
-    *alloc_size += *nbytes;
+    *nbytes = chk->sel_nbytes;
+    *alloc_size = *nbytes;
+
+    tmp = *chunk;
     *chunk = chk;
+    tmp = H5MM_xfree(tmp);
 
 done:
     FUNC_LEAVE_NOAPI(ret_value)
@@ -1628,7 +1682,6 @@ static herr_t
 H5D__struct_chunk_condense(H5D_t *dset, size_t *nbytes /*in, out*/, void **chunk /*in, out*/,
                            void H5_ATTR_UNUSED *udata)
 {
-    H5O_pline_t           *pline;                                       /* I/O pipeline info  */
     H5D_chunk_cache_mem_t *chk       = (H5D_chunk_cache_mem_t *)*chunk; /* Chunk's memory cache info */
     herr_t                 ret_value = SUCCEED;                         /* Return value */
 
@@ -1636,8 +1689,6 @@ H5D__struct_chunk_condense(H5D_t *dset, size_t *nbytes /*in, out*/, void **chunk
 
     /* Sanity checks */
     assert(dset);
-
-    pline = &(dset->shared->dcpl_cache.pline);
 
     if ((chk->sel_alloc_size + chk->data_alloc_size) == (chk->sel_nbytes + chk->data_nbytes))
         /* Nothing to condense */
@@ -1683,7 +1734,6 @@ done:
  * NOTE: Only handle two sections for now
  *-------------------------------------------------------------------------
  */
-#ifdef out
 static herr_t
 H5D__struct_chunk_encode(H5D_t *dset, hsize_t *write_size /*out*/, hsize_t *write_buf_alloc /*out*/,
                          bool H5_ATTR_UNUSED partial_bound, const void *chunk, void *_udata,
@@ -1691,157 +1741,8 @@ H5D__struct_chunk_encode(H5D_t *dset, hsize_t *write_size /*out*/, hsize_t *writ
 {
     const H5D_chunk_cache_mem_t *chk   = (const H5D_chunk_cache_mem_t *)chunk; /* Chunk memory cache info */
     H5D_chunk_ud_t              *udata = (H5D_chunk_ud_t *)_udata;
-    void                        *sel_buf;
     void                        *data_buf;
-    uint8_t                     *p     = NULL;
-    unsigned char               *sel_p = NULL;
-    size_t                       sel_nbytes, sel_alloc_size;
-    size_t                       data_nbytes, data_alloc_size;
-    H5O_pline_t                 *pline   = NULL; /* I/O pipeline info */
-    void                        *tot_buf = NULL;
-    hsize_t                      nelmts;
-    size_t                       type_size;
-    uint32_t                     metadata_chksum;
-    herr_t                       ret_value = SUCCEED; /* Return value */
-
-    FUNC_ENTER_PACKAGE
-
-    /* Sanity checks */
-    assert(dset);
-
-    pline = &(dset->shared->dcpl_cache.pline);
-
-    /* Determine size of selection dataspace */
-    if (H5S_encode(chk->sel_space, &sel_p, &sel_nbytes) < 0)
-        HGOTO_ERROR(H5E_DATASET, H5E_CANTGET, FAIL, "unable to get encoded dataspace size");
-
-    /* Allocate buffer for selection */
-    sel_alloc_size = sel_nbytes;
-#ifdef out
-    if (NULL == (sel_buf = H5D__chunk_mem_alloc(sel_alloc_size, pline)))
-        HGOTO_ERROR(H5E_RESOURCE, H5E_NOSPACE, FAIL, "memory allocation failed for the chunk");
-#endif
-    if (NULL == (sel_buf = H5MM_malloc(sel_alloc_size)))
-        HGOTO_ERROR(H5E_RESOURCE, H5E_NOSPACE, FAIL, "memory allocation failed for the chunk");
-
-    sel_p = sel_buf;
-
-    /* Encode the selection */
-    if (H5S_encode(chk->sel_space, &sel_p, &sel_nbytes) < 0)
-        HGOTO_ERROR(H5E_DATASET, H5E_CANTGET, FAIL, "unable to encode dataspace");
-
-    /* Get the number of elements in the selection */
-    nelmts    = H5S_GET_SELECT_NPOINTS(chk->sel_space);
-    type_size = H5T_GET_SIZE(dset->shared->type);
-
-    assert(nelmts * type_size == chk->data_nbytes);
-
-    /* Compression */
-    if (pline && pline->tot_filt_nsects) {
-        H5Z_EDC_t              err_detect; /* Error detection info */
-        H5Z_cb_t               filter_cb;  /* I/O filter callback function */
-        unsigned               i;
-        H5Z_stc_filter_sect_t *filt_sect;
-        size_t                *nbytes;
-        size_t                *buf_size;
-        void                 **buf;
-        unsigned              *filt_mask;
-
-        udata->unfilt_size[0] = chk->sel_nbytes;
-        udata->unfilt_size[1] = chk->data_nbytes;
-
-        /* Retrieve filter settings from API context */
-        if (H5CX_get_err_detect(&err_detect) < 0)
-            HGOTO_ERROR(H5E_DATASET, H5E_CANTGET, FAIL, "can't get error detection info");
-        if (H5CX_get_filter_cb(&filter_cb) < 0)
-            HGOTO_ERROR(H5E_DATASET, H5E_CANTGET, FAIL, "can't get I/O filter callback function");
-
-        for (i = 0, filt_sect = &pline->filt_sects[0]; i < pline->tot_filt_nsects; i++, filt_sect++) {
-
-            if (filt_sect->nused) {
-                switch (filt_sect->seq_sect) {
-                    case H5_SECTION_SELECTION:
-                        filt_mask = &udata->filt_mask[0];
-                        nbytes    = &sel_nbytes;
-                        buf_size  = &sel_alloc_size;
-                        buf       = &sel_buf;
-                        break;
-
-                    case H5_SECTION_FIXED:
-                        filt_mask = &udata->filt_mask[1];
-                        nbytes    = &data_nbytes;
-                        buf_size  = &data_alloc_size;
-                        buf       = &data_buf;
-                        break;
-
-                    case H5_SECTION_VL:
-                    case H5_SECTION_NUM:
-                    default:
-                        assert(0 && "Unknown action?!?");
-                }
-                if (H5Z_apply_pipeline(pline->version, filt_sect->nused, filt_sect->filter, 0, filt_mask,
-                                       err_detect, filter_cb, nbytes, buf_size, buf) < 0)
-                    HGOTO_ERROR(H5E_DATASET, H5E_CANTFILTER, FAIL, "output pipeline failed");
-            } /* end if nused */
-
-        } /* end for */
-
-    } /* end if pline */
-
-    /* Allocate write_buf for selection + data */
-#ifdef out
-    if (NULL ==
-        (tot_buf = H5D__chunk_mem_alloc(sel_alloc_size + H5_SIZEOF_CHKSUM + chk->data_alloc_size, pline)))
-        HGOTO_ERROR(H5E_RESOURCE, H5E_NOSPACE, FAIL, "memory allocation failed for the chunk");
-#endif
-    if (NULL == (tot_buf = H5MM_malloc(sel_alloc_size + H5_SIZEOF_CHKSUM + chk->data_alloc_size)))
-        HGOTO_ERROR(H5E_RESOURCE, H5E_NOSPACE, FAIL, "memory allocation failed for the chunk");
-
-    /* Copy selection to tot_buf */
-    H5MM_memcpy(tot_buf, sel_buf, sel_nbytes);
-
-    /* Compute metadata checksum */
-    metadata_chksum = H5_checksum_metadata(sel_buf, (size_t)sel_nbytes, 0);
-
-    p = (uint8_t *)tot_buf + sel_nbytes;
-    /* Encode metadata checksum for the selection */
-    UINT32ENCODE(p, metadata_chksum);
-
-    sel_nbytes += H5_SIZEOF_CHKSUM;
-    sel_alloc_size += H5_SIZEOF_CHKSUM;
-
-    /* Copy data to tot_buf */
-    H5MM_memcpy((uint8_t *)tot_buf + sel_nbytes, chk->data_buf, chk->data_nbytes);
-
-    udata->offset[0] = 0; /* Filler */
-    udata->offset[1] = sel_nbytes;
-
-    *write_size      = sel_nbytes + chk->data_nbytes;
-    *write_buf_alloc = sel_alloc_size + chk->data_alloc_size;
-    *write_buf       = tot_buf;
-
-done:
-#ifdef out
-    if (sel_buf)
-        sel_buf = (uint8_t *)H5D__chunk_mem_xfree(sel_buf, pline);
-#endif
-    if (sel_buf)
-        sel_buf = H5MM_xfree(sel_buf);
-
-    FUNC_LEAVE_NOAPI(ret_value)
-} /* H5D__struct_chunk_encode() */
-#endif
-
-static herr_t
-H5D__struct_chunk_encode(H5D_t *dset, hsize_t *write_size /*out*/, hsize_t *write_buf_alloc /*out*/,
-                         bool H5_ATTR_UNUSED partial_bound, const void *chunk, void *_udata,
-                         void **write_buf /*out*/)
-{
-    const H5D_chunk_cache_mem_t *chk   = (const H5D_chunk_cache_mem_t *)chunk; /* Chunk memory cache info */
-    H5D_chunk_ud_t              *udata = (H5D_chunk_ud_t *)_udata;
-    void                        *sel_buf;
-    void                        *data_buf;
-    uint8_t                     *p     = NULL;
+    uint8_t                     *p = NULL;
     unsigned char               *sel_p = NULL;
     size_t                       sel_nbytes, sel_alloc_size;
     size_t                       data_nbytes, data_alloc_size;
@@ -1859,7 +1760,7 @@ H5D__struct_chunk_encode(H5D_t *dset, hsize_t *write_size /*out*/, hsize_t *writ
     assert(dset);
 
     pline = &(dset->shared->dcpl_cache.pline);
-    if (pline && pline->nused)
+    if (pline && pline->tot_filt_nsects)
         filtered = true;
 
     /* Determine size of selection dataspace */
@@ -1868,28 +1769,49 @@ H5D__struct_chunk_encode(H5D_t *dset, hsize_t *write_size /*out*/, hsize_t *writ
 
     /* Allocate buffer for selection */
     sel_alloc_size = sel_nbytes;
-    if (NULL == (sel_buf = H5MM_malloc(sel_alloc_size)))
+    if (NULL == (tot_buf = H5MM_malloc(sel_alloc_size + H5_SIZEOF_CHKSUM)))
         HGOTO_ERROR(H5E_RESOURCE, H5E_NOSPACE, FAIL, "memory allocation failed for the chunk");
 
-    sel_p = sel_buf;
+    sel_p = tot_buf;
 
     /* Encode the selection */
     if (H5S_encode(chk->sel_space, &sel_p, &sel_nbytes) < 0)
         HGOTO_ERROR(H5E_DATASET, H5E_CANTGET, FAIL, "unable to encode dataspace");
+
+    /* Compute metadata checksum for sel_space */
+    metadata_chksum = H5_checksum_metadata(tot_buf, (size_t)sel_nbytes, 0);
+
+    /* Encode metadata checksum for the selection */
+    p = (uint8_t *)tot_buf + sel_nbytes;
+    UINT32ENCODE(p, metadata_chksum);
+
+    sel_nbytes += H5_SIZEOF_CHKSUM;
+    sel_alloc_size += H5_SIZEOF_CHKSUM;
 
     /* Get the number of elements in the selection */
     nelmts    = H5S_GET_SELECT_NPOINTS(chk->sel_space);
     type_size = H5T_GET_SIZE(dset->shared->type);
 
     assert(nelmts * type_size == chk->data_nbytes);
+    assert(chk->data_alloc_size >= chk->data_nbytes);
 
+    data_nbytes = chk->data_nbytes;
+    data_alloc_size = chk->data_alloc_size;
+
+    if (NULL == (data_buf = H5MM_malloc(data_alloc_size)))
+        HGOTO_ERROR(H5E_RESOURCE, H5E_NOSPACE, FAIL, "memory allocation failed for the chunk");
+
+    H5MM_memcpy(data_buf, chk->data_buf, chk->data_nbytes);
+    
     /* Compression */
     if (filtered) {
         H5Z_EDC_t err_detect; /* Error detection info */
         H5Z_cb_t  filter_cb;  /* I/O filter callback function */
+        unsigned i;
+        H5Z_stc_filter_sect_t *filt_sect;
 
-        udata->unfilt_size[0] = chk->sel_nbytes;
-        udata->unfilt_size[1] = chk->data_nbytes;
+        udata->unfilt_size[0] = sel_nbytes;
+        udata->unfilt_size[1] = data_nbytes;
 
         /* Retrieve filter settings from API context */
         if (H5CX_get_err_detect(&err_detect) < 0)
@@ -1897,51 +1819,56 @@ H5D__struct_chunk_encode(H5D_t *dset, hsize_t *write_size /*out*/, hsize_t *writ
         if (H5CX_get_filter_cb(&filter_cb) < 0)
             HGOTO_ERROR(H5E_DATASET, H5E_CANTGET, FAIL, "can't get I/O filter callback function");
 
-        /* Process sel_space and data through the filter pipeline */
-        if (H5Z_pipeline(pline, 0, &udata->filt_mask[0], err_detect, filter_cb, &sel_nbytes, &sel_alloc_size,
-                         &sel_buf) < 0)
-            HGOTO_ERROR(H5E_DATASET, H5E_CANTFILTER, FAIL, "output pipeline failed");
+        for (i = 0, filt_sect = &pline->filt_sects[0]; i < pline->tot_filt_nsects; i++, filt_sect++) {
 
-        if (H5Z_pipeline(pline, 0, &udata->filt_mask[1], err_detect, filter_cb, &data_nbytes,
-                         &data_alloc_size, &data_buf) < 0)
-            HGOTO_ERROR(H5E_DATASET, H5E_CANTFILTER, FAIL, "output pipeline failed");
+            if (filt_sect->nused) {
+                switch(filt_sect->seq_sect) {
+                    case H5_SECTION_SELECTION:
+                        if (H5Z_apply_filters(filt_sect->nused, filt_sect->filter, 0, &udata->filt_mask[0],
+                                               err_detect, filter_cb, &sel_nbytes, &sel_alloc_size, &tot_buf) < 0)
+                            HGOTO_ERROR(H5E_DATASET, H5E_CANTFILTER, FAIL, "output pipeline failed");
+                        break;
+
+                    case H5_SECTION_FIXED:
+                        if (H5Z_apply_filters(filt_sect->nused, filt_sect->filter, 0, &udata->filt_mask[1],
+                                               err_detect, filter_cb, &data_nbytes, &data_alloc_size, &data_buf) < 0)
+                            HGOTO_ERROR(H5E_DATASET, H5E_CANTFILTER, FAIL, "output pipeline failed");
+                        break;
+
+                    case H5_SECTION_VL:
+                    case H5_SECTION_NUM:
+                    default:
+                        assert(0 && "Unknown action?!?");
+                }
+            } /* end if nused */
+
+        } /* end for */ 
+
     }
 
-    /* Allocate write_buf for selection + data */
-    if (NULL == (tot_buf = H5MM_malloc(sel_alloc_size + H5_SIZEOF_CHKSUM + chk->data_alloc_size)))
+    /* Re-allocate write_buf to include + data */
+    if (NULL ==
+        (tot_buf = H5MM_realloc(tot_buf, sel_alloc_size + data_alloc_size)))
         HGOTO_ERROR(H5E_RESOURCE, H5E_NOSPACE, FAIL, "memory allocation failed for the chunk");
 
-    /* Copy selection to tot_buf */
-    H5MM_memcpy(tot_buf, sel_buf, sel_nbytes);
-
-    /* Compute metadata checksum */
-    metadata_chksum = H5_checksum_metadata(sel_buf, (size_t)sel_nbytes, 0);
-
-    p = (uint8_t *)tot_buf + sel_nbytes;
-    /* Encode metadata checksum for the selection */
-    UINT32ENCODE(p, metadata_chksum);
-
-    sel_nbytes += H5_SIZEOF_CHKSUM;
-    sel_alloc_size += H5_SIZEOF_CHKSUM;
-
     /* Copy data to tot_buf */
-    H5MM_memcpy((uint8_t *)tot_buf + sel_nbytes, chk->data_buf, chk->data_nbytes);
+    H5MM_memcpy((uint8_t *)tot_buf + sel_nbytes, data_buf, data_nbytes);
 
     udata->offset[0] = 0; /* Filler */
     udata->offset[1] = sel_nbytes;
 
-    *write_size      = sel_nbytes + chk->data_nbytes;
-    *write_buf_alloc = sel_alloc_size + chk->data_alloc_size;
+    *write_size      = sel_nbytes + data_nbytes;
+    *write_buf_alloc = sel_alloc_size + data_alloc_size;
     *write_buf       = tot_buf;
 
 done:
-    if (sel_buf)
-        sel_buf = H5MM_xfree(sel_buf);
+    if (data_buf)
+        data_buf = H5MM_xfree(data_buf);
 
     FUNC_LEAVE_NOAPI(ret_value)
 } /* H5D__struct_chunk_encode() */
 
-/*------------------------------------------------------------------------e
+/*------------------------------------------------------------------------
  * Function:    H5D__struct_chunk_encode_in_place
  *
  * Purpose:     The same as H5D_struct_chunk_encode()  but does not preserve
@@ -1968,10 +1895,10 @@ H5D__struct_chunk_encode_in_place(H5D_t *dset, size_t *write_size /*out*/, bool 
     H5D_chunk_cache_mem_t *chk   = (H5D_chunk_cache_mem_t *)*chunk; /* Chunk memory cache info */
     H5D_chunk_ud_t        *udata = (H5D_chunk_ud_t *)_udata;
     H5O_pline_t           *pline; /* I/O pipeline info */
-    hbool_t                filtered = false;
+    hbool_t               filtered = false;
     uint32_t               metadata_chksum;
     uint8_t               *p;
-    unsigned char         *sel_p = NULL;
+    unsigned char          *sel_p = NULL;
     H5D_chunk_cache_mem_t *tmp;
     hsize_t                nelmts;
     size_t                 type_size;
@@ -1983,8 +1910,10 @@ H5D__struct_chunk_encode_in_place(H5D_t *dset, size_t *write_size /*out*/, bool 
     assert(dset);
 
     pline = &(dset->shared->dcpl_cache.pline);
-    if (pline && pline->nused)
+    if (pline && pline->tot_filt_nsects)
         filtered = true;
+
+    /* Determine size of selection dataspace */
 
     /* Determine size of selection dataspace */
     if (H5S_encode(chk->sel_space, &sel_p, &chk->sel_nbytes) < 0)
@@ -2023,6 +1952,8 @@ H5D__struct_chunk_encode_in_place(H5D_t *dset, size_t *write_size /*out*/, bool 
     if (filtered) {
         H5Z_EDC_t err_detect; /* Error detection info */
         H5Z_cb_t  filter_cb;  /* I/O filter callback function */
+        unsigned i;
+        H5Z_stc_filter_sect_t *filt_sect;
 
         udata->unfilt_size[0] = chk->sel_nbytes;
         udata->unfilt_size[1] = chk->data_nbytes;
@@ -2030,16 +1961,34 @@ H5D__struct_chunk_encode_in_place(H5D_t *dset, size_t *write_size /*out*/, bool 
         /* Retrieve filter settings from API context */
         if (H5CX_get_err_detect(&err_detect) < 0)
             HGOTO_ERROR(H5E_DATASET, H5E_CANTGET, FAIL, "can't get error detection info");
-        if (H5CX_get_filter_cb(&filter_cb) < 0)
+         if (H5CX_get_filter_cb(&filter_cb) < 0)
             HGOTO_ERROR(H5E_DATASET, H5E_CANTGET, FAIL, "can't get I/O filter callback function");
 
-        /* Compress ds and data */
-        if (H5Z_pipeline(pline, 0, &(udata->filt_mask[0]), err_detect, filter_cb, &chk->sel_nbytes,
-                         &chk->sel_alloc_size, &chk->sel_buf) < 0)
-            HGOTO_ERROR(H5E_DATASET, H5E_CANTFILTER, FAIL, "output pipeline failed");
-        if (H5Z_pipeline(pline, 0, &(udata->filt_mask[1]), err_detect, filter_cb, &chk->data_nbytes,
-                         &chk->data_alloc_size, &chk->data_buf) < 0)
-            HGOTO_ERROR(H5E_DATASET, H5E_CANTFILTER, FAIL, "output pipeline failed");
+        for (i = 0, filt_sect = &pline->filt_sects[0]; i < pline->tot_filt_nsects; i++, filt_sect++) {
+    
+            if (filt_sect->nused) {
+                switch(filt_sect->seq_sect) {
+                    case H5_SECTION_SELECTION:
+                        if (H5Z_apply_filters(filt_sect->nused, filt_sect->filter, 0, &udata->filt_mask[0], 
+                                               err_detect, filter_cb, &chk->sel_nbytes, &chk->sel_alloc_size, &chk->sel_buf) < 0)
+                            HGOTO_ERROR(H5E_DATASET, H5E_CANTFILTER, FAIL, "output pipeline failed");
+                        break;
+
+                    case H5_SECTION_FIXED:
+                        if (H5Z_apply_filters(filt_sect->nused, filt_sect->filter, 0, &udata->filt_mask[1], 
+                                               err_detect, filter_cb, &chk->data_nbytes, &chk->data_alloc_size, &chk->data_buf) < 0)
+                            HGOTO_ERROR(H5E_DATASET, H5E_CANTFILTER, FAIL, "output pipeline failed");
+                        break;
+
+                    case H5_SECTION_VL:
+                    case H5_SECTION_NUM:
+                    default:
+                        assert(0 && "Unknown action?!?");
+                }
+            } /* end if nused */
+    
+        } /* end for */
+
     }
 
     /* Realloc chk->data_buf to provide space for encoded selection and data */
@@ -2086,7 +2035,6 @@ static herr_t
 H5D__struct_chunk_evict(H5D_t *dset, void *chunk, void *udata)
 {
     H5D_chunk_cache_mem_t *chk = (H5D_chunk_cache_mem_t *)chunk; /* Chunk memory cache info */
-    H5O_pline_t           *pline;                                /* I/O pipeline info */
     herr_t                 ret_value = SUCCEED;                  /* Return value */
 
     FUNC_ENTER_PACKAGE
@@ -2276,7 +2224,7 @@ H5D__struct_chunk_vector_read(H5D_t *dset, haddr_t addr, const H5S_t *file_space
     }
 
     pline = &(dset->shared->dcpl_cache.pline);
-    if (pline && pline->nused) {
+    if (pline && pline->tot_filt_nsects) {
         *vector_possible = false;
         HGOTO_DONE(SUCCEED);
     }
@@ -2470,7 +2418,7 @@ H5D__struct_chunk_vector_write(H5D_t *dset, haddr_t addr, const H5S_t *file_spac
     }
 
     pline = &(dset->shared->dcpl_cache.pline);
-    if (pline && pline->nused) {
+    if (pline && pline->tot_filt_nsects) {
         *vector_possible = false;
         HGOTO_DONE(SUCCEED);
     }
@@ -3600,14 +3548,11 @@ H5D__struct_chunk_evict_values(H5D_t *dset, size_t *nbytes /*in,out*/, size_t *a
                                void *chunk, void H5_ATTR_UNUSED *udata)
 {
     H5D_chunk_cache_mem_t *chk = (H5D_chunk_cache_mem_t *)chunk; /* Chunk memory cache info */
-    H5O_pline_t           *pline;                                /* I/O pipeline info */
 
     FUNC_ENTER_PACKAGE_NOERR
 
     /* Sanity check */
     assert(dset);
-
-    pline = &(dset->shared->dcpl_cache.pline);
 
     chk->data_buf = H5MM_xfree(chk->data_buf);
 
@@ -3643,12 +3588,15 @@ static herr_t
 H5D__struct_chunk_layout_query(H5D_t *dset, hsize_t *chunk_dims, bool *encode_decode_necessary,
                                bool *partial_bound_chunks_different_encoding)
 {
+    H5O_pline_t            *pline; /* I/O pipeline info */
     herr_t ret_value = SUCCEED; /* Return value		*/
 
     FUNC_ENTER_PACKAGE
 
     /* Sanity check */
     assert(dset);
+
+    pline = &(dset->shared->dcpl_cache.pline);
 
     /* Check for invalid chunk dimension rank */
     if (0 == dset->shared->layout.u.struct_chunk.ndims)
@@ -3670,7 +3618,7 @@ H5D__struct_chunk_layout_query(H5D_t *dset, hsize_t *chunk_dims, bool *encode_de
 
     if (partial_bound_chunks_different_encoding) {
         *partial_bound_chunks_different_encoding = false;
-        if (dset->shared->dcpl_cache.pline.nused > 0) {
+        if (pline && pline->tot_filt_nsects > 0) {
             if (dset->shared->layout.u.struct_chunk.flags & H5O_LAYOUT_CHUNK_DONT_FILTER_PARTIAL_BOUND_CHUNKS)
                 *partial_bound_chunks_different_encoding = true;
         }

--- a/src/H5Opline.c
+++ b/src/H5Opline.c
@@ -109,11 +109,11 @@ static void *
 H5O__pline_decode(H5F_t H5_ATTR_UNUSED *f, H5O_t H5_ATTR_UNUSED *open_oh, unsigned H5_ATTR_UNUSED mesg_flags,
                   unsigned H5_ATTR_UNUSED *ioflags, size_t p_size, const uint8_t *p)
 {
-    H5O_pline_t       *pline = NULL;               /* Pipeline message */
-    size_t             name_length;                /* Length of filter name */
-    size_t             i, j, k;                    /* Local index variable */
-    const uint8_t     *p_end     = p + p_size - 1; /* End of the p buffer */
-    void              *ret_value = NULL;
+    H5O_pline_t   *pline = NULL;               /* Pipeline message */
+    size_t         name_length;                /* Length of filter name */
+    size_t         i, j, k;                    /* Local index variable */
+    const uint8_t *p_end     = p + p_size - 1; /* End of the p buffer */
+    void          *ret_value = NULL;
 
     FUNC_ENTER_PACKAGE
 
@@ -133,7 +133,7 @@ H5O__pline_decode(H5F_t H5_ATTR_UNUSED *f, H5O_t H5_ATTR_UNUSED *open_oh, unsign
         HGOTO_ERROR(H5E_PLINE, H5E_CANTLOAD, NULL, "bad version number for filter pipeline message");
 
     if (pline->version <= H5O_PLINE_VERSION_2) {
-        H5Z_filter_info_t *filter;                     /* Filter to decode */
+        H5Z_filter_info_t *filter; /* Filter to decode */
 
         /* Number of filters */
         if (H5_IS_BUFFER_OVERFLOW(p, 1, p_end))
@@ -158,7 +158,8 @@ H5O__pline_decode(H5F_t H5_ATTR_UNUSED *f, H5O_t H5_ATTR_UNUSED *open_oh, unsign
 
         /* Allocate array for filters */
         pline->nalloc = pline->nused;
-        if (NULL == (pline->filter = (H5Z_filter_info_t *)H5MM_calloc(pline->nalloc * sizeof(pline->filter[0]))))
+        if (NULL ==
+            (pline->filter = (H5Z_filter_info_t *)H5MM_calloc(pline->nalloc * sizeof(pline->filter[0]))))
             HGOTO_ERROR(H5E_RESOURCE, H5E_NOSPACE, NULL, "memory allocation failed");
 
         /* Decode filters */
@@ -176,7 +177,8 @@ H5O__pline_decode(H5F_t H5_ATTR_UNUSED *f, H5O_t H5_ATTR_UNUSED *open_oh, unsign
                     HGOTO_ERROR(H5E_OHDR, H5E_OVERFLOW, NULL, "ran off end of input buffer while decoding");
                 UINT16DECODE(p, name_length);
                 if (pline->version == H5O_PLINE_VERSION_1 && name_length % 8)
-                    HGOTO_ERROR(H5E_PLINE, H5E_CANTLOAD, NULL, "filter name length is not a multiple of eight");
+                    HGOTO_ERROR(H5E_PLINE, H5E_CANTLOAD, NULL,
+                                "filter name length is not a multiple of eight");
             }
 
             /* Filter flags */
@@ -204,7 +206,8 @@ H5O__pline_decode(H5F_t H5_ATTR_UNUSED *f, H5O_t H5_ATTR_UNUSED *open_oh, unsign
                 if (actual_name_length > H5Z_COMMON_NAME_LEN) {
                     filter->name = (char *)H5MM_malloc(actual_name_length);
                     if (NULL == filter->name)
-                        HGOTO_ERROR(H5E_RESOURCE, H5E_NOSPACE, NULL, "memory allocation failed for filter name");
+                        HGOTO_ERROR(H5E_RESOURCE, H5E_NOSPACE, NULL,
+                                    "memory allocation failed for filter name");
                 }
                 else
                     filter->name = filter->_name;
@@ -223,7 +226,8 @@ H5O__pline_decode(H5F_t H5_ATTR_UNUSED *f, H5O_t H5_ATTR_UNUSED *open_oh, unsign
                 if (filter->cd_nelmts > H5Z_COMMON_CD_VALUES) {
                     filter->cd_values = (unsigned *)H5MM_malloc(filter->cd_nelmts * sizeof(unsigned));
                     if (NULL == filter->cd_values)
-                        HGOTO_ERROR(H5E_RESOURCE, H5E_NOSPACE, NULL, "memory allocation failed for client data");
+                        HGOTO_ERROR(H5E_RESOURCE, H5E_NOSPACE, NULL,
+                                    "memory allocation failed for client data");
                 }
                 else
                     filter->cd_values = filter->_cd_values;
@@ -231,7 +235,8 @@ H5O__pline_decode(H5F_t H5_ATTR_UNUSED *f, H5O_t H5_ATTR_UNUSED *open_oh, unsign
                 /* Read the client data values and the padding */
                 for (j = 0; j < filter->cd_nelmts; j++) {
                     if (H5_IS_BUFFER_OVERFLOW(p, 4, p_end))
-                        HGOTO_ERROR(H5E_OHDR, H5E_OVERFLOW, NULL, "ran off end of input buffer while decoding");
+                        HGOTO_ERROR(H5E_OHDR, H5E_OVERFLOW, NULL,
+                                    "ran off end of input buffer while decoding");
                     UINT32DECODE(p, filter->cd_values[j]);
                 }
 
@@ -244,10 +249,10 @@ H5O__pline_decode(H5F_t H5_ATTR_UNUSED *f, H5O_t H5_ATTR_UNUSED *open_oh, unsign
                     }
             }
         }
-
-    } else if (pline->version == H5O_PLINE_VERSION_3) {
+    }
+    else if (pline->version == H5O_PLINE_VERSION_3) {
         H5Z_stc_filter_sect_t *filt_sect;
-        H5Z_filter_info_t *filter;
+        H5Z_filter_info_t     *filter;
 
         /* Total number of filtered sections in the structured chunk */
         if (H5_IS_BUFFER_OVERFLOW(p, 1, p_end))
@@ -255,7 +260,8 @@ H5O__pline_decode(H5F_t H5_ATTR_UNUSED *f, H5O_t H5_ATTR_UNUSED *open_oh, unsign
         pline->tot_filt_nsects = *p++;
 
         if (pline->tot_filt_nsects > H5O_MAX_STC_NSECTS)
-            HGOTO_ERROR(H5E_PLINE, H5E_CANTLOAD, NULL, "filter pipeline message has too many filtered sections");
+            HGOTO_ERROR(H5E_PLINE, H5E_CANTLOAD, NULL,
+                        "filter pipeline message has too many filtered sections");
 
         /* Decode array of filtered sections */
         for (i = 0, filt_sect = &pline->filt_sects[0]; i < pline->tot_filt_nsects; i++, filt_sect++) {
@@ -285,7 +291,8 @@ H5O__pline_decode(H5F_t H5_ATTR_UNUSED *f, H5O_t H5_ATTR_UNUSED *open_oh, unsign
 
             /* Allocate array of filter decription for the ith filtered section */
             filt_sect->nalloc = filt_sect->nused;
-            if (NULL == (filt_sect->filter = (H5Z_filter_info_t *)H5MM_calloc(filt_sect->nalloc * sizeof(filt_sect->filter[0]))))
+            if (NULL == (filt_sect->filter = (H5Z_filter_info_t *)H5MM_calloc(filt_sect->nalloc *
+                                                                              sizeof(filt_sect->filter[0]))))
                 HGOTO_ERROR(H5E_RESOURCE, H5E_NOSPACE, NULL, "memory allocation failed");
 
             /* Decode array of filter description */
@@ -300,7 +307,8 @@ H5O__pline_decode(H5F_t H5_ATTR_UNUSED *f, H5O_t H5_ATTR_UNUSED *open_oh, unsign
                     name_length = 0;
                 else {
                     if (H5_IS_BUFFER_OVERFLOW(p, 2, p_end))
-                        HGOTO_ERROR(H5E_OHDR, H5E_OVERFLOW, NULL, "ran off end of input buffer while decoding");
+                        HGOTO_ERROR(H5E_OHDR, H5E_OVERFLOW, NULL,
+                                    "ran off end of input buffer while decoding");
                     UINT16DECODE(p, name_length);
                 }
 
@@ -329,7 +337,8 @@ H5O__pline_decode(H5F_t H5_ATTR_UNUSED *f, H5O_t H5_ATTR_UNUSED *open_oh, unsign
                     if (actual_name_length > H5Z_COMMON_NAME_LEN) {
                         filter->name = (char *)H5MM_malloc(actual_name_length);
                         if (NULL == filter->name)
-                            HGOTO_ERROR(H5E_RESOURCE, H5E_NOSPACE, NULL, "memory allocation failed for filter name");
+                            HGOTO_ERROR(H5E_RESOURCE, H5E_NOSPACE, NULL,
+                                        "memory allocation failed for filter name");
                     }
                     else
                         filter->name = filter->_name;
@@ -337,7 +346,8 @@ H5O__pline_decode(H5F_t H5_ATTR_UNUSED *f, H5O_t H5_ATTR_UNUSED *open_oh, unsign
                     strncpy(filter->name, (const char *)p, actual_name_length);
 
                     if (H5_IS_BUFFER_OVERFLOW(p, name_length, p_end))
-                        HGOTO_ERROR(H5E_OHDR, H5E_OVERFLOW, NULL, "ran off end of input buffer while decoding");
+                        HGOTO_ERROR(H5E_OHDR, H5E_OVERFLOW, NULL,
+                                    "ran off end of input buffer while decoding");
                     p += name_length;
                 }
 
@@ -348,7 +358,8 @@ H5O__pline_decode(H5F_t H5_ATTR_UNUSED *f, H5O_t H5_ATTR_UNUSED *open_oh, unsign
                     if (filter->cd_nelmts > H5Z_COMMON_CD_VALUES) {
                         filter->cd_values = (unsigned *)H5MM_malloc(filter->cd_nelmts * sizeof(unsigned));
                         if (NULL == filter->cd_values)
-                            HGOTO_ERROR(H5E_RESOURCE, H5E_NOSPACE, NULL, "memory allocation failed for client data");
+                            HGOTO_ERROR(H5E_RESOURCE, H5E_NOSPACE, NULL,
+                                        "memory allocation failed for client data");
                     }
                     else
                         filter->cd_values = filter->_cd_values;
@@ -356,10 +367,10 @@ H5O__pline_decode(H5F_t H5_ATTR_UNUSED *f, H5O_t H5_ATTR_UNUSED *open_oh, unsign
                     /* Read the client data values and the padding */
                     for (k = 0; k < filter->cd_nelmts; k++) {
                         if (H5_IS_BUFFER_OVERFLOW(p, 4, p_end))
-                            HGOTO_ERROR(H5E_OHDR, H5E_OVERFLOW, NULL, "ran off end of input buffer while decoding");
+                            HGOTO_ERROR(H5E_OHDR, H5E_OVERFLOW, NULL,
+                                        "ran off end of input buffer while decoding");
                         UINT32DECODE(p, filter->cd_values[k]);
                     }
-
                 }
 
             } /* end of array for filgter decription */
@@ -392,8 +403,8 @@ done:
 static herr_t
 H5O__pline_encode(H5F_t H5_ATTR_UNUSED *f, uint8_t *p /*out*/, const void *mesg)
 {
-    const H5O_pline_t       *pline = (const H5O_pline_t *)mesg; /* Pipeline message to encode */
-    size_t                   i, j, k;                            /* Local index variables */
+    const H5O_pline_t *pline = (const H5O_pline_t *)mesg; /* Pipeline message to encode */
+    size_t             i, j, k;                           /* Local index variables */
 
     FUNC_ENTER_PACKAGE_NOERR
 
@@ -405,7 +416,7 @@ H5O__pline_encode(H5F_t H5_ATTR_UNUSED *f, uint8_t *p /*out*/, const void *mesg)
     *p++ = (uint8_t)pline->version;
 
     if (pline->version <= H5O_PLINE_VERSION_2) {
-        const H5Z_filter_info_t *filter;                            /* Filter to encode */
+        const H5Z_filter_info_t *filter; /* Filter to encode */
 
         *p++ = (uint8_t)(pline->nused);
         if (pline->version == H5O_PLINE_VERSION_1) {
@@ -446,7 +457,8 @@ H5O__pline_encode(H5F_t H5_ATTR_UNUSED *f, uint8_t *p /*out*/, const void *mesg)
                 name_length = name ? strlen(name) + 1 : 0;
 
                 /* Filter name length */
-                UINT16ENCODE(p, pline->version == H5O_PLINE_VERSION_1 ? H5O_ALIGN_OLD(name_length) : name_length);
+                UINT16ENCODE(p, pline->version == H5O_PLINE_VERSION_1 ? H5O_ALIGN_OLD(name_length)
+                                                                      : name_length);
             } /* end else */
 
             /* Filter flags */
@@ -476,16 +488,15 @@ H5O__pline_encode(H5F_t H5_ATTR_UNUSED *f, uint8_t *p /*out*/, const void *mesg)
                 if (filter->cd_nelmts % 2)
                     UINT32ENCODE(p, 0);
         } /* end for */
-
-    } else if (pline->version == H5O_PLINE_VERSION_3) {
+    }
+    else if (pline->version == H5O_PLINE_VERSION_3) {
 
         *p++ = (uint8_t)pline->tot_filt_nsects;
 
         for (i = 0; i < pline->tot_filt_nsects; i++) {
-            const H5Z_filter_info_t *filter;                            /* Filter to encode */
-            size_t size_filt_descr = 0;
-            uint8_t *save_p;
-
+            const H5Z_filter_info_t *filter; /* Filter to encode */
+            size_t                   size_filt_descr = 0;
+            uint8_t                 *save_p;
 
             *p++ = (uint8_t)(pline->filt_sects[i].seq_sect);
             *p++ = (uint8_t)(pline->filt_sects[i].nused);
@@ -495,7 +506,8 @@ H5O__pline_encode(H5F_t H5_ATTR_UNUSED *f, uint8_t *p /*out*/, const void *mesg)
             save_p = p;
             p += 2;
 
-            for (j = 0, filter = &pline->filt_sects[i].filter[0]; j < pline->filt_sects[i].nused; j++, filter++) {
+            for (j = 0, filter = &pline->filt_sects[i].filter[0]; j < pline->filt_sects[i].nused;
+                 j++, filter++) {
                 const char *name;        /* Filter name */
                 size_t      name_length; /* Length of filter name */
 
@@ -543,14 +555,14 @@ H5O__pline_encode(H5F_t H5_ATTR_UNUSED *f, uint8_t *p /*out*/, const void *mesg)
                 /* Filter parameters */
                 for (k = 0; k < filter->cd_nelmts; k++)
                     UINT32ENCODE(p, filter->cd_values[k]);
-                
-                size_filt_descr += 2 +                      /* filter identification number */
+
+                size_filt_descr += 2 + /* filter identification number */
                                    (size_t)((filter->id >= H5Z_FILTER_RESERVED) ? 2 : 0) + /* name length */
-                                   2 +                      /* flags */
-                                   2 +                      /* number of client data values    */
-                                   name_length +            /* length of the filter name    */
-                                   filter->cd_nelmts * 4;   /* Client data values */
-                
+                                   2 +                                                     /* flags */
+                                   2 +                    /* number of client data values    */
+                                   name_length +          /* length of the filter name    */
+                                   filter->cd_nelmts * 4; /* Client data values */
+
             } /* end for */
 
             UINT16ENCODE(save_p, size_filt_descr);
@@ -560,7 +572,6 @@ H5O__pline_encode(H5F_t H5_ATTR_UNUSED *f, uint8_t *p /*out*/, const void *mesg)
     FUNC_LEAVE_NOAPI(SUCCEED)
 
 } /* end H5O__pline_encode() */
-
 
 /*-------------------------------------------------------------------------
  * Function:    H5O__pline_copy
@@ -598,7 +609,8 @@ H5O__pline_copy(const void *_src, void *_dst /*out*/)
         dst->nalloc = dst->nused;
         if (dst->nalloc) {
             /* Allocate array to hold filters */
-            if (NULL == (dst->filter = (H5Z_filter_info_t *)H5MM_calloc(dst->nalloc * sizeof(dst->filter[0]))))
+            if (NULL ==
+                (dst->filter = (H5Z_filter_info_t *)H5MM_calloc(dst->nalloc * sizeof(dst->filter[0]))))
                 HGOTO_ERROR(H5E_RESOURCE, H5E_NOSPACE, NULL, "memory allocation failed");
 
             /* Deep-copy filters */
@@ -627,8 +639,8 @@ H5O__pline_copy(const void *_src, void *_dst /*out*/)
                 if (src->filter[i].cd_nelmts > 0) {
                     /* Allocate space for the client data elements, or use the internal buffer */
                     if (src->filter[i].cd_nelmts > H5Z_COMMON_CD_VALUES) {
-                        if (NULL == (dst->filter[i].cd_values =
-                                        (unsigned *)H5MM_malloc(src->filter[i].cd_nelmts * sizeof(unsigned))))
+                        if (NULL == (dst->filter[i].cd_values = (unsigned *)H5MM_malloc(
+                                         src->filter[i].cd_nelmts * sizeof(unsigned))))
                             HGOTO_ERROR(H5E_RESOURCE, H5E_NOSPACE, NULL, "memory allocation failed");
 
                         H5MM_memcpy(dst->filter[i].cd_values, src->filter[i].cd_values,
@@ -641,23 +653,24 @@ H5O__pline_copy(const void *_src, void *_dst /*out*/)
         }         /* end if */
         else
             dst->filter = NULL;
-
-    } else if (src->version == H5O_PLINE_VERSION_3) {
+    }
+    else if (src->version == H5O_PLINE_VERSION_3) {
         const H5Z_stc_filter_sect_t *src_filt_sect;
-        H5Z_stc_filter_sect_t *dst_filt_sect;
+        H5Z_stc_filter_sect_t       *dst_filt_sect;
 
         if (src->tot_filt_nsects) {
-             for (i = 0, src_filt_sect = &src->filt_sects[0], dst_filt_sect = &dst->filt_sects[0]; 
-                  i < src->tot_filt_nsects; i++, src_filt_sect++, dst_filt_sect++) {
+            for (i = 0, src_filt_sect = &src->filt_sects[0], dst_filt_sect = &dst->filt_sects[0];
+                 i < src->tot_filt_nsects; i++, src_filt_sect++, dst_filt_sect++) {
 
                 /* Copy over filters, if any */
                 dst_filt_sect->nalloc = dst_filt_sect->nused;
                 if (dst_filt_sect->nalloc) {
 
                     /* Allocate array to hold filters */
-                    if (NULL == (dst_filt_sect->filter = (H5Z_filter_info_t *)H5MM_calloc(dst_filt_sect->nalloc * sizeof(dst_filt_sect->filter[0]))))
+                    if (NULL == (dst_filt_sect->filter = (H5Z_filter_info_t *)H5MM_calloc(
+                                     dst_filt_sect->nalloc * sizeof(dst_filt_sect->filter[0]))))
                         HGOTO_ERROR(H5E_RESOURCE, H5E_NOSPACE, NULL, "memory allocation failed");
-                    
+
                     for (i = 0; i < src_filt_sect->nused; i++) {
                         /* Basic filter information */
                         dst_filt_sect->filter[i] = src_filt_sect->filter[i];
@@ -670,9 +683,11 @@ H5O__pline_copy(const void *_src, void *_dst /*out*/)
 
                             /* Allocate space for the filter name, or use the internal buffer */
                             if (namelen > H5Z_COMMON_NAME_LEN) {
-                                dst_filt_sect->filter[i].name = (char *)H5MM_strdup(src_filt_sect->filter[i].name);
+                                dst_filt_sect->filter[i].name =
+                                    (char *)H5MM_strdup(src_filt_sect->filter[i].name);
                                 if (NULL == dst_filt_sect->filter[i].name)
-                                    HGOTO_ERROR(H5E_RESOURCE, H5E_NOSPACE, NULL, "memory allocation failed for filter name");
+                                    HGOTO_ERROR(H5E_RESOURCE, H5E_NOSPACE, NULL,
+                                                "memory allocation failed for filter name");
                             } /* end if */
                             else
                                 dst_filt_sect->filter[i].name = dst_filt_sect->filter[i]._name;
@@ -682,11 +697,12 @@ H5O__pline_copy(const void *_src, void *_dst /*out*/)
                         if (src_filt_sect->filter[i].cd_nelmts > 0) {
                             /* Allocate space for the client data elements, or use the internal buffer */
                             if (src_filt_sect->filter[i].cd_nelmts > H5Z_COMMON_CD_VALUES) {
-                                if (NULL == (dst_filt_sect->filter[i].cd_values =
-                                                (unsigned *)H5MM_malloc(src_filt_sect->filter[i].cd_nelmts * sizeof(unsigned))))
+                                if (NULL == (dst_filt_sect->filter[i].cd_values = (unsigned *)H5MM_malloc(
+                                                 src_filt_sect->filter[i].cd_nelmts * sizeof(unsigned))))
                                     HGOTO_ERROR(H5E_RESOURCE, H5E_NOSPACE, NULL, "memory allocation failed");
 
-                                H5MM_memcpy(dst_filt_sect->filter[i].cd_values, src_filt_sect->filter[i].cd_values,
+                                H5MM_memcpy(dst_filt_sect->filter[i].cd_values,
+                                            src_filt_sect->filter[i].cd_values,
                                             src_filt_sect->filter[i].cd_nelmts * sizeof(unsigned));
                             } /* end if */
                             else
@@ -766,8 +782,8 @@ H5O__pline_size(const H5F_t H5_ATTR_UNUSED *f, const void *mesg)
             ret_value +=
                 2 + /*filter identification number    */
                 (size_t)((pline->version == H5O_PLINE_VERSION_1 || pline->filter[i].id >= H5Z_FILTER_RESERVED)
-                            ? 2
-                            : 0) + /*name length            */
+                             ? 2
+                             : 0) + /*name length            */
                 2 +                 /*flags                */
                 2 +                 /*number of client data values    */
                 (pline->version == H5O_PLINE_VERSION_1 ? (size_t)H5O_ALIGN_OLD(name_len)
@@ -778,18 +794,18 @@ H5O__pline_size(const H5F_t H5_ATTR_UNUSED *f, const void *mesg)
                 if (pline->filter[i].cd_nelmts % 2)
                     ret_value += 4;
         } /* end for */
-
-    } else if (pline->version == H5O_PLINE_VERSION_3) {
+    }
+    else if (pline->version == H5O_PLINE_VERSION_3) {
         const H5Z_stc_filter_sect_t *filt_sect;
 
         /* Message header */
-        ret_value = (size_t)(1 +        /*version            */
-                             1);        /*number of filtered sections */
+        ret_value = (size_t)(1 + /*version            */
+                             1); /*number of filtered sections */
 
         for (i = 0, filt_sect = &pline->filt_sects[0]; i < pline->tot_filt_nsects; i++, filt_sect++) {
-            ret_value += (1 +           /* Sequence number of the ith filtered section */
-                          1 +           /* Number of filters for the ith filtered section */
-                          2);           /* Size of the ith filtered description list */
+            ret_value += (1 + /* Sequence number of the ith filtered section */
+                          1 + /* Number of filters for the ith filtered section */
+                          2); /* Size of the ith filtered description list */
 
             /* Calculate size of each filter in pipeline for each filtered section */
             for (j = 0; j < filt_sect->nused; j++) {
@@ -813,16 +829,14 @@ H5O__pline_size(const H5F_t H5_ATTR_UNUSED *f, const void *mesg)
 
                 ret_value +=
                     2 + /*filter identification number    */
-                    (size_t)((filt_sect->filter[j].id >= H5Z_FILTER_RESERVED)
-                                ? 2
-                                : 0) +  /*name length            */
-                    2 +                 /*flags                */
-                    2 +                 /*number of client data values    */
-                    name_len;           /*length of the filter name    */
+                    (size_t)((filt_sect->filter[j].id >= H5Z_FILTER_RESERVED) ? 2 : 0) + /*name length */
+                    2 +       /*flags                */
+                    2 +       /*number of client data values    */
+                    name_len; /*length of the filter name    */
 
                 ret_value += filt_sect->filter[j].cd_nelmts * 4;
             } /* end for */
-        } /* end for */
+        }     /* end for */
     }
 
     FUNC_LEAVE_NOAPI(ret_value)
@@ -876,8 +890,8 @@ H5O__pline_reset(void *mesg)
 
         /* Reset version # of pipeline message */
         pline->version = H5O_PLINE_VERSION_1;
-
-    } else if (pline->version == H5O_PLINE_VERSION_3) {
+    }
+    else if (pline->version == H5O_PLINE_VERSION_3) {
         H5Z_stc_filter_sect_t *filt_sect;
 
         for (i = 0, filt_sect = &pline->filt_sects[0]; i < pline->tot_filt_nsects; i++, filt_sect++) {
@@ -889,10 +903,12 @@ H5O__pline_reset(void *mesg)
                     if (filt_sect->filter[j].name != filt_sect->filter[j]._name)
                         filt_sect->filter[j].name = (char *)H5MM_xfree(filt_sect->filter[j].name);
 
-                    if (filt_sect->filter[j].cd_values && filt_sect->filter[j].cd_values != filt_sect->filter[j]._cd_values)
+                    if (filt_sect->filter[j].cd_values &&
+                        filt_sect->filter[j].cd_values != filt_sect->filter[j]._cd_values)
                         assert(filt_sect->filter[j].cd_nelmts > H5Z_COMMON_CD_VALUES);
                     if (filt_sect->filter[j].cd_values != filt_sect->filter[j]._cd_values)
-                        filt_sect->filter[j].cd_values = (unsigned *)H5MM_xfree(filt_sect->filter[j].cd_values);
+                        filt_sect->filter[j].cd_values =
+                            (unsigned *)H5MM_xfree(filt_sect->filter[j].cd_values);
                 } /* end for */
 
                 /* Free filter array for the section */
@@ -900,7 +916,7 @@ H5O__pline_reset(void *mesg)
             }
             filt_sect->nused = filt_sect->nalloc = 0;
 
-       } /* end for */
+        } /* end for */
     }
 
     FUNC_LEAVE_NOAPI(SUCCEED)
@@ -1016,7 +1032,7 @@ H5O__pline_debug(H5F_t H5_ATTR_UNUSED *f, const void *mesg, FILE *stream, int in
                     "Filter identification:", (unsigned)(pline->filter[i].id));
             if (pline->filter[i].name)
                 fprintf(stream, "%*s%-*s \"%s\"\n", indent + 3, "", MAX(0, fwidth - 3),
-                    "Filter name:", pline->filter[i].name);
+                        "Filter name:", pline->filter[i].name);
             else
                 fprintf(stream, "%*s%-*s NONE\n", indent + 3, "", MAX(0, fwidth - 3), "Filter name:");
             fprintf(stream, "%*s%-*s 0x%04x\n", indent + 3, "", MAX(0, fwidth - 3),
@@ -1030,18 +1046,20 @@ H5O__pline_debug(H5F_t H5_ATTR_UNUSED *f, const void *mesg, FILE *stream, int in
 
                 snprintf(field_name, sizeof(field_name), "CD value %lu", (unsigned long)j);
                 fprintf(stream, "%*s%-*s %u\n", indent + 6, "", MAX(0, fwidth - 6), field_name,
-                    pline->filter[i].cd_values[j]);
+                        pline->filter[i].cd_values[j]);
             }
         }
-
-    } else if (pline->version == H5O_PLINE_VERSION_3) {
+    }
+    else if (pline->version == H5O_PLINE_VERSION_3) {
         const H5Z_stc_filter_sect_t *filt_sect;
-        size_t i, j, k;
+        size_t                       i, j, k;
 
         for (i = 0, filt_sect = &pline->filt_sects[0]; i < pline->tot_filt_nsects; i++, filt_sect++) {
-            fprintf(stream, "%*s%-*s %zu\n", indent, "", fwidth, "Sequence # of filtered section:", filt_sect->seq_sect);
+            fprintf(stream, "%*s%-*s %zu\n", indent, "", fwidth,
+                    "Sequence # of filtered section:", filt_sect->seq_sect);
 
-            fprintf(stream, "%*s%-*s %zu/%zu\n", indent, "", fwidth, "Number of filters:", filt_sect->nused, filt_sect->nalloc);
+            fprintf(stream, "%*s%-*s %zu/%zu\n", indent, "", fwidth, "Number of filters:", filt_sect->nused,
+                    filt_sect->nalloc);
 
             /* Loop over all the filters */
             for (j = 0; j < filt_sect->nused; j++) {
@@ -1063,7 +1081,7 @@ H5O__pline_debug(H5F_t H5_ATTR_UNUSED *f, const void *mesg, FILE *stream, int in
                     fprintf(stream, "%*s%-*s NONE\n", indent + 3, "", MAX(0, fwidth - 3), "Filter name:");
 
                 fprintf(stream, "%*s%-*s 0x%04x\n", indent + 3, "", MAX(0, fwidth - 3),
-                    "Flags:", filt_sect->filter[i].flags);
+                        "Flags:", filt_sect->filter[i].flags);
 
                 fprintf(stream, "%*s%-*s %zu\n", indent + 3, "", MAX(0, fwidth - 3),
                         "Num CD values:", filt_sect->filter[j].cd_nelmts);
@@ -1076,8 +1094,8 @@ H5O__pline_debug(H5F_t H5_ATTR_UNUSED *f, const void *mesg, FILE *stream, int in
                     fprintf(stream, "%*s%-*s %u\n", indent + 6, "", MAX(0, fwidth - 6), field_name,
                             filt_sect->filter[j].cd_values[k]);
                 } /* for k */
-            } /* for j */
-        } /* for i */
+            }     /* for j */
+        }         /* for i */
 
     } /* if version 3 */
 

--- a/src/H5Opline.c
+++ b/src/H5Opline.c
@@ -110,9 +110,8 @@ H5O__pline_decode(H5F_t H5_ATTR_UNUSED *f, H5O_t H5_ATTR_UNUSED *open_oh, unsign
                   unsigned H5_ATTR_UNUSED *ioflags, size_t p_size, const uint8_t *p)
 {
     H5O_pline_t       *pline = NULL;               /* Pipeline message */
-    H5Z_filter_info_t *filter;                     /* Filter to decode */
     size_t             name_length;                /* Length of filter name */
-    size_t             i;                          /* Local index variable */
+    size_t             i, j, k;                    /* Local index variable */
     const uint8_t     *p_end     = p + p_size - 1; /* End of the p buffer */
     void              *ret_value = NULL;
 
@@ -129,118 +128,245 @@ H5O__pline_decode(H5F_t H5_ATTR_UNUSED *f, H5O_t H5_ATTR_UNUSED *open_oh, unsign
     if (H5_IS_BUFFER_OVERFLOW(p, 1, p_end))
         HGOTO_ERROR(H5E_OHDR, H5E_OVERFLOW, NULL, "ran off end of input buffer while decoding");
     pline->version = *p++;
-    if (pline->version < H5O_PLINE_VERSION_1 || pline->version > H5O_PLINE_VERSION_LATEST)
+
+    if (pline->version < H5O_PLINE_VERSION_1 || pline->version > H5O_PLINE_VERSION_3)
         HGOTO_ERROR(H5E_PLINE, H5E_CANTLOAD, NULL, "bad version number for filter pipeline message");
 
-    /* Number of filters */
-    if (H5_IS_BUFFER_OVERFLOW(p, 1, p_end))
-        HGOTO_ERROR(H5E_OHDR, H5E_OVERFLOW, NULL, "ran off end of input buffer while decoding");
-    pline->nused = *p++;
-    if (pline->nused > H5Z_MAX_NFILTERS) {
+    if (pline->version <= H5O_PLINE_VERSION_2) {
+        H5Z_filter_info_t *filter;                     /* Filter to decode */
 
-        /* Reset the number of filters used to avoid array traversal in error
-         * handling code.
-         */
-        pline->nused = 0;
-
-        HGOTO_ERROR(H5E_PLINE, H5E_CANTLOAD, NULL, "filter pipeline message has too many filters");
-    }
-
-    /* Reserved */
-    if (pline->version == H5O_PLINE_VERSION_1) {
-        if (H5_IS_BUFFER_OVERFLOW(p, 6, p_end))
+        /* Number of filters */
+        if (H5_IS_BUFFER_OVERFLOW(p, 1, p_end))
             HGOTO_ERROR(H5E_OHDR, H5E_OVERFLOW, NULL, "ran off end of input buffer while decoding");
-        p += 6;
-    }
+        pline->nused = *p++;
+        if (pline->nused > H5Z_MAX_NFILTERS) {
 
-    /* Allocate array for filters */
-    pline->nalloc = pline->nused;
-    if (NULL == (pline->filter = (H5Z_filter_info_t *)H5MM_calloc(pline->nalloc * sizeof(pline->filter[0]))))
-        HGOTO_ERROR(H5E_RESOURCE, H5E_NOSPACE, NULL, "memory allocation failed");
+            /* Reset the number of filters used to avoid array traversal in error
+             * handling code.
+             */
+            pline->nused = 0;
 
-    /* Decode filters */
-    for (i = 0, filter = &pline->filter[0]; i < pline->nused; i++, filter++) {
-        /* Filter ID */
-        if (H5_IS_BUFFER_OVERFLOW(p, 2, p_end))
-            HGOTO_ERROR(H5E_OHDR, H5E_OVERFLOW, NULL, "ran off end of input buffer while decoding");
-        UINT16DECODE(p, filter->id);
+            HGOTO_ERROR(H5E_PLINE, H5E_CANTLOAD, NULL, "filter pipeline message has too many filters");
+        }
 
-        /* Length of filter name */
-        if (pline->version > H5O_PLINE_VERSION_1 && filter->id < H5Z_FILTER_RESERVED)
-            name_length = 0;
-        else {
+        /* Reserved */
+        if (pline->version == H5O_PLINE_VERSION_1) {
+            if (H5_IS_BUFFER_OVERFLOW(p, 6, p_end))
+                HGOTO_ERROR(H5E_OHDR, H5E_OVERFLOW, NULL, "ran off end of input buffer while decoding");
+            p += 6;
+        }
+
+        /* Allocate array for filters */
+        pline->nalloc = pline->nused;
+        if (NULL == (pline->filter = (H5Z_filter_info_t *)H5MM_calloc(pline->nalloc * sizeof(pline->filter[0]))))
+            HGOTO_ERROR(H5E_RESOURCE, H5E_NOSPACE, NULL, "memory allocation failed");
+
+        /* Decode filters */
+        for (i = 0, filter = &pline->filter[0]; i < pline->nused; i++, filter++) {
+            /* Filter ID */
             if (H5_IS_BUFFER_OVERFLOW(p, 2, p_end))
                 HGOTO_ERROR(H5E_OHDR, H5E_OVERFLOW, NULL, "ran off end of input buffer while decoding");
-            UINT16DECODE(p, name_length);
-            if (pline->version == H5O_PLINE_VERSION_1 && name_length % 8)
-                HGOTO_ERROR(H5E_PLINE, H5E_CANTLOAD, NULL, "filter name length is not a multiple of eight");
-        }
+            UINT16DECODE(p, filter->id);
 
-        /* Filter flags */
-        if (H5_IS_BUFFER_OVERFLOW(p, 2, p_end))
-            HGOTO_ERROR(H5E_OHDR, H5E_OVERFLOW, NULL, "ran off end of input buffer while decoding");
-        UINT16DECODE(p, filter->flags);
-
-        /* Number of filter parameters ("client data elements") */
-        if (H5_IS_BUFFER_OVERFLOW(p, 2, p_end))
-            HGOTO_ERROR(H5E_OHDR, H5E_OVERFLOW, NULL, "ran off end of input buffer while decoding");
-        UINT16DECODE(p, filter->cd_nelmts);
-
-        /* Filter name, if there is one */
-        if (name_length) {
-            size_t actual_name_length;            /* Actual length of name */
-            size_t max = (size_t)(p_end - p + 1); /* Max possible name length */
-
-            /* Determine actual name length (without padding, but with null terminator) */
-            actual_name_length = strnlen((const char *)p, max);
-            if (actual_name_length == max)
-                HGOTO_ERROR(H5E_OHDR, H5E_NOSPACE, NULL, "filter name not null terminated");
-            actual_name_length += 1; /* include \0 byte */
-
-            /* Allocate space for the filter name, or use the internal buffer */
-            if (actual_name_length > H5Z_COMMON_NAME_LEN) {
-                filter->name = (char *)H5MM_malloc(actual_name_length);
-                if (NULL == filter->name)
-                    HGOTO_ERROR(H5E_RESOURCE, H5E_NOSPACE, NULL, "memory allocation failed for filter name");
-            }
-            else
-                filter->name = filter->_name;
-
-            strncpy(filter->name, (const char *)p, actual_name_length);
-
-            if (H5_IS_BUFFER_OVERFLOW(p, name_length, p_end))
-                HGOTO_ERROR(H5E_OHDR, H5E_OVERFLOW, NULL, "ran off end of input buffer while decoding");
-            p += name_length;
-        }
-
-        /* Filter parameters */
-        if (filter->cd_nelmts) {
-
-            /* Allocate space for the client data elements, or use the internal buffer */
-            if (filter->cd_nelmts > H5Z_COMMON_CD_VALUES) {
-                filter->cd_values = (unsigned *)H5MM_malloc(filter->cd_nelmts * sizeof(unsigned));
-                if (NULL == filter->cd_values)
-                    HGOTO_ERROR(H5E_RESOURCE, H5E_NOSPACE, NULL, "memory allocation failed for client data");
-            }
-            else
-                filter->cd_values = filter->_cd_values;
-
-            /* Read the client data values and the padding */
-            for (size_t j = 0; j < filter->cd_nelmts; j++) {
-                if (H5_IS_BUFFER_OVERFLOW(p, 4, p_end))
+            /* Length of filter name */
+            if (pline->version > H5O_PLINE_VERSION_1 && filter->id < H5Z_FILTER_RESERVED)
+                name_length = 0;
+            else {
+                if (H5_IS_BUFFER_OVERFLOW(p, 2, p_end))
                     HGOTO_ERROR(H5E_OHDR, H5E_OVERFLOW, NULL, "ran off end of input buffer while decoding");
-                UINT32DECODE(p, filter->cd_values[j]);
+                UINT16DECODE(p, name_length);
+                if (pline->version == H5O_PLINE_VERSION_1 && name_length % 8)
+                    HGOTO_ERROR(H5E_PLINE, H5E_CANTLOAD, NULL, "filter name length is not a multiple of eight");
             }
 
-            if (pline->version == H5O_PLINE_VERSION_1)
-                if (filter->cd_nelmts % 2) {
-                    if (H5_IS_BUFFER_OVERFLOW(p, 4, p_end))
-                        HGOTO_ERROR(H5E_OHDR, H5E_OVERFLOW, NULL,
-                                    "ran off end of input buffer while decoding");
-                    p += 4; /* padding */
+            /* Filter flags */
+            if (H5_IS_BUFFER_OVERFLOW(p, 2, p_end))
+                HGOTO_ERROR(H5E_OHDR, H5E_OVERFLOW, NULL, "ran off end of input buffer while decoding");
+            UINT16DECODE(p, filter->flags);
+
+            /* Number of filter parameters ("client data elements") */
+            if (H5_IS_BUFFER_OVERFLOW(p, 2, p_end))
+                HGOTO_ERROR(H5E_OHDR, H5E_OVERFLOW, NULL, "ran off end of input buffer while decoding");
+            UINT16DECODE(p, filter->cd_nelmts);
+
+            /* Filter name, if there is one */
+            if (name_length) {
+                size_t actual_name_length;            /* Actual length of name */
+                size_t max = (size_t)(p_end - p + 1); /* Max possible name length */
+
+                /* Determine actual name length (without padding, but with null terminator) */
+                actual_name_length = strnlen((const char *)p, max);
+                if (actual_name_length == max)
+                    HGOTO_ERROR(H5E_OHDR, H5E_NOSPACE, NULL, "filter name not null terminated");
+                actual_name_length += 1; /* include \0 byte */
+
+                /* Allocate space for the filter name, or use the internal buffer */
+                if (actual_name_length > H5Z_COMMON_NAME_LEN) {
+                    filter->name = (char *)H5MM_malloc(actual_name_length);
+                    if (NULL == filter->name)
+                        HGOTO_ERROR(H5E_RESOURCE, H5E_NOSPACE, NULL, "memory allocation failed for filter name");
                 }
+                else
+                    filter->name = filter->_name;
+
+                strncpy(filter->name, (const char *)p, actual_name_length);
+
+                if (H5_IS_BUFFER_OVERFLOW(p, name_length, p_end))
+                    HGOTO_ERROR(H5E_OHDR, H5E_OVERFLOW, NULL, "ran off end of input buffer while decoding");
+                p += name_length;
+            }
+
+            /* Filter parameters */
+            if (filter->cd_nelmts) {
+
+                /* Allocate space for the client data elements, or use the internal buffer */
+                if (filter->cd_nelmts > H5Z_COMMON_CD_VALUES) {
+                    filter->cd_values = (unsigned *)H5MM_malloc(filter->cd_nelmts * sizeof(unsigned));
+                    if (NULL == filter->cd_values)
+                        HGOTO_ERROR(H5E_RESOURCE, H5E_NOSPACE, NULL, "memory allocation failed for client data");
+                }
+                else
+                    filter->cd_values = filter->_cd_values;
+
+                /* Read the client data values and the padding */
+                for (j = 0; j < filter->cd_nelmts; j++) {
+                    if (H5_IS_BUFFER_OVERFLOW(p, 4, p_end))
+                        HGOTO_ERROR(H5E_OHDR, H5E_OVERFLOW, NULL, "ran off end of input buffer while decoding");
+                    UINT32DECODE(p, filter->cd_values[j]);
+                }
+
+                if (pline->version == H5O_PLINE_VERSION_1)
+                    if (filter->cd_nelmts % 2) {
+                        if (H5_IS_BUFFER_OVERFLOW(p, 4, p_end))
+                            HGOTO_ERROR(H5E_OHDR, H5E_OVERFLOW, NULL,
+                                        "ran off end of input buffer while decoding");
+                        p += 4; /* padding */
+                    }
+            }
         }
-    }
+
+    } else if (pline->version == H5O_PLINE_VERSION_3) {
+        H5Z_stc_filter_sect_t *filt_sect;
+        H5Z_filter_info_t *filter;
+
+        /* Total number of filtered sections in the structured chunk */
+        if (H5_IS_BUFFER_OVERFLOW(p, 1, p_end))
+            HGOTO_ERROR(H5E_OHDR, H5E_OVERFLOW, NULL, "ran off end of input buffer while decoding");
+        pline->tot_filt_nsects = *p++;
+
+        if (pline->tot_filt_nsects > H5O_MAX_STC_NSECTS)
+            HGOTO_ERROR(H5E_PLINE, H5E_CANTLOAD, NULL, "filter pipeline message has too many filtered sections");
+
+        /* Decode array of filtered sections */
+        for (i = 0, filt_sect = &pline->filt_sects[0]; i < pline->tot_filt_nsects; i++, filt_sect++) {
+
+            if (H5_IS_BUFFER_OVERFLOW(p, 1, p_end))
+                HGOTO_ERROR(H5E_OHDR, H5E_OVERFLOW, NULL, "ran off end of input buffer while decoding");
+            filt_sect->seq_sect = *p++;
+
+            if (H5_IS_BUFFER_OVERFLOW(p, 1, p_end))
+                HGOTO_ERROR(H5E_OHDR, H5E_OVERFLOW, NULL, "ran off end of input buffer while decoding");
+            filt_sect->nused = *p++;
+
+            if (H5_IS_BUFFER_OVERFLOW(p, 2, p_end))
+                HGOTO_ERROR(H5E_OHDR, H5E_OVERFLOW, NULL, "ran off end of input buffer while decoding");
+            UINT16DECODE(p, filt_sect->size_filt_descr);
+
+            filt_sect->nalloc = filt_sect->nused;
+            if (filt_sect->nused > H5Z_MAX_NFILTERS) {
+
+                /* Reset the number of filters used to avoid array traversal in error
+                 * handling code.
+                 */
+                filt_sect->nused = 0;
+
+                HGOTO_ERROR(H5E_PLINE, H5E_CANTLOAD, NULL, "filtered section has too many filters");
+            }
+
+            /* Allocate array of filter decription for the ith filtered section */
+            filt_sect->nalloc = filt_sect->nused;
+            if (NULL == (filt_sect->filter = (H5Z_filter_info_t *)H5MM_calloc(filt_sect->nalloc * sizeof(filt_sect->filter[0]))))
+                HGOTO_ERROR(H5E_RESOURCE, H5E_NOSPACE, NULL, "memory allocation failed");
+
+            /* Decode array of filter description */
+            for (j = 0, filter = &filt_sect->filter[0]; j < filt_sect->nused; j++, filter++) {
+                /* Filter ID */
+                if (H5_IS_BUFFER_OVERFLOW(p, 2, p_end))
+                    HGOTO_ERROR(H5E_OHDR, H5E_OVERFLOW, NULL, "ran off end of input buffer while decoding");
+                UINT16DECODE(p, filter->id);
+
+                /* Length of filter name */
+                if (pline->version > H5O_PLINE_VERSION_1 && filter->id < H5Z_FILTER_RESERVED)
+                    name_length = 0;
+                else {
+                    if (H5_IS_BUFFER_OVERFLOW(p, 2, p_end))
+                        HGOTO_ERROR(H5E_OHDR, H5E_OVERFLOW, NULL, "ran off end of input buffer while decoding");
+                    UINT16DECODE(p, name_length);
+                }
+
+                /* Filter flags */
+                if (H5_IS_BUFFER_OVERFLOW(p, 2, p_end))
+                    HGOTO_ERROR(H5E_OHDR, H5E_OVERFLOW, NULL, "ran off end of input buffer while decoding");
+                UINT16DECODE(p, filter->flags);
+
+                /* Number of filter parameters ("client data elements") */
+                if (H5_IS_BUFFER_OVERFLOW(p, 2, p_end))
+                    HGOTO_ERROR(H5E_OHDR, H5E_OVERFLOW, NULL, "ran off end of input buffer while decoding");
+                UINT16DECODE(p, filter->cd_nelmts);
+
+                /* Filter name, if there is one */
+                if (name_length) {
+                    size_t actual_name_length;            /* Actual length of name */
+                    size_t max = (size_t)(p_end - p + 1); /* Max possible name length */
+
+                    /* Determine actual name length (without padding, but with null terminator) */
+                    actual_name_length = strnlen((const char *)p, max);
+                    if (actual_name_length == max)
+                        HGOTO_ERROR(H5E_OHDR, H5E_NOSPACE, NULL, "filter name not null terminated");
+                    actual_name_length += 1; /* include \0 byte */
+
+                    /* Allocate space for the filter name, or use the internal buffer */
+                    if (actual_name_length > H5Z_COMMON_NAME_LEN) {
+                        filter->name = (char *)H5MM_malloc(actual_name_length);
+                        if (NULL == filter->name)
+                            HGOTO_ERROR(H5E_RESOURCE, H5E_NOSPACE, NULL, "memory allocation failed for filter name");
+                    }
+                    else
+                        filter->name = filter->_name;
+
+                    strncpy(filter->name, (const char *)p, actual_name_length);
+
+                    if (H5_IS_BUFFER_OVERFLOW(p, name_length, p_end))
+                        HGOTO_ERROR(H5E_OHDR, H5E_OVERFLOW, NULL, "ran off end of input buffer while decoding");
+                    p += name_length;
+                }
+
+                /* Filter parameters */
+                if (filter->cd_nelmts) {
+
+                    /* Allocate space for the client data elements, or use the internal buffer */
+                    if (filter->cd_nelmts > H5Z_COMMON_CD_VALUES) {
+                        filter->cd_values = (unsigned *)H5MM_malloc(filter->cd_nelmts * sizeof(unsigned));
+                        if (NULL == filter->cd_values)
+                            HGOTO_ERROR(H5E_RESOURCE, H5E_NOSPACE, NULL, "memory allocation failed for client data");
+                    }
+                    else
+                        filter->cd_values = filter->_cd_values;
+
+                    /* Read the client data values and the padding */
+                    for (k = 0; k < filter->cd_nelmts; k++) {
+                        if (H5_IS_BUFFER_OVERFLOW(p, 4, p_end))
+                            HGOTO_ERROR(H5E_OHDR, H5E_OVERFLOW, NULL, "ran off end of input buffer while decoding");
+                        UINT32DECODE(p, filter->cd_values[k]);
+                    }
+
+                }
+
+            } /* end of array for filgter decription */
+
+        } /* end of array for filtered sections */
+
+    } /* end of version 3 */
 
     /* Set return value */
     ret_value = pline;
@@ -267,8 +393,7 @@ static herr_t
 H5O__pline_encode(H5F_t H5_ATTR_UNUSED *f, uint8_t *p /*out*/, const void *mesg)
 {
     const H5O_pline_t       *pline = (const H5O_pline_t *)mesg; /* Pipeline message to encode */
-    const H5Z_filter_info_t *filter;                            /* Filter to encode */
-    size_t                   i, j;                              /* Local index variables */
+    size_t                   i, j, k;                            /* Local index variables */
 
     FUNC_ENTER_PACKAGE_NOERR
 
@@ -278,78 +403,164 @@ H5O__pline_encode(H5F_t H5_ATTR_UNUSED *f, uint8_t *p /*out*/, const void *mesg)
 
     /* Message header */
     *p++ = (uint8_t)pline->version;
-    *p++ = (uint8_t)(pline->nused);
-    if (pline->version == H5O_PLINE_VERSION_1) {
-        *p++ = 0; /*reserved 1*/
-        *p++ = 0; /*reserved 2*/
-        *p++ = 0; /*reserved 3*/
-        *p++ = 0; /*reserved 4*/
-        *p++ = 0; /*reserved 5*/
-        *p++ = 0; /*reserved 6*/
-    }             /* end if */
 
-    /* Encode filters */
-    for (i = 0, filter = &pline->filter[0]; i < pline->nused; i++, filter++) {
-        const char *name;        /* Filter name */
-        size_t      name_length; /* Length of filter name */
+    if (pline->version <= H5O_PLINE_VERSION_2) {
+        const H5Z_filter_info_t *filter;                            /* Filter to encode */
 
-        /* Filter ID */
-        UINT16ENCODE(p, filter->id);
+        *p++ = (uint8_t)(pline->nused);
+        if (pline->version == H5O_PLINE_VERSION_1) {
+            *p++ = 0; /*reserved 1*/
+            *p++ = 0; /*reserved 2*/
+            *p++ = 0; /*reserved 3*/
+            *p++ = 0; /*reserved 4*/
+            *p++ = 0; /*reserved 5*/
+            *p++ = 0; /*reserved 6*/
+        }             /* end if */
 
-        /* Skip writing the name length & name if the filter is an internal filter */
-        if (pline->version > H5O_PLINE_VERSION_1 && filter->id < H5Z_FILTER_RESERVED) {
-            name_length = 0;
-            name        = NULL;
-        } /* end if */
-        else {
-            /*
-             * Get the filter name.  If the pipeline message has a name in it then
-             * use that one.  Otherwise try to look up the filter and get the name
-             * as it was registered.
-             */
-            if (NULL == (name = filter->name)) {
-                H5Z_class2_t *cls; /* Filter class */
+        /* Encode filters */
+        for (i = 0, filter = &pline->filter[0]; i < pline->nused; i++, filter++) {
+            const char *name;        /* Filter name */
+            size_t      name_length; /* Length of filter name */
 
-                H5Z_find(true, filter->id, &cls);
-                if (cls)
-                    name = cls->name;
-            }
-            name_length = name ? strlen(name) + 1 : 0;
+            /* Filter ID */
+            UINT16ENCODE(p, filter->id);
 
-            /* Filter name length */
-            UINT16ENCODE(p, pline->version == H5O_PLINE_VERSION_1 ? H5O_ALIGN_OLD(name_length) : name_length);
-        } /* end else */
+            /* Skip writing the name length & name if the filter is an internal filter */
+            if (pline->version > H5O_PLINE_VERSION_1 && filter->id < H5Z_FILTER_RESERVED) {
+                name_length = 0;
+                name        = NULL;
+            } /* end if */
+            else {
+                /*
+                 * Get the filter name.  If the pipeline message has a name in it then
+                 * use that one.  Otherwise try to look up the filter and get the name
+                 * as it was registered.
+                 */
+                if (NULL == (name = filter->name)) {
+                    H5Z_class3_t *cls; /* Filter class */
 
-        /* Filter flags */
-        UINT16ENCODE(p, filter->flags);
+                    H5Z_find(true, filter->id, &cls);
+                    if (cls)
+                        name = cls->name;
+                }
+                name_length = name ? strlen(name) + 1 : 0;
 
-        /* # of filter parameters */
-        UINT16ENCODE(p, filter->cd_nelmts);
+                /* Filter name length */
+                UINT16ENCODE(p, pline->version == H5O_PLINE_VERSION_1 ? H5O_ALIGN_OLD(name_length) : name_length);
+            } /* end else */
 
-        /* Encode name, if there is one to encode */
-        if (name_length > 0) {
-            /* Store name, with null terminator */
-            H5MM_memcpy(p, name, name_length);
-            p += name_length;
+            /* Filter flags */
+            UINT16ENCODE(p, filter->flags);
 
-            /* Pad out name to alignment, in older versions */
+            /* # of filter parameters */
+            UINT16ENCODE(p, filter->cd_nelmts);
+
+            /* Encode name, if there is one to encode */
+            if (name_length > 0) {
+                /* Store name, with null terminator */
+                H5MM_memcpy(p, name, name_length);
+                p += name_length;
+
+                /* Pad out name to alignment, in older versions */
+                if (pline->version == H5O_PLINE_VERSION_1)
+                    while (name_length++ % 8)
+                        *p++ = 0;
+            } /* end if */
+
+            /* Filter parameters */
+            for (j = 0; j < filter->cd_nelmts; j++)
+                UINT32ENCODE(p, filter->cd_values[j]);
+
+            /* Align the parameters for older versions of the format */
             if (pline->version == H5O_PLINE_VERSION_1)
-                while (name_length++ % 8)
-                    *p++ = 0;
-        } /* end if */
+                if (filter->cd_nelmts % 2)
+                    UINT32ENCODE(p, 0);
+        } /* end for */
 
-        /* Filter parameters */
-        for (j = 0; j < filter->cd_nelmts; j++)
-            UINT32ENCODE(p, filter->cd_values[j]);
+    } else if (pline->version == H5O_PLINE_VERSION_3) {
 
-        /* Align the parameters for older versions of the format */
-        if (pline->version == H5O_PLINE_VERSION_1)
-            if (filter->cd_nelmts % 2)
-                UINT32ENCODE(p, 0);
-    } /* end for */
+        *p++ = (uint8_t)pline->tot_filt_nsects;
+
+        for (i = 0; i < pline->tot_filt_nsects; i++) {
+            const H5Z_filter_info_t *filter;                            /* Filter to encode */
+            size_t size_filt_descr = 0;
+            uint8_t *save_p;
+
+
+            *p++ = (uint8_t)(pline->filt_sects[i].seq_sect);
+            *p++ = (uint8_t)(pline->filt_sects[i].nused);
+
+            /* Save pointer to the field "size of ith filter description list" */
+            /* It will be encoded later after the following for loop calculation */
+            save_p = p;
+            p += 2;
+
+            for (j = 0, filter = &pline->filt_sects[i].filter[0]; j < pline->filt_sects[i].nused; j++, filter++) {
+                const char *name;        /* Filter name */
+                size_t      name_length; /* Length of filter name */
+
+                /* Filter ID */
+                UINT16ENCODE(p, filter->id);
+
+                /* Skip writing the name length & name if the filter is an internal filter */
+                if (filter->id < H5Z_FILTER_RESERVED) {
+                    name_length = 0;
+                    name        = NULL;
+                } /* end if */
+                else {
+                    /*
+                     * Get the filter name.  If the pipeline message has a name in it then
+                     * use that one.  Otherwise try to look up the filter and get the name
+                     * as it was registered.
+                     */
+                    if (NULL == (name = filter->name)) {
+                        H5Z_class3_t *cls; /* Filter class */
+
+                        H5Z_find(true, filter->id, &cls);
+                        if (cls)
+                            name = cls->name;
+                    }
+                    name_length = name ? strlen(name) + 1 : 0;
+
+                    /* Filter name length */
+                    UINT16ENCODE(p, name_length);
+                } /* end else */
+
+                /* Filter flags */
+                UINT16ENCODE(p, filter->flags);
+
+                /* # of filter parameters */
+                UINT16ENCODE(p, filter->cd_nelmts);
+
+                /* Encode name, if there is one to encode */
+                if (name_length > 0) {
+                    /* Store name, with null terminator */
+                    H5MM_memcpy(p, name, name_length);
+                    p += name_length;
+
+                } /* end if */
+
+                /* Filter parameters */
+                for (k = 0; k < filter->cd_nelmts; k++)
+                    UINT32ENCODE(p, filter->cd_values[k]);
+                
+                size_filt_descr += 2 +                      /* filter identification number */
+                                   (size_t)((filter->id >= H5Z_FILTER_RESERVED) ? 2 : 0) + /* name length */
+                                   2 +                      /* flags */
+                                   2 +                      /* number of client data values    */
+                                   name_length +            /* length of the filter name    */
+                                   filter->cd_nelmts * 4;   /* Client data values */
+                
+            } /* end for */
+
+            UINT16ENCODE(save_p, size_filt_descr);
+        }
+    } /* end version 3 */
 
     FUNC_LEAVE_NOAPI(SUCCEED)
+
 } /* end H5O__pline_encode() */
+
 
 /*-------------------------------------------------------------------------
  * Function:    H5O__pline_copy
@@ -381,53 +592,116 @@ H5O__pline_copy(const void *_src, void *_dst /*out*/)
     /* Shallow copy basic fields */
     *dst = *src;
 
-    /* Copy over filters, if any */
-    dst->nalloc = dst->nused;
-    if (dst->nalloc) {
-        /* Allocate array to hold filters */
-        if (NULL == (dst->filter = (H5Z_filter_info_t *)H5MM_calloc(dst->nalloc * sizeof(dst->filter[0]))))
-            HGOTO_ERROR(H5E_RESOURCE, H5E_NOSPACE, NULL, "memory allocation failed");
+    if (src->version <= H5O_PLINE_VERSION_2) {
 
-        /* Deep-copy filters */
-        for (i = 0; i < src->nused; i++) {
-            /* Basic filter information */
-            dst->filter[i] = src->filter[i];
+        /* Copy over filters, if any */
+        dst->nalloc = dst->nused;
+        if (dst->nalloc) {
+            /* Allocate array to hold filters */
+            if (NULL == (dst->filter = (H5Z_filter_info_t *)H5MM_calloc(dst->nalloc * sizeof(dst->filter[0]))))
+                HGOTO_ERROR(H5E_RESOURCE, H5E_NOSPACE, NULL, "memory allocation failed");
 
-            /* Filter name */
-            if (src->filter[i].name) {
-                size_t namelen; /* Length of source filter name, including null terminator  */
+            /* Deep-copy filters */
+            for (i = 0; i < src->nused; i++) {
+                /* Basic filter information */
+                dst->filter[i] = src->filter[i];
 
-                namelen = strlen(src->filter[i].name) + 1;
+                /* Filter name */
+                if (src->filter[i].name) {
+                    size_t namelen; /* Length of source filter name, including null terminator  */
 
-                /* Allocate space for the filter name, or use the internal buffer */
-                if (namelen > H5Z_COMMON_NAME_LEN) {
-                    dst->filter[i].name = (char *)H5MM_strdup(src->filter[i].name);
-                    if (NULL == dst->filter[i].name)
-                        HGOTO_ERROR(H5E_RESOURCE, H5E_NOSPACE, NULL,
-                                    "memory allocation failed for filter name");
+                    namelen = strlen(src->filter[i].name) + 1;
+
+                    /* Allocate space for the filter name, or use the internal buffer */
+                    if (namelen > H5Z_COMMON_NAME_LEN) {
+                        dst->filter[i].name = (char *)H5MM_strdup(src->filter[i].name);
+                        if (NULL == dst->filter[i].name)
+                            HGOTO_ERROR(H5E_RESOURCE, H5E_NOSPACE, NULL,
+                                        "memory allocation failed for filter name");
+                    } /* end if */
+                    else
+                        dst->filter[i].name = dst->filter[i]._name;
                 } /* end if */
-                else
-                    dst->filter[i].name = dst->filter[i]._name;
-            } /* end if */
 
-            /* Filter parameters */
-            if (src->filter[i].cd_nelmts > 0) {
-                /* Allocate space for the client data elements, or use the internal buffer */
-                if (src->filter[i].cd_nelmts > H5Z_COMMON_CD_VALUES) {
-                    if (NULL == (dst->filter[i].cd_values =
-                                     (unsigned *)H5MM_malloc(src->filter[i].cd_nelmts * sizeof(unsigned))))
+                /* Filter parameters */
+                if (src->filter[i].cd_nelmts > 0) {
+                    /* Allocate space for the client data elements, or use the internal buffer */
+                    if (src->filter[i].cd_nelmts > H5Z_COMMON_CD_VALUES) {
+                        if (NULL == (dst->filter[i].cd_values =
+                                        (unsigned *)H5MM_malloc(src->filter[i].cd_nelmts * sizeof(unsigned))))
+                            HGOTO_ERROR(H5E_RESOURCE, H5E_NOSPACE, NULL, "memory allocation failed");
+
+                        H5MM_memcpy(dst->filter[i].cd_values, src->filter[i].cd_values,
+                                    src->filter[i].cd_nelmts * sizeof(unsigned));
+                    } /* end if */
+                    else
+                        dst->filter[i].cd_values = dst->filter[i]._cd_values;
+                } /* end if */
+            }     /* end for */
+        }         /* end if */
+        else
+            dst->filter = NULL;
+
+    } else if (src->version == H5O_PLINE_VERSION_3) {
+        const H5Z_stc_filter_sect_t *src_filt_sect;
+        H5Z_stc_filter_sect_t *dst_filt_sect;
+
+        if (src->tot_filt_nsects) {
+             for (i = 0, src_filt_sect = &src->filt_sects[0], dst_filt_sect = &dst->filt_sects[0]; 
+                  i < src->tot_filt_nsects; i++, src_filt_sect++, dst_filt_sect++) {
+
+                /* Copy over filters, if any */
+                dst_filt_sect->nalloc = dst_filt_sect->nused;
+                if (dst_filt_sect->nalloc) {
+
+                    /* Allocate array to hold filters */
+                    if (NULL == (dst_filt_sect->filter = (H5Z_filter_info_t *)H5MM_calloc(dst_filt_sect->nalloc * sizeof(dst_filt_sect->filter[0]))))
                         HGOTO_ERROR(H5E_RESOURCE, H5E_NOSPACE, NULL, "memory allocation failed");
+                    
+                    for (i = 0; i < src_filt_sect->nused; i++) {
+                        /* Basic filter information */
+                        dst_filt_sect->filter[i] = src_filt_sect->filter[i];
 
-                    H5MM_memcpy(dst->filter[i].cd_values, src->filter[i].cd_values,
-                                src->filter[i].cd_nelmts * sizeof(unsigned));
-                } /* end if */
+                        /* Filter name */
+                        if (src_filt_sect->filter[i].name) {
+                            size_t namelen; /* Length of source filter name, including null terminator  */
+
+                            namelen = strlen(src_filt_sect->filter[i].name) + 1;
+
+                            /* Allocate space for the filter name, or use the internal buffer */
+                            if (namelen > H5Z_COMMON_NAME_LEN) {
+                                dst_filt_sect->filter[i].name = (char *)H5MM_strdup(src_filt_sect->filter[i].name);
+                                if (NULL == dst_filt_sect->filter[i].name)
+                                    HGOTO_ERROR(H5E_RESOURCE, H5E_NOSPACE, NULL, "memory allocation failed for filter name");
+                            } /* end if */
+                            else
+                                dst_filt_sect->filter[i].name = dst_filt_sect->filter[i]._name;
+                        } /* end if */
+
+                        /* Filter parameters */
+                        if (src_filt_sect->filter[i].cd_nelmts > 0) {
+                            /* Allocate space for the client data elements, or use the internal buffer */
+                            if (src_filt_sect->filter[i].cd_nelmts > H5Z_COMMON_CD_VALUES) {
+                                if (NULL == (dst_filt_sect->filter[i].cd_values =
+                                                (unsigned *)H5MM_malloc(src_filt_sect->filter[i].cd_nelmts * sizeof(unsigned))))
+                                    HGOTO_ERROR(H5E_RESOURCE, H5E_NOSPACE, NULL, "memory allocation failed");
+
+                                H5MM_memcpy(dst_filt_sect->filter[i].cd_values, src_filt_sect->filter[i].cd_values,
+                                            src_filt_sect->filter[i].cd_nelmts * sizeof(unsigned));
+                            } /* end if */
+                            else
+                                dst_filt_sect->filter[i].cd_values = dst_filt_sect->filter[i]._cd_values;
+                        } /* end if */
+                    }     /* end for */
+                }
                 else
-                    dst->filter[i].cd_values = dst->filter[i]._cd_values;
-            } /* end if */
-        }     /* end for */
-    }         /* end if */
-    else
-        dst->filter = NULL;
+                    dst_filt_sect->filter = NULL;
+
+            } /* end for */
+
+        } /* end if tot_filt_nsects */
+
+    } /* end if version 3 */
 
     /* Set return value */
     ret_value = dst;
@@ -457,51 +731,99 @@ static size_t
 H5O__pline_size(const H5F_t H5_ATTR_UNUSED *f, const void *mesg)
 {
     const H5O_pline_t *pline = (const H5O_pline_t *)mesg; /* Pipeline message */
-    size_t             i;                                 /* Local index variable */
+    size_t             i, j;                              /* Local index variable */
     size_t             ret_value = 0;                     /* Return value */
 
     FUNC_ENTER_PACKAGE_NOERR
 
-    /* Message header */
-    ret_value = (size_t)(1 +                                               /*version            */
-                         1 +                                               /*number of filters        */
-                         (pline->version == H5O_PLINE_VERSION_1 ? 6 : 0)); /*reserved            */
+    if (pline->version <= H5O_PLINE_VERSION_2) {
 
-    /* Calculate size of each filter in pipeline */
-    for (i = 0; i < pline->nused; i++) {
-        size_t      name_len; /* Length of filter name */
-        const char *name;     /* Filter name */
+        /* Message header */
+        ret_value = (size_t)(1 +                                               /*version            */
+                             1 +                                               /*number of filters        */
+                             (pline->version == H5O_PLINE_VERSION_1 ? 6 : 0)); /*reserved            */
 
-        /* Don't write the name length & name if the filter is an internal filter */
-        if (pline->version > H5O_PLINE_VERSION_1 && pline->filter[i].id < H5Z_FILTER_RESERVED)
-            name_len = 0;
-        else {
-            /* Get the name of the filter, same as done with H5O__pline_encode() */
-            if (NULL == (name = pline->filter[i].name)) {
-                H5Z_class2_t *cls; /* Filter class */
+        /* Calculate size of each filter in pipeline */
+        for (i = 0; i < pline->nused; i++) {
+            size_t      name_len; /* Length of filter name */
+            const char *name;     /* Filter name */
 
-                H5Z_find(true, pline->filter[i].id, &cls);
-                if (cls)
-                    name = cls->name;
-            }
-            name_len = name ? strlen(name) + 1 : 0;
-        } /* end else */
+            /* Don't write the name length & name if the filter is an internal filter */
+            if (pline->version > H5O_PLINE_VERSION_1 && pline->filter[i].id < H5Z_FILTER_RESERVED)
+                name_len = 0;
+            else {
+                /* Get the name of the filter, same as done with H5O__pline_encode() */
+                if (NULL == (name = pline->filter[i].name)) {
+                    H5Z_class3_t *cls; /* Filter class */
 
-        ret_value +=
-            2 + /*filter identification number    */
-            (size_t)((pline->version == H5O_PLINE_VERSION_1 || pline->filter[i].id >= H5Z_FILTER_RESERVED)
-                         ? 2
-                         : 0) + /*name length            */
-            2 +                 /*flags                */
-            2 +                 /*number of client data values    */
-            (pline->version == H5O_PLINE_VERSION_1 ? (size_t)H5O_ALIGN_OLD(name_len)
-                                                   : name_len); /*length of the filter name    */
+                    H5Z_find(true, pline->filter[i].id, &cls);
+                    if (cls)
+                        name = cls->name;
+                }
+                name_len = name ? strlen(name) + 1 : 0;
+            } /* end else */
 
-        ret_value += pline->filter[i].cd_nelmts * 4;
-        if (pline->version == H5O_PLINE_VERSION_1)
-            if (pline->filter[i].cd_nelmts % 2)
-                ret_value += 4;
-    } /* end for */
+            ret_value +=
+                2 + /*filter identification number    */
+                (size_t)((pline->version == H5O_PLINE_VERSION_1 || pline->filter[i].id >= H5Z_FILTER_RESERVED)
+                            ? 2
+                            : 0) + /*name length            */
+                2 +                 /*flags                */
+                2 +                 /*number of client data values    */
+                (pline->version == H5O_PLINE_VERSION_1 ? (size_t)H5O_ALIGN_OLD(name_len)
+                                                       : name_len); /*length of the filter name    */
+
+            ret_value += pline->filter[i].cd_nelmts * 4;
+            if (pline->version == H5O_PLINE_VERSION_1)
+                if (pline->filter[i].cd_nelmts % 2)
+                    ret_value += 4;
+        } /* end for */
+
+    } else if (pline->version == H5O_PLINE_VERSION_3) {
+        const H5Z_stc_filter_sect_t *filt_sect;
+
+        /* Message header */
+        ret_value = (size_t)(1 +        /*version            */
+                             1);        /*number of filtered sections */
+
+        for (i = 0, filt_sect = &pline->filt_sects[0]; i < pline->tot_filt_nsects; i++, filt_sect++) {
+            ret_value += (1 +           /* Sequence number of the ith filtered section */
+                          1 +           /* Number of filters for the ith filtered section */
+                          2);           /* Size of the ith filtered description list */
+
+            /* Calculate size of each filter in pipeline for each filtered section */
+            for (j = 0; j < filt_sect->nused; j++) {
+                size_t      name_len; /* Length of filter name */
+                const char *name;     /* Filter name */
+
+                /* Don't write the name length & name if the filter is an internal filter */
+                if (filt_sect->filter[j].id < H5Z_FILTER_RESERVED)
+                    name_len = 0;
+                else {
+                    /* Get the name of the filter, same as done with H5O__pline_encode() */
+                    if (NULL == (name = filt_sect->filter[j].name)) {
+                        H5Z_class3_t *cls; /* Filter class */
+
+                        H5Z_find(true, filt_sect->filter[j].id, &cls);
+                        if (cls)
+                            name = cls->name;
+                    }
+                    name_len = name ? strlen(name) + 1 : 0;
+                } /* end else */
+
+                ret_value +=
+                    2 + /*filter identification number    */
+                    (size_t)((filt_sect->filter[j].id >= H5Z_FILTER_RESERVED)
+                                ? 2
+                                : 0) +  /*name length            */
+                    2 +                 /*flags                */
+                    2 +                 /*number of client data values    */
+                    name_len;           /*length of the filter name    */
+
+                ret_value += filt_sect->filter[j].cd_nelmts * 4;
+            } /* end for */
+        } /* end for */
+    }
 
     FUNC_LEAVE_NOAPI(ret_value)
 } /* end H5O__pline_size() */
@@ -520,7 +842,7 @@ static herr_t
 H5O__pline_reset(void *mesg)
 {
     H5O_pline_t *pline = (H5O_pline_t *)mesg; /* Pipeline message */
-    size_t       i;                           /* Local index variable */
+    size_t       i, j;                        /* Local index variable */
 
     FUNC_ENTER_PACKAGE_NOERR
 
@@ -530,29 +852,56 @@ H5O__pline_reset(void *mesg)
 
     assert(pline);
 
-    /* Free the filter information and array */
-    if (pline->filter) {
-        /* Free information for each filter */
-        for (i = 0; i < pline->nused; i++) {
-            if (pline->filter[i].name && pline->filter[i].name != pline->filter[i]._name)
-                assert((strlen(pline->filter[i].name) + 1) > H5Z_COMMON_NAME_LEN);
-            if (pline->filter[i].name != pline->filter[i]._name)
-                pline->filter[i].name = (char *)H5MM_xfree(pline->filter[i].name);
-            if (pline->filter[i].cd_values && pline->filter[i].cd_values != pline->filter[i]._cd_values)
-                assert(pline->filter[i].cd_nelmts > H5Z_COMMON_CD_VALUES);
-            if (pline->filter[i].cd_values != pline->filter[i]._cd_values)
-                pline->filter[i].cd_values = (unsigned *)H5MM_xfree(pline->filter[i].cd_values);
-        } /* end for */
+    if (pline->version <= H5O_PLINE_VERSION_2) {
 
-        /* Free filter array */
-        pline->filter = (H5Z_filter_info_t *)H5MM_xfree(pline->filter);
+        if (pline->filter) {
+            /* Free information for each filter */
+            for (i = 0; i < pline->nused; i++) {
+                if (pline->filter[i].name && pline->filter[i].name != pline->filter[i]._name)
+                    assert((strlen(pline->filter[i].name) + 1) > H5Z_COMMON_NAME_LEN);
+                if (pline->filter[i].name != pline->filter[i]._name)
+                    pline->filter[i].name = (char *)H5MM_xfree(pline->filter[i].name);
+                if (pline->filter[i].cd_values && pline->filter[i].cd_values != pline->filter[i]._cd_values)
+                    assert(pline->filter[i].cd_nelmts > H5Z_COMMON_CD_VALUES);
+                if (pline->filter[i].cd_values != pline->filter[i]._cd_values)
+                    pline->filter[i].cd_values = (unsigned *)H5MM_xfree(pline->filter[i].cd_values);
+            } /* end for */
+
+            /* Free filter array */
+            pline->filter = (H5Z_filter_info_t *)H5MM_xfree(pline->filter);
+        }
+
+        /* Reset # of filters */
+        pline->nused = pline->nalloc = 0;
+
+        /* Reset version # of pipeline message */
+        pline->version = H5O_PLINE_VERSION_1;
+
+    } else if (pline->version == H5O_PLINE_VERSION_3) {
+        H5Z_stc_filter_sect_t *filt_sect;
+
+        for (i = 0, filt_sect = &pline->filt_sects[0]; i < pline->tot_filt_nsects; i++, filt_sect++) {
+            if (filt_sect->filter) {
+                /* Free information for each filter */
+                for (j = 0; j < filt_sect->nused; j++) {
+                    if (filt_sect->filter[j].name && filt_sect->filter[j].name != filt_sect->filter[j]._name)
+                        assert((strlen(filt_sect->filter[j].name) + 1) > H5Z_COMMON_NAME_LEN);
+                    if (filt_sect->filter[j].name != filt_sect->filter[j]._name)
+                        filt_sect->filter[j].name = (char *)H5MM_xfree(filt_sect->filter[j].name);
+
+                    if (filt_sect->filter[j].cd_values && filt_sect->filter[j].cd_values != filt_sect->filter[j]._cd_values)
+                        assert(filt_sect->filter[j].cd_nelmts > H5Z_COMMON_CD_VALUES);
+                    if (filt_sect->filter[j].cd_values != filt_sect->filter[j]._cd_values)
+                        filt_sect->filter[j].cd_values = (unsigned *)H5MM_xfree(filt_sect->filter[j].cd_values);
+                } /* end for */
+
+                /* Free filter array for the section */
+                filt_sect->filter = (H5Z_filter_info_t *)H5MM_xfree(filt_sect->filter);
+            }
+            filt_sect->nused = filt_sect->nalloc = 0;
+
+       } /* end for */
     }
-
-    /* Reset # of filters */
-    pline->nused = pline->nalloc = 0;
-
-    /* Reset version # of pipeline message */
-    pline->version = H5O_PLINE_VERSION_1;
 
     FUNC_LEAVE_NOAPI(SUCCEED)
 } /* end H5O__pline_reset() */
@@ -647,41 +996,90 @@ H5O__pline_debug(H5F_t H5_ATTR_UNUSED *f, const void *mesg, FILE *stream, int in
     assert(indent >= 0);
     assert(fwidth >= 0);
 
-    fprintf(stream, "%*s%-*s %zu/%zu\n", indent, "", fwidth, "Number of filters:", pline->nused,
-            pline->nalloc);
+    if (pline->version <= H5O_PLINE_VERSION_2) {
 
-    /* Loop over all the filters */
-    for (size_t i = 0; i < pline->nused; i++) {
-        /* 19 characters for text + 20 characters for largest 64-bit size_t +
-         * terminal NUL = 40 characters.
-         */
-        char name[64];
+        fprintf(stream, "%*s%-*s %zu/%zu\n", indent, "", fwidth, "Number of filters:", pline->nused,
+                pline->nalloc);
 
-        memset(name, 0, 64);
-        snprintf(name, sizeof(name), "Filter at position %zu", i);
+        /* Loop over all the filters */
+        for (size_t i = 0; i < pline->nused; i++) {
+            /* 19 characters for text + 20 characters for largest 64-bit size_t +
+             * terminal NUL = 40 characters.
+             */
+            char name[64];
 
-        fprintf(stream, "%*s%-*s\n", indent, "", fwidth, name);
-        fprintf(stream, "%*s%-*s 0x%04x\n", indent + 3, "", MAX(0, fwidth - 3),
-                "Filter identification:", (unsigned)(pline->filter[i].id));
-        if (pline->filter[i].name)
-            fprintf(stream, "%*s%-*s \"%s\"\n", indent + 3, "", MAX(0, fwidth - 3),
+            memset(name, 0, 64);
+            snprintf(name, sizeof(name), "Filter at position %zu", i);
+
+            fprintf(stream, "%*s%-*s\n", indent, "", fwidth, name);
+            fprintf(stream, "%*s%-*s 0x%04x\n", indent + 3, "", MAX(0, fwidth - 3),
+                    "Filter identification:", (unsigned)(pline->filter[i].id));
+            if (pline->filter[i].name)
+                fprintf(stream, "%*s%-*s \"%s\"\n", indent + 3, "", MAX(0, fwidth - 3),
                     "Filter name:", pline->filter[i].name);
-        else
-            fprintf(stream, "%*s%-*s NONE\n", indent + 3, "", MAX(0, fwidth - 3), "Filter name:");
-        fprintf(stream, "%*s%-*s 0x%04x\n", indent + 3, "", MAX(0, fwidth - 3),
-                "Flags:", pline->filter[i].flags);
-        fprintf(stream, "%*s%-*s %zu\n", indent + 3, "", MAX(0, fwidth - 3),
-                "Num CD values:", pline->filter[i].cd_nelmts);
+            else
+                fprintf(stream, "%*s%-*s NONE\n", indent + 3, "", MAX(0, fwidth - 3), "Filter name:");
+            fprintf(stream, "%*s%-*s 0x%04x\n", indent + 3, "", MAX(0, fwidth - 3),
+                    "Flags:", pline->filter[i].flags);
+            fprintf(stream, "%*s%-*s %zu\n", indent + 3, "", MAX(0, fwidth - 3),
+                    "Num CD values:", pline->filter[i].cd_nelmts);
 
-        /* Filter parameters */
-        for (size_t j = 0; j < pline->filter[i].cd_nelmts; j++) {
-            char field_name[32];
+            /* Filter parameters */
+            for (size_t j = 0; j < pline->filter[i].cd_nelmts; j++) {
+                char field_name[32];
 
-            snprintf(field_name, sizeof(field_name), "CD value %lu", (unsigned long)j);
-            fprintf(stream, "%*s%-*s %u\n", indent + 6, "", MAX(0, fwidth - 6), field_name,
+                snprintf(field_name, sizeof(field_name), "CD value %lu", (unsigned long)j);
+                fprintf(stream, "%*s%-*s %u\n", indent + 6, "", MAX(0, fwidth - 6), field_name,
                     pline->filter[i].cd_values[j]);
+            }
         }
-    }
+
+    } else if (pline->version == H5O_PLINE_VERSION_3) {
+        const H5Z_stc_filter_sect_t *filt_sect;
+        size_t i, j, k;
+
+        for (i = 0, filt_sect = &pline->filt_sects[0]; i < pline->tot_filt_nsects; i++, filt_sect++) {
+            fprintf(stream, "%*s%-*s %zu\n", indent, "", fwidth, "Sequence # of filtered section:", filt_sect->seq_sect);
+
+            fprintf(stream, "%*s%-*s %zu/%zu\n", indent, "", fwidth, "Number of filters:", filt_sect->nused, filt_sect->nalloc);
+
+            /* Loop over all the filters */
+            for (j = 0; j < filt_sect->nused; j++) {
+                /* 19 characters for text + 20 characters for largest 64-bit size_t +
+                 * terminal NUL = 40 characters.
+                 */
+                char name[64];
+
+                memset(name, 0, 64);
+                snprintf(name, sizeof(name), "Filter at position %zu", i);
+
+                fprintf(stream, "%*s%-*s\n", indent, "", fwidth, name);
+                fprintf(stream, "%*s%-*s 0x%04x\n", indent + 3, "", MAX(0, fwidth - 3),
+                        "Filter identification:", (unsigned)(filt_sect->filter[j].id));
+                if (filt_sect->filter[j].name)
+                    fprintf(stream, "%*s%-*s \"%s\"\n", indent + 3, "", MAX(0, fwidth - 3),
+                            "Filter name:", filt_sect->filter[j].name);
+                else
+                    fprintf(stream, "%*s%-*s NONE\n", indent + 3, "", MAX(0, fwidth - 3), "Filter name:");
+
+                fprintf(stream, "%*s%-*s 0x%04x\n", indent + 3, "", MAX(0, fwidth - 3),
+                    "Flags:", filt_sect->filter[i].flags);
+
+                fprintf(stream, "%*s%-*s %zu\n", indent + 3, "", MAX(0, fwidth - 3),
+                        "Num CD values:", filt_sect->filter[j].cd_nelmts);
+
+                /* Filter parameters */
+                for (k = 0; k < filt_sect->filter[j].cd_nelmts; k++) {
+                    char field_name[32];
+
+                    snprintf(field_name, sizeof(field_name), "CD value %lu", (unsigned long)k);
+                    fprintf(stream, "%*s%-*s %u\n", indent + 6, "", MAX(0, fwidth - 6), field_name,
+                            filt_sect->filter[j].cd_values[k]);
+                } /* for k */
+            } /* for j */
+        } /* for i */
+
+    } /* if version 3 */
 
     FUNC_LEAVE_NOAPI(SUCCEED)
 } /* end H5O__pline_debug() */

--- a/src/H5Opline.c
+++ b/src/H5Opline.c
@@ -289,7 +289,7 @@ H5O__pline_decode(H5F_t H5_ATTR_UNUSED *f, H5O_t H5_ATTR_UNUSED *open_oh, unsign
                 HGOTO_ERROR(H5E_PLINE, H5E_CANTLOAD, NULL, "filtered section has too many filters");
             }
 
-            /* Allocate array of filter decription for the ith filtered section */
+            /* Allocate array of filter description for the ith filtered section */
             filt_sect->nalloc = filt_sect->nused;
             if (NULL == (filt_sect->filter = (H5Z_filter_info_t *)H5MM_calloc(filt_sect->nalloc *
                                                                               sizeof(filt_sect->filter[0]))))
@@ -373,7 +373,7 @@ H5O__pline_decode(H5F_t H5_ATTR_UNUSED *f, H5O_t H5_ATTR_UNUSED *open_oh, unsign
                     }
                 }
 
-            } /* end of array for filgter decription */
+            } /* end of array for filter description */
 
         } /* end of array for filtered sections */
 

--- a/src/H5Oprivate.h
+++ b/src/H5Oprivate.h
@@ -99,8 +99,13 @@ typedef struct H5O_mesg_t      H5O_mesg_t;
 #define H5O_CRT_PIPELINE_NAME         "pline"               /* Filter pipeline */
 #define H5O_CRT_PIPELINE_DEF                                                                                 \
     {                                                                                                        \
-        {0, NULL, H5O_NULL_ID, {{0, HADDR_UNDEF}}}, H5O_PLINE_VERSION_1, 0, 0, NULL,                         \
-        0, {{0, 0, 0, 0,  NULL}, {0, 0, 0, 0, NULL}, {0, 0, 0, 0, NULL}}                                     \
+        {0, NULL, H5O_NULL_ID, {{0, HADDR_UNDEF}}}, H5O_PLINE_VERSION_1, 0, 0, NULL, 0,                      \
+        {                                                                                                    \
+            {0, 0, 0, 0, NULL}, {0, 0, 0, 0, NULL},                                                          \
+            {                                                                                                \
+                0, 0, 0, 0, NULL                                                                             \
+            }                                                                                                \
+        }                                                                                                    \
     }
 #ifdef H5O_ENABLE_BOGUS
 #define H5O_BOGUS_MSG_FLAGS_NAME "bogus msg flags" /* Flags for 'bogus' message */
@@ -446,7 +451,6 @@ typedef struct H5O_efl_t {
                                         */
 #define H5O_STRUCT_CHUNK_OFFSET_SIZE 8 /* Predefined to be 8, will be changed later */
 
-
 /* Forward declaration of structs used below */
 struct H5D_layout_ops_t; /* Defined in H5Dpkg.h               */
 struct H5D_chunk_ops_t;  /* Defined in H5Dpkg.h               */
@@ -780,17 +784,16 @@ typedef struct H5O_ginfo_t {
 #define H5O_PLINE_VERSION_LATEST H5O_PLINE_VERSION_2
 
 typedef struct H5O_pline_t {
-    H5O_shared_t sh_loc; /* Shared message info (must be first) */
-    unsigned           version; /* Encoding version number */
+    H5O_shared_t sh_loc;  /* Shared message info (must be first) */
+    unsigned     version; /* Encoding version number */
     /* For dense chunks */
-    size_t             nalloc;  /*num elements in `filter' array     */
-    size_t             nused;   /*num filters defined		     */
-    H5Z_filter_info_t *filter;  /*array of filters		     */
+    size_t             nalloc; /*num elements in `filter' array     */
+    size_t             nused;  /*num filters defined		     */
+    H5Z_filter_info_t *filter; /*array of filters		     */
     /* For structured chunk */
-    size_t tot_filt_nsects;     /* Total # of filtered sections in the structured chunk */
+    size_t                tot_filt_nsects; /* Total # of filtered sections in the structured chunk */
     H5Z_stc_filter_sect_t filt_sects[H5O_MAX_STC_NSECTS];
 } H5O_pline_t;
-
 
 /*
  * Object name message.

--- a/src/H5Oprivate.h
+++ b/src/H5Oprivate.h
@@ -99,7 +99,8 @@ typedef struct H5O_mesg_t      H5O_mesg_t;
 #define H5O_CRT_PIPELINE_NAME         "pline"               /* Filter pipeline */
 #define H5O_CRT_PIPELINE_DEF                                                                                 \
     {                                                                                                        \
-        {0, NULL, H5O_NULL_ID, {{0, HADDR_UNDEF}}}, H5O_PLINE_VERSION_1, 0, 0, NULL                          \
+        {0, NULL, H5O_NULL_ID, {{0, HADDR_UNDEF}}}, H5O_PLINE_VERSION_1, 0, 0, NULL,                         \
+        0, {{0, 0, 0, 0,  NULL}, {0, 0, 0, 0, NULL}, {0, 0, 0, 0, NULL}}                                     \
     }
 #ifdef H5O_ENABLE_BOGUS
 #define H5O_BOGUS_MSG_FLAGS_NAME "bogus msg flags" /* Flags for 'bogus' message */
@@ -445,6 +446,7 @@ typedef struct H5O_efl_t {
                                         */
 #define H5O_STRUCT_CHUNK_OFFSET_SIZE 8 /* Predefined to be 8, will be changed later */
 
+
 /* Forward declaration of structs used below */
 struct H5D_layout_ops_t; /* Defined in H5Dpkg.h               */
 struct H5D_chunk_ops_t;  /* Defined in H5Dpkg.h               */
@@ -771,6 +773,7 @@ typedef struct H5O_ginfo_t {
  *      filter name at all if it's a filter provided by the library)
  */
 #define H5O_PLINE_VERSION_2 2
+#define H5O_PLINE_VERSION_3 3
 
 /* The latest version of the format.  Look through the 'encode' and 'size'
  *      callbacks for places to change when updating this. */
@@ -778,12 +781,16 @@ typedef struct H5O_ginfo_t {
 
 typedef struct H5O_pline_t {
     H5O_shared_t sh_loc; /* Shared message info (must be first) */
-
     unsigned           version; /* Encoding version number */
+    /* For dense chunks */
     size_t             nalloc;  /*num elements in `filter' array     */
     size_t             nused;   /*num filters defined		     */
     H5Z_filter_info_t *filter;  /*array of filters		     */
+    /* For structured chunk */
+    size_t tot_filt_nsects;     /* Total # of filtered sections in the structured chunk */
+    H5Z_stc_filter_sect_t filt_sects[H5O_MAX_STC_NSECTS];
 } H5O_pline_t;
+
 
 /*
  * Object name message.

--- a/src/H5PLint.c
+++ b/src/H5PLint.c
@@ -378,10 +378,10 @@ H5PL__open(const char *path, H5PL_type_t type, const H5PL_key_t *key, bool *succ
     /* Get the plugin information */
     switch (loaded_plugin_type) {
         case H5PL_TYPE_FILTER: {
-            const H5Z_class2_t *filter_info;
+            const H5Z_class3_t *filter_info;
 
             /* Get the plugin info */
-            if (NULL == (filter_info = (const H5Z_class2_t *)(*get_plugin_info)()))
+            if (NULL == (filter_info = (const H5Z_class3_t *)(*get_plugin_info)()))
                 HGOTO_ERROR(H5E_PLUGIN, H5E_CANTGET, FAIL, "can't get filter info from plugin");
 
             /* Setup temporary plugin key if one wasn't supplied */

--- a/src/H5PLmodule.h
+++ b/src/H5PLmodule.h
@@ -272,7 +272,7 @@
  * It is very important for the users of the filter that developers provide filter information in the “name”
  * field of the filter structure, for example:
  * \code
- *   const H5Z_class2_t H5Z_BZIP2[1] = {{
+ *   const H5Z_class3_t H5Z_BZIP2[1] = {{
  *     H5Z_CLASS_T_VERS,                    // H5Z_class_t version
  *     (H5Z_filter_t)H5Z_FILTER_BZIP2,      // Filter id number
  *     1,                                   // encoder_present flag (set to true)

--- a/src/H5Pocpl.c
+++ b/src/H5Pocpl.c
@@ -93,9 +93,10 @@ static herr_t H5P__ocrt_pipeline_close(const char *name, size_t size, void *valu
 
 /* Local routines */
 static herr_t H5P__set_filter1(H5P_genplist_t *plist, H5Z_filter_t filter, unsigned int flags,
-                              size_t cd_nelmts, const unsigned int cd_values[/*cd_nelmts*/]);
-static herr_t H5P__set_filter2(H5P_genplist_t *plist, H5_section_type_t sec_type, H5Z_filter_t filter, 
-                               unsigned int flags, size_t cd_nelmts, const unsigned int cd_values[/*cd_nelmts*/]);
+                               size_t cd_nelmts, const unsigned int cd_values[/*cd_nelmts*/]);
+static herr_t H5P__set_filter2(H5P_genplist_t *plist, H5_section_type_t sec_type, H5Z_filter_t filter,
+                               unsigned int flags, size_t cd_nelmts,
+                               const unsigned int cd_values[/*cd_nelmts*/]);
 
 /*********************/
 /* Package Variables */
@@ -479,8 +480,8 @@ done:
  *-------------------------------------------------------------------------
  */
 herr_t
-H5P_modify_filter(H5P_genplist_t *plist, H5Z_filter_t id, H5_section_type_t sec_type, 
-                  unsigned flags, size_t cd_nelmts, const unsigned cd_values[/*cd_nelmts*/])
+H5P_modify_filter(H5P_genplist_t *plist, H5Z_filter_t id, H5_section_type_t sec_type, unsigned flags,
+                  size_t cd_nelmts, const unsigned cd_values[/*cd_nelmts*/])
 {
     H5O_pline_t pline;
     herr_t      ret_value = SUCCEED; /* return value */
@@ -497,12 +498,13 @@ H5P_modify_filter(H5P_genplist_t *plist, H5Z_filter_t id, H5_section_type_t sec_
         /* Modify the filter parameters of the I/O pipeline */
         if (H5Z_modify(pline.filter, pline.nused, id, flags, cd_nelmts, cd_values) < 0)
             HGOTO_ERROR(H5E_PLINE, H5E_CANTINIT, FAIL, "unable to modify filter parameters in pipeline");
-    } else {
+    }
+    else {
         assert(pline.version == H5O_PLINE_VERSION_3);
         H5Z_stc_filter_sect_t *filt_sect = NULL;
-        unsigned i;
+        unsigned               i;
 
-        for (i = 0, filt_sect = &pline.filt_sects[0]; i <  pline.tot_filt_nsects; i++, filt_sect++) {
+        for (i = 0, filt_sect = &pline.filt_sects[0]; i < pline.tot_filt_nsects; i++, filt_sect++) {
             if (filt_sect->seq_sect == (size_t)sec_type)
                 break;
         }
@@ -558,7 +560,7 @@ done:
 /* HERE need to add to versioning ? */
 herr_t
 H5Pmodify_filter1(hid_t plist_id, H5Z_filter_t filter, unsigned int flags, size_t cd_nelmts,
-                 const unsigned int cd_values[/*cd_nelmts*/])
+                  const unsigned int cd_values[/*cd_nelmts*/])
 {
     H5P_genplist_t *plist;               /* Property list */
     herr_t          ret_value = SUCCEED; /* return value */
@@ -654,7 +656,6 @@ done:
     FUNC_LEAVE_API(ret_value)
 } /* end H5Pmodify_filter2() */
 
-
 /*-------------------------------------------------------------------------
  * Function:    H5Pset_filter1
  *
@@ -686,7 +687,7 @@ done:
  */
 herr_t
 H5Pset_filter1(hid_t plist_id, H5Z_filter_t filter, unsigned int flags, size_t cd_nelmts,
-              const unsigned int cd_values[/*cd_nelmts*/])
+               const unsigned int cd_values[/*cd_nelmts*/])
 {
     H5P_genplist_t *plist;               /* Property list */
     herr_t          ret_value = SUCCEED; /* return value */
@@ -747,7 +748,7 @@ done:
  */
 static herr_t
 H5P__set_filter1(H5P_genplist_t *plist, H5Z_filter_t filter, unsigned int flags, size_t cd_nelmts,
-                const unsigned int cd_values[/*cd_nelmts*/])
+                 const unsigned int cd_values[/*cd_nelmts*/])
 {
     H5O_pline_t pline;               /* Filter pipeline */
     htri_t      filter_avail;        /* Filter availability */
@@ -784,7 +785,7 @@ done:
  *        The PLIST_ID argument is a dataset creation or group
  *        creation property list.
  *
- *        The SEC_TYPE argument is the type identifier for a section 
+ *        The SEC_TYPE argument is the type identifier for a section
  *        in structured chunk to which the filter is applied.
  *
  *        The FILTER argument is the filter identifier for the filter
@@ -823,7 +824,7 @@ H5Pset_filter2(hid_t plist_id, H5_section_type_t sec_type, H5Z_filter_t filter, 
                size_t cd_nelmts, const unsigned int cd_values[/*cd_nelmts*/])
 {
     H5P_genplist_t *plist;               /* Property list */
-    H5O_layout_t    layout;    /* Layout property */
+    H5O_layout_t    layout;              /* Layout property */
     herr_t          ret_value = SUCCEED; /* return value */
 
     FUNC_ENTER_API(FAIL)
@@ -905,15 +906,15 @@ done:
  */
 /* HERE */
 static herr_t
-H5P__set_filter2(H5P_genplist_t *plist, H5_section_type_t sec_type, H5Z_filter_t filter_id, unsigned int flags,
-                 size_t cd_nelmts, const unsigned int cd_values[/*cd_nelmts*/])
+H5P__set_filter2(H5P_genplist_t *plist, H5_section_type_t sec_type, H5Z_filter_t filter_id,
+                 unsigned int flags, size_t cd_nelmts, const unsigned int cd_values[/*cd_nelmts*/])
 {
-    H5O_pline_t pline;               /* Filter pipeline */
-    htri_t      filter_avail;        /* Filter availability */
+    H5O_pline_t            pline;        /* Filter pipeline */
+    htri_t                 filter_avail; /* Filter availability */
     H5Z_stc_filter_sect_t *filt_sect = NULL;
-    bool found = false;
-    unsigned i = 0;
-    herr_t      ret_value = SUCCEED; /* Return value */
+    bool                   found     = false;
+    unsigned               i         = 0;
+    herr_t                 ret_value = SUCCEED; /* Return value */
 
     FUNC_ENTER_PACKAGE
 
@@ -927,9 +928,9 @@ H5P__set_filter2(H5P_genplist_t *plist, H5_section_type_t sec_type, H5Z_filter_t
 
     /* For structured chunk, pline version should be 3 */
     if (pline.version != H5O_PLINE_VERSION_3)
-        pline.version = H5O_PLINE_VERSION_3; 
+        pline.version = H5O_PLINE_VERSION_3;
 
-    for (i = 0; i <  pline.tot_filt_nsects; i++)
+    for (i = 0; i < pline.tot_filt_nsects; i++)
         if (pline.filt_sects[i].seq_sect == (size_t)sec_type) {
             found = true;
             break;
@@ -938,8 +939,8 @@ H5P__set_filter2(H5P_genplist_t *plist, H5_section_type_t sec_type, H5Z_filter_t
     filt_sect = &pline.filt_sects[i];
 
     /* Add the filter to the I/O pipeline for the section */
-    if (H5Z_append_filter(filter_id, flags, cd_nelmts, cd_values, 
-                          &filt_sect->filter, &filt_sect->nused, &filt_sect->nalloc) < 0)
+    if (H5Z_append_filter(filter_id, flags, cd_nelmts, cd_values, &filt_sect->filter, &filt_sect->nused,
+                          &filt_sect->nalloc) < 0)
         HGOTO_ERROR(H5E_PLINE, H5E_CANTINIT, FAIL, "unable to add filter to pipeline");
 
     /* Add the new filter to the pipeline */
@@ -1004,7 +1005,7 @@ done:
  *        pipeline depending on whether PLIST_ID is a dataset creation
  *        or group creation property list.
  *        In each pipeline the filters are numbered from zero through
- *        N-1 where N is the value returned by this function in the 
+ *        N-1 where N is the value returned by this function in the
  *        parameter NUM_FILTERS.
  *        During output to the file the filters of a pipeline are applied
  *        in increasing order (the inverse is true for input).
@@ -1020,8 +1021,8 @@ done:
 herr_t
 H5Pget_nfilters2(hid_t plist_id, H5_section_type_t sec_type, int *num_filters)
 {
-    H5P_genplist_t *plist;     /* Property list */
-    H5O_pline_t     pline;     /* Filter pipeline */
+    H5P_genplist_t *plist; /* Property list */
+    H5O_pline_t     pline; /* Filter pipeline */
     unsigned        i;
     int             num;
     herr_t          ret_value = SUCCEED; /* return value */
@@ -1038,7 +1039,7 @@ H5Pget_nfilters2(hid_t plist_id, H5_section_type_t sec_type, int *num_filters)
 
     /* Set return value */
     ret_value = 0;
-    for (i = 0; i <  pline.tot_filt_nsects; i++) {
+    for (i = 0; i < pline.tot_filt_nsects; i++) {
         if (pline.filt_sects[i].seq_sect == (size_t)sec_type) {
             num = (int)(pline.filt_sects[i].nused);
             break;
@@ -1166,17 +1167,17 @@ done:
 /* HERE */
 H5Z_filter_t
 H5Pget_filter3(hid_t plist_id, H5_section_type_t sec_type, unsigned idx, unsigned int *flags /*out*/,
-               size_t *cd_nelmts /*in,out*/, unsigned cd_values[] /*out*/, 
-               size_t namelen /*in*/, char name[] /*out*/, unsigned *filter_config /*out*/)
+               size_t *cd_nelmts /*in,out*/, unsigned cd_values[] /*out*/, size_t namelen /*in*/,
+               char name[] /*out*/, unsigned *filter_config /*out*/)
 {
-    H5P_genplist_t          *plist;     /* Property list */
-    const H5Z_filter_info_t *filter;    /* Pointer to filter information */
-    H5O_pline_t              pline;     /* Filter pipeline */
-    unsigned i;
-    H5Z_filter_t ret_value; /* return value */
+    H5P_genplist_t          *plist;  /* Property list */
+    const H5Z_filter_info_t *filter; /* Pointer to filter information */
+    H5O_pline_t              pline;  /* Filter pipeline */
+    unsigned                 i;
+    H5Z_filter_t             ret_value; /* return value */
 
     FUNC_ENTER_API(H5Z_FILTER_ERROR)
-    
+
     /* Check args */
     if (cd_nelmts || cd_values) {
         /*
@@ -1207,7 +1208,7 @@ H5Pget_filter3(hid_t plist_id, H5_section_type_t sec_type, unsigned idx, unsigne
     if (H5P_peek(plist, H5O_CRT_PIPELINE_NAME, &pline) < 0)
         HGOTO_ERROR(H5E_PLIST, H5E_CANTGET, H5Z_FILTER_ERROR, "can't get pipeline");
 
-    for (i = 0; i <  pline.tot_filt_nsects; i++) {
+    for (i = 0; i < pline.tot_filt_nsects; i++) {
         if (pline.filt_sects[i].seq_sect == (size_t)sec_type) {
             if (idx >= pline.filt_sects[i].nused)
                 HGOTO_ERROR(H5E_ARGS, H5E_BADVALUE, H5Z_FILTER_ERROR, "filter number is invalid");
@@ -1250,8 +1251,8 @@ done:
  *-------------------------------------------------------------------------
  */
 herr_t
-H5P_get_filter_by_id(H5P_genplist_t *plist, H5Z_filter_t id, H5_section_type_t sec_type, 
-                     unsigned int *flags /*out*/, size_t *cd_nelmts /*in,out*/, unsigned cd_values[] /*out*/, 
+H5P_get_filter_by_id(H5P_genplist_t *plist, H5Z_filter_t id, H5_section_type_t sec_type,
+                     unsigned int *flags /*out*/, size_t *cd_nelmts /*in,out*/, unsigned cd_values[] /*out*/,
                      size_t namelen, char name[] /*out*/, unsigned *filter_config)
 {
     H5O_pline_t        pline;               /* Filter pipeline */
@@ -1269,13 +1270,13 @@ H5P_get_filter_by_id(H5P_genplist_t *plist, H5Z_filter_t id, H5_section_type_t s
         /* Get pointer to filter in pipeline */
         if (NULL == (filter = H5Z_filter_info(pline.filter, pline.nused, id)))
             HGOTO_ERROR(H5E_ARGS, H5E_BADVALUE, FAIL, "filter ID is invalid");
-
-    } else {
+    }
+    else {
         assert(pline.version == H5O_PLINE_VERSION_3);
         H5Z_stc_filter_sect_t *filt_sect = NULL;
-        unsigned i;
-        
-        for (i = 0, filt_sect = &pline.filt_sects[0]; i <  pline.tot_filt_nsects; i++, filt_sect++) {
+        unsigned               i;
+
+        for (i = 0, filt_sect = &pline.filt_sects[0]; i < pline.tot_filt_nsects; i++, filt_sect++) {
             if (filt_sect->seq_sect == (size_t)sec_type)
                 break;
         }
@@ -1285,8 +1286,7 @@ H5P_get_filter_by_id(H5P_genplist_t *plist, H5Z_filter_t id, H5_section_type_t s
         /* Get pointer to filter in pipeline */
         if (NULL == (filter = H5Z_filter_info(filt_sect->filter, filt_sect->nused, id)))
             HGOTO_ERROR(H5E_ARGS, H5E_BADVALUE, FAIL, "filter ID is invalid");
-
-    } 
+    }
 
     /* Get filter information */
     if (H5P__get_filter(filter, flags, cd_nelmts, cd_values, namelen, name, filter_config) < 0)
@@ -1353,7 +1353,8 @@ H5Pget_filter_by_id2(hid_t plist_id, H5Z_filter_t id, unsigned int *flags /*out*
         HGOTO_ERROR(H5E_ID, H5E_BADID, FAIL, "can't find object for ID");
 
     /* Get filter information */
-    if (H5P_get_filter_by_id(plist, id, H5_SECTION_UNKNOWN, flags, cd_nelmts, cd_values, namelen, name, filter_config) < 0)
+    if (H5P_get_filter_by_id(plist, id, H5_SECTION_UNKNOWN, flags, cd_nelmts, cd_values, namelen, name,
+                             filter_config) < 0)
         HGOTO_ERROR(H5E_PLIST, H5E_CANTGET, FAIL, "can't get filter info");
 
 done:
@@ -1391,12 +1392,12 @@ done:
  */
 /* HERE need to add to versioning ? */
 herr_t
-H5Pget_filter_by_id3(hid_t plist_id, H5_section_type_t sec_type, H5Z_filter_t id, unsigned int *flags /*out*/, 
-                     size_t *cd_nelmts /*in,out*/, unsigned cd_values[] /*out*/, 
-                     size_t namelen /*in*/, char name[] /*out*/, unsigned *filter_config /*out*/)
+H5Pget_filter_by_id3(hid_t plist_id, H5_section_type_t sec_type, H5Z_filter_t id, unsigned int *flags /*out*/,
+                     size_t *cd_nelmts /*in,out*/, unsigned cd_values[] /*out*/, size_t namelen /*in*/,
+                     char name[] /*out*/, unsigned *filter_config /*out*/)
 {
-    H5P_genplist_t *plist;      /* Property list */
-    herr_t ret_value = SUCCEED; /* Return value */
+    H5P_genplist_t *plist;               /* Property list */
+    herr_t          ret_value = SUCCEED; /* Return value */
 
     FUNC_ENTER_API(H5Z_FILTER_ERROR)
 
@@ -1432,7 +1433,8 @@ H5Pget_filter_by_id3(hid_t plist_id, H5_section_type_t sec_type, H5Z_filter_t id
         HGOTO_ERROR(H5E_ID, H5E_BADID, FAIL, "can't find object for ID");
 
     /* Get filter information */
-    if (H5P_get_filter_by_id(plist, id, sec_type, flags, cd_nelmts, cd_values, namelen, name, filter_config) < 0)
+    if (H5P_get_filter_by_id(plist, id, sec_type, flags, cd_nelmts, cd_values, namelen, name, filter_config) <
+        0)
         HGOTO_ERROR(H5E_PLIST, H5E_CANTGET, FAIL, "can't get filter info");
 
 done:
@@ -1474,20 +1476,20 @@ H5Pall_filters_avail(hid_t plist_id)
         /* Check if all filters are available */
         if ((ret_value = H5Z_all_filters_avail(pline.filter, pline.nused)) < 0)
             HGOTO_ERROR(H5E_PLIST, H5E_NOTFOUND, FAIL, "can't check pipeline information");
-
-    } else {
+    }
+    else {
         assert(pline.version == H5O_PLINE_VERSION_3);
         H5Z_stc_filter_sect_t *filt_sect = NULL;
-        unsigned i;
-        
+        unsigned               i;
+
         /* Check if all filters are available */
-        for (i = 0, filt_sect = &pline.filt_sects[0]; i <  pline.tot_filt_nsects; i++, filt_sect++) {
+        for (i = 0, filt_sect = &pline.filt_sects[0]; i < pline.tot_filt_nsects; i++, filt_sect++) {
             if ((ret_value = H5Z_all_filters_avail(filt_sect->filter, filt_sect->nused)) < 0)
                 HGOTO_ERROR(H5E_PLIST, H5E_NOTFOUND, FAIL, "can't check pipeline information");
             if (ret_value == false)
                 break;
         }
-    } 
+    }
 
 done:
     FUNC_LEAVE_API(ret_value)
@@ -1517,19 +1519,19 @@ H5P_filter_in_pline(H5P_genplist_t *plist, H5Z_filter_t id)
     if (H5P_peek(plist, H5O_CRT_PIPELINE_NAME, &pline) < 0)
         HGOTO_ERROR(H5E_PLIST, H5E_CANTGET, FAIL, "can't get pipeline");
 
-     if (pline.version < H5O_PLINE_VERSION_3) {
+    if (pline.version < H5O_PLINE_VERSION_3) {
 
         /* Get pointer to filter in pipeline */
         if ((ret_value = H5Z_filter_in_pline(pline.filter, pline.nused, id)) < 0)
             HGOTO_ERROR(H5E_PLINE, H5E_CANTCOMPARE, FAIL, "can't find filter");
-
-    } else {
+    }
+    else {
         assert(pline.version == H5O_PLINE_VERSION_3);
         H5Z_stc_filter_sect_t *filt_sect = NULL;
-        unsigned i;
+        unsigned               i;
 
         /* Check if filter is in the pipeline for each section */
-        for (i = 0, filt_sect = &pline.filt_sects[0]; i <  pline.tot_filt_nsects; i++, filt_sect++) {
+        for (i = 0, filt_sect = &pline.filt_sects[0]; i < pline.tot_filt_nsects; i++, filt_sect++) {
             if ((ret_value = H5Z_filter_in_pline(filt_sect->filter, filt_sect->nused, id)) < 0)
                 HGOTO_ERROR(H5E_PLINE, H5E_CANTCOMPARE, FAIL, "can't find filter");
             if (ret_value)
@@ -2363,7 +2365,8 @@ H5Pget_filter_by_id1(hid_t plist_id, H5Z_filter_t id, unsigned int *flags /*out*
         HGOTO_ERROR(H5E_ID, H5E_BADID, FAIL, "can't find object for ID");
 
     /* Get filter info */
-    if (H5P_get_filter_by_id(plist, id, H5_SECTION_UNKNOWN, flags, cd_nelmts, cd_values, namelen, name, NULL) < 0)
+    if (H5P_get_filter_by_id(plist, id, H5_SECTION_UNKNOWN, flags, cd_nelmts, cd_values, namelen, name,
+                             NULL) < 0)
         HGOTO_ERROR(H5E_PLIST, H5E_CANTGET, FAIL, "can't get filter info");
 
 done:

--- a/src/H5Pocpl.c
+++ b/src/H5Pocpl.c
@@ -33,6 +33,7 @@
 #include "H5Eprivate.h"  /* Error handling                           */
 #include "H5MMprivate.h" /* Memory management                        */
 #include "H5Opkg.h"      /* Object headers                           */
+#include "H5Dprivate.h"  /* Dataset functions                        */
 #include "H5Ppkg.h"      /* Property lists                           */
 #include "H5VMprivate.h" /* Vector Functions                         */
 #include "H5Zprivate.h"  /* Filter pipeline                          */
@@ -91,10 +92,10 @@ static int    H5P__ocrt_pipeline_cmp(const void *value1, const void *value2, siz
 static herr_t H5P__ocrt_pipeline_close(const char *name, size_t size, void *value);
 
 /* Local routines */
-static herr_t H5P__set_filter(H5P_genplist_t *plist, H5Z_filter_t filter, unsigned int flags,
+static herr_t H5P__set_filter1(H5P_genplist_t *plist, H5Z_filter_t filter, unsigned int flags,
                               size_t cd_nelmts, const unsigned int cd_values[/*cd_nelmts*/]);
-static herr_t H5P__set_filter2(H5P_genplist_t *plist, uint64_t section_number, H5Z_filter_t filter,
-                               uint64_t flags, size_t buf_size, const void *buf);
+static herr_t H5P__set_filter2(H5P_genplist_t *plist, H5_section_type_t sec_type, H5Z_filter_t filter, 
+                               unsigned int flags, size_t cd_nelmts, const unsigned int cd_values[/*cd_nelmts*/]);
 
 /*********************/
 /* Package Variables */
@@ -478,8 +479,8 @@ done:
  *-------------------------------------------------------------------------
  */
 herr_t
-H5P_modify_filter(H5P_genplist_t *plist, H5Z_filter_t filter, unsigned flags, size_t cd_nelmts,
-                  const unsigned cd_values[/*cd_nelmts*/])
+H5P_modify_filter(H5P_genplist_t *plist, H5Z_filter_t id, H5_section_type_t sec_type, 
+                  unsigned flags, size_t cd_nelmts, const unsigned cd_values[/*cd_nelmts*/])
 {
     H5O_pline_t pline;
     herr_t      ret_value = SUCCEED; /* return value */
@@ -490,9 +491,28 @@ H5P_modify_filter(H5P_genplist_t *plist, H5Z_filter_t filter, unsigned flags, si
     if (H5P_peek(plist, H5O_CRT_PIPELINE_NAME, &pline) < 0)
         HGOTO_ERROR(H5E_PLIST, H5E_CANTGET, FAIL, "can't get pipeline");
 
-    /* Modify the filter parameters of the I/O pipeline */
-    if (H5Z_modify(&pline, filter, flags, cd_nelmts, cd_values) < 0)
-        HGOTO_ERROR(H5E_PLINE, H5E_CANTINIT, FAIL, "unable to add filter to pipeline");
+    if (pline.version < H5O_PLINE_VERSION_3) {
+
+        /* Get pointer to filter in pipeline */
+        /* Modify the filter parameters of the I/O pipeline */
+        if (H5Z_modify(pline.filter, pline.nused, id, flags, cd_nelmts, cd_values) < 0)
+            HGOTO_ERROR(H5E_PLINE, H5E_CANTINIT, FAIL, "unable to modify filter parameters in pipeline");
+    } else {
+        assert(pline.version == H5O_PLINE_VERSION_3);
+        H5Z_stc_filter_sect_t *filt_sect = NULL;
+        unsigned i;
+
+        for (i = 0, filt_sect = &pline.filt_sects[0]; i <  pline.tot_filt_nsects; i++, filt_sect++) {
+            if (filt_sect->seq_sect == (size_t)sec_type)
+                break;
+        }
+        if (i >= pline.tot_filt_nsects)
+            HGOTO_ERROR(H5E_ARGS, H5E_BADVALUE, H5Z_FILTER_ERROR, "no filter defined for sec_type");
+
+        /* Modify the filter parameters of the I/O pipeline */
+        if (H5Z_modify(filt_sect->filter, filt_sect->nused, id, flags, cd_nelmts, cd_values) < 0)
+            HGOTO_ERROR(H5E_PLINE, H5E_CANTINIT, FAIL, "unable to modify filter parameters in pipeline");
+    }
 
     /* Put the I/O pipeline information back into the property list */
     if (H5P_poke(plist, H5O_CRT_PIPELINE_NAME, &pline) < 0)
@@ -503,7 +523,7 @@ done:
 } /* end H5P_modify_filter() */
 
 /*-------------------------------------------------------------------------
- * Function:    H5Pmodify_filter
+ * Function:    H5Pmodify_filter1
  *
  * Purpose:     Modifies the specified FILTER in the
  *              transient or permanent output filter pipeline
@@ -535,8 +555,9 @@ done:
  *
  *-------------------------------------------------------------------------
  */
+/* HERE need to add to versioning ? */
 herr_t
-H5Pmodify_filter(hid_t plist_id, H5Z_filter_t filter, unsigned int flags, size_t cd_nelmts,
+H5Pmodify_filter1(hid_t plist_id, H5Z_filter_t filter, unsigned int flags, size_t cd_nelmts,
                  const unsigned int cd_values[/*cd_nelmts*/])
 {
     H5P_genplist_t *plist;               /* Property list */
@@ -557,12 +578,12 @@ H5Pmodify_filter(hid_t plist_id, H5Z_filter_t filter, unsigned int flags, size_t
         HGOTO_ERROR(H5E_ID, H5E_BADID, FAIL, "can't find object for ID");
 
     /* Modify the filter parameters of the I/O pipeline */
-    if (H5P_modify_filter(plist, filter, flags, cd_nelmts, cd_values) < 0)
+    if (H5P_modify_filter(plist, filter, H5_SECTION_UNKNOWN, flags, cd_nelmts, cd_values) < 0)
         HGOTO_ERROR(H5E_PLIST, H5E_CANTINIT, FAIL, "can't modify filter");
 
 done:
     FUNC_LEAVE_API(ret_value)
-} /* end H5Pmodify_filter() */
+} /* end H5Pmodify_filter1() */
 
 /*-------------------------------------------------------------------------
  * Function:    H5Pmodify_filter2
@@ -603,9 +624,10 @@ done:
  *
  *-------------------------------------------------------------------------
  */
+/* HERE need to add to versioning ? */
 herr_t
-H5Pmodify_filter2(hid_t plist_id, uint64_t H5_ATTR_UNUSED section_number, H5Z_filter_t filter, uint64_t flags,
-                  size_t buf_size, const void *buf)
+H5Pmodify_filter2(hid_t plist_id, H5_section_type_t sec_type, H5Z_filter_t filter, unsigned int flags,
+                  size_t cd_nelmts, const unsigned int cd_values[/*cd_nelmts*/])
 {
     H5P_genplist_t *plist;               /* Property list */
     herr_t          ret_value = SUCCEED; /* return value */
@@ -617,27 +639,141 @@ H5Pmodify_filter2(hid_t plist_id, uint64_t H5_ATTR_UNUSED section_number, H5Z_fi
         HGOTO_ERROR(H5E_ARGS, H5E_BADVALUE, FAIL, "invalid filter identifier");
     if (flags & ~((unsigned)H5Z_FLAG_DEFMASK))
         HGOTO_ERROR(H5E_ARGS, H5E_BADVALUE, FAIL, "invalid flags");
-    if (buf_size > 0 && !buf)
+    if (cd_nelmts > 0 && !cd_values)
         HGOTO_ERROR(H5E_ARGS, H5E_BADVALUE, FAIL, "no client data values supplied");
 
     /* Get the plist structure */
     if (NULL == (plist = H5P_object_verify(plist_id, H5P_OBJECT_CREATE, false)))
         HGOTO_ERROR(H5E_ID, H5E_BADID, FAIL, "can't find object for ID");
 
-#ifdef TBD
-
-    Call new H5P_modify_filter() with buf_size and buf instead of cd_nelmts and cd_values
-
-        /* Modify the filter parameters of the I/O pipeline */
-        if (H5P_modify_filter(plist, filter, flags, cd_nelmts, cd_values) < 0)
-            HGOTO_ERROR(H5E_PLIST, H5E_CANTINIT, FAIL, "can't modify filter");
-#endif
-
-    /* For now, just return SUCCEED */
+    /* Modify the filter parameters of the I/O pipeline */
+    if (H5P_modify_filter(plist, filter, sec_type, flags, cd_nelmts, cd_values) < 0)
+        HGOTO_ERROR(H5E_PLIST, H5E_CANTINIT, FAIL, "can't modify filter");
 
 done:
     FUNC_LEAVE_API(ret_value)
 } /* end H5Pmodify_filter2() */
+
+
+/*-------------------------------------------------------------------------
+ * Function:    H5Pset_filter1
+ *
+ * Purpose:    Adds the specified FILTER and corresponding properties to the
+ *        end of the data or link output filter pipeline
+ *        depending on whether PLIST is a dataset creation or group
+ *        creation property list.  The FLAGS argument specifies certain
+ *        general properties of the filter and is documented below.
+ *        The CD_VALUES is an array of CD_NELMTS integers which are
+ *        auxiliary data for the filter.  The integer values will be
+ *        stored in the dataset object header as part of the filter
+ *        information.
+ *
+ *         The FLAGS argument is a bit vector of the following fields:
+ *
+ *         H5Z_FLAG_OPTIONAL(0x0001)
+ *        If this bit is set then the filter is optional.  If the
+ *        filter fails during an H5Dwrite() operation then the filter
+ *        is just excluded from the pipeline for the chunk for which it
+ *        failed; the filter will not participate in the pipeline
+ *        during an H5Dread() of the chunk.  If this bit is clear and
+ *        the filter fails then the entire I/O operation fails.
+ *      If this bit is set but encoding is disabled for a filter,
+ *      attempting to write will generate an error.
+ *
+ * Return:    Non-negative on success/Negative on failure
+ *
+ *-------------------------------------------------------------------------
+ */
+herr_t
+H5Pset_filter1(hid_t plist_id, H5Z_filter_t filter, unsigned int flags, size_t cd_nelmts,
+              const unsigned int cd_values[/*cd_nelmts*/])
+{
+    H5P_genplist_t *plist;               /* Property list */
+    herr_t          ret_value = SUCCEED; /* return value */
+
+    FUNC_ENTER_API(FAIL)
+
+    /* Check args */
+    if (filter < 0 || filter > H5Z_FILTER_MAX)
+        HGOTO_ERROR(H5E_ARGS, H5E_BADVALUE, FAIL, "invalid filter identifier");
+    if (flags & ~((unsigned)H5Z_FLAG_DEFMASK))
+        HGOTO_ERROR(H5E_ARGS, H5E_BADVALUE, FAIL, "invalid flags");
+    if (cd_nelmts > 0 && !cd_values)
+        HGOTO_ERROR(H5E_ARGS, H5E_BADVALUE, FAIL, "no client data values supplied");
+
+    /* Get the plist structure */
+    if (NULL == (plist = H5P_object_verify(plist_id, H5P_OBJECT_CREATE, false)))
+        HGOTO_ERROR(H5E_ID, H5E_BADID, FAIL, "can't find object for ID");
+
+    /* Call the private function */
+    if (H5P__set_filter1(plist, filter, flags, cd_nelmts, cd_values) < 0)
+        HGOTO_ERROR(H5E_PLIST, H5E_CANTSET, FAIL, "failed to call private function");
+
+done:
+    FUNC_LEAVE_API(ret_value)
+} /* end H5Pset_filter1() */
+
+/*-------------------------------------------------------------------------
+ * Function:    H5P__set_filter1
+ *
+ * Purpose:    Adds the specified FILTER and corresponding properties to the
+ *        end of the data or link output filter pipeline
+ *        depending on whether PLIST is a dataset creation or group
+ *        creation property list.  The FLAGS argument specifies certain
+ *        general properties of the filter and is documented below.
+ *        The CD_VALUES is an array of CD_NELMTS integers which are
+ *        auxiliary data for the filter.  The integer values will be
+ *        stored in the dataset object header as part of the filter
+ *        information.
+ *
+ *         The FLAGS argument is a bit vector of the following fields:
+ *
+ *         H5Z_FLAG_OPTIONAL(0x0001)
+ *        If this bit is set then the filter is optional.  If the
+ *        filter fails during an H5Dwrite() operation then the filter
+ *        is just excluded from the pipeline for the chunk for which it
+ *        failed; the filter will not participate in the pipeline
+ *        during an H5Dread() of the chunk.  If this bit is clear and
+ *        the filter fails then the entire I/O operation fails.
+ *        If this bit is set but encoding is disabled for a filter,
+ *        attempting to write will generate an error.
+ *
+ *              If the filter is not registered, this function tries to load
+ *              it dynamically during run time.
+ *
+ * Return:    Non-negative on success/Negative on failure
+ *
+ *-------------------------------------------------------------------------
+ */
+static herr_t
+H5P__set_filter1(H5P_genplist_t *plist, H5Z_filter_t filter, unsigned int flags, size_t cd_nelmts,
+                const unsigned int cd_values[/*cd_nelmts*/])
+{
+    H5O_pline_t pline;               /* Filter pipeline */
+    htri_t      filter_avail;        /* Filter availability */
+    herr_t      ret_value = SUCCEED; /* Return value */
+
+    FUNC_ENTER_PACKAGE
+
+    /* Check if filter is already available */
+    if ((filter_avail = H5Z_filter_avail(filter)) < 0)
+        HGOTO_ERROR(H5E_PLIST, H5E_CANTSET, FAIL, "can't check filter availability");
+
+    /* Get the pipeline property to append to */
+    if (H5P_peek(plist, H5O_CRT_PIPELINE_NAME, &pline) < 0)
+        HGOTO_ERROR(H5E_PLIST, H5E_CANTGET, FAIL, "can't get pipeline");
+
+    /* Add the filter to the I/O pipeline */
+    if (H5Z_append(&pline, filter, flags, cd_nelmts, cd_values) < 0)
+        HGOTO_ERROR(H5E_PLINE, H5E_CANTINIT, FAIL, "unable to add filter to pipeline");
+
+    /* Put the I/O pipeline information back into the property list */
+    if (H5P_poke(plist, H5O_CRT_PIPELINE_NAME, &pline) < 0)
+        HGOTO_ERROR(H5E_PLIST, H5E_CANTSET, FAIL, "can't set pipeline");
+
+done:
+    FUNC_LEAVE_NOAPI(ret_value)
+} /* end H5P__set_filter1() */
 
 /*-------------------------------------------------------------------------
  * Function:    H5Pset_filter2
@@ -648,8 +784,8 @@ done:
  *        The PLIST_ID argument is a dataset creation or group
  *        creation property list.
  *
- *        The SECTION_NUMBER argument specified the section of the
- *        structured chunk to which the filter is applied.
+ *        The SEC_TYPE argument is the type identifier for a section 
+ *        in structured chunk to which the filter is applied.
  *
  *        The FILTER argument is the filter identifier for the filter
  *        to be added to the pipeline.
@@ -657,8 +793,8 @@ done:
  *        The FLAGS argument specifies certain
  *        general properties of the filter and is documented below.
  *
- *        The BUF argument points to a buffer of BUF_SIZE bytes which
- *        contains auxiliary data for the filter.  The values will be
+ *        The CD_VALUES is an array of CD_NELMTS integers which are
+ *        auxiliary data for the filter.  The integer values will be
  *        stored in the dataset object header as part of the filter
  *        information.
  *
@@ -681,31 +817,43 @@ done:
  *
  *-------------------------------------------------------------------------
  */
+/* HERE */
 herr_t
-H5Pset_filter2(hid_t plist_id, uint64_t H5_ATTR_UNUSED section_number, H5Z_filter_t filter, uint64_t flags,
-               size_t buf_size, const void *buf)
+H5Pset_filter2(hid_t plist_id, H5_section_type_t sec_type, H5Z_filter_t filter, unsigned int flags,
+               size_t cd_nelmts, const unsigned int cd_values[/*cd_nelmts*/])
 {
     H5P_genplist_t *plist;               /* Property list */
+    H5O_layout_t    layout;    /* Layout property */
     herr_t          ret_value = SUCCEED; /* return value */
 
     FUNC_ENTER_API(FAIL)
 
     /* Check args */
-    if (filter > 255)
-        HGOTO_ERROR(H5E_ARGS, H5E_BADVALUE, FAIL, "invalid section number");
+    if (sec_type < 0 || sec_type > H5_SECTION_NUM)
+        HGOTO_ERROR(H5E_ARGS, H5E_BADVALUE, FAIL, "invalid section ");
+
     if (filter < 0 || filter > H5Z_FILTER_MAX)
         HGOTO_ERROR(H5E_ARGS, H5E_BADVALUE, FAIL, "invalid filter identifier");
+
     if (flags & ~((unsigned)H5Z_FLAG_DEFMASK))
         HGOTO_ERROR(H5E_ARGS, H5E_BADVALUE, FAIL, "invalid flags");
-    if (buf_size > 0 && !buf)
+
+    if (cd_nelmts > 0 && !cd_values)
         HGOTO_ERROR(H5E_ARGS, H5E_BADVALUE, FAIL, "no client data values supplied");
 
     /* Get the plist structure */
     if (NULL == (plist = H5P_object_verify(plist_id, H5P_OBJECT_CREATE, false)))
         HGOTO_ERROR(H5E_ID, H5E_BADID, FAIL, "can't find object for ID");
 
+    /* Peek at layout property */
+    if (H5P_peek(plist, H5D_CRT_LAYOUT_NAME, &layout) < 0)
+        HGOTO_ERROR(H5E_PLIST, H5E_CANTGET, FAIL, "can't get layout");
+
+    if (layout.type != H5D_STRUCT_CHUNK)
+        HGOTO_ERROR(H5E_PLIST, H5E_BADVALUE, FAIL, "incorrect layout for setting filter");
+
     /* Call the private function */
-    if (H5P__set_filter2(plist, section_number, filter, flags, buf_size, buf) < 0)
+    if (H5P__set_filter2(plist, sec_type, filter, flags, cd_nelmts, cd_values) < 0)
         HGOTO_ERROR(H5E_PLIST, H5E_CANTSET, FAIL, "failed to call private function");
 
 done:
@@ -739,6 +887,7 @@ done:
  *        filter fails during an H5Dwrite() operation then the filter
  *        is just excluded from the pipeline for the chunk for which it
  *        failed; the filter will not participate in the pipeline
+
  *        during an H5Dread() of the chunk.
  *
  *        If this bit is clear and the filter fails then the entire I/O
@@ -754,152 +903,50 @@ done:
  *
  *-------------------------------------------------------------------------
  */
+/* HERE */
 static herr_t
-H5P__set_filter2(H5P_genplist_t H5_ATTR_UNUSED *plist, uint64_t H5_ATTR_UNUSED section_number,
-                 H5Z_filter_t H5_ATTR_UNUSED filter, uint64_t H5_ATTR_UNUSED flags,
-                 size_t H5_ATTR_UNUSED buf_size, const void H5_ATTR_UNUSED *buf)
-{
-    herr_t ret_value = SUCCEED; /* Return value */
-
-    FUNC_ENTER_PACKAGE_NOERR
-
-#ifdef TBD
-    Need to set up new H5O_pline_t message Need to do something similar like H5P__set_filter1() as below :
-
-        /* Check if filter is already available */
-        if ((filter_avail = H5Z_filter_avail(filter)) < 0)
-
-            HGOTO_ERROR(H5E_PLIST, H5E_CANTSET, FAIL, "can't check filter availability");
-
-    /* Get the pipeline property to append to */
-    if (H5P_peek(plist, H5O_CRT_PIPELINE_NAME, &pline) < 0)
-        HGOTO_ERROR(H5E_PLIST, H5E_CANTGET, FAIL, "can't get pipeline");
-
-    /* Add the filter to the I/O pipeline */
-    if (H5Z_append(&pline, filter, flags, cd_nelmts, cd_values) < 0)
-        HGOTO_ERROR(H5E_PLINE, H5E_CANTINIT, FAIL, "unable to add filter to pipeline");
-
-    /* Put the I/O pipeline information back into the property list */
-    if (H5P_poke(plist, H5O_CRT_PIPELINE_NAME, &pline) < 0)
-        HGOTO_ERROR(H5E_PLIST, H5E_CANTSET, FAIL, "can't set pipeline");
-#endif
-
-    /* For now: just return SUCCEED */
-
-    FUNC_LEAVE_NOAPI(ret_value)
-} /* end H5P__set_filter2() */
-
-/*-------------------------------------------------------------------------
- * Function:    H5Pset_filter
- *
- * Purpose:    Adds the specified FILTER and corresponding properties to the
- *        end of the data or link output filter pipeline
- *        depending on whether PLIST is a dataset creation or group
- *        creation property list.  The FLAGS argument specifies certain
- *        general properties of the filter and is documented below.
- *        The CD_VALUES is an array of CD_NELMTS integers which are
- *        auxiliary data for the filter.  The integer values will be
- *        stored in the dataset object header as part of the filter
- *        information.
- *
- *         The FLAGS argument is a bit vector of the following fields:
- *
- *         H5Z_FLAG_OPTIONAL(0x0001)
- *        If this bit is set then the filter is optional.  If the
- *        filter fails during an H5Dwrite() operation then the filter
- *        is just excluded from the pipeline for the chunk for which it
- *        failed; the filter will not participate in the pipeline
- *        during an H5Dread() of the chunk.  If this bit is clear and
- *        the filter fails then the entire I/O operation fails.
- *      If this bit is set but encoding is disabled for a filter,
- *      attempting to write will generate an error.
- *
- * Return:    Non-negative on success/Negative on failure
- *
- *-------------------------------------------------------------------------
- */
-herr_t
-H5Pset_filter(hid_t plist_id, H5Z_filter_t filter, unsigned int flags, size_t cd_nelmts,
-              const unsigned int cd_values[/*cd_nelmts*/])
-{
-    H5P_genplist_t *plist;               /* Property list */
-    herr_t          ret_value = SUCCEED; /* return value */
-
-    FUNC_ENTER_API(FAIL)
-
-    /* Check args */
-    if (filter < 0 || filter > H5Z_FILTER_MAX)
-        HGOTO_ERROR(H5E_ARGS, H5E_BADVALUE, FAIL, "invalid filter identifier");
-    if (flags & ~((unsigned)H5Z_FLAG_DEFMASK))
-        HGOTO_ERROR(H5E_ARGS, H5E_BADVALUE, FAIL, "invalid flags");
-    if (cd_nelmts > 0 && !cd_values)
-        HGOTO_ERROR(H5E_ARGS, H5E_BADVALUE, FAIL, "no client data values supplied");
-
-    /* Get the plist structure */
-    if (NULL == (plist = H5P_object_verify(plist_id, H5P_OBJECT_CREATE, false)))
-        HGOTO_ERROR(H5E_ID, H5E_BADID, FAIL, "can't find object for ID");
-
-    /* Call the private function */
-    if (H5P__set_filter(plist, filter, flags, cd_nelmts, cd_values) < 0)
-        HGOTO_ERROR(H5E_PLIST, H5E_CANTSET, FAIL, "failed to call private function");
-
-done:
-    FUNC_LEAVE_API(ret_value)
-} /* end H5Pset_filter() */
-
-/*-------------------------------------------------------------------------
- * Function:    H5P__set_filter
- *
- * Purpose:    Adds the specified FILTER and corresponding properties to the
- *        end of the data or link output filter pipeline
- *        depending on whether PLIST is a dataset creation or group
- *        creation property list.  The FLAGS argument specifies certain
- *        general properties of the filter and is documented below.
- *        The CD_VALUES is an array of CD_NELMTS integers which are
- *        auxiliary data for the filter.  The integer values will be
- *        stored in the dataset object header as part of the filter
- *        information.
- *
- *         The FLAGS argument is a bit vector of the following fields:
- *
- *         H5Z_FLAG_OPTIONAL(0x0001)
- *        If this bit is set then the filter is optional.  If the
- *        filter fails during an H5Dwrite() operation then the filter
- *        is just excluded from the pipeline for the chunk for which it
- *        failed; the filter will not participate in the pipeline
- *        during an H5Dread() of the chunk.  If this bit is clear and
- *        the filter fails then the entire I/O operation fails.
- *        If this bit is set but encoding is disabled for a filter,
- *        attempting to write will generate an error.
- *
- *              If the filter is not registered, this function tries to load
- *              it dynamically during run time.
- *
- * Return:    Non-negative on success/Negative on failure
- *
- *-------------------------------------------------------------------------
- */
-static herr_t
-H5P__set_filter(H5P_genplist_t *plist, H5Z_filter_t filter, unsigned int flags, size_t cd_nelmts,
-                const unsigned int cd_values[/*cd_nelmts*/])
+H5P__set_filter2(H5P_genplist_t *plist, H5_section_type_t sec_type, H5Z_filter_t filter_id, unsigned int flags,
+                 size_t cd_nelmts, const unsigned int cd_values[/*cd_nelmts*/])
 {
     H5O_pline_t pline;               /* Filter pipeline */
     htri_t      filter_avail;        /* Filter availability */
+    H5Z_stc_filter_sect_t *filt_sect = NULL;
+    bool found = false;
+    unsigned i = 0;
     herr_t      ret_value = SUCCEED; /* Return value */
 
     FUNC_ENTER_PACKAGE
 
     /* Check if filter is already available */
-    if ((filter_avail = H5Z_filter_avail(filter)) < 0)
+    if ((filter_avail = H5Z_filter_avail(filter_id)) < 0)
         HGOTO_ERROR(H5E_PLIST, H5E_CANTSET, FAIL, "can't check filter availability");
 
     /* Get the pipeline property to append to */
     if (H5P_peek(plist, H5O_CRT_PIPELINE_NAME, &pline) < 0)
         HGOTO_ERROR(H5E_PLIST, H5E_CANTGET, FAIL, "can't get pipeline");
 
-    /* Add the filter to the I/O pipeline */
-    if (H5Z_append(&pline, filter, flags, cd_nelmts, cd_values) < 0)
+    /* For structured chunk, pline version should be 3 */
+    if (pline.version != H5O_PLINE_VERSION_3)
+        pline.version = H5O_PLINE_VERSION_3; 
+
+    for (i = 0; i <  pline.tot_filt_nsects; i++)
+        if (pline.filt_sects[i].seq_sect == (size_t)sec_type) {
+            found = true;
+            break;
+        }
+
+    filt_sect = &pline.filt_sects[i];
+
+    /* Add the filter to the I/O pipeline for the section */
+    if (H5Z_append_filter(filter_id, flags, cd_nelmts, cd_values, 
+                          &filt_sect->filter, &filt_sect->nused, &filt_sect->nalloc) < 0)
         HGOTO_ERROR(H5E_PLINE, H5E_CANTINIT, FAIL, "unable to add filter to pipeline");
+
+    /* Add the new filter to the pipeline */
+    if (!found) {
+        pline.tot_filt_nsects++;
+        filt_sect->seq_sect = (size_t)sec_type;
+    }
 
     /* Put the I/O pipeline information back into the property list */
     if (H5P_poke(plist, H5O_CRT_PIPELINE_NAME, &pline) < 0)
@@ -907,10 +954,10 @@ H5P__set_filter(H5P_genplist_t *plist, H5Z_filter_t filter, unsigned int flags, 
 
 done:
     FUNC_LEAVE_NOAPI(ret_value)
-} /* end H5P__set_filter() */
+} /* end H5P__set_filter2() */
 
 /*-------------------------------------------------------------------------
- * Function:    H5Pget_nfilters
+ * Function:    H5Pget_nfilters1
  *
  * Purpose:    Returns the number of filters in the data or link
  *        pipeline depending on whether PLIST_ID is a dataset creation
@@ -927,7 +974,7 @@ done:
  *-------------------------------------------------------------------------
  */
 int
-H5Pget_nfilters(hid_t plist_id)
+H5Pget_nfilters1(hid_t plist_id)
 {
     H5P_genplist_t *plist;     /* Property list */
     H5O_pline_t     pline;     /* Filter pipeline */
@@ -948,7 +995,7 @@ H5Pget_nfilters(hid_t plist_id)
 
 done:
     FUNC_LEAVE_API(ret_value)
-} /* end H5Pget_nfilters */
+} /* end H5Pget_nfilters1 */
 
 /*-------------------------------------------------------------------------
  * Function:    H5Pget_nfilters2
@@ -957,24 +1004,27 @@ done:
  *        pipeline depending on whether PLIST_ID is a dataset creation
  *        or group creation property list.
  *        In each pipeline the filters are numbered from zero through
- *        N-1 where N is the value returned by this function.
+ *        N-1 where N is the value returned by this function in the 
+ *        parameter NUM_FILTERS.
  *        During output to the file the filters of a pipeline are applied
  *        in increasing order (the inverse is true for input).
  *
- *        The SECTION_NUMBER argument specified the section of the
- *        structured chunk to which the filter is applied.
+ *        The argument SEC_TYPE is the type identifier for a section
+ *        in the structured chunk.
  *
- * Return:    Success:    Number of filters or zero if there are none.
- *
- *        Failure:    Negative
+ * Return:    Non-negative on success/Negative on failure
  *
  *-------------------------------------------------------------------------
  */
-int
-H5Pget_nfilters2(hid_t plist_id, uint64_t H5_ATTR_UNUSED section_number)
+/* HERE */
+herr_t
+H5Pget_nfilters2(hid_t plist_id, H5_section_type_t sec_type, int *num_filters)
 {
     H5P_genplist_t *plist;     /* Property list */
-    int             ret_value; /* return value */
+    H5O_pline_t     pline;     /* Filter pipeline */
+    unsigned        i;
+    int             num;
+    herr_t          ret_value = SUCCEED; /* return value */
 
     FUNC_ENTER_API(FAIL)
 
@@ -982,20 +1032,21 @@ H5Pget_nfilters2(hid_t plist_id, uint64_t H5_ATTR_UNUSED section_number)
     if (NULL == (plist = H5P_object_verify(plist_id, H5P_OBJECT_CREATE, true)))
         HGOTO_ERROR(H5E_ID, H5E_BADID, FAIL, "can't find object for ID");
 
-#ifdef TBD
-
-    Need to get the new pline with pline.nused for the specified section
-
     /* Get the pipeline property to query */
     if (H5P_peek(plist, H5O_CRT_PIPELINE_NAME, &pline) < 0)
         HGOTO_ERROR(H5E_PLIST, H5E_CANTGET, FAIL, "can't get pipeline");
 
     /* Set return value */
-    ret_value = (int)(pline.nused);
-#endif
-
-    /* For now just return 0 */
     ret_value = 0;
+    for (i = 0; i <  pline.tot_filt_nsects; i++) {
+        if (pline.filt_sects[i].seq_sect == (size_t)sec_type) {
+            num = (int)(pline.filt_sects[i].nused);
+            break;
+        }
+    }
+
+    if (num_filters)
+        *num_filters = num;
 
 done:
     FUNC_LEAVE_API(ret_value)
@@ -1093,14 +1144,15 @@ done:
  *        dataset creation or group creation property list.
  *
  *        On input:
- *        SECTION_NUMBER is the specified section of the structured chunk
+ *        SEC_TYPE is the type identifier for a section in the structured
+ *        chunk.
  *
  *        IDX should be a value between zero and N-1 as described
- *        for H5Pget_nfilters().
+ *        for H5Pget_nfilters2().
  *
- *        BUF_SIZE indicates the size in bytes of the buffer pointed to
- *        by BUF which is allocated by the caller.  On exit, it contains the
- *        values defined by the filter.
+ *        CD_NELMTS indicates the number of entries in the CD_VALUES
+ *        array allocated by the caller.  On exit it contains the
+ *        number of values defined by the filter.
  *
  *        FILTER_CONFIG is a bit field containing encode/decode flags from H5Zpublic.h.
  *
@@ -1111,26 +1163,22 @@ done:
  *
  *-------------------------------------------------------------------------
  */
+/* HERE */
 H5Z_filter_t
-H5Pget_filter3(hid_t H5_ATTR_UNUSED plist_id, uint64_t H5_ATTR_UNUSED section_number,
-               unsigned H5_ATTR_UNUSED idx, uint64_t H5_ATTR_UNUSED *flags /*out*/,
-               size_t H5_ATTR_UNUSED *buf_size /*in,out*/, void H5_ATTR_UNUSED *buf /*out*/,
-               size_t H5_ATTR_UNUSED namelen, char H5_ATTR_UNUSED name[] /*out*/,
-               unsigned H5_ATTR_UNUSED *filter_config /*out*/)
+H5Pget_filter3(hid_t plist_id, H5_section_type_t sec_type, unsigned idx, unsigned int *flags /*out*/,
+               size_t *cd_nelmts /*in,out*/, unsigned cd_values[] /*out*/, 
+               size_t namelen /*in*/, char name[] /*out*/, unsigned *filter_config /*out*/)
 {
+    H5P_genplist_t          *plist;     /* Property list */
+    const H5Z_filter_info_t *filter;    /* Pointer to filter information */
+    H5O_pline_t              pline;     /* Filter pipeline */
+    unsigned i;
     H5Z_filter_t ret_value; /* return value */
 
     FUNC_ENTER_API(H5Z_FILTER_ERROR)
-
-#ifdef TBD
-
-    --Check arguments buf_size and buf instead of cd_nelmts and cd_values
-    --Obtain new pline info for structured chunk
-    --Call new H5P__get_filter() routine with buf_size and buf in place of cd_nelemts and cd_values
-
+    
     /* Check args */
-    if (cd_nelmts || cd_values)
-    {
+    if (cd_nelmts || cd_values) {
         /*
          * It's likely that users forget to initialize this on input, so
          * we'll check that it has a reasonable value.  The actual number
@@ -1159,23 +1207,24 @@ H5Pget_filter3(hid_t H5_ATTR_UNUSED plist_id, uint64_t H5_ATTR_UNUSED section_nu
     if (H5P_peek(plist, H5O_CRT_PIPELINE_NAME, &pline) < 0)
         HGOTO_ERROR(H5E_PLIST, H5E_CANTGET, H5Z_FILTER_ERROR, "can't get pipeline");
 
-    /* Check index */
-    if (idx >= pline.nused)
-        HGOTO_ERROR(H5E_ARGS, H5E_BADVALUE, H5Z_FILTER_ERROR, "filter number is invalid");
+    for (i = 0; i <  pline.tot_filt_nsects; i++) {
+        if (pline.filt_sects[i].seq_sect == (size_t)sec_type) {
+            if (idx >= pline.filt_sects[i].nused)
+                HGOTO_ERROR(H5E_ARGS, H5E_BADVALUE, H5Z_FILTER_ERROR, "filter number is invalid");
+            break;
+        }
+    }
+    if (i == pline.tot_filt_nsects)
+        HGOTO_ERROR(H5E_ARGS, H5E_BADVALUE, H5Z_FILTER_ERROR, "no filter defined for sec_type");
 
     /* Set pointer to particular filter to query */
-    filter = &pline.filter[idx];
+    filter = &pline.filt_sects[i].filter[idx];
 
-    /* Get filter information */
     if (H5P__get_filter(filter, flags, cd_nelmts, cd_values, namelen, name, filter_config) < 0)
         HGOTO_ERROR(H5E_PLIST, H5E_CANTGET, H5Z_FILTER_ERROR, "can't get filter info");
 
-    /* Set return value */
-    ret_value = filter->id;
-#endif
-
     /* For new just return 0 */
-    ret_value = H5Z_FILTER_NONE;
+    ret_value = filter->id;
 
 done:
     FUNC_LEAVE_API(ret_value)
@@ -1201,9 +1250,9 @@ done:
  *-------------------------------------------------------------------------
  */
 herr_t
-H5P_get_filter_by_id(H5P_genplist_t *plist, H5Z_filter_t id, unsigned int *flags /*out*/,
-                     size_t *cd_nelmts /*in,out*/, unsigned cd_values[] /*out*/, size_t namelen,
-                     char name[] /*out*/, unsigned *filter_config)
+H5P_get_filter_by_id(H5P_genplist_t *plist, H5Z_filter_t id, H5_section_type_t sec_type, 
+                     unsigned int *flags /*out*/, size_t *cd_nelmts /*in,out*/, unsigned cd_values[] /*out*/, 
+                     size_t namelen, char name[] /*out*/, unsigned *filter_config)
 {
     H5O_pline_t        pline;               /* Filter pipeline */
     H5Z_filter_info_t *filter;              /* Pointer to filter information */
@@ -1215,9 +1264,29 @@ H5P_get_filter_by_id(H5P_genplist_t *plist, H5Z_filter_t id, unsigned int *flags
     if (H5P_peek(plist, H5O_CRT_PIPELINE_NAME, &pline) < 0)
         HGOTO_ERROR(H5E_PLIST, H5E_CANTGET, FAIL, "can't get pipeline");
 
-    /* Get pointer to filter in pipeline */
-    if (NULL == (filter = H5Z_filter_info(&pline, id)))
-        HGOTO_ERROR(H5E_ARGS, H5E_BADVALUE, FAIL, "filter ID is invalid");
+    if (pline.version < H5O_PLINE_VERSION_3) {
+
+        /* Get pointer to filter in pipeline */
+        if (NULL == (filter = H5Z_filter_info(pline.filter, pline.nused, id)))
+            HGOTO_ERROR(H5E_ARGS, H5E_BADVALUE, FAIL, "filter ID is invalid");
+
+    } else {
+        assert(pline.version == H5O_PLINE_VERSION_3);
+        H5Z_stc_filter_sect_t *filt_sect = NULL;
+        unsigned i;
+        
+        for (i = 0, filt_sect = &pline.filt_sects[0]; i <  pline.tot_filt_nsects; i++, filt_sect++) {
+            if (filt_sect->seq_sect == (size_t)sec_type)
+                break;
+        }
+        if (i >= pline.tot_filt_nsects)
+            HGOTO_ERROR(H5E_ARGS, H5E_BADVALUE, H5Z_FILTER_ERROR, "no filter defined for sect_type");
+
+        /* Get pointer to filter in pipeline */
+        if (NULL == (filter = H5Z_filter_info(filt_sect->filter, filt_sect->nused, id)))
+            HGOTO_ERROR(H5E_ARGS, H5E_BADVALUE, FAIL, "filter ID is invalid");
+
+    } 
 
     /* Get filter information */
     if (H5P__get_filter(filter, flags, cd_nelmts, cd_values, namelen, name, filter_config) < 0)
@@ -1284,7 +1353,7 @@ H5Pget_filter_by_id2(hid_t plist_id, H5Z_filter_t id, unsigned int *flags /*out*
         HGOTO_ERROR(H5E_ID, H5E_BADID, FAIL, "can't find object for ID");
 
     /* Get filter information */
-    if (H5P_get_filter_by_id(plist, id, flags, cd_nelmts, cd_values, namelen, name, filter_config) < 0)
+    if (H5P_get_filter_by_id(plist, id, H5_SECTION_UNKNOWN, flags, cd_nelmts, cd_values, namelen, name, filter_config) < 0)
         HGOTO_ERROR(H5E_PLIST, H5E_CANTGET, FAIL, "can't get filter info");
 
 done:
@@ -1320,26 +1389,25 @@ done:
  *
  *-------------------------------------------------------------------------
  */
+/* HERE need to add to versioning ? */
 herr_t
-H5Pget_filter_by_id3(hid_t H5_ATTR_UNUSED plist_id, uint64_t H5_ATTR_UNUSED section_number, H5Z_filter_t id,
-                     uint64_t H5_ATTR_UNUSED *flags /*out*/, size_t H5_ATTR_UNUSED *buf_size /*in,out*/,
-                     void H5_ATTR_UNUSED *buf /*out*/, size_t H5_ATTR_UNUSED namelen,
-                     char H5_ATTR_UNUSED name[] /*out*/, unsigned H5_ATTR_UNUSED *filter_config /*out*/)
+H5Pget_filter_by_id3(hid_t plist_id, H5_section_type_t sec_type, H5Z_filter_t id, unsigned int *flags /*out*/, 
+                     size_t *cd_nelmts /*in,out*/, unsigned cd_values[] /*out*/, 
+                     size_t namelen /*in*/, char name[] /*out*/, unsigned *filter_config /*out*/)
 {
+    H5P_genplist_t *plist;      /* Property list */
     herr_t ret_value = SUCCEED; /* Return value */
 
-    FUNC_ENTER_API(FAIL)
+    FUNC_ENTER_API(H5Z_FILTER_ERROR)
 
     /* Check args */
+    if (sec_type < 0 || sec_type > H5_SECTION_NUM)
+        HGOTO_ERROR(H5E_ARGS, H5E_BADVALUE, FAIL, "invalid section ");
+
     if (id < 0 || id > H5Z_FILTER_MAX)
         HGOTO_ERROR(H5E_ARGS, H5E_BADVALUE, FAIL, "filter ID value out of range");
 
-#ifdef TBD
-    --Check arguments buf_size and buf instead of cd_nelmts  and cd_values-- Call new H5P_get_filter_by_id()
-        routine with buf_size and buf in place of cd_nelemts and cd_values
-
-        if (cd_nelmts || cd_values)
-    {
+    if (cd_nelmts || cd_values) {
         /*
          * It's likely that users forget to initialize this on input, so
          * we'll check that it has a reasonable value.  The actual number
@@ -1364,11 +1432,9 @@ H5Pget_filter_by_id3(hid_t H5_ATTR_UNUSED plist_id, uint64_t H5_ATTR_UNUSED sect
         HGOTO_ERROR(H5E_ID, H5E_BADID, FAIL, "can't find object for ID");
 
     /* Get filter information */
-    if (H5P_get_filter_by_id(plist, id, flags, cd_nelmts, cd_values, namelen, name, filter_config) < 0)
+    if (H5P_get_filter_by_id(plist, id, sec_type, flags, cd_nelmts, cd_values, namelen, name, filter_config) < 0)
         HGOTO_ERROR(H5E_PLIST, H5E_CANTGET, FAIL, "can't get filter info");
-#endif
 
-    /* For now just return SUCCEED */
 done:
     FUNC_LEAVE_API(ret_value)
 } /* end H5Pget_filter_by_id3() */
@@ -1385,6 +1451,7 @@ done:
  *
  *-------------------------------------------------------------------------
  */
+/* HERE */
 htri_t
 H5Pall_filters_avail(hid_t plist_id)
 {
@@ -1402,9 +1469,25 @@ H5Pall_filters_avail(hid_t plist_id)
     if (H5P_peek(plist, H5O_CRT_PIPELINE_NAME, &pline) < 0)
         HGOTO_ERROR(H5E_PLIST, H5E_CANTGET, FAIL, "can't get pipeline");
 
-    /* Check if all filters are available */
-    if ((ret_value = H5Z_all_filters_avail(&pline)) < 0)
-        HGOTO_ERROR(H5E_PLIST, H5E_NOTFOUND, FAIL, "can't check pipeline information");
+    if (pline.version < H5O_PLINE_VERSION_3) {
+
+        /* Check if all filters are available */
+        if ((ret_value = H5Z_all_filters_avail(pline.filter, pline.nused)) < 0)
+            HGOTO_ERROR(H5E_PLIST, H5E_NOTFOUND, FAIL, "can't check pipeline information");
+
+    } else {
+        assert(pline.version == H5O_PLINE_VERSION_3);
+        H5Z_stc_filter_sect_t *filt_sect = NULL;
+        unsigned i;
+        
+        /* Check if all filters are available */
+        for (i = 0, filt_sect = &pline.filt_sects[0]; i <  pline.tot_filt_nsects; i++, filt_sect++) {
+            if ((ret_value = H5Z_all_filters_avail(filt_sect->filter, filt_sect->nused)) < 0)
+                HGOTO_ERROR(H5E_PLIST, H5E_NOTFOUND, FAIL, "can't check pipeline information");
+            if (ret_value == false)
+                break;
+        }
+    } 
 
 done:
     FUNC_LEAVE_API(ret_value)
@@ -1434,9 +1517,27 @@ H5P_filter_in_pline(H5P_genplist_t *plist, H5Z_filter_t id)
     if (H5P_peek(plist, H5O_CRT_PIPELINE_NAME, &pline) < 0)
         HGOTO_ERROR(H5E_PLIST, H5E_CANTGET, FAIL, "can't get pipeline");
 
-    /* Check if the file is in the pipeline */
-    if ((ret_value = H5Z_filter_in_pline(&pline, id)) < 0)
-        HGOTO_ERROR(H5E_PLINE, H5E_CANTCOMPARE, FAIL, "can't find filter");
+     if (pline.version < H5O_PLINE_VERSION_3) {
+
+        /* Get pointer to filter in pipeline */
+        if ((ret_value = H5Z_filter_in_pline(pline.filter, pline.nused, id)) < 0)
+            HGOTO_ERROR(H5E_PLINE, H5E_CANTCOMPARE, FAIL, "can't find filter");
+
+    } else {
+        assert(pline.version == H5O_PLINE_VERSION_3);
+        H5Z_stc_filter_sect_t *filt_sect = NULL;
+        unsigned i;
+
+        /* Check if filter is in the pipeline for each section */
+        for (i = 0, filt_sect = &pline.filt_sects[0]; i <  pline.tot_filt_nsects; i++, filt_sect++) {
+            if ((ret_value = H5Z_filter_in_pline(filt_sect->filter, filt_sect->nused, id)) < 0)
+                HGOTO_ERROR(H5E_PLINE, H5E_CANTCOMPARE, FAIL, "can't find filter");
+            if (ret_value)
+                break;
+        }
+        if (i >= pline.tot_filt_nsects)
+            ret_value = false;
+    }
 
 done:
     FUNC_LEAVE_NOAPI(ret_value)
@@ -1495,6 +1596,7 @@ done:
  *
  *-------------------------------------------------------------------------
  */
+/* TBD */
 herr_t
 H5Premove_filter2(hid_t H5_ATTR_UNUSED plist_id, uint64_t H5_ATTR_UNUSED section_number,
                   H5Z_filter_t H5_ATTR_UNUSED filter)
@@ -1622,8 +1724,6 @@ done:
 } /* end H5Pset_fletcher32() */
 
 /*-------------------------------------------------------------------------
- * Function:    H5P__get_filter
- *
  * Purpose:    Internal component of H5Pget_filter & H5Pget_filter_id
  *
  * Return:    Non-negative on success/Negative on failure
@@ -1662,7 +1762,7 @@ H5P__get_filter(const H5Z_filter_info_t *filter, unsigned int *flags /*out*/, si
 
         /* If there's no name on the filter, use the class's filter name */
         if (!s) {
-            H5Z_class2_t *cls;
+            H5Z_class3_t *cls;
 
             H5Z_find(true, filter->id, &cls);
             if (cls)
@@ -2263,7 +2363,7 @@ H5Pget_filter_by_id1(hid_t plist_id, H5Z_filter_t id, unsigned int *flags /*out*
         HGOTO_ERROR(H5E_ID, H5E_BADID, FAIL, "can't find object for ID");
 
     /* Get filter info */
-    if (H5P_get_filter_by_id(plist, id, flags, cd_nelmts, cd_values, namelen, name, NULL) < 0)
+    if (H5P_get_filter_by_id(plist, id, H5_SECTION_UNKNOWN, flags, cd_nelmts, cd_values, namelen, name, NULL) < 0)
         HGOTO_ERROR(H5E_PLIST, H5E_CANTGET, FAIL, "can't get filter info");
 
 done:

--- a/src/H5Pprivate.h
+++ b/src/H5Pprivate.h
@@ -195,11 +195,11 @@ H5_DLL herr_t H5P_set_vlen_mem_manager(H5P_genplist_t *plist, H5MM_allocate_t al
                                        H5MM_free_t free_func, void *free_info);
 H5_DLL herr_t H5P_is_fill_value_defined(const struct H5O_fill_t *fill, H5D_fill_value_t *status);
 H5_DLL int    H5P_fill_value_cmp(const void *value1, const void *value2, size_t size);
-H5_DLL herr_t H5P_modify_filter(H5P_genplist_t *plist, H5Z_filter_t filter, unsigned flags, size_t cd_nelmts,
-                                const unsigned cd_values[]);
-H5_DLL herr_t H5P_get_filter_by_id(H5P_genplist_t *plist, H5Z_filter_t id, unsigned int *flags,
-                                   size_t *cd_nelmts, unsigned cd_values[], size_t namelen, char name[],
-                                   unsigned *filter_config);
+H5_DLL herr_t H5P_modify_filter(H5P_genplist_t *plist, H5Z_filter_t id, H5_section_type_t sec_type, 
+                                unsigned flags, size_t cd_nelmts, const unsigned cd_values[]);
+H5_DLL herr_t H5P_get_filter_by_id(H5P_genplist_t *plist, H5Z_filter_t id, H5_section_type_t sec_type, 
+                                   unsigned int *flags, size_t *cd_nelmts, unsigned cd_values[], 
+                                   size_t namelen, char name[], unsigned *filter_config);
 H5_DLL htri_t H5P_filter_in_pline(H5P_genplist_t *plist, H5Z_filter_t id);
 H5_DLL bool   H5P_is_default_plist(hid_t plist_id);
 

--- a/src/H5Pprivate.h
+++ b/src/H5Pprivate.h
@@ -195,10 +195,10 @@ H5_DLL herr_t H5P_set_vlen_mem_manager(H5P_genplist_t *plist, H5MM_allocate_t al
                                        H5MM_free_t free_func, void *free_info);
 H5_DLL herr_t H5P_is_fill_value_defined(const struct H5O_fill_t *fill, H5D_fill_value_t *status);
 H5_DLL int    H5P_fill_value_cmp(const void *value1, const void *value2, size_t size);
-H5_DLL herr_t H5P_modify_filter(H5P_genplist_t *plist, H5Z_filter_t id, H5_section_type_t sec_type, 
+H5_DLL herr_t H5P_modify_filter(H5P_genplist_t *plist, H5Z_filter_t id, H5_section_type_t sec_type,
                                 unsigned flags, size_t cd_nelmts, const unsigned cd_values[]);
-H5_DLL herr_t H5P_get_filter_by_id(H5P_genplist_t *plist, H5Z_filter_t id, H5_section_type_t sec_type, 
-                                   unsigned int *flags, size_t *cd_nelmts, unsigned cd_values[], 
+H5_DLL herr_t H5P_get_filter_by_id(H5P_genplist_t *plist, H5Z_filter_t id, H5_section_type_t sec_type,
+                                   unsigned int *flags, size_t *cd_nelmts, unsigned cd_values[],
                                    size_t namelen, char name[], unsigned *filter_config);
 H5_DLL htri_t H5P_filter_in_pline(H5P_genplist_t *plist, H5Z_filter_t id);
 H5_DLL bool   H5P_is_default_plist(hid_t plist_id);

--- a/src/H5Ppublic.h
+++ b/src/H5Ppublic.h
@@ -11069,7 +11069,7 @@ H5_DLL herr_t H5Pget_filter_by_id1(hid_t plist_id, H5Z_filter_t id, unsigned int
  * \version 1.6.4 \p boot, \p freelist, \p stab, \p shhdr parameter types
  *                changed to unsigned.
  *
- ion_number* \since 1.0.0
+ * \since 1.0.0
  *
  */
 H5_DLL herr_t H5Pget_version(hid_t plist_id, unsigned *boot /*out*/, unsigned *freelist /*out*/,

--- a/src/H5Ppublic.h
+++ b/src/H5Ppublic.h
@@ -2133,13 +2133,13 @@ H5_DLL H5Z_filter_t H5Pget_filter2(hid_t plist_id, unsigned idx, unsigned int *f
  *        of the structured chunk
  *
  * \ocpl_id{plist_id}
- * \param[in]     section_number    An integer specifying section number of the structured chunk
+ * \param[in]     sec_type          Type identifier for a section in the structured chunk
  * \param[in]     idx               Sequence number within the filter pipeline of
  *                                  the filter for which information is sought
  * \param[out]    flags             Bit vector specifying certain general properties
  *                                  of the filter
- * \param[in,out] buf_size          Size in bytes of \p buf buffer
- * \param[out]    buf               Buffer with auxiliary data for the filter
+ * \param[in,out] cd_nelmts         Number of elements in \p cd_values
+ * \param[out]    cd_values         Auxiliary data for the filter
  * \param[in]     namelen           Anticipated number of characters in \p name
  * \param[out]    name              Name of the filter
  * \param[out]    filter_config     Bit field, as described in H5Zget_filter_info()
@@ -2159,25 +2159,25 @@ H5_DLL H5Z_filter_t H5Pget_filter2(hid_t plist_id, unsigned idx, unsigned int *f
  *                                     scale-offset algorithm
  *
  * \details H5Pget_filter3() returns information about a filter for a specified
- *          section in the structured chunk.  The filter is specified
+ *          section type in the structured chunk.  The filter is specified
  *          by its filter number, in a filter pipeline specified by the property
  *          list with which it is associated.
  *
  *          \p plist_id must be a dataset or group creation property list.
  *
- *          \p section_number is an integer specifying a section in the
+ *          \p sec_type is an identifer specifying the section type in the
  *          structured chunk.
  *
  *          \p idx is a value between zero and N-1, as described in
- *          H5Pget_nfilters(). The function will return a negative value if
+ *          H5Pget_nfilters2(). The function will return a negative value if
  *          the filter number is out of range.
  *
  *          The structure of the \p flags argument is discussed in
  *          H5Pset_filter2().
  *
- *          On input, \p buf_size indicates the size of the buffer pointerd
- *          to by \p buf, as allocated by the caller; on return,
- *          \p buf_size contains the size of the values defined by the filter.
+ *          On input, \p cd_nelmts indicates the number of entries in the
+ *          \p cd_values array, as allocated by the caller; on return,
+ *          \p cd_nelmts contains the number of values defined by the filter.
  *
  *          If \p name is a pointer to an array of at least \p namelen bytes,
  *          the filter name will be copied into that array. The name will be
@@ -2196,8 +2196,9 @@ H5_DLL H5Z_filter_t H5Pget_filter2(hid_t plist_id, unsigned idx, unsigned int *f
  * \since 1.x.x
  *
  */
-H5_DLL H5Z_filter_t H5Pget_filter3(hid_t plist_id, uint64_t section_number, unsigned idx,
-                                   uint64_t *flags /*out*/, size_t *buf_size /*in,out*/, void *buf /*out*/,
+H5_DLL H5Z_filter_t H5Pget_filter3(hid_t plist_id, H5_section_type_t sect_type, unsigned idx, 
+                                   unsigned int *flags /*out*/, 
+                                   size_t *cd_nelmts /*in,out*/, unsigned cd_values[] /*out*/,
                                    size_t namelen /*in*/, char name[] /*out*/,
                                    unsigned *filter_config /*out*/);
 
@@ -2266,7 +2267,7 @@ H5_DLL herr_t H5Pget_filter_by_id2(hid_t plist_id, H5Z_filter_t filter_id, unsig
  *        pipeline for a specified section of the structured chunk
  *
  * \ocpl_id{plist_id}
- * \param[in]     section_number    An integer specifying section number of the structured chunk
+ * \param[in]     sec_type      Type identifier for a section in the structured chunk
  * \param[in]     filter_id     Filter identifier
  * \param[out]    flags         Bit vector specifying certain general
  *                              properties of the filter
@@ -2325,10 +2326,9 @@ H5_DLL herr_t H5Pget_filter_by_id2(hid_t plist_id, H5Z_filter_t filter_id, unsig
  * \since 1.x.x
  *
  */
-H5_DLL herr_t H5Pget_filter_by_id3(hid_t plist_id, uint64_t section_number, H5Z_filter_t filter_id,
-                                   uint64_t *flags /*out*/, size_t *buf_size /*in,out*/, void *buf /*out*/,
-                                   size_t namelen /*in*/, char name[] /*out*/,
-                                   unsigned *filter_config /*out*/);
+H5_DLL herr_t H5Pget_filter_by_id3(hid_t plist_id, H5_section_type_t sec_type, H5Z_filter_t id, unsigned int *flags /*out*/, 
+                                   size_t *cd_nelmts /*in,out*/, unsigned cd_values[] /*out*/,
+                                   size_t namelen /*in*/, char name[] /*out*/, unsigned *filter_config /*out*/);
 
 /**
  * \ingroup OCPL
@@ -2340,7 +2340,7 @@ H5_DLL herr_t H5Pget_filter_by_id3(hid_t plist_id, uint64_t section_number, H5Z_
  * \return  Returns the number of filters in the pipeline if successful;
  *          otherwise returns a negative value.
  *
- * \details H5Pget_nfilters() returns the number of filters defined in the
+ * \details H5Pget_nfilters1() returns the number of filters defined in the
  *          filter pipeline associated with the property list \p plist_id.
  *
  *          In each pipeline, the filters are numbered from 0 through \TText{N-1},
@@ -2348,13 +2348,13 @@ H5_DLL herr_t H5Pget_filter_by_id3(hid_t plist_id, uint64_t section_number, H5Z_
  *          the file, the filters are applied in increasing order; during
  *          input from the file, they are applied in decreasing order.
  *
- *          H5Pget_nfilters() returns the number of filters in the pipeline,
+ *          H5Pget_nfilters1() returns the number of filters in the pipeline,
  *          including zero (0) if there are none.
  *
  * \since 1.0.0
  *
  */
-H5_DLL int H5Pget_nfilters(hid_t plist_id);
+H5_DLL int H5Pget_nfilters1(hid_t plist_id);
 
 /**
  * \ingroup OCPL
@@ -2362,22 +2362,23 @@ H5_DLL int H5Pget_nfilters(hid_t plist_id);
  * \brief Returns the number of filters in the pipeline for a section of the structured chunk
  *
  * \ocpl_id{plist_id}
- * \param[in] section_number    An integer specifying section number of the structured chunk
+ * \param[in] sec_type Type identifier for a section in the structured chunk
+ * \param[out] num_filters The number of filters defined for \p sec_type
  *
  * \return  Returns the number of filters in the pipeline if successful;
  *          otherwise returns a negative value.
  *
  * \details H5Pget_nfilters2() returns the number of filters defined in the
- *          filter pipeline for the section \p section_number that is
+ *          filter pipeline for the section type \p sec_type that is
  *          associated with the property list \p plist_id.
  *
  *          In each pipeline, the filters are numbered from 0 through \Code{N-1},
- *          where \c N is the value returned by this function. During output to
- *          the file, the filters are applied in increasing order; during
+ *          where \c N is the value returned in \p num_filters by this function. 
+ *          During output to the file, the filters are applied in increasing order; during
  *          input from the file, they are applied in decreasing order.
  *
- *          H5Pget_nfilters() returns the number of filters in the pipeline
- *          for the section \p section_number, including zero (0) if there are none.
+ *          H5Pget_nfilters2() returns the number of filters in the pipeline
+ *          for the section type \p sec_type, including zero (0) if there are none.
  *
  * \par Example
  * \snippet H5P_struct_chunk_examples.c struct_chunk_filter
@@ -2387,7 +2388,7 @@ H5_DLL int H5Pget_nfilters(hid_t plist_id);
  * \since 1.0.0
  *
  */
-H5_DLL int H5Pget_nfilters2(hid_t plist_id, uint64_t section_number);
+H5_DLL herr_t H5Pget_nfilters2(hid_t plist_id, H5_section_type_t sec_type, int *num_filters);
 
 /**
  * \ingroup OCPL
@@ -2436,7 +2437,7 @@ H5_DLL herr_t H5Pget_obj_track_times(hid_t plist_id, hbool_t *track_times);
  *
  * \return \herr_t
  *
- * \details H5Pmodify_filter() modifies the specified \p filter in the
+ * \details H5Pmodify_filter1() modifies the specified \p filter in the
  *          filter pipeline. \p plist_id must be a dataset or group
  *          creation property list.
  *
@@ -2449,8 +2450,8 @@ H5_DLL herr_t H5Pget_obj_track_times(hid_t plist_id, hbool_t *track_times);
  * \since 1.6.0
  *
  */
-H5_DLL herr_t H5Pmodify_filter(hid_t plist_id, H5Z_filter_t filter, unsigned int flags, size_t cd_nelmts,
-                               const unsigned int cd_values[/*cd_nelmts*/]);
+H5_DLL herr_t H5Pmodify_filter1(hid_t plist_id, H5Z_filter_t filter, unsigned int flags, size_t cd_nelmts,
+                                const unsigned int cd_values[/*cd_nelmts*/]);
 
 /**
  * \ingroup OCPL
@@ -2459,7 +2460,7 @@ H5_DLL herr_t H5Pmodify_filter(hid_t plist_id, H5Z_filter_t filter, unsigned int
  *        structured chunk
  *
  * \ocpl_id{plist_id}
- * \param[in] section_number    An integer specifying section number of the structured chunk
+ * \param[in] sec_type    Type identifier for a section in the structured chunk
  * \param[in] filter      Filter to be modified
  * \param[in] flags       Bit vector specifying certain general properties
  *                        of the filter
@@ -2490,8 +2491,9 @@ H5_DLL herr_t H5Pmodify_filter(hid_t plist_id, H5Z_filter_t filter, unsigned int
  * \since 1.x.x
  *
  */
-H5_DLL herr_t H5Pmodify_filter2(hid_t plist_id, uint64_t section_number, H5Z_filter_t filter, uint64_t flags,
-                                size_t buf_size, const void *buf);
+H5_DLL herr_t H5Pmodify_filter2(hid_t plist_id, H5_section_type_t sec_type, H5Z_filter_t filter, unsigned int flags,
+                  size_t cd_nelmts, const unsigned int cd_values[/*cd_nelmts*/]);
+
 
 /**
  * \ingroup OCPL
@@ -2794,7 +2796,7 @@ H5_DLL herr_t H5Pset_deflate(hid_t plist_id, unsigned level);
  * \param[in] flags     Bit vector specifying certain general properties of
  *                      the filter
  * \param[in] cd_nelmts Number of elements in \p c_values
- * \param[in] c_values  Auxiliary data for the filter
+ * \param[in] cd_values  Auxiliary data for the filter
  *
  * \return \herr_t
  *
@@ -3049,7 +3051,7 @@ H5_DLL herr_t H5Pset_deflate(hid_t plist_id, unsigned level);
  * \since 1.6.0
  *
  */
-H5_DLL herr_t H5Pset_filter(hid_t plist_id, H5Z_filter_t filter, unsigned int flags, size_t cd_nelmts,
+H5_DLL herr_t H5Pset_filter1(hid_t plist_id, H5Z_filter_t filter, unsigned int flags, size_t cd_nelmts,
                             const unsigned int c_values[]);
 
 /**
@@ -3058,31 +3060,32 @@ H5_DLL herr_t H5Pset_filter(hid_t plist_id, H5Z_filter_t filter, unsigned int fl
  * \brief Adds a filter to the filter pipeline for a specified section of the structured chunk
  *
  * \ocpl_id{plist_id}
- * \param[in] section_number    An integer specifying section number of the structured chunk
+ * \param[in] sec_type          Type identifier for a section in the structured chunk
  * \param[in] filter            Filter identifier for the filter to be added to the
  *                              pipeline
  * \param[in] flags             Bit vector specifying certain general properties of
  *                              the filter
- * \param[in] buf_size          Size in bytes of \p buf buffer
- * \param[in] buf               Buffer with an auxiliary data for the filter
+ * \param[in] cd_nelmts         Number of elements in \p c_values
+ * \param[in] cd_values         Auxiliary data for the filter
  *
  * \return \herr_t
  *
  * \details H5Pset_filter2() adds a filter and corresponding properties to the end
  *          of an output filter pipeline.  This function can be used with
- *          both current chunked storage and structured chunk storage
- *          including sparse chunk.  It also addresses deficiency of
- *          H5Pset_filter1() in passing the filter’s data as described below.
+ *          both current chunked storage and structured chunk storage.
  *
  *          Note the following differences with H5Pset_filter1():
- *          - This function accepts a new parameter \p section_number that
- *            specifies the section of the structured chunk to which the filter is applied.
+ *          - This function accepts a new parameter \p sec_type that
+ *            specifies the section type in the structured chunk to which the 
+ *            filter is applied.
  *            For chunked storage, there is just one section.
- *          - Data type for the \p flags parameter is changed to uint64_t to provide
+ *          - On hold: 
+ *            To address the deficiencies in passing filter’s auxiliary data, 
+ *            this new signature intends to replace the parameters \p cd_nelmts
+ *            and \p cd_values by buf_size and buf.  buf_size is the size in bytes of
+ *            buf which is a void pointer to the buffer.
+ *            Data type for the \p flags parameter is changed to uint64_t to provide
  *            more flexibility to the VOL connectors that use the function.
- *          - This function passes the filter’s data by using a void pointer to a buffer
- *            with auxiliary data for the filter instead of unsigned int c_values[].
- *
  *          \p plist_id must be either a dataset creation property list or
  *          group creation property list identifier. If \p plist_id is a
  *          dataset creation property list identifier, the filter is added
@@ -3096,36 +3099,9 @@ H5_DLL herr_t H5Pset_filter(hid_t plist_id, H5Z_filter_t filter, unsigned int fl
  *          (#H5Z_FILTER_DEFLATE) and the Fletcher32 error detection filter
  *          (#H5Z_FILTER_FLETCHER32).
  *
- *          \p section_number specifies the section number. The value
- *          is 0 to 255 when native HDF5 file format is used.
- *          For sparse chunk, the convenience flag can be used to specify
- *          a section of the structured chunk to be filtered as described below:
+ *          \p sec_type specifies the section type in the structured chunk. 
  *
- *          <table>
- *           <tr>
- *            <td>#H5Z_FLAG_SPARSE_SELECTION</td>
- *            <td>Adds the filter to the filter pipeline for the encoded
- *                selection section of the sparse chunk. It has the same
- *                effect as passing 0. The flag will be ignored if the
- *                structured chunk is not sparse.
- *            </td>
- *           </tr>
- *           <tr>
- *            <td>#H5Z_FLAG_SPARSE_FIXED_DATA</td>
- *            <td>Adds the filter to the filter pipeline for section 1 of
- *                the sparse chunk. It has the same effect as passing 1.
- *            </td>
- *           </tr>
- *           <tr>
- *            <td>#H5Z_FLAG_SPARSE_VL_DATA</td>
- *            <td>Adds the filter to the filter pipeline for section 2 of
- *                the sparse chunk if data has variable-length datatype.
- *                It has the same effect as passing 2.
- *            </td>
- *           </tr>
- *          </table>
- *
- *          \p buf points to \p buf_size bytes of buffer
+ *          The array \p cd_values contains \p cd_nelmts unsigned integers
  *          which are auxiliary data for the filter. The values are typically
  *          used as parameters to control the filter. In a filter's
  *          \p set_local method (called from \p H5Dcreate), the values are
@@ -3369,8 +3345,8 @@ H5_DLL herr_t H5Pset_filter(hid_t plist_id, H5Z_filter_t filter, unsigned int fl
  * \since 1.6.0
  *
  */
-H5_DLL herr_t H5Pset_filter2(hid_t plist_id, uint64_t section_number, H5Z_filter_t filter, uint64_t flags,
-                             size_t buf_size, const void *buf);
+H5_DLL herr_t H5Pset_filter2(hid_t plist_id, H5_section_type_t sec_type, H5Z_filter_t filter, unsigned int flags,
+                             size_t cd_nelmts, const unsigned int c_values[]);
 
 /**
  * \ingroup OCPL
@@ -10983,7 +10959,7 @@ H5_DLL herr_t H5Pencode1(hid_t plist_id, void *buf, size_t *nalloc);
  *          \p plist_id must be a dataset or group creation property list.
  *
  *          \p filter is a value between zero and N-1, as described in
- *          H5Pget_nfilters(). The function will return a negative value
+ *          H5Pget_nfilters1(). The function will return a negative value
  *          if the filter number is out of range.
  *
  *          The structure of the \p flags argument is discussed in
@@ -11093,7 +11069,7 @@ H5_DLL herr_t H5Pget_filter_by_id1(hid_t plist_id, H5Z_filter_t id, unsigned int
  * \version 1.6.4 \p boot, \p freelist, \p stab, \p shhdr parameter types
  *                changed to unsigned.
  *
- * \since 1.0.0
+ ion_number* \since 1.0.0
  *
  */
 H5_DLL herr_t H5Pget_version(hid_t plist_id, unsigned *boot /*out*/, unsigned *freelist /*out*/,

--- a/src/H5Ppublic.h
+++ b/src/H5Ppublic.h
@@ -2196,10 +2196,9 @@ H5_DLL H5Z_filter_t H5Pget_filter2(hid_t plist_id, unsigned idx, unsigned int *f
  * \since 1.x.x
  *
  */
-H5_DLL H5Z_filter_t H5Pget_filter3(hid_t plist_id, H5_section_type_t sect_type, unsigned idx, 
-                                   unsigned int *flags /*out*/, 
-                                   size_t *cd_nelmts /*in,out*/, unsigned cd_values[] /*out*/,
-                                   size_t namelen /*in*/, char name[] /*out*/,
+H5_DLL H5Z_filter_t H5Pget_filter3(hid_t plist_id, H5_section_type_t sect_type, unsigned idx,
+                                   unsigned int *flags /*out*/, size_t *cd_nelmts /*in,out*/,
+                                   unsigned cd_values[] /*out*/, size_t namelen /*in*/, char name[] /*out*/,
                                    unsigned *filter_config /*out*/);
 
 /**
@@ -2326,9 +2325,10 @@ H5_DLL herr_t H5Pget_filter_by_id2(hid_t plist_id, H5Z_filter_t filter_id, unsig
  * \since 1.x.x
  *
  */
-H5_DLL herr_t H5Pget_filter_by_id3(hid_t plist_id, H5_section_type_t sec_type, H5Z_filter_t id, unsigned int *flags /*out*/, 
-                                   size_t *cd_nelmts /*in,out*/, unsigned cd_values[] /*out*/,
-                                   size_t namelen /*in*/, char name[] /*out*/, unsigned *filter_config /*out*/);
+H5_DLL herr_t H5Pget_filter_by_id3(hid_t plist_id, H5_section_type_t sec_type, H5Z_filter_t id,
+                                   unsigned int *flags /*out*/, size_t *cd_nelmts /*in,out*/,
+                                   unsigned cd_values[] /*out*/, size_t namelen /*in*/, char name[] /*out*/,
+                                   unsigned *filter_config /*out*/);
 
 /**
  * \ingroup OCPL
@@ -2373,7 +2373,7 @@ H5_DLL int H5Pget_nfilters1(hid_t plist_id);
  *          associated with the property list \p plist_id.
  *
  *          In each pipeline, the filters are numbered from 0 through \Code{N-1},
- *          where \c N is the value returned in \p num_filters by this function. 
+ *          where \c N is the value returned in \p num_filters by this function.
  *          During output to the file, the filters are applied in increasing order; during
  *          input from the file, they are applied in decreasing order.
  *
@@ -2491,9 +2491,9 @@ H5_DLL herr_t H5Pmodify_filter1(hid_t plist_id, H5Z_filter_t filter, unsigned in
  * \since 1.x.x
  *
  */
-H5_DLL herr_t H5Pmodify_filter2(hid_t plist_id, H5_section_type_t sec_type, H5Z_filter_t filter, unsigned int flags,
-                  size_t cd_nelmts, const unsigned int cd_values[/*cd_nelmts*/]);
-
+H5_DLL herr_t H5Pmodify_filter2(hid_t plist_id, H5_section_type_t sec_type, H5Z_filter_t filter,
+                                unsigned int flags, size_t cd_nelmts,
+                                const unsigned int cd_values[/*cd_nelmts*/]);
 
 /**
  * \ingroup OCPL
@@ -3052,7 +3052,7 @@ H5_DLL herr_t H5Pset_deflate(hid_t plist_id, unsigned level);
  *
  */
 H5_DLL herr_t H5Pset_filter1(hid_t plist_id, H5Z_filter_t filter, unsigned int flags, size_t cd_nelmts,
-                            const unsigned int c_values[]);
+                             const unsigned int c_values[]);
 
 /**
  * \ingroup OCPL
@@ -3076,11 +3076,11 @@ H5_DLL herr_t H5Pset_filter1(hid_t plist_id, H5Z_filter_t filter, unsigned int f
  *
  *          Note the following differences with H5Pset_filter1():
  *          - This function accepts a new parameter \p sec_type that
- *            specifies the section type in the structured chunk to which the 
+ *            specifies the section type in the structured chunk to which the
  *            filter is applied.
  *            For chunked storage, there is just one section.
- *          - On hold: 
- *            To address the deficiencies in passing filter’s auxiliary data, 
+ *          - On hold:
+ *            To address the deficiencies in passing filter’s auxiliary data,
  *            this new signature intends to replace the parameters \p cd_nelmts
  *            and \p cd_values by buf_size and buf.  buf_size is the size in bytes of
  *            buf which is a void pointer to the buffer.
@@ -3099,7 +3099,7 @@ H5_DLL herr_t H5Pset_filter1(hid_t plist_id, H5Z_filter_t filter, unsigned int f
  *          (#H5Z_FILTER_DEFLATE) and the Fletcher32 error detection filter
  *          (#H5Z_FILTER_FLETCHER32).
  *
- *          \p sec_type specifies the section type in the structured chunk. 
+ *          \p sec_type specifies the section type in the structured chunk.
  *
  *          The array \p cd_values contains \p cd_nelmts unsigned integers
  *          which are auxiliary data for the filter. The values are typically
@@ -3345,8 +3345,8 @@ H5_DLL herr_t H5Pset_filter1(hid_t plist_id, H5Z_filter_t filter, unsigned int f
  * \since 1.6.0
  *
  */
-H5_DLL herr_t H5Pset_filter2(hid_t plist_id, H5_section_type_t sec_type, H5Z_filter_t filter, unsigned int flags,
-                             size_t cd_nelmts, const unsigned int c_values[]);
+H5_DLL herr_t H5Pset_filter2(hid_t plist_id, H5_section_type_t sec_type, H5Z_filter_t filter,
+                             unsigned int flags, size_t cd_nelmts, const unsigned int c_values[]);
 
 /**
  * \ingroup OCPL

--- a/src/H5Ppublic.h
+++ b/src/H5Ppublic.h
@@ -2795,7 +2795,7 @@ H5_DLL herr_t H5Pset_deflate(hid_t plist_id, unsigned level);
  *                      pipeline
  * \param[in] flags     Bit vector specifying certain general properties of
  *                      the filter
- * \param[in] cd_nelmts Number of elements in \p c_values
+ * \param[in] cd_nelmts Number of elements in \p cd_values
  * \param[in] cd_values  Auxiliary data for the filter
  *
  * \return \herr_t

--- a/src/H5Ppublic.h
+++ b/src/H5Ppublic.h
@@ -2165,7 +2165,7 @@ H5_DLL H5Z_filter_t H5Pget_filter2(hid_t plist_id, unsigned idx, unsigned int *f
  *
  *          \p plist_id must be a dataset or group creation property list.
  *
- *          \p sec_type is an identifer specifying the section type in the
+ *          \p sec_type is an identifier specifying the section type in the
  *          structured chunk.
  *
  *          \p idx is a value between zero and N-1, as described in

--- a/src/H5SC.c
+++ b/src/H5SC.c
@@ -229,9 +229,7 @@ done:
  *-------------------------------------------------------------------------
  */
 static herr_t
-H5SC__io_info_init(H5SC_t H5_ATTR_NDEBUG_UNUSED *cache, H5SC_io_info_t *sc_io_info, size_t count,
-                   H5D_dset_io_info_t *dset_info)
-{
+H5SC__io_info_init(H5SC_t H5_ATTR_NDEBUG_UNUSED *cache, H5SC_io_info_t *sc_io_info, size_t count, H5D_dset_io_info_t *dset_info) {
     H5S_t *tmp_dset_space     = NULL;
     H5S_t *single_chunk_space = NULL;
     size_t i;
@@ -290,12 +288,12 @@ H5SC__io_info_init(H5SC_t H5_ATTR_NDEBUG_UNUSED *cache, H5SC_io_info_t *sc_io_in
         assert(dset_info[i].dset->shared->layout.sc_ops->layout_query);
         if (dset_info[i].dset->shared->layout.sc_ops->layout_query(dset_info[i].dset, chunk_dims, NULL,
                                                                    NULL) < 0)
-
             HGOTO_ERROR(H5E_DATASET, H5E_CANTGET, FAIL, "unable to query chunk dimensions");
 
-        /* Get dataspace ranks */
+        /* Get dataspace ranks */    
         file_ndims = (unsigned)H5S_GET_EXTENT_NDIMS(dset_info[i].file_space);
         mem_ndims  = (unsigned)H5S_GET_EXTENT_NDIMS(dset_info[i].mem_space);
+    
 
         /* Get the file and memory selection types */
         if ((file_sel_type = H5S_GET_SELECT_TYPE(dset_info[i].file_space)) < H5S_SEL_NONE)
@@ -1219,7 +1217,6 @@ done:
 
     FUNC_LEAVE_NOAPI(ret_value)
 } /* end H5SC_write() */
-
 /*-------------------------------------------------------------------------
  * Function: H5SC_direct_chunk_read
  *

--- a/src/H5SC.c
+++ b/src/H5SC.c
@@ -229,7 +229,9 @@ done:
  *-------------------------------------------------------------------------
  */
 static herr_t
-H5SC__io_info_init(H5SC_t H5_ATTR_NDEBUG_UNUSED *cache, H5SC_io_info_t *sc_io_info, size_t count, H5D_dset_io_info_t *dset_info) {
+H5SC__io_info_init(H5SC_t H5_ATTR_NDEBUG_UNUSED *cache, H5SC_io_info_t *sc_io_info, size_t count,
+                   H5D_dset_io_info_t *dset_info)
+{
     H5S_t *tmp_dset_space     = NULL;
     H5S_t *single_chunk_space = NULL;
     size_t i;
@@ -290,10 +292,9 @@ H5SC__io_info_init(H5SC_t H5_ATTR_NDEBUG_UNUSED *cache, H5SC_io_info_t *sc_io_in
                                                                    NULL) < 0)
             HGOTO_ERROR(H5E_DATASET, H5E_CANTGET, FAIL, "unable to query chunk dimensions");
 
-        /* Get dataspace ranks */    
+        /* Get dataspace ranks */
         file_ndims = (unsigned)H5S_GET_EXTENT_NDIMS(dset_info[i].file_space);
         mem_ndims  = (unsigned)H5S_GET_EXTENT_NDIMS(dset_info[i].mem_space);
-    
 
         /* Get the file and memory selection types */
         if ((file_sel_type = H5S_GET_SELECT_TYPE(dset_info[i].file_space)) < H5S_SEL_NONE)

--- a/src/H5Z.c
+++ b/src/H5Z.c
@@ -756,7 +756,6 @@ done:
     FUNC_LEAVE_NOAPI(ret_value)
 } /* end H5Z_filter_avail() */
 
-
 /*-------------------------------------------------------------------------
  * Function: H5Z__prelude_callback_real
  *
@@ -771,8 +770,8 @@ done:
  *-------------------------------------------------------------------------
  */
 static herr_t
-H5Z__prelude_callback_real(hid_t dcpl_id, hid_t type_id, hid_t space_id,
-                      H5Z_prelude_type_t prelude_type, size_t nused, H5Z_filter_info_t *filter, H5_section_type_t sec_type)
+H5Z__prelude_callback_real(hid_t dcpl_id, hid_t type_id, hid_t space_id, H5Z_prelude_type_t prelude_type,
+                           size_t nused, H5Z_filter_info_t *filter, H5_section_type_t sec_type)
 {
     H5Z_class3_t *fclass;           /* Individual filter information */
     size_t        u;                /* Local index variable */
@@ -866,24 +865,26 @@ static herr_t
 H5Z__prelude_callback(const H5O_pline_t *pline, hid_t dcpl_id, hid_t type_id, hid_t space_id,
                       H5Z_prelude_type_t prelude_type)
 {
-    htri_t        ret_value = true; /* Return value */
+    htri_t ret_value = true; /* Return value */
 
     FUNC_ENTER_PACKAGE
 
     if (pline->version < H5O_PLINE_VERSION_3) {
 
-        if (H5Z__prelude_callback_real(dcpl_id, type_id, space_id, prelude_type, pline->nused, pline->filter, H5_SECTION_UNKNOWN) < 0)
+        if (H5Z__prelude_callback_real(dcpl_id, type_id, space_id, prelude_type, pline->nused, pline->filter,
+                                       H5_SECTION_UNKNOWN) < 0)
             HGOTO_ERROR(H5E_PLINE, H5E_CANAPPLY, FAIL, "unable to apply prelude callback");
-
-    } else {
+    }
+    else {
         const H5Z_stc_filter_sect_t *filt_sect;
-        unsigned i;
+        unsigned                     i;
         assert(pline->version == H5O_PLINE_VERSION_3);
 
         for (i = 0, filt_sect = &pline->filt_sects[0]; i < pline->tot_filt_nsects; i++, filt_sect++) {
 
             if (filt_sect->nused) {
-                if (H5Z__prelude_callback_real(dcpl_id, type_id, space_id, prelude_type, filt_sect->nused, filt_sect->filter, filt_sect->seq_sect) < 0)
+                if (H5Z__prelude_callback_real(dcpl_id, type_id, space_id, prelude_type, filt_sect->nused,
+                                               filt_sect->filter, filt_sect->seq_sect) < 0)
                     HGOTO_ERROR(H5E_PLINE, H5E_CANAPPLY, FAIL, "unable to apply prelude callback");
             }
         }
@@ -938,7 +939,7 @@ H5Z__prepare_prelude_callback_dcpl(hid_t dcpl_id, hid_t type_id, H5Z_prelude_typ
         /* Check if the dataset is chunked */
         if (H5D_CHUNKED == dcpl_layout->type || H5D_STRUCT_CHUNK == dcpl_layout->type) {
             H5O_pline_t dcpl_pline; /* Object's I/O pipeline information */
-            bool have_filters = false;
+            bool        have_filters = false;
 
             /* Get I/O pipeline information */
             if (H5P_peek(dc_plist, H5O_CRT_PIPELINE_NAME, &dcpl_pline) < 0)
@@ -948,9 +949,10 @@ H5Z__prepare_prelude_callback_dcpl(hid_t dcpl_id, hid_t type_id, H5Z_prelude_typ
                 have_filters = true;
             if (H5D_STRUCT_CHUNK == dcpl_layout->type && dcpl_pline.tot_filt_nsects > 0) {
                 const H5Z_stc_filter_sect_t *filt_sect;
-                unsigned i;
+                unsigned                     i;
 
-                for (i = 0, filt_sect = &dcpl_pline.filt_sects[0]; i <  dcpl_pline.tot_filt_nsects; i++, filt_sect++) {
+                for (i = 0, filt_sect = &dcpl_pline.filt_sects[0]; i < dcpl_pline.tot_filt_nsects;
+                     i++, filt_sect++) {
                     if (filt_sect->nused) {
                         have_filters = true;
                         break;
@@ -1171,12 +1173,12 @@ H5Z_ignore_filters(hid_t dcpl_id, const H5T_t *type, const H5S_t *space)
 
             /* All filters are optional, we can ignore them */
             ret_value = true;
-
-        } else if (pline.version == H5O_PLINE_VERSION_3 && pline.tot_filt_nsects) {
+        }
+        else if (pline.version == H5O_PLINE_VERSION_3 && pline.tot_filt_nsects) {
             const H5Z_stc_filter_sect_t *filt_sect;
-            const H5Z_filter_info_t *filter;
+            const H5Z_filter_info_t     *filter;
 
-            for (ii = 0, filt_sect = &pline.filt_sects[0]; ii <  pline.tot_filt_nsects; ii++, filt_sect++) {
+            for (ii = 0, filt_sect = &pline.filt_sects[0]; ii < pline.tot_filt_nsects; ii++, filt_sect++) {
                 for (jj = 0, filter = &filt_sect->filter[0]; jj < filt_sect->nused; jj++, filter++) {
                     if (!(filter->flags & H5Z_FLAG_OPTIONAL))
                         HGOTO_ERROR(H5E_PLINE, H5E_CANTFILTER, FAIL, "not suitable for filters");
@@ -1291,8 +1293,8 @@ H5Z_append(H5O_pline_t *pline, H5Z_filter_t filter_id, unsigned flags, size_t cd
     if (pline->version == 0)
         pline->version = H5O_PLINE_VERSION_1;
 
-    if (H5Z_append_filter(filter_id, flags, cd_nelmts, cd_values, 
-                          &pline->filter, &pline->nused, &pline->nalloc) < 0)
+    if (H5Z_append_filter(filter_id, flags, cd_nelmts, cd_values, &pline->filter, &pline->nused,
+                          &pline->nalloc) < 0)
         HGOTO_ERROR(H5E_PLINE, H5E_CANTINIT, FAIL, "unable to add filter to pipeline");
 
 done:
@@ -1310,20 +1312,21 @@ done:
  */
 herr_t
 H5Z_append_filter(H5Z_filter_t filter_id, unsigned flags, size_t cd_nelmts,
-           const unsigned int cd_values[/*cd_nelmts*/], H5Z_filter_info_t **_filter, size_t *_nused, size_t *_nalloc)
+                  const unsigned int cd_values[/*cd_nelmts*/], H5Z_filter_info_t **_filter, size_t *_nused,
+                  size_t *_nalloc)
 {
-    size_t nused = *_nused;
-    size_t nalloc = *_nalloc;
+    size_t             nused  = *_nused;
+    size_t             nalloc = *_nalloc;
     H5Z_filter_info_t *filter = *_filter;
-    size_t idx;
-    herr_t ret_value = SUCCEED; /* Return value */
+    size_t             idx;
+    herr_t             ret_value = SUCCEED; /* Return value */
 
     FUNC_ENTER_NOAPI(FAIL)
 
     /* Allocate additional space in the pipeline if it's full */
     if (nused >= nalloc) {
-        size_t      n;
-        size_t      x_nalloc;
+        size_t             n;
+        size_t             x_nalloc;
         H5Z_filter_info_t *x_filter;
 
         /* Each filter's data may be stored internally or may be
@@ -1381,15 +1384,13 @@ H5Z_append_filter(H5Z_filter_t filter_id, unsigned flags, size_t cd_nelmts,
 
     nused++;
 
-    *_nused = nused;
+    *_nused  = nused;
     *_nalloc = nalloc;
     *_filter = filter;
 
 done:
     FUNC_LEAVE_NOAPI(ret_value)
 } /* H5Z_append_filter() */
-
-
 
 /*-------------------------------------------------------------------------
  * Function: H5Z__find_idx
@@ -1478,7 +1479,7 @@ H5Z_pipeline(const H5O_pline_t *pline, unsigned flags, unsigned *filter_mask /*i
              H5Z_cb_t cb_struct, size_t *nbytes /*in,out*/, size_t *buf_size /*in,out*/,
              void **buf /*in,out*/)
 {
-    herr_t   ret_value = SUCCEED; /* Return value */
+    herr_t ret_value = SUCCEED; /* Return value */
 
     FUNC_ENTER_NOAPI(FAIL)
 
@@ -1500,10 +1501,9 @@ H5Z_pipeline(const H5O_pline_t *pline, unsigned flags, unsigned *filter_mask /*i
 done:
     FUNC_LEAVE_NOAPI(ret_value)
 
-/* clang-format on */
+    /* clang-format on */
 
 } /* H5Z_pipeline() */
-
 
 /*-------------------------------------------------------------------------
  * Function: H5Z_apply_filters
@@ -1529,9 +1529,9 @@ done:
  *-------------------------------------------------------------------------
  */
 herr_t
-H5Z_apply_filters(size_t nused, H5Z_filter_info_t *filter, unsigned flags, 
-                   unsigned *filter_mask /*in,out*/, H5Z_EDC_t edc_read, H5Z_cb_t cb_struct, 
-                   size_t *nbytes /*in,out*/, size_t *buf_size /*in,out*/, void **buf /*in,out*/)
+H5Z_apply_filters(size_t nused, H5Z_filter_info_t *filter, unsigned flags, unsigned *filter_mask /*in,out*/,
+                  H5Z_EDC_t edc_read, H5Z_cb_t cb_struct, size_t *nbytes /*in,out*/,
+                  size_t *buf_size /*in,out*/, void **buf /*in,out*/)
 {
     size_t        idx;
     size_t        new_nbytes;
@@ -1615,126 +1615,125 @@ H5Z_apply_filters(size_t nused, H5Z_filter_info_t *filter, unsigned flags,
 
             H5E_PAUSE_ERRORS
                 {/* Prepare & restore library for user callback */
-                    H5_BEFORE_USER_CB(FAIL)
-                        {
-                            new_nbytes = (fclass->filter)(tmp_flags, filter[idx].cd_nelmts,
-                                                          filter[idx].cd_values, *nbytes, buf_size, buf);
-                        }
-                    H5_AFTER_USER_CB(FAIL)
-                }
-            H5E_RESUME_ERRORS
-
-#ifdef H5Z_DEBUG
-            H5_timer_stop(&timer);
-            H5_timer_get_times(timer, &times);
-            fstats->stats[1].times.elapsed += times.elapsed;
-            fstats->stats[1].times.system += times.system;
-            fstats->stats[1].times.user += times.user;
-
-            fstats->stats[1].total += MAX(*nbytes, new_nbytes);
-            if (0 == new_nbytes)
-                fstats->stats[1].errors += *nbytes;
-#endif
-
-            if (0 == new_nbytes) {
-                if (cb_struct.func) {
-                    H5Z_cb_return_t status;
-
-                    /* Prepare & restore library for user callback */
-                    H5_BEFORE_USER_CB(FAIL)
-                        {
-                            status = cb_struct.func(filter[idx].id, *buf, *buf_size, cb_struct.op_data);
-                        }
-                    H5_AFTER_USER_CB(FAIL)
-                    if (H5Z_CB_FAIL == status)
-                        HGOTO_ERROR(H5E_PLINE, H5E_READERROR, FAIL, "filter returned failure during read");
-                }
-                else
-                    HGOTO_ERROR(H5E_PLINE, H5E_READERROR, FAIL, "filter returned failure during read");
-
-                *nbytes = *buf_size;
-                failed |= (unsigned)1 << idx;
-            }
-            else
-                *nbytes = new_nbytes;
+                 H5_BEFORE_USER_CB(FAIL){new_nbytes =
+                                             (fclass->filter)(tmp_flags, filter[idx].cd_nelmts,
+                                                              filter[idx].cd_values, *nbytes, buf_size, buf);
         }
-    }
-    else 
-    { /* Write */
-        for (idx = 0; idx < nused; idx++) {
-            if (*filter_mask & ((unsigned)1 << idx)) {
-                failed |= (unsigned)1 << idx;
-                continue; /* filter excluded */
-            }
-
-            if ((fclass_idx = H5Z__find_idx(filter[idx].id)) < 0) {
-                /* Check if filter is optional -- If it isn't, then error */
-                if ((filter[idx].flags & H5Z_FLAG_OPTIONAL) == 0)
-                    HGOTO_ERROR(H5E_PLINE, H5E_WRITEERROR, FAIL, "required filter is not registered");
-                failed |= (unsigned)1 << idx;
-                continue; /* filter excluded */
-            }             /* end if */
-
-            fclass = &H5Z_table_g[fclass_idx];
+H5_AFTER_USER_CB
+(FAIL)
+}
+H5E_RESUME_ERRORS
 
 #ifdef H5Z_DEBUG
-            fstats = &H5Z_stat_table_g[fclass_idx];
-            H5_timer_start(&timer);
+H5_timer_stop(&timer);
+H5_timer_get_times(timer, &times);
+fstats->stats[1].times.elapsed += times.elapsed;
+fstats->stats[1].times.system += times.system;
+fstats->stats[1].times.user += times.user;
+
+fstats->stats[1].total += MAX(*nbytes, new_nbytes);
+if (0 == new_nbytes)
+    fstats->stats[1].errors += *nbytes;
 #endif
 
-            H5E_PAUSE_ERRORS
-                {/* Prepare & restore library for user callback */
-                    H5_BEFORE_USER_CB(FAIL)
-                        {
-                            new_nbytes = (fclass->filter)(flags | (filter[idx].flags), filter[idx].cd_nelmts, 
+if (0 == new_nbytes) {
+    if (cb_struct.func) {
+        H5Z_cb_return_t status;
+
+        /* Prepare & restore library for user callback */
+        H5_BEFORE_USER_CB(FAIL)
+            {
+                status = cb_struct.func(filter[idx].id, *buf, *buf_size, cb_struct.op_data);
+            }
+        H5_AFTER_USER_CB(FAIL)
+        if (H5Z_CB_FAIL == status)
+            HGOTO_ERROR(H5E_PLINE, H5E_READERROR, FAIL, "filter returned failure during read");
+    }
+    else
+        HGOTO_ERROR(H5E_PLINE, H5E_READERROR, FAIL, "filter returned failure during read");
+
+    *nbytes = *buf_size;
+    failed |= (unsigned)1 << idx;
+}
+else
+    *nbytes = new_nbytes;
+}
+}
+else
+{ /* Write */
+    for (idx = 0; idx < nused; idx++) {
+        if (*filter_mask & ((unsigned)1 << idx)) {
+            failed |= (unsigned)1 << idx;
+            continue; /* filter excluded */
+        }
+
+        if ((fclass_idx = H5Z__find_idx(filter[idx].id)) < 0) {
+            /* Check if filter is optional -- If it isn't, then error */
+            if ((filter[idx].flags & H5Z_FLAG_OPTIONAL) == 0)
+                HGOTO_ERROR(H5E_PLINE, H5E_WRITEERROR, FAIL, "required filter is not registered");
+            failed |= (unsigned)1 << idx;
+            continue; /* filter excluded */
+        }             /* end if */
+
+        fclass = &H5Z_table_g[fclass_idx];
+
+#ifdef H5Z_DEBUG
+        fstats = &H5Z_stat_table_g[fclass_idx];
+        H5_timer_start(&timer);
+#endif
+
+        H5E_PAUSE_ERRORS
+            {/* Prepare & restore library for user callback */
+             H5_BEFORE_USER_CB(FAIL){new_nbytes =
+                                         (fclass->filter)(flags | (filter[idx].flags), filter[idx].cd_nelmts,
                                                           filter[idx].cd_values, *nbytes, buf_size, buf);
-                        }
-                    H5_AFTER_USER_CB(FAIL)
-                }
-            H5E_RESUME_ERRORS
+    }
+H5_AFTER_USER_CB
+(FAIL)
+}
+H5E_RESUME_ERRORS
 
 #ifdef H5Z_DEBUG
-            H5_timer_stop(&timer);
-            H5_timer_get_times(timer, &times);
-            fstats->stats[0].times.elapsed += times.elapsed;
-            fstats->stats[0].times.system += times.system;
-            fstats->stats[0].times.user += times.user;
+H5_timer_stop(&timer);
+H5_timer_get_times(timer, &times);
+fstats->stats[0].times.elapsed += times.elapsed;
+fstats->stats[0].times.system += times.system;
+fstats->stats[0].times.user += times.user;
 
-            fstats->stats[0].total += MAX(*nbytes, new_nbytes);
-            if (0 == new_nbytes)
-                fstats->stats[0].errors += *nbytes;
+fstats->stats[0].total += MAX(*nbytes, new_nbytes);
+if (0 == new_nbytes)
+    fstats->stats[0].errors += *nbytes;
 #endif
 
-            if (0 == new_nbytes) {
-                if (0 == (filter[idx].flags & H5Z_FLAG_OPTIONAL)) {
-                    if (cb_struct.func) {
-                        H5Z_cb_return_t status;
+if (0 == new_nbytes) {
+    if (0 == (filter[idx].flags & H5Z_FLAG_OPTIONAL)) {
+        if (cb_struct.func) {
+            H5Z_cb_return_t status;
 
-                        /* Prepare & restore library for user callback */
-                        H5_BEFORE_USER_CB(FAIL)
-                            {
-                                status = cb_struct.func(filter[idx].id, *buf, *nbytes, cb_struct.op_data);
-                            }
-                        H5_AFTER_USER_CB(FAIL)
-                        if (H5Z_CB_FAIL == status)
-                            HGOTO_ERROR(H5E_PLINE, H5E_WRITEERROR, FAIL, "filter returned failure");
-                    }
-                    else
-                        HGOTO_ERROR(H5E_PLINE, H5E_WRITEERROR, FAIL, "filter returned failure");
-
-                    *nbytes = *buf_size;
+            /* Prepare & restore library for user callback */
+            H5_BEFORE_USER_CB(FAIL)
+                {
+                    status = cb_struct.func(filter[idx].id, *buf, *nbytes, cb_struct.op_data);
                 }
-                failed |= (unsigned)1 << idx;
-            }
-            else
-                *nbytes = new_nbytes;
-        } /* end for */
+            H5_AFTER_USER_CB(FAIL)
+            if (H5Z_CB_FAIL == status)
+                HGOTO_ERROR(H5E_PLINE, H5E_WRITEERROR, FAIL, "filter returned failure");
+        }
+        else
+            HGOTO_ERROR(H5E_PLINE, H5E_WRITEERROR, FAIL, "filter returned failure");
+
+        *nbytes = *buf_size;
     }
+    failed |= (unsigned)1 << idx;
+}
+else
+    *nbytes = new_nbytes;
+} /* end for */
+}
 
-    *filter_mask = failed;
+*filter_mask = failed;
 
-done:
-    FUNC_LEAVE_NOAPI(ret_value)
+done : FUNC_LEAVE_NOAPI(ret_value)
 
 } /* H5Z_apply_filters() */
 
@@ -1784,7 +1783,7 @@ done:
  *           FAIL   - error
  *-------------------------------------------------------------------------
  */
-htri_t 
+htri_t
 H5Z_filter_in_pline(H5Z_filter_info_t *filter, size_t nused, H5Z_filter_t filter_id)
 {
     size_t i;                /* Index of filter in pipeline */

--- a/src/H5Z.c
+++ b/src/H5Z.c
@@ -64,7 +64,7 @@ bool H5_PKG_INIT_VAR = false;
 /* Local variables */
 static size_t        H5Z_table_alloc_g = 0;
 static size_t        H5Z_table_used_g  = 0;
-static H5Z_class2_t *H5Z_table_g       = NULL;
+static H5Z_class3_t *H5Z_table_g       = NULL;
 #ifdef H5Z_DEBUG
 static H5Z_stats_t *H5Z_stat_table_g = NULL;
 /* Set to true if you want to dump compression statistics to stdout */
@@ -196,7 +196,7 @@ next:
 
         /* Free the table of filters */
         if (H5Z_table_g) {
-            H5Z_table_g = (H5Z_class2_t *)H5MM_xfree(H5Z_table_g);
+            H5Z_table_g = (H5Z_class3_t *)H5MM_xfree(H5Z_table_g);
 
 #ifdef H5Z_DEBUG
             H5Z_stat_table_g = (H5Z_stats_t *)H5MM_xfree(H5Z_stat_table_g);
@@ -225,7 +225,7 @@ next:
 herr_t
 H5Zregister(const void *cls)
 {
-    const H5Z_class2_t *cls_real  = (const H5Z_class2_t *)cls; /* "Real" class pointer */
+    const H5Z_class3_t *cls_real  = (const H5Z_class3_t *)cls; /* "Real" class pointer */
     herr_t              ret_value = SUCCEED;                   /* Return value */
 #ifndef H5_NO_DEPRECATED_SYMBOLS
     H5Z_class2_t cls_new; /* Translated class struct */
@@ -263,7 +263,7 @@ H5Zregister(const void *cls)
         cls_new.filter          = cls_old->filter;
 
         /* Set cls_real to point to the translated structure */
-        cls_real = &cls_new;
+        cls_real = (H5Z_class3_t *)&cls_new;
 
 #else  /* H5_NO_DEPRECATED_SYMBOLS */
         /* Deprecated symbols not allowed, throw an error */
@@ -297,7 +297,7 @@ done:
  *-------------------------------------------------------------------------
  */
 herr_t
-H5Z_register(const H5Z_class2_t *cls)
+H5Z_register(const H5Z_class3_t *cls)
 {
     size_t i;
     herr_t ret_value = SUCCEED; /* Return value */
@@ -316,7 +316,7 @@ H5Z_register(const H5Z_class2_t *cls)
     if (i >= H5Z_table_used_g) {
         if (H5Z_table_used_g >= H5Z_table_alloc_g) {
             size_t        n     = MAX(H5Z_MAX_NFILTERS, 2 * H5Z_table_alloc_g);
-            H5Z_class2_t *table = (H5Z_class2_t *)H5MM_realloc(H5Z_table_g, n * sizeof(H5Z_class2_t));
+            H5Z_class3_t *table = (H5Z_class3_t *)H5MM_realloc(H5Z_table_g, n * sizeof(H5Z_class3_t));
 #ifdef H5Z_DEBUG
             H5Z_stats_t *stat_table = (H5Z_stats_t *)H5MM_realloc(H5Z_stat_table_g, n * sizeof(H5Z_stats_t));
 #endif /* H5Z_DEBUG */
@@ -333,7 +333,7 @@ H5Z_register(const H5Z_class2_t *cls)
 
         /* Initialize */
         i = H5Z_table_used_g++;
-        H5MM_memcpy(H5Z_table_g + i, cls, sizeof(H5Z_class2_t));
+        H5MM_memcpy(H5Z_table_g + i, cls, sizeof(H5Z_class3_t));
 #ifdef H5Z_DEBUG
         memset(H5Z_stat_table_g + i, 0, sizeof(H5Z_stats_t));
 #endif /* H5Z_DEBUG */
@@ -341,7 +341,7 @@ H5Z_register(const H5Z_class2_t *cls)
     /* Filter already registered */
     else {
         /* Replace old contents */
-        H5MM_memcpy(H5Z_table_g + i, cls, sizeof(H5Z_class2_t));
+        H5MM_memcpy(H5Z_table_g + i, cls, sizeof(H5Z_class3_t));
     } /* end else */
 
 done:
@@ -438,7 +438,7 @@ H5Z__unregister(H5Z_filter_t filter_id)
     /* Remove filter from table */
     /* Don't worry about shrinking table size (for now) */
     memmove(&H5Z_table_g[filter_index], &H5Z_table_g[filter_index + 1],
-            sizeof(H5Z_class2_t) * ((H5Z_table_used_g - 1) - filter_index));
+            sizeof(H5Z_class3_t) * ((H5Z_table_used_g - 1) - filter_index));
 #ifdef H5Z_DEBUG
     memmove(&H5Z_stat_table_g[filter_index], &H5Z_stat_table_g[filter_index + 1],
             sizeof(H5Z_stats_t) * ((H5Z_table_used_g - 1) - filter_index));
@@ -734,7 +734,7 @@ htri_t
 H5Z_filter_avail(H5Z_filter_t id)
 {
     H5PL_key_t          key;               /* Key for finding a plugin     */
-    const H5Z_class2_t *filter_info;       /* Filter information           */
+    const H5Z_class3_t *filter_info;       /* Filter information           */
     size_t              i;                 /* Local index variable         */
     htri_t              ret_value = false; /* Return value                 */
 
@@ -746,7 +746,7 @@ H5Z_filter_avail(H5Z_filter_t id)
             HGOTO_DONE(true);
 
     key.id = (int)id;
-    if (NULL != (filter_info = (const H5Z_class2_t *)H5PL_load(H5PL_TYPE_FILTER, &key))) {
+    if (NULL != (filter_info = (const H5Z_class3_t *)H5PL_load(H5PL_TYPE_FILTER, &key))) {
         if (H5Z_register(filter_info) < 0)
             HGOTO_ERROR(H5E_PLINE, H5E_CANTINIT, FAIL, "unable to register loaded filter");
         HGOTO_DONE(true);
@@ -756,8 +756,9 @@ done:
     FUNC_LEAVE_NOAPI(ret_value)
 } /* end H5Z_filter_avail() */
 
+
 /*-------------------------------------------------------------------------
- * Function: H5Z__prelude_callback
+ * Function: H5Z__prelude_callback_real
  *
  * Purpose:  Makes a dataset creation "prelude" callback for the "can_apply"
  *           or "set_local" routines.
@@ -770,21 +771,21 @@ done:
  *-------------------------------------------------------------------------
  */
 static herr_t
-H5Z__prelude_callback(const H5O_pline_t *pline, hid_t dcpl_id, hid_t type_id, hid_t space_id,
-                      H5Z_prelude_type_t prelude_type)
+H5Z__prelude_callback_real(hid_t dcpl_id, hid_t type_id, hid_t space_id,
+                      H5Z_prelude_type_t prelude_type, size_t nused, H5Z_filter_info_t *filter, H5_section_type_t sec_type)
 {
-    H5Z_class2_t *fclass;           /* Individual filter information */
+    H5Z_class3_t *fclass;           /* Individual filter information */
     size_t        u;                /* Local index variable */
     htri_t        ret_value = true; /* Return value */
 
     FUNC_ENTER_PACKAGE
 
-    assert(pline->nused > 0);
+    assert(nused > 0);
 
     /* Iterate over filters */
-    for (u = 0; u < pline->nused; u++) {
+    for (u = 0; u < nused; u++) {
         /* Get filter information, ignoring failure from optional filters */
-        if (H5Z_find(pline->filter[u].flags & H5Z_FLAG_OPTIONAL, pline->filter[u].id, &fclass) < 0)
+        if (H5Z_find(filter[u].flags & H5Z_FLAG_OPTIONAL, filter[u].id, &fclass) < 0)
             HGOTO_ERROR(H5E_PLINE, H5E_NOTFOUND, FAIL, "required filter was not located");
         if (fclass) {
             /* Make correct callback */
@@ -813,7 +814,7 @@ H5Z__prelude_callback(const H5O_pline_t *pline, hid_t dcpl_id, hid_t type_id, hi
 
                         /* Indicate filter can't apply to this combination of parameters.
                          * If the filter is NOT optional, returns failure. */
-                        if (status == false && !(pline->filter[u].flags & H5Z_FLAG_OPTIONAL))
+                        if (status == false && !(filter[u].flags & H5Z_FLAG_OPTIONAL))
                             HGOTO_ERROR(H5E_PLINE, H5E_CANAPPLY, FAIL, "filter parameters not appropriate");
                     } /* end if */
                     break;
@@ -827,7 +828,7 @@ H5Z__prelude_callback(const H5O_pline_t *pline, hid_t dcpl_id, hid_t type_id, hi
                         H5_BEFORE_USER_CB(FAIL)
                             {
                                 /* Make callback to filter's "set local" function */
-                                status = (fclass->set_local)(dcpl_id, type_id, space_id);
+                                status = (fclass->set_local)(dcpl_id, type_id, space_id, sec_type);
                             }
                         H5_AFTER_USER_CB(FAIL)
 
@@ -842,6 +843,51 @@ H5Z__prelude_callback(const H5O_pline_t *pline, hid_t dcpl_id, hid_t type_id, hi
             } /* end switch */
         }     /* end else */
     }         /* end for */
+
+done:
+
+    FUNC_LEAVE_NOAPI(ret_value)
+} /* end H5Z__prelude_callback_real() */
+
+/*-------------------------------------------------------------------------
+ * Function: H5Z__prelude_callback
+ *
+ * Purpose:  Makes a dataset creation "prelude" callback for the "can_apply"
+ *           or "set_local" routines.
+ *
+ * Return:   Non-negative on success/Negative on failure
+ *
+ * Notes:    The chunk dimensions are used to create a dataspace, instead
+ *           of passing in the dataset's dataspace, since the chunk
+ *           dimensions are what the I/O filter will actually see
+ *-------------------------------------------------------------------------
+ */
+static herr_t
+H5Z__prelude_callback(const H5O_pline_t *pline, hid_t dcpl_id, hid_t type_id, hid_t space_id,
+                      H5Z_prelude_type_t prelude_type)
+{
+    htri_t        ret_value = true; /* Return value */
+
+    FUNC_ENTER_PACKAGE
+
+    if (pline->version < H5O_PLINE_VERSION_3) {
+
+        if (H5Z__prelude_callback_real(dcpl_id, type_id, space_id, prelude_type, pline->nused, pline->filter, H5_SECTION_UNKNOWN) < 0)
+            HGOTO_ERROR(H5E_PLINE, H5E_CANAPPLY, FAIL, "unable to apply prelude callback");
+
+    } else {
+        const H5Z_stc_filter_sect_t *filt_sect;
+        unsigned i;
+        assert(pline->version == H5O_PLINE_VERSION_3);
+
+        for (i = 0, filt_sect = &pline->filt_sects[0]; i < pline->tot_filt_nsects; i++, filt_sect++) {
+
+            if (filt_sect->nused) {
+                if (H5Z__prelude_callback_real(dcpl_id, type_id, space_id, prelude_type, filt_sect->nused, filt_sect->filter, filt_sect->seq_sect) < 0)
+                    HGOTO_ERROR(H5E_PLINE, H5E_CANAPPLY, FAIL, "unable to apply prelude callback");
+            }
+        }
+    }
 
 done:
 
@@ -890,15 +936,30 @@ H5Z__prepare_prelude_callback_dcpl(hid_t dcpl_id, hid_t type_id, H5Z_prelude_typ
             HGOTO_ERROR(H5E_PLIST, H5E_CANTGET, FAIL, "can't retrieve layout");
 
         /* Check if the dataset is chunked */
-        if (H5D_CHUNKED == dcpl_layout->type) {
+        if (H5D_CHUNKED == dcpl_layout->type || H5D_STRUCT_CHUNK == dcpl_layout->type) {
             H5O_pline_t dcpl_pline; /* Object's I/O pipeline information */
+            bool have_filters = false;
 
             /* Get I/O pipeline information */
             if (H5P_peek(dc_plist, H5O_CRT_PIPELINE_NAME, &dcpl_pline) < 0)
                 HGOTO_ERROR(H5E_PLIST, H5E_CANTGET, FAIL, "can't retrieve pipeline filter");
 
+            if (H5D_CHUNKED == dcpl_layout->type && dcpl_pline.nused > 0)
+                have_filters = true;
+            if (H5D_STRUCT_CHUNK == dcpl_layout->type && dcpl_pline.tot_filt_nsects > 0) {
+                const H5Z_stc_filter_sect_t *filt_sect;
+                unsigned i;
+
+                for (i = 0, filt_sect = &dcpl_pline.filt_sects[0]; i <  dcpl_pline.tot_filt_nsects; i++, filt_sect++) {
+                    if (filt_sect->nused) {
+                        have_filters = true;
+                        break;
+                    }
+                }
+            }
+
             /* Check if the chunks have filters */
-            if (dcpl_pline.nused > 0) {
+            if (have_filters) {
                 hsize_t chunk_dims[H5O_LAYOUT_NDIMS]; /* Size of chunk dimensions */
                 H5S_t  *space;                        /* Dataspace describing chunk */
                 size_t  u;                            /* Local index variable */
@@ -1100,7 +1161,8 @@ H5Z_ignore_filters(hid_t dcpl_id, const H5T_t *type, const H5S_t *space)
     /* When these conditions occur, if there are required filters in pline,
        then report a failure, otherwise, set flag that they can be ignored */
     if (bad_for_filters) {
-        size_t ii;
+        size_t ii, jj;
+
         if (pline.nused > 0) {
             for (ii = 0; ii < pline.nused; ii++) {
                 if (!(pline.filter[ii].flags & H5Z_FLAG_OPTIONAL))
@@ -1109,7 +1171,22 @@ H5Z_ignore_filters(hid_t dcpl_id, const H5T_t *type, const H5S_t *space)
 
             /* All filters are optional, we can ignore them */
             ret_value = true;
+
+        } else if (pline.version == H5O_PLINE_VERSION_3 && pline.tot_filt_nsects) {
+            const H5Z_stc_filter_sect_t *filt_sect;
+            const H5Z_filter_info_t *filter;
+
+            for (ii = 0, filt_sect = &pline.filt_sects[0]; ii <  pline.tot_filt_nsects; ii++, filt_sect++) {
+                for (jj = 0, filter = &filt_sect->filter[0]; jj < filt_sect->nused; jj++, filter++) {
+                    if (!(filter->flags & H5Z_FLAG_OPTIONAL))
+                        HGOTO_ERROR(H5E_PLINE, H5E_CANTFILTER, FAIL, "not suitable for filters");
+                }
+            }
+
+            /* All filters are optional, we can ignore them */
+            ret_value = true;
         }
+
     } /* bad for filters */
 
 done:
@@ -1126,7 +1203,7 @@ done:
  *-------------------------------------------------------------------------
  */
 herr_t
-H5Z_modify(const H5O_pline_t *pline, H5Z_filter_t filter, unsigned flags, size_t cd_nelmts,
+H5Z_modify(H5Z_filter_info_t *filter, size_t nused, H5Z_filter_t filter_id, unsigned flags, size_t cd_nelmts,
            const unsigned int cd_values[/*cd_nelmts*/])
 {
     size_t idx;                 /* Index of filter in pipeline */
@@ -1134,27 +1211,27 @@ H5Z_modify(const H5O_pline_t *pline, H5Z_filter_t filter, unsigned flags, size_t
 
     FUNC_ENTER_NOAPI(FAIL)
 
-    assert(pline);
-    assert(filter >= 0 && filter <= H5Z_FILTER_MAX);
+    assert(filter);
+    assert(filter_id >= 0 && filter_id <= H5Z_FILTER_MAX);
     assert(0 == (flags & ~((unsigned)H5Z_FLAG_DEFMASK)));
     assert(0 == cd_nelmts || cd_values);
 
     /* Locate the filter in the pipeline */
-    for (idx = 0; idx < pline->nused; idx++)
-        if (pline->filter[idx].id == filter)
+    for (idx = 0; idx < nused; idx++)
+        if (filter[idx].id == filter_id)
             break;
 
     /* Check if the filter was not already in the pipeline */
-    if (idx > pline->nused)
+    if (idx > nused)
         HGOTO_ERROR(H5E_PLINE, H5E_NOTFOUND, FAIL, "filter not in pipeline");
 
     /* Change parameters for filter */
-    pline->filter[idx].flags     = flags;
-    pline->filter[idx].cd_nelmts = cd_nelmts;
+    filter[idx].flags     = flags;
+    filter[idx].cd_nelmts = cd_nelmts;
 
     /* Free any existing parameters */
-    if (pline->filter[idx].cd_values != NULL && pline->filter[idx].cd_values != pline->filter[idx]._cd_values)
-        H5MM_xfree(pline->filter[idx].cd_values);
+    if (filter[idx].cd_values != NULL && filter[idx].cd_values != filter[idx]._cd_values)
+        H5MM_xfree(filter[idx].cd_values);
 
     /* Set parameters */
     if (cd_nelmts > 0) {
@@ -1162,20 +1239,20 @@ H5Z_modify(const H5O_pline_t *pline, H5Z_filter_t filter, unsigned flags, size_t
 
         /* Allocate memory or point at internal buffer */
         if (cd_nelmts > H5Z_COMMON_CD_VALUES) {
-            pline->filter[idx].cd_values = (unsigned *)H5MM_malloc(cd_nelmts * sizeof(unsigned));
-            if (NULL == pline->filter[idx].cd_values)
+            filter[idx].cd_values = (unsigned *)H5MM_malloc(cd_nelmts * sizeof(unsigned));
+            if (NULL == filter[idx].cd_values)
                 HGOTO_ERROR(H5E_RESOURCE, H5E_NOSPACE, FAIL,
                             "memory allocation failed for filter parameters");
         } /* end if */
         else
-            pline->filter[idx].cd_values = pline->filter[idx]._cd_values;
+            filter[idx].cd_values = filter[idx]._cd_values;
 
         /* Copy client data values */
         for (i = 0; i < cd_nelmts; i++)
-            pline->filter[idx].cd_values[i] = cd_values[i];
+            filter[idx].cd_values[i] = cd_values[i];
     } /* end if */
     else
-        pline->filter[idx].cd_values = NULL;
+        filter[idx].cd_values = NULL;
 
 done:
     FUNC_LEAVE_NOAPI(ret_value)
@@ -1191,16 +1268,15 @@ done:
  *-------------------------------------------------------------------------
  */
 herr_t
-H5Z_append(H5O_pline_t *pline, H5Z_filter_t filter, unsigned flags, size_t cd_nelmts,
+H5Z_append(H5O_pline_t *pline, H5Z_filter_t filter_id, unsigned flags, size_t cd_nelmts,
            const unsigned int cd_values[/*cd_nelmts*/])
 {
-    size_t idx;
     herr_t ret_value = SUCCEED; /* Return value */
 
     FUNC_ENTER_NOAPI(FAIL)
 
     assert(pline);
-    assert(filter >= 0 && filter <= H5Z_FILTER_MAX);
+    assert(filter_id >= 0 && filter_id <= H5Z_FILTER_MAX);
     assert(0 == (flags & ~((unsigned)H5Z_FLAG_DEFMASK)));
     assert(0 == cd_nelmts || cd_values);
 
@@ -1215,10 +1291,40 @@ H5Z_append(H5O_pline_t *pline, H5Z_filter_t filter, unsigned flags, size_t cd_ne
     if (pline->version == 0)
         pline->version = H5O_PLINE_VERSION_1;
 
+    if (H5Z_append_filter(filter_id, flags, cd_nelmts, cd_values, 
+                          &pline->filter, &pline->nused, &pline->nalloc) < 0)
+        HGOTO_ERROR(H5E_PLINE, H5E_CANTINIT, FAIL, "unable to add filter to pipeline");
+
+done:
+    FUNC_LEAVE_NOAPI(ret_value)
+} /* end H5Z_append() */
+
+/*-------------------------------------------------------------------------
+ * Function: H5Z_append_filter
+ *
+ * Purpose:  Append another filter to the specified pipeline.
+ *
+ * Return:   Non-negative on success
+ *           Negative on failure
+ *-------------------------------------------------------------------------
+ */
+herr_t
+H5Z_append_filter(H5Z_filter_t filter_id, unsigned flags, size_t cd_nelmts,
+           const unsigned int cd_values[/*cd_nelmts*/], H5Z_filter_info_t **_filter, size_t *_nused, size_t *_nalloc)
+{
+    size_t nused = *_nused;
+    size_t nalloc = *_nalloc;
+    H5Z_filter_info_t *filter = *_filter;
+    size_t idx;
+    herr_t ret_value = SUCCEED; /* Return value */
+
+    FUNC_ENTER_NOAPI(FAIL)
+
     /* Allocate additional space in the pipeline if it's full */
-    if (pline->nused >= pline->nalloc) {
-        H5O_pline_t x;
+    if (nused >= nalloc) {
         size_t      n;
+        size_t      x_nalloc;
+        H5Z_filter_info_t *x_filter;
 
         /* Each filter's data may be stored internally or may be
          * a separate block of memory.
@@ -1227,57 +1333,63 @@ H5Z_append(H5O_pline_t *pline, H5Z_filter_t filter, unsigned flags, size_t cd_ne
          * filter struct is reallocated.  Set these pointers to ~NULL
          * so that we can reset them after reallocating the filters array.
          */
-        for (n = 0; n < pline->nalloc; ++n)
-            if (pline->filter[n].cd_values == pline->filter[n]._cd_values)
-                pline->filter[n].cd_values = (unsigned *)((void *)~((size_t)NULL));
+        for (n = 0; n < nalloc; ++n)
+            if (filter[n].cd_values == filter[n]._cd_values)
+                filter[n].cd_values = (unsigned *)((void *)~((size_t)NULL));
 
-        x.nalloc = MAX(H5Z_MAX_NFILTERS, 2 * pline->nalloc);
-        x.filter = (H5Z_filter_info_t *)H5MM_realloc(pline->filter, x.nalloc * sizeof(x.filter[0]));
-        if (NULL == x.filter)
+        x_nalloc = MAX(H5Z_MAX_NFILTERS, 2 * nalloc);
+        x_filter = (H5Z_filter_info_t *)H5MM_realloc(filter, x_nalloc * sizeof(x_filter[0]));
+        if (NULL == x_filter)
             HGOTO_ERROR(H5E_RESOURCE, H5E_NOSPACE, FAIL, "memory allocation failed for filter pipeline");
 
         /* Fix pointers in previous filters that need to point to their own
          *      internal data.
          */
-        for (n = 0; n < pline->nalloc; ++n)
-            if (x.filter[n].cd_values == (void *)~((size_t)NULL))
-                x.filter[n].cd_values = x.filter[n]._cd_values;
+        for (n = 0; n < nalloc; ++n)
+            if (x_filter[n].cd_values == (void *)~((size_t)NULL))
+                x_filter[n].cd_values = x_filter[n]._cd_values;
 
         /* Point to newly allocated buffer */
-        pline->nalloc = x.nalloc;
-        pline->filter = x.filter;
+        nalloc = x_nalloc;
+        filter = x_filter;
     } /* end if */
 
     /* Add the new filter to the pipeline */
-    idx                          = pline->nused;
-    pline->filter[idx].id        = filter;
-    pline->filter[idx].flags     = flags;
-    pline->filter[idx].name      = NULL; /*we'll pick it up later*/
-    pline->filter[idx].cd_nelmts = cd_nelmts;
+    idx                   = nused;
+    filter[idx].id        = filter_id;
+    filter[idx].flags     = flags;
+    filter[idx].name      = NULL; /*we'll pick it up later*/
+    filter[idx].cd_nelmts = cd_nelmts;
     if (cd_nelmts > 0) {
         size_t i; /* Local index variable */
 
         /* Allocate memory or point at internal buffer */
         if (cd_nelmts > H5Z_COMMON_CD_VALUES) {
-            pline->filter[idx].cd_values = (unsigned *)H5MM_malloc(cd_nelmts * sizeof(unsigned));
-            if (NULL == pline->filter[idx].cd_values)
+            filter[idx].cd_values = (unsigned *)H5MM_malloc(cd_nelmts * sizeof(unsigned));
+            if (NULL == filter[idx].cd_values)
                 HGOTO_ERROR(H5E_RESOURCE, H5E_NOSPACE, FAIL, "memory allocation failed for filter");
         } /* end if */
         else
-            pline->filter[idx].cd_values = pline->filter[idx]._cd_values;
+            filter[idx].cd_values = filter[idx]._cd_values;
 
         /* Copy client data values */
         for (i = 0; i < cd_nelmts; i++)
-            pline->filter[idx].cd_values[i] = cd_values[i];
+            filter[idx].cd_values[i] = cd_values[i];
     } /* end if */
     else
-        pline->filter[idx].cd_values = NULL;
+        filter[idx].cd_values = NULL;
 
-    pline->nused++;
+    nused++;
+
+    *_nused = nused;
+    *_nalloc = nalloc;
+    *_filter = filter;
 
 done:
     FUNC_LEAVE_NOAPI(ret_value)
-} /* end H5Z_append() */
+} /* H5Z_append_filter() */
+
+
 
 /*-------------------------------------------------------------------------
  * Function: H5Z__find_idx
@@ -1316,7 +1428,7 @@ done:
  *-------------------------------------------------------------------------
  */
 herr_t
-H5Z_find(bool try, H5Z_filter_t id, H5Z_class2_t **cls)
+H5Z_find(bool try, H5Z_filter_t id, H5Z_class3_t **cls)
 {
     int    idx;                 /* Filter index in global table */
     herr_t ret_value = SUCCEED; /* Return value */
@@ -1366,10 +1478,65 @@ H5Z_pipeline(const H5O_pline_t *pline, unsigned flags, unsigned *filter_mask /*i
              H5Z_cb_t cb_struct, size_t *nbytes /*in,out*/, size_t *buf_size /*in,out*/,
              void **buf /*in,out*/)
 {
+    herr_t   ret_value = SUCCEED; /* Return value */
+
+    FUNC_ENTER_NOAPI(FAIL)
+
+    assert(0 == (flags & ~((unsigned)H5Z_FLAG_INVMASK)));
+    assert(filter_mask);
+    assert(nbytes && *nbytes > 0);
+    assert(buf_size && *buf_size > 0);
+    assert(buf && *buf);
+    assert(!pline || pline->nused < H5Z_MAX_NFILTERS);
+
+    /* clang-format off */
+
+    if (pline) {
+
+        if (H5Z_apply_filters(pline->nused, pline->filter, flags, filter_mask, edc_read, cb_struct, nbytes, buf_size, buf) < 0)
+            HGOTO_ERROR(H5E_PLINE, H5E_CANTINIT, FAIL, "unable to apply filter");
+    }
+
+done:
+    FUNC_LEAVE_NOAPI(ret_value)
+
+/* clang-format on */
+
+} /* H5Z_pipeline() */
+
+
+/*-------------------------------------------------------------------------
+ * Function: H5Z_apply_filters
+ *
+ * Purpose:  Process data through the filter pipeline.  The FLAGS argument
+ *           is the filter invocation flags (definition flags come from
+ *           the PLINE->filter[].flags).  The filters are processed in
+ *           definition order unless the H5Z_FLAG_REVERSE is set.  The
+ *           FILTER_MASK is a bit-mask to indicate which filters to skip
+ *           and on exit will indicate which filters failed.  Each
+ *           filter has an index number in the pipeline and that index
+ *           number is the filter's bit in the FILTER_MASK.  NBYTES is the
+ *           number of bytes of data to filter and on exit should be the
+ *           number of resulting bytes while BUF_SIZE holds the total
+ *           allocated size of the buffer, which is pointed to BUF.
+ *
+ *           If the buffer must grow during processing of the pipeline
+ *           then the pipeline function should free the original buffer
+ *           and return a fresh buffer, adjusting BUF_SIZE accordingly.
+ *
+ * Return:   Non-negative on success
+ *           Negative on failure
+ *-------------------------------------------------------------------------
+ */
+herr_t
+H5Z_apply_filters(size_t nused, H5Z_filter_info_t *filter, unsigned flags, 
+                   unsigned *filter_mask /*in,out*/, H5Z_EDC_t edc_read, H5Z_cb_t cb_struct, 
+                   size_t *nbytes /*in,out*/, size_t *buf_size /*in,out*/, void **buf /*in,out*/)
+{
     size_t        idx;
     size_t        new_nbytes;
     int           fclass_idx;    /* Index of filter class in global table */
-    H5Z_class2_t *fclass = NULL; /* Filter class pointer */
+    H5Z_class3_t *fclass = NULL; /* Filter class pointer */
 #ifdef H5Z_DEBUG
     H5Z_stats_t  *fstats = NULL; /* Filter stats pointer */
     H5_timer_t    timer;         /* Timer for filter operations */
@@ -1387,15 +1554,12 @@ H5Z_pipeline(const H5O_pline_t *pline, unsigned flags, unsigned *filter_mask /*i
     assert(nbytes && *nbytes > 0);
     assert(buf_size && *buf_size > 0);
     assert(buf && *buf);
-    assert(!pline || pline->nused < H5Z_MAX_NFILTERS);
-
-    /* clang-format off */
 
 #ifdef H5Z_DEBUG
     H5_timer_init(&timer);
 #endif
-    if (pline && (flags & H5Z_FLAG_REVERSE)) { /* Read */
-        for (i = pline->nused; i > 0; --i) {
+    if (flags & H5Z_FLAG_REVERSE) { /* Read */
+        for (i = nused; i > 0; --i) {
             idx = i - 1;
             if (*filter_mask & ((unsigned)1 << idx)) {
                 failed |= (unsigned)1 << idx;
@@ -1406,21 +1570,21 @@ H5Z_pipeline(const H5O_pline_t *pline, unsigned flags, unsigned *filter_mask /*i
              * indicate no plugin through HDF5_PRELOAD_PLUG (using the symbol "::"),
              * try to load it dynamically and register it.  Otherwise, return failure
              */
-            if ((fclass_idx = H5Z__find_idx(pline->filter[idx].id)) < 0) {
+            if ((fclass_idx = H5Z__find_idx(filter[idx].id)) < 0) {
                 H5PL_key_t          key;
-                const H5Z_class2_t *filter_info;
+                const H5Z_class3_t *filter_info;
                 bool                issue_error = false;
 
                 /* Try loading the filter */
-                key.id = (int)(pline->filter[idx].id);
-                if (NULL != (filter_info = (const H5Z_class2_t *)H5PL_load(H5PL_TYPE_FILTER, &key))) {
+                key.id = (int)(filter[idx].id);
+                if (NULL != (filter_info = (const H5Z_class3_t *)H5PL_load(H5PL_TYPE_FILTER, &key))) {
                     /* Register the filter we loaded */
                     if (H5Z_register(filter_info) < 0)
                         HGOTO_ERROR(H5E_PLINE, H5E_CANTINIT, FAIL, "unable to register filter");
 
                     /* Search in the table of registered filters again to find the dynamic filter just loaded
                      * and registered */
-                    if ((fclass_idx = H5Z__find_idx(pline->filter[idx].id)) < 0)
+                    if ((fclass_idx = H5Z__find_idx(filter[idx].id)) < 0)
                         issue_error = true;
                 }
                 else
@@ -1430,9 +1594,9 @@ H5Z_pipeline(const H5O_pline_t *pline, unsigned flags, unsigned *filter_mask /*i
                 if (issue_error) {
                     /* Print out the filter name to give more info.  But the name is optional for
                      * the filter */
-                    if (pline->filter[idx].name)
+                    if (filter[idx].name)
                         HGOTO_ERROR(H5E_PLINE, H5E_READERROR, FAIL, "required filter '%s' is not registered",
-                                    pline->filter[idx].name);
+                                    filter[idx].name);
                     else
                         HGOTO_ERROR(H5E_PLINE, H5E_READERROR, FAIL,
                                     "required filter (name unavailable) is not registered");
@@ -1446,15 +1610,15 @@ H5Z_pipeline(const H5O_pline_t *pline, unsigned flags, unsigned *filter_mask /*i
             H5_timer_start(&timer);
 #endif
 
-            tmp_flags = flags | (pline->filter[idx].flags);
+            tmp_flags = flags | (filter[idx].flags);
             tmp_flags |= (edc_read == H5Z_DISABLE_EDC) ? H5Z_FLAG_SKIP_EDC : 0;
 
             H5E_PAUSE_ERRORS
                 {/* Prepare & restore library for user callback */
                     H5_BEFORE_USER_CB(FAIL)
                         {
-                            new_nbytes = (fclass->filter)(tmp_flags, pline->filter[idx].cd_nelmts,
-                                                          pline->filter[idx].cd_values, *nbytes, buf_size, buf);
+                            new_nbytes = (fclass->filter)(tmp_flags, filter[idx].cd_nelmts,
+                                                          filter[idx].cd_values, *nbytes, buf_size, buf);
                         }
                     H5_AFTER_USER_CB(FAIL)
                 }
@@ -1479,7 +1643,7 @@ H5Z_pipeline(const H5O_pline_t *pline, unsigned flags, unsigned *filter_mask /*i
                     /* Prepare & restore library for user callback */
                     H5_BEFORE_USER_CB(FAIL)
                         {
-                            status = cb_struct.func(pline->filter[idx].id, *buf, *buf_size, cb_struct.op_data);
+                            status = cb_struct.func(filter[idx].id, *buf, *buf_size, cb_struct.op_data);
                         }
                     H5_AFTER_USER_CB(FAIL)
                     if (H5Z_CB_FAIL == status)
@@ -1495,16 +1659,17 @@ H5Z_pipeline(const H5O_pline_t *pline, unsigned flags, unsigned *filter_mask /*i
                 *nbytes = new_nbytes;
         }
     }
-    else if (pline)
+    else 
     { /* Write */
-        for (idx = 0; idx < pline->nused; idx++) {
+        for (idx = 0; idx < nused; idx++) {
             if (*filter_mask & ((unsigned)1 << idx)) {
                 failed |= (unsigned)1 << idx;
                 continue; /* filter excluded */
             }
-            if ((fclass_idx = H5Z__find_idx(pline->filter[idx].id)) < 0) {
+
+            if ((fclass_idx = H5Z__find_idx(filter[idx].id)) < 0) {
                 /* Check if filter is optional -- If it isn't, then error */
-                if ((pline->filter[idx].flags & H5Z_FLAG_OPTIONAL) == 0)
+                if ((filter[idx].flags & H5Z_FLAG_OPTIONAL) == 0)
                     HGOTO_ERROR(H5E_PLINE, H5E_WRITEERROR, FAIL, "required filter is not registered");
                 failed |= (unsigned)1 << idx;
                 continue; /* filter excluded */
@@ -1521,8 +1686,8 @@ H5Z_pipeline(const H5O_pline_t *pline, unsigned flags, unsigned *filter_mask /*i
                 {/* Prepare & restore library for user callback */
                     H5_BEFORE_USER_CB(FAIL)
                         {
-                            new_nbytes = (fclass->filter)(flags | (pline->filter[idx].flags), pline->filter[idx].cd_nelmts,
-                                                          pline->filter[idx].cd_values, *nbytes, buf_size, buf);
+                            new_nbytes = (fclass->filter)(flags | (filter[idx].flags), filter[idx].cd_nelmts, 
+                                                          filter[idx].cd_values, *nbytes, buf_size, buf);
                         }
                     H5_AFTER_USER_CB(FAIL)
                 }
@@ -1541,14 +1706,14 @@ H5Z_pipeline(const H5O_pline_t *pline, unsigned flags, unsigned *filter_mask /*i
 #endif
 
             if (0 == new_nbytes) {
-                if (0 == (pline->filter[idx].flags & H5Z_FLAG_OPTIONAL)) {
+                if (0 == (filter[idx].flags & H5Z_FLAG_OPTIONAL)) {
                     if (cb_struct.func) {
                         H5Z_cb_return_t status;
 
                         /* Prepare & restore library for user callback */
                         H5_BEFORE_USER_CB(FAIL)
                             {
-                                status = cb_struct.func(pline->filter[idx].id, *buf, *nbytes, cb_struct.op_data);
+                                status = cb_struct.func(filter[idx].id, *buf, *nbytes, cb_struct.op_data);
                             }
                         H5_AFTER_USER_CB(FAIL)
                         if (H5Z_CB_FAIL == status)
@@ -1571,8 +1736,7 @@ H5Z_pipeline(const H5O_pline_t *pline, unsigned flags, unsigned *filter_mask /*i
 done:
     FUNC_LEAVE_NOAPI(ret_value)
 
-/* clang-format on */
-}
+} /* H5Z_apply_filters() */
 
 /*-------------------------------------------------------------------------
  * Function: H5Z_filter_info
@@ -1584,27 +1748,26 @@ done:
  *-------------------------------------------------------------------------
  */
 H5Z_filter_info_t *
-H5Z_filter_info(const H5O_pline_t *pline, H5Z_filter_t filter)
+H5Z_filter_info(H5Z_filter_info_t *filter, size_t nused, H5Z_filter_t filter_id)
 {
     size_t             idx;              /* Index of filter in pipeline */
     H5Z_filter_info_t *ret_value = NULL; /* Return value */
 
     FUNC_ENTER_NOAPI(NULL)
 
-    assert(pline);
-    assert(filter >= 0 && filter <= H5Z_FILTER_MAX);
+    assert(filter_id >= 0 && filter_id <= H5Z_FILTER_MAX);
 
     /* Locate the filter in the pipeline */
-    for (idx = 0; idx < pline->nused; idx++)
-        if (pline->filter[idx].id == filter)
+    for (idx = 0; idx < nused; idx++)
+        if (filter[idx].id == filter_id)
             break;
 
     /* Check if the filter was not already in the pipeline */
-    if (idx >= pline->nused)
+    if (idx >= nused)
         HGOTO_ERROR(H5E_PLINE, H5E_NOTFOUND, NULL, "filter not in pipeline");
 
     /* Set return value */
-    ret_value = &pline->filter[idx];
+    ret_value = &filter[idx];
 
 done:
     FUNC_LEAVE_NOAPI(ret_value)
@@ -1621,24 +1784,24 @@ done:
  *           FAIL   - error
  *-------------------------------------------------------------------------
  */
-htri_t
-H5Z_filter_in_pline(const H5O_pline_t *pline, H5Z_filter_t filter)
+htri_t 
+H5Z_filter_in_pline(H5Z_filter_info_t *filter, size_t nused, H5Z_filter_t filter_id)
 {
-    size_t idx;              /* Index of filter in pipeline */
+    size_t i;                /* Index of filter in pipeline */
     htri_t ret_value = true; /* Return value */
 
     FUNC_ENTER_NOAPI(FAIL)
 
-    assert(pline);
-    assert(filter >= 0 && filter <= H5Z_FILTER_MAX);
+    assert(filter);
+    assert(filter_id >= 0 && filter_id <= H5Z_FILTER_MAX);
 
     /* Locate the filter in the pipeline */
-    for (idx = 0; idx < pline->nused; idx++)
-        if (pline->filter[idx].id == filter)
+    for (i = 0; i < nused; i++) {
+        if (filter[i].id == filter_id)
             break;
-
+    }
     /* Check if the filter was not already in the pipeline */
-    if (idx >= pline->nused)
+    if (i >= nused)
         ret_value = false;
 
 done:
@@ -1656,7 +1819,7 @@ done:
  *-------------------------------------------------------------------------
  */
 htri_t
-H5Z_all_filters_avail(const H5O_pline_t *pline)
+H5Z_all_filters_avail(H5Z_filter_info_t *filter, size_t nused)
 {
     size_t i, j;             /* Local index variable */
     htri_t ret_value = true; /* Return value */
@@ -1664,13 +1827,13 @@ H5Z_all_filters_avail(const H5O_pline_t *pline)
     FUNC_ENTER_NOAPI(FAIL)
 
     /* Check args */
-    assert(pline);
+    assert(filter);
 
     /* Iterate through all the filters in pipeline */
-    for (i = 0; i < pline->nused; i++) {
+    for (i = 0; i < nused; i++) {
         /* Look for each filter in the list of registered filters */
         for (j = 0; j < H5Z_table_used_g; j++)
-            if (H5Z_table_g[j].id == pline->filter[i].id)
+            if (H5Z_table_g[j].id == filter[i].id)
                 break;
 
         /* Check if we didn't find the filter */
@@ -1799,7 +1962,7 @@ done:
 herr_t
 H5Z_get_filter_info(H5Z_filter_t filter, unsigned int *filter_config_flags)
 {
-    H5Z_class2_t *fclass    = NULL;
+    H5Z_class3_t *fclass    = NULL;
     herr_t        ret_value = SUCCEED;
 
     FUNC_ENTER_NOAPI(FAIL)

--- a/src/H5Zdeflate.c
+++ b/src/H5Zdeflate.c
@@ -31,7 +31,7 @@ static size_t H5Z__filter_deflate(unsigned flags, size_t cd_nelmts, const unsign
                                   size_t *buf_size, void **buf);
 
 /* This message derives from H5Z */
-const H5Z_class2_t H5Z_DEFLATE[1] = {{
+const H5Z_class3_t H5Z_DEFLATE[1] = {{
     H5Z_CLASS_T_VERS,    /* H5Z_class_t version */
     H5Z_FILTER_DEFLATE,  /* Filter id number		*/
     1,                   /* encoder_present flag (set to true) */

--- a/src/H5Zdevelop.h
+++ b/src/H5Zdevelop.h
@@ -116,7 +116,7 @@ typedef htri_t (*H5Z_can_apply_func_t)(hid_t dcpl_id, hid_t type_id, hid_t space
 typedef herr_t (*H5Z_set_local_func_t)(hid_t dcpl_id, hid_t type_id, hid_t space_id);
 //! <!-- [H5Z_set_local_func_t_snip] -->
 
-//! <!-- [H5Z_stc-set_local_func_t_snip] -->
+//! <!-- [H5Z_stc_set_local_func_t_snip] -->
 typedef herr_t (*H5Z_stc_set_local_func_t)(hid_t dcpl_id, hid_t type_id, hid_t space_id,
                                            H5_section_type_t sec_type);
 //! <!-- [H5Z_stc-set_local_func_t_snip] -->

--- a/src/H5Zdevelop.h
+++ b/src/H5Zdevelop.h
@@ -117,7 +117,8 @@ typedef herr_t (*H5Z_set_local_func_t)(hid_t dcpl_id, hid_t type_id, hid_t space
 //! <!-- [H5Z_set_local_func_t_snip] -->
 
 //! <!-- [H5Z_stc-set_local_func_t_snip] -->
-typedef herr_t (*H5Z_stc_set_local_func_t)(hid_t dcpl_id, hid_t type_id, hid_t space_id, H5_section_type_t sec_type);
+typedef herr_t (*H5Z_stc_set_local_func_t)(hid_t dcpl_id, hid_t type_id, hid_t space_id,
+                                           H5_section_type_t sec_type);
 //! <!-- [H5Z_stc-set_local_func_t_snip] -->
 
 /**
@@ -177,15 +178,15 @@ typedef struct H5Z_class2_t {
 
 //! <!-- [H5Z_class3_t_snip] -->
 typedef struct H5Z_class3_t {
-    int                  version;         /**< Version number of the H5Z_class_t struct     */
-    H5Z_filter_t         id;              /**< Filter ID number                             */
-    unsigned             encoder_present; /**< Does this filter have an encoder?            */
-    unsigned             decoder_present; /**< Does this filter have a decoder?             */
-    const char          *name;            /**< Comment for debugging                        */
-    H5Z_can_apply_func_t can_apply;       /**< The "can apply" callback for a filter        */
-    H5Z_stc_set_local_func_t set_local;   /**< The "set local" callback for a filter        */
-                                          /** With section info for structured chunk        */
-    H5Z_func_t           filter;          /**< The actual filter function                   */
+    int                      version;         /**< Version number of the H5Z_class_t struct     */
+    H5Z_filter_t             id;              /**< Filter ID number                             */
+    unsigned                 encoder_present; /**< Does this filter have an encoder?            */
+    unsigned                 decoder_present; /**< Does this filter have a decoder?             */
+    const char              *name;            /**< Comment for debugging                        */
+    H5Z_can_apply_func_t     can_apply;       /**< The "can apply" callback for a filter        */
+    H5Z_stc_set_local_func_t set_local;       /**< The "set local" callback for a filter        */
+                                              /** With section info for structured chunk        */
+    H5Z_func_t filter;                        /**< The actual filter function                   */
 } H5Z_class3_t;
 //! <!-- [H5Z_class3_t_snip] -->
 

--- a/src/H5Zdevelop.h
+++ b/src/H5Zdevelop.h
@@ -116,6 +116,10 @@ typedef htri_t (*H5Z_can_apply_func_t)(hid_t dcpl_id, hid_t type_id, hid_t space
 typedef herr_t (*H5Z_set_local_func_t)(hid_t dcpl_id, hid_t type_id, hid_t space_id);
 //! <!-- [H5Z_set_local_func_t_snip] -->
 
+//! <!-- [H5Z_stc-set_local_func_t_snip] -->
+typedef herr_t (*H5Z_stc_set_local_func_t)(hid_t dcpl_id, hid_t type_id, hid_t space_id, H5_section_type_t sec_type);
+//! <!-- [H5Z_stc-set_local_func_t_snip] -->
+
 /**
  * \brief The filter operation callback function, defining a filter's operation
  *        on data
@@ -170,6 +174,20 @@ typedef struct H5Z_class2_t {
     H5Z_func_t           filter;          /**< The actual filter function                   */
 } H5Z_class2_t;
 //! <!-- [H5Z_class2_t_snip] -->
+
+//! <!-- [H5Z_class3_t_snip] -->
+typedef struct H5Z_class3_t {
+    int                  version;         /**< Version number of the H5Z_class_t struct     */
+    H5Z_filter_t         id;              /**< Filter ID number                             */
+    unsigned             encoder_present; /**< Does this filter have an encoder?            */
+    unsigned             decoder_present; /**< Does this filter have a decoder?             */
+    const char          *name;            /**< Comment for debugging                        */
+    H5Z_can_apply_func_t can_apply;       /**< The "can apply" callback for a filter        */
+    H5Z_stc_set_local_func_t set_local;   /**< The "set local" callback for a filter        */
+                                          /** With section info for structured chunk        */
+    H5Z_func_t           filter;          /**< The actual filter function                   */
+} H5Z_class3_t;
+//! <!-- [H5Z_class3_t_snip] -->
 
 /********************/
 /* Public Variables */

--- a/src/H5Zfletcher32.c
+++ b/src/H5Zfletcher32.c
@@ -22,7 +22,7 @@ static size_t H5Z__filter_fletcher32(unsigned flags, size_t cd_nelmts, const uns
                                      size_t nbytes, size_t *buf_size, void **buf);
 
 /* This message derives from H5Z */
-const H5Z_class2_t H5Z_FLETCHER32[1] = {{
+const H5Z_class3_t H5Z_FLETCHER32[1] = {{
     H5Z_CLASS_T_VERS,       /* H5Z_class_t version */
     H5Z_FILTER_FLETCHER32,  /* Filter id number		*/
     1,                      /* encoder_present flag (set to true) */

--- a/src/H5Znbit.c
+++ b/src/H5Znbit.c
@@ -33,7 +33,7 @@ typedef struct {
 
 /* Local function prototypes */
 static htri_t H5Z__can_apply_nbit(hid_t dcpl_id, hid_t type_id, hid_t space_id);
-static herr_t H5Z__set_local_nbit(hid_t dcpl_id, hid_t type_id, hid_t space_id);
+static herr_t H5Z__set_local_nbit(hid_t dcpl_id, hid_t type_id, hid_t space_id, H5_section_type_t sec_type);
 static size_t H5Z__filter_nbit(unsigned flags, size_t cd_nelmts, const unsigned cd_values[], size_t nbytes,
                                size_t *buf_size, void **buf);
 
@@ -83,7 +83,7 @@ static void   H5Z__nbit_compress(unsigned char *data, unsigned d_nelmts, unsigne
                                  size_t *buffer_size, const unsigned parms[]);
 
 /* This message derives from H5Z */
-H5Z_class2_t H5Z_NBIT[1] = {{
+H5Z_class3_t H5Z_NBIT[1] = {{
     H5Z_CLASS_T_VERS,    /* H5Z_class_t version */
     H5Z_FILTER_NBIT,     /* Filter id number		*/
     1,                   /* Assume encoder present: check before registering */
@@ -749,7 +749,7 @@ done:
  *-------------------------------------------------------------------------
  */
 static herr_t
-H5Z__set_local_nbit(hid_t dcpl_id, hid_t type_id, hid_t space_id)
+H5Z__set_local_nbit(hid_t dcpl_id, hid_t type_id, hid_t space_id, H5_section_type_t sec_type)
 {
     H5P_genplist_t *dcpl_plist;                       /* Property list pointer */
     const H5T_t    *type;                             /* Datatype */
@@ -829,7 +829,7 @@ H5Z__set_local_nbit(hid_t dcpl_id, hid_t type_id, hid_t space_id)
         HGOTO_ERROR(H5E_ID, H5E_BADID, FAIL, "can't find object for ID");
 
     /* Get the filter's current parameters */
-    if (H5P_get_filter_by_id(dcpl_plist, H5Z_FILTER_NBIT, &flags, &cd_nelmts, cd_values, (size_t)0, NULL,
+    if (H5P_get_filter_by_id(dcpl_plist, H5Z_FILTER_NBIT, sec_type, &flags, &cd_nelmts, cd_values, (size_t)0, NULL,
                              NULL) < 0)
         HGOTO_ERROR(H5E_PLINE, H5E_CANTGET, FAIL, "can't get nbit parameters");
 
@@ -898,7 +898,7 @@ H5Z__set_local_nbit(hid_t dcpl_id, hid_t type_id, hid_t space_id)
     cd_values[1] = (unsigned)need_not_compress;
 
     /* Modify the filter's parameters for this dataset */
-    if (H5P_modify_filter(dcpl_plist, H5Z_FILTER_NBIT, flags, cd_values_actual_nparms, cd_values) < 0)
+    if (H5P_modify_filter(dcpl_plist, H5Z_FILTER_NBIT, sec_type, flags, cd_values_actual_nparms, cd_values) < 0)
         HGOTO_ERROR(H5E_PLINE, H5E_CANTSET, FAIL, "can't set local nbit parameters");
 
 done:

--- a/src/H5Znbit.c
+++ b/src/H5Znbit.c
@@ -829,8 +829,8 @@ H5Z__set_local_nbit(hid_t dcpl_id, hid_t type_id, hid_t space_id, H5_section_typ
         HGOTO_ERROR(H5E_ID, H5E_BADID, FAIL, "can't find object for ID");
 
     /* Get the filter's current parameters */
-    if (H5P_get_filter_by_id(dcpl_plist, H5Z_FILTER_NBIT, sec_type, &flags, &cd_nelmts, cd_values, (size_t)0, NULL,
-                             NULL) < 0)
+    if (H5P_get_filter_by_id(dcpl_plist, H5Z_FILTER_NBIT, sec_type, &flags, &cd_nelmts, cd_values, (size_t)0,
+                             NULL, NULL) < 0)
         HGOTO_ERROR(H5E_PLINE, H5E_CANTGET, FAIL, "can't get nbit parameters");
 
     /* Get dataspace */
@@ -898,7 +898,8 @@ H5Z__set_local_nbit(hid_t dcpl_id, hid_t type_id, hid_t space_id, H5_section_typ
     cd_values[1] = (unsigned)need_not_compress;
 
     /* Modify the filter's parameters for this dataset */
-    if (H5P_modify_filter(dcpl_plist, H5Z_FILTER_NBIT, sec_type, flags, cd_values_actual_nparms, cd_values) < 0)
+    if (H5P_modify_filter(dcpl_plist, H5Z_FILTER_NBIT, sec_type, flags, cd_values_actual_nparms, cd_values) <
+        0)
         HGOTO_ERROR(H5E_PLINE, H5E_CANTSET, FAIL, "can't set local nbit parameters");
 
 done:

--- a/src/H5Zpkg.h
+++ b/src/H5Zpkg.h
@@ -25,16 +25,16 @@
 /********************/
 
 /* Shuffle filter */
-H5_DLLVAR const H5Z_class2_t H5Z_SHUFFLE[1];
+H5_DLLVAR const H5Z_class3_t H5Z_SHUFFLE[1];
 
 /* Fletcher32 filter */
-H5_DLLVAR const H5Z_class2_t H5Z_FLETCHER32[1];
+H5_DLLVAR const H5Z_class3_t H5Z_FLETCHER32[1];
 
 /* n-bit filter */
-H5_DLLVAR H5Z_class2_t H5Z_NBIT[1];
+H5_DLLVAR H5Z_class3_t H5Z_NBIT[1];
 
 /* Scale/offset filter */
-H5_DLLVAR H5Z_class2_t H5Z_SCALEOFFSET[1];
+H5_DLLVAR H5Z_class3_t H5Z_SCALEOFFSET[1];
 
 /********************/
 /* External filters */
@@ -42,12 +42,12 @@ H5_DLLVAR H5Z_class2_t H5Z_SCALEOFFSET[1];
 
 /* Deflate filter */
 #ifdef H5_HAVE_FILTER_DEFLATE
-H5_DLLVAR const H5Z_class2_t H5Z_DEFLATE[1];
+H5_DLLVAR const H5Z_class3_t H5Z_DEFLATE[1];
 #endif /* H5_HAVE_FILTER_DEFLATE */
 
 /* szip filter */
 #ifdef H5_HAVE_FILTER_SZIP
-H5_DLLVAR H5Z_class2_t H5Z_SZIP[1];
+H5_DLLVAR H5Z_class3_t H5Z_SZIP[1];
 #endif /* H5_HAVE_FILTER_SZIP */
 
 /* Package internal routines */

--- a/src/H5Zprivate.h
+++ b/src/H5Zprivate.h
@@ -15,6 +15,7 @@
 
 /* Early typedefs to avoid circular dependencies */
 typedef struct H5Z_filter_info_t H5Z_filter_info_t;
+typedef struct H5Z_stc_filter_info_t H5Z_stc_filter_info_t;
 
 /* Include package's public headers */
 #include "H5Zpublic.h"
@@ -49,6 +50,8 @@ typedef struct H5Z_filter_info_t H5Z_filter_info_t;
 /****************************/
 
 /* Structure to store information about each filter's parameters */
+/* Originally filter APIs for structured chunk use buf_size and buf but on hold for now */
+/* For now the same structure is used also for structured chunk */
 struct H5Z_filter_info_t {
     H5Z_filter_t id;                               /*filter identification number	     */
     unsigned     flags;                            /*defn and invocation flags	     */
@@ -58,6 +61,16 @@ struct H5Z_filter_info_t {
     unsigned     _cd_values[H5Z_COMMON_CD_VALUES]; /*internal client data values		     */
     unsigned    *cd_values;                        /*client data values		     */
 };
+
+/* Structured chunk */
+/* Structure to store filter information for a section */
+typedef struct H5Z_stc_filter_sect_t {
+    size_t seq_sect;            /* Sequence # of the ith filtered section */
+    size_t nused;               /* Number of filters defined for 'seq_sect' */
+    size_t nalloc;              /* (not stored) Number of elements allocated for the `filter' description array */
+    size_t size_filt_descr;     /* Size of the 'filter' dsecription array */
+    H5Z_filter_info_t *filter;  /* Array of filters   */
+} H5Z_stc_filter_sect_t;
 
 /*****************************/
 /* Library-private Variables */
@@ -70,23 +83,34 @@ struct H5O_pline_t; /*forward decl*/
 
 /* Internal API routines */
 H5_DLL herr_t H5Z_init(void);
-H5_DLL herr_t H5Z_register(const H5Z_class2_t *cls);
+H5_DLL herr_t H5Z_register(const H5Z_class3_t *cls);
+
 H5_DLL herr_t H5Z_append(struct H5O_pline_t *pline, H5Z_filter_t filter, unsigned flags, size_t cd_nelmts,
                          const unsigned int cd_values[]);
-H5_DLL herr_t H5Z_modify(const struct H5O_pline_t *pline, H5Z_filter_t filter, unsigned flags,
-                         size_t cd_nelmts, const unsigned int cd_values[]);
+H5_DLL herr_t H5Z_append_filter(H5Z_filter_t filter_id, unsigned flags, size_t cd_nelmts,
+           const unsigned int cd_values[/*cd_nelmts*/], H5Z_filter_info_t **filter_info, size_t *nused, size_t *nalloc);
+
+H5_DLL herr_t H5Z_modify(H5Z_filter_info_t *filter, size_t nused, H5Z_filter_t filter_id, unsigned flags, 
+                         size_t cd_nelmts, const unsigned int cd_values[/*cd_nelmts*/]);
+
 H5_DLL herr_t H5Z_pipeline(const struct H5O_pline_t *pline, unsigned flags, unsigned *filter_mask /*in,out*/,
                            H5Z_EDC_t edc_read, H5Z_cb_t cb_struct, size_t *nbytes /*in,out*/,
                            size_t *buf_size /*in,out*/, void **buf /*in,out*/);
-H5_DLL herr_t H5Z_find(bool attempt, H5Z_filter_t id, H5Z_class2_t **cls);
+H5_DLL herr_t H5Z_apply_filters(size_t nused, H5Z_filter_info_t *filter, unsigned flags, 
+                               unsigned *filter_mask /*in,out*/, H5Z_EDC_t edc_read, H5Z_cb_t cb_struct,
+                               size_t *nbytes /*in,out*/, size_t *buf_size /*in,out*/, void **buf /*in,out*/); 
+
+H5_DLL herr_t H5Z_find(bool attempt, H5Z_filter_t id, H5Z_class3_t **cls);
 H5_DLL herr_t H5Z_can_apply(hid_t dcpl_id, hid_t type_id);
 H5_DLL herr_t H5Z_set_local(hid_t dcpl_id, hid_t type_id);
 H5_DLL herr_t H5Z_can_apply_direct(const struct H5O_pline_t *pline);
 H5_DLL herr_t H5Z_set_local_direct(const struct H5O_pline_t *pline);
 H5_DLL htri_t H5Z_ignore_filters(hid_t dcpl_id, const H5T_t *type, const H5S_t *space);
-H5_DLL H5Z_filter_info_t *H5Z_filter_info(const struct H5O_pline_t *pline, H5Z_filter_t filter);
-H5_DLL htri_t             H5Z_filter_in_pline(const struct H5O_pline_t *pline, H5Z_filter_t filter);
-H5_DLL htri_t             H5Z_all_filters_avail(const struct H5O_pline_t *pline);
+
+H5_DLL H5Z_filter_info_t *H5Z_filter_info(H5Z_filter_info_t *filter, size_t nused, H5Z_filter_t filter_id);
+H5_DLL htri_t H5Z_filter_in_pline(H5Z_filter_info_t *filter, size_t nused, H5Z_filter_t filter_id);
+
+H5_DLL htri_t             H5Z_all_filters_avail(H5Z_filter_info_t *filter, size_t nused);
 H5_DLL htri_t             H5Z_filter_avail(H5Z_filter_t id);
 H5_DLL herr_t             H5Z_delete(struct H5O_pline_t *pline, H5Z_filter_t filter);
 H5_DLL herr_t             H5Z_get_filter_info(H5Z_filter_t filter, unsigned int *filter_config_flags);

--- a/src/H5Zprivate.h
+++ b/src/H5Zprivate.h
@@ -14,7 +14,7 @@
 #define H5Zprivate_H
 
 /* Early typedefs to avoid circular dependencies */
-typedef struct H5Z_filter_info_t H5Z_filter_info_t;
+typedef struct H5Z_filter_info_t     H5Z_filter_info_t;
 typedef struct H5Z_stc_filter_info_t H5Z_stc_filter_info_t;
 
 /* Include package's public headers */
@@ -65,11 +65,11 @@ struct H5Z_filter_info_t {
 /* Structured chunk */
 /* Structure to store filter information for a section */
 typedef struct H5Z_stc_filter_sect_t {
-    size_t seq_sect;            /* Sequence # of the ith filtered section */
-    size_t nused;               /* Number of filters defined for 'seq_sect' */
-    size_t nalloc;              /* (not stored) Number of elements allocated for the `filter' description array */
-    size_t size_filt_descr;     /* Size of the 'filter' dsecription array */
-    H5Z_filter_info_t *filter;  /* Array of filters   */
+    size_t seq_sect;        /* Sequence # of the ith filtered section */
+    size_t nused;           /* Number of filters defined for 'seq_sect' */
+    size_t nalloc;          /* (not stored) Number of elements allocated for the `filter' description array */
+    size_t size_filt_descr; /* Size of the 'filter' dsecription array */
+    H5Z_filter_info_t *filter; /* Array of filters   */
 } H5Z_stc_filter_sect_t;
 
 /*****************************/
@@ -88,17 +88,19 @@ H5_DLL herr_t H5Z_register(const H5Z_class3_t *cls);
 H5_DLL herr_t H5Z_append(struct H5O_pline_t *pline, H5Z_filter_t filter, unsigned flags, size_t cd_nelmts,
                          const unsigned int cd_values[]);
 H5_DLL herr_t H5Z_append_filter(H5Z_filter_t filter_id, unsigned flags, size_t cd_nelmts,
-           const unsigned int cd_values[/*cd_nelmts*/], H5Z_filter_info_t **filter_info, size_t *nused, size_t *nalloc);
+                                const unsigned int cd_values[/*cd_nelmts*/], H5Z_filter_info_t **filter_info,
+                                size_t *nused, size_t *nalloc);
 
-H5_DLL herr_t H5Z_modify(H5Z_filter_info_t *filter, size_t nused, H5Z_filter_t filter_id, unsigned flags, 
+H5_DLL herr_t H5Z_modify(H5Z_filter_info_t *filter, size_t nused, H5Z_filter_t filter_id, unsigned flags,
                          size_t cd_nelmts, const unsigned int cd_values[/*cd_nelmts*/]);
 
 H5_DLL herr_t H5Z_pipeline(const struct H5O_pline_t *pline, unsigned flags, unsigned *filter_mask /*in,out*/,
                            H5Z_EDC_t edc_read, H5Z_cb_t cb_struct, size_t *nbytes /*in,out*/,
                            size_t *buf_size /*in,out*/, void **buf /*in,out*/);
-H5_DLL herr_t H5Z_apply_filters(size_t nused, H5Z_filter_info_t *filter, unsigned flags, 
-                               unsigned *filter_mask /*in,out*/, H5Z_EDC_t edc_read, H5Z_cb_t cb_struct,
-                               size_t *nbytes /*in,out*/, size_t *buf_size /*in,out*/, void **buf /*in,out*/); 
+H5_DLL herr_t H5Z_apply_filters(size_t nused, H5Z_filter_info_t *filter, unsigned flags,
+                                unsigned *filter_mask /*in,out*/, H5Z_EDC_t edc_read, H5Z_cb_t cb_struct,
+                                size_t *nbytes /*in,out*/, size_t *buf_size /*in,out*/,
+                                void **buf /*in,out*/);
 
 H5_DLL herr_t H5Z_find(bool attempt, H5Z_filter_t id, H5Z_class3_t **cls);
 H5_DLL herr_t H5Z_can_apply(hid_t dcpl_id, hid_t type_id);
@@ -110,10 +112,10 @@ H5_DLL htri_t H5Z_ignore_filters(hid_t dcpl_id, const H5T_t *type, const H5S_t *
 H5_DLL H5Z_filter_info_t *H5Z_filter_info(H5Z_filter_info_t *filter, size_t nused, H5Z_filter_t filter_id);
 H5_DLL htri_t H5Z_filter_in_pline(H5Z_filter_info_t *filter, size_t nused, H5Z_filter_t filter_id);
 
-H5_DLL htri_t             H5Z_all_filters_avail(H5Z_filter_info_t *filter, size_t nused);
-H5_DLL htri_t             H5Z_filter_avail(H5Z_filter_t id);
-H5_DLL herr_t             H5Z_delete(struct H5O_pline_t *pline, H5Z_filter_t filter);
-H5_DLL herr_t             H5Z_get_filter_info(H5Z_filter_t filter, unsigned int *filter_config_flags);
+H5_DLL htri_t H5Z_all_filters_avail(H5Z_filter_info_t *filter, size_t nused);
+H5_DLL htri_t H5Z_filter_avail(H5Z_filter_t id);
+H5_DLL herr_t H5Z_delete(struct H5O_pline_t *pline, H5Z_filter_t filter);
+H5_DLL herr_t H5Z_get_filter_info(H5Z_filter_t filter, unsigned int *filter_config_flags);
 
 /* Data Transform Functions */
 typedef struct H5Z_data_xform_t H5Z_data_xform_t; /* Defined in H5Ztrans.c */

--- a/src/H5Zprivate.h
+++ b/src/H5Zprivate.h
@@ -68,7 +68,7 @@ typedef struct H5Z_stc_filter_sect_t {
     size_t seq_sect;        /* Sequence # of the ith filtered section */
     size_t nused;           /* Number of filters defined for 'seq_sect' */
     size_t nalloc;          /* (not stored) Number of elements allocated for the `filter' description array */
-    size_t size_filt_descr; /* Size of the 'filter' dsecription array */
+    size_t size_filt_descr; /* Size of the 'filter' description array */
     H5Z_filter_info_t *filter; /* Array of filters   */
 } H5Z_stc_filter_sect_t;
 

--- a/src/H5Zpublic.h
+++ b/src/H5Zpublic.h
@@ -291,12 +291,6 @@ typedef enum H5Z_cb_return_t {
 typedef H5Z_cb_return_t (*H5Z_filter_func_t)(H5Z_filter_t filter, void *buf, size_t buf_size, void *op_data);
 //! <!-- [H5Z_filter_func_t_snip] -->
 
-/* TBD: */
-/* Convenience flag used by H5Pset_filter2() to specify a section of the sparse chunk to be filtered */
-#define H5Z_FLAG_SPARSE_SELECTION  0
-#define H5Z_FLAG_SPARSE_FIXED_DATA 1
-#define H5Z_FLAG_SPARSE_VL_DATA    2
-
 #ifdef __cplusplus
 extern "C" {
 #endif

--- a/src/H5Zscaleoffset.c
+++ b/src/H5Zscaleoffset.c
@@ -52,7 +52,8 @@ static enum H5Z_scaleoffset_t H5Z__scaleoffset_get_type(unsigned dtype_class, un
 static herr_t                 H5Z__scaleoffset_set_parms_fillval(H5P_genplist_t *dcpl_plist, H5T_t *type,
                                                                  enum H5Z_scaleoffset_t scale_type, unsigned cd_values[],
                                                                  int need_convert);
-static herr_t                 H5Z__set_local_scaleoffset(hid_t dcpl_id, hid_t type_id, hid_t space_id, H5_section_type_t sec_type);
+static herr_t                 H5Z__set_local_scaleoffset(hid_t dcpl_id, hid_t type_id, hid_t space_id,
+                                                         H5_section_type_t sec_type);
 static size_t H5Z__filter_scaleoffset(unsigned flags, size_t cd_nelmts, const unsigned cd_values[],
                                       size_t nbytes, size_t *buf_size, void **buf);
 static void   H5Z__scaleoffset_convert(void *buf, unsigned d_nelmts, unsigned dtype_size);
@@ -949,8 +950,8 @@ H5Z__set_local_scaleoffset(hid_t dcpl_id, hid_t type_id, hid_t space_id, H5_sect
     memset(cd_values, 0, sizeof(cd_values));
 
     /* Get the filter's current parameters */
-    if (H5P_get_filter_by_id(dcpl_plist, H5Z_FILTER_SCALEOFFSET, sec_type, &flags, &cd_nelmts, cd_values, (size_t)0,
-                             NULL, NULL) < 0)
+    if (H5P_get_filter_by_id(dcpl_plist, H5Z_FILTER_SCALEOFFSET, sec_type, &flags, &cd_nelmts, cd_values,
+                             (size_t)0, NULL, NULL) < 0)
         HGOTO_ERROR(H5E_PLINE, H5E_CANTGET, FAIL, "can't get scaleoffset parameters");
 
     /* Get dataspace */
@@ -1074,8 +1075,8 @@ H5Z__set_local_scaleoffset(hid_t dcpl_id, hid_t type_id, hid_t space_id, H5_sect
     } /* end else */
 
     /* Modify the filter's parameters for this dataset */
-    if (H5P_modify_filter(dcpl_plist, H5Z_FILTER_SCALEOFFSET, sec_type, flags, (size_t)H5Z_SCALEOFFSET_TOTAL_NPARMS,
-                          cd_values) < 0)
+    if (H5P_modify_filter(dcpl_plist, H5Z_FILTER_SCALEOFFSET, sec_type, flags,
+                          (size_t)H5Z_SCALEOFFSET_TOTAL_NPARMS, cd_values) < 0)
         HGOTO_ERROR(H5E_PLINE, H5E_CANTSET, FAIL, "can't set local scaleoffset parameters");
 
 done:

--- a/src/H5Zscaleoffset.c
+++ b/src/H5Zscaleoffset.c
@@ -52,7 +52,7 @@ static enum H5Z_scaleoffset_t H5Z__scaleoffset_get_type(unsigned dtype_class, un
 static herr_t                 H5Z__scaleoffset_set_parms_fillval(H5P_genplist_t *dcpl_plist, H5T_t *type,
                                                                  enum H5Z_scaleoffset_t scale_type, unsigned cd_values[],
                                                                  int need_convert);
-static herr_t                 H5Z__set_local_scaleoffset(hid_t dcpl_id, hid_t type_id, hid_t space_id);
+static herr_t                 H5Z__set_local_scaleoffset(hid_t dcpl_id, hid_t type_id, hid_t space_id, H5_section_type_t sec_type);
 static size_t H5Z__filter_scaleoffset(unsigned flags, size_t cd_nelmts, const unsigned cd_values[],
                                       size_t nbytes, size_t *buf_size, void **buf);
 static void   H5Z__scaleoffset_convert(void *buf, unsigned d_nelmts, unsigned dtype_size);
@@ -88,7 +88,7 @@ static void   H5Z__scaleoffset_compress(unsigned char *data, unsigned d_nelmts, 
                                         size_t buffer_size, parms_atomic p);
 
 /* This message derives from H5Z */
-H5Z_class2_t H5Z_SCALEOFFSET[1] = {{
+H5Z_class3_t H5Z_SCALEOFFSET[1] = {{
     H5Z_CLASS_T_VERS,           /* H5Z_class_t version */
     H5Z_FILTER_SCALEOFFSET,     /* Filter id number        */
     1,                          /* Assume encoder present: check before registering */
@@ -918,7 +918,7 @@ done:
  *-------------------------------------------------------------------------
  */
 static herr_t
-H5Z__set_local_scaleoffset(hid_t dcpl_id, hid_t type_id, hid_t space_id)
+H5Z__set_local_scaleoffset(hid_t dcpl_id, hid_t type_id, hid_t space_id, H5_section_type_t sec_type)
 {
     H5P_genplist_t        *dcpl_plist;                              /* Property list pointer */
     H5T_t                 *type;                                    /* Datatype */
@@ -949,7 +949,7 @@ H5Z__set_local_scaleoffset(hid_t dcpl_id, hid_t type_id, hid_t space_id)
     memset(cd_values, 0, sizeof(cd_values));
 
     /* Get the filter's current parameters */
-    if (H5P_get_filter_by_id(dcpl_plist, H5Z_FILTER_SCALEOFFSET, &flags, &cd_nelmts, cd_values, (size_t)0,
+    if (H5P_get_filter_by_id(dcpl_plist, H5Z_FILTER_SCALEOFFSET, sec_type, &flags, &cd_nelmts, cd_values, (size_t)0,
                              NULL, NULL) < 0)
         HGOTO_ERROR(H5E_PLINE, H5E_CANTGET, FAIL, "can't get scaleoffset parameters");
 
@@ -1074,7 +1074,7 @@ H5Z__set_local_scaleoffset(hid_t dcpl_id, hid_t type_id, hid_t space_id)
     } /* end else */
 
     /* Modify the filter's parameters for this dataset */
-    if (H5P_modify_filter(dcpl_plist, H5Z_FILTER_SCALEOFFSET, flags, (size_t)H5Z_SCALEOFFSET_TOTAL_NPARMS,
+    if (H5P_modify_filter(dcpl_plist, H5Z_FILTER_SCALEOFFSET, sec_type, flags, (size_t)H5Z_SCALEOFFSET_TOTAL_NPARMS,
                           cd_values) < 0)
         HGOTO_ERROR(H5E_PLINE, H5E_CANTSET, FAIL, "can't set local scaleoffset parameters");
 

--- a/src/H5Zshuffle.c
+++ b/src/H5Zshuffle.c
@@ -21,7 +21,8 @@
 #include "H5Zpkg.h"      /* Data filters				*/
 
 /* Local function prototypes */
-static herr_t H5Z__set_local_shuffle(hid_t dcpl_id, hid_t type_id, hid_t space_id, H5_section_type_t sec_type);
+static herr_t H5Z__set_local_shuffle(hid_t dcpl_id, hid_t type_id, hid_t space_id,
+                                     H5_section_type_t sec_type);
 static size_t H5Z__filter_shuffle(unsigned flags, size_t cd_nelmts, const unsigned cd_values[], size_t nbytes,
                                   size_t *buf_size, void **buf);
 
@@ -52,7 +53,8 @@ const H5Z_class3_t H5Z_SHUFFLE[1] = {{
  *-------------------------------------------------------------------------
  */
 static herr_t
-H5Z__set_local_shuffle(hid_t dcpl_id, hid_t type_id, hid_t H5_ATTR_UNUSED space_id, H5_section_type_t sec_type)
+H5Z__set_local_shuffle(hid_t dcpl_id, hid_t type_id, hid_t H5_ATTR_UNUSED space_id,
+                       H5_section_type_t sec_type)
 {
     H5P_genplist_t *dcpl_plist;                          /* Property list pointer */
     const H5T_t    *type;                                /* Datatype */
@@ -72,8 +74,8 @@ H5Z__set_local_shuffle(hid_t dcpl_id, hid_t type_id, hid_t H5_ATTR_UNUSED space_
         HGOTO_ERROR(H5E_ARGS, H5E_BADTYPE, FAIL, "not a datatype");
 
     /* Get the filter's current parameters */
-    if (H5P_get_filter_by_id(dcpl_plist, H5Z_FILTER_SHUFFLE, sec_type, &flags, &cd_nelmts, cd_values, (size_t)0, NULL,
-                             NULL) < 0)
+    if (H5P_get_filter_by_id(dcpl_plist, H5Z_FILTER_SHUFFLE, sec_type, &flags, &cd_nelmts, cd_values,
+                             (size_t)0, NULL, NULL) < 0)
         HGOTO_ERROR(H5E_PLINE, H5E_CANTGET, FAIL, "can't get shuffle parameters");
 
     /* Set "local" parameter for this dataset */

--- a/src/H5Zshuffle.c
+++ b/src/H5Zshuffle.c
@@ -21,12 +21,12 @@
 #include "H5Zpkg.h"      /* Data filters				*/
 
 /* Local function prototypes */
-static herr_t H5Z__set_local_shuffle(hid_t dcpl_id, hid_t type_id, hid_t space_id);
+static herr_t H5Z__set_local_shuffle(hid_t dcpl_id, hid_t type_id, hid_t space_id, H5_section_type_t sec_type);
 static size_t H5Z__filter_shuffle(unsigned flags, size_t cd_nelmts, const unsigned cd_values[], size_t nbytes,
                                   size_t *buf_size, void **buf);
 
 /* This message derives from H5Z */
-const H5Z_class2_t H5Z_SHUFFLE[1] = {{
+const H5Z_class3_t H5Z_SHUFFLE[1] = {{
     H5Z_CLASS_T_VERS,       /* H5Z_class_t version */
     H5Z_FILTER_SHUFFLE,     /* Filter id number		*/
     1,                      /* encoder_present flag (set to true) */
@@ -52,7 +52,7 @@ const H5Z_class2_t H5Z_SHUFFLE[1] = {{
  *-------------------------------------------------------------------------
  */
 static herr_t
-H5Z__set_local_shuffle(hid_t dcpl_id, hid_t type_id, hid_t H5_ATTR_UNUSED space_id)
+H5Z__set_local_shuffle(hid_t dcpl_id, hid_t type_id, hid_t H5_ATTR_UNUSED space_id, H5_section_type_t sec_type)
 {
     H5P_genplist_t *dcpl_plist;                          /* Property list pointer */
     const H5T_t    *type;                                /* Datatype */
@@ -72,7 +72,7 @@ H5Z__set_local_shuffle(hid_t dcpl_id, hid_t type_id, hid_t H5_ATTR_UNUSED space_
         HGOTO_ERROR(H5E_ARGS, H5E_BADTYPE, FAIL, "not a datatype");
 
     /* Get the filter's current parameters */
-    if (H5P_get_filter_by_id(dcpl_plist, H5Z_FILTER_SHUFFLE, &flags, &cd_nelmts, cd_values, (size_t)0, NULL,
+    if (H5P_get_filter_by_id(dcpl_plist, H5Z_FILTER_SHUFFLE, sec_type, &flags, &cd_nelmts, cd_values, (size_t)0, NULL,
                              NULL) < 0)
         HGOTO_ERROR(H5E_PLINE, H5E_CANTGET, FAIL, "can't get shuffle parameters");
 
@@ -81,7 +81,7 @@ H5Z__set_local_shuffle(hid_t dcpl_id, hid_t type_id, hid_t H5_ATTR_UNUSED space_
         HGOTO_ERROR(H5E_PLINE, H5E_BADTYPE, FAIL, "bad datatype size");
 
     /* Modify the filter's parameters for this dataset */
-    if (H5P_modify_filter(dcpl_plist, H5Z_FILTER_SHUFFLE, flags, (size_t)H5Z_SHUFFLE_TOTAL_NPARMS,
+    if (H5P_modify_filter(dcpl_plist, H5Z_FILTER_SHUFFLE, sec_type, flags, (size_t)H5Z_SHUFFLE_TOTAL_NPARMS,
                           cd_values) < 0)
         HGOTO_ERROR(H5E_PLINE, H5E_CANTSET, FAIL, "can't set local shuffle parameters");
 

--- a/src/H5Zszip.c
+++ b/src/H5Zszip.c
@@ -30,12 +30,12 @@
 
 /* Local function prototypes */
 static htri_t H5Z__can_apply_szip(hid_t dcpl_id, hid_t type_id, hid_t space_id);
-static herr_t H5Z__set_local_szip(hid_t dcpl_id, hid_t type_id, hid_t space_id);
+static herr_t H5Z__set_local_szip(hid_t dcpl_id, hid_t type_id, hid_t space_id, H5_section_type_t sec_type);
 static size_t H5Z__filter_szip(unsigned flags, size_t cd_nelmts, const unsigned cd_values[], size_t nbytes,
                                size_t *buf_size, void **buf);
 
 /* This message derives from H5Z */
-H5Z_class2_t H5Z_SZIP[1] = {{
+H5Z_class3_t H5Z_SZIP[1] = {{
     H5Z_CLASS_T_VERS,    /* H5Z_class_t version */
     H5Z_FILTER_SZIP,     /* Filter id number		*/
     1,                   /* Assume encoder present: check before registering */
@@ -110,7 +110,7 @@ done:
  *-------------------------------------------------------------------------
  */
 static herr_t
-H5Z__set_local_szip(hid_t dcpl_id, hid_t type_id, hid_t space_id)
+H5Z__set_local_szip(hid_t dcpl_id, hid_t type_id, hid_t space_id, H5_section_type_t sec_type)
 {
     H5P_genplist_t *dcpl_plist;                       /* Property list pointer */
     const H5T_t    *type;                             /* Datatype */
@@ -138,7 +138,7 @@ H5Z__set_local_szip(hid_t dcpl_id, hid_t type_id, hid_t space_id)
         HGOTO_ERROR(H5E_ARGS, H5E_BADTYPE, FAIL, "not a datatype");
 
     /* Get the filter's current parameters */
-    if (H5P_get_filter_by_id(dcpl_plist, H5Z_FILTER_SZIP, &flags, &cd_nelmts, cd_values, 0, NULL, NULL) < 0)
+    if (H5P_get_filter_by_id(dcpl_plist, H5Z_FILTER_SZIP, sec_type, &flags, &cd_nelmts, cd_values, 0, NULL, NULL) < 0)
         HGOTO_ERROR(H5E_PLINE, H5E_CANTGET, FAIL, "can't get szip parameters");
 
     /* Get datatype's size, for checking the "bits-per-pixel" */
@@ -229,7 +229,7 @@ H5Z__set_local_szip(hid_t dcpl_id, hid_t type_id, hid_t space_id)
     } /* end switch */
 
     /* Modify the filter's parameters for this dataset */
-    if (H5P_modify_filter(dcpl_plist, H5Z_FILTER_SZIP, flags, H5Z_SZIP_TOTAL_NPARMS, cd_values) < 0)
+    if (H5P_modify_filter(dcpl_plist, H5Z_FILTER_SZIP, seec_type, flags, H5Z_SZIP_TOTAL_NPARMS, cd_values) < 0)
         HGOTO_ERROR(H5E_PLINE, H5E_CANTSET, FAIL, "can't set local szip parameters");
 
 done:

--- a/src/H5Zszip.c
+++ b/src/H5Zszip.c
@@ -230,8 +230,7 @@ H5Z__set_local_szip(hid_t dcpl_id, hid_t type_id, hid_t space_id, H5_section_typ
     } /* end switch */
 
     /* Modify the filter's parameters for this dataset */
-    if (H5P_modify_filter(dcpl_plist, H5Z_FILTER_SZIP, sec_type, flags, H5Z_SZIP_TOTAL_NPARMS, cd_values) <
-        0)
+    if (H5P_modify_filter(dcpl_plist, H5Z_FILTER_SZIP, sec_type, flags, H5Z_SZIP_TOTAL_NPARMS, cd_values) < 0)
         HGOTO_ERROR(H5E_PLINE, H5E_CANTSET, FAIL, "can't set local szip parameters");
 
 done:

--- a/src/H5Zszip.c
+++ b/src/H5Zszip.c
@@ -138,7 +138,8 @@ H5Z__set_local_szip(hid_t dcpl_id, hid_t type_id, hid_t space_id, H5_section_typ
         HGOTO_ERROR(H5E_ARGS, H5E_BADTYPE, FAIL, "not a datatype");
 
     /* Get the filter's current parameters */
-    if (H5P_get_filter_by_id(dcpl_plist, H5Z_FILTER_SZIP, sec_type, &flags, &cd_nelmts, cd_values, 0, NULL, NULL) < 0)
+    if (H5P_get_filter_by_id(dcpl_plist, H5Z_FILTER_SZIP, sec_type, &flags, &cd_nelmts, cd_values, 0, NULL,
+                             NULL) < 0)
         HGOTO_ERROR(H5E_PLINE, H5E_CANTGET, FAIL, "can't get szip parameters");
 
     /* Get datatype's size, for checking the "bits-per-pixel" */
@@ -229,7 +230,8 @@ H5Z__set_local_szip(hid_t dcpl_id, hid_t type_id, hid_t space_id, H5_section_typ
     } /* end switch */
 
     /* Modify the filter's parameters for this dataset */
-    if (H5P_modify_filter(dcpl_plist, H5Z_FILTER_SZIP, seec_type, flags, H5Z_SZIP_TOTAL_NPARMS, cd_values) < 0)
+    if (H5P_modify_filter(dcpl_plist, H5Z_FILTER_SZIP, seec_type, flags, H5Z_SZIP_TOTAL_NPARMS, cd_values) <
+        0)
         HGOTO_ERROR(H5E_PLINE, H5E_CANTSET, FAIL, "can't set local szip parameters");
 
 done:

--- a/src/H5Zszip.c
+++ b/src/H5Zszip.c
@@ -230,7 +230,7 @@ H5Z__set_local_szip(hid_t dcpl_id, hid_t type_id, hid_t space_id, H5_section_typ
     } /* end switch */
 
     /* Modify the filter's parameters for this dataset */
-    if (H5P_modify_filter(dcpl_plist, H5Z_FILTER_SZIP, seec_type, flags, H5Z_SZIP_TOTAL_NPARMS, cd_values) <
+    if (H5P_modify_filter(dcpl_plist, H5Z_FILTER_SZIP, sec_type, flags, H5Z_SZIP_TOTAL_NPARMS, cd_values) <
         0)
         HGOTO_ERROR(H5E_PLINE, H5E_CANTSET, FAIL, "can't set local szip parameters");
 

--- a/src/H5public.h
+++ b/src/H5public.h
@@ -431,11 +431,11 @@ typedef struct H5_ih_info_t {
 
 //! <!-- [H5_section_type_t_snip] -->
 typedef enum H5_section_type_t {
-     H5_SECTION_UNKNOWN = -1,
-     H5_SECTION_SELECTION,
-     H5_SECTION_FIXED,
-     H5_SECTION_VL,
-     H5_SECTION_NUM /* Should be the last item */
+    H5_SECTION_UNKNOWN = -1,
+    H5_SECTION_SELECTION,
+    H5_SECTION_FIXED,
+    H5_SECTION_VL,
+    H5_SECTION_NUM /* Should be the last item */
 } H5_section_type_t;
 //! <!-- [H5_section_type_t_snip] -->
 

--- a/src/H5public.h
+++ b/src/H5public.h
@@ -429,6 +429,16 @@ typedef struct H5_ih_info_t {
 } H5_ih_info_t;
 //! <!-- [H5_ih_info_t_snip] -->
 
+//! <!-- [H5_section_type_t_snip] -->
+typedef enum H5_section_type_t {
+     H5_SECTION_UNKNOWN = -1,
+     H5_SECTION_SELECTION,
+     H5_SECTION_FIXED,
+     H5_SECTION_VL,
+     H5_SECTION_NUM /* Should be the last item */
+} H5_section_type_t;
+//! <!-- [H5_section_type_t_snip] -->
+
 /**
  * The maximum size allowed for tokens
  * \details Tokens are unique and permanent identifiers that are

--- a/src/H5trace.c
+++ b/src/H5trace.c
@@ -3897,9 +3897,9 @@ H5_trace_args(H5RS_str_t *rs, const char *type, va_list ap)
                         }     /* end block */
                         break;
 
-                        case 'c': /* H5Z_class2_t */
+                        case 'c': /* H5Z_class3_t */
                         {
-                            H5Z_class2_t *filter = va_arg(ap, H5Z_class2_t *);
+                            H5Z_class3_t *filter = va_arg(ap, H5Z_class3_t *);
 
                             H5RS_asprintf_cat(rs, "%p", (void *)filter);
                         } /* end block  */

--- a/src/H5version.h
+++ b/src/H5version.h
@@ -116,6 +116,14 @@
   #define H5Gopen_vers 1
 #endif /* !defined(H5Gopen_vers) */
 
+#if !defined(H5Pset_filter_vers)
+  #define H5Pset_filter_vers 1
+#endif /* !defined(H5Pset_filter_vers) */
+
+#if !defined(H5Pget_nfilters_vers)
+  #define H5Pget_nfilters_vers 1
+#endif /* !defined(H5Pget_nfilters_vers) */
+
 #if !defined(H5Pget_filter_vers)
   #define H5Pget_filter_vers 1
 #endif /* !defined(H5Pget_filter_vers) */
@@ -123,6 +131,10 @@
 #if !defined(H5Pget_filter_by_id_vers)
   #define H5Pget_filter_by_id_vers 1
 #endif /* !defined(H5Pget_filter_by_id_vers) */
+
+#if !defined(H5Pmodify_filter_vers)
+  #define H5Pmodify_filter_vers 1
+#endif /* !defined(H5Pmodify_filter_vers) */
 
 #if !defined(H5Pinsert_vers)
   #define H5Pinsert_vers 1
@@ -276,6 +288,14 @@
   #define H5Ovisit_by_name_vers 1
 #endif /* !defined(H5Ovisit_by_name_vers) */
 
+#if !defined(H5Pset_filter_vers)
+  #define H5Pset_filter_vers 1
+#endif /* !defined(H5Pset_filter_vers) */
+
+#if !defined(H5Pget_nfilters_vers)
+  #define H5Pget_nfilters_vers 1
+#endif /* !defined(H5Pget_nfilters_vers) */
+
 #if !defined(H5Pget_filter_vers)
   #define H5Pget_filter_vers 2
 #endif /* !defined(H5Pget_filter_vers) */
@@ -283,6 +303,10 @@
 #if !defined(H5Pget_filter_by_id_vers)
   #define H5Pget_filter_by_id_vers 2
 #endif /* !defined(H5Pget_filter_by_id_vers) */
+
+#if !defined(H5Pmodify_filter_vers)
+  #define H5Pmodify_filter_vers 1
+#endif /* !defined(H5Pmodify_filter_vers) */
 
 #if !defined(H5Pinsert_vers)
   #define H5Pinsert_vers 2
@@ -456,6 +480,14 @@
   #define H5Pencode_vers 1
 #endif /* !defined(H5Pencode_vers) */
 
+#if !defined(H5Pset_filter_vers)
+  #define H5Pset_filter_vers 1
+#endif /* !defined(H5Pset_filter_vers) */
+
+#if !defined(H5Pget_nfilters_vers)
+  #define H5Pget_nfilters_vers 1
+#endif /* !defined(H5Pget_nfilters_vers) */
+
 #if !defined(H5Pget_filter_vers)
   #define H5Pget_filter_vers 2
 #endif /* !defined(H5Pget_filter_vers) */
@@ -463,6 +495,10 @@
 #if !defined(H5Pget_filter_by_id_vers)
   #define H5Pget_filter_by_id_vers 2
 #endif /* !defined(H5Pget_filter_by_id_vers) */
+
+#if !defined(H5Pmodify_filter_vers)
+  #define H5Pmodify_filter_vers 1
+#endif /* !defined(H5Pmodify_filter_vers) */
 
 #if !defined(H5Pinsert_vers)
   #define H5Pinsert_vers 2
@@ -636,6 +672,14 @@
   #define H5Pencode_vers 2
 #endif /* !defined(H5Pencode_vers) */
 
+#if !defined(H5Pset_filter_vers)
+  #define H5Pset_filter_vers 1
+#endif /* !defined(H5Pset_filter_vers) */
+
+#if !defined(H5Pget_nfilters_vers)
+  #define H5Pget_nfilters_vers 1
+#endif /* !defined(H5Pget_nfilters_vers) */
+
 #if !defined(H5Pget_filter_vers)
   #define H5Pget_filter_vers 2
 #endif /* !defined(H5Pget_filter_vers) */
@@ -643,6 +687,10 @@
 #if !defined(H5Pget_filter_by_id_vers)
   #define H5Pget_filter_by_id_vers 2
 #endif /* !defined(H5Pget_filter_by_id_vers) */
+
+#if !defined(H5Pmodify_filter_vers)
+  #define H5Pmodify_filter_vers 1
+#endif /* !defined(H5Pmodify_filter_vers) */
 
 #if !defined(H5Pinsert_vers)
   #define H5Pinsert_vers 2
@@ -816,6 +864,14 @@
   #define H5Pencode_vers 2
 #endif /* !defined(H5Pencode_vers) */
 
+#if !defined(H5Pset_filter_vers)
+  #define H5Pset_filter_vers 1
+#endif /* !defined(H5Pset_filter_vers) */
+
+#if !defined(H5Pget_nfilters_vers)
+  #define H5Pget_nfilters_vers 1
+#endif /* !defined(H5Pget_nfilters_vers) */
+
 #if !defined(H5Pget_filter_vers)
   #define H5Pget_filter_vers 2
 #endif /* !defined(H5Pget_filter_vers) */
@@ -823,6 +879,10 @@
 #if !defined(H5Pget_filter_by_id_vers)
   #define H5Pget_filter_by_id_vers 2
 #endif /* !defined(H5Pget_filter_by_id_vers) */
+
+#if !defined(H5Pmodify_filter_vers)
+  #define H5Pmodify_filter_vers 1
+#endif /* !defined(H5Pmodify_filter_vers) */
 
 #if !defined(H5Pinsert_vers)
   #define H5Pinsert_vers 2
@@ -881,7 +941,7 @@
 #endif /* !defined(H5O_iterate_t_vers) */
 
 #if !defined(H5Z_class_t_vers)
-  #define H5Z_class_t_vers 2
+  #define H5Z_class_t_vers 3
 #endif /* !defined(H5Z_class_t_vers) */
 
 #endif /* H5_USE_114_API */
@@ -996,13 +1056,25 @@
   #define H5Pencode_vers 2
 #endif /* !defined(H5Pencode_vers) */
 
+#if !defined(H5Pset_filter_vers)
+  #define H5Pset_filter_vers 2
+#endif /* !defined(H5Pset_filter_vers) */
+
+#if !defined(H5Pget_nfilters_vers)
+  #define H5Pget_nfilters_vers 2
+#endif /* !defined(H5Pget_nfilters_vers) */
+
 #if !defined(H5Pget_filter_vers)
-  #define H5Pget_filter_vers 2
+  #define H5Pget_filter_vers 3
 #endif /* !defined(H5Pget_filter_vers) */
 
 #if !defined(H5Pget_filter_by_id_vers)
-  #define H5Pget_filter_by_id_vers 2
+  #define H5Pget_filter_by_id_vers 3
 #endif /* !defined(H5Pget_filter_by_id_vers) */
+
+#if !defined(H5Pmodify_filter_vers)
+  #define H5Pmodify_filter_vers 2
+#endif /* !defined(H5Pmodify_filter_vers) */
 
 #if !defined(H5Pinsert_vers)
   #define H5Pinsert_vers 2
@@ -1061,7 +1133,7 @@
 #endif /* !defined(H5O_iterate_t_vers) */
 
 #if !defined(H5Z_class_t_vers)
-  #define H5Z_class_t_vers 2
+  #define H5Z_class_t_vers 3
 #endif /* !defined(H5Z_class_t_vers) */
 
 #endif /* H5_USE_200_API */
@@ -1393,7 +1465,34 @@
   #error "H5Pencode_vers set to invalid value"
 #endif /* H5Pencode_vers */
 
-#if !defined(H5Pget_filter_vers) || H5Pget_filter_vers == 2
+#if !defined(H5Pset_filter_vers) || H5Pset_filter_vers == 2
+  #ifndef H5Pset_filter_vers
+    #define H5Pset_filter_vers 2
+  #endif /* H5Pset_filter_vers */
+  #define H5Pset_filter H5Pset_filter2
+#elif H5Pset_filter_vers == 1
+  #define H5Pset_filter H5Pset_filter1
+#else /* H5Pset_filter_vers */
+  #error "H5Pset_filter_vers set to invalid value"
+#endif /* H5Pset_filter_vers */
+
+#if !defined(H5Pget_nfilters_vers) || H5Pget_nfilters_vers == 2
+  #ifndef H5Pget_nfilters_vers
+    #define H5Pget_nfilters_vers 2
+  #endif /* H5Pget_nfilters_vers */
+  #define H5Pget_nfilters H5Pget_nfilters2
+#elif H5Pget_nfilters_vers == 1
+  #define H5Pget_nfilters H5Pget_nfilters1
+#else /* H5Pget_nfilters_vers */
+  #error "H5Pget_nfilters_vers set to invalid value"
+#endif /* H5Pget_nfilters_vers */
+
+#if !defined(H5Pget_filter_vers) || H5Pget_filter_vers == 3
+  #ifndef H5Pget_filter_vers
+    #define H5Pget_filter_vers 3
+  #endif /* H5Pget_filter_vers */
+  #define H5Pget_filter H5Pget_filter3
+#elif !defined(H5Pget_filter_vers) || H5Pget_filter_vers == 2
   #ifndef H5Pget_filter_vers
     #define H5Pget_filter_vers 2
   #endif /* H5Pget_filter_vers */
@@ -1404,7 +1503,12 @@
   #error "H5Pget_filter_vers set to invalid value"
 #endif /* H5Pget_filter_vers */
 
-#if !defined(H5Pget_filter_by_id_vers) || H5Pget_filter_by_id_vers == 2
+#if !defined(H5Pget_filter_by_id_vers) || H5Pget_filter_by_id_vers == 3
+  #ifndef H5Pget_filter_by_id_vers
+    #define H5Pget_filter_by_id_vers 3
+  #endif /* H5Pget_filter_by_id_vers */
+  #define H5Pget_filter_by_id H5Pget_filter_by_id3
+#elif !defined(H5Pget_filter_by_id_vers) || H5Pget_filter_by_id_vers == 2
   #ifndef H5Pget_filter_by_id_vers
     #define H5Pget_filter_by_id_vers 2
   #endif /* H5Pget_filter_by_id_vers */
@@ -1414,6 +1518,17 @@
 #else /* H5Pget_filter_by_id_vers */
   #error "H5Pget_filter_by_id_vers set to invalid value"
 #endif /* H5Pget_filter_by_id_vers */
+
+#if !defined(H5Pmodify_filter_vers) || H5Pmodify_filter_vers == 2
+  #ifndef H5Pmodify_filter_vers
+    #define H5Pmodify_filter_vers 2
+  #endif /* H5Pmodify_filter_vers */
+  #define H5Pmodify_filter H5Pmodify_filter2
+#elif H5Pmodify_filter_vers == 1
+  #define H5Pmodify_filter H5Pmodify_filter1
+#else /* H5Pmodify_filter_vers */
+  #error "H5Pmodify_filter_vers set to invalid value"
+#endif /* H5Pmodify_filter_vers */
 
 #if !defined(H5Pinsert_vers) || H5Pinsert_vers == 2
   #ifndef H5Pinsert_vers
@@ -1565,7 +1680,12 @@
 #endif /* H5O_iterate_t_vers */
 
 
-#if !defined(H5Z_class_t_vers) || H5Z_class_t_vers == 2
+#if !defined(H5Z_class_t_vers) || H5Z_class_t_vers == 3
+  #ifndef H5Z_class_t_vers
+    #define H5Z_class_t_vers 3
+  #endif /* H5Z_class_t_vers */
+  #define H5Z_class_t H5Z_class3_t
+#elif H5Z_class_t_vers == 2
   #ifndef H5Z_class_t_vers
     #define H5Z_class_t_vers 2
   #endif /* H5Z_class_t_vers */

--- a/test/direct_chunk.c
+++ b/test/direct_chunk.c
@@ -799,7 +799,7 @@ test_skip_compress_write2(hid_t file)
     if (H5Zregister(H5Z_BOGUS1) < 0)
         goto error;
 
-    if (H5Pset_filter(cparms, H5Z_FILTER_BOGUS1, 0, (size_t)0, NULL) < 0)
+    if (H5Pset_filter1(cparms, H5Z_FILTER_BOGUS1, 0, (size_t)0, NULL) < 0)
         goto error;
 
     /* Enable compression filter */
@@ -810,7 +810,7 @@ test_skip_compress_write2(hid_t file)
     if (H5Zregister(H5Z_BOGUS2) < 0)
         goto error;
 
-    if (H5Pset_filter(cparms, H5Z_FILTER_BOGUS2, 0, (size_t)0, NULL) < 0)
+    if (H5Pset_filter1(cparms, H5Z_FILTER_BOGUS2, 0, (size_t)0, NULL) < 0)
         goto error;
 
     /*

--- a/test/dsets.c
+++ b/test/dsets.c
@@ -1703,7 +1703,7 @@ set_local_bogus2(hid_t dcpl_id, hid_t type_id, hid_t H5_ATTR_UNUSED space_id)
     cd_values[3] = add_on;                 /* Amount the data was modified by */
 
     /* Modify the filter's parameters for this dataset */
-    if (H5Pmodify_filter(dcpl_id, H5Z_FILTER_SET_LOCAL_TEST, flags, (size_t)BOGUS2_ALL_NPARMS, cd_values) < 0)
+    if (H5Pmodify_filter1(dcpl_id, H5Z_FILTER_SET_LOCAL_TEST, flags, (size_t)BOGUS2_ALL_NPARMS, cd_values) < 0)
         return (FAIL);
 
     return (SUCCEED);
@@ -2532,7 +2532,7 @@ test_filters(hid_t file)
         goto error;
     if (H5Zregister(H5Z_BOGUS) < 0)
         goto error;
-    if (H5Pset_filter(dc, H5Z_FILTER_BOGUS, 0, (size_t)0, NULL) < 0)
+    if (H5Pset_filter1(dc, H5Z_FILTER_BOGUS, 0, (size_t)0, NULL) < 0)
         goto error;
 
     if (test_filter_internal(file, DSET_BOGUS_NAME, dc, DISABLE_FLETCHER32, DATA_NOT_CORRUPTED, &null_size) <
@@ -2552,7 +2552,7 @@ test_filters(hid_t file)
         goto error;
     if (H5Pset_chunk(dc, 2, chunk_size) < 0)
         goto error;
-    if (H5Pset_filter(dc, H5Z_FILTER_FLETCHER32, 0, (size_t)0, NULL) < 0)
+    if (H5Pset_filter1(dc, H5Z_FILTER_FLETCHER32, 0, (size_t)0, NULL) < 0)
         goto error;
 
     /* Enable checksum during read */
@@ -2584,7 +2584,7 @@ test_filters(hid_t file)
 
     if (H5Zregister(H5Z_CORRUPT) < 0)
         goto error;
-    if (H5Pset_filter(dc, H5Z_FILTER_CORRUPT, 0, (size_t)3, data_corrupt) < 0)
+    if (H5Pset_filter1(dc, H5Z_FILTER_CORRUPT, 0, (size_t)3, data_corrupt) < 0)
         goto error;
     if (test_filter_internal(file, DSET_FLETCHER32_NAME_3, dc, DISABLE_FLETCHER32, DATA_CORRUPTED,
                              &fletcher32_size) < 0)
@@ -6164,7 +6164,7 @@ test_can_apply(hid_t file)
         goto error;
     }
     /* The filter is mandate. */
-    if (H5Pset_filter(dcpl, H5Z_FILTER_CAN_APPLY_TEST, 0, (size_t)0, NULL) < 0) {
+    if (H5Pset_filter1(dcpl, H5Z_FILTER_CAN_APPLY_TEST, 0, (size_t)0, NULL) < 0) {
         H5_FAILED();
         printf("    Line %d: Can't set bogus filter\n", __LINE__);
         goto error;
@@ -6345,7 +6345,7 @@ test_can_apply2(hid_t file)
         goto error;
     }
     /* The filter is optional. */
-    if (H5Pset_filter(dcpl, H5Z_FILTER_CAN_APPLY_TEST2, H5Z_FLAG_OPTIONAL, (size_t)0, NULL) < 0) {
+    if (H5Pset_filter1(dcpl, H5Z_FILTER_CAN_APPLY_TEST2, H5Z_FLAG_OPTIONAL, (size_t)0, NULL) < 0) {
         H5_FAILED();
         printf("    Line %d: Can't set bogus filter\n", __LINE__);
         goto error;
@@ -6484,7 +6484,7 @@ test_optional_filters(hid_t file)
         TEST_ERROR;
 
     /* The filter is optional. */
-    if (H5Pset_filter(dcplid, H5Z_FILTER_DEFLATE, H5Z_FLAG_OPTIONAL, cd_nelmts, cd_values) < 0)
+    if (H5Pset_filter1(dcplid, H5Z_FILTER_DEFLATE, H5Z_FLAG_OPTIONAL, cd_nelmts, cd_values) < 0)
         TEST_ERROR;
 
     /* Create dataset with optional filter */
@@ -6818,7 +6818,7 @@ test_set_local(hid_t fapl)
         printf("    Line %d: Can't register 'set local' filter\n", __LINE__);
         goto error;
     }
-    if (H5Pset_filter(dcpl, H5Z_FILTER_SET_LOCAL_TEST, 0, (size_t)BOGUS2_PERM_NPARMS, cd_values) < 0) {
+    if (H5Pset_filter1(dcpl, H5Z_FILTER_SET_LOCAL_TEST, 0, (size_t)BOGUS2_PERM_NPARMS, cd_values) < 0) {
         H5_FAILED();
         printf("    Line %d: Can't set bogus2 filter\n", __LINE__);
         goto error;
@@ -7345,7 +7345,7 @@ test_filter_delete(hid_t file)
         goto error;
 
     /* get information about filters */
-    if ((nfilters = H5Pget_nfilters(dcpl1)) < 0)
+    if ((nfilters = H5Pget_nfilters1(dcpl1)) < 0)
         goto error;
 
     /* check if filter was deleted */
@@ -7388,7 +7388,7 @@ test_filter_delete(hid_t file)
         goto error;
 
     /* get information about filters */
-    if ((nfilters = H5Pget_nfilters(dcpl1)) < 0)
+    if ((nfilters = H5Pget_nfilters1(dcpl1)) < 0)
         goto error;
 
     /* check if filters were deleted */
@@ -8835,7 +8835,7 @@ test_deprec(hid_t file)
         goto error;
     if (H5Zregister(H5Z_DEPREC) < 0)
         goto error;
-    if (H5Pset_filter(dcpl, H5Z_FILTER_DEPREC, 0, (size_t)0, NULL) < 0)
+    if (H5Pset_filter1(dcpl, H5Z_FILTER_DEPREC, 0, (size_t)0, NULL) < 0)
         goto error;
 
     puts("");
@@ -10459,9 +10459,9 @@ test_chunk_expand(hid_t fapl)
                 FAIL_STACK_ERROR;
 
             /* Set "expand" filter */
-            if (H5Pset_filter(dcpl, H5Z_FILTER_EXPAND, 0, (size_t)0, NULL) < 0)
+            if (H5Pset_filter1(dcpl, H5Z_FILTER_EXPAND, 0, (size_t)0, NULL) < 0)
                 FAIL_STACK_ERROR;
-            if (H5Pset_filter(dcpl2, H5Z_FILTER_EXPAND, 0, (size_t)0, NULL) < 0)
+            if (H5Pset_filter1(dcpl2, H5Z_FILTER_EXPAND, 0, (size_t)0, NULL) < 0)
                 FAIL_STACK_ERROR;
 
             /* Create scalar dataspace */
@@ -11860,7 +11860,7 @@ test_unfiltered_edge_chunks(hid_t fapl)
         TEST_ERROR;
 
     /* Add "count" filter */
-    if (H5Pset_filter(dcpl, H5Z_FILTER_COUNT, 0U, (size_t)0, NULL) < 0)
+    if (H5Pset_filter1(dcpl, H5Z_FILTER_COUNT, 0U, (size_t)0, NULL) < 0)
         TEST_ERROR;
 
     /* Disable filters on partial chunks */
@@ -11903,6 +11903,7 @@ test_unfiltered_edge_chunks(hid_t fapl)
         TEST_ERROR;
     if (count_nbytes_written != (size_t)(2 * cdim[0] * cdim[1]))
         TEST_ERROR;
+
 
     /* Reopen the dataset */
     if ((did = H5Dopen2(fid, DSET_CHUNKED_NAME, H5P_DEFAULT)) < 0)

--- a/test/dsets.c
+++ b/test/dsets.c
@@ -1703,7 +1703,8 @@ set_local_bogus2(hid_t dcpl_id, hid_t type_id, hid_t H5_ATTR_UNUSED space_id)
     cd_values[3] = add_on;                 /* Amount the data was modified by */
 
     /* Modify the filter's parameters for this dataset */
-    if (H5Pmodify_filter1(dcpl_id, H5Z_FILTER_SET_LOCAL_TEST, flags, (size_t)BOGUS2_ALL_NPARMS, cd_values) < 0)
+    if (H5Pmodify_filter1(dcpl_id, H5Z_FILTER_SET_LOCAL_TEST, flags, (size_t)BOGUS2_ALL_NPARMS, cd_values) <
+        0)
         return (FAIL);
 
     return (SUCCEED);
@@ -11903,7 +11904,6 @@ test_unfiltered_edge_chunks(hid_t fapl)
         TEST_ERROR;
     if (count_nbytes_written != (size_t)(2 * cdim[0] * cdim[1]))
         TEST_ERROR;
-
 
     /* Reopen the dataset */
     if ((did = H5Dopen2(fid, DSET_CHUNKED_NAME, H5P_DEFAULT)) < 0)

--- a/test/enc_dec_plist.c
+++ b/test/enc_dec_plist.c
@@ -316,7 +316,7 @@ main(void)
             if ((H5Pset_attr_phase_change(ocpl, 110, 105)) < 0)
                 FAIL_STACK_ERROR;
 
-            if ((H5Pset_filter(ocpl, H5Z_FILTER_FLETCHER32, 0, (size_t)0, NULL)) < 0)
+            if ((H5Pset_filter1(ocpl, H5Z_FILTER_FLETCHER32, 0, (size_t)0, NULL)) < 0)
                 FAIL_STACK_ERROR;
 
             /* Test encoding & decoding property list */

--- a/test/filter_fail.c
+++ b/test/filter_fail.c
@@ -133,7 +133,7 @@ test_filter_write(char *file_name, hid_t my_fapl, bool cache_enabled)
         FAIL_STACK_ERROR;
 
     /* Enable the filter as mandatory */
-    if (H5Pset_filter(dcpl, H5Z_FILTER_FAIL_TEST, 0, (size_t)0, NULL) < 0)
+    if (H5Pset_filter1(dcpl, H5Z_FILTER_FAIL_TEST, 0, (size_t)0, NULL) < 0)
         TEST_ERROR;
 
     /* create a dataset */

--- a/test/gen_filters.c
+++ b/test/gen_filters.c
@@ -178,7 +178,7 @@ create_file_with_bogus_filter(void)
     /* register bogus filter */
     if (H5Zregister(H5Z_BOGUS) < 0)
         goto error;
-    if (H5Pset_filter(dcpl, H5Z_FILTER_BOGUS, 0, (size_t)0, NULL) < 0)
+    if (H5Pset_filter1(dcpl, H5Z_FILTER_BOGUS, 0, (size_t)0, NULL) < 0)
         goto error;
 
     /* create a dataset */

--- a/test/links.c
+++ b/test/links.c
@@ -16879,12 +16879,12 @@ link_filters(hid_t fapl, bool new_format)
     filter_class.filter          = link_filter_filter;
     if (H5Zregister(&filter_class) < 0)
         TEST_ERROR;
-    if (H5Pset_filter(gcpl1, H5Z_FILTER_RESERVED + 42, 0, (size_t)1, &cd_value) < 0)
+    if (H5Pset_filter1(gcpl1, H5Z_FILTER_RESERVED + 42, 0, (size_t)1, &cd_value) < 0)
         TEST_ERROR;
     nfilters++;
 
     /* Test various other filter functions for use on gcpl's */
-    if (H5Pget_nfilters(gcpl1) != nfilters)
+    if (H5Pget_nfilters1(gcpl1) != nfilters)
         TEST_ERROR;
     if (H5Pall_filters_avail(gcpl1) != true)
         TEST_ERROR;
@@ -16918,7 +16918,7 @@ link_filters(hid_t fapl, bool new_format)
     /* Retrieve gcpl, verify number of filters */
     if ((gcpl2 = H5Gget_create_plist(gid1)) < 0)
         TEST_ERROR;
-    if (H5Pget_nfilters(gcpl2) != nfilters)
+    if (H5Pget_nfilters1(gcpl2) != nfilters)
         TEST_ERROR;
     if (H5Pclose(gcpl2) < 0)
         TEST_ERROR;
@@ -16926,7 +16926,7 @@ link_filters(hid_t fapl, bool new_format)
     /* Now try copying gcpl1, and verify number of filters */
     if ((gcpl2 = H5Pcopy(gcpl1)) < 0)
         TEST_ERROR;
-    if (H5Pget_nfilters(gcpl2) != nfilters)
+    if (H5Pget_nfilters1(gcpl2) != nfilters)
         TEST_ERROR;
     if (H5Pclose(gcpl2) < 0)
         TEST_ERROR;
@@ -16954,7 +16954,7 @@ link_filters(hid_t fapl, bool new_format)
     /* Retrieve gcpl, verify number of filters */
     if ((gcpl2 = H5Gget_create_plist(gid2)) < 0)
         TEST_ERROR;
-    if (H5Pget_nfilters(gcpl2) != nfilters)
+    if (H5Pget_nfilters1(gcpl2) != nfilters)
         TEST_ERROR;
 
     /* Delete 3 links to force the group back into compact mode */
@@ -17012,7 +17012,7 @@ link_filters(hid_t fapl, bool new_format)
 
     /* Test H5Pmodify_filter */
     cd_value++;
-    if (H5Pmodify_filter(gcpl2, H5Z_FILTER_RESERVED + 42, 0, (size_t)1, &cd_value) < 0)
+    if (H5Pmodify_filter1(gcpl2, H5Z_FILTER_RESERVED + 42, 0, (size_t)1, &cd_value) < 0)
         TEST_ERROR;
     if (H5Pget_filter_by_id2(gcpl2, H5Z_FILTER_RESERVED + 42, &flags_out, &cd_nelmts, &cd_value_out,
                              (size_t)24, name_out, &filter_config_out) < 0)
@@ -17063,7 +17063,7 @@ link_filters(hid_t fapl, bool new_format)
     /* Verify that new group doesn't have filters */
     if ((gcpl1 = H5Gget_create_plist(gid1)) < 0)
         TEST_ERROR;
-    if (H5Pget_nfilters(gcpl1) != 0)
+    if (H5Pget_nfilters1(gcpl1) != 0)
         TEST_ERROR;
 
     /* Close group & GCPL IDs */
@@ -17077,7 +17077,7 @@ link_filters(hid_t fapl, bool new_format)
         TEST_ERROR;
     if ((gcpl1 = H5Gget_create_plist(gid1)) < 0)
         TEST_ERROR;
-    if (H5Pget_nfilters(gcpl1) != nfilters)
+    if (H5Pget_nfilters1(gcpl1) != nfilters)
         TEST_ERROR;
     if (H5Pclose(gcpl1) < 0)
         TEST_ERROR;
@@ -17087,7 +17087,7 @@ link_filters(hid_t fapl, bool new_format)
         TEST_ERROR;
     if ((gcpl1 = H5Gget_create_plist(gid1)) < 0)
         TEST_ERROR;
-    if (H5Pget_nfilters(gcpl1) != nfilters)
+    if (H5Pget_nfilters1(gcpl1) != nfilters)
         TEST_ERROR;
     if (H5Pclose(gcpl1) < 0)
         TEST_ERROR;

--- a/test/objcopy.c
+++ b/test/objcopy.c
@@ -1380,7 +1380,7 @@ compare_datasets(hid_t did, hid_t did2, hid_t pid, const void *wbuf)
         TEST_ERROR;
 
     /* Get the number of filters on dataset (for later) */
-    if ((nfilters = H5Pget_nfilters(dcpl)) < 0)
+    if ((nfilters = H5Pget_nfilters1(dcpl)) < 0)
         TEST_ERROR;
 
     /* close the source dataset creation property list */

--- a/test/objcopy_ref.c
+++ b/test/objcopy_ref.c
@@ -1101,7 +1101,7 @@ compare_datasets(hid_t did, hid_t did2, hid_t pid, const void *wbuf)
         TEST_ERROR;
 
     /* Get the number of filters on dataset (for later) */
-    if ((nfilters = H5Pget_nfilters(dcpl)) < 0)
+    if ((nfilters = H5Pget_nfilters1(dcpl)) < 0)
         TEST_ERROR;
 
     /* close the source dataset creation property list */

--- a/test/ohdr.c
+++ b/test/ohdr.c
@@ -1352,7 +1352,7 @@ test_minimized_dset_ohdr_with_filter(hid_t fapl_id)
     ret = H5Pset_chunk(dcpl_xZ_id, ndims, chunk_dim);
     if (ret < 0)
         TEST_ERROR;
-    ret = H5Pset_filter(dcpl_xZ_id, H5Z_FILTER_DEFLATE, H5Z_FLAG_OPTIONAL, 0, filter_values);
+    ret = H5Pset_filter1(dcpl_xZ_id, H5Z_FILTER_DEFLATE, H5Z_FLAG_OPTIONAL, 0, filter_values);
     if (ret < 0)
         TEST_ERROR;
     dcpl_mZ_id = H5Pcreate(H5P_DATASET_CREATE);
@@ -1364,7 +1364,7 @@ test_minimized_dset_ohdr_with_filter(hid_t fapl_id)
     ret = H5Pset_chunk(dcpl_mZ_id, ndims, chunk_dim);
     if (ret < 0)
         TEST_ERROR;
-    ret = H5Pset_filter(dcpl_mZ_id, H5Z_FILTER_DEFLATE, H5Z_FLAG_OPTIONAL, 0, filter_values);
+    ret = H5Pset_filter1(dcpl_mZ_id, H5Z_FILTER_DEFLATE, H5Z_FLAG_OPTIONAL, 0, filter_values);
     if (ret < 0)
         TEST_ERROR;
 

--- a/test/struct_chunk_storage.c
+++ b/test/struct_chunk_storage.c
@@ -102,6 +102,11 @@ test_struct_chunk_api(hid_t fapl)
     unsigned     my_flag;
     int          my_rank;
     H5D_layout_t my_layout;
+    unsigned int level;
+    size_t        cd_nelmts;
+    unsigned int  cd_value;
+    H5Z_filter_t  filter;
+    uint64_t      flags;
 
     TESTING("structured chunk APIs");
 
@@ -118,9 +123,11 @@ test_struct_chunk_api(hid_t fapl)
     if ((dcpl = H5Pcreate(H5P_DATASET_CREATE)) < 0)
         TEST_ERROR;
 
-    if (H5Pset_layout(dcpl, H5D_STRUCT_CHUNK) < 0)
+    if (H5Pset_layout(dcpl, H5D_CHUNKED) < 0)
         TEST_ERROR;
 
+    if (H5Pset_layout(dcpl, H5D_STRUCT_CHUNK) < 0)
+        TEST_ERROR;
     if (H5Pset_struct_chunk(dcpl, 1, chunk_dim, H5D_SPARSE_CHUNK) < 0)
         TEST_ERROR;
 
@@ -238,6 +245,7 @@ error:
  *              Failure:        -1
  *-------------------------------------------------------------------------
  */
+#ifdef out
 static herr_t
 test_sparse_data(hid_t fapl)
 {
@@ -345,6 +353,117 @@ error:
         H5Sclose(sid);
         H5Sclose(sid1);
         H5Sclose(sid2);
+        H5Pclose(dcpl);
+        H5Dclose(did);
+        H5Fclose(fid);
+    }
+    H5E_END_TRY
+
+    return FAIL;
+} /* end test_sparse_data() */
+#endif
+
+static herr_t
+test_sparse_data(hid_t fapl)
+{
+    char    filename[FILENAME_BUF_SIZE]; /* File name */
+    hid_t   fid          = H5I_INVALID_HID;
+    hid_t   sid          = H5I_INVALID_HID;
+    hid_t   dcpl         = H5I_INVALID_HID;
+    hid_t   did          = H5I_INVALID_HID;
+    hsize_t dim[1]       = {10}; /* 1-d dataspace */
+    hsize_t chunk_dim[1] = {5};  /* Chunk size */
+    int     wbuf[5];            /* Write buffer */
+    int     rbuf[5];            /* Read buffer */
+    herr_t  ret;
+unsigned int level        = 9;
+unsigned int cd_values[1] = {level};
+size_t       cd_nelmts    = 1;
+
+    int num_filters;
+    H5Z_filter_t  filter;
+    unsigned int flags;
+
+    TESTING("APIs for handling sparse data");
+
+    /* Create a file */
+    h5_fixname(FILENAME[1], fapl, filename, sizeof filename);
+    if ((fid = H5Fcreate(filename, H5F_ACC_TRUNC, H5P_DEFAULT, fapl)) < 0)
+        TEST_ERROR;
+
+    /* Create dataspace */
+    if ((sid = H5Screate_simple(1, dim, NULL)) < 0)
+        TEST_ERROR;
+
+    /* Create property list for compact dataset creation */
+    if ((dcpl = H5Pcreate(H5P_DATASET_CREATE)) < 0)
+        TEST_ERROR;
+
+    if (H5Pset_layout(dcpl, H5D_STRUCT_CHUNK) < 0)
+        TEST_ERROR;
+
+    if (H5Pset_struct_chunk(dcpl, 1, chunk_dim, H5D_SPARSE_CHUNK) < 0)
+        TEST_ERROR;
+
+    if (H5Pset_filter2(dcpl, H5_SECTION_SELECTION, H5Z_FILTER_DEFLATE, H5Z_FLAG_OPTIONAL, cd_nelmts, cd_values) < -1)
+        TEST_ERROR;
+    //if (H5Pset_filter2(dcpl, H5_SECTION_SELECTION, H5Z_FILTER_NBIT, H5Z_FLAG_OPTIONAL, 0, NULL) < -1)
+     // TEST_ERROR;
+    if (H5Pset_filter2(dcpl, H5_SECTION_SELECTION, H5Z_FILTER_SHUFFLE, H5Z_FLAG_OPTIONAL, 0, NULL) < -1)
+      TEST_ERROR;
+
+    H5Pget_nfilters2(dcpl, H5_SECTION_SELECTION, &num_filters);
+    H5Pget_nfilters2(dcpl, H5_SECTION_FIXED, &num_filters);
+
+    if ((did = H5Dcreate2(fid, SPARSE_DSET, H5T_NATIVE_INT, sid, H5P_DEFAULT, dcpl, H5P_DEFAULT)) < 0)
+        TEST_ERROR;
+
+    /* Write sparse data to the dataset */
+    memset(wbuf, 0, sizeof(wbuf));
+
+    /* Initialize and write sparse data to the dataset */
+    wbuf[1]  = 1;
+    wbuf[2]  = 2;
+    wbuf[3]  = 3;
+
+    if (H5Dwrite(did, H5T_NATIVE_INT, H5S_ALL, H5S_ALL, H5P_DEFAULT, wbuf) < 0)
+        TEST_ERROR;
+
+    if (H5Dclose(did) < 0)
+        TEST_ERROR;
+
+    if (H5Fclose(fid) < 0)
+        TEST_ERROR;
+
+    if ((fid = H5Fopen(filename, H5F_ACC_RDWR, fapl)) < 0)
+        TEST_ERROR;
+
+    if ((did = H5Dopen2(fid, SPARSE_DSET, H5P_DEFAULT)) < 0)
+        TEST_ERROR;
+
+    if (H5Dread(did, H5T_NATIVE_INT, H5S_ALL, H5S_ALL, H5P_DEFAULT, rbuf) < 0 )
+        TEST_ERROR;
+
+    if (H5Dclose(did) < 0)
+        TEST_ERROR;
+
+    /* Closing */
+    if (H5Sclose(sid) < 0)
+        TEST_ERROR;
+
+    if (H5Pclose(dcpl) < 0)
+        TEST_ERROR;
+
+    if (H5Fclose(fid) < 0)
+        TEST_ERROR;
+
+    PASSED();
+    return SUCCEED;
+
+error:
+    H5E_BEGIN_TRY
+    {
+        H5Sclose(sid);
         H5Pclose(dcpl);
         H5Dclose(did);
         H5Fclose(fid);
@@ -833,6 +952,7 @@ error:
  *
  *-------------------------------------------------------------------------
  */
+#ifdef OUT
 static int
 test_sparse_filter(hid_t fapl)
 {
@@ -953,6 +1073,7 @@ error:
 
     return 1;
 } /* test_sparse_filter() */
+#endif
 
 typedef struct chunk_iter_info_t {
     hsize_t  offset[2];
@@ -1253,10 +1374,10 @@ main(void)
                 /* Create its own testfile */
                 nerrors += (test_struct_chunk_api(my_fapl) < 0 ? 1 : 0);
                 nerrors += (test_sparse_data(my_fapl) < 0 ? 1 : 0);
-                nerrors += (test_sparse_direct_chunk(my_fapl) < 0 ? 1 : 0);
-                nerrors += (test_sparse_direct_chunk_query(my_fapl) < 0 ? 1 : 0);
-                nerrors += (test_sparse_filter(my_fapl) < 0 ? 1 : 0);
-                nerrors += (test_dense_chunk_api_on_sparse(my_fapl) < 0 ? 1 : 0);
+                //nerrors += (test_sparse_direct_chunk(my_fapl) < 0 ? 1 : 0);
+                //nerrors += (test_sparse_direct_chunk_query(my_fapl) < 0 ? 1 : 0);
+                //nerrors += (test_sparse_filter(my_fapl) < 0 ? 1 : 0);
+                //nerrors += (test_dense_chunk_api_on_sparse(my_fapl) < 0 ? 1 : 0);
 
                 if (H5Fclose(file) < 0)
                     goto error;

--- a/test/struct_chunk_storage.c
+++ b/test/struct_chunk_storage.c
@@ -103,10 +103,10 @@ test_struct_chunk_api(hid_t fapl)
     int          my_rank;
     H5D_layout_t my_layout;
     unsigned int level;
-    size_t        cd_nelmts;
-    unsigned int  cd_value;
-    H5Z_filter_t  filter;
-    uint64_t      flags;
+    size_t       cd_nelmts;
+    unsigned int cd_value;
+    H5Z_filter_t filter;
+    uint64_t     flags;
 
     TESTING("structured chunk APIs");
 
@@ -366,22 +366,22 @@ error:
 static herr_t
 test_sparse_data(hid_t fapl)
 {
-    char    filename[FILENAME_BUF_SIZE]; /* File name */
-    hid_t   fid          = H5I_INVALID_HID;
-    hid_t   sid          = H5I_INVALID_HID;
-    hid_t   dcpl         = H5I_INVALID_HID;
-    hid_t   did          = H5I_INVALID_HID;
-    hsize_t dim[1]       = {10}; /* 1-d dataspace */
-    hsize_t chunk_dim[1] = {5};  /* Chunk size */
-    int     wbuf[5];            /* Write buffer */
-    int     rbuf[5];            /* Read buffer */
-    herr_t  ret;
-unsigned int level        = 9;
-unsigned int cd_values[1] = {level};
-size_t       cd_nelmts    = 1;
+    char         filename[FILENAME_BUF_SIZE]; /* File name */
+    hid_t        fid          = H5I_INVALID_HID;
+    hid_t        sid          = H5I_INVALID_HID;
+    hid_t        dcpl         = H5I_INVALID_HID;
+    hid_t        did          = H5I_INVALID_HID;
+    hsize_t      dim[1]       = {10}; /* 1-d dataspace */
+    hsize_t      chunk_dim[1] = {5};  /* Chunk size */
+    int          wbuf[5];             /* Write buffer */
+    int          rbuf[5];             /* Read buffer */
+    herr_t       ret;
+    unsigned int level        = 9;
+    unsigned int cd_values[1] = {level};
+    size_t       cd_nelmts    = 1;
 
-    int num_filters;
-    H5Z_filter_t  filter;
+    int          num_filters;
+    H5Z_filter_t filter;
     unsigned int flags;
 
     TESTING("APIs for handling sparse data");
@@ -405,12 +405,13 @@ size_t       cd_nelmts    = 1;
     if (H5Pset_struct_chunk(dcpl, 1, chunk_dim, H5D_SPARSE_CHUNK) < 0)
         TEST_ERROR;
 
-    if (H5Pset_filter2(dcpl, H5_SECTION_SELECTION, H5Z_FILTER_DEFLATE, H5Z_FLAG_OPTIONAL, cd_nelmts, cd_values) < -1)
+    if (H5Pset_filter2(dcpl, H5_SECTION_SELECTION, H5Z_FILTER_DEFLATE, H5Z_FLAG_OPTIONAL, cd_nelmts,
+                       cd_values) < -1)
         TEST_ERROR;
-    //if (H5Pset_filter2(dcpl, H5_SECTION_SELECTION, H5Z_FILTER_NBIT, H5Z_FLAG_OPTIONAL, 0, NULL) < -1)
-     // TEST_ERROR;
+    // if (H5Pset_filter2(dcpl, H5_SECTION_SELECTION, H5Z_FILTER_NBIT, H5Z_FLAG_OPTIONAL, 0, NULL) < -1)
+    //  TEST_ERROR;
     if (H5Pset_filter2(dcpl, H5_SECTION_SELECTION, H5Z_FILTER_SHUFFLE, H5Z_FLAG_OPTIONAL, 0, NULL) < -1)
-      TEST_ERROR;
+        TEST_ERROR;
 
     H5Pget_nfilters2(dcpl, H5_SECTION_SELECTION, &num_filters);
     H5Pget_nfilters2(dcpl, H5_SECTION_FIXED, &num_filters);
@@ -422,9 +423,9 @@ size_t       cd_nelmts    = 1;
     memset(wbuf, 0, sizeof(wbuf));
 
     /* Initialize and write sparse data to the dataset */
-    wbuf[1]  = 1;
-    wbuf[2]  = 2;
-    wbuf[3]  = 3;
+    wbuf[1] = 1;
+    wbuf[2] = 2;
+    wbuf[3] = 3;
 
     if (H5Dwrite(did, H5T_NATIVE_INT, H5S_ALL, H5S_ALL, H5P_DEFAULT, wbuf) < 0)
         TEST_ERROR;
@@ -441,7 +442,7 @@ size_t       cd_nelmts    = 1;
     if ((did = H5Dopen2(fid, SPARSE_DSET, H5P_DEFAULT)) < 0)
         TEST_ERROR;
 
-    if (H5Dread(did, H5T_NATIVE_INT, H5S_ALL, H5S_ALL, H5P_DEFAULT, rbuf) < 0 )
+    if (H5Dread(did, H5T_NATIVE_INT, H5S_ALL, H5S_ALL, H5P_DEFAULT, rbuf) < 0)
         TEST_ERROR;
 
     if (H5Dclose(did) < 0)
@@ -1374,10 +1375,10 @@ main(void)
                 /* Create its own testfile */
                 nerrors += (test_struct_chunk_api(my_fapl) < 0 ? 1 : 0);
                 nerrors += (test_sparse_data(my_fapl) < 0 ? 1 : 0);
-                //nerrors += (test_sparse_direct_chunk(my_fapl) < 0 ? 1 : 0);
-                //nerrors += (test_sparse_direct_chunk_query(my_fapl) < 0 ? 1 : 0);
-                //nerrors += (test_sparse_filter(my_fapl) < 0 ? 1 : 0);
-                //nerrors += (test_dense_chunk_api_on_sparse(my_fapl) < 0 ? 1 : 0);
+                // nerrors += (test_sparse_direct_chunk(my_fapl) < 0 ? 1 : 0);
+                // nerrors += (test_sparse_direct_chunk_query(my_fapl) < 0 ? 1 : 0);
+                // nerrors += (test_sparse_filter(my_fapl) < 0 ? 1 : 0);
+                // nerrors += (test_dense_chunk_api_on_sparse(my_fapl) < 0 ? 1 : 0);
 
                 if (H5Fclose(file) < 0)
                     goto error;

--- a/test/testfiles/error_test_1
+++ b/test/testfiles/error_test_1
@@ -68,10 +68,13 @@ HDF5-DIAG: Error detected in HDF5 (version (number)):
   #007: (file name) line (number) in H5D__chunk_lock(): data pipeline read failed
     major: Dataset
     minor: Filter operation failed
-  #008: (file name) line (number) in H5Z_pipeline(): required filter 'bogus' is not registered
+  #008: (file name) line (number) in H5Z_pipeline(): unable to apply filter
+    major: Data filters
+    minor: Unable to initialize object
+  #009: (file name) line (number) in H5Z_apply_filters(): required filter 'bogus' is not registered
     major: Data filters
     minor: Read failed
-  #009: (file name) line (number) in H5PL_load(): filter plugins disabled
+  #010: (file name) line (number) in H5PL_load(): filter plugins disabled
     major: Plugin for dynamically loaded library
     minor: Unable to load metadata into cache
 

--- a/test/unregister.c
+++ b/test/unregister.c
@@ -124,7 +124,7 @@ test_unregister_filters(hid_t fapl_id)
     /* Use DUMMY filter for creating groups */
     if ((gcpl_id = H5Pcreate(H5P_GROUP_CREATE)) < 0)
         goto error;
-    if (H5Pset_filter(gcpl_id, H5Z_FILTER_DUMMY, H5Z_FLAG_MANDATORY, (size_t)0, NULL) < 0)
+    if (H5Pset_filter1(gcpl_id, H5Z_FILTER_DUMMY, H5Z_FLAG_MANDATORY, (size_t)0, NULL) < 0)
         goto error;
 
     /* Create a group using this filter */
@@ -173,7 +173,7 @@ test_unregister_filters(hid_t fapl_id)
         goto error;
     if (H5Pset_chunk(dcpl_id, 2, chunk_dims) < 0)
         goto error;
-    if (H5Pset_filter(dcpl_id, H5Z_FILTER_DUMMY, 0, (size_t)0, NULL) < 0)
+    if (H5Pset_filter1(dcpl_id, H5Z_FILTER_DUMMY, 0, (size_t)0, NULL) < 0)
         goto error;
 
     /* Initialize the data for writing */

--- a/tools/lib/h5tools_dump.c
+++ b/tools/lib/h5tools_dump.c
@@ -3206,7 +3206,7 @@ h5tools_dump_dcpl(FILE *stream, const h5tool_format_t *info, h5tools_context_t *
 
     storage_size = H5Dget_storage_size(dset_id);
     if (dcpl_id >= 0)
-        nfilters = H5Pget_nfilters(dcpl_id);
+        nfilters = H5Pget_nfilters1(dcpl_id);
 
     strcpy(f_name, "\0");
 

--- a/tools/lib/h5tools_filters.c
+++ b/tools/lib/h5tools_filters.c
@@ -48,7 +48,7 @@ h5tools_canreadf(const char *name, /* object name, serves also as boolean print 
     int          ret_value = 1;
 
     /* get information about filters */
-    if ((nfilters = H5Pget_nfilters(dcpl_id)) < 0)
+    if ((nfilters = H5Pget_nfilters1(dcpl_id)) < 0)
         H5TOOLS_GOTO_ERROR(FAIL, "H5Pget_nfilters failed");
 
     /* if we do not have filters, we can read the dataset safely */

--- a/tools/src/h5dump/h5dump_xml.c
+++ b/tools/src/h5dump/h5dump_xml.c
@@ -3422,7 +3422,7 @@ check_filters(hid_t dcpl)
     string_dataformat.do_escape = dump_opts.display_escape;
     outputformat                = &string_dataformat;
 
-    nfilt = H5Pget_nfilters(dcpl);
+    nfilt = H5Pget_nfilters1(dcpl);
     if (nfilt <= 0)
         return;
     for (i = 0; i < nfilt; i++) {

--- a/tools/src/h5ls/h5ls.c
+++ b/tools/src/h5ls/h5ls.c
@@ -2071,7 +2071,7 @@ dataset_list2(hid_t dset, const char H5_ATTR_UNUSED *name)
         h5tools_str_append(&buffer, "\n");
 
         /* Print information about raw data filters */
-        if ((nf = H5Pget_nfilters(dcpl)) > 0) {
+        if ((nf = H5Pget_nfilters1(dcpl)) > 0) {
             for (i = 0; i < nf; i++) {
                 cd_nelmts = NELMTS(cd_values);
                 filt_id   = H5Pget_filter2(dcpl, (unsigned)i, &filt_flags, &cd_nelmts, cd_values,

--- a/tools/src/h5repack/h5repack_copy.c
+++ b/tools/src/h5repack/h5repack_copy.c
@@ -1531,7 +1531,7 @@ print_dataset_info(hid_t dcpl_id, char *objname, double ratio, int pr, pack_opt_
     strcpy(strfilter, "\0");
 
     /* get information about input filters */
-    if ((nfilters = H5Pget_nfilters(dcpl_id)) < 0)
+    if ((nfilters = H5Pget_nfilters1(dcpl_id)) < 0)
         return;
 
     for (i = 0; i < nfilters; i++) {

--- a/tools/src/h5repack/h5repack_filters.c
+++ b/tools/src/h5repack/h5repack_filters.c
@@ -46,8 +46,8 @@ aux_copy_obj(hid_t        dcpl_id,        /* dataset creation property list */
     int          ret_value = 0;
 
     /* get information about input filters */
-    if ((nfilters = H5Pget_nfilters(dcpl_id)) < 0)
-        H5TOOLS_GOTO_ERROR((-1), "H5Pget_nfilters failed");
+    if ((nfilters = H5Pget_nfilters1(dcpl_id)) < 0)
+        H5TOOLS_GOTO_ERROR((-1), "H5Pget_nfilters1 failed");
     /* copy filter_info_t structure */
     for (i = 0; i < nfilters; i++) {
         if ((objout->filter[i].filtn = H5Pget_filter2(
@@ -271,8 +271,8 @@ apply_filters(const char    *name,    /* object name from traverse list */
         H5TOOLS_GOTO_DONE(0);
 
     /* get information about input filters */
-    if ((nfilters = H5Pget_nfilters(dcpl_id)) < 0)
-        H5TOOLS_GOTO_ERROR((-1), "H5Pget_nfilters failed");
+    if ((nfilters = H5Pget_nfilters1(dcpl_id)) < 0)
+        H5TOOLS_GOTO_ERROR((-1), "H5Pget_nfilters1 failed");
 
     /*-------------------------------------------------------------------------
      * check if we have filters in the pipeline
@@ -452,7 +452,7 @@ apply_filters(const char    *name,    /* object name from traverse list */
                 default: {
                     if (H5Pset_chunk(dcpl_id, obj.chunk.rank, obj.chunk.chunk_lengths) < 0)
                         H5TOOLS_GOTO_ERROR((-1), "H5Pset_chunk failed");
-                    if (H5Pset_filter(dcpl_id, obj.filter[i].filtn, obj.filter[i].filt_flag,
+                    if (H5Pset_filter1(dcpl_id, obj.filter[i].filtn, obj.filter[i].filt_flag,
                                       obj.filter[i].cd_nelmts, obj.filter[i].cd_values) < 0)
                         H5TOOLS_GOTO_ERROR((-1), "H5Pset_filter failed");
                 } break;

--- a/tools/src/h5repack/h5repack_filters.c
+++ b/tools/src/h5repack/h5repack_filters.c
@@ -453,7 +453,7 @@ apply_filters(const char    *name,    /* object name from traverse list */
                     if (H5Pset_chunk(dcpl_id, obj.chunk.rank, obj.chunk.chunk_lengths) < 0)
                         H5TOOLS_GOTO_ERROR((-1), "H5Pset_chunk failed");
                     if (H5Pset_filter1(dcpl_id, obj.filter[i].filtn, obj.filter[i].filt_flag,
-                                      obj.filter[i].cd_nelmts, obj.filter[i].cd_values) < 0)
+                                       obj.filter[i].cd_nelmts, obj.filter[i].cd_values) < 0)
                         H5TOOLS_GOTO_ERROR((-1), "H5Pset_filter failed");
                 } break;
             } /* switch */

--- a/tools/src/h5repack/h5repack_verify.c
+++ b/tools/src/h5repack/h5repack_verify.c
@@ -316,7 +316,7 @@ verify_layout(hid_t pid, pack_info_t *obj)
     int          i;          /* index */
 
     /* check if we have filters in the input object */
-    if ((nfilters = H5Pget_nfilters(pid)) < 0)
+    if ((nfilters = H5Pget_nfilters1(pid)) < 0)
         return -1;
 
     /* a non chunked layout was requested on a filtered object */
@@ -508,7 +508,7 @@ verify_filters(hid_t pid, hid_t tid, int nfilters, filter_info_t *filter)
     unsigned     j;             /* index */
 
     /* get information about filters */
-    if ((nfilters_dcpl = H5Pget_nfilters(pid)) < 0)
+    if ((nfilters_dcpl = H5Pget_nfilters1(pid)) < 0)
         return -1;
 
     /* if we do not have filters and the requested filter is NONE, return 1 */

--- a/tools/src/h5stat/h5stat.c
+++ b/tools/src/h5stat/h5stat.c
@@ -558,7 +558,7 @@ dataset_stats(iter_t *iter, const char *name, const H5O_info2_t *oi, const H5O_n
         H5TOOLS_GOTO_ERROR(FAIL, "H5Tclose() failed");
 
     /* Track different filters */
-    if ((nfltr = H5Pget_nfilters(dcpl)) >= 0) {
+    if ((nfltr = H5Pget_nfilters1(dcpl)) >= 0) {
         if (nfltr == 0)
             iter->dset_comptype[0]++;
         for (u = 0; u < (unsigned)nfltr; u++) {

--- a/tools/test/h5dump/h5dumpgentest.c
+++ b/tools/test/h5dump/h5dumpgentest.c
@@ -5778,7 +5778,7 @@ gent_filters(void)
     ret = H5Zregister(H5Z_MYFILTER);
     assert(ret >= 0);
 
-    ret = H5Pset_filter(dcpl, MYFILTER_ID, 0, 0, NULL);
+    ret = H5Pset_filter1(dcpl, MYFILTER_ID, 0, 0, NULL);
     assert(ret >= 0);
 
     ret = make_dset(fid, "myfilter", sid, H5T_NATIVE_INT, dcpl, buf1);
@@ -5888,7 +5888,7 @@ set_local_myfilter(hid_t dcpl_id, hid_t H5_ATTR_UNUSED tid, hid_t H5_ATTR_UNUSED
     cd_nelmts = 2;
 
     /* Modify the filter's parameters for this dataset */
-    if (H5Pmodify_filter(dcpl_id, MYFILTER_ID, flags, cd_nelmts, cd_values) < 0)
+    if (H5Pmodify_filter1(dcpl_id, MYFILTER_ID, flags, cd_nelmts, cd_values) < 0)
         return (FAIL);
 
     return (SUCCEED);
@@ -11231,7 +11231,7 @@ gent_udfilter(void)
     ret = H5Zregister(H5Z_DYNLIBUD);
     assert(ret >= 0);
 
-    ret = H5Pset_filter(dcpl, H5Z_FILTER_DYNLIBUD, H5Z_FLAG_MANDATORY, 0, NULL);
+    ret = H5Pset_filter1(dcpl, H5Z_FILTER_DYNLIBUD, H5Z_FLAG_MANDATORY, 0, NULL);
     assert(ret >= 0);
 
     /* create the dataset */

--- a/tools/test/perform/chunk.c
+++ b/tools/test/perform/chunk.c
@@ -132,7 +132,7 @@ create_dataset(void)
     size[0] = size[1] = CH_SIZE;
     H5Pset_chunk(dcpl, 2, size);
     H5Zregister(H5Z_COUNTER);
-    H5Pset_filter(dcpl, FILTER_COUNTER, 0, 0, NULL);
+    H5Pset_filter1(dcpl, FILTER_COUNTER, 0, 0, NULL);
 
     /* The dataset */
     dset = H5Dcreate2(file, "dset", H5T_NATIVE_SCHAR, space, H5P_DEFAULT, dcpl, H5P_DEFAULT);

--- a/tools/test/perform/chunk_cache.c
+++ b/tools/test/perform/chunk_cache.c
@@ -115,7 +115,7 @@ create_dset1(hid_t file)
     if (H5Zregister(H5Z_COUNTER) < 0)
         goto error;
 
-    if (H5Pset_filter(dcpl, FILTER_COUNTER, 0, 0, NULL) < 0)
+    if (H5Pset_filter1(dcpl, FILTER_COUNTER, 0, 0, NULL) < 0)
         goto error;
 
     /* Create a new dataset within the file using chunk creation properties.  */
@@ -179,7 +179,7 @@ create_dset2(hid_t file)
     /* Set the dummy filter simply for counting the number of bytes being read into the memory */
     if (H5Zregister(H5Z_COUNTER) < 0)
         goto error;
-    if (H5Pset_filter(dcpl, FILTER_COUNTER, 0, 0, NULL) < 0)
+    if (H5Pset_filter1(dcpl, FILTER_COUNTER, 0, 0, NULL) < 0)
         goto error;
 
     /* Create a new dataset within the file using chunk creation properties.  */


### PR DESCRIPTION
Adding filter support for structured chunk.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Add structured chunk filter support, updating filter handling and dataset creation logic across multiple files.
> 
>   - **Behavior**:
>     - Add structured chunk filter support, modifying filter handling logic in `H5P`, `H5Z`, and `H5D` related files.
>     - Introduce new logic for handling structured chunks in `H5Pset_filter2`, `H5Pget_nfilters2`, and `H5Pget_filter3`.
>     - Update `H5Z_class2_t` to `H5Z_class3_t` to support structured chunk filters.
>   - **Functions**:
>     - Modify `H5Pset_filter2`, `H5Pget_nfilters2`, `H5Pget_filter3`, and `H5Pmodify_filter2` to handle structured chunk filters.
>     - Add `H5Z_apply_filters` to process data through the filter pipeline for structured chunks.
>     - Update `H5Z_register` and `H5Z_find` to accommodate new filter class version.
>   - **Misc**:
>     - Update test files like `chunk.c` and `chunk_cache.c` to use `H5Pset_filter1` for backward compatibility.
>     - Modify `H5Z` and `H5P` headers to include new structured chunk filter logic.
>     - Adjust `H5Z` filter registration and application logic to support structured chunks.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=HDFGroup%2Fhdf5&utm_source=github&utm_medium=referral)<sup> for e0e48f52e697fda2ce63afeae0d5dffe80b582a2. You can [customize](https://app.ellipsis.dev/HDFGroup/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->