### PR TITLE
chore: fix typo in H5pubconf.h.in

### DIFF
--- a/src/H5pubconf.h.in
+++ b/src/H5pubconf.h.in
@@ -653,7 +653,7 @@
 # endif
 #endif
 
-#cmakedefine WORDS_BIGENDIAN @H5_WORDS_BIGENDIANR@
+#cmakedefine WORDS_BIGENDIAN @H5_WORDS_BIGENDIAN@
 
 /* Number of bits in a file offset, on hosts where this is settable. */
 #cmakedefine H5__FILE_OFFSET_BITS


### PR DESCRIPTION
Remove `R` at the end from `#cmakedefine WORDS_BIGENDIAN @H5_WORDS_BIGENDIANR@`.