### PR TITLE
fixes the GitHub Actions CPack failure on macOS

### DIFF
--- a/.github/workflows/arm-main.yml
+++ b/.github/workflows/arm-main.yml
@@ -380,8 +380,19 @@ jobs:
         working-directory: ${{ runner.workspace }}/build
 
       - name: Run Package
-        run: cpack -C ${{ inputs.build_mode }} -V
+        run: |
+          # Clean any stale mounts
+          for vol in /Volumes/HDF5*; do
+            [ -d "$vol" ] && hdiutil detach "$vol" -force || true
+          done
+
+          # Disable indexing
+          sudo mdutil -i off / || true
+
+          # Run cpack with retry
+          cpack -C ${{ inputs.build_mode }} -V || (sleep 5 && cpack -C ${{ inputs.build_mode }} -V)
         working-directory: ${{ runner.workspace }}/build
+        shell: bash
 
       - name: List files in the space
         run: |

--- a/.github/workflows/arm-main.yml
+++ b/.github/workflows/arm-main.yml
@@ -381,12 +381,7 @@ jobs:
 
       - name: Run Package
         run: |
-          # Clean any stale mounts
-          for vol in /Volumes/HDF5*; do
-            [ -d "$vol" ] && hdiutil detach "$vol" -force || true
-          done
-
-          # Disable indexing
+          # Disable indexing to prevent file locking during CPack
           sudo mdutil -i off / || true
 
           # Run cpack with retry

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -308,8 +308,23 @@ jobs:
         if: ${{ matrix.run_tests }}
 
       - name: Run Package
-        run: cpack -C ${{ inputs.build_mode }} -V
+        run: |
+          if [[ "${{ matrix.ostype }}" == "macos" ]]; then
+            # Clean any stale mounts
+            for vol in /Volumes/HDF5*; do
+              [ -d "$vol" ] && hdiutil detach "$vol" -force || true
+            done
+
+            # Disable indexing
+            sudo mdutil -i off / || true
+
+            # Run cpack with retry
+            cpack -C ${{ inputs.build_mode }} -V || (sleep 5 && cpack -C ${{ inputs.build_mode }} -V)
+          else
+            cpack -C ${{ inputs.build_mode }} -V
+          fi
         working-directory: ${{ runner.workspace }}/build
+        shell: bash
 #        if: ${{ (matrix.ostype != 'macos') && (inputs.build_mode != 'Debug') }}
 
 #      - name: Run Package (Mac_latest)

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -310,12 +310,7 @@ jobs:
       - name: Run Package
         run: |
           if [[ "${{ matrix.ostype }}" == "macos" ]]; then
-            # Clean any stale mounts
-            for vol in /Volumes/HDF5*; do
-              [ -d "$vol" ] && hdiutil detach "$vol" -force || true
-            done
-
-            # Disable indexing
+            # Disable indexing to prevent file locking during CPack
             sudo mdutil -i off / || true
 
             # Run cpack with retry

--- a/.github/workflows/maven-staging.yml
+++ b/.github/workflows/maven-staging.yml
@@ -306,17 +306,8 @@ jobs:
         id: buildhdf5
         shell: bash
         run: |
-          # macOS: Clean any stale disk image mounts before running CPack
+          # macOS: Disable Spotlight indexing to prevent file locking during CPack
           if [[ "$RUNNER_OS" == "macOS" ]]; then
-            echo "=== Cleaning stale HDF5 disk image mounts on macOS ==="
-            for vol in /Volumes/HDF5*; do
-              if [ -d "$vol" ]; then
-                echo "Detaching stale mount: $vol"
-                hdiutil detach "$vol" -force || true
-              fi
-            done
-
-            # Disable Spotlight indexing to prevent file locking during CPack
             echo "Disabling Spotlight indexing temporarily"
             sudo mdutil -i off / || true
           fi
