### PR TITLE
ci: add mac-26

### DIFF
--- a/.github/workflows/macos-26-matrix.yml
+++ b/.github/workflows/macos-26-matrix.yml
@@ -239,6 +239,8 @@ jobs:
           elif [[ "${{ matrix.mpi }}" == "mpich" ]]; then
             CMAKE_OPTS="$CMAKE_OPTS -DMPI_C_COMPILER=mpicc"
             CMAKE_OPTS="$CMAKE_OPTS -DCMAKE_Fortran_COMPILER=mpifort"
+            sudo ln -s /opt/homebrew/bin/gfortran-15 /opt/homebrew/bin/gfortran
+            mpifort --version
           fi
         fi
 

--- a/.github/workflows/macos-26-matrix.yml
+++ b/.github/workflows/macos-26-matrix.yml
@@ -187,7 +187,7 @@ jobs:
     - name: Get Sources
       uses: actions/checkout@v5
 
-    - name: Configure CMake
+    - name: Configure
       run: |
         mkdir "${{ runner.workspace }}/build"
         cd "${{ runner.workspace }}/build"
@@ -242,7 +242,7 @@ jobs:
           fi
         fi
 
-        echo "CMake configuration options: $CMAKE_OPTS"
+        echo "Configuration options: $CMAKE_OPTS"
         cmake $CMAKE_OPTS "$GITHUB_WORKSPACE"
       shell: bash
 

--- a/.github/workflows/macos-26-matrix.yml
+++ b/.github/workflows/macos-26-matrix.yml
@@ -236,6 +236,7 @@ jobs:
           CMAKE_OPTS="$CMAKE_OPTS -DMPIEXEC_MAX_NUMPROCS=2"
           if [[ "${{ matrix.mpi }}" == "openmpi" ]]; then
             CMAKE_OPTS="$CMAKE_OPTS -DMPI_C_COMPILER=mpicc"
+            CMAKE_OPTS="$CMAKE_OPTS -DMPIEXEC_PREFLAGS=--oversubscribe"
           elif [[ "${{ matrix.mpi }}" == "mpich" ]]; then
             CMAKE_OPTS="$CMAKE_OPTS -DMPI_C_COMPILER=mpicc"
             CMAKE_OPTS="$CMAKE_OPTS -DCMAKE_Fortran_COMPILER=mpifort"

--- a/.github/workflows/macos-26-matrix.yml
+++ b/.github/workflows/macos-26-matrix.yml
@@ -168,7 +168,7 @@ jobs:
     - name: Install Dependencies
       run: |
         # Install base dependencies
-        brew install ninja cmake autoconf automake libtool
+        brew install autoconf automake libtool
 
         # Install compression libraries
         brew install zlib
@@ -181,11 +181,6 @@ jobs:
           brew install openmpi
         elif [[ "${{ matrix.mpi }}" == "mpich" ]]; then
           brew install mpich
-        fi
-
-        # Install Java if needed
-        if [[ "${{ matrix.java }}" == "ON" ]]; then
-          brew install openjdk
         fi
 
 
@@ -217,7 +212,9 @@ jobs:
 
         # Plugin support if specified
         if [[ "${{ matrix.plugins }}" == "ON" ]]; then
-          CMAKE_OPTS="$CMAKE_OPTS -DHDF5_ENABLE_PLUGIN_SUPPORT=ON -DPLUGIN_USE_LOCALCONTENT:BOOL=OFF"
+          CMAKE_OPTS="$CMAKE_OPTS -DHDF5_ENABLE_PLUGIN_SUPPORT=ON"
+          CMAKE_OPTS="$CMAKE_OPTS -DHDF5_ALLOW_EXTERNAL_SUPPORT=TGZ"
+          CMAKE_OPTS="$CMAKE_OPTS -DPLUGIN_USE_LOCALCONTENT=OFF"
         fi
 
         # Set Java environment if needed

--- a/.github/workflows/macos-26-matrix.yml
+++ b/.github/workflows/macos-26-matrix.yml
@@ -16,14 +16,14 @@ jobs:
         # Test combinations of key options
         include:
           # Shared libraries with OpenMPI
-          - name: "macOS-26 Shared OpenMPI C++"
+          - name: "macOS-26 Shared OpenMPI Fortran Java"
             os: macos-26
             mpi: openmpi
             shared_libs: ON
             static_libs: OFF
