### PR TITLE
Adds release version to constants in H5Z and H5AC

### DIFF
--- a/src/H5ACpublic.h
+++ b/src/H5ACpublic.h
@@ -437,7 +437,7 @@
  * Maximum allowed length (in characters) of a metadata cache trace file name
  * \since 1.8.0
  */
-#define H5AC__MAX_TRACE_FILE_NAME_LEN   1024
+#define H5AC__MAX_TRACE_FILE_NAME_LEN 1024
 /**
  * Only process 0 performs metadata writes to disk; other processes retain dirty
  * metadata and mark entries clean only after process 0 flushes them and broadcasts
@@ -451,7 +451,7 @@
  * entry is flushed exactly once and marked clean everywhere.
  * \since 1.8.6
  */
-#define H5AC_METADATA_WRITE_STRATEGY__DISTRIBUTED    1
+#define H5AC_METADATA_WRITE_STRATEGY__DISTRIBUTED 1
 
 /**
  * H5AC_cache_config_t is a public structure intended for use in public APIs.

--- a/src/H5ACpublic.h
+++ b/src/H5ACpublic.h
@@ -428,10 +428,29 @@
  *
  ****************************************************************************/
 
+/**
+ * Current version number of the metadata cache configuration structure
+ * \since 1.8.0
+ */
 #define H5AC__CURR_CACHE_CONFIG_VERSION 1
+/**
+ * Maximum allowed length (in characters) of a metadata cache trace file name
+ * \since 1.8.0
+ */
 #define H5AC__MAX_TRACE_FILE_NAME_LEN   1024
-
+/**
+ * Only process 0 performs metadata writes to disk; other processes retain dirty
+ * metadata and mark entries clean only after process 0 flushes them and broadcasts
+ * the results at a sync point.
+ * \since 1.8.6
+ */
 #define H5AC_METADATA_WRITE_STRATEGY__PROCESS_0_ONLY 0
+/**
+ * Process 0 determines which metadata entries to flush, but the actual writes are
+ * distributed across processes at a sync point, with coordination ensuring each
+ * entry is flushed exactly once and marked clean everywhere.
+ * \since 1.8.6
+ */
 #define H5AC_METADATA_WRITE_STRATEGY__DISTRIBUTED    1
 
 /**
@@ -717,6 +736,10 @@ typedef struct H5AC_cache_config_t {
 } H5AC_cache_config_t;
 //! <!-- [H5AC_cache_config_t_snip] -->
 
+/**
+ * Current version number of the metadata cache image configuration structure
+ * \since 1.10.1
+ */
 #define H5AC__CURR_CACHE_IMAGE_CONFIG_VERSION 1
 
 /**

--- a/src/H5Dpublic.h
+++ b/src/H5Dpublic.h
@@ -24,13 +24,24 @@
 /*****************/
 
 /* Macros used to "unset" chunk cache configuration parameters */
-/** Default of chunk slots in the raw data chunk cache for this dataset.  See \ref H5Pset_chunk_cache for
- * details. \since 1.8.3 */
+
+/**
+ * Default of chunk slots in the raw data chunk cache for this dataset.
+ * See \ref H5Pset_chunk_cache for details.
+ * \since 1.8.3
+ */
 #define H5D_CHUNK_CACHE_NSLOTS_DEFAULT SIZE_MAX
-/** Total size of the raw data chunk cache for this dataset.  See \ref H5Pset_chunk_cache for details.
- * \since 1.8.3 */
+/**
+ * Total size of the raw data chunk cache for this dataset.
+ * See \ref H5Pset_chunk_cache for details.
+ * \since 1.8.3
+ */
 #define H5D_CHUNK_CACHE_NBYTES_DEFAULT SIZE_MAX
-/** Chunk preemption policy for this dataset.  See \ref H5Pset_chunk_cache for details. \since 1.8.3 */
+/**
+ * Chunk preemption policy for this dataset.
+ * See \ref H5Pset_chunk_cache for details.
+ * \since 1.8.3
+ */
 #define H5D_CHUNK_CACHE_W0_DEFAULT (-1.0)
 
 /** Bit flags for the H5Pset/get_chunk_opts() \since 1.10.0 */

