### PR TITLE
Update nvhpc.yml to NVHPC 25.9 and CUDA 13.0

### DIFF
--- a/.github/workflows/nvhpc.yml
+++ b/.github/workflows/nvhpc.yml
@@ -17,9 +17,9 @@ jobs:
     name: "nvhpc ${{ inputs.build_mode }}"
     runs-on: ubuntu-latest
     env:
-      CUDAVERDOT: "12.9"
-      NVERDOT: "25.7"
-      NVERDASH: "25-7"
+      CUDAVERDOT: "13.0"
+      NVERDOT: "25.9"
+      NVERDASH: "25-9"
 
     steps:
       - name: Get Sources
@@ -54,15 +54,15 @@ jobs:
           echo "OMPI_CXX=/opt/nvidia/hpc_sdk/Linux_x86_64/${{ env.NVERDOT }}/compilers/bin/nvc++" >> $GITHUB_ENV
           echo "OMPI_CC=/opt/nvidia/hpc_sdk/Linux_x86_64/${{ env.NVERDOT }}/compilers/bin/nvc" >> $GITHUB_ENV
           echo "OMPI_FC=/opt/nvidia/hpc_sdk/Linux_x86_64/${{ env.NVERDOT }}/compilers/bin/nvfortran" >> $GITHUB_ENV
-          echo "CC=/opt/nvidia/hpc_sdk/Linux_x86_64/${{ env.NVERDOT }}/comm_libs/openmpi4/bin/mpicc" >> $GITHUB_ENV
-          echo "FC=/opt/nvidia/hpc_sdk/Linux_x86_64/${{ env.NVERDOT }}/comm_libs/openmpi4/bin/mpifort" >> $GITHUB_ENV
+          echo "CC=/opt/nvidia/hpc_sdk/Linux_x86_64/${{ env.NVERDOT }}/comm_libs/hpcx/bin/mpicc" >> $GITHUB_ENV
+          echo "FC=/opt/nvidia/hpc_sdk/Linux_x86_64/${{ env.NVERDOT }}/comm_libs/hpcx/bin/mpifort" >> $GITHUB_ENV
           echo "LD_LIBRARY_PATH=/opt/nvidia/hpc_sdk/Linux_x86_64/${{ env.NVERDOT }}/cuda/${{ env.CUDAVERDOT }}/lib64:/opt/nvidia/hpc_sdk/Linux_x86_64/${{ env.NVERDOT }}/compilers/lib" >> $GITHUB_ENV
           echo "DESTDIR=/tmp" >> $GITHUB_ENV
 
       - name: Configure
         shell: bash
         run: |
-          export PATH=/opt/nvidia/hpc_sdk/Linux_x86_64/${{ env.NVERDOT }}/comm_libs/openmpi4/bin:/opt/nvidia/hpc_sdk/Linux_x86_64/${{ env.NVERDOT }}/compilers/bin:$PATH
+          export PATH=/opt/nvidia/hpc_sdk/Linux_x86_64/${{ env.NVERDOT }}/comm_libs/hpcx/bin:/opt/nvidia/hpc_sdk/Linux_x86_64/${{ env.NVERDOT }}/compilers/bin:$PATH
           mkdir "${{ runner.workspace }}/build"
           cd "${{ runner.workspace }}/build"
           cmake -C $GITHUB_WORKSPACE/config/cmake/cacheinit.cmake -G Ninja \

--- a/.github/workflows/nvhpc.yml
+++ b/.github/workflows/nvhpc.yml
@@ -62,7 +62,6 @@ jobs:
       - name: Configure
         shell: bash
         run: |
-          export UCX_WARN_UNUSED_ENV_VARS=n
           export PATH=/opt/nvidia/hpc_sdk/Linux_x86_64/${{ env.NVERDOT }}/comm_libs/hpcx/bin:/opt/nvidia/hpc_sdk/Linux_x86_64/${{ env.NVERDOT }}/compilers/bin:$PATH
           mkdir "${{ runner.workspace }}/build"
           cd "${{ runner.workspace }}/build"
@@ -101,5 +100,6 @@ jobs:
       - name: Run Parallel Tests
         shell: bash
         run: |
+          export UCX_WARN_UNUSED_ENV_VARS=n
           ctest . -R MPI_TEST -E "_by_chunk|_by_pattern" -C ${{ inputs.build_mode }} -V
         working-directory: ${{ runner.workspace }}/build

--- a/.github/workflows/nvhpc.yml
+++ b/.github/workflows/nvhpc.yml
@@ -62,6 +62,7 @@ jobs:
       - name: Configure
         shell: bash
         run: |
+          export UCX_WARN_UNUSED_ENV_VARS=n
           export PATH=/opt/nvidia/hpc_sdk/Linux_x86_64/${{ env.NVERDOT }}/comm_libs/hpcx/bin:/opt/nvidia/hpc_sdk/Linux_x86_64/${{ env.NVERDOT }}/compilers/bin:$PATH
           mkdir "${{ runner.workspace }}/build"
           cd "${{ runner.workspace }}/build"


### PR DESCRIPTION
## Summary
Updates the nvhpc.yml GitHub Action workflow to use NVHPC compiler version 25.9 and CUDA 13.0, and updates the MPI library paths to use hpcx instead of openmpi4.

## Changes
- Updated `CUDAVERDOT` from "12.9" to "13.0"
- Updated `NVERDOT` from "25.7" to "25.9"
- Updated `NVERDASH` from "25-7" to "25-9"
- Updated all MPI paths from `openmpi4/bin` to `hpcx/bin`

These changes align with the current NVHPC SDK 25.9 distribution which uses hpcx for MPI libraries.

## Test Plan
- [x] GitHub Actions workflow runs successfully with new NVHPC 25.9 and CUDA 13.0
- [x] MPI tests pass with hpcx MPI library

Closes #5917

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Update `nvhpc.yml` to NVHPC 25.9, CUDA 13.0, and switch MPI library to HPCX.
> 
>   - **Environment Variables**:
>     - Update `CUDAVERDOT` to "13.0" and `NVERDOT` to "25.9" in `nvhpc.yml`.
>     - Update `NVERDASH` to "25-9" in `nvhpc.yml`.
>   - **MPI Library**:
>     - Change MPI paths from `openmpi4/bin` to `hpcx/bin` in `nvhpc.yml`.
>   - **Purpose**:
>     - Aligns with NVHPC SDK 25.9 distribution using HPCX for MPI.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=HDFGroup%2Fhdf5&utm_source=github&utm_medium=referral)<sup> for 1a38c03d7471442c4b36eb878b6d671766f2af32. You can [customize](https://app.ellipsis.dev/HDFGroup/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->