### PR TITLE
Fixes link checker failure

### DIFF
--- a/doxygen/dox/RFC.dox
+++ b/doxygen/dox/RFC.dox
@@ -5,7 +5,7 @@ Navigate back: \ref index "Main"
 
 <table>
 <tr><th>RFC ID</th><th>Title</th></tr>
-<tr> <td>2025-11-15</td> <td>https://dl.acm.org/doi/full/10.1145/3731599.3767557</td></tr>
+<tr> <td>2025-11-15</td> <td>Open access at dl.acm.org/doi/full/10.1145/3731599.3767557</td></tr>
 <tr> <td>2024-04-22</td> <td>\ref_rfc20240422</td></tr>
 <tr> <td>2022-08-19</td> <td>\ref_rfc20220819</td></tr>
 <tr> <td>2021-05-28</td> <td>\ref_rfc20210528</td></tr>


### PR DESCRIPTION
Removed https:// as a workaround to avoid error by the link checker.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Removed `https://` from URL in `doxygen/dox/RFC.dox` to avoid link checker error.
> 
>   - **Workaround**:
>     - Removed `https://` from URL in `doxygen/dox/RFC.dox` to avoid link checker error.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=HDFGroup%2Fhdf5&utm_source=github&utm_medium=referral)<sup> for 8380d6292d2d4418f9f7f7a0d032a67ba1f75700. You can [customize](https://app.ellipsis.dev/HDFGroup/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->