### PR TITLE
(build) remove -E option in config/libh5cc.in

### DIFF
--- a/config/libh5cc.in
+++ b/config/libh5cc.in
@@ -244,7 +244,7 @@ if test "$do_link" = "yes" -a "$USE_SHARED_LIB" = "no"; then
   escaped_libdir=$(echo "$libdir" | sed 's/\//\\\//g')
 
   # Replace flags of form '-lhdf5*' with path to matching static library
-  edited_pc_flags=$(echo "$pc_flags" | sed -E 's/-l(hdf5[a-z0-9_]*)/'"${escaped_libdir}\/"'lib\1.a/g')
+  edited_pc_flags=$(echo "$pc_flags" | sed 's/-l(hdf5[a-z0-9_]*)/'"${escaped_libdir}\/"'lib\1.a/g')
   if test $? -ne 0; then
     echo "couldn't edit flags to compile against static HDF5 libraries" >&2
     exit $EXIT_FAILURE


### PR DESCRIPTION
You do not need the -E option for the [a-z0-9_]* expression in sed.

Here's why:

Character Classes ([]): Character classes like [a-z0-9_] are part of basic regular expressions (BRE) and do not require -E.

Asterisk (*): The asterisk * (matching zero or more occurrences of the preceding character or group) is also a standard BRE quantifier and works without -E.

So, sed 's/[a-z0-9_]*/replacement/g' will work perfectly fine without -E.

You would only need -E if you were using extended regular expression (ERE) features like:

```
+ (one or more)

? (zero or one)

| (OR)

() (grouping without backslashes)
```

close #5690

Credit: Gemini

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Removes unnecessary `-E` option from `sed` command in `config/libh5cc.in` for basic regex usage.
> 
>   - **Behavior**:
>     - Removes `-E` option from `sed` command in `config/libh5cc.in` as the regex `[a-z0-9_]*` does not require extended regex features.
>     - The command now uses basic regex, which is sufficient for the intended pattern replacement.
>   - **Misc**:
>     - Closes issue #5690.
>     - Credit to Gemini for identifying the unnecessary use of `-E`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=HDFGroup%2Fhdf5&utm_source=github&utm_medium=referral)<sup> for 43932c975357d1cc69c2972803cc5648a268d6e2. You can [customize](https://app.ellipsis.dev/HDFGroup/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->