### PR TITLE
CI: fix remaining zizmor template-injection findings

### DIFF
--- a/.github/workflows/vol_cache.yml
+++ b/.github/workflows/vol_cache.yml
@@ -75,11 +75,14 @@ jobs:
       # FetchContent's OVERRIDE_FIND_PACKAGE)
       - name: Configure HDF5 with cache VOL connector
         shell: bash
+        env:
+          BUILD_MODE: ${{ inputs.build_mode }}
+          RUNNER_WORKSPACE: ${{ runner.workspace }}
         run: |
-          mkdir ${{ github.workspace }}/hdf5/build
-          cd ${{ github.workspace }}/hdf5/build
-          cmake -DCMAKE_BUILD_TYPE=${{ inputs.build_mode }} \
-            -DCMAKE_INSTALL_PREFIX=${{ runner.workspace }}/hdf5_build \
+          mkdir $GITHUB_WORKSPACE/hdf5/build
+          cd $GITHUB_WORKSPACE/hdf5/build
+          cmake -DCMAKE_BUILD_TYPE=$BUILD_MODE \
+            -DCMAKE_INSTALL_PREFIX=$RUNNER_WORKSPACE/hdf5_build \
             -DBUILD_STATIC_LIBS=OFF \
             -DHDF5_TEST_API:BOOL=ON \
             -DHDF5_TEST_API_ENABLE_ASYNC:BOOL=ON \
@@ -97,18 +100,20 @@ jobs:
             -DHDF5_VOL_VOL-CACHE_BRANCH:STRING="develop" \
             -DHDF5_VOL_VOL-CACHE_NAME:STRING="$HDF5_VOL_CACHE_TEST_NAME" \
             -DHDF5_VOL_VOL-CACHE_TEST_PARALLEL:BOOL=ON \
-            -DASYNC_INCLUDE_DIR=${{ github.workspace }}/hdf5/build/_deps/vol-async-src/src \
-            -DASYNC_INCLUDE_DIRS=${{ github.workspace }}/hdf5/build/_deps/vol-async-src/src \
-            -DASYNC_LIBRARIES=${{ github.workspace }}/hdf5/build/bin/libasynchdf5.a\;${{ github.workspace }}/hdf5/build/bin/libh5async.so \
-            ${{ github.workspace }}/hdf5
+            -DASYNC_INCLUDE_DIR=$GITHUB_WORKSPACE/hdf5/build/_deps/vol-async-src/src \
+            -DASYNC_INCLUDE_DIRS=$GITHUB_WORKSPACE/hdf5/build/_deps/vol-async-src/src \
+            -DASYNC_LIBRARIES=$GITHUB_WORKSPACE/hdf5/build/bin/libasynchdf5.a\;$GITHUB_WORKSPACE/hdf5/build/bin/libh5async.so \
+            $GITHUB_WORKSPACE/hdf5
           cat src/libhdf5.settings
 
       - name: Build HDF5 and cache VOL connector
         shell: bash
         working-directory: ${{ github.workspace }}/hdf5/build
+        env:
+          BUILD_MODE: ${{ inputs.build_mode }}
         run: |
-          cmake --build . --parallel 3 --config ${{ inputs.build_mode }}
-          echo "LD_LIBRARY_PATH=/usr/local/lib:${{ github.workspace }}/hdf5/build/bin" >> $GITHUB_ENV
+          cmake --build . --parallel 3 --config $BUILD_MODE
+          echo "LD_LIBRARY_PATH=/usr/local/lib:$GITHUB_WORKSPACE/hdf5/build/bin" >> $GITHUB_ENV
 
       - name: Create cache VOL connector configuration file for testing
         shell: bash
@@ -134,26 +139,28 @@ jobs:
 
       - name: Set environment variables for external tests (cache VOL only)
         run: |
-          echo "HDF5_PLUGIN_PATH=${{ github.workspace }}/hdf5/build/bin/" >> $GITHUB_ENV
+          echo "HDF5_PLUGIN_PATH=$GITHUB_WORKSPACE/hdf5/build/bin/" >> $GITHUB_ENV
           echo "HDF5_VOL_CONNECTOR=cache_ext config=$GITHUB_WORKSPACE/config1.cfg;under_vol=0;under_info={};" >> $GITHUB_ENV
         if: ${{ ! matrix.async }}
 
       - name: Set environment variables for external tests (cache VOL atop async VOL)
         run: |
