### PR TITLE
Fix CVE-2025-44904

### DIFF
--- a/release_docs/CHANGELOG.md
+++ b/release_docs/CHANGELOG.md
@@ -112,6 +112,12 @@ We would like to thank the many HDF5 community members who contributed to this r
 
 ## Library
 
+### Fixed a potential buffer overflow
+
+   For unfiltered dataset chunks, the size on disk should be constant for all chunks in a dataset. In some cases the size of each chunk is stored even in this case where it can be inferred from the chunk dimensions and datatype. The code previously assumed this stored size was equal to the inferred size, leading to a mismatch in the expected and actual buffer size. Modified the library to throw an error if the size does not match the expected size.
+
+   Fixes CVE-2025-44904
+
 ### Fixed a double-free bug in H5D__chunk_copy
 
    Fixed a double-free bug in the internal H5D__chunk_copy() function which occurred when a buffer was re-allocated without updating the original pointer freed later on.

--- a/src/H5Dchunk.c
+++ b/src/H5Dchunk.c
@@ -4856,7 +4856,8 @@ H5D__chunk_lock(const H5D_io_info_t H5_ATTR_NDEBUG_UNUSED *io_info, const H5D_ds
 
                     /* Make sure the chunk is the correct size after being unfiltered */
                     if (chunk_nbytes != chunk_size)
-                        HGOTO_ERROR(H5E_DATASET, H5E_BADVALUE, NULL, "chunk size is incorrect after being unfiltered");
+                        HGOTO_ERROR(H5E_DATASET, H5E_BADVALUE, NULL,
+                                    "chunk size is incorrect after being unfiltered");
 
                     /* Reallocate chunk if necessary */
                     if (udata->new_unfilt_chunk) {

--- a/src/H5Dchunk.c
+++ b/src/H5Dchunk.c
@@ -4868,10 +4868,6 @@ H5D__chunk_lock(const H5D_io_info_t H5_ATTR_NDEBUG_UNUSED *io_info, const H5D_ds
                     } /* end if */
                 }     /* end if */
 
-                /* Assert that the chunk is the correct size and the buffer is big enough */
-                assert(chunk_nbytes == chunk_size);
-                assert(buf_alloc >= chunk_size);
-
                 /* Increment # of cache misses */
                 rdcc->stats.nmisses++;
             } /* end if */

--- a/src/H5Dchunk.c
+++ b/src/H5Dchunk.c
@@ -4854,6 +4854,10 @@ H5D__chunk_lock(const H5D_io_info_t H5_ATTR_NDEBUG_UNUSED *io_info, const H5D_ds
                                      filter_cb, &chunk_nbytes, &buf_alloc, &chunk) < 0)
                         HGOTO_ERROR(H5E_DATASET, H5E_CANTFILTER, NULL, "data pipeline read failed");
 
+                    /* Make sure the chunk is the correct size after being unfiltered */
+                    if (chunk_nbytes != chunk_size)
+                        HGOTO_ERROR(H5E_DATASET, H5E_BADVALUE, NULL, "chunk size is incorrect after being unfiltered");
+
                     /* Reallocate chunk if necessary */
                     if (udata->new_unfilt_chunk) {
                         void *tmp_chunk = chunk;

--- a/src/H5Dchunk.c
+++ b/src/H5Dchunk.c
@@ -4854,11 +4854,6 @@ H5D__chunk_lock(const H5D_io_info_t H5_ATTR_NDEBUG_UNUSED *io_info, const H5D_ds
                                      filter_cb, &chunk_nbytes, &buf_alloc, &chunk) < 0)
                         HGOTO_ERROR(H5E_DATASET, H5E_CANTFILTER, NULL, "data pipeline read failed");
 
