### PR TITLE
Fix CMake C99 complex detection cache pollution

### DIFF
--- a/config/ConfigureChecks.cmake
+++ b/config/ConfigureChecks.cmake
@@ -939,14 +939,19 @@ if (${HDF_PREFIX}_HAVE_COMPLEX_H)
       HDF_FUNCTION_TEST (HAVE_COMPLEX_NUMBERS)
 
       if (H5_HAVE_COMPLEX_NUMBERS)
-        # Determine if we're using C99 or MSVC types based on which types were detected
-        # This is deterministic: if MSVC-specific type sizes exist, we're using MSVC types
-        if (${HDF_PREFIX}_SIZEOF__FCOMPLEX)
-          set (H5_HAVE_C99_COMPLEX_NUMBERS 0)
-          message (STATUS "Using MSVC complex number types")
-        else ()
+        # Test if we can actually use C99 complex syntax
+        # This test explicitly tries float _Complex, double _Complex, and long double _Complex
+        # with C99 operations. If this passes, we prefer C99 regardless of whether MSVC
+        # types also exist (for forward compatibility if MSVC adds C99 support in the future)
+        HDF_FUNCTION_TEST (HAVE_C99_COMPLEX_SYNTAX)
+
+        if (H5_HAVE_C99_COMPLEX_SYNTAX)
           set (H5_HAVE_C99_COMPLEX_NUMBERS 1)
           message (STATUS "Using C99 complex number types")
+        else ()
+          # C99 syntax test failed, so we must be using MSVC types
+          set (H5_HAVE_C99_COMPLEX_NUMBERS 0)
+          message (STATUS "Using MSVC complex number types")
         endif ()
       else ()
         message (STATUS "Complex number support has been disabled since a simple test program couldn't be compiled and linked")

--- a/config/ConfigureChecks.cmake
+++ b/config/ConfigureChecks.cmake
@@ -893,14 +893,16 @@ endmacro ()
 message (STATUS "Checking if complex number support is available")
 CHECK_INCLUDE_FILE (complex.h ${HDF_PREFIX}_HAVE_COMPLEX_H)
 if (${HDF_PREFIX}_HAVE_COMPLEX_H)
-  set (H5_HAVE_C99_COMPLEX_NUMBERS 1)
-
+  # Try standard C99 complex types first
   HDF_CHECK_TYPE_SIZE ("float _Complex" ${HDF_PREFIX}_SIZEOF_FLOAT_COMPLEX)
   HDF_CHECK_TYPE_SIZE ("double _Complex" ${HDF_PREFIX}_SIZEOF_DOUBLE_COMPLEX)
   HDF_CHECK_TYPE_SIZE ("long double _Complex" ${HDF_PREFIX}_SIZEOF_LONG_DOUBLE_COMPLEX)
 
-  if (MSVC AND NOT ${HDF_PREFIX}_SIZEOF_FLOAT_COMPLEX AND NOT ${HDF_PREFIX}_SIZEOF_DOUBLE_COMPLEX
-      AND NOT ${HDF_PREFIX}_SIZEOF_LONG_DOUBLE_COMPLEX)
+  # MSVC fallback: only runs if ALL standard types failed
+  if (MSVC AND
+      (NOT ${HDF_PREFIX}_SIZEOF_FLOAT_COMPLEX) AND
+      (NOT ${HDF_PREFIX}_SIZEOF_DOUBLE_COMPLEX) AND
+      (NOT ${HDF_PREFIX}_SIZEOF_LONG_DOUBLE_COMPLEX))
     # If using MSVC, the _Complex types (if available) are _Fcomplex, _Dcomplex and _Lcomplex.
     # The standard types are checked for first in case MSVC uses them in the future or in case
     # the compiler used is simulating MSVC and uses the standard types.
@@ -910,20 +912,23 @@ if (${HDF_PREFIX}_HAVE_COMPLEX_H)
     HDF_CHECK_TYPE_SIZE ("_Dcomplex" ${HDF_PREFIX}_SIZEOF__DCOMPLEX)
     HDF_CHECK_TYPE_SIZE ("_Lcomplex" ${HDF_PREFIX}_SIZEOF__LCOMPLEX)
     cmake_pop_check_state ()
-    if (${HDF_PREFIX}_SIZEOF__FCOMPLEX AND ${HDF_PREFIX}_SIZEOF__DCOMPLEX AND
-        ${HDF_PREFIX}_SIZEOF__FCOMPLEX)
+
+    # If MSVC types succeeded, alias them to standard names for uniform handling
+    if (${HDF_PREFIX}_SIZEOF__FCOMPLEX AND
+        ${HDF_PREFIX}_SIZEOF__DCOMPLEX AND
+        ${HDF_PREFIX}_SIZEOF__LCOMPLEX)
       set (${HDF_PREFIX}_SIZEOF_FLOAT_COMPLEX ${${HDF_PREFIX}_SIZEOF__FCOMPLEX}
            CACHE INTERNAL "SizeOf for float _Complex" FORCE)
       set (${HDF_PREFIX}_SIZEOF_DOUBLE_COMPLEX ${${HDF_PREFIX}_SIZEOF__DCOMPLEX}
            CACHE INTERNAL "SizeOf for double _Complex" FORCE)
       set (${HDF_PREFIX}_SIZEOF_LONG_DOUBLE_COMPLEX ${${HDF_PREFIX}_SIZEOF__LCOMPLEX}
            CACHE INTERNAL "SizeOf for long double _Complex" FORCE)
