### PR TITLE
Added a missing entry for predefined datatype

### DIFF
--- a/doxygen/dox/hdf5_2_0.dox
+++ b/doxygen/dox/hdf5_2_0.dox
@@ -148,8 +148,6 @@ This section includes the new features introduced in the HDF5 2.0 series:
 
 \li Support for chunks larger than 4 GiB using 64 bit addressing.
 
-\li New predefined datatypes for FP8 data in E4M3 and E5M2 formats (https://arxiv.org/abs/2209.05433), but not a native FP8 datatype.  Please refer to the <a href="https://\SRCURL/release_docs/CHANGELOG.md">CHANGELOG</a> for detail.
-
 \li New predefined datatypes for
     - FP8 data in E4M3 and E5M2 formats (https://arxiv.org/abs/2209.05433), but not a native FP8 datatype.
     - little- and big-endian [bfloat16](https://en.wikipedia.org/wiki/Bfloat16_floating-point_format) data.

--- a/doxygen/dox/hdf5_2_0.dox
+++ b/doxygen/dox/hdf5_2_0.dox
@@ -150,6 +150,11 @@ This section includes the new features introduced in the HDF5 2.0 series:
 
 \li New predefined datatypes for FP8 data in E4M3 and E5M2 formats (https://arxiv.org/abs/2209.05433), but not a native FP8 datatype.  Please refer to the <a href="https://\SRCURL/release_docs/CHANGELOG.md">CHANGELOG</a> for detail.
 
+\li New predefined datatypes for
+    - FP8 data in E4M3 and E5M2 formats (https://arxiv.org/abs/2209.05433), but not a native FP8 datatype.
+    - little- and big-endian [bfloat16](https://en.wikipedia.org/wiki/Bfloat16_floating-point_format) data.
+<br>Please refer to the <a href="https://\SRCURL/release_docs/CHANGELOG.md">CHANGELOG</a> for detail.
+
 \li Default chunk cache hash table size increased to 8191
 <br>In order to reduce hash collisions and take advantage of modern memory capacity, the default hash table size for the chunk cache has been increased from 521 to 8191. This means the hash table will consume approximately 64 KiB per open dataset. This value can be changed with `H5Pset_cache()` or `H5Pset_chunk_cache()`. This value was chosen because it is a prime number close to 8K.
 


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Added missing documentation entry for predefined bfloat16 datatypes in `hdf5_2_0.dox`.
> 
>   - **Documentation**:
>     - Added missing entry for predefined datatypes for little- and big-endian bfloat16 data in `hdf5_2_0.dox`.
>     - Entry includes reference to bfloat16 format and CHANGELOG for details.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=HDFGroup%2Fhdf5&utm_source=github&utm_medium=referral)<sup> for 8fcc8712dad0db53b1ba244dcc5ce89804430709. You can [customize](https://app.ellipsis.dev/HDFGroup/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->