### PR TITLE
Fix use of uninit memory in h5dumpgentest

### DIFF
--- a/tools/test/h5dump/h5dumpgentest.c
+++ b/tools/test/h5dump/h5dumpgentest.c
@@ -2554,7 +2554,7 @@ gent_nestcomp(void)
     hsize_t  array_dims[] = {2}; /* Dataspace dimensions */
     unsigned ndims        = 1;   /* Number of dimensions in the array field */
 
-    s2_t  s1[10] = {0};
+    s2_t  s1[10];
     hid_t s2_tid; /* File datatype identifier */
 
     int     i;
@@ -2567,6 +2567,7 @@ gent_nestcomp(void)
     /*
      * Initialize the data
      */
+    memset(s1, 0, sizeof(s1));
     for (i = 0; i < 10; i++) {
         s1[i].a      = i;
         s1[i].b      = (float)(i * i);
@@ -4118,8 +4119,8 @@ write_attr_in(hid_t loc_id, const char *dset_name, /* for saving reference to da
     char       buf1[2][2] = {"ab", "de"}; /* string, NO NUL fixed length */
     char       buf2[2]    = {1, 2};       /* bitfield, opaque */
     s_t        buf3[2];                   /* compound */
-    hobj_ref_t buf4[2] = {0};             /* reference */
-    hvl_t      buf5[2] = {0};             /* vlen */
+    hobj_ref_t buf4[2];                   /* reference */
+    hvl_t      buf5[2];                   /* vlen */
 
     memset(buf3, 0, sizeof(buf3));
     buf3[0].a           = 1;
@@ -4137,41 +4138,34 @@ write_attr_in(hid_t loc_id, const char *dset_name, /* for saving reference to da
     char       buf12[6][2] = {"ab", "cd", "ef", "gh", "ij", "kl"}; /* string, NO NUL fixed length */
     char       buf22[3][2] = {{1, 2}, {3, 4}, {5, 6}};             /* bitfield, opaque */
     s_t        buf32[6];                                           /* compound */
-    hobj_ref_t buf42[3][2] = {0};                                  /* reference */
-    hvl_t      buf52[3][2] = {0};                                  /* vlen */
+    hobj_ref_t buf42[3][2];                                        /* reference */
+    hvl_t      buf52[3][2];                                        /* vlen */
     int buf62[6][3] = {{1, 2, 3}, {4, 5, 6}, {7, 8, 9}, {10, 11, 12}, {13, 14, 15}, {16, 17, 18}}; /* array */
     int buf72[3][2] = {{1, 2}, {3, 4}, {5, 6}};                              /* integer */
     float buf82[3][2] = {{1, 2}, {3, 4}, {5, 6}};                            /* float */
     float buf92[6][2] = {{1, 2}, {3, 4}, {5, 6}, {7, 8}, {9, 10}, {11, 12}}; /* complex */
 
     memset(buf32, 0, sizeof(buf32));
-    buf32[0].a = 1;
-    buf32[0].b = 2;
-    buf32[1].a = 3;
-    buf32[1].b = 4;
-    buf32[2].a = 5;
-    buf32[2].b = 6;
-    buf32[3].a = 7;
-    buf32[3].b = 8;
-    buf32[4].a = 9;
-    buf32[4].b = 10;
-    buf32[5].a = 11;
-    buf32[5].b = 12;
+    for (i = 0; i < 6; i++) {
+        buf32[i].a = (2 * i) + 1;
+        buf32[i].b = (2 * i) + 2;
+    }
 
     /* create 3D attributes with dimension [4][3][2], 24 elements */
     hsize_t dims3[3]     = {4, 3, 2};
     char    buf13[24][2] = {
         "ab", "cd", "ef", "gh", "ij", "kl", "mn", "pq", "rs", "tu", "vw", "xz", "AB",
         "CD", "EF", "GH", "IJ", "KL", "MN", "PQ", "RS", "TU", "VW", "XZ"}; /* string, NO NUL fixed length */
-    char       buf23[4][3][2] = {0};                                          /* bitfield, opaque */
-    s_t        buf33[4][3][2] = {0};                                          /* compound */
-    hobj_ref_t buf43[4][3][2] = {HADDR_UNDEF};                                /* reference */
-    hvl_t      buf53[4][3][2] = {0};                                          /* vlen */
-    int        buf63[24][3]   = {0};                                          /* array */
-    int        buf73[4][3][2] = {0};                                          /* integer */
-    float      buf83[4][3][2] = {0};                                          /* float */
-    float      buf93[24][2]   = {0};                                          /* complex */
+    char       buf23[4][3][2];                                                /* bitfield, opaque */
+    s_t        buf33[4][3][2];                                                /* compound */
+    hobj_ref_t buf43[4][3][2];                                                /* reference */
+    hvl_t      buf53[4][3][2];                                                /* vlen */
+    int        buf63[24][3];                                                  /* array */
+    int        buf73[4][3][2];                                                /* integer */
+    float      buf83[4][3][2];                                                /* float */
+    float      buf93[24][2];                                                  /* complex */
 
+    memset(buf33, 0, sizeof(buf33));
     /*-------------------------------------------------------------------------
      * 1D attributes
      *-------------------------------------------------------------------------
@@ -4596,8 +4590,8 @@ write_dset_in(hid_t loc_id, const char *dset_name, /* for saving reference to da
     char       buf1[2][2] = {"ab", "de"}; /* string, NO NUL fixed length */
     char       buf2[2]    = {1, 2};       /* bitfield, opaque */
     s_t        buf3[2];                   /* compound */
-    hobj_ref_t buf4[2] = {0};             /* reference */
-    hvl_t      buf5[2] = {0};             /* vlen */
+    hobj_ref_t buf4[2];                   /* reference */
+    hvl_t      buf5[2];                   /* vlen */
 
     memset(buf3, 0, sizeof(buf3));
     buf3[0].a           = 1;
@@ -4615,41 +4609,34 @@ write_dset_in(hid_t loc_id, const char *dset_name, /* for saving reference to da
     char       buf12[6][2] = {"ab", "cd", "ef", "gh", "ij", "kl"}; /* string, NO NUL fixed length */
     char       buf22[3][2] = {{1, 2}, {3, 4}, {5, 6}};             /* bitfield, opaque */
     s_t        buf32[6];                                           /* compound */
-    hobj_ref_t buf42[3][2] = {0};                                  /* reference */
-    hvl_t      buf52[3][2] = {0};                                  /* vlen */
+    hobj_ref_t buf42[3][2];                                        /* reference */
+    hvl_t      buf52[3][2];                                        /* vlen */
     int buf62[6][3] = {{1, 2, 3}, {4, 5, 6}, {7, 8, 9}, {10, 11, 12}, {13, 14, 15}, {16, 17, 18}}; /* array */
     int buf72[3][2] = {{1, 2}, {3, 4}, {5, 6}};                              /* integer */
     float buf82[3][2] = {{1, 2}, {3, 4}, {5, 6}};                            /* float */
     float buf92[6][2] = {{1, 2}, {3, 4}, {5, 6}, {7, 8}, {9, 10}, {11, 12}}; /* complex */
 
     memset(buf32, 0, sizeof(buf32));
-    buf32[0].a = 1;
-    buf32[0].b = 2;
-    buf32[1].a = 3;
-    buf32[1].b = 4;
-    buf32[2].a = 5;
-    buf32[2].b = 6;
-    buf32[3].a = 7;
-    buf32[3].b = 8;
-    buf32[4].a = 9;
-    buf32[4].b = 10;
-    buf32[5].a = 11;
-    buf32[5].b = 12;
+    for (int i = 0; i < 6; i++) {
+        buf32[i].a = (2 * i) + 1;
+        buf32[i].b = (2 * i) + 2;
+    }
 
     /* create 3D attributes with dimension [4][3][2], 24 elements */
     hsize_t dims3[3]     = {4, 3, 2};
     char    buf13[24][2] = {
         "ab", "cd", "ef", "gh", "ij", "kl", "mn", "pq", "rs", "tu", "vw", "xz", "AB",
         "CD", "EF", "GH", "IJ", "KL", "MN", "PQ", "RS", "TU", "VW", "XZ"}; /* string, NO NUL fixed length */
-    char       buf23[4][3][2] = {0};                                          /* bitfield, opaque */
-    s_t        buf33[4][3][2] = {0};                                          /* compound */
-    hobj_ref_t buf43[4][3][2] = {0};                                          /* reference */
-    hvl_t      buf53[4][3][2] = {0};                                          /* vlen */
-    int        buf63[24][3]   = {0};                                          /* array */
-    int        buf73[4][3][2] = {0};                                          /* integer */
-    float      buf83[4][3][2] = {0};                                          /* float */
-    float      buf93[24][2]   = {0};                                          /* complex */
+    char       buf23[4][3][2];                                                /* bitfield, opaque */
+    s_t        buf33[4][3][2];                                                /* compound */
+    hobj_ref_t buf43[4][3][2];                                                /* reference */
+    hvl_t      buf53[4][3][2];                                                /* vlen */
+    int        buf63[24][3];                                                  /* array */
+    int        buf73[4][3][2];                                                /* integer */
+    float      buf83[4][3][2];                                                /* float */
+    float      buf93[24][2];                                                  /* complex */
 
+    memset(buf33, 0, sizeof(buf33));
     /*-------------------------------------------------------------------------
      * 1D
      *-------------------------------------------------------------------------
@@ -11260,11 +11247,13 @@ gent_bitnopaquefields(void)
           dset = H5I_INVALID_HID;
     size_t   i;
     hsize_t  nelmts = F80_DIM32;
-    uint8_t  buf[F80_DIM32];        /* bitfield, opaque */
-    uint16_t buf2[F80_DIM32];       /* bitfield, opaque */
-    uint32_t buf3[F80_DIM32];       /* bitfield, opaque */
-    uint64_t buf4[F80_DIM32];       /* bitfield, opaque */
-    s_t      buf5[F80_DIM32] = {0}; /* compound */
+    uint8_t  buf[F80_DIM32];  /* bitfield, opaque */
+    uint16_t buf2[F80_DIM32]; /* bitfield, opaque */
+    uint32_t buf3[F80_DIM32]; /* bitfield, opaque */
+    uint64_t buf4[F80_DIM32]; /* bitfield, opaque */
+    s_t      buf5[F80_DIM32]; /* compound */
+
+    memset(buf5, 0, sizeof(buf5));
 
     file_id = H5Fcreate(FILE80, H5F_ACC_TRUNC, H5P_DEFAULT, H5P_DEFAULT);
 

--- a/tools/test/h5dump/h5dumpgentest.c
+++ b/tools/test/h5dump/h5dumpgentest.c
@@ -11245,7 +11245,7 @@ gent_bitnopaquefields(void)
     uint16_t buf2[F80_DIM32]; /* bitfield, opaque */
     uint32_t buf3[F80_DIM32]; /* bitfield, opaque */
     uint64_t buf4[F80_DIM32]; /* bitfield, opaque */
-    s_t      buf5[F80_DIM32]; /* compound */
+    s_t      buf5[F80_DIM32] = {0}; /* compound */
 
     file_id = H5Fcreate(FILE80, H5F_ACC_TRUNC, H5P_DEFAULT, H5P_DEFAULT);
 

--- a/tools/test/h5dump/h5dumpgentest.c
+++ b/tools/test/h5dump/h5dumpgentest.c
@@ -4115,54 +4115,62 @@ write_attr_in(hid_t loc_id, const char *dset_name, /* for saving reference to da
 
     /* create 1D attributes with dimension [2], 2 elements */
     hsize_t    dims[1]    = {2};
-    char       buf1[2][2] = {"ab", "de"};            /* string, NO NUL fixed length */
-    char       buf2[2]    = {1, 2};                  /* bitfield, opaque */
-    s_t        buf3[2];                              /* compound */
-    hobj_ref_t buf4[2] = {0};                              /* reference */
-    hvl_t      buf5[2] = {0};                              /* vlen */
+    char       buf1[2][2] = {"ab", "de"}; /* string, NO NUL fixed length */
+    char       buf2[2]    = {1, 2};       /* bitfield, opaque */
+    s_t        buf3[2];                   /* compound */
+    hobj_ref_t buf4[2] = {0};             /* reference */
+    hvl_t      buf5[2] = {0};             /* vlen */
 
     memset(buf3, 0, sizeof(buf3));
-    buf3[0].a = 1; buf3[0].b = 2;
-    buf3[1].a = 3; buf3[1].b = 4;
-    hsize_t    dimarray[1] = {3};                    /* array dimension */
-    int        buf6[2][3]  = {{1, 2, 3}, {4, 5, 6}}; /* array */
-    int        buf7[2]     = {1, 2};                 /* integer */
-    float      buf8[2]     = {1, 2};                 /* float */
-    float      buf9[4]     = {1, 2, 3, 4};           /* complex */
+    buf3[0].a           = 1;
+    buf3[0].b           = 2;
+    buf3[1].a           = 3;
+    buf3[1].b           = 4;
+    hsize_t dimarray[1] = {3};                    /* array dimension */
+    int     buf6[2][3]  = {{1, 2, 3}, {4, 5, 6}}; /* array */
+    int     buf7[2]     = {1, 2};                 /* integer */
+    float   buf8[2]     = {1, 2};                 /* float */
+    float   buf9[4]     = {1, 2, 3, 4};           /* complex */
 
     /* create 2D attributes with dimension [3][2], 6 elements */
     hsize_t    dims2[2]    = {3, 2};
     char       buf12[6][2] = {"ab", "cd", "ef", "gh", "ij", "kl"}; /* string, NO NUL fixed length */
     char       buf22[3][2] = {{1, 2}, {3, 4}, {5, 6}};             /* bitfield, opaque */
     s_t        buf32[6];                                           /* compound */
-    hobj_ref_t buf42[3][2] = {0};                                                       /* reference */
-    hvl_t      buf52[3][2] = {0};                                                       /* vlen */
+    hobj_ref_t buf42[3][2] = {0};                                  /* reference */
+    hvl_t      buf52[3][2] = {0};                                  /* vlen */
     int buf62[6][3] = {{1, 2, 3}, {4, 5, 6}, {7, 8, 9}, {10, 11, 12}, {13, 14, 15}, {16, 17, 18}}; /* array */
     int buf72[3][2] = {{1, 2}, {3, 4}, {5, 6}};                              /* integer */
     float buf82[3][2] = {{1, 2}, {3, 4}, {5, 6}};                            /* float */
     float buf92[6][2] = {{1, 2}, {3, 4}, {5, 6}, {7, 8}, {9, 10}, {11, 12}}; /* complex */
 
     memset(buf32, 0, sizeof(buf32));
-    buf32[0].a = 1; buf32[0].b = 2;
-    buf32[1].a = 3; buf32[1].b = 4;
-    buf32[2].a = 5; buf32[2].b = 6;
-    buf32[3].a = 7; buf32[3].b = 8;
-    buf32[4].a = 9; buf32[4].b = 10;
-    buf32[5].a = 11; buf32[5].b = 12;
+    buf32[0].a = 1;
+    buf32[0].b = 2;
+    buf32[1].a = 3;
+    buf32[1].b = 4;
+    buf32[2].a = 5;
+    buf32[2].b = 6;
+    buf32[3].a = 7;
+    buf32[3].b = 8;
+    buf32[4].a = 9;
+    buf32[4].b = 10;
+    buf32[5].a = 11;
+    buf32[5].b = 12;
 
     /* create 3D attributes with dimension [4][3][2], 24 elements */
     hsize_t dims3[3]     = {4, 3, 2};
     char    buf13[24][2] = {
         "ab", "cd", "ef", "gh", "ij", "kl", "mn", "pq", "rs", "tu", "vw", "xz", "AB",
         "CD", "EF", "GH", "IJ", "KL", "MN", "PQ", "RS", "TU", "VW", "XZ"}; /* string, NO NUL fixed length */
-    char       buf23[4][3][2] = {0};                                                /* bitfield, opaque */
+    char       buf23[4][3][2] = {0};                                          /* bitfield, opaque */
     s_t        buf33[4][3][2] = {0};                                          /* compound */
-    hobj_ref_t buf43[4][3][2] = {0};                                                /* reference */
-    hvl_t      buf53[4][3][2] = {0};                                                /* vlen */
-    int        buf63[24][3] = {0};                                                  /* array */
-    int        buf73[4][3][2] = {0};                                                /* integer */
-    float      buf83[4][3][2] = {0};                                                /* float */
-    float      buf93[24][2] = {0};                                                  /* complex */
+    hobj_ref_t buf43[4][3][2] = {0};                                          /* reference */
+    hvl_t      buf53[4][3][2] = {0};                                          /* vlen */
+    int        buf63[24][3]   = {0};                                          /* array */
+    int        buf73[4][3][2] = {0};                                          /* integer */
+    float      buf83[4][3][2] = {0};                                          /* float */
+    float      buf93[24][2]   = {0};                                          /* complex */
 
     /*-------------------------------------------------------------------------
      * 1D attributes
@@ -4585,54 +4593,62 @@ write_dset_in(hid_t loc_id, const char *dset_name, /* for saving reference to da
 
     /* create 1D attributes with dimension [2], 2 elements */
     hsize_t    dims[1]    = {2};
-    char       buf1[2][2] = {"ab", "de"};            /* string, NO NUL fixed length */
-    char       buf2[2]    = {1, 2};                  /* bitfield, opaque */
-    s_t        buf3[2];                              /* compound */
-    hobj_ref_t buf4[2] = {0};                              /* reference */
-    hvl_t      buf5[2] = {0};                              /* vlen */
+    char       buf1[2][2] = {"ab", "de"}; /* string, NO NUL fixed length */
+    char       buf2[2]    = {1, 2};       /* bitfield, opaque */
+    s_t        buf3[2];                   /* compound */
+    hobj_ref_t buf4[2] = {0};             /* reference */
+    hvl_t      buf5[2] = {0};             /* vlen */
 
     memset(buf3, 0, sizeof(buf3));
-    buf3[0].a = 1; buf3[0].b = 2;
-    buf3[1].a = 3; buf3[1].b = 4;
-    hsize_t    dimarray[1] = {3};                    /* array dimension */
-    int        buf6[2][3]  = {{1, 2, 3}, {4, 5, 6}}; /* array */
-    int        buf7[2]     = {1, 2};                 /* integer */
-    float      buf8[2]     = {1, 2};                 /* float */
-    float      buf9[4]     = {1, 2, 3, 4};           /* complex */
+    buf3[0].a           = 1;
+    buf3[0].b           = 2;
+    buf3[1].a           = 3;
+    buf3[1].b           = 4;
+    hsize_t dimarray[1] = {3};                    /* array dimension */
+    int     buf6[2][3]  = {{1, 2, 3}, {4, 5, 6}}; /* array */
+    int     buf7[2]     = {1, 2};                 /* integer */
+    float   buf8[2]     = {1, 2};                 /* float */
+    float   buf9[4]     = {1, 2, 3, 4};           /* complex */
 
     /* create 2D attributes with dimension [3][2], 6 elements */
     hsize_t    dims2[2]    = {3, 2};
     char       buf12[6][2] = {"ab", "cd", "ef", "gh", "ij", "kl"}; /* string, NO NUL fixed length */
     char       buf22[3][2] = {{1, 2}, {3, 4}, {5, 6}};             /* bitfield, opaque */
     s_t        buf32[6];                                           /* compound */
-    hobj_ref_t buf42[3][2] = {0};                                                       /* reference */
-    hvl_t      buf52[3][2] = {0};                                                       /* vlen */
+    hobj_ref_t buf42[3][2] = {0};                                  /* reference */
+    hvl_t      buf52[3][2] = {0};                                  /* vlen */
     int buf62[6][3] = {{1, 2, 3}, {4, 5, 6}, {7, 8, 9}, {10, 11, 12}, {13, 14, 15}, {16, 17, 18}}; /* array */
     int buf72[3][2] = {{1, 2}, {3, 4}, {5, 6}};                              /* integer */
     float buf82[3][2] = {{1, 2}, {3, 4}, {5, 6}};                            /* float */
     float buf92[6][2] = {{1, 2}, {3, 4}, {5, 6}, {7, 8}, {9, 10}, {11, 12}}; /* complex */
 
     memset(buf32, 0, sizeof(buf32));
-    buf32[0].a = 1; buf32[0].b = 2;
-    buf32[1].a = 3; buf32[1].b = 4;
-    buf32[2].a = 5; buf32[2].b = 6;
-    buf32[3].a = 7; buf32[3].b = 8;
-    buf32[4].a = 9; buf32[4].b = 10;
-    buf32[5].a = 11; buf32[5].b = 12;
+    buf32[0].a = 1;
+    buf32[0].b = 2;
+    buf32[1].a = 3;
+    buf32[1].b = 4;
+    buf32[2].a = 5;
+    buf32[2].b = 6;
+    buf32[3].a = 7;
+    buf32[3].b = 8;
+    buf32[4].a = 9;
+    buf32[4].b = 10;
+    buf32[5].a = 11;
+    buf32[5].b = 12;
 
     /* create 3D attributes with dimension [4][3][2], 24 elements */
     hsize_t dims3[3]     = {4, 3, 2};
     char    buf13[24][2] = {
         "ab", "cd", "ef", "gh", "ij", "kl", "mn", "pq", "rs", "tu", "vw", "xz", "AB",
         "CD", "EF", "GH", "IJ", "KL", "MN", "PQ", "RS", "TU", "VW", "XZ"}; /* string, NO NUL fixed length */
-    char       buf23[4][3][2] = {0};                                                /* bitfield, opaque */
+    char       buf23[4][3][2] = {0};                                          /* bitfield, opaque */
     s_t        buf33[4][3][2] = {0};                                          /* compound */
-    hobj_ref_t buf43[4][3][2] = {0};                                                /* reference */
-    hvl_t      buf53[4][3][2] = {0};                                                /* vlen */
-    int        buf63[24][3] = {0};                                                  /* array */
-    int        buf73[4][3][2] = {0};                                                /* integer */
-    float      buf83[4][3][2] = {0};                                                /* float */
-    float      buf93[24][2] = {0};                                                  /* complex */
+    hobj_ref_t buf43[4][3][2] = {0};                                          /* reference */
+    hvl_t      buf53[4][3][2] = {0};                                          /* vlen */
+    int        buf63[24][3]   = {0};                                          /* array */
+    int        buf73[4][3][2] = {0};                                          /* integer */
+    float      buf83[4][3][2] = {0};                                          /* float */
+    float      buf93[24][2]   = {0};                                          /* complex */
 
     /*-------------------------------------------------------------------------
      * 1D
@@ -6104,26 +6120,29 @@ gent_fvalues(void)
         double b;
     } c_t;
 
-    hid_t                     fid;  /* file id */
-    hid_t                     dcpl; /* dataset creation property list */
-    hid_t                     sid;  /* dataspace ID */
-    hid_t                     tid;  /* datatype ID */
-    hid_t                     did;  /* datasetID */
-    hsize_t                   dims[1]     = {2};
-    int                       buf[2]      = {1, 2};                 /* integer */
-    int                       fillval1    = -99;                    /* integer fill value */
-    c_t                       buf2[2];                              /* compound */
-    c_t                       fillval2[1];                          /* compound fill value */
-    hvl_t                     buf3[2];                              /* vlen */
-    hvl_t                     fillval3;                             /* vlen fill value */
-    hsize_t                   dimarray[1] = {3};                    /* array dimension */
+    hid_t   fid;  /* file id */
+    hid_t   dcpl; /* dataset creation property list */
+    hid_t   sid;  /* dataspace ID */
+    hid_t   tid;  /* datatype ID */
+    hid_t   did;  /* datasetID */
+    hsize_t dims[1]  = {2};
+    int     buf[2]   = {1, 2}; /* integer */
+    int     fillval1 = -99;    /* integer fill value */
+    c_t     buf2[2];           /* compound */
+    c_t     fillval2[1];       /* compound fill value */
+    hvl_t   buf3[2];           /* vlen */
+    hvl_t   fillval3;          /* vlen fill value */
+    hsize_t dimarray[1] = {3}; /* array dimension */
 
     memset(buf2, 0, sizeof(buf2));
-    buf2[0].a = 1; buf2[0].b = 2;
-    buf2[1].a = 3; buf2[1].b = 4;
+    buf2[0].a = 1;
+    buf2[0].b = 2;
+    buf2[1].a = 3;
+    buf2[1].b = 4;
     memset(fillval2, 0, sizeof(fillval2));
-    fillval2[0].a = 1; fillval2[0].b = 2;
-    int                       buf4[2][3]  = {{1, 2, 3}, {4, 5, 6}}; /* array */
+    fillval2[0].a                        = 1;
+    fillval2[0].b                        = 2;
+    int                       buf4[2][3] = {{1, 2, 3}, {4, 5, 6}}; /* array */
     int H5_ATTR_NDEBUG_UNUSED ret;
 
     /* create a file */
@@ -11241,10 +11260,10 @@ gent_bitnopaquefields(void)
           dset = H5I_INVALID_HID;
     size_t   i;
     hsize_t  nelmts = F80_DIM32;
-    uint8_t  buf[F80_DIM32];  /* bitfield, opaque */
-    uint16_t buf2[F80_DIM32]; /* bitfield, opaque */
-    uint32_t buf3[F80_DIM32]; /* bitfield, opaque */
-    uint64_t buf4[F80_DIM32]; /* bitfield, opaque */
+    uint8_t  buf[F80_DIM32];        /* bitfield, opaque */
+    uint16_t buf2[F80_DIM32];       /* bitfield, opaque */
+    uint32_t buf3[F80_DIM32];       /* bitfield, opaque */
+    uint64_t buf4[F80_DIM32];       /* bitfield, opaque */
     s_t      buf5[F80_DIM32] = {0}; /* compound */
 
     file_id = H5Fcreate(FILE80, H5F_ACC_TRUNC, H5P_DEFAULT, H5P_DEFAULT);

--- a/tools/test/h5dump/h5dumpgentest.c
+++ b/tools/test/h5dump/h5dumpgentest.c
@@ -2554,7 +2554,7 @@ gent_nestcomp(void)
     hsize_t  array_dims[] = {2}; /* Dataspace dimensions */
     unsigned ndims        = 1;   /* Number of dimensions in the array field */
 
-    s2_t  s1[10];
+    s2_t  s1[10] = {0};
     hid_t s2_tid; /* File datatype identifier */
 
     int     i;

--- a/tools/test/h5dump/h5dumpgentest.c
+++ b/tools/test/h5dump/h5dumpgentest.c
@@ -4165,7 +4165,7 @@ write_attr_in(hid_t loc_id, const char *dset_name, /* for saving reference to da
         "CD", "EF", "GH", "IJ", "KL", "MN", "PQ", "RS", "TU", "VW", "XZ"}; /* string, NO NUL fixed length */
     char       buf23[4][3][2] = {0};                                          /* bitfield, opaque */
     s_t        buf33[4][3][2] = {0};                                          /* compound */
-    hobj_ref_t buf43[4][3][2] = {0};                                          /* reference */
+    hobj_ref_t buf43[4][3][2] = {HADDR_UNDEF};                                /* reference */
     hvl_t      buf53[4][3][2] = {0};                                          /* vlen */
     int        buf63[24][3]   = {0};                                          /* array */
     int        buf73[4][3][2] = {0};                                          /* integer */

--- a/tools/test/h5dump/h5dumpgentest.c
+++ b/tools/test/h5dump/h5dumpgentest.c
@@ -4117,9 +4117,13 @@ write_attr_in(hid_t loc_id, const char *dset_name, /* for saving reference to da
     hsize_t    dims[1]    = {2};
     char       buf1[2][2] = {"ab", "de"};            /* string, NO NUL fixed length */
     char       buf2[2]    = {1, 2};                  /* bitfield, opaque */
-    s_t        buf3[2]    = {{1, 2}, {3, 4}};        /* compound */
-    hobj_ref_t buf4[2];                              /* reference */
-    hvl_t      buf5[2];                              /* vlen */
+    s_t        buf3[2];                              /* compound */
+    hobj_ref_t buf4[2] = {0};                              /* reference */
+    hvl_t      buf5[2] = {0};                              /* vlen */
+
+    memset(buf3, 0, sizeof(buf3));
+    buf3[0].a = 1; buf3[0].b = 2;
+    buf3[1].a = 3; buf3[1].b = 4;
     hsize_t    dimarray[1] = {3};                    /* array dimension */
     int        buf6[2][3]  = {{1, 2, 3}, {4, 5, 6}}; /* array */
     int        buf7[2]     = {1, 2};                 /* integer */
@@ -4130,27 +4134,35 @@ write_attr_in(hid_t loc_id, const char *dset_name, /* for saving reference to da
     hsize_t    dims2[2]    = {3, 2};
     char       buf12[6][2] = {"ab", "cd", "ef", "gh", "ij", "kl"}; /* string, NO NUL fixed length */
     char       buf22[3][2] = {{1, 2}, {3, 4}, {5, 6}};             /* bitfield, opaque */
-    s_t        buf32[6]    = {{1, 2}, {3, 4}, {5, 6}, {7, 8}, {9, 10}, {11, 12}}; /* compound */
-    hobj_ref_t buf42[3][2];                                                       /* reference */
-    hvl_t      buf52[3][2];                                                       /* vlen */
+    s_t        buf32[6];                                           /* compound */
+    hobj_ref_t buf42[3][2] = {0};                                                       /* reference */
+    hvl_t      buf52[3][2] = {0};                                                       /* vlen */
     int buf62[6][3] = {{1, 2, 3}, {4, 5, 6}, {7, 8, 9}, {10, 11, 12}, {13, 14, 15}, {16, 17, 18}}; /* array */
     int buf72[3][2] = {{1, 2}, {3, 4}, {5, 6}};                              /* integer */
     float buf82[3][2] = {{1, 2}, {3, 4}, {5, 6}};                            /* float */
     float buf92[6][2] = {{1, 2}, {3, 4}, {5, 6}, {7, 8}, {9, 10}, {11, 12}}; /* complex */
+
+    memset(buf32, 0, sizeof(buf32));
+    buf32[0].a = 1; buf32[0].b = 2;
+    buf32[1].a = 3; buf32[1].b = 4;
+    buf32[2].a = 5; buf32[2].b = 6;
+    buf32[3].a = 7; buf32[3].b = 8;
+    buf32[4].a = 9; buf32[4].b = 10;
+    buf32[5].a = 11; buf32[5].b = 12;
 
     /* create 3D attributes with dimension [4][3][2], 24 elements */
     hsize_t dims3[3]     = {4, 3, 2};
     char    buf13[24][2] = {
         "ab", "cd", "ef", "gh", "ij", "kl", "mn", "pq", "rs", "tu", "vw", "xz", "AB",
         "CD", "EF", "GH", "IJ", "KL", "MN", "PQ", "RS", "TU", "VW", "XZ"}; /* string, NO NUL fixed length */
-    char       buf23[4][3][2];                                                /* bitfield, opaque */
-    s_t        buf33[4][3][2];                                                /* compound */
-    hobj_ref_t buf43[4][3][2];                                                /* reference */
-    hvl_t      buf53[4][3][2];                                                /* vlen */
-    int        buf63[24][3];                                                  /* array */
-    int        buf73[4][3][2];                                                /* integer */
-    float      buf83[4][3][2];                                                /* float */
-    float      buf93[24][2];                                                  /* complex */
+    char       buf23[4][3][2] = {0};                                                /* bitfield, opaque */
+    s_t        buf33[4][3][2] = {0};                                          /* compound */
+    hobj_ref_t buf43[4][3][2] = {0};                                                /* reference */
+    hvl_t      buf53[4][3][2] = {0};                                                /* vlen */
+    int        buf63[24][3] = {0};                                                  /* array */
+    int        buf73[4][3][2] = {0};                                                /* integer */
+    float      buf83[4][3][2] = {0};                                                /* float */
+    float      buf93[24][2] = {0};                                                  /* complex */
 
     /*-------------------------------------------------------------------------
      * 1D attributes
@@ -4575,9 +4587,13 @@ write_dset_in(hid_t loc_id, const char *dset_name, /* for saving reference to da
     hsize_t    dims[1]    = {2};
     char       buf1[2][2] = {"ab", "de"};            /* string, NO NUL fixed length */
     char       buf2[2]    = {1, 2};                  /* bitfield, opaque */
-    s_t        buf3[2]    = {{1, 2}, {3, 4}};        /* compound */
-    hobj_ref_t buf4[2];                              /* reference */
-    hvl_t      buf5[2];                              /* vlen */
+    s_t        buf3[2];                              /* compound */
+    hobj_ref_t buf4[2] = {0};                              /* reference */
+    hvl_t      buf5[2] = {0};                              /* vlen */
+
+    memset(buf3, 0, sizeof(buf3));
+    buf3[0].a = 1; buf3[0].b = 2;
+    buf3[1].a = 3; buf3[1].b = 4;
     hsize_t    dimarray[1] = {3};                    /* array dimension */
     int        buf6[2][3]  = {{1, 2, 3}, {4, 5, 6}}; /* array */
     int        buf7[2]     = {1, 2};                 /* integer */
@@ -4588,27 +4604,35 @@ write_dset_in(hid_t loc_id, const char *dset_name, /* for saving reference to da
     hsize_t    dims2[2]    = {3, 2};
     char       buf12[6][2] = {"ab", "cd", "ef", "gh", "ij", "kl"}; /* string, NO NUL fixed length */
     char       buf22[3][2] = {{1, 2}, {3, 4}, {5, 6}};             /* bitfield, opaque */
-    s_t        buf32[6]    = {{1, 2}, {3, 4}, {5, 6}, {7, 8}, {9, 10}, {11, 12}}; /* compound */
-    hobj_ref_t buf42[3][2];                                                       /* reference */
-    hvl_t      buf52[3][2];                                                       /* vlen */
+    s_t        buf32[6];                                           /* compound */
+    hobj_ref_t buf42[3][2] = {0};                                                       /* reference */
+    hvl_t      buf52[3][2] = {0};                                                       /* vlen */
     int buf62[6][3] = {{1, 2, 3}, {4, 5, 6}, {7, 8, 9}, {10, 11, 12}, {13, 14, 15}, {16, 17, 18}}; /* array */
     int buf72[3][2] = {{1, 2}, {3, 4}, {5, 6}};                              /* integer */
     float buf82[3][2] = {{1, 2}, {3, 4}, {5, 6}};                            /* float */
     float buf92[6][2] = {{1, 2}, {3, 4}, {5, 6}, {7, 8}, {9, 10}, {11, 12}}; /* complex */
+
+    memset(buf32, 0, sizeof(buf32));
+    buf32[0].a = 1; buf32[0].b = 2;
+    buf32[1].a = 3; buf32[1].b = 4;
+    buf32[2].a = 5; buf32[2].b = 6;
+    buf32[3].a = 7; buf32[3].b = 8;
+    buf32[4].a = 9; buf32[4].b = 10;
+    buf32[5].a = 11; buf32[5].b = 12;
 
     /* create 3D attributes with dimension [4][3][2], 24 elements */
     hsize_t dims3[3]     = {4, 3, 2};
     char    buf13[24][2] = {
         "ab", "cd", "ef", "gh", "ij", "kl", "mn", "pq", "rs", "tu", "vw", "xz", "AB",
         "CD", "EF", "GH", "IJ", "KL", "MN", "PQ", "RS", "TU", "VW", "XZ"}; /* string, NO NUL fixed length */
-    char       buf23[4][3][2];                                                /* bitfield, opaque */
-    s_t        buf33[4][3][2];                                                /* compound */
-    hobj_ref_t buf43[4][3][2];                                                /* reference */
-    hvl_t      buf53[4][3][2];                                                /* vlen */
-    int        buf63[24][3];                                                  /* array */
-    int        buf73[4][3][2];                                                /* integer */
-    float      buf83[4][3][2];                                                /* float */
-    float      buf93[24][2];                                                  /* complex */
+    char       buf23[4][3][2] = {0};                                                /* bitfield, opaque */
+    s_t        buf33[4][3][2] = {0};                                          /* compound */
+    hobj_ref_t buf43[4][3][2] = {0};                                                /* reference */
+    hvl_t      buf53[4][3][2] = {0};                                                /* vlen */
+    int        buf63[24][3] = {0};                                                  /* array */
+    int        buf73[4][3][2] = {0};                                                /* integer */
+    float      buf83[4][3][2] = {0};                                                /* float */
+    float      buf93[24][2] = {0};                                                  /* complex */
 
     /*-------------------------------------------------------------------------
      * 1D

--- a/tools/test/h5dump/h5dumpgentest.c
+++ b/tools/test/h5dump/h5dumpgentest.c
@@ -6112,11 +6112,17 @@ gent_fvalues(void)
     hsize_t                   dims[1]     = {2};
     int                       buf[2]      = {1, 2};                 /* integer */
     int                       fillval1    = -99;                    /* integer fill value */
-    c_t                       buf2[2]     = {{1, 2}, {3, 4}};       /* compound */
-    c_t                       fillval2[1] = {{1, 2}};               /* compound fill value */
+    c_t                       buf2[2];                              /* compound */
+    c_t                       fillval2[1];                          /* compound fill value */
     hvl_t                     buf3[2];                              /* vlen */
     hvl_t                     fillval3;                             /* vlen fill value */
     hsize_t                   dimarray[1] = {3};                    /* array dimension */
+
+    memset(buf2, 0, sizeof(buf2));
+    buf2[0].a = 1; buf2[0].b = 2;
+    buf2[1].a = 3; buf2[1].b = 4;
+    memset(fillval2, 0, sizeof(fillval2));
+    fillval2[0].a = 1; fillval2[0].b = 2;
     int                       buf4[2][3]  = {{1, 2, 3}, {4, 5, 6}}; /* array */
     int H5_ATTR_NDEBUG_UNUSED ret;
 

--- a/tools/test/h5dump/h5dumpgentest.c
+++ b/tools/test/h5dump/h5dumpgentest.c
@@ -11498,7 +11498,7 @@ gent_compound_complex2(void)
     hsize_t  nelmts = F82_DIM32;
 
     /* Allocate buffer */
-    buf = (compound *)malloc(sizeof(compound) * F82_DIM32);
+    buf = (compound *)calloc(F82_DIM32, sizeof(compound));
     assert(buf);
 
     file = H5Fcreate(FILE82, H5F_ACC_TRUNC, H5P_DEFAULT, H5P_DEFAULT);

--- a/tools/test/h5dump/h5dumpgentest.c
+++ b/tools/test/h5dump/h5dumpgentest.c
@@ -14319,6 +14319,10 @@ gent_test_reference_external(void)
     if (H5Dwrite(dataset, H5T_STD_REF, H5S_ALL, H5S_ALL, H5P_DEFAULT, ref_wbuf) < 0)
         return 1;
 
+    /* Destroy references to free allocated memory */
+    for (i = 0; i < SPACE1_DIM1; i++)
+        H5Rdestroy(&ref_wbuf[i]);
+
     /* Close disk dataspace */
     if (H5Sclose(sid) < 0)
         return 1;

--- a/tools/test/h5dump/h5dumpgentest.c
+++ b/tools/test/h5dump/h5dumpgentest.c
@@ -10225,9 +10225,9 @@ gent_compound_ints(void)
     int m; /* Array init loop vars     */
 
     /* Allocate buffers */
-    Cmpd1 = (Cmpd1Struct *)malloc(sizeof(Cmpd1Struct) * F77_LENGTH);
+    Cmpd1 = (Cmpd1Struct *)calloc(F77_LENGTH, sizeof(Cmpd1Struct));
     assert(Cmpd1);
-    Cmpd2 = (Cmpd2Struct *)malloc(sizeof(Cmpd2Struct) * F77_LENGTH);
+    Cmpd2 = (Cmpd2Struct *)calloc(F77_LENGTH, sizeof(Cmpd2Struct));
     assert(Cmpd2);
 
     /* Initialize the data in the arrays/datastructure                */


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Fix uninitialized memory usage in `h5dumpgentest.c` by initializing arrays and structures, using `calloc`, and adding memory deallocation.
> 
>   - **Memory Initialization**:
>     - Initialize arrays `s1`, `buf3`, `buf32`, `buf33`, `buf2`, `fillval2`, `buf5`, `buf52`, `buf53`, `buf42`, `buf43`, `buf4`, `buf`, `buf2`, `buf3`, `buf4`, `buf5` to zero in `h5dumpgentest.c`.
>     - Use `memset` to initialize compound structures `buf3`, `buf32`, `buf2`, `fillval2`.
>   - **Memory Allocation**:
>     - Replace `malloc` with `calloc` for `Cmpd1`, `Cmpd2`, and `buf` to ensure zero-initialized memory.
>   - **Memory Deallocation**:
>     - Add loop to destroy references in `gent_test_reference_external()` to free allocated memory.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=HDFGroup%2Fhdf5&utm_source=github&utm_medium=referral)<sup> for 69df16f53a36dcc505be2efca7cf233b57af456b. You can [customize](https://app.ellipsis.dev/HDFGroup/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->