### PR TITLE
Fixed uninitialized memory issue in link table allocation.

### DIFF
--- a/src/H5Gdense.c
+++ b/src/H5Gdense.c
@@ -767,10 +767,8 @@ H5G__dense_build_table(H5F_t *f, const H5O_linfo_t *linfo, H5_index_t idx_type, 
 
         /* Initialize all links to invalid. NOTE: If H5O_link_t changes, update this loop. */
         for (size_t i = 0; i < ltable->nlinks; i++) {
+            memset(&ltable->lnks[i], 0, sizeof(H5O_link_t));
             ltable->lnks[i].type        = H5L_TYPE_ERROR;
-            ltable->lnks[i].name        = NULL;
-            ltable->lnks[i].u.soft.name = NULL;
-            ltable->lnks[i].u.ud.udata  = NULL;
         }
 
         /* Set up user data for iteration */

--- a/src/H5Gdense.c
+++ b/src/H5Gdense.c
@@ -768,7 +768,7 @@ H5G__dense_build_table(H5F_t *f, const H5O_linfo_t *linfo, H5_index_t idx_type, 
         /* Initialize all links to invalid. NOTE: If H5O_link_t changes, update this loop. */
         for (size_t i = 0; i < ltable->nlinks; i++) {
             memset(&ltable->lnks[i], 0, sizeof(H5O_link_t));
-            ltable->lnks[i].type        = H5L_TYPE_ERROR;
+            ltable->lnks[i].type = H5L_TYPE_ERROR;
         }
 
         /* Set up user data for iteration */

--- a/src/H5Gdense.c
+++ b/src/H5Gdense.c
@@ -762,14 +762,12 @@ H5G__dense_build_table(H5F_t *f, const H5O_linfo_t *linfo, H5_index_t idx_type, 
         H5G_dense_bt_ud_t udata; /* User data for iteration callback */
 
         /* Allocate the table to store the links */
-        if ((ltable->lnks = (H5O_link_t *)H5MM_malloc(sizeof(H5O_link_t) * ltable->nlinks)) == NULL)
+        if ((ltable->lnks = (H5O_link_t *)H5MM_calloc(sizeof(H5O_link_t) * ltable->nlinks)) == NULL)
             HGOTO_ERROR(H5E_RESOURCE, H5E_NOSPACE, FAIL, "memory allocation failed");
 
         /* Initialize all links to invalid. NOTE: If H5O_link_t changes, update this loop. */
-        for (size_t i = 0; i < ltable->nlinks; i++) {
-            memset(&ltable->lnks[i], 0, sizeof(H5O_link_t));
+        for (size_t i = 0; i < ltable->nlinks; i++)
             ltable->lnks[i].type = H5L_TYPE_ERROR;
-        }
 
         /* Set up user data for iteration */
         udata.ltable   = ltable;

--- a/src/H5Gdense.c
+++ b/src/H5Gdense.c
@@ -765,6 +765,14 @@ H5G__dense_build_table(H5F_t *f, const H5O_linfo_t *linfo, H5_index_t idx_type, 
         if ((ltable->lnks = (H5O_link_t *)H5MM_malloc(sizeof(H5O_link_t) * ltable->nlinks)) == NULL)
             HGOTO_ERROR(H5E_RESOURCE, H5E_NOSPACE, FAIL, "memory allocation failed");
 
+        /* Initialize all links to invalid */
+        for (size_t i = 0; i < ltable->nlinks; i++) {
+            ltable->lnks[i].type = H5L_TYPE_ERROR;
+            ltable->lnks[i].name = NULL;
+            ltable->lnks[i].u.soft.name = NULL;
+            ltable->lnks[i].u.ud.udata = NULL;
+        }
+
         /* Set up user data for iteration */
         udata.ltable   = ltable;
         udata.curr_lnk = 0;

--- a/src/H5Gdense.c
+++ b/src/H5Gdense.c
@@ -767,10 +767,10 @@ H5G__dense_build_table(H5F_t *f, const H5O_linfo_t *linfo, H5_index_t idx_type, 
 
         /* Initialize all links to invalid */
         for (size_t i = 0; i < ltable->nlinks; i++) {
-            ltable->lnks[i].type = H5L_TYPE_ERROR;
-            ltable->lnks[i].name = NULL;
+            ltable->lnks[i].type        = H5L_TYPE_ERROR;
+            ltable->lnks[i].name        = NULL;
             ltable->lnks[i].u.soft.name = NULL;
-            ltable->lnks[i].u.ud.udata = NULL;
+            ltable->lnks[i].u.ud.udata  = NULL;
         }
 
         /* Set up user data for iteration */

--- a/src/H5Gdense.c
+++ b/src/H5Gdense.c
@@ -765,7 +765,7 @@ H5G__dense_build_table(H5F_t *f, const H5O_linfo_t *linfo, H5_index_t idx_type, 
         if ((ltable->lnks = (H5O_link_t *)H5MM_malloc(sizeof(H5O_link_t) * ltable->nlinks)) == NULL)
             HGOTO_ERROR(H5E_RESOURCE, H5E_NOSPACE, FAIL, "memory allocation failed");
 
-        /* Initialize all links to invalid */
+        /* Initialize all links to invalid. NOTE: If H5O_link_t changes, update this loop. */
         for (size_t i = 0; i < ltable->nlinks; i++) {
             ltable->lnks[i].type        = H5L_TYPE_ERROR;
             ltable->lnks[i].name        = NULL;


### PR DESCRIPTION
When H5G__dense_iterate failed early, the allocated H5O_link_t structures were never populated, causing cleanup code to read uninitialized lnk->type values and attempt to free invalid pointers.

The structures are now initialized with proper values and NULL pointers immediately after allocation.

Fixes #5375
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fixes uninitialized memory issue in `H5G__dense_build_table` in `H5Gdense.c` by initializing `H5O_link_t` structures immediately after allocation.
> 
>   - **Behavior**:
>     - Fixes uninitialized memory issue in `H5G__dense_build_table` in `H5Gdense.c` by initializing `H5O_link_t` structures immediately after allocation.
>     - Prevents reading uninitialized `lnk->type` values and freeing invalid pointers during cleanup.
>   - **Misc**:
>     - Addresses GitHub issue #5375.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=HDFGroup%2Fhdf5&utm_source=github&utm_medium=referral)<sup> for 2ec28bc2f19f6fd2bfec2fd6953bc3b2b974a2aa. You can [customize](https://app.ellipsis.dev/HDFGroup/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->