### PR TITLE
Avoid placing CMake generator expressions in pkg-config files

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1391,7 +1391,13 @@ foreach (lib ${LINK_LIBS})
   get_target_property (lib_interface_compile_opts ${lib} INTERFACE_COMPILE_OPTIONS)
   if (lib_interface_compile_opts)
     foreach (compile_opt ${lib_interface_compile_opts})
-      set (_PKG_CONFIG_EXTRA_CFLAGS "${_PKG_CONFIG_EXTRA_CFLAGS} ${compile_opt}")
+      # Avoid generator expressions related to flags for now.
+      # A more complete solution will be needed in order to
+      # correctly evaluate these.
+      string (GENEX_STRIP "${compile_opt}" compile_opt_genex_stripped)
+      if ("${compile_opt}" STREQUAL "${compile_opt_genex_stripped}")
+        set (_PKG_CONFIG_EXTRA_CFLAGS "${_PKG_CONFIG_EXTRA_CFLAGS} ${compile_opt}")
+      endif ()
     endforeach ()
   endif ()
 
@@ -1413,7 +1419,13 @@ foreach (lib ${LINK_LIBS})
         continue ()
       endif ()
 
-      set (_PKG_CONFIG_LIBS_PRIVATE "${_PKG_CONFIG_LIBS_PRIVATE} ${interface_link_lib}")
+      # Avoid generator expressions related to flags for now.
+      # A more complete solution will be needed in order to
+      # correctly evaluate these.
+      string (GENEX_STRIP "${interface_link_lib}" interface_link_lib_genex_stripped)
+      if ("${interface_link_lib}" STREQUAL "${interface_link_lib_genex_stripped}")
+        set (_PKG_CONFIG_LIBS_PRIVATE "${_PKG_CONFIG_LIBS_PRIVATE} ${interface_link_lib}")
+      endif ()
     endforeach()
   endif ()
 endforeach ()


### PR DESCRIPTION
Skips processing of flags inside CMake generator expressions until they can properly be handled with a more complete solution

Fixes #5699
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Avoids processing CMake generator expressions in `src/CMakeLists.txt` for pkg-config files, addressing issue #5699.
> 
>   - **Behavior**:
>     - Skips processing flags inside CMake generator expressions in `src/CMakeLists.txt`.
>     - Uses `string(GENEX_STRIP ...)` to strip generator expressions and only processes flags if stripped version matches original.
>   - **Files**:
>     - Modifications in `src/CMakeLists.txt` to handle `_PKG_CONFIG_EXTRA_CFLAGS` and `_PKG_CONFIG_LIBS_PRIVATE`.
>   - **Fixes**:
>     - Addresses issue #5699 by avoiding incorrect handling of generator expressions in pkg-config files.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=HDFGroup%2Fhdf5&utm_source=github&utm_medium=referral)<sup> for 3bafb42cef8649badb9792b3b736ee2a8ee21eb7. You can [customize](https://app.ellipsis.dev/HDFGroup/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->