### PR TITLE
Generate VOL tests for h5dump

### DIFF
--- a/.github/workflows/vol_rest.yml
+++ b/.github/workflows/vol_rest.yml
@@ -191,4 +191,4 @@ jobs:
           HSDS_ENDPOINT=http+unix://%2Ftmp%2Fhs%2Fsn_1.sock \
           ROOT_DIR=${{github.workspace}}/hsdsdata \
           BUCKET_NAME=hsdstest \
-          ctest --build-config ${{ inputs.build_mode }} -VV -R "h5_api" -E "H5COPY|H5DIFF|H5LS" .
+          ctest --build-config ${{ inputs.build_mode }} -VV -R "h5_api" -E "H5COPY|H5DIFF|H5LS|H5DUMP" .

--- a/tools/test/h5dump/CMakeTests.cmake
+++ b/tools/test/h5dump/CMakeTests.cmake
@@ -1218,9 +1218,7 @@ ADD_H5_TEST (texceedsubblock RESULT_CODE 1 H5ERRREF "exceed dataset dims" --enab
 
 # tests for filters
 # SZIP
-if (H5_HAVE_FILTER_SZIP)
-  ADD_H5_TEST (tszip RESULT_CODE 0 APPLY_FILTERS 2 --enable-error-stack -H -p -d szip TARGET_FILE tfilters.h5)
-endif()
+ADD_H5_TEST (tszip RESULT_CODE 0 APPLY_FILTERS 2 --enable-error-stack -H -p -d szip TARGET_FILE tfilters.h5)
 
 # deflate
 ADD_H5_TEST (tdeflate RESULT_CODE 0 APPLY_FILTERS 2 --enable-error-stack -H -p -d deflate TARGET_FILE tfilters.h5)
@@ -1238,9 +1236,7 @@ ADD_H5_TEST (tnbit RESULT_CODE 0 APPLY_FILTERS 1 --enable-error-stack -H -p -d n
 ADD_H5_TEST (tscaleoffset RESULT_CODE 0 APPLY_FILTERS 4 --enable-error-stack -H -p -d scaleoffset  TARGET_FILE tfilters.h5)
 
 # all
-if (H5_HAVE_FILTER_SZIP)
-  ADD_H5_TEST (tallfilters RESULT_CODE 0 APPLY_FILTERS 1 --enable-error-stack -H -p -d all  TARGET_FILE tfilters.h5 APPLY_FILTERS 1)
-endif ()
+ADD_H5_TEST (tallfilters RESULT_CODE 0 APPLY_FILTERS 1 --enable-error-stack -H -p -d all  TARGET_FILE tfilters.h5 APPLY_FILTERS 1)
 
 # user defined
 ADD_H5_TEST (tuserfilter RESULT_CODE 0 --enable-error-stack -H  -p -d myfilter  TARGET_FILE tfilters.h5)

--- a/tools/test/h5dump/CMakeTests.cmake
+++ b/tools/test/h5dump/CMakeTests.cmake
@@ -747,9 +747,6 @@ macro (ADD_H5_TEST testname)
       if (${ARG_RESULT_CODE})
         set_tests_properties (${vol_prefix}H5DUMP-${ctest_testname} PROPERTIES WILL_FAIL "true")
       endif ()
-      set_tests_properties (${vol_prefix}H5DUMP-${ctest_testname} PROPERTIES
-          WORKING_DIRECTORY "${workdir}"
-      )
     else ()
       add_test (
           NAME ${vol_prefix}H5DUMP-${ctest_testname}
@@ -775,10 +772,6 @@ macro (ADD_H5_TEST testname)
         WORKING_DIRECTORY "${workdir}"
     )
 
-    if ("${vol_prefix}H5DUMP-${ctest_testname}" MATCHES "${HDF5_DISABLE_TESTS_REGEX}")
-      set_tests_properties (${vol_prefix}H5DUMP-${ctest_testname} PROPERTIES DISABLED true)
-    endif ()
-    
     # Set VOL-specific properties
     if (NOT "${vol}" STREQUAL "native")
       set_tests_properties (${vol_prefix}H5DUMP-${ctest_testname} PROPERTIES

--- a/tools/test/h5dump/CMakeTests.cmake
+++ b/tools/test/h5dump/CMakeTests.cmake
@@ -1271,10 +1271,8 @@ ADD_H5_TEST (tldouble RESULT_CODE 0 --enable-error-stack TARGET_FILE tldouble.h5
 ADD_H5_TEST (tldouble_scalar RESULT_CODE 0 -p --enable-error-stack TARGET_FILE tldouble_scalar.h5)
 
 # Add tests for _Float16 type
-if (${${HDF_PREFIX}_HAVE__FLOAT16})
-  ADD_H5_TEST (tfloat16 RESULT_CODE 0 --enable-error-stack TARGET_FILE tfloat16.h5)
-  ADD_H5_TEST (tfloat16_be RESULT_CODE 0 --enable-error-stack TARGET_FILE tfloat16_be.h5)
-endif()
+ADD_H5_TEST (tfloat16 RESULT_CODE 0 --enable-error-stack TARGET_FILE tfloat16.h5)
+ADD_H5_TEST (tfloat16_be RESULT_CODE 0 --enable-error-stack TARGET_FILE tfloat16_be.h5)
 
 # Add tests for bfloat16 type
 ADD_H5_TEST (tbfloat16 RESULT_CODE 0 --enable-error-stack TARGET_FILE tbfloat16.h5)

--- a/tools/test/h5dump/CMakeTests.cmake
+++ b/tools/test/h5dump/CMakeTests.cmake
@@ -1283,8 +1283,8 @@ ADD_H5_TEST (tfloat16 RESULT_CODE 0 --enable-error-stack TARGET_FILE tfloat16.h5
 ADD_H5_TEST (tfloat16_be RESULT_CODE 0 --enable-error-stack TARGET_FILE tfloat16_be.h5 ${F16_NATIVE_ONLY})
 
 # Add tests for bfloat16 type
-ADD_H5_TEST (tbfloat16 RESULT_CODE 0 --enable-error-stack TARGET_FILE tbfloat16.h5 ${F16_NATIVE_ONLY})
-ADD_H5_TEST (tbfloat16_be RESULT_CODE 0 --enable-error-stack TARGET_FILE tbfloat16_be.h5 ${F16_NATIVE_ONLY})
+ADD_H5_TEST (tbfloat16 RESULT_CODE 0 --enable-error-stack TARGET_FILE tbfloat16.h5)
+ADD_H5_TEST (tbfloat16_be RESULT_CODE 0 --enable-error-stack TARGET_FILE tbfloat16_be.h5)
 
 # Add tests for complex numbers. For portability, use a fixed floating-point
 # precision and skip dumping of the "long double _Complex" dataset. The "long

--- a/tools/test/h5dump/CMakeTests.cmake
+++ b/tools/test/h5dump/CMakeTests.cmake
@@ -16,6 +16,15 @@
 ##############################################################################
 ##############################################################################
 
+include(${HDF_CONFIG_DIR}/HDF5Macros.cmake)
+
+# System-independent path separator
+if (WIN32)
+  set (CMAKE_SEP "\;")
+else ()
+  set (CMAKE_SEP ":")
+endif ()
+
 # --------------------------------------------------------------------
 # Copy all the HDF5 files from the test directory into the source directory
 # --------------------------------------------------------------------
@@ -426,6 +435,52 @@ else ()
 endif ()
 add_custom_target(h5dump_std_files ALL COMMENT "Copying files needed by h5dump_std tests" DEPENDS ${h5dump_std_files_list})
 
+# --------------------------------------------------------------------
+# Copy test files for each external VOL connector
+# --------------------------------------------------------------------
+set(h5dump_vol_files_list "")
+foreach(external_vol_tgt ${HDF5_EXTERNAL_VOL_TARGETS})
+  HDF5_GET_VOL_TGT_INFO(${external_vol_tgt} ext_vol_dir_name vol_env)
+  # Setup testfiles directory
+  file (MAKE_DIRECTORY "${PROJECT_BINARY_DIR}/${ext_vol_dir_name}/testfiles/std")
+
+  # Generate test files
+  add_test(NAME ${external_vol_tgt}-h5dumpgentest COMMAND ${CMAKE_CROSSCOMPILING_EMULATOR} $<TARGET_FILE:h5gentest> --h5dump)
+  set_tests_properties(${external_vol_tgt}-h5dumpgentest PROPERTIES
+    ENVIRONMENT "${vol_env}"
+    WORKING_DIRECTORY "${PROJECT_BINARY_DIR}/${ext_vol_dir_name}/testfiles/std"
+    FIXTURES_SETUP "h5dump_vol_files"
+  )
+
+  # These aren't HDF5 files, just copy them to the VOL's subdirectory
+  foreach (tst_exp_file ${HDF5_REFERENCE_EXP_FILES})
+    HDFTEST_COPY_FILE("${HDF5_TOOLS_TST_DIR}/h5dump/exportfiles/${tst_exp_file}" "${PROJECT_BINARY_DIR}/${ext_vol_dir_name}/testfiles/std/${tst_exp_file}" "h5dump_vol_files")
+  endforeach ()
+
+  foreach (tst_other_file ${HDF5_REFERENCE_FILES})
+    HDFTEST_COPY_FILE("${HDF5_TOOLS_TST_DIR}/h5dump/expected/${tst_other_file}" "${PROJECT_BINARY_DIR}/${ext_vol_dir_name}/testfiles/std/${tst_other_file}" "h5dump_vol_files")
+  endforeach ()
+
+  foreach (tst_h5N_file ${HDF5_N_REFERENCE_FILES})
+    HDFTEST_COPY_FILE("${HDF5_TOOLS_TST_DIR}/h5dump/expected/${tst_h5N_file}" "${PROJECT_BINARY_DIR}/${ext_vol_dir_name}/testfiles/std/${tst_h5N_file}-N" "h5dump_vol_files")
+  endforeach ()
+
+  # Don't copy s3 files for each VOL connector, since the s3 files are specific to the native-exlusive ROS3 VFD
+
+  # --------------------------------------------------------------------
+  # Special file handling
+  # --------------------------------------------------------------------
+  HDFTEST_COPY_FILE("${HDF5_TOOLS_TST_DIR}/h5dump/expected/tbin1.ddl" "${PROJECT_BINARY_DIR}/${ext_vol_dir_name}/testfiles/std/tbin1LE.ddl" "h5dump_vol_files")
+  
+  # Certain versions of Visual Studio produce rounding differences compared with the reference data of the tfloatsattr test
+  if (WIN32 AND (CMAKE_VS_WINDOWS_TARGET_PLATFORM_VERSION VERSION_LESS 10.0.18362.0))
+    configure_file(${HDF5_TOOLS_TST_DIR}/h5dump/exportfiles/tbinregR.exp ${PROJECT_BINARY_DIR}/${ext_vol_dir_name}/testfiles/std/tbinregR.exp NEWLINE_STYLE CRLF)
+  else ()
+    HDFTEST_COPY_FILE("${HDF5_TOOLS_TST_DIR}/h5dump/exportfiles/tbinregR.exp" "${PROJECT_BINARY_DIR}/${ext_vol_dir_name}/testfiles/std/tbinregR.exp" "h5dump_vol_files")
+  endif ()
+endforeach ()
+add_custom_target(h5dump_vol_files ALL COMMENT "Copying files needed by h5dump VOL tests" DEPENDS ${h5dump_vol_files_list})
+
 ##############################################################################
 ##############################################################################
 ###           T H E   T E S T S  M A C R O S                               ###
@@ -477,6 +532,7 @@ endmacro ()
 #   GREP_COMPARE - whether to perform a grep comparison on the output file
 #   BINFILE - if provided, use h5dump to put binary output into <testname>.bin
 #   SKIP_TEST - if provided, do not add this test
+#   NATIVE_ONLY - if provided, only run test with native VOL connector
 #
 # OPTIONAL KEYWORD ARGUMENTS:
 #   APPLY_FILTERS <resultvalue> - If provided, test will apply filters to output before comparison.
@@ -493,7 +549,7 @@ endmacro ()
 #
 macro (ADD_H5_TEST testname)
   cmake_parse_arguments(ARG
-    "BINARY_OUTPUT;MASK_ERROR;GREP_COMPARE;BINFILE;SKIP_TEST" # Flags
+    "BINARY_OUTPUT;MASK_ERROR;GREP_COMPARE;BINFILE;SKIP_TEST;NATIVE_ONLY" # Flags
     "RESULT_CODE;APPLY_FILTERS;TARGET_FILE;OUTPUT_FILE;DDL_FILE;H5ERRREF;ENVVAR;ENVVAL" # Single value args
     "ANY_PATHS" # Multi value args
     ${ARGN}
@@ -511,11 +567,33 @@ macro (ADD_H5_TEST testname)
   # Validate optional parameters
   if (DEFINED ARG_APPLY_FILTERS)
     if ("${ARG_APPLY_FILTERS}" STREQUAL "")
-      message(FATAL_ERROR "ADD_H5_TEST: APPLY_FILTERS requires a resultvalue")
+      # default
+      set (_FILTER_VAL "1")
+    else()
+      set (_FILTER_VAL "${ARG_APPLY_FILTERS}")
     endif ()
 
-    set (filters_in "SIZE [0-9]* \\(${ARG_APPLY_FILTERS}\\\.[0-9][0-9][0-9]:1 COMPRESSION\\)")
-    set (filters_out "SIZE XXXX (${ARG_APPLY_FILTERS}.XXX:1 COMPRESSION)")
+    set (filters_in "")
+    set (filters_out "")
+
+    list (APPEND filters_in "SIZE [0-9]* \\(${_FILTER_VAL}\\\.[0-9][0-9][0-9]:1 COMPRESSION\\)")
+    list (APPEND filters_out "SIZE XXXX (${_FILTER_VAL}.XXX:1 COMPRESSION)")
+
+    # Mask out the h5dump-assigned anonymous committed datatype numbers
+    # Datatype number may have a forward slash before #
+    list (APPEND filters_in "DATATYPE[ \t]*\"(/?#)[0-9]+\"")
+    list (APPEND filters_out "DATATYPE \"#XXXX\"")
+
+    # With -n, oputput that must be filtered appears different
+    list (APPEND filters_in "datatype [ \t]*(/?#)[0-9]+")
+    list (APPEND filters_out "datatype [ \t]*(/?#)XXXX")
+  
+    # Size/Offset within file will differ across VOL connectors
+    list (APPEND filters_in "OFFSET [0-9]+")
+    list (APPEND filters_out "OFFSET XXXX")
+
+    list (APPEND filters_in "SIZE [0-9]+")
+    list (APPEND filters_out "SIZE XXXX")
   else ()
     set (filters_in "")
     set (filters_out "")
@@ -609,101 +687,151 @@ macro (ADD_H5_TEST testname)
     set(should_skip_test TRUE)
   endif()
 
-  # Cleanup if test produces artifacts
-  if (${DO_CLEANUP})
-    add_test (
-        NAME H5DUMP-${ctest_testname}-clear-objects
+  if (${ARG_NATIVE_ONLY})
+    set(num_ext_vols 0)
+  else()
+    list(LENGTH HDF5_EXTERNAL_VOL_TARGETS num_ext_vols)
+  endif()
+
+  # Add a test for the native connector and each external VOL connector
+  foreach (vol_idx RANGE 0 ${num_ext_vols})
+    set(vol_env "")
+
+    # First, populate VOL info to be passed to tests
+    if (${vol_idx} EQUAL 0)
+      set(vol "native")
+      set (vol_prefix "")
+      set (workdir "${PROJECT_BINARY_DIR}/testfiles/std")
+    else ()
+      # An external VOL connector
+      math(EXPR vol_idx_fixed "${vol_idx} - 1")
+      list(GET HDF5_EXTERNAL_VOL_TARGETS ${vol_idx_fixed} ext_vol_tgt)
+      HDF5_GET_VOL_TGT_INFO(${ext_vol_tgt} vol vol_env)
+
+      set (vol_prefix "HDF5_VOL_${vol}-")
+
+      set (workdir "${PROJECT_BINARY_DIR}/${vol}/testfiles/std")
+      # Isolate plugin path string
+      string(FIND "${vol_env}" "HDF5_PLUGIN_PATH=" vol_plugin_path_posn)
+
+      if (vol_plugin_path_posn GREATER -1)
+        # Grab path string after HDF5_PLUGIN_PATH=
+        string(LENGTH "HDF5_PLUGIN_PATH=" path_prefix_len)
+        math(EXPR vol_plugin_path_posn "${vol_plugin_path_posn} + ${path_prefix_len}")
+        string(SUBSTRING "${vol_env}" ${vol_plugin_path_posn} -1 vol_plugin_path)
+      else()
+        set(vol_plugin_path "")
+      endif()
+    endif () # env VOL arg setup
+
+    # Clean up if test produces artifacts
+    if (${DO_CLEANUP})
+      add_test (
+          NAME ${vol_prefix}H5DUMP-${ctest_testname}-clear-objects
+          COMMAND ${CMAKE_COMMAND} -E remove
+            "${testname}.txt"
+            "${ARG_OUTPUT_FILE}.txt"
+            "${ARG_DDL_FILE}.txt"
+            "${testname}.bin"
+
+      )
+
+      set_tests_properties (${vol_prefix}H5DUMP-${ctest_testname}-clear-objects PROPERTIES
+          WORKING_DIRECTORY "${workdir}"
+      )
+    endif ()
+
+    # If using memchecker add tests without using scripts
+    if (HDF5_ENABLE_USING_MEMCHECKER AND NOT ARG_MASK_ERROR AND NOT ARG_GREP_COMPARE AND NOT DEFINED ARG_H5ERRREF)
+      add_test (NAME ${vol_prefix}H5DUMP-${ctest_testname} COMMAND ${CMAKE_CROSSCOMPILING_EMULATOR} $<TARGET_FILE:h5dump> ${ARG_ANY_PATHS} ${ARG_UNPARSED_ARGUMENTS} ${ARG_DDL_FILE_CMD} ${BINARY_OUTPUT_FLAG} ${ARG_OUTPUT_FILEARGS} ${ARG_TARGET_FILE})
+      if (${ARG_RESULT_CODE})
+        set_tests_properties (${vol_prefix}H5DUMP-${ctest_testname} PROPERTIES WILL_FAIL "true")
+      endif ()
+      set_tests_properties (${vol_prefix}H5DUMP-${ctest_testname} PROPERTIES
+          WORKING_DIRECTORY "${workdir}"
+      )
+    else ()
+      add_test (
+          NAME ${vol_prefix}H5DUMP-${ctest_testname}
+          COMMAND "${CMAKE_COMMAND}"
+              -D "TEST_EMULATOR=${CMAKE_CROSSCOMPILING_EMULATOR}"
+              -D "TEST_PROGRAM=$<TARGET_FILE:h5dump>"
+              -D "TEST_ARGS:STRING=${ARG_ANY_PATHS};${ARG_UNPARSED_ARGUMENTS};${ARG_DDL_FILE_CMD};${BINARY_OUTPUT_FLAG};${ARG_OUTPUT_FILEARGS};${ARG_TARGET_FILE}"
+              -D "TEST_FOLDER=${workdir}"
+              -D "TEST_OUTPUT=${testname}.out"
+              -D "TEST_EXPECT=${ARG_RESULT_CODE}"
+              -D "TEST_REFERENCE=${ARG_RESULT_CHECK_FILE}"
+              -D "TEST_FILTER:STRING=${filters_in}"
+              -D "TEST_FILTER_REPLACE:STRING=${filters_out}"
+              -D "TEST_MASK_ERROR:BOOL=${ARG_MASK_ERROR}"
+              -D "TEST_GREP_COMPARE:BOOL=${ARG_GREP_COMPARE}"
+              -D "TEST_ERRREF=${ARG_H5ERRREF}"
+              -D "TEST_ENV_VAR:STRING=${ARG_ENVVAR}"
+              -D "TEST_ENV_VALUE:STRING=${ARG_ENVVAL}"
+              -P "${HDF_RESOURCES_DIR}/runTest.cmake"
+      )
+    endif ()
+    set_tests_properties (${vol_prefix}H5DUMP-${ctest_testname} PROPERTIES
+        WORKING_DIRECTORY "${workdir}"
+    )
+
+    if ("${vol_prefix}H5DUMP-${ctest_testname}" MATCHES "${HDF5_DISABLE_TESTS_REGEX}")
+      set_tests_properties (${vol_prefix}H5DUMP-${ctest_testname} PROPERTIES DISABLED true)
+    endif ()
+    
+    # Set VOL-specific properties
+    if (NOT "${vol}" STREQUAL "native")
+      set_tests_properties (${vol_prefix}H5DUMP-${ctest_testname} PROPERTIES
+        ENVIRONMENT "${vol_env}"
+        FIXTURES_REQUIRED "h5dump_vol_files"
+      )
+    endif ()
+
+    if ("${vol_prefix}H5DUMP-${ctest_testname}" MATCHES "${HDF5_DISABLE_TESTS_REGEX}")
+      set_tests_properties (${vol_prefix}H5DUMP-${ctest_testname} PROPERTIES DISABLED true)
+    endif ()
+      
+    set(CLEANUP_DEPENDENCIES "${vol_prefix}H5DUMP-${ctest_testname}")
+
+    if (DEFINED ARG_TARGET_FILE AND DEFINED ARG_OUTPUT_FILE)
+      add_test (
+        NAME ${vol_prefix}H5DUMP-${ctest_testname}-output-cmp
+        COMMAND ${CMAKE_COMMAND} -E compare_files --ignore-eol ${testname}.txt ${testname}.exp
+      )
+
+      set_tests_properties(${vol_prefix}H5DUMP-${ctest_testname}-output-cmp PROPERTIES
+        DEPENDS H5DUMP-${ctest_testname}
+        WORKING_DIRECTORY "${workdir}"
+      )
+
+      if ("${vol_prefix}H5DUMP-${ctest_testname}-output-cmp" MATCHES "${HDF5_DISABLE_TESTS_REGEX}")
+        set_tests_properties (${vol_prefix}H5DUMP-${ctest_testname}-output-cmp PROPERTIES DISABLED true)
+      endif ()
+
+      list(APPEND CLEANUP_DEPENDENCIES "${vol_prefix}H5DUMP-${ctest_testname}-output-cmp")
+    endif ()
+
+    if (${DO_CLEANUP})
+      add_test (
+        NAME ${vol_prefix}H5DUMP-${ctest_testname}-clean-objects
         COMMAND ${CMAKE_COMMAND} -E remove
           "${testname}.txt"
           "${ARG_OUTPUT_FILE}.txt"
           "${ARG_DDL_FILE}.txt"
           "${testname}.bin"
+      )
 
-    )
-
-    set_tests_properties (H5DUMP-${ctest_testname}-clear-objects PROPERTIES
-        WORKING_DIRECTORY "${PROJECT_BINARY_DIR}/testfiles/std"
-    )
-  endif ()
-
-  # If using memchecker add tests without using scripts
-  if (HDF5_ENABLE_USING_MEMCHECKER AND NOT ARG_MASK_ERROR AND NOT ARG_GREP_COMPARE AND NOT DEFINED ARG_H5ERRREF)
-    add_test (NAME H5DUMP-${ctest_testname} COMMAND ${CMAKE_CROSSCOMPILING_EMULATOR} $<TARGET_FILE:h5dump> ${ARG_ANY_PATHS} ${ARG_UNPARSED_ARGUMENTS} ${ARG_DDL_FILE_CMD} ${BINARY_OUTPUT_FLAG} ${ARG_OUTPUT_FILEARGS} ${ARG_TARGET_FILE})
-    if (${ARG_RESULT_CODE})
-      set_tests_properties (H5DUMP-${ctest_testname} PROPERTIES WILL_FAIL "true")
-    endif ()
-    set_tests_properties (H5DUMP-${ctest_testname} PROPERTIES
-        WORKING_DIRECTORY "${PROJECT_BINARY_DIR}/testfiles/std"
-    )
-  else ()
-    add_test (
-        NAME H5DUMP-${ctest_testname}
-        COMMAND "${CMAKE_COMMAND}"
-            -D "TEST_EMULATOR=${CMAKE_CROSSCOMPILING_EMULATOR}"
-            -D "TEST_PROGRAM=$<TARGET_FILE:h5dump>"
-            -D "TEST_ARGS:STRING=${ARG_ANY_PATHS};${ARG_UNPARSED_ARGUMENTS};${ARG_DDL_FILE_CMD};${BINARY_OUTPUT_FLAG};${ARG_OUTPUT_FILEARGS};${ARG_TARGET_FILE}"
-            -D "TEST_FOLDER=${PROJECT_BINARY_DIR}/testfiles/std"
-            -D "TEST_OUTPUT=${testname}.out"
-            -D "TEST_EXPECT=${ARG_RESULT_CODE}"
-            -D "TEST_REFERENCE=${ARG_RESULT_CHECK_FILE}"
-            -D "TEST_FILTER:STRING=${filters_in}"
-            -D "TEST_FILTER_REPLACE:STRING=${filters_out}"
-            -D "TEST_MASK_ERROR:BOOL=${ARG_MASK_ERROR}"
-            -D "TEST_GREP_COMPARE:BOOL=${ARG_GREP_COMPARE}"
-            -D "TEST_ERRREF=${ARG_H5ERRREF}"
-            -D "TEST_ENV_VAR:STRING=${ARG_ENVVAR}"
-            -D "TEST_ENV_VALUE:STRING=${ARG_ENVVAL}"
-            -P "${HDF_RESOURCES_DIR}/runTest.cmake"
-    )
-  endif ()
-  set_tests_properties (H5DUMP-${ctest_testname} PROPERTIES
-      WORKING_DIRECTORY "${PROJECT_BINARY_DIR}/testfiles/std"
-  )
-
-  if ("H5DUMP-${ctest_testname}" MATCHES "${HDF5_DISABLE_TESTS_REGEX}")
-    set_tests_properties (H5DUMP-${ctest_testname} PROPERTIES DISABLED true)
-  endif ()
-
-  set(CLEANUP_DEPENDENCIES "H5DUMP-${ctest_testname}")
-
-  if (DEFINED ARG_TARGET_FILE AND DEFINED ARG_OUTPUT_FILE)
-    add_test (
-      NAME H5DUMP-${ctest_testname}-output-cmp
-      COMMAND ${CMAKE_COMMAND} -E compare_files --ignore-eol ${testname}.txt ${testname}.exp
-    )
-
-    set_tests_properties(H5DUMP-${ctest_testname}-output-cmp PROPERTIES
-      DEPENDS H5DUMP-${ctest_testname}
-      WORKING_DIRECTORY "${PROJECT_BINARY_DIR}/testfiles/std"
-    )
-
-    if ("H5DUMP-${ctest_testname}-output-cmp" MATCHES "${HDF5_DISABLE_TESTS_REGEX}")
-      set_tests_properties (H5DUMP-${ctest_testname}-output-cmp PROPERTIES DISABLED true)
+      set_tests_properties (${vol_prefix}H5DUMP-${ctest_testname}-clean-objects PROPERTIES
+          DEPENDS "${CLEANUP_DEPENDENCIES}"
+          WORKING_DIRECTORY "${workdir}"
+      )
     endif ()
 
-    list(APPEND CLEANUP_DEPENDENCIES "H5DUMP-${ctest_testname}-output-cmp")
-  endif ()
-
-  if (${DO_CLEANUP})
-    add_test (
-      NAME H5DUMP-${ctest_testname}-clean-objects
-      COMMAND ${CMAKE_COMMAND} -E remove
-        "${testname}.txt"
-        "${ARG_OUTPUT_FILE}.txt"
-        "${ARG_DDL_FILE}.txt"
-        "${testname}.bin"
-    )
-
-    set_tests_properties (H5DUMP-${ctest_testname}-clean-objects PROPERTIES
-        DEPENDS "${CLEANUP_DEPENDENCIES}"
-        WORKING_DIRECTORY "${PROJECT_BINARY_DIR}/testfiles/std"
-    )
-  endif ()
-
-  # Mark the test as disabled if needed
-  if (should_skip_test)
-    set_tests_properties(H5DUMP-${ctest_testname} PROPERTIES DISABLED true)
-  endif()
+    # Mark the test as disabled if needed
+    if (should_skip_test)
+      set_tests_properties(${vol_prefix}H5DUMP-${ctest_testname} PROPERTIES DISABLED true)
+    endif()
+  endforeach () # per-VOL loop
 endmacro ()
 
 macro (ADD_H5_TEST_IMPORT conffile resultfile testfile resultcode)
@@ -917,12 +1045,12 @@ ADD_H5_TEST (thlink-5 RESULT_CODE 0 --enable-error-stack -d /dset1 -g /g2 -d /g1
 ADD_H5_TEST (thlink-5-N RESULT_CODE 0 --enable-error-stack TARGET_FILE thlink.h5 ANY_PATHS /dset1 /g2 /g1/dset2)
 
 # tests for compound data types
-ADD_H5_TEST (tcomp-1 RESULT_CODE 0 --enable-error-stack TARGET_FILE tcompound.h5)
+ADD_H5_TEST (tcomp-1 RESULT_CODE 0 --enable-error-stack TARGET_FILE tcompound.h5 APPLY_FILTERS 0)
 # test for named data types
 ADD_H5_TEST (tcomp-2 RESULT_CODE 0 --enable-error-stack -t /type1 --datatype /type2 --datatype=/group1/type3 TARGET_FILE tcompound.h5)
 ADD_H5_TEST (tcomp-2-N RESULT_CODE 0 --enable-error-stack TARGET_FILE tcompound.h5 ANY_PATHS /type1 /type2 /group1/type3)
-# test for unnamed type
-ADD_H5_TEST (tcomp-3 RESULT_CODE 0 H5ERRREF "object '#6632' doesn't exist" "--enable-error-stack;-t;/#6632;-g;/group2" TARGET_FILE tcompound.h5)
+# test for unnamed type - restrict to native VOL since other VOLs will assign different numbers
+ADD_H5_TEST (tcomp-3 RESULT_CODE 0 H5ERRREF "object '#6632' doesn't exist" "--enable-error-stack;-t;/#6632;-g;/group2" TARGET_FILE tcompound.h5 NATIVE_ONLY)
 # test complicated compound datatype
 ADD_H5_TEST (tcomp-4 RESULT_CODE 0 --enable-error-stack TARGET_FILE tcompound_complex.h5)
 ADD_H5_TEST (tcompound_complex2 RESULT_CODE 0 --enable-error-stack TARGET_FILE tcompound_complex2.h5)
@@ -953,7 +1081,7 @@ ADD_H5_TEST (tstr-1 RESULT_CODE 0 --enable-error-stack TARGET_FILE tstr.h5)
 ADD_H5_TEST (tstr-2 RESULT_CODE 0 --enable-error-stack TARGET_FILE tstr2.h5)
 
 # test for file created by Lib SAF team
-ADD_H5_TEST (tsaf RESULT_CODE 0 --enable-error-stack TARGET_FILE tsaf.h5)
+ADD_H5_TEST (tsaf RESULT_CODE 0 --enable-error-stack TARGET_FILE tsaf.h5 NATIVE_ONLY)
 
 # test for file with variable length data
 ADD_H5_TEST (tvldtypes1 RESULT_CODE 0 --enable-error-stack TARGET_FILE tvldtypes1.h5)
@@ -1037,9 +1165,9 @@ ADD_H5_TEST (file_space_cache RESULT_CODE 0 --enable-error-stack=2 --page-buffer
 ADD_H5_TEST (tperror RESULT_CODE 1 H5ERRREF "h5dump error: unable to get link info from \"bogus\"" --enable-error-stack -p -d bogus TARGET_FILE tfcontents1.h5)
 
 # test for file contents
-ADD_H5_TEST (tcontents RESULT_CODE 0 --enable-error-stack -n TARGET_FILE tfcontents1.h5)
-ADD_H5_TEST (tordercontents1 RESULT_CODE 0 --enable-error-stack -n --sort_by=name --sort_order=ascending TARGET_FILE tfcontents1.h5)
-ADD_H5_TEST (tordercontents2 RESULT_CODE 0 --enable-error-stack -n --sort_by=name --sort_order=descending TARGET_FILE tfcontents1.h5)
+ADD_H5_TEST (tcontents RESULT_CODE 0 --enable-error-stack -n TARGET_FILE tfcontents1.h5 APPLY_FILTERS 0)
+ADD_H5_TEST (tordercontents1 RESULT_CODE 0 --enable-error-stack -n --sort_by=name --sort_order=ascending TARGET_FILE tfcontents1.h5 APPLY_FILTERS 1)
+ADD_H5_TEST (tordercontents2 RESULT_CODE 0 --enable-error-stack -n --sort_by=name --sort_order=descending TARGET_FILE tfcontents1.h5 APPLY_FILTERS 1)
 ADD_H5_TEST (tattrcontents1 RESULT_CODE 0 --enable-error-stack -n 1 --sort_order=ascending TARGET_FILE tall.h5)
 ADD_H5_TEST (tattrcontents2 RESULT_CODE 0 --enable-error-stack -n 1 --sort_order=descending TARGET_FILE tall.h5)
 
@@ -1054,7 +1182,7 @@ ADD_H5_TEST (tchunked RESULT_CODE 0 --enable-error-stack -H -p -d chunked TARGET
 ADD_H5_TEST (texternal RESULT_CODE 0 --enable-error-stack -H -p -d external TARGET_FILE tfilters.h5)
 
 # fill values
-ADD_H5_TEST (tfill RESULT_CODE 0 --enable-error-stack -p TARGET_FILE tfvalues.h5)
+ADD_H5_TEST (tfill RESULT_CODE 0 --enable-error-stack -p TARGET_FILE tfvalues.h5 APPLY_FILTERS 1)
 
 # several datatype, with references , print path
 ADD_H5_TEST (treference RESULT_CODE 0 --enable-error-stack  TARGET_FILE tattr2.h5)
@@ -1090,7 +1218,9 @@ ADD_H5_TEST (texceedsubblock RESULT_CODE 1 H5ERRREF "exceed dataset dims" --enab
 
 # tests for filters
 # SZIP
-ADD_H5_TEST (tszip RESULT_CODE 0 APPLY_FILTERS 2 --enable-error-stack -H -p -d szip TARGET_FILE tfilters.h5)
+if (H5_HAVE_FILTER_SZIP)
+  ADD_H5_TEST (tszip RESULT_CODE 0 APPLY_FILTERS 2 --enable-error-stack -H -p -d szip TARGET_FILE tfilters.h5)
+endif()
 
 # deflate
 ADD_H5_TEST (tdeflate RESULT_CODE 0 APPLY_FILTERS 2 --enable-error-stack -H -p -d deflate TARGET_FILE tfilters.h5)
@@ -1108,7 +1238,9 @@ ADD_H5_TEST (tnbit RESULT_CODE 0 APPLY_FILTERS 1 --enable-error-stack -H -p -d n
 ADD_H5_TEST (tscaleoffset RESULT_CODE 0 APPLY_FILTERS 4 --enable-error-stack -H -p -d scaleoffset  TARGET_FILE tfilters.h5)
 
 # all
-ADD_H5_TEST (tallfilters RESULT_CODE 0 APPLY_FILTERS 1 --enable-error-stack -H -p -d all  TARGET_FILE tfilters.h5)
+if (H5_HAVE_FILTER_SZIP)
+  ADD_H5_TEST (tallfilters RESULT_CODE 0 APPLY_FILTERS 1 --enable-error-stack -H -p -d all  TARGET_FILE tfilters.h5 APPLY_FILTERS 1)
+endif ()
 
 # user defined
 ADD_H5_TEST (tuserfilter RESULT_CODE 0 --enable-error-stack -H  -p -d myfilter  TARGET_FILE tfilters.h5)
@@ -1120,14 +1252,6 @@ ADD_H5_TEST (tuserfilter RESULT_CODE 0 --enable-error-stack -H  -p -d myfilter  
 
 # detect whether the encoder is present.
 if (H5_HAVE_FILTER_DEFLATE)
-  set (USE_FILTER_DEFLATE "true")
-endif ()
-
-if (H5_HAVE_FILTER_SZIP)
-  set (USE_FILTER_SZIP "true")
-endif ()
-
-if (USE_FILTER_DEFLATE)
   # data read internal filters
   ADD_H5_TEST (treadintfilter RESULT_CODE 0 --enable-error-stack -d deflate -d shuffle -d fletcher32 -d nbit -d scaleoffset TARGET_FILE tfilters.h5)
   if (HDF5_ENABLE_SZIP_SUPPORT)
@@ -1158,8 +1282,10 @@ ADD_H5_TEST (tldouble RESULT_CODE 0 --enable-error-stack TARGET_FILE tldouble.h5
 ADD_H5_TEST (tldouble_scalar RESULT_CODE 0 -p --enable-error-stack TARGET_FILE tldouble_scalar.h5)
 
 # Add tests for _Float16 type
-ADD_H5_TEST (tfloat16 RESULT_CODE 0 --enable-error-stack TARGET_FILE tfloat16.h5)
-ADD_H5_TEST (tfloat16_be RESULT_CODE 0 --enable-error-stack TARGET_FILE tfloat16_be.h5)
+if (${${HDF_PREFIX}_HAVE__FLOAT16})
+  ADD_H5_TEST (tfloat16 RESULT_CODE 0 --enable-error-stack TARGET_FILE tfloat16.h5)
+  ADD_H5_TEST (tfloat16_be RESULT_CODE 0 --enable-error-stack TARGET_FILE tfloat16_be.h5)
+endif()
 
 # Add tests for bfloat16 type
 ADD_H5_TEST (tbfloat16 RESULT_CODE 0 --enable-error-stack TARGET_FILE tbfloat16.h5)
@@ -1243,8 +1369,8 @@ ADD_H5_TEST (torderattr3 RESULT_CODE 0 --enable-error-stack -H --sort_by=creatio
 ADD_H5_TEST (torderattr4 RESULT_CODE 0 --enable-error-stack -H --sort_by=creation_order --sort_order=descending TARGET_FILE torderattr.h5)
 
 # tests for link references and order
-ADD_H5_TEST (torderlinks1 RESULT_CODE 0 H5ERRREF "unable to open external file, external link file name = 'fname'" --enable-error-stack --sort_by=name --sort_order=ascending TARGET_FILE tfcontents1.h5)
-ADD_H5_TEST (torderlinks2 RESULT_CODE 0 H5ERRREF "unable to open external file, external link file name = 'fname'" --enable-error-stack --sort_by=name --sort_order=descending TARGET_FILE tfcontents1.h5)
+ADD_H5_TEST (torderlinks1 RESULT_CODE 0 H5ERRREF "unable to open external file, external link file name = 'fname'" --enable-error-stack --sort_by=name --sort_order=ascending TARGET_FILE tfcontents1.h5 APPLY_FILTERS 1)
+ADD_H5_TEST (torderlinks2 RESULT_CODE 0 H5ERRREF "unable to open external file, external link file name = 'fname'" --enable-error-stack --sort_by=name --sort_order=descending TARGET_FILE tfcontents1.h5 APPLY_FILTERS 1)
 
 # tests for floating point user defined printf format
 ADD_H5_TEST (tfpformat RESULT_CODE 0 --enable-error-stack --format=%.7f TARGET_FILE tfpformat.h5)
@@ -1257,7 +1383,7 @@ ADD_H5_TEST (textlinkfar RESULT_CODE 0 H5ERRREF "Too many soft links in path" --
 ADD_H5_TEST (textlink RESULT_CODE 0 H5ERRREF "unable to open external file, external link file name = 'anotherfile'" --enable-error-stack TARGET_FILE textlink.h5)
 
 # test for error stack display (BZ2048)
-ADD_H5_TEST (filter_fail RESULT_CODE 1 H5ERRREF "filter plugins disabled" ENVVAR "HDF5_PLUGIN_PRELOAD" ENVVAL "::" --enable-error-stack TARGET_FILE filter_fail.h5)
+ADD_H5_TEST (filter_fail RESULT_CODE 1 H5ERRREF "filter plugins disabled" ENVVAR "HDF5_PLUGIN_PRELOAD" ENVVAL "::" --enable-error-stack TARGET_FILE filter_fail.h5 NATIVE_ONLY)
 
 # test for -o -y for dataset with attributes
 ADD_H5_TEST (tall-6 OUTPUT_FILE tall-6 TARGET_FILE tall.h5 RESULT_CODE 0 --enable-error-stack -d /g1/g1.1/dset1.1.1 -y)

--- a/tools/test/h5dump/CMakeTests.cmake
+++ b/tools/test/h5dump/CMakeTests.cmake
@@ -1271,12 +1271,20 @@ ADD_H5_TEST (tldouble RESULT_CODE 0 --enable-error-stack TARGET_FILE tldouble.h5
 ADD_H5_TEST (tldouble_scalar RESULT_CODE 0 -p --enable-error-stack TARGET_FILE tldouble_scalar.h5)
 
 # Add tests for _Float16 type
-ADD_H5_TEST (tfloat16 RESULT_CODE 0 --enable-error-stack TARGET_FILE tfloat16.h5)
-ADD_H5_TEST (tfloat16_be RESULT_CODE 0 --enable-error-stack TARGET_FILE tfloat16_be.h5)
+# VOL testing must generate the F16 files, which it can only do if F16 is enabled
+# - so mark these tests as Native only if Float16 isn't enabled.
+if (${${HDF_PREFIX}_HAVE__FLOAT16})
+  set (F16_NATIVE_ONLY "")
+else ()
+  set (F16_NATIVE_ONLY "NATIVE_ONLY")
+endif ()
+
+ADD_H5_TEST (tfloat16 RESULT_CODE 0 --enable-error-stack TARGET_FILE tfloat16.h5 ${F16_NATIVE_ONLY})
+ADD_H5_TEST (tfloat16_be RESULT_CODE 0 --enable-error-stack TARGET_FILE tfloat16_be.h5 ${F16_NATIVE_ONLY})
 
 # Add tests for bfloat16 type
-ADD_H5_TEST (tbfloat16 RESULT_CODE 0 --enable-error-stack TARGET_FILE tbfloat16.h5)
-ADD_H5_TEST (tbfloat16_be RESULT_CODE 0 --enable-error-stack TARGET_FILE tbfloat16_be.h5)
+ADD_H5_TEST (tbfloat16 RESULT_CODE 0 --enable-error-stack TARGET_FILE tbfloat16.h5 ${F16_NATIVE_ONLY})
+ADD_H5_TEST (tbfloat16_be RESULT_CODE 0 --enable-error-stack TARGET_FILE tbfloat16_be.h5 ${F16_NATIVE_ONLY})
 
 # Add tests for complex numbers. For portability, use a fixed floating-point
 # precision and skip dumping of the "long double _Complex" dataset. The "long

--- a/tools/test/h5dump/CMakeTestsXML.cmake
+++ b/tools/test/h5dump/CMakeTestsXML.cmake
@@ -303,10 +303,8 @@ ADD_XML_H5_TEST (torderattr3.h5 0 -H --sort_by=creation_order --sort_order=ascen
 ADD_XML_H5_TEST (torderattr4.h5 0 -H --sort_by=creation_order --sort_order=descending torderattr.h5)
 
 # Add tests for _Float16 type
-if (${${HDF_PREFIX}_HAVE__FLOAT16})
-  ADD_XML_H5_TEST (tfloat16.h5 0 tfloat16.h5)
-  ADD_XML_H5_TEST (tfloat16_be.h5 0 tfloat16_be.h5)
-endif ()
+ADD_XML_H5_TEST (tfloat16.h5 0 tfloat16.h5)
+ADD_XML_H5_TEST (tfloat16_be.h5 0 tfloat16_be.h5)
 
 # Add tests for bfloat16 type
 ADD_XML_H5_TEST (tbfloat16.h5 0 tbfloat16.h5)

--- a/tools/test/h5dump/CMakeTestsXML.cmake
+++ b/tools/test/h5dump/CMakeTestsXML.cmake
@@ -303,8 +303,10 @@ ADD_XML_H5_TEST (torderattr3.h5 0 -H --sort_by=creation_order --sort_order=ascen
 ADD_XML_H5_TEST (torderattr4.h5 0 -H --sort_by=creation_order --sort_order=descending torderattr.h5)
 
 # Add tests for _Float16 type
-ADD_XML_H5_TEST (tfloat16.h5 0 tfloat16.h5)
-ADD_XML_H5_TEST (tfloat16_be.h5 0 tfloat16_be.h5)
+if (${${HDF_PREFIX}_HAVE__FLOAT16})
+  ADD_XML_H5_TEST (tfloat16.h5 0 tfloat16.h5)
+  ADD_XML_H5_TEST (tfloat16_be.h5 0 tfloat16_be.h5)
+endif ()
 
 # Add tests for bfloat16 type
 ADD_XML_H5_TEST (tbfloat16.h5 0 tbfloat16.h5)

--- a/tools/test/h5dump/h5dumpgentest.c
+++ b/tools/test/h5dump/h5dumpgentest.c
@@ -4620,7 +4620,7 @@ write_dset_in(hid_t loc_id, const char *dset_name, /* for saving reference to da
      */
     tid    = H5Tcopy(H5T_C_S1);
     status = H5Tset_size(tid, 2);
-    write_dset(loc_id, 1, dims, "string", tid, H5I_INVALID_HID, buf1);
+    write_dset(loc_id, 1, dims, "string", tid, tid, buf1);
     status = H5Tclose(tid);
 
     /*-------------------------------------------------------------------------
@@ -4628,7 +4628,7 @@ write_dset_in(hid_t loc_id, const char *dset_name, /* for saving reference to da
      *-------------------------------------------------------------------------
      */
     tid = H5Tcopy(H5T_STD_B8LE);
-    write_dset(loc_id, 1, dims, "bitfield", tid, H5I_INVALID_HID, buf2);
+    write_dset(loc_id, 1, dims, "bitfield", tid, tid, buf2);
     status = H5Tclose(tid);
 
     /*-------------------------------------------------------------------------
@@ -4637,7 +4637,7 @@ write_dset_in(hid_t loc_id, const char *dset_name, /* for saving reference to da
      */
     tid    = H5Tcreate(H5T_OPAQUE, 1);
     status = H5Tset_tag(tid, "1-byte opaque type"); /* must set this */
-    write_dset(loc_id, 1, dims, "opaque", tid, H5I_INVALID_HID, buf2);
+    write_dset(loc_id, 1, dims, "opaque", tid, tid, buf2);
     status = H5Tclose(tid);
 
     /*-------------------------------------------------------------------------
@@ -4647,7 +4647,7 @@ write_dset_in(hid_t loc_id, const char *dset_name, /* for saving reference to da
     tid = H5Tcreate(H5T_COMPOUND, sizeof(s_t));
     H5Tinsert(tid, "a", HOFFSET(s_t, a), H5T_NATIVE_CHAR);
     H5Tinsert(tid, "b", HOFFSET(s_t, b), H5T_NATIVE_DOUBLE);
-    write_dset(loc_id, 1, dims, "compound", tid, H5I_INVALID_HID, buf3);
+    write_dset(loc_id, 1, dims, "compound", tid, tid, buf3);
     status = H5Tclose(tid);
 
     /*-------------------------------------------------------------------------
@@ -4658,7 +4658,7 @@ write_dset_in(hid_t loc_id, const char *dset_name, /* for saving reference to da
     if (dset_name) {
         status = H5Rcreate(&buf4[0], fid, dset_name, H5R_OBJECT, (hid_t)-1);
         status = H5Rcreate(&buf4[1], fid, dset_name, H5R_OBJECT, (hid_t)-1);
-        write_dset(loc_id, 1, dims, "reference", H5T_STD_REF_OBJ, H5I_INVALID_HID, buf4);
+        write_dset(loc_id, 1, dims, "reference", H5T_STD_REF_OBJ, H5T_STD_REF_OBJ, buf4);
     }
 
     /*-------------------------------------------------------------------------
@@ -4668,7 +4668,7 @@ write_dset_in(hid_t loc_id, const char *dset_name, /* for saving reference to da
     tid = H5Tcreate(H5T_ENUM, sizeof(e_t));
     H5Tenum_insert(tid, "RED", (val = 0, &val));
     H5Tenum_insert(tid, "GREEN", (val = 1, &val));
-    write_dset(loc_id, 1, dims, "enum", tid, H5I_INVALID_HID, 0);
+    write_dset(loc_id, 1, dims, "enum", tid, tid, 0);
     status = H5Tclose(tid);
 
     /*-------------------------------------------------------------------------
@@ -4702,22 +4702,22 @@ write_dset_in(hid_t loc_id, const char *dset_name, /* for saving reference to da
      *-------------------------------------------------------------------------
      */
     tid = H5Tarray_create2(H5T_NATIVE_INT, 1, dimarray);
-    write_dset(loc_id, 1, dims, "array", tid, H5I_INVALID_HID, buf6);
+    write_dset(loc_id, 1, dims, "array", tid, tid, buf6);
     status = H5Tclose(tid);
 
     /*-------------------------------------------------------------------------
      * H5T_INTEGER and H5T_FLOAT
      *-------------------------------------------------------------------------
      */
-    write_dset(loc_id, 1, dims, "integer", H5T_NATIVE_INT, H5I_INVALID_HID, buf7);
-    write_dset(loc_id, 1, dims, "float", H5T_NATIVE_FLOAT, H5I_INVALID_HID, buf8);
+    write_dset(loc_id, 1, dims, "integer", H5T_NATIVE_INT, H5T_NATIVE_INT, buf7);
+    write_dset(loc_id, 1, dims, "float", H5T_NATIVE_FLOAT, H5T_NATIVE_FLOAT, buf8);
 
     /*-------------------------------------------------------------------------
      * H5T_COMPLEX
      *-------------------------------------------------------------------------
      */
     tid = H5Tcomplex_create(H5T_NATIVE_FLOAT);
-    write_dset(loc_id, 1, dims, "complex", tid, H5I_INVALID_HID, buf9);
+    write_dset(loc_id, 1, dims, "complex", tid, tid, buf9);
     status = H5Tclose(tid);
 
     /*-------------------------------------------------------------------------
@@ -4731,7 +4731,7 @@ write_dset_in(hid_t loc_id, const char *dset_name, /* for saving reference to da
      */
     tid    = H5Tcopy(H5T_C_S1);
     status = H5Tset_size(tid, 2);
-    write_dset(loc_id, 2, dims2, "string2D", tid, H5I_INVALID_HID, buf12);
+    write_dset(loc_id, 2, dims2, "string2D", tid, tid, buf12);
     status = H5Tclose(tid);
 
     /*-------------------------------------------------------------------------
@@ -4739,7 +4739,7 @@ write_dset_in(hid_t loc_id, const char *dset_name, /* for saving reference to da
      *-------------------------------------------------------------------------
      */
     tid = H5Tcopy(H5T_STD_B8LE);
-    write_dset(loc_id, 2, dims2, "bitfield2D", tid, H5I_INVALID_HID, buf22);
+    write_dset(loc_id, 2, dims2, "bitfield2D", tid, tid, buf22);
     status = H5Tclose(tid);
 
     /*-------------------------------------------------------------------------
@@ -4748,7 +4748,7 @@ write_dset_in(hid_t loc_id, const char *dset_name, /* for saving reference to da
      */
     tid    = H5Tcreate(H5T_OPAQUE, 1);
     status = H5Tset_tag(tid, "1-byte opaque type"); /* must set this */
-    write_dset(loc_id, 2, dims2, "opaque2D", tid, H5I_INVALID_HID, buf22);
+    write_dset(loc_id, 2, dims2, "opaque2D", tid, tid, buf22);
     status = H5Tclose(tid);
 
     /*-------------------------------------------------------------------------
@@ -4758,7 +4758,7 @@ write_dset_in(hid_t loc_id, const char *dset_name, /* for saving reference to da
     tid = H5Tcreate(H5T_COMPOUND, sizeof(s_t));
     H5Tinsert(tid, "a", HOFFSET(s_t, a), H5T_NATIVE_CHAR);
     H5Tinsert(tid, "b", HOFFSET(s_t, b), H5T_NATIVE_DOUBLE);
-    write_dset(loc_id, 2, dims2, "compound2D", tid, H5I_INVALID_HID, buf32);
+    write_dset(loc_id, 2, dims2, "compound2D", tid, tid, buf32);
     status = H5Tclose(tid);
 
     /*-------------------------------------------------------------------------
@@ -4772,7 +4772,7 @@ write_dset_in(hid_t loc_id, const char *dset_name, /* for saving reference to da
                 status = H5Rcreate(&buf42[i][j], fid, dset_name, H5R_OBJECT, (hid_t)-1);
             }
         }
-        write_dset(loc_id, 2, dims2, "reference2D", H5T_STD_REF_OBJ, H5I_INVALID_HID, buf42);
+        write_dset(loc_id, 2, dims2, "reference2D", H5T_STD_REF_OBJ, H5T_STD_REF_OBJ, buf42);
     }
 
     /*-------------------------------------------------------------------------
@@ -4782,7 +4782,7 @@ write_dset_in(hid_t loc_id, const char *dset_name, /* for saving reference to da
     tid = H5Tcreate(H5T_ENUM, sizeof(e_t));
     H5Tenum_insert(tid, "RED", (val = 0, &val));
     H5Tenum_insert(tid, "GREEN", (val = 1, &val));
-    write_dset(loc_id, 2, dims2, "enum2D", tid, H5I_INVALID_HID, 0);
+    write_dset(loc_id, 2, dims2, "enum2D", tid, tid, 0);
     status = H5Tclose(tid);
 
     /*-------------------------------------------------------------------------
@@ -4818,7 +4818,7 @@ write_dset_in(hid_t loc_id, const char *dset_name, /* for saving reference to da
      *-------------------------------------------------------------------------
      */
     tid = H5Tarray_create2(H5T_NATIVE_INT, 1, dimarray);
-    write_dset(loc_id, 2, dims2, "array2D", tid, H5I_INVALID_HID, buf62);
+    write_dset(loc_id, 2, dims2, "array2D", tid, tid, buf62);
     status = H5Tclose(tid);
 
     /*-------------------------------------------------------------------------
@@ -4839,14 +4839,14 @@ write_dset_in(hid_t loc_id, const char *dset_name, /* for saving reference to da
      *-------------------------------------------------------------------------
      */
 
-    write_dset(loc_id, 2, dims2, "float2D", H5T_NATIVE_FLOAT, H5I_INVALID_HID, buf82);
+    write_dset(loc_id, 2, dims2, "float2D", H5T_NATIVE_FLOAT, H5T_NATIVE_FLOAT, buf82);
 
     /*-------------------------------------------------------------------------
      * H5T_COMPLEX
      *-------------------------------------------------------------------------
      */
     tid = H5Tcomplex_create(H5T_NATIVE_FLOAT);
-    write_dset(loc_id, 2, dims2, "complex2D", tid, H5I_INVALID_HID, buf92);
+    write_dset(loc_id, 2, dims2, "complex2D", tid, tid, buf92);
     status = H5Tclose(tid);
 
     /*-------------------------------------------------------------------------
@@ -4860,7 +4860,7 @@ write_dset_in(hid_t loc_id, const char *dset_name, /* for saving reference to da
      */
     tid    = H5Tcopy(H5T_C_S1);
     status = H5Tset_size(tid, 2);
-    write_dset(loc_id, 3, dims3, "string3D", tid, H5I_INVALID_HID, buf13);
+    write_dset(loc_id, 3, dims3, "string3D", tid, tid, buf13);
     status = H5Tclose(tid);
 
     /*-------------------------------------------------------------------------
@@ -4874,7 +4874,7 @@ write_dset_in(hid_t loc_id, const char *dset_name, /* for saving reference to da
             for (k = 0; k < 2; k++)
                 buf23[i][j][k] = (char)n++;
     tid = H5Tcopy(H5T_STD_B8LE);
-    write_dset(loc_id, 3, dims3, "bitfield3D", tid, H5I_INVALID_HID, buf23);
+    write_dset(loc_id, 3, dims3, "bitfield3D", tid, tid, buf23);
     status = H5Tclose(tid);
 
     /*-------------------------------------------------------------------------
@@ -4883,7 +4883,7 @@ write_dset_in(hid_t loc_id, const char *dset_name, /* for saving reference to da
      */
     tid    = H5Tcreate(H5T_OPAQUE, 1);
     status = H5Tset_tag(tid, "1-byte opaque type"); /* must set this */
-    write_dset(loc_id, 3, dims3, "opaque3D", tid, H5I_INVALID_HID, buf23);
+    write_dset(loc_id, 3, dims3, "opaque3D", tid, tid, buf23);
     status = H5Tclose(tid);
 
     /*-------------------------------------------------------------------------
@@ -4901,7 +4901,7 @@ write_dset_in(hid_t loc_id, const char *dset_name, /* for saving reference to da
     tid = H5Tcreate(H5T_COMPOUND, sizeof(s_t));
     H5Tinsert(tid, "a", HOFFSET(s_t, a), H5T_NATIVE_CHAR);
     H5Tinsert(tid, "b", HOFFSET(s_t, b), H5T_NATIVE_DOUBLE);
-    write_dset(loc_id, 3, dims3, "compound3D", tid, H5I_INVALID_HID, buf33);
+    write_dset(loc_id, 3, dims3, "compound3D", tid, tid, buf33);
     status = H5Tclose(tid);
 
     /*-------------------------------------------------------------------------
@@ -4916,7 +4916,7 @@ write_dset_in(hid_t loc_id, const char *dset_name, /* for saving reference to da
                     status = H5Rcreate(&buf43[i][j][k], fid, dset_name, H5R_OBJECT, (hid_t)-1);
             }
         }
-        write_dset(loc_id, 3, dims3, "reference3D", H5T_STD_REF_OBJ, H5I_INVALID_HID, buf43);
+        write_dset(loc_id, 3, dims3, "reference3D", H5T_STD_REF_OBJ, H5T_STD_REF_OBJ, buf43);
     }
 
     /*-------------------------------------------------------------------------
@@ -4926,7 +4926,7 @@ write_dset_in(hid_t loc_id, const char *dset_name, /* for saving reference to da
     tid = H5Tcreate(H5T_ENUM, sizeof(e_t));
     H5Tenum_insert(tid, "RED", (val = 0, &val));
     H5Tenum_insert(tid, "GREEN", (val = 1, &val));
-    write_dset(loc_id, 3, dims3, "enum3D", tid, H5I_INVALID_HID, 0);
+    write_dset(loc_id, 3, dims3, "enum3D", tid, tid, 0);
     status = H5Tclose(tid);
 
     /*-------------------------------------------------------------------------
@@ -4970,7 +4970,7 @@ write_dset_in(hid_t loc_id, const char *dset_name, /* for saving reference to da
     }
 
     tid = H5Tarray_create2(H5T_NATIVE_INT, 1, dimarray);
-    write_dset(loc_id, 3, dims3, "array3D", tid, H5I_INVALID_HID, buf63);
+    write_dset(loc_id, 3, dims3, "array3D", tid, tid, buf63);
     status = H5Tclose(tid);
 
     /*-------------------------------------------------------------------------
@@ -4987,8 +4987,8 @@ write_dset_in(hid_t loc_id, const char *dset_name, /* for saving reference to da
             }
         }
     }
-    write_dset(loc_id, 3, dims3, "integer3D", H5T_NATIVE_INT, H5I_INVALID_HID, buf73);
-    write_dset(loc_id, 3, dims3, "float3D", H5T_NATIVE_FLOAT, H5I_INVALID_HID, buf83);
+    write_dset(loc_id, 3, dims3, "integer3D", H5T_NATIVE_INT, H5T_NATIVE_INT, buf73);
+    write_dset(loc_id, 3, dims3, "float3D", H5T_NATIVE_FLOAT, H5T_NATIVE_FLOAT, buf83);
 
     /*-------------------------------------------------------------------------
      * H5T_COMPLEX
@@ -5000,7 +5000,7 @@ write_dset_in(hid_t loc_id, const char *dset_name, /* for saving reference to da
             buf93[i][j] = f++;
 
     tid = H5Tcomplex_create(H5T_NATIVE_FLOAT);
-    write_dset(loc_id, 3, dims3, "complex3D", tid, H5I_INVALID_HID, buf93);
+    write_dset(loc_id, 3, dims3, "complex3D", tid, tid, buf93);
     status = H5Tclose(tid);
 }
 
@@ -5120,9 +5120,6 @@ write_dset(hid_t loc_id, int rank, hsize_t *dims, const char *dset_name, hid_t t
     hid_t  did;
     hid_t  sid;
     herr_t status;
-
-    if (tid_memory == H5I_INVALID_HID)
-        tid_memory = tid_dset;
 
     /* Create a buf space  */
     sid = H5Screate_simple(rank, dims, NULL);
@@ -6155,7 +6152,7 @@ gent_fvalues(void)
      * dataset with no fill value
      *-------------------------------------------------------------------------
      */
-    write_dset(fid, 1, dims, "no_fill", H5T_NATIVE_INT, H5I_INVALID_HID, buf);
+    write_dset(fid, 1, dims, "no_fill", H5T_NATIVE_INT, H5T_NATIVE_INT, buf);
 
     /*-------------------------------------------------------------------------
      * dataset with a H5T_COMPOUND fill value
@@ -6209,7 +6206,7 @@ gent_fvalues(void)
      *-------------------------------------------------------------------------
      */
     tid = H5Tarray_create2(H5T_NATIVE_INT, 1, dimarray);
-    write_dset(fid, 1, dims, "fill_array", tid, H5I_INVALID_HID, buf4);
+    write_dset(fid, 1, dims, "fill_array", tid, tid, buf4);
     ret = H5Tclose(tid);
 
     /*-------------------------------------------------------------------------
@@ -6272,7 +6269,7 @@ gent_string(void)
     tid = H5Tcopy(H5T_C_S1);
     ret = H5Tset_size(tid, sizeof(buf1));
     assert(ret >= 0);
-    write_dset(fid, 1, dims1, "str1", tid, H5I_INVALID_HID, buf1);
+    write_dset(fid, 1, dims1, "str1", tid, tid, buf1);
     assert(ret >= 0);
     ret = H5Tclose(tid);
     assert(ret >= 0);
@@ -6378,10 +6375,10 @@ gent_aindices(void)
      * root datasets
      *-------------------------------------------------------------------------
      */
-    write_dset(fid, 1, dims1, "1d", H5T_NATIVE_INT, H5I_INVALID_HID, buf1);
-    write_dset(fid, 2, dims2, "2d", H5T_NATIVE_INT, H5I_INVALID_HID, buf2);
-    write_dset(fid, 3, dims3, "3d", H5T_NATIVE_INT, H5I_INVALID_HID, buf3);
-    write_dset(fid, 4, dims4, "4d", H5T_NATIVE_INT, H5I_INVALID_HID, buf4);
+    write_dset(fid, 1, dims1, "1d", H5T_NATIVE_INT, H5T_NATIVE_INT, buf1);
+    write_dset(fid, 2, dims2, "2d", H5T_NATIVE_INT, H5T_NATIVE_INT, buf2);
+    write_dset(fid, 3, dims3, "3d", H5T_NATIVE_INT, H5T_NATIVE_INT, buf3);
+    write_dset(fid, 4, dims4, "4d", H5T_NATIVE_INT, H5T_NATIVE_INT, buf4);
 
     /*-------------------------------------------------------------------------
      * test with group indentation
@@ -6393,10 +6390,10 @@ gent_aindices(void)
     gid[3] = H5Gcreate2(fid, "g1/g2/g3/g4", H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT);
     gid[4] = H5Gcreate2(fid, "g1/g2/g3/g4/g5", H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT);
     gid[5] = H5Gcreate2(fid, "g1/g2/g3/g4/g5/g6", H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT);
-    write_dset(gid[5], 1, dims1, "1d", H5T_NATIVE_INT, H5I_INVALID_HID, buf1);
-    write_dset(gid[5], 2, dims2, "2d", H5T_NATIVE_INT, H5I_INVALID_HID, buf2);
-    write_dset(gid[5], 3, dims3, "3d", H5T_NATIVE_INT, H5I_INVALID_HID, buf3);
-    write_dset(gid[5], 4, dims4, "4d", H5T_NATIVE_INT, H5I_INVALID_HID, buf4);
+    write_dset(gid[5], 1, dims1, "1d", H5T_NATIVE_INT, H5T_NATIVE_INT, buf1);
+    write_dset(gid[5], 2, dims2, "2d", H5T_NATIVE_INT, H5T_NATIVE_INT, buf2);
+    write_dset(gid[5], 3, dims3, "3d", H5T_NATIVE_INT, H5T_NATIVE_INT, buf3);
+    write_dset(gid[5], 4, dims4, "4d", H5T_NATIVE_INT, H5T_NATIVE_INT, buf4);
     for (i = 0; i < 6; i++)
         H5Gclose(gid[i]);
 
@@ -6788,7 +6785,7 @@ gent_hyperslab(void)
     fid = H5Fcreate(FILE57, H5F_ACC_TRUNC, H5P_DEFAULT, H5P_DEFAULT);
     assert(fid >= 0);
 
-    write_dset(fid, 2, dims, "stripmine", H5T_NATIVE_DOUBLE, H5I_INVALID_HID, buf);
+    write_dset(fid, 2, dims, "stripmine", H5T_NATIVE_DOUBLE, H5T_NATIVE_DOUBLE, buf);
 
     ret = H5Fclose(fid);
     assert(ret >= 0);

--- a/tools/test/h5dump/h5dumpgentest.c
+++ b/tools/test/h5dump/h5dumpgentest.c
@@ -119,21 +119,19 @@
 #define FILE96 "tcomplex_be.h5"
 #endif
 
-#define FILE_FLOAT16  "tbfloat16.h5"
-#define FILE_FLOAT16_BE  "tbfloat16_be.h5"
-
-#define FILE_REFER_COMPAT "trefer_compat.h5"
-#define FILE_REFER_GRP "trefer_grp.h5"
-#define FILE_REFER_OBJ_DEL "trefer_obj_del.h5"
-#define FILE_REFER_OBJ "trefer_obj.h5"
-#define FILE_REFER_PARAM "trefer_param.h5"
-#define FILE_REFER_REG "trefer_reg.h5"
-#define FILE_REFER_REG_1D "trefer_reg_1d.h5"
-
-#define FILE_REFER_ATTR   "trefer_attr.h5"
-#define FILE_ATTR4_BE   "tattr4_be.h5"
-#define FILE_NO_SUBSET   "tno-subset.h5"
-#define FILE_TVMS  "tvms.h5"
+#define FILE97  "tbfloat16.h5"
+#define FILE98  "tbfloat16_be.h5"
+#define FILE99  "trefer_attr.h5"
+#define FILE100 "tattr4_be.h5"
+#define FILE101 "tno-subset.h5"
+#define FILE102 "trefer_compat.h5"
+#define FILE103 "trefer_grp.h5"
+#define FILE104 "trefer_obj_del.h5"
+#define FILE105 "trefer_obj.h5"
+#define FILE106 "trefer_param.h5"
+#define FILE107 "trefer_reg.h5"
+#define FILE108 "trefer_reg_1d.h5"
+#define FILE109 "tvms.h5"
 
 #define ONION_TEST_FIXNAME_SIZE 1024
 #define ONION_TEST_PAGE_SIZE    (uint32_t)32
@@ -12915,7 +12913,7 @@ gent_bfloat16(void)
 
     aset16 = calloc(F97_XDIM * F97_YDIM, sizeof(float));
 
-    fid = H5Fcreate(FILE_FLOAT16, H5F_ACC_TRUNC, H5P_DEFAULT, H5P_DEFAULT);
+    fid = H5Fcreate(FILE97, H5F_ACC_TRUNC, H5P_DEFAULT, H5P_DEFAULT);
 
     /* Dataset of 16-bit little-endian bfloat16 */
     dims[0] = F97_XDIM;
@@ -12991,7 +12989,7 @@ gent_bfloat16_be(void)
 
     aset16 = calloc(F98_XDIM * F98_YDIM, sizeof(float));
 
-    fid = H5Fcreate(FILE_FLOAT16_BE, H5F_ACC_TRUNC, H5P_DEFAULT, H5P_DEFAULT);
+    fid = H5Fcreate(FILE98, H5F_ACC_TRUNC, H5P_DEFAULT, H5P_DEFAULT);
 
     /* Dataset of 16-bit big-endian bfloat16 */
     dims[0] = F98_XDIM;
@@ -13059,7 +13057,7 @@ gent_trefer_attr(void)
     unsigned int  attr2_data[4] = {1, 4, 7, 10};
     unsigned int  attr3_data[4] = {2, 5, 8, 11};
 
-    file_id = H5Fcreate(FILE_REFER_ATTR, H5F_ACC_TRUNC, H5P_DEFAULT, H5P_DEFAULT);
+    file_id = H5Fcreate(FILE99, H5F_ACC_TRUNC, H5P_DEFAULT, H5P_DEFAULT);
 
     group_id = H5Gcreate2(file_id, "Group1", H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT);
 
@@ -13133,7 +13131,7 @@ gent_tattr4_be(void)
     float   data_value        = 0.0f;
     char    attr_name[10]     = {0};
 
-    file_id = H5Fcreate(FILE_ATTR4_BE, H5F_ACC_TRUNC, H5P_DEFAULT, H5P_DEFAULT);
+    file_id = H5Fcreate(FILE100, H5F_ACC_TRUNC, H5P_DEFAULT, H5P_DEFAULT);
 
     dataspace_id = H5Screate_simple(1, dims, NULL);
 
@@ -13175,7 +13173,7 @@ gent_tno_subset(void)
     hsize_t dims[2]      = {1, 1};
     int     data[1][1]   = {{0}};
 
-    file_id      = H5Fcreate(FILE_NO_SUBSET, H5F_ACC_TRUNC, H5P_DEFAULT, H5P_DEFAULT);
+    file_id      = H5Fcreate(FILE101, H5F_ACC_TRUNC, H5P_DEFAULT, H5P_DEFAULT);
     dataspace_id = H5Screate_simple(2, dims, NULL);
     dataset_id =
         H5Dcreate2(file_id, F101_DSET, H5T_STD_I32LE, dataspace_id, H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT);
@@ -13213,7 +13211,7 @@ gent_trefer_compat(void)
     memset(data1, 0, sizeof(data1));
     memset(data2, 0, sizeof(data2));
 
-    file_id = H5Fcreate(FILE_REFER_COMPAT, H5F_ACC_TRUNC, H5P_DEFAULT, H5P_DEFAULT);
+    file_id = H5Fcreate(FILE102, H5F_ACC_TRUNC, H5P_DEFAULT, H5P_DEFAULT);
 
     group_id = H5Gcreate2(file_id, "Group1", H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT);
 
@@ -13285,7 +13283,7 @@ gent_trefer_grp(void)
     hid_t     space_id  = H5I_INVALID_HID;
     H5R_ref_t ref;
 
-    file_id = H5Fcreate(FILE_REFER_GRP, H5F_ACC_TRUNC, H5P_DEFAULT, H5P_DEFAULT);
+    file_id = H5Fcreate(FILE103, H5F_ACC_TRUNC, H5P_DEFAULT, H5P_DEFAULT);
 
     group_id  = H5Gcreate2(file_id, "group", H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT);
     group3_id = H5Gcreate2(group_id, "group3", H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT);
@@ -13313,7 +13311,7 @@ gent_trefer_obj_del(void)
     hid_t     space_id = H5I_INVALID_HID;
     H5R_ref_t ref;
 
-    file_id = H5Fcreate(FILE_REFER_OBJ_DEL, H5F_ACC_TRUNC, H5P_DEFAULT, H5P_DEFAULT);
+    file_id = H5Fcreate(FILE104, H5F_ACC_TRUNC, H5P_DEFAULT, H5P_DEFAULT);
 
     space_id = H5Screate(H5S_SCALAR);
 
@@ -13359,7 +13357,7 @@ gent_trefer_obj(void)
     H5R_ref_t       ref_data5[1];
     hdset_reg_ref_t ref_data6[1];
 
-    file_id = H5Fcreate(FILE_REFER_OBJ, H5F_ACC_TRUNC, H5P_DEFAULT, H5P_DEFAULT);
+    file_id = H5Fcreate(FILE105, H5F_ACC_TRUNC, H5P_DEFAULT, H5P_DEFAULT);
 
     group_id = H5Gcreate2(file_id, "Group1", H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT);
 
@@ -13429,7 +13427,7 @@ gent_trefer_param(void)
     uint8_t   data2[4] = {0, 0, 0, 0};
     H5R_ref_t ref_data[4];
 
-    file_id = H5Fcreate(FILE_REFER_PARAM, H5F_ACC_TRUNC, H5P_DEFAULT, H5P_DEFAULT);
+    file_id = H5Fcreate(FILE106, H5F_ACC_TRUNC, H5P_DEFAULT, H5P_DEFAULT);
 
     group_id = H5Gcreate2(file_id, "Group1", H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT);
 
@@ -13493,7 +13491,7 @@ gent_trefer_reg(void)
         for (j = 0; j < 10; j++, n += 3)
             data2[i][j] = (uint8_t)(n % 256);
 
-    file_id = H5Fcreate(FILE_REFER_REG, H5F_ACC_TRUNC, H5P_DEFAULT, H5P_DEFAULT);
+    file_id = H5Fcreate(FILE107, H5F_ACC_TRUNC, H5P_DEFAULT, H5P_DEFAULT);
 
     space2_id = H5Screate_simple(2, dims2, NULL);
     dset2_id =
@@ -13553,7 +13551,7 @@ gent_trefer_reg_1d(void)
     hsize_t       block[1]  = {2};
     hsize_t       coord[10] = {16, 22, 38, 41, 52, 63, 70, 89, 97, 3};
 
-    file_id = H5Fcreate(FILE_REFER_REG_1D, H5F_ACC_TRUNC, H5P_DEFAULT, H5P_DEFAULT);
+    file_id = H5Fcreate(FILE108, H5F_ACC_TRUNC, H5P_DEFAULT, H5P_DEFAULT);
 
     for (int i = 0; i < 100; i++) {
         data[i] = (unsigned char)(i * 3 % 256);
@@ -13806,7 +13804,7 @@ gent_tvms(void)
         }
     }
 
-    if ((file_id = H5Fcreate(FILE_TVMS, H5F_ACC_TRUNC, H5P_DEFAULT, H5P_DEFAULT)) < 0)
+    if ((file_id = H5Fcreate(FILE109, H5F_ACC_TRUNC, H5P_DEFAULT, H5P_DEFAULT)) < 0)
         return -1;
 
     if ((dataspace_id = H5Screate_simple(2, dims, NULL)) < 0)

--- a/tools/test/h5dump/h5dumpgentest.c
+++ b/tools/test/h5dump/h5dumpgentest.c
@@ -133,7 +133,6 @@
 #define FILE_REFER_ATTR   "trefer_attr.h5"
 #define FILE_ATTR4_BE   "tattr4_be.h5"
 #define FILE_NO_SUBSET   "tno-subset.h5"
-#define F99_DSET "AHFINDERDIRECT::ah_centroid_t[0] it=0 tl=0"
 #define FILE_TVMS  "tvms.h5"
 
 #define ONION_TEST_FIXNAME_SIZE 1024

--- a/tools/test/h5dump/h5dumpgentest.c
+++ b/tools/test/h5dump/h5dumpgentest.c
@@ -118,18 +118,23 @@
 #define FILE95 "tcomplex.h5"
 #define FILE96 "tcomplex_be.h5"
 #endif
-#define FILE97  "tbfloat16.h5"
-#define FILE98  "tbfloat16_be.h5"
-#define FILE99  "trefer_attr.h5"
-#define FILE100 "tattr4_be.h5"
-#define FILE101 "tno-subset.h5"
-#define FILE102 "trefer_compat.h5"
-#define FILE103 "trefer_grp.h5"
-#define FILE104 "trefer_obj_del.h5"
-#define FILE105 "trefer_obj.h5"
-#define FILE106 "trefer_param.h5"
-#define FILE107 "trefer_reg.h5"
-#define FILE108 "trefer_reg_1d.h5"
+
+#define FILE_FLOAT16  "tbfloat16.h5"
+#define FILE_FLOAT16_BE  "tbfloat16_be.h5"
+
+#define FILE_REFER_COMPAT "trefer_compat.h5"
+#define FILE_REFER_GRP "trefer_grp.h5"
+#define FILE_REFER_OBJ_DEL "trefer_obj_del.h5"
+#define FILE_REFER_OBJ "trefer_obj.h5"
+#define FILE_REFER_PARAM "trefer_param.h5"
+#define FILE_REFER_REG "trefer_reg.h5"
+#define FILE_REFER_REG_1D "trefer_reg_1d.h5"
+
+#define FILE_REFER_ATTR   "trefer_attr.h5"
+#define FILE_ATTR4_BE   "tattr4_be.h5"
+#define FILE_NO_SUBSET   "tno-subset.h5"
+#define F99_DSET "AHFINDERDIRECT::ah_centroid_t[0] it=0 tl=0"
+#define FILE_TVMS  "tvms.h5"
 
 #define ONION_TEST_FIXNAME_SIZE 1024
 #define ONION_TEST_PAGE_SIZE    (uint32_t)32
@@ -143,7 +148,7 @@
 /* utility functions */
 static int make_dset(hid_t loc_id, const char *name, hid_t sid, hid_t tid, hid_t dcpl, void *buf);
 static int write_attr(hid_t loc_id, int rank, hsize_t *dims, const char *attr_name, hid_t tid, void *buf);
-static int write_dset(hid_t loc_id, int rank, hsize_t *dims, const char *dset_name, hid_t tid, void *buf);
+static int write_dset(hid_t loc_id, int rank, hsize_t *dims, const char *dset_name, hid_t tid_dset, hid_t tid_memory, void *buf);
 
 /* a filter operation callback function */
 static size_t myfilter(unsigned int H5_ATTR_UNUSED flags, size_t H5_ATTR_UNUSED cd_nelmts,
@@ -4614,7 +4619,7 @@ write_dset_in(hid_t loc_id, const char *dset_name, /* for saving reference to da
      */
     tid    = H5Tcopy(H5T_C_S1);
     status = H5Tset_size(tid, 2);
-    write_dset(loc_id, 1, dims, "string", tid, buf1);
+    write_dset(loc_id, 1, dims, "string", tid, H5I_INVALID_HID, buf1);
     status = H5Tclose(tid);
 
     /*-------------------------------------------------------------------------
@@ -4622,7 +4627,7 @@ write_dset_in(hid_t loc_id, const char *dset_name, /* for saving reference to da
      *-------------------------------------------------------------------------
      */
     tid = H5Tcopy(H5T_STD_B8LE);
-    write_dset(loc_id, 1, dims, "bitfield", tid, buf2);
+    write_dset(loc_id, 1, dims, "bitfield", tid, H5I_INVALID_HID, buf2);
     status = H5Tclose(tid);
 
     /*-------------------------------------------------------------------------
@@ -4631,7 +4636,7 @@ write_dset_in(hid_t loc_id, const char *dset_name, /* for saving reference to da
      */
     tid    = H5Tcreate(H5T_OPAQUE, 1);
     status = H5Tset_tag(tid, "1-byte opaque type"); /* must set this */
-    write_dset(loc_id, 1, dims, "opaque", tid, buf2);
+    write_dset(loc_id, 1, dims, "opaque", tid, H5I_INVALID_HID, buf2);
     status = H5Tclose(tid);
 
     /*-------------------------------------------------------------------------
@@ -4641,7 +4646,7 @@ write_dset_in(hid_t loc_id, const char *dset_name, /* for saving reference to da
     tid = H5Tcreate(H5T_COMPOUND, sizeof(s_t));
     H5Tinsert(tid, "a", HOFFSET(s_t, a), H5T_NATIVE_CHAR);
     H5Tinsert(tid, "b", HOFFSET(s_t, b), H5T_NATIVE_DOUBLE);
-    write_dset(loc_id, 1, dims, "compound", tid, buf3);
+    write_dset(loc_id, 1, dims, "compound", tid, H5I_INVALID_HID, buf3);
     status = H5Tclose(tid);
 
     /*-------------------------------------------------------------------------
@@ -4652,7 +4657,7 @@ write_dset_in(hid_t loc_id, const char *dset_name, /* for saving reference to da
     if (dset_name) {
         status = H5Rcreate(&buf4[0], fid, dset_name, H5R_OBJECT, (hid_t)-1);
         status = H5Rcreate(&buf4[1], fid, dset_name, H5R_OBJECT, (hid_t)-1);
-        write_dset(loc_id, 1, dims, "reference", H5T_STD_REF_OBJ, buf4);
+        write_dset(loc_id, 1, dims, "reference", H5T_STD_REF_OBJ, H5I_INVALID_HID, buf4);
     }
 
     /*-------------------------------------------------------------------------
@@ -4662,7 +4667,7 @@ write_dset_in(hid_t loc_id, const char *dset_name, /* for saving reference to da
     tid = H5Tcreate(H5T_ENUM, sizeof(e_t));
     H5Tenum_insert(tid, "RED", (val = 0, &val));
     H5Tenum_insert(tid, "GREEN", (val = 1, &val));
-    write_dset(loc_id, 1, dims, "enum", tid, 0);
+    write_dset(loc_id, 1, dims, "enum", tid, H5I_INVALID_HID, 0);
     status = H5Tclose(tid);
 
     /*-------------------------------------------------------------------------
@@ -4696,22 +4701,22 @@ write_dset_in(hid_t loc_id, const char *dset_name, /* for saving reference to da
      *-------------------------------------------------------------------------
      */
     tid = H5Tarray_create2(H5T_NATIVE_INT, 1, dimarray);
-    write_dset(loc_id, 1, dims, "array", tid, buf6);
+    write_dset(loc_id, 1, dims, "array", tid, H5I_INVALID_HID, buf6);
     status = H5Tclose(tid);
 
     /*-------------------------------------------------------------------------
      * H5T_INTEGER and H5T_FLOAT
      *-------------------------------------------------------------------------
      */
-    write_dset(loc_id, 1, dims, "integer", H5T_NATIVE_INT, buf7);
-    write_dset(loc_id, 1, dims, "float", H5T_NATIVE_FLOAT, buf8);
+    write_dset(loc_id, 1, dims, "integer", H5T_NATIVE_INT, H5I_INVALID_HID, buf7);
+    write_dset(loc_id, 1, dims, "float", H5T_NATIVE_FLOAT, H5I_INVALID_HID, buf8);
 
     /*-------------------------------------------------------------------------
      * H5T_COMPLEX
      *-------------------------------------------------------------------------
      */
     tid = H5Tcomplex_create(H5T_NATIVE_FLOAT);
-    write_dset(loc_id, 1, dims, "complex", tid, buf9);
+    write_dset(loc_id, 1, dims, "complex", tid, H5I_INVALID_HID, buf9);
     status = H5Tclose(tid);
 
     /*-------------------------------------------------------------------------
@@ -4725,7 +4730,7 @@ write_dset_in(hid_t loc_id, const char *dset_name, /* for saving reference to da
      */
     tid    = H5Tcopy(H5T_C_S1);
     status = H5Tset_size(tid, 2);
-    write_dset(loc_id, 2, dims2, "string2D", tid, buf12);
+    write_dset(loc_id, 2, dims2, "string2D", tid, H5I_INVALID_HID, buf12);
     status = H5Tclose(tid);
 
     /*-------------------------------------------------------------------------
@@ -4733,7 +4738,7 @@ write_dset_in(hid_t loc_id, const char *dset_name, /* for saving reference to da
      *-------------------------------------------------------------------------
      */
     tid = H5Tcopy(H5T_STD_B8LE);
-    write_dset(loc_id, 2, dims2, "bitfield2D", tid, buf22);
+    write_dset(loc_id, 2, dims2, "bitfield2D", tid, H5I_INVALID_HID, buf22);
     status = H5Tclose(tid);
 
     /*-------------------------------------------------------------------------
@@ -4742,7 +4747,7 @@ write_dset_in(hid_t loc_id, const char *dset_name, /* for saving reference to da
      */
     tid    = H5Tcreate(H5T_OPAQUE, 1);
     status = H5Tset_tag(tid, "1-byte opaque type"); /* must set this */
-    write_dset(loc_id, 2, dims2, "opaque2D", tid, buf22);
+    write_dset(loc_id, 2, dims2, "opaque2D", tid, H5I_INVALID_HID, buf22);
     status = H5Tclose(tid);
 
     /*-------------------------------------------------------------------------
@@ -4752,7 +4757,7 @@ write_dset_in(hid_t loc_id, const char *dset_name, /* for saving reference to da
     tid = H5Tcreate(H5T_COMPOUND, sizeof(s_t));
     H5Tinsert(tid, "a", HOFFSET(s_t, a), H5T_NATIVE_CHAR);
     H5Tinsert(tid, "b", HOFFSET(s_t, b), H5T_NATIVE_DOUBLE);
-    write_dset(loc_id, 2, dims2, "compound2D", tid, buf32);
+    write_dset(loc_id, 2, dims2, "compound2D", tid, H5I_INVALID_HID, buf32);
     status = H5Tclose(tid);
 
     /*-------------------------------------------------------------------------
@@ -4766,7 +4771,7 @@ write_dset_in(hid_t loc_id, const char *dset_name, /* for saving reference to da
                 status = H5Rcreate(&buf42[i][j], fid, dset_name, H5R_OBJECT, (hid_t)-1);
             }
         }
-        write_dset(loc_id, 2, dims2, "reference2D", H5T_STD_REF_OBJ, buf42);
+        write_dset(loc_id, 2, dims2, "reference2D", H5T_STD_REF_OBJ, H5I_INVALID_HID, buf42);
     }
 
     /*-------------------------------------------------------------------------
@@ -4776,7 +4781,7 @@ write_dset_in(hid_t loc_id, const char *dset_name, /* for saving reference to da
     tid = H5Tcreate(H5T_ENUM, sizeof(e_t));
     H5Tenum_insert(tid, "RED", (val = 0, &val));
     H5Tenum_insert(tid, "GREEN", (val = 1, &val));
-    write_dset(loc_id, 2, dims2, "enum2D", tid, 0);
+    write_dset(loc_id, 2, dims2, "enum2D", tid, H5I_INVALID_HID, 0);
     status = H5Tclose(tid);
 
     /*-------------------------------------------------------------------------
@@ -4812,7 +4817,7 @@ write_dset_in(hid_t loc_id, const char *dset_name, /* for saving reference to da
      *-------------------------------------------------------------------------
      */
     tid = H5Tarray_create2(H5T_NATIVE_INT, 1, dimarray);
-    write_dset(loc_id, 2, dims2, "array2D", tid, buf62);
+    write_dset(loc_id, 2, dims2, "array2D", tid, H5I_INVALID_HID, buf62);
     status = H5Tclose(tid);
 
     /*-------------------------------------------------------------------------
@@ -4833,14 +4838,14 @@ write_dset_in(hid_t loc_id, const char *dset_name, /* for saving reference to da
      *-------------------------------------------------------------------------
      */
 
-    write_dset(loc_id, 2, dims2, "float2D", H5T_NATIVE_FLOAT, buf82);
+    write_dset(loc_id, 2, dims2, "float2D", H5T_NATIVE_FLOAT, H5I_INVALID_HID, buf82);
 
     /*-------------------------------------------------------------------------
      * H5T_COMPLEX
      *-------------------------------------------------------------------------
      */
     tid = H5Tcomplex_create(H5T_NATIVE_FLOAT);
-    write_dset(loc_id, 2, dims2, "complex2D", tid, buf92);
+    write_dset(loc_id, 2, dims2, "complex2D", tid, H5I_INVALID_HID, buf92);
     status = H5Tclose(tid);
 
     /*-------------------------------------------------------------------------
@@ -4854,7 +4859,7 @@ write_dset_in(hid_t loc_id, const char *dset_name, /* for saving reference to da
      */
     tid    = H5Tcopy(H5T_C_S1);
     status = H5Tset_size(tid, 2);
-    write_dset(loc_id, 3, dims3, "string3D", tid, buf13);
+    write_dset(loc_id, 3, dims3, "string3D", tid, H5I_INVALID_HID, buf13);
     status = H5Tclose(tid);
 
     /*-------------------------------------------------------------------------
@@ -4868,7 +4873,7 @@ write_dset_in(hid_t loc_id, const char *dset_name, /* for saving reference to da
             for (k = 0; k < 2; k++)
                 buf23[i][j][k] = (char)n++;
     tid = H5Tcopy(H5T_STD_B8LE);
-    write_dset(loc_id, 3, dims3, "bitfield3D", tid, buf23);
+    write_dset(loc_id, 3, dims3, "bitfield3D", tid, H5I_INVALID_HID, buf23);
     status = H5Tclose(tid);
 
     /*-------------------------------------------------------------------------
@@ -4877,7 +4882,7 @@ write_dset_in(hid_t loc_id, const char *dset_name, /* for saving reference to da
      */
     tid    = H5Tcreate(H5T_OPAQUE, 1);
     status = H5Tset_tag(tid, "1-byte opaque type"); /* must set this */
-    write_dset(loc_id, 3, dims3, "opaque3D", tid, buf23);
+    write_dset(loc_id, 3, dims3, "opaque3D", tid, H5I_INVALID_HID, buf23);
     status = H5Tclose(tid);
 
     /*-------------------------------------------------------------------------
@@ -4895,7 +4900,7 @@ write_dset_in(hid_t loc_id, const char *dset_name, /* for saving reference to da
     tid = H5Tcreate(H5T_COMPOUND, sizeof(s_t));
     H5Tinsert(tid, "a", HOFFSET(s_t, a), H5T_NATIVE_CHAR);
     H5Tinsert(tid, "b", HOFFSET(s_t, b), H5T_NATIVE_DOUBLE);
-    write_dset(loc_id, 3, dims3, "compound3D", tid, buf33);
+    write_dset(loc_id, 3, dims3, "compound3D", tid, H5I_INVALID_HID, buf33);
     status = H5Tclose(tid);
 
     /*-------------------------------------------------------------------------
@@ -4910,7 +4915,7 @@ write_dset_in(hid_t loc_id, const char *dset_name, /* for saving reference to da
                     status = H5Rcreate(&buf43[i][j][k], fid, dset_name, H5R_OBJECT, (hid_t)-1);
             }
         }
-        write_dset(loc_id, 3, dims3, "reference3D", H5T_STD_REF_OBJ, buf43);
+        write_dset(loc_id, 3, dims3, "reference3D", H5T_STD_REF_OBJ, H5I_INVALID_HID, buf43);
     }
 
     /*-------------------------------------------------------------------------
@@ -4920,7 +4925,7 @@ write_dset_in(hid_t loc_id, const char *dset_name, /* for saving reference to da
     tid = H5Tcreate(H5T_ENUM, sizeof(e_t));
     H5Tenum_insert(tid, "RED", (val = 0, &val));
     H5Tenum_insert(tid, "GREEN", (val = 1, &val));
-    write_dset(loc_id, 3, dims3, "enum3D", tid, 0);
+    write_dset(loc_id, 3, dims3, "enum3D", tid, H5I_INVALID_HID, 0);
     status = H5Tclose(tid);
 
     /*-------------------------------------------------------------------------
@@ -4964,7 +4969,7 @@ write_dset_in(hid_t loc_id, const char *dset_name, /* for saving reference to da
     }
 
     tid = H5Tarray_create2(H5T_NATIVE_INT, 1, dimarray);
-    write_dset(loc_id, 3, dims3, "array3D", tid, buf63);
+    write_dset(loc_id, 3, dims3, "array3D", tid, H5I_INVALID_HID, buf63);
     status = H5Tclose(tid);
 
     /*-------------------------------------------------------------------------
@@ -4981,8 +4986,8 @@ write_dset_in(hid_t loc_id, const char *dset_name, /* for saving reference to da
             }
         }
     }
-    write_dset(loc_id, 3, dims3, "integer3D", H5T_NATIVE_INT, buf73);
-    write_dset(loc_id, 3, dims3, "float3D", H5T_NATIVE_FLOAT, buf83);
+    write_dset(loc_id, 3, dims3, "integer3D", H5T_NATIVE_INT, H5I_INVALID_HID, buf73);
+    write_dset(loc_id, 3, dims3, "float3D", H5T_NATIVE_FLOAT, H5I_INVALID_HID, buf83);
 
     /*-------------------------------------------------------------------------
      * H5T_COMPLEX
@@ -4994,7 +4999,7 @@ write_dset_in(hid_t loc_id, const char *dset_name, /* for saving reference to da
             buf93[i][j] = f++;
 
     tid = H5Tcomplex_create(H5T_NATIVE_FLOAT);
-    write_dset(loc_id, 3, dims3, "complex3D", tid, buf93);
+    write_dset(loc_id, 3, dims3, "complex3D", tid, H5I_INVALID_HID, buf93);
     status = H5Tclose(tid);
 }
 
@@ -5108,21 +5113,24 @@ write_attr(hid_t loc_id, int rank, hsize_t *dims, const char *attr_name, hid_t t
  */
 
 static int
-write_dset(hid_t loc_id, int rank, hsize_t *dims, const char *dset_name, hid_t tid, void *buf)
+write_dset(hid_t loc_id, int rank, hsize_t *dims, const char *dset_name, hid_t tid_dset, hid_t tid_memory, void *buf)
 {
     hid_t  did;
     hid_t  sid;
     herr_t status;
 
+    if (tid_memory == H5I_INVALID_HID)
+        tid_memory = tid_dset;
+
     /* Create a buf space  */
     sid = H5Screate_simple(rank, dims, NULL);
 
     /* Create a dataset */
-    did = H5Dcreate2(loc_id, dset_name, tid, sid, H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT);
+    did = H5Dcreate2(loc_id, dset_name, tid_dset, sid, H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT);
 
     /* Write the buf */
     if (buf)
-        status = H5Dwrite(did, tid, H5S_ALL, H5S_ALL, H5P_DEFAULT, buf);
+        status = H5Dwrite(did, tid_memory, H5S_ALL, H5S_ALL, H5P_DEFAULT, buf);
 
     /* Close */
     status = H5Dclose(did);
@@ -5974,7 +5982,7 @@ gent_fcontents(void)
     fid = H5Fcreate(FILE46, H5F_ACC_TRUNC, H5P_DEFAULT, H5P_DEFAULT);
     assert(fid >= 0);
 
-    write_dset(fid, 1, dims, "dset", H5T_STD_I32BE, buf);
+    write_dset(fid, 1, dims, "dset", H5T_STD_I32BE, H5T_NATIVE_INT, buf);
 
     /*-------------------------------------------------------------------------
      * links
@@ -6024,17 +6032,17 @@ gent_fcontents(void)
      * datatypes
      *-------------------------------------------------------------------------
      */
-    tid = H5Tcopy(H5T_NATIVE_INT);
+    tid = H5Tcopy(H5T_STD_I32BE);
     ret = H5Tcommit2(fid, "mytype", tid, H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT);
     assert(ret >= 0);
     ret = H5Tclose(tid);
     assert(ret >= 0);
 
     /* no name datatype */
-    tid = H5Tcopy(H5T_NATIVE_INT);
+    tid = H5Tcopy(H5T_STD_I32BE);
     ret = H5Tcommit2(fid, "mytype2", tid, H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT);
     assert(ret >= 0);
-    write_dset(fid, 1, dims, "dsetmytype2", tid, buf);
+    write_dset(fid, 1, dims, "dsetmytype2", tid, H5T_NATIVE_INT, buf);
     ret = H5Ldelete(fid, "mytype2", H5P_DEFAULT);
     assert(ret >= 0);
     ret = H5Tclose(tid);
@@ -6145,7 +6153,7 @@ gent_fvalues(void)
      * dataset with no fill value
      *-------------------------------------------------------------------------
      */
-    write_dset(fid, 1, dims, "no_fill", H5T_NATIVE_INT, buf);
+    write_dset(fid, 1, dims, "no_fill", H5T_NATIVE_INT, H5I_INVALID_HID, buf);
 
     /*-------------------------------------------------------------------------
      * dataset with a H5T_COMPOUND fill value
@@ -6199,7 +6207,7 @@ gent_fvalues(void)
      *-------------------------------------------------------------------------
      */
     tid = H5Tarray_create2(H5T_NATIVE_INT, 1, dimarray);
-    write_dset(fid, 1, dims, "fill_array", tid, buf4);
+    write_dset(fid, 1, dims, "fill_array", tid, H5I_INVALID_HID, buf4);
     ret = H5Tclose(tid);
 
     /*-------------------------------------------------------------------------
@@ -6262,7 +6270,7 @@ gent_string(void)
     tid = H5Tcopy(H5T_C_S1);
     ret = H5Tset_size(tid, sizeof(buf1));
     assert(ret >= 0);
-    write_dset(fid, 1, dims1, "str1", tid, buf1);
+    write_dset(fid, 1, dims1, "str1", tid, H5I_INVALID_HID, buf1);
     assert(ret >= 0);
     ret = H5Tclose(tid);
     assert(ret >= 0);
@@ -6368,10 +6376,10 @@ gent_aindices(void)
      * root datasets
      *-------------------------------------------------------------------------
      */
-    write_dset(fid, 1, dims1, "1d", H5T_NATIVE_INT, buf1);
-    write_dset(fid, 2, dims2, "2d", H5T_NATIVE_INT, buf2);
-    write_dset(fid, 3, dims3, "3d", H5T_NATIVE_INT, buf3);
-    write_dset(fid, 4, dims4, "4d", H5T_NATIVE_INT, buf4);
+    write_dset(fid, 1, dims1, "1d", H5T_NATIVE_INT, H5I_INVALID_HID, buf1);
+    write_dset(fid, 2, dims2, "2d", H5T_NATIVE_INT, H5I_INVALID_HID, buf2);
+    write_dset(fid, 3, dims3, "3d", H5T_NATIVE_INT, H5I_INVALID_HID, buf3);
+    write_dset(fid, 4, dims4, "4d", H5T_NATIVE_INT, H5I_INVALID_HID, buf4);
 
     /*-------------------------------------------------------------------------
      * test with group indentation
@@ -6383,10 +6391,10 @@ gent_aindices(void)
     gid[3] = H5Gcreate2(fid, "g1/g2/g3/g4", H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT);
     gid[4] = H5Gcreate2(fid, "g1/g2/g3/g4/g5", H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT);
     gid[5] = H5Gcreate2(fid, "g1/g2/g3/g4/g5/g6", H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT);
-    write_dset(gid[5], 1, dims1, "1d", H5T_NATIVE_INT, buf1);
-    write_dset(gid[5], 2, dims2, "2d", H5T_NATIVE_INT, buf2);
-    write_dset(gid[5], 3, dims3, "3d", H5T_NATIVE_INT, buf3);
-    write_dset(gid[5], 4, dims4, "4d", H5T_NATIVE_INT, buf4);
+    write_dset(gid[5], 1, dims1, "1d", H5T_NATIVE_INT, H5I_INVALID_HID, buf1);
+    write_dset(gid[5], 2, dims2, "2d", H5T_NATIVE_INT, H5I_INVALID_HID, buf2);
+    write_dset(gid[5], 3, dims3, "3d", H5T_NATIVE_INT, H5I_INVALID_HID, buf3);
+    write_dset(gid[5], 4, dims4, "4d", H5T_NATIVE_INT, H5I_INVALID_HID, buf4);
     for (i = 0; i < 6; i++)
         H5Gclose(gid[i]);
 
@@ -6778,7 +6786,7 @@ gent_hyperslab(void)
     fid = H5Fcreate(FILE57, H5F_ACC_TRUNC, H5P_DEFAULT, H5P_DEFAULT);
     assert(fid >= 0);
 
-    write_dset(fid, 2, dims, "stripmine", H5T_NATIVE_DOUBLE, buf);
+    write_dset(fid, 2, dims, "stripmine", H5T_NATIVE_DOUBLE, H5I_INVALID_HID, buf);
 
     ret = H5Fclose(fid);
     assert(ret >= 0);
@@ -9809,7 +9817,7 @@ gent_compound_ints(void)
     assert(Cmpd2Structid >= 0);
 
     /* Insert the arrays and variables into the structure             */
-    status = H5Tinsert(Cmpd2Structid, F76_DATASETU64, HOFFSET(Cmpd2Struct, dsetu64), H5T_STD_I64LE);
+    status = H5Tinsert(Cmpd2Structid, F76_DATASETU64, HOFFSET(Cmpd2Struct, dsetu64), H5T_STD_U64LE);
     assert(status >= 0);
 
     status = H5Tinsert(Cmpd2Structid, F76_DATASETU32, HOFFSET(Cmpd2Struct, dsetu32), H5T_NATIVE_UINT);
@@ -12909,7 +12917,7 @@ gent_bfloat16(void)
 
     aset16 = calloc(F97_XDIM * F97_YDIM, sizeof(float));
 
-    fid = H5Fcreate(FILE97, H5F_ACC_TRUNC, H5P_DEFAULT, H5P_DEFAULT);
+    fid = H5Fcreate(FILE_FLOAT16, H5F_ACC_TRUNC, H5P_DEFAULT, H5P_DEFAULT);
 
     /* Dataset of 16-bit little-endian bfloat16 */
     dims[0] = F97_XDIM;
@@ -12985,7 +12993,7 @@ gent_bfloat16_be(void)
 
     aset16 = calloc(F98_XDIM * F98_YDIM, sizeof(float));
 
-    fid = H5Fcreate(FILE98, H5F_ACC_TRUNC, H5P_DEFAULT, H5P_DEFAULT);
+    fid = H5Fcreate(FILE_FLOAT16_BE, H5F_ACC_TRUNC, H5P_DEFAULT, H5P_DEFAULT);
 
     /* Dataset of 16-bit big-endian bfloat16 */
     dims[0] = F98_XDIM;
@@ -13053,7 +13061,7 @@ gent_trefer_attr(void)
     unsigned int  attr2_data[4] = {1, 4, 7, 10};
     unsigned int  attr3_data[4] = {2, 5, 8, 11};
 
-    file_id = H5Fcreate(FILE99, H5F_ACC_TRUNC, H5P_DEFAULT, H5P_DEFAULT);
+    file_id = H5Fcreate(FILE_REFER_ATTR, H5F_ACC_TRUNC, H5P_DEFAULT, H5P_DEFAULT);
 
     group_id = H5Gcreate2(file_id, "Group1", H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT);
 
@@ -13127,7 +13135,7 @@ gent_tattr4_be(void)
     float   data_value        = 0.0f;
     char    attr_name[10]     = {0};
 
-    file_id = H5Fcreate(FILE100, H5F_ACC_TRUNC, H5P_DEFAULT, H5P_DEFAULT);
+    file_id = H5Fcreate(FILE_ATTR4_BE, H5F_ACC_TRUNC, H5P_DEFAULT, H5P_DEFAULT);
 
     dataspace_id = H5Screate_simple(1, dims, NULL);
 
@@ -13169,7 +13177,7 @@ gent_tno_subset(void)
     hsize_t dims[2]      = {1, 1};
     int     data[1][1]   = {{0}};
 
-    file_id      = H5Fcreate(FILE101, H5F_ACC_TRUNC, H5P_DEFAULT, H5P_DEFAULT);
+    file_id      = H5Fcreate(FILE_NO_SUBSET, H5F_ACC_TRUNC, H5P_DEFAULT, H5P_DEFAULT);
     dataspace_id = H5Screate_simple(2, dims, NULL);
     dataset_id =
         H5Dcreate2(file_id, F101_DSET, H5T_STD_I32LE, dataspace_id, H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT);
@@ -13207,7 +13215,7 @@ gent_trefer_compat(void)
     memset(data1, 0, sizeof(data1));
     memset(data2, 0, sizeof(data2));
 
-    file_id = H5Fcreate(FILE102, H5F_ACC_TRUNC, H5P_DEFAULT, H5P_DEFAULT);
+    file_id = H5Fcreate(FILE_REFER_COMPAT, H5F_ACC_TRUNC, H5P_DEFAULT, H5P_DEFAULT);
 
     group_id = H5Gcreate2(file_id, "Group1", H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT);
 
@@ -13279,7 +13287,7 @@ gent_trefer_grp(void)
     hid_t     space_id  = H5I_INVALID_HID;
     H5R_ref_t ref;
 
-    file_id = H5Fcreate(FILE103, H5F_ACC_TRUNC, H5P_DEFAULT, H5P_DEFAULT);
+    file_id = H5Fcreate(FILE_REFER_GRP, H5F_ACC_TRUNC, H5P_DEFAULT, H5P_DEFAULT);
 
     group_id  = H5Gcreate2(file_id, "group", H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT);
     group3_id = H5Gcreate2(group_id, "group3", H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT);
@@ -13307,7 +13315,7 @@ gent_trefer_obj_del(void)
     hid_t     space_id = H5I_INVALID_HID;
     H5R_ref_t ref;
 
-    file_id = H5Fcreate(FILE104, H5F_ACC_TRUNC, H5P_DEFAULT, H5P_DEFAULT);
+    file_id = H5Fcreate(FILE_REFER_OBJ_DEL, H5F_ACC_TRUNC, H5P_DEFAULT, H5P_DEFAULT);
 
     space_id = H5Screate(H5S_SCALAR);
 
@@ -13353,7 +13361,7 @@ gent_trefer_obj(void)
     H5R_ref_t       ref_data5[1];
     hdset_reg_ref_t ref_data6[1];
 
-    file_id = H5Fcreate(FILE105, H5F_ACC_TRUNC, H5P_DEFAULT, H5P_DEFAULT);
+    file_id = H5Fcreate(FILE_REFER_OBJ, H5F_ACC_TRUNC, H5P_DEFAULT, H5P_DEFAULT);
 
     group_id = H5Gcreate2(file_id, "Group1", H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT);
 
@@ -13423,7 +13431,7 @@ gent_trefer_param(void)
     uint8_t   data2[4] = {0, 0, 0, 0};
     H5R_ref_t ref_data[4];
 
-    file_id = H5Fcreate(FILE106, H5F_ACC_TRUNC, H5P_DEFAULT, H5P_DEFAULT);
+    file_id = H5Fcreate(FILE_REFER_PARAM, H5F_ACC_TRUNC, H5P_DEFAULT, H5P_DEFAULT);
 
     group_id = H5Gcreate2(file_id, "Group1", H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT);
 
@@ -13487,7 +13495,7 @@ gent_trefer_reg(void)
         for (j = 0; j < 10; j++, n += 3)
             data2[i][j] = (uint8_t)(n % 256);
 
-    file_id = H5Fcreate(FILE107, H5F_ACC_TRUNC, H5P_DEFAULT, H5P_DEFAULT);
+    file_id = H5Fcreate(FILE_REFER_REG, H5F_ACC_TRUNC, H5P_DEFAULT, H5P_DEFAULT);
 
     space2_id = H5Screate_simple(2, dims2, NULL);
     dset2_id =
@@ -13547,7 +13555,7 @@ gent_trefer_reg_1d(void)
     hsize_t       block[1]  = {2};
     hsize_t       coord[10] = {16, 22, 38, 41, 52, 63, 70, 89, 97, 3};
 
-    file_id = H5Fcreate(FILE108, H5F_ACC_TRUNC, H5P_DEFAULT, H5P_DEFAULT);
+    file_id = H5Fcreate(FILE_REFER_REG_1D, H5F_ACC_TRUNC, H5P_DEFAULT, H5P_DEFAULT);
 
     for (int i = 0; i < 100; i++) {
         data[i] = (unsigned char)(i * 3 % 256);
@@ -13779,6 +13787,49 @@ gent_test_reference_external(void)
     /* Close file */
     if (H5Fclose(fid2) < 0)
         return 1;
+
+    return 0;
+}
+
+int gent_tvms(void)
+{
+    hid_t   file_id = H5I_INVALID_HID;
+    hid_t   dataset_id = H5I_INVALID_HID;
+    hid_t   dataspace_id = H5I_INVALID_HID;
+    hsize_t dims[2] = {5, 6};
+    int  data[5][6];
+    int  i, j;
+
+    /* Initialize the data array */
+    for (i = 0; i < 5; i++) {
+        for (j = 0; j < 6; j++) {
+            data[i][j] = (i + j);
+        }
+    }
+
+    if ((file_id = H5Fcreate(FILE_TVMS, H5F_ACC_TRUNC, H5P_DEFAULT, H5P_DEFAULT)) < 0)
+        return -1;
+
+    if ((dataspace_id = H5Screate_simple(2, dims, NULL)) < 0)
+        return -1;
+
+    /* Create the dataset with VAX F64 datatype */
+    if ((dataset_id = H5Dcreate2(file_id, "/Array", H5T_VAX_F64, dataspace_id,
+                                H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT)) < 0)
+        return -1;
+
+    /* Write the data to the dataset */
+    if (H5Dwrite(dataset_id, H5T_NATIVE_INT, H5S_ALL, H5S_ALL, H5P_DEFAULT, data) < 0)
+        return -1;
+
+    if (H5Dclose(dataset_id) < 0)
+        return -1;
+
+    if (H5Sclose(dataspace_id) < 0)
+        return -1;
+
+    if (H5Fclose(file_id) < 0)
+        return -1;
 
     return 0;
 }

--- a/tools/test/h5dump/h5dumpgentest.c
+++ b/tools/test/h5dump/h5dumpgentest.c
@@ -148,7 +148,8 @@
 /* utility functions */
 static int make_dset(hid_t loc_id, const char *name, hid_t sid, hid_t tid, hid_t dcpl, void *buf);
 static int write_attr(hid_t loc_id, int rank, hsize_t *dims, const char *attr_name, hid_t tid, void *buf);
-static int write_dset(hid_t loc_id, int rank, hsize_t *dims, const char *dset_name, hid_t tid_dset, hid_t tid_memory, void *buf);
+static int write_dset(hid_t loc_id, int rank, hsize_t *dims, const char *dset_name, hid_t tid_dset,
+                      hid_t tid_memory, void *buf);
 
 /* a filter operation callback function */
 static size_t myfilter(unsigned int H5_ATTR_UNUSED flags, size_t H5_ATTR_UNUSED cd_nelmts,
@@ -5113,7 +5114,8 @@ write_attr(hid_t loc_id, int rank, hsize_t *dims, const char *attr_name, hid_t t
  */
 
 static int
-write_dset(hid_t loc_id, int rank, hsize_t *dims, const char *dset_name, hid_t tid_dset, hid_t tid_memory, void *buf)
+write_dset(hid_t loc_id, int rank, hsize_t *dims, const char *dset_name, hid_t tid_dset, hid_t tid_memory,
+           void *buf)
 {
     hid_t  did;
     hid_t  sid;
@@ -13791,14 +13793,15 @@ gent_test_reference_external(void)
     return 0;
 }
 
-int gent_tvms(void)
+int
+gent_tvms(void)
 {
-    hid_t   file_id = H5I_INVALID_HID;
-    hid_t   dataset_id = H5I_INVALID_HID;
+    hid_t   file_id      = H5I_INVALID_HID;
+    hid_t   dataset_id   = H5I_INVALID_HID;
     hid_t   dataspace_id = H5I_INVALID_HID;
-    hsize_t dims[2] = {5, 6};
-    int  data[5][6];
-    int  i, j;
+    hsize_t dims[2]      = {5, 6};
+    int     data[5][6];
+    int     i, j;
 
     /* Initialize the data array */
     for (i = 0; i < 5; i++) {
@@ -13814,8 +13817,8 @@ int gent_tvms(void)
         return -1;
 
     /* Create the dataset with VAX F64 datatype */
-    if ((dataset_id = H5Dcreate2(file_id, "/Array", H5T_VAX_F64, dataspace_id,
-                                H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT)) < 0)
+    if ((dataset_id = H5Dcreate2(file_id, "/Array", H5T_VAX_F64, dataspace_id, H5P_DEFAULT, H5P_DEFAULT,
+                                 H5P_DEFAULT)) < 0)
         return -1;
 
     /* Write the data to the dataset */

--- a/tools/test/h5dump/h5dumpgentest.h
+++ b/tools/test/h5dump/h5dumpgentest.h
@@ -140,4 +140,5 @@ void gent_trefer_reg(void);
 void gent_trefer_reg_1d(void);
 
 int gent_test_reference_external(void);
+int gent_tvms(void);
 #endif /* H5DUMP_GENTEST_H */

--- a/tools/test/h5gentest.c
+++ b/tools/test/h5gentest.c
@@ -278,7 +278,7 @@ gen_h5dump_files(void)
     gent_trefer_reg_1d();
 
     nerrors += gent_test_reference_external();
-
+    nerrors += (gent_tvms() < 0 ? 1 : 0);
     return nerrors;
 }
 


### PR DESCRIPTION
Depends on #5761 and #5752. Will be marked ready for review once those are merged
<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Add VOL tests for h5dump, update test generation logic, and modify test configurations.
> 
>   - **Tests**:
>     - Add VOL tests for `h5dump` in `CMakeTests.cmake` and `CMakeTestsXML.cmake`.
>     - Modify `ADD_H5_TEST` macro to support VOL-specific tests and filtering.
>     - Add `gent_tvms()` function in `h5dumpgentest.c` and `h5dumpgentest.h` for generating test files.
>   - **Configuration**:
>     - Update `.github/workflows/vol_rest.yml` to exclude `H5DUMP` from certain tests.
>     - Add `NATIVE_ONLY` flag to `ADD_H5_TEST` macro for native VOL connector tests.
>   - **Functions**:
>     - Modify `write_dset()` in `h5dumpgentest.c` to accept `tid_memory` parameter for memory datatype.
>     - Update `gent_fcontents()` and `gent_fvalues()` to use new `write_dset()` signature.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=HDFGroup%2Fhdf5&utm_source=github&utm_medium=referral)<sup> for 5dfa416979acbb75b0ebe18a9527e54d6d9d4645. You can [customize](https://app.ellipsis.dev/HDFGroup/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->