### PR TITLE
Fixed the URL to the compatibility reports

### DIFF
--- a/doxygen/dox/hdf5_2_0.dox
+++ b/doxygen/dox/hdf5_2_0.dox
@@ -64,7 +64,7 @@ Additional Release Information
 <td style="background-color:#F5F5F5">
 </td>
 <td>
-[API Compatibility Reports between 2.0 and 1.14.6](https://github.com/HDFGroup/hdf5/releases/download/hdf5_2.0/hdf5-2.0.html.abi.reports.tar.gz)
+[API Compatibility Reports between 2.0 and 1.14.6](https://github.com/HDFGroup/hdf5/releases/download/2.0.0/hdf5-2.0.0.html.abi.reports.tar.gz)
 </td>
 </tr>
 <tr>

--- a/doxygen/dox/hdf5_2_0.dox
+++ b/doxygen/dox/hdf5_2_0.dox
@@ -64,7 +64,7 @@ Additional Release Information
 <td style="background-color:#F5F5F5">
 </td>
 <td>
-[API Compatibility Reports between 2.0 and 1.14.6](https://support.hdfgroup.org/releases/hdf5/v2_0/v2_0_0/downloads/hdf5-2.0.0.html.abi.reports.tar.gz)
+[API Compatibility Reports between 2.0 and 1.14.6](https://\RELURL/v2_0/v2_0_0/downloads/hdf5-2.0.0.html.abi.reports.tar.gz)
 </td>
 </tr>
 <tr>
@@ -80,9 +80,9 @@ Additional Release Information
 \subsection subsec_download Downloads
 
 Source code and binaries are available at:
-<a href="https://support.hdfgroup.org/releases/hdf5/v2_0/v2_0_0/downloads/index.html">https://support.hdfgroup.org/releases/hdf5/v2_0/v2_0_0/downloads/index.html</a>
+<a href="https://\RELURL/v2_0/v2_0_0/downloads/index.html">https://support.hdfgroup.org/releases/hdf5/v2_0/v2_0_0/downloads/index.html</a>
 
-Please refer to [Build instructions](https://github.com/HDFGroup/hdf5/blob/hdf5_2.0/release_docs/INSTALL) for building with either CMake or Autotools.
+Please refer to [Build instructions](https://\SRCURL/release_docs/INSTALL) for building with either CMake or Autotools.
 
 
 \subsection subsec_obtain_method Methods to obtain (gz file)
@@ -91,24 +91,24 @@ Please refer to [Build instructions](https://github.com/HDFGroup/hdf5/blob/hdf5_
 \li chrome –  Download file and then run:  `gzip -cd <distribution>.tar.gz | tar xvf -`
 \li wget –
 <div style="margin-left: 2em;">
-    `wget https://github.com/HDFGroup/hdf5/releases/download/hdf5_1.N.N/<distribution>.tar.gz`<br>
+    `wget https://github.com/HDFGroup/hdf5/releases/download/1.N.N/<distribution>.tar.gz`<br>
     `gzip -cd <distribution>.tar.gz | tar xvf -`
 </div>
 
 \subsection subsec_api_compat_reps Individual API Compatibility Reports
 
-* [hdf5-2.0-hdf5_compat_report.html](https://support.hdfgroup.org/releases/hdf5/v2_0/v2_0_0/downloads/compat_report/hdf5-2.0.0-hdf5_compat_report.html) -- HTML C library ABI report file
+* [hdf5-2.0-hdf5_compat_report.html](https://\RELURL/v2_0/v2_0_0/downloads/compat_report/hdf5-2.0.0-hdf5_compat_report.html) -- HTML C library ABI report file
 
-* [hdf5-2.0-hdf5_cpp_compat_report.html](https://support.hdfgroup.org/releases/hdf5/v2_0/v2_0_0/downloads/compat_report/hdf5-2.0.0-hdf5_cpp_compat_report.html) -- HTML CPP library ABI report file
+* [hdf5-2.0-hdf5_cpp_compat_report.html](https://\RELURL/v2_0/v2_0_0/downloads/compat_report/hdf5-2.0.0-hdf5_cpp_compat_report.html) -- HTML CPP library ABI report file
 
-* [hdf5-2.0-hdf5_hl_compat_report.html](https://support.hdfgroup.org/releases/hdf5/v2_0/v2_0_0/downloads/compat_report/hdf5-2.0.0-hdf5_hl_compat_report.html) -- HTML HL C library ABI report file
+* [hdf5-2.0-hdf5_hl_compat_report.html](https://\RELURL/v2_0/v2_0_0/downloads/compat_report/hdf5-2.0.0-hdf5_hl_compat_report.html) -- HTML HL C library ABI report file
 
-* [hdf5-2.0-java_compat_report.html](https://support.hdfgroup.org/releases/hdf5/v2_0/v2_0_0/downloads/compat_report/hdf5-2.0.0-java_compat_report.html) -- HTML Java library ABI report file
+* [hdf5-2.0-java_compat_report.html](https://\RELURL/v2_0/v2_0_0/downloads/compat_report/hdf5-2.0.0-java_compat_report.html) -- HTML Java library ABI report file
 
 
 \subsection subsec_dox_gen_doc Doxygen Generated Reference Manual
 
-The new HDF5 documentation based on [Doxygen](https://www.doxygen.nl/index.html) is available [here](https://support.hdfgroup.org/releases/hdf5/v2/index.html)
+The new HDF5 documentation based on [Doxygen](https://www.doxygen.nl/index.html) is available \ref index "here".
 
 This documentation is WORK-IN-PROGRESS. 
 

--- a/doxygen/dox/hdf5_2_0.dox
+++ b/doxygen/dox/hdf5_2_0.dox
@@ -64,7 +64,7 @@ Additional Release Information
 <td style="background-color:#F5F5F5">
 </td>
 <td>
-[API Compatibility Reports between 2.0 and 1.14.6](https://github.com/HDFGroup/hdf5/releases/download/2.0.0/hdf5-2.0.0.html.abi.reports.tar.gz)
+[API Compatibility Reports between 2.0 and 1.14.6](https://support.hdfgroup.org/releases/hdf5/v2_0/v2_0_0/downloads/hdf5-2.0.0.html.abi.reports.tar.gz)
 </td>
 </tr>
 <tr>
@@ -97,13 +97,13 @@ Please refer to [Build instructions](https://github.com/HDFGroup/hdf5/blob/hdf5_
 
 \subsection subsec_api_compat_reps Individual API Compatibility Reports
 
-* [hdf5-2.0-hdf5_compat_report.html](https://support.hdfgroup.org/releases/hdf5/v2_0/v2_0_0/downloads/compat_report/hdf5-2.0-hdf5_compat_report.html) -- HTML C library ABI report file
+* [hdf5-2.0-hdf5_compat_report.html](https://support.hdfgroup.org/releases/hdf5/v2_0/v2_0_0/downloads/compat_report/hdf5-2.0.0-hdf5_compat_report.html) -- HTML C library ABI report file
 
-* [hdf5-2.0-hdf5_cpp_compat_report.html](https://support.hdfgroup.org/releases/hdf5/v2_0/v2_0_0/downloads/compat_report/hdf5-2.0-hdf5_cpp_compat_report.html) -- HTML CPP library ABI report file
+* [hdf5-2.0-hdf5_cpp_compat_report.html](https://support.hdfgroup.org/releases/hdf5/v2_0/v2_0_0/downloads/compat_report/hdf5-2.0.0-hdf5_cpp_compat_report.html) -- HTML CPP library ABI report file
 
-* [hdf5-2.0-hdf5_hl_compat_report.html](https://support.hdfgroup.org/releases/hdf5/v2_0/v2_0_0/downloads/compat_report/hdf5-2.0-hdf5_hl_compat_report.html) -- HTML HL C library ABI report file
+* [hdf5-2.0-hdf5_hl_compat_report.html](https://support.hdfgroup.org/releases/hdf5/v2_0/v2_0_0/downloads/compat_report/hdf5-2.0.0-hdf5_hl_compat_report.html) -- HTML HL C library ABI report file
 
-* [hdf5-2.0-java_compat_report.html](https://support.hdfgroup.org/releases/hdf5/v2_0/v2_0_0/downloads/compat_report/hdf5-2.0-java_compat_report.html) -- HTML Java library ABI report file
+* [hdf5-2.0-java_compat_report.html](https://support.hdfgroup.org/releases/hdf5/v2_0/v2_0_0/downloads/compat_report/hdf5-2.0.0-java_compat_report.html) -- HTML Java library ABI report file
 
 
 \subsection subsec_dox_gen_doc Doxygen Generated Reference Manual

--- a/doxygen/dox/hdf5_2_0.dox
+++ b/doxygen/dox/hdf5_2_0.dox
@@ -91,7 +91,7 @@ Please refer to [Build instructions](https://\SRCURL/release_docs/INSTALL) for b
 \li chrome –  Download file and then run:  `gzip -cd <distribution>.tar.gz | tar xvf -`
 \li wget –
 <div style="margin-left: 2em;">
-    `wget https://github.com/HDFGroup/hdf5/releases/download/1.N.N/<distribution>.tar.gz`<br>
+    `wget https://github.com/HDFGroup/hdf5/releases/download/2.N.N/<distribution>.tar.gz`<br>
     `gzip -cd <distribution>.tar.gz | tar xvf -`
 </div>
 


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Fixed URL in `hdf5_2_0.dox` for API Compatibility Reports to correct release version `2.0.0`.
> 
>   - **Documentation**:
>     - Fixed URL in `hdf5_2_0.dox` for API Compatibility Reports between 2.0 and 1.14.6 to point to the correct release version `2.0.0`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=HDFGroup%2Fhdf5&utm_source=github&utm_medium=referral)<sup> for 00eea0dc7ec7a754d31b75cbad62fb34da6e54ea. You can [customize](https://app.ellipsis.dev/HDFGroup/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->