### PR TITLE
Fix for compilation errors on macOS from src/H5EAtest.c.

### DIFF
--- a/src/H5EAtest.c
+++ b/src/H5EAtest.c
@@ -66,7 +66,8 @@ static herr_t H5EA__test_dst_context(void *ctx);
 static herr_t H5EA__test_fill(void *nat_blk, size_t nelmts);
 static herr_t H5EA__test_encode(void *raw, const void *elmt, size_t nelmts, void *ctx);
 static herr_t H5EA__test_decode(const void *raw, void *elmt, size_t nelmts, void *ctx);
-static herr_t H5EA__test_debug(FILE *stream, int indent, int fwidth, hsize_t idx, const void *elmt);
+static herr_t H5EA__test_debug(FILE *stream, int indent, int fwidth, hsize_t idx, const void *elmt,
+                               void *dbg_ctx);
 static void  *H5EA__test_crt_dbg_context(H5F_t H5_ATTR_UNUSED *f, haddr_t H5_ATTR_UNUSED obj_addr);
 static herr_t H5EA__test_dst_dbg_context(void *_ctx);
 
@@ -290,7 +291,8 @@ H5EA__test_decode(const void *_raw, void *_elmt, size_t nelmts, void H5_ATTR_NDE
  *-------------------------------------------------------------------------
  */
 static herr_t
-H5EA__test_debug(FILE *stream, int indent, int fwidth, hsize_t idx, const void *elmt)
+H5EA__test_debug(FILE *stream, int indent, int fwidth, hsize_t idx, const void *elmt,
+                 void H5_ATTR_UNUSED *dbg_ctx)
 {
     char temp_str[128]; /* Temporary string, for formatting */
 


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Add `dbg_ctx` parameter to `H5EA__test_debug` in `src/H5EAtest.c` to fix macOS compilation errors.
> 
>   - **Function Signature Change**:
>     - `H5EA__test_debug` in `src/H5EAtest.c` now includes an additional parameter `void *dbg_ctx` to fix compilation errors on macOS.
>   - **Attributes**:
>     - Marks `dbg_ctx` as `H5_ATTR_UNUSED` to indicate it is not used in the function body.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=HDFGroup%2Fhdf5&utm_source=github&utm_medium=referral)<sup> for 9118066486669a521d044d660aa9a3cc78720356. You can [customize](https://app.ellipsis.dev/HDFGroup/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->