### PR TITLE
ci(nvhpc): update version to 25.11

### DIFF
--- a/.github/workflows/nvhpc.yml
+++ b/.github/workflows/nvhpc.yml
@@ -21,8 +21,8 @@ jobs:
     runs-on: ubuntu-latest
     env:
       CUDAVERDOT: "13.0"
-      NVERDOT: "25.9"
-      NVERDASH: "25-9"
+      NVERDOT: "25.11"
+      NVERDASH: "25-11"
 
     steps:
       - name: Get Sources


### PR DESCRIPTION
close #6148 
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Update NVHPC version to 25.11 in `.github/workflows/nvhpc.yml`.
> 
>   - **Environment Variables**:
>     - Update `NVERDOT` to `25.11` and `NVERDASH` to `25-11` in `.github/workflows/nvhpc.yml` to use the latest NVHPC version.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=HDFGroup%2Fhdf5&utm_source=github&utm_medium=referral)<sup> for a35a2d79c746f83b85605b68d8b8c843b2cc6b05. You can [customize](https://app.ellipsis.dev/HDFGroup/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->