### PR TITLE
Update ci hdf5config.cmake to re-enable GitHub daily tests

### DIFF
--- a/.github/actions/symlink-ctest-scripts/action.yml
+++ b/.github/actions/symlink-ctest-scripts/action.yml
@@ -12,12 +12,14 @@ runs:
       if: runner.os != 'Windows'
       shell: bash
       run: |
-        ln -s ${{ github.workspace }}/${{ inputs.source-base }}/config/cmake/scripts/CTestScript.cmake ${{ runner.workspace }}/hdf5/CTestScript.cmake
-        ln -s ${{ github.workspace }}/${{ inputs.source-base }}/config/cmake/scripts/HDF5config.cmake ${{ runner.workspace }}/hdf5/HDF5config.cmake
+        mkdir -p ${{ runner.workspace }}/hdf5
+        ln -sf ${{ github.workspace }}/${{ inputs.source-base }}/config/cmake/scripts/CTestScript.cmake ${{ runner.workspace }}/hdf5/CTestScript.cmake
+        ln -sf ${{ github.workspace }}/${{ inputs.source-base }}/config/cmake/scripts/HDF5config.cmake ${{ runner.workspace }}/hdf5/HDF5config.cmake
 
     - name: Create symlinks (Windows)
       if: runner.os == 'Windows'
       shell: pwsh
       run: |
-        New-Item -ItemType SymbolicLink -Path ${{ runner.workspace }}/hdf5/CTestScript.cmake -Target ${{ github.workspace }}/${{ inputs.source-base }}/config/cmake/scripts/CTestScript.cmake
-        New-Item -ItemType SymbolicLink -Path ${{ runner.workspace }}/hdf5/HDF5config.cmake -Target ${{ github.workspace }}/${{ inputs.source-base }}/config/cmake/scripts/HDF5config.cmake
+        New-Item -ItemType Directory -Path ${{ runner.workspace }}/hdf5 -Force | Out-Null
+        New-Item -ItemType SymbolicLink -Path ${{ runner.workspace }}/hdf5/CTestScript.cmake -Target ${{ github.workspace }}/${{ inputs.source-base }}/config/cmake/scripts/CTestScript.cmake -Force
+        New-Item -ItemType SymbolicLink -Path ${{ runner.workspace }}/hdf5/HDF5config.cmake -Target ${{ github.workspace }}/${{ inputs.source-base }}/config/cmake/scripts/HDF5config.cmake -Force

--- a/.github/actions/symlink-ctest-scripts/action.yml
+++ b/.github/actions/symlink-ctest-scripts/action.yml
@@ -1,0 +1,23 @@
+name: 'Symlink CTest Scripts'
+description: 'Create symlinks for HDF5config.cmake and CTestScript.cmake in the ctest run directory'
+inputs:
+  source-base:
+    description: 'Source base directory name (e.g., hdfsrc)'
+    required: true
+
+runs:
+  using: 'composite'
+  steps:
+    - name: Create symlinks (Unix)
+      if: runner.os != 'Windows'
+      shell: bash
+      run: |
+        ln -s ${{ github.workspace }}/${{ inputs.source-base }}/config/cmake/scripts/CTestScript.cmake ${{ runner.workspace }}/hdf5/CTestScript.cmake
+        ln -s ${{ github.workspace }}/${{ inputs.source-base }}/config/cmake/scripts/HDF5config.cmake ${{ runner.workspace }}/hdf5/HDF5config.cmake
+
+    - name: Create symlinks (Windows)
+      if: runner.os == 'Windows'
+      shell: pwsh
+      run: |
+        New-Item -ItemType SymbolicLink -Path ${{ runner.workspace }}/hdf5/CTestScript.cmake -Target ${{ github.workspace }}/${{ inputs.source-base }}/config/cmake/scripts/CTestScript.cmake
+        New-Item -ItemType SymbolicLink -Path ${{ runner.workspace }}/hdf5/HDF5config.cmake -Target ${{ github.workspace }}/${{ inputs.source-base }}/config/cmake/scripts/HDF5config.cmake

--- a/.github/workflows/analysis.yml
+++ b/.github/workflows/analysis.yml
@@ -69,8 +69,8 @@ jobs:
 
     - name: Copy script files for the space (Linux_coverage)
       run: |
-        cp ${{ github.workspace }}/${{ steps.set-file-base.outputs.SOURCE_BASE }}/config/cmake/scripts/CTestScript.cmake ${{ runner.workspace }}/hdf5
-        cp ${{ github.workspace }}/${{ steps.set-file-base.outputs.SOURCE_BASE }}/config/cmake/scripts/HDF5config.cmake ${{ runner.workspace }}/hdf5
+        ln -s  ${{ runner.workspace }}/hdf5//CTestScript.cmake ${{ github.workspace }}/${{ steps.set-file-base.outputs.SOURCE_BASE }}/config/cmake/scripts/CTestScript.cmake
+        ln -s ${{ runner.workspace }}/hdf5/HDF5config.cmake ${{ github.workspace }}/${{ steps.set-file-base.outputs.SOURCE_BASE }}/config/cmake/scripts/HDF5config.cmake
 
     - name: List files for the hdf5 (Linux_coverage)
       run: |
@@ -170,8 +170,8 @@ jobs:
 
       - name: Copy script files for the space (Linux_Leak)
         run: |
-          cp ${{ github.workspace }}/${{ steps.set-file-base.outputs.SOURCE_BASE }}/config/cmake/scripts/CTestScript.cmake ${{ runner.workspace }}/hdf5
-          cp ${{ github.workspace }}/${{ steps.set-file-base.outputs.SOURCE_BASE }}/config/cmake/scripts/HDF5config.cmake ${{ runner.workspace }}/hdf5
+          ln -s  ${{ runner.workspace }}/hdf5//CTestScript.cmake ${{ github.workspace }}/${{ steps.set-file-base.outputs.SOURCE_BASE }}/config/cmake/scripts/CTestScript.cmake
+          ln -s ${{ runner.workspace }}/hdf5/HDF5config.cmake ${{ github.workspace }}/${{ steps.set-file-base.outputs.SOURCE_BASE }}/config/cmake/scripts/HDF5config.cmake
 
       - name: List files for the hdf5 (Linux_Leak)
         run: |
@@ -271,8 +271,8 @@ jobs:
 
       - name: Copy script files for the space (Linux_Address)
         run: |
