### PR TITLE
ci(freebsd): disable 15.0

### DIFF
--- a/.github/workflows/freebsd.yml
+++ b/.github/workflows/freebsd.yml
@@ -37,7 +37,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        freebsd-version: ['13.5', '14.3', '15.0']
+        freebsd-version: ['13.5', '14.3']
 
     steps:
       - name: Checkout repository


### PR DESCRIPTION
Package installation is broken.

```
pkg: Failed to fetch https://pkg.freebsd.org/FreeBSD:15:amd64/quarterly/All/Hashed/libidn2-2.3.8~10185dcbb5.pkg: Not found
pkg: Failed to fetch https://pkg.freebsd.org/FreeBSD:15:amd64/quarterly/All/Hashed/libidn2-2.3.8~10185dcbb5.pkg: Not found
```
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Removes FreeBSD 15.0 from CI matrix in `freebsd.yml` due to package installation issues.
> 
>   - **CI Configuration**:
>     - Removes FreeBSD version `15.0` from the `freebsd-version` matrix in `.github/workflows/freebsd.yml` due to package installation failures.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=HDFGroup%2Fhdf5&utm_source=github&utm_medium=referral)<sup> for 4845e900be6ce9998a24997fdde0cb498539d949. You can [customize](https://app.ellipsis.dev/HDFGroup/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->