### PR TITLE
Remove "CMake" from CI names, descriptions, etc.

### DIFF
--- a/.github/workflows/aocc-cmake.yml
+++ b/.github/workflows/aocc-cmake.yml
@@ -1,4 +1,4 @@
-name: hdf5 dev PAR CMake aocc ompi
+name: hdf5 dev PAR aocc ompi
 
 # Triggers the workflow on a call from another workflow
 on:
@@ -65,7 +65,7 @@ jobs:
           make
           make install
 
-      - name: CMake Configure
+      - name: Configure
         shell: bash
         run: |
           export LD_LIBRARY_PATH=/home/runner/work/hdf5/hdf5/aocc-compiler-${{ env.AOCCVERDOT }}/lib:/home/runner/work/hdf5/hdf5/openmpi-${{ env.MPIVERDOT }}-install/lib:/usr/local/lib
@@ -88,19 +88,19 @@ jobs:
           $GITHUB_WORKSPACE
           #cat src/libhdf5.settings
 
-      - name: CMake Build
+      - name: Build
         shell: bash
         run: |
           cmake --build . --parallel 3 --config ${{ inputs.build_mode }}
         working-directory: ${{ runner.workspace }}/build
 
-      - name: CMake Run Tests
+      - name: Run Tests
         shell: bash
         run: |
           ctest . -E MPI_TEST --parallel 2 -C ${{ inputs.build_mode }} -V
         working-directory: ${{ runner.workspace }}/build
 
-      - name: CMake Run Parallel Tests
+      - name: Run Parallel Tests
         shell: bash
         run: |
           ctest . -R MPI_TEST -E "_by_chunk|_by_pattern" -C ${{ inputs.build_mode }} -V

--- a/.github/workflows/arm-main-cmake.yml
+++ b/.github/workflows/arm-main-cmake.yml
@@ -1,4 +1,4 @@
-name: hdf5 dev CMake CI
+name: hdf5 dev CI
 
 # Triggers the workflow on a call from another workflow
 on:
@@ -62,8 +62,8 @@ jobs:
       - name: Get Sources
         uses: actions/checkout@v4.1.7
 
-      # CMAKE CONFIGURE
-      - name: CMake Configure
+      # CONFIGURE
+      - name: Configure
         run: |
           mkdir "${{ runner.workspace }}/build"
           cd "${{ runner.workspace }}/build"
@@ -84,7 +84,7 @@ jobs:
         shell: bash
         if: ${{ inputs.thread_safety != 'TS' && inputs.concurrent != 'CC'}}
 
-      - name: CMake Configure (Thread-Safe)
+      - name: Configure (Thread-Safe)
         run: |
           mkdir "${{ runner.workspace }}/build"
           cd "${{ runner.workspace }}/build"
@@ -108,7 +108,7 @@ jobs:
         shell: bash
         if: ${{ inputs.thread_safety == 'TS' && inputs.concurrent != 'CC'}}
 
-      - name: CMake Configure (Concurrency)
+      - name: Configure (Concurrency)
         run: |
           mkdir "${{ runner.workspace }}/build"
           cd "${{ runner.workspace }}/build"
@@ -132,16 +132,16 @@ jobs:
         if: ${{ inputs.thread_safety != 'TS' && inputs.concurrent == 'CC'}}
 
       # BUILD
-      - name: CMake Build
+      - name: Build
         run: cmake --build . --parallel 3 --config ${{ inputs.build_mode }}
         working-directory: ${{ runner.workspace }}/build
 
       # RUN TESTS
-      - name: CMake Run Tests
+      - name: Run Tests
         run: ctest . --parallel 2 -C ${{ inputs.build_mode }} -V
         working-directory: ${{ runner.workspace }}/build
 
-      - name: CMake Run Package
+      - name: Run Package
         run: cpack -C ${{ inputs.build_mode }} -V
         working-directory: ${{ runner.workspace }}/build
 
@@ -149,7 +149,7 @@ jobs:
         run: |
               ls -l ${{ runner.workspace }}/build
 
-      # Save files created by ctest script
+      # Save files created by CTest script
       - name: Save published binary (Windows)
         uses: actions/upload-artifact@v4
         with:
@@ -162,7 +162,7 @@ jobs:
     name: "Ubuntu gcc-${{ inputs.build_mode }}-${{ inputs.thread_safety }}-${{ inputs.concurrent }}"
     runs-on: ubuntu-24.04-arm
     steps:
-      - name: Install CMake Dependencies (Linux)
+      - name: Install Dependencies (Linux)
         run: |
           sudo apt-get update
           sudo apt-get install ninja-build graphviz
@@ -177,8 +177,8 @@ jobs:
       - name: Get Sources
         uses: actions/checkout@v4.1.7
 
-      # CMAKE CONFIGURE
-      - name: CMake Configure
+      # CONFIGURE
+      - name: Configure
         run: |
            mkdir "${{ runner.workspace }}/build"
            cd "${{ runner.workspace }}/build"
@@ -198,7 +198,7 @@ jobs:
         shell: bash
         if: ${{ inputs.thread_safety != 'TS' && inputs.concurrent != 'CC'}}
 
-      - name: CMake Configure (Thread-Safe)
+      - name: Configure (Thread-Safe)
         run: |
            mkdir "${{ runner.workspace }}/build"
            cd "${{ runner.workspace }}/build"
@@ -222,7 +222,7 @@ jobs:
         shell: bash
         if: ${{ inputs.thread_safety == 'TS' && inputs.concurrent != 'CC'}}
 
-      - name: CMake Configure (Concurrency)
+      - name: Configure (Concurrency)
         run: |
            mkdir "${{ runner.workspace }}/build"
            cd "${{ runner.workspace }}/build"
@@ -244,16 +244,16 @@ jobs:
         if: ${{ inputs.thread_safety != 'TS' && inputs.concurrent == 'CC'}}
 
       # BUILD
-      - name: CMake Build
+      - name: Build
         run: cmake --build . --parallel 3 --config ${{ inputs.build_mode }}
         working-directory: ${{ runner.workspace }}/build
 
       # RUN TESTS
-      - name: CMake Run Tests
+      - name: Run Tests
         run: ctest . --parallel 2 -C ${{ inputs.build_mode }} -V
         working-directory: ${{ runner.workspace }}/build
 
-      - name: CMake Run Package
+      - name: Run Package
         run: cpack -C ${{ inputs.build_mode }} -V
         working-directory: ${{ runner.workspace }}/build
 
@@ -297,8 +297,8 @@ jobs:
       - name: Get Sources
         uses: actions/checkout@v4.1.7
 
-      # CMAKE CONFIGURE
-      - name: CMake Configure
+      # CONFIGURE
+      - name: Configure
         run: |
           mkdir "${{ runner.workspace }}/build"
           cd "${{ runner.workspace }}/build"
@@ -322,7 +322,7 @@ jobs:
         shell: bash
         if: ${{ inputs.thread_safety != 'TS' && inputs.concurrent != 'CC'}}
 
-      - name: CMake Configure (Thread-Safe)
+      - name: Configure (Thread-Safe)
         run: |
           mkdir "${{ runner.workspace }}/build"
           cd "${{ runner.workspace }}/build"
@@ -347,7 +347,7 @@ jobs:
         shell: bash
         if: ${{ inputs.thread_safety == 'TS' && inputs.concurrent != 'CC'}}
 
-      - name: CMake Configure (Concurrency)
+      - name: Configure (Concurrency)
         run: |
           mkdir "${{ runner.workspace }}/build"
           cd "${{ runner.workspace }}/build"
@@ -370,16 +370,16 @@ jobs:
         if: ${{ inputs.thread_safety != 'TS' && inputs.concurrent == 'CC'}}
 
       # BUILD
-      - name: CMake Build
+      - name: Build
         run: cmake --build . --parallel 3 --config ${{ inputs.build_mode }}
         working-directory: ${{ runner.workspace }}/build
 
       # RUN TESTS
-      - name: CMake Run Tests
+      - name: Run Tests
         run: ctest . --parallel 2 -C ${{ inputs.build_mode }} -V
         working-directory: ${{ runner.workspace }}/build
 
-      - name: CMake Run Package
+      - name: Run Package
         run: cpack -C ${{ inputs.build_mode }} -V
         working-directory: ${{ runner.workspace }}/build
 

--- a/.github/workflows/cmake-analysis.yml
+++ b/.github/workflows/cmake-analysis.yml
@@ -1,4 +1,4 @@
-name: hdf5 dev ctest analysis runs
+name: hdf5 dev CTest analysis runs
 
 # Triggers the workflow on a call from another workflow
 on:
@@ -29,7 +29,7 @@ jobs:
     name: "Ubuntu GCC Coverage"
     runs-on: ubuntu-22.04
     steps:
-    - name: Install CMake Dependencies (Linux_coverage)
+    - name: Install Dependencies (Linux_coverage)
       run: |
         sudo apt update
         sudo apt-get install ninja-build doxygen graphviz curl build-essential
@@ -104,14 +104,14 @@ jobs:
             set (ADD_BUILD_OPTIONS "${ADD_BUILD_OPTIONS} -DHDF5_PACKAGE_EXTLIBS:BOOL=OFF")
             set (ADD_BUILD_OPTIONS "${ADD_BUILD_OPTIONS} -DHDF5_NO_PACKAGES:BOOL=ON")
 
-    - name: Run ctest (Linux_coverage)
+    - name: Run CTest (Linux_coverage)
       run: |
         cd "${{ runner.workspace }}/hdf5"
         ctest -S HDF5config.cmake,CTEST_SITE_EXT=${{ github.event.repository.full_name }}_COV,LOCAL_SUBMIT=ON,NINJA=TRUE,BUILD_GENERATOR=Unix,CTEST_SOURCE_NAME=${{ steps.set-file-base.outputs.SOURCE_BASE }} -C Debug -VV -O hdf5.log
       shell: bash
       continue-on-error: true
 
-    # Save log files created by ctest script
+    # Save log files created by CTest script
     - name: Save log (Linux_coverage)
       uses: actions/upload-artifact@v4
       with:
@@ -125,7 +125,7 @@ jobs:
     name: "Ubuntu Clang LeakSanitizer"
     runs-on: ubuntu-22.04
     steps:
-      - name: Install CMake Dependencies (Linux_Leak)
+      - name: Install Dependencies (Linux_Leak)
         run: |
           sudo apt update
           sudo apt-get install ninja-build doxygen graphviz curl libtinfo5
@@ -205,14 +205,14 @@ jobs:
               set (ADD_BUILD_OPTIONS "${ADD_BUILD_OPTIONS} -DZLIB_USE_LOCALCONTENT:BOOL=OFF")
               set (ADD_BUILD_OPTIONS "${ADD_BUILD_OPTIONS} -DPLUGIN_USE_LOCALCONTENT:BOOL=OFF")
 
-      - name: Run ctest (Linux_Leak)
+      - name: Run CTest (Linux_Leak)
         run: |
           cd "${{ runner.workspace }}/hdf5"
           ctest -S HDF5config.cmake,CTEST_SITE_EXT=${{ github.event.repository.full_name }}-LEAK,LOCAL_SUBMIT=ON,NINJA=TRUE,BUILD_GENERATOR=Unix,CTEST_SOURCE_NAME=${{ steps.set-file-base.outputs.SOURCE_BASE }} -C Debug -VV -O hdf5.log
         shell: bash
         continue-on-error: true
 
-      # Save log files created by ctest script
+      # Save log files created by CTest script
       - name: Save log (Linux_Leak)
         uses: actions/upload-artifact@v4
         with:
@@ -226,7 +226,7 @@ jobs:
     name: "Ubuntu Clang AddressSanitizer"
     runs-on: ubuntu-22.04
     steps:
-      - name: Install CMake Dependencies (Linux_Address)
+      - name: Install Dependencies (Linux_Address)
         run: |
           sudo apt update
           sudo apt-get install ninja-build doxygen graphviz curl libtinfo5
@@ -306,14 +306,14 @@ jobs:
               set (ADD_BUILD_OPTIONS "${ADD_BUILD_OPTIONS} -DZLIB_USE_LOCALCONTENT:BOOL=OFF")
               set (ADD_BUILD_OPTIONS "${ADD_BUILD_OPTIONS} -DPLUGIN_USE_LOCALCONTENT:BOOL=OFF")
 
