### PR TITLE
Merge 5 documentation commits cherry-picked from develop to hdf5_2_0_0

### DIFF
--- a/HDF5Examples/JAVA/README-MAVEN.md
+++ b/HDF5Examples/JAVA/README-MAVEN.md
@@ -23,7 +23,7 @@ HDF5Examples/JAVA/
 <dependency>
     <groupId>org.hdfgroup</groupId>
     <artifactId>hdf5-java-examples</artifactId>
-    <version>2.0.0-3</version>
+    <version>2.0.0</version>
 </dependency>
 ```
 
@@ -36,7 +36,7 @@ The examples depend on platform-specific HDF5 Java libraries:
 <dependency>
     <groupId>org.hdfgroup</groupId>
     <artifactId>hdf5-java</artifactId>
-    <version>2.0.0-3</version>
+    <version>2.0.0</version>
     <classifier>linux-x86_64</classifier>
 </dependency>
 
@@ -44,7 +44,7 @@ The examples depend on platform-specific HDF5 Java libraries:
 <dependency>
     <groupId>org.hdfgroup</groupId>
     <artifactId>hdf5-java</artifactId>
-    <version>2.0.0-3</version>
+    <version>2.0.0</version>
     <classifier>windows-x86_64</classifier>
 </dependency>
 
@@ -52,7 +52,7 @@ The examples depend on platform-specific HDF5 Java libraries:
 <dependency>
     <groupId>org.hdfgroup</groupId>
     <artifactId>hdf5-java</artifactId>
-    <version>2.0.0-3</version>
+    <version>2.0.0</version>
     <classifier>macos-x86_64</classifier>
 </dependency>
 
@@ -60,7 +60,7 @@ The examples depend on platform-specific HDF5 Java libraries:
 <dependency>
     <groupId>org.hdfgroup</groupId>
     <artifactId>hdf5-java</artifactId>
-    <version>2.0.0-3</version>
+    <version>2.0.0</version>
     <classifier>macos-aarch64</classifier>
 </dependency>
 ```

--- a/LICENSE
+++ b/LICENSE
@@ -105,4 +105,7 @@ and/or accompanying materials:
 
 -----------------------------------------------------------------------------
 
+Portions of HDF5 were developed with support from the National Science
+Foundation under Federal Award No. 2534078.
 
+-----------------------------------------------------------------------------

--- a/doxygen/dox/H5.format.4.0.dox
+++ b/doxygen/dox/H5.format.4.0.dox
@@ -1913,7 +1913,7 @@ The record layout for each stored (in other words, non-testing) B-tree type is a
     &ldquo;@ref FMT4SizeOfOffsetsV0 "Size of Offsets"&rdquo; field in the superblock.
 
 <table>
-<caption><strong>Fields: Version 2 B-tree, Type 11 Record Layout - Filtered Dataset Chunks</strong></caption>
+<caption><strong>Fields: Version 2 B-tree, Type 10 Record Layout - Non-filtered Dataset Chunks</strong></caption>
 <tr>
   <th width="30%">Field Name</th>
   <th>Description</th>
@@ -1932,7 +1932,7 @@ The record layout for each stored (in other words, non-testing) B-tree type is a
 </table>
 
 <table>
-<caption>\anchor FMT4V2BtType11 <strong>Layout: Version 2 B-tree, Type 11 Record Layout - Filtered Dataset Chunks</strong></caption>
+<caption>\anchor FMT4V2BtType11 <strong>Layout: Version 2 B-tree, Type 11 Record Layout - Filtered Dataset Chunks (Layout Version 4)</strong></caption>
 <tr>
   <th width="25%">byte</th>
   <th width="25%">byte</th>
@@ -1963,9 +1963,44 @@ The record layout for each stored (in other words, non-testing) B-tree type is a
 </table>
 \li Items marked with an &lsquo;O&rsquo; in the above table are of the size specified in
     &ldquo;@ref FMT4SizeOfOffsetsV0 "Size of Offsets"&rdquo; field in the superblock.
+\li This encoding is used when this B-Tree is used as an index for a dataset with layout message version 4.
 
 <table>
-<caption><strong>Fields: Version 2 B-tree, Type 5 Record Layout - Non-filtered Dataset Chunks</strong></caption>
+<caption>Type11 <strong>Layout: Version 2 B-tree, Type 11 Record Layout - Filtered Dataset Chunks (Layout Version 5)</strong></caption>
+<tr>
+  <th width="25%">byte</th>
+  <th width="25%">byte</th>
+  <th width="25%">byte</th>
+  <th>byte</th>
+</tr>
+<tr>
+  <td colspan="4"><br />Address<sup>O</sup><br /><br /></td>
+</tr>
+<tr>
+  <td colspan="4"><br />Chunk Size<sup>O</sup><br /><br /></td>
+</tr>
+<tr>
+  <td colspan="4">Filter Mask</td>
+</tr>
+<tr>
+  <td colspan="4"><br />Dimension 0 Scaled Offset <em>(8 bytes)</em><br /><br /></td>
+</tr>
+<tr>
+  <td colspan="4"><br />Dimension 1 Scaled Offset <em>(8 bytes)</em><br /><br /></td>
+</tr>
+<tr>
+  <td colspan="4"><br />...<br /><br /></td>
+</tr>
+<tr>
+  <td colspan="4"><br />Dimension \#n Scaled Offset <em>(8 bytes)</em><br /><br /></td>
+</tr>
+</table>
+\li Items marked with an &lsquo;O&rsquo; in the above table are of the size specified in
+    &ldquo;@ref FMT4SizeOfOffsetsV0 "Size of Offsets"&rdquo; field in the superblock.
+\li This encoding is used when this B-tree is used as an index for a dataset with layout message version 5 or above.
+
+<table>
+<caption><strong>Fields: Version 2 B-tree, Type 11 Record Layout - Filtered Dataset Chunks</strong></caption>
 <tr>
   <th width="30%">Field Name</th>
   <th>Description</th>
@@ -1976,7 +2011,21 @@ The record layout for each stored (in other words, non-testing) B-tree type is a
 </tr>
 <tr>
   <td>Chunk Size</td>
-  <td>This field is the size of the dataset chunk in bytes.</td>
+  <td>This field is the size of the dataset chunk in bytes. The length of this field is determined depending on the version of the associated layout message as follows:
+      <table>
+      <tr>
+        <th width="20%" align="center">Layout Message Version</th>
+        <th align="left">Chunk Size Encoding Length</th>
+      </tr>
+      <tr>
+        <td align="center"><code>4</code></td>
+        <td>One more than the number of bytes that would be needed to encode the size of an unfiltered chunk, but not more than 8.</td>
+      </tr>
+      <tr>
+        <td align="center"><code>5</code> or above</td>
+        <td>The size specified in the &ldquo;@ref FMT4SizeOfOffsetsV0 "Size of Offsets"&rdquo; field in the superblock.</td>
+      </tr>
+      </table></td>
 </tr>
 <tr>
   <td>Filter Mask</td>
