### PR TITLE
Generate VOL tests for h5mkgrp

### DIFF
--- a/tools/test/misc/CMakeTestsMkgrp.cmake
+++ b/tools/test/misc/CMakeTestsMkgrp.cmake
@@ -54,51 +54,82 @@ configure_file (${HDF5_TOOLS_TEST_MISC_SOURCE_DIR}/testfiles/h5mkgrp_version.txt
 ##############################################################################
 ##############################################################################
 
-macro (ADD_H5_TEST resultfile resultcode resultoption)
-  if (HDF5_ENABLE_USING_MEMCHECKER)
-    add_test (
-        NAME H5MKGRP-${resultfile}
-        COMMAND ${CMAKE_CROSSCOMPILING_EMULATOR} $<TARGET_FILE:h5mkgrp> ${resultoption} ${resultfile}.h5 ${ARGN}
-    )
-    if ("H5MKGRP-${resultfile}" MATCHES "${HDF5_DISABLE_TESTS_REGEX}")
-      set_tests_properties (H5MKGRP-${resultfile} PROPERTIES DISABLED true)
-    endif ()
-  else ()
-    add_test (
-        NAME H5MKGRP-${resultfile}-clear-objects
-        COMMAND ${CMAKE_COMMAND} -E remove ${resultfile}.h5
-    )
-    set_tests_properties (H5MKGRP-${resultfile}-clear-objects PROPERTIES
-        WORKING_DIRECTORY "${PROJECT_BINARY_DIR}/testfiles"
-    )
-    add_test (
-        NAME H5MKGRP-${resultfile}
-        COMMAND ${CMAKE_CROSSCOMPILING_EMULATOR} $<TARGET_FILE:h5mkgrp> ${resultoption} ${resultfile}.h5 ${ARGN}
-    )
-    set_tests_properties (H5MKGRP-${resultfile} PROPERTIES
-        DEPENDS H5MKGRP-${resultfile}-clear-objects
-        WORKING_DIRECTORY "${PROJECT_BINARY_DIR}/testfiles"
-    )
-    if ("H5MKGRP-${resultfile}" MATCHES "${HDF5_DISABLE_TESTS_REGEX}")
-      set_tests_properties (H5MKGRP-${resultfile} PROPERTIES DISABLED true)
-    endif ()
-    add_test (
-        NAME H5MKGRP-${resultfile}-h5ls
-        COMMAND "${CMAKE_COMMAND}"
-            -D "TEST_EMULATOR=${CMAKE_CROSSCOMPILING_EMULATOR}"
-            -D "TEST_PROGRAM=$<TARGET_FILE:h5ls>"
-            -D "TEST_ARGS:STRING=-v;-r;${resultfile}.h5"
-            -D "TEST_FOLDER=${PROJECT_BINARY_DIR}/testfiles"
-            -D "TEST_OUTPUT=${resultfile}.out"
-            -D "TEST_EXPECT=${resultcode}"
-            -D "TEST_REFERENCE=${resultfile}.ls"
-            -P "${HDF_RESOURCES_DIR}/runTest.cmake"
-    )
-    set_tests_properties (H5MKGRP-${resultfile}-h5ls PROPERTIES DEPENDS H5MKGRP-${resultfile})
-    if ("H5MKGRP-${resultfile}-h5ls" MATCHES "${HDF5_DISABLE_TESTS_REGEX}")
-      set_tests_properties (H5MKGRP-${resultfile}-h5ls PROPERTIES DISABLED true)
-    endif ()
+#
+# Adds a test that performs h5mkgrp according to given parameters
+#
+# REQUIRED POSITIONAL ARGUMENTS:
+#  testname  - name of the test (used to name the test and output files)
+#
+# REQUIRED KEYWORD ARGUMENTS:
+#  RESULT_CODE <resultcode> - expected return code from h5mkgrp
+#
+# OPTIONAL KEYWORD ARGUMENTS:
+#  RESULT_OPTION <flag> - a flag to pass to h5mkgrp
+#
+macro (ADD_H5_TEST testname)
+  # === Argument processing  ===
+  cmake_parse_arguments(
+      ARG
+      "" # flags
+      "RESULT_CODE;RESULT_OPTION" # one value args
+      "" # multi value args
+      ${ARGN}
+  )
+
+  if (NOT DEFINED ARG_RESULT_CODE)
+    message (FATAL_ERROR "ADD_H5_TEST: RESULT_CODE must be defined")
   endif ()
+
+  if (NOT DEFINED ARG_RESULT_OPTION)
+    set (ARG_RESULT_OPTION "")
+  endif ()
+
+  # === Adding the Test ===
+  if (NOT HDF5_ENABLE_USING_MEMCHECKER)
+    add_test (
+      NAME H5MKGRP-${testname}-clear-objects
+      COMMAND ${CMAKE_COMMAND} -E remove ${testname}.h5
+    )
+    set_tests_properties (H5MKGRP-${testname}-clear-objects PROPERTIES
+        WORKING_DIRECTORY "${PROJECT_BINARY_DIR}/testfiles"
+    )
+  endif ()
+
+  add_test (
+      NAME H5MKGRP-${testname}
+      COMMAND ${CMAKE_CROSSCOMPILING_EMULATOR} $<TARGET_FILE:h5mkgrp> ${ARG_RESULT_OPTION} ${testname}.h5 ${ARG_UNPARSED_ARGUMENTS}
+  )
+
+  if (NOT HDF5_ENABLE_USING_MEMCHECKER)
+    set_tests_properties (H5MKGRP-${testname} PROPERTIES
+      DEPENDS H5MKGRP-${testname}-clear-objects
+    )
+  endif()
+
+  add_test (
+    NAME H5MKGRP-${testname}-h5ls
+    COMMAND "${CMAKE_COMMAND}"
+        -D "TEST_EMULATOR=${CMAKE_CROSSCOMPILING_EMULATOR}"
+        -D "TEST_PROGRAM=$<TARGET_FILE:h5ls>"
+        -D "TEST_ARGS:STRING=-v;-r;${testname}.h5"
+        -D "TEST_FOLDER=${PROJECT_BINARY_DIR}/testfiles"
+        -D "TEST_OUTPUT=${testname}.out"
+        -D "TEST_EXPECT=${ARG_RESULT_CODE}"
+        -D "TEST_REFERENCE=${testname}.ls"
+        -P "${HDF_RESOURCES_DIR}/runTest.cmake"
+  )
+
+  set_tests_properties (H5MKGRP-${testname}-h5ls PROPERTIES
+    DEPENDS H5MKGRP-${testname}
+  )
+
+  if ("H5MKGRP-${testname}" MATCHES "${HDF5_DISABLE_TESTS_REGEX}")
+    set_tests_properties (H5MKGRP-${testname} PROPERTIES DISABLED true)
+  endif ()
+
+  set_tests_properties("H5MKGRP-${testname}" PROPERTIES
+    WORKING_DIRECTORY "${PROJECT_BINARY_DIR}/testfiles"
+  )
 endmacro ()
 
 macro (ADD_H5_CMP resultfile resultcode)
@@ -165,19 +196,19 @@ ADD_H5_CMP (h5mkgrp_help 0 "-h")
 ADD_H5_CMP (h5mkgrp_version 0 "-V")
 
 # Create single group at root level
-ADD_H5_TEST (h5mkgrp_single 0 "" single)
-ADD_H5_TEST (h5mkgrp_single_v 0 "-v" single)
-ADD_H5_TEST (h5mkgrp_single_p 0 "-p" single)
-ADD_H5_TEST (h5mkgrp_single_l 0 "-l" latest)
+ADD_H5_TEST (h5mkgrp_single RESULT_CODE 0 single)
+ADD_H5_TEST (h5mkgrp_single_v RESULT_CODE 0 RESULT_OPTION "-v" single)
+ADD_H5_TEST (h5mkgrp_single_p RESULT_CODE 0 RESULT_OPTION "-p" single)
+ADD_H5_TEST (h5mkgrp_single_l RESULT_CODE 0 RESULT_OPTION "-l" latest)
 
 # Create several groups at root level
-ADD_H5_TEST (h5mkgrp_several 0 "" one two)
-ADD_H5_TEST (h5mkgrp_several_v 0 "-v" one two)
-ADD_H5_TEST (h5mkgrp_several_p 0 "-p" one two)
-ADD_H5_TEST (h5mkgrp_several_l 0 "-l" one two)
+ADD_H5_TEST (h5mkgrp_several RESULT_CODE 0 one two)
+ADD_H5_TEST (h5mkgrp_several_v RESULT_CODE 0 RESULT_OPTION "-v" one two)
+ADD_H5_TEST (h5mkgrp_several_p RESULT_CODE 0 RESULT_OPTION "-p" one two)
+ADD_H5_TEST (h5mkgrp_several_l RESULT_CODE 0 RESULT_OPTION "-l" one two)
 
 # Create various nested groups
-ADD_H5_TEST (h5mkgrp_nested_p 0 "-p" /one/two)
-ADD_H5_TEST (h5mkgrp_nested_lp 0 "-lp" /one/two)
-ADD_H5_TEST (h5mkgrp_nested_mult_p 0 "-p" /one/two /three/four)
-ADD_H5_TEST (h5mkgrp_nested_mult_lp 0 "-lp" /one/two /three/four)
+ADD_H5_TEST (h5mkgrp_nested_p RESULT_CODE 0 RESULT_OPTION "-p" /one/two)
+ADD_H5_TEST (h5mkgrp_nested_lp RESULT_CODE 0 RESULT_OPTION "-lp" /one/two)
+ADD_H5_TEST (h5mkgrp_nested_mult_p RESULT_CODE 0 RESULT_OPTION "-p" /one/two /three/four)
+ADD_H5_TEST (h5mkgrp_nested_mult_lp RESULT_CODE 0 RESULT_OPTION "-lp" /one/two /three/four)

--- a/tools/test/misc/CMakeTestsMkgrp.cmake
+++ b/tools/test/misc/CMakeTestsMkgrp.cmake
@@ -157,6 +157,10 @@ macro (ADD_H5_TEST testname)
         COMMAND ${CMAKE_CROSSCOMPILING_EMULATOR} $<TARGET_FILE:h5mkgrp> ${ARG_RESULT_OPTION} ${testname}.h5 ${ARG_UNPARSED_ARGUMENTS}
     )
 
