### PR TITLE
Add h5diff message about file object difference

### DIFF
--- a/tools/src/h5diff/h5diff_common.c
+++ b/tools/src/h5diff/h5diff_common.c
@@ -491,6 +491,7 @@ print_info(diff_opt_t *opts)
         printf("No common objects found. Files are not comparable.\n");
         if (!opts->mode_verbose)
             printf("Use -v for a list of objects.\n");
+        return;
     }
 
     if (opts->not_cmp == 1) {

--- a/tools/src/h5diff/h5diff_common.c
+++ b/tools/src/h5diff/h5diff_common.c
@@ -506,7 +506,7 @@ print_info(diff_opt_t *opts)
     }
 
     if (opts->contents == 0 && !opts->mode_verbose) {
-        printf("Files do not have the same set of objects\n");
+        printf("Files do not have the same set of objects.\n");
         printf("Use -v for a list of objects.\n");
     }
 }

--- a/tools/src/h5diff/h5diff_common.c
+++ b/tools/src/h5diff/h5diff_common.c
@@ -504,6 +504,11 @@ print_info(diff_opt_t *opts)
                 printf("Use -c for a list of objects.\n");
         }
     }
+
+    if (opts->contents == 0 && !opts->mode_verbose) {
+        printf("Files do not have the same set of objects\n");
+        printf("Use -v for a list of objects.\n");
+    }
 }
 
 /*-------------------------------------------------------------------------

--- a/tools/test/h5diff/expected/h5diff_11.txt
+++ b/tools/test/h5diff/expected/h5diff_11.txt
@@ -1,2 +1,4 @@
 dataset: </g1/dset1> and </g1/dset1>
 5 differences found
+Files do not have the same set of objects.
+Use -v for a list of objects.

--- a/tools/test/h5diff/expected/h5diff_13.txt
+++ b/tools/test/h5diff/expected/h5diff_13.txt
@@ -8,3 +8,5 @@ position        dset1           dset1           difference
 [ 1 1 ]          1               1.001           0.001          
 [ 2 1 ]          0               1               1              
 5 differences found
+Files do not have the same set of objects.
+Use -v for a list of objects.


### PR DESCRIPTION
`h5diff` silently returns an error code of 1 whenever the two provided files differ structurally (one contains an object the other does not, different total object count). This PR adds a message indicating that the two files do not contain the same object set. 


Resolves #6102
<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Add message in `h5diff` to indicate when files do not have the same set of objects, with updates to expected test outputs.
> 
>   - **Behavior**:
>     - Adds message in `print_info()` in `h5diff_common.c` when files differ structurally and `opts->contents` is 0, suggesting to use `-v` for more details.
>   - **Tests**:
>     - Updates `h5diff_11.txt` and `h5diff_13.txt` to include new message about differing object sets.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=HDFGroup%2Fhdf5&utm_source=github&utm_medium=referral)<sup> for 2a421957cc94132b57364c2af0382a81ad844210. You can [customize](https://app.ellipsis.dev/HDFGroup/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->