### PR TITLE
Skip building Doxygen when no documentation inputs have changed 

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1118,26 +1118,12 @@ if (HDF5_BUILD_JAVA)
 endif ()
 
 #-----------------------------------------------------------------------------
-# Add the HDF5 Library Target to the build
-#-----------------------------------------------------------------------------
-add_subdirectory (src)
-
-if (HDF5_ALLOW_EXTERNAL_SUPPORT MATCHES "GIT" OR HDF5_ALLOW_EXTERNAL_SUPPORT MATCHES "TGZ")
-  if ((H5_ZLIB_FOUND AND ZLIB_USE_EXTERNAL) OR (H5_SZIP_FOUND AND SZIP_USE_EXTERNAL))
-    if (BUILD_STATIC_LIBS)
-      add_dependencies (${HDF5_LIB_TARGET} ${LINK_COMP_LIBS})
-    endif ()
-    if (BUILD_SHARED_LIBS)
-      add_dependencies (${HDF5_LIBSH_TARGET} ${LINK_COMP_LIBS})
-    endif ()
-  endif ()
-endif ()
-
-#-----------------------------------------------------------------------------
 # Option to build documentation
+# NOTE: This block must appear before add_subdirectory(src) so that
+# DOXYGEN_FOUND and related variables are visible in src/CMakeLists.txt
+# and all subsequent subdirectories that define doc targets.
 #-----------------------------------------------------------------------------
 if (HDF5_BUILD_DOC AND EXISTS "${HDF5_DOXYGEN_DIR}" AND IS_DIRECTORY "${HDF5_DOXYGEN_DIR}")
-# check if Doxygen is installed
   find_package (Doxygen)
   if (DOXYGEN_FOUND)
     option (HDF5_ENABLE_DOXY_WARNINGS "Enable fail if doxygen parsing has warnings." OFF)
