### PR TITLE
Added release 2.0 documentation

### DIFF
--- a/doxygen/aliases
+++ b/doxygen/aliases
@@ -279,6 +279,8 @@ ALIASES += ref_vol_doc="VOL documentation"
 ################################################################################
 
 ALIASES += ref_rfc20240129="<a href=\"https://\RFCURL/RFC__Adding_support_for_16_bit_floating_point_and_Complex_number_datatypes_to_HDF5.pdf\">Adding support for 16-bit floating point and Complex number datatypes to HDF</a>"
+# Same RFC, but complex number datatypes was delayed to 2.0
+ALIASES += ref_rfc20240129complex="<a href=\"https://\RFCURL/RFC__Adding_support_for_16_bit_floating_point_and_Complex_number_datatypes_to_HDF5.pdf\">Support for Complex number datatypes</a>"
 ALIASES += ref_rfc20220819="<a href=\"https://\RFCURL/Terminal_VOL_Connector_Feature_Flags.pdf\">Terminal VOL Connector Feature Flags</a>"
 ALIASES += ref_rfc20210528="<a href=\"https://\RFCURL/RFC_multi_thread.pdf\">Multi-Thread HDF5</a>"
 ALIASES += ref_rfc20210219="<a href=\"https://\RFCURL/selection_io_RFC_210610.pdf\">Selection I/O</a>"

--- a/doxygen/aliases
+++ b/doxygen/aliases
@@ -16,8 +16,9 @@ ALIASES += DWNURL="\RELURL/downloads/latest"
 # URL for RFCs
 ALIASES += RFCURL="\DOCURL/rfc"
 ALIASES += AEXURL="\HDFURL/archive/support/ftp/HDF5/examples"
-#branch name (develop, hdf5_1_14)
+#branch name (develop, hdf5_2_0_0)
 ALIASES += SRCURL="github.com/HDFGroup/hdf5/blob/develop"
+ALIASES += SRCURL20="github.com/HDFGroup/hdf5/blob/hdf5_2_0_0"
 #Other projects that contribute to HDF5
 ALIASES += PRJURL="\HDFURL/archive/support/projects"
 ALIASES += HVURL="github.com/HDFGroup/hdfview/blob/master"

--- a/doxygen/dox/hdf5_2_0.dox
+++ b/doxygen/dox/hdf5_2_0.dox
@@ -43,7 +43,7 @@ Additional Release Information
 <td style="background-color:#F5F5F5">
 </td>
 <td>
-\ref sec_rel_spec_20_change
+\ref subsec_rel_spec_20_change
 </td>
 </tr>
 <tr>