-            cpp: ON
-            fortran: OFF
-            java: OFF
+            cpp: OFF
+            fortran: ON
+            java: ON
             hl: ON
             threadsafe: OFF
             parallel: ON
@@ -190,7 +190,7 @@ jobs:
 
         # Install Fortran compiler if needed
         if [[ "${{ matrix.fortran }}" == "ON" ]]; then
-          brew install gcc
+          brew install gfortran
         fi
 
     - name: Get Sources

--- a/.github/workflows/macos-26-matrix.yml
+++ b/.github/workflows/macos-26-matrix.yml
@@ -220,16 +220,6 @@ jobs:
           CMAKE_OPTS="$CMAKE_OPTS -DHDF5_ENABLE_PLUGIN_SUPPORT=ON -DPLUGIN_USE_LOCALCONTENT:BOOL=OFF"
         fi
 
-        # MPI configuration
-        if [[ "${{ matrix.parallel }}" == "ON" ]]; then
-          CMAKE_OPTS="$CMAKE_OPTS -DMPIEXEC_MAX_NUMPROCS=2"
-          if [[ "${{ matrix.mpi }}" == "openmpi" ]]; then
-            CMAKE_OPTS="$CMAKE_OPTS -DMPI_C_COMPILER=mpicc"
-          elif [[ "${{ matrix.mpi }}" == "mpich" ]]; then
-            CMAKE_OPTS="$CMAKE_OPTS -DMPI_C_COMPILER=mpicc"
-          fi
-        fi
-
         # Set Java environment if needed
         if [[ "${{ matrix.java }}" == "ON" ]]; then
           export JAVA_HOME=$(/usr/libexec/java_home)
@@ -239,6 +229,17 @@ jobs:
         # Set Fortran compiler if needed
         if [[ "${{ matrix.fortran }}" == "ON" ]]; then
           CMAKE_OPTS="$CMAKE_OPTS -DCMAKE_Fortran_COMPILER=gfortran-15"
+        fi
+
+        # MPI configuration
+        if [[ "${{ matrix.parallel }}" == "ON" ]]; then
+          CMAKE_OPTS="$CMAKE_OPTS -DMPIEXEC_MAX_NUMPROCS=2"
+          if [[ "${{ matrix.mpi }}" == "openmpi" ]]; then
+            CMAKE_OPTS="$CMAKE_OPTS -DMPI_C_COMPILER=mpicc"
+          elif [[ "${{ matrix.mpi }}" == "mpich" ]]; then
+            CMAKE_OPTS="$CMAKE_OPTS -DMPI_C_COMPILER=mpicc"
+            CMAKE_OPTS="$CMAKE_OPTS -DCMAKE_Fortran_COMPILER=mpifort"
+          fi
         fi
 
         echo "CMake configuration options: $CMAKE_OPTS"

