### PR TITLE
Fixed compilation errors and warnings when compiled on MAC.

### DIFF
--- a/src/H5Dfarray.c
+++ b/src/H5Dfarray.c
@@ -2413,7 +2413,7 @@ H5D__farray_stc_idx_iterate_cb(hsize_t H5_ATTR_UNUSED idx, const void *_elmt, vo
     else {
         const H5D_farray_stc_elmt_t *elmt = (const H5D_farray_stc_elmt_t *)_elmt;
 
-        udata->stc_rec.chunk_addr = (const haddr_t *)elmt->addr;
+        udata->stc_rec.chunk_addr = elmt->addr;
         udata->stc_rec.nbytes     = elmt->nbytes;
         for (unsigned u = 0; u < udata->stc_nsects; u++) {
             udata->stc_rec.offset[u]      = elmt->offset[u];

--- a/tools/src/h5stat/h5stat.c
+++ b/tools/src/h5stat/h5stat.c
@@ -568,11 +568,11 @@ dataset_stats(iter_t *iter, const char *name, const H5O_info2_t *oi, const H5O_n
         /* Track different filters for structured chunk dataset */
         /* For now don't do anything for H5_VL_DATA */
         for (k = 0; k < (H5_SECTION_NUM - 1); k++) {
-            if ((H5Pget_nfilters2(dcpl, k, &nfltr)) >= 0) {
+            if ((H5Pget_nfilters2(dcpl, (H5_section_type_t)k, &nfltr)) >= 0) {
                 if (nfltr == 0)
                     iter->stc_dset_comptype[k][0]++;
                 for (u = 0; u < (unsigned)nfltr; u++) {
-                    fltr = H5Pget_filter3(dcpl, k, u, 0, 0, 0, 0, 0, NULL);
+                    fltr = H5Pget_filter3(dcpl, (H5_section_type_t)k, u, 0, 0, 0, 0, 0, NULL);
                     if (fltr >= 0) {
                         if (fltr < (H5_NFILTERS_IMPL - 1))
                             iter->stc_dset_comptype[k][fltr]++;


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Fix compilation errors on Mac by adjusting type casting and function calls in `H5Dfarray.c` and `h5stat.c`.
> 
>   - **Behavior**:
>     - Fix type casting in `H5D__farray_stc_idx_iterate_cb()` in `H5Dfarray.c` by removing unnecessary cast to `const haddr_t *`.
>     - Correct function call in `dataset_stats()` in `h5stat.c` by casting `k` to `H5_section_type_t` in `H5Pget_nfilters2()` and `H5Pget_filter3()`.
>   - **Misc**:
>     - These changes resolve compilation errors and warnings on Mac.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=HDFGroup%2Fhdf5&utm_source=github&utm_medium=referral)<sup> for 173bca259baefc5bbe62c52764e32c8d8d89b0cb. You can [customize](https://app.ellipsis.dev/HDFGroup/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->