### PR TITLE
Merge h5dump test macros

### DIFF
--- a/tools/test/h5dump/CMakeTests.cmake
+++ b/tools/test/h5dump/CMakeTests.cmake
@@ -466,6 +466,10 @@ endmacro ()
 #   TARGET_FILE <filename> - the file to target with h5dump
 #   RESULT_CODE <code>    - expected return code after test execution. 0 is success
 #
+# OPTIONAL FLAG ARGUMENTS:
+#   BINARY_OUTPUT - whether to pass the binary output flag (-b) to h5dump
+#                   requires OUTPUT_FILE
+#
 # OPTIONAL KEYWORD ARGUMENTS:
 #   APPLY_FILTERS <resultvalue> - If provided, test will apply filters to output before comparison.
 #                                 <resultvalue> is used to construct the filter expressions
@@ -477,7 +481,7 @@ endmacro ()
 #
 macro (ADD_H5_TEST testname)
   cmake_parse_arguments(ARG
-    ""
+    "BINARY_OUTPUT"
     "RESULT_CODE;APPLY_FILTERS;TARGET_FILE;OUTPUT_FILE;DDL_FILE"
     "ANY_PATHS"
     ${ARGN}
@@ -563,9 +567,19 @@ macro (ADD_H5_TEST testname)
     set (ARG_DDL_FILE_CMD "")
   endif ()
 
+  if (${ARG_BINARY_OUTPUT})
+    if (NOT DEFINED ARG_OUTPUT_FILE)
+      message(FATAL_ERROR "ADD_H5_TEST: BINARY_OUTPUT flag requires OUTPUT_FILE")
+    endif ()
+
+    set (BINARY_OUTPUT_FLAG "-b")
+  else ()
+    set (BINARY_OUTPUT_FLAG "")
+  endif()
+
   # If using memchecker add tests without using scripts
   if (HDF5_ENABLE_USING_MEMCHECKER)
-    add_test (NAME H5DUMP-${testname} COMMAND ${CMAKE_CROSSCOMPILING_EMULATOR} $<TARGET_FILE:h5dump> ${ARG_ANY_PATHS} ${ARG_UNPARSED_ARGUMENTS} ${ARG_DDL_FILE_CMD} ${ARG_OUTPUT_FILE} ${ARG_TARGET_FILE})
+    add_test (NAME H5DUMP-${testname} COMMAND ${CMAKE_CROSSCOMPILING_EMULATOR} $<TARGET_FILE:h5dump> ${ARG_ANY_PATHS} ${ARG_UNPARSED_ARGUMENTS} ${ARG_DDL_FILE_CMD} ${BINARY_OUTPUT_FLAG} ${ARG_OUTPUT_FILE} ${ARG_TARGET_FILE})
     if (${ARG_RESULT_CODE})
       set_tests_properties (H5DUMP-${testname} PROPERTIES WILL_FAIL "true")
     endif ()
@@ -578,7 +592,7 @@ macro (ADD_H5_TEST testname)
         COMMAND "${CMAKE_COMMAND}"
             -D "TEST_EMULATOR=${CMAKE_CROSSCOMPILING_EMULATOR}"
             -D "TEST_PROGRAM=$<TARGET_FILE:h5dump>"
-            -D "TEST_ARGS:STRING=${ARG_ANY_PATHS};${ARG_UNPARSED_ARGUMENTS};${ARG_DDL_FILE_CMD};${ARG_OUTPUT_FILE};${ARG_TARGET_FILE}"
+            -D "TEST_ARGS:STRING=${ARG_ANY_PATHS};${ARG_UNPARSED_ARGUMENTS};${ARG_DDL_FILE_CMD};${BINARY_OUTPUT_FLAG};${ARG_OUTPUT_FILE};${ARG_TARGET_FILE}"
             -D "TEST_FOLDER=${PROJECT_BINARY_DIR}/testfiles/std"
             -D "TEST_OUTPUT=${testname}.out"
             -D "TEST_EXPECT=${ARG_RESULT_CODE}"
@@ -629,50 +643,6 @@ macro (ADD_H5_TEST testname)
     )
   endif ()
 
-endmacro ()
-
-macro (ADD_H5_EXPORT_TEST resultfile targetfile resultcode)
-  if (NOT HDF5_ENABLE_USING_MEMCHECKER)
-    add_test (
-        NAME H5DUMP-output-${resultfile}-clear-objects
-        COMMAND ${CMAKE_COMMAND} -E remove
-            ${resultfile}.txt
-    )
-    set_tests_properties (H5DUMP-output-${resultfile}-clear-objects PROPERTIES
-        WORKING_DIRECTORY "${PROJECT_BINARY_DIR}/testfiles/std"
-    )
-    add_test (
-        NAME H5DUMP-output-${resultfile}
-        COMMAND ${CMAKE_CROSSCOMPILING_EMULATOR} $<TARGET_FILE:h5dump> ${ARGN} ${resultfile}.txt ${targetfile}
-    )
-    set_tests_properties (H5DUMP-output-${resultfile} PROPERTIES
-        DEPENDS H5DUMP-output-${resultfile}-clear-objects
-        WORKING_DIRECTORY "${PROJECT_BINARY_DIR}/testfiles/std"
-    )
-    if ("H5DUMP-output-${resultfile}" MATCHES "${HDF5_DISABLE_TESTS_REGEX}")
-      set_tests_properties (H5DUMP-output-${resultfile} PROPERTIES DISABLED true)
-    endif ()
-    add_test (
-        NAME H5DUMP-output-cmp-${resultfile}
-        COMMAND ${CMAKE_COMMAND} -E compare_files --ignore-eol ${resultfile}.txt ${resultfile}.exp
-    )
-    set_tests_properties (H5DUMP-output-cmp-${resultfile} PROPERTIES
-        DEPENDS H5DUMP-output-${resultfile}
-        WORKING_DIRECTORY "${PROJECT_BINARY_DIR}/testfiles/std"
-    )
-    if ("H5DUMP-output-cmp-${resultfile}" MATCHES "${HDF5_DISABLE_TESTS_REGEX}")
-      set_tests_properties (H5DUMP-output-cmp-${resultfile} PROPERTIES DISABLED true)
-    endif ()
-    add_test (
-        NAME H5DUMP-output-${resultfile}-clean-objects
-        COMMAND ${CMAKE_COMMAND} -E remove
-            ${resultfile}.txt
-    )
-    set_tests_properties (H5DUMP-output-${resultfile}-clean-objects PROPERTIES
-        DEPENDS H5DUMP-output-cmp-${resultfile}
-        WORKING_DIRECTORY "${PROJECT_BINARY_DIR}/testfiles/std"
-    )
-  endif ()
 endmacro ()
 
 macro (ADD_H5_MASK_TEST resultfile resultcode)
@@ -1296,8 +1266,8 @@ ADD_H5_TEST (tvms RESULT_CODE 0 --enable-error-stack TARGET_FILE tvms.h5)
 ADD_H5_BIN_EXPORT (tbin1LE 0 tbinary.h5 --enable-error-stack -d integer -b LE)
 
 # test for string binary output
-ADD_H5_EXPORT_TEST (tstr2bin2 tstr2.h5 0 --enable-error-stack -d /g2/dset2 -b -o)
-ADD_H5_EXPORT_TEST (tstr2bin6 tstr2.h5 0 --enable-error-stack -d /g6/dset6 -b -o)
+ADD_H5_TEST (tstr2bin2 OUTPUT_FILE tstr2bin2 TARGET_FILE tstr2.h5 RESULT_CODE 0 --enable-error-stack -d /g2/dset2 BINARY_OUTPUT)
+ADD_H5_TEST (tstr2bin6 OUTPUT_FILE tstr2bin6 TARGET_FILE tstr2.h5 RESULT_CODE 0 --enable-error-stack -d /g6/dset6 BINARY_OUTPUT)
 
 # NATIVE default. the NATIVE test can be validated with h5import/h5diff
 #  ADD_H5_TEST_IMPORT (tbin1 out1D TARGET_FILE tbinary.h5 0 --enable-error-stack -d integer -b)
@@ -1318,7 +1288,7 @@ ADD_H5_TEST (tdatareg RESULT_CODE 0 --enable-error-stack TARGET_FILE tdatareg.h5
 ADD_H5ERR_MASK_TEST (tdataregR 0 "NULL token size" --enable-error-stack -R tdatareg.h5)
 ADD_H5_TEST (tattrreg RESULT_CODE 0 --enable-error-stack TARGET_FILE tattrreg.h5)
 ADD_H5ERR_MASK_TEST (tattrregR 0 "NULL token size" -R --enable-error-stack tattrreg.h5)
-ADD_H5_EXPORT_TEST (tbinregR tdatareg.h5 0 --enable-error-stack -d /Dataset1 -s 0 -R -y -o)
+ADD_H5_TEST (tbinregR OUTPUT_FILE tbinregR TARGET_FILE tdatareg.h5 RESULT_CODE 0 --enable-error-stack -d /Dataset1 -s 0 -R -y)
 
 # test for 1.12 region references
 ADD_H5_TEST (trefer_attrR RESULT_CODE 0 --enable-error-stack -R TARGET_FILE trefer_attr.h5)

--- a/tools/test/h5dump/CMakeTests.cmake
+++ b/tools/test/h5dump/CMakeTests.cmake
@@ -454,20 +454,6 @@ macro (ADD_HELP_TEST testname resultcode)
   endif ()
 endmacro ()
 
-macro (ADD_SKIP_H5_TEST skipresultfile skipresultcode testtype)
-  if ("${testtype}" STREQUAL "SKIP")
-    if (NOT HDF5_USING_ANALYSIS_TOOL)
-      add_test (
-          NAME H5DUMP-${skipresultfile}
-          COMMAND ${CMAKE_COMMAND} -E echo "SKIP ${skipresultfile} ${ARGN}"
-      )
-      set_property(TEST H5DUMP-${skipresultfile} PROPERTY DISABLED true)
-    endif ()
-  else ()
-    ADD_H5_TEST (${skipresultfile} ${skipresultcode} ${ARGN})
-  endif ()
-endmacro ()
-
 macro (ADD_H5_TEST resultfile resultcode)
   # If using memchecker add tests without using scripts
   if (HDF5_ENABLE_USING_MEMCHECKER)

--- a/tools/test/h5dump/CMakeTests.cmake
+++ b/tools/test/h5dump/CMakeTests.cmake
@@ -470,7 +470,8 @@ endmacro ()
 #   BINARY_OUTPUT - whether to pass the binary output flag (-b) to h5dump
 #                   requires OUTPUT_FILE
 #   MASK_ERROR - whether to mask out error stack info from output reference file or the .err ref file
-# 
+#   GREP_COMPARE - whether to perform a grep comparison on the output file
+#
 # OPTIONAL KEYWORD ARGUMENTS:
 #   APPLY_FILTERS <resultvalue> - If provided, test will apply filters to output before comparison.
 #                                 <resultvalue> is used to construct the filter expressions
@@ -482,7 +483,7 @@ endmacro ()
 #
 macro (ADD_H5_TEST testname)
   cmake_parse_arguments(ARG
-    "BINARY_OUTPUT;MASK_ERROR"
+    "BINARY_OUTPUT;MASK_ERROR;GREP_COMPARE"
     "RESULT_CODE;APPLY_FILTERS;TARGET_FILE;OUTPUT_FILE;DDL_FILE"
     "ANY_PATHS"
     ${ARGN}
@@ -579,7 +580,7 @@ macro (ADD_H5_TEST testname)
   endif()
 
   # If using memchecker add tests without using scripts
-  if (HDF5_ENABLE_USING_MEMCHECKER AND NOT ARG_MASK_ERROR)
+  if (HDF5_ENABLE_USING_MEMCHECKER AND NOT ARG_MASK_ERROR AND NOT ARG_GREP_COMPARE)
     add_test (NAME H5DUMP-${testname} COMMAND ${CMAKE_CROSSCOMPILING_EMULATOR} $<TARGET_FILE:h5dump> ${ARG_ANY_PATHS} ${ARG_UNPARSED_ARGUMENTS} ${ARG_DDL_FILE_CMD} ${BINARY_OUTPUT_FLAG} ${ARG_OUTPUT_FILE} ${ARG_TARGET_FILE})
     if (${ARG_RESULT_CODE})
       set_tests_properties (H5DUMP-${testname} PROPERTIES WILL_FAIL "true")
@@ -601,6 +602,7 @@ macro (ADD_H5_TEST testname)
             -D "TEST_FILTER:STRING=${filters_in}"
             -D "TEST_FILTER_REPLACE:STRING=${filters_out}"
             -D "TEST_MASK_ERROR:BOOL=${ARG_MASK_ERROR}"
+            -D "TEST_GREP_COMPARE:BOOL=${ARG_GREP_COMPARE}"
             -P "${HDF_RESOURCES_DIR}/runTest.cmake"
     )
   endif ()
@@ -645,30 +647,6 @@ macro (ADD_H5_TEST testname)
     )
   endif ()
 
-endmacro ()
-
-macro (ADD_H5_GREP_TEST resultfile resultcode result_check)
-  if (NOT HDF5_ENABLE_USING_MEMCHECKER)
-    add_test (
-        NAME H5DUMP-${resultfile}
-        COMMAND "${CMAKE_COMMAND}"
-            -D "TEST_EMULATOR=${CMAKE_CROSSCOMPILING_EMULATOR}"
-            -D "TEST_PROGRAM=$<TARGET_FILE:h5dump>"
-            -D "TEST_ARGS:STRING=${ARGN}"
-            -D "TEST_FOLDER=${PROJECT_BINARY_DIR}/testfiles/std"
-            -D "TEST_OUTPUT=${resultfile}.out"
-            -D "TEST_EXPECT=${resultcode}"
-            -D "TEST_REFERENCE=${result_check}"
-            -D "TEST_GREP_COMPARE=TRUE"
-            -P "${HDF_RESOURCES_DIR}/runTest.cmake"
-    )
-    set_tests_properties (H5DUMP-${resultfile} PROPERTIES
-        WORKING_DIRECTORY "${PROJECT_BINARY_DIR}/testfiles/std"
-    )
-    if ("H5DUMP-${resultfile}" MATCHES "${HDF5_DISABLE_TESTS_REGEX}")
-      set_tests_properties (H5DUMP-${resultfile} PROPERTIES DISABLED true)
-    endif ()
-  endif ()
 endmacro ()
 
 macro (ADD_H5ERR_MASK_TEST resultfile resultcode result_errcheck)
