### PR TITLE
ci: remove EOL OS versions from workflows

### DIFF
--- a/.github/workflows/freebsd.yml
+++ b/.github/workflows/freebsd.yml
@@ -45,7 +45,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        freebsd-version: ['13.5', '14.3', '15.0']
+        freebsd-version: ['14.3', '15.0']
 
     steps:
       - name: Checkout repository

--- a/.github/workflows/i386.yml
+++ b/.github/workflows/i386.yml
@@ -33,8 +33,10 @@ jobs:
       - name: Install dependencies
         run: |
           docker exec i386_build bash -c "
+            echo 'deb http://deb.debian.org/debian bookworm-backports main' > /etc/apt/sources.list.d/backports.list
             apt-get update -y
-            apt-get install -y build-essential cmake libaec-dev libgit2-dev
+            apt-get install -y build-essential libaec-dev libgit2-dev
+            apt-get install -y -t bookworm-backports cmake
           "
 
       - name: Configure

--- a/.github/workflows/i386.yml
+++ b/.github/workflows/i386.yml
@@ -19,36 +19,51 @@ jobs:
   i386_build_and_test:
     name: "i386 ${{ inputs.build_mode }}"
     runs-on: ubuntu-latest
-    container:
-      image: i386/debian:bookworm
     steps:
-      - name: Install dependencies
-        run: |
-          apt-get update -y
-          apt-get install -y build-essential cmake libaec-dev libgit2-dev
-
       - name: Get Sources
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
+      - name: Start i386 container
+        run: |
+          docker run -d --name i386_build --platform linux/386 \
+            -e CTEST_OUTPUT_ON_FAILURE=1 \
+            -v "${{ github.workspace }}:/workspace" \
+            i386/debian:bookworm sleep infinity
+
+      - name: Install dependencies
+        run: |
+          docker exec i386_build bash -c "
+            apt-get update -y
+            apt-get install -y build-essential cmake libaec-dev libgit2-dev
+          "
+
       - name: Configure
         run: |
-          mkdir build
-          cd build
-          cmake -C ../config/cmake/cacheinit.cmake -G "Unix Makefiles" \
-          --log-level=VERBOSE \
-          -DCMAKE_BUILD_TYPE=${{ inputs.build_mode }} \
-          -DHDF5_ENABLE_ZLIB_SUPPORT:BOOL=OFF \
-          -DHDF5_ENABLE_SZIP_SUPPORT:BOOL=OFF \
-          -DHDF5_ENABLE_PLUGIN_SUPPORT:BOOL=OFF \
-          -DHDF5_BUILD_CPP_LIB:BOOL=OFF \
-          -DHDF5_BUILD_FORTRAN:BOOL=OFF \
-          -DHDF5_BUILD_JAVA:BOOL=OFF \
-          ..
+          docker exec -w /workspace i386_build bash -c "
+            mkdir build
+            cd build
+            cmake -C ../config/cmake/cacheinit.cmake -G 'Unix Makefiles' \
+              --log-level=VERBOSE \
+              -DCMAKE_BUILD_TYPE=${{ inputs.build_mode }} \
+              -DHDF5_ENABLE_ZLIB_SUPPORT:BOOL=OFF \
+              -DHDF5_ENABLE_SZIP_SUPPORT:BOOL=OFF \
+              -DHDF5_ENABLE_PLUGIN_SUPPORT:BOOL=OFF \
+              -DHDF5_BUILD_CPP_LIB:BOOL=OFF \
+              -DHDF5_BUILD_FORTRAN:BOOL=OFF \
+              -DHDF5_BUILD_JAVA:BOOL=OFF \
+              ..
+          "
 
       - name: Build
-        run: cmake --build . --parallel 3 --config ${{ inputs.build_mode }}
-        working-directory: build
+        run: |
+          docker exec -w /workspace/build i386_build \
+            cmake --build . --parallel 3 --config ${{ inputs.build_mode }}
 
       - name: Run Tests
-        run: ctest . --parallel 2 -C ${{ inputs.build_mode }}
-        working-directory: build
+        run: |
+          docker exec -w /workspace/build i386_build \
+            ctest . --parallel 2 -C ${{ inputs.build_mode }}
+
+      - name: Cleanup
+        if: always()
+        run: docker rm -f i386_build

--- a/.github/workflows/i386.yml
+++ b/.github/workflows/i386.yml
@@ -19,22 +19,18 @@ jobs:
   i386_build_and_test:
     name: "i386 ${{ inputs.build_mode }}"
     runs-on: ubuntu-latest
+    container:
+      image: i386/debian:bookworm
     steps:
