### PR TITLE
Correct the link to list of planned features

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,7 +103,7 @@ HDF5 releases listed on this schedule are tentative.
 | 2.0.0 | Drop Autotools support, drop the HDF5 <--> GIF tools, add complex number support, update library defaults (cache sizes, etc.) |
 | FUTURE | Multi-threaded HDF5, crashproofing / metadata journaling, Full (VFD) SWMR, encryption, digital signatures, sparse datasets, improved storage for variable-length datatypes, better Unicode support (especially on Windows) |
 
-[A list of planned HDF5 2.0 features and bugfixes can be found here.](https://github.com/HDFGroup/hdf5/wiki/HDF5-2.0-Planning)
+[A list of planned HDF5 2.0 features and bugfixes can be found here.](https://github.com/orgs/HDFGroup/projects/39/views/14)
 
 This list of feature release versions is tentative, and the release
 in which a feature is introduced may change.


### PR DESCRIPTION
It pointed to a wiki page template.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Corrected the link to planned HDF5 2.0 features in `README.md`.
> 
>   - **Documentation**:
>     - Corrected link in `README.md` for planned HDF5 2.0 features from a wiki page template to the correct GitHub project view.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=HDFGroup%2Fhdf5&utm_source=github&utm_medium=referral)<sup> for 0a22f259a8d97789c28ac96d9f3dbc429be8798b. You can [customize](https://app.ellipsis.dev/HDFGroup/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->