--- a/src/H5ESpublic.h
+++ b/src/H5ESpublic.h
@@ -26,7 +26,8 @@
 
 /**
  * Default value for "no event set" / synchronous execution. Used in
- * place of a @ref hid_t identifier. \since 1.14.0
+ * place of a @ref hid_t identifier.
+ * \since 1.14.0
  */
 #define H5ES_NONE 0
 
@@ -37,7 +38,8 @@
 
 /**
  * Don't wait for operations to complete, just check their status.
- * (This allows @ref H5ESwait to behave like a 'test' operation) \since 1.14.0
+ * (This allows @ref H5ESwait to behave like a 'test' operation)
+ * \since 1.14.0
  */
 #define H5ES_WAIT_NONE (0)
 

--- a/src/H5Epublic.h
+++ b/src/H5Epublic.h
@@ -21,7 +21,7 @@
 #include "H5public.h"  /* Generic Functions                        */
 #include "H5Ipublic.h" /* Identifiers                              */
 
-/** Value for the default error stack \since 1.12.2 */
+/** Value for the default error stack \since 1.8.0 */
 #define H5E_DEFAULT 0 /* (hid_t) */
 
 /**

--- a/src/H5Fpublic.h
+++ b/src/H5Fpublic.h
@@ -36,7 +36,6 @@
  * Indicates that this file is open for writing in a single-writer/multi-reader
  * (SWMR) scenario. Note that the process(es) opening the file for reading must
  * open the file with #H5F_ACC_RDONLY and use the #H5F_ACC_SWMR_READ access flag.
- *
  * \since 1.10.0
  */
 #define H5F_ACC_SWMR_WRITE (0x0020u)
@@ -45,17 +44,16 @@
  * Indicates that this file is open for reading in a single-writer/multi-reader
  * (SWMR) scenario. Note that the process(es) opening the file for SWMR reading
  * must also open the file with the #H5F_ACC_RDONLY flag.
- *
  * \since 1.10.0
  */
 #define H5F_ACC_SWMR_READ (0x0040u)
 
 /**
  * Default file access
+ * \since 1.8.3
  *
  * \internal Value passed to H5Pset_elink_acc_flags to cause flags to be taken from the parent file.
  * \internal ignore setting on lapl
- * \since 1.8.3
  */
 #define H5F_ACC_DEFAULT (0xffffu)
 
@@ -70,7 +68,9 @@
 
 /**
  * Restrict search to objects opened through current file ID (as opposed to
- * objects opened through any file ID accessing this file) \since 1.6.5 */
+ * objects opened through any file ID accessing this file)
+ * \since 1.6.5
+ */
 #define H5F_OBJ_LOCAL (0x0020u)
 
 /**

--- a/src/H5Zpublic.h
+++ b/src/H5Zpublic.h
@@ -62,7 +62,7 @@ typedef int H5Z_filter_t;
 /** No filter */
 #define H5Z_FILTER_NONE 0
 
-/** Neflation like gzip \since 1.0.0 */
+/** Deflation like gzip \since 1.0.0 */
 #define H5Z_FILTER_DEFLATE 1
 
 /** Shuffle the data \since 1.6.0 */

--- a/src/H5Zpublic.h
+++ b/src/H5Zpublic.h
@@ -86,7 +86,6 @@ typedef int H5Z_filter_t;
 /** Maximum filter id \since 1.0.0 */
 #define H5Z_FILTER_MAX 65535
 
-
 /* General macros */
 /**
  * Symbol to remove all filters in H5Premove_filter()
@@ -112,7 +111,6 @@ typedef int H5Z_filter_t;
 /** Filter is optional \since 1.0.0 */
 #define H5Z_FLAG_OPTIONAL 0x0001
 
-
 /* Additional flags for filter invocation (not stored) */
 /** Invocation flag mask \since 1.0.0 */
 #define H5Z_FLAG_INVMASK 0xff00
