### PR TITLE
Allow cygwin to finish

### DIFF
--- a/.github/workflows/cygwin.yml
+++ b/.github/workflows/cygwin.yml
@@ -26,7 +26,7 @@ jobs:
   cygwin_build_and_test:
     name: "cygwin-${{ inputs.build_mode }}"
     runs-on: windows-latest
-    timeout-minutes: 30
+    timeout-minutes: 40
     steps:
       - name: Set git to use LF
         run: |
@@ -92,7 +92,7 @@ jobs:
             set (MODEL "GHDaily")
             set (GROUP "GHDaily")
             set (SITE_BUILDNAME_SUFFIX "${{ steps.set-file-base.outputs.FILE_BASE }}")
-            set (ADD_BUILD_OPTIONS "${ADD_BUILD_OPTIONS} --log-level=VERBOSE")
+            set (ADD_BUILD_OPTIONS "${ADD_BUILD_OPTIONS} --log-level=NOTICE")
             set (ADD_BUILD_OPTIONS "${ADD_BUILD_OPTIONS} -DHDF5_GENERATE_HEADERS:BOOL=OFF")
             set (ADD_BUILD_OPTIONS "${ADD_BUILD_OPTIONS} -DHDF5_BUILD_JAVA:BOOL=OFF")
             set (ADD_BUILD_OPTIONS "${ADD_BUILD_OPTIONS} -DHDF5_BUILD_CPP_LIB:BOOL=OFF")
@@ -114,7 +114,7 @@ jobs:
         run: |
           export PATH=/usr/bin:$PATH
           cd "${{ runner.workspace }}/hdf5"
-          ctest -S HDF5config.cmake,CTEST_SITE_EXT=GH-${{ github.event.repository.full_name }}-CYG,LOCAL_SUBMIT=ON,NINJA=TRUE,BUILD_GENERATOR=Unix,CTEST_SOURCE_NAME=${{ steps.set-file-base.outputs.SOURCE_BASE }} -C Release -O hdf5.log
+          ctest -S HDF5config.cmake,CTEST_SITE_EXT=GH-${{ github.event.repository.full_name }}-CYG,LOCAL_SUBMIT=ON,NINJA=TRUE,BUILD_GENERATOR=Unix,CTEST_SOURCE_NAME=${{ steps.set-file-base.outputs.SOURCE_BASE }} -C Release -V -O hdf5.log
         continue-on-error: true
 
       # Save log files created by CTest script

--- a/.github/workflows/cygwin.yml
+++ b/.github/workflows/cygwin.yml
@@ -114,7 +114,7 @@ jobs:
         run: |
           export PATH=/usr/bin:$PATH
           cd "${{ runner.workspace }}/hdf5"
-          ctest -S HDF5config.cmake,CTEST_SITE_EXT=GH-${{ github.event.repository.full_name }}-CYG,LOCAL_SUBMIT=ON,NINJA=TRUE,BUILD_GENERATOR=Unix,CTEST_SOURCE_NAME=${{ steps.set-file-base.outputs.SOURCE_BASE }} -C Release -VV -O hdf5.log
+          ctest -S HDF5config.cmake,CTEST_SITE_EXT=GH-${{ github.event.repository.full_name }}-CYG,LOCAL_SUBMIT=ON,NINJA=TRUE,BUILD_GENERATOR=Unix,CTEST_SOURCE_NAME=${{ steps.set-file-base.outputs.SOURCE_BASE }} -C Release -O hdf5.log
         continue-on-error: true
 
       # Save log files created by CTest script

--- a/.github/workflows/cygwin.yml
+++ b/.github/workflows/cygwin.yml
@@ -109,6 +109,8 @@ jobs:
 
       - name: Run CTest (Cygwin)
         shell: C:\cygwin\bin\bash.exe -eo pipefail -o igncr '{0}'
+        env:
+            CTEST_OUTPUT_ON_FAILURE: true
         run: |
           export PATH=/usr/bin:$PATH
           cd "${{ runner.workspace }}/hdf5"


### PR DESCRIPTION
Increased the job timeout to 40 mins. Only runs in daily-build and now the documentation will be published as the cygwin workflow will complete.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Increase Cygwin workflow timeout to 40 minutes and adjust logging settings to ensure completion and documentation publication.
> 
>   - **Workflow Changes**:
>     - Increase `timeout-minutes` from 30 to 40 in `cygwin.yml` to allow Cygwin workflow to complete.
>     - Change log level from `VERBOSE` to `NOTICE` in `HDF5options.cmake`.
>     - Add `CTEST_OUTPUT_ON_FAILURE: true` environment variable in `Run CTest (Cygwin)` step.
>     - Modify `ctest` command to use `-V` instead of `-VV` for verbosity in `Run CTest (Cygwin)` step.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=HDFGroup%2Fhdf5&utm_source=github&utm_medium=referral)<sup> for 608912e3436390bf9cffc2e2f683dec3bd92192a. You can [customize](https://app.ellipsis.dev/HDFGroup/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->