### PR TITLE
Adds RFCs to the RFC table

### DIFF
--- a/doxygen/aliases
+++ b/doxygen/aliases
@@ -279,7 +279,6 @@ ALIASES += ref_vol_doc="VOL documentation"
 # RFCs
 ################################################################################
 
-ALIASES += ref_rfc20250114="<a href=\"https://\RFCWIP/HDF5_Library/Signed_Plugins/RFC-signed-plugins-v1.pdf\">Adding support for digitally signed plugins to HDF5</a>"
 ALIASES += ref_rfc20240422="<a href=\"https://\RFCWIP/HDF5_Library/WriteAheadLog/RFC_WriteAheadLog.pdf\">Write-Ahead Log</a>"
 ALIASES += ref_rfc20240129="<a href=\"https://\RFCURL/RFC__Adding_support_for_16_bit_floating_point_and_Complex_number_datatypes_to_HDF5.pdf\">Adding support for 16-bit floating point and Complex number datatypes to HDF</a>"
 # Same RFC, but complex number datatypes was delayed to 2.0

--- a/doxygen/aliases
+++ b/doxygen/aliases
@@ -16,6 +16,7 @@ ALIASES += DWNURL="\RELURL/downloads/latest"
 # URL for RFCs
 ALIASES += RFCURL="\DOCURL/rfc"
 ALIASES += AEXURL="\HDFURL/archive/support/ftp/HDF5/examples"
+ALIASES += RFCWIP="github.com/HDFGroup/hdf5doc/tree/master/RFCs"
 #branch name (develop, hdf5_2_0_0)
 ALIASES += SRCURL="github.com/HDFGroup/hdf5/blob/develop"
 ALIASES += SRCURL114="github.com/HDFGroup/hdf5/blob/hdf5_1.14.6"
@@ -278,6 +279,8 @@ ALIASES += ref_vol_doc="VOL documentation"
 # RFCs
 ################################################################################
 
+ALIASES += ref_rfc20250114="<a href=\"https://\RFCWIP/HDF5_Library/Signed_Plugins/RFC-signed-plugins-v1.pdf\">Adding support for digitally signed plugins to HDF5</a>"
+ALIASES += ref_rfc20240422="<a href=\"https://\RFCWIP/HDF5_Library/WriteAheadLog/RFC_WriteAheadLog.pdf\">Write-Ahead Log</a>"
 ALIASES += ref_rfc20240129="<a href=\"https://\RFCURL/RFC__Adding_support_for_16_bit_floating_point_and_Complex_number_datatypes_to_HDF5.pdf\">Adding support for 16-bit floating point and Complex number datatypes to HDF</a>"
 # Same RFC, but complex number datatypes was delayed to 2.0
 ALIASES += ref_rfc20240129complex="<a href=\"https://\RFCURL/RFC__Adding_support_for_16_bit_floating_point_and_Complex_number_datatypes_to_HDF5.pdf\">Support for Complex number datatypes</a>"

--- a/doxygen/dox/RFC.dox
+++ b/doxygen/dox/RFC.dox
@@ -5,7 +5,7 @@ Navigate back: \ref index "Main"
 
 <table>
 <tr><th>RFC ID</th><th>Title</th></tr>
-<tr> <td>2025-01-14</td> <td>\ref_rfc20250114</td></tr>
+<tr> <td>2025-11-15</td> <td>https://dl.acm.org/doi/full/10.1145/3731599.3767557</td></tr>
 <tr> <td>2024-04-22</td> <td>\ref_rfc20240422</td></tr>
 <tr> <td>2022-08-19</td> <td>\ref_rfc20220819</td></tr>
 <tr> <td>2021-05-28</td> <td>\ref_rfc20210528</td></tr>

--- a/doxygen/dox/RFC.dox
+++ b/doxygen/dox/RFC.dox
@@ -5,6 +5,8 @@ Navigate back: \ref index "Main"
 
 <table>
 <tr><th>RFC ID</th><th>Title</th></tr>
+<tr> <td>2025-01-14</td> <td>\ref_rfc20250114</td></tr>
+<tr> <td>2024-04-22</td> <td>\ref_rfc20240422</td></tr>
 <tr> <td>2022-08-19</td> <td>\ref_rfc20220819</td></tr>
 <tr> <td>2021-05-28</td> <td>\ref_rfc20210528</td></tr>
 <tr> <td>2021-02-19</td> <td>\ref_rfc20210219</td></tr>


### PR DESCRIPTION
These two RFCs are now in the RFC table:
"Adding support for digitally signed plugins to HDF5"
" Write-Ahead log"

Fixes #6186 and fixes #6185
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Add two new RFCs to the documentation: "Adding support for digitally signed plugins to HDF5" and "Write-Ahead Log".
> 
>   - **RFC Additions**:
>     - Added RFC "Adding support for digitally signed plugins to HDF5" with ID `2025-01-14` in `aliases` and `RFC.dox`.
>     - Added RFC "Write-Ahead Log" with ID `2024-04-22` in `aliases` and `RFC.dox`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=HDFGroup%2Fhdf5&utm_source=github&utm_medium=referral)<sup> for 527f30690f742e7f3910e9d32ffaccd815efc76c. You can [customize](https://app.ellipsis.dev/HDFGroup/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->