### PR TITLE
[hdf5_2_1_1] backport #6395: validate VL datatype during decode + check file pointer in H5T_set_loc

### DIFF
--- a/src/H5Odtype.c
+++ b/src/H5Odtype.c
@@ -760,6 +760,8 @@ H5O__dtype_decode_helper(unsigned *ioflags /*in,out*/, const uint8_t **pp, H5T_t
              */
             /* Set the type of VL information, either sequence or string */
             dt->shared->u.vlen.type = (H5T_vlen_type_t)(flags & 0x0f);
+            if (dt->shared->u.vlen.type != H5T_VLEN_SEQUENCE && dt->shared->u.vlen.type != H5T_VLEN_STRING)
+                HGOTO_ERROR(H5E_DATATYPE, H5E_BADVALUE, FAIL, "invalid VL datatype type");
             if (dt->shared->u.vlen.type == H5T_VLEN_STRING) {
                 dt->shared->u.vlen.pad  = (H5T_str_t)((flags >> 4) & 0x0f);
                 dt->shared->u.vlen.cset = (H5T_cset_t)((flags >> 8) & 0x0f);

--- a/src/H5T.c
+++ b/src/H5T.c
@@ -7013,6 +7013,11 @@ H5T_set_loc(H5T_t *dt, H5VL_object_t *file, H5T_loc_t loc)
                         ret_value = changed;
                 } /* end if */
 
+                /* Validate file pointer for disk-based VL types */
+                if (loc == H5T_LOC_DISK && NULL == file)
+                    HGOTO_ERROR(H5E_DATATYPE, H5E_BADVALUE, FAIL,
+                                "NULL file pointer for disk-based VL datatype");
+
                 /* Mark this VL sequence */
                 if ((changed = H5T__vlen_set_loc(dt, file, loc)) < 0)
                     HGOTO_ERROR(H5E_DATATYPE, H5E_CANTINIT, FAIL, "Unable to set VL location");


### PR DESCRIPTION
hdf5_2_1_1 doesn't have the VL-datatype decode validation that landed on develop (#6395, 2026-05-28 — after this branch's tip). On hdf5_2_1_1, H5O__dtype_decode_helper accepts a variable-length datatype whose type nibble is neither SEQUENCE nor STRING, and H5T_set_loc's memory branch then falls through leaving the vlen class unset, so a later deref hits a NULL pointer (and an assert(0) sink). A crafted .h5 file reaches it.

checked it on hdf5_2_1_1 rather than just diffing: built the decode -> H5T__vlen_set_loc path as a release-like (-DNDEBUG) harness with -fsanitize=address,undefined on ubuntu:22.04, fed a vlen type with nibble 0x0a. Pre-fix: UBSan member-access-within-null-pointer then ASan SEGV on 0x0. With #6395 cherry-picked the decode rejects the bad type and it's clean.

(yes, .h5 files are a trust boundary in many embedders — flagging it as a real decode crash rather than just a fuzzer artifact; it was originally an OSS-Fuzz find.)

Clean cherry-pick (-x), original author (tbeu) preserved. Two files (H5Odtype.c, H5T.c). Glad to rebase if you'd prefer.

upstream: https://github.com/HDFGroup/hdf5/commit/3fa6ed6e9dfeebbc784e21d8c48e31e35a8042bc