### PR TITLE
Changes to print structured chunk storage info for h5dump.

### DIFF
--- a/tools/lib/h5tools.h
+++ b/tools/lib/h5tools.h
@@ -88,6 +88,7 @@
 #define CONTIGUOUS         "CONTIGUOUS"
 #define COMPACT            "COMPACT"
 #define CHUNKED            "CHUNKED"
+#define STRUCT_CHUNKED     "STRUCTURED CHUNK"
 #define EXTERNAL_FILE      "EXTERNAL_FILE"
 #define FILLVALUE          "FILLVALUE"
 #define FILE_CONTENTS      "FILE_CONTENTS"

--- a/tools/lib/h5tools_dump.c
+++ b/tools/lib/h5tools_dump.c
@@ -3196,8 +3196,8 @@ h5tools_dump_dcpl(FILE *stream, const h5tool_format_t *info, h5tools_context_t *
     hsize_t          chsize[64];    /* chunk size in elements */
     hsize_t          size;          /* size of external file   */
     hsize_t          storage_size;
-    hsize_t          curr_pos = 0; /* total data element position   */
-    h5tools_str_t    buffer;       /* string into which to render   */
+    hsize_t          curr_pos = 0;   /* total data element position   */
+    h5tools_str_t    buffer;         /* string into which to render   */
     unsigned         str_chunk_flag; /* type og structired chunk     */
 
     /* setup */
@@ -3226,7 +3226,7 @@ h5tools_dump_dcpl(FILE *stream, const h5tool_format_t *info, h5tools_context_t *
 
     switch (stl) {
         case H5D_STRUCT_CHUNK:
-	        ctx->indent_level++;
+            ctx->indent_level++;
             ctx->need_prefix = true;
 
             h5tools_str_reset(&buffer);
@@ -3243,7 +3243,7 @@ h5tools_dump_dcpl(FILE *stream, const h5tool_format_t *info, h5tools_context_t *
 
             ctx->need_prefix = true;
 
-            h5tools_str_reset(&buffer); 
+            h5tools_str_reset(&buffer);
             h5tools_str_append(&buffer, "SIZE %" PRIuHSIZE, storage_size);
             h5tools_render_element(stream, info, ctx, &buffer, &curr_pos, (size_t)ncols, (hsize_t)0,
                                    (hsize_t)0);

--- a/tools/lib/h5tools_dump.c
+++ b/tools/lib/h5tools_dump.c
@@ -3198,6 +3198,7 @@ h5tools_dump_dcpl(FILE *stream, const h5tool_format_t *info, h5tools_context_t *
     hsize_t          storage_size;
     hsize_t          curr_pos = 0; /* total data element position   */
     h5tools_str_t    buffer;       /* string into which to render   */
+    unsigned         str_chunk_flag; /* type og structired chunk     */
 
     /* setup */
     memset(&buffer, 0, sizeof(h5tools_str_t));
@@ -3224,6 +3225,30 @@ h5tools_dump_dcpl(FILE *stream, const h5tool_format_t *info, h5tools_context_t *
         stl = H5Pget_layout(dcpl_id);
 
     switch (stl) {
+        case H5D_STRUCT_CHUNK:
+	        ctx->indent_level++;
+            ctx->need_prefix = true;
+
+            h5tools_str_reset(&buffer);
+            h5tools_str_append(&buffer, "%s ", STRUCT_CHUNKED);
+
+            rank = H5Pget_struct_chunk(dcpl_id, (int)NELMTS(chsize), chsize, &str_chunk_flag);
+            h5tools_str_append(&buffer, "%s %" PRIuHSIZE, h5tools_dump_header_format->dataspacedimbegin,
+                               chsize[0]);
+            for (i = 1; i < rank; i++)
+                h5tools_str_append(&buffer, ", %" PRIuHSIZE, chsize[i]);
+            h5tools_str_append(&buffer, " %s", h5tools_dump_header_format->dataspacedimend);
+            h5tools_render_element(stream, info, ctx, &buffer, &curr_pos, (size_t)ncols, (hsize_t)0,
+                                   (hsize_t)0);
+
+            ctx->need_prefix = true;
+
+            h5tools_str_reset(&buffer); 
+            h5tools_str_append(&buffer, "SIZE %" PRIuHSIZE, storage_size);
+            h5tools_render_element(stream, info, ctx, &buffer, &curr_pos, (size_t)ncols, (hsize_t)0,
+                                   (hsize_t)0);
+            ctx->indent_level--;
+            break;
         case H5D_CHUNKED:
             ctx->indent_level++;
             ctx->need_prefix = true;


### PR DESCRIPTION
This is a fix from Elena.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Adds support for structured chunk storage in `h5tools_dump_dcpl()` to print structured chunk dimensions and storage size.
> 
>   - **Behavior**:
>     - Adds support for structured chunk storage in `h5tools_dump_dcpl()` in `h5tools_dump.c`.
>     - Handles `H5D_STRUCT_CHUNK` layout by printing structured chunk dimensions and storage size.
>   - **Constants**:
>     - Adds `STRUCT_CHUNKED` to `h5tools.h` for structured chunk layout identification.
>   - **Rendering**:
>     - Uses `h5tools_render_element()` to output structured chunk information in `h5tools_dump.c`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=HDFGroup%2Fhdf5&utm_source=github&utm_medium=referral)<sup> for f5dfcabd495d854a649eb734c3e3d7411dff0dac. You can [customize](https://app.ellipsis.dev/HDFGroup/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->