### PR TITLE
Add note to CHANGELOG.md for PR #6178

### DIFF
--- a/release_docs/CHANGELOG.md
+++ b/release_docs/CHANGELOG.md
@@ -113,6 +113,10 @@ We would like to thank the many HDF5 community members who contributed to this r
 
 ## Library
 
+### Fixed a problem with using filters with variable length datatypes
+
+   When using data filters with a dataset with a variable length datatype, the library would not invoke the filters' can_apply and set_local callbacks. This has been addressed and the library will now make those callbacks no matter what the datatype is.
+
 ### Fixed a potential out of bound read
 
    When a file is corrupted such that an array datatype's size, the number of elements, and the element size are not in agreement, it can trigger an out of bounds read.  A check has been added to detect such situation.


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Add note to `CHANGELOG.md` about fixing filter callbacks for variable length datatypes.
> 
>   - **Documentation**:
>     - Added note in `CHANGELOG.md` about fixing a problem with using filters with variable length datatypes, ensuring callbacks are invoked regardless of datatype.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=HDFGroup%2Fhdf5&utm_source=github&utm_medium=referral)<sup> for 1643eab04532c4773fd5f1ca62944892e2447a07. You can [customize](https://app.ellipsis.dev/HDFGroup/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->