@@ -122,7 +120,6 @@ typedef int H5Z_filter_t;
 
 /** Skip EDC filters for read \since 1.6.0 */
 #define H5Z_FLAG_SKIP_EDC 0x0200
-
 
 /* Special parameters for szip compression
  *

--- a/src/H5Zpublic.h
+++ b/src/H5Zpublic.h
@@ -55,54 +55,46 @@
 typedef int H5Z_filter_t;
 
 /* Filter IDs */
-/**
- * no filter
- */
+
+/** Filter operation error \since 1.0.0 */
 #define H5Z_FILTER_ERROR (-1)
-/**
- * reserved indefinitely
- */
+
+/** No filter */
 #define H5Z_FILTER_NONE 0
-/**
- * deflation like gzip
- */
+
+/** Neflation like gzip \since 1.0.0 */
 #define H5Z_FILTER_DEFLATE 1
-/**
- * shuffle the data
- */
+
+/** Shuffle the data \since 1.6.0 */
 #define H5Z_FILTER_SHUFFLE 2
-/**
- * fletcher32 checksum of EDC
- */
+
+/** Fletcher32 checksum of EDC \since 1.6.0 */
 #define H5Z_FILTER_FLETCHER32 3
-/**
- * szip compression
- */
+
+/** Szip compression \since 1.6.0 */
 #define H5Z_FILTER_SZIP 4
-/**
- * nbit compression
- */
+
+/** Nbit compression \since 1.8.0 */
 #define H5Z_FILTER_NBIT 5
-/**
- * scale+offset compression
- */
+
+/** Scale+offset compression \since 1.8.0 */
 #define H5Z_FILTER_SCALEOFFSET 6
-/**
- * filter ids below this value are reserved for library use
- */
+
+/** Filter ids below this value are reserved for library use \since 1.6.0 */
 #define H5Z_FILTER_RESERVED 256
-/**
- * maximum filter id
- */
+
+/** Maximum filter id \since 1.0.0 */
 #define H5Z_FILTER_MAX 65535
+
 
 /* General macros */
 /**
  * Symbol to remove all filters in H5Premove_filter()
+ * \since 1.6.3
  */
 #define H5Z_FILTER_ALL 0
 /**
- * Maximum number of filters allowed in a pipeline
+ * Maximum number of filters allowed in a pipeline \since 1.6.0
  *
  * \internal (should probably be allowed to be an unlimited amount, but
  *            currently each filter uses a bit in a 32-bit field, so the format
@@ -111,32 +103,26 @@ typedef int H5Z_filter_t;
 #define H5Z_MAX_NFILTERS 32
 
 /* Flags for filter definition (stored) */
-/**
- * definition flag mask
- */
+/** Definition flag mask \since 1.0.0 */
 #define H5Z_FLAG_DEFMASK 0x00ff
-/**
- * filter is mandatory
- */
+
+/** Filter is mandatory \since 1.6.0 */
 #define H5Z_FLAG_MANDATORY 0x0000
-/**
- * filter is optional
- */
+
+/** Filter is optional \since 1.0.0 */
 #define H5Z_FLAG_OPTIONAL 0x0001
 
+
 /* Additional flags for filter invocation (not stored) */
-/**
- * invocation flag mask
- */
+/** Invocation flag mask \since 1.0.0 */
 #define H5Z_FLAG_INVMASK 0xff00
-/**
- * reverse direction; read
- */
+
+/** Reverse direction; read \since 1.0.0 */
 #define H5Z_FLAG_REVERSE 0x0100
-/**
- * skip EDC filters for read
- */
+
+/** Skip EDC filters for read \since 1.6.0 */
 #define H5Z_FLAG_SKIP_EDC 0x0200
