### PR TITLE
Resolve VOL CI h5dump/h5repack failures

### DIFF
--- a/tools/test/h5dump/CMakeTests.cmake
+++ b/tools/test/h5dump/CMakeTests.cmake
@@ -1180,7 +1180,7 @@ ADD_H5_TEST (tattrcontents2 RESULT_CODE 0 --enable-error-stack -n 1 --sort_order
 # compact
 ADD_H5_TEST (tcompact RESULT_CODE 0 --enable-error-stack -H -p -d compact TARGET_FILE tfilters.h5)
 # contiguous
-ADD_H5_TEST (tcontiguos RESULT_CODE 0 --enable-error-stack -H -p -d contiguous TARGET_FILE tfilters.h5 APPLY_FILTERS 1)
+ADD_H5_TEST (tcontiguos RESULT_CODE 0 --enable-error-stack -H -p -d contiguous TARGET_FILE tfilters.h5)
 # chunked
 ADD_H5_TEST (tchunked RESULT_CODE 0 --enable-error-stack -H -p -d chunked TARGET_FILE tfilters.h5)
 # external
@@ -1296,7 +1296,7 @@ ADD_H5_TEST (tgrpnullspace RESULT_CODE 0 -p --enable-error-stack TARGET_FILE tgr
 ADD_H5_TEST (zerodim RESULT_CODE 0 --enable-error-stack TARGET_FILE zerodim.h5)
 
 # test for long double (some systems do not have long double)
-ADD_H5_TEST (tfloatsattrs RESULT_CODE 0 -p --format=%.4g --lformat=%.4Lg --width=80 --enable-error-stack TARGET_FILE tfloatsattrs.h5 APPLY_FILTERS 1)
+ADD_H5_TEST (tfloatsattrs RESULT_CODE 0 -p --format=%.4g --lformat=%.4Lg --width=80 --enable-error-stack TARGET_FILE tfloatsattrs.h5)
 ADD_H5_TEST (tldouble RESULT_CODE 0 --enable-error-stack TARGET_FILE tldouble.h5)
 ADD_H5_TEST (tldouble_scalar RESULT_CODE 0 -p --enable-error-stack TARGET_FILE tldouble_scalar.h5)
 
@@ -1340,13 +1340,13 @@ ADD_H5_TEST (tcomplex RESULT_CODE 0 --enable-error-stack -m %.6f -w80 -d ArrayDa
               -d VariableLengthDatasetFloatComplex TARGET_FILE tcomplex.h5)
 ADD_H5_TEST (tcomplex_info RESULT_CODE 0 --enable-error-stack -p -H -m %.6f -w80 -d ArrayDatasetFloatComplex
               -d CompoundDatasetFloatComplex -d DatasetDoubleComplex -d DatasetFloatComplex
-              -d VariableLengthDatasetFloatComplex TARGET_FILE tcomplex.h5 APPLY_FILTERS 1)
+              -d VariableLengthDatasetFloatComplex TARGET_FILE tcomplex.h5)
 ADD_H5_TEST (tcomplex_be RESULT_CODE 0 --enable-error-stack -m %.6f -w80 -d ArrayDatasetFloatComplex
               -d CompoundDatasetFloatComplex -d DatasetDoubleComplex -d DatasetFloatComplex
               -d VariableLengthDatasetFloatComplex TARGET_FILE tcomplex_be.h5)
 ADD_H5_TEST (tcomplex_be_info RESULT_CODE 0 --enable-error-stack -p -H -m %.6f -w80 -d ArrayDatasetFloatComplex
               -d CompoundDatasetFloatComplex -d DatasetDoubleComplex -d DatasetFloatComplex
-              -d VariableLengthDatasetFloatComplex TARGET_FILE tcomplex_be.h5 APPLY_FILTERS 1)
+              -d VariableLengthDatasetFloatComplex TARGET_FILE tcomplex_be.h5)
 
 # test for vms
 ADD_H5_TEST (tvms RESULT_CODE 0 --enable-error-stack TARGET_FILE tvms.h5)

