### PR TITLE
Add missing test files to h5gentest --h5repack

### DIFF
--- a/tools/test/h5dump/h5dumpgentest.c
+++ b/tools/test/h5dump/h5dumpgentest.c
@@ -2238,7 +2238,7 @@ gent_objref(void)
 }
 
 void
-gent_datareg(void)
+gent_datareg(bool undefined_fill_value)
 {
     /*some code is taken from enum.c in the test dir */
 
@@ -2247,6 +2247,7 @@ gent_datareg(void)
         dset2;   /* Dereferenced dataset ID */
     hid_t sid1,  /* Dataspace ID #1  */
         sid2;    /* Dataspace ID #2  */
+    hid_t dcpl_id = H5I_INVALID_HID;
     hsize_t          dims1[] = {SPACE1_DIM1}, dims2[] = {SPACE2_DIM1, SPACE2_DIM2};
     hsize_t          start[SPACE2_RANK];                  /* Starting location of hyperslab */
     hsize_t          stride[SPACE2_RANK];                 /* Stride of hyperslab */
@@ -2272,8 +2273,16 @@ gent_datareg(void)
     /* Create dataspace for datasets */
     sid2 = H5Screate_simple(SPACE2_RANK, dims2, NULL);
 
+    dcpl_id = H5Pcreate(H5P_DATASET_CREATE);
+
+    if (undefined_fill_value) {
+        /* Set the fill value to be undefined */
+        H5Pset_fill_time(dcpl_id, H5D_FILL_TIME_IFSET);
+        H5Pset_fill_value(dcpl_id, H5I_INVALID_HID, NULL);
+    }
+
     /* Create a dataset */
-    dset2 = H5Dcreate2(fid1, "Dataset2", H5T_STD_U8BE, sid2, H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT);
+    dset2 = H5Dcreate2(fid1, "Dataset2", H5T_STD_U8BE, sid2, H5P_DEFAULT, dcpl_id, H5P_DEFAULT);
 
     for (tu8 = dwbuf, i = 0; i < SPACE2_DIM1 * SPACE2_DIM2; i++)
         *tu8++ = (uint8_t)(i * 3);
@@ -2288,7 +2297,7 @@ gent_datareg(void)
     sid1 = H5Screate_simple(SPACE1_RANK, dims1, NULL);
 
     /* Create a dataset */
-    dset1 = H5Dcreate2(fid1, "Dataset1", H5T_STD_REF_DSETREG, sid1, H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT);
+    dset1 = H5Dcreate2(fid1, "Dataset1", H5T_STD_REF_DSETREG, sid1, H5P_DEFAULT, dcpl_id, H5P_DEFAULT);
 
     /* Create references */
 
@@ -2350,6 +2359,8 @@ gent_datareg(void)
 
     /* Close file */
     H5Fclose(fid1);
+
+    H5Pclose(dcpl_id);
 
     /* Free memory buffers */
     free(wbuf);

--- a/tools/test/h5dump/h5dumpgentest.c
+++ b/tools/test/h5dump/h5dumpgentest.c
@@ -691,7 +691,7 @@ gent_softlink2(bool big_endian_committed)
     hid_t   fileid1 = H5I_INVALID_HID;
     hid_t   gid1 = H5I_INVALID_HID, gid2 = H5I_INVALID_HID;
     hid_t   target_type = H5I_INVALID_HID;
-    hid_t   datatype = H5I_INVALID_HID;
+    hid_t   datatype    = H5I_INVALID_HID;
     hid_t   dset1 = H5I_INVALID_HID, dset2 = H5I_INVALID_HID;
     hid_t   dataspace = H5I_INVALID_HID;
     hsize_t dimsf[2]; /* dataset dimensions */
@@ -745,7 +745,7 @@ gent_softlink2(bool big_endian_committed)
 
     datatype = H5Tcopy(target_type);
 
-    status   = H5Tcommit2(fileid1, "dtype", datatype, H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT);
+    status = H5Tcommit2(fileid1, "dtype", datatype, H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT);
     if (status < 0) {
         fprintf(stderr, "Error: %s> H5Tcommit2 failed.\n", FILE4_1);
         status = FAIL;
@@ -2259,7 +2259,7 @@ gent_datareg(bool undefined_fill_value)
         dset2;   /* Dereferenced dataset ID */
     hid_t sid1,  /* Dataspace ID #1  */
         sid2;    /* Dataspace ID #2  */
-    hid_t dcpl_id = H5I_INVALID_HID;
+    hid_t            dcpl_id = H5I_INVALID_HID;
     hsize_t          dims1[] = {SPACE1_DIM1}, dims2[] = {SPACE2_DIM1, SPACE2_DIM2};
     hsize_t          start[SPACE2_RANK];                  /* Starting location of hyperslab */
     hsize_t          stride[SPACE2_RANK];                 /* Stride of hyperslab */
@@ -4120,8 +4120,8 @@ write_attr_in(hid_t loc_id, const char *dset_name, /* for saving reference to da
     /* create 3D attributes with dimension [4][3][2], 24 elements */
     hsize_t dims3[3]     = {4, 3, 2};
     char    buf13[24][2] = {
-        "ab", "cd", "ef", "gh", "ij", "kl", "mn", "pq", "rs", "tu", "vw", "xz", "AB",
-        "CD", "EF", "GH", "IJ", "KL", "MN", "PQ", "RS", "TU", "VW", "XZ"}; /* string, NO NUL fixed length */
+           "ab", "cd", "ef", "gh", "ij", "kl", "mn", "pq", "rs", "tu", "vw", "xz", "AB",
+           "CD", "EF", "GH", "IJ", "KL", "MN", "PQ", "RS", "TU", "VW", "XZ"}; /* string, NO NUL fixed length */
     char       buf23[4][3][2];                                                /* bitfield, opaque */
     s_t        buf33[4][3][2];                                                /* compound */
     hobj_ref_t buf43[4][3][2];                                                /* reference */
@@ -4578,8 +4578,8 @@ write_dset_in(hid_t loc_id, const char *dset_name, /* for saving reference to da
     /* create 3D attributes with dimension [4][3][2], 24 elements */
     hsize_t dims3[3]     = {4, 3, 2};
     char    buf13[24][2] = {
-        "ab", "cd", "ef", "gh", "ij", "kl", "mn", "pq", "rs", "tu", "vw", "xz", "AB",
-        "CD", "EF", "GH", "IJ", "KL", "MN", "PQ", "RS", "TU", "VW", "XZ"}; /* string, NO NUL fixed length */
+           "ab", "cd", "ef", "gh", "ij", "kl", "mn", "pq", "rs", "tu", "vw", "xz", "AB",
+           "CD", "EF", "GH", "IJ", "KL", "MN", "PQ", "RS", "TU", "VW", "XZ"}; /* string, NO NUL fixed length */
     char       buf23[4][3][2];                                                /* bitfield, opaque */
     s_t        buf33[4][3][2];                                                /* compound */
     hobj_ref_t buf43[4][3][2];                                                /* reference */
@@ -7441,31 +7441,31 @@ gent_packedbits(void)
 
     struct {
         uint8_t arr[F66_XDIM][F66_YDIM8];
-    } *dsetu8;
+    } * dsetu8;
     struct {
         uint16_t arr[F66_XDIM][F66_YDIM16];
-    } *dsetu16;
+    } * dsetu16;
     struct {
         uint32_t arr[F66_XDIM][F66_YDIM32];
-    } *dsetu32;
+    } * dsetu32;
     struct {
         uint64_t arr[F66_XDIM][F66_YDIM64];
-    } *dsetu64;
+    } * dsetu64;
     struct {
         int8_t arr[F66_XDIM][F66_YDIM8];
-    } *dset8;
+    } * dset8;
     struct {
         int16_t arr[F66_XDIM][F66_YDIM16];
-    } *dset16;
+    } * dset16;
     struct {
         int32_t arr[F66_XDIM][F66_YDIM32];
-    } *dset32;
+    } * dset32;
     struct {
         int64_t arr[F66_XDIM][F66_YDIM64];
-    } *dset64;
+    } * dset64;
     struct {
         double arr[F66_XDIM][F66_YDIM8];
-    } *dsetdbl;
+    } * dsetdbl;
 
     uint8_t  valu8bits;
     uint16_t valu16bits;
