### PR TITLE
Remove unused macro H5_MY_PKG_ERR

### DIFF
--- a/src/H5ACmodule.h
+++ b/src/H5ACmodule.h
@@ -23,7 +23,6 @@
  */
 #define H5AC_MODULE
 #define H5_MY_PKG      H5AC
-#define H5_MY_PKG_ERR  H5E_CACHE
 #define H5_MY_PKG_INIT YES
 
 #endif /* H5ACmodule_H */

--- a/src/H5Amodule.h
+++ b/src/H5Amodule.h
@@ -23,7 +23,6 @@
  */
 #define H5A_MODULE
 #define H5_MY_PKG      H5A
-#define H5_MY_PKG_ERR  H5E_ATTR
 #define H5_MY_PKG_INIT YES
 
 /** \page H5A_UG HDF5 Attributes

--- a/src/H5B2module.h
+++ b/src/H5B2module.h
@@ -23,7 +23,6 @@
  */
 #define H5B2_MODULE
 #define H5_MY_PKG      H5B2
-#define H5_MY_PKG_ERR  H5E_BTREE
 #define H5_MY_PKG_INIT NO
 
 #endif /* H5B2module_H */

--- a/src/H5Bmodule.h
+++ b/src/H5Bmodule.h
@@ -23,7 +23,6 @@
  */
 #define H5B_MODULE
 #define H5_MY_PKG      H5B
-#define H5_MY_PKG_ERR  H5E_BTREE
 #define H5_MY_PKG_INIT NO
 
 #endif /* H5Bmodule_H */

--- a/src/H5CXmodule.h
+++ b/src/H5CXmodule.h
@@ -23,7 +23,6 @@
  */
 #define H5CX_MODULE
 #define H5_MY_PKG      H5CX
-#define H5_MY_PKG_ERR  H5E_CONTEXT
 #define H5_MY_PKG_INIT YES
 
 #endif /* H5CXmodule_H */

--- a/src/H5Cmodule.h
+++ b/src/H5Cmodule.h
@@ -23,7 +23,6 @@
  */
 #define H5C_MODULE
 #define H5_MY_PKG      H5C
-#define H5_MY_PKG_ERR  H5E_CACHE
 #define H5_MY_PKG_INIT NO
 
 #endif /* H5Cmodule_H */

--- a/src/H5Dmodule.h
+++ b/src/H5Dmodule.h
@@ -23,7 +23,6 @@
  */
 #define H5D_MODULE
 #define H5_MY_PKG      H5D
-#define H5_MY_PKG_ERR  H5E_DATASET
 #define H5_MY_PKG_INIT YES
 
 /** \page H5D_UG HDF5 Datasets

--- a/src/H5EAmodule.h
+++ b/src/H5EAmodule.h
@@ -23,7 +23,6 @@
  */
 #define H5EA_MODULE
 #define H5_MY_PKG      H5EA
-#define H5_MY_PKG_ERR  H5E_EARRAY
 #define H5_MY_PKG_INIT NO
 
 #endif /* H5EAmodule_H */

--- a/src/H5ESmodule.h
+++ b/src/H5ESmodule.h
@@ -23,7 +23,6 @@
  */
 #define H5ES_MODULE
 #define H5_MY_PKG      H5ES
-#define H5_MY_PKG_ERR  H5E_EVENTSET
 #define H5_MY_PKG_INIT YES
 
 /** \page H5ES_UG HDF5 Event Set

--- a/src/H5Emodule.h
+++ b/src/H5Emodule.h
@@ -23,7 +23,6 @@
  */
 #define H5E_MODULE
 #define H5_MY_PKG      H5E
-#define H5_MY_PKG_ERR  H5E_ERROR
 #define H5_MY_PKG_INIT YES
 
 /** \page H5E_UG HDF5 Error Handling

--- a/src/H5FAmodule.h
+++ b/src/H5FAmodule.h
@@ -23,7 +23,6 @@
  */
 #define H5FA_MODULE
 #define H5_MY_PKG      H5FA
-#define H5_MY_PKG_ERR  H5E_FARRAY
 #define H5_MY_PKG_INIT NO
 
 #endif /* H5FAmodule_H */

--- a/src/H5FDmodule.h
+++ b/src/H5FDmodule.h
@@ -23,7 +23,6 @@
  */
 #define H5FD_MODULE
 #define H5_MY_PKG      H5FD
-#define H5_MY_PKG_ERR  H5E_VFL
 #define H5_MY_PKG_INIT YES
 /**
  * \defgroup H5VFD Virtual File Driver Features

--- a/src/H5FLmodule.h
+++ b/src/H5FLmodule.h
@@ -23,7 +23,6 @@
  */
 #define H5FL_MODULE
 #define H5_MY_PKG      H5FL
-#define H5_MY_PKG_ERR  H5E_RESOURCE
 #define H5_MY_PKG_INIT NO
 
 #endif /* H5FLmodule_H */

--- a/src/H5FSmodule.h
+++ b/src/H5FSmodule.h
@@ -23,7 +23,6 @@
  */
 #define H5FS_MODULE
 #define H5_MY_PKG      H5FS