+    if ("${vol_prefix}H5MKGRP-${testname}" MATCHES "${HDF5_DISABLE_TESTS_REGEX}")
+      set_tests_properties (${vol_prefix}H5MKGRP-${testname} PROPERTIES DISABLED true)
+    endif ()
+
     if (NOT HDF5_ENABLE_USING_MEMCHECKER)
       set_tests_properties (${vol_prefix}H5MKGRP-${testname} PROPERTIES
         DEPENDS ${vol_prefix}H5MKGRP-${testname}-clear-objects
@@ -195,8 +199,8 @@ macro (ADD_H5_TEST testname)
       )
     endif ()
 
-    if ("${vol_prefix}H5MKGRP-${testname}" MATCHES "${HDF5_DISABLE_TESTS_REGEX}")
-      set_tests_properties (${vol_prefix}H5MKGRP-${testname} PROPERTIES DISABLED true)
+    if ("${vol_prefix}H5MKGRP-${testname}-h5ls" MATCHES "${HDF5_DISABLE_TESTS_REGEX}")
+      set_tests_properties (${vol_prefix}H5MKGRP-${testname}-h5ls PROPERTIES DISABLED true)
     endif ()
 
     set_tests_properties("${vol_prefix}H5MKGRP-${testname}" PROPERTIES

--- a/tools/test/misc/CMakeTestsMkgrp.cmake
+++ b/tools/test/misc/CMakeTestsMkgrp.cmake
@@ -48,6 +48,29 @@ add_custom_target(h5mkgrp_files ALL COMMENT "Copying files needed by h5mkgrp tes
 
 configure_file (${HDF5_TOOLS_TEST_MISC_SOURCE_DIR}/testfiles/h5mkgrp_version.txt.in ${PROJECT_BINARY_DIR}/testfiles/h5mkgrp_version.txt @ONLY)
 
+#  Generate testfiles for VOL connector(s), if any
+set(h5mkgrp_vol_files_list "")
+
+foreach (external_vol_tgt ${HDF5_EXTERNAL_VOL_TARGETS})
+  HDF5_GET_VOL_TGT_INFO(${external_vol_tgt} vol vol_env)
+
+  # Setup testfiles directory
+  file (MAKE_DIRECTORY "${PROJECT_BINARY_DIR}/${vol}/testfiles" RESULT)
+  if (NOT ${RESULT} EQUAL 0)
+    message (FATAL_ERROR "Failed to create directory: ${PROJECT_BINARY_DIR}/${vol}/testfiles")
+  endif ()
+
+  # h5mkgrp depends on no pre-existing HDF5 files; no need to use h5gentest here
+
+  # Copy expected output files
+  foreach (h5_mkgrp_file ${HDF5_MKGRP_TEST_FILES})
+    HDFTEST_COPY_FILE("${HDF5_TOOLS_TST_DIR}/misc/expected/${h5_mkgrp_file}"
+      "${PROJECT_BINARY_DIR}/${vol}/testfiles/${h5_mkgrp_file}"
+      "h5mkgrp_vol_files")
+  endforeach ()
+endforeach()
+
+add_custom_target(h5mkgrp_vol_files ALL COMMENT "Copying files needed by h5mkgrp VOL tests" DEPENDS ${h5mkgrp_vol_files_list})
 ##############################################################################
 ##############################################################################
 ###           T H E   T E S T S  M A C R O S                               ###
@@ -85,51 +108,101 @@ macro (ADD_H5_TEST testname)
   endif ()
 
   # === Adding the Test ===
-  if (NOT HDF5_ENABLE_USING_MEMCHECKER)
+  list(LENGTH HDF5_EXTERNAL_VOL_TARGETS num_ext_vols)
+
+  # Add a test for the native connector and each external VOL connector
+  foreach (vol_idx RANGE 0 ${num_ext_vols})
+    # First, populate VOL info to be passed to tests
+    if (${vol_idx} EQUAL 0)
+      set(vol "native")
+      set(vol_prefix "")
+      set(vol_workdir "${PROJECT_BINARY_DIR}/testfiles")
+    else ()
+      # An external VOL connector
+      set(vol_env "")
+
+      math(EXPR vol_idx_fixed "${vol_idx} - 1")
+      list(GET HDF5_EXTERNAL_VOL_TARGETS ${vol_idx_fixed} ext_vol_tgt)
+      HDF5_GET_VOL_TGT_INFO(${ext_vol_tgt} vol vol_env)
+
+      set (vol_prefix "HDF5_VOL_${vol}-")
+      set (vol_workdir "${PROJECT_BINARY_DIR}/${vol}/testfiles")
+      set (vol_fixtures "${vol_prefix}files")
+    endif ()
+
+    # == Clean up ==
+    if (NOT HDF5_ENABLE_USING_MEMCHECKER)
+      add_test (
+        NAME ${vol_prefix}H5MKGRP-${testname}-clear-objects
+        COMMAND ${CMAKE_CROSSCOMPILING_EMULATOR} $<TARGET_FILE:h5delete> ${testname}.h5
+      )
+
+      set_tests_properties (${vol_prefix}H5MKGRP-${testname}-clear-objects PROPERTIES
+        WORKING_DIRECTORY "${vol_workdir}"
+          # h5delete will return an error code if targeted file does not exist - accept any result
+        PASS_REGULAR_EXPRESSION "^$|"
+      )
+
+      if (NOT "${vol}" STREQUAL "native")
+        set_tests_properties (${vol_prefix}H5MKGRP-${testname}-clear-objects PROPERTIES
+          DEPENDS h5mkgrp_vol_files
+          ENVIRONMENT "${vol_env}"
+        )
+      endif ()
+    endif ()
+
+    # == Main test ==
     add_test (
-      NAME H5MKGRP-${testname}-clear-objects
-      COMMAND ${CMAKE_COMMAND} -E remove ${testname}.h5
+        NAME ${vol_prefix}H5MKGRP-${testname}
+        COMMAND ${CMAKE_CROSSCOMPILING_EMULATOR} $<TARGET_FILE:h5mkgrp> ${ARG_RESULT_OPTION} ${testname}.h5 ${ARG_UNPARSED_ARGUMENTS}
     )
-    set_tests_properties (H5MKGRP-${testname}-clear-objects PROPERTIES
-        WORKING_DIRECTORY "${PROJECT_BINARY_DIR}/testfiles"
+
+    if (NOT HDF5_ENABLE_USING_MEMCHECKER)
+      set_tests_properties (${vol_prefix}H5MKGRP-${testname} PROPERTIES
+        DEPENDS ${vol_prefix}H5MKGRP-${testname}-clear-objects
+      )
+    endif()
+
+    if (NOT "${vol}" STREQUAL "native")
+      set_tests_properties (${vol_prefix}H5MKGRP-${testname} PROPERTIES
+        DEPENDS h5mkgrp_vol_files
+        ENVIRONMENT "${vol_env}"
+      )
+    endif ()
+
+    # == Verify with h5ls ==
+    add_test (
+      NAME ${vol_prefix}H5MKGRP-${testname}-h5ls
+      COMMAND "${CMAKE_COMMAND}"
+          -D "TEST_EMULATOR=${CMAKE_CROSSCOMPILING_EMULATOR}"
+          -D "TEST_PROGRAM=$<TARGET_FILE:h5ls>"
+          -D "TEST_ARGS:STRING=-v;-r;${testname}.h5"
+          -D "TEST_FOLDER=${vol_workdir}"
+          -D "TEST_OUTPUT=${testname}.out"
+          -D "TEST_EXPECT=${ARG_RESULT_CODE}"
+          -D "TEST_REFERENCE=${testname}.ls"
+          -P "${HDF_RESOURCES_DIR}/runTest.cmake"
     )
-  endif ()
 
-  add_test (
-      NAME H5MKGRP-${testname}
-      COMMAND ${CMAKE_CROSSCOMPILING_EMULATOR} $<TARGET_FILE:h5mkgrp> ${ARG_RESULT_OPTION} ${testname}.h5 ${ARG_UNPARSED_ARGUMENTS}
-  )
-
-  if (NOT HDF5_ENABLE_USING_MEMCHECKER)
-    set_tests_properties (H5MKGRP-${testname} PROPERTIES
-      DEPENDS H5MKGRP-${testname}-clear-objects
+    set_tests_properties (${vol_prefix}H5MKGRP-${testname}-h5ls PROPERTIES
+      DEPENDS ${vol_prefix}H5MKGRP-${testname}
     )
-  endif()
 
-  add_test (
-    NAME H5MKGRP-${testname}-h5ls
-    COMMAND "${CMAKE_COMMAND}"
-        -D "TEST_EMULATOR=${CMAKE_CROSSCOMPILING_EMULATOR}"
-        -D "TEST_PROGRAM=$<TARGET_FILE:h5ls>"
-        -D "TEST_ARGS:STRING=-v;-r;${testname}.h5"
-        -D "TEST_FOLDER=${PROJECT_BINARY_DIR}/testfiles"
-        -D "TEST_OUTPUT=${testname}.out"
-        -D "TEST_EXPECT=${ARG_RESULT_CODE}"
-        -D "TEST_REFERENCE=${testname}.ls"
-        -P "${HDF_RESOURCES_DIR}/runTest.cmake"
-  )
+    if (NOT "${vol}" STREQUAL "native")
+      set_tests_properties (${vol_prefix}H5MKGRP-${testname}-h5ls PROPERTIES
+        DEPENDS h5mkgrp_vol_files
+        ENVIRONMENT "${vol_env}"
+      )
+    endif ()
 
-  set_tests_properties (H5MKGRP-${testname}-h5ls PROPERTIES
-    DEPENDS H5MKGRP-${testname}
-  )
+    if ("${vol_prefix}H5MKGRP-${testname}" MATCHES "${HDF5_DISABLE_TESTS_REGEX}")
+      set_tests_properties (${vol_prefix}H5MKGRP-${testname} PROPERTIES DISABLED true)
+    endif ()
 
-  if ("H5MKGRP-${testname}" MATCHES "${HDF5_DISABLE_TESTS_REGEX}")
-    set_tests_properties (H5MKGRP-${testname} PROPERTIES DISABLED true)
-  endif ()
-
-  set_tests_properties("H5MKGRP-${testname}" PROPERTIES
-    WORKING_DIRECTORY "${PROJECT_BINARY_DIR}/testfiles"
-  )
+    set_tests_properties("${vol_prefix}H5MKGRP-${testname}" PROPERTIES
+      WORKING_DIRECTORY "${vol_workdir}"
+    )
+  endforeach() # per-VOL loop
 endmacro ()
 
 macro (ADD_H5_CMP resultfile resultcode)


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Generate VOL tests for `h5mkgrp` by updating test macros and adding support for VOL connectors in `CMakeTestsMkgrp.cmake`.
> 
>   - **Test Generation**:
>     - Generate test files for VOL connectors in `CMakeTestsMkgrp.cmake`.
>     - Add `h5mkgrp_vol_files` target to copy necessary files for VOL tests.
>   - **Macro Updates**:
>     - Update `ADD_H5_TEST` macro to include `RESULT_CODE` and `RESULT_OPTION` arguments.
>     - Add support for running tests with both native and external VOL connectors.
>     - Ensure cleanup and verification steps are included for each test.
>   - **Test Cases**:
>     - Add tests for creating single, several, and nested groups with various options (e.g., `-v`, `-p`, `-l`).
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=HDFGroup%2Fhdf5&utm_source=github&utm_medium=referral)<sup> for efadfd5f34281baa11177f14b25721d16de2b389. You can [customize](https://app.ellipsis.dev/HDFGroup/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->