### PR TITLE
Unlink file free space section on failure to update data structures

### DIFF
--- a/src/H5FSsection.c
+++ b/src/H5FSsection.c
@@ -1057,8 +1057,9 @@ done:
 static herr_t
 H5FS__sect_link(H5FS_t *fspace, H5FS_section_info_t *sect, unsigned flags)
 {
-    const H5FS_section_class_t *cls;                 /* Class of section */
-    herr_t                      ret_value = SUCCEED; /* Return value */
+    const H5FS_section_class_t *cls;                   /* Class of section */
+    bool                        linked_sect = false;   /* Was the section linked in? */
+    herr_t                      ret_value   = SUCCEED; /* Return value */
 
     FUNC_ENTER_PACKAGE
 
@@ -1073,6 +1074,7 @@ H5FS__sect_link(H5FS_t *fspace, H5FS_section_info_t *sect, unsigned flags)
     /* Add section to size tracked data structures */
     if (H5FS__sect_link_size(fspace->sinfo, cls, sect) < 0)
         HGOTO_ERROR(H5E_FSPACE, H5E_CANTINSERT, FAIL, "can't add section to size tracking data structures");
+    linked_sect = true;
 
     /* Update rest of free space manager data structures for section addition */
     if (H5FS__sect_link_rest(fspace, cls, sect, flags) < 0)
@@ -1080,6 +1082,12 @@ H5FS__sect_link(H5FS_t *fspace, H5FS_section_info_t *sect, unsigned flags)
                     "can't add section to non-size tracking data structures");
 
 done:
+    if (ret_value < 0) {
+        if (linked_sect && H5FS__sect_unlink_size(fspace->sinfo, cls, sect) < 0)
+            HDONE_ERROR(H5E_FSPACE, H5E_CANTFREE, FAIL,
+                        "can't remove section from size tracking data structures");
+    }
+
     FUNC_LEAVE_NOAPI(ret_value)
 } /* H5FS__sect_link() */
 


### PR DESCRIPTION
When linking a file free space section into a free space manager's internal data structures, the library previously wouldn't unlink the free space section when it failed to update the free space manager's internal data structures. This could eventually result in a use-after-free issue due to the stale reference kept around.
<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Ensure free space sections are unlinked on failure to update data structures in `H5FS__sect_link` to prevent use-after-free issues.
> 
>   - **Behavior**:
>     - In `H5FS__sect_link` in `H5FSsection.c`, added logic to unlink a free space section if an error occurs after it is linked to size tracking data structures.
>     - Introduced `linked_sect` flag to track if the section was successfully linked before an error.
>   - **Error Handling**:
>     - On failure, if `linked_sect` is true, attempt to unlink the section using `H5FS__sect_unlink_size`.
>     - Logs an error if unlinking fails, preventing potential use-after-free issues.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=HDFGroup%2Fhdf5&utm_source=github&utm_medium=referral)<sup> for 1bc11ba2952dd942cf637f5a2c748e8e9c4031a4. You can [customize](https://app.ellipsis.dev/HDFGroup/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->