### PR TITLE
Increment minor version:  set version 2.1.0.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-HDF5 version 2.0.1 currently under development
+HDF5 version 2.1.0 currently under development
 
 > [!WARNING]
 > **Heads Up: HDF5 Dropped Autotools March 10th**

--- a/config/cmake/scripts/HDF5config.cmake
+++ b/config/cmake/scripts/HDF5config.cmake
@@ -38,7 +38,7 @@ cmake_minimum_required (VERSION 3.26)
 #     CTEST_SOURCE_NAME  -  source folder
 ##############################################################################
 
-set (CTEST_SOURCE_VERSION "2.0.1")
+set (CTEST_SOURCE_VERSION "2.1.0")
 set (CTEST_SOURCE_VERSEXT "")
 
 ##############################################################################

--- a/config/examples/HDF5AsSubdirMacros.cmake
+++ b/config/examples/HDF5AsSubdirMacros.cmake
@@ -17,7 +17,7 @@
 # and build it.  The HDF5 options should be set after the FetchContent_Declare command and before
 # the add_subdirectory command..
 macro (EXTERNAL_HDF5_LIBRARY compress_type)
-  set (HDF5_VERSION "2.0.1")
+  set (HDF5_VERSION "2.1.0")
   set (HDF5_VERSEXT "")
   set (HDF5_VERSION_MAJOR "2.0")
   set (HDF5LIB_TGZ_NAME "hdf5.tar.gz" CACHE STRING "Use HDF5LIB from compressed file" FORCE)

--- a/java/hdf/hdf5lib/H5.java
+++ b/java/hdf/hdf5lib/H5.java
@@ -256,7 +256,7 @@ import org.slf4j.LoggerFactory;
  * which prints out the HDF5 error stack, as described in the HDF5 C API <i><b>@ref H5Eprint()</b>.</i> This
  * may be used by Java exception handlers to print out the HDF5 error stack. <hr>
  *
- * @version HDF5 2.0.1 <BR>
+ * @version HDF5 2.1.0 <BR>
  *          <b>See also: </b>
  *          @ref HDFARRAY hdf.hdf5lib.HDFArray<br />
  *          @ref HDF5CONST hdf.hdf5lib.HDF5Constants<br />
