### PR TITLE
Fix staging test workflow

### DIFF
--- a/.github/workflows/maven-staging.yml
+++ b/.github/workflows/maven-staging.yml
@@ -659,6 +659,11 @@ jobs:
           path: ./artifacts
           merge-multiple: false
 
+      - name: Checkout code for version extraction
+        uses: actions/checkout@v5.0.0
+        with:
+          path: source
+
       - name: Extract version for testing
         id: extract-version
         run: |
@@ -667,10 +672,28 @@ jobs:
           if [ -n "$POM_FILE" ]; then
             VERSION=$(grep -o '<version>[^<]*</version>' "$POM_FILE" | head -1 | sed 's/<[^>]*>//g')
             echo "version=$VERSION" >> $GITHUB_OUTPUT
-            echo "Extracted version: $VERSION"
+            echo "✅ Extracted version from POM: $VERSION"
           else
-            echo "version=2.0.0-SNAPSHOT" >> $GITHUB_OUTPUT
-            echo "Could not extract version, using default: 2.0.0-SNAPSHOT"
+            # Fallback: Extract version from H5public.h
+            echo "⚠️ No POM file found, extracting version from source..."
+            if [ -f "source/src/H5public.h" ]; then
+              H5_MAJOR=$(grep '#define H5_VERS_MAJOR' source/src/H5public.h | awk '{print $3}')
+              H5_MINOR=$(grep '#define H5_VERS_MINOR' source/src/H5public.h | awk '{print $3}')
+              H5_RELEASE=$(grep '#define H5_VERS_RELEASE' source/src/H5public.h | awk '{print $3}')
+
+              # Determine if this should be a SNAPSHOT version
+              if [ "${{ inputs.use_snapshot_version }}" == "true" ] || [ "${{ github.event_name }}" == "pull_request" ]; then
+                VERSION="${H5_MAJOR}.${H5_MINOR}.${H5_RELEASE}-SNAPSHOT"
+              else
+                VERSION="${H5_MAJOR}.${H5_MINOR}.${H5_RELEASE}"
+              fi
+
+              echo "version=$VERSION" >> $GITHUB_OUTPUT
+              echo "✅ Extracted version from H5public.h: $VERSION"
+            else
+              echo "::error::Could not extract version from POM or source files"
+              exit 1
+            fi
           fi
 
       - name: Test Maven deployment (dry run)

--- a/.github/workflows/test-maven-packages.yml
+++ b/.github/workflows/test-maven-packages.yml
@@ -123,8 +123,28 @@ jobs:
             echo "Fetching SNAPSHOT metadata..."
             METADATA_URL="${REPO_URL}/org/hdfgroup/${ARTIFACT_ID}/${VERSION}/maven-metadata.xml"
 
-            # Download metadata
-            curl -u "$GITHUB_ACTOR:$GITHUB_TOKEN" -fsSL "$METADATA_URL" -o /tmp/maven-metadata.xml
+            # Download metadata with retry (GitHub Packages may need time to propagate)
+            echo "Downloading metadata (with retry for GitHub Packages propagation)..."
+            RETRY_COUNT=0
+            MAX_RETRIES=12
+            RETRY_DELAY=10
+
+            while [ $RETRY_COUNT -lt $MAX_RETRIES ]; do
+              if curl -u "$GITHUB_ACTOR:$GITHUB_TOKEN" -fsSL "$METADATA_URL" -o /tmp/maven-metadata.xml; then
+                echo "✅ Metadata downloaded successfully"
+                break
+              else
+                RETRY_COUNT=$((RETRY_COUNT + 1))
+                if [ $RETRY_COUNT -lt $MAX_RETRIES ]; then
+                  echo "⏳ Attempt $RETRY_COUNT/$MAX_RETRIES failed. Waiting ${RETRY_DELAY}s for GitHub Packages to propagate..."
+                  sleep $RETRY_DELAY
+                else
+                  echo "::error::Failed to download metadata after $MAX_RETRIES attempts"
+                  echo "::error::URL: $METADATA_URL"
+                  exit 1
+                fi
+              fi
+            done
 
             # Extract timestamped version from metadata
             # Note: Maven may truncate long classifiers, so we search for partial matches
@@ -167,16 +187,54 @@ jobs:
             POM_FILENAME="${ARTIFACT_ID}-${VERSION}.pom"
           fi
 
