### PR TITLE
Change default nslots value for chunk cache to 8191

### DIFF
--- a/java/test/TestH5Pfapl.java
+++ b/java/test/TestH5Pfapl.java
@@ -720,7 +720,7 @@ public class TestH5Pfapl {
         double[] rdcc_w0   = {0};
         try {
             H5.H5Pget_cache(fapl_id, null, rdcc_nelmts, rdcc_nbytes, rdcc_w0);
-            assertTrue("H5P_cache default", rdcc_nelmts[0] == 521);
+            assertTrue("H5P_cache default", rdcc_nelmts[0] == 8191);
             assertTrue("H5P_cache default", rdcc_nbytes[0] == (8 * 1024 * 1024));
             assertTrue("H5P_cache default", rdcc_w0[0] == 0.75);
         }
@@ -748,7 +748,7 @@ public class TestH5Pfapl {
         double[] rdcc_w0   = {0};
         try {
             H5.H5Pget_chunk_cache(dapl_id, rdcc_nslots, rdcc_nbytes, rdcc_w0);
-            assertTrue("H5P_chunk_cache default", rdcc_nslots[0] == 521);
+            assertTrue("H5P_chunk_cache default", rdcc_nslots[0] == 8191);
             assertTrue("H5P_chunk_cache default", rdcc_nbytes[0] == (8 * 1024 * 1024));
             assertTrue("H5P_chunk_cache default", rdcc_w0[0] == 0.75);
         }

--- a/release_docs/CHANGELOG.md
+++ b/release_docs/CHANGELOG.md
@@ -185,6 +185,10 @@ All other HDF5 library CMake options are prefixed with `HDF5_`
 
 ## Library
 
+### Changed default chunk cache hash table size to 8191
+
+   In order to reduce hash collisions and take advantage of modern memory capacity, the default hash table size for the chunk cache has been increased from 521 to 8191. This means the hash table will consume approximately 64 KiB per open dataset. This value can be changed with `H5Pset_cache()` or `H5Pset_chunk_cache()`. This value was chosen because it is a prime number close to 8K.
+
 ### Added predefined datatypes for bfloat16 data
 
    Predefined datatypes have been added for little- and big-endian bfloat16 (https://en.wikipedia.org/wiki/Bfloat16_floating-point_format) data.

--- a/src/H5Pfapl.c
+++ b/src/H5Pfapl.c
@@ -86,7 +86,7 @@
 #define H5F_ACS_META_CACHE_INIT_CONFIG_CMP  H5P__facc_cache_config_cmp
 /* Definitions for size of raw data chunk cache(slots) */
 #define H5F_ACS_DATA_CACHE_NUM_SLOTS_SIZE sizeof(size_t)
-#define H5F_ACS_DATA_CACHE_NUM_SLOTS_DEF  521
+#define H5F_ACS_DATA_CACHE_NUM_SLOTS_DEF  8191
 #define H5F_ACS_DATA_CACHE_NUM_SLOTS_ENC  H5P__encode_size_t
 #define H5F_ACS_DATA_CACHE_NUM_SLOTS_DEC  H5P__decode_size_t
 /* Definition for size of raw data chunk cache(bytes) */

--- a/src/H5Ppublic.h
+++ b/src/H5Ppublic.h
@@ -4241,7 +4241,7 @@ H5_DLL herr_t H5Pset_alignment(hid_t fapl_id, hsize_t threshold, hsize_t alignme
  *                        that can fit in \p rdcc_nbytes bytes. For
  *                        maximum performance, this value should be set
  *                        approximately 100 times that number of chunks.
- *                        The default value is 521.
+ *                        The default value is 8191.
  * \param[in] rdcc_nbytes Total size of the raw data chunk cache in bytes.
  *                        The default size is 8 MiB per dataset.
  * \param[in] rdcc_w0     The chunk preemption policy for all datasets.
@@ -7552,7 +7552,7 @@ H5_DLL herr_t H5Pset_append_flush(hid_t dapl_id, unsigned ndims, const hsize_t b
  *                        that can fit in \p rdcc_nbytes bytes. For maximum
  *                        performance, this value should be set
  *                        approximately 100 times that number of chunks.
- *                        The default value is 521. If the value passed is
+ *                        The default value is 8191. If the value passed is
  *                        #H5D_CHUNK_CACHE_NSLOTS_DEFAULT, then the
  *                        property will not be set on \p dapl_id and the
  *                        parameter will come from the file access

--- a/test/cache_tagging.c
+++ b/test/cache_tagging.c
@@ -2749,7 +2749,7 @@ check_dataset_write_tags(void)
         dump_cache(fid);
 #endif /* NDEBUG */ /* end debugging functions */
 
-    /* Verify 10 b-tree nodes belonging to dataset  */
+    /* Verify 19 b-tree nodes belonging to dataset  */
     for (i = 0; i < 19; i++)
         if (verify_tag(fid, H5AC_BT_ID, d_tag) < 0)
             TEST_ERROR;

--- a/test/cache_tagging.c
+++ b/test/cache_tagging.c
@@ -2693,6 +2693,10 @@ check_dataset_write_tags(void)
     if ((H5Dwrite(did, H5T_NATIVE_INT, sid, sid, H5P_DEFAULT, data)) < 0)
         TEST_ERROR;
 
+    /* Flush dataset so all index nodes are created */
+    if (H5Dflush(did) < 0)
+        TEST_ERROR;
+
         /* =================================== */
         /* Verification of Metadata Tag Values */
         /* =================================== */
@@ -2704,7 +2708,7 @@ check_dataset_write_tags(void)
 #endif /* NDEBUG */ /* end debugging functions */
 
     /* Verify 10 b-tree nodes belonging to dataset  */
-    for (i = 0; i < 10; i++)
+    for (i = 0; i < 19; i++)
         if (verify_tag(fid, H5AC_BT_ID, d_tag) < 0)
             TEST_ERROR;
 


### PR DESCRIPTION
In order to reduce hash collisions and take advantage of modern memory capacity, the default hash table size for the chunk cache has been increased from 521 to 8191. This means the hash table will consume approximately 64 KiB per open dataset. This value can be changed with `H5Pset_cache()` or `H5Pset_chunk_cache()`. This value was chosen because it is a prime number close to 8K.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Increase default chunk cache hash table size from 521 to 8191 to reduce hash collisions and improve memory usage.
> 
>   - **Behavior**:
>     - Default hash table size for chunk cache increased from 521 to 8191 in `H5Pfapl.c` and `H5Ppublic.h`.
>     - This change reduces hash collisions and uses approximately 64 KiB per open dataset.
>     - The value can be modified using `H5Pset_cache()` or `H5Pset_chunk_cache()`.
>   - **Documentation**:
>     - Updated `CHANGELOG.md` to document the new default chunk cache hash table size.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=HDFGroup%2Fhdf5&utm_source=github&utm_medium=referral)<sup> for 9c0f440c166eaedcb053eabf9aa44bbfda011ffc. You can [customize](https://app.ellipsis.dev/HDFGroup/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->