### PR TITLE
docs: add 2.

### DIFF
--- a/doxygen/dox/file-locking.dox
+++ b/doxygen/dox/file-locking.dox
@@ -55,7 +55,7 @@ it wrong could result in corrupt files or crashed readers, we decided to add
 a file locking scheme to help users get it right. Since this would also help
 prevent harmful accesses when SWMR is not in use, we decided to switch the
 file locking scheme on by default. This scheme has been carried forward into
-HDF5 1.12 and 1.14 (soon to be 2.0).
+HDF5 1.12, 1.14, and 2.0.
 
 Note that the current implementation of SWMR is only useful for appending to chunked
 datasets. Creating file objects like groups and datasets is not supported

--- a/doxygen/dox/file-locking.dox
+++ b/doxygen/dox/file-locking.dox
@@ -55,7 +55,7 @@ it wrong could result in corrupt files or crashed readers, we decided to add
 a file locking scheme to help users get it right. Since this would also help
 prevent harmful accesses when SWMR is not in use, we decided to switch the
 file locking scheme on by default. This scheme has been carried forward into
-HDF5 1.12, 1.14, and 2.0.
+HDF5 1.12, 1.14, and 2.
 
 Note that the current implementation of SWMR is only useful for appending to chunked
 datasets. Creating file objects like groups and datasets is not supported

--- a/doxygen/dox/file-locking.dox
+++ b/doxygen/dox/file-locking.dox
@@ -55,7 +55,7 @@ it wrong could result in corrupt files or crashed readers, we decided to add
 a file locking scheme to help users get it right. Since this would also help
 prevent harmful accesses when SWMR is not in use, we decided to switch the
 file locking scheme on by default. This scheme has been carried forward into
-HDF5 1.12, 1.14, and 2.
+HDF5 1.12 and later versions.
 
 Note that the current implementation of SWMR is only useful for appending to chunked
 datasets. Creating file objects like groups and datasets is not supported


### PR DESCRIPTION
2.0 is released.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Update `file-locking.dox` to include version 2.0 in the file locking scheme documentation.
> 
>   - **Documentation**:
>     - Update `file-locking.dox` to include version 2.0 in the list of versions carrying forward the file locking scheme.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=HDFGroup%2Fhdf5&utm_source=github&utm_medium=referral)<sup> for 514de80641788158241e83055742f6f219c896b6. You can [customize](https://app.ellipsis.dev/HDFGroup/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->