@@ -7684,31 +7684,31 @@ gent_attr_intsize(void)
 
     struct {
         uint8_t arr[F66_XDIM][F66_YDIM8];
-    } *dsetu8;
+    } * dsetu8;
     struct {
         uint16_t arr[F66_XDIM][F66_YDIM16];
-    } *dsetu16;
+    } * dsetu16;
     struct {
         uint32_t arr[F66_XDIM][F66_YDIM32];
-    } *dsetu32;
+    } * dsetu32;
     struct {
         uint64_t arr[F66_XDIM][F66_YDIM64];
-    } *dsetu64;
+    } * dsetu64;
     struct {
         int8_t arr[F66_XDIM][F66_YDIM8];
-    } *dset8;
+    } * dset8;
     struct {
         int16_t arr[F66_XDIM][F66_YDIM16];
-    } *dset16;
+    } * dset16;
     struct {
         int32_t arr[F66_XDIM][F66_YDIM32];
-    } *dset32;
+    } * dset32;
     struct {
         int64_t arr[F66_XDIM][F66_YDIM64];
-    } *dset64;
+    } * dset64;
     struct {
         double arr[F66_XDIM][F66_YDIM8];
-    } *dsetdbl;
+    } * dsetdbl;
 
     uint8_t  valu8bits;
     uint16_t valu16bits;
@@ -8023,8 +8023,8 @@ gent_charsets(void)
     hid_t       ascii_dtid   = H5Tcreate(H5T_STRING, H5T_VARIABLE);
     hid_t       utf8_dtid    = H5Tcreate(H5T_STRING, H5T_VARIABLE);
     const char *writeData[]  = {
-        "ascii",
-        "utf8",
+         "ascii",
+         "utf8",
     };
 
     sid    = H5Screate_simple(1, dim, NULL);
@@ -8799,31 +8799,31 @@ gent_intscalars(void)
 
     struct {
         uint8_t arr[F73_XDIM][F73_YDIM8];
-    } *dsetu8;
+    } * dsetu8;
     struct {
         uint16_t arr[F73_XDIM][F73_YDIM16];
-    } *dsetu16;
+    } * dsetu16;
     struct {
         uint32_t arr[F73_XDIM][F73_YDIM32];
-    } *dsetu32;
+    } * dsetu32;
     struct {
         uint64_t arr[F73_XDIM][F73_YDIM64];
-    } *dsetu64;
+    } * dsetu64;
     struct {
         int8_t arr[F73_XDIM][F73_YDIM8];
-    } *dset8;
+    } * dset8;
     struct {
         int16_t arr[F73_XDIM][F73_YDIM16];
-    } *dset16;
+    } * dset16;
     struct {
         int32_t arr[F73_XDIM][F73_YDIM32];
-    } *dset32;
+    } * dset32;
     struct {
         int64_t arr[F73_XDIM][F73_YDIM64];
-    } *dset64;
+    } * dset64;
     struct {
         double arr[F73_XDIM][F73_YDIM8];
-    } *dsetdbl;
+    } * dsetdbl;
 
     uint8_t  valu8bits;
     uint16_t valu16bits;
@@ -9060,31 +9060,31 @@ gent_attr_intscalars(void)
 
     struct {
         uint8_t arr[F73_XDIM][F73_YDIM8];
-    } *dsetu8;
+    } * dsetu8;
     struct {
         uint16_t arr[F73_XDIM][F73_YDIM16];
-    } *dsetu16;
+    } * dsetu16;
     struct {
         uint32_t arr[F73_XDIM][F73_YDIM32];
-    } *dsetu32;
+    } * dsetu32;
     struct {
         uint64_t arr[F73_XDIM][F73_YDIM64];
-    } *dsetu64;
+    } * dsetu64;
     struct {
         int8_t arr[F73_XDIM][F73_YDIM8];
-    } *dset8;
+    } * dset8;
     struct {
         int16_t arr[F73_XDIM][F73_YDIM16];
-    } *dset16;
+    } * dset16;
     struct {
         int32_t arr[F73_XDIM][F73_YDIM32];
-    } *dset32;
+    } * dset32;
     struct {
         int64_t arr[F73_XDIM][F73_YDIM64];
-    } *dset64;
+    } * dset64;
     struct {
         double arr[F73_XDIM][F73_YDIM8];
-    } *dsetdbl;
+    } * dsetdbl;
 
     uint8_t  valu8bits;
     uint16_t valu16bits;
@@ -10164,31 +10164,31 @@ gent_intsattrs(void)
 
     struct {
         uint8_t arr[F66_XDIM][F66_YDIM8];
-    } *dsetu8;
+    } * dsetu8;
     struct {
         uint16_t arr[F66_XDIM][F66_YDIM16];
-    } *dsetu16;
+    } * dsetu16;
     struct {
         uint32_t arr[F66_XDIM][F66_YDIM32];
-    } *dsetu32;
+    } * dsetu32;
     struct {
         uint64_t arr[F66_XDIM][F66_YDIM64];
-    } *dsetu64;
+    } * dsetu64;
     struct {
         int8_t arr[F66_XDIM][F66_YDIM8];
-    } *dset8;
+    } * dset8;
     struct {
         int16_t arr[F66_XDIM][F66_YDIM16];
-    } *dset16;
+    } * dset16;
     struct {
         int32_t arr[F66_XDIM][F66_YDIM32];
-    } *dset32;
+    } * dset32;
     struct {
         int64_t arr[F66_XDIM][F66_YDIM64];
-    } *dset64;
+    } * dset64;
     struct {
         double arr[F66_XDIM][F66_YDIM8];
-    } *dsetdbl;
+    } * dsetdbl;
 
     uint8_t  *asetu8  = NULL;
     uint16_t *asetu16 = NULL;
@@ -10524,13 +10524,13 @@ gent_floatsattrs(void)
 
     struct {
         float arr[F89_XDIM][F89_YDIM32];
-    } *dset32;
+    } * dset32;
     struct {
         double arr[F89_XDIM][F89_YDIM64];
-    } *dset64;
+    } * dset64;
     struct {
         long double arr[F89_XDIM][F89_YDIM128];
-    } *dset128;
+    } * dset128;
 
     float       *aset32  = NULL;
     double      *aset64  = NULL;
@@ -10834,7 +10834,7 @@ gent_intsfourdims(void)
     hsize_t dims[F81_RANK];
     struct {
         uint32_t arr[F81_ZDIM][F81_YDIM][F81_XDIM][F81_WDIM];
-    }           *dset1;
+    } * dset1;
     unsigned int i, j, k, l;
 
     fid = H5Fcreate(FILE81, H5F_ACC_TRUNC, H5P_DEFAULT, H5P_DEFAULT);
