### PR TITLE
Correct return values for HGOTO_ERROR calls to FAIL instead of '0'.

### DIFF
--- a/src/H5Zscaleoffset.c
+++ b/src/H5Zscaleoffset.c
@@ -1626,7 +1626,7 @@ H5Z__scaleoffset_decompress_one_byte(unsigned char *data, size_t data_offset, un
     FUNC_ENTER_PACKAGE
 
     if (*j >= buf_size)
-        HGOTO_ERROR(H5E_PLINE, H5E_BADVALUE, 0, "Buffer too short");
+        HGOTO_ERROR(H5E_PLINE, H5E_BADVALUE, FAIL, "Buffer too short");
 
     /* initialize value and bits of unsigned char to be copied */
     val = buffer[*j];
@@ -1648,7 +1648,7 @@ H5Z__scaleoffset_decompress_one_byte(unsigned char *data, size_t data_offset, un
         if (bits_to_copy == 0)
             goto done;
         else if (*j >= buf_size)
-            HGOTO_ERROR(H5E_PLINE, H5E_BADVALUE, 0, "Buffer too short");
+            HGOTO_ERROR(H5E_PLINE, H5E_BADVALUE, FAIL, "Buffer too short");
 
         val = buffer[*j];
         data[data_offset + k] |= (unsigned char)((unsigned)(val >> (*bits_to_fill - bits_to_copy)) &
@@ -1682,7 +1682,7 @@ H5Z__scaleoffset_decompress_one_atomic(unsigned char *data, size_t data_offset, 
         for (k = (int)begin_i; k >= 0; k--)
             if (H5Z__scaleoffset_decompress_one_byte(data, data_offset, (unsigned)k, begin_i, buffer,
                                                      buf_size, j, bits_to_fill, p, dtype_len))
-                HGOTO_ERROR(H5E_PLINE, H5E_BADVALUE, 0, "Atomic decompression failed");
+                HGOTO_ERROR(H5E_PLINE, H5E_BADVALUE, FAIL, "Atomic decompression failed");
     }
     else { /* big endian */
         assert(p.mem_order == H5Z_SCALEOFFSET_ORDER_BE);
@@ -1692,7 +1692,7 @@ H5Z__scaleoffset_decompress_one_atomic(unsigned char *data, size_t data_offset, 
         for (k = (int)begin_i; k <= (int)(p.size - 1); k++)
             if (H5Z__scaleoffset_decompress_one_byte(data, data_offset, (unsigned)k, begin_i, buffer,
                                                      buf_size, j, bits_to_fill, p, dtype_len))
-                HGOTO_ERROR(H5E_PLINE, H5E_BADVALUE, 0, "Atomic decompression failed");
+                HGOTO_ERROR(H5E_PLINE, H5E_BADVALUE, FAIL, "Atomic decompression failed");
     }
 
 done:
@@ -1722,7 +1722,7 @@ H5Z__scaleoffset_decompress(unsigned char *data, unsigned d_nelmts, unsigned cha
     /* decompress */
     for (i = 0; i < d_nelmts; i++)
         if (H5Z__scaleoffset_decompress_one_atomic(data, i * p.size, buffer, buf_size, &j, &bits_to_fill, p))
-            HGOTO_ERROR(H5E_PLINE, H5E_BADVALUE, 0, "Scaleoffset decompression failed");
+            HGOTO_ERROR(H5E_PLINE, H5E_BADVALUE, FAIL, "Scaleoffset decompression failed");
 
 done:
     FUNC_LEAVE_NOAPI(ret_value)


### PR DESCRIPTION
Fixes incorrect error return values in PR #5960 merged earlier today
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Corrects error return values from `0` to `FAIL` in `H5Zscaleoffset.c` for consistent error handling.
> 
>   - **Error Handling**:
>     - Corrects error return values from `0` to `FAIL` in `H5Z__scaleoffset_decompress_one_byte()`, `H5Z__scaleoffset_decompress_one_atomic()`, and `H5Z__scaleoffset_decompress()` in `H5Zscaleoffset.c`.
>     - Ensures consistent error handling by using `FAIL` for error returns instead of `0`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=HDFGroup%2Fhdf5&utm_source=github&utm_medium=referral)<sup> for 2c80213ea3a96b39377bc3573c24b73f9450d9f3. You can [customize](https://app.ellipsis.dev/HDFGroup/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->