-          echo "HDF5_PLUGIN_PATH=${{ github.workspace }}/hdf5/build/bin/" >> $GITHUB_ENV
+          echo "HDF5_PLUGIN_PATH=$GITHUB_WORKSPACE/hdf5/build/bin/" >> $GITHUB_ENV
           echo "HDF5_VOL_CONNECTOR=cache_ext config=$GITHUB_WORKSPACE/config1.cfg;under_vol=512;under_info={under_vol=0;under_info={}};" >> $GITHUB_ENV
         if: ${{ matrix.async }}
 
       # Until cache VOL tests are namespaced properly, run them directly
       - name: Test HDF5 cache VOL connector with external tests
         working-directory: ${{ github.workspace }}/hdf5/build
+        env:
+          BUILD_MODE: ${{ inputs.build_mode }}
         run: |
-          ctest --build-config ${{ inputs.build_mode }} -R "^test_file$" .
-          ctest --build-config ${{ inputs.build_mode }} -R "^test_group$" .
-          ctest --build-config ${{ inputs.build_mode }} -R "^test_dataset$" .
-          ctest --build-config ${{ inputs.build_mode }} -R "^test_dataset_async_api$" .
-          ctest --build-config ${{ inputs.build_mode }} -R "^test_write_multi$" .
-          ctest --build-config ${{ inputs.build_mode }} -R "^test_multdset$" .
+          ctest --build-config $BUILD_MODE -R "^test_file$" .
+          ctest --build-config $BUILD_MODE -R "^test_group$" .
+          ctest --build-config $BUILD_MODE -R "^test_dataset$" .
+          ctest --build-config $BUILD_MODE -R "^test_dataset_async_api$" .
+          ctest --build-config $BUILD_MODE -R "^test_write_multi$" .
+          ctest --build-config $BUILD_MODE -R "^test_multdset$" .
 
       - name: Test HDF5 cache VOL connector with HDF5 API tests
         working-directory: ${{ github.workspace }}/hdf5/build
@@ -163,5 +170,7 @@ jobs:
         # all the tests. Leave the step in, but skip it to leave an indication
         # that this should be re-enabled in the future.
         if: ${{ ! matrix.async }}
+        env:
+          BUILD_MODE: ${{ inputs.build_mode }}
         run: |
-          ctest --build-config ${{ inputs.build_mode }} -R "HDF5_VOL_vol-cache" -E "H5DIFF" .
+          ctest --build-config $BUILD_MODE -R "HDF5_VOL_vol-cache" -E "H5DIFF" .

--- a/.github/workflows/vol_ext_passthru.yml
+++ b/.github/workflows/vol_ext_passthru.yml
@@ -37,11 +37,14 @@ jobs:
 
       - name: Configure HDF5 with external passthrough VOL connector
         shell: bash
+        env:
+          BUILD_MODE: ${{ inputs.build_mode }}
+          RUNNER_WORKSPACE: ${{ runner.workspace }}
         run: |
-          mkdir ${{ github.workspace }}/hdf5/build
-          cd ${{ github.workspace }}/hdf5/build
-          cmake -DCMAKE_BUILD_TYPE=${{ inputs.build_mode }} \
-            -DCMAKE_INSTALL_PREFIX=${{ runner.workspace }}/hdf5_build \
+          mkdir $GITHUB_WORKSPACE/hdf5/build
+          cd $GITHUB_WORKSPACE/hdf5/build
+          cmake -DCMAKE_BUILD_TYPE=$BUILD_MODE \
+            -DCMAKE_INSTALL_PREFIX=$RUNNER_WORKSPACE/hdf5_build \
             -DBUILD_STATIC_LIBS=OFF \
             -DHDF5_TEST_API:BOOL=ON \
             -DHDF5_ENABLE_PARALLEL:BOOL=ON \
@@ -52,16 +55,20 @@ jobs:
             -DHDF5_VOL_VOL-EXTERNAL-PASSTHROUGH_BRANCH:STRING="develop" \
             -DHDF5_VOL_VOL-EXTERNAL-PASSTHROUGH_NAME:STRING="pass_through_ext under_vol=0\;under_info={}\;" \
             -DHDF5_VOL_VOL-EXTERNAL-PASSTHROUGH_TEST_PARALLEL:BOOL=ON \
