### PR TITLE
Fix CVE-2025-2310

### DIFF
--- a/release_docs/CHANGELOG.md
+++ b/release_docs/CHANGELOG.md
@@ -654,6 +654,11 @@ Added Fortran wrapper h5fdsubfiling_get_file_mapping_f() for the subfiling file 
 
    Fixed GitHub issue [#4952](https://github.com/HDFGroup/hdf5/issues/4952)
 
+### Fixed security issue CVE-2025-2310
+
+   A malformed HDF5 file could have an attribute with a recorded name length of zero.This would lead to an overflow and an invalid memory access. An integrity check
+   has been added to detect this case and safely stop file decoding.
+
 ## Java Library
 
 ### Renamed the Callbacks.java file to H5Callbacks.java

--- a/src/H5Oattr.c
+++ b/src/H5Oattr.c
@@ -167,6 +167,11 @@ H5O__attr_decode(H5F_t *f, H5O_t *open_oh, unsigned H5_ATTR_UNUSED mesg_flags, u
     if (H5_IS_BUFFER_OVERFLOW(p, 2, p_end))
         HGOTO_ERROR(H5E_OHDR, H5E_OVERFLOW, NULL, "ran off end of input buffer while decoding");
     UINT16DECODE(p, name_len); /* Including null */
+
+    /* Verify that retrieved name length (including null byte) is valid */
+    if (name_len <= 1)
+        HGOTO_ERROR(H5E_OHDR, H5E_CANTDECODE, NULL, "decoded name length is invalid");
+
     if (H5_IS_BUFFER_OVERFLOW(p, 2, p_end))
         HGOTO_ERROR(H5E_OHDR, H5E_OVERFLOW, NULL, "ran off end of input buffer while decoding");
     UINT16DECODE(p, attr->shared->dt_size);
@@ -190,10 +195,6 @@ H5O__attr_decode(H5F_t *f, H5O_t *open_oh, unsigned H5_ATTR_UNUSED mesg_flags, u
      */
     if (H5_IS_BUFFER_OVERFLOW(p, name_len, p_end))
         HGOTO_ERROR(H5E_OHDR, H5E_OVERFLOW, NULL, "ran off end of input buffer while decoding");
-
-    /* Verify that retrieved name length (including null byte) is valid */
-    if (name_len <= 1)
-        HGOTO_ERROR(H5E_OHDR, H5E_CANTDECODE, NULL, "decoded name length is invalid");
 
     if (NULL == (attr->shared->name = H5MM_strndup((const char *)p, name_len - 1)))
         HGOTO_ERROR(H5E_RESOURCE, H5E_NOSPACE, NULL, "memory allocation failed");

--- a/src/H5Oattr.c
+++ b/src/H5Oattr.c
@@ -190,6 +190,11 @@ H5O__attr_decode(H5F_t *f, H5O_t *open_oh, unsigned H5_ATTR_UNUSED mesg_flags, u
      */
     if (H5_IS_BUFFER_OVERFLOW(p, name_len, p_end))
         HGOTO_ERROR(H5E_OHDR, H5E_OVERFLOW, NULL, "ran off end of input buffer while decoding");
+
+    /* Verify that name is null-terminated within its expected length to prevent overrun during strndup */
+    if (memchr((const char *)p, '\0', name_len) == NULL)
+        HGOTO_ERROR(H5E_ATTR, H5E_CANTDECODE, NULL, "attribute name not properly null-terminated within buffer");
+
     if (NULL == (attr->shared->name = H5MM_strndup((const char *)p, name_len - 1)))
         HGOTO_ERROR(H5E_RESOURCE, H5E_NOSPACE, NULL, "memory allocation failed");
 

--- a/src/H5Oattr.c
+++ b/src/H5Oattr.c
@@ -191,9 +191,9 @@ H5O__attr_decode(H5F_t *f, H5O_t *open_oh, unsigned H5_ATTR_UNUSED mesg_flags, u
     if (H5_IS_BUFFER_OVERFLOW(p, name_len, p_end))
         HGOTO_ERROR(H5E_OHDR, H5E_OVERFLOW, NULL, "ran off end of input buffer while decoding");
 
-    /* Verify that name is null-terminated within its expected length to prevent overrun during strndup */
-    if (memchr((const char *)p, '\0', name_len) == NULL)
-        HGOTO_ERROR(H5E_ATTR, H5E_CANTDECODE, NULL, "attribute name not properly null-terminated within buffer");
+    /* Verify that retrieved name length (including null byte) is valid */
+    if (name_len <= 1)
+        HGOTO_ERROR(H5E_OHDR, H5E_CANTDECODE, NULL, "decoded name length is invalid");
 
     if (NULL == (attr->shared->name = H5MM_strndup((const char *)p, name_len - 1)))
         HGOTO_ERROR(H5E_RESOURCE, H5E_NOSPACE, NULL, "memory allocation failed");


### PR DESCRIPTION
Malformed files can have a zero name-length, which when subtracted lead to an overflow and an out-of-bounds read.

Check that name length is not too small in addition to checking for an overflow directly.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fixes overflow and out-of-bounds read in `H5O__attr_decode()` by ensuring `name_len` is greater than 1 in `H5Oattr.c`.
> 
>   - **Security Fix**:
>     - In `H5O__attr_decode()` in `H5Oattr.c`, added a check to ensure `name_len` is greater than 1 to prevent overflow and out-of-bounds read.
>     - This prevents processing of malformed files with zero-length names.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=HDFGroup%2Fhdf5&utm_source=github&utm_medium=referral)<sup> for a5a0b305acd8fcd2a2d0e5e012072411f7411756. You can [customize](https://app.ellipsis.dev/HDFGroup/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->