### PR TITLE
Update generated error files

### DIFF
--- a/src/H5Edefin.h
+++ b/src/H5Edefin.h
@@ -49,6 +49,7 @@ hid_t H5E_PLUGIN_g         = H5I_INVALID_HID;      /* Plugin for dynamically loa
 hid_t H5E_REFERENCE_g      = H5I_INVALID_HID;      /* References */
 hid_t H5E_RESOURCE_g       = H5I_INVALID_HID;      /* Resource unavailable */
 hid_t H5E_RS_g             = H5I_INVALID_HID;      /* Reference Counted Strings */
+hid_t H5E_RTREE_g          = H5I_INVALID_HID;      /* R-Tree spatial index */
 hid_t H5E_SLIST_g          = H5I_INVALID_HID;      /* Skip Lists */
 hid_t H5E_SOHM_g           = H5I_INVALID_HID;      /* Shared Object Header Messages */
 hid_t H5E_STORAGE_g        = H5I_INVALID_HID;      /* Data storage */
@@ -59,7 +60,7 @@ hid_t H5E_VFL_g            = H5I_INVALID_HID;      /* Virtual File Layer */
 hid_t H5E_VOL_g            = H5I_INVALID_HID;      /* Virtual Object Layer */
 
 /* Number of major error messages */
-#define H5E_NUM_MAJ_ERRORS 40
+#define H5E_NUM_MAJ_ERRORS 41
 
 /* Minor error IDs */
 

