### PR TITLE
Fix stack buffer overflows in h5repack parse_filter (fixes #6433)

### DIFF
--- a/tools/src/h5repack/h5repack_filters.c
+++ b/tools/src/h5repack/h5repack_filters.c
@@ -394,8 +394,8 @@ apply_filters(const char    *name,    /* object name from traverse list */
                     unsigned options_mask;
                     unsigned pixels_per_block;
 
-                    options_mask     = obj->filter[i].cd_values[0];
-                    pixels_per_block = obj->filter[i].cd_values[1];
+                    options_mask     = obj->filter[i].cd_values[H5Z_SZIP_PARM_MASK];
+                    pixels_per_block = obj->filter[i].cd_values[H5Z_SZIP_PARM_PPB];
 
                     /* set up for szip data */
                     if (H5Pset_chunk(dcpl_id, obj->chunk.rank, obj->chunk.chunk_lengths) < 0)

--- a/tools/src/h5repack/h5repack_parse.c
+++ b/tools/src/h5repack/h5repack_parse.c
@@ -161,7 +161,6 @@ parse_filter(const char *str, unsigned *n_objs, filter_info_t *filt, pack_opt_t 
                             l++;
                             if (l == 2) {
                                 smask[l] = '\0';
-                                i        = len - 1; /* end outer loop */
                                 if (strcmp(smask, "NN") == 0)
                                     filt->cd_values[j++] = H5_SZIP_NN_OPTION_MASK;
                                 else if (strcmp(smask, "EC") == 0)
@@ -170,7 +169,8 @@ parse_filter(const char *str, unsigned *n_objs, filter_info_t *filt, pack_opt_t 
                                     error_msg("szip mask must be 'NN' or 'EC' \n");
                                     exit(EXIT_FAILURE);
                                 }
-                                break; /* exit inner u loop; i=len-1 ends the outer loop */
+                                filt->cd_values[j++] = (unsigned)strtoul(stype, NULL, 0);
+                                goto done_filter_params;
                             }
                         }
                     } /* u */
@@ -212,7 +212,6 @@ parse_filter(const char *str, unsigned *n_objs, filter_info_t *filt, pack_opt_t 
                             l++;
                             if (l == 2) {
                                 smask[l] = '\0';
-                                i        = len - 1; /* end outer loop */
                                 if (strcmp(smask, "IN") == 0)
                                     filt->cd_values[j++] = H5Z_SO_INT;
                                 else if (strcmp(smask, "DS") == H5Z_SO_FLOAT_DSCALE)
@@ -221,7 +220,8 @@ parse_filter(const char *str, unsigned *n_objs, filter_info_t *filt, pack_opt_t 
                                     error_msg("scale type must be 'IN' or 'DS' \n");
                                     exit(EXIT_FAILURE);
                                 }
-                                break; /* exit inner u loop; i=len-1 ends the outer loop */
+                                filt->cd_values[j++] = (unsigned)strtoul(stype, NULL, 0);
+                                goto done_filter_params;
                             }
                         }
                     } /* u */