-                    /* Make sure the chunk is the correct size after being unfiltered */
-                    if (chunk_nbytes != chunk_size)
-                        HGOTO_ERROR(H5E_DATASET, H5E_BADVALUE, NULL,
-                                    "chunk size is incorrect after being unfiltered");
-
                     /* Reallocate chunk if necessary */
                     if (udata->new_unfilt_chunk) {
                         void *tmp_chunk = chunk;

--- a/src/H5Dchunk.c
+++ b/src/H5Dchunk.c
@@ -4823,10 +4823,7 @@ H5D__chunk_lock(const H5D_io_info_t H5_ATTR_NDEBUG_UNUSED *io_info, const H5D_ds
                 H5_CHECKED_ASSIGN(chunk_nbytes, size_t, chunk_disk_size, hsize_t);
                 H5_CHECKED_ASSIGN(buf_alloc, size_t, chunk_disk_size, hsize_t);
 
-                /* Chunk size on disk isn't [likely] the same size as the final chunk
-                 * size in memory, so allocate memory big enough. */
-                if (chunk_size > buf_alloc)
-                    buf_alloc = chunk_size;
+                /* Ideally we should allocate a buffer at least as large as chunk_size, to give the filter the opportunity to avoid doing a realloc when uncompressing. This causes problems now, however, and needs more investigation. -NAF */
 
                 /* Allocate chunk buffer */
                 if (NULL ==

--- a/src/H5Dchunk.c
+++ b/src/H5Dchunk.c
@@ -4787,8 +4787,10 @@ H5D__chunk_lock(const H5D_io_info_t H5_ATTR_NDEBUG_UNUSED *io_info, const H5D_ds
         }         /* end if */
 
         /* If the chunk on disk is unfiltered, verify the index returned the correct size for the chunk */
-        if (H5_UNLIKELY((chunk_disk_size != (hsize_t)chunk_size) && H5_addr_defined(chunk_addr) && (!old_pline || !old_pline->nused)))
-            HGOTO_ERROR(H5E_DATASET, H5E_BADVALUE, NULL, "incorrect chunk size returned from index for unfiltered chunk");
+        if (H5_UNLIKELY((chunk_disk_size != (hsize_t)chunk_size) && H5_addr_defined(chunk_addr) &&
+                        (!old_pline || !old_pline->nused)))
+            HGOTO_ERROR(H5E_DATASET, H5E_BADVALUE, NULL,
+                        "incorrect chunk size returned from index for unfiltered chunk");
 
         if (relax) {
             /*
@@ -4827,8 +4829,8 @@ H5D__chunk_lock(const H5D_io_info_t H5_ATTR_NDEBUG_UNUSED *io_info, const H5D_ds
                     buf_alloc = chunk_size;
 
                 /* Allocate chunk buffer */
-                if (NULL == (chunk = H5D__chunk_mem_alloc(buf_alloc,
-                                                          (udata->new_unfilt_chunk ? old_pline : pline))))
+                if (NULL ==
+                    (chunk = H5D__chunk_mem_alloc(buf_alloc, (udata->new_unfilt_chunk ? old_pline : pline))))
                     HGOTO_ERROR(H5E_RESOURCE, H5E_NOSPACE, NULL,
                                 "memory allocation failed for raw data chunk");
 

--- a/src/H5Dchunk.c
+++ b/src/H5Dchunk.c
@@ -4823,7 +4823,9 @@ H5D__chunk_lock(const H5D_io_info_t H5_ATTR_NDEBUG_UNUSED *io_info, const H5D_ds
                 H5_CHECKED_ASSIGN(chunk_nbytes, size_t, chunk_disk_size, hsize_t);
                 H5_CHECKED_ASSIGN(buf_alloc, size_t, chunk_disk_size, hsize_t);
 
-                /* Ideally we should allocate a buffer at least as large as chunk_size, to give the filter the opportunity to avoid doing a realloc when uncompressing. This causes problems now, however, and needs more investigation. -NAF */
+                /* Ideally we should allocate a buffer at least as large as chunk_size, to give the filter the
+                 * opportunity to avoid doing a realloc when uncompressing. This causes problems now, however,
+                 * and needs more investigation. -NAF */
 
                 /* Allocate chunk buffer */
                 if (NULL ==

--- a/src/H5Dchunk.c
+++ b/src/H5Dchunk.c
@@ -4749,12 +4749,12 @@ H5D__chunk_lock(const H5D_io_info_t H5_ATTR_NDEBUG_UNUSED *io_info, const H5D_ds
         } /* end if */
     }     /* end if */
     else {
-        haddr_t chunk_addr;  /* Address of chunk on disk */
-        hsize_t chunk_alloc; /* Length of chunk on disk */
+        haddr_t chunk_addr;      /* Address of chunk on disk */
+        hsize_t chunk_disk_size; /* Length of chunk on disk */
 
         /* Save the chunk info so the cache stays consistent */
-        chunk_addr  = udata->chunk_block.offset;
-        chunk_alloc = udata->chunk_block.length;
+        chunk_addr      = udata->chunk_block.offset;
+        chunk_disk_size = udata->chunk_block.length;
 
         /* Check if we should disable filters on this chunk */
         if (pline->nused) {
@@ -4786,6 +4786,10 @@ H5D__chunk_lock(const H5D_io_info_t H5_ATTR_NDEBUG_UNUSED *io_info, const H5D_ds
             }     /* end if */
         }         /* end if */
 
+        /* If the chunk on disk is unfiltered, verify the index returned the correct size for the chunk */
+        if (H5_UNLIKELY((chunk_disk_size != (hsize_t)chunk_size) && H5_addr_defined(chunk_addr) && (!old_pline || !old_pline->nused)))
+            HGOTO_ERROR(H5E_DATASET, H5E_BADVALUE, NULL, "incorrect chunk size returned from index for unfiltered chunk");
+
         if (relax) {
             /*
              * Not in the cache, but we're about to overwrite the whole thing
@@ -4810,23 +4814,30 @@ H5D__chunk_lock(const H5D_io_info_t H5_ATTR_NDEBUG_UNUSED *io_info, const H5D_ds
 
             /* Check if the chunk exists on disk */
             if (H5_addr_defined(chunk_addr)) {
-                size_t my_chunk_alloc; /* Allocated buffer size */
-                size_t buf_alloc;      /* [Re-]allocated buffer size */
+                size_t chunk_nbytes; /* Length of the chunk in memory */
+                size_t buf_alloc;    /* [Re-]allocated chunk buffer size */
 
                 /* Assign above variables and check for overflow */
-                H5_CHECKED_ASSIGN(my_chunk_alloc, size_t, chunk_alloc, hsize_t);
-                H5_CHECKED_ASSIGN(buf_alloc, size_t, chunk_alloc, hsize_t);
+                H5_CHECKED_ASSIGN(chunk_nbytes, size_t, chunk_disk_size, hsize_t);
+                H5_CHECKED_ASSIGN(buf_alloc, size_t, chunk_disk_size, hsize_t);
 
                 /* Chunk size on disk isn't [likely] the same size as the final chunk
                  * size in memory, so allocate memory big enough. */
-                if (NULL == (chunk = H5D__chunk_mem_alloc(my_chunk_alloc,
+                if (chunk_size > buf_alloc)
+                    buf_alloc = chunk_size;
+
+                /* Allocate chunk buffer */
+                if (NULL == (chunk = H5D__chunk_mem_alloc(buf_alloc,
                                                           (udata->new_unfilt_chunk ? old_pline : pline))))
                     HGOTO_ERROR(H5E_RESOURCE, H5E_NOSPACE, NULL,
                                 "memory allocation failed for raw data chunk");
+
+                /* Read chunk from disk */
                 if (H5F_shared_block_read(H5F_SHARED(dset->oloc.file), H5FD_MEM_DRAW, chunk_addr,
-                                          my_chunk_alloc, chunk) < 0)
+                                          chunk_disk_size, chunk) < 0)
                     HGOTO_ERROR(H5E_IO, H5E_READERROR, NULL, "unable to read raw data chunk");
 
+                /* Unfilter chunk */
                 if (old_pline && old_pline->nused) {
                     H5Z_EDC_t err_detect; /* Error detection info */
                     H5Z_cb_t  filter_cb;  /* I/O filter callback function */
@@ -4837,15 +4848,16 @@ H5D__chunk_lock(const H5D_io_info_t H5_ATTR_NDEBUG_UNUSED *io_info, const H5D_ds
                     if (H5CX_get_filter_cb(&filter_cb) < 0)
                         HGOTO_ERROR(H5E_DATASET, H5E_CANTGET, NULL, "can't get I/O filter callback function");
 
+                    /* Perform filter pipeline */
                     if (H5Z_pipeline(old_pline, H5Z_FLAG_REVERSE, &(udata->filter_mask), err_detect,
-                                     filter_cb, &my_chunk_alloc, &buf_alloc, &chunk) < 0)
+                                     filter_cb, &chunk_nbytes, &buf_alloc, &chunk) < 0)
                         HGOTO_ERROR(H5E_DATASET, H5E_CANTFILTER, NULL, "data pipeline read failed");
 
                     /* Reallocate chunk if necessary */
                     if (udata->new_unfilt_chunk) {
                         void *tmp_chunk = chunk;
 
-                        if (NULL == (chunk = H5D__chunk_mem_alloc(my_chunk_alloc, pline))) {
+                        if (NULL == (chunk = H5D__chunk_mem_alloc(chunk_nbytes, pline))) {
                             (void)H5D__chunk_mem_xfree(tmp_chunk, old_pline);
                             HGOTO_ERROR(H5E_RESOURCE, H5E_NOSPACE, NULL,
                                         "memory allocation failed for raw data chunk");
@@ -4854,6 +4866,10 @@ H5D__chunk_lock(const H5D_io_info_t H5_ATTR_NDEBUG_UNUSED *io_info, const H5D_ds
                         (void)H5D__chunk_mem_xfree(tmp_chunk, old_pline);
                     } /* end if */
                 }     /* end if */
+
+                /* Assert that the chunk is the correct size and the buffer is big enough */
+                assert(chunk_nbytes == chunk_size);
+                assert(buf_alloc >= chunk_size);
 
                 /* Increment # of cache misses */
                 rdcc->stats.nmisses++;
@@ -4864,8 +4880,7 @@ H5D__chunk_lock(const H5D_io_info_t H5_ATTR_NDEBUG_UNUSED *io_info, const H5D_ds
                 /* Sanity check */
                 assert(fill->alloc_time != H5D_ALLOC_TIME_EARLY);
 
-                /* Chunk size on disk isn't [likely] the same size as the final chunk
-                 * size in memory, so allocate memory big enough. */
+                /* Allocate chunk buffer large enough to hold an unfiltered (in cache) chunk */
                 if (NULL == (chunk = H5D__chunk_mem_alloc(chunk_size, pline)))
                     HGOTO_ERROR(H5E_RESOURCE, H5E_NOSPACE, NULL,
                                 "memory allocation failed for raw data chunk");
@@ -4929,7 +4944,7 @@ H5D__chunk_lock(const H5D_io_info_t H5_ATTR_NDEBUG_UNUSED *io_info, const H5D_ds
 
                 /* Initialize the new entry */
                 ent->chunk_block.offset = chunk_addr;
-                ent->chunk_block.length = chunk_alloc;
+                ent->chunk_block.length = chunk_disk_size;
                 ent->chunk_idx          = udata->chunk_idx;
                 H5MM_memcpy(ent->scaled, udata->common.scaled, sizeof(hsize_t) * layout->u.chunk.ndims);
                 H5_CHECKED_ASSIGN(ent->rd_count, hsize_t, chunk_size, size_t);

--- a/src/H5Z.c
+++ b/src/H5Z.c
@@ -1491,14 +1491,8 @@ H5Z_pipeline(const H5O_pline_t *pline, unsigned flags, unsigned *filter_mask /*i
                 *nbytes = *buf_size;
                 failed |= (unsigned)1 << idx;
             }
-            else {
-                /* Make sure returned new_nbytes is consistent with the returned buffer size */
-                if (*buf_size < new_nbytes)
-                    HGOTO_ERROR(H5E_PLINE, H5E_BADVALUE, FAIL, "buffer size is too small after filter callback");
-
-                /* Update nbytes */
+            else
                 *nbytes = new_nbytes;
-            }
         }
     }
     else if (pline)
@@ -1567,14 +1561,8 @@ H5Z_pipeline(const H5O_pline_t *pline, unsigned flags, unsigned *filter_mask /*i
                 }
                 failed |= (unsigned)1 << idx;
             }
-            else {
-                /* Make sure returned new_nbytes is consistent with the returned buffer size */
-                if (*buf_size < new_nbytes)
-                    HGOTO_ERROR(H5E_PLINE, H5E_BADVALUE, FAIL, "buffer size is too small after filter callback");
-
-                /* Update nbytes */
+            else
                 *nbytes = new_nbytes;
-            }
         } /* end for */
     }
 

--- a/src/H5Z.c
+++ b/src/H5Z.c
@@ -1491,8 +1491,14 @@ H5Z_pipeline(const H5O_pline_t *pline, unsigned flags, unsigned *filter_mask /*i
                 *nbytes = *buf_size;
                 failed |= (unsigned)1 << idx;
             }
-            else
+            else {
+                /* Make sure returned new_nbytes is consistent with the returned buffer size */
+                if (*buf_size < new_nbytes)
+                    HGOTO_ERROR(H5E_PLINE, H5E_BADVALUE, FAIL, "buffer size is too small after filter callback");
+
+                /* Update nbytes */
                 *nbytes = new_nbytes;
+            }
         }
     }
     else if (pline)
@@ -1561,8 +1567,14 @@ H5Z_pipeline(const H5O_pline_t *pline, unsigned flags, unsigned *filter_mask /*i
                 }
                 failed |= (unsigned)1 << idx;
             }
-            else
+            else {
+                /* Make sure returned new_nbytes is consistent with the returned buffer size */
+                if (*buf_size < new_nbytes)
+                    HGOTO_ERROR(H5E_PLINE, H5E_BADVALUE, FAIL, "buffer size is too small after filter callback");
+
+                /* Update nbytes */
                 *nbytes = new_nbytes;
+            }
         } /* end for */
     }
 


### PR DESCRIPTION
For unfiltered dataset chunks, the size on disk should be constant for all chunks in a dataset. In some cases the size of each chunk is stored even in this case where it can be inferred from the chunk dimensions and datatype. The code previously assumed this stored size was equal to the inferred size, leading to a mismatch in the expected and actual buffer size. Modified the library to throw an error if the size does not match the expected size.

Fixes CVE-2025-44904
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fixes CVE-2025-44904 by ensuring unfiltered dataset chunk sizes on disk match expected sizes, with error handling added in `H5D__chunk_lock`.
> 
>   - **Security Fix**:
>     - Fixes CVE-2025-44904 by ensuring unfiltered dataset chunk sizes on disk match expected sizes.
>     - Adds error handling in `H5D__chunk_lock` in `H5Dchunk.c` for size mismatches.
>   - **Code Changes**:
>     - Renames `chunk_alloc` to `chunk_disk_size` in `H5Dchunk.c` for clarity.
>     - Adds assertions to verify chunk and buffer sizes in `H5D__chunk_lock`.
>   - **Documentation**:
>     - Updates `CHANGELOG.md` to document the fix for CVE-2025-44904.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=HDFGroup%2Fhdf5&utm_source=github&utm_medium=referral)<sup> for 3e27fbd7fa9b9d945fd6d9c132a46d455868a48d. You can [customize](https://app.ellipsis.dev/HDFGroup/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->