-          cp ${{ github.workspace }}/${{ steps.set-file-base.outputs.SOURCE_BASE }}/config/cmake/scripts/CTestScript.cmake ${{ runner.workspace }}/hdf5
-          cp ${{ github.workspace }}/${{ steps.set-file-base.outputs.SOURCE_BASE }}/config/cmake/scripts/HDF5config.cmake ${{ runner.workspace }}/hdf5
+        ln -s  ${{ runner.workspace }}/hdf5//CTestScript.cmake ${{ github.workspace }}/${{ steps.set-file-base.outputs.SOURCE_BASE }}/config/cmake/scripts/CTestScript.cmake
+        ln -s ${{ runner.workspace }}/hdf5/HDF5config.cmake ${{ github.workspace }}/${{ steps.set-file-base.outputs.SOURCE_BASE }}/config/cmake/scripts/HDF5config.cmake
 
       - name: List files for the hdf5 (Linux_Address)
         run: |
@@ -372,8 +372,8 @@ jobs:
 
       - name: Copy script files for the space (Linux_UndefinedBehavior)
         run: |
-          cp ${{ github.workspace }}/${{ steps.set-file-base.outputs.SOURCE_BASE }}/config/cmake/scripts/CTestScript.cmake ${{ runner.workspace }}/hdf5
-          cp ${{ github.workspace }}/${{ steps.set-file-base.outputs.SOURCE_BASE }}/config/cmake/scripts/HDF5config.cmake ${{ runner.workspace }}/hdf5
+          ln -s  ${{ runner.workspace }}/hdf5//CTestScript.cmake ${{ github.workspace }}/${{ steps.set-file-base.outputs.SOURCE_BASE }}/config/cmake/scripts/CTestScript.cmake
+          ln -s ${{ runner.workspace }}/hdf5/HDF5config.cmake ${{ github.workspace }}/${{ steps.set-file-base.outputs.SOURCE_BASE }}/config/cmake/scripts/HDF5config.cmake
 
       - name: List files for the hdf5 (Linux_UndefinedBehavior)
         run: |

--- a/.github/workflows/analysis.yml
+++ b/.github/workflows/analysis.yml
@@ -271,8 +271,8 @@ jobs:
 
       - name: Copy script files for the space (Linux_Address)
         run: |
-        ln -s  ${{ runner.workspace }}/hdf5//CTestScript.cmake ${{ github.workspace }}/${{ steps.set-file-base.outputs.SOURCE_BASE }}/config/cmake/scripts/CTestScript.cmake
-        ln -s ${{ runner.workspace }}/hdf5/HDF5config.cmake ${{ github.workspace }}/${{ steps.set-file-base.outputs.SOURCE_BASE }}/config/cmake/scripts/HDF5config.cmake
+          ln -s  ${{ runner.workspace }}/hdf5//CTestScript.cmake ${{ github.workspace }}/${{ steps.set-file-base.outputs.SOURCE_BASE }}/config/cmake/scripts/CTestScript.cmake
+          ln -s ${{ runner.workspace }}/hdf5/HDF5config.cmake ${{ github.workspace }}/${{ steps.set-file-base.outputs.SOURCE_BASE }}/config/cmake/scripts/HDF5config.cmake
 
       - name: List files for the hdf5 (Linux_Address)
         run: |

--- a/.github/workflows/analysis.yml
+++ b/.github/workflows/analysis.yml
@@ -32,6 +32,11 @@ jobs:
     name: "Ubuntu GCC Coverage"
     runs-on: ubuntu-22.04
     steps:
+    - name: Get Actions
+      uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
+      with:
+        sparse-checkout: .github/actions
+
     - name: Install Dependencies (Linux_coverage)
       run: |
         sudo apt update
@@ -67,10 +72,10 @@ jobs:
     - name: Uncompress source (Linux_coverage)
       run: tar -zxvf ${{ github.workspace }}/${{ steps.set-file-base.outputs.FILE_BASE }}.tar.gz
 
-    - name: Copy script files for the space (Linux_coverage)
-      run: |
-        ln -s  ${{ runner.workspace }}/hdf5//CTestScript.cmake ${{ github.workspace }}/${{ steps.set-file-base.outputs.SOURCE_BASE }}/config/cmake/scripts/CTestScript.cmake
-        ln -s ${{ runner.workspace }}/hdf5/HDF5config.cmake ${{ github.workspace }}/${{ steps.set-file-base.outputs.SOURCE_BASE }}/config/cmake/scripts/HDF5config.cmake
+    - name: Symlink script files for the space (Linux_coverage)
+      uses: ./.github/actions/symlink-ctest-scripts
+      with:
+        source-base: ${{ steps.set-file-base.outputs.SOURCE_BASE }}
 
     - name: List files for the hdf5 (Linux_coverage)
       run: |
@@ -128,6 +133,11 @@ jobs:
     name: "Ubuntu Clang LeakSanitizer"
     runs-on: ubuntu-22.04
     steps:
+      - name: Get Actions
+        uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
+        with:
+          sparse-checkout: .github/actions
+
       - name: Install Dependencies (Linux_Leak)
         run: |
           sudo apt update
@@ -168,10 +178,10 @@ jobs:
       - name: Uncompress source (Linux_Leak)
         run: tar -zxvf ${{ github.workspace }}/${{ steps.set-file-base.outputs.FILE_BASE }}.tar.gz
 
-      - name: Copy script files for the space (Linux_Leak)
-        run: |
-          ln -s  ${{ runner.workspace }}/hdf5//CTestScript.cmake ${{ github.workspace }}/${{ steps.set-file-base.outputs.SOURCE_BASE }}/config/cmake/scripts/CTestScript.cmake
-          ln -s ${{ runner.workspace }}/hdf5/HDF5config.cmake ${{ github.workspace }}/${{ steps.set-file-base.outputs.SOURCE_BASE }}/config/cmake/scripts/HDF5config.cmake
+      - name: Symlink script files for the space (Linux_Leak)
+        uses: ./.github/actions/symlink-ctest-scripts
+        with:
+          source-base: ${{ steps.set-file-base.outputs.SOURCE_BASE }}
 
       - name: List files for the hdf5 (Linux_Leak)
         run: |
@@ -229,6 +239,11 @@ jobs:
     name: "Ubuntu Clang AddressSanitizer"
     runs-on: ubuntu-22.04
     steps:
+      - name: Get Actions
+        uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
+        with:
+          sparse-checkout: .github/actions
+
       - name: Install Dependencies (Linux_Address)
         run: |
           sudo apt update
@@ -269,10 +284,10 @@ jobs:
       - name: Uncompress source (Linux_Address)
         run: tar -zxvf ${{ github.workspace }}/${{ steps.set-file-base.outputs.FILE_BASE }}.tar.gz
 
