### PR TITLE
Add retries for testing Maven packages in draft releases.

### DIFF
--- a/.github/workflows/test-maven-packages.yml
+++ b/.github/workflows/test-maven-packages.yml
@@ -200,12 +200,12 @@ jobs:
               if curl -u "$GITHUB_ACTOR:$GITHUB_TOKEN" -fsSL "$ARTIFACT_META_URL" \
                    -o /tmp/artifact-metadata.xml 2>/dev/null && \
                  grep -q "<version>${VERSION}</version>" /tmp/artifact-metadata.xml 2>/dev/null; then
-                echo "✅ Release version ${VERSION} is available in GitHub Packages"
+                echo "Release version ${VERSION} is available in GitHub Packages"
                 break
               else
                 RETRY_COUNT=$((RETRY_COUNT + 1))
                 if [ $RETRY_COUNT -lt $MAX_RETRIES ]; then
-                  echo "⏳ Attempt $RETRY_COUNT/$MAX_RETRIES: Version ${VERSION} not yet available. Waiting ${RETRY_DELAY}s for GitHub Packages to propagate..."
+                  echo "Attempt $RETRY_COUNT/$MAX_RETRIES: Version ${VERSION} not yet available. Waiting ${RETRY_DELAY}s for GitHub Packages to propagate..."
                   sleep $RETRY_DELAY
                 else
                   echo "::error::Release artifact version ${VERSION} not available in GitHub Packages after $MAX_RETRIES attempts"
@@ -490,12 +490,12 @@ jobs:
               if curl -u "$GITHUB_ACTOR:$GITHUB_TOKEN" -fsSL "$ARTIFACT_META_URL" \
                    -o /tmp/artifact-metadata.xml 2>/dev/null && \
                  grep -q "<version>${VERSION}</version>" /tmp/artifact-metadata.xml 2>/dev/null; then
-                echo "✅ Release version ${VERSION} is available in GitHub Packages"
+                echo "Release version ${VERSION} is available in GitHub Packages"
                 break
               else
                 RETRY_COUNT=$((RETRY_COUNT + 1))
                 if [ $RETRY_COUNT -lt $MAX_RETRIES ]; then
-                  echo "⏳ Attempt $RETRY_COUNT/$MAX_RETRIES: Version ${VERSION} not yet available. Waiting ${RETRY_DELAY}s for GitHub Packages to propagate..."
+                  echo "Attempt $RETRY_COUNT/$MAX_RETRIES: Version ${VERSION} not yet available. Waiting ${RETRY_DELAY}s for GitHub Packages to propagate..."
                   sleep $RETRY_DELAY
                 else
                   echo "::error::Release artifact version ${VERSION} not available in GitHub Packages after $MAX_RETRIES attempts"

--- a/.github/workflows/test-maven-packages.yml
+++ b/.github/workflows/test-maven-packages.yml
@@ -185,6 +185,35 @@ jobs:
             # Release version - use version as-is
             JAR_FILENAME="${ARTIFACT_ID}-${VERSION}-${PLATFORM_CLASSIFIER}.jar"
             POM_FILENAME="${ARTIFACT_ID}-${VERSION}.pom"
