### PR TITLE
Exclude www.doxygen.org/index.html from checking in linkchecker workflow

### DIFF
--- a/.github/workflows/linkchecker.yml
+++ b/.github/workflows/linkchecker.yml
@@ -79,16 +79,6 @@ jobs:
           # Let the action fail naturally - we'll handle it in the summary step
           fail: true
 
-      - name: Setup to check Doxygen footer URL (once)
-        run: printf 'https://www.doxygen.org/index.html\n' > /tmp/doxygen-url.txt
-
-      - name: Check Doxygen footer URL (once)
-        uses: lycheeverse/lychee-action@8646ba30535128ac92d33dfc9133794bfdd9b411
-        with:
-            args: >
-              --accept 200..=299,429
-              /tmp/doxygen-url.txt
-
       - name: Publish Report to Job Summary
         if: always()
         run: |

--- a/.github/workflows/linkchecker.yml
+++ b/.github/workflows/linkchecker.yml
@@ -79,10 +79,15 @@ jobs:
           # Let the action fail naturally - we'll handle it in the summary step
           fail: true
 
+      - name: Setup to check Doxygen footer URL (once)
+        run: printf 'https://www.doxygen.org/index.html\n' > /tmp/doxygen-url.txt
+
       - name: Check Doxygen footer URL (once)
         uses: lycheeverse/lychee-action@8646ba30535128ac92d33dfc9133794bfdd9b411
         with:
-            args: "https://www.doxygen.org/index.html"
+            args: >
+              --accept 200..=299,429
+              /tmp/doxygen-url.txt
 
       - name: Publish Report to Job Summary
         if: always()

--- a/.github/workflows/linkchecker.yml
+++ b/.github/workflows/linkchecker.yml
@@ -48,7 +48,7 @@ jobs:
             --max-concurrency 4
             --retry-wait-time 10
             --timeout 30
-            --accept 200..=299,415,429
+            --accept 200..=299,429
             --user-agent "Mozilla/5.0 (compatible; Lychee/v0.1)"
             --skip-missing
             --exclude ".*%23.*"
@@ -71,12 +71,18 @@ jobs:
             --exclude "twitter.com"
             --exclude "linkedin.com"
             --exclude "web.cels.anl.gov"
+            --exclude "www.doxygen.org"
             "${{ steps.build_docs.outputs.html_path }}/**/*.html"
           output: lychee-report.md
           format: markdown
           jobSummary: false
           # Let the action fail naturally - we'll handle it in the summary step
           fail: true
+
+      - name: Check Doxygen footer URL (once)
+        uses: lycheeverse/lychee-action@8646ba30535128ac92d33dfc9133794bfdd9b411
+        with:
+            args: "https://www.doxygen.org/index.html"
 
       - name: Publish Report to Job Summary
         if: always()

--- a/.github/workflows/linkchecker.yml
+++ b/.github/workflows/linkchecker.yml
@@ -38,6 +38,10 @@ jobs:
           make doxygen
           echo "html_path=$(pwd)/hdf5lib_docs/html" >> $GITHUB_OUTPUT
 
+      - name: Create single-check URL list
+        run: |
+          printf 'https://www.doxygen.org/index.html\n' > /tmp/check-once-urls.txt
+
       - name: Run Comprehensive Link Check
         id: lychee
         uses: lycheeverse/lychee-action@8646ba30535128ac92d33dfc9133794bfdd9b411 # v2.8.0
@@ -71,6 +75,8 @@ jobs:
             --exclude "twitter.com"
             --exclude "linkedin.com"
             --exclude "web.cels.anl.gov"
+            --exclude "www.doxygen.org"
+            /tmp/check-once-urls.txt
             "${{ steps.build_docs.outputs.html_path }}/**/*.html"
           output: lychee-report.md
           format: markdown

--- a/.github/workflows/linkchecker.yml
+++ b/.github/workflows/linkchecker.yml
@@ -38,10 +38,6 @@ jobs:
           make doxygen
           echo "html_path=$(pwd)/hdf5lib_docs/html" >> $GITHUB_OUTPUT
 
-      - name: Create single-check URL list
-        run: |
-          printf 'https://www.doxygen.org/index.html\n' > /tmp/check-once-urls.txt
-
       - name: Run Comprehensive Link Check
         id: lychee
         uses: lycheeverse/lychee-action@8646ba30535128ac92d33dfc9133794bfdd9b411 # v2.8.0
@@ -52,7 +48,7 @@ jobs:
             --max-concurrency 4
             --retry-wait-time 10
             --timeout 30
-            --accept 200..=299,429
+            --accept 200..=299,415,429
             --user-agent "Mozilla/5.0 (compatible; Lychee/v0.1)"
             --skip-missing
             --exclude ".*%23.*"
@@ -75,8 +71,6 @@ jobs:
             --exclude "twitter.com"
             --exclude "linkedin.com"
             --exclude "web.cels.anl.gov"
-            --exclude "www.doxygen.org"
-            /tmp/check-once-urls.txt
             "${{ steps.build_docs.outputs.html_path }}/**/*.html"
           output: lychee-report.md
           format: markdown


### PR DESCRIPTION
Doxygen adds a footer link to doxygen.org on every generated HTML page, causing lychee to check the same URL 31 times. Fix by excluding www.doxygen.org from the HTML glob scan and adding the URL to a small text file that lychee reads as a separate input, checking it once.

However, www.doxygen.org apparently blocks requests run directly from github actions, so we exclude it from checking. 