@@ -298,7 +298,7 @@ public class H5 implements java.io.Serializable {
      * </ul>
      * Make sure to update the versions number when a different library is used.
      */
-    public final static int LIB_VERSION[] = {2, 0, 1};
+    public final static int LIB_VERSION[] = {2, 1, 0};
 
     private final static LinkedHashSet<Long> OPEN_IDS = new LinkedHashSet<Long>();
     private static boolean isLibraryLoaded            = false;

--- a/java/src-jni/hdf/hdf5lib/H5.java
+++ b/java/src-jni/hdf/hdf5lib/H5.java
@@ -231,7 +231,7 @@ import org.slf4j.LoggerFactory;
  * which prints out the HDF5 error stack, as described in the HDF5 C API <i><b>@ref H5Eprint()</b>.</i> This
  * may be used by Java exception handlers to print out the HDF5 error stack. <hr>
  *
- * @version HDF5 2.0.1 <BR>
+ * @version HDF5 2.1.0 <BR>
  *          <b>See also: </b>
  *          @ref HDFARRAY hdf.hdf5lib.HDFArray<br />
  *          @ref HDF5CONST hdf.hdf5lib.HDF5Constants<br />
@@ -273,7 +273,7 @@ public class H5 implements java.io.Serializable {
      * </ul>
      * Make sure to update the versions number when a different library is used.
      */
-    public final static int LIB_VERSION[] = {2, 0, 1};
+    public final static int LIB_VERSION[] = {2, 1, 0};
 
     /**
      * @ingroup JH5

--- a/java/src-jni/test/TestH5.java
+++ b/java/src-jni/test/TestH5.java
@@ -313,7 +313,7 @@ public class TestH5 {
     @Test
     public void testH5get_libversion()
     {
-        int libversion[] = {2, 0, 1};
+        int libversion[] = {2, 1, 0};
 
         try {
             H5.H5get_libversion(libversion);
@@ -351,7 +351,7 @@ public class TestH5 {
     @Test
     public void testH5check_version()
     {
-        int majnum = 2, minnum = 0, relnum = 1;
+        int majnum = 2, minnum = 1, relnum = 0;
 
         try {
             H5.H5check_version(majnum, minnum, relnum);

--- a/java/test/TestH5.java
+++ b/java/test/TestH5.java
@@ -313,7 +313,7 @@ public class TestH5 {
     @Test
     public void testH5get_libversion()
     {
-        int libversion[] = {2, 0, 1};
+        int libversion[] = {2, 1, 0};
 
         try {
             H5.H5get_libversion(libversion);
@@ -351,7 +351,7 @@ public class TestH5 {
     @Test
     public void testH5check_version()
     {
-        int majnum = 2, minnum = 0, relnum = 1;
+        int majnum = 2, minnum = 1, relnum = 0;
 
         try {
             H5.H5check_version(majnum, minnum, relnum);

--- a/release_docs/CHANGELOG.md
+++ b/release_docs/CHANGELOG.md
@@ -1,4 +1,4 @@
-HDF5 version 2.0.1 currently under development
+HDF5 version 2.1.0 currently under development
 
 # 🔺 HDF5 Changelog
 All notable changes to this project will be documented in this file. This document describes the differences between this release and the previous
@@ -21,7 +21,7 @@ For releases prior to version 2.0.0, please see the release.txt file and for mor
 * [Platforms Tested](CHANGELOG.md#%EF%B8%8F-platforms-tested)
 * [Known Problems](CHANGELOG.md#-known-problems)
 
-# 🔆 Executive Summary: HDF5 Version 2.0.1
+# 🔆 Executive Summary: HDF5 Version 2.1.0
 
 ## Performance Enhancements:
 

--- a/src/H5public.h
+++ b/src/H5public.h
@@ -65,11 +65,11 @@
 /**
  * For minor interface/format changes
  */
-#define H5_VERS_MINOR 0
+#define H5_VERS_MINOR 1
 /**
  * For tweaks, bug-fixes, or development
  */
-#define H5_VERS_RELEASE 1
+#define H5_VERS_RELEASE 0
 /**
  * For pre-releases like \c snap0. Empty string for official releases.
  */
@@ -77,11 +77,11 @@
 /**
  * Short version string
  */
-#define H5_VERS_STR "2.0.1"
+#define H5_VERS_STR "2.1.0"
 /**
  * Full version string
  */
-#define H5_VERS_INFO "HDF5 library version: 2.0.1"
+#define H5_VERS_INFO "HDF5 library version: 2.1.0"
 
 #define H5check() H5check_version(H5_VERS_MAJOR, H5_VERS_MINOR, H5_VERS_RELEASE)
 


### PR DESCRIPTION
New Fortran SWMR APIs were added;  next release must increment minor version.

#6024 
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Incremented HDF5 library version from 2.0.1 to 2.1.0 across documentation, configuration, and Java files.
> 
>   - **Version Update**:
>     - Incremented version from `2.0.1` to `2.1.0` in `README.md`, `HDF5config.cmake`, and `H5.java`.
>     - Updated `LIB_VERSION` array in `H5.java` and `TestH5.java` to `{2, 1, 0}`.
>     - Changed `H5_VERS_MINOR` to `1` and `H5_VERS_RELEASE` to `0` in `H5public.h`.
>   - **Documentation**:
>     - Updated version references in `CHANGELOG.md` to `2.1.0`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=HDFGroup%2Fhdf5&utm_source=github&utm_medium=referral)<sup> for 4151e96e8da4403c0f67fc43edd026a639a6876a. You can [customize](https://app.ellipsis.dev/HDFGroup/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->