-      - name: Copy script files for the space (Linux_Address)
-        run: |
-          ln -s  ${{ runner.workspace }}/hdf5//CTestScript.cmake ${{ github.workspace }}/${{ steps.set-file-base.outputs.SOURCE_BASE }}/config/cmake/scripts/CTestScript.cmake
-          ln -s ${{ runner.workspace }}/hdf5/HDF5config.cmake ${{ github.workspace }}/${{ steps.set-file-base.outputs.SOURCE_BASE }}/config/cmake/scripts/HDF5config.cmake
+      - name: Symlink script files for the space (Linux_Address)
+        uses: ./.github/actions/symlink-ctest-scripts
+        with:
+          source-base: ${{ steps.set-file-base.outputs.SOURCE_BASE }}
 
       - name: List files for the hdf5 (Linux_Address)
         run: |
@@ -330,6 +345,11 @@ jobs:
     name: "Ubuntu Clang UndefinedBehaviorSanitizer"
     runs-on: ubuntu-22.04
     steps:
+      - name: Get Actions
+        uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
+        with:
+          sparse-checkout: .github/actions
+
       - name: Install Dependencies (Linux_UndefinedBehavior)
         run: |
           sudo apt update
@@ -370,10 +390,10 @@ jobs:
       - name: Uncompress source (Linux_UndefinedBehavior)
         run: tar -zxvf ${{ github.workspace }}/${{ steps.set-file-base.outputs.FILE_BASE }}.tar.gz
 
-      - name: Copy script files for the space (Linux_UndefinedBehavior)
-        run: |
-          ln -s  ${{ runner.workspace }}/hdf5//CTestScript.cmake ${{ github.workspace }}/${{ steps.set-file-base.outputs.SOURCE_BASE }}/config/cmake/scripts/CTestScript.cmake
-          ln -s ${{ runner.workspace }}/hdf5/HDF5config.cmake ${{ github.workspace }}/${{ steps.set-file-base.outputs.SOURCE_BASE }}/config/cmake/scripts/HDF5config.cmake
+      - name: Symlink script files for the space (Linux_UndefinedBehavior)
+        uses: ./.github/actions/symlink-ctest-scripts
+        with:
+          source-base: ${{ steps.set-file-base.outputs.SOURCE_BASE }}
 
       - name: List files for the hdf5 (Linux_UndefinedBehavior)
         run: |

--- a/.github/workflows/analysis.yml
+++ b/.github/workflows/analysis.yml
@@ -30,7 +30,7 @@ jobs:
   # Linux (Ubuntu) w/ gcc + coverage
   #
     name: "Ubuntu GCC Coverage"
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     steps:
     - name: Install Dependencies (Linux_coverage)
       run: |
@@ -67,7 +67,7 @@ jobs:
     - name: Uncompress source (Linux_coverage)
       run: tar -zxvf ${{ github.workspace }}/${{ steps.set-file-base.outputs.FILE_BASE }}.tar.gz
 
-    - name: Copy script files for the space (Linux_coverage)
+    - name: Link script files for the space (Linux_coverage)
       run: |
         ln -s  ${{ runner.workspace }}/hdf5//CTestScript.cmake ${{ github.workspace }}/${{ steps.set-file-base.outputs.SOURCE_BASE }}/config/cmake/scripts/CTestScript.cmake
         ln -s ${{ runner.workspace }}/hdf5/HDF5config.cmake ${{ github.workspace }}/${{ steps.set-file-base.outputs.SOURCE_BASE }}/config/cmake/scripts/HDF5config.cmake
@@ -126,7 +126,7 @@ jobs:
   # Linux (Ubuntu) w/ clang + LeakSanitizer
   #
     name: "Ubuntu Clang LeakSanitizer"
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     steps:
       - name: Install Dependencies (Linux_Leak)
         run: |
@@ -168,7 +168,7 @@ jobs:
       - name: Uncompress source (Linux_Leak)
         run: tar -zxvf ${{ github.workspace }}/${{ steps.set-file-base.outputs.FILE_BASE }}.tar.gz
 
-      - name: Copy script files for the space (Linux_Leak)
+      - name: Link script files for the space (Linux_Leak)
         run: |
           ln -s  ${{ runner.workspace }}/hdf5//CTestScript.cmake ${{ github.workspace }}/${{ steps.set-file-base.outputs.SOURCE_BASE }}/config/cmake/scripts/CTestScript.cmake
           ln -s ${{ runner.workspace }}/hdf5/HDF5config.cmake ${{ github.workspace }}/${{ steps.set-file-base.outputs.SOURCE_BASE }}/config/cmake/scripts/HDF5config.cmake
@@ -227,7 +227,7 @@ jobs:
   # Linux (Ubuntu) w/ clang + AddressSanitizer
   #
     name: "Ubuntu Clang AddressSanitizer"
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     steps:
       - name: Install Dependencies (Linux_Address)
         run: |
@@ -269,7 +269,7 @@ jobs:
       - name: Uncompress source (Linux_Address)
         run: tar -zxvf ${{ github.workspace }}/${{ steps.set-file-base.outputs.FILE_BASE }}.tar.gz
 
-      - name: Copy script files for the space (Linux_Address)
+      - name: Link script files for the space (Linux_Address)
         run: |
           ln -s  ${{ runner.workspace }}/hdf5//CTestScript.cmake ${{ github.workspace }}/${{ steps.set-file-base.outputs.SOURCE_BASE }}/config/cmake/scripts/CTestScript.cmake
           ln -s ${{ runner.workspace }}/hdf5/HDF5config.cmake ${{ github.workspace }}/${{ steps.set-file-base.outputs.SOURCE_BASE }}/config/cmake/scripts/HDF5config.cmake
@@ -328,7 +328,7 @@ jobs:
   # Linux (Ubuntu) w/ clang + UndefinedBehaviorSanitizer
   #
     name: "Ubuntu Clang UndefinedBehaviorSanitizer"
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     steps:
       - name: Install Dependencies (Linux_UndefinedBehavior)
         run: |

--- a/.github/workflows/cross-compile.yml
+++ b/.github/workflows/cross-compile.yml
@@ -18,7 +18,7 @@ env:
 jobs:
   build_and_test_linux:
     name: "Ubuntu mingw64-${{ inputs.build_mode }}"
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-latest
     steps:
       - name: Install CMake Dependencies (Linux)
         run: |

--- a/.github/workflows/cygwin.yml
+++ b/.github/workflows/cygwin.yml
@@ -74,10 +74,10 @@ jobs:
         run: 7z x ${{ steps.set-file-base.outputs.FILE_BASE }}.zip
         shell: C:\cygwin\bin\bash.exe -eo pipefail -o igncr '{0}'
 
