### PR TITLE
Remove 'set -e' from Maven testing scripts

### DIFF
--- a/HDF5Examples/JAVA/test-maven-ffm.sh
+++ b/HDF5Examples/JAVA/test-maven-ffm.sh
@@ -11,8 +11,6 @@
 #   ./test-maven-ffm.sh 2.0.1-SNAPSHOT https://maven.pkg.github.com/HDFGroup/hdf5 /tmp/maven-test-ffm
 #
 
-set -e  # Exit on error
-
 # Determine source directory (where this script lives)
 SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 

--- a/HDF5Examples/JAVA/test-maven-jni.sh
+++ b/HDF5Examples/JAVA/test-maven-jni.sh
@@ -11,8 +11,6 @@
 #   ./test-maven-jni.sh 2.0.1-SNAPSHOT https://maven.pkg.github.com/HDFGroup/hdf5 /tmp/maven-test-jni
 #
 
-set -e  # Exit on error
-
 # Determine source directory (where this script lives)
 SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 


### PR DESCRIPTION
These scripts do their own error handling for the most part and failed examples immediately terminate the script and obscure any failures
<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Remove `set -e` from `test-maven-ffm.sh` and `test-maven-jni.sh` to allow internal error handling without immediate termination.
> 
>   - **Scripts**:
>     - Remove `set -e` from `test-maven-ffm.sh` and `test-maven-jni.sh` to prevent immediate termination on error.
>     - Scripts now rely on internal error handling to manage failures and continue execution.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=HDFGroup%2Fhdf5&utm_source=github&utm_medium=referral)<sup> for b87f1c557258c15dd23c9e68d6134c9a70c69713. You can [customize](https://app.ellipsis.dev/HDFGroup/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->