### PR TITLE
Updated current release in README files

### DIFF
--- a/HDF5Examples/README.md
+++ b/HDF5Examples/README.md
@@ -73,11 +73,12 @@ Periodically development code snapshots are provided at the following URL:
 
 Source packages for current and previous releases are located at:
 
-   hdf5 1.14 releases:
-   https://support.hdfgroup.org/releases/hdf5/v1_14/index.html
+   hdf5 2.0 releases:
+   https://support.hdfgroup.org/releases/hdf5/v2_0/index.html
 
    Archived releases:
-   https://support.hdfgroup.org/archive/support/ftp/HDF5/releases/index.html
+   https://support.hdfgroup.org/releases/hdf5/v1_14/index.html (1.14 releases)
+   https://support.hdfgroup.org/archive/support/ftp/HDF5/releases/index.html (prior to 1.14)
 
 Development code is available at our Github location:
 

--- a/HDF5Examples/README.md
+++ b/HDF5Examples/README.md
@@ -73,8 +73,10 @@ Periodically development code snapshots are provided at the following URL:
 
 Source packages for current and previous releases are located at:
 
-   hdf5 2.0 releases:
-   https://support.hdfgroup.org/releases/hdf5/v2_0/index.html
+   hdf5 2.0.0 release:
+   [hdf5-2.0.0.tar.gz](https://github.com/HDFGroup/hdf5/releases/download/2.0.0/hdf5-2.0.0.tar.gz)
+   or [hdf5-2.0.0.zip](https://github.com/HDFGroup/hdf5/releases/download/2.0.0/hdf5-2.0.0.zip),
+   or [browse release files](https://github.com/HDFGroup/hdf5/releases).
 
    Archived releases:
    https://support.hdfgroup.org/releases/hdf5/v1_14/index.html (1.14 releases)

--- a/HDF5Examples/README.md
+++ b/HDF5Examples/README.md
@@ -73,7 +73,7 @@ Periodically development code snapshots are provided at the following URL:
 
 Source packages for current and previous releases are located at:
 
-   hdf5 2.0.0 release:
+   HDF5 2.0.0 release:
    [hdf5-2.0.0.tar.gz](https://github.com/HDFGroup/hdf5/releases/download/2.0.0/hdf5-2.0.0.tar.gz)
    or [hdf5-2.0.0.zip](https://github.com/HDFGroup/hdf5/releases/download/2.0.0/hdf5-2.0.0.zip),
    or [browse release files](https://github.com/HDFGroup/hdf5/releases).

--- a/HDF5Examples/README.md
+++ b/HDF5Examples/README.md
@@ -73,14 +73,8 @@ Periodically development code snapshots are provided at the following URL:
 
 Source packages for current and previous releases are located at:
 
-   HDF5 2.0.0 release:
-   [hdf5-2.0.0.tar.gz](https://github.com/HDFGroup/hdf5/releases/download/2.0.0/hdf5-2.0.0.tar.gz)
-   or [hdf5-2.0.0.zip](https://github.com/HDFGroup/hdf5/releases/download/2.0.0/hdf5-2.0.0.zip),
-   or [browse release files](https://github.com/HDFGroup/hdf5/releases).
-
-   Archived releases:
-   https://support.hdfgroup.org/releases/hdf5/v1_14/index.html (1.14 releases)
-   https://support.hdfgroup.org/archive/support/ftp/HDF5/releases/index.html (prior to 1.14)
+   [Latest HDF5 release](https://github.com/HDFGroup/hdf5/releases)
+   [Previous releases](https://support.hdfgroup.org/archive/support/ftp/HDF5/releases/index.html)
 
 Development code is available at our Github location:
 

--- a/README.md
+++ b/README.md
@@ -117,11 +117,12 @@ Periodically development code snapshots are provided at the following URL:
 
 Source packages for current and previous releases are located at:
 
-   hdf5 1.14 releases:
-   https://support.hdfgroup.org/releases/hdf5/v1_14/index.html
+   hdf5 2.0 releases:
+   https://support.hdfgroup.org/releases/hdf5/v2_0/index.html
 
    Archived releases:
-   https://support.hdfgroup.org/archive/support/ftp/HDF5/releases/index.html
+   https://support.hdfgroup.org/releases/hdf5/v1_14/index.html (1.14 releases)
+   https://support.hdfgroup.org/archive/support/ftp/HDF5/releases/index.html (prior to 1.14)
 
 Maven artifacts for Java bindings and examples are available at:
 

--- a/README.md
+++ b/README.md
@@ -117,14 +117,8 @@ Periodically development code snapshots are provided at the following URL:
 
 Source packages for current and previous releases are located at:
 
-   HDF5 2.0.0 release:
-   [hdf5-2.0.0.tar.gz](https://github.com/HDFGroup/hdf5/releases/download/2.0.0/hdf5-2.0.0.tar.gz)
-   or [hdf5-2.0.0.zip](https://github.com/HDFGroup/hdf5/releases/download/2.0.0/hdf5-2.0.0.zip),
-   or [browse release files](https://github.com/HDFGroup/hdf5/releases).
-
-   Archived releases:
-   https://support.hdfgroup.org/releases/hdf5/v1_14/index.html (1.14 releases)
-   https://support.hdfgroup.org/archive/support/ftp/HDF5/releases/index.html (prior to 1.14)
+   [Latest HDF5 release](https://github.com/HDFGroup/hdf5/releases)
+   [Previous releases](https://support.hdfgroup.org/archive/support/ftp/HDF5/releases/index.html)
 
 Maven artifacts for Java bindings and examples are available at:
 

--- a/README.md
+++ b/README.md
@@ -117,8 +117,10 @@ Periodically development code snapshots are provided at the following URL:
 
 Source packages for current and previous releases are located at:
 
-   hdf5 2.0 releases:
-   https://support.hdfgroup.org/releases/hdf5/v2_0/index.html
+   hdf5 2.0.0 release:
+   [hdf5-2.0.0.tar.gz](https://github.com/HDFGroup/hdf5/releases/download/2.0.0/hdf5-2.0.0.tar.gz)
+   or [hdf5-2.0.0.zip](https://github.com/HDFGroup/hdf5/releases/download/2.0.0/hdf5-2.0.0.zip),
+   or [browse release files](https://github.com/HDFGroup/hdf5/releases).
 
    Archived releases:
    https://support.hdfgroup.org/releases/hdf5/v1_14/index.html (1.14 releases)

--- a/README.md
+++ b/README.md
@@ -117,7 +117,7 @@ Periodically development code snapshots are provided at the following URL:
 
 Source packages for current and previous releases are located at:
 
-   hdf5 2.0.0 release:
+   HDF5 2.0.0 release:
    [hdf5-2.0.0.tar.gz](https://github.com/HDFGroup/hdf5/releases/download/2.0.0/hdf5-2.0.0.tar.gz)
    or [hdf5-2.0.0.zip](https://github.com/HDFGroup/hdf5/releases/download/2.0.0/hdf5-2.0.0.zip),
    or [browse release files](https://github.com/HDFGroup/hdf5/releases).


### PR DESCRIPTION
- Updated current release to 2.0 series
- Temporarily provided the url for 1.14 series until https://support.hdfgroup.org/ftp/HDF5/releases/index.html is fixed to include 1.14 (#6071)
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Updated README files to reflect the 2.0 release and temporarily added URL for 1.14 series.
> 
>   - **Behavior**:
>     - Updated current release to 2.0 series in `README.md` and `HDF5Examples/README.md`.
>     - Temporarily added URL for 1.14 series in both README files until the official site is updated.
>   - **Misc**:
>     - Adjusted archived release URLs in `README.md` and `HDF5Examples/README.md` to include 1.14 series.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=HDFGroup%2Fhdf5&utm_source=github&utm_medium=referral)<sup> for 846abf77b3a243b9f5fc1a7b51d6bcbb78de6bcb. You can [customize](https://app.ellipsis.dev/HDFGroup/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->