### PR TITLE
Add new size field to H5D_compact_storage_t to address buffer overflows

### DIFF
--- a/src/H5Dchunk.c
+++ b/src/H5Dchunk.c
@@ -307,7 +307,8 @@ static unsigned H5D__chunk_hash_val(const H5D_shared_t *shared, const hsize_t *s
 static herr_t   H5D__chunk_flush_entry(const H5D_t *dset, H5D_rdcc_ent_t *ent, bool reset);
 static herr_t   H5D__chunk_cache_evict(const H5D_t *dset, H5D_rdcc_ent_t *ent, bool flush);
 static void    *H5D__chunk_lock(const H5D_io_info_t *io_info, const H5D_dset_io_info_t *dset_info,
-                                H5D_chunk_ud_t *udata, bool relax, bool prev_unfilt_chunk);
+                                H5D_chunk_ud_t *udata, bool relax, bool prev_unfilt_chunk,
+                                size_t *alloc_chunk_size);
 static herr_t   H5D__chunk_unlock(const H5D_io_info_t *io_info, const H5D_dset_io_info_t *dset_info,
                                   const H5D_chunk_ud_t *udata, bool dirty, void *chunk, uint32_t naccessed);
 static herr_t   H5D__chunk_cache_prune(const H5D_t *dset, size_t size);
@@ -2677,6 +2678,7 @@ H5D__chunk_read(H5D_io_info_t *io_info, H5D_dset_io_info_t *dset_info)
     H5S_t             *chunk_file_spaces_local[8];  /* Local buffer for chunk_file_spaces */
     haddr_t           *chunk_addrs = NULL;          /* Array of chunk addresses */
     haddr_t            chunk_addrs_local[8];        /* Local buffer for chunk_addrs */
+    size_t             alloc_chunk_size = 0;        /* Size of allocated chunk buffer */
     herr_t             ret_value = SUCCEED;         /*return value        */
 
     FUNC_ENTER_PACKAGE
@@ -2922,11 +2924,12 @@ H5D__chunk_read(H5D_io_info_t *io_info, H5D_dset_io_info_t *dset_info)
                         (uint32_t)chunk_info->piece_points * (uint32_t)dset_info->type_info.src_type_size;
 
                     /* Lock the chunk into the cache */
-                    if (NULL == (chunk = H5D__chunk_lock(io_info, dset_info, &udata, false, false)))
+                    if (NULL == (chunk = H5D__chunk_lock(io_info, dset_info, &udata, false, false, &alloc_chunk_size)))
                         HGOTO_ERROR(H5E_IO, H5E_READERROR, FAIL, "unable to read raw data chunk");
 
                     /* Set up the storage buffer information for this chunk */
                     cpt_store.compact.buf = chunk;
+                    cpt_store.compact.size = alloc_chunk_size;
 
                     /* Point I/O info at contiguous I/O info for this chunk */
                     chk_io_info = &cpt_io_info;
@@ -3009,6 +3012,7 @@ H5D__chunk_write(H5D_io_info_t *io_info, H5D_dset_io_info_t *dset_info)
     H5S_t             *chunk_file_spaces_local[8]; /* Local buffer for chunk_file_spaces */
     haddr_t           *chunk_addrs = NULL;         /* Array of chunk addresses */
     haddr_t            chunk_addrs_local[8];       /* Local buffer for chunk_addrs */
+    size_t             alloc_chunk_size = 0;       /* Size of allocated chunk buffer */
     herr_t             ret_value = SUCCEED;        /* Return value        */
 
     FUNC_ENTER_PACKAGE
@@ -3129,11 +3133,12 @@ H5D__chunk_write(H5D_io_info_t *io_info, H5D_dset_io_info_t *dset_info)
                     entire_chunk = false;
 
                 /* Lock the chunk into the cache */
-                if (NULL == (chunk = H5D__chunk_lock(io_info, dset_info, &udata, entire_chunk, false)))
+                if (NULL == (chunk = H5D__chunk_lock(io_info, dset_info, &udata, entire_chunk, false, &alloc_chunk_size)))
                     HGOTO_ERROR(H5E_IO, H5E_READERROR, FAIL, "unable to read raw data chunk");
 
                 /* Set up the storage buffer information for this chunk */
                 cpt_store.compact.buf = chunk;
+                cpt_store.compact.size = alloc_chunk_size;
 
                 /* Set up compact dataset info for write to cached chunk */
                 cpt_dset_info.layout_io_info.contig_piece_info = chunk_info;
@@ -3298,11 +3303,12 @@ H5D__chunk_write(H5D_io_info_t *io_info, H5D_dset_io_info_t *dset_info)
                     entire_chunk = false;
 
                 /* Lock the chunk into the cache */
-                if (NULL == (chunk = H5D__chunk_lock(io_info, dset_info, &udata, entire_chunk, false)))
+                if (NULL == (chunk = H5D__chunk_lock(io_info, dset_info, &udata, entire_chunk, false, &alloc_chunk_size)))
                     HGOTO_ERROR(H5E_IO, H5E_READERROR, FAIL, "unable to read raw data chunk");
 
                 /* Set up the storage buffer information for this chunk */
                 cpt_store.compact.buf = chunk;
+                cpt_store.compact.size = alloc_chunk_size;
 
                 /* Point I/O info at main I/O info for this chunk */
                 chk_io_info = &cpt_io_info;
@@ -4322,7 +4328,7 @@ done:
  */
 static void *
 H5D__chunk_lock(const H5D_io_info_t H5_ATTR_NDEBUG_UNUSED *io_info, const H5D_dset_io_info_t *dset_info,
-                H5D_chunk_ud_t *udata, bool relax, bool prev_unfilt_chunk)
+                H5D_chunk_ud_t *udata, bool relax, bool prev_unfilt_chunk, size_t *alloc_chunk_size)
 {
     const H5D_t *dset;      /* Convenience pointer to the dataset */
     H5O_pline_t *pline;     /* I/O pipeline info - always equal to the pline passed to H5D__chunk_mem_alloc */
@@ -4348,6 +4354,9 @@ H5D__chunk_lock(const H5D_io_info_t H5_ATTR_NDEBUG_UNUSED *io_info, const H5D_ds
     assert(dset);
     assert(udata);
     assert(!(udata->new_unfilt_chunk && prev_unfilt_chunk));
+
+    /* Initialize return */
+    *alloc_chunk_size = 0;
 
     /* Set convenience pointers */
     pline     = &(dset->shared->dcpl_cache.pline);
@@ -4536,6 +4545,7 @@ H5D__chunk_lock(const H5D_io_info_t H5_ATTR_NDEBUG_UNUSED *io_info, const H5D_ds
                                                           (udata->new_unfilt_chunk ? old_pline : pline))))
                     HGOTO_ERROR(H5E_RESOURCE, H5E_NOSPACE, NULL,
                                 "memory allocation failed for raw data chunk");
+                *alloc_chunk_size = my_chunk_alloc;
                 if (H5F_shared_block_read(H5F_SHARED(dset->oloc.file), H5FD_MEM_DRAW, chunk_addr,
                                           my_chunk_alloc, chunk) < 0)
                     HGOTO_ERROR(H5E_IO, H5E_READERROR, NULL, "unable to read raw data chunk");
