### PR TITLE
HL: Fix prefix-match bugs in H5TB field lookup and H5DS/H5IM CLASS checks (#5633)

### DIFF
--- a/hl/fortran/src/H5TBff.F90
+++ b/hl/fortran/src/H5TBff.F90
@@ -42,6 +42,12 @@
   USE h5fortran_types
   USE hdf5
 
+  !> Maximum length of a field name buffer returned by h5tbget_field_info_f.
+  !! Matches HLTB_MAX_FIELD_LEN defined in H5TBpublic.h.
+  !! Declare field_names character arrays with at least this length:
+  !!   CHARACTER(LEN=HLTB_MAX_FIELD_LEN_F) :: field_names(nfields)
+  INTEGER, PARAMETER :: HLTB_MAX_FIELD_LEN_F = 255
+
   INTERFACE h5tbwrite_field_name_f
 #ifdef H5_DOXYGEN
      MODULE PROCEDURE h5tbwrite_field_name_f
@@ -209,6 +215,8 @@ CONTAINS
 !! \param nrecords      The number of records.
 !! \param type_size     The size in bytes of the structure associated with the table. Obtained with sizeof or storage_size.
 !! \param field_names   An array containing the names of the fields.
+!!                      Names longer than HLTB_MAX_FIELD_LEN_F - 1 characters
+!!                      are silently truncated when read back by h5tbget_field_info_f().
 !! \param field_offset  An array containing the offsets of the fields.
 !! \param field_types   An array containing the type of the fields.
 !! \param chunk_size    The chunk size.
@@ -325,7 +333,9 @@ CONTAINS
 !! \param nfields       The number of fields
 !! \param nrecords      The number of records
 !! \param type_size     The size in bytes of the structure associated with the table; This value is obtained with sizeof().
-!! \param field_names   An array containing the names of the fields
+!! \param field_names   An array containing the names of the fields.
+!!                      Names longer than HLTB_MAX_FIELD_LEN_F - 1 characters
+!!                      are silently truncated when read back by h5tbget_field_info_f().
 !! \param field_offset  An array containing the offsets of the fields
 !! \param field_types   An array containing the type of the fields
 !! \param chunk_size    The chunk size
@@ -1057,10 +1067,15 @@ CONTAINS
 !! \param loc_id        Location identifier. The identifier may be that of a file or group.
 !! \param dset_name     The name of the dataset to read.
 !! \param nfields       The number of fields.
-!! \param field_names   An array containing the names of the fields.
+!! \param field_names   An array of character buffers to receive the field names.
+!!                      Each element must be declared with at least HLTB_MAX_FIELD_LEN_F
+!!                      characters. Field names longer than HLTB_MAX_FIELD_LEN_F - 1
+!!                      characters are silently truncated. A truncated name may
+!!                      inadvertently match a different, shorter field when subsequently
+!!                      passed to h5tbread_fields_name_f() or h5tbwrite_fields_name_f().
 !! \param field_sizes   An array containing the size of the fields.
-!! \param field_offsets	An array containing the offsets of the fields.
-!! \param type_size	The size of the HDF5 datatype associated with the table
+!! \param field_offsets An array containing the offsets of the fields.
+!! \param type_size     The size of the HDF5 datatype associated with the table
 !!                      (i.e., the size in bytes of the HDF5 compound datatype used to define a row, or record, in the table).
 !! \param errcode       \fortran_error
 !! \param maxlen_out    Maximum character length of the field names.

--- a/hl/src/H5DS.c
+++ b/hl/src/H5DS.c
@@ -2221,6 +2221,7 @@ H5DSis_scale(hid_t did)
     hid_t       aid = H5I_INVALID_HID; /* attribute ID */
     htri_t      attr_class;            /* has the "CLASS" attribute */
     htri_t      is_ds = -1;            /* set to "not a dimension scale" */
+    htri_t      isvl;                  /* result of H5Tis_variable_str */
     H5I_type_t  it;                    /* type of identifier */
     char       *buf = NULL;            /* buffer to read name of attribute */
     size_t      string_size;           /* size of storage for the attribute */
@@ -2261,54 +2262,71 @@ H5DSis_scale(hid_t did)
             is_ds = 0;
             goto out;
         }
-        /* check to make sure string is null-terminated;
-           if not, then it is not dimension scale */
-        if ((strpad = H5Tget_strpad(tid)) < 0)
+        if ((isvl = H5Tis_variable_str(tid)) < 0)
             goto out;