@@ -1153,16 +1139,43 @@ if (HDF5_BUILD_DOC AND EXISTS "${HDF5_DOXYGEN_DIR}" AND IS_DIRECTORY "${HDF5_DOX
     if (Java_VERSION_STRING VERSION_GREATER_EQUAL "25.0.0")
       if (HDF5_ENABLE_JNI)
         set (DOXYGEN_JAVA_DIR ${HDF5_JAVA_SRCJNI_PATH})
-     else ()
+      else ()
         set (DOXYGEN_JAVA_DIR ${HDF5_JAVA_SRC_PATH})
       endif ()
     else ()
       set (DOXYGEN_JAVA_DIR ${HDF5_JAVA_SRCJNI_PATH})
     endif ()
 
+    # Doxygen content and configuration files shared by all doc targets.
+    # Defined here once to avoid duplication in src/ and hl/src/.
+    file (GLOB_RECURSE HDF5_DOXYGEN_CONTENT_INPUTS CONFIGURE_DEPENDS
+      "${HDF5_DOXYGEN_DIR}/dox/*.dox"
+      "${HDF5_DOXYGEN_DIR}/*.html"
+      "${HDF5_DOXYGEN_DIR}/*.css"
+      "${HDF5_DOXYGEN_DIR}/*.xml"
+      "${HDF5_DOXYGEN_DIR}/*.js"
+      "${HDF5_DOXYGEN_DIR}/examples/menus/*.md"
+    )
+
     add_subdirectory (doxygen)
   else ()
     message (WARNING "Doxygen needs to be installed to generate the doxygen documentation")
+  endif ()
+endif ()
+
+#-----------------------------------------------------------------------------
+# Add the HDF5 Library Target to the build
+#-----------------------------------------------------------------------------
+add_subdirectory (src)
+
+if (HDF5_ALLOW_EXTERNAL_SUPPORT MATCHES "GIT" OR HDF5_ALLOW_EXTERNAL_SUPPORT MATCHES "TGZ")
+  if ((H5_ZLIB_FOUND AND ZLIB_USE_EXTERNAL) OR (H5_SZIP_FOUND AND SZIP_USE_EXTERNAL))
+    if (BUILD_STATIC_LIBS)
+      add_dependencies (${HDF5_LIB_TARGET} ${LINK_COMP_LIBS})
+    endif ()
+    if (BUILD_SHARED_LIBS)
+      add_dependencies (${HDF5_LIBSH_TARGET} ${LINK_COMP_LIBS})
+    endif ()
   endif ()
 endif ()
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1147,9 +1147,9 @@ if (HDF5_BUILD_DOC AND EXISTS "${HDF5_DOXYGEN_DIR}" AND IS_DIRECTORY "${HDF5_DOX
     endif ()
 
     # Doxygen content and configuration files shared by all doc targets.
-    # Defined here once to avoid duplication.  CONFIGURE_DEPENDS tells
+    # Defined here once to avoid duplication. CONFIGURE_DEPENDS tells
     # Ninja/Make to re-run CMake when a file is added or removed from these
-    # directories.  The per-null-build cost of checking small, stable
+    # directories. The per-null-build cost of checking small, stable
     # documentation directories is negligible compared to source code globs.
     # GLOB_RECURSE is required so that files added inside subdirectories
     # (e.g. dox/cookbook/, dox/high_level/, examples/tables/) also trigger
@@ -1164,7 +1164,7 @@ if (HDF5_BUILD_DOC AND EXISTS "${HDF5_DOXYGEN_DIR}" AND IS_DIRECTORY "${HDF5_DOX
     )
 
     # Define the umbrella doxygen target once, here, so that ownership is
-    # unambiguous.  Subdirectories and the end-of-file doc block add
+    # unambiguous. Subdirectories and the end-of-file doc block add
     # dependencies to it; the fallback at the bottom of this file handles
     # the case where Doxygen is not found or HDF5_BUILD_DOC is OFF.
     add_custom_target (doxygen)
@@ -1363,7 +1363,7 @@ if (HDF5_BUILD_DOC AND DOXYGEN_FOUND)
     list (APPEND _hdf5_doxy_inputs ${_hdf5_hl_doxy_inputs})
   endif ()
 
-  # Java sources: only when Java bindings are enabled.  DOXYGEN_JAVA_DIR
+  # Java sources: only when Java bindings are enabled. DOXYGEN_JAVA_DIR
   # (set in the HDF5_BUILD_DOC block above) selects the correct path
   # regardless of whether the JNI or pure-Java tree was chosen.
   if (HDF5_BUILD_JAVA)
@@ -1408,12 +1408,12 @@ if (HDF5_BUILD_DOC AND DOXYGEN_FOUND)
   # -----------------------------------------------------------------------
   # Make the stamp file config-agnostic so multi-config generators (VS,
   # Xcode, Ninja Multi-Config) deduplicate the custom command and only run
-  # Doxygen once.  Doxygen writes to a single, config-agnostic output
+  # Doxygen once. Doxygen writes to a single, config-agnostic output
   # directory, so per-config stamps would race over the same HTML files.
   set (_hdf5lib_doc_stamp "${HDF5_SRC_BINARY_DIR}/hdf5lib_doc.stamp")
 
   # Use add_custom_command with a stamp file so that CMake can perform a
-  # timestamp-based up-to-date check.  A bare add_custom_target(... COMMAND
+  # timestamp-based up-to-date check. A bare add_custom_target(... COMMAND
   # ...) would unconditionally invoke Doxygen on every build.
   add_custom_command (
     OUTPUT  "${_hdf5lib_doc_stamp}"

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1163,6 +1163,12 @@ if (HDF5_BUILD_DOC AND EXISTS "${HDF5_DOXYGEN_DIR}" AND IS_DIRECTORY "${HDF5_DOX
       "${HDF5_DOXYGEN_DIR}/*.md"
     )
 
+    # Define the umbrella doxygen target once, here, so that ownership is
+    # unambiguous.  Subdirectories and the end-of-file doc block add
+    # dependencies to it; the fallback at the bottom of this file handles
+    # the case where Doxygen is not found or HDF5_BUILD_DOC is OFF.
+    add_custom_target (doxygen)
+
     add_subdirectory (doxygen)
   else ()
     message (WARNING "Doxygen needs to be installed to generate the doxygen documentation")
@@ -1337,7 +1343,7 @@ if (EXISTS "${HDF5_SOURCE_DIR}/HDF5Examples" AND IS_DIRECTORY "${HDF5_SOURCE_DIR
 endif ()
 
 #-----------------------------------------------------------------------------
-# Define Doxygen documentation targets
+# Define Doxygen documentation target
 # This block must appear AFTER all add_subdirectory() calls so that every
 # language/tool subdirectory has had the opportunity to append its sources
 # to the HDF5_DOXYGEN_LIB_INPUTS and HDF5_DOXYGEN_HL_INPUTS global
@@ -1348,48 +1354,57 @@ if (HDF5_BUILD_DOC AND DOXYGEN_FOUND)
   # -----------------------------------------------------------------------
   # Retrieve explicitly tracked source lists contributed by subdirectories.
   # -----------------------------------------------------------------------
-  get_property (_hdf5lib_doxy_inputs GLOBAL PROPERTY HDF5_DOXYGEN_LIB_INPUTS)
+  get_property (_hdf5_doxy_inputs GLOBAL PROPERTY HDF5_DOXYGEN_LIB_INPUTS)
 
-  # Java sources: enumerated explicitly using DOXYGEN_JAVA_DIR (set above in
-  # the HDF5_BUILD_DOC block) so the correct path is used regardless of
-  # whether the JNI or pure-Java tree was selected.
-  list (APPEND _hdf5lib_doxy_inputs
-    "${DOXYGEN_JAVA_DIR}/hdf/hdf5lib/H5.java"
-    "${DOXYGEN_JAVA_DIR}/hdf/hdf5lib/HDF5Constants.java"
-    "${DOXYGEN_JAVA_DIR}/hdf/hdf5lib/HDFArray.java"
-    "${DOXYGEN_JAVA_DIR}/hdf/hdf5lib/HDFNativeData.java"
-    "${DOXYGEN_JAVA_DIR}/hdf/hdf5lib/exceptions/HDF5Exception.java"
-    "${DOXYGEN_JAVA_DIR}/hdf/hdf5lib/exceptions/HDF5IdException.java"
-    "${DOXYGEN_JAVA_DIR}/hdf/hdf5lib/exceptions/HDF5AttributeException.java"
-    "${DOXYGEN_JAVA_DIR}/hdf/hdf5lib/exceptions/HDF5BtreeException.java"
-    "${DOXYGEN_JAVA_DIR}/hdf/hdf5lib/exceptions/HDF5DataFiltersException.java"
-    "${DOXYGEN_JAVA_DIR}/hdf/hdf5lib/exceptions/HDF5DatasetInterfaceException.java"
-    "${DOXYGEN_JAVA_DIR}/hdf/hdf5lib/exceptions/HDF5DataspaceInterfaceException.java"
-    "${DOXYGEN_JAVA_DIR}/hdf/hdf5lib/exceptions/HDF5DataStorageException.java"
-    "${DOXYGEN_JAVA_DIR}/hdf/hdf5lib/exceptions/HDF5DatatypeInterfaceException.java"
-    "${DOXYGEN_JAVA_DIR}/hdf/hdf5lib/exceptions/HDF5ExternalFileListException.java"
-    "${DOXYGEN_JAVA_DIR}/hdf/hdf5lib/exceptions/HDF5FileInterfaceException.java"
-    "${DOXYGEN_JAVA_DIR}/hdf/hdf5lib/exceptions/HDF5FunctionArgumentException.java"
-    "${DOXYGEN_JAVA_DIR}/hdf/hdf5lib/exceptions/HDF5FunctionEntryExitException.java"
-    "${DOXYGEN_JAVA_DIR}/hdf/hdf5lib/exceptions/HDF5HeapException.java"
-    "${DOXYGEN_JAVA_DIR}/hdf/hdf5lib/exceptions/HDF5InternalErrorException.java"
-    "${DOXYGEN_JAVA_DIR}/hdf/hdf5lib/exceptions/HDF5JavaException.java"
-    "${DOXYGEN_JAVA_DIR}/hdf/hdf5lib/exceptions/HDF5LibraryException.java"
-    "${DOXYGEN_JAVA_DIR}/hdf/hdf5lib/exceptions/HDF5LowLevelIOException.java"
-    "${DOXYGEN_JAVA_DIR}/hdf/hdf5lib/exceptions/HDF5MetaDataCacheException.java"
-    "${DOXYGEN_JAVA_DIR}/hdf/hdf5lib/exceptions/HDF5ObjectHeaderException.java"
-    "${DOXYGEN_JAVA_DIR}/hdf/hdf5lib/exceptions/HDF5PropertyListInterfaceException.java"
-    "${DOXYGEN_JAVA_DIR}/hdf/hdf5lib/exceptions/HDF5ReferenceException.java"
-    "${DOXYGEN_JAVA_DIR}/hdf/hdf5lib/exceptions/HDF5ResourceUnavailableException.java"
-    "${DOXYGEN_JAVA_DIR}/hdf/hdf5lib/exceptions/HDF5SymbolTableException.java"
-  )
+  # Merge HL inputs when the HL library is enabled — there is only one
+  # Doxyfile / output directory, so a single Doxygen invocation covers both.
+  if (HDF5_BUILD_HL_LIB)
+    get_property (_hdf5_hl_doxy_inputs GLOBAL PROPERTY HDF5_DOXYGEN_HL_INPUTS)
+    list (APPEND _hdf5_doxy_inputs ${_hdf5_hl_doxy_inputs})
+  endif ()
 
-  # Shared doxygen content inputs (*.dox, *.html, *.css, etc.) are appended
-  # last so the DEPENDS list is readable with source files first.
-  list (APPEND _hdf5lib_doxy_inputs ${HDF5_DOXYGEN_CONTENT_INPUTS})
+  # Java sources: only when Java bindings are enabled.  DOXYGEN_JAVA_DIR
+  # (set in the HDF5_BUILD_DOC block above) selects the correct path
+  # regardless of whether the JNI or pure-Java tree was chosen.
+  if (HDF5_BUILD_JAVA)
+    list (APPEND _hdf5_doxy_inputs
+      "${DOXYGEN_JAVA_DIR}/hdf/hdf5lib/H5.java"
+      "${DOXYGEN_JAVA_DIR}/hdf/hdf5lib/HDF5Constants.java"
+      "${DOXYGEN_JAVA_DIR}/hdf/hdf5lib/HDFArray.java"
+      "${DOXYGEN_JAVA_DIR}/hdf/hdf5lib/HDFNativeData.java"
+      "${DOXYGEN_JAVA_DIR}/hdf/hdf5lib/exceptions/HDF5Exception.java"
+      "${DOXYGEN_JAVA_DIR}/hdf/hdf5lib/exceptions/HDF5IdException.java"
+      "${DOXYGEN_JAVA_DIR}/hdf/hdf5lib/exceptions/HDF5AttributeException.java"
+      "${DOXYGEN_JAVA_DIR}/hdf/hdf5lib/exceptions/HDF5BtreeException.java"
+      "${DOXYGEN_JAVA_DIR}/hdf/hdf5lib/exceptions/HDF5DataFiltersException.java"
+      "${DOXYGEN_JAVA_DIR}/hdf/hdf5lib/exceptions/HDF5DatasetInterfaceException.java"
+      "${DOXYGEN_JAVA_DIR}/hdf/hdf5lib/exceptions/HDF5DataspaceInterfaceException.java"
+      "${DOXYGEN_JAVA_DIR}/hdf/hdf5lib/exceptions/HDF5DataStorageException.java"
+      "${DOXYGEN_JAVA_DIR}/hdf/hdf5lib/exceptions/HDF5DatatypeInterfaceException.java"
+      "${DOXYGEN_JAVA_DIR}/hdf/hdf5lib/exceptions/HDF5ExternalFileListException.java"
+      "${DOXYGEN_JAVA_DIR}/hdf/hdf5lib/exceptions/HDF5FileInterfaceException.java"
+      "${DOXYGEN_JAVA_DIR}/hdf/hdf5lib/exceptions/HDF5FunctionArgumentException.java"
+      "${DOXYGEN_JAVA_DIR}/hdf/hdf5lib/exceptions/HDF5FunctionEntryExitException.java"
+      "${DOXYGEN_JAVA_DIR}/hdf/hdf5lib/exceptions/HDF5HeapException.java"
+      "${DOXYGEN_JAVA_DIR}/hdf/hdf5lib/exceptions/HDF5InternalErrorException.java"
+      "${DOXYGEN_JAVA_DIR}/hdf/hdf5lib/exceptions/HDF5JavaException.java"
+      "${DOXYGEN_JAVA_DIR}/hdf/hdf5lib/exceptions/HDF5LibraryException.java"
+      "${DOXYGEN_JAVA_DIR}/hdf/hdf5lib/exceptions/HDF5LowLevelIOException.java"
+      "${DOXYGEN_JAVA_DIR}/hdf/hdf5lib/exceptions/HDF5MetaDataCacheException.java"
+      "${DOXYGEN_JAVA_DIR}/hdf/hdf5lib/exceptions/HDF5ObjectHeaderException.java"
+      "${DOXYGEN_JAVA_DIR}/hdf/hdf5lib/exceptions/HDF5PropertyListInterfaceException.java"
+      "${DOXYGEN_JAVA_DIR}/hdf/hdf5lib/exceptions/HDF5ReferenceException.java"
+      "${DOXYGEN_JAVA_DIR}/hdf/hdf5lib/exceptions/HDF5ResourceUnavailableException.java"
+      "${DOXYGEN_JAVA_DIR}/hdf/hdf5lib/exceptions/HDF5SymbolTableException.java"
+    )
+  endif ()
+
+  # Shared doxygen content inputs (*.dox, *.html, *.css, etc.) — defined
+  # earlier in the HDF5_BUILD_DOC block via file(GLOB_RECURSE).
+  list (APPEND _hdf5_doxy_inputs ${HDF5_DOXYGEN_CONTENT_INPUTS})
 
   # -----------------------------------------------------------------------
-  # hdf5lib_doc: main HDF5 library documentation target
+  # hdf5lib_doc: single documentation target for the entire HDF5 API
   # -----------------------------------------------------------------------
   set (_hdf5lib_doc_stamp "${HDF5_SRC_BINARY_DIR}/$<CONFIG>/hdf5lib_doc.stamp")
 
@@ -1404,10 +1419,10 @@ if (HDF5_BUILD_DOC AND DOXYGEN_FOUND)
     COMMAND ${CMAKE_COMMAND} -E make_directory "$<PATH:GET_PARENT_PATH,${_hdf5lib_doc_stamp}>"
     COMMAND ${DOXYGEN_EXECUTABLE} ${HDF5_BINARY_DIR}/Doxyfile
     COMMAND ${CMAKE_COMMAND} -E touch "${_hdf5lib_doc_stamp}"
-    DEPENDS ${_hdf5lib_doxy_inputs}
+    DEPENDS ${_hdf5_doxy_inputs}
             ${HDF5_BINARY_DIR}/Doxyfile
     WORKING_DIRECTORY "${HDF5_SOURCE_DIR}"
-    COMMENT "Generating HDF5 library Source API documentation with Doxygen"
+    COMMENT "Generating HDF5 API documentation with Doxygen"
     VERBATIM
   )
 
@@ -1415,38 +1430,9 @@ if (HDF5_BUILD_DOC AND DOXYGEN_FOUND)
   # SOURCES exposes the dependency list in IDE project trees (CLion, VS, Xcode).
   add_custom_target (hdf5lib_doc ALL
     DEPENDS "${_hdf5lib_doc_stamp}"
-    SOURCES ${_hdf5lib_doxy_inputs}
+    SOURCES ${_hdf5_doxy_inputs}
   )
   add_dependencies (doxygen hdf5lib_doc)
-
-  # -----------------------------------------------------------------------
-  # hdf5hllib_doc: HL library documentation target (optional)
-  # -----------------------------------------------------------------------
-  if (HDF5_BUILD_HL_LIB)
-    get_property (_hdf5hllib_doxy_inputs GLOBAL PROPERTY HDF5_DOXYGEN_HL_INPUTS)
-    list (APPEND _hdf5hllib_doxy_inputs ${HDF5_DOXYGEN_CONTENT_INPUTS})
-
-    set (_hdf5hllib_doc_stamp "${HDF5_HL_SRC_BINARY_DIR}/$<CONFIG>/hdf5hllib_doc.stamp")
-
-    add_custom_command (
-      OUTPUT  "${_hdf5hllib_doc_stamp}"
-      COMMAND ${CMAKE_COMMAND} -E make_directory "$<PATH:GET_PARENT_PATH,${_hdf5hllib_doc_stamp}>"
-      COMMAND ${DOXYGEN_EXECUTABLE} ${HDF5_BINARY_DIR}/Doxyfile
-      COMMAND ${CMAKE_COMMAND} -E touch "${_hdf5hllib_doc_stamp}"
-      DEPENDS ${_hdf5hllib_doxy_inputs}
-              ${HDF5_BINARY_DIR}/Doxyfile
-      WORKING_DIRECTORY "${HDF5_SOURCE_DIR}"
-      COMMENT "Generating HDF5 HL library Source API documentation with Doxygen"
-      VERBATIM
-    )
-
-    # SOURCES exposes the dependency list in IDE project trees (CLion, VS, Xcode).
-    add_custom_target (hdf5hllib_doc ALL
-      DEPENDS "${_hdf5hllib_doc_stamp}"
-      SOURCES ${_hdf5hllib_doxy_inputs}
-    )
-    add_dependencies (doxygen hdf5hllib_doc)
-  endif ()
 
 endif ()
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1406,17 +1406,17 @@ if (HDF5_BUILD_DOC AND DOXYGEN_FOUND)
   # -----------------------------------------------------------------------
   # hdf5lib_doc: single documentation target for the entire HDF5 API
   # -----------------------------------------------------------------------
-  set (_hdf5lib_doc_stamp "${HDF5_SRC_BINARY_DIR}/$<CONFIG>/hdf5lib_doc.stamp")
+  # Make the stamp file config-agnostic so multi-config generators (VS,
+  # Xcode, Ninja Multi-Config) deduplicate the custom command and only run
+  # Doxygen once.  Doxygen writes to a single, config-agnostic output
+  # directory, so per-config stamps would race over the same HTML files.
+  set (_hdf5lib_doc_stamp "${HDF5_SRC_BINARY_DIR}/hdf5lib_doc.stamp")
 
   # Use add_custom_command with a stamp file so that CMake can perform a
   # timestamp-based up-to-date check.  A bare add_custom_target(... COMMAND
   # ...) would unconditionally invoke Doxygen on every build.
-  # The stamp is placed under a per-configuration subdirectory so that
-  # multi-config generators (Visual Studio, Xcode, Ninja Multi-Config) do not
-  # race over a shared stamp file when building Debug and Release in parallel.
   add_custom_command (
     OUTPUT  "${_hdf5lib_doc_stamp}"
-    COMMAND ${CMAKE_COMMAND} -E make_directory "$<PATH:GET_PARENT_PATH,${_hdf5lib_doc_stamp}>"
     COMMAND ${DOXYGEN_EXECUTABLE} ${HDF5_BINARY_DIR}/Doxyfile
     COMMAND ${CMAKE_COMMAND} -E touch "${_hdf5lib_doc_stamp}"
     DEPENDS ${_hdf5_doxy_inputs}

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1151,13 +1151,16 @@ if (HDF5_BUILD_DOC AND EXISTS "${HDF5_DOXYGEN_DIR}" AND IS_DIRECTORY "${HDF5_DOX
     # Ninja/Make to re-run CMake when a file is added or removed from these
     # directories.  The per-null-build cost of checking small, stable
     # documentation directories is negligible compared to source code globs.
-    file (GLOB HDF5_DOXYGEN_CONTENT_INPUTS CONFIGURE_DEPENDS
-      "${HDF5_DOXYGEN_DIR}/dox/*.dox"
+    # GLOB_RECURSE is required so that files added inside subdirectories
+    # (e.g. dox/cookbook/, dox/high_level/, examples/tables/) also trigger
+    # CMake re-configuration.
+    file (GLOB_RECURSE HDF5_DOXYGEN_CONTENT_INPUTS CONFIGURE_DEPENDS
+      "${HDF5_DOXYGEN_DIR}/*.dox"
       "${HDF5_DOXYGEN_DIR}/*.html"
       "${HDF5_DOXYGEN_DIR}/*.css"
       "${HDF5_DOXYGEN_DIR}/*.xml"
       "${HDF5_DOXYGEN_DIR}/*.js"
-      "${HDF5_DOXYGEN_DIR}/examples/menus/*.md"
+      "${HDF5_DOXYGEN_DIR}/*.md"
     )
 
     add_subdirectory (doxygen)
@@ -1388,24 +1391,32 @@ if (HDF5_BUILD_DOC AND DOXYGEN_FOUND)
   # -----------------------------------------------------------------------
   # hdf5lib_doc: main HDF5 library documentation target
   # -----------------------------------------------------------------------
-  set (_hdf5lib_doc_stamp ${HDF5_SRC_BINARY_DIR}/hdf5lib_doc.stamp)
+  set (_hdf5lib_doc_stamp "${HDF5_SRC_BINARY_DIR}/$<CONFIG>/hdf5lib_doc.stamp")
 
   # Use add_custom_command with a stamp file so that CMake can perform a
   # timestamp-based up-to-date check.  A bare add_custom_target(... COMMAND
   # ...) would unconditionally invoke Doxygen on every build.
+  # The stamp is placed under a per-configuration subdirectory so that
+  # multi-config generators (Visual Studio, Xcode, Ninja Multi-Config) do not
+  # race over a shared stamp file when building Debug and Release in parallel.
   add_custom_command (
-    OUTPUT  ${_hdf5lib_doc_stamp}
+    OUTPUT  "${_hdf5lib_doc_stamp}"
+    COMMAND ${CMAKE_COMMAND} -E make_directory "$<PATH:GET_PARENT_PATH,${_hdf5lib_doc_stamp}>"
     COMMAND ${DOXYGEN_EXECUTABLE} ${HDF5_BINARY_DIR}/Doxyfile
-    COMMAND ${CMAKE_COMMAND} -E touch ${_hdf5lib_doc_stamp}
+    COMMAND ${CMAKE_COMMAND} -E touch "${_hdf5lib_doc_stamp}"
     DEPENDS ${_hdf5lib_doxy_inputs}
             ${HDF5_BINARY_DIR}/Doxyfile
-    WORKING_DIRECTORY ${HDF5_SRC_DIR}
+    WORKING_DIRECTORY "${HDF5_SOURCE_DIR}"
     COMMENT "Generating HDF5 library Source API documentation with Doxygen"
     VERBATIM
   )
 
   # Part of ALL so that HDF5_BUILD_DOC=ON builds docs during a normal build.
-  add_custom_target (hdf5lib_doc ALL DEPENDS ${_hdf5lib_doc_stamp})
+  # SOURCES exposes the dependency list in IDE project trees (CLion, VS, Xcode).
+  add_custom_target (hdf5lib_doc ALL
+    DEPENDS "${_hdf5lib_doc_stamp}"
+    SOURCES ${_hdf5lib_doxy_inputs}
+  )
   add_dependencies (doxygen hdf5lib_doc)
 
   # -----------------------------------------------------------------------
@@ -1415,23 +1426,37 @@ if (HDF5_BUILD_DOC AND DOXYGEN_FOUND)
     get_property (_hdf5hllib_doxy_inputs GLOBAL PROPERTY HDF5_DOXYGEN_HL_INPUTS)
     list (APPEND _hdf5hllib_doxy_inputs ${HDF5_DOXYGEN_CONTENT_INPUTS})
 
-    set (_hdf5hllib_doc_stamp ${HDF5_HL_SRC_BINARY_DIR}/hdf5hllib_doc.stamp)
+    set (_hdf5hllib_doc_stamp "${HDF5_HL_SRC_BINARY_DIR}/$<CONFIG>/hdf5hllib_doc.stamp")
 
     add_custom_command (
-      OUTPUT  ${_hdf5hllib_doc_stamp}
+      OUTPUT  "${_hdf5hllib_doc_stamp}"
+      COMMAND ${CMAKE_COMMAND} -E make_directory "$<PATH:GET_PARENT_PATH,${_hdf5hllib_doc_stamp}>"
       COMMAND ${DOXYGEN_EXECUTABLE} ${HDF5_BINARY_DIR}/Doxyfile
-      COMMAND ${CMAKE_COMMAND} -E touch ${_hdf5hllib_doc_stamp}
+      COMMAND ${CMAKE_COMMAND} -E touch "${_hdf5hllib_doc_stamp}"
       DEPENDS ${_hdf5hllib_doxy_inputs}
               ${HDF5_BINARY_DIR}/Doxyfile
-      WORKING_DIRECTORY ${HDF5_HL_SRC_DIR}
+      WORKING_DIRECTORY "${HDF5_SOURCE_DIR}"
       COMMENT "Generating HDF5 HL library Source API documentation with Doxygen"
       VERBATIM
     )
 
-    add_custom_target (hdf5hllib_doc ALL DEPENDS ${_hdf5hllib_doc_stamp})
+    # SOURCES exposes the dependency list in IDE project trees (CLion, VS, Xcode).
+    add_custom_target (hdf5hllib_doc ALL
+      DEPENDS "${_hdf5hllib_doc_stamp}"
+      SOURCES ${_hdf5hllib_doxy_inputs}
+    )
     add_dependencies (doxygen hdf5hllib_doc)
   endif ()
 
+endif ()
+
+# Always define the umbrella doxygen target so that scripts and IDEs can
+# unconditionally reference it (e.g. cmake --build . --target doxygen).
+# When HDF5_BUILD_DOC=OFF or Doxygen is absent this becomes a no-op.
+if (NOT TARGET doxygen)
+  add_custom_target (doxygen
+    COMMENT "Doxygen documentation not enabled (HDF5_BUILD_DOC=OFF or Doxygen not found)"
+  )
 endif ()
 
 include (CMakeInstallation.cmake)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1148,7 +1148,10 @@ if (HDF5_BUILD_DOC AND EXISTS "${HDF5_DOXYGEN_DIR}" AND IS_DIRECTORY "${HDF5_DOX
 
     # Doxygen content and configuration files shared by all doc targets.
     # Defined here once to avoid duplication in src/ and hl/src/.
-    file (GLOB_RECURSE HDF5_DOXYGEN_CONTENT_INPUTS CONFIGURE_DEPENDS
+    # No CONFIGURE_DEPENDS — these files change rarely in structure and
+    # adding/removing one is not worth penalizing every null build.
+    # Edits to existing files still correctly trigger the stamp-file rebuild.
+    file (GLOB HDF5_DOXYGEN_CONTENT_INPUTS
       "${HDF5_DOXYGEN_DIR}/dox/*.dox"
       "${HDF5_DOXYGEN_DIR}/*.html"
       "${HDF5_DOXYGEN_DIR}/*.css"

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1147,11 +1147,11 @@ if (HDF5_BUILD_DOC AND EXISTS "${HDF5_DOXYGEN_DIR}" AND IS_DIRECTORY "${HDF5_DOX
     endif ()
 
     # Doxygen content and configuration files shared by all doc targets.
-    # Defined here once to avoid duplication in src/ and hl/src/.
-    # No CONFIGURE_DEPENDS — these files change rarely in structure and
-    # adding/removing one is not worth penalizing every null build.
-    # Edits to existing files still correctly trigger the stamp-file rebuild.
-    file (GLOB HDF5_DOXYGEN_CONTENT_INPUTS
+    # Defined here once to avoid duplication.  CONFIGURE_DEPENDS tells
+    # Ninja/Make to re-run CMake when a file is added or removed from these
+    # directories.  The per-null-build cost of checking small, stable
+    # documentation directories is negligible compared to source code globs.
+    file (GLOB HDF5_DOXYGEN_CONTENT_INPUTS CONFIGURE_DEPENDS
       "${HDF5_DOXYGEN_DIR}/dox/*.dox"
       "${HDF5_DOXYGEN_DIR}/*.html"
       "${HDF5_DOXYGEN_DIR}/*.css"
@@ -1331,6 +1331,107 @@ if (EXISTS "${HDF5_SOURCE_DIR}/HDF5Examples" AND IS_DIRECTORY "${HDF5_SOURCE_DIR
     set (HDF5_VERSION ${HDF5_PACKAGE_VERSION})
     add_subdirectory (HDF5Examples)
   endif ()
+endif ()
+
+#-----------------------------------------------------------------------------
+# Define Doxygen documentation targets
+# This block must appear AFTER all add_subdirectory() calls so that every
+# language/tool subdirectory has had the opportunity to append its sources
+# to the HDF5_DOXYGEN_LIB_INPUTS and HDF5_DOXYGEN_HL_INPUTS global
+# properties via set_property(GLOBAL APPEND ...).
+#-----------------------------------------------------------------------------
+if (HDF5_BUILD_DOC AND DOXYGEN_FOUND)
+
+  # -----------------------------------------------------------------------
+  # Retrieve explicitly tracked source lists contributed by subdirectories.
+  # -----------------------------------------------------------------------
+  get_property (_hdf5lib_doxy_inputs GLOBAL PROPERTY HDF5_DOXYGEN_LIB_INPUTS)
+
+  # Java sources: enumerated explicitly using DOXYGEN_JAVA_DIR (set above in
+  # the HDF5_BUILD_DOC block) so the correct path is used regardless of
+  # whether the JNI or pure-Java tree was selected.
+  list (APPEND _hdf5lib_doxy_inputs
+    "${DOXYGEN_JAVA_DIR}/hdf/hdf5lib/H5.java"
+    "${DOXYGEN_JAVA_DIR}/hdf/hdf5lib/HDF5Constants.java"
+    "${DOXYGEN_JAVA_DIR}/hdf/hdf5lib/HDFArray.java"
+    "${DOXYGEN_JAVA_DIR}/hdf/hdf5lib/HDFNativeData.java"
+    "${DOXYGEN_JAVA_DIR}/hdf/hdf5lib/exceptions/HDF5Exception.java"
+    "${DOXYGEN_JAVA_DIR}/hdf/hdf5lib/exceptions/HDF5IdException.java"
+    "${DOXYGEN_JAVA_DIR}/hdf/hdf5lib/exceptions/HDF5AttributeException.java"
+    "${DOXYGEN_JAVA_DIR}/hdf/hdf5lib/exceptions/HDF5BtreeException.java"
+    "${DOXYGEN_JAVA_DIR}/hdf/hdf5lib/exceptions/HDF5DataFiltersException.java"
+    "${DOXYGEN_JAVA_DIR}/hdf/hdf5lib/exceptions/HDF5DatasetInterfaceException.java"
+    "${DOXYGEN_JAVA_DIR}/hdf/hdf5lib/exceptions/HDF5DataspaceInterfaceException.java"
+    "${DOXYGEN_JAVA_DIR}/hdf/hdf5lib/exceptions/HDF5DataStorageException.java"
+    "${DOXYGEN_JAVA_DIR}/hdf/hdf5lib/exceptions/HDF5DatatypeInterfaceException.java"
+    "${DOXYGEN_JAVA_DIR}/hdf/hdf5lib/exceptions/HDF5ExternalFileListException.java"
+    "${DOXYGEN_JAVA_DIR}/hdf/hdf5lib/exceptions/HDF5FileInterfaceException.java"
+    "${DOXYGEN_JAVA_DIR}/hdf/hdf5lib/exceptions/HDF5FunctionArgumentException.java"
+    "${DOXYGEN_JAVA_DIR}/hdf/hdf5lib/exceptions/HDF5FunctionEntryExitException.java"
+    "${DOXYGEN_JAVA_DIR}/hdf/hdf5lib/exceptions/HDF5HeapException.java"
+    "${DOXYGEN_JAVA_DIR}/hdf/hdf5lib/exceptions/HDF5InternalErrorException.java"
+    "${DOXYGEN_JAVA_DIR}/hdf/hdf5lib/exceptions/HDF5JavaException.java"
+    "${DOXYGEN_JAVA_DIR}/hdf/hdf5lib/exceptions/HDF5LibraryException.java"
+    "${DOXYGEN_JAVA_DIR}/hdf/hdf5lib/exceptions/HDF5LowLevelIOException.java"
+    "${DOXYGEN_JAVA_DIR}/hdf/hdf5lib/exceptions/HDF5MetaDataCacheException.java"
+    "${DOXYGEN_JAVA_DIR}/hdf/hdf5lib/exceptions/HDF5ObjectHeaderException.java"
+    "${DOXYGEN_JAVA_DIR}/hdf/hdf5lib/exceptions/HDF5PropertyListInterfaceException.java"
+    "${DOXYGEN_JAVA_DIR}/hdf/hdf5lib/exceptions/HDF5ReferenceException.java"
+    "${DOXYGEN_JAVA_DIR}/hdf/hdf5lib/exceptions/HDF5ResourceUnavailableException.java"
+    "${DOXYGEN_JAVA_DIR}/hdf/hdf5lib/exceptions/HDF5SymbolTableException.java"
+  )
+
+  # Shared doxygen content inputs (*.dox, *.html, *.css, etc.) are appended
+  # last so the DEPENDS list is readable with source files first.
+  list (APPEND _hdf5lib_doxy_inputs ${HDF5_DOXYGEN_CONTENT_INPUTS})
+
+  # -----------------------------------------------------------------------
+  # hdf5lib_doc: main HDF5 library documentation target
+  # -----------------------------------------------------------------------
+  set (_hdf5lib_doc_stamp ${HDF5_SRC_BINARY_DIR}/hdf5lib_doc.stamp)
+
+  # Use add_custom_command with a stamp file so that CMake can perform a
+  # timestamp-based up-to-date check.  A bare add_custom_target(... COMMAND
+  # ...) would unconditionally invoke Doxygen on every build.
+  add_custom_command (
+    OUTPUT  ${_hdf5lib_doc_stamp}
+    COMMAND ${DOXYGEN_EXECUTABLE} ${HDF5_BINARY_DIR}/Doxyfile
+    COMMAND ${CMAKE_COMMAND} -E touch ${_hdf5lib_doc_stamp}
+    DEPENDS ${_hdf5lib_doxy_inputs}
+            ${HDF5_BINARY_DIR}/Doxyfile
+    WORKING_DIRECTORY ${HDF5_SRC_DIR}
+    COMMENT "Generating HDF5 library Source API documentation with Doxygen"
+    VERBATIM
+  )
+
+  # Part of ALL so that HDF5_BUILD_DOC=ON builds docs during a normal build.
+  add_custom_target (hdf5lib_doc ALL DEPENDS ${_hdf5lib_doc_stamp})
+  add_dependencies (doxygen hdf5lib_doc)
+
+  # -----------------------------------------------------------------------
+  # hdf5hllib_doc: HL library documentation target (optional)
+  # -----------------------------------------------------------------------
+  if (HDF5_BUILD_HL_LIB)
+    get_property (_hdf5hllib_doxy_inputs GLOBAL PROPERTY HDF5_DOXYGEN_HL_INPUTS)
+    list (APPEND _hdf5hllib_doxy_inputs ${HDF5_DOXYGEN_CONTENT_INPUTS})
+
+    set (_hdf5hllib_doc_stamp ${HDF5_HL_SRC_BINARY_DIR}/hdf5hllib_doc.stamp)
+
+    add_custom_command (
+      OUTPUT  ${_hdf5hllib_doc_stamp}
+      COMMAND ${DOXYGEN_EXECUTABLE} ${HDF5_BINARY_DIR}/Doxyfile
+      COMMAND ${CMAKE_COMMAND} -E touch ${_hdf5hllib_doc_stamp}
+      DEPENDS ${_hdf5hllib_doxy_inputs}
+              ${HDF5_BINARY_DIR}/Doxyfile
+      WORKING_DIRECTORY ${HDF5_HL_SRC_DIR}
+      COMMENT "Generating HDF5 HL library Source API documentation with Doxygen"
+      VERBATIM
+    )
+
+    add_custom_target (hdf5hllib_doc ALL DEPENDS ${_hdf5hllib_doc_stamp})
+    add_dependencies (doxygen hdf5hllib_doc)
+  endif ()
+
 endif ()
 
 include (CMakeInstallation.cmake)

--- a/c++/src/CMakeLists.txt
+++ b/c++/src/CMakeLists.txt
@@ -241,7 +241,7 @@ endif ()
 #-----------------------------------------------------------------------------
 if (DOXYGEN_FOUND)
   # Contribute C++ sources and headers to the main library documentation
-  # input list.  The hdf5lib_doc target is defined at the end of the top-level
+  # input list. The hdf5lib_doc target is defined at the end of the top-level
   # CMakeLists.txt, after this subdirectory is processed, so get_property()
   # there will see these entries.
   set_property (GLOBAL APPEND PROPERTY HDF5_DOXYGEN_LIB_INPUTS

--- a/c++/src/CMakeLists.txt
+++ b/c++/src/CMakeLists.txt
@@ -236,3 +236,17 @@ if (H5_HAVE_PKGCONFIG)
   )
 endif ()
 
+#-----------------------------------------------------------------------------
+# Option to build documentation
+#-----------------------------------------------------------------------------
+if (DOXYGEN_FOUND)
+  # Contribute C++ sources and headers to the main library documentation
+  # input list.  The hdf5lib_doc target is defined at the end of the top-level
+  # CMakeLists.txt, after this subdirectory is processed, so get_property()
+  # there will see these entries.
+  set_property (GLOBAL APPEND PROPERTY HDF5_DOXYGEN_LIB_INPUTS
+    ${CPP_SOURCES}
+    ${CPP_HDRS}
+  )
+endif ()
+

--- a/doxygen/CMakeLists.txt
+++ b/doxygen/CMakeLists.txt
@@ -75,8 +75,4 @@ if (DOXYGEN_FOUND)
       COMPONENT hdfdocuments
   )
 
-  if (NOT TARGET doxygen)
-    add_custom_target (doxygen)
-  endif ()
-
 endif ()

--- a/fortran/src/CMakeLists.txt
+++ b/fortran/src/CMakeLists.txt
@@ -710,7 +710,7 @@ endif ()
 #-----------------------------------------------------------------------------
 if (DOXYGEN_FOUND)
   # Contribute the static (non-generated) Fortran F90 sources to the main
-  # library documentation input list.  Generated files (H5_gen.F90,
+  # library documentation input list. Generated files (H5_gen.F90,
   # H5fortran_types.F90) are build-time artefacts and are omitted since
   # Doxygen does not require them for the API reference.
   set_property (GLOBAL APPEND PROPERTY HDF5_DOXYGEN_LIB_INPUTS

--- a/fortran/src/CMakeLists.txt
+++ b/fortran/src/CMakeLists.txt
@@ -704,3 +704,16 @@ if (H5_HAVE_PKGCONFIG)
     )
   endif ()
 endif ()
+
+#-----------------------------------------------------------------------------
+# Option to build documentation
+#-----------------------------------------------------------------------------
+if (DOXYGEN_FOUND)
+  # Contribute the static (non-generated) Fortran F90 sources to the main
+  # library documentation input list.  Generated files (H5_gen.F90,
+  # H5fortran_types.F90) are build-time artefacts and are omitted since
+  # Doxygen does not require them for the API reference.
+  set_property (GLOBAL APPEND PROPERTY HDF5_DOXYGEN_LIB_INPUTS
+    ${f90_F_BASE_SOURCES}
+  )
+endif ()

--- a/hl/fortran/src/CMakeLists.txt
+++ b/hl/fortran/src/CMakeLists.txt
@@ -403,3 +403,15 @@ install (
     DESTINATION ${HDF5_INSTALL_LIB_DIR}/pkgconfig
     COMPONENT hlfortlibraries
 )
+
+#-----------------------------------------------------------------------------
+# Option to build documentation
+#-----------------------------------------------------------------------------
+if (DOXYGEN_FOUND)
+  # Contribute the HL Fortran F90 sources to the HL library documentation
+  # input list.  The hdf5hllib_doc target is defined at the end of the
+  # top-level CMakeLists.txt, after this subdirectory is processed.
+  set_property (GLOBAL APPEND PROPERTY HDF5_DOXYGEN_HL_INPUTS
+    ${HDF5_HL_F90_F_BASE_SOURCES}
+  )
+endif ()

--- a/hl/fortran/src/CMakeLists.txt
+++ b/hl/fortran/src/CMakeLists.txt
@@ -409,7 +409,7 @@ install (
 #-----------------------------------------------------------------------------
 if (DOXYGEN_FOUND)
   # Contribute the HL Fortran F90 sources to the HL library documentation
-  # input list.  The hdf5hllib_doc target is defined at the end of the
+  # input list. The hdf5hllib_doc target is defined at the end of the
   # top-level CMakeLists.txt, after this subdirectory is processed.
   set_property (GLOBAL APPEND PROPERTY HDF5_DOXYGEN_HL_INPUTS
     ${HDF5_HL_F90_F_BASE_SOURCES}

--- a/hl/src/CMakeLists.txt
+++ b/hl/src/CMakeLists.txt
@@ -177,7 +177,7 @@ install (
 #-----------------------------------------------------------------------------
 if (DOXYGEN_FOUND)
   # Contribute HL public headers to the global property that the top-level
-  # hdf5hllib_doc target reads.  The target itself is defined at the very end
+  # hdf5hllib_doc target reads. The target itself is defined at the very end
   # of the top-level CMakeLists.txt so that hl/fortran/src can also append its
   # F90 sources to HDF5_DOXYGEN_HL_INPUTS before the target is created.
   set_property (GLOBAL APPEND PROPERTY HDF5_DOXYGEN_HL_INPUTS

--- a/hl/src/CMakeLists.txt
+++ b/hl/src/CMakeLists.txt
@@ -187,14 +187,9 @@ if (DOXYGEN_FOUND)
     "${HDF5_SOURCE_DIR}/hl/fortran/src/*.F90"
     # HL tool headers (h5watch is the only HL tool with a documented header)
     "${HDF5_HL_TOOLS_DIR}/h5watch/h5watch.h"
-    # Doxygen content and configuration
-    "${HDF5_DOXYGEN_DIR}/dox/*.dox"
-    "${HDF5_DOXYGEN_DIR}/*.html"
-    "${HDF5_DOXYGEN_DIR}/*.css"
-    "${HDF5_DOXYGEN_DIR}/*.xml"
-    "${HDF5_DOXYGEN_DIR}/*.js"
-    "${HDF5_DOXYGEN_DIR}/examples/menus/*.md"
   )
+  # Append shared doxygen content inputs (defined in top-level CMakeLists.txt)
+  list (APPEND _hdf5hllib_doxy_inputs ${HDF5_DOXYGEN_CONTENT_INPUTS})
 
   set (_hdf5hllib_doc_stamp ${CMAKE_CURRENT_BINARY_DIR}/hdf5hllib_doc.stamp)
 

--- a/hl/src/CMakeLists.txt
+++ b/hl/src/CMakeLists.txt
@@ -204,7 +204,8 @@ if (DOXYGEN_FOUND)
     VERBATIM
   )
 
-  add_custom_target (hdf5hllib_doc ALL DEPENDS ${_hdf5hllib_doc_stamp})
+  # Not part of ALL — build docs on demand via "cmake --build . --target doxygen".
+  add_custom_target (hdf5hllib_doc DEPENDS ${_hdf5hllib_doc_stamp})
 
   if (NOT TARGET doxygen)
     add_custom_target (doxygen)

--- a/hl/src/CMakeLists.txt
+++ b/hl/src/CMakeLists.txt
@@ -176,23 +176,35 @@ install (
 # Option to build documentation
 #-----------------------------------------------------------------------------
 if (DOXYGEN_FOUND)
-# This cmake function requires that the non-default doxyfile settings are provided with set (DOXYGEN_xxx) commands
-# In addition the doxyfile aliases @INCLUDE option is not supported and would need to be provided in a set (DOXYGEN_ALIASES) command.
-#  doxygen_add_docs (hdf5lib_doc
-##      ${HL_SOURCES} ${HL_HEADERS} ${HDF5_DOXYGEN_DIR}/dox
-#      ${DOXYGEN_INPUT_DIRECTORY}
-#      ALL
-#      WORKING_DIRECTORY ${HDF5_HL_SRC_DIR}
-#      COMMENT "Generating HDF5 HL library Source Documentation"
-#  )
+  # Collect HL Doxygen input files for dependency tracking.
+  # See corresponding note in src/CMakeLists.txt regarding the file(GLOB_RECURSE)
+  # trade-off for documentation inputs.
+  file (GLOB_RECURSE _hdf5hllib_doxy_inputs
+    ${HDF5_HL_SRC_DIR}/H5*public.h
+    ${HDF5_HL_SRC_DIR}/H5*module.h
+    ${HDF5_DOXYGEN_DIR}/dox/*.dox
+    ${HDF5_DOXYGEN_DIR}/*.html
+    ${HDF5_DOXYGEN_DIR}/*.css
+    ${HDF5_DOXYGEN_DIR}/*.xml
+    ${HDF5_DOXYGEN_DIR}/*.js
+  )
 
-# This custom target and doxygen/configure work together
-  # Replace variables inside @@ with the current values
-  add_custom_target (hdf5hllib_doc ALL
-        COMMAND ${DOXYGEN_EXECUTABLE} ${HDF5_BINARY_DIR}/Doxyfile
-        WORKING_DIRECTORY ${HDF5_HL_SRC_DIR}
-        COMMENT "Generating HDF5 HL library Source API documentation with Doxygen"
-        VERBATIM )
+  set (_hdf5hllib_doc_stamp ${CMAKE_CURRENT_BINARY_DIR}/hdf5hllib_doc.stamp)
+
+  # Stamp-file pattern: Doxygen is only re-invoked when an input file is
+  # newer than the stamp.  See src/CMakeLists.txt for the detailed rationale.
+  add_custom_command (
+    OUTPUT  ${_hdf5hllib_doc_stamp}
+    COMMAND ${DOXYGEN_EXECUTABLE} ${HDF5_BINARY_DIR}/Doxyfile
+    COMMAND ${CMAKE_COMMAND} -E touch ${_hdf5hllib_doc_stamp}
+    DEPENDS ${_hdf5hllib_doxy_inputs}
+            ${HDF5_BINARY_DIR}/Doxyfile
+    WORKING_DIRECTORY ${HDF5_HL_SRC_DIR}
+    COMMENT "Generating HDF5 HL library Source API documentation with Doxygen"
+    VERBATIM
+  )
+
+  add_custom_target (hdf5hllib_doc ALL DEPENDS ${_hdf5hllib_doc_stamp})
 
   if (NOT TARGET doxygen)
     add_custom_target (doxygen)

--- a/hl/src/CMakeLists.txt
+++ b/hl/src/CMakeLists.txt
@@ -177,18 +177,15 @@ install (
 #-----------------------------------------------------------------------------
 if (DOXYGEN_FOUND)
   # Collect HL Doxygen input files for dependency tracking.
-  # CONFIGURE_DEPENDS ensures that adding or removing a file matching these
-  # patterns will automatically trigger a CMake re-configure.
-  file (GLOB_RECURSE _hdf5hllib_doxy_inputs CONFIGURE_DEPENDS
-    # HL public headers
-    "${HDF5_HL_SRC_DIR}/H5*public.h"
-    "${HDF5_HL_SRC_DIR}/H5*module.h"
-    # HL Fortran sources
-    "${HDF5_SOURCE_DIR}/hl/fortran/src/*.F90"
-    # HL tool headers (h5watch is the only HL tool with a documented header)
+  # HL_HEADERS is the explicit list already maintained in this file.
+  set (_hdf5hllib_doxy_inputs
+    ${HL_HEADERS}
     "${HDF5_HL_TOOLS_DIR}/h5watch/h5watch.h"
   )
-  # Append shared doxygen content inputs (defined in top-level CMakeLists.txt)
+  # HL Fortran sources live in a sibling subdirectory scope; narrow glob.
+  file (GLOB _hdf5hllib_doxy_fortran "${HDF5_SOURCE_DIR}/hl/fortran/src/*.F90")
+  list (APPEND _hdf5hllib_doxy_inputs ${_hdf5hllib_doxy_fortran})
+  # Shared doxygen content inputs (defined in top-level CMakeLists.txt)
   list (APPEND _hdf5hllib_doxy_inputs ${HDF5_DOXYGEN_CONTENT_INPUTS})
 
   set (_hdf5hllib_doc_stamp ${CMAKE_CURRENT_BINARY_DIR}/hdf5hllib_doc.stamp)

--- a/hl/src/CMakeLists.txt
+++ b/hl/src/CMakeLists.txt
@@ -176,39 +176,12 @@ install (
 # Option to build documentation
 #-----------------------------------------------------------------------------
 if (DOXYGEN_FOUND)
-  # Collect HL Doxygen input files for dependency tracking.
-  # HL_HEADERS is the explicit list already maintained in this file.
-  set (_hdf5hllib_doxy_inputs
+  # Contribute HL public headers to the global property that the top-level
+  # hdf5hllib_doc target reads.  The target itself is defined at the very end
+  # of the top-level CMakeLists.txt so that hl/fortran/src can also append its
+  # F90 sources to HDF5_DOXYGEN_HL_INPUTS before the target is created.
+  set_property (GLOBAL APPEND PROPERTY HDF5_DOXYGEN_HL_INPUTS
     ${HL_HEADERS}
     "${HDF5_HL_TOOLS_DIR}/h5watch/h5watch.h"
   )
-  # HL Fortran sources live in a sibling subdirectory scope; narrow glob.
-  file (GLOB _hdf5hllib_doxy_fortran "${HDF5_SOURCE_DIR}/hl/fortran/src/*.F90")
-  list (APPEND _hdf5hllib_doxy_inputs ${_hdf5hllib_doxy_fortran})
-  # Shared doxygen content inputs (defined in top-level CMakeLists.txt)
-  list (APPEND _hdf5hllib_doxy_inputs ${HDF5_DOXYGEN_CONTENT_INPUTS})
-
-  set (_hdf5hllib_doc_stamp ${CMAKE_CURRENT_BINARY_DIR}/hdf5hllib_doc.stamp)
-
-  # Stamp-file pattern: Doxygen is only re-invoked when an input file is
-  # newer than the stamp.  See src/CMakeLists.txt for the detailed rationale.
-  add_custom_command (
-    OUTPUT  ${_hdf5hllib_doc_stamp}
-    COMMAND ${DOXYGEN_EXECUTABLE} ${HDF5_BINARY_DIR}/Doxyfile
-    COMMAND ${CMAKE_COMMAND} -E touch ${_hdf5hllib_doc_stamp}
-    DEPENDS ${_hdf5hllib_doxy_inputs}
-            ${HDF5_BINARY_DIR}/Doxyfile
-    WORKING_DIRECTORY ${HDF5_HL_SRC_DIR}
-    COMMENT "Generating HDF5 HL library Source API documentation with Doxygen"
-    VERBATIM
-  )
-
-  # Part of ALL when HDF5_BUILD_DOC=ON; stamp file prevents redundant rebuilds.
-  add_custom_target (hdf5hllib_doc ALL DEPENDS ${_hdf5hllib_doc_stamp})
-
-  if (NOT TARGET doxygen)
-    add_custom_target (doxygen)
-  endif ()
-
-  add_dependencies (doxygen hdf5hllib_doc)
 endif ()

--- a/hl/src/CMakeLists.txt
+++ b/hl/src/CMakeLists.txt
@@ -177,16 +177,16 @@ install (
 #-----------------------------------------------------------------------------
 if (DOXYGEN_FOUND)
   # Collect HL Doxygen input files for dependency tracking.
-  # See corresponding note in src/CMakeLists.txt regarding the file(GLOB_RECURSE)
-  # trade-off for documentation inputs.
-  file (GLOB_RECURSE _hdf5hllib_doxy_inputs
-    ${HDF5_HL_SRC_DIR}/H5*public.h
-    ${HDF5_HL_SRC_DIR}/H5*module.h
-    ${HDF5_DOXYGEN_DIR}/dox/*.dox
-    ${HDF5_DOXYGEN_DIR}/*.html
-    ${HDF5_DOXYGEN_DIR}/*.css
-    ${HDF5_DOXYGEN_DIR}/*.xml
-    ${HDF5_DOXYGEN_DIR}/*.js
+  # CONFIGURE_DEPENDS ensures that adding or removing a file matching these
+  # patterns will automatically trigger a CMake re-configure.
+  file (GLOB_RECURSE _hdf5hllib_doxy_inputs CONFIGURE_DEPENDS
+    "${HDF5_HL_SRC_DIR}/H5*public.h"
+    "${HDF5_HL_SRC_DIR}/H5*module.h"
+    "${HDF5_DOXYGEN_DIR}/dox/*.dox"
+    "${HDF5_DOXYGEN_DIR}/*.html"
+    "${HDF5_DOXYGEN_DIR}/*.css"
+    "${HDF5_DOXYGEN_DIR}/*.xml"
+    "${HDF5_DOXYGEN_DIR}/*.js"
   )
 
   set (_hdf5hllib_doc_stamp ${CMAKE_CURRENT_BINARY_DIR}/hdf5hllib_doc.stamp)

--- a/hl/src/CMakeLists.txt
+++ b/hl/src/CMakeLists.txt
@@ -204,8 +204,8 @@ if (DOXYGEN_FOUND)
     VERBATIM
   )
 
-  # Not part of ALL — build docs on demand via "cmake --build . --target doxygen".
-  add_custom_target (hdf5hllib_doc DEPENDS ${_hdf5hllib_doc_stamp})
+  # Part of ALL when HDF5_BUILD_DOC=ON; stamp file prevents redundant rebuilds.
+  add_custom_target (hdf5hllib_doc ALL DEPENDS ${_hdf5hllib_doc_stamp})
 
   if (NOT TARGET doxygen)
     add_custom_target (doxygen)

--- a/hl/src/CMakeLists.txt
+++ b/hl/src/CMakeLists.txt
@@ -180,13 +180,20 @@ if (DOXYGEN_FOUND)
   # CONFIGURE_DEPENDS ensures that adding or removing a file matching these
   # patterns will automatically trigger a CMake re-configure.
   file (GLOB_RECURSE _hdf5hllib_doxy_inputs CONFIGURE_DEPENDS
+    # HL public headers
     "${HDF5_HL_SRC_DIR}/H5*public.h"
     "${HDF5_HL_SRC_DIR}/H5*module.h"
+    # HL Fortran sources
+    "${HDF5_SOURCE_DIR}/hl/fortran/src/*.F90"
+    # HL tool headers (h5watch is the only HL tool with a documented header)
+    "${HDF5_HL_TOOLS_DIR}/h5watch/h5watch.h"
+    # Doxygen content and configuration
     "${HDF5_DOXYGEN_DIR}/dox/*.dox"
     "${HDF5_DOXYGEN_DIR}/*.html"
     "${HDF5_DOXYGEN_DIR}/*.css"
     "${HDF5_DOXYGEN_DIR}/*.xml"
     "${HDF5_DOXYGEN_DIR}/*.js"
+    "${HDF5_DOXYGEN_DIR}/examples/menus/*.md"
   )
 
   set (_hdf5hllib_doc_stamp ${CMAKE_CURRENT_BINARY_DIR}/hdf5hllib_doc.stamp)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1452,60 +1452,15 @@ endif ()
 # Option to build documentation
 #-----------------------------------------------------------------------------
 if (DOXYGEN_FOUND)
-  # 1. Gather explicit core headers (zero cost to incremental builds).
-  #    These variables are already maintained in this file.
-  set (_hdf5lib_doxy_inputs
+  # Contribute the core library headers and the H5build_settings.c generated
+  # file to the global property that the top-level doc target reads.  The
+  # hdf5lib_doc target itself is defined at the very end of the top-level
+  # CMakeLists.txt, after all language-binding subdirectories (c++, fortran,
+  # java, tools) have been processed and have appended their own sources to
+  # HDF5_DOXYGEN_LIB_INPUTS.  This eliminates the need for file(GLOB) here.
+  set_property (GLOBAL APPEND PROPERTY HDF5_DOXYGEN_LIB_INPUTS
     ${H5_PUBLIC_HEADERS}
     ${H5_GENERATED_HEADERS}
+    ${HDF5_SRC_BINARY_DIR}/H5build_settings.c
   )
-
-  # 2. Add narrow, directory-specific globs for encapsulated languages
-  #    and tool headers whose source lists live in sibling subdirectory
-  #    scopes and are not visible here.  No CONFIGURE_DEPENDS — avoids
-  #    the Ninja/Make re-evaluation penalty on every null build.  Adding
-  #    a *new* file requires a manual CMake re-run; edits to existing
-  #    files correctly trigger the stamp-file rebuild.
-  file (GLOB _hdf5lib_doxy_lang_inputs
-    "${HDF5_F90_SRC_DIR}/src/*.F90"
-    "${HDF5_CPP_SRC_DIR}/*.h"
-    "${HDF5_CPP_SRC_DIR}/*.cpp"
-    "${DOXYGEN_JAVA_DIR}/hdf/hdf5lib/H5*.java"
-    "${DOXYGEN_JAVA_DIR}/hdf/hdf5lib/HDF*.java"
-    "${DOXYGEN_JAVA_DIR}/hdf/hdf5lib/exceptions/HDF*.java"
-    "${HDF5_TOOLS_SRC_DIR}/*/*.h"
-  )
-
-  # 3. Merge with shared doxygen content inputs (defined in top-level CMakeLists.txt).
-  list (APPEND _hdf5lib_doxy_inputs ${_hdf5lib_doxy_lang_inputs} ${HDF5_DOXYGEN_CONTENT_INPUTS})
-
-  set (_hdf5lib_doc_stamp ${CMAKE_CURRENT_BINARY_DIR}/hdf5lib_doc.stamp)
-
-  # Use add_custom_command with a stamp file so that CMake can perform a
-  # timestamp-based up-to-date check.  A bare add_custom_target(... COMMAND ...)
-  # would unconditionally invoke Doxygen on every build because custom targets
-  # are always considered out-of-date.
-  add_custom_command (
-    OUTPUT  ${_hdf5lib_doc_stamp}
-    COMMAND ${DOXYGEN_EXECUTABLE} ${HDF5_BINARY_DIR}/Doxyfile
-    COMMAND ${CMAKE_COMMAND} -E touch ${_hdf5lib_doc_stamp}
-    DEPENDS ${_hdf5lib_doxy_inputs}
-            ${HDF5_SRC_BINARY_DIR}/H5build_settings.c
-            ${HDF5_BINARY_DIR}/Doxyfile
-    WORKING_DIRECTORY ${HDF5_SRC_DIR}
-    COMMENT "Generating HDF5 library Source API documentation with Doxygen"
-    VERBATIM
-  )
-
-  # Part of ALL so that HDF5_BUILD_DOC=ON builds docs during a normal build.
-  # The stamp-file dependency ensures Doxygen is only re-invoked when an input
-  # file has changed.  Docs can also be built independently of compilation via
-  # the umbrella target: cmake --build . --target doxygen
-  add_custom_target (hdf5lib_doc ALL DEPENDS ${_hdf5lib_doc_stamp})
-
-  if (NOT TARGET doxygen)
-    add_custom_target (doxygen)
-  endif ()
-
-  add_dependencies (doxygen hdf5lib_doc)
-
 endif ()

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1478,9 +1478,9 @@ if (DOXYGEN_FOUND)
   set (_hdf5lib_doc_stamp ${CMAKE_CURRENT_BINARY_DIR}/hdf5lib_doc.stamp)
 
   # Use add_custom_command with a stamp file so that CMake can perform a
-  # timestamp-based up-to-date check.  The previous add_custom_target(... ALL
-  # COMMAND ...) approach unconditionally invoked Doxygen on every build
-  # because custom targets are always considered out-of-date.
+  # timestamp-based up-to-date check.  A bare add_custom_target(... COMMAND ...)
+  # would unconditionally invoke Doxygen on every build because custom targets
+  # are always considered out-of-date.
   add_custom_command (
     OUTPUT  ${_hdf5lib_doc_stamp}
     COMMAND ${DOXYGEN_EXECUTABLE} ${HDF5_BINARY_DIR}/Doxyfile
@@ -1493,7 +1493,10 @@ if (DOXYGEN_FOUND)
     VERBATIM
   )
 
-  add_custom_target (hdf5lib_doc ALL DEPENDS ${_hdf5lib_doc_stamp})
+  # Not part of ALL — documentation is built on demand via the "doxygen" target
+  # (e.g. cmake --build . --target doxygen).  HDF5_BUILD_DOC already gates
+  # whether this infrastructure is configured at all.
+  add_custom_target (hdf5lib_doc DEPENDS ${_hdf5lib_doc_stamp})
 
   if (NOT TARGET doxygen)
     add_custom_target (doxygen)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1458,6 +1458,7 @@ if (DOXYGEN_FOUND)
   # CONFIGURE_DEPENDS ensures that adding or removing a file matching these
   # patterns will automatically trigger a CMake re-configure.
   file (GLOB_RECURSE _hdf5lib_doxy_inputs CONFIGURE_DEPENDS
+    # Core C public/develop/module headers
     "${HDF5_SRC_DIR}/H5*public.h"
     "${HDF5_SRC_DIR}/H5*module.h"
     "${HDF5_SRC_DIR}/H5*develop.h"
@@ -1468,11 +1469,37 @@ if (DOXYGEN_FOUND)
     "${HDF5_SRC_DIR}/H5PLextern.h"
     "${HDF5_SRC_DIR}/H5Zdevelop.h"
     "${HDF5_SRC_DIR}/H5version.h"
+    # Fortran sources (*.F90, excluding test/examples/generated via EXCLUDE_PATTERNS)
+    "${HDF5_F90_SRC_DIR}/src/*.F90"
+    # C++ headers and sources
+    "${HDF5_CPP_SRC_DIR}/*.h"
+    "${HDF5_CPP_SRC_DIR}/*.cpp"
+    # Java sources
+    "${DOXYGEN_JAVA_DIR}/hdf/hdf5lib/H5*.java"
+    "${DOXYGEN_JAVA_DIR}/hdf/hdf5lib/HDF*.java"
+    "${DOXYGEN_JAVA_DIR}/hdf/hdf5lib/exceptions/HDF*.java"
+    # Tool headers
+    "${HDF5_TOOLS_SRC_DIR}/h5copy/h5copy.h"
+    "${HDF5_TOOLS_SRC_DIR}/h5diff/h5diff_main.h"
+    "${HDF5_TOOLS_SRC_DIR}/h5dump/h5dump.h"
+    "${HDF5_TOOLS_SRC_DIR}/h5format_convert/h5format_convert.h"
+    "${HDF5_TOOLS_SRC_DIR}/h5import/h5import.h"
+    "${HDF5_TOOLS_SRC_DIR}/h5jam/h5jam.h"
+    "${HDF5_TOOLS_SRC_DIR}/h5ls/h5ls.h"
+    "${HDF5_TOOLS_SRC_DIR}/h5repack/h5repack.h"
+    "${HDF5_TOOLS_SRC_DIR}/h5stat/h5stat.h"
+    "${HDF5_TOOLS_SRC_DIR}/misc/h5clear.h"
+    "${HDF5_TOOLS_SRC_DIR}/misc/h5debug.h"
+    "${HDF5_TOOLS_SRC_DIR}/misc/h5delete.h"
+    "${HDF5_TOOLS_SRC_DIR}/misc/h5mkgrp.h"
+    "${HDF5_TOOLS_SRC_DIR}/misc/h5repart.h"
+    # Doxygen content and configuration
     "${HDF5_DOXYGEN_DIR}/dox/*.dox"
     "${HDF5_DOXYGEN_DIR}/*.html"
     "${HDF5_DOXYGEN_DIR}/*.css"
     "${HDF5_DOXYGEN_DIR}/*.xml"
     "${HDF5_DOXYGEN_DIR}/*.js"
+    "${HDF5_DOXYGEN_DIR}/examples/menus/*.md"
   )
 
   set (_hdf5lib_doc_stamp ${CMAKE_CURRENT_BINARY_DIR}/hdf5lib_doc.stamp)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1453,11 +1453,11 @@ endif ()
 #-----------------------------------------------------------------------------
 if (DOXYGEN_FOUND)
   # Contribute the core library headers and the H5build_settings.c generated
-  # file to the global property that the top-level doc target reads.  The
+  # file to the global property that the top-level doc target reads. The
   # hdf5lib_doc target itself is defined at the very end of the top-level
   # CMakeLists.txt, after all language-binding subdirectories (c++, fortran,
   # java, tools) have been processed and have appended their own sources to
-  # HDF5_DOXYGEN_LIB_INPUTS.  This eliminates the need for file(GLOB) here.
+  # HDF5_DOXYGEN_LIB_INPUTS. This eliminates the need for file(GLOB) here.
   set_property (GLOBAL APPEND PROPERTY HDF5_DOXYGEN_LIB_INPUTS
     ${H5_PUBLIC_HEADERS}
     ${H5_GENERATED_HEADERS}

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1452,49 +1452,31 @@ endif ()
 # Option to build documentation
 #-----------------------------------------------------------------------------
 if (DOXYGEN_FOUND)
-  # Collect Doxygen input files for dependency tracking so that Doxygen only
-  # re-runs when a relevant file has actually changed.
-  #
-  # Core C headers use the explicit lists already maintained in this file
-  # (H5_PUBLIC_HEADERS, H5_GENERATED_HEADERS) to avoid filesystem globbing.
-  # Bindings in sibling subdirectories (C++, Fortran, Java) use narrow,
-  # directory-scoped globs because their source lists are not in scope here.
-  # These globs do NOT use CONFIGURE_DEPENDS — adding/removing a file in
-  # those directories requires a manual CMake re-run, but edits to existing
-  # files still correctly trigger the stamp-file rebuild.
+  # 1. Gather explicit core headers (zero cost to incremental builds).
+  #    These variables are already maintained in this file.
   set (_hdf5lib_doxy_inputs
-    # Core C public and generated headers (explicit, no glob needed)
     ${H5_PUBLIC_HEADERS}
     ${H5_GENERATED_HEADERS}
-    # Tool headers
-    "${HDF5_TOOLS_SRC_DIR}/h5copy/h5copy.h"
-    "${HDF5_TOOLS_SRC_DIR}/h5diff/h5diff_main.h"
-    "${HDF5_TOOLS_SRC_DIR}/h5dump/h5dump.h"
-    "${HDF5_TOOLS_SRC_DIR}/h5format_convert/h5format_convert.h"
-    "${HDF5_TOOLS_SRC_DIR}/h5import/h5import.h"
-    "${HDF5_TOOLS_SRC_DIR}/h5jam/h5jam.h"
-    "${HDF5_TOOLS_SRC_DIR}/h5ls/h5ls.h"
-    "${HDF5_TOOLS_SRC_DIR}/h5repack/h5repack.h"
-    "${HDF5_TOOLS_SRC_DIR}/h5stat/h5stat.h"
-    "${HDF5_TOOLS_SRC_DIR}/misc/h5clear.h"
-    "${HDF5_TOOLS_SRC_DIR}/misc/h5debug.h"
-    "${HDF5_TOOLS_SRC_DIR}/misc/h5delete.h"
-    "${HDF5_TOOLS_SRC_DIR}/misc/h5mkgrp.h"
-    "${HDF5_TOOLS_SRC_DIR}/misc/h5repart.h"
   )
-  # Bindings whose source lists live in sibling subdirectory scopes.
-  # Narrow globs over small, specific directories (not tree-wide scans).
-  file (GLOB _hdf5lib_doxy_bindings
+
+  # 2. Add narrow, directory-specific globs for encapsulated languages
+  #    and tool headers whose source lists live in sibling subdirectory
+  #    scopes and are not visible here.  No CONFIGURE_DEPENDS — avoids
+  #    the Ninja/Make re-evaluation penalty on every null build.  Adding
+  #    a *new* file requires a manual CMake re-run; edits to existing
+  #    files correctly trigger the stamp-file rebuild.
+  file (GLOB _hdf5lib_doxy_lang_inputs
     "${HDF5_F90_SRC_DIR}/src/*.F90"
     "${HDF5_CPP_SRC_DIR}/*.h"
     "${HDF5_CPP_SRC_DIR}/*.cpp"
     "${DOXYGEN_JAVA_DIR}/hdf/hdf5lib/H5*.java"
     "${DOXYGEN_JAVA_DIR}/hdf/hdf5lib/HDF*.java"
     "${DOXYGEN_JAVA_DIR}/hdf/hdf5lib/exceptions/HDF*.java"
+    "${HDF5_TOOLS_SRC_DIR}/*/*.h"
   )
-  list (APPEND _hdf5lib_doxy_inputs ${_hdf5lib_doxy_bindings})
-  # Shared doxygen content inputs (defined in top-level CMakeLists.txt)
-  list (APPEND _hdf5lib_doxy_inputs ${HDF5_DOXYGEN_CONTENT_INPUTS})
+
+  # 3. Merge with shared doxygen content inputs (defined in top-level CMakeLists.txt).
+  list (APPEND _hdf5lib_doxy_inputs ${_hdf5lib_doxy_lang_inputs} ${HDF5_DOXYGEN_CONTENT_INPUTS})
 
   set (_hdf5lib_doc_stamp ${CMAKE_CURRENT_BINARY_DIR}/hdf5lib_doc.stamp)
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1453,31 +1453,19 @@ endif ()
 #-----------------------------------------------------------------------------
 if (DOXYGEN_FOUND)
   # Collect Doxygen input files for dependency tracking so that Doxygen only
-  # re-runs when a relevant file has actually changed.  The glob patterns here
-  # mirror the FILE_PATTERNS in Doxyfile.in for the core library.
-  # CONFIGURE_DEPENDS ensures that adding or removing a file matching these
-  # patterns will automatically trigger a CMake re-configure.
-  file (GLOB_RECURSE _hdf5lib_doxy_inputs CONFIGURE_DEPENDS
-    # Core C public/develop/module headers
-    "${HDF5_SRC_DIR}/H5*public.h"
-    "${HDF5_SRC_DIR}/H5*module.h"
-    "${HDF5_SRC_DIR}/H5*develop.h"
-    "${HDF5_SRC_DIR}/H5FD*.h"
-    "${HDF5_SRC_DIR}/H5VLconnector.h"
-    "${HDF5_SRC_DIR}/H5VLconnector_passthru.h"
-    "${HDF5_SRC_DIR}/H5VLnative.h"
-    "${HDF5_SRC_DIR}/H5PLextern.h"
-    "${HDF5_SRC_DIR}/H5Zdevelop.h"
-    "${HDF5_SRC_DIR}/H5version.h"
-    # Fortran sources (*.F90, excluding test/examples/generated via EXCLUDE_PATTERNS)
-    "${HDF5_F90_SRC_DIR}/src/*.F90"
-    # C++ headers and sources
-    "${HDF5_CPP_SRC_DIR}/*.h"
-    "${HDF5_CPP_SRC_DIR}/*.cpp"
-    # Java sources
-    "${DOXYGEN_JAVA_DIR}/hdf/hdf5lib/H5*.java"
-    "${DOXYGEN_JAVA_DIR}/hdf/hdf5lib/HDF*.java"
-    "${DOXYGEN_JAVA_DIR}/hdf/hdf5lib/exceptions/HDF*.java"
+  # re-runs when a relevant file has actually changed.
+  #
+  # Core C headers use the explicit lists already maintained in this file
+  # (H5_PUBLIC_HEADERS, H5_GENERATED_HEADERS) to avoid filesystem globbing.
+  # Bindings in sibling subdirectories (C++, Fortran, Java) use narrow,
+  # directory-scoped globs because their source lists are not in scope here.
+  # These globs do NOT use CONFIGURE_DEPENDS — adding/removing a file in
+  # those directories requires a manual CMake re-run, but edits to existing
+  # files still correctly trigger the stamp-file rebuild.
+  set (_hdf5lib_doxy_inputs
+    # Core C public and generated headers (explicit, no glob needed)
+    ${H5_PUBLIC_HEADERS}
+    ${H5_GENERATED_HEADERS}
     # Tool headers
     "${HDF5_TOOLS_SRC_DIR}/h5copy/h5copy.h"
     "${HDF5_TOOLS_SRC_DIR}/h5diff/h5diff_main.h"
@@ -1494,7 +1482,18 @@ if (DOXYGEN_FOUND)
     "${HDF5_TOOLS_SRC_DIR}/misc/h5mkgrp.h"
     "${HDF5_TOOLS_SRC_DIR}/misc/h5repart.h"
   )
-  # Append shared doxygen content inputs (defined in top-level CMakeLists.txt)
+  # Bindings whose source lists live in sibling subdirectory scopes.
+  # Narrow globs over small, specific directories (not tree-wide scans).
+  file (GLOB _hdf5lib_doxy_bindings
+    "${HDF5_F90_SRC_DIR}/src/*.F90"
+    "${HDF5_CPP_SRC_DIR}/*.h"
+    "${HDF5_CPP_SRC_DIR}/*.cpp"
+    "${DOXYGEN_JAVA_DIR}/hdf/hdf5lib/H5*.java"
+    "${DOXYGEN_JAVA_DIR}/hdf/hdf5lib/HDF*.java"
+    "${DOXYGEN_JAVA_DIR}/hdf/hdf5lib/exceptions/HDF*.java"
+  )
+  list (APPEND _hdf5lib_doxy_inputs ${_hdf5lib_doxy_bindings})
+  # Shared doxygen content inputs (defined in top-level CMakeLists.txt)
   list (APPEND _hdf5lib_doxy_inputs ${HDF5_DOXYGEN_CONTENT_INPUTS})
 
   set (_hdf5lib_doc_stamp ${CMAKE_CURRENT_BINARY_DIR}/hdf5lib_doc.stamp)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1452,14 +1452,51 @@ endif ()
 # Option to build documentation
 #-----------------------------------------------------------------------------
 if (DOXYGEN_FOUND)
-  # This custom target and doxygen/configure work together
-  # Replace variables inside @@ with the current values
-  add_custom_target (hdf5lib_doc ALL
-        COMMAND ${DOXYGEN_EXECUTABLE} ${HDF5_BINARY_DIR}/Doxyfile
-        DEPENDS ${HDF5_SRC_BINARY_DIR}/H5build_settings.c
-        WORKING_DIRECTORY ${HDF5_SRC_DIR}
-        COMMENT "Generating HDF5 library Source API documentation with Doxygen"
-        VERBATIM )
+  # Collect Doxygen input files for dependency tracking so that Doxygen only
+  # re-runs when a relevant file has actually changed.  The glob patterns here
+  # mirror the FILE_PATTERNS in Doxyfile.in for the core library.
+  #
+  # NOTE: file(GLOB_RECURSE) is evaluated at configure time, so newly added
+  # files will not trigger a rebuild until the next CMake configure.  This is
+  # an acceptable trade-off for documentation inputs — explicitly listing
+  # hundreds of public headers would be impractical to maintain.
+  file (GLOB_RECURSE _hdf5lib_doxy_inputs
+    ${HDF5_SRC_DIR}/H5*public.h
+    ${HDF5_SRC_DIR}/H5*module.h
+    ${HDF5_SRC_DIR}/H5*develop.h
+    ${HDF5_SRC_DIR}/H5FD*.h
+    ${HDF5_SRC_DIR}/H5VLconnector.h
+    ${HDF5_SRC_DIR}/H5VLconnector_passthru.h
+    ${HDF5_SRC_DIR}/H5VLnative.h
+    ${HDF5_SRC_DIR}/H5PLextern.h
+    ${HDF5_SRC_DIR}/H5Zdevelop.h
+    ${HDF5_SRC_DIR}/H5version.h
+    ${HDF5_DOXYGEN_DIR}/dox/*.dox
+    ${HDF5_DOXYGEN_DIR}/*.html
+    ${HDF5_DOXYGEN_DIR}/*.css
+    ${HDF5_DOXYGEN_DIR}/*.xml
+    ${HDF5_DOXYGEN_DIR}/*.js
+  )
+
+  set (_hdf5lib_doc_stamp ${CMAKE_CURRENT_BINARY_DIR}/hdf5lib_doc.stamp)
+
+  # Use add_custom_command with a stamp file so that CMake can perform a
+  # timestamp-based up-to-date check.  The previous add_custom_target(... ALL
+  # COMMAND ...) approach unconditionally invoked Doxygen on every build
+  # because custom targets are always considered out-of-date.
+  add_custom_command (
+    OUTPUT  ${_hdf5lib_doc_stamp}
+    COMMAND ${DOXYGEN_EXECUTABLE} ${HDF5_BINARY_DIR}/Doxyfile
+    COMMAND ${CMAKE_COMMAND} -E touch ${_hdf5lib_doc_stamp}
+    DEPENDS ${_hdf5lib_doxy_inputs}
+            ${HDF5_SRC_BINARY_DIR}/H5build_settings.c
+            ${HDF5_BINARY_DIR}/Doxyfile
+    WORKING_DIRECTORY ${HDF5_SRC_DIR}
+    COMMENT "Generating HDF5 library Source API documentation with Doxygen"
+    VERBATIM
+  )
+
+  add_custom_target (hdf5lib_doc ALL DEPENDS ${_hdf5lib_doc_stamp})
 
   if (NOT TARGET doxygen)
     add_custom_target (doxygen)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1455,27 +1455,24 @@ if (DOXYGEN_FOUND)
   # Collect Doxygen input files for dependency tracking so that Doxygen only
   # re-runs when a relevant file has actually changed.  The glob patterns here
   # mirror the FILE_PATTERNS in Doxyfile.in for the core library.
-  #
-  # NOTE: file(GLOB_RECURSE) is evaluated at configure time, so newly added
-  # files will not trigger a rebuild until the next CMake configure.  This is
-  # an acceptable trade-off for documentation inputs — explicitly listing
-  # hundreds of public headers would be impractical to maintain.
-  file (GLOB_RECURSE _hdf5lib_doxy_inputs
-    ${HDF5_SRC_DIR}/H5*public.h
-    ${HDF5_SRC_DIR}/H5*module.h
-    ${HDF5_SRC_DIR}/H5*develop.h
-    ${HDF5_SRC_DIR}/H5FD*.h
-    ${HDF5_SRC_DIR}/H5VLconnector.h
-    ${HDF5_SRC_DIR}/H5VLconnector_passthru.h
-    ${HDF5_SRC_DIR}/H5VLnative.h
-    ${HDF5_SRC_DIR}/H5PLextern.h
-    ${HDF5_SRC_DIR}/H5Zdevelop.h
-    ${HDF5_SRC_DIR}/H5version.h
-    ${HDF5_DOXYGEN_DIR}/dox/*.dox
-    ${HDF5_DOXYGEN_DIR}/*.html
-    ${HDF5_DOXYGEN_DIR}/*.css
-    ${HDF5_DOXYGEN_DIR}/*.xml
-    ${HDF5_DOXYGEN_DIR}/*.js
+  # CONFIGURE_DEPENDS ensures that adding or removing a file matching these
+  # patterns will automatically trigger a CMake re-configure.
+  file (GLOB_RECURSE _hdf5lib_doxy_inputs CONFIGURE_DEPENDS
+    "${HDF5_SRC_DIR}/H5*public.h"
+    "${HDF5_SRC_DIR}/H5*module.h"
+    "${HDF5_SRC_DIR}/H5*develop.h"
+    "${HDF5_SRC_DIR}/H5FD*.h"
+    "${HDF5_SRC_DIR}/H5VLconnector.h"
+    "${HDF5_SRC_DIR}/H5VLconnector_passthru.h"
+    "${HDF5_SRC_DIR}/H5VLnative.h"
+    "${HDF5_SRC_DIR}/H5PLextern.h"
+    "${HDF5_SRC_DIR}/H5Zdevelop.h"
+    "${HDF5_SRC_DIR}/H5version.h"
+    "${HDF5_DOXYGEN_DIR}/dox/*.dox"
+    "${HDF5_DOXYGEN_DIR}/*.html"
+    "${HDF5_DOXYGEN_DIR}/*.css"
+    "${HDF5_DOXYGEN_DIR}/*.xml"
+    "${HDF5_DOXYGEN_DIR}/*.js"
   )
 
   set (_hdf5lib_doc_stamp ${CMAKE_CURRENT_BINARY_DIR}/hdf5lib_doc.stamp)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1493,10 +1493,11 @@ if (DOXYGEN_FOUND)
     VERBATIM
   )
 
-  # Not part of ALL — documentation is built on demand via the "doxygen" target
-  # (e.g. cmake --build . --target doxygen).  HDF5_BUILD_DOC already gates
-  # whether this infrastructure is configured at all.
-  add_custom_target (hdf5lib_doc DEPENDS ${_hdf5lib_doc_stamp})
+  # Part of ALL so that HDF5_BUILD_DOC=ON builds docs during a normal build.
+  # The stamp-file dependency ensures Doxygen is only re-invoked when an input
+  # file has changed.  Docs can also be built independently of compilation via
+  # the umbrella target: cmake --build . --target doxygen
+  add_custom_target (hdf5lib_doc ALL DEPENDS ${_hdf5lib_doc_stamp})
 
   if (NOT TARGET doxygen)
     add_custom_target (doxygen)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1493,14 +1493,9 @@ if (DOXYGEN_FOUND)
     "${HDF5_TOOLS_SRC_DIR}/misc/h5delete.h"
     "${HDF5_TOOLS_SRC_DIR}/misc/h5mkgrp.h"
     "${HDF5_TOOLS_SRC_DIR}/misc/h5repart.h"
-    # Doxygen content and configuration
-    "${HDF5_DOXYGEN_DIR}/dox/*.dox"
-    "${HDF5_DOXYGEN_DIR}/*.html"
-    "${HDF5_DOXYGEN_DIR}/*.css"
-    "${HDF5_DOXYGEN_DIR}/*.xml"
-    "${HDF5_DOXYGEN_DIR}/*.js"
-    "${HDF5_DOXYGEN_DIR}/examples/menus/*.md"
   )
+  # Append shared doxygen content inputs (defined in top-level CMakeLists.txt)
+  list (APPEND _hdf5lib_doxy_inputs ${HDF5_DOXYGEN_CONTENT_INPUTS})
 
   set (_hdf5lib_doc_stamp ${CMAKE_CURRENT_BINARY_DIR}/hdf5lib_doc.stamp)
 

--- a/tools/src/CMakeLists.txt
+++ b/tools/src/CMakeLists.txt
@@ -6,10 +6,10 @@ project (HDF5_TOOLS_SRC C)
 #-----------------------------------------------------------------------------
 if (DOXYGEN_FOUND)
   # Contribute tool public headers to the main library documentation input
-  # list.  Headers are enumerated explicitly here, mirroring the explicit
+  # list. Headers are enumerated explicitly here, mirroring the explicit
   # source lists used elsewhere, so that adding a new tool header is tracked
   # by version control and does not require an explanation of why GLOB was
-  # used.  CMAKE_CURRENT_SOURCE_DIR is set to tools/src/ at this point.
+  # used. CMAKE_CURRENT_SOURCE_DIR is set to tools/src/ at this point.
   set_property (GLOBAL APPEND PROPERTY HDF5_DOXYGEN_LIB_INPUTS
     ${CMAKE_CURRENT_SOURCE_DIR}/h5copy/h5copy.h
     ${CMAKE_CURRENT_SOURCE_DIR}/h5diff/h5diff_common.h

--- a/tools/src/CMakeLists.txt
+++ b/tools/src/CMakeLists.txt
@@ -1,6 +1,40 @@
 cmake_minimum_required (VERSION 3.26)
 project (HDF5_TOOLS_SRC C)
 
+#-----------------------------------------------------------------------------
+# Option to build documentation
+#-----------------------------------------------------------------------------
+if (DOXYGEN_FOUND)
+  # Contribute tool public headers to the main library documentation input
+  # list.  Headers are enumerated explicitly here, mirroring the explicit
+  # source lists used elsewhere, so that adding a new tool header is tracked
+  # by version control and does not require an explanation of why GLOB was
+  # used.  CMAKE_CURRENT_SOURCE_DIR is set to tools/src/ at this point.
+  set_property (GLOBAL APPEND PROPERTY HDF5_DOXYGEN_LIB_INPUTS
+    ${CMAKE_CURRENT_SOURCE_DIR}/h5copy/h5copy.h
+    ${CMAKE_CURRENT_SOURCE_DIR}/h5diff/h5diff_common.h
+    ${CMAKE_CURRENT_SOURCE_DIR}/h5diff/h5diff_main.h
+    ${CMAKE_CURRENT_SOURCE_DIR}/h5dump/h5dump.h
+    ${CMAKE_CURRENT_SOURCE_DIR}/h5dump/h5dump_ddl.h
+    ${CMAKE_CURRENT_SOURCE_DIR}/h5dump/h5dump_defines.h
+    ${CMAKE_CURRENT_SOURCE_DIR}/h5dump/h5dump_extern.h
+    ${CMAKE_CURRENT_SOURCE_DIR}/h5dump/h5dump_xml.h
+    ${CMAKE_CURRENT_SOURCE_DIR}/h5format_convert/h5format_convert.h
+    ${CMAKE_CURRENT_SOURCE_DIR}/h5import/h5import.h
+    ${CMAKE_CURRENT_SOURCE_DIR}/h5jam/h5jam.h
+    ${CMAKE_CURRENT_SOURCE_DIR}/h5ls/h5ls.h
+    ${CMAKE_CURRENT_SOURCE_DIR}/h5perf/pio_perf.h
+    ${CMAKE_CURRENT_SOURCE_DIR}/h5perf/sio_perf.h
+    ${CMAKE_CURRENT_SOURCE_DIR}/h5repack/h5repack.h
+    ${CMAKE_CURRENT_SOURCE_DIR}/h5stat/h5stat.h
+    ${CMAKE_CURRENT_SOURCE_DIR}/misc/h5clear.h
+    ${CMAKE_CURRENT_SOURCE_DIR}/misc/h5debug.h
+    ${CMAKE_CURRENT_SOURCE_DIR}/misc/h5delete.h
+    ${CMAKE_CURRENT_SOURCE_DIR}/misc/h5mkgrp.h
+    ${CMAKE_CURRENT_SOURCE_DIR}/misc/h5repart.h
+  )
+endif ()
+
 #-- Add the h5diff and test executables
 add_subdirectory (h5diff)
 


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


Fixes #6247 

> [!IMPORTANT]
> Optimize Doxygen build process by skipping rebuilds when input files are unchanged, using timestamp checks in CMake configuration.
> 
>   - **Behavior**:
>     - Skip Doxygen build if input files unchanged using timestamp check in `CMakeLists.txt`, `hl/src/CMakeLists.txt`, and `src/CMakeLists.txt`.
>     - Introduces stamp files (`hdf5lib_doc.stamp`, `hdf5hllib_doc.stamp`) to track changes.
>   - **Documentation**:
>     - `add_custom_command` and `add_custom_target` used to manage Doxygen builds.
>     - Shared Doxygen content inputs defined in top-level `CMakeLists.txt` for reuse.
>   - **Misc**:
>     - Reorder `add_subdirectory(src)` in `CMakeLists.txt` for visibility of Doxygen variables.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=HDFGroup%2Fhdf5&utm_source=github&utm_medium=referral)<sup> for 640cd81e16f4d6814c5a42dd5d25a1ddd039bebf. You can [customize](https://app.ellipsis.dev/HDFGroup/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->