### PR TITLE
Fix MPI Fortran configuration for HDF5Examples

### DIFF
--- a/HDF5Examples/CMakeLists.txt
+++ b/HDF5Examples/CMakeLists.txt
@@ -143,10 +143,12 @@ if (${H5_LIBVER_DIR} GREATER 16)
   if (EXISTS "${H5EXAMPLES_SOURCE_DIR}/FORTRAN" AND IS_DIRECTORY "${H5EXAMPLES_SOURCE_DIR}/FORTRAN")
     option (H5EXAMPLE_BUILD_FORTRAN "Build examples FORTRAN support" OFF)
     if (H5EXAMPLE_BUILD_FORTRAN AND HDF5_PROVIDES_FORTRAN)
+      enable_language(Fortran)
       set (H5EXAMPLE_LINK_Fortran_LIBS ${H5EXAMPLE_HDF5_LINK_LIBS})
 
       # Parallel IO usage requires MPI to be Linked and Included
       if (H5_HAVE_PARALLEL)
+        find_package(MPI REQUIRED COMPONENTS Fortran)
         set (H5EXAMPLE_LINK_Fortran_LIBS ${H5EXAMPLE_LINK_Fortran_LIBS} ${MPI_Fortran_LIBRARIES})
         if (MPI_Fortran_LINK_FLAGS)
           set (CMAKE_Fortran_EXE_LINKER_FLAGS "${MPI_Fortran_LINK_FLAGS} ${CMAKE_EXE_LINKER_FLAGS}")


### PR DESCRIPTION
When building Fortran parallel examples without MPI wrappers, the compiler couldn't find mpi.mod because MPI_Fortran_INCLUDE_DIRS was not populated. This occurred because find_package(MPI) was only called for C, not Fortran.

Added enable_language(Fortran) and find_package(MPI REQUIRED COMPONENTS Fortran) to properly configure MPI for Fortran examples, ensuring MPI include directories and libraries are correctly set.

Fixes #6205, Fixes #6175

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fixes MPI Fortran configuration in `HDF5Examples/CMakeLists.txt` to ensure proper setup for Fortran parallel examples.
> 
>   - **Configuration**:
>     - Add `enable_language(Fortran)` in `HDF5Examples/CMakeLists.txt` to support Fortran examples.
>     - Add `find_package(MPI REQUIRED COMPONENTS Fortran)` to ensure MPI Fortran components are configured.
>   - **Behavior**:
>     - Fixes issue where `mpi.mod` was not found due to unpopulated `MPI_Fortran_INCLUDE_DIRS`.
>     - Ensures MPI include directories and libraries are set for Fortran parallel examples.
>   - **Issues Fixed**:
>     - Fixes #6205, Fixes #6175.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=HDFGroup%2Fhdf5&utm_source=github&utm_medium=referral)<sup> for cb3093174d4dd8c64f4ea1cb2d2761a40800699d. You can [customize](https://app.ellipsis.dev/HDFGroup/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->