@@ -7876,8 +7925,9 @@ Class-specific information for chunked storage (layout class 2):
 
 \anchor FMT4DataLayoutV4 <h4>Version 4 of this message is similar to version 3 but has additional
 information for the virtual layout class as well as indexing information for the chunked layout class.</h4>
+<h4>Version 5 of this message is identical to version 4, except for the encoding of filtered chunk records for Fixed Array, Extensible Array, and v2 B-Tree indices. The Library also requires layout version 5 for datasets with chunk size greater than or equal to 4 GiB.</h4>
 <table>
-<caption><strong>Layout: Data Layout Message (Version 4)</strong></caption>
+<caption><strong>Layout: Data Layout Message (Versions 4 and 5)</strong></caption>
 <tr>
   <th width="25%">byte</th>
   <th width="25%">byte</th>
@@ -7895,15 +7945,29 @@ information for the virtual layout class as well as indexing information for the
 </table>
 
 <table>
-<caption><strong>Fields: Data Layout Message (Version 4)</strong></caption>
+<caption><strong>Fields: Data Layout Message (Versions 4 and 5)</strong></caption>
 <tr>
   <th width="30%">Field Name</th>
   <th>Description</th>
 </tr>
 <tr>
   <td>Version</td>
-  <td>The value for this field is 4 and is used by version 1.10.0 and later of the library to
-      store properties for each layout class and indexing information for the chunked layout.</td>
+  <td>The version number information is used for changes in the format of the data layout message and
+      is described here:
+      <table>
+      <tr>
+        <th width="20%">Version</th>
+        <th align="left">Description</th>
+      </tr>
+      <tr>
+        <td align="center"><code>4</code></td>
+        <td>Used by version 1.10.0 and later of the library to store properties for each layout class and indexing information for the chunked layout.</td>
+      </tr>
+      <tr>
+        <td align="center"><code>5</code></td>
+        <td>Used by version 2.0.0 and later of the library and is identical to version 4, except the encoding of filtered chunk records for Fixed Array, Extensible Array, and v2 B-Tree indices has been changed to allow for filters that expand chunks up to 2<sup>64</sup>-1 bytes. The Library will also not allow creation of datasets with chunk size greater than 2<sup>32</sup>-1 bytes (4 GiB - 1) with layout version 4 or below (including unfiltered chunks), because versions of the library that don't understand layout version 5 cannot process these large chunks. However, such large chunks are not precluded by the version 4 layout encoding per se.</td>
+      </tr>
+      </table></td>
 </tr>
 <tr>
   <td>Layout Class</td>
@@ -10968,7 +11032,7 @@ types are described below.<br />
 
 \anchor FMT4FaFilterChunk
 <table>
-<caption><strong>Layout: Data Block Element for Filtered Dataset Chunk</strong></caption>
+<caption><strong>Layout: Data Block Element for Filtered Dataset Chunk (Layout Version 4)</strong></caption>
 <tr>
   <th width="25%">byte</th>
   <th width="25%">byte</th>
@@ -10987,6 +11051,29 @@ types are described below.<br />
 </table>
 \li Items marked with an &lsquo;O&rsquo; in the above table are of the size specified in
     &ldquo;@ref FMT4SizeOfOffsetsV0 "Size of Offsets"&rdquo; field in the superblock.
+\li This encoding is used when this Fixed Array is used as an index for a dataset with layout message version 4.
+
+<table>
+<caption><strong>Layout: Data Block Element for Filtered Dataset Chunk (Layout Version 5)</strong></caption>
+<tr>
+  <th width="25%">byte</th>
+  <th width="25%">byte</th>
+  <th width="25%">byte</th>
+  <th>byte</th>
+</tr>
+<tr>
+  <td colspan="4"><br />Address<sup>O</sup><br /><br /></td>
+</tr>
+<tr>
+  <td colspan="4"><br />Chunk Size<sup>O</sup><br /><br /></td>
+</tr>
+<tr>
+  <td colspan="4">Filter Mask</td>
+</tr>
+</table>
+\li Items marked with an &lsquo;O&rsquo; in the above table are of the size specified in
+    &ldquo;@ref FMT4SizeOfOffsetsV0 "Size of Offsets"&rdquo; field in the superblock.
+\li This encoding is used when this Fixed Array is used as an index for a dataset with layout message version 5 or above.
 
 <table>
 <caption><strong>Fields: Data Block Element for Filtered Dataset Chunk</strong></caption>
@@ -11000,7 +11087,21 @@ types are described below.<br />
 </tr>
 <tr>
   <td>Chunk Size</td>
-  <td>The size of the dataset chunk in bytes.</td>
+  <td>The size of the dataset chunk in bytes. The length of this field is determined depending on the version of the associated layout message as follows:
+      <table>
+      <tr>
+        <th width="20%" align="center">Layout Message Version</th>
+        <th align="left">Chunk Size Encoding Length</th>
+      </tr>
+      <tr>
+        <td align="center"><code>4</code></td>
+        <td>One more than the number of bytes that would be needed to encode the size of an unfiltered chunk, but not more than 8.</td>
+      </tr>
+      <tr>
+        <td align="center"><code>5</code> or above</td>
+        <td>The size specified in the &ldquo;@ref FMT4SizeOfOffsetsV0 "Size of Offsets"&rdquo; field in the superblock.</td>
+      </tr>
+      </table></td>
 </tr>
 <tr>
   <td>Filter Mask</td>
@@ -11574,7 +11675,7 @@ blocks/pages in a chunk index varies as they are allocated as needed and the fir
 
 \anchor FMT4EaFilterChunk
 <table>
-<caption><strong>Layout: Data Block Element for Filtered Dataset Chunk</strong></caption>
+<caption><strong>Layout: Data Block Element for Filtered Dataset Chunk (Layout Version 4)</strong></caption>
 <tr>
   <th width="25%">byte</th>
   <th width="25%">byte</th>
@@ -11593,6 +11694,30 @@ blocks/pages in a chunk index varies as they are allocated as needed and the fir
 </table>
 \li Items marked with an &lsquo;O&rsquo; in the above table are of the size specified in
     &ldquo;@ref FMT4SizeOfOffsetsV0 "Size of Offsets"&rdquo; field in the superblock.
