### PR TITLE
Fix JNI handling of H5T_NATIVE_FLOAT16 datatype

### DIFF
--- a/java/src-jni/jni/h5util.c
+++ b/java/src-jni/jni/h5util.c
@@ -2173,7 +2173,8 @@ h5str_get_little_endian_type(hid_t tid)
                     p_type = H5Tcopy(H5T_FLOAT_F8E5M2);
             }
             else if (size == 2) {
-                if (true == H5Tequal(tid, H5T_IEEE_F16LE) || true == H5Tequal(tid, H5T_IEEE_F16BE))
+                if (true == H5Tequal(tid, H5T_IEEE_F16LE) || true == H5Tequal(tid, H5T_IEEE_F16BE) ||
+                    true == H5Tequal(tid, H5T_NATIVE_FLOAT16))
                     p_type = H5Tcopy(H5T_IEEE_F16LE);
                 else if (true == H5Tequal(tid, H5T_FLOAT_BFLOAT16LE) ||
                          true == H5Tequal(tid, H5T_FLOAT_BFLOAT16BE))
@@ -2299,7 +2300,8 @@ h5str_get_big_endian_type(hid_t tid)
                 }
             }
             else if (size == 2) {
-                if (true == H5Tequal(tid, H5T_IEEE_F16LE) || true == H5Tequal(tid, H5T_IEEE_F16BE))
+                if (true == H5Tequal(tid, H5T_IEEE_F16LE) || true == H5Tequal(tid, H5T_IEEE_F16BE) ||
+                    true == H5Tequal(tid, H5T_NATIVE_FLOAT16))
                     p_type = H5Tcopy(H5T_IEEE_F16BE);
                 else if (true == H5Tequal(tid, H5T_FLOAT_BFLOAT16LE) ||
                          true == H5Tequal(tid, H5T_FLOAT_BFLOAT16BE))

--- a/java/src-jni/test/TestH5T.java
+++ b/java/src-jni/test/TestH5T.java
@@ -580,4 +580,90 @@ public class TestH5T {
                 }
         }
     }
+
+    @Test
+    public void testH5Tfloat16_dataset()
+    {
+        long dataset_id = HDF5Constants.H5I_INVALID_HID;
+        long dataspace_id = HDF5Constants.H5I_INVALID_HID;
+        long[] dims = {4, 4};
+
+        try {
+            // Create a simple dataspace
+            dataspace_id = H5.H5Screate_simple(2, dims, null);
+            assertTrue("testH5Tfloat16_dataset:H5Screate_simple", dataspace_id >= 0);
+
+            // Create a dataset with H5T_NATIVE_FLOAT16 datatype
+            dataset_id = H5.H5Dcreate(H5fid, "float16_dataset",
+                                      HDF5Constants.H5T_NATIVE_FLOAT16,
+                                      dataspace_id,
+                                      HDF5Constants.H5P_DEFAULT,
+                                      HDF5Constants.H5P_DEFAULT,
+                                      HDF5Constants.H5P_DEFAULT);
+            assertTrue("testH5Tfloat16_dataset:H5Dcreate", dataset_id >= 0);
+
+            // Get the dataset type
+            long dtype_id = H5.H5Dget_type(dataset_id);
+            assertTrue("testH5Tfloat16_dataset:H5Dget_type", dtype_id >= 0);
+
+            // Verify it's a float type with size 2
+            int type_class = H5.H5Tget_class(dtype_id);
+            assertTrue("testH5Tfloat16_dataset: type should be H5T_FLOAT",
+                      type_class == HDF5Constants.H5T_FLOAT);
+
+            long size = H5.H5Tget_size(dtype_id);
+            assertTrue("testH5Tfloat16_dataset: size should be 2", size == 2);
+
+            // Close the datatype
+            if (dtype_id >= 0)
+                H5.H5Tclose(dtype_id);
+        }
+        catch (Throwable err) {
+            err.printStackTrace();
+            fail("testH5Tfloat16_dataset: " + err);
+        }
+        finally {
+            if (dataset_id >= 0)
+                try {
+                    H5.H5Dclose(dataset_id);
+                }
+                catch (Exception ex) {
+                }
+            if (dataspace_id >= 0)
+                try {
+                    H5.H5Sclose(dataspace_id);
+                }
+                catch (Exception ex) {
+                }
+        }
+    }
+
+    @Test
+    public void testH5Tfloat16_properties()
+    {
+        try {
+            // Verify H5T_NATIVE_FLOAT16 is valid
+            assertTrue("H5T_NATIVE_FLOAT16 should be valid",
+                      HDF5Constants.H5T_NATIVE_FLOAT16 >= 0);
+
+            // Get the type class
+            int type_class = H5.H5Tget_class(HDF5Constants.H5T_NATIVE_FLOAT16);
+            assertTrue("H5T_NATIVE_FLOAT16 should be H5T_FLOAT class",
+                      type_class == HDF5Constants.H5T_FLOAT);
+
+            // Get the size
+            long size = H5.H5Tget_size(HDF5Constants.H5T_NATIVE_FLOAT16);
+            assertTrue("H5T_NATIVE_FLOAT16 size should be 2", size == 2);
+
+            // Get the byte order
+            int order = H5.H5Tget_order(HDF5Constants.H5T_NATIVE_FLOAT16);
+            assertTrue("H5T_NATIVE_FLOAT16 should have valid byte order",
+                      order == HDF5Constants.H5T_ORDER_LE ||
+                      order == HDF5Constants.H5T_ORDER_BE);
+        }
+        catch (Throwable err) {
+            err.printStackTrace();
+            fail("testH5Tfloat16_properties: " + err);
+        }
+    }
 }

