### PR TITLE
chore: remove duplicate `options` in comment

### DIFF
--- a/CMakeBuildOptions.cmake
+++ b/CMakeBuildOptions.cmake
@@ -1,4 +1,4 @@
-# Put all top-level options build options into one place
+# Put all top-level build options into one place
 # This file will be included at the beginning of the root CMakeLists.txt
 option (HDF5_USE_FOLDERS "Enable folder grouping of projects in IDEs." ON)
 mark_as_advanced (HDF5_USE_FOLDERS)


### PR DESCRIPTION
`Put all top-level options build options into one place` -> `Put all top-level build options into one place`
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fix duplicate word in comment in `CMakeBuildOptions.cmake`.
> 
>   - **Comment Correction**:
>     - Fix duplicate word in comment in `CMakeBuildOptions.cmake`: "Put all top-level options build options into one place" to "Put all top-level build options into one place".
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=HDFGroup%2Fhdf5&utm_source=github&utm_medium=referral)<sup> for fd11717cf6492b75184a4cf2e6da0d442806c2e9. You can [customize](https://app.ellipsis.dev/HDFGroup/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->