### PR TITLE
Add external ref test files to h5dumpgentest

### DIFF
--- a/tools/test/h5dump/h5dumpgentest.c
+++ b/tools/test/h5dump/h5dumpgentest.c
@@ -13381,3 +13381,204 @@ gent_trefer_reg_1d(void)
 
     return;
 }
+
+
+/* For test_reference_external_generate() */
+#define GROUPNAME     "/group"
+#define DSETNAME      "/dset"
+#define DS1_NAME      "Dataset1"
+#define DS2_NAME      "Dataset2"
+#define DS3_NAME      "Dataset3"
+#define DT1_NAME      "Datatype1"
+#define GROUPNAME1    "/Group1"
+#define DS1_REF_OBJ   "/Group1/Dataset1"
+#define DS2_REF_OBJ   "/Group1/Dataset2"
+#define DT1_REF_OBJ   "/Group1/Datatype1"
+#define ATTR1_REF_OBJ "Attr1"
+#define ATTR2_REF_OBJ "Attr2"
+
+#define FILE_REF_EXT1      "trefer_ext1.h5"
+#define FILE_REF_EXT2      "trefer_ext2.h5"
+
+/* 1-D dataset with fixed dimensions */
+#define SPACE1_RANK 1
+#define SPACE1_DIM1 4
+
+/* TBD: This is a duplicate from trefer.c, test_reference_external_generate
+ * Eventually these should share the same routine, but that will
+ * require substantial modification of how h5gentest is built */
+int gent_test_reference_external(void) {
+    hid_t     fid1 = H5I_INVALID_HID; /* File ID */
+    hid_t     fid2 = H5I_INVALID_HID;
+    hid_t     dataset = H5I_INVALID_HID;    /* Dataset ID */
+    hid_t     group = H5I_INVALID_HID;      /* Group ID */
+    hid_t     attr = H5I_INVALID_HID;       /* Attribute ID */
+    hid_t     sid = H5I_INVALID_HID;        /* Dataspace ID */
+    hid_t     tid = H5I_INVALID_HID;        /* Datatype ID */
+    hsize_t   dims[] = {SPACE1_DIM1};
+    H5R_ref_t ref_wbuf[SPACE1_DIM1]; /* Buffer to write to disk */
+    unsigned   wbuf[SPACE1_DIM1];
+    unsigned   i;        /* Local index variables */
+    H5O_type_t obj_type; /* Object type */
+
+    /* Create file */
+    if ((fid1 = H5Fcreate(FILE_REF_EXT1, H5F_ACC_TRUNC, H5P_DEFAULT, H5P_DEFAULT)) < 0)
+        return 1;
+
+    /* Create dataspace for datasets */
+    if ((sid = H5Screate_simple(SPACE1_RANK, dims, NULL)) < 0)
+        return 1;
+
+    /* Create a group */
+    if ((group = H5Gcreate2(fid1, GROUPNAME1, H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT)) < 0)
+        return 1;
+
+    /* Create an attribute for the dataset */
+    if ((attr = H5Acreate2(group, ATTR2_REF_OBJ, H5T_NATIVE_UINT, sid, H5P_DEFAULT, H5P_DEFAULT)) < 0)
+        return 1;
+
+    for (i = 0; i < SPACE1_DIM1; i++)
+        wbuf[i] = (i * 3) + 1;
+
+    /* Write attribute to disk */
+    if (H5Awrite(attr, H5T_NATIVE_UINT, wbuf) < 0)
+        return 1;
+
+    /* Close attribute */
+    if (H5Aclose(attr) < 0)
+        return 1;
+
+    /* Create a dataset (inside Group1) */
+    if ((dataset = H5Dcreate2(group, DS1_NAME, H5T_NATIVE_UINT, sid, H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT)) < 0)
+        return 1;
+
+    /* Create an attribute for the dataset */
+    if ((attr = H5Acreate2(dataset, ATTR1_REF_OBJ, H5T_NATIVE_UINT, sid, H5P_DEFAULT, H5P_DEFAULT)) < 0)
+        return 1;
+
+    for (i = 0; i < SPACE1_DIM1; i++)
+        wbuf[i] = i * 3;
+
+    /* Write attribute to disk */
+    if (H5Awrite(attr, H5T_NATIVE_UINT, wbuf) < 0)
+        return 1;
+
+    /* Close attribute */
+    if (H5Aclose(attr) < 0)
+        return 1;
+
+    /* Close Dataset */
+    if (H5Dclose(dataset) < 0)
+        return 1;
+
+    /* Create another dataset (inside Group1) */
+    if ((dataset = H5Dcreate2(group, DS2_NAME, H5T_NATIVE_UCHAR, sid, H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT)) < 0)
+        return 1;
+
+    /* Close Dataset */
+    if (H5Dclose(dataset) < 0)
+        return 1;
+
+    /* Create a datatype to refer to */
+    if ((tid = H5Tcreate(H5T_COMPOUND, sizeof(s1_t))) < 0)
+        return 1;
+
+    /* Insert fields */
+    if (H5Tinsert(tid, "a", HOFFSET(s1_t, a), H5T_NATIVE_INT) < 0)
+        return 1;
+
+    if (H5Tinsert(tid, "b", HOFFSET(s1_t, b), H5T_NATIVE_INT) < 0)
+        return 1;
+
+    if (H5Tinsert(tid, "c", HOFFSET(s1_t, c), H5T_NATIVE_FLOAT) < 0)
+        return 1;
+
+    /* Save datatype for later */
+    if (H5Tcommit2(group, DT1_NAME, tid, H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT) < 0)
+        return 1;
+
+    /* Create an attribute for the datatype */
+    if ((attr = H5Acreate2(tid, "Attr3", H5T_NATIVE_UINT, sid, H5P_DEFAULT, H5P_DEFAULT)) < 0)
+        return 1;
+
+    for (i = 0; i < SPACE1_DIM1; i++)
+        wbuf[i] = (i * 3) + 2;
+
+    /* Write attribute to disk */
+    if (H5Awrite(attr, H5T_NATIVE_UINT, wbuf) < 0)
+        return 1;
+
+    /* Close attribute */
+    if (H5Aclose(attr) < 0)
+        return 1;
+
+    /* Close datatype */
+    if (H5Tclose(tid) < 0)
+        return 1;
+
+    /* Close group */
+    if (H5Gclose(group) < 0)
+        return 1;
+
+    /* Create reference to dataset1 attribute */
+    if (H5Rcreate_attr(fid1, DS1_REF_OBJ, ATTR1_REF_OBJ, H5P_DEFAULT, &ref_wbuf[0]) < 0)
+        return 1;
+    if (H5Rget_obj_type3(&ref_wbuf[0], H5P_DEFAULT, &obj_type) < 0)
+        return 1;
+
+    /* Create reference to dataset2 attribute */
+    if (H5Rcreate_attr(fid1, DS2_REF_OBJ, ATTR1_REF_OBJ, H5P_DEFAULT, &ref_wbuf[1]) < 0)
+        return 1;
+    if (H5Rget_obj_type3(&ref_wbuf[1], H5P_DEFAULT, &obj_type) < 0)
+        return 1;
+
+    /* Create reference to group attribute */
+    if (H5Rcreate_attr(fid1, "/Group1", ATTR2_REF_OBJ, H5P_DEFAULT, &ref_wbuf[2]) < 0)
+        return 1;
+    if (H5Rget_obj_type3(&ref_wbuf[2], H5P_DEFAULT, &obj_type) < 0)
+        return 1;
+
+    /* Create reference to named datatype attribute */
+    if (H5Rcreate_attr(fid1, DT1_REF_OBJ, "Attr3", H5P_DEFAULT, &ref_wbuf[3]) < 0)
+        return 1;
+    if (H5Rget_obj_type3(&ref_wbuf[3], H5P_DEFAULT, &obj_type) < 0)
+        return 1;
+
+    /* Close disk dataspace */
+    if (H5Sclose(sid) < 0)
+        return 1;
+
+    /* Close file */
+    if (H5Fclose(fid1) < 0)
+        return 1;
+
+    /* Create file */
+    if ((fid2 = H5Fcreate(FILE_REF_EXT2, H5F_ACC_TRUNC, H5P_DEFAULT, H5P_DEFAULT)) < 0)
+        return 1;
+
+    /* Create dataspace for datasets */
+    if ((sid = H5Screate_simple(SPACE1_RANK, dims, NULL)) < 0)
+        return 1;
+
+    /* Create a dataset */
+    if ((dataset = H5Dcreate2(fid2, DS3_NAME, H5T_STD_REF, sid, H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT)) < 0)
+        return 1;
+
+    /* Write selection to disk */
+    if (H5Dwrite(dataset, H5T_STD_REF, H5S_ALL, H5S_ALL, H5P_DEFAULT, ref_wbuf) < 0)
+        return 1;
+
+    /* Close disk dataspace */
+    if (H5Sclose(sid) < 0)
+        return 1;
+
+    /* Close Dataset */
+    if (H5Dclose(dataset) < 0)
+        return 1;
+
+    /* Close file */
+    if (H5Fclose(fid2) < 0)
+        return 1;
+
+    return 0;
+}

