### PR TITLE
Adds release version to more constants

### DIFF
--- a/src/H5Fpublic.h
+++ b/src/H5Fpublic.h
@@ -30,7 +30,7 @@
 #define H5F_ACC_TRUNC  (0x0002u) /**< Overwrite existing files \since 1.0.0    */
 #define H5F_ACC_EXCL   (0x0004u) /**< Fail if file already exists \since 1.0.0 */
 /* NOTE: 0x0008u was H5F_ACC_DEBUG, now deprecated */
-#define H5F_ACC_CREAT (0x0010u) /**< Create non-existing files \since 1.4.0    */
+#define H5F_ACC_CREAT (0x0010u)  /**< Create non-existing files \since 1.4.0    */
 
 /**
  * Indicates that this file is open for writing in a single-writer/multi-reader
@@ -78,7 +78,7 @@
  * member is unknown \since 1.8.0 */
 #define H5F_FAMILY_DEFAULT 0 /* (hsize_t) */
 
-/* Macro used to "unset" the page buffer size in a FAPL */
+/** Macro used to "unset" the page buffer size in a FAPL \since 2.0.0 */
 #define H5F_PAGE_BUFFER_SIZE_DEFAULT SIZE_MAX
 
 #ifdef H5_HAVE_PARALLEL
@@ -86,7 +86,7 @@
  * Use this constant string as the MPI_Info key to set H5Fmpio debug flags.
  * To turn on H5Fmpio debug flags, set the MPI_Info value with this key to
  * have the value of a string consisting of the characters that turn on the
- * desired flags.
+ * desired flags. \since 1.0.0
  */
 #define H5F_MPIO_DEBUG_KEY "H5F_mpio_debug_key"
 #endif /* H5_HAVE_PARALLEL */
@@ -100,9 +100,7 @@ typedef enum H5F_scope_t {
     H5F_SCOPE_GLOBAL = 1  /**< The entire virtual file        */
 } H5F_scope_t;
 
-/**
- * Unlimited file size for H5Pset_external()
- */
+/** Unlimited file size for H5Pset_external() \since 1.0.0 */
 #define H5F_UNLIMITED HSIZE_UNDEF
 
 /**
@@ -248,13 +246,13 @@ typedef herr_t (*H5F_flush_cb_t)(hid_t object_id, void *udata);
 /**
  * Suppress errors for numeric datatypes with an unusually high number of
  * unused bits. See documentation for H5Pset_relax_file_integrity_checks()
- * for details.
+ * for details. \since 1.14.4
  */
 #define H5F_RFIC_UNUSUAL_NUM_UNUSED_NUMERIC_BITS (0x0001u)
 
 /**
  * Suppress all format integrity check errors. See documentation for
- * H5Pset_relax_file_integrity_checks() for details.
+ * H5Pset_relax_file_integrity_checks() for details. \since 1.14.4
  */
 #define H5F_RFIC_ALL (H5F_RFIC_UNUSUAL_NUM_UNUSED_NUMERIC_BITS)
 
@@ -1907,7 +1905,7 @@ H5_DLL herr_t H5Fformat_convert(hid_t fid);
 #ifndef H5_NO_DEPRECATED_SYMBOLS
 
 /* Macros */
-#define H5F_ACC_DEBUG (0x0000u) /**< Print debug info \deprecated In which version? */
+#define H5F_ACC_DEBUG (0x0000u) /**< Print debug info \deprecated 1.8.16 */
 
 /* Typedefs */
 

--- a/src/H5Fpublic.h
+++ b/src/H5Fpublic.h
@@ -30,7 +30,7 @@
 #define H5F_ACC_TRUNC  (0x0002u) /**< Overwrite existing files \since 1.0.0    */
 #define H5F_ACC_EXCL   (0x0004u) /**< Fail if file already exists \since 1.0.0 */
 /* NOTE: 0x0008u was H5F_ACC_DEBUG, now deprecated */
