### PR TITLE
Fix location of EXTERNAL_HDF5_STATUS

### DIFF
--- a/release_docs/CHANGELOG.md
+++ b/release_docs/CHANGELOG.md
@@ -95,7 +95,7 @@ We would like to thank the many HDF5 community members who contributed to HDF5 2
 
    The variables used in hdf5-config.cmake to indicate what options were used to build the installed library have been renamed. All `HDF5_BUILD/ENABLE_{feature}` variables are now `HDF5_PROVIDES_{feature}`. This more clearly indicates that these variables reflect whether the feature is supported by the installed library, instead of whether the feature is an option that can be changed when building an application with the library.
 
-   Created macro `EXTERNAL_HDF5_STATUS` to convert between the old and new names. The macro is in the config/examples/HDF5SubdirMacros.cmake file and can be copied into a project's CMakeLists.txt file to provide backward compatibility.
+   Created macro `EXTERNAL_HDF5_STATUS` to convert between the old and new names. The macro is in the config/examples/HDF5AsSubdirMacros.cmake file and can be copied into a project's CMakeLists.txt file to provide backward compatibility.
 
 ### CMake minimum version is now 3.26
 

--- a/release_docs/release_archive.txt
+++ b/release_docs/release_archive.txt
@@ -57,7 +57,7 @@ New Features
       an application with the library.
 
       Created MACRO EXTERNAL_HDF5_STATUS to convert between the old and new names.
-      The macro is in the config/examples/HDF5SubdirMacros.cmake file and can be
+      The macro is in the config/examples/HDF5AsSubdirMacros.cmake file and can be
       copied into a project's CMakeLists.txt file to provide backward compatibility.
 
     - CMake minimum version is now 3.26


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Fixes the path of `EXTERNAL_HDF5_STATUS` macro in documentation files for correct reference.
> 
>   - **Documentation**:
>     - Corrected the path of `EXTERNAL_HDF5_STATUS` macro in `CHANGELOG.md` and `release_archive.txt` from `config/examples/HDF5SubdirMacros.cmake` to `config/examples/HDF5AsSubdirMacros.cmake`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=HDFGroup%2Fhdf5&utm_source=github&utm_medium=referral)<sup> for 6ac7ec4194e3f3e2c2d9eb088bcbf0210a097e48. You can [customize](https://app.ellipsis.dev/HDFGroup/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->