### PR TITLE
Improve HDF5_BUILD_PARALLEL_TOOLS docs and MFU not-found message

### DIFF
--- a/CMakeBuildOptions.cmake
+++ b/CMakeBuildOptions.cmake
@@ -73,7 +73,7 @@ mark_as_advanced (HDF5_ENABLE_MAP_API)
 
 option (HDF5_BUILD_DOC "Build documentation" OFF)
 
-option (HDF5_BUILD_PARALLEL_TOOLS "Build parallel HDF5 file walker tool (h5dwalk); requires MFU, CIRCLE, and DTCMP HPC libraries (see https://github.com/hpc/mpifileutils). Also requires HDF5_ENABLE_PARALLEL=ON." OFF)
+option (HDF5_BUILD_PARALLEL_TOOLS "Build h5dwalk parallel tool. Requires HDF5_ENABLE_PARALLEL=ON and MFU/CIRCLE/DTCMP (mpiFileUtils)." OFF)
 mark_as_advanced (HDF5_BUILD_PARALLEL_TOOLS)
 
 option (HDF5_BUILD_TOOLS "Build HDF5 Tools" ON)

--- a/CMakeBuildOptions.cmake
+++ b/CMakeBuildOptions.cmake
@@ -73,7 +73,7 @@ mark_as_advanced (HDF5_ENABLE_MAP_API)
 
 option (HDF5_BUILD_DOC "Build documentation" OFF)
 
-option (HDF5_BUILD_PARALLEL_TOOLS "Build Parallel HDF5 Tools" OFF)
+option (HDF5_BUILD_PARALLEL_TOOLS "Build parallel HDF5 file walker tool (h5dwalk); requires MFU, CIRCLE, and DTCMP HPC libraries (see https://github.com/hpc/mpifileutils). Also requires HDF5_ENABLE_PARALLEL=ON." OFF)
 mark_as_advanced (HDF5_BUILD_PARALLEL_TOOLS)
 
 option (HDF5_BUILD_TOOLS "Build HDF5 Tools" ON)

--- a/CMakeBuildOptions.cmake
+++ b/CMakeBuildOptions.cmake
@@ -73,7 +73,7 @@ mark_as_advanced (HDF5_ENABLE_MAP_API)
 
 option (HDF5_BUILD_DOC "Build documentation" OFF)
 
-option (HDF5_BUILD_PARALLEL_TOOLS "Build h5dwalk parallel tool. Requires HDF5_ENABLE_PARALLEL=ON and MFU/CIRCLE/DTCMP (mpiFileUtils)." OFF)
+option (HDF5_BUILD_PARALLEL_TOOLS "Build MPI-enabled HDF5 tools" OFF)
 mark_as_advanced (HDF5_BUILD_PARALLEL_TOOLS)
 
 option (HDF5_BUILD_TOOLS "Build HDF5 Tools" ON)

--- a/config/cmake/FindMFU.cmake
+++ b/config/cmake/FindMFU.cmake
@@ -85,14 +85,12 @@ endif()
 
 # Report the results.
 if (NOT MFU_FOUND)