--- a/tools/test/h5dump/CMakeTests.cmake
+++ b/tools/test/h5dump/CMakeTests.cmake
@@ -1124,7 +1124,8 @@ ADD_H5_TEST (tgrp_comments RESULT_CODE 0 --enable-error-stack TARGET_FILE tgrp_c
 # test the --filedriver flag
 ADD_H5_TEST (tsplit_file RESULT_CODE 0 --enable-error-stack --filedriver=split TARGET_FILE tsplit_file)
 ADD_H5_TEST (tfamily RESULT_CODE 0 --enable-error-stack --filedriver=family TARGET_FILE tfamily%05d.h5)
-ADD_H5_TEST (tmulti RESULT_CODE 0 --enable-error-stack --filedriver=multi TARGET_FILE tmulti)
+# Flagged as NATIVE_ONLY because the Cache VOL interacts badly with the multi VFD's EOA tracking
+ADD_H5_TEST (tmulti RESULT_CODE 0 --enable-error-stack --filedriver=multi TARGET_FILE tmulti NATIVE_ONLY)
 
 # test for files with group names which reach > 1024 bytes in size
 ADD_H5_TEST (tlarge_objname RESULT_CODE 0 --enable-error-stack -w157 TARGET_FILE tlarge_objname.h5)
@@ -1179,7 +1180,7 @@ ADD_H5_TEST (tattrcontents2 RESULT_CODE 0 --enable-error-stack -n 1 --sort_order
 # compact
 ADD_H5_TEST (tcompact RESULT_CODE 0 --enable-error-stack -H -p -d compact TARGET_FILE tfilters.h5)
 # contiguous
-ADD_H5_TEST (tcontiguos RESULT_CODE 0 --enable-error-stack -H -p -d contiguous TARGET_FILE tfilters.h5)
+ADD_H5_TEST (tcontiguos RESULT_CODE 0 --enable-error-stack -H -p -d contiguous TARGET_FILE tfilters.h5 APPLY_FILTERS 1)
 # chunked
 ADD_H5_TEST (tchunked RESULT_CODE 0 --enable-error-stack -H -p -d chunked TARGET_FILE tfilters.h5)
 # external
@@ -1295,7 +1296,7 @@ ADD_H5_TEST (tgrpnullspace RESULT_CODE 0 -p --enable-error-stack TARGET_FILE tgr
 ADD_H5_TEST (zerodim RESULT_CODE 0 --enable-error-stack TARGET_FILE zerodim.h5)
 
 # test for long double (some systems do not have long double)
-ADD_H5_TEST (tfloatsattrs RESULT_CODE 0 -p --format=%.4g --lformat=%.4Lg --width=80 --enable-error-stack TARGET_FILE tfloatsattrs.h5)
+ADD_H5_TEST (tfloatsattrs RESULT_CODE 0 -p --format=%.4g --lformat=%.4Lg --width=80 --enable-error-stack TARGET_FILE tfloatsattrs.h5 APPLY_FILTERS 1)
 ADD_H5_TEST (tldouble RESULT_CODE 0 --enable-error-stack TARGET_FILE tldouble.h5)
 ADD_H5_TEST (tldouble_scalar RESULT_CODE 0 -p --enable-error-stack TARGET_FILE tldouble_scalar.h5)
 
@@ -1339,13 +1340,13 @@ ADD_H5_TEST (tcomplex RESULT_CODE 0 --enable-error-stack -m %.6f -w80 -d ArrayDa
               -d VariableLengthDatasetFloatComplex TARGET_FILE tcomplex.h5)
 ADD_H5_TEST (tcomplex_info RESULT_CODE 0 --enable-error-stack -p -H -m %.6f -w80 -d ArrayDatasetFloatComplex
               -d CompoundDatasetFloatComplex -d DatasetDoubleComplex -d DatasetFloatComplex
-              -d VariableLengthDatasetFloatComplex TARGET_FILE tcomplex.h5)
+              -d VariableLengthDatasetFloatComplex TARGET_FILE tcomplex.h5 APPLY_FILTERS 1)
 ADD_H5_TEST (tcomplex_be RESULT_CODE 0 --enable-error-stack -m %.6f -w80 -d ArrayDatasetFloatComplex
               -d CompoundDatasetFloatComplex -d DatasetDoubleComplex -d DatasetFloatComplex
               -d VariableLengthDatasetFloatComplex TARGET_FILE tcomplex_be.h5)
 ADD_H5_TEST (tcomplex_be_info RESULT_CODE 0 --enable-error-stack -p -H -m %.6f -w80 -d ArrayDatasetFloatComplex
               -d CompoundDatasetFloatComplex -d DatasetDoubleComplex -d DatasetFloatComplex
-              -d VariableLengthDatasetFloatComplex TARGET_FILE tcomplex_be.h5)
+              -d VariableLengthDatasetFloatComplex TARGET_FILE tcomplex_be.h5 APPLY_FILTERS 1)
 
 # test for vms
 ADD_H5_TEST (tvms RESULT_CODE 0 --enable-error-stack TARGET_FILE tvms.h5)

--- a/tools/test/h5dump/h5dumpgentest.c
+++ b/tools/test/h5dump/h5dumpgentest.c
@@ -5725,10 +5725,11 @@ make_external(hid_t fid)
 void
 gent_filters(void)
 {
-    hid_t fid;  /* file id */
-    hid_t dcpl; /* dataset creation property list */
-    hid_t sid;  /* dataspace ID */
-    hid_t tid;  /* datatype ID */
+    hid_t fid;     /* file id */
+    hid_t dcpl;    /* dataset creation property list */
+    hid_t sid;     /* dataspace ID */
+    hid_t tid;     /* datatype ID */
+    hid_t fapl_id; /* file access property list */
 #ifdef H5_HAVE_FILTER_SZIP
     unsigned szip_options_mask     = H5_SZIP_ALLOW_K13_OPTION_MASK | H5_SZIP_NN_OPTION_MASK;
     unsigned szip_pixels_per_block = 4;
@@ -5746,8 +5747,14 @@ gent_filters(void)
         }
     }
 
