### PR TITLE
Fix in H5Dio.c:

### DIFF
--- a/src/H5Dio.c
+++ b/src/H5Dio.c
@@ -934,9 +934,6 @@ H5D__write(size_t count, H5D_dset_io_info_t *dset_info)
         if (H5SC_write(H5F_SHARED_CACHE(dset_info[0].dset->oloc.file), count, dset_info) < 0)
             HGOTO_ERROR(H5E_DATASET, H5E_WRITEERROR, FAIL, "write through shared chunk cache failed");
 
-        if (orig_mem_space) {
-            orig_mem_space = NULL;
-        }
     }
 
 done:

--- a/src/H5Dio.c
+++ b/src/H5Dio.c
@@ -933,7 +933,6 @@ H5D__write(size_t count, H5D_dset_io_info_t *dset_info)
 
         if (H5SC_write(H5F_SHARED_CACHE(dset_info[0].dset->oloc.file), count, dset_info) < 0)
             HGOTO_ERROR(H5E_DATASET, H5E_WRITEERROR, FAIL, "write through shared chunk cache failed");
-
     }
 
 done:

--- a/src/H5Dstruct_chunk.c
+++ b/src/H5Dstruct_chunk.c
@@ -1387,6 +1387,9 @@ H5D__struct_chunk_lookup(H5D_t *dset, size_t count, const hsize_t *scaled[] /*in
 
             if (defined_values_size_hint[i])
                 *defined_values_size_hint[i] = filtered ? udata->unfilt_size[0] : *defined_values_size[i];
+        } else {
+
+            *addr[i] = HADDR_UNDEF;
         }
 
         _udata[i] = (void *)udata;
@@ -3201,18 +3204,22 @@ H5D__struct_chunk_gather_mem(H5D_dset_io_info_t *dset_info, H5D_io_type_info_t *
         hsize_t n;
 
         /* Combine selections */
+        /* TBD: how about other types: H5S_SEL_NONE, H5S_SEL_POINTS */
         if (chk->sel_space) {
-            if (NULL == (sel_space = H5S__combine_select(chk->sel_space, H5S_SELECT_OR, flex_fspace.vp)))
-                HGOTO_ERROR(H5E_DATASET, H5E_CANTINIT, FAIL, "unable to get dataspace");
-            if (H5S_close(chk->sel_space) < 0)
-                HGOTO_ERROR(H5E_DATASET, H5E_CANTRELEASE, FAIL, "can't release dataspace");
+            if (H5S_GET_SELECT_TYPE(chk->sel_space) != H5S_SEL_ALL) {
 
-            if (NULL == (chk->sel_space = H5S_copy(sel_space, false, true)))
-                HGOTO_ERROR(H5E_DATASET, H5E_CANTINIT, FAIL, "unable to get dataspace");
-            if (H5S_close(sel_space) < 0)
-                HGOTO_ERROR(H5E_DATASET, H5E_CANTRELEASE, FAIL, "can't release dataspace");
-        }
-        else {
+                if (NULL == (sel_space = H5S__combine_select(chk->sel_space, H5S_SELECT_OR, flex_fspace.vp)))
+                    HGOTO_ERROR(H5E_DATASET, H5E_CANTINIT, FAIL, "unable to get dataspace");
+                if (H5S_close(chk->sel_space) < 0)
+                    HGOTO_ERROR(H5E_DATASET, H5E_CANTRELEASE, FAIL, "can't release dataspace");
+
+                if (NULL == (chk->sel_space = H5S_copy(sel_space, false, true)))
+                    HGOTO_ERROR(H5E_DATASET, H5E_CANTINIT, FAIL, "unable to get dataspace");
+                if (H5S_close(sel_space) < 0)
+                    HGOTO_ERROR(H5E_DATASET, H5E_CANTRELEASE, FAIL, "can't release dataspace");
+
+            }
+        } else {
             if (NULL == (chk->sel_space = H5S_copy(file_space, false, true)))
                 HGOTO_ERROR(H5E_DATASET, H5E_CANTINIT, FAIL, "unable to get dataspace");
         }
@@ -3413,7 +3420,7 @@ H5D__struct_chunk_defined_values(H5D_t *dset, const H5S_t *selection, void *chun
 
     flex_sel.cvp = selection;
 
-    if (H5S_GET_SELECT_TYPE(selection) == H5S_ALL) {
+    if (H5S_GET_SELECT_TYPE(selection) == H5S_SEL_ALL) {
         if (NULL == (*defined_values = H5S_copy(chk->sel_space, false, true)))
             HGOTO_ERROR(H5E_DATASET, H5E_CANTINIT, FAIL, "unable to get dataspace");
     }

--- a/src/H5Dstruct_chunk.c
+++ b/src/H5Dstruct_chunk.c
@@ -1387,7 +1387,8 @@ H5D__struct_chunk_lookup(H5D_t *dset, size_t count, const hsize_t *scaled[] /*in
 
             if (defined_values_size_hint[i])
                 *defined_values_size_hint[i] = filtered ? udata->unfilt_size[0] : *defined_values_size[i];
-        } else {
+        }
+        else {
 
             *addr[i] = HADDR_UNDEF;
         }
@@ -3217,9 +3218,9 @@ H5D__struct_chunk_gather_mem(H5D_dset_io_info_t *dset_info, H5D_io_type_info_t *
                     HGOTO_ERROR(H5E_DATASET, H5E_CANTINIT, FAIL, "unable to get dataspace");
                 if (H5S_close(sel_space) < 0)
                     HGOTO_ERROR(H5E_DATASET, H5E_CANTRELEASE, FAIL, "can't release dataspace");
-
             }
-        } else {
+        }
+        else {
             if (NULL == (chk->sel_space = H5S_copy(file_space, false, true)))
                 HGOTO_ERROR(H5E_DATASET, H5E_CANTINIT, FAIL, "unable to get dataspace");
         }

--- a/src/H5SC.c
+++ b/src/H5SC.c
@@ -1528,7 +1528,6 @@ H5SC_write(H5SC_t *cache, size_t count, H5D_dset_io_info_t *dset_info)
         /* Sanity checks for the SCC callbacks for this dataset. */
         assert(dset_info[i].dset->shared->layout.sc_ops->lookup);
         assert(dset_info[i].dset->shared->layout.sc_ops->new_chunk);
-        assert(dset_info[i].dset->shared->layout.sc_ops->new_chunk);
         assert(dset_info[i].dset->shared->layout.sc_ops->gather_mem);
         assert(dset_info[i].dset->shared->layout.sc_ops->encode_in_place);
         assert(dset_info[i].dset->shared->layout.sc_ops->insert);

--- a/src/H5SC.c
+++ b/src/H5SC.c
@@ -971,15 +971,15 @@ done:
 herr_t
 H5SC_read(H5SC_t *cache, size_t count, H5D_dset_io_info_t *dset_info)
 {
-    H5SC_io_info_t sc_io_info;
-    herr_t ret_value = SUCCEED;
-    H5D_io_type_info_t my_io_type_info; /* First used in the scatter_mem callback */
-    const H5S_t *scatter_mem_space;     /* Used in the scatter_mem callback */
-    const H5S_t *scatter_file_space;    /* Used in the scatter_mem callback */
-    haddr_t md_tag = HADDR_UNDEF;
-    bool partial_bound_chunks_different_encoding = false;
-    H5O_pline_t *pline = NULL; /* I/O pipeline info */
-    hbool_t filtered = false;
+    H5SC_io_info_t     sc_io_info;
+    herr_t             ret_value = SUCCEED;
+    H5D_io_type_info_t my_io_type_info;    /* First used in the scatter_mem callback */
+    const H5S_t       *scatter_mem_space;  /* Used in the scatter_mem callback */
+    const H5S_t       *scatter_file_space; /* Used in the scatter_mem callback */
+    haddr_t            md_tag                                  = HADDR_UNDEF;
+    bool               partial_bound_chunks_different_encoding = false;
+    H5O_pline_t       *pline                                   = NULL; /* I/O pipeline info */
+    hbool_t            filtered                                = false;
     // size_t             nbytes;
     // size_t             buf_size;
     size_t alloc_size;
@@ -994,14 +994,12 @@ H5SC_read(H5SC_t *cache, size_t count, H5D_dset_io_info_t *dset_info)
      * Set up selections for the provided I/O request in the sc_io_info structure. This structure will contain
      * the per-chunk selection which is relevant to the provided I/O request.
      */
-    if (H5SC__io_info_init(cache, &sc_io_info, count, dset_info) < 0)
-    {
+    if (H5SC__io_info_init(cache, &sc_io_info, count, dset_info) < 0) {
         HGOTO_ERROR(H5E_DATASPACE, H5E_CANTINIT, FAIL, "can't initialize selections for I/O");
     }
 
     /* Loop through the datasets */
-    for (size_t i = 0; i < count; i++)
-    {
+    for (size_t i = 0; i < count; i++) {
 
         /* Sanity checks to ensure the SCC callbacks are defined for this dataset. */
         assert(dset_info[i].dset->shared->layout.sc_ops->lookup);
@@ -1018,42 +1016,40 @@ H5SC_read(H5SC_t *cache, size_t count, H5D_dset_io_info_t *dset_info)
         /* Create arrays to hold information necessary for callback operations relevant to the read operation.
          */
         const hsize_t *scaled[chunk_count];
-        haddr_t *addr[chunk_count];
-        hsize_t *size[chunk_count];
-        hsize_t *defined_values_size[chunk_count];
-        size_t *size_hint[chunk_count];
-        size_t *defined_values_size_hint[chunk_count];
-        void **udata_arr[chunk_count];
+        haddr_t       *addr[chunk_count];
+        hsize_t       *size[chunk_count];
+        hsize_t       *defined_values_size[chunk_count];
+        size_t        *size_hint[chunk_count];
+        size_t        *defined_values_size_hint[chunk_count];
+        void         **udata_arr[chunk_count];
 
         /* For each chunk in this dataset, initialize each necessary array value*/
-        for (size_t j = 0; j < chunk_count; j++)
-        {
+        for (size_t j = 0; j < chunk_count; j++) {
             /* Setup scaled for the jth chunk */
             scaled[j] = sc_io_info.sel_chunks[j].scaled;
 
             /* Setup the initial address with a unique pointer */
             haddr_t *tmp_addr = malloc(sizeof(haddr_t));
-            addr[j] = tmp_addr;
+            addr[j]           = tmp_addr;
 
             /* Setup the initial size with a unique pointer */
             hsize_t *tmp_size = malloc(sizeof(hsize_t));
-            size[j] = tmp_size;
+            size[j]           = tmp_size;
 
             hsize_t *tmp_def_val_size = malloc(sizeof(hsize_t));
-            defined_values_size[j] = tmp_def_val_size;
+            defined_values_size[j]    = tmp_def_val_size;
 
             size_t *tmp_size_hint = malloc(sizeof(size_t));
-            *tmp_size_hint = 0;
-            size_hint[j] = tmp_size_hint;
+            *tmp_size_hint        = 0;
+            size_hint[j]          = tmp_size_hint;
 
             size_t *tmp_def_val_size_hint = malloc(sizeof(size_t));
-            defined_values_size_hint[j] = tmp_def_val_size_hint;
+            defined_values_size_hint[j]   = tmp_def_val_size_hint;
         }
 
         if (dset_info[i].dset->shared->layout.sc_ops->lookup(dset_info[i].dset, chunk_count, scaled, addr,
                                                              size, defined_values_size, size_hint,
-                                                             defined_values_size_hint, &udata_arr) < 0)
-        {
+                                                             defined_values_size_hint, &udata_arr) < 0) {
             HGOTO_ERROR(H5E_DATASET, H5E_CANTGET, FAIL, "unable to lookup chunk (SCC)");
         }
 
@@ -1075,18 +1071,17 @@ H5SC_read(H5SC_t *cache, size_t count, H5D_dset_io_info_t *dset_info)
             filtered = true;
 
         /* For each chunk in this dataset: */
-        for (size_t j = 0; j < chunk_count; j++)
-        {
+        for (size_t j = 0; j < chunk_count; j++) {
             /* true: a NOT-to-be-filtered-partial-edge chunk */
             /* false : a to-be-filtered-partial-edge-chunk */
             bool partial_bound = false;
 
             // Needed for all chunks (check whether this is should be generated for each chunk or each
             // dataset)
-            my_io_type_info.tconv_buf = NULL; /* Pointer to the datatype conv buffer */
+            my_io_type_info.tconv_buf      = NULL; /* Pointer to the datatype conv buffer */
             my_io_type_info.tconv_buf_size = dset_info[i].type_info.src_type_size;
-            my_io_type_info.bkg_buf = NULL; /* Pointer to background buffer */
-            my_io_type_info.bkg_buf_size = dset_info[i].type_info.dst_type_size;
+            my_io_type_info.bkg_buf        = NULL; /* Pointer to background buffer */
+            my_io_type_info.bkg_buf_size   = dset_info[i].type_info.dst_type_size;
 
             /* Pointer to the memory space ID for the chunk (derived from sc_io_info) */
             scatter_mem_space = sc_io_info.sel_chunks[j].mem_space;
@@ -1101,28 +1096,24 @@ H5SC_read(H5SC_t *cache, size_t count, H5D_dset_io_info_t *dset_info)
              *
              * NOTE: This chunk should not be written to file by default.
              */
-            if (!H5_addr_defined(*addr[j]))
-            {
+            if (!H5_addr_defined(*addr[j])) {
                 /* Free the invalid udata created by the lookup callback. */
                 udata_arr[j] = H5MM_xfree(udata_arr[j]);
 
                 /* Create a new chunk that will then have the fill value written to it. */
                 if (dset_info[i].dset->shared->layout.sc_ops->new_chunk(
-                        dset_info[i].dset, false, size[j], size_hint[j], &chunk_arr[j], &udata_arr[j]) < 0)
-                {
+                        dset_info[i].dset, false, size[j], size_hint[j], &chunk_arr[j], &udata_arr[j]) < 0) {
                     HGOTO_ERROR(H5E_DATASET, H5E_CANTGET, FAIL, "unable to create new chunk (SCC)");
                 }
 
                 if (dset_info[i].dset->shared->layout.sc_ops->fill(
                         &dset_info[i], &my_io_type_info, sc_io_info.sel_chunks->file_space, size[j],
-                        size_hint[j], &alloc_size_total, chunk_arr[j], udata_arr[j]) < 0)
-                {
+                        size_hint[j], &alloc_size_total, chunk_arr[j], udata_arr[j]) < 0) {
                     HGOTO_ERROR(H5E_DATASET, H5E_CANTGET, FAIL, "unable to fill chunk (SCC)");
                 }
                 /* If the chunk addr is valid: */
             }
-            else
-            {
+            else {
                 /* If the chunk lookup is successful: */
                 if (filtered && partial_bound_chunks_different_encoding &&
                     H5D__chunk_is_partial_edge_chunk(dset_info[i].dset->shared->ndims,
@@ -1131,8 +1122,7 @@ H5SC_read(H5SC_t *cache, size_t count, H5D_dset_io_info_t *dset_info)
                     partial_bound = true;
 
                 /* Allocate buffer for the chunk data */
-                if (NULL == (chunk_arr[j] = H5MM_malloc(*size_hint[j])))
-                {
+                if (NULL == (chunk_arr[j] = H5MM_malloc(*size_hint[j]))) {
                     HGOTO_ERROR(H5E_RESOURCE, H5E_NOSPACE, H5_ITER_ERROR,
                                 "memory allocation failed for raw data chunk (SCC)");
                 }
@@ -1144,16 +1134,14 @@ H5SC_read(H5SC_t *cache, size_t count, H5D_dset_io_info_t *dset_info)
                  * into the intermediate format.)
                  */
                 if (H5F_block_read(dset_info[i].dset->oloc.file, H5FD_MEM_DRAW, *addr[j], *size[j],
-                                   chunk_arr[j]) < 0)
-                {
+                                   chunk_arr[j]) < 0) {
                     HGOTO_ERROR(H5E_DATASET, H5E_READERROR, FAIL, "unable to block read from file (SCC)");
                 }
 
                 // Skip for invalid addr
                 if (dset_info[i].dset->shared->layout.sc_ops->decode(dset_info[i].dset, size[j], size_hint[j],
                                                                      partial_bound, &chunk_arr[j],
-                                                                     udata_arr[j]) < 0)
-                {
+                                                                     udata_arr[j]) < 0) {
                     HGOTO_ERROR(H5E_DATASET, H5E_CANTGET, FAIL, "unable to decode chunk in place (SCC)");
                 }
             }
@@ -1161,23 +1149,20 @@ H5SC_read(H5SC_t *cache, size_t count, H5D_dset_io_info_t *dset_info)
             // Double check that the scatter_mem_space and scatter_file_space are correctly set.
             if (dset_info[i].dset->shared->layout.sc_ops->scatter_mem(&dset_info[i], &my_io_type_info,
                                                                       scatter_mem_space, scatter_file_space,
-                                                                      chunk_arr[j], udata_arr[j]) < 0)
-            {
+                                                                      chunk_arr[j], udata_arr[j]) < 0) {
                 HGOTO_ERROR(H5E_DATASET, H5E_CANTGET, FAIL, "unable to scatter mem for read chunk (SCC)");
             }
 
             /* Free the buffers via callback after scattering data to user buffer */
             if (dset_info[i].dset->shared->layout.sc_ops->evict(dset_info[i].dset, chunk_arr[j],
-                                                                udata_arr[j]) < 0)
-            {
+                                                                udata_arr[j]) < 0) {
                 HGOTO_ERROR(H5E_DATASET, H5E_CANTGET, FAIL, "unable to evict the chunk (SCC)");
             }
 
         } /* Chunk Processing Loop End */
 
         /* Free the allocated components prior to processing the next dataset */
-        for (size_t j = 0; j < chunk_count; j++)
-        {
+        for (size_t j = 0; j < chunk_count; j++) {
             free(addr[j]);
             free(size[j]);
             free(defined_values_size[j]);
@@ -1186,7 +1171,7 @@ H5SC_read(H5SC_t *cache, size_t count, H5D_dset_io_info_t *dset_info)
         }
 
         H5AC_tag(md_tag, NULL); /* Reset the metadata tag for the next dataset */
-    } /* Dataset Loop End */
+    }                           /* Dataset Loop End */
 
 done:
     /* Terminate sc_io_info */
@@ -1506,20 +1491,20 @@ done:
 herr_t
 H5SC_write(H5SC_t *cache, size_t count, H5D_dset_io_info_t *dset_info)
 {
-    H5SC_io_info_t sc_io_info;
-    herr_t ret_value = SUCCEED;
-    size_t nbytes;   /* Used in the new chunk callback */
-    size_t buf_size; /* Used in the new chunk callback */
-    size_t alloc_size;
-    size_t alloc_size_total;
-    size_t write_size;
+    H5SC_io_info_t     sc_io_info;
+    herr_t             ret_value = SUCCEED;
+    size_t             nbytes;   /* Used in the new chunk callback */
+    size_t             buf_size; /* Used in the new chunk callback */
+    size_t             alloc_size;
+    size_t             alloc_size_total;
+    size_t             write_size;
     H5D_io_type_info_t my_io_type_info; /* Used in gather_mem callback */
-    const H5S_t *gather_mem_space;
-    const H5S_t *gather_file_space;
-    haddr_t md_tag = HADDR_UNDEF;
-    bool partial_bound_chunks_different_encoding = false;
-    H5O_pline_t *pline = NULL; /* I/O pipeline info */
-    hbool_t filtered = false;
+    const H5S_t       *gather_mem_space;
+    const H5S_t       *gather_file_space;
+    haddr_t            md_tag                                  = HADDR_UNDEF;
+    bool               partial_bound_chunks_different_encoding = false;
+    H5O_pline_t       *pline                                   = NULL; /* I/O pipeline info */
+    hbool_t            filtered                                = false;
 
     FUNC_ENTER_NOAPI(FAIL)
 
@@ -1527,21 +1512,18 @@ H5SC_write(H5SC_t *cache, size_t count, H5D_dset_io_info_t *dset_info)
     assert(count == 0 || dset_info);
 
     /* Set up selections in sc_io_info */
-    if (H5SC__io_info_init(cache, &sc_io_info, count, dset_info) < 0)
-    {
+    if (H5SC__io_info_init(cache, &sc_io_info, count, dset_info) < 0) {
         HGOTO_ERROR(H5E_DATASET, H5E_CANTINIT, FAIL, "can't initialize selections for I/O");
     }
 
     /* Throw an error if no chunks were selected */
-    if (sc_io_info.num_sel_chunks == 0)
-    {
+    if (sc_io_info.num_sel_chunks == 0) {
         HDONE_ERROR(H5E_DATASET, H5E_CANTGETSIZE, FAIL,
                     "The number of selected structured chunks should be non-zero (SCC)");
     }
 
     /* Loop through the datasets */
-    for (size_t i = 0; i < count; i++)
-    {
+    for (size_t i = 0; i < count; i++) {
 
         /* Sanity checks for the SCC callbacks for this dataset. */
         assert(dset_info[i].dset->shared->layout.sc_ops->lookup);
@@ -1557,10 +1539,10 @@ H5SC_write(H5SC_t *cache, size_t count, H5D_dset_io_info_t *dset_info)
          * initialize it (passing NULL causes an error and should be avoided)
          */
 
-        my_io_type_info.tconv_buf = NULL; /* Datatype conv buffer (pointer) */
-        my_io_type_info.tconv_buf_size = dset_info[i].type_info.src_type_size;
-        my_io_type_info.bkg_buf = NULL; /* Pointer to background buffer */
-        my_io_type_info.bkg_buf_size = dset_info[i].type_info.dst_type_size;
+        my_io_type_info.tconv_buf              = NULL; /* Datatype conv buffer (pointer) */
+        my_io_type_info.tconv_buf_size         = dset_info[i].type_info.src_type_size;
+        my_io_type_info.bkg_buf                = NULL; /* Pointer to background buffer */
+        my_io_type_info.bkg_buf_size           = dset_info[i].type_info.dst_type_size;
         my_io_type_info.may_use_in_place_tconv = true; /* Use in-place if possible */
 
         /*
@@ -1578,21 +1560,20 @@ H5SC_write(H5SC_t *cache, size_t count, H5D_dset_io_info_t *dset_info)
 
         /* Create the arrays necessary for write operation. */
         const hsize_t *scaled[chunk_count];
-        haddr_t *addr[chunk_count];
-        hsize_t *size[chunk_count];
-        hsize_t old_disk_size[chunk_count];
-        hsize_t *defined_values_size[chunk_count];
-        size_t *size_hint[chunk_count];
-        size_t *defined_values_size_hint[chunk_count];
-        void *udata_arr[chunk_count];
-        hsize_t write_size_arr[chunk_count];
+        haddr_t       *addr[chunk_count];
+        hsize_t       *size[chunk_count];
+        hsize_t        old_disk_size[chunk_count];
+        hsize_t       *defined_values_size[chunk_count];
+        size_t        *size_hint[chunk_count];
+        size_t        *defined_values_size_hint[chunk_count];
+        void          *udata_arr[chunk_count];
+        hsize_t        write_size_arr[chunk_count];
 
         /*
          * Loop to initialize the components necessary for processing the I/O request through the SCC
          * callbacks.
          */
-        for (size_t j = 0; j < chunk_count; j++)
-        {
+        for (size_t j = 0; j < chunk_count; j++) {
             /* Set up scaled for the jth chunk */
             scaled[j] = sc_io_info.sel_chunks[j].scaled;
 
@@ -1600,30 +1581,29 @@ H5SC_write(H5SC_t *cache, size_t count, H5D_dset_io_info_t *dset_info)
              * dataset)
              */
             haddr_t *tmp_addr = malloc(sizeof(haddr_t));
-            *tmp_addr = HADDR_UNDEF;
-            addr[j] = tmp_addr;
+            *tmp_addr         = HADDR_UNDEF;
+            addr[j]           = tmp_addr;
 
             /*
              * Setup the size with a unique pointer (will need to be freed after looping through the
              * dataset).
              */
             hsize_t *tmp_size = malloc(sizeof(hsize_t));
-            size[j] = tmp_size;
+            size[j]           = tmp_size;
 
             hsize_t *tmp_def_val_size = malloc(sizeof(hsize_t));
-            defined_values_size[j] = tmp_def_val_size;
+            defined_values_size[j]    = tmp_def_val_size;
 
             size_t *tmp_size_hint = malloc(sizeof(size_t));
-            size_hint[j] = tmp_size_hint;
+            size_hint[j]          = tmp_size_hint;
 
             size_t *tmp_def_val_size_hint = malloc(sizeof(size_t));
-            defined_values_size_hint[j] = tmp_def_val_size_hint;
+            defined_values_size_hint[j]   = tmp_def_val_size_hint;
         }
 
         if (dset_info[i].dset->shared->layout.sc_ops->lookup(dset_info[i].dset, chunk_count, scaled, addr,
                                                              size, defined_values_size, size_hint,
-                                                             defined_values_size_hint, udata_arr) < 0)
-        {
+                                                             defined_values_size_hint, udata_arr) < 0) {
             HGOTO_ERROR(H5E_DATASET, H5E_CANTGET, FAIL, "unable to lookup chunk (SCC)");
         }
 
@@ -1644,12 +1624,10 @@ H5SC_write(H5SC_t *cache, size_t count, H5D_dset_io_info_t *dset_info)
         /* Create the array that will hold the pointers to the chunk data structure */
         void *chunk_arr[chunk_count];
 
-        for (size_t j = 0; j < chunk_count; j++)
-        {
+        for (size_t j = 0; j < chunk_count; j++) {
             bool partial_bound = false;
             /* if assert(addr[j]); free the old udata, then create a new chunk*/
-            if (!H5_addr_defined(*addr[j]))
-            {
+            if (!H5_addr_defined(*addr[j])) {
                 /* As a consequence of how the lookup callback functions, it is necessary to free the udata
                  * for each chunk not found on disk.
                  */
@@ -1660,13 +1638,11 @@ H5SC_write(H5SC_t *cache, size_t count, H5D_dset_io_info_t *dset_info)
                  */
                 // Set the size from sc_io_info struct
                 if (dset_info[i].dset->shared->layout.sc_ops->new_chunk(
-                        dset_info[i].dset, false, size[j], size_hint[j], &chunk_arr[j], &udata_arr[j]) < 0)
-                {
+                        dset_info[i].dset, false, size[j], size_hint[j], &chunk_arr[j], &udata_arr[j]) < 0) {
                     HGOTO_ERROR(H5E_DATASET, H5E_CANTGET, FAIL, "unable to create new chunk (SCC)");
                 }
             }
-            else
-            {
+            else {
                 old_disk_size[j] = *size[j];
 
                 /* If the chunk lookup is successful: */
@@ -1677,8 +1653,7 @@ H5SC_write(H5SC_t *cache, size_t count, H5D_dset_io_info_t *dset_info)
                     partial_bound = true;
 
                 /* Allocate buffer for the chunk data */
-                if (NULL == (chunk_arr[j] = H5MM_malloc(*size_hint[j])))
-                {
+                if (NULL == (chunk_arr[j] = H5MM_malloc(*size_hint[j]))) {
                     HGOTO_ERROR(H5E_RESOURCE, H5E_NOSPACE, H5_ITER_ERROR,
                                 "memory allocation failed for raw data chunk (SCC)");
                 }
@@ -1686,21 +1661,18 @@ H5SC_write(H5SC_t *cache, size_t count, H5D_dset_io_info_t *dset_info)
                 /* Read in the chunk, then decode the chunk */
 
                 if (H5F_block_read(dset_info[i].dset->oloc.file, H5FD_MEM_DRAW, *addr[j], *size[j],
-                                   chunk_arr[j]) < 0)
-                {
+                                   chunk_arr[j]) < 0) {
                     HGOTO_ERROR(H5E_DATASET, H5E_READERROR, FAIL, "unable to block read from file (SCC)");
                 }
                 if (dset_info[i].dset->shared->layout.sc_ops->decode(dset_info[i].dset, size[j], size_hint[j],
                                                                      partial_bound, &chunk_arr[j],
-                                                                     udata_arr[j]) < 0)
-                {
+                                                                     udata_arr[j]) < 0) {
                     HGOTO_ERROR(H5E_DATASET, H5E_CANTGET, FAIL, "unable to decode chunk in place (SCC)");
                 }
             }
         }
 
-        for (size_t j = 0; j < chunk_count; j++)
-        {
+        for (size_t j = 0; j < chunk_count; j++) {
 
             /* Pointer to the memory space ID, derived from sc_io_info */
             gather_mem_space = sc_io_info.sel_chunks[j].mem_space;
@@ -1713,8 +1685,7 @@ H5SC_write(H5SC_t *cache, size_t count, H5D_dset_io_info_t *dset_info)
              */
             if (dset_info[i].dset->shared->layout.sc_ops->gather_mem(
                     &dset_info[i], &my_io_type_info, gather_mem_space, gather_file_space, size[j],
-                    size_hint[j], &alloc_size_total, chunk_arr[j], udata_arr[j]) < 0)
-            {
+                    size_hint[j], &alloc_size_total, chunk_arr[j], udata_arr[j]) < 0) {
                 HGOTO_ERROR(H5E_DATASET, H5E_CANTGET, FAIL, "unable to gather mem for new chunk (SCC)");
             }
         }
@@ -1723,9 +1694,7 @@ H5SC_write(H5SC_t *cache, size_t count, H5D_dset_io_info_t *dset_info)
          * First, we encode in place (chunk becomes disk formatted chunk buffer)
          */
 
-
-        for (int j = 0; j < chunk_count; j++)
-        {
+        for (int j = 0; j < chunk_count; j++) {
             /* true: a NOT-to-be-filtered-partial-edge chunk */
             /* false : a to-be-filtered-partial-edge-chunk */
             bool partial_bound = false;
@@ -1737,8 +1706,7 @@ H5SC_write(H5SC_t *cache, size_t count, H5D_dset_io_info_t *dset_info)
                 partial_bound = true;
 
             if (dset_info[i].dset->shared->layout.sc_ops->encode_in_place(
-                    dset_info[i].dset, &write_size, partial_bound, &chunk_arr[j], udata_arr[j]) < 0)
-            {
+                    dset_info[i].dset, &write_size, partial_bound, &chunk_arr[j], udata_arr[j]) < 0) {
                 HGOTO_ERROR(H5E_DATASET, H5E_CANTGET, FAIL, "unable to encode chunk in place (SCC)");
             }
 
@@ -1748,15 +1716,14 @@ H5SC_write(H5SC_t *cache, size_t count, H5D_dset_io_info_t *dset_info)
 
         /* Insert the chunk into the chunk index within the file */
         if (dset_info[i].dset->shared->layout.sc_ops->insert(dset_info[i].dset, chunk_count, &scaled, addr,
-                                                             old_disk_size, write_size_arr, chunk_arr, udata_arr) < 0)
+                                                             old_disk_size, write_size_arr, chunk_arr,
+                                                             udata_arr) < 0)
             HGOTO_ERROR(H5E_DATASET, H5E_CANTINSERT, FAIL, "unable to insert chunk into file (SCC)");
 
-        for (size_t j = 0; j < chunk_count; j++)
-        {
+        for (size_t j = 0; j < chunk_count; j++) {
             /* Write the chunk to file using H5F_block_write */
             if (H5F_block_write(dset_info[i].dset->oloc.file, H5FD_MEM_DRAW, *addr[j], write_size_arr[j],
-                                chunk_arr[j]) < 0)
-            {
+                                chunk_arr[j]) < 0) {
                 HGOTO_ERROR(H5E_DATASET, H5E_WRITEERROR, FAIL, "unable to block write to file(SCC)");
             }
 
@@ -1770,7 +1737,7 @@ H5SC_write(H5SC_t *cache, size_t count, H5D_dset_io_info_t *dset_info)
             free(defined_values_size_hint[j]);
         }
         H5AC_tag(md_tag, NULL); /* Reset the metadata tag for the next dataset */
-    } /* End Dataset Loop */
+    }                           /* End Dataset Loop */
 done:
     /* Terminate sc_io_info */
     if (H5SC__io_info_term(&sc_io_info) < 0)

--- a/src/H5SC.c
+++ b/src/H5SC.c
@@ -1724,7 +1724,7 @@ H5SC_write(H5SC_t *cache, size_t count, H5D_dset_io_info_t *dset_info)
             /* Write the chunk to file using H5F_block_write */
             if (H5F_block_write(dset_info[i].dset->oloc.file, H5FD_MEM_DRAW, *addr[j], write_size_arr[j],
                                 chunk_arr[j]) < 0) {
-                HGOTO_ERROR(H5E_DATASET, H5E_WRITEERROR, FAIL, "unable to block write to file(SCC)");
+                HGOTO_ERROR(H5E_DATASET, H5E_WRITEERROR, FAIL, "unable to block write to file (SCC)");
             }
 
             chunk_arr[j] = H5MM_xfree(chunk_arr[j]);

--- a/src/H5SC.c
+++ b/src/H5SC.c
@@ -736,6 +736,7 @@ H5SC__io_info_term(H5SC_io_info_t *sc_io_info)
  * Return:   SUCCEED on success, FAIL on failure
  *-------------------------------------------------------------------------
  */
+#ifdef OUT
 herr_t
 H5SC_read(H5SC_t *cache, size_t count, H5D_dset_io_info_t *dset_info)
 {
@@ -966,6 +967,234 @@ done:
 
     FUNC_LEAVE_NOAPI(ret_value)
 } /* end H5SC_read() */
+#endif
+herr_t
+H5SC_read(H5SC_t *cache, size_t count, H5D_dset_io_info_t *dset_info)
+{
+    H5SC_io_info_t sc_io_info;
+    herr_t ret_value = SUCCEED;
+    H5D_io_type_info_t my_io_type_info; /* First used in the scatter_mem callback */
+    const H5S_t *scatter_mem_space;     /* Used in the scatter_mem callback */
+    const H5S_t *scatter_file_space;    /* Used in the scatter_mem callback */
+    haddr_t md_tag = HADDR_UNDEF;
+    bool partial_bound_chunks_different_encoding = false;
+    H5O_pline_t *pline = NULL; /* I/O pipeline info */
+    hbool_t filtered = false;
+    // size_t             nbytes;
+    // size_t             buf_size;
+    size_t alloc_size;
+    size_t alloc_size_total;
+
+    FUNC_ENTER_NOAPI(FAIL)
+
+    assert(cache);
+    assert(count == 0 || dset_info);
+
+    /*
+     * Set up selections for the provided I/O request in the sc_io_info structure. This structure will contain
+     * the per-chunk selection which is relevant to the provided I/O request.
+     */
+    if (H5SC__io_info_init(cache, &sc_io_info, count, dset_info) < 0)
+    {
+        HGOTO_ERROR(H5E_DATASPACE, H5E_CANTINIT, FAIL, "can't initialize selections for I/O");
+    }
+
+    /* Loop through the datasets */
+    for (size_t i = 0; i < count; i++)
+    {
+
+        /* Sanity checks to ensure the SCC callbacks are defined for this dataset. */
+        assert(dset_info[i].dset->shared->layout.sc_ops->lookup);
+        assert(dset_info[i].dset->shared->layout.sc_ops->decode);
+        assert(dset_info[i].dset->shared->layout.sc_ops->scatter_mem);
+
+        /* Set metadata tagging for this dataset */
+        H5AC_tag(dset_info[i].dset->oloc.addr, &md_tag);
+
+        size_t chunk_count = sc_io_info.num_sel_chunks;
+
+        /* Chunk lookup (in file) */
+
+        /* Create arrays to hold information necessary for callback operations relevant to the read operation.
+         */
+        const hsize_t *scaled[chunk_count];
+        haddr_t *addr[chunk_count];
+        hsize_t *size[chunk_count];
+        hsize_t *defined_values_size[chunk_count];
+        size_t *size_hint[chunk_count];
+        size_t *defined_values_size_hint[chunk_count];
+        void **udata_arr[chunk_count];
+
+        /* For each chunk in this dataset, initialize each necessary array value*/
+        for (size_t j = 0; j < chunk_count; j++)
+        {
+            /* Setup scaled for the jth chunk */
+            scaled[j] = sc_io_info.sel_chunks[j].scaled;
+
+            /* Setup the initial address with a unique pointer */
+            haddr_t *tmp_addr = malloc(sizeof(haddr_t));
+            addr[j] = tmp_addr;
+
+            /* Setup the initial size with a unique pointer */
+            hsize_t *tmp_size = malloc(sizeof(hsize_t));
+            size[j] = tmp_size;
+
+            hsize_t *tmp_def_val_size = malloc(sizeof(hsize_t));
+            defined_values_size[j] = tmp_def_val_size;
+
+            size_t *tmp_size_hint = malloc(sizeof(size_t));
+            *tmp_size_hint = 0;
+            size_hint[j] = tmp_size_hint;
+
+            size_t *tmp_def_val_size_hint = malloc(sizeof(size_t));
+            defined_values_size_hint[j] = tmp_def_val_size_hint;
+        }
+
+        if (dset_info[i].dset->shared->layout.sc_ops->lookup(dset_info[i].dset, chunk_count, scaled, addr,
+                                                             size, defined_values_size, size_hint,
+                                                             defined_values_size_hint, &udata_arr) < 0)
+        {
+            HGOTO_ERROR(H5E_DATASET, H5E_CANTGET, FAIL, "unable to lookup chunk (SCC)");
+        }
+
+        void *chunk_arr[chunk_count];
+
+        /* partial_bound_chunks_different_encoding:
+         *  When enabled, filters are not applied to partial edge chunks.
+         *  When disabled, partial edge chunks are filtered.
+         *  Enabling this option will improve performance when appending to the dataset and, when
+         *  compression filters are used, prevent reallocation of these chunks.
+         */
+        if (dset_info[i].dset->shared->layout.sc_ops->layout_query(
+                dset_info[i].dset, NULL, NULL, &partial_bound_chunks_different_encoding) < 0)
+            HGOTO_ERROR(H5E_DATASET, H5E_CANTGET, FAIL, "unable to query chunk dimensions");
+
+        /* Filtered or not */
+        pline = &(dset_info[i].dset->shared->dcpl_cache.pline);
+        if (pline && pline->tot_filt_nsects)
+            filtered = true;
+
+        /* For each chunk in this dataset: */
+        for (size_t j = 0; j < chunk_count; j++)
+        {
+            /* true: a NOT-to-be-filtered-partial-edge chunk */
+            /* false : a to-be-filtered-partial-edge-chunk */
+            bool partial_bound = false;
+
+            // Needed for all chunks (check whether this is should be generated for each chunk or each
+            // dataset)
+            my_io_type_info.tconv_buf = NULL; /* Pointer to the datatype conv buffer */
+            my_io_type_info.tconv_buf_size = dset_info[i].type_info.src_type_size;
+            my_io_type_info.bkg_buf = NULL; /* Pointer to background buffer */
+            my_io_type_info.bkg_buf_size = dset_info[i].type_info.dst_type_size;
+
+            /* Pointer to the memory space ID for the chunk (derived from sc_io_info) */
+            scatter_mem_space = sc_io_info.sel_chunks[j].mem_space;
+
+            /* Pointer to the file space ID for the chunk (derived from sc_io_info) */
+            scatter_file_space = sc_io_info.sel_chunks[j].file_space;
+
+            /*
+             * If the chunk address is invalid (i.e., has a value of HADDR_UNDEF), the chunk is not present in
+             * the file; to ensure the write buffer is not disrupted, a new chunk should be created and the
+             * fill value should be propagated into this new chunk using the appropriate callback.
+             *
+             * NOTE: This chunk should not be written to file by default.
+             */
+            if (!H5_addr_defined(*addr[j]))
+            {
+                /* Free the invalid udata created by the lookup callback. */
+                udata_arr[j] = H5MM_xfree(udata_arr[j]);
+
+                /* Create a new chunk that will then have the fill value written to it. */
+                if (dset_info[i].dset->shared->layout.sc_ops->new_chunk(
+                        dset_info[i].dset, false, size[j], size_hint[j], &chunk_arr[j], &udata_arr[j]) < 0)
+                {
+                    HGOTO_ERROR(H5E_DATASET, H5E_CANTGET, FAIL, "unable to create new chunk (SCC)");
+                }
+
+                if (dset_info[i].dset->shared->layout.sc_ops->fill(
+                        &dset_info[i], &my_io_type_info, sc_io_info.sel_chunks->file_space, size[j],
+                        size_hint[j], &alloc_size_total, chunk_arr[j], udata_arr[j]) < 0)
+                {
+                    HGOTO_ERROR(H5E_DATASET, H5E_CANTGET, FAIL, "unable to fill chunk (SCC)");
+                }
+                /* If the chunk addr is valid: */
+            }
+            else
+            {
+                /* If the chunk lookup is successful: */
+                if (filtered && partial_bound_chunks_different_encoding &&
+                    H5D__chunk_is_partial_edge_chunk(dset_info[i].dset->shared->ndims,
+                                                     dset_info[i].dset->shared->layout.u.struct_chunk.dim,
+                                                     scaled[j], dset_info[i].dset->shared->curr_dims))
+                    partial_bound = true;
+
+                /* Allocate buffer for the chunk data */
+                if (NULL == (chunk_arr[j] = H5MM_malloc(*size_hint[j])))
+                {
+                    HGOTO_ERROR(H5E_RESOURCE, H5E_NOSPACE, H5_ITER_ERROR,
+                                "memory allocation failed for raw data chunk (SCC)");
+                }
+
+                /*
+                 * Block read the current chunk using the file ID, the type of allocation request
+                 * (H5FD_MEM_DRAW based on the definitions given in the H5F_mem_t type), the on-disk address
+                 * of the chunk, the size of the request, and the chunk buffer (which will be transitioned
+                 * into the intermediate format.)
+                 */
+                if (H5F_block_read(dset_info[i].dset->oloc.file, H5FD_MEM_DRAW, *addr[j], *size[j],
+                                   chunk_arr[j]) < 0)
+                {
+                    HGOTO_ERROR(H5E_DATASET, H5E_READERROR, FAIL, "unable to block read from file (SCC)");
+                }
+
+                // Skip for invalid addr
+                if (dset_info[i].dset->shared->layout.sc_ops->decode(dset_info[i].dset, size[j], size_hint[j],
+                                                                     partial_bound, &chunk_arr[j],
+                                                                     udata_arr[j]) < 0)
+                {
+                    HGOTO_ERROR(H5E_DATASET, H5E_CANTGET, FAIL, "unable to decode chunk in place (SCC)");
+                }
+            }
+
+            // Double check that the scatter_mem_space and scatter_file_space are correctly set.
+            if (dset_info[i].dset->shared->layout.sc_ops->scatter_mem(&dset_info[i], &my_io_type_info,
+                                                                      scatter_mem_space, scatter_file_space,
+                                                                      chunk_arr[j], udata_arr[j]) < 0)
+            {
+                HGOTO_ERROR(H5E_DATASET, H5E_CANTGET, FAIL, "unable to scatter mem for read chunk (SCC)");
+            }
+
+            /* Free the buffers via callback after scattering data to user buffer */
+            if (dset_info[i].dset->shared->layout.sc_ops->evict(dset_info[i].dset, chunk_arr[j],
+                                                                udata_arr[j]) < 0)
+            {
+                HGOTO_ERROR(H5E_DATASET, H5E_CANTGET, FAIL, "unable to evict the chunk (SCC)");
+            }
+
+        } /* Chunk Processing Loop End */
+
+        /* Free the allocated components prior to processing the next dataset */
+        for (size_t j = 0; j < chunk_count; j++)
+        {
+            free(addr[j]);
+            free(size[j]);
+            free(defined_values_size[j]);
+            free(size_hint[j]);
+            free(defined_values_size_hint[j]);
+        }
+
+        H5AC_tag(md_tag, NULL); /* Reset the metadata tag for the next dataset */
+    } /* Dataset Loop End */
+
+done:
+    /* Terminate sc_io_info */
+    if (H5SC__io_info_term(&sc_io_info) < 0)
+        HDONE_ERROR(H5E_DATASET, H5E_CANTRELEASE, FAIL, "can't close I/O info");
+
+    FUNC_LEAVE_NOAPI(ret_value)
+} /* end H5SC_read() */
 
 /*-------------------------------------------------------------------------
  * Function: H5SC_write
@@ -977,6 +1206,7 @@ done:
  * Return:   SUCCEED on success, FAIL on failure
  *-------------------------------------------------------------------------
  */
+#ifdef OUT
 herr_t
 H5SC_write(H5SC_t *cache, size_t count, H5D_dset_io_info_t *dset_info)
 {
@@ -1265,6 +1495,282 @@ H5SC_write(H5SC_t *cache, size_t count, H5D_dset_io_info_t *dset_info)
         }
         H5AC_tag(md_tag, NULL); /* Reset the metadata tag for the next dataset */
     }                           /* End Dataset Loop */
+done:
+    /* Terminate sc_io_info */
+    if (H5SC__io_info_term(&sc_io_info) < 0)
+        HDONE_ERROR(H5E_DATASET, H5E_CANTRELEASE, FAIL, "can't close I/O info");
+
+    FUNC_LEAVE_NOAPI(ret_value)
+} /* end H5SC_write() */
+#endif
+herr_t
+H5SC_write(H5SC_t *cache, size_t count, H5D_dset_io_info_t *dset_info)
+{
+    H5SC_io_info_t sc_io_info;
+    herr_t ret_value = SUCCEED;
+    size_t nbytes;   /* Used in the new chunk callback */
+    size_t buf_size; /* Used in the new chunk callback */
+    size_t alloc_size;
+    size_t alloc_size_total;
+    size_t write_size;
+    H5D_io_type_info_t my_io_type_info; /* Used in gather_mem callback */
+    const H5S_t *gather_mem_space;
+    const H5S_t *gather_file_space;
+    haddr_t md_tag = HADDR_UNDEF;
+    bool partial_bound_chunks_different_encoding = false;
+    H5O_pline_t *pline = NULL; /* I/O pipeline info */
+    hbool_t filtered = false;
+
+    FUNC_ENTER_NOAPI(FAIL)
+
+    assert(cache);
+    assert(count == 0 || dset_info);
+
+    /* Set up selections in sc_io_info */
+    if (H5SC__io_info_init(cache, &sc_io_info, count, dset_info) < 0)
+    {
+        HGOTO_ERROR(H5E_DATASET, H5E_CANTINIT, FAIL, "can't initialize selections for I/O");
+    }
+
+    /* Throw an error if no chunks were selected */
+    if (sc_io_info.num_sel_chunks == 0)
+    {
+        HDONE_ERROR(H5E_DATASET, H5E_CANTGETSIZE, FAIL,
+                    "The number of selected structured chunks should be non-zero (SCC)");
+    }
+
+    /* Loop through the datasets */
+    for (size_t i = 0; i < count; i++)
+    {
+
+        /* Sanity checks for the SCC callbacks for this dataset. */
+        assert(dset_info[i].dset->shared->layout.sc_ops->lookup);
+        assert(dset_info[i].dset->shared->layout.sc_ops->new_chunk);
+        assert(dset_info[i].dset->shared->layout.sc_ops->new_chunk);
+        assert(dset_info[i].dset->shared->layout.sc_ops->gather_mem);
+        assert(dset_info[i].dset->shared->layout.sc_ops->encode_in_place);
+        assert(dset_info[i].dset->shared->layout.sc_ops->insert);
+
+        /*
+         * Set the io_type_info struct parameters.
+         * NOTE: Since vlen_buf_info isn't required for the v0, we simply avoided
+         * initialize it (passing NULL causes an error and should be avoided)
+         */
+
+        my_io_type_info.tconv_buf = NULL; /* Datatype conv buffer (pointer) */
+        my_io_type_info.tconv_buf_size = dset_info[i].type_info.src_type_size;
+        my_io_type_info.bkg_buf = NULL; /* Pointer to background buffer */
+        my_io_type_info.bkg_buf_size = dset_info[i].type_info.dst_type_size;
+        my_io_type_info.may_use_in_place_tconv = true; /* Use in-place if possible */
+
+        /*
+         * To avoid issues with metadata tagging while doing multi-dataset I/O,
+         * we need to handle tagging within the SCC
+         */
+        H5AC_tag(dset_info[i].dset->oloc.addr, &md_tag); /* Set the metadata tag */
+
+        size_t chunk_count = sc_io_info.num_sel_chunks;
+
+        /*
+         * Begin the write process (cache emulation)
+         * Look up the chunk in file (for now, simply assert that the callback is present)
+         */
+
+        /* Create the arrays necessary for write operation. */
+        const hsize_t *scaled[chunk_count];
+        haddr_t *addr[chunk_count];
+        hsize_t *size[chunk_count];
+        hsize_t old_disk_size[chunk_count];
+        hsize_t *defined_values_size[chunk_count];
+        size_t *size_hint[chunk_count];
+        size_t *defined_values_size_hint[chunk_count];
+        void *udata_arr[chunk_count];
+        hsize_t write_size_arr[chunk_count];
+
+        /*
+         * Loop to initialize the components necessary for processing the I/O request through the SCC
+         * callbacks.
+         */
+        for (size_t j = 0; j < chunk_count; j++)
+        {
+            /* Set up scaled for the jth chunk */
+            scaled[j] = sc_io_info.sel_chunks[j].scaled;
+
+            /* Setup the address with a unique pointer (will need to be freed after looping through the
+             * dataset)
+             */
+            haddr_t *tmp_addr = malloc(sizeof(haddr_t));
+            *tmp_addr = HADDR_UNDEF;
+            addr[j] = tmp_addr;
+
+            /*
+             * Setup the size with a unique pointer (will need to be freed after looping through the
+             * dataset).
+             */
+            hsize_t *tmp_size = malloc(sizeof(hsize_t));
+            size[j] = tmp_size;
+
+            hsize_t *tmp_def_val_size = malloc(sizeof(hsize_t));
+            defined_values_size[j] = tmp_def_val_size;
+
+            size_t *tmp_size_hint = malloc(sizeof(size_t));
+            size_hint[j] = tmp_size_hint;
+
+            size_t *tmp_def_val_size_hint = malloc(sizeof(size_t));
+            defined_values_size_hint[j] = tmp_def_val_size_hint;
+        }
+
+        if (dset_info[i].dset->shared->layout.sc_ops->lookup(dset_info[i].dset, chunk_count, scaled, addr,
+                                                             size, defined_values_size, size_hint,
+                                                             defined_values_size_hint, udata_arr) < 0)
+        {
+            HGOTO_ERROR(H5E_DATASET, H5E_CANTGET, FAIL, "unable to lookup chunk (SCC)");
+        }
+
+        /* partial_bound_chunks_different_encoding:
+         *  When enabled, filters are not applied to partial edge chunks.
+         *  When disabled, partial edge chunks are filtered.
+         *  Enabling this option will improve performance when appending to the dataset and, when
+         *  compression filters are used, prevent reallocation of these chunks.
+         */
+        if (dset_info[i].dset->shared->layout.sc_ops->layout_query(
+                dset_info[i].dset, NULL, NULL, &partial_bound_chunks_different_encoding) < 0)
+            HGOTO_ERROR(H5E_DATASET, H5E_CANTGET, FAIL, "unable to query chunk dimensions");
+
+        pline = &(dset_info[i].dset->shared->dcpl_cache.pline);
+        if (pline && pline->tot_filt_nsects)
+            filtered = true;
+
+        /* Create the array that will hold the pointers to the chunk data structure */
+        void *chunk_arr[chunk_count];
+
+        for (size_t j = 0; j < chunk_count; j++)
+        {
+            bool partial_bound = false;
+            /* if assert(addr[j]); free the old udata, then create a new chunk*/
+            if (!H5_addr_defined(*addr[j]))
+            {
+                /* As a consequence of how the lookup callback functions, it is necessary to free the udata
+                 * for each chunk not found on disk.
+                 */
+                udata_arr[j] = H5MM_xfree(udata_arr[j]);
+
+                /* When not found on disk, a new (empty) chunk needs to be created using this callback. Note
+                 * that this callback does not insert this newly created chunk into the on-disk index.
+                 */
+                // Set the size from sc_io_info struct
+                if (dset_info[i].dset->shared->layout.sc_ops->new_chunk(
+                        dset_info[i].dset, false, size[j], size_hint[j], &chunk_arr[j], &udata_arr[j]) < 0)
+                {
+                    HGOTO_ERROR(H5E_DATASET, H5E_CANTGET, FAIL, "unable to create new chunk (SCC)");
+                }
+            }
+            else
+            {
+                old_disk_size[j] = *size[j];
+
+                /* If the chunk lookup is successful: */
+                if (filtered && partial_bound_chunks_different_encoding &&
+                    H5D__chunk_is_partial_edge_chunk(dset_info[i].dset->shared->ndims,
+                                                     dset_info[i].dset->shared->layout.u.struct_chunk.dim,
+                                                     scaled[j], dset_info[i].dset->shared->curr_dims))
+                    partial_bound = true;
+
+                /* Allocate buffer for the chunk data */
+                if (NULL == (chunk_arr[j] = H5MM_malloc(*size_hint[j])))
+                {
+                    HGOTO_ERROR(H5E_RESOURCE, H5E_NOSPACE, H5_ITER_ERROR,
+                                "memory allocation failed for raw data chunk (SCC)");
+                }
+
+                /* Read in the chunk, then decode the chunk */
+
+                if (H5F_block_read(dset_info[i].dset->oloc.file, H5FD_MEM_DRAW, *addr[j], *size[j],
+                                   chunk_arr[j]) < 0)
+                {
+                    HGOTO_ERROR(H5E_DATASET, H5E_READERROR, FAIL, "unable to block read from file (SCC)");
+                }
+                if (dset_info[i].dset->shared->layout.sc_ops->decode(dset_info[i].dset, size[j], size_hint[j],
+                                                                     partial_bound, &chunk_arr[j],
+                                                                     udata_arr[j]) < 0)
+                {
+                    HGOTO_ERROR(H5E_DATASET, H5E_CANTGET, FAIL, "unable to decode chunk in place (SCC)");
+                }
+            }
+        }
+
+        for (size_t j = 0; j < chunk_count; j++)
+        {
+
+            /* Pointer to the memory space ID, derived from sc_io_info */
+            gather_mem_space = sc_io_info.sel_chunks[j].mem_space;
+            // gather_mem_space = dset_info[i].mem_space;
+            /* Pointer to the file space ID, derived from sc_io_info */
+            gather_file_space = sc_io_info.sel_chunks[j].file_space;
+            // gather_file_space = dset_info[i].file_space;
+
+            /* The gather_mem callback is used to collect data from the memory buffer into the chunk buffer.
+             */
+            if (dset_info[i].dset->shared->layout.sc_ops->gather_mem(
+                    &dset_info[i], &my_io_type_info, gather_mem_space, gather_file_space, size[j],
+                    size_hint[j], &alloc_size_total, chunk_arr[j], udata_arr[j]) < 0)
+            {
+                HGOTO_ERROR(H5E_DATASET, H5E_CANTGET, FAIL, "unable to gather mem for new chunk (SCC)");
+            }
+        }
+        /*
+         * Start the "eviction" process
+         * First, we encode in place (chunk becomes disk formatted chunk buffer)
+         */
+
+
+        for (int j = 0; j < chunk_count; j++)
+        {
+            /* true: a NOT-to-be-filtered-partial-edge chunk */
+            /* false : a to-be-filtered-partial-edge-chunk */
+            bool partial_bound = false;
+
+            if (partial_bound_chunks_different_encoding && filtered &&
+                H5D__chunk_is_partial_edge_chunk(dset_info[i].dset->shared->ndims,
+                                                 dset_info[i].dset->shared->layout.u.struct_chunk.dim,
+                                                 scaled[j], dset_info[i].dset->shared->curr_dims))
+                partial_bound = true;
+
+            if (dset_info[i].dset->shared->layout.sc_ops->encode_in_place(
+                    dset_info[i].dset, &write_size, partial_bound, &chunk_arr[j], udata_arr[j]) < 0)
+            {
+                HGOTO_ERROR(H5E_DATASET, H5E_CANTGET, FAIL, "unable to encode chunk in place (SCC)");
+            }
+
+            /* Add the computed write size to the appropriate array */
+            write_size_arr[j] = write_size;
+        }
+
+        /* Insert the chunk into the chunk index within the file */
+        if (dset_info[i].dset->shared->layout.sc_ops->insert(dset_info[i].dset, chunk_count, &scaled, addr,
+                                                             old_disk_size, write_size_arr, chunk_arr, udata_arr) < 0)
+            HGOTO_ERROR(H5E_DATASET, H5E_CANTINSERT, FAIL, "unable to insert chunk into file (SCC)");
+
+        for (size_t j = 0; j < chunk_count; j++)
+        {
+            /* Write the chunk to file using H5F_block_write */
+            if (H5F_block_write(dset_info[i].dset->oloc.file, H5FD_MEM_DRAW, *addr[j], write_size_arr[j],
+                                chunk_arr[j]) < 0)
+            {
+                HGOTO_ERROR(H5E_DATASET, H5E_WRITEERROR, FAIL, "unable to block write to file(SCC)");
+            }
+
+            chunk_arr[j] = H5MM_xfree(chunk_arr[j]);
+            udata_arr[j] = H5MM_xfree(udata_arr[j]);
+
+            free(addr[j]);
+            free(size[j]);
+            free(defined_values_size[j]);
+            free(size_hint[j]);
+            free(defined_values_size_hint[j]);
+        }
+        H5AC_tag(md_tag, NULL); /* Reset the metadata tag for the next dataset */
+    } /* End Dataset Loop */
 done:
     /* Terminate sc_io_info */
     if (H5SC__io_info_term(&sc_io_info) < 0)

--- a/tools/lib/h5tools_dump.c
+++ b/tools/lib/h5tools_dump.c
@@ -3198,7 +3198,7 @@ h5tools_dump_dcpl(FILE *stream, const h5tool_format_t *info, h5tools_context_t *
     hsize_t          storage_size;
     hsize_t          curr_pos = 0;   /* total data element position   */
     h5tools_str_t    buffer;         /* string into which to render   */
-    unsigned         str_chunk_flag; /* type og structired chunk     */
+    unsigned         str_chunk_flag; /* type og structured chunk     */
 
     /* setup */
     memset(&buffer, 0, sizeof(h5tools_str_t));


### PR DESCRIPTION
1) Remove the two lines of code for orig_mem_space after H5SC_write() call so that the projected mem spaces will be closed at the end of H5D__write().  This will fix the infinite loop closing library problem when running ELena's test program.
Fixes in H5SC.c:
2) Fix a bug in H5SC_read() whn invoking the new chunk callback. 3) Save old_disk_size and use that when invoking the insert callback. Fixes in H5Dstruct_chunk.c:
4) Fix a bug when combing selection in gather_mem callback. 5) Fix a bug in defined_values callback.
6) Fix a bug in lookup callback when the chunk is not found via get_addr callback.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fixes bugs in chunk handling callbacks and memory management in HDF5 library, preventing infinite loops and improving data handling.
> 
>   - **H5Dio.c**:
>     - Removed redundant code for `orig_mem_space` after `H5SC_write()` call to prevent infinite loop issues.
>   - **H5SC.c**:
>     - Fixed bug in `H5SC_read()` when invoking new chunk callback.
>     - Saved `old_disk_size` for use in insert callback.
>   - **H5Dstruct_chunk.c**:
>     - Fixed bug in `gather_mem` callback related to selection combination.
>     - Corrected `defined_values` callback to handle selection types properly.
>     - Fixed `lookup` callback to handle missing chunks correctly.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=HDFGroup%2Fhdf5&utm_source=github&utm_medium=referral)<sup> for cb1ca30c12779ab05c3105bd3f4907a2b0d786d1. You can [customize](https://app.ellipsis.dev/HDFGroup/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->