### PR TITLE
Delete leftover line from bin/h5vers.

### DIFF
--- a/bin/h5vers
+++ b/bin/h5vers
@@ -322,7 +322,6 @@ if ($CHANGELOG) {
   for (my $i = 0; $i < $#contents; ++$i) {
     if ($contents[$i] =~ /^# 🔆 Executive Summary: HDF5 Version/) {
       $contents[$i] = sprintf("# 🔆 Executive Summary: HDF5 Version %d.%d.%d\n", @newver[0,1,2]);
-                              @newver[0,1,2]);
       last;
     }
   }


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Remove redundant line from `bin/h5vers` script, which was a leftover and had no effect on functionality.
> 
>   - **Code Cleanup**:
>     - Remove redundant line `@newver[0,1,2]);` from `bin/h5vers` script, which was a leftover and had no effect on functionality.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=HDFGroup%2Fhdf5&utm_source=github&utm_medium=referral)<sup> for fec54087e8cca353d15db53e3905afab4ff0554d. You can [customize](https://app.ellipsis.dev/HDFGroup/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->