### PR TITLE
Edits to autotools to cmake document & added a link to changelog

### DIFF
--- a/release_docs/AutotoolsToCMakeOptions.md
+++ b/release_docs/AutotoolsToCMakeOptions.md
@@ -1,6 +1,6 @@
 # <img src="Cmake_logo.svg" alt="Cmake logo" width=24> CMake Installations
 
-CMake produces the following set of folders; bin, include, lib and share. The LICENSE and RELEASE.txt file are placed in the share folder.
+CMake produces the following set of folders; bin, include, lib and share. The LICENSE and CHANGELOG.md file are placed in the share folder.
 
 The bin folder contains the tools and the build scripts. Additionally, CMake creates dynamic versions of the tools with the suffix "-shared".
 
@@ -26,7 +26,7 @@ release_docs/INSTALL_CMake.txt file for more information on the CMake build syst
 | Autotools Build Options | CMake Build Options | Notes |
 | ------- |  ------- | ------------ |
 | warnings-as-errors[default=no] | HDF5_ENABLE_WARNINGS_AS_ERRORS "Interpret some warnings as errors" [OFF] |  |
-| build-mode[--enable-build-mode=(debug|production|clean)] | CMAKE_BUILD_TYPE "Debug" "Release" "RelWithDebInfo" "MinSizeRel" "Developer" [Release] |  |
+| build-mode[--enable-build-mode=(debug\|production\|clean)] | CMAKE_BUILD_TYPE "Debug" "Release" "RelWithDebInfo" "MinSizeRel" "Developer" [Release] |  |
 | unsupported[Allow unsupported combinations of configure options] | HDF5_ALLOW_UNSUPPORTED "Allow unsupported combinations of configure options" [OFF] |  |
 | nonstandard-features[Enable support for non-standard programming language features[default=yes]] | HDF5_ENABLE_NONSTANDARD_FEATURES "Enable support for non-standard programming language features" [ON] |  |
 | nonstandard-feature-float16[Enable support for _Float16 C datatype [default=yes]] | HDF5_ENABLE_NONSTANDARD_FEATURE_FLOAT16 "Enable support for _Float16 C datatype" [${HDF5_ENABLE_NONSTANDARD_FEATURES}] | if (HDF5_ENABLE_NONSTANDARD_FEATURES) |
@@ -36,9 +36,7 @@ release_docs/INSTALL_CMake.txt file for more information on the CMake build syst
 | szlib[Use szlib library for external szlib I/O filter [default=yes]] | HDF5_ENABLE_SZIP_SUPPORT "Use SZip Filter" [OFF] |  |
 | default-api-version[Specify default release version of public symbols [default=v200]] | HDF5_DEFAULT_API_VERSION "v200" CACHE STRING "Enable v2.0 API (v16, v18, v110, v112, v114, v200)" [v200] |  |
 | default-plugindir[--with-default-plugindir=location], [Specify default location for plugins [default="/usr/local/hdf5/lib/plugin"]] | H5_DEFAULT_PLUGINDIR “Define the default plugins path” | if (WINDOWS)<br>H5_DEFAULT_PLUGINDIR "%ALLUSERSPROFILE%/hdf5/lib/plugin"<br>else ()<br>H5_DEFAULT_PLUGINDIR "/usr/local/hdf5/lib/plugin"<br>endif () |
-
-| Autotools Features Options | CMake Features Options | Notes |
-| ------- |  ------- | ------------ |
+| **Autotools Features Options** | **CMake Features Options** | **Notes** |
 | dimension-scales-with-new-ref[Use new references when creating dimension scales. [default=no]] | HDF5_DIMENSION_SCALES_NEW_REF "Use new-style references with dimension scale APIs" [OFF] |  |
 | map-api[Build the map API (H5M). [default=no]] | HDF5_ENABLE_MAP_API "Build the map API" [OFF] |  |
 | subfiling-vfd[Build the subfiling I/O virtual file driver (VFD). Requires --enable-parallel. [default=no]] | HDF5_ENABLE_SUBFILING_VFD "Build Parallel HDF5 Subfiling VFD" [OFF] | if (HDF5_BUILD_UTILS) |