+\li This encoding is used when this B-Tree is used as an index for a dataset with layout message version 4.
+
+
+<table>
+<caption><strong>Layout: Data Block Element for Filtered Dataset Chunk (Layout Version 5)</strong></caption>
+<tr>
+  <th width="25%">byte</th>
+  <th width="25%">byte</th>
+  <th width="25%">byte</th>
+  <th>byte</th>
+</tr>
+<tr>
+  <td colspan="4"><br />Address<sup>O</sup><br /><br /></td>
+</tr>
+<tr>
+  <td colspan="4"><br />Chunk Size<em> (variable size; at most 8 bytes)</em><br /><br /></td>
+</tr>
+<tr>
+  <td colspan="4">Filter Mask</td>
+</tr>
+</table>
+\li Items marked with an &lsquo;O&rsquo; in the above table are of the size specified in
+    &ldquo;@ref FMT4SizeOfOffsetsV0 "Size of Offsets"&rdquo; field in the superblock.
+\li This encoding is used when this B-Tree is used as an index for a dataset with layout message version 5 or above.
 
 <table>
 <caption><strong>Fields: Data Block Element for Filtered Dataset Chunk</strong></caption>
@@ -11606,7 +11731,21 @@ blocks/pages in a chunk index varies as they are allocated as needed and the fir
 </tr>
 <tr>
   <td>Chunk Size</td>
-  <td>The size of the dataset chunk in bytes.</td>
+  <td>The size of the dataset chunk in bytes. The length of this field is determined depending on the version of the associated layout message as follows:
+      <table>
+      <tr>
+        <th width="20%" align="center">Layout Message Version</th>
+        <th align="left">Chunk Size Encoding Length</th>
+      </tr>
+      <tr>
+        <td align="center"><code>4</code></td>
+        <td>One more than the number of bytes that would be needed to encode the size of an unfiltered chunk, but not more than 8.</td>
+      </tr>
+      <tr>
+        <td align="center"><code>5</code> or above</td>
+        <td>The size specified in the &ldquo;@ref FMT4SizeOfOffsetsV0 "Size of Offsets"&rdquo; field in the superblock.</td>
+      </tr>
+      </table></td>
 </tr>
 <tr>
   <td>Filter Mask</td>

--- a/doxygen/dox/H5.format.4.0.dox
+++ b/doxygen/dox/H5.format.4.0.dox
@@ -1966,7 +1966,7 @@ The record layout for each stored (in other words, non-testing) B-tree type is a
 \li This encoding is used when this B-Tree is used as an index for a dataset with layout message version 4.
 
 <table>
-<caption>Type11 <strong>Layout: Version 2 B-tree, Type 11 Record Layout - Filtered Dataset Chunks (Layout Version 5)</strong></caption>
+<caption>Type 11 <strong>Layout: Version 2 B-tree, Type 11 Record Layout - Filtered Dataset Chunks (Layout Version 5)</strong></caption>
 <tr>
   <th width="25%">byte</th>
   <th width="25%">byte</th>

--- a/doxygen/dox/api-compat-macros.dox
+++ b/doxygen/dox/api-compat-macros.dox
@@ -152,7 +152,17 @@ Navigate back: \ref index "Main" / \ref TN
   <th>Deprecated functions available? <br/> (\TText{H5Lvisit1})</th>
   </tr>
   <tr align="center">
-  <td>\TText{-DHDF5_DEFAULT_API_VERSION:STRING="v112"} <br/> (the default in 1.12)</td>
+  <td>\TText{-DHDF5_DEFAULT_API_VERSION:STRING="v200"} <br/> (the default in 2.0.0)</td>
+  <td>2.0.x (\TText{H5Lvisit2})</td>
+  <td>yes</td>
+  </tr>
+  <tr align="center">
+  <td>\TText{-DHDF5_DEFAULT_API_VERSION:STRING="v114"}</td>
+  <td>1.14.x (\TText{H5Lvisit2})</td>
+  <td>yes</td>
+  </tr>
+  <tr align="center">
+  <td>\TText{-DHDF5_DEFAULT_API_VERSION:STRING="v112"}</td>
   <td>1.12.x (\TText{H5Lvisit2})</td>
   <td>yes</td>
   </tr>
@@ -182,7 +192,7 @@ Navigate back: \ref index "Main" / \ref TN
   installed to determine the \TText{configure} flags used to build the library. In particular,
   look for the two lines shown here under \Emph{Features}:
 
-  \TText{Default API mapping: v112}
+  \TText{Default API mapping: v200}
 
   \TText{With deprecated public symbols: yes}
 
@@ -204,13 +214,23 @@ Navigate back: \ref index "Main" / \ref TN
   <th>Deprecated functions available? <br/>(\TText{H5Lvisit1})</th>
   </tr>
   <tr align="center">
-  <td align="left">\TText{-DH5_USE_112_API} <br/> \Emph{(Default behavior if no option specified.)}</td>
-  <td>1.12.x (\TText{HLvisit2})</td>
+  <td align="left">\TText{-DH5_USE_200_API} <br/> \Emph{(Default behavior if no option specified.)}</td>
+  <td>2.0.x (\TText{H5Lvisit2})</td>
+  <td>yes* <br/> \Emph{*if available in library}</td>
+  </tr>
+  <tr align="center">
+  <td align="left">\TText{-DH5_USE_114_API}</td>
+  <td>1.14.x (\TText{H5Lvisit2})</td>
+  <td>yes* <br/> \Emph{*if available in library}</td>
+  </tr>
+  <tr align="center">
+  <td align="left">\TText{-DH5_USE_112_API}</td>
+  <td>1.12.x (\TText{H5Lvisit2})</td>
   <td>yes* <br/> \Emph{*if available in library}</td>
   </tr>
   <tr align="center">
   <td align="left">\TText{-DH5_USE_110_API}</td>
-  <td>1.10.x (\TText{HLvisit1})</td>
+  <td>1.10.x (\TText{H5Lvisit1})</td>
   <td>yes* <br/> \Emph{*if available in library}</td>
   </tr>
   <tr align="center">
@@ -302,6 +322,61 @@ Navigate back: \ref index "Main" / \ref TN
                 -DH5L_iterate_t_vers=1 -DH5Lget_info_by_idx_vers=1 \
                 -DH5Lget_info_vers=1 application.c
            \endcode
