### PR TITLE
Disable szip/deflate tests when test files can't be generated

### DIFF
--- a/tools/test/h5dump/CMakeTests.cmake
+++ b/tools/test/h5dump/CMakeTests.cmake
@@ -1211,10 +1211,23 @@ ADD_H5_TEST (texceedsubblock RESULT_CODE 1 H5ERRREF "exceed dataset dims" --enab
 
 # tests for filters
 # SZIP
-ADD_H5_TEST (tszip RESULT_CODE 0 APPLY_FILTERS 2 --enable-error-stack -H -p -d szip TARGET_FILE tfilters.h5)
+# For VOL connectors, test files are generated during testing, which requires the filter itself to be available.
+if (HDF5_ENABLE_SZIP_SUPPORT)
+  set (SZIP_NATIVE_ONLY "")
+else ()
+  set (SZIP_NATIVE_ONLY "NATIVE_ONLY")
+endif ()
+
+ADD_H5_TEST (tszip RESULT_CODE 0 APPLY_FILTERS 2 --enable-error-stack -H -p -d szip TARGET_FILE tfilters.h5 ${SZIP_NATIVE_ONLY})
 
 # deflate
-ADD_H5_TEST (tdeflate RESULT_CODE 0 APPLY_FILTERS 2 --enable-error-stack -H -p -d deflate TARGET_FILE tfilters.h5)
+# For VOL connectors, test files are generated during testing, which requires the filter itself to be available.
+if (H5_HAVE_FILTER_DEFLATE)
+  set (DEFLATE_NATIVE_ONLY "")
+else ()
+  set (DEFLATE_NATIVE_ONLY "NATIVE_ONLY")
+endif ()
+ADD_H5_TEST (tdeflate RESULT_CODE 0 APPLY_FILTERS 2 --enable-error-stack -H -p -d deflate TARGET_FILE tfilters.h5 ${DEFLATE_NATIVE_ONLY})
 
 # shuffle
 ADD_H5_TEST (tshuffle RESULT_CODE 0 --enable-error-stack -H -p -d shuffle TARGET_FILE tfilters.h5)
@@ -1229,7 +1242,12 @@ ADD_H5_TEST (tnbit RESULT_CODE 0 APPLY_FILTERS 1 --enable-error-stack -H -p -d n
 ADD_H5_TEST (tscaleoffset RESULT_CODE 0 APPLY_FILTERS 4 --enable-error-stack -H -p -d scaleoffset  TARGET_FILE tfilters.h5)
 
 # all
-ADD_H5_TEST (tallfilters RESULT_CODE 0 APPLY_FILTERS 1 --enable-error-stack -H -p -d all  TARGET_FILE tfilters.h5 APPLY_FILTERS 1)
+if (HDF5_ENABLE_SZIP_SUPPORT AND H5_HAVE_FILTER_DEFLATE)
+  set (ALL_NATIVE_ONLY "")
+else ()
+  set (ALL_NATIVE_ONLY "NATIVE_ONLY")
+endif ()
+ADD_H5_TEST (tallfilters RESULT_CODE 0 APPLY_FILTERS 1 --enable-error-stack -H -p -d all  TARGET_FILE tfilters.h5 APPLY_FILTERS 1 ${ALL_NATIVE_ONLY})
 
 # user defined
 ADD_H5_TEST (tuserfilter RESULT_CODE 0 --enable-error-stack -H  -p -d myfilter  TARGET_FILE tfilters.h5)


### PR DESCRIPTION
This should fix the CI test failures with the external passthrough VOL.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Disable `tszip` and `tdeflate` tests in `CMakeTests.cmake` when SZIP or deflate filters are unavailable to fix CI test failures.
> 
>   - **Behavior**:
>     - Disable `tszip` and `tdeflate` tests in `CMakeTests.cmake` if SZIP or deflate filters are unavailable, respectively.
>     - Add `NATIVE_ONLY` flag to `tszip`, `tdeflate`, and `tallfilters` tests when filters are not available.
>   - **Conditions**:
>     - Check `HDF5_ENABLE_SZIP_SUPPORT` for SZIP filter availability.
>     - Check `H5_HAVE_FILTER_DEFLATE` for deflate filter availability.
>   - **Misc**:
>     - Fix CI test failures related to external passthrough VOL by ensuring tests only run when filters are available.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=HDFGroup%2Fhdf5&utm_source=github&utm_medium=referral)<sup> for ab914d259cd28c59349fd9a17f2ab4ab513c7249. You can [customize](https://app.ellipsis.dev/HDFGroup/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->