### PR TITLE
Add ZLIB_USE_EXTERNAL/SZIP_USE_EXTERNAL for CMakePresets to replace

### DIFF
--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -76,7 +76,9 @@
         "HDF5_USE_ZLIB_STATIC": "ON",
         "HDF5_USE_LIBAEC_STATIC": "ON",
         "HDF5_ENABLE_SZIP_SUPPORT": "ON",
-        "HDF5_ENABLE_ZLIB_SUPPORT": "ON"
+        "HDF5_ENABLE_ZLIB_SUPPORT": "ON",
+        "ZLIB_USE_EXTERNAL": "ON",
+        "SZIP_USE_EXTERNAL": "ON"
       }
     },
     {


### PR DESCRIPTION
force-setting removed from CMakeFilters.cmake (PR #6222).

Github daily-biuld tests using cmake presets are failing.  The presets don't use cacheinit.cmake, so they were missing the USE_EXTERNAL settings.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Add `ZLIB_USE_EXTERNAL` and `SZIP_USE_EXTERNAL` to `ci-StdCompression` in `CMakePresets.json` to fix GitHub daily-build test failures.
> 
>   - **Behavior**:
>     - Adds `ZLIB_USE_EXTERNAL` and `SZIP_USE_EXTERNAL` to `ci-StdCompression` in `CMakePresets.json` to enable external usage of ZLIB and SZIP.
>     - Addresses failing GitHub daily-build tests due to missing external settings in presets.
>   - **Misc**:
>     - Ensures compatibility with changes from PR #6222 by removing force-setting from `CMakeFilters.cmake`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=HDFGroup%2Fhdf5&utm_source=github&utm_medium=referral)<sup> for 09753287d0c239da8ba6d3b2a729215c13c914f5. You can [customize](https://app.ellipsis.dev/HDFGroup/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->