### PR TITLE
Add `include-what-you-use` support to CMake

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -677,6 +677,17 @@ if (HDF5_ENABLE_COVERAGE)
 endif ()
 
 #-----------------------------------------------------------------------------
+# Option to use build with include-what-you-use
+#-----------------------------------------------------------------------------
+option(HDF5_USE_IWYU "Run include-what-you-use when compiling" OFF)
+
+if(HDF5_USE_IWYU)
+    find_program(IWYU_EXE NAMES include-what-you-use REQUIRED)
+    set(CMAKE_C_INCLUDE_WHAT_YOU_USE ${IWYU_EXE})
+    set(CMAKE_CXX_INCLUDE_WHAT_YOU_USE ${IWYU_EXE})
+endif()
+
+#-----------------------------------------------------------------------------
 # Option to indicate using a memory checker
 #-----------------------------------------------------------------------------
 if (HDF5_ENABLE_USING_MEMCHECKER)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -677,7 +677,7 @@ if (HDF5_ENABLE_COVERAGE)
 endif ()
 
 #-----------------------------------------------------------------------------
-# Option to use build with include-what-you-use
+# Option to build with include-what-you-use
 #-----------------------------------------------------------------------------
 option(HDF5_USE_IWYU "Run include-what-you-use when compiling" OFF)
 

--- a/release_docs/CHANGELOG.md
+++ b/release_docs/CHANGELOG.md
@@ -83,6 +83,14 @@ We would like to thank the many HDF5 community members who contributed to HDF5 2
 
 ## Configuration
 
+### Added CMake support for include-what-you-use
+
+   Adds an `HDF5_USE_IWYU` option to CMake (default OFF). This will run the `include-what-you-use` tool while compiling.
+
+   See https://include-what-you-use.org/ for more information.
+
+   This requires `include-what-you-use` to be installed.
+
 ### Improved the cross-compile support in the build system
 
    The CMake build system has been improved to better support cross-compiling. This includes the following changes:


### PR DESCRIPTION
Adds an `HDF5_USE_IWYU` option to CMake (default OFF).
This will run the `include-what-you-use` tool while compiling.

See https://include-what-you-use.org/ for more information.

This requires `include-what-you-use` to be installed.

Addresses #6001 
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Adds `HDF5_USE_IWYU` option to CMake to run `include-what-you-use` during compilation, documented in `CHANGELOG.md`.
> 
>   - **CMake Configuration**:
>     - Adds `HDF5_USE_IWYU` option to `CMakeLists.txt` to run `include-what-you-use` during compilation (default OFF).
>     - Requires `include-what-you-use` to be installed.
>   - **Documentation**:
>     - Updates `CHANGELOG.md` to document the new `HDF5_USE_IWYU` option.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=HDFGroup%2Fhdf5&utm_source=github&utm_medium=referral)<sup> for 86382934b9b8e690f9c1f6a19ac43ad1184cd398. You can [customize](https://app.ellipsis.dev/HDFGroup/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->