### PR TITLE
Fix POSIX header guard to include _WIN32 for Intel icx on Windows

### DIFF
--- a/test/atomic_reader.c
+++ b/test/atomic_reader.c
@@ -31,7 +31,7 @@
 #include <stdlib.h>
 #include <string.h>
 
-#if !defined(WIN32) && !defined(__MINGW32__)
+#if !defined(WIN32) && !defined(__MINGW32__) && !defined(_WIN32)
 
 #include <fcntl.h>
 #include <unistd.h>

--- a/test/atomic_writer.c
+++ b/test/atomic_writer.c
@@ -34,7 +34,7 @@
 #include <stdint.h>
 #include <string.h>
 
-#if !defined(WIN32) && !defined(__MINGW32__)
+#if !defined(WIN32) && !defined(__MINGW32__) && !defined(_WIN32)
 
 #include <fcntl.h>
 #include <unistd.h>

--- a/tools/test/perform/direct_write_perf.c
+++ b/tools/test/perform/direct_write_perf.c
@@ -25,7 +25,7 @@
 #include H5_ZLIB_HEADER /* "zlib.h" */
 #endif
 
-#if !defined(WIN32) && !defined(__MINGW32__)
+#if !defined(WIN32) && !defined(__MINGW32__) && !defined(_WIN32)
 
 #include <errno.h>
 #include <fcntl.h>


### PR DESCRIPTION
Intel's icx compiler defines _WIN32 (with underscore) but not WIN32, causing unistd.h and other POSIX headers to be incorrectly included on Windows builds.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fixes header guards to include `_WIN32` for Intel icx on Windows, preventing incorrect POSIX header inclusion.
> 
>   - **Behavior**:
>     - Fixes header guard to include `_WIN32` in `test/atomic_reader.c`, `test/atomic_writer.c`, and `tools/test/perform/direct_write_perf.c`.
>     - Prevents incorrect inclusion of POSIX headers on Windows when using Intel's icx compiler.
>   - **Files Affected**:
>     - `test/atomic_reader.c`: Adds `_WIN32` to the header guard.
>     - `test/atomic_writer.c`: Adds `_WIN32` to the header guard.
>     - `direct_write_perf.c`: Adds `_WIN32` to the header guard.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=HDFGroup%2Fhdf5&utm_source=github&utm_medium=referral)<sup> for 52194da730902d17aa2356bb6b36385ff29e96c9. You can [customize](https://app.ellipsis.dev/HDFGroup/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->