### PR TITLE
Fix inconsistent empty postfix handling

### DIFF
--- a/HDF5Examples/config/HDFMacros.cmake
+++ b/HDF5Examples/config/HDFMacros.cmake
@@ -173,15 +173,6 @@ macro (HDF_DIR_PATHS package_prefix)
     set (CMAKE_PREFIX_PATH ${ADDITIONAL_CMAKE_PREFIX_PATH} ${CMAKE_PREFIX_PATH})
   endif ()
 
-  #set the default debug suffix for all library targets
-  if(NOT CMAKE_DEBUG_POSTFIX)
-    if (WIN32)
-      set (CMAKE_DEBUG_POSTFIX "_D")
-    else ()
-      set (CMAKE_DEBUG_POSTFIX "_debug")
-    endif ()
-  endif ()
-
   SET_HDF_BUILD_TYPE()
 
   SET_HDF_OUTPUT_DIRS(${package_prefix})

--- a/config/cmake/cacheinit.cmake
+++ b/config/cmake/cacheinit.cmake
@@ -42,9 +42,9 @@ set (HDF5_MINGW_STATIC_GCC_LIBS ON CACHE BOOL "Statically link libgcc/libstdc++"
 #set the default debug suffix for all library targets
 if (NOT DEFINED CMAKE_DEBUG_POSTFIX)
   if (WIN32)
-    set (CMAKE_DEBUG_POSTFIX "_D" CACHE STRING "Debug library postfix" FORCE)
+    set (CMAKE_DEBUG_POSTFIX "_D" CACHE STRING "Debug library postfix")
   else ()
-    set (CMAKE_DEBUG_POSTFIX "_debug" CACHE STRING "Debug library postfix" FORCE)
+    set (CMAKE_DEBUG_POSTFIX "_debug" CACHE STRING "Debug library postfix")
   endif ()
 endif ()
 

--- a/config/cmake/cacheinit.cmake
+++ b/config/cmake/cacheinit.cmake
@@ -40,7 +40,7 @@ set (HDF_TEST_EXPRESS "2" CACHE STRING "Control testing framework (0-3)" FORCE)
 set (HDF5_MINGW_STATIC_GCC_LIBS ON CACHE BOOL "Statically link libgcc/libstdc++" FORCE)
 
 #set the default debug suffix for all library targets
-if (NOT CMAKE_DEBUG_POSTFIX)
+if (NOT DEFINED CMAKE_DEBUG_POSTFIX)
   if (WIN32)
     set (CMAKE_DEBUG_POSTFIX "_D")
   else ()

--- a/config/cmake/cacheinit.cmake
+++ b/config/cmake/cacheinit.cmake
@@ -42,9 +42,9 @@ set (HDF5_MINGW_STATIC_GCC_LIBS ON CACHE BOOL "Statically link libgcc/libstdc++"
 #set the default debug suffix for all library targets
 if (NOT DEFINED CMAKE_DEBUG_POSTFIX)
   if (WIN32)
-    set (CMAKE_DEBUG_POSTFIX "_D")
+    set (CMAKE_DEBUG_POSTFIX "_D" CACHE STRING "Debug library postfix" FORCE)
   else ()
-    set (CMAKE_DEBUG_POSTFIX "_debug")
+    set (CMAKE_DEBUG_POSTFIX "_debug" CACHE STRING "Debug library postfix" FORCE)
   endif ()
 endif ()
 


### PR DESCRIPTION
If the `cacheinit.cmake` file is used, the library sets an OS-specific Debug build library postfix if none is provided by the user. However, the way this check is done means that if a user manually provides an empty string value for the postfix, it will be detected the same as an unprovided postfix and replaced. This is likely to lead to confusion, since the user manually specified an empty postfix but instead receives the default postfixes.

This updates the check to distinguish between a user-provided empty postfix and an undefined postfix.

I also removed an old postfix check from an examples counterpart of the `HDF_DIR_PATHS` macro in `HDF5Examples/config/HDFMacros.cmake`, since it appears that this was copied and became out of date with the modern version of the macro in `HDFMacros.cmake`.

Fixes #6087 