### PR TITLE
Add flag -tp=x86-64-v3 to CMAKE C, Fortran, and CXX flags to avoid crashing …

### DIFF
--- a/.github/workflows/nvhpc.yml
+++ b/.github/workflows/nvhpc.yml
@@ -76,6 +76,9 @@ jobs:
           -DHDF5_BUILD_CPP_LIB:BOOL=OFF \
           -DHDF5_BUILD_FORTRAN:BOOL=ON \
           -DHDF5_BUILD_JAVA:BOOL=OFF \
+          -DCMAKE_C_FLAGS="-tp=x86-64-v3" \
+          -DCMAKE_Fortran_FLAGS="-tp=x86-64-v3" \
+          -DCMAKE_CXX_FLAGS="-tp=x86-64-v3" \
           -DMPIEXEC_MAX_NUMPROCS:STRING="2" \
           -DMPIEXEC_PREFLAGS:STRING="--mca;opal_warn_on_missing_libcuda;0" \
           -DCMAKE_C_FLAGS="-Mnovect" \

--- a/.github/workflows/nvhpc.yml
+++ b/.github/workflows/nvhpc.yml
@@ -81,7 +81,6 @@ jobs:
           -DCMAKE_CXX_FLAGS="-tp=x86-64-v3" \
           -DMPIEXEC_MAX_NUMPROCS:STRING="2" \
           -DMPIEXEC_PREFLAGS:STRING="--mca;opal_warn_on_missing_libcuda;0" \
-          -DCMAKE_C_FLAGS="-Mnovect" \
           $GITHUB_WORKSPACE
 
       - name: Build


### PR DESCRIPTION
…llvm in nvhpc tests.  