@@ -1323,7 +1301,7 @@ ADD_H5ERR_MASK_TEST (infinite_loop 1 "unable to open file" 3790_infinite_loop.h5
 ADD_H5ERR_MASK_TEST (err_attr_dspace 1 "error getting attribute information" err_attr_dspace.h5)
 
 # test to verify HDFFV-9407: long double full precision
-#  ADD_H5_GREP_TEST (t128bit_float 1 "1.123456789012345" -m %.35Lg t128bit_float.h5)
+# ADD_H5_GREP_TEST (t128bit_float 1 "1.123456789012345" -m %.35Lg t128bit_float.h5)
 
 # test to verify HDFFV-10480: out of bounds read in H5O_fill_new[old]_decode
 ADD_H5ERR_MASK_TEST (tCVE_2018_11206_fill_old 1 "" tCVE_2018_11206_fill_old.h5)

--- a/tools/test/h5dump/CMakeTests.cmake
+++ b/tools/test/h5dump/CMakeTests.cmake
@@ -470,6 +470,7 @@ endmacro ()
 #   APPLY_FILTERS <resultvalue> - If provided, test will apply filters to output before comparison.
 #                                 <resultvalue> is used to construct the filter expressions
 #   OUTPUT_FILE <filename> - if provided, put h5dump output into <filename>.txt and compare it to <filename>.exp
+#   DDL_FILE <ddlname> - if provided, have h5dump generate <ddlname>.ddl and compare it to <ddlname>.exp
 #
 # OPTIONAL MULTI-KEYWORD ARGUMENTS
 #   ANY_PATHS <paths>   - The -N/--any_path argument(s) to h5dump.
@@ -477,7 +478,7 @@ endmacro ()
 macro (ADD_H5_TEST testname)
   cmake_parse_arguments(ARG
     ""
-    "RESULT_CODE;APPLY_FILTERS;TARGET_FILE;OUTPUT_FILE"
+    "RESULT_CODE;APPLY_FILTERS;TARGET_FILE;OUTPUT_FILE;DDL_FILE"
     "ANY_PATHS"
     ${ARGN}
   )
@@ -521,36 +522,50 @@ macro (ADD_H5_TEST testname)
     set (ARG_OUTPUT_FILE "-o" "${ARG_OUTPUT_FILE}.txt")
   endif ()
 
-  # Cleanup if test produces artifacts
+  # Set up list of files to clean up
+  set(CLEANUP_FILES "")
+  set(CLEANUP_DEPENDENCIES "")
+
+  if (DEFINED ARG_TARGET_FILE)
+    list(APPEND CLEANUP_FILES "${testname}.txt")
+  endif ()
+
+  if (DEFINED ARG_DDL_FILE)
+    list(APPEND CLEANUP_FILES "${ARG_DDL_FILE}.txt")
+  endif ()
+
   if (DEFINED ARG_ANY_PATHS)
+    list(APPEND CLEANUP_FILES "${testname}.bin")
+  endif ()
+
+  # Cleanup if test produces artifacts
+  if (CLEANUP_FILES)
     add_test (
-        NAME H5DUMP-${testname}-clear-binary-objects
+        NAME H5DUMP-${testname}-clear-objects
         COMMAND ${CMAKE_COMMAND} -E remove
-            ${testname}.bin
+            "${CLEANUP_FILES}"
     )
-    set_tests_properties (H5DUMP-${testname}-clear-binary-objects PROPERTIES
+
+    set_tests_properties (H5DUMP-${testname}-clear-objects PROPERTIES
         WORKING_DIRECTORY "${PROJECT_BINARY_DIR}/testfiles/std"
     )
   endif ()
 
   if (DEFINED ARG_TARGET_FILE)
     set (target_file_txt ${testname}.txt)
-    add_test (
-      NAME H5DUMP-${testname}-clear-txt-objects
-      COMMAND ${CMAKE_COMMAND} -E remove
-        ${testname}.txt
-    )
-
-    set_tests_properties (H5DUMP-${testname}-clear-txt-objects PROPERTIES
-      WORKING_DIRECTORY "${PROJECT_BINARY_DIR}/testfiles/std"
-    )
   else ()
     set (target_file_txt "")
   endif ()
 
+  if (DEFINED ARG_DDL_FILE)
+    set (ARG_DDL_FILE_CMD "--ddl=${ARG_DDL_FILE}.txt")
+  else ()
+    set (ARG_DDL_FILE_CMD "")
+  endif ()
+
   # If using memchecker add tests without using scripts
   if (HDF5_ENABLE_USING_MEMCHECKER)
-    add_test (NAME H5DUMP-${testname} COMMAND ${CMAKE_CROSSCOMPILING_EMULATOR} $<TARGET_FILE:h5dump> ${ARG_ANY_PATHS} ${ARG_UNPARSED_ARGUMENTS} ${ARG_OUTPUT_FILE} ${ARG_TARGET_FILE})
+    add_test (NAME H5DUMP-${testname} COMMAND ${CMAKE_CROSSCOMPILING_EMULATOR} $<TARGET_FILE:h5dump> ${ARG_ANY_PATHS} ${ARG_UNPARSED_ARGUMENTS} ${ARG_DDL_FILE_CMD} ${ARG_OUTPUT_FILE} ${ARG_TARGET_FILE})
     if (${ARG_RESULT_CODE})
       set_tests_properties (H5DUMP-${testname} PROPERTIES WILL_FAIL "true")
     endif ()
@@ -563,7 +578,7 @@ macro (ADD_H5_TEST testname)
         COMMAND "${CMAKE_COMMAND}"
             -D "TEST_EMULATOR=${CMAKE_CROSSCOMPILING_EMULATOR}"
             -D "TEST_PROGRAM=$<TARGET_FILE:h5dump>"
-            -D "TEST_ARGS:STRING=${ARG_ANY_PATHS};${ARG_UNPARSED_ARGUMENTS};${ARG_OUTPUT_FILE};${ARG_TARGET_FILE}"
+            -D "TEST_ARGS:STRING=${ARG_ANY_PATHS};${ARG_UNPARSED_ARGUMENTS};${ARG_DDL_FILE_CMD};${ARG_OUTPUT_FILE};${ARG_TARGET_FILE}"
             -D "TEST_FOLDER=${PROJECT_BINARY_DIR}/testfiles/std"
             -D "TEST_OUTPUT=${testname}.out"
             -D "TEST_EXPECT=${ARG_RESULT_CODE}"
@@ -581,6 +596,8 @@ macro (ADD_H5_TEST testname)
     set_tests_properties (H5DUMP-${testname} PROPERTIES DISABLED true)
   endif ()
 
+  set(CLEANUP_DEPENDENCIES "H5DUMP-${testname}")
+
   if (DEFINED ARG_TARGET_FILE AND DEFINED ARG_OUTPUT_FILE)
     add_test (
       NAME H5DUMP-${testname}-output-cmp
@@ -596,114 +613,22 @@ macro (ADD_H5_TEST testname)
       set_tests_properties (H5DUMP-${testname}-output-cmp PROPERTIES DISABLED true)
     endif ()
 
-    # Cleanup txt
+    list(APPEND CLEANUP_DEPENDENCIES "H5DUMP-${testname}-output-cmp")
+  endif ()
+
+  if (CLEANUP_FILES)
     add_test (
-      NAME H5DUMP-${testname}-clean-txt-objects
+      NAME H5DUMP-${testname}-clean-objects
       COMMAND ${CMAKE_COMMAND} -E remove
-          ${testname}.txt
+          "${CLEANUP_FILES}"
     )
 
-    set_tests_properties (H5DUMP-${testname}-clean-txt-objects PROPERTIES
-        DEPENDS H5DUMP-${testname}-output-cmp
+    set_tests_properties (H5DUMP-${testname}-clean-objects PROPERTIES
+        DEPENDS "${CLEANUP_DEPENDENCIES}"
         WORKING_DIRECTORY "${PROJECT_BINARY_DIR}/testfiles/std"
     )
   endif ()
 
-  if (DEFINED ARG_ANY_PATHS)
-    set_tests_properties (H5DUMP-${testname} PROPERTIES
-      DEPENDS H5DUMP-${testname}-clear-objects
-    )
-    
-    add_test (
-      NAME H5DUMP-${testname}-clean-binary-objects
-      COMMAND ${CMAKE_COMMAND} -E remove
-          ${testname}.bin
-    )
-
-    set_tests_properties (H5DUMP-${testname}-clean-binary-objects PROPERTIES
-        DEPENDS H5DUMP-${testname}
-        WORKING_DIRECTORY "${PROJECT_BINARY_DIR}/testfiles/std"
-    )
-  endif ()
-endmacro ()
-
-macro (ADD_H5_TEST_EXPORT_DDL resultfile targetfile resultcode ddlfile)
-  add_test (
-      NAME H5DUMP-${resultfile}-clear-objects
-      COMMAND ${CMAKE_COMMAND} -E remove
-          ${ddlfile}.txt
-          ${resultfile}.txt
-  )
-  set_tests_properties (H5DUMP-${resultfile}-clear-objects PROPERTIES
-      WORKING_DIRECTORY "${PROJECT_BINARY_DIR}/testfiles/std"
-  )
-  # If using memchecker add tests without using scripts
-  if (HDF5_ENABLE_USING_MEMCHECKER)
-    add_test (NAME H5DUMP-${resultfile} COMMAND ${CMAKE_CROSSCOMPILING_EMULATOR} $<TARGET_FILE:h5dump> --ddl=${ddlfile}.txt ${ARGN} ${resultfile}.txt ${targetfile})
-    if (${resultcode})
-      set_tests_properties (H5DUMP-${resultfile} PROPERTIES WILL_FAIL "true")
-    endif ()
-    set_tests_properties (H5DUMP-${resultfile} PROPERTIES
-        DEPENDS H5DUMP-${resultfile}-clear-objects
-        WORKING_DIRECTORY "${PROJECT_BINARY_DIR}/testfiles/std"
-    )
-  else ()
-    add_test (
-        NAME H5DUMP-${resultfile}
-        COMMAND "${CMAKE_COMMAND}"
-            -D "TEST_EMULATOR=${CMAKE_CROSSCOMPILING_EMULATOR}"
-            -D "TEST_PROGRAM=$<TARGET_FILE:h5dump>"
-            -D "TEST_ARGS:STRING=--ddl=${ddlfile}.txt;${ARGN};${resultfile}.txt;${targetfile}"
-            -D "TEST_FOLDER=${PROJECT_BINARY_DIR}/testfiles/std"
-            -D "TEST_OUTPUT=${resultfile}.out"
-            -D "TEST_EXPECT=${resultcode}"
-            -D "TEST_REFERENCE=${resultfile}.ddl"
-            -P "${HDF_RESOURCES_DIR}/runTest.cmake"
-    )
-    set_tests_properties (H5DUMP-${resultfile} PROPERTIES
-        DEPENDS H5DUMP-${resultfile}-clear-objects
-        WORKING_DIRECTORY "${PROJECT_BINARY_DIR}/testfiles/std"
-    )
-    if ("H5DUMP-${resultfile}" MATCHES "${HDF5_DISABLE_TESTS_REGEX}")
-      set_tests_properties (H5DUMP-${resultfile} PROPERTIES DISABLED true)
-    endif ()
-    add_test (
-        NAME H5DUMP-${resultfile}-output-cmp
-        COMMAND ${CMAKE_COMMAND} -E compare_files --ignore-eol ${resultfile}.txt ${resultfile}.exp
-    )
-    set_tests_properties (H5DUMP-${resultfile}-output-cmp PROPERTIES
-        DEPENDS H5DUMP-${resultfile}
-        WORKING_DIRECTORY "${PROJECT_BINARY_DIR}/testfiles/std"
-    )
-    add_test (
-        NAME H5DUMP-${resultfile}-output-cmp-ddl
-        COMMAND ${CMAKE_COMMAND} -E compare_files --ignore-eol ${ddlfile}.txt ${ddlfile}.exp
-    )
-    set_tests_properties (H5DUMP-${resultfile}-output-cmp-ddl PROPERTIES
-        DEPENDS H5DUMP-${resultfile}-output-cmp
-        WORKING_DIRECTORY "${PROJECT_BINARY_DIR}/testfiles/std"
-    )
-    if ("H5DUMP-${resultfile}-output-cmp-ddl" MATCHES "${HDF5_DISABLE_TESTS_REGEX}")
-      set_tests_properties (H5DUMP-${resultfile}-output-cmp-ddl PROPERTIES DISABLED true)
-    endif ()
-  endif ()
-  add_test (
-      NAME H5DUMP-${resultfile}-clean-objects
-      COMMAND ${CMAKE_COMMAND} -E remove
-          ${ddlfile}.txt
-          ${resultfile}.txt
-  )
-  if (HDF5_ENABLE_USING_MEMCHECKER)
-    set_tests_properties (H5DUMP-${resultfile}-clean-objects PROPERTIES
-        DEPENDS H5DUMP-${resultfile}
-        WORKING_DIRECTORY "${PROJECT_BINARY_DIR}/testfiles/std"
-    )
-  else ()
-    set_tests_properties (H5DUMP-${resultfile}-clean-objects PROPERTIES
-        DEPENDS H5DUMP-${resultfile}-output-cmp-ddl
-        WORKING_DIRECTORY "${PROJECT_BINARY_DIR}/testfiles/std"
-    )
-  endif ()
 endmacro ()
 
 macro (ADD_H5_EXPORT_TEST resultfile targetfile resultcode)
@@ -1029,7 +954,7 @@ ADD_H5_TEST (trawdatafile OUTPUT_FILE trawdatafile TARGET_FILE packedbits.h5 RES
 ADD_H5_TEST (tnoddlfile OUTPUT_FILE tnoddlfile TARGET_FILE packedbits.h5 RESULT_CODE 0 --enable-error-stack -O -y)
 ADD_H5_TEST (trawssetfile OUTPUT_FILE trawssetfile TARGET_FILE tdset.h5 RESULT_CODE 0 --enable-error-stack -d "/dset1[1,1;;;]" -y)
 
-ADD_H5_TEST_EXPORT_DDL (twithddlfile packedbits.h5 0 twithddl --enable-error-stack --ddl=twithddl.txt -y -o)
+ADD_H5_TEST (twithddlfile OUTPUT_FILE twithddlfile TARGET_FILE packedbits.h5 RESULT_CODE 0 DDL_FILE twithddl --enable-error-stack --ddl=twithddl.txt -y)
 
 # test for maximum display datasets
 ADD_H5_TEST (twidedisplay RESULT_CODE 0 --enable-error-stack -w0 TARGET_FILE packedbits.h5)

--- a/tools/test/h5dump/CMakeTests.cmake
+++ b/tools/test/h5dump/CMakeTests.cmake
@@ -580,12 +580,6 @@ macro (ADD_H5_TEST testname)
     message(FATAL_ERROR "ADD_H5_TEST: ENVVAR requires ENVVAL")
   endif ()
 
-  if (DEFINED ARG_TARGET_FILE)
-    set (target_file_txt ${testname}.txt)
-  else ()
-    set (target_file_txt "")
-  endif ()
-
   if (DEFINED ARG_DDL_FILE)
     set (ARG_DDL_FILE_CMD "--ddl=${ARG_DDL_FILE}.txt")
   else ()

--- a/tools/test/h5dump/CMakeTests.cmake
+++ b/tools/test/h5dump/CMakeTests.cmake
@@ -479,6 +479,7 @@ endmacro ()
 #                                 <resultvalue> is used to construct the filter expressions
 #   OUTPUT_FILE <filename> - if provided, put h5dump output into <filename>.txt and compare it to <filename>.exp
 #   DDL_FILE <ddlname> - if provided, have h5dump generate <ddlname>.ddl and compare it to <ddlname>.exp
+#   RESULT_CHECK <string> - if provided, use <string> as TEST_REFERENCE instead of <testname>.ddl
 #   H5ERRREF <errref_string> - if provided, expect the error output from h5dump to contain this string
 #   ENVVAR <varname> - if provided, set environment variable <varname> to ENVVAL. If memchecker is enabled, does nothing.
 #   ENVVAL <value> - if provided, set environment variable ENVVAR to this value. If memchecker is enabled, does nothing.
@@ -597,11 +598,17 @@ macro (ADD_H5_TEST testname)
     set (BINARY_OUTPUT_FLAG "")
   endif()
 
+  if (DEFINED ${ARG_RESULT_CHECK})
+    set (ARG_RESULT_CHECK_FILE "${ARG_RESULT_CHECK}")
+  else ()
+    set (ARG_RESULT_CHECK_FILE "${testname}.ddl")
+  endif ()
+
   # Certain args are fully incompatible with memchecker; skip in these cases
   set(should_add_test TRUE)
 
   if (HDF5_ENABLE_USING_MEMCHECKER)
-    if (DEFINED ARG_H5ERRREF OR ${ARG_BINFILE})
+    if (DEFINED ARG_H5ERRREF OR ${ARG_BINFILE} OR ${ARG_GREP_COMPARE})
       set(should_add_test FALSE)
     endif()
   endif()
@@ -643,7 +650,7 @@ macro (ADD_H5_TEST testname)
               -D "TEST_FOLDER=${PROJECT_BINARY_DIR}/testfiles/std"
               -D "TEST_OUTPUT=${testname}.out"
               -D "TEST_EXPECT=${ARG_RESULT_CODE}"
-              -D "TEST_REFERENCE=${testname}.ddl"
+              -D "TEST_REFERENCE=${ARG_RESULT_CHECK_FILE}"
               -D "TEST_FILTER:STRING=${filters_in}"
               -D "TEST_FILTER_REPLACE:STRING=${filters_out}"
               -D "TEST_MASK_ERROR:BOOL=${ARG_MASK_ERROR}"
@@ -1260,7 +1267,7 @@ ADD_H5_TEST (infinite_loop RESULT_CODE 1 H5ERRREF "unable to open file" TARGET_F
 ADD_H5_TEST (err_attr_dspace RESULT_CODE 1 H5ERRREF "error getting attribute information" TARGET_FILE err_attr_dspace.h5)
 
 # test to verify HDFFV-9407: long double full precision
-# ADD_H5_GREP_TEST (t128bit_float 1 "1.123456789012345" -m %.35Lg t128bit_float.h5)
+ADD_H5_TEST (t128bit_float RESULT_CODE 1 RESULT_ERRCHECK "1.123456789012345" -m %.35Lg TARGET_FILE t128bit_float.h5 SKIP_TEST)
 
 # test to verify HDFFV-10480: out of bounds read in H5O_fill_new[old]_decode
 ADD_H5_TEST (tCVE_2018_11206_fill_old RESULT_CODE 1 H5ERRREF "" TARGET_FILE tCVE_2018_11206_fill_old.h5)

--- a/tools/test/h5dump/CMakeTests.cmake
+++ b/tools/test/h5dump/CMakeTests.cmake
@@ -472,6 +472,7 @@ endmacro ()
 #   MASK_ERROR - whether to mask out error stack info from output reference file or the .err ref file
 #   GREP_COMPARE - whether to perform a grep comparison on the output file
 #   BINFILE - if provided, use h5dump to put binary output into <testname>.bin
+#   SKIP_TEST - if provided, do not add this test
 #
 # OPTIONAL KEYWORD ARGUMENTS:
 #   APPLY_FILTERS <resultvalue> - If provided, test will apply filters to output before comparison.
@@ -487,7 +488,7 @@ endmacro ()
 #
 macro (ADD_H5_TEST testname)
   cmake_parse_arguments(ARG
-    "BINARY_OUTPUT;MASK_ERROR;GREP_COMPARE;BINFILE" # Flags
+    "BINARY_OUTPUT;MASK_ERROR;GREP_COMPARE;BINFILE;SKIP_TEST" # Flags
     "RESULT_CODE;APPLY_FILTERS;TARGET_FILE;OUTPUT_FILE;DDL_FILE;H5ERRREF;ENVVAR;ENVVAL" # Single value args
     "ANY_PATHS" # Multi value args
     ${ARGN}
@@ -603,6 +604,10 @@ macro (ADD_H5_TEST testname)
     if (DEFINED ARG_H5ERRREF OR ${ARG_BINFILE})
       set(should_add_test FALSE)
     endif()
+  endif()
+
+  if (${ARG_SKIP_TEST})
+    set(should_add_test FALSE)
   endif()
 
   if (should_add_test)

--- a/tools/test/h5dump/CMakeTests.cmake
+++ b/tools/test/h5dump/CMakeTests.cmake
@@ -750,7 +750,7 @@ macro (ADD_H5_TEST_IMPORT conffile resultfile testfile resultcode)
     if ("H5DUMP-IMPORT-h5import-${resultfile}" MATCHES "${HDF5_DISABLE_TESTS_REGEX}")
       set_tests_properties (H5DUMP-IMPORT-h5import-${resultfile} PROPERTIES DISABLED true)
     endif ()
-    add_test (NAME H5DUMP-IMPORT- -${resultfile} COMMAND ${CMAKE_CROSSCOMPILING_EMULATOR} $<TARGET_FILE:h5diff> ${testfile} ${resultfile}.h5 /integer /integer)
+    add_test (NAME H5DUMP-IMPORT-h5diff-${resultfile} COMMAND ${CMAKE_CROSSCOMPILING_EMULATOR} $<TARGET_FILE:h5diff> ${testfile} ${resultfile}.h5 /integer /integer)
     set_tests_properties (H5DUMP-IMPORT-h5diff-${resultfile} PROPERTIES
         DEPENDS H5DUMP-IMPORT-h5import-${resultfile}
         WORKING_DIRECTORY "${PROJECT_BINARY_DIR}/testfiles/std"

--- a/tools/test/h5dump/CMakeTests.cmake
+++ b/tools/test/h5dump/CMakeTests.cmake
@@ -469,7 +469,8 @@ endmacro ()
 # OPTIONAL FLAG ARGUMENTS:
 #   BINARY_OUTPUT - whether to pass the binary output flag (-b) to h5dump
 #                   requires OUTPUT_FILE
-#
+#   MASK_ERROR - whether to mask out error stack info from output reference file or the .err ref file
+# 
 # OPTIONAL KEYWORD ARGUMENTS:
 #   APPLY_FILTERS <resultvalue> - If provided, test will apply filters to output before comparison.
 #                                 <resultvalue> is used to construct the filter expressions
@@ -481,7 +482,7 @@ endmacro ()
 #
 macro (ADD_H5_TEST testname)
   cmake_parse_arguments(ARG
-    "BINARY_OUTPUT"
+    "BINARY_OUTPUT;MASK_ERROR"
     "RESULT_CODE;APPLY_FILTERS;TARGET_FILE;OUTPUT_FILE;DDL_FILE"
     "ANY_PATHS"
     ${ARGN}
@@ -578,7 +579,7 @@ macro (ADD_H5_TEST testname)
   endif()
 
   # If using memchecker add tests without using scripts
-  if (HDF5_ENABLE_USING_MEMCHECKER)
+  if (HDF5_ENABLE_USING_MEMCHECKER AND NOT ARG_MASK_ERROR)
     add_test (NAME H5DUMP-${testname} COMMAND ${CMAKE_CROSSCOMPILING_EMULATOR} $<TARGET_FILE:h5dump> ${ARG_ANY_PATHS} ${ARG_UNPARSED_ARGUMENTS} ${ARG_DDL_FILE_CMD} ${BINARY_OUTPUT_FLAG} ${ARG_OUTPUT_FILE} ${ARG_TARGET_FILE})
     if (${ARG_RESULT_CODE})
       set_tests_properties (H5DUMP-${testname} PROPERTIES WILL_FAIL "true")
@@ -599,6 +600,7 @@ macro (ADD_H5_TEST testname)
             -D "TEST_REFERENCE=${testname}.ddl"
             -D "TEST_FILTER:STRING=${filters_in}"
             -D "TEST_FILTER_REPLACE:STRING=${filters_out}"
+            -D "TEST_MASK_ERROR:BOOL=${ARG_MASK_ERROR}"
             -P "${HDF_RESOURCES_DIR}/runTest.cmake"
     )
   endif ()
@@ -643,30 +645,6 @@ macro (ADD_H5_TEST testname)
     )
   endif ()
 
-endmacro ()
-
-macro (ADD_H5_MASK_TEST resultfile resultcode)
-  if (NOT HDF5_ENABLE_USING_MEMCHECKER)
-    add_test (
-        NAME H5DUMP-${resultfile}
-        COMMAND "${CMAKE_COMMAND}"
-            -D "TEST_EMULATOR=${CMAKE_CROSSCOMPILING_EMULATOR}"
-            -D "TEST_PROGRAM=$<TARGET_FILE:h5dump>"
-            -D "TEST_ARGS:STRING=${ARGN}"
-            -D "TEST_FOLDER=${PROJECT_BINARY_DIR}/testfiles/std"
-            -D "TEST_OUTPUT=${resultfile}.out"
-            -D "TEST_EXPECT=${resultcode}"
-            -D "TEST_REFERENCE=${resultfile}.ddl"
-            -D "TEST_MASK_ERROR=true"
-            -P "${HDF_RESOURCES_DIR}/runTest.cmake"
-    )
-    set_tests_properties (H5DUMP-${resultfile} PROPERTIES
-        WORKING_DIRECTORY "${PROJECT_BINARY_DIR}/testfiles/std"
-    )
-    if ("H5DUMP-${resultfile}" MATCHES "${HDF5_DISABLE_TESTS_REGEX}")
-      set_tests_properties (H5DUMP-${resultfile} PROPERTIES DISABLED true)
-    endif ()
-  endif ()
 endmacro ()
 
 macro (ADD_H5_GREP_TEST resultfile resultcode result_check)
@@ -1056,8 +1034,8 @@ ADD_H5_TEST (tarray7 RESULT_CODE 0 --enable-error-stack TARGET_FILE tarray7.h5)
 ADD_H5_TEST (tarray8 RESULT_CODE 0 --enable-error-stack TARGET_FILE tarray8.h5)
 
 # test for wildcards in filename (does not work with cmake)
-#ADD_H5_MASK_TEST (tstarfile 0 --enable-error-stack -H -d Dataset1 tarr*.h5)
-#ADD_H5_MASK_TEST (tqmarkfile 0 --enable-error-stack -H -d Dataset1 tarray?.h5)
+# ADD_H5_TEST (tstarfile MASK_ERROR RESULT_CODE 0 --enable-error-stack -H -d Dataset1 TARGET_FILE tarr*.h5)
+# ADD_H5_TEST (tqmarkfile MASK_ERROR RESULT_CODE 0 --enable-error-stack -H -d Dataset1 TARGET_FILE tarray?.h5)
 ADD_H5_TEST (tmultifile RESULT_CODE 0 --enable-error-stack -H -d Dataset1 tarray2.h5 tarray3.h5 tarray4.h5 tarray5.h5 tarray6.h5 TARGET_FILE tarray7.h5)
 
 # test for files with empty data

--- a/tools/test/h5dump/CMakeTests.cmake
+++ b/tools/test/h5dump/CMakeTests.cmake
@@ -471,6 +471,7 @@ endmacro ()
 #                   requires OUTPUT_FILE
 #   MASK_ERROR - whether to mask out error stack info from output reference file or the .err ref file
 #   GREP_COMPARE - whether to perform a grep comparison on the output file
+#   BINFILE - if provided, use h5dump to put binary output into <testname>.bin
 #
 # OPTIONAL KEYWORD ARGUMENTS:
 #   APPLY_FILTERS <resultvalue> - If provided, test will apply filters to output before comparison.
@@ -478,17 +479,17 @@ endmacro ()
 #   OUTPUT_FILE <filename> - if provided, put h5dump output into <filename>.txt and compare it to <filename>.exp
 #   DDL_FILE <ddlname> - if provided, have h5dump generate <ddlname>.ddl and compare it to <ddlname>.exp
 #   H5ERRREF <errref_string> - if provided, expect the error output from h5dump to contain this string
-#   ENVVAR <varname> - if provided, set environment variable <varname> to ENVVALUE. If memchecker is enabled, does nothing.
-#   ENVVALUE <value> - if provided, set environment variable ENVVAR to this value. If memchecker is enabled, does nothing.
+#   ENVVAR <varname> - if provided, set environment variable <varname> to ENVVAL. If memchecker is enabled, does nothing.
+#   ENVVAL <value> - if provided, set environment variable ENVVAR to this value. If memchecker is enabled, does nothing.
 #
 # OPTIONAL MULTI-KEYWORD ARGUMENTS
 #   ANY_PATHS <paths>   - The -N/--any_path argument(s) to h5dump.
 #
 macro (ADD_H5_TEST testname)
   cmake_parse_arguments(ARG
-    "BINARY_OUTPUT;MASK_ERROR;GREP_COMPARE"
-    "RESULT_CODE;APPLY_FILTERS;TARGET_FILE;OUTPUT_FILE;DDL_FILE;H5ERRREF;ENVVAR;ENVVALUE"
-    "ANY_PATHS"
+    "BINARY_OUTPUT;MASK_ERROR;GREP_COMPARE;BINFILE" # Flags
+    "RESULT_CODE;APPLY_FILTERS;TARGET_FILE;OUTPUT_FILE;DDL_FILE;H5ERRREF;ENVVAR;ENVVAL" # Single value args
+    "ANY_PATHS" # Multi value args
     ${ARGN}
   )
 
@@ -527,9 +528,25 @@ macro (ADD_H5_TEST testname)
     set (ARG_ANY_PATHS ${temp_path_arg})
   endif ()
 
+  # both of these args want to define argument to -o flag
+  if (DEFINED ARG_OUTPUT_FILE AND ${ARG_BINFILE}) 
+    message(FATAL_ERROR "ADD_H5_TEST: OUTPUT_FILE and BINFILE are mutually exclusive")
+  endif()
+
   if (DEFINED ARG_OUTPUT_FILE)
-    set (ARG_OUTPUT_FILE "-o" "${ARG_OUTPUT_FILE}.txt")
+    set (ARG_OUTPUT_FILEARGS "-o" "${ARG_OUTPUT_FILE}.txt")
+  elseif (${ARG_BINFILE})
+    set (ARG_OUTPUT_FILEARGS "-o" "${testname}.bin")
+  else()
+    set (ARG_OUTPUT_FILEARGS "")
   endif ()
+
+  # handle arguments that modify ctest testname
+  set (ctest_testname ${testname})
+
+  if (${ARG_BINFILE})
+    set (ctest_testname "BIN_EXPORT-${testname}")
+  endif()
 
   # Set up list of files to clean up
   set(CLEANUP_FILES "")
@@ -543,29 +560,16 @@ macro (ADD_H5_TEST testname)
     list(APPEND CLEANUP_FILES "${ARG_DDL_FILE}.txt")
   endif ()
 
-  if (DEFINED ARG_ANY_PATHS)
+  if (DEFINED ARG_ANY_PATHS OR ${ARG_BINFILE})
     list(APPEND CLEANUP_FILES "${testname}.bin")
   endif ()
 
   if (DEFINED ARG_ENVVAL AND NOT DEFINED ARG_ENVVAR)
-    message(FATAL_ERROR "ADD_H5_TEST: ENVVALUE requires ENVVAR")
+    message(FATAL_ERROR "ADD_H5_TEST: ENVVAL requires ENVVAR")
   endif ()
 
   if (DEFINED ARG_ENVVAR AND NOT DEFINED ARG_ENVVAL)
-    message(FATAL_ERROR "ADD_H5_TEST: ENVVAR requires ENVVALUE")
-  endif ()
-
-  # Cleanup if test produces artifacts
-  if (CLEANUP_FILES)
-    add_test (
-        NAME H5DUMP-${testname}-clear-objects
-        COMMAND ${CMAKE_COMMAND} -E remove
-            "${CLEANUP_FILES}"
-    )
-
-    set_tests_properties (H5DUMP-${testname}-clear-objects PROPERTIES
-        WORKING_DIRECTORY "${PROJECT_BINARY_DIR}/testfiles/std"
-    )
+    message(FATAL_ERROR "ADD_H5_TEST: ENVVAR requires ENVVAL")
   endif ()
 
   if (DEFINED ARG_TARGET_FILE)
@@ -590,117 +594,101 @@ macro (ADD_H5_TEST testname)
     set (BINARY_OUTPUT_FLAG "")
   endif()
 
-  # If using memchecker add tests without using scripts
-  if (HDF5_ENABLE_USING_MEMCHECKER AND NOT ARG_MASK_ERROR AND NOT ARG_GREP_COMPARE AND NOT DEFINED ARG_H5ERRREF)
-    add_test (NAME H5DUMP-${testname} COMMAND ${CMAKE_CROSSCOMPILING_EMULATOR} $<TARGET_FILE:h5dump> ${ARG_ANY_PATHS} ${ARG_UNPARSED_ARGUMENTS} ${ARG_DDL_FILE_CMD} ${BINARY_OUTPUT_FLAG} ${ARG_OUTPUT_FILE} ${ARG_TARGET_FILE})
-    if (${ARG_RESULT_CODE})
-      set_tests_properties (H5DUMP-${testname} PROPERTIES WILL_FAIL "true")
-    endif ()
-    set_tests_properties (H5DUMP-${testname} PROPERTIES
-        WORKING_DIRECTORY "${PROJECT_BINARY_DIR}/testfiles/std"
-    )
-  else ()
-    add_test (
-        NAME H5DUMP-${testname}
-        COMMAND "${CMAKE_COMMAND}"
-            -D "TEST_EMULATOR=${CMAKE_CROSSCOMPILING_EMULATOR}"
-            -D "TEST_PROGRAM=$<TARGET_FILE:h5dump>"
-            -D "TEST_ARGS:STRING=${ARG_ANY_PATHS};${ARG_UNPARSED_ARGUMENTS};${ARG_DDL_FILE_CMD};${BINARY_OUTPUT_FLAG};${ARG_OUTPUT_FILE};${ARG_TARGET_FILE}"
-            -D "TEST_FOLDER=${PROJECT_BINARY_DIR}/testfiles/std"
-            -D "TEST_OUTPUT=${testname}.out"
-            -D "TEST_EXPECT=${ARG_RESULT_CODE}"
-            -D "TEST_REFERENCE=${testname}.ddl"
-            -D "TEST_FILTER:STRING=${filters_in}"
-            -D "TEST_FILTER_REPLACE:STRING=${filters_out}"
-            -D "TEST_MASK_ERROR:BOOL=${ARG_MASK_ERROR}"
-            -D "TEST_GREP_COMPARE:BOOL=${ARG_GREP_COMPARE}"
-            -D "TEST_ERRREF=${ARG_H5ERRREF}"
-            -D "TEST_ENV_VAR:STRING=${ARG_ENVVAR}"
-            -D "TEST_ENV_VALUE:STRING=${ARG_ENVVALUE}"
-            -P "${HDF_RESOURCES_DIR}/runTest.cmake"
-    )
-  endif ()
-  set_tests_properties (H5DUMP-${testname} PROPERTIES
-      WORKING_DIRECTORY "${PROJECT_BINARY_DIR}/testfiles/std"
-  )
+  # Certain args are fully incompatible with memchecker; skip in these cases
+  set(should_add_test TRUE)
 
-  if ("H5DUMP-${testname}" MATCHES "${HDF5_DISABLE_TESTS_REGEX}")
-    set_tests_properties (H5DUMP-${testname} PROPERTIES DISABLED true)
-  endif ()
+  if (HDF5_ENABLE_USING_MEMCHECKER)
+    if (DEFINED ARG_H5ERRREF OR ${ARG_BINFILE})
+      set(should_add_test FALSE)
+    endif()
+  endif()
 
-  set(CLEANUP_DEPENDENCIES "H5DUMP-${testname}")
+  if (should_add_test)
+    # Cleanup if test produces artifacts
+    if (CLEANUP_FILES)
+      add_test (
+          NAME H5DUMP-${ctest_testname}-clear-objects
+          COMMAND ${CMAKE_COMMAND} -E remove
+              "${CLEANUP_FILES}"
+      )
 
-  if (DEFINED ARG_TARGET_FILE AND DEFINED ARG_OUTPUT_FILE)
-    add_test (
-      NAME H5DUMP-${testname}-output-cmp
-      COMMAND ${CMAKE_COMMAND} -E compare_files --ignore-eol ${testname}.txt ${testname}.exp
-    )
-
-    set_tests_properties(H5DUMP-${testname}-output-cmp PROPERTIES
-      DEPENDS H5DUMP-${testname}
-      WORKING_DIRECTORY "${PROJECT_BINARY_DIR}/testfiles/std"
-    )
-
-    if ("H5DUMP-${testname}-output-cmp" MATCHES "${HDF5_DISABLE_TESTS_REGEX}")
-      set_tests_properties (H5DUMP-${testname}-output-cmp PROPERTIES DISABLED true)
+      set_tests_properties (H5DUMP-${ctest_testname}-clear-objects PROPERTIES
+          WORKING_DIRECTORY "${PROJECT_BINARY_DIR}/testfiles/std"
+      )
     endif ()
 
-    list(APPEND CLEANUP_DEPENDENCIES "H5DUMP-${testname}-output-cmp")
-  endif ()
-
-  if (CLEANUP_FILES)
-    add_test (
-      NAME H5DUMP-${testname}-clean-objects
-      COMMAND ${CMAKE_COMMAND} -E remove
-          "${CLEANUP_FILES}"
-    )
-
-    set_tests_properties (H5DUMP-${testname}-clean-objects PROPERTIES
-        DEPENDS "${CLEANUP_DEPENDENCIES}"
+    # If using memchecker add tests without using scripts
+    if (HDF5_ENABLE_USING_MEMCHECKER AND NOT ARG_MASK_ERROR AND NOT ARG_GREP_COMPARE AND NOT DEFINED ARG_H5ERRREF)
+      add_test (NAME H5DUMP-${ctest_testname} COMMAND ${CMAKE_CROSSCOMPILING_EMULATOR} $<TARGET_FILE:h5dump> ${ARG_ANY_PATHS} ${ARG_UNPARSED_ARGUMENTS} ${ARG_DDL_FILE_CMD} ${BINARY_OUTPUT_FLAG} ${ARG_OUTPUT_FILEARGS} ${ARG_TARGET_FILE})
+      if (${ARG_RESULT_CODE})
+        set_tests_properties (H5DUMP-${ctest_testname} PROPERTIES WILL_FAIL "true")
+      endif ()
+      set_tests_properties (H5DUMP-${ctest_testname} PROPERTIES
+          WORKING_DIRECTORY "${PROJECT_BINARY_DIR}/testfiles/std"
+      )
+    else ()
+      add_test (
+          NAME H5DUMP-${ctest_testname}
+          COMMAND "${CMAKE_COMMAND}"
+              -D "TEST_EMULATOR=${CMAKE_CROSSCOMPILING_EMULATOR}"
+              -D "TEST_PROGRAM=$<TARGET_FILE:h5dump>"
+              -D "TEST_ARGS:STRING=${ARG_ANY_PATHS};${ARG_UNPARSED_ARGUMENTS};${ARG_DDL_FILE_CMD};${BINARY_OUTPUT_FLAG};${ARG_OUTPUT_FILEARGS};${ARG_TARGET_FILE}"
+              -D "TEST_FOLDER=${PROJECT_BINARY_DIR}/testfiles/std"
+              -D "TEST_OUTPUT=${testname}.out"
+              -D "TEST_EXPECT=${ARG_RESULT_CODE}"
+              -D "TEST_REFERENCE=${testname}.ddl"
+              -D "TEST_FILTER:STRING=${filters_in}"
+              -D "TEST_FILTER_REPLACE:STRING=${filters_out}"
+              -D "TEST_MASK_ERROR:BOOL=${ARG_MASK_ERROR}"
+              -D "TEST_GREP_COMPARE:BOOL=${ARG_GREP_COMPARE}"
+              -D "TEST_ERRREF=${ARG_H5ERRREF}"
+              -D "TEST_ENV_VAR:STRING=${ARG_ENVVAR}"
+              -D "TEST_ENV_VALUE:STRING=${ARG_ENVVAL}"
+              -P "${HDF_RESOURCES_DIR}/runTest.cmake"
+      )
+    endif ()
+    set_tests_properties (H5DUMP-${ctest_testname} PROPERTIES
         WORKING_DIRECTORY "${PROJECT_BINARY_DIR}/testfiles/std"
     )
-  endif ()
 
-endmacro ()
+    if ("H5DUMP-${ctest_testname}" MATCHES "${HDF5_DISABLE_TESTS_REGEX}")
+      set_tests_properties (H5DUMP-${ctest_testname} PROPERTIES DISABLED true)
+    endif ()
 
-macro (ADD_H5_BIN_EXPORT conffile resultcode testfile)
-  if (NOT HDF5_ENABLE_USING_MEMCHECKER)
-    add_test (
-        NAME H5DUMP-BIN_EXPORT-${conffile}-clear-objects
+    set(CLEANUP_DEPENDENCIES "H5DUMP-${ctest_testname}")
+
+    if (DEFINED ARG_TARGET_FILE AND DEFINED ARG_OUTPUT_FILE)
+      add_test (
+        NAME H5DUMP-${ctest_testname}-output-cmp
+        COMMAND ${CMAKE_COMMAND} -E compare_files --ignore-eol ${testname}.txt ${testname}.exp
+      )
+
+      set_tests_properties(H5DUMP-${ctest_testname}-output-cmp PROPERTIES
+        DEPENDS H5DUMP-${ctest_testname}
+        WORKING_DIRECTORY "${PROJECT_BINARY_DIR}/testfiles/std"
+      )
+
+      if ("H5DUMP-${ctest_testname}-output-cmp" MATCHES "${HDF5_DISABLE_TESTS_REGEX}")
+        set_tests_properties (H5DUMP-${ctest_testname}-output-cmp PROPERTIES DISABLED true)
+      endif ()
+
+      list(APPEND CLEANUP_DEPENDENCIES "H5DUMP-${ctest_testname}-output-cmp")
+    endif ()
+
+    if (CLEANUP_FILES)
+      add_test (
+        NAME H5DUMP-${ctest_testname}-clean-objects
         COMMAND ${CMAKE_COMMAND} -E remove
-            ${conffile}.bin
-    )
-    set_tests_properties (H5DUMP-BIN_EXPORT-${conffile}-clear-objects PROPERTIES
-        WORKING_DIRECTORY "${PROJECT_BINARY_DIR}/testfiles/std"
-    )
-    add_test (
-        NAME H5DUMP-BIN_EXPORT-${conffile}
-        COMMAND "${CMAKE_COMMAND}"
-            -D "TEST_EMULATOR=${CMAKE_CROSSCOMPILING_EMULATOR}"
-            -D "TEST_PROGRAM=$<TARGET_FILE:h5dump>"
-            -D "TEST_ARGS:STRING=${ARGN};-o;${conffile}.bin;${testfile}"
-            -D "TEST_FOLDER=${PROJECT_BINARY_DIR}/testfiles/std"
-            -D "TEST_OUTPUT=${conffile}.out"
-            -D "TEST_EXPECT=${resultcode}"
-            -D "TEST_REFERENCE=${conffile}.ddl"
-            -P "${HDF_RESOURCES_DIR}/runTest.cmake"
-    )
-    set_tests_properties (H5DUMP-BIN_EXPORT-${conffile} PROPERTIES
-        WORKING_DIRECTORY "${PROJECT_BINARY_DIR}/testfiles/std"
-    )
-    if ("H5DUMP-BIN_EXPORT-${conffile}" MATCHES "${HDF5_DISABLE_TESTS_REGEX}")
-      set_tests_properties (H5DUMP-BIN_EXPORT-${conffile} PROPERTIES DISABLED true)
+            "${CLEANUP_FILES}"
+      )
+
+      set_tests_properties (H5DUMP-${ctest_testname}-clean-objects PROPERTIES
+          DEPENDS "${CLEANUP_DEPENDENCIES}"
+          WORKING_DIRECTORY "${PROJECT_BINARY_DIR}/testfiles/std"
+      )
     endif ()
-    add_test (
-        NAME H5DUMP-BIN_EXPORT-${conffile}-clean-objects
-        COMMAND ${CMAKE_COMMAND} -E remove
-            ${conffile}.bin
-    )
-    set_tests_properties (H5DUMP-BIN_EXPORT-${conffile}-clean-objects PROPERTIES
-        DEPENDS H5DUMP-BIN_EXPORT-${conffile}
-        WORKING_DIRECTORY "${PROJECT_BINARY_DIR}/testfiles/std"
-    )
-  endif ()
+  endif () # should_add_test
+
 endmacro ()
 
 macro (ADD_H5_TEST_IMPORT conffile resultfile testfile resultcode)
@@ -1183,7 +1171,7 @@ ADD_H5_TEST (tcomplex_be_info RESULT_CODE 0 --enable-error-stack -p -H -m %.6f -
 ADD_H5_TEST (tvms RESULT_CODE 0 --enable-error-stack TARGET_FILE tvms.h5)
 
 # test for binary output
-ADD_H5_BIN_EXPORT (tbin1LE 0 tbinary.h5 --enable-error-stack -d integer -b LE)
+ADD_H5_TEST (tbin1LE BINFILE RESULT_CODE 0 TARGET_FILE tbinary.h5 --enable-error-stack -d integer -b LE)
 
 # test for string binary output
 ADD_H5_TEST (tstr2bin2 OUTPUT_FILE tstr2bin2 TARGET_FILE tstr2.h5 RESULT_CODE 0 --enable-error-stack -d /g2/dset2 BINARY_OUTPUT)
@@ -1193,14 +1181,14 @@ ADD_H5_TEST (tstr2bin6 OUTPUT_FILE tstr2bin6 TARGET_FILE tstr2.h5 RESULT_CODE 0 
 #  ADD_H5_TEST_IMPORT (tbin1 out1D TARGET_FILE tbinary.h5 0 --enable-error-stack -d integer -b)
 
 if (NOT HDF5_ENABLE_USING_MEMCHECKER)
-  ADD_H5_BIN_EXPORT (tbin2 0 tbinary.h5 --enable-error-stack -b BE -d float)
+  ADD_H5_TEST (tbin2 BINFILE RESULT_CODE 0 TARGET_FILE tbinary.h5 --enable-error-stack -b BE -d float)
 endif ()
 
 # the NATIVE test can be validated with h5import/h5diff
 #  ADD_H5_TEST_IMPORT (tbin3 out3D TARGET_FILE tbinary.h5 0 --enable-error-stack -d integer -b NATIVE)
 
 if (NOT HDF5_ENABLE_USING_MEMCHECKER)
-  ADD_H5_BIN_EXPORT (tbin4 0 tbinary.h5 --enable-error-stack -d double -b FILE)
+  ADD_H5_TEST (tbin4 BINFILE RESULT_CODE 0 TARGET_FILE tbinary.h5 --enable-error-stack -d double -b FILE)
 endif ()
 
 # test for dataset region references

--- a/tools/test/h5dump/CMakeTests.cmake
+++ b/tools/test/h5dump/CMakeTests.cmake
@@ -477,6 +477,7 @@ endmacro ()
 #                                 <resultvalue> is used to construct the filter expressions
 #   OUTPUT_FILE <filename> - if provided, put h5dump output into <filename>.txt and compare it to <filename>.exp
 #   DDL_FILE <ddlname> - if provided, have h5dump generate <ddlname>.ddl and compare it to <ddlname>.exp
+#   H5ERRREF <errref_string> - if provided, expect the error output from h5dump to contain this string
 #
 # OPTIONAL MULTI-KEYWORD ARGUMENTS
 #   ANY_PATHS <paths>   - The -N/--any_path argument(s) to h5dump.
@@ -484,7 +485,7 @@ endmacro ()
 macro (ADD_H5_TEST testname)
   cmake_parse_arguments(ARG
     "BINARY_OUTPUT;MASK_ERROR;GREP_COMPARE"
-    "RESULT_CODE;APPLY_FILTERS;TARGET_FILE;OUTPUT_FILE;DDL_FILE"
+    "RESULT_CODE;APPLY_FILTERS;TARGET_FILE;OUTPUT_FILE;DDL_FILE;H5ERRREF"
     "ANY_PATHS"
     ${ARGN}
   )
@@ -580,7 +581,7 @@ macro (ADD_H5_TEST testname)
   endif()
 
   # If using memchecker add tests without using scripts
-  if (HDF5_ENABLE_USING_MEMCHECKER AND NOT ARG_MASK_ERROR AND NOT ARG_GREP_COMPARE)
+  if (HDF5_ENABLE_USING_MEMCHECKER AND NOT ARG_MASK_ERROR AND NOT ARG_GREP_COMPARE AND NOT DEFINED ARG_H5ERRREF)
     add_test (NAME H5DUMP-${testname} COMMAND ${CMAKE_CROSSCOMPILING_EMULATOR} $<TARGET_FILE:h5dump> ${ARG_ANY_PATHS} ${ARG_UNPARSED_ARGUMENTS} ${ARG_DDL_FILE_CMD} ${BINARY_OUTPUT_FLAG} ${ARG_OUTPUT_FILE} ${ARG_TARGET_FILE})
     if (${ARG_RESULT_CODE})
       set_tests_properties (H5DUMP-${testname} PROPERTIES WILL_FAIL "true")
@@ -603,6 +604,7 @@ macro (ADD_H5_TEST testname)
             -D "TEST_FILTER_REPLACE:STRING=${filters_out}"
             -D "TEST_MASK_ERROR:BOOL=${ARG_MASK_ERROR}"
             -D "TEST_GREP_COMPARE:BOOL=${ARG_GREP_COMPARE}"
+            -D "TEST_ERRREF=${ARG_H5ERRREF}"
             -P "${HDF_RESOURCES_DIR}/runTest.cmake"
     )
   endif ()
@@ -647,30 +649,6 @@ macro (ADD_H5_TEST testname)
     )
   endif ()
 
-endmacro ()
-
-macro (ADD_H5ERR_MASK_TEST resultfile resultcode result_errcheck)
-  if (NOT HDF5_ENABLE_USING_MEMCHECKER)
-    add_test (
-        NAME H5DUMP-${resultfile}
-        COMMAND "${CMAKE_COMMAND}"
-            -D "TEST_EMULATOR=${CMAKE_CROSSCOMPILING_EMULATOR}"
-            -D "TEST_PROGRAM=$<TARGET_FILE:h5dump>"
-            -D "TEST_ARGS:STRING=${ARGN}"
-            -D "TEST_FOLDER=${PROJECT_BINARY_DIR}/testfiles/std"
-            -D "TEST_OUTPUT=${resultfile}.out"
-            -D "TEST_EXPECT=${resultcode}"
-            -D "TEST_REFERENCE=${resultfile}.ddl"
-            -D "TEST_ERRREF=${result_errcheck}"
-            -P "${HDF_RESOURCES_DIR}/runTest.cmake"
-    )
-    set_tests_properties (H5DUMP-${resultfile} PROPERTIES
-        WORKING_DIRECTORY "${PROJECT_BINARY_DIR}/testfiles/std"
-    )
-    if ("H5DUMP-${resultfile}" MATCHES "${HDF5_DISABLE_TESTS_REGEX}")
-      set_tests_properties (H5DUMP-${resultfile} PROPERTIES DISABLED true)
-    endif ()
-  endif ()
 endmacro ()
 
 macro (ADD_H5ERR_MASK_ENV_TEST resultfile resultcode result_errcheck envvar envval)
@@ -911,12 +889,12 @@ ADD_H5_TEST (tintsattrs RESULT_CODE 0 --enable-error-stack TARGET_FILE tintsattr
 # test for displaying groups
 ADD_H5_TEST (tgroup-1 RESULT_CODE 0 --enable-error-stack TARGET_FILE tgroup.h5)
 # test for displaying the selected groups
-ADD_H5ERR_MASK_TEST (tgroup-2 1 "h5dump error: unable to open group \"/y\"" --enable-error-stack --group=/g2 --group / -g /y tgroup.h5)
+ADD_H5_TEST (tgroup-2 RESULT_CODE 1 H5ERRREF "h5dump error: unable to open group \"/y\"" --enable-error-stack --group=/g2 --group / -g /y TARGET_FILE tgroup.h5)
 
 # test for displaying simple space datasets
 ADD_H5_TEST (tdset-1 RESULT_CODE 0 --enable-error-stack TARGET_FILE tdset.h5)
 # test for displaying selected datasets
-ADD_H5ERR_MASK_TEST (tdset-2 1 "h5dump error: unable to get link info from \"dset3\"" --enable-error-stack -H -d dset1 -d /dset2 --dataset=dset3 tdset.h5)
+ADD_H5_TEST (tdset-2 RESULT_CODE 1 H5ERRREF "h5dump error: unable to get link info from \"dset3\"" --enable-error-stack -H -d dset1 -d /dset2 --dataset=dset3 TARGET_FILE tdset.h5)
 
 # test for displaying attributes
 ADD_H5_TEST (tattr-1 RESULT_CODE 0 --enable-error-stack TARGET_FILE tattr.h5)
@@ -924,7 +902,7 @@ ADD_H5_TEST (tattr-1 RESULT_CODE 0 --enable-error-stack TARGET_FILE tattr.h5)
 ADD_H5_TEST (tattr-2 RESULT_CODE 0 --enable-error-stack -a /\\\\/attr1 --attribute /attr4 --attribute=/attr5 TARGET_FILE tattr.h5)
 ADD_H5_TEST (tattr-2-N RESULT_CODE 0 --enable-error-stack  TARGET_FILE tattr.h5 ANY_PATHS /\\\\/attr1 /attr4 /attr5)
 # test for header and error messages
-ADD_H5ERR_MASK_TEST (tattr-3 1 "h5dump error: unable to open attribute \"attr\"" --enable-error-stack --header -a /attr2 --attribute=/attr tattr.h5)
+ADD_H5_TEST (tattr-3 RESULT_CODE 1 H5ERRREF "h5dump error: unable to open attribute \"attr\"" --enable-error-stack --header -a /attr2 --attribute=/attr TARGET_FILE tattr.h5)
 # test for displaying at least 9 attributes on root from a be machine
 ADD_H5_TEST (tattr-4_be RESULT_CODE 0 --enable-error-stack TARGET_FILE tattr4_be.h5)
 # test for displaying attributes in shared datatype (also in group and dataset)
@@ -938,7 +916,7 @@ ADD_H5_TEST (tslink-2 RESULT_CODE 0 --enable-error-stack -l slink2 TARGET_FILE t
 ADD_H5_TEST (tslink-2-N RESULT_CODE 0 --enable-error-stack TARGET_FILE tslink.h5 ANY_PATHS slink2 )
 ADD_H5_TEST (tudlink-2 RESULT_CODE 0 --enable-error-stack -l udlink2 TARGET_FILE tudlink.h5)
 # test for displaying dangling soft links
-ADD_H5ERR_MASK_TEST (tslink-D 0 "component not found" --enable-error-stack -d /slink1 tslink.h5)
+ADD_H5_TEST (tslink-D RESULT_CODE 0 H5ERRREF "component not found" --enable-error-stack -d /slink1 TARGET_FILE tslink.h5)
 
 # tests for hard links
 ADD_H5_TEST (thlink-1 RESULT_CODE 0 --enable-error-stack TARGET_FILE thlink.h5)
@@ -955,7 +933,7 @@ ADD_H5_TEST (tcomp-1 RESULT_CODE 0 --enable-error-stack TARGET_FILE tcompound.h5
 ADD_H5_TEST (tcomp-2 RESULT_CODE 0 --enable-error-stack -t /type1 --datatype /type2 --datatype=/group1/type3 TARGET_FILE tcompound.h5)
 ADD_H5_TEST (tcomp-2-N RESULT_CODE 0 --enable-error-stack TARGET_FILE tcompound.h5 ANY_PATHS /type1 /type2 /group1/type3)
 # test for unnamed type
-ADD_H5ERR_MASK_TEST (tcomp-3 0 "object '#6632' doesn't exist" "--enable-error-stack;-t;/#6632;-g;/group2;tcompound.h5")
+ADD_H5_TEST (tcomp-3 RESULT_CODE 0 H5ERRREF "object '#6632' doesn't exist" "--enable-error-stack;-t;/#6632;-g;/group2" TARGET_FILE tcompound.h5)
 # test complicated compound datatype
 ADD_H5_TEST (tcomp-4 RESULT_CODE 0 --enable-error-stack TARGET_FILE tcompound_complex.h5)
 ADD_H5_TEST (tcompound_complex2 RESULT_CODE 0 --enable-error-stack TARGET_FILE tcompound_complex2.h5)
@@ -971,7 +949,7 @@ ADD_H5_TEST (tnestcomp-1 RESULT_CODE 0 --enable-error-stack TARGET_FILE tnestedc
 ADD_H5_TEST (tnestedcmpddt RESULT_CODE 0 --enable-error-stack TARGET_FILE tnestedcmpddt.h5)
 
 # test for options
-ADD_H5ERR_MASK_TEST (tall-1 0 "unable to open external file, external link file name = 'somefile'" --enable-error-stack tall.h5)
+ADD_H5_TEST (tall-1 RESULT_CODE 0 H5ERRREF "unable to open external file, external link file name = 'somefile'" --enable-error-stack TARGET_FILE tall.h5)
 ADD_H5_TEST (tall-2 RESULT_CODE 0 --enable-error-stack --header -g /g1/g1.1 -a attr2 TARGET_FILE tall.h5)
 ADD_H5_TEST (tall-3 RESULT_CODE 0 --enable-error-stack -d /g2/dset2.1 -l /g1/g1.2/g1.2.1/slink TARGET_FILE tall.h5)
 ADD_H5_TEST (tall-3-N RESULT_CODE 0 --enable-error-stack  TARGET_FILE tall.h5 ANY_PATHS /g2/dset2.1 /g1/g1.2/g1.2.1/slink)
@@ -1002,7 +980,7 @@ ADD_H5_TEST (tvlenstr_array RESULT_CODE 0 --enable-error-stack TARGET_FILE tvlen
 # test for files with array data
 ADD_H5_TEST (tarray1 RESULT_CODE 0 --enable-error-stack TARGET_FILE tarray1.h5)
 # # added for bug# 2092 - tarray1_big.h5
-ADD_H5ERR_MASK_TEST (tarray1_big 0 "NULL token size" --enable-error-stack -R tarray1_big.h5)
+ADD_H5_TEST (tarray1_big RESULT_CODE 0 H5ERRREF "NULL token size" --enable-error-stack -R TARGET_FILE tarray1_big.h5)
 ADD_H5_TEST (tarray2 RESULT_CODE 0 --enable-error-stack TARGET_FILE tarray2.h5)
 ADD_H5_TEST (tarray3 RESULT_CODE 0 --enable-error-stack TARGET_FILE tarray3.h5)
 ADD_H5_TEST (tarray4 RESULT_CODE 0 --enable-error-stack TARGET_FILE tarray4.h5)
@@ -1031,13 +1009,13 @@ ADD_H5_TEST (tmulti RESULT_CODE 0 --enable-error-stack --filedriver=multi TARGET
 ADD_H5_TEST (tlarge_objname RESULT_CODE 0 --enable-error-stack -w157 TARGET_FILE tlarge_objname.h5)
 
 # test '-A' to suppress data but print attr's
-ADD_H5ERR_MASK_TEST (tall-2A 0 "unable to open external file, external link file name = 'somefile'" --enable-error-stack -A tall.h5)
+ADD_H5_TEST (tall-2A RESULT_CODE 0 H5ERRREF "unable to open external file, external link file name = 'somefile'" --enable-error-stack -A TARGET_FILE tall.h5)
 
 # test '-A' to suppress attr's but print data
-ADD_H5ERR_MASK_TEST (tall-2A0 0 "unable to open external file, external link file name = 'somefile'" --enable-error-stack -A 0 tall.h5)
+ADD_H5_TEST (tall-2A0 RESULT_CODE 0 H5ERRREF "unable to open external file, external link file name = 'somefile'" --enable-error-stack -A 0 TARGET_FILE tall.h5)
 
 # test '-r' to print attributes in ASCII instead of decimal
-ADD_H5ERR_MASK_TEST (tall-2B 0 "unable to open external file, external link file name = 'somefile'" --enable-error-stack -A -r tall.h5)
+ADD_H5_TEST (tall-2B RESULT_CODE 0 H5ERRREF "unable to open external file, external link file name = 'somefile'" --enable-error-stack -A -r TARGET_FILE tall.h5)
 
 # test Subsetting
 ADD_H5_TEST (tall-4s RESULT_CODE 0 --enable-error-stack --dataset=/g1/g1.1/dset1.1.1 --start=1,1 --stride=2,3 --count=3,2 --block=1,1 TARGET_FILE tall.h5)
@@ -1067,7 +1045,7 @@ ADD_H5_TEST (file_space RESULT_CODE 0 --enable-error-stack -B TARGET_FILE file_s
 ADD_H5_TEST (file_space_cache RESULT_CODE 0 --enable-error-stack=2 --page-buffer-size=16384 -B TARGET_FILE file_space.h5)
 
 # test -p with a non existing dataset
-ADD_H5ERR_MASK_TEST (tperror 1 "h5dump error: unable to get link info from \"bogus\"" --enable-error-stack -p -d bogus tfcontents1.h5)
+ADD_H5_TEST (tperror RESULT_CODE 1 H5ERRREF "h5dump error: unable to get link info from \"bogus\"" --enable-error-stack -p -d bogus TARGET_FILE tfcontents1.h5)
 
 # test for file contents
 ADD_H5_TEST (tcontents RESULT_CODE 0 --enable-error-stack -n TARGET_FILE tfcontents1.h5)
@@ -1116,10 +1094,10 @@ ADD_H5_TEST (tindicessub3 RESULT_CODE 0 --enable-error-stack -d 3d -s 0,1,2 -S 1
 ADD_H5_TEST (tindicessub4 RESULT_CODE 0 --enable-error-stack -d 4d -s 0,0,1,2  -c 2,2,3,2 -S 1,1,3,3 -k 1,1,2,2  TARGET_FILE taindices.h5)
 
 # Exceed the dimensions for subsetting
-ADD_H5ERR_MASK_TEST (texceedsubstart 1 "exceed dataset dims" --enable-error-stack -d 1d -s 1,3 taindices.h5)
-ADD_H5ERR_MASK_TEST (texceedsubcount 1 "exceed dataset dims" --enable-error-stack -d 1d -c 1,3 taindices.h5)
-ADD_H5ERR_MASK_TEST (texceedsubstride 1 "exceed dataset dims" --enable-error-stack -d 1d -S 1,3 taindices.h5)
-ADD_H5ERR_MASK_TEST (texceedsubblock 1 "exceed dataset dims" --enable-error-stack -d 1d -k 1,3 taindices.h5)
+ADD_H5_TEST (texceedsubstart RESULT_CODE 1 H5ERRREF "exceed dataset dims" --enable-error-stack -d 1d -s 1,3 TARGET_FILE taindices.h5)
+ADD_H5_TEST (texceedsubcount RESULT_CODE 1 H5ERRREF "exceed dataset dims" --enable-error-stack -d 1d -c 1,3 TARGET_FILE taindices.h5)
+ADD_H5_TEST (texceedsubstride RESULT_CODE 1 H5ERRREF "exceed dataset dims" --enable-error-stack -d 1d -S 1,3 TARGET_FILE taindices.h5)
+ADD_H5_TEST (texceedsubblock RESULT_CODE 1 H5ERRREF "exceed dataset dims" --enable-error-stack -d 1d -k 1,3 TARGET_FILE taindices.h5)
 
 # tests for filters
 # SZIP
@@ -1241,9 +1219,9 @@ endif ()
 
 # test for dataset region references
 ADD_H5_TEST (tdatareg RESULT_CODE 0 --enable-error-stack TARGET_FILE tdatareg.h5)
-ADD_H5ERR_MASK_TEST (tdataregR 0 "NULL token size" --enable-error-stack -R tdatareg.h5)
+ADD_H5_TEST (tdataregR RESULT_CODE 0 H5ERRREF "NULL token size" --enable-error-stack -R TARGET_FILE tdatareg.h5)
 ADD_H5_TEST (tattrreg RESULT_CODE 0 --enable-error-stack TARGET_FILE tattrreg.h5)
-ADD_H5ERR_MASK_TEST (tattrregR 0 "NULL token size" -R --enable-error-stack tattrreg.h5)
+ADD_H5_TEST (tattrregR RESULT_CODE 0 H5ERRREF "NULL token size" -R --enable-error-stack TARGET_FILE tattrreg.h5)
 ADD_H5_TEST (tbinregR OUTPUT_FILE tbinregR TARGET_FILE tdatareg.h5 RESULT_CODE 0 --enable-error-stack -d /Dataset1 -s 0 -R -y)
 
 # test for 1.12 region references
@@ -1272,18 +1250,18 @@ ADD_H5_TEST (torderattr3 RESULT_CODE 0 --enable-error-stack -H --sort_by=creatio
 ADD_H5_TEST (torderattr4 RESULT_CODE 0 --enable-error-stack -H --sort_by=creation_order --sort_order=descending TARGET_FILE torderattr.h5)
 
 # tests for link references and order
-ADD_H5ERR_MASK_TEST (torderlinks1 0 "unable to open external file, external link file name = 'fname'" --enable-error-stack --sort_by=name --sort_order=ascending tfcontents1.h5)
-ADD_H5ERR_MASK_TEST (torderlinks2 0 "unable to open external file, external link file name = 'fname'" --enable-error-stack --sort_by=name --sort_order=descending tfcontents1.h5)
+ADD_H5_TEST (torderlinks1 RESULT_CODE 0 H5ERRREF "unable to open external file, external link file name = 'fname'" --enable-error-stack --sort_by=name --sort_order=ascending TARGET_FILE tfcontents1.h5)
+ADD_H5_TEST (torderlinks2 RESULT_CODE 0 H5ERRREF "unable to open external file, external link file name = 'fname'" --enable-error-stack --sort_by=name --sort_order=descending TARGET_FILE tfcontents1.h5)
 
 # tests for floating point user defined printf format
 ADD_H5_TEST (tfpformat RESULT_CODE 0 --enable-error-stack --format=%.7f TARGET_FILE tfpformat.h5)
 
 # tests for traversal of external links
-ADD_H5ERR_MASK_TEST (textlinksrc 0 "Too many soft links in path" --enable-error-stack textlinksrc.h5)
-ADD_H5ERR_MASK_TEST (textlinkfar 0 "Too many soft links in path" --enable-error-stack textlinkfar.h5)
+ADD_H5_TEST (textlinksrc RESULT_CODE 0 H5ERRREF "Too many soft links in path" --enable-error-stack TARGET_FILE textlinksrc.h5)
+ADD_H5_TEST (textlinkfar RESULT_CODE 0 H5ERRREF "Too many soft links in path" --enable-error-stack TARGET_FILE textlinkfar.h5)
 
 # test for dangling external links
-ADD_H5ERR_MASK_TEST (textlink 0 "unable to open external file, external link file name = 'anotherfile'" --enable-error-stack textlink.h5)
+ADD_H5_TEST (textlink RESULT_CODE 0 H5ERRREF "unable to open external file, external link file name = 'anotherfile'" --enable-error-stack TARGET_FILE textlink.h5)
 
 # test for error stack display (BZ2048)
 ADD_H5ERR_MASK_ENV_TEST (filter_fail 1 "filter plugins disabled" "HDF5_PLUGIN_PRELOAD" "::" --enable-error-stack filter_fail.h5)
@@ -1292,24 +1270,24 @@ ADD_H5ERR_MASK_ENV_TEST (filter_fail 1 "filter plugins disabled" "HDF5_PLUGIN_PR
 ADD_H5_TEST (tall-6 OUTPUT_FILE tall-6 TARGET_FILE tall.h5 RESULT_CODE 0 --enable-error-stack -d /g1/g1.1/dset1.1.1 -y)
 
 # test for non-existing file
-ADD_H5ERR_MASK_TEST (non_existing 1 "unable to open file" --enable-error-stack tgroup.h5 non_existing.h5)
+ADD_H5_TEST (non_existing RESULT_CODE 1 H5ERRREF "unable to open file" --enable-error-stack tgroup.h5 TARGET_FILE non_existing.h5)
 
 # test to verify github issue#3790: infinite loop closing library
-ADD_H5ERR_MASK_TEST (infinite_loop 1 "unable to open file" 3790_infinite_loop.h5)
+ADD_H5_TEST (infinite_loop RESULT_CODE 1 H5ERRREF "unable to open file" TARGET_FILE 3790_infinite_loop.h5)
 
 # test to verify HDFFV-10333: error similar to H5O_attr_decode in the jira issue
-ADD_H5ERR_MASK_TEST (err_attr_dspace 1 "error getting attribute information" err_attr_dspace.h5)
+ADD_H5_TEST (err_attr_dspace RESULT_CODE 1 H5ERRREF "error getting attribute information" TARGET_FILE err_attr_dspace.h5)
 
 # test to verify HDFFV-9407: long double full precision
 # ADD_H5_GREP_TEST (t128bit_float 1 "1.123456789012345" -m %.35Lg t128bit_float.h5)
 
 # test to verify HDFFV-10480: out of bounds read in H5O_fill_new[old]_decode
-ADD_H5ERR_MASK_TEST (tCVE_2018_11206_fill_old 1 "" tCVE_2018_11206_fill_old.h5)
-ADD_H5ERR_MASK_TEST (tCVE_2018_11206_fill_new 1 "" tCVE_2018_11206_fill_new.h5)
+ADD_H5_TEST (tCVE_2018_11206_fill_old RESULT_CODE 1 H5ERRREF "" TARGET_FILE tCVE_2018_11206_fill_old.h5)
+ADD_H5_TEST (tCVE_2018_11206_fill_new RESULT_CODE 1 H5ERRREF "" TARGET_FILE tCVE_2018_11206_fill_new.h5)
 
 # test to verify fix for CVE-2021-37501: multiplication overflow in H5O__attr_decode()
 # https://github.com/ST4RF4LL/Something_Found/blob/main/HDF5_v1.13.0_h5dump_heap_overflow.assets/poc
-ADD_H5ERR_MASK_TEST (tCVE-2021-37501_attr_decode 1 "error getting attribute information" tCVE-2021-37501_attr_decode.h5)
+ADD_H5_TEST (tCVE-2021-37501_attr_decode RESULT_CODE 1 H5ERRREF "error getting attribute information" TARGET_FILE tCVE-2021-37501_attr_decode.h5)
 
 # onion VFD tests
 ADD_H5_TEST (tst_onion_objs RESULT_CODE 0 --enable-error-stack --vfd-name onion --vfd-info 3 TARGET_FILE tst_onion_objs.h5)

--- a/tools/test/h5dump/CMakeTests.cmake
+++ b/tools/test/h5dump/CMakeTests.cmake
@@ -463,6 +463,7 @@ endmacro ()
 #   testname - name of test to add
 #
 # REQUIRED KEYWORD ARGUMENTS:
+#   TARGET_FILE <filename> - the file to target with h5dump
 #   RESULT_CODE <code>    - expected return code after test execution. 0 is success
 #
 # OPTIONAL KEYWORD ARGUMENTS:
@@ -474,7 +475,7 @@ endmacro ()
 macro (ADD_H5_TEST testname)
   cmake_parse_arguments(ARG
     ""
-    "RESULT_CODE;APPLY_FILTERS"
+    "RESULT_CODE;APPLY_FILTERS;TARGET_FILE"
     "ANY_PATHS"
     ${ARGN}
   )
@@ -482,6 +483,10 @@ macro (ADD_H5_TEST testname)
   # Validate required parameters
   if (NOT DEFINED ARG_RESULT_CODE)
     message(FATAL_ERROR "ADD_H5_TEST: RESULT_CODE is required")
+  endif ()
+
+  if (NOT DEFINED ARG_TARGET_FILE)
+    message(FATAL_ERROR "ADD_H5_TEST: TARGET_FILE is required")
   endif ()
 
   # Validate optional parameters
@@ -524,7 +529,7 @@ macro (ADD_H5_TEST testname)
 
   # If using memchecker add tests without using scripts
   if (HDF5_ENABLE_USING_MEMCHECKER)
-    add_test (NAME H5DUMP-${testname} COMMAND ${CMAKE_CROSSCOMPILING_EMULATOR} $<TARGET_FILE:h5dump> ${ARG_ANY_PATHS} ${ARG_UNPARSED_ARGUMENTS})
+    add_test (NAME H5DUMP-${testname} COMMAND ${CMAKE_CROSSCOMPILING_EMULATOR} $<TARGET_FILE:h5dump> ${ARG_ANY_PATHS} ${ARG_UNPARSED_ARGUMENTS} ${ARG_TARGET_FILE})
     if (${ARG_RESULT_CODE})
       set_tests_properties (H5DUMP-${testname} PROPERTIES WILL_FAIL "true")
     endif ()
@@ -537,7 +542,7 @@ macro (ADD_H5_TEST testname)
         COMMAND "${CMAKE_COMMAND}"
             -D "TEST_EMULATOR=${CMAKE_CROSSCOMPILING_EMULATOR}"
             -D "TEST_PROGRAM=$<TARGET_FILE:h5dump>"
-            -D "TEST_ARGS:STRING=${ARG_ANY_PATHS};${ARG_UNPARSED_ARGUMENTS}"
+            -D "TEST_ARGS:STRING=${ARG_ANY_PATHS};${ARG_UNPARSED_ARGUMENTS};${ARG_TARGET_FILE}"
             -D "TEST_FOLDER=${PROJECT_BINARY_DIR}/testfiles/std"
             -D "TEST_OUTPUT=${testname}.out"
             -D "TEST_EXPECT=${ARG_RESULT_CODE}"
@@ -1033,12 +1038,12 @@ endmacro ()
 ADD_HELP_TEST(help 0 -h)
 
 # test data output redirection
-#ADD_H5_TEST (tnoddl RESULT_CODE RESULT_CODE 0 --enable-error-stack -O -y packedbits.h5)
-ADD_H5_TEST (tnoddl RESULT_CODE 0 --enable-error-stack --ddl -y packedbits.h5)
-#ADD_H5_TEST (tnodata RESULT_CODE 0 --enable-error-stack -o packedbits.h5)
-ADD_H5_TEST (tnodata RESULT_CODE 0 --enable-error-stack --output packedbits.h5)
-ADD_H5_TEST (tnoattrddl RESULT_CODE 0 --enable-error-stack -O -y tattr.h5)
-ADD_H5_TEST (tnoattrdata RESULT_CODE 0 --enable-error-stack -A -o tattr.h5)
+#ADD_H5_TEST (tnoddl RESULT_CODE RESULT_CODE 0 --enable-error-stack -O -y TARGET_FILE packedbits.h5)
+ADD_H5_TEST (tnoddl RESULT_CODE 0 --enable-error-stack --ddl -y TARGET_FILE packedbits.h5)
+#ADD_H5_TEST (tnodata RESULT_CODE 0 --enable-error-stack -o TARGET_FILE packedbits.h5)
+ADD_H5_TEST (tnodata RESULT_CODE 0 --enable-error-stack --output TARGET_FILE packedbits.h5)
+ADD_H5_TEST (tnoattrddl RESULT_CODE 0 --enable-error-stack -O -y TARGET_FILE tattr.h5)
+ADD_H5_TEST (tnoattrdata RESULT_CODE 0 --enable-error-stack -A -o TARGET_FILE tattr.h5)
 ADD_H5_TEST_EXPORT (trawdatafile packedbits.h5 0 --enable-error-stack -y -o)
 ADD_H5_TEST_EXPORT (tnoddlfile packedbits.h5 0 --enable-error-stack -O -y -o)
 ADD_H5_TEST_EXPORT (trawssetfile tdset.h5 0 --enable-error-stack -d "/dset1[1,1;;;]" -y -o)
@@ -1046,152 +1051,152 @@ ADD_H5_TEST_EXPORT (trawssetfile tdset.h5 0 --enable-error-stack -d "/dset1[1,1;
 ADD_H5_TEST_EXPORT_DDL (twithddlfile packedbits.h5 0 twithddl --enable-error-stack --ddl=twithddl.txt -y -o)
 
 # test for maximum display datasets
-ADD_H5_TEST (twidedisplay RESULT_CODE 0 --enable-error-stack -w0 packedbits.h5)
+ADD_H5_TEST (twidedisplay RESULT_CODE 0 --enable-error-stack -w0 TARGET_FILE packedbits.h5)
 
 # test for unwritten datasets
-ADD_H5_TEST (tintsnodata RESULT_CODE 0 --enable-error-stack -p tintsnodata.h5)
+ADD_H5_TEST (tintsnodata RESULT_CODE 0 --enable-error-stack -p TARGET_FILE tintsnodata.h5)
 
 # test for signed/unsigned datasets
-ADD_H5_TEST (packedbits RESULT_CODE 0 --enable-error-stack packedbits.h5)
+ADD_H5_TEST (packedbits RESULT_CODE 0 --enable-error-stack TARGET_FILE packedbits.h5)
 # test for compound signed/unsigned datasets
-ADD_H5_TEST (tcmpdintarray RESULT_CODE 0 --enable-error-stack tcmpdintarray.h5)
-ADD_H5_TEST (tcmpdints RESULT_CODE 0 --enable-error-stack tcmpdints.h5)
-ADD_H5_TEST (tcmpdintsize RESULT_CODE 0 --enable-error-stack tcmpdintsize.h5)
+ADD_H5_TEST (tcmpdintarray RESULT_CODE 0 --enable-error-stack TARGET_FILE tcmpdintarray.h5)
+ADD_H5_TEST (tcmpdints RESULT_CODE 0 --enable-error-stack TARGET_FILE tcmpdints.h5)
+ADD_H5_TEST (tcmpdintsize RESULT_CODE 0 --enable-error-stack TARGET_FILE tcmpdintsize.h5)
 # test for signed/unsigned scalar datasets
-ADD_H5_TEST (tscalarintsize RESULT_CODE 0 --enable-error-stack tscalarintsize.h5)
+ADD_H5_TEST (tscalarintsize RESULT_CODE 0 --enable-error-stack TARGET_FILE tscalarintsize.h5)
 # test for signed/unsigned attributes
-ADD_H5_TEST (tattrintsize RESULT_CODE 0 --enable-error-stack tattrintsize.h5)
+ADD_H5_TEST (tattrintsize RESULT_CODE 0 --enable-error-stack TARGET_FILE tattrintsize.h5)
 # test for compound signed/unsigned attributes
-ADD_H5_TEST (tcmpdattrintsize RESULT_CODE 0 --enable-error-stack tcmpdattrintsize.h5)
+ADD_H5_TEST (tcmpdattrintsize RESULT_CODE 0 --enable-error-stack TARGET_FILE tcmpdattrintsize.h5)
 # test for signed/unsigned scalar attributes
-ADD_H5_TEST (tscalarattrintsize RESULT_CODE 0 --enable-error-stack tscalarattrintsize.h5)
+ADD_H5_TEST (tscalarattrintsize RESULT_CODE 0 --enable-error-stack TARGET_FILE tscalarattrintsize.h5)
 # test for string scalar dataset and attribute
-ADD_H5_TEST (tscalarstring RESULT_CODE 0 --enable-error-stack tscalarstring.h5)
+ADD_H5_TEST (tscalarstring RESULT_CODE 0 --enable-error-stack TARGET_FILE tscalarstring.h5)
 # test for signed/unsigned scalar datasets with attributes
-ADD_H5_TEST (tscalarintattrsize RESULT_CODE 0 --enable-error-stack tscalarintattrsize.h5)
+ADD_H5_TEST (tscalarintattrsize RESULT_CODE 0 --enable-error-stack TARGET_FILE tscalarintattrsize.h5)
 # test for signed/unsigned datasets attributes
-ADD_H5_TEST (tintsattrs RESULT_CODE 0 --enable-error-stack tintsattrs.h5)
+ADD_H5_TEST (tintsattrs RESULT_CODE 0 --enable-error-stack TARGET_FILE tintsattrs.h5)
 # test for displaying groups
-ADD_H5_TEST (tgroup-1 RESULT_CODE 0 --enable-error-stack tgroup.h5)
+ADD_H5_TEST (tgroup-1 RESULT_CODE 0 --enable-error-stack TARGET_FILE tgroup.h5)
 # test for displaying the selected groups
 ADD_H5ERR_MASK_TEST (tgroup-2 1 "h5dump error: unable to open group \"/y\"" --enable-error-stack --group=/g2 --group / -g /y tgroup.h5)
 
 # test for displaying simple space datasets
-ADD_H5_TEST (tdset-1 RESULT_CODE 0 --enable-error-stack tdset.h5)
+ADD_H5_TEST (tdset-1 RESULT_CODE 0 --enable-error-stack TARGET_FILE tdset.h5)
 # test for displaying selected datasets
 ADD_H5ERR_MASK_TEST (tdset-2 1 "h5dump error: unable to get link info from \"dset3\"" --enable-error-stack -H -d dset1 -d /dset2 --dataset=dset3 tdset.h5)
 
 # test for displaying attributes
-ADD_H5_TEST (tattr-1 RESULT_CODE 0 --enable-error-stack tattr.h5)
+ADD_H5_TEST (tattr-1 RESULT_CODE 0 --enable-error-stack TARGET_FILE tattr.h5)
 # test for displaying the selected attributes of string type and scalar space
-ADD_H5_TEST (tattr-2 RESULT_CODE 0 --enable-error-stack -a /\\\\/attr1 --attribute /attr4 --attribute=/attr5 tattr.h5)
-ADD_H5_TEST (tattr-2-N RESULT_CODE 0 --enable-error-stack  tattr.h5 ANY_PATHS /\\\\/attr1 /attr4 /attr5)
+ADD_H5_TEST (tattr-2 RESULT_CODE 0 --enable-error-stack -a /\\\\/attr1 --attribute /attr4 --attribute=/attr5 TARGET_FILE tattr.h5)
+ADD_H5_TEST (tattr-2-N RESULT_CODE 0 --enable-error-stack  TARGET_FILE tattr.h5 ANY_PATHS /\\\\/attr1 /attr4 /attr5)
 # test for header and error messages
 ADD_H5ERR_MASK_TEST (tattr-3 1 "h5dump error: unable to open attribute \"attr\"" --enable-error-stack --header -a /attr2 --attribute=/attr tattr.h5)
 # test for displaying at least 9 attributes on root from a be machine
-ADD_H5_TEST (tattr-4_be RESULT_CODE 0 --enable-error-stack tattr4_be.h5)
+ADD_H5_TEST (tattr-4_be RESULT_CODE 0 --enable-error-stack TARGET_FILE tattr4_be.h5)
 # test for displaying attributes in shared datatype (also in group and dataset)
-ADD_H5_TEST (tnamed_dtype_attr RESULT_CODE 0 --enable-error-stack tnamed_dtype_attr.h5)
+ADD_H5_TEST (tnamed_dtype_attr RESULT_CODE 0 --enable-error-stack TARGET_FILE tnamed_dtype_attr.h5)
 
 # test for displaying soft links and user-defined links
-ADD_H5_TEST (tslink-1 RESULT_CODE 0 --enable-error-stack tslink.h5)
-ADD_H5_TEST (tudlink-1 RESULT_CODE 0 --enable-error-stack tudlink.h5)
+ADD_H5_TEST (tslink-1 RESULT_CODE 0 --enable-error-stack TARGET_FILE tslink.h5)
+ADD_H5_TEST (tudlink-1 RESULT_CODE 0 --enable-error-stack TARGET_FILE tudlink.h5)
 # test for displaying the selected link
-ADD_H5_TEST (tslink-2 RESULT_CODE 0 --enable-error-stack -l slink2 tslink.h5)
-ADD_H5_TEST (tslink-2-N RESULT_CODE 0 --enable-error-stack tslink.h5 ANY_PATHS slink2 )
-ADD_H5_TEST (tudlink-2 RESULT_CODE 0 --enable-error-stack -l udlink2 tudlink.h5)
+ADD_H5_TEST (tslink-2 RESULT_CODE 0 --enable-error-stack -l slink2 TARGET_FILE tslink.h5)
+ADD_H5_TEST (tslink-2-N RESULT_CODE 0 --enable-error-stack TARGET_FILE tslink.h5 ANY_PATHS slink2 )
+ADD_H5_TEST (tudlink-2 RESULT_CODE 0 --enable-error-stack -l udlink2 TARGET_FILE tudlink.h5)
 # test for displaying dangling soft links
 ADD_H5ERR_MASK_TEST (tslink-D 0 "component not found" --enable-error-stack -d /slink1 tslink.h5)
 
 # tests for hard links
-ADD_H5_TEST (thlink-1 RESULT_CODE 0 --enable-error-stack thlink.h5)
-ADD_H5_TEST (thlink-2 RESULT_CODE 0 --enable-error-stack -d /g1/dset2 --dataset /dset1 --dataset=/g1/g1.1/dset3 thlink.h5)
-ADD_H5_TEST (thlink-3 RESULT_CODE 0 --enable-error-stack -d /g1/g1.1/dset3 --dataset /g1/dset2 --dataset=/dset1 thlink.h5)
-ADD_H5_TEST (thlink-4 RESULT_CODE 0 --enable-error-stack -g /g1 thlink.h5)
-ADD_H5_TEST (thlink-4-N RESULT_CODE 0 --enable-error-stack thlink.h5 ANY_PATHS /g1)
-ADD_H5_TEST (thlink-5 RESULT_CODE 0 --enable-error-stack -d /dset1 -g /g2 -d /g1/dset2 thlink.h5)
-ADD_H5_TEST (thlink-5-N RESULT_CODE 0 --enable-error-stack thlink.h5 ANY_PATHS /dset1 /g2 /g1/dset2)
+ADD_H5_TEST (thlink-1 RESULT_CODE 0 --enable-error-stack TARGET_FILE thlink.h5)
+ADD_H5_TEST (thlink-2 RESULT_CODE 0 --enable-error-stack -d /g1/dset2 --dataset /dset1 --dataset=/g1/g1.1/dset3 TARGET_FILE thlink.h5)
+ADD_H5_TEST (thlink-3 RESULT_CODE 0 --enable-error-stack -d /g1/g1.1/dset3 --dataset /g1/dset2 --dataset=/dset1 TARGET_FILE thlink.h5)
+ADD_H5_TEST (thlink-4 RESULT_CODE 0 --enable-error-stack -g /g1 TARGET_FILE thlink.h5)
+ADD_H5_TEST (thlink-4-N RESULT_CODE 0 --enable-error-stack TARGET_FILE thlink.h5 ANY_PATHS /g1)
+ADD_H5_TEST (thlink-5 RESULT_CODE 0 --enable-error-stack -d /dset1 -g /g2 -d /g1/dset2 TARGET_FILE thlink.h5)
+ADD_H5_TEST (thlink-5-N RESULT_CODE 0 --enable-error-stack TARGET_FILE thlink.h5 ANY_PATHS /dset1 /g2 /g1/dset2)
 
 # tests for compound data types
-ADD_H5_TEST (tcomp-1 RESULT_CODE 0 --enable-error-stack tcompound.h5)
+ADD_H5_TEST (tcomp-1 RESULT_CODE 0 --enable-error-stack TARGET_FILE tcompound.h5)
 # test for named data types
-ADD_H5_TEST (tcomp-2 RESULT_CODE 0 --enable-error-stack -t /type1 --datatype /type2 --datatype=/group1/type3 tcompound.h5)
-ADD_H5_TEST (tcomp-2-N RESULT_CODE 0 --enable-error-stack tcompound.h5 ANY_PATHS /type1 /type2 /group1/type3)
+ADD_H5_TEST (tcomp-2 RESULT_CODE 0 --enable-error-stack -t /type1 --datatype /type2 --datatype=/group1/type3 TARGET_FILE tcompound.h5)
+ADD_H5_TEST (tcomp-2-N RESULT_CODE 0 --enable-error-stack TARGET_FILE tcompound.h5 ANY_PATHS /type1 /type2 /group1/type3)
 # test for unnamed type
 ADD_H5ERR_MASK_TEST (tcomp-3 0 "object '#6632' doesn't exist" "--enable-error-stack;-t;/#6632;-g;/group2;tcompound.h5")
 # test complicated compound datatype
-ADD_H5_TEST (tcomp-4 RESULT_CODE 0 --enable-error-stack tcompound_complex.h5)
-ADD_H5_TEST (tcompound_complex2 RESULT_CODE 0 --enable-error-stack tcompound_complex2.h5)
+ADD_H5_TEST (tcomp-4 RESULT_CODE 0 --enable-error-stack TARGET_FILE tcompound_complex.h5)
+ADD_H5_TEST (tcompound_complex2 RESULT_CODE 0 --enable-error-stack TARGET_FILE tcompound_complex2.h5)
 # tests for bitfields and opaque data types
 if (H5_WORDS_BIGENDIAN)
-  ADD_H5_TEST (tbitnopaque_be RESULT_CODE 0 --enable-error-stack tbitnopaque.h5)
+  ADD_H5_TEST (tbitnopaque_be RESULT_CODE 0 --enable-error-stack TARGET_FILE tbitnopaque.h5)
 else ()
-  ADD_H5_TEST (tbitnopaque_le RESULT_CODE 0 --enable-error-stack tbitnopaque.h5)
+  ADD_H5_TEST (tbitnopaque_le RESULT_CODE 0 --enable-error-stack TARGET_FILE tbitnopaque.h5)
 endif ()
 
 # test for the nested compound type
-ADD_H5_TEST (tnestcomp-1 RESULT_CODE 0 --enable-error-stack tnestedcomp.h5)
-ADD_H5_TEST (tnestedcmpddt RESULT_CODE 0 --enable-error-stack tnestedcmpddt.h5)
+ADD_H5_TEST (tnestcomp-1 RESULT_CODE 0 --enable-error-stack TARGET_FILE tnestedcomp.h5)
+ADD_H5_TEST (tnestedcmpddt RESULT_CODE 0 --enable-error-stack TARGET_FILE tnestedcmpddt.h5)
 
 # test for options
 ADD_H5ERR_MASK_TEST (tall-1 0 "unable to open external file, external link file name = 'somefile'" --enable-error-stack tall.h5)
-ADD_H5_TEST (tall-2 RESULT_CODE 0 --enable-error-stack --header -g /g1/g1.1 -a attr2 tall.h5)
-ADD_H5_TEST (tall-3 RESULT_CODE 0 --enable-error-stack -d /g2/dset2.1 -l /g1/g1.2/g1.2.1/slink tall.h5)
-ADD_H5_TEST (tall-3-N RESULT_CODE 0 --enable-error-stack  tall.h5 ANY_PATHS /g2/dset2.1 /g1/g1.2/g1.2.1/slink)
-ADD_H5_TEST (tall-7 RESULT_CODE 0 --enable-error-stack -a attr1 tall.h5)
-ADD_H5_TEST (tall-7N RESULT_CODE 0 --enable-error-stack tall.h5 ANY_PATHS attr1)
+ADD_H5_TEST (tall-2 RESULT_CODE 0 --enable-error-stack --header -g /g1/g1.1 -a attr2 TARGET_FILE tall.h5)
+ADD_H5_TEST (tall-3 RESULT_CODE 0 --enable-error-stack -d /g2/dset2.1 -l /g1/g1.2/g1.2.1/slink TARGET_FILE tall.h5)
+ADD_H5_TEST (tall-3-N RESULT_CODE 0 --enable-error-stack  TARGET_FILE tall.h5 ANY_PATHS /g2/dset2.1 /g1/g1.2/g1.2.1/slink)
+ADD_H5_TEST (tall-7 RESULT_CODE 0 --enable-error-stack -a attr1 TARGET_FILE tall.h5)
+ADD_H5_TEST (tall-7N RESULT_CODE 0 --enable-error-stack TARGET_FILE tall.h5 ANY_PATHS attr1)
 
 # test for loop detection
-ADD_H5_TEST (tloop-1 RESULT_CODE 0 --enable-error-stack tloop.h5)
+ADD_H5_TEST (tloop-1 RESULT_CODE 0 --enable-error-stack TARGET_FILE tloop.h5)
 
 # test for string
-ADD_H5_TEST (tstr-1 RESULT_CODE 0 --enable-error-stack tstr.h5)
-ADD_H5_TEST (tstr-2 RESULT_CODE 0 --enable-error-stack tstr2.h5)
+ADD_H5_TEST (tstr-1 RESULT_CODE 0 --enable-error-stack TARGET_FILE tstr.h5)
+ADD_H5_TEST (tstr-2 RESULT_CODE 0 --enable-error-stack TARGET_FILE tstr2.h5)
 
 # test for file created by Lib SAF team
-ADD_H5_TEST (tsaf RESULT_CODE 0 --enable-error-stack tsaf.h5)
+ADD_H5_TEST (tsaf RESULT_CODE 0 --enable-error-stack TARGET_FILE tsaf.h5)
 
 # test for file with variable length data
-ADD_H5_TEST (tvldtypes1 RESULT_CODE 0 --enable-error-stack tvldtypes1.h5)
-ADD_H5_TEST (tvldtypes2 RESULT_CODE 0 --enable-error-stack tvldtypes2.h5)
-ADD_H5_TEST (tvldtypes3 RESULT_CODE 0 --enable-error-stack tvldtypes3.h5)
-ADD_H5_TEST (tvldtypes4 RESULT_CODE 0 --enable-error-stack tvldtypes4.h5)
-ADD_H5_TEST (tvldtypes5 RESULT_CODE 0 --enable-error-stack tvldtypes5.h5)
+ADD_H5_TEST (tvldtypes1 RESULT_CODE 0 --enable-error-stack TARGET_FILE tvldtypes1.h5)
+ADD_H5_TEST (tvldtypes2 RESULT_CODE 0 --enable-error-stack TARGET_FILE tvldtypes2.h5)
+ADD_H5_TEST (tvldtypes3 RESULT_CODE 0 --enable-error-stack TARGET_FILE tvldtypes3.h5)
+ADD_H5_TEST (tvldtypes4 RESULT_CODE 0 --enable-error-stack TARGET_FILE tvldtypes4.h5)
+ADD_H5_TEST (tvldtypes5 RESULT_CODE 0 --enable-error-stack TARGET_FILE tvldtypes5.h5)
 
 # test for file with variable length string data
-ADD_H5_TEST (tvlstr RESULT_CODE 0 --enable-error-stack tvlstr.h5)
-ADD_H5_TEST (tvlenstr_array RESULT_CODE 0 --enable-error-stack tvlenstr_array.h5)
+ADD_H5_TEST (tvlstr RESULT_CODE 0 --enable-error-stack TARGET_FILE tvlstr.h5)
+ADD_H5_TEST (tvlenstr_array RESULT_CODE 0 --enable-error-stack TARGET_FILE tvlenstr_array.h5)
 
 # test for files with array data
-ADD_H5_TEST (tarray1 RESULT_CODE 0 --enable-error-stack tarray1.h5)
+ADD_H5_TEST (tarray1 RESULT_CODE 0 --enable-error-stack TARGET_FILE tarray1.h5)
 # # added for bug# 2092 - tarray1_big.h5
 ADD_H5ERR_MASK_TEST (tarray1_big 0 "NULL token size" --enable-error-stack -R tarray1_big.h5)
-ADD_H5_TEST (tarray2 RESULT_CODE 0 --enable-error-stack tarray2.h5)
-ADD_H5_TEST (tarray3 RESULT_CODE 0 --enable-error-stack tarray3.h5)
-ADD_H5_TEST (tarray4 RESULT_CODE 0 --enable-error-stack tarray4.h5)
-ADD_H5_TEST (tarray5 RESULT_CODE 0 --enable-error-stack tarray5.h5)
-ADD_H5_TEST (tarray6 RESULT_CODE 0 --enable-error-stack tarray6.h5)
-ADD_H5_TEST (tarray7 RESULT_CODE 0 --enable-error-stack tarray7.h5)
-ADD_H5_TEST (tarray8 RESULT_CODE 0 --enable-error-stack tarray8.h5)
+ADD_H5_TEST (tarray2 RESULT_CODE 0 --enable-error-stack TARGET_FILE tarray2.h5)
+ADD_H5_TEST (tarray3 RESULT_CODE 0 --enable-error-stack TARGET_FILE tarray3.h5)
+ADD_H5_TEST (tarray4 RESULT_CODE 0 --enable-error-stack TARGET_FILE tarray4.h5)
+ADD_H5_TEST (tarray5 RESULT_CODE 0 --enable-error-stack TARGET_FILE tarray5.h5)
+ADD_H5_TEST (tarray6 RESULT_CODE 0 --enable-error-stack TARGET_FILE tarray6.h5)
+ADD_H5_TEST (tarray7 RESULT_CODE 0 --enable-error-stack TARGET_FILE tarray7.h5)
+ADD_H5_TEST (tarray8 RESULT_CODE 0 --enable-error-stack TARGET_FILE tarray8.h5)
 
 # test for wildcards in filename (does not work with cmake)
 #ADD_H5_MASK_TEST (tstarfile 0 --enable-error-stack -H -d Dataset1 tarr*.h5)
 #ADD_H5_MASK_TEST (tqmarkfile 0 --enable-error-stack -H -d Dataset1 tarray?.h5)
-ADD_H5_TEST (tmultifile RESULT_CODE 0 --enable-error-stack -H -d Dataset1 tarray2.h5 tarray3.h5 tarray4.h5 tarray5.h5 tarray6.h5 tarray7.h5)
+ADD_H5_TEST (tmultifile RESULT_CODE 0 --enable-error-stack -H -d Dataset1 tarray2.h5 tarray3.h5 tarray4.h5 tarray5.h5 tarray6.h5 TARGET_FILE tarray7.h5)
 
 # test for files with empty data
-ADD_H5_TEST (tempty RESULT_CODE 0 --enable-error-stack tempty.h5)
+ADD_H5_TEST (tempty RESULT_CODE 0 --enable-error-stack TARGET_FILE tempty.h5)
 
 # test for files with groups that have comments
-ADD_H5_TEST (tgrp_comments RESULT_CODE 0 --enable-error-stack tgrp_comments.h5)
+ADD_H5_TEST (tgrp_comments RESULT_CODE 0 --enable-error-stack TARGET_FILE tgrp_comments.h5)
 
 # test the --filedriver flag
-ADD_H5_TEST (tsplit_file RESULT_CODE 0 --enable-error-stack --filedriver=split tsplit_file)
-ADD_H5_TEST (tfamily RESULT_CODE 0 --enable-error-stack --filedriver=family tfamily%05d.h5)
-ADD_H5_TEST (tmulti RESULT_CODE 0 --enable-error-stack --filedriver=multi tmulti)
+ADD_H5_TEST (tsplit_file RESULT_CODE 0 --enable-error-stack --filedriver=split TARGET_FILE tsplit_file)
+ADD_H5_TEST (tfamily RESULT_CODE 0 --enable-error-stack --filedriver=family TARGET_FILE tfamily%05d.h5)
+ADD_H5_TEST (tmulti RESULT_CODE 0 --enable-error-stack --filedriver=multi TARGET_FILE tmulti)
 
 # test for files with group names which reach > 1024 bytes in size
-ADD_H5_TEST (tlarge_objname RESULT_CODE 0 --enable-error-stack -w157 tlarge_objname.h5)
+ADD_H5_TEST (tlarge_objname RESULT_CODE 0 --enable-error-stack -w157 TARGET_FILE tlarge_objname.h5)
 
 # test '-A' to suppress data but print attr's
 ADD_H5ERR_MASK_TEST (tall-2A 0 "unable to open external file, external link file name = 'somefile'" --enable-error-stack -A tall.h5)
@@ -1203,80 +1208,80 @@ ADD_H5ERR_MASK_TEST (tall-2A0 0 "unable to open external file, external link fil
 ADD_H5ERR_MASK_TEST (tall-2B 0 "unable to open external file, external link file name = 'somefile'" --enable-error-stack -A -r tall.h5)
 
 # test Subsetting
-ADD_H5_TEST (tall-4s RESULT_CODE 0 --enable-error-stack --dataset=/g1/g1.1/dset1.1.1 --start=1,1 --stride=2,3 --count=3,2 --block=1,1 tall.h5)
-ADD_H5_TEST (tall-5s RESULT_CODE 0 --enable-error-stack -d "/g1/g1.1/dset1.1.2[0;2;10;]" tall.h5)
-ADD_H5_TEST (tdset-3s RESULT_CODE 0 --enable-error-stack -d "/dset1[1,1;;;]" tdset.h5)
-ADD_H5_TEST (tno-subset RESULT_CODE 0 --enable-error-stack --no-compact-subset -d "AHFINDERDIRECT::ah_centroid_t[0] it=0 tl=0" tno-subset.h5)
+ADD_H5_TEST (tall-4s RESULT_CODE 0 --enable-error-stack --dataset=/g1/g1.1/dset1.1.1 --start=1,1 --stride=2,3 --count=3,2 --block=1,1 TARGET_FILE tall.h5)
+ADD_H5_TEST (tall-5s RESULT_CODE 0 --enable-error-stack -d "/g1/g1.1/dset1.1.2[0;2;10;]" TARGET_FILE tall.h5)
+ADD_H5_TEST (tdset-3s RESULT_CODE 0 --enable-error-stack -d "/dset1[1,1;;;]" TARGET_FILE tdset.h5)
+ADD_H5_TEST (tno-subset RESULT_CODE 0 --enable-error-stack --no-compact-subset -d "AHFINDERDIRECT::ah_centroid_t[0] it=0 tl=0" TARGET_FILE  tno-subset.h5)
 
-ADD_H5_TEST (tints4dimsCount2 RESULT_CODE 0 --enable-error-stack -d FourDimInts -s 0,0,0,0 -c 2,2,2,2 tints4dims.h5)
-ADD_H5_TEST (tints4dimsBlock2 RESULT_CODE 0 --enable-error-stack -d FourDimInts -s 0,0,0,0 -c 1,1,1,1 -k 2,2,2,2 tints4dims.h5)
-ADD_H5_TEST (tints4dimsStride2 RESULT_CODE 0 --enable-error-stack -d FourDimInts -s 0,0,0,0 -S 2,2,2,2 -c 2,2,2,2 tints4dims.h5)
-ADD_H5_TEST (tints4dimsCountEq RESULT_CODE 0 --enable-error-stack -d FourDimInts -s 0,0,0,0 -S 2,2,1,1 -k 1,2,1,1 -c 2,2,4,4 tints4dims.h5)
-ADD_H5_TEST (tints4dimsBlockEq RESULT_CODE 0 --enable-error-stack -d FourDimInts -s 0,0,0,0 -S 2,2,1,1 -c 2,2,1,1 -k 1,2,4,4 tints4dims.h5)
+ADD_H5_TEST (tints4dimsCount2 RESULT_CODE 0 --enable-error-stack -d FourDimInts -s 0,0,0,0 -c 2,2,2,2 TARGET_FILE tints4dims.h5)
+ADD_H5_TEST (tints4dimsBlock2 RESULT_CODE 0 --enable-error-stack -d FourDimInts -s 0,0,0,0 -c 1,1,1,1 -k 2,2,2,2 TARGET_FILE tints4dims.h5)
+ADD_H5_TEST (tints4dimsStride2 RESULT_CODE 0 --enable-error-stack -d FourDimInts -s 0,0,0,0 -S 2,2,2,2 -c 2,2,2,2 TARGET_FILE tints4dims.h5)
+ADD_H5_TEST (tints4dimsCountEq RESULT_CODE 0 --enable-error-stack -d FourDimInts -s 0,0,0,0 -S 2,2,1,1 -k 1,2,1,1 -c 2,2,4,4 TARGET_FILE tints4dims.h5)
+ADD_H5_TEST (tints4dimsBlockEq RESULT_CODE 0 --enable-error-stack -d FourDimInts -s 0,0,0,0 -S 2,2,1,1 -c 2,2,1,1 -k 1,2,4,4 TARGET_FILE tints4dims.h5)
 
 # test printing characters in ASCII instead of decimal
-ADD_H5_TEST (tchar1 RESULT_CODE 0 --enable-error-stack -r tchar.h5)
+ADD_H5_TEST (tchar1 RESULT_CODE 0 --enable-error-stack -r TARGET_FILE tchar.h5)
 
 # test datatypes in ASCII and UTF8
-ADD_H5_TEST (charsets RESULT_CODE 0 --enable-error-stack charsets.h5)
+ADD_H5_TEST (charsets RESULT_CODE 0 --enable-error-stack TARGET_FILE charsets.h5)
 
 # rev. 2004
 # tests for super block
-ADD_H5_TEST (tboot1 RESULT_CODE 0 --enable-error-stack -H -B -d dset tfcontents1.h5)
-ADD_H5_TEST (tboot2 RESULT_CODE 0 --enable-error-stack -B tfcontents2.h5)
-ADD_H5_TEST (tboot2A RESULT_CODE 0 --enable-error-stack --boot-block tfcontents2.h5)
-ADD_H5_TEST (tboot2B RESULT_CODE 0 --enable-error-stack --superblock tfcontents2.h5)
-ADD_H5_TEST (file_space RESULT_CODE 0 --enable-error-stack -B file_space.h5)
-ADD_H5_TEST (file_space_cache RESULT_CODE 0 --enable-error-stack=2 --page-buffer-size=16384 -B file_space.h5)
+ADD_H5_TEST (tboot1 RESULT_CODE 0 --enable-error-stack -H -B -d dset TARGET_FILE tfcontents1.h5)
+ADD_H5_TEST (tboot2 RESULT_CODE 0 --enable-error-stack -B TARGET_FILE tfcontents2.h5)
+ADD_H5_TEST (tboot2A RESULT_CODE 0 --enable-error-stack --boot-block TARGET_FILE tfcontents2.h5)
+ADD_H5_TEST (tboot2B RESULT_CODE 0 --enable-error-stack --superblock TARGET_FILE tfcontents2.h5)
+ADD_H5_TEST (file_space RESULT_CODE 0 --enable-error-stack -B TARGET_FILE file_space.h5)
+ADD_H5_TEST (file_space_cache RESULT_CODE 0 --enable-error-stack=2 --page-buffer-size=16384 -B TARGET_FILE file_space.h5)
 
 # test -p with a non existing dataset
 ADD_H5ERR_MASK_TEST (tperror 1 "h5dump error: unable to get link info from \"bogus\"" --enable-error-stack -p -d bogus tfcontents1.h5)
 
 # test for file contents
-ADD_H5_TEST (tcontents RESULT_CODE 0 --enable-error-stack -n tfcontents1.h5)
-ADD_H5_TEST (tordercontents1 RESULT_CODE 0 --enable-error-stack -n --sort_by=name --sort_order=ascending tfcontents1.h5)
-ADD_H5_TEST (tordercontents2 RESULT_CODE 0 --enable-error-stack -n --sort_by=name --sort_order=descending tfcontents1.h5)
-ADD_H5_TEST (tattrcontents1 RESULT_CODE 0 --enable-error-stack -n 1 --sort_order=ascending tall.h5)
-ADD_H5_TEST (tattrcontents2 RESULT_CODE 0 --enable-error-stack -n 1 --sort_order=descending tall.h5)
+ADD_H5_TEST (tcontents RESULT_CODE 0 --enable-error-stack -n TARGET_FILE tfcontents1.h5)
+ADD_H5_TEST (tordercontents1 RESULT_CODE 0 --enable-error-stack -n --sort_by=name --sort_order=ascending TARGET_FILE tfcontents1.h5)
+ADD_H5_TEST (tordercontents2 RESULT_CODE 0 --enable-error-stack -n --sort_by=name --sort_order=descending TARGET_FILE tfcontents1.h5)
+ADD_H5_TEST (tattrcontents1 RESULT_CODE 0 --enable-error-stack -n 1 --sort_order=ascending TARGET_FILE tall.h5)
+ADD_H5_TEST (tattrcontents2 RESULT_CODE 0 --enable-error-stack -n 1 --sort_order=descending TARGET_FILE tall.h5)
 
 # tests for storage layout
 # compact
-ADD_H5_TEST (tcompact RESULT_CODE 0 --enable-error-stack -H -p -d compact tfilters.h5)
+ADD_H5_TEST (tcompact RESULT_CODE 0 --enable-error-stack -H -p -d compact TARGET_FILE tfilters.h5)
 # contiguous
-ADD_H5_TEST (tcontiguos RESULT_CODE 0 --enable-error-stack -H -p -d contiguous tfilters.h5)
+ADD_H5_TEST (tcontiguos RESULT_CODE 0 --enable-error-stack -H -p -d contiguous TARGET_FILE tfilters.h5)
 # chunked
-ADD_H5_TEST (tchunked RESULT_CODE 0 --enable-error-stack -H -p -d chunked tfilters.h5)
+ADD_H5_TEST (tchunked RESULT_CODE 0 --enable-error-stack -H -p -d chunked TARGET_FILE tfilters.h5)
 # external
-ADD_H5_TEST (texternal RESULT_CODE 0 --enable-error-stack -H -p -d external tfilters.h5)
+ADD_H5_TEST (texternal RESULT_CODE 0 --enable-error-stack -H -p -d external TARGET_FILE tfilters.h5)
 
 # fill values
-ADD_H5_TEST (tfill RESULT_CODE 0 --enable-error-stack -p tfvalues.h5)
+ADD_H5_TEST (tfill RESULT_CODE 0 --enable-error-stack -p TARGET_FILE tfvalues.h5)
 
 # several datatype, with references , print path
-ADD_H5_TEST (treference RESULT_CODE 0 --enable-error-stack  tattr2.h5)
+ADD_H5_TEST (treference RESULT_CODE 0 --enable-error-stack  TARGET_FILE tattr2.h5)
 
 # escape/not escape non printable characters
-ADD_H5_TEST (tstringe RESULT_CODE 0 --enable-error-stack -e tstr3.h5)
-ADD_H5_TEST (tstring RESULT_CODE 0 --enable-error-stack tstr3.h5)
+ADD_H5_TEST (tstringe RESULT_CODE 0 --enable-error-stack -e TARGET_FILE tstr3.h5)
+ADD_H5_TEST (tstring RESULT_CODE 0 --enable-error-stack TARGET_FILE tstr3.h5)
 # char data as ASCII with non escape
-ADD_H5_TEST (tstring2 RESULT_CODE 0 --enable-error-stack -r -d str4 tstr3.h5)
+ADD_H5_TEST (tstring2 RESULT_CODE 0 --enable-error-stack -r -d str4 TARGET_FILE tstr3.h5)
 
 # array indices print/not print
-ADD_H5_TEST (tindicesyes RESULT_CODE 0 --enable-error-stack taindices.h5)
-ADD_H5_TEST (tindicesno RESULT_CODE 0 --enable-error-stack -y taindices.h5)
+ADD_H5_TEST (tindicesyes RESULT_CODE 0 --enable-error-stack TARGET_FILE taindices.h5)
+ADD_H5_TEST (tindicesno RESULT_CODE 0 --enable-error-stack -y TARGET_FILE taindices.h5)
 
 ########## array indices with subsetting
 # 1D case
-ADD_H5_TEST (tindicessub1 RESULT_CODE 0 --enable-error-stack -d 1d -s 1 -S 10 -c 2  -k 3 taindices.h5)
+ADD_H5_TEST (tindicessub1 RESULT_CODE 0 --enable-error-stack -d 1d -s 1 -S 10 -c 2  -k 3 TARGET_FILE taindices.h5)
 
 # 2D case
-ADD_H5_TEST (tindicessub2 RESULT_CODE 0 --enable-error-stack -d 2d -s 1,2  -S 3,3 -c 3,2 -k 2,2 taindices.h5)
+ADD_H5_TEST (tindicessub2 RESULT_CODE 0 --enable-error-stack -d 2d -s 1,2  -S 3,3 -c 3,2 -k 2,2 TARGET_FILE taindices.h5)
 
 # 3D case
-ADD_H5_TEST (tindicessub3 RESULT_CODE 0 --enable-error-stack -d 3d -s 0,1,2 -S 1,3,3 -c 2,2,2  -k 1,2,2  taindices.h5)
+ADD_H5_TEST (tindicessub3 RESULT_CODE 0 --enable-error-stack -d 3d -s 0,1,2 -S 1,3,3 -c 2,2,2  -k 1,2,2  TARGET_FILE taindices.h5)
 
 # 4D case
-ADD_H5_TEST (tindicessub4 RESULT_CODE 0 --enable-error-stack -d 4d -s 0,0,1,2  -c 2,2,3,2 -S 1,1,3,3 -k 1,1,2,2  taindices.h5)
+ADD_H5_TEST (tindicessub4 RESULT_CODE 0 --enable-error-stack -d 4d -s 0,0,1,2  -c 2,2,3,2 -S 1,1,3,3 -k 1,1,2,2  TARGET_FILE taindices.h5)
 
 # Exceed the dimensions for subsetting
 ADD_H5ERR_MASK_TEST (texceedsubstart 1 "exceed dataset dims" --enable-error-stack -d 1d -s 1,3 taindices.h5)
@@ -1286,28 +1291,28 @@ ADD_H5ERR_MASK_TEST (texceedsubblock 1 "exceed dataset dims" --enable-error-stac
 
 # tests for filters
 # SZIP
-ADD_H5_TEST (tszip RESULT_CODE 0 APPLY_FILTERS 2 --enable-error-stack -H -p -d szip tfilters.h5)
+ADD_H5_TEST (tszip RESULT_CODE 0 APPLY_FILTERS 2 --enable-error-stack -H -p -d szip TARGET_FILE tfilters.h5)
 
 # deflate
-ADD_H5_TEST (tdeflate RESULT_CODE 0 APPLY_FILTERS 2 --enable-error-stack -H -p -d deflate tfilters.h5)
+ADD_H5_TEST (tdeflate RESULT_CODE 0 APPLY_FILTERS 2 --enable-error-stack -H -p -d deflate TARGET_FILE tfilters.h5)
 
 # shuffle
-ADD_H5_TEST (tshuffle RESULT_CODE 0 --enable-error-stack -H -p -d shuffle tfilters.h5)
+ADD_H5_TEST (tshuffle RESULT_CODE 0 --enable-error-stack -H -p -d shuffle TARGET_FILE tfilters.h5)
 
 # fletcher32
-ADD_H5_TEST (tfletcher32 RESULT_CODE 0 APPLY_FILTERS 0 --enable-error-stack -H -p -d fletcher32  tfilters.h5)
+ADD_H5_TEST (tfletcher32 RESULT_CODE 0 APPLY_FILTERS 0 --enable-error-stack -H -p -d fletcher32  TARGET_FILE tfilters.h5)
 
 # nbit
-ADD_H5_TEST (tnbit RESULT_CODE 0 APPLY_FILTERS 1 --enable-error-stack -H -p -d nbit  tfilters.h5)
+ADD_H5_TEST (tnbit RESULT_CODE 0 APPLY_FILTERS 1 --enable-error-stack -H -p -d nbit  TARGET_FILE tfilters.h5)
 
 # scaleoffset
-ADD_H5_TEST (tscaleoffset RESULT_CODE 0 APPLY_FILTERS 4 --enable-error-stack -H -p -d scaleoffset  tfilters.h5)
+ADD_H5_TEST (tscaleoffset RESULT_CODE 0 APPLY_FILTERS 4 --enable-error-stack -H -p -d scaleoffset  TARGET_FILE tfilters.h5)
 
 # all
-ADD_H5_TEST (tallfilters RESULT_CODE 0 APPLY_FILTERS 1 --enable-error-stack -H -p -d all  tfilters.h5)
+ADD_H5_TEST (tallfilters RESULT_CODE 0 APPLY_FILTERS 1 --enable-error-stack -H -p -d all  TARGET_FILE tfilters.h5)
 
 # user defined
-ADD_H5_TEST (tuserfilter RESULT_CODE 0 --enable-error-stack -H  -p -d myfilter  tfilters.h5)
+ADD_H5_TEST (tuserfilter RESULT_CODE 0 --enable-error-stack -H  -p -d myfilter  TARGET_FILE tfilters.h5)
 
 
 # See which filters are usable (and skip tests for filters we
@@ -1325,37 +1330,37 @@ endif ()
 
 if (USE_FILTER_DEFLATE)
   # data read internal filters
-  ADD_H5_TEST (treadintfilter RESULT_CODE 0 --enable-error-stack -d deflate -d shuffle -d fletcher32 -d nbit -d scaleoffset tfilters.h5)
+  ADD_H5_TEST (treadintfilter RESULT_CODE 0 --enable-error-stack -d deflate -d shuffle -d fletcher32 -d nbit -d scaleoffset TARGET_FILE tfilters.h5)
   if (HDF5_ENABLE_SZIP_SUPPORT)
     # data read all filters
-    ADD_H5_TEST (treadfilter RESULT_CODE 0 --enable-error-stack -d all -d szip tfilters.h5)
+    ADD_H5_TEST (treadfilter RESULT_CODE 0 --enable-error-stack -d all -d szip TARGET_FILE tfilters.h5)
   endif ()
 endif ()
 
 # test for displaying objects with very long names
-ADD_H5_TEST (tlonglinks RESULT_CODE 0 --enable-error-stack tlonglinks.h5)
+ADD_H5_TEST (tlonglinks RESULT_CODE 0 --enable-error-stack TARGET_FILE tlonglinks.h5)
 
 # dimensions over 4GB, print boundary
-ADD_H5_TEST (tbigdims RESULT_CODE 0 --enable-error-stack -d dset4gb -s 4294967284 -c 22 tbigdims.h5)
+ADD_H5_TEST (tbigdims RESULT_CODE 0 --enable-error-stack -d dset4gb -s 4294967284 -c 22 TARGET_FILE tbigdims.h5)
 
 # hyperslab read
-ADD_H5_TEST (thyperslab RESULT_CODE 0 --enable-error-stack thyperslab.h5)
+ADD_H5_TEST (thyperslab RESULT_CODE 0 --enable-error-stack TARGET_FILE thyperslab.h5)
 
 # test for displaying dataset and attribute of null space
-ADD_H5_TEST (tnullspace RESULT_CODE 0 --enable-error-stack tnullspace.h5)
-ADD_H5_TEST (tgrpnullspace RESULT_CODE 0 -p --enable-error-stack tgrpnullspace.h5)
+ADD_H5_TEST (tnullspace RESULT_CODE 0 --enable-error-stack TARGET_FILE tnullspace.h5)
+ADD_H5_TEST (tgrpnullspace RESULT_CODE 0 -p --enable-error-stack TARGET_FILE tgrpnullspace.h5)
 
 # test for displaying dataset and attribute of space with 0 dimension size
-ADD_H5_TEST (zerodim RESULT_CODE 0 --enable-error-stack zerodim.h5)
+ADD_H5_TEST (zerodim RESULT_CODE 0 --enable-error-stack TARGET_FILE zerodim.h5)
 
 # test for long double (some systems do not have long double)
-ADD_H5_TEST (tfloatsattrs RESULT_CODE 0 -p --format=%.4g --lformat=%.4Lg --width=80 --enable-error-stack tfloatsattrs.h5)
-ADD_H5_TEST (tldouble RESULT_CODE 0 --enable-error-stack tldouble.h5)
-ADD_H5_TEST (tldouble_scalar RESULT_CODE 0 -p --enable-error-stack tldouble_scalar.h5)
+ADD_H5_TEST (tfloatsattrs RESULT_CODE 0 -p --format=%.4g --lformat=%.4Lg --width=80 --enable-error-stack TARGET_FILE tfloatsattrs.h5)
+ADD_H5_TEST (tldouble RESULT_CODE 0 --enable-error-stack TARGET_FILE tldouble.h5)
+ADD_H5_TEST (tldouble_scalar RESULT_CODE 0 -p --enable-error-stack TARGET_FILE tldouble_scalar.h5)
 
 # Add tests for _Float16 type
-ADD_H5_TEST (tfloat16 RESULT_CODE 0 --enable-error-stack tfloat16.h5)
-ADD_H5_TEST (tfloat16_be RESULT_CODE 0 --enable-error-stack tfloat16_be.h5)
+ADD_H5_TEST (tfloat16 RESULT_CODE 0 --enable-error-stack TARGET_FILE tfloat16.h5)
+ADD_H5_TEST (tfloat16_be RESULT_CODE 0 --enable-error-stack TARGET_FILE tfloat16_be.h5)
 
 # Add tests for complex numbers. For portability, use a fixed floating-point
 # precision and skip dumping of the "long double _Complex" dataset. The "long
@@ -1367,19 +1372,19 @@ ADD_H5_TEST (tfloat16_be RESULT_CODE 0 --enable-error-stack tfloat16_be.h5)
 # default number of columns value.
 ADD_H5_TEST (tcomplex RESULT_CODE 0 --enable-error-stack -m %.6f -w80 -d ArrayDatasetFloatComplex
               -d CompoundDatasetFloatComplex -d DatasetDoubleComplex -d DatasetFloatComplex
-              -d VariableLengthDatasetFloatComplex tcomplex.h5)
+              -d VariableLengthDatasetFloatComplex TARGET_FILE tcomplex.h5)
 ADD_H5_TEST (tcomplex_info RESULT_CODE 0 --enable-error-stack -p -H -m %.6f -w80 -d ArrayDatasetFloatComplex
               -d CompoundDatasetFloatComplex -d DatasetDoubleComplex -d DatasetFloatComplex
-              -d VariableLengthDatasetFloatComplex tcomplex.h5)
+              -d VariableLengthDatasetFloatComplex TARGET_FILE tcomplex.h5)
 ADD_H5_TEST (tcomplex_be RESULT_CODE 0 --enable-error-stack -m %.6f -w80 -d ArrayDatasetFloatComplex
               -d CompoundDatasetFloatComplex -d DatasetDoubleComplex -d DatasetFloatComplex
-              -d VariableLengthDatasetFloatComplex tcomplex_be.h5)
+              -d VariableLengthDatasetFloatComplex TARGET_FILE tcomplex_be.h5)
 ADD_H5_TEST (tcomplex_be_info RESULT_CODE 0 --enable-error-stack -p -H -m %.6f -w80 -d ArrayDatasetFloatComplex
               -d CompoundDatasetFloatComplex -d DatasetDoubleComplex -d DatasetFloatComplex
-              -d VariableLengthDatasetFloatComplex tcomplex_be.h5)
+              -d VariableLengthDatasetFloatComplex TARGET_FILE tcomplex_be.h5)
 
 # test for vms
-ADD_H5_TEST (tvms RESULT_CODE 0 --enable-error-stack tvms.h5)
+ADD_H5_TEST (tvms RESULT_CODE 0 --enable-error-stack TARGET_FILE tvms.h5)
 
 # test for binary output
 ADD_H5_BIN_EXPORT (tbin1LE 0 tbinary.h5 --enable-error-stack -d integer -b LE)
@@ -1389,57 +1394,57 @@ ADD_H5_EXPORT_TEST (tstr2bin2 tstr2.h5 0 --enable-error-stack -d /g2/dset2 -b -o
 ADD_H5_EXPORT_TEST (tstr2bin6 tstr2.h5 0 --enable-error-stack -d /g6/dset6 -b -o)
 
 # NATIVE default. the NATIVE test can be validated with h5import/h5diff
-#  ADD_H5_TEST_IMPORT (tbin1 out1D tbinary.h5 0 --enable-error-stack -d integer -b)
+#  ADD_H5_TEST_IMPORT (tbin1 out1D TARGET_FILE tbinary.h5 0 --enable-error-stack -d integer -b)
 
 if (NOT HDF5_ENABLE_USING_MEMCHECKER)
   ADD_H5_BIN_EXPORT (tbin2 0 tbinary.h5 --enable-error-stack -b BE -d float)
 endif ()
 
 # the NATIVE test can be validated with h5import/h5diff
-#  ADD_H5_TEST_IMPORT (tbin3 out3D tbinary.h5 0 --enable-error-stack -d integer -b NATIVE)
+#  ADD_H5_TEST_IMPORT (tbin3 out3D TARGET_FILE tbinary.h5 0 --enable-error-stack -d integer -b NATIVE)
 
 if (NOT HDF5_ENABLE_USING_MEMCHECKER)
   ADD_H5_BIN_EXPORT (tbin4 0 tbinary.h5 --enable-error-stack -d double -b FILE)
 endif ()
 
 # test for dataset region references
-ADD_H5_TEST (tdatareg RESULT_CODE 0 --enable-error-stack tdatareg.h5)
+ADD_H5_TEST (tdatareg RESULT_CODE 0 --enable-error-stack TARGET_FILE tdatareg.h5)
 ADD_H5ERR_MASK_TEST (tdataregR 0 "NULL token size" --enable-error-stack -R tdatareg.h5)
-ADD_H5_TEST (tattrreg RESULT_CODE 0 --enable-error-stack tattrreg.h5)
+ADD_H5_TEST (tattrreg RESULT_CODE 0 --enable-error-stack TARGET_FILE tattrreg.h5)
 ADD_H5ERR_MASK_TEST (tattrregR 0 "NULL token size" -R --enable-error-stack tattrreg.h5)
 ADD_H5_EXPORT_TEST (tbinregR tdatareg.h5 0 --enable-error-stack -d /Dataset1 -s 0 -R -y -o)
 
 # test for 1.12 region references
-ADD_H5_TEST (trefer_attrR RESULT_CODE 0 --enable-error-stack -R trefer_attr.h5)
-ADD_H5_TEST (trefer_compatR RESULT_CODE 0 --enable-error-stack -R trefer_compat.h5)
-ADD_H5_TEST (trefer_extR RESULT_CODE 0 --enable-error-stack -R trefer_ext2.h5)
-ADD_H5_TEST (trefer_grpR RESULT_CODE 0 --enable-error-stack -R trefer_grp.h5)
-ADD_H5_TEST (trefer_obj_delR RESULT_CODE 0 --enable-error-stack -R trefer_obj_del.h5)
-ADD_H5_TEST (trefer_objR RESULT_CODE 0 --enable-error-stack -R trefer_obj.h5)
-ADD_H5_TEST (trefer_paramR RESULT_CODE 0 --enable-error-stack -R trefer_param.h5)
-ADD_H5_TEST (trefer_regR RESULT_CODE 0 --enable-error-stack -R trefer_reg.h5)
-ADD_H5_TEST (trefer_reg_1dR RESULT_CODE 0 --enable-error-stack -R trefer_reg_1d.h5)
+ADD_H5_TEST (trefer_attrR RESULT_CODE 0 --enable-error-stack -R TARGET_FILE trefer_attr.h5)
+ADD_H5_TEST (trefer_compatR RESULT_CODE 0 --enable-error-stack -R TARGET_FILE trefer_compat.h5)
+ADD_H5_TEST (trefer_extR RESULT_CODE 0 --enable-error-stack -R TARGET_FILE trefer_ext2.h5)
+ADD_H5_TEST (trefer_grpR RESULT_CODE 0 --enable-error-stack -R TARGET_FILE trefer_grp.h5)
+ADD_H5_TEST (trefer_obj_delR RESULT_CODE 0 --enable-error-stack -R TARGET_FILE trefer_obj_del.h5)
+ADD_H5_TEST (trefer_objR RESULT_CODE 0 --enable-error-stack -R TARGET_FILE trefer_obj.h5)
+ADD_H5_TEST (trefer_paramR RESULT_CODE 0 --enable-error-stack -R TARGET_FILE trefer_param.h5)
+ADD_H5_TEST (trefer_regR RESULT_CODE 0 --enable-error-stack -R TARGET_FILE trefer_reg.h5)
+ADD_H5_TEST (trefer_reg_1dR RESULT_CODE 0 --enable-error-stack -R TARGET_FILE trefer_reg_1d.h5)
 
 # tests for group creation order
 # "1" tracked, "2" name, root tracked
-ADD_H5_TEST (tordergr1 RESULT_CODE 0 --enable-error-stack --group=1 --sort_by=creation_order --sort_order=ascending tordergr.h5)
-ADD_H5_TEST (tordergr2 RESULT_CODE 0 --enable-error-stack --group=1 --sort_by=creation_order --sort_order=descending tordergr.h5)
-ADD_H5_TEST (tordergr3 RESULT_CODE 0 --enable-error-stack -g 2 -q name -z ascending tordergr.h5)
-ADD_H5_TEST (tordergr4 RESULT_CODE 0 --enable-error-stack -g 2 -q name -z descending tordergr.h5)
-ADD_H5_TEST (tordergr5 RESULT_CODE 0 --enable-error-stack -q creation_order tordergr.h5)
+ADD_H5_TEST (tordergr1 RESULT_CODE 0 --enable-error-stack --group=1 --sort_by=creation_order --sort_order=ascending TARGET_FILE tordergr.h5)
+ADD_H5_TEST (tordergr2 RESULT_CODE 0 --enable-error-stack --group=1 --sort_by=creation_order --sort_order=descending TARGET_FILE tordergr.h5)
+ADD_H5_TEST (tordergr3 RESULT_CODE 0 --enable-error-stack -g 2 -q name -z ascending TARGET_FILE tordergr.h5)
+ADD_H5_TEST (tordergr4 RESULT_CODE 0 --enable-error-stack -g 2 -q name -z descending TARGET_FILE tordergr.h5)
+ADD_H5_TEST (tordergr5 RESULT_CODE 0 --enable-error-stack -q creation_order TARGET_FILE tordergr.h5)
 
 # tests for attribute order
-ADD_H5_TEST (torderattr1 RESULT_CODE 0 --enable-error-stack -H --sort_by=name --sort_order=ascending torderattr.h5)
-ADD_H5_TEST (torderattr2 RESULT_CODE 0 --enable-error-stack -H --sort_by=name --sort_order=descending torderattr.h5)
-ADD_H5_TEST (torderattr3 RESULT_CODE 0 --enable-error-stack -H --sort_by=creation_order --sort_order=ascending torderattr.h5)
-ADD_H5_TEST (torderattr4 RESULT_CODE 0 --enable-error-stack -H --sort_by=creation_order --sort_order=descending torderattr.h5)
+ADD_H5_TEST (torderattr1 RESULT_CODE 0 --enable-error-stack -H --sort_by=name --sort_order=ascending TARGET_FILE torderattr.h5)
+ADD_H5_TEST (torderattr2 RESULT_CODE 0 --enable-error-stack -H --sort_by=name --sort_order=descending TARGET_FILE torderattr.h5)
+ADD_H5_TEST (torderattr3 RESULT_CODE 0 --enable-error-stack -H --sort_by=creation_order --sort_order=ascending TARGET_FILE torderattr.h5)
+ADD_H5_TEST (torderattr4 RESULT_CODE 0 --enable-error-stack -H --sort_by=creation_order --sort_order=descending TARGET_FILE torderattr.h5)
 
 # tests for link references and order
 ADD_H5ERR_MASK_TEST (torderlinks1 0 "unable to open external file, external link file name = 'fname'" --enable-error-stack --sort_by=name --sort_order=ascending tfcontents1.h5)
 ADD_H5ERR_MASK_TEST (torderlinks2 0 "unable to open external file, external link file name = 'fname'" --enable-error-stack --sort_by=name --sort_order=descending tfcontents1.h5)
 
 # tests for floating point user defined printf format
-ADD_H5_TEST (tfpformat RESULT_CODE 0 --enable-error-stack --format=%.7f tfpformat.h5)
+ADD_H5_TEST (tfpformat RESULT_CODE 0 --enable-error-stack --format=%.7f TARGET_FILE tfpformat.h5)
 
 # tests for traversal of external links
 ADD_H5ERR_MASK_TEST (textlinksrc 0 "Too many soft links in path" --enable-error-stack textlinksrc.h5)
@@ -1475,10 +1480,10 @@ ADD_H5ERR_MASK_TEST (tCVE_2018_11206_fill_new 1 "" tCVE_2018_11206_fill_new.h5)
 ADD_H5ERR_MASK_TEST (tCVE-2021-37501_attr_decode 1 "error getting attribute information" tCVE-2021-37501_attr_decode.h5)
 
 # onion VFD tests
-ADD_H5_TEST (tst_onion_objs RESULT_CODE 0 --enable-error-stack --vfd-name onion --vfd-info 3 tst_onion_objs.h5)
-ADD_H5_TEST (tst_onion_dset_ext RESULT_CODE 0 --enable-error-stack --vfd-name onion --vfd-info 1 tst_onion_dset_ext.h5)
-ADD_H5_TEST (tst_onion_dset_1d RESULT_CODE 0 --enable-error-stack --vfd-name onion --vfd-info 1 tst_onion_dset_1d.h5)
-ADD_H5_TEST (tst_onion_revision_count RESULT_CODE 0 --enable-error-stack --vfd-name onion --vfd-info revision_count tst_onion_objs.h5)
+ADD_H5_TEST (tst_onion_objs RESULT_CODE 0 --enable-error-stack --vfd-name onion --vfd-info 3 TARGET_FILE tst_onion_objs.h5)
+ADD_H5_TEST (tst_onion_dset_ext RESULT_CODE 0 --enable-error-stack --vfd-name onion --vfd-info 1 TARGET_FILE tst_onion_dset_ext.h5)
+ADD_H5_TEST (tst_onion_dset_1d RESULT_CODE 0 --enable-error-stack --vfd-name onion --vfd-info 1 TARGET_FILE tst_onion_dset_1d.h5)
+ADD_H5_TEST (tst_onion_revision_count RESULT_CODE 0 --enable-error-stack --vfd-name onion --vfd-info revision_count TARGET_FILE tst_onion_objs.h5)
 
 
 ##############################################################################

--- a/tools/test/h5dump/CMakeTests.cmake
+++ b/tools/test/h5dump/CMakeTests.cmake
@@ -605,105 +605,101 @@ macro (ADD_H5_TEST testname)
     set(should_skip_test TRUE)
   endif()
 
-  if (should_skip_test)
-    # Add a test that just displays a skip message instead
-    add_test(
-      NAME H5DUMP-${ctest_testname}-SKIPPED
-      COMMAND ${CMAKE_COMMAND} -E echo "SKIP ${ctest_testname} ${ARGN}"
-    )
-  else()
-    # Cleanup if test produces artifacts
-    if (${DO_CLEANUP})
-      add_test (
-          NAME H5DUMP-${ctest_testname}-clear-objects
-          COMMAND ${CMAKE_COMMAND} -E remove
-            "${testname}.txt"
-            "${ARG_OUTPUT_FILE}.txt"
-            "${ARG_DDL_FILE}.txt"
-            "${testname}.bin"
-
-      )
-
-      set_tests_properties (H5DUMP-${ctest_testname}-clear-objects PROPERTIES
-          WORKING_DIRECTORY "${PROJECT_BINARY_DIR}/testfiles/std"
-      )
-    endif ()
-
-    # If using memchecker add tests without using scripts
-    if (HDF5_ENABLE_USING_MEMCHECKER AND NOT ARG_MASK_ERROR AND NOT ARG_GREP_COMPARE AND NOT DEFINED ARG_H5ERRREF)
-      add_test (NAME H5DUMP-${ctest_testname} COMMAND ${CMAKE_CROSSCOMPILING_EMULATOR} $<TARGET_FILE:h5dump> ${ARG_ANY_PATHS} ${ARG_UNPARSED_ARGUMENTS} ${ARG_DDL_FILE_CMD} ${BINARY_OUTPUT_FLAG} ${ARG_OUTPUT_FILEARGS} ${ARG_TARGET_FILE})
-      if (${ARG_RESULT_CODE})
-        set_tests_properties (H5DUMP-${ctest_testname} PROPERTIES WILL_FAIL "true")
-      endif ()
-      set_tests_properties (H5DUMP-${ctest_testname} PROPERTIES
-          WORKING_DIRECTORY "${PROJECT_BINARY_DIR}/testfiles/std"
-      )
-    else ()
-      add_test (
-          NAME H5DUMP-${ctest_testname}
-          COMMAND "${CMAKE_COMMAND}"
-              -D "TEST_EMULATOR=${CMAKE_CROSSCOMPILING_EMULATOR}"
-              -D "TEST_PROGRAM=$<TARGET_FILE:h5dump>"
-              -D "TEST_ARGS:STRING=${ARG_ANY_PATHS};${ARG_UNPARSED_ARGUMENTS};${ARG_DDL_FILE_CMD};${BINARY_OUTPUT_FLAG};${ARG_OUTPUT_FILEARGS};${ARG_TARGET_FILE}"
-              -D "TEST_FOLDER=${PROJECT_BINARY_DIR}/testfiles/std"
-              -D "TEST_OUTPUT=${testname}.out"
-              -D "TEST_EXPECT=${ARG_RESULT_CODE}"
-              -D "TEST_REFERENCE=${ARG_RESULT_CHECK_FILE}"
-              -D "TEST_FILTER:STRING=${filters_in}"
-              -D "TEST_FILTER_REPLACE:STRING=${filters_out}"
-              -D "TEST_MASK_ERROR:BOOL=${ARG_MASK_ERROR}"
-              -D "TEST_GREP_COMPARE:BOOL=${ARG_GREP_COMPARE}"
-              -D "TEST_ERRREF=${ARG_H5ERRREF}"
-              -D "TEST_ENV_VAR:STRING=${ARG_ENVVAR}"
-              -D "TEST_ENV_VALUE:STRING=${ARG_ENVVAL}"
-              -P "${HDF_RESOURCES_DIR}/runTest.cmake"
-      )
-    endif ()
-    set_tests_properties (H5DUMP-${ctest_testname} PROPERTIES
-        WORKING_DIRECTORY "${PROJECT_BINARY_DIR}/testfiles/std"
-    )
-
-    if ("H5DUMP-${ctest_testname}" MATCHES "${HDF5_DISABLE_TESTS_REGEX}")
-      set_tests_properties (H5DUMP-${ctest_testname} PROPERTIES DISABLED true)
-    endif ()
-
-    set(CLEANUP_DEPENDENCIES "H5DUMP-${ctest_testname}")
-
-    if (DEFINED ARG_TARGET_FILE AND DEFINED ARG_OUTPUT_FILE)
-      add_test (
-        NAME H5DUMP-${ctest_testname}-output-cmp
-        COMMAND ${CMAKE_COMMAND} -E compare_files --ignore-eol ${testname}.txt ${testname}.exp
-      )
-
-      set_tests_properties(H5DUMP-${ctest_testname}-output-cmp PROPERTIES
-        DEPENDS H5DUMP-${ctest_testname}
-        WORKING_DIRECTORY "${PROJECT_BINARY_DIR}/testfiles/std"
-      )
-
-      if ("H5DUMP-${ctest_testname}-output-cmp" MATCHES "${HDF5_DISABLE_TESTS_REGEX}")
-        set_tests_properties (H5DUMP-${ctest_testname}-output-cmp PROPERTIES DISABLED true)
-      endif ()
-
-      list(APPEND CLEANUP_DEPENDENCIES "H5DUMP-${ctest_testname}-output-cmp")
-    endif ()
-
-    if (${DO_CLEANUP})
-      add_test (
-        NAME H5DUMP-${ctest_testname}-clean-objects
+  # Cleanup if test produces artifacts
+  if (${DO_CLEANUP})
+    add_test (
+        NAME H5DUMP-${ctest_testname}-clear-objects
         COMMAND ${CMAKE_COMMAND} -E remove
           "${testname}.txt"
           "${ARG_OUTPUT_FILE}.txt"
           "${ARG_DDL_FILE}.txt"
           "${testname}.bin"
-      )
 
-      set_tests_properties (H5DUMP-${ctest_testname}-clean-objects PROPERTIES
-          DEPENDS "${CLEANUP_DEPENDENCIES}"
-          WORKING_DIRECTORY "${PROJECT_BINARY_DIR}/testfiles/std"
-      )
+    )
+
+    set_tests_properties (H5DUMP-${ctest_testname}-clear-objects PROPERTIES
+        WORKING_DIRECTORY "${PROJECT_BINARY_DIR}/testfiles/std"
+    )
+  endif ()
+
+  # If using memchecker add tests without using scripts
+  if (HDF5_ENABLE_USING_MEMCHECKER AND NOT ARG_MASK_ERROR AND NOT ARG_GREP_COMPARE AND NOT DEFINED ARG_H5ERRREF)
+    add_test (NAME H5DUMP-${ctest_testname} COMMAND ${CMAKE_CROSSCOMPILING_EMULATOR} $<TARGET_FILE:h5dump> ${ARG_ANY_PATHS} ${ARG_UNPARSED_ARGUMENTS} ${ARG_DDL_FILE_CMD} ${BINARY_OUTPUT_FLAG} ${ARG_OUTPUT_FILEARGS} ${ARG_TARGET_FILE})
+    if (${ARG_RESULT_CODE})
+      set_tests_properties (H5DUMP-${ctest_testname} PROPERTIES WILL_FAIL "true")
     endif ()
-  endif () # should_skip_test
+    set_tests_properties (H5DUMP-${ctest_testname} PROPERTIES
+        WORKING_DIRECTORY "${PROJECT_BINARY_DIR}/testfiles/std"
+    )
+  else ()
+    add_test (
+        NAME H5DUMP-${ctest_testname}
+        COMMAND "${CMAKE_COMMAND}"
+            -D "TEST_EMULATOR=${CMAKE_CROSSCOMPILING_EMULATOR}"
+            -D "TEST_PROGRAM=$<TARGET_FILE:h5dump>"
+            -D "TEST_ARGS:STRING=${ARG_ANY_PATHS};${ARG_UNPARSED_ARGUMENTS};${ARG_DDL_FILE_CMD};${BINARY_OUTPUT_FLAG};${ARG_OUTPUT_FILEARGS};${ARG_TARGET_FILE}"
+            -D "TEST_FOLDER=${PROJECT_BINARY_DIR}/testfiles/std"
+            -D "TEST_OUTPUT=${testname}.out"
+            -D "TEST_EXPECT=${ARG_RESULT_CODE}"
+            -D "TEST_REFERENCE=${ARG_RESULT_CHECK_FILE}"
+            -D "TEST_FILTER:STRING=${filters_in}"
+            -D "TEST_FILTER_REPLACE:STRING=${filters_out}"
+            -D "TEST_MASK_ERROR:BOOL=${ARG_MASK_ERROR}"
+            -D "TEST_GREP_COMPARE:BOOL=${ARG_GREP_COMPARE}"
+            -D "TEST_ERRREF=${ARG_H5ERRREF}"
+            -D "TEST_ENV_VAR:STRING=${ARG_ENVVAR}"
+            -D "TEST_ENV_VALUE:STRING=${ARG_ENVVAL}"
+            -P "${HDF_RESOURCES_DIR}/runTest.cmake"
+    )
+  endif ()
+  set_tests_properties (H5DUMP-${ctest_testname} PROPERTIES
+      WORKING_DIRECTORY "${PROJECT_BINARY_DIR}/testfiles/std"
+  )
 
+  if ("H5DUMP-${ctest_testname}" MATCHES "${HDF5_DISABLE_TESTS_REGEX}")
+    set_tests_properties (H5DUMP-${ctest_testname} PROPERTIES DISABLED true)
+  endif ()
+
+  set(CLEANUP_DEPENDENCIES "H5DUMP-${ctest_testname}")
+
+  if (DEFINED ARG_TARGET_FILE AND DEFINED ARG_OUTPUT_FILE)
+    add_test (
+      NAME H5DUMP-${ctest_testname}-output-cmp
+      COMMAND ${CMAKE_COMMAND} -E compare_files --ignore-eol ${testname}.txt ${testname}.exp
+    )
+
+    set_tests_properties(H5DUMP-${ctest_testname}-output-cmp PROPERTIES
+      DEPENDS H5DUMP-${ctest_testname}
+      WORKING_DIRECTORY "${PROJECT_BINARY_DIR}/testfiles/std"
+    )
+
+    if ("H5DUMP-${ctest_testname}-output-cmp" MATCHES "${HDF5_DISABLE_TESTS_REGEX}")
+      set_tests_properties (H5DUMP-${ctest_testname}-output-cmp PROPERTIES DISABLED true)
+    endif ()
+
+    list(APPEND CLEANUP_DEPENDENCIES "H5DUMP-${ctest_testname}-output-cmp")
+  endif ()
+
+  if (${DO_CLEANUP})
+    add_test (
+      NAME H5DUMP-${ctest_testname}-clean-objects
+      COMMAND ${CMAKE_COMMAND} -E remove
+        "${testname}.txt"
+        "${ARG_OUTPUT_FILE}.txt"
+        "${ARG_DDL_FILE}.txt"
+        "${testname}.bin"
+    )
+
+    set_tests_properties (H5DUMP-${ctest_testname}-clean-objects PROPERTIES
+        DEPENDS "${CLEANUP_DEPENDENCIES}"
+        WORKING_DIRECTORY "${PROJECT_BINARY_DIR}/testfiles/std"
+    )
+  endif ()
+
+  # Mark the test as disabled if needed
+  if (should_skip_test)
+    set_tests_properties(H5DUMP-${ctest_testname} PROPERTIES DISABLED true)
+  endif()
 endmacro ()
 
 macro (ADD_H5_TEST_IMPORT conffile resultfile testfile resultcode)

--- a/tools/test/h5dump/CMakeTests.cmake
+++ b/tools/test/h5dump/CMakeTests.cmake
@@ -546,6 +546,10 @@ macro (ADD_H5_TEST testname)
 
   if (${ARG_BINFILE})
     set (ctest_testname "BIN_EXPORT-${testname}")
+  elseif(DEFINED ARG_ANY_PATHS)
+    set (ctest_testname "N-${testname}")
+  elseif(DEFINED ARG_OUTPUT_FILE AND ARG_BINARY_OUTPUT)
+    set (ctest_testname "output-${testname}")
   endif()
 
   # Set up list of files to clean up

--- a/tools/test/h5dump/CMakeTests.cmake
+++ b/tools/test/h5dump/CMakeTests.cmake
@@ -478,6 +478,8 @@ endmacro ()
 #   OUTPUT_FILE <filename> - if provided, put h5dump output into <filename>.txt and compare it to <filename>.exp
 #   DDL_FILE <ddlname> - if provided, have h5dump generate <ddlname>.ddl and compare it to <ddlname>.exp
 #   H5ERRREF <errref_string> - if provided, expect the error output from h5dump to contain this string
+#   ENVVAR <varname> - if provided, set environment variable <varname> to ENVVALUE. If memchecker is enabled, does nothing.
+#   ENVVALUE <value> - if provided, set environment variable ENVVAR to this value. If memchecker is enabled, does nothing.
 #
 # OPTIONAL MULTI-KEYWORD ARGUMENTS
 #   ANY_PATHS <paths>   - The -N/--any_path argument(s) to h5dump.
@@ -485,7 +487,7 @@ endmacro ()
 macro (ADD_H5_TEST testname)
   cmake_parse_arguments(ARG
     "BINARY_OUTPUT;MASK_ERROR;GREP_COMPARE"
-    "RESULT_CODE;APPLY_FILTERS;TARGET_FILE;OUTPUT_FILE;DDL_FILE;H5ERRREF"
+    "RESULT_CODE;APPLY_FILTERS;TARGET_FILE;OUTPUT_FILE;DDL_FILE;H5ERRREF;ENVVAR;ENVVALUE"
     "ANY_PATHS"
     ${ARGN}
   )
@@ -543,6 +545,14 @@ macro (ADD_H5_TEST testname)
 
   if (DEFINED ARG_ANY_PATHS)
     list(APPEND CLEANUP_FILES "${testname}.bin")
+  endif ()
+
+  if (DEFINED ARG_ENVVAL AND NOT DEFINED ARG_ENVVAR)
+    message(FATAL_ERROR "ADD_H5_TEST: ENVVALUE requires ENVVAR")
+  endif ()
+
+  if (DEFINED ARG_ENVVAR AND NOT DEFINED ARG_ENVVAL)
+    message(FATAL_ERROR "ADD_H5_TEST: ENVVAR requires ENVVALUE")
   endif ()
 
   # Cleanup if test produces artifacts
@@ -605,6 +615,8 @@ macro (ADD_H5_TEST testname)
             -D "TEST_MASK_ERROR:BOOL=${ARG_MASK_ERROR}"
             -D "TEST_GREP_COMPARE:BOOL=${ARG_GREP_COMPARE}"
             -D "TEST_ERRREF=${ARG_H5ERRREF}"
+            -D "TEST_ENV_VAR:STRING=${ARG_ENVVAR}"
+            -D "TEST_ENV_VALUE:STRING=${ARG_ENVVALUE}"
             -P "${HDF_RESOURCES_DIR}/runTest.cmake"
     )
   endif ()
@@ -649,32 +661,6 @@ macro (ADD_H5_TEST testname)
     )
   endif ()
 
-endmacro ()
-
-macro (ADD_H5ERR_MASK_ENV_TEST resultfile resultcode result_errcheck envvar envval)
-  if (NOT HDF5_ENABLE_USING_MEMCHECKER)
-    add_test (
-        NAME H5DUMP-${resultfile}
-        COMMAND "${CMAKE_COMMAND}"
-            -D "TEST_EMULATOR=${CMAKE_CROSSCOMPILING_EMULATOR}"
-            -D "TEST_PROGRAM=$<TARGET_FILE:h5dump>"
-            -D "TEST_ARGS:STRING=${ARGN}"
-            -D "TEST_FOLDER=${PROJECT_BINARY_DIR}/testfiles/std"
-            -D "TEST_OUTPUT=${resultfile}.out"
-            -D "TEST_EXPECT=${resultcode}"
-            -D "TEST_REFERENCE=${resultfile}.ddl"
-            -D "TEST_ERRREF=${result_errcheck}"
-            -D "TEST_ENV_VAR:STRING=${envvar}"
-            -D "TEST_ENV_VALUE:STRING=${envval}"
-            -P "${HDF_RESOURCES_DIR}/runTest.cmake"
-    )
-    set_tests_properties (H5DUMP-${resultfile} PROPERTIES
-        WORKING_DIRECTORY "${PROJECT_BINARY_DIR}/testfiles/std"
-    )
-    if ("H5DUMP-${resultfile}" MATCHES "${HDF5_DISABLE_TESTS_REGEX}")
-      set_tests_properties (H5DUMP-${resultfile} PROPERTIES DISABLED true)
-    endif ()
-  endif ()
 endmacro ()
 
 macro (ADD_H5_BIN_EXPORT conffile resultcode testfile)
@@ -1264,7 +1250,7 @@ ADD_H5_TEST (textlinkfar RESULT_CODE 0 H5ERRREF "Too many soft links in path" --
 ADD_H5_TEST (textlink RESULT_CODE 0 H5ERRREF "unable to open external file, external link file name = 'anotherfile'" --enable-error-stack TARGET_FILE textlink.h5)
 
 # test for error stack display (BZ2048)
-ADD_H5ERR_MASK_ENV_TEST (filter_fail 1 "filter plugins disabled" "HDF5_PLUGIN_PRELOAD" "::" --enable-error-stack filter_fail.h5)
+ADD_H5_TEST (filter_fail RESULT_CODE 1 H5ERRREF "filter plugins disabled" ENVVAR "HDF5_PLUGIN_PRELOAD" ENVVAL "::" --enable-error-stack TARGET_FILE filter_fail.h5)
 
 # test for -o -y for dataset with attributes
 ADD_H5_TEST (tall-6 OUTPUT_FILE tall-6 TARGET_FILE tall.h5 RESULT_CODE 0 --enable-error-stack -d /g1/g1.1/dset1.1.1 -y)

--- a/tools/test/h5dump/CMakeTests.cmake
+++ b/tools/test/h5dump/CMakeTests.cmake
@@ -605,19 +605,25 @@ macro (ADD_H5_TEST testname)
   endif ()
 
   # Certain args are fully incompatible with memchecker; skip in these cases
-  set(should_add_test TRUE)
+  set(should_skip_test FALSE)
 
   if (HDF5_ENABLE_USING_MEMCHECKER)
     if (DEFINED ARG_H5ERRREF OR ${ARG_BINFILE} OR ${ARG_GREP_COMPARE})
-      set(should_add_test FALSE)
+      set(should_skip_test TRUE)
     endif()
   endif()
 
   if (${ARG_SKIP_TEST})
-    set(should_add_test FALSE)
+    set(should_skip_test TRUE)
   endif()
 
-  if (should_add_test)
+  if (should_skip_test)
+    # Add a test that just displays a skip message instead
+    add_test(
+      NAME H5DUMP-${ctest_testname}-SKIPPED
+      COMMAND ${CMAKE_COMMAND} -E echo "SKIP ${ctest_testname} ${ARGN}"
+    )
+  else()
     # Cleanup if test produces artifacts
     if (CLEANUP_FILES)
       add_test (
@@ -701,7 +707,7 @@ macro (ADD_H5_TEST testname)
           WORKING_DIRECTORY "${PROJECT_BINARY_DIR}/testfiles/std"
       )
     endif ()
-  endif () # should_add_test
+  endif () # should_skip_test
 
 endmacro ()
 

--- a/tools/test/h5dump/CMakeTests.cmake
+++ b/tools/test/h5dump/CMakeTests.cmake
@@ -555,23 +555,11 @@ macro (ADD_H5_TEST testname)
   endif()
 
   # Set up list of files to clean up
-  set(CLEANUP_FILES "")
+  set(DO_CLEANUP FALSE)
   set(CLEANUP_DEPENDENCIES "")
 
-  if (DEFINED ARG_TARGET_FILE)
-    list(APPEND CLEANUP_FILES "${testname}.txt")
-  endif ()
-
-  if (DEFINED ARG_OUTPUT_FILE)
-    list(APPEND CLEANUP_FILES "${ARG_OUTPUT_FILE}.txt")
-  endif ()
-
-  if (DEFINED ARG_DDL_FILE)
-    list(APPEND CLEANUP_FILES "${ARG_DDL_FILE}.txt")
-  endif ()
-
-  if (DEFINED ARG_ANY_PATHS OR ${ARG_BINFILE})
-    list(APPEND CLEANUP_FILES "${testname}.bin")
+  if (DEFINED ARG_TARGET_FILE OR DEFINED ARG_OUTPUT_FILE OR DEFINED ARG_DDL_FILE OR DEFINED ARG_ANY_PATHS OR ${ARG_BINFILE})
+    set(DO_CLEANUP TRUE)
   endif ()
 
   if (DEFINED ARG_ENVVAL AND NOT DEFINED ARG_ENVVAR)
@@ -625,11 +613,15 @@ macro (ADD_H5_TEST testname)
     )
   else()
     # Cleanup if test produces artifacts
-    if (CLEANUP_FILES)
+    if (${DO_CLEANUP})
       add_test (
           NAME H5DUMP-${ctest_testname}-clear-objects
           COMMAND ${CMAKE_COMMAND} -E remove
-              "${CLEANUP_FILES}"
+            "${testname}.txt"
+            "${ARG_OUTPUT_FILE}.txt"
+            "${ARG_DDL_FILE}.txt"
+            "${testname}.bin"
+
       )
 
       set_tests_properties (H5DUMP-${ctest_testname}-clear-objects PROPERTIES
@@ -695,11 +687,14 @@ macro (ADD_H5_TEST testname)
       list(APPEND CLEANUP_DEPENDENCIES "H5DUMP-${ctest_testname}-output-cmp")
     endif ()
 
-    if (CLEANUP_FILES)
+    if (${DO_CLEANUP})
       add_test (
         NAME H5DUMP-${ctest_testname}-clean-objects
         COMMAND ${CMAKE_COMMAND} -E remove
-            "${CLEANUP_FILES}"
+          "${testname}.txt"
+          "${ARG_OUTPUT_FILE}.txt"
+          "${ARG_DDL_FILE}.txt"
+          "${testname}.bin"
       )
 
       set_tests_properties (H5DUMP-${ctest_testname}-clean-objects PROPERTIES

--- a/tools/test/h5dump/CMakeTests.cmake
+++ b/tools/test/h5dump/CMakeTests.cmake
@@ -454,35 +454,58 @@ macro (ADD_HELP_TEST testname resultcode)
   endif ()
 endmacro ()
 
-macro (ADD_H5_TEST resultfile resultcode)
+#
+# Perform h5dump according to passed parameters
+#
+# Usage: ADD_H5_TEST(<testname> <required_args> [optional_args] [flags])
+#
+# REQUIRED POSITIONAL ARGUMENT:
+#   testname - name of test to add
+#
+# REQUIRED KEYWORD ARGUMENTS:
+#   RESULT_CODE <code>    - expected return code after test execution. 0 is success
+#
+macro (ADD_H5_TEST testname)
+  cmake_parse_arguments(ARG
+    ""
+    "RESULT_CODE"
+    ""
+    ${ARGN}
+  )
+
+  # Validate required parameters
+  if (NOT DEFINED ARG_RESULT_CODE)
+    message(FATAL_ERROR "ADD_H5_TEST: RESULT_CODE is required")
+  endif ()
+
   # If using memchecker add tests without using scripts
   if (HDF5_ENABLE_USING_MEMCHECKER)
-    add_test (NAME H5DUMP-${resultfile} COMMAND ${CMAKE_CROSSCOMPILING_EMULATOR} $<TARGET_FILE:h5dump> ${ARGN})
-    if (${resultcode})
-      set_tests_properties (H5DUMP-${resultfile} PROPERTIES WILL_FAIL "true")
+    add_test (NAME H5DUMP-${testname} COMMAND ${CMAKE_CROSSCOMPILING_EMULATOR} $<TARGET_FILE:h5dump> ${ARG_UNPARSED_ARGUMENTS})
+    if (${ARG_RESULT_CODE})
+      set_tests_properties (H5DUMP-${testname} PROPERTIES WILL_FAIL "true")
     endif ()
-    set_tests_properties (H5DUMP-${resultfile} PROPERTIES
+    set_tests_properties (H5DUMP-${testname} PROPERTIES
         WORKING_DIRECTORY "${PROJECT_BINARY_DIR}/testfiles/std"
     )
   else ()
     add_test (
-        NAME H5DUMP-${resultfile}
+        NAME H5DUMP-${testname}
         COMMAND "${CMAKE_COMMAND}"
             -D "TEST_EMULATOR=${CMAKE_CROSSCOMPILING_EMULATOR}"
             -D "TEST_PROGRAM=$<TARGET_FILE:h5dump>"
-            -D "TEST_ARGS:STRING=${ARGN}"
+            -D "TEST_ARGS:STRING=${ARG_UNPARSED_ARGUMENTS}"
             -D "TEST_FOLDER=${PROJECT_BINARY_DIR}/testfiles/std"
-            -D "TEST_OUTPUT=${resultfile}.out"
-            -D "TEST_EXPECT=${resultcode}"
-            -D "TEST_REFERENCE=${resultfile}.ddl"
+            -D "TEST_OUTPUT=${testname}.out"
+            -D "TEST_EXPECT=${ARG_RESULT_CODE}"
+            -D "TEST_REFERENCE=${testname}.ddl"
             -P "${HDF_RESOURCES_DIR}/runTest.cmake"
     )
   endif ()
-  set_tests_properties (H5DUMP-${resultfile} PROPERTIES
+  set_tests_properties (H5DUMP-${testname} PROPERTIES
       WORKING_DIRECTORY "${PROJECT_BINARY_DIR}/testfiles/std"
   )
-  if ("H5DUMP-${resultfile}" MATCHES "${HDF5_DISABLE_TESTS_REGEX}")
-    set_tests_properties (H5DUMP-${resultfile} PROPERTIES DISABLED true)
+  if ("H5DUMP-${testname}" MATCHES "${HDF5_DISABLE_TESTS_REGEX}")
+    set_tests_properties (H5DUMP-${testname} PROPERTIES DISABLED true)
   endif ()
 endmacro ()
 
@@ -1029,12 +1052,12 @@ endmacro ()
 ADD_HELP_TEST(help 0 -h)
 
 # test data output redirection
-#ADD_H5_TEST (tnoddl 0 --enable-error-stack -O -y packedbits.h5)
-ADD_H5_TEST (tnoddl 0 --enable-error-stack --ddl -y packedbits.h5)
-#ADD_H5_TEST (tnodata 0 --enable-error-stack -o packedbits.h5)
-ADD_H5_TEST (tnodata 0 --enable-error-stack --output packedbits.h5)
-ADD_H5_TEST (tnoattrddl 0 --enable-error-stack -O -y tattr.h5)
-ADD_H5_TEST (tnoattrdata 0 --enable-error-stack -A -o tattr.h5)
+#ADD_H5_TEST (tnoddl RESULT_CODE RESULT_CODE 0 --enable-error-stack -O -y packedbits.h5)
+ADD_H5_TEST (tnoddl RESULT_CODE 0 --enable-error-stack --ddl -y packedbits.h5)
+#ADD_H5_TEST (tnodata RESULT_CODE 0 --enable-error-stack -o packedbits.h5)
+ADD_H5_TEST (tnodata RESULT_CODE 0 --enable-error-stack --output packedbits.h5)
+ADD_H5_TEST (tnoattrddl RESULT_CODE 0 --enable-error-stack -O -y tattr.h5)
+ADD_H5_TEST (tnoattrdata RESULT_CODE 0 --enable-error-stack -A -o tattr.h5)
 ADD_H5_TEST_EXPORT (trawdatafile packedbits.h5 0 --enable-error-stack -y -o)
 ADD_H5_TEST_EXPORT (tnoddlfile packedbits.h5 0 --enable-error-stack -O -y -o)
 ADD_H5_TEST_EXPORT (trawssetfile tdset.h5 0 --enable-error-stack -d "/dset1[1,1;;;]" -y -o)
@@ -1042,152 +1065,152 @@ ADD_H5_TEST_EXPORT (trawssetfile tdset.h5 0 --enable-error-stack -d "/dset1[1,1;
 ADD_H5_TEST_EXPORT_DDL (twithddlfile packedbits.h5 0 twithddl --enable-error-stack --ddl=twithddl.txt -y -o)
 
 # test for maximum display datasets
-ADD_H5_TEST (twidedisplay 0 --enable-error-stack -w0 packedbits.h5)
+ADD_H5_TEST (twidedisplay RESULT_CODE 0 --enable-error-stack -w0 packedbits.h5)
 
 # test for unwritten datasets
-ADD_H5_TEST (tintsnodata 0 --enable-error-stack -p tintsnodata.h5)
+ADD_H5_TEST (tintsnodata RESULT_CODE 0 --enable-error-stack -p tintsnodata.h5)
 
 # test for signed/unsigned datasets
-ADD_H5_TEST (packedbits 0 --enable-error-stack packedbits.h5)
+ADD_H5_TEST (packedbits RESULT_CODE 0 --enable-error-stack packedbits.h5)
 # test for compound signed/unsigned datasets
-ADD_H5_TEST (tcmpdintarray 0 --enable-error-stack tcmpdintarray.h5)
-ADD_H5_TEST (tcmpdints 0 --enable-error-stack tcmpdints.h5)
-ADD_H5_TEST (tcmpdintsize 0 --enable-error-stack tcmpdintsize.h5)
+ADD_H5_TEST (tcmpdintarray RESULT_CODE 0 --enable-error-stack tcmpdintarray.h5)
+ADD_H5_TEST (tcmpdints RESULT_CODE 0 --enable-error-stack tcmpdints.h5)
+ADD_H5_TEST (tcmpdintsize RESULT_CODE 0 --enable-error-stack tcmpdintsize.h5)
 # test for signed/unsigned scalar datasets
-ADD_H5_TEST (tscalarintsize 0 --enable-error-stack tscalarintsize.h5)
+ADD_H5_TEST (tscalarintsize RESULT_CODE 0 --enable-error-stack tscalarintsize.h5)
 # test for signed/unsigned attributes
-ADD_H5_TEST (tattrintsize 0 --enable-error-stack tattrintsize.h5)
+ADD_H5_TEST (tattrintsize RESULT_CODE 0 --enable-error-stack tattrintsize.h5)
 # test for compound signed/unsigned attributes
-ADD_H5_TEST (tcmpdattrintsize 0 --enable-error-stack tcmpdattrintsize.h5)
+ADD_H5_TEST (tcmpdattrintsize RESULT_CODE 0 --enable-error-stack tcmpdattrintsize.h5)
 # test for signed/unsigned scalar attributes
-ADD_H5_TEST (tscalarattrintsize 0 --enable-error-stack tscalarattrintsize.h5)
+ADD_H5_TEST (tscalarattrintsize RESULT_CODE 0 --enable-error-stack tscalarattrintsize.h5)
 # test for string scalar dataset and attribute
-ADD_H5_TEST (tscalarstring 0 --enable-error-stack tscalarstring.h5)
+ADD_H5_TEST (tscalarstring RESULT_CODE 0 --enable-error-stack tscalarstring.h5)
 # test for signed/unsigned scalar datasets with attributes
-ADD_H5_TEST (tscalarintattrsize 0 --enable-error-stack tscalarintattrsize.h5)
+ADD_H5_TEST (tscalarintattrsize RESULT_CODE 0 --enable-error-stack tscalarintattrsize.h5)
 # test for signed/unsigned datasets attributes
-ADD_H5_TEST (tintsattrs 0 --enable-error-stack tintsattrs.h5)
+ADD_H5_TEST (tintsattrs RESULT_CODE 0 --enable-error-stack tintsattrs.h5)
 # test for displaying groups
-ADD_H5_TEST (tgroup-1 0 --enable-error-stack tgroup.h5)
+ADD_H5_TEST (tgroup-1 RESULT_CODE 0 --enable-error-stack tgroup.h5)
 # test for displaying the selected groups
 ADD_H5ERR_MASK_TEST (tgroup-2 1 "h5dump error: unable to open group \"/y\"" --enable-error-stack --group=/g2 --group / -g /y tgroup.h5)
 
 # test for displaying simple space datasets
-ADD_H5_TEST (tdset-1 0 --enable-error-stack tdset.h5)
+ADD_H5_TEST (tdset-1 RESULT_CODE 0 --enable-error-stack tdset.h5)
 # test for displaying selected datasets
 ADD_H5ERR_MASK_TEST (tdset-2 1 "h5dump error: unable to get link info from \"dset3\"" --enable-error-stack -H -d dset1 -d /dset2 --dataset=dset3 tdset.h5)
 
 # test for displaying attributes
-ADD_H5_TEST (tattr-1 0 --enable-error-stack tattr.h5)
+ADD_H5_TEST (tattr-1 RESULT_CODE 0 --enable-error-stack tattr.h5)
 # test for displaying the selected attributes of string type and scalar space
-ADD_H5_TEST (tattr-2 0 --enable-error-stack -a /\\\\/attr1 --attribute /attr4 --attribute=/attr5 tattr.h5)
+ADD_H5_TEST (tattr-2 RESULT_CODE 0 --enable-error-stack -a /\\\\/attr1 --attribute /attr4 --attribute=/attr5 tattr.h5)
 ADD_H5_TEST_N (tattr-2 0 --enable-error-stack -N /\\\\/attr1 --any_path /attr4 --any_path=/attr5 tattr.h5)
 # test for header and error messages
 ADD_H5ERR_MASK_TEST (tattr-3 1 "h5dump error: unable to open attribute \"attr\"" --enable-error-stack --header -a /attr2 --attribute=/attr tattr.h5)
 # test for displaying at least 9 attributes on root from a be machine
-ADD_H5_TEST (tattr-4_be 0 --enable-error-stack tattr4_be.h5)
+ADD_H5_TEST (tattr-4_be RESULT_CODE 0 --enable-error-stack tattr4_be.h5)
 # test for displaying attributes in shared datatype (also in group and dataset)
-ADD_H5_TEST (tnamed_dtype_attr 0 --enable-error-stack tnamed_dtype_attr.h5)
+ADD_H5_TEST (tnamed_dtype_attr RESULT_CODE 0 --enable-error-stack tnamed_dtype_attr.h5)
 
 # test for displaying soft links and user-defined links
-ADD_H5_TEST (tslink-1 0 --enable-error-stack tslink.h5)
-ADD_H5_TEST (tudlink-1 0 --enable-error-stack tudlink.h5)
+ADD_H5_TEST (tslink-1 RESULT_CODE 0 --enable-error-stack tslink.h5)
+ADD_H5_TEST (tudlink-1 RESULT_CODE 0 --enable-error-stack tudlink.h5)
 # test for displaying the selected link
-ADD_H5_TEST (tslink-2 0 --enable-error-stack -l slink2 tslink.h5)
+ADD_H5_TEST (tslink-2 RESULT_CODE 0 --enable-error-stack -l slink2 tslink.h5)
 ADD_H5_TEST_N (tslink-2 0 --enable-error-stack -N slink2 tslink.h5)
-ADD_H5_TEST (tudlink-2 0 --enable-error-stack -l udlink2 tudlink.h5)
+ADD_H5_TEST (tudlink-2 RESULT_CODE 0 --enable-error-stack -l udlink2 tudlink.h5)
 # test for displaying dangling soft links
 ADD_H5ERR_MASK_TEST (tslink-D 0 "component not found" --enable-error-stack -d /slink1 tslink.h5)
 
 # tests for hard links
-ADD_H5_TEST (thlink-1 0 --enable-error-stack thlink.h5)
-ADD_H5_TEST (thlink-2 0 --enable-error-stack -d /g1/dset2 --dataset /dset1 --dataset=/g1/g1.1/dset3 thlink.h5)
-ADD_H5_TEST (thlink-3 0 --enable-error-stack -d /g1/g1.1/dset3 --dataset /g1/dset2 --dataset=/dset1 thlink.h5)
-ADD_H5_TEST (thlink-4 0 --enable-error-stack -g /g1 thlink.h5)
+ADD_H5_TEST (thlink-1 RESULT_CODE 0 --enable-error-stack thlink.h5)
+ADD_H5_TEST (thlink-2 RESULT_CODE 0 --enable-error-stack -d /g1/dset2 --dataset /dset1 --dataset=/g1/g1.1/dset3 thlink.h5)
+ADD_H5_TEST (thlink-3 RESULT_CODE 0 --enable-error-stack -d /g1/g1.1/dset3 --dataset /g1/dset2 --dataset=/dset1 thlink.h5)
+ADD_H5_TEST (thlink-4 RESULT_CODE 0 --enable-error-stack -g /g1 thlink.h5)
 ADD_H5_TEST_N (thlink-4 0 --enable-error-stack -N /g1 thlink.h5)
-ADD_H5_TEST (thlink-5 0 --enable-error-stack -d /dset1 -g /g2 -d /g1/dset2 thlink.h5)
+ADD_H5_TEST (thlink-5 RESULT_CODE 0 --enable-error-stack -d /dset1 -g /g2 -d /g1/dset2 thlink.h5)
 ADD_H5_TEST_N (thlink-5 0 --enable-error-stack -N /dset1 -N /g2 -N /g1/dset2 thlink.h5)
 
 # tests for compound data types
-ADD_H5_TEST (tcomp-1 0 --enable-error-stack tcompound.h5)
+ADD_H5_TEST (tcomp-1 RESULT_CODE 0 --enable-error-stack tcompound.h5)
 # test for named data types
-ADD_H5_TEST (tcomp-2 0 --enable-error-stack -t /type1 --datatype /type2 --datatype=/group1/type3 tcompound.h5)
+ADD_H5_TEST (tcomp-2 RESULT_CODE 0 --enable-error-stack -t /type1 --datatype /type2 --datatype=/group1/type3 tcompound.h5)
 ADD_H5_TEST_N (tcomp-2 0 --enable-error-stack -N /type1 --any_path /type2 --any_path=/group1/type3 tcompound.h5)
 # test for unnamed type
 ADD_H5ERR_MASK_TEST (tcomp-3 0 "object '#6632' doesn't exist" "--enable-error-stack;-t;/#6632;-g;/group2;tcompound.h5")
 # test complicated compound datatype
-ADD_H5_TEST (tcomp-4 0 --enable-error-stack tcompound_complex.h5)
-ADD_H5_TEST (tcompound_complex2 0 --enable-error-stack tcompound_complex2.h5)
+ADD_H5_TEST (tcomp-4 RESULT_CODE 0 --enable-error-stack tcompound_complex.h5)
+ADD_H5_TEST (tcompound_complex2 RESULT_CODE 0 --enable-error-stack tcompound_complex2.h5)
 # tests for bitfields and opaque data types
 if (H5_WORDS_BIGENDIAN)
-  ADD_H5_TEST (tbitnopaque_be 0 --enable-error-stack tbitnopaque.h5)
+  ADD_H5_TEST (tbitnopaque_be RESULT_CODE 0 --enable-error-stack tbitnopaque.h5)
 else ()
-  ADD_H5_TEST (tbitnopaque_le 0 --enable-error-stack tbitnopaque.h5)
+  ADD_H5_TEST (tbitnopaque_le RESULT_CODE 0 --enable-error-stack tbitnopaque.h5)
 endif ()
 
 # test for the nested compound type
-ADD_H5_TEST (tnestcomp-1 0 --enable-error-stack tnestedcomp.h5)
-ADD_H5_TEST (tnestedcmpddt 0 --enable-error-stack tnestedcmpddt.h5)
+ADD_H5_TEST (tnestcomp-1 RESULT_CODE 0 --enable-error-stack tnestedcomp.h5)
+ADD_H5_TEST (tnestedcmpddt RESULT_CODE 0 --enable-error-stack tnestedcmpddt.h5)
 
 # test for options
 ADD_H5ERR_MASK_TEST (tall-1 0 "unable to open external file, external link file name = 'somefile'" --enable-error-stack tall.h5)
-ADD_H5_TEST (tall-2 0 --enable-error-stack --header -g /g1/g1.1 -a attr2 tall.h5)
-ADD_H5_TEST (tall-3 0 --enable-error-stack -d /g2/dset2.1 -l /g1/g1.2/g1.2.1/slink tall.h5)
+ADD_H5_TEST (tall-2 RESULT_CODE 0 --enable-error-stack --header -g /g1/g1.1 -a attr2 tall.h5)
+ADD_H5_TEST (tall-3 RESULT_CODE 0 --enable-error-stack -d /g2/dset2.1 -l /g1/g1.2/g1.2.1/slink tall.h5)
 ADD_H5_TEST_N (tall-3 0 --enable-error-stack -N /g2/dset2.1 -N /g1/g1.2/g1.2.1/slink tall.h5)
-ADD_H5_TEST (tall-7 0 --enable-error-stack -a attr1 tall.h5)
-ADD_H5_TEST (tall-7N 0 --enable-error-stack -N attr1 tall.h5)
+ADD_H5_TEST (tall-7 RESULT_CODE 0 --enable-error-stack -a attr1 tall.h5)
+ADD_H5_TEST (tall-7N RESULT_CODE 0 --enable-error-stack -N attr1 tall.h5)
 
 # test for loop detection
-ADD_H5_TEST (tloop-1 0 --enable-error-stack tloop.h5)
+ADD_H5_TEST (tloop-1 RESULT_CODE 0 --enable-error-stack tloop.h5)
 
 # test for string
-ADD_H5_TEST (tstr-1 0 --enable-error-stack tstr.h5)
-ADD_H5_TEST (tstr-2 0 --enable-error-stack tstr2.h5)
+ADD_H5_TEST (tstr-1 RESULT_CODE 0 --enable-error-stack tstr.h5)
+ADD_H5_TEST (tstr-2 RESULT_CODE 0 --enable-error-stack tstr2.h5)
 
 # test for file created by Lib SAF team
-ADD_H5_TEST (tsaf 0 --enable-error-stack tsaf.h5)
+ADD_H5_TEST (tsaf RESULT_CODE 0 --enable-error-stack tsaf.h5)
 
 # test for file with variable length data
-ADD_H5_TEST (tvldtypes1 0 --enable-error-stack tvldtypes1.h5)
-ADD_H5_TEST (tvldtypes2 0 --enable-error-stack tvldtypes2.h5)
-ADD_H5_TEST (tvldtypes3 0 --enable-error-stack tvldtypes3.h5)
-ADD_H5_TEST (tvldtypes4 0 --enable-error-stack tvldtypes4.h5)
-ADD_H5_TEST (tvldtypes5 0 --enable-error-stack tvldtypes5.h5)
+ADD_H5_TEST (tvldtypes1 RESULT_CODE 0 --enable-error-stack tvldtypes1.h5)
+ADD_H5_TEST (tvldtypes2 RESULT_CODE 0 --enable-error-stack tvldtypes2.h5)
+ADD_H5_TEST (tvldtypes3 RESULT_CODE 0 --enable-error-stack tvldtypes3.h5)
+ADD_H5_TEST (tvldtypes4 RESULT_CODE 0 --enable-error-stack tvldtypes4.h5)
+ADD_H5_TEST (tvldtypes5 RESULT_CODE 0 --enable-error-stack tvldtypes5.h5)
 
 # test for file with variable length string data
-ADD_H5_TEST (tvlstr 0 --enable-error-stack tvlstr.h5)
-ADD_H5_TEST (tvlenstr_array 0 --enable-error-stack tvlenstr_array.h5)
+ADD_H5_TEST (tvlstr RESULT_CODE 0 --enable-error-stack tvlstr.h5)
+ADD_H5_TEST (tvlenstr_array RESULT_CODE 0 --enable-error-stack tvlenstr_array.h5)
 
 # test for files with array data
-ADD_H5_TEST (tarray1 0 --enable-error-stack tarray1.h5)
+ADD_H5_TEST (tarray1 RESULT_CODE 0 --enable-error-stack tarray1.h5)
 # # added for bug# 2092 - tarray1_big.h5
 ADD_H5ERR_MASK_TEST (tarray1_big 0 "NULL token size" --enable-error-stack -R tarray1_big.h5)
-ADD_H5_TEST (tarray2 0 --enable-error-stack tarray2.h5)
-ADD_H5_TEST (tarray3 0 --enable-error-stack tarray3.h5)
-ADD_H5_TEST (tarray4 0 --enable-error-stack tarray4.h5)
-ADD_H5_TEST (tarray5 0 --enable-error-stack tarray5.h5)
-ADD_H5_TEST (tarray6 0 --enable-error-stack tarray6.h5)
-ADD_H5_TEST (tarray7 0 --enable-error-stack tarray7.h5)
-ADD_H5_TEST (tarray8 0 --enable-error-stack tarray8.h5)
+ADD_H5_TEST (tarray2 RESULT_CODE 0 --enable-error-stack tarray2.h5)
+ADD_H5_TEST (tarray3 RESULT_CODE 0 --enable-error-stack tarray3.h5)
+ADD_H5_TEST (tarray4 RESULT_CODE 0 --enable-error-stack tarray4.h5)
+ADD_H5_TEST (tarray5 RESULT_CODE 0 --enable-error-stack tarray5.h5)
+ADD_H5_TEST (tarray6 RESULT_CODE 0 --enable-error-stack tarray6.h5)
+ADD_H5_TEST (tarray7 RESULT_CODE 0 --enable-error-stack tarray7.h5)
+ADD_H5_TEST (tarray8 RESULT_CODE 0 --enable-error-stack tarray8.h5)
 
 # test for wildcards in filename (does not work with cmake)
 #ADD_H5_MASK_TEST (tstarfile 0 --enable-error-stack -H -d Dataset1 tarr*.h5)
 #ADD_H5_MASK_TEST (tqmarkfile 0 --enable-error-stack -H -d Dataset1 tarray?.h5)
-ADD_H5_TEST (tmultifile 0 --enable-error-stack -H -d Dataset1 tarray2.h5 tarray3.h5 tarray4.h5 tarray5.h5 tarray6.h5 tarray7.h5)
+ADD_H5_TEST (tmultifile RESULT_CODE 0 --enable-error-stack -H -d Dataset1 tarray2.h5 tarray3.h5 tarray4.h5 tarray5.h5 tarray6.h5 tarray7.h5)
 
 # test for files with empty data
-ADD_H5_TEST (tempty 0 --enable-error-stack tempty.h5)
+ADD_H5_TEST (tempty RESULT_CODE 0 --enable-error-stack tempty.h5)
 
 # test for files with groups that have comments
-ADD_H5_TEST (tgrp_comments 0 --enable-error-stack tgrp_comments.h5)
+ADD_H5_TEST (tgrp_comments RESULT_CODE 0 --enable-error-stack tgrp_comments.h5)
 
 # test the --filedriver flag
-ADD_H5_TEST (tsplit_file 0 --enable-error-stack --filedriver=split tsplit_file)
-ADD_H5_TEST (tfamily 0 --enable-error-stack --filedriver=family tfamily%05d.h5)
-ADD_H5_TEST (tmulti 0 --enable-error-stack --filedriver=multi tmulti)
+ADD_H5_TEST (tsplit_file RESULT_CODE 0 --enable-error-stack --filedriver=split tsplit_file)
+ADD_H5_TEST (tfamily RESULT_CODE 0 --enable-error-stack --filedriver=family tfamily%05d.h5)
+ADD_H5_TEST (tmulti RESULT_CODE 0 --enable-error-stack --filedriver=multi tmulti)
 
 # test for files with group names which reach > 1024 bytes in size
-ADD_H5_TEST (tlarge_objname 0 --enable-error-stack -w157 tlarge_objname.h5)
+ADD_H5_TEST (tlarge_objname RESULT_CODE 0 --enable-error-stack -w157 tlarge_objname.h5)
 
 # test '-A' to suppress data but print attr's
 ADD_H5ERR_MASK_TEST (tall-2A 0 "unable to open external file, external link file name = 'somefile'" --enable-error-stack -A tall.h5)
@@ -1199,80 +1222,80 @@ ADD_H5ERR_MASK_TEST (tall-2A0 0 "unable to open external file, external link fil
 ADD_H5ERR_MASK_TEST (tall-2B 0 "unable to open external file, external link file name = 'somefile'" --enable-error-stack -A -r tall.h5)
 
 # test Subsetting
-ADD_H5_TEST (tall-4s 0 --enable-error-stack --dataset=/g1/g1.1/dset1.1.1 --start=1,1 --stride=2,3 --count=3,2 --block=1,1 tall.h5)
-ADD_H5_TEST (tall-5s 0 --enable-error-stack -d "/g1/g1.1/dset1.1.2[0;2;10;]" tall.h5)
-ADD_H5_TEST (tdset-3s 0 --enable-error-stack -d "/dset1[1,1;;;]" tdset.h5)
-ADD_H5_TEST (tno-subset 0 --enable-error-stack --no-compact-subset -d "AHFINDERDIRECT::ah_centroid_t[0] it=0 tl=0" tno-subset.h5)
+ADD_H5_TEST (tall-4s RESULT_CODE 0 --enable-error-stack --dataset=/g1/g1.1/dset1.1.1 --start=1,1 --stride=2,3 --count=3,2 --block=1,1 tall.h5)
+ADD_H5_TEST (tall-5s RESULT_CODE 0 --enable-error-stack -d "/g1/g1.1/dset1.1.2[0;2;10;]" tall.h5)
+ADD_H5_TEST (tdset-3s RESULT_CODE 0 --enable-error-stack -d "/dset1[1,1;;;]" tdset.h5)
+ADD_H5_TEST (tno-subset RESULT_CODE 0 --enable-error-stack --no-compact-subset -d "AHFINDERDIRECT::ah_centroid_t[0] it=0 tl=0" tno-subset.h5)
 
-ADD_H5_TEST (tints4dimsCount2 0 --enable-error-stack -d FourDimInts -s 0,0,0,0 -c 2,2,2,2 tints4dims.h5)
-ADD_H5_TEST (tints4dimsBlock2 0 --enable-error-stack -d FourDimInts -s 0,0,0,0 -c 1,1,1,1 -k 2,2,2,2 tints4dims.h5)
-ADD_H5_TEST (tints4dimsStride2 0 --enable-error-stack -d FourDimInts -s 0,0,0,0 -S 2,2,2,2 -c 2,2,2,2 tints4dims.h5)
-ADD_H5_TEST (tints4dimsCountEq 0 --enable-error-stack -d FourDimInts -s 0,0,0,0 -S 2,2,1,1 -k 1,2,1,1 -c 2,2,4,4 tints4dims.h5)
-ADD_H5_TEST (tints4dimsBlockEq 0 --enable-error-stack -d FourDimInts -s 0,0,0,0 -S 2,2,1,1 -c 2,2,1,1 -k 1,2,4,4 tints4dims.h5)
+ADD_H5_TEST (tints4dimsCount2 RESULT_CODE 0 --enable-error-stack -d FourDimInts -s 0,0,0,0 -c 2,2,2,2 tints4dims.h5)
+ADD_H5_TEST (tints4dimsBlock2 RESULT_CODE 0 --enable-error-stack -d FourDimInts -s 0,0,0,0 -c 1,1,1,1 -k 2,2,2,2 tints4dims.h5)
+ADD_H5_TEST (tints4dimsStride2 RESULT_CODE 0 --enable-error-stack -d FourDimInts -s 0,0,0,0 -S 2,2,2,2 -c 2,2,2,2 tints4dims.h5)
+ADD_H5_TEST (tints4dimsCountEq RESULT_CODE 0 --enable-error-stack -d FourDimInts -s 0,0,0,0 -S 2,2,1,1 -k 1,2,1,1 -c 2,2,4,4 tints4dims.h5)
+ADD_H5_TEST (tints4dimsBlockEq RESULT_CODE 0 --enable-error-stack -d FourDimInts -s 0,0,0,0 -S 2,2,1,1 -c 2,2,1,1 -k 1,2,4,4 tints4dims.h5)
 
 # test printing characters in ASCII instead of decimal
-ADD_H5_TEST (tchar1 0 --enable-error-stack -r tchar.h5)
+ADD_H5_TEST (tchar1 RESULT_CODE 0 --enable-error-stack -r tchar.h5)
 
 # test datatypes in ASCII and UTF8
-ADD_H5_TEST (charsets 0 --enable-error-stack charsets.h5)
+ADD_H5_TEST (charsets RESULT_CODE 0 --enable-error-stack charsets.h5)
 
 # rev. 2004
 # tests for super block
-ADD_H5_TEST (tboot1 0 --enable-error-stack -H -B -d dset tfcontents1.h5)
-ADD_H5_TEST (tboot2 0 --enable-error-stack -B tfcontents2.h5)
-ADD_H5_TEST (tboot2A 0 --enable-error-stack --boot-block tfcontents2.h5)
-ADD_H5_TEST (tboot2B 0 --enable-error-stack --superblock tfcontents2.h5)
-ADD_H5_TEST (file_space 0 --enable-error-stack -B file_space.h5)
-ADD_H5_TEST (file_space_cache 0 --enable-error-stack=2 --page-buffer-size=16384 -B file_space.h5)
+ADD_H5_TEST (tboot1 RESULT_CODE 0 --enable-error-stack -H -B -d dset tfcontents1.h5)
+ADD_H5_TEST (tboot2 RESULT_CODE 0 --enable-error-stack -B tfcontents2.h5)
+ADD_H5_TEST (tboot2A RESULT_CODE 0 --enable-error-stack --boot-block tfcontents2.h5)
+ADD_H5_TEST (tboot2B RESULT_CODE 0 --enable-error-stack --superblock tfcontents2.h5)
+ADD_H5_TEST (file_space RESULT_CODE 0 --enable-error-stack -B file_space.h5)
+ADD_H5_TEST (file_space_cache RESULT_CODE 0 --enable-error-stack=2 --page-buffer-size=16384 -B file_space.h5)
 
 # test -p with a non existing dataset
 ADD_H5ERR_MASK_TEST (tperror 1 "h5dump error: unable to get link info from \"bogus\"" --enable-error-stack -p -d bogus tfcontents1.h5)
 
 # test for file contents
-ADD_H5_TEST (tcontents 0 --enable-error-stack -n tfcontents1.h5)
-ADD_H5_TEST (tordercontents1 0 --enable-error-stack -n --sort_by=name --sort_order=ascending tfcontents1.h5)
-ADD_H5_TEST (tordercontents2 0 --enable-error-stack -n --sort_by=name --sort_order=descending tfcontents1.h5)
-ADD_H5_TEST (tattrcontents1 0 --enable-error-stack -n 1 --sort_order=ascending tall.h5)
-ADD_H5_TEST (tattrcontents2 0 --enable-error-stack -n 1 --sort_order=descending tall.h5)
+ADD_H5_TEST (tcontents RESULT_CODE 0 --enable-error-stack -n tfcontents1.h5)
+ADD_H5_TEST (tordercontents1 RESULT_CODE 0 --enable-error-stack -n --sort_by=name --sort_order=ascending tfcontents1.h5)
+ADD_H5_TEST (tordercontents2 RESULT_CODE 0 --enable-error-stack -n --sort_by=name --sort_order=descending tfcontents1.h5)
+ADD_H5_TEST (tattrcontents1 RESULT_CODE 0 --enable-error-stack -n 1 --sort_order=ascending tall.h5)
+ADD_H5_TEST (tattrcontents2 RESULT_CODE 0 --enable-error-stack -n 1 --sort_order=descending tall.h5)
 
 # tests for storage layout
 # compact
-ADD_H5_TEST (tcompact 0 --enable-error-stack -H -p -d compact tfilters.h5)
+ADD_H5_TEST (tcompact RESULT_CODE 0 --enable-error-stack -H -p -d compact tfilters.h5)
 # contiguous
-ADD_H5_TEST (tcontiguos 0 --enable-error-stack -H -p -d contiguous tfilters.h5)
+ADD_H5_TEST (tcontiguos RESULT_CODE 0 --enable-error-stack -H -p -d contiguous tfilters.h5)
 # chunked
-ADD_H5_TEST (tchunked 0 --enable-error-stack -H -p -d chunked tfilters.h5)
+ADD_H5_TEST (tchunked RESULT_CODE 0 --enable-error-stack -H -p -d chunked tfilters.h5)
 # external
-ADD_H5_TEST (texternal 0 --enable-error-stack -H -p -d external tfilters.h5)
+ADD_H5_TEST (texternal RESULT_CODE 0 --enable-error-stack -H -p -d external tfilters.h5)
 
 # fill values
-ADD_H5_TEST (tfill 0 --enable-error-stack -p tfvalues.h5)
+ADD_H5_TEST (tfill RESULT_CODE 0 --enable-error-stack -p tfvalues.h5)
 
 # several datatype, with references , print path
-ADD_H5_TEST (treference 0 --enable-error-stack  tattr2.h5)
+ADD_H5_TEST (treference RESULT_CODE 0 --enable-error-stack  tattr2.h5)
 
 # escape/not escape non printable characters
-ADD_H5_TEST (tstringe 0 --enable-error-stack -e tstr3.h5)
-ADD_H5_TEST (tstring 0 --enable-error-stack tstr3.h5)
+ADD_H5_TEST (tstringe RESULT_CODE 0 --enable-error-stack -e tstr3.h5)
+ADD_H5_TEST (tstring RESULT_CODE 0 --enable-error-stack tstr3.h5)
 # char data as ASCII with non escape
-ADD_H5_TEST (tstring2 0 --enable-error-stack -r -d str4 tstr3.h5)
+ADD_H5_TEST (tstring2 RESULT_CODE 0 --enable-error-stack -r -d str4 tstr3.h5)
 
 # array indices print/not print
-ADD_H5_TEST (tindicesyes 0 --enable-error-stack taindices.h5)
-ADD_H5_TEST (tindicesno 0 --enable-error-stack -y taindices.h5)
+ADD_H5_TEST (tindicesyes RESULT_CODE 0 --enable-error-stack taindices.h5)
+ADD_H5_TEST (tindicesno RESULT_CODE 0 --enable-error-stack -y taindices.h5)
 
 ########## array indices with subsetting
 # 1D case
-ADD_H5_TEST (tindicessub1 0 --enable-error-stack -d 1d -s 1 -S 10 -c 2  -k 3 taindices.h5)
+ADD_H5_TEST (tindicessub1 RESULT_CODE 0 --enable-error-stack -d 1d -s 1 -S 10 -c 2  -k 3 taindices.h5)
 
 # 2D case
-ADD_H5_TEST (tindicessub2 0 --enable-error-stack -d 2d -s 1,2  -S 3,3 -c 3,2 -k 2,2 taindices.h5)
+ADD_H5_TEST (tindicessub2 RESULT_CODE 0 --enable-error-stack -d 2d -s 1,2  -S 3,3 -c 3,2 -k 2,2 taindices.h5)
 
 # 3D case
-ADD_H5_TEST (tindicessub3 0 --enable-error-stack -d 3d -s 0,1,2 -S 1,3,3 -c 2,2,2  -k 1,2,2  taindices.h5)
+ADD_H5_TEST (tindicessub3 RESULT_CODE 0 --enable-error-stack -d 3d -s 0,1,2 -S 1,3,3 -c 2,2,2  -k 1,2,2  taindices.h5)
 
 # 4D case
-ADD_H5_TEST (tindicessub4 0 --enable-error-stack -d 4d -s 0,0,1,2  -c 2,2,3,2 -S 1,1,3,3 -k 1,1,2,2  taindices.h5)
+ADD_H5_TEST (tindicessub4 RESULT_CODE 0 --enable-error-stack -d 4d -s 0,0,1,2  -c 2,2,3,2 -S 1,1,3,3 -k 1,1,2,2  taindices.h5)
 
 # Exceed the dimensions for subsetting
 ADD_H5ERR_MASK_TEST (texceedsubstart 1 "exceed dataset dims" --enable-error-stack -d 1d -s 1,3 taindices.h5)
@@ -1288,7 +1311,7 @@ ADD_H5_COMP_TEST (tszip 0 2 --enable-error-stack -H -p -d szip tfilters.h5)
 ADD_H5_COMP_TEST (tdeflate 0 2 --enable-error-stack -H -p -d deflate tfilters.h5)
 
 # shuffle
-ADD_H5_TEST (tshuffle 0 --enable-error-stack -H -p -d shuffle tfilters.h5)
+ADD_H5_TEST (tshuffle RESULT_CODE 0 --enable-error-stack -H -p -d shuffle tfilters.h5)
 
 # fletcher32
 ADD_H5_COMP_TEST (tfletcher32 0 0 --enable-error-stack -H -p -d fletcher32  tfilters.h5)
@@ -1303,7 +1326,7 @@ ADD_H5_COMP_TEST (tscaleoffset 0 4 --enable-error-stack -H -p -d scaleoffset  tf
 ADD_H5_COMP_TEST (tallfilters 0 1 --enable-error-stack -H -p -d all  tfilters.h5)
 
 # user defined
-ADD_H5_TEST (tuserfilter 0 --enable-error-stack -H  -p -d myfilter  tfilters.h5)
+ADD_H5_TEST (tuserfilter RESULT_CODE 0 --enable-error-stack -H  -p -d myfilter  tfilters.h5)
 
 
 # See which filters are usable (and skip tests for filters we
@@ -1321,37 +1344,37 @@ endif ()
 
 if (USE_FILTER_DEFLATE)
   # data read internal filters
-  ADD_H5_TEST (treadintfilter 0 --enable-error-stack -d deflate -d shuffle -d fletcher32 -d nbit -d scaleoffset tfilters.h5)
+  ADD_H5_TEST (treadintfilter RESULT_CODE 0 --enable-error-stack -d deflate -d shuffle -d fletcher32 -d nbit -d scaleoffset tfilters.h5)
   if (HDF5_ENABLE_SZIP_SUPPORT)
     # data read all filters
-    ADD_H5_TEST (treadfilter 0 --enable-error-stack -d all -d szip tfilters.h5)
+    ADD_H5_TEST (treadfilter RESULT_CODE 0 --enable-error-stack -d all -d szip tfilters.h5)
   endif ()
 endif ()
 
 # test for displaying objects with very long names
-ADD_H5_TEST (tlonglinks 0 --enable-error-stack tlonglinks.h5)
+ADD_H5_TEST (tlonglinks RESULT_CODE 0 --enable-error-stack tlonglinks.h5)
 
 # dimensions over 4GB, print boundary
-ADD_H5_TEST (tbigdims 0 --enable-error-stack -d dset4gb -s 4294967284 -c 22 tbigdims.h5)
+ADD_H5_TEST (tbigdims RESULT_CODE 0 --enable-error-stack -d dset4gb -s 4294967284 -c 22 tbigdims.h5)
 
 # hyperslab read
-ADD_H5_TEST (thyperslab 0 --enable-error-stack thyperslab.h5)
+ADD_H5_TEST (thyperslab RESULT_CODE 0 --enable-error-stack thyperslab.h5)
 
 # test for displaying dataset and attribute of null space
-ADD_H5_TEST (tnullspace 0 --enable-error-stack tnullspace.h5)
-ADD_H5_TEST (tgrpnullspace 0 -p --enable-error-stack tgrpnullspace.h5)
+ADD_H5_TEST (tnullspace RESULT_CODE 0 --enable-error-stack tnullspace.h5)
+ADD_H5_TEST (tgrpnullspace RESULT_CODE 0 -p --enable-error-stack tgrpnullspace.h5)
 
 # test for displaying dataset and attribute of space with 0 dimension size
-ADD_H5_TEST (zerodim 0 --enable-error-stack zerodim.h5)
+ADD_H5_TEST (zerodim RESULT_CODE 0 --enable-error-stack zerodim.h5)
 
 # test for long double (some systems do not have long double)
-ADD_H5_TEST (tfloatsattrs 0 -p --format=%.4g --lformat=%.4Lg --width=80 --enable-error-stack tfloatsattrs.h5)
-ADD_H5_TEST (tldouble 0 --enable-error-stack tldouble.h5)
-ADD_H5_TEST (tldouble_scalar 0 -p --enable-error-stack tldouble_scalar.h5)
+ADD_H5_TEST (tfloatsattrs RESULT_CODE 0 -p --format=%.4g --lformat=%.4Lg --width=80 --enable-error-stack tfloatsattrs.h5)
+ADD_H5_TEST (tldouble RESULT_CODE 0 --enable-error-stack tldouble.h5)
+ADD_H5_TEST (tldouble_scalar RESULT_CODE 0 -p --enable-error-stack tldouble_scalar.h5)
 
 # Add tests for _Float16 type
-ADD_H5_TEST (tfloat16 0 --enable-error-stack tfloat16.h5)
-ADD_H5_TEST (tfloat16_be 0 --enable-error-stack tfloat16_be.h5)
+ADD_H5_TEST (tfloat16 RESULT_CODE 0 --enable-error-stack tfloat16.h5)
+ADD_H5_TEST (tfloat16_be RESULT_CODE 0 --enable-error-stack tfloat16_be.h5)
 
 # Add tests for complex numbers. For portability, use a fixed floating-point
 # precision and skip dumping of the "long double _Complex" dataset. The "long
@@ -1361,21 +1384,21 @@ ADD_H5_TEST (tfloat16_be 0 --enable-error-stack tfloat16_be.h5)
 # sizeof(long double) != sizeof(double). Use -w80 after the floating-point
 # format option since specifying a fixed floating-point precision resets h5dump's
 # default number of columns value.
-ADD_H5_TEST (tcomplex 0 --enable-error-stack -m %.6f -w80 -d ArrayDatasetFloatComplex
+ADD_H5_TEST (tcomplex RESULT_CODE 0 --enable-error-stack -m %.6f -w80 -d ArrayDatasetFloatComplex
               -d CompoundDatasetFloatComplex -d DatasetDoubleComplex -d DatasetFloatComplex
               -d VariableLengthDatasetFloatComplex tcomplex.h5)
-ADD_H5_TEST (tcomplex_info 0 --enable-error-stack -p -H -m %.6f -w80 -d ArrayDatasetFloatComplex
+ADD_H5_TEST (tcomplex_info RESULT_CODE 0 --enable-error-stack -p -H -m %.6f -w80 -d ArrayDatasetFloatComplex
               -d CompoundDatasetFloatComplex -d DatasetDoubleComplex -d DatasetFloatComplex
               -d VariableLengthDatasetFloatComplex tcomplex.h5)
-ADD_H5_TEST (tcomplex_be 0 --enable-error-stack -m %.6f -w80 -d ArrayDatasetFloatComplex
+ADD_H5_TEST (tcomplex_be RESULT_CODE 0 --enable-error-stack -m %.6f -w80 -d ArrayDatasetFloatComplex
               -d CompoundDatasetFloatComplex -d DatasetDoubleComplex -d DatasetFloatComplex
               -d VariableLengthDatasetFloatComplex tcomplex_be.h5)
-ADD_H5_TEST (tcomplex_be_info 0 --enable-error-stack -p -H -m %.6f -w80 -d ArrayDatasetFloatComplex
+ADD_H5_TEST (tcomplex_be_info RESULT_CODE 0 --enable-error-stack -p -H -m %.6f -w80 -d ArrayDatasetFloatComplex
               -d CompoundDatasetFloatComplex -d DatasetDoubleComplex -d DatasetFloatComplex
               -d VariableLengthDatasetFloatComplex tcomplex_be.h5)
 
 # test for vms
-ADD_H5_TEST (tvms 0 --enable-error-stack tvms.h5)
+ADD_H5_TEST (tvms RESULT_CODE 0 --enable-error-stack tvms.h5)
 
 # test for binary output
 ADD_H5_BIN_EXPORT (tbin1LE 0 tbinary.h5 --enable-error-stack -d integer -b LE)
@@ -1399,43 +1422,43 @@ if (NOT HDF5_ENABLE_USING_MEMCHECKER)
 endif ()
 
 # test for dataset region references
-ADD_H5_TEST (tdatareg 0 --enable-error-stack tdatareg.h5)
+ADD_H5_TEST (tdatareg RESULT_CODE 0 --enable-error-stack tdatareg.h5)
 ADD_H5ERR_MASK_TEST (tdataregR 0 "NULL token size" --enable-error-stack -R tdatareg.h5)
-ADD_H5_TEST (tattrreg 0 --enable-error-stack tattrreg.h5)
+ADD_H5_TEST (tattrreg RESULT_CODE 0 --enable-error-stack tattrreg.h5)
 ADD_H5ERR_MASK_TEST (tattrregR 0 "NULL token size" -R --enable-error-stack tattrreg.h5)
 ADD_H5_EXPORT_TEST (tbinregR tdatareg.h5 0 --enable-error-stack -d /Dataset1 -s 0 -R -y -o)
 
 # test for 1.12 region references
-ADD_H5_TEST (trefer_attrR 0 --enable-error-stack -R trefer_attr.h5)
-ADD_H5_TEST (trefer_compatR 0 --enable-error-stack -R trefer_compat.h5)
-ADD_H5_TEST (trefer_extR 0 --enable-error-stack -R trefer_ext2.h5)
-ADD_H5_TEST (trefer_grpR 0 --enable-error-stack -R trefer_grp.h5)
-ADD_H5_TEST (trefer_obj_delR 0 --enable-error-stack -R trefer_obj_del.h5)
-ADD_H5_TEST (trefer_objR 0 --enable-error-stack -R trefer_obj.h5)
-ADD_H5_TEST (trefer_paramR 0 --enable-error-stack -R trefer_param.h5)
-ADD_H5_TEST (trefer_regR 0 --enable-error-stack -R trefer_reg.h5)
-ADD_H5_TEST (trefer_reg_1dR 0 --enable-error-stack -R trefer_reg_1d.h5)
+ADD_H5_TEST (trefer_attrR RESULT_CODE 0 --enable-error-stack -R trefer_attr.h5)
+ADD_H5_TEST (trefer_compatR RESULT_CODE 0 --enable-error-stack -R trefer_compat.h5)
+ADD_H5_TEST (trefer_extR RESULT_CODE 0 --enable-error-stack -R trefer_ext2.h5)
+ADD_H5_TEST (trefer_grpR RESULT_CODE 0 --enable-error-stack -R trefer_grp.h5)
+ADD_H5_TEST (trefer_obj_delR RESULT_CODE 0 --enable-error-stack -R trefer_obj_del.h5)
+ADD_H5_TEST (trefer_objR RESULT_CODE 0 --enable-error-stack -R trefer_obj.h5)
+ADD_H5_TEST (trefer_paramR RESULT_CODE 0 --enable-error-stack -R trefer_param.h5)
+ADD_H5_TEST (trefer_regR RESULT_CODE 0 --enable-error-stack -R trefer_reg.h5)
+ADD_H5_TEST (trefer_reg_1dR RESULT_CODE 0 --enable-error-stack -R trefer_reg_1d.h5)
 
 # tests for group creation order
 # "1" tracked, "2" name, root tracked
-ADD_H5_TEST (tordergr1 0 --enable-error-stack --group=1 --sort_by=creation_order --sort_order=ascending tordergr.h5)
-ADD_H5_TEST (tordergr2 0 --enable-error-stack --group=1 --sort_by=creation_order --sort_order=descending tordergr.h5)
-ADD_H5_TEST (tordergr3 0 --enable-error-stack -g 2 -q name -z ascending tordergr.h5)
-ADD_H5_TEST (tordergr4 0 --enable-error-stack -g 2 -q name -z descending tordergr.h5)
-ADD_H5_TEST (tordergr5 0 --enable-error-stack -q creation_order tordergr.h5)
+ADD_H5_TEST (tordergr1 RESULT_CODE 0 --enable-error-stack --group=1 --sort_by=creation_order --sort_order=ascending tordergr.h5)
+ADD_H5_TEST (tordergr2 RESULT_CODE 0 --enable-error-stack --group=1 --sort_by=creation_order --sort_order=descending tordergr.h5)
+ADD_H5_TEST (tordergr3 RESULT_CODE 0 --enable-error-stack -g 2 -q name -z ascending tordergr.h5)
+ADD_H5_TEST (tordergr4 RESULT_CODE 0 --enable-error-stack -g 2 -q name -z descending tordergr.h5)
+ADD_H5_TEST (tordergr5 RESULT_CODE 0 --enable-error-stack -q creation_order tordergr.h5)
 
 # tests for attribute order
-ADD_H5_TEST (torderattr1 0 --enable-error-stack -H --sort_by=name --sort_order=ascending torderattr.h5)
-ADD_H5_TEST (torderattr2 0 --enable-error-stack -H --sort_by=name --sort_order=descending torderattr.h5)
-ADD_H5_TEST (torderattr3 0 --enable-error-stack -H --sort_by=creation_order --sort_order=ascending torderattr.h5)
-ADD_H5_TEST (torderattr4 0 --enable-error-stack -H --sort_by=creation_order --sort_order=descending torderattr.h5)
+ADD_H5_TEST (torderattr1 RESULT_CODE 0 --enable-error-stack -H --sort_by=name --sort_order=ascending torderattr.h5)
+ADD_H5_TEST (torderattr2 RESULT_CODE 0 --enable-error-stack -H --sort_by=name --sort_order=descending torderattr.h5)
+ADD_H5_TEST (torderattr3 RESULT_CODE 0 --enable-error-stack -H --sort_by=creation_order --sort_order=ascending torderattr.h5)
+ADD_H5_TEST (torderattr4 RESULT_CODE 0 --enable-error-stack -H --sort_by=creation_order --sort_order=descending torderattr.h5)
 
 # tests for link references and order
 ADD_H5ERR_MASK_TEST (torderlinks1 0 "unable to open external file, external link file name = 'fname'" --enable-error-stack --sort_by=name --sort_order=ascending tfcontents1.h5)
 ADD_H5ERR_MASK_TEST (torderlinks2 0 "unable to open external file, external link file name = 'fname'" --enable-error-stack --sort_by=name --sort_order=descending tfcontents1.h5)
 
 # tests for floating point user defined printf format
-ADD_H5_TEST (tfpformat 0 --enable-error-stack --format=%.7f tfpformat.h5)
+ADD_H5_TEST (tfpformat RESULT_CODE 0 --enable-error-stack --format=%.7f tfpformat.h5)
 
 # tests for traversal of external links
 ADD_H5ERR_MASK_TEST (textlinksrc 0 "Too many soft links in path" --enable-error-stack textlinksrc.h5)
@@ -1471,10 +1494,10 @@ ADD_H5ERR_MASK_TEST (tCVE_2018_11206_fill_new 1 "" tCVE_2018_11206_fill_new.h5)
 ADD_H5ERR_MASK_TEST (tCVE-2021-37501_attr_decode 1 "error getting attribute information" tCVE-2021-37501_attr_decode.h5)
 
 # onion VFD tests
-ADD_H5_TEST (tst_onion_objs 0 --enable-error-stack --vfd-name onion --vfd-info 3 tst_onion_objs.h5)
-ADD_H5_TEST (tst_onion_dset_ext 0 --enable-error-stack --vfd-name onion --vfd-info 1 tst_onion_dset_ext.h5)
-ADD_H5_TEST (tst_onion_dset_1d 0 --enable-error-stack --vfd-name onion --vfd-info 1 tst_onion_dset_1d.h5)
-ADD_H5_TEST (tst_onion_revision_count 0 --enable-error-stack --vfd-name onion --vfd-info revision_count tst_onion_objs.h5)
+ADD_H5_TEST (tst_onion_objs RESULT_CODE 0 --enable-error-stack --vfd-name onion --vfd-info 3 tst_onion_objs.h5)
+ADD_H5_TEST (tst_onion_dset_ext RESULT_CODE 0 --enable-error-stack --vfd-name onion --vfd-info 1 tst_onion_dset_ext.h5)
+ADD_H5_TEST (tst_onion_dset_1d RESULT_CODE 0 --enable-error-stack --vfd-name onion --vfd-info 1 tst_onion_dset_1d.h5)
+ADD_H5_TEST (tst_onion_revision_count RESULT_CODE 0 --enable-error-stack --vfd-name onion --vfd-info revision_count tst_onion_objs.h5)
 
 
 ##############################################################################

--- a/tools/test/h5dump/CMakeTests.cmake
+++ b/tools/test/h5dump/CMakeTests.cmake
@@ -464,14 +464,18 @@ endmacro ()
 #
 # REQUIRED KEYWORD ARGUMENTS:
 #   RESULT_CODE <code>    - expected return code after test execution. 0 is success
+#
+# OPTIONAL KEYWORD ARGUMENTS:
 #   APPLY_FILTERS <resultvalue> - If provided, test will apply filters to output before comparison.
 #                                 <resultvalue> is used to construct the filter expressions
+# OPTIONAL MULTI-KEYWORD ARGUMENTS
+#   ANY_PATHS <paths>   - The -N/--any_path argument(s) to h5dump.
 #
 macro (ADD_H5_TEST testname)
   cmake_parse_arguments(ARG
     ""
     "RESULT_CODE;APPLY_FILTERS"
-    ""
+    "ANY_PATHS"
     ${ARGN}
   )
 
@@ -480,7 +484,7 @@ macro (ADD_H5_TEST testname)
     message(FATAL_ERROR "ADD_H5_TEST: RESULT_CODE is required")
   endif ()
 
-  # Set up filters
+  # Validate optional parameters
   if (DEFINED ARG_APPLY_FILTERS)
     if ("${ARG_APPLY_FILTERS}" STREQUAL "")
       message(FATAL_ERROR "ADD_H5_TEST: APPLY_FILTERS requires a resultvalue")
@@ -493,9 +497,34 @@ macro (ADD_H5_TEST testname)
     set (filters_out "")
   endif ()
 
+  if (DEFINED ARG_ANY_PATHS)
+    set(temp_path_arg "")
+    foreach (arg_path IN LISTS ARG_ANY_PATHS)
+        if (arg_path STREQUAL "")
+            message(FATAL_ERROR "ADD_H5_TEST: ANY_PATHS requires a path")
+        endif ()
+
+        list(APPEND temp_path_arg "--any_path=${arg_path}")
+    endforeach()
+
+    set (ARG_ANY_PATHS ${temp_path_arg})
+  endif ()
+
+  # Cleanup if test produces artifacts
+  if (DEFINED ARG_ANY_PATHS)
+    add_test (
+        NAME H5DUMP-${testname}-clear-objects
+        COMMAND ${CMAKE_COMMAND} -E remove
+            ${testname}.bin
+    )
+    set_tests_properties (H5DUMP-${testname}-clear-objects PROPERTIES
+        WORKING_DIRECTORY "${PROJECT_BINARY_DIR}/testfiles/std"
+    )
+  endif ()
+
   # If using memchecker add tests without using scripts
   if (HDF5_ENABLE_USING_MEMCHECKER)
-    add_test (NAME H5DUMP-${testname} COMMAND ${CMAKE_CROSSCOMPILING_EMULATOR} $<TARGET_FILE:h5dump> ${ARG_UNPARSED_ARGUMENTS})
+    add_test (NAME H5DUMP-${testname} COMMAND ${CMAKE_CROSSCOMPILING_EMULATOR} $<TARGET_FILE:h5dump> ${ARG_ANY_PATHS} ${ARG_UNPARSED_ARGUMENTS})
     if (${ARG_RESULT_CODE})
       set_tests_properties (H5DUMP-${testname} PROPERTIES WILL_FAIL "true")
     endif ()
@@ -508,7 +537,7 @@ macro (ADD_H5_TEST testname)
         COMMAND "${CMAKE_COMMAND}"
             -D "TEST_EMULATOR=${CMAKE_CROSSCOMPILING_EMULATOR}"
             -D "TEST_PROGRAM=$<TARGET_FILE:h5dump>"
-            -D "TEST_ARGS:STRING=${ARG_UNPARSED_ARGUMENTS}"
+            -D "TEST_ARGS:STRING=${ARG_ANY_PATHS};${ARG_UNPARSED_ARGUMENTS}"
             -D "TEST_FOLDER=${PROJECT_BINARY_DIR}/testfiles/std"
             -D "TEST_OUTPUT=${testname}.out"
             -D "TEST_EXPECT=${ARG_RESULT_CODE}"
@@ -521,58 +550,27 @@ macro (ADD_H5_TEST testname)
   set_tests_properties (H5DUMP-${testname} PROPERTIES
       WORKING_DIRECTORY "${PROJECT_BINARY_DIR}/testfiles/std"
   )
+
   if ("H5DUMP-${testname}" MATCHES "${HDF5_DISABLE_TESTS_REGEX}")
     set_tests_properties (H5DUMP-${testname} PROPERTIES DISABLED true)
   endif ()
-endmacro ()
 
-macro (ADD_H5_TEST_N resultfile resultcode)
-  add_test (
-      NAME H5DUMP-N-${resultfile}-clear-objects
+  if (DEFINED ARG_ANY_PATHS)
+    set_tests_properties (H5DUMP-${testname} PROPERTIES
+      DEPENDS H5DUMP-${testname}-clear-objects
+    )
+    
+    add_test (
+      NAME H5DUMP-${testname}-clean-objects
       COMMAND ${CMAKE_COMMAND} -E remove
-          ${resultfile}-N.bin
-  )
-  set_tests_properties (H5DUMP-N-${resultfile}-clear-objects PROPERTIES
-      WORKING_DIRECTORY "${PROJECT_BINARY_DIR}/testfiles/std"
-  )
-  # If using memchecker add tests without using scripts
-  if (HDF5_ENABLE_USING_MEMCHECKER)
-    add_test (NAME H5DUMP-N-${resultfile} COMMAND ${CMAKE_CROSSCOMPILING_EMULATOR} $<TARGET_FILE:h5dump> ${ARGN})
-    if (${resultcode})
-      set_tests_properties (H5DUMP-N-${resultfile} PROPERTIES WILL_FAIL "true")
-    endif ()
-    set_tests_properties (H5DUMP-N-${resultfile} PROPERTIES
+          ${testname}.bin
+    )
+
+    set_tests_properties (H5DUMP-${testname}-clean-objects PROPERTIES
+        DEPENDS H5DUMP-${testname}
         WORKING_DIRECTORY "${PROJECT_BINARY_DIR}/testfiles/std"
     )
-  else ()
-    add_test (
-        NAME H5DUMP-N-${resultfile}
-        COMMAND "${CMAKE_COMMAND}"
-            -D "TEST_EMULATOR=${CMAKE_CROSSCOMPILING_EMULATOR}"
-            -D "TEST_PROGRAM=$<TARGET_FILE:h5dump>"
-            -D "TEST_ARGS:STRING=${ARGN}"
-            -D "TEST_FOLDER=${PROJECT_BINARY_DIR}/testfiles/std"
-            -D "TEST_OUTPUT=${resultfile}-N.out"
-            -D "TEST_EXPECT=${resultcode}"
-            -D "TEST_REFERENCE=${resultfile}-N.ddl"
-            -P "${HDF_RESOURCES_DIR}/runTest.cmake"
-    )
   endif ()
-  set_tests_properties (H5DUMP-N-${resultfile} PROPERTIES
-      DEPENDS H5DUMP-N-${resultfile}-clear-objects
-  )
-  if ("H5DUMP-N-${resultfile}" MATCHES "${HDF5_DISABLE_TESTS_REGEX}")
-    set_tests_properties (H5DUMP-N-${resultfile} PROPERTIES DISABLED true)
-  endif ()
-  add_test (
-      NAME H5DUMP-N-${resultfile}-clean-objects
-      COMMAND ${CMAKE_COMMAND} -E remove
-          ${resultfile}-N.bin
-  )
-  set_tests_properties (H5DUMP-N-${resultfile}-clean-objects PROPERTIES
-      DEPENDS H5DUMP-N-${resultfile}
-      WORKING_DIRECTORY "${PROJECT_BINARY_DIR}/testfiles/std"
-  )
 endmacro ()
 
 macro (ADD_H5_TEST_EXPORT resultfile targetfile resultcode)
@@ -1087,7 +1085,7 @@ ADD_H5ERR_MASK_TEST (tdset-2 1 "h5dump error: unable to get link info from \"dse
 ADD_H5_TEST (tattr-1 RESULT_CODE 0 --enable-error-stack tattr.h5)
 # test for displaying the selected attributes of string type and scalar space
 ADD_H5_TEST (tattr-2 RESULT_CODE 0 --enable-error-stack -a /\\\\/attr1 --attribute /attr4 --attribute=/attr5 tattr.h5)
-ADD_H5_TEST_N (tattr-2 0 --enable-error-stack -N /\\\\/attr1 --any_path /attr4 --any_path=/attr5 tattr.h5)
+ADD_H5_TEST (tattr-2-N RESULT_CODE 0 --enable-error-stack  tattr.h5 ANY_PATHS /\\\\/attr1 /attr4 /attr5)
 # test for header and error messages
 ADD_H5ERR_MASK_TEST (tattr-3 1 "h5dump error: unable to open attribute \"attr\"" --enable-error-stack --header -a /attr2 --attribute=/attr tattr.h5)
 # test for displaying at least 9 attributes on root from a be machine
@@ -1100,7 +1098,7 @@ ADD_H5_TEST (tslink-1 RESULT_CODE 0 --enable-error-stack tslink.h5)
 ADD_H5_TEST (tudlink-1 RESULT_CODE 0 --enable-error-stack tudlink.h5)
 # test for displaying the selected link
 ADD_H5_TEST (tslink-2 RESULT_CODE 0 --enable-error-stack -l slink2 tslink.h5)
-ADD_H5_TEST_N (tslink-2 0 --enable-error-stack -N slink2 tslink.h5)
+ADD_H5_TEST (tslink-2-N RESULT_CODE 0 --enable-error-stack tslink.h5 ANY_PATHS slink2 )
 ADD_H5_TEST (tudlink-2 RESULT_CODE 0 --enable-error-stack -l udlink2 tudlink.h5)
 # test for displaying dangling soft links
 ADD_H5ERR_MASK_TEST (tslink-D 0 "component not found" --enable-error-stack -d /slink1 tslink.h5)
@@ -1110,15 +1108,15 @@ ADD_H5_TEST (thlink-1 RESULT_CODE 0 --enable-error-stack thlink.h5)
 ADD_H5_TEST (thlink-2 RESULT_CODE 0 --enable-error-stack -d /g1/dset2 --dataset /dset1 --dataset=/g1/g1.1/dset3 thlink.h5)
 ADD_H5_TEST (thlink-3 RESULT_CODE 0 --enable-error-stack -d /g1/g1.1/dset3 --dataset /g1/dset2 --dataset=/dset1 thlink.h5)
 ADD_H5_TEST (thlink-4 RESULT_CODE 0 --enable-error-stack -g /g1 thlink.h5)
-ADD_H5_TEST_N (thlink-4 0 --enable-error-stack -N /g1 thlink.h5)
+ADD_H5_TEST (thlink-4-N RESULT_CODE 0 --enable-error-stack thlink.h5 ANY_PATHS /g1)
 ADD_H5_TEST (thlink-5 RESULT_CODE 0 --enable-error-stack -d /dset1 -g /g2 -d /g1/dset2 thlink.h5)
-ADD_H5_TEST_N (thlink-5 0 --enable-error-stack -N /dset1 -N /g2 -N /g1/dset2 thlink.h5)
+ADD_H5_TEST (thlink-5-N RESULT_CODE 0 --enable-error-stack thlink.h5 ANY_PATHS /dset1 /g2 /g1/dset2)
 
 # tests for compound data types
 ADD_H5_TEST (tcomp-1 RESULT_CODE 0 --enable-error-stack tcompound.h5)
 # test for named data types
 ADD_H5_TEST (tcomp-2 RESULT_CODE 0 --enable-error-stack -t /type1 --datatype /type2 --datatype=/group1/type3 tcompound.h5)
-ADD_H5_TEST_N (tcomp-2 0 --enable-error-stack -N /type1 --any_path /type2 --any_path=/group1/type3 tcompound.h5)
+ADD_H5_TEST (tcomp-2-N RESULT_CODE 0 --enable-error-stack tcompound.h5 ANY_PATHS /type1 /type2 /group1/type3)
 # test for unnamed type
 ADD_H5ERR_MASK_TEST (tcomp-3 0 "object '#6632' doesn't exist" "--enable-error-stack;-t;/#6632;-g;/group2;tcompound.h5")
 # test complicated compound datatype
@@ -1139,9 +1137,9 @@ ADD_H5_TEST (tnestedcmpddt RESULT_CODE 0 --enable-error-stack tnestedcmpddt.h5)
 ADD_H5ERR_MASK_TEST (tall-1 0 "unable to open external file, external link file name = 'somefile'" --enable-error-stack tall.h5)
 ADD_H5_TEST (tall-2 RESULT_CODE 0 --enable-error-stack --header -g /g1/g1.1 -a attr2 tall.h5)
 ADD_H5_TEST (tall-3 RESULT_CODE 0 --enable-error-stack -d /g2/dset2.1 -l /g1/g1.2/g1.2.1/slink tall.h5)
-ADD_H5_TEST_N (tall-3 0 --enable-error-stack -N /g2/dset2.1 -N /g1/g1.2/g1.2.1/slink tall.h5)
+ADD_H5_TEST (tall-3-N RESULT_CODE 0 --enable-error-stack  tall.h5 ANY_PATHS /g2/dset2.1 /g1/g1.2/g1.2.1/slink)
 ADD_H5_TEST (tall-7 RESULT_CODE 0 --enable-error-stack -a attr1 tall.h5)
-ADD_H5_TEST (tall-7N RESULT_CODE 0 --enable-error-stack -N attr1 tall.h5)
+ADD_H5_TEST (tall-7N RESULT_CODE 0 --enable-error-stack tall.h5 ANY_PATHS attr1)
 
 # test for loop detection
 ADD_H5_TEST (tloop-1 RESULT_CODE 0 --enable-error-stack tloop.h5)

--- a/tools/test/h5dump/CMakeTests.cmake
+++ b/tools/test/h5dump/CMakeTests.cmake
@@ -560,6 +560,10 @@ macro (ADD_H5_TEST testname)
     list(APPEND CLEANUP_FILES "${testname}.txt")
   endif ()
 
+  if (DEFINED ARG_OUTPUT_FILE)
+    list(APPEND CLEANUP_FILES "${ARG_OUTPUT_FILE}.txt")
+  endif ()
+
   if (DEFINED ARG_DDL_FILE)
     list(APPEND CLEANUP_FILES "${ARG_DDL_FILE}.txt")
   endif ()

--- a/tools/test/h5dump/CMakeTests.cmake
+++ b/tools/test/h5dump/CMakeTests.cmake
@@ -469,13 +469,15 @@ endmacro ()
 # OPTIONAL KEYWORD ARGUMENTS:
 #   APPLY_FILTERS <resultvalue> - If provided, test will apply filters to output before comparison.
 #                                 <resultvalue> is used to construct the filter expressions
+#   OUTPUT_FILE <filename> - if provided, put h5dump output into <filename>.txt and compare it to <filename>.exp
+#
 # OPTIONAL MULTI-KEYWORD ARGUMENTS
 #   ANY_PATHS <paths>   - The -N/--any_path argument(s) to h5dump.
 #
 macro (ADD_H5_TEST testname)
   cmake_parse_arguments(ARG
     ""
-    "RESULT_CODE;APPLY_FILTERS;TARGET_FILE"
+    "RESULT_CODE;APPLY_FILTERS;TARGET_FILE;OUTPUT_FILE"
     "ANY_PATHS"
     ${ARGN}
   )
@@ -515,21 +517,40 @@ macro (ADD_H5_TEST testname)
     set (ARG_ANY_PATHS ${temp_path_arg})
   endif ()
 
+  if (DEFINED ARG_OUTPUT_FILE)
+    set (ARG_OUTPUT_FILE "-o" "${ARG_OUTPUT_FILE}.txt")
+  endif ()
+
   # Cleanup if test produces artifacts
   if (DEFINED ARG_ANY_PATHS)
     add_test (
-        NAME H5DUMP-${testname}-clear-objects
+        NAME H5DUMP-${testname}-clear-binary-objects
         COMMAND ${CMAKE_COMMAND} -E remove
             ${testname}.bin
     )
-    set_tests_properties (H5DUMP-${testname}-clear-objects PROPERTIES
+    set_tests_properties (H5DUMP-${testname}-clear-binary-objects PROPERTIES
         WORKING_DIRECTORY "${PROJECT_BINARY_DIR}/testfiles/std"
     )
   endif ()
 
+  if (DEFINED ARG_TARGET_FILE)
+    set (target_file_txt ${testname}.txt)
+    add_test (
+      NAME H5DUMP-${testname}-clear-txt-objects
+      COMMAND ${CMAKE_COMMAND} -E remove
+        ${testname}.txt
+    )
+
+    set_tests_properties (H5DUMP-${testname}-clear-txt-objects PROPERTIES
+      WORKING_DIRECTORY "${PROJECT_BINARY_DIR}/testfiles/std"
+    )
+  else ()
+    set (target_file_txt "")
+  endif ()
+
   # If using memchecker add tests without using scripts
   if (HDF5_ENABLE_USING_MEMCHECKER)
-    add_test (NAME H5DUMP-${testname} COMMAND ${CMAKE_CROSSCOMPILING_EMULATOR} $<TARGET_FILE:h5dump> ${ARG_ANY_PATHS} ${ARG_UNPARSED_ARGUMENTS} ${ARG_TARGET_FILE})
+    add_test (NAME H5DUMP-${testname} COMMAND ${CMAKE_CROSSCOMPILING_EMULATOR} $<TARGET_FILE:h5dump> ${ARG_ANY_PATHS} ${ARG_UNPARSED_ARGUMENTS} ${ARG_OUTPUT_FILE} ${ARG_TARGET_FILE})
     if (${ARG_RESULT_CODE})
       set_tests_properties (H5DUMP-${testname} PROPERTIES WILL_FAIL "true")
     endif ()
@@ -542,7 +563,7 @@ macro (ADD_H5_TEST testname)
         COMMAND "${CMAKE_COMMAND}"
             -D "TEST_EMULATOR=${CMAKE_CROSSCOMPILING_EMULATOR}"
             -D "TEST_PROGRAM=$<TARGET_FILE:h5dump>"
-            -D "TEST_ARGS:STRING=${ARG_ANY_PATHS};${ARG_UNPARSED_ARGUMENTS};${ARG_TARGET_FILE}"
+            -D "TEST_ARGS:STRING=${ARG_ANY_PATHS};${ARG_UNPARSED_ARGUMENTS};${ARG_OUTPUT_FILE};${ARG_TARGET_FILE}"
             -D "TEST_FOLDER=${PROJECT_BINARY_DIR}/testfiles/std"
             -D "TEST_OUTPUT=${testname}.out"
             -D "TEST_EXPECT=${ARG_RESULT_CODE}"
@@ -560,87 +581,47 @@ macro (ADD_H5_TEST testname)
     set_tests_properties (H5DUMP-${testname} PROPERTIES DISABLED true)
   endif ()
 
+  if (DEFINED ARG_TARGET_FILE AND DEFINED ARG_OUTPUT_FILE)
+    add_test (
+      NAME H5DUMP-${testname}-output-cmp
+      COMMAND ${CMAKE_COMMAND} -E compare_files --ignore-eol ${testname}.txt ${testname}.exp
+    )
+
+    set_tests_properties(H5DUMP-${testname}-output-cmp PROPERTIES
+      DEPENDS H5DUMP-${testname}
+      WORKING_DIRECTORY "${PROJECT_BINARY_DIR}/testfiles/std"
+    )
+
+    if ("H5DUMP-${testname}-output-cmp" MATCHES "${HDF5_DISABLE_TESTS_REGEX}")
+      set_tests_properties (H5DUMP-${testname}-output-cmp PROPERTIES DISABLED true)
+    endif ()
+
+    # Cleanup txt
+    add_test (
+      NAME H5DUMP-${testname}-clean-txt-objects
+      COMMAND ${CMAKE_COMMAND} -E remove
+          ${testname}.txt
+    )
+
+    set_tests_properties (H5DUMP-${testname}-clean-txt-objects PROPERTIES
+        DEPENDS H5DUMP-${testname}-output-cmp
+        WORKING_DIRECTORY "${PROJECT_BINARY_DIR}/testfiles/std"
+    )
+  endif ()
+
   if (DEFINED ARG_ANY_PATHS)
     set_tests_properties (H5DUMP-${testname} PROPERTIES
       DEPENDS H5DUMP-${testname}-clear-objects
     )
     
     add_test (
-      NAME H5DUMP-${testname}-clean-objects
+      NAME H5DUMP-${testname}-clean-binary-objects
       COMMAND ${CMAKE_COMMAND} -E remove
           ${testname}.bin
     )
 
-    set_tests_properties (H5DUMP-${testname}-clean-objects PROPERTIES
+    set_tests_properties (H5DUMP-${testname}-clean-binary-objects PROPERTIES
         DEPENDS H5DUMP-${testname}
-        WORKING_DIRECTORY "${PROJECT_BINARY_DIR}/testfiles/std"
-    )
-  endif ()
-endmacro ()
-
-macro (ADD_H5_TEST_EXPORT resultfile targetfile resultcode)
-  add_test (
-      NAME H5DUMP-${resultfile}-clear-objects
-      COMMAND ${CMAKE_COMMAND} -E remove
-          ${resultfile}.txt
-  )
-  set_tests_properties (H5DUMP-${resultfile}-clear-objects PROPERTIES
-      WORKING_DIRECTORY "${PROJECT_BINARY_DIR}/testfiles/std"
-  )
-  # If using memchecker add tests without using scripts
-  if (HDF5_ENABLE_USING_MEMCHECKER)
-    add_test (NAME H5DUMP-${resultfile} COMMAND ${CMAKE_CROSSCOMPILING_EMULATOR} $<TARGET_FILE:h5dump> ${ARGN} ${resultfile}.txt ${targetfile})
-    if (${resultcode})
-      set_tests_properties (H5DUMP-${resultfile} PROPERTIES WILL_FAIL "true")
-    endif ()
-    set_tests_properties (H5DUMP-${resultfile} PROPERTIES
-        WORKING_DIRECTORY "${PROJECT_BINARY_DIR}/testfiles/std"
-    )
-  else ()
-    add_test (
-        NAME H5DUMP-${resultfile}
-        COMMAND "${CMAKE_COMMAND}"
-            -D "TEST_EMULATOR=${CMAKE_CROSSCOMPILING_EMULATOR}"
-            -D "TEST_PROGRAM=$<TARGET_FILE:h5dump>"
-            -D "TEST_ARGS:STRING=${ARGN};${resultfile}.txt;${targetfile}"
-            -D "TEST_FOLDER=${PROJECT_BINARY_DIR}/testfiles/std"
-            -D "TEST_OUTPUT=${resultfile}.out"
-            -D "TEST_EXPECT=${resultcode}"
-            -D "TEST_REFERENCE=${resultfile}.ddl"
-            -P "${HDF_RESOURCES_DIR}/runTest.cmake"
-    )
-    set_tests_properties (H5DUMP-${resultfile} PROPERTIES
-        DEPENDS H5DUMP-${resultfile}-clear-objects
-    )
-    if ("H5DUMP-${resultfile}" MATCHES "${HDF5_DISABLE_TESTS_REGEX}")
-      set_tests_properties (H5DUMP-${resultfile} PROPERTIES DISABLED true)
-    endif ()
-    add_test (
-        NAME H5DUMP-${resultfile}-output-cmp
-        COMMAND ${CMAKE_COMMAND} -E compare_files --ignore-eol ${resultfile}.txt ${resultfile}.exp
-    )
-    set_tests_properties (H5DUMP-${resultfile}-output-cmp PROPERTIES
-        DEPENDS H5DUMP-${resultfile}
-        WORKING_DIRECTORY "${PROJECT_BINARY_DIR}/testfiles/std"
-    )
-    set_tests_properties (H5DUMP-${resultfile}-output-cmp PROPERTIES DEPENDS H5DUMP-${resultfile})
-    if ("H5DUMP-${resultfile}-output-cmp" MATCHES "${HDF5_DISABLE_TESTS_REGEX}")
-      set_tests_properties (H5DUMP-${resultfile}-output-cmp PROPERTIES DISABLED true)
-    endif ()
-  endif ()
-  add_test (
-      NAME H5DUMP-${resultfile}-clean-objects
-      COMMAND ${CMAKE_COMMAND} -E remove
-          ${resultfile}.txt
-  )
-  if (HDF5_ENABLE_USING_MEMCHECKER)
-    set_tests_properties (H5DUMP-${resultfile}-clean-objects PROPERTIES
-        DEPENDS H5DUMP-${resultfile}
-        WORKING_DIRECTORY "${PROJECT_BINARY_DIR}/testfiles/std"
-    )
-  else ()
-    set_tests_properties (H5DUMP-${resultfile}-clean-objects PROPERTIES
-        DEPENDS H5DUMP-${resultfile}-output-cmp
         WORKING_DIRECTORY "${PROJECT_BINARY_DIR}/testfiles/std"
     )
   endif ()
@@ -946,7 +927,7 @@ macro (ADD_H5_TEST_IMPORT conffile resultfile testfile resultcode)
     if ("H5DUMP-IMPORT-h5import-${resultfile}" MATCHES "${HDF5_DISABLE_TESTS_REGEX}")
       set_tests_properties (H5DUMP-IMPORT-h5import-${resultfile} PROPERTIES DISABLED true)
     endif ()
-    add_test (NAME H5DUMP-IMPORT-h5diff-${resultfile} COMMAND ${CMAKE_CROSSCOMPILING_EMULATOR} $<TARGET_FILE:h5diff> ${testfile} ${resultfile}.h5 /integer /integer)
+    add_test (NAME H5DUMP-IMPORT- -${resultfile} COMMAND ${CMAKE_CROSSCOMPILING_EMULATOR} $<TARGET_FILE:h5diff> ${testfile} ${resultfile}.h5 /integer /integer)
     set_tests_properties (H5DUMP-IMPORT-h5diff-${resultfile} PROPERTIES
         DEPENDS H5DUMP-IMPORT-h5import-${resultfile}
         WORKING_DIRECTORY "${PROJECT_BINARY_DIR}/testfiles/std"
@@ -1044,9 +1025,9 @@ ADD_H5_TEST (tnoddl RESULT_CODE 0 --enable-error-stack --ddl -y TARGET_FILE pack
 ADD_H5_TEST (tnodata RESULT_CODE 0 --enable-error-stack --output TARGET_FILE packedbits.h5)
 ADD_H5_TEST (tnoattrddl RESULT_CODE 0 --enable-error-stack -O -y TARGET_FILE tattr.h5)
 ADD_H5_TEST (tnoattrdata RESULT_CODE 0 --enable-error-stack -A -o TARGET_FILE tattr.h5)
-ADD_H5_TEST_EXPORT (trawdatafile packedbits.h5 0 --enable-error-stack -y -o)
-ADD_H5_TEST_EXPORT (tnoddlfile packedbits.h5 0 --enable-error-stack -O -y -o)
-ADD_H5_TEST_EXPORT (trawssetfile tdset.h5 0 --enable-error-stack -d "/dset1[1,1;;;]" -y -o)
+ADD_H5_TEST (trawdatafile OUTPUT_FILE trawdatafile TARGET_FILE packedbits.h5 RESULT_CODE 0 --enable-error-stack -y)
+ADD_H5_TEST (tnoddlfile OUTPUT_FILE tnoddlfile TARGET_FILE packedbits.h5 RESULT_CODE 0 --enable-error-stack -O -y)
+ADD_H5_TEST (trawssetfile OUTPUT_FILE trawssetfile TARGET_FILE tdset.h5 RESULT_CODE 0 --enable-error-stack -d "/dset1[1,1;;;]" -y)
 
 ADD_H5_TEST_EXPORT_DDL (twithddlfile packedbits.h5 0 twithddl --enable-error-stack --ddl=twithddl.txt -y -o)
 
@@ -1457,7 +1438,7 @@ ADD_H5ERR_MASK_TEST (textlink 0 "unable to open external file, external link fil
 ADD_H5ERR_MASK_ENV_TEST (filter_fail 1 "filter plugins disabled" "HDF5_PLUGIN_PRELOAD" "::" --enable-error-stack filter_fail.h5)
 
 # test for -o -y for dataset with attributes
-ADD_H5_TEST_EXPORT (tall-6 tall.h5 0 --enable-error-stack -d /g1/g1.1/dset1.1.1 -y -o)
+ADD_H5_TEST (tall-6 OUTPUT_FILE tall-6 TARGET_FILE tall.h5 RESULT_CODE 0 --enable-error-stack -d /g1/g1.1/dset1.1.1 -y)
 
 # test for non-existing file
 ADD_H5ERR_MASK_TEST (non_existing 1 "unable to open file" --enable-error-stack tgroup.h5 non_existing.h5)

--- a/tools/test/h5dump/CMakeTests.cmake
+++ b/tools/test/h5dump/CMakeTests.cmake
@@ -464,11 +464,13 @@ endmacro ()
 #
 # REQUIRED KEYWORD ARGUMENTS:
 #   RESULT_CODE <code>    - expected return code after test execution. 0 is success
+#   APPLY_FILTERS <resultvalue> - If provided, test will apply filters to output before comparison.
+#                                 <resultvalue> is used to construct the filter expressions
 #
 macro (ADD_H5_TEST testname)
   cmake_parse_arguments(ARG
     ""
-    "RESULT_CODE"
+    "RESULT_CODE;APPLY_FILTERS"
     ""
     ${ARGN}
   )
@@ -476,6 +478,19 @@ macro (ADD_H5_TEST testname)
   # Validate required parameters
   if (NOT DEFINED ARG_RESULT_CODE)
     message(FATAL_ERROR "ADD_H5_TEST: RESULT_CODE is required")
+  endif ()
+
+  # Set up filters
+  if (DEFINED ARG_APPLY_FILTERS)
+    if ("${ARG_APPLY_FILTERS}" STREQUAL "")
+      message(FATAL_ERROR "ADD_H5_TEST: APPLY_FILTERS requires a resultvalue")
+    endif ()
+
+    set (filters_in "SIZE [0-9]* \\(${ARG_APPLY_FILTERS}\\\.[0-9][0-9][0-9]:1 COMPRESSION\\)")
+    set (filters_out "SIZE XXXX (${ARG_APPLY_FILTERS}.XXX:1 COMPRESSION)")
+  else ()
+    set (filters_in "")
+    set (filters_out "")
   endif ()
 
   # If using memchecker add tests without using scripts
@@ -498,6 +513,8 @@ macro (ADD_H5_TEST testname)
             -D "TEST_OUTPUT=${testname}.out"
             -D "TEST_EXPECT=${ARG_RESULT_CODE}"
             -D "TEST_REFERENCE=${testname}.ddl"
+            -D "TEST_FILTER:STRING=${filters_in}"
+            -D "TEST_FILTER_REPLACE:STRING=${filters_out}"
             -P "${HDF_RESOURCES_DIR}/runTest.cmake"
     )
   endif ()
@@ -506,40 +523,6 @@ macro (ADD_H5_TEST testname)
   )
   if ("H5DUMP-${testname}" MATCHES "${HDF5_DISABLE_TESTS_REGEX}")
     set_tests_properties (H5DUMP-${testname} PROPERTIES DISABLED true)
-  endif ()
-endmacro ()
-
-macro (ADD_H5_COMP_TEST resultfile resultcode resultvalue)
-  # If using memchecker add tests without using scripts
-  if (HDF5_ENABLE_USING_MEMCHECKER)
-    add_test (NAME H5DUMP-${resultfile} COMMAND ${CMAKE_CROSSCOMPILING_EMULATOR} $<TARGET_FILE:h5dump> ${ARGN})
-    if (${resultcode})
-      set_tests_properties (H5DUMP-${resultfile} PROPERTIES WILL_FAIL "true")
-    endif ()
-    set_tests_properties (H5DUMP-${resultfile} PROPERTIES
-        WORKING_DIRECTORY "${PROJECT_BINARY_DIR}/testfiles/std"
-    )
-  else ()
-    add_test (
-        NAME H5DUMP-${resultfile}
-        COMMAND "${CMAKE_COMMAND}"
-            -D "TEST_EMULATOR=${CMAKE_CROSSCOMPILING_EMULATOR}"
-            -D "TEST_PROGRAM=$<TARGET_FILE:h5dump>"
-            -D "TEST_ARGS:STRING=${ARGN}"
-            -D "TEST_FOLDER=${PROJECT_BINARY_DIR}/testfiles/std"
-            -D "TEST_OUTPUT=${resultfile}.out"
-            -D "TEST_EXPECT=${resultcode}"
-            -D "TEST_REFERENCE=${resultfile}.ddl"
-            -D "TEST_FILTER:STRING=SIZE [0-9]* \\(${resultvalue}\\\.[0-9][0-9][0-9]:1 COMPRESSION\\)"
-            -D "TEST_FILTER_REPLACE:STRING=SIZE XXXX (${resultvalue}.XXX:1 COMPRESSION)"
-            -P "${HDF_RESOURCES_DIR}/runTest.cmake"
-    )
-  endif ()
-  set_tests_properties (H5DUMP-${resultfile} PROPERTIES
-      WORKING_DIRECTORY "${PROJECT_BINARY_DIR}/testfiles/std"
-  )
-  if ("H5DUMP-${resultfile}" MATCHES "${HDF5_DISABLE_TESTS_REGEX}")
-    set_tests_properties (H5DUMP-${resultfile} PROPERTIES DISABLED true)
   endif ()
 endmacro ()
 
@@ -1305,25 +1288,25 @@ ADD_H5ERR_MASK_TEST (texceedsubblock 1 "exceed dataset dims" --enable-error-stac
 
 # tests for filters
 # SZIP
-ADD_H5_COMP_TEST (tszip 0 2 --enable-error-stack -H -p -d szip tfilters.h5)
+ADD_H5_TEST (tszip RESULT_CODE 0 APPLY_FILTERS 2 --enable-error-stack -H -p -d szip tfilters.h5)
 
 # deflate
-ADD_H5_COMP_TEST (tdeflate 0 2 --enable-error-stack -H -p -d deflate tfilters.h5)
+ADD_H5_TEST (tdeflate RESULT_CODE 0 APPLY_FILTERS 2 --enable-error-stack -H -p -d deflate tfilters.h5)
 
 # shuffle
 ADD_H5_TEST (tshuffle RESULT_CODE 0 --enable-error-stack -H -p -d shuffle tfilters.h5)
 
 # fletcher32
-ADD_H5_COMP_TEST (tfletcher32 0 0 --enable-error-stack -H -p -d fletcher32  tfilters.h5)
+ADD_H5_TEST (tfletcher32 RESULT_CODE 0 APPLY_FILTERS 0 --enable-error-stack -H -p -d fletcher32  tfilters.h5)
 
 # nbit
-ADD_H5_COMP_TEST (tnbit 0 1 --enable-error-stack -H -p -d nbit  tfilters.h5)
+ADD_H5_TEST (tnbit RESULT_CODE 0 APPLY_FILTERS 1 --enable-error-stack -H -p -d nbit  tfilters.h5)
 
 # scaleoffset
-ADD_H5_COMP_TEST (tscaleoffset 0 4 --enable-error-stack -H -p -d scaleoffset  tfilters.h5)
+ADD_H5_TEST (tscaleoffset RESULT_CODE 0 APPLY_FILTERS 4 --enable-error-stack -H -p -d scaleoffset  tfilters.h5)
 
 # all
-ADD_H5_COMP_TEST (tallfilters 0 1 --enable-error-stack -H -p -d all  tfilters.h5)
+ADD_H5_TEST (tallfilters RESULT_CODE 0 APPLY_FILTERS 1 --enable-error-stack -H -p -d all  tfilters.h5)
 
 # user defined
 ADD_H5_TEST (tuserfilter RESULT_CODE 0 --enable-error-stack -H  -p -d myfilter  tfilters.h5)


### PR DESCRIPTION
Merge several macros in the h5dump test code into `ADD_H5_TEST` to reduce duplication.