+    fapl_id = H5Pcreate(H5P_FILE_ACCESS);
+    assert(fapl_id >= 0);
+
+    ret = H5Pset_libver_bounds(fapl_id, H5F_LIBVER_EARLIEST, H5F_LIBVER_LATEST);
+    assert(ret >= 0);
+
     /* create a file */
-    fid = H5Fcreate(FILE44, H5F_ACC_TRUNC, H5P_DEFAULT, H5P_DEFAULT);
+    fid = H5Fcreate(FILE44, H5F_ACC_TRUNC, H5P_DEFAULT, fapl_id);
     assert(fid >= 0);
 
     /* Check if we support comments in the current VOL connector */
@@ -6028,6 +6035,9 @@ gent_filters(void)
     assert(ret >= 0);
 
     ret = H5Pclose(dcpl);
+    assert(ret >= 0);
+
+    ret = H5Pclose(fapl_id);
     assert(ret >= 0);
 
     ret = H5Fclose(fid);
@@ -11186,6 +11196,7 @@ void
 gent_floatsattrs(void)
 {
     hid_t   fid     = H5I_INVALID_HID;
+    hid_t   fapl_id = H5I_INVALID_HID;
     hid_t   tid     = H5I_INVALID_HID;
     hid_t   attr    = H5I_INVALID_HID;
     hid_t   dataset = H5I_INVALID_HID;
@@ -11222,7 +11233,11 @@ gent_floatsattrs(void)
     aset64  = calloc(F89_XDIM * F89_YDIM64, sizeof(double));
     aset128 = calloc(F89_XDIM * F89_YDIM128, sizeof(long double));
 
-    fid = H5Fcreate(FILE89, H5F_ACC_TRUNC, H5P_DEFAULT, H5P_DEFAULT);
+    fapl_id = H5Pcreate(H5P_FILE_ACCESS);
+
+    H5Pset_libver_bounds(fapl_id, H5F_LIBVER_EARLIEST, H5F_LIBVER_LATEST);
+
+    fid = H5Fcreate(FILE89, H5F_ACC_TRUNC, H5P_DEFAULT, fapl_id);
 
     if ((tid = H5Tcopy(H5T_NATIVE_FLOAT)) < 0)
         goto error;
@@ -11319,6 +11334,7 @@ gent_floatsattrs(void)
     H5Sclose(aspace);
     H5Sclose(space);
     H5Dclose(dataset);
+    H5Pclose(fapl_id);
 
 error:
     H5Fclose(fid);
@@ -13028,6 +13044,7 @@ gent_complex(void)
     hsize_t            varlen_dims[1] = {F95_XDIM};
     hsize_t            single_dims[2] = {1, 1};
     hid_t              fid            = H5I_INVALID_HID;
+    hid_t              fapl_id        = H5I_INVALID_HID;
     hid_t              dcpl_id        = H5I_INVALID_HID;
     hid_t              tid            = H5I_INVALID_HID;
     hid_t              complex_tid    = H5I_INVALID_HID;
@@ -13054,7 +13071,11 @@ gent_complex(void)
         hvl_t arr[F95_XDIM];
     } *dset_var_fc;
 
