### PR TITLE
Update HDF5UseFortran.cmake

### DIFF
--- a/config/HDF5UseFortran.cmake
+++ b/config/HDF5UseFortran.cmake
@@ -391,7 +391,7 @@ if (PAC_FC_ALL_REAL_KINDS_SIZEOF STREQUAL "")
 endif ()
 
 set (${HDF_PREFIX}_H5CONFIG_F_RKIND_SIZEOF "INTEGER, DIMENSION(1:num_rkinds) :: rkind_sizeof = (/${PAC_FC_ALL_REAL_KINDS_SIZEOF}/)")
-message (STATUS "....FOUND SIZEOF for REAL KINDs \{${PAC_FC_ALL_REAL_KINDS_SIZEOF}\}")
+message (STATUS "....FOUND SIZEOF for REAL KINDs ${PAC_FC_ALL_REAL_KINDS_SIZEOF}")
 
 #find the maximum kind of the real
 string (REGEX REPLACE "," ";" VAR "${PAC_FC_ALL_REAL_KINDS_SIZEOF}")


### PR DESCRIPTION
Remove extraneous curly braces from log output
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Remove extraneous curly braces from log message in `HDF5UseFortran.cmake`.
> 
>   - **Logging**:
>     - Remove extraneous curly braces from log message in `HDF5UseFortran.cmake` for `PAC_FC_ALL_REAL_KINDS_SIZEOF`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=HDFGroup%2Fhdf5&utm_source=github&utm_medium=referral)<sup> for 63c0e0086e9f6fdba62adf87d06929f08637f3e1. You can [customize](https://app.ellipsis.dev/HDFGroup/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->