### PR TITLE
Restrict fscanf %s in h5import

### DIFF
--- a/tools/src/h5import/h5import.c
+++ b/tools/src/h5import/h5import.c
@@ -586,7 +586,7 @@ readIntegerData(FILE *strm, struct Input *in)
             switch (in->inputClass) {
                 case 0: /* TEXTIN */
                     for (i = 0; i < len; i++, in64++) {
-                        if (fscanf(strm, "%s", buffer) < 1) {
+                        if (fscanf(strm, "%255s", buffer) < 1) {
                             (void)fprintf(rawerrorstream, "%s", err1);
                             return (-1);
                         }
@@ -753,7 +753,7 @@ readUIntegerData(FILE *strm, struct Input *in)
             switch (in->inputClass) {
                 case 6: /* TEXTUIN */
                     for (i = 0; i < len; i++, in64++) {
-                        if (fscanf(strm, "%s", buffer) < 1) {
+                        if (fscanf(strm, "%255s", buffer) < 1) {
                             (void)fprintf(rawerrorstream, "%s", err1);
                             return (-1);
                         }


### PR DESCRIPTION
A couple of places in the h5import.c code use fscanf with %s to read strings into a fixed-size buffer without restricting the number of characters, which could lead to a stack buffer overflow.

This fix restricts the number of characters that can be read to the size of the buffer.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Restrict `fscanf` to read a maximum of 255 characters into `buffer` in `h5import.c` to prevent stack buffer overflow.
> 
>   - **Security Fix**:
>     - Restrict `fscanf` to read a maximum of 255 characters into `buffer` in `readIntegerData()` and `readUIntegerData()` in `h5import.c` to prevent stack buffer overflow.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=HDFGroup%2Fhdf5&utm_source=github&utm_medium=referral)<sup> for 235e40e9f037eb32ef4df8d64c660d3d4b4bb2c7. You can [customize](https://app.ellipsis.dev/HDFGroup/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->