+
+  \subsubsection fun-options-200 Function Mapping Options in Releases 2.0.x
+  <table>
+  <tr>
+  <th style="text-align: left;">Macro <br/> (\TText{H5xxx})</th>
+  <th>Default function used if no macro specified
+  <ul><li>Function mapping: \TText{H5xxx_vers=N}</li></ul>
+  </th>
+  <th>Function used for backwards compatibility with 1.12 or 1.14
+  <ul><li>Function mapping: \TText{H5xxx_vers=1}</li></ul>
+  </th>
+  </tr>
+  <tr>
+  <td>H5Dread_chunk()</td>
+  <td>H5Dread_chunk2()
+  <ul>
+  <li>Function mapping:\TText{H5Dread_chunk_vers=2}</li>
+  </ul>
+  </td>
+  <td>H5Dread_chunk1()
+  <ul>
+  <li>Function mapping:\TText{H5Dread_chunk_vers=1}</li>
+  </ul>
+  </td>
+  </tr>
+  <tr>
+  <td>H5Iregister_type()</td>
+  <td>H5Iregister_type2()
+  <ul>
+  <li>Function mapping:\TText{H5Iregister_type_vers=2}</li>
+  </ul>
+  </td>
+  <td>H5Iregister_type1()
+  <ul>
+  <li>Function mapping:\TText{H5Iregister_type_vers=1}</li>
+  </ul>
+  </td>
+  </tr>
+  <tr>
+  <td>H5Tdecode()</td>
+  <td>H5Tdecode2()
+  <ul>
+  <li>Function mapping:\TText{H5Tdecode_vers=2}</li>
+  </ul>
+  </td>
+  <td>H5Tdecode1()
+  <ul>
+  <li>Function mapping:\TText{H5Tdecode_vers=1}</li>
+  </ul>
+  </td>
+  </tr>
+  </table>
+
+  \subsubsection fun-options-114 Function Mapping Options in Releases 1.14.x
+  No versioned functions were added in the 1.14.x releases.
 
   \subsubsection fun-options-112 Function Mapping Options in Releases 1.12.x
   <table>

--- a/doxygen/dox/cookbook/MavenArtifacts.dox
+++ b/doxygen/dox/cookbook/MavenArtifacts.dox
@@ -34,7 +34,7 @@ HDF5 provides three main Maven artifacts:
 <tr>
   <td><strong>hdf5-java-examples</strong></td>
   <td>Java 8+</td>
-  <td>62 example programs</td>
+  <td>example programs</td>
   <td>Platform-independent</td>
 </tr>
 </table>
@@ -50,7 +50,7 @@ Add the following dependency to your <code>pom.xml</code>:
 <dependency>
     <groupId>org.hdfgroup</groupId>
     <artifactId>hdf5-java-jni</artifactId>
-    <version>2.0.0-3</version>
+    <version>2.0.0</version>
     <classifier>linux-x86_64</classifier>
 </dependency>
 \endcode
@@ -93,7 +93,7 @@ Add the following dependency to your <code>pom.xml</code>:
 <dependency>
     <groupId>org.hdfgroup</groupId>
     <artifactId>hdf5-java-ffm</artifactId>
-    <version>2.0.0-3</version>
+    <version>2.0.0</version>
     <classifier>linux-x86_64</classifier>
 </dependency>
 \endcode
@@ -131,7 +131,7 @@ import hdf.hdf5lib.HDF5Constants;
 <dependency>
     <groupId>org.hdfgroup</groupId>
     <artifactId>hdf5-java-examples</artifactId>
-    <version>2.0.0-3</version>
+    <version>2.0.0</version>
 </dependency>
 \endcode
 
@@ -145,10 +145,10 @@ The examples artifact contains 62 educational examples covering:
 \par Running Examples
 \code
 # List available examples
-java -cp hdf5-java-examples-2.0.0-3.jar examples.intro.H5_CreateFile
+java -cp hdf5-java-examples-2.0.0.jar examples.intro.H5_CreateFile
 
 # Run a specific example
-java -cp "hdf5-java-jni-2.0.0-3-linux-x86_64.jar:hdf5-java-examples-2.0.0-3.jar" \
+java -cp "hdf5-java-jni-2.0.0-linux-x86_64.jar:hdf5-java-examples-2.0.0.jar" \
      examples.intro.H5_CreateFile
 \endcode
 

--- a/release_docs/AutotoolsToCMakeOptions.md
+++ b/release_docs/AutotoolsToCMakeOptions.md
@@ -1,6 +1,6 @@
 # <img src="Cmake_logo.svg" alt="Cmake logo" width=24> CMake Installations
 
-CMake produces the following set of folders; bin, include, lib and share. The LICENSE and RELEASE.txt file are placed in the share folder.
+CMake produces the following set of folders; bin, include, lib and share. The LICENSE and CHANGELOG.md file are placed in the share folder.
 
 The bin folder contains the tools and the build scripts. Additionally, CMake creates dynamic versions of the tools with the suffix "-shared".
 
@@ -26,7 +26,7 @@ release_docs/INSTALL_CMake.txt file for more information on the CMake build syst
 | Autotools Build Options | CMake Build Options | Notes |
 | ------- |  ------- | ------------ |
 | warnings-as-errors[default=no] | HDF5_ENABLE_WARNINGS_AS_ERRORS "Interpret some warnings as errors" [OFF] |  |
-| build-mode[--enable-build-mode=(debug|production|clean)] | CMAKE_BUILD_TYPE "Debug" "Release" "RelWithDebInfo" "MinSizeRel" "Developer" [Release] |  |
+| build-mode[--enable-build-mode=(debug\|production\|clean)] | CMAKE_BUILD_TYPE "Debug" "Release" "RelWithDebInfo" "MinSizeRel" "Developer" [Release] |  |
 | unsupported[Allow unsupported combinations of configure options] | HDF5_ALLOW_UNSUPPORTED "Allow unsupported combinations of configure options" [OFF] |  |
 | nonstandard-features[Enable support for non-standard programming language features[default=yes]] | HDF5_ENABLE_NONSTANDARD_FEATURES "Enable support for non-standard programming language features" [ON] |  |
 | nonstandard-feature-float16[Enable support for _Float16 C datatype [default=yes]] | HDF5_ENABLE_NONSTANDARD_FEATURE_FLOAT16 "Enable support for _Float16 C datatype" [${HDF5_ENABLE_NONSTANDARD_FEATURES}] | if (HDF5_ENABLE_NONSTANDARD_FEATURES) |
@@ -36,9 +36,7 @@ release_docs/INSTALL_CMake.txt file for more information on the CMake build syst
 | szlib[Use szlib library for external szlib I/O filter [default=yes]] | HDF5_ENABLE_SZIP_SUPPORT "Use SZip Filter" [OFF] |  |
 | default-api-version[Specify default release version of public symbols [default=v200]] | HDF5_DEFAULT_API_VERSION "v200" CACHE STRING "Enable v2.0 API (v16, v18, v110, v112, v114, v200)" [v200] |  |
 | default-plugindir[--with-default-plugindir=location], [Specify default location for plugins [default="/usr/local/hdf5/lib/plugin"]] | H5_DEFAULT_PLUGINDIR “Define the default plugins path” | if (WINDOWS)<br>H5_DEFAULT_PLUGINDIR "%ALLUSERSPROFILE%/hdf5/lib/plugin"<br>else ()<br>H5_DEFAULT_PLUGINDIR "/usr/local/hdf5/lib/plugin"<br>endif () |