-      - name: Copy script files for the space (Cygwin)
-        run: |
-          ln -s  ${{ runner.workspace }}/hdf5//CTestScript.cmake ${{ github.workspace }}/${{ steps.set-file-base.outputs.SOURCE_BASE }}/config/cmake/scripts/CTestScript.cmake
-          ln -s ${{ runner.workspace }}/hdf5/HDF5config.cmake ${{ github.workspace }}/${{ steps.set-file-base.outputs.SOURCE_BASE }}/config/cmake/scripts/HDF5config.cmake
+      - name: Symlink script files for the space (Cygwin)
+        uses: ./.github/actions/symlink-ctest-scripts
+        with:
+          source-base: ${{ steps.set-file-base.outputs.SOURCE_BASE }}
 
       - name: List files for the hdf5 (Cygwin)
         run: |

--- a/.github/workflows/cygwin.yml
+++ b/.github/workflows/cygwin.yml
@@ -76,8 +76,8 @@ jobs:
 
       - name: Copy script files for the space (Cygwin)
         run: |
-          cp ${{ github.workspace }}/${{ steps.set-file-base.outputs.SOURCE_BASE }}/config/cmake/scripts/CTestScript.cmake ${{ runner.workspace }}/hdf5
-          cp ${{ github.workspace }}/${{ steps.set-file-base.outputs.SOURCE_BASE }}/config/cmake/scripts/HDF5config.cmake ${{ runner.workspace }}/hdf5
+          ln -s  ${{ runner.workspace }}/hdf5//CTestScript.cmake ${{ github.workspace }}/${{ steps.set-file-base.outputs.SOURCE_BASE }}/config/cmake/scripts/CTestScript.cmake
+          ln -s ${{ runner.workspace }}/hdf5/HDF5config.cmake ${{ github.workspace }}/${{ steps.set-file-base.outputs.SOURCE_BASE }}/config/cmake/scripts/HDF5config.cmake
 
       - name: List files for the hdf5 (Cygwin)
         run: |

--- a/.github/workflows/dev.yml
+++ b/.github/workflows/dev.yml
@@ -261,7 +261,7 @@ jobs:
     # Linux (Ubuntu) w/ clang
     #
     name: "Ubuntu Clang"
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     steps:
       - name: Install Dependencies (Linux_clang)
         run: |

--- a/.github/workflows/par-script.yml
+++ b/.github/workflows/par-script.yml
@@ -107,11 +107,10 @@ jobs:
         run: 7z x ${{ steps.set-file-base.outputs.FILE_BASE }}.zip
         shell: bash
 
-      - name: Copy script files for the space (${{ matrix.mpi }})
-        run: |
-          New-Item -ItemType SymbolicLink -Path ${{ runner.workspace }}/hdf5/CTestScript.cmake -Target ${{ github.workspace }}/${{ steps.set-file-base.outputs.SOURCE_BASE }}/config/cmake/scripts/CTestScript.cmake
-          New-Item -ItemType SymbolicLink -Path ${{ runner.workspace }}/hdf5/HDF5config.cmake -Target ${{ github.workspace }}/${{ steps.set-file-base.outputs.SOURCE_BASE }}/config/cmake/scripts/HDF5config.cmake
-        shell: pwsh
+      - name: Symlink script files for the space (${{ matrix.mpi }})
+        uses: ./.github/actions/symlink-ctest-scripts
+        with:
+          source-base: ${{ steps.set-file-base.outputs.SOURCE_BASE }}
 
       - name: List files for the hdf5 (${{ matrix.mpi }})
         run: |
@@ -170,6 +169,11 @@ jobs:
         mpi: [ 'mpich', 'openmpi', 'intelmpi']
     name: "Parallel ${{ matrix.mpi }} Linux-${{ inputs.build_mode }}"
     steps:
+      - name: Get Actions
+        uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
+        with:
+          sparse-checkout: .github/actions
+
       - name: Install Dependencies (${{ matrix.mpi }})
         run: |
           sudo apt-get update
@@ -229,10 +233,10 @@ jobs:
       - name: Uncompress source (Linux)
         run: tar -zxvf ${{ github.workspace }}/${{ steps.set-file-base.outputs.FILE_BASE }}.tar.gz
 
-      - name: Copy script files for the space (${{ matrix.mpi }})
-        run: |
-          ln -s  ${{ runner.workspace }}/hdf5//CTestScript.cmake ${{ github.workspace }}/${{ steps.set-file-base.outputs.SOURCE_BASE }}/config/cmake/scripts/CTestScript.cmake
-          ln -s ${{ runner.workspace }}/hdf5/HDF5config.cmake ${{ github.workspace }}/${{ steps.set-file-base.outputs.SOURCE_BASE }}/config/cmake/scripts/HDF5config.cmake
+      - name: Symlink script files for the space (${{ matrix.mpi }})
+        uses: ./.github/actions/symlink-ctest-scripts
+        with:
+          source-base: ${{ steps.set-file-base.outputs.SOURCE_BASE }}
 
       - name: List files for the hdf5 (${{ matrix.mpi }})
         run: |
@@ -339,10 +343,10 @@ jobs:
       - name: Uncompress source (${{ matrix.mpi }})
         run: tar -zxvf ${{ github.workspace }}/${{ steps.set-file-base.outputs.FILE_BASE }}.tar.gz
 
-      - name: Copy script files for the space (${{ matrix.mpi }})
-        run: |
-          ln -s  ${{ runner.workspace }}/hdf5//CTestScript.cmake ${{ github.workspace }}/${{ steps.set-file-base.outputs.SOURCE_BASE }}/config/cmake/scripts/CTestScript.cmake
-          ln -s ${{ runner.workspace }}/hdf5/HDF5config.cmake ${{ github.workspace }}/${{ steps.set-file-base.outputs.SOURCE_BASE }}/config/cmake/scripts/HDF5config.cmake
+      - name: Symlink script files for the space (${{ matrix.mpi }})
+        uses: ./.github/actions/symlink-ctest-scripts
+        with:
+          source-base: ${{ steps.set-file-base.outputs.SOURCE_BASE }}
 
       - name: List files for the hdf5 (${{ matrix.mpi }})
         run: |

--- a/.github/workflows/par-script.yml
+++ b/.github/workflows/par-script.yml
@@ -109,8 +109,8 @@ jobs:
 
       - name: Copy script files for the space (${{ matrix.mpi }})
         run: |
