### PR TITLE
Update workflow versions

### DIFF
--- a/.github/workflows/abi-report.yml
+++ b/.github/workflows/abi-report.yml
@@ -84,7 +84,7 @@ jobs:
         run: |
           mkdir "${{ github.workspace }}/hdf5R"
           cd "${{ github.workspace }}/hdf5R"
-          wget -q https://github.com/HDFGroup/hdf5/releases/download/hdf5_${{ inputs.file_ref }}/hdf5-${{ steps.convert-hdf5lib-refname.outputs.HDF5R_DOTS }}-ubuntu-2404_gcc.tar.gz
+          wget -q https://github.com/HDFGroup/hdf5/releases/download/${{ inputs.file_ref }}/hdf5-${{ steps.convert-hdf5lib-refname.outputs.HDF5R_DOTS }}-ubuntu-2404_gcc.tar.gz
           tar zxf hdf5-${{ steps.convert-hdf5lib-refname.outputs.HDF5R_DOTS }}-ubuntu-2404_gcc.tar.gz
 
       - name: List files for the space (Linux)

--- a/.github/workflows/daily-build.yml
+++ b/.github/workflows/daily-build.yml
@@ -159,7 +159,8 @@ jobs:
     needs: [get-old-names, call-workflow-tarball, call-workflow-ctest]
     uses: ./.github/workflows/abi-report.yml
     with:
-      file_ref: '1.14.5'
+      # previous release version
+      file_ref: '2.0.0'
       file_base: ${{ needs.call-workflow-tarball.outputs.file_base }}
       use_tag: snapshot
       use_environ: snapshots

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -5,7 +5,7 @@ on:
   workflow_dispatch:
     inputs:
       use_tag:
-        description: HDF5 Release version tag (e.g., v1.14.0)
+        description: HDF5 Release version tag (e.g., 2.0.0)
         type: string
         required: true
       file_name:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -82,7 +82,8 @@ jobs:
     needs: [log-the-inputs, call-workflow-tarball, call-workflow-ctest]
     uses: ./.github/workflows/abi-report.yml
     with:
-      file_ref: '1.14.5'
+      # previous release version
+      file_ref: '2.0.0'
       file_base: ${{ needs.call-workflow-tarball.outputs.file_base }}
       use_tag: ${{ needs.log-the-inputs.outputs.rel_tag }}
       use_environ: release

--- a/.github/workflows/test-binary-installation.yml
+++ b/.github/workflows/test-binary-installation.yml
@@ -12,7 +12,7 @@ on:
         description: 'Maven artifact version to test'
         type: string
         required: true
-        default: '2.0.0-SNAPSHOT'
+        default: '2.1.0-SNAPSHOT'
       maven_repository:
         description: 'Maven repository URL'
         type: string

--- a/.github/workflows/test-maven-deployment.yml
+++ b/.github/workflows/test-maven-deployment.yml
@@ -96,7 +96,7 @@ jobs:
           # Compile and create JAR
           cd temp-jar
           javac org/hdfgroup/test/TestClass.java
-          jar cf ../test-artifacts/maven-staging-artifacts-linux-x86_64/jarhdf5-2.0.0-test.jar org/hdfgroup/test/TestClass.class
+          jar cf ../test-artifacts/maven-staging-artifacts-linux-x86_64/jarhdf5-2.1.0-test.jar org/hdfgroup/test/TestClass.class
           cd ..
 
           # Create a test POM file
@@ -108,7 +108,7 @@ jobs:
               <modelVersion>4.0.0</modelVersion>
               <groupId>org.hdfgroup</groupId>
               <artifactId>hdf5-java</artifactId>
-              <version>2.0.0-test</version>
+              <version>2.1.0-test</version>
               <name>HDF5 Java Test</name>
               <description>Test artifact for HDF5 Java Maven deployment</description>
           </project>

--- a/.github/workflows/test-maven-packages.yml
+++ b/.github/workflows/test-maven-packages.yml
@@ -29,7 +29,7 @@ on:
         description: 'Maven artifact version to test'
         type: string
         required: true
-        default: '2.0.0-SNAPSHOT'
+        default: '2.1.0-SNAPSHOT'
       java_implementation:
         description: 'Java implementation(s) to test'
         type: choice


### PR DESCRIPTION
Updated to run abi compatibility against the 2.0.0 binary, and to test the current 2.1.0 version where appropriate.  These should be updated to be automated, but it will take some work, so I'll create an issue for changes in develop.
<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Update workflow files to test against new software versions, specifically updating to version 2.1.0 where applicable, and maintain compatibility checks with version 2.0.0.
> 
>   - **Version Updates**:
>     - Update `file_ref` to '2.0.0' in `daily-build.yml` and `release.yml` for ABI compatibility checks.
>     - Update default `maven_version` to '2.1.0-SNAPSHOT' in `test-binary-installation.yml` and `test-maven-packages.yml`.
>     - Update Maven artifact version to '2.1.0-test' in `test-maven-deployment.yml`.
>   - **Workflow Changes**:
>     - Modify `wget` command in `abi-report.yml` to remove redundant path segment.
>     - Update `use_tag` description in `publish-release.yml` to reflect new version format.
>   - **Miscellaneous**:
>     - Minor comment updates in `publish-release.yml` and `release.yml` to reflect version changes.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=HDFGroup%2Fhdf5&utm_source=github&utm_medium=referral)<sup> for 4d3648e3142676dd08f27c195d3c1ba8306bb178. You can [customize](https://app.ellipsis.dev/HDFGroup/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->