@@ -327,19 +318,8 @@ jobs:
           if [[ "$RUNNER_OS" == "macOS" ]]; then
             echo "Running CMake workflow with macOS retry logic..."
             if ! cmake --workflow --preset="${{ steps.set-preset.outputs.preset }}" --fresh; then
-              echo "⚠️ First attempt failed, cleaning up and retrying in 5 seconds..."
+              echo "⚠️ First attempt failed, retrying in 5 seconds..."
               sleep 5
-
-              # Clean up again before retry
-              for vol in /Volumes/HDF5*; do
-                if [ -d "$vol" ]; then
-                  echo "Detaching stale mount: $vol"
-                  hdiutil detach "$vol" -force || true
-                fi
-              done
-
-              # Retry the workflow
-              echo "Retrying CMake workflow..."
               cmake --workflow --preset="${{ steps.set-preset.outputs.preset }}" --fresh
             fi
           else

--- a/.github/workflows/maven-staging.yml
+++ b/.github/workflows/maven-staging.yml
@@ -306,8 +306,46 @@ jobs:
         id: buildhdf5
         shell: bash
         run: |
+          # macOS: Clean any stale disk image mounts before running CPack
+          if [[ "$RUNNER_OS" == "macOS" ]]; then
+            echo "=== Cleaning stale HDF5 disk image mounts on macOS ==="
+            for vol in /Volumes/HDF5*; do
+              if [ -d "$vol" ]; then
+                echo "Detaching stale mount: $vol"
+                hdiutil detach "$vol" -force || true
+              fi
+            done
+
+            # Disable Spotlight indexing to prevent file locking during CPack
+            echo "Disabling Spotlight indexing temporarily"
+            sudo mdutil -i off / || true
+          fi
+
           cd "${{ github.workspace }}"
-          cmake --workflow --preset="${{ steps.set-preset.outputs.preset }}" --fresh
+
+          # Run workflow with retry logic for macOS CPack failures
+          if [[ "$RUNNER_OS" == "macOS" ]]; then
+            echo "Running CMake workflow with macOS retry logic..."
+            if ! cmake --workflow --preset="${{ steps.set-preset.outputs.preset }}" --fresh; then
+              echo "⚠️ First attempt failed, cleaning up and retrying in 5 seconds..."
+              sleep 5
+
+              # Clean up again before retry
+              for vol in /Volumes/HDF5*; do
+                if [ -d "$vol" ]; then
+                  echo "Detaching stale mount: $vol"
+                  hdiutil detach "$vol" -force || true
+                fi
+              done
+
+              # Retry the workflow
+              echo "Retrying CMake workflow..."
+              cmake --workflow --preset="${{ steps.set-preset.outputs.preset }}" --fresh
+            fi
+          else
+            # Non-macOS: run normally without retry
+            cmake --workflow --preset="${{ steps.set-preset.outputs.preset }}" --fresh
+          fi
 
       - name: Extract version information
         id: version-info


### PR DESCRIPTION
    * Added conditional logic to detect macOS builds
    * Cleans stale HDF5 volume mounts before running CPack
    * Disables Spotlight indexing which can interfere with disk image operations
    * Implements retry logic (waits 5 seconds and retries once if CPack fails)
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fixes CPack failure on macOS in GitHub Actions by cleaning stale mounts, disabling Spotlight, and adding retry logic.
> 
>   - **GitHub Actions Workflow**:
>     - Adds conditional logic in `main.yml` and `arm-main.yml` to handle macOS builds specifically.
>     - Cleans stale HDF5 volume mounts before running CPack to prevent conflicts.
>     - Disables Spotlight indexing on macOS to avoid interference with disk image operations.
>     - Implements retry logic for CPack execution, waiting 5 seconds and retrying once if it fails initially.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=HDFGroup%2Fhdf5&utm_source=github&utm_medium=referral)<sup> for 42d0a88f169451bea5bef19fc168c804d15b6563. You can [customize](https://app.ellipsis.dev/HDFGroup/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->