### PR TITLE
Disable Java on arm64-windows while Java on the runner is incorrect f…

### DIFF
--- a/.github/workflows/arm-main-cmake.yml
+++ b/.github/workflows/arm-main-cmake.yml
@@ -52,7 +52,7 @@ jobs:
             os: windows-11-arm
             cpp: ON
             fortran: OFF
-            java: ON
+            java: OFF
             docs: ON
             libaecfc: ON
             localaec: OFF


### PR DESCRIPTION
…or arm64.

We will look into installing a suitable Java package when time permits, but will skip Java tests on arm64-windows in the meantime. 

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Disable Java for `windows-11-arm` in `arm-main-cmake.yml` due to incorrect Java setup on the runner.
> 
>   - **Behavior**:
>     - Disables Java (`java: OFF`) for `windows-11-arm` in `arm-main-cmake.yml` due to incorrect Java setup on the runner.
>   - **Configuration**:
>     - Affects the `Windows MSVC` configuration in the matrix setup.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=HDFGroup%2Fhdf5&utm_source=github&utm_medium=referral)<sup> for f3c8ad8c697179af9a4fc7ff189b849f98f1f68a. You can [customize](https://app.ellipsis.dev/HDFGroup/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->