### PR TITLE
Clean up some obsolete CMake version conditions in CMakeLists.txt.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -52,10 +52,8 @@ if (POLICY CMP0127)
   cmake_policy (SET CMP0127 NEW)
 endif ()
 
-# Avoid warning about DOWNLOAD_EXTRACT_TIMESTAMP in CMake 3.24:
-if (CMAKE_VERSION VERSION_GREATER_EQUAL "3.24.0")
-    cmake_policy(SET CMP0135 NEW)
-endif()
+# Avoid warning about DOWNLOAD_EXTRACT_TIMESTAMP in CMake versions > 3.24:
+cmake_policy(SET CMP0135 NEW)
 
 #-----------------------------------------------------------------------------
 # Instructions for use : Normal Build
@@ -86,14 +84,8 @@ endif ()
 
 # Whether the most recently called project() command, in the current scope or above,
 # was in the top level CMakeLists.txt file.
-if (CMAKE_VERSION VERSION_GREATER_EQUAL "3.21.0")
-  if(NOT PROJECT_IS_TOP_LEVEL)
-    set (HDF5_EXTERNALLY_CONFIGURED 1)
-  endif()
-else()
-  if (NOT CMAKE_SOURCE_DIR STREQUAL PROJECT_SOURCE_DIR)
-    set (HDF5_EXTERNALLY_CONFIGURED 1)
-  endif()
+if(NOT PROJECT_IS_TOP_LEVEL)
+  set (HDF5_EXTERNALLY_CONFIGURED 1)
 endif()
 
 #-----------------------------------------------------------------------------
@@ -519,14 +511,14 @@ set (HDF5_PACKAGE_BUGREPORT "help@hdfgroup.org")
 set (HDF5_VERSION_STRING ${HDF5_PACKAGE_VERSION})
 set (HDF5_VERSION_MAJOR  ${HDF5_PACKAGE_VERSION_MAJOR})
 set (HDF5_VERSION_MINOR  ${HDF5_PACKAGE_VERSION_MINOR})
-if (H5_VERS_MAJOR GREATER 1)
-  if (H5_VERS_MINOR GREATER 9)
-    set (H5_LIBVER_DIR ${H5_VERS_MAJOR}${H5_VERS_MINOR})
-  else ()
-    set (H5_LIBVER_DIR ${H5_VERS_MAJOR}0${H5_VERS_MINOR})
-  endif()
-else ()
+# H5_LIBVER_DIR is used in HDF5Examples to compile examples from older hdf5 versions.
+# Because the range of minor version numbers exceded single digits, a 0 was needed for
+# the single digit minor numbers so that version 2.0 (200) will greater than version 
+# version 1.14 (114).
+if (H5_VERS_MINOR GREATER 9)
   set (H5_LIBVER_DIR ${H5_VERS_MAJOR}${H5_VERS_MINOR})
+else ()
+  set (H5_LIBVER_DIR ${H5_VERS_MAJOR}0${H5_VERS_MINOR})
 endif()
 #-----------------------------------------------------------------------------
 # Include some macros for reusable code
@@ -1211,7 +1203,7 @@ endif ()
 # Include filter plugins
 #-----------------------------------------------------------------------------
 if (HDF5_ENABLE_PLUGIN_SUPPORT)
-  if (${H5_LIBVER_DIR} EQUAL 16 OR HDF5_DEFAULT_API_VERSION MATCHES "v16")
+  if HDF5_DEFAULT_API_VERSION MATCHES "v16")
     set (HDF5_ENABLE_PLUGIN_SUPPORT OFF CACHE BOOL "" FORCE)
     message (VERBOSE "Filter PLUGINs cannot be used with 1.6 API")
   else ()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -512,8 +512,8 @@ set (HDF5_VERSION_STRING ${HDF5_PACKAGE_VERSION})
 set (HDF5_VERSION_MAJOR  ${HDF5_PACKAGE_VERSION_MAJOR})
 set (HDF5_VERSION_MINOR  ${HDF5_PACKAGE_VERSION_MINOR})
 # H5_LIBVER_DIR is used in HDF5Examples to compile examples from older hdf5 versions.
-# Because the range of minor version numbers exceded single digits, a 0 was needed for
-# the single digit minor numbers so that version 2.0 (200) will greater than version 
+# Because the range of minor version numbers exceeded single digits, a 0 was needed for
+# the single digit minor numbers so that version 2.0 (200) will be greater than version 
 # version 1.14 (114).
 if (H5_VERS_MINOR GREATER 9)
   set (H5_LIBVER_DIR ${H5_VERS_MAJOR}${H5_VERS_MINOR})