@@ -4553,6 +4563,7 @@ H5D__chunk_lock(const H5D_io_info_t H5_ATTR_NDEBUG_UNUSED *io_info, const H5D_ds
                     if (H5Z_pipeline(old_pline, H5Z_FLAG_REVERSE, &(udata->filter_mask), err_detect,
                                      filter_cb, &my_chunk_alloc, &buf_alloc, &chunk) < 0)
                         HGOTO_ERROR(H5E_DATASET, H5E_CANTFILTER, NULL, "data pipeline read failed");
+                    *alloc_chunk_size = 0;
 
                     /* Reallocate chunk if necessary */
                     if (udata->new_unfilt_chunk) {
@@ -5396,6 +5407,7 @@ H5D__chunk_update_old_edge_chunks(H5D_t *dset, hsize_t old_dim[])
     H5D_dset_io_info_t  chk_dset_info;                    /* Chunked I/O dset info object */
     void               *chunk;                            /* The file chunk  */
     bool                carry; /* Flag to indicate that chunk increment carrys to higher dimension (sorta) */
+    size_t              alloc_chunk_size = 0;        /* Size of allocated chunk buffer */
     herr_t              ret_value = SUCCEED; /* Return value */
 
     FUNC_ENTER_PACKAGE
@@ -5499,7 +5511,7 @@ H5D__chunk_update_old_edge_chunks(H5D_t *dset, hsize_t old_dim[])
                 /* Lock the chunk into cache.  H5D__chunk_lock will take care of
                  * updating the chunk to no longer be an edge chunk. */
                 if (NULL ==
-                    (chunk = (void *)H5D__chunk_lock(&chk_io_info, &chk_dset_info, &chk_udata, false, true)))
+                    (chunk = (void *)H5D__chunk_lock(&chk_io_info, &chk_dset_info, &chk_udata, false, true, &alloc_chunk_size)))
                     HGOTO_ERROR(H5E_DATASET, H5E_READERROR, FAIL, "unable to lock raw data chunk");
 
                 /* Unlock the chunk */
@@ -5782,6 +5794,7 @@ H5D__chunk_prune_fill(H5D_chunk_it_ud1_t *udata, bool new_unfilt_chunk)
     H5D_chunk_ud_t       chk_udata;               /* User data for locking chunk */
     uint32_t             bytes_accessed;          /* Bytes accessed in chunk */
     unsigned             u;                       /* Local index variable */
+    size_t               alloc_chunk_size = 0;    /* Size of allocated chunk buffer */
     herr_t               ret_value = SUCCEED;     /* Return value */
 
     FUNC_ENTER_PACKAGE
@@ -5823,7 +5836,7 @@ H5D__chunk_prune_fill(H5D_chunk_it_ud1_t *udata, bool new_unfilt_chunk)
         HGOTO_ERROR(H5E_DATASET, H5E_CANTSELECT, FAIL, "unable to select hyperslab");
 
     /* Lock the chunk into the cache, to get a pointer to the chunk buffer */
-    if (NULL == (chunk = (void *)H5D__chunk_lock(io_info, udata->dset_info, &chk_udata, false, false)))
+    if (NULL == (chunk = (void *)H5D__chunk_lock(io_info, udata->dset_info, &chk_udata, false, false, &alloc_chunk_size)))
         HGOTO_ERROR(H5E_DATASET, H5E_READERROR, FAIL, "unable to lock raw data chunk");
 
     /* Fill the selection in the memory buffer */

--- a/src/H5Dchunk.c
+++ b/src/H5Dchunk.c
@@ -2679,7 +2679,7 @@ H5D__chunk_read(H5D_io_info_t *io_info, H5D_dset_io_info_t *dset_info)
     haddr_t           *chunk_addrs = NULL;          /* Array of chunk addresses */
     haddr_t            chunk_addrs_local[8];        /* Local buffer for chunk_addrs */
     size_t             alloc_chunk_size = 0;        /* Size of allocated chunk buffer */
-    herr_t             ret_value = SUCCEED;         /*return value        */
+    herr_t             ret_value        = SUCCEED;  /*return value        */
 
     FUNC_ENTER_PACKAGE
 
@@ -2924,11 +2924,12 @@ H5D__chunk_read(H5D_io_info_t *io_info, H5D_dset_io_info_t *dset_info)
                         (uint32_t)chunk_info->piece_points * (uint32_t)dset_info->type_info.src_type_size;
 
                     /* Lock the chunk into the cache */
-                    if (NULL == (chunk = H5D__chunk_lock(io_info, dset_info, &udata, false, false, &alloc_chunk_size)))
+                    if (NULL == (chunk = H5D__chunk_lock(io_info, dset_info, &udata, false, false,
+                                                         &alloc_chunk_size)))
                         HGOTO_ERROR(H5E_IO, H5E_READERROR, FAIL, "unable to read raw data chunk");
 
                     /* Set up the storage buffer information for this chunk */
-                    cpt_store.compact.buf = chunk;
+                    cpt_store.compact.buf  = chunk;
                     cpt_store.compact.size = alloc_chunk_size;
 
                     /* Point I/O info at contiguous I/O info for this chunk */
@@ -3013,7 +3014,7 @@ H5D__chunk_write(H5D_io_info_t *io_info, H5D_dset_io_info_t *dset_info)
     haddr_t           *chunk_addrs = NULL;         /* Array of chunk addresses */
     haddr_t            chunk_addrs_local[8];       /* Local buffer for chunk_addrs */
     size_t             alloc_chunk_size = 0;       /* Size of allocated chunk buffer */
-    herr_t             ret_value = SUCCEED;        /* Return value        */
+    herr_t             ret_value        = SUCCEED; /* Return value        */
 
     FUNC_ENTER_PACKAGE
 
@@ -3133,11 +3134,12 @@ H5D__chunk_write(H5D_io_info_t *io_info, H5D_dset_io_info_t *dset_info)
                     entire_chunk = false;
 
                 /* Lock the chunk into the cache */
-                if (NULL == (chunk = H5D__chunk_lock(io_info, dset_info, &udata, entire_chunk, false, &alloc_chunk_size)))
+                if (NULL == (chunk = H5D__chunk_lock(io_info, dset_info, &udata, entire_chunk, false,
+                                                     &alloc_chunk_size)))
                     HGOTO_ERROR(H5E_IO, H5E_READERROR, FAIL, "unable to read raw data chunk");
 
                 /* Set up the storage buffer information for this chunk */
-                cpt_store.compact.buf = chunk;
+                cpt_store.compact.buf  = chunk;
                 cpt_store.compact.size = alloc_chunk_size;
 
                 /* Set up compact dataset info for write to cached chunk */
@@ -3303,11 +3305,12 @@ H5D__chunk_write(H5D_io_info_t *io_info, H5D_dset_io_info_t *dset_info)
                     entire_chunk = false;
 
                 /* Lock the chunk into the cache */
-                if (NULL == (chunk = H5D__chunk_lock(io_info, dset_info, &udata, entire_chunk, false, &alloc_chunk_size)))
+                if (NULL == (chunk = H5D__chunk_lock(io_info, dset_info, &udata, entire_chunk, false,
+                                                     &alloc_chunk_size)))
                     HGOTO_ERROR(H5E_IO, H5E_READERROR, FAIL, "unable to read raw data chunk");
 
                 /* Set up the storage buffer information for this chunk */
-                cpt_store.compact.buf = chunk;
+                cpt_store.compact.buf  = chunk;
                 cpt_store.compact.size = alloc_chunk_size;
 
                 /* Point I/O info at main I/O info for this chunk */
@@ -5407,8 +5410,8 @@ H5D__chunk_update_old_edge_chunks(H5D_t *dset, hsize_t old_dim[])
     H5D_dset_io_info_t  chk_dset_info;                    /* Chunked I/O dset info object */
     void               *chunk;                            /* The file chunk  */
     bool                carry; /* Flag to indicate that chunk increment carrys to higher dimension (sorta) */
-    size_t              alloc_chunk_size = 0;        /* Size of allocated chunk buffer */
-    herr_t              ret_value = SUCCEED; /* Return value */
+    size_t              alloc_chunk_size = 0;       /* Size of allocated chunk buffer */
+    herr_t              ret_value        = SUCCEED; /* Return value */
 
     FUNC_ENTER_PACKAGE
 
@@ -5510,8 +5513,8 @@ H5D__chunk_update_old_edge_chunks(H5D_t *dset, hsize_t old_dim[])
             if (H5_addr_defined(chk_udata.chunk_block.offset) || (UINT_MAX != chk_udata.idx_hint)) {
                 /* Lock the chunk into cache.  H5D__chunk_lock will take care of
                  * updating the chunk to no longer be an edge chunk. */
-                if (NULL ==
-                    (chunk = (void *)H5D__chunk_lock(&chk_io_info, &chk_dset_info, &chk_udata, false, true, &alloc_chunk_size)))
+                if (NULL == (chunk = (void *)H5D__chunk_lock(&chk_io_info, &chk_dset_info, &chk_udata, false,
+                                                             true, &alloc_chunk_size)))
                     HGOTO_ERROR(H5E_DATASET, H5E_READERROR, FAIL, "unable to lock raw data chunk");
 
                 /* Unlock the chunk */
@@ -5785,17 +5788,17 @@ H5D__chunk_prune_fill(H5D_chunk_it_ud1_t *udata, bool new_unfilt_chunk)
     const H5O_layout_t  *layout          = &(dset->shared->layout); /* Dataset's layout */
     unsigned             rank            = udata->common.layout->ndims - 1; /* Dataset rank */
     const hsize_t       *scaled          = udata->common.scaled;            /* Scaled chunk offset */
-    H5S_sel_iter_t      *chunk_iter      = NULL;  /* Memory selection iteration info */
-    bool                 chunk_iter_init = false; /* Whether the chunk iterator has been initialized */
-    hsize_t              sel_nelmts;              /* Number of elements in selection */
-    hsize_t              count[H5O_LAYOUT_NDIMS]; /* Element count of hyperslab */
-    size_t               chunk_size;              /*size of a chunk       */
-    void                *chunk;                   /* The file chunk  */
-    H5D_chunk_ud_t       chk_udata;               /* User data for locking chunk */
-    uint32_t             bytes_accessed;          /* Bytes accessed in chunk */
-    unsigned             u;                       /* Local index variable */
-    size_t               alloc_chunk_size = 0;    /* Size of allocated chunk buffer */
-    herr_t               ret_value = SUCCEED;     /* Return value */
+    H5S_sel_iter_t      *chunk_iter      = NULL;     /* Memory selection iteration info */
+    bool                 chunk_iter_init = false;    /* Whether the chunk iterator has been initialized */
+    hsize_t              sel_nelmts;                 /* Number of elements in selection */
+    hsize_t              count[H5O_LAYOUT_NDIMS];    /* Element count of hyperslab */
+    size_t               chunk_size;                 /*size of a chunk       */
+    void                *chunk;                      /* The file chunk  */
+    H5D_chunk_ud_t       chk_udata;                  /* User data for locking chunk */
+    uint32_t             bytes_accessed;             /* Bytes accessed in chunk */
+    unsigned             u;                          /* Local index variable */
+    size_t               alloc_chunk_size = 0;       /* Size of allocated chunk buffer */
+    herr_t               ret_value        = SUCCEED; /* Return value */
 
     FUNC_ENTER_PACKAGE
 
@@ -5836,7 +5839,8 @@ H5D__chunk_prune_fill(H5D_chunk_it_ud1_t *udata, bool new_unfilt_chunk)
         HGOTO_ERROR(H5E_DATASET, H5E_CANTSELECT, FAIL, "unable to select hyperslab");
 
     /* Lock the chunk into the cache, to get a pointer to the chunk buffer */
-    if (NULL == (chunk = (void *)H5D__chunk_lock(io_info, udata->dset_info, &chk_udata, false, false, &alloc_chunk_size)))
+    if (NULL == (chunk = (void *)H5D__chunk_lock(io_info, udata->dset_info, &chk_udata, false, false,
+                                                 &alloc_chunk_size)))
         HGOTO_ERROR(H5E_DATASET, H5E_READERROR, FAIL, "unable to lock raw data chunk");
 
     /* Fill the selection in the memory buffer */

--- a/src/H5Dchunk.c
+++ b/src/H5Dchunk.c
@@ -136,6 +136,7 @@ typedef struct H5D_rdcc_ent_t {
     H5F_block_t            chunk_block;              /*offset/length of chunk in file        */
     hsize_t                chunk_idx;                /*index of chunk in dataset             */
     uint8_t               *chunk;                    /*the unfiltered chunk data        */
+    size_t                 chunk_size;               /*size of the unfiltered chunk data        */
     unsigned               idx;                      /*index in hash table            */
     struct H5D_rdcc_ent_t *next;                     /*next item in doubly-linked list    */
     struct H5D_rdcc_ent_t *prev;                     /*previous item in doubly-linked list    */
@@ -4010,6 +4011,7 @@ H5D__chunk_flush_entry(const H5D_t *dset, H5D_rdcc_ent_t *ent, bool reset)
                  */
                 point_of_no_return = true;
                 ent->chunk         = NULL;
+                ent->chunk_size    = 0;
             } /* end else */
             H5_CHECKED_ASSIGN(nbytes, size_t, udata.chunk_block.length, hsize_t);
             if (H5Z_pipeline(&(dset->shared->dcpl_cache.pline), 0, &(udata.filter_mask), err_detect,
@@ -4096,11 +4098,13 @@ H5D__chunk_flush_entry(const H5D_t *dset, H5D_rdcc_ent_t *ent, bool reset)
         point_of_no_return = false;
         if (buf == ent->chunk)
             buf = NULL;
-        if (ent->chunk != NULL)
+        if (ent->chunk != NULL) {
             ent->chunk = (uint8_t *)H5D__chunk_mem_xfree(ent->chunk,
                                                          ((ent->edge_chunk_state & H5D_RDCC_DISABLE_FILTERS)
                                                               ? NULL
                                                               : &(dset->shared->dcpl_cache.pline)));
+            ent->chunk_size = 0;
+        } /* end if */
     } /* end if */
 
 done:
@@ -4115,11 +4119,13 @@ done:
      * list.
      */
     if (ret_value < 0 && point_of_no_return)
-        if (ent->chunk)
+        if (ent->chunk) {
             ent->chunk = (uint8_t *)H5D__chunk_mem_xfree(ent->chunk,
                                                          ((ent->edge_chunk_state & H5D_RDCC_DISABLE_FILTERS)
                                                               ? NULL
                                                               : &(dset->shared->dcpl_cache.pline)));
+            ent->chunk_size = 0;
+        } /* end if */
 
     FUNC_LEAVE_NOAPI(ret_value)
 } /* end H5D__chunk_flush_entry() */
@@ -4155,11 +4161,13 @@ H5D__chunk_cache_evict(const H5D_t *dset, H5D_rdcc_ent_t *ent, bool flush)
     } /* end if */
     else {
         /* Don't flush, just free chunk */
-        if (ent->chunk != NULL)
+        if (ent->chunk != NULL) {
             ent->chunk = (uint8_t *)H5D__chunk_mem_xfree(ent->chunk,
                                                          ((ent->edge_chunk_state & H5D_RDCC_DISABLE_FILTERS)
                                                               ? NULL
                                                               : &(dset->shared->dcpl_cache.pline)));
+            ent->chunk_size = 0;
+        } /* end if */
     } /* end else */
 
     /* Unlink from list */
@@ -4343,6 +4351,7 @@ H5D__chunk_lock(const H5D_io_info_t H5_ATTR_NDEBUG_UNUSED *io_info, const H5D_ds
     H5D_rdcc_t         *rdcc;                    /*raw data chunk cache*/
     H5D_rdcc_ent_t     *ent;                     /*cache entry        */
     size_t              chunk_size;              /*size of a chunk    */
+    size_t              ret_alloc_size  = 0;     /*size of allocated chunk    */
     bool                disable_filters = false; /* Whether to disable filters (when adding to cache) */
     void               *chunk           = NULL;  /*the file chunk    */
     void               *ret_value       = NULL;  /* Return value         */
@@ -4357,9 +4366,6 @@ H5D__chunk_lock(const H5D_io_info_t H5_ATTR_NDEBUG_UNUSED *io_info, const H5D_ds
     assert(dset);
     assert(udata);
     assert(!(udata->new_unfilt_chunk && prev_unfilt_chunk));
-
-    /* Initialize return */
-    *alloc_chunk_size = 0;
 
     /* Set convenience pointers */
     pline     = &(dset->shared->dcpl_cache.pline);
@@ -4420,9 +4426,11 @@ H5D__chunk_lock(const H5D_io_info_t H5_ATTR_NDEBUG_UNUSED *io_info, const H5D_ds
                 if (NULL == (chunk = H5D__chunk_mem_alloc(chunk_size, pline)))
                     HGOTO_ERROR(H5E_RESOURCE, H5E_NOSPACE, NULL,
                                 "memory allocation failed for raw data chunk");
+                ret_alloc_size = chunk_size;
                 H5MM_memcpy(chunk, ent->chunk, chunk_size);
                 ent->chunk = (uint8_t *)H5D__chunk_mem_xfree(ent->chunk, old_pline);
                 ent->chunk = (uint8_t *)chunk;
+                ent->chunk_size = chunk_size;
                 chunk      = NULL;
 
                 /* Mark the chunk as having filters disabled as well as "newly
@@ -4446,10 +4454,12 @@ H5D__chunk_lock(const H5D_io_info_t H5_ATTR_NDEBUG_UNUSED *io_info, const H5D_ds
                 if (NULL == (chunk = H5D__chunk_mem_alloc(chunk_size, pline)))
                     HGOTO_ERROR(H5E_RESOURCE, H5E_NOSPACE, NULL,
                                 "memory allocation failed for raw data chunk");
+                ret_alloc_size = chunk_size;
                 H5MM_memcpy(chunk, ent->chunk, chunk_size);
 
                 ent->chunk = (uint8_t *)H5D__chunk_mem_xfree(ent->chunk, old_pline);
                 ent->chunk = (uint8_t *)chunk;
+                ent->chunk_size = chunk_size;
                 chunk      = NULL;
 
                 /* Mark the chunk as having filters enabled */
@@ -4526,6 +4536,7 @@ H5D__chunk_lock(const H5D_io_info_t H5_ATTR_NDEBUG_UNUSED *io_info, const H5D_ds
 
             if (NULL == (chunk = H5D__chunk_mem_alloc(chunk_size, pline)))
                 HGOTO_ERROR(H5E_RESOURCE, H5E_NOSPACE, NULL, "memory allocation failed for raw data chunk");
+            ret_alloc_size = chunk_size;
 
             /* In the case that some dataset functions look through this data,
              * clear it to all 0s. */
@@ -4548,7 +4559,7 @@ H5D__chunk_lock(const H5D_io_info_t H5_ATTR_NDEBUG_UNUSED *io_info, const H5D_ds
                                                           (udata->new_unfilt_chunk ? old_pline : pline))))
                     HGOTO_ERROR(H5E_RESOURCE, H5E_NOSPACE, NULL,
                                 "memory allocation failed for raw data chunk");
-                *alloc_chunk_size = my_chunk_alloc;
+                ret_alloc_size = my_chunk_alloc;
                 if (H5F_shared_block_read(H5F_SHARED(dset->oloc.file), H5FD_MEM_DRAW, chunk_addr,
                                           my_chunk_alloc, chunk) < 0)
                     HGOTO_ERROR(H5E_IO, H5E_READERROR, NULL, "unable to read raw data chunk");
@@ -4566,7 +4577,7 @@ H5D__chunk_lock(const H5D_io_info_t H5_ATTR_NDEBUG_UNUSED *io_info, const H5D_ds
                     if (H5Z_pipeline(old_pline, H5Z_FLAG_REVERSE, &(udata->filter_mask), err_detect,
                                      filter_cb, &my_chunk_alloc, &buf_alloc, &chunk) < 0)
                         HGOTO_ERROR(H5E_DATASET, H5E_CANTFILTER, NULL, "data pipeline read failed");
-                    *alloc_chunk_size = 0;
+                    ret_alloc_size = buf_alloc;
 
                     /* Reallocate chunk if necessary */
                     if (udata->new_unfilt_chunk) {
@@ -4577,6 +4588,7 @@ H5D__chunk_lock(const H5D_io_info_t H5_ATTR_NDEBUG_UNUSED *io_info, const H5D_ds
                             HGOTO_ERROR(H5E_RESOURCE, H5E_NOSPACE, NULL,
                                         "memory allocation failed for raw data chunk");
                         } /* end if */
+                        ret_alloc_size = my_chunk_alloc;
                         H5MM_memcpy(chunk, tmp_chunk, chunk_size);
                         (void)H5D__chunk_mem_xfree(tmp_chunk, old_pline);
                     } /* end if */
@@ -4596,6 +4608,7 @@ H5D__chunk_lock(const H5D_io_info_t H5_ATTR_NDEBUG_UNUSED *io_info, const H5D_ds
                 if (NULL == (chunk = H5D__chunk_mem_alloc(chunk_size, pline)))
                     HGOTO_ERROR(H5E_RESOURCE, H5E_NOSPACE, NULL,
                                 "memory allocation failed for raw data chunk");
+                ret_alloc_size = chunk_size;
 
                 if (H5P_is_fill_value_defined(fill, &fill_status) < 0)
                     HGOTO_ERROR(H5E_PLIST, H5E_CANTGET, NULL, "can't tell if fill value defined");
@@ -4662,6 +4675,7 @@ H5D__chunk_lock(const H5D_io_info_t H5_ATTR_NDEBUG_UNUSED *io_info, const H5D_ds
                 H5_CHECKED_ASSIGN(ent->rd_count, uint32_t, chunk_size, size_t);
                 H5_CHECKED_ASSIGN(ent->wr_count, uint32_t, chunk_size, size_t);
                 ent->chunk = (uint8_t *)chunk;
+                ent->chunk_size = ret_alloc_size;
 
                 /* Add it to the cache */
                 assert(NULL == rdcc->slot[udata->idx_hint]);
@@ -4695,6 +4709,7 @@ H5D__chunk_lock(const H5D_io_info_t H5_ATTR_NDEBUG_UNUSED *io_info, const H5D_ds
         assert(!ent->locked);
         ent->locked = true;
         chunk       = ent->chunk;
+        ret_alloc_size = ent->chunk_size;
     } /* end if */
     else
         /*
@@ -4705,6 +4720,7 @@ H5D__chunk_lock(const H5D_io_info_t H5_ATTR_NDEBUG_UNUSED *io_info, const H5D_ds
         udata->idx_hint = UINT_MAX;
 
     /* Set return value */
+    *alloc_chunk_size = ret_alloc_size;
     ret_value = chunk;
 
 done:

--- a/src/H5Dchunk.c
+++ b/src/H5Dchunk.c
@@ -4099,13 +4099,13 @@ H5D__chunk_flush_entry(const H5D_t *dset, H5D_rdcc_ent_t *ent, bool reset)
         if (buf == ent->chunk)
             buf = NULL;
         if (ent->chunk != NULL) {
-            ent->chunk = (uint8_t *)H5D__chunk_mem_xfree(ent->chunk,
-                                                         ((ent->edge_chunk_state & H5D_RDCC_DISABLE_FILTERS)
-                                                              ? NULL
-                                                              : &(dset->shared->dcpl_cache.pline)));
+            ent->chunk      = (uint8_t *)H5D__chunk_mem_xfree(ent->chunk,
+                                                              ((ent->edge_chunk_state & H5D_RDCC_DISABLE_FILTERS)
+                                                                   ? NULL
+                                                                   : &(dset->shared->dcpl_cache.pline)));
             ent->chunk_size = 0;
         } /* end if */
-    } /* end if */
+    }     /* end if */
 
 done:
     /* Free the temp buffer only if it's different than the entry chunk */
@@ -4120,10 +4120,10 @@ done:
      */
     if (ret_value < 0 && point_of_no_return)
         if (ent->chunk) {
-            ent->chunk = (uint8_t *)H5D__chunk_mem_xfree(ent->chunk,
-                                                         ((ent->edge_chunk_state & H5D_RDCC_DISABLE_FILTERS)
-                                                              ? NULL
-                                                              : &(dset->shared->dcpl_cache.pline)));
+            ent->chunk      = (uint8_t *)H5D__chunk_mem_xfree(ent->chunk,
+                                                              ((ent->edge_chunk_state & H5D_RDCC_DISABLE_FILTERS)
+                                                                   ? NULL
+                                                                   : &(dset->shared->dcpl_cache.pline)));
             ent->chunk_size = 0;
         } /* end if */
 
@@ -4162,13 +4162,13 @@ H5D__chunk_cache_evict(const H5D_t *dset, H5D_rdcc_ent_t *ent, bool flush)
     else {
         /* Don't flush, just free chunk */
         if (ent->chunk != NULL) {
-            ent->chunk = (uint8_t *)H5D__chunk_mem_xfree(ent->chunk,
-                                                         ((ent->edge_chunk_state & H5D_RDCC_DISABLE_FILTERS)
-                                                              ? NULL
-                                                              : &(dset->shared->dcpl_cache.pline)));
+            ent->chunk      = (uint8_t *)H5D__chunk_mem_xfree(ent->chunk,
+                                                              ((ent->edge_chunk_state & H5D_RDCC_DISABLE_FILTERS)
+                                                                   ? NULL
+                                                                   : &(dset->shared->dcpl_cache.pline)));
             ent->chunk_size = 0;
         } /* end if */
-    } /* end else */
+    }     /* end else */
 
     /* Unlink from list */
     if (ent->prev)
@@ -4428,10 +4428,10 @@ H5D__chunk_lock(const H5D_io_info_t H5_ATTR_NDEBUG_UNUSED *io_info, const H5D_ds
                                 "memory allocation failed for raw data chunk");
                 ret_alloc_size = chunk_size;
                 H5MM_memcpy(chunk, ent->chunk, chunk_size);
-                ent->chunk = (uint8_t *)H5D__chunk_mem_xfree(ent->chunk, old_pline);
-                ent->chunk = (uint8_t *)chunk;
+                ent->chunk      = (uint8_t *)H5D__chunk_mem_xfree(ent->chunk, old_pline);
+                ent->chunk      = (uint8_t *)chunk;
                 ent->chunk_size = chunk_size;
-                chunk      = NULL;
+                chunk           = NULL;
 
                 /* Mark the chunk as having filters disabled as well as "newly
                  * disabled" so it is inserted on flush */
@@ -4457,10 +4457,10 @@ H5D__chunk_lock(const H5D_io_info_t H5_ATTR_NDEBUG_UNUSED *io_info, const H5D_ds
                 ret_alloc_size = chunk_size;
                 H5MM_memcpy(chunk, ent->chunk, chunk_size);
 
-                ent->chunk = (uint8_t *)H5D__chunk_mem_xfree(ent->chunk, old_pline);
-                ent->chunk = (uint8_t *)chunk;
+                ent->chunk      = (uint8_t *)H5D__chunk_mem_xfree(ent->chunk, old_pline);
+                ent->chunk      = (uint8_t *)chunk;
                 ent->chunk_size = chunk_size;
-                chunk      = NULL;
+                chunk           = NULL;
 
                 /* Mark the chunk as having filters enabled */
                 ent->edge_chunk_state &= ~(H5D_RDCC_DISABLE_FILTERS | H5D_RDCC_NEWLY_DISABLED_FILTERS);
@@ -4674,7 +4674,7 @@ H5D__chunk_lock(const H5D_io_info_t H5_ATTR_NDEBUG_UNUSED *io_info, const H5D_ds
                 H5MM_memcpy(ent->scaled, udata->common.scaled, sizeof(hsize_t) * layout->u.chunk.ndims);
                 H5_CHECKED_ASSIGN(ent->rd_count, uint32_t, chunk_size, size_t);
                 H5_CHECKED_ASSIGN(ent->wr_count, uint32_t, chunk_size, size_t);
-                ent->chunk = (uint8_t *)chunk;
+                ent->chunk      = (uint8_t *)chunk;
                 ent->chunk_size = ret_alloc_size;
 
                 /* Add it to the cache */
@@ -4707,8 +4707,8 @@ H5D__chunk_lock(const H5D_io_info_t H5_ATTR_NDEBUG_UNUSED *io_info, const H5D_ds
     /* Lock the chunk into the cache */
     if (ent) {
         assert(!ent->locked);
-        ent->locked = true;
-        chunk       = ent->chunk;
+        ent->locked    = true;
+        chunk          = ent->chunk;
         ret_alloc_size = ent->chunk_size;
     } /* end if */
     else
@@ -4721,7 +4721,7 @@ H5D__chunk_lock(const H5D_io_info_t H5_ATTR_NDEBUG_UNUSED *io_info, const H5D_ds
 
     /* Set return value */
     *alloc_chunk_size = ret_alloc_size;
-    ret_value = chunk;
+    ret_value         = chunk;
 
 done:
     /* Release the fill buffer info, if it's been initialized */

--- a/src/H5Dcompact.c
+++ b/src/H5Dcompact.c
@@ -388,18 +388,10 @@ H5D__compact_readvv(const H5D_io_info_t *io_info, const H5D_dset_io_info_t *dset
             HGOTO_ERROR(H5E_IO, H5E_WRITEERROR, FAIL, "vectorized memcpy failed");
     }
     else {
-        size_t *src_len_ptr;
-        src_len_ptr = dset_size_arr + *dset_curr_seq;
-        if (dset_info->store->compact.size > 0) {
-            if (dset_info->store->compact.size < *src_len_ptr)
-                HGOTO_ERROR(H5E_IO, H5E_READERROR, FAIL,
-                            "attempting to read more data than allocated compact storage");
-        }
-
         /* Use the vectorized memory copy routine to do actual work */
         if ((ret_value = H5VM_memcpyvv(dset_info->buf.vp, mem_max_nseq, mem_curr_seq, mem_size_arr,
                                        mem_offset_arr, dset_info->store->compact.buf, dset_max_nseq,
-                                       dset_curr_seq, dset_size_arr, dset_offset_arr)) < 0)
+                                       dset_curr_seq, dset_size_arr, dset_offset_arr, dset_info->store->compact.size)) < 0)
             HGOTO_ERROR(H5E_IO, H5E_WRITEERROR, FAIL, "vectorized memcpy failed");
     }
 
@@ -457,7 +449,7 @@ H5D__compact_writevv(const H5D_io_info_t *io_info, const H5D_dset_io_info_t *dse
         /* Use the vectorized memory copy routine to do actual work */
         if ((ret_value = H5VM_memcpyvv(dset_info->store->compact.buf, dset_max_nseq, dset_curr_seq,
                                        dset_size_arr, dset_offset_arr, dset_info->buf.cvp, mem_max_nseq,
-                                       mem_curr_seq, mem_size_arr, mem_offset_arr)) < 0)
+                                       mem_curr_seq, mem_size_arr, mem_offset_arr, 0)) < 0)
             HGOTO_ERROR(H5E_IO, H5E_WRITEERROR, FAIL, "vectorized memcpy failed");
     }
 

--- a/src/H5Dcompact.c
+++ b/src/H5Dcompact.c
@@ -388,6 +388,14 @@ H5D__compact_readvv(const H5D_io_info_t *io_info, const H5D_dset_io_info_t *dset
             HGOTO_ERROR(H5E_IO, H5E_WRITEERROR, FAIL, "vectorized memcpy failed");
     }
     else {
+        size_t *src_len_ptr;
+        src_len_ptr = dset_size_arr + *dset_curr_seq;
+        if (dset_info->store->compact.size > 0) {
+            if (dset_info->store->compact.size < *src_len_ptr)
+                HGOTO_ERROR(H5E_IO, H5E_READERROR, FAIL,
+                            "attempting to read more data than allocated compact storage");
+        }
+
         /* Use the vectorized memory copy routine to do actual work */
         if ((ret_value = H5VM_memcpyvv(dset_info->buf.vp, mem_max_nseq, mem_curr_seq, mem_size_arr,
                                        mem_offset_arr, dset_info->store->compact.buf, dset_max_nseq,

--- a/src/H5Dcompact.c
+++ b/src/H5Dcompact.c
@@ -292,6 +292,7 @@ H5D__compact_io_init(H5D_io_info_t *io_info, H5D_dset_io_info_t *dinfo)
     FUNC_ENTER_PACKAGE_NOERR
 
     dinfo->store->compact.buf               = dinfo->dset->shared->layout.storage.u.compact.buf;
+    dinfo->store->compact.size              = dinfo->dset->shared->layout.storage.u.compact.size;
     dinfo->store->compact.dirty             = &dinfo->dset->shared->layout.storage.u.compact.dirty;
     dinfo->layout_io_info.contig_piece_info = NULL;
 
@@ -449,7 +450,7 @@ H5D__compact_writevv(const H5D_io_info_t *io_info, const H5D_dset_io_info_t *dse
         /* Use the vectorized memory copy routine to do actual work */
         if ((ret_value = H5VM_memcpyvv(dset_info->store->compact.buf, dset_max_nseq, dset_curr_seq,
                                        dset_size_arr, dset_offset_arr, dset_info->buf.cvp, mem_max_nseq,
-                                       mem_curr_seq, mem_size_arr, mem_offset_arr, 0)) < 0)
+                                       mem_curr_seq, mem_size_arr, mem_offset_arr, SIZE_MAX)) < 0)
             HGOTO_ERROR(H5E_IO, H5E_WRITEERROR, FAIL, "vectorized memcpy failed");
     }
 

--- a/src/H5Dcompact.c
+++ b/src/H5Dcompact.c
@@ -389,9 +389,10 @@ H5D__compact_readvv(const H5D_io_info_t *io_info, const H5D_dset_io_info_t *dset
     }
     else {
         /* Use the vectorized memory copy routine to do actual work */
-        if ((ret_value = H5VM_memcpyvv(dset_info->buf.vp, mem_max_nseq, mem_curr_seq, mem_size_arr,
-                                       mem_offset_arr, dset_info->store->compact.buf, dset_max_nseq,
-                                       dset_curr_seq, dset_size_arr, dset_offset_arr, dset_info->store->compact.size)) < 0)
+        if ((ret_value =
+                 H5VM_memcpyvv(dset_info->buf.vp, mem_max_nseq, mem_curr_seq, mem_size_arr, mem_offset_arr,
+                               dset_info->store->compact.buf, dset_max_nseq, dset_curr_seq, dset_size_arr,
+                               dset_offset_arr, dset_info->store->compact.size)) < 0)
             HGOTO_ERROR(H5E_IO, H5E_WRITEERROR, FAIL, "vectorized memcpy failed");
     }
 

--- a/src/H5Dmpio.c
+++ b/src/H5Dmpio.c
@@ -4625,8 +4625,8 @@ H5D__mpio_collective_filtered_chunk_read(H5D_filtered_collective_io_info_t *chun
         iter_nelmts = H5S_GET_SELECT_NPOINTS(chunk_info->fspace);
 
         if (H5D_select_io_mem(chunk_info->dset_info->buf.vp, chunk_info->mspace, chunk_entry->buf,
-                              chunk_entry->chunk_buf_size, chunk_info->fspace, chunk_info->dset_info->type_info.src_type_size,
-                              (size_t)iter_nelmts) < 0)
+                              chunk_entry->chunk_buf_size, chunk_info->fspace,
+                              chunk_info->dset_info->type_info.src_type_size, (size_t)iter_nelmts) < 0)
             HGOTO_ERROR(H5E_DATASET, H5E_READERROR, FAIL, "couldn't copy chunk data to read buffer");
     }
 
