### PR TITLE
Pin GHA dependencies by hash

### DIFF
--- a/.github/workflows/abi-report.yml
+++ b/.github/workflows/abi-report.yml
@@ -46,7 +46,7 @@ jobs:
           FILE_DOTSMAIN=$(echo "${{ inputs.file_ref }}" | sed -r "s/([0-9]+)\.([0-9]+)\.([0-9]+).*/\1\.\2\.\3/")
           echo "HDF5R_DOTSMAIN=$FILE_DOTSMAIN" >> $GITHUB_OUTPUT
 
-      - uses: actions/checkout@v6.0.0
+      - uses: actions/checkout@1af3b93b6815bc44a9784bd300feb67ff0d1eeb3 # v6.0.0
 
       - name: Get published binary (Linux)
         uses: actions/download-artifact@018cc2cf5baa6db3ef3c5f8a56943fffe632ef53 # v6.0.0
@@ -179,7 +179,7 @@ jobs:
         shell: bash
 
       - name: Save output as artifact
-        uses: actions/upload-artifact@v5
+        uses: actions/upload-artifact@330a01c490aca151604b8cf639adc76d48f6c5d4 # v5
         with:
           name: abi-reports
           path: |

--- a/.github/workflows/analysis.yml
+++ b/.github/workflows/analysis.yml
@@ -74,7 +74,7 @@ jobs:
         ls ${{ runner.workspace }}/hdf5
 
     - name: Create options file (Linux_coverage)
-      uses: "DamianReeves/write-file-action@master"
+      uses: "DamianReeves/write-file-action@1d019960841941be46b139298996df6f139cc7a4" # master
       with:
         path: ${{ runner.workspace }}/hdf5/HDF5options.cmake
         write-mode: overwrite
@@ -113,7 +113,7 @@ jobs:
 
     # Save log files created by CTest script
     - name: Save log (Linux_coverage)
-      uses: actions/upload-artifact@v5
+      uses: actions/upload-artifact@330a01c490aca151604b8cf639adc76d48f6c5d4 # v5
       with:
         name: clang-coverage-log
         path: ${{ runner.workspace }}/hdf5/hdf5.log
@@ -131,7 +131,7 @@ jobs:
           sudo apt-get install ninja-build doxygen graphviz curl libtinfo5
 
       - name: add clang to env
-        uses: KyleMayes/install-llvm-action@v2.0.8
+        uses: KyleMayes/install-llvm-action@98e68e10c96dffcb7bfed8b2144541a66b49aa02 # v2.0.8
         id: setup-clang
         with:
           env: true
@@ -175,7 +175,7 @@ jobs:
           ls ${{ runner.workspace }}/hdf5
 
       - name: Create options file (Linux_Leak)
-        uses: "DamianReeves/write-file-action@master"
+        uses: "DamianReeves/write-file-action@1d019960841941be46b139298996df6f139cc7a4" # master
         with:
           path: ${{ runner.workspace }}/hdf5/HDF5options.cmake
           write-mode: overwrite
@@ -214,7 +214,7 @@ jobs:
 
       # Save log files created by CTest script
       - name: Save log (Linux_Leak)
-        uses: actions/upload-artifact@v5
+        uses: actions/upload-artifact@330a01c490aca151604b8cf639adc76d48f6c5d4 # v5
         with:
           name: leak-ubuntu-log
           path: ${{ runner.workspace }}/hdf5/hdf5.log
@@ -232,7 +232,7 @@ jobs:
           sudo apt-get install ninja-build doxygen graphviz curl libtinfo5
 
       - name: add clang to env
-        uses: KyleMayes/install-llvm-action@v2.0.8
+        uses: KyleMayes/install-llvm-action@98e68e10c96dffcb7bfed8b2144541a66b49aa02 # v2.0.8
         id: setup-clang
         with:
           env: true
@@ -276,7 +276,7 @@ jobs:
           ls ${{ runner.workspace }}/hdf5
 
       - name: Create options file (Linux_Address)
-        uses: "DamianReeves/write-file-action@master"
+        uses: "DamianReeves/write-file-action@1d019960841941be46b139298996df6f139cc7a4" # master
         with:
           path: ${{ runner.workspace }}/hdf5/HDF5options.cmake
           write-mode: overwrite
@@ -315,7 +315,7 @@ jobs:
 
       # Save log files created by CTest script
       - name: Save log (Linux_Address)
-        uses: actions/upload-artifact@v5
+        uses: actions/upload-artifact@330a01c490aca151604b8cf639adc76d48f6c5d4 # v5
         with:
           name: address-ubuntu-log
           path: ${{ runner.workspace }}/hdf5/hdf5.log
@@ -333,7 +333,7 @@ jobs:
           sudo apt-get install ninja-build doxygen graphviz curl libtinfo5
 
       - name: add clang to env
-        uses: KyleMayes/install-llvm-action@v2.0.8
+        uses: KyleMayes/install-llvm-action@98e68e10c96dffcb7bfed8b2144541a66b49aa02 # v2.0.8
         id: setup-clang
         with:
           env: true
@@ -377,7 +377,7 @@ jobs:
           ls ${{ runner.workspace }}/hdf5
 
       - name: Create options file (Linux_UndefinedBehavior)
-        uses: "DamianReeves/write-file-action@master"
+        uses: "DamianReeves/write-file-action@1d019960841941be46b139298996df6f139cc7a4" # master
         with:
           path: ${{ runner.workspace }}/hdf5/HDF5options.cmake
           write-mode: overwrite
@@ -416,7 +416,7 @@ jobs:
 
       # Save log files created by CTest script
       - name: Save log (Linux_UndefinedBehavior)
-        uses: actions/upload-artifact@v5
+        uses: actions/upload-artifact@330a01c490aca151604b8cf639adc76d48f6c5d4 # v5
         with:
           name: undefined-ubuntu-log
           path: ${{ runner.workspace }}/hdf5/hdf5.log

--- a/.github/workflows/aocc.yml
+++ b/.github/workflows/aocc.yml
@@ -24,7 +24,7 @@ jobs:
 
     steps:
       - name: Get Sources
-        uses: actions/checkout@v6.0.0
+        uses: actions/checkout@1af3b93b6815bc44a9784bd300feb67ff0d1eeb3 # v6.0.0
 
       - name: Install Dependencies
         shell: bash
@@ -49,7 +49,7 @@ jobs:
 
       - name: Cache OpenMPI ${{ env.MPIVERDOT }} installation
         id: cache-openmpi-5_0_7
-        uses: actions/cache@v4
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
         with:
           path: /home/runner/work/hdf5/hdf5/openmpi-${{ env.MPIVERDOT }}-install
           key: ${{ runner.os }}-${{ runner.arch }}-openmpi-5_0_7-cache

--- a/.github/workflows/arm-main.yml
+++ b/.github/workflows/arm-main.yml
@@ -36,12 +36,12 @@ jobs:
     if: ${{ inputs.build_mode != 'Debug' }}
     steps:
       - name: Install Dependencies
-        uses: ssciwr/doxygen-install@v1
+        uses: ssciwr/doxygen-install@501e53b879da7648ab392ee226f5b90e42148449 # v1
         with:
           version: "1.13.2"
 
       - name: Install CMake
-        uses: lukka/get-cmake@latest
+        uses: lukka/get-cmake@9e07ecdcee1b12e5037e42f410b67f03e2f626e1 # latest
         with:
           cmakeVersion: ${{ inputs.cmake_version }}
           ninjaVersion: latest
@@ -60,7 +60,7 @@ jobs:
 
       # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
       - name: Get Sources
-        uses: actions/checkout@v6.0.0
+        uses: actions/checkout@1af3b93b6815bc44a9784bd300feb67ff0d1eeb3 # v6.0.0
 
       # CONFIGURE
       - name: Configure
@@ -151,7 +151,7 @@ jobs:
 
       # Save files created by CTest script
       - name: Save published binary (Windows)
-        uses: actions/upload-artifact@v5
+        uses: actions/upload-artifact@330a01c490aca151604b8cf639adc76d48f6c5d4 # v5
         with:
               name: zip-vs2022_cl-${{ inputs.build_mode }}-${{ inputs.save_binary }}-binary
               path: ${{ runner.workspace }}/build/HDF5-*-win64.zip
@@ -169,13 +169,13 @@ jobs:
           sudo apt install libssl3 libssl-dev libcurl4 libcurl4-openssl-dev
 
       - name: Install Dependencies
-        uses: ssciwr/doxygen-install@v1
+        uses: ssciwr/doxygen-install@501e53b879da7648ab392ee226f5b90e42148449 # v1
         with:
           version: "1.13.2"
 
       # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
       - name: Get Sources
-        uses: actions/checkout@v6.0.0
+        uses: actions/checkout@1af3b93b6815bc44a9784bd300feb67ff0d1eeb3 # v6.0.0
 
       # CONFIGURE
       - name: Configure
@@ -262,7 +262,7 @@ jobs:
                ls -l ${{ runner.workspace }}/build
 
       - name: Save published binary (linux)
-        uses: actions/upload-artifact@v5
+        uses: actions/upload-artifact@330a01c490aca151604b8cf639adc76d48f6c5d4 # v5
         with:
           name: tgz-ubuntu-2404_gcc-${{ inputs.build_mode }}-${{ inputs.save_binary }}-binary
           path: ${{ runner.workspace }}/build/HDF5-*-Linux.tar.gz
@@ -277,12 +277,12 @@ jobs:
         run: brew install ninja curl
 
       - name: Install Dependencies
-        uses: ssciwr/doxygen-install@v1
+        uses: ssciwr/doxygen-install@501e53b879da7648ab392ee226f5b90e42148449 # v1
         with:
           version: "1.13.2"
 
       - name: Install CMake
-        uses: lukka/get-cmake@latest
+        uses: lukka/get-cmake@9e07ecdcee1b12e5037e42f410b67f03e2f626e1 # latest
         with:
             cmakeVersion: ${{ inputs.cmake_version }}
             ninjaVersion: latest
@@ -295,7 +295,7 @@ jobs:
 
       # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
       - name: Get Sources
-        uses: actions/checkout@v6.0.0
+        uses: actions/checkout@1af3b93b6815bc44a9784bd300feb67ff0d1eeb3 # v6.0.0
 
       # CONFIGURE
       - name: Configure
@@ -394,7 +394,7 @@ jobs:
               ls -l ${{ runner.workspace }}/build
 
       - name: Save published binary (Mac_latest)
-        uses: actions/upload-artifact@v5
+        uses: actions/upload-artifact@330a01c490aca151604b8cf639adc76d48f6c5d4 # v5
         with:
               name: tgz-macos14_clang-${{ inputs.build_mode }}-${{ inputs.save_binary }}-binary
               path: ${{ runner.workspace }}/build/HDF5-*-Darwin.tar.gz

--- a/.github/workflows/bintest.yml
+++ b/.github/workflows/bintest.yml
@@ -33,7 +33,7 @@ jobs:
         run: choco install ninja
 
       - name: Set up JDK ${{ inputs.java_version }}
