### PR TITLE
Add release 1.14.6 page to doxygen

### DIFF
--- a/doxygen/aliases
+++ b/doxygen/aliases
@@ -18,7 +18,7 @@ ALIASES += RFCURL="\DOCURL/rfc"
 ALIASES += AEXURL="\HDFURL/archive/support/ftp/HDF5/examples"
 #branch name (develop, hdf5_2_0_0)
 ALIASES += SRCURL="github.com/HDFGroup/hdf5/blob/develop"
-ALIASES += SRCURL20="github.com/HDFGroup/hdf5/blob/hdf5_2_0_0"
+ALIASES += SRCURL114="github.com/HDFGroup/hdf5/blob/hdf5_1.14.6"
 #Other projects that contribute to HDF5
 ALIASES += PRJURL="\HDFURL/archive/support/projects"
 ALIASES += HVURL="github.com/HDFGroup/hdfview/blob/master"

--- a/doxygen/dox/hdf5_1_14.dox
+++ b/doxygen/dox/hdf5_1_14.dox
@@ -95,7 +95,7 @@ Please refer to [Build instructions](https://\SRCURL/release_docs/INSTALL) for b
     `wget https://github.com/HDFGroup/hdf5/releases/download/${PACKAGEVERSION}/<distribution>.tar.gz`<br>
     `gzip -cd <distribution>.tar.gz | tar xvf -`
 </div>
-\li `<distribution>` is hdf5-${PACKAGEVERSION}, where PACKAGEVERSION is 2.0.0 for this release
+\li `<distribution>` is hdf5-${PACKAGEVERSION}, where PACKAGEVERSION is 1.14.6 for this release
 
 
 \subsection subsec_dox_gen_doc Doxygen Generated Reference Manual

--- a/doxygen/dox/hdf5_1_14.dox
+++ b/doxygen/dox/hdf5_1_14.dox
@@ -3,6 +3,108 @@
  * Navigate back: \ref index "Main" / \ref release_specific_info
  * <hr>
 
+
+\section sec_rel_spec_114 HDF5 Library and Tools 1.14.6
+
+\subsection subsec_rel_info Release Information
+
+<table>
+<tr>
+<td style="background-color:#F5F5F5">
+Version
+</td>
+<td>
+HDF5 1.14.6
+</td>
+</tr>
+<tr>
+<td style="background-color:#F5F5F5">
+Release Date
+</td>
+<td>
+02/05/25
+</td>
+</tr>
+<tr>
+<td style="background-color:#F5F5F5">
+Additional Release Information
+</td>
+<td>
+<a href="https://\SRCURL114/release_docs/RELEASE.txt">RELEASE.txt</a>
+</td>
+</tr>
+<tr>
+<td style="background-color:#F5F5F5">
+</td>
+<td>
+\ref sec_rel_spec_114_migrate
+</td>
+</tr>
+<tr>
+<td style="background-color:#F5F5F5">
+</td>
+<td>
+\ref sec_rel_spec_114_change
+</td>
+</tr>
+<tr>
+<td style="background-color:#F5F5F5">
+</td>
+<td>
+\ref sec_rel_spec_114_feat
+</td>
+</tr>
+<tr>
+<td style="background-color:#F5F5F5">
+</td>
+<td>
+[Newsletter Announcement](https://www.hdfgroup.org/2025/02/05/release-of-hdf5-1-14-6-newsletter-205/)
+</td>
+</tr>
+<tr>
+<td style="background-color:#F5F5F5">
+</td>
+<td>
+ABI/API compatibility reports between 1.14.6 and 1.14.5 [tar file](https://\RELURL/v1_14/v1_14_6/downloads/hdf5-1.14.6.html.abi.reports.tar.gz) or [individual html files](https://\RELURL/v1_14/v1_14_6/downloads/compat_report/index.html)
+</td>
+</tr>
+<tr>
+<td style="background-color:#F5F5F5">
+</td>
+<td>
+[Doxygen generated Reference Manual](https://support.hdfgroup.org/documentation/hdf5/latest/)
+</td>
+</tr>
+</table>
+
+
+\subsection subsec_download Downloads
+
+Source code and binaries are available at:
+<a href="https://\RELURL/v1_14/v1_14_6/downloads/index.html">https://support.hdfgroup.org/releases/hdf5/v1_14/v1_14_6</a>
+
+Please refer to [Build instructions](https://\SRCURL/release_docs/INSTALL) for building with either CMake or Autotools.
+
+
+\subsection subsec_obtain_method Methods to obtain (gz file)
+
+\li firefox – Download file and then run:  `gzip <distribution>.tar.gz | tar xzf -`
+\li chrome –  Download file and then run:  `gzip -cd <distribution>.tar.gz | tar xvf -`
+\li wget –
+<div style="margin-left: 2em;">
+    `wget https://github.com/HDFGroup/hdf5/releases/download/${PACKAGEVERSION}/<distribution>.tar.gz`<br>
+    `gzip -cd <distribution>.tar.gz | tar xvf -`
+</div>
+\li `<distribution>` is hdf5-${PACKAGEVERSION}, where PACKAGEVERSION is 2.0.0 for this release
+
+
+\subsection subsec_dox_gen_doc Doxygen Generated Reference Manual
+
+The new HDF5 documentation based on [Doxygen](https://www.doxygen.nl/index.html) is available \ref index "here".
+
+This documentation is WORK-IN-PROGRESS.
+Since this portion of the HDF5 documentation is now part of the source code, it gets the same treatment as code. In other words, issues, inaccuracies, corrections should be reported as issues in [GitHub](https://github.com/HDFGroup/hdf5/issues), and pull requests will be reviewed and accepted as any other code changes.
+
 \section sec_rel_spec_114_migrate Migrating from HDF5 1.12 to HDF5 1.14
 # Migrating to HDF5 1.14 from Previous Versions of HDF5
 

--- a/doxygen/dox/hdf5_1_14.dox
+++ b/doxygen/dox/hdf5_1_14.dox
@@ -6,7 +6,7 @@
 
 \section sec_rel_spec_114 HDF5 Library and Tools 1.14.6
 
-\subsection subsec_rel_info Release Information
+\subsection subsec_rel_info_114 Release Information
 
 <table>
 <tr>
@@ -78,7 +78,7 @@ ABI/API compatibility reports between 1.14.6 and 1.14.5 [tar file](https://\RELU
 </table>
 
 
-\subsection subsec_download Downloads
+\subsection subsec_download_114 Downloads
 
 Source code and binaries are available at:
 <a href="https://\RELURL/v1_14/v1_14_6/downloads/index.html">https://support.hdfgroup.org/releases/hdf5/v1_14/v1_14_6</a>
@@ -86,7 +86,7 @@ Source code and binaries are available at:
 Please refer to [Build instructions](https://\SRCURL/release_docs/INSTALL) for building with either CMake or Autotools.
 
 
-\subsection subsec_obtain_method Methods to obtain (gz file)
+\subsection subsec_obtain_method_114 Methods to obtain (gz file)
 
 \li firefox – Download file and then run:  `gzip <distribution>.tar.gz | tar xzf -`
 \li chrome –  Download file and then run:  `gzip -cd <distribution>.tar.gz | tar xvf -`
@@ -98,7 +98,7 @@ Please refer to [Build instructions](https://\SRCURL/release_docs/INSTALL) for b
 \li `<distribution>` is hdf5-${PACKAGEVERSION}, where PACKAGEVERSION is 1.14.6 for this release
 
 
-\subsection subsec_dox_gen_doc Doxygen Generated Reference Manual
+\subsection subsec_dox_gen_doc_114 Doxygen Generated Reference Manual
 
 The new HDF5 documentation based on [Doxygen](https://www.doxygen.nl/index.html) is available \ref index "here".
 

--- a/doxygen/dox/hdf5_2_0.dox
+++ b/doxygen/dox/hdf5_2_0.dox
@@ -5,7 +5,7 @@
 
 \section sec_rel_spec_20 HDF5 Library and Tools 2.0.0
 
-\subsection subsec_rel_info Release Information
+\subsection subsec_rel_info_20 Release Information
 
 <table>
 <tr>
@@ -77,7 +77,7 @@ ABI/API Compatibility Reports between 2.0.0 and 1.14.6 [tar file](https://\RELUR
 </table>
 
 
-\subsection subsec_download Downloads
+\subsection subsec_download_20 Downloads
 
 Source code and binaries are available at:
 <a href="https://\RELURL/v2_0/v2_0_0/downloads/index.html">https://support.hdfgroup.org/releases/hdf5/v2_0/v2_0_0/downloads/index.html</a>
@@ -85,7 +85,7 @@ Source code and binaries are available at:
 Please refer to [Build instructions](https://\SRCURL/release_docs/INSTALL) for building with CMake.
 
 
-\subsection subsec_obtain_method Methods to obtain (gz file)
+\subsection subsec_obtain_method_20 Methods to obtain (gz file)
 
 \li firefox – Download file and then run:  `gzip <distribution>.tar.gz | tar xzf -`
 \li chrome –  Download file and then run:  `gzip -cd <distribution>.tar.gz | tar xvf -`
@@ -97,7 +97,7 @@ Please refer to [Build instructions](https://\SRCURL/release_docs/INSTALL) for b
 \li `<distribution>` is hdf5-${PACKAGEVERSION}, where PACKAGEVERSION is 2.0.0 for this release
 
 
-\subsection subsec_dox_gen_doc Doxygen Generated Reference Manual
+\subsection subsec_dox_gen_doc_20 Doxygen Generated Reference Manual
 
 The new HDF5 documentation based on [Doxygen](https://www.doxygen.nl/index.html) is available \ref index "here".
 

--- a/doxygen/dox/hdf5_2_0.dox
+++ b/doxygen/dox/hdf5_2_0.dox
@@ -64,7 +64,7 @@ Additional Release Information
 <td style="background-color:#F5F5F5">
 </td>
 <td>
-ABI/API Compatibility Reports between 2.0.0 and 1.14.6[tar file](https://\RELURL/v2_0/v2_0_0/downloads/hdf5-2.0.0.html.abi.reports.tar.gz) or [individual html files](https://\RELURL/v2_0/v2_0_0/downloads/compat_report/index.html)
+ABI/API Compatibility Reports between 2.0.0 and 1.14.6 [tar file](https://\RELURL/v2_0/v2_0_0/downloads/hdf5-2.0.0.html.abi.reports.tar.gz) or [individual html files](https://\RELURL/v2_0/v2_0_0/downloads/compat_report/index.html)
 </td>
 </tr>
 <tr>

--- a/doxygen/dox/hdf5_2_0.dox
+++ b/doxygen/dox/hdf5_2_0.dox
@@ -64,7 +64,7 @@ Additional Release Information
 <td style="background-color:#F5F5F5">
 </td>
 <td>
-[API Compatibility Reports between 2.0.0 and 1.14.6](https://\RELURL/v2_0/v2_0_0/downloads/hdf5-2.0.0.html.abi.reports.tar.gz)
+ABI/API Compatibility Reports between 2.0.0 and 1.14.6[tar file](https://\RELURL/v2_0/v2_0_0/downloads/hdf5-2.0.0.html.abi.reports.tar.gz) or [individual html files](https://\RELURL/v2_0/v2_0_0/downloads/compat_report/index.html)
 </td>
 </tr>
 <tr>
@@ -82,7 +82,7 @@ Additional Release Information
 Source code and binaries are available at:
 <a href="https://\RELURL/v2_0/v2_0_0/downloads/index.html">https://support.hdfgroup.org/releases/hdf5/v2_0/v2_0_0/downloads/index.html</a>
 
-Please refer to [Build instructions](https://\SRCURL/release_docs/INSTALL) for building with either CMake or Autotools.
+Please refer to [Build instructions](https://\SRCURL/release_docs/INSTALL) for building with CMake.
 
 
 \subsection subsec_obtain_method Methods to obtain (gz file)
@@ -95,16 +95,6 @@ Please refer to [Build instructions](https://\SRCURL/release_docs/INSTALL) for b
     `gzip -cd <distribution>.tar.gz | tar xvf -`
 </div>
 \li `<distribution>` is hdf5-${PACKAGEVERSION}, where PACKAGEVERSION is 2.0.0 for this release
-
-\subsection subsec_api_compat_reps Individual API Compatibility Reports
-
-* [hdf5-2.0-hdf5_compat_report.html](https://\RELURL/v2_0/v2_0_0/downloads/compat_report/hdf5-2.0.0-hdf5_compat_report.html) -- HTML C library ABI report file
-
-* [hdf5-2.0-hdf5_cpp_compat_report.html](https://\RELURL/v2_0/v2_0_0/downloads/compat_report/hdf5-2.0.0-hdf5_cpp_compat_report.html) -- HTML CPP library ABI report file
-
-* [hdf5-2.0-hdf5_hl_compat_report.html](https://\RELURL/v2_0/v2_0_0/downloads/compat_report/hdf5-2.0.0-hdf5_hl_compat_report.html) -- HTML HL C library ABI report file
-
-* [hdf5-2.0-java_compat_report.html](https://\RELURL/v2_0/v2_0_0/downloads/compat_report/hdf5-2.0.0-java_compat_report.html) -- HTML Java library ABI report file
 
 
 \subsection subsec_dox_gen_doc Doxygen Generated Reference Manual


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Add HDF5 1.14.6 release documentation to Doxygen, update aliases, and correct compatibility links.
> 
>   - **Documentation**:
>     - Add release 1.14.6 information to `doxygen/dox/hdf5_1_14.dox`, including release date, version, and download links.
>     - Update `doxygen/aliases` to include `SRCURL114` for HDF5 1.14.6 source URL.
>   - **Compatibility**:
>     - Correct ABI/API compatibility report links in `doxygen/dox/hdf5_2_0.dox`.
>   - **Build Instructions**:
>     - Update build instructions in `doxygen/dox/hdf5_2_0.dox` to specify CMake only.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=HDFGroup%2Fhdf5&utm_source=github&utm_medium=referral)<sup> for f82204746898f1599e8f7a94abc51ee12e8f8cc0. You can [customize](https://app.ellipsis.dev/HDFGroup/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->