### PR TITLE
Added entries for GH issues #5572 and #5573

### DIFF
--- a/release_docs/CHANGELOG.md
+++ b/release_docs/CHANGELOG.md
@@ -557,6 +557,20 @@ Added Fortran wrapper h5fdsubfiling_get_file_mapping_f() for the subfiling file 
 
 ## Library
 
+### Security issue CVE-2025-6818
+
+   A bad file caused H5C__load_entry() to attempt to allocate a very large buffer,
+   resulting in a crash.  This issue is indirectly fixed by PR #5710.
+
+   Fixes GitHub issue #5572
+
+### Security issue CVE-2025-6818
+
+   A bad file caused a heap-buffer-overflow in H5O__chunk_protect() and the issue is
+   indirectly fixed by PR #5829.
+
+   Fixes GitHub issue #5573
+
 ### Fixed security issue CVE-2025-7068
 
    Failures during the discard process on a metadata cache entry could cause the library to skip calling the callback to free the cache entry. This could result in resource leaks and issues with flushing and closing the metadata cache during file close. This has been fixed by noting errors during the discard process, but attempting to fully free a cache entry before signalling that an error has occurred.

--- a/release_docs/CHANGELOG.md
+++ b/release_docs/CHANGELOG.md
@@ -557,17 +557,17 @@ Added Fortran wrapper h5fdsubfiling_get_file_mapping_f() for the subfiling file 
 
 ## Library
 
-### Security issue CVE-2025-6818
+### Security issue CVE-2025-6817
 
-   A bad file caused H5C__load_entry() to attempt to allocate a very large buffer,
-   resulting in a crash.  This issue is indirectly fixed by PR #5710.
+   A malformed file caused H5C__load_entry() to attempt to allocate a very large
+   buffer, resulting in a crash.  This issue is indirectly fixed by PR #5710.
 
    Fixes GitHub issue #5572
 
 ### Security issue CVE-2025-6818
 
-   A bad file caused a heap-buffer-overflow in H5O__chunk_protect() and the issue is
-   indirectly fixed by PR #5829.
+   A malformed file caused a heap-buffer-overflow in H5O__chunk_protect() and
+   the issue is indirectly fixed by PR #5829.
 
    Fixes GitHub issue #5573
 


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Added `CHANGELOG.md` entries for CVE-2025-6818, addressing GitHub issues #5572 and #5573.
> 
>   - **Security Fixes**:
>     - Added entry for CVE-2025-6818 in `CHANGELOG.md`.
>     - Fixes GitHub issue #5572: Crash due to large buffer allocation in `H5C__load_entry()`.
>     - Fixes GitHub issue #5573: Heap-buffer-overflow in `H5O__chunk_protect()`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=HDFGroup%2Fhdf5&utm_source=github&utm_medium=referral)<sup> for fe12b05c76172d09714814dde86988ba6768ecd3. You can [customize](https://app.ellipsis.dev/HDFGroup/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->