### PR TITLE
ci: update oneAPI version to 2025.2

### DIFF
--- a/.github/workflows/intel.yml
+++ b/.github/workflows/intel.yml
@@ -81,7 +81,7 @@ jobs:
         id: setup-fortran
         with:
           compiler: intel
-          version: '2025.0'
+          version: '2025.2'
 
       - name: Configure (Windows)
         shell: pwsh

--- a/.github/workflows/intel.yml
+++ b/.github/workflows/intel.yml
@@ -9,10 +9,6 @@ on:
         required: true
         type: string
 
-
-concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
-  cancel-in-progress: true
 permissions:
   contents: read
 

--- a/.github/workflows/intel.yml
+++ b/.github/workflows/intel.yml
@@ -9,6 +9,10 @@ on:
         required: true
         type: string
 
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
 permissions:
   contents: read
 
@@ -32,7 +36,7 @@ jobs:
         id: setup-fortran
         with:
           compiler: intel
-          version: '2025.0'
+          version: '2025.2'
 
       - name: Configure (Linux)
         shell: bash


### PR DESCRIPTION
close #5969 
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Update oneAPI compiler version to 2025.2 for Linux CI job in `intel.yml`.
> 
>   - **CI Configuration**:
>     - Update oneAPI compiler version from '2025.0' to '2025.2' in `intel.yml` for Linux job.
>     - Windows job remains on version '2025.0'.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=HDFGroup%2Fhdf5&utm_source=github&utm_medium=referral)<sup> for f7bc745e15ca3428bf81c49e313172bb6111e63a. You can [customize](https://app.ellipsis.dev/HDFGroup/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->