### PR TITLE
h5repack: fix silent loss of a declared cd_nelmts for UD filters

### DIFF
--- a/release_docs/CHANGELOG.md
+++ b/release_docs/CHANGELOG.md
@@ -190,6 +190,15 @@ The `h5repack` tool now obtains its default low and high library version bounds 
 
 ## Tools
 
+### Fixed h5repack silently dropping a declared cd_nelmts for user-defined filters
+
+   `h5repack -f UD=<filtn>,<flag>,<cd_nelmts>` with no values following `cd_nelmts` silently
+   treated the declared count as 0 instead of validating it, because the trailing token (with
+   no comma after it) was never committed to `cd_nelmts` inside the parser. `parse_filter()` now
+   commits the trailing token to whichever UD field is still pending, so a declared, unfulfilled
+   `cd_nelmts` is correctly rejected with "incorrect number of compression parameters" instead of
+   being silently coerced to 0.
+
 ## Performance
 
 ## Fortran API

--- a/tools/src/h5repack/h5repack_parse.c
+++ b/tools/src/h5repack/h5repack_parse.c
@@ -58,7 +58,7 @@ parse_filter(const char *str, unsigned *n_objs, filter_info_t *filt, pack_opt_t 
     size_t      i, m, u;
     char        c;
     size_t      len = strlen(str);
-    int         f, k, l, p, q, end_obj = -1, no_param = 0;
+    int         f = -1, k, l = -1, p = -1, q, end_obj = -1, no_param = 0;
     unsigned    j, n;
     char        sobj[MAX_NC_NAME];
     char        scomp[16] = {0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0};
@@ -297,8 +297,19 @@ parse_filter(const char *str, unsigned *n_objs, filter_info_t *filt, pack_opt_t 
                 } /*if */
 
 done_filter_params:;
-                if ((strcmp(scomp, "UD") == 0) && (filt->cd_nelmts == 0))
-                    j = 0;
+                if (strcmp(scomp, "UD") == 0) {
+                    /* the trailing token (no comma after it) was never committed inside
+                     * the loop above; commit it to whichever UD field is still pending,
+                     * mirroring the comma-triggered branch exactly */
+                    if (l == -1)
+                        filt->filtn = atoi(stype);
+                    else if (f == -1)
+                        filt->filt_flag = (unsigned)strtoul(stype, NULL, 0);
+                    else if (p == -1)
+                        filt->cd_nelmts = strtoull(stype, NULL, 0);
+                    else if (filt->cd_nelmts > 0)
+                        filt->cd_values[j++] = (unsigned)strtoul(stype, NULL, 0);
+                }
                 else
                     filt->cd_values[j++] = (unsigned)strtoul(stype, NULL, 0);
             }

--- a/tools/test/h5repack/CMakeTests.cmake
+++ b/tools/test/h5repack/CMakeTests.cmake
@@ -1892,6 +1892,9 @@ if (BUILD_SHARED_LIBS)
   ADD_H5_UD_TEST (plugin_test_ex 1 h5repack_layout.h5 --enable-error-stack -v -f UD=257,0,1,9,9,9)
   # check for extra parameters, which are ignored when nelms is 0
   ADD_H5_UD_TEST (plugin_zero_extra 0 h5repack_layout.h5 --enable-error-stack -v -f UD=250,0,0,1,2)
+  # check for a declared cd_nelmts with no values following it (filter 250 does no
+  # internal cd_values validation, so this only fails if parse_filter() catches it itself)
+  ADD_H5_UD_TEST (plugin_test_nelmts_no_values 1 h5repack_layout.h5 --enable-error-stack -v -f UD=250,0,1)
 endif ()
 
 ##############################################################################


### PR DESCRIPTION
## Summary

Fixes #6462.

A declared `cd_nelmts` with no values following it (e.g. `UD=<filtn>,<flag>,1`) was never committed to `filt->cd_nelmts` in `parse_filter()`: the trailing token (the one with no comma after it) was always treated as a *value*, never checked against the `l`/`f`/`p` pending flags the way the comma-triggered branch already does. `h5repack`'s own "incorrect number of compression parameters" validation then silently passed, since `filt->cd_nelmts` stayed at its `memset` default of `0` regardless of what the user actually wrote. The mismatch was only ever caught by coincidence, when the underlying filter plugin happened to do its own internal `cd_values` count check (see discussion on #6434).

- Commits the trailing token to whichever UD field (`filtn`/`filt_flag`/`cd_nelmts`/value) is still pending, mirroring the comma-triggered branch.
- Initializes `l`/`f`/`p` at declaration to clear a real `-Wmaybe-uninitialized` warning the change exposed (the compiler can't otherwise prove the UD branch that sets them was taken).
- Adds a regression test (`plugin_test_nelmts_no_values`, `UD=250,0,1`) using filter 250, which has no internal validation, so the parser's own check is what's actually being exercised — the existing `plugin_test_less` test (`UD=257,0,1`) passed for the wrong reason (filter 257's internal check, not `parse_filter()`'s), and still does, but now for the right reason too.