--- a/java/test/TestH5T.java
+++ b/java/test/TestH5T.java
@@ -580,4 +580,90 @@ public class TestH5T {
                 }
         }
     }
+
+    @Test
+    public void testH5Tfloat16_dataset()
+    {
+        long dataset_id = HDF5Constants.H5I_INVALID_HID;
+        long dataspace_id = HDF5Constants.H5I_INVALID_HID;
+        long[] dims = {4, 4};
+
+        try {
+            // Create a simple dataspace
+            dataspace_id = H5.H5Screate_simple(2, dims, null);
+            assertTrue("testH5Tfloat16_dataset:H5Screate_simple", dataspace_id >= 0);
+
+            // Create a dataset with H5T_NATIVE_FLOAT16 datatype
+            dataset_id = H5.H5Dcreate(H5fid, "float16_dataset",
+                                      HDF5Constants.H5T_NATIVE_FLOAT16,
+                                      dataspace_id,
+                                      HDF5Constants.H5P_DEFAULT,
+                                      HDF5Constants.H5P_DEFAULT,
+                                      HDF5Constants.H5P_DEFAULT);
+            assertTrue("testH5Tfloat16_dataset:H5Dcreate", dataset_id >= 0);
+
+            // Get the dataset type
+            long dtype_id = H5.H5Dget_type(dataset_id);
+            assertTrue("testH5Tfloat16_dataset:H5Dget_type", dtype_id >= 0);
+
+            // Verify it's a float type with size 2
+            int type_class = H5.H5Tget_class(dtype_id);
+            assertTrue("testH5Tfloat16_dataset: type should be H5T_FLOAT",
+                      type_class == HDF5Constants.H5T_FLOAT);
+
+            long size = H5.H5Tget_size(dtype_id);
+            assertTrue("testH5Tfloat16_dataset: size should be 2", size == 2);
+
+            // Close the datatype
+            if (dtype_id >= 0)
+                H5.H5Tclose(dtype_id);
+        }
+        catch (Throwable err) {
+            err.printStackTrace();
+            fail("testH5Tfloat16_dataset: " + err);
+        }
+        finally {
+            if (dataset_id >= 0)
+                try {
+                    H5.H5Dclose(dataset_id);
+                }
+                catch (Exception ex) {
+                }
+            if (dataspace_id >= 0)
+                try {
+                    H5.H5Sclose(dataspace_id);
+                }
+                catch (Exception ex) {
+                }
+        }
+    }
+
+    @Test
+    public void testH5Tfloat16_properties()
+    {
+        try {
+            // Verify H5T_NATIVE_FLOAT16 is valid
+            assertTrue("H5T_NATIVE_FLOAT16 should be valid",
+                      HDF5Constants.H5T_NATIVE_FLOAT16 >= 0);
+
+            // Get the type class
+            int type_class = H5.H5Tget_class(HDF5Constants.H5T_NATIVE_FLOAT16);
+            assertTrue("H5T_NATIVE_FLOAT16 should be H5T_FLOAT class",
+                      type_class == HDF5Constants.H5T_FLOAT);
+
+            // Get the size
+            long size = H5.H5Tget_size(HDF5Constants.H5T_NATIVE_FLOAT16);
+            assertTrue("H5T_NATIVE_FLOAT16 size should be 2", size == 2);
+
+            // Get the byte order
+            int order = H5.H5Tget_order(HDF5Constants.H5T_NATIVE_FLOAT16);
+            assertTrue("H5T_NATIVE_FLOAT16 should have valid byte order",
+                      order == HDF5Constants.H5T_ORDER_LE ||
+                      order == HDF5Constants.H5T_ORDER_BE);
+        }
+        catch (Throwable err) {
+            err.printStackTrace();
+            fail("testH5Tfloat16_properties: " + err);
+        }
+    }
 }