--- a/.github/workflows/macos-26-matrix.yml
+++ b/.github/workflows/macos-26-matrix.yml
@@ -1,0 +1,287 @@
+name: macOS-26 Matrix Testing
+
+on:
+  push:
+    branches:
+      - develop
+  pull_request:
+    branches:
+      - develop
+
+jobs:
+  build-test:
+    strategy:
+      fail-fast: false
+      matrix:
+        # Test combinations of key options
+        include:
+          # Shared libraries with OpenMPI
+          - name: "macOS-26 Shared OpenMPI C++"
+            os: macos-26
+            mpi: openmpi
+            shared_libs: ON
+            static_libs: OFF
+            cpp: ON
+            fortran: OFF
+            java: OFF
+            hl: ON
+            threadsafe: OFF
+            parallel: ON
+            tools: ON
+            tests: ON
+            examples: ON
+            zlib: ON
+            szip: ON
+
+          # Shared libraries with MPICH
+          - name: "macOS-26 Shared MPICH Fortran"
+            os: macos-26
+            mpi: mpich
+            shared_libs: ON
+            static_libs: OFF
+            cpp: OFF
+            fortran: ON
+            java: OFF
+            hl: ON
+            threadsafe: OFF
+            parallel: ON
+            tools: ON
+            tests: ON
+            examples: ON
+            zlib: ON
+            szip: ON
+
+          # Static libraries with OpenMPI
+          - name: "macOS-26 Static OpenMPI Java"
+            os: macos-26
+            mpi: openmpi
+            shared_libs: OFF
+            static_libs: ON
+            cpp: OFF
+            fortran: OFF
+            java: ON
+            hl: ON
+            threadsafe: OFF
+            parallel: ON
+            tools: ON
+            tests: ON
+            examples: ON
+            zlib: ON
+            szip: OFF
+
+          # Both static and shared with MPICH
+          - name: "macOS-26 Both MPICH All Features"
+            os: macos-26
+            mpi: mpich
+            shared_libs: ON
+            static_libs: ON
+            cpp: ON
+            fortran: ON
+            java: OFF
+            hl: ON
+            threadsafe: OFF
+            parallel: ON
+            tools: ON
+            tests: ON
+            examples: ON
+            zlib: ON
+            szip: ON
+
+          # Serial build with thread-safety
+          - name: "macOS-26 Serial Threadsafe"
+            os: macos-26
+            mpi: none
+            shared_libs: ON
+            static_libs: ON
+            cpp: ON
+            fortran: OFF
+            java: OFF
+            hl: OFF
+            threadsafe: ON
+            parallel: OFF
+            tools: ON
+            tests: ON
+            examples: ON
+            zlib: ON
+            szip: ON
+
+          # Minimal configuration
+          - name: "macOS-26 Minimal Config"
+            os: macos-26
+            mpi: none
+            shared_libs: ON
+            static_libs: OFF
+            cpp: OFF
+            fortran: OFF
+            java: OFF
+            hl: OFF
+            threadsafe: OFF
+            parallel: OFF
+            tools: OFF
+            tests: ON
+            examples: OFF
+            zlib: OFF
+            szip: OFF
+
+          # Plugin support with OpenMPI
+          - name: "macOS-26 Plugins OpenMPI"
+            os: macos-26
+            mpi: openmpi
+            shared_libs: ON
+            static_libs: OFF
+            cpp: OFF
+            fortran: OFF
+            java: OFF
+            hl: ON
+            threadsafe: OFF
+            parallel: ON
+            tools: ON
+            tests: ON
+            examples: ON
+            zlib: ON
+            szip: ON
+            plugins: ON
+
+          # No High Level API with MPICH
+          - name: "macOS-26 No HL MPICH"
+            os: macos-26
+            mpi: mpich
+            shared_libs: ON
+            static_libs: ON
+            cpp: ON
+            fortran: OFF
+            java: OFF
+            hl: OFF
+            threadsafe: OFF
+            parallel: ON
+            tools: ON
+            tests: ON
+            examples: ON
+            zlib: ON
+            szip: ON
+
+    name: ${{ matrix.name }}
+    runs-on: ${{ matrix.os }}
+    if: "!contains(github.event.head_commit.message, 'skip-ci')"
+
+    steps:
+    - name: Install Dependencies
+      run: |
+        # Install base dependencies
+        brew install ninja cmake autoconf automake libtool
+
+        # Install compression libraries
+        brew install zlib
+        if [[ "${{ matrix.szip }}" == "ON" ]]; then
+          brew install libaec
+        fi
+
+        # Install MPI libraries
+        if [[ "${{ matrix.mpi }}" == "openmpi" ]]; then
+          brew install openmpi
+        elif [[ "${{ matrix.mpi }}" == "mpich" ]]; then
+          brew install mpich
+        fi
+
+        # Install Java if needed
+        if [[ "${{ matrix.java }}" == "ON" ]]; then
+          brew install openjdk
+        fi
+
+        # Install Fortran compiler if needed
+        if [[ "${{ matrix.fortran }}" == "ON" ]]; then
+          brew install gcc
+        fi
+
+    - name: Get Sources
+      uses: actions/checkout@v5
+
+    - name: Configure CMake
+      run: |
+        mkdir "${{ runner.workspace }}/build"
+        cd "${{ runner.workspace }}/build"
+
+        # Base CMake options
+        CMAKE_OPTS="-G Ninja"
+        CMAKE_OPTS="$CMAKE_OPTS -DCMAKE_BUILD_TYPE=Release"
+        CMAKE_OPTS="$CMAKE_OPTS -DBUILD_SHARED_LIBS=${{ matrix.shared_libs }}"
+        CMAKE_OPTS="$CMAKE_OPTS -DBUILD_STATIC_LIBS=${{ matrix.static_libs }}"
+        CMAKE_OPTS="$CMAKE_OPTS -DHDF5_BUILD_CPP_LIB=${{ matrix.cpp }}"
+        CMAKE_OPTS="$CMAKE_OPTS -DHDF5_BUILD_FORTRAN=${{ matrix.fortran }}"
+        CMAKE_OPTS="$CMAKE_OPTS -DHDF5_BUILD_JAVA=${{ matrix.java }}"
+        CMAKE_OPTS="$CMAKE_OPTS -DHDF5_BUILD_HL_LIB=${{ matrix.hl }}"
+        CMAKE_OPTS="$CMAKE_OPTS -DHDF5_ENABLE_THREADSAFE=${{ matrix.threadsafe }}"
+        CMAKE_OPTS="$CMAKE_OPTS -DHDF5_ENABLE_PARALLEL=${{ matrix.parallel }}"
+        CMAKE_OPTS="$CMAKE_OPTS -DHDF5_BUILD_TOOLS=${{ matrix.tools }}"
+        CMAKE_OPTS="$CMAKE_OPTS -DBUILD_TESTING=${{ matrix.tests }}"
+        CMAKE_OPTS="$CMAKE_OPTS -DHDF5_BUILD_EXAMPLES=${{ matrix.examples }}"
+        CMAKE_OPTS="$CMAKE_OPTS -DHDF5_ENABLE_ZLIB_SUPPORT=${{ matrix.zlib }}"
+        CMAKE_OPTS="$CMAKE_OPTS -DHDF5_ENABLE_SZIP_SUPPORT=${{ matrix.szip }}"
+
+        # Plugin support if specified
+        if [[ "${{ matrix.plugins }}" == "ON" ]]; then
+          CMAKE_OPTS="$CMAKE_OPTS -DHDF5_ENABLE_PLUGIN_SUPPORT=ON"
+        fi
+
+        # MPI configuration
+        if [[ "${{ matrix.parallel }}" == "ON" ]]; then
+          CMAKE_OPTS="$CMAKE_OPTS -DMPIEXEC_MAX_NUMPROCS=2"
+          if [[ "${{ matrix.mpi }}" == "openmpi" ]]; then
+            CMAKE_OPTS="$CMAKE_OPTS -DMPI_C_COMPILER=mpicc"
+          elif [[ "${{ matrix.mpi }}" == "mpich" ]]; then
+            CMAKE_OPTS="$CMAKE_OPTS -DMPI_C_COMPILER=mpicc"
+          fi
+        fi
+
+        # Set Java environment if needed
+        if [[ "${{ matrix.java }}" == "ON" ]]; then
+          export JAVA_HOME=$(/usr/libexec/java_home)
+          CMAKE_OPTS="$CMAKE_OPTS -DJAVA_HOME=$JAVA_HOME"
+        fi
+
+        # Set Fortran compiler if needed
+        if [[ "${{ matrix.fortran }}" == "ON" ]]; then
+          CMAKE_OPTS="$CMAKE_OPTS -DCMAKE_Fortran_COMPILER=gfortran"
+        fi
+
+        echo "CMake configuration options: $CMAKE_OPTS"
+        cmake $CMAKE_OPTS "$GITHUB_WORKSPACE"
+      shell: bash
+
+    - name: Build
+      run: cmake --build . --config Release --parallel 2
+      working-directory: ${{ runner.workspace }}/build
+
+    - name: Test
+      run: |
+        # Run tests with appropriate settings for each configuration
+        if [[ "${{ matrix.parallel }}" == "ON" ]]; then
+          # For parallel builds, limit concurrent tests
+          ctest --build . -C Release -V --parallel 1
+        else
+          # For serial builds, can run more tests concurrently
+          ctest --build . -C Release -V --parallel 2
+        fi
+      working-directory: ${{ runner.workspace }}/build
+      env:
+        # Set test timeout
+        CTEST_TIMEOUT: 3600
+
+    - name: Upload Test Results
+      uses: actions/upload-artifact@v4
+      if: always()
+      with:
+        name: test-results-${{ matrix.name }}
+        path: |
+          ${{ runner.workspace }}/build/Testing/Temporary/CTestCostData.txt
+          ${{ runner.workspace }}/build/Testing/Temporary/LastTest.log
+        retention-days: 7
+
+    - name: Show Test Summary
+      if: always()
+      run: |
+        echo "=== Test Summary for ${{ matrix.name }} ==="
+        if [[ -f Testing/Temporary/LastTest.log ]]; then
+          tail -50 Testing/Temporary/LastTest.log
+        fi
+      working-directory: ${{ runner.workspace }}/build

