### PR TITLE
Move macos-26-matrix.yml workflow to run nightly.

### DIFF
--- a/.github/workflows/macos-26-matrix.yml
+++ b/.github/workflows/macos-26-matrix.yml
@@ -1,12 +1,14 @@
 name: macOS-26 Matrix Testing
 
 on:
-  push:
-    branches:
-      - develop
-  pull_request:
-    branches:
-      - develop
+   workflow_dispatch:
+     schedule:
+         - cron: "0 9 * * *"
+
+# Using concurrency to cancel any in-progress job or run
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref && github.ref || github.run_id }}
+  cancel-in-progress: true
 
 jobs:
   build-test:

--- a/.github/workflows/macos-26-matrix.yml
+++ b/.github/workflows/macos-26-matrix.yml
@@ -2,8 +2,8 @@ name: macOS-26 Matrix Testing
 
 on:
    workflow_dispatch:
-     schedule:
-         - cron: "0 9 * * *"
+   schedule:
+     - cron: "0 9 * * *"
 
 # Using concurrency to cancel any in-progress job or run
 concurrency:


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> The `macos-26-matrix.yml` workflow is updated to run nightly at 9 AM UTC with concurrency control to cancel in-progress jobs.
> 
>   - **Workflow Trigger**:
>     - Changes `macos-26-matrix.yml` to run nightly at 9 AM UTC using a cron schedule.
>     - Removes triggers for `push` and `pull_request` on the `develop` branch.
>   - **Concurrency**:
>     - Adds concurrency control to cancel in-progress jobs when a new job starts in `macos-26-matrix.yml`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=HDFGroup%2Fhdf5&utm_source=github&utm_medium=referral)<sup> for b19dec50ff3d9e7d584001e6d096bbb0d8e14fee. You can [customize](https://app.ellipsis.dev/HDFGroup/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->