### PR TITLE
Fix scale-offset filter errors

### DIFF
--- a/release_docs/CHANGELOG.md
+++ b/release_docs/CHANGELOG.md
@@ -483,6 +483,12 @@ HDF5 release, platforms tested, and known problems in this release.
 
 ## Library
 
+### Fixed a problem with the scale-offset filter
+
+A security fix added to 1.14.6 introduced a regression where certain data values could trigger a library error (not a crash or segfault).
+
+Fixes GitHub issue #5861
+
 ### Fixed security issue CVE-2025-6857
 
    An HDF5 file had a corrupted v1 B-tree that would result in a stack overflow when performing a lookup on it. This has been fixed with additional integrity checks.

--- a/src/H5Zscaleoffset.c
+++ b/src/H5Zscaleoffset.c
@@ -1211,7 +1211,7 @@ H5Z__filter_scaleoffset(unsigned flags, size_t cd_nelmts, const unsigned cd_valu
             minbits_mask <<= i * 8;
             minbits |= minbits_mask;
         }
-        if (minbits >= p.size * 8)
+        if (minbits > p.size * 8)
             HGOTO_ERROR(H5E_ARGS, H5E_BADVALUE, 0, "minimum number of bits exceeds size of type");
 
         /* retrieval of minval takes into consideration situation where sizeof


### PR DESCRIPTION
A security fix from 1.14.6 introduced a regression in the scale-offset filter where normal data values could cause the library to emit an error (not a crash/segfault).

Fixes GitHub #5861
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fixes regression in `H5Z__filter_scaleoffset` to prevent errors from normal data values by adjusting `minbits` condition.
> 
>   - **Behavior**:
>     - Fixes regression in `H5Z__filter_scaleoffset` in `H5Zscaleoffset.c` where `minbits` condition was changed from `>=` to `>` to prevent errors when `minbits` equals the size of the type.
>     - Addresses issue where normal data values could trigger a library error.
>   - **Documentation**:
>     - Updates `CHANGELOG.md` to include the fix for the scale-offset filter regression and reference GitHub issue #5861.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=HDFGroup%2Fhdf5&utm_source=github&utm_medium=referral)<sup> for 612485eab119578fec2e6f03f756532861a98d69. You can [customize](https://app.ellipsis.dev/HDFGroup/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->