### PR TITLE
Update bin/h5vers to omit any subversion in the "Executive Summary" line

### DIFF
--- a/bin/h5vers
+++ b/bin/h5vers
@@ -321,7 +321,7 @@ if ($CHANGELOG) {
 
   for (my $i = 0; $i < $#contents; ++$i) {
     if ($contents[$i] =~ /^# 🔆 Executive Summary: HDF5 Version/) {
-      $contents[$i] = sprintf("# 🔆 Executive Summary: HDF5 Version %d.%d.%d%s\n",
+      $contents[$i] = sprintf("# 🔆 Executive Summary: HDF5 Version %d.%d.%d\n", @newver[0,1,2]);
                               @newver[0,1,2]);
       last;
     }

--- a/bin/h5vers
+++ b/bin/h5vers
@@ -322,8 +322,7 @@ if ($CHANGELOG) {
   for (my $i = 0; $i < $#contents; ++$i) {
     if ($contents[$i] =~ /^# 🔆 Executive Summary: HDF5 Version/) {
       $contents[$i] = sprintf("# 🔆 Executive Summary: HDF5 Version %d.%d.%d%s\n",
-                              @newver[0,1,2],
-                              $newver[3] eq "" ? "" : "-".$newver[3]);
+                              @newver[0,1,2]);
       last;
     }
   }

--- a/release_docs/CHANGELOG.md
+++ b/release_docs/CHANGELOG.md
@@ -21,7 +21,7 @@ For releases prior to version 2.0.0, please see the release.txt file and for mor
 * [Platforms Tested](CHANGELOG.md#%EF%B8%8F-platforms-tested)
 * [Known Problems](CHANGELOG.md#-known-problems)
 
-# 🔆 Executive Summary: HDF5 Version 2.0.0-3
+# 🔆 Executive Summary: HDF5 Version 2.0.0
 
 ## Performance Enhancements:
 


### PR DESCRIPTION
Omit the subversion part of the HDF5 version in CHANGELOG.md to avoid confusion in the snapshot summary in the github.com HDF5 Releases page.  The "Executive Summary" line with the HDF5 Version is the second line in the snapshot summary.  It previously displayed the HDF5 version of the last snapshot release, but was updated by subsequent daily builds with the subversion for the upcoming next snapshot release, which didn't match the paths in the snapshot tar.gz and zip files as reported in issue #5889.  With this change the conflicting sub-release version will not be displayed in the snapshot summary.

Addresses issue #5889.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Update `bin/h5vers` to omit subversion in "Executive Summary" line of `CHANGELOG.md` to prevent confusion on GitHub HDF5 Releases page.
> 
>   - **Behavior**:
>     - Update `bin/h5vers` to omit subversion in "Executive Summary" line of `CHANGELOG.md`.
>     - Prevents confusion on GitHub HDF5 Releases page by aligning version display with snapshot tar.gz and zip files.
>   - **Files**:
>     - Modify `bin/h5vers` to change version string format.
>     - Update `CHANGELOG.md` to remove subversion from version line.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=HDFGroup%2Fhdf5&utm_source=github&utm_medium=referral)<sup> for 5e24d317b4e352af8e28f15cab7752f991530c9b. You can [customize](https://app.ellipsis.dev/HDFGroup/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->