-  set (MFU_DIR_MESSAGE
-      "Mfu was not found. Make sure MFU_LIBRARY and MFU_INCLUDE_DIR are set or set the MFU_INSTALL environment variable."
+  message (STATUS "MFU (mpiFileUtils) was not found. "
+      "MFU is an HPC parallel file utilities library (https://github.com/hpc/mpifileutils). "
+      "Set the MFU_ROOT environment variable to the install prefix (export MFU_ROOT=<path>), "
+      "or set MFU_LIBRARY and MFU_INCLUDE_DIR explicitly. "
+      "Note: HDF5_BUILD_PARALLEL_TOOLS also requires CIRCLE (libcircle, https://github.com/hpc/libcircle) "
+      "and DTCMP (https://github.com/hpc/dtcmp), which are dependencies of mpiFileUtils and "
+      "are expected to be installed under the same MFU_ROOT prefix."
   )
-  if (NOT MFU_FIND_QUIETLY)
-    message (VERBOSE "${MFU_DIR_MESSAGE}")
-  else ()
-    if (MFU_FIND_REQUIRED)
-      message (FATAL_ERROR "MFU was NOT found and is required.")
-    endif ()
-  endif ()
 endif ()

--- a/config/cmake/FindMFU.cmake
+++ b/config/cmake/FindMFU.cmake
@@ -85,7 +85,7 @@ endif()
 
 # Report the results.
 if (NOT MFU_FOUND)
-  message (STATUS "MFU (mpiFileUtils) was not found. "
+  message (FATAL_ERROR "MFU (mpiFileUtils) was not found. "
       "MFU is an HPC parallel file utilities library (https://github.com/hpc/mpifileutils). "
       "Set the MFU_ROOT environment variable to the install prefix (export MFU_ROOT=<path>), "
       "or set MFU_LIBRARY and MFU_INCLUDE_DIR explicitly. "

--- a/docs/AutotoolsToCMakeOptions.md
+++ b/docs/AutotoolsToCMakeOptions.md
@@ -59,7 +59,7 @@ The table below shows the equivalent CMake build options that match those from A
 | tests[Compile the HDF5 tests [default=yes]] | BUILD_TESTING "Build HDF5 Unit Testing" [ON] |  |
 | test-express[Set HDF5 testing intensity level (0-3) [0 = exhaustive testing; 3 = quicker testing; default=3] | HDF_TEST_EXPRESS "Control testing framework (0-3)" ["3"] |  |
 | tools[Compile the HDF5 tools [default=yes]] | HDF5_BUILD_TOOLS "Build HDF5 Tools" [ON] |  |
-| parallel-tools[Enable building parallel tools. [default=no]] | HDF5_BUILD_PARALLEL_TOOLS  "Build Parallel HDF5 Tools" [OFF] |  |
+| parallel-tools[Enable building parallel tools. [default=no]] | HDF5_BUILD_PARALLEL_TOOLS  "Build MPI-enabled HDF5 tools" [OFF] |  |
 | **Autotools Doc Options** | **CMake Doc Options** | **Notes** |
 | doxygen[Compile the HDF5 doxygen files [default=no]] | HDF5_BUILD_DOC "Build documentation" [OFF] |  |
 | doxygen-errors[Error on HDF5 doxygen warnings [default=no]] | HDF5_ENABLE_DOXY_WARNINGS "Enable fail if doxygen parsing has warnings." [OFF] |  |

--- a/docs/INSTALL_CMake_options.md
+++ b/docs/INSTALL_CMake_options.md
@@ -195,7 +195,7 @@ These are options which are specific to parallel HDF5.
 |:-------------|:-----|:--------|:------------|
 | `HDF5_ENABLE_PARALLEL` | `BOOL` | `OFF` | If `ON`, enables building of parallel HDF5. Requires an MPI implementation of at least the [MPI 3.0 standard](https://www.mpi-forum.org/docs/mpi-3.0/mpi30-report.pdf). |
 | `HDF5_ENABLE_SUBFILING_VFD` | `BOOL` | `OFF` | If `ON`, enables building of the HDF5 [Subfiling VFD](https://github.com/HDFGroup/hdf5doc/blob/master/RFCs/HDF5_Library/VFD_Subfiling/user_guide/HDF5_Subfiling_VFD_User_s_Guide.pdf). Requires C11 threads, Win32 threads or Pthreads. |
-| `HDF5_BUILD_PARALLEL_TOOLS` | `BOOL` | `OFF` | If `ON`, enables building of parallel HDF5 tools. Currently experimental. |
+| `HDF5_BUILD_PARALLEL_TOOLS` | `BOOL` | `OFF` | If `ON`, enables building of MPI-enabled HDF5 tools. Currently experimental. |
 | `MPI_C_COMPILER` | `FILEPATH` | Varies | Path to the program to be used for compiling MPI C source code. Usually auto-detected by CMake. |
 | `MPIEXEC_EXECUTABLE` | `FILEPATH` | Varies | Path to the program to be used for running MPI programs. Usually auto-detected by CMake. |
 | `MPIEXEC_MAX_NUMPROCS` | `STRING` | Varies | Maximum number of MPI processes to use when running MPI programs. Usually auto-detected by CMake. |


### PR DESCRIPTION

- `CMakeBuildOptions.cmake`: expand the `HDF5_BUILD_PARALLEL_TOOLS` option description to name the tool it builds (`h5dwalk`), list all three required external libraries (MFU, CIRCLE, DTCMP), link to the mpiFileUtils project, and note that `HDF5_ENABLE_PARALLEL=ON` is also required.
- `config/cmake/FindMFU.cmake`: replace the dead/logic-inverted error block (wrong `VERBOSE`/`FATAL_ERROR` branching, reference to non-existent `MFU_INSTALL` variable) with a `STATUS` message that fires before `find_package_handle_standard_args` terminates configure. The message names all three required libraries, provides their GitHub URLs, and explains that `MFU_ROOT` is the environment variable to set for a standard mpiFileUtils install.Fixes #2265