### PR TITLE
bugfix: CMake install Find{libaec,ZLIBNG}.cmake

### DIFF
--- a/CMakeInstallation.cmake
+++ b/CMakeInstallation.cmake
@@ -174,12 +174,12 @@ endif ()
 # Add CMake Find modules to installation
 #-----------------------------------------------------------------------------
 install (
-    FILES ${CMAKE_SOURCE_DIR}/config/cmake/Findlibaec.cmake
+    FILES ${HDF_RESOURCES_DIR}/Findlibaec.cmake
     DESTINATION ${HDF5_INSTALL_CMAKE_DIR}/Modules
     COMPONENT configinstall
 )
 install (
-    FILES ${CMAKE_SOURCE_DIR}/config/cmake/FindZLIBNG.cmake
+    FILES ${HDF_RESOURCES_DIR}/FindZLIBNG.cmake
     DESTINATION ${HDF5_INSTALL_CMAKE_DIR}/Modules
     COMPONENT configinstall
 )


### PR DESCRIPTION
Before this, error on install when using HDF5 via FetchContent as CMAKE_SOURCE_DIR pointed to parent project

fixes #6300