### PR TITLE
Fix compilation issue when H5_TOOLS_DEBUG is defined

### DIFF
--- a/tools/lib/h5diff_array.c
+++ b/tools/lib/h5diff_array.c
@@ -2562,7 +2562,7 @@ diff_float_complex_element(unsigned char *mem1, unsigned char *mem2, hsize_t ele
 
     nfound += diff_float_complex(temp1_real, temp1_imag, temp2_real, temp2_imag, elem_idx, opts);
 
-    H5TOOLS_ENDDEBUG(": %" PRIuHSIZE " zero:%d - errstat:%d", nfound, both_zero, opts->err_stat);
+    H5TOOLS_ENDDEBUG(": %" PRIuHSIZE " - errstat:%d", nfound, opts->err_stat);
     return nfound;
 }
 
@@ -2596,7 +2596,7 @@ diff_double_complex_element(unsigned char *mem1, unsigned char *mem2, hsize_t el
 
     nfound += diff_double_complex(temp1_real, temp1_imag, temp2_real, temp2_imag, elem_idx, opts);
 
-    H5TOOLS_ENDDEBUG(": %" PRIuHSIZE " zero:%d - errstat:%d", nfound, both_zero, opts->err_stat);
+    H5TOOLS_ENDDEBUG(": %" PRIuHSIZE " - errstat:%d", nfound, opts->err_stat);
     return nfound;
 }
 
@@ -2630,7 +2630,7 @@ diff_ldouble_complex_element(unsigned char *mem1, unsigned char *mem2, hsize_t e
 
     nfound += diff_ldouble_complex(temp1_real, temp1_imag, temp2_real, temp2_imag, elem_idx, opts);
 
-    H5TOOLS_ENDDEBUG(": %" PRIuHSIZE " zero:%d - errstat:%d", nfound, both_zero, opts->err_stat);
+    H5TOOLS_ENDDEBUG(": %" PRIuHSIZE " - errstat:%d", nfound, opts->err_stat);
     return nfound;
 }
 #endif
@@ -3393,7 +3393,7 @@ diff_complex_element(unsigned char *mem1, unsigned char *mem2, hsize_t elem_idx,
         nfound += diff_ldouble_complex(temp1_real, temp1_imag, temp2_real, temp2_imag, elem_idx, opts);
     }
 
-    H5TOOLS_ENDDEBUG(": %" PRIuHSIZE " zero:%d - errstat:%d", nfound, both_zero, opts->err_stat);
+    H5TOOLS_ENDDEBUG(": %" PRIuHSIZE " - errstat:%d", nfound, opts->err_stat);
     return nfound;
 }
 


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Fixes compilation issue in `h5diff_array.c` by removing unnecessary debug argument from `H5TOOLS_ENDDEBUG` calls when `H5_TOOLS_DEBUG` is defined.
> 
>   - **Compilation Fix**:
>     - Remove `zero:%d` argument from `H5TOOLS_ENDDEBUG` calls in `diff_float_complex_element`, `diff_double_complex_element`, `diff_ldouble_complex_element`, and `diff_complex_element` functions in `h5diff_array.c`.
>   - **Behavior**:
>     - Fixes compilation issue when `H5_TOOLS_DEBUG` is defined by removing unnecessary debug argument.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=HDFGroup%2Fhdf5&utm_source=github&utm_medium=referral)<sup> for ee070cd4e21a4caa84cd2ed7fbe67780843e71d2. You can [customize](https://app.ellipsis.dev/HDFGroup/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->