@@ -11075,7 +11075,7 @@ gent_compound_complex2(void)
                         buf[i].b[j] = (int)(j - i * 10);
                     for (j = 0; j < dset_array_c_dims[0]; j++)
                         for (k = 0; k < dset_array_c_dims[1]; k++)
-                            buf[i].c[j][k] = (float)(j + k + i * 10) + (float)(j) * 0.1F;
+                            buf[i].c[j][k] = (float)(j + k + i * 10) + (float)(j)*0.1F;
 
                     /* Set up first nested compound */
                     buf[i].d.nested_a = (double)i;
@@ -11588,14 +11588,14 @@ gent_onion_1d_dset(void)
     hid_t                   fapl_id    = H5I_INVALID_HID;
     struct onion_filepaths *paths      = NULL;
     H5FD_onion_fapl_info_t  onion_info = {
-        H5FD_ONION_FAPL_INFO_VERSION_CURR,
-        H5I_INVALID_HID,               /* backing_fapl_id  */
-        ONION_TEST_PAGE_SIZE,          /* page_size        */
-        H5FD_ONION_STORE_TARGET_ONION, /* store_target     */
-        H5FD_ONION_FAPL_INFO_REVISION_ID_LATEST,
-        0,               /* force_write_open */
-        0,               /* creation flags, was H5FD_ONION_FAPL_INFO_CREATE_FLAG_ENABLE_PAGE_ALIGNMENT */
-        "initial commit" /* comment          */
+         H5FD_ONION_FAPL_INFO_VERSION_CURR,
+         H5I_INVALID_HID,               /* backing_fapl_id  */
+         ONION_TEST_PAGE_SIZE,          /* page_size        */
+         H5FD_ONION_STORE_TARGET_ONION, /* store_target     */
+         H5FD_ONION_FAPL_INFO_REVISION_ID_LATEST,
+         0,               /* force_write_open */
+         0,               /* creation flags, was H5FD_ONION_FAPL_INFO_CREATE_FLAG_ENABLE_PAGE_ALIGNMENT */
+         "initial commit" /* comment          */
     };
     hsize_t dims[2]    = {1, ONE_DIM_SIZE};
     hsize_t maxdims[2] = {1, ONE_DIM_SIZE};
@@ -12017,14 +12017,14 @@ gent_onion_dset_extension(void)
     hid_t                   dcpl       = H5I_INVALID_HID;
     struct onion_filepaths *paths      = NULL;
     H5FD_onion_fapl_info_t  onion_info = {
-        H5FD_ONION_FAPL_INFO_VERSION_CURR,
-        H5I_INVALID_HID,               /* backing_fapl_id  */
-        ONION_TEST_PAGE_SIZE,          /* page_size        */
-        H5FD_ONION_STORE_TARGET_ONION, /* store_target     */
-        H5FD_ONION_FAPL_INFO_REVISION_ID_LATEST,
-        0,               /* force_write_open */
-        0,               /* creation flags, was H5FD_ONION_FAPL_INFO_CREATE_FLAG_ENABLE_PAGE_ALIGNMENT */
-        "initial commit" /* comment          */
+         H5FD_ONION_FAPL_INFO_VERSION_CURR,
+         H5I_INVALID_HID,               /* backing_fapl_id  */
+         ONION_TEST_PAGE_SIZE,          /* page_size        */
+         H5FD_ONION_STORE_TARGET_ONION, /* store_target     */
+         H5FD_ONION_FAPL_INFO_REVISION_ID_LATEST,
+         0,               /* force_write_open */
+         0,               /* creation flags, was H5FD_ONION_FAPL_INFO_CREATE_FLAG_ENABLE_PAGE_ALIGNMENT */
+         "initial commit" /* comment          */
     };
     hsize_t dims[2]    = {4, 4};
     hsize_t maxdims[2] = {H5S_UNLIMITED, H5S_UNLIMITED};
@@ -12205,7 +12205,7 @@ gent_float16(void)
 
     struct {
         H5__Float16 arr[F93_XDIM][F93_YDIM];
-    } *dset16;
+    } * dset16;
 
     H5__Float16 *aset16 = NULL;
     H5__Float16  val16bits;
@@ -12275,7 +12275,7 @@ gent_float16_be(void)
 
     struct {
         H5__Float16 arr[F94_XDIM][F94_YDIM];
-    } *dset16;
+    } * dset16;
 
     H5__Float16 *aset16 = NULL;
     H5__Float16  val16bits;
@@ -12359,19 +12359,19 @@ gent_complex(void)
 
     struct {
         H5_float_complex arr[F95_XDIM][F95_YDIM];
-    } *dset_fc;
+    } * dset_fc;
 
     struct {
         H5_double_complex arr[F95_XDIM][F95_YDIM];
-    } *dset_dc;
+    } * dset_dc;
 
     struct {
         H5_ldouble_complex arr[F95_XDIM][F95_YDIM];
-    } *dset_ldc;
+    } * dset_ldc;
 
     struct {
         hvl_t arr[F95_XDIM];
-    } *dset_var_fc;
+    } * dset_var_fc;
 
     fid = H5Fcreate(FILE95, H5F_ACC_TRUNC, H5P_DEFAULT, H5P_DEFAULT);
 
@@ -12622,19 +12622,19 @@ gent_complex_be(void)
 
     struct {
         H5_float_complex arr[F96_XDIM][F96_YDIM];
-    } *dset_fc;
+    } * dset_fc;
 
     struct {
         H5_double_complex arr[F96_XDIM][F96_YDIM];
-    } *dset_dc;
+    } * dset_dc;
 
     struct {
         H5_ldouble_complex arr[F96_XDIM][F96_YDIM];
-    } *dset_ldc;
+    } * dset_ldc;
 
     struct {
         hvl_t arr[F96_XDIM];
-    } *dset_var_fc;
+    } * dset_var_fc;
 
     fid = H5Fcreate(FILE96, H5F_ACC_TRUNC, H5P_DEFAULT, H5P_DEFAULT);
 

--- a/tools/test/h5dump/h5dumpgentest.c
+++ b/tools/test/h5dump/h5dumpgentest.c
@@ -4120,8 +4120,8 @@ write_attr_in(hid_t loc_id, const char *dset_name, /* for saving reference to da
     /* create 3D attributes with dimension [4][3][2], 24 elements */
     hsize_t dims3[3]     = {4, 3, 2};
     char    buf13[24][2] = {
-           "ab", "cd", "ef", "gh", "ij", "kl", "mn", "pq", "rs", "tu", "vw", "xz", "AB",
-           "CD", "EF", "GH", "IJ", "KL", "MN", "PQ", "RS", "TU", "VW", "XZ"}; /* string, NO NUL fixed length */
+        "ab", "cd", "ef", "gh", "ij", "kl", "mn", "pq", "rs", "tu", "vw", "xz", "AB",
+        "CD", "EF", "GH", "IJ", "KL", "MN", "PQ", "RS", "TU", "VW", "XZ"}; /* string, NO NUL fixed length */
     char       buf23[4][3][2];                                                /* bitfield, opaque */
     s_t        buf33[4][3][2];                                                /* compound */
     hobj_ref_t buf43[4][3][2];                                                /* reference */
