### PR TITLE
Test

### DIFF
--- a/HDF5Examples/JAVA/test-maven-ffm.sh
+++ b/HDF5Examples/JAVA/test-maven-ffm.sh
@@ -11,8 +11,6 @@
 #   ./test-maven-ffm.sh 2.0.1-SNAPSHOT https://maven.pkg.github.com/HDFGroup/hdf5 /tmp/maven-test-ffm
 #
 
-set -e  # Exit on error
-
 # Determine source directory (where this script lives)
 SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 

--- a/HDF5Examples/JAVA/test-maven-jni.sh
+++ b/HDF5Examples/JAVA/test-maven-jni.sh
@@ -11,8 +11,6 @@
 #   ./test-maven-jni.sh 2.0.1-SNAPSHOT https://maven.pkg.github.com/HDFGroup/hdf5 /tmp/maven-test-jni
 #
 
-set -e  # Exit on error
-
 # Determine source directory (where this script lives)
 SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Remove `set -e` from `test-maven-ffm.sh` and `test-maven-jni.sh` to allow scripts to continue on errors.
> 
>   - **Behavior**:
>     - Remove `set -e` from `test-maven-ffm.sh` and `test-maven-jni.sh`, allowing scripts to continue on errors.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=HDFGroup%2Fhdf5&utm_source=github&utm_medium=referral)<sup> for 20b37ef57ca0336f99cd49d0c2dcbeb67fed00b1. You can [customize](https://app.ellipsis.dev/HDFGroup/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->