@@ -4846,7 +4846,7 @@ H5D__mpio_collective_filtered_chunk_update(H5D_filtered_collective_io_info_t *ch
 
         iter_nelmts = H5S_GET_SELECT_NPOINTS(chunk_info->mspace);
 
-        if (H5D_select_io_mem(chunk_entry->buf, chunk_info->fspace, chunk_info->dset_info->buf.cvp, SIZE_MAX, 
+        if (H5D_select_io_mem(chunk_entry->buf, chunk_info->fspace, chunk_info->dset_info->buf.cvp, SIZE_MAX,
                               chunk_info->mspace, chunk_info->dset_info->type_info.dst_type_size,
                               (size_t)iter_nelmts) < 0)
             HGOTO_ERROR(H5E_DATASET, H5E_WRITEERROR, FAIL, "couldn't copy chunk data to write buffer");

--- a/src/H5Dmpio.c
+++ b/src/H5Dmpio.c
@@ -4625,7 +4625,7 @@ H5D__mpio_collective_filtered_chunk_read(H5D_filtered_collective_io_info_t *chun
         iter_nelmts = H5S_GET_SELECT_NPOINTS(chunk_info->fspace);
 
         if (H5D_select_io_mem(chunk_info->dset_info->buf.vp, chunk_info->mspace, chunk_entry->buf,
-                              chunk_info->fspace, chunk_info->dset_info->type_info.src_type_size,
+                              chunk_entry->chunk_buf_size, chunk_info->fspace, chunk_info->dset_info->type_info.src_type_size,
                               (size_t)iter_nelmts) < 0)
             HGOTO_ERROR(H5E_DATASET, H5E_READERROR, FAIL, "couldn't copy chunk data to read buffer");
     }
@@ -4846,7 +4846,7 @@ H5D__mpio_collective_filtered_chunk_update(H5D_filtered_collective_io_info_t *ch
 
         iter_nelmts = H5S_GET_SELECT_NPOINTS(chunk_info->mspace);
 
-        if (H5D_select_io_mem(chunk_entry->buf, chunk_info->fspace, chunk_info->dset_info->buf.cvp,
+        if (H5D_select_io_mem(chunk_entry->buf, chunk_info->fspace, chunk_info->dset_info->buf.cvp, SIZE_MAX, 
                               chunk_info->mspace, chunk_info->dset_info->type_info.dst_type_size,
                               (size_t)iter_nelmts) < 0)
             HGOTO_ERROR(H5E_DATASET, H5E_WRITEERROR, FAIL, "couldn't copy chunk data to write buffer");

--- a/src/H5Dpkg.h
+++ b/src/H5Dpkg.h
@@ -719,8 +719,8 @@ H5_DLL herr_t H5D__select_read(const H5D_io_info_t *io_info, const H5D_dset_io_i
 H5_DLL herr_t H5D__select_write(const H5D_io_info_t *io_info, const H5D_dset_io_info_t *dset_info);
 
 /* Functions that perform direct copying between memory buffers */
-H5_DLL herr_t H5D_select_io_mem(void *dst_buf, H5S_t *dst_space, const void *src_buf, H5S_t *src_space,
-                                size_t elmt_size, size_t nelmts);
+H5_DLL herr_t H5D_select_io_mem(void *dst_buf, H5S_t *dst_space, const void *src_buf, size_t src_buf_size, 
+                                H5S_t *src_space, size_t elmt_size, size_t nelmts);
 
 /* Functions that perform scatter-gather I/O operations */
 H5_DLL herr_t H5D__scatter_mem(const void *_tscat_buf, H5S_sel_iter_t *iter, size_t nelmts, void *_buf);

--- a/src/H5Dpkg.h
+++ b/src/H5Dpkg.h
@@ -719,7 +719,7 @@ H5_DLL herr_t H5D__select_read(const H5D_io_info_t *io_info, const H5D_dset_io_i
 H5_DLL herr_t H5D__select_write(const H5D_io_info_t *io_info, const H5D_dset_io_info_t *dset_info);
 
 /* Functions that perform direct copying between memory buffers */
-H5_DLL herr_t H5D_select_io_mem(void *dst_buf, H5S_t *dst_space, const void *src_buf, size_t src_buf_size, 
+H5_DLL herr_t H5D_select_io_mem(void *dst_buf, H5S_t *dst_space, const void *src_buf, size_t src_buf_size,
                                 H5S_t *src_space, size_t elmt_size, size_t nelmts);
 
 /* Functions that perform scatter-gather I/O operations */

--- a/src/H5Dpkg.h
+++ b/src/H5Dpkg.h
@@ -263,6 +263,7 @@ typedef struct {
 
 typedef struct {
     void *buf;   /* Buffer for compact dataset */
+    size_t size; /* Size of buffer in bytes */
     bool *dirty; /* Pointer to dirty flag to mark */
 } H5D_compact_storage_t;
 

--- a/src/H5Dpkg.h
+++ b/src/H5Dpkg.h
@@ -262,9 +262,9 @@ typedef struct {
 } H5D_chunk_storage_t;
 
 typedef struct {
-    void *buf;   /* Buffer for compact dataset */
-    size_t size; /* Size of buffer in bytes */
-    bool *dirty; /* Pointer to dirty flag to mark */
+    void  *buf;   /* Buffer for compact dataset */
+    size_t size;  /* Size of buffer in bytes */
+    bool  *dirty; /* Pointer to dirty flag to mark */
 } H5D_compact_storage_t;
 
 typedef union H5D_storage_t {

--- a/src/H5Dselect.c
+++ b/src/H5Dselect.c
@@ -273,7 +273,7 @@ done:
  *-------------------------------------------------------------------------
  */
 herr_t
-H5D_select_io_mem(void *dst_buf, H5S_t *dst_space, const void *src_buf, H5S_t *src_space, size_t elmt_size,
+H5D_select_io_mem(void *dst_buf, H5S_t *dst_space, const void *src_buf, size_t src_buf_size, H5S_t *src_space, size_t elmt_size,
                   size_t nelmts)
 {
     H5S_sel_iter_t *dst_sel_iter      = NULL;  /* Destination dataspace iteration info */
@@ -326,7 +326,7 @@ H5D_select_io_mem(void *dst_buf, H5S_t *dst_space, const void *src_buf, H5S_t *s
         /* Perform vectorized memcpy from src_buf to dst_buf */
         if ((bytes_copied =
                  H5VM_memcpyvv(dst_buf, dst_nseq, &curr_dst_seq, &single_dst_len, &single_dst_off, src_buf,
-                               src_nseq, &curr_src_seq, &single_src_len, &single_src_off, 0)) < 0)
+                               src_nseq, &curr_src_seq, &single_src_len, &single_src_off, src_buf_size)) < 0)
             HGOTO_ERROR(H5E_IO, H5E_WRITEERROR, FAIL, "vectorized memcpy failed");
 
         assert(((size_t)bytes_copied % elmt_size) == 0);
@@ -401,7 +401,7 @@ H5D_select_io_mem(void *dst_buf, H5S_t *dst_space, const void *src_buf, H5S_t *s
 
             /* Perform vectorized memcpy from src_buf to dst_buf */
             if ((bytes_copied = H5VM_memcpyvv(dst_buf, dst_nseq, &curr_dst_seq, dst_len, dst_off, src_buf,
-                                              src_nseq, &curr_src_seq, src_len, src_off, 0)) < 0)
+                                              src_nseq, &curr_src_seq, src_len, src_off, src_buf_size)) < 0)
                 HGOTO_ERROR(H5E_IO, H5E_WRITEERROR, FAIL, "vectorized memcpy failed");
 
             /* Decrement number of elements left to process */

--- a/src/H5Dselect.c
+++ b/src/H5Dselect.c
@@ -273,8 +273,8 @@ done:
  *-------------------------------------------------------------------------
  */
 herr_t
-H5D_select_io_mem(void *dst_buf, H5S_t *dst_space, const void *src_buf, size_t src_buf_size, H5S_t *src_space, size_t elmt_size,
-                  size_t nelmts)
+H5D_select_io_mem(void *dst_buf, H5S_t *dst_space, const void *src_buf, size_t src_buf_size, H5S_t *src_space,
+                  size_t elmt_size, size_t nelmts)
 {
     H5S_sel_iter_t *dst_sel_iter      = NULL;  /* Destination dataspace iteration info */
     H5S_sel_iter_t *src_sel_iter      = NULL;  /* Source dataspace iteration info */

--- a/src/H5Dselect.c
+++ b/src/H5Dselect.c
@@ -326,7 +326,7 @@ H5D_select_io_mem(void *dst_buf, H5S_t *dst_space, const void *src_buf, H5S_t *s
         /* Perform vectorized memcpy from src_buf to dst_buf */
         if ((bytes_copied =
                  H5VM_memcpyvv(dst_buf, dst_nseq, &curr_dst_seq, &single_dst_len, &single_dst_off, src_buf,
-                               src_nseq, &curr_src_seq, &single_src_len, &single_src_off)) < 0)
+                               src_nseq, &curr_src_seq, &single_src_len, &single_src_off, 0)) < 0)
             HGOTO_ERROR(H5E_IO, H5E_WRITEERROR, FAIL, "vectorized memcpy failed");
 
         assert(((size_t)bytes_copied % elmt_size) == 0);
@@ -401,7 +401,7 @@ H5D_select_io_mem(void *dst_buf, H5S_t *dst_space, const void *src_buf, H5S_t *s
 
             /* Perform vectorized memcpy from src_buf to dst_buf */
             if ((bytes_copied = H5VM_memcpyvv(dst_buf, dst_nseq, &curr_dst_seq, dst_len, dst_off, src_buf,
-                                              src_nseq, &curr_src_seq, src_len, src_off)) < 0)
+                                              src_nseq, &curr_src_seq, src_len, src_off, 0)) < 0)
                 HGOTO_ERROR(H5E_IO, H5E_WRITEERROR, FAIL, "vectorized memcpy failed");
 
             /* Decrement number of elements left to process */

--- a/src/H5VM.c
+++ b/src/H5VM.c
@@ -1369,8 +1369,8 @@ H5VM_memcpyvv(void *_dst, size_t dst_max_nseq, size_t *dst_curr_seq, size_t dst_
     max_src_off_ptr = src_off_arr + src_max_nseq;
 
     /* Compute buffer offsets */
-    dst = (unsigned char *)_dst + *dst_off_ptr;
-    src = (const unsigned char *)_src + *src_off_ptr;
+    dst      = (unsigned char *)_dst + *dst_off_ptr;
+    src      = (const unsigned char *)_src + *src_off_ptr;
     _src_end = (const unsigned char *)_src + src_alloc_size;
 
     /* Work through the sequences */

--- a/src/H5VM.c
+++ b/src/H5VM.c
@@ -1331,6 +1331,7 @@ H5VM_memcpyvv(void *_dst, size_t dst_max_nseq, size_t *dst_curr_seq, size_t dst_
 {
     unsigned char       *dst;                   /* Destination buffer pointer */
     const unsigned char *src;                   /* Source buffer pointer */
+    const unsigned char *_src_end;              /* End of source buffer pointer */
     hsize_t *max_dst_off_ptr, *max_src_off_ptr; /* Pointers to max. source and destination offset locations */
     hsize_t *dst_off_ptr, *src_off_ptr;         /* Pointers to source and destination offset arrays */
     size_t  *dst_len_ptr, *src_len_ptr;         /* Pointers to source and destination length arrays */
@@ -1370,12 +1371,7 @@ H5VM_memcpyvv(void *_dst, size_t dst_max_nseq, size_t *dst_curr_seq, size_t dst_
     /* Compute buffer offsets */
     dst = (unsigned char *)_dst + *dst_off_ptr;
     src = (const unsigned char *)_src + *src_off_ptr;
-
-    /* Check if src buffer size is less than expected */
-    if (src_alloc_size > 0) {
-        if (src_alloc_size < tmp_src_len)
-            HGOTO_ERROR(H5E_INTERNAL, H5E_CANTOPERATE, FAIL, "src buffer size is less than expected");
-    }
+    _src_end = (const unsigned char *)_src + src_alloc_size;
 
     /* Work through the sequences */
     /* (Choose smallest sequence available initially) */
@@ -1385,6 +1381,8 @@ H5VM_memcpyvv(void *_dst, size_t dst_max_nseq, size_t *dst_curr_seq, size_t dst_
 src_smaller:
         acc_len = 0;
         do {
+            if (H5_IS_BUFFER_OVERFLOW(src, tmp_src_len, _src_end))
+                HGOTO_ERROR(H5E_INTERNAL, H5E_OVERFLOW, (-1), "src buffer overflow");
             /* Copy data */
             H5MM_memcpy(dst, src, tmp_src_len);
 
@@ -1428,6 +1426,8 @@ src_smaller:
 dst_smaller:
         acc_len = 0;
         do {
+            if (H5_IS_BUFFER_OVERFLOW(src, tmp_dst_len, _src_end))
+                HGOTO_ERROR(H5E_INTERNAL, H5E_OVERFLOW, (-1), "src buffer overflow");
             /* Copy data */
             H5MM_memcpy(dst, src, tmp_dst_len);
 
@@ -1471,6 +1471,8 @@ dst_smaller:
 equal:
         acc_len = 0;
         do {
+            if (H5_IS_BUFFER_OVERFLOW(src, tmp_dst_len, _src_end))
+                HGOTO_ERROR(H5E_INTERNAL, H5E_OVERFLOW, (-1), "src buffer overflow");
             /* Copy data */
             H5MM_memcpy(dst, src, tmp_dst_len);
 

--- a/src/H5VM.c
+++ b/src/H5VM.c
@@ -1327,7 +1327,7 @@ done:
 ssize_t
 H5VM_memcpyvv(void *_dst, size_t dst_max_nseq, size_t *dst_curr_seq, size_t dst_len_arr[],
               hsize_t dst_off_arr[], const void *_src, size_t src_max_nseq, size_t *src_curr_seq,
-              size_t src_len_arr[], hsize_t src_off_arr[])
+              size_t src_len_arr[], hsize_t src_off_arr[], size_t src_alloc_size)
 {
     unsigned char       *dst;                   /* Destination buffer pointer */
     const unsigned char *src;                   /* Source buffer pointer */
@@ -1339,7 +1339,7 @@ H5VM_memcpyvv(void *_dst, size_t dst_max_nseq, size_t *dst_curr_seq, size_t dst_
     size_t   acc_len;                           /* Accumulated length of sequences */
     ssize_t  ret_value = 0;                     /* Return value (Total size of sequence in bytes) */
 
-    FUNC_ENTER_NOAPI_NOINIT_NOERR
+    FUNC_ENTER_NOAPI_NOINIT
 
     /* Sanity check */
     assert(_dst);
@@ -1370,6 +1370,12 @@ H5VM_memcpyvv(void *_dst, size_t dst_max_nseq, size_t *dst_curr_seq, size_t dst_
     /* Compute buffer offsets */
     dst = (unsigned char *)_dst + *dst_off_ptr;
     src = (const unsigned char *)_src + *src_off_ptr;
+
+    /* Check if src buffer size is less than expected */
+    if (src_alloc_size > 0) {
+        if (src_alloc_size < tmp_src_len)
+            HGOTO_ERROR(H5E_INTERNAL, H5E_CANTOPERATE, FAIL, "src buffer size is less than expected");
+    }
 
     /* Work through the sequences */
     /* (Choose smallest sequence available initially) */
@@ -1507,5 +1513,6 @@ finished:
     *dst_curr_seq = (size_t)(dst_off_ptr - dst_off_arr);
     *src_curr_seq = (size_t)(src_off_ptr - src_off_arr);
 
+done:
     FUNC_LEAVE_NOAPI(ret_value)
 } /* end H5VM_memcpyvv() */

--- a/src/H5VMprivate.h
+++ b/src/H5VMprivate.h
@@ -115,7 +115,8 @@ H5_DLL ssize_t H5VM_opvv(size_t dst_max_nseq, size_t *dst_curr_seq, size_t dst_l
                          size_t src_len_arr[], hsize_t src_off_arr[], H5VM_opvv_func_t op, void *op_data);
 H5_DLL ssize_t H5VM_memcpyvv(void *_dst, size_t dst_max_nseq, size_t *dst_curr_seq, size_t dst_len_arr[],
                              hsize_t dst_off_arr[], const void *_src, size_t src_max_nseq,
-                             size_t *src_curr_seq, size_t src_len_arr[], hsize_t src_off_arr[]);
+                             size_t *src_curr_seq, size_t src_len_arr[], hsize_t src_off_arr[],
+                             size_t src_alloc_size);
 
 /*-------------------------------------------------------------------------
  * Function:    H5VM_vector_reduce_product


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Add `size` field to `H5D_compact_storage_t` and update related functions to prevent buffer overflows.
> 
>   - **Behavior**:
>     - Add `size` field to `H5D_compact_storage_t` to track buffer size.
>     - Update `H5D__compact_readvv()` in `H5Dcompact.c` to check buffer size before reading.
>     - Modify `H5D__chunk_lock()` in `H5Dchunk.c` to initialize and set `alloc_chunk_size`.
>   - **Functions**:
>     - Update `H5D__chunk_lock()` to accept `size_t *alloc_chunk_size` and set it during chunk allocation.
>     - Modify `H5D__chunk_read()` and `H5D__chunk_write()` in `H5Dchunk.c` to use `alloc_chunk_size`.
>   - **Structures**:
>     - Add `size` field to `H5D_compact_storage_t` in `H5Dpkg.h` to store buffer size.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=HDFGroup%2Fhdf5&utm_source=github&utm_medium=referral)<sup> for 72bdcc40e6a6b2390d92eea54ff6735860b6a680. You can [customize](https://app.ellipsis.dev/HDFGroup/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->