### PR TITLE
Exclude HISTORY-2.X file from Doxygen parsing

### DIFF
--- a/doxygen/Doxyfile.in
+++ b/doxygen/Doxyfile.in
@@ -810,7 +810,7 @@ EXCLUDE_PATTERNS       = */fortran/test/* \
                          */sanitizer/* \
                          */CONTRIBUTING.md \
                          */CHANGELOG.md \
-                         */HISTORY-2.X.md
+                         */HISTORY-*.md
 
 # The EXCLUDE_SYMBOLS tag can be used to specify one or more symbol names
 # (namespaces, classes, functions, etc.) that should be excluded from the

--- a/doxygen/Doxyfile.in
+++ b/doxygen/Doxyfile.in
@@ -810,6 +810,7 @@ EXCLUDE_PATTERNS       = */fortran/test/* \
                          */sanitizer/* \
                          */CONTRIBUTING.md \
                          */CHANGELOG.md \
+                         */HISTORY-2.X.md
 
 # The EXCLUDE_SYMBOLS tag can be used to specify one or more symbol names
 # (namespaces, classes, functions, etc.) that should be excluded from the


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Exclude `HISTORY-2.X.md` from Doxygen parsing by updating `EXCLUDE_PATTERNS` in `Doxyfile.in`.
> 
>   - **Configuration**:
>     - Exclude `HISTORY-2.X.md` from Doxygen parsing by adding it to `EXCLUDE_PATTERNS` in `Doxyfile.in`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=HDFGroup%2Fhdf5&utm_source=github&utm_medium=referral)<sup> for f9ab224f2570ddce38050a88fc34e6b83e0f63e4. You can [customize](https://app.ellipsis.dev/HDFGroup/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->