### PR TITLE
Fix CVE-2025-2924

### DIFF
--- a/release_docs/RELEASE.txt
+++ b/release_docs/RELEASE.txt
@@ -841,6 +841,13 @@ Bug Fixes since HDF5-2.0.0 release
 
       Fixes GitHub issue #4952
 
+    - Check for overflow in decoded heap block addresses
+
+      Currently, we do not check for overflow when decoding addresses from
+      the heap, which can cause overflow problems. We've added a check in 
+      H5HL__fl_deserialize to ensure no overflow can occur.
+
+      Fixes GitHub issue #5382
 
     Java Library
     ------------

--- a/src/H5HLcache.c
+++ b/src/H5HLcache.c
@@ -232,7 +232,7 @@ H5HL__fl_deserialize(H5HL_t *heap)
         const uint8_t *image; /* Pointer into image buffer */
 
         /* Sanity check */
-        if ((free_block + (2 * heap->sizeof_size)) > heap->dblk_size)
+        if ((free_block > heap->dblk_size) || ((free_block + (2 * heap->sizeof_size)) > heap->dblk_size))
             HGOTO_ERROR(H5E_HEAP, H5E_BADRANGE, FAIL, "bad heap free list");
 
         /* Allocate & initialize free list node */

--- a/src/H5HLcache.c
+++ b/src/H5HLcache.c
@@ -225,15 +225,15 @@ H5HL__fl_deserialize(H5HL_t *heap)
     /* check arguments */
     assert(heap);
     assert(!heap->freelist);
-
+    HDcompile_assert(sizeof(hsize_t) == sizeof(uint64_t));
+    
     /* Build free list */
     free_block = heap->free_block;
     while (H5HL_FREE_NULL != free_block) {
         const uint8_t *image; /* Pointer into image buffer */
 
         /* Sanity check */
-        HDcompile_assert(sizeof(hsize_t) == sizeof(uint64_t));
-
+        
         if (free_block > UINT64_MAX - (2 * heap->sizeof_size))
             HGOTO_ERROR(H5E_HEAP, H5E_BADRANGE, FAIL, "decoded heap block address overflow");
 

--- a/src/H5HLcache.c
+++ b/src/H5HLcache.c
@@ -232,7 +232,12 @@ H5HL__fl_deserialize(H5HL_t *heap)
         const uint8_t *image; /* Pointer into image buffer */
 
         /* Sanity check */
-        if ((free_block > heap->dblk_size) || ((free_block + (2 * heap->sizeof_size)) > heap->dblk_size))
+        HDcompile_assert(sizeof(hsize_t) == sizeof(uint64_t));
+
+        if (free_block > UINT64_MAX - (2 * heap->sizeof_size))
+            HGOTO_ERROR(H5E_HEAP, H5E_BADRANGE, FAIL, "decoded heap block address overflow");
+
+        if ((free_block + (2 * heap->sizeof_size)) > heap->dblk_size)
             HGOTO_ERROR(H5E_HEAP, H5E_BADRANGE, FAIL, "bad heap free list");
 
         /* Allocate & initialize free list node */

--- a/src/H5HLcache.c
+++ b/src/H5HLcache.c
@@ -226,14 +226,14 @@ H5HL__fl_deserialize(H5HL_t *heap)
     assert(heap);
     assert(!heap->freelist);
     HDcompile_assert(sizeof(hsize_t) == sizeof(uint64_t));
-    
+
     /* Build free list */
     free_block = heap->free_block;
     while (H5HL_FREE_NULL != free_block) {
         const uint8_t *image; /* Pointer into image buffer */
 
         /* Sanity check */
-        
+
         if (free_block > UINT64_MAX - (2 * heap->sizeof_size))
             HGOTO_ERROR(H5E_HEAP, H5E_BADRANGE, FAIL, "decoded heap block address overflow");
 


### PR DESCRIPTION
This PR addresses issue https://github.com/HDFGroup/hdf5/issues/5382. Previously, overflow was not checked for when decoding addresses from the heap, which could cause issues. A check has been added in H5HL__fl_deserialize to ensure no overflow can occur.

The bug was first reproduced using the fuzzer and the POC file from https://github.com/HDFGroup/hdf5/issues/5382. With this change, the heap based buffer overflow no longer occurs.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fixes heap-based buffer overflow in `H5HL__fl_deserialize` by adding an overflow check.
> 
>   - **Security Fix**:
>     - Added overflow check in `H5HL__fl_deserialize` in `H5HLcache.c` to prevent heap-based buffer overflow.
>     - Specifically checks if `free_block` exceeds `UINT64_MAX - (2 * heap->sizeof_size)`.
>   - **Documentation**:
>     - Updated `RELEASE.txt` to include the fix for GitHub issue #5382.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=HDFGroup%2Fhdf5&utm_source=github&utm_medium=referral)<sup> for 69c15c2576262eda14342ee1fccc2f25a7b30ade. You can [customize](https://app.ellipsis.dev/HDFGroup/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->