### PR TITLE
chore(h5ls): improve help message consistency

### DIFF
--- a/tools/src/h5ls/h5ls.c
+++ b/tools/src/h5ls/h5ls.c
@@ -183,7 +183,7 @@ usage(void)
     PRINTVALSTREAM(rawoutstream, "   -d, --data      Print the values of datasets\n");
     PRINTVALSTREAM(rawoutstream, "   --enable-error-stack\n");
     PRINTVALSTREAM(rawoutstream,
-                   "                   Prints messages from the HDF5 error stack as they occur.\n");
+                   "                   Print messages from the HDF5 error stack as they occur.\n");
     PRINTVALSTREAM(rawoutstream, "   --follow-symlinks\n");
     PRINTVALSTREAM(rawoutstream,
                    "                   Follow symbolic links (soft links and external links)\n");


### PR DESCRIPTION
All other options start with `Print`.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Update help message in `h5ls.c` for `--enable-error-stack` option to start with "Print" for consistency.
> 
>   - **Help Message Consistency**:
>     - In `h5ls.c`, updated help message for `--enable-error-stack` option to start with "Print" instead of "Prints" for consistency with other options.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=HDFGroup%2Fhdf5&utm_source=github&utm_medium=referral)<sup> for 131c94ef4b2b63a8e7a94f7e6367245ac942d53c. You can [customize](https://app.ellipsis.dev/HDFGroup/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->