--- a/.github/workflows/macos-26-matrix.yml
+++ b/.github/workflows/macos-26-matrix.yml
@@ -22,7 +22,7 @@ jobs:
             shared_libs: ON
             static_libs: OFF
             cpp: OFF
-            fortran: ON
+            fortran: OFF
             java: ON
             hl: ON
             threadsafe: OFF
@@ -188,10 +188,6 @@ jobs:
           brew install openjdk
         fi
 
-        # Install Fortran compiler if needed
-        if [[ "${{ matrix.fortran }}" == "ON" ]]; then
-          brew install gfortran
-        fi
 
     - name: Get Sources
       uses: actions/checkout@v5
@@ -241,7 +237,7 @@ jobs:
 
         # Set Fortran compiler if needed
         if [[ "${{ matrix.fortran }}" == "ON" ]]; then
-          CMAKE_OPTS="$CMAKE_OPTS -DCMAKE_Fortran_COMPILER=gfortran"
+          CMAKE_OPTS="$CMAKE_OPTS -DCMAKE_Fortran_COMPILER=gfortran-15"
         fi
 
         echo "CMake configuration options: $CMAKE_OPTS"

--- a/.github/workflows/macos-26-matrix.yml
+++ b/.github/workflows/macos-26-matrix.yml
@@ -52,14 +52,14 @@ jobs:
             szip: ON
 
           # Static libraries with OpenMPI