-      - name: Run ctest (Linux_Address)
+      - name: Run CTest (Linux_Address)
         run: |
           cd "${{ runner.workspace }}/hdf5"
           ctest -S HDF5config.cmake,CTEST_SITE_EXT=${{ github.event.repository.full_name }}-ADDR,LOCAL_SUBMIT=ON,NINJA=TRUE,BUILD_GENERATOR=Unix,CTEST_SOURCE_NAME=${{ steps.set-file-base.outputs.SOURCE_BASE }} -C Debug -VV -O hdf5.log
         shell: bash
         continue-on-error: true
 
-      # Save log files created by ctest script
+      # Save log files created by CTest script
       - name: Save log (Linux_Address)
         uses: actions/upload-artifact@v4
         with:
@@ -327,7 +327,7 @@ jobs:
     name: "Ubuntu Clang UndefinedBehaviorSanitizer"
     runs-on: ubuntu-22.04
     steps:
-      - name: Install CMake Dependencies (Linux_UndefinedBehavior)
+      - name: Install Dependencies (Linux_UndefinedBehavior)
         run: |
           sudo apt update
           sudo apt-get install ninja-build doxygen graphviz curl libtinfo5
@@ -407,14 +407,14 @@ jobs:
               set (ADD_BUILD_OPTIONS "${ADD_BUILD_OPTIONS} -DZLIB_USE_LOCALCONTENT:BOOL=OFF")
               set (ADD_BUILD_OPTIONS "${ADD_BUILD_OPTIONS} -DPLUGIN_USE_LOCALCONTENT:BOOL=OFF")
 
-      - name: Run ctest (Linux_UndefinedBehavior)
+      - name: Run CTest (Linux_UndefinedBehavior)
         run: |
           cd "${{ runner.workspace }}/hdf5"
           ctest -S HDF5config.cmake,CTEST_SITE_EXT=${{ github.event.repository.full_name }}-UNDEF,LOCAL_SUBMIT=ON,NINJA=TRUE,BUILD_GENERATOR=Unix,CTEST_SOURCE_NAME=${{ steps.set-file-base.outputs.SOURCE_BASE }} -C Debug -VV -O hdf5.log
         shell: bash
         continue-on-error: true
 
-      # Save log files created by ctest script
+      # Save log files created by CTest script
       - name: Save log (Linux_UndefinedBehavior)
         uses: actions/upload-artifact@v4
         with:

--- a/.github/workflows/cmake-bintest.yml
+++ b/.github/workflows/cmake-bintest.yml
@@ -14,7 +14,7 @@ permissions:
 
 jobs:
   test_binary_win:
-  # Windows w/ MSVC + CMake
+  # Windows w/ MSVC
   #
     name: "Windows MSVC Binary Test"
     runs-on: windows-latest
@@ -80,7 +80,7 @@ jobs:
               Get-ChildItem -Path ${{ runner.workspace }}
         shell: pwsh
 
-      - name: Run ctest (Windows)
+      - name: Run CTest (Windows)
         env:
           HDF5_ROOT: ${{ steps.set-hdf5lib-name.outputs.HDF5_ROOT }}
           HDF5_PLUGIN_PATH: ${{ steps.set-hdf5lib-name.outputs.HDF5_PLUGIN_PATH }}
@@ -90,12 +90,12 @@ jobs:
         shell: bash
 
   test_binary_linux:
-  # Linux (Ubuntu) w/ gcc + CMake
+  # Linux (Ubuntu) w/ gcc
   #
     name: "Ubuntu gcc Binary Test"
     runs-on: ubuntu-latest
     steps:
-      - name: Install CMake Dependencies (Linux)
+      - name: Install Dependencies (Linux)
         run: |
           sudo apt-get update
           sudo apt-get install ninja-build doxygen graphviz
@@ -134,7 +134,7 @@ jobs:
               ls -l ${{ github.workspace }}
               ls ${{ runner.workspace }}
 
-      - name: Run ctest (Linux)
+      - name: Run CTest (Linux)
         env:
           HDF5_ROOT: ${{ steps.set-hdf5lib-name.outputs.HDF5_ROOT }}
           HDF5_PLUGIN_PATH: ${{ steps.set-hdf5lib-name.outputs.HDF5_PLUGIN_PATH }}
@@ -144,7 +144,7 @@ jobs:
         shell: bash
 
   test_binary_mac_latest:
-  # MacOS w/ Clang + CMake
+  # MacOS w/ Clang
   #
     name: "MacOS Clang Binary Test"
     runs-on: macos-latest
@@ -194,7 +194,7 @@ jobs:
           compiler: gcc
           version: 14
 
-      - name: Run ctest (MacOS_latest)
+      - name: Run CTest (MacOS_latest)
         id: run-ctest
         env:
           HDF5_ROOT: ${{ steps.set-hdf5lib-name.outputs.HDF5_ROOT }}
@@ -205,12 +205,12 @@ jobs:
         shell: bash
 
   test_h5cc_linux:
-  # Linux (Ubuntu) w/ gcc + CMake
+  # Linux (Ubuntu) w/ gcc
   #
     name: "Ubuntu h5cc Binary Test"
     runs-on: ubuntu-latest
     steps:
-      - name: Install CMake Dependencies (Linux)
+      - name: Install Dependencies (Linux)
         run: |
           sudo apt-get update
           sudo apt-get install ninja-build doxygen graphviz

--- a/.github/workflows/cmake-ctest.yml
+++ b/.github/workflows/cmake-ctest.yml
@@ -1,4 +1,4 @@
-name: hdf5 dev ctest runs
+name: hdf5 dev CTest runs
 
 # Triggers the workflow on a call from another workflow
 on:
@@ -73,7 +73,7 @@ jobs:
       - run: echo "signing is ${{ steps.set-signing-state.outputs.BINSIGN }}."
 
   build_and_test_win:
-  # Windows w/ MSVC + CMake
+  # Windows w/ MSVC
   #
     name: "Windows MSVC CTest"
     runs-on: windows-latest
@@ -155,7 +155,7 @@ jobs:
             json: '{"Endpoint": "${{ secrets.AZURE_ENDPOINT }}","CodeSigningAccountName": "${{ secrets.AZURE_CODE_SIGNING_NAME }}","CertificateProfileName": "${{ secrets.AZURE_CERT_PROFILE_NAME }}"}'
         if: ${{ needs.check-secret.outputs.sign-state == 'exists' }}
 
-      - name: Run ctest (Windows)
+      - name: Run CTest (Windows)
         env:
           BINSIGN: ${{ needs.check-secret.outputs.sign-state }}
           SIGNTOOLDIR: ${{ github.workspace }}/Microsoft.Windows.SDK.BuildTools/bin/10.0.22621.0/x64
@@ -205,7 +205,7 @@ jobs:
               Get-ChildItem -Path ${{ runner.workspace }}
         shell: pwsh
 
-      # Save files created by ctest script
+      # Save files created by CTest script
       - name: Save published binary (Windows)
         uses: actions/upload-artifact@v4
         with:
@@ -221,13 +221,13 @@ jobs:
               if-no-files-found: error # 'warn' or 'ignore' are also available, defaults to `warn`
 
   build_and_test_linux:
-  # Linux (Ubuntu) w/ gcc + CMake
+  # Linux (Ubuntu) w/ gcc
   #
-    name: "Ubuntu gcc CMake"
+    name: "Ubuntu gcc"
     runs-on: ubuntu-latest
     needs: [check-secret]
     steps:
-      - name: Install CMake Dependencies (Linux)
+      - name: Install Dependencies (Linux)
         run: |
           sudo apt-get update
           sudo apt-get install ninja-build graphviz
@@ -277,7 +277,7 @@ jobs:
       - name: Uncompress source (Linux)
         run: tar -zxvf ${{ github.workspace }}/${{ steps.set-file-base.outputs.FILE_BASE }}.tar.gz
 
-      - name: Run ctest (Linux)
+      - name: Run CTest (Linux)
         run: |
           cd "${{ runner.workspace }}/hdf5/${{ steps.set-file-base.outputs.SOURCE_BASE }}"
           cmake --workflow --preset=${{ inputs.preset_name }}-GNUC --fresh
@@ -314,7 +314,7 @@ jobs:
               ls ${{ github.workspace }}
               ls -l ${{ runner.workspace }}
 
-      # Save files created by ctest script
+      # Save files created by CTest script
       - name: Save published binary (Linux)
         uses: actions/upload-artifact@v4
         with:
@@ -336,7 +336,7 @@ jobs:
               path: ${{ runner.workspace }}/buildrpm/${{ steps.set-file-base.outputs.FILE_BASE }}-ubuntu-2404_gcc.rpm
               if-no-files-found: error # 'warn' or 'ignore' are also available, defaults to `warn`
 
-      # Save doxygen files created by ctest script
+      # Save doxygen files created by CTest script
       - name: Save published doxygen (Linux)
         uses: actions/upload-artifact@v4
         with:
@@ -345,9 +345,9 @@ jobs:
               if-no-files-found: error # 'warn' or 'ignore' are also available, defaults to `warn`
 
   build_and_test_mac_latest:
-  # MacOS w/ Clang + CMake
+  # MacOS w/ Clang
   #
-    name: "MacOS Clang CMake"
+    name: "MacOS Clang"
     runs-on: macos-latest
     needs: [check-secret]
     steps:
@@ -441,7 +441,7 @@ jobs:
           compiler: gcc
           version: 14
 
-      - name: Run ctest (MacOS_latest)
+      - name: Run CTest (MacOS_latest)
         id: run-ctest
         env:
           BINSIGN: ${{ needs.check-secret.outputs.sign-state }}
@@ -561,7 +561,7 @@ jobs:
               ls ${{ github.workspace }}
               ls -l ${{ runner.workspace }}
 
-      # Save files created by ctest script
+      # Save files created by CTest script
       - name: Save published binary (MacOS_latest)
         uses: actions/upload-artifact@v4
         with:
@@ -577,12 +577,12 @@ jobs:
               if-no-files-found: error # 'warn' or 'ignore' are also available, defaults to `warn`
 
   build_and_test_S3_linux:
-  # Linux S3 (Ubuntu) w/ gcc + CMake
+  # Linux S3 (Ubuntu) w/ gcc
   #
-    name: "Ubuntu gcc CMake S3"
+    name: "Ubuntu gcc S3"
     runs-on: ubuntu-latest
     steps:
-      - name: Install CMake Dependencies (Linux S3)
+      - name: Install Dependencies (Linux S3)
         run: |
           sudo apt-get update
           sudo apt-get install ninja-build doxygen
@@ -640,7 +640,7 @@ jobs:
       - name: Uncompress source (Linux S3)
         run: tar -zxvf ${{ github.workspace }}/${{ steps.set-file-base.outputs.FILE_BASE }}.tar.gz
 
-      - name: Run ctest (Linux S3)
+      - name: Run CTest (Linux S3)
         run: |
           cd "${{ runner.workspace }}/hdf5/${{ steps.set-file-base.outputs.SOURCE_BASE }}"
           cmake --workflow --preset=${{ inputs.preset_name }}-GNUC-S3 --fresh
@@ -663,7 +663,7 @@ jobs:
               ls ${{ github.workspace }}
               ls -l ${{ runner.workspace }}
 
-      # Save files created by ctest script
+      # Save files created by CTest script
       - name: Save published binary (Linux S3)
         uses: actions/upload-artifact@v4
         with:
@@ -673,7 +673,7 @@ jobs:
 
 ####### intel builds
   build_and_test_win_intel:
-  # Windows w/ OneAPI + CMake
+  # Windows w/ OneAPI
   #
     name: "Windows Intel CTest"
     runs-on: windows-latest
@@ -748,7 +748,7 @@ jobs:
             json: '{"Endpoint": "${{ secrets.AZURE_ENDPOINT }}","CodeSigningAccountName": "${{ secrets.AZURE_CODE_SIGNING_NAME }}","CertificateProfileName": "${{ secrets.AZURE_CERT_PROFILE_NAME }}"}'
         if: ${{ needs.check-secret.outputs.sign-state == 'exists' }}
 
-      - name: Run ctest (Windows_intel) with oneapi
+      - name: Run CTest (Windows_intel) with oneapi
         env:
           FC: ${{ steps.setup-fortran.outputs.fc }}
           CC: ${{ steps.setup-fortran.outputs.cc }}
@@ -801,7 +801,7 @@ jobs:
               Get-ChildItem -Path ${{ runner.workspace }}
         shell: pwsh
 
-      # Save files created by ctest script
+      # Save files created by CTest script
       - name: Save published binary (Windows_intel)
         uses: actions/upload-artifact@v4
         with:
