### PR TITLE
Release workflow fixes

### DIFF
--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -34,8 +34,8 @@ jobs:
         run: |
           set -euo pipefail
           echo "Validating inputs..."
-          if [[ ! "${{ inputs.use_tag }}" =~ ^hdf5[_-][0-9]+[._][0-9]+[._][0-9]+([._][0-9]+)?(-.*)?$ ]]; then
-            echo "❌ Invalid tag format. Expected: hdf5_X.Y.Z, hdf5-X_Y_Z, or hdf5_X.Y.Z.W"
+          if [[ ! "${{ inputs.use_tag }}" =~ ^[0-9]+[._][0-9]+[._][0-9]+([._][0-9]+)?(-.*)?$ ]]; then
+            echo "❌ Invalid tag format. Expected:  X.Y.Z or X.Y.Z-*"
             exit 1
           fi
           if [[ "${{ inputs.target_dir }}" == *".."* ]] || [[ "${{ inputs.target_dir }}" == /* ]]; then

--- a/.github/workflows/release-files.yml
+++ b/.github/workflows/release-files.yml
@@ -265,6 +265,7 @@ jobs:
         with:
           tag_name: "${{ steps.create_release_tag_name.outputs.TAG_BASE }}"
           name: "HDF5 Release ${{ inputs.use_tag }}"
+          draft: true
           prerelease: false
           body_path: description.txt
           files: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -99,7 +99,6 @@ jobs:
       file_sha: ${{ needs.call-workflow-tarball.outputs.file_sha }}
       use_tag: ${{ needs.log-the-inputs.outputs.rel_tag }}
       use_environ: release
-      draft: true
 
   call-workflow-maven-staging:
     needs: [log-the-inputs, call-workflow-tarball]

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -99,6 +99,7 @@ jobs:
       file_sha: ${{ needs.call-workflow-tarball.outputs.file_sha }}
       use_tag: ${{ needs.log-the-inputs.outputs.rel_tag }}
       use_environ: release
+      draft: true
 
   call-workflow-maven-staging:
     needs: [log-the-inputs, call-workflow-tarball]


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Fix tag format validation and add draft status to releases in HDF5 workflows.
> 
>   - **Validation**:
>     - Update tag format validation in `publish-release.yml` to expect `X.Y.Z` or `X.Y.Z-*`.
>   - **Release Management**:
>     - Add `draft: true` to release creation in `release-files.yml` to mark releases as drafts initially.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=HDFGroup%2Fhdf5&utm_source=github&utm_medium=referral)<sup> for aeafa2b009d2074f7d4e9364aa0e05e86e22df70. You can [customize](https://app.ellipsis.dev/HDFGroup/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->