### PR TITLE
chore: rename README to README.md in .h5chkright.ini

### DIFF
--- a/.h5chkright.ini
+++ b/.h5chkright.ini
@@ -21,7 +21,7 @@
 skip LICENSE
 
 # Sort of strange to have a copyright notice in README
-skip README
+skip README.md
 
 # Generated files in src.
 skip H5config.h.in


### PR DESCRIPTION
`README` doesn't exist any more.