-
-      unset (H5_HAVE_C99_COMPLEX_NUMBERS)
     endif ()
   endif ()
 
-  if (${HDF_PREFIX}_SIZEOF_FLOAT_COMPLEX AND ${HDF_PREFIX}_SIZEOF_DOUBLE_COMPLEX AND
+  # Now check if we have ALL THREE types (regardless of which variant)
+  if (${HDF_PREFIX}_SIZEOF_FLOAT_COMPLEX AND
+      ${HDF_PREFIX}_SIZEOF_DOUBLE_COMPLEX AND
       ${HDF_PREFIX}_SIZEOF_LONG_DOUBLE_COMPLEX)
     # Check if __STDC_NO_COMPLEX__ macro is defined, in which case complex number
     # support is not available
@@ -934,10 +939,14 @@ if (${HDF_PREFIX}_HAVE_COMPLEX_H)
       HDF_FUNCTION_TEST (HAVE_COMPLEX_NUMBERS)
 
       if (H5_HAVE_COMPLEX_NUMBERS)
-        if (H5_HAVE_C99_COMPLEX_NUMBERS)
-          message (STATUS "Using C99 complex number types")
-        else ()
+        # Determine if we're using C99 or MSVC types based on which types were detected
+        # This is deterministic: if MSVC-specific type sizes exist, we're using MSVC types
+        if (${HDF_PREFIX}_SIZEOF__FCOMPLEX)
+          set (H5_HAVE_C99_COMPLEX_NUMBERS 0)
           message (STATUS "Using MSVC complex number types")
+        else ()
+          set (H5_HAVE_C99_COMPLEX_NUMBERS 1)
+          message (STATUS "Using C99 complex number types")
         endif ()
       else ()
         message (STATUS "Complex number support has been disabled since a simple test program couldn't be compiled and linked")

--- a/config/HDFTests.c
+++ b/config/HDFTests.c
@@ -108,6 +108,35 @@ main(void)
 #endif
 #endif
 
+#ifdef HAVE_C99_COMPLEX_SYNTAX
+/* Test specifically for C99 complex syntax support */
+#include <complex.h>
+
+int
+main(void)
+{
+    /* Try to use C99 complex types directly */
+    float _Complex fc = 1.0f + 2.0f * I;
+    double _Complex dc = 3.0 + 4.0 * I;
+    long double _Complex ldc = 5.0L + 6.0L * I;
+
+    /* Test arithmetic operations */
+    fc = fc + (1.0f + 1.0f * I);
+    dc = dc * (2.0 + 0.0 * I);
+    ldc = ldc - (1.0L + 1.0L * I);
+
+    /* Test standard functions */
+    float r1 = crealf(fc);
+    float i1 = cimagf(fc);
+    double r2 = creal(dc);
+    double i2 = cimag(dc);
+    long double r3 = creall(ldc);
+    long double i3 = cimagl(ldc);
+
+    return ((r1 > 0) && (i1 > 0) && (r2 > 0) && (i2 > 0) && (r3 > 0) && (i3 > 0)) ? 0 : 1;
+}
+#endif
+
 #ifdef HAVE_COMPLEX_NUMBERS
 #include <complex.h>
 


### PR DESCRIPTION
Remove premature flag assignment and derive H5_HAVE_C99_COMPLEX_NUMBERS
deterministically from cached type sizes instead of caching the flag.
Fixes re-configuration failures and eliminates cache pollution.

Also fixes typo checking _FCOMPLEX twice instead of _LCOMPLEX.

Fixes #6051
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fix C99 complex detection in `ConfigureChecks.cmake` by removing premature flag assignment and fixing MSVC type check typo.
> 
>   - **Behavior**:
>     - Remove premature assignment of `H5_HAVE_C99_COMPLEX_NUMBERS` in `ConfigureChecks.cmake`.
>     - Derive `H5_HAVE_C99_COMPLEX_NUMBERS` from cached type sizes instead of caching the flag.
>     - Fixes re-configuration failures and eliminates cache pollution.
>   - **Bug Fixes**:
>     - Fix typo in MSVC complex type check: check `_LCOMPLEX` instead of `_FCOMPLEX` twice.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=HDFGroup%2Fhdf5&utm_source=github&utm_medium=referral)<sup> for f7b377f90052ddc7f6f7897ecb7191a8a58cf039. You can [customize](https://app.ellipsis.dev/HDFGroup/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->