### PR TITLE
chore: change man page 3c to 3

### DIFF
--- a/src/H5Fmodule.h
+++ b/src/H5Fmodule.h
@@ -925,7 +925,7 @@
  *  ls -l
  * \endcode
  * on a Unix system or the detailed folder listing on an Apple or Microsoft Windows
- * system. The name passed to #H5Fcreate or #H5Fopen should include a printf(3c)-style integer
+ * system. The name passed to #H5Fcreate or #H5Fopen should include a printf(3)-style integer
  * format specifier which will be replaced with the family member number. The first family
  * member is numbered zero (0).
  *

--- a/tools/lib/h5tools.h
+++ b/tools/lib/h5tools.h
@@ -408,7 +408,7 @@ typedef struct h5tool_format_t {
     /*
      * Fields associated with the individual elements.
      *
-     *   fmt:       A printf(3c) format to use to print the value string
+     *   fmt:       A printf(3) format to use to print the value string
      *              after it has been rendered.  The default is "%s".
      *
      *   suf1:      This string is appended to elements which are followed by
@@ -427,7 +427,7 @@ typedef struct h5tool_format_t {
      * Fields associated with the index values printed at the left edge of
      * each line of output.
      *
-     *   n_fmt:     Each index value is printed according to this printf(3c)
+     *   n_fmt:     Each index value is printed according to this printf(3)
      *              format string which should include a format for a long
      *              integer.  The default is "%lu".
      *
@@ -437,7 +437,7 @@ typedef struct h5tool_format_t {
      *   fmt:       After the index values are formatted individually and
      *              separated from one another by some string, the entire
      *              resulting string will be formatted according to this
-     *              printf(3c) format which should include a format for a
+     *              printf(3) format which should include a format for a
      *              character string.  The default is "%s".
      */
     const char *idx_n_fmt; /*index number format           */


### PR DESCRIPTION
Match the convention:

https://github.com/HDFGroup/hdf5/blob/develop/doxygen/dox/code-conventions.dox

3c is Sys-V/SunOS/(Open)Solaris/Illumos/OmniOS/SmartOS convention.