### PR TITLE
Remove (HD)off_t from the H5Pset/get_external calls

### DIFF
--- a/HDF5Examples/FORTRAN/H5D/h5ex_d_extern.F90
+++ b/HDF5Examples/FORTRAN/H5D/h5ex_d_extern.F90
@@ -40,8 +40,8 @@ PROGRAM main
   INTEGER :: i, j
   ! This change was introduced in the 1.8.12 release
 #if H5_VERSION_GE(1,8,12)
-  INTEGER(OFF_T) :: offset = 0 ! Offset, in bytes, from the beginning of the file to the 
-                               ! location in the file where the data starts.
+  INTEGER(C_INT64_T) :: offset = 0 ! Offset, in bytes, from the beginning of the file to the 
+                                   ! location in the file where the data starts.
 #else
   INTEGER :: offset = 0
 #endif

--- a/c++/src/C2Cppfunction_map.htm
+++ b/c++/src/C2Cppfunction_map.htm
@@ -16851,7 +16851,7 @@ normal'><span style='font-size:14.0pt;mso-bidi-font-size:11.0pt;line-height:
   mso-border-top-alt:solid windowtext .5pt;mso-border-left-alt:solid windowtext .5pt;
   mso-border-alt:solid windowtext .5pt;padding:0in 5.4pt 0in 5.4pt'>
   <p class=MsoNormal style='margin-bottom:0in;margin-bottom:.0001pt;line-height:
-  normal'>void DSetCreatPropList::setExternal(const char* name, HDoff_t offset,
+  normal'>void DSetCreatPropList::setExternal(const char* name, uint64_t offset,
   hsize_t size)</p>
   </td>
   <td width=35 valign=top style='width:26.05pt;border-top:none;border-left:
@@ -16925,7 +16925,7 @@ normal'><span style='font-size:14.0pt;mso-bidi-font-size:11.0pt;line-height:
   mso-border-alt:solid windowtext .5pt;padding:0in 5.4pt 0in 5.4pt'>
   <p class=MsoNormal style='margin-bottom:0in;margin-bottom:.0001pt;line-height:
   normal'>void DSetCreatPropList::getExternal(unsigned idx, size_t name_size,
-  char* name, HDoff_t&amp; offset, hsize_t&amp; size)</p>
+  char* name, uint64_t&amp; offset, hsize_t&amp; size)</p>
   </td>
   <td width=35 valign=top style='width:26.05pt;border-top:none;border-left:
   none;border-bottom:solid windowtext 1.0pt;border-right:solid windowtext 1.0pt;

--- a/c++/src/H5DcreatProp.cpp
+++ b/c++/src/H5DcreatProp.cpp
@@ -649,10 +649,10 @@ DSetCreatPropList::setFletcher32() const
 ///             which is a 32-bit signed long value on Windows, which limited
 ///             the valid offset that can be set to 2 GiB.
 ///
-///\version     2.0.0 \p offset parameter type changed to HDoff_t from off_t.
+///\version     2.0.0 \p offset parameter type changed to uint64_t from off_t.
 //--------------------------------------------------------------------------
 void
