### PR TITLE
Add Doxygen setup that results in missing Doygen documentation.

### DIFF
--- a/.github/workflows/ctest.yml
+++ b/.github/workflows/ctest.yml
@@ -241,6 +241,11 @@ jobs:
           sudo apt-get update
           sudo apt-get install ninja-build graphviz
 
+      - name: Get Actions
+        uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
+        with:
+          sparse-checkout: .github/actions
+
       - name: Setup Doxygen
         uses: ./.github/actions/setup-doxygen
 

--- a/.github/workflows/ctest.yml
+++ b/.github/workflows/ctest.yml
@@ -241,6 +241,9 @@ jobs:
           sudo apt-get update
           sudo apt-get install ninja-build graphviz
 
+      - name: Setup Doxygen
+        uses: ./.github/actions/setup-doxygen
+
       - name: Install CMake
         uses: lukka/get-cmake@f176ccd3f28bda569c43aae4894f06b2435a3375 # latest
         with:

--- a/.github/workflows/script.yml
+++ b/.github/workflows/script.yml
@@ -160,9 +160,6 @@ jobs:
           sudo apt-get update
           sudo apt-get install ninja-build graphviz curl
 
-      - name: Setup Doxygen
-        uses: ./.github/actions/setup-doxygen
-
       - name: Install CMake
         uses: lukka/get-cmake@f176ccd3f28bda569c43aae4894f06b2435a3375 # latest
         with:

--- a/.github/workflows/script.yml
+++ b/.github/workflows/script.yml
@@ -160,6 +160,9 @@ jobs:
           sudo apt-get update
           sudo apt-get install ninja-build graphviz curl
 
+      - name: Setup Doxygen
+        uses: ./.github/actions/setup-doxygen
+
       - name: Install CMake
         uses: lukka/get-cmake@f176ccd3f28bda569c43aae4894f06b2435a3375 # latest
         with:


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Add Doxygen setup step to Linux CI workflow in `ctest.yml` to generate documentation.
> 
>   - **Workflow Changes**:
>     - Adds a new step `Setup Doxygen` in `build_and_test_linux` job in `ctest.yml`.
>     - Uses custom action `./.github/actions/setup-doxygen` to set up Doxygen.
>   - **Purpose**:
>     - Intended to generate Doxygen documentation during CI for Linux builds.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=HDFGroup%2Fhdf5&utm_source=github&utm_medium=referral)<sup> for 7c4840b5c2ecb8293c9b7b071e9f7b7ce1b0d1ca. You can [customize](https://app.ellipsis.dev/HDFGroup/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->