### PR TITLE
Fix duplicate env keys in test-maven-packages.yml

### DIFF
--- a/.github/workflows/test-maven-packages.yml
+++ b/.github/workflows/test-maven-packages.yml
@@ -108,6 +108,8 @@ jobs:
         env:
           ARTIFACT_VERSION: ${{ inputs.version }}
           REPOSITORY_URL: ${{ inputs.repository_url }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_ACTOR: ${{ github.actor }}
         run: |
           echo "::group::Download JNI artifact"
           # Clear cached SNAPSHOT to force fresh download
@@ -252,9 +254,6 @@ jobs:
 
           echo "✅ Artifact installed successfully"
           echo "::endgroup::"
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          GITHUB_ACTOR: ${{ github.actor }}
 
       - name: Verify JAR contents (JNI)
         env:
@@ -377,6 +376,8 @@ jobs:
         env:
           ARTIFACT_VERSION: ${{ inputs.version }}
           REPOSITORY_URL: ${{ inputs.repository_url }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_ACTOR: ${{ github.actor }}
         run: |
           echo "::group::Download FFM artifact"
           # Clear cached SNAPSHOT to force fresh download
@@ -521,9 +522,6 @@ jobs:
 
           echo "✅ Artifact installed successfully"
           echo "::endgroup::"
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          GITHUB_ACTOR: ${{ github.actor }}
 
       - name: Verify JAR contents (FFM)
         env:


### PR DESCRIPTION
The JNI and FFM download steps each had two `env:` blocks in the same step mapping — one before `run:` and one after — which is invalid YAML. GitHub's strict reusable-workflow parser rejects this, causing release.yml to fail with "'env' is already defined" at lines 255 and 524.

Merge GITHUB_TOKEN/GITHUB_ACTOR into the single env block at the top of each step, removing the trailing duplicate blocks.