-#define H5_MY_PKG_ERR  H5E_FSPACE
 #define H5_MY_PKG_INIT NO
 
 #endif /* H5FSmodule_H */

--- a/src/H5Fmodule.h
+++ b/src/H5Fmodule.h
@@ -23,7 +23,6 @@
  */
 #define H5F_MODULE
 #define H5_MY_PKG      H5F
-#define H5_MY_PKG_ERR  H5E_FILE
 #define H5_MY_PKG_INIT YES
 
 /** \page H5F_UG HDF5 File

--- a/src/H5Gmodule.h
+++ b/src/H5Gmodule.h
@@ -23,7 +23,6 @@
  */
 #define H5G_MODULE
 #define H5_MY_PKG      H5G
-#define H5_MY_PKG_ERR  H5E_SYM
 #define H5_MY_PKG_INIT YES
 
 /**  \page H5G_UG HDF5 Groups

--- a/src/H5HFmodule.h
+++ b/src/H5HFmodule.h
@@ -23,7 +23,6 @@
  */
 #define H5HF_MODULE
 #define H5_MY_PKG      H5HF
-#define H5_MY_PKG_ERR  H5E_HEAP
 #define H5_MY_PKG_INIT NO
 
 #endif /* H5HFmodule_H */

--- a/src/H5HGmodule.h
+++ b/src/H5HGmodule.h
@@ -23,7 +23,6 @@
  */
 #define H5HG_MODULE
 #define H5_MY_PKG      H5HG
-#define H5_MY_PKG_ERR  H5E_HEAP
 #define H5_MY_PKG_INIT NO
 
 #endif /* H5HGmodule_H */

--- a/src/H5HLmodule.h
+++ b/src/H5HLmodule.h
@@ -23,7 +23,6 @@
  */
 #define H5HL_MODULE
 #define H5_MY_PKG      H5HL
-#define H5_MY_PKG_ERR  H5E_HEAP
 #define H5_MY_PKG_INIT NO
 
 #endif /* H5HLmodule_H */

--- a/src/H5Imodule.h
+++ b/src/H5Imodule.h
@@ -23,7 +23,6 @@
  */
 #define H5I_MODULE
 #define H5_MY_PKG      H5I
-#define H5_MY_PKG_ERR  H5E_ID
 #define H5_MY_PKG_INIT NO
 
 /** \page H5I_UG HDF5 Identifiers

--- a/src/H5Lmodule.h
+++ b/src/H5Lmodule.h
@@ -23,7 +23,6 @@
  */
 #define H5L_MODULE
 #define H5_MY_PKG      H5L
-#define H5_MY_PKG_ERR  H5E_LINK
 #define H5_MY_PKG_INIT YES
 
 /** \page H5L_UG HDF5 Links

--- a/src/H5MFmodule.h
+++ b/src/H5MFmodule.h
@@ -23,7 +23,6 @@
  */
 #define H5MF_MODULE
 #define H5_MY_PKG      H5MF
-#define H5_MY_PKG_ERR  H5E_RESOURCE
 #define H5_MY_PKG_INIT NO
 
 #endif /* H5MFmodule_H */

--- a/src/H5Mmodule.h
+++ b/src/H5Mmodule.h
@@ -23,7 +23,6 @@
  */
 #define H5M_MODULE
 #define H5_MY_PKG      H5M
-#define H5_MY_PKG_ERR  H5E_MAP
 #define H5_MY_PKG_INIT YES
 
 /**

--- a/src/H5Omodule.h
+++ b/src/H5Omodule.h
@@ -23,7 +23,6 @@
  */
 #define H5O_MODULE
 #define H5_MY_PKG      H5O
-#define H5_MY_PKG_ERR  H5E_OHDR
 #define H5_MY_PKG_INIT YES
 
 /** \page H5O_UG HDF5 Objects

--- a/src/H5PBmodule.h
+++ b/src/H5PBmodule.h
@@ -23,7 +23,6 @@
  */
 #define H5PB_MODULE
 #define H5_MY_PKG      H5PB
-#define H5_MY_PKG_ERR  H5E_RESOURCE
 #define H5_MY_PKG_INIT NO
 
 #endif /* H5PBmodule_H */

--- a/src/H5PLmodule.h
+++ b/src/H5PLmodule.h
@@ -24,7 +24,6 @@
  */
 #define H5PL_MODULE
 #define H5_MY_PKG      H5PL
-#define H5_MY_PKG_ERR  H5E_PLUGIN
 #define H5_MY_PKG_INIT YES
 
 /** \page H5PL_UG HDF5 Plugins

--- a/src/H5Pmodule.h
+++ b/src/H5Pmodule.h
@@ -23,7 +23,6 @@
  */
 #define H5P_MODULE
 #define H5_MY_PKG      H5P
-#define H5_MY_PKG_ERR  H5E_PLIST
 #define H5_MY_PKG_INIT YES
 
 /** \page H5P_UG  Properties and Property Lists in HDF5

--- a/src/H5RSmodule.h
+++ b/src/H5RSmodule.h
@@ -23,7 +23,6 @@
  */
 #define H5RS_MODULE
 #define H5_MY_PKG      H5RS
