### PR TITLE
Update AOCC workflow concurrency group

### DIFF
--- a/.github/workflows/aocc.yml
+++ b/.github/workflows/aocc.yml
@@ -11,7 +11,7 @@ on:
 
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  group: ${{ github.workflow }}-${{ github.head_ref && github.ref || github.run_id }}
   cancel-in-progress: true
 permissions:
   contents: read


### PR DESCRIPTION
Prevent AOCC workflows from being cancelled when pushes are made to develop branch on merge of PRs
<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Update concurrency group in `aocc.yml` to prevent workflow cancellation on develop branch pushes during PR merges.
> 
>   - **Concurrency Group Update**:
>     - In `.github/workflows/aocc.yml`, update concurrency group to `${{ github.workflow }}-${{ github.head_ref && github.ref || github.run_id }}`.
>     - Prevents workflow cancellation on pushes to the develop branch during PR merges.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=HDFGroup%2Fhdf5&utm_source=github&utm_medium=referral)<sup> for 15c0f92270e24ee4b17a2c90a799e1d80025b45b. You can [customize](https://app.ellipsis.dev/HDFGroup/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->