@@ -817,13 +817,13 @@ jobs:
               if-no-files-found: error # 'warn' or 'ignore' are also available, defaults to `warn`
 
   build_and_test_linux_intel:
-  # Linux (Ubuntu) w/ OneAPI + CMake
+  # Linux (Ubuntu) w/ OneAPI
   #
-    name: "Ubuntu Intel CMake"
+    name: "Ubuntu Intel"
     runs-on: ubuntu-latest
     needs: [check-secret]
     steps:
-      - name: Install CMake Dependencies (Linux_intel)
+      - name: Install Dependencies (Linux_intel)
         run: |
           sudo apt-get update
           sudo apt-get install ninja-build doxygen graphviz
@@ -869,7 +869,7 @@ jobs:
       - name: Uncompress source (Linux_intel)
         run: tar -zxvf ${{ github.workspace }}/${{ steps.set-file-base.outputs.FILE_BASE }}.tar.gz
 
-      - name: Run ctest (Linux_intel)
+      - name: Run CTest (Linux_intel)
         env:
           FC: ${{ steps.setup-fortran.outputs.fc }}
           CC: ${{ steps.setup-fortran.outputs.cc }}
@@ -895,7 +895,7 @@ jobs:
               ls ${{ github.workspace }}
               ls -l ${{ runner.workspace }}
 
-      # Save files created by ctest script
+      # Save files created by CTest script
       - name: Save published binary (Linux_intel)
         uses: actions/upload-artifact@v4
         with:

--- a/.github/workflows/cmake-par-script.yml
+++ b/.github/workflows/cmake-par-script.yml
@@ -1,6 +1,6 @@
 name: hdf5 callable parallel report to cdash
 
-# Triggers hdf5 dev parallel ctest script the workflow on a call from another workflow
+# Triggers hdf5 dev parallel CTest script the workflow on a call from another workflow
 on:
   workflow_call:
     inputs:
@@ -31,7 +31,7 @@ permissions:
   contents: read
 
 jobs:
-  CMake_build_parallel_windows:
+  Build_parallel_windows:
     runs-on: windows-latest
     strategy:
       matrix:
@@ -146,28 +146,28 @@ jobs:
             set (ADD_BUILD_OPTIONS "${ADD_BUILD_OPTIONS} -DZLIB_USE_LOCALCONTENT:BOOL=OFF")
             set (ADD_BUILD_OPTIONS "${ADD_BUILD_OPTIONS} -DPLUGIN_USE_LOCALCONTENT:BOOL=OFF")
 
-      - name: Run ctest script (${{ matrix.mpi }})
+      - name: Run CTest script (${{ matrix.mpi }})
         run: |
           cd "${{ runner.workspace }}/hdf5"
           ctest -S HDF5config.cmake,CTEST_SITE_EXT=GH-${{ github.event.repository.full_name }}-${{ matrix.mpi }},LOCAL_SUBMIT=ON,NINJA=TRUE,BUILD_GENERATOR=VS202264,CTEST_SOURCE_NAME=${{ steps.set-file-base.outputs.SOURCE_BASE }} -C ${{ inputs.build_mode }} -VV -O hdf5.log
         shell: bash
         continue-on-error: true
 
-      # Save log files created by ctest script
+      # Save log files created by CTest script
       - name: Save log (${{ matrix.mpi }})
         uses: actions/upload-artifact@v4
         with:
           name: windows-${{ matrix.mpi }}-log
           path: ${{ runner.workspace }}/hdf5/hdf5.log
 
-  CMake_build_parallel_linux:
+  Build_parallel_linux:
     runs-on: ubuntu-latest
     strategy:
       matrix:
         mpi: [ 'mpich', 'openmpi', 'intelmpi']
     name: "Parallel ${{ matrix.mpi }} Linux-${{ inputs.build_mode }}"
     steps:
-      - name: Install CMake Dependencies (${{ matrix.mpi }})
+      - name: Install Dependencies (${{ matrix.mpi }})
         run: |
           sudo apt-get update
           sudo apt-get install ninja-build graphviz curl
@@ -266,21 +266,21 @@ jobs:
             set (ADD_BUILD_OPTIONS "${ADD_BUILD_OPTIONS} -DZLIB_USE_LOCALCONTENT:BOOL=OFF")
             set (ADD_BUILD_OPTIONS "${ADD_BUILD_OPTIONS} -DPLUGIN_USE_LOCALCONTENT:BOOL=OFF")
 
-      - name: Run ctest script (${{ matrix.mpi }})
+      - name: Run CTest script (${{ matrix.mpi }})
         run: |
           cd "${{ runner.workspace }}/hdf5"
           ctest -S HDF5config.cmake,CTEST_SITE_EXT=GH-${{ github.event.repository.full_name }}-${{ matrix.mpi }},LOCAL_SUBMIT=ON,NINJA=TRUE,BUILD_GENERATOR=Unix,CTEST_SOURCE_NAME=${{ steps.set-file-base.outputs.SOURCE_BASE }} -C ${{ inputs.build_mode }} -VV -O hdf5.log
         shell: bash
         continue-on-error: true
 
-      # Save log files created by ctest script
+      # Save log files created by CTest script
       - name: Save log (${{ matrix.mpi }})
         uses: actions/upload-artifact@v4
         with:
           name: linux-${{ matrix.mpi }}-log
           path: ${{ runner.workspace }}/hdf5/hdf5.log
 
-  CMake_build_parallel_intelmpi_macos:
+  Build_parallel_intelmpi_macos:
     runs-on: macos-latest
     strategy:
       matrix:
@@ -376,14 +376,14 @@ jobs:
             set (ADD_BUILD_OPTIONS "${ADD_BUILD_OPTIONS} -DZLIB_USE_LOCALCONTENT:BOOL=OFF")
             set (ADD_BUILD_OPTIONS "${ADD_BUILD_OPTIONS} -DPLUGIN_USE_LOCALCONTENT:BOOL=OFF")
 
-      - name: Run ctest script (${{ matrix.mpi }})
+      - name: Run CTest script (${{ matrix.mpi }})
         run: |
           cd "${{ runner.workspace }}/hdf5"
           ctest -S HDF5config.cmake,CTEST_SITE_EXT=GH-${{ github.event.repository.full_name }}-${{ matrix.mpi }},LOCAL_SUBMIT=ON,NINJA=TRUE,BUILD_GENERATOR=Unix,CTEST_SOURCE_NAME=${{ steps.set-file-base.outputs.SOURCE_BASE }} -C ${{ inputs.build_mode }} -VV -O hdf5.log
         shell: bash
         continue-on-error: true
 
-      # Save log files created by ctest script
+      # Save log files created by CTest script
       - name: Save log (${{ matrix.mpi }})
         uses: actions/upload-artifact@v4
         with:

--- a/.github/workflows/cmake-par-source.yml
+++ b/.github/workflows/cmake-par-source.yml
@@ -1,4 +1,4 @@
-name: hdf5 dev parallel from source ctest script runs
+name: hdf5 dev parallel from source CTest script runs
 
 # Triggers the workflow on a call from another workflow
 on:
@@ -43,7 +43,7 @@ jobs:
     with:
       build_mode: ${{ inputs.build_mode }}
 
-  CMake_build_parallel_src_openmpi:
+  Build_parallel_src_openmpi:
     needs: Build_openmpi_source
     name: "Parallel OpenMPI GCC-${{ inputs.build_mode }}"
     runs-on: ubuntu-latest
@@ -148,14 +148,14 @@ jobs:
             set (ADD_BUILD_OPTIONS "${ADD_BUILD_OPTIONS} -DZLIB_USE_LOCALCONTENT:BOOL=OFF")
             set (ADD_BUILD_OPTIONS "${ADD_BUILD_OPTIONS} -DPLUGIN_USE_LOCALCONTENT:BOOL=OFF")
 
-      - name: Run ctest script (OpenMPI)
+      - name: Run CTest script (OpenMPI)
         run: |
           cd "${{ runner.workspace }}/hdf5"
           ctest -S HDF5config.cmake,CTEST_SITE_EXT=GH-${{ github.event.repository.full_name }}-OpenMPI-source,LOCAL_SUBMIT=ON,NINJA=TRUE,BUILD_GENERATOR=Unix,CTEST_SOURCE_NAME=${{ steps.set-file-base.outputs.SOURCE_BASE }} -C ${{ inputs.build_mode }} -VV -O hdf5.log
         shell: bash
         continue-on-error: true
 
-      # Save log files created by ctest script
+      # Save log files created by CTest script
       - name: Save log (OpenMPI)
         uses: actions/upload-artifact@v4
         with:
@@ -163,7 +163,7 @@ jobs:
           path: ${{ runner.workspace }}/hdf5/hdf5.log
           if-no-files-found: error # 'warn' or 'ignore' are also available, defaults to `warn`
 
-  CMake_build_parallel_src_mpich:
+  Build_parallel_src_mpich:
     needs: Build_mpich_source
     name: "Parallel Mpich GCC-${{ inputs.build_mode }}"
     runs-on: ubuntu-latest
@@ -270,14 +270,14 @@ jobs:
             set (ADD_BUILD_OPTIONS "${ADD_BUILD_OPTIONS} -DZLIB_USE_LOCALCONTENT:BOOL=OFF")
             set (ADD_BUILD_OPTIONS "${ADD_BUILD_OPTIONS} -DPLUGIN_USE_LOCALCONTENT:BOOL=OFF")
 
-      - name: Run ctest script (MPICH)
+      - name: Run CTest script (MPICH)
         run: |
           cd "${{ runner.workspace }}/hdf5"
           ctest -S HDF5config.cmake,CTEST_SITE_EXT=GH-${{ github.event.repository.full_name }}-MPICH-source,LOCAL_SUBMIT=ON,NINJA=TRUE,BUILD_GENERATOR=Unix,CTEST_SOURCE_NAME=${{ steps.set-file-base.outputs.SOURCE_BASE }} -C ${{ inputs.build_mode }} -VV -O hdf5.log
         shell: bash
         continue-on-error: true
 
-      # Save log files created by ctest script
+      # Save log files created by CTest script
       - name: Save log (MPICH)
         uses: actions/upload-artifact@v4
         with:

--- a/.github/workflows/cmake-script.yml
+++ b/.github/workflows/cmake-script.yml
@@ -1,4 +1,4 @@
-name: hdf5 dev ctest script runs
+name: hdf5 dev CTest script runs
 
 # Triggers the workflow on a call from another workflow
 on:
@@ -28,7 +28,7 @@ permissions:
 
 jobs:
   build_and_test_win:
-  # Windows w/ MSVC + CMake
+  # Windows w/ MSVC
   #
     name: "Windows MSVC CTest"
     runs-on: windows-latest
@@ -127,14 +127,14 @@ jobs:
               set (ADD_BUILD_OPTIONS "${ADD_BUILD_OPTIONS} -DZLIB_USE_LOCALCONTENT:BOOL=OFF")
               set (ADD_BUILD_OPTIONS "${ADD_BUILD_OPTIONS} -DPLUGIN_USE_LOCALCONTENT:BOOL=OFF")
 
-      - name: Run ctest script (Windows)
+      - name: Run CTest script (Windows)
         run: |
           cd "${{ runner.workspace }}/hdf5"
           ctest -S HDF5config.cmake,CTEST_SITE_EXT=GH-${{ github.event.repository.full_name }},LOCAL_SUBMIT=ON,NINJA=TRUE,BUILD_GENERATOR=VS202264,CTEST_SOURCE_NAME=${{ steps.set-file-base.outputs.SOURCE_BASE }} -C Release -VV -O hdf5.log
         shell: bash
         continue-on-error: true
 
-      # Save log files created by ctest script
+      # Save log files created by CTest script
       - name: Save log (Windows_intel)
         uses: actions/upload-artifact@v4
         with:
@@ -143,12 +143,12 @@ jobs:
           if-no-files-found: error # 'warn' or 'ignore' are also available, defaults to `warn`
 
   build_and_test_linux:
-  # Linux (Ubuntu) w/ gcc + CMake
+  # Linux (Ubuntu) w/ gcc
   #
-    name: "Ubuntu gcc CMake"
+    name: "Ubuntu gcc"
     runs-on: ubuntu-latest
     steps:
-      - name: Install CMake Dependencies (Linux)
+      - name: Install Dependencies (Linux)
         run: |
           sudo apt-get update
           sudo apt-get install ninja-build graphviz curl
