### PR TITLE
Update nvhpc version to 26.1 with CUDA version 13.1.

### DIFF
--- a/.github/workflows/nvhpc.yml
+++ b/.github/workflows/nvhpc.yml
@@ -20,9 +20,9 @@ jobs:
     name: "nvhpc ${{ inputs.build_mode }}"
     runs-on: ubuntu-latest
     env:
-      CUDAVERDOT: "13.0"
-      NVERDOT: "25.9"
-      NVERDASH: "25-9"
+      CUDAVERDOT: "13.1"
+      NVERDOT: "26.1"
+      NVERDASH: "26-1"
 
     steps:
       - name: Get Sources


### PR DESCRIPTION
# branches: [develop]
----
<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Update NVHPC to version 26.1 and CUDA to version 13.1 in GitHub Actions workflow.
> 
>   - **Environment Variables**:
>     - Update `CUDAVERDOT` to "13.1" in `.github/workflows/nvhpc.yml`.
>     - Update `NVERDOT` to "26.1" and `NVERDASH` to "26-1" in `.github/workflows/nvhpc.yml`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=HDFGroup%2Fhdf5&utm_source=github&utm_medium=referral)<sup> for 11c21027f573eb5e3492bf0e8bb6cf1fde52b291. You can [customize](https://app.ellipsis.dev/HDFGroup/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->