### PR TITLE
Workflow will no longer post a Maven comment status to PRs

### DIFF
--- a/.github/workflows/maven-staging.yml
+++ b/.github/workflows/maven-staging.yml
@@ -1308,58 +1308,6 @@ jobs:
             HDF5Examples/JAVA/*/*.h5
           retention-days: 7
 
-  comment-pr:
-    name: Comment on Pull Request
-    runs-on: ubuntu-latest
-    needs: [detect-changes, determine-matrix, build-maven-artifacts, test-maven-deployment]
-    if: ${{ github.event_name == 'pull_request' && needs.detect-changes.outputs.should-test == 'true' && needs.build-maven-artifacts.result == 'success' && needs.test-maven-deployment.result == 'success' }}
-    steps:
-      - name: Generate comment body
-        id: comment
-        run: |
-          COMMENT="## ✅ Maven Staging Tests Passed
-
-          Maven artifacts successfully generated and validated.
-
-          Ready for Maven deployment to GitHub Packages."
-
-          echo "comment<<EOF" >> $GITHUB_OUTPUT
-          echo "$COMMENT" >> $GITHUB_OUTPUT
-          echo "EOF" >> $GITHUB_OUTPUT
-
-      - name: Comment on PR
-        # Skip commenting if running from a fork due to permission restrictions
-        if: ${{ github.event.pull_request.head.repo.full_name == github.repository }}
-        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8
-        with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}
-          script: |
-            try {
-              await github.rest.issues.createComment({
-                issue_number: context.issue.number,
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                body: process.env.COMMENT_BODY
-              });
-              console.log('✅ Comment posted successfully');
-            } catch (error) {
-              console.log('❌ Failed to post comment:', error.message);
-              console.log('This may be due to insufficient permissions or fork restrictions');
-              // Don't fail the workflow if commenting fails
-            }
-        env:
-          COMMENT_BODY: ${{ steps.comment.outputs.comment }}
-
-      - name: Output test results (fallback)
-        if: ${{ github.event.pull_request.head.repo.full_name != github.repository }}
-        run: |
-          echo "==========================================="
-          echo "✅ Maven Staging Tests Passed"
-          echo "Maven artifacts successfully generated and validated"
-          echo "Ready for Maven deployment to GitHub Packages"
-          echo "==========================================="
-          echo "Note: Running from fork - PR comment skipped due to permission restrictions"
-
   cleanup:
     name: Cleanup Staging Artifacts
     runs-on: ubuntu-latest


### PR DESCRIPTION
I see no reason to call out the Maven passing/failing status.
```
Maven Staging Tests Passed
Maven artifacts successfully generated and validated.
Ready for Maven deployment to GitHub Packages.
```


<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Removes the `comment-pr` job from `.github/workflows/maven-staging.yml`, stopping Maven status comments on pull requests.
> 
>   - **Behavior**:
>     - Removes `comment-pr` job from `.github/workflows/maven-staging.yml`, which posted Maven status comments on pull requests.
>     - Maven status comments are no longer posted, regardless of Maven test results.
>   - **Misc**:
>     - The workflow still performs Maven tests and deployments without posting status comments.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=HDFGroup%2Fhdf5&utm_source=github&utm_medium=referral)<sup> for 747915a3cda12324bfc6b3e3019cbf45061b2a2e. You can [customize](https://app.ellipsis.dev/HDFGroup/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->