-
-| Autotools Features Options | CMake Features Options | Notes |
-| ------- |  ------- | ------------ |
+| **Autotools Features Options** | **CMake Features Options** | **Notes** |
 | dimension-scales-with-new-ref[Use new references when creating dimension scales. [default=no]] | HDF5_DIMENSION_SCALES_NEW_REF "Use new-style references with dimension scale APIs" [OFF] |  |
 | map-api[Build the map API (H5M). [default=no]] | HDF5_ENABLE_MAP_API "Build the map API" [OFF] |  |
 | subfiling-vfd[Build the subfiling I/O virtual file driver (VFD). Requires --enable-parallel. [default=no]] | HDF5_ENABLE_SUBFILING_VFD "Build Parallel HDF5 Subfiling VFD" [OFF] | if (HDF5_BUILD_UTILS) |
@@ -50,29 +48,22 @@ release_docs/INSTALL_CMake.txt file for more information on the CMake build syst
 | threadsafe[Enable thread-safe capability. Not compatible with the high-level library, Fortran, or C++ wrappers.  [default=no]] | HDF5_ENABLE_THREADSAFE "Enable Threadsafety" [OFF] |  |
 | file-locking[Sets the default for whether or not to use file locking when opening files. [default=best-effort]] | HDF5_USE_FILE_LOCKING "Use file locking by default (mainly for SWMR)" [ON] | HDF5_IGNORE_DISABLED_FILE_LOCKS "Ignore file locks when disabled on file system" [ON] |
 | enable-concurrency[Support for concurrent multithreaded operation of supported API routines [default=no]] | HDF5_ENABLE_CONCURRENCY "Enable multi-threaded concurrency" [OFF] | This option also provides threadsafe execution of all other, non-concurrent operations. |
