### PR TITLE
Updates to #6205

### DIFF
--- a/HDF5Examples/CMakeLists.txt
+++ b/HDF5Examples/CMakeLists.txt
@@ -143,12 +143,22 @@ if (${H5_LIBVER_DIR} GREATER 16)
   if (EXISTS "${H5EXAMPLES_SOURCE_DIR}/FORTRAN" AND IS_DIRECTORY "${H5EXAMPLES_SOURCE_DIR}/FORTRAN")
     option (H5EXAMPLE_BUILD_FORTRAN "Build examples FORTRAN support" OFF)
     if (H5EXAMPLE_BUILD_FORTRAN AND HDF5_PROVIDES_FORTRAN)
-      enable_language(Fortran)
+      # For standalone builds, enable Fortran and find MPI Fortran components.
+      # For inline builds, both are already handled by the parent HDF5 project.
+      if (NOT EXAMPLES_EXTERNALLY_CONFIGURED)
+        get_property (_languages GLOBAL PROPERTY ENABLED_LANGUAGES)
+        if (NOT "Fortran" IN_LIST _languages)
+          enable_language (Fortran)
+        endif ()
+      endif ()
+
       set (H5EXAMPLE_LINK_Fortran_LIBS ${H5EXAMPLE_HDF5_LINK_LIBS})
 
       # Parallel IO usage requires MPI to be Linked and Included
       if (H5_HAVE_PARALLEL)
-        find_package(MPI REQUIRED COMPONENTS Fortran)
+        if (NOT EXAMPLES_EXTERNALLY_CONFIGURED)
+          find_package(MPI REQUIRED COMPONENTS Fortran)
+        endif ()
         set (H5EXAMPLE_LINK_Fortran_LIBS ${H5EXAMPLE_LINK_Fortran_LIBS} ${MPI_Fortran_LIBRARIES})
         if (MPI_Fortran_LINK_FLAGS)
           set (CMAKE_Fortran_EXE_LINKER_FLAGS "${MPI_Fortran_LINK_FLAGS} ${CMAKE_EXE_LINKER_FLAGS}")

--- a/HDF5Examples/CMakeLists.txt
+++ b/HDF5Examples/CMakeLists.txt
@@ -215,6 +215,7 @@ endif ()
 # Build examples
 #-----------------------------------------------------------------------------
 add_subdirectory (C)
+# Fortran MPI setup (find_package, link flags) is handled in FORTRAN/CMakeLists.txt
 if (H5EXAMPLE_BUILD_FORTRAN AND HDF5_PROVIDES_FORTRAN)
   add_subdirectory (FORTRAN)
 endif ()

--- a/HDF5Examples/CMakeLists.txt
+++ b/HDF5Examples/CMakeLists.txt
@@ -143,27 +143,7 @@ if (${H5_LIBVER_DIR} GREATER 16)
   if (EXISTS "${H5EXAMPLES_SOURCE_DIR}/FORTRAN" AND IS_DIRECTORY "${H5EXAMPLES_SOURCE_DIR}/FORTRAN")
     option (H5EXAMPLE_BUILD_FORTRAN "Build examples FORTRAN support" OFF)
     if (H5EXAMPLE_BUILD_FORTRAN AND HDF5_PROVIDES_FORTRAN)
-      # For standalone builds, enable Fortran and find MPI Fortran components.
-      # For inline builds, both are already handled by the parent HDF5 project.
-      if (NOT EXAMPLES_EXTERNALLY_CONFIGURED)
-        get_property (_languages GLOBAL PROPERTY ENABLED_LANGUAGES)
-        if (NOT "Fortran" IN_LIST _languages)
-          enable_language (Fortran)
-        endif ()
-      endif ()
-
       set (H5EXAMPLE_LINK_Fortran_LIBS ${H5EXAMPLE_HDF5_LINK_LIBS})
-
-      # Parallel IO usage requires MPI to be Linked and Included
-      if (H5_HAVE_PARALLEL)
-        if (NOT EXAMPLES_EXTERNALLY_CONFIGURED)
-          find_package(MPI REQUIRED COMPONENTS Fortran)
-        endif ()
-        set (H5EXAMPLE_LINK_Fortran_LIBS ${H5EXAMPLE_LINK_Fortran_LIBS} ${MPI_Fortran_LIBRARIES})
-        if (MPI_Fortran_LINK_FLAGS)
-          set (CMAKE_Fortran_EXE_LINKER_FLAGS "${MPI_Fortran_LINK_FLAGS} ${CMAKE_EXE_LINKER_FLAGS}")
-        endif ()
-      endif ()
 
       configure_file (${H5EXAMPLE_F90_SRC_DIR}/H5D/h5_version.h.in ${PROJECT_BINARY_DIR}/FORTRAN/H5D/h5_version.h @ONLY)
       configure_file (${H5EXAMPLE_F90_SRC_DIR}/H5D/h5_version.h.in ${PROJECT_BINARY_DIR}/FORTRAN/H5G/h5_version.h @ONLY)

