### PR TITLE
Fixes gcc -15 warning message about potential null pointer dereference

### DIFF
--- a/src/H5B.c
+++ b/src/H5B.c
@@ -1434,7 +1434,7 @@ H5B__remove_helper(H5F_t *f, haddr_t addr, const H5B_class_t *type, int level, u
         ret_value = H5B_INS_NOOP;
 
     /* Patch keys in neighboring trees if necessary */
-    if (*lt_key_changed && H5_addr_defined(bt->left)) {
+    if (*lt_key_changed && bt != NULL && H5_addr_defined(bt->left)) {
         assert(type->critical_key == H5B_LEFT);
         assert(level > 0);
 
@@ -1449,7 +1449,7 @@ H5B__remove_helper(H5F_t *f, haddr_t addr, const H5B_class_t *type, int level, u
             HGOTO_ERROR(H5E_BTREE, H5E_CANTUNPROTECT, H5B_INS_ERROR, "unable to release node from tree");
         sibling = NULL; /* Make certain future references will be caught */
     }                   /* end if */
-    else if (*rt_key_changed && H5_addr_defined(bt->right)) {
+    else if (*rt_key_changed && bt != NULL && H5_addr_defined(bt->right)) {
         assert(type->critical_key == H5B_RIGHT);
         assert(level > 0);
 


### PR DESCRIPTION
Fixes warning message indicating, for example, that the H5_addr_defined(bt->right)  macro might be evaluated with a null bt pointer..

Fixes #5780 
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Add null pointer check in `H5B__remove_helper()` in `H5B.c` to prevent potential null pointer dereference warnings from GCC.
> 
>   - **Behavior**:
>     - Add null pointer check for `bt` in `H5B__remove_helper()` in `H5B.c` to prevent potential null pointer dereference when evaluating `H5_addr_defined(bt->left)` and `H5_addr_defined(bt->right)`.
>   - **Misc**:
>     - Fixes GCC warning about potential null pointer dereference.
>     - Addresses issue #5780.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=HDFGroup%2Fhdf5&utm_source=github&utm_medium=referral)<sup> for e18867431ba495dcc21b1392f64a5006dfbcf6bb. You can [customize](https://app.ellipsis.dev/HDFGroup/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->