### PR TITLE
Update path and tarfile name for hdf5_plugins release in

### DIFF
--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -215,11 +215,11 @@
         },
         "PLUGIN_TGZ_ORIGPATH": {
           "type": "STRING",
-          "value": "https://github.com/HDFGroup/hdf5_plugins/releases/download/snapshot"
+          "value": "https://github.com/HDFGroup/hdf5_plugins/releases/download/2.1.0"
         },
         "PLUGIN_TGZ_NAME": {
           "type": "STRING",
-          "value": "hdf5_plugins-master.tar.gz"
+          "value": "hdf5_plugins-2.1.0.tar.gz"
         }
       }
     },


### PR DESCRIPTION
CMakePresets.json.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Update `CMakePresets.json` to use the 2.1.0 release of HDF5 plugins.
> 
>   - **CMakePresets.json**:
>     - Update `PLUGIN_TGZ_ORIGPATH` to `https://github.com/HDFGroup/hdf5_plugins/releases/download/2.1.0`.
>     - Update `PLUGIN_TGZ_NAME` to `hdf5_plugins-2.1.0.tar.gz`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=HDFGroup%2Fhdf5&utm_source=github&utm_medium=referral)<sup> for d88052a40b3bd3d2a44d8db35b7170a53802b183. You can [customize](https://app.ellipsis.dev/HDFGroup/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->