### PR TITLE
Fix reading bad size in the raw header continuation message

### DIFF
--- a/src/H5Ocont.c
+++ b/src/H5Ocont.c
@@ -100,6 +100,8 @@ H5O__cont_decode(H5F_t *f, H5O_t H5_ATTR_UNUSED *open_oh, unsigned H5_ATTR_UNUSE
     if (H5_IS_BUFFER_OVERFLOW(p, H5F_sizeof_size(f), p_end))
         HGOTO_ERROR(H5E_OHDR, H5E_OVERFLOW, NULL, "ran off end of input buffer while decoding");
     H5F_DECODE_LENGTH(f, p, cont->size);
+    if (cont->size == 0)
+        HGOTO_ERROR(H5E_OHDR, H5E_BADVALUE, NULL, "invalid continuation chunk size (0)");
 
     cont->chunkno = 0;
 


### PR DESCRIPTION
This issue was reported in GH-5376 as a heap-use-after-free vulnerability in one of the free lists.  It appeared that the library came to this vulnerability after it encountered an undetected reading of a bad value.  The fuzzer now failed with an appropriate error message.

This considers addressing what GH-5376 reported.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Adds a check in `H5O__cont_decode()` to prevent zero-size continuation chunks, addressing a potential heap-use-after-free vulnerability.
> 
>   - **Behavior**:
>     - Adds a check in `H5O__cont_decode()` in `H5Ocont.c` to ensure `cont->size` is not zero, preventing invalid continuation chunk sizes.
>     - If `cont->size` is zero, an error is raised with `HGOTO_ERROR`.
>   - **Error Handling**:
>     - Improves error handling by detecting and reporting invalid sizes early in the decoding process.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=HDFGroup%2Fhdf5&utm_source=github&utm_medium=referral)<sup> for ff3d6722a91587daaaac82e78b25d26ad3f50172. You can [customize](https://app.ellipsis.dev/HDFGroup/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->