### PR TITLE
Set max POSIX IO size to 0x7ffff000 bytes

### DIFF
--- a/release_docs/CHANGELOG.md
+++ b/release_docs/CHANGELOG.md
@@ -172,7 +172,11 @@ HDF5 release, platforms tested, and known problems in this release.
 
    The standard for building the library is now C11. We have updated the build files to set the C standard to C11, though some platforms use gnu11 to get some GNU things to work.
 
-## Library 
+## Library
+
+### The maximum POSIX I/O size has been set to 0x7ffff000 bytes for all platforms
+
+This was previously set to SSIZE_MAX on Linux, which is correct as far as POSIX is concerned, but Linux defines the max as MAX_RW_COUNT, which is set to INT_MAX & PAGE_CACHE_MASK (0x7ffff000) in fs.h. Since this is very close to the INT_MAX value that was previously set for MacOS and Windows, HDF5 will now use the Linux value on all platforms. Larger I/O sizes will be split into multiple smaller read/write calls in the VFDs.
 
 ### Removed hbool_t from public API calls
 

--- a/src/H5private.h
+++ b/src/H5private.h
@@ -401,22 +401,18 @@
 #endif /* H5_HAVE_PARALLEL */
 
 /*
- * Types and max sizes for POSIX I/O.
- * OS X (Darwin) is odd since the max I/O size does not match the types.
+ * Types and max I/O size for POSIX read/write calls
  */
 #if defined(H5_HAVE_WIN32_API)
-#define h5_posix_io_t         unsigned int
-#define h5_posix_io_ret_t     int
-#define H5_POSIX_MAX_IO_BYTES INT_MAX
-#elif defined(H5_HAVE_DARWIN)
-#define h5_posix_io_t         size_t
-#define h5_posix_io_ret_t     ssize_t
-#define H5_POSIX_MAX_IO_BYTES INT_MAX
+#define h5_posix_io_t     unsigned int
+#define h5_posix_io_ret_t int
 #else
-#define h5_posix_io_t         size_t
-#define h5_posix_io_ret_t     ssize_t
-#define H5_POSIX_MAX_IO_BYTES SSIZE_MAX
+#define h5_posix_io_t     size_t
+#define h5_posix_io_ret_t ssize_t
 #endif
+
+/* Use the Linux limit (MAX_RW_COUNT, which is INT_MAX & PAGE_CACHE_MASK) for everyone */
+#define H5_POSIX_MAX_IO_BYTES 0x7ffff000
 
 /* POSIX I/O mode used as the third parameter to open/_open
  * when creating a new file (O_CREAT is set).


### PR DESCRIPTION
This was previously set to SSIZE_MAX on Linux, which is correct as far as POSIX is concerned, but Linux defines the max as MAX_RW_COUNT, which is set to INT_MAX & PAGE_CACHE_MASK (0x7ffff000) in fs.h. Since this is very close to the INT_MAX value that was previously set for MacOS and Windows, HDF5 will now use the Linux value on all platforms.

Larger I/O sizes will be split into multiple smaller read/write calls in the VFDs.

Fixes #5873
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Set maximum POSIX I/O size to `0x7ffff000` bytes for all platforms, splitting larger operations, and updated documentation.
> 
>   - **Behavior**:
>     - Set maximum POSIX I/O size to `0x7ffff000` bytes for all platforms in `H5private.h`.
>     - Larger I/O operations are split into smaller read/write calls.
>   - **Documentation**:
>     - Updated `CHANGELOG.md` to reflect the new maximum POSIX I/O size.
>   - **Issue Fix**:
>     - Fixes issue #5873 by standardizing I/O size limits across platforms.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=HDFGroup%2Fhdf5&utm_source=github&utm_medium=referral)<sup> for 3b0b7cfa53c0affa596ca77ec8f553865d225d9f. You can [customize](https://app.ellipsis.dev/HDFGroup/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->