### PR TITLE
chore: add space between `publish` and `release`

### DIFF
--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -1,4 +1,4 @@
-name: hdf5 publishrelease
+name: hdf5 publish release
 
 # Triggers the workflow on demand
 on:


### PR DESCRIPTION
`publishrelease` -> `publish release`
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Renamed workflow name from `hdf5 publishrelease` to `hdf5 publish release` in `.github/workflows/publish-release.yml`.
> 
>   - **Misc**:
>     - Renamed workflow name from `hdf5 publishrelease` to `hdf5 publish release` in `.github/workflows/publish-release.yml`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=HDFGroup%2Fhdf5&utm_source=github&utm_medium=referral)<sup> for 0464fd70e7fa5baba23d74e5913849fa5257df7f. You can [customize](https://app.ellipsis.dev/HDFGroup/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->