@@ -225,14 +225,14 @@ jobs:
             set (ADD_BUILD_OPTIONS "${ADD_BUILD_OPTIONS} -DZLIB_USE_LOCALCONTENT:BOOL=OFF")
             set (ADD_BUILD_OPTIONS "${ADD_BUILD_OPTIONS} -DPLUGIN_USE_LOCALCONTENT:BOOL=OFF")
 
-      - name: Run ctest (Linux)
+      - name: Run CTest (Linux)
         run: |
           cd "${{ runner.workspace }}/hdf5"
           ctest -S HDF5config.cmake,CTEST_SITE_EXT=GH-${{ github.event.repository.full_name }}-GCC,LOCAL_SUBMIT=ON,NINJA=TRUE,BUILD_GENERATOR=Unix,CTEST_SOURCE_NAME=${{ steps.set-file-base.outputs.SOURCE_BASE }} -C Release -VV -O hdf5.log
         shell: bash
         continue-on-error: true
 
-      # Save log files created by ctest script
+      # Save log files created by CTest script
       - name: Save log (Linux)
         uses: actions/upload-artifact@v4
         with:
@@ -241,9 +241,9 @@ jobs:
             if-no-files-found: error # 'warn' or 'ignore' are also available, defaults to `warn`
 
   build_and_test_mac_latest:
-  # MacOS w/ Clang + CMake
+  # MacOS w/ Clang
   #
-    name: "MacOS Clang CMake"
+    name: "MacOS Clang"
     runs-on: macos-latest
     steps:
       - name: Install Dependencies (MacOS_latest)
@@ -347,7 +347,7 @@ jobs:
             set (ADD_BUILD_OPTIONS "${ADD_BUILD_OPTIONS} -DZLIB_USE_LOCALCONTENT:BOOL=OFF")
             set (ADD_BUILD_OPTIONS "${ADD_BUILD_OPTIONS} -DPLUGIN_USE_LOCALCONTENT:BOOL=OFF")
 
-      - name: Run ctest (MacOS_latest)
+      - name: Run CTest (MacOS_latest)
         id: run-ctest
         run: |
           cd "${{ runner.workspace }}/hdf5"
@@ -355,7 +355,7 @@ jobs:
         shell: bash
         continue-on-error: true
 
-      # Save log files created by ctest script
+      # Save log files created by CTest script
       - name: Save log (MacOS_latest)
         uses: actions/upload-artifact@v4
         with:
@@ -364,12 +364,12 @@ jobs:
           if-no-files-found: error # 'warn' or 'ignore' are also available, defaults to `warn`
 
   build_and_test_S3_linux:
-  # Linux S3 (Ubuntu) w/ gcc + CMake
+  # Linux S3 (Ubuntu) w/ gcc
   #
-    name: "Ubuntu gcc CMake S3"
+    name: "Ubuntu gcc S3"
     runs-on: ubuntu-latest
     steps:
-      - name: Install CMake Dependencies (Linux S3)
+      - name: Install Dependencies (Linux S3)
         run: |
           sudo apt-get update
           sudo apt-get install ninja-build doxygen
@@ -460,14 +460,14 @@ jobs:
             set (ADD_BUILD_OPTIONS "${ADD_BUILD_OPTIONS} -DZLIB_USE_LOCALCONTENT:BOOL=OFF")
             set (ADD_BUILD_OPTIONS "${ADD_BUILD_OPTIONS} -DPLUGIN_USE_LOCALCONTENT:BOOL=OFF")
 
-      - name: Run ctest (Linux S3)
+      - name: Run CTest (Linux S3)
         run: |
           cd "${{ runner.workspace }}/hdf5"
           ctest -S HDF5config.cmake,CTEST_SITE_EXT=GH-${{ github.event.repository.full_name }}-S3,LOCAL_SUBMIT=ON,NINJA=TRUE,BUILD_GENERATOR=Unix,CTEST_SOURCE_NAME=${{ steps.set-file-base.outputs.SOURCE_BASE }} -C Release -VV -O hdf5.log
         shell: bash
         continue-on-error: true
 
-      # Save log files created by ctest script
+      # Save log files created by CTest script
       - name: Save log (Linux S3)
         uses: actions/upload-artifact@v4
         with:
@@ -477,7 +477,7 @@ jobs:
 
 ####### intel builds
   build_and_test_win_intel:
-  # Windows w/ OneAPI + CMake
+  # Windows w/ OneAPI
   #
     name: "Windows Intel CTest"
     runs-on: windows-latest
@@ -571,7 +571,7 @@ jobs:
             set (ADD_BUILD_OPTIONS "${ADD_BUILD_OPTIONS} -DZLIB_USE_LOCALCONTENT:BOOL=OFF")
             set (ADD_BUILD_OPTIONS "${ADD_BUILD_OPTIONS} -DPLUGIN_USE_LOCALCONTENT:BOOL=OFF")
 
-      - name: Run ctest (Windows_intel) with oneapi
+      - name: Run CTest (Windows_intel) with oneapi
         env:
           FC: ${{ steps.setup-fortran.outputs.fc }}
           CC: ${{ steps.setup-fortran.outputs.cc }}
@@ -581,7 +581,7 @@ jobs:
         shell: pwsh
         continue-on-error: true
 
-      # Save log files created by ctest script
+      # Save log files created by CTest script
       - name: Save log (Windows_intel)
         uses: actions/upload-artifact@v4
         with:
@@ -590,12 +590,12 @@ jobs:
           if-no-files-found: error # 'warn' or 'ignore' are also available, defaults to `warn`
 
   build_and_test_linux_intel:
-  # Linux (Ubuntu) w/ OneAPI + CMake
+  # Linux (Ubuntu) w/ OneAPI
   #
-    name: "Ubuntu Intel CMake"
+    name: "Ubuntu Intel"
     runs-on: ubuntu-latest
     steps:
-      - name: Install CMake Dependencies (Linux_intel)
+      - name: Install Dependencies (Linux_intel)
         run: |
           sudo apt-get update
           sudo apt-get install ninja-build doxygen graphviz curl
@@ -674,7 +674,7 @@ jobs:
             set (ADD_BUILD_OPTIONS "${ADD_BUILD_OPTIONS} -DZLIB_USE_LOCALCONTENT:BOOL=OFF")
             set (ADD_BUILD_OPTIONS "${ADD_BUILD_OPTIONS} -DPLUGIN_USE_LOCALCONTENT:BOOL=OFF")
 
-      - name: Run ctest (Linux_intel)
+      - name: Run CTest (Linux_intel)
         env:
           FC: ${{ steps.setup-fortran.outputs.fc }}
           CC: ${{ steps.setup-fortran.outputs.cc }}
@@ -684,7 +684,7 @@ jobs:
         shell: bash
         continue-on-error: true
 
-      # Save log files created by ctest script
+      # Save log files created by CTest script
       - name: Save log (Linux_intel)
         uses: actions/upload-artifact@v4
         with:
@@ -694,12 +694,12 @@ jobs:
 
 ####### clang builds
   build_and_test_linux_clang:
-  # Linux (Ubuntu) w/ clang + CMake
+  # Linux (Ubuntu) w/ clang
   #
-    name: "Ubuntu Clang CMake"
+    name: "Ubuntu Clang"
     runs-on: ubuntu-22.04
     steps:
-      - name: Install CMake Dependencies (Linux_clang)
+      - name: Install Dependencies (Linux_clang)
         run: |
           sudo apt-get update
           sudo apt-get install ninja-build doxygen graphviz curl libtinfo5
@@ -792,14 +792,14 @@ jobs:
               set (ADD_BUILD_OPTIONS "${ADD_BUILD_OPTIONS} -DZLIB_USE_LOCALCONTENT:BOOL=OFF")
               set (ADD_BUILD_OPTIONS "${ADD_BUILD_OPTIONS} -DPLUGIN_USE_LOCALCONTENT:BOOL=OFF")
 
-      - name: Run ctest (Linux_clang)
+      - name: Run CTest (Linux_clang)
         run: |
           cd "${{ runner.workspace }}/hdf5"
           ctest -S HDF5config.cmake,CTEST_SITE_EXT=GH-${{ github.event.repository.full_name }}-Clang,LOCAL_SUBMIT=ON,NINJA=TRUE,BUILD_GENERATOR=Unix,CTEST_SOURCE_NAME=${{ steps.set-file-base.outputs.SOURCE_BASE }} -C Release -VV -O hdf5.log
         shell: bash
         continue-on-error: true
 
-      # Save log files created by ctest script
+      # Save log files created by CTest script
       - name: Save log (Linux_clang)
         uses: actions/upload-artifact@v4
         with:

--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -25,11 +25,11 @@ permissions:
 
 jobs:
     call-workflow-special-cmake:
-      name: "CMake Special Workflows"
+      name: "Special Workflows"
       uses: ./.github/workflows/main-cmake-spc.yml
 
     call-workflow-ros3-cmake:
-      name: "CMake ROS3 VFD Workflows"
+      name: "ROS3 VFD Workflows"
       uses: ./.github/workflows/vfd-ros3.yml
       with:
         build_mode: "Release"
@@ -40,7 +40,7 @@ jobs:
         aws_c_s3_tag: "v0.8.0"
 
     call-debug-concurrent-cmake:
-        name: "CMake Debug Concurrency Workflows"
+        name: "Debug Concurrency Workflows"
         uses: ./.github/workflows/main-cmake.yml
         with:
             cmake_version: "latest"
@@ -49,7 +49,7 @@ jobs:
             build_mode: "Debug"
 
     call-release-concurrent-cmake:
-        name: "CMake Release Concurrency Workflows"
+        name: "Release Concurrency Workflows"
         uses: ./.github/workflows/main-cmake.yml
         with:
             cmake_version: "latest"
@@ -58,7 +58,7 @@ jobs:
             build_mode: "Release"
 
     call-debug-thread-cmake:
-        name: "CMake Debug Thread-Safety Workflows"
+        name: "Debug Thread-Safety Workflows"
         uses: ./.github/workflows/main-cmake.yml
         with:
             cmake_version: "latest"
@@ -67,7 +67,7 @@ jobs:
             build_mode: "Debug"
 
     call-release-thread-cmake:
-        name: "CMake Release Thread-Safety Workflows"
+        name: "Release Thread-Safety Workflows"
         uses: ./.github/workflows/main-cmake.yml
         with:
             cmake_version: "latest"
@@ -76,7 +76,7 @@ jobs:
             build_mode: "Release"
 
     call-debug-cmake:
-        name: "CMake Debug Workflows"
+        name: "Debug Workflows"
         uses: ./.github/workflows/main-cmake.yml
         with:
             cmake_version: "latest"
@@ -85,7 +85,7 @@ jobs:
             build_mode: "Debug"
 
     call-release-cmake:
-        name: "CMake Release Workflows"
+        name: "Release Workflows"
         uses: ./.github/workflows/main-cmake.yml
         with:
             cmake_version: "latest"
@@ -95,7 +95,7 @@ jobs:
             save_binary: "std"
 
     call-release-cmake4:
-        name: "CMake4 Release Workflows"
+        name: "CMake 4 Release Workflows"
         uses: ./.github/workflows/main-cmake.yml
         with:
             cmake_version: "latest"
@@ -104,7 +104,7 @@ jobs:
             build_mode: "Release"
 
     call-release-cmakeMin:
-        name: "CMake Minimum Release Workflows"
+        name: "Minimum Release Workflows"
         uses: ./.github/workflows/main-cmake.yml
         with:
             cmake_version: "3.26.0"
@@ -113,7 +113,7 @@ jobs:
             build_mode: "Release"
 
     call-arm64-cmake:
-        name: "CMake arm64 Workflows"
+        name: "arm64 Workflows"
         uses: ./.github/workflows/arm-main-cmake.yml
         with:
             cmake_version: "latest"
@@ -123,7 +123,7 @@ jobs:
             save_binary: "arm64"
 
     call-debug-arm64-cmake:
-        name: "CMake arm64 Workflows"
+        name: "arm64 Workflows"
         uses: ./.github/workflows/arm-main-cmake.yml
         with:
             cmake_version: "latest"
@@ -132,7 +132,7 @@ jobs:
             build_mode: "Debug"
 
     call-arm64-cmake4:
-        name: "CMake4 arm64 Workflows"
+        name: "CMake 4 arm64 Workflows"
         uses: ./.github/workflows/arm-main-cmake.yml
         with:
             cmake_version: "latest"
@@ -141,72 +141,72 @@ jobs:
             build_mode: "Release"
 
     call-release-bintest:
-        name: "CMake Test Release Binaries"
+        name: "Test Release Binaries"
         needs: call-release-cmake
         uses: ./.github/workflows/cmake-bintest.yml
         with:
             build_mode: "Release"
 
     call-release-par:
