### PR TITLE
move link checking to only mergers

### DIFF
--- a/.github/workflows/linkchecker.yml
+++ b/.github/workflows/linkchecker.yml
@@ -2,9 +2,9 @@ name: linkchecker
 
 on:
   workflow_dispatch:
-  push:
   pull_request:
-    branches: [ develop ]
+    types: [closed]
+    branches: [develop]
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref && github.ref || github.run_id }}
@@ -15,6 +15,7 @@ permissions:
 
 jobs:
   build:
+    if: github.event.pull_request.merged == true
     runs-on: ubuntu-latest
     steps:
       - name: get


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Modify `linkchecker.yml` to run link checks only on merged pull requests to the `develop` branch.
> 
>   - **Workflow Trigger**:
>     - Changes `linkchecker.yml` to trigger on `pull_request` events of type `closed` for the `develop` branch.
>     - Removes trigger on `push` events.
>   - **Conditional Execution**:
>     - Adds condition `if: github.event.pull_request.merged == true` to `build` job in `linkchecker.yml` to ensure it runs only if the PR is merged.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=HDFGroup%2Fhdf5&utm_source=github&utm_medium=referral)<sup> for 8ecf8c15d2431f3249bceb1dcffd0473ccbde9bf. You can [customize](https://app.ellipsis.dev/HDFGroup/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->