--- a/HDF5Examples/FORTRAN/CMakeLists.txt
+++ b/HDF5Examples/FORTRAN/CMakeLists.txt
@@ -2,13 +2,10 @@ cmake_minimum_required (VERSION 3.26)
 PROJECT (HDF5Examples_F90 Fortran)
 
 # Parallel IO usage requires MPI to be linked and included
-# Find MPI Fortran components to populate MPI_Fortran_LIBRARIES
 if (H5_HAVE_PARALLEL)
   find_package(MPI REQUIRED COMPONENTS Fortran)
-  set (H5EXAMPLE_LINK_Fortran_LIBS ${H5EXAMPLE_LINK_Fortran_LIBS} ${MPI_Fortran_LIBRARIES})
-  if (MPI_Fortran_LINK_FLAGS)
-    set (CMAKE_Fortran_EXE_LINKER_FLAGS "${MPI_Fortran_LINK_FLAGS} ${CMAKE_Fortran_EXE_LINKER_FLAGS}")
-  endif ()
+  # Use imported target — carries include dirs, compile flags, and link flags transitively
+  list(APPEND H5EXAMPLE_LINK_Fortran_LIBS MPI::MPI_Fortran)
 endif ()
 
 #-----------------------------------------------------------------------------

--- a/HDF5Examples/FORTRAN/CMakeLists.txt
+++ b/HDF5Examples/FORTRAN/CMakeLists.txt
@@ -1,6 +1,16 @@
 cmake_minimum_required (VERSION 3.26)
 PROJECT (HDF5Examples_F90 Fortran)
 
+# Parallel IO usage requires MPI to be linked and included
+# Find MPI Fortran components to populate MPI_Fortran_LIBRARIES
+if (H5_HAVE_PARALLEL)
+  find_package(MPI REQUIRED COMPONENTS Fortran)
+  set (H5EXAMPLE_LINK_Fortran_LIBS ${H5EXAMPLE_LINK_Fortran_LIBS} ${MPI_Fortran_LIBRARIES})
+  if (MPI_Fortran_LINK_FLAGS)
+    set (CMAKE_Fortran_EXE_LINKER_FLAGS "${MPI_Fortran_LINK_FLAGS} ${CMAKE_Fortran_EXE_LINKER_FLAGS}")
+  endif ()
+endif ()
+
 #-----------------------------------------------------------------------------
 # Build the Fortran Examples
 #-----------------------------------------------------------------------------

--- a/HDF5Examples/FORTRAN/H5PAR/CMakeLists.txt
+++ b/HDF5Examples/FORTRAN/H5PAR/CMakeLists.txt
@@ -30,7 +30,6 @@ foreach (example_name ${examples})
           "$<$<BOOL:${${EXAMPLE_VARNAME}_USE_114_API}>:-DH5_USE_114_API>"
           "$<$<BOOL:${${EXAMPLE_VARNAME}_USE_200_API}>:-DH5_USE_200_API>"
   )
-  target_include_directories (${EXAMPLE_VARNAME}_f90_${example_name} PUBLIC ${MPI_Fortran_INCLUDE_DIRS})
   target_link_libraries (${EXAMPLE_VARNAME}_f90_${example_name} ${H5EXAMPLE_LINK_Fortran_LIBS})
   set_target_properties (${EXAMPLE_VARNAME}_f90_${example_name} PROPERTIES LINKER_LANGUAGE Fortran)
 endforeach ()


### PR DESCRIPTION
Rework of the solution of #6205 
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Conditional Fortran support and MPI integration for Fortran in `CMakeLists.txt` based on HDF5 version and directory checks.
> 
>   - **Fortran Language Support**:
>     - Conditional enabling of Fortran language in `CMakeLists.txt` if `H5_LIBVER_DIR` is greater than 16 and Fortran directory exists.
>     - Adds `option` for `H5EXAMPLE_BUILD_FORTRAN` and checks `HDF5_PROVIDES_FORTRAN` before enabling Fortran.
>   - **MPI Integration**:
>     - Ensures `MPI` is linked for Fortran when `H5_HAVE_PARALLEL` is set in `CMakeLists.txt`.
>     - Uses `find_package(MPI REQUIRED COMPONENTS Fortran)` to include MPI Fortran libraries and link flags.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=HDFGroup%2Fhdf5&utm_source=github&utm_medium=referral)<sup> for 8962389d92e3c0a77fdd5e48aebbb9c99849f90e. You can [customize](https://app.ellipsis.dev/HDFGroup/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->