@@ -1203,7 +1203,7 @@ endif ()
 # Include filter plugins
 #-----------------------------------------------------------------------------
 if (HDF5_ENABLE_PLUGIN_SUPPORT)
-  if HDF5_DEFAULT_API_VERSION MATCHES "v16")
+  if (HDF5_DEFAULT_API_VERSION MATCHES "v16")
     set (HDF5_ENABLE_PLUGIN_SUPPORT OFF CACHE BOOL "" FORCE)
     message (VERBOSE "Filter PLUGINs cannot be used with 1.6 API")
   else ()

--- a/README.md
+++ b/README.md
@@ -5,7 +5,6 @@ HDF5 version 2.0.1 currently under development
 >
 > It's happened—the day we've all been dreading—or eagerly anticipating, depending on your perspective. Yes, we have switched to CMake-only builds in HDF5.
 >
-> The [PR stripping all autotools](https://github.com/HDFGroup/hdf5/pull/5308) was merged into the "develop" branch on **March 10, 2025**. Starting with HDF5 2.0, *only* the CMake build system is supported.
 
 ![HDF5 Logo][u3]
 
@@ -92,9 +91,10 @@ HDF5 does not follow a regular release schedule. Instead, updates are based on t
 introduction of new features and the resolution of bugs. However, we aim to have at
 least one annual release for each maintenance branch.
 
+> The [PR stripping all autotools](https://github.com/HDFGroup/hdf5/pull/5308) was merged into the "develop" branch on **March 10, 2025**. .
 | Release | New Features |
 | ------- | ------------ |
-| 2.0.0 | Drop Autotools support, drop the HDF5 <--> GIF tools, add complex number support, update library defaults (cache sizes, etc.) |
+| 2.0.0 | Starting with HDF5 2.0, *only* the CMake build system is supported. Dropped the HDF5 <--> GIF tools, added complex number support, updated library defaults (cache sizes, etc.) |
 | FUTURE | Multi-threaded HDF5, crashproofing / metadata journaling, Full (VFD) SWMR, encryption, digital signatures, sparse datasets, improved storage for variable-length datatypes, better Unicode support (especially on Windows) |
 
 ### Release Progress

--- a/README.md
+++ b/README.md
@@ -91,7 +91,7 @@ HDF5 does not follow a regular release schedule. Instead, updates are based on t
 introduction of new features and the resolution of bugs. However, we aim to have at
 least one annual release for each maintenance branch.
 
-> The [PR stripping all autotools](https://github.com/HDFGroup/hdf5/pull/5308) was merged into the "develop" branch on **March 10, 2025**. .
+> The [PR stripping all autotools](https://github.com/HDFGroup/hdf5/pull/5308) was merged into the "develop" branch on **March 10, 2025**.
 | Release | New Features |
 | ------- | ------------ |
 | 2.0.0 | Starting with HDF5 2.0, *only* the CMake build system is supported. Dropped the HDF5 <--> GIF tools, added complex number support, updated library defaults (cache sizes, etc.) |

--- a/release_docs/CHANGELOG.md
+++ b/release_docs/CHANGELOG.md
@@ -4,7 +4,8 @@ HDF5 version 2.0.1 currently under development
 All notable changes to this project will be documented in this file. This document describes the differences between this release and the previous
 HDF5 release, platforms tested, and known problems in this release.
 
-For releases prior to version 2.0.0, please see the release.txt file and for more details check the HISTORY*.txt files in the HDF5 source.
+For changes in previous releases, please see the HISTORY*.txt files in the HDF5 source.
+
 
 # 🔗 Quick Links
 * [HDF5 documentation](https://support.hdfgroup.org/documentation/hdf5/latest/)


### PR DESCRIPTION
Improve outdated text in CHANGELOG.md.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Clean up obsolete CMake version conditions in `CMakeLists.txt` and update outdated text in `CHANGELOG.md`.
> 
>   - **CMakeLists.txt**:
>     - Removed obsolete CMake version conditions for `CMP0135` and `HDF5_EXTERNALLY_CONFIGURED`.
>     - Simplified logic for setting `H5_LIBVER_DIR`.
>   - **Documentation**:
>     - Updated `CHANGELOG.md` to remove outdated references to `release.txt` and emphasize `HISTORY*.txt` for previous changes.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=HDFGroup%2Fhdf5&utm_source=github&utm_medium=referral)<sup> for ff06eae4013afa7a736f572520da09dcf8af4b7f. You can [customize](https://app.ellipsis.dev/HDFGroup/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->