### PR TITLE
A small correction/modification on the first C/Fortran examples in src/H5Smodule.h.

### DIFF
--- a/src/H5Smodule.h
+++ b/src/H5Smodule.h
@@ -243,8 +243,8 @@
  * which it was written. The HDF5 Fortran interface handles this transposition automatically.
  * \code
  * // C
- *     \#define NX          3 // dataset dimensions
- *     \#define NY          5
+ *     #define NX          3 // dataset dimensions
+ *     #define NY          5
  *     . . .
  *     int     data[NX][NY]; // data to write
  *     . . .
@@ -266,15 +266,15 @@
  * \code
  * ! Fortran
  *     INTEGER, PARAMETER :: NX = 3
- *     INTEGER, PARAMETER :: NX = 5
+ *     INTEGER, PARAMETER :: NY = 5
  *     . . .
  *     INTEGER(HSIZE_T), DIMENSION(2) :: dims = (/NY, NX/) ! Dataset dimensions
  *     . . .
  *     !
  *     ! Initialize data
  *     !
- *     do i = 1, NY
- *         do j = 1, NX
+ *     do j = 1, NX
+ *         do i = 1, NY
  *             data(i,j) = i + (j-1)*NY
  *         enddo
  *     enddo


### PR DESCRIPTION
Though not tested using Doxygen, by inspecting the `h5_write.c` shown later, it seems hash marks need not be escaped.

In the first Fortran example, the second integer parameter should read NY.
Though not wrong (and no appreciable difference in this case), I think the inner loop should be for "_the fastest-changing dimension_" described in the _Note:_ just below.  Therefore the nested loops were interchanged.

Further, I noticed that the second (larger) hyperslab shown in the figure "**Transferring hyperslab unions**" (`Dspace_transfer.gif`) is 5x5 although the corresponding text reads "The second hyperslab is 6 x 5 at the position (2,4)."
IMHO, as an example it's better to have 6x5 images rather to have the square  region (and it's also used in the accompanying C code fragment as `count[0] = 6;`), and therefore I didn't modify the "6 x 5"s.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Corrects C and Fortran code examples in `src/H5Smodule.h` and notes a hyperslab dimension discrepancy.
> 
>   - **Code Corrections**:
>     - Unescape hash marks in C example in `src/H5Smodule.h`.
>     - Correct Fortran parameter from `NX` to `NY` in `src/H5Smodule.h`.
>     - Swap loop order in Fortran example to iterate over the fastest-changing dimension first in `src/H5Smodule.h`.
>   - **Documentation**:
>     - Note discrepancy in hyperslab dimensions in `Dspace_transfer.gif` but no changes made to the figure.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=HDFGroup%2Fhdf5&utm_source=github&utm_medium=referral)<sup> for 0a94db62440bd96b00dbcdf31e8a351998f34878. You can [customize](https://app.ellipsis.dev/HDFGroup/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->