@@ -4578,8 +4578,8 @@ write_dset_in(hid_t loc_id, const char *dset_name, /* for saving reference to da
     /* create 3D attributes with dimension [4][3][2], 24 elements */
     hsize_t dims3[3]     = {4, 3, 2};
     char    buf13[24][2] = {
-           "ab", "cd", "ef", "gh", "ij", "kl", "mn", "pq", "rs", "tu", "vw", "xz", "AB",
-           "CD", "EF", "GH", "IJ", "KL", "MN", "PQ", "RS", "TU", "VW", "XZ"}; /* string, NO NUL fixed length */
+        "ab", "cd", "ef", "gh", "ij", "kl", "mn", "pq", "rs", "tu", "vw", "xz", "AB",
+        "CD", "EF", "GH", "IJ", "KL", "MN", "PQ", "RS", "TU", "VW", "XZ"}; /* string, NO NUL fixed length */
     char       buf23[4][3][2];                                                /* bitfield, opaque */
     s_t        buf33[4][3][2];                                                /* compound */
     hobj_ref_t buf43[4][3][2];                                                /* reference */
@@ -7441,31 +7441,31 @@ gent_packedbits(void)
 
     struct {
         uint8_t arr[F66_XDIM][F66_YDIM8];
-    } * dsetu8;
+    } *dsetu8;
     struct {
         uint16_t arr[F66_XDIM][F66_YDIM16];
-    } * dsetu16;
+    } *dsetu16;
     struct {
         uint32_t arr[F66_XDIM][F66_YDIM32];
-    } * dsetu32;
+    } *dsetu32;
     struct {
         uint64_t arr[F66_XDIM][F66_YDIM64];
-    } * dsetu64;
+    } *dsetu64;
     struct {
         int8_t arr[F66_XDIM][F66_YDIM8];
-    } * dset8;
+    } *dset8;
     struct {
         int16_t arr[F66_XDIM][F66_YDIM16];
-    } * dset16;
+    } *dset16;
     struct {
         int32_t arr[F66_XDIM][F66_YDIM32];
-    } * dset32;
+    } *dset32;
     struct {
         int64_t arr[F66_XDIM][F66_YDIM64];
-    } * dset64;
+    } *dset64;
     struct {
         double arr[F66_XDIM][F66_YDIM8];
-    } * dsetdbl;
+    } *dsetdbl;
 
     uint8_t  valu8bits;
     uint16_t valu16bits;
@@ -7684,31 +7684,31 @@ gent_attr_intsize(void)
 
     struct {
         uint8_t arr[F66_XDIM][F66_YDIM8];
-    } * dsetu8;
+    } *dsetu8;
     struct {
         uint16_t arr[F66_XDIM][F66_YDIM16];
-    } * dsetu16;
+    } *dsetu16;
     struct {
         uint32_t arr[F66_XDIM][F66_YDIM32];
-    } * dsetu32;
+    } *dsetu32;
     struct {
         uint64_t arr[F66_XDIM][F66_YDIM64];
-    } * dsetu64;
+    } *dsetu64;
     struct {
         int8_t arr[F66_XDIM][F66_YDIM8];
-    } * dset8;
+    } *dset8;
     struct {
         int16_t arr[F66_XDIM][F66_YDIM16];
-    } * dset16;
+    } *dset16;
     struct {
         int32_t arr[F66_XDIM][F66_YDIM32];
-    } * dset32;
+    } *dset32;
     struct {
         int64_t arr[F66_XDIM][F66_YDIM64];
-    } * dset64;
+    } *dset64;
     struct {
         double arr[F66_XDIM][F66_YDIM8];
-    } * dsetdbl;
+    } *dsetdbl;
 
     uint8_t  valu8bits;
     uint16_t valu16bits;
@@ -8023,8 +8023,8 @@ gent_charsets(void)
     hid_t       ascii_dtid   = H5Tcreate(H5T_STRING, H5T_VARIABLE);
     hid_t       utf8_dtid    = H5Tcreate(H5T_STRING, H5T_VARIABLE);
     const char *writeData[]  = {
-         "ascii",
-         "utf8",
+        "ascii",
+        "utf8",
     };
 
     sid    = H5Screate_simple(1, dim, NULL);
@@ -8799,31 +8799,31 @@ gent_intscalars(void)
 
     struct {
         uint8_t arr[F73_XDIM][F73_YDIM8];
-    } * dsetu8;
+    } *dsetu8;
     struct {
         uint16_t arr[F73_XDIM][F73_YDIM16];
-    } * dsetu16;
+    } *dsetu16;
     struct {
         uint32_t arr[F73_XDIM][F73_YDIM32];
-    } * dsetu32;
+    } *dsetu32;
     struct {
         uint64_t arr[F73_XDIM][F73_YDIM64];
-    } * dsetu64;
+    } *dsetu64;
     struct {
         int8_t arr[F73_XDIM][F73_YDIM8];
-    } * dset8;
+    } *dset8;
     struct {
         int16_t arr[F73_XDIM][F73_YDIM16];
-    } * dset16;
+    } *dset16;
     struct {
         int32_t arr[F73_XDIM][F73_YDIM32];
-    } * dset32;
+    } *dset32;
     struct {
         int64_t arr[F73_XDIM][F73_YDIM64];
-    } * dset64;
+    } *dset64;
     struct {
         double arr[F73_XDIM][F73_YDIM8];
-    } * dsetdbl;
+    } *dsetdbl;
 
     uint8_t  valu8bits;
     uint16_t valu16bits;
@@ -9060,31 +9060,31 @@ gent_attr_intscalars(void)
 
     struct {
         uint8_t arr[F73_XDIM][F73_YDIM8];
-    } * dsetu8;
+    } *dsetu8;
     struct {
         uint16_t arr[F73_XDIM][F73_YDIM16];
-    } * dsetu16;
+    } *dsetu16;
     struct {
         uint32_t arr[F73_XDIM][F73_YDIM32];
-    } * dsetu32;
+    } *dsetu32;
     struct {
         uint64_t arr[F73_XDIM][F73_YDIM64];
-    } * dsetu64;
+    } *dsetu64;
     struct {
         int8_t arr[F73_XDIM][F73_YDIM8];
-    } * dset8;
+    } *dset8;
     struct {
         int16_t arr[F73_XDIM][F73_YDIM16];
-    } * dset16;
+    } *dset16;
     struct {
         int32_t arr[F73_XDIM][F73_YDIM32];
-    } * dset32;
+    } *dset32;
     struct {
         int64_t arr[F73_XDIM][F73_YDIM64];
-    } * dset64;
+    } *dset64;
     struct {
         double arr[F73_XDIM][F73_YDIM8];
-    } * dsetdbl;
+    } *dsetdbl;
 
     uint8_t  valu8bits;
     uint16_t valu16bits;
@@ -10164,31 +10164,31 @@ gent_intsattrs(void)
 
     struct {
         uint8_t arr[F66_XDIM][F66_YDIM8];
-    } * dsetu8;
+    } *dsetu8;
     struct {
         uint16_t arr[F66_XDIM][F66_YDIM16];
-    } * dsetu16;
+    } *dsetu16;
     struct {
         uint32_t arr[F66_XDIM][F66_YDIM32];
-    } * dsetu32;
+    } *dsetu32;
     struct {
         uint64_t arr[F66_XDIM][F66_YDIM64];
-    } * dsetu64;
+    } *dsetu64;
     struct {
         int8_t arr[F66_XDIM][F66_YDIM8];
-    } * dset8;
+    } *dset8;
     struct {
         int16_t arr[F66_XDIM][F66_YDIM16];
-    } * dset16;
+    } *dset16;
     struct {
         int32_t arr[F66_XDIM][F66_YDIM32];
-    } * dset32;
+    } *dset32;
     struct {
         int64_t arr[F66_XDIM][F66_YDIM64];
-    } * dset64;
+    } *dset64;
     struct {
         double arr[F66_XDIM][F66_YDIM8];
-    } * dsetdbl;
+    } *dsetdbl;
 
     uint8_t  *asetu8  = NULL;
     uint16_t *asetu16 = NULL;
