### PR TITLE
Inherit Debug C build flags in Developer build mode

### DIFF
--- a/config/cmake/HDF5DeveloperBuild.cmake
+++ b/config/cmake/HDF5DeveloperBuild.cmake
@@ -12,19 +12,25 @@
 
 # CMake settings for HDF5 Developer mode builds
 
-# Set CMake C++ flags based off of Debug build flags
+# Set initial CMake Developer build C flags based off of Debug build flags
+set (CMAKE_C_FLAGS_DEVELOPER "${CMAKE_C_FLAGS_DEBUG}" CACHE STRING
+  "Flags used by the C compiler during developer builds." FORCE
+)
+
+# Set initial CMake Developer build C++ flags based off of Debug build flags
 set (CMAKE_CXX_FLAGS_DEVELOPER ${CMAKE_CXX_FLAGS_DEBUG} CACHE STRING
   "Flags used by the C++ compiler during developer builds." FORCE
 )
 
-# Set CMake binary linker flags based off of Debug binary linker flags
+# Set initial CMake Developer build binary linker flags based off of Debug
+# binary linker flags
 set (CMAKE_EXE_LINKER_FLAGS_DEVELOPER ${CMAKE_EXE_LINKER_FLAGS_DEBUG}
   CACHE STRING "Flags used for linking binaries during developer builds."
   FORCE
 )
 
-# Set CMake shared library linker flags based off of Debug shared library
-# linker flags
+# Set initial CMake Developer build shared library linker flags based off
+# of Debug shared library linker flags
 set (CMAKE_SHARED_LINKER_FLAGS_DEVELOPER ${CMAKE_SHARED_LINKER_FLAGS_DEBUG}
   CACHE STRING "Flags used by the shared libraries linker during developer builds."
   FORCE


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Inherit Debug build flags for Developer build mode in `HDF5DeveloperBuild.cmake`.
> 
>   - **CMake Configuration**:
>     - In `HDF5DeveloperBuild.cmake`, set `CMAKE_C_FLAGS_DEVELOPER` to inherit from `CMAKE_C_FLAGS_DEBUG`.
>     - Set `CMAKE_CXX_FLAGS_DEVELOPER` to inherit from `CMAKE_CXX_FLAGS_DEBUG`.
>     - Set `CMAKE_EXE_LINKER_FLAGS_DEVELOPER` and `CMAKE_SHARED_LINKER_FLAGS_DEVELOPER` to inherit from their Debug equivalents.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=HDFGroup%2Fhdf5&utm_source=github&utm_medium=referral)<sup> for 45968924febb5c49402fe315900dac9938672b84. You can [customize](https://app.ellipsis.dev/HDFGroup/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->