### PR TITLE
CI: base draft PR staleness on real activity, not pr.updated_at

### DIFF
--- a/.github/scripts/draft-pr-policy.js
+++ b/.github/scripts/draft-pr-policy.js
@@ -33,6 +33,32 @@ async function findKeepAliveComment(github, owner, repo, issue_number) {
   return marked.length ? marked[marked.length - 1] : null; // most recent stale episode's comment
 }
 
+// pr.updated_at is bumped by metadata-only changes (reviewer requested/removed, labels,
+// milestone, assignee, etc.), which would let a draft dodge the staleness check forever
+// without any real work happening. Use the latest commit/comment/review activity instead.
+async function lastRealActivityAt(github, owner, repo, pr) {
+  const timestamps = [new Date(pr.created_at).getTime()];
+
+  const commits = await github.paginate(github.rest.pulls.listCommits, { owner, repo, pull_number: pr.number, per_page: 100 });
+  for (const c of commits) {
+    const date = c.commit?.committer?.date || c.commit?.author?.date;
+    if (date) timestamps.push(new Date(date).getTime());
+  }
+
+  const comments = await github.paginate(github.rest.issues.listComments, { owner, repo, issue_number: pr.number, per_page: 100 });
+  for (const c of comments) timestamps.push(new Date(c.created_at).getTime());
+
+  const reviews = await github.paginate(github.rest.pulls.listReviews, { owner, repo, pull_number: pr.number, per_page: 100 });
+  for (const r of reviews) {
+    if (r.submitted_at) timestamps.push(new Date(r.submitted_at).getTime());
+  }
+
+  const reviewComments = await github.paginate(github.rest.pulls.listReviewComments, { owner, repo, pull_number: pr.number, per_page: 100 });
+  for (const rc of reviewComments) timestamps.push(new Date(rc.created_at).getTime());
+
+  return Math.max(...timestamps);
+}
+
 async function runDraftPolicy({ github, context, core }) {
   const { owner, repo } = context.repo;
   await ensureLabel(github, owner, repo);
@@ -44,7 +70,8 @@ async function runDraftPolicy({ github, context, core }) {
     const labelNames = pr.labels.map((l) => l.name);
 
     if (!labelNames.includes(LABEL)) {
-      if (daysSince(pr.updated_at) >= STALE_DAYS) {
+      const lastActivity = await lastRealActivityAt(github, owner, repo, pr);
+      if (daysSince(lastActivity) >= STALE_DAYS) {
         await github.rest.issues.addLabels({ owner, repo, issue_number: pr.number, labels: [LABEL] });
         await github.rest.issues.createComment({
           owner,


### PR DESCRIPTION
## Summary
- `draft-pr-policy.js` decided whether a draft PR is stale by checking `daysSince(pr.updated_at)`, but GitHub bumps `updated_at` on metadata-only changes (reviewer requested/removed, labels, milestone, assignee) with no real work happening.
- Found via PR #6162: it dodged the 60-day draft-stale window because a reviewer request was removed 8 days ago, even though the last real commit was ~143 days ago.
- Adds `lastRealActivityAt()`, which takes the max timestamp across the PR's commits, issue comments, reviews, and review comments, and uses that instead of `pr.updated_at` for the staleness gate.