### PR TITLE
Validate VL datatype type during decode and check file pointer in H5T_set_loc

### DIFF
--- a/src/H5Odtype.c
+++ b/src/H5Odtype.c
@@ -760,6 +760,8 @@ H5O__dtype_decode_helper(unsigned *ioflags /*in,out*/, const uint8_t **pp, H5T_t
              */
             /* Set the type of VL information, either sequence or string */
             dt->shared->u.vlen.type = (H5T_vlen_type_t)(flags & 0x0f);
+            if (dt->shared->u.vlen.type != H5T_VLEN_SEQUENCE && dt->shared->u.vlen.type != H5T_VLEN_STRING)
+                HGOTO_ERROR(H5E_DATATYPE, H5E_BADVALUE, FAIL, "invalid VL datatype type");
             if (dt->shared->u.vlen.type == H5T_VLEN_STRING) {
                 dt->shared->u.vlen.pad  = (H5T_str_t)((flags >> 4) & 0x0f);
                 dt->shared->u.vlen.cset = (H5T_cset_t)((flags >> 8) & 0x0f);

--- a/src/H5T.c
+++ b/src/H5T.c
@@ -7014,6 +7014,11 @@ H5T_set_loc(H5T_t *dt, H5VL_object_t *file, H5T_loc_t loc)
                         ret_value = changed;
                 } /* end if */
 
+                /* Validate file pointer for disk-based VL types */
+                if (loc == H5T_LOC_DISK && NULL == file)
+                    HGOTO_ERROR(H5E_DATATYPE, H5E_BADVALUE, FAIL,
+                                "NULL file pointer for disk-based VL datatype");
+
                 /* Mark this VL sequence */
                 if ((changed = H5T__vlen_set_loc(dt, file, loc)) < 0)
                     HGOTO_ERROR(H5E_DATATYPE, H5E_CANTINIT, FAIL, "Unable to set VL location");


### PR DESCRIPTION
## Description

This fixes the crash reported in #6378 and #6385 by addressing the root cause at the decode level, as requested by reviewers.

`H5O__dtype_decode_helper()` reads `vlen.type` from the file without validation. With corrupted HDF5 files (e.g. from fuzzing), this field can have an invalid value that is neither `H5T_VLEN_SEQUENCE` nor `H5T_VLEN_STRING`, which later triggers `assert(0)` in `H5T__vlen_set_loc()` (debug builds) or a NULL pointer dereference / SEGV in release builds.

## Changes

1. **src/H5Odtype.c** (`H5O__dtype_decode_helper`): Added validation immediately after reading `vlen.type` from the file. If the value is invalid, `HGOTO_ERROR` is returned so the corrupted type is rejected at the point where the bad value enters the system.

2. **src/H5T.c** (`H5T_set_loc`): Added a NULL file pointer check before calling `H5T__vlen_set_loc()` when `loc == H5T_LOC_DISK`, so the low-level `assert(file)` invariant is never violated even if a higher-level caller fails to provide a valid file.

## Rationale

Per the review feedback on #6378 and #6385: the `assert()` statements in `H5T__vlen_set_loc()` and the vlen disk operations are intended to catch internal programming errors and should remain. The proper fix is to validate inputs at the higher level where corrupted data is first ingested. This PR does exactly that.

## How was this found

Found by OSS-Fuzz via the [matio](https://github.com/tbeu/matio) fuzzer (ClusterFuzz testcase 5366895365914624).

OSS-Fuzz issue: https://issues.oss-fuzz.com/issues/472641758

Reproducer file: [clusterfuzz-testcase-minimized-matio_fuzzer-5366895365914624.zip](https://github.com/HDFGroup/hdf5/pull/6378#issuecomment-2851543746)

Supersedes #6378 and #6385.