### PR TITLE
Clean up the setting for the need_insert variable in the insert callb…

### DIFF
--- a/src/H5Dstruct_chunk.c
+++ b/src/H5Dstruct_chunk.c
@@ -2178,7 +2178,7 @@ H5D__struct_chunk_insert(H5D_t *dset, size_t count, const hsize_t *scaled[] /*in
         HGOTO_ERROR(H5E_ARGS, H5E_CANTALLOC, FAIL, "could not malloc space for udata");
 
     for (i = 0; i < count; i++) {
-        bool need_alloc  = true;
+        bool need_alloc = true;
 
         memset(my_udata, 0, sizeof(H5D_chunk_ud_t));
 

--- a/src/H5Dstruct_chunk.c
+++ b/src/H5Dstruct_chunk.c
@@ -2179,7 +2179,6 @@ H5D__struct_chunk_insert(H5D_t *dset, size_t count, const hsize_t *scaled[] /*in
 
     for (i = 0; i < count; i++) {
         bool need_alloc  = true;
-        bool need_insert = true;
 
         memset(my_udata, 0, sizeof(H5D_chunk_ud_t));
 
@@ -2214,19 +2213,19 @@ H5D__struct_chunk_insert(H5D_t *dset, size_t count, const hsize_t *scaled[] /*in
                 HGOTO_ERROR(H5E_DATASET, H5E_CANTALLOC, FAIL, "file allocation failed");
         }
 
-        if (need_insert) {
+        /* For dense chunk, no need to insert for non-filtered chunk with the same old/new sizes */
+        /* For structured chunk, there is metadata for filtered and non-filtered chunk, so insert anyway */
 
-            udata = (H5D_chunk_ud_t *)_udata[i];
+        udata = (H5D_chunk_ud_t *)_udata[i];
 
-            udata->chunk_block.offset = *(addr[i]);
-            udata->chunk_block.length = new_disk_size[i];
-            udata->chunk_idx          = my_udata->chunk_idx;
-            udata->common.scaled      = scaled[i];
+        udata->chunk_block.offset = *(addr[i]);
+        udata->chunk_block.length = new_disk_size[i];
+        udata->chunk_idx          = my_udata->chunk_idx;
+        udata->common.scaled      = scaled[i];
 
-            if (storage->ops->insert) {
-                if ((storage->ops->insert)(&idx_info, udata, dset) < 0)
-                    HGOTO_ERROR(H5E_DATASET, H5E_CANTINSERT, FAIL, "unable to insert chunk addr into index");
-            }
+        if (storage->ops->insert) {
+            if ((storage->ops->insert)(&idx_info, udata, dset) < 0)
+                HGOTO_ERROR(H5E_DATASET, H5E_CANTINSERT, FAIL, "unable to insert chunk addr into index");
         }
 
     } /* end for */


### PR DESCRIPTION
…ack.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Remove `need_insert` variable and simplify logic in `H5D__struct_chunk_insert()` to always perform insert if possible.
> 
>   - **Behavior**:
>     - Remove `need_insert` variable in `H5D__struct_chunk_insert()` in `H5Dstruct_chunk.c`.
>     - Always perform insert operation if `storage->ops->insert` is available.
>     - Update comments to reflect new logic for structured chunks.
>   - **Code Simplification**:
>     - Simplify logic by removing unnecessary variable and conditions.
>     - Reorganize code for clarity in `H5D__struct_chunk_insert()`.
>   - **Comments**:
>     - Update comments to explain the behavior for dense and structured chunks.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=HDFGroup%2Fhdf5&utm_source=github&utm_medium=referral)<sup> for 40f09aa25124f02cbba9571821be0f58cdfe7804. You can [customize](https://app.ellipsis.dev/HDFGroup/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->