### PR TITLE
Set version 2.0.0 for release.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-HDF5 version 2.0.0-2 currently under development
+HDF5 version 2.0.0 currently under development
 
 > [!WARNING]
 > **Heads Up: HDF5 Dropped Autotools March 10th**

--- a/config/cmake/scripts/HDF5config.cmake
+++ b/config/cmake/scripts/HDF5config.cmake
@@ -39,7 +39,7 @@ cmake_minimum_required (VERSION 3.26)
 ##############################################################################
 
 set (CTEST_SOURCE_VERSION "2.0.0")
-set (CTEST_SOURCE_VERSEXT "-2")
+set (CTEST_SOURCE_VERSEXT "")
 
 ##############################################################################
 # handle input parameters to script.

--- a/config/examples/HDF5AsSubdirMacros.cmake
+++ b/config/examples/HDF5AsSubdirMacros.cmake
@@ -18,7 +18,7 @@
 # the add_subdirectory command..
 macro (EXTERNAL_HDF5_LIBRARY compress_type)
   set (HDF5_VERSION "2.0.0")
-  set (HDF5_VERSEXT "-2")
+  set (HDF5_VERSEXT "")
   set (HDF5_VERSION_MAJOR "2.0")
   set (HDF5LIB_TGZ_NAME "hdf5.tar.gz" CACHE STRING "Use HDF5LIB from compressed file" FORCE)
   set (HDF5LIB_TGZ_ORIGPATH "https://github.com/HDFGroup/hdf5/releases/download/snapshot" CACHE STRING "Use HDF5LIB from original location" FORCE)

--- a/release_docs/CHANGELOG.md
+++ b/release_docs/CHANGELOG.md
@@ -1,4 +1,4 @@
-HDF5 version 2.0.0-2 currently under development
+HDF5 version 2.0.0 currently under development
 
 # 🔺 HDF5 Changelog
 All notable changes to this project will be documented in this file. This document describes the differences between this release and the previous

--- a/src/H5public.h
+++ b/src/H5public.h
@@ -73,15 +73,15 @@
 /**
  * For pre-releases like \c snap0. Empty string for official releases.
  */
-#define H5_VERS_SUBRELEASE "2"
+#define H5_VERS_SUBRELEASE ""
 /**
  * Short version string
  */
-#define H5_VERS_STR "2.0.0-2"
+#define H5_VERS_STR "2.0.0"
 /**
  * Full version string
  */
-#define H5_VERS_INFO "HDF5 library version: 2.0.0-2"
+#define H5_VERS_INFO "HDF5 library version: 2.0.0"
 
 #define H5check() H5check_version(H5_VERS_MAJOR, H5_VERS_MINOR, H5_VERS_RELEASE)
 


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Set HDF5 version to 2.0.0 for release, removing '-2' suffix from version strings across multiple files.
> 
>   - **Version Update**:
>     - Set version to `2.0.0` in `README.md`, `HDF5config.cmake`, `HDF5AsSubdirMacros.cmake`, `CHANGELOG.md`, and `H5public.h`.
>     - Removed `-2` suffix from version strings in these files.
>   - **Configuration**:
>     - Updated `CTEST_SOURCE_VERSEXT` to an empty string in `HDF5config.cmake` and `HDF5AsSubdirMacros.cmake`.
>   - **Documentation**:
>     - Updated version references in `README.md` and `CHANGELOG.md` to reflect the release version.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=HDFGroup%2Fhdf5&utm_source=github&utm_medium=referral)<sup> for 62f537e6b71a2a078936986552f2139b42ace9ac. You can [customize](https://app.ellipsis.dev/HDFGroup/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->