-            ${{ github.workspace }}/hdf5
+            $GITHUB_WORKSPACE/hdf5
           cat src/libhdf5.settings
 
       - name: Build HDF5 and external passthrough VOL connector
         shell: bash
         working-directory: ${{ github.workspace }}/hdf5/build
+        env:
+          BUILD_MODE: ${{ inputs.build_mode }}
         run: |
-          cmake --build . --parallel 3 --config ${{ inputs.build_mode }}
+          cmake --build . --parallel 3 --config $BUILD_MODE
 
       - name: Test HDF5 external passthrough VOL connector with HDF5 API tests
         working-directory: ${{ github.workspace }}/hdf5/build
+        env:
+          BUILD_MODE: ${{ inputs.build_mode }}
         run: |
-          ctest --build-config ${{ inputs.build_mode }} -R "HDF5_VOL_vol-external-passthrough" .
+          ctest --build-config $BUILD_MODE -R "HDF5_VOL_vol-external-passthrough" .

--- a/.github/workflows/vol_log.yml
+++ b/.github/workflows/vol_log.yml
@@ -33,11 +33,14 @@ jobs:
       # Log-based VOL currently doesn't have CMake support
       - name: Configure HDF5
         shell: bash
+        env:
+          BUILD_MODE: ${{ inputs.build_mode }}
+          RUNNER_WORKSPACE: ${{ runner.workspace }}
         run: |
-          mkdir ${{ github.workspace }}/hdf5/build
-          cd ${{ github.workspace }}/hdf5/build
-          cmake -DCMAKE_BUILD_TYPE=${{ inputs.build_mode }} \
-            -DCMAKE_INSTALL_PREFIX=${{ runner.workspace }}/hdf5_build \
+          mkdir $GITHUB_WORKSPACE/hdf5/build
+          cd $GITHUB_WORKSPACE/hdf5/build
+          cmake -DCMAKE_BUILD_TYPE=$BUILD_MODE \
+            -DCMAKE_INSTALL_PREFIX=$RUNNER_WORKSPACE/hdf5_build \
             -DBUILD_STATIC_LIBS=OFF \
             -DHDF5_TEST_API:BOOL=ON \
             -DHDF5_TEST_API_ENABLE_ASYNC:BOOL=ON \
@@ -46,17 +49,20 @@ jobs:
             -DHDF5_ALLOW_UNSUPPORTED:BOOL=ON \
             -DHDF5_ENABLE_ZLIB_SUPPORT:BOOL=ON \
             -DHDF5_ENABLE_SZIP_SUPPORT:BOOL=OFF \
-            ${{ github.workspace }}/hdf5
+            $GITHUB_WORKSPACE/hdf5
           cat src/libhdf5.settings
 
       - name: Build and install HDF5
         shell: bash
         working-directory: ${{ github.workspace }}/hdf5/build
+        env:
+          BUILD_MODE: ${{ inputs.build_mode }}
+          RUNNER_WORKSPACE: ${{ runner.workspace }}
         run: |
-          cmake --build . --parallel 3 --config ${{ inputs.build_mode }}
+          cmake --build . --parallel 3 --config $BUILD_MODE
           cmake --install .
-          echo "LD_LIBRARY_PATH=${{ github.workspace }}/hdf5/build/bin" >> $GITHUB_ENV
-          echo "PATH=${{ runner.workspace }}/hdf5_build/bin:${PATH}" >> $GITHUB_ENV
+          echo "LD_LIBRARY_PATH=$GITHUB_WORKSPACE/hdf5/build/bin" >> $GITHUB_ENV
+          echo "PATH=$RUNNER_WORKSPACE/hdf5_build/bin:${PATH}" >> $GITHUB_ENV
 
       - name: Checkout Log-based VOL
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
@@ -69,12 +75,13 @@ jobs:
           CXX: mpic++
           CC: mpicc
           LD_LIBRARY_PATH: ${{ runner.workspace }}/hdf5_build/lib
+          RUNNER_WORKSPACE: ${{ runner.workspace }}
         run: |
           cd vol-log-based
           autoreconf -i
-          ./configure --prefix=${{ runner.workspace }}/vol-log-based-build --with-hdf5=${{ runner.workspace }}/hdf5_build/ --enable-shared --enable-zlib
+          ./configure --prefix=$RUNNER_WORKSPACE/vol-log-based-build --with-hdf5=$RUNNER_WORKSPACE/hdf5_build/ --enable-shared --enable-zlib
           make -j2 && make install
