### PR TITLE
Link Checker Fix

### DIFF
--- a/doxygen/dox/IntroParExamples.dox
+++ b/doxygen/dox/IntroParExamples.dox
@@ -51,7 +51,7 @@ The number of processes that you could use would be 1, 2, 4, or 8. The number of
 <table>
 <tr>
 <th><strong>Processes</strong></th>
-<th><strong>Size of count[0](\# of rows) </strong></th>
+<th><strong>Size of count[0](# of rows) </strong></th>
 </tr><tr>
 <td>1</td><td>8</td>
 </tr><tr>
@@ -163,7 +163,7 @@ columns that could be written by each slab is as follows:
 <table>
 <tr>
 <th><strong>Processes</strong></th>
-<th><strong>Size of count (2)(\# of columns) </strong></th>
+<th><strong>Size of count (2)(# of columns) </strong></th>
 </tr><tr>
 <td>1</td><td>8</td>
 </tr><tr>

--- a/doxygen/dox/IntroParExamples.dox
+++ b/doxygen/dox/IntroParExamples.dox
@@ -51,7 +51,7 @@ The number of processes that you could use would be 1, 2, 4, or 8. The number of
 <table>
 <tr>
 <th><strong>Processes</strong></th>
-<th><strong>Size of count[0](# of rows) </strong></th>
+<th><strong>Size of count[0](&#35; of rows) </strong></th>
 </tr><tr>
 <td>1</td><td>8</td>
 </tr><tr>
@@ -163,7 +163,7 @@ columns that could be written by each slab is as follows:
 <table>
 <tr>
 <th><strong>Processes</strong></th>
-<th><strong>Size of count (2)(# of columns) </strong></th>
+<th><strong>Size of count (2)(&#35; of columns) </strong></th>
 </tr><tr>
 <td>1</td><td>8</td>
 </tr><tr>


### PR DESCRIPTION
Fixed the Doxygen reference warning by replacing the # symbol with its HTML entity &#35;
Resolves PR #5807 
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fixes Doxygen reference warnings in `IntroParExamples.dox` by replacing `#` with `&#35;`.
> 
>   - **Fixes**:
>     - Replaces `#` with `&#35;` in `IntroParExamples.dox` to fix Doxygen reference warnings.
>     - Affects two instances: "Size of count[0](# of rows)" and "Size of count (2)(# of columns)".
>   - **Resolves**:
>     - Resolves issue reported in PR #5807.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=HDFGroup%2Fhdf5&utm_source=github&utm_medium=referral)<sup> for eefb898f62eb41f83d96c94d87b77e72be527800. You can [customize](https://app.ellipsis.dev/HDFGroup/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->