### PR TITLE
Fix checking of HDF5_VOL_CONNECTOR env. var. in some tests

### DIFF
--- a/test/API/H5_api_test.c
+++ b/test/API/H5_api_test.c
@@ -208,7 +208,9 @@ main(int argc, char **argv)
 
     snprintf(H5_api_test_filename, H5_API_TEST_FILENAME_MAX_LENGTH, "%s%s", test_path_prefix, TEST_FILE_NAME);
 
-    if (NULL == (vol_connector_string = getenv(HDF5_VOL_CONNECTOR))) {
+    vol_connector_string = getenv(HDF5_VOL_CONNECTOR);
+
+    if (!vol_connector_string || *vol_connector_string == '\0') {
         printf("No VOL connector selected; using native VOL connector\n");
         vol_connector_name = "native";
         vol_connector_info = NULL;

--- a/test/vol.c
+++ b/test/vol.c
@@ -2047,7 +2047,7 @@ test_async_vol_props(void)
 
     /* Override possible environment variable & re-initialize default VOL connector */
     conn_env_str = getenv(HDF5_VOL_CONNECTOR);
-    if (conn_env_str) {
+    if (conn_env_str && *conn_env_str) {
         if (NULL == (conn_env_str = strdup(conn_env_str)))
             TEST_ERROR;
         if (HDunsetenv(HDF5_VOL_CONNECTOR) < 0)
@@ -2292,7 +2292,7 @@ test_get_vol_name(void)
     TESTING("getting connector name");
 
     conn_env_str = getenv(HDF5_VOL_CONNECTOR);
-    if (NULL == (conn_env_str = getenv("HDF5_VOL_CONNECTOR")))
+    if (!conn_env_str || *conn_env_str == '\0')
         conn_env_str = "native";
 
     /* Skip the connectors other than the native and pass_through connector */

--- a/testpar/API/H5_api_test_parallel.c
+++ b/testpar/API/H5_api_test_parallel.c
@@ -296,7 +296,9 @@ main(int argc, char **argv)
     snprintf(H5_api_test_parallel_filename, H5_API_TEST_FILENAME_MAX_LENGTH, "%s%s", test_path_prefix,
              PARALLEL_TEST_FILE_NAME);
 
-    if (NULL == (vol_connector_string = getenv(HDF5_VOL_CONNECTOR))) {
+    vol_connector_string = getenv(HDF5_VOL_CONNECTOR);
+
+    if (!vol_connector_string || *vol_connector_string == '\0') {
         if (MAINPROCESS)
             printf("No VOL connector selected; using native VOL connector\n");
         vol_connector_name = "native";


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Fix handling of `HDF5_VOL_CONNECTOR` in tests to check for null and empty string, defaulting to native VOL connector if unset or empty.
> 
>   - **Behavior**:
>     - Fix handling of `HDF5_VOL_CONNECTOR` in `main()` in `H5_api_test.c` and `H5_api_test_parallel.c` to check for both null and empty string.
>     - Update `test_async_vol_props()` and `test_get_vol_name()` in `vol.c` to check for empty `HDF5_VOL_CONNECTOR` string.
>   - **Misc**:
>     - Ensure tests default to native VOL connector if `HDF5_VOL_CONNECTOR` is unset or empty.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=HDFGroup%2Fhdf5&utm_source=github&utm_medium=referral)<sup> for cea993b5823f214c15b33fa9f7c1fd147313e841. You can [customize](https://app.ellipsis.dev/HDFGroup/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->