-        name: "CMake Parallel Release Workflows"
+        name: "Parallel Release Workflows"
         uses: ./.github/workflows/main-cmake-par.yml
         with:
             build_mode: "Release"
 
     call-debug-par:
-        name: "CMake Parallel Debug Workflows"
+        name: "Parallel Debug Workflows"
         uses: ./.github/workflows/main-cmake-par.yml
         with:
             build_mode: "Debug"
 
     call-release-special-par:
-        name: "CMake Parallel Release Special Workflows"
+        name: "Parallel Release Special Workflows"
         uses: ./.github/workflows/main-cmake-par-spc.yml
         with:
             build_mode: "Release"
 
     call-debug-special-par:
-        name: "CMake Parallel Debug Special Workflows"
+        name: "Parallel Debug Special Workflows"
         uses: ./.github/workflows/main-cmake-par-spc.yml
         with:
             build_mode: "Debug"
 
     call-release-cmake-intel:
-        name: "CMake Intel Workflows"
+        name: "Intel Workflows"
         uses: ./.github/workflows/intel-cmake.yml
         with:
             build_mode: "Release"
 
     call-release-cmake-nvhpc:
-        name: "CMake nvhpc Workflows"
+        name: "nvhpc Workflows"
         uses: ./.github/workflows/nvhpc-cmake.yml
         with:
             build_mode: "Release"
 
     call-release-cmake-aocc:
-        name: "CMake aocc Workflows"
+        name: "aocc Workflows"
         uses: ./.github/workflows/aocc-cmake.yml
         with:
             build_mode: "Release"
 
     call-release-cmake-xpr:
-        name: "CMake TestExpress Workflows"
+        name: "TestExpress Workflows"
         uses: ./.github/workflows/testxpr-cmake.yml
 
 #    call-release-cmake-julia:
-#        name: "CMake Julia Workflows"
+#        name: "Julia Workflows"
 #        uses: ./.github/workflows/julia-cmake.yml
 #        with:
 #         build_mode: "Release"
 
     call-release-cmake-msys2:
-        name: "CMake Msys2 Workflows"
+        name: "Msys2 Workflows"
         uses: ./.github/workflows/msys2-cmake.yml
         with:
           build_mode: "Release"
 
     call-release-cmake-i386:
-        name: "CMake i386 Workflows"
+        name: "i386 Workflows"
         uses: ./.github/workflows/i386-cmake.yml
         with:
             build_mode: "Release"

--- a/.github/workflows/cygwin-cmake.yml
+++ b/.github/workflows/cygwin-cmake.yml
@@ -1,4 +1,4 @@
-name: hdf5 dev CMake cygwin
+name: hdf5 dev cygwin
 
 # Triggers the workflow on a call from another workflow
 on:
@@ -107,7 +107,7 @@ jobs:
             set (ADD_BUILD_OPTIONS "${ADD_BUILD_OPTIONS} -DENABLE_ZFP:BOOL=OFF")
             set (ADD_BUILD_OPTIONS "${ADD_BUILD_OPTIONS} -DENABLE_ZSTD:BOOL=OFF")
 
-      - name: Run ctest (Cygwin)
+      - name: Run CTest (Cygwin)
         shell: C:\cygwin\bin\bash.exe -eo pipefail -o igncr '{0}'
         run: |
           export PATH=/usr/bin:$PATH
@@ -115,7 +115,7 @@ jobs:
           ctest -S HDF5config.cmake,CTEST_SITE_EXT=GH-${{ github.event.repository.full_name }}-CYG,LOCAL_SUBMIT=ON,NINJA=TRUE,BUILD_GENERATOR=Unix,CTEST_SOURCE_NAME=${{ steps.set-file-base.outputs.SOURCE_BASE }} -C Release -VV -O hdf5.log
         continue-on-error: true
 
-      # Save log files created by ctest script
+      # Save log files created by CTest script
       - name: Save log (Cygwin)
         uses: actions/upload-artifact@v4
         with:

--- a/.github/workflows/daily-build.yml
+++ b/.github/workflows/daily-build.yml
@@ -81,7 +81,7 @@ jobs:
 
   call-release-cmake-cygwin:
     needs: [get-old-names, call-workflow-tarball]
-    name: "CMake Cygwin Workflows"
+    name: "Cygwin Workflows"
     uses: ./.github/workflows/cygwin-cmake.yml
     with:
       file_base: ${{ needs.call-workflow-tarball.outputs.file_base }}
@@ -119,7 +119,7 @@ jobs:
 
   call-developer-cmake:
     needs: [get-old-names, call-workflow-tarball]
-    name: "CMake Developer Workflows"
+    name: "Developer Workflows"
     uses: ./.github/workflows/dev-cmake.yml
     with:
       file_base: ${{ needs.call-workflow-tarball.outputs.file_base }}

--- a/.github/workflows/dev-cmake.yml
+++ b/.github/workflows/dev-cmake.yml
@@ -1,4 +1,4 @@
-name: hdf5 Developer Mode CMake CI
+name: hdf5 Developer Mode CI
 
 on:
   workflow_call:
@@ -57,7 +57,7 @@ jobs:
               ls -l ${{ github.workspace }}
               ls ${{ runner.workspace }}
 
-      - name: CMake Configure
+      - name: Configure
         shell: bash
         run: |
             mkdir "${{ runner.workspace }}/build"
@@ -79,11 +79,11 @@ jobs:
                  -DHDF_TEST_EXPRESS=0 \
                  ${{ github.workspace }}/hdfsrc
 
-      - name: CMake Build
+      - name: Build
         run: cmake --build . --parallel 3 --config Developer
         working-directory: ${{ runner.workspace }}/build
 
-      - name: CMake Run Tests
+      - name: Run Tests
         env:
           HDF5TestExpress: 0
         run: ctest . --parallel 2 -C Developer -V -R H5TESTXPR -E fheap
@@ -150,27 +150,27 @@ jobs:
         run: 7z x ${{ steps.set-file-base.outputs.FILE_BASE }}.zip
         shell: bash
 
-      - name: CMake Configure (Windows)
+      - name: Configure (Windows)
         shell: pwsh
         run: |
           mkdir "${{ runner.workspace }}/build"
           Set-Location -Path "${{ runner.workspace }}\\build"
           cmake -C ${{ github.workspace }}/hdfsrc/config/cmake/cacheinit.cmake -G Ninja -DCMAKE_BUILD_TYPE=Developer -DBUILD_SHARED_LIBS=ON -DHDF5_ENABLE_ALL_WARNINGS=ON -DHDF5_ENABLE_DEBUG_H5B2=ON -DHDF5_ENABLE_DEBUG_H5FS_ASSERT=ON -DHDF5_ENABLE_PARALLEL:BOOL=OFF -DHDF5_BUILD_CPP_LIB=OFF -DHDF5_BUILD_FORTRAN=OFF -DHDF5_BUILD_JAVA=OFF -DHDF5_BUILD_DOC=OFF -DLIBAEC_USE_LOCALCONTENT=OFF -DZLIB_USE_LOCALCONTENT=OFF -DHDF_TEST_EXPRESS=0 ${{ github.workspace }}/hdfsrc
 
-      - name: CMake Build
+      - name: Build
         run: cmake --build . --parallel 3 --config Developer
         working-directory: ${{ runner.workspace }}/build
 
-      - name: CMake Run Tests
+      - name: Run Tests
         env:
           HDF5TestExpress: 0
         run: ctest . --parallel 2 -C Developer -V -R H5TESTXPR -E fheap
         working-directory: ${{ runner.workspace }}/build
 
   build_and_test_mac_latest:
-  # MacOS w/ Clang + CMake
+  # MacOS w/ Clang
   #
-    name: "MacOS Clang CMake"
+    name: "MacOS Clang"
     runs-on: macos-latest
     steps:
       - name: Install Dependencies (MacOS_latest)
@@ -221,7 +221,7 @@ jobs:
       - name: Uncompress source (MacOS_latest)
         run: tar -zxvf ${{ github.workspace }}/${{ steps.set-file-base.outputs.FILE_BASE }}.tar.gz
 
-      - name: CMake Configure
+      - name: Configure
         shell: bash
         run: |
           mkdir "${{ runner.workspace }}/build"
@@ -243,11 +243,11 @@ jobs:
                -DHDF_TEST_EXPRESS=0 \
                ${{ github.workspace }}/hdfsrc
 
-      - name: CMake Build
+      - name: Build
         run: cmake --build . --parallel 3 --config Developer
         working-directory: ${{ runner.workspace }}/build
 
-      - name: CMake Run Tests
+      - name: Run Tests
         env:
           HDF5TestExpress: 0
         run: ctest . --parallel 2 -C Developer -V -R H5TESTXPR -E fheap
@@ -255,12 +255,12 @@ jobs:
 
   ####### clang builds
   build_and_test_linux_clang:
-    # Linux (Ubuntu) w/ clang + CMake
+    # Linux (Ubuntu) w/ clang
     #
-    name: "Ubuntu Clang CMake"
+    name: "Ubuntu Clang"
     runs-on: ubuntu-22.04
     steps:
-      - name: Install CMake Dependencies (Linux_clang)
+      - name: Install Dependencies (Linux_clang)
         run: |
           sudo apt-get update
           sudo apt-get install ninja-build doxygen graphviz curl libtinfo5
@@ -312,7 +312,7 @@ jobs:
       - name: Uncompress source (Linux_clang)
         run: tar -zxvf ${{ github.workspace }}/${{ steps.set-file-base.outputs.FILE_BASE }}.tar.gz
 
-      - name: CMake Configure
+      - name: Configure
         shell: bash
         run: |
           mkdir "${{ runner.workspace }}/build"
@@ -334,11 +334,11 @@ jobs:
                -DHDF_TEST_EXPRESS=0 \
                ${{ github.workspace }}/hdfsrc
 
-      - name: CMake Build
+      - name: Build
         run: cmake --build . --parallel 3 --config Developer
         working-directory: ${{ runner.workspace }}/build
 
-      - name: CMake Run Tests
+      - name: Run Tests
         env:
           HDF5TestExpress: 0
         run: ctest . --parallel 2 -C Developer -V -R H5TESTXPR -E fheap

--- a/.github/workflows/hdfeos5.yml
+++ b/.github/workflows/hdfeos5.yml
@@ -38,7 +38,7 @@ jobs:
       - name: Checkout HDF5
         uses: actions/checkout@v4.1.7
 
-      - name: CMake Configure
+      - name: Configure
         run: |
             mkdir "${{ runner.workspace }}/build"
             cd "${{ runner.workspace }}/build"
@@ -58,7 +58,7 @@ jobs:
               $GITHUB_WORKSPACE
         shell: bash
 
-      - name: CMake Build
+      - name: Build
         run: cmake --build . --parallel 3 --config Release
         working-directory: ${{ runner.workspace }}/build
 

--- a/.github/workflows/i386-cmake.yml
+++ b/.github/workflows/i386-cmake.yml
@@ -1,4 +1,4 @@
-name: hdf5 dev CMake i386
+name: hdf5 dev i386
 
 # Triggers the workflow on a call from another workflow
 on:
@@ -30,7 +30,7 @@ jobs:
             libgit2-dev
             cmake
 
-      - name: CMake Configure
+      - name: Configure
         shell: alpine.sh --root {0}
         run: |
           mkdir build
@@ -46,13 +46,13 @@ jobs:
           -DHDF5_BUILD_JAVA:BOOL=OFF \
           ..
 
-      - name: CMake Build
+      - name: Build
         shell: alpine.sh --root {0}
         run: |
           cmake --build . --parallel 3 --config ${{ inputs.build_mode }}
         working-directory: build
 
-      - name: CMake Run Tests
+      - name: Run Tests
         shell: alpine.sh --root {0}
         run: |
           ctest . --parallel 2 -C ${{ inputs.build_mode }} -VV

--- a/.github/workflows/intel-cmake.yml
+++ b/.github/workflows/intel-cmake.yml
@@ -1,4 +1,4 @@
-name: hdf5 dev CMake icx CI
+name: hdf5 dev icx CI
 
 # Triggers the workflow on a call from another workflow
 on:
@@ -34,7 +34,7 @@ jobs:
           compiler: intel
           version: '2025.0'
 
-      - name: CMake Configure (Linux)
+      - name: Configure (Linux)
         shell: bash
         env:
           FC: ${{ steps.setup-fortran.outputs.fc }}