@@ -10524,13 +10524,13 @@ gent_floatsattrs(void)
 
     struct {
         float arr[F89_XDIM][F89_YDIM32];
-    } * dset32;
+    } *dset32;
     struct {
         double arr[F89_XDIM][F89_YDIM64];
-    } * dset64;
+    } *dset64;
     struct {
         long double arr[F89_XDIM][F89_YDIM128];
-    } * dset128;
+    } *dset128;
 
     float       *aset32  = NULL;
     double      *aset64  = NULL;
@@ -10834,7 +10834,7 @@ gent_intsfourdims(void)
     hsize_t dims[F81_RANK];
     struct {
         uint32_t arr[F81_ZDIM][F81_YDIM][F81_XDIM][F81_WDIM];
-    } * dset1;
+    }           *dset1;
     unsigned int i, j, k, l;
 
     fid = H5Fcreate(FILE81, H5F_ACC_TRUNC, H5P_DEFAULT, H5P_DEFAULT);
@@ -11075,7 +11075,7 @@ gent_compound_complex2(void)
                         buf[i].b[j] = (int)(j - i * 10);
                     for (j = 0; j < dset_array_c_dims[0]; j++)
                         for (k = 0; k < dset_array_c_dims[1]; k++)
-                            buf[i].c[j][k] = (float)(j + k + i * 10) + (float)(j)*0.1F;
+                            buf[i].c[j][k] = (float)(j + k + i * 10) + (float)(j) * 0.1F;
 
                     /* Set up first nested compound */
                     buf[i].d.nested_a = (double)i;
@@ -11588,14 +11588,14 @@ gent_onion_1d_dset(void)
     hid_t                   fapl_id    = H5I_INVALID_HID;
     struct onion_filepaths *paths      = NULL;
     H5FD_onion_fapl_info_t  onion_info = {
-         H5FD_ONION_FAPL_INFO_VERSION_CURR,
-         H5I_INVALID_HID,               /* backing_fapl_id  */
-         ONION_TEST_PAGE_SIZE,          /* page_size        */
-         H5FD_ONION_STORE_TARGET_ONION, /* store_target     */
-         H5FD_ONION_FAPL_INFO_REVISION_ID_LATEST,
-         0,               /* force_write_open */
-         0,               /* creation flags, was H5FD_ONION_FAPL_INFO_CREATE_FLAG_ENABLE_PAGE_ALIGNMENT */
-         "initial commit" /* comment          */
+        H5FD_ONION_FAPL_INFO_VERSION_CURR,
+        H5I_INVALID_HID,               /* backing_fapl_id  */
+        ONION_TEST_PAGE_SIZE,          /* page_size        */
+        H5FD_ONION_STORE_TARGET_ONION, /* store_target     */
+        H5FD_ONION_FAPL_INFO_REVISION_ID_LATEST,
+        0,               /* force_write_open */
+        0,               /* creation flags, was H5FD_ONION_FAPL_INFO_CREATE_FLAG_ENABLE_PAGE_ALIGNMENT */
+        "initial commit" /* comment          */
     };
     hsize_t dims[2]    = {1, ONE_DIM_SIZE};
     hsize_t maxdims[2] = {1, ONE_DIM_SIZE};
@@ -12017,14 +12017,14 @@ gent_onion_dset_extension(void)
     hid_t                   dcpl       = H5I_INVALID_HID;
     struct onion_filepaths *paths      = NULL;
     H5FD_onion_fapl_info_t  onion_info = {
-         H5FD_ONION_FAPL_INFO_VERSION_CURR,
-         H5I_INVALID_HID,               /* backing_fapl_id  */
-         ONION_TEST_PAGE_SIZE,          /* page_size        */
-         H5FD_ONION_STORE_TARGET_ONION, /* store_target     */
-         H5FD_ONION_FAPL_INFO_REVISION_ID_LATEST,
-         0,               /* force_write_open */
-         0,               /* creation flags, was H5FD_ONION_FAPL_INFO_CREATE_FLAG_ENABLE_PAGE_ALIGNMENT */
-         "initial commit" /* comment          */
+        H5FD_ONION_FAPL_INFO_VERSION_CURR,
+        H5I_INVALID_HID,               /* backing_fapl_id  */
+        ONION_TEST_PAGE_SIZE,          /* page_size        */
+        H5FD_ONION_STORE_TARGET_ONION, /* store_target     */
+        H5FD_ONION_FAPL_INFO_REVISION_ID_LATEST,
+        0,               /* force_write_open */
+        0,               /* creation flags, was H5FD_ONION_FAPL_INFO_CREATE_FLAG_ENABLE_PAGE_ALIGNMENT */
+        "initial commit" /* comment          */
     };
     hsize_t dims[2]    = {4, 4};
     hsize_t maxdims[2] = {H5S_UNLIMITED, H5S_UNLIMITED};
@@ -12205,7 +12205,7 @@ gent_float16(void)
 
     struct {
         H5__Float16 arr[F93_XDIM][F93_YDIM];
-    } * dset16;
+    } *dset16;
 
     H5__Float16 *aset16 = NULL;
     H5__Float16  val16bits;
@@ -12275,7 +12275,7 @@ gent_float16_be(void)
 
     struct {
         H5__Float16 arr[F94_XDIM][F94_YDIM];
-    } * dset16;
+    } *dset16;
 
     H5__Float16 *aset16 = NULL;
     H5__Float16  val16bits;
@@ -12359,19 +12359,19 @@ gent_complex(void)
 
     struct {
         H5_float_complex arr[F95_XDIM][F95_YDIM];
-    } * dset_fc;
+    } *dset_fc;
 
     struct {
         H5_double_complex arr[F95_XDIM][F95_YDIM];
-    } * dset_dc;
+    } *dset_dc;
 
     struct {
         H5_ldouble_complex arr[F95_XDIM][F95_YDIM];
-    } * dset_ldc;
+    } *dset_ldc;
 
     struct {
         hvl_t arr[F95_XDIM];
-    } * dset_var_fc;
+    } *dset_var_fc;
 
     fid = H5Fcreate(FILE95, H5F_ACC_TRUNC, H5P_DEFAULT, H5P_DEFAULT);
 
@@ -12622,19 +12622,19 @@ gent_complex_be(void)
 
     struct {
         H5_float_complex arr[F96_XDIM][F96_YDIM];
-    } * dset_fc;
+    } *dset_fc;
 
     struct {
         H5_double_complex arr[F96_XDIM][F96_YDIM];
-    } * dset_dc;
+    } *dset_dc;
 
     struct {
         H5_ldouble_complex arr[F96_XDIM][F96_YDIM];
-    } * dset_ldc;
+    } *dset_ldc;
 
     struct {
         hvl_t arr[F96_XDIM];
-    } * dset_var_fc;
+    } *dset_var_fc;
 
     fid = H5Fcreate(FILE96, H5F_ACC_TRUNC, H5P_DEFAULT, H5P_DEFAULT);
 