-          export HDF5_PLUGIN_PATH="${{ runner.workspace }}/vol-log-based-build/lib"
+          export HDF5_PLUGIN_PATH="$RUNNER_WORKSPACE/vol-log-based-build/lib"
           export HDF5_VOL_CONNECTOR="LOG under_vol=0;under_info={}"
           make check
           echo "HDF5_PLUGIN_PATH=${HDF5_PLUGIN_PATH}" >> $GITHUB_ENV
@@ -88,5 +95,7 @@ jobs:
         # but skip it to leave an indication that this should be re-enabled
         # in the future.
         if: false
+        env:
+          BUILD_MODE: ${{ inputs.build_mode }}
         run: |
-          ctest --build-config ${{ inputs.build_mode }} -R "h5_api" -E "parallel" .
+          ctest --build-config $BUILD_MODE -R "h5_api" -E "parallel" .

--- a/.github/workflows/vol_rest.yml
+++ b/.github/workflows/vol_rest.yml
@@ -49,11 +49,14 @@ jobs:
 
       - name: Configure HDF5 with REST VOL connector
         shell: bash
+        env:
+          BUILD_MODE: ${{ inputs.build_mode }}
+          RUNNER_WORKSPACE: ${{ runner.workspace }}
         run: |
-          mkdir ${{ github.workspace }}/hdf5/build
-          cd ${{ github.workspace }}/hdf5/build
-          cmake -DCMAKE_BUILD_TYPE=${{ inputs.build_mode }} \
-            -DCMAKE_INSTALL_PREFIX=${{ runner.workspace }}/hdf5_build \
+          mkdir $GITHUB_WORKSPACE/hdf5/build
+          cd $GITHUB_WORKSPACE/hdf5/build
+          cmake -DCMAKE_BUILD_TYPE=$BUILD_MODE \
+            -DCMAKE_INSTALL_PREFIX=$RUNNER_WORKSPACE/hdf5_build \
             -DBUILD_STATIC_LIBS=OFF \
             -DHDF5_BUILD_HL_LIB:BOOL=ON \
             -DHDF5_TEST_API:BOOL=ON \
@@ -66,16 +69,18 @@ jobs:
             -DHDF5_VOL_VOL-REST_NAME:STRING="REST" \
             -DHDF5_VOL_VOL-REST_TEST_PARALLEL:BOOL=OFF \
             -DHDF5_VOL_REST_ENABLE_EXAMPLES=ON \
-            ${{ github.workspace }}/hdf5
+            $GITHUB_WORKSPACE/hdf5
           cat src/libhdf5.settings
 
       - name: Build and install HDF5 and REST VOL connector
         shell: bash
         working-directory: ${{ github.workspace }}/hdf5/build
+        env:
+          BUILD_MODE: ${{ inputs.build_mode }}
         run: |
-          cmake --build . --parallel 3 --config ${{ inputs.build_mode }}
+          cmake --build . --parallel 3 --config $BUILD_MODE
           cmake --install .
-          echo "LD_LIBRARY_PATH=${{ github.workspace }}/hdf5/build/bin" >> $GITHUB_ENV
+          echo "LD_LIBRARY_PATH=$GITHUB_WORKSPACE/hdf5/build/bin" >> $GITHUB_ENV
 
       - name: Set up Python ${{ matrix.python-version }}
         uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6
@@ -119,7 +124,7 @@ jobs:
         #if: ${{ ! steps.restore-hsds.outputs.cache-hit }}
         shell: bash
         run: |
-          cd ${{github.workspace}}/hsds
+          cd $GITHUB_WORKSPACE/hsds
           pip install -e .
 
       #- name: Cache HSDS (${{ env.HSDS_COMMIT_SHORT }}) installation
@@ -143,13 +148,13 @@ jobs:
       - name: Start HSDS
         working-directory: ${{github.workspace}}/hsds
         run: |
-          mkdir ${{github.workspace}}/hsdsdata &&
-          mkdir ${{github.workspace}}/hsdsdata/hsdstest &&
+          mkdir $GITHUB_WORKSPACE/hsdsdata &&
+          mkdir $GITHUB_WORKSPACE/hsdsdata/hsdstest &&
           cp admin/config/groups.default admin/config/groups.txt &&
           cp admin/config/passwd.default admin/config/passwd.txt &&
           cp admin/config/groups.default admin/config/groups.txt &&
           cp admin/config/passwd.default admin/config/passwd.txt