@@ -48,7 +48,7 @@ jobs:
             -DHDF5_BUILD_CPP_LIB:BOOL=ON \
             ${{ github.workspace }}
 
-      - name: CMake Build (Linux)
+      - name: Build (Linux)
         shell: bash
         env:
           FC: ${{ steps.setup-fortran.outputs.fc }}
@@ -57,7 +57,7 @@ jobs:
           cmake --build . --parallel 3 --config ${{ inputs.build_mode }}
         working-directory: ${{ runner.workspace }}/build
 
-      - name: CMake Run Tests (Linux)
+      - name: Run Tests (Linux)
         shell: bash
         env:
           FC: ${{ steps.setup-fortran.outputs.fc }}
@@ -83,7 +83,7 @@ jobs:
           compiler: intel
           version: '2025.0'
 
-      - name: CMake Configure (Windows)
+      - name: Configure (Windows)
         shell: pwsh
         env:
           FC: ${{ steps.setup-fortran.outputs.fc }}
@@ -93,7 +93,7 @@ jobs:
           Set-Location -Path "${{ runner.workspace }}\\build"
           cmake -C ${{ github.workspace }}/config/cmake/cacheinit.cmake -G Ninja -DCMAKE_BUILD_TYPE=${{ inputs.build_mode }} -DHDF5_BUILD_FORTRAN=ON -DHDF5_BUILD_CPP_LIB=ON -DLIBAEC_USE_LOCALCONTENT=OFF -DZLIB_USE_LOCALCONTENT=OFF ${{ github.workspace }}
 
-      - name: CMake Build (Windows)
+      - name: Build (Windows)
         shell: pwsh
         env:
           FC: ${{ steps.setup-fortran.outputs.fc }}
@@ -102,7 +102,7 @@ jobs:
           cmake --build . --parallel 3 --config ${{ inputs.build_mode }}
         working-directory: ${{ runner.workspace }}/build
 
-      - name: CMake Run Tests (Windows)
+      - name: Run Tests (Windows)
         shell: pwsh
         env:
           FC: ${{ steps.setup-fortran.outputs.fc }}

--- a/.github/workflows/julia-cmake.yml
+++ b/.github/workflows/julia-cmake.yml
@@ -1,4 +1,4 @@
-name: hdf5 dev CMake julia
+name: hdf5 dev julia
 
 on:
   workflow_call:
@@ -27,7 +27,7 @@ jobs:
           sudo apt install libssl3 libssl-dev libcurl4 libcurl4-openssl-dev
           sudo apt install -y libaec-dev zlib1g-dev wget curl bzip2 flex bison cmake libzip-dev openssl build-essential
 
-      - name: CMake Configure
+      - name: Configure
         shell: bash
         run: |
           mkdir "${{ runner.workspace }}/build"
@@ -45,7 +45,7 @@ jobs:
           -DCMAKE_INSTALL_PREFIX=/tmp \
           $GITHUB_WORKSPACE
 
-      - name: CMake Build
+      - name: Build
         shell: bash
         run: |
           cmake --build . --parallel 3 --config ${{ inputs.build_mode }}

--- a/.github/workflows/main-cmake-par-spc.yml
+++ b/.github/workflows/main-cmake-par-spc.yml
@@ -1,4 +1,4 @@
-name: hdf5 dev parallel special CMake CI
+name: hdf5 dev parallel special CI
 
 on:
   workflow_call:
@@ -17,9 +17,9 @@ jobs:
   # so we catch most issues in daily testing. What we have here is just
   # a compile check to make sure nothing obvious is broken.
   # A workflow that builds the library
-  # Parallel Linux (Ubuntu) w/ gcc + CMake
+  # Parallel Linux (Ubuntu) w/ gcc
   #
-  CMake_build_parallel_werror:
+  Build_parallel_werror:
     name: "Parallel GCC-${{ inputs.build_mode }}"
     runs-on: ubuntu-latest
     steps:
@@ -36,7 +36,7 @@ jobs:
            echo "CC=mpicc" >> $GITHUB_ENV
            echo "FC=mpif90" >> $GITHUB_ENV
 
-      - name: CMake Configure
+      - name: Configure
         shell: bash
         run: |
           mkdir "${{ runner.workspace }}/build"
@@ -62,17 +62,17 @@ jobs:
             $GITHUB_WORKSPACE
 
       # BUILD
-      - name: CMake Build
+      - name: Build
         run: cmake --build . --parallel 3 --config ${{ inputs.build_mode }}
         working-directory: ${{ runner.workspace }}/build
 
       # RUN TESTS
-      - name: CMake Run Tests
+      - name: Run Tests
         run: ctest . -E MPI_TEST --parallel 2 -C ${{ inputs.build_mode }} -V
         working-directory: ${{ runner.workspace }}/build
         if: ${{ inputs.thread_safety != 'TS' }}
 
-      - name: CMake Run Parallel Tests
+      - name: Run Parallel Tests
         run: ctest . -R MPI_TEST -C ${{ inputs.build_mode }} -V
         working-directory: ${{ runner.workspace }}/build
         if: ${{ matrix.run_tests && (inputs.thread_safety != 'TS') }}

--- a/.github/workflows/main-cmake-par.yml
+++ b/.github/workflows/main-cmake-par.yml
@@ -1,4 +1,4 @@
-name: hdf5 dev parallel CMake CI
+name: hdf5 dev parallel CI
 
 on:
   workflow_call:
@@ -17,9 +17,9 @@ jobs:
   # so we catch most issues in daily testing. What we have here is just
   # a compile check to make sure nothing obvious is broken.
   # A workflow that builds the library
-  # Parallel Linux (Ubuntu) w/ gcc + CMake
+  # Parallel Linux (Ubuntu) w/ gcc
   #
-  CMake_build_parallel:
+  Build_parallel:
     name: "Parallel GCC-${{ inputs.build_mode }}"
     runs-on: ubuntu-latest
     steps:
@@ -36,7 +36,7 @@ jobs:
            echo "CC=mpicc" >> $GITHUB_ENV
            echo "FC=mpif90" >> $GITHUB_ENV
 
-      - name: CMake Configure
+      - name: Configure
         shell: bash
         run: |
           mkdir "${{ runner.workspace }}/build"
@@ -61,19 +61,19 @@ jobs:
             $GITHUB_WORKSPACE
 
       # BUILD
-      - name: CMake Build
+      - name: Build
         run: cmake --build . --parallel 3 --config ${{ inputs.build_mode }}
         working-directory: ${{ runner.workspace }}/build
 
       #
       # RUN TESTS
       #
-      - name: CMake Run Tests
+      - name: Run Tests
         run: ctest . -E MPI_TEST --parallel 2 -C ${{ inputs.build_mode }} -V
         working-directory: ${{ runner.workspace }}/build
         if: ${{ inputs.thread_safety != 'TS' }}
 
-      - name: CMake Run Parallel Tests
+      - name: Run Parallel Tests
         run: ctest . -R MPI_TEST -E "_by_chunk|_by_pattern" -C ${{ inputs.build_mode }} -V
         working-directory: ${{ runner.workspace }}/build
         if: ${{ inputs.thread_safety != 'TS' }}

--- a/.github/workflows/main-cmake-spc.yml
+++ b/.github/workflows/main-cmake-spc.yml
@@ -1,4 +1,4 @@
-name: hdf5 dev CMake special CI
+name: hdf5 dev special CI
 
 # Controls when the action will run. Triggers the workflow on a call
 on:
@@ -12,7 +12,7 @@ permissions:
 # run in parallel.
 jobs:
   #
-  # SPECIAL CMake BUILDS
+  # SPECIAL BUILDS
   #
   # These are not built into the matrix and instead
   # become NEW configs as their name would clobber one of the matrix
@@ -38,8 +38,8 @@ jobs:
       - name: Get Sources
         uses: actions/checkout@v4.1.7
 
-      # CMAKE CONFIGURE
-      - name: CMake Configure
+      # CONFIGURE
+      - name: Configure
         run: |
           mkdir "${{ runner.workspace }}/build"
           cd "${{ runner.workspace }}/build"
@@ -62,17 +62,17 @@ jobs:
         shell: bash
 
       # BUILD
-      - name: CMake Build
+      - name: Build
         run: cmake --build . --parallel 3 --config Debug
         working-directory: ${{ runner.workspace }}/build
 
       # RUN TESTS
-      - name: CMake Run Tests
+      - name: Run Tests
         run: |
           ctest . --parallel 2 -C Debug -V -E "testhdf5-base|cache_api|dt_arith|H5TEST-dtypes|err_compat"
         working-directory: ${{ runner.workspace }}/build
 
-      - name: CMake Run Expected to Fail Tests
+      - name: Run Expected to Fail Tests
         run: |
           ctest . --parallel 2 -C Debug -V -R "testhdf5-base|cache_api|dt_arith|H5TEST-dtypes|err_compat"
         working-directory: ${{ runner.workspace }}/build
@@ -97,8 +97,8 @@ jobs:
       - name: Get Sources
         uses: actions/checkout@v4.1.7
 
-      # CMAKE CONFIGURE
-      - name: CMake Configure
+      # CONFIGURE
+      - name: Configure
         run: |
           mkdir "${{ runner.workspace }}/build"
           cd "${{ runner.workspace }}/build"
@@ -121,14 +121,14 @@ jobs:
         shell: bash
 
       # BUILD
-      - name: CMake Build
+      - name: Build
         run: cmake --build . --parallel 3 --config Debug
         working-directory: ${{ runner.workspace }}/build
 
       #
       # RUN TESTS
       #
-      - name: CMake Run Tests
+      - name: Run Tests
         run: ctest . --parallel 2 -C Debug -V
         working-directory: ${{ runner.workspace }}/build
 
@@ -151,8 +151,8 @@ jobs:
       - name: Get Sources
         uses: actions/checkout@v4.1.7
 
-      # CMAKE CONFIGURE
-      - name: CMake Configure
+      # CONFIGURE
+      - name: Configure
         run: |
           mkdir "${{ runner.workspace }}/build"
           cd "${{ runner.workspace }}/build"
@@ -175,14 +175,14 @@ jobs:
         shell: bash
 
       # BUILD
-      - name: CMake Build
+      - name: Build
         run: cmake --build . --parallel 3 --config Debug
         working-directory: ${{ runner.workspace }}/build
 
       #
       # RUN TESTS
       #
-      - name: CMake Run Tests
+      - name: Run Tests
         run: ctest . --parallel 2 -C Debug -V
         working-directory: ${{ runner.workspace }}/build
 
@@ -205,8 +205,8 @@ jobs:
       - name: Get Sources
         uses: actions/checkout@v4.1.7
 
-      # CMAKE CONFIGURE
-      - name: CMake Configure
+      # CONFIGURE
+      - name: Configure
         run: |
           mkdir "${{ runner.workspace }}/build"
           cd "${{ runner.workspace }}/build"
@@ -229,12 +229,12 @@ jobs:
         shell: bash
 
       # BUILD
-      - name: CMake Build
+      - name: Build
         run: cmake --build . --parallel 3 --config Debug
         working-directory: ${{ runner.workspace }}/build
 
       # RUN TESTS
-      - name: CMake Run Tests
+      - name: Run Tests
         run: ctest . --parallel 2 -C Debug -V
         working-directory: ${{ runner.workspace }}/build
 
@@ -257,8 +257,8 @@ jobs:
       - name: Get Sources
         uses: actions/checkout@v4.1.7
 
-      # CMAKE CONFIGURE
-      - name: CMake Configure
+      # CONFIGURE
+      - name: Configure
         run: |
           mkdir "${{ runner.workspace }}/build"
           cd "${{ runner.workspace }}/build"
@@ -281,12 +281,12 @@ jobs:
         shell: bash
 
       # BUILD
-      - name: CMake Build
+      - name: Build
         run: cmake --build . --parallel 3 --config Debug
         working-directory: ${{ runner.workspace }}/build
 
       # RUN TESTS
-      - name: CMake Run Tests
+      - name: Run Tests
         run: ctest . --parallel 2 -C Debug -V
         working-directory: ${{ runner.workspace }}/build
 
@@ -309,8 +309,8 @@ jobs:
       - name: Get Sources
         uses: actions/checkout@v4.1.7
 
-      # CMAKE CONFIGURE
-      - name: CMake Configure
+      # CONFIGURE
+      - name: Configure
         run: |
           mkdir "${{ runner.workspace }}/build"
           cd "${{ runner.workspace }}/build"
@@ -334,12 +334,12 @@ jobs:
         shell: bash
 
       # BUILD
