### PR TITLE
Fix macos-26 java workflow

### DIFF
--- a/.github/workflows/macos-26-matrix.yml
+++ b/.github/workflows/macos-26-matrix.yml
@@ -223,10 +223,10 @@ jobs:
         fi
 
         # Set Java environment if needed
-        if [[ "${{ matrix.java }}" == "ON" ]]; then
-          export JAVA_HOME=$(/usr/libexec/java_home)
-          CMAKE_OPTS="$CMAKE_OPTS -DJAVA_HOME=$JAVA_HOME"
-        fi
+#        if [[ "${{ matrix.java }}" == "ON" ]]; then
+#          export JAVA_HOME=$(/usr/libexec/java_home)
+#          CMAKE_OPTS="$CMAKE_OPTS -DJAVA_HOME=$JAVA_HOME"
+#        fi
 
         # Set Fortran compiler if needed
         if [[ "${{ matrix.fortran }}" == "ON" ]]; then

--- a/.github/workflows/macos-26-matrix.yml
+++ b/.github/workflows/macos-26-matrix.yml
@@ -188,6 +188,12 @@ jobs:
           brew install mpich
         fi
 
+        - name: Setup Java 25
+          uses: actions/setup-java@v4
+          with:
+            distribution: 'temurin'
+            java-version: '25-ea' # or '25' if available
+
 
     - name: Get Sources
       uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
@@ -252,7 +258,13 @@ jobs:
       shell: bash
 
     - name: Build
-      run: cmake --build . --config Release --parallel 2
+      run:
+        [[ "${{ matrix.java }}" == "ON" ]]; then
+          # DO NOT run export JAVA_HOME=$(/usr/libexec/java_home) here!
+          # Just use the $JAVA_HOME that setup-java already set:
+          CMAKE_OPTS="$CMAKE_OPTS -DJAVA_HOME=$JAVA_HOME"
+        fi
+        cmake --build . --config Release --parallel 2
       working-directory: ${{ runner.workspace }}/build
 
     - name: Test

--- a/.github/workflows/macos-26-matrix.yml
+++ b/.github/workflows/macos-26-matrix.yml
@@ -227,12 +227,6 @@ jobs:
           CMAKE_OPTS="$CMAKE_OPTS -DPLUGIN_USE_LOCALCONTENT=OFF"
         fi
 
-        # Set Java environment if needed
-#        if [[ "${{ matrix.java }}" == "ON" ]]; then
-#          export JAVA_HOME=$(/usr/libexec/java_home)
-#          CMAKE_OPTS="$CMAKE_OPTS -DJAVA_HOME=$JAVA_HOME"
-#        fi
-
         # Set Fortran compiler if needed
         if [[ "${{ matrix.fortran }}" == "ON" ]]; then
           CMAKE_OPTS="$CMAKE_OPTS -DCMAKE_Fortran_COMPILER=gfortran-15"
@@ -257,14 +251,7 @@ jobs:
       shell: bash
 
     - name: Build
-      run: |
-        if [[ "${{ matrix.java }}" == "ON" ]]; then
-          # DO NOT run export JAVA_HOME=$(/usr/libexec/java_home) here!
-
-          # Just use the $JAVA_HOME that setup-java already set:
-          CMAKE_OPTS="$CMAKE_OPTS -DJAVA_HOME=$JAVA_HOME"
-        fi
-        cmake --build . --config Release --parallel 2
+      run: cmake --build . --config Release --parallel 2
       working-directory: ${{ runner.workspace }}/build
 
     - name: Test

--- a/.github/workflows/macos-26-matrix.yml
+++ b/.github/workflows/macos-26-matrix.yml
@@ -2,8 +2,9 @@ name: macOS-26 Matrix Testing
 
 on:
    workflow_dispatch:
-   schedule:
-     - cron: "0 9 * * *"
+
+#schedule:
+# - cron: "0 9 * * *"
 
 # Using concurrency to cancel any in-progress job or run
 concurrency:

--- a/.github/workflows/macos-26-matrix.yml
+++ b/.github/workflows/macos-26-matrix.yml
@@ -282,7 +282,6 @@ jobs:
         # Set test timeout
         CTEST_TIMEOUT: 3600
 
-
     - name: Upload Test Results
       uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v5
       if: always()

--- a/.github/workflows/macos-26-matrix.yml
+++ b/.github/workflows/macos-26-matrix.yml
@@ -258,8 +258,9 @@ jobs:
 
     - name: Build
       run:
-        [[ "${{ matrix.java }}" == "ON" ]]; then
+        if [[ "${{ matrix.java }}" == "ON" ]]; then
           # DO NOT run export JAVA_HOME=$(/usr/libexec/java_home) here!
+
           # Just use the $JAVA_HOME that setup-java already set:
           CMAKE_OPTS="$CMAKE_OPTS -DJAVA_HOME=$JAVA_HOME"
         fi
@@ -280,6 +281,7 @@ jobs:
       env:
         # Set test timeout
         CTEST_TIMEOUT: 3600
+
 
     - name: Upload Test Results
       uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v5

--- a/.github/workflows/macos-26-matrix.yml
+++ b/.github/workflows/macos-26-matrix.yml
@@ -188,12 +188,6 @@ jobs:
           brew install mpich
         fi
 
-    - name: Setup Java 25
-      uses: actions/setup-java@v4
-      with:
-        distribution: 'temurin'
-        java-version: '25-ea' # or '25' if available
-
     - name: Get Sources
       uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
 

--- a/.github/workflows/macos-26-matrix.yml
+++ b/.github/workflows/macos-26-matrix.yml
@@ -257,7 +257,7 @@ jobs:
       shell: bash
 
     - name: Build
-      run:
+      run: |
         if [[ "${{ matrix.java }}" == "ON" ]]; then
           # DO NOT run export JAVA_HOME=$(/usr/libexec/java_home) here!
 

--- a/.github/workflows/macos-26-matrix.yml
+++ b/.github/workflows/macos-26-matrix.yml
@@ -188,12 +188,11 @@ jobs:
           brew install mpich
         fi
 
-        - name: Setup Java 25
-          uses: actions/setup-java@v4
-          with:
-            distribution: 'temurin'
-            java-version: '25-ea' # or '25' if available
-
+    - name: Setup Java 25
+      uses: actions/setup-java@v4
+      with:
+        distribution: 'temurin'
+        java-version: '25-ea' # or '25' if available
 
     - name: Get Sources
       uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1

--- a/.github/workflows/macos-26-matrix.yml
+++ b/.github/workflows/macos-26-matrix.yml
@@ -2,9 +2,8 @@ name: macOS-26 Matrix Testing
 
 on:
    workflow_dispatch:
-
-#schedule:
-# - cron: "0 9 * * *"
+   schedule:
+     - cron: "0 9 * * *"
 
 # Using concurrency to cancel any in-progress job or run
 concurrency:


### PR DESCRIPTION
Removes:
  setting JAVA_HOME to a specific directory, which probably set the runtime JRE to an earlier version, conflicting with the one set by default.
  With the removal of the JAVA_HOME setting, configure now finds Java_Temurin-Hotspot_jdk/21.0.9-10.0/arm64 (Java 21.0.9) and all tests pass, including JUnit and H5_jcompat-h5-H5Ex tests.
  We can consider also testing Java 25 with a later PR.

Fixes #6021.
