### PR TITLE
Fix NULL file pointer dereferences in vlen disk operations

### DIFF
--- a/src/H5Tvlen.c
+++ b/src/H5Tvlen.c
@@ -282,7 +282,8 @@ H5T__vlen_set_loc(H5T_t *dt, H5VL_object_t *file, H5T_loc_t loc)
                 H5VL_file_cont_info_t cont_info = {H5VL_CONTAINER_INFO_VERSION, 0, 0, 0};
                 H5VL_file_get_args_t  vol_cb_args; /* Arguments to VOL callback */
 
-                assert(file);
+                if (NULL == file)
+                    HGOTO_ERROR(H5E_DATATYPE, H5E_BADVALUE, FAIL, "file pointer is NULL for disk VL type");
 
                 /* Mark this type as being stored on disk */
                 dt->shared->u.vlen.loc = H5T_LOC_DISK;
@@ -749,7 +750,8 @@ H5T__vlen_disk_isnull(const H5VL_object_t *file, void *_vl, bool *isnull)
     FUNC_ENTER_PACKAGE
 
     /* Check parameters */
-    assert(file);
+    if (NULL == file)
+        HGOTO_ERROR(H5E_DATATYPE, H5E_BADVALUE, FAIL, "file pointer is NULL");
     assert(vl);
     assert(isnull);
 
@@ -787,7 +789,8 @@ H5T__vlen_disk_setnull(H5VL_object_t *file, void *_vl, void *bg)
     FUNC_ENTER_PACKAGE
 
     /* check parameters */
-    assert(file);
+    if (NULL == file)
+        HGOTO_ERROR(H5E_DATATYPE, H5E_BADVALUE, FAIL, "file pointer is NULL");
     assert(vl);
 
     /* Free heap object for old data */
@@ -828,7 +831,8 @@ H5T__vlen_disk_read(H5VL_object_t *file, void *_vl, void *buf, size_t len)
     FUNC_ENTER_PACKAGE
 
     /* Check parameters */
-    assert(file);
+    if (NULL == file)
+        HGOTO_ERROR(H5E_DATATYPE, H5E_BADVALUE, FAIL, "file pointer is NULL");
     assert(vl);
     assert(buf);
 
@@ -865,7 +869,8 @@ H5T__vlen_disk_write(H5VL_object_t *file, const H5T_vlen_alloc_info_t H5_ATTR_UN
     /* check parameters */
     assert(vl);
     assert(seq_len == 0 || buf);
-    assert(file);
+    if (NULL == file)
+        HGOTO_ERROR(H5E_DATATYPE, H5E_BADVALUE, FAIL, "file pointer is NULL");
 
     /* Free heap object for old data, if non-NULL */
     if (bg != NULL)
@@ -901,7 +906,8 @@ H5T__vlen_disk_delete(H5VL_object_t *file, void *_vl)
     FUNC_ENTER_PACKAGE
 
     /* Check parameters */
-    assert(file);
+    if (NULL == file)
+        HGOTO_ERROR(H5E_DATATYPE, H5E_BADVALUE, FAIL, "file pointer is NULL");
 
     /* Free heap object for old data */
     if (vl != NULL) {


### PR DESCRIPTION
When reading corrupted HDF5 files, the file pointer passed to the disk-based vlen type operations (`H5T__vlen_disk_read`, `H5T__vlen_disk_write`, `H5T__vlen_disk_isnull`, `H5T__vlen_disk_setnull`, `H5T__vlen_disk_delete`) and `H5T__vlen_set_loc` can be NULL. The existing `assert(file)` causes a crash in debug builds, while release builds proceed to dereference the NULL pointer in `H5VL_blob_put` / `H5VL_blob_get` / `H5VL_blob_specific`, causing a SEGV.

### Changes

Replace `assert(file)` with proper NULL checks and `HGOTO_ERROR` so that the error is propagated through the normal HDF5 error handling mechanism.

### ASAN report (from OSS-Fuzz)

https://issues.oss-fuzz.com/issues?q=5366895365914624

> =================================================================
> ==1150==ERROR: AddressSanitizer: SEGV on unknown address 0x000000000008 (pc 0x5d09af33f82f bp 0x7ffd030797b0 sp 0x7ffd03079770 T0)
> ==1150==The signal is caused by a READ memory access.
> ==1150==Hint: address points to the zero page.
>     # 0 H5VL_blob_put hdf5/src/H5VLcallback.c:7453:48
>     # 1 H5T__vlen_disk_write hdf5/src/H5Tvlen.c:879:9
>     # 2 H5T__conv_vlen hdf5/src/H5Tconv_vlen.c:474:29
>     # 3 H5T_convert_with_ctx hdf5/src/H5T.c:6545:14
>     # 4 H5T_convert hdf5/src/H5T.c:6474:9
>     # 5 H5A__read hdf5/src/H5Aint.c:787:21