### PR TITLE
Fix CMAKE_CROSSCOMPILING spelling

### DIFF
--- a/release_docs/CHANGELOG.md
+++ b/release_docs/CHANGELOG.md
@@ -86,7 +86,7 @@ We would like to thank the many HDF5 community members who contributed to HDF5 2
 ### Improved the cross-compile support in the build system
 
    The CMake build system has been improved to better support cross-compiling. This includes the following changes:
-   - The CMake option, `CMAKE_CROSS_COMPILING`, indicates that the library is being cross-compiled. This option, usually in a toolchain file, can be set to ON when cross-compiling.
+   - The CMake option, `CMAKE_CROSSCOMPILING`, indicates that the library is being cross-compiled. This option, usually in a toolchain file, can be set to ON when cross-compiling.
    - Removed the `CMAKE_CROSSCOMPILING_EMULATOR` when cross-compiling, CMake will automatically insert it in the command.
    - Added an option `HDF5_USE_PREGEN` to supply pre-generated files located in `HDF5_USE_PREGEN_DIR` directory, to bypass running feature detection programs when cross-compiling.
    - Added a variable `CROSSCOMPILING_PATH` to specify a path to search for programs when cross-compiling. This is useful when the build system needs to run programs that were built for the host system.


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Corrected spelling of `CMAKE_CROSSCOMPILING` in `CHANGELOG.md`.
> 
>   - **Documentation**:
>     - Corrected spelling of `CMAKE_CROSSCOMPILING` in `CHANGELOG.md` from `CMAKE_CROSS_COMPILING`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=HDFGroup%2Fhdf5&utm_source=github&utm_medium=referral)<sup> for a9664c374c73e19013a14570ac1110079ea60c07. You can [customize](https://app.ellipsis.dev/HDFGroup/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->