### PR TITLE
chore: fix typo in external link message

### DIFF
--- a/docs/doxygen/examples/H5L_examples.c
+++ b/docs/doxygen/examples/H5L_examples.c
@@ -19,7 +19,7 @@ iter_cb(hid_t group, const char *name, const H5L_info_t *info, void *op_data)
             printf(" soft link.\n");
             break;
         case H5L_TYPE_EXTERNAL:
-            printf("n external link.\n");
+            printf(" external link.\n");
             break;
         default:
             printf(" UFO link.\n");


### PR DESCRIPTION
`n` in `n external` is unnecessary.