### PR TITLE
Fix __builtin_expect() handling in H5public.h

### DIFF
--- a/src/H5private.h
+++ b/src/H5private.h
@@ -432,6 +432,18 @@
  */
 #define H5_REQUEST_NULL NULL
 
+/*
+ * Does the compiler support the __builtin_expect() syntax?
+ * It's not a problem if not.
+ */
+#if H5_HAVE_BUILTIN_EXPECT
+#define H5_LIKELY(expression)   __builtin_expect(!!(expression), 1)
+#define H5_UNLIKELY(expression) __builtin_expect(!!(expression), 0)
+#else
+#define H5_LIKELY(expression)   (expression)
+#define H5_UNLIKELY(expression) (expression)
+#endif
+
 /* clang-format off */
 /* Address-related macros */
 #define H5_addr_overflow(X,Z)    (HADDR_UNDEF == (X) ||                     \

--- a/src/H5public.h
+++ b/src/H5public.h
@@ -457,18 +457,6 @@ typedef void (*H5_atclose_func_t)(void *ctx);
 /* API adapter header (defines H5_DLL, etc.) */
 #include "H5api_adpt.h"
 
-/*
- * Does the compiler support the __builtin_expect() syntax?
- * It's not a problem if not.
- */
-#if H5_HAVE_BUILTIN_EXPECT
-#define H5_LIKELY(expression)   __builtin_expect(!!(expression), 1)
-#define H5_UNLIKELY(expression) __builtin_expect(!!(expression), 0)
-#else
-#define H5_LIKELY(expression)   (expression)
-#define H5_UNLIKELY(expression) (expression)
-#endif
-
 /* Definition of H5OPEN macro used for returning library defined IDs to
  * applications with macros, e.g. H5FD_SEC2.  Will only call H5open() for
  * the application  once per library init/term epoch, and will not call


### PR DESCRIPTION
H5_HAVE_BUILTIN_EXPECT will be private when we split up H5pubconf.h. This needs to either be private or protected by normal feature tests.

Also, there is no guarantee that the compiler that is used to build the library and the application compiler will have the same support for __builtin_expect().

Partial fix for #5819
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Move `__builtin_expect()` handling from `H5public.h` to `H5private.h` to keep it internal and not part of the public API.
> 
>   - **Refactoring**:
>     - Move `__builtin_expect()` handling from `H5public.h` to `H5private.h`.
>     - Redefine `H5_LIKELY` and `H5_UNLIKELY` macros in `H5private.h`.
>   - **Purpose**:
>     - Ensure `__builtin_expect()` handling is internal, not part of public API.
>     - Part of effort to make `H5_HAVE_BUILTIN_EXPECT` private and split `H5pubconf.h`.
>   - **Issue**:
>     - Partial fix for issue #5819.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=HDFGroup%2Fhdf5&utm_source=github&utm_medium=referral)<sup> for b4518a66f11f4eee74e60c316d6e62c087224111. You can [customize](https://app.ellipsis.dev/HDFGroup/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->