### PR TITLE
Fix CVE-2025-2925

### DIFF
--- a/release_docs/CHANGELOG.md
+++ b/release_docs/CHANGELOG.md
@@ -496,7 +496,7 @@ Simple example programs showing how to use complex number datatypes have been ad
 ## Library
 
 ### Fixed security issue CVE-2025-2925
-   H5C__load_entry() now checks for an image buffer length of 0 before calling realloc. A bug was occurring due to actual_len + H5C_IMAGE_EXTRA_SPACE being able to be 0 due to bad inputs. When realloc was called, it freed image, but got sent to done before new_image could be assigned to image. Because the pointer for image wasn't null, it is freed again in done, causing a double free bug.
+   Actual_len + H5C_IMAGE_EXTRA_SPACE, which was used by H5MM_realloc as the size input, could equal 0 due to bad inputs. When H5MM_realloc was called, it freed image, but then could get sent to done before new_image could be assigned to image. Because the pointer for image wasn't null, it was freed again in done, causing a double-free vulnerability. H5C__load_entry() now checks for an image buffer length of 0 before calling H5MM_realloc.
 
    Fixes issue Github issue #5383
 

--- a/release_docs/CHANGELOG.md
+++ b/release_docs/CHANGELOG.md
@@ -495,7 +495,7 @@ Simple example programs showing how to use complex number datatypes have been ad
 
 ## Library
 
-### Fixed security issue CCVE-2025-2925
+### Fixed security issue CVE-2025-2925
    H5C__load_entry() now checks for an image buffer length of 0 before calling realloc. A bug was occurring due to actual_len + H5C_IMAGE_EXTRA_SPACE being able to be 0 due to bad inputs. When realloc was called, it freed image, but got sent to done before new_image could be assigned to image. Because the pointer for image wasn't null, it is freed again in done, causing a double free bug.
 
    Fixes issue Github issue #5383

--- a/release_docs/CHANGELOG.md
+++ b/release_docs/CHANGELOG.md
@@ -498,7 +498,7 @@ Simple example programs showing how to use complex number datatypes have been ad
 ### Fixed security issue CVE-2025-2925
    Actual_len + H5C_IMAGE_EXTRA_SPACE, which was used by H5MM_realloc as the size input, could equal 0 due to bad inputs. When H5MM_realloc was called, it freed image, but then could get sent to done before new_image could be assigned to image. Because the pointer for image wasn't null, it was freed again in done, causing a double-free vulnerability. H5C__load_entry() now checks for an image buffer length of 0 before calling H5MM_realloc.
 
-   Fixes issue Github issue #5383
+   Fixes Github issue #5383
 
 ### Fixed security issue CVE-2025-6857
 

--- a/release_docs/CHANGELOG.md
+++ b/release_docs/CHANGELOG.md
@@ -495,6 +495,11 @@ Simple example programs showing how to use complex number datatypes have been ad
 
 ## Library
 
+### Fixed security issue CCVE-2025-2925
+   H5C__load_entry() now checks for an image buffer length of 0 before calling realloc. A bug was occurring due to actual_len + H5C_IMAGE_EXTRA_SPACE being able to be 0 due to bad inputs. When realloc was called, it freed image, but got sent to done before new_image could be assigned to image. Because the pointer for image wasn't null, it is freed again in done, causing a double free bug.
+
+   Fixes issue Github issue #5383
+
 ### Fixed security issue CVE-2025-6857
 
    An HDF5 file had a corrupted v1 B-tree that would result in a stack overflow when performing a lookup on it. This has been fixed with additional integrity checks.

--- a/release_docs/release_archive.txt
+++ b/release_docs/release_archive.txt
@@ -700,16 +700,6 @@ New Features
       library behavior, and the connector ID and information could not be read back
       from that plist later.
 
-    - H5C__load_entry() now checks for an image buffer length of 0 before
-      calling realloc 
-
-      A bug was occurring due to actual_len + H5C_IMAGE_EXTRA_SPACE being able to
-      be 0 due to bad inputs. When realloc was called, it freed image, but got sent 
-      to done before new_image could be assigned to image. Because the pointer for 
-      image wasn't null, it is freed again in done, causing a double free bug.
-
-      Fixes issue Github issue #5383
-
     Parallel Library:
     -----------------
     -