-    fid = H5Fcreate(FILE95, H5F_ACC_TRUNC, H5P_DEFAULT, H5P_DEFAULT);
+    fapl_id = H5Pcreate(H5P_FILE_ACCESS);
+
+    H5Pset_libver_bounds(fapl_id, H5F_LIBVER_EARLIEST, H5F_LIBVER_LATEST);
+
+    fid = H5Fcreate(FILE95, H5F_ACC_TRUNC, H5P_DEFAULT, fapl_id);
 
     dims[0] = F95_XDIM;
     dims[1] = F95_YDIM;
@@ -13275,6 +13296,7 @@ gent_complex(void)
     H5Dclose(dataset);
 
     H5Sclose(space);
+    H5Pclose(fapl_id);
     H5Fclose(fid);
 }
 
@@ -13291,6 +13313,7 @@ gent_complex_be(void)
     hsize_t            varlen_dims[1] = {F96_XDIM};
     hsize_t            single_dims[2] = {1, 1};
     hid_t              fid            = H5I_INVALID_HID;
+    hid_t              fapl_id        = H5I_INVALID_HID;
     hid_t              dcpl_id        = H5I_INVALID_HID;
     hid_t              tid            = H5I_INVALID_HID;
     hid_t              complex_tid    = H5I_INVALID_HID;
@@ -13317,7 +13340,11 @@ gent_complex_be(void)
         hvl_t arr[F96_XDIM];
     } *dset_var_fc;
 
-    fid = H5Fcreate(FILE96, H5F_ACC_TRUNC, H5P_DEFAULT, H5P_DEFAULT);
+    fapl_id = H5Pcreate(H5P_FILE_ACCESS);
+
+    H5Pset_libver_bounds(fapl_id, H5F_LIBVER_EARLIEST, H5F_LIBVER_LATEST);
+
+    fid = H5Fcreate(FILE96, H5F_ACC_TRUNC, H5P_DEFAULT, fapl_id);
 
     dims[0] = F96_XDIM;
     dims[1] = F96_YDIM;
@@ -13534,6 +13561,7 @@ gent_complex_be(void)
     H5Dclose(dataset);
 
     H5Sclose(space);
+    H5Pclose(fapl_id);
     H5Fclose(fid);
 }
 #endif

