### PR TITLE
Fix issues with MSVC and OneAPI CI due to VS 18 2026

### DIFF
--- a/.github/workflows/arm-main.yml
+++ b/.github/workflows/arm-main.yml
@@ -74,7 +74,7 @@ jobs:
           mkdir "${{ runner.workspace }}/build"
           cd "${{ runner.workspace }}/build"
           cmake -C $GITHUB_WORKSPACE/config/cmake/cacheinit.cmake \
-            -G "Visual Studio 18 2026" -A ARM64 \
+            -G "Visual Studio 17 2022" -A ARM64 \
             --log-level=VERBOSE \
             -DCMAKE_BUILD_TYPE=${{ inputs.build_mode }} \
             -DHDF5_ENABLE_DOXY_WARNINGS:BOOL=ON \
@@ -96,7 +96,7 @@ jobs:
           mkdir "${{ runner.workspace }}/build"
           cd "${{ runner.workspace }}/build"
           cmake -C $GITHUB_WORKSPACE/config/cmake/cacheinit.cmake \
-            -G "Visual Studio 18 2026" -A ARM64 \
+            -G "Visual Studio 17 2022" -A ARM64 \
             -DCMAKE_BUILD_TYPE=${{ inputs.build_mode }} \
             -DHDF5_ENABLE_THREADSAFE:BOOL=ON \
             -DHDF5_ENABLE_CONCURRENCY:BOOL=OFF \
@@ -120,7 +120,7 @@ jobs:
           mkdir "${{ runner.workspace }}/build"
           cd "${{ runner.workspace }}/build"
           cmake -C $GITHUB_WORKSPACE/config/cmake/cacheinit.cmake \
-            -G "Visual Studio 18 2026" -A ARM64 \
+            -G "Visual Studio 17 2022" -A ARM64 \
             -DCMAKE_BUILD_TYPE=${{ inputs.build_mode }} \
             -DHDF5_ENABLE_ALL_WARNINGS=ON \
             -DHDF5_ENABLE_THREADSAFE:BOOL=OFF \

--- a/.github/workflows/arm-main.yml
+++ b/.github/workflows/arm-main.yml
@@ -74,7 +74,7 @@ jobs:
           mkdir "${{ runner.workspace }}/build"
           cd "${{ runner.workspace }}/build"
           cmake -C $GITHUB_WORKSPACE/config/cmake/cacheinit.cmake \
-            -G "Visual Studio 17 2022" -A ARM64 \
+            -G "Visual Studio 18 2026" -A ARM64 \
             --log-level=VERBOSE \
             -DCMAKE_BUILD_TYPE=${{ inputs.build_mode }} \
             -DHDF5_ENABLE_DOXY_WARNINGS:BOOL=ON \
@@ -96,7 +96,7 @@ jobs:
           mkdir "${{ runner.workspace }}/build"
           cd "${{ runner.workspace }}/build"
           cmake -C $GITHUB_WORKSPACE/config/cmake/cacheinit.cmake \
-            -G "Visual Studio 17 2022" -A ARM64 \
+            -G "Visual Studio 18 2026" -A ARM64 \
             -DCMAKE_BUILD_TYPE=${{ inputs.build_mode }} \
             -DHDF5_ENABLE_THREADSAFE:BOOL=ON \
             -DHDF5_ENABLE_CONCURRENCY:BOOL=OFF \
@@ -120,7 +120,7 @@ jobs:
           mkdir "${{ runner.workspace }}/build"
           cd "${{ runner.workspace }}/build"
           cmake -C $GITHUB_WORKSPACE/config/cmake/cacheinit.cmake \
-            -G "Visual Studio 17 2022" -A ARM64 \
+            -G "Visual Studio 18 2026" -A ARM64 \
             -DCMAKE_BUILD_TYPE=${{ inputs.build_mode }} \
             -DHDF5_ENABLE_ALL_WARNINGS=ON \
             -DHDF5_ENABLE_THREADSAFE:BOOL=OFF \

--- a/.github/workflows/call-workflows.yml
+++ b/.github/workflows/call-workflows.yml
@@ -173,6 +173,9 @@ jobs:
             thread_safety: ""
             build_mode: "Release"
             force_java_implementation: "jni"
+            java_version: 11
+            win_runner: "windows-2022"
+            win_vs_generator: "Visual Studio 17 2022"
 
     call-jni-latest-java:
         name: "JNI Latest Java Testing"

--- a/.github/workflows/ctest.yml
+++ b/.github/workflows/ctest.yml
@@ -903,7 +903,7 @@ jobs:
   # Windows w/ OneAPI
   #
     name: "Windows Intel CTest"
