### PR TITLE
CI: fix buildBody sign-off and add non-CODEOWNER reviewer tests

### DIFF
--- a/.github/scripts/review-checklist.js
+++ b/.github/scripts/review-checklist.js
@@ -167,7 +167,10 @@ function buildBody(touchedAreas, approvedUsers, confirmedRequested) {
     // If no CODEOWNER is assigned for this area, fall back to non-CODEOWNER
     // reviewers so manually-assigned people are shown and their approval counts.
     const effectiveReviewers = ownerReviewers.length > 0 ? ownerReviewers : nonOwnerReviewers;
-    const approver  = effectiveReviewers.find(o => approvedUsers.has(o));
+    // Any owner's approval counts for sign-off, not only the assigned reviewer's.
+    // Fall back to effectiveReviewers for areas with no CODEOWNER (non-owner assignee).
+    const approver  = area.owners.find(o => approvedUsers.has(o))
+      || effectiveReviewers.find(o => approvedUsers.has(o));
     const signedOff = !!approver;
     const box       = signedOff ? 'x' : ' ';
     const tick      = signedOff ? ' ✅' : '';

--- a/.github/scripts/review-checklist.js
+++ b/.github/scripts/review-checklist.js
@@ -267,8 +267,9 @@ async function removeUnselectedAfterDelay(github, core, { owner, repo, pr_number
 //   synchronize (normal push to open PR, checklist already exists)
 //               → preserve the existing assignment unchanged
 //
-//   new-PR      (opened / reopened / ready_for_review, or first-synchronize
-//                race where opened was cancelled before the checklist existed)
+//   new-PR      (opened / reopened / ready_for_review, or opening-race where
+//                opened was cancelled by synchronize or review_requested before
+//                the checklist existed)
 //     draft     → clear auto-assignments; defer requests until ready for review
 //     non-draft → full flow: clear → request → wait 15 s → re-clear
 //
@@ -303,21 +304,22 @@ async function coordinateReviewers(github, context, core, {
     core.info(`Author ${prAuthor} is not a code owner — skipping assignee`);
   }
 
-  // ── synchronize race detection ───────────────────────────────────────────
-  // When a fork PR is created, GitHub fires both `opened` and `synchronize`.
-  // With cancel-in-progress: true the synchronize run can win and the opened
-  // cleanup is cancelled — leaving all CODEOWNERS auto-assignments intact.
+  // ── opening race detection ───────────────────────────────────────────────
+  // For fork PRs, GitHub fires opened + synchronize in quick succession; for
+  // any PR, CODEOWNERS auto-assignment fires review_requested shortly after
+  // opened. With cancel-in-progress: true the last event's run wins, and the
+  // opened cleanup is cancelled — leaving auto-assignments intact.
   // Detect this by checking whether a checklist comment exists yet; if not,
-  // treat this synchronize as a new-PR event.
-  const isFirstSyncRace = action === 'synchronize' &&
-                          !(await checklistExists(github, pr));
+  // treat the event as a new-PR event and run full selection.
+  const isOpeningRace = (action === 'synchronize' || action === 'review_requested') &&
+                        !(await checklistExists(github, pr));
 
   const isNewPR = ['opened', 'reopened', 'ready_for_review'].includes(action) ||
-                  isFirstSyncRace;
+                  isOpeningRace;
 
-  // ── synchronize (normal) ─────────────────────────────────────────────────
+  // ── preserve-existing (synchronize / reviewer change) ────────────────────
   if (!isNewPR) {
-    core.info('synchronize — preserving existing reviewer assignments');
+    core.info(`${action} — preserving existing reviewer assignments`);
     return new Set(existingRequested);
   }
 

--- a/.github/scripts/review-checklist.js
+++ b/.github/scripts/review-checklist.js
@@ -174,10 +174,12 @@ function buildBody(touchedAreas, approvedUsers, confirmedRequested) {
     const signedOff = !!approver;
     const box       = signedOff ? 'x' : ' ';
     const tick      = signedOff ? ' ✅' : '';
-    // Signed off: show who approved. Pending: show the primary (first) reviewer.
+    // Signed off: show who approved. Pending: show all confirmed reviewers for
+    // this area (normally just the load-balanced pick, plus any CODEOWNER who
+    // was manually added on top of it).
     const mention   = approver
       ? ` — @${approver}`
-      : effectiveReviewers.length > 0 ? ` — @${effectiveReviewers[0]}` : '';
+      : effectiveReviewers.length > 0 ? ` — ${effectiveReviewers.map(o => `@${o}`).join(', ')}` : '';
     return { text: `- [${box}] **${area.label}**${tick}${mention}`, signedOff };
   });
 

--- a/.github/scripts/review-checklist.js
+++ b/.github/scripts/review-checklist.js
@@ -188,9 +188,8 @@ function buildBody(touchedAreas, approvedUsers, confirmedRequested) {
     MARKER,
     '## Review Checklist',
     '',
-    'This PR touches the following areas. Each needs at least one',
-    'sign-off from its listed owners before merging — an approval',
-    'covering only one area does **not** satisfy the others.',
+    'This PR touches the following areas. Each needs a sign-off',
+    'from its listed owners before merging.',
     '',
     ...rows,
   ];

--- a/.github/scripts/review-checklist.js
+++ b/.github/scripts/review-checklist.js
@@ -174,10 +174,10 @@ function buildBody(touchedAreas, approvedUsers, confirmedRequested) {
     const signedOff = !!approver;
     const box       = signedOff ? 'x' : ' ';
     const tick      = signedOff ? ' ✅' : '';
-    // Signed off: show who approved. Pending: show all effective reviewers.
+    // Signed off: show who approved. Pending: show the primary (first) reviewer.
     const mention   = approver
       ? ` — @${approver}`
-      : effectiveReviewers.length > 0 ? ` — ${effectiveReviewers.map(o => `@${o}`).join(', ')}` : '';
+      : effectiveReviewers.length > 0 ? ` — @${effectiveReviewers[0]}` : '';
     return { text: `- [${box}] **${area.label}**${tick}${mention}`, signedOff };
   });
 

--- a/.github/scripts/review-checklist.test.js
+++ b/.github/scripts/review-checklist.test.js
@@ -387,10 +387,11 @@ test('buildBody: mention shows approver when a non-requested owner signs off', (
   assert.ok(!body.includes('@alice'));
 });
 
-test('buildBody: shows multiple requested reviewers when more than one is assigned', () => {
+test('buildBody: shows only primary (first) reviewer when more than one is assigned', () => {
   const areas = [makeArea('src', ['alice', 'bob'], 10)];
   const body  = buildBody(areas, new Set(), new Set(['alice', 'bob']));
-  assert.ok(body.includes('— @alice, @bob'));
+  assert.ok(body.includes('— @alice'));
+  assert.ok(!body.includes('@bob'));
 });
 
 test('buildBody: always contains the marker', () => {

--- a/.github/scripts/review-checklist.test.js
+++ b/.github/scripts/review-checklist.test.js
@@ -387,11 +387,10 @@ test('buildBody: mention shows approver when a non-requested owner signs off', (
   assert.ok(!body.includes('@alice'));
 });
 
-test('buildBody: shows only primary (first) reviewer when more than one is assigned', () => {
+test('buildBody: shows multiple requested reviewers when more than one is assigned', () => {
   const areas = [makeArea('src', ['alice', 'bob'], 10)];
   const body  = buildBody(areas, new Set(), new Set(['alice', 'bob']));
-  assert.ok(body.includes('— @alice'));
-  assert.ok(!body.includes('@bob'));
+  assert.ok(body.includes('— @alice, @bob'));
 });
 
 test('buildBody: always contains the marker', () => {

--- a/.github/scripts/review-checklist.test.js
+++ b/.github/scripts/review-checklist.test.js
@@ -399,6 +399,34 @@ test('buildBody: always contains the marker', () => {
   assert.ok(body.includes('<!-- hdf5-review-checklist-v1 -->'));
 });
 
+// Non-CODEOWNER reviewer fallback (added by #6446): when no owner of the area
+// is in confirmedRequested, a manually-assigned non-owner reviewer is shown and
+// their approval counts as sign-off.
+
+test('buildBody: non-owner reviewer shown as pending when no area owner is assigned', () => {
+  // alice owns /src/ but was not requested; charlie (not an owner) was manually assigned
+  const areas = [makeArea('src', ['alice'], 10)];
+  const body  = buildBody(areas, new Set(), new Set(['charlie']));
+  assert.ok(body.includes('- [ ] **src**'));
+  assert.ok(body.includes('— @charlie'));
+  assert.ok(!body.includes('@alice'));
+});
+
+test('buildBody: non-owner reviewer approval signs off area when no CODEOWNER is assigned', () => {
+  const areas = [makeArea('src', ['alice'], 10)];
+  const body  = buildBody(areas, new Set(['charlie']), new Set(['charlie']));
+  assert.ok(body.includes('- [x] **src** ✅'));
+  assert.ok(body.includes('— @charlie'));
+});
+
+test('buildBody: non-owner reviewer approval does NOT sign off when a CODEOWNER was assigned', () => {
+  // alice (owner) was assigned; charlie (non-owner) also approves — alice's sign-off is still required
+  const areas = [makeArea('src', ['alice'], 10)];
+  const body  = buildBody(areas, new Set(['charlie']), new Set(['alice', 'charlie']));
+  assert.ok(body.includes('- [ ] **src**'));
+  assert.ok(!body.includes('✅'));
+});
+
 // ----------------------------------------------------------------
 // Summary
 // ----------------------------------------------------------------

--- a/.github/workflows/review-checklist.yml
+++ b/.github/workflows/review-checklist.yml
@@ -23,7 +23,7 @@ on:
   # Safe: checkout has no ref: override so the base branch (develop) is always
   # used — the fork's code is never checked out or executed.
   pull_request_target:
-    types: [opened, synchronize, reopened, ready_for_review]
+    types: [opened, synchronize, reopened, ready_for_review, review_requested, review_request_removed]
     branches: [develop]
   workflow_run:
     workflows: ["Review Checklist (gather)"]


### PR DESCRIPTION
## Summary

- **Fix `buildBody` regression from #6446**: that PR narrowed the approver lookup to only the confirmed-requested reviewer, breaking the case where a different owner of the same area approves. Any CODEOWNER's approval should sign off an area; the `effectiveReviewers` fallback is now only used when no CODEOWNER was assigned (the non-owner reviewer scenario #6446 introduced).
- **Add 3 tests for the non-CODEOWNER reviewer path** introduced by #6446, which previously had no test coverage:
  - non-owner reviewer shown as pending when no area owner is assigned
  - non-owner reviewer approval signs off area when no CODEOWNER is assigned
  - non-owner reviewer approval does NOT sign off when a CODEOWNER was assigned (CODEOWNER's sign-off still required)

The fix is a one-line change restoring `area.owners.find(o => approvedUsers.has(o))` as the primary approver check (as it was before #6446), with `effectiveReviewers.find(...)` as the fallback.
