### PR TITLE
Fixing CVE-2025-44905

### DIFF
--- a/src/H5Zscaleoffset.c
+++ b/src/H5Zscaleoffset.c
@@ -1225,7 +1225,7 @@ H5Z__filter_scaleoffset(unsigned flags, size_t cd_nelmts, const unsigned cd_valu
                                                                                : ((unsigned char *)*buf)[4];
         minval      = 0;
         if (H5_IS_BUFFER_OVERFLOW((unsigned char *)*buf, 5 + minval_size,
-                                                        (unsigned char *)*buf + *buf_size - 1))
+                                  (unsigned char *)*buf + *buf_size - 1))
             HGOTO_ERROR(H5E_ARGS, H5E_BADVALUE, 0, "buffer too short");
         for (i = 0; i < minval_size; i++) {
             minval_mask = ((unsigned char *)*buf)[5 + i];

--- a/src/H5Zscaleoffset.c
+++ b/src/H5Zscaleoffset.c
@@ -1206,7 +1206,7 @@ H5Z__filter_scaleoffset(unsigned flags, size_t cd_nelmts, const unsigned cd_valu
         unsigned           minval_size  = 0;
 
         minbits = 0;
-        if (*buf_size < 4)
+        if (H5_IS_BUFFER_OVERFLOW(buf, 4, buf + *buf_size - 1))
             HGOTO_ERROR(H5E_ARGS, H5E_BADVALUE, 0, "buffer too short");
 
         for (i = 0; i < 4; i++) {

--- a/src/H5Zscaleoffset.c
+++ b/src/H5Zscaleoffset.c
@@ -1206,6 +1206,9 @@ H5Z__filter_scaleoffset(unsigned flags, size_t cd_nelmts, const unsigned cd_valu
         unsigned           minval_size  = 0;
 
         minbits = 0;
+        if (*buf_size < 4)
+            HGOTO_ERROR(H5E_ARGS, H5E_BADVALUE, 0, "buffer too short");
+
         for (i = 0; i < 4; i++) {
             minbits_mask = ((unsigned char *)*buf)[i];
             minbits_mask <<= i * 8;

--- a/src/H5Zscaleoffset.c
+++ b/src/H5Zscaleoffset.c
@@ -1206,7 +1206,7 @@ H5Z__filter_scaleoffset(unsigned flags, size_t cd_nelmts, const unsigned cd_valu
         unsigned           minval_size  = 0;
 
         minbits = 0;
-        if (H5_IS_BUFFER_OVERFLOW((unsigned char *)*buf, 5, (unsigned char*)*buf + *buf_size - 1))
+        if (H5_IS_BUFFER_OVERFLOW((unsigned char *)*buf, 5, (unsigned char *)*buf + *buf_size - 1))
             HGOTO_ERROR(H5E_ARGS, H5E_BADVALUE, 0, "buffer too short");
 
         for (i = 0; i < 4; i++) {
@@ -1224,7 +1224,8 @@ H5Z__filter_scaleoffset(unsigned flags, size_t cd_nelmts, const unsigned cd_valu
         minval_size = sizeof(unsigned long long) <= ((unsigned char *)*buf)[4] ? sizeof(unsigned long long)
                                                                                : ((unsigned char *)*buf)[4];
         minval      = 0;
-        if (H5_IS_BUFFER_OVERFLOW((unsigned char *)*buf, 5 + minval_size, (unsigned char*)*buf + *buf_size - 1))
+        if (H5_IS_BUFFER_OVERFLOW((unsigned char *)*buf, 5 + minval_size,
+                                                        (unsigned char *)*buf + *buf_size - 1))
             HGOTO_ERROR(H5E_ARGS, H5E_BADVALUE, 0, "buffer too short");
         for (i = 0; i < minval_size; i++) {
             minval_mask = ((unsigned char *)*buf)[5 + i];

--- a/src/H5Zscaleoffset.c
+++ b/src/H5Zscaleoffset.c
@@ -1206,7 +1206,7 @@ H5Z__filter_scaleoffset(unsigned flags, size_t cd_nelmts, const unsigned cd_valu
         unsigned           minval_size  = 0;
 
         minbits = 0;
-        if (H5_IS_BUFFER_OVERFLOW(buf, 4, buf + *buf_size - 1))
+        if (H5_IS_BUFFER_OVERFLOW((unsigned char *)*buf, 5, (unsigned char*)*buf + *buf_size - 1))
             HGOTO_ERROR(H5E_ARGS, H5E_BADVALUE, 0, "buffer too short");
 
         for (i = 0; i < 4; i++) {
@@ -1224,6 +1224,8 @@ H5Z__filter_scaleoffset(unsigned flags, size_t cd_nelmts, const unsigned cd_valu
         minval_size = sizeof(unsigned long long) <= ((unsigned char *)*buf)[4] ? sizeof(unsigned long long)
                                                                                : ((unsigned char *)*buf)[4];
         minval      = 0;
+        if (H5_IS_BUFFER_OVERFLOW((unsigned char *)*buf, 5 + minval_size, (unsigned char*)*buf + *buf_size - 1))
+            HGOTO_ERROR(H5E_ARGS, H5E_BADVALUE, 0, "buffer too short");
         for (i = 0; i < minval_size; i++) {
             minval_mask = ((unsigned char *)*buf)[5 + i];
             minval_mask <<= i * 8;


### PR DESCRIPTION
A malformed HDF5 can cause reading beyond a heap allocation.
Fixing [CVE-2025-44905](https://nvd.nist.gov/vuln/detail/CVE-2025-44905).  

A [**POC**](https://github.com/madao123123/crash_report/blob/main/hdf5_poc/hdf5_poc5.md) of this issue is available.

**POC result:**
*Environment:* Ubuntu 24.04.3 LTS
*Compiler:* Ubuntu clang version 18.1.3 (1ubuntu1)
*Version*: Latest commit [61cfe6c](https://github.com/HDFGroup/hdf5/commit/61cfe6ca933d4bb188ec3d9d1854e23ee358698b)
```
DATASET "Scale_offset_int_data_le" {
      DATATYPE  H5T_STD_I32LE
      DATASPACE  SIMPLE { ( 7, 6 ) / ( 7, 6 ) }
=================================================================
==50973==ERROR: AddressSanitizer: heap-buffer-overflow on address 0x5020000092f1 at pc 0x791c515c1cf4 bp 0x7ffc785e0aa0 sp 0x7ffc785e0a98
READ of size 1 at 0x5020000092f1 thread T0
    #0 0x791c515c1cf3 in H5Z__filter_scaleoffset /home/christian/code/hdf5/src/H5Zscaleoffset.c:1210:28
    #1 0x791c515b5bc4 in H5Z_pipeline /home/christian/code/hdf5/src/H5Z.c:1456:42
    #2 0x791c50c5f508 in H5D__chunk_lock /home/christian/code/hdf5/src/H5Dchunk.c:4553:25
    #3 0x791c50c4b653 in H5D__chunk_read /home/christian/code/hdf5/src/H5Dchunk.c:2925:42
    #4 0x791c50cbf2e3 in H5D__read /home/christian/code/hdf5/src/H5Dio.c:398:17
    #5 0x791c5158beb5 in H5VL__native_dataset_read /home/christian/code/hdf5/src/H5VLnative_dataset.c:373:9
    #6 0x791c51548372 in H5VL__dataset_read /home/christian/code/hdf5/src/H5VLcallback.c:2160:25
    #7 0x791c51547d45 in H5VL_dataset_read /home/christian/code/hdf5/src/H5VLcallback.c:2207:9
    #8 0x791c50c1f923 in H5D__read_api_common /home/christian/code/hdf5/src/H5D.c:997:9
    #9 0x791c50c1ed3d in H5Dread /home/christian/code/hdf5/src/H5D.c:1049:9
    #10 0x791c51dc539e in h5tools_dump_simple_dset /home/christian/code/hdf5/tools/lib/h5tools_dump.c:1747:17
    #11 0x791c51dc539e in h5tools_dump_dset /home/christian/code/hdf5/tools/lib/h5tools_dump.c:1948:25
    #12 0x791c51dbadc4 in h5tools_dump_data /home/christian/code/hdf5/tools/lib/h5tools_dump.c:4498:22
    #13 0x56993a7b8993 in dump_dataset /home/christian/code/hdf5/tools/src/h5dump/h5dump_ddl.c:1087:21
    #14 0x56993a7b5ad5 in dump_all_cb /home/christian/code/hdf5/tools/src/h5dump/h5dump_ddl.c:365:21
    #15 0x791c50e9c39f in H5G__iterate_cb /home/christian/code/hdf5/src/H5Gint.c:881:33
    #16 0x791c50eb446c in H5G__node_iterate /home/christian/code/hdf5/src/H5Gnode.c:937:25
    #17 0x791c50b42d01 in H5B__iterate_helper /home/christian/code/hdf5/src/H5B.c:1148:25
    #18 0x791c50b426f8 in H5B_iterate /home/christian/code/hdf5/src/H5B.c:1187:22
    #19 0x791c50ec6f87 in H5G__stab_iterate /home/christian/code/hdf5/src/H5Gstab.c:504:26
    #20 0x791c50ebb85f in H5G__obj_iterate /home/christian/code/hdf5/src/H5Gobj.c:664:26
    #21 0x791c50e9bb50 in H5G_iterate /home/christian/code/hdf5/src/H5Gint.c:936:14
    #22 0x791c50f8e781 in H5L_iterate /home/christian/code/hdf5/src/H5Lint.c:2204:22
    #23 0x791c515998a3 in H5VL__native_link_specific /home/christian/code/hdf5/src/H5VLnative_link.c:364:38
    #24 0x791c515605c8 in H5VL__link_specific /home/christian/code/hdf5/src/H5VLcallback.c:5558:25
    #25 0x791c51560068 in H5VL_link_specific /home/christian/code/hdf5/src/H5VLcallback.c:5595:14
    #26 0x791c50f7b763 in H5L__iterate_api_common /home/christian/code/hdf5/src/H5L.c:1571:22
    #27 0x791c50f7afce in H5Literate2 /home/christian/code/hdf5/src/H5L.c:1606:22
    #28 0x56993a7b7a4e in link_iteration /home/christian/code/hdf5/tools/src/h5dump/h5dump_ddl.c
    #29 0x56993a7b7a4e in dump_group /home/christian/code/hdf5/tools/src/h5dump/h5dump_ddl.c:914:13
    #30 0x56993a7af267 in main /home/christian/code/hdf5/tools/src/h5dump/h5dump.c:1633:17
    #31 0x791c5042a1c9 in __libc_start_call_main csu/../sysdeps/nptl/libc_start_call_main.h:58:16
    #32 0x791c5042a28a in __libc_start_main csu/../csu/libc-start.c:360:3
    #33 0x56993a6d3c94 in _start (/home/christian/code/hdf5/build/bin/h5dump+0x3ac94) (BuildId: 249efba5a748aa156a468bc585fe93aa423fccac)

0x5020000092f1 is located 0 bytes after 1-byte region [0x5020000092f0,0x5020000092f1)
allocated by thread T0 here:
    #0 0x56993a76eae3 in malloc (/home/christian/code/hdf5/build/bin/h5dump+0xd5ae3) (BuildId: 249efba5a748aa156a468bc585fe93aa423fccac)
    #1 0x791c50c5f407 in H5D__chunk_lock /home/christian/code/hdf5/src/H5Dchunk.c:4535:38
    #2 0x791c50c4b653 in H5D__chunk_read /home/christian/code/hdf5/src/H5Dchunk.c:2925:42
    #3 0x791c50cbf2e3 in H5D__read /home/christian/code/hdf5/src/H5Dio.c:398:17
    #4 0x791c5158beb5 in H5VL__native_dataset_read /home/christian/code/hdf5/src/H5VLnative_dataset.c:373:9
    #5 0x791c51548372 in H5VL__dataset_read /home/christian/code/hdf5/src/H5VLcallback.c:2160:25
    #6 0x791c51547d45 in H5VL_dataset_read /home/christian/code/hdf5/src/H5VLcallback.c:2207:9
    #7 0x791c50c1f923 in H5D__read_api_common /home/christian/code/hdf5/src/H5D.c:997:9
    #8 0x791c50c1ed3d in H5Dread /home/christian/code/hdf5/src/H5D.c:1049:9
    #9 0x791c51dc539e in h5tools_dump_simple_dset /home/christian/code/hdf5/tools/lib/h5tools_dump.c:1747:17
    #10 0x791c51dc539e in h5tools_dump_dset /home/christian/code/hdf5/tools/lib/h5tools_dump.c:1948:25
    #11 0x791c51dbadc4 in h5tools_dump_data /home/christian/code/hdf5/tools/lib/h5tools_dump.c:4498:22
    #12 0x56993a7b8993 in dump_dataset /home/christian/code/hdf5/tools/src/h5dump/h5dump_ddl.c:1087:21
    #13 0x56993a7b5ad5 in dump_all_cb /home/christian/code/hdf5/tools/src/h5dump/h5dump_ddl.c:365:21
    #14 0x791c50e9c39f in H5G__iterate_cb /home/christian/code/hdf5/src/H5Gint.c:881:33
    #15 0x791c50eb446c in H5G__node_iterate /home/christian/code/hdf5/src/H5Gnode.c:937:25
    #16 0x791c50b42d01 in H5B__iterate_helper /home/christian/code/hdf5/src/H5B.c:1148:25
    #17 0x791c50b426f8 in H5B_iterate /home/christian/code/hdf5/src/H5B.c:1187:22
    #18 0x791c50ebb85f in H5G__obj_iterate /home/christian/code/hdf5/src/H5Gobj.c:664:26
    #19 0x791c50e9bb50 in H5G_iterate /home/christian/code/hdf5/src/H5Gint.c:936:14
    #20 0x791c50f8e781 in H5L_iterate /home/christian/code/hdf5/src/H5Lint.c:2204:22
    #21 0x791c515998a3 in H5VL__native_link_specific /home/christian/code/hdf5/src/H5VLnative_link.c:364:38
    #22 0x791c515605c8 in H5VL__link_specific /home/christian/code/hdf5/src/H5VLcallback.c:5558:25
    #23 0x791c51560068 in H5VL_link_specific /home/christian/code/hdf5/src/H5VLcallback.c:5595:14

SUMMARY: AddressSanitizer: heap-buffer-overflow /home/christian/code/hdf5/src/H5Zscaleoffset.c:1210:28 in H5Z__filter_scaleoffset
Shadow bytes around the buggy address:
  0x502000009000: fa fa fd fa fa fa fd fa fa fa fd fa fa fa fd fa
  0x502000009080: fa fa fd fa fa fa fd fa fa fa fd fa fa fa fd fa
  0x502000009100: fa fa fd fa fa fa fd fa fa fa fd fa fa fa 00 fa
  0x502000009180: fa fa fd fa fa fa 00 fa fa fa fd fa fa fa 00 fa
  0x502000009200: fa fa fd fa fa fa 00 fa fa fa 04 fa fa fa 04 fa
=>0x502000009280: fa fa 04 fa fa fa fd fa fa fa fd fa fa fa[01]fa
  0x502000009300: fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa
  0x502000009380: fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa
  0x502000009400: fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa
  0x502000009480: fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa
  0x502000009500: fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa
Shadow byte legend (one shadow byte represents 8 application bytes):
  Addressable:           00
  Partially addressable: 01 02 03 04 05 06 07
  Heap left redzone:       fa
  Freed heap region:       fd
  Stack left redzone:      f1
  Stack mid redzone:       f2
  Stack right redzone:     f3
  Stack after return:      f5
  Stack use after scope:   f8
  Global redzone:          f9
  Global init order:       f6
  Poisoned by user:        f7
  Container overflow:      fc
  Array cookie:            ac
  Intra object redzone:    bb
  ASan internal:           fe
  Left alloca redzone:     ca
  Right alloca redzone:    cb
==50973==ABORTING
```
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Adds a buffer size check in `H5Z__filter_scaleoffset` to prevent out-of-bounds reads with malformed HDF5 files.
> 
>   - **Security Fix**:
>     - Adds a check in `H5Z__filter_scaleoffset` to ensure `*buf_size` is at least 4 before processing, preventing out-of-bounds reads with malformed HDF5 files.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=HDFGroup%2Fhdf5&utm_source=github&utm_medium=referral)<sup> for 28ab45329218d9e41bd77929fd3e9cd8a80bd3c7. You can [customize](https://app.ellipsis.dev/HDFGroup/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->