### PR TITLE
Minor optimizations of r-tree implementation

### DIFF
--- a/src/H5RT.c
+++ b/src/H5RT.c
@@ -363,27 +363,27 @@ H5RT__bulk_load(H5RT_node_t *node, int rank, H5RT_leaf_t *leaves, size_t count, 
     assert(prev_sort_dim >= -1);
     assert(rank >= 1 && rank <= H5S_MAX_RANK);
 
+    /* Compute the max/min bounds of the provided node */
+    /* Initial values */
+    for (int i = 0; i < rank; i++) {
+        node->min[i] = leaves[0].min[i];
+        node->max[i] = leaves[0].max[i];
+    }
+    /* Compute max/min from leaves */
+    for (size_t i = 0; i < count; i++) {
+        for (int d = 0; d < rank; d++) {
+            if (leaves[i].min[d] < node->min[d])
+                node->min[d] = leaves[i].min[d];
+            if (leaves[i].max[d] > node->max[d])
+                node->max[d] = leaves[i].max[d];
+        }
+    }
+
     if (count <= H5RT_MAX_NODE_SIZE) {
         /* Base Case - All leaves will fit into this node */
         node->nchildren           = (int)count;
         node->children_are_leaves = true;
         node->children.leaves     = leaves;
-
-        /* Compute the max/min bounds of the provided node using the values from the child leaves */
-        /* Initial values */
-        for (int i = 0; i < rank; i++) {
-            node->min[i] = leaves[0].min[i];
-            node->max[i] = leaves[0].max[i];
-        }
-        /* Compute max/min from leaves */
-        for (size_t i = 1; i < count; i++) {
-            for (int d = 0; d < rank; d++) {
-                if (leaves[i].min[d] < node->min[d])
-                    node->min[d] = leaves[i].min[d];
-                if (leaves[i].max[d] > node->max[d])
-                    node->max[d] = leaves[i].max[d];
-            }
-        }
     }
     else {
         /* Recursive case - there will be child nodes */
@@ -434,22 +434,6 @@ H5RT__bulk_load(H5RT_node_t *node, int rank, H5RT_leaf_t *leaves, size_t count, 
             /* The next 'child_leaf_count' leaves are now assigned */
             child_leaf_start += child_leaf_count;
             leaves_left -= child_leaf_count;
-
-            /* Compute the max/min bounds of the provided node using the values from the child nodes */
-            if (i == 0)
-                /* Initial values */
-                for (int d = 0; d < rank; d++) {
-                    node->min[d] = node->children.nodes[0]->min[d];
-                    node->max[d] = node->children.nodes[0]->max[d];
-                }
-            else
-                /* Compute max/min from child nodes */
-                for (int d = 0; d < rank; d++) {
-                    if (node->children.nodes[i]->min[d] < node->min[d])
-                        node->min[d] = node->children.nodes[i]->min[d];
-                    if (node->children.nodes[i]->max[d] > node->max[d])
-                        node->max[d] = node->children.nodes[i]->max[d];
-                }
         }
     }
 

--- a/src/H5RT.c
+++ b/src/H5RT.c
@@ -363,27 +363,27 @@ H5RT__bulk_load(H5RT_node_t *node, int rank, H5RT_leaf_t *leaves, size_t count, 
     assert(prev_sort_dim >= -1);
     assert(rank >= 1 && rank <= H5S_MAX_RANK);
 
-    /* Compute the max/min bounds of the provided node */
-    /* Initial values */
-    for (int i = 0; i < rank; i++) {
-        node->min[i] = leaves[0].min[i];
-        node->max[i] = leaves[0].max[i];
-    }
-    /* Compute max/min from leaves */
-    for (size_t i = 0; i < count; i++) {
-        for (int d = 0; d < rank; d++) {
-            if (leaves[i].min[d] < node->min[d])
-                node->min[d] = leaves[i].min[d];
-            if (leaves[i].max[d] > node->max[d])
-                node->max[d] = leaves[i].max[d];
-        }
-    }
-
     if (count <= H5RT_MAX_NODE_SIZE) {
         /* Base Case - All leaves will fit into this node */
         node->nchildren           = (int)count;
         node->children_are_leaves = true;
         node->children.leaves     = leaves;
+
+        /* Compute the max/min bounds of the provided node using the values from the child leaves */
+        /* Initial values */
+        for (int i = 0; i < rank; i++) {
+            node->min[i] = leaves[0].min[i];
+            node->max[i] = leaves[0].max[i];
+        }
+        /* Compute max/min from leaves */
+        for (size_t i = 1; i < count; i++) {
+            for (int d = 0; d < rank; d++) {
+                if (leaves[i].min[d] < node->min[d])
+                    node->min[d] = leaves[i].min[d];
+                if (leaves[i].max[d] > node->max[d])
+                    node->max[d] = leaves[i].max[d];
+            }
+        }
     }
     else {
         /* Recursive case - there will be child nodes */
@@ -434,6 +434,22 @@ H5RT__bulk_load(H5RT_node_t *node, int rank, H5RT_leaf_t *leaves, size_t count, 
             /* The next 'child_leaf_count' leaves are now assigned */
             child_leaf_start += child_leaf_count;
             leaves_left -= child_leaf_count;
+
+            /* Compute the max/min bounds of the provided node using the values from the child nodes */
+            if (i == 0)
+                /* Initial values */
+                for (int d = 0; d < rank; d++) {
+                    node->min[d] = node->children.nodes[0]->min[d];
+                    node->max[d] = node->children.nodes[0]->max[d];
+                }
+            else
+                /* Compute max/min from child nodes */
+                for (int d = 0; d < rank; d++) {
+                    if (node->children.nodes[i]->min[d] < node->min[d])
+                        node->min[d] = node->children.nodes[i]->min[d];
+                    if (node->children.nodes[i]->max[d] > node->max[d])
+                        node->max[d] = node->children.nodes[i]->max[d];
+                }
         }
     }
 
@@ -527,9 +543,6 @@ H5RT__search_recurse(H5RT_node_t *node, int rank, hsize_t min[], hsize_t max[], 
 {
     hsize_t *curr_min = NULL;
     hsize_t *curr_max = NULL;
-
-    H5RT_leaf_t *curr_leaf = NULL;
-    H5RT_node_t *curr_node = NULL;
     herr_t       ret_value = SUCCEED;
 
     FUNC_ENTER_PACKAGE
@@ -538,9 +551,9 @@ H5RT__search_recurse(H5RT_node_t *node, int rank, hsize_t min[], hsize_t max[], 
     assert(result_set);
 
     /* Check all children for intersection */
-    for (int i = 0; i < node->nchildren; i++)
-        if (node->children_are_leaves) {
-            curr_leaf = node->children.leaves + i;
+    if (node->children_are_leaves)
+        for (int i = 0; i < node->nchildren; i++) {
+            H5RT_leaf_t *curr_leaf = node->children.leaves + i;
             curr_min  = curr_leaf->min;
             curr_max  = curr_leaf->max;
 
@@ -550,9 +563,10 @@ H5RT__search_recurse(H5RT_node_t *node, int rank, hsize_t min[], hsize_t max[], 
                     HGOTO_ERROR(H5E_RTREE, H5E_CANTALLOC, FAIL, "failed to add result to result set");
             }
         }
-        else {
+    else
+        for (int i = 0; i < node->nchildren; i++) {
             /* This is an internal node in the r-tree */
-            curr_node = node->children.nodes[i];
+            H5RT_node_t *curr_node = node->children.nodes[i];
             curr_min  = curr_node->min;
             curr_max  = curr_node->max;
 

--- a/src/H5RT.c
+++ b/src/H5RT.c
@@ -541,9 +541,9 @@ done:
 static herr_t
 H5RT__search_recurse(H5RT_node_t *node, int rank, hsize_t min[], hsize_t max[], H5RT_result_set_t *result_set)
 {
-    hsize_t *curr_min = NULL;
-    hsize_t *curr_max = NULL;
-    herr_t       ret_value = SUCCEED;
+    hsize_t *curr_min  = NULL;
+    hsize_t *curr_max  = NULL;
+    herr_t   ret_value = SUCCEED;
 
     FUNC_ENTER_PACKAGE
 
@@ -554,8 +554,8 @@ H5RT__search_recurse(H5RT_node_t *node, int rank, hsize_t min[], hsize_t max[], 
     if (node->children_are_leaves)
         for (int i = 0; i < node->nchildren; i++) {
             H5RT_leaf_t *curr_leaf = node->children.leaves + i;
-            curr_min  = curr_leaf->min;
-            curr_max  = curr_leaf->max;
+            curr_min               = curr_leaf->min;
+            curr_max               = curr_leaf->max;
 
             if (H5RT__leaves_intersect(rank, min, max, curr_min, curr_max)) {
                 /* We found an intersecting leaf, add it to the result set */
@@ -567,8 +567,8 @@ H5RT__search_recurse(H5RT_node_t *node, int rank, hsize_t min[], hsize_t max[], 
         for (int i = 0; i < node->nchildren; i++) {
             /* This is an internal node in the r-tree */
             H5RT_node_t *curr_node = node->children.nodes[i];
-            curr_min  = curr_node->min;
-            curr_max  = curr_node->max;
+            curr_min               = curr_node->min;
+            curr_max               = curr_node->max;
 
             /* Only recurse into child node if its bounding box overlaps with the search region */
             if (H5RT__leaves_intersect(rank, min, max, curr_min, curr_max)) {


### PR DESCRIPTION
Two optimizatins:

1. When bulk loading the rtree, instead of calculating the bounds of each node by iterating over all child leaf nodes (doing this even for nodes whose children aren't leaves), iterate only over direct children after child nodes are created. This does mean the bounds are invalid until later in the bulk loading process, but this info isn't currently used until search. If we change the bulk loading algorithm to need this info (for example when deciding on the dimension to split along). we may need to revert this change.
2. Split the loop in the search algorithm into one for when children are internal nodes and one when they are leaves. This avoids checking the children_are_leaves flag on every iteration.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Optimize R-tree bulk loading and search in `H5RT.c` by refining bounds calculation and splitting search loops.
> 
>   - **Bulk Loading Optimization**:
>     - In `H5RT__bulk_load()`, calculate node bounds by iterating over direct children after child nodes are created, instead of iterating over all child leaf nodes.
>     - Bounds are invalid until later in the bulk loading process, but this is acceptable as bounds are not used until search.
>   - **Search Optimization**:
>     - In `H5RT__search_recurse()`, split the loop into two: one for internal nodes and one for leaves, avoiding the need to check `children_are_leaves` flag on every iteration.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=HDFGroup%2Fhdf5&utm_source=github&utm_medium=referral)<sup> for 12f744e5699f9f8be0d44aa390373aef97e7653b. You can [customize](https://app.ellipsis.dev/HDFGroup/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->