### PR TITLE
CI: remove redundant macOS brew installs for ninja and curl

### DIFF
--- a/.github/workflows/arm-main.yml
+++ b/.github/workflows/arm-main.yml
@@ -285,9 +285,6 @@ jobs:
       - name: Setup Doxygen
         uses: ./.github/actions/setup-doxygen
 
-      - name: Install Dependencies (macOS)
-        run: brew install ninja curl
-
       - name: Install CMake
         uses: lukka/get-cmake@7bfc9baacbbdcb5e37957ad05c3546b3e222be3c # latest
         with:

--- a/.github/workflows/bintest.yml
+++ b/.github/workflows/bintest.yml
@@ -172,9 +172,6 @@ jobs:
     name: "MacOS Clang Binary Test"
     runs-on: macos-latest
     steps:
-      - name: Install Dependencies (MacOS_latest)
-        run: brew install ninja
-
       - name: Set up JDK ${{ inputs.java_version }}
         uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5
         with:

--- a/.github/workflows/ctest.yml
+++ b/.github/workflows/ctest.yml
@@ -586,9 +586,6 @@ jobs:
     runs-on: macos-latest
     needs: [check-secret]
     steps:
-      - name: Install Dependencies (MacOS_latest)
-        run: brew install ninja
-
       - name: check clang version
         shell: bash
         run: |

--- a/.github/workflows/dev.yml
+++ b/.github/workflows/dev.yml
@@ -195,9 +195,6 @@ jobs:
       - name: Setup Doxygen
         uses: ./.github/actions/setup-doxygen
 
-      - name: Install Dependencies (MacOS_latest)
-        run: brew install ninja
-
       - name: Check Clang Version
         shell: bash
         run: |

--- a/.github/workflows/java-implementation-test.yml
+++ b/.github/workflows/java-implementation-test.yml
@@ -145,7 +145,7 @@ jobs:
       - name: Setup Build Environment (macOS)
         if: runner.os == 'macOS'
         run: |
-          brew install ninja libaec
+          brew install libaec
 
       - name: Setup Build Environment (Windows)
         if: runner.os == 'Windows'

--- a/.github/workflows/main-static.yml
+++ b/.github/workflows/main-static.yml
@@ -141,10 +141,6 @@ jobs:
 
       # CMake gets libaec from fetchcontent
 
-      - name: Install Dependencies (macOS)
-        run: brew install ninja curl
-        if: ${{ matrix.ostype == 'macos' }}
-
       - name: Install CMake
         uses: lukka/get-cmake@7bfc9baacbbdcb5e37957ad05c3546b3e222be3c # latest
         with:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -158,10 +158,6 @@ jobs:
 
       # CMake gets libaec from fetchcontent
 
-      - name: Install Dependencies (macOS)
-        run: brew install ninja curl
-        if: ${{ matrix.ostype == 'macos' }}
-
       - name: Install CMake
         uses: lukka/get-cmake@7bfc9baacbbdcb5e37957ad05c3546b3e222be3c # latest
         with:

--- a/.github/workflows/maven-staging.yml
+++ b/.github/workflows/maven-staging.yml
@@ -244,7 +244,7 @@ jobs:
       - name: Install Dependencies (macOS)
         if: ${{ runner.os == 'macOS' }}
         run: |
-          brew install ninja graphviz
+          brew install graphviz
 
       - name: Install Dependencies (Windows)
         if: ${{ runner.os == 'Windows' }}

--- a/.github/workflows/par-script.yml
+++ b/.github/workflows/par-script.yml
@@ -286,9 +286,6 @@ jobs:
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
-      - name: Install Dependencies (MacOS_latest)
-        run: brew install ninja
-
       - name: Setup MPI (${{ matrix.mpi }})
         id: setup-mpi
         uses: mpi4py/setup-mpi@dbbb80b116bea57fc1788daf7dbbf7ab3df3a0f1 # v1

--- a/.github/workflows/script.yml
+++ b/.github/workflows/script.yml
@@ -253,9 +253,6 @@ jobs:
         with:
           sparse-checkout: .github/actions
 
-      - name: Install Dependencies (MacOS_latest)
-        run: brew install ninja curl
-
       - name: check clang version
         shell: bash
         run: |


### PR DESCRIPTION
- `ninja` and `curl` are pre-installed on the GitHub macOS runners, causing noisy "already installed" warnings in CI logs
- Removed the redundant `brew install` steps entirely where they only installed `ninja`/`curl`
- For `maven-staging.yml` and `java-implementation-test.yml`, only removed `ninja` since those steps also install `graphviz`/`libaec` which are not pre-installed