-        if (H5T_STR_NULLTERM != strpad) {
-            is_ds = 0;
-            goto out;
+
+        if (isvl > 0) {
+            /* Variable-length string: H5Aread allocates the string and writes
+             * its address into the buffer; use H5Treclaim to free it after use. */
+            char *vl_str = NULL;
+            hid_t asid   = H5I_INVALID_HID;
+
+            if ((asid = H5Aget_space(aid)) < 0)
+                goto out;
+            if (H5Aread(aid, tid, &vl_str) < 0) {
+                H5Sclose(asid);
+                goto out;
+            }
+            is_ds = (vl_str && strcmp(vl_str, DIMENSION_SCALE_CLASS) == 0) ? 1 : 0;
+            H5Treclaim(tid, asid, H5P_DEFAULT, &vl_str);
+            H5Sclose(asid);
         }
+        else {
+            /* check to make sure string is null-terminated;
+               if not, then it is not dimension scale */
+            if ((strpad = H5Tget_strpad(tid)) < 0)
+                goto out;
+            if (H5T_STR_NULLTERM != strpad) {
+                is_ds = 0;
+                goto out;
+            }
 
-        /* According to Spec string is ASCII and its size should be 16 to hold
-           "DIMENSION_SCALE" string */
-        if ((string_size = H5Tget_size(tid)) == 0)
-            goto out;
-        if (string_size != 16) {
-            is_ds = 0;
-            goto out;
+            /* According to Spec string is ASCII and its size should be 16 to hold
+               "DIMENSION_SCALE" string */
+            if ((string_size = H5Tget_size(tid)) == 0)
+                goto out;
+            if (string_size != 16) {
+                is_ds = 0;
+                goto out;
+            }
+
+            /* Allocate one extra byte and force null termination so strcmp never
+             * reads past the buffer even if some tool wrote the attribute without
+             * honoring the H5T_STR_NULLTERM invariant. */
+            buf = (char *)malloc((size_t)string_size * sizeof(char) + 1);
+            if (buf == NULL)
+                goto out;
+
+            /* Read the attribute */
+            if (H5Aread(aid, tid, buf) < 0)
+                goto out;
+            buf[string_size] = '\0';
+
+            /* compare strings */
+            if (strcmp(buf, DIMENSION_SCALE_CLASS) == 0)
+                is_ds = 1;
+            else
+                is_ds = 0;
         }
-
-        buf = (char *)malloc((size_t)string_size * sizeof(char));
-        if (buf == NULL)
-            goto out;
-
-        /* Read the attribute */
-        if (H5Aread(aid, tid, buf) < 0)
-            goto out;
-
-        /* compare strings */
-        if (strncmp(buf, DIMENSION_SCALE_CLASS, MIN(strlen(DIMENSION_SCALE_CLASS), strlen(buf))) == 0)
-            is_ds = 1;
-
-        free(buf);
-
-        if (H5Tclose(tid) < 0)
-            goto out;
-
-        if (H5Aclose(aid) < 0)
-            goto out;
     }
 out:
-    if (is_ds < 0) {
-        free(buf);
-        H5E_BEGIN_TRY
-        {
-            H5Aclose(aid);
-            H5Tclose(tid);
-        }
-        H5E_END_TRY
+    free(buf);
+    H5E_BEGIN_TRY
+    {
+        H5Aclose(aid);
+        H5Tclose(tid);
     }
+    H5E_END_TRY
     return is_ds;
 }
 
@@ -2441,6 +2459,7 @@ static herr_t
 H5DS_is_reserved(hid_t did, bool *is_reserved)
 {
     htri_t has_class;
+    htri_t isvl;
     hid_t  tid = H5I_INVALID_HID;
     hid_t  aid = H5I_INVALID_HID;
     char  *buf = NULL;  /* Name of attribute */
@@ -2463,28 +2482,53 @@ H5DS_is_reserved(hid_t did, bool *is_reserved)
     if (H5T_STRING != H5Tget_class(tid))
         goto error;
 
-    /* Check to make sure string is null-terminated */
-    if (H5T_STR_NULLTERM != H5Tget_strpad(tid))
+    if ((isvl = H5Tis_variable_str(tid)) < 0)
         goto error;
 
-    /* Allocate buffer large enough to hold string */
-    if ((string_size = H5Tget_size(tid)) == 0)
-        goto error;
-    if (NULL == (buf = malloc(string_size * sizeof(char))))
-        goto error;
+    if (isvl > 0) {
+        /* Variable-length string: H5Aread allocates the string and writes
+         * its address into the buffer; use H5Treclaim to free it after use. */
+        char *vl_str = NULL;
+        hid_t asid   = H5I_INVALID_HID;
 
-    /* Read the attribute */
-    if (H5Aread(aid, tid, buf) < 0)
-        goto error;
+        if ((asid = H5Aget_space(aid)) < 0)
+            goto error;
+        if (H5Aread(aid, tid, &vl_str) < 0) {
+            H5Sclose(asid);
+            goto error;
+        }
+        *is_reserved = vl_str && (strcmp(vl_str, IMAGE_CLASS) == 0 || strcmp(vl_str, PALETTE_CLASS) == 0 ||
+                                  strcmp(vl_str, TABLE_CLASS) == 0);
+        H5Treclaim(tid, asid, H5P_DEFAULT, &vl_str);
+        H5Sclose(asid);
+    }
+    else {
+        /* Check to make sure string is null-terminated */
+        if (H5T_STR_NULLTERM != H5Tget_strpad(tid))
+            goto error;
 
-    if (strncmp(buf, IMAGE_CLASS, MIN(strlen(IMAGE_CLASS), strlen(buf))) == 0 ||
-        strncmp(buf, PALETTE_CLASS, MIN(strlen(PALETTE_CLASS), strlen(buf))) == 0 ||
-        strncmp(buf, TABLE_CLASS, MIN(strlen(TABLE_CLASS), strlen(buf))) == 0)
-        *is_reserved = true;
-    else
-        *is_reserved = false;
+        /* Allocate buffer large enough to hold string */
+        if ((string_size = H5Tget_size(tid)) == 0)
+            goto error;
+        /* Allocate one extra byte and force null termination so strcmp never
+         * reads past the buffer even if some tool wrote the attribute without
+         * honoring the H5T_STR_NULLTERM invariant. */
+        if (NULL == (buf = malloc(string_size * sizeof(char) + 1)))
+            goto error;
 
-    free(buf);
+        /* Read the attribute */
+        if (H5Aread(aid, tid, buf) < 0)
+            goto error;
+        buf[string_size] = '\0';
+
+        if (strcmp(buf, IMAGE_CLASS) == 0 || strcmp(buf, PALETTE_CLASS) == 0 || strcmp(buf, TABLE_CLASS) == 0)
+            *is_reserved = true;
+        else
+            *is_reserved = false;
+
+        free(buf);
+        buf = NULL;
+    }
 
     if (H5Tclose(tid) < 0)
         goto error;

--- a/hl/src/H5IM.c
+++ b/hl/src/H5IM.c
@@ -967,6 +967,101 @@ out:
 }
 
 /*-------------------------------------------------------------------------
+ * Function: H5IM__class_attr_equals
+ *
+ * Purpose: Opens dset_name under loc_id, reads its "CLASS" attribute
+ *          (fixed-length or variable-length string), and returns 1 if the
+ *          value equals expected, 0 if it does not, or -1 on error.
+ *
+ *-------------------------------------------------------------------------
+ */
+static htri_t
+H5IM__class_attr_equals(hid_t loc_id, const char *dset_name, const char *expected)
+{
+    hid_t   did       = H5I_INVALID_HID;
+    hid_t   atid      = H5I_INVALID_HID;
+    hid_t   aid       = H5I_INVALID_HID;
+    char   *attr_data = NULL;
+    htri_t  has_class;
+    htri_t  isvl;
+    hsize_t storage_size;
+    htri_t  ret = -1;
+
+    if (dset_name == NULL)
+        return -1;
+
+    if ((did = H5Dopen2(loc_id, dset_name, H5P_DEFAULT)) < 0)
+        goto out;
+
+    if ((has_class = H5Aexists(did, "CLASS")) < 0)
+        goto out;
+
+    if (has_class == 0) {
+        ret = 0;
+        goto out;
+    }
+
+    if ((aid = H5Aopen(did, "CLASS", H5P_DEFAULT)) < 0)
+        goto out;
+
+    if ((atid = H5Aget_type(aid)) < 0)
+        goto out;
+
+    if (H5T_STRING != H5Tget_class(atid))
+        goto out;
+
+    if ((isvl = H5Tis_variable_str(atid)) < 0)
+        goto out;
+
+    if (isvl > 0) {
+        /* Variable-length string: H5Aread allocates the string and writes
+         * its address into the buffer; use H5Treclaim to free it after use. */
+        char *vl_str = NULL;
+        hid_t sid    = H5I_INVALID_HID;
+
+        if ((sid = H5Aget_space(aid)) < 0)
+            goto out;
+        if (H5Aread(aid, atid, &vl_str) < 0) {
+            H5Sclose(sid);
+            goto out;
+        }
+        ret = (vl_str && strcmp(vl_str, expected) == 0) ? 1 : 0;
+        H5Treclaim(atid, sid, H5P_DEFAULT, &vl_str);
+        H5Sclose(sid);
+    }
+    else {
+        if (H5T_STR_NULLTERM != H5Tget_strpad(atid))
+            goto out;
+
+        if ((storage_size = H5Aget_storage_size(aid)) == 0)
+            goto out;
+
+        /* Allocate one extra byte; force null termination in case the attribute
+         * was written without honoring H5T_STR_NULLTERM. */
+        attr_data = (char *)malloc((size_t)storage_size * sizeof(char) + 1);
+        if (attr_data == NULL)
+            goto out;
+
+        if (H5Aread(aid, atid, attr_data) < 0)
+            goto out;
+        attr_data[storage_size] = '\0';
+
+        ret = (strcmp(attr_data, expected) == 0) ? 1 : 0;
+    }
+
+out:
+    free(attr_data);
+    H5E_BEGIN_TRY
+    {
+        H5Tclose(atid);
+        H5Aclose(aid);
+        H5Dclose(did);
+    }
+    H5E_END_TRY
+    return ret;
+}
+
+/*-------------------------------------------------------------------------
  * Function: H5IMis_image
  *
  * Purpose:
@@ -982,83 +1077,7 @@ out:
 herr_t
 H5IMis_image(hid_t loc_id, const char *dset_name)
 {
-    hid_t   did;
-    htri_t  has_class;
-    hid_t   atid;
-    hid_t   aid = -1;
-    char   *attr_data;    /* Name of attribute */
-    hsize_t storage_size; /* Size of storage for attribute */
-    herr_t  ret;
-
-    /* check the arguments */
-    if (dset_name == NULL)
-        return -1;
-
-    /* Assume initially fail condition */
-    ret = -1;
-
-    /* Open the dataset. */
-    if ((did = H5Dopen2(loc_id, dset_name, H5P_DEFAULT)) < 0)
-        return -1;
-
-    /* Try to find the attribute "CLASS" on the dataset */
-    if ((has_class = H5Aexists(did, "CLASS")) < 0)
-        goto out;
-
-    if (has_class == 0) {
-        H5Dclose(did);
-        return 0;
-    }
-    else {
-
-        if ((aid = H5Aopen(did, "CLASS", H5P_DEFAULT)) < 0)
-            goto out;
-
-        if ((atid = H5Aget_type(aid)) < 0)
-            goto out;
-
-        /* check to make sure attribute is a string */
-        if (H5T_STRING != H5Tget_class(atid))
-            goto out;
-
-        /* check to make sure string is null-terminated */
-        if (H5T_STR_NULLTERM != H5Tget_strpad(atid))
-            goto out;
-
-        /* allocate buffer large enough to hold string */
-        if ((storage_size = H5Aget_storage_size(aid)) == 0)
-            goto out;
-
-        attr_data = (char *)malloc((size_t)storage_size * sizeof(char) + 1);
-        if (attr_data == NULL)
-            goto out;
-
-        if (H5Aread(aid, atid, attr_data) < 0)
-            goto out;
-
-        if (strncmp(attr_data, IMAGE_CLASS, MIN(strlen(IMAGE_CLASS), strlen(attr_data))) == 0)
-            ret = 1;
-        else
-            ret = 0;
-
-        free(attr_data);
-
-        if (H5Tclose(atid) < 0)
-            goto out;
-
-        if (H5Aclose(aid) < 0)
-            goto out;
-    }
-
-    /* Close the dataset. */
-    if (H5Dclose(did) < 0)
-        return -1;
-
-    return ret;
-
-out:
-    H5Dclose(did);
-    return -1;
+    return H5IM__class_attr_equals(loc_id, dset_name, IMAGE_CLASS);
 }
 
 /*-------------------------------------------------------------------------
@@ -1077,81 +1096,5 @@ out:
 herr_t
 H5IMis_palette(hid_t loc_id, const char *dset_name)
 {
-    hid_t   did;
-    htri_t  has_class;
-    hid_t   atid;
-    hid_t   aid = -1;
-    char   *attr_data;    /* Name of attribute */
-    hsize_t storage_size; /* Size of storage for attribute */
-    herr_t  ret;
-
-    /* check the arguments */
-    if (dset_name == NULL)
-        return -1;
-
-    /* Assume initially fail condition */
-    ret = -1;
-
-    /* Open the dataset. */
-    if ((did = H5Dopen2(loc_id, dset_name, H5P_DEFAULT)) < 0)
-        return -1;
-
-    /* Try to find the attribute "CLASS" on the dataset */
-    if ((has_class = H5Aexists(did, "CLASS")) < 0)
-        goto out;
-
-    if (has_class == 0) {
-        H5Dclose(did);
-        return 0;
-    }
-    else {
-
-        if ((aid = H5Aopen(did, "CLASS", H5P_DEFAULT)) < 0)
-            goto out;
-
-        if ((atid = H5Aget_type(aid)) < 0)
-            goto out;
-
-        /* check to make sure attribute is a string */
-        if (H5T_STRING != H5Tget_class(atid))
-            goto out;
-
-        /* check to make sure string is null-terminated */
-        if (H5T_STR_NULLTERM != H5Tget_strpad(atid))
-            goto out;
-
-        /* allocate buffer large enough to hold string */
-        if ((storage_size = H5Aget_storage_size(aid)) == 0)
-            goto out;
-
-        attr_data = (char *)malloc((size_t)storage_size * sizeof(char) + 1);
-        if (attr_data == NULL)
-            goto out;
-
-        if (H5Aread(aid, atid, attr_data) < 0)
-            goto out;
-
-        if (strncmp(attr_data, PALETTE_CLASS, MIN(strlen(PALETTE_CLASS), strlen(attr_data))) == 0)
-            ret = 1;
-        else
-            ret = 0;
-
-        free(attr_data);
-
-        if (H5Tclose(atid) < 0)
-            goto out;
-
-        if (H5Aclose(aid) < 0)
-            goto out;
-    }
-
-    /* Close the dataset. */
-    if (H5Dclose(did) < 0)
-        return -1;
-
-    return ret;
-
-out:
-    H5Dclose(did);
-    return -1;
+    return H5IM__class_attr_equals(loc_id, dset_name, PALETTE_CLASS);
 }

