### PR TITLE
Add buffer overflow detection

### DIFF
--- a/src/H5Cimage.c
+++ b/src/H5Cimage.c
@@ -1291,7 +1291,7 @@ H5C__decode_cache_image_header(const H5F_t *f, H5C_t *cache_ptr, const uint8_t *
     p = *buf;
 
     /* Ensure buffer has enough data for signature comparison */
-    if (H5_IS_BUFFER_OVERFLOW(p, H5C__MDCI_BLOCK_SIGNATURE_LEN, *buf + buf_size - 1))
+    if (H5_IS_BUFFER_OVERFLOW(p, H5C__MDCI_BLOCK_SIGNATURE_LEN, p_end))
         HGOTO_ERROR(H5E_CACHE, H5E_OVERFLOW, FAIL, "Insufficient buffer size for signature");
 
     /* Check signature */

--- a/src/H5Cimage.c
+++ b/src/H5Cimage.c
@@ -1277,6 +1277,7 @@ H5C__decode_cache_image_header(const H5F_t *f, H5C_t *cache_ptr, const uint8_t *
     size_t         actual_header_len;
     size_t         expected_header_len;
     const uint8_t *p;
+    const uint8_t *p_end     = p + buf_size - 1; /* End of the p buffer */
     herr_t         ret_value = SUCCEED; /* Return value */
 
     FUNC_ENTER_PACKAGE
@@ -1299,11 +1300,15 @@ H5C__decode_cache_image_header(const H5F_t *f, H5C_t *cache_ptr, const uint8_t *
     p += H5C__MDCI_BLOCK_SIGNATURE_LEN;
 
     /* Check version */
+    if (H5_IS_BUFFER_OVERFLOW(p, 1, p_end))
+        HGOTO_ERROR(H5E_CACHE, H5E_OVERFLOW, NULL, "ran off end of input buffer while decoding");
     version = *p++;
     if (version != (uint8_t)H5C__MDCI_BLOCK_VERSION_0)
         HGOTO_ERROR(H5E_CACHE, H5E_BADVALUE, FAIL, "Bad metadata cache image version");
 
     /* Decode flags */
+    if (H5_IS_BUFFER_OVERFLOW(p, 1, p_end))
+        HGOTO_ERROR(H5E_CACHE, H5E_OVERFLOW, NULL, "ran off end of input buffer while decoding");
     flags = *p++;
     if (flags & H5C__MDCI_HEADER_HAVE_RESIZE_STATUS)
         have_resize_status = true;
@@ -1311,6 +1316,8 @@ H5C__decode_cache_image_header(const H5F_t *f, H5C_t *cache_ptr, const uint8_t *
         HGOTO_ERROR(H5E_CACHE, H5E_BADVALUE, FAIL, "MDC resize status not yet supported");
 
     /* Read image data length */
+    if (H5_IS_BUFFER_OVERFLOW(p, H5F_sizeof_size(f), p_end))
+        HGOTO_ERROR(H5E_OHDR, H5E_OVERFLOW, NULL, "ran off end of input buffer while decoding");
     H5F_DECODE_LENGTH(f, p, cache_ptr->image_data_len);
 
     /* For now -- will become <= eventually */
@@ -1318,6 +1325,8 @@ H5C__decode_cache_image_header(const H5F_t *f, H5C_t *cache_ptr, const uint8_t *
         HGOTO_ERROR(H5E_CACHE, H5E_BADVALUE, FAIL, "Bad metadata cache image data length");
 
     /* Read num entries */
+    if (H5_IS_BUFFER_OVERFLOW(p, 4, p_end))
+        HGOTO_ERROR(H5E_OHDR, H5E_OVERFLOW, NULL, "ran off end of input buffer while decoding");
     UINT32DECODE(p, cache_ptr->num_entries_in_image);
     if (cache_ptr->num_entries_in_image == 0)
         HGOTO_ERROR(H5E_CACHE, H5E_BADVALUE, FAIL, "Bad metadata cache entry count");
@@ -2393,10 +2402,9 @@ H5C__reconstruct_cache_contents(H5F_t *f, H5C_t *cache_ptr)
 
     /* Decode metadata cache image header */
     p         = (uint8_t *)cache_ptr->image_buffer;
-    image_len = cache_ptr->image_len;
-    if (H5C__decode_cache_image_header(f, cache_ptr, &p, image_len + 1) < 0)
+    if (H5C__decode_cache_image_header(f, cache_ptr, &p, cache_ptr->image_len + 1) < 0)
         HGOTO_ERROR(H5E_CACHE, H5E_CANTDECODE, FAIL, "cache image header decode failed");
-    assert((size_t)(p - (uint8_t *)cache_ptr->image_buffer) < image_len);
+    assert((size_t)(p - (uint8_t *)cache_ptr->image_buffer) < cache_ptr->image_len);
 
     /* The image_data_len and # of entries should be defined now */
     assert(cache_ptr->image_data_len > 0);
@@ -2404,6 +2412,7 @@ H5C__reconstruct_cache_contents(H5F_t *f, H5C_t *cache_ptr)
     assert(cache_ptr->num_entries_in_image > 0);
 
     /* Reconstruct entries in image */
+    image_len = cache_ptr->image_len;
     for (u = 0; u < cache_ptr->num_entries_in_image; u++) {
         /* Create the prefetched entry described by the ith
          * entry in cache_ptr->image_entrise.

--- a/src/H5Cimage.c
+++ b/src/H5Cimage.c
@@ -1277,8 +1277,8 @@ H5C__decode_cache_image_header(const H5F_t *f, H5C_t *cache_ptr, const uint8_t *
     size_t         actual_header_len;
     size_t         expected_header_len;
     const uint8_t *p;
-    const uint8_t *p_end     = p + buf_size - 1; /* End of the p buffer */
-    herr_t         ret_value = SUCCEED;          /* Return value */
+    const uint8_t *p_end     = *buf + buf_size - 1; /* End of the p buffer */
+    herr_t         ret_value = SUCCEED;             /* Return value */
 
     FUNC_ENTER_PACKAGE
 
@@ -1301,14 +1301,14 @@ H5C__decode_cache_image_header(const H5F_t *f, H5C_t *cache_ptr, const uint8_t *
 
     /* Check version */
     if (H5_IS_BUFFER_OVERFLOW(p, 1, p_end))
-        HGOTO_ERROR(H5E_CACHE, H5E_OVERFLOW, NULL, "ran off end of input buffer while decoding");
+        HGOTO_ERROR(H5E_CACHE, H5E_OVERFLOW, FAIL, "ran off end of input buffer while decoding");
     version = *p++;
     if (version != (uint8_t)H5C__MDCI_BLOCK_VERSION_0)
         HGOTO_ERROR(H5E_CACHE, H5E_BADVALUE, FAIL, "Bad metadata cache image version");
 
     /* Decode flags */
     if (H5_IS_BUFFER_OVERFLOW(p, 1, p_end))
-        HGOTO_ERROR(H5E_CACHE, H5E_OVERFLOW, NULL, "ran off end of input buffer while decoding");
+        HGOTO_ERROR(H5E_CACHE, H5E_OVERFLOW, FAIL, "ran off end of input buffer while decoding");
     flags = *p++;
     if (flags & H5C__MDCI_HEADER_HAVE_RESIZE_STATUS)
         have_resize_status = true;
@@ -1317,7 +1317,7 @@ H5C__decode_cache_image_header(const H5F_t *f, H5C_t *cache_ptr, const uint8_t *
 
     /* Read image data length */
     if (H5_IS_BUFFER_OVERFLOW(p, H5F_sizeof_size(f), p_end))
-        HGOTO_ERROR(H5E_OHDR, H5E_OVERFLOW, NULL, "ran off end of input buffer while decoding");
+        HGOTO_ERROR(H5E_CACHE, H5E_OVERFLOW, FAIL, "ran off end of input buffer while decoding");
     H5F_DECODE_LENGTH(f, p, cache_ptr->image_data_len);
 
     /* For now -- will become <= eventually */
@@ -1326,7 +1326,7 @@ H5C__decode_cache_image_header(const H5F_t *f, H5C_t *cache_ptr, const uint8_t *
 
     /* Read num entries */
     if (H5_IS_BUFFER_OVERFLOW(p, 4, p_end))
-        HGOTO_ERROR(H5E_OHDR, H5E_OVERFLOW, NULL, "ran off end of input buffer while decoding");
+        HGOTO_ERROR(H5E_CACHE, H5E_OVERFLOW, FAIL, "ran off end of input buffer while decoding");
     UINT32DECODE(p, cache_ptr->num_entries_in_image);
     if (cache_ptr->num_entries_in_image == 0)
         HGOTO_ERROR(H5E_CACHE, H5E_BADVALUE, FAIL, "Bad metadata cache entry count");

--- a/src/H5Cimage.c
+++ b/src/H5Cimage.c
@@ -1278,7 +1278,7 @@ H5C__decode_cache_image_header(const H5F_t *f, H5C_t *cache_ptr, const uint8_t *
     size_t         expected_header_len;
     const uint8_t *p;
     const uint8_t *p_end     = p + buf_size - 1; /* End of the p buffer */
-    herr_t         ret_value = SUCCEED; /* Return value */
+    herr_t         ret_value = SUCCEED;          /* Return value */
 
     FUNC_ENTER_PACKAGE
 
@@ -2401,7 +2401,7 @@ H5C__reconstruct_cache_contents(H5F_t *f, H5C_t *cache_ptr)
     assert(cache_ptr->image_len > 0);
 
     /* Decode metadata cache image header */
-    p         = (uint8_t *)cache_ptr->image_buffer;
+    p = (uint8_t *)cache_ptr->image_buffer;
     if (H5C__decode_cache_image_header(f, cache_ptr, &p, cache_ptr->image_len + 1) < 0)
         HGOTO_ERROR(H5E_CACHE, H5E_CANTDECODE, FAIL, "cache image header decode failed");
     assert((size_t)(p - (uint8_t *)cache_ptr->image_buffer) < cache_ptr->image_len);


### PR DESCRIPTION
This PR hardens H5C__decode_cache_image_header() by adding buffer overflow checks.  It doesn't specifically address a CVE issue, but simply responds to [this comment](https://github.com/HDFGroup/hdf5/pull/5841#discussion_r2376272759) in PR #5841.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Add buffer overflow checks to `H5C__decode_cache_image_header()` in `H5Cimage.c` for security hardening.
> 
>   - **Security Hardening**:
>     - Add buffer overflow checks in `H5C__decode_cache_image_header()` in `H5Cimage.c`.
>     - Use `H5_IS_BUFFER_OVERFLOW()` to verify buffer space before accessing elements.
>     - Checks added for signature, version, flags, image data length, and number of entries.
>   - **Misc**:
>     - Adjust `H5C__reconstruct_cache_contents()` to use updated buffer handling logic.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=HDFGroup%2Fhdf5&utm_source=github&utm_medium=referral)<sup> for df86e9da4995f987ea47a40091951c5237674e7d. You can [customize](https://app.ellipsis.dev/HDFGroup/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->