### PR TITLE
fixed Doxygen parameter annotation issues

### DIFF
--- a/src/H5Apublic.h
+++ b/src/H5Apublic.h
@@ -983,7 +983,7 @@ H5_DLL herr_t H5Arename_by_name_async(hid_t loc_id, const char *obj_name, const 
  *
  * \attr_id
  * \mem_type_id{type_id}
- * \param[out]  buf       Data to be written
+ * \param[in]  buf       Data to be written
  *
  * \return \herr_t
  *

--- a/src/H5Dpublic.h
+++ b/src/H5Dpublic.h
@@ -992,7 +992,7 @@ H5_DLL herr_t H5Dread_multi_async(size_t count, hid_t dset_id[], hid_t mem_type_
  * \param[in] mem_space_id   Identifier of the memory dataspace
  * \param[in] file_space_id  Identifier of the dataset's dataspace in the file
  * \dxpl_id
- * \param[out] buf           Buffer with data to be written to the file
+ * \param[in] buf           Buffer with data to be written to the file
  *
  * \return \herr_t
  *
@@ -1249,7 +1249,7 @@ H5_DLL herr_t H5Dwrite_chunk(hid_t dset_id, hid_t dxpl_id, uint32_t filters, con
  * \param[in]  offset   Logical position of the chunk's first element in the
  *                      dataspace
  * \param[in,out]  filters  Mask for identifying the filters in use
- * \param[out]  buf     Buffer containing data to be read from the chunk
+ * \param[out]  buf     Buffer to receive data read from the chunk
  * \param[in,out]  buf_size   Size of buf in bytes
  *
  * \return \herr_t
@@ -1912,7 +1912,7 @@ H5_DLL herr_t H5Dvlen_reclaim(hid_t type_id, hid_t space_id, hid_t dxpl_id, void
  * \param[in]  offset   Logical position of the chunk's first element in the
  *                      dataspace
  * \param[in,out]  filters  Mask for identifying the filters in use
- * \param[out]  buf     Buffer containing data to be read from the chunk
+ * \param[out]  buf     Buffer to receive data read from the chunk
  *
  * \return \herr_t
  *

--- a/src/H5Gpublic.h
+++ b/src/H5Gpublic.h
@@ -940,7 +940,7 @@ H5_DLL herr_t H5Gset_comment(hid_t loc_id, const char *name, const char *comment
  *                 name must be \TText{'.'} (dot) if \p loc_id fully specifies
  *                 the object for which the comment is to be set.
  * \param[in] bufsize Maximum number of comment characters to be returned in \p buf.
- * \param[in] buf The comment
+ * \param[out] buf The comment
  *
  * \return Returns the number of characters in the comment, counting the \c NULL
  *         terminator, if successful; the value returned may be larger than
@@ -1130,7 +1130,7 @@ H5_DLL herr_t H5Gget_objinfo(hid_t loc_id, const char *name, bool follow_link, H
  *
  * \fg_loc_id
  * \param[in] idx Transient index identifying object
- * \param[in,out] name Pointer to user-provided buffer the object name
+ * \param[out] name Pointer to user-provided buffer the object name
  * \param[in] size Name length
  *
  * \return Returns the size of the object name if successful, or 0 if no name is

--- a/src/H5Rpublic.h
+++ b/src/H5Rpublic.h
@@ -518,7 +518,7 @@ H5_DLL herr_t H5Rget_obj_type3(H5R_ref_t *ref_ptr, hid_t rapl_id, H5O_type_t *ob
  * \brief Retrieves the file name for a referenced object
  *
  * \param[in] ref_ptr  Pointer to reference to query
- * \param[in,out] name Buffer to place the file name of the reference
+ * \param[out] name Buffer to place the file name of the reference
  * \param[in] size     Size of the \p name buffer. When the size is passed in,
  *                     the \c NULL terminator needs to be included.
  *
@@ -542,7 +542,7 @@ H5_DLL ssize_t H5Rget_file_name(const H5R_ref_t *ref_ptr, char *name, size_t siz
  *
  * \param[in] ref_ptr  Pointer to reference to query
  * \rapl_id
- * \param[in,out] name Buffer to place the object name of the reference
+ * \param[out] name Buffer to place the object name of the reference
  * \param[in] size     Size of the \p name buffer. When the size is passed in,
  *                     the \c NULL terminator needs to be included.
  *
@@ -581,7 +581,7 @@ H5_DLL ssize_t H5Rget_obj_name(H5R_ref_t *ref_ptr, hid_t rapl_id, char *name, si
  * \brief Retrieves the attribute name for a referenced object
  *
  * \param[in] ref_ptr  Pointer to reference to query
- * \param[in,out] name Buffer to place the attribute name of the reference
+ * \param[out] name Buffer to place the attribute name of the reference
  * \param[in] size     Size of the \p name buffer
  *
  * \return Returns the length of the name if successful, otherwise, a negative value.


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Fix Doxygen parameter annotations in HDF5 header files to accurately reflect data flow direction.
> 
>   - **Doxygen Annotations**:
>     - Correct `\param[out]` to `\param[in]` for `buf` in `H5Apublic.h` and `H5Dpublic.h` to reflect data being written to the buffer.
>     - Correct `\param[in,out]` to `\param[out]` for `buf` in `H5Dpublic.h` to indicate buffer is used to receive data.
>     - Correct `\param[in]` to `\param[out]` for `buf` in `H5Gpublic.h` to indicate buffer is used to receive data.
>     - Correct `\param[in,out]` to `\param[out]` for `name` in `H5Rpublic.h` to indicate buffer is used to receive data.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=HDFGroup%2Fhdf5&utm_source=github&utm_medium=referral)<sup> for 30ff447ccce03c192af1c2fff8bd5392eb4a168f. You can [customize](https://app.ellipsis.dev/HDFGroup/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->