-#define H5F_ACC_CREAT (0x0010u)  /**< Create non-existing files \since 1.4.0    */
+#define H5F_ACC_CREAT (0x0010u) /**< Create non-existing files \since 1.4.0    */
 
 /**
  * Indicates that this file is open for writing in a single-writer/multi-reader

--- a/src/H5Gpublic.h
+++ b/src/H5Gpublic.h
@@ -531,11 +531,11 @@ H5_DLL herr_t H5Gclose_async(hid_t group_id, hid_t es_id);
 #define H5G_link_t     H5L_type_t     /**< Link types \since 1.0.0 */
 
 /* Macros for types of objects in a group (see H5G_obj_t definition) */
-#define H5G_NTYPES      256           /**< Max possible number of types \since 1.0.0 */
-#define H5G_NLIBTYPES   8             /**< Number of internal types \since 1.2.0 */
-#define H5G_NUSERTYPES  (H5G_NTYPES - H5G_NLIBTYPES)
-                                      /**< Number of user-defined types \since 1.2.0 */
-#define H5G_USERTYPE(X) (8 + (X))     /**< User defined types \since 1.2.0 */
+#define H5G_NTYPES     256 /**< Max possible number of types \since 1.0.0 */
+#define H5G_NLIBTYPES  8   /**< Number of internal types \since 1.2.0 */
+#define H5G_NUSERTYPES (H5G_NTYPES - H5G_NLIBTYPES)
+/**< Number of user-defined types \since 1.2.0 */
+#define H5G_USERTYPE(X) (8 + (X)) /**< User defined types \since 1.2.0 */
 
 /* Typedefs */
 

--- a/src/H5Gpublic.h
+++ b/src/H5Gpublic.h
@@ -524,17 +524,18 @@ H5_DLL herr_t H5Gclose_async(hid_t group_id, hid_t es_id);
 /* Macros */
 
 /* Link definitions */
-#define H5G_SAME_LOC   H5L_SAME_LOC
-#define H5G_LINK_ERROR H5L_TYPE_ERROR
-#define H5G_LINK_HARD  H5L_TYPE_HARD
-#define H5G_LINK_SOFT  H5L_TYPE_SOFT
-#define H5G_link_t     H5L_type_t
+#define H5G_SAME_LOC   H5L_SAME_LOC   /**< Indicates operation occurs on same location \since 1.6.0 */
+#define H5G_LINK_ERROR H5L_TYPE_ERROR /**< Invalid link type id \since 1.8.0 */
+#define H5G_LINK_HARD  H5L_TYPE_HARD  /**< Hard link id \since 1.8.0 */
+#define H5G_LINK_SOFT  H5L_TYPE_SOFT  /**< Soft link id \since 1.8.0 */
+#define H5G_link_t     H5L_type_t     /**< Link types \since 1.0.0 */
 
 /* Macros for types of objects in a group (see H5G_obj_t definition) */
-#define H5G_NTYPES      256 /* Max possible number of types	*/
-#define H5G_NLIBTYPES   8   /* Number of internal types	*/
+#define H5G_NTYPES      256           /**< Max possible number of types \since 1.0.0 */
+#define H5G_NLIBTYPES   8             /**< Number of internal types \since 1.2.0 */
 #define H5G_NUSERTYPES  (H5G_NTYPES - H5G_NLIBTYPES)
-#define H5G_USERTYPE(X) (8 + (X)) /* User defined types		*/
+                                      /**< Number of user-defined types \since 1.2.0 */
+#define H5G_USERTYPE(X) (8 + (X))     /**< User defined types \since 1.2.0 */
 
 /* Typedefs */
 

--- a/src/H5Ipublic.h
+++ b/src/H5Ipublic.h
@@ -64,14 +64,10 @@ typedef int64_t hid_t;
 #define PRIXHID PRIX64
 #define PRIoHID PRIo64
 
