### PR TITLE
enforce light mode for Doxygen docs: removed dark theme elements

### DIFF
--- a/doxygen/doxygen-awesome.css
+++ b/doxygen/doxygen-awesome.css
@@ -183,127 +183,6 @@ html {
     }
 }
 
-@media (prefers-color-scheme: dark) {
-    html:not(.light-mode) {
-        color-scheme: dark;
-
-        --primary-color: #1982d2;
-        --primary-dark-color: #86a9c4;
-        --primary-light-color: #4779ac;
-
-        --box-shadow: 0 2px 8px 0 rgba(0,0,0,.35);
-
-        --odd-color: rgba(100,100,100,.06);
-
-        --menu-selected-background: rgba(0,0,0,.4);
-
-        --page-background-color: #1C1D1F;
-        --page-foreground-color: #d2dbde;
-        --page-secondary-foreground-color: #859399;
-        --separator-color: #38393b;
-        --side-nav-background: #252628;
-
-        --code-background: #2a2c2f;
-
-        --tablehead-background: #2a2c2f;
-    
-        --blockquote-background: #222325;
-        --blockquote-foreground: #7e8c92;
-
-        --warning-color: #3b2e04;
-        --warning-color-dark: #f1b602;
-        --warning-color-darker: #ceb670;
-        --note-color: #163750;
-        --note-color-dark: #1982D2;
-        --note-color-darker: #dcf0fa;
-        --todo-color: #2a2536;
-        --todo-color-dark: #7661b3;
-        --todo-color-darker: #ae9ed6;
-        --deprecated-color: #2e323b;
-        --deprecated-color-dark: #738396;
-        --deprecated-color-darker: #abb0bd;
-        --bug-color: #2e1917;
-        --bug-color-dark: #ad2617;
-        --bug-color-darker: #f5b1aa;
-        --invariant-color: #303a35;
-        --invariant-color-dark: #76ce96;
-        --invariant-color-darker: #cceed5;
-
-        --fragment-background: #282c34;
-        --fragment-foreground: #dbe4eb;
-        --fragment-keyword: #cc99cd;
-        --fragment-keywordtype: #ab99cd;
-        --fragment-keywordflow: #e08000;
-        --fragment-token: #7ec699;
-        --fragment-comment: #999999;
-        --fragment-link: #98c0e3;
-        --fragment-preprocessor: #65cabe;
-        --fragment-linenumber-color: #cccccc;
-        --fragment-linenumber-background: #35393c;
-        --fragment-linenumber-border: #1f1f1f;
-    }
-}
-
-/* dark mode variables are defined twice, to support both the dark-mode without and with doxygen-awesome-darkmode-toggle.js */
-html.dark-mode {
-    color-scheme: dark;
-
-    --primary-color: #1982d2;
-    --primary-dark-color: #86a9c4;
-    --primary-light-color: #4779ac;
-
-    --box-shadow: 0 2px 8px 0 rgba(0,0,0,.30);
-
-    --odd-color: rgba(100,100,100,.06);
-
-    --menu-selected-background: rgba(0,0,0,.4);
-
-    --page-background-color: #1C1D1F;
-    --page-foreground-color: #d2dbde;
-    --page-secondary-foreground-color: #859399;
-    --separator-color: #38393b;
-    --side-nav-background: #252628;
-
-    --code-background: #2a2c2f;
-
-    --tablehead-background: #2a2c2f;
-
-    --blockquote-background: #222325;
-    --blockquote-foreground: #7e8c92;
-
-    --warning-color: #3b2e04;
-    --warning-color-dark: #f1b602;
-    --warning-color-darker: #ceb670;
-    --note-color: #163750;
-    --note-color-dark: #1982D2;
-    --note-color-darker: #dcf0fa;
-    --todo-color: #2a2536;
-    --todo-color-dark: #7661b3;
-    --todo-color-darker: #ae9ed6;
-    --deprecated-color: #2e323b;
-    --deprecated-color-dark: #738396;
-    --deprecated-color-darker: #abb0bd;
-    --bug-color: #2e1917;
-    --bug-color-dark: #ad2617;
-    --bug-color-darker: #f5b1aa;
-    --invariant-color: #303a35;
-    --invariant-color-dark: #76ce96;
-    --invariant-color-darker: #cceed5;
-
-    --fragment-background: #282c34;
-    --fragment-foreground: #dbe4eb;
-    --fragment-keyword: #cc99cd;
-    --fragment-keywordtype: #ab99cd;
-    --fragment-keywordflow: #e08000;
-    --fragment-token: #7ec699;
-    --fragment-comment: #999999;
-    --fragment-link: #98c0e3;
-    --fragment-preprocessor: #65cabe;
-    --fragment-linenumber-color: #cccccc;
-    --fragment-linenumber-background: #35393c;
-    --fragment-linenumber-border: #1f1f1f;
-}
-
 body {
     color: var(--page-foreground-color);
     background-color: var(--page-background-color);
@@ -676,16 +555,6 @@ iframe {
     color-scheme: normal;
 }
 
-@media (prefers-color-scheme: dark) {
-    html:not(.light-mode) iframe#MSearchResults {
-        filter: invert() hue-rotate(180deg);
-    }
-}
-
-html.dark-mode iframe#MSearchResults {
-    filter: invert() hue-rotate(180deg);
-}
-
 #MSearchResults .SRPage {
     background-color: transparent;
 }
