### PR TITLE
Use 'find_dependency' instead of 'find_package'

### DIFF
--- a/config/install/hdf5-config.cmake.in
+++ b/config/install/hdf5-config.cmake.in
@@ -16,6 +16,8 @@
 #-----------------------------------------------------------------------------
 @PACKAGE_INIT@
 
+include(CMakeFindDependencyMacro)
+
 string(TOUPPER @HDF5_PACKAGE@ HDF5_PACKAGE_NAME)
 
 set (${HDF5_PACKAGE_NAME}_VALID_COMPONENTS
@@ -93,12 +95,12 @@ if (${HDF5_PACKAGE_NAME}_PROVIDES_PARALLEL)
   set (${HDF5_PACKAGE_NAME}_PROVIDES_LARGE_PARALLEL_IO        @LARGE_PARALLEL_IO@)
 
   enable_language(C) # for MPI::MPI_C
-  find_package(MPI QUIET REQUIRED)
+  find_dependency(MPI QUIET REQUIRED)
 endif ()
 
 if (${HDF5_PACKAGE_NAME}_PROVIDES_THREADS)
   set(THREADS_PREFER_PTHREAD_FLAG ON)
-  find_package(Threads QUIET REQUIRED)
+  find_dependency(Threads QUIET REQUIRED)
 endif ()
 
 if (${HDF5_PACKAGE_NAME}_PROVIDES_JAVA AND ${HDF5_PACKAGE_NAME}_PROVIDES_JNI)
@@ -124,16 +126,16 @@ if (${HDF5_PACKAGE_NAME}_PROVIDES_ZLIB_SUPPORT)
   if (NOT @ZLIB_USE_EXTERNAL@)
     if (@HDF5_MODULE_MODE_ZLIB@)
       # Expect that the default shared library is expected with FindZLIB.cmake
-      find_package (ZLIB MODULE)
+      find_dependency (ZLIB MODULE)
     else ()
-      find_package (ZLIB NAMES @Z_PACKAGE_NAME@ CONFIG OPTIONAL_COMPONENTS @ZLIB_SEARCH_TYPE@)
+      find_dependency (ZLIB NAMES @Z_PACKAGE_NAME@ CONFIG OPTIONAL_COMPONENTS @ZLIB_SEARCH_TYPE@)
     endif ()
   endif ()
 endif ()
 
 if (${HDF5_PACKAGE_NAME}_PROVIDES_SZIP_SUPPORT)
   if (NOT @SZIP_USE_EXTERNAL@)
-    find_package (LIBAEC NAMES @LIBAEC_PACKAGE_NAME@ CONFIG OPTIONAL_COMPONENTS @LIBAEC_SEARCH_TYPE@)
+    find_dependency (LIBAEC NAMES @LIBAEC_PACKAGE_NAME@ CONFIG OPTIONAL_COMPONENTS @LIBAEC_SEARCH_TYPE@)
   endif ()
 endif ()
 


### PR DESCRIPTION
It is considered best practice for cmake package configuration files to use "find_dependency" instead of "find_package". This is because it can propagate flags properly, gives more clear error messages and is able to avoid duplicate dependency include issues.

This change fixes an issue I am seeing in some external cmake projects when including hdf5. As per issue report here https://github.com/HDFGroup/hdf5/issues/6107
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Replace `find_package` with `find_dependency` in `hdf5-config.cmake.in` to improve dependency handling.
> 
>   - **Behavior**:
>     - Replace `find_package` with `find_dependency` in `hdf5-config.cmake.in` for dependencies: `MPI`, `Threads`, `ZLIB`, and `LIBAEC`.
>     - Improves flag propagation, error messages, and avoids duplicate dependency issues.
>   - **Misc**:
>     - Add `include(CMakeFindDependencyMacro)` at the beginning of `hdf5-config.cmake.in`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=HDFGroup%2Fhdf5&utm_source=github&utm_medium=referral)<sup> for 253d3835d423741b945a921f11b2990f7913a9d3. You can [customize](https://app.ellipsis.dev/HDFGroup/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->