### PR TITLE
Allow reading of files with chunk dimensions encoded using more bytes than necessary

### DIFF
--- a/src/H5Dchunk.c
+++ b/src/H5Dchunk.c
@@ -855,10 +855,9 @@ H5D__chunk_set_sizes(H5D_t *dset)
 
     /* Set encoding length in layout */
     if (dset->shared->layout.u.chunk.enc_bytes_per_dim) {
-        if (dset->shared->layout.u.chunk.enc_bytes_per_dim != max_enc_bytes_per_dim)
+        if (dset->shared->layout.u.chunk.enc_bytes_per_dim < max_enc_bytes_per_dim)
             HGOTO_ERROR(H5E_DATASET, H5E_BADVALUE, FAIL,
-                        "stored chunk dimension encoding length does not match value calculated from chunk "
-                        "dimensions");
+                        "stored chunk dimension encoding length is insufficient to encode chunk dimensions");
     }
     else
         dset->shared->layout.u.chunk.enc_bytes_per_dim = max_enc_bytes_per_dim;


### PR DESCRIPTION
See title. While the library will never create these files, the wording of the file format spec allows it and third party software may create HDF5 files using the file format spec with larger than necessary chunk dimension encoding.

Fixes #6409 