-      - name: CMake Build
+      - name: Build
         run: cmake --build . --parallel 3 --config Debug
         working-directory: ${{ runner.workspace }}/build
 
       # RUN TESTS
-      - name: CMake Run Tests
+      - name: Run Tests
         run: ctest . --parallel 2 -C Debug -V
         working-directory: ${{ runner.workspace }}/build
 
@@ -367,7 +367,7 @@ jobs:
       - name: Get Sources
         uses: actions/checkout@v4.1.7
 
-      - name: CMake Configure (Windows)
+      - name: Configure (Windows)
         shell: pwsh
         env:
           FC: ${{ steps.setup-fortran.outputs.fc }}
@@ -377,7 +377,7 @@ jobs:
           Set-Location -Path "${{ runner.workspace }}\\build"
           cmake -C ${{ github.workspace }}/config/cmake/cacheinit.cmake -G Ninja -DCMAKE_BUILD_TYPE=Debug -DBUILD_SHARED_LIBS=ON -DHDF5_ENABLE_ALL_WARNINGS=ON -DHDF5_ENABLE_PARALLEL:BOOL=OFF -DHDF5_BUILD_CPP_LIB:BOOL=ON -DHDF5_BUILD_FORTRAN=ON -DHDF5_BUILD_JAVA=ON -DHDF5_BUILD_DOC=OFF -DLIBAEC_USE_LOCALCONTENT=OFF -DZLIB_USE_LOCALCONTENT=OFF -DHDF5_ENABLE_MIRROR_VFD:BOOL=ON -DHDF5_ENABLE_DIRECT_VFD:BOOL=OFF -DHDF5_ENABLE_DEPRECATED_SYMBOLS:BOOL=OFF -DHDF5_DEFAULT_API_VERSION:STRING=v200 ${{ github.workspace }}
 
-      - name: CMake Build (Windows)
+      - name: Build (Windows)
         shell: pwsh
         env:
           FC: ${{ steps.setup-fortran.outputs.fc }}
@@ -386,7 +386,7 @@ jobs:
           cmake --build . --parallel 3 --config Debug
         working-directory: ${{ runner.workspace }}/build
 
-      - name: CMake Run Tests (Windows)
+      - name: Run Tests (Windows)
         shell: pwsh
         env:
           FC: ${{ steps.setup-fortran.outputs.fc }}
@@ -414,8 +414,8 @@ jobs:
       - name: Get Sources
         uses: actions/checkout@v4.1.7
 
-      # CMAKE CONFIGURE
-      - name: CMake Configure
+      # CONFIGURE
+      - name: Configure
         run: |
           mkdir "${{ runner.workspace }}/build"
           cd "${{ runner.workspace }}/build"
@@ -443,12 +443,12 @@ jobs:
         shell: bash
 
       # BUILD
-      - name: CMake Build
+      - name: Build
         run: cmake --build . --parallel 3 --config Debug
         working-directory: ${{ runner.workspace }}/build
 
       # RUN TESTS
-      - name: CMake Run Tests
+      - name: Run Tests
         run: ctest . --parallel 2 -C Debug -V
         working-directory: ${{ runner.workspace }}/build
 
@@ -471,8 +471,8 @@ jobs:
       - name: Get Sources
         uses: actions/checkout@v4.1.7
 
-      # CMAKE CONFIGURE
-      - name: CMake Configure
+      # CONFIGURE
+      - name: Configure
         run: |
           mkdir "${{ runner.workspace }}/build"
           cd "${{ runner.workspace }}/build"
@@ -496,12 +496,12 @@ jobs:
         shell: bash
 
       # BUILD
-      - name: CMake Build
+      - name: Build
         run: cmake --build . --parallel 3 --config Release
         working-directory: ${{ runner.workspace }}/build
 
       # RUN TESTS
-      - name: CMake Run Tests
+      - name: Run Tests
         run: ctest . --parallel 2 -C Release -V
         working-directory: ${{ runner.workspace }}/build
 
@@ -524,8 +524,8 @@ jobs:
       - name: Get Sources
         uses: actions/checkout@v4.1.7
 
-      # CMAKE CONFIGURE
-      - name: CMake Configure
+      # CONFIGURE
+      - name: Configure
         run: |
           mkdir "${{ runner.workspace }}/build"
           cd "${{ runner.workspace }}/build"
@@ -549,12 +549,12 @@ jobs:
         shell: bash
 
       # BUILD
-      - name: CMake Build
+      - name: Build
         run: cmake --build . --parallel 3 --config Release
         working-directory: ${{ runner.workspace }}/build
 
       # RUN TESTS
-      - name: CMake Run Tests
+      - name: Run Tests
         run: ctest . --parallel 2 -C Release -V
         working-directory: ${{ runner.workspace }}/build
 
@@ -577,8 +577,8 @@ jobs:
       - name: Get Sources
         uses: actions/checkout@v4.1.7
 
-      # CMAKE CONFIGURE
-      - name: CMake Configure
+      # CONFIGURE
+      - name: Configure
         run: |
           mkdir "${{ runner.workspace }}/build"
           cd "${{ runner.workspace }}/build"
@@ -602,7 +602,7 @@ jobs:
         shell: bash
 
       # BUILD
-      - name: CMake Build
+      - name: Build
         run: cmake --build . --parallel 3 --config Release
         working-directory: ${{ runner.workspace }}/build
 
@@ -625,8 +625,8 @@ jobs:
       - name: Get Sources
         uses: actions/checkout@v4.1.7
 
-      # CMAKE CONFIGURE
-      - name: CMake Configure
+      # CONFIGURE
+      - name: Configure
         run: |
           mkdir "${{ runner.workspace }}/build"
           cd "${{ runner.workspace }}/build"
@@ -650,7 +650,7 @@ jobs:
         shell: bash
 
       # BUILD
-      - name: CMake Build
+      - name: Build
         run: cmake --build . --parallel 3 --config Release
         working-directory: ${{ runner.workspace }}/build
 

--- a/.github/workflows/main-cmake.yml
+++ b/.github/workflows/main-cmake.yml
@@ -1,4 +1,4 @@
-name: hdf5 dev CMake CI
+name: hdf5 dev CI
 
 # Triggers the workflow on a call from another workflow
 on:
@@ -32,7 +32,7 @@ permissions:
 jobs:
 
   # A workflow that builds the library and runs all the tests
-  CMake_build_and_test:
+  Build_and_test:
     strategy:
       # The current matrix has one dimensions:
       #
@@ -53,7 +53,7 @@ jobs:
 
         include:
 
-          # Windows w/ MSVC + CMake
+          # Windows w/ MSVC
           #
           # No Fortran, parallel, or VFDs that rely on POSIX things
           - name: "Windows MSVC"
@@ -74,7 +74,7 @@ jobs:
             generator: "-G \"Visual Studio 17 2022\" -A x64"
             run_tests: true
 
-          # Linux (Ubuntu) w/ gcc + CMake
+          # Linux (Ubuntu) w/ gcc
           #
           - name: "Ubuntu gcc"
             ostype: ubuntu
@@ -94,7 +94,7 @@ jobs:
             generator: "-G Ninja"
             run_tests: true
 
-          # MacOS w/ Clang + CMake
+          # MacOS w/ Clang
           #
           - name: "MacOS Clang"
             ostype: macos
@@ -129,7 +129,7 @@ jobs:
       - name: Dump matrix context
         run: echo '${{ toJSON(matrix) }}'
 
-      - name: Install CMake Dependencies (Linux)
+      - name: Install Dependencies (Linux)
         run: |
            sudo apt-get update
            sudo apt-get install ninja-build graphviz
@@ -170,8 +170,8 @@ jobs:
       - name: Get Sources
         uses: actions/checkout@v4.1.7
 
-      # CMAKE CONFIGURE
-      - name: CMake Configure
+      # CONFIGURE
+      - name: Configure
         run: |
           mkdir "${{ runner.workspace }}/build"
           cd "${{ runner.workspace }}/build"
@@ -203,7 +203,7 @@ jobs:
         shell: bash
         if: ${{ inputs.thread_safety != 'TS' && inputs.concurrent != 'CC'}}
 
-      - name: CMake Configure (Thread-Safe)
+      - name: Configure (Thread-Safe)
         run: |
           mkdir "${{ runner.workspace }}/build"
           cd "${{ runner.workspace }}/build"
@@ -233,7 +233,7 @@ jobs:
         shell: bash
         if: ${{ inputs.thread_safety == 'TS' && inputs.concurrent != 'CC'}}
 
-      - name: CMake Configure (Concurrency)
+      - name: Configure (Concurrency)
         run: |
           mkdir "${{ runner.workspace }}/build"
           cd "${{ runner.workspace }}/build"
@@ -261,22 +261,22 @@ jobs:
         if: ${{ inputs.thread_safety != 'TS' && inputs.concurrent == 'CC'}}
 
       # BUILD
-      - name: CMake Build
+      - name: Build
         run: cmake --build . --parallel 3 --config ${{ inputs.build_mode }}
         working-directory: ${{ runner.workspace }}/build
 
       # RUN TESTS
-      - name: CMake Run Tests
+      - name: Run Tests
         run: ctest . --parallel 2 -C ${{ inputs.build_mode }} -V
         working-directory: ${{ runner.workspace }}/build
         if: ${{ matrix.run_tests }}
 
-      - name: CMake Run Package
+      - name: Run Package
         run: cpack -C ${{ inputs.build_mode }} -V
         working-directory: ${{ runner.workspace }}/build
 #        if: ${{ (matrix.ostype != 'macos') && (inputs.build_mode != 'Debug') }}
 
-#      - name: CMake Run Package (Mac_latest)
+#      - name: Run Package (Mac_latest)
 #        run: cpack -C ${{ inputs.build_mode }} -G STGZ -V
 #        if: ${{ (matrix.ostype == 'macos') }}
 
@@ -284,7 +284,7 @@ jobs:
         run: |
               ls -l ${{ runner.workspace }}/build
 
-      # Save files created by ctest script
+      # Save files created by CTest script
       - name: Save published binary (Windows)
         uses: actions/upload-artifact@v4
         with:
@@ -402,7 +402,7 @@ jobs:
       - name: Dump matrix context
         run: echo '${{ toJSON(matrix) }}'
 
-      - name: Install CMake Dependencies (Linux)
+      - name: Install Dependencies (Linux)
         run: |
            sudo apt-get update
            sudo apt-get install ninja-build graphviz
@@ -443,8 +443,8 @@ jobs:
       - name: Get Sources
         uses: actions/checkout@v4.1.7
 
-      # CMAKE CONFIGURE
-      - name: CMake Configure
+      # CONFIGURE
+      - name: Configure
         run: |
           mkdir "${{ runner.workspace }}/build"
           cd "${{ runner.workspace }}/build"
@@ -474,12 +474,12 @@ jobs:
         shell: bash
 
       # BUILD
-      - name: CMake Build
+      - name: Build
         run: cmake --build . --parallel 3 --config ${{ inputs.build_mode }}
         working-directory: ${{ runner.workspace }}/build
 
       # RUN TESTS
-      - name: CMake Run Tests
+      - name: Run Tests
         run: ctest . --parallel 2 -C ${{ inputs.build_mode }} -V
         working-directory: ${{ runner.workspace }}/build
         if: ${{ matrix.run_tests }}

--- a/.github/workflows/msys2-cmake.yml
+++ b/.github/workflows/msys2-cmake.yml
@@ -1,4 +1,4 @@
-name: hdf5 dev CMake MSys2 CI
+name: hdf5 dev MSys2 CI
 
 # Triggers the workflow on a call from another workflow
 on:
@@ -14,7 +14,7 @@ permissions:
 
 jobs:
 
-  CMake_build_and_test:
+  Build_and_test:
 
     # The type of runner that the job will run on
     runs-on: windows-latest
@@ -54,7 +54,7 @@ jobs:
       - name: Get Sources
         uses: actions/checkout@v4.1.1
 
-      - name: CMake Configure
+      - name: Configure
         run: |
           mkdir "${{ runner.workspace }}/build"
           cd "${{ runner.workspace }}/build"
@@ -72,17 +72,17 @@ jobs:
             -DHDF5_BUILD_DOC:BOOL=OFF \
             $GITHUB_WORKSPACE
 
-      - name: CMake Build
+      - name: Build
         run: |
           cmake --build . --parallel 3 --config ${{ inputs.build_mode }}
         working-directory: ${{ runner.workspace }}/build
 
