### PR TITLE
Fix VOL CMake builds

### DIFF
--- a/config/HDF5Macros.cmake
+++ b/config/HDF5Macros.cmake
@@ -138,8 +138,12 @@ macro(HDF5_GET_VOL_TGT_INFO vol_tgt vol_name_out vol_env_out)
   # HDF5_PLUGIN_PATH
   get_target_property(vol_lib_targets "${vol_tgt}" HDF5_VOL_TARGETS)
 
-  if (${vol_lib_targets} STREQUAL vol_lib_targets-NOTFOUND)
-    message(FATAL_ERROR "VOL target ${vol_tgt} has no defined HDF5_VOL_TARGETS")
+  # Sanity check
+  string(FIND "${vol_lib_targets}" ";" semicolon_pos)
+  if (semicolon_pos EQUAL -1)
+    if ("${vol_lib_targets}" STREQUAL vol_lib_targets-NOTFOUND)
+      message(FATAL_ERROR "${vol_tgt} has no corresponding targets")
+    endif ()
   endif ()
 
   set(vol_plugin_paths "${CMAKE_BINARY_DIR}/${HDF5_INSTALL_BIN_DIR}")

--- a/config/HDF5Macros.cmake
+++ b/config/HDF5Macros.cmake
@@ -141,7 +141,7 @@ macro(HDF5_GET_VOL_TGT_INFO vol_tgt vol_name_out vol_env_out)
   # Sanity check
   string(FIND "${vol_lib_targets}" ";" semicolon_pos)
   if (semicolon_pos EQUAL -1)
-    if ("${vol_lib_targets}" STREQUAL vol_lib_targets-NOTFOUND)
+    if ("${vol_lib_targets}" STREQUAL "vol_lib_targets-NOTFOUND")
       message(FATAL_ERROR "${vol_tgt} has no corresponding targets")
     endif ()
   endif ()

--- a/tools/test/h5copy/CMakeTests.cmake
+++ b/tools/test/h5copy/CMakeTests.cmake
@@ -51,6 +51,7 @@ file (MAKE_DIRECTORY "${PROJECT_BINARY_DIR}/testfiles")
 
 # Generate testfiles for VOL connector(s), if any
 set(h5copy_vol_files_list "")
+
 foreach (external_vol_tgt ${HDF5_EXTERNAL_VOL_TARGETS})
   HDF5_GET_VOL_TGT_INFO(${external_vol_tgt} ext_vol_dir_name vol_env)
 


### PR DESCRIPTION
Assuming that this string would never be a list caused build failures with several VOL connectors. We now check that it's not a list before performing the string comparison.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fixes build failures by ensuring `vol_lib_targets` is not a list before string comparison in `HDF5_GET_VOL_TGT_INFO`.
> 
>   - **Behavior**:
>     - Fixes build failures by checking if `vol_lib_targets` is not a list before string comparison in `HDF5_GET_VOL_TGT_INFO` in `HDF5Macros.cmake`.
>     - Ensures `vol_lib_targets` is not a list by using `string(FIND ...)` to detect semicolons.
>   - **Error Handling**:
>     - If `vol_lib_targets` is not found, a fatal error is triggered with a message indicating the missing targets.
>   - **Misc**:
>     - Minor formatting change in `CMakeTests.cmake` (added a newline).
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=HDFGroup%2Fhdf5&utm_source=github&utm_medium=referral)<sup> for 6314701b9945a922833b497e4d2bfe7a6b7e4207. You can [customize](https://app.ellipsis.dev/HDFGroup/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->