### PR TITLE
Clean up compilation warnings that showed up when compiled the librar…

### DIFF
--- a/src/H5Dstruct_chunk.c
+++ b/src/H5Dstruct_chunk.c
@@ -95,8 +95,8 @@ typedef struct H5D_chunk_cache_mem_t {
     /* size tracking */
     size_t  sel_nbytes;      /* nbytes for selection */
     size_t  sel_alloc_size;  /* alloc_size for selection */
-    hsize_t data_nbytes;     /* nbytes for data values */
-    hsize_t data_alloc_size; /* alloc_size for data values */
+    size_t data_nbytes;      /* nbytes for data values */
+    size_t data_alloc_size;  /* alloc_size for data values */
 } H5D_chunk_cache_mem_t;
 
 /********************/
@@ -1733,7 +1733,7 @@ H5D__struct_chunk_encode(H5D_t *dset, hsize_t *write_size /*out*/, hsize_t *writ
 {
     const H5D_chunk_cache_mem_t *chk   = (const H5D_chunk_cache_mem_t *)chunk; /* Chunk memory cache info */
     H5D_chunk_ud_t              *udata = (H5D_chunk_ud_t *)_udata;
-    void                        *data_buf;
+    void                        *data_buf = NULL;
     uint8_t                     *p     = NULL;
     unsigned char               *sel_p = NULL;
     size_t                       sel_nbytes, sel_alloc_size;
@@ -2222,7 +2222,7 @@ H5D__struct_chunk_vector_read(H5D_t *dset, haddr_t addr, const H5S_t *file_space
     size_t                  file_nseq;
     size_t                  io_len;
     size_t                  file_nelmts;
-    size_t                  chk_nelmts;
+    hsize_t                 chk_nelmts;
     hssize_t                hss_nelmts;
     size_t                  seq_nelem;
     H5S_sel_iter_t         *file_iter      = NULL;
@@ -2264,7 +2264,7 @@ H5D__struct_chunk_vector_read(H5D_t *dset, haddr_t addr, const H5S_t *file_space
     /* Get the number of elements in chk->sel_space */
     if ((hss_nelmts = (hssize_t)H5S_GET_SELECT_NPOINTS(chk->sel_space)) < 0)
         HGOTO_ERROR(H5E_VFL, H5E_CANTCOUNT, FAIL, "can't get number of elements selected");
-    H5_CHECKED_ASSIGN(chk_nelmts, size_t, hss_nelmts, hssize_t);
+    H5_CHECKED_ASSIGN(chk_nelmts, hsize_t, hss_nelmts, hssize_t);
 
     /* Get the number of elements in file_space_in */
     if ((hss_nelmts = (hssize_t)H5S_GET_SELECT_NPOINTS(file_space_in)) < 0)
@@ -2417,14 +2417,14 @@ H5D__struct_chunk_vector_write(H5D_t *dset, haddr_t addr, const H5S_t *file_spac
     size_t                  file_nseq;
     size_t                  io_len;
     size_t                  file_nelmts;
-    size_t                  chk_nelmts;
+    hsize_t                 chk_nelmts;
     hssize_t                hss_nelmts;
     size_t                  seq_nelem;
     H5S_sel_iter_t         *file_iter      = NULL;
     bool                    file_iter_init = false;
     size_t                  vec_arr_nused  = 0;
     size_t                  vec_arr_nalloc = VECTOR_LEN;
-    H5O_pline_t            *pline; /* I/O pipeline info */
+    H5O_pline_t            *pline = NULL; /* I/O pipeline info */
     H5S_t                  *serial_values_space;
     H5S_t                  *serial_file_space;
     H5_flexible_const_ptr_t flex_selection;
@@ -2460,7 +2460,7 @@ H5D__struct_chunk_vector_write(H5D_t *dset, haddr_t addr, const H5S_t *file_spac
     /* Get the number of elements in chk->sel_space */
     if ((hss_nelmts = (hssize_t)H5S_GET_SELECT_NPOINTS(chk->sel_space)) < 0)
         HGOTO_ERROR(H5E_VFL, H5E_CANTCOUNT, FAIL, "can't get number of elements selected");
-    H5_CHECKED_ASSIGN(chk_nelmts, size_t, hss_nelmts, hssize_t);
+    H5_CHECKED_ASSIGN(chk_nelmts, hsize_t, hss_nelmts, hssize_t);
 
     /* Get the number of elements in file_space_in */
     if ((hss_nelmts = (hssize_t)H5S_GET_SELECT_NPOINTS(file_space_in)) < 0)
@@ -2601,15 +2601,15 @@ H5D__struct_chunk_scatter_mem(H5D_dset_io_info_t *dset_info, H5D_io_type_info_t 
     bool            bkg_iter_init  = false; /* Background iteration info has been initialized */
     H5S_sel_iter_t *sel_iter       = NULL;  /* Memory selection iteration info*/
     bool            sel_iter_init  = false; /* Memory selection iteration info has been initialized */
-    hsize_t         nelmts;                 /* Number of elements selected in file & memory dataspaces */
+    hsize_t         nelmts = 0;                 /* Number of elements selected in file & memory dataspaces */
     hsize_t         smine_start;            /* Strip mine start loc */
     size_t          smine_nelmts;           /* Elements per strip   */
-    bool            in_place_tconv;         /* Whether to perform in-place type_conversion */
+    bool            in_place_tconv = false;     /* Whether to perform in-place type_conversion */
     size_t          mem_type_size;
     size_t          file_type_size;
     size_t          buf_off          = 0; /* Buffer offset for in-place type conversion */
     const H5D_chunk_cache_mem_t *chk = (const H5D_chunk_cache_mem_t *)chunk; /* Chunk's memory cache info */
-    void                        *data_scat_buf;
+    void                        *data_scat_buf = NULL;
     hsize_t                      scat_buf_size;
     H5_flexible_const_ptr_t      flex_mspace;
     H5_flexible_const_ptr_t      flex_fspace;
@@ -2894,7 +2894,7 @@ H5D__struct_chunk_gather_mem(H5D_dset_io_info_t *dset_info, H5D_io_type_info_t *
     size_t                  mem_type_size;
     size_t                  file_type_size;
     size_t                  buf_off = 0;    /* Buffer offset for in-place type conversion */
-    bool                    in_place_tconv; /* Whether to perform in-place type_conversion */
+    bool                    in_place_tconv = false; /* Whether to perform in-place type_conversion */
     H5D_chunk_cache_mem_t  *chk = (H5D_chunk_cache_mem_t *)chunk; /* Chunk's memory cache info */
     void                   *data_scat_buf;
     hsize_t                 scat_buf_size;
@@ -3415,7 +3415,7 @@ H5D__struct_chunk_erase_values(H5D_t *dset, const H5S_t *selection, size_t *nbyt
     hsize_t         prev_persist_end_off;
     hsize_t         tmp_off;
     hsize_t         num_bytes;
-    hsize_t         tot_erased_bytes;
+    hsize_t         tot_erased_bytes = 0;
     H5S_t          *new_space;
 
     herr_t ret_value = SUCCEED; /* Return value		*/

--- a/src/H5Dstruct_chunk.c
+++ b/src/H5Dstruct_chunk.c
@@ -93,10 +93,10 @@ typedef struct H5D_chunk_cache_mem_t {
     void  *sel_buf;   /* Buffer pointer to the encoded selection */
     H5S_t *sel_space; /* Dataspace for encoded selection */
     /* size tracking */
-    size_t  sel_nbytes;      /* nbytes for selection */
-    size_t  sel_alloc_size;  /* alloc_size for selection */
-    size_t data_nbytes;      /* nbytes for data values */
-    size_t data_alloc_size;  /* alloc_size for data values */
+    size_t sel_nbytes;      /* nbytes for selection */
+    size_t sel_alloc_size;  /* alloc_size for selection */
+    size_t data_nbytes;     /* nbytes for data values */
+    size_t data_alloc_size; /* alloc_size for data values */
 } H5D_chunk_cache_mem_t;
 
 /********************/
@@ -1734,8 +1734,8 @@ H5D__struct_chunk_encode(H5D_t *dset, hsize_t *write_size /*out*/, hsize_t *writ
     const H5D_chunk_cache_mem_t *chk   = (const H5D_chunk_cache_mem_t *)chunk; /* Chunk memory cache info */
     H5D_chunk_ud_t              *udata = (H5D_chunk_ud_t *)_udata;
     void                        *data_buf = NULL;
-    uint8_t                     *p     = NULL;
-    unsigned char               *sel_p = NULL;
+    uint8_t                     *p        = NULL;
+    unsigned char               *sel_p    = NULL;
     size_t                       sel_nbytes, sel_alloc_size;
     size_t                       data_nbytes, data_alloc_size;
     H5O_pline_t                 *pline    = NULL; /* I/O pipeline info */
@@ -2424,7 +2424,7 @@ H5D__struct_chunk_vector_write(H5D_t *dset, haddr_t addr, const H5S_t *file_spac
     bool                    file_iter_init = false;
     size_t                  vec_arr_nused  = 0;
     size_t                  vec_arr_nalloc = VECTOR_LEN;
-    H5O_pline_t            *pline = NULL; /* I/O pipeline info */
+    H5O_pline_t            *pline          = NULL; /* I/O pipeline info */
     H5S_t                  *serial_values_space;
     H5S_t                  *serial_file_space;
     H5_flexible_const_ptr_t flex_selection;
@@ -2601,10 +2601,10 @@ H5D__struct_chunk_scatter_mem(H5D_dset_io_info_t *dset_info, H5D_io_type_info_t 
     bool            bkg_iter_init  = false; /* Background iteration info has been initialized */
     H5S_sel_iter_t *sel_iter       = NULL;  /* Memory selection iteration info*/
     bool            sel_iter_init  = false; /* Memory selection iteration info has been initialized */
-    hsize_t         nelmts = 0;                 /* Number of elements selected in file & memory dataspaces */
+    hsize_t         nelmts         = 0;     /* Number of elements selected in file & memory dataspaces */
     hsize_t         smine_start;            /* Strip mine start loc */
     size_t          smine_nelmts;           /* Elements per strip   */
-    bool            in_place_tconv = false;     /* Whether to perform in-place type_conversion */
+    bool            in_place_tconv = false; /* Whether to perform in-place type_conversion */
     size_t          mem_type_size;
     size_t          file_type_size;
     size_t          buf_off          = 0; /* Buffer offset for in-place type conversion */
@@ -2893,9 +2893,9 @@ H5D__struct_chunk_gather_mem(H5D_dset_io_info_t *dset_info, H5D_io_type_info_t *
     hsize_t                 nelmts; /* Number of elements selected in file & memory dataspaces */
     size_t                  mem_type_size;
     size_t                  file_type_size;
-    size_t                  buf_off = 0;    /* Buffer offset for in-place type conversion */
+    size_t                  buf_off        = 0;     /* Buffer offset for in-place type conversion */
     bool                    in_place_tconv = false; /* Whether to perform in-place type_conversion */
-    H5D_chunk_cache_mem_t  *chk = (H5D_chunk_cache_mem_t *)chunk; /* Chunk's memory cache info */
+    H5D_chunk_cache_mem_t  *chk            = (H5D_chunk_cache_mem_t *)chunk; /* Chunk's memory cache info */
     void                   *data_scat_buf;
     hsize_t                 scat_buf_size;
     H5_flexible_const_ptr_t flex_mspace;

--- a/src/H5Z.c
+++ b/src/H5Z.c
@@ -884,7 +884,7 @@ H5Z__prelude_callback(const H5O_pline_t *pline, hid_t dcpl_id, hid_t type_id, hi
 
             if (filt_sect->nused) {
                 if (H5Z__prelude_callback_real(dcpl_id, type_id, space_id, prelude_type, filt_sect->nused,
-                                               filt_sect->filter, filt_sect->seq_sect) < 0)
+                                               filt_sect->filter, (H5_section_type_t)filt_sect->seq_sect) < 0)
                     HGOTO_ERROR(H5E_PLINE, H5E_CANAPPLY, FAIL, "unable to apply prelude callback");
             }
         }


### PR DESCRIPTION
…y on macOS.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fix compilation warnings on macOS by adjusting types, initializing variables, and adding casts in `H5Dstruct_chunk.c` and `H5Z.c`.
> 
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=HDFGroup%2Fhdf5&utm_source=github&utm_medium=referral)<sup> for 237a9efca764031cf7a2fc07849c63361ad6f637. You can [customize](https://app.ellipsis.dev/HDFGroup/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->