### PR TITLE
Remove unused variables in test

### DIFF
--- a/test/dsets.c
+++ b/test/dsets.c
@@ -16893,13 +16893,10 @@ test_vds_shared_strings(hid_t fapl)
      */
     char file_name[64];
     char dset_name[64];
-    int  shared_file_count = 0;
-    int  shared_dset_count = 0;
 
     for (int i = 0; i < NUM_MAPPINGS_MANY; i++) {
         if (i % 10 == 0) {
             strcpy(file_name, "shared_file.h5");
-            shared_file_count++;
         }
         else {
             snprintf(file_name, sizeof(file_name), "file_%d.h5", i);
@@ -16907,7 +16904,6 @@ test_vds_shared_strings(hid_t fapl)
 
         if (i % 5 == 0) {
             strcpy(dset_name, "/shared_dataset");
-            shared_dset_count++;
         }
         else {
             snprintf(dset_name, sizeof(dset_name), "/dataset_%d", i);


### PR DESCRIPTION
Fixes several warnings in Developer builds about variables declared past the start of the function

Fixes #5798
<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Remove unused variables `shared_file_count` and `shared_dset_count` from `test_vds_shared_strings` in `test/dsets.c` to fix developer build warnings.
> 
>   - **Code Cleanup**:
>     - Remove unused variables `shared_file_count` and `shared_dset_count` from `test_vds_shared_strings` in `test/dsets.c`.
>   - **Warnings**:
>     - Fixes warnings in developer builds about unused variables.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=HDFGroup%2Fhdf5&utm_source=github&utm_medium=referral)<sup> for 8787970111016234599a27ecc385b03d7898580f. You can [customize](https://app.ellipsis.dev/HDFGroup/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->