-          Copy-Item -Path ${{ github.workspace }}/${{ steps.set-file-base.outputs.SOURCE_BASE }}/config/cmake/scripts/CTestScript.cmake -Destination ${{ runner.workspace }}/hdf5
-          Copy-Item -Path ${{ github.workspace }}/${{ steps.set-file-base.outputs.SOURCE_BASE }}/config/cmake/scripts/HDF5config.cmake -Destination ${{ runner.workspace }}/hdf5
+          New-Item -ItemType SymbolicLink -Path ${{ runner.workspace }}/hdf5/CTestScript.cmake -Target ${{ github.workspace }}/${{ steps.set-file-base.outputs.SOURCE_BASE }}/config/cmake/scripts/CTestScript.cmake
+          New-Item -ItemType SymbolicLink -Path ${{ runner.workspace }}/hdf5/HDF5config.cmake -Target ${{ github.workspace }}/${{ steps.set-file-base.outputs.SOURCE_BASE }}/config/cmake/scripts/HDF5config.cmake
         shell: pwsh
 
       - name: List files for the hdf5 (${{ matrix.mpi }})
@@ -231,8 +231,8 @@ jobs:
 
       - name: Copy script files for the space (${{ matrix.mpi }})
         run: |
-          cp ${{ github.workspace }}/${{ steps.set-file-base.outputs.SOURCE_BASE }}/config/cmake/scripts/CTestScript.cmake ${{ runner.workspace }}/hdf5
-          cp ${{ github.workspace }}/${{ steps.set-file-base.outputs.SOURCE_BASE }}/config/cmake/scripts/HDF5config.cmake ${{ runner.workspace }}/hdf5
+          ln -s  ${{ runner.workspace }}/hdf5//CTestScript.cmake ${{ github.workspace }}/${{ steps.set-file-base.outputs.SOURCE_BASE }}/config/cmake/scripts/CTestScript.cmake
+          ln -s ${{ runner.workspace }}/hdf5/HDF5config.cmake ${{ github.workspace }}/${{ steps.set-file-base.outputs.SOURCE_BASE }}/config/cmake/scripts/HDF5config.cmake
 
       - name: List files for the hdf5 (${{ matrix.mpi }})
         run: |
@@ -341,8 +341,8 @@ jobs:
 
       - name: Copy script files for the space (${{ matrix.mpi }})
         run: |
-          cp ${{ github.workspace }}/${{ steps.set-file-base.outputs.SOURCE_BASE }}/config/cmake/scripts/CTestScript.cmake ${{ runner.workspace }}/hdf5
-          cp ${{ github.workspace }}/${{ steps.set-file-base.outputs.SOURCE_BASE }}/config/cmake/scripts/HDF5config.cmake ${{ runner.workspace }}/hdf5
+          ln -s  ${{ runner.workspace }}/hdf5//CTestScript.cmake ${{ github.workspace }}/${{ steps.set-file-base.outputs.SOURCE_BASE }}/config/cmake/scripts/CTestScript.cmake
+          ln -s ${{ runner.workspace }}/hdf5/HDF5config.cmake ${{ github.workspace }}/${{ steps.set-file-base.outputs.SOURCE_BASE }}/config/cmake/scripts/HDF5config.cmake
 
       - name: List files for the hdf5 (${{ matrix.mpi }})
         run: |

--- a/.github/workflows/par-source.yml
+++ b/.github/workflows/par-source.yml
@@ -51,6 +51,11 @@ jobs:
     name: "Parallel OpenMPI GCC-${{ inputs.build_mode }}"
     runs-on: ubuntu-latest
     steps:
+      - name: Get Actions
+        uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
+        with:
+          sparse-checkout: .github/actions
+
       - name: Install Linux Dependencies (OpenMPI)
         run: |
           sudo apt-get update
@@ -113,10 +118,10 @@ jobs:
       - name: Uncompress source (OpenMPI)
         run: tar -zxvf ${{ github.workspace }}/${{ steps.set-file-base.outputs.FILE_BASE }}.tar.gz
 
-      - name: Copy script files for the space (OpenMPI)
-        run: |
-          ln -s  ${{ runner.workspace }}/hdf5//CTestScript.cmake ${{ github.workspace }}/${{ steps.set-file-base.outputs.SOURCE_BASE }}/config/cmake/scripts/CTestScript.cmake
-          ln -s ${{ runner.workspace }}/hdf5/HDF5config.cmake ${{ github.workspace }}/${{ steps.set-file-base.outputs.SOURCE_BASE }}/config/cmake/scripts/HDF5config.cmake
+      - name: Symlink script files for the space (OpenMPI)
+        uses: ./.github/actions/symlink-ctest-scripts
+        with:
+          source-base: ${{ steps.set-file-base.outputs.SOURCE_BASE }}
 
       - name: List files for the hdf5 (OpenMPI)
         run: |
@@ -235,10 +240,10 @@ jobs:
       - name: Uncompress source (MPICH)
         run: tar -zxvf ${{ github.workspace }}/${{ steps.set-file-base.outputs.FILE_BASE }}.tar.gz
 
-      - name: Copy script files for the space (MPICH)
-        run: |
-          ln -s  ${{ runner.workspace }}/hdf5//CTestScript.cmake ${{ github.workspace }}/${{ steps.set-file-base.outputs.SOURCE_BASE }}/config/cmake/scripts/CTestScript.cmake
-          ln -s ${{ runner.workspace }}/hdf5/HDF5config.cmake ${{ github.workspace }}/${{ steps.set-file-base.outputs.SOURCE_BASE }}/config/cmake/scripts/HDF5config.cmake
+      - name: Symlink script files for the space (MPICH)
+        uses: ./.github/actions/symlink-ctest-scripts
+        with:
+          source-base: ${{ steps.set-file-base.outputs.SOURCE_BASE }}
 
       - name: List files for the hdf5 (MPICH)
         run: |

--- a/.github/workflows/par-source.yml
+++ b/.github/workflows/par-source.yml
@@ -115,8 +115,8 @@ jobs:
 
       - name: Copy script files for the space (OpenMPI)
         run: |
-          cp ${{ github.workspace }}/${{ steps.set-file-base.outputs.SOURCE_BASE }}/config/cmake/scripts/CTestScript.cmake ${{ runner.workspace }}/hdf5
-          cp ${{ github.workspace }}/${{ steps.set-file-base.outputs.SOURCE_BASE }}/config/cmake/scripts/HDF5config.cmake ${{ runner.workspace }}/hdf5
+          ln -s  ${{ runner.workspace }}/hdf5//CTestScript.cmake ${{ github.workspace }}/${{ steps.set-file-base.outputs.SOURCE_BASE }}/config/cmake/scripts/CTestScript.cmake
+          ln -s ${{ runner.workspace }}/hdf5/HDF5config.cmake ${{ github.workspace }}/${{ steps.set-file-base.outputs.SOURCE_BASE }}/config/cmake/scripts/HDF5config.cmake
 
       - name: List files for the hdf5 (OpenMPI)
         run: |
