### PR TITLE
Replace assert with HGOTO_ERROR for invalid VL types in H5Tvlen.c

### DIFF
--- a/src/H5Tvlen.c
+++ b/src/H5Tvlen.c
@@ -264,7 +264,7 @@ H5T__vlen_set_loc(H5T_t *dt, H5VL_object_t *file, H5T_loc_t loc)
                     dt->shared->u.vlen.cls = &H5T_vlen_mem_str_g;
                 } /* end else-if */
                 else
-                    assert(0 && "Invalid VL type");
+                    HGOTO_ERROR(H5E_DATATYPE, H5E_BADVALUE, FAIL, "invalid VL type for memory location");
 
                 /* Release owned file */
                 if (dt->shared->owned_vol_obj) {
@@ -1019,7 +1019,7 @@ H5T__vlen_reclaim(void *elem, const H5T_t *dt, H5T_vlen_alloc_info_t *alloc_info
                     free(*(char **)elem);
             }
             else {
-                assert(0 && "Invalid VL type");
+                HGOTO_ERROR(H5E_DATATYPE, H5E_BADVALUE, FAIL, "invalid VL type for reclaim");
             } /* end else */
             break;
 


### PR DESCRIPTION
## Description

`H5T__vlen_set_loc()` and `H5T__vlen_reclaim()` use `assert(0)` to handle the case where `dt->shared->u.vlen.type` is neither `H5T_VLEN_SEQUENCE` nor `H5T_VLEN_STRING`. With corrupted HDF5 files, this code path can be reached at runtime, causing an abort in debug builds and undefined behavior (SEGV via NULL pointer dereference) in release builds.

This replaces both `assert(0)` calls with `HGOTO_ERROR` so that the error is propagated through the normal HDF5 error handling mechanism instead of crashing.

## How was this found

Found by OSS-Fuzz via the [matio](https://github.com/tbeu/matio) fuzzer (ClusterFuzz testcase 5366895365914624). The crash occurs when reading a malformed HDF5 file where a vlen attribute has a corrupt internal `vlen.type` field. The call path is:

```
Mat_H5ReadFieldNames -> H5Aget_type -> H5A__get_type -> H5T_set_loc -> H5T__vlen_set_loc -> assert(0)
```

## Changes

- `src/H5Tvlen.c`: `H5T__vlen_set_loc()` line 267: `assert(0 && "Invalid VL type")` replaced with `HGOTO_ERROR(H5E_DATATYPE, H5E_BADVALUE, FAIL, ...)`
- `src/H5Tvlen.c`: `H5T__vlen_reclaim()` line 1022: same change