--- a/tools/test/h5dump/h5dumpgentest.c
+++ b/tools/test/h5dump/h5dumpgentest.c
@@ -6087,15 +6087,23 @@ set_local_myfilter(hid_t dcpl_id, hid_t H5_ATTR_UNUSED tid, hid_t H5_ATTR_UNUSED
 void
 gent_fcontents(void)
 {
-    hid_t                     fid;  /* file id */
-    hid_t                     gid1; /* group ID */
-    hid_t                     tid;  /* datatype ID */
+    hid_t                     fid;     /* file id */
+    hid_t                     gid1;    /* group ID */
+    hid_t                     tid;     /* datatype ID */
+    hid_t                     fapl_id; /* file access property list */
     hsize_t                   dims[1] = {4};
     int                       buf[4]  = {1, 2, 3, 4};
     int H5_ATTR_NDEBUG_UNUSED ret;
 
+    fapl_id = H5Pcreate(H5P_FILE_ACCESS);
+    assert(fapl_id >= 0);
+
+    /* reference file has superblock version 0 */
+    ret = H5Pset_libver_bounds(fapl_id, H5F_LIBVER_EARLIEST, H5F_LIBVER_LATEST);
+    assert(ret >= 0);
+
     /* create a file */
-    fid = H5Fcreate(FILE46, H5F_ACC_TRUNC, H5P_DEFAULT, H5P_DEFAULT);
+    fid = H5Fcreate(FILE46, H5F_ACC_TRUNC, H5P_DEFAULT, fapl_id);
     assert(fid >= 0);
 
     write_dset(fid, 1, dims, "dset", H5T_STD_I32BE, H5T_NATIVE_INT, buf);
@@ -6173,10 +6181,13 @@ gent_fcontents(void)
     assert(ret >= 0);
 
     /* create a file for the bootblock test */
-    fid = H5Fcreate(FILE47, H5F_ACC_TRUNC, H5P_DEFAULT, H5P_DEFAULT);
+    fid = H5Fcreate(FILE47, H5F_ACC_TRUNC, H5P_DEFAULT, fapl_id);
     assert(fid >= 0);
 
     ret = H5Fclose(fid);
+    assert(ret >= 0);
+
+    ret = H5Pclose(fapl_id);
     assert(ret >= 0);
 }
 

--- a/tools/test/h5repack/h5repackgentest.c
+++ b/tools/test/h5repack/h5repackgentest.c
@@ -5781,6 +5781,7 @@ gen_filespaces(void)
 {
     hid_t                 fid  = H5I_INVALID_HID; /* File ID */
     hid_t                 fcpl = H5I_INVALID_HID; /* File creation property list */
+    hid_t                 fapl = H5I_INVALID_HID; /* File access property list */
     hid_t                 did  = H5I_INVALID_HID; /* Dataset ID */
     hid_t                 sid  = H5I_INVALID_HID; /* Dataspace ID */
     hsize_t               dim[1];                 /* Dimension sizes */
@@ -5801,11 +5802,17 @@ gen_filespaces(void)
             if ((fcpl = H5Pcreate(H5P_FILE_CREATE)) < 0)
                 goto error;
 
+            if ((fapl = H5Pcreate(H5P_FILE_ACCESS)) < 0)
+                goto error;
+
+            if ((H5Pset_libver_bounds(fapl, H5F_LIBVER_EARLIEST, H5F_LIBVER_LATEST)) < 0)
+                goto error;
+
             if (H5Pset_file_space_strategy(fcpl, fs_strategy, fs_persist, (hsize_t)1) < 0)
                 goto error;
 
             /* Create the file with the file space info */
-            if ((fid = H5Fcreate(FILENAMES[j], H5F_ACC_TRUNC, fcpl, H5P_DEFAULT)) < 0)
+            if ((fid = H5Fcreate(FILENAMES[j], H5F_ACC_TRUNC, fcpl, fapl)) < 0)
                 goto error;
 
             /* Create the dataset */
@@ -5832,6 +5839,8 @@ gen_filespaces(void)
                 goto error;
             if (H5Pclose(fcpl) < 0)
                 goto error;
+            if (H5Pclose(fapl) < 0)
+                goto error;
             ++j;
         }
     }
@@ -5845,6 +5854,7 @@ error:
         H5Sclose(sid);
         H5Sclose(did);
         H5Pclose(fcpl);
+        H5Pclose(fapl);
         H5Fclose(fid);
     }
     H5E_END_TRY


### PR DESCRIPTION
Most of the failures are due to the default file format change not being accounted for in the gentest routines, leading to the tests creating 1.8 files and comparing them against the earliest format files. This changes the tests to specifically generate earliest format files again. 
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fix VOL CI failures by setting library version bounds in `h5dump` and `h5repack` tests to generate earliest format files.
> 
>   - **Behavior**:
>     - Modify `gent_filters()`, `gent_fcontents()`, `gent_floatsattrs()`, `gent_complex()`, and `gent_complex_be()` in `h5dumpgentest.c` to set file access property list with `H5F_LIBVER_EARLIEST` and `H5F_LIBVER_LATEST`.
>     - Update `gen_filespaces()` in `h5repackgentest.c` to set library version bounds for file access property list.
>   - **Tests**:
>     - Add `NATIVE_ONLY` flag to `tmulti` test in `CMakeTests.cmake` due to Cache VOL interaction issues.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=HDFGroup%2Fhdf5&utm_source=github&utm_medium=referral)<sup> for 6b5126b4bc4e0a57cff55f6c9873dfb523fe16d0. You can [customize](https://app.ellipsis.dev/HDFGroup/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->