### PR TITLE
Rewrite complex number configuration logic to fix re-configuration issue and improve clarity

### DIFF
--- a/config/ConfigureChecks.cmake
+++ b/config/ConfigureChecks.cmake
@@ -891,65 +891,82 @@ endmacro ()
 # Check for complex number support
 #-----------------------------------------------------------------------------
 message (STATUS "Checking if complex number support is available")
-CHECK_INCLUDE_FILE (complex.h ${HDF_PREFIX}_HAVE_COMPLEX_H)
-if (${HDF_PREFIX}_HAVE_COMPLEX_H)
-  set (H5_HAVE_C99_COMPLEX_NUMBERS 1)
 
-  HDF_CHECK_TYPE_SIZE ("float _Complex" ${HDF_PREFIX}_SIZEOF_FLOAT_COMPLEX)
-  HDF_CHECK_TYPE_SIZE ("double _Complex" ${HDF_PREFIX}_SIZEOF_DOUBLE_COMPLEX)
-  HDF_CHECK_TYPE_SIZE ("long double _Complex" ${HDF_PREFIX}_SIZEOF_LONG_DOUBLE_COMPLEX)
+# Check if __STDC_NO_COMPLEX__ macro is defined, in which case complex number
+# support is not available
+HDF_FUNCTION_TEST (HAVE_STDC_NO_COMPLEX)
+if (NOT H5_HAVE_STDC_NO_COMPLEX)
+  CHECK_INCLUDE_FILE (complex.h ${HDF_PREFIX}_HAVE_COMPLEX_H)
+  if (${HDF_PREFIX}_HAVE_COMPLEX_H)
+    # Check for C99 complex number types first
+    HDF_CHECK_TYPE_SIZE ("float _Complex" ${HDF_PREFIX}_SIZEOF_C99_FLOAT_COMPLEX)
+    HDF_CHECK_TYPE_SIZE ("double _Complex" ${HDF_PREFIX}_SIZEOF_C99_DOUBLE_COMPLEX)
+    HDF_CHECK_TYPE_SIZE ("long double _Complex" ${HDF_PREFIX}_SIZEOF_C99_LONG_DOUBLE_COMPLEX)
 
-  if (MSVC AND NOT ${HDF_PREFIX}_SIZEOF_FLOAT_COMPLEX AND NOT ${HDF_PREFIX}_SIZEOF_DOUBLE_COMPLEX
-      AND NOT ${HDF_PREFIX}_SIZEOF_LONG_DOUBLE_COMPLEX)
-    # If using MSVC, the _Complex types (if available) are _Fcomplex, _Dcomplex and _Lcomplex.
-    # The standard types are checked for first in case MSVC uses them in the future or in case
-    # the compiler used is simulating MSVC and uses the standard types.
-    cmake_push_check_state ()
-    list (APPEND CMAKE_EXTRA_INCLUDE_FILES complex.h)
-    HDF_CHECK_TYPE_SIZE ("_Fcomplex" ${HDF_PREFIX}_SIZEOF__FCOMPLEX)
-    HDF_CHECK_TYPE_SIZE ("_Dcomplex" ${HDF_PREFIX}_SIZEOF__DCOMPLEX)
-    HDF_CHECK_TYPE_SIZE ("_Lcomplex" ${HDF_PREFIX}_SIZEOF__LCOMPLEX)
-    cmake_pop_check_state ()
-    if (${HDF_PREFIX}_SIZEOF__FCOMPLEX AND ${HDF_PREFIX}_SIZEOF__DCOMPLEX AND
-        ${HDF_PREFIX}_SIZEOF__FCOMPLEX)
-      set (${HDF_PREFIX}_SIZEOF_FLOAT_COMPLEX ${${HDF_PREFIX}_SIZEOF__FCOMPLEX}
-           CACHE INTERNAL "SizeOf for float _Complex" FORCE)
-      set (${HDF_PREFIX}_SIZEOF_DOUBLE_COMPLEX ${${HDF_PREFIX}_SIZEOF__DCOMPLEX}
-           CACHE INTERNAL "SizeOf for double _Complex" FORCE)
-      set (${HDF_PREFIX}_SIZEOF_LONG_DOUBLE_COMPLEX ${${HDF_PREFIX}_SIZEOF__LCOMPLEX}
-           CACHE INTERNAL "SizeOf for long double _Complex" FORCE)
-
-      unset (H5_HAVE_C99_COMPLEX_NUMBERS)
+    if (${HDF_PREFIX}_SIZEOF_C99_FLOAT_COMPLEX AND
+        ${HDF_PREFIX}_SIZEOF_C99_DOUBLE_COMPLEX AND
+        ${HDF_PREFIX}_SIZEOF_C99_LONG_DOUBLE_COMPLEX)
+      set (h5_have_c99_complex_numbers 1)
     endif ()
-  endif ()
 
