### PR TITLE
Replace last link with version directory path on support site.

### DIFF
--- a/config/README.md.cmake.in
+++ b/config/README.md.cmake.in
@@ -74,6 +74,6 @@ add "-VV" to the ctest command. The output should show;
 For more information see USING_CMake_Examples.txt in the install folder.
 ===========================================================================
 
-Documentation to download for this release can be found as hdf5-<version>.doxygen.zip in https://github.com/HDFGroup/hdf5/releases.  Documentation for the latest development version can be seen at https://support.hdfgroup.org/documentation/hdf5/latest/
+Documentation to download for this release can be found as hdf5-\<version\>.doxygen.zip in https://github.com/HDFGroup/hdf5/releases.  Documentation for the latest development version can be seen at https://support.hdfgroup.org/documentation/hdf5/latest/
 
 Bugs should be reported to help@hdfgroup.org.

--- a/config/README.md.cmake.in
+++ b/config/README.md.cmake.in
@@ -74,6 +74,6 @@ add "-VV" to the ctest command. The output should show;
 For more information see USING_CMake_Examples.txt in the install folder.
 ===========================================================================
 
-Documentation for this release can be found as a doxygen.zip file at https://github.com/HDFGroup/hdf5/releases.  Documentation for the datest development version can be seen at https://support.hdfgroup.org/documentation/hdf5/latest/
+Documentation to download for this release can be found as hdf5-<version>.doxygen.zip in https://github.com/HDFGroup/hdf5/releases.  Documentation for the datest development version can be seen at https://support.hdfgroup.org/documentation/hdf5/latest/
 
 Bugs should be reported to help@hdfgroup.org.

--- a/config/README.md.cmake.in
+++ b/config/README.md.cmake.in
@@ -74,6 +74,6 @@ add "-VV" to the ctest command. The output should show;
 For more information see USING_CMake_Examples.txt in the install folder.
 ===========================================================================
 
-Documentation for this release can be found as a doxygen.zip file at https://github.com/HDFGroup/hdf5/releases.  Documentation for the datest development version can be seen at https://support.hdfgroup.org/documentation/hdf5/latest/
+Documentation for this release can be found as a doxygen.zip file at https://github.com/HDFGroup/hdf5/releases.  Documentation for the latest development version can be seen at https://support.hdfgroup.org/documentation/hdf5/latest/
 
 Bugs should be reported to help@hdfgroup.org.

--- a/config/README.md.cmake.in
+++ b/config/README.md.cmake.in
@@ -74,7 +74,6 @@ add "-VV" to the ctest command. The output should show;
 For more information see USING_CMake_Examples.txt in the install folder.
 ===========================================================================
 
-Documentation for this release can be found at the following URL:
-    https://support.hdfgroup.org/releases/hdf5/v@H5_VERS_MAJOR@_@H5_VERS_MINOR@/v@H5_VERS_MAJOR@_@H5_VERS_MINOR@_@H5_VERS_RELEASE@/documentation/doxygen/index.html
+Documentation for this release can be found as a doxygen.zip file at https://github.com/HDFGroup/hdf5/releases.  Documentation for the datest development version can be seen at https://support.hdfgroup.org/documentation/hdf5/latest/
 
 Bugs should be reported to help@hdfgroup.org.

--- a/doxygen/dox/Overview.dox
+++ b/doxygen/dox/Overview.dox
@@ -23,7 +23,7 @@ documents cover a mix of tasks, concepts, and reference, to help a specific
 \ref release_specific_info
 
 \par Offline reading
-     You can download the hdf5-<version>.doxygen.zip file for offline reading from HDF5 <a href="https://github.com/HDFGroup/hdf5/releases">releases</a>.
+     You can download the hdf5-\<version\>.doxygen.zip file for offline reading from HDF5 <a href="https://github.com/HDFGroup/hdf5/releases">releases</a>.
 
 \par ToDo List
      There is plenty of \ref todo unfinished business.

--- a/doxygen/dox/Overview.dox
+++ b/doxygen/dox/Overview.dox
@@ -23,7 +23,7 @@ documents cover a mix of tasks, concepts, and reference, to help a specific
 \ref release_specific_info
 
 \par Offline reading
-     You can download the hdf5-x.y.z.doxygen.zip file from the most recent release as an archive for offline reading from <a href="https://\DWNURL/">this page</a>.
+     You can download HDF5 released doxygen.zip files for offline reading from HDF5 <a href="https://github.com/HDFGroup/hdf5/releases">releases</a>.
 
 \par ToDo List
      There is plenty of \ref todo unfinished business.

--- a/doxygen/dox/Overview.dox
+++ b/doxygen/dox/Overview.dox
@@ -23,7 +23,7 @@ documents cover a mix of tasks, concepts, and reference, to help a specific
 \ref release_specific_info
 
 \par Offline reading
-     You can download HDF5 released doxygen.zip files for offline reading from HDF5 <a href="https://github.com/HDFGroup/hdf5/releases">releases</a>.
+     You can download the hdf5-<version>.doxygen.zip file for offline reading from HDF5 <a href="https://github.com/HDFGroup/hdf5/releases">releases</a>.
 
 \par ToDo List
      There is plenty of \ref todo unfinished business.


### PR DESCRIPTION
Links for downloading doxygen.zip files will be to the GitHub HDF5 releases page.

The Link Checker should pass for develop once this change is merged.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Update documentation download links to GitHub HDF5 releases in `config/README.md.cmake.in` and `doxygen/dox/Overview.dox`.
> 
>   - **Documentation Links**:
>     - Update download link in `config/README.md.cmake.in` to point to GitHub HDF5 releases for doxygen.zip files.
>     - Update offline reading link in `doxygen/dox/Overview.dox` to GitHub HDF5 releases.
>   - **Misc**:
>     - Link Checker expected to pass post-merge for develop branch.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=HDFGroup%2Fhdf5&utm_source=github&utm_medium=referral)<sup> for 0e2a3146940d029ed28195e080af76bbc2206039. You can [customize](https://app.ellipsis.dev/HDFGroup/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->