--- a/tools/test/h5dump/h5dumpgentest.c
+++ b/tools/test/h5dump/h5dumpgentest.c
@@ -686,10 +686,11 @@ gent_softlink(void)
 #define NX 4
 #define NY 2
 int
-gent_softlink2(void)
+gent_softlink2(bool big_endian_committed)
 {
     hid_t   fileid1 = H5I_INVALID_HID;
     hid_t   gid1 = H5I_INVALID_HID, gid2 = H5I_INVALID_HID;
+    hid_t   target_type = H5I_INVALID_HID;
     hid_t   datatype = H5I_INVALID_HID;
     hid_t   dset1 = H5I_INVALID_HID, dset2 = H5I_INVALID_HID;
     hid_t   dataspace = H5I_INVALID_HID;
@@ -729,7 +730,14 @@ gent_softlink2(void)
     /*-----------------------------------------------------------------------
      * Named datatype
      *------------------------------------------------------------------------*/
-    datatype = H5Tcopy(H5T_NATIVE_INT);
+    if (big_endian_committed) {
+        target_type = H5T_STD_I32BE;
+    } else {
+        target_type = H5T_NATIVE_INT;
+    }
+    
+    datatype = H5Tcopy(target_type);
+
     status   = H5Tcommit2(fileid1, "dtype", datatype, H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT);
     if (status < 0) {
         fprintf(stderr, "Error: %s> H5Tcommit2 failed.\n", FILE4_1);
@@ -748,13 +756,10 @@ gent_softlink2(void)
     dimsf[1]  = NY;
     dataspace = H5Screate_simple(2, dimsf, NULL);
 
-    /*
-     * We will store little endian INT numbers.
-     */
-
     /*---------------
      * dset1
      */
+
     /* Create a new dataset as sample object */
     dset1 = H5Dcreate2(fileid1, "/dset1", H5T_STD_I32BE, dataspace, H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT);
     if (dset1 < 0) {
@@ -774,14 +779,14 @@ gent_softlink2(void)
      * dset2
      */
     /* Create a new dataset as sample object */
-    dset2 = H5Dcreate2(fileid1, "/dset2", H5T_NATIVE_INT, dataspace, H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT);
+    dset2 = H5Dcreate2(fileid1, "/dset2", target_type, dataspace, H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT);
     if (dset2 < 0) {
         fprintf(stderr, "Error: %s> H5Dcreate2 failed.\n", FILE4_1);
         status = FAIL;
         goto out;
     }
 
-    status = H5Dwrite(dset2, H5T_NATIVE_INT, H5S_ALL, H5S_ALL, H5P_DEFAULT, data2);
+    status = H5Dwrite(dset2, target_type, H5S_ALL, H5S_ALL, H5P_DEFAULT, data2);
     if (status < 0) {
         fprintf(stderr, "Error: %s> H5Dwrite failed.\n", FILE4_1);
         status = FAIL;

--- a/tools/test/h5dump/h5dumpgentest.c
+++ b/tools/test/h5dump/h5dumpgentest.c
@@ -730,12 +730,19 @@ gent_softlink2(bool big_endian_committed)
     /*-----------------------------------------------------------------------
      * Named datatype
      *------------------------------------------------------------------------*/
-    if (big_endian_committed) {
-        target_type = H5T_STD_I32BE;
-    } else {
-        target_type = H5T_NATIVE_INT;
+    if ((target_type = H5Tcopy(H5T_NATIVE_INT)) < 0) {
+        fprintf(stderr, "Error: %s> H5Tcopy failed.\n", FILE4_1);
+        status = FAIL;
+        goto out;
     }
-    
+
+    if (big_endian_committed) {
+        if (H5Tset_order(target_type, H5T_ORDER_BE) < 0) {
+            status = FAIL;
+            goto out;
+        }
+    }
+
     datatype = H5Tcopy(target_type);
 
     status   = H5Tcommit2(fileid1, "dtype", datatype, H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT);

--- a/tools/test/h5dump/h5dumpgentest.h
+++ b/tools/test/h5dump/h5dumpgentest.h
@@ -37,7 +37,7 @@ void gent_str(void);
 void gent_str2(void);
 void gent_enum(void);
 void gent_objref(void);
-void gent_datareg(void);
+void gent_datareg(bool undefined_fill_value);
 void gent_attrreg(void);
 void gent_nestcomp(void);
 void gent_opaque(void);

--- a/tools/test/h5dump/h5dumpgentest.h
+++ b/tools/test/h5dump/h5dumpgentest.h
@@ -22,7 +22,7 @@ void gent_dataset(void);
 void gent_dataset2(void);
 void gent_attribute(void);
 void gent_softlink(void);
-int  gent_softlink2(void);
+int  gent_softlink2(bool big_endian_committed);
 void gent_hardlink(void);
 void gent_extlink(void);
 void gent_udlink(void);

--- a/tools/test/h5gentest.c
+++ b/tools/test/h5gentest.c
@@ -342,7 +342,25 @@ gen_h5repack_files(void)
         nerrors += (generate_f32le(external) < 0 ? 1 : 0);
     } /* end for external data storage or not */
 
+    Test_Extlink_Copy();
+
+    gent_group_creation_order();
+
+    gent_extlink();
+    gent_extlinks();
+    gent_softlink2();
+    gent_attrreg();
+    gent_datareg();
+    gent_family();
+
+    nerrors += (gent_onion_1d_dset() < 0 ? 1 : 0);
+    nerrors += (gent_onion_create_delete_objects() < 0 ? 1 : 0);
+    nerrors += (gent_onion_dset_extension() < 0 ? 1 : 0);
+
     nerrors += (make_h5repack_testfiles() < 0 ? 1 : 0);
+    nerrors += (gen_filespaces() < 0 ? 1 : 0);
+
+    nerrors += (test_attributes(H5DIFF_FILE5, 0) < 0 ? 1 : 0);
     return nerrors;
 }
 

--- a/tools/test/h5gentest.c
+++ b/tools/test/h5gentest.c
@@ -155,7 +155,7 @@ gen_h5dump_files(void)
     gent_group();
     gent_attribute();
     gent_softlink();
-    nerrors += (gent_softlink2() < 0 ? 1 : 0);
+    nerrors += (gent_softlink2(false) < 0 ? 1 : 0);
     gent_dataset();
     gent_hardlink();
     gent_extlink();
@@ -348,7 +348,7 @@ gen_h5repack_files(void)
 
     gent_extlink();
     gent_extlinks();
-    gent_softlink2();
+    gent_softlink2(true);
     gent_attrreg();
     gent_datareg(true);
     gent_family();
@@ -423,7 +423,7 @@ gen_h5ls_files(void)
     gent_group();
     gent_dataset();
     gent_softlink();
-    gent_softlink2();
+    gent_softlink2(false);
     gent_str();
 
     gent_vldatatypes();

--- a/tools/test/h5gentest.c
+++ b/tools/test/h5gentest.c
@@ -171,7 +171,7 @@ gen_h5dump_files(void)
     gent_str2();
     gent_enum();
     gent_objref();
-    gent_datareg();
+    gent_datareg(false);
     gent_attrreg();
     gent_nestcomp();
     gent_opaque();
@@ -350,7 +350,7 @@ gen_h5repack_files(void)
     gent_extlinks();
     gent_softlink2();
     gent_attrreg();
-    gent_datareg();
+    gent_datareg(true);
     gent_family();
 
     nerrors += (gent_onion_1d_dset() < 0 ? 1 : 0);
@@ -428,7 +428,7 @@ gen_h5ls_files(void)
 
     gent_vldatatypes();
     gent_compound_dt();
-    gent_datareg();
+    gent_datareg(false);
     gent_empty();
     gent_hardlink();
     gent_loop();

--- a/tools/test/h5repack/h5repackgentest.c
+++ b/tools/test/h5repack/h5repackgentest.c
@@ -2594,8 +2594,8 @@ write_dset_in(hid_t loc_id, const char *dset_name, /* for saving reference to da
     hsize_t dims3[3]     = {4, 3, 2};
     hsize_t dims3r[3]    = {1, 1, 1};
     char    buf13[24][2] = {
-           "ab", "cd", "ef", "gh", "ij", "kl", "mn", "pq", "rs", "tu", "vw", "xz", "AB",
-           "CD", "EF", "GH", "IJ", "KL", "MN", "PQ", "RS", "TU", "VW", "XZ"}; /* string, NO NUL fixed length */
+        "ab", "cd", "ef", "gh", "ij", "kl", "mn", "pq", "rs", "tu", "vw", "xz", "AB",
+        "CD", "EF", "GH", "IJ", "KL", "MN", "PQ", "RS", "TU", "VW", "XZ"}; /* string, NO NUL fixed length */
     char       buf23[4][3][2];                                                /* bitfield, opaque */
     s_t        buf33[4][3][2];                                                /* compound */
     hobj_ref_t buf43[1][1][1];                                                /* reference */
@@ -3485,8 +3485,8 @@ write_attr_in(hid_t loc_id, const char *dset_name, /* for saving reference to da
     /* create 3D attributes with dimension [4][3][2], 24 elements */
     hsize_t dims3[3]     = {4, 3, 2};
     char    buf13[24][2] = {
-           "ab", "cd", "ef", "gh", "ij", "kl", "mn", "pq", "rs", "tu", "vw", "xz", "AB",
-           "CD", "EF", "GH", "IJ", "KL", "MN", "PQ", "RS", "TU", "VW", "XZ"}; /* string, NO NUL fixed length */
+        "ab", "cd", "ef", "gh", "ij", "kl", "mn", "pq", "rs", "tu", "vw", "xz", "AB",
+        "CD", "EF", "GH", "IJ", "KL", "MN", "PQ", "RS", "TU", "VW", "XZ"}; /* string, NO NUL fixed length */
     char       buf23[4][3][2];                                                /* bitfield, opaque */
     s_t        buf33[4][3][2];                                                /* compound */
     hobj_ref_t buf43[4][3][2];                                                /* reference */
@@ -5405,9 +5405,9 @@ make_complex_attr_references(hid_t loc_id)
     hid_t   objgid = 0, objdid = 0, objtid = 0, objsid = 0;
     hsize_t obj_dims[RANK_OBJ]           = {DIM0_OBJ, DIM1_OBJ};
     int     obj_data[DIM0_OBJ][DIM1_OBJ] = {
-            {0, 1, 2, 3, 4, 5, 6, 7, 8, 9},           {10, 11, 12, 13, 14, 15, 16, 17, 18, 19},
-            {20, 21, 22, 23, 24, 25, 26, 27, 28, 29}, {30, 31, 32, 33, 34, 35, 36, 37, 38, 39},
-            {40, 41, 42, 43, 44, 45, 46, 47, 48, 49}, {50, 51, 52, 53, 54, 55, 56, 57, 58, 59}};
+        {0, 1, 2, 3, 4, 5, 6, 7, 8, 9},           {10, 11, 12, 13, 14, 15, 16, 17, 18, 19},
+        {20, 21, 22, 23, 24, 25, 26, 27, 28, 29}, {30, 31, 32, 33, 34, 35, 36, 37, 38, 39},
+        {40, 41, 42, 43, 44, 45, 46, 47, 48, 49}, {50, 51, 52, 53, 54, 55, 56, 57, 58, 59}};
 
     /*
      * group main

--- a/tools/test/h5repack/h5repackgentest.c
+++ b/tools/test/h5repack/h5repackgentest.c
@@ -26,6 +26,20 @@
 #define FILE_UINT8BE   "h5repack_uint8be"
 #define FILE_F32LE     "h5repack_f32le"
 
+#define NELMTS(X) (sizeof(X) / sizeof(X[0])) /* # of elements */
+
+const char *FILENAMES[] = {
+    "h5repack_fsm_aggr_nopersist.h5", /* H5F_FSPACE_STRATEGY_FSM_AGGR + not persisting free-space */
+    "h5repack_fsm_aggr_persist.h5",   /* H5F_FSPACE_STRATEGY_FSM_AGGR + persisting free-space */
+    "h5repack_paged_nopersist.h5",    /* H5F_FSPACE_STRATEGY_PAGE + not persisting free-space */
+    "h5repack_paged_persist.h5",      /* H5F_FSPACE_STRATEGY_PAGE + persisting free-space */
+    "h5repack_aggr.h5",               /* H5F_FSPACE_STRATEGY_AGGR */
+    "h5repack_none.h5"                /* H5F_FSPACE_STRATEGY_NONE */
+};
+
+#define NUM_ELMTS 100
+
+
 #define H5REPACKGENTEST_OOPS                                                                                 \
     {                                                                                                        \
         ret_value = -1;                                                                                      \
@@ -5760,4 +5774,78 @@ out:
         H5Tclose(vlen_regref_attr_tid);
 
     return ret;
+}
+
+int gen_filespaces(void)
+{
+    hid_t                 fid  = H5I_INVALID_HID; /* File ID */
+    hid_t                 fcpl = H5I_INVALID_HID; /* File creation property list */
+    hid_t                 did  = H5I_INVALID_HID; /* Dataset ID */
+    hid_t                 sid  = H5I_INVALID_HID; /* Dataspace ID */
+    hsize_t               dim[1];                 /* Dimension sizes */
+    int                   data[NUM_ELMTS];        /* Buffer for data */
+    int                   i, j;                   /* Local index variables */
+    H5F_fspace_strategy_t fs_strategy;            /* File space handling strategy */
+    unsigned              fs_persist;             /* Persisting free-space or not */
+
+    j = 0;
+    for (fs_strategy = H5F_FSPACE_STRATEGY_FSM_AGGR; fs_strategy < H5F_FSPACE_STRATEGY_NTYPES;
+         fs_strategy++) {
+        for (fs_persist = false; fs_persist <= true; fs_persist++) {
+
+            if (fs_persist && fs_strategy >= H5F_FSPACE_STRATEGY_AGGR)
+                continue;
+
+            /* Get a copy of the default file creation property */
+            if ((fcpl = H5Pcreate(H5P_FILE_CREATE)) < 0)
+                goto error;
+
+            if (H5Pset_file_space_strategy(fcpl, fs_strategy, fs_persist, (hsize_t)1) < 0)
+                goto error;
+
+            /* Create the file with the file space info */
+            if ((fid = H5Fcreate(FILENAMES[j], H5F_ACC_TRUNC, fcpl, H5P_DEFAULT)) < 0)
+                goto error;
+
+            /* Create the dataset */
+            dim[0] = NUM_ELMTS;
+            if ((sid = H5Screate_simple(1, dim, NULL)) < 0)
+                goto error;
+            if ((did = H5Dcreate2(fid, "dset", H5T_NATIVE_INT, sid, H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT)) <
+                0)
+                goto error;
+
+            for (i = 0; i < NUM_ELMTS; i++)
+                data[i] = i;
+
+            /* Write the dataset */
+            if (H5Dwrite(did, H5T_NATIVE_INT, H5S_ALL, H5S_ALL, H5P_DEFAULT, data) < 0)
+                goto error;
+
+            /* Closing */
+            if (H5Dclose(did) < 0)
+                goto error;
+            if (H5Sclose(sid) < 0)
+                goto error;
+            if (H5Fclose(fid) < 0)
+                goto error;
+            if (H5Pclose(fcpl) < 0)
+                goto error;
+            ++j;
+        }
+    }
+    assert(j == NELMTS(FILENAMES));
+
+    return 0;
+
+error:
+    H5E_BEGIN_TRY
+    {
+        H5Sclose(sid);
+        H5Sclose(did);
+        H5Pclose(fcpl);
+        H5Fclose(fid);
+    }
+    H5E_END_TRY
+    return -1;
 }

--- a/tools/test/h5repack/h5repackgentest.c
+++ b/tools/test/h5repack/h5repackgentest.c
@@ -39,7 +39,6 @@ const char *FILENAMES[] = {
 
 #define NUM_ELMTS 100
 
-
 #define H5REPACKGENTEST_OOPS                                                                                 \
     {                                                                                                        \
         ret_value = -1;                                                                                      \
@@ -2595,8 +2594,8 @@ write_dset_in(hid_t loc_id, const char *dset_name, /* for saving reference to da
     hsize_t dims3[3]     = {4, 3, 2};
     hsize_t dims3r[3]    = {1, 1, 1};
     char    buf13[24][2] = {
-        "ab", "cd", "ef", "gh", "ij", "kl", "mn", "pq", "rs", "tu", "vw", "xz", "AB",
-        "CD", "EF", "GH", "IJ", "KL", "MN", "PQ", "RS", "TU", "VW", "XZ"}; /* string, NO NUL fixed length */
+           "ab", "cd", "ef", "gh", "ij", "kl", "mn", "pq", "rs", "tu", "vw", "xz", "AB",
+           "CD", "EF", "GH", "IJ", "KL", "MN", "PQ", "RS", "TU", "VW", "XZ"}; /* string, NO NUL fixed length */
     char       buf23[4][3][2];                                                /* bitfield, opaque */
     s_t        buf33[4][3][2];                                                /* compound */
     hobj_ref_t buf43[1][1][1];                                                /* reference */
@@ -3486,8 +3485,8 @@ write_attr_in(hid_t loc_id, const char *dset_name, /* for saving reference to da
     /* create 3D attributes with dimension [4][3][2], 24 elements */
     hsize_t dims3[3]     = {4, 3, 2};
     char    buf13[24][2] = {
-        "ab", "cd", "ef", "gh", "ij", "kl", "mn", "pq", "rs", "tu", "vw", "xz", "AB",
-        "CD", "EF", "GH", "IJ", "KL", "MN", "PQ", "RS", "TU", "VW", "XZ"}; /* string, NO NUL fixed length */
+           "ab", "cd", "ef", "gh", "ij", "kl", "mn", "pq", "rs", "tu", "vw", "xz", "AB",
+           "CD", "EF", "GH", "IJ", "KL", "MN", "PQ", "RS", "TU", "VW", "XZ"}; /* string, NO NUL fixed length */
     char       buf23[4][3][2];                                                /* bitfield, opaque */
     s_t        buf33[4][3][2];                                                /* compound */
     hobj_ref_t buf43[4][3][2];                                                /* reference */
@@ -5406,9 +5405,9 @@ make_complex_attr_references(hid_t loc_id)
     hid_t   objgid = 0, objdid = 0, objtid = 0, objsid = 0;
     hsize_t obj_dims[RANK_OBJ]           = {DIM0_OBJ, DIM1_OBJ};
     int     obj_data[DIM0_OBJ][DIM1_OBJ] = {
-        {0, 1, 2, 3, 4, 5, 6, 7, 8, 9},           {10, 11, 12, 13, 14, 15, 16, 17, 18, 19},
-        {20, 21, 22, 23, 24, 25, 26, 27, 28, 29}, {30, 31, 32, 33, 34, 35, 36, 37, 38, 39},
-        {40, 41, 42, 43, 44, 45, 46, 47, 48, 49}, {50, 51, 52, 53, 54, 55, 56, 57, 58, 59}};
+            {0, 1, 2, 3, 4, 5, 6, 7, 8, 9},           {10, 11, 12, 13, 14, 15, 16, 17, 18, 19},
+            {20, 21, 22, 23, 24, 25, 26, 27, 28, 29}, {30, 31, 32, 33, 34, 35, 36, 37, 38, 39},
+            {40, 41, 42, 43, 44, 45, 46, 47, 48, 49}, {50, 51, 52, 53, 54, 55, 56, 57, 58, 59}};
 
     /*
      * group main
@@ -5777,7 +5776,8 @@ out:
 }
 
 /* TODO: This is duplicated from gen_filespace.c. Eventually, this should be centralized somewhere. */
-int gen_filespaces(void)
+int
+gen_filespaces(void)
 {
     hid_t                 fid  = H5I_INVALID_HID; /* File ID */
     hid_t                 fcpl = H5I_INVALID_HID; /* File creation property list */

--- a/tools/test/h5repack/h5repackgentest.c
+++ b/tools/test/h5repack/h5repackgentest.c
@@ -5776,6 +5776,7 @@ out:
     return ret;
 }
 
+/* TODO: This is duplicated from gen_filespace.c. Eventually, this should be centralized somewhere. */
 int gen_filespaces(void)
 {
     hid_t                 fid  = H5I_INVALID_HID; /* File ID */

--- a/tools/test/h5repack/h5repackgentest.h
+++ b/tools/test/h5repack/h5repackgentest.h
@@ -22,6 +22,7 @@ int generate_uint8be(bool external);
 int generate_f32le(bool external);
 int make_h5repack_testfiles(void);
 int verify_userblock(const char *filename);
+int gen_filespaces(void);
 
 /* fill value test */
 #define H5REPACK_FNAME0    "h5repack_fill.h5"


### PR DESCRIPTION
Also add options to a couple generator routines, since the reference files different in expected types between different tools
<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Add missing test files to `h5gentest` for `--h5repack` and update generator routines for type handling.
> 
>   - **Behavior**:
>     - Add missing test files to `h5gentest` for `--h5repack` option.
>     - Update `gent_softlink2()` in `h5dumpgentest.c` and `h5gentest.c` to accept `bool big_endian_committed`.
>     - Update `gent_datareg()` in `h5dumpgentest.c` and `h5gentest.c` to accept `bool undefined_fill_value`.
>   - **Functions**:
>     - Modify `gent_softlink2()` to handle big-endian committed types.
>     - Modify `gent_datareg()` to handle undefined fill values.
>   - **Misc**:
>     - Add `gen_filespaces()` to `h5repackgentest.c` for generating file spaces with different strategies.
>     - Adjust indentation in `write_attr_in()` and `write_dset_in()` in `h5dumpgentest.c`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=HDFGroup%2Fhdf5&utm_source=github&utm_medium=referral)<sup> for b3cedc71df4e3124b2c7c5440d38a22e3d3706c9. You can [customize](https://app.ellipsis.dev/HDFGroup/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->