### PR TITLE
Added entry for issue #5375

### DIFF
--- a/release_docs/CHANGELOG.md
+++ b/release_docs/CHANGELOG.md
@@ -701,6 +701,12 @@ Added Fortran wrapper `h5fdsubfiling_get_file_mapping_f()` for the subfiling fil
 
    Fixes GitHub issue [#5382](https://github.com/HDFGroup/hdf5/issues/5382)
 
+### Fixed a segfault with a corrupted file based on netCDF-4
+
+   When the internal function H5G__dense_iterate failed early, allocated structures were never populated, causing cleanup code to read uninitialized values and attempt to free invalid pointers.  The structures are now initialized with proper values and NULL pointers immediately after allocation.
+
+   Fixes GitHub issue [#5375](https://github.com/HDFGroup/hdf5/issues/5375)
+
 ### Fixed security issues [CVE-2025-2913](https://nvd.nist.gov/vuln/detail/CVE-2025-2913), [CVE-2025-2926](https://nvd.nist.gov/vuln/detail/CVE-2025-2926), [CVE-2025-6817](https://nvd.nist.gov/vuln/detail/CVE-2025-6817), and [CVE-2025-6858](https://nvd.nist.gov/vuln/detail/CVE-2025-6858)
 
    The size of a continuation message was decoded as 0, causing multiple vulnerabilities.  An error check was added to return failure to prevent further processing of invalid data.


### PR DESCRIPTION
The issue: crash on opening a corrupted SOFA file
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fixes a segfault in `H5G__dense_iterate` for corrupted netCDF-4 files by initializing structures properly, documented in `CHANGELOG.md`.
> 
>   - **Bug Fix**:
>     - Fixed a segfault in `H5G__dense_iterate` when opening corrupted netCDF-4 files by initializing structures with proper values and NULL pointers immediately after allocation.
>     - Documented in `CHANGELOG.md` under the bug fixes section.
>     - Fixes GitHub issue [#5375](https://github.com/HDFGroup/hdf5/issues/5375).
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=HDFGroup%2Fhdf5&utm_source=github&utm_medium=referral)<sup> for 90ecaa45a2fd0cb3f6e347c61ce3a66b8257213e. You can [customize](https://app.ellipsis.dev/HDFGroup/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->