### PR TITLE
Fix ci-Intel preset to use intel toolchain

### DIFF
--- a/config/cmake-presets/hidden-presets.json
+++ b/config/cmake-presets/hidden-presets.json
@@ -97,7 +97,7 @@
       "name": "ci-Intel",
       "hidden": true,
       "cacheVariables": {
-        "CMAKE_TOOLCAHIN_FILE": "config/toolchain/intel.cmake"
+        "CMAKE_TOOLCHAIN_FILE": "config/toolchain/intel.cmake"
       }
     },
     {

--- a/config/cmake-presets/hidden-presets.json
+++ b/config/cmake-presets/hidden-presets.json
@@ -95,7 +95,10 @@
     },
     {
       "name": "ci-Intel",
-      "hidden": true
+      "hidden": true,
+      "cacheVariables": {
+        "CMAKE_TOOLCAHIN_FILE": "config/toolchain/intel.cmake"
+      }
     },
     {
       "name": "ci-Fortran",


### PR DESCRIPTION
fix #6029 to correctly use intel toolchain
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fixes `ci-Intel` preset to use Intel toolchain by setting `CMAKE_TOOLCHAIN_FILE` in `hidden-presets.json`.
> 
>   - **Behavior**:
>     - Fixes `ci-Intel` preset in `hidden-presets.json` to use Intel toolchain by adding `CMAKE_TOOLCHAIN_FILE` set to `config/toolchain/intel.cmake`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=HDFGroup%2Fhdf5&utm_source=github&utm_medium=referral)<sup> for 5c0c61aa81de72e8ef1230417479731a95310232. You can [customize](https://app.ellipsis.dev/HDFGroup/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->