### PR DESCRIPTION
The h5str_get_little_endian_type() and h5str_get_big_endian_type() functions in h5util.c were not recognizing H5T_NATIVE_FLOAT16 when converting 2-byte float types. This caused HDFView and other JNI-based tools to fail when reading datasets with native float16 datatypes.

The functions only checked for H5T_IEEE_F16LE/BE and H5T_FLOAT_BFLOAT16LE/BE, but H5T_NATIVE_FLOAT16 (the native _Float16 representation) was missing from the checks. This resulted in an invalid type handle being returned, causing downstream errors.

Changes:
- Added H5T_NATIVE_FLOAT16 to equality checks in h5str_get_little_endian_type()
- Added H5T_NATIVE_FLOAT16 to equality checks in h5str_get_big_endian_type()
- Added testH5Tfloat16_dataset() test to verify dataset creation and properties
- Added testH5Tfloat16_properties() test to verify H5T_NATIVE_FLOAT16 constant
- Tests added to both JNI and FFM compatibility test suites

This fix enables proper handling of float16 datatypes in HDFView and other JNI applications, which is important for machine learning and scientific computing applications using half-precision floats.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fixes handling of `H5T_NATIVE_FLOAT16` in JNI functions and adds tests for dataset creation and properties.
> 
>   - **Behavior**:
>     - Add `H5T_NATIVE_FLOAT16` to checks in `h5str_get_little_endian_type()` and `h5str_get_big_endian_type()` in `h5util.c`.
>     - Fixes issue with unrecognized `H5T_NATIVE_FLOAT16` causing errors in HDFView and other JNI tools.
>   - **Tests**:
>     - Add `testH5Tfloat16_dataset()` to verify dataset creation with `H5T_NATIVE_FLOAT16` in `TestH5T.java`.
>     - Add `testH5Tfloat16_properties()` to verify properties of `H5T_NATIVE_FLOAT16` in `TestH5T.java`.
>     - Tests added to both JNI and FFM compatibility test suites.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=HDFGroup%2Fhdf5&utm_source=github&utm_medium=referral)<sup> for 713a19a387274581288e78e9a6cf46b681b6941f. You can [customize](https://app.ellipsis.dev/HDFGroup/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->