-      - name: CMake Run Tests
+      - name: Run Tests
         run: |
           ctest . --parallel 2 -C ${{ inputs.build_mode }} -V -E "testhdf5-base|cache_api|dt_arith|H5TEST-dtypes|err_compat"
         working-directory: ${{ runner.workspace }}/build
 
-      - name: CMake Run Expected to Fail Tests
+      - name: Run Expected to Fail Tests
         run: |
           ctest . --parallel 2 -C ${{ inputs.build_mode }} -V -R "testhdf5-base|cache_api|dt_arith|H5TEST-dtypes|err_compat"
         working-directory: ${{ runner.workspace }}/build

--- a/.github/workflows/netcdf.yml
+++ b/.github/workflows/netcdf.yml
@@ -37,7 +37,7 @@ jobs:
     - name: Checkout HDF5
       uses: actions/checkout@v4.1.7
 
-    - name: CMake Configure
+    - name: Configure
       run: |
           mkdir "${{ runner.workspace }}/build"
           cd "${{ runner.workspace }}/build"
@@ -59,7 +59,7 @@ jobs:
             $GITHUB_WORKSPACE
       shell: bash
 
-    - name: CMake Build
+    - name: Build
       run: cmake --build . --parallel 3 --config Release
       working-directory: ${{ runner.workspace }}/build
 

--- a/.github/workflows/nvhpc-cmake.yml
+++ b/.github/workflows/nvhpc-cmake.yml
@@ -1,4 +1,4 @@
-name: hdf5 dev CMake nvhpc
+name: hdf5 dev nvhpc
 
 # Triggers the workflow on a call from another workflow
 on:
@@ -49,7 +49,7 @@ jobs:
           echo "LD_LIBRARY_PATH=/opt/nvidia/hpc_sdk/Linux_x86_64/${{ env.NVERDOT }}/cuda/${{ env.CUDAVERDOT }}/lib64:/opt/nvidia/hpc_sdk/Linux_x86_64/${{ env.NVERDOT }}/compilers/lib" >> $GITHUB_ENV
           echo "DESTDIR=/tmp" >> $GITHUB_ENV
 
-      - name: CMake Configure
+      - name: Configure
         shell: bash
         run: |
           export PATH=/opt/nvidia/hpc_sdk/Linux_x86_64/${{ env.NVERDOT }}/comm_libs/openmpi4/bin:/opt/nvidia/hpc_sdk/Linux_x86_64/${{ env.NVERDOT }}/compilers/bin:$PATH
@@ -67,27 +67,27 @@ jobs:
           -DMPIEXEC_PREFLAGS:STRING="--mca;opal_warn_on_missing_libcuda;0" \
           $GITHUB_WORKSPACE
 
-      - name: CMake Build
+      - name: Build
         shell: bash
         run: |
           cmake --build . --parallel 3 --config ${{ inputs.build_mode }}
         working-directory: ${{ runner.workspace }}/build
 
       # Skipping dt_arith and dtransform while we investigate long double failures
-      - name: CMake Run Tests
+      - name: Run Tests
         shell: bash
         run: |
           ctest . -E "MPI_TEST|H5TEST-dt_arith" --parallel 2 -C ${{ inputs.build_mode }} -V
         working-directory: ${{ runner.workspace }}/build
 
-      - name: CMake Run Expected To Fail Tests
+      - name: Run Expected To Fail Tests
         shell: bash
         run: |
           ctest . -R "H5TEST-dt_arith" --parallel 2 -C ${{ inputs.build_mode }} -V
         working-directory: ${{ runner.workspace }}/build
         continue-on-error: true
 
-      - name: CMake Run Parallel Tests
+      - name: Run Parallel Tests
         shell: bash
         run: |
           ctest . -R MPI_TEST -E "_by_chunk|_by_pattern" -C ${{ inputs.build_mode }} -V

--- a/.github/workflows/testxpr-cmake.yml
+++ b/.github/workflows/testxpr-cmake.yml
@@ -1,4 +1,4 @@
-name: hdf5 TestExpress CMake CI
+name: hdf5 TestExpress CI
 
 on:
   workflow_call:
@@ -15,7 +15,7 @@ jobs:
           - build_mode: "Release"
           - build_mode: "Debug"
 
-    name: "CMake ${{ matrix.build_mode }} Express Test Workflows"
+    name: "${{ matrix.build_mode }} Express Test Workflows"
 
     # Don't run the action if the commit message says to skip CI
     if: "!contains(github.event.head_commit.message, 'skip-ci')"
@@ -36,7 +36,7 @@ jobs:
       - name: Get Sources
         uses: actions/checkout@v4.1.7
 
-      - name: CMake Configure
+      - name: Configure
         shell: bash
         run: |
            mkdir "${{ runner.workspace }}/build"
@@ -56,11 +56,11 @@ jobs:
                 -DHDF_TEST_EXPRESS=0 \
                 $GITHUB_WORKSPACE
 
-      - name: CMake Build
+      - name: Build
         run: cmake --build . --parallel 3 --config ${{ matrix.build_mode }}
         working-directory: ${{ runner.workspace }}/build
 
-      - name: CMake Run Tests
+      - name: Run Tests
         env:
           HDF5TestExpress: 0
         run: ctest . --parallel 2 -C ${{ matrix.build_mode }} -V -R H5TESTXPR

--- a/.github/workflows/vfd-main.yml
+++ b/.github/workflows/vfd-main.yml
@@ -4,7 +4,7 @@ on:
   workflow_call:
     inputs:
       build_mode:
-        description: "CMake build type (CMAKE_BUILD_TYPE)"
+        description: "Build type (CMAKE_BUILD_TYPE)"
         required: true
         type: string
 

--- a/.github/workflows/vfd-ros3.yml
+++ b/.github/workflows/vfd-ros3.yml
@@ -4,7 +4,7 @@ on:
   workflow_call:
     inputs:
       build_mode:
-        description: "CMake build type (CMAKE_BUILD_TYPE)"
+        description: "Build type (CMAKE_BUILD_TYPE)"
         required: true
         type: string
       build_aws_c_s3_only:
@@ -321,7 +321,7 @@ jobs:
         uses: actions/checkout@v4.1.7
 
       # For Windows, use vcpkg toolchain file to allow find_package() calls to resolve
-      - name: "CMake Configure (vcpkg; ROS3 testing: ${{ matrix.test_ros3 }})"
+      - name: "Configure (vcpkg; ROS3 testing: ${{ matrix.test_ros3 }})"
         if: ${{ matrix.os_name == 'Windows MSVC' }}
         run: |
           mkdir "${{ runner.workspace }}/build"
@@ -347,7 +347,7 @@ jobs:
             $GITHUB_WORKSPACE
         shell: bash
 
-      - name: "CMake Configure (ROS3 testing: ${{ matrix.test_ros3 }})"
+      - name: "Configure (ROS3 testing: ${{ matrix.test_ros3 }})"
         if: ${{ matrix.os_name != 'Windows MSVC' }}
         run: |
           mkdir "${{ runner.workspace }}/build"
@@ -372,11 +372,11 @@ jobs:
             $GITHUB_WORKSPACE
         shell: bash
 
-      - name: CMake Build
+      - name: Build
         run: cmake --build . --parallel 3 --config ${{ inputs.build_mode }}
         working-directory: ${{ runner.workspace }}/build
 
-      - name: CMake Run Tests
+      - name: Run Tests
         if: matrix.test_ros3 == 'ON'
         run: |
           # For now, just run S3 tests
@@ -417,7 +417,7 @@ jobs:
       - name: Get HDF5 sources
         uses: actions/checkout@v4.1.7
 
-      - name: CMake Configure
+      - name: Configure
         run: |
           mkdir "${{ runner.workspace }}/build"
           cd "${{ runner.workspace }}/build"
@@ -441,11 +441,11 @@ jobs:
             $GITHUB_WORKSPACE
         shell: bash
 
-      - name: CMake Build
+      - name: Build
         run: cmake --build . --parallel 3 --config ${{ inputs.build_mode }}
         working-directory: ${{ runner.workspace }}/build
 
-      - name: CMake Run Tests
+      - name: Run Tests
         run: |
           # For now, just run S3 tests
           ctest . -C ${{ inputs.build_mode }} -R "S3TEST" -V

--- a/.github/workflows/vfd-subfiling.yml
+++ b/.github/workflows/vfd-subfiling.yml
@@ -4,7 +4,7 @@ on:
   workflow_call:
     inputs:
       build_mode:
-        description: "CMake build type (CMAKE_BUILD_TYPE)"
+        description: "Build type (CMAKE_BUILD_TYPE)"
         required: true
         type: string
 
@@ -36,7 +36,7 @@ jobs:
 #            mpi_lib: "MPICH"
 
     # Sets the job's name from the properties
-    name: "Test HDF5 Subfiling VFD (CMake ${{ inputs.build_mode }}) on ${{ matrix.os_name }} with ${{ matrix.mpi_lib }}"
+    name: "Test HDF5 Subfiling VFD (${{ inputs.build_mode }}) on ${{ matrix.os_name }} with ${{ matrix.mpi_lib }}"
 
     runs-on: ${{ matrix.os }}
 

--- a/.github/workflows/vfd.yml
+++ b/.github/workflows/vfd.yml
@@ -16,7 +16,7 @@ jobs:
         build_mode: ["Release", "Debug"]
 
     # Sets the job's name from the properties
-    name: "CMake ${{ matrix.build_mode }} Workflows"
+    name: "${{ matrix.build_mode }} Workflows"
 
     # Don't run the action if the commit message says to skip CI
     if: "!contains(github.event.head_commit.message, 'skip-ci')"

--- a/.github/workflows/vol_adios2.yml
+++ b/.github/workflows/vol_adios2.yml
@@ -4,7 +4,7 @@ on:
   workflow_call:
     inputs:
       build_mode:
-        description: "CMake Build type"
+        description: "Build type"
         required: true
         type: string
 

--- a/.github/workflows/vol_async.yml
+++ b/.github/workflows/vol_async.yml
@@ -4,7 +4,7 @@ on:
   workflow_call:
     inputs:
       build_mode:
-        description: "CMake Build type"
+        description: "Build type"
         required: true
         type: string
 

--- a/.github/workflows/vol_cache.yml
+++ b/.github/workflows/vol_cache.yml
@@ -4,7 +4,7 @@ on:
   workflow_call:
     inputs:
       build_mode:
-        description: "CMake Build type"
+        description: "Build type"
         required: true
         type: string
 

--- a/.github/workflows/vol_ext_passthru.yml
+++ b/.github/workflows/vol_ext_passthru.yml
@@ -4,7 +4,7 @@ on:
   workflow_call:
     inputs:
       build_mode:
-        description: "CMake Build type"
+        description: "Build type"
         required: true
         type: string
 

--- a/.github/workflows/vol_log.yml
+++ b/.github/workflows/vol_log.yml
@@ -4,7 +4,7 @@ on:
   workflow_call:
     inputs:
       build_mode:
-        description: "CMake Build type"
+        description: "Build type"
         required: true
         type: string
 

--- a/.github/workflows/vol_rest.yml
+++ b/.github/workflows/vol_rest.yml
@@ -4,7 +4,7 @@ on:
   workflow_call:
     inputs:
       build_mode:
-        description: "CMake Build type"
+        description: "Build type"
         required: true
         type: string
 
@@ -192,4 +192,3 @@ jobs:
           ROOT_DIR=${{github.workspace}}/hsdsdata \
           BUCKET_NAME=hsdstest \
           ctest --build-config ${{ inputs.build_mode }} -VV -R "h5_api" -E "H5COPY|H5DIFF" .
-      


### PR DESCRIPTION
These are leftovers from when the CI included Autotools builds.

Also changes ctest --> CTest in a few places.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Remove 'CMake' from CI workflow names and descriptions, and standardize 'CTest' capitalization across multiple files.
> 
>   - **CI Workflow Names**:
>     - Remove "CMake" from workflow names in `.github/workflows/*.yml`, e.g., `aocc-cmake.yml`, `arm-main-cmake.yml`, `cmake-analysis.yml`, and 10 other files.
>     - Standardize capitalization of `CTest` in workflow steps across multiple files.
>   - **Miscellaneous**:
>     - Update comments and descriptions to remove references to "CMake" where not needed.
>     - No functional changes to the CI processes, only naming and description updates.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=HDFGroup%2Fhdf5&utm_source=github&utm_medium=referral)<sup> for e84dde03e475f18c146e215ba7643cb60d677f3e. You can [customize](https://app.ellipsis.dev/HDFGroup/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->