### PR TITLE
Add flag -Mnovect for compiling test/dt_arith.c 

### DIFF
--- a/.github/workflows/nvhpc.yml
+++ b/.github/workflows/nvhpc.yml
@@ -78,6 +78,7 @@ jobs:
           -DHDF5_BUILD_JAVA:BOOL=OFF \
           -DMPIEXEC_MAX_NUMPROCS:STRING="2" \
           -DMPIEXEC_PREFLAGS:STRING="--mca;opal_warn_on_missing_libcuda;0" \
+          -DCMAKE_C_FLAGS="-Mnovect" \
           $GITHUB_WORKSPACE
 
       - name: Build

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -570,9 +570,6 @@ foreach (h5_test ${H5_TESTS} ${H5_EXPRESS_TESTS} ${H5_S3TESTS})
     ADD_H5_EXE(${h5_test})
   endif ()
 endforeach ()
-if (CMAKE_C_COMPILER_ID MATCHES "NVHPC")
-  target_compile_options(dt_arith PRIVATE -Mnovect)
-endif()
 
 ##############################################################################
 ###           M U L T I P L E  S O U R C E   T E S T S                     ###

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -570,6 +570,9 @@ foreach (h5_test ${H5_TESTS} ${H5_EXPRESS_TESTS} ${H5_S3TESTS})
     ADD_H5_EXE(${h5_test})
   endif ()
 endforeach ()
+if (CMAKE_C_COMPILER_ID MATCHES "NVHPC")
+  target_compile_options(dt_arith PRIVATE -Mnovect)
+endif()
 
 ##############################################################################
 ###           M U L T I P L E  S O U R C E   T E S T S                     ###


### PR DESCRIPTION
to work around LLVM crash in nvhpc.yml workflow.

Posted issue on https://forums.developer.nvidia.com/t/hdf5-develop-testing-on-github-with-nvhpc-26-3-0-fails-to-compile-test-dt-arith-c-crashing-llvm/371564.

We opted to add the flag to CMAKE_C-FLAGS in the workflow instead of adding it to the CMake target code for test/dt_arith.c to avoid forcing it on users for all versions of nvhpc.  