### PR TITLE
Changed download link to use the GitHub release page.

### DIFF
--- a/doxygen/dox/hdf5_2_0.dox
+++ b/doxygen/dox/hdf5_2_0.dox
@@ -80,7 +80,7 @@ Additional Release Information
 \subsection subsec_download Downloads
 
 Source code and binaries are available at:
-<a href="https://\RELURL/v2_0/v2_0_0/downloads/index.html">https://support.hdfgroup.org/releases/hdf5/v2_0/v2_0_0/downloads/index.html</a>
+<a href="https://github.com/HDFGroup/hdf5/releases/tag/2.0.0">HDF5 2.0.0 on GitHub</a>
 
 Please refer to [Build instructions](https://\SRCURL/release_docs/INSTALL) for building with either CMake or Autotools.
 


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Updated download link in `hdf5_2_0.dox` to point to GitHub release page for HDF5 2.0.0.
> 
>   - **Documentation**:
>     - Updated download link in `hdf5_2_0.dox` to point to the GitHub release page for HDF5 2.0.0.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=HDFGroup%2Fhdf5&utm_source=github&utm_medium=referral)<sup> for e7c8ae620ba2a82e317c585e1ee881065cd7db23. You can [customize](https://app.ellipsis.dev/HDFGroup/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->