### PR TITLE
Fixed typos to prevent Doxigen parsing failures

### DIFF
--- a/doxygen/dox/LearnBasics3.dox
+++ b/doxygen/dox/LearnBasics3.dox
@@ -868,6 +868,7 @@ libhdf5_fortran.lib
 libhdf5_hl.lib
 libhdf5.lib
 \endcode
+</td>
 </tr>
 </table>
 
@@ -919,6 +920,7 @@ hdf5_fortran.lib
 hdf5_hl.lib
 hdf5.lib
 \endcode
+</td>
 </tr>
 </table>
 

--- a/src/H5Ppublic.h
+++ b/src/H5Ppublic.h
@@ -4770,7 +4770,7 @@ H5_DLL herr_t H5Pset_file_image(hid_t fapl_id, void *buf_ptr, size_t buf_len);
  *          The callbacks and their parameters, along with a struct and
  *          an \c ENUM required for their use, are described below.
  *
- *          <b>Callback struct and \c ENUM:</b>
+ *          <b>Callback struct and \TText{ENUM:}</b>
  *
  *          The callback functions set up by H5Pset_file_image_callbacks() use
  *          a struct and an \c ENUM that are defined as follows


### PR DESCRIPTION
- Added missing html tags
- When \c is used inside <b></b>, Doxygen did not parse correctly, causing a mismatched error.  Replaced \c with \<tt>\</tt>.