@@ -237,8 +237,8 @@ jobs:
 
       - name: Copy script files for the space (MPICH)
         run: |
-          cp ${{ github.workspace }}/${{ steps.set-file-base.outputs.SOURCE_BASE }}/config/cmake/scripts/CTestScript.cmake ${{ runner.workspace }}/hdf5
-          cp ${{ github.workspace }}/${{ steps.set-file-base.outputs.SOURCE_BASE }}/config/cmake/scripts/HDF5config.cmake ${{ runner.workspace }}/hdf5
+          ln -s  ${{ runner.workspace }}/hdf5//CTestScript.cmake ${{ github.workspace }}/${{ steps.set-file-base.outputs.SOURCE_BASE }}/config/cmake/scripts/CTestScript.cmake
+          ln -s ${{ runner.workspace }}/hdf5/HDF5config.cmake ${{ github.workspace }}/${{ steps.set-file-base.outputs.SOURCE_BASE }}/config/cmake/scripts/HDF5config.cmake
 
       - name: List files for the hdf5 (MPICH)
         run: |

--- a/.github/workflows/script.yml
+++ b/.github/workflows/script.yml
@@ -97,8 +97,8 @@ jobs:
 
       - name: Copy script files for the space (Windows)
         run: |
-          Copy-Item -Path ${{ runner.workspace }}/hdf5/${{ steps.set-file-base.outputs.SOURCE_BASE }}/config/cmake/scripts/CTestScript.cmake -Destination ${{ runner.workspace }}/hdf5/
-          Copy-Item -Path ${{ runner.workspace }}/hdf5/${{ steps.set-file-base.outputs.SOURCE_BASE }}/config/cmake/scripts/HDF5config.cmake -Destination ${{ runner.workspace }}/hdf5/
+          New-Item -ItemType SymbolicLink -Path ${{ runner.workspace }}/hdf5/CTestScript.cmake -Target ${{ github.workspace }}/${{ steps.set-file-base.outputs.SOURCE_BASE }}/config/cmake/scripts/CTestScript.cmake
+          New-Item -ItemType SymbolicLink -Path ${{ runner.workspace }}/hdf5/HDF5config.cmake -Target ${{ github.workspace }}/${{ steps.set-file-base.outputs.SOURCE_BASE }}/config/cmake/scripts/HDF5config.cmake
         shell: pwsh
 
       - name: List files for the hdf5 (Windows)
@@ -197,8 +197,8 @@ jobs:
 
       - name: Copy script files for the space (Linux)
         run: |
-          cp ${{ github.workspace }}/${{ steps.set-file-base.outputs.SOURCE_BASE }}/config/cmake/scripts/CTestScript.cmake ${{ runner.workspace }}/hdf5
-          cp ${{ github.workspace }}/${{ steps.set-file-base.outputs.SOURCE_BASE }}/config/cmake/scripts/HDF5config.cmake ${{ runner.workspace }}/hdf5
+          ln -s  ${{ runner.workspace }}/hdf5//CTestScript.cmake ${{ github.workspace }}/${{ steps.set-file-base.outputs.SOURCE_BASE }}/config/cmake/scripts/CTestScript.cmake
+          ln -s ${{ runner.workspace }}/hdf5/HDF5config.cmake ${{ github.workspace }}/${{ steps.set-file-base.outputs.SOURCE_BASE }}/config/cmake/scripts/HDF5config.cmake
 
       - name: List files for the hdf5 (Linux)
         run: |
@@ -311,8 +311,8 @@ jobs:
 
       - name: Copy script files for the space (MacOS_latest)
         run: |
-          cp ${{ github.workspace }}/${{ steps.set-file-base.outputs.SOURCE_BASE }}/config/cmake/scripts/CTestScript.cmake ${{ runner.workspace }}/hdf5
-          cp ${{ github.workspace }}/${{ steps.set-file-base.outputs.SOURCE_BASE }}/config/cmake/scripts/HDF5config.cmake ${{ runner.workspace }}/hdf5
+          ln -s  ${{ runner.workspace }}/hdf5//CTestScript.cmake ${{ github.workspace }}/${{ steps.set-file-base.outputs.SOURCE_BASE }}/config/cmake/scripts/CTestScript.cmake
+          ln -s ${{ runner.workspace }}/hdf5/HDF5config.cmake ${{ github.workspace }}/${{ steps.set-file-base.outputs.SOURCE_BASE }}/config/cmake/scripts/HDF5config.cmake
 
       # symlinks the compiler executables to a common location 
       - name: Setup GNU Fortran
@@ -432,8 +432,8 @@ jobs:
 
       - name: Copy script files for the space (Linux S3)
         run: |
-          cp ${{ github.workspace }}/${{ steps.set-file-base.outputs.SOURCE_BASE }}/config/cmake/scripts/CTestScript.cmake ${{ runner.workspace }}/hdf5
-          cp ${{ github.workspace }}/${{ steps.set-file-base.outputs.SOURCE_BASE }}/config/cmake/scripts/HDF5config.cmake ${{ runner.workspace }}/hdf5
+          ln -s  ${{ runner.workspace }}/hdf5//CTestScript.cmake ${{ github.workspace }}/${{ steps.set-file-base.outputs.SOURCE_BASE }}/config/cmake/scripts/CTestScript.cmake
+          ln -s ${{ runner.workspace }}/hdf5/HDF5config.cmake ${{ github.workspace }}/${{ steps.set-file-base.outputs.SOURCE_BASE }}/config/cmake/scripts/HDF5config.cmake
 
       - name: List files for the hdf5 (Linux S3)
         run: |
@@ -539,8 +539,8 @@ jobs:
 
       - name: Copy script files for the space (Windows_intel)
         run: |
-          Copy-Item -Path ${{ runner.workspace }}/hdf5/${{ steps.set-file-base.outputs.SOURCE_BASE }}/config/cmake/scripts/CTestScript.cmake -Destination ${{ runner.workspace }}/hdf5/
-          Copy-Item -Path ${{ runner.workspace }}/hdf5/${{ steps.set-file-base.outputs.SOURCE_BASE }}/config/cmake/scripts/HDF5config.cmake -Destination ${{ runner.workspace }}/hdf5/
+          New-Item -ItemType SymbolicLink -Path ${{ runner.workspace }}/hdf5/CTestScript.cmake -Target ${{ github.workspace }}/${{ steps.set-file-base.outputs.SOURCE_BASE }}/config/cmake/scripts/CTestScript.cmake
+          New-Item -ItemType SymbolicLink -Path ${{ runner.workspace }}/hdf5/HDF5config.cmake -Target ${{ github.workspace }}/${{ steps.set-file-base.outputs.SOURCE_BASE }}/config/cmake/scripts/HDF5config.cmake
         shell: pwsh
 
       - name: List files for the hdf5 (Windows_intel)