@@ -50,29 +48,22 @@ release_docs/INSTALL_CMake.txt file for more information on the CMake build syst
 | threadsafe[Enable thread-safe capability. Not compatible with the high-level library, Fortran, or C++ wrappers.  [default=no]] | HDF5_ENABLE_THREADSAFE "Enable Threadsafety" [OFF] |  |
 | file-locking[Sets the default for whether or not to use file locking when opening files. [default=best-effort]] | HDF5_USE_FILE_LOCKING "Use file locking by default (mainly for SWMR)" [ON] | HDF5_IGNORE_DISABLED_FILE_LOCKS "Ignore file locks when disabled on file system" [ON] |
 | enable-concurrency[Support for concurrent multithreaded operation of supported API routines [default=no]] | HDF5_ENABLE_CONCURRENCY "Enable multi-threaded concurrency" [OFF] | This option also provides threadsafe execution of all other, non-concurrent operations. |
-
-| Autotools Language Options | CMake Language Options | Notes |
-| ------- |  ------- | ------------ |
+| **Autotools Language Options** | **CMake Language Options** | **Notes** |
 | fortran[Compile the Fortran interface [default=no]] | HDF5_BUILD_FORTRAN "Build FORTRAN support" [OFF] |  |
 | fmoddir[--with-fmoddir=DIR], [Fortran module install directory] | HDF5_INSTALL_MODULE_DIR=$<INSTALL_PREFIX>/mod |  |
 | cxx[Compile the C++ interface [default=no]] | HDF5_BUILD_CPP_LIB "Build HDF5 C++ Library" [OFF] |  |
 | hl[Enable the high-level library. [default=yes (unless build mode = clean)] | HDF5_BUILD_HL_LIB "Build HIGH Level HDF5 Library" [ON] |  |
 | java[Compile the Java JNI interface [default=no]] | HDF5_BUILD_JAVA "Build JAVA support" [OFF] |  |
 | parallel[Search for MPI-IO and MPI support files] | HDF5_ENABLE_PARALLEL "Enable parallel build (requires MPI)" [OFF] |  |
-
-| Autotools Test Options | CMake Test Options | Notes |
-| ------- |  ------- | ------------ |
+| **Autotools Test Options** | **CMake Test Options** | **Notes** |
 | tests[Compile the HDF5 tests [default=yes]] | BUILD_TESTING "Build HDF5 Unit Testing" [ON] |  |
 | test-express[Set HDF5 testing intensity level (0-3) [0 = exhaustive testing; 3 = quicker testing; default=3] | HDF_TEST_EXPRESS "Control testing framework (0-3)" ["3"] |  |
 | tools[Compile the HDF5 tools [default=yes]] | HDF5_BUILD_TOOLS "Build HDF5 Tools" [ON] |  |
 | parallel-tools[Enable building parallel tools. [default=no]] | HDF5_BUILD_PARALLEL_TOOLS  "Build Parallel HDF5 Tools" [OFF] |  |
-
-| Autotools Doc Options | CMake Doc Options | Notes |
+| **Autotools Doc Options** | **CMake Doc Options** | **Notes** |
 | doxygen[Compile the HDF5 doxygen files [default=no]] | HDF5_BUILD_DOC "Build documentation" [OFF] |  |
 | doxygen-errors[Error on HDF5 doxygen warnings [default=no]] | HDF5_ENABLE_DOXY_WARNINGS "Enable fail if doxygen parsing has warnings." [OFF] |  |
-
-| Autotools Dev Options | CMake Dev Options | Notes |
-| ------- |  ------- | ------------ |
+| **Autotools Dev Options** | **CMake Dev Options** | **Notes** |
 | sanitize-checks[default=none] | HDF5_USE_SANITIZER ["Compile with a sanitizer. Options are: Address, Memory, MemoryWithOrigins, Undefined, Thread, Leak, 'Address;Undefined', CFI"] | Requires HDF5_ENABLE_SANITIZERS "execute the Clang sanitizer" [OFF] |
 | asserts[Determines whether NDEBUG is defined or not, which controls assertions. [default=yes if debug build, otherwise no]] | HDF5_ENABLE_ASSERTS "Determines whether NDEBUG is defined to control assertions." [OFF] |  |
 | developer-warnings[Determines whether developer warnings will be emitted. [default=no]] | HDF5_ENABLE_DEV_WARNINGS "Enable HDF5 developer group warnings" [OFF |  |
@@ -91,9 +82,7 @@ release_docs/INSTALL_CMake.txt file for more information on the CMake build syst
 | strict-format-checks[Enable strict file format checks. [default=yes if debug build, otherwise no]] | HDF5_STRICT_FORMAT_CHECKS "Whether to perform strict file format checks" [OFF] |  |
 | preadwrite[Enable using pread/pwrite instead of read/write in sec2/log/core VFDs. [default=yes if pread/pwrite are present]] | HDF5_ENABLE_PREADWRITE "Use pread/pwrite in sec2/log/core VFDs in place of read/write (when available)" [ON] |  |
 | embedded-libinfo[Enable embedded library information [default=yes]] | HDF5_ENABLE_EMBEDDED_LIBINFO "Embed library info into executables" [ON] |  |
-
-| Autotools Options | CMake Unused | Notes |
-| ------- |  ------- | ------------ |
+| **Autotools Options** | **CMake Unused** | **Notes** |
 | examplesdir[--with-examplesdir=location], [Specify path for examples [default="DATAROOTDIR/hdf5_examples"]] |  |  |
 | libmfu[--with-libmfu=DIR], [Use the libmfu library [default=no]] |  |  |
 | pthread[--with-pthread=DIR][Specify alternative path to Pthreads library] | Handled by HDF5_THREADS_ENABLED |  |

--- a/release_docs/CHANGELOG.md
+++ b/release_docs/CHANGELOG.md
@@ -59,7 +59,7 @@ For releases prior to version 2.0.0, please see the release.txt file and for mor
   
 ## Acknowledgements: 
 
-We would like to thank the many HDF5 community members that contributed to HDF5 2.0.
+We would like to thank the many HDF5 community members who contributed to HDF5 2.0.
 
 # ⚠️ Breaking Changes
 
@@ -105,7 +105,7 @@ We would like to thank the many HDF5 community members that contributed to HDF5 
 
    The `HDF5_ENABLE_THREADS` option has been removed, as it no longer functions as a proper build option. The library will always check for thread support and set the internal status variable, `HDF5_THREADS_ENABLED`. The `HDF5_ENABLE_THREADSAFE` option is still available to build with thread-safe API calls.
 
-- Enhanced Maven repository deployment support
+### Enhanced Maven repository deployment support
 
    Added comprehensive Maven integration with optimized workflows for Java artifact deployment:
    - **New CMake options**: `HDF5_ENABLE_MAVEN_DEPLOY` and `HDF5_MAVEN_SNAPSHOT` for Maven repository deployment
@@ -123,7 +123,7 @@ We would like to thank the many HDF5 community members that contributed to HDF5 
    - **Production deployment validation**: Successfully resolved HTTP 409 version conflicts through snapshot versioning strategy
    - **Deployment status**: ✅ Fully validated and production-ready with comprehensive error resolution and testing documentation
 
- - Reorganized the files in the config/cmake folder into the config folder structure
+### Reorganized the files in the config/cmake folder into the config folder structure
 
    The config folder CMake files have been reorganized to make it easier to maintain and add new features. This includes the following changes:
    - The files in the config folder are the macros and templates for the build process.

--- a/release_docs/CHANGELOG.md
+++ b/release_docs/CHANGELOG.md
@@ -34,7 +34,7 @@ For releases prior to version 2.0.0, please see the release.txt file and for mor
 - Full [UTF-8](https://github.com/HDFGroup/hdf5/blob/develop/release_docs/CHANGELOG.md#utf-8) filename support on Windows, resolving encoding issues from previous versions.
 - Introduction of [bfloat16 predefined datatypes](https://github.com/HDFGroup/hdf5/blob/develop/release_docs/CHANGELOG.md#added-predefined-datatypes-for-bfloat16-data) for efficient machine learning conversions.
 - First-class support for [complex numbers](https://github.com/HDFGroup/hdf5/blob/develop/release_docs/CHANGELOG.md#complex), eliminating manual workarounds in scientific applications.
-- [New chunk size limit](https://github.com/HDFGroup/hdf5/blob/develop/release_docs/CHANGELOG.md#added-support-for-large-chunks) of 16,384 PiB (replacing the old 4GiB chunk size limit), enabling efficient storage and I/O for massive, high-resolution datasets common in fields like genomics and climate modeling.
+- A [new, larger chunk size limit](https://github.com/HDFGroup/hdf5/blob/develop/release_docs/CHANGELOG.md#added-support-for-large-chunks), in multi-petabytes, replaces the previous 4 GiB limit, potentially improving compression and general I/O performance depending on your I/O patterns and system.
 
 ## Updated Foundation:
 

--- a/release_docs/CHANGELOG.md
+++ b/release_docs/CHANGELOG.md
@@ -71,7 +71,7 @@ We would like to thank the many HDF5 community members that contributed to HDF5 
 
 ### Autotools support was removed from HDF5<a name="cmake">
 
-   CMake is now the build system available in HDF5 code. Version 3.26 or later is required. See the AutotoolsToCMakeOptions.md file for highlights of the CMake HDF5 install layout and CMake options to use in place of former Autotools options.
+   CMake is now the build system available in HDF5 code. Version 3.26 or later is required. See the [AutotoolsToCMakeOptions.md](https://github.com/HDFGroup/hdf5/blob/develop/release_docs/AutotoolsToCMakeOptions.md) file for highlights of the CMake HDF5 install layout and CMake options to use in place of former Autotools options.
 
 ### Fixed problems with family driver and user block
 

--- a/release_docs/CHANGELOG.md
+++ b/release_docs/CHANGELOG.md
@@ -34,7 +34,7 @@ For releases prior to version 2.0.0, please see the release.txt file and for mor
 - Full [UTF-8](/CHANGELOG.md#utf-8) filename support on Windows, resolving encoding issues from previous versions.
 - Introduction of [bfloat16 predefined datatypes](/CHANGELOG.md#added-predefined-datatypes-for-bfloat16-data) for efficient machine learning conversions.
 - First-class support for [complex numbers](/CHANGELOG.md#complex), eliminating manual workarounds in scientific applications.
-- A [new, larger chunk size limit](/CHANGELOG.md#added-support-for-large-chunks), in multi-petabytes, replaces the previous 4 GiB limit, potentially improving compression and general I/O performance depending on your I/O patterns and system.
+- A [new, larger chunk size limit](/CHANGELOG.md#added-support-for-large-chunks), in multi-petabytes, replaces the previous 4 GiB limit.
 
 ## Updated Foundation:
 

--- a/release_docs/CHANGELOG.md
+++ b/release_docs/CHANGELOG.md
@@ -25,31 +25,31 @@ For releases prior to version 2.0.0, please see the release.txt file and for mor
 
 ## Performance Enhancements:
 
-- Up to [2500% faster](https://github.com/HDFGroup/hdf5/blob/develop/release_docs/CHANGELOG.md#rtree) Virtual Dataset read/write operations
-- [30% faster opening](https://github.com/HDFGroup/hdf5/blob/develop/release_docs/CHANGELOG.md#layoutcopydelay) and [25% faster closing](https://github.com/HDFGroup/hdf5/blob/develop/release_docs/CHANGELOG.md#fileformat) of virtual datasets.
-- [Reduced memory overhead](https://github.com/HDFGroup/hdf5/blob/develop/release_docs/CHANGELOG.md#fileformat) via shared name strings and optimized spatial search algorithms for virtual datasets.
+- Up to [2500% faster](/CHANGELOG.md#rtree) Virtual Dataset read/write operations
+- [30% faster opening](/CHANGELOG.md#layoutcopydelay) and [25% faster closing](/CHANGELOG.md#fileformat) of virtual datasets.
+- [Reduced memory overhead](/CHANGELOG.md#fileformat) via shared name strings and optimized spatial search algorithms for virtual datasets.
 
 ## Significant Advancements:
 
-- Full [UTF-8](https://github.com/HDFGroup/hdf5/blob/develop/release_docs/CHANGELOG.md#utf-8) filename support on Windows, resolving encoding issues from previous versions.
-- Introduction of [bfloat16 predefined datatypes](https://github.com/HDFGroup/hdf5/blob/develop/release_docs/CHANGELOG.md#added-predefined-datatypes-for-bfloat16-data) for efficient machine learning conversions.
-- First-class support for [complex numbers](https://github.com/HDFGroup/hdf5/blob/develop/release_docs/CHANGELOG.md#complex), eliminating manual workarounds in scientific applications.
-- A [new, larger chunk size limit](https://github.com/HDFGroup/hdf5/blob/develop/release_docs/CHANGELOG.md#added-support-for-large-chunks), in multi-petabytes, replaces the previous 4 GiB limit, potentially improving compression and general I/O performance depending on your I/O patterns and system.
+- Full [UTF-8](/CHANGELOG.md#utf-8) filename support on Windows, resolving encoding issues from previous versions.
+- Introduction of [bfloat16 predefined datatypes](/CHANGELOG.md#added-predefined-datatypes-for-bfloat16-data) for efficient machine learning conversions.
+- First-class support for [complex numbers](/CHANGELOG.md#complex), eliminating manual workarounds in scientific applications.
+- A [new, larger chunk size limit](/CHANGELOG.md#added-support-for-large-chunks), in multi-petabytes, replaces the previous 4 GiB limit, potentially improving compression and general I/O performance depending on your I/O patterns and system.
 
 ## Updated Foundation:
 
-- New [file format](https://github.com/HDFGroup/hdf5/blob/develop/release_docs/CHANGELOG.md#fileformat) version (4.0) and compliance with the C11 standard.
+- New [file format](/CHANGELOG.md#fileformat) version (4.0) and compliance with the C11 standard.
 - Adopted [semantic versioning](https://github.com/HDFGroup/hdf5/wiki/HDF5-Version-Numbers-and-Branch-Strategy) to clearly convey changes between versions.
 
 > [!IMPORTANT]
 >
-> - Transitioned to [CMake-only](https://github.com/HDFGroup/hdf5/blob/develop/release_docs/CHANGELOG.md#cmake) builds, and Autotools is no longer in use.
+> - Transitioned to [CMake-only](/CHANGELOG.md#cmake) builds, and Autotools is no longer in use.
 > - Renamed library state variables, notably `HDF5_ENABLE_PARALLEL` is now `HDF5_PROVIDES_PARALLEL`, see PR [#5716](https://github.com/HDFGroup/hdf5/pull/5716) for more details.
 > - The default setting for `H5Fset_libver_bounds` has been updated to set the lower bound to the HDF5 library version 1.8. This change ensures that users can take advantage of the library's optimal performance and the latest features by default. If users need their files to be compatible with older versions of the HDF5 library, they will need to adjust this lower bound manually.
 
 ## Enhanced Features:
 
-- Improved [ROS3 VFD](https://github.com/HDFGroup/hdf5/blob/develop/release_docs/CHANGELOG.md#ros3) capabilities using the aws-c-s3 library.
+- Improved [ROS3 VFD](/CHANGELOG.md#ros3) capabilities using the aws-c-s3 library.
 
 ## Java Enhancements:
 
@@ -73,7 +73,7 @@ We would like to thank the many HDF5 community members who contributed to HDF5 2
 
 ### Autotools support was removed from HDF5<a name="cmake">
 
-   CMake is now the build system available in HDF5 code. Version 3.26 or later is required. See the [AutotoolsToCMakeOptions.md](https://github.com/HDFGroup/hdf5/blob/develop/release_docs/AutotoolsToCMakeOptions.md) file for highlights of the CMake HDF5 install layout and CMake options to use in place of former Autotools options.
+   CMake is now the build system available in HDF5 code. Version 3.26 or later is required. See the [AutotoolsToCMakeOptions.md](/AutotoolsToCMakeOptions.md) file for highlights of the CMake HDF5 install layout and CMake options to use in place of former Autotools options.
 
 ### Fixed problems with family driver and user block
 
@@ -629,7 +629,7 @@ Added Fortran wrapper `h5fdsubfiling_get_file_mapping_f()` for the subfiling fil
 
    Fixed a heap buffer overflow in H5FS__sinfo_serialize_node_cb() by discarding file free space sections from the file free space manager when they are found to be invalid. Specifically crafted HDF5 files can result in an attempt to insert duplicate or overlapping file free space sections into a file free space manager, later resulting in a buffer overflow when the same free space section is serialized to the file multiple times.
 
-   Fixes GitHub issue #5577
+   Fixes GitHub issue [#5577](https://github.com/HDFGroup/hdf5/issues/5577)
 
 ### Fixed security issue [CVE-2025-2915](https://nvd.nist.gov/vuln/detail/CVE-2025-2915) and [OSV-2024-381](https://osv.dev/vulnerability/OSV-2024-381)
 
@@ -701,7 +701,7 @@ Added Fortran wrapper `h5fdsubfiling_get_file_mapping_f()` for the subfiling fil
 
    The size of a continuation message was decoded as 0, causing multiple vulnerabilities.  An error check was added to return failure to prevent further processing of invalid data.
 
-   Fixes GitHub issue #5376 and #5384
+   Fixes GitHub issue [#5376](https://github.com/HDFGroup/hdf5/issues/5376) and [#5384](https://github.com/HDFGroup/hdf5/issues/5384)
 
 ### Revised handling of Unicode filenames on Windows<a name="utf-8">
 

--- a/release_docs/CHANGELOG.md
+++ b/release_docs/CHANGELOG.md
@@ -34,10 +34,12 @@ For releases prior to version 2.0.0, please see the release.txt file and for mor
 - Full [UTF-8](https://github.com/HDFGroup/hdf5/blob/develop/release_docs/CHANGELOG.md#utf-8) filename support on Windows, resolving encoding issues from previous versions.
 - Introduction of [bfloat16 predefined datatypes](https://github.com/HDFGroup/hdf5/blob/develop/release_docs/CHANGELOG.md#added-predefined-datatypes-for-bfloat16-data) for efficient machine learning conversions.
 - First-class support for [complex numbers](https://github.com/HDFGroup/hdf5/blob/develop/release_docs/CHANGELOG.md#complex), eliminating manual workarounds in scientific applications.
+- [New chunk size limit](https://github.com/HDFGroup/hdf5/blob/develop/release_docs/CHANGELOG.md#added-support-for-large-chunks) of 16,384 PiB (replacing the old 4GiB chunk size limit), enabling efficient storage and I/O for massive, high-resolution datasets common in fields like genomics and climate modeling.
 
 ## Updated Foundation:
 
 - New [file format](https://github.com/HDFGroup/hdf5/blob/develop/release_docs/CHANGELOG.md#fileformat) version (4.0) and compliance with the C11 standard.
+- Adopted [semantic versioning](https://github.com/HDFGroup/hdf5/wiki/HDF5-Version-Numbers-and-Branch-Strategy) to clearly convey changes between versions.
 
 > [!IMPORTANT]
 >


### PR DESCRIPTION
Autotools to cmake document 
- there was a problem with the first table because the | wasn't escaped
- I combined all the tables into one table with subheads so the columns lined up

Changelog
- added link to autotools to cmake document
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fixed table formatting in `AutotoolsToCMakeOptions.md` and added a link to it in `CHANGELOG.md`.
> 
>   - **Documentation**:
>     - Fixed table formatting in `AutotoolsToCMakeOptions.md` by escaping pipe characters and combining tables into one with subheadings.
>     - Added a hyperlink to `AutotoolsToCMakeOptions.md` in `CHANGELOG.md` for easier access to CMake options information.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=HDFGroup%2Fhdf5&utm_source=github&utm_medium=referral)<sup> for 82ca202be6cdb95849e5800d0abbbeca463aa9dc. You can [customize](https://app.ellipsis.dev/HDFGroup/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->