-          # Download JAR and POM
+          # Download JAR and POM with retry
           JAR_URL="${REPO_URL}/org/hdfgroup/${ARTIFACT_ID}/${VERSION}/${JAR_FILENAME}"
           POM_URL="${REPO_URL}/org/hdfgroup/${ARTIFACT_ID}/${VERSION}/${POM_FILENAME}"
-
-          echo "Downloading JAR: ${JAR_URL}"
           mkdir -p /tmp/maven-download
-          curl -u "$GITHUB_ACTOR:$GITHUB_TOKEN" -fsSL "$JAR_URL" -o "/tmp/maven-download/${JAR_FILENAME}"
 
+          # Download JAR with retry
+          echo "Downloading JAR: ${JAR_URL}"
+          RETRY_COUNT=0
+          MAX_RETRIES=12
+          RETRY_DELAY=10
+
+          while [ $RETRY_COUNT -lt $MAX_RETRIES ]; do
+            if curl -u "$GITHUB_ACTOR:$GITHUB_TOKEN" -fsSL "$JAR_URL" -o "/tmp/maven-download/${JAR_FILENAME}"; then
+              echo "✅ JAR downloaded successfully"
+              break
+            else
+              RETRY_COUNT=$((RETRY_COUNT + 1))
+              if [ $RETRY_COUNT -lt $MAX_RETRIES ]; then
+                echo "⏳ JAR download attempt $RETRY_COUNT/$MAX_RETRIES failed. Waiting ${RETRY_DELAY}s..."
+                sleep $RETRY_DELAY
+              else
+                echo "::error::Failed to download JAR after $MAX_RETRIES attempts"
+                echo "::error::URL: $JAR_URL"
+                exit 1
+              fi
+            fi
+          done
+
+          # Download POM with retry
           echo "Downloading POM: ${POM_URL}"
-          curl -u "$GITHUB_ACTOR:$GITHUB_TOKEN" -fsSL "$POM_URL" -o "/tmp/maven-download/${POM_FILENAME}"
+          RETRY_COUNT=0
+
+          while [ $RETRY_COUNT -lt $MAX_RETRIES ]; do
+            if curl -u "$GITHUB_ACTOR:$GITHUB_TOKEN" -fsSL "$POM_URL" -o "/tmp/maven-download/${POM_FILENAME}"; then
+              echo "✅ POM downloaded successfully"
+              break
+            else
+              RETRY_COUNT=$((RETRY_COUNT + 1))
+              if [ $RETRY_COUNT -lt $MAX_RETRIES ]; then
+                echo "⏳ POM download attempt $RETRY_COUNT/$MAX_RETRIES failed. Waiting ${RETRY_DELAY}s..."
+                sleep $RETRY_DELAY
+              else
+                echo "::error::Failed to download POM after $MAX_RETRIES attempts"
+                echo "::error::URL: $POM_URL"
+                exit 1
+              fi
+            fi
+          done
 
           # Install to local Maven repository
           echo "Installing artifact to local repository..."
@@ -326,8 +384,28 @@ jobs:
             echo "Fetching SNAPSHOT metadata..."
             METADATA_URL="${REPO_URL}/org/hdfgroup/${ARTIFACT_ID}/${VERSION}/maven-metadata.xml"
 
-            # Download metadata
-            curl -u "$GITHUB_ACTOR:$GITHUB_TOKEN" -fsSL "$METADATA_URL" -o /tmp/maven-metadata.xml
+            # Download metadata with retry (GitHub Packages may need time to propagate)
+            echo "Downloading metadata (with retry for GitHub Packages propagation)..."
+            RETRY_COUNT=0
+            MAX_RETRIES=12
+            RETRY_DELAY=10
+
+            while [ $RETRY_COUNT -lt $MAX_RETRIES ]; do
+              if curl -u "$GITHUB_ACTOR:$GITHUB_TOKEN" -fsSL "$METADATA_URL" -o /tmp/maven-metadata.xml; then
+                echo "✅ Metadata downloaded successfully"
+                break
+              else
+                RETRY_COUNT=$((RETRY_COUNT + 1))
+                if [ $RETRY_COUNT -lt $MAX_RETRIES ]; then
+                  echo "⏳ Attempt $RETRY_COUNT/$MAX_RETRIES failed. Waiting ${RETRY_DELAY}s for GitHub Packages to propagate..."
+                  sleep $RETRY_DELAY
+                else
+                  echo "::error::Failed to download metadata after $MAX_RETRIES attempts"
+                  echo "::error::URL: $METADATA_URL"
+                  exit 1
+                fi
+              fi
+            done
 
             # Extract timestamped version from metadata
             # Note: Maven may truncate long classifiers, so we search for partial matches