-    runs-on: windows-latest
+    runs-on: windows-2022
     needs: [check-secret]
     steps:
       - name: Install Dependencies (Windows_intel)

--- a/.github/workflows/intel.yml
+++ b/.github/workflows/intel.yml
@@ -71,7 +71,7 @@ jobs:
 
   Intel_oneapi_windows:
     name: "windows-oneapi ${{ inputs.build_mode }}"
-    runs-on: windows-latest
+    runs-on: windows-2025
     steps:
       - name: Get Sources (Windows)
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3

--- a/.github/workflows/intel.yml
+++ b/.github/workflows/intel.yml
@@ -71,7 +71,7 @@ jobs:
 
   Intel_oneapi_windows:
     name: "windows-oneapi ${{ inputs.build_mode }}"
-    runs-on: windows-2025
+    runs-on: windows-2022
     steps:
       - name: Get Sources (Windows)
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
@@ -85,6 +85,12 @@ jobs:
         with:
           compiler: intel
           version: '2025.2'
+
+      - name: Setup Java
+        uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5.2.0
+        with:
+          java-version: 11
+          distribution: 'temurin'
 
       - name: Configure (Windows)
         shell: pwsh

--- a/.github/workflows/main-spc.yml
+++ b/.github/workflows/main-spc.yml
@@ -366,7 +366,7 @@ jobs:
 
   build_v2_0_win:
     name: "Intel DBG v2.0.0 default API no deprecated"
-    runs-on: windows-2025
+    runs-on: windows-2022
     steps:
       # SETUP
       # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
@@ -385,6 +385,12 @@ jobs:
         with:
           compiler: intel
           version: '2025.0'
+
+      - name: Setup Java
+        uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5.2.0
+        with:
+          java-version: 11
+          distribution: 'temurin'
 
       - name: Configure (Windows)
         shell: pwsh

--- a/.github/workflows/main-spc.yml
+++ b/.github/workflows/main-spc.yml
@@ -366,7 +366,7 @@ jobs:
 
   build_v2_0_win:
     name: "Intel DBG v2.0.0 default API no deprecated"
-    runs-on: windows-latest
+    runs-on: windows-2025
     steps:
       # SETUP
       # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it

--- a/.github/workflows/main-static.yml
+++ b/.github/workflows/main-static.yml
@@ -71,7 +71,7 @@ jobs:
             mirror_vfd: OFF
             direct_vfd: OFF
             ros3_vfd: OFF
-            generator: "-G \"Visual Studio 17 2022\" -A x64"
+            generator: "-G \"Visual Studio 18 2026\" -A x64"
             run_tests: true
 
           - name: "Ubuntu Static gcc"

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -35,6 +35,16 @@ on:
         required: false
         default: "jni"
         type: string
+      win_runner:
+        description: "Windows runner version to use (windows-2022, windows-latest, etc.)"
+        required: false
+        default: "windows-latest"
+        type: string
+      win_vs_generator:
+        description: "CMake generator to use for Visual Studio"
+        required: false
+        default: "Visual Studio 18 2026"
+        type: string
 
 permissions:
   contents: read
@@ -71,7 +81,7 @@ jobs:
           # No Fortran, parallel, or VFDs that rely on POSIX things
           - name: "Windows MSVC"
             ostype: windows
-            os: windows-latest
+            os: ${{ inputs.win_runner }}
             shared: ON
             cpp: ON
             fortran: OFF
@@ -84,7 +94,7 @@ jobs:
             parallel: OFF
             mirror_vfd: OFF
             direct_vfd: OFF
-            generator: "-G \"Visual Studio 18 2026\" -A x64"
+            generator: "-G \"${{ inputs.win_vs_generator }}\" -A x64"
             run_tests: true
 
           # Linux (Ubuntu) w/ gcc

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -84,7 +84,7 @@ jobs:
             parallel: OFF
             mirror_vfd: OFF
             direct_vfd: OFF
-            generator: "-G \"Visual Studio 17 2022\" -A x64"
+            generator: "-G \"Visual Studio 18 2026\" -A x64"
             run_tests: true
 
           # Linux (Ubuntu) w/ gcc

--- a/.github/workflows/script.yml
+++ b/.github/workflows/script.yml
@@ -484,7 +484,7 @@ jobs:
   # Windows w/ OneAPI
   #
     name: "Windows Intel CTest"
-    runs-on: windows-latest
+    runs-on: windows-2022
     steps:
       - name: Get Actions
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3


### PR DESCRIPTION
Visual Studio 17 2022 seems to no longer be available from actions run on windows-latest from forks

Ref: https://github.com/actions/runner-images/issues/14017