### PR TITLE
Skip some parallel example tests for small MPIEXEC_MAX_NUMPROCS values

### DIFF
--- a/HDF5Examples/C/H5PAR/CMakeLists.txt
+++ b/HDF5Examples/C/H5PAR/CMakeLists.txt
@@ -22,30 +22,32 @@ foreach (example_name ${examples})
 endforeach ()
 
 if (H5EXAMPLE_BUILD_TESTING)
-  macro (ADD_GREP_TEST testname mumprocs)
-    add_test (
-        NAME ${EXAMPLE_VARNAME}_${testname}-clearall
-        COMMAND    ${CMAKE_COMMAND}
-            -E remove
-            ${testname}.h5
-    )
-    if (last_test)
-      set_tests_properties (${EXAMPLE_VARNAME}_${testname}-clearall PROPERTIES DEPENDS ${last_test})
+  macro (ADD_GREP_TEST testname numprocs)
+    if (MPIEXEC_MAX_NUMPROCS GREATER_EQUAL "${numprocs}")
+      add_test (
+          NAME ${EXAMPLE_VARNAME}_${testname}-clearall
+          COMMAND    ${CMAKE_COMMAND}
+              -E remove
+              ${testname}.h5
+      )
+      if (last_test)
+        set_tests_properties (${EXAMPLE_VARNAME}_${testname}-clearall PROPERTIES DEPENDS ${last_test})
+      endif ()
+      add_test (NAME MPI_TEST_${EXAMPLE_VARNAME}_${testname} COMMAND "${CMAKE_COMMAND}"
+          -D "TEST_PROGRAM=${MPIEXEC_EXECUTABLE};${MPIEXEC_NUMPROC_FLAG};${numprocs};${MPIEXEC_PREFLAGS};$<TARGET_FILE:${EXAMPLE_VARNAME}_${testname}>;${MPIEXEC_POSTFLAGS}"
+          -D "TEST_ARGS:STRING="
+          -D "TEST_FOLDER=${PROJECT_BINARY_DIR}"
+          -D "TEST_EXPECT=0"
+          -D "TEST_SKIP_COMPARE=TRUE"
+          -D "TEST_OUTPUT=${testname}.out"
+          -D "TEST_GREP_COMPARE=TRUE"
+          -D "TEST_REFERENCE:STRING=PHDF5 example finished with no errors"
+          -D "TEST_LIBRARY_DIRECTORY=${CMAKE_TEST_LIB_DIRECTORY}"
+          -P "${H5EXAMPLE_RESOURCES_DIR}/runTest.cmake"
+      )
+      set_tests_properties (MPI_TEST_${EXAMPLE_VARNAME}_${testname} PROPERTIES DEPENDS ${EXAMPLE_VARNAME}_${testname}-clearall)
+      set (last_test "MPI_TEST_${EXAMPLE_VARNAME}_${testname}")
     endif ()
-    add_test (NAME MPI_TEST_${EXAMPLE_VARNAME}_${testname} COMMAND "${CMAKE_COMMAND}"
-        -D "TEST_PROGRAM=${MPIEXEC_EXECUTABLE};${MPIEXEC_NUMPROC_FLAG};${mumprocs};${MPIEXEC_PREFLAGS};$<TARGET_FILE:${EXAMPLE_VARNAME}_${testname}>;${MPIEXEC_POSTFLAGS}"
-        -D "TEST_ARGS:STRING="
-        -D "TEST_FOLDER=${PROJECT_BINARY_DIR}"
-        -D "TEST_EXPECT=0"
-        -D "TEST_SKIP_COMPARE=TRUE"
-        -D "TEST_OUTPUT=${testname}.out"
-        -D "TEST_GREP_COMPARE=TRUE"
-        -D "TEST_REFERENCE:STRING=PHDF5 example finished with no errors"
-        -D "TEST_LIBRARY_DIRECTORY=${CMAKE_TEST_LIB_DIRECTORY}"
-        -P "${H5EXAMPLE_RESOURCES_DIR}/runTest.cmake"
-    )
-    set_tests_properties (MPI_TEST_${EXAMPLE_VARNAME}_${testname} PROPERTIES DEPENDS ${EXAMPLE_VARNAME}_${testname}-clearall)
-    set (last_test "MPI_TEST_${EXAMPLE_VARNAME}_${testname}")
   endmacro ()
 
   # Ensure that 24 is a multiple of the number of processes.

--- a/HDF5Examples/FORTRAN/H5PAR/CMakeLists.txt
+++ b/HDF5Examples/FORTRAN/H5PAR/CMakeLists.txt
@@ -35,34 +35,36 @@ foreach (example_name ${examples})
 endforeach ()
 
 if (H5EXAMPLE_BUILD_TESTING)
