### PR TITLE
add the s3-build workflow to release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -32,8 +32,20 @@ jobs:
       use_tag: ${{ needs.log-the-inputs.outputs.rel_tag }}
       use_environ: release
 
-  call-workflow-ctest:
+  call-aws-c-s3-build:
     needs: call-workflow-tarball
+    name: "Build aws-c-s3 library"
+    uses: ./.github/workflows/vfd-ros3.yml
+    with:
+      build_mode: "Release"
+      build_aws_c_s3_only: true
+      aws_c_s3_build_type: "source"
+      # Use latest release for building from source on Ubuntu
+      # until a package is available to install 
+      aws_c_s3_tag: "v0.8.0"
+
+  call-workflow-ctest:
+    needs: [call-workflow-tarball, call-aws-c-s3-build]
     uses: ./.github/workflows/cmake-ctest.yml
     with:
       cmake_version: "latest"


### PR DESCRIPTION
Fixes #5786
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Adds `call-aws-c-s3-build` job to `release.yml` to build `aws-c-s3` library, updating dependencies for `call-workflow-ctest`.
> 
>   - **Workflow Changes**:
>     - Adds `call-aws-c-s3-build` job to `release.yml` to build `aws-c-s3` library using `vfd-ros3.yml`.
>     - Sets `build_mode` to "Release" and `aws_c_s3_tag` to "v0.8.0".
>     - `call-workflow-ctest` now depends on `call-aws-c-s3-build`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=HDFGroup%2Fhdf5&utm_source=github&utm_medium=referral)<sup> for 09f27d081725bc5f72b913c0d25897a1ecf5e5c8. You can [customize](https://app.ellipsis.dev/HDFGroup/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->