### PR TITLE
Fix CVE-2025-2925

### DIFF
--- a/src/H5Centry.c
+++ b/src/H5Centry.c
@@ -1053,10 +1053,10 @@ H5C__load_entry(H5F_t *f,
         do {
             if (actual_len != len) {
                 new_image = H5MM_realloc(image, len + H5C_IMAGE_EXTRA_SPACE);
-                image = (uint8_t *)new_image;
+                image     = (uint8_t *)new_image;
                 if (NULL == image)
                     HGOTO_ERROR(H5E_CACHE, H5E_CANTALLOC, NULL, "image null after H5MM_realloc()");
-                
+
 #if H5C_DO_MEMORY_SANITY_CHECKS
                 H5MM_memcpy(image + len, H5C_IMAGE_SANITY_VALUE, H5C_IMAGE_EXTRA_SPACE);
 #endif        /* H5C_DO_MEMORY_SANITY_CHECKS */
@@ -1109,10 +1109,10 @@ H5C__load_entry(H5F_t *f,
 
                     /* Expand buffer to new size */
                     new_image = H5MM_realloc(image, actual_len + H5C_IMAGE_EXTRA_SPACE);
-                    image = (uint8_t *)new_image;
+                    image     = (uint8_t *)new_image;
                     if (NULL == image)
                         HGOTO_ERROR(H5E_CACHE, H5E_CANTALLOC, NULL, "image null after H5MM_realloc()");
-                    
+
 #if H5C_DO_MEMORY_SANITY_CHECKS
                     H5MM_memcpy(image + actual_len, H5C_IMAGE_SANITY_VALUE, H5C_IMAGE_EXTRA_SPACE);
 #endif /* H5C_DO_MEMORY_SANITY_CHECKS */

--- a/src/H5Centry.c
+++ b/src/H5Centry.c
@@ -1037,7 +1037,6 @@ H5C__load_entry(H5F_t *f,
         htri_t   chk_ret;            /* return from verify_chksum callback   */
         size_t   actual_len = len;   /* The actual length, after speculative reads have been resolved */
         uint64_t nanosec    = 1;     /* # of nanoseconds to sleep between retries */
-        void    *new_image;          /* Pointer to image                     */
         bool     len_changed = true; /* Whether to re-check speculative entries */
 
         /* Get the # of read attempts */
@@ -1052,11 +1051,8 @@ H5C__load_entry(H5F_t *f,
          */
         do {
             if (actual_len != len) {
-                new_image = H5MM_realloc(image, len + H5C_IMAGE_EXTRA_SPACE);
-                image = (uint8_t *)new_image;
-                if (NULL == image)
+                if (NULL == (image = (uint8_t *)H5MM_realloc(image, len + H5C_IMAGE_EXTRA_SPACE)))
                     HGOTO_ERROR(H5E_CACHE, H5E_CANTALLOC, NULL, "image null after H5MM_realloc()");
-                
 #if H5C_DO_MEMORY_SANITY_CHECKS
                 H5MM_memcpy(image + len, H5C_IMAGE_SANITY_VALUE, H5C_IMAGE_EXTRA_SPACE);
 #endif        /* H5C_DO_MEMORY_SANITY_CHECKS */
@@ -1108,11 +1104,8 @@ H5C__load_entry(H5F_t *f,
                         HGOTO_ERROR(H5E_CACHE, H5E_BADVALUE, NULL, "actual_len exceeds EOA");
 
                     /* Expand buffer to new size */
-                    new_image = H5MM_realloc(image, actual_len + H5C_IMAGE_EXTRA_SPACE);
-                    image = (uint8_t *)new_image;
-                    if (NULL == image)
+                    if (NULL == (image = (uint8_t *)H5MM_realloc(image, actual_len + H5C_IMAGE_EXTRA_SPACE)))
                         HGOTO_ERROR(H5E_CACHE, H5E_CANTALLOC, NULL, "image null after H5MM_realloc()");
-                    
 #if H5C_DO_MEMORY_SANITY_CHECKS
                     H5MM_memcpy(image + actual_len, H5C_IMAGE_SANITY_VALUE, H5C_IMAGE_EXTRA_SPACE);
 #endif /* H5C_DO_MEMORY_SANITY_CHECKS */

--- a/src/H5Centry.c
+++ b/src/H5Centry.c
@@ -1052,9 +1052,11 @@ H5C__load_entry(H5F_t *f,
          */
         do {
             if (actual_len != len) {
-                if (NULL == (new_image = H5MM_realloc(image, len + H5C_IMAGE_EXTRA_SPACE)))
-                    HGOTO_ERROR(H5E_CACHE, H5E_CANTALLOC, NULL, "image null after H5MM_realloc()");
+                new_image = H5MM_realloc(image, len + H5C_IMAGE_EXTRA_SPACE);
                 image = (uint8_t *)new_image;
+                if (NULL == image)
+                    HGOTO_ERROR(H5E_CACHE, H5E_CANTALLOC, NULL, "image null after H5MM_realloc()");
+                
 #if H5C_DO_MEMORY_SANITY_CHECKS
                 H5MM_memcpy(image + len, H5C_IMAGE_SANITY_VALUE, H5C_IMAGE_EXTRA_SPACE);
 #endif        /* H5C_DO_MEMORY_SANITY_CHECKS */
@@ -1106,9 +1108,11 @@ H5C__load_entry(H5F_t *f,
                         HGOTO_ERROR(H5E_CACHE, H5E_BADVALUE, NULL, "actual_len exceeds EOA");
 
                     /* Expand buffer to new size */
-                    if (NULL == (new_image = H5MM_realloc(image, actual_len + H5C_IMAGE_EXTRA_SPACE)))
-                        HGOTO_ERROR(H5E_CACHE, H5E_CANTALLOC, NULL, "image null after H5MM_realloc()");
+                    new_image = H5MM_realloc(image, actual_len + H5C_IMAGE_EXTRA_SPACE);
                     image = (uint8_t *)new_image;
+                    if (NULL == image)
+                        HGOTO_ERROR(H5E_CACHE, H5E_CANTALLOC, NULL, "image null after H5MM_realloc()");
+                    
 #if H5C_DO_MEMORY_SANITY_CHECKS
                     H5MM_memcpy(image + actual_len, H5C_IMAGE_SANITY_VALUE, H5C_IMAGE_EXTRA_SPACE);
 #endif /* H5C_DO_MEMORY_SANITY_CHECKS */

--- a/src/H5Centry.c
+++ b/src/H5Centry.c
@@ -1053,11 +1053,11 @@ H5C__load_entry(H5F_t *f,
         do {
             if (actual_len != len) {
                 new_image = H5MM_realloc(image, len + H5C_IMAGE_EXTRA_SPACE);
-                if (new_image) 
+                if (new_image)
                     image = (uint8_t *)new_image;
                 else
                     HGOTO_ERROR(H5E_CACHE, H5E_CANTALLOC, NULL, "image null after H5MM_realloc()");
-                    
+
 #if H5C_DO_MEMORY_SANITY_CHECKS
                 H5MM_memcpy(image + len, H5C_IMAGE_SANITY_VALUE, H5C_IMAGE_EXTRA_SPACE);
 #endif        /* H5C_DO_MEMORY_SANITY_CHECKS */
@@ -1110,7 +1110,7 @@ H5C__load_entry(H5F_t *f,
 
                     /* Expand buffer to new size */
                     new_image = H5MM_realloc(image, len + H5C_IMAGE_EXTRA_SPACE);
-                    if (new_image) 
+                    if (new_image)
                         image = (uint8_t *)new_image;
                     else
                         HGOTO_ERROR(H5E_CACHE, H5E_CANTALLOC, NULL, "image null after H5MM_realloc()");

--- a/src/H5Centry.c
+++ b/src/H5Centry.c
@@ -1037,6 +1037,7 @@ H5C__load_entry(H5F_t *f,
         htri_t   chk_ret;            /* return from verify_chksum callback   */
         size_t   actual_len = len;   /* The actual length, after speculative reads have been resolved */
         uint64_t nanosec    = 1;     /* # of nanoseconds to sleep between retries */
+        void    *new_image;          /* Pointer to image */
         bool     len_changed = true; /* Whether to re-check speculative entries */
 
         /* Get the # of read attempts */
@@ -1051,8 +1052,12 @@ H5C__load_entry(H5F_t *f,
          */
         do {
             if (actual_len != len) {
-                if (NULL == (image = (uint8_t *)H5MM_realloc(image, len + H5C_IMAGE_EXTRA_SPACE)))
+                new_image = H5MM_realloc(image, len + H5C_IMAGE_EXTRA_SPACE);
+                if (new_image) 
+                    image = (uint8_t *)new_image;
+                else
                     HGOTO_ERROR(H5E_CACHE, H5E_CANTALLOC, NULL, "image null after H5MM_realloc()");
+                    
 #if H5C_DO_MEMORY_SANITY_CHECKS
                 H5MM_memcpy(image + len, H5C_IMAGE_SANITY_VALUE, H5C_IMAGE_EXTRA_SPACE);
 #endif        /* H5C_DO_MEMORY_SANITY_CHECKS */
@@ -1104,8 +1109,12 @@ H5C__load_entry(H5F_t *f,
                         HGOTO_ERROR(H5E_CACHE, H5E_BADVALUE, NULL, "actual_len exceeds EOA");
 
                     /* Expand buffer to new size */
-                    if (NULL == (image = (uint8_t *)H5MM_realloc(image, actual_len + H5C_IMAGE_EXTRA_SPACE)))
+                    new_image = H5MM_realloc(image, len + H5C_IMAGE_EXTRA_SPACE);
+                    if (new_image) 
+                        image = (uint8_t *)new_image;
+                    else
                         HGOTO_ERROR(H5E_CACHE, H5E_CANTALLOC, NULL, "image null after H5MM_realloc()");
+                        
 #if H5C_DO_MEMORY_SANITY_CHECKS
                     H5MM_memcpy(image + actual_len, H5C_IMAGE_SANITY_VALUE, H5C_IMAGE_EXTRA_SPACE);
 #endif /* H5C_DO_MEMORY_SANITY_CHECKS */

--- a/src/H5Centry.c
+++ b/src/H5Centry.c
@@ -1035,8 +1035,8 @@ H5C__load_entry(H5F_t *f,
         unsigned tries, max_tries;   /* The # of read attempts               */
         unsigned retries;            /* The # of retries                     */
         htri_t   chk_ret;            /* return from verify_chksum callback   */
-        size_t   actual_len = len;   /* The actual length, after speculative reads have been resolved */
-        uint64_t nanosec    = 1;     /* # of nanoseconds to sleep between retries */
+        size_t   actual_len  = len;  /* The actual length, after speculative reads have been resolved */
+        uint64_t nanosec     = 1;    /* # of nanoseconds to sleep between retries */
         bool     len_changed = true; /* Whether to re-check speculative entries */
 
         /* Get the # of read attempts */


### PR DESCRIPTION
This PR fixes issue #5383, which was occurring due to actual_len + H5C_IMAGE_EXTRA_SPACE being 0. When realloc was called, it freed image, but gets sent to done before new_image can be assigned to image. Because the pointer for image isn't null, it attempts to free it here again, causing the double free to occur. This PR removes new_image, which is only used for pointer conversion and directly uses image instead, which then avoids the above situation.

The bug was first reproduced using the fuzzer and the POC file from https://github.com/HDFGroup/hdf5/issues/5383. With this change, the double free no longer occurs.