@@ -85,11 +85,15 @@ Source code and binaries are available at:
 Please refer to [Build instructions](https://github.com/HDFGroup/hdf5/blob/hdf5_2.0/release_docs/INSTALL) for building with either CMake or Autotools.
 
 
-**Methods to obtain  (gz file)**
-* firefox – Download file and then run:  `gzip <distribution>.tar.gz | tar xzf -`
-* chrome –  Download file and then run:  `gzip -cd <distribution>.tar.gz | tar xvf -`
-* `wget – wget https://github.com/HDFGroup/hdf5/releases/download/hdf5_1.N.N/<distribution>.tar.gz`
-  * `gzip -cd <distribution>.tar.gz | tar xvf -`
+<h3 id="method">Methods to obtain (gz file)</h3>
+
+\li firefox – Download file and then run:  `gzip <distribution>.tar.gz | tar xzf -`
+\li chrome –  Download file and then run:  `gzip -cd <distribution>.tar.gz | tar xvf -`
+\li wget –
+<div style="margin-left: 2em;">
+    `wget https://github.com/HDFGroup/hdf5/releases/download/hdf5_1.N.N/<distribution>.tar.gz`<br>
+    `gzip -cd <distribution>.tar.gz | tar xvf -`
+</div>
 
 <h3 id="api_compat">Individual API Compatibility Reports</h3>
 
@@ -112,54 +116,42 @@ Since this portion of the HDF5 documentation is now part of the source code, it 
 
 \subsection subsec_rel_spec_20_migrate Migrating from HDF5 1.14 to HDF5 2.0
 
+This section highlights some changes that might affect migrating to HDF5.20, please refer to the \ref subsec_rel_spec_20_change or the <a href="https://\SRCURL/release_docs/CHANGELOG.md">Change log</a> for detail.
+
 \li Default file format is now 1.8
-
 \li The file format has been updated to 4.0<a name="fileformat"></a>
-
 \li API signature changes
-  \li `H5Dread_chunk()`
-  \li `H5Tdecode()`
-
-Please refer to \ref sec_rel_spec_20_change or <a href="https://\SRCURL/release_docs/CHANGELOG.md">Change log</a> for detail.
-
-\li A new backend based on the [aws-c-s3 library](https://github.com/awslabs/aws-c-s3)<a name="ros3"></a> replaced the ROS3 VFD's S3 backend based on libcurl.  The ROS3 VFD now requires the `aws-c-s3` library in order to be built.  See the <a href="https://\SRCURL/release_docs/CHANGELOG.md">Change log</a> for a complete description on this feature.
-
+    - `H5Dread_chunk()`<br>
+    - `H5Tdecode()`<br>
+    - `H5Iregister_type()`<br>
+\li A new backend based on the [aws-c-s3 library](https://github.com/awslabs/aws-c-s3) replaced the ROS3 VFD's S3 backend based on libcurl.  The ROS3 VFD now requires the `aws-c-s3` library in order to be built.  See the <a href="https://\SRCURL/release_docs/CHANGELOG.md">Change log</a> for a complete description on this feature.
 \li Significance in tools
-   <br>The tool h5dump has a new option --lformat and its XML option is deprecated.
-
-   <br>The high-level GIF tools, `h52gif` and `gif2h5` have been removed. We may move them to a separate repository in the future.  See <a href="https://\SRCURL/release_docs/CHANGELOG.md">Change log</a> for an explanation.
-
+    - The tool h5dump has a new option `--lformat` and its `XML` option is deprecated.
+    - The high-level GIF tools, `h52gif` and `gif2h5` have been removed. We may move them to a separate repository in the future.  See <a href="https://\SRCURL/release_docs/CHANGELOG.md">Change log</a> for an explanation.
 
 \subsection subsec_rel_spec_20_feat New Features in HDF5 Release 2.0
 
-The new features in the HDF5 2.0 series include:
+This section includes the new features introduced in the HDF5 2.0 series:
 
-\li Support for complex number datatypes<a name="complex"></a>
-
-Support for the C99 `float _Complex`, `double _Complex` and `long double _Complex` (with MSVC, `_Fcomplex`, `_Dcomplex` and `_Lcomplex`) types has been added for platforms/compilers that support them. These types have been implemented with a new datatype class, `H5T_COMPLEX`. Note that any datatypes of class H5T_COMPLEX will not be readable with previous versions of HDF5. If a file is accessed with a library version bounds "high" setting less than `H5F_LIBVER_V200`, an error will occur if the application tries to create an object with a complex number datatype. If compatibility with previous versions of HDF5 is desired, applications should instead consider adopting [one of the existing conventions](https://nc-complex.readthedocs.io/en/latest/#conventions-used-in-applications). \ref_rfc20240129<br />
+\li \ref_rfc20240129complex
+<br>Support for the C99 `float _Complex`, `double _Complex` and `long double _Complex` (with MSVC, `_Fcomplex`, `_Dcomplex` and `_Lcomplex`) types has been added for platforms/compilers that support them. These types have been implemented with a new datatype class, `H5T_COMPLEX`. Note that any datatypes of class H5T_COMPLEX will not be readable with previous versions of HDF5. If a file is accessed with a library version bounds "high" setting less than `H5F_LIBVER_V200`, an error will occur if the application tries to create an object with a complex number datatype. If compatibility with previous versions of HDF5 is desired, applications should instead consider adopting [one of the existing conventions](https://nc-complex.readthedocs.io/en/latest/#conventions-used-in-applications).<br />
 
 \li An AWS endpoint command option
-
-   The new option is `--endpoint-url`, which allows the user to set an alternate endpoint URL other than the standard "protocol://service-code.region-code.amazonaws.com". If `--endpoint-url` is not specified, the ROS3 VFD will first check the `AWS_ENDPOINT_URL_S3` and `AWS_ENDPOINT_URL` environment variables for an alternate endpoint URL before using a default one, with the region-code being supplied by the FAPL or standard AWS locations/environment variables.
-
-   This option is supported by the following tools:
-      `h5dump`, `h5ls`, `h5stat`
+<br>The new option is `--endpoint-url`, which allows the user to set an alternate endpoint URL other than the standard "protocol://service-code.region-code.amazonaws.com". If `--endpoint-url` is not specified, the ROS3 VFD will first check the `AWS_ENDPOINT_URL_S3` and `AWS_ENDPOINT_URL` environment variables for an alternate endpoint URL before using a default one, with the region-code being supplied by the FAPL or standard AWS locations/environment variables.
+<br>This option is supported by the following tools: `h5dump`, `h5ls`, `h5stat`
 
 \li Specifying ROS3 VFD on the command line is not required when using S3 URI
-
-   This feature applies to the following tools: `h5dump`, `h5ls`, `h5stat`.
+<br>This feature applies to the following tools: `h5dump`, `h5ls`, `h5stat`.
 
 \li Performance improvement in opening a virtual dataset with many mappings
-
-   When opening a virtual dataset, the library would previously decode the mappings in the object header package, then copy them to the dataset struct, then copy them to the internal dataset creation property list. Copying the VDS mappings could be very expensive if there were many mappings. Changed this to delay decoding the mappings until the dataset code, and delay copying the layout to the DCPL until it is needed. This results in only the decoding and no copies in most use cases, as opposed to the decoding and two copies with the previous code.
+<br>When opening a virtual dataset, the library would previously decode the mappings in the object header package, then copy them to the dataset struct, then copy them to the internal dataset creation property list. Copying the VDS mappings could be very expensive if there were many mappings. Changed this to delay decoding the mappings until the dataset code, and delay copying the layout to the DCPL until it is needed. This results in only the decoding and no copies in most use cases, as opposed to the decoding and two copies with the previous code.
 
 \li Support for chunks larger than 4 GiB using 64 bit addressing.
 
 \li New predefined datatypes for FP8 data in E4M3 and E5M2 formats (https://arxiv.org/abs/2209.05433), but not a native FP8 datatype.  Please refer to the <a href="https://\SRCURL/release_docs/CHANGELOG.md">CHANGELOG</a> for detail.
 
 \li Default chunk cache hash table size increased to 8191
-
-In order to reduce hash collisions and take advantage of modern memory capacity, the default hash table size for the chunk cache has been increased from 521 to 8191. This means the hash table will consume approximately 64 KiB per open dataset. This value can be changed with `H5Pset_cache()` or `H5Pset_chunk_cache()`. This value was chosen because it is a prime number close to 8K.
+<br>In order to reduce hash collisions and take advantage of modern memory capacity, the default hash table size for the chunk cache has been increased from 521 to 8191. This means the hash table will consume approximately 64 KiB per open dataset. This value can be changed with `H5Pset_cache()` or `H5Pset_chunk_cache()`. This value was chosen because it is a prime number close to 8K.
 
 
  *

--- a/doxygen/dox/hdf5_2_0.dox
+++ b/doxygen/dox/hdf5_2_0.dox
@@ -3,9 +3,9 @@
  * Navigate back: \ref index "Main" / \ref release_specific_info
  * <hr>
 
-<h2 id="library_tools_20">HDF5 Library and Tools 2.0</h2>
+\section sec_rel_spec_20 HDF5 Library and Tools 2.0
 
-<h3 id="release">Release Information</h3>
+\subsection subsec_rel_info Release Information
 
 <table>
 <tr>
@@ -21,7 +21,7 @@ HDF5 2.0
 Release Date
 </td>
 <td>
-11/10/25
+11/11/25
 </td>
 </tr>
 <tr>
@@ -36,21 +36,21 @@ Additional Release Information
 <td style="background-color:#F5F5F5">
 </td>
 <td>
-\ref subsec_rel_spec_20_migrate
+\ref sec_rel_spec_20_migrate
 </td>
 </tr>
 <tr>
 <td style="background-color:#F5F5F5">
 </td>
 <td>
-\ref subsec_rel_spec_20_change
+\ref sec_rel_spec_20_change
 </td>
 </tr>
 <tr>
 <td style="background-color:#F5F5F5">
 </td>
 <td>
-\ref subsec_rel_spec_20_feat
+\ref sec_rel_spec_20_feat
 </td>
 </tr>
 <tr>
@@ -77,7 +77,7 @@ Additional Release Information
 </table>
 
 
-<h3 id="download">Downloads</h3>
+\subsection subsec_download Downloads
 
 Source code and binaries are available at:
 <a href="https://support.hdfgroup.org/releases/hdf5/v2_0/v2_0_0/downloads/index.html">https://support.hdfgroup.org/releases/hdf5/v2_0/v2_0_0/downloads/index.html</a>
@@ -85,7 +85,7 @@ Source code and binaries are available at:
 Please refer to [Build instructions](https://github.com/HDFGroup/hdf5/blob/hdf5_2.0/release_docs/INSTALL) for building with either CMake or Autotools.
 
 
-<h3 id="method">Methods to obtain (gz file)</h3>
+\subsection subsec_obtain_method Methods to obtain (gz file)
 
 \li firefox – Download file and then run:  `gzip <distribution>.tar.gz | tar xzf -`
 \li chrome –  Download file and then run:  `gzip -cd <distribution>.tar.gz | tar xvf -`
@@ -95,7 +95,7 @@ Please refer to [Build instructions](https://github.com/HDFGroup/hdf5/blob/hdf5_
     `gzip -cd <distribution>.tar.gz | tar xvf -`
 </div>
 
-<h3 id="api_compat">Individual API Compatibility Reports</h3>
+\subsection subsec_api_compat_reps Individual API Compatibility Reports
 
 * [hdf5-2.0-hdf5_compat_report.html](https://support.hdfgroup.org/releases/hdf5/v2_0/v2_0_0/downloads/compat_report/hdf5-2.0-hdf5_compat_report.html) -- HTML C library ABI report file
 
@@ -106,7 +106,7 @@ Please refer to [Build instructions](https://github.com/HDFGroup/hdf5/blob/hdf5_
 * [hdf5-2.0-java_compat_report.html](https://support.hdfgroup.org/releases/hdf5/v2_0/v2_0_0/downloads/compat_report/hdf5-2.0-java_compat_report.html) -- HTML Java library ABI report file
 
 
-<h3 id="dox_gen_doc">Doxygen Generated Reference Manual</h3>
+\subsection subsec_dox_gen_doc Doxygen Generated Reference Manual
 
 The new HDF5 documentation based on [Doxygen](https://www.doxygen.nl/index.html) is available [here](https://support.hdfgroup.org/releases/hdf5/v2/index.html)
 
@@ -114,9 +114,9 @@ This documentation is WORK-IN-PROGRESS.
 
 Since this portion of the HDF5 documentation is now part of the source code, it gets the same treatment as code. In other words, issues, inaccuracies, corrections should be reported as issues in [GitHub](https://github.com/HDFGroup/hdf5/issues), and pull requests will be reviewed and accepted as any other code changes.
 
-\subsection subsec_rel_spec_20_migrate Migrating from HDF5 1.14 to HDF5 2.0
+\section sec_rel_spec_20_migrate Migrating from HDF5 1.14 to HDF5 2.0
 
-This section highlights some changes that might affect migrating to HDF5.20, please refer to the \ref subsec_rel_spec_20_change or the <a href="https://\SRCURL/release_docs/CHANGELOG.md">Change log</a> for detail.
+This section highlights some changes that might affect migrating to HDF5.20, please refer to the \ref sec_rel_spec_20_change or the <a href="https://\SRCURL/release_docs/CHANGELOG.md">Change log</a> for detail.
 
 \li Default file format is now 1.8
 \li The file format has been updated to 4.0<a name="fileformat"></a>
@@ -129,7 +129,7 @@ This section highlights some changes that might affect migrating to HDF5.20, ple
     - The tool h5dump has a new option `--lformat` and its `XML` option is deprecated.
     - The high-level GIF tools, `h52gif` and `gif2h5` have been removed. We may move them to a separate repository in the future.  See <a href="https://\SRCURL/release_docs/CHANGELOG.md">Change log</a> for an explanation.
 
-\subsection subsec_rel_spec_20_feat New Features in HDF5 Release 2.0
+\section sec_rel_spec_20_feat New Features in HDF5 Release 2.0
 
 This section includes the new features introduced in the HDF5 2.0 series:
 
@@ -153,7 +153,7 @@ This section includes the new features introduced in the HDF5 2.0 series:
 \li Default chunk cache hash table size increased to 8191
 <br>In order to reduce hash collisions and take advantage of modern memory capacity, the default hash table size for the chunk cache has been increased from 521 to 8191. This means the hash table will consume approximately 64 KiB per open dataset. This value can be changed with `H5Pset_cache()` or `H5Pset_chunk_cache()`. This value was chosen because it is a prime number close to 8K.
 
-\ref subsec_rel_spec_20_change
+\ref sec_rel_spec_20_change
 
  *
  * <hr>

--- a/doxygen/dox/hdf5_2_0.dox
+++ b/doxygen/dox/hdf5_2_0.dox
@@ -153,6 +153,7 @@ This section includes the new features introduced in the HDF5 2.0 series:
 \li Default chunk cache hash table size increased to 8191
 <br>In order to reduce hash collisions and take advantage of modern memory capacity, the default hash table size for the chunk cache has been increased from 521 to 8191. This means the hash table will consume approximately 64 KiB per open dataset. This value can be changed with `H5Pset_cache()` or `H5Pset_chunk_cache()`. This value was chosen because it is a prime number close to 8K.
 
+\ref subsec_rel_spec_20_change
 
  *
  * <hr>

--- a/doxygen/dox/hdf5_2_0.dox
+++ b/doxygen/dox/hdf5_2_0.dox
@@ -1,0 +1,178 @@
+/** \page rel_spec_20 Release Specific Information for HDF5 2.0
+ *
+ * Navigate back: \ref index "Main" / \ref release_specific_info
+ * <hr>
+
+<h2 id="library_tools_20">HDF5 Library and Tools 2.0</h2>
+
+<h3 id="release">Release Information</h3>
+
+<table>
+<tr>
+<td style="background-color:#F5F5F5">
+Version
+</td>
+<td>
+HDF5 2.0
+</td>
+</tr>
+<tr>
+<td style="background-color:#F5F5F5">
+Release Date
+</td>
+<td>
+11/10/25
+</td>
+</tr>
+<tr>
+<td style="background-color:#F5F5F5">
+Additional Release Information
+</td>
+<td>
+<a href="https://\SRCURL/release_docs/CHANGELOG.md">Change log</a>
+</td>
+</tr>
+<tr>
+<td style="background-color:#F5F5F5">
+</td>
+<td>
+\ref subsec_rel_spec_20_migrate
+</td>
+</tr>
+<tr>
+<td style="background-color:#F5F5F5">
+</td>
+<td>
+\ref sec_rel_spec_20_change
+</td>
+</tr>
+<tr>
+<td style="background-color:#F5F5F5">
+</td>
+<td>
+\ref subsec_rel_spec_20_feat
+</td>
+</tr>
+<tr>
+<td style="background-color:#F5F5F5">
+</td>
+<td>
+[Newsletter Announcement](https://www.hdfgroup.org/2025/02/05/release-of-hdf5-2.0-newsletter-205)
+</td>
+</tr>
+<tr>
+<td style="background-color:#F5F5F5">
+</td>
+<td>
+[API Compatibility Reports between 2.0 and 1.14.6](https://github.com/HDFGroup/hdf5/releases/download/hdf5_2.0/hdf5-2.0.html.abi.reports.tar.gz)
+</td>
+</tr>
+<tr>
+<td style="background-color:#F5F5F5">
+</td>
+<td>
+[Doxygen generated Reference Manual](https://support.hdfgroup.org/documentation/hdf5/latest/
+)
+</td>
+</tr>
+</table>
+
+
+<h3 id="download">Downloads</h3>
+
+Source code and binaries are available at:
+<a href="https://support.hdfgroup.org/releases/hdf5/v2_0/v2_0_0/downloads/index.html">https://support.hdfgroup.org/releases/hdf5/v2_0/v2_0_0/downloads/index.html</a>
+
+Please refer to [Build instructions](https://github.com/HDFGroup/hdf5/blob/hdf5_2.0/release_docs/INSTALL) for building with either CMake or Autotools.
+
+
+**Methods to obtain  (gz file)**
+* firefox – Download file and then run:  `gzip <distribution>.tar.gz | tar xzf -`
+* chrome –  Download file and then run:  `gzip -cd <distribution>.tar.gz | tar xvf -`
+* `wget – wget https://github.com/HDFGroup/hdf5/releases/download/hdf5_1.N.N/<distribution>.tar.gz`
+  * `gzip -cd <distribution>.tar.gz | tar xvf -`
+
+<h3 id="api_compat">Individual API Compatibility Reports</h3>
+
+* [hdf5-2.0-hdf5_compat_report.html](https://support.hdfgroup.org/releases/hdf5/v2_0/v2_0_0/downloads/compat_report/hdf5-2.0-hdf5_compat_report.html) -- HTML C library ABI report file
+
+* [hdf5-2.0-hdf5_cpp_compat_report.html](https://support.hdfgroup.org/releases/hdf5/v2_0/v2_0_0/downloads/compat_report/hdf5-2.0-hdf5_cpp_compat_report.html) -- HTML CPP library ABI report file
+
+* [hdf5-2.0-hdf5_hl_compat_report.html](https://support.hdfgroup.org/releases/hdf5/v2_0/v2_0_0/downloads/compat_report/hdf5-2.0-hdf5_hl_compat_report.html) -- HTML HL C library ABI report file
+
+* [hdf5-2.0-java_compat_report.html](https://support.hdfgroup.org/releases/hdf5/v2_0/v2_0_0/downloads/compat_report/hdf5-2.0-java_compat_report.html) -- HTML Java library ABI report file
+
+
+<h3 id="dox_gen_doc">Doxygen Generated Reference Manual</h3>
+
+The new HDF5 documentation based on [Doxygen](https://www.doxygen.nl/index.html) is available [here](https://support.hdfgroup.org/releases/hdf5/v2/index.html)
+
+This documentation is WORK-IN-PROGRESS. 
+
+Since this portion of the HDF5 documentation is now part of the source code, it gets the same treatment as code. In other words, issues, inaccuracies, corrections should be reported as issues in [GitHub](https://github.com/HDFGroup/hdf5/issues), and pull requests will be reviewed and accepted as any other code changes.
+
+\subsection subsec_rel_spec_20_migrate Migrating from HDF5 1.14 to HDF5 2.0
+
+\li Default file format is now 1.8
+
+\li The file format has been updated to 4.0<a name="fileformat"></a>
+
+\li API signature changes
+  \li `H5Dread_chunk()`
+  \li `H5Tdecode()`
+
+Please refer to \ref sec_rel_spec_20_change or <a href="https://\SRCURL/release_docs/CHANGELOG.md">Change log</a> for detail.
+
+\li A new backend based on the [aws-c-s3 library](https://github.com/awslabs/aws-c-s3)<a name="ros3"></a> replaced the ROS3 VFD's S3 backend based on libcurl.  The ROS3 VFD now requires the `aws-c-s3` library in order to be built.  See the <a href="https://\SRCURL/release_docs/CHANGELOG.md">Change log</a> for a complete description on this feature.
+
+\li Significance in tools
+   <br>The tool h5dump has a new option --lformat and its XML option is deprecated.
+
+   <br>The high-level GIF tools, `h52gif` and `gif2h5` have been removed. We may move them to a separate repository in the future.  See <a href="https://\SRCURL/release_docs/CHANGELOG.md">Change log</a> for an explanation.
+
+\subsubsection subsubsec_rel_spec_20_migrate_api API Changes
+Sample text
+
+\subsubsection subsubsec_rel_spec_20_migrate_api_h5ireg Sample / Sample
+Sample text
+\li <strong>Old:</strong> - <code>typedef herr_t (*H5I_free_t)(void *obj);</code>
+\li <strong>New:</strong> - <code>typedef herr_t (*H5I_free_t)(void *obj, void **request);</code>
+
+
+\subsection subsec_rel_spec_20_feat New Features in HDF5 Release 2.0
+
+The new features in the HDF5 2.0 series include:
+
+\li Support for complex number datatypes<a name="complex"></a>
+
+Support for the C99 `float _Complex`, `double _Complex` and `long double _Complex` (with MSVC, `_Fcomplex`, `_Dcomplex` and `_Lcomplex`) types has been added for platforms/compilers that support them. These types have been implemented with a new datatype class, `H5T_COMPLEX`. Note that any datatypes of class H5T_COMPLEX will not be readable with previous versions of HDF5. If a file is accessed with a library version bounds "high" setting less than `H5F_LIBVER_V200`, an error will occur if the application tries to create an object with a complex number datatype. If compatibility with previous versions of HDF5 is desired, applications should instead consider adopting [one of the existing conventions](https://nc-complex.readthedocs.io/en/latest/#conventions-used-in-applications). \ref_rfc20240129<br />
+
+\li An AWS endpoint command option
+
+   The new option is `--endpoint-url`, which allows the user to set an alternate endpoint URL other than the standard "protocol://service-code.region-code.amazonaws.com". If `--endpoint-url` is not specified, the ROS3 VFD will first check the `AWS_ENDPOINT_URL_S3` and `AWS_ENDPOINT_URL` environment variables for an alternate endpoint URL before using a default one, with the region-code being supplied by the FAPL or standard AWS locations/environment variables.
+
+   This option is supported by the following tools:
+      `h5dump`, `h5ls`, `h5stat`
+
+\li Specifying ROS3 VFD on the command line is not required when using S3 URI
+
+   This feature applies to the following tools: `h5dump`, `h5ls`, `h5stat`.
+
+\li Performance improvement in opening a virtual dataset with many mappings
+
+   When opening a virtual dataset, the library would previously decode the mappings in the object header package, then copy them to the dataset struct, then copy them to the internal dataset creation property list. Copying the VDS mappings could be very expensive if there were many mappings. Changed this to delay decoding the mappings until the dataset code, and delay copying the layout to the DCPL until it is needed. This results in only the decoding and no copies in most use cases, as opposed to the decoding and two copies with the previous code.
+
+\li Support for chunks larger than 4 GiB using 64 bit addressing.
+
+\li New predefined datatypes for FP8 data in E4M3 and E5M2 formats (https://arxiv.org/abs/2209.05433), but not a native FP8 datatype.  Please refer to the <a href="https://\SRCURL/release_docs/CHANGELOG.md">CHANGELOG</a> for detail.
+
+\li Default chunk cache hash table size increased to 8191
+
+In order to reduce hash collisions and take advantage of modern memory capacity, the default hash table size for the chunk cache has been increased from 521 to 8191. This means the hash table will consume approximately 64 KiB per open dataset. This value can be changed with `H5Pset_cache()` or `H5Pset_chunk_cache()`. This value was chosen because it is a prime number close to 8K.
+
+
+ *
+ * <hr>
+ * Navigate back: \ref index "Main" / \ref release_specific_info
+ *
+*/

--- a/doxygen/dox/hdf5_2_0.dox
+++ b/doxygen/dox/hdf5_2_0.dox
@@ -71,8 +71,7 @@ Additional Release Information
 <td style="background-color:#F5F5F5">
 </td>
 <td>
-[Doxygen generated Reference Manual](https://support.hdfgroup.org/documentation/hdf5/latest/
-)
+[Doxygen generated Reference Manual](https://support.hdfgroup.org/documentation/hdf5/latest/)
 </td>
 </tr>
 </table>
@@ -129,14 +128,6 @@ Please refer to \ref sec_rel_spec_20_change or <a href="https://\SRCURL/release_
    <br>The tool h5dump has a new option --lformat and its XML option is deprecated.
 
    <br>The high-level GIF tools, `h52gif` and `gif2h5` have been removed. We may move them to a separate repository in the future.  See <a href="https://\SRCURL/release_docs/CHANGELOG.md">Change log</a> for an explanation.
-
-\subsubsection subsubsec_rel_spec_20_migrate_api API Changes
-Sample text
-
-\subsubsection subsubsec_rel_spec_20_migrate_api_h5ireg Sample / Sample
-Sample text
-\li <strong>Old:</strong> - <code>typedef herr_t (*H5I_free_t)(void *obj);</code>
-\li <strong>New:</strong> - <code>typedef herr_t (*H5I_free_t)(void *obj, void **request);</code>
 
 
 \subsection subsec_rel_spec_20_feat New Features in HDF5 Release 2.0

--- a/doxygen/dox/release_specific_info.dox
+++ b/doxygen/dox/release_specific_info.dox
@@ -4,9 +4,9 @@
  * <hr>
 
 \ref rel_spec_20
-\li \ref subsec_rel_spec_20_feat
+\li \ref sec_rel_spec_20_feat
 \li \ref sec_rel_spec_20_change
-\li \ref subsec_rel_spec_20_migrate
+\li \ref sec_rel_spec_20_migrate
 
 \ref rel_spec_114
 \li \ref sec_rel_spec_114_feat

--- a/doxygen/dox/release_specific_info.dox
+++ b/doxygen/dox/release_specific_info.dox
@@ -3,6 +3,11 @@
  * Navigate back: \ref index "Main"
  * <hr>
 
+\ref rel_spec_20
+\li \ref subsec_rel_spec_20_feat
+\li \ref subsec_rel_spec_20_change
+\li \ref subsec_rel_spec_20_migrate
+
 \ref rel_spec_114
 \li \ref sec_rel_spec_114_feat
 \li \ref sec_rel_spec_114_change

--- a/doxygen/dox/release_specific_info.dox
+++ b/doxygen/dox/release_specific_info.dox
@@ -5,7 +5,7 @@
 
 \ref rel_spec_20
 \li \ref subsec_rel_spec_20_feat
-\li \ref subsec_rel_spec_20_change
+\li \ref sec_rel_spec_20_change
 \li \ref subsec_rel_spec_20_migrate
 
 \ref rel_spec_114

--- a/doxygen/dox/sw_changes_2.0.dox
+++ b/doxygen/dox/sw_changes_2.0.dox
@@ -14,7 +14,7 @@ be aware of between successive releases of HDF5, such as:
 
 \subsubsection subsubsec_rel_spec_20_change_compat API Compatibility
 See \ref api-compat-macros for details on using HDF5 version 2.0 with previous releases.
-\li <a href="https://\RELURL/v2_0/v2_0_0/downloads/compat_report/hdf5-2.0.1.html.abi.reports.tar.gz">Compatibility reports for Release 2.0 versus Release 1.14.6</a>]
+\li <a href="https://\RELURL/v2_0/v2_0_0/downloads/compat_report/hdf5-2.0.1.html.abi.reports.tar.gz">Compatibility reports for Release 2.0 versus Release 1.14.6</a>
 
 \subsubsection subsubsec_rel_spec_20_bw_releases Differences between releases
 \li \ref subsubsec_rel_spec_20_change_0versus14_6
@@ -25,7 +25,7 @@ the HDF5 source code tree in the release_docs directory.
 
 \subsubsection subsubsec_rel_spec_20_change_0versus14_6 Release 2.0 versus Release 1.14.6
 
-HDF5 version 2.0 provides a number of new C APIs and other user-visible changes in behavior in the transition from HDF5 Release 1.14.6 to Release 2.0.  Some of those require the use of the API Compatibility Macros for the main library. In addtion, some APIs have been removed or have had their signature change.
+HDF5 version 2.0 provides a number of new C APIs and other user-visible changes in behavior in the transition from HDF5 Release 1.14.6 to Release 2.0.  Some of those require the use of the API Compatibility Macros for the main library. In addition, some APIs have been removed or have had their signature change.
 
 \li <a href="https://\RELURL/v2_0/v2_0_0/downloads/compat_report/hdf5-2.0-vs-hdf5-1.14.6-interface_compatibility_report.html">API Compatibility report for Release 2.0 versus Release 1.14.6</a>
 

--- a/doxygen/dox/sw_changes_2.0.dox
+++ b/doxygen/dox/sw_changes_2.0.dox
@@ -280,7 +280,7 @@ Identifier for the native VOL connector
 </tr>
 <tr>
 <td style="background-color:#F5F5F5">
-#H5VL_PASSTHRU
+H5VL_PASSTHRU
 </td>
 <td>
 Identifier for the pass-through VOL connector

--- a/doxygen/dox/sw_changes_2.0.dox
+++ b/doxygen/dox/sw_changes_2.0.dox
@@ -27,60 +27,57 @@ the HDF5 source code tree in the release_docs directory.
 
 HDF5 version 2.0 provides a number of new C APIs and other user-visible changes in behavior in the transition from HDF5 Release 1.14.6 to Release 2.0.  Some of those require the use of the API Compatibility Macros for the main library. In addition, some APIs have been removed or have had their signature change.
 
-\li <a href="https://\RELURL/v2_0/v2_0_0/downloads/compat_report/hdf5-2.0-vs-hdf5-1.14.6-interface_compatibility_report.html">API Compatibility report for Release 2.0 versus Release 1.14.6</a>
+\li `hbool_t` has been removed from public API calls
+<br>The `hbool_t` type was introduced before the library supported C99's Boolean type. Originally typedef'd to an integer, it has been typedef'd to C99's bool for many years.  Prior to HDF5 2.0, it had been purged from the library code and only remained in public API signatures. In HDF5 2.0, it has also been removed from public API signatures.
+<br>The `hbool_t` typedef remains in H5public.h so existing code does not need to be updated.
 
-<h4 id="remove_hbool_t">`hbool_t` has been removed from public API calls</h4>
+\li Default page buffer size for the ROS3 driver changed
+<br>Calling `H5Pset_fapl_ros3` now has the side effect of setting the page buffer size in the FAPL to 64 MiB if it was not previously set. This will only have an effect if the file uses paged allocation. Also added the `H5F_PAGE_BUFFER_SIZE_DEFAULT` to allow the user to unset the page buffer size in an FAPL so it can be similarly overridden.
 
-The `hbool_t` type was introduced before the library supported C99's Boolean type. Originally typedef'd to an integer, it has been typedef'd to C99's bool for many years.  Prior to HDF5 2.0, it had been purged from the library code and only remained in public API signatures. In HDF5 2.0, it has also been removed from public API signatures.
+\li Default dataset chunk cache size increased
+<br>The default dataset chunk cache size was increased to 8 MiB (8,388,608 bytes).
 
-The `hbool_t` typedef remains in H5public.h so existing code does not need to be updated.
-
-<h4 id="page_bfsize">Default page buffer size for the ROS3 driver changed</h4>
-
-Calling `H5Pset_fapl_ros3` now has the side effect of setting the page buffer size in the FAPL to 64 MiB if it was not previously set. This will only have an effect if the file uses paged allocation. Also added the `H5F_PAGE_BUFFER_SIZE_DEFAULT` to allow the user to unset the page buffer size in an FAPL so it can be similarly overridden.
-
-<h4 id="ds_chk_cachesize">Default dataset chunk cache size increased</h4>
-
-   The default dataset chunk cache size was increased to 8 MiB (8,388,608 bytes).
-
-<h4 id="h5dread_chunk">`H5Dread_chunk` signature has changed</h4>
-
-A new parameter, `nalloc`, has been added to `H5Dread_chunk`. This parameter contains a pointer to a variable that holds the size of the buffer buf. If *nalloc is not large enough to hold the entire chunk being read, no data is read. On exit, the value of this variable is set to the buffer size needed to read the chunk.
-
-The old signature has been renamed to `H5Dread_chunk1` and is considered deprecated:
+\li `H5Dread_chunk()` signature has changed
+<br>A new parameter, `nalloc`, has been added to `H5Dread_chunk()`. This parameter contains a pointer to a variable that holds the size of the buffer buf. If *nalloc is not large enough to hold the entire chunk being read, no data is read. On exit, the value of this variable is set to the buffer size needed to read the chunk.
+The old signature has been renamed to `H5Dread_chunk1()` and is considered deprecated:
 ```c
    herr_t H5Dread_chunk1(hid_t dset_id, hid_t dxpl_id, const hsize_t *offset, uint32_t *filters, void *buf);
 ```
-
-The new signature is `H5Dread_chunk2`. All code should be updated to use this version:
+The new signature is `H5Dread_chunk2()`. All code should be updated to use this version:
 ```c
    herr_t H5Dread_chunk2(hid_t dset_id, hid_t dxpl_id, const hsize_t *offset, uint32_t *filters, void *buf, size_t *nalloc);
 ```
+`H5Dread_chunk()` will map to the new signature unless the library is explicitly configured to use an older version of the API.
 
-`H5Dread_chunk` will map to the new signature unless the library is explicitly configured to use an older version of the API.
-
-
-<h4 id="h5tdecode">`H5Tdecode` signature has changed</h4>
-
-A new parameter, `buf_size`, has been added to `H5Tdecode` to prevent walking off the end of the buffer.
-
-The old signature has been renamed to `H5Tdecode1` and is considered deprecated:
+\li `H5Tdecode()` signature has changed
+<br>A new parameter, `buf_size`, has been added to `H5Tdecode()` to prevent walking off the end of the buffer.
+The old signature has been renamed to `H5Tdecode1()` and is considered deprecated:
 ```c
    herr_t H5Tdecode1(const void *buf);
 ```
-
-The new signature is `H5Tdecode2`. All code should be updated to use this version:
+The new signature is `H5Tdecode2()`. All code should be updated to use this version:
 ```c
    herr_t H5Tdecode2(const void *buf, size_t buf_size);
 ```
+`H5Tdecode()` will map to the new signature unless the library is explicitly configured to use an older version of the API.
 
-`H5Tdecode` will map to the new signature unless the library is explicitly configured to use an older version of the API.
 
+\li `H5Iregister_type()` signature has changed
+<br>The hash_size parameter has not been used since early versions of HDF5 1.8, so it has been removed and the API call has been versioned.
+The old signature has been renamed to `H5Iregister_type1()` and is considered deprecated:
+```c
+   H5I_type_t H5Iregister_type1(size_t hash_size, unsigned reserved, H5I_free_t free_func);
+```
+The new signature is H5Iregister_type2(). New code should use this version:
+```c
+   H5I_type_t H5Iregister_type2(unsigned reserved, H5I_free_t free_func);
+```
+`H5Iregister_type()` will map to the new signature unless the library is explicitly configured to use an older version of the API.
 
 List of new public APIs/Macros
 
 <table>
-<tr><th>Function/Constant</th><th>Description</th></tr>
+<tr><th>This Function/Constant</th><th>Description</th></tr>
 <tr>
 <td style="background-color:#F5F5F5">
 H5Dread_chunk1

--- a/doxygen/dox/sw_changes_2.0.dox
+++ b/doxygen/dox/sw_changes_2.0.dox
@@ -27,12 +27,12 @@ the HDF5 source code tree in the release_docs directory.
 
 HDF5 version 2.0 provides a number of new C APIs and other user-visible changes in behavior in the transition from HDF5 Release 1.14.6 to Release 2.0.  Some of those require the use of the API Compatibility Macros for the main library. In addition, some APIs have been removed or have had their signature change.
 
-\li `hbool_t` has been removed from public API calls
-<br>The `hbool_t` type was introduced before the library supported C99's Boolean type. Originally typedef'd to an integer, it has been typedef'd to C99's bool for many years.  Prior to HDF5 2.0, it had been purged from the library code and only remained in public API signatures. In HDF5 2.0, it has also been removed from public API signatures.
-<br>The `hbool_t` typedef remains in H5public.h so existing code does not need to be updated.
+\li `#hbool_t` has been removed from public API calls
+<br>The `#hbool_t` type was introduced before the library supported C99's Boolean type. Originally typedef'd to an integer, it has been typedef'd to C99's bool for many years.  Prior to HDF5 2.0, it had been purged from the library code and only remained in public API signatures. In HDF5 2.0, it has also been removed from public API signatures.
+<br>The `#hbool_t` typedef remains in H5public.h so existing code does not need to be updated.
 
 \li Default page buffer size for the ROS3 driver changed
-<br>Calling `H5Pset_fapl_ros3` now has the side effect of setting the page buffer size in the FAPL to 64 MiB if it was not previously set. This will only have an effect if the file uses paged allocation. Also added the `H5F_PAGE_BUFFER_SIZE_DEFAULT` to allow the user to unset the page buffer size in an FAPL so it can be similarly overridden.
+<br>Calling `H5Pset_fapl_ros3()` now has the side effect of setting the page buffer size in the FAPL to 64 MiB if it was not previously set. This will only have an effect if the file uses paged allocation. Also added the `#H5F_PAGE_BUFFER_SIZE_DEFAULT` to allow the user to unset the page buffer size in an FAPL so it can be similarly overridden.
 
 \li Default dataset chunk cache size increased
 <br>The default dataset chunk cache size was increased to 8 MiB (8,388,608 bytes).
@@ -80,184 +80,210 @@ List of new public APIs/Macros
 <tr><th>This Function/Constant</th><th>Description</th></tr>
 <tr>
 <td style="background-color:#F5F5F5">
-H5Dread_chunk1
+H5Dread_chunk1()
 </td>
 <td>
+Reads an entire chunk from the file directly (Deprecated in favor of `H5Dread_chunk2()`)
 </td>
 </tr>
 <tr>
 <td style="background-color:#F5F5F5">
-H5Dread_chunk2
+H5Dread_chunk2()
 </td>
 <td>
+Reads an entire chunk from the file directly
 </td>
 </tr>
 <tr>
 <td style="background-color:#F5F5F5">
-H5Iregister_type1
+H5Iregister_type1()
 </td>
 <td>
+Creates a new type of ID ((Deprecated in favor of `H5Iregister_type2)()`
 </td>
 </tr>
 <tr>
 <td style="background-color:#F5F5F5">
-H5Iregister_type2
+H5Iregister_type2()
 </td>
 <td>
+Creates a new type of ID
 </td>
 </tr>
 <tr>
 <td style="background-color:#F5F5F5">
-H5Pget_virtual_spatial_tree
+H5Pget_virtual_spatial_tree()
 </td>
 <td>
+Retrieves the setting for whether or not to use a spatial tree for VDS mappings
 </td>
 </tr>
 <tr>
 <td style="background-color:#F5F5F5">
-H5Pset_virtual_spatial_tree
+H5Pset_virtual_spatial_tree()
 </td>
 <td>
+Sets the flag to use a spatial tree for mappings
 </td>
 </tr>
 <tr>
 <td style="background-color:#F5F5F5">
-H5Tcomplex_create
+H5Tcomplex_create()
 </td>
 <td>
+Creates a new complex number datatype
 </td>
 </tr>
 <tr>
 <td style="background-color:#F5F5F5">
-H5Tdecode1
+H5Tdecode1()
 </td>
 <td>
+Decodes a binary object description ()
 </td>
 </tr>
 <tr>
 <td style="background-color:#F5F5F5">
-H5Tdecode2
+H5Tdecode2()
 </td>
 <td>
+Decodes a binary object description
 </td>
 </tr>
 <tr>
 <td style="background-color:#F5F5F5">
-H5VLclose_lib_context
+H5VLclose_lib_context()
 </td>
 <td>
+Closes the state of the library, undoing the effects of `H5VLopen_lib_context()`
 </td>
 </tr>
 <tr>
 <td style="background-color:#F5F5F5">
-H5VLopen_lib_context
+H5VLopen_lib_context()
 </td>
 <td>
+Opens a new internal context for the HDF5 library
 </td>
 </tr>
 <tr>
 <td style="background-color:#F5F5F5">
-H5T_COMPLEX_IEEE_F16BE
+#H5T_COMPLEX_IEEE_F16BE
 </td>
 <td>
+Complex number of 2 16-bit big-endian IEEE floating point numbers
 </td>
 </tr>
 <tr>
 <td style="background-color:#F5F5F5">
-H5T_COMPLEX_IEEE_F16LE
+#H5T_COMPLEX_IEEE_F16LE
 </td>
 <td>
+Complex number of 2 16-bit little-endian IEEE floating point numbers
 </td>
 </tr>
 <tr>
 <td style="background-color:#F5F5F5">
-H5T_COMPLEX_IEEE_F32BE
+#H5T_COMPLEX_IEEE_F32BE
 </td>
 <td>
+Complex number of 2 32-bit big-endian IEEE floating point numbers
 </td>
 </tr>
 <tr>
 <td style="background-color:#F5F5F5">
-H5T_COMPLEX_IEEE_F32LE
+#H5T_COMPLEX_IEEE_F32LE
 </td>
 <td>
+Complex number of 2 32-bit little-endian IEEE floating point numbers
 </td>
 </tr>
 <tr>
 <td style="background-color:#F5F5F5">
-H5T_COMPLEX_IEEE_F64BE
+#H5T_COMPLEX_IEEE_F64BE
 </td>
 <td>
+Complex number of 2 64-bit big-endian IEEE floating point numbers
 </td>
 </tr>
 <tr>
 <td style="background-color:#F5F5F5">
-H5T_COMPLEX_IEEE_F64LE
+#H5T_COMPLEX_IEEE_F64LE
 </td>
 <td>
+Complex number of 2 64-bit little-endian IEEE floating point numbers
 </td>
 </tr>
 <tr>
 <td style="background-color:#F5F5F5">
-H5T_FLOAT_BFLOAT16BE
+#H5T_FLOAT_BFLOAT16BE
 </td>
 <td>
+16-bit big-endian bfloat16 floating point
 </td>
 </tr>
 <tr>
 <td style="background-color:#F5F5F5">
-H5T_FLOAT_BFLOAT16LE
+#H5T_FLOAT_BFLOAT16LE
 </td>
 <td>
+16-bit little-endian bfloat16 floating point
 </td>
 </tr>
 <tr>
 <td style="background-color:#F5F5F5">
-H5T_FLOAT_F8E4M3
+#H5T_FLOAT_F8E4M3
 </td>
 <td>
+8-bit FP8 E4M3 (4 exponent bits, 3 mantissa bits) floating point
 </td>
 </tr>
 <tr>
 <td style="background-color:#F5F5F5">
-H5T_FLOAT_F8E5M2
+#H5T_FLOAT_F8E5M2
 </td>
 <td>
+8-bit FP8 E5M2 (5 exponent bits, 2 mantissa bits) floating point
 </td>
 </tr>
 <tr>
 <td style="background-color:#F5F5F5">
-H5T_NATIVE_DOUBLE_COMPLEX
+#H5T_NATIVE_DOUBLE_COMPLEX
 </td>
 <td>
+double _Complex (MSVC _Dcomplex)
 </td>
 </tr>
 <tr>
 <td style="background-color:#F5F5F5">
-H5T_NATIVE_FLOAT_COMPLEX
+#H5T_NATIVE_FLOAT_COMPLEX
 </td>
 <td>
+float _Complex (MSVC _Fcomplex)
 </td>
 </tr>
 <tr>
 <td style="background-color:#F5F5F5">
-H5T_NATIVE_LDOUBLE_COMPLEX
+#H5T_NATIVE_LDOUBLE_COMPLEX
 </td>
 <td>
+long double _Complex (MSVC _Lcomplex)
 </td>
 </tr>
 <tr>
 <td style="background-color:#F5F5F5">
-H5VL_NATIVE
+#H5VL_NATIVE
 </td>
 <td>
+Identifier for the native VOL connector
 </td>
 </tr>
 <tr>
 <td style="background-color:#F5F5F5">
-H5VL_PASSTHRU
+#H5VL_PASSTHRU
 </td>
 <td>
+Identifier for the pass-through VOL connector
 </td>
 </tr>
 </table>
@@ -265,61 +291,45 @@ H5VL_PASSTHRU
 List of removed public APIs
 
 <table>
-<tr><th>Function</th><th>Description</th></tr>
+<tr><th>Function</th></tr>
 <tr>
 <td style="background-color:#F5F5F5">
-H5Dread_chunk
-</td>
-<td>
+H5Dread_chunk()
 </td>
 </tr>
 <tr>
 <td style="background-color:#F5F5F5">
-H5FDperform_init
-</td>
-<td>
+H5FDperform_init()
 </td>
 </tr>
 <tr>
 <td style="background-color:#F5F5F5">
-H5Iregister_type
-</td>
-<td>
+H5Iregister_type()
 </td>
 </tr>
 <tr>
 <td style="background-color:#F5F5F5">
-H5Tdecode
-</td>
-<td>
+H5Tdecode()
 </td>
 </tr>
 <tr>
 <td style="background-color:#F5F5F5">
-H5VLpeek_connector_id_by_name
-</td>
-<td>
+H5VLpeek_connector_id_by_name()
 </td>
 </tr>
 <tr>
 <td style="background-color:#F5F5F5">
-H5VLpeek_connector_id_by_value
-</td>
-<td>
+H5VLpeek_connector_id_by_value()
 </td>
 </tr>
 <tr>
 <td style="background-color:#F5F5F5">
-H5VLfinish_lib_state
-</td>
-<td>
+H5VLfinish_lib_state()
 </td>
 </tr>
 <tr>
 <td style="background-color:#F5F5F5">
-H5VLstart_lib_state
-</td>
-<td>
+H5VLstart_lib_state()
 </td>
 </tr>
 </table>

--- a/doxygen/dox/sw_changes_2.0.dox
+++ b/doxygen/dox/sw_changes_2.0.dox
@@ -1,0 +1,334 @@
+/** \page rel_spec_20_change Release Software Changes for HDF5 2.0
+ *
+ * Navigate back: \ref index "Main" / \ref release_specific_info / \ref rel_spec_20
+ * <hr>
+
+\subsection subsec_rel_spec_20_change Software Changes from Release to Release in HDF5 2.0
+
+This page provides information on the changes that a maintenance developer needs to
+be aware of between successive releases of HDF5, such as:
+\li New or changed features or tools
+\li Syntax and behavioral changes in the existing application programming interface (the API)
+\li Certain types of changes in configuration or build processes
+\li Note that bug fixes and performance enhancements in the C library are automatically picked up by the C++, Fortran, and Java libraries.
+
+\subsubsection subsubsec_rel_spec_20_change_compat API Compatibility
+See \ref api-compat-macros for details on using HDF5 version 2.0 with previous releases.
+\li <a href="https://\RELURL/v2_0/v2_0_0/downloads/compat_report/hdf5-2.0.1.html.abi.reports.tar.gz">Compatibility reports for Release 2.0 versus Release 1.14.6</a>]
+
+\subsubsection subsubsec_rel_spec_20_bw_releases Differences between releases
+\li \ref subsubsec_rel_spec_20_change_0versus14_6
+
+The <a href="https://\SRCURL/release_docs/CHANGELOG.md">Change log</a> (a.k.a. the RELEASE.txt prior to release 2.0) also lists changes made to the library, but these notes tend to be more at a more detail-oriented level. It include new features, bugs fixed, supported configuration features, platforms on which the library has been tested, and known problems.
+The change log files are listed in each release section and can be found at the top level of
+the HDF5 source code tree in the release_docs directory.
+
+\subsubsection subsubsec_rel_spec_20_change_0versus14_6 Release 2.0 versus Release 1.14.6
+
+HDF5 version 2.0 provides a number of new C APIs and other user-visible changes in behavior in the transition from HDF5 Release 1.14.6 to Release 2.0.  Some of those require the use of the API Compatibility Macros for the main library. In addtion, some APIs have been removed or have had their signature change.
+
+\li <a href="https://\RELURL/v2_0/v2_0_0/downloads/compat_report/hdf5-2.0-vs-hdf5-1.14.6-interface_compatibility_report.html">API Compatibility report for Release 2.0 versus Release 1.14.6</a>
+
+<h4 id="remove_hbool_t">`hbool_t` has been removed from public API calls</h4>
+
+The `hbool_t` type was introduced before the library supported C99's Boolean type. Originally typedef'd to an integer, it has been typedef'd to C99's bool for many years.  Prior to HDF5 2.0, it had been purged from the library code and only remained in public API signatures. In HDF5 2.0, it has also been removed from public API signatures.
+
+The `hbool_t` typedef remains in H5public.h so existing code does not need to be updated.
+
+<h4 id="page_bfsize">Default page buffer size for the ROS3 driver changed</h4>
+
+Calling `H5Pset_fapl_ros3` now has the side effect of setting the page buffer size in the FAPL to 64 MiB if it was not previously set. This will only have an effect if the file uses paged allocation. Also added the `H5F_PAGE_BUFFER_SIZE_DEFAULT` to allow the user to unset the page buffer size in an FAPL so it can be similarly overridden.
+
+<h4 id="ds_chk_cachesize">Default dataset chunk cache size increased</h4>
+
+   The default dataset chunk cache size was increased to 8 MiB (8,388,608 bytes).
+
+<h4 id="h5dread_chunk">`H5Dread_chunk` signature has changed</h4>
+
+A new parameter, `nalloc`, has been added to `H5Dread_chunk`. This parameter contains a pointer to a variable that holds the size of the buffer buf. If *nalloc is not large enough to hold the entire chunk being read, no data is read. On exit, the value of this variable is set to the buffer size needed to read the chunk.
+
+The old signature has been renamed to `H5Dread_chunk1` and is considered deprecated:
+```c
+   herr_t H5Dread_chunk1(hid_t dset_id, hid_t dxpl_id, const hsize_t *offset, uint32_t *filters, void *buf);
+```
+
+The new signature is `H5Dread_chunk2`. All code should be updated to use this version:
+```c
+   herr_t H5Dread_chunk2(hid_t dset_id, hid_t dxpl_id, const hsize_t *offset, uint32_t *filters, void *buf, size_t *nalloc);
+```
+
+`H5Dread_chunk` will map to the new signature unless the library is explicitly configured to use an older version of the API.
+
+
+<h4 id="h5tdecode">`H5Tdecode` signature has changed</h4>
+
+A new parameter, `buf_size`, has been added to `H5Tdecode` to prevent walking off the end of the buffer.
+
+The old signature has been renamed to `H5Tdecode1` and is considered deprecated:
+```c
+   herr_t H5Tdecode1(const void *buf);
+```
+
+The new signature is `H5Tdecode2`. All code should be updated to use this version:
+```c
+   herr_t H5Tdecode2(const void *buf, size_t buf_size);
+```
+
+`H5Tdecode` will map to the new signature unless the library is explicitly configured to use an older version of the API.
+
+
+List of new public APIs/Macros
+
+<table>
+<tr><th>Function/Constant</th><th>Description</th></tr>
+<tr>
+<td style="background-color:#F5F5F5">
+H5Dread_chunk1
+</td>
+<td>
+</td>
+</tr>
+<tr>
+<td style="background-color:#F5F5F5">
+H5Dread_chunk2
+</td>
+<td>
+</td>
+</tr>
+<tr>
+<td style="background-color:#F5F5F5">
+H5Iregister_type1
+</td>
+<td>
+</td>
+</tr>
+<tr>
+<td style="background-color:#F5F5F5">
+H5Iregister_type2
+</td>
+<td>
+</td>
+</tr>
+<tr>
+<td style="background-color:#F5F5F5">
+H5Pget_virtual_spatial_tree
+</td>
+<td>
+</td>
+</tr>
+<tr>
+<td style="background-color:#F5F5F5">
+H5Pset_virtual_spatial_tree
+</td>
+<td>
+</td>
+</tr>
+<tr>
+<td style="background-color:#F5F5F5">
+H5Tcomplex_create
+</td>
+<td>
+</td>
+</tr>
+<tr>
+<td style="background-color:#F5F5F5">
+H5Tdecode1
+</td>
+<td>
+</td>
+</tr>
+<tr>
+<td style="background-color:#F5F5F5">
+H5Tdecode2
+</td>
+<td>
+</td>
+</tr>
+<tr>
+<td style="background-color:#F5F5F5">
+H5VLclose_lib_context
+</td>
+<td>
+</td>
+</tr>
+<tr>
+<td style="background-color:#F5F5F5">
+H5VLopen_lib_context
+</td>
+<td>
+</td>
+</tr>
+<tr>
+<td style="background-color:#F5F5F5">
+H5T_COMPLEX_IEEE_F16BE
+</td>
+<td>
+</td>
+</tr>
+<tr>
+<td style="background-color:#F5F5F5">
+H5T_COMPLEX_IEEE_F16LE
+</td>
+<td>
+</td>
+</tr>
+<tr>
+<td style="background-color:#F5F5F5">
+H5T_COMPLEX_IEEE_F32BE
+</td>
+<td>
+</td>
+</tr>
+<tr>
+<td style="background-color:#F5F5F5">
+H5T_COMPLEX_IEEE_F32LE
+</td>
+<td>
+</td>
+</tr>
+<tr>
+<td style="background-color:#F5F5F5">
+H5T_COMPLEX_IEEE_F64BE
+</td>
+<td>
+</td>
+</tr>
+<tr>
+<td style="background-color:#F5F5F5">
+H5T_COMPLEX_IEEE_F64LE
+</td>
+<td>
+</td>
+</tr>
+<tr>
+<td style="background-color:#F5F5F5">
+H5T_FLOAT_BFLOAT16BE
+</td>
+<td>
+</td>
+</tr>
+<tr>
+<td style="background-color:#F5F5F5">
+H5T_FLOAT_BFLOAT16LE
+</td>
+<td>
+</td>
+</tr>
+<tr>
+<td style="background-color:#F5F5F5">
+H5T_FLOAT_F8E4M3
+</td>
+<td>
+</td>
+</tr>
+<tr>
+<td style="background-color:#F5F5F5">
+H5T_FLOAT_F8E5M2
+</td>
+<td>
+</td>
+</tr>
+<tr>
+<td style="background-color:#F5F5F5">
+H5T_NATIVE_DOUBLE_COMPLEX
+</td>
+<td>
+</td>
+</tr>
+<tr>
+<td style="background-color:#F5F5F5">
+H5T_NATIVE_FLOAT_COMPLEX
+</td>
+<td>
+</td>
+</tr>
+<tr>
+<td style="background-color:#F5F5F5">
+H5T_NATIVE_LDOUBLE_COMPLEX
+</td>
+<td>
+</td>
+</tr>
+<tr>
+<td style="background-color:#F5F5F5">
+H5VL_NATIVE
+</td>
+<td>
+</td>
+</tr>
+<tr>
+<td style="background-color:#F5F5F5">
+H5VL_PASSTHRU
+</td>
+<td>
+</td>
+</tr>
+</table>
+
+List of removed public APIs
+
+<table>
+<tr><th>Function</th><th>Description</th></tr>
+<tr>
+<td style="background-color:#F5F5F5">
+H5Dread_chunk
+</td>
+<td>
+</td>
+</tr>
+<tr>
+<td style="background-color:#F5F5F5">
+H5FDperform_init
+</td>
+<td>
+</td>
+</tr>
+<tr>
+<td style="background-color:#F5F5F5">
+H5Iregister_type
+</td>
+<td>
+</td>
+</tr>
+<tr>
+<td style="background-color:#F5F5F5">
+H5Tdecode
+</td>
+<td>
+</td>
+</tr>
+<tr>
+<td style="background-color:#F5F5F5">
+H5VLpeek_connector_id_by_name
+</td>
+<td>
+</td>
+</tr>
+<tr>
+<td style="background-color:#F5F5F5">
+H5VLpeek_connector_id_by_value
+</td>
+<td>
+</td>
+</tr>
+<tr>
+<td style="background-color:#F5F5F5">
+H5VLfinish_lib_state
+</td>
+<td>
+</td>
+</tr>
+<tr>
+<td style="background-color:#F5F5F5">
+H5VLstart_lib_state
+</td>
+<td>
+</td>
+</tr>
+</table>
+
+
+ *
+ * <hr>
+ * Navigate back: \ref index "Main" / \ref release_specific_info / \ref rel_spec_20
+*/

--- a/doxygen/dox/sw_changes_2.0.dox
+++ b/doxygen/dox/sw_changes_2.0.dox
@@ -3,7 +3,7 @@
  * Navigate back: \ref index "Main" / \ref release_specific_info / \ref rel_spec_20
  * <hr>
 
-\subsection subsec_rel_spec_20_change Software Changes from Release to Release in HDF5 2.0
+\subsection sec_rel_spec_20_change Software Changes from Release to Release in HDF5 2.0
 
 This page provides information on the changes that a maintenance developer needs to
 be aware of between successive releases of HDF5, such as:

--- a/doxygen/dox/sw_changes_2.0.dox
+++ b/doxygen/dox/sw_changes_2.0.dox
@@ -1,9 +1,9 @@
-/** \page rel_spec_20_change Release Software Changes for HDF5 2.0
+/** \page rel_spec_20_change Release Specific Information for HDF5 2.0
  *
  * Navigate back: \ref index "Main" / \ref release_specific_info / \ref rel_spec_20
  * <hr>
 
-\subsection sec_rel_spec_20_change Software Changes from Release to Release in HDF5 2.0
+\section sec_rel_spec_20_change Software Changes from Release to Release in HDF5 2.0
 
 This page provides information on the changes that a maintenance developer needs to
 be aware of between successive releases of HDF5, such as:
@@ -12,11 +12,11 @@ be aware of between successive releases of HDF5, such as:
 \li Certain types of changes in configuration or build processes
 \li Note that bug fixes and performance enhancements in the C library are automatically picked up by the C++, Fortran, and Java libraries.
 
-\subsubsection subsubsec_rel_spec_20_change_compat API Compatibility
+\subsection subsec_rel_spec_20_change_compat API Compatibility
 See \ref api-compat-macros for details on using HDF5 version 2.0 with previous releases.
 \li <a href="https://\RELURL/v2_0/v2_0_0/downloads/compat_report/hdf5-2.0.1.html.abi.reports.tar.gz">Compatibility reports for Release 2.0 versus Release 1.14.6</a>
 
-\subsubsection subsubsec_rel_spec_20_bw_releases Differences between releases
+\subsection subsec_rel_spec_20_bw_releases Differences between releases
 \li \ref subsubsec_rel_spec_20_change_0versus14_6
 
 The <a href="https://\SRCURL/release_docs/CHANGELOG.md">Change log</a> (a.k.a. the RELEASE.txt prior to release 2.0) also lists changes made to the library, but these notes tend to be more at a more detail-oriented level. It include new features, bugs fixed, supported configuration features, platforms on which the library has been tested, and known problems.
@@ -37,7 +37,7 @@ HDF5 version 2.0 provides a number of new C APIs and other user-visible changes 
 \li Default dataset chunk cache size increased
 <br>The default dataset chunk cache size was increased to 8 MiB (8,388,608 bytes).
 
-\li `H5Dread_chunk()` signature has changed
+\li H5Dread_chunk() signature has changed
 <br>A new parameter, `nalloc`, has been added to `H5Dread_chunk()`. This parameter contains a pointer to a variable that holds the size of the buffer buf. If *nalloc is not large enough to hold the entire chunk being read, no data is read. On exit, the value of this variable is set to the buffer size needed to read the chunk.
 The old signature has been renamed to `H5Dread_chunk1()` and is considered deprecated:
 ```c
@@ -49,7 +49,7 @@ The new signature is `H5Dread_chunk2()`. All code should be updated to use this 
 ```
 `H5Dread_chunk()` will map to the new signature unless the library is explicitly configured to use an older version of the API.
 
-\li `H5Tdecode()` signature has changed
+\li H5Tdecode() signature has changed
 <br>A new parameter, `buf_size`, has been added to `H5Tdecode()` to prevent walking off the end of the buffer.
 The old signature has been renamed to `H5Tdecode1()` and is considered deprecated:
 ```c
@@ -62,7 +62,7 @@ The new signature is `H5Tdecode2()`. All code should be updated to use this vers
 `H5Tdecode()` will map to the new signature unless the library is explicitly configured to use an older version of the API.
 
 
-\li `H5Iregister_type()` signature has changed
+\li H5Iregister_type() signature has changed
 <br>The hash_size parameter has not been used since early versions of HDF5 1.8, so it has been removed and the API call has been versioned.
 The old signature has been renamed to `H5Iregister_type1()` and is considered deprecated:
 ```c
@@ -77,7 +77,7 @@ The new signature is H5Iregister_type2(). New code should use this version:
 List of new public APIs/Macros
 
 <table>
-<tr><th>This Function/Constant</th><th>Description</th></tr>
+<tr><th>Function/Constant</th><th>Description</th></tr>
 <tr>
 <td style="background-color:#F5F5F5">
 H5Dread_chunk1()
@@ -99,7 +99,7 @@ Reads an entire chunk from the file directly
 H5Iregister_type1()
 </td>
 <td>
-Creates a new type of ID ((Deprecated in favor of `H5Iregister_type2)()`
+Creates a new type of ID (Deprecated in favor of `H5Iregister_type2()`)
 </td>
 </tr>
 <tr>
@@ -139,7 +139,7 @@ Creates a new complex number datatype
 H5Tdecode1()
 </td>
 <td>
-Decodes a binary object description ()
+Decodes a binary object description (Deprecated in favor of `H5Tdecode2()`)
 </td>
 </tr>
 <tr>


### PR DESCRIPTION
Moved HDF5 2.0 release page from the github.io repo to the HDF5 repo's documentation and added information about release 2.0 and compatibility with the previous release.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Added documentation for HDF5 2.0 release, including new features, API changes, and updated aliases for the new branch.
> 
>   - **Documentation**:
>     - Added `hdf5_2_0.dox` for HDF5 2.0 release information, including release date, changelog, and compatibility reports.
>     - Added `sw_changes_2.0.dox` detailing software changes, API compatibility, and new/removed APIs for HDF5 2.0.
>     - Updated `release_specific_info.dox` to include references to HDF5 2.0 sections.
>   - **Aliases**:
>     - Added `SRCURL20` alias in `aliases` for the HDF5 2.0 branch.
>   - **Features**:
>     - New features include support for complex number datatypes, AWS endpoint command option, and performance improvements for virtual datasets.
>   - **API Changes**:
>     - `H5Dread_chunk` and `H5Tdecode` signatures changed; old versions deprecated.
>     - `hbool_t` removed from public API calls.
>     - Default dataset chunk cache size increased to 8 MiB.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=HDFGroup%2Fhdf5&utm_source=github&utm_medium=referral)<sup> for 91ebc0786e4ddd15d0458be694dedf3d655bad31. You can [customize](https://app.ellipsis.dev/HDFGroup/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->