### PR TITLE
Add installing and building JAVA 21 on windows-11-arm test runner.

### DIFF
--- a/.github/workflows/arm-main.yml
+++ b/.github/workflows/arm-main.yml
@@ -52,6 +52,12 @@ jobs:
           which cmake
           cmake --version
 
+      - name: Set up JDK 21
+        uses: actions/setup-java@v5
+        with:
+          java-version: '21'
+          distribution: 'temurin'
+
       - name: Set environment for MSVC (Windows)
         run: |
           # Set these environment variables so CMake picks the correct compiler
@@ -73,6 +79,7 @@ jobs:
             -DCMAKE_BUILD_TYPE=${{ inputs.build_mode }} \
             -DHDF5_ENABLE_DOXY_WARNINGS:BOOL=ON \
             -DHDF5_BUILD_FORTRAN:BOOL=OFF \
+            -DHDF5_BUILD_JAVA=ON \
             -DHDF5_BUILD_DOC:BOOL=ON \
             -DHDF5_ENABLE_ZLIB_SUPPORT:BOOL=OFF \
             -DHDF5_ENABLE_SZIP_SUPPORT:BOOL=OFF \


### PR DESCRIPTION
Fixes #5677

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Add JDK 21 setup and enable Java build in CMake for Windows 11 ARM in `arm-main.yml`.
> 
>   - **Setup**:
>     - Add JDK 21 setup using `actions/setup-java@v5` in `arm-main.yml` for Windows 11 ARM.
>   - **CMake Configuration**:
>     - Enable Java build with `-DHDF5_BUILD_JAVA=ON` in `arm-main.yml` for Windows 11 ARM.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=HDFGroup%2Fhdf5&utm_source=github&utm_medium=referral)<sup> for a132e4d5d83c7a8ef0e39cd724b75e0253d3d744. You can [customize](https://app.ellipsis.dev/HDFGroup/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->