@@ -370,16 +448,54 @@ jobs:
             POM_FILENAME="${ARTIFACT_ID}-${VERSION}.pom"
           fi
 
-          # Download JAR and POM
+          # Download JAR and POM with retry
           JAR_URL="${REPO_URL}/org/hdfgroup/${ARTIFACT_ID}/${VERSION}/${JAR_FILENAME}"
           POM_URL="${REPO_URL}/org/hdfgroup/${ARTIFACT_ID}/${VERSION}/${POM_FILENAME}"
-
-          echo "Downloading JAR: ${JAR_URL}"
           mkdir -p /tmp/maven-download
-          curl -u "$GITHUB_ACTOR:$GITHUB_TOKEN" -fsSL "$JAR_URL" -o "/tmp/maven-download/${JAR_FILENAME}"
 
+          # Download JAR with retry
+          echo "Downloading JAR: ${JAR_URL}"
+          RETRY_COUNT=0
+          MAX_RETRIES=12
+          RETRY_DELAY=10
+
+          while [ $RETRY_COUNT -lt $MAX_RETRIES ]; do
+            if curl -u "$GITHUB_ACTOR:$GITHUB_TOKEN" -fsSL "$JAR_URL" -o "/tmp/maven-download/${JAR_FILENAME}"; then
+              echo "✅ JAR downloaded successfully"
+              break
+            else
+              RETRY_COUNT=$((RETRY_COUNT + 1))
+              if [ $RETRY_COUNT -lt $MAX_RETRIES ]; then
+                echo "⏳ JAR download attempt $RETRY_COUNT/$MAX_RETRIES failed. Waiting ${RETRY_DELAY}s..."
+                sleep $RETRY_DELAY
+              else
+                echo "::error::Failed to download JAR after $MAX_RETRIES attempts"
+                echo "::error::URL: $JAR_URL"
+                exit 1
+              fi
+            fi
+          done
+
+          # Download POM with retry
           echo "Downloading POM: ${POM_URL}"
-          curl -u "$GITHUB_ACTOR:$GITHUB_TOKEN" -fsSL "$POM_URL" -o "/tmp/maven-download/${POM_FILENAME}"
+          RETRY_COUNT=0
+
+          while [ $RETRY_COUNT -lt $MAX_RETRIES ]; do
+            if curl -u "$GITHUB_ACTOR:$GITHUB_TOKEN" -fsSL "$POM_URL" -o "/tmp/maven-download/${POM_FILENAME}"; then
+              echo "✅ POM downloaded successfully"
+              break
+            else
+              RETRY_COUNT=$((RETRY_COUNT + 1))
+              if [ $RETRY_COUNT -lt $MAX_RETRIES ]; then
+                echo "⏳ POM download attempt $RETRY_COUNT/$MAX_RETRIES failed. Waiting ${RETRY_DELAY}s..."
+                sleep $RETRY_DELAY
+              else
+                echo "::error::Failed to download POM after $MAX_RETRIES attempts"
+                echo "::error::URL: $POM_URL"
+                exit 1
+              fi
+            fi
+          done
 
           # Install to local Maven repository
           echo "Installing artifact to local repository..."


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Improve Maven workflows by adding retry logic for downloads and enhancing version extraction fallback.
> 
>   - **Workflows**:
>     - `.github/workflows/maven-staging.yml`: Add `actions/checkout@v5.0.0` step for version extraction.
>     - `.github/workflows/test-maven-packages.yml`: Add retry logic for downloading metadata, JAR, and POM files.
>   - **Version Extraction**:
>     - Enhance version extraction in `maven-staging.yml` to fallback to `H5public.h` if POM is unavailable.
>   - **Retry Logic**:
>     - Implement retry mechanism for metadata, JAR, and POM downloads in `test-maven-packages.yml` to handle GitHub Packages propagation delays.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=HDFGroup%2Fhdf5&utm_source=github&utm_medium=referral)<sup> for 41a818f4c0ffb81f48144d0eda758c0225ef0375. You can [customize](https://app.ellipsis.dev/HDFGroup/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->