### PR TITLE
test(swmr): remove test directory before creating a new one

### DIFF
--- a/test/test_swmr.sh.in
+++ b/test/test_swmr.sh.in
@@ -114,6 +114,7 @@ done
 # different, occasionally the wrong file is deleted, interrupting the flow of
 # the test.  Running each of these tests in its own directory should eliminate
 # the problem.
+rm -rf swmr_test
 mkdir swmr_test
 for FILE in swmr*; do
     case "$FILE" in


### PR DESCRIPTION
Make sure that everything is clean before copying files to a directory.