-DSetCreatPropList::setExternal(const char *name, HDoff_t offset, hsize_t size) const
+DSetCreatPropList::setExternal(const char *name, uint64_t offset, hsize_t size) const
 {
     herr_t ret_value = H5Pset_external(id, name, offset, size);
     if (ret_value < 0) {
@@ -702,10 +702,10 @@ DSetCreatPropList::getExternalCount() const
 ///             which is a 32-bit signed long value on Windows, which limited
 ///             the valid offset that can be returned to 2 GiB.
 ///
-///\version     2.0.0 \p offset parameter type changed to HDoff_t from off_t.
+///\version     2.0.0 \p offset parameter type changed to uint64_t from off_t.
 //--------------------------------------------------------------------------
 void
-DSetCreatPropList::getExternal(unsigned idx, size_t name_size, char *name, HDoff_t &offset,
+DSetCreatPropList::getExternal(unsigned idx, size_t name_size, char *name, uint64_t &offset,
                                hsize_t &size) const
 {
     herr_t ret_value = H5Pget_external(id, idx, name_size, name, &offset, &size);

--- a/c++/src/H5DcreatProp.h
+++ b/c++/src/H5DcreatProp.h
@@ -50,7 +50,7 @@ class H5CPP_DLL DSetCreatPropList : public ObjCreatPropList {
     void setChunk(int ndims, const hsize_t *dim) const;
 
     // Returns information about an external file.
-    void getExternal(unsigned idx, size_t name_size, char *name, HDoff_t &offset, hsize_t &size) const;
+    void getExternal(unsigned idx, size_t name_size, char *name, uint64_t &offset, hsize_t &size) const;
 
     // Returns the number of external files for a dataset.
     int getExternalCount() const;
@@ -101,7 +101,7 @@ class H5CPP_DLL DSetCreatPropList : public ObjCreatPropList {
     void setDeflate(int level) const;
 
     // Adds an external file to the list of external files.
-    void setExternal(const char *name, HDoff_t offset, hsize_t size) const;
+    void setExternal(const char *name, uint64_t offset, hsize_t size) const;
 
     // Adds a filter to the filter pipeline.
     void setFilter(H5Z_filter_t filter, unsigned int flags = 0, size_t cd_nelmts = 0,

--- a/fortran/src/H5Pf.c
+++ b/fortran/src/H5Pf.c
@@ -1516,18 +1516,19 @@ DONE:
  * SOURCE
  */
 int_f
-h5pset_external_c(hid_t_f *prp_id, _fcd name, int_f *namelen, off_t_f *offset, hsize_t_f *bytes)
+h5pset_external_c(hid_t_f *prp_id, _fcd name, int_f *namelen, uint64_t_f *offset, hsize_t_f *bytes)
 /******/
 {
-    int     ret_value = -1;
-    hid_t   c_prp_id;
-    herr_t  ret;
-    hsize_t c_bytes;
-    char   *c_name;
-    size_t  c_namelen = (size_t)*namelen;
-    off_t   c_offset;
+    int      ret_value = -1;
+    hid_t    c_prp_id;
+    herr_t   ret;
+    hsize_t  c_bytes;
+    char    *c_name;
+    size_t   c_namelen = (size_t)*namelen;
+    uint64_t c_offset;
+
     c_bytes  = (hsize_t)*bytes;
-    c_offset = (off_t)*offset;
+    c_offset = (uint64_t)*offset;
 
     c_name = (char *)HD5f2cstring(name, c_namelen);
     if (c_name == NULL)
@@ -1600,7 +1601,7 @@ h5pget_external_count_c(hid_t_f *prp_id, int_f *count)
  * SOURCE
  */
 int_f
-h5pget_external_c(hid_t_f *prp_id, int_f *idx, size_t_f *name_size, _fcd name, off_t_f *offset,
+h5pget_external_c(hid_t_f *prp_id, int_f *idx, size_t_f *name_size, _fcd name, uint64_t_f *offset,
                   hsize_t_f *bytes)
 /******/
 {
@@ -1610,7 +1611,7 @@ h5pget_external_c(hid_t_f *prp_id, int_f *idx, size_t_f *name_size, _fcd name, o
     herr_t   status;
     size_t   c_namelen;
     char    *c_name = NULL;
-    HDoff_t  c_offset;
+    uint64_t c_offset;
     hsize_t  size;
 
     c_namelen = (size_t)*name_size;
@@ -1632,7 +1633,7 @@ h5pget_external_c(hid_t_f *prp_id, int_f *idx, size_t_f *name_size, _fcd name, o
     if (status < 0)
         goto DONE;
 
-    *offset = (off_t_f)c_offset;
+    *offset = (uint64_t_f)c_offset;
     *bytes  = (hsize_t_f)size;
     /* Note: if the size of the fortran buffer is larger then the returned string
      *       from the function then we need to give HD5packFstring the fortran buffer size so

--- a/fortran/src/H5Pff.F90
+++ b/fortran/src/H5Pff.F90
@@ -1623,16 +1623,13 @@ CONTAINS
 !! \param bytes  Size of the external file data.
 !! \param hdferr \fortran_error
 !!
-!! \note On Windows, off_t is typically a 32-bit signed long value, which
-!!       limits the valid offset that can be set to 2 GiB.
-!!
 !! See C API: @ref H5Pset_external()
 !!
   SUBROUTINE h5pset_external_f(prp_id, name, offset, bytes, hdferr)
     IMPLICIT NONE
     INTEGER(HID_T), INTENT(IN) :: prp_id
     CHARACTER(LEN=*), INTENT(IN) :: name
-    INTEGER(OFF_T), INTENT(IN) :: offset
+    INTEGER(C_INT64_T), INTENT(IN) :: offset
     INTEGER(HSIZE_T), INTENT(IN) :: bytes
     INTEGER, INTENT(OUT) :: hdferr
     INTEGER :: namelen
@@ -1641,12 +1638,12 @@ CONTAINS
        INTEGER FUNCTION h5pset_external_c(prp_id, name,namelen, offset, bytes) &
             BIND(C,NAME='h5pset_external_c')
          IMPORT :: C_CHAR
-         IMPORT :: HID_T, OFF_T, HSIZE_T
+         IMPORT :: HID_T, C_INT64_T, HSIZE_T
          IMPLICIT NONE
          INTEGER(HID_T), INTENT(IN) :: prp_id
          CHARACTER(KIND=C_CHAR), DIMENSION(*), INTENT(IN) :: name
          INTEGER :: namelen
-         INTEGER(OFF_T), INTENT(IN) :: offset
+         INTEGER(C_INT64_T), INTENT(IN) :: offset
          INTEGER(HSIZE_T), INTENT(IN) :: bytes
        END FUNCTION h5pset_external_c
     END INTERFACE
@@ -1697,9 +1694,6 @@ CONTAINS
 !! \param bytes     Size of the external file data.
 !! \param hdferr    \fortran_error
 !!
-!! \note On Windows, off_t is typically a 32-bit signed long value, which
-!!       limits the valid offset that can be returned to 2 GiB.
-!!
 !! See C API: @ref H5Pget_external()
 !!
   SUBROUTINE h5pget_external_f(prp_id, idx, name_size, name, offset, bytes, hdferr)
@@ -1708,20 +1702,20 @@ CONTAINS
     INTEGER, INTENT(IN) :: idx
     INTEGER(SIZE_T), INTENT(IN) :: name_size
     CHARACTER(LEN=*), INTENT(OUT) :: name
-    INTEGER(OFF_T), INTENT(OUT) :: offset
+    INTEGER(C_INT64_T), INTENT(OUT) :: offset
     INTEGER(HSIZE_T), INTENT(OUT) :: bytes
     INTEGER, INTENT(OUT) :: hdferr
     INTERFACE
        INTEGER FUNCTION h5pget_external_c(prp_id, idx, name_size, name, offset, bytes) &
             BIND(C,NAME='h5pget_external_c')
          IMPORT :: C_CHAR
-         IMPORT :: HID_T, SIZE_T, HSIZE_T, OFF_T
+         IMPORT :: HID_T, SIZE_T, HSIZE_T, C_INT64_T
          IMPLICIT NONE
          INTEGER(HID_T), INTENT(IN) :: prp_id
          INTEGER, INTENT(IN) :: idx
          INTEGER(SIZE_T), INTENT(IN) :: name_size
          CHARACTER(KIND=C_CHAR), DIMENSION(*), INTENT(OUT) :: name
-         INTEGER(OFF_T), INTENT(OUT) :: offset
+         INTEGER(C_INT64_T), INTENT(OUT) :: offset
          INTEGER(HSIZE_T), INTENT(OUT) :: bytes
        END FUNCTION h5pget_external_c
     END INTERFACE

--- a/fortran/src/H5f90proto.h
+++ b/fortran/src/H5f90proto.h
@@ -426,11 +426,11 @@ H5FC_DLL int_f h5pget_filter_c(hid_t_f *prp_id, int_f *filter_number, int_f *fla
                                int_f *cd_values, size_t_f *namelen, _fcd name, int_f *filter_id);
 H5FC_DLL int_f h5pget_filter_by_id_c(hid_t_f *prp_id, int_f *filter_id, int_f *flags, size_t_f *cd_nelmts,
                                      int_f *cd_values, size_t_f *namelen, _fcd name);
-H5FC_DLL int_f h5pset_external_c(hid_t_f *prp_id, _fcd name, int_f *namelen, off_t_f *offset,
+H5FC_DLL int_f h5pset_external_c(hid_t_f *prp_id, _fcd name, int_f *namelen, uint64_t_f *offset,
                                  hsize_t_f *bytes);
 H5FC_DLL int_f h5pget_external_count_c(hid_t_f *prp_id, int_f *count);
-H5FC_DLL int_f h5pget_external_c(hid_t_f *prp_id, int_f *idx, size_t_f *name_size, _fcd name, off_t_f *offset,
-                                 hsize_t_f *bytes);
+H5FC_DLL int_f h5pget_external_c(hid_t_f *prp_id, int_f *idx, size_t_f *name_size, _fcd name,
+                                 uint64_t_f *offset, hsize_t_f *bytes);
 H5FC_DLL int_f h5pget_btree_ratios_c(hid_t_f *prp_id, real_f *left, real_f *middle, real_f *right);
 H5FC_DLL int_f h5pset_btree_ratios_c(hid_t_f *prp_id, real_f *left, real_f *middle, real_f *right);
 H5FC_DLL int_f h5pset_fclose_degree_c(hid_t_f *fapl, int_f *degree);

--- a/fortran/src/H5match_types.c
+++ b/fortran/src/H5match_types.c
@@ -295,17 +295,6 @@ main(void)
             return -1;
     }
 
-    /* off_t */
-    for (i = 0; i < FORTRAN_NUM_INTEGER_KINDS; i++) {
-        if (IntKinds_SizeOf[i] == H5_SIZEOF_OFF_T) {
-            writeToFiles("int", "OFF_T", "off_t_f", IntKinds[i]);
-            break;
-        }
-        if (i == (FORTRAN_NUM_INTEGER_KINDS - 1))
-            /* Error: couldn't find a size for off_t */
-            return -1;
-    }
-
     /* size_t */
     for (i = 0; i < FORTRAN_NUM_INTEGER_KINDS; i++) {
         if (IntKinds_SizeOf[i] == H5_SIZEOF_SIZE_T) {

--- a/fortran/test/tH5P.F90
+++ b/fortran/test/tH5P.F90
@@ -50,7 +50,7 @@ SUBROUTINE external_test(cleanup, total_error)
   INTEGER(HSIZE_T), DIMENSION(1) :: cur_size !data space current size
   INTEGER(HSIZE_T), DIMENSION(1) :: max_size !data space maximum size
   CHARACTER(LEN=256) :: name !external file name
-  INTEGER(OFF_T) :: file_offset !external file offset
+  INTEGER(C_INT64_T) :: file_offset !external file offset
   INTEGER(HSIZE_T) :: file_size   !sizeof external file segment
   INTEGER :: error !error code
   INTEGER(SIZE_T) :: int_size !size of integer
@@ -134,7 +134,7 @@ SUBROUTINE external_test(cleanup, total_error)
   CALL h5tget_size_f(H5T_NATIVE_INTEGER, int_size, error)
   CALL check("h5tget_size_f",error,total_error)
   file_size = int_size * max_size(1)
-  CALL h5pset_external_f(plist_id, "ext1.data", INT(0,off_t), file_size, error)
+  CALL h5pset_external_f(plist_id, "ext1.data", INT(0,uint64_t), file_size, error)
   CALL check("h5pset_external_f",error,total_error)
   CALL h5screate_simple_f(RANK, cur_size, space_id, error, max_size)
   CALL check("h5screate_simple_f", error, total_error)

--- a/fortran/test/tH5P_F03.F90
+++ b/fortran/test/tH5P_F03.F90
@@ -570,13 +570,13 @@ SUBROUTINE external_test_offset(cleanup,total_error)
 
   CALL h5pcreate_f(H5P_DATASET_CREATE_F, dcpl, error)
   CALL check("h5pcreate_f", error, total_error)
-  CALL h5pset_external_f(dcpl, "extern_1a.raw", INT(0,off_t), sizeof_part, error)
+  CALL h5pset_external_f(dcpl, "extern_1a.raw", INT(0,uint64_t), sizeof_part, error)
   CALL check("h5pset_external_f",error,total_error)
-  CALL h5pset_external_f(dcpl, "extern_2a.raw", INT(10,off_t), sizeof_part, error)
+  CALL h5pset_external_f(dcpl, "extern_2a.raw", INT(10,uint64_t), sizeof_part, error)
   CALL check("h5pset_external_f",error,total_error)
-  CALL h5pset_external_f(dcpl, "extern_3a.raw", INT(20,off_t), sizeof_part, error)
+  CALL h5pset_external_f(dcpl, "extern_3a.raw", INT(20,uint64_t), sizeof_part, error)
   CALL check("h5pset_external_f",error,total_error)
-  CALL h5pset_external_f(dcpl, "extern_4a.raw", INT(30,off_t), sizeof_part, error)
+  CALL h5pset_external_f(dcpl, "extern_4a.raw", INT(30,uint64_t), sizeof_part, error)
   CALL check("h5pset_external_f",error,total_error)
 
   cur_size(1) = 100

--- a/java/src/jni/h5pDCPLImp.c
+++ b/java/src/jni/h5pDCPLImp.c
@@ -1061,7 +1061,7 @@ Java_hdf_hdf5lib_H5_H5Pset_1external(JNIEnv *env, jclass clss, jlong plist, jstr
 
     PIN_JAVA_STRING(ENVONLY, name, fileName, NULL, "H5Pset_external: file name not pinned");
 
-    if ((status = H5Pset_external((hid_t)plist, fileName, (HDoff_t)offset, (hsize_t)size)) < 0)
+    if ((status = H5Pset_external((hid_t)plist, fileName, (uint64_t)offset, (hsize_t)size)) < 0)
         H5_LIBRARY_ERROR(ENVONLY);
 
 done:
@@ -1083,7 +1083,7 @@ Java_hdf_hdf5lib_H5_H5Pget_1external(JNIEnv *env, jclass clss, jlong plist, jint
     jboolean isCopy;
     jstring  str;
     hsize_t  s;
-    HDoff_t  o;
+    uint64_t o;
     jsize    arrLen;
     jlong   *theArray = NULL;
     char    *file     = NULL;
@@ -1112,7 +1112,7 @@ Java_hdf_hdf5lib_H5_H5Pget_1external(JNIEnv *env, jclass clss, jlong plist, jint
     if (NULL != size) {
         PIN_LONG_ARRAY(ENVONLY, size, theArray, &isCopy, "H5Pget_external: size array not pinned");
 
-        theArray[0] = o;
+        theArray[0] = (jlong)o;
         theArray[1] = (jlong)s;
     }
 

--- a/release_docs/RELEASE.txt
+++ b/release_docs/RELEASE.txt
@@ -654,17 +654,12 @@ New Features
       developers who wish to provide an ID for their driver should create
       a routine specific to their individual implementation.
 
-    - H5Pset_external() now uses HDoff_t, which is always a 64-bit type
+    - H5P(set|get)_external() now take a uint64_t offset parameter
 
-      The H5Pset_external() call took an off_t parameter in HDF5 1.14.x and
-      earlier. On POSIX systems, off_t is specified as a 64-bit type via
-      POSIX large-file support (LFS). On Windows, however, off_t is defined
-      as a 32-bit type, even on 64-bit Windows.
-
-      HDoff_t has been added to H5public.h and is defined to be int64_t on
-      Windows and the library has been updated to use HDoff_t in place of
-      off_t throughout. The H5Pset_external() offset parameter has also been
-      updated to be HDoff_t.
+      These calls took an off_t parameter in HDF5 1.14.x and earlier. On POSIX
+      systems, off_t is specified as a 64-bit type via POSIX large-file support
+      (LFS). On Windows, however, off_t is defined as a 32-bit type, even on
+      64-bit Windows, which limited external files to 2 GiB.
 
       There is no API compatibility wrapper for this change.
 
@@ -969,7 +964,10 @@ Bug Fixes since HDF5-2.0.0 release
 
     Fortran API
     -----------
-    -
+    - The offset parameter for H5P(set|get)_external_f() is now always a 64-bit type
+
+      The parameter was changed from an INTEGER of KIND OFF_T to C_INT64_T, and
+      OFF_T is no longer a defined INTEGER KIND.
 
 
     High-Level Library
@@ -999,7 +997,10 @@ Bug Fixes since HDF5-2.0.0 release
 
     C++ APIs
     --------
-    -
+    - The offset parameter in (get|set)External is now a uint64_t
+
+      This has been changed from off_t. See the main library section for
+      the justification.
 
 
     Testing

--- a/src/H5Defl.c
+++ b/src/H5Defl.c
@@ -316,7 +316,7 @@ H5D__efl_read(const H5O_efl_t *efl, const H5D_t *dset, haddr_t addr, size_t size
             HGOTO_ERROR(H5E_EFL, H5E_NOSPACE, FAIL, "can't build external file name");
         if ((fd = HDopen(full_name, O_RDONLY)) < 0)
             HGOTO_ERROR(H5E_EFL, H5E_CANTOPENFILE, FAIL, "unable to open external raw data file");
-        if (HDlseek(fd, (HDoff_t)(efl->slot[u].offset + (HDoff_t)skip), SEEK_SET) < 0)
+        if (HDlseek(fd, (HDoff_t)(efl->slot[u].offset + skip), SEEK_SET) < 0)
             HGOTO_ERROR(H5E_EFL, H5E_SEEKERROR, FAIL, "unable to seek in external raw data file");
 #ifndef NDEBUG
         tempto_read = MIN((size_t)(efl->slot[u].size - skip), (hsize_t)size);
@@ -434,7 +434,7 @@ H5D__efl_write(const H5O_efl_t *efl, const H5D_t *dset, haddr_t addr, size_t siz
             else
                 HGOTO_ERROR(H5E_EFL, H5E_CANTOPENFILE, FAIL, "unable to open external raw data file");
         } /* end if */
-        if (HDlseek(fd, (HDoff_t)(efl->slot[u].offset + (HDoff_t)skip), SEEK_SET) < 0)
+        if (HDlseek(fd, (HDoff_t)(efl->slot[u].offset + skip), SEEK_SET) < 0)
             HGOTO_ERROR(H5E_EFL, H5E_SEEKERROR, FAIL, "unable to seek in external raw data file");
 #ifndef NDEBUG
         tempto_write = MIN(efl->slot[u].size - skip, (hsize_t)size);

--- a/src/H5FDstdio.c
+++ b/src/H5FDstdio.c
@@ -121,26 +121,36 @@ typedef struct H5FD_stdio_t {
 
 /* Platform-independent names for some file-oriented functions */
 
+/* off_t exists on Windows, but is always a 32-bit long, even on 64-bit Windows,
+ * so on Windows we define my_off_t to be int64_t, which is equivalent to __int64,
+ * the type of the st_size field of the _stati64 struct.
+ */
+#ifdef H5_HAVE_WIN32_API
+typedef int64_t my_off_t;
+#else
+typedef off_t my_off_t;
+#endif
+
 #ifdef H5_HAVE_WIN32_API
 /* Windows and MinGW */
-#define file_ftell _ftelli64
+#define my_ftell _ftelli64
 #else
 /* Everyone else */
-#define file_ftell ftello
+#define my_ftell ftello
 #endif
 
 #if defined(H5_HAVE_WIN32_API) && !defined(H5_HAVE_MINGW)
 /* Windows (but NOT MinGW) */
-#define file_fseek     _fseeki64
-#define file_ftruncate _chsize_s
+#define my_fseek     _fseeki64
+#define my_ftruncate _chsize_s
 #else
 /* Everyone else */
-#define file_fseek     fseeko
-#define file_ftruncate ftruncate
+#define my_fseek     fseeko
+#define my_ftruncate ftruncate
 #endif
 
 /* These macros check for overflow of various quantities.  These macros
- * assume that HDoff_t is signed and haddr_t and size_t are unsigned.
+ * assume that my_off_t is signed and haddr_t and size_t are unsigned.
  *
  * MY_ADDR_OVERFLOW:   Checks whether a file address of type `haddr_t'
  *                     is too large to be represented by the second argument
@@ -153,12 +163,12 @@ typedef struct H5FD_stdio_t {
  *                     which can be addressed entirely by the second
  *                     argument of the file seek function.
  */
-#define MY_MAXADDR          (((haddr_t)1 << (8 * sizeof(HDoff_t) - 1)) - 1)
+#define MY_MAXADDR          (((haddr_t)1 << (8 * sizeof(my_off_t) - 1)) - 1)
 #define MY_ADDR_OVERFLOW(A) (HADDR_UNDEF == (A) || ((A) & ~(haddr_t)MY_MAXADDR))
 #define MY_SIZE_OVERFLOW(Z) ((Z) & ~(hsize_t)MY_MAXADDR)
 #define MY_REGION_OVERFLOW(A, Z)                                                                             \
     (MY_ADDR_OVERFLOW(A) || MY_SIZE_OVERFLOW(Z) || HADDR_UNDEF == (A) + (Z) ||                               \
-     (HDoff_t)((A) + (Z)) < (HDoff_t)(A))
+     (my_off_t)((A) + (Z)) < (my_off_t)(A))
 
 /* Prototypes */
 static H5FD_t *H5FD_stdio_open(const char *name, unsigned flags, hid_t fapl_id, haddr_t maxaddr);
@@ -310,7 +320,7 @@ H5FD_stdio_open(const char *name, unsigned flags, hid_t fapl_id, haddr_t maxaddr
 #endif /* H5_HAVE_WIN32_API */
 
     /* Sanity check on file offsets */
-    assert(sizeof(HDoff_t) >= sizeof(size_t));
+    assert(sizeof(my_off_t) >= sizeof(size_t));
 
     /* Quiet compiler */
     (void)fapl_id;
@@ -375,11 +385,11 @@ H5FD_stdio_open(const char *name, unsigned flags, hid_t fapl_id, haddr_t maxaddr
     file->op           = H5FD_STDIO_OP_SEEK;
     file->pos          = HADDR_UNDEF;
     file->write_access = write_access; /* Note the write_access for later */
-    if (file_fseek(file->fp, 0, SEEK_END) < 0) {
+    if (my_fseek(file->fp, 0, SEEK_END) < 0) {
         file->op = H5FD_STDIO_OP_UNKNOWN;
     }
     else {
-        HDoff_t x = file_ftell(file->fp);
+        my_off_t x = my_ftell(file->fp);
         assert(x >= 0);
         file->eof = (haddr_t)x;
     }
@@ -755,7 +765,7 @@ H5FD_stdio_read(H5FD_t *_file, H5FD_mem_t /*UNUSED*/ type, hid_t /*UNUSED*/ dxpl
 
     /* Seek to the correct file position. */
     if (!(file->op == H5FD_STDIO_OP_READ || file->op == H5FD_STDIO_OP_SEEK) || file->pos != addr) {
-        if (file_fseek(file->fp, (HDoff_t)addr, SEEK_SET) < 0) {
+        if (my_fseek(file->fp, (my_off_t)addr, SEEK_SET) < 0) {
             file->op  = H5FD_STDIO_OP_UNKNOWN;
             file->pos = HADDR_UNDEF;
             H5Epush_ret(__func__, H5E_ERR_CLS, H5E_IO, H5E_SEEKERROR, "fseek failed", -1);
@@ -846,7 +856,7 @@ H5FD_stdio_write(H5FD_t *_file, H5FD_mem_t /*UNUSED*/ type, hid_t /*UNUSED*/ dxp
 
     /* Seek to the correct file position. */
     if ((file->op != H5FD_STDIO_OP_WRITE && file->op != H5FD_STDIO_OP_SEEK) || file->pos != addr) {
-        if (file_fseek(file->fp, (HDoff_t)addr, SEEK_SET) < 0) {
+        if (my_fseek(file->fp, (my_off_t)addr, SEEK_SET) < 0) {
             file->op  = H5FD_STDIO_OP_UNKNOWN;
             file->pos = HADDR_UNDEF;
             H5Epush_ret(__func__, H5E_ERR_CLS, H5E_IO, H5E_SEEKERROR, "fseek failed", -1);
@@ -1002,7 +1012,7 @@ H5FD_stdio_truncate(H5FD_t *_file, hid_t /*UNUSED*/ dxpl_id, bool /*UNUSED*/ clo
             rewind(file->fp);
 
             /* Truncate file to proper length */
-            if (-1 == file_ftruncate(file->fd, (HDoff_t)file->eoa))
+            if (-1 == my_ftruncate(file->fd, (my_off_t)file->eoa))
                 H5Epush_ret(__func__, H5E_ERR_CLS, H5E_IO, H5E_SEEKERROR,
                             "unable to truncate/extend file properly", -1);
 #endif /* H5_HAVE_WIN32_API */

--- a/src/H5Oefl.c
+++ b/src/H5Oefl.c
@@ -145,7 +145,7 @@ H5O__efl_decode(H5F_t *f, H5O_t H5_ATTR_UNUSED *open_oh, unsigned H5_ATTR_UNUSED
 
     for (size_t u = 0; u < mesg->nused; u++) {
 
-        hsize_t offset = 0;
+        uint64_t offset = 0;
 
         /* Name */
         if (H5_IS_BUFFER_OVERFLOW(p, H5F_sizeof_size(f), p_end))
@@ -163,8 +163,8 @@ H5O__efl_decode(H5F_t *f, H5O_t H5_ATTR_UNUSED *open_oh, unsigned H5_ATTR_UNUSED
         /* File offset */
         if (H5_IS_BUFFER_OVERFLOW(p, H5F_sizeof_size(f), p_end))
             HGOTO_ERROR(H5E_OHDR, H5E_OVERFLOW, NULL, "ran off end of input buffer while decoding");
-        H5F_DECODE_LENGTH(f, p, offset); /* Decode into an hsize_t to avoid sign warnings */
-        mesg->slot[u].offset = (HDoff_t)offset;
+        H5F_DECODE_LENGTH(f, p, offset);
+        mesg->slot[u].offset = offset;
 
         /* Size */
         if (H5_IS_BUFFER_OVERFLOW(p, H5F_sizeof_size(f), p_end))

--- a/src/H5Oprivate.h
+++ b/src/H5Oprivate.h
@@ -377,10 +377,10 @@ typedef struct H5O_link_t {
 #define H5O_EFL_UNLIMITED H5F_UNLIMITED /*max possible file size	     */
 
 typedef struct H5O_efl_entry_t {
-    size_t  name_offset; /*offset of name within heap	     */
-    char   *name;        /*malloc'd name			     */
-    HDoff_t offset;      /*offset of data within file	     */
-    hsize_t size;        /*size allocated within file	     */
+    size_t   name_offset; /* Offset of name within heap */
+    char    *name;        /* Malloc'd name */
+    uint64_t offset;      /* Offset of data within file */
+    hsize_t  size;        /* Size allocated within file */
 } H5O_efl_entry_t;
 
 typedef struct H5O_efl_t {

--- a/src/H5Pdcpl.c
+++ b/src/H5Pdcpl.c
@@ -1466,7 +1466,6 @@ H5P__dcrt_ext_file_list_enc(const void *value, void **_pp, size_t *size)
     /* Sanity check */
     assert(efl);
     HDcompile_assert(sizeof(size_t) <= sizeof(uint64_t));
-    HDcompile_assert(sizeof(HDoff_t) <= sizeof(uint64_t));
     HDcompile_assert(sizeof(hsize_t) <= sizeof(uint64_t));
     assert(size);
 
@@ -1550,7 +1549,6 @@ H5P__dcrt_ext_file_list_dec(const void **_pp, void *_value)
     assert(*pp);
     assert(efl);
     HDcompile_assert(sizeof(size_t) <= sizeof(uint64_t));
-    HDcompile_assert(sizeof(HDoff_t) <= sizeof(uint64_t));
     HDcompile_assert(sizeof(hsize_t) <= sizeof(uint64_t));
 
     /* Set property to default value */
@@ -1589,7 +1587,7 @@ H5P__dcrt_ext_file_list_dec(const void **_pp, void *_value)
         enc_size = *(*pp)++;
         assert(enc_size < 256);
         UINT64DECODE_VAR(*pp, enc_value, enc_size);
-        efl->slot[u].offset = (HDoff_t)enc_value;
+        efl->slot[u].offset = enc_value;
 
         /* Decode size */
         enc_size = *(*pp)++;
@@ -2669,7 +2667,7 @@ done:
  *-------------------------------------------------------------------------
  */
 herr_t
-H5Pset_external(hid_t plist_id, const char *name, HDoff_t offset, hsize_t size)
+H5Pset_external(hid_t plist_id, const char *name, uint64_t offset, hsize_t size)
 {
     size_t          idx;
     hsize_t         total, tmp;
@@ -2682,8 +2680,6 @@ H5Pset_external(hid_t plist_id, const char *name, HDoff_t offset, hsize_t size)
     /* Check arguments */
     if (!name || !*name)
         HGOTO_ERROR(H5E_ARGS, H5E_BADVALUE, FAIL, "no name given");
-    if (offset < 0)
-        HGOTO_ERROR(H5E_ARGS, H5E_BADVALUE, FAIL, "negative external file offset");
 
     /* Get the plist structure */
     if (NULL == (plist = H5P_object_verify(plist_id, H5P_DATASET_CREATE, false)))
@@ -2784,7 +2780,7 @@ done:
  *-------------------------------------------------------------------------
  */
 herr_t
-H5Pget_external(hid_t plist_id, unsigned idx, size_t name_size, char *name /*out*/, HDoff_t *offset /*out*/,
+H5Pget_external(hid_t plist_id, unsigned idx, size_t name_size, char *name /*out*/, uint64_t *offset /*out*/,
                 hsize_t *size /*out*/)
 {
     H5O_efl_t       efl;

--- a/src/H5Ppublic.h
+++ b/src/H5Ppublic.h
@@ -6042,13 +6042,13 @@ H5_DLL herr_t H5Pget_dset_no_attrs_hint(hid_t dcpl_id, hbool_t *minimize);
  *          which is a 32-bit signed long value on Windows, which limited
  *          the valid offset that can be returned to 2 GiB.
  *
- * \version 2.0.0 \p offset parameter type changed to HDoff_t from off_t.
+ * \version 2.0.0 \p offset parameter type changed to uint64_t from off_t.
  * \version 1.6.4 \p idx parameter type changed to unsigned.
  * \since 1.0.0
  *
  */
 H5_DLL herr_t H5Pget_external(hid_t plist_id, unsigned idx, size_t name_size, char *name /*out*/,
-                              HDoff_t *offset /*out*/, hsize_t *size /*out*/);
+                              uint64_t *offset /*out*/, hsize_t *size /*out*/);
 /**
  * \ingroup DCPL
  *
@@ -6539,11 +6539,11 @@ H5_DLL herr_t H5Pset_dset_no_attrs_hint(hid_t dcpl_id, hbool_t minimize);
  *          which is a 32-bit signed long value on Windows, which limited
  *          the valid offset that can be set to 2 GiB.
  *
- * \version 2.0.0 \p offset parameter type changed to HDoff_t from off_t.
+ * \version 2.0.0 \p offset parameter type changed to uint64_t from off_t.
  * \since 1.0.0
  *
  */
-H5_DLL herr_t H5Pset_external(hid_t plist_id, const char *name, HDoff_t offset, hsize_t size);
+H5_DLL herr_t H5Pset_external(hid_t plist_id, const char *name, uint64_t offset, hsize_t size);
 /**
  * \ingroup DCPL
  *

--- a/src/H5private.h
+++ b/src/H5private.h
@@ -594,9 +594,25 @@ typedef double _Complex H5_double_complex;
 typedef long double _Complex H5_ldouble_complex;
 #endif
 
+/* off_t exists on Windows, but is always a 32-bit long, even on 64-bit Windows,
+ * so on Windows we define HDoff_t to be int64_t, which is equivalent to __int64,
+ * the type of the st_size field of the _stati64 struct.
+ */
+#ifdef H5_HAVE_WIN32_API
+/**
+ * Platform-independent offset
+ */
+typedef int64_t HDoff_t;
+#else
+/**
+ * Platform-independent offset
+ */
+typedef off_t HDoff_t;
+#endif
+
 /* __int64 is the correct type for the st_size field of the _stati64
  * struct on Windows (MSDN isn't very clear about this). POSIX systems use
- * off_t. Both of these are typedef'd to HDoff_t in H5public.h.
+ * off_t. Both of these are typedef'd to HDoff_t above.
  */
 typedef HDoff_t h5_stat_size_t;
 

--- a/src/H5public.h
+++ b/src/H5public.h
@@ -315,22 +315,6 @@ typedef long long ssize_t;
  */
 typedef uint64_t hsize_t;
 
-/* off_t exists on Windows, but is always a 32-bit long, even on 64-bit Windows,
- * so on Windows we define HDoff_t to be int64_t, which is equivalent to __int64,
- * the type of the st_size field of the _stati64 struct.
- */
-#ifdef H5_HAVE_WIN32_API
-/**
- * Platform-independent offset
- */
-typedef int64_t HDoff_t;
-#else
-/**
- * Platform-independent offset
- */
-typedef off_t HDoff_t;
-#endif
-
 #ifdef H5_HAVE_PARALLEL
 #define HSIZE_AS_MPI_TYPE MPI_UINT64_T
 #endif

--- a/test/external.c
+++ b/test/external.c
@@ -91,15 +91,15 @@ out:
 static int
 test_non_extendible(hid_t file)
 {
-    hid_t   dcpl        = H5I_INVALID_HID; /* dataset creation properties          */
-    hid_t   space       = H5I_INVALID_HID; /* data space                           */
-    hid_t   dset        = H5I_INVALID_HID; /* dataset                              */
-    hsize_t cur_size[1] = {100};           /* data space current size              */
-    hsize_t max_size[1] = {100};           /* data space maximum size              */
-    int     n           = 0;               /* number of external files             */
-    HDoff_t file_offset = 0;               /* external file offset                 */
-    hsize_t file_size   = 0;               /* sizeof external file segment         */
-    haddr_t dset_addr   = HADDR_UNDEF;     /* address of dataset                   */
+    hid_t    dcpl        = H5I_INVALID_HID; /* dataset creation properties          */
+    hid_t    space       = H5I_INVALID_HID; /* data space                           */
+    hid_t    dset        = H5I_INVALID_HID; /* dataset                              */
+    hsize_t  cur_size[1] = {100};           /* data space current size              */
+    hsize_t  max_size[1] = {100};           /* data space maximum size              */
+    int      n           = 0;               /* number of external files             */
+    uint64_t file_offset = 0;               /* external file offset                 */
+    hsize_t  file_size   = 0;               /* sizeof external file segment         */
+    haddr_t  dset_addr   = HADDR_UNDEF;     /* address of dataset                   */
 
     TESTING("fixed-size data space, exact storage");
 
@@ -357,14 +357,14 @@ error:
 static int
 test_unlimited(hid_t file)
 {
-    hid_t   dcpl        = H5I_INVALID_HID; /* dataset creation properties   */
-    hid_t   space       = H5I_INVALID_HID; /* data space                    */
-    hid_t   dset        = H5I_INVALID_HID; /* dataset                       */
-    hsize_t cur_size[1] = {100};           /* data space current size       */
-    hsize_t max_size[1] = {H5S_UNLIMITED}; /* data space maximum size       */
-    int     n;                             /* number of external files      */
-    HDoff_t file_offset;                   /* external file offset          */
-    hsize_t file_size;                     /* sizeof external file segment  */
+    hid_t    dcpl        = H5I_INVALID_HID; /* dataset creation properties   */
+    hid_t    space       = H5I_INVALID_HID; /* data space                    */
+    hid_t    dset        = H5I_INVALID_HID; /* dataset                       */
+    hsize_t  cur_size[1] = {100};           /* data space current size       */
+    hsize_t  max_size[1] = {H5S_UNLIMITED}; /* data space maximum size       */
+    int      n;                             /* number of external files      */
+    uint64_t file_offset;                   /* external file offset          */
+    hsize_t  file_size;                     /* sizeof external file segment  */
 
     TESTING("unlimited dataspace, unlimited external storage");
 
@@ -446,7 +446,7 @@ error:
  *-------------------------------------------------------------------------
  */
 static int
-add_external_files(hid_t dcpl_id, unsigned int n_external_files, HDoff_t offset, hsize_t max_ext_size)
+add_external_files(hid_t dcpl_id, unsigned int n_external_files, uint64_t offset, hsize_t max_ext_size)
 {
     char         exname[AEF_EXNAME_MAX_LEN + 1];
     unsigned int i = 0;
@@ -704,7 +704,7 @@ test_read_file_set(hid_t fapl)
         FAIL_STACK_ERROR;
     for (i = 0; i < N_EXT_FILES; i++) {
         snprintf(filename, sizeof(filename), "extern_%dr.raw", (int)i + 1);
-        if (H5Pset_external(dcpl, filename, (HDoff_t)(i * GARBAGE_PER_FILE), (hsize_t)sizeof(part)) < 0)
+        if (H5Pset_external(dcpl, filename, (uint64_t)(i * GARBAGE_PER_FILE), (hsize_t)sizeof(part)) < 0)
             FAIL_STACK_ERROR;
     }
 
@@ -823,7 +823,7 @@ test_write_file_set(hid_t fapl)
         else
             size = H5F_UNLIMITED;
 
-        if (H5Pset_external(dcpl, filename, (HDoff_t)(i * GARBAGE_PER_FILE), size) < 0)
+        if (H5Pset_external(dcpl, filename, (uint64_t)(i * GARBAGE_PER_FILE), size) < 0)
             FAIL_STACK_ERROR;
     } /* end for */
 
@@ -948,7 +948,7 @@ test_path_absolute(hid_t fapl)
         if (i == 1)
             snprintf(filename, sizeof(filename), "%s%sextern_%zur.raw", cwdpath + 2, H5_DIR_SEPS, i + 1);
 #endif
-        if (H5Pset_external(dcpl, filename, (HDoff_t)(i * GARBAGE_PER_FILE), (hsize_t)sizeof(part)) < 0)
+        if (H5Pset_external(dcpl, filename, (uint64_t)(i * GARBAGE_PER_FILE), (hsize_t)sizeof(part)) < 0)
             FAIL_STACK_ERROR;
     }
 
@@ -1038,7 +1038,7 @@ test_path_relative(hid_t fapl)
         FAIL_STACK_ERROR;
     for (i = 0; i < N_EXT_FILES; i++) {
         snprintf(filename, sizeof(filename), "extern_%dr.raw", (int)i + 1);
-        if (H5Pset_external(dcpl, filename, (HDoff_t)(i * GARBAGE_PER_FILE), (hsize_t)sizeof(part)) < 0)
+        if (H5Pset_external(dcpl, filename, (uint64_t)(i * GARBAGE_PER_FILE), (hsize_t)sizeof(part)) < 0)
             FAIL_STACK_ERROR;
     }
 
@@ -1132,7 +1132,7 @@ test_path_relative_cwd(hid_t fapl)
         FAIL_STACK_ERROR;
     for (i = 0; i < N_EXT_FILES; i++) {
         snprintf(filename, sizeof(filename), "..%sextern_%dr.raw", H5_DIR_SEPS, (int)i + 1);
-        if (H5Pset_external(dcpl, filename, (HDoff_t)(i * GARBAGE_PER_FILE), (hsize_t)sizeof(part)) < 0)
+        if (H5Pset_external(dcpl, filename, (uint64_t)(i * GARBAGE_PER_FILE), (hsize_t)sizeof(part)) < 0)
             FAIL_STACK_ERROR;
     }
 

--- a/test/external_env.c
+++ b/test/external_env.c
@@ -68,7 +68,7 @@ test_path_env(hid_t fapl)
         FAIL_STACK_ERROR;
     for (i = 0; i < N_EXT_FILES; i++) {
         snprintf(filename, sizeof(filename), "..%sextern_env_%dr.raw", H5_DIR_SEPS, (int)i + 1);
-        if (H5Pset_external(dcpl, filename, (HDoff_t)(i * GARBAGE_PER_FILE), (hsize_t)sizeof(part)) < 0)
+        if (H5Pset_external(dcpl, filename, (uint64_t)(i * GARBAGE_PER_FILE), (hsize_t)sizeof(part)) < 0)
             FAIL_STACK_ERROR;
     } /* end for */
 

--- a/test/set_extent.c
+++ b/test/set_extent.c
@@ -1838,9 +1838,9 @@ test_external(hid_t fapl, bool use_select_io)
 
     {
 
-        char    name[256];   /*external file name        */
-        HDoff_t file_offset; /*external file offset        */
-        hsize_t file_size;   /*sizeof external file segment    */
+        char     name[256];   /* External file name */
+        uint64_t file_offset; /* External file offset */
+        hsize_t  file_size;   /* Size of external file segment */
 
         if (H5Pget_external(dcpl, 0, sizeof(name), name, &file_offset, &file_size) < 0)
             FAIL_STACK_ERROR;

--- a/tools/lib/h5tools_dump.c
+++ b/tools/lib/h5tools_dump.c
@@ -3190,7 +3190,7 @@ h5tools_dump_dcpl(FILE *stream, const h5tool_format_t *info, h5tools_context_t *
     H5D_layout_t     stl      = H5D_LAYOUT_ERROR;
     size_t           ncols    = 80; /* available output width        */
     size_t           cd_nelmts;     /* filter client number of values */
-    HDoff_t          offset;        /* offset of external file     */
+    uint64_t         offset;        /* offset of external file     */
     char             f_name[256];   /* filter name */
     char             name[256];     /* external or virtual file name       */
     hsize_t          chsize[64];    /* chunk size in elements */
@@ -3342,11 +3342,7 @@ h5tools_dump_dcpl(FILE *stream, const h5tool_format_t *info, h5tools_context_t *
 
                     h5tools_str_reset(&buffer);
                     h5tools_str_append(&buffer, "FILENAME %s SIZE %" PRIuHSIZE, name, size);
-                    /* Using %lld with a cast to (long long) is probably the only portable
-                     * way to print off_t values. There's no real standard for off_t other
-                     * than it must be signed, according to POSIX.
-                     */
-                    h5tools_str_append(&buffer, " OFFSET %lld", (long long)offset);
+                    h5tools_str_append(&buffer, " OFFSET %" PRIu64 "", offset);
                     h5tools_render_element(stream, info, ctx, &buffer, &curr_pos, (size_t)ncols, (hsize_t)0,
                                            (hsize_t)0);
                 }

--- a/tools/src/h5ls/h5ls.c
+++ b/tools/src/h5ls/h5ls.c
@@ -1917,7 +1917,7 @@ dataset_list2(hid_t dset, const char H5_ATTR_UNUSED *name)
     size_t            cd_num;                      /* filter client data counter */
     char              f_name[256];                 /* filter/file name */
     char              s[64];                       /* temporary string buffer */
-    HDoff_t           f_offset;                    /* offset in external file */
+    uint64_t          f_offset;                    /* offset in external file */
     hsize_t           f_size;                      /* bytes used in external file */
     hsize_t           total, used;                 /* total size or offset */
     int               ndims;                       /* dimensionality */

--- a/tools/src/misc/h5repart.c
+++ b/tools/src/misc/h5repart.c
@@ -376,7 +376,7 @@ main(int argc, char *argv[])
          * needed. The first member is extended to the logical member size
          * but other members might be smaller if they end with a hole.
          */
-        dst_offset = dst_offset + (off_t)n;
+        dst_offset = dst_offset + (HDoff_t)n;
         if (dst_is_family && dst_offset == dst_size) {
             if (0 == dst_membno) {
                 if (HDlseek(dst, dst_size - 1, SEEK_SET) < 0) {


### PR DESCRIPTION
Supporting off_t is a pain on Windows and is only used in one
pair of public API calls, where it's semantically odd because
negative values aren't allowed.

This PR removes off_t and replaces it with uint64_t.

* Remove off_t from H5Pset/get_external() calls
* Remove off_t from set/getExternal() C++ calls
* Remove off_t from the Fortran interface
* Remove OFF_T as a Fortran INTEGER KIND

Internally, HDoff_t remains in a few places where it's used
in POSIX I/O calls.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Replace `off_t` with `uint64_t` in HDF5 external file interfaces for better Windows compatibility.
> 
>   - **Behavior**:
>     - Replace `off_t` with `uint64_t` in `H5Pset_external()` and `H5Pget_external()` in `H5Pdcpl.c` and `H5Ppublic.h`.
>     - Update C++ methods `setExternal()` and `getExternal()` in `H5DcreatProp.cpp` and `H5DcreatProp.h` to use `uint64_t`.
>     - Modify Fortran interfaces `h5pset_external_c()` and `h5pget_external_c()` in `H5Pf.c` and `H5Pff.F90` to use `uint64_t_f`.
>   - **Fortran**:
>     - Remove `OFF_T` as a Fortran INTEGER KIND in `H5match_types.c`.
>   - **Java**:
>     - Change `offset` parameter to `uint64_t` in `h5pDCPLImp.c`.
>   - **Documentation**:
>     - Update `RELEASE.txt` to reflect changes in offset parameter types and removal of `OFF_T`.
>   - **Misc**:
>     - Internal `HDoff_t` usage remains for POSIX I/O calls in `H5Defl.c` and `H5FDstdio.c`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=HDFGroup%2Fhdf5&utm_source=github&utm_medium=referral)<sup> for cc4a37f81146cd1c3976a16cb46b383c686c36e2. You can [customize](https://app.ellipsis.dev/HDFGroup/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->