+
+            # For release versions, wait for GitHub Packages to propagate before downloading.
+            # SNAPSHOT versions use the metadata retry above for this purpose; release
+            # versions need an equivalent check using the artifact-level maven-metadata.xml,
+            # which lists all published versions and is updated when a new release is pushed.
+            echo "Verifying release artifact is available on GitHub Packages..."
+            ARTIFACT_META_URL="${REPO_URL}/org/hdfgroup/${ARTIFACT_ID}/maven-metadata.xml"
+            RETRY_COUNT=0
+            MAX_RETRIES=12
+            RETRY_DELAY=10
+
+            while [ $RETRY_COUNT -lt $MAX_RETRIES ]; do
+              if curl -u "$GITHUB_ACTOR:$GITHUB_TOKEN" -fsSL "$ARTIFACT_META_URL" \
+                   -o /tmp/artifact-metadata.xml 2>/dev/null && \
+                 grep -q "<version>${VERSION}</version>" /tmp/artifact-metadata.xml 2>/dev/null; then
+                echo "✅ Release version ${VERSION} is available in GitHub Packages"
+                break
+              else
+                RETRY_COUNT=$((RETRY_COUNT + 1))
+                if [ $RETRY_COUNT -lt $MAX_RETRIES ]; then
+                  echo "⏳ Attempt $RETRY_COUNT/$MAX_RETRIES: Version ${VERSION} not yet available. Waiting ${RETRY_DELAY}s for GitHub Packages to propagate..."
+                  sleep $RETRY_DELAY
+                else
+                  echo "::error::Release artifact version ${VERSION} not available in GitHub Packages after $MAX_RETRIES attempts"
+                  echo "::error::Checked: $ARTIFACT_META_URL"
+                  exit 1
+                fi
+              fi
+            done
           fi
 
           # Download JAR and POM with retry
@@ -446,6 +475,35 @@ jobs:
             # Release version - use version as-is
             JAR_FILENAME="${ARTIFACT_ID}-${VERSION}-${PLATFORM_CLASSIFIER}.jar"
             POM_FILENAME="${ARTIFACT_ID}-${VERSION}.pom"
+
+            # For release versions, wait for GitHub Packages to propagate before downloading.
+            # SNAPSHOT versions use the metadata retry above for this purpose; release
+            # versions need an equivalent check using the artifact-level maven-metadata.xml,
+            # which lists all published versions and is updated when a new release is pushed.
+            echo "Verifying release artifact is available on GitHub Packages..."
+            ARTIFACT_META_URL="${REPO_URL}/org/hdfgroup/${ARTIFACT_ID}/maven-metadata.xml"
+            RETRY_COUNT=0
+            MAX_RETRIES=12
+            RETRY_DELAY=10
+
+            while [ $RETRY_COUNT -lt $MAX_RETRIES ]; do
+              if curl -u "$GITHUB_ACTOR:$GITHUB_TOKEN" -fsSL "$ARTIFACT_META_URL" \
+                   -o /tmp/artifact-metadata.xml 2>/dev/null && \
+                 grep -q "<version>${VERSION}</version>" /tmp/artifact-metadata.xml 2>/dev/null; then
+                echo "✅ Release version ${VERSION} is available in GitHub Packages"
+                break
+              else
+                RETRY_COUNT=$((RETRY_COUNT + 1))
+                if [ $RETRY_COUNT -lt $MAX_RETRIES ]; then
+                  echo "⏳ Attempt $RETRY_COUNT/$MAX_RETRIES: Version ${VERSION} not yet available. Waiting ${RETRY_DELAY}s for GitHub Packages to propagate..."
+                  sleep $RETRY_DELAY
+                else
+                  echo "::error::Release artifact version ${VERSION} not available in GitHub Packages after $MAX_RETRIES attempts"
+                  echo "::error::Checked: $ARTIFACT_META_URL"
+                  exit 1
+                fi
+              fi
+            done
           fi
 
           # Download JAR and POM with retry


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Adds retry logic for downloading Maven release artifacts in `test-maven-packages.yml` to handle GitHub Packages propagation delays.
> 
>   - **Behavior**:
>     - Adds retry logic for downloading Maven release artifacts in `test-maven-packages.yml`.
>     - Checks `maven-metadata.xml` for release version availability with up to 12 retries and 10-second delays.
>     - Logs success or failure after retries, exiting on failure.
>   - **Files**:
>     - Modifies `.github/workflows/test-maven-packages.yml` to include retry logic for both `test-jni-package` and `test-ffm-package` jobs.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=HDFGroup%2Fhdf5&utm_source=github&utm_medium=referral)<sup> for b008d0c3d48047b71daadfbf9d5158a27de3d407. You can [customize](https://app.ellipsis.dev/HDFGroup/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->