### PR TITLE
Fix protection for __builtin_expect() in H5public.h

### DIFF
--- a/config/HDFTests.c
+++ b/config/HDFTests.c
@@ -27,21 +27,6 @@ main ()
 
 #endif /* HAVE___FLOAT128 */
 
-#ifdef HAVE_BUILTIN_EXPECT
-
-int
-main ()
-{
-    void *ptr = (void*) 0;
-
-    if (__builtin_expect (ptr != (void*) 0, 1))
-        return 0;
-
-    return 0;
-}
-
-#endif /* HAVE_BUILTIN_EXPECT */
-
 #ifdef HAVE_ATTRIBUTE
 
 int

--- a/src/H5pubconf.h.in
+++ b/src/H5pubconf.h.in
@@ -307,9 +307,6 @@
 /* Define to 1 if you have the <szlib.h> header file. */
 #cmakedefine H5_HAVE_SZLIB_H @H5_HAVE_SZLIB_H@
 
-/* Define to 1 if the compiler supports the __builtin_expect() extension */
-#cmakedefine H5_HAVE_BUILTIN_EXPECT @H5_HAVE_BUILTIN_EXPECT@
-
 /* Define if we have thread support */
 # cmakedefine H5_HAVE_THREADS @H5_HAVE_THREADS@
 

--- a/src/H5public.h
+++ b/src/H5public.h
@@ -461,6 +461,22 @@ typedef void (*H5_atclose_func_t)(void *ctx);
  * Does the compiler support the __builtin_expect() syntax?
  * It's not a problem if not.
  */
+
+/* clang-format off */
+#if defined(__has_builtin)
+    /* clang extension to check for builtins. Do this first, because clang
+     * also defines __GNUC__ and didn't support __builtin_expect() until
+     * more recently.
+     */
+#   if __has_builtin(__builtin_expect)
+#       define H5_HAVE_BUILTIN_EXPECT 1
+#   endif
+#elif defined(__GNUC__)
+    /* __builtin_expect() has been supported since 2.95 or 2.96 (circa 2000) */
+#   define H5_HAVE_BUILTIN_EXPECT 1
+#endif
+/* clang-format on */
+
 #if H5_HAVE_BUILTIN_EXPECT
 #define H5_LIKELY(expression)   __builtin_expect(!!(expression), 1)
 #define H5_UNLIKELY(expression) __builtin_expect(!!(expression), 0)


### PR DESCRIPTION
This feature is required to be in H5public.h, but is protected by an HDF5 feature test macro that will soon be private. There is also no guarantee that the compiler used to build the software has the same support for __builtin_expect() that the application compiler has.

This PR updates the feature test checks for __builtin_expect()

Partial fix for #5819
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Update feature test checks for `__builtin_expect()` in `H5public.h` to ensure compiler compatibility.
> 
>   - **Feature Test Update**:
>     - Updated feature test checks for `__builtin_expect()` in `H5public.h` to use `__has_builtin` for Clang and `__GNUC__` for GCC.
>     - Removed outdated `H5_HAVE_BUILTIN_EXPECT` checks from `H5pubconf.h.in` and `HDFTests.c`.
>   - **Behavior**:
>     - Ensures compatibility with compilers that may not support `__builtin_expect()`.
>     - Addresses issue of private HDF5 feature test macro.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=HDFGroup%2Fhdf5&utm_source=github&utm_medium=referral)<sup> for f113675af1382d89d812dd30be79985d48a88928. You can [customize](https://app.ellipsis.dev/HDFGroup/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->