### PR TITLE
Update h5vers and release scripts to handle change from RELEASE.txt to CHANGELOG.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# HDF5 version 2.0.0-2 currently under development
+HDF5 version 2.0.0-2 currently under development
 
 > [!WARNING]
 > **Heads Up: HDF5 Dropped Autotools March 10th**

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-HDF5 version 2.0.0-2 currently under development
+# HDF5 version 2.0.0-2 currently under development
 
 > [!WARNING]
 > **Heads Up: HDF5 Dropped Autotools March 10th**

--- a/bin/h5vers
+++ b/bin/h5vers
@@ -63,7 +63,7 @@ use strict;
 # ./H5public.h or ./src/H5public.h.
 #
 # If the version number is changed (either `-s' or `-i' was used on
-# the command line) then the version line of the README.md and RELEASE.txt files
+# the command line) then the version line of the README.md and CHANGELOG.md files
 # one directory above the H5public.h file is also modified so it looks
 # something like: This is hdf5-2.0.1-1 currently under development.
 # Version changes are also reflected in the Windows-maintained H5pubconf.h
@@ -155,9 +155,9 @@ while ($_ = shift) {
 die "mutually exclusive options given\n" if $set && $inc;
 
 # Determine file to use as H5public.h, README.md,
-# release_docs/RELEASE.txt, windows/src/H5pubconf.h
+# release_docs/CHANGELOG.md, windows/src/H5pubconf.h
 # config/lt_vers.am and config/cmake/scripts/HDF5config.cmake. 
-# The README.md, release_docs/RELEASE.txt, # windows/src/H5pubconf.h,
+# The README.md, release_docs/CHANGELOG.md, # windows/src/H5pubconf.h,
 # config/lt_vers.am and config/cmake/scripts/HDF5config.cmake
 # files are always in the directory above H5public.h
 unless ($file) {
@@ -183,10 +183,10 @@ die "unable to read file: $HDF5EXCONFCMAKE\n" unless -r $file;
 my $README = $file;
 $README =~ s/[^\/]*$/..\/README.md/;
 die "unable to read file: $README\n" unless -r $file;
-# release_docs/RELEASE.txt
-my $RELEASE = $file;
-$RELEASE =~ s/[^\/]*$/..\/release_docs\/RELEASE.txt/;
-die "unable to read file: $RELEASE\n" unless -r $file;
+# release_docs/CHANGELOG.md
+my $CHANGELOG = $file;
+$CHANGELOG =~ s/[^\/]*$/..\/release_docs\/CHANGELOG.md/;
+die "unable to read file: $CHANGELOG\n" unless -r $file;
 my $H5_JAVA = $file;
 $H5_JAVA =~ s/[^\/]*$/..\/java\/src\/hdf\/hdf5lib\/H5.java/;
 die "unable to read file: $H5_JAVA\n" unless -r $file;
@@ -241,7 +241,7 @@ if ($set) {
 } else {
   # Nothing to do but print result
   $README = "";
-  $RELEASE = "";
+  $CHANGELOG = "";
   $LT_VERS = "";       
   $HDF5CONFIGCMAKE = "";
   $HDF5EXCONFCMAKE = "";
@@ -300,7 +300,7 @@ if ($README) {
   open FILE, $README or die "$README: $!\n";
   my @contents = <FILE>;
   close FILE;
-  $contents[0] = sprintf("HDF5 version %d.%d.%d%s %s",
+  $contents[0] = sprintf("# HDF5 version %d.%d.%d%s %s",
 			 @newver[0,1,2],
 			 $newver[3] eq "" ? "" : "-".$newver[3],
 			 "currently under development\n");
@@ -309,16 +309,26 @@ if ($README) {
   close FILE;
 }
 
-# Update the release_docs/RELEASE.txt file
-if ($RELEASE) {
-  open FILE, $RELEASE or die "$RELEASE: $!\n";
+# Update the release_docs/CHANGELOG.md file
+if ($CHANGELOG) {
+  open FILE, $CHANGELOG or die "$CHANGELOG: $!\n";
   my @contents = <FILE>;
   close FILE;
-  $contents[0] = sprintf("HDF5 version %d.%d.%d%s %s",
+  $contents[0] = sprintf("# HDF5 version %d.%d.%d%s %s",
 			 @newver[0,1,2],
 			 $newver[3] eq "" ? "" : "-".$newver[3],
 			 "currently under development\n");
-  open FILE, ">$RELEASE" or die "$RELEASE: $!\n";
+
+  for (my $i = 0; $i < $#contents; ++$i) {
+    if ($contents[$i] =~ /^# 🔆 Executive Summary: HDF5 Version/) {
+      $contents[$i] = sprintf("# 🔆 Executive Summary: HDF5 Version %d.%d.%d%s\n",
+                              @newver[0,1,2],
+                              $newver[3] eq "" ? "" : "-".$newver[3]);
+      last;
+    }
+  }
+
+  open FILE, ">$CHANGELOG" or die "$CHANGELOG: $!\n";
   print FILE @contents;
   close FILE;
 }

--- a/bin/h5vers
+++ b/bin/h5vers
@@ -300,7 +300,7 @@ if ($README) {
   open FILE, $README or die "$README: $!\n";
   my @contents = <FILE>;
   close FILE;
-  $contents[0] = sprintf("# HDF5 version %d.%d.%d%s %s",
+  $contents[0] = sprintf("HDF5 version %d.%d.%d%s %s",
 			 @newver[0,1,2],
 			 $newver[3] eq "" ? "" : "-".$newver[3],
 			 "currently under development\n");
@@ -314,7 +314,7 @@ if ($CHANGELOG) {
   open FILE, $CHANGELOG or die "$CHANGELOG: $!\n";
   my @contents = <FILE>;
   close FILE;
-  $contents[0] = sprintf("# HDF5 version %d.%d.%d%s %s",
+  $contents[0] = sprintf("HDF5 version %d.%d.%d%s %s",
 			 @newver[0,1,2],
 			 $newver[3] eq "" ? "" : "-".$newver[3],
 			 "currently under development\n");

--- a/bin/release
+++ b/bin/release
@@ -64,6 +64,8 @@ Examples:
     /tmp/hdf5-1.8.13.zip
     /tmp/hdf5-1.8.13.zip.sha256
 
+    Note:  as of HDF5 2.0.0, RELEASE.txt is replaced by CHANGELOG.md
+
 The integrity of a downloaded file can be verified on Linux platforms by running 
 "sha256sum --check <filename>.sha256, which will display 'OK' if the calculated
 checksum of <filename> matches the checksum in <filename>.sha256.
@@ -259,9 +261,9 @@ fi
 # we want (gnu's --transform isn't portable)
 ln -s `pwd` $tmpdir/$HDF5_IN_VERS || exit 1
 
-# Update README.md and release_docs/RELEASE.txt with release information in
+# Update README.md and release_docs/CHANGELOG.md with release information in
 # line 1.
-for f in README.md release_docs/RELEASE.txt; do
+for f in README.md release_docs/CHANGELOG.md; do
     echo "HDF5 version $VERS released on $release_date" >$f.x
     sed -e 1d $f >>$f.x
     mv $f.x $f
@@ -304,8 +306,8 @@ for comp in $methods; do
     esac
 done
 
-# Copy the RELEASE.txt to the release area.
-cp release_docs/RELEASE.txt $DEST/$HDF5_VERS-RELEASE.txt
+# Copy CHANGELOG.mc to the release area
+cp release_docs/CHANGELOG.md $DEST/$HDF5_VERS-CHANGELOG.md
 
 # Restore OLD version information, then no need for trap.
 if [ X$pmode = Xyes ] || [ X$revmode = Xyes ]; then

--- a/bin/release
+++ b/bin/release
@@ -262,7 +262,7 @@ ln -s `pwd` $tmpdir/$HDF5_IN_VERS || exit 1
 # Update README.md and release_docs/RELEASE.txt with release information in
 # line 1.
 for f in README.md release_docs/RELEASE.txt; do
-    echo "# HDF5 version $VERS released on $release_date" >$f.x
+    echo "HDF5 version $VERS released on $release_date" >$f.x
     sed -e 1d $f >>$f.x
     mv $f.x $f
     # Make sure new files are of the right access mode

--- a/bin/release
+++ b/bin/release
@@ -262,7 +262,7 @@ ln -s `pwd` $tmpdir/$HDF5_IN_VERS || exit 1
 # Update README.md and release_docs/RELEASE.txt with release information in
 # line 1.
 for f in README.md release_docs/RELEASE.txt; do
-    echo "HDF5 version $VERS released on $release_date" >$f.x
+    echo "# HDF5 version $VERS released on $release_date" >$f.x
     sed -e 1d $f >>$f.x
     mv $f.x $f
     # Make sure new files are of the right access mode

--- a/release_docs/CHANGELOG.md
+++ b/release_docs/CHANGELOG.md
@@ -1,4 +1,4 @@
-# HDF5 2.0.0 - 2025-09-30
+# HDF5 version 2.0.0-2 currently under development
 
 # 🔺 HDF5 Changelog
 All notable changes to this project will be documented in this file. This document describes the differences between this release and the previous
@@ -21,7 +21,7 @@ HDF5 release, platforms tested, and known problems in this release.
 * [Platforms Tested](#%EF%B8%8F-platforms-tested)
 * [Known Problems](#-known-problems)
 
-# 🔆 Executive Summary: HDF5 Version 2.0.0
+# 🔆 Executive Summary: HDF5 Version 2.0.0-2
 
 ## Performance Enhancements:
 

--- a/release_docs/CHANGELOG.md
+++ b/release_docs/CHANGELOG.md
@@ -1,4 +1,4 @@
-# HDF5 version 2.0.0-2 currently under development
+HDF5 version 2.0.0-2 currently under development
 
 # 🔺 HDF5 Changelog
 All notable changes to this project will be documented in this file. This document describes the differences between this release and the previous

--- a/release_docs/CHANGELOG.md
+++ b/release_docs/CHANGELOG.md
@@ -652,7 +652,8 @@ HDF5 release, platforms tested, and known problems in this release.
 
 # ☑️ Platforms Tested 
 
-Data to come from cdash.
+A table of platforms tested can be seen on the [wiki](https://github.com/HDFGroup/hdf5/wiki/Platforms-Tested).
+Current test results are available [here](https://my.cdash.org/index.php?project=HDF5).
 
 # ⛔ Known Problems
 


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Update scripts and documentation to replace `RELEASE.txt` with `CHANGELOG.md` for version updates.
> 
>   - **Scripts**:
>     - In `bin/h5vers`, replace references to `RELEASE.txt` with `CHANGELOG.md`.
>     - In `bin/release`, update script to modify `CHANGELOG.md` instead of `RELEASE.txt`.
>   - **Documentation**:
>     - Update version line format in `README.md` and `CHANGELOG.md` to include header marker `#`.
>   - **Misc**:
>     - Ensure version updates are reflected in `CHANGELOG.md` instead of `RELEASE.txt`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=HDFGroup%2Fhdf5&utm_source=github&utm_medium=referral)<sup> for 4e099f5c217f15a3fbc6b9dff035a25be4204bb0. You can [customize](https://app.ellipsis.dev/HDFGroup/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->