### PR TITLE
Make test/evict_on_close.c FILENAMES static

### DIFF
--- a/test/evict_on_close.c
+++ b/test/evict_on_close.c
@@ -36,8 +36,8 @@
 /* (Requires debug build of the library) */
 /* #define EOC_MANUAL_INSPECTION */
 
-const char *FILENAMES[] = {"evict-on-close", /* 0 */
-                           NULL};
+static const char *FILENAMES[] = {"evict-on-close", /* 0 */
+                                  NULL};
 #define FILENAME_BUF_SIZE 1024
 
 /* Group names */


### PR DESCRIPTION
close #5988 
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Make `FILENAMES` array static in `test/evict_on_close.c` to limit its scope.
> 
>   - **Code Changes**:
>     - Make `FILENAMES` array `static` in `test/evict_on_close.c` to limit its scope to the file.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=HDFGroup%2Fhdf5&utm_source=github&utm_medium=referral)<sup> for b69e6c27fe9f718a82989d167e1a95457b1836c2. You can [customize](https://app.ellipsis.dev/HDFGroup/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->