### PR TITLE
chore: make comment consistent in tH5T_F03.F90

### DIFF
--- a/fortran/test/tH5T_F03.F90
+++ b/fortran/test/tH5T_F03.F90
@@ -2876,7 +2876,7 @@ SUBROUTINE setup_buffer(data_in, line_lengths, char_type)
 
   IMPLICIT NONE
 
-  ! Creates a simple "Data_in" consisting of the letters of the alphabet,
+  ! Create a simple "Data_in" consisting of the letters of the alphabet,
   ! one per line, with a control character.
 
   CHARACTER(len=10), DIMENSION(:) :: data_in


### PR DESCRIPTION
There is 1 `Creates`. The rest (=87) are `Create`. 

Change `Creates` to `Create`.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Corrects a comment in `tH5T_F03.F90` from `Creates` to `Create` for consistency.
> 
>   - **Comments**:
>     - Corrects comment in `tH5T_F03.F90` from `Creates` to `Create` for consistency with 87 other instances.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=HDFGroup%2Fhdf5&utm_source=github&utm_medium=referral)<sup> for f4bf0de78216a0aa3ba1b41c88469ce87632741b. You can [customize](https://app.ellipsis.dev/HDFGroup/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->