### PR TITLE
test/cache_api: avoid false rpt_fcn pointer mismatch on Windows

### DIFF
--- a/.github/workflows/msys2.yml
+++ b/.github/workflows/msys2.yml
@@ -83,11 +83,11 @@ jobs:
 
       - name: Run Tests
         run: |
-          ctest . --parallel 2 -C ${{ inputs.build_mode }} -E "cache_api|dt_arith|err_compat"
+          ctest . --parallel 2 -C ${{ inputs.build_mode }} -E "dt_arith|err_compat"
         working-directory: ${{ runner.workspace }}/build
 
       - name: Run Expected to Fail Tests
         run: |
-          ctest . --parallel 2 -C ${{ inputs.build_mode }} -R "cache_api|dt_arith|err_compat"
+          ctest . --parallel 2 -C ${{ inputs.build_mode }} -R "dt_arith|err_compat"
         working-directory: ${{ runner.workspace }}/build
         continue-on-error: true

--- a/test/cache_common.c
+++ b/test/cache_common.c
@@ -4990,14 +4990,9 @@ resize_configs_are_equal(const H5C_auto_size_ctl_t *a, const H5C_auto_size_ctl_t
 {
     if (a->version != b->version)
         return (false);
-#if defined(_WIN32)
-    /*
-     * On Windows, function pointer addresses can differ because of import
-     * thunks even when they represent the same callback symbol.
-     */
     else if ((a->rpt_fcn == NULL) != (b->rpt_fcn == NULL))
         return (false);
-#else
+#ifndef H5_HAVE_MINGW
     else if (a->rpt_fcn != b->rpt_fcn)
         return (false);
 #endif

--- a/test/cache_common.c
+++ b/test/cache_common.c
@@ -4990,8 +4990,17 @@ resize_configs_are_equal(const H5C_auto_size_ctl_t *a, const H5C_auto_size_ctl_t
 {
     if (a->version != b->version)
         return (false);
+#if defined(_WIN32)
+    /*
+     * On Windows, function pointer addresses can differ because of import
+     * thunks even when they represent the same callback symbol.
+     */
+    else if ((a->rpt_fcn == NULL) != (b->rpt_fcn == NULL))
+        return (false);
+#else
     else if (a->rpt_fcn != b->rpt_fcn)
         return (false);
+#endif
     else if (compare_init && (a->set_initial_size != b->set_initial_size))
         return (false);
     else if (compare_init && (a->initial_size != b->initial_size))


### PR DESCRIPTION
## Summary
On Windows, raw function-pointer address comparison can differ because of import thunks even when callbacks are semantically equivalent.

This patch updates cache_api test config comparison to avoid false negatives:
- On _WIN32: compare rpt_fcn nullness
- On non-Windows: keep strict pointer equality

## Validation
- Rebuilt cache_api in MinGW
- Ran: ctest --test-dir build-mingw -R "^H5TESTXPR-cache_api$" --output-on-failure
- Result: pass
