### PR TITLE
Add CHANGELOG entry for fix for CVE-2025-7067

### DIFF
--- a/release_docs/CHANGELOG.md
+++ b/release_docs/CHANGELOG.md
@@ -557,6 +557,12 @@ Added Fortran wrapper h5fdsubfiling_get_file_mapping_f() for the subfiling file 
 
 ## Library
 
+### Fixed security issue CVE-2025-7067
+
+   Fixed a heap buffer overflow in H5FS__sinfo_serialize_node_cb() by discarding file free space sections from the file free space manager when they are found to be invalid. Specifically crafted HDF5 files can result in an attempt to insert duplicate or overlapping file free space sections into a file free space manager, later resulting in a buffer overflow when the same free space section is serialized to the file multiple times.
+
+   Fixes GitHub issue #5577
+
 ### Fixed security issue CVE-2025-2915 and OSV-2024-381
 
    Fixed a heap-based buffer overflow in H5F__accum_free caused by an integer overflow when calculating new_accum_size. Added validation in H5O__mdci_decode to detect and reject invalid values early, preventing the overflow condition.


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Add changelog entry for CVE-2025-7067 fix, detailing heap buffer overflow resolution in `H5FS__sinfo_serialize_node_cb()`.
> 
>   - **Changelog Update**:
>     - Added entry for CVE-2025-7067 in `CHANGELOG.md`.
>     - Describes fix for heap buffer overflow in `H5FS__sinfo_serialize_node_cb()` by discarding invalid file free space sections.
>     - References GitHub issue #5577.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=HDFGroup%2Fhdf5&utm_source=github&utm_medium=referral)<sup> for dd981c2cc2ce78f5c934aec076556adbc05a4258. You can [customize](https://app.ellipsis.dev/HDFGroup/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->