### PR TITLE
ci(aocc): update version to 5.1

### DIFF
--- a/.github/workflows/aocc.yml
+++ b/.github/workflows/aocc.yml
@@ -9,6 +9,10 @@ on:
         required: true
         type: string
 
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
 permissions:
   contents: read
 
@@ -20,9 +24,9 @@ jobs:
     name: "aocc ${{ inputs.build_mode }}"
     runs-on: ubuntu-latest
     env:
-      AOCCVERDOT: "5.0.0"
-      AOCCVERDASH: "5-0"
-      MPIVERDOT: "5.0.7"
+      AOCCVERDOT: "5.1.0"
+      AOCCVERDASH: "5-1"
+      MPIVERDOT: "5.0.9"
       #MPIVERUND: Change is needed in the lines below.
 
     steps:


### PR DESCRIPTION
close #6155
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Update AOCC version to 5.1 and MPI version to 5.0.9 in `aocc.yml`, adding concurrency control.
> 
>   - **Workflow Configuration**:
>     - Adds `concurrency` control to `aocc.yml` to cancel in-progress runs for the same workflow and pull request.
>   - **Environment Variables**:
>     - Updates `AOCCVERDOT` to `5.1.0` and `AOCCVERDASH` to `5-1` in `aocc.yml`.
>     - Updates `MPIVERDOT` to `5.0.9` in `aocc.yml`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=HDFGroup%2Fhdf5&utm_source=github&utm_medium=referral)<sup> for d790a4fd34af88cf324aa1760c4bec4df21f9d08. You can [customize](https://app.ellipsis.dev/HDFGroup/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->