### PR TITLE
tf.F90: Comment fix only, remove incorrect names

### DIFF
--- a/fortran/test/tf.F90
+++ b/fortran/test/tf.F90
@@ -20,8 +20,8 @@
 ! * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * *
 !
 ! CONTAINS SUBROUTINES
-!  write_test_status, check, verify, verifyLogical, verifyString, h5_fixname_f,
-!  h5_cleanup_f, h5_exit_f, h5_env_nocleanup_f,dreal_eqv
+!  write_test_status, check, h5_fixname_f,
+!  h5_cleanup_f, h5_exit_f, h5_env_nocleanup_f
 !
 !*****
 


### PR DESCRIPTION
fortran/test/tf.F90:

In this file's header comments, the list of included subroutines contains several names that are (no longer) part of this source file.  So remove them from the comment.