--- a/release_docs/release_archive.txt
+++ b/release_docs/release_archive.txt
@@ -700,6 +700,16 @@ New Features
       library behavior, and the connector ID and information could not be read back
       from that plist later.
 
+    - H5C__load_entry() now checks for an image buffer length of 0 before
+      calling realloc 
+
+      A bug was occurring due to actual_len + H5C_IMAGE_EXTRA_SPACE being able to
+      be 0 due to bad inputs. When realloc was called, it freed image, but got sent 
+      to done before new_image could be assigned to image. Because the pointer for 
+      image wasn't null, it is freed again in done, causing a double free bug.
+
+      Fixes issue Github issue #5383
+
     Parallel Library:
     -----------------
     -

--- a/src/H5Centry.c
+++ b/src/H5Centry.c
@@ -1052,11 +1052,14 @@ H5C__load_entry(H5F_t *f,
          */
         do {
             if (actual_len != len) {
-                new_image = H5MM_realloc(image, len + H5C_IMAGE_EXTRA_SPACE);
-                image = (uint8_t *)new_image;
-                if (NULL == image)
+                /* Verify that the length isn't a bad value  */
+                if (actual_len <= 0)
+                    HGOTO_ERROR(H5E_CACHE, H5E_BADVALUE, NULL, "len is a bad value");
+
+                if (NULL == (new_image = H5MM_realloc(image, len + H5C_IMAGE_EXTRA_SPACE)))
                     HGOTO_ERROR(H5E_CACHE, H5E_CANTALLOC, NULL, "image null after H5MM_realloc()");
-                
+                image = (uint8_t *)new_image;
+
 #if H5C_DO_MEMORY_SANITY_CHECKS
                 H5MM_memcpy(image + len, H5C_IMAGE_SANITY_VALUE, H5C_IMAGE_EXTRA_SPACE);
 #endif        /* H5C_DO_MEMORY_SANITY_CHECKS */
@@ -1107,11 +1110,14 @@ H5C__load_entry(H5F_t *f,
                     if (H5C__verify_len_eoa(f, type, addr, &actual_len, true) < 0)
                         HGOTO_ERROR(H5E_CACHE, H5E_BADVALUE, NULL, "actual_len exceeds EOA");
 
+                    /* Verify that the length isn't 0  */
+                    if (actual_len <= 0)
+                        HGOTO_ERROR(H5E_CACHE, H5E_BADVALUE, NULL, "actual_len is a bad value");
+
                     /* Expand buffer to new size */
-                    new_image = H5MM_realloc(image, actual_len + H5C_IMAGE_EXTRA_SPACE);
-                    image = (uint8_t *)new_image;
-                    if (NULL == image)
+                    if (NULL == (new_image = H5MM_realloc(image, actual_len + H5C_IMAGE_EXTRA_SPACE)))
                         HGOTO_ERROR(H5E_CACHE, H5E_CANTALLOC, NULL, "image null after H5MM_realloc()");
+                    image = (uint8_t *)new_image;
                     
 #if H5C_DO_MEMORY_SANITY_CHECKS
                     H5MM_memcpy(image + actual_len, H5C_IMAGE_SANITY_VALUE, H5C_IMAGE_EXTRA_SPACE);

--- a/src/H5Centry.c
+++ b/src/H5Centry.c
@@ -1052,9 +1052,11 @@ H5C__load_entry(H5F_t *f,
          */
         do {
             if (actual_len != len) {
-                if (NULL == (new_image = H5MM_realloc(image, len + H5C_IMAGE_EXTRA_SPACE)))
-                    HGOTO_ERROR(H5E_CACHE, H5E_CANTALLOC, NULL, "image null after H5MM_realloc()");
+                new_image = H5MM_realloc(image, len + H5C_IMAGE_EXTRA_SPACE);
                 image = (uint8_t *)new_image;
+                if (NULL == image)
+                    HGOTO_ERROR(H5E_CACHE, H5E_CANTALLOC, NULL, "image null after H5MM_realloc()");
+                
 #if H5C_DO_MEMORY_SANITY_CHECKS
                 H5MM_memcpy(image + len, H5C_IMAGE_SANITY_VALUE, H5C_IMAGE_EXTRA_SPACE);
 #endif        /* H5C_DO_MEMORY_SANITY_CHECKS */
@@ -1106,9 +1108,11 @@ H5C__load_entry(H5F_t *f,
                         HGOTO_ERROR(H5E_CACHE, H5E_BADVALUE, NULL, "actual_len exceeds EOA");
 
                     /* Expand buffer to new size */
-                    if (NULL == (new_image = H5MM_realloc(image, actual_len + H5C_IMAGE_EXTRA_SPACE)))
-                        HGOTO_ERROR(H5E_CACHE, H5E_CANTALLOC, NULL, "image null after H5MM_realloc()");
+                    new_image = H5MM_realloc(image, actual_len + H5C_IMAGE_EXTRA_SPACE);
                     image = (uint8_t *)new_image;
+                    if (NULL == image)
+                        HGOTO_ERROR(H5E_CACHE, H5E_CANTALLOC, NULL, "image null after H5MM_realloc()");
+                    
 #if H5C_DO_MEMORY_SANITY_CHECKS
                     H5MM_memcpy(image + actual_len, H5C_IMAGE_SANITY_VALUE, H5C_IMAGE_EXTRA_SPACE);
 #endif /* H5C_DO_MEMORY_SANITY_CHECKS */

--- a/src/H5Centry.c
+++ b/src/H5Centry.c
@@ -1118,7 +1118,7 @@ H5C__load_entry(H5F_t *f,
                     if (NULL == (new_image = H5MM_realloc(image, actual_len + H5C_IMAGE_EXTRA_SPACE)))
                         HGOTO_ERROR(H5E_CACHE, H5E_CANTALLOC, NULL, "image null after H5MM_realloc()");
                     image = (uint8_t *)new_image;
-                    
+
 #if H5C_DO_MEMORY_SANITY_CHECKS
                     H5MM_memcpy(image + actual_len, H5C_IMAGE_SANITY_VALUE, H5C_IMAGE_EXTRA_SPACE);
 #endif /* H5C_DO_MEMORY_SANITY_CHECKS */

--- a/src/H5Centry.c
+++ b/src/H5Centry.c
@@ -1053,7 +1053,7 @@ H5C__load_entry(H5F_t *f,
         do {
             if (actual_len != len) {
                 /* Verify that the length isn't a bad value  */
-                if (actual_len <= 0)
+                if (len == 0)
                     HGOTO_ERROR(H5E_CACHE, H5E_BADVALUE, NULL, "len is a bad value");
 
                 if (NULL == (new_image = H5MM_realloc(image, len + H5C_IMAGE_EXTRA_SPACE)))
@@ -1111,7 +1111,7 @@ H5C__load_entry(H5F_t *f,
                         HGOTO_ERROR(H5E_CACHE, H5E_BADVALUE, NULL, "actual_len exceeds EOA");
 
                     /* Verify that the length isn't 0  */
-                    if (actual_len <= 0)
+                    if (actual_len == 0)
                         HGOTO_ERROR(H5E_CACHE, H5E_BADVALUE, NULL, "actual_len is a bad value");
 
                     /* Expand buffer to new size */


### PR DESCRIPTION
This PR fixes issue https://github.com/HDFGroup/hdf5/issues/5383, which was occurring due to actual_len + H5C_IMAGE_EXTRA_SPACE being 0. When realloc was called, it freed image, but gets sent to done before new_image can be assigned to image. Because the pointer for image isn't null, it attempts to free it here again, causing the double free to occur. This PR addresses Quincey's concern and fixes the issue while preserving new_image and image.

The bug was first reproduced using the fuzzer and the POC file from https://github.com/HDFGroup/hdf5/issues/5383. With this change, the double free no longer occurs.