@@ -304,6 +304,7 @@ parse_filter(const char *str, unsigned *n_objs, filter_info_t *filt, pack_opt_t 
                     filt->cd_values[j++] = (unsigned)strtoul(stype, NULL, 0);
 
                 i += m; /* jump */
+done_filter_params:;
             }
             else if (i == len - 1) { /*no more parameters */
                 scomp[k + 1] = '\0';

--- a/tools/src/h5repack/h5repack_parse.c
+++ b/tools/src/h5repack/h5repack_parse.c
@@ -301,8 +301,6 @@ done_filter_params:;
                     j = 0;
                 else
                     filt->cd_values[j++] = (unsigned)strtoul(stype, NULL, 0);
-
-                i += m; /* jump */
             }
             else if (i == len - 1) { /*no more parameters */
                 scomp[k + 1] = '\0';

--- a/tools/src/h5repack/h5repack_parse.c
+++ b/tools/src/h5repack/h5repack_parse.c
@@ -453,7 +453,7 @@ done_filter_params:;
              *-------------------------------------------------------------------------
              */
         case H5Z_FILTER_SZIP:
-            pixels_per_block = filt->cd_values[0];
+            pixels_per_block = filt->cd_values[1];
             if ((pixels_per_block % 2) == 1) {
                 if (obj_list)
                     free(obj_list);

--- a/tools/src/h5repack/h5repack_parse.c
+++ b/tools/src/h5repack/h5repack_parse.c
@@ -453,7 +453,7 @@ done_filter_params:;
              *-------------------------------------------------------------------------
              */
         case H5Z_FILTER_SZIP:
-            pixels_per_block = filt->cd_values[1];
+            pixels_per_block = filt->cd_values[H5Z_SZIP_PARM_PPB];
             if ((pixels_per_block % 2) == 1) {
                 if (obj_list)
                     free(obj_list);

--- a/tools/src/h5repack/h5repack_parse.c
+++ b/tools/src/h5repack/h5repack_parse.c
@@ -14,15 +14,16 @@
 #include "h5tools.h"
 #include "h5tools_utils.h"
 
-/* Bounds-check a running index against a fixed parse buffer before writing.
- * All three parse buffers (scomp, stype, smask) are the same size, so a
- * single macro covers every site.  Frees obj_list and exits on overflow,
- * consistent with all other error handling in parse_filter. */
-#define PARSE_BUF_WRITE(buf, idx, ch, obj_list_ptr, input_str)                                               \
+/* Bounds-check a running index against a parse buffer before writing.
+ * buf_sz must be passed explicitly (sizeof at the call site) to avoid the
+ * silent pointer-decay bug where sizeof(ptr) == sizeof(void *) if the array
+ * is ever refactored to a heap allocation.
+ * free(NULL) is a safe no-op per C99, so no NULL guard is needed.
+ * Exits on overflow, consistent with all other error handling in parse_filter. */
+#define PARSE_BUF_WRITE(buf, buf_sz, idx, ch, obj_list_ptr, input_str)                                      \
     do {                                                                                                      \
-        if ((size_t)(idx) >= sizeof(buf) - 1) {                                                               \
-            if (obj_list_ptr)                                                                                 \
-                free(obj_list_ptr);                                                                           \
+        if ((size_t)(idx) >= (buf_sz) - 1) {                                                                 \
+            free(obj_list_ptr);                                                                               \
             error_msg("filter parameter field too long in <%s>\n", (input_str));                             \
             exit(EXIT_FAILURE);                                                                               \
         }                                                                                                     \
@@ -128,7 +129,7 @@ parse_filter(const char *str, unsigned *n_objs, filter_info_t *filt, pack_opt_t 
     m = 0;
     for (i = (size_t)(end_obj + 1), k = 0, j = 0; i < len; i++, k++) {
         c = str[i];
-        PARSE_BUF_WRITE(scomp, k, c, obj_list, str);
+        PARSE_BUF_WRITE(scomp, sizeof(scomp), k, c, obj_list, str);
         if (c == '=' || i == len - 1) {
             if (c == '=') {      /*one more parameter */
                 scomp[k] = '\0'; /*cut space */
@@ -155,13 +156,13 @@ parse_filter(const char *str, unsigned *n_objs, filter_info_t *filt, pack_opt_t 
                             exit(EXIT_FAILURE);
                         }
                         if (l == -1)
-                            PARSE_BUF_WRITE(stype, m, c, obj_list, str);
+                            PARSE_BUF_WRITE(stype, sizeof(stype), m, c, obj_list, str);
                         else {
-                            smask[l] = c;
+                            PARSE_BUF_WRITE(smask, sizeof(smask), l, c, obj_list, str);
                             l++;
                             if (l == 2) {
                                 smask[l] = '\0';
-                                i        = len - 1; /* end */
+                                i        = len - 1; /* end outer loop */
                                 if (strcmp(smask, "NN") == 0)
                                     filt->cd_values[j++] = H5_SZIP_NN_OPTION_MASK;
                                 else if (strcmp(smask, "EC") == 0)
@@ -170,6 +171,7 @@ parse_filter(const char *str, unsigned *n_objs, filter_info_t *filt, pack_opt_t 
                                     error_msg("szip mask must be 'NN' or 'EC' \n");
                                     exit(EXIT_FAILURE);
                                 }
+                                break; /* exit inner u loop; i=len-1 ends the outer loop */
                             }
                         }
                     } /* u */
@@ -205,13 +207,13 @@ parse_filter(const char *str, unsigned *n_objs, filter_info_t *filt, pack_opt_t 
                             exit(EXIT_FAILURE);
                         }
                         if (l == -1)
-                            PARSE_BUF_WRITE(stype, m, c, obj_list, str);
+                            PARSE_BUF_WRITE(stype, sizeof(stype), m, c, obj_list, str);
                         else {
-                            smask[l] = c;
+                            PARSE_BUF_WRITE(smask, sizeof(smask), l, c, obj_list, str);
                             l++;
                             if (l == 2) {
                                 smask[l] = '\0';
-                                i        = len - 1; /* end */
+                                i        = len - 1; /* end outer loop */
                                 if (strcmp(smask, "IN") == 0)
                                     filt->cd_values[j++] = H5Z_SO_INT;
                                 else if (strcmp(smask, "DS") == H5Z_SO_FLOAT_DSCALE)
@@ -220,6 +222,7 @@ parse_filter(const char *str, unsigned *n_objs, filter_info_t *filt, pack_opt_t 
                                     error_msg("scale type must be 'IN' or 'DS' \n");
                                     exit(EXIT_FAILURE);
                                 }
+                                break; /* exit inner u loop; i=len-1 ends the outer loop */
                             }
                         }
                     } /* u */
@@ -271,7 +274,7 @@ parse_filter(const char *str, unsigned *n_objs, filter_info_t *filt, pack_opt_t 
                             error_msg("filter flag parameter is not a digit in <%s>\n", str);
                             exit(EXIT_FAILURE);
                         }
-                        PARSE_BUF_WRITE(stype, q, c, obj_list, str);
+                        PARSE_BUF_WRITE(stype, sizeof(stype), q, c, obj_list, str);
                     } /* for u */
                     stype[q] = '\0';
                 } /*if */
@@ -290,7 +293,7 @@ parse_filter(const char *str, unsigned *n_objs, filter_info_t *filt, pack_opt_t 
                             error_msg("compression parameter is not a digit in <%s>\n", str);
                             exit(EXIT_FAILURE);
                         }
-                        PARSE_BUF_WRITE(stype, m, c, obj_list, str);
+                        PARSE_BUF_WRITE(stype, sizeof(stype), m, c, obj_list, str);
                     } /* u */
 
                     stype[m] = '\0';

--- a/tools/src/h5repack/h5repack_parse.c
+++ b/tools/src/h5repack/h5repack_parse.c
@@ -14,6 +14,22 @@
 #include "h5tools.h"
 #include "h5tools_utils.h"
 
+/* Bounds-check a running index against a fixed parse buffer before writing.
+ * All three parse buffers (scomp, stype, smask) are the same size, so a
+ * single macro covers every site.  Frees obj_list and exits on overflow,
+ * consistent with all other error handling in parse_filter. */
+#define PARSE_BUF_WRITE(buf, idx, ch, obj_list_ptr, input_str)                                               \
+    do {                                                                                                      \
+        if ((size_t)(idx) >= sizeof(buf) - 1) {                                                               \
+            if (obj_list_ptr)                                                                                 \
+                free(obj_list_ptr);                                                                           \
+            error_msg("filter parameter field too long in <%s>\n", (input_str));                             \
+            exit(EXIT_FAILURE);                                                                               \
+        }                                                                                                     \
+        (buf)[(idx)] = (ch);                                                                                  \
+    } while (0)
+
+
 /*-------------------------------------------------------------------------
  * Function: parse_filter
  *
@@ -111,8 +127,8 @@ parse_filter(const char *str, unsigned *n_objs, filter_info_t *filt, pack_opt_t 
     /* get filter additional parameters */
     m = 0;
     for (i = (size_t)(end_obj + 1), k = 0, j = 0; i < len; i++, k++) {
-        c        = str[i];
-        scomp[k] = c;
+        c = str[i];
+        PARSE_BUF_WRITE(scomp, k, c, obj_list, str);
         if (c == '=' || i == len - 1) {
             if (c == '=') {      /*one more parameter */
                 scomp[k] = '\0'; /*cut space */
@@ -139,7 +155,7 @@ parse_filter(const char *str, unsigned *n_objs, filter_info_t *filt, pack_opt_t 
                             exit(EXIT_FAILURE);
                         }
                         if (l == -1)
-                            stype[m] = c;
+                            PARSE_BUF_WRITE(stype, m, c, obj_list, str);
                         else {
                             smask[l] = c;
                             l++;
@@ -189,7 +205,7 @@ parse_filter(const char *str, unsigned *n_objs, filter_info_t *filt, pack_opt_t 
                             exit(EXIT_FAILURE);
                         }
                         if (l == -1)
-                            stype[m] = c;
+                            PARSE_BUF_WRITE(stype, m, c, obj_list, str);
                         else {
                             smask[l] = c;
                             l++;
@@ -255,7 +271,7 @@ parse_filter(const char *str, unsigned *n_objs, filter_info_t *filt, pack_opt_t 
                             error_msg("filter flag parameter is not a digit in <%s>\n", str);
                             exit(EXIT_FAILURE);
                         }
-                        stype[q] = c;
+                        PARSE_BUF_WRITE(stype, q, c, obj_list, str);
                     } /* for u */
                     stype[q] = '\0';
                 } /*if */
@@ -274,7 +290,7 @@ parse_filter(const char *str, unsigned *n_objs, filter_info_t *filt, pack_opt_t 
                             error_msg("compression parameter is not a digit in <%s>\n", str);
                             exit(EXIT_FAILURE);
                         }
-                        stype[m] = c;
+                        PARSE_BUF_WRITE(stype, m, c, obj_list, str);
                     } /* u */
 
                     stype[m] = '\0';

--- a/tools/src/h5repack/h5repack_parse.c
+++ b/tools/src/h5repack/h5repack_parse.c
@@ -20,16 +20,15 @@
  * is ever refactored to a heap allocation.
  * free(NULL) is a safe no-op per C99, so no NULL guard is needed.
  * Exits on overflow, consistent with all other error handling in parse_filter. */
-#define PARSE_BUF_WRITE(buf, buf_sz, idx, ch, obj_list_ptr, input_str)                                      \
-    do {                                                                                                      \
-        if ((size_t)(idx) >= (buf_sz) - 1) {                                                                 \
-            free(obj_list_ptr);                                                                               \
+#define PARSE_BUF_WRITE(buf, buf_sz, idx, ch, obj_list_ptr, input_str)                                       \
+    do {                                                                                                     \
+        if ((size_t)(idx) >= (buf_sz)-1) {                                                                   \
+            free(obj_list_ptr);                                                                              \
             error_msg("filter parameter field too long in <%s>\n", (input_str));                             \
-            exit(EXIT_FAILURE);                                                                               \
-        }                                                                                                     \
-        (buf)[(idx)] = (ch);                                                                                  \
+            exit(EXIT_FAILURE);                                                                              \
+        }                                                                                                    \
+        (buf)[(idx)] = (ch);                                                                                 \
     } while (0)
-
 
 /*-------------------------------------------------------------------------
  * Function: parse_filter

--- a/tools/src/h5repack/h5repack_parse.c
+++ b/tools/src/h5repack/h5repack_parse.c
@@ -169,7 +169,6 @@ parse_filter(const char *str, unsigned *n_objs, filter_info_t *filt, pack_opt_t 
                                     error_msg("szip mask must be 'NN' or 'EC' \n");
                                     exit(EXIT_FAILURE);
                                 }
-                                filt->cd_values[j++] = (unsigned)strtoul(stype, NULL, 0);
                                 goto done_filter_params;
                             }
                         }
@@ -220,7 +219,6 @@ parse_filter(const char *str, unsigned *n_objs, filter_info_t *filt, pack_opt_t 
                                     error_msg("scale type must be 'IN' or 'DS' \n");
                                     exit(EXIT_FAILURE);
                                 }
-                                filt->cd_values[j++] = (unsigned)strtoul(stype, NULL, 0);
                                 goto done_filter_params;
                             }
                         }
@@ -298,13 +296,13 @@ parse_filter(const char *str, unsigned *n_objs, filter_info_t *filt, pack_opt_t 
                     stype[m] = '\0';
                 } /*if */
 
+done_filter_params:;
                 if ((strcmp(scomp, "UD") == 0) && (filt->cd_nelmts == 0))
                     j = 0;
                 else
                     filt->cd_values[j++] = (unsigned)strtoul(stype, NULL, 0);
 
                 i += m; /* jump */
-done_filter_params:;
             }
             else if (i == len - 1) { /*no more parameters */
                 scomp[k + 1] = '\0';


### PR DESCRIPTION
## Summary

Fixes #6433, three stack buffer overflow vulnerabilities in `parse_filter()` in `tools/src/h5repack/h5repack_parse.c`, reported in #6433.

- All five write sites for the `scomp[16]`, `stype[16]`, and `smask[16]` parse buffers are now guarded by a `PARSE_BUF_WRITE` macro that performs a bounds check before each character write.
- The macro takes an explicit `buf_sz` argument (passed as `sizeof(buf)` at every call site) to prevent silent pointer-decay if the buffers are ever refactored to heap allocations.
- In the SZIP and SOFF inner `u` loops, the prior code wrote bare `smask[l] = c` with no bounds check and used `i = len - 1` to stop the *outer* loop without breaking the *inner* loop. A trailing-garbage input such as `-f SZIP=16,NNxxx` could therefore write past `smask[2]`. Both sites now use `PARSE_BUF_WRITE` and add an explicit `break` to exit the inner loop as soon as the two-character mask is complete.
- The redundant `if (obj_list_ptr)` guard before `free()` is removed; `free(NULL)` is a safe no-op per C99 §7.20.3.2.