+
 
 /* Special parameters for szip compression
  *
@@ -193,11 +179,13 @@ typedef int H5Z_filter_t;
 /**
  * \ingroup SHUFFLE
  * Number of parameters that users can set for the shuffle filter
+ * \since 1.6.8
  */
 #define H5Z_SHUFFLE_USER_NPARMS 0
 /**
  * \ingroup SHUFFLE
  * Total number of parameters for the shuffle filter
+ * \since 1.6.8
  */
 #define H5Z_SHUFFLE_TOTAL_NPARMS 1
 
@@ -205,31 +193,37 @@ typedef int H5Z_filter_t;
 /**
  * \ingroup SZIP
  * Number of parameters that users can set for SZIP
+ * \since 1.6.8
  */
 #define H5Z_SZIP_USER_NPARMS 2
 /**
  * \ingroup SZIP
  * Total number of parameters for SZIP filter
+ * \since 1.6.8
  */
 #define H5Z_SZIP_TOTAL_NPARMS 4
 /**
  * \ingroup SZIP
  * "User" parameter for option mask
+ * \since 1.6.8
  */
 #define H5Z_SZIP_PARM_MASK 0
 /**
  * \ingroup SZIP
  * "User" parameter for pixels-per-block
+ * \since 1.6.8
  */
 #define H5Z_SZIP_PARM_PPB 1
 /**
  * \ingroup SZIP
  * "Local" parameter for bits-per-pixel
+ * \since 1.6.8
  */
 #define H5Z_SZIP_PARM_BPP 2
 /**
  * \ingroup SZIP
  * "Local" parameter for pixels-per-scanline
+ * \since 1.6.8
  */
 #define H5Z_SZIP_PARM_PPS 3
 
@@ -237,6 +231,7 @@ typedef int H5Z_filter_t;
 /**
  * \ingroup NBIT
  * Number of parameters that users can set for the N-bit filter
+ * \since 1.8.0
  */
 #define H5Z_NBIT_USER_NPARMS 0 /* Number of parameters that users can set */
 
@@ -244,12 +239,16 @@ typedef int H5Z_filter_t;
 /**
  * \ingroup SCALEOFFSET
  * Number of parameters that users can set for the scale-offset filter
+ * \since 1.8.0
  */
 #define H5Z_SCALEOFFSET_USER_NPARMS 2
 
 /* Special parameters for ScaleOffset filter*/
 /**
- * \ingroup SCALEOFFSET */
+ * \ingroup SCALEOFFSET
+ * Indicates minbits not set yet
+ * \since 1.8.0
+ */
 #define H5Z_SO_INT_MINBITS_DEFAULT 0
 /**
  * \ingroup SCALEOFFSET */
@@ -270,8 +269,10 @@ typedef enum H5Z_EDC_t {
     H5Z_NO_EDC      = 2 /**< sentinel */
 } H5Z_EDC_t;
 
-/* Bit flags for H5Zget_filter_info */
+/** Encode bit flag for H5Zget_filter_info \since 1.6.3 */
 #define H5Z_FILTER_CONFIG_ENCODE_ENABLED (0x0001)
+
+/** Decode bit flag for H5Zget_filter_info \since 1.6.3 */
 #define H5Z_FILTER_CONFIG_DECODE_ENABLED (0x0002)
 
 /**


### PR DESCRIPTION
Also, included minor fixes for consistency.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Add release version information to constants in `H5Zpublic.h` and `H5ACpublic.h`, with minor formatting updates for consistency.
> 
>   - **Constants**:
>     - Add release version information to constants in `H5Zpublic.h` and `H5ACpublic.h`.
>   - **Documentation**:
>     - Add `\since` tags to various constants in `H5Zpublic.h` and `H5ACpublic.h` to indicate the release version.
>     - Minor formatting changes for consistency in `H5Dpublic.h`, `H5ESpublic.h`, and `H5Fpublic.h`.
>   - **Misc**:
>     - Fix incorrect version in `H5Epublic.h` for `H5E_DEFAULT`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=HDFGroup%2Fhdf5&utm_source=github&utm_medium=referral)<sup> for 89fd44481f7f497005104af7d1d9f98c6970ddb3. You can [customize](https://app.ellipsis.dev/HDFGroup/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->