### PR TITLE
Include VDS changes in CHANGELOG

### DIFF
--- a/release_docs/CHANGELOG.md
+++ b/release_docs/CHANGELOG.md
@@ -25,8 +25,8 @@ For releases prior to version 2.0.0, please see the release.txt file and for mor
 
 ## Performance Enhancements:
 
-- [30% faster opening](https://github.com/HDFGroup/hdf5/blob/develop/release_docs/CHANGELOG.md#layoutcopydelay) and 25% faster closing of virtual datasets.
-- Reduced memory overhead via shared name strings and optimized spatial search algorithms for virtual datasets.
+- [30% faster opening](https://github.com/HDFGroup/hdf5/blob/develop/release_docs/CHANGELOG.md#layoutcopydelay) and [25% faster closing](https://github.com/HDFGroup/hdf5/blob/develop/release_docs/CHANGELOG.md#fileformat) of virtual datasets.
+- [Reduced memory overhead](https://github.com/HDFGroup/hdf5/blob/develop/release_docs/CHANGELOG.md#fileformat) via shared name strings and optimized spatial search algorithms for virtual datasets.
 
 ## Significant Advancements:
 
@@ -211,6 +211,8 @@ Calling `H5Pset_fapl_ros3()` now has the side effect of setting the page buffer 
 ### The file format has been updated to 4.0<a name="fileformat"></a>
 
 The Virtual Dataset Global Heap Block format has been updated to version 1 to support shared string storage for source filenames and dataset names, reducing file size when multiple mappings reference the same sources. This new format is only used when the HDF5 library version bounds lower bound is set to 2.0 or later.
+
+Use of the shared strings option for Virtual Datasets reduces memory overhead and optimizes dataset close operations.
 
 ### The `H5Dread_chunk()` signature has changed
 

--- a/release_docs/CHANGELOG.md
+++ b/release_docs/CHANGELOG.md
@@ -25,7 +25,7 @@ For releases prior to version 2.0.0, please see the release.txt file and for mor
 
 ## Performance Enhancements:
 
-- 30% faster opening and 25% faster closing of virtual datasets.
+- [30% faster opening](https://github.com/HDFGroup/hdf5/blob/develop/release_docs/CHANGELOG.md#layoutcopydelay) and 25% faster closing of virtual datasets.
 - Reduced memory overhead via shared name strings and optimized spatial search algorithms for virtual datasets.
 
 ## Significant Advancements:
@@ -438,6 +438,12 @@ Simple example programs showing how to use complex number datatypes have been ad
 ### `H5Pset_vol()` now fails when used on a non-file-access property list
 
    Similar to the above. Setting the connector on a non-FAPL had no effect on library behavior, and the connector ID and information could not be read back from that plist later.
+
+### Optimized Virtual Dataset opens by delaying layout copy<a name="layoutcopydelay"></a>
+
+   On dataset open, the dataset performed an internal copy of the layout in order to populate its internal DCPL. For virtual datasets, this added a significant amount of overhead to the open operation.
+
+   This layout copy is now delayed until either a user requests the DCPL, or until the start of an operation that needs to read the layout from the DCPL.
 
 ## Parallel Library
 


### PR DESCRIPTION
- Link from Executive Summary bullet points related to shared strings to the description of the new file format for them
- Add CHANGELOG section for the delayed VDS layout copy
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Update `CHANGELOG.md` to include VDS performance enhancements and optimizations, with links and a new section on delayed layout copy.
> 
>   - **CHANGELOG Updates**:
>     - Added links in `CHANGELOG.md` for faster opening and closing of virtual datasets to specific sections: `layoutcopydelay` and `fileformat`.
>     - Added a new section in `CHANGELOG.md` for optimized VDS opens by delaying layout copy, reducing overhead during open operations.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=HDFGroup%2Fhdf5&utm_source=github&utm_medium=referral)<sup> for ed74926243f6b4ee4f314933b885783add83fe4d. You can [customize](https://app.ellipsis.dev/HDFGroup/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->