### PR TITLE
Fix a crash when duplicate addesses occur (related to CVE-2025-6269)

### DIFF
--- a/src/H5Cimage.c
+++ b/src/H5Cimage.c
@@ -138,8 +138,7 @@ typedef struct H5C_recon_entry_t {
 /* Helper routines */
 static size_t H5C__cache_image_block_entry_header_size(const H5F_t *f);
 static size_t H5C__cache_image_block_header_size(const H5F_t *f);
-static herr_t H5C__check_for_duplicates(H5C_cache_entry_t *pf_entry_ptr,
-                                        H5C_recon_entry_t **recon_table_ptr);
+static herr_t H5C__check_for_duplicates(H5C_cache_entry_t *pf_entry_ptr, H5C_recon_entry_t **recon_table_ptr);
 static herr_t H5C__decode_cache_image_header(const H5F_t *f, H5C_t *cache_ptr, const uint8_t **buf,
                                              size_t buf_size);
 #ifndef NDEBUG /* only used in assertions */
@@ -2653,7 +2652,7 @@ done:
                     H5MM_xfree(entry_ptr->fd_parent_addrs);
                 entry_ptr = H5FL_FREE(H5C_cache_entry_t, entry_ptr);
                 HDONE_ERROR(H5E_FILE, H5E_CANTEXPUNGE, FAIL, "unable to expunge driver info block");
-}
+            }
 
             HASH_DEL(recon_table, recon_entry);
             H5MM_xfree(recon_entry);

