### PR TITLE
Fix Release Progress badges and workflow

### DIFF
--- a/.github/workflows/update-progress.py
+++ b/.github/workflows/update-progress.py
@@ -266,6 +266,10 @@ def main():
 
         # Also output to stdout for local testing
         print(f"percentage={stats['percentage']}")
+        print(f"blocker_done={stats['blocker_done']}")
+        print(f"blocker_total={stats['blocker_total']}")
+        print(f"mustdo_done={stats['mustdo_done']}")
+        print(f"mustdo_total={stats['mustdo_total']}")
         print(f"Calculated progress: {stats['percentage']}%")
         print(f"Done / Total: {stats['done']} / {stats['total']}")
         print(f"Blockers: {stats['blocker_done']} / {stats['blocker_total']}")

--- a/README.md
+++ b/README.md
@@ -94,9 +94,9 @@ least one annual release for each maintenance branch.
 
 ### Release Progress
 
-[![Release Blockers](https://img.shields.io/endpoint?url=https://gist.githubusercontent.com/brtnfld/a4fbdde293677bf3f63f3cfd3aef6b44/raw/release-blockers.json)](https://github.com/orgs/HDFGroup/projects/39)
+[![Release Blockers](https://img.shields.io/endpoint?url=https://gist.githubusercontent.com/brtnfld/a4fbdde293677bf3f63f3cfd3aef6b44/raw/release-blockers.json)](https://github.com/orgs/HDFGroup/projects/39/views/24)
 
-[![Release Must Do](https://img.shields.io/endpoint?url=https://gist.githubusercontent.com/brtnfld/8a077a919d048ce5dc9f56350bec10bc/raw/release-mustdo.json)](https://github.com/orgs/HDFGroup/projects/39)
+[![Release Must Do](https://img.shields.io/endpoint?url=https://gist.githubusercontent.com/brtnfld/8a077a919d048ce5dc9f56350bec10bc/raw/release-mustdo.json)](https://github.com/orgs/HDFGroup/projects/39/views/24)
 
 The badges above show the current progress of **release-blocking** and **must-do** issues with colors that reflect completion status:
 


### PR DESCRIPTION
- Fix update-progress.py to output blocker/mustdo counts in correct format The workflow expects blocker_done=, blocker_total=, mustdo_done=, mustdo_total= output lines but the script was only outputting human-readable format

- Update README badge links to point to project view 24 instead of base project

This fixes the workflow failures where BLOCKER_DONE and related environment variables were not being set, causing badge updates to fail.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fixes `update-progress.py` output format and updates badge links in `README.md` for correct workflow operation.
> 
>   - **Scripts**:
>     - Fix `update-progress.py` to output `blocker_done`, `blocker_total`, `mustdo_done`, and `mustdo_total` in the required format for workflow environment variables.
>   - **Documentation**:
>     - Update badge links in `README.md` to point to project view 24 instead of the base project.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=HDFGroup%2Fhdf5&utm_source=github&utm_medium=referral)<sup> for 294dcdcf26df83f09c5ffb00cc5719b60215f849. You can [customize](https://app.ellipsis.dev/HDFGroup/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->