-  if (${HDF_PREFIX}_SIZEOF_FLOAT_COMPLEX AND ${HDF_PREFIX}_SIZEOF_DOUBLE_COMPLEX AND
-      ${HDF_PREFIX}_SIZEOF_LONG_DOUBLE_COMPLEX)
-    # Check if __STDC_NO_COMPLEX__ macro is defined, in which case complex number
-    # support is not available
-    HDF_FUNCTION_TEST (HAVE_STDC_NO_COMPLEX)
+    # If using MSVC, the _Complex types (if available) are currently _Fcomplex,
+    # _Dcomplex and _Lcomplex. The standard types are checked for first in case
+    # MSVC uses them in the future or in case the compiler used is simulating
+    # MSVC and uses the standard types.
+    if (MSVC AND NOT h5_have_c99_complex_numbers)
+      cmake_push_check_state ()
+      list (APPEND CMAKE_EXTRA_INCLUDE_FILES complex.h)
+      HDF_CHECK_TYPE_SIZE ("_Fcomplex" ${HDF_PREFIX}_SIZEOF__FCOMPLEX)
+      HDF_CHECK_TYPE_SIZE ("_Dcomplex" ${HDF_PREFIX}_SIZEOF__DCOMPLEX)
+      HDF_CHECK_TYPE_SIZE ("_Lcomplex" ${HDF_PREFIX}_SIZEOF__LCOMPLEX)
+      cmake_pop_check_state ()
 
-    if (NOT H5_HAVE_STDC_NO_COMPLEX)
+      if (${HDF_PREFIX}_SIZEOF__FCOMPLEX AND
+          ${HDF_PREFIX}_SIZEOF__DCOMPLEX AND
+          ${HDF_PREFIX}_SIZEOF__LCOMPLEX)
+        set (h5_have_msvc_complex_numbers 1)
+      endif ()
+    endif ()
+
+    if (h5_have_c99_complex_numbers OR h5_have_msvc_complex_numbers)
       # Compile simple test program with complex numbers
       HDF_FUNCTION_TEST (HAVE_COMPLEX_NUMBERS)
 
       if (H5_HAVE_COMPLEX_NUMBERS)
-        if (H5_HAVE_C99_COMPLEX_NUMBERS)
+        # Set values for macros used by HDF5
+        if (h5_have_c99_complex_numbers)
+          # Note here that the public macro is all-caps
+          set (H5_HAVE_C99_COMPLEX_NUMBERS 1)
+
+          set (${HDF_PREFIX}_SIZEOF_FLOAT_COMPLEX ${${HDF_PREFIX}_SIZEOF_C99_FLOAT_COMPLEX}
+               CACHE INTERNAL "SizeOf for float _Complex" FORCE)
+          set (${HDF_PREFIX}_SIZEOF_DOUBLE_COMPLEX ${${HDF_PREFIX}_SIZEOF_C99_DOUBLE_COMPLEX}
+               CACHE INTERNAL "SizeOf for double _Complex" FORCE)
+          set (${HDF_PREFIX}_SIZEOF_LONG_DOUBLE_COMPLEX ${${HDF_PREFIX}_SIZEOF_C99_LONG_DOUBLE_COMPLEX}
+               CACHE INTERNAL "SizeOf for long double _Complex" FORCE)
+
           message (STATUS "Using C99 complex number types")
         else ()
+          set (${HDF_PREFIX}_SIZEOF_FLOAT_COMPLEX ${${HDF_PREFIX}_SIZEOF__FCOMPLEX}
+               CACHE INTERNAL "SizeOf for float _Complex" FORCE)
+          set (${HDF_PREFIX}_SIZEOF_DOUBLE_COMPLEX ${${HDF_PREFIX}_SIZEOF__DCOMPLEX}
+               CACHE INTERNAL "SizeOf for double _Complex" FORCE)
+          set (${HDF_PREFIX}_SIZEOF_LONG_DOUBLE_COMPLEX ${${HDF_PREFIX}_SIZEOF__LCOMPLEX}
+               CACHE INTERNAL "SizeOf for long double _Complex" FORCE)
+
           message (STATUS "Using MSVC complex number types")
         endif ()
       else ()
         message (STATUS "Complex number support has been disabled since a simple test program couldn't be compiled and linked")
       endif ()
     else ()
-      message (STATUS "Complex number support has been disabled since __STDC_NO_COMPLEX__ is defined")
+      message (STATUS "Complex number support has been disabled since the C types were not found")
     endif ()
   else ()
-    message (STATUS "Complex number support has been disabled since the C types were not found")
+    message (STATUS "Complex number support has been disabled since the complex.h header was not found")
   endif ()
 else ()
-  message (STATUS "Complex number support has been disabled since the complex.h header was not found")
+  message (STATUS "Complex number support has been disabled since __STDC_NO_COMPLEX__ is defined")
 endif ()
 
 #-----------------------------------------------------------------------------


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Rewrites complex number configuration logic in `ConfigureChecks.cmake` to improve clarity and fix re-configuration issues by restructuring checks for C99 and MSVC complex types.
> 
>   - **Behavior**:
>     - Rewrites complex number support check in `ConfigureChecks.cmake` to first check `__STDC_NO_COMPLEX__` macro.
>     - Checks for `complex.h` and C99 complex types (`float _Complex`, `double _Complex`, `long double _Complex`).
>     - Separates MSVC complex type checks (`_Fcomplex`, `_Dcomplex`, `_Lcomplex`) if C99 types are unavailable.
>     - Sets `H5_HAVE_C99_COMPLEX_NUMBERS` if C99 types are available.
>     - Improved status messages for complex number support availability.
>   - **Misc**:
>     - Removes redundant checks and simplifies logic flow for complex number configuration.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=HDFGroup%2Fhdf5&utm_source=github&utm_medium=referral)<sup> for 984bfda8df0984364d14c4f1f89c45278b1e6f89. You can [customize](https://app.ellipsis.dev/HDFGroup/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->