-          - name: "macOS-26 Static OpenMPI Java"
+          - name: "macOS-26 Static OpenMPI"
             os: macos-26
             mpi: openmpi
             shared_libs: OFF
             static_libs: ON
             cpp: OFF
             fortran: OFF
-            java: ON
+            java: OFF
             hl: ON
             threadsafe: OFF
             parallel: ON
@@ -213,10 +213,11 @@ jobs:
         CMAKE_OPTS="$CMAKE_OPTS -DHDF5_BUILD_EXAMPLES=${{ matrix.examples }}"
         CMAKE_OPTS="$CMAKE_OPTS -DHDF5_ENABLE_ZLIB_SUPPORT=${{ matrix.zlib }}"
         CMAKE_OPTS="$CMAKE_OPTS -DHDF5_ENABLE_SZIP_SUPPORT=${{ matrix.szip }}"
+        CMAKE_OPTS="$CMAKE_OPTS -DHDF5_ALLOW_UNSUPPORTED=ON"
 
         # Plugin support if specified
         if [[ "${{ matrix.plugins }}" == "ON" ]]; then
-          CMAKE_OPTS="$CMAKE_OPTS -DHDF5_ENABLE_PLUGIN_SUPPORT=ON"
+          CMAKE_OPTS="$CMAKE_OPTS -DHDF5_ENABLE_PLUGIN_SUPPORT=ON -DPLUGIN_USE_LOCALCONTENT:BOOL=OFF"
         fi
 
         # MPI configuration
@@ -253,10 +254,10 @@ jobs:
         # Run tests with appropriate settings for each configuration
         if [[ "${{ matrix.parallel }}" == "ON" ]]; then
           # For parallel builds, limit concurrent tests
-          ctest --build . -C Release -V --parallel 1
+          ctest . -C Release -V --parallel 1
         else
           # For serial builds, can run more tests concurrently
-          ctest --build . -C Release -V --parallel 2
+          ctest . -C Release -V --parallel 2
         fi
       working-directory: ${{ runner.workspace }}/build
       env:


### PR DESCRIPTION
close #5848
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Adds macOS-26 matrix testing workflow to CI for diverse build configurations.
> 
>   - **Workflow Addition**:
>     - Adds `macos-26-matrix.yml` for macOS-26 matrix testing.
>     - Triggers on `push` and `pull_request` to `develop` branch.
>   - **Configurations**:
>     - Tests combinations of shared/static libraries, OpenMPI/MPICH, and language support (C++, Fortran, Java).
>     - Includes configurations for thread-safety, plugin support, and minimal setup.
>   - **Steps**:
>     - Installs dependencies using Homebrew (e.g., `ninja`, `cmake`, `zlib`, `openmpi`, `mpich`).
>     - Configures CMake with options based on matrix variables.
>     - Builds using CMake and Ninja.
>     - Runs tests with `ctest`, adjusting parallelism based on configuration.
>     - Uploads test results and displays a summary.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=HDFGroup%2Fhdf5&utm_source=github&utm_medium=referral)<sup> for 50d904476892d9d02ecbd20ced3510581a2f519b. You can [customize](https://app.ellipsis.dev/HDFGroup/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->