+      - name: Install dependencies
+        run: |
+          apt-get update -y
+          apt-get install -y build-essential cmake libaec-dev libgit2-dev
+
       - name: Get Sources
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
-      - name: setup alpine
-        uses: jirutka/setup-alpine@ae3b3ddba35054804fc4a3507b519fa7e8152050 # v1
-        with:
-          arch: x86
-          packages: >
-            build-base
-            libaec-dev
-            libgit2-dev
-            cmake
-
       - name: Configure
-        shell: alpine.sh --root {0}
         run: |
           mkdir build
           cd build
@@ -50,13 +46,9 @@ jobs:
           ..
 
       - name: Build
-        shell: alpine.sh --root {0}
-        run: |
-          cmake --build . --parallel 3 --config ${{ inputs.build_mode }}
+        run: cmake --build . --parallel 3 --config ${{ inputs.build_mode }}
         working-directory: build
 
       - name: Run Tests
-        shell: alpine.sh --root {0}
-        run: |
-          ctest . --parallel 2 -C ${{ inputs.build_mode }}
+        run: ctest . --parallel 2 -C ${{ inputs.build_mode }}
         working-directory: build

--- a/.github/workflows/openbsd.yml
+++ b/.github/workflows/openbsd.yml
@@ -45,7 +45,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        openbsd-version: ['7.5']
+        openbsd-version: ['7.8']
 
     steps:
       - name: Checkout repository
@@ -58,7 +58,7 @@ jobs:
           usesh: true
           prepare: |
             echo "https://ftp.openbsd.org/pub/OpenBSD" > /etc/installurl
-            pkg_add cmake gmake pkgconf curl gcc-11.2.0p11
+            pkg_add cmake gmake pkgconf curl gcc
           run: |
             set -e
 

--- a/.github/workflows/openbsd.yml
+++ b/.github/workflows/openbsd.yml
@@ -52,18 +52,15 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Build and test on OpenBSD
-        uses: vmactions/openbsd-vm@271a1ba62300483cfc58345ff9f425f1349a2cab # v1.3.4
+        uses: vmactions/openbsd-vm@d7d892b7b9ba97ed2747b0fc201be65037d64c3e # v1.4.0
         with:
           release: ${{ matrix.openbsd-version }}
           usesh: true
           prepare: |
             echo "https://ftp.openbsd.org/pub/OpenBSD" > /etc/installurl
-            pkg_add cmake gmake pkgconf curl gcc
+            pkg_add cmake gmake pkgconf curl
           run: |
             set -e
-
-            # Set up library path for gcc
-            export LD_LIBRARY_PATH=/usr/local/lib:$LD_LIBRARY_PATH
 
             # Get number of processors (OpenBSD uses sysctl in /sbin)
             NPROC=$(/sbin/sysctl -n hw.ncpu)
@@ -75,8 +72,6 @@ jobs:
             cmake -C ../config/cmake/cacheinit.cmake \
               --log-level=VERBOSE \
               -DCMAKE_BUILD_TYPE=Release \
-              -DCMAKE_C_COMPILER=egcc \
-              -DCMAKE_CXX_COMPILER=eg++ \
               -DCMAKE_MAKE_PROGRAM=gmake \
               -DBUILD_SHARED_LIBS:BOOL=ON \
               -DHDF5_ENABLE_ALL_WARNINGS:BOOL=ON \

--- a/.github/workflows/openbsd.yml
+++ b/.github/workflows/openbsd.yml
@@ -58,7 +58,7 @@ jobs:
           usesh: true
           prepare: |
             echo "https://ftp.openbsd.org/pub/OpenBSD" > /etc/installurl
-            pkg_add cmake gmake pkgconf curl
+            pkg_add cmake pkgconf curl
           run: |
             set -e
 
@@ -72,7 +72,6 @@ jobs:
             cmake -C ../config/cmake/cacheinit.cmake \
               --log-level=VERBOSE \
               -DCMAKE_BUILD_TYPE=Release \
-              -DCMAKE_MAKE_PROGRAM=gmake \
               -DBUILD_SHARED_LIBS:BOOL=ON \
               -DHDF5_ENABLE_ALL_WARNINGS:BOOL=ON \
               -DHDF5_ENABLE_PARALLEL:BOOL=OFF \


### PR DESCRIPTION
- freebsd.yml: drop FreeBSD 13.5 (EOL Jan 2026); keep 14.3 and 15.0
- openbsd.yml: bump 7.5 → 7.8 (7.5 EOL ~Nov 2024); drop pinned gcc version
- i386.yml: replace Alpine 3.16 x86 (EOL May 2024) with i386/debian:bookworm (EOL Jun 2028)