### PR TITLE
Add the C++ API introduction page

### DIFF
--- a/doxygen/dox/CppAPIIntro.dox
+++ b/doxygen/dox/CppAPIIntro.dox
@@ -1,0 +1,58 @@
+/** \page h5_cpp_intro C++ API Introduction
+
+\section cpp_overview Overview
+
+The HDF5 C++ API provides object-oriented wrappers for the HDF5 C Library,
+enabling modern C++ applications to leverage HDF5's powerful data management
+capabilities with:
+- Automatic resource management through RAII
+- Exception-based error handling
+- Type-safe interfaces
+- STL integration (std::string support)
+
+\subsection cpp_prerequisites Prerequisites
+
+Users should be familiar with:
+- HDF5 concepts (files, groups, datasets, attributes, datatypes, dataspaces)
+- Basic C++ programming (classes, exceptions, templates)
+- The HDF5 \ref RM "Reference Manual" for underlying C API concepts
+
+\subsection cpp_mapping C API to C++ Class Mapping
+
+The C++ classes closely mirror the HDF5 C API modules:
+
+| C API Module | C++ Class | Purpose |
+|--------------|-----------|---------|
+| H5A (Attributes) | H5::Attribute | Metadata attached to objects |
+| H5D (Datasets) | H5::DataSet | Data storage and I/O |
+| H5S (Dataspaces) | H5::DataSpace | Dimensional structure of data |
+| H5T (Datatypes) | H5::DataType | Data type definitions |
+| H5F (Files) | H5::H5File | File access and management |
+| H5G (Groups) | H5::Group | Hierarchical organization |
+| H5P (Property Lists) | H5::PropList + subclasses | Configuration parameters |
+| H5L/H5O (Links/Objects) | H5::Location | Management of links and objects |
+| H5E (Errors) | H5::Exception | Error reporting |
+
+\subsection cpp_examples Quick Start Examples
+
+See the \ref cpp_examples "C++ Examples" page for:
+- Creating groups and dataset: <a href="https://\CPPEXS/h5tutr_crtgrp.cpp">h5tutr_crtgrp.cpp</a> <a href="https://\CPPEXS/h5tutr_crtdat.cpp">h5tutr_crtdat.cpp</a>
+- Writing/Reading data <a href="https://\CPPEXS/h5tutr_rdwt.cpp">h5tutr_rdwt.cpp</a> <a href="https://\CPPEXS/h5tutr_subset.cpp">h5tutr_subset.cpp</a>
+- Working with attributes <a href="https://\CPPEXS/h5tutr_crtatt.cpp">h5tutr_crtatt.cpp</a>
+- Extendible datasets <a href="https://\CPPEXS/h5tutr_extend.cpp">h5tutr_extend.cpp</a>
+- Chunked/Compressed datasets <a href="https://\CPPEXS/h5tutr_cmprss.cpp">h5tutr_cmprss.cpp</a>
+
+\subsection cpp_building Building Applications
+
+The HDF5 C++ API is built when configured with:
+\code{.sh}
+cmake -DHDF5_BUILD_CPP_LIB=ON ...
+\endcode
+
+Link against: `hdf5_cpp` and `hdf5`
+
+
+<hr>
+Navigate back: \ref index "Main" / \ref GettingStarted
+
+*/

--- a/doxygen/dox/CppAPIIntro.dox
+++ b/doxygen/dox/CppAPIIntro.dox
@@ -48,7 +48,7 @@ See the See \ref LBExamples for additional examples.
 
 \subsection cpp_building Building Applications
 
-Please refer to the release_docs/INSTALL_CMake.txt file under the top directory of the HDF5 source code or <a href="https://\SRCURL/release_docs/INSTALL_CMake.txt">INSTALL_CMake.txt on GitHub for information about installing, building, and testing the C++ API.
+Please refer to the release_docs/INSTALL_CMake.txt file under the top directory of the HDF5 source code or <a href="https://\SRCURL/release_docs/INSTALL_CMake.txt">INSTALL_CMake.txt on GitHub for information about installing, building, and testing the C++ API.</a>
 
 
 <hr>

--- a/doxygen/dox/CppAPIIntro.dox
+++ b/doxygen/dox/CppAPIIntro.dox
@@ -1,5 +1,8 @@
 /** \page h5_cpp_intro C++ API Introduction
 
+Navigate back: \ref index "Main" / \ref GettingStarted
+<hr>
+
 \section cpp_overview Overview
 
 The HDF5 C++ API provides object-oriented wrappers for the HDF5 C Library,
@@ -35,21 +38,17 @@ The C++ classes closely mirror the HDF5 C API modules:
 
 \subsection cpp_examples Quick Start Examples
 
-See the \ref cpp_examples "C++ Examples" page for:
-- Creating groups and dataset: <a href="https://\CPPEXS/h5tutr_crtgrp.cpp">h5tutr_crtgrp.cpp</a> <a href="https://\CPPEXS/h5tutr_crtdat.cpp">h5tutr_crtdat.cpp</a>
+- Creating groups and datasets: <a href="https://\CPPEXS/h5tutr_crtgrp.cpp">h5tutr_crtgrp.cpp</a> <a href="https://\CPPEXS/h5tutr_crtdat.cpp">h5tutr_crtdat.cpp</a>
 - Writing/Reading data <a href="https://\CPPEXS/h5tutr_rdwt.cpp">h5tutr_rdwt.cpp</a> <a href="https://\CPPEXS/h5tutr_subset.cpp">h5tutr_subset.cpp</a>
 - Working with attributes <a href="https://\CPPEXS/h5tutr_crtatt.cpp">h5tutr_crtatt.cpp</a>
 - Extendible datasets <a href="https://\CPPEXS/h5tutr_extend.cpp">h5tutr_extend.cpp</a>
 - Chunked/Compressed datasets <a href="https://\CPPEXS/h5tutr_cmprss.cpp">h5tutr_cmprss.cpp</a>
 
+See the See \ref LBExamples for additional examples.
+
 \subsection cpp_building Building Applications
 
-The HDF5 C++ API is built when configured with:
-\code{.sh}
-cmake -DHDF5_BUILD_CPP_LIB=ON ...
-\endcode
-
-Link against: `hdf5_cpp` and `hdf5`
+Please refer to the release_docs/INSTALL_CMake.txt file under the top directory of the HDF5 source code or <a href="https://\SRCURL/release_docs/INSTALL_CMake.txt">INSTALL_CMake.txt on GitHub for information about installing, building, and testing the C++ API.
 
 
 <hr>

--- a/doxygen/dox/ReferenceManual.dox
+++ b/doxygen/dox/ReferenceManual.dox
@@ -177,6 +177,10 @@ Follow these simple rules and stay out of trouble:
 
 \cpp_c_api_note
 
+\par C++ API Guide
+     New to the HDF5 C++ API? See the \ref h5_cpp_intro for an introduction,
+     class mapping guide, and examples.
+
 \par Don't like what you see? - You can help to improve this Reference Manual
      Complete the survey linked near the top of this page!\n
      We treat documentation like code: Fork the


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Adds a new C++ API introduction page and updates the reference manual to link to it.
> 
>   - **Documentation**:
>     - Adds `CppAPIIntro.dox` for C++ API introduction, covering overview, prerequisites, C API to C++ class mapping, examples, and build instructions.
>     - Updates `ReferenceManual.dox` to include a link to the new C++ API introduction page.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=HDFGroup%2Fhdf5&utm_source=github&utm_medium=referral)<sup> for c44b217ae4c7bd1cb00d4aef1c6dac8664607cd1. You can [customize](https://app.ellipsis.dev/HDFGroup/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->