### PR TITLE
Validate page size to refix PR-5209

### DIFF
--- a/src/H5Fsuper.c
+++ b/src/H5Fsuper.c
@@ -730,6 +730,8 @@ H5F__super_read(H5F_t *f, H5P_genplist_t *fa_plist, bool initial_read)
             if (!(flags & H5O_MSG_FLAG_WAS_UNKNOWN)) {
                 H5O_fsinfo_t fsinfo; /* File space info message from superblock extension */
 
+                memset(&fsinfo, 0, sizeof(H5O_fsinfo_t));
+
                 /* f->shared->null_fsm_addr: Whether to drop free-space to the floor */
                 /* The h5clear tool uses this property to tell the library
                  * to drop free-space to the floor

--- a/src/H5Ofsinfo.c
+++ b/src/H5Ofsinfo.c
@@ -184,6 +184,9 @@ H5O__fsinfo_decode(H5F_t *f, H5O_t H5_ATTR_UNUSED *open_oh, unsigned H5_ATTR_UNU
         if (H5_IS_BUFFER_OVERFLOW(p, H5F_sizeof_size(f), p_end))
             HGOTO_ERROR(H5E_OHDR, H5E_OVERFLOW, NULL, "ran off end of input buffer while decoding");
         H5F_DECODE_LENGTH(f, p, fsinfo->page_size); /* File space page size */
+        /* Basic sanity check */
+        if (fsinfo->page_size == 0 || fsinfo->page_size > H5F_FILE_SPACE_PAGE_SIZE_MAX)
+            HGOTO_ERROR(H5E_OHDR, H5E_BADVALUE, NULL, "invalid page size in file space info");
 
         if (H5_IS_BUFFER_OVERFLOW(p, 2, p_end))
             HGOTO_ERROR(H5E_OHDR, H5E_OVERFLOW, NULL, "ran off end of input buffer while decoding");


### PR DESCRIPTION
This PR addresses the root cause of the issue by adding a sanity-check immediately after reading the file space page size from the file.  All the POCs files in the original PR, [PR-5209](https://github.com/HDFGroup/hdf5/pull/5209), were verified.

The same fuzzer in GH-5376 was used to verify that the assert before the vulnerability had occurred and that an error indicating a corrupted file space page size replaced it.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Adds a sanity check for file space page size in `H5O__fsinfo_decode()` to prevent vulnerabilities from corrupted files.
> 
>   - **Sanity Check**:
>     - Adds a sanity check in `H5O__fsinfo_decode()` in `H5Ofsinfo.c` to validate `fsinfo->page_size` is not zero and does not exceed `H5F_FILE_SPACE_PAGE_SIZE_MAX`.
>   - **Verification**:
>     - Verified with fuzzer from GH-5376 to ensure error is caught before vulnerability occurs.
>   - **Misc**:
>     - Initializes `fsinfo` with `memset` in `H5F__super_read()` in `H5Fsuper.c` to ensure clean state.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=HDFGroup%2Fhdf5&utm_source=github&utm_medium=referral)<sup> for 54f404b5ad8e63d99e3283646b543b2842a22fd3. You can [customize](https://app.ellipsis.dev/HDFGroup/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->