### PR TITLE
Fix qsort_r compatibility for older Linux systems (CentOS-5)

### DIFF
--- a/config/ConfigureChecks.cmake
+++ b/config/ConfigureChecks.cmake
@@ -440,6 +440,11 @@ CHECK_FUNCTION_EXISTS (vasprintf         ${HDF_PREFIX}_HAVE_VASPRINTF)
 CHECK_FUNCTION_EXISTS (waitpid           ${HDF_PREFIX}_HAVE_WAITPID)
 
 #-----------------------------------------------------------------------------
+# Check for qsort_r (not available on older Linux systems like CentOS-5)
+#-----------------------------------------------------------------------------
+CHECK_FUNCTION_EXISTS (qsort_r           ${HDF_PREFIX}_HAVE_QSORT_R)
+
+#-----------------------------------------------------------------------------
 # sigsetjmp is special; may actually be a macro
 #-----------------------------------------------------------------------------
 if (NOT ${HDF_PREFIX}_HAVE_SIGSETJMP)

--- a/src/H5private.h
+++ b/src/H5private.h
@@ -770,9 +770,11 @@ H5_DLL void HDqsort_context(void *base, size_t nel, size_t size,
 #define HDunsetenv(S) unsetenv(S)
 #endif
 #ifndef HDqsort_r
-#ifdef H5_HAVE_DARWIN
+#if defined(H5_HAVE_DARWIN) || !defined(H5_HAVE_QSORT_R)
+/* Use HDqsort_context fallback on Darwin (BSD qsort_r) or when qsort_r is not available */
 #define HDqsort_r(B, N, S, C, A) HDqsort_context(B, N, S, C, A)
 #else
+/* Use GNU qsort_r on systems that have it */
 #define HDqsort_r(B, N, S, C, A) qsort_r(B, N, S, C, A)
 #endif
 #endif

--- a/src/H5pubconf.h.in
+++ b/src/H5pubconf.h.in
@@ -347,6 +347,9 @@
 /* Define to 1 if you have the `vasprintf' function. */
 #cmakedefine H5_HAVE_VASPRINTF @H5_HAVE_VASPRINTF@
 
+/* Define to 1 if you have the `qsort_r' function. */
+#cmakedefine H5_HAVE_QSORT_R @H5_HAVE_QSORT_R@
+
 /* Define to 1 if you have the `waitpid' function. */
 #cmakedefine H5_HAVE_WAITPID @H5_HAVE_WAITPID@
 

--- a/src/H5system.c
+++ b/src/H5system.c
@@ -1428,7 +1428,7 @@ H5_strcasestr(const char *haystack, const char *needle)
  * Usage:
  *   HDqsort_context(base, count, elem_size, compare_func, context);
  */
-#if defined(H5_HAVE_WIN32_API) || defined(H5_HAVE_DARWIN) || (defined(__FreeBSD__) && __FreeBSD__ < 14) || \
+#if defined(H5_HAVE_WIN32_API) || defined(H5_HAVE_DARWIN) || (defined(__FreeBSD__) && __FreeBSD__ < 14) ||   \
     !defined(H5_HAVE_QSORT_R)
 /* Need wrapper for Windows, macOS, FreeBSD < 14, and systems without qsort_r */
 typedef struct HDqsort_context_wrapper_t {
@@ -1436,11 +1436,11 @@ typedef struct HDqsort_context_wrapper_t {
     void *gnu_arg;
 } HDqsort_context_wrapper_t;
 
-#if !defined(H5_HAVE_WIN32_API) && !defined(H5_HAVE_DARWIN) && \
+#if !defined(H5_HAVE_WIN32_API) && !defined(H5_HAVE_DARWIN) &&                                               \
     !(defined(__FreeBSD__) && __FreeBSD__ < 14) && !defined(H5_HAVE_QSORT_R)
 /* Thread-local storage for context on systems without any reentrant qsort */
 #ifdef H5_HAVE_THREADSAFE
-static H5TS_key_t qsort_context_key;
+static H5TS_key_t  qsort_context_key;
 static H5TS_once_t qsort_context_once = H5TS_ONCE_INITIALIZER;
 
 static void
@@ -1457,7 +1457,8 @@ static int
 HDqsort_context_wrapper_func_noarg(const void *a, const void *b)
 {
 #ifdef H5_HAVE_THREADSAFE
-    HDqsort_context_wrapper_t *w = (HDqsort_context_wrapper_t *)H5TS_get_thread_local_value(qsort_context_key);
+    HDqsort_context_wrapper_t *w =
+        (HDqsort_context_wrapper_t *)H5TS_get_thread_local_value(qsort_context_key);
 #else
     HDqsort_context_wrapper_t *w = qsort_context_static;
 #endif

--- a/src/H5system.c
+++ b/src/H5system.c
@@ -1423,23 +1423,55 @@ H5_strcasestr(const char *haystack, const char *needle)
  * The macro handles platform differences internally, allowing the same
  * comparator signature to work on Windows (qsort_s), macOS (BSD qsort_r),
  * FreeBSD (use BSD qsort_r < 14.0, but GNU qsort_r >= 14.0), and Linux (GNU qsort_r).
+ * For older systems without any reentrant qsort, a thread-local fallback is used.
  *
  * Usage:
  *   HDqsort_context(base, count, elem_size, compare_func, context);
  */
-#if defined(H5_HAVE_WIN32_API) || defined(H5_HAVE_DARWIN) || (defined(__FreeBSD__) && __FreeBSD__ < 14)
-/* Need wrapper for Windows, macOS, and FreeBSD < 14 which expect context-first comparators */
+#if defined(H5_HAVE_WIN32_API) || defined(H5_HAVE_DARWIN) || (defined(__FreeBSD__) && __FreeBSD__ < 14) || \
+    !defined(H5_HAVE_QSORT_R)
+/* Need wrapper for Windows, macOS, FreeBSD < 14, and systems without qsort_r */
 typedef struct HDqsort_context_wrapper_t {
     int (*gnu_compar)(const void *, const void *, void *);
     void *gnu_arg;
 } HDqsort_context_wrapper_t;
 
+#if !defined(H5_HAVE_WIN32_API) && !defined(H5_HAVE_DARWIN) && \
+    !(defined(__FreeBSD__) && __FreeBSD__ < 14) && !defined(H5_HAVE_QSORT_R)
+/* Thread-local storage for context on systems without any reentrant qsort */
+#ifdef H5_HAVE_THREADSAFE
+static H5TS_key_t qsort_context_key;
+static H5TS_once_t qsort_context_once = H5TS_ONCE_INITIALIZER;
+
+static void
+HDqsort_context_key_init(void)
+{
+    H5TS_key_create(&qsort_context_key, NULL);
+}
+#else
+/* Non-threaded fallback - use static variable */
+static HDqsort_context_wrapper_t *qsort_context_static = NULL;
+#endif
+
+static int
+HDqsort_context_wrapper_func_noarg(const void *a, const void *b)
+{
+#ifdef H5_HAVE_THREADSAFE
+    HDqsort_context_wrapper_t *w = (HDqsort_context_wrapper_t *)H5TS_get_thread_local_value(qsort_context_key);
+#else
+    HDqsort_context_wrapper_t *w = qsort_context_static;
+#endif
+    return w->gnu_compar(a, b, w->gnu_arg);
+}
+#else
+/* Wrapper for platforms with qsort_s or BSD qsort_r */
 static int
 HDqsort_context_wrapper_func(void *wrapper_arg, const void *a, const void *b)
 {
     HDqsort_context_wrapper_t *w = (HDqsort_context_wrapper_t *)wrapper_arg;
     return w->gnu_compar(a, b, w->gnu_arg);
 }
+#endif
 
 void
 HDqsort_context(void *base, size_t nel, size_t size, int (*compar)(const void *, const void *, void *),
@@ -1453,6 +1485,20 @@ HDqsort_context(void *base, size_t nel, size_t size, int (*compar)(const void *,
 #elif defined(H5_HAVE_DARWIN) || (defined(__FreeBSD__) && __FreeBSD__ < 14)
     /* Old BSD-style: context parameter comes before comparator function */
     qsort_r(base, nel, size, &wrapper, HDqsort_context_wrapper_func);
+#elif !defined(H5_HAVE_QSORT_R)
+    /* Fallback for systems without any reentrant qsort (e.g., CentOS-5) */
+#ifdef H5_HAVE_THREADSAFE
+    H5TS_once(&qsort_context_once, HDqsort_context_key_init);
+    H5TS_set_thread_local_value(qsort_context_key, &wrapper);
+#else
+    qsort_context_static = &wrapper;
+#endif
+    qsort(base, nel, size, HDqsort_context_wrapper_func_noarg);
+#ifdef H5_HAVE_THREADSAFE
+    H5TS_set_thread_local_value(qsort_context_key, NULL);
+#else
+    qsort_context_static = NULL;
+#endif
 #endif
 }
 #endif


### PR DESCRIPTION
## Summary

Fixes compilation errors on older Linux systems (e.g., CentOS-5) that don't have `qsort_r` by adding a configure-time check and fallback implementation.

## Problem

Building HDF5 fails on CentOS-5 and other systems with glibc < 2.8 with undefined reference errors:
```
../bin/libhdf5.a(H5RT.c.o): In function `H5RT__bulk_load':
H5RT.c:(.text+0xc48): undefined reference to `qsort_r'
H5RT.c:(.text+0x1258): undefined reference to `qsort_r'
../bin/libhdf5.a(H5RT.c.o): In function `H5RT_create':
H5RT.c:(.text+0x1af2): undefined reference to `qsort_r'
collect2: error: ld returned 1 exit status
```

The `qsort_r` function:
- Was introduced in glibc 2.8 (2008)
- Is not part of POSIX
- Has different signatures across BSD and GNU systems

## Solution

This PR adds:
1. **Configure-time check** for `qsort_r` availability in `ConfigureChecks.cmake`
2. **Conditional macro** in `H5private.h` that uses `HDqsort_context` fallback when `qsort_r` is not available
3. **Fallback implementation** in `H5system.c` that uses regular `qsort` with thread-local storage (or static variable for non-threaded builds) to pass context

## Changes

- `config/ConfigureChecks.cmake`: Add `CHECK_FUNCTION_EXISTS(qsort_r)` check
- `src/H5pubconf.h.in`: Add `H5_HAVE_QSORT_R` configuration define
- `src/H5private.h`: Update `HDqsort_r` macro to check for `qsort_r` availability
- `src/H5system.c`: Extend `HDqsort_context` to handle systems without `qsort_r`

## Testing

The fix maintains existing optimized code paths for:
- Windows (`qsort_s`)
- macOS/Darwin (BSD `qsort_r`)
- FreeBSD < 14 (BSD `qsort_r`)
- Modern Linux (GNU `qsort_r`)

And adds a new fallback path for older systems without any reentrant qsort variant.

## Related Issue

Fixes #5896

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Fixes `qsort_r` compatibility on older Linux systems by adding a configure-time check and fallback implementation using `HDqsort_context`.
> 
>   - **Behavior**:
>     - Adds configure-time check for `qsort_r` in `ConfigureChecks.cmake`.
>     - Uses `HDqsort_context` as a fallback in `H5private.h` and `H5system.c` when `qsort_r` is unavailable.
>   - **Implementation**:
>     - `ConfigureChecks.cmake`: Adds `CHECK_FUNCTION_EXISTS(qsort_r)`.
>     - `H5private.h`: Updates `HDqsort_r` macro to use `HDqsort_context` if `qsort_r` is not available.
>     - `H5system.c`: Implements `HDqsort_context` to handle sorting with context on systems without `qsort_r`.
>   - **Testing**:
>     - Maintains existing code paths for systems with `qsort_r` and adds fallback for older systems.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=HDFGroup%2Fhdf5&utm_source=github&utm_medium=referral)<sup> for ad5dde940c2ed36be2cdf975e723c00a2201c665. You can [customize](https://app.ellipsis.dev/HDFGroup/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->