### PR TITLE
Fixes invalid example URLs

### DIFF
--- a/c++/src/H5Location.h
+++ b/c++/src/H5Location.h
@@ -24,7 +24,6 @@ namespace H5 {
     It provides a collection of wrappers for the C functions that take a
     location identifier to specify the HDF5 object.  The location identifier
     can be either file, group, dataset, attribute, or named datatype.
-    Wrappers for H5A functions stay in H5Object.
 */
 // Inheritance: IdComponent
 class H5CPP_DLL H5Location : public IdComponent {

--- a/doxygen/dox/CppAPIIntro.dox
+++ b/doxygen/dox/CppAPIIntro.dox
@@ -33,22 +33,20 @@ The C++ classes closely mirror the HDF5 C API modules:
 | H5F (Files) | H5::H5File | File access and management |
 | H5G (Groups) | H5::Group | Hierarchical organization |
 | H5P (Property Lists) | H5::PropList + subclasses | Configuration parameters |
-| H5L/H5O (Links/Objects) | H5::Location | Management of links and objects |
+| H5L/H5O (Links/Objects) | H5::H5Location | Management of links and objects |
 | H5E (Errors) | H5::Exception | Error reporting |
 
 \subsection cpp_examples Quick Start Examples
 
-- Creating groups and datasets: <a href="https://\CPPEXS/h5tutr_crtgrp.cpp">h5tutr_crtgrp.cpp</a> <a href="https://\CPPEXS/h5tutr_crtdat.cpp">h5tutr_crtdat.cpp</a>
-- Writing/Reading data <a href="https://\CPPEXS/h5tutr_rdwt.cpp">h5tutr_rdwt.cpp</a> <a href="https://\CPPEXS/h5tutr_subset.cpp">h5tutr_subset.cpp</a>
-- Working with attributes <a href="https://\CPPEXS/h5tutr_crtatt.cpp">h5tutr_crtatt.cpp</a>
-- Extendible datasets <a href="https://\CPPEXS/h5tutr_extend.cpp">h5tutr_extend.cpp</a>
-- Chunked/Compressed datasets <a href="https://\CPPEXS/h5tutr_cmprss.cpp">h5tutr_cmprss.cpp</a>
+- Creating groups and datasets: <a href="https://\SRCURL/HDF5Examples/CXX/TUTR/h5tutr_crtgrp.cpp">h5tutr_crtgrp.cpp</a> <a href="https://\SRCURL/HDF5Examples/CXX/TUTR/h5tutr_crtdat.cpp">h5tutr_crtdat.cpp</a>
+- Writing/Reading data <a href="https://\SRCURL/HDF5Examples/CXX/TUTR/h5tutr_rdwt.cpp">h5tutr_rdwt.cpp</a> <a href="https://\SRCURL/HDF5Examples/CXX/TUTR/h5tutr_subset.cpp">h5tutr_subset.cpp</a>
+- Working with attributes <a href="https://\SRCURL/HDF5Examples/CXX/TUTR/h5tutr_crtatt.cpp">h5tutr_crtatt.cpp</a>
 
-See the See \ref LBExamples for additional examples.
+See the \ref LBExamples for additional examples.
 
 \subsection cpp_building Building Applications
 
-Please refer to the release_docs/INSTALL_CMake.txt file under the top directory of the HDF5 source code or <a href="https://\SRCURL/release_docs/INSTALL_CMake.txt">INSTALL_CMake.txt on GitHub for information about installing, building, and testing the C++ API.</a>
+Please refer to the release_docs/INSTALL_CMake.txt file under the top directory of the HDF5 source code or <a href="https://\SRCURL/release_docs/INSTALL_CMake.txt">INSTALL_CMake.txt</a> on GitHub for information about installing, building, and testing the C++ API.
 
 
 <hr>

--- a/doxygen/hdf5doxy.css
+++ b/doxygen/hdf5doxy.css
@@ -276,3 +276,14 @@ div[style*="background:#FFDDDD"] a:hover {
   color: #1976D2 !important; /* Lighter blue on hover */
   text-decoration: none;
 }
+
+/* Style the C++ diagrams */
+/* Make inheritance diagram header look clickable */
+.dynheader {
+    cursor: pointer;
+    color: #0066cc;
+}
+
+.dynheader:hover {
+    text-decoration: underline;
+}


### PR DESCRIPTION
Fixes invalid example URLs and makes other improvement in the C++ documentation, including adding style to make diagram links displayed as clickable.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fixes invalid example URLs in C++ documentation and adds clickable style to diagram links.
> 
>   - **Documentation**:
>     - Fixes invalid example URLs in `CppAPIIntro.dox` by updating to `https://\SRCURL/HDF5Examples/CXX/TUTR/`.
>     - Corrects reference to `INSTALL_CMake.txt` in `CppAPIIntro.dox`.
>   - **CSS**:
>     - Adds styles in `hdf5doxy.css` to make C++ diagram headers look clickable with `.dynheader` class.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=HDFGroup%2Fhdf5&utm_source=github&utm_medium=referral)<sup> for 9b31ad79203a819843309e5324f8e963a05d5c35. You can [customize](https://app.ellipsis.dev/HDFGroup/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->