-        uses: actions/setup-java@v5
+        uses: actions/setup-java@f2beeb24e141e01a676f977032f5a29d81c9e27e # v5
         with:
           java-version: |
             ${{
@@ -44,7 +44,7 @@ jobs:
           distribution: ${{ inputs.save_binary == 'ffm' && 'oracle' || 'temurin' }}
 
       - name: Enable Developer Command Prompt
-        uses: ilammy/msvc-dev-cmd@v1.13.0
+        uses: ilammy/msvc-dev-cmd@0b201ec74fa43914dc39ae48a89fd1d8cb592756 # v1.13.0
 
       # Get files created by cmake-ctest script
       - name: Get published binary (Windows)
@@ -116,7 +116,7 @@ jobs:
           sudo apt-get install ninja-build doxygen graphviz
 
       - name: Set up JDK ${{ inputs.java_version }}
-        uses: actions/setup-java@v5
+        uses: actions/setup-java@f2beeb24e141e01a676f977032f5a29d81c9e27e # v5
         with:
           java-version: |
             ${{
@@ -173,7 +173,7 @@ jobs:
         run: brew install ninja doxygen
 
       - name: Set up JDK ${{ inputs.java_version }}
-        uses: actions/setup-java@v5
+        uses: actions/setup-java@f2beeb24e141e01a676f977032f5a29d81c9e27e # v5
         with:
           java-version: |
             ${{
@@ -213,7 +213,7 @@ jobs:
 
       # symlinks the compiler executables to a common location 
       - name: Setup GNU Fortran
-        uses: fortran-lang/setup-fortran@v1
+        uses: fortran-lang/setup-fortran@47809fdb6e637da656ce9ada436527b240c1287f # v1
         id: setup-fortran
         with:
           compiler: gcc
@@ -241,7 +241,7 @@ jobs:
           sudo apt-get install ninja-build doxygen graphviz
 
       - name: Set up JDK ${{ inputs.java_version }}
-        uses: actions/setup-java@v5
+        uses: actions/setup-java@f2beeb24e141e01a676f977032f5a29d81c9e27e # v5
         with:
           java-version: |
             ${{

--- a/.github/workflows/build-aws-c-s3.yml
+++ b/.github/workflows/build-aws-c-s3.yml
@@ -28,7 +28,7 @@ jobs:
     steps:
       - name: Check if 'libaws-c-s3-${{ inputs.build_mode }}' exists
         id: check_artifact
-        uses: softwareforgood/check-artifact-v4-existence@v0
+        uses: softwareforgood/check-artifact-v4-existence@9772fb919376f476e208587e99db557f956a2276 # v0
         with:
           name: libaws-c-s3-${{ inputs.build_mode }}
 
@@ -52,14 +52,14 @@ jobs:
     steps:
       - name: Get aws-c-s3 sources (main)
         if: inputs.aws_c_s3_tag == ''
-        uses: actions/checkout@v6.0.0
+        uses: actions/checkout@1af3b93b6815bc44a9784bd300feb67ff0d1eeb3 # v6.0.0
         with:
           repository: awslabs/aws-c-s3
           path: aws-c-s3
 
       - name: Get aws-c-s3 sources (tag)
         if: inputs.aws_c_s3_tag != ''
-        uses: actions/checkout@v6.0.0
+        uses: actions/checkout@1af3b93b6815bc44a9784bd300feb67ff0d1eeb3 # v6.0.0
         with:
           repository: awslabs/aws-c-s3
           path: aws-c-s3
@@ -78,77 +78,77 @@ jobs:
 
       - name: Cache/Restore aws-c-s3 (GCC) installation
         id: cache-aws-c-s3-ubuntu-gcc
-        uses: actions/cache@v4
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
         with:
           path: ${{ runner.workspace }}/aws-c-s3-build
           key: ${{ runner.os }}-${{ runner.arch }}-gcc-aws-c-s3-${{ steps.get-sha.outputs.sha }}-${{ inputs.build_mode }}
 
       - name: Get aws-lc sources
         if: ${{ steps.cache-aws-c-s3-ubuntu-gcc.outputs.cache-hit != 'true' }}
-        uses: actions/checkout@v6.0.0
+        uses: actions/checkout@1af3b93b6815bc44a9784bd300feb67ff0d1eeb3 # v6.0.0
         with:
           repository: aws/aws-lc
           path: aws-lc
 
       - name: Get s2n-tls sources
         if: ${{ steps.cache-aws-c-s3-ubuntu-gcc.outputs.cache-hit != 'true' }}
-        uses: actions/checkout@v6.0.0
+        uses: actions/checkout@1af3b93b6815bc44a9784bd300feb67ff0d1eeb3 # v6.0.0
         with:
           repository: aws/s2n-tls
           path: s2n-tls
 
       - name: Get aws-c-common sources
         if: ${{ steps.cache-aws-c-s3-ubuntu-gcc.outputs.cache-hit != 'true' }}
-        uses: actions/checkout@v6.0.0
+        uses: actions/checkout@1af3b93b6815bc44a9784bd300feb67ff0d1eeb3 # v6.0.0
         with:
           repository: awslabs/aws-c-common
           path: aws-c-common
 
       - name: Get aws-checksums sources
         if: ${{ steps.cache-aws-c-s3-ubuntu-gcc.outputs.cache-hit != 'true' }}
-        uses: actions/checkout@v6.0.0
+        uses: actions/checkout@1af3b93b6815bc44a9784bd300feb67ff0d1eeb3 # v6.0.0
         with:
           repository: awslabs/aws-checksums
           path: aws-checksums
 
       - name: Get aws-c-cal sources
         if: ${{ steps.cache-aws-c-s3-ubuntu-gcc.outputs.cache-hit != 'true' }}
-        uses: actions/checkout@v6.0.0
+        uses: actions/checkout@1af3b93b6815bc44a9784bd300feb67ff0d1eeb3 # v6.0.0
         with:
           repository: awslabs/aws-c-cal
           path: aws-c-cal
 
       - name: Get aws-c-io sources
         if: ${{ steps.cache-aws-c-s3-ubuntu-gcc.outputs.cache-hit != 'true' }}
-        uses: actions/checkout@v6.0.0
+        uses: actions/checkout@1af3b93b6815bc44a9784bd300feb67ff0d1eeb3 # v6.0.0
         with:
           repository: awslabs/aws-c-io
           path: aws-c-io
 
       - name: Get aws-c-compression sources
         if: ${{ steps.cache-aws-c-s3-ubuntu-gcc.outputs.cache-hit != 'true' }}
-        uses: actions/checkout@v6.0.0
+        uses: actions/checkout@1af3b93b6815bc44a9784bd300feb67ff0d1eeb3 # v6.0.0
         with:
           repository: awslabs/aws-c-compression
           path: aws-c-compression
 
       - name: Get aws-c-http sources
         if: ${{ steps.cache-aws-c-s3-ubuntu-gcc.outputs.cache-hit != 'true' }}
-        uses: actions/checkout@v6.0.0
+        uses: actions/checkout@1af3b93b6815bc44a9784bd300feb67ff0d1eeb3 # v6.0.0
         with:
           repository: awslabs/aws-c-http
           path: aws-c-http
 
       - name: Get aws-c-sdkutils sources
         if: ${{ steps.cache-aws-c-s3-ubuntu-gcc.outputs.cache-hit != 'true' }}
-        uses: actions/checkout@v6.0.0
+        uses: actions/checkout@1af3b93b6815bc44a9784bd300feb67ff0d1eeb3 # v6.0.0
         with:
           repository: awslabs/aws-c-sdkutils
           path: aws-c-sdkutils
 
       - name: Get aws-c-auth sources
         if: ${{ steps.cache-aws-c-s3-ubuntu-gcc.outputs.cache-hit != 'true' }}
-        uses: actions/checkout@v6.0.0
+        uses: actions/checkout@1af3b93b6815bc44a9784bd300feb67ff0d1eeb3 # v6.0.0
         with:
           repository: awslabs/aws-c-auth
           path: aws-c-auth
@@ -247,7 +247,7 @@ jobs:
         run: tar -cvf libaws-c-s3.tar -C ${{ runner.workspace }} aws-c-s3-build
 
       - name: Save aws-c-s3 installation artifact
-        uses: actions/upload-artifact@v5
+        uses: actions/upload-artifact@330a01c490aca151604b8cf639adc76d48f6c5d4 # v5
         with:
           name: libaws-c-s3-${{ inputs.build_mode }}
           path: libaws-c-s3.tar

--- a/.github/workflows/build_mpich_source.yml
+++ b/.github/workflows/build_mpich_source.yml
@@ -30,7 +30,7 @@ jobs:
           sudo apt-get install build-essential libtool libtool-bin
 
       - name: Get MPICH source
-        uses: actions/checkout@v6.0.0
+        uses: actions/checkout@1af3b93b6815bc44a9784bd300feb67ff0d1eeb3 # v6.0.0
         with:
           repository: 'pmodels/mpich'
           path: 'mpich'
@@ -49,7 +49,7 @@ jobs:
 
       - name: Cache MPICH (GCC) installation
         id: cache-mpich-ubuntu-gcc
-        uses: actions/cache@v4
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
         with:
           path: ${{ runner.workspace }}/mpich
           key: ${{ runner.os }}-${{ runner.arch }}-gcc-mpich-${{ steps.get-sha.outputs.sha }}-${{ inputs.build_mode }}
@@ -88,7 +88,7 @@ jobs:
         run: tar -cvf mpich.tar -C ${{ runner.workspace }} mpich
 
       - name: Save MPICH installation artifact
-        uses: actions/upload-artifact@v5
+        uses: actions/upload-artifact@330a01c490aca151604b8cf639adc76d48f6c5d4 # v5
         with:
           name: mpich
           path: mpich.tar

--- a/.github/workflows/build_openmpi_source.yml
+++ b/.github/workflows/build_openmpi_source.yml
@@ -30,7 +30,7 @@ jobs:
           sudo apt-get install build-essential libtool libtool-bin
 
       - name: Get OpenMPI source
-        uses: actions/checkout@v6.0.0
+        uses: actions/checkout@1af3b93b6815bc44a9784bd300feb67ff0d1eeb3 # v6.0.0
         with:
           repository: 'open-mpi/ompi'
           path: 'ompi'
@@ -49,7 +49,7 @@ jobs:
 
       - name: Cache OpenMPI (GCC) installation
         id: cache-openmpi-ubuntu-gcc
-        uses: actions/cache@v4
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
         with:
           path: ${{ runner.workspace }}/openmpi
           key: ${{ runner.os }}-${{ runner.arch }}-gcc-openmpi-${{ steps.get-sha.outputs.sha }}-${{ inputs.build_mode }}
@@ -81,7 +81,7 @@ jobs:
         run: tar -cvf openmpi.tar -C ${{ runner.workspace }} openmpi
 
       - name: Save OpenMPI installation artifact
-        uses: actions/upload-artifact@v5
+        uses: actions/upload-artifact@330a01c490aca151604b8cf639adc76d48f6c5d4 # v5
         with:
           name: openmpi
           path: openmpi.tar

--- a/.github/workflows/clang-format-check.yml
+++ b/.github/workflows/clang-format-check.yml
@@ -11,10 +11,10 @@ jobs:
     runs-on: ubuntu-latest
     if: "!contains(github.event.head_commit.message, 'skip-ci')"
     steps:
-    - uses: actions/checkout@v6.0.0
+    - uses: actions/checkout@1af3b93b6815bc44a9784bd300feb67ff0d1eeb3 # v6.0.0
 
     - name: Run clang-format style check for C and Java code
-      uses: DoozyX/clang-format-lint-action@v0.20
+      uses: DoozyX/clang-format-lint-action@bcb4eb2cb0d707ee4f3e5cc3b456eb075f12cf73 # v0.20
       with:
         source: '.'
         extensions: 'c,h,cpp,hpp,java'

--- a/.github/workflows/clang-format-fix.yml
+++ b/.github/workflows/clang-format-fix.yml
@@ -23,10 +23,10 @@ jobs:
     permissions:
         contents: write # In order to allow EndBug/add-and-commit to commit changes
     steps:
-    - uses: actions/checkout@v6.0.0
+    - uses: actions/checkout@1af3b93b6815bc44a9784bd300feb67ff0d1eeb3 # v6.0.0
 
     - name: Fix C and Java formatting issues detected by clang-format
-      uses: DoozyX/clang-format-lint-action@v0.20
+      uses: DoozyX/clang-format-lint-action@bcb4eb2cb0d707ee4f3e5cc3b456eb075f12cf73 # v0.20
       with:
         source: '.'
         extensions: 'c,h,cpp,hpp,java'

--- a/.github/workflows/codespell.yml
+++ b/.github/workflows/codespell.yml
@@ -10,5 +10,5 @@ jobs:
     name: Check for spelling errors
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6.0.0
-      - uses: codespell-project/actions-codespell@master
+      - uses: actions/checkout@1af3b93b6815bc44a9784bd300feb67ff0d1eeb3 # v6.0.0
+      - uses: codespell-project/actions-codespell@bca0a5887de255a8903221c67b6478c7501c5edc # master

--- a/.github/workflows/cross-compile.yml
+++ b/.github/workflows/cross-compile.yml
@@ -38,13 +38,13 @@ jobs:
           sudo apt-get install gfortran-mingw-w64-x86-64-win32
 
       - name: Install Dependencies
-        uses: ssciwr/doxygen-install@v1
+        uses: ssciwr/doxygen-install@501e53b879da7648ab392ee226f5b90e42148449 # v1
         with:
           version: "1.13.2"
 
       # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
       - name: Get Sources
-        uses: actions/checkout@v6.0.0
+        uses: actions/checkout@1af3b93b6815bc44a9784bd300feb67ff0d1eeb3 # v6.0.0
 
       # CMAKE CONFIGURE
       - name: CMake Configure
@@ -96,7 +96,7 @@ jobs:
                ls -l ${{ runner.workspace }}/build
 
       - name: Save published binary (linux)
-        uses: actions/upload-artifact@v5
+        uses: actions/upload-artifact@330a01c490aca151604b8cf639adc76d48f6c5d4 # v5
         with:
           name: tgz-ubuntu-2404_mingw64-${{ inputs.build_mode }}-binary
           path: ${{ runner.workspace }}/build/HDF5-*-win64.zip

--- a/.github/workflows/ctest.yml
+++ b/.github/workflows/ctest.yml
@@ -88,15 +88,15 @@ jobs:
         run: choco install ninja
 
       - name: Install Dependencies
-        uses: ssciwr/doxygen-install@v1
+        uses: ssciwr/doxygen-install@501e53b879da7648ab392ee226f5b90e42148449 # v1
         with:
           version: "1.13.2"
 
       - name: Enable Developer Command Prompt
-        uses: ilammy/msvc-dev-cmd@v1.13.0
+        uses: ilammy/msvc-dev-cmd@0b201ec74fa43914dc39ae48a89fd1d8cb592756 # v1.13.0
 
       - name: Install CMake
-        uses: lukka/get-cmake@latest
+        uses: lukka/get-cmake@9e07ecdcee1b12e5037e42f410b67f03e2f626e1 # latest
         with:
             cmakeVersion: ${{ inputs.cmake_version }}
             ninjaVersion: latest
@@ -108,7 +108,7 @@ jobs:
           cmake --version
 
       - name: Set up JDK 21
-        uses: actions/setup-java@v5
+        uses: actions/setup-java@f2beeb24e141e01a676f977032f5a29d81c9e27e # v5
         with:
           java-version: '21'
           distribution: 'temurin'
@@ -129,7 +129,7 @@ jobs:
 
       # Get files created by release script
       - name: Get zip-tarball (Windows)
-        uses: actions/download-artifact@v6
+        uses: actions/download-artifact@018cc2cf5baa6db3ef3c5f8a56943fffe632ef53 # v6
         with:
               name: zip-tarball
               path: ${{ github.workspace }}
@@ -159,7 +159,7 @@ jobs:
 
       - name: create-json
         id: create-json
-        uses: jsdaniell/create-json@v1.2.3
+        uses: jsdaniell/create-json@b8e77fa01397ca39cc4a6198cc29a3be5481afef # v1.2.3
         with:
             name: "credentials.json"
             dir: '${{ steps.set-file-base.outputs.SOURCE_BASE }}'
@@ -176,7 +176,7 @@ jobs:
         shell: bash
 
       - name: Sign files with Trusted Signing
-        uses: azure/trusted-signing-action@v0.5.10
+        uses: azure/trusted-signing-action@fc390cf8ed0f14e248a542af1d838388a47c7a7c # v0.5.10
         with:
           azure-tenant-id: ${{ secrets.AZURE_TENANT_ID }}
           azure-client-id: ${{ secrets.AZURE_CLIENT_ID }}
@@ -218,14 +218,14 @@ jobs:
 
       # Save files created by CTest script
       - name: Save published binary (Windows)
-        uses: actions/upload-artifact@v5
+        uses: actions/upload-artifact@330a01c490aca151604b8cf639adc76d48f6c5d4 # v5
         with:
               name: zip-vs2022_cl-binary
               path: ${{ runner.workspace }}/build/${{ steps.set-file-base.outputs.FILE_BASE }}-win-vs2022_cl.zip
               if-no-files-found: error # 'warn' or 'ignore' are also available, defaults to `warn`
 
       - name: Save published msi binary (Windows)
-        uses: actions/upload-artifact@v5
+        uses: actions/upload-artifact@330a01c490aca151604b8cf639adc76d48f6c5d4 # v5
         with:
               name: msi-vs2022_cl-binary
               path: ${{ runner.workspace }}/buildmsi/${{ steps.set-file-base.outputs.FILE_BASE }}-win-vs2022_cl.msi
@@ -244,12 +244,12 @@ jobs:
           sudo apt-get install ninja-build graphviz
 
       - name: Install Dependencies
-        uses: ssciwr/doxygen-install@v1
+        uses: ssciwr/doxygen-install@501e53b879da7648ab392ee226f5b90e42148449 # v1
         with:
           version: "1.13.2"
 
       - name: Install CMake
-        uses: lukka/get-cmake@latest
+        uses: lukka/get-cmake@9e07ecdcee1b12e5037e42f410b67f03e2f626e1 # latest
         with:
             cmakeVersion: ${{ inputs.cmake_version }}
             ninjaVersion: latest
@@ -261,7 +261,7 @@ jobs:
           cmake --version
 
       - name: Set up JDK 21
-        uses: actions/setup-java@v5
+        uses: actions/setup-java@f2beeb24e141e01a676f977032f5a29d81c9e27e # v5
         with:
           java-version: '21'
           distribution: 'temurin'
@@ -281,7 +281,7 @@ jobs:
 
       # Get files created by release script
       - name: Get tgz-tarball (Linux)
-        uses: actions/download-artifact@v6
+        uses: actions/download-artifact@018cc2cf5baa6db3ef3c5f8a56943fffe632ef53 # v6
         with:
               name: tgz-tarball
               path: ${{ github.workspace }}
@@ -347,21 +347,21 @@ jobs:
 
       # Save files created by CTest script
       - name: Save published binary (Linux)
-        uses: actions/upload-artifact@v5
+        uses: actions/upload-artifact@330a01c490aca151604b8cf639adc76d48f6c5d4 # v5
         with:
               name: tgz-ubuntu-2404_gcc-binary
               path: ${{ runner.workspace }}/build/${{ steps.set-file-base.outputs.FILE_BASE }}-ubuntu-2404_gcc.tar.gz
               if-no-files-found: error # 'warn' or 'ignore' are also available, defaults to `warn`
 
       - name: Save published binary deb (Linux)
-        uses: actions/upload-artifact@v5
+        uses: actions/upload-artifact@330a01c490aca151604b8cf639adc76d48f6c5d4 # v5
         with:
               name: deb-ubuntu-2404_gcc-binary
               path: ${{ runner.workspace }}/builddeb/${{ steps.set-file-base.outputs.FILE_BASE }}-ubuntu-2404_gcc.deb
               if-no-files-found: error # 'warn' or 'ignore' are also available, defaults to `warn`
 
       - name: Save published binary rpm (Linux)
-        uses: actions/upload-artifact@v5
+        uses: actions/upload-artifact@330a01c490aca151604b8cf639adc76d48f6c5d4 # v5
         with:
               name: rpm-ubuntu-2404_gcc-binary
               path: ${{ runner.workspace }}/buildrpm/${{ steps.set-file-base.outputs.FILE_BASE }}-ubuntu-2404_gcc.rpm
@@ -369,7 +369,7 @@ jobs:
 
       # Save doxygen files created by CTest script
       - name: Save published doxygen (Linux)
-        uses: actions/upload-artifact@v5
+        uses: actions/upload-artifact@330a01c490aca151604b8cf639adc76d48f6c5d4 # v5
         with:
               name: docs-doxygen
               path: ${{ runner.workspace }}/hdf5/build/${{ steps.run-ctest.outputs.ACTIVE_PRESET }}/hdf5lib_docs/html
@@ -400,7 +400,7 @@ jobs:
 
       - name: Upload Maven artifacts (Linux)
         if: ${{ inputs.maven_enabled == true }}
-        uses: actions/upload-artifact@v5
+        uses: actions/upload-artifact@330a01c490aca151604b8cf639adc76d48f6c5d4 # v5
         with:
               name: Linux-${{ inputs.preset_name }}-artifacts
               path: ${{ runner.workspace }}/maven-artifacts
@@ -417,7 +417,7 @@ jobs:
         run: brew install ninja
 
       - name: Install Dependencies
-        uses: ssciwr/doxygen-install@v1
+        uses: ssciwr/doxygen-install@501e53b879da7648ab392ee226f5b90e42148449 # v1
         with:
           version: "1.13.2"
 
@@ -428,7 +428,7 @@ jobs:
           clang -v
 
       - name: Install CMake
-        uses: lukka/get-cmake@latest
+        uses: lukka/get-cmake@9e07ecdcee1b12e5037e42f410b67f03e2f626e1 # latest
         with:
             cmakeVersion: ${{ inputs.cmake_version }}
             ninjaVersion: latest
@@ -462,7 +462,7 @@ jobs:
         if: ${{ needs.check-secret.outputs.sign-state == 'exists' }}
 
       - name: Set up JDK 19
-        uses: actions/setup-java@v5
+        uses: actions/setup-java@f2beeb24e141e01a676f977032f5a29d81c9e27e # v5
         with:
           java-version: '21'
           distribution: 'temurin'
@@ -482,7 +482,7 @@ jobs:
 
       # Get files created by release script
       - name: Get tgz-tarball (MacOS_latest)
-        uses: actions/download-artifact@v6
+        uses: actions/download-artifact@018cc2cf5baa6db3ef3c5f8a56943fffe632ef53 # v6
         with:
               name: tgz-tarball
               path: ${{ github.workspace }}
@@ -497,7 +497,7 @@ jobs:
 
       # symlinks the compiler executables to a common location 
       - name: Setup GNU Fortran
-        uses: fortran-lang/setup-fortran@v1
+        uses: fortran-lang/setup-fortran@47809fdb6e637da656ce9ada436527b240c1287f # v1
         id: setup-fortran
         with:
           compiler: gcc
@@ -625,14 +625,14 @@ jobs:
 
       # Save files created by CTest script
       - name: Save published binary (MacOS_latest)
-        uses: actions/upload-artifact@v5
+        uses: actions/upload-artifact@330a01c490aca151604b8cf639adc76d48f6c5d4 # v5
         with:
               name: tgz-macos14_clang-binary
               path: ${{ runner.workspace }}/build/${{ steps.set-file-base.outputs.FILE_BASE }}-macos14_clang.tar.gz
               if-no-files-found: error # 'warn' or 'ignore' are also available, defaults to `warn`
 
       - name: Save published dmg binary (MacOS_latest)
-        uses: actions/upload-artifact@v5
+        uses: actions/upload-artifact@330a01c490aca151604b8cf639adc76d48f6c5d4 # v5
         with:
               name: tgz-macos14_clang-dmg-binary
               path: ${{ runner.workspace }}/builddmg/${{ steps.set-file-base.outputs.FILE_BASE }}-macos14_clang.dmg
@@ -650,13 +650,13 @@ jobs:
           sudo apt-get install ninja-build doxygen
 
       - name: Install CMake
-        uses: lukka/get-cmake@latest
+        uses: lukka/get-cmake@9e07ecdcee1b12e5037e42f410b67f03e2f626e1 # latest
         with:
             cmakeVersion: ${{ inputs.cmake_version }}
             ninjaVersion: latest
 
       - name: Install aws-c-s3 (Cached installation)
-        uses: actions/download-artifact@v6
+        uses: actions/download-artifact@018cc2cf5baa6db3ef3c5f8a56943fffe632ef53 # v6
         with:
           name: libaws-c-s3-Release
 
@@ -689,7 +689,7 @@ jobs:
 
       # Get files created by release script
       - name: Get tgz-tarball (Linux S3)
-        uses: actions/download-artifact@v6
+        uses: actions/download-artifact@018cc2cf5baa6db3ef3c5f8a56943fffe632ef53 # v6
         with:
               name: tgz-tarball
               path: ${{ github.workspace }}
@@ -727,7 +727,7 @@ jobs:
 
       # Save files created by CTest script
       - name: Save published binary (Linux S3)
-        uses: actions/upload-artifact@v5
+        uses: actions/upload-artifact@330a01c490aca151604b8cf639adc76d48f6c5d4 # v5
         with:
               name: tgz-ubuntu-2404_gcc_s3-binary
               path: ${{ runner.workspace }}/build/${{ steps.set-file-base.outputs.FILE_BASE }}-ubuntu-2404_gcc_s3.tar.gz
@@ -745,14 +745,14 @@ jobs:
         run: choco install ninja
 
       - name: add oneAPI to env
-        uses: fortran-lang/setup-fortran@v1
+        uses: fortran-lang/setup-fortran@47809fdb6e637da656ce9ada436527b240c1287f # v1
         id: setup-fortran
         with:
           compiler: intel
           version: '2025.0'
 
       - name: Install CMake
-        uses: lukka/get-cmake@latest
+        uses: lukka/get-cmake@9e07ecdcee1b12e5037e42f410b67f03e2f626e1 # latest
         with:
             cmakeVersion: ${{ inputs.cmake_version }}
             ninjaVersion: latest
@@ -773,7 +773,7 @@ jobs:
 
       # Get files created by release script
       - name: Get zip-tarball (Windows_intel)
-        uses: actions/download-artifact@v6
+        uses: actions/download-artifact@018cc2cf5baa6db3ef3c5f8a56943fffe632ef53 # v6
         with:
               name: zip-tarball
               path: ${{ github.workspace }}
@@ -803,7 +803,7 @@ jobs:
 
       - name: create-json
         id: create-json
-        uses: jsdaniell/create-json@v1.2.3
+        uses: jsdaniell/create-json@b8e77fa01397ca39cc4a6198cc29a3be5481afef # v1.2.3
         with:
             name: "credentials.json"
             dir: '${{ steps.set-file-base.outputs.SOURCE_BASE }}'
@@ -823,7 +823,7 @@ jobs:
         shell: pwsh
 
       - name: Sign files with Trusted Signing (Windows_intel)
-        uses: azure/trusted-signing-action@v0.5.10
+        uses: azure/trusted-signing-action@fc390cf8ed0f14e248a542af1d838388a47c7a7c # v0.5.10
         with:
           azure-tenant-id: ${{ secrets.AZURE_TENANT_ID }}
           azure-client-id: ${{ secrets.AZURE_CLIENT_ID }}
@@ -865,14 +865,14 @@ jobs:
 
       # Save files created by CTest script
       - name: Save published binary (Windows_intel)
-        uses: actions/upload-artifact@v5
+        uses: actions/upload-artifact@330a01c490aca151604b8cf639adc76d48f6c5d4 # v5
         with:
               name: zip-vs2022_intel-binary
               path: ${{ runner.workspace }}/build/${{ steps.set-file-base.outputs.FILE_BASE }}-win-vs2022_intel.zip
               if-no-files-found: error # 'warn' or 'ignore' are also available, defaults to `warn`
 
       - name: Save published msi binary (Windows_intel)
-        uses: actions/upload-artifact@v5
+        uses: actions/upload-artifact@330a01c490aca151604b8cf639adc76d48f6c5d4 # v5
         with:
               name: msi-vs2022_intel-binary
               path: ${{ runner.workspace }}/buildmsi/${{ steps.set-file-base.outputs.FILE_BASE }}-win-vs2022_intel.msi
@@ -891,14 +891,14 @@ jobs:
           sudo apt-get install ninja-build doxygen graphviz
 
       - name: add oneAPI to env
-        uses: fortran-lang/setup-fortran@v1
+        uses: fortran-lang/setup-fortran@47809fdb6e637da656ce9ada436527b240c1287f # v1
         id: setup-fortran
         with:
           compiler: intel
           version: '2025.0'
 
       - name: Install CMake
-        uses: lukka/get-cmake@latest
+        uses: lukka/get-cmake@9e07ecdcee1b12e5037e42f410b67f03e2f626e1 # latest
         with:
             cmakeVersion: ${{ inputs.cmake_version }}
             ninjaVersion: latest
@@ -918,7 +918,7 @@ jobs:
 
       # Get files created by release script
       - name: Get tgz-tarball (Linux_intel)
-        uses: actions/download-artifact@v6
+        uses: actions/download-artifact@018cc2cf5baa6db3ef3c5f8a56943fffe632ef53 # v6
         with:
               name: tgz-tarball
               path: ${{ github.workspace }}
@@ -959,7 +959,7 @@ jobs:
 
       # Save files created by CTest script
       - name: Save published binary (Linux_intel)
-        uses: actions/upload-artifact@v5
+        uses: actions/upload-artifact@330a01c490aca151604b8cf639adc76d48f6c5d4 # v5
         with:
               name: tgz-ubuntu-2404_intel-binary
               path: ${{ runner.workspace }}/build/${{ steps.set-file-base.outputs.FILE_BASE }}-ubuntu-2404_intel.tar.gz

--- a/.github/workflows/cve.yml
+++ b/.github/workflows/cve.yml
@@ -28,7 +28,7 @@ jobs:
     name: CVE regression
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6.0.0
+      - uses: actions/checkout@1af3b93b6815bc44a9784bd300feb67ff0d1eeb3 # v6.0.0
 
       - name: Install HDF5
         run: |
@@ -38,7 +38,7 @@ jobs:
           make
           sudo make install
       - name: Checkout CVE test repository
-        uses: actions/checkout@v6.0.0
+        uses: actions/checkout@1af3b93b6815bc44a9784bd300feb67ff0d1eeb3 # v6.0.0
         with:
           repository: HDFGroup/cve_hdf5
           path: cve_hdf5

--- a/.github/workflows/cygwin.yml
+++ b/.github/workflows/cygwin.yml
@@ -33,10 +33,10 @@ jobs:
           git config --global core.autocrlf input
 
       - name: Get Sources
-        uses: actions/checkout@v6.0.0
+        uses: actions/checkout@1af3b93b6815bc44a9784bd300feb67ff0d1eeb3 # v6.0.0
 
       - name: Install Cygwin
-        uses: cygwin/cygwin-install-action@master
+        uses: cygwin/cygwin-install-action@b9bf9147075ee9811ac11beee9351eeb93e2f2fb # master
         with:
           packages: cmake gcc-fortran make ninja zlib-devel flex bison perl
 
@@ -81,7 +81,7 @@ jobs:
             ls ${{ runner.workspace }}/hdf5
 
       - name: Create options file (Cygwin)
-        uses: "DamianReeves/write-file-action@master"
+        uses: "DamianReeves/write-file-action@1d019960841941be46b139298996df6f139cc7a4" # master
         with:
           path: ${{ runner.workspace }}/hdf5/HDF5options.cmake
           write-mode: overwrite
@@ -119,7 +119,7 @@ jobs:
 
       # Save log files created by CTest script
       - name: Save log (Cygwin)
-        uses: actions/upload-artifact@v5
+        uses: actions/upload-artifact@330a01c490aca151604b8cf639adc76d48f6c5d4 # v5
         with:
             name: gcc-cygwin-log
             path: ${{ runner.workspace }}/hdf5/hdf5.log

--- a/.github/workflows/daily-build.yml
+++ b/.github/workflows/daily-build.yml
@@ -36,10 +36,10 @@ jobs:
       run-ignore: ${{ steps.getinputs.outputs.INPUTS_IGNORE }}
 
     steps:
-    - uses: actions/checkout@v6.0.0
+    - uses: actions/checkout@1af3b93b6815bc44a9784bd300feb67ff0d1eeb3 # v6.0.0
 
     - name: Get hdf5 release base name
-      uses: dsaltares/fetch-gh-release-asset@master
+      uses: dsaltares/fetch-gh-release-asset@aa2ab1243d6e0d5b405b973c89fa4d06a2d0fff7 # master
       with:
         version: 'tags/snapshot'
         file: 'last-file.txt'

--- a/.github/workflows/daily-schedule.yml
+++ b/.github/workflows/daily-schedule.yml
@@ -29,7 +29,7 @@ jobs:
 
       # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
       - name: Get Sources
-        uses: actions/checkout@v6.0.0
+        uses: actions/checkout@1af3b93b6815bc44a9784bd300feb67ff0d1eeb3 # v6.0.0
         with:
           fetch-depth: 0
           ref: '${{ github.head_ref || github.ref_name }}'
@@ -42,7 +42,7 @@ jobs:
           path: ${{ github.workspace }}/${{ steps.get-file-base.outputs.FILE_BASE }}.doxygen
 
       - name: Setup AWS CLI
-        uses: aws-actions/configure-aws-credentials@v5
+        uses: aws-actions/configure-aws-credentials@61815dcd50bd041e203e49132bacad1fd04d2708 # v5
         with:
                aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
                aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}

--- a/.github/workflows/dev.yml
+++ b/.github/workflows/dev.yml
@@ -101,12 +101,12 @@ jobs:
         run: choco install ninja
 
       - name: Install Dependencies
-        uses: ssciwr/doxygen-install@v1
+        uses: ssciwr/doxygen-install@501e53b879da7648ab392ee226f5b90e42148449 # v1
         with:
           version: "1.13.2"
 
       - name: Enable Developer Command Prompt
-        uses: ilammy/msvc-dev-cmd@v1.13.0
+        uses: ilammy/msvc-dev-cmd@0b201ec74fa43914dc39ae48a89fd1d8cb592756 # v1.13.0
 
       - name: Check CMake Version
         shell: bash
@@ -177,7 +177,7 @@ jobs:
         run: brew install ninja
 
       - name: Install Dependencies
-        uses: ssciwr/doxygen-install@v1
+        uses: ssciwr/doxygen-install@501e53b879da7648ab392ee226f5b90e42148449 # v1
         with:
           version: "1.13.2"
 
@@ -266,7 +266,7 @@ jobs:
           sudo apt-get install ninja-build doxygen graphviz curl libtinfo5
 
       - name: add clang to env
-        uses: KyleMayes/install-llvm-action@v2.0.8
+        uses: KyleMayes/install-llvm-action@98e68e10c96dffcb7bfed8b2144541a66b49aa02 # v2.0.8
         id: setup-clang
         with:
           env: true

--- a/.github/workflows/freebsd.yml
+++ b/.github/workflows/freebsd.yml
@@ -38,10 +38,10 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6.0.0
+        uses: actions/checkout@1af3b93b6815bc44a9784bd300feb67ff0d1eeb3 # v6.0.0
 
       - name: Build and test on FreeBSD
-        uses: vmactions/freebsd-vm@v1
+        uses: vmactions/freebsd-vm@670398e4236735b8b65805c3da44b7a511fb8b27 # v1
         with:
           release: ${{ matrix.freebsd-version }}
           usesh: true

--- a/.github/workflows/h5py.yml
+++ b/.github/workflows/h5py.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Checkout Spack
-      uses: actions/checkout@v6.0.0
+      uses: actions/checkout@1af3b93b6815bc44a9784bd300feb67ff0d1eeb3 # v6.0.0
       with:
         repository: spack/spack
         path: ./spack

--- a/.github/workflows/hdfeos5.yml
+++ b/.github/workflows/hdfeos5.yml
@@ -36,7 +36,7 @@ jobs:
             sudo apt install -y libaec-dev zlib1g-dev automake autoconf libcurl4-openssl-dev libjpeg-dev wget curl bzip2 m4 flex bison cmake libzip-dev doxygen openssl libtool libtool-bin
 
       - name: Checkout HDF5
-        uses: actions/checkout@v6.0.0
+        uses: actions/checkout@1af3b93b6815bc44a9784bd300feb67ff0d1eeb3 # v6.0.0
 
       - name: Configure
         run: |

--- a/.github/workflows/i386.yml
+++ b/.github/workflows/i386.yml
@@ -18,10 +18,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Get Sources
-        uses: actions/checkout@v6.0.0
+        uses: actions/checkout@1af3b93b6815bc44a9784bd300feb67ff0d1eeb3 # v6.0.0
 
       - name: setup alpine
-        uses: jirutka/setup-alpine@v1
+        uses: jirutka/setup-alpine@ae3b3ddba35054804fc4a3507b519fa7e8152050 # v1
         with:
           arch: x86
           packages: >

--- a/.github/workflows/intel.yml
+++ b/.github/workflows/intel.yml
@@ -18,7 +18,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Get Sources (Linux)
-        uses: actions/checkout@v6.0.0
+        uses: actions/checkout@1af3b93b6815bc44a9784bd300feb67ff0d1eeb3 # v6.0.0
 
       - name: Install Dependencies (Linux)
         shell: bash
@@ -28,7 +28,7 @@ jobs:
            sudo apt install libssl3 libssl-dev libcurl4 libcurl4-openssl-dev
 
       - name: Install oneAPI (Linux)
-        uses: fortran-lang/setup-fortran@v1
+        uses: fortran-lang/setup-fortran@47809fdb6e637da656ce9ada436527b240c1287f # v1
         id: setup-fortran
         with:
           compiler: intel
@@ -71,13 +71,13 @@ jobs:
     runs-on: windows-latest
     steps:
       - name: Get Sources (Windows)
-        uses: actions/checkout@v6.0.0
+        uses: actions/checkout@1af3b93b6815bc44a9784bd300feb67ff0d1eeb3 # v6.0.0
 
       - name: Install Dependencies (Windows)
         run: choco install ninja
 
       - name: install oneAPI (Windows)
-        uses: fortran-lang/setup-fortran@v1
+        uses: fortran-lang/setup-fortran@47809fdb6e637da656ce9ada436527b240c1287f # v1
         id: setup-fortran
         with:
           compiler: intel

--- a/.github/workflows/java-examples-maven-test.yml
+++ b/.github/workflows/java-examples-maven-test.yml
@@ -27,7 +27,7 @@ jobs:
         category: [H5D, H5T, H5G, TUTR]
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6.0.0
+        uses: actions/checkout@1af3b93b6815bc44a9784bd300feb67ff0d1eeb3 # v6.0.0
 
       - name: Download Maven artifacts (Linux)
         uses: actions/download-artifact@018cc2cf5baa6db3ef3c5f8a56943fffe632ef53 # v6.0.0
@@ -37,13 +37,13 @@ jobs:
         continue-on-error: true
 
       - name: Set up JDK 21
-        uses: actions/setup-java@v5
+        uses: actions/setup-java@f2beeb24e141e01a676f977032f5a29d81c9e27e # v5
         with:
           java-version: '21'
           distribution: 'temurin'
 
       - name: Cache Maven dependencies
-        uses: actions/cache@v4
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
         with:
           path: ~/.m2/repository
           key: ${{ runner.os }}-maven-examples-${{ hashFiles('**/pom-examples.xml*') }}
@@ -171,7 +171,7 @@ jobs:
 
       - name: Upload failure artifacts (Linux ${{ matrix.category }})
         if: steps.test-examples.outputs.test-status == 'FAILED'
-        uses: actions/upload-artifact@v5
+        uses: actions/upload-artifact@330a01c490aca151604b8cf639adc76d48f6c5d4 # v5
         with:
           name: java-examples-failure-linux-${{ matrix.category }}-${{ github.run_id }}
           path: |
@@ -190,7 +190,7 @@ jobs:
         category: [H5D, H5T, H5G, TUTR]
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6.0.0
+        uses: actions/checkout@1af3b93b6815bc44a9784bd300feb67ff0d1eeb3 # v6.0.0
 
       - name: Download Maven artifacts (Windows)
         uses: actions/download-artifact@018cc2cf5baa6db3ef3c5f8a56943fffe632ef53 # v6.0.0
@@ -200,13 +200,13 @@ jobs:
         continue-on-error: true
 
       - name: Set up JDK 21
-        uses: actions/setup-java@v5
+        uses: actions/setup-java@f2beeb24e141e01a676f977032f5a29d81c9e27e # v5
         with:
           java-version: '21'
           distribution: 'temurin'
 
       - name: Cache Maven dependencies
-        uses: actions/cache@v4
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
         with:
           path: ~/.m2/repository
           key: ${{ runner.os }}-maven-examples-${{ hashFiles('**/pom-examples.xml*') }}
@@ -291,7 +291,7 @@ jobs:
 
       - name: Upload failure artifacts (Windows ${{ matrix.category }})
         if: steps.test-examples.outputs.test-status == 'FAILED'
-        uses: actions/upload-artifact@v5
+        uses: actions/upload-artifact@330a01c490aca151604b8cf639adc76d48f6c5d4 # v5
         with:
           name: java-examples-failure-windows-${{ matrix.category }}-${{ github.run_id }}
           path: |
@@ -309,7 +309,7 @@ jobs:
         category: [H5D, H5T, H5G, TUTR]
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6.0.0
+        uses: actions/checkout@1af3b93b6815bc44a9784bd300feb67ff0d1eeb3 # v6.0.0
 
       - name: Download Maven artifacts (macOS aarch64)
         uses: actions/download-artifact@018cc2cf5baa6db3ef3c5f8a56943fffe632ef53 # v6.0.0
@@ -319,13 +319,13 @@ jobs:
         continue-on-error: true
 
       - name: Set up JDK 21
-        uses: actions/setup-java@v5
+        uses: actions/setup-java@f2beeb24e141e01a676f977032f5a29d81c9e27e # v5
         with:
           java-version: '21'
           distribution: 'temurin'
 
       - name: Cache Maven dependencies
-        uses: actions/cache@v4
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
         with:
           path: ~/.m2/repository
           key: ${{ runner.os }}-maven-examples-${{ hashFiles('**/pom-examples.xml*') }}
@@ -417,7 +417,7 @@ jobs:
 
       - name: Upload failure artifacts (macOS ${{ matrix.category }})
         if: steps.test-examples.outputs.test-status == 'FAILED'
-        uses: actions/upload-artifact@v5
+        uses: actions/upload-artifact@330a01c490aca151604b8cf639adc76d48f6c5d4 # v5
         with:
           name: java-examples-failure-macos-${{ matrix.category }}-${{ github.run_id }}
           path: |
@@ -467,7 +467,7 @@ jobs:
           echo "Test summary report generated"
 
       - name: Upload Test Summary
-        uses: actions/upload-artifact@v5
+        uses: actions/upload-artifact@330a01c490aca151604b8cf639adc76d48f6c5d4 # v5
         with:
           name: java-examples-test-summary-${{ github.run_id }}
           path: java-examples-test-summary.md

--- a/.github/workflows/java-implementation-test.yml
+++ b/.github/workflows/java-implementation-test.yml
@@ -120,12 +120,12 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6.0.0
+        uses: actions/checkout@1af3b93b6815bc44a9784bd300feb67ff0d1eeb3 # v6.0.0
         with:
           submodules: recursive
 
       - name: Set up Java ${{ matrix.java-version }} (${{ matrix.implementation }})
-        uses: actions/setup-java@v5
+        uses: actions/setup-java@f2beeb24e141e01a676f977032f5a29d81c9e27e # v5
         with:
           distribution: ${{ matrix.implementation == 'ffm' && 'oracle' || 'temurin' }}
           java-version: ${{ matrix.implementation == 'ffm' && '25' || matrix.java-version }}
@@ -153,7 +153,7 @@ jobs:
           choco install ninja
 
       - name: Cache CMake build
-        uses: actions/cache@v4
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
         with:
           path: |
             build-test-*
@@ -187,7 +187,7 @@ jobs:
 
       - name: Upload build artifacts on failure
         if: failure()
-        uses: actions/upload-artifact@v5
+        uses: actions/upload-artifact@330a01c490aca151604b8cf639adc76d48f6c5d4 # v5
         with:
           name: build-logs-${{ matrix.os }}-java${{ matrix.java-version }}-${{ matrix.implementation }}
           path: |
@@ -198,7 +198,7 @@ jobs:
 
       - name: Upload Maven artifacts (if generated)
         if: inputs.test_mode == 'maven' || inputs.test_mode == 'full'
-        uses: actions/upload-artifact@v5
+        uses: actions/upload-artifact@330a01c490aca151604b8cf639adc76d48f6c5d4 # v5
         with:
           name: maven-artifacts-${{ matrix.os }}-java${{ matrix.java-version }}-${{ matrix.implementation }}
           path: |
@@ -213,7 +213,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6.0.0
+        uses: actions/checkout@1af3b93b6815bc44a9784bd300feb67ff0d1eeb3 # v6.0.0
 
       - name: Download all Maven artifacts
         uses: actions/download-artifact@018cc2cf5baa6db3ef3c5f8a56943fffe632ef53 # v6.0.0

--- a/.github/workflows/julia.yml
+++ b/.github/workflows/julia.yml
@@ -17,7 +17,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Get HDF5 source
-        uses: actions/checkout@v6.0.0
+        uses: actions/checkout@1af3b93b6815bc44a9784bd300feb67ff0d1eeb3 # v6.0.0
 
       - name: Install Dependencies
         shell: bash
@@ -58,13 +58,13 @@ jobs:
         working-directory: ${{ runner.workspace }}/build
 
       - name: Install julia
-        uses: julia-actions/setup-julia@latest
+        uses: julia-actions/setup-julia@5c9647d97b78a5debe5164e9eec09d653d29bd71 # latest
         with:
           version: '1.6'
           arch: 'x64'
 
       - name: Get julia hdf5 source
-        uses: actions/checkout@v6.0.0
+        uses: actions/checkout@1af3b93b6815bc44a9784bd300feb67ff0d1eeb3 # v6.0.0
         with:
           repository: JuliaIO/HDF5.jl
           path: .
@@ -75,9 +75,9 @@ jobs:
           echo 'libhdf5 = "/tmp/lib/libhdf5.so"' >> LocalPreferences.toml
           echo 'libhdf5_hl = "/tmp/lib/libhdf5_hl.so"' >> LocalPreferences.toml
 
-      - uses: julia-actions/julia-buildpkg@latest
+      - uses: julia-actions/julia-buildpkg@e3eb439fad4f9aba7da2667e7510e4a46ebc46e1 # latest
 
       - name: Julia Run Tests
-        uses: julia-actions/julia-runtest@latest
+        uses: julia-actions/julia-runtest@d60b785c6f2bdf4ebfb18b2b6f7d93b7dfb0efe3 # latest
         env:
           JULIA_DEBUG: Main

--- a/.github/workflows/linkchecker.yml
+++ b/.github/workflows/linkchecker.yml
@@ -18,7 +18,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Repository
-        uses: actions/checkout@v6.0.0
+        uses: actions/checkout@1af3b93b6815bc44a9784bd300feb67ff0d1eeb3 # v6.0.0
 
       - name: Install System Dependencies
         run: |
@@ -40,7 +40,7 @@ jobs:
 
       - name: Run Comprehensive Link Check
         id: lychee
-        uses: lycheeverse/lychee-action@v2.7.0
+        uses: lycheeverse/lychee-action@a8c4c7cb88f0c7386610c35eb25108e448569cb0 # v2.7.0
         with:
           args: >
             --base ${{ steps.build_docs.outputs.html_path }}

--- a/.github/workflows/macos-26-matrix.yml
+++ b/.github/workflows/macos-26-matrix.yml
@@ -187,7 +187,7 @@ jobs:
 
 
     - name: Get Sources
-      uses: actions/checkout@v6.0.0
+      uses: actions/checkout@1af3b93b6815bc44a9784bd300feb67ff0d1eeb3 # v6.0.0
 
     - name: Configure
       run: |
@@ -268,7 +268,7 @@ jobs:
         CTEST_TIMEOUT: 3600
 
     - name: Upload Test Results
-      uses: actions/upload-artifact@v5
+      uses: actions/upload-artifact@330a01c490aca151604b8cf639adc76d48f6c5d4 # v5
       if: always()
       with:
         name: test-results-${{ matrix.name }}

--- a/.github/workflows/main-par-spc.yml
+++ b/.github/workflows/main-par-spc.yml
@@ -23,7 +23,7 @@ jobs:
     name: "Parallel GCC-${{ inputs.build_mode }}"
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6.0.0
+      - uses: actions/checkout@1af3b93b6815bc44a9784bd300feb67ff0d1eeb3 # v6.0.0
 
       - name: Install Linux Dependencies
         run: |

--- a/.github/workflows/main-par.yml
+++ b/.github/workflows/main-par.yml
@@ -23,7 +23,7 @@ jobs:
     name: "Parallel GCC-${{ inputs.build_mode }}"
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6.0.0
+      - uses: actions/checkout@1af3b93b6815bc44a9784bd300feb67ff0d1eeb3 # v6.0.0
 
       - name: Install Linux Dependencies
         run: |

--- a/.github/workflows/main-spc.yml
+++ b/.github/workflows/main-spc.yml
@@ -36,7 +36,7 @@ jobs:
  
       # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
       - name: Get Sources
-        uses: actions/checkout@v6.0.0
+        uses: actions/checkout@1af3b93b6815bc44a9784bd300feb67ff0d1eeb3 # v6.0.0
 
       # CONFIGURE
       - name: Configure
@@ -95,7 +95,7 @@ jobs:
  
       # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
       - name: Get Sources
-        uses: actions/checkout@v6.0.0
+        uses: actions/checkout@1af3b93b6815bc44a9784bd300feb67ff0d1eeb3 # v6.0.0
 
       # CONFIGURE
       - name: Configure
@@ -149,7 +149,7 @@ jobs:
  
       # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
       - name: Get Sources
-        uses: actions/checkout@v6.0.0
+        uses: actions/checkout@1af3b93b6815bc44a9784bd300feb67ff0d1eeb3 # v6.0.0
 
       # CONFIGURE
       - name: Configure
@@ -203,7 +203,7 @@ jobs:
  
       # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
       - name: Get Sources
-        uses: actions/checkout@v6.0.0
+        uses: actions/checkout@1af3b93b6815bc44a9784bd300feb67ff0d1eeb3 # v6.0.0
 
       # CONFIGURE
       - name: Configure
@@ -255,7 +255,7 @@ jobs:
 
       # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
       - name: Get Sources
-        uses: actions/checkout@v6.0.0
+        uses: actions/checkout@1af3b93b6815bc44a9784bd300feb67ff0d1eeb3 # v6.0.0
 
       # CONFIGURE
       - name: Configure
@@ -307,7 +307,7 @@ jobs:
 
       # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
       - name: Get Sources
-        uses: actions/checkout@v6.0.0
+        uses: actions/checkout@1af3b93b6815bc44a9784bd300feb67ff0d1eeb3 # v6.0.0
 
       # CONFIGURE
       - name: Configure
@@ -352,12 +352,12 @@ jobs:
         run: choco install ninja
 
       - name: Install Dependencies
-        uses: ssciwr/doxygen-install@v1
+        uses: ssciwr/doxygen-install@501e53b879da7648ab392ee226f5b90e42148449 # v1
         with:
           version: "1.13.2"
 
       - name: install oneAPI (Windows)
-        uses: fortran-lang/setup-fortran@v1
+        uses: fortran-lang/setup-fortran@47809fdb6e637da656ce9ada436527b240c1287f # v1
         id: setup-fortran
         with:
           compiler: intel
@@ -365,7 +365,7 @@ jobs:
 
       # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
       - name: Get Sources
-        uses: actions/checkout@v6.0.0
+        uses: actions/checkout@1af3b93b6815bc44a9784bd300feb67ff0d1eeb3 # v6.0.0
 
       - name: Configure (Windows)
         shell: pwsh
@@ -412,7 +412,7 @@ jobs:
 
       # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
       - name: Get Sources
-        uses: actions/checkout@v6.0.0
+        uses: actions/checkout@1af3b93b6815bc44a9784bd300feb67ff0d1eeb3 # v6.0.0
 
       # CONFIGURE
       - name: Configure
@@ -469,7 +469,7 @@ jobs:
 
       # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
       - name: Get Sources
-        uses: actions/checkout@v6.0.0
+        uses: actions/checkout@1af3b93b6815bc44a9784bd300feb67ff0d1eeb3 # v6.0.0
 
       # CONFIGURE
       - name: Configure
@@ -522,7 +522,7 @@ jobs:
 
       # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
       - name: Get Sources
-        uses: actions/checkout@v6.0.0
+        uses: actions/checkout@1af3b93b6815bc44a9784bd300feb67ff0d1eeb3 # v6.0.0
 
       # CONFIGURE
       - name: Configure
@@ -575,7 +575,7 @@ jobs:
 
       # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
       - name: Get Sources
-        uses: actions/checkout@v6.0.0
+        uses: actions/checkout@1af3b93b6815bc44a9784bd300feb67ff0d1eeb3 # v6.0.0
 
       # CONFIGURE
       - name: Configure
@@ -623,7 +623,7 @@ jobs:
 
       # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
       - name: Get Sources
-        uses: actions/checkout@v6.0.0
+        uses: actions/checkout@1af3b93b6815bc44a9784bd300feb67ff0d1eeb3 # v6.0.0
 
       # CONFIGURE
       - name: Configure

--- a/.github/workflows/main-static.yml
+++ b/.github/workflows/main-static.yml
@@ -136,12 +136,12 @@ jobs:
         if: ${{ matrix.ostype == 'macos' }}
 
       - name: Install Dependencies
-        uses: ssciwr/doxygen-install@v1
+        uses: ssciwr/doxygen-install@501e53b879da7648ab392ee226f5b90e42148449 # v1
         with:
           version: "1.13.2"
 
       - name: Install CMake
-        uses: lukka/get-cmake@latest
+        uses: lukka/get-cmake@9e07ecdcee1b12e5037e42f410b67f03e2f626e1 # latest
         with:
             cmakeVersion: ${{ inputs.cmake_version }}
             ninjaVersion: latest
@@ -161,7 +161,7 @@ jobs:
 
       # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
       - name: Get Sources
-        uses: actions/checkout@v6.0.0
+        uses: actions/checkout@1af3b93b6815bc44a9784bd300feb67ff0d1eeb3 # v6.0.0
 
       # CONFIGURE
       - name: Configure

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -153,12 +153,12 @@ jobs:
         if: ${{ matrix.ostype == 'macos' }}
 
       - name: Install Dependencies
-        uses: ssciwr/doxygen-install@v1
+        uses: ssciwr/doxygen-install@501e53b879da7648ab392ee226f5b90e42148449 # v1
         with:
           version: "1.13.2"
 
       - name: Install CMake
-        uses: lukka/get-cmake@latest
+        uses: lukka/get-cmake@9e07ecdcee1b12e5037e42f410b67f03e2f626e1 # latest
         with:
             cmakeVersion: ${{ inputs.cmake_version }}
             ninjaVersion: latest
@@ -171,7 +171,7 @@ jobs:
 
       - name: Set up Java (if specified or FFM required)
         if: inputs.java_version != 'auto' || inputs.force_java_implementation == 'ffm'
-        uses: actions/setup-java@v5
+        uses: actions/setup-java@f2beeb24e141e01a676f977032f5a29d81c9e27e # v5
         with:
           distribution: ${{ inputs.force_java_implementation == 'ffm' && 'oracle' || 'temurin' }}
           java-version: |
@@ -197,7 +197,7 @@ jobs:
 
       # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
       - name: Get Sources
-        uses: actions/checkout@v6.0.0
+        uses: actions/checkout@1af3b93b6815bc44a9784bd300feb67ff0d1eeb3 # v6.0.0
 
       - name: Setup jextract (FFM builds only)
         if: ${{ inputs.force_java_implementation == 'ffm' }}
@@ -332,7 +332,7 @@ jobs:
 
       # Save files created by CTest script
       - name: Save published binary (Windows)
-        uses: actions/upload-artifact@v5
+        uses: actions/upload-artifact@330a01c490aca151604b8cf639adc76d48f6c5d4 # v5
         with:
               name: zip-vs2022_cl-${{ inputs.build_mode }}-${{ inputs.save_binary }}-binary
               path: ${{ runner.workspace }}/build/HDF5-*-win64.zip
@@ -340,7 +340,7 @@ jobs:
         if:  ${{ (matrix.ostype == 'windows') && ( inputs.save_binary != 'skip') }}
 
       - name: Save published binary (linux)
-        uses: actions/upload-artifact@v5
+        uses: actions/upload-artifact@330a01c490aca151604b8cf639adc76d48f6c5d4 # v5
         with:
               name: tgz-ubuntu-2404_gcc-${{ inputs.build_mode }}-${{ inputs.save_binary }}-binary
               path: ${{ runner.workspace }}/build/HDF5-*-Linux.tar.gz
@@ -348,7 +348,7 @@ jobs:
         if:  ${{ (matrix.ostype == 'ubuntu') && ( inputs.save_binary != 'skip') }}
 
       - name: Save published binary (Mac_latest)
-        uses: actions/upload-artifact@v5
+        uses: actions/upload-artifact@330a01c490aca151604b8cf639adc76d48f6c5d4 # v5
         with:
               name: tgz-macos14_clang-${{ inputs.build_mode }}-${{ inputs.save_binary }}-binary
               path: ${{ runner.workspace }}/build/HDF5-*-Darwin.tar.gz

--- a/.github/workflows/markdown-link-check.yml
+++ b/.github/workflows/markdown-link-check.yml
@@ -12,7 +12,7 @@ jobs:
   markdown-link-check:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@master
-    - uses: gaurav-nelson/github-action-markdown-link-check@v1
+    - uses: actions/checkout@61b9e3751b92087fd0b06925ba6dd6314e06f089 # master
+    - uses: gaurav-nelson/github-action-markdown-link-check@5c5dfc0ac2e225883c0e5f03a85311ec2830d368 # v1
       with:
         config-file: '.github/workflows/markdown_config.json'

--- a/.github/workflows/maven-build-test.yml
+++ b/.github/workflows/maven-build-test.yml
@@ -68,10 +68,10 @@ jobs:
       packages: write
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6.0.0
+        uses: actions/checkout@1af3b93b6815bc44a9784bd300feb67ff0d1eeb3 # v6.0.0
 
       - name: Download all Maven staging artifacts
-        uses: actions/download-artifact@v6
+        uses: actions/download-artifact@018cc2cf5baa6db3ef3c5f8a56943fffe632ef53 # v6
         with:
           pattern: maven-staging-artifacts-*
           path: ./artifacts
@@ -82,7 +82,7 @@ jobs:
           ls -R ./artifacts/
 
       - name: Set up Java
-        uses: actions/setup-java@v5
+        uses: actions/setup-java@f2beeb24e141e01a676f977032f5a29d81c9e27e # v5
         with:
           java-version: '11'
           distribution: 'temurin'
@@ -143,16 +143,16 @@ jobs:
       (inputs.java_implementation == 'both' || inputs.java_implementation == 'jni')
     steps:
       - name: Checkout HDF5 repository (contains HDF5Examples)
-        uses: actions/checkout@v6.0.0
+        uses: actions/checkout@1af3b93b6815bc44a9784bd300feb67ff0d1eeb3 # v6.0.0
 
       - name: Set up Java 21 for JNI
-        uses: actions/setup-java@v5
+        uses: actions/setup-java@f2beeb24e141e01a676f977032f5a29d81c9e27e # v5
         with:
           java-version: '21'
           distribution: 'temurin'
 
       - name: Download HDF5 installation from workflow
-        uses: actions/download-artifact@v6
+        uses: actions/download-artifact@018cc2cf5baa6db3ef3c5f8a56943fffe632ef53 # v6
         with:
           name: hdf5-install-linux-x86_64-jni
           path: ${{ runner.workspace }}/hdf5-install
@@ -177,7 +177,7 @@ jobs:
 
       - name: Upload test artifacts (JNI)
         if: always()
-        uses: actions/upload-artifact@v5
+        uses: actions/upload-artifact@330a01c490aca151604b8cf639adc76d48f6c5d4 # v5
         with:
           name: jni-test-results-${{ needs.build-maven-packages.outputs.version }}
           path: |
@@ -193,16 +193,16 @@ jobs:
       (inputs.java_implementation == 'both' || inputs.java_implementation == 'ffm')
     steps:
       - name: Checkout HDF5 repository (contains HDF5Examples)
-        uses: actions/checkout@v6.0.0
+        uses: actions/checkout@1af3b93b6815bc44a9784bd300feb67ff0d1eeb3 # v6.0.0
 
       - name: Set up Java 25 for FFM
-        uses: actions/setup-java@v5
+        uses: actions/setup-java@f2beeb24e141e01a676f977032f5a29d81c9e27e # v5
         with:
           java-version: '25'
           distribution: 'oracle'
 
       - name: Download HDF5 installation from workflow
-        uses: actions/download-artifact@v6
+        uses: actions/download-artifact@018cc2cf5baa6db3ef3c5f8a56943fffe632ef53 # v6
         with:
           name: hdf5-install-linux-x86_64-ffm
           path: ${{ runner.workspace }}/hdf5-install
@@ -227,7 +227,7 @@ jobs:
 
       - name: Upload test artifacts (FFM)
         if: always()
-        uses: actions/upload-artifact@v5
+        uses: actions/upload-artifact@330a01c490aca151604b8cf639adc76d48f6c5d4 # v5
         with:
           name: ffm-test-results-${{ needs.build-maven-packages.outputs.version }}
           path: |

--- a/.github/workflows/maven-deploy.yml
+++ b/.github/workflows/maven-deploy.yml
@@ -85,7 +85,7 @@ jobs:
       platform-classifier: ${{ steps.platform-info.outputs.classifier }}
     steps:
       - name: Download all Maven artifacts
-        uses: actions/download-artifact@v6
+        uses: actions/download-artifact@018cc2cf5baa6db3ef3c5f8a56943fffe632ef53 # v6
         with:
           pattern: maven-staging-artifacts-*
           path: ./artifacts
@@ -255,7 +255,7 @@ jobs:
     if: ${{ !inputs.dry_run }}
     steps:
       - name: Download all Maven artifacts
-        uses: actions/download-artifact@v6
+        uses: actions/download-artifact@018cc2cf5baa6db3ef3c5f8a56943fffe632ef53 # v6
         with:
           pattern: maven-staging-artifacts-*
           path: ./artifacts
@@ -269,7 +269,7 @@ jobs:
           done
 
       - name: Set up Java
-        uses: actions/setup-java@v5
+        uses: actions/setup-java@f2beeb24e141e01a676f977032f5a29d81c9e27e # v5
         with:
           java-version: '11'
           distribution: 'temurin'
@@ -529,7 +529,7 @@ jobs:
           echo "Maven deployment summary created"
 
       - name: Upload deployment summary
-        uses: actions/upload-artifact@v5
+        uses: actions/upload-artifact@330a01c490aca151604b8cf639adc76d48f6c5d4 # v5
         with:
           name: maven-deployment-summary
           path: maven-deployment-summary.md

--- a/.github/workflows/maven-staging.yml
+++ b/.github/workflows/maven-staging.yml
@@ -86,7 +86,7 @@ jobs:
       should-test: ${{ steps.should-test.outputs.result }}
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6.0.0
+        uses: actions/checkout@1af3b93b6815bc44a9784bd300feb67ff0d1eeb3 # v6.0.0
         with:
           fetch-depth: 0
 
@@ -255,16 +255,16 @@ jobs:
 
       - name: Enable Developer Command Prompt (Windows)
         if: ${{ runner.os == 'Windows' }}
-        uses: ilammy/msvc-dev-cmd@v1.13.0
+        uses: ilammy/msvc-dev-cmd@0b201ec74fa43914dc39ae48a89fd1d8cb592756 # v1.13.0
 
       - name: Set up JDK (Java 25 for FFM builds)
-        uses: actions/setup-java@v5
+        uses: actions/setup-java@f2beeb24e141e01a676f977032f5a29d81c9e27e # v5
         with:
           java-version: ${{ matrix.implementation == 'ffm' && '25' || '21' }}
           distribution: ${{ matrix.implementation == 'ffm' && 'oracle' || 'temurin' }}
 
       - name: Checkout code
-        uses: actions/checkout@v6.0.0
+        uses: actions/checkout@1af3b93b6815bc44a9784bd300feb67ff0d1eeb3 # v6.0.0
 
       - name: Setup jextract (FFM builds only)
         if: ${{ matrix.implementation == 'ffm' }}
@@ -643,14 +643,14 @@ jobs:
           fi
 
       - name: Upload Maven artifacts
-        uses: actions/upload-artifact@v5
+        uses: actions/upload-artifact@330a01c490aca151604b8cf639adc76d48f6c5d4 # v5
         with:
           name: maven-staging-artifacts-${{ matrix.artifact-suffix }}
           path: ${{ runner.workspace }}/maven-artifacts
           retention-days: 7
 
       - name: Upload HDF5 installation for testing
-        uses: actions/upload-artifact@v5
+        uses: actions/upload-artifact@330a01c490aca151604b8cf639adc76d48f6c5d4 # v5
         with:
           name: hdf5-install-${{ matrix.artifact-suffix }}
           path: ${{ runner.workspace }}/hdf5-install
@@ -665,20 +665,20 @@ jobs:
       version: ${{ steps.extract-version.outputs.version }}
     steps:
       - name: Set up JDK 21
-        uses: actions/setup-java@v5
+        uses: actions/setup-java@f2beeb24e141e01a676f977032f5a29d81c9e27e # v5
         with:
           java-version: '21'
           distribution: 'temurin'
 
       - name: Download all Maven artifacts
-        uses: actions/download-artifact@v6
+        uses: actions/download-artifact@018cc2cf5baa6db3ef3c5f8a56943fffe632ef53 # v6
         with:
           pattern: maven-staging-artifacts-*
           path: ./artifacts
           merge-multiple: false
 
       - name: Checkout code for version extraction
-        uses: actions/checkout@v6.0.0
+        uses: actions/checkout@1af3b93b6815bc44a9784bd300feb67ff0d1eeb3 # v6.0.0
         with:
           path: source
 
@@ -786,10 +786,10 @@ jobs:
       matrix: ${{ fromJson(needs.determine-matrix.outputs.matrix) }}
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6.0.0
+        uses: actions/checkout@1af3b93b6815bc44a9784bd300feb67ff0d1eeb3 # v6.0.0
 
       - name: Set up JDK (Java 25 for FFM builds)
-        uses: actions/setup-java@v5
+        uses: actions/setup-java@f2beeb24e141e01a676f977032f5a29d81c9e27e # v5
         with:
           java-version: ${{ matrix.implementation == 'ffm' && '25' || '21' }}
           distribution: ${{ matrix.implementation == 'ffm' && 'oracle' || 'temurin' }}
@@ -802,14 +802,14 @@ jobs:
           echo "Installed gtimeout: $(which gtimeout)"
 
       - name: Download Maven artifacts (${{ matrix.platform }} - ${{ matrix.implementation }})
-        uses: actions/download-artifact@v6
+        uses: actions/download-artifact@018cc2cf5baa6db3ef3c5f8a56943fffe632ef53 # v6
         with:
           name: maven-staging-artifacts-${{ matrix.artifact-suffix }}
           path: ./maven-artifacts/${{ matrix.platform }}
         continue-on-error: true
 
       - name: Cache Maven dependencies
-        uses: actions/cache@v4
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
         with:
           path: ~/.m2/repository
           key: ${{ runner.os }}-maven-examples-${{ hashFiles('**/pom-examples.xml*') }}
@@ -1299,7 +1299,7 @@ jobs:
 
       - name: Upload failure artifacts (Java Examples)
         if: steps.test-examples-unix.outputs.test-status == 'FAILED' || steps.test-examples-windows.outputs.test-status == 'FAILED'
-        uses: actions/upload-artifact@v5
+        uses: actions/upload-artifact@330a01c490aca151604b8cf639adc76d48f6c5d4 # v5
         with:
           name: java-examples-staging-failure-${{ matrix.platform }}-${{ github.run_id }}
           path: |
@@ -1331,7 +1331,7 @@ jobs:
       - name: Comment on PR
         # Skip commenting if running from a fork due to permission restrictions
         if: ${{ github.event.pull_request.head.repo.full_name == github.repository }}
-        uses: actions/github-script@v8
+        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |

--- a/.github/workflows/msys2.yml
+++ b/.github/workflows/msys2.yml
@@ -32,7 +32,7 @@ jobs:
 
     steps:
       - name: '${{ matrix.icon }} Setup MSYS2'
-        uses: msys2/setup-msys2@v2
+        uses: msys2/setup-msys2@fb197b72ce45fb24f17bf3f807a388985654d1f2 # v2
         with:
           msystem: ${{matrix.sys}}
           update: true
@@ -52,7 +52,7 @@ jobs:
           git config --global core.autocrlf input
 
       - name: Get Sources
-        uses: actions/checkout@v6.0.0
+        uses: actions/checkout@1af3b93b6815bc44a9784bd300feb67ff0d1eeb3 # v6.0.0
 
       - name: Configure
         run: |

--- a/.github/workflows/netcdf.yml
+++ b/.github/workflows/netcdf.yml
@@ -35,7 +35,7 @@ jobs:
         sudo apt install -y libaec-dev zlib1g-dev automake autoconf libcurl4-openssl-dev libjpeg-dev wget curl bzip2 m4 flex bison cmake libzip-dev doxygen openssl libtool libtool-bin
 
     - name: Checkout HDF5
-      uses: actions/checkout@v6.0.0
+      uses: actions/checkout@1af3b93b6815bc44a9784bd300feb67ff0d1eeb3 # v6.0.0
 
     - name: Configure
       run: |
@@ -69,7 +69,7 @@ jobs:
       working-directory: ${{ runner.workspace }}/build
 
     - name: Checkout netCDF
-      uses: actions/checkout@v6.0.0
+      uses: actions/checkout@1af3b93b6815bc44a9784bd300feb67ff0d1eeb3 # v6.0.0
       with:
         repository: unidata/netcdf-c
         path: netcdf-c

--- a/.github/workflows/nvhpc.yml
+++ b/.github/workflows/nvhpc.yml
@@ -23,10 +23,10 @@ jobs:
 
     steps:
       - name: Get Sources
-        uses: actions/checkout@v6.0.0
+        uses: actions/checkout@1af3b93b6815bc44a9784bd300feb67ff0d1eeb3 # v6.0.0
 
       - name: Free Disk Space (Ubuntu)
-        uses: jlumbroso/free-disk-space@v1.3.1
+        uses: jlumbroso/free-disk-space@54081f138730dfa15788a46383842cd2f914a1be # v1.3.1
         with:
           android: true
           dotnet: true

--- a/.github/workflows/openbsd.yml
+++ b/.github/workflows/openbsd.yml
@@ -38,10 +38,10 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6.0.0
+        uses: actions/checkout@1af3b93b6815bc44a9784bd300feb67ff0d1eeb3 # v6.0.0
 
       - name: Build and test on OpenBSD
-        uses: vmactions/openbsd-vm@v1
+        uses: vmactions/openbsd-vm@2e29de1eb150dfe1c9c97b84ff2b7896f14ca690 # v1
         with:
           release: ${{ matrix.openbsd-version }}
           usesh: true

--- a/.github/workflows/par-script.yml
+++ b/.github/workflows/par-script.yml
@@ -38,28 +38,28 @@ jobs:
         mpi: [ 'msmpi', 'intelmpi']
     name: "Parallel ${{ matrix.mpi }} Windows-${{ inputs.build_mode }}"
     steps:
-      - uses: actions/checkout@v6.0.0
+      - uses: actions/checkout@1af3b93b6815bc44a9784bd300feb67ff0d1eeb3 # v6.0.0
 
       - name: Install Dependencies (Windows)
         run: choco install ninja
 
       - name: Install Dependencies
-        uses: ssciwr/doxygen-install@v1
+        uses: ssciwr/doxygen-install@501e53b879da7648ab392ee226f5b90e42148449 # v1
         with:
           version: "1.13.2"
 
       - name: Install CMake
-        uses: lukka/get-cmake@latest
+        uses: lukka/get-cmake@9e07ecdcee1b12e5037e42f410b67f03e2f626e1 # latest
         with:
             cmakeVersion: ${{ inputs.cmake_version }}
             ninjaVersion: latest
 
       - name: Enable Developer Command Prompt
-        uses: ilammy/msvc-dev-cmd@v1.13.0
+        uses: ilammy/msvc-dev-cmd@0b201ec74fa43914dc39ae48a89fd1d8cb592756 # v1.13.0
 
       - name: Setup MPI (${{ matrix.mpi }})
         id: setup-mpi
-        uses: mpi4py/setup-mpi@v1
+        uses: mpi4py/setup-mpi@d0a3bf17a182b37921ff27a6737f9009ec76d3b6 # v1
         with:
           mpi: ${{ matrix.mpi }}
 
@@ -116,7 +116,7 @@ jobs:
         shell: pwsh
 
       - name: Create options file (${{ matrix.mpi }})
-        uses: "DamianReeves/write-file-action@master"
+        uses: "DamianReeves/write-file-action@1d019960841941be46b139298996df6f139cc7a4" # master
         with:
           path: ${{ runner.workspace }}/hdf5/HDF5options.cmake
           write-mode: overwrite
@@ -155,7 +155,7 @@ jobs:
 
       # Save log files created by CTest script
       - name: Save log (${{ matrix.mpi }})
-        uses: actions/upload-artifact@v5
+        uses: actions/upload-artifact@330a01c490aca151604b8cf639adc76d48f6c5d4 # v5
         with:
           name: windows-${{ matrix.mpi }}-log
           path: ${{ runner.workspace }}/hdf5/hdf5.log
@@ -176,19 +176,19 @@ jobs:
           sudo apt install libaec0 libaec-dev
 
       - name: Install Dependencies
-        uses: ssciwr/doxygen-install@v1
+        uses: ssciwr/doxygen-install@501e53b879da7648ab392ee226f5b90e42148449 # v1
         with:
           version: "1.13.2"
 
       - name: Install CMake
-        uses: lukka/get-cmake@latest
+        uses: lukka/get-cmake@9e07ecdcee1b12e5037e42f410b67f03e2f626e1 # latest
         with:
             cmakeVersion: ${{ inputs.cmake_version }}
             ninjaVersion: latest
 
       - name: Setup MPI (${{ matrix.mpi }})
         id: setup-mpi
-        uses: mpi4py/setup-mpi@v1
+        uses: mpi4py/setup-mpi@d0a3bf17a182b37921ff27a6737f9009ec76d3b6 # v1
         with:
           mpi: ${{ matrix.mpi }}
 
@@ -236,7 +236,7 @@ jobs:
             ls ${{ runner.workspace }}/hdf5
 
       - name: Create options file (${{ matrix.mpi }})
-        uses: "DamianReeves/write-file-action@master"
+        uses: "DamianReeves/write-file-action@1d019960841941be46b139298996df6f139cc7a4" # master
         with:
           path: ${{ runner.workspace }}/hdf5/HDF5options.cmake
           write-mode: overwrite
@@ -275,7 +275,7 @@ jobs:
 
       # Save log files created by CTest script
       - name: Save log (${{ matrix.mpi }})
-        uses: actions/upload-artifact@v5
+        uses: actions/upload-artifact@330a01c490aca151604b8cf639adc76d48f6c5d4 # v5
         with:
           name: linux-${{ matrix.mpi }}-log
           path: ${{ runner.workspace }}/hdf5/hdf5.log
@@ -287,19 +287,19 @@ jobs:
         mpi: [ 'mpich', 'openmpi']
     name: "Parallel ${{ matrix.mpi }} macos-${{ inputs.build_mode }}"
     steps:
-      - uses: actions/checkout@v6.0.0
+      - uses: actions/checkout@1af3b93b6815bc44a9784bd300feb67ff0d1eeb3 # v6.0.0
 
       - name: Install Dependencies (MacOS_latest)
         run: brew install ninja
 
       - name: Install Dependencies
-        uses: ssciwr/doxygen-install@v1
+        uses: ssciwr/doxygen-install@501e53b879da7648ab392ee226f5b90e42148449 # v1
         with:
           version: "1.13.2"
 
       - name: Setup MPI (${{ matrix.mpi }})
         id: setup-mpi
-        uses: mpi4py/setup-mpi@v1
+        uses: mpi4py/setup-mpi@d0a3bf17a182b37921ff27a6737f9009ec76d3b6 # v1
         with:
           mpi: ${{ matrix.mpi }}
 
@@ -346,7 +346,7 @@ jobs:
             ls ${{ runner.workspace }}/hdf5
 
       - name: Create options file (${{ matrix.mpi }})
-        uses: "DamianReeves/write-file-action@master"
+        uses: "DamianReeves/write-file-action@1d019960841941be46b139298996df6f139cc7a4" # master
         with:
           path: ${{ runner.workspace }}/hdf5/HDF5options.cmake
           write-mode: overwrite
@@ -385,7 +385,7 @@ jobs:
 
       # Save log files created by CTest script
       - name: Save log (${{ matrix.mpi }})
-        uses: actions/upload-artifact@v5
+        uses: actions/upload-artifact@330a01c490aca151604b8cf639adc76d48f6c5d4 # v5
         with:
           name: macos-${{ matrix.mpi }}-log
           path: ${{ runner.workspace }}/hdf5/hdf5.log

--- a/.github/workflows/par-source.yml
+++ b/.github/workflows/par-source.yml
@@ -72,12 +72,12 @@ jobs:
           echo "FC=${{ runner.workspace }}/openmpi/bin/mpif90" >> $GITHUB_ENV
 
       - name: Install Doxygen
-        uses: ssciwr/doxygen-install@v1
+        uses: ssciwr/doxygen-install@501e53b879da7648ab392ee226f5b90e42148449 # v1
         with:
           version: "1.13.2"
 
       - name: Install CMake
-        uses: lukka/get-cmake@latest
+        uses: lukka/get-cmake@9e07ecdcee1b12e5037e42f410b67f03e2f626e1 # latest
         with:
             cmakeVersion: ${{ inputs.cmake_version }}
             ninjaVersion: latest
@@ -120,7 +120,7 @@ jobs:
             ls ${{ runner.workspace }}/hdf5
 
       - name: Create options file (OpenMPI)
-        uses: "DamianReeves/write-file-action@master"
+        uses: "DamianReeves/write-file-action@1d019960841941be46b139298996df6f139cc7a4" # master
         with:
           path: ${{ runner.workspace }}/hdf5/HDF5options.cmake
           write-mode: overwrite
@@ -157,7 +157,7 @@ jobs:
 
       # Save log files created by CTest script
       - name: Save log (OpenMPI)
-        uses: actions/upload-artifact@v5
+        uses: actions/upload-artifact@330a01c490aca151604b8cf639adc76d48f6c5d4 # v5
         with:
           name: openmpi-log
           path: ${{ runner.workspace }}/hdf5/hdf5.log
@@ -168,7 +168,7 @@ jobs:
     name: "Parallel Mpich GCC-${{ inputs.build_mode }}"
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6.0.0
+      - uses: actions/checkout@1af3b93b6815bc44a9784bd300feb67ff0d1eeb3 # v6.0.0
 
       - name: Install Linux Dependencies (MPICH)
         run: |
@@ -194,12 +194,12 @@ jobs:
           echo "FC=${{ runner.workspace }}/mpich/bin/mpif90" >> $GITHUB_ENV
 
       - name: Install Doxygen
-        uses: ssciwr/doxygen-install@v1
+        uses: ssciwr/doxygen-install@501e53b879da7648ab392ee226f5b90e42148449 # v1
         with:
           version: "1.13.2"
 
       - name: Install CMake
-        uses: lukka/get-cmake@latest
+        uses: lukka/get-cmake@9e07ecdcee1b12e5037e42f410b67f03e2f626e1 # latest
         with:
             cmakeVersion: ${{ inputs.cmake_version }}
             ninjaVersion: latest
@@ -242,7 +242,7 @@ jobs:
             ls ${{ runner.workspace }}/hdf5
 
       - name: Create options file (MPICH)
-        uses: "DamianReeves/write-file-action@master"
+        uses: "DamianReeves/write-file-action@1d019960841941be46b139298996df6f139cc7a4" # master
         with:
           path: ${{ runner.workspace }}/hdf5/HDF5options.cmake
           write-mode: overwrite
@@ -279,7 +279,7 @@ jobs:
 
       # Save log files created by CTest script
       - name: Save log (MPICH)
-        uses: actions/upload-artifact@v5
+        uses: actions/upload-artifact@330a01c490aca151604b8cf639adc76d48f6c5d4 # v5
         with:
           name: mpich-log
           path: ${{ runner.workspace }}/hdf5/hdf5.log

--- a/.github/workflows/publish-branch.yml
+++ b/.github/workflows/publish-branch.yml
@@ -22,7 +22,7 @@ jobs:
     steps:
         # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
         - name: Get Sources
-          uses: actions/checkout@v6.0.0
+          uses: actions/checkout@1af3b93b6815bc44a9784bd300feb67ff0d1eeb3 # v6.0.0
           with:
             fetch-depth: 0
             ref: '${{ github.head_ref || github.ref_name }}'
@@ -33,7 +33,7 @@ jobs:
               ls ${{ github.workspace }}/HDF5
 
         - name: Setup AWS CLI
-          uses: aws-actions/configure-aws-credentials@v5
+          uses: aws-actions/configure-aws-credentials@61815dcd50bd041e203e49132bacad1fd04d2708 # v5
           with:
                  aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
                  aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -50,7 +50,7 @@ jobs:
 
       # Checks-out your repository under $GITHUB_WORKSPACE
       - name: Get Sources
-        uses: actions/checkout@v6.0.0  # Updated to latest stable
+        uses: actions/checkout@1af3b93b6815bc44a9784bd300feb67ff0d1eeb3 # Updated to latest stable v6.0.0
         with:
           fetch-depth: 0
           ref: '${{ github.head_ref || github.ref_name }}'
@@ -59,7 +59,7 @@ jobs:
         run: mkdir -p HDF5
 
       - name: Get HDF5 release assets
-        uses: robinraju/release-downloader@v1.12  # More reliable alternative
+        uses: robinraju/release-downloader@daf26c55d821e836577a15f77d86ddc078948b05 # More reliable alternative v1.12
         with:
           repository: HDFGroup/hdf5
           tag: ${{ inputs.use_tag }}
@@ -85,7 +85,7 @@ jobs:
 
       - name: Setup AWS CLI
         if: ${{ !inputs.dry_run }}
-        uses: aws-actions/configure-aws-credentials@v5
+        uses: aws-actions/configure-aws-credentials@61815dcd50bd041e203e49132bacad1fd04d2708 # v5
         with:
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}

--- a/.github/workflows/release-files.yml
+++ b/.github/workflows/release-files.yml
@@ -40,7 +40,7 @@ jobs:
     steps:
       # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
       - name: Get Sources
-        uses: actions/checkout@v6.0.0
+        uses: actions/checkout@1af3b93b6815bc44a9784bd300feb67ff0d1eeb3 # v6.0.0
         with:
           fetch-depth: 0
           ref: '${{ github.head_ref || github.ref_name }}'

--- a/.github/workflows/remove-files.yml
+++ b/.github/workflows/remove-files.yml
@@ -40,7 +40,7 @@ jobs:
       - name: PreRelease delete from tag
         id: delete_prerelease
         if: ${{ (inputs.use_environ == 'snapshots') }}
-        uses: mknejp/delete-release-assets@v1
+        uses: mknejp/delete-release-assets@6a8fd1fd4ce4296fde58ab811acf5fc13fef3cc9 # v1
         with:
           token: ${{ github.token }}
           tag: "${{ inputs.use_tag }}"

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -32,7 +32,7 @@ jobs:
 
     steps:
       - name: "Checkout code"
-        uses: actions/checkout@v6.0.0
+        uses: actions/checkout@1af3b93b6815bc44a9784bd300feb67ff0d1eeb3 # v6.0.0
         with:
           persist-credentials: false
 
@@ -59,7 +59,7 @@ jobs:
       # Upload the results as artifacts (optional). Commenting out will disable uploads of run results in SARIF
       # format to the repository Actions tab.
       - name: "Upload artifact"
-        uses: actions/upload-artifact@v5
+        uses: actions/upload-artifact@330a01c490aca151604b8cf639adc76d48f6c5d4 # v5
         with:
           name: SARIF file
           path: results.sarif

--- a/.github/workflows/script.yml
+++ b/.github/workflows/script.yml
@@ -37,15 +37,15 @@ jobs:
         run: choco install ninja
 
       - name: Install Dependencies
-        uses: ssciwr/doxygen-install@v1
+        uses: ssciwr/doxygen-install@501e53b879da7648ab392ee226f5b90e42148449 # v1
         with:
           version: "1.13.2"
 
       - name: Enable Developer Command Prompt
-        uses: ilammy/msvc-dev-cmd@v1.13.0
+        uses: ilammy/msvc-dev-cmd@0b201ec74fa43914dc39ae48a89fd1d8cb592756 # v1.13.0
 
       - name: Install CMake
-        uses: lukka/get-cmake@latest
+        uses: lukka/get-cmake@9e07ecdcee1b12e5037e42f410b67f03e2f626e1 # latest
         with:
             cmakeVersion: ${{ inputs.cmake_version }}
             ninjaVersion: latest
@@ -104,7 +104,7 @@ jobs:
         shell: pwsh
 
       - name: Create options file (Windows)
-        uses: "DamianReeves/write-file-action@master"
+        uses: "DamianReeves/write-file-action@1d019960841941be46b139298996df6f139cc7a4" # master
         with:
             path: ${{ runner.workspace }}/hdf5/HDF5options.cmake
             write-mode: overwrite
@@ -136,7 +136,7 @@ jobs:
 
       # Save log files created by CTest script
       - name: Save log (Windows_intel)
-        uses: actions/upload-artifact@v5
+        uses: actions/upload-artifact@330a01c490aca151604b8cf639adc76d48f6c5d4 # v5
         with:
           name: cl-win-log
           path: ${{ runner.workspace }}/hdf5/hdf5.log
@@ -154,12 +154,12 @@ jobs:
           sudo apt-get install ninja-build graphviz curl
 
       - name: Install Dependencies
-        uses: ssciwr/doxygen-install@v1
+        uses: ssciwr/doxygen-install@501e53b879da7648ab392ee226f5b90e42148449 # v1
         with:
           version: "1.13.2"
 
       - name: Install CMake
-        uses: lukka/get-cmake@latest
+        uses: lukka/get-cmake@9e07ecdcee1b12e5037e42f410b67f03e2f626e1 # latest
         with:
             cmakeVersion: ${{ inputs.cmake_version }}
             ninjaVersion: latest
@@ -202,7 +202,7 @@ jobs:
             ls ${{ runner.workspace }}/hdf5
 
       - name: Create options file (Linux)
-        uses: "DamianReeves/write-file-action@master"
+        uses: "DamianReeves/write-file-action@1d019960841941be46b139298996df6f139cc7a4" # master
         with:
           path: ${{ runner.workspace }}/hdf5/HDF5options.cmake
           write-mode: overwrite
@@ -234,7 +234,7 @@ jobs:
 
       # Save log files created by CTest script
       - name: Save log (Linux)
-        uses: actions/upload-artifact@v5
+        uses: actions/upload-artifact@330a01c490aca151604b8cf639adc76d48f6c5d4 # v5
         with:
             name: gcc-ubuntu-log
             path: ${{ runner.workspace }}/hdf5/hdf5.log
@@ -250,7 +250,7 @@ jobs:
         run: brew install ninja curl
 
       - name: Install Dependencies
-        uses: ssciwr/doxygen-install@v1
+        uses: ssciwr/doxygen-install@501e53b879da7648ab392ee226f5b90e42148449 # v1
         with:
           version: "1.13.2"
 
@@ -261,7 +261,7 @@ jobs:
           clang -v
 
       - name: Install CMake
-        uses: lukka/get-cmake@latest
+        uses: lukka/get-cmake@9e07ecdcee1b12e5037e42f410b67f03e2f626e1 # latest
         with:
             cmakeVersion: ${{ inputs.cmake_version }}
             ninjaVersion: latest
@@ -273,7 +273,7 @@ jobs:
           cmake --version
 
       - name: Set up JDK 19
-        uses: actions/setup-java@v5
+        uses: actions/setup-java@f2beeb24e141e01a676f977032f5a29d81c9e27e # v5
         with:
           java-version: '21'
           distribution: 'temurin'
@@ -313,7 +313,7 @@ jobs:
 
       # symlinks the compiler executables to a common location 
       - name: Setup GNU Fortran
-        uses: fortran-lang/setup-fortran@v1
+        uses: fortran-lang/setup-fortran@47809fdb6e637da656ce9ada436527b240c1287f # v1
         id: setup-fortran
         with:
           compiler: gcc
@@ -324,7 +324,7 @@ jobs:
               ls ${{ runner.workspace }}/hdf5
 
       - name: Create options file (MacOS_latest)
-        uses: "DamianReeves/write-file-action@master"
+        uses: "DamianReeves/write-file-action@1d019960841941be46b139298996df6f139cc7a4" # master
         with:
           path: ${{ runner.workspace }}/hdf5/HDF5options.cmake
           write-mode: overwrite
@@ -357,7 +357,7 @@ jobs:
 
       # Save log files created by CTest script
       - name: Save log (MacOS_latest)
-        uses: actions/upload-artifact@v5
+        uses: actions/upload-artifact@330a01c490aca151604b8cf639adc76d48f6c5d4 # v5
         with:
           name: macos-log
           path: ${{ runner.workspace }}/hdf5/hdf5.log
@@ -375,7 +375,7 @@ jobs:
           sudo apt-get install ninja-build doxygen
 
       - name: Install CMake
-        uses: lukka/get-cmake@latest
+        uses: lukka/get-cmake@9e07ecdcee1b12e5037e42f410b67f03e2f626e1 # latest
         with:
             cmakeVersion: ${{ inputs.cmake_version }}
             ninjaVersion: latest
@@ -437,7 +437,7 @@ jobs:
               ls ${{ runner.workspace }}/hdf5
 
       - name: Create options file (Linux S3)
-        uses: "DamianReeves/write-file-action@master"
+        uses: "DamianReeves/write-file-action@1d019960841941be46b139298996df6f139cc7a4" # master
         with:
           path: ${{ runner.workspace }}/hdf5/HDF5options.cmake
           write-mode: overwrite
@@ -469,7 +469,7 @@ jobs:
 
       # Save log files created by CTest script
       - name: Save log (Linux S3)
-        uses: actions/upload-artifact@v5
+        uses: actions/upload-artifact@330a01c490aca151604b8cf639adc76d48f6c5d4 # v5
         with:
           name: s3-ubuntu-log
           path: ${{ runner.workspace }}/hdf5/hdf5.log
@@ -486,14 +486,14 @@ jobs:
         run: choco install ninja
 
       - name: add oneAPI to env
-        uses: fortran-lang/setup-fortran@v1
+        uses: fortran-lang/setup-fortran@47809fdb6e637da656ce9ada436527b240c1287f # v1
         id: setup-fortran
         with:
           compiler: intel
           version: '2025.0'
 
       - name: Install CMake
-        uses: lukka/get-cmake@latest
+        uses: lukka/get-cmake@9e07ecdcee1b12e5037e42f410b67f03e2f626e1 # latest
         with:
             cmakeVersion: ${{ inputs.cmake_version }}
             ninjaVersion: latest
@@ -546,7 +546,7 @@ jobs:
         shell: pwsh
 
       - name: Create options file (Windows_intel)
-        uses: "DamianReeves/write-file-action@master"
+        uses: "DamianReeves/write-file-action@1d019960841941be46b139298996df6f139cc7a4" # master
         with:
           path: ${{ runner.workspace }}/hdf5/HDF5options.cmake
           write-mode: overwrite
@@ -583,7 +583,7 @@ jobs:
 
       # Save log files created by CTest script
       - name: Save log (Windows_intel)
-        uses: actions/upload-artifact@v5
+        uses: actions/upload-artifact@330a01c490aca151604b8cf639adc76d48f6c5d4 # v5
         with:
           name: intel-win-log
           path: ${{ runner.workspace }}/hdf5/hdf5.log
@@ -601,14 +601,14 @@ jobs:
           sudo apt-get install ninja-build doxygen graphviz curl
 
       - name: add oneAPI to env
-        uses: fortran-lang/setup-fortran@v1
+        uses: fortran-lang/setup-fortran@47809fdb6e637da656ce9ada436527b240c1287f # v1
         id: setup-fortran
         with:
           compiler: intel
           version: '2025.0'
 
       - name: Install CMake
-        uses: lukka/get-cmake@latest
+        uses: lukka/get-cmake@9e07ecdcee1b12e5037e42f410b67f03e2f626e1 # latest
         with:
             cmakeVersion: ${{ inputs.cmake_version }}
             ninjaVersion: latest
@@ -651,7 +651,7 @@ jobs:
           ls ${{ runner.workspace }}/hdf5
 
       - name: Create options file (Linux_intel)
-        uses: "DamianReeves/write-file-action@master"
+        uses: "DamianReeves/write-file-action@1d019960841941be46b139298996df6f139cc7a4" # master
         with:
           path: ${{ runner.workspace }}/hdf5/HDF5options.cmake
           write-mode: overwrite
@@ -686,7 +686,7 @@ jobs:
 
       # Save log files created by CTest script
       - name: Save log (Linux_intel)
-        uses: actions/upload-artifact@v5
+        uses: actions/upload-artifact@330a01c490aca151604b8cf639adc76d48f6c5d4 # v5
         with:
           name: intel-ubuntu-log
           path: ${{ runner.workspace }}/hdf5/hdf5.log
@@ -705,7 +705,7 @@ jobs:
           sudo apt-get install ninja-build doxygen graphviz curl libtinfo5
 
       - name: add clang to env
-        uses: KyleMayes/install-llvm-action@v2.0.8
+        uses: KyleMayes/install-llvm-action@98e68e10c96dffcb7bfed8b2144541a66b49aa02 # v2.0.8
         id: setup-clang
         with:
           env: true
@@ -718,7 +718,7 @@ jobs:
           clang -v
 
       - name: Install CMake
-        uses: lukka/get-cmake@latest
+        uses: lukka/get-cmake@9e07ecdcee1b12e5037e42f410b67f03e2f626e1 # latest
         with:
             cmakeVersion: ${{ inputs.cmake_version }}
             ninjaVersion: latest
@@ -767,7 +767,7 @@ jobs:
           ls ${{ runner.workspace }}/hdf5
 
       - name: Create options file (Linux_clang)
-        uses: "DamianReeves/write-file-action@master"
+        uses: "DamianReeves/write-file-action@1d019960841941be46b139298996df6f139cc7a4" # master
         with:
           path: ${{ runner.workspace }}/hdf5/HDF5options.cmake
           write-mode: overwrite
@@ -801,7 +801,7 @@ jobs:
 
       # Save log files created by CTest script
       - name: Save log (Linux_clang)
-        uses: actions/upload-artifact@v5
+        uses: actions/upload-artifact@330a01c490aca151604b8cf639adc76d48f6c5d4 # v5
         with:
           name: clang-ubuntu-log
           path: ${{ runner.workspace }}/hdf5/hdf5.log

--- a/.github/workflows/tarball.yml
+++ b/.github/workflows/tarball.yml
@@ -48,7 +48,7 @@ jobs:
       branch_ref: ${{ steps.get-branch-name.outputs.BRANCH_REF }}
       branch_sha: ${{ steps.get-branch-sha.outputs.BRANCH_SHA }}
     steps:
-    - uses: actions/checkout@v6.0.0
+    - uses: actions/checkout@1af3b93b6815bc44a9784bd300feb67ff0d1eeb3 # v6.0.0
 
     - name: Get branch name
       id: get-branch-name
@@ -70,7 +70,7 @@ jobs:
 
     - name: Check for changed source
       id: check-new-commits
-      uses: adriangl/check-new-commits-action@v1
+      uses: adriangl/check-new-commits-action@e6471f4fda990ebdb3bf44726371e1ad45ac4d37 # v1
       with:
         seconds: 86400 # One day in seconds
         branch: '${{ steps.get-branch-name.outputs.branch_ref }}'
@@ -92,7 +92,7 @@ jobs:
     steps:
       # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
       - name: Get Sources
-        uses: actions/checkout@v6.0.0
+        uses: actions/checkout@1af3b93b6815bc44a9784bd300feb67ff0d1eeb3 # v6.0.0
         with:
           path: hdfsrc
           ref: '${{needs.check_commits.outputs.branch_ref }}'
@@ -164,14 +164,14 @@ jobs:
 
       # Save files created by release script
       - name: Save tgz-tarball
-        uses: actions/upload-artifact@v5
+        uses: actions/upload-artifact@330a01c490aca151604b8cf639adc76d48f6c5d4 # v5
         with:
               name: tgz-tarball
               path: ${{ steps.set-file-base.outputs.FILE_BASE }}.tar.gz
               if-no-files-found: error # 'warn' or 'ignore' are also available, defaults to `warn`
 
       - name: Save zip-tarball
-        uses: actions/upload-artifact@v5
+        uses: actions/upload-artifact@330a01c490aca151604b8cf639adc76d48f6c5d4 # v5
         with:
               name: zip-tarball
               path: ${{ steps.set-file-base.outputs.FILE_BASE }}.zip
@@ -179,7 +179,7 @@ jobs:
 
       - name: Save tgz-tarball-nover
         if: ${{ (inputs.use_environ == 'release') }}
-        uses: actions/upload-artifact@v5
+        uses: actions/upload-artifact@330a01c490aca151604b8cf639adc76d48f6c5d4 # v5
         with:
               name: tgz-tarball-nover
               path: hdf5.tar.gz
@@ -187,7 +187,7 @@ jobs:
 
       - name: Save zip-tarball-nover
         if: ${{ (inputs.use_environ == 'release') }}
-        uses: actions/upload-artifact@v5
+        uses: actions/upload-artifact@330a01c490aca151604b8cf639adc76d48f6c5d4 # v5
         with:
               name: zip-tarball-nover
               path: hdf5.zip
@@ -203,7 +203,7 @@ jobs:
               ls $GITHUB_WORKSPACE
 
       - name: Upload description.txt
-        uses: actions/upload-artifact@v5
+        uses: actions/upload-artifact@330a01c490aca151604b8cf639adc76d48f6c5d4 # v5
         with:
               name: description.txt
               path: ./description.txt

--- a/.github/workflows/test-binary-installation.yml
+++ b/.github/workflows/test-binary-installation.yml
@@ -71,13 +71,13 @@ jobs:
       inputs.java_implementation == 'jni'
     steps:
       - name: Checkout HDF5Examples
-        uses: actions/checkout@v6.0.0
+        uses: actions/checkout@1af3b93b6815bc44a9784bd300feb67ff0d1eeb3 # v6.0.0
         with:
           repository: HDFGroup/HDF5Examples
           path: HDF5Examples
 
       - name: Set up Java 11 for JNI
-        uses: actions/setup-java@v5
+        uses: actions/setup-java@f2beeb24e141e01a676f977032f5a29d81c9e27e # v5
         with:
           java-version: '11'
           distribution: 'temurin'
@@ -266,13 +266,13 @@ jobs:
       inputs.java_implementation == 'ffm'
     steps:
       - name: Checkout HDF5Examples
-        uses: actions/checkout@v6.0.0
+        uses: actions/checkout@1af3b93b6815bc44a9784bd300feb67ff0d1eeb3 # v6.0.0
         with:
           repository: HDFGroup/HDF5Examples
           path: HDF5Examples
 
       - name: Set up Java 25 for FFM
-        uses: actions/setup-java@v5
+        uses: actions/setup-java@f2beeb24e141e01a676f977032f5a29d81c9e27e # v5
         with:
           java-version: '25'
           distribution: 'oracle'

--- a/.github/workflows/test-maven-deployment.yml
+++ b/.github/workflows/test-maven-deployment.yml
@@ -31,7 +31,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6.0.0
+        uses: actions/checkout@1af3b93b6815bc44a9784bd300feb67ff0d1eeb3 # v6.0.0
 
       - name: Display test configuration
         run: |
@@ -119,7 +119,7 @@ jobs:
           find test-artifacts -type f -exec ls -la {} \;
 
       - name: Upload test artifacts
-        uses: actions/upload-artifact@v5
+        uses: actions/upload-artifact@330a01c490aca151604b8cf639adc76d48f6c5d4 # v5
         with:
           name: maven-staging-artifacts-linux-x86_64
           path: test-artifacts/maven-staging-artifacts-linux-x86_64/

--- a/.github/workflows/test-maven-packages.yml
+++ b/.github/workflows/test-maven-packages.yml
@@ -58,10 +58,10 @@ jobs:
       inputs.java_implementation == 'jni'
     steps:
       - name: Checkout HDF5 repository (contains HDF5Examples)
-        uses: actions/checkout@v6.0.0
+        uses: actions/checkout@1af3b93b6815bc44a9784bd300feb67ff0d1eeb3 # v6.0.0
 
       - name: Set up Java 21 for JNI
-        uses: actions/setup-java@v5
+        uses: actions/setup-java@f2beeb24e141e01a676f977032f5a29d81c9e27e # v5
         with:
           java-version: '21'
           distribution: 'temurin'
@@ -280,7 +280,7 @@ jobs:
           echo "::endgroup::"
 
       - name: Download HDF5 installation from workflow
-        uses: actions/download-artifact@v6
+        uses: actions/download-artifact@018cc2cf5baa6db3ef3c5f8a56943fffe632ef53 # v6
         with:
           name: hdf5-install-linux-x86_64-jni
           path: ${{ runner.workspace }}/hdf5-install
@@ -305,7 +305,7 @@ jobs:
 
       - name: Upload test artifacts (JNI)
         if: always()
-        uses: actions/upload-artifact@v5
+        uses: actions/upload-artifact@330a01c490aca151604b8cf639adc76d48f6c5d4 # v5
         with:
           name: jni-test-results-${{ inputs.version }}
           path: |
@@ -319,10 +319,10 @@ jobs:
       inputs.java_implementation == 'ffm'
     steps:
       - name: Checkout HDF5 repository (contains HDF5Examples)
-        uses: actions/checkout@v6.0.0
+        uses: actions/checkout@1af3b93b6815bc44a9784bd300feb67ff0d1eeb3 # v6.0.0
 
       - name: Set up Java 25 for FFM
-        uses: actions/setup-java@v5
+        uses: actions/setup-java@f2beeb24e141e01a676f977032f5a29d81c9e27e # v5
         with:
           java-version: '25'
           distribution: 'oracle'
@@ -541,7 +541,7 @@ jobs:
           echo "::endgroup::"
 
       - name: Download HDF5 installation from workflow
-        uses: actions/download-artifact@v6
+        uses: actions/download-artifact@018cc2cf5baa6db3ef3c5f8a56943fffe632ef53 # v6
         with:
           name: hdf5-install-linux-x86_64-ffm
           path: ${{ runner.workspace }}/hdf5-install
@@ -566,7 +566,7 @@ jobs:
 
       - name: Upload test artifacts (FFM)
         if: always()
-        uses: actions/upload-artifact@v5
+        uses: actions/upload-artifact@330a01c490aca151604b8cf639adc76d48f6c5d4 # v5
         with:
           name: ffm-test-results-${{ inputs.version }}
           path: |

--- a/.github/workflows/testxpr.yml
+++ b/.github/workflows/testxpr.yml
@@ -34,7 +34,7 @@ jobs:
            echo "FC=gfortran-12" >> $GITHUB_ENV
 
       - name: Get Sources
-        uses: actions/checkout@v6.0.0
+        uses: actions/checkout@1af3b93b6815bc44a9784bd300feb67ff0d1eeb3 # v6.0.0
 
       - name: Configure
         shell: bash

--- a/.github/workflows/update-progress.yml
+++ b/.github/workflows/update-progress.yml
@@ -13,15 +13,15 @@ jobs:
     if: github.repository_owner == 'HDFGROUP'
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v6.0.0
+      uses: actions/checkout@1af3b93b6815bc44a9784bd300feb67ff0d1eeb3 # v6.0.0
         
     - name: Set up Python
-      uses: actions/setup-python@v6
+      uses: actions/setup-python@83679a892e2d95755f2dac6acb0bfd1e9ac5d548 # v6
       with:
         python-version: '3.11'  # Use specific version for consistency
         
     - name: Cache pip dependencies
-      uses: actions/cache@v4
+      uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
       with:
         path: ~/.cache/pip
         key: ${{ runner.os }}-pip-${{ hashFiles('**/requirements.txt') }}

--- a/.github/workflows/vfd-ros3.yml
+++ b/.github/workflows/vfd-ros3.yml
@@ -101,7 +101,7 @@ jobs:
 
       - name: Set up Java (if specified or FFM required)
         if: inputs.java_version != 'auto' || inputs.force_java_implementation == 'ffm'
-        uses: actions/setup-java@v5
+        uses: actions/setup-java@f2beeb24e141e01a676f977032f5a29d81c9e27e # v5
         with:
           distribution: ${{ inputs.force_java_implementation == 'ffm' && 'oracle' || 'temurin' }}
           java-version: |
@@ -126,7 +126,7 @@ jobs:
           echo "CC=cl.exe" >> $GITHUB_ENV
 
       - name: Get HDF5 sources
-        uses: actions/checkout@v6.0.0
+        uses: actions/checkout@1af3b93b6815bc44a9784bd300feb67ff0d1eeb3 # v6.0.0
 
       - name: Setup jextract (FFM builds only)
         if: ${{ inputs.force_java_implementation == 'ffm' }}
@@ -263,7 +263,7 @@ jobs:
 
       - name: Set up Java (if specified or FFM required)
         if: inputs.java_version != 'auto' || inputs.force_java_implementation == 'ffm'
-        uses: actions/setup-java@v5
+        uses: actions/setup-java@f2beeb24e141e01a676f977032f5a29d81c9e27e # v5
         with:
           distribution: ${{ inputs.force_java_implementation == 'ffm' && 'oracle' || 'temurin' }}
           java-version: |
@@ -288,7 +288,7 @@ jobs:
           echo "CC=cl.exe" >> $GITHUB_ENV
 
       - name: Get HDF5 sources
-        uses: actions/checkout@v6.0.0
+        uses: actions/checkout@1af3b93b6815bc44a9784bd300feb67ff0d1eeb3 # v6.0.0
 
       - name: Setup jextract (FFM builds only)
         if: ${{ inputs.force_java_implementation == 'ffm' }}
@@ -373,7 +373,7 @@ jobs:
 
       # Save files created by CTest script
       - name: Save published binary (Windows)
-        uses: actions/upload-artifact@v5
+        uses: actions/upload-artifact@330a01c490aca151604b8cf639adc76d48f6c5d4 # v5
         with:
               name: zip-vs2022_cl-S3-${{ inputs.build_mode }}-${{ inputs.save_binary }}-binary
               path: ${{ runner.workspace }}/build/HDF5-*-win64.zip
@@ -381,7 +381,7 @@ jobs:
         if:  ${{ (matrix.ostype == 'windows') && ( inputs.save_binary != 'skip') }}
 
       - name: Save published binary (linux)
-        uses: actions/upload-artifact@v5
+        uses: actions/upload-artifact@330a01c490aca151604b8cf639adc76d48f6c5d4 # v5
         with:
               name: tgz-ubuntu-2404_gcc-S3-${{ inputs.build_mode }}-${{ inputs.save_binary }}-binary
               path: ${{ runner.workspace }}/build/HDF5-*-Linux.tar.gz
@@ -389,7 +389,7 @@ jobs:
         if:  ${{ (matrix.ostype == 'ubuntu') && ( inputs.save_binary != 'skip') }}
 
       - name: Save published binary (Mac_latest)
-        uses: actions/upload-artifact@v5
+        uses: actions/upload-artifact@330a01c490aca151604b8cf639adc76d48f6c5d4 # v5
         with:
               name: tgz-macos14_clang-S3-${{ inputs.build_mode }}-${{ inputs.save_binary }}-binary
               path: ${{ runner.workspace }}/build/HDF5-*-Darwin.tar.gz

--- a/.github/workflows/vfd-subfiling.yml
+++ b/.github/workflows/vfd-subfiling.yml
@@ -65,7 +65,7 @@ jobs:
         if: ${{ matrix.os == 'ubuntu-latest' && matrix.mpi_lib == 'MPICH' }}
 
       - name: Checkout HDF5
-        uses: actions/checkout@v6.0.0
+        uses: actions/checkout@1af3b93b6815bc44a9784bd300feb67ff0d1eeb3 # v6.0.0
 
       - name: Configure HDF5 with Subfiling VFD
         shell: bash

--- a/.github/workflows/vol_adios2.yml
+++ b/.github/workflows/vol_adios2.yml
@@ -26,7 +26,7 @@ jobs:
           sudo apt-get install libopenmpi-dev
 
       - name: Checkout HDF5
-        uses: actions/checkout@v6.0.0
+        uses: actions/checkout@1af3b93b6815bc44a9784bd300feb67ff0d1eeb3 # v6.0.0
         with:
           path: hdf5
 
@@ -66,14 +66,14 @@ jobs:
       # still test the connector against changes in HDF5.
       - name: Restore ADIOS2 (${{ env.ADIOS2_COMMIT_SHORT }}) installation cache
         id: cache-adios2
-        uses: actions/cache@v4
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
         with:
           path: ${{ runner.workspace }}/adios2-${{ env.ADIOS2_COMMIT_SHORT }}-install
           key: ${{ runner.os }}-${{ runner.arch }}-adios2-${{ env.ADIOS2_COMMIT }}-${{ inputs.build_mode }}-cache
 
       - if: ${{ steps.cache-adios2.outputs.cache-hit != 'true' }}
         name: Checkout ADIOS2 (${{ env.ADIOS2_COMMIT_SHORT }})
-        uses: actions/checkout@v6.0.0
+        uses: actions/checkout@1af3b93b6815bc44a9784bd300feb67ff0d1eeb3 # v6.0.0
         with:
           repository: ornladios/ADIOS2
           ref: ${{ env.ADIOS2_COMMIT }}
@@ -96,7 +96,7 @@ jobs:
           make -j2 install
 
       - name: Cache ADIOS2 (${{ env.ADIOS2_COMMIT_SHORT }}) installation
-        uses: actions/cache/save@v4
+        uses: actions/cache/save@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
         if: ${{ steps.cache-adios2.outputs.cache-hit != 'true' }}
         with:
           path: ${{ runner.workspace }}/adios2-${{ env.ADIOS2_COMMIT_SHORT }}-install

--- a/.github/workflows/vol_async.yml
+++ b/.github/workflows/vol_async.yml
@@ -22,12 +22,12 @@ jobs:
           sudo apt-get install automake autoconf libtool libtool-bin libopenmpi-dev
 
       - name: Checkout HDF5
-        uses: actions/checkout@v6.0.0
+        uses: actions/checkout@1af3b93b6815bc44a9784bd300feb67ff0d1eeb3 # v6.0.0
         with:
           path: hdf5
 
       - name: Checkout Argobots
-        uses: actions/checkout@v6.0.0
+        uses: actions/checkout@1af3b93b6815bc44a9784bd300feb67ff0d1eeb3 # v6.0.0
         with:
           repository: pmodels/argobots
           path: abt

--- a/.github/workflows/vol_cache.yml
+++ b/.github/workflows/vol_cache.yml
@@ -35,12 +35,12 @@ jobs:
           sudo apt-get install automake autoconf libtool libtool-bin libopenmpi-dev
 
       - name: Checkout HDF5
-        uses: actions/checkout@v6.0.0
+        uses: actions/checkout@1af3b93b6815bc44a9784bd300feb67ff0d1eeb3 # v6.0.0
         with:
           path: hdf5
 
       - name: Checkout Argobots
-        uses: actions/checkout@v6.0.0
+        uses: actions/checkout@1af3b93b6815bc44a9784bd300feb67ff0d1eeb3 # v6.0.0
         with:
           repository: pmodels/argobots
           path: abt

--- a/.github/workflows/vol_ext_passthru.yml
+++ b/.github/workflows/vol_ext_passthru.yml
@@ -22,12 +22,12 @@ jobs:
           sudo apt-get install libopenmpi-dev
 
       - name: Checkout HDF5
-        uses: actions/checkout@v6.0.0
+        uses: actions/checkout@1af3b93b6815bc44a9784bd300feb67ff0d1eeb3 # v6.0.0
         with:
           path: hdf5
 
       - name: Checkout vol-external-passthrough
-        uses: actions/checkout@v6.0.0
+        uses: actions/checkout@1af3b93b6815bc44a9784bd300feb67ff0d1eeb3 # v6.0.0
         with:
           repository: hpc-io/vol-external-passthrough
           path: vol-external-passthrough

--- a/.github/workflows/vol_log.yml
+++ b/.github/workflows/vol_log.yml
@@ -23,7 +23,7 @@ jobs:
           #mpich
 
       - name: Checkout HDF5
-        uses: actions/checkout@v6.0.0
+        uses: actions/checkout@1af3b93b6815bc44a9784bd300feb67ff0d1eeb3 # v6.0.0
         with:
           path: hdf5
 
@@ -56,7 +56,7 @@ jobs:
           echo "PATH=${{ runner.workspace }}/hdf5_build/bin:${PATH}" >> $GITHUB_ENV
 
       - name: Checkout Log-based VOL
-        uses: actions/checkout@v6.0.0
+        uses: actions/checkout@1af3b93b6815bc44a9784bd300feb67ff0d1eeb3 # v6.0.0
         with:
           repository: HDFGroup/vol-log-based
           path: vol-log-based

--- a/.github/workflows/vol_rest.yml
+++ b/.github/workflows/vol_rest.yml
@@ -42,7 +42,7 @@ jobs:
           sudo apt-get install libcurl4-openssl-dev libyajl-dev
 
       - name: Checkout HDF5
-        uses: actions/checkout@v6.0.0
+        uses: actions/checkout@1af3b93b6815bc44a9784bd300feb67ff0d1eeb3 # v6.0.0
         with:
           path: hdf5
 
@@ -77,12 +77,12 @@ jobs:
           echo "LD_LIBRARY_PATH=${{ github.workspace }}/hdf5/build/bin" >> $GITHUB_ENV
 
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@83679a892e2d95755f2dac6acb0bfd1e9ac5d548 # v6
         with:
           python-version: ${{ matrix.python-version }}
 
       - name: Checkout HSDS
-        uses: actions/checkout@v6.0.0
+        uses: actions/checkout@1af3b93b6815bc44a9784bd300feb67ff0d1eeb3 # v6.0.0
         with:
           repository: HDFGroup/hsds
           path: ${{github.workspace}}/hsds


### PR DESCRIPTION
Hash-pinned dependencies are an important requirement enforced by the OpenSSF scorecard tool: https://github.com/ossf/scorecard/blob/main/docs/checks.md#pinned-dependencies

This commit pins all GitHub Actions workflows to a commit hash.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Pin all GitHub Actions dependencies to specific commit hashes across multiple workflows for enhanced security compliance.
> 
>   - **Security**:
>     - Pin all GitHub Actions dependencies to specific commit hashes in various workflow files to comply with OpenSSF scorecard requirements.
>   - **Workflows**:
>     - `.github/workflows/abi-report.yml`: Pin `actions/checkout`, `actions/download-artifact`, and `actions/upload-artifact`.
>     - `.github/workflows/analysis.yml`: Pin `DamianReeves/write-file-action`, `actions/upload-artifact`, and `KyleMayes/install-llvm-action`.
>     - `.github/workflows/aocc.yml`: Pin `actions/checkout` and `actions/cache`.
>     - ... and 50 other workflow files.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=HDFGroup%2Fhdf5&utm_source=github&utm_medium=referral)<sup> for 4aa61dec22779d0c665eb107060b145bde40b052. You can [customize](https://app.ellipsis.dev/HDFGroup/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->