--- a/src/H5Cimage.c
+++ b/src/H5Cimage.c
@@ -138,7 +138,7 @@ typedef struct H5C_recon_entry_t {
 /* Helper routines */
 static size_t H5C__cache_image_block_entry_header_size(const H5F_t *f);
 static size_t H5C__cache_image_block_header_size(const H5F_t *f);
-static herr_t H5C__check_for_duplicates(H5F_t *f, H5C_cache_entry_t *pf_entry_ptr,
+static herr_t H5C__check_for_duplicates(H5C_cache_entry_t *pf_entry_ptr,
                                         H5C_recon_entry_t **recon_table_ptr);
 static herr_t H5C__decode_cache_image_header(const H5F_t *f, H5C_t *cache_ptr, const uint8_t **buf,
                                              size_t buf_size);
@@ -2394,7 +2394,7 @@ done:
  *-------------------------------------------------------------------------
  */
 static herr_t
-H5C__check_for_duplicates(H5F_t *f, H5C_cache_entry_t *pf_entry_ptr, H5C_recon_entry_t **recon_table_ptr)
+H5C__check_for_duplicates(H5C_cache_entry_t *pf_entry_ptr, H5C_recon_entry_t **recon_table_ptr)
 {
     haddr_t            addr        = pf_entry_ptr->addr;
     herr_t             ret_value   = SUCCEED; /* Return value */
@@ -2406,10 +2406,8 @@ H5C__check_for_duplicates(H5F_t *f, H5C_cache_entry_t *pf_entry_ptr, H5C_recon_e
     HASH_FIND(hh, *recon_table_ptr, &addr, sizeof(haddr_t), recon_entry);
 
     /* Duplicate found, remove the duplicated entry */
-    if (recon_entry) {
-        H5AC_expunge_entry(f, H5AC_PREFETCHED_ENTRY, addr, H5AC__NO_FLAGS_SET);
+    if (recon_entry)
         HGOTO_ERROR(H5E_CACHE, H5E_SYSTEM, FAIL, "duplicate addresses found");
-    }
     else {
         /* Insert address into the hash table for checking against later */
         if (NULL == (recon_entry = (H5C_recon_entry_t *)H5MM_malloc(sizeof(H5C_recon_entry_t))))
@@ -2482,7 +2480,7 @@ H5C__reconstruct_cache_contents(H5F_t *f, H5C_t *cache_ptr)
             HGOTO_ERROR(H5E_CACHE, H5E_SYSTEM, FAIL, "reconstruction of cache entry failed");
 
         /* Make sure different entries don't have the same address */
-        if (H5C__check_for_duplicates(f, pf_entry_ptr, &recon_table) < 0) {
+        if (H5C__check_for_duplicates(pf_entry_ptr, &recon_table) < 0) {
             /* Free the half-processed entry */
             if (pf_entry_ptr->image_ptr)
                 H5MM_xfree(pf_entry_ptr->image_ptr);
@@ -2627,7 +2625,7 @@ H5C__reconstruct_cache_contents(H5F_t *f, H5C_t *cache_ptr)
     } /* end if */
 
 done:
-    if (FAIL == ret_value && pf_entry_ptr) {
+    if (FAIL == ret_value) {
 
         /* If we failed during reconstruction, remove reconstructed entries */
         H5C_recon_entry_t *recon_entry, *tmp;
@@ -2640,16 +2638,23 @@ done:
             /* If the entry is protected, unprotect it */
             if (entry_ptr->is_protected)
                 if (H5C_unprotect(f, addr, (void *)entry_ptr, H5C__DELETED_FLAG) < 0)
-                    HGOTO_ERROR(H5E_CACHE, H5E_CANTUNPROTECT, FAIL, "can't unprotect entry");
+                    HDONE_ERROR(H5E_CACHE, H5E_CANTUNPROTECT, FAIL, "can't unprotect entry");
 
             /* If the entry is pinned, unpin it */
             if (entry_ptr->is_pinned)
                 if (H5C_unpin_entry((void *)entry_ptr) < 0)
-                    HGOTO_ERROR(H5E_CACHE, H5E_CANTUNPIN, FAIL, "can't unpin entry");
+                    HDONE_ERROR(H5E_CACHE, H5E_CANTUNPIN, FAIL, "can't unpin entry");
 
             /* Remove the unpinned and unprotected entry */
-            if (H5AC_expunge_entry(f, H5AC_PREFETCHED_ENTRY, addr, H5AC__NO_FLAGS_SET) < 0)
+            if (H5AC_expunge_entry(f, H5AC_PREFETCHED_ENTRY, addr, H5AC__NO_FLAGS_SET) < 0) {
+                if (entry_ptr->image_ptr)
+                    H5MM_xfree(entry_ptr->image_ptr);
+                if (entry_ptr->fd_parent_count > 0 && entry_ptr->fd_parent_addrs)
+                    H5MM_xfree(entry_ptr->fd_parent_addrs);
+                entry_ptr = H5FL_FREE(H5C_cache_entry_t, entry_ptr);
                 HDONE_ERROR(H5E_FILE, H5E_CANTEXPUNGE, FAIL, "unable to expunge driver info block");
+}
+
             HASH_DEL(recon_table, recon_entry);
             H5MM_xfree(recon_entry);
         }

--- a/src/H5Cimage.c
+++ b/src/H5Cimage.c
@@ -109,6 +109,28 @@
 /* Local Typedefs */
 /******************/
 
+/****************************************************************************
+ *
+ * structure H5C_recon_entry_t
+ *
+ * This structure provides a temporary uthash table to detect duplicate
+ * addresses.  Its fields are as follows:
+ *
+ * addr:      file offset of a metadata entry.  Entries are added to this
+ *            list when they are decoded.  If an entry has already existed
+ *            in the table, error will occur.
+ *
+ * entry_ptr: pointer to the cache entry, for expunging in failure cleanup.
+ *
+ * hh:        uthash hash table handle
+ *
+ ****************************************************************************/
+typedef struct H5C_recon_entry_t {
+    haddr_t addr;        /* The file address as key */
+    H5C_cache_entry_t *entry_ptr;
+    UT_hash_handle hh;   /* Hash table handle */
+} H5C_recon_entry_t;
+
 /********************/
 /* Local Prototypes */
 /********************/
@@ -2374,12 +2396,17 @@ done:
 static herr_t
 H5C__reconstruct_cache_contents(H5F_t *f, H5C_t *cache_ptr)
 {
-    H5C_cache_entry_t *pf_entry_ptr;        /* Pointer to prefetched entry */
+    H5C_cache_entry_t *pf_entry_ptr = NULL;        /* Pointer to prefetched entry */
     H5C_cache_entry_t *parent_ptr;          /* Pointer to parent of prefetched entry */
     hsize_t            image_len;           /* Image length */
     const uint8_t     *p;                   /* Pointer into image buffer */
     unsigned           u, v;                /* Local index variable */
     herr_t             ret_value = SUCCEED; /* Return value */
+
+    /* Declare a uthash table to detect duplicate addresses.  It will be destroyed
+       after decoding the cache contents */
+    H5C_recon_entry_t *recon_table = NULL;    /* Hash table head */
+    H5C_recon_entry_t *recon_entry = NULL;    /* Points to an address struct */
 
     FUNC_ENTER_PACKAGE
 
@@ -2405,11 +2432,28 @@ H5C__reconstruct_cache_contents(H5F_t *f, H5C_t *cache_ptr)
 
     /* Reconstruct entries in image */
     for (u = 0; u < cache_ptr->num_entries_in_image; u++) {
+        haddr_t addr;   /* temporary var */
+
         /* Create the prefetched entry described by the ith
          * entry in cache_ptr->image_entrise.
          */
         if (NULL == (pf_entry_ptr = H5C__reconstruct_cache_entry(f, cache_ptr, &image_len, &p)))
             HGOTO_ERROR(H5E_CACHE, H5E_SYSTEM, FAIL, "reconstruction of cache entry failed");
+        addr = pf_entry_ptr->addr;
+
+        /* Make sure the address is not duplicated */
+        HASH_FIND(hh, recon_table, &addr, sizeof(haddr_t), recon_entry);
+        if (recon_entry)
+            /* Duplicate found */
+            HGOTO_ERROR(H5E_CACHE, H5E_SYSTEM, FAIL, "duplicate addresses in cache");
+        else {
+            /* Insert address into the hash table */
+            if (NULL == (recon_entry = (H5C_recon_entry_t *)H5MM_malloc(sizeof(H5C_recon_entry_t))))
+                HGOTO_ERROR(H5E_CACHE, H5E_CANTALLOC, FAIL, "memory allocation failed for address entry");
+            recon_entry->addr = addr;
+            recon_entry->entry_ptr = pf_entry_ptr;
+            HASH_ADD(hh, recon_table, addr, sizeof(haddr_t), recon_entry);
+        }
 
         /* Note that we make no checks on available cache space before
          * inserting the reconstructed entry into the metadata cache.
@@ -2546,6 +2590,48 @@ H5C__reconstruct_cache_contents(H5F_t *f, H5C_t *cache_ptr)
     } /* end if */
 
 done:
+    if (FAIL == ret_value && pf_entry_ptr) {
+#ifndef NDEBUG
+        /* If we failed during reconstruction, remove reconstructed entries */
+        H5C_recon_entry_t *recon_entry, *tmp;
+
+        HASH_ITER(hh, recon_table, recon_entry, tmp) {
+            H5C_cache_entry_t *entry_ptr = recon_entry->entry_ptr;
+
+            /* Only touch entries from the image reconstruction */
+            if (entry_ptr->type->id == H5AC_PREFETCHED_ENTRY_ID) {
+ /*                 if (!entry_ptr->is_pinned && !entry_ptr->is_protected)
+ */ 
+                    H5AC_expunge_entry(f, H5AC_PREFETCHED_ENTRY, recon_entry->addr, H5AC__NO_FLAGS_SET);
+
+                if (entry_ptr->image_ptr)
+                    H5MM_xfree(entry_ptr->image_ptr);
+            }
+
+            HASH_DEL(recon_table, recon_entry);
+            H5MM_xfree(recon_entry);
+        }
+    /* The temporary hash table should be empty */
+    assert(recon_table == NULL);
+#endif /* NDEBUG */
+
+    /* Free the half-processed entry */
+        if (pf_entry_ptr->image_ptr)
+            H5MM_xfree(pf_entry_ptr->image_ptr);
+        if (pf_entry_ptr->fd_parent_count > 0 && pf_entry_ptr->fd_parent_addrs)
+            H5MM_xfree(pf_entry_ptr->fd_parent_addrs);
+        pf_entry_ptr = H5FL_FREE(H5C_cache_entry_t, pf_entry_ptr);
+    }
+    /* No failure, only cleanup the temporary hash table */
+    else if (recon_table) {
+        /* Free the temporary hash table */
+        H5C_recon_entry_t *cur, *tmp;
+        HASH_ITER(hh, recon_table, cur, tmp) {
+            HASH_DEL(recon_table, cur);
+            H5MM_xfree(cur);
+        }
+    }
+
     FUNC_LEAVE_NOAPI(ret_value)
 } /* H5C__reconstruct_cache_contents() */
 

--- a/src/H5Cimage.c
+++ b/src/H5Cimage.c
@@ -2394,8 +2394,7 @@ done:
  *-------------------------------------------------------------------------
  */
 static herr_t
-H5C__check_for_duplicates(H5F_t *f, H5C_cache_entry_t *pf_entry_ptr,
-                          H5C_recon_entry_t **recon_table_ptr)
+H5C__check_for_duplicates(H5F_t *f, H5C_cache_entry_t *pf_entry_ptr, H5C_recon_entry_t **recon_table_ptr)
 {
     haddr_t            addr        = pf_entry_ptr->addr;
     herr_t             ret_value   = SUCCEED; /* Return value */
@@ -2490,7 +2489,7 @@ H5C__reconstruct_cache_contents(H5F_t *f, H5C_t *cache_ptr)
             if (pf_entry_ptr->fd_parent_count > 0 && pf_entry_ptr->fd_parent_addrs)
                 H5MM_xfree(pf_entry_ptr->fd_parent_addrs);
             pf_entry_ptr = H5FL_FREE(H5C_cache_entry_t, pf_entry_ptr);
-                HGOTO_ERROR(H5E_CACHE, H5E_SYSTEM, FAIL, "duplicate addresses in cache");
+            HGOTO_ERROR(H5E_CACHE, H5E_SYSTEM, FAIL, "duplicate addresses in cache");
         }
 
         /* Note that we make no checks on available cache space before

--- a/src/H5Cimage.c
+++ b/src/H5Cimage.c
@@ -138,6 +138,8 @@ typedef struct H5C_recon_entry_t {
 /* Helper routines */
 static size_t H5C__cache_image_block_entry_header_size(const H5F_t *f);
 static size_t H5C__cache_image_block_header_size(const H5F_t *f);
+static herr_t H5C__check_for_duplicates(H5F_t *f, H5C_cache_entry_t *pf_entry_ptr,
+                                        H5C_recon_entry_t **recon_table_ptr);
 static herr_t H5C__decode_cache_image_header(const H5F_t *f, H5C_t *cache_ptr, const uint8_t **buf,
                                              size_t buf_size);
 #ifndef NDEBUG /* only used in assertions */
@@ -2381,6 +2383,52 @@ done:
 } /* H5C__prep_for_file_close__scan_entries() */
 
 /*-------------------------------------------------------------------------
+ * Function:    H5C__check_for_duplicates()
+ *
+ * Purpose:     Detects two entries with the same address.  When the
+ *      duplicate occurs, expunge the entry from the cache.  Leave the
+ *      half-processed entry for the caller to clean up as with other failures.
+ *
+ * Return:      SUCCEED on success, and FAIL on failure.
+ *
+ *-------------------------------------------------------------------------
+ */
+static herr_t
+H5C__check_for_duplicates(H5F_t *f, H5C_cache_entry_t *pf_entry_ptr,
+                          H5C_recon_entry_t **recon_table_ptr)
+{
+    haddr_t            addr        = pf_entry_ptr->addr;
+    herr_t             ret_value   = SUCCEED; /* Return value */
+    H5C_recon_entry_t *recon_entry = NULL;    /* Points to an entry in the temp table */
+
+    FUNC_ENTER_PACKAGE
+
+    /* Check whether the address is duplicated */
+    HASH_FIND(hh, *recon_table_ptr, &addr, sizeof(haddr_t), recon_entry);
+
+    /* Duplicate found, remove the duplicated entry */
+    if (recon_entry) {
+        H5C_cache_entry_t *entry_ptr = recon_entry->entry_ptr;
+
+        /* Only touch entries from the image reconstruction */
+        if (entry_ptr->type->id == H5AC_PREFETCHED_ENTRY_ID)
+            H5AC_expunge_entry(f, H5AC_PREFETCHED_ENTRY, addr, H5AC__NO_FLAGS_SET);
+        HGOTO_ERROR(H5E_CACHE, H5E_SYSTEM, FAIL, "duplicate addresses found");
+    }
+    else {
+        /* Insert address into the hash table for checking against later */
+        if (NULL == (recon_entry = (H5C_recon_entry_t *)H5MM_malloc(sizeof(H5C_recon_entry_t))))
+            HGOTO_ERROR(H5E_CACHE, H5E_CANTALLOC, FAIL, "memory allocation failed for address entry");
+        recon_entry->addr      = addr;
+        recon_entry->entry_ptr = pf_entry_ptr;
+        HASH_ADD(hh, *recon_table_ptr, addr, sizeof(haddr_t), recon_entry);
+    }
+
+done:
+    FUNC_LEAVE_NOAPI(ret_value)
+} /* H5C__check_for_duplicates() */
+
+/*-------------------------------------------------------------------------
  * Function:    H5C__reconstruct_cache_contents()
  *
  * Purpose:     Scan the image buffer, and create a prefetched
@@ -2406,7 +2454,6 @@ H5C__reconstruct_cache_contents(H5F_t *f, H5C_t *cache_ptr)
     /* Declare a uthash table to detect duplicate addresses.  It will be destroyed
        after decoding the cache contents */
     H5C_recon_entry_t *recon_table = NULL; /* Hash table head */
-    H5C_recon_entry_t *recon_entry = NULL; /* Points to an address struct */
 
     FUNC_ENTER_PACKAGE
 
@@ -2432,27 +2479,22 @@ H5C__reconstruct_cache_contents(H5F_t *f, H5C_t *cache_ptr)
 
     /* Reconstruct entries in image */
     for (u = 0; u < cache_ptr->num_entries_in_image; u++) {
-        haddr_t addr; /* temporary var */
 
         /* Create the prefetched entry described by the ith
          * entry in cache_ptr->image_entrise.
          */
         if (NULL == (pf_entry_ptr = H5C__reconstruct_cache_entry(f, cache_ptr, &image_len, &p)))
             HGOTO_ERROR(H5E_CACHE, H5E_SYSTEM, FAIL, "reconstruction of cache entry failed");
-        addr = pf_entry_ptr->addr;
 
-        /* Make sure the address is not duplicated */
-        HASH_FIND(hh, recon_table, &addr, sizeof(haddr_t), recon_entry);
-        if (recon_entry)
-            /* Duplicate found */
-            HGOTO_ERROR(H5E_CACHE, H5E_SYSTEM, FAIL, "duplicate addresses in cache");
-        else {
-            /* Insert address into the hash table */
-            if (NULL == (recon_entry = (H5C_recon_entry_t *)H5MM_malloc(sizeof(H5C_recon_entry_t))))
-                HGOTO_ERROR(H5E_CACHE, H5E_CANTALLOC, FAIL, "memory allocation failed for address entry");
-            recon_entry->addr      = addr;
-            recon_entry->entry_ptr = pf_entry_ptr;
-            HASH_ADD(hh, recon_table, addr, sizeof(haddr_t), recon_entry);
+        /* Make sure different entries don't have the same address */
+        if (H5C__check_for_duplicates(f, pf_entry_ptr, &recon_table) < 0) {
+            /* Free the half-processed entry */
+            if (pf_entry_ptr->image_ptr)
+                H5MM_xfree(pf_entry_ptr->image_ptr);
+            if (pf_entry_ptr->fd_parent_count > 0 && pf_entry_ptr->fd_parent_addrs)
+                H5MM_xfree(pf_entry_ptr->fd_parent_addrs);
+            pf_entry_ptr = H5FL_FREE(H5C_cache_entry_t, pf_entry_ptr);
+                HGOTO_ERROR(H5E_CACHE, H5E_SYSTEM, FAIL, "duplicate addresses in cache");
         }
 
         /* Note that we make no checks on available cache space before
@@ -2591,37 +2633,33 @@ H5C__reconstruct_cache_contents(H5F_t *f, H5C_t *cache_ptr)
 
 done:
     if (FAIL == ret_value && pf_entry_ptr) {
-#ifndef NDEBUG
+
         /* If we failed during reconstruction, remove reconstructed entries */
         H5C_recon_entry_t *recon_entry, *tmp;
 
         HASH_ITER(hh, recon_table, recon_entry, tmp)
         {
             H5C_cache_entry_t *entry_ptr = recon_entry->entry_ptr;
+            haddr_t            addr      = entry_ptr->addr;
 
-            /* Only touch entries from the image reconstruction */
-            if (entry_ptr->type->id == H5AC_PREFETCHED_ENTRY_ID) {
-                /*                 if (!entry_ptr->is_pinned && !entry_ptr->is_protected)
-                 */
-                H5AC_expunge_entry(f, H5AC_PREFETCHED_ENTRY, recon_entry->addr, H5AC__NO_FLAGS_SET);
+            /* If the entry is protected, unprotect it */
+            if (entry_ptr->is_protected)
+                if (H5C_unprotect(f, addr, (void *)entry_ptr, H5C__DELETED_FLAG) < 0)
+                    HGOTO_ERROR(H5E_CACHE, H5E_CANTUNPROTECT, FAIL, "can't unprotect entry");
 
-                if (entry_ptr->image_ptr)
-                    H5MM_xfree(entry_ptr->image_ptr);
-            }
+            /* If the entry is pinned, unpin it */
+            if (entry_ptr->is_pinned)
+                if (H5C_unpin_entry((void *)entry_ptr) < 0)
+                    HGOTO_ERROR(H5E_CACHE, H5E_CANTUNPIN, FAIL, "can't unpin entry");
 
+            /* Remove the unpinned and unprotected entry */
+            if (H5AC_expunge_entry(f, H5AC_PREFETCHED_ENTRY, addr, H5AC__NO_FLAGS_SET) < 0)
+                HDONE_ERROR(H5E_FILE, H5E_CANTEXPUNGE, FAIL, "unable to expunge driver info block");
             HASH_DEL(recon_table, recon_entry);
             H5MM_xfree(recon_entry);
         }
         /* The temporary hash table should be empty */
         assert(recon_table == NULL);
-#endif /* NDEBUG */
-
-        /* Free the half-processed entry */
-        if (pf_entry_ptr->image_ptr)
-            H5MM_xfree(pf_entry_ptr->image_ptr);
-        if (pf_entry_ptr->fd_parent_count > 0 && pf_entry_ptr->fd_parent_addrs)
-            H5MM_xfree(pf_entry_ptr->fd_parent_addrs);
-        pf_entry_ptr = H5FL_FREE(H5C_cache_entry_t, pf_entry_ptr);
     }
     /* No failure, only cleanup the temporary hash table */
     else if (recon_table) {

--- a/src/H5Cimage.c
+++ b/src/H5Cimage.c
@@ -2408,11 +2408,7 @@ H5C__check_for_duplicates(H5F_t *f, H5C_cache_entry_t *pf_entry_ptr,
 
     /* Duplicate found, remove the duplicated entry */
     if (recon_entry) {
-        H5C_cache_entry_t *entry_ptr = recon_entry->entry_ptr;
-
-        /* Only touch entries from the image reconstruction */
-        if (entry_ptr->type->id == H5AC_PREFETCHED_ENTRY_ID)
-            H5AC_expunge_entry(f, H5AC_PREFETCHED_ENTRY, addr, H5AC__NO_FLAGS_SET);
+        H5AC_expunge_entry(f, H5AC_PREFETCHED_ENTRY, addr, H5AC__NO_FLAGS_SET);
         HGOTO_ERROR(H5E_CACHE, H5E_SYSTEM, FAIL, "duplicate addresses found");
     }
     else {

--- a/src/H5Cimage.c
+++ b/src/H5Cimage.c
@@ -126,9 +126,9 @@
  *
  ****************************************************************************/
 typedef struct H5C_recon_entry_t {
-    haddr_t addr;        /* The file address as key */
+    haddr_t            addr; /* The file address as key */
     H5C_cache_entry_t *entry_ptr;
-    UT_hash_handle hh;   /* Hash table handle */
+    UT_hash_handle     hh; /* Hash table handle */
 } H5C_recon_entry_t;
 
 /********************/
@@ -2396,7 +2396,7 @@ done:
 static herr_t
 H5C__reconstruct_cache_contents(H5F_t *f, H5C_t *cache_ptr)
 {
-    H5C_cache_entry_t *pf_entry_ptr = NULL;        /* Pointer to prefetched entry */
+    H5C_cache_entry_t *pf_entry_ptr = NULL; /* Pointer to prefetched entry */
     H5C_cache_entry_t *parent_ptr;          /* Pointer to parent of prefetched entry */
     hsize_t            image_len;           /* Image length */
     const uint8_t     *p;                   /* Pointer into image buffer */
@@ -2405,8 +2405,8 @@ H5C__reconstruct_cache_contents(H5F_t *f, H5C_t *cache_ptr)
 
     /* Declare a uthash table to detect duplicate addresses.  It will be destroyed
        after decoding the cache contents */
-    H5C_recon_entry_t *recon_table = NULL;    /* Hash table head */
-    H5C_recon_entry_t *recon_entry = NULL;    /* Points to an address struct */
+    H5C_recon_entry_t *recon_table = NULL; /* Hash table head */
+    H5C_recon_entry_t *recon_entry = NULL; /* Points to an address struct */
 
     FUNC_ENTER_PACKAGE
 
@@ -2432,7 +2432,7 @@ H5C__reconstruct_cache_contents(H5F_t *f, H5C_t *cache_ptr)
 
     /* Reconstruct entries in image */
     for (u = 0; u < cache_ptr->num_entries_in_image; u++) {
-        haddr_t addr;   /* temporary var */
+        haddr_t addr; /* temporary var */
 
         /* Create the prefetched entry described by the ith
          * entry in cache_ptr->image_entrise.
@@ -2450,7 +2450,7 @@ H5C__reconstruct_cache_contents(H5F_t *f, H5C_t *cache_ptr)
             /* Insert address into the hash table */
             if (NULL == (recon_entry = (H5C_recon_entry_t *)H5MM_malloc(sizeof(H5C_recon_entry_t))))
                 HGOTO_ERROR(H5E_CACHE, H5E_CANTALLOC, FAIL, "memory allocation failed for address entry");
-            recon_entry->addr = addr;
+            recon_entry->addr      = addr;
             recon_entry->entry_ptr = pf_entry_ptr;
             HASH_ADD(hh, recon_table, addr, sizeof(haddr_t), recon_entry);
         }
@@ -2595,14 +2595,15 @@ done:
         /* If we failed during reconstruction, remove reconstructed entries */
         H5C_recon_entry_t *recon_entry, *tmp;
 
-        HASH_ITER(hh, recon_table, recon_entry, tmp) {
+        HASH_ITER(hh, recon_table, recon_entry, tmp)
+        {
             H5C_cache_entry_t *entry_ptr = recon_entry->entry_ptr;
 
             /* Only touch entries from the image reconstruction */
             if (entry_ptr->type->id == H5AC_PREFETCHED_ENTRY_ID) {
- /*                 if (!entry_ptr->is_pinned && !entry_ptr->is_protected)
- */ 
-                    H5AC_expunge_entry(f, H5AC_PREFETCHED_ENTRY, recon_entry->addr, H5AC__NO_FLAGS_SET);
+                /*                 if (!entry_ptr->is_pinned && !entry_ptr->is_protected)
+                 */
+                H5AC_expunge_entry(f, H5AC_PREFETCHED_ENTRY, recon_entry->addr, H5AC__NO_FLAGS_SET);
 
                 if (entry_ptr->image_ptr)
                     H5MM_xfree(entry_ptr->image_ptr);
@@ -2611,11 +2612,11 @@ done:
             HASH_DEL(recon_table, recon_entry);
             H5MM_xfree(recon_entry);
         }
-    /* The temporary hash table should be empty */
-    assert(recon_table == NULL);
+        /* The temporary hash table should be empty */
+        assert(recon_table == NULL);
 #endif /* NDEBUG */
 
-    /* Free the half-processed entry */
+        /* Free the half-processed entry */
         if (pf_entry_ptr->image_ptr)
             H5MM_xfree(pf_entry_ptr->image_ptr);
         if (pf_entry_ptr->fd_parent_count > 0 && pf_entry_ptr->fd_parent_addrs)
@@ -2626,7 +2627,8 @@ done:
     else if (recon_table) {
         /* Free the temporary hash table */
         H5C_recon_entry_t *cur, *tmp;
-        HASH_ITER(hh, recon_table, cur, tmp) {
+        HASH_ITER(hh, recon_table, cur, tmp)
+        {
             HASH_DEL(recon_table, cur);
             H5MM_xfree(cur);
         }

--- a/src/H5Cprefetched.c
+++ b/src/H5Cprefetched.c
@@ -231,7 +231,7 @@ H5C__prefetched_entry_notify(H5C_notify_action_t action, void *_thing)
             break;
 
         case H5C_NOTIFY_ACTION_BEFORE_EVICT:
-            for (u = 0; u < entry_ptr->flush_dep_nparents; u++) {
+            for (u = entry_ptr->flush_dep_nparents - 1; u < entry_ptr->flush_dep_nparents; u--) {
                 H5C_cache_entry_t *parent_ptr;
 
                 /* Sanity checks */


### PR DESCRIPTION
When two entries in the cache image have the same address, the library did not fail and later crashed.  This occurred in the debug build of the issue #5579, CVE-2025-6269.

The cache reconstruction functions now detect duplicate addresses.  When a failure occurs during the reconstruction, the cache is not clean properly. H5C__reconstruct_cache_contents now expunges any prefetched entries that were already added to the cache during the reconstruction.

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fix crash by detecting and handling duplicate addresses during cache reconstruction in `H5C__reconstruct_cache_contents`.
> 
>   - **Behavior**:
>     - `H5C__reconstruct_cache_contents` in `H5Cimage.c` now detects duplicate addresses using a hash table and fails gracefully if duplicates are found.
>     - On failure during reconstruction, expunges prefetched entries already added to the cache.
>   - **Structures**:
>     - Adds `H5C_recon_entry_t` structure to track addresses and entries during reconstruction.
>   - **Error Handling**:
>     - Improved error handling in `H5C__reconstruct_cache_contents` to clean up partially processed entries and hash table on failure.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=HDFGroup%2Fhdf5&utm_source=github&utm_medium=referral)<sup> for 9b19286accc721c3bd339344c62d4f6753007ec4. You can [customize](https://app.ellipsis.dev/HDFGroup/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->