@@ -646,8 +646,8 @@ jobs:
 
       - name: Copy script files for the space (Linux_intel)
         run: |
-          cp ${{ github.workspace }}/${{ steps.set-file-base.outputs.SOURCE_BASE }}/config/cmake/scripts/CTestScript.cmake ${{ runner.workspace }}/hdf5
-          cp ${{ github.workspace }}/${{ steps.set-file-base.outputs.SOURCE_BASE }}/config/cmake/scripts/HDF5config.cmake ${{ runner.workspace }}/hdf5
+          ln -s  ${{ runner.workspace }}/hdf5//CTestScript.cmake ${{ github.workspace }}/${{ steps.set-file-base.outputs.SOURCE_BASE }}/config/cmake/scripts/CTestScript.cmake
+          ln -s ${{ runner.workspace }}/hdf5/HDF5config.cmake ${{ github.workspace }}/${{ steps.set-file-base.outputs.SOURCE_BASE }}/config/cmake/scripts/HDF5config.cmake
 
       - name: List files for the hdf5 (Linux_Linux)
         run: |
@@ -762,8 +762,8 @@ jobs:
 
       - name: Copy script files for the space (Linux_clang)
         run: |
-          cp ${{ github.workspace }}/${{ steps.set-file-base.outputs.SOURCE_BASE }}/config/cmake/scripts/CTestScript.cmake ${{ runner.workspace }}/hdf5
-          cp ${{ github.workspace }}/${{ steps.set-file-base.outputs.SOURCE_BASE }}/config/cmake/scripts/HDF5config.cmake ${{ runner.workspace }}/hdf5
+          ln -s  ${{ runner.workspace }}/hdf5//CTestScript.cmake ${{ github.workspace }}/${{ steps.set-file-base.outputs.SOURCE_BASE }}/config/cmake/scripts/CTestScript.cmake
+          ln -s ${{ runner.workspace }}/hdf5/HDF5config.cmake ${{ github.workspace }}/${{ steps.set-file-base.outputs.SOURCE_BASE }}/config/cmake/scripts/HDF5config.cmake
 
       - name: List files for the hdf5 (Linux_clang)
         run: |

--- a/.github/workflows/script.yml
+++ b/.github/workflows/script.yml
@@ -36,6 +36,11 @@ jobs:
     name: "Windows MSVC CTest"
     runs-on: windows-latest
     steps:
+      - name: Get Actions
+        uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
+        with:
+          sparse-checkout: .github/actions
+
       - name: Install Dependencies (Windows)
         run: choco install ninja
 
@@ -95,11 +100,10 @@ jobs:
         run: 7z x ${{ steps.set-file-base.outputs.FILE_BASE }}.zip
         shell: bash
 
-      - name: Copy script files for the space (Windows)
-        run: |
-          New-Item -ItemType SymbolicLink -Path ${{ runner.workspace }}/hdf5/CTestScript.cmake -Target ${{ github.workspace }}/${{ steps.set-file-base.outputs.SOURCE_BASE }}/config/cmake/scripts/CTestScript.cmake
-          New-Item -ItemType SymbolicLink -Path ${{ runner.workspace }}/hdf5/HDF5config.cmake -Target ${{ github.workspace }}/${{ steps.set-file-base.outputs.SOURCE_BASE }}/config/cmake/scripts/HDF5config.cmake
-        shell: pwsh
+      - name: Symlink script files for the space (Windows)
+        uses: ./.github/actions/symlink-ctest-scripts
+        with:
+          source-base: ${{ steps.set-file-base.outputs.SOURCE_BASE }}
 
       - name: List files for the hdf5 (Windows)
         run: |
@@ -151,6 +155,11 @@ jobs:
     name: "Ubuntu gcc"
     runs-on: ubuntu-latest
     steps:
+      - name: Get Actions
+        uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
+        with:
+          sparse-checkout: .github/actions
+
       - name: Install Dependencies (Linux)
         run: |
           sudo apt-get update
@@ -195,10 +204,10 @@ jobs:
       - name: Uncompress source (Linux)
         run: tar -zxvf ${{ github.workspace }}/${{ steps.set-file-base.outputs.FILE_BASE }}.tar.gz
 
-      - name: Copy script files for the space (Linux)
-        run: |
-          ln -s  ${{ runner.workspace }}/hdf5//CTestScript.cmake ${{ github.workspace }}/${{ steps.set-file-base.outputs.SOURCE_BASE }}/config/cmake/scripts/CTestScript.cmake
-          ln -s ${{ runner.workspace }}/hdf5/HDF5config.cmake ${{ github.workspace }}/${{ steps.set-file-base.outputs.SOURCE_BASE }}/config/cmake/scripts/HDF5config.cmake
+      - name: Symlink script files for the space (Linux)
+        uses: ./.github/actions/symlink-ctest-scripts
+        with:
+          source-base: ${{ steps.set-file-base.outputs.SOURCE_BASE }}
 
       - name: List files for the hdf5 (Linux)
         run: |
@@ -249,6 +258,11 @@ jobs:
     name: "MacOS Clang"
     runs-on: macos-latest
     steps:
+      - name: Get Actions
+        uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
+        with:
+          sparse-checkout: .github/actions
+
       - name: Install Dependencies (MacOS_latest)
         run: brew install ninja curl
 
@@ -309,10 +323,10 @@ jobs:
       - name: Uncompress source (MacOS_latest)
         run: tar -zxvf ${{ github.workspace }}/${{ steps.set-file-base.outputs.FILE_BASE }}.tar.gz
 
-      - name: Copy script files for the space (MacOS_latest)
-        run: |
-          ln -s  ${{ runner.workspace }}/hdf5//CTestScript.cmake ${{ github.workspace }}/${{ steps.set-file-base.outputs.SOURCE_BASE }}/config/cmake/scripts/CTestScript.cmake
-          ln -s ${{ runner.workspace }}/hdf5/HDF5config.cmake ${{ github.workspace }}/${{ steps.set-file-base.outputs.SOURCE_BASE }}/config/cmake/scripts/HDF5config.cmake
+      - name: Symlink script files for the space (MacOS_latest)
+        uses: ./.github/actions/symlink-ctest-scripts
+        with:
+          source-base: ${{ steps.set-file-base.outputs.SOURCE_BASE }}
 
       # symlinks the compiler executables to a common location 
       - name: Setup GNU Fortran
@@ -372,6 +386,11 @@ jobs:
     name: "Ubuntu gcc S3"
     runs-on: ubuntu-latest
     steps:
