### PR TITLE
Cleanup link checker reporting

### DIFF
--- a/.github/workflows/linkchecker.yml
+++ b/.github/workflows/linkchecker.yml
@@ -50,6 +50,7 @@ jobs:
             --max-concurrency 4
             --retry-wait-time 10
             --timeout 30
+            --accept 200..=299,429
             --user-agent "Mozilla/5.0 (compatible; Lychee/v0.1)"
             --skip-missing
             --exclude ".*%23.*"
@@ -74,6 +75,7 @@ jobs:
             "${{ steps.build_docs.outputs.html_path }}/**/*.html"
           output: lychee-report.md
           format: markdown
+          jobSummary: false
           # Let the action fail naturally - we'll handle it in the summary step
           fail: true
 
@@ -104,17 +106,8 @@ jobs:
           echo "" >> "$GITHUB_STEP_SUMMARY"
           echo "### Full Report:" >> "$GITHUB_STEP_SUMMARY"
           if [ -f "lychee-report.md" ]; then
-            # Limit output to first 500 lines to avoid exceeding 1MB GitHub limit
             echo '```' >> "$GITHUB_STEP_SUMMARY"
-            head -n 500 lychee-report.md >> "$GITHUB_STEP_SUMMARY"
-
-            # Check if report was truncated
-            TOTAL_LINES=$(wc -l < lychee-report.md)
-            if [ "$TOTAL_LINES" -gt 500 ]; then
-              echo "" >> "$GITHUB_STEP_SUMMARY"
-              echo "... (Truncated. Showing first 500 of $TOTAL_LINES lines)" >> "$GITHUB_STEP_SUMMARY"
-              echo "View the full job logs for complete results." >> "$GITHUB_STEP_SUMMARY"
-            fi
+            cat lychee-report.md >> "$GITHUB_STEP_SUMMARY"
             echo '```' >> "$GITHUB_STEP_SUMMARY"
           else
             echo "No detailed report available." >> "$GITHUB_STEP_SUMMARY"


### PR DESCRIPTION
Suppresses redirect spam and prevents duplicate output in the reporting
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Suppresses redirect spam and prevents duplicate output in link checker reporting by updating `linkchecker.yml`.
> 
>   - **Behavior**:
>     - Suppresses redirect spam by updating `--accept` argument in `linkchecker.yml` to include status codes 200 to 299 and 429.
>     - Prevents duplicate output by appending the entire `lychee-report.md` to the job summary instead of truncating to 500 lines.
>   - **Misc**:
>     - Removes truncation logic for `lychee-report.md` in `linkchecker.yml`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=HDFGroup%2Fhdf5&utm_source=github&utm_medium=referral)<sup> for 09bcadd517af624f612f2cd1a676a6a94cfeccda. You can [customize](https://app.ellipsis.dev/HDFGroup/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->