### PR TITLE
Fix a snprintf warning in H5match_types.c

### DIFF
--- a/fortran/src/H5match_types.c
+++ b/fortran/src/H5match_types.c
@@ -152,7 +152,7 @@ main(void)
     int  RealKinds[]        = H5_FORTRAN_REAL_KINDS;
     int  RealKinds_SizeOf[] = H5_FORTRAN_REAL_KINDS_SIZEOF;
     char Real_C_TYPES[10][32];
-    int  Real_C_TYPES_Y = 32; /* Has to match second dimension of Real_C_TYPES */
+    int  Real_C_TYPES_Y = 31; /* Has to match second dimension of Real_C_TYPES - 1 */
 
     int FORTRAN_NUM_INTEGER_KINDS = H5_FORTRAN_NUM_INTEGER_KINDS;
     int H5_FORTRAN_NUM_REAL_KINDS;

--- a/fortran/src/H5match_types.c
+++ b/fortran/src/H5match_types.c
@@ -152,6 +152,7 @@ main(void)
     int  RealKinds[]        = H5_FORTRAN_REAL_KINDS;
     int  RealKinds_SizeOf[] = H5_FORTRAN_REAL_KINDS_SIZEOF;
     char Real_C_TYPES[10][32];
+    int  Real_C_TYPES_Y = 32; /* Has to match second dimension of Real_C_TYPES */
 
     int FORTRAN_NUM_INTEGER_KINDS = H5_FORTRAN_NUM_INTEGER_KINDS;
     int H5_FORTRAN_NUM_REAL_KINDS;
@@ -357,8 +358,9 @@ main(void)
 
     for (i = 0; i < H5_FORTRAN_NUM_REAL_KINDS; i++) {
         if (RealKinds[i] > 0) {
-            snprintf(chrA, sizeof(chrA), "Fortran_REAL_%s", Real_C_TYPES[i]);
-            snprintf(chrB, sizeof(chrB), "real_%s_f", Real_C_TYPES[i]);
+            /* Limit snprintf to Real_C_TYPES_Y characters to quiet warnings */
+            snprintf(chrA, sizeof(chrA), "Fortran_REAL_%.*s", Real_C_TYPES_Y, Real_C_TYPES[i]);
+            snprintf(chrB, sizeof(chrB), "real_%.*s_f", Real_C_TYPES_Y, Real_C_TYPES[i]);
             writeToFiles("float", chrA, chrB, RealKinds[i]);
         }
     }


### PR DESCRIPTION
gcc complains about writing too many characters into a buffer since we're writing from a 2D array. This PR limits the output and quiets the warnings.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fixes `snprintf` warning in `H5match_types.c` by limiting output to prevent buffer overflow.
> 
>   - **Behavior**:
>     - Fixes `snprintf` warning in `main()` in `H5match_types.c` by limiting output to `Real_C_TYPES_Y` characters.
>     - Ensures no buffer overflow when writing from `Real_C_TYPES` 2D array.
>   - **Misc**:
>     - Adds `Real_C_TYPES_Y` constant to define buffer size limit.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=HDFGroup%2Fhdf5&utm_source=github&utm_medium=referral)<sup> for 3387376c162945a60d56a17cfb3113051f57add7. You can [customize](https://app.ellipsis.dev/HDFGroup/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->