-/**
- * The size of identifiers
- */
+/** The size of identifiers \since 1.8.0 */
 #define H5_SIZEOF_HID_T H5_SIZEOF_INT64_T
 
-/**
- * An invalid object ID. This is also negative for error return.
- */
+/** An invalid object ID. This is also negative for error return. \since 1.6.0 */
 #define H5I_INVALID_HID (-1)
 
 /**

--- a/src/H5PLpublic.h
+++ b/src/H5PLpublic.h
@@ -40,16 +40,10 @@ typedef enum H5PL_type_t {
 //! <!-- [H5PL_type_t_snip] -->
 
 /* Common dynamic plugin type flags used by the set/get_loading_state functions */
-/** Flag for filter plugin \since 1.8.15 */
-#define H5PL_FILTER_PLUGIN 0x0001
-/** Flag for VOL plugin \since 1.12.0 */
-#define H5PL_VOL_PLUGIN 0x0002
-/** Flag for VFD plugin \since 1.14.0 */
-#define H5PL_VFD_PLUGIN 0x0004
-/** Flag for all plugin types \since 1.8.15 */
-#define H5PL_ALL_PLUGIN 0xFFFF
-
-#define H5F_ACC_DEBUG (0x0000u) /**< Print debug info \deprecated In which version? */
+#define H5PL_FILTER_PLUGIN 0x0001 /**< Flag for filter plugin \since 1.8.15 */
+#define H5PL_VOL_PLUGIN    0x0002 /**< Flag for VOL plugin \since 1.12.0 */
+#define H5PL_VFD_PLUGIN    0x0004 /**< Flag for VFD plugin \since 1.14.0 */
+#define H5PL_ALL_PLUGIN    0xFFFF /**< Flag for all plugin types \since 1.8.15 */
 
 #ifdef __cplusplus
 extern "C" {

--- a/src/H5Rpublic.h
+++ b/src/H5Rpublic.h
@@ -30,7 +30,7 @@
 #define H5R_DSET_REG_REF_BUF_SIZE (sizeof(haddr_t) + 4)
 
 /**
- * Default reference buffer size.
+ * Default reference buffer size. \since 1.12.0
  *
  * \internal Note! Be careful with the sizes of the references because they
  *           should really depend on the run-time values in the file.


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Add version annotations to constants in multiple HDF5 header files for better documentation.
> 
>   - **Documentation**:
>     - Add `\since` version annotations to constants in `H5Fpublic.h`, `H5Gpublic.h`, `H5Ipublic.h`, `H5PLpublic.h`, and `H5Rpublic.h`.
>     - Specific constants updated include `H5F_ACC_CREAT`, `H5F_PAGE_BUFFER_SIZE_DEFAULT`, `H5F_MPIO_DEBUG_KEY`, `H5F_UNLIMITED`, `H5F_RFIC_UNUSUAL_NUM_UNUSED_NUMERIC_BITS`, `H5F_RFIC_ALL`, `H5F_ACC_DEBUG`, `H5G_SAME_LOC`, `H5G_LINK_ERROR`, `H5G_LINK_HARD`, `H5G_LINK_SOFT`, `H5G_link_t`, `H5G_NTYPES`, `H5G_NLIBTYPES`, `H5G_USERTYPE`, `H5_SIZEOF_HID_T`, `H5I_INVALID_HID`, `H5PL_FILTER_PLUGIN`, `H5PL_VOL_PLUGIN`, `H5PL_VFD_PLUGIN`, `H5PL_ALL_PLUGIN`, `H5R_REF_BUF_SIZE`.
>   - **Misc**:
>     - Minor formatting adjustments in `H5Fpublic.h` and `H5PLpublic.h`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=HDFGroup%2Fhdf5&utm_source=github&utm_medium=referral)<sup> for e8624fa187cb29f186d71ef90f38c009c63cf1a0. You can [customize](https://app.ellipsis.dev/HDFGroup/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->