### PR TITLE
Fix Family VFD filename conflict in tests

### DIFF
--- a/test/dsets.c
+++ b/test/dsets.c
@@ -16004,7 +16004,7 @@ test_dcpl_layout_caching(H5D_layout_t layout_type)
                 char src_fname[FILENAME_BUF_SIZE];
                 char src_dname[FILENAME_BUF_SIZE];
 
-                if (snprintf(src_fname, FILENAME_BUF_SIZE, "%s%s%d.h5", DCPL_LAYOUT_FILENAME, "_src", i) >=
+                if (snprintf(src_fname, FILENAME_BUF_SIZE, "%d%s%s.h5", i, DCPL_LAYOUT_FILENAME, "_src") >=
                     FILENAME_BUF_SIZE)
                     TEST_ERROR;
 
@@ -16141,9 +16141,11 @@ error:
         H5Tclose(type_id);
         H5Sclose(space_id);
         H5Dclose(dset_id);
-        for (int i = 0; i < DCPL_LAYOUT_NUM_SRC_DSETS; i++) {
-            H5Fclose(src_files[i]);
-            H5Dclose(src_dsets[i]);
+        if (layout_type == H5D_VIRTUAL) {
+            for (int i = 0; i < DCPL_LAYOUT_NUM_SRC_DSETS; i++) {
+                H5Fclose(src_files[i]);
+                H5Dclose(src_dsets[i]);
+            }
         }
     }
     H5E_END_TRY;


### PR DESCRIPTION
`test_dcpl_layout_caching()` has been failing with the Family VFD ever since this test was added. The failure seems unrelated to the actual behavior change to the DCPL layout and instead related to conflicts between the user-provided filename and the filenames that the family VFD uses internally for its member files.

This avoids the problem for now by using slightly different filenames, but the family VFD issue should be investigated separately.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fix filename conflict in `test_dcpl_layout_caching()` in `test/dsets.c` by changing filename format and adding conditional resource closure.
> 
>   - **Tests**:
>     - Fix filename conflict in `test_dcpl_layout_caching()` in `test/dsets.c` by changing `src_fname` format to `%d%s%s.h5`.
>     - Add condition to close `src_files` and `src_dsets` only if `layout_type` is `H5D_VIRTUAL`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=HDFGroup%2Fhdf5&utm_source=github&utm_medium=referral)<sup> for 66499c77dc193e218686e71f1d5df4924517b4cc. You can [customize](https://app.ellipsis.dev/HDFGroup/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->