### PR TITLE
build: change sed to perl

### DIFF
--- a/config/libh5cc.in
+++ b/config/libh5cc.in
@@ -244,7 +244,7 @@ if test "$do_link" = "yes" -a "$USE_SHARED_LIB" = "no"; then
   escaped_libdir=$(echo "$libdir" | sed 's/\//\\\//g')
 
   # Replace flags of form '-lhdf5*' with path to matching static library
-  edited_pc_flags=$(echo "$pc_flags" | sed -E 's/-l(hdf5[a-z0-9_]*)/'"${escaped_libdir}\/"'lib\1.a/g')
+  edited_pc_flags=$(echo "$pc_flags" | perl -p -e 's/-l(hdf5[a-z0-9_]*)/'"${escaped_libdir}\/"'lib\$1.a/g')
   if test $? -ne 0; then
     echo "couldn't edit flags to compile against static HDF5 libraries" >&2
     exit $EXIT_FAILURE

--- a/config/libh5cc.in
+++ b/config/libh5cc.in
@@ -244,7 +244,7 @@ if test "$do_link" = "yes" -a "$USE_SHARED_LIB" = "no"; then
   escaped_libdir=$(echo "$libdir" | sed 's/\//\\\//g')
 
   # Replace flags of form '-lhdf5*' with path to matching static library
-  edited_pc_flags=$(echo "$pc_flags" | perl -p -e 's/-l(hdf5[a-z0-9_]*)/'"${escaped_libdir}\/"'lib\$1.a/g')
+  edited_pc_flags=$(echo "$pc_flags" | perl -p -e 's/-l(hdf5[a-z0-9_]*)/'"${escaped_libdir}\/"'lib$1.a/g')
   if test $? -ne 0; then
     echo "couldn't edit flags to compile against static HDF5 libraries" >&2
     exit $EXIT_FAILURE


### PR DESCRIPTION
close #5690
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Replaces `sed` with `perl` in `config/libh5cc.in` for editing flags when linking against static HDF5 libraries, closing issue #5690.
> 
>   - **Behavior**:
>     - Replaces `sed` with `perl` in `config/libh5cc.in` for editing `pc_flags` when linking against static HDF5 libraries.
>     - Ensures compatibility with complex regex patterns in flag substitution.
>   - **Misc**:
>     - Closes issue #5690.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=HDFGroup%2Fhdf5&utm_source=github&utm_medium=referral)<sup> for 934091a1ebe60371779a5e0c60942c4cc7a31663. You can [customize](https://app.ellipsis.dev/HDFGroup/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->