### PR TITLE
Fix integer overflow in array datatype nelem computation

### DIFF
--- a/release_docs/CHANGELOG.md
+++ b/release_docs/CHANGELOG.md
@@ -130,6 +130,10 @@ We would like to thank the many HDF5 community members who contributed to this r
 
    The direct I/O VFD attempts to determine data alignment requirements for a file on file open to try and avoid extra work when data alignment isn't required. Depending on the file access flags used when opening a file, the VFD could incorrectly determine these requirements for either writes or reads, eventually leading to a possible EINVAL return value on write or read. This has been fixed by separately determining the requirements for writes and reads and being more conservative about trying to avoid data alignment requirements.
 
+### Fixed integer overflow in array datatype element count computation
+
+   Fixed a bug in H5O__dtype_decode_helper() where the loop computing the total number of elements in an array datatype had no per-step overflow check. On 64-bit systems, large dimension sizes could cause the element count to wrap around, bypassing the post-loop overflow check and producing silently incorrect results in downstream type conversion and size calculations.
+
 ### Fixed an issue with chunked datasets using the wrong index type with parallel HDF5
 
    Fixed a bug in parallel HDF5 that would cause chunked datasets with fixed dimensions and without filters applied to use the "none" index type instead of the "fixed array" index type.

--- a/src/H5Odtype.c
+++ b/src/H5Odtype.c
@@ -812,8 +812,7 @@ H5O__dtype_decode_helper(unsigned *ioflags /*in,out*/, const uint8_t **pp, H5T_t
                 UINT32DECODE(*pp, dt->shared->u.array.dim[u]);
                 if (dt->shared->u.array.dim[u] != 0 &&
                     dt->shared->u.array.nelem > SIZE_MAX / dt->shared->u.array.dim[u])
-                    HGOTO_ERROR(H5E_DATATYPE, H5E_OVERFLOW, FAIL,
-                                "array element count overflows size_t");
+                    HGOTO_ERROR(H5E_DATATYPE, H5E_OVERFLOW, FAIL, "array element count overflows size_t");
                 dt->shared->u.array.nelem *= dt->shared->u.array.dim[u];
             }
 

--- a/src/H5Odtype.c
+++ b/src/H5Odtype.c
@@ -810,6 +810,10 @@ H5O__dtype_decode_helper(unsigned *ioflags /*in,out*/, const uint8_t **pp, H5T_t
                 HGOTO_ERROR(H5E_OHDR, H5E_OVERFLOW, FAIL, "ran off end of input buffer while decoding");
             for (unsigned u = 0; u < dt->shared->u.array.ndims; u++) {
                 UINT32DECODE(*pp, dt->shared->u.array.dim[u]);
+                if (dt->shared->u.array.dim[u] != 0 &&
+                    dt->shared->u.array.nelem > SIZE_MAX / dt->shared->u.array.dim[u])
+                    HGOTO_ERROR(H5E_DATATYPE, H5E_OVERFLOW, FAIL,
+                                "array element count overflows size_t");
                 dt->shared->u.array.nelem *= dt->shared->u.array.dim[u];
             }
 


### PR DESCRIPTION
 Fixes #6349 

The loop in `H5O__dtype_decode_helper()` that computes `nelem` by multiplying array dimension sizes has no per-step overflow check. 

On 64-bit, three dimensions of 2^22 each wrap `nelem` from 2^66 to 4, bypassing the post-loop overflow check which validates the already-wrapped value. This produces silently incorrect element counts that propagate through type conversion, vlen iteration, and size calculations.

  ## Fix

Add a per-step overflow guard (`nelem > SIZE_MAX / dim[u]`) inside the multiplication loop at `src/H5Odtype.c:813` so the wrap is caught before it happens. 

The `dim[u] != 0` guard prevents division by zero — zero dimensions fall through to the existing size-mismatch check at line 838.

  ## Testing
  - Built with CMake (GCC 14.3, Ubuntu 22.04), no warnings from H5Odtype.c
  - Full test suite passes (2,842 tests, 0 failures)
  - CHANGELOG.md entry included