### PR TITLE
Validate datatype size for consistency

### DIFF
--- a/release_docs/CHANGELOG.md
+++ b/release_docs/CHANGELOG.md
@@ -112,6 +112,10 @@ We would like to thank the many HDF5 community members who contributed to this r
 
 ## Library
 
+### Fixed a potential out of bound read
+
+   When a file is corrupted such that an array datatype's size, the number of elements, and the element size are not in agreement, it can trigger an out of bounds read.  A check has been added to detect such situation.
+
 ### Fixed a performance issue with chunked dataset I/O
 
    When dataset chunks are unable to be placed in the dataset chunk cache (for example, if a chunk

--- a/src/H5Odtype.c
+++ b/src/H5Odtype.c
@@ -827,19 +827,20 @@ H5O__dtype_decode_helper(unsigned *ioflags /*in,out*/, const uint8_t **pp, H5T_t
                 HGOTO_ERROR(H5E_DATATYPE, H5E_CANTDECODE, FAIL, "unable to decode array parent type");
 
             /* Check for multiplication overflow */
-            if (dt->shared->parent->shared->size > 0 && 
+            if (dt->shared->parent->shared->size > 0 &&
                 dt->shared->u.array.nelem > SIZE_MAX / dt->shared->parent->shared->size)
-                HGOTO_ERROR(H5E_DATATYPE, H5E_BADVALUE, FAIL, 
+                HGOTO_ERROR(H5E_DATATYPE, H5E_BADVALUE, FAIL,
                             "array datatype size calculation would overflow");
-    
+
             expected_size = dt->shared->parent->shared->size * dt->shared->u.array.nelem;
-    
+
             /* Verify the stored size matches the calculated size */
             if (dt->shared->size != expected_size)
-                HGOTO_ERROR(H5E_DATATYPE, H5E_BADVALUE, FAIL,
-                            "array datatype size mismatch: expected %zu (element_size=%zu * nelem=%zu), got %zu",
-                            expected_size, dt->shared->parent->shared->size, 
-                            dt->shared->u.array.nelem, dt->shared->size);
+                HGOTO_ERROR(
+                    H5E_DATATYPE, H5E_BADVALUE, FAIL,
+                    "array datatype size mismatch: expected %zu (element_size=%zu * nelem=%zu), got %zu",
+                    expected_size, dt->shared->parent->shared->size, dt->shared->u.array.nelem,
+                    dt->shared->size);
 
             /* Check if the parent of this array has a version greater than the
              * array itself. */

--- a/src/H5Odtype.c
+++ b/src/H5Odtype.c
@@ -783,7 +783,8 @@ H5O__dtype_decode_helper(unsigned *ioflags /*in,out*/, const uint8_t **pp, H5T_t
                 HGOTO_ERROR(H5E_DATATYPE, H5E_CANTINIT, FAIL, "invalid datatype location");
             break;
 
-        case H5T_ARRAY:
+        case H5T_ARRAY: {
+            size_t expected_size; /* for validating array datatype size consistency */
             /*
              * Array datatypes...
              */
@@ -825,6 +826,21 @@ H5O__dtype_decode_helper(unsigned *ioflags /*in,out*/, const uint8_t **pp, H5T_t
             if (H5O__dtype_decode_helper(ioflags, pp, dt->shared->parent, skip, p_end) < 0)
                 HGOTO_ERROR(H5E_DATATYPE, H5E_CANTDECODE, FAIL, "unable to decode array parent type");
 
+            /* Check for multiplication overflow */
+            if (dt->shared->parent->shared->size > 0 && 
+                dt->shared->u.array.nelem > SIZE_MAX / dt->shared->parent->shared->size)
+                HGOTO_ERROR(H5E_DATATYPE, H5E_BADVALUE, FAIL, 
+                            "array datatype size calculation would overflow");
+    
+            expected_size = dt->shared->parent->shared->size * dt->shared->u.array.nelem;
+    
+            /* Verify the stored size matches the calculated size */
+            if (dt->shared->size != expected_size)
+                HGOTO_ERROR(H5E_DATATYPE, H5E_BADVALUE, FAIL,
+                            "array datatype size mismatch: expected %zu (element_size=%zu * nelem=%zu), got %zu",
+                            expected_size, dt->shared->parent->shared->size, 
+                            dt->shared->u.array.nelem, dt->shared->size);
+
             /* Check if the parent of this array has a version greater than the
              * array itself. */
             H5O_DTYPE_CHECK_VERSION(dt, version, dt->shared->parent->shared->version, ioflags, "array", FAIL)
@@ -838,6 +854,7 @@ H5O__dtype_decode_helper(unsigned *ioflags /*in,out*/, const uint8_t **pp, H5T_t
             if (dt->shared->parent->shared->force_conv == true)
                 dt->shared->force_conv = true;
             break;
+        }
 
         case H5T_COMPLEX: {
             bool homogeneous;


### PR DESCRIPTION
User reported:
When a file is corrupted such that an array datatype's size, the number of elements, and the element size are not in agreement, it can trigger an out of bounds read.

This PR adds a validation to ensure the above are in agreement.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Add validation in `H5O__dtype_decode_helper()` to ensure array datatype size consistency, preventing out-of-bounds reads in corrupted files.
> 
>   - **Validation**:
>     - Adds validation in `H5O__dtype_decode_helper()` in `H5Odtype.c` to ensure array datatype size consistency.
>     - Checks for multiplication overflow and verifies stored size matches calculated size.
>   - **Error Handling**:
>     - Triggers error if array datatype size calculation overflows or if size mismatch is detected.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=HDFGroup%2Fhdf5&utm_source=github&utm_medium=referral)<sup> for 7a1e42d13420c2e498ad70199fafcd88fa97a8f3. You can [customize](https://app.ellipsis.dev/HDFGroup/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->