### PR TITLE
Add missing cleanup dependency to h5repack tests

### DIFF
--- a/tools/test/h5repack/CMakeTests.cmake
+++ b/tools/test/h5repack/CMakeTests.cmake
@@ -528,7 +528,7 @@ macro (ADD_H5_TEST testname)
         DEPENDS H5REPACK-${ctest_testname}-clear-objects
     )
 
-    set (ARG_CLEANUP_DEPENDS "H5REPACK-${ctest_testname}")
+    list (APPEND ARG_CLEANUP_DEPENDS "H5REPACK-${ctest_testname}")
 
     if ("H5REPACK-${ctest_testname}" MATCHES "${HDF5_DISABLE_TESTS_REGEX}")
       set_tests_properties (H5REPACK-${ctest_testname} PROPERTIES DISABLED true)
@@ -548,7 +548,7 @@ macro (ADD_H5_TEST testname)
         set_tests_properties (H5REPACK-${ctest_testname}_DFF PROPERTIES DISABLED true)
       endif ()
 
-      set (ARG_CLEANUP_DEPENDS "H5REPACK-${ctest_testname}_DFF")
+      list (APPEND ARG_CLEANUP_DEPENDS "H5REPACK-${ctest_testname}_DFF")
     elseif (${ARG_COMPARE_LOCAL} AND ${ARG_FULL_DIFF})
       # h5diff via runTest
       add_test (

--- a/tools/test/h5repack/CMakeTests.cmake
+++ b/tools/test/h5repack/CMakeTests.cmake
@@ -527,6 +527,9 @@ macro (ADD_H5_TEST testname)
     set_tests_properties (H5REPACK-${ctest_testname} PROPERTIES
         DEPENDS H5REPACK-${ctest_testname}-clear-objects
     )
+
+    set (ARG_CLEANUP_DEPENDS "H5REPACK-${ctest_testname}")
+
     if ("H5REPACK-${ctest_testname}" MATCHES "${HDF5_DISABLE_TESTS_REGEX}")
       set_tests_properties (H5REPACK-${ctest_testname} PROPERTIES DISABLED true)
     endif ()


### PR DESCRIPTION
During merging of the h5repack test macros, the cleanup test was erroneously not marked as depending on the main repack test. This seems to cause failure during parallel testing, since the cleanup can run before the main test and fail to find the output file.

This should resolve [this failure](https://github.com/HDFGroup/hdf5/actions/runs/18009896731/job/51239403410).
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Adds missing dependency in `CMakeTests.cmake` to ensure cleanup tests run after the main repack test, preventing parallel testing failures.
> 
>   - **Behavior**:
>     - Adds missing dependency in `CMakeTests.cmake` for cleanup tests to depend on the main repack test, preventing premature execution during parallel testing.
>   - **Misc**:
>     - Resolves parallel testing failure issue linked in the PR description.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=HDFGroup%2Fhdf5&utm_source=github&utm_medium=referral)<sup> for e93bc4ebd39e411e142bdf4964dc25a195ba1e26. You can [customize](https://app.ellipsis.dev/HDFGroup/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->