--- a/tools/test/h5dump/h5dumpgentest.c
+++ b/tools/test/h5dump/h5dumpgentest.c
@@ -13382,7 +13382,6 @@ gent_trefer_reg_1d(void)
     return;
 }
 
-
 /* For test_reference_external_generate() */
 #define GROUPNAME     "/group"
 #define DSETNAME      "/dset"
@@ -13397,8 +13396,8 @@ gent_trefer_reg_1d(void)
 #define ATTR1_REF_OBJ "Attr1"
 #define ATTR2_REF_OBJ "Attr2"
 
-#define FILE_REF_EXT1      "trefer_ext1.h5"
-#define FILE_REF_EXT2      "trefer_ext2.h5"
+#define FILE_REF_EXT1 "trefer_ext1.h5"
+#define FILE_REF_EXT2 "trefer_ext2.h5"
 
 /* 1-D dataset with fixed dimensions */
 #define SPACE1_RANK 1
@@ -13407,16 +13406,18 @@ gent_trefer_reg_1d(void)
 /* TBD: This is a duplicate from trefer.c, test_reference_external_generate
  * Eventually these should share the same routine, but that will
  * require substantial modification of how h5gentest is built */
-int gent_test_reference_external(void) {
-    hid_t     fid1 = H5I_INVALID_HID; /* File ID */
-    hid_t     fid2 = H5I_INVALID_HID;
-    hid_t     dataset = H5I_INVALID_HID;    /* Dataset ID */
-    hid_t     group = H5I_INVALID_HID;      /* Group ID */
-    hid_t     attr = H5I_INVALID_HID;       /* Attribute ID */
-    hid_t     sid = H5I_INVALID_HID;        /* Dataspace ID */
-    hid_t     tid = H5I_INVALID_HID;        /* Datatype ID */
-    hsize_t   dims[] = {SPACE1_DIM1};
-    H5R_ref_t ref_wbuf[SPACE1_DIM1]; /* Buffer to write to disk */
+int
+gent_test_reference_external(void)
+{
+    hid_t      fid1    = H5I_INVALID_HID; /* File ID */
+    hid_t      fid2    = H5I_INVALID_HID;
+    hid_t      dataset = H5I_INVALID_HID; /* Dataset ID */
+    hid_t      group   = H5I_INVALID_HID; /* Group ID */
+    hid_t      attr    = H5I_INVALID_HID; /* Attribute ID */
+    hid_t      sid     = H5I_INVALID_HID; /* Dataspace ID */
+    hid_t      tid     = H5I_INVALID_HID; /* Datatype ID */
+    hsize_t    dims[]  = {SPACE1_DIM1};
+    H5R_ref_t  ref_wbuf[SPACE1_DIM1]; /* Buffer to write to disk */
     unsigned   wbuf[SPACE1_DIM1];
     unsigned   i;        /* Local index variables */
     H5O_type_t obj_type; /* Object type */
@@ -13449,7 +13450,8 @@ int gent_test_reference_external(void) {
         return 1;
 
     /* Create a dataset (inside Group1) */
-    if ((dataset = H5Dcreate2(group, DS1_NAME, H5T_NATIVE_UINT, sid, H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT)) < 0)
+    if ((dataset = H5Dcreate2(group, DS1_NAME, H5T_NATIVE_UINT, sid, H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT)) <
+        0)
         return 1;
 
     /* Create an attribute for the dataset */
@@ -13472,7 +13474,8 @@ int gent_test_reference_external(void) {
         return 1;
 
     /* Create another dataset (inside Group1) */
-    if ((dataset = H5Dcreate2(group, DS2_NAME, H5T_NATIVE_UCHAR, sid, H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT)) < 0)
+    if ((dataset =
+             H5Dcreate2(group, DS2_NAME, H5T_NATIVE_UCHAR, sid, H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT)) < 0)
         return 1;
 
     /* Close Dataset */

--- a/tools/test/h5dump/h5dumpgentest.h
+++ b/tools/test/h5dump/h5dumpgentest.h
@@ -135,4 +135,6 @@ void gent_trefer_obj(void);
 void gent_trefer_param(void);
 void gent_trefer_reg(void);
 void gent_trefer_reg_1d(void);
+
+int gent_test_reference_external(void);
 #endif /* H5DUMP_GENTEST_H */

--- a/tools/test/h5gentest.c
+++ b/tools/test/h5gentest.c
@@ -274,6 +274,8 @@ gen_h5dump_files(void)
     gent_trefer_reg();
     gent_trefer_reg_1d();
 
+    nerrors += gent_test_reference_external();
+
     return nerrors;
 }
 


### PR DESCRIPTION
The `trefer_extR` test depends upon this pair of files, but always uses the pre-generated ones checked into the repo. This adds a routine to generate them, which will soon be used by the h5dump VOL tests.