--- a/hl/src/H5TB.c
+++ b/hl/src/H5TB.c
@@ -497,6 +497,11 @@ H5TBwrite_fields_name(hid_t loc_id, const char *dset_name, const char *field_nam
         member_name = NULL;
     } /* end for */
 
+    /* check to make sure at least one field was found, no reason to continue if none exist;
+       ret_val is already -1 from initialization, so goto out returns failure */
+    if (j == 0)
+        goto out;
+
     /* get the dataspace handle */
     if ((file_space_id = H5Dget_space(did)) < 0)
         goto out;
@@ -3021,11 +3026,23 @@ H5TBget_field_info(hid_t loc_id, const char *dset_name, char *field_names[], siz
     for (i = 0; i < nfields; i++) {
         /* get the member name */
         if (field_names) {
-            char *member_name;
+            char  *member_name;
+            size_t name_len;
 
             if (NULL == (member_name = H5Tget_member_name(tid, (unsigned)i)))
                 goto out;
-            strcpy(field_names[i], member_name);
+
+            name_len = strlen(member_name);
+            if (name_len >= HLTB_MAX_FIELD_LEN) {
+                memcpy(field_names[i], member_name, HLTB_MAX_FIELD_LEN - 1);
+                field_names[i][HLTB_MAX_FIELD_LEN - 1] = '\0';
+            }
+            else {
+                /* name_len < HLTB_MAX_FIELD_LEN, so name_len + 1 <= HLTB_MAX_FIELD_LEN.
+                 * Callers must provide buffers of at least HLTB_MAX_FIELD_LEN bytes each
+                 * (documented in H5TBpublic.h), so this copy is within bounds. */
+                memcpy(field_names[i], member_name, name_len + 1);
+            }
             H5free_memory(member_name);
         } /* end if */
 
@@ -3111,7 +3128,7 @@ H5TB_find_field(const char *field, const char *field_list)
         start = end + 1;
     } /* end while */
 
-    if (strncmp(start, field, strlen(field)) == 0)
+    if (strcmp(start, field) == 0)
         return true;
 
     return false;

--- a/hl/src/H5TBprivate.h
+++ b/hl/src/H5TBprivate.h
@@ -19,9 +19,8 @@
 /* public TB prototypes			*/
 #include "H5TBpublic.h"
 
-#define TABLE_CLASS        "TABLE"
-#define TABLE_VERSION      "3.0"
-#define HLTB_MAX_FIELD_LEN 255
+#define TABLE_CLASS   "TABLE"
+#define TABLE_VERSION "3.0"
 
 /*-------------------------------------------------------------------------
  *

--- a/hl/src/H5TBpublic.h
+++ b/hl/src/H5TBpublic.h
@@ -45,6 +45,17 @@ extern "C" {
  * Navigate back: \ref index "Main" / \ref UG
  */
 
+/**
+ * Maximum length (including null terminator) of a table field name in the
+ * HDF5 Table API. Field names passed to H5TBmake_table() that exceed
+ * HLTB_MAX_FIELD_LEN - 1 characters are silently truncated when read back
+ * by H5TBget_field_info(). Caller-provided output buffers in field_names[]
+ * must be at least this many bytes each.
+ *
+ * \since 2.2.0
+ */
+#define HLTB_MAX_FIELD_LEN 255
+
 /**\defgroup H5TB HDF5 Table APIs (H5TB)
  *
  * <em>Creating and manipulating HDF5 datasets intended to be
@@ -130,8 +141,10 @@ extern "C" {
  * \param[in] type_size     The size in bytes of the structure
  *                          associated with the table;
  *                          This value is obtained with \c sizeof().
- * \param[in] field_names   An array containing the names of
- *                          the fields
+ * \param[in] field_names   An array containing the names of the fields.
+ *                          Names longer than #HLTB_MAX_FIELD_LEN - 1 characters
+ *                          are silently truncated when read back by
+ *                          H5TBget_field_info().
  * \param[in] field_offset  An array containing the offsets of
  *                          the fields
  * \param[in] field_types   An array containing the type of
@@ -457,7 +470,15 @@ H5HL_DLL herr_t H5TBget_table_info(hid_t loc_id, const char *dset_name, hsize_t 
  *
  * \fg_loc_id
  * \param[in] dset_name         The name of the dataset to read
- * \param[out] field_names      An array containing the names of the fields
+ * \param[out] field_names      An array of character buffers to receive the field names.
+ *                              Each buffer must be at least #HLTB_MAX_FIELD_LEN bytes.
+ *                              Field names longer than #HLTB_MAX_FIELD_LEN - 1 characters
+ *                              are silently truncated. Callers that subsequently use the
+ *                              returned names for strict field lookups (e.g., via
+ *                              H5TBread_fields_name() or H5TBwrite_fields_name()) should
+ *                              be aware that a truncated name may inadvertently match a
+ *                              different, shorter field whose name is a prefix of the
+ *                              original.
  * \param[out] field_sizes      An array containing the size of the fields
  * \param[out] field_offsets    An array containing the offsets of the fields
  * \param[out] type_size        The size of the HDF5 datatype associated

--- a/hl/test/CMakeTests.cmake
+++ b/hl/test/CMakeTests.cmake
@@ -65,14 +65,18 @@ set (test_hl_CLEANFILES
     test_ds8.h5
     test_ds9.h5
     test_ds10.h5
+    test_ds_class_prefix.h5
+    test_ds_reserved_prefix.h5
     test_image1.h5
     test_image2.h5
     test_image3.h5
+    test_image_class_prefix.h5
     test_lite1.h5
     test_lite2.h5
     test_lite3.h5
     test_lite4.h5
     test_packet_compress.h5
+    test_boundary.h5
     test_packet_table.h5
     test_packet_table_vlen.h5
     testfl_packet_table_vlen.h5

--- a/hl/test/test_ds.c
+++ b/hl/test/test_ds.c
@@ -93,6 +93,8 @@ static int test_iterators(void);
 static int test_data(void);
 static int read_data(const char *fname, int ndims, hsize_t *dims, float **buf);
 static int test_attach_detach(void);
+static int test_is_scale_class_prefix(void);
+static int test_is_reserved_class_prefix(void);
 
 #define RANK1     1
 #define RANK      2
@@ -211,6 +213,8 @@ main(void)
     nerrors += test_iterators() < 0 ? 1 : 0;
     nerrors += test_types() < 0 ? 1 : 0;
     nerrors += test_data() < 0 ? 1 : 0;
+    nerrors += test_is_scale_class_prefix() < 0 ? 1 : 0;
+    nerrors += test_is_reserved_class_prefix() < 0 ? 1 : 0;
 
     if (nerrors)
         goto error;
@@ -5435,6 +5439,269 @@ out:
         H5Dclose(var3_id);
         H5Dclose(dsid);
         H5Gclose(gid);
+        H5Fclose(fid);
+    }
+    H5E_END_TRY
+    H5_FAILED();
+    return FAIL;
+}
+
+/*-------------------------------------------------------------------------
+ * write_class_attr: create a scalar "CLASS" attribute on did using the
+ * given type tid and write val through it.  Closes the attribute and
+ * dataspace before returning; the caller owns tid.
+ *-------------------------------------------------------------------------
+ */
+static herr_t
+write_class_attr(hid_t did, hid_t tid, const void *val)
+{
+    hid_t  aspace_id = H5I_INVALID_HID;
+    hid_t  aid       = H5I_INVALID_HID;
+    herr_t ret       = FAIL;
+
+    if ((aspace_id = H5Screate(H5S_SCALAR)) < 0)
+        goto done;
+    if ((aid = H5Acreate2(did, "CLASS", tid, aspace_id, H5P_DEFAULT, H5P_DEFAULT)) < 0)
+        goto done;
+    if (H5Awrite(aid, tid, val) < 0)
+        goto done;
+    ret = SUCCEED;
+done:
+    if (aid != H5I_INVALID_HID)
+        H5Aclose(aid);
+    if (aspace_id != H5I_INVALID_HID)
+        H5Sclose(aspace_id);
+    return ret;
+}
+
+/*-------------------------------------------------------------------------
+ * test_is_scale_class_prefix
+ *
+ * Verify that H5DSis_scale() rejects a CLASS attribute whose value shares a
+ * prefix with "DIMENSION_SCALE" but is not equal to it, and that
+ * variable-length CLASS strings are handled correctly. H5DSis_scale() only
+ * reaches the string comparison when the CLASS attribute has datatype size
+ * 16, so the fixed-length attribute is created explicitly at that size with
+ * "DIMENSION_S" and null-padded to 16 bytes.
+ *-------------------------------------------------------------------------
+ */
+static int
+test_is_scale_class_prefix(void)
+{
+    hid_t   fid     = H5I_INVALID_HID;
+    hid_t   sid     = H5I_INVALID_HID;
+    hid_t   did     = H5I_INVALID_HID;
+    hid_t   atid    = H5I_INVALID_HID;
+    hsize_t dims[1] = {1};
+    /* DIMENSION_SCALE_CLASS is "DIMENSION_SCALE"; the spec stores the CLASS
+     * attribute as a fixed-length string of exactly this many bytes. */
+    const size_t ds_class_len                             = sizeof(DIMENSION_SCALE_CLASS); /* includes null */
+    char         class_buf[sizeof(DIMENSION_SCALE_CLASS)] = {0};
+
+    HL_TESTING2("H5DSis_scale rejects CLASS values that only share a prefix");
+
+    memcpy(class_buf, "DIMENSION_S", sizeof("DIMENSION_S") - 1);
+
+    if ((fid = H5Fcreate("test_ds_class_prefix.h5", H5F_ACC_TRUNC, H5P_DEFAULT, H5P_DEFAULT)) < 0)
+        goto out;
+    if ((sid = H5Screate_simple(1, dims, NULL)) < 0)
+        goto out;
+    if ((did = H5Dcreate2(fid, "dset", H5T_NATIVE_INT, sid, H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT)) < 0)
+        goto out;
+
+    if ((atid = H5Tcopy(H5T_C_S1)) < 0)
+        goto out;
+    if (H5Tset_size(atid, ds_class_len) < 0)
+        goto out;
+    if (H5Tset_strpad(atid, H5T_STR_NULLTERM) < 0)
+        goto out;
+    if (write_class_attr(did, atid, class_buf) < 0)
+        goto out;
+    if (H5Tclose(atid) < 0)
+        goto out;
+    atid = H5I_INVALID_HID;
+
+    /* CLASS is "DIMENSION_S" (prefix of DIMENSION_SCALE), so H5DSis_scale() must return 0. */
+    if (H5DSis_scale(did) != 0)
+        goto out;
+
+    if (H5Dclose(did) < 0)
+        goto out;
+    did = H5I_INVALID_HID;
+
+    /* VLEN-string CLASS attribute tests for H5DSis_scale: exact match → 1,
+     * prefix/wrong value → 0. */
+    {
+        static const struct {
+            const char *dset_name;
+            const char *class_val;
+            int         expected;
+        } vl_cases[] = {
+            {"dset_vlen_match", "DIMENSION_SCALE", 1},
+            {"dset_vlen_prefix", "DIMENSION_S", 0},
+            {"dset_vlen_nomatch", "NOT_A_SCALE", 0},
+        };
+        size_t k;
+
+        for (k = 0; k < sizeof(vl_cases) / sizeof(vl_cases[0]); k++) {
+            const char *vl_val = vl_cases[k].class_val;
+
+            if ((did = H5Dcreate2(fid, vl_cases[k].dset_name, H5T_NATIVE_INT, sid, H5P_DEFAULT, H5P_DEFAULT,
+                                  H5P_DEFAULT)) < 0)
+                goto out;
+            if ((atid = H5Tcopy(H5T_C_S1)) < 0)
+                goto out;
+            if (H5Tset_size(atid, H5T_VARIABLE) < 0)
+                goto out;
+            if (write_class_attr(did, atid, &vl_val) < 0)
+                goto out;
+            if (H5Tclose(atid) < 0)
+                goto out;
+            atid = H5I_INVALID_HID;
+            if (H5DSis_scale(did) != vl_cases[k].expected)
+                goto out;
+            if (H5Dclose(did) < 0)
+                goto out;
+            did = H5I_INVALID_HID;
+        }
+    }
+
+    if (H5Sclose(sid) < 0)
+        goto out;
+    if (H5Fclose(fid) < 0)
+        goto out;
+
+    PASSED();
+    return 0;
+
+out:
+    H5E_BEGIN_TRY
+    {
+        H5Tclose(atid);
+        H5Dclose(did);
+        H5Sclose(sid);
+        H5Fclose(fid);
+    }
+    H5E_END_TRY
+    H5_FAILED();
+    return FAIL;
+}
+
+/*-------------------------------------------------------------------------
+ * test_is_reserved_class_prefix
+ *
+ * Verify that H5DS_is_reserved (exercised through H5DSattach_scale) correctly
+ * identifies CLASS values "IMAGE", "PALETTE", and "TABLE" as reserved, while
+ * prefix-only matches and variable-length CLASS strings are handled correctly.
+ *-------------------------------------------------------------------------
+ */
+static int
+test_is_reserved_class_prefix(void)
+{
+    hid_t   fid     = H5I_INVALID_HID;
+    hid_t   sid     = H5I_INVALID_HID;
+    hid_t   did     = H5I_INVALID_HID;
+    hid_t   dsid    = H5I_INVALID_HID;
+    hid_t   atid    = H5I_INVALID_HID;
+    hsize_t dims[1] = {4};
+
+    HL_TESTING2("H5DS_is_reserved rejects CLASS prefix; recognizes VL reserved CLASS");
+
+    if ((fid = H5Fcreate("test_ds_reserved_prefix.h5", H5F_ACC_TRUNC, H5P_DEFAULT, H5P_DEFAULT)) < 0)
+        goto out;
+    if ((sid = H5Screate_simple(1, dims, NULL)) < 0)
+        goto out;
+
+    /* Dataset that will receive the scale, tagged with CLASS="IMAGE_EXTRA".
+     * H5DS_is_reserved must return false: "IMAGE_EXTRA" is not a reserved
+     * class name even though it shares a prefix with "IMAGE". */
+    if ((did = H5Dcreate2(fid, "data", H5T_NATIVE_INT, sid, H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT)) < 0)
+        goto out;
+    if (H5LTset_attribute_string(fid, "data", "CLASS", "IMAGE_EXTRA") < 0)
+        goto out;
+
+    /* Dimension-scale dataset */
+    if ((dsid = H5Dcreate2(fid, "ds", H5T_NATIVE_INT, sid, H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT)) < 0)
+        goto out;
+    if (H5DSset_scale(dsid, "xdim") < 0)
+        goto out;
+
+    /* Attaching a scale to a non-reserved dataset must succeed. */
+    if (H5DSattach_scale(did, dsid, 0) < 0)
+        goto out;
+
+    if (H5Dclose(did) < 0)
+        goto out;
+    did = H5I_INVALID_HID;
+
+    /* VLEN-string CLASS attribute tests for H5DS_is_reserved (via
+     * H5DSattach_scale): all three reserved names must block attachment;
+     * a non-reserved name must allow it. */
+    {
+        static const struct {
+            const char *dset_name;
+            const char *class_val;
+            bool        attach_should_fail;
+        } vl_cases[] = {
+            {"data_vl_image", "IMAGE", true},
+            {"data_vl_palette", "PALETTE", true},
+            {"data_vl_table", "TABLE", true},
+            {"data_vl_unreserved", "NOT_RESERVED", false},
+        };
+        size_t k;
+
+        for (k = 0; k < sizeof(vl_cases) / sizeof(vl_cases[0]); k++) {
+            const char *vl_val = vl_cases[k].class_val;
+            herr_t      ret;
+
+            if ((did = H5Dcreate2(fid, vl_cases[k].dset_name, H5T_NATIVE_INT, sid, H5P_DEFAULT, H5P_DEFAULT,
+                                  H5P_DEFAULT)) < 0)
+                goto out;
+            if ((atid = H5Tcopy(H5T_C_S1)) < 0)
+                goto out;
+            if (H5Tset_size(atid, H5T_VARIABLE) < 0)
+                goto out;
+            if (write_class_attr(did, atid, &vl_val) < 0)
+                goto out;
+            if (H5Tclose(atid) < 0)
+                goto out;
+            atid = H5I_INVALID_HID;
+
+            H5E_BEGIN_TRY
+            {
+                ret = H5DSattach_scale(did, dsid, 0);
+            }
+            H5E_END_TRY
+
+            if (vl_cases[k].attach_should_fail && ret >= 0)
+                goto out;
+            if (!vl_cases[k].attach_should_fail && ret < 0)
+                goto out;
+
+            if (H5Dclose(did) < 0)
+                goto out;
+            did = H5I_INVALID_HID;
+        }
+    }
+
+    if (H5Dclose(dsid) < 0)
+        goto out;
+    dsid = H5I_INVALID_HID;
+    if (H5Sclose(sid) < 0)
+        goto out;
+    if (H5Fclose(fid) < 0)
+        goto out;
+
+    PASSED();
+    return 0;
+
+out:
+    H5E_BEGIN_TRY
+    {
+        H5Tclose(atid);
+        H5Dclose(dsid);
+        H5Dclose(did);
+        H5Sclose(sid);
         H5Fclose(fid);
     }
     H5E_END_TRY

--- a/hl/test/test_image.c
+++ b/hl/test/test_image.c
@@ -49,6 +49,7 @@ typedef struct rgb_t {
 static int test_simple(void);
 static int test_data(void);
 static int test_generate(void);
+static int test_class_prefix(void);
 static int read_data(const char *file_name, hsize_t *width, hsize_t *height);
 static int read_palette(const char *file_name, rgb_t *palette, size_t palette_size);
 
@@ -68,6 +69,7 @@ main(void)
     nerrors += test_simple() < 0 ? 1 : 0;
     nerrors += test_data() < 0 ? 1 : 0;
     nerrors += test_generate() < 0 ? 1 : 0;
+    nerrors += test_class_prefix() < 0 ? 1 : 0;
 
     if (nerrors)
         goto error;
@@ -735,6 +737,136 @@ out:
         fclose(f);
     H5_FAILED();
     return retval;
+}
+
+/*-------------------------------------------------------------------------
+ * test_class_prefix
+ *
+ * Verify that H5IMis_image() and H5IMis_palette() reject CLASS attribute
+ * values that merely share a prefix with (or are a prefix of) "IMAGE" /
+ * "PALETTE", and that variable-length CLASS strings are handled correctly.
+ *-------------------------------------------------------------------------
+ */
+static int
+test_class_prefix(void)
+{
+    hid_t   fid     = H5I_INVALID_HID;
+    hid_t   sid     = H5I_INVALID_HID;
+    hid_t   did     = H5I_INVALID_HID;
+    hid_t   vl_atid = H5I_INVALID_HID;
+    hid_t   vl_aid  = H5I_INVALID_HID;
+    hid_t   vl_spc  = H5I_INVALID_HID;
+    hsize_t dims[1] = {1};
+    size_t  i;
+
+    static const struct {
+        const char *dset_name;
+        const char *class_val;
+        herr_t (*check_func)(hid_t, const char *);
+    } cases[] = {
+        /* longer-than and prefix-of IMAGE / PALETTE: none must match */
+        {"bogus_image_long", "IMAGE_EXTRA", H5IMis_image},
+        {"bogus_image_short", "I", H5IMis_image},
+        {"bogus_palette_long", "PALETTE_EXTRA", H5IMis_palette},
+        {"bogus_palette_short", "PAL", H5IMis_palette},
+    };
+
+    HL_TESTING2("CLASS prefix/vlen handling in H5IMis_image/H5IMis_palette");
+
+    if ((fid = H5Fcreate("test_image_class_prefix.h5", H5F_ACC_TRUNC, H5P_DEFAULT, H5P_DEFAULT)) < 0)
+        goto out;
+    if ((sid = H5Screate_simple(1, dims, NULL)) < 0)
+        goto out;
+
+    for (i = 0; i < sizeof(cases) / sizeof(cases[0]); i++) {
+        if ((did = H5Dcreate2(fid, cases[i].dset_name, H5T_NATIVE_INT, sid, H5P_DEFAULT, H5P_DEFAULT,
+                              H5P_DEFAULT)) < 0)
+            goto out;
+        if (H5Dclose(did) < 0)
+            goto out;
+        did = H5I_INVALID_HID;
+        if (H5LTset_attribute_string(fid, cases[i].dset_name, "CLASS", cases[i].class_val) < 0)
+            goto out;
+        if (cases[i].check_func(fid, cases[i].dset_name) != 0)
+            goto out;
+    }
+
+    /* VLEN-string CLASS attribute tests: exact matches must return 1,
+     * non-matches and cross-checks must return 0. */
+    {
+        static const struct {
+            const char *dset_name;
+            const char *class_val;
+            herr_t (*check_func)(hid_t, const char *);
+            int expected;
+        } vl_cases[] = {
+            /* exact matches */
+            {"vlen_image", "IMAGE", H5IMis_image, 1},
+            {"vlen_palette", "PALETTE", H5IMis_palette, 1},
+            /* wrong value — must not match */
+            {"vlen_image_extra", "IMAGE_EXTRA", H5IMis_image, 0},
+            {"vlen_palette_extra", "PALETTE_EXTRA", H5IMis_palette, 0},
+            /* cross-check — correct value, wrong function */
+            {"vlen_cross", "IMAGE", H5IMis_palette, 0},
+        };
+        size_t j;
+
+        if ((vl_atid = H5Tcopy(H5T_C_S1)) < 0)
+            goto out;
+        if (H5Tset_size(vl_atid, H5T_VARIABLE) < 0)
+            goto out;
+        if ((vl_spc = H5Screate(H5S_SCALAR)) < 0)
+            goto out;
+
+        for (j = 0; j < sizeof(vl_cases) / sizeof(vl_cases[0]); j++) {
+            const char *vl_val = vl_cases[j].class_val;
+
+            if ((did = H5Dcreate2(fid, vl_cases[j].dset_name, H5T_NATIVE_INT, sid, H5P_DEFAULT, H5P_DEFAULT,
+                                  H5P_DEFAULT)) < 0)
+                goto out;
+            if ((vl_aid = H5Acreate2(did, "CLASS", vl_atid, vl_spc, H5P_DEFAULT, H5P_DEFAULT)) < 0)
+                goto out;
+            if (H5Awrite(vl_aid, vl_atid, &vl_val) < 0)
+                goto out;
+            if (H5Aclose(vl_aid) < 0)
+                goto out;
+            vl_aid = H5I_INVALID_HID;
+            if (H5Dclose(did) < 0)
+                goto out;
+            did = H5I_INVALID_HID;
+            if (vl_cases[j].check_func(fid, vl_cases[j].dset_name) != vl_cases[j].expected)
+                goto out;
+        }
+
+        if (H5Tclose(vl_atid) < 0)
+            goto out;
+        vl_atid = H5I_INVALID_HID;
+        if (H5Sclose(vl_spc) < 0)
+            goto out;
+        vl_spc = H5I_INVALID_HID;
+    }
+
+    if (H5Sclose(sid) < 0)
+        goto out;
+    if (H5Fclose(fid) < 0)
+        goto out;
+
+    PASSED();
+    return 0;
+
+out:
+    H5E_BEGIN_TRY
+    {
+        H5Tclose(vl_atid);
+        H5Aclose(vl_aid);
+        H5Sclose(vl_spc);
+        H5Dclose(did);
+        H5Sclose(sid);
+        H5Fclose(fid);
+    }
+    H5E_END_TRY
+    H5_FAILED();
+    return FAIL;
 }
 
 /*-------------------------------------------------------------------------

--- a/hl/test/test_table.c
+++ b/hl/test/test_table.c
@@ -47,6 +47,12 @@
 #define NRECORDS     8
 #define NRECORDS_ADD 3
 
+#define BOUNDARY_NFIELDS      5
+#define BOUNDARY_NRECORDS     2
+#define BOUNDARY_FILE         "test_boundary.h5"
+#define BOUNDARY_SHORT_NAME   "ShortName"
+#define BOUNDARY_OVERLONG_LEN 1000 /* arbitrary length well above HLTB_MAX_FIELD_LEN */
+
 /*-------------------------------------------------------------------------
  * structure used for all tests, a particle with properties
  *-------------------------------------------------------------------------
@@ -1011,15 +1017,22 @@ test_table(hid_t fid, int do_write)
                                   field_offset_pos, field_sizes_pos, position_in) < 0)
             goto out;
 
-        /* read back the all table */
+        /* write an invalid field name whose prefix matches a real field, should fail */
+        if (H5TBwrite_fields_name(fid, "table9", "PressureExtra", start, nrecords, sizeof(float), 0,
+                                  field_sizes_pre, pressure_in) >= 0)
+            goto out;
+
+        /* Read back the whole table.  Verify two things:
+         *  1. The valid writes (Pressure records 2-4, Latitude/Longitude records 2-4)
+         *     are intact.
+         *  2. The failing PressureExtra write left no partial mutation: records
+         *     outside the written range still carry the fill value (-99.0F). */
         start    = 0;
         nrecords = NRECORDS;
         if (H5TBread_table(fid, "table9", type_size_mem, field_offset, field_size, rbuf) < 0)
             goto out;
 
         {
-
-            /* compare the read values with the initial values */
             for (i = 0; i < NRECORDS; i++) {
                 if (i >= 2 && i <= 4) {
                     if (rbuf[i].lati != position_in[i - NRECORDS_ADD + 1].lati ||
@@ -1030,6 +1043,11 @@ test_table(hid_t fid, int do_write)
                                 position_in[i].lati);
                         goto out;
                     }
+                }
+                else {
+                    /* Records outside the written range must still be at fill value */
+                    if (!H5_FLT_ABS_EQUAL(rbuf[i].pressure, fill1[0].pressure))
+                        goto out;
                 }
             }
         }
@@ -1069,6 +1087,11 @@ test_table(hid_t fid, int do_write)
 
     /* read an invalid field, should fail */
     if (H5TBread_fields_name(fid, "table10", "DoesNotExist", start, nrecords, sizeof(float), 0,
+                             field_sizes_pre, pressure_out) >= 0)
+        goto out;
+
+    /* read an invalid field name whose prefix matches a real field, should fail */
+    if (H5TBread_fields_name(fid, "table10", "PressureExtra", start, nrecords, sizeof(float), 0,
                              field_sizes_pre, pressure_out) >= 0)
         goto out;
 
@@ -1466,8 +1489,12 @@ test_table(hid_t fid, int do_write)
 
     /* allocate */
     names_out = (char **)malloc(sizeof(char *) * (size_t)NFIELDS);
+    if (!names_out)
+        goto out;
     for (i = 0; i < NFIELDS; i++) {
         names_out[i] = (char *)malloc(sizeof(char) * 255);
+        if (!names_out[i])
+            goto out;
     }
 
     /* Get field info */
@@ -1480,13 +1507,179 @@ test_table(hid_t fid, int do_write)
         }
     }
 
