### PR TITLE
Correct the setting of sizes in lookup callback.

### DIFF
--- a/src/H5Dstruct_chunk.c
+++ b/src/H5Dstruct_chunk.c
@@ -1373,20 +1373,12 @@ H5D__struct_chunk_lookup(H5D_t *dset, size_t count, const hsize_t *scaled[] /*in
                 *addr[i] = udata->chunk_block.offset;
             if (size[i])
                 *size[i] = udata->chunk_block.length;
-
-            if (filtered)
-                /* For now: assume two sections for fixed data */
-                tot_unfilt_size = udata->unfilt_size[0] + udata->unfilt_size[1];
-
             if (size_hint[i])
-                *size_hint[i] = filtered ? tot_unfilt_size : *size[i];
-
-            /* Size of defined values */
+                *size_hint[i] = *size[i];
             if (defined_values_size[i])
-                *defined_values_size[i] = filtered ? udata->unfilt_size[0] : udata->offset[1];
-
+                *defined_values_size[i] = udata->offset[1];
             if (defined_values_size_hint[i])
-                *defined_values_size_hint[i] = filtered ? udata->unfilt_size[0] : *defined_values_size[i];
+                *defined_values_size_hint[i] = *defined_values_size[i];
         }
         else {
 


### PR DESCRIPTION
This will fix the compression of data section problem with mm2h5-r-struct-d.c as well as the h5stat problem with text2hdf5_batch_struct.c.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fixes size setting in `H5D__struct_chunk_lookup()` to resolve data compression and statistics issues.
> 
>   - **Behavior**:
>     - Fixes size setting in `H5D__struct_chunk_lookup()` in `H5Dstruct_chunk.c` by removing handling of filtered data.
>     - Simplifies logic for setting `size_hint` and `defined_values_size_hint`.
>   - **Impact**:
>     - Resolves data compression issue in `mm2h5-r-struct-d.c`.
>     - Fixes statistics reporting problem in `text2hdf5_batch_struct.c`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=HDFGroup%2Fhdf5&utm_source=github&utm_medium=referral)<sup> for 8da5db86e5cac408447f854d31f6e75849771615. You can [customize](https://app.ellipsis.dev/HDFGroup/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->