-          ROOT_DIR=${{github.workspace}}/hsdsdata ./runall.sh --no-docker 1 &
+          ROOT_DIR=$GITHUB_WORKSPACE/hsdsdata ./runall.sh --no-docker 1 &
           sleep 10
 
       - name: Test HSDS
@@ -159,9 +164,12 @@ jobs:
 
       - name: Test HDF5 REST VOL connector with external tests
         working-directory: ${{github.workspace}}/hdf5/build/
+        env:
+          BUILD_MODE: ${{ inputs.build_mode }}
+          RUNNER_WORKSPACE: ${{ runner.workspace }}
         run: |
           sudo \
-          HDF5_PLUGIN_PATH="${{ runner.workspace }}/hdf5_build/lib" \
+          HDF5_PLUGIN_PATH="$RUNNER_WORKSPACE/hdf5_build/lib" \
           HDF5_VOL_CONNECTOR=REST \
           ADMIN_USERNAME=admin ADMIN_PASSWORD=admin \
           USER_NAME=test_user1 USER_PASSWORD=test \
@@ -169,9 +177,9 @@ jobs:
           HSDS_USERNAME=test_user1 HSDS_PASSWORD=test \
           HSDS_PATH=/home/test_user1/ HDF5_API_TEST_PATH_PREFIX=/home/test_user1/ \
           HSDS_ENDPOINT=http+unix://%2Ftmp%2Fhs%2Fsn_1.sock \
-          ROOT_DIR=${{github.workspace}}/hsdsdata \
+          ROOT_DIR=$GITHUB_WORKSPACE/hsdsdata \
           BUCKET_NAME=hsdstest \
-          ctest --build-config ${{ inputs.build_mode }} -R "test_rest_vol" .
+          ctest --build-config $BUILD_MODE -R "test_rest_vol" .
 
       - name: Test HDF5 REST VOL connector with HDF5 API tests
         working-directory: ${{github.workspace}}/hdf5/build/
@@ -180,9 +188,12 @@ jobs:
         # but skip it to leave an indication that this should be re-enabled
         # in the future.
         if: false
+        env:
+          BUILD_MODE: ${{ inputs.build_mode }}
+          RUNNER_WORKSPACE: ${{ runner.workspace }}
         run: |
           sudo \
-          HDF5_PLUGIN_PATH="${{ runner.workspace }}/hdf5_build/lib" \
+          HDF5_PLUGIN_PATH="$RUNNER_WORKSPACE/hdf5_build/lib" \
           HDF5_VOL_CONNECTOR=REST \
           ADMIN_USERNAME=admin ADMIN_PASSWORD=admin \
           USER_NAME=test_user1 USER_PASSWORD=test \
@@ -190,6 +201,6 @@ jobs:
           HSDS_USERNAME=test_user1 HSDS_PASSWORD=test \
           HSDS_PATH=/home/test_user1/ HDF5_API_TEST_PATH_PREFIX=/home/test_user1/ \
           HSDS_ENDPOINT=http+unix://%2Ftmp%2Fhs%2Fsn_1.sock \
-          ROOT_DIR=${{github.workspace}}/hsdsdata \
+          ROOT_DIR=$GITHUB_WORKSPACE/hsdsdata \
           BUCKET_NAME=hsdstest \
-          ctest --build-config ${{ inputs.build_mode }} -R "h5_api" -E "H5COPY|H5DIFF|H5LS|H5DUMP|H5REPACK" .
+          ctest --build-config $BUILD_MODE -R "h5_api" -E "H5COPY|H5DIFF|H5LS|H5DUMP|H5REPACK" .


### PR DESCRIPTION
## Summary

Fixes the 22 remaining open zizmor `template-injection` alerts in the Security tab, all in four VOL workflow files:

- `vol_log.yml` (8 findings)
- `vol_rest.yml` (7 findings)
- `vol_ext_passthru.yml` (4 findings)
- `vol_cache.yml` (3 findings)

**Changes per file:** move `${{ inputs.build_mode }}` and `${{ runner.workspace }}` out of `run:` scripts into step-level `env:` blocks; replace `${{ github.workspace }}` with the built-in `$GITHUB_WORKSPACE` env var directly.

Once this and #6447 merge, the Security tab will be clean — any future zizmor finding will be a real signal rather than pre-existing noise.
