### PR TITLE
Revert "Fix MPI Fortran configuration for HDF5Examples"

### DIFF
--- a/HDF5Examples/CMakeLists.txt
+++ b/HDF5Examples/CMakeLists.txt
@@ -143,12 +143,10 @@ if (${H5_LIBVER_DIR} GREATER 16)
   if (EXISTS "${H5EXAMPLES_SOURCE_DIR}/FORTRAN" AND IS_DIRECTORY "${H5EXAMPLES_SOURCE_DIR}/FORTRAN")
     option (H5EXAMPLE_BUILD_FORTRAN "Build examples FORTRAN support" OFF)
     if (H5EXAMPLE_BUILD_FORTRAN AND HDF5_PROVIDES_FORTRAN)
-      enable_language(Fortran)
       set (H5EXAMPLE_LINK_Fortran_LIBS ${H5EXAMPLE_HDF5_LINK_LIBS})
 
       # Parallel IO usage requires MPI to be Linked and Included
       if (H5_HAVE_PARALLEL)
-        find_package(MPI REQUIRED COMPONENTS Fortran)
         set (H5EXAMPLE_LINK_Fortran_LIBS ${H5EXAMPLE_LINK_Fortran_LIBS} ${MPI_Fortran_LIBRARIES})
         if (MPI_Fortran_LINK_FLAGS)
           set (CMAKE_Fortran_EXE_LINKER_FLAGS "${MPI_Fortran_LINK_FLAGS} ${CMAKE_EXE_LINKER_FLAGS}")


### PR DESCRIPTION
Reverts HDFGroup/hdf5#6206
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Reverts MPI Fortran configuration changes in `HDF5Examples/CMakeLists.txt`, affecting Fortran examples build with MPI.
> 
>   - **Revert Changes**:
>     - Reverts `HDF5Examples/CMakeLists.txt` to remove `enable_language(Fortran)` and `find_package(MPI REQUIRED COMPONENTS Fortran)`.
>     - Affects Fortran examples build configuration with MPI.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=HDFGroup%2Fhdf5&utm_source=github&utm_medium=referral)<sup> for d32208d8da4081146e173d2065f856fd6419bbe7. You can [customize](https://app.ellipsis.dev/HDFGroup/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->