-
-| Autotools Language Options | CMake Language Options | Notes |
-| ------- |  ------- | ------------ |
+| **Autotools Language Options** | **CMake Language Options** | **Notes** |
 | fortran[Compile the Fortran interface [default=no]] | HDF5_BUILD_FORTRAN "Build FORTRAN support" [OFF] |  |
 | fmoddir[--with-fmoddir=DIR], [Fortran module install directory] | HDF5_INSTALL_MODULE_DIR=$<INSTALL_PREFIX>/mod |  |
 | cxx[Compile the C++ interface [default=no]] | HDF5_BUILD_CPP_LIB "Build HDF5 C++ Library" [OFF] |  |
 | hl[Enable the high-level library. [default=yes (unless build mode = clean)] | HDF5_BUILD_HL_LIB "Build HIGH Level HDF5 Library" [ON] |  |
 | java[Compile the Java JNI interface [default=no]] | HDF5_BUILD_JAVA "Build JAVA support" [OFF] |  |
 | parallel[Search for MPI-IO and MPI support files] | HDF5_ENABLE_PARALLEL "Enable parallel build (requires MPI)" [OFF] |  |
-
-| Autotools Test Options | CMake Test Options | Notes |
-| ------- |  ------- | ------------ |
+| **Autotools Test Options** | **CMake Test Options** | **Notes** |
 | tests[Compile the HDF5 tests [default=yes]] | BUILD_TESTING "Build HDF5 Unit Testing" [ON] |  |
 | test-express[Set HDF5 testing intensity level (0-3) [0 = exhaustive testing; 3 = quicker testing; default=3] | HDF_TEST_EXPRESS "Control testing framework (0-3)" ["3"] |  |
 | tools[Compile the HDF5 tools [default=yes]] | HDF5_BUILD_TOOLS "Build HDF5 Tools" [ON] |  |
 | parallel-tools[Enable building parallel tools. [default=no]] | HDF5_BUILD_PARALLEL_TOOLS  "Build Parallel HDF5 Tools" [OFF] |  |
-
-| Autotools Doc Options | CMake Doc Options | Notes |
+| **Autotools Doc Options** | **CMake Doc Options** | **Notes** |
 | doxygen[Compile the HDF5 doxygen files [default=no]] | HDF5_BUILD_DOC "Build documentation" [OFF] |  |
 | doxygen-errors[Error on HDF5 doxygen warnings [default=no]] | HDF5_ENABLE_DOXY_WARNINGS "Enable fail if doxygen parsing has warnings." [OFF] |  |
-
-| Autotools Dev Options | CMake Dev Options | Notes |
-| ------- |  ------- | ------------ |
+| **Autotools Dev Options** | **CMake Dev Options** | **Notes** |
 | sanitize-checks[default=none] | HDF5_USE_SANITIZER ["Compile with a sanitizer. Options are: Address, Memory, MemoryWithOrigins, Undefined, Thread, Leak, 'Address;Undefined', CFI"] | Requires HDF5_ENABLE_SANITIZERS "execute the Clang sanitizer" [OFF] |
 | asserts[Determines whether NDEBUG is defined or not, which controls assertions. [default=yes if debug build, otherwise no]] | HDF5_ENABLE_ASSERTS "Determines whether NDEBUG is defined to control assertions." [OFF] |  |
 | developer-warnings[Determines whether developer warnings will be emitted. [default=no]] | HDF5_ENABLE_DEV_WARNINGS "Enable HDF5 developer group warnings" [OFF |  |
@@ -91,9 +82,7 @@ release_docs/INSTALL_CMake.txt file for more information on the CMake build syst
 | strict-format-checks[Enable strict file format checks. [default=yes if debug build, otherwise no]] | HDF5_STRICT_FORMAT_CHECKS "Whether to perform strict file format checks" [OFF] |  |
 | preadwrite[Enable using pread/pwrite instead of read/write in sec2/log/core VFDs. [default=yes if pread/pwrite are present]] | HDF5_ENABLE_PREADWRITE "Use pread/pwrite in sec2/log/core VFDs in place of read/write (when available)" [ON] |  |
 | embedded-libinfo[Enable embedded library information [default=yes]] | HDF5_ENABLE_EMBEDDED_LIBINFO "Embed library info into executables" [ON] |  |
-
-| Autotools Options | CMake Unused | Notes |
-| ------- |  ------- | ------------ |
+| **Autotools Options** | **CMake Unused** | **Notes** |
 | examplesdir[--with-examplesdir=location], [Specify path for examples [default="DATAROOTDIR/hdf5_examples"]] |  |  |
 | libmfu[--with-libmfu=DIR], [Use the libmfu library [default=no]] |  |  |
 | pthread[--with-pthread=DIR][Specify alternative path to Pthreads library] | Handled by HDF5_THREADS_ENABLED |  |

--- a/release_docs/CHANGELOG.md
+++ b/release_docs/CHANGELOG.md
@@ -25,31 +25,31 @@ For releases prior to version 2.0.0, please see the release.txt file and for mor
 
 ## Performance Enhancements:
 
-- Up to [2500% faster](/CHANGELOG.md#rtree) Virtual Dataset read/write operations
-- [30% faster opening](/CHANGELOG.md#layoutcopydelay) and [25% faster closing](/CHANGELOG.md#fileformat) of virtual datasets.
-- [Reduced memory overhead](/CHANGELOG.md#fileformat) via shared name strings and optimized spatial search algorithms for virtual datasets.
+- Up to [2500% faster](CHANGELOG.md#rtree) Virtual Dataset read/write operations
+- [30% faster opening](CHANGELOG.md#layoutcopydelay) and [25% faster closing](CHANGELOG.md#fileformat) of virtual datasets.
+- [Reduced memory overhead](CHANGELOG.md#fileformat) via shared name strings and optimized spatial search algorithms for virtual datasets.
 
 ## Significant Advancements:
 
-- Full [UTF-8](/CHANGELOG.md#utf-8) filename support on Windows, resolving encoding issues from previous versions.
-- Introduction of [bfloat16 predefined datatypes](/CHANGELOG.md#added-predefined-datatypes-for-bfloat16-data) for efficient machine learning conversions.
-- First-class support for [complex numbers](/CHANGELOG.md#complex), eliminating manual workarounds in scientific applications.
-- A [new, larger chunk size limit](/CHANGELOG.md#added-support-for-large-chunks), in multi-petabytes, replaces the previous 4 GiB limit.
+- Full [UTF-8](CHANGELOG.md#utf-8) filename support on Windows, resolving encoding issues from previous versions.
+- Introduction of [bfloat16 predefined datatypes](CHANGELOG.md#added-predefined-datatypes-for-bfloat16-data) for efficient machine learning conversions.
+- First-class support for [complex numbers](CHANGELOG.md#complex), eliminating manual workarounds in scientific applications.
+- A [new, larger chunk size limit](CHANGELOG.md#added-support-for-large-chunks), in multi-petabytes, replaces the previous 4 GiB limit.
 
 ## Updated Foundation:
 
-- New [file format](/CHANGELOG.md#fileformat) version (4.0) and compliance with the C11 standard.
+- New [file format](CHANGELOG.md#fileformat) version (4.0) and compliance with the C11 standard.
 - Adopted [semantic versioning](https://github.com/HDFGroup/hdf5/wiki/HDF5-Version-Numbers-and-Branch-Strategy) to clearly convey changes between versions.
 
 > [!IMPORTANT]
 >
-> - Transitioned to [CMake-only](/CHANGELOG.md#cmake) builds, and Autotools is no longer in use.
+> - Transitioned to [CMake-only](CHANGELOG.md#cmake) builds, and Autotools is no longer in use.
 > - Renamed library state variables, notably `HDF5_ENABLE_PARALLEL` is now `HDF5_PROVIDES_PARALLEL`, see PR [#5716](https://github.com/HDFGroup/hdf5/pull/5716) for more details.
 > - The default setting for `H5Fset_libver_bounds` has been updated to set the lower bound to the HDF5 library version 1.8. This change ensures that users can take advantage of the library's optimal performance and the latest features by default. If users need their files to be compatible with older versions of the HDF5 library, they will need to adjust this lower bound manually.
 
 ## Enhanced Features:
 
-- Improved [ROS3 VFD](/CHANGELOG.md#ros3) capabilities using the aws-c-s3 library.
+- Improved [ROS3 VFD](CHANGELOG.md#ros3) capabilities using the aws-c-s3 library.
 
 ## Java Enhancements:
 
@@ -73,7 +73,7 @@ We would like to thank the many HDF5 community members who contributed to HDF5 2
 
 ### Autotools support was removed from HDF5<a name="cmake">
 
-   CMake is now the build system available in HDF5 code. Version 3.26 or later is required. See the [AutotoolsToCMakeOptions.md](/AutotoolsToCMakeOptions.md) file for highlights of the CMake HDF5 install layout and CMake options to use in place of former Autotools options.
+   CMake is now the build system available in HDF5 code. Version 3.26 or later is required. See the [AutotoolsToCMakeOptions.md](AutotoolsToCMakeOptions.md) file for highlights of the CMake HDF5 install layout and CMake options to use in place of former Autotools options.
 
 ### Fixed problems with family driver and user block
 

--- a/release_docs/CHANGELOG.md
+++ b/release_docs/CHANGELOG.md
@@ -25,31 +25,31 @@ For releases prior to version 2.0.0, please see the release.txt file and for mor
 
 ## Performance Enhancements:
 
-- Up to [2500% faster](CHANGELOG.md#rtree) Virtual Dataset read/write operations
-- [30% faster opening](CHANGELOG.md#layoutcopydelay) and [25% faster closing](CHANGELOG.md#fileformat) of virtual datasets.
-- [Reduced memory overhead](CHANGELOG.md#fileformat) via shared name strings and optimized spatial search algorithms for virtual datasets.
+- Up to [2500% faster](/CHANGELOG.md#rtree) Virtual Dataset read/write operations
+- [30% faster opening](/CHANGELOG.md#layoutcopydelay) and [25% faster closing](/CHANGELOG.md#fileformat) of virtual datasets.
+- [Reduced memory overhead](/CHANGELOG.md#fileformat) via shared name strings and optimized spatial search algorithms for virtual datasets.
 
 ## Significant Advancements:
 
-- Full [UTF-8](CHANGELOG.md#utf-8) filename support on Windows, resolving encoding issues from previous versions.
-- Introduction of [bfloat16 predefined datatypes](CHANGELOG.md#added-predefined-datatypes-for-bfloat16-data) for efficient machine learning conversions.
-- First-class support for [complex numbers](CHANGELOG.md#complex), eliminating manual workarounds in scientific applications.
-- A [new, larger chunk size limit](CHANGELOG.md#added-support-for-large-chunks), in multi-petabytes, replaces the previous 4 GiB limit.
+- Full [UTF-8](/CHANGELOG.md#utf-8) filename support on Windows, resolving encoding issues from previous versions.
+- Introduction of [bfloat16 predefined datatypes](/CHANGELOG.md#added-predefined-datatypes-for-bfloat16-data) for efficient machine learning conversions.
+- First-class support for [complex numbers](/CHANGELOG.md#complex), eliminating manual workarounds in scientific applications.
+- A [new, larger chunk size limit](/CHANGELOG.md#added-support-for-large-chunks), in multi-petabytes, replaces the previous 4 GiB limit.
 
 ## Updated Foundation:
 
-- New [file format](CHANGELOG.md#fileformat) version (4.0) and compliance with the C11 standard.
+- New [file format](/CHANGELOG.md#fileformat) version (4.0) and compliance with the C11 standard.
 - Adopted [semantic versioning](https://github.com/HDFGroup/hdf5/wiki/HDF5-Version-Numbers-and-Branch-Strategy) to clearly convey changes between versions.
 
 > [!IMPORTANT]
 >
-> - Transitioned to [CMake-only](CHANGELOG.md#cmake) builds, and Autotools is no longer in use.
+> - Transitioned to [CMake-only](/CHANGELOG.md#cmake) builds, and Autotools is no longer in use.
 > - Renamed library state variables, notably `HDF5_ENABLE_PARALLEL` is now `HDF5_PROVIDES_PARALLEL`, see PR [#5716](https://github.com/HDFGroup/hdf5/pull/5716) for more details.
 > - The default setting for `H5Fset_libver_bounds` has been updated to set the lower bound to the HDF5 library version 1.8. This change ensures that users can take advantage of the library's optimal performance and the latest features by default. If users need their files to be compatible with older versions of the HDF5 library, they will need to adjust this lower bound manually.
 
 ## Enhanced Features:
 
-- Improved [ROS3 VFD](CHANGELOG.md#ros3) capabilities using the aws-c-s3 library.
+- Improved [ROS3 VFD](/CHANGELOG.md#ros3) capabilities using the aws-c-s3 library.
 
 ## Java Enhancements:
 
@@ -73,7 +73,7 @@ We would like to thank the many HDF5 community members who contributed to HDF5 2
 
 ### Autotools support was removed from HDF5<a name="cmake">
 
-   CMake is now the build system available in HDF5 code. Version 3.26 or later is required. See the [AutotoolsToCMakeOptions.md](AutotoolsToCMakeOptions.md) file for highlights of the CMake HDF5 install layout and CMake options to use in place of former Autotools options.
+   CMake is now the build system available in HDF5 code. Version 3.26 or later is required. See the [AutotoolsToCMakeOptions.md](/AutotoolsToCMakeOptions.md) file for highlights of the CMake HDF5 install layout and CMake options to use in place of former Autotools options.
 
 ### Fixed problems with family driver and user block
 

--- a/release_docs/CHANGELOG.md
+++ b/release_docs/CHANGELOG.md
@@ -25,29 +25,31 @@ For releases prior to version 2.0.0, please see the release.txt file and for mor
 
 ## Performance Enhancements:
 
-- Up to [2500% faster](https://github.com/HDFGroup/hdf5/blob/develop/release_docs/CHANGELOG.md#rtree) Virtual Dataset read/write operations
-- [30% faster opening](https://github.com/HDFGroup/hdf5/blob/develop/release_docs/CHANGELOG.md#layoutcopydelay) and [25% faster closing](https://github.com/HDFGroup/hdf5/blob/develop/release_docs/CHANGELOG.md#fileformat) of virtual datasets.
-- [Reduced memory overhead](https://github.com/HDFGroup/hdf5/blob/develop/release_docs/CHANGELOG.md#fileformat) via shared name strings and optimized spatial search algorithms for virtual datasets.
+- Up to [2500% faster](/CHANGELOG.md#rtree) Virtual Dataset read/write operations
+- [30% faster opening](/CHANGELOG.md#layoutcopydelay) and [25% faster closing](/CHANGELOG.md#fileformat) of virtual datasets.
+- [Reduced memory overhead](/CHANGELOG.md#fileformat) via shared name strings and optimized spatial search algorithms for virtual datasets.
 
 ## Significant Advancements:
 
-- Full [UTF-8](https://github.com/HDFGroup/hdf5/blob/develop/release_docs/CHANGELOG.md#utf-8) filename support on Windows, resolving encoding issues from previous versions.
-- Introduction of [bfloat16 predefined datatypes](https://github.com/HDFGroup/hdf5/blob/develop/release_docs/CHANGELOG.md#added-predefined-datatypes-for-bfloat16-data) for efficient machine learning conversions.
-- First-class support for [complex numbers](https://github.com/HDFGroup/hdf5/blob/develop/release_docs/CHANGELOG.md#complex), eliminating manual workarounds in scientific applications.
+- Full [UTF-8](/CHANGELOG.md#utf-8) filename support on Windows, resolving encoding issues from previous versions.
+- Introduction of [bfloat16 predefined datatypes](/CHANGELOG.md#added-predefined-datatypes-for-bfloat16-data) for efficient machine learning conversions.
+- First-class support for [complex numbers](/CHANGELOG.md#complex), eliminating manual workarounds in scientific applications.
+- A [new, larger chunk size limit](/CHANGELOG.md#added-support-for-large-chunks), in multi-petabytes, replaces the previous 4 GiB limit.
 
 ## Updated Foundation:
 
-- New [file format](https://github.com/HDFGroup/hdf5/blob/develop/release_docs/CHANGELOG.md#fileformat) version (4.0) and compliance with the C11 standard.
+- New [file format](/CHANGELOG.md#fileformat) version (4.0) and compliance with the C11 standard.
+- Adopted [semantic versioning](https://github.com/HDFGroup/hdf5/wiki/HDF5-Version-Numbers-and-Branch-Strategy) to clearly convey changes between versions.
 
 > [!IMPORTANT]
 >
-> - Transitioned to [CMake-only](https://github.com/HDFGroup/hdf5/blob/develop/release_docs/CHANGELOG.md#cmake) builds, and Autotools is no longer in use.
+> - Transitioned to [CMake-only](/CHANGELOG.md#cmake) builds, and Autotools is no longer in use.
 > - Renamed library state variables, notably `HDF5_ENABLE_PARALLEL` is now `HDF5_PROVIDES_PARALLEL`, see PR [#5716](https://github.com/HDFGroup/hdf5/pull/5716) for more details.
 > - The default setting for `H5Fset_libver_bounds` has been updated to set the lower bound to the HDF5 library version 1.8. This change ensures that users can take advantage of the library's optimal performance and the latest features by default. If users need their files to be compatible with older versions of the HDF5 library, they will need to adjust this lower bound manually.
 
 ## Enhanced Features:
 
-- Improved [ROS3 VFD](https://github.com/HDFGroup/hdf5/blob/develop/release_docs/CHANGELOG.md#ros3) capabilities using the aws-c-s3 library.
+- Improved [ROS3 VFD](/CHANGELOG.md#ros3) capabilities using the aws-c-s3 library.
 
 ## Java Enhancements:
 
@@ -57,7 +59,7 @@ For releases prior to version 2.0.0, please see the release.txt file and for mor
   
 ## Acknowledgements: 
 
-We would like to thank the many HDF5 community members that contributed to HDF5 2.0.
+We would like to thank the many HDF5 community members who contributed to HDF5 2.0.
 
 # ⚠️ Breaking Changes
 
@@ -71,7 +73,7 @@ We would like to thank the many HDF5 community members that contributed to HDF5 
 
 ### Autotools support was removed from HDF5<a name="cmake">
 
-   CMake is now the build system available in HDF5 code. Version 3.26 or later is required. See the AutotoolsToCMakeOptions.md file for highlights of the CMake HDF5 install layout and CMake options to use in place of former Autotools options.
+   CMake is now the build system available in HDF5 code. Version 3.26 or later is required. See the [AutotoolsToCMakeOptions.md](/AutotoolsToCMakeOptions.md) file for highlights of the CMake HDF5 install layout and CMake options to use in place of former Autotools options.
 
 ### Fixed problems with family driver and user block
 
@@ -103,7 +105,7 @@ We would like to thank the many HDF5 community members that contributed to HDF5 
 
    The `HDF5_ENABLE_THREADS` option has been removed, as it no longer functions as a proper build option. The library will always check for thread support and set the internal status variable, `HDF5_THREADS_ENABLED`. The `HDF5_ENABLE_THREADSAFE` option is still available to build with thread-safe API calls.
 
-- Enhanced Maven repository deployment support
+### Enhanced Maven repository deployment support
 
    Added comprehensive Maven integration with optimized workflows for Java artifact deployment:
    - **New CMake options**: `HDF5_ENABLE_MAVEN_DEPLOY` and `HDF5_MAVEN_SNAPSHOT` for Maven repository deployment
@@ -121,7 +123,7 @@ We would like to thank the many HDF5 community members that contributed to HDF5 
    - **Production deployment validation**: Successfully resolved HTTP 409 version conflicts through snapshot versioning strategy
    - **Deployment status**: ✅ Fully validated and production-ready with comprehensive error resolution and testing documentation
 
- - Reorganized the files in the config/cmake folder into the config folder structure
+### Reorganized the files in the config/cmake folder into the config folder structure
 
    The config folder CMake files have been reorganized to make it easier to maintain and add new features. This includes the following changes:
    - The files in the config folder are the macros and templates for the build process.
@@ -627,7 +629,7 @@ Added Fortran wrapper `h5fdsubfiling_get_file_mapping_f()` for the subfiling fil
 
    Fixed a heap buffer overflow in H5FS__sinfo_serialize_node_cb() by discarding file free space sections from the file free space manager when they are found to be invalid. Specifically crafted HDF5 files can result in an attempt to insert duplicate or overlapping file free space sections into a file free space manager, later resulting in a buffer overflow when the same free space section is serialized to the file multiple times.
 
-   Fixes GitHub issue #5577
+   Fixes GitHub issue [#5577](https://github.com/HDFGroup/hdf5/issues/5577)
 
 ### Fixed security issue [CVE-2025-2915](https://nvd.nist.gov/vuln/detail/CVE-2025-2915) and [OSV-2024-381](https://osv.dev/vulnerability/OSV-2024-381)
 

--- a/src/H5Ppublic.h
+++ b/src/H5Ppublic.h
@@ -928,9 +928,9 @@ H5_DLL hid_t H5Pdecode(const void *buf);
  *          control the encoding via the \a libver_bounds property
  *          (see H5Pset_libver_bounds()). If the \a libver_bounds
  *          property is missing, H5Pencode2() proceeds as if the \a
- *          libver_bounds property were set to (#H5F_LIBVER_EARLIEST,
+ *          libver_bounds property were set to (#H5F_LIBVER_V18,
  *          #H5F_LIBVER_LATEST). (Functionally, H5Pencode1() is identical to
- *          H5Pencode2() with \a libver_bounds set to (#H5F_LIBVER_EARLIEST,
+ *          H5Pencode2() with \a libver_bounds set to (#H5F_LIBVER_V18,
  *          #H5F_LIBVER_LATEST).)
  *          Properties that do not have encode callbacks will be skipped.
  *          There is currently no mechanism to register an encode callback for
@@ -5116,12 +5116,16 @@ H5_DLL herr_t H5Pset_gc_references(hid_t fapl_id, unsigned gc_ref);
  *           </tr>
  *          </table>
  *
+ *          The default settings are \p low=#H5F_LIBVER_V18, \p high=#H5F_LIBVER_LATEST.
+ *
  * \note *H5F_LIBVER_LATEST*:<br />
  *                 Since 2.0.x is also #H5F_LIBVER_LATEST, there is no upper
  *                 limit on the format versions to use.  That is, if a
  *                 newer format version is required to support a feature
  *                 in 2.0.x series, this setting will allow the object to be
  *                 created.
+ *
+ * \version 2.0.0  Default setting for \p low changed to #H5F_LIBVER_V18
  *
  * \version 1.10.2 #H5F_LIBVER_V18 added to the enumerated defines in
  *                 #H5F_libver_t.


### PR DESCRIPTION
<!-- ELLIPSIS_HIDDEN -->
PRs #5991, #5990, #5980, #5979 and #5968


> [!IMPORTANT]
> Update documentation and configuration for version 2.0.0, including Maven dependencies, API versioning, and layout encoding descriptions.
> 
>   - **Version Updates**:
>     - Updated Maven dependency versions from `2.0.0-3` to `2.0.0` in `README-MAVEN.md` and `MavenArtifacts.dox`.
>     - Changed default API version to `v200` in `api-compat-macros.dox`.
>   - **Documentation**:
>     - Added NSF support acknowledgment in `LICENSE`.
>     - Updated layout version descriptions and chunk size encoding in `H5.format.4.0.dox`.
>     - Corrected links and references in `CHANGELOG.md`.
>     - Updated CMake options and documentation in `AutotoolsToCMakeOptions.md`.
>   - **Miscellaneous**:
>     - Changed default `libver_bounds` to `H5F_LIBVER_V18` in `H5Ppublic.h`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=HDFGroup%2Fhdf5&utm_source=github&utm_medium=referral)<sup> for 6a2e88d366ca5cf2bbf5892fa69bb37f18306fc8. You can [customize](https://app.ellipsis.dev/HDFGroup/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->