-  macro (ADD_GREP_TEST testname mumprocs)
-    add_test (
-        NAME MPI_TEST_${EXAMPLE_VARNAME}_f90_${testname}-clearall
-        COMMAND    ${CMAKE_COMMAND}
-            -E remove
-            ${testname}.h5
-    )
-    add_test (NAME MPI_TEST_${EXAMPLE_VARNAME}_f90_${testname} COMMAND "${CMAKE_COMMAND}"
-        -D "TEST_PROGRAM=${MPIEXEC_EXECUTABLE};${MPIEXEC_NUMPROC_FLAG};${mumprocs};${MPIEXEC_PREFLAGS};$<TARGET_FILE:${EXAMPLE_VARNAME}_f90_${testname}>;${MPIEXEC_POSTFLAGS}"
-        -D "TEST_ARGS:STRING="
-        -D "TEST_FOLDER=${PROJECT_BINARY_DIR}"
-        -D "TEST_EXPECT=0"
-        -D "TEST_SKIP_COMPARE=TRUE"
-        -D "TEST_OUTPUT=${testname}.out"
-        -D "TEST_GREP_COMPARE=TRUE"
-        -D "TEST_REFERENCE:STRING=PHDF5 example finished with no errors"
-        -D "TEST_LIBRARY_DIRECTORY=${CMAKE_TEST_LIB_DIRECTORY}"
-        -P "${H5EXAMPLE_RESOURCES_DIR}/runTest.cmake"
-    )
-    set_tests_properties (MPI_TEST_${EXAMPLE_VARNAME}_f90_${testname} PROPERTIES DEPENDS MPI_TEST_${EXAMPLE_VARNAME}_f90_${testname}-clearall)
-    add_test (
-        NAME MPI_TEST_${EXAMPLE_VARNAME}_f90_${testname}-clean
-        COMMAND    ${CMAKE_COMMAND}
-            -E remove
-            ${testname}.h5
-    )
-    set_tests_properties (MPI_TEST_${EXAMPLE_VARNAME}_f90_${testname}-clean PROPERTIES DEPENDS MPI_TEST_${EXAMPLE_VARNAME}_f90_${testname})
-    set (last_test "MPI_TEST_${EXAMPLE_VARNAME}_f90_${testname}-clean")
+  macro (ADD_GREP_TEST testname numprocs)
+    if (MPIEXEC_MAX_NUMPROCS GREATER_EQUAL "${numprocs}")
+      add_test (
+          NAME MPI_TEST_${EXAMPLE_VARNAME}_f90_${testname}-clearall
+          COMMAND    ${CMAKE_COMMAND}
+              -E remove
+              ${testname}.h5
+      )
+      add_test (NAME MPI_TEST_${EXAMPLE_VARNAME}_f90_${testname} COMMAND "${CMAKE_COMMAND}"
+          -D "TEST_PROGRAM=${MPIEXEC_EXECUTABLE};${MPIEXEC_NUMPROC_FLAG};${numprocs};${MPIEXEC_PREFLAGS};$<TARGET_FILE:${EXAMPLE_VARNAME}_f90_${testname}>;${MPIEXEC_POSTFLAGS}"
+          -D "TEST_ARGS:STRING="
+          -D "TEST_FOLDER=${PROJECT_BINARY_DIR}"
+          -D "TEST_EXPECT=0"
+          -D "TEST_SKIP_COMPARE=TRUE"
+          -D "TEST_OUTPUT=${testname}.out"
+          -D "TEST_GREP_COMPARE=TRUE"
+          -D "TEST_REFERENCE:STRING=PHDF5 example finished with no errors"
+          -D "TEST_LIBRARY_DIRECTORY=${CMAKE_TEST_LIB_DIRECTORY}"
+          -P "${H5EXAMPLE_RESOURCES_DIR}/runTest.cmake"
+      )
+      set_tests_properties (MPI_TEST_${EXAMPLE_VARNAME}_f90_${testname} PROPERTIES DEPENDS MPI_TEST_${EXAMPLE_VARNAME}_f90_${testname}-clearall)
+      add_test (
+          NAME MPI_TEST_${EXAMPLE_VARNAME}_f90_${testname}-clean
+          COMMAND    ${CMAKE_COMMAND}
+              -E remove
+              ${testname}.h5
+      )
+      set_tests_properties (MPI_TEST_${EXAMPLE_VARNAME}_f90_${testname}-clean PROPERTIES DEPENDS MPI_TEST_${EXAMPLE_VARNAME}_f90_${testname})
+      set (last_test "MPI_TEST_${EXAMPLE_VARNAME}_f90_${testname}-clean")
+    endif ()
   endmacro ()
 
   # Ensure that 24 is a multiple of the number of processes.


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Modify `ADD_GREP_TEST` macro to skip tests if `MPIEXEC_MAX_NUMPROCS` is insufficient in `H5PAR/CMakeLists.txt` and `H5PAR/FORTRAN/CMakeLists.txt`.
> 
>   - **Behavior**:
>     - Modify `ADD_GREP_TEST` macro in `H5PAR/CMakeLists.txt` and `H5PAR/FORTRAN/CMakeLists.txt` to skip tests if `MPIEXEC_MAX_NUMPROCS` is less than required `numprocs`.
>     - Ensures tests are only run when sufficient processes are available.
>   - **Misc**:
>     - Fix typo in macro parameter from `mumprocs` to `numprocs` in both files.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=HDFGroup%2Fhdf5&utm_source=github&utm_medium=referral)<sup> for a32950fc84b83c674ddee98195492d187f7eaaa0. You can [customize](https://app.ellipsis.dev/HDFGroup/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->