### PR TITLE
Fix Fortran compilation - add missing copy of the h5vfd.mod at install

### DIFF
--- a/fortran/src/CMakeLists.txt
+++ b/fortran/src/CMakeLists.txt
@@ -500,6 +500,7 @@ set (mod_export_files
     h5r.mod
     h5s.mod
     h5t.mod
+    h5vfd.mod
     h5vl.mod
     h5z.mod
     h5_gen.mod


### PR DESCRIPTION
Fortran compilation fails due to the fact that h5vfd.mod is not copied at install stage, as reported in the issue https://github.com/HDFGroup/hdf5/issues/5908. This is a trivial fix that updates mod_export_files with the missing module name.
<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Fixes Fortran compilation by adding `h5vfd.mod` to `mod_export_files` in `fortran/src/CMakeLists.txt`.
> 
>   - **Behavior**:
>     - Fixes Fortran compilation by adding `h5vfd.mod` to `mod_export_files` in `fortran/src/CMakeLists.txt`.
>     - Ensures `h5vfd.mod` is copied during the install stage, resolving issue #5908.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=HDFGroup%2Fhdf5&utm_source=github&utm_medium=referral)<sup> for ed4751e890942e24e85b2a5659961b4ee5ae9e42. You can [customize](https://app.ellipsis.dev/HDFGroup/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->