### PR TITLE
Fix several issues uncovered by CVE-2025-7067

### DIFF
--- a/src/H5FScache.c
+++ b/src/H5FScache.c
@@ -1024,7 +1024,7 @@ H5FS__cache_sinfo_deserialize(const void *_image, size_t H5_ATTR_NDEBUG_UNUSED l
 
                 /* Insert section in free space manager, unless requested not to */
                 if (!(des_flags & H5FS_DESERIALIZE_NO_ADD))
-                    if (H5FS_sect_add(udata->f, fspace, new_sect, H5FS_ADD_DESERIALIZING, udata) < 0)
+                    if (H5FS_sect_add(udata->f, fspace, new_sect, H5FS_ADD_DESERIALIZING, udata, NULL) < 0)
                         HGOTO_ERROR(H5E_FSPACE, H5E_CANTINSERT, NULL,
                                     "can't add section to free space manager");
             } /* end for */

--- a/src/H5FSprivate.h
+++ b/src/H5FSprivate.h
@@ -201,7 +201,7 @@ H5_DLL herr_t  H5FS_free(H5F_t *f, H5FS_t *fspace, bool free_file_space);
 
 /* Free space section routines */
 H5_DLL herr_t H5FS_sect_add(H5F_t *f, H5FS_t *fspace, H5FS_section_info_t *node, unsigned flags,
-                            void *op_data);
+                            void *op_data, bool *merged_or_shrunk);
 H5_DLL htri_t H5FS_sect_try_merge(H5F_t *f, H5FS_t *fspace, H5FS_section_info_t *sect, unsigned flags,
                                   void *op_data);
 H5_DLL htri_t H5FS_sect_try_extend(H5F_t *f, H5FS_t *fspace, haddr_t addr, hsize_t size,

--- a/src/H5FSsection.c
+++ b/src/H5FSsection.c
@@ -1297,7 +1297,8 @@ done:
  *-------------------------------------------------------------------------
  */
 herr_t
-H5FS_sect_add(H5F_t *f, H5FS_t *fspace, H5FS_section_info_t *sect, unsigned flags, void *op_data)
+H5FS_sect_add(H5F_t *f, H5FS_t *fspace, H5FS_section_info_t *sect, unsigned flags, void *op_data,
+              bool *merged_or_shrunk)
 {
     H5FS_section_class_t *cls;                      /* Section's class */
     bool                  sinfo_valid    = false;   /* Whether the section info is valid */
@@ -1317,6 +1318,9 @@ H5FS_sect_add(H5F_t *f, H5FS_t *fspace, H5FS_section_info_t *sect, unsigned flag
     assert(sect);
     assert(H5_addr_defined(sect->addr));
     assert(sect->size);
+
+    if (merged_or_shrunk)
+        *merged_or_shrunk = false;
 
     /* Get a pointer to the section info */
     if (H5FS__sinfo_lock(f, fspace, H5AC__NO_FLAGS_SET) < 0)
@@ -1344,9 +1348,12 @@ H5FS_sect_add(H5F_t *f, H5FS_t *fspace, H5FS_section_info_t *sect, unsigned flag
     /* (If section has been completely merged or shrunk away, 'sect' will
      *  be NULL at this point - QAK)
      */
-    if (sect)
+    if (sect) {
         if (H5FS__sect_link(fspace, sect, flags) < 0)
             HGOTO_ERROR(H5E_FSPACE, H5E_CANTINSERT, FAIL, "can't insert free space section into skip list");
+    }
+    else if (merged_or_shrunk)
+        *merged_or_shrunk = true;
 
 #ifdef H5FS_SINFO_DEBUG
     fprintf(stderr, "%s: fspace->tot_space = %" PRIuHSIZE "\n", __func__, fspace->tot_space);
@@ -2314,11 +2321,15 @@ done:
 herr_t
 H5FS_vfd_alloc_hdr_and_section_info_if_needed(H5F_t *f, H5FS_t *fspace, haddr_t *fs_addr_ptr)
 {
-    hsize_t hdr_alloc_size;
-    hsize_t sinfo_alloc_size;
-    haddr_t sect_addr = HADDR_UNDEF; /* address of sinfo */
-    haddr_t eoa       = HADDR_UNDEF; /* Initial EOA for the file */
-    herr_t  ret_value = SUCCEED;     /* Return value */
+    hsize_t hdr_alloc_size    = 0;
+    hsize_t sinfo_alloc_size  = 0;
+    haddr_t sect_addr         = HADDR_UNDEF; /* address of sinfo */
+    haddr_t eoa               = HADDR_UNDEF; /* Initial EOA for the file */
+    bool    allocated_header  = false;       /* Whether a free space header was allocated */
+    bool    inserted_header   = false; /* Whether a free space header was inserted into the metadata cache */
+    bool    allocated_section = false; /* Whether a free space section was allocated */
+    bool    inserted_section  = false; /* Whether a free space section was inserted into the metadata cache */
+    herr_t  ret_value         = SUCCEED; /* Return value */
 
     FUNC_ENTER_NOAPI_NOINIT
 
@@ -2367,10 +2378,12 @@ H5FS_vfd_alloc_hdr_and_section_info_if_needed(H5F_t *f, H5FS_t *fspace, haddr_t 
             /* Allocate space for the free space header */
             if (HADDR_UNDEF == (fspace->addr = H5MF_alloc(f, H5FD_MEM_FSPACE_HDR, hdr_alloc_size)))
                 HGOTO_ERROR(H5E_RESOURCE, H5E_NOSPACE, FAIL, "file allocation failed for free space header");
+            allocated_header = true;
 
             /* Cache the new free space header (pinned) */
             if (H5AC_insert_entry(f, H5AC_FSPACE_HDR, fspace->addr, fspace, H5AC__PIN_ENTRY_FLAG) < 0)
                 HGOTO_ERROR(H5E_FSPACE, H5E_CANTINIT, FAIL, "can't add free space header to cache");
+            inserted_header = true;
 
             *fs_addr_ptr = fspace->addr;
         }
@@ -2396,6 +2409,7 @@ H5FS_vfd_alloc_hdr_and_section_info_if_needed(H5F_t *f, H5FS_t *fspace, haddr_t 
             /* allocate space for the section info */
             if (HADDR_UNDEF == (sect_addr = H5MF_alloc(f, H5FD_MEM_FSPACE_SINFO, sinfo_alloc_size)))
                 HGOTO_ERROR(H5E_FSPACE, H5E_NOSPACE, FAIL, "file allocation failed for section info");
+            allocated_section = true;
 
             /* update fspace->alloc_sect_size and fspace->sect_addr to reflect
              * the allocation
@@ -2437,6 +2451,7 @@ H5FS_vfd_alloc_hdr_and_section_info_if_needed(H5F_t *f, H5FS_t *fspace, haddr_t 
                  */
                 if (H5AC_insert_entry(f, H5AC_FSPACE_SINFO, sect_addr, fspace->sinfo, H5AC__NO_FLAGS_SET) < 0)
                     HGOTO_ERROR(H5E_FSPACE, H5E_CANTINIT, FAIL, "can't add free space sinfo to cache");
+                inserted_section = true;
 
                 /* We have changed the sinfo address -- Mark free space header dirty */
                 if (H5AC_mark_entry_dirty(fspace) < 0)
@@ -2453,5 +2468,53 @@ H5FS_vfd_alloc_hdr_and_section_info_if_needed(H5F_t *f, H5FS_t *fspace, haddr_t 
     } /* end if */
 
 done:
+    if (ret_value < 0) {
+        /* Remove the free space section that was inserted into the metadata cache,
+         * making sure to free the file space that was allocated for it as well.
+         * Avoid expunging the entry, as the information needs to be kept around
+         * until we finish trying to settle the metadata free space manager(s).
+         */
+        if (allocated_section && (sect_addr == fspace->sect_addr)) {
+            assert(H5_addr_defined(fspace->sect_addr));
+
+            if (H5MF_xfree(f, H5FD_MEM_FSPACE_SINFO, sect_addr, sinfo_alloc_size) < 0)
+                HDONE_ERROR(H5E_FSPACE, H5E_CANTFREE, FAIL, "unable to free free space sections");
+            fspace->sect_addr = HADDR_UNDEF;
+        }
+
+        if (inserted_section) {
+            if (H5AC_remove_entry(fspace->sinfo) < 0)
+                HDONE_ERROR(H5E_FSPACE, H5E_CANTEXPUNGE, FAIL,
+                            "can't remove file free space section from cache");
+        }
+
+        /* Remove the free space header that was inserted into the metadata cache,
+         * making sure to free the file space that was allocated for it as well.
+         * Avoid expunging the entry, as the information needs to be kept around
+         * until we finish trying to settle the metadata free space manager(s).
+         */
+        if (allocated_header) {
+            assert(H5_addr_defined(fspace->addr));
+
+            /* Free file space before removing entry from cache, as freeing the
+             * file space may depend on a valid cache pointer.
+             */
+            if (H5MF_xfree(f, H5FD_MEM_FSPACE_HDR, fspace->addr, hdr_alloc_size) < 0)
+                HDONE_ERROR(H5E_FSPACE, H5E_CANTFREE, FAIL, "unable to free file free space header");
+            fspace->addr = HADDR_UNDEF;
+        }
+
+        if (inserted_header) {
+            if (H5AC_mark_entry_clean(fspace) < 0)
+                HDONE_ERROR(H5E_FSPACE, H5E_CANTMARKCLEAN, FAIL,
+                            "can't mark file free space header as clean");
+            if (H5AC_unpin_entry(fspace) < 0)
+                HDONE_ERROR(H5E_FSPACE, H5E_CANTUNPIN, FAIL, "can't unpin file free space header");
+            if (H5AC_remove_entry(fspace) < 0)
+                HDONE_ERROR(H5E_FSPACE, H5E_CANTEXPUNGE, FAIL,
+                            "can't remove file free space header from cache");
+        }
+    }
+
     FUNC_LEAVE_NOAPI(ret_value)
 } /* H5FS_vfd_alloc_hdr_and_section_info_if_needed() */

--- a/src/H5HFspace.c
+++ b/src/H5HFspace.c
@@ -159,7 +159,7 @@ H5HF__space_add(H5HF_hdr_t *hdr, H5HF_free_section_t *node, unsigned flags)
     udata.hdr = hdr;
 
     /* Add to the free space for the heap */
-    if (H5FS_sect_add(hdr->f, hdr->fspace, (H5FS_section_info_t *)node, flags, &udata) < 0)
+    if (H5FS_sect_add(hdr->f, hdr->fspace, (H5FS_section_info_t *)node, flags, &udata, NULL) < 0)
         HGOTO_ERROR(H5E_HEAP, H5E_CANTINSERT, FAIL, "can't add section to heap free space");
 
 done:

--- a/src/H5MF.c
+++ b/src/H5MF.c
@@ -599,7 +599,8 @@ done:
  *-------------------------------------------------------------------------
  */
 herr_t
-H5MF__add_sect(H5F_t *f, H5FD_mem_t alloc_type, H5FS_t *fspace, H5MF_free_section_t *node)
+H5MF__add_sect(H5F_t *f, H5FD_mem_t alloc_type, H5FS_t *fspace, H5MF_free_section_t *node,
+               bool *merged_or_shrunk)
 {
     H5AC_ring_t    orig_ring = H5AC_RING_INV; /* Original ring value */
     H5AC_ring_t    fsm_ring  = H5AC_RING_INV; /* Ring of FSM */
@@ -631,7 +632,8 @@ H5MF__add_sect(H5F_t *f, H5FD_mem_t alloc_type, H5FS_t *fspace, H5MF_free_sectio
             __func__, node->sect_info.addr, node->sect_info.size);
 #endif /* H5MF_ALLOC_DEBUG_MORE */
     /* Add the section */
-    if (H5FS_sect_add(f, fspace, (H5FS_section_info_t *)node, H5FS_ADD_RETURNED_SPACE, &udata) < 0)
+    if (H5FS_sect_add(f, fspace, (H5FS_section_info_t *)node, H5FS_ADD_RETURNED_SPACE, &udata,
+                      merged_or_shrunk) < 0)
         HGOTO_ERROR(H5E_RESOURCE, H5E_CANTINSERT, FAIL, "can't re-add section to file free space");
 
 done:
@@ -711,8 +713,11 @@ H5MF__find_sect(H5F_t *f, H5FD_mem_t alloc_type, hsize_t size, H5FS_t *fspace, h
 #endif /* H5MF_ALLOC_DEBUG_MORE */
 
             /* Re-add the section to the free-space manager */
-            if (H5MF__add_sect(f, alloc_type, fspace, node) < 0)
+            if (H5MF__add_sect(f, alloc_type, fspace, node, NULL) < 0) {
+                node->sect_info.addr -= size;
+                node->sect_info.size += size;
                 HGOTO_ERROR(H5E_RESOURCE, H5E_CANTINSERT, FAIL, "can't re-add section to file free space");
+            }
         } /* end else */
     }     /* end if */
 
@@ -852,9 +857,10 @@ done:
 static haddr_t
 H5MF__alloc_pagefs(H5F_t *f, H5FD_mem_t alloc_type, hsize_t size)
 {
-    H5F_mem_page_t       ptype;                   /* Free-space manager type */
-    H5MF_free_section_t *node      = NULL;        /* Free space section pointer */
-    haddr_t              ret_value = HADDR_UNDEF; /* Return value */
+    H5F_mem_page_t       ptype;                     /* Free-space manager type */
+    H5MF_free_section_t *node        = NULL;        /* Free space section pointer */
+    bool    section_merged_or_shrunk = false;       /* Whether free space section was merged or shrunk away */
+    haddr_t ret_value                = HADDR_UNDEF; /* Return value */
 
     FUNC_ENTER_PACKAGE
 
@@ -900,9 +906,13 @@ H5MF__alloc_pagefs(H5F_t *f, H5FD_mem_t alloc_type, hsize_t size)
                                 "can't initialize free space section");
 
                 /* Add the fragment to the large free-space manager */
-                if (H5MF__add_sect(f, alloc_type, f->shared->fs_man[ptype], node) < 0)
+                if (H5MF__add_sect(f, alloc_type, f->shared->fs_man[ptype], node, &section_merged_or_shrunk) <
+                    0) {
+                    if (section_merged_or_shrunk)
+                        node = NULL;
                     HGOTO_ERROR(H5E_RESOURCE, H5E_CANTINSERT, HADDR_UNDEF,
                                 "can't re-add section to file free space");
+                }
 
                 node = NULL;
             } /* end if */
@@ -931,9 +941,13 @@ H5MF__alloc_pagefs(H5F_t *f, H5FD_mem_t alloc_type, hsize_t size)
                 HGOTO_ERROR(H5E_RESOURCE, H5E_CANTINIT, HADDR_UNDEF, "can't initialize free space section");
 
             /* Add the remaining space in the page to the manager */
-            if (H5MF__add_sect(f, alloc_type, f->shared->fs_man[ptype], node) < 0)
+            if (H5MF__add_sect(f, alloc_type, f->shared->fs_man[ptype], node, &section_merged_or_shrunk) <
+                0) {
+                if (section_merged_or_shrunk)
+                    node = NULL;
                 HGOTO_ERROR(H5E_RESOURCE, H5E_CANTINSERT, HADDR_UNDEF,
                             "can't re-add section to file free space");
+            }
 
             node = NULL;
 
@@ -1154,6 +1168,8 @@ H5MF_xfree(H5F_t *f, H5FD_mem_t alloc_type, haddr_t addr, hsize_t size)
 
     /* If size of the freed section is larger than threshold, add it to the free space manager */
     if (size >= f->shared->fs_threshold) {
+        bool section_merged_or_shrunk = false; /* Whether free space section was merged or shrunk away */
+
         assert(f->shared->fs_man[fs_type]);
 
 #ifdef H5MF_ALLOC_DEBUG_MORE
@@ -1161,8 +1177,12 @@ H5MF_xfree(H5F_t *f, H5FD_mem_t alloc_type, haddr_t addr, hsize_t size)
 #endif /* H5MF_ALLOC_DEBUG_MORE */
 
         /* Add to the free space for the file */
-        if (H5MF__add_sect(f, alloc_type, f->shared->fs_man[fs_type], node) < 0)
+        if (H5MF__add_sect(f, alloc_type, f->shared->fs_man[fs_type], node, &section_merged_or_shrunk) < 0) {
+            if (section_merged_or_shrunk)
+                node = NULL;
             HGOTO_ERROR(H5E_RESOURCE, H5E_CANTINSERT, FAIL, "can't add section to file free space");
+        }
+
         node = NULL;
 
 #ifdef H5MF_ALLOC_DEBUG_MORE
@@ -1316,7 +1336,7 @@ H5MF_try_extend(H5F_t *f, H5FD_mem_t alloc_type, haddr_t addr, hsize_t size, hsi
                 HGOTO_ERROR(H5E_RESOURCE, H5E_CANTINIT, FAIL, "can't initialize free space section");
 
             /* Add the fragment to the large-sized free-space manager */
-            if (H5MF__add_sect(f, alloc_type, f->shared->fs_man[fs_type], node) < 0)
+            if (H5MF__add_sect(f, alloc_type, f->shared->fs_man[fs_type], node, NULL) < 0)
                 HGOTO_ERROR(H5E_RESOURCE, H5E_CANTINSERT, FAIL, "can't re-add section to file free space");
 
             node = NULL;
@@ -3059,8 +3079,13 @@ H5MF_settle_meta_data_fsm(H5F_t *f, bool *fsm_settled)
         assert(sm_fssinfo_fs_type > H5F_MEM_PAGE_DEFAULT);
         assert(sm_fssinfo_fs_type < H5F_MEM_PAGE_LARGE_SUPER);
 
-        assert(!H5_addr_defined(f->shared->fs_addr[sm_fshdr_fs_type]));
-        assert(!H5_addr_defined(f->shared->fs_addr[sm_fssinfo_fs_type]));
+        if (H5_addr_defined(f->shared->fs_addr[sm_fshdr_fs_type]))
+            HGOTO_ERROR(H5E_FSPACE, H5E_BADVALUE, FAIL,
+                        "small free space header block manager should not have had file space allocated");
+        if (H5_addr_defined(f->shared->fs_addr[sm_fssinfo_fs_type]))
+            HGOTO_ERROR(
+                H5E_FSPACE, H5E_BADVALUE, FAIL,
+                "small free space serialized section manager should not have had file space allocated");
 
         /* Note that in most cases, sm_hdr_fspace will equal sm_sinfo_fspace. */
         sm_hdr_fspace   = f->shared->fs_man[sm_fshdr_fs_type];
@@ -3078,8 +3103,13 @@ H5MF_settle_meta_data_fsm(H5F_t *f, bool *fsm_settled)
             assert(lg_fssinfo_fs_type >= H5F_MEM_PAGE_LARGE_SUPER);
             assert(lg_fssinfo_fs_type < H5F_MEM_PAGE_NTYPES);
 
-            assert(!H5_addr_defined(f->shared->fs_addr[lg_fshdr_fs_type]));
-            assert(!H5_addr_defined(f->shared->fs_addr[lg_fssinfo_fs_type]));
+            if (H5_addr_defined(f->shared->fs_addr[lg_fshdr_fs_type]))
+                HGOTO_ERROR(H5E_FSPACE, H5E_BADVALUE, FAIL,
+                            "large free space header block manager should not have had file space allocated");
+            if (H5_addr_defined(f->shared->fs_addr[lg_fssinfo_fs_type]))
+                HGOTO_ERROR(
+                    H5E_FSPACE, H5E_BADVALUE, FAIL,
+                    "large free space serialized section manager should not have had file space allocated");
 
             /* Note that in most cases, lg_hdr_fspace will equal lg_sinfo_fspace. */
             lg_hdr_fspace   = f->shared->fs_man[lg_fshdr_fs_type];

--- a/src/H5MFpkg.h
+++ b/src/H5MFpkg.h
@@ -176,7 +176,8 @@ H5_DLLVAR const H5FS_section_class_t H5MF_FSPACE_SECT_CLS_LARGE[1];
 H5_DLL herr_t H5MF__open_fstype(H5F_t *f, H5F_mem_page_t type);
 H5_DLL herr_t H5MF__start_fstype(H5F_t *f, H5F_mem_page_t type);
 H5_DLL htri_t H5MF__find_sect(H5F_t *f, H5FD_mem_t alloc_type, hsize_t size, H5FS_t *fspace, haddr_t *addr);
-H5_DLL herr_t H5MF__add_sect(H5F_t *f, H5FD_mem_t alloc_type, H5FS_t *fspace, H5MF_free_section_t *node);
+H5_DLL herr_t H5MF__add_sect(H5F_t *f, H5FD_mem_t alloc_type, H5FS_t *fspace, H5MF_free_section_t *node,
+                             bool *merged_or_shrunk);
 H5_DLL void   H5MF__alloc_to_fs_type(H5F_shared_t *f_sh, H5FD_mem_t alloc_type, hsize_t size,
                                      H5F_mem_page_t *fs_type);
 

--- a/src/H5MFsection.c
+++ b/src/H5MFsection.c
@@ -360,7 +360,13 @@ H5MF__sect_simple_can_merge(const H5FS_section_info_t *_sect1, const H5FS_sectio
     assert(sect1);
     assert(sect2);
     assert(sect1->sect_info.type == sect2->sect_info.type); /* Checks "MERGE_SYM" flag */
-    assert(H5_addr_lt(sect1->sect_info.addr, sect2->sect_info.addr));
+
+    /*
+     * The library currently doesn't attempt to detect duplicate or overlapping
+     * free space sections being inserted into the free space managers. Until it
+     * does so, this assertion must be left out.
+     */
+    /* assert(H5_addr_lt(sect1->sect_info.addr, sect2->sect_info.addr)); */
 
     /* Check if second section adjoins first section */
     ret_value = H5_addr_eq(sect1->sect_info.addr + sect1->sect_info.size, sect2->sect_info.addr);
@@ -663,7 +669,13 @@ H5MF__sect_small_can_merge(const H5FS_section_info_t *_sect1, const H5FS_section
     assert(sect1);
     assert(sect2);
     assert(sect1->sect_info.type == sect2->sect_info.type); /* Checks "MERGE_SYM" flag */
-    assert(H5_addr_lt(sect1->sect_info.addr, sect2->sect_info.addr));
+
+    /*
+     * The library currently doesn't attempt to detect duplicate or overlapping
+     * free space sections being inserted into the free space managers. Until it
+     * does so, this assertion must be left out.
+     */
+    /* assert(H5_addr_lt(sect1->sect_info.addr, sect2->sect_info.addr)); */
 
     /* Check if second section adjoins first section */
     ret_value = H5_addr_eq(sect1->sect_info.addr + sect1->sect_info.size, sect2->sect_info.addr);
@@ -769,7 +781,13 @@ H5MF__sect_large_can_merge(const H5FS_section_info_t *_sect1, const H5FS_section
     assert(sect1);
     assert(sect2);
     assert(sect1->sect_info.type == sect2->sect_info.type); /* Checks "MERGE_SYM" flag */
-    assert(H5_addr_lt(sect1->sect_info.addr, sect2->sect_info.addr));
+
+    /*
+     * The library currently doesn't attempt to detect duplicate or overlapping
+     * free space sections being inserted into the free space managers. Until it
+     * does so, this assertion must be left out.
+     */
+    /* assert(H5_addr_lt(sect1->sect_info.addr, sect2->sect_info.addr)); */
 
     ret_value = H5_addr_eq(sect1->sect_info.addr + sect1->sect_info.size, sect2->sect_info.addr);
 

--- a/test/freespace.c
+++ b/test/freespace.c
@@ -638,7 +638,7 @@ test_fs_sect_add(hid_t fapl)
     init_sect_node(sect_node, (haddr_t)TEST_SECT_ADDR80, (hsize_t)TEST_SECT_SIZE20, TEST_FSPACE_SECT_TYPE,
                    H5FS_SECT_LIVE);
 
-    if (H5FS_sect_add(f, frsp, (H5FS_section_info_t *)sect_node, H5FS_ADD_RETURNED_SPACE, NULL) < 0)
+    if (H5FS_sect_add(f, frsp, (H5FS_section_info_t *)sect_node, H5FS_ADD_RETURNED_SPACE, NULL, NULL) < 0)
         FAIL_STACK_ERROR;
 
     memset(&state, 0, sizeof(frspace_state_t));
@@ -704,7 +704,7 @@ test_fs_sect_add(hid_t fapl)
     init_sect_node(sect_node, (haddr_t)TEST_SECT_ADDR80, (hsize_t)TEST_SECT_SIZE20, TEST_FSPACE_SECT_TYPE,
                    H5FS_SECT_LIVE);
 
-    if (H5FS_sect_add(f, frsp, (H5FS_section_info_t *)sect_node, 0, NULL) < 0)
+    if (H5FS_sect_add(f, frsp, (H5FS_section_info_t *)sect_node, 0, NULL, NULL) < 0)
         FAIL_STACK_ERROR;
 
     memset(&state, 0, sizeof(frspace_state_t));
@@ -781,7 +781,8 @@ test_fs_sect_add(hid_t fapl)
     init_sect_node(sect_node, (haddr_t)TEST_SECT_ADDR100, (hsize_t)TEST_SECT_SIZE50, TEST_FSPACE_SECT_TYPE,
                    H5FS_SECT_LIVE);
 
-    if (H5FS_sect_add(f, frsp, (H5FS_section_info_t *)sect_node, H5FS_ADD_RETURNED_SPACE, &can_shrink) < 0)
+    if (H5FS_sect_add(f, frsp, (H5FS_section_info_t *)sect_node, H5FS_ADD_RETURNED_SPACE, &can_shrink, NULL) <
+        0)
         FAIL_STACK_ERROR;
 
     /* nothing in free-space */
@@ -851,7 +852,8 @@ test_fs_sect_add(hid_t fapl)
     init_sect_node(sect_node, (haddr_t)TEST_SECT_ADDR100, (hsize_t)TEST_SECT_SIZE50, TEST_FSPACE_SECT_TYPE,
                    H5FS_SECT_LIVE);
 
-    if (H5FS_sect_add(f, frsp, (H5FS_section_info_t *)sect_node, H5FS_ADD_DESERIALIZING, &can_shrink) < 0)
+    if (H5FS_sect_add(f, frsp, (H5FS_section_info_t *)sect_node, H5FS_ADD_DESERIALIZING, &can_shrink, NULL) <
+        0)
         FAIL_STACK_ERROR;
 
     memset(&state, 0, sizeof(frspace_state_t));
@@ -1007,7 +1009,7 @@ test_fs_sect_find(hid_t fapl)
     init_sect_node(sect_node1, (haddr_t)TEST_SECT_ADDR60, (hsize_t)TEST_SECT_SIZE30, TEST_FSPACE_SECT_TYPE,
                    H5FS_SECT_LIVE);
 
-    if (H5FS_sect_add(f, frsp, (H5FS_section_info_t *)sect_node1, H5FS_ADD_RETURNED_SPACE, NULL) < 0)
+    if (H5FS_sect_add(f, frsp, (H5FS_section_info_t *)sect_node1, H5FS_ADD_RETURNED_SPACE, NULL, NULL) < 0)
         FAIL_STACK_ERROR;
 
     memset(&state, 0, sizeof(frspace_state_t));
@@ -1027,7 +1029,7 @@ test_fs_sect_find(hid_t fapl)
     init_sect_node(sect_node3, (haddr_t)(TEST_SECT_ADDR200), (hsize_t)TEST_SECT_SIZE50, TEST_FSPACE_SECT_TYPE,
                    H5FS_SECT_LIVE);
 
-    if (H5FS_sect_add(f, frsp, (H5FS_section_info_t *)sect_node3, H5FS_ADD_RETURNED_SPACE, NULL) < 0)
+    if (H5FS_sect_add(f, frsp, (H5FS_section_info_t *)sect_node3, H5FS_ADD_RETURNED_SPACE, NULL, NULL) < 0)
         FAIL_STACK_ERROR;
 
     state.tot_space += sect_node3->sect_info.size;
@@ -1046,7 +1048,7 @@ test_fs_sect_find(hid_t fapl)
     init_sect_node(sect_node2, (haddr_t)TEST_SECT_ADDR100, (hsize_t)TEST_SECT_SIZE50, TEST_FSPACE_SECT_TYPE,
                    H5FS_SECT_LIVE);
 
-    if (H5FS_sect_add(f, frsp, (H5FS_section_info_t *)sect_node2, H5FS_ADD_RETURNED_SPACE, NULL) < 0)
+    if (H5FS_sect_add(f, frsp, (H5FS_section_info_t *)sect_node2, H5FS_ADD_RETURNED_SPACE, NULL, NULL) < 0)
         FAIL_STACK_ERROR;
 
     state.tot_space += sect_node2->sect_info.size;
@@ -1065,7 +1067,7 @@ test_fs_sect_find(hid_t fapl)
     init_sect_node(sect_node4, (haddr_t)TEST_SECT_ADDR300, (hsize_t)TEST_SECT_SIZE80, TEST_FSPACE_SECT_TYPE,
                    H5FS_SECT_LIVE);
 
-    if (H5FS_sect_add(f, frsp, (H5FS_section_info_t *)sect_node4, H5FS_ADD_RETURNED_SPACE, NULL) < 0)
+    if (H5FS_sect_add(f, frsp, (H5FS_section_info_t *)sect_node4, H5FS_ADD_RETURNED_SPACE, NULL, NULL) < 0)
         FAIL_STACK_ERROR;
 
     state.tot_space += sect_node4->sect_info.size;
@@ -1134,7 +1136,7 @@ test_fs_sect_find(hid_t fapl)
     init_sect_node(sect_node1, (haddr_t)TEST_SECT_ADDR60, (hsize_t)TEST_SECT_SIZE30, TEST_FSPACE_SECT_TYPE,
                    H5FS_SECT_LIVE);
 
-    if (H5FS_sect_add(f, frsp, (H5FS_section_info_t *)sect_node1, H5FS_ADD_RETURNED_SPACE, NULL) < 0)
+    if (H5FS_sect_add(f, frsp, (H5FS_section_info_t *)sect_node1, H5FS_ADD_RETURNED_SPACE, NULL, NULL) < 0)
         FAIL_STACK_ERROR;
 
     memset(&state, 0, sizeof(frspace_state_t));
@@ -1154,7 +1156,7 @@ test_fs_sect_find(hid_t fapl)
     init_sect_node(sect_node2, (haddr_t)TEST_SECT_ADDR200, (hsize_t)TEST_SECT_SIZE80, TEST_FSPACE_SECT_TYPE,
                    H5FS_SECT_LIVE);
 
-    if (H5FS_sect_add(f, frsp, (H5FS_section_info_t *)sect_node2, H5FS_ADD_RETURNED_SPACE, NULL) < 0)
+    if (H5FS_sect_add(f, frsp, (H5FS_section_info_t *)sect_node2, H5FS_ADD_RETURNED_SPACE, NULL, NULL) < 0)
         FAIL_STACK_ERROR;
 
     state.tot_space += sect_node2->sect_info.size;
@@ -1213,7 +1215,7 @@ test_fs_sect_find(hid_t fapl)
     init_sect_node(sect_node1, (haddr_t)TEST_SECT_ADDR60, (hsize_t)TEST_SECT_SIZE30, TEST_FSPACE_SECT_TYPE,
                    H5FS_SECT_LIVE);
 
-    if (H5FS_sect_add(f, frsp, (H5FS_section_info_t *)sect_node1, H5FS_ADD_RETURNED_SPACE, NULL) < 0)
+    if (H5FS_sect_add(f, frsp, (H5FS_section_info_t *)sect_node1, H5FS_ADD_RETURNED_SPACE, NULL, NULL) < 0)
         FAIL_STACK_ERROR;
 
     memset(&state, 0, sizeof(frspace_state_t));
@@ -1361,7 +1363,7 @@ test_fs_sect_merge(hid_t fapl)
     init_sect_node(sect_node1, (haddr_t)TEST_SECT_ADDR100, (hsize_t)TEST_SECT_SIZE50, TEST_FSPACE_SECT_TYPE,
                    H5FS_SECT_LIVE);
 
-    if (H5FS_sect_add(f, frsp, (H5FS_section_info_t *)sect_node1, H5FS_ADD_RETURNED_SPACE, NULL) < 0)
+    if (H5FS_sect_add(f, frsp, (H5FS_section_info_t *)sect_node1, H5FS_ADD_RETURNED_SPACE, NULL, NULL) < 0)
         FAIL_STACK_ERROR;
 
     memset(&state, 0, sizeof(frspace_state_t));
@@ -1381,7 +1383,7 @@ test_fs_sect_merge(hid_t fapl)
     init_sect_node(sect_node2, (haddr_t)TEST_SECT_ADDR70, (hsize_t)TEST_SECT_SIZE30, TEST_FSPACE_SECT_TYPE,
                    H5FS_SECT_LIVE);
 
-    if (H5FS_sect_add(f, frsp, (H5FS_section_info_t *)sect_node2, H5FS_ADD_RETURNED_SPACE, NULL) < 0)
+    if (H5FS_sect_add(f, frsp, (H5FS_section_info_t *)sect_node2, H5FS_ADD_RETURNED_SPACE, NULL, NULL) < 0)
         FAIL_STACK_ERROR;
 
     /* section B & C are merged */
@@ -1399,7 +1401,7 @@ test_fs_sect_merge(hid_t fapl)
     init_sect_node(sect_node3, (haddr_t)TEST_SECT_ADDR60, (hsize_t)TEST_SECT_SIZE10, TEST_FSPACE_SECT_TYPE,
                    H5FS_SECT_LIVE);
 
-    if (H5FS_sect_add(f, frsp, (H5FS_section_info_t *)sect_node3, H5FS_ADD_RETURNED_SPACE, NULL) < 0)
+    if (H5FS_sect_add(f, frsp, (H5FS_section_info_t *)sect_node3, H5FS_ADD_RETURNED_SPACE, NULL, NULL) < 0)
         FAIL_STACK_ERROR;
 
     /* section A is merged with the merged section of B & C */
@@ -1417,7 +1419,7 @@ test_fs_sect_merge(hid_t fapl)
     init_sect_node(sect_node4, (haddr_t)TEST_SECT_ADDR150, (hsize_t)TEST_SECT_SIZE80, TEST_FSPACE_SECT_TYPE,
                    H5FS_SECT_LIVE);
 
-    if (H5FS_sect_add(f, frsp, (H5FS_section_info_t *)sect_node4, H5FS_ADD_RETURNED_SPACE, NULL) < 0)
+    if (H5FS_sect_add(f, frsp, (H5FS_section_info_t *)sect_node4, H5FS_ADD_RETURNED_SPACE, NULL, NULL) < 0)
         FAIL_STACK_ERROR;
 
     /* section D is merged with the merged section of A & B & C */
@@ -1490,7 +1492,7 @@ test_fs_sect_merge(hid_t fapl)
     init_sect_node(sect_node1, (haddr_t)TEST_SECT_ADDR70, (hsize_t)TEST_SECT_SIZE30, TEST_FSPACE_SECT_TYPE,
                    H5FS_SECT_LIVE);
 
-    if (H5FS_sect_add(f, frsp, (H5FS_section_info_t *)sect_node1, H5FS_ADD_RETURNED_SPACE, NULL) < 0)
+    if (H5FS_sect_add(f, frsp, (H5FS_section_info_t *)sect_node1, H5FS_ADD_RETURNED_SPACE, NULL, NULL) < 0)
         FAIL_STACK_ERROR;
 
     memset(&state, 0, sizeof(frspace_state_t));
@@ -1510,7 +1512,7 @@ test_fs_sect_merge(hid_t fapl)
     init_sect_node(sect_node2, (haddr_t)TEST_SECT_ADDR100, (hsize_t)TEST_SECT_SIZE50, TEST_FSPACE_SECT_TYPE,
                    H5FS_SECT_LIVE);
 
-    if (H5FS_sect_add(f, frsp, (H5FS_section_info_t *)sect_node2, H5FS_ADD_RETURNED_SPACE, NULL) < 0)
+    if (H5FS_sect_add(f, frsp, (H5FS_section_info_t *)sect_node2, H5FS_ADD_RETURNED_SPACE, NULL, NULL) < 0)
         FAIL_STACK_ERROR;
 
     /* section A & B are not merged because H5FS_CLS_SEPAR_OBJ is set */
@@ -1593,7 +1595,7 @@ test_fs_sect_merge(hid_t fapl)
     init_sect_node(sect_node1, (haddr_t)TEST_SECT_ADDR60, (hsize_t)TEST_SECT_SIZE10, TEST_FSPACE_SECT_TYPE,
                    H5FS_SECT_LIVE);
 
-    if (H5FS_sect_add(f, frsp, (H5FS_section_info_t *)sect_node1, H5FS_ADD_RETURNED_SPACE, NULL) < 0)
+    if (H5FS_sect_add(f, frsp, (H5FS_section_info_t *)sect_node1, H5FS_ADD_RETURNED_SPACE, NULL, NULL) < 0)
         FAIL_STACK_ERROR;
 
     memset(&state, 0, sizeof(frspace_state_t));
@@ -1613,7 +1615,7 @@ test_fs_sect_merge(hid_t fapl)
     init_sect_node(sect_node2, (haddr_t)TEST_SECT_ADDR70, (hsize_t)TEST_SECT_SIZE30,
                    TEST_FSPACE_SECT_TYPE_NEW, H5FS_SECT_LIVE);
 
-    if (H5FS_sect_add(f, frsp, (H5FS_section_info_t *)sect_node2, H5FS_ADD_RETURNED_SPACE, NULL) < 0)
+    if (H5FS_sect_add(f, frsp, (H5FS_section_info_t *)sect_node2, H5FS_ADD_RETURNED_SPACE, NULL, NULL) < 0)
         FAIL_STACK_ERROR;
 
     /* sections A & B are not merged because H5FS_CLS_MERGE_SYM is set & section class type is different */
@@ -1633,7 +1635,7 @@ test_fs_sect_merge(hid_t fapl)
     init_sect_node(sect_node3, (haddr_t)TEST_SECT_ADDR100, (hsize_t)TEST_SECT_SIZE50,
                    TEST_FSPACE_SECT_TYPE_NEW, H5FS_SECT_LIVE);
 
-    if (H5FS_sect_add(f, frsp, (H5FS_section_info_t *)sect_node3, H5FS_ADD_RETURNED_SPACE, NULL) < 0)
+    if (H5FS_sect_add(f, frsp, (H5FS_section_info_t *)sect_node3, H5FS_ADD_RETURNED_SPACE, NULL, NULL) < 0)
         FAIL_STACK_ERROR;
 
     /* sections B & C are merged because H5FS_CLS_MERGE_SYM is set & section class type is the same */
@@ -1651,7 +1653,7 @@ test_fs_sect_merge(hid_t fapl)
     init_sect_node(sect_node4, (haddr_t)TEST_SECT_ADDR150, (hsize_t)TEST_SECT_SIZE80, TEST_FSPACE_SECT_TYPE,
                    H5FS_SECT_LIVE);
 
-    if (H5FS_sect_add(f, frsp, (H5FS_section_info_t *)sect_node4, H5FS_ADD_RETURNED_SPACE, NULL) < 0)
+    if (H5FS_sect_add(f, frsp, (H5FS_section_info_t *)sect_node4, H5FS_ADD_RETURNED_SPACE, NULL, NULL) < 0)
         FAIL_STACK_ERROR;
 
     /*
@@ -1840,7 +1842,8 @@ test_fs_sect_shrink(hid_t fapl)
                    TEST_FSPACE_SECT_TYPE_NEW, H5FS_SECT_LIVE);
 
     can_shrink = false;
-    if (H5FS_sect_add(f, frsp, (H5FS_section_info_t *)sect_node1, H5FS_ADD_RETURNED_SPACE, &can_shrink) < 0)
+    if (H5FS_sect_add(f, frsp, (H5FS_section_info_t *)sect_node1, H5FS_ADD_RETURNED_SPACE, &can_shrink,
+                      NULL) < 0)
         FAIL_STACK_ERROR;
 
     memset(&state, 0, sizeof(frspace_state_t));
@@ -1875,7 +1878,8 @@ test_fs_sect_shrink(hid_t fapl)
                    H5FS_SECT_LIVE);
 
     can_shrink = false;
-    if (H5FS_sect_add(f, frsp, (H5FS_section_info_t *)sect_node1, H5FS_ADD_RETURNED_SPACE, &can_shrink) < 0)
+    if (H5FS_sect_add(f, frsp, (H5FS_section_info_t *)sect_node1, H5FS_ADD_RETURNED_SPACE, &can_shrink,
+                      NULL) < 0)
         FAIL_STACK_ERROR;
 
     /* should have nothing in free-space */
@@ -1941,7 +1945,8 @@ test_fs_sect_shrink(hid_t fapl)
     init_sect_node(sect_node1, (haddr_t)TEST_SECT_ADDR80, (hsize_t)TEST_SECT_SIZE20, TEST_FSPACE_SECT_TYPE,
                    H5FS_SECT_LIVE);
 
-    if (H5FS_sect_add(f, frsp, (H5FS_section_info_t *)sect_node1, H5FS_ADD_RETURNED_SPACE, &can_shrink) < 0)
+    if (H5FS_sect_add(f, frsp, (H5FS_section_info_t *)sect_node1, H5FS_ADD_RETURNED_SPACE, &can_shrink,
+                      NULL) < 0)
         FAIL_STACK_ERROR;
 
     memset(&state, 0, sizeof(frspace_state_t));
@@ -1961,7 +1966,8 @@ test_fs_sect_shrink(hid_t fapl)
     init_sect_node(sect_node2, (haddr_t)TEST_SECT_ADDR100, (hsize_t)TEST_SECT_SIZE50, TEST_FSPACE_SECT_TYPE,
                    H5FS_SECT_LIVE);
 
-    if (H5FS_sect_add(f, frsp, (H5FS_section_info_t *)sect_node2, H5FS_ADD_RETURNED_SPACE, &can_shrink) < 0)
+    if (H5FS_sect_add(f, frsp, (H5FS_section_info_t *)sect_node2, H5FS_ADD_RETURNED_SPACE, &can_shrink,
+                      NULL) < 0)
         FAIL_STACK_ERROR;
 
     /* free-space should be the same since section B is shrunk */
@@ -2041,7 +2047,8 @@ test_fs_sect_shrink(hid_t fapl)
     init_sect_node(sect_node1, (haddr_t)TEST_SECT_ADDR70, (hsize_t)TEST_SECT_SIZE30, TEST_FSPACE_SECT_TYPE,
                    H5FS_SECT_LIVE);
 
-    if (H5FS_sect_add(f, frsp, (H5FS_section_info_t *)sect_node1, H5FS_ADD_RETURNED_SPACE, &can_shrink) < 0)
+    if (H5FS_sect_add(f, frsp, (H5FS_section_info_t *)sect_node1, H5FS_ADD_RETURNED_SPACE, &can_shrink,
+                      NULL) < 0)
         FAIL_STACK_ERROR;
 
     memset(&state, 0, sizeof(frspace_state_t));
@@ -2061,7 +2068,8 @@ test_fs_sect_shrink(hid_t fapl)
     init_sect_node(sect_node2, (haddr_t)TEST_SECT_ADDR100, (hsize_t)TEST_SECT_SIZE50, TEST_FSPACE_SECT_TYPE,
                    H5FS_SECT_LIVE);
 
-    if (H5FS_sect_add(f, frsp, (H5FS_section_info_t *)sect_node2, H5FS_ADD_RETURNED_SPACE, &can_shrink) < 0)
+    if (H5FS_sect_add(f, frsp, (H5FS_section_info_t *)sect_node2, H5FS_ADD_RETURNED_SPACE, &can_shrink,
+                      NULL) < 0)
         FAIL_STACK_ERROR;
 
     /* section A & B are merged and then strunk, so there is nothing in free-space */
@@ -2183,7 +2191,7 @@ test_fs_sect_change_class(hid_t fapl)
     init_sect_node(sect_node1, (haddr_t)TEST_SECT_ADDR60, (hsize_t)TEST_SECT_SIZE30, TEST_FSPACE_SECT_TYPE,
                    H5FS_SECT_LIVE);
 
-    if (H5FS_sect_add(f, frsp, (H5FS_section_info_t *)sect_node1, H5FS_ADD_RETURNED_SPACE, NULL) < 0)
+    if (H5FS_sect_add(f, frsp, (H5FS_section_info_t *)sect_node1, H5FS_ADD_RETURNED_SPACE, NULL, NULL) < 0)
         FAIL_STACK_ERROR;
 
     memset(&state, 0, sizeof(frspace_state_t));
@@ -2203,7 +2211,7 @@ test_fs_sect_change_class(hid_t fapl)
     init_sect_node(sect_node2, (haddr_t)TEST_SECT_ADDR100, (hsize_t)TEST_SECT_SIZE50,
                    TEST_FSPACE_SECT_TYPE_NONE, H5FS_SECT_LIVE);
 
-    if (H5FS_sect_add(f, frsp, (H5FS_section_info_t *)sect_node2, H5FS_ADD_RETURNED_SPACE, NULL) < 0)
+    if (H5FS_sect_add(f, frsp, (H5FS_section_info_t *)sect_node2, H5FS_ADD_RETURNED_SPACE, NULL, NULL) < 0)
         FAIL_STACK_ERROR;
 
     state.tot_space += TEST_SECT_SIZE50;
@@ -2287,7 +2295,7 @@ test_fs_sect_change_class(hid_t fapl)
     init_sect_node(sect_node1, (haddr_t)TEST_SECT_ADDR70, (hsize_t)TEST_SECT_SIZE30, TEST_FSPACE_SECT_TYPE,
                    H5FS_SECT_LIVE);
 
-    if (H5FS_sect_add(f, frsp, (H5FS_section_info_t *)sect_node1, H5FS_ADD_RETURNED_SPACE, NULL) < 0)
+    if (H5FS_sect_add(f, frsp, (H5FS_section_info_t *)sect_node1, H5FS_ADD_RETURNED_SPACE, NULL, NULL) < 0)
         FAIL_STACK_ERROR;
 
     /*
@@ -2299,7 +2307,7 @@ test_fs_sect_change_class(hid_t fapl)
     init_sect_node(sect_node2, (haddr_t)TEST_SECT_ADDR100, (hsize_t)TEST_SECT_SIZE50,
                    TEST_FSPACE_SECT_TYPE_NONE, H5FS_SECT_LIVE);
 
-    if (H5FS_sect_add(f, frsp, (H5FS_section_info_t *)sect_node2, H5FS_ADD_RETURNED_SPACE, NULL) < 0)
+    if (H5FS_sect_add(f, frsp, (H5FS_section_info_t *)sect_node2, H5FS_ADD_RETURNED_SPACE, NULL, NULL) < 0)
         FAIL_STACK_ERROR;
 
     /*
@@ -2311,7 +2319,7 @@ test_fs_sect_change_class(hid_t fapl)
     init_sect_node(sect_node3, (haddr_t)TEST_SECT_ADDR200, (hsize_t)TEST_SECT_SIZE80,
                    TEST_FSPACE_SECT_TYPE_NONE, H5FS_SECT_LIVE);
 
-    if (H5FS_sect_add(f, frsp, (H5FS_section_info_t *)sect_node3, H5FS_ADD_RETURNED_SPACE, NULL) < 0)
+    if (H5FS_sect_add(f, frsp, (H5FS_section_info_t *)sect_node3, H5FS_ADD_RETURNED_SPACE, NULL, NULL) < 0)
         FAIL_STACK_ERROR;
 
     /* change the class of B to A's class */
@@ -2471,7 +2479,7 @@ test_fs_sect_extend(hid_t fapl)
     init_sect_node(sect_node1, (haddr_t)TEST_SECT_ADDR70, (hsize_t)TEST_SECT_SIZE5, TEST_FSPACE_SECT_TYPE,
                    H5FS_SECT_LIVE);
 
-    if (H5FS_sect_add(f, frsp, (H5FS_section_info_t *)sect_node1, H5FS_ADD_RETURNED_SPACE, NULL) < 0)
+    if (H5FS_sect_add(f, frsp, (H5FS_section_info_t *)sect_node1, H5FS_ADD_RETURNED_SPACE, NULL, NULL) < 0)
         FAIL_STACK_ERROR;
 
     memset(&state, 0, sizeof(frspace_state_t));
@@ -2491,7 +2499,7 @@ test_fs_sect_extend(hid_t fapl)
     init_sect_node(sect_node2, (haddr_t)TEST_SECT_ADDR100, (hsize_t)TEST_SECT_SIZE40, TEST_FSPACE_SECT_TYPE,
                    H5FS_SECT_LIVE);
 
-    if (H5FS_sect_add(f, frsp, (H5FS_section_info_t *)sect_node2, H5FS_ADD_RETURNED_SPACE, NULL) < 0)
+    if (H5FS_sect_add(f, frsp, (H5FS_section_info_t *)sect_node2, H5FS_ADD_RETURNED_SPACE, NULL, NULL) < 0)
         FAIL_STACK_ERROR;
 
     state.tot_space += sect_node2->sect_info.size;
@@ -2548,7 +2556,7 @@ test_fs_sect_extend(hid_t fapl)
     init_sect_node(sect_node1, (haddr_t)TEST_SECT_ADDR70, (hsize_t)TEST_SECT_SIZE5, TEST_FSPACE_SECT_TYPE,
                    H5FS_SECT_LIVE);
 
-    if (H5FS_sect_add(f, frsp, (H5FS_section_info_t *)sect_node1, H5FS_ADD_RETURNED_SPACE, NULL) < 0)
+    if (H5FS_sect_add(f, frsp, (H5FS_section_info_t *)sect_node1, H5FS_ADD_RETURNED_SPACE, NULL, NULL) < 0)
         FAIL_STACK_ERROR;
 
     memset(&state, 0, sizeof(frspace_state_t));
@@ -2568,7 +2576,7 @@ test_fs_sect_extend(hid_t fapl)
     init_sect_node(sect_node2, (haddr_t)TEST_SECT_ADDR100, (hsize_t)TEST_SECT_SIZE40, TEST_FSPACE_SECT_TYPE,
                    H5FS_SECT_LIVE);
 
-    if (H5FS_sect_add(f, frsp, (H5FS_section_info_t *)sect_node2, H5FS_ADD_RETURNED_SPACE, NULL) < 0)
+    if (H5FS_sect_add(f, frsp, (H5FS_section_info_t *)sect_node2, H5FS_ADD_RETURNED_SPACE, NULL, NULL) < 0)
         FAIL_STACK_ERROR;
 
     state.tot_space += sect_node2->sect_info.size;
@@ -2622,7 +2630,7 @@ test_fs_sect_extend(hid_t fapl)
     init_sect_node(sect_node1, (haddr_t)TEST_SECT_ADDR70, (hsize_t)TEST_SECT_SIZE5, TEST_FSPACE_SECT_TYPE,
                    H5FS_SECT_LIVE);
 
-    if (H5FS_sect_add(f, frsp, (H5FS_section_info_t *)sect_node1, H5FS_ADD_RETURNED_SPACE, NULL) < 0)
+    if (H5FS_sect_add(f, frsp, (H5FS_section_info_t *)sect_node1, H5FS_ADD_RETURNED_SPACE, NULL, NULL) < 0)
         FAIL_STACK_ERROR;
 
     memset(&state, 0, sizeof(frspace_state_t));
@@ -2642,7 +2650,7 @@ test_fs_sect_extend(hid_t fapl)
     init_sect_node(sect_node2, (haddr_t)TEST_SECT_ADDR100, (hsize_t)TEST_SECT_SIZE40, TEST_FSPACE_SECT_TYPE,
                    H5FS_SECT_LIVE);
 
-    if (H5FS_sect_add(f, frsp, (H5FS_section_info_t *)sect_node2, H5FS_ADD_RETURNED_SPACE, NULL) < 0)
+    if (H5FS_sect_add(f, frsp, (H5FS_section_info_t *)sect_node2, H5FS_ADD_RETURNED_SPACE, NULL, NULL) < 0)
         FAIL_STACK_ERROR;
 
     state.tot_space += sect_node2->sect_info.size;
@@ -2697,7 +2705,7 @@ test_fs_sect_extend(hid_t fapl)
     init_sect_node(sect_node1, (haddr_t)TEST_SECT_ADDR70, (hsize_t)TEST_SECT_SIZE5, TEST_FSPACE_SECT_TYPE,
                    H5FS_SECT_LIVE);
 
-    if (H5FS_sect_add(f, frsp, (H5FS_section_info_t *)sect_node1, H5FS_ADD_RETURNED_SPACE, NULL) < 0)
+    if (H5FS_sect_add(f, frsp, (H5FS_section_info_t *)sect_node1, H5FS_ADD_RETURNED_SPACE, NULL, NULL) < 0)
         FAIL_STACK_ERROR;
 
     memset(&state, 0, sizeof(frspace_state_t));
@@ -2717,7 +2725,7 @@ test_fs_sect_extend(hid_t fapl)
     init_sect_node(sect_node2, (haddr_t)TEST_SECT_ADDR100, (hsize_t)TEST_SECT_SIZE40, TEST_FSPACE_SECT_TYPE,
                    H5FS_SECT_LIVE);
 
-    if (H5FS_sect_add(f, frsp, (H5FS_section_info_t *)sect_node2, H5FS_ADD_RETURNED_SPACE, NULL) < 0)
+    if (H5FS_sect_add(f, frsp, (H5FS_section_info_t *)sect_node2, H5FS_ADD_RETURNED_SPACE, NULL, NULL) < 0)
         FAIL_STACK_ERROR;
 
     state.tot_space += sect_node2->sect_info.size;
@@ -2828,7 +2836,7 @@ test_fs_sect_iterate(hid_t fapl)
         sect_size = (unsigned)((i - 1) % 9) + 1;
         init_sect_node(sect_node, (haddr_t)i * 10, (hsize_t)sect_size, TEST_FSPACE_SECT_TYPE, H5FS_SECT_LIVE);
 
-        if (H5FS_sect_add(f, frsp, (H5FS_section_info_t *)sect_node, H5FS_ADD_RETURNED_SPACE, NULL) < 0)
+        if (H5FS_sect_add(f, frsp, (H5FS_section_info_t *)sect_node, H5FS_ADD_RETURNED_SPACE, NULL, NULL) < 0)
             FAIL_STACK_ERROR;
     } /* end for */
 

--- a/test/mf.c
+++ b/test/mf.c
@@ -1222,7 +1222,7 @@ test_mf_fs_alloc_free(hid_t fapl)
     sect_node = H5MF__sect_new(H5MF_FSPACE_SECT_SIMPLE, (haddr_t)TBLOCK_ADDR70, (hsize_t)TBLOCK_SIZE30);
 
     /* Add section A to free-space manager */
-    if (H5MF__add_sect(f, H5FD_MEM_SUPER, f->shared->fs_man[H5FD_MEM_SUPER], sect_node))
+    if (H5MF__add_sect(f, H5FD_MEM_SUPER, f->shared->fs_man[H5FD_MEM_SUPER], sect_node, NULL))
         FAIL_STACK_ERROR;
 
     memset(&state, 0, sizeof(H5FS_stat_t));
@@ -1300,7 +1300,7 @@ test_mf_fs_alloc_free(hid_t fapl)
     sect_node = H5MF__sect_new(H5MF_FSPACE_SECT_SIMPLE, (haddr_t)TBLOCK_ADDR70, (hsize_t)TBLOCK_SIZE30);
 
     /* Add section A to free-space manager */
-    if (H5MF__add_sect(f, H5FD_MEM_SUPER, f->shared->fs_man[H5FD_MEM_SUPER], sect_node))
+    if (H5MF__add_sect(f, H5FD_MEM_SUPER, f->shared->fs_man[H5FD_MEM_SUPER], sect_node, NULL))
         FAIL_STACK_ERROR;
 
     memset(&state, 0, sizeof(H5FS_stat_t));
@@ -1376,7 +1376,7 @@ test_mf_fs_alloc_free(hid_t fapl)
     sect_node = H5MF__sect_new(H5MF_FSPACE_SECT_SIMPLE, (haddr_t)TBLOCK_ADDR70, (hsize_t)TBLOCK_SIZE30);
 
     /* Add section A to free-space manager */
-    if (H5MF__add_sect(f, H5FD_MEM_SUPER, f->shared->fs_man[H5FD_MEM_SUPER], sect_node))
+    if (H5MF__add_sect(f, H5FD_MEM_SUPER, f->shared->fs_man[H5FD_MEM_SUPER], sect_node, NULL))
         FAIL_STACK_ERROR;
 
     memset(&state, 0, sizeof(H5FS_stat_t));
@@ -1552,7 +1552,7 @@ test_mf_fs_extend(hid_t fapl)
     sect_node1 = H5MF__sect_new(H5MF_FSPACE_SECT_SIMPLE, (haddr_t)TBLOCK_ADDR70, (hsize_t)TBLOCK_SIZE30);
 
     /* Add section A to free-space manager */
-    if (H5MF__add_sect(f, H5FD_MEM_SUPER, f->shared->fs_man[H5FD_MEM_SUPER], sect_node1))
+    if (H5MF__add_sect(f, H5FD_MEM_SUPER, f->shared->fs_man[H5FD_MEM_SUPER], sect_node1, NULL))
         FAIL_STACK_ERROR;
 
     memset(&state, 0, sizeof(H5FS_stat_t));
@@ -1581,7 +1581,7 @@ test_mf_fs_extend(hid_t fapl)
     sect_node2 = H5MF__sect_new(H5MF_FSPACE_SECT_SIMPLE, (haddr_t)TBLOCK_ADDR100, (hsize_t)TBLOCK_SIZE50);
 
     /* Add section B to free-space manager */
-    if (H5MF__add_sect(f, H5FD_MEM_SUPER, f->shared->fs_man[H5FD_MEM_SUPER], sect_node2))
+    if (H5MF__add_sect(f, H5FD_MEM_SUPER, f->shared->fs_man[H5FD_MEM_SUPER], sect_node2, NULL))
         FAIL_STACK_ERROR;
 
     state.tot_space += TBLOCK_SIZE50;
@@ -1662,7 +1662,7 @@ test_mf_fs_extend(hid_t fapl)
     sect_node1 = H5MF__sect_new(H5MF_FSPACE_SECT_SIMPLE, (haddr_t)TBLOCK_ADDR70, (hsize_t)TBLOCK_SIZE30);
 
     /* Add section A to free-space manager */
-    if (H5MF__add_sect(f, H5FD_MEM_SUPER, f->shared->fs_man[H5FD_MEM_SUPER], sect_node1))
+    if (H5MF__add_sect(f, H5FD_MEM_SUPER, f->shared->fs_man[H5FD_MEM_SUPER], sect_node1, NULL))
         FAIL_STACK_ERROR;
 
     memset(&state, 0, sizeof(H5FS_stat_t));
@@ -1691,7 +1691,7 @@ test_mf_fs_extend(hid_t fapl)
     sect_node2 = H5MF__sect_new(H5MF_FSPACE_SECT_SIMPLE, (haddr_t)TBLOCK_ADDR100, (hsize_t)TBLOCK_SIZE50);
 
     /* Add section B to free-space manager */
-    if (H5MF__add_sect(f, H5FD_MEM_SUPER, f->shared->fs_man[H5FD_MEM_SUPER], sect_node2))
+    if (H5MF__add_sect(f, H5FD_MEM_SUPER, f->shared->fs_man[H5FD_MEM_SUPER], sect_node2, NULL))
         FAIL_STACK_ERROR;
 
     state.tot_space += TBLOCK_SIZE50;
@@ -1767,7 +1767,7 @@ test_mf_fs_extend(hid_t fapl)
     sect_node1 = H5MF__sect_new(H5MF_FSPACE_SECT_SIMPLE, (haddr_t)TBLOCK_ADDR70, (hsize_t)TBLOCK_SIZE30);
 
     /* Add section A to free-space manager */
-    if (H5MF__add_sect(f, H5FD_MEM_SUPER, f->shared->fs_man[H5FD_MEM_SUPER], sect_node1))
+    if (H5MF__add_sect(f, H5FD_MEM_SUPER, f->shared->fs_man[H5FD_MEM_SUPER], sect_node1, NULL))
         FAIL_STACK_ERROR;
 
     memset(&state, 0, sizeof(H5FS_stat_t));
@@ -1796,7 +1796,7 @@ test_mf_fs_extend(hid_t fapl)
     sect_node2 = H5MF__sect_new(H5MF_FSPACE_SECT_SIMPLE, (haddr_t)TBLOCK_ADDR100, (hsize_t)TBLOCK_SIZE50);
 
     /* Add section B to free-space manager */
-    if (H5MF__add_sect(f, H5FD_MEM_SUPER, f->shared->fs_man[H5FD_MEM_SUPER], sect_node2))
+    if (H5MF__add_sect(f, H5FD_MEM_SUPER, f->shared->fs_man[H5FD_MEM_SUPER], sect_node2, NULL))
         FAIL_STACK_ERROR;
 
     state.tot_space += TBLOCK_SIZE50;
@@ -1873,7 +1873,7 @@ test_mf_fs_extend(hid_t fapl)
         H5MF__sect_new(H5MF_FSPACE_SECT_SIMPLE, (haddr_t)TBLOCK_ADDR70, (hsize_t)(TBLOCK_SIZE30 - 10));
 
     /* Add section A of size=20 to free-space */
-    if (H5MF__add_sect(f, H5FD_MEM_SUPER, f->shared->fs_man[H5FD_MEM_SUPER], sect_node1))
+    if (H5MF__add_sect(f, H5FD_MEM_SUPER, f->shared->fs_man[H5FD_MEM_SUPER], sect_node1, NULL))
         FAIL_STACK_ERROR;
 
     memset(&state, 0, sizeof(H5FS_stat_t));
@@ -1902,7 +1902,7 @@ test_mf_fs_extend(hid_t fapl)
     sect_node2 = H5MF__sect_new(H5MF_FSPACE_SECT_SIMPLE, (haddr_t)TBLOCK_ADDR100, (hsize_t)TBLOCK_SIZE50);
 
     /* Add section B to free-space manager */
-    if (H5MF__add_sect(f, H5FD_MEM_SUPER, f->shared->fs_man[H5FD_MEM_SUPER], sect_node2))
+    if (H5MF__add_sect(f, H5FD_MEM_SUPER, f->shared->fs_man[H5FD_MEM_SUPER], sect_node2, NULL))
         FAIL_STACK_ERROR;
 
     state.tot_space += TBLOCK_SIZE50;
@@ -2057,7 +2057,7 @@ test_mf_fs_absorb(const char *driver_name, hid_t fapl)
             H5MF__sect_new(H5MF_FSPACE_SECT_SIMPLE, (haddr_t)(ma_addr + ma_size), (hsize_t)TBLOCK_SIZE2048);
 
         /* Add a section to free-space that adjoins end of the aggregator */
-        if (H5MF__add_sect(f, H5FD_MEM_SUPER, f->shared->fs_man[H5FD_MEM_SUPER], sect_node))
+        if (H5MF__add_sect(f, H5FD_MEM_SUPER, f->shared->fs_man[H5FD_MEM_SUPER], sect_node, NULL))
             FAIL_STACK_ERROR;
 
         /* Verify that the section did absorb the aggregator */
@@ -2117,7 +2117,7 @@ test_mf_fs_absorb(const char *driver_name, hid_t fapl)
         sect_node = H5MF__sect_new(H5MF_FSPACE_SECT_SIMPLE, (haddr_t)addr, (hsize_t)TBLOCK_SIZE30);
 
         /* When adding, meta_aggr is absorbed onto the end of the section */
-        if (H5MF__add_sect(f, H5FD_MEM_SUPER, f->shared->fs_man[H5FD_MEM_SUPER], sect_node))
+        if (H5MF__add_sect(f, H5FD_MEM_SUPER, f->shared->fs_man[H5FD_MEM_SUPER], sect_node, NULL))
             FAIL_STACK_ERROR;
 
         /* Verify that the section did absorb the aggregator */
@@ -4183,7 +4183,7 @@ test_mf_align_fs(const char *driver_name, hid_t fapl, hid_t new_fapl)
     sect_node = H5MF__sect_new(H5MF_FSPACE_SECT_SIMPLE, (haddr_t)alignment, (hsize_t)TBLOCK_SIZE50);
 
     /* Add section A to free-space manager */
-    if (H5MF__add_sect(f, H5FD_MEM_SUPER, f->shared->fs_man[H5FD_MEM_SUPER], sect_node))
+    if (H5MF__add_sect(f, H5FD_MEM_SUPER, f->shared->fs_man[H5FD_MEM_SUPER], sect_node, NULL))
         FAIL_STACK_ERROR;
 
     memset(&state, 0, sizeof(H5FS_stat_t));
@@ -4247,7 +4247,7 @@ test_mf_align_fs(const char *driver_name, hid_t fapl, hid_t new_fapl)
     sect_node = H5MF__sect_new(H5MF_FSPACE_SECT_SIMPLE, (haddr_t)TBLOCK_ADDR70, (hsize_t)TBLOCK_SIZE8000);
 
     /* Add section A to free-space manager */
-    if (H5MF__add_sect(f, H5FD_MEM_SUPER, f->shared->fs_man[H5FD_MEM_SUPER], sect_node))
+    if (H5MF__add_sect(f, H5FD_MEM_SUPER, f->shared->fs_man[H5FD_MEM_SUPER], sect_node, NULL))
         FAIL_STACK_ERROR;
 
     memset(&state, 0, sizeof(H5FS_stat_t));
@@ -4334,7 +4334,7 @@ test_mf_align_fs(const char *driver_name, hid_t fapl, hid_t new_fapl)
         sect_node = H5MF__sect_new(H5MF_FSPACE_SECT_SIMPLE, (haddr_t)TBLOCK_ADDR70, (hsize_t)TBLOCK_SIZE700);
 
         /* Add section A to free-space manager */
-        if (H5MF__add_sect(f, H5FD_MEM_SUPER, f->shared->fs_man[H5FD_MEM_SUPER], sect_node))
+        if (H5MF__add_sect(f, H5FD_MEM_SUPER, f->shared->fs_man[H5FD_MEM_SUPER], sect_node, NULL))
             FAIL_STACK_ERROR;
 
         memset(&state, 0, sizeof(H5FS_stat_t));


### PR DESCRIPTION
Fixes several crashes/assertion failures related to CVE-2025-7067
<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Fixes CVE-2025-7067 issues by updating `H5FS_sect_add` to handle section merging/shrinking and improving error handling.
> 
>   - **Functionality**:
>     - `H5FS_sect_add` in `H5FSsection.c` now accepts an additional `bool *merged_or_shrunk` parameter to track if sections are merged or shrunk.
>     - Updates to `H5MF__add_sect` in `H5MF.c` to handle `merged_or_shrunk` parameter.
>   - **Error Handling**:
>     - Improved error handling in `H5FS_vfd_alloc_hdr_and_section_info_if_needed` in `H5MF.c` to manage allocation failures.
>   - **Tests**:
>     - Updated test cases in `freespace.c` and `mf.c` to include the new parameter in `H5FS_sect_add` calls.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=HDFGroup%2Fhdf5&utm_source=github&utm_medium=referral)<sup> for ef61da4e905d542a72bed8fccfb9fcba59e60d31. You can [customize](https://app.ellipsis.dev/HDFGroup/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->