@@ -964,29 +833,6 @@ div.contents p, div.contents li {
 
 div.contents div.dyncontent {
     margin: var(--spacing-medium) 0;
-}
-
-@media (prefers-color-scheme: dark) {
-    html:not(.light-mode) div.contents div.dyncontent img,
-    html:not(.light-mode) div.contents center img,
-    html:not(.light-mode) div.contents > table img,
-    html:not(.light-mode) div.contents div.dyncontent iframe,
-    html:not(.light-mode) div.contents center iframe,
-    html:not(.light-mode) div.contents table iframe,
-    html:not(.light-mode) div.contents .dotgraph iframe {
-        filter: brightness(89%) hue-rotate(180deg) invert();
-    }
-}
-
-html.dark-mode div.contents div.dyncontent img,
-html.dark-mode div.contents center img,
-html.dark-mode div.contents > table img,
-html.dark-mode div.contents div.dyncontent iframe,
-html.dark-mode div.contents center iframe,
-html.dark-mode div.contents table iframe,
-html.dark-mode div.contents .dotgraph iframe
- {
-    filter: brightness(89%) hue-rotate(180deg) invert();
 }
 
 h2.groupheader {
@@ -2101,16 +1947,6 @@ table.directory tr.odd {
     }
 }
 
-@media (prefers-color-scheme: dark) {
-    html:not(.light-mode) .iconfopen, html:not(.light-mode) .iconfclosed {
-        filter: hue-rotate(180deg) invert();
-    }
-}
-
-html.dark-mode .iconfopen, html.dark-mode .iconfclosed {
-    filter: hue-rotate(180deg) invert();
-}
-
 /*
  Class list
  */
@@ -2124,8 +1960,8 @@ html.dark-mode .iconfopen, html.dark-mode .iconfclosed {
     background-color: transparent;
 }
 
-/* 
- Class Index Doxygen 1.8 
+/*
+ Class Index Doxygen 1.8
 */
 
 table.classindex {
@@ -2336,46 +2172,6 @@ div.contents .toc,
 .contents .dotgraph,
 .contents .tabs-overview-container {
     scrollbar-width: thin;
-}
-
-/*
-  Optional Dark mode toggle button
-*/
-
-doxygen-awesome-dark-mode-toggle {
-    display: inline-block;
-    margin: 0 0 0 var(--spacing-small);
-    padding: 0;
-    width: var(--searchbar-height);
-    height: var(--searchbar-height);
-    background: none;
-    border: none;
-    border-radius: var(--searchbar-height);
-    vertical-align: middle;
-    text-align: center;
-    line-height: var(--searchbar-height);
-    font-size: 22px;
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    user-select: none;
-    cursor: pointer;
-}
-
-doxygen-awesome-dark-mode-toggle > svg {
-    transition: transform var(--animation-duration) ease-in-out;
-}
-
-doxygen-awesome-dark-mode-toggle:active > svg {
-    transform: scale(.5);
-}
-
-doxygen-awesome-dark-mode-toggle:hover {
-    background-color: rgba(0,0,0,.03);
-}
-
-html.dark-mode doxygen-awesome-dark-mode-toggle:hover {
-    background-color: rgba(0,0,0,.18);
 }
 
 /*


### PR DESCRIPTION
Since the main HDF Group webpages and many of the Doxygen documentation assume a white background to appear correctly, the dark theme was removed.

Closes #5302 