### PR TITLE
Feature/sparse data

### DIFF
--- a/src/H5Dstruct_chunk.c
+++ b/src/H5Dstruct_chunk.c
@@ -2153,8 +2153,8 @@ H5D__struct_chunk_insert(H5D_t *dset, size_t count, const hsize_t *scaled[] /*in
 {
     H5D_chunk_ud_t             *udata;
     H5D_chk_idx_info_t          idx_info; /* Chunked index info */
-    H5O_storage_struct_chunk_t *storage     = &(dset->shared->layout.storage.u.struct_chunk);
-    H5O_layout_struct_chunk_t  *layout      = &(dset->shared->layout.u.struct_chunk);
+    H5O_storage_struct_chunk_t *storage = &(dset->shared->layout.storage.u.struct_chunk);
+    H5O_layout_struct_chunk_t  *layout  = &(dset->shared->layout.u.struct_chunk);
     size_t                      i;
     H5D_chunk_ud_t             *my_udata;
     herr_t                      ret_value = SUCCEED; /* Return value */
@@ -2178,8 +2178,8 @@ H5D__struct_chunk_insert(H5D_t *dset, size_t count, const hsize_t *scaled[] /*in
         HGOTO_ERROR(H5E_ARGS, H5E_CANTALLOC, FAIL, "could not malloc space for udata");
 
     for (i = 0; i < count; i++) {
-        bool                        need_alloc  = true;
-        bool                        need_insert = true;
+        bool need_alloc  = true;
+        bool need_insert = true;
 
         memset(my_udata, 0, sizeof(H5D_chunk_ud_t));
 
@@ -2199,7 +2199,7 @@ H5D__struct_chunk_insert(H5D_t *dset, size_t count, const hsize_t *scaled[] /*in
             assert(old_disk_size[i] == my_udata->chunk_block.length);
 
             if (old_disk_size[i] == new_disk_size[i])
-                need_alloc  = false;
+                need_alloc = false;
             else {
                 if (H5MF_xfree(dset->oloc.file, H5FD_MEM_DRAW, *addr[i], old_disk_size[i]) < 0)
                     HGOTO_ERROR(H5E_DATASET, H5E_CANTFREE, FAIL, "unable to free chunk");

--- a/src/H5Dstruct_chunk.c
+++ b/src/H5Dstruct_chunk.c
@@ -2155,8 +2155,6 @@ H5D__struct_chunk_insert(H5D_t *dset, size_t count, const hsize_t *scaled[] /*in
     H5D_chk_idx_info_t          idx_info; /* Chunked index info */
     H5O_storage_struct_chunk_t *storage     = &(dset->shared->layout.storage.u.struct_chunk);
     H5O_layout_struct_chunk_t  *layout      = &(dset->shared->layout.u.struct_chunk);
-    bool                        need_alloc  = true;
-    bool                        need_insert = true;
     size_t                      i;
     H5D_chunk_ud_t             *my_udata;
     herr_t                      ret_value = SUCCEED; /* Return value */
@@ -2180,6 +2178,8 @@ H5D__struct_chunk_insert(H5D_t *dset, size_t count, const hsize_t *scaled[] /*in
         HGOTO_ERROR(H5E_ARGS, H5E_CANTALLOC, FAIL, "could not malloc space for udata");
 
     for (i = 0; i < count; i++) {
+        bool                        need_alloc  = true;
+        bool                        need_insert = true;
 
         memset(my_udata, 0, sizeof(H5D_chunk_ud_t));
 
@@ -2198,10 +2198,8 @@ H5D__struct_chunk_insert(H5D_t *dset, size_t count, const hsize_t *scaled[] /*in
             assert(*addr[i] == my_udata->chunk_block.offset);
             assert(old_disk_size[i] == my_udata->chunk_block.length);
 
-            if (old_disk_size[i] == new_disk_size[i]) {
+            if (old_disk_size[i] == new_disk_size[i])
                 need_alloc  = false;
-                need_insert = false;
-            }
             else {
                 if (H5MF_xfree(dset->oloc.file, H5FD_MEM_DRAW, *addr[i], old_disk_size[i]) < 0)
                     HGOTO_ERROR(H5E_DATASET, H5E_CANTFREE, FAIL, "unable to free chunk");


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Move `need_alloc` and `need_insert` variables inside loop in `H5D__struct_chunk_insert()` to ensure correct allocation and insertion logic for each chunk.
> 
>   - **Functionality**:
>     - Move `need_alloc` and `need_insert` variables inside the loop in `H5D__struct_chunk_insert()` in `H5Dstruct_chunk.c`.
>     - Ensures `need_alloc` and `need_insert` are reset for each chunk processed, affecting allocation and insertion logic.
>   - **Code Quality**:
>     - Removes redundant initialization of `need_alloc` and `need_insert` outside the loop.
>     - Simplifies logic by ensuring variables are scoped to their usage context.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=HDFGroup%2Fhdf5&utm_source=github&utm_medium=referral)<sup> for 9ef26a26ce9c6fa22e81aafddd6b273ef6473de7. You can [customize](https://app.ellipsis.dev/HDFGroup/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->