-    /* release */
+    /* Release */
     for (i = 0; i < NFIELDS; i++) {
         free(names_out[i]);
     }
     free(names_out);
 
     PASSED();
+
+    /*-------------------------------------------------------------------------
+     *
+     * Test backward compatibility: smaller buffers for short field names
+     *
+     *-------------------------------------------------------------------------
+     */
+
+    HL_TESTING2("field info with small buffers (backward compatibility)");
+
+    names_out = (char **)malloc(sizeof(char *) * (size_t)NFIELDS);
+    if (!names_out)
+        goto out;
+    for (i = 0; i < NFIELDS; i++) {
+        names_out[i] = (char *)malloc(sizeof(char) * 32);
+        if (!names_out[i])
+            goto out;
+    }
+
+    if (H5TBget_field_info(fid, "table1", names_out, sizes_out, offset_out, &size_out) < 0)
+        goto out;
+
+    for (i = 0; i < NFIELDS; i++) {
+        if ((strcmp(field_names[i], names_out[i]) != 0)) {
+            goto out;
+        }
+    }
+
+    /* Release */
+    for (i = 0; i < NFIELDS; i++) {
+        free(names_out[i]);
+    }
+    free(names_out);
+
+    PASSED();
+
+    /*-------------------------------------------------------------------------
+     *
+     * Test field name length boundaries around HLTB_MAX_FIELD_LEN
+     *
+     *-------------------------------------------------------------------------
+     */
+
+    HL_TESTING2("field name length boundaries");
+
+    {
+        hid_t   fid_boundary = H5I_INVALID_HID;
+        hid_t   boundary_field_types[BOUNDARY_NFIELDS];
+        size_t  boundary_field_offsets[BOUNDARY_NFIELDS];
+        char  **boundary_names_out = NULL;
+        size_t  boundary_sizes_out[BOUNDARY_NFIELDS];
+        size_t  boundary_offset_out[BOUNDARY_NFIELDS];
+        size_t  boundary_size_out;
+        hsize_t boundary_nfields;
+        hsize_t boundary_nrecords;
+        /* one below max name length: no truncation */
+        char *field_below_max = (char *)malloc(HLTB_MAX_FIELD_LEN - 1);
+        /* exactly max name length: fits at boundary, no truncation */
+        char *field_at_max = (char *)malloc(HLTB_MAX_FIELD_LEN);
+        /* one above max name length: truncated when read back */
+        char *field_over_max = (char *)malloc(HLTB_MAX_FIELD_LEN + 1);
+        /* far above max: truncated when read back */
+        char *field_far_over = (char *)malloc(BOUNDARY_OVERLONG_LEN + 1);
+
+        if (!field_below_max || !field_at_max || !field_over_max || !field_far_over)
+            goto boundary_out;
+
+        memset(field_below_max, 'A', HLTB_MAX_FIELD_LEN - 2);
+        field_below_max[HLTB_MAX_FIELD_LEN - 2] = '\0';
+        memset(field_at_max, 'B', HLTB_MAX_FIELD_LEN - 1);
+        field_at_max[HLTB_MAX_FIELD_LEN - 1] = '\0';
+        memset(field_over_max, 'C', HLTB_MAX_FIELD_LEN);
+        field_over_max[HLTB_MAX_FIELD_LEN] = '\0';
+        memset(field_far_over, 'D', BOUNDARY_OVERLONG_LEN);
+        field_far_over[BOUNDARY_OVERLONG_LEN] = '\0';
+
+        const char *boundary_field_names[BOUNDARY_NFIELDS] = {field_below_max, field_at_max, field_over_max,
+                                                              field_far_over, BOUNDARY_SHORT_NAME};
+
+        if ((fid_boundary = H5Fcreate(BOUNDARY_FILE, H5F_ACC_TRUNC, H5P_DEFAULT, H5P_DEFAULT)) < 0)
+            goto boundary_out;
+
+        for (i = 0; i < BOUNDARY_NFIELDS; i++) {
+            boundary_field_types[i]   = H5T_NATIVE_INT;
+            boundary_field_offsets[i] = i * sizeof(int);
+        }
+
+        int boundary_data[BOUNDARY_NRECORDS][BOUNDARY_NFIELDS] = {{1, 2, 3, 4, 5}, {6, 7, 8, 9, 10}};
+
+        if (H5TBmake_table("Boundary Test", fid_boundary, "boundary_table", BOUNDARY_NFIELDS,
+                           BOUNDARY_NRECORDS, BOUNDARY_NFIELDS * sizeof(int), boundary_field_names,
+                           boundary_field_offsets, boundary_field_types, 10, NULL, 0, boundary_data) < 0)
+            goto boundary_out;
+
+        boundary_names_out = (char **)malloc(sizeof(char *) * BOUNDARY_NFIELDS);
+        if (!boundary_names_out)
+            goto boundary_out;
+        for (i = 0; i < BOUNDARY_NFIELDS; i++) {
+            boundary_names_out[i] = (char *)malloc(HLTB_MAX_FIELD_LEN);
+            if (!boundary_names_out[i])
+                goto boundary_out;
+        }
+
+        if (H5TBget_field_info(fid_boundary, "boundary_table", boundary_names_out, boundary_sizes_out,
+                               boundary_offset_out, &boundary_size_out) < 0)
+            goto boundary_out;
+
+        /* HLTB_MAX_FIELD_LEN-2 char name: fits without truncation */
+        if (strlen(boundary_names_out[0]) != HLTB_MAX_FIELD_LEN - 2 ||
+            strncmp(boundary_names_out[0], field_below_max, HLTB_MAX_FIELD_LEN - 2) != 0)
+            goto boundary_out;
+        /* HLTB_MAX_FIELD_LEN-1 char name: fits exactly at boundary, no truncation */
+        if (strlen(boundary_names_out[1]) != HLTB_MAX_FIELD_LEN - 1 ||
+            strncmp(boundary_names_out[1], field_at_max, HLTB_MAX_FIELD_LEN - 1) != 0)
+            goto boundary_out;
+        /* HLTB_MAX_FIELD_LEN char name: truncated to HLTB_MAX_FIELD_LEN-1 chars */
+        if (strlen(boundary_names_out[2]) != HLTB_MAX_FIELD_LEN - 1 ||
+            strncmp(boundary_names_out[2], field_over_max, HLTB_MAX_FIELD_LEN - 1) != 0)
+            goto boundary_out;
+        /* far-over-max name: truncated to HLTB_MAX_FIELD_LEN-1 chars */
+        if (strlen(boundary_names_out[3]) != HLTB_MAX_FIELD_LEN - 1 ||
+            strncmp(boundary_names_out[3], field_far_over, HLTB_MAX_FIELD_LEN - 1) != 0)
+            goto boundary_out;
+        /* short name: unchanged */
+        if (strcmp(boundary_names_out[4], BOUNDARY_SHORT_NAME) != 0)
+            goto boundary_out;
+
+        if (H5TBget_table_info(fid_boundary, "boundary_table", &boundary_nfields, &boundary_nrecords) < 0)
+            goto boundary_out;
+        if (boundary_nfields != BOUNDARY_NFIELDS || boundary_nrecords != BOUNDARY_NRECORDS)
+            goto boundary_out;
+
+        for (i = 0; i < BOUNDARY_NFIELDS; i++)
+            free(boundary_names_out[i]);
+        free(boundary_names_out);
+        free(field_below_max);
+        free(field_at_max);
+        free(field_over_max);
+        free(field_far_over);
+
+        if (H5Fclose(fid_boundary) < 0)
+            goto out;
+
+        PASSED();
+        goto boundary_cleanup;
+
+boundary_out:
+        H5_FAILED();
+        if (boundary_names_out) {
+            for (i = 0; i < BOUNDARY_NFIELDS; i++)
+                free(boundary_names_out[i]);
+            free(boundary_names_out);
+        }
+        free(field_below_max);
+        free(field_at_max);
+        free(field_over_max);
+        free(field_far_over);
+        H5E_BEGIN_TRY
+        {
+            H5Fclose(fid_boundary);
+        }
+        H5E_END_TRY
+        return -1;
+
+boundary_cleanup:;
+    }
 
     /*-------------------------------------------------------------------------
      * end

--- a/release_docs/CHANGELOG.md
+++ b/release_docs/CHANGELOG.md
@@ -180,6 +180,59 @@ We would like to thank the many HDF5 community members who contributed to this r
 
 ## High-Level Library
 
+### Fixed critical buffer overflow vulnerability in H5TBget_field_info() (CWE-120)
+
+   `H5TBget_field_info()` copied field names into caller-provided buffers using unbounded `strcpy()`,
+   allowing a malicious HDF5 file with overly long field names to overflow those buffers. The copy
+   now uses bounds-checked `memcpy()`: names shorter than `HLTB_MAX_FIELD_LEN` (255) are copied
+   exactly (preserving backward compatibility); names at or above that limit are safely truncated to
+   254 characters plus a NUL terminator.
+
+### Made HLTB_MAX_FIELD_LEN public
+
+   `HLTB_MAX_FIELD_LEN` (255) has been moved from the private header `H5TBprivate.h` to the public
+   header `H5TBpublic.h`. Applications can now use this constant to correctly size their
+   `field_names[]` buffers when calling `H5TBget_field_info()`.
+
+### Fixed H5TBread_fields_name/H5TBwrite_fields_name matching the wrong field when one field name is a prefix of another
+
+   H5TB_find_field() used strncmp() limited to strlen(field) when comparing the last entry of the supplied comma-separated field list against a table member name. This matched any user-supplied name whose leading characters equaled an existing field name (for example, requesting "PressureExtra" on a table containing "Pressure" would silently operate on the "Pressure" field). The comparison has been changed to strcmp() so full names must match exactly. In addition, H5TBwrite_fields_name() now returns an error when none of the requested field names are found (previously it silently performed a no-op write), matching the existing behavior of H5TBread_fields_name().
+
+   Fixes GitHub issue #5633
+
+### Fixed prefix-based false matches when checking "CLASS" attribute strings in the High-Level API
+
+   `H5DSis_scale()`, `H5DS_is_reserved()`, `H5IMis_image()`, and `H5IMis_palette()` all compared a
+   dataset's "CLASS" attribute against an expected class name using
+   `strncmp(buf, CLASS, MIN(strlen(CLASS), strlen(buf)))`. Because the comparison was limited to the
+   shorter of the two strings, any non-empty value whose leading characters matched the expected class
+   name was accepted — for example, a CLASS of `"IMAGE_EXTRA"` was treated as an IMAGE dataset, and
+   `"DIMENSION_S"` (null-padded to 16 bytes) was treated as a DIMENSION_SCALE. (`H5DSis_scale()` already
+   required the attribute datatype to be exactly 16 bytes, which incidentally prevented false matches
+   against shorter class names such as `"IMAGE"` or `"PALETTE"`; the other three functions had no such
+   guard and were directly exposed.) These
+   comparisons now use `strcmp()` so only an exact class name is accepted.
+
+   Additional fixes applied to all four routines:
+
+   - **VLEN-string CLASS attributes are now handled correctly.** Previously, reading a VLEN-typed
+     attribute into a fixed `char *` buffer would overwrite it with a heap-allocated `char *` pointer
+     rather than the string content, which is undefined behaviour and could corrupt memory or produce
+     garbage comparison results.
+     All four routines now read VLEN CLASS attributes properly (via `H5Treclaim`) and compare the
+     string content: `H5DSis_scale()`, `H5IMis_image()`, and `H5IMis_palette()` return 1 when the
+     value matches exactly, and `H5DS_is_reserved()` correctly identifies reserved class names stored
+     as VLEN strings.
+   - **NUL-termination hardening.** The read buffer is now allocated one byte larger than the stored
+     attribute size, and a NUL terminator is explicitly written after the attribute data. This protects
+     `strcmp` from over-reading files where the CLASS attribute was written without strictly honouring
+     `H5T_STR_NULLTERM`.
+   - **Resource leak fix in `H5IMis_image()` and `H5IMis_palette()`.** The `out:` error-handling block
+     previously closed only the dataset ID, leaving the attribute ID (`aid`) and attribute datatype ID
+     (`atid`) open on every error path. Both IDs are now properly closed on error.
+
+   Related to GitHub issue #5633
+
 ## Fortran High-Level APIs
 
 ## Documentation


### PR DESCRIPTION
Fixes #5633 and related prefix-match bugs across the HL library.

H5TB

H5TB_find_field() compared only strlen(field) bytes of a tokenized user field name, so a user-supplied name like "PressureExtra" would match a real column "Pressure". Changed to strcmp against the NUL-terminated token parsed out of the comma-separated list. Applies to both H5TBread_fields_name() and H5TBwrite_fields_name(). The write path also silently accepted input with zero matching fields; it now returns an error, matching the read path's existing behavior.

H5DS

H5DSis_scale() and H5DS_is_reserved() used strncmp(buf, CLASS, MIN(strlen(CLASS), strlen(buf))), which matched any value whose prefix equaled the expected class name. Replaced with strcmp. Also:

Fixed a latent double-free in H5DSis_scale() on the no-match path, which was previously unreachable because the buggy compare always matched.
Added a variable-length string guard: a VLEN CLASS attribute passes the H5T_STR_NULLTERM check, but H5Aread into a char* buffer would write an hvl_t, so it is now explicitly rejected.
Allocate one extra byte and explicitly NUL-terminate after H5Aread as defense-in-depth.

H5IM

Same class of bug in H5IMis_image() (IMAGE class) and H5IMis_palette() (PALETTE class). Additionally:

Initialized did/aid/atid/attr_data at declaration so the out: error handler is safe from any failure point.
Added VLEN string guard (same rationale as H5DS).
Fixed pre-existing resource leaks in the out: handler: aid, atid, and attr_data were not closed/freed on mid-function failures.
Allocate one extra byte and explicitly NUL-terminate after H5Aread.

Regression tests

hl/test/test_table.c: read and write tests that request "PressureExtra" against a table with a real "Pressure" column and expect failure.
hl/test/test_image.c: test_class_prefix covers CLASS values "IMAGE_EXTRA", "I", "PALETTE_EXTRA", and "PAL" — all must return 0.
hl/test/test_ds.c: test_is_scale_class_prefix writes a 16-byte CLASS attribute holding "DIMENSION_S" (null-padded), the exact path H5DSis_scale() walks for the scale class length, and asserts 0. test_is_reserved_class_prefix exercises H5DS_is_reserved() indirectly via H5DSattach_scale() on a dataset tagged CLASS="IMAGE_EXTRA", which must not be treated as reserved.

All new tests were verified to fail against the unpatched sources and pass with the fix.
