### PR TITLE
Add ZLIB_USE_EXTERNAL/SZIP_USE_EXTERNAL for CMakePresets to replace

### DIFF
--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -76,7 +76,9 @@
         "HDF5_USE_ZLIB_STATIC": "ON",
         "HDF5_USE_LIBAEC_STATIC": "ON",
         "HDF5_ENABLE_SZIP_SUPPORT": "ON",
-        "HDF5_ENABLE_ZLIB_SUPPORT": "ON"
+        "HDF5_ENABLE_ZLIB_SUPPORT": "ON",
+        "ZLIB_USE_EXTERNAL": "ON",
+        "SZIP_USE_EXTERNAL": "ON"
       }
     },
     {


### PR DESCRIPTION
force-setting removed from CMakeFilters.cmake (PR #6222).

Github daily-biuld tests using cmake presets are failing.  The presets don't use cacheinit.cmake, so they were missing the USE_EXTERNAL settings.  Thanks to Claude for locating the lines for the fix.

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Add `ZLIB_USE_EXTERNAL` and `SZIP_USE_EXTERNAL` to `ci-StdCompression` in `CMakePresets.json`.
> 
>   - **CMake Presets**:
>     - Add `ZLIB_USE_EXTERNAL` and `SZIP_USE_EXTERNAL` to `ci-StdCompression` in `CMakePresets.json`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=HDFGroup%2Fhdf5&utm_source=github&utm_medium=referral)<sup> for 30fd3906495e1c7fdd85ce003b44bb18c5db92d3. You can [customize](https://app.ellipsis.dev/HDFGroup/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->