### PR TITLE
Temporarily turn off h5diff tests for cache VOL

### DIFF
--- a/.github/workflows/vol_cache.yml
+++ b/.github/workflows/vol_cache.yml
@@ -161,4 +161,4 @@ jobs:
         # that this should be re-enabled in the future.
         if: ${{ ! matrix.async }}
         run: |
-          ctest --build-config ${{ inputs.build_mode }} -VV -R "HDF5_VOL_vol-cache" .
+          ctest --build-config ${{ inputs.build_mode }} -VV -R "HDF5_VOL_vol-cache" -E "H5DIFF" .


### PR DESCRIPTION
#5680 introduced VOL-specific testing of h5diff. These tests are currently failing in CI with the Cache VOL due to requiring special handling of MPI. For now, disable the new tests in the cache VOL workflow. 