### PR TITLE
ci: free space for nvhpc.yml

### DIFF
--- a/.github/workflows/nvhpc.yml
+++ b/.github/workflows/nvhpc.yml
@@ -25,6 +25,16 @@ jobs:
       - name: Get Sources
         uses: actions/checkout@v4.2.1
 
+      - name: Free Disk Space (Ubuntu)
+        uses: jlumbroso/free-disk-space@main
+        with:
+          android: true
+          dotnet: true
+          haskell: true
+          large-packages: true
+          tool-cache: false
+          swap-storage: true 
+
       - name: Install Dependencies
         shell: bash
         run: |

--- a/.github/workflows/nvhpc.yml
+++ b/.github/workflows/nvhpc.yml
@@ -26,7 +26,7 @@ jobs:
         uses: actions/checkout@v4.2.1
 
       - name: Free Disk Space (Ubuntu)
-        uses: jlumbroso/free-disk-space@main
+        uses: jlumbroso/free-disk-space@v1.3.0
         with:
           android: true
           dotnet: true


### PR DESCRIPTION
close #5880
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Adds a step to free disk space in `nvhpc.yml` using `jlumbroso/free-disk-space@main`.
> 
>   - **Workflow Changes**:
>     - Adds a step to free disk space in `nvhpc.yml` using `jlumbroso/free-disk-space@main`.
>     - Configures the action to remove Android, .NET, Haskell, large packages, and swap storage.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=HDFGroup%2Fhdf5&utm_source=github&utm_medium=referral)<sup> for c5693e96be54cc5cb7fd881fcf7ec05ee987d4c2. You can [customize](https://app.ellipsis.dev/HDFGroup/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->