### PR TITLE
chore: fix filename format for offline reading archive

### DIFF
--- a/doxygen/dox/Overview.dox
+++ b/doxygen/dox/Overview.dox
@@ -23,7 +23,7 @@ documents cover a mix of tasks, concepts, and reference, to help a specific
 \ref release_specific_info
 
 \par Offline reading
-     You can download the hdf5-x.y.z-doxygen.zip file from the most recent release as an archive for offline reading from <a href="https://\DWNURL/">this page</a>.
+     You can download the hdf5-x.y.z.doxygen.zip file from the most recent release as an archive for offline reading from <a href="https://\DWNURL/">this page</a>.
 
 \par ToDo List
      There is plenty of \ref todo unfinished business.


### PR DESCRIPTION
There is no `-` in file name.

Ref: https://support.hdfgroup.org/releases/hdf5/v2_0/v2_0_0/downloads/hdf5-2.0.0.doxygen.zip
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fix filename format in `Overview.dox` for offline reading archive to remove hyphen before 'doxygen'.
> 
>   - **Documentation**:
>     - Fix filename format in `Overview.dox` for offline reading archive from `hdf5-x.y.z-doxygen.zip` to `hdf5-x.y.z.doxygen.zip`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=HDFGroup%2Fhdf5&utm_source=github&utm_medium=referral)<sup> for 55a6efbbf8e768a57f9a2f718e22b990921b923c. You can [customize](https://app.ellipsis.dev/HDFGroup/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->