### PR TITLE
Adds release info for 2.1.0

### DIFF
--- a/doxygen/aliases
+++ b/doxygen/aliases
@@ -17,9 +17,10 @@ ALIASES += DWNURL="\RELURL/downloads/latest"
 ALIASES += RFCURL="\DOCURL/rfc"
 ALIASES += AEXURL="\HDFURL/archive/support/ftp/HDF5/examples"
 ALIASES += RFCWIP="github.com/HDFGroup/hdf5doc/tree/master/RFCs"
-#branch name (develop, hdf5_2_0_0)
+# URL for source develop
 ALIASES += SRCURL="github.com/HDFGroup/hdf5/blob/develop"
-ALIASES += SRCURL114="github.com/HDFGroup/hdf5/blob/hdf5_1.14.6"
+# URL for source of all other branches
+ALIASES += SRCURLALL="github.com/HDFGroup/hdf5/blob"
 #Other projects that contribute to HDF5
 ALIASES += PRJURL="\HDFURL/archive/support/projects"
 ALIASES += HVURL="github.com/HDFGroup/hdfview/blob/master"

--- a/doxygen/dox/hdf5_1_14.dox
+++ b/doxygen/dox/hdf5_1_14.dox
@@ -30,7 +30,7 @@ Release Date
 Additional Release Information
 </td>
 <td>
-<a href="https://\SRCURL114/release_docs/RELEASE.txt">RELEASE.txt</a>
+<a href="https://\SRCURLALL/hdf5_1.14.6/release_docs/RELEASE.txt">RELEASE.txt</a>
 </td>
 </tr>
 <tr>

--- a/doxygen/dox/hdf5_2x.dox
+++ b/doxygen/dox/hdf5_2x.dox
@@ -62,7 +62,7 @@ Additional Release Information
 <td style="background-color:#F5F5F5">
 </td>
 <td>
