### PR TITLE
Remove concurrency group setting from AOCC workflow

### DIFF
--- a/.github/workflows/aocc.yml
+++ b/.github/workflows/aocc.yml
@@ -9,10 +9,6 @@ on:
         required: true
         type: string
 
-
-concurrency:
-  group: ${{ github.workflow }}-${{ github.head_ref && github.ref || github.run_id }}
-  cancel-in-progress: true
 permissions:
   contents: read
 


### PR DESCRIPTION
Follow-up to https://github.com/HDFGroup/hdf5/pull/6237.

After the AOCC workflow was converted into a callable workflow that gets called from the main CI workflows in https://github.com/HDFGroup/hdf5/commit/fd280df53a17ba7de1e81f2f439de5169a178baa, it no longer needs a concurrency group setting as it just uses the one specified in `call-workflows.yml`. When https://github.com/HDFGroup/hdf5/pull/6237 changed the concurrency group to match the one specified in `call-workflows.yml`, this started causing a concurrency group deadlock error causing CI to report failure even after all the workflows passed.
<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Remove concurrency group setting from `aocc.yml` to prevent CI deadlock error.
> 
>   - **Workflow Changes**:
>     - Remove `concurrency` group setting from `aocc.yml`.
>     - Prevents concurrency group deadlock error in CI.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=HDFGroup%2Fhdf5&utm_source=github&utm_medium=referral)<sup> for 0291d46fb6a29b6798730e18b72d0c7d12730124. You can [customize](https://app.ellipsis.dev/HDFGroup/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->