-#define H5_MY_PKG_ERR  H5E_RS
 #define H5_MY_PKG_INIT NO
 
 #endif /* H5RSmodule_H */

--- a/src/H5RTmodule.h
+++ b/src/H5RTmodule.h
@@ -22,7 +22,6 @@
  *      reporting macros.
  */
 #define H5RT_MODULE
-#define H5_MY_PKG_ERR  H5E_RTREE
 #define H5_MY_PKG_INIT NO
 
 #endif /* H5RTmodule_H */

--- a/src/H5Rmodule.h
+++ b/src/H5Rmodule.h
@@ -22,7 +22,6 @@
  */
 #define H5R_MODULE
 #define H5_MY_PKG      H5R
-#define H5_MY_PKG_ERR  H5E_REFERENCE
 #define H5_MY_PKG_INIT YES
 
 /** \page H5R_UG HDF5 References

--- a/src/H5SLmodule.h
+++ b/src/H5SLmodule.h
@@ -23,7 +23,6 @@
  */
 #define H5SL_MODULE
 #define H5_MY_PKG      H5SL
-#define H5_MY_PKG_ERR  H5E_SLIST
 #define H5_MY_PKG_INIT YES
 
 #endif /* H5SLmodule_H */

--- a/src/H5SMmodule.h
+++ b/src/H5SMmodule.h
@@ -23,7 +23,6 @@
  */
 #define H5SM_MODULE
 #define H5_MY_PKG      H5SM
-#define H5_MY_PKG_ERR  H5E_SOHM
 #define H5_MY_PKG_INIT NO
 
 #endif /* H5SMmodule_H */

--- a/src/H5Smodule.h
+++ b/src/H5Smodule.h
@@ -23,7 +23,6 @@
  */
 #define H5S_MODULE
 #define H5_MY_PKG      H5S
-#define H5_MY_PKG_ERR  H5E_DATASPACE
 #define H5_MY_PKG_INIT YES
 
 /** \page H5S_UG Dataspaces and Partial I/O

--- a/src/H5TSmodule.h
+++ b/src/H5TSmodule.h
@@ -23,7 +23,6 @@
  */
 #define H5TS_MODULE
 #define H5_MY_PKG      H5TS
-#define H5_MY_PKG_ERR  H5E_THREADSAFE
 #define H5_MY_PKG_INIT NO
 
 #endif /* H5TSmodule_H */

--- a/src/H5Tmodule.h
+++ b/src/H5Tmodule.h
@@ -23,7 +23,6 @@
  */
 #define H5T_MODULE
 #define H5_MY_PKG      H5T
-#define H5_MY_PKG_ERR  H5E_DATATYPE
 #define H5_MY_PKG_INIT YES
 
 /** \page H5T_UG HDF5 Datatypes

--- a/src/H5VLmodule.h
+++ b/src/H5VLmodule.h
@@ -24,7 +24,6 @@
  */
 #define H5VL_MODULE
 #define H5_MY_PKG      H5VL
-#define H5_MY_PKG_ERR  H5E_VOL
 #define H5_MY_PKG_INIT YES
 
 /** \page H5VL_UG HDF5 Virtual Object Layer (VOL)

--- a/src/H5Zmodule.h
+++ b/src/H5Zmodule.h
@@ -23,7 +23,6 @@
  */
 #define H5Z_MODULE
 #define H5_MY_PKG      H5Z
-#define H5_MY_PKG_ERR  H5E_PLINE
 #define H5_MY_PKG_INIT YES
 
 /** \page H5Z_UG HDF5 Filters

--- a/src/H5module.h
+++ b/src/H5module.h
@@ -23,7 +23,6 @@
  */
 #define H5_MODULE
 #define H5_MY_PKG      H5
-#define H5_MY_PKG_ERR  H5E_LIB
 #define H5_MY_PKG_INIT YES
 
 /** \page H5DM_UG HDF5 Data Model and File Structure


### PR DESCRIPTION
This macro used to be used for the FUNC_ENTER/FUNC_LEAVE machinery but is no longer used anywhere, so this PR removes it from all the module headers,
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Remove unused `H5_MY_PKG_ERR` macro from multiple module headers as it is no longer used.
> 
>   - **Removal**:
>     - Remove `#define H5_MY_PKG_ERR` from `H5ACmodule.h`, `H5Amodule.h`, and `H5B2module.h`.
>     - Also removed from `H5Bmodule.h`, `H5CXmodule.h`, and 28 other module headers.
>   - **Purpose**:
>     - `H5_MY_PKG_ERR` was part of the FUNC_ENTER/FUNC_LEAVE machinery but is no longer used anywhere in the codebase.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=HDFGroup%2Fhdf5&utm_source=github&utm_medium=referral)<sup> for a3786da9c07f4c246848687a5474d02834e60f67. You can [customize](https://app.ellipsis.dev/HDFGroup/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->