+      - name: Get Actions
+        uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
+        with:
+          sparse-checkout: .github/actions
+
       - name: Install Dependencies (Linux S3)
         run: |
           sudo apt-get update
@@ -430,10 +449,10 @@ jobs:
       - name: Uncompress source (Linux S3)
         run: tar -zxvf ${{ github.workspace }}/${{ steps.set-file-base.outputs.FILE_BASE }}.tar.gz
 
-      - name: Copy script files for the space (Linux S3)
-        run: |
-          ln -s  ${{ runner.workspace }}/hdf5//CTestScript.cmake ${{ github.workspace }}/${{ steps.set-file-base.outputs.SOURCE_BASE }}/config/cmake/scripts/CTestScript.cmake
-          ln -s ${{ runner.workspace }}/hdf5/HDF5config.cmake ${{ github.workspace }}/${{ steps.set-file-base.outputs.SOURCE_BASE }}/config/cmake/scripts/HDF5config.cmake
+      - name: Symlink script files for the space (Linux S3)
+        uses: ./.github/actions/symlink-ctest-scripts
+        with:
+          source-base: ${{ steps.set-file-base.outputs.SOURCE_BASE }}
 
       - name: List files for the hdf5 (Linux S3)
         run: |
@@ -485,6 +504,11 @@ jobs:
     name: "Windows Intel CTest"
     runs-on: windows-latest
     steps:
+      - name: Get Actions
+        uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
+        with:
+          sparse-checkout: .github/actions
+
       - name: Install Dependencies (Windows_intel)
         run: choco install ninja
 
@@ -537,11 +561,10 @@ jobs:
         run: 7z x ${{ steps.set-file-base.outputs.FILE_BASE }}.zip
         shell: bash
 
-      - name: Copy script files for the space (Windows_intel)
-        run: |
-          New-Item -ItemType SymbolicLink -Path ${{ runner.workspace }}/hdf5/CTestScript.cmake -Target ${{ github.workspace }}/${{ steps.set-file-base.outputs.SOURCE_BASE }}/config/cmake/scripts/CTestScript.cmake
-          New-Item -ItemType SymbolicLink -Path ${{ runner.workspace }}/hdf5/HDF5config.cmake -Target ${{ github.workspace }}/${{ steps.set-file-base.outputs.SOURCE_BASE }}/config/cmake/scripts/HDF5config.cmake
-        shell: pwsh
+      - name: Symlink script files for the space (Windows_intel)
+        uses: ./.github/actions/symlink-ctest-scripts
+        with:
+          source-base: ${{ steps.set-file-base.outputs.SOURCE_BASE }}
 
       - name: List files for the hdf5 (Windows_intel)
         run: |
@@ -598,6 +621,11 @@ jobs:
     name: "Ubuntu Intel"
     runs-on: ubuntu-latest
     steps:
+      - name: Get Actions
+        uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
+        with:
+          sparse-checkout: .github/actions
+
       - name: Install Dependencies (Linux_intel)
         run: |
           sudo apt-get update
@@ -644,10 +672,10 @@ jobs:
       - name: Uncompress source (Linux_intel)
         run: tar -zxvf ${{ github.workspace }}/${{ steps.set-file-base.outputs.FILE_BASE }}.tar.gz
 
-      - name: Copy script files for the space (Linux_intel)
-        run: |
-          ln -s  ${{ runner.workspace }}/hdf5//CTestScript.cmake ${{ github.workspace }}/${{ steps.set-file-base.outputs.SOURCE_BASE }}/config/cmake/scripts/CTestScript.cmake
-          ln -s ${{ runner.workspace }}/hdf5/HDF5config.cmake ${{ github.workspace }}/${{ steps.set-file-base.outputs.SOURCE_BASE }}/config/cmake/scripts/HDF5config.cmake
+      - name: Symlink script files for the space (Linux_intel)
+        uses: ./.github/actions/symlink-ctest-scripts
+        with:
+          source-base: ${{ steps.set-file-base.outputs.SOURCE_BASE }}
 
       - name: List files for the hdf5 (Linux_Linux)
         run: |
@@ -702,6 +730,11 @@ jobs:
     name: "Ubuntu Clang"
     runs-on: ubuntu-22.04
     steps:
+      - name: Get Actions
+        uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
+        with:
+          sparse-checkout: .github/actions
+
       - name: Install Dependencies (Linux_clang)
         run: |
           sudo apt-get update
@@ -760,10 +793,10 @@ jobs:
       - name: Uncompress source (Linux_clang)
         run: tar -zxvf ${{ github.workspace }}/${{ steps.set-file-base.outputs.FILE_BASE }}.tar.gz
 
-      - name: Copy script files for the space (Linux_clang)
-        run: |
-          ln -s  ${{ runner.workspace }}/hdf5//CTestScript.cmake ${{ github.workspace }}/${{ steps.set-file-base.outputs.SOURCE_BASE }}/config/cmake/scripts/CTestScript.cmake
-          ln -s ${{ runner.workspace }}/hdf5/HDF5config.cmake ${{ github.workspace }}/${{ steps.set-file-base.outputs.SOURCE_BASE }}/config/cmake/scripts/HDF5config.cmake
+      - name: Symlink script files for the space (Linux_clang)
+        uses: ./.github/actions/symlink-ctest-scripts
+        with:
+          source-base: ${{ steps.set-file-base.outputs.SOURCE_BASE }}
 
       - name: List files for the hdf5 (Linux_clang)
         run: |

--- a/.github/workflows/script.yml
+++ b/.github/workflows/script.yml
@@ -700,7 +700,7 @@ jobs:
   # Linux (Ubuntu) w/ clang
   #
     name: "Ubuntu Clang"
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     steps:
       - name: Install Dependencies (Linux_clang)
         run: |


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Update CI workflows to use symbolic links instead of copying files to re-enable GitHub daily tests.
> 
>   - **Workflows**:
>     - Update `analysis.yml`, `cygwin.yml`, and `par-script.yml` to use symbolic links instead of copying `CTestScript.cmake` and `HDF5config.cmake`.
>     - Update `par-source.yml` and `script.yml` similarly to use symbolic links for the same files.
>   - **Commands**:
>     - Replace `cp` with `ln -s` in Linux workflows.
>     - Replace `Copy-Item` with `New-Item -ItemType SymbolicLink` in Windows workflows.
>   - **Purpose**:
>     - Re-enable GitHub daily tests by ensuring consistent file handling across workflows.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=HDFGroup%2Fhdf5&utm_source=github&utm_medium=referral)<sup> for 519cdec7f84b0d12701beb42f4ab655eccfbf3e1. You can [customize](https://app.ellipsis.dev/HDFGroup/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->