### PR TITLE
ci: only upload empty SARIF for pull_request events

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -236,7 +236,7 @@ jobs:
           fi
 
       - name: Create empty SARIF file
-        if: needs.analyze.result == 'skipped'
+        if: needs.analyze.result == 'skipped' && github.event_name == 'pull_request'
         run: |
           cat <<'EOF' > "${{ github.workspace }}/empty.sarif"
           {
@@ -250,7 +250,7 @@ jobs:
           EOF
 
       - name: Upload empty SARIF for skipped analysis
-        if: needs.analyze.result == 'skipped'
+        if: needs.analyze.result == 'skipped' && github.event_name == 'pull_request'
         uses: github/codeql-action/upload-sarif@e34fc2711fb7964ca6850c8a8382121f34745f3b # v4.32.4
         with:
           sarif_file: ${{ github.workspace }}/empty.sarif


### PR DESCRIPTION
## Summary
- Restricts the empty SARIF upload in the `codeql-complete` gate job to `pull_request` events only.
- Prevents push-to-develop (e.g. after merging a text-only PR) from overwriting real CodeQL results in the Security tab with an empty SARIF.
- Follows up on #6351.

## Test plan
- [ ] Merge a text-only PR and verify Security tab still shows real CodeQL results for `develop`
- [ ] Open a text-only PR and verify the code scanning requirement is still satisfied