-ABI/API Compatibility Reports between 2.1.0 and 2.0.0 [tar file](https://\RELURL/v2_1/v2_1_0/downloads/hdf5-2.1.0.html.abi.reports.tar.gz) or [individual html files](https://\RELURL/v2_1/v2_1_0/downloads/compat_report/index.html)
+ABI/API Compatibility Reports between 2.1.0 and 2.0.0 [tar file](https://\RELURL/2.1.0/downloads/hdf5-2.1.0.html.abi.reports.tar.gz) or [individual html files](https://\RELURL/2.1.0/downloads/compat_report/index.html)
 </td>
 </tr>
 <tr>
@@ -138,9 +138,25 @@ This section includes the new features introduced in the HDF5 2.x series:
 \li Support for chunks larger than 4 GiB using 64 bit addressing.
 
 \li New predefined datatypes for
-    - FP8 data in E4M3 and E5M2 formats (https://arxiv.org/abs/2209.05433), but not a native FP8 datatype.
-    - little- and big-endian [bfloat16](https://en.wikipedia.org/wiki/Bfloat16_floating-point_format) data.
-<br>Please refer to the <a href="https://\SRCURLALL/hdf5_2.1.0/release_docs/CHANGELOG.md">CHANGELOG</a> for detail.
+
+<table>
+<tr>
+  <td rowspan="2">2.1.0</td>
+  <td>FP6 data in E2M3 and E3M2 formats</td>
+  <td rowspan="2">For details, please see the Software Changes section of \ref subsubsec_rel_spec_2x_change_21versus20</td>
+</tr>
+<tr>
+  <td>FP4 data in E2M1 format</td>
+</tr>
+<tr>
+  <td rowspan="2">2.0.0</td>
+  <td>FP8 data in E4M3 and E5M2 formats (<a href="https://arxiv.org/abs/2209.05433">https://arxiv.org/abs/2209.05433</a>), but not a native FP8 datatype</td>
+  <td rowspan="2">For details, please see the Software Changes section of \ref subsubsec_rel_spec_2x_change_20versus14_6</td>
+</tr>
+<tr>
+  <td>little- and big-endian bfloat16 data</td>
+</tr>
+</table>
 
 \li Default chunk cache hash table size increased to 8191
 <br>In order to reduce hash collisions and take advantage of modern memory capacity, the default hash table size for the chunk cache has been increased from 521 to 8191. This means the hash table will consume approximately 64 KiB per open dataset. This value can be changed with `H5Pset_cache()` or `H5Pset_chunk_cache()`. This value was chosen because it is a prime number close to 8K.

--- a/doxygen/dox/hdf5_2x.dox
+++ b/doxygen/dox/hdf5_2x.dox
@@ -1,27 +1,25 @@
-/** \page rel_spec_20 Release Specific Information for HDF5 2.0
+/** \page rel_spec_2x Release Specific Information for HDF5 2.x
  *
  * Navigate back: \ref index "Main" / \ref release_specific_info
  * <hr>
 
-\section sec_rel_spec_20 HDF5 Library and Tools 2.0.0
+\section sec_rel_spec_2x HDF5 Library and Tools 2.1.0
 
-\subsection subsec_rel_info_20 Release Information
+\subsection subsec_rel_info_2x Release Information
 
 <table>
 <tr>
-<td style="background-color:#F5F5F5">
-Version
+<td style="background-color:#FFFFFF">
+![GitHub release (latest by date)](https://img.shields.io/github/v/release/HDFGroup/hdf5?label=Version&color=white)
 </td>
 <td>
-HDF5 2.0.0
 </td>
 </tr>
 <tr>
-<td style="background-color:#F5F5F5">
-Release Date
+<td style="background-color:#FFFFFF">
+![GitHub Release Date](https://img.shields.io/badge/dynamic/json?label=Released&query=$.published_at&url=https://api.github.com/repos/HDFGroup/hdf5/releases/latest&color=white)
 </td>
 <td>
-11/10/25
 </td>
 </tr>
 <tr>
@@ -36,21 +34,21 @@ Additional Release Information
 <td style="background-color:#F5F5F5">
 </td>
 <td>
-\ref sec_rel_spec_20_migrate
+\ref sec_rel_spec_2x_migrate
 </td>
 </tr>
 <tr>
 <td style="background-color:#F5F5F5">
 </td>
 <td>
-\ref sec_rel_spec_20_change
+\ref sec_rel_spec_2x_change
 </td>
 </tr>
 <tr>
 <td style="background-color:#F5F5F5">
 </td>
 <td>
-\ref sec_rel_spec_20_feat
+\ref sec_rel_spec_2x_feat
 </td>
 </tr>
 <tr>
@@ -64,7 +62,7 @@ Additional Release Information
 <td style="background-color:#F5F5F5">
 </td>
 <td>
-ABI/API Compatibility Reports between 2.0.0 and 1.14.6 [tar file](https://\RELURL/v2_0/v2_0_0/downloads/hdf5-2.0.0.html.abi.reports.tar.gz) or [individual html files](https://\RELURL/v2_0/v2_0_0/downloads/compat_report/index.html)
+ABI/API Compatibility Reports between 2.1.0 and 2.0.0 [tar file](https://\RELURL/v2_1/v2_1_0/downloads/hdf5-2.1.0.html.abi.reports.tar.gz) or [individual html files](https://\RELURL/v2_1/v2_1_0/downloads/compat_report/index.html)
 </td>
 </tr>
 <tr>
@@ -77,15 +75,15 @@ ABI/API Compatibility Reports between 2.0.0 and 1.14.6 [tar file](https://\RELUR
 </table>
 
 
-\subsection subsec_download_20 Downloads
+\subsection subsec_download_2x Downloads
 
 Source code and binaries are available at:
-<a href="https://github.com/HDFGroup/hdf5/releases/tag/2.0.0">HDF5 2.0.0 on GitHub</a>
+<a href="https://github.com/HDFGroup/hdf5/releases/tag/2.1.0">HDF5 2.1.0 on GitHub</a>
 
 Please refer to [Build instructions](https://\SRCURL/release_docs/INSTALL) for building with CMake.
 
 
-\subsection subsec_obtain_method_20 Methods to obtain (gz file)
+\subsection subsec_obtain_method_2x Methods to obtain (gz file)
 
 \li firefox – Download file and then run:  `gzip <distribution>.tar.gz | tar xzf -`
 \li chrome –  Download file and then run:  `gzip -cd <distribution>.tar.gz | tar xvf -`
@@ -94,10 +92,10 @@ Please refer to [Build instructions](https://\SRCURL/release_docs/INSTALL) for b
     `wget https://github.com/HDFGroup/hdf5/releases/download/${PACKAGEVERSION}/<distribution>.tar.gz`<br>
     `gzip -cd <distribution>.tar.gz | tar xvf -`
 </div>
-\li `<distribution>` is hdf5-${PACKAGEVERSION}, where PACKAGEVERSION is 2.0.0 for this release
+\li `<distribution>` is hdf5-${PACKAGEVERSION}, where PACKAGEVERSION is 2.1.0 for this release
 
 
-\subsection subsec_dox_gen_doc_20 Doxygen Generated Reference Manual
+\subsection subsec_dox_gen_doc_2x Doxygen Generated Reference Manual
 
 The new HDF5 documentation based on [Doxygen](https://www.doxygen.nl/index.html) is available \ref index "here".
 
@@ -105,9 +103,9 @@ This documentation is WORK-IN-PROGRESS.
 
 Since this portion of the HDF5 documentation is now part of the source code, it gets the same treatment as code. In other words, issues, inaccuracies, corrections should be reported as issues in [GitHub](https://github.com/HDFGroup/hdf5/issues), and pull requests will be reviewed and accepted as any other code changes.
 
-\section sec_rel_spec_20_migrate Migrating from HDF5 1.14 to HDF5 2.0
+\section sec_rel_spec_2x_migrate Migrating from HDF5 1.14 to HDF5 2.x
 
-This section highlights some changes that might affect migrating to HDF5.20, please refer to the \ref sec_rel_spec_20_change or the <a href="https://\SRCURL/release_docs/CHANGELOG.md">Change log</a> for detail.
+This section highlights some changes that might affect migrating to HDF5.20, please refer to the \ref sec_rel_spec_2x_change or the <a href="https://\SRCURL/release_docs/CHANGELOG.md">Change log</a> for detail.
 
 \li Default file format is now 1.8
 \li The file format has been updated to 4.0<a name="fileformat"></a>
@@ -120,9 +118,9 @@ This section highlights some changes that might affect migrating to HDF5.20, ple
     - The tool h5dump has a new option `--lformat` and its `XML` option is deprecated.
     - The high-level GIF tools, `h52gif` and `gif2h5` have been removed. We may move them to a separate repository in the future.  See <a href="https://\SRCURL/release_docs/CHANGELOG.md">Change log</a> for an explanation.
 
-\section sec_rel_spec_20_feat New Features in HDF5 Release 2.0
+\section sec_rel_spec_2x_feat New Features in HDF5 Release 2.x
 
-This section includes the new features introduced in the HDF5 2.0 series:
+This section includes the new features introduced in the HDF5 2.x series:
 
 \li \ref_rfc20240129complex
 <br>Support for the C99 `float _Complex`, `double _Complex` and `long double _Complex` (with MSVC, `_Fcomplex`, `_Dcomplex` and `_Lcomplex`) types has been added for platforms/compilers that support them. These types have been implemented with a new datatype class, `H5T_COMPLEX`. Note that any datatypes of class H5T_COMPLEX will not be readable with previous versions of HDF5. If a file is accessed with a library version bounds "high" setting less than `H5F_LIBVER_V200`, an error will occur if the application tries to create an object with a complex number datatype. If compatibility with previous versions of HDF5 is desired, applications should instead consider adopting [one of the existing conventions](https://nc-complex.readthedocs.io/en/latest/#conventions-used-in-applications).<br />
@@ -147,7 +145,7 @@ This section includes the new features introduced in the HDF5 2.0 series:
 \li Default chunk cache hash table size increased to 8191
 <br>In order to reduce hash collisions and take advantage of modern memory capacity, the default hash table size for the chunk cache has been increased from 521 to 8191. This means the hash table will consume approximately 64 KiB per open dataset. This value can be changed with `H5Pset_cache()` or `H5Pset_chunk_cache()`. This value was chosen because it is a prime number close to 8K.
 
-\ref sec_rel_spec_20_change
+\ref sec_rel_spec_2x_change
 
  *
  * <hr>

--- a/doxygen/dox/hdf5_2x.dox
+++ b/doxygen/dox/hdf5_2x.dox
@@ -27,7 +27,7 @@
 Additional Release Information
 </td>
 <td>
-<a href="https://\SRCURL/release_docs/CHANGELOG.md">Change log</a>
+<a href="https://\SRCURLALL/hdf5_2.1.0/release_docs/CHANGELOG.md">Change log</a>
 </td>
 </tr>
 <tr>
@@ -55,7 +55,7 @@ Additional Release Information
 <td style="background-color:#F5F5F5">
 </td>
 <td>
-[Newsletter Announcement](https://www.hdfgroup.org/2025/11/10/release-of-hdf5-2-0-0-newsletter-207/)
+[Newsletter Announcement](https://www.hdfgroup.org/)
 </td>
 </tr>
 <tr>
@@ -80,7 +80,7 @@ ABI/API Compatibility Reports between 2.1.0 and 2.0.0 [tar file](https://\RELURL
 Source code and binaries are available at:
 <a href="https://github.com/HDFGroup/hdf5/releases/tag/2.1.0">HDF5 2.1.0 on GitHub</a>
 
-Please refer to [Build instructions](https://\SRCURL/release_docs/INSTALL) for building with CMake.
+Please refer to [Build instructions](https://\SRCURLALL/hdf5_2.1.0/release_docs/INSTALL) for building with CMake.
 
 
 \subsection subsec_obtain_method_2x Methods to obtain (gz file)
@@ -105,7 +105,7 @@ Since this portion of the HDF5 documentation is now part of the source code, it 
 
 \section sec_rel_spec_2x_migrate Migrating from HDF5 1.14 to HDF5 2.x
 
-This section highlights some changes that might affect migrating to HDF5.20, please refer to the \ref sec_rel_spec_2x_change or the <a href="https://\SRCURL/release_docs/CHANGELOG.md">Change log</a> for detail.
+This section highlights some changes that might affect migrating to HDF5.20, please refer to the \ref sec_rel_spec_2x_change or the <a href="https://\SRCURLALL/hdf5_2.1.0/release_docs/CHANGELOG.md">Change log</a> for detail.
 
 \li Default file format is now 1.8
 \li The file format has been updated to 4.0<a name="fileformat"></a>
@@ -113,10 +113,10 @@ This section highlights some changes that might affect migrating to HDF5.20, ple
     - `H5Dread_chunk()`<br>
     - `H5Tdecode()`<br>
     - `H5Iregister_type()`<br>
-\li A new backend based on the [aws-c-s3 library](https://github.com/awslabs/aws-c-s3) replaced the ROS3 VFD's S3 backend based on libcurl.  The ROS3 VFD now requires the `aws-c-s3` library in order to be built.  See the <a href="https://\SRCURL/release_docs/CHANGELOG.md">Change log</a> for a complete description on this feature.
+\li A new backend based on the [aws-c-s3 library](https://github.com/awslabs/aws-c-s3) replaced the ROS3 VFD's S3 backend based on libcurl.  The ROS3 VFD now requires the `aws-c-s3` library in order to be built.  See the <a href="https://\SRCURLALL/hdf5_2.1.0/release_docs/CHANGELOG.md">Change log</a> for a complete description on this feature.
 \li Significance in tools
     - The tool h5dump has a new option `--lformat` and its `XML` option is deprecated.
-    - The high-level GIF tools, `h52gif` and `gif2h5` have been removed. We may move them to a separate repository in the future.  See <a href="https://\SRCURL/release_docs/CHANGELOG.md">Change log</a> for an explanation.
+    - The high-level GIF tools, `h52gif` and `gif2h5` have been removed. We may move them to a separate repository in the future.  See <a href="https://\SRCURLALL/hdf5_2.1.0/release_docs/CHANGELOG.md">Change log</a> for an explanation.
 
 \section sec_rel_spec_2x_feat New Features in HDF5 Release 2.x
 
@@ -140,7 +140,7 @@ This section includes the new features introduced in the HDF5 2.x series:
 \li New predefined datatypes for
     - FP8 data in E4M3 and E5M2 formats (https://arxiv.org/abs/2209.05433), but not a native FP8 datatype.
     - little- and big-endian [bfloat16](https://en.wikipedia.org/wiki/Bfloat16_floating-point_format) data.
-<br>Please refer to the <a href="https://\SRCURL/release_docs/CHANGELOG.md">CHANGELOG</a> for detail.
+<br>Please refer to the <a href="https://\SRCURLALL/hdf5_2.1.0/release_docs/CHANGELOG.md">CHANGELOG</a> for detail.
 
 \li Default chunk cache hash table size increased to 8191
 <br>In order to reduce hash collisions and take advantage of modern memory capacity, the default hash table size for the chunk cache has been increased from 521 to 8191. This means the hash table will consume approximately 64 KiB per open dataset. This value can be changed with `H5Pset_cache()` or `H5Pset_chunk_cache()`. This value was chosen because it is a prime number close to 8K.

--- a/doxygen/dox/release_specific_info.dox
+++ b/doxygen/dox/release_specific_info.dox
@@ -3,10 +3,10 @@
  * Navigate back: \ref index "Main"
  * <hr>
 
-\ref rel_spec_20
-\li \ref sec_rel_spec_20_feat
-\li \ref sec_rel_spec_20_change
-\li \ref sec_rel_spec_20_migrate
+\ref rel_spec_2x
+\li \ref sec_rel_spec_2x_feat
+\li \ref sec_rel_spec_2x_change
+\li \ref sec_rel_spec_2x_migrate
 
 \ref rel_spec_114
 \li \ref sec_rel_spec_114_feat

--- a/doxygen/dox/sw_changes_2.0.dox
+++ b/doxygen/dox/sw_changes_2.0.dox
@@ -1,9 +1,9 @@
-/** \page rel_spec_20_change Release Specific Information for HDF5 2.0
+/** \page rel_spec_2x_change Release Specific Information for HDF5 2.x
  *
- * Navigate back: \ref index "Main" / \ref release_specific_info / \ref rel_spec_20
+ * Navigate back: \ref index "Main" / \ref release_specific_info / \ref rel_spec_2x
  * <hr>
 
-\section sec_rel_spec_20_change Software Changes from Release to Release in HDF5 2.0
+\section sec_rel_spec_2x_change Software Changes from Release to Release in HDF5 2.x
 
 This page provides information on the changes that a maintenance developer needs to
 be aware of between successive releases of HDF5, such as:
@@ -12,18 +12,18 @@ be aware of between successive releases of HDF5, such as:
 \li Certain types of changes in configuration or build processes
 \li Note that bug fixes and performance enhancements in the C library are automatically picked up by the C++, Fortran, and Java libraries.
 
-\subsection subsec_rel_spec_20_change_compat API Compatibility
+\subsection subsec_rel_spec_2x_change_compat API Compatibility
 See \ref api-compat-macros for details on using HDF5 version 2.0 with previous releases.
 \li <a href="https://\RELURL/v2_0/v2_0_0/downloads/hdf5-2.0.0.html.abi.reports.tar.gz">Compatibility reports for Release 2.0 versus Release 1.14.6</a>
 
-\subsection subsec_rel_spec_20_bw_releases Differences between releases
-\li \ref subsubsec_rel_spec_20_change_0versus14_6
+\subsection subsec_rel_spec_2x_bw_releases Differences between releases
+\li \ref subsubsec_rel_spec_2x_change_0versus14_6
 
 The <a href="https://\SRCURL/release_docs/CHANGELOG.md">Change log</a> (a.k.a. the RELEASE.txt prior to release 2.0) also lists changes made to the library, but these notes tend to be more at a more detail-oriented level. It include new features, bugs fixed, supported configuration features, platforms on which the library has been tested, and known problems.
 The change log files are listed in each release section and can be found at the top level of
 the HDF5 source code tree in the release_docs directory.
 
-\subsubsection subsubsec_rel_spec_20_change_0versus14_6 Release 2.0 versus Release 1.14.6
+\subsubsection subsubsec_rel_spec_2x_change_0versus14_6 Release 2.0 versus Release 1.14.6
 
 HDF5 version 2.0 provides a number of new C APIs and other user-visible changes in behavior in the transition from HDF5 Release 1.14.6 to Release 2.0.  Some of those require the use of the API Compatibility Macros for the main library. In addition, some APIs have been removed or have had their signature change.
 
@@ -337,5 +337,5 @@ H5VLstart_lib_state()
 
  *
  * <hr>
- * Navigate back: \ref index "Main" / \ref release_specific_info / \ref rel_spec_20
+ * Navigate back: \ref index "Main" / \ref release_specific_info / \ref rel_spec_2x
 */

--- a/doxygen/dox/sw_changes_2.0.dox
+++ b/doxygen/dox/sw_changes_2.0.dox
@@ -13,17 +13,52 @@ be aware of between successive releases of HDF5, such as:
 \li Note that bug fixes and performance enhancements in the C library are automatically picked up by the C++, Fortran, and Java libraries.
 
 \subsection subsec_rel_spec_2x_change_compat API Compatibility
-See \ref api-compat-macros for details on using HDF5 version 2.0 with previous releases.
-\li <a href="https://\RELURL/v2_0/v2_0_0/downloads/hdf5-2.0.0.html.abi.reports.tar.gz">Compatibility reports for Release 2.0 versus Release 1.14.6</a>
+See \ref api-compat-macros for details of HDF5 versions when considering upgrading to the later HDF5 release to take advantage of the library features and enhancements.
+
+\li <a href="https://\RELURL/2.1.0/downloads/hdf5-2.1.0.html.abi.reports.tar.gz">Compatibility reports for Release 2.1.0 versus Release 2.0.0</a>
+\li <a href="https://\RELURL/v2_0/v2_0_0/downloads/hdf5-2.0.0.html.abi.reports.tar.gz">Compatibility reports for Release 2.0.0 versus Release 1.14.6</a>
 
 \subsection subsec_rel_spec_2x_bw_releases Differences between releases
-\li \ref subsubsec_rel_spec_2x_change_0versus14_6
+\li \ref subsubsec_rel_spec_2x_change_21versus20
+\li \ref subsubsec_rel_spec_2x_change_20versus14_6
 
-The <a href="https://\SRCURL/release_docs/CHANGELOG.md">Change log</a> (a.k.a. the RELEASE.txt prior to release 2.0) also lists changes made to the library, but these notes tend to be more at a more detail-oriented level. It include new features, bugs fixed, supported configuration features, platforms on which the library has been tested, and known problems.
+The Change log (a.k.a. the RELEASE.txt prior to release 2.x) also lists changes made to the library, but these notes tend to be more at a more detail-oriented level. It includes new features, bugs fixed, supported configuration features, platforms on which the library has been tested, and known problems.
 The change log files are listed in each release section and can be found at the top level of
 the HDF5 source code tree in the release_docs directory.
 
-\subsubsection subsubsec_rel_spec_2x_change_0versus14_6 Release 2.0 versus Release 1.14.6
+\subsubsection subsubsec_rel_spec_2x_change_21versus20 Release 2.1.0 versus Release 2.0.0
+
+List of new public APIs/Macros
+
+<table>
+<tr><th>Function/Constant</th><th>Description</th></tr>
+<tr>
+<td style="background-color:#F5F5F5">
+#H5T_FLOAT_F6E2M3
+</td>
+<td>
+6-bit FP6 E2M3 (2 exponent bits, 3 mantissa bits) floating-point
+</td>
+</tr>
+<tr>
+<td style="background-color:#F5F5F5">
+#H5T_FLOAT_F6E3M2
+</td>
+<td>
+6-bit FP6 E3M2 (3 exponent bits, 2 mantissa bits) floating-point
+</td>
+</tr>
+<tr>
+<td style="background-color:#F5F5F5">
+#H5T_FLOAT_F4E2M1
+</td>
+<td>
+4-bit FP4 E2M1 (2 exponent bits, 1 mantissa bit) floating-point
+</td>
+</tr>
+</table>
+
+\subsubsection subsubsec_rel_spec_2x_change_20versus14_6 Release 2.0.0 versus Release 1.14.6
 
 HDF5 version 2.0 provides a number of new C APIs and other user-visible changes in behavior in the transition from HDF5 Release 1.14.6 to Release 2.0.  Some of those require the use of the API Compatibility Macros for the main library. In addition, some APIs have been removed or have had their signature change.
 


### PR DESCRIPTION
- Changed 2.0.0 release page to 2.1.0
- Started using dynamic release version and date
- Updated the New Features page and the Software Changes page
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Update release documentation for HDF5 2.1.0 with dynamic versioning and new features.
> 
>   - **Release Information**:
>     - Update release page from 2.0.0 to 2.1.0 in `hdf5_2x.dox`.
>     - Use dynamic version and release date in `hdf5_2x.dox`.
>   - **Documentation**:
>     - Update `release_specific_info.dox` to include new features and changes for 2.1.0.
>     - Rename `hdf5_2_0.dox` to `hdf5_2x.dox` and update content for 2.1.0.
>   - **Aliases**:
>     - Add `SRCURLALL` alias in `aliases` for dynamic branch URLs.
>     - Update `SRCURL114` to `SRCURLALL` in `hdf5_1_14.dox` for release document links.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=HDFGroup%2Fhdf5&utm_source=github&utm_medium=referral)<sup> for 628a42aea4fc928204273a0b363deeac98d2a93e. You can [customize](https://app.ellipsis.dev/HDFGroup/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->