--- a/src/H5Einit.h
+++ b/src/H5Einit.h
@@ -153,6 +153,10 @@ if((H5E_RESOURCE_g = H5I_register(H5I_ERROR_MSG, &H5E_RESOURCE_msg_s, false)) < 
 assert(H5I_INVALID_HID == H5E_RS_g);
 if((H5E_RS_g = H5I_register(H5I_ERROR_MSG, &H5E_RS_msg_s, false)) < 0)
     HGOTO_ERROR(H5E_ERROR, H5E_CANTREGISTER, FAIL, "can't register error message");
+/* H5E_RTREE */
+assert(H5I_INVALID_HID == H5E_RTREE_g);
+if((H5E_RTREE_g = H5I_register(H5I_ERROR_MSG, &H5E_RTREE_msg_s, false)) < 0)
+    HGOTO_ERROR(H5E_ERROR, H5E_CANTREGISTER, FAIL, "can't register error message");
 /* H5E_SLIST */
 assert(H5I_INVALID_HID == H5E_SLIST_g);
 if((H5E_SLIST_g = H5I_register(H5I_ERROR_MSG, &H5E_SLIST_msg_s, false)) < 0)

--- a/src/H5Emajdef.h
+++ b/src/H5Emajdef.h
@@ -53,6 +53,7 @@ static const H5E_msg_t H5E_PLUGIN_msg_s = {false, "Plugin for dynamically loaded
 static const H5E_msg_t H5E_REFERENCE_msg_s = {false, "References", H5E_MAJOR, &H5E_err_cls_s};
 static const H5E_msg_t H5E_RESOURCE_msg_s = {false, "Resource unavailable", H5E_MAJOR, &H5E_err_cls_s};
 static const H5E_msg_t H5E_RS_msg_s = {false, "Reference Counted Strings", H5E_MAJOR, &H5E_err_cls_s};
+static const H5E_msg_t H5E_RTREE_msg_s = {false, "R-Tree spatial index", H5E_MAJOR, &H5E_err_cls_s};
 static const H5E_msg_t H5E_SLIST_msg_s = {false, "Skip Lists", H5E_MAJOR, &H5E_err_cls_s};
 static const H5E_msg_t H5E_SOHM_msg_s = {false, "Shared Object Header Messages", H5E_MAJOR, &H5E_err_cls_s};
 static const H5E_msg_t H5E_STORAGE_msg_s = {false, "Data storage", H5E_MAJOR, &H5E_err_cls_s};

--- a/src/H5Epubgen.h
+++ b/src/H5Epubgen.h
@@ -56,6 +56,7 @@ extern "C" {
 #define H5E_REFERENCE        (H5OPEN H5E_REFERENCE_g)
 #define H5E_RESOURCE         (H5OPEN H5E_RESOURCE_g)
 #define H5E_RS               (H5OPEN H5E_RS_g)
+#define H5E_RTREE            (H5OPEN H5E_RTREE_g)
 #define H5E_SLIST            (H5OPEN H5E_SLIST_g)
 #define H5E_SOHM             (H5OPEN H5E_SOHM_g)
 #define H5E_STORAGE          (H5OPEN H5E_STORAGE_g)
@@ -96,6 +97,7 @@ H5_DLLVAR hid_t H5E_PLUGIN_g;        /* Plugin for dynamically loaded library */
 H5_DLLVAR hid_t H5E_REFERENCE_g;     /* References */
 H5_DLLVAR hid_t H5E_RESOURCE_g;      /* Resource unavailable */
 H5_DLLVAR hid_t H5E_RS_g;            /* Reference Counted Strings */
+H5_DLLVAR hid_t H5E_RTREE_g;         /* R-Tree spatial index */
 H5_DLLVAR hid_t H5E_SLIST_g;         /* Skip Lists */
 H5_DLLVAR hid_t H5E_SOHM_g;          /* Shared Object Header Messages */
 H5_DLLVAR hid_t H5E_STORAGE_g;       /* Data storage */

--- a/src/H5Eterm.h
+++ b/src/H5Eterm.h
@@ -49,6 +49,7 @@
     H5E_REFERENCE_g =
     H5E_RESOURCE_g =
     H5E_RS_g =
+    H5E_RTREE_g =
     H5E_SLIST_g =
     H5E_SOHM_g =
     H5E_STORAGE_g =

--- a/src/H5RT.c
+++ b/src/H5RT.c
@@ -83,7 +83,7 @@ H5RT_leaf_init(H5RT_leaf_t *leaf, int rank, void *record)
 done:
     if (ret_value < 0 && leaf) {
         if (H5RT_leaf_cleanup(leaf) < 0)
-            HDONE_ERROR(H5E_INTERNAL, H5E_CANTRELEASE, FAIL, "failed to clean up leaf on error");
+            HDONE_ERROR(H5E_RTREE, H5E_CANTRELEASE, FAIL, "failed to clean up leaf on error");
     }
 
     FUNC_LEAVE_NOAPI(ret_value)
@@ -196,14 +196,14 @@ H5RT__compute_slabs(size_t node_capacity, size_t leaf_count, size_t *slab_count_
         slab_size_d = ceil((double)leaf_count / (double)node_capacity);
 
         if (slab_size_d > (double)SIZE_MAX)
-            HGOTO_ERROR(H5E_INTERNAL, H5E_OVERFLOW, FAIL, "slab size overflows size_t");
+            HGOTO_ERROR(H5E_RTREE, H5E_OVERFLOW, FAIL, "slab size overflows size_t");
         assert(slab_size_d > 0.0);
         slab_size = (size_t)slab_size_d;
         assert(slab_size > 0);
 
         num_slabs_d = ceil((double)leaf_count / (double)slab_size);
         if (num_slabs_d > (double)SIZE_MAX)
-            HGOTO_ERROR(H5E_INTERNAL, H5E_OVERFLOW, FAIL, "number of slabs overflows size_t");
+            HGOTO_ERROR(H5E_RTREE, H5E_OVERFLOW, FAIL, "number of slabs overflows size_t");
         assert(num_slabs_d > 0.0);
         num_slabs = (size_t)num_slabs_d;
     }
@@ -277,7 +277,7 @@ H5RT__result_set_grow(H5RT_result_set_t *result_set)
 
     /* Overflow check */
     if (new_capacity < result_set->capacity || new_capacity > (SIZE_MAX / sizeof(H5RT_leaf_t *)))
-        HGOTO_ERROR(H5E_INTERNAL, H5E_OVERFLOW, FAIL, "result buffer capacity overflow");
+        HGOTO_ERROR(H5E_RTREE, H5E_OVERFLOW, FAIL, "result buffer capacity overflow");
 
     /* Reallocate the buffer */
     new_results = (H5RT_leaf_t **)realloc(result_set->results, new_capacity * sizeof(H5RT_leaf_t *));
@@ -313,7 +313,7 @@ H5RT__result_set_add(H5RT_result_set_t *result_set, H5RT_leaf_t *leaf)
     /* Grow buffer if full */
     if (result_set->count >= result_set->capacity) {
         if (H5RT__result_set_grow(result_set) < 0)
-            HGOTO_ERROR(H5E_INTERNAL, H5E_CANTALLOC, FAIL, "failed to grow result buffer");
+            HGOTO_ERROR(H5E_RTREE, H5E_CANTALLOC, FAIL, "failed to grow result buffer");
     }
 
     /* Add the new result */
@@ -427,7 +427,7 @@ H5RT__bulk_load(H5RT_node_t *node, int rank, H5RT_leaf_t *leaves, size_t count, 
              * 'child_leaf_count' */
             if (H5RT__bulk_load(node->children.nodes[i], rank, child_leaf_start, child_leaf_count, sort_dim) <
                 0)
-                HGOTO_ERROR(H5E_INTERNAL, H5E_CANTINIT, FAIL, "failed to fill R-tree");
+                HGOTO_ERROR(H5E_RTREE, H5E_CANTINIT, FAIL, "failed to fill R-tree");
 
             /* The next 'child_leaf_count' leaves are now assigned */
             child_leaf_start += child_leaf_count;
@@ -488,7 +488,7 @@ H5RT_create(int rank, H5RT_leaf_t *leaves, size_t count)
 
     /* Populate the r-tree with nodes containing the provided leaves */
     if (H5RT__bulk_load(&rtree->root, rank, rtree->leaves, count, -1) < 0)
-        HGOTO_ERROR(H5E_INTERNAL, H5E_CANTINIT, NULL, "failed to fill R-tree");
+        HGOTO_ERROR(H5E_RTREE, H5E_CANTINIT, NULL, "failed to fill R-tree");
 
     ret_value = rtree;
 
@@ -540,7 +540,7 @@ H5RT__search_recurse(H5RT_node_t *node, int rank, hsize_t min[], hsize_t max[], 
             if (H5RT__leaves_intersect(rank, min, max, curr_min, curr_max)) {
                 /* We found an intersecting leaf, add it to the result set */
                 if (H5RT__result_set_add(result_set, curr_leaf) < 0)
-                    HGOTO_ERROR(H5E_INTERNAL, H5E_CANTALLOC, FAIL, "failed to add result to result set");
+                    HGOTO_ERROR(H5E_RTREE, H5E_CANTALLOC, FAIL, "failed to add result to result set");
             }
         }
         else {
@@ -553,7 +553,7 @@ H5RT__search_recurse(H5RT_node_t *node, int rank, hsize_t min[], hsize_t max[], 
             if (H5RT__leaves_intersect(rank, min, max, curr_min, curr_max)) {
                 /* We found an intersecting internal node, recurse into it */
                 if (H5RT__search_recurse(curr_node, rank, min, max, result_set) < 0)
-                    HGOTO_ERROR(H5E_INTERNAL, H5E_CANTGET, FAIL, "recursive search failed");
+                    HGOTO_ERROR(H5E_RTREE, H5E_CANTGET, FAIL, "recursive search failed");
             }
         }
 
@@ -597,11 +597,11 @@ H5RT_search(H5RT_t *rtree, hsize_t min[], hsize_t max[], H5RT_result_set_t **res
         HGOTO_ERROR(H5E_RESOURCE, H5E_CANTALLOC, FAIL, "failed to allocate result set");
 
     if (H5RT__result_set_init(result_set) < 0)
-        HGOTO_ERROR(H5E_INTERNAL, H5E_CANTINIT, FAIL, "failed to initialize result buffer");
+        HGOTO_ERROR(H5E_RTREE, H5E_CANTINIT, FAIL, "failed to initialize result buffer");
 
     /* Perform the actual search */
     if (H5RT__search_recurse(&rtree->root, rtree->rank, min, max, result_set) < 0)
-        HGOTO_ERROR(H5E_INTERNAL, H5E_CANTGET, FAIL, "search failed");
+        HGOTO_ERROR(H5E_RTREE, H5E_CANTGET, FAIL, "search failed");
 
     /* Don't cleanup result set on success - caller owns it now */
     *results_out = result_set;
@@ -610,7 +610,7 @@ done:
     if (ret_value < 0) {
         /* Clean up buffer on failure */
         if (H5RT_free_results(result_set) < 0)
-            HDONE_ERROR(H5E_INTERNAL, H5E_CANTFREE, FAIL, "unable to free result set on error");
+            HDONE_ERROR(H5E_RTREE, H5E_CANTFREE, FAIL, "unable to free result set on error");
         *results_out = NULL;
     }
     FUNC_LEAVE_NOAPI(ret_value)
@@ -695,7 +695,7 @@ H5RT__node_copy(H5RT_node_t *dest_node, const H5RT_node_t *src_node, const H5RT_
             /* Recursively copy the child */
             if (H5RT__node_copy(dest_node->children.nodes[i], src_node->children.nodes[i], old_leaves_base,
                                 new_leaves_base) < 0)
-                HGOTO_ERROR(H5E_INTERNAL, H5E_CANTCOPY, FAIL, "failed to copy child node");
+                HGOTO_ERROR(H5E_RTREE, H5E_CANTCOPY, FAIL, "failed to copy child node");
         }
     }
 
@@ -846,7 +846,7 @@ H5RT_copy(const H5RT_t *rtree)
 
     /* Deep copy the root node structure */
     if (H5RT__node_copy(&new_tree->root, &rtree->root, rtree->leaves, new_leaves) < 0)
-        HGOTO_ERROR(H5E_INTERNAL, H5E_CANTCOPY, NULL, "failed to copy r-tree structure");
+        HGOTO_ERROR(H5E_RTREE, H5E_CANTCOPY, NULL, "failed to copy r-tree structure");
 
     ret_value = new_tree;
 
@@ -854,7 +854,7 @@ done:
     if (!ret_value) {
         if (new_tree) {
             if (H5RT_free(new_tree) < 0)
-                HDONE_ERROR(H5E_INTERNAL, H5E_CANTFREE, NULL, "unable to free partially copied r-tree");
+                HDONE_ERROR(H5E_RTREE, H5E_CANTFREE, NULL, "unable to free partially copied r-tree");
         }
         else if (new_leaves) {
             /* Free copied leaves and their coordinates */


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Add `H5E_RTREE` error type for R-Tree spatial index errors and update related error handling.
> 
>   - **Error Handling**:
>     - Add `H5E_RTREE` for R-Tree spatial index errors in `H5Edefin.h`, `H5Einit.h`, `H5Emajdef.h`, `H5Epubgen.h`, and `H5Eterm.h`.
>     - Update error handling in `H5RT.c` to use `H5E_RTREE` for R-Tree related errors, replacing `H5E_INTERNAL` in functions like `H5RT_leaf_init()`, `H5RT__compute_slabs()`, `H5RT__result_set_grow()`, `H5RT__bulk_load()`, `H5RT_search()`, and `H5RT_copy()`.
>   - **Misc**:
>     - Increment `H5E_NUM_MAJ_ERRORS` from 40 to 41 in `H5Edefin.h`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=HDFGroup%2Fhdf5&utm_source=github&utm_medium=referral)<sup> for 4bd7a1009be11d70fcc1232f11a8194f231a77f0. You can [customize](https://app.ellipsis.dev/HDFGroup/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->