### PR TITLE
fix(review-checklist): re-request dismissed reviewer on fixup push

### DIFF
--- a/.github/scripts/review-checklist.js
+++ b/.github/scripts/review-checklist.js
@@ -347,20 +347,36 @@ function planSynchronizeSwaps(eligibleAreas, allReviews, {
 //                 signal that someone, right now, individually decided this
 //                 person should be back — see the updatedExcluded comment).
 //
-//   draft, just (re)opened as one
+//   draft, just (re)opened as one — OR no checklist comment posted yet
 //               → GitHub's CODEOWNERS auto-assignment fires immediately on
 //                 creation regardless of draft status, dumping every
 //                 touched-area owner onto the PR before anyone's decided
 //                 review is even wanted yet. Cleared in full — no checklist
 //                 posted until the PR is ready for review.
 //
-//   non-draft, just (re)opened or just marked ready_for_review
+//   non-draft, just (re)opened or just marked ready_for_review —
+//   OR no checklist comment posted yet
 //               → Same CODEOWNERS avalanche — GitHub auto-requests CODEOWNERS
 //                 reviewers both on creation and again when a draft is marked
 //                 ready for review. Pruned to the load-balanced single pick
 //                 per area before the checklist is first posted, so reviewers
 //                 aren't @-mentioned en masse before the final reviewer set
 //                 is known.
+//
+//                 The "no comment posted yet" clause covers a race: GitHub's
+//                 CODEOWNERS engine fires one review_requested per
+//                 auto-assigned owner, and each re-triggers this workflow.
+//                 With concurrency: cancel-in-progress, whichever run starts
+//                 last wins — and that's just as likely to be one of those
+//                 review_requested runs as the opened run itself (PR #6479
+//                 hit exactly this: a review_requested run survived, fell
+//                 through to the additive-fill branch below, saw every area
+//                 already "covered" by the avalanche, and pruned nothing).
+//                 Whether a checklist comment exists yet is a far more
+//                 reliable signal than which specific action survived the
+//                 race: if none exists, this is the PR's first coordination
+//                 pass no matter what action got here, so the avalanche
+//                 still needs pruning.
 //
 //   synchronize with a dismissed reviewer
 //               → see planSynchronizeSwaps: re-requests a reviewer whose
@@ -393,10 +409,17 @@ function planSynchronizeSwaps(eligibleAreas, allReviews, {
 //
 async function coordinateReviewers(github, context, core, {
   owner, repo, pr_number, prData, allCodeOwners, catchAllOwners, touchedAreas, reviewerLoad,
-  excludedReviewers, allReviews, LINE_THRESHOLD, AREA_THRESHOLDS, PUBLIC_HEADER,
+  excludedReviewers, allReviews, hasExistingComment, LINE_THRESHOLD, AREA_THRESHOLDS, PUBLIC_HEADER,
 }) {
   const pr     = { owner, repo, pr_number };
   const action = context.payload.action;
+  // No checklist comment yet means this is this PR's first coordination
+  // pass, regardless of which webhook action's run happened to survive the
+  // opened-vs-review_requested cancel-in-progress race — see coordinateReviewers
+  // doc comment above. Require an explicit `false` so a caller that omits the
+  // field (or a stale/odd payload) defaults to the safer additive-fill path
+  // instead of unexpectedly pruning an established PR's reviewers.
+  const isFirstCoordinationPass = hasExistingComment === false;
 
   // A removal happening right now joins the persisted exclusion set
   // immediately, so it's enforced starting with this very run. A direct
@@ -473,7 +496,7 @@ async function coordinateReviewers(github, context, core, {
   const touchedAreaOwners = new Set([...touchedAreas.flatMap(a => a.owners), ...catchAllOwners]);
 
   if (isDraft) {
-    if (action === 'opened' || action === 'reopened') {
+    if (action === 'opened' || action === 'reopened' || isFirstCoordinationPass) {
       // (Re)opened directly as a draft — clear the CODEOWNERS avalanche from
       // this PR's creation. Owners of areas this PR actually touches, plus
       // catch-all "*" owners (who GitHub auto-assigns on every PR regardless
@@ -499,13 +522,17 @@ async function coordinateReviewers(github, context, core, {
     owners: area.owners.filter(o => !updatedExcluded.has(o)),
   }));
 
-  if (action === 'opened' || action === 'reopened' || action === 'ready_for_review') {
+  if (action === 'opened' || action === 'reopened' || action === 'ready_for_review' || isFirstCoordinationPass) {
     // Non-draft, just (re)opened — same CODEOWNERS avalanche problem as the
     // draft case: GitHub has already auto-assigned every touched-area owner.
     // ready_for_review gets the same treatment: GitHub auto-requests CODEOWNERS
     // reviewers again when a draft is marked ready, dumping the avalanche on a
     // PR that may have sat in draft (untouched, per the isDraft branch above)
-    // for a while. Prune to a load-balanced single pick per area BEFORE posting
+    // for a while. isFirstCoordinationPass catches the case where neither of
+    // those actions is the one that happened to survive the cancel-in-progress
+    // race against the avalanche's own review_requested events (see the doc
+    // comment above coordinateReviewers — this is exactly what happened on
+    // PR #6479). Prune to a load-balanced single pick per area BEFORE posting
     // the checklist so reviewers aren't @-mentioned en masse. Pass an empty
     // existingRequested so chooseReviewers treats every area as uncovered and
     // picks fresh rather than seeing "already has an owner" and returning nothing.
@@ -767,6 +794,7 @@ module.exports = async function run({ github, context, core }) {
   //    (if any), then coordinate reviewer assignment.
   // ----------------------------------------------------------------
   let existingComment;
+  let commentFetchFailed = false;
   try {
     const comments = await github.paginate(github.rest.issues.listComments, {
       owner, repo, issue_number: pr_number, per_page: 100,
@@ -774,12 +802,18 @@ module.exports = async function run({ github, context, core }) {
     existingComment = comments.find(c => c.body.includes(MARKER));
   } catch (error) {
     core.warning(`Could not fetch existing checklist comment: ${error.message}`);
+    commentFetchFailed = true;
   }
   const excludedReviewers = parseExcluded(existingComment && existingComment.body);
+  // On a fetch failure we genuinely don't know whether a comment exists —
+  // default to true (assume it does) so coordinateReviewers falls back to its
+  // non-destructive additive-fill path rather than treating an API hiccup as
+  // "first coordination pass" and pruning an established PR's reviewers.
+  const hasExistingComment = commentFetchFailed ? true : !!existingComment;
 
   const { confirmedRequested, excludedReviewers: updatedExcluded } = await coordinateReviewers(github, context, core, {
     owner, repo, pr_number, prData, allCodeOwners, catchAllOwners, touchedAreas, reviewerLoad,
-    excludedReviewers, allReviews, LINE_THRESHOLD, AREA_THRESHOLDS, PUBLIC_HEADER,
+    excludedReviewers, allReviews, hasExistingComment, LINE_THRESHOLD, AREA_THRESHOLDS, PUBLIC_HEADER,
   });
 
   // ----------------------------------------------------------------

--- a/.github/scripts/review-checklist.js
+++ b/.github/scripts/review-checklist.js
@@ -286,6 +286,13 @@ async function requestReviewers(github, core, { owner, repo, pr_number }, select
 // on a synchronize event: for each area whose dismissed reviewer isn't yet
 // re-requested, identify the fresh CODEOWNERS pick that needs to be removed.
 //
+// freshPick is left null (no removal) when the candidate also owns a
+// DIFFERENT touched area — removeRequestedReviewers strips them from the
+// whole PR, not just this area, so removing them here would silently
+// uncover that other area even though it has nothing to do with this
+// dismissal. Erring toward leaving an extra reviewer on the PR is safer
+// than erring toward an unintentionally uncovered area.
+//
 // Pure — no I/O. Exported for testing.
 function planSynchronizeSwaps(eligibleAreas, allReviews, {
   prAuthor, existingRequested, updatedExcluded, touchedAreaOwners,
@@ -300,9 +307,12 @@ function planSynchronizeSwaps(eligibleAreas, allReviews, {
     const dismissedOwner = area.owners.find(o => dismissedLogins.has(o) && o !== prAuthor);
     if (!dismissedOwner || existingRequested.has(dismissedOwner)) continue;
     // Find a different owner of this area that was auto-assigned by CODEOWNERS.
-    const freshPick = [...existingRequested].find(r =>
+    const candidate = [...existingRequested].find(r =>
       area.owners.includes(r) && r !== dismissedOwner && touchedAreaOwners.has(r)
-    ) || null;
+    );
+    const neededElsewhere = candidate &&
+      eligibleAreas.some(other => other !== area && other.owners.includes(candidate));
+    const freshPick = (candidate && !neededElsewhere) ? candidate : null;
     swaps.push({ area, dismissedOwner, freshPick });
   }
   return swaps;
@@ -499,7 +509,9 @@ async function coordinateReviewers(github, context, core, {
       prAuthor, existingRequested, updatedExcluded, touchedAreaOwners,
     });
     for (const { area, dismissedOwner, freshPick } of swaps) {
-      if (freshPick) {
+      // freshPick may already be gone if an earlier iteration in this same
+      // loop removed them (e.g. they were the fresh pick for two areas).
+      if (freshPick && !updatedExcluded.has(freshPick) && [...existingRequested].includes(freshPick)) {
         try {
           await github.rest.pulls.removeRequestedReviewers({
             owner, repo, pull_number: pr_number, reviewers: [freshPick],
@@ -508,13 +520,17 @@ async function coordinateReviewers(github, context, core, {
           core.info(`synchronize: swapped ${freshPick} → ${dismissedOwner} for area "${area.label}"`);
         } catch (e) { core.warning(`Could not remove ${freshPick}: ${e.message}`); }
       }
-      try {
-        await github.rest.pulls.requestReviewers({
-          owner, repo, pull_number: pr_number, reviewers: [dismissedOwner],
-        });
-        existingRequested.add(dismissedOwner);
-        core.info(`synchronize: re-requested dismissed reviewer ${dismissedOwner} for area "${area.label}"`);
-      } catch (e) { core.warning(`Could not re-request ${dismissedOwner}: ${e.message}`); }
+      // dismissedOwner may already have been re-requested by an earlier
+      // iteration (e.g. they own two areas dismissed by the same review).
+      if (!existingRequested.has(dismissedOwner)) {
+        try {
+          await github.rest.pulls.requestReviewers({
+            owner, repo, pull_number: pr_number, reviewers: [dismissedOwner],
+          });
+          existingRequested.add(dismissedOwner);
+          core.info(`synchronize: re-requested dismissed reviewer ${dismissedOwner} for area "${area.label}"`);
+        } catch (e) { core.warning(`Could not re-request ${dismissedOwner}: ${e.message}`); }
+      }
     }
   }
 

--- a/.github/scripts/review-checklist.js
+++ b/.github/scripts/review-checklist.js
@@ -282,6 +282,32 @@ async function requestReviewers(github, core, { owner, repo, pr_number }, select
   return confirmed;
 }
 
+// Returns [{area, dismissedOwner, freshPick|null}] describing swaps to apply
+// on a synchronize event: for each area whose dismissed reviewer isn't yet
+// re-requested, identify the fresh CODEOWNERS pick that needs to be removed.
+//
+// Pure — no I/O. Exported for testing.
+function planSynchronizeSwaps(eligibleAreas, allReviews, {
+  prAuthor, existingRequested, updatedExcluded, touchedAreaOwners,
+}) {
+  const dismissedLogins = new Set(
+    (allReviews || [])
+      .filter(r => r.state === 'DISMISSED' && r.user && !updatedExcluded.has(r.user.login))
+      .map(r => r.user.login)
+  );
+  const swaps = [];
+  for (const area of eligibleAreas) {
+    const dismissedOwner = area.owners.find(o => dismissedLogins.has(o) && o !== prAuthor);
+    if (!dismissedOwner || existingRequested.has(dismissedOwner)) continue;
+    // Find a different owner of this area that was auto-assigned by CODEOWNERS.
+    const freshPick = [...existingRequested].find(r =>
+      area.owners.includes(r) && r !== dismissedOwner && touchedAreaOwners.has(r)
+    ) || null;
+    swaps.push({ area, dismissedOwner, freshPick });
+  }
+  return swaps;
+}
+
 // ── Reviewer coordination ─────────────────────────────────────────────────────
 //
 // Determines who should be in confirmedRequested (the checklist display set).
@@ -335,7 +361,7 @@ async function requestReviewers(github, core, { owner, repo, pr_number }, select
 //
 async function coordinateReviewers(github, context, core, {
   owner, repo, pr_number, prData, allCodeOwners, catchAllOwners, touchedAreas, reviewerLoad,
-  excludedReviewers, LINE_THRESHOLD, AREA_THRESHOLDS, PUBLIC_HEADER,
+  excludedReviewers, allReviews, LINE_THRESHOLD, AREA_THRESHOLDS, PUBLIC_HEADER,
 }) {
   const pr     = { owner, repo, pr_number };
   const action = context.payload.action;
@@ -463,6 +489,33 @@ async function coordinateReviewers(github, context, core, {
 
     core.info(`Non-draft PR opened — pruned to load-balanced selection: ${[...selected].join(', ') || '(none)'}`);
     return { confirmedRequested: selected, excludedReviewers: updatedExcluded };
+  }
+
+  // Synchronize: a new commit dismissed a prior reviewer's approval.
+  // Re-request that reviewer instead of keeping a fresh CODEOWNERS pick —
+  // they already have context and only need to see what changed.
+  if (action === 'synchronize') {
+    const swaps = planSynchronizeSwaps(eligibleAreas, allReviews, {
+      prAuthor, existingRequested, updatedExcluded, touchedAreaOwners,
+    });
+    for (const { area, dismissedOwner, freshPick } of swaps) {
+      if (freshPick) {
+        try {
+          await github.rest.pulls.removeRequestedReviewers({
+            owner, repo, pull_number: pr_number, reviewers: [freshPick],
+          });
+          existingRequested.delete(freshPick);
+          core.info(`synchronize: swapped ${freshPick} → ${dismissedOwner} for area "${area.label}"`);
+        } catch (e) { core.warning(`Could not remove ${freshPick}: ${e.message}`); }
+      }
+      try {
+        await github.rest.pulls.requestReviewers({
+          owner, repo, pull_number: pr_number, reviewers: [dismissedOwner],
+        });
+        existingRequested.add(dismissedOwner);
+        core.info(`synchronize: re-requested dismissed reviewer ${dismissedOwner} for area "${area.label}"`);
+      } catch (e) { core.warning(`Could not re-request ${dismissedOwner}: ${e.message}`); }
+    }
   }
 
   // Non-draft, any other event: fill in a load-balanced reviewer only for
@@ -685,7 +738,7 @@ module.exports = async function run({ github, context, core }) {
 
   const { confirmedRequested, excludedReviewers: updatedExcluded } = await coordinateReviewers(github, context, core, {
     owner, repo, pr_number, prData, allCodeOwners, catchAllOwners, touchedAreas, reviewerLoad,
-    excludedReviewers, LINE_THRESHOLD, AREA_THRESHOLDS, PUBLIC_HEADER,
+    excludedReviewers, allReviews, LINE_THRESHOLD, AREA_THRESHOLDS, PUBLIC_HEADER,
   });
 
   // ----------------------------------------------------------------
@@ -707,11 +760,12 @@ module.exports = async function run({ github, context, core }) {
   }
 };
 
-module.exports.matchesPattern    = matchesPattern;
-module.exports.labelFromPattern  = labelFromPattern;
-module.exports.attributeFiles    = attributeFiles;
-module.exports.computeApprovals  = computeApprovals;
-module.exports.chooseReviewers   = chooseReviewers;
-module.exports.buildBody         = buildBody;
-module.exports.parseExcluded     = parseExcluded;
-module.exports.serializeExcluded = serializeExcluded;
+module.exports.matchesPattern       = matchesPattern;
+module.exports.labelFromPattern     = labelFromPattern;
+module.exports.attributeFiles       = attributeFiles;
+module.exports.computeApprovals     = computeApprovals;
+module.exports.chooseReviewers      = chooseReviewers;
+module.exports.buildBody            = buildBody;
+module.exports.parseExcluded        = parseExcluded;
+module.exports.serializeExcluded    = serializeExcluded;
+module.exports.planSynchronizeSwaps = planSynchronizeSwaps;

--- a/.github/scripts/review-checklist.js
+++ b/.github/scripts/review-checklist.js
@@ -30,6 +30,20 @@ function serializeExcluded(excluded) {
   return `${EXCLUDED_PREFIX}${[...excluded].join(',')}${EXCLUDED_SUFFIX}`;
 }
 
+// Returns commentBody with its exclusion-marker section replaced by the
+// serialized form of `excluded`. Appends the marker if the body doesn't
+// already have one. Centralized here (rather than duplicated by other
+// writers, e.g. the /remove-reviewer slash command) so the marker format
+// only needs to be understood in one place.
+function withExcluded(commentBody, excluded) {
+  const marker = serializeExcluded(excluded);
+  const start = commentBody.indexOf(EXCLUDED_PREFIX);
+  if (start === -1) return `${commentBody}\n${marker}`;
+  const end = commentBody.indexOf(EXCLUDED_SUFFIX, start);
+  if (end === -1) return `${commentBody}\n${marker}`;
+  return commentBody.slice(0, start) + marker + commentBody.slice(end + EXCLUDED_SUFFIX.length);
+}
+
 // ── Pure helpers ──────────────────────────────────────────────────────────────
 
 function labelFromPattern(pattern) {
@@ -340,11 +354,19 @@ function planSynchronizeSwaps(eligibleAreas, allReviews, {
 //                 review is even wanted yet. Cleared in full — no checklist
 //                 posted until the PR is ready for review.
 //
-//   non-draft, just (re)opened
-//               → Same CODEOWNERS avalanche. Pruned to the load-balanced
-//                 single pick per area before the checklist is first posted,
-//                 so reviewers aren't @-mentioned en masse before the final
-//                 reviewer set is known.
+//   non-draft, just (re)opened or just marked ready_for_review
+//               → Same CODEOWNERS avalanche — GitHub auto-requests CODEOWNERS
+//                 reviewers both on creation and again when a draft is marked
+//                 ready for review. Pruned to the load-balanced single pick
+//                 per area before the checklist is first posted, so reviewers
+//                 aren't @-mentioned en masse before the final reviewer set
+//                 is known.
+//
+//   synchronize with a dismissed reviewer
+//               → see planSynchronizeSwaps: re-requests a reviewer whose
+//                 approval a new push just dismissed, swapping out a fresh
+//                 CODEOWNERS pick for the same area if one was auto-assigned
+//                 (never removing a pick still needed by another area).
 //
 // Everywhere else:
 //
@@ -477,11 +499,14 @@ async function coordinateReviewers(github, context, core, {
     owners: area.owners.filter(o => !updatedExcluded.has(o)),
   }));
 
-  if (action === 'opened' || action === 'reopened') {
+  if (action === 'opened' || action === 'reopened' || action === 'ready_for_review') {
     // Non-draft, just (re)opened — same CODEOWNERS avalanche problem as the
     // draft case: GitHub has already auto-assigned every touched-area owner.
-    // Prune to a load-balanced single pick per area BEFORE posting the
-    // checklist so reviewers aren't @-mentioned en masse. Pass an empty
+    // ready_for_review gets the same treatment: GitHub auto-requests CODEOWNERS
+    // reviewers again when a draft is marked ready, dumping the avalanche on a
+    // PR that may have sat in draft (untouched, per the isDraft branch above)
+    // for a while. Prune to a load-balanced single pick per area BEFORE posting
+    // the checklist so reviewers aren't @-mentioned en masse. Pass an empty
     // existingRequested so chooseReviewers treats every area as uncovered and
     // picks fresh rather than seeing "already has an owner" and returning nothing.
     const { selected, log } = chooseReviewers(eligibleAreas, {
@@ -497,7 +522,7 @@ async function coordinateReviewers(github, context, core, {
     const toRequest = new Set([...selected].filter(l => !existingRequested.has(l)));
     if (toRequest.size > 0) await requestReviewers(github, core, pr, toRequest);
 
-    core.info(`Non-draft PR opened — pruned to load-balanced selection: ${[...selected].join(', ') || '(none)'}`);
+    core.info(`Non-draft PR ${action} — pruned to load-balanced selection: ${[...selected].join(', ') || '(none)'}`);
     return { confirmedRequested: selected, excludedReviewers: updatedExcluded };
   }
 
@@ -776,6 +801,7 @@ module.exports = async function run({ github, context, core }) {
   }
 };
 
+module.exports.MARKER               = MARKER;
 module.exports.matchesPattern       = matchesPattern;
 module.exports.labelFromPattern     = labelFromPattern;
 module.exports.attributeFiles       = attributeFiles;
@@ -784,4 +810,6 @@ module.exports.chooseReviewers      = chooseReviewers;
 module.exports.buildBody            = buildBody;
 module.exports.parseExcluded        = parseExcluded;
 module.exports.serializeExcluded    = serializeExcluded;
+module.exports.withExcluded         = withExcluded;
+module.exports.coordinateReviewers  = coordinateReviewers;
 module.exports.planSynchronizeSwaps = planSynchronizeSwaps;

--- a/.github/scripts/review-checklist.test.js
+++ b/.github/scripts/review-checklist.test.js
@@ -731,6 +731,9 @@ function makeCoordinateBaseArgs(overrides) {
     reviewerLoad: {},
     excludedReviewers: new Set(),
     allReviews: [],
+    // Most scenarios model an already-established PR (checklist already
+    // posted); tests exercising the fresh-PR race override this explicitly.
+    hasExistingComment: true,
     LINE_THRESHOLD: 300,
     AREA_THRESHOLDS: {},
     PUBLIC_HEADER: /public\.h$/,
@@ -782,6 +785,45 @@ asyncTest('coordinateReviewers: plain synchronize (no dismissed reviews) is left
 
   assert.strictEqual(github.calls.removeRequestedReviewers.length, 0);
   assert.strictEqual(github.calls.requestReviewers.length, 0);
+  assert.deepStrictEqual([...confirmedRequested].sort(), ['glennsong09', 'hyoklee', 'jhendersonHDF']);
+});
+
+asyncTest('coordinateReviewers: review_requested survives the opened race and still prunes (PR #6479 scenario)', async () => {
+  // GitHub's CODEOWNERS engine fires one review_requested per auto-assigned
+  // owner; each re-triggers this workflow, and concurrency: cancel-in-progress
+  // means any of those runs — not necessarily the "opened" run — can be the
+  // one that actually executes. hasExistingComment: false (no checklist
+  // posted yet) is what lets a surviving review_requested run still prune
+  // the avalanche instead of falling through to additive-fill and keeping
+  // all three.
+  const github = makeGithubMock();
+  const context = {
+    eventName: 'pull_request_target',
+    payload: { action: 'review_requested', requested_reviewer: { login: 'jhendersonHDF' }, sender: { type: 'User' } },
+  };
+  const args = makeCoordinateBaseArgs({ hasExistingComment: false });
+
+  const { confirmedRequested } = await coordinateReviewers(github, context, makeCore(), args);
+
+  assert.strictEqual(confirmedRequested.size, 1);
+  assert.ok(github.calls.removeRequestedReviewers.length > 0);
+});
+
+asyncTest('coordinateReviewers: review_requested on an already-established PR is NOT treated as a fresh-PR prune', async () => {
+  // Contrast case: once a checklist comment exists, a routine review_requested
+  // later in the PR's life (e.g. a human manually adding a reviewer) must stay
+  // on the additive-fill path — it must not be reinterpreted as "first
+  // coordination pass" and prune reviewers an established PR already has.
+  const github = makeGithubMock();
+  const context = {
+    eventName: 'pull_request_target',
+    payload: { action: 'review_requested', requested_reviewer: { login: 'jhendersonHDF' }, sender: { type: 'User' } },
+  };
+  const args = makeCoordinateBaseArgs({ hasExistingComment: true });
+
+  const { confirmedRequested } = await coordinateReviewers(github, context, makeCore(), args);
+
+  assert.strictEqual(github.calls.removeRequestedReviewers.length, 0);
   assert.deepStrictEqual([...confirmedRequested].sort(), ['glennsong09', 'hyoklee', 'jhendersonHDF']);
 });
 

--- a/.github/scripts/review-checklist.test.js
+++ b/.github/scripts/review-checklist.test.js
@@ -11,6 +11,7 @@ const {
   buildBody,
   parseExcluded,
   serializeExcluded,
+  planSynchronizeSwaps,
 } = require('./review-checklist.js');
 
 let passed = 0;
@@ -497,6 +498,91 @@ test('serializeExcluded: round-trips through parseExcluded', () => {
   const original = new Set(['alice', 'bob']);
   const roundTripped = parseExcluded(serializeExcluded(original));
   assert.deepStrictEqual([...roundTripped].sort(), ['alice', 'bob']);
+});
+
+// ----------------------------------------------------------------
+// planSynchronizeSwaps
+// ----------------------------------------------------------------
+
+function makeSyncCtx(overrides) {
+  return {
+    prAuthor:        'lrknox',
+    existingRequested: new Set(),
+    updatedExcluded: new Set(),
+    touchedAreaOwners: new Set(['jhendersonHDF', 'hyoklee', 'glennsong09', 'lrknox']),
+    ...overrides,
+  };
+}
+
+test('planSynchronizeSwaps: dismissed reviewer swaps out fresh CODEOWNERS pick (PR 6475 scenario)', () => {
+  // Jordan reviewed and got dismissed; GitHub auto-assigned Joe (hyoklee) for the fixup push.
+  const areas = [makeArea('.github', ['hyoklee', 'lrknox', 'jhendersonHDF', 'glennsong09'], 5)];
+  const reviews = [{ user: { login: 'jhendersonHDF' }, state: 'DISMISSED' }];
+  const ctx = makeSyncCtx({ existingRequested: new Set(['hyoklee']) });
+  const swaps = planSynchronizeSwaps(areas, reviews, ctx);
+  assert.strictEqual(swaps.length, 1);
+  assert.strictEqual(swaps[0].dismissedOwner, 'jhendersonHDF');
+  assert.strictEqual(swaps[0].freshPick, 'hyoklee');
+});
+
+test('planSynchronizeSwaps: no swaps when dismissed reviewer is already re-requested', () => {
+  const areas = [makeArea('.github', ['hyoklee', 'jhendersonHDF'], 5)];
+  const reviews = [{ user: { login: 'jhendersonHDF' }, state: 'DISMISSED' }];
+  const ctx = makeSyncCtx({ existingRequested: new Set(['jhendersonHDF']) });
+  const swaps = planSynchronizeSwaps(areas, reviews, ctx);
+  assert.strictEqual(swaps.length, 0);
+});
+
+test('planSynchronizeSwaps: no fresh pick when GitHub assigned no one for the area', () => {
+  // Dismissed reviewer exists but GitHub didn't auto-assign anyone new.
+  const areas = [makeArea('.github', ['hyoklee', 'jhendersonHDF'], 5)];
+  const reviews = [{ user: { login: 'jhendersonHDF' }, state: 'DISMISSED' }];
+  const ctx = makeSyncCtx({ existingRequested: new Set() });
+  const swaps = planSynchronizeSwaps(areas, reviews, ctx);
+  assert.strictEqual(swaps.length, 1);
+  assert.strictEqual(swaps[0].dismissedOwner, 'jhendersonHDF');
+  assert.strictEqual(swaps[0].freshPick, null);
+});
+
+test('planSynchronizeSwaps: dismissed reviewer who is excluded is skipped', () => {
+  const areas = [makeArea('.github', ['hyoklee', 'jhendersonHDF'], 5)];
+  const reviews = [{ user: { login: 'jhendersonHDF' }, state: 'DISMISSED' }];
+  const ctx = makeSyncCtx({
+    existingRequested: new Set(['hyoklee']),
+    updatedExcluded: new Set(['jhendersonHDF']),
+  });
+  const swaps = planSynchronizeSwaps(areas, reviews, ctx);
+  assert.strictEqual(swaps.length, 0);
+});
+
+test('planSynchronizeSwaps: PR author as dismissed reviewer is skipped', () => {
+  const areas = [makeArea('.github', ['lrknox', 'jhendersonHDF'], 5)];
+  const reviews = [{ user: { login: 'lrknox' }, state: 'DISMISSED' }];
+  const ctx = makeSyncCtx({ existingRequested: new Set(['jhendersonHDF']) });
+  const swaps = planSynchronizeSwaps(areas, reviews, ctx);
+  assert.strictEqual(swaps.length, 0);
+});
+
+test('planSynchronizeSwaps: no dismissed reviews produces no swaps', () => {
+  const areas = [makeArea('.github', ['hyoklee', 'jhendersonHDF'], 5)];
+  const reviews = [{ user: { login: 'jhendersonHDF' }, state: 'APPROVED' }];
+  const ctx = makeSyncCtx({ existingRequested: new Set(['hyoklee']) });
+  const swaps = planSynchronizeSwaps(areas, reviews, ctx);
+  assert.strictEqual(swaps.length, 0);
+});
+
+test('planSynchronizeSwaps: manually added non-CODEOWNER is not treated as a fresh pick', () => {
+  // 'outsider' is in existingRequested but NOT in touchedAreaOwners (manually added).
+  // Should not be removed as a fresh CODEOWNERS pick.
+  const areas = [makeArea('.github', ['hyoklee', 'jhendersonHDF'], 5)];
+  const reviews = [{ user: { login: 'jhendersonHDF' }, state: 'DISMISSED' }];
+  const ctx = makeSyncCtx({
+    existingRequested: new Set(['outsider']),
+    touchedAreaOwners: new Set(['hyoklee', 'jhendersonHDF', 'glennsong09']),
+  });
+  const swaps = planSynchronizeSwaps(areas, reviews, ctx);
+  assert.strictEqual(swaps.length, 1);
+  assert.strictEqual(swaps[0].freshPick, null); // outsider not swapped out
 });
 
 // ----------------------------------------------------------------

--- a/.github/scripts/review-checklist.test.js
+++ b/.github/scripts/review-checklist.test.js
@@ -3,6 +3,7 @@
 
 const assert = require('assert');
 const {
+  MARKER,
   matchesPattern,
   labelFromPattern,
   attributeFiles,
@@ -11,8 +12,32 @@ const {
   buildBody,
   parseExcluded,
   serializeExcluded,
+  withExcluded,
   planSynchronizeSwaps,
+  coordinateReviewers,
 } = require('./review-checklist.js');
+
+// Minimal recording mock for the github.rest surface coordinateReviewers
+// touches. Each call resolves successfully and is appended to its call log.
+function makeGithubMock() {
+  const calls = { removeRequestedReviewers: [], requestReviewers: [], addAssignees: [] };
+  return {
+    calls,
+    rest: {
+      pulls: {
+        removeRequestedReviewers: async (opts) => { calls.removeRequestedReviewers.push(opts.reviewers[0]); },
+        requestReviewers:         async (opts) => { calls.requestReviewers.push(opts.reviewers[0]); },
+      },
+      issues: {
+        addAssignees: async (opts) => { calls.addAssignees.push(opts.assignees[0]); },
+      },
+    },
+  };
+}
+
+function makeCore() {
+  return { info: () => {}, warning: () => {}, setFailed: () => {} };
+}
 
 let passed = 0;
 let failed = 0;
@@ -26,6 +51,14 @@ function test(name, fn) {
     console.log(`✗ ${name} — ${e.message}`);
     failed++;
   }
+}
+
+// coordinateReviewers exercises real async API calls (mocked). test() doesn't
+// await, so an async fn's assertions would run after the pass/fail tally is
+// already printed — queue these separately and await them before the summary.
+const asyncTests = [];
+function asyncTest(name, fn) {
+  asyncTests.push({ name, fn });
 }
 
 // ----------------------------------------------------------------
@@ -501,6 +534,34 @@ test('serializeExcluded: round-trips through parseExcluded', () => {
 });
 
 // ----------------------------------------------------------------
+// withExcluded — used by /remove-reviewer to persist a deliberate removal
+// into the checklist comment's exclusion marker.
+// ----------------------------------------------------------------
+
+test('withExcluded: replaces an existing marker in place, preserving the rest of the body', () => {
+  const body = `${MARKER}\nsome checklist text\n<!-- hdf5-review-checklist-excluded:alice-->`;
+  const updated = withExcluded(body, new Set(['alice', 'bob']));
+  assert.ok(updated.includes('some checklist text'));
+  assert.ok(updated.startsWith(MARKER));
+  assert.deepStrictEqual([...parseExcluded(updated)].sort(), ['alice', 'bob']);
+  // Only one marker present afterward — not appended alongside the old one.
+  assert.strictEqual(updated.split('hdf5-review-checklist-excluded:').length - 1, 1);
+});
+
+test('withExcluded: appends a marker when the body has none', () => {
+  const body = `${MARKER}\nsome checklist text`;
+  const updated = withExcluded(body, new Set(['alice']));
+  assert.ok(updated.includes('some checklist text'));
+  assert.deepStrictEqual([...parseExcluded(updated)], ['alice']);
+});
+
+test('withExcluded: round-trips an empty set to the empty marker', () => {
+  const body = `${MARKER}\ntext\n<!-- hdf5-review-checklist-excluded:alice-->`;
+  const updated = withExcluded(body, new Set());
+  assert.strictEqual(parseExcluded(updated).size, 0);
+});
+
+// ----------------------------------------------------------------
 // planSynchronizeSwaps
 // ----------------------------------------------------------------
 
@@ -652,9 +713,142 @@ test('planSynchronizeSwaps: dismissedOwner already covering a different area is 
 });
 
 // ----------------------------------------------------------------
+// coordinateReviewers — ready_for_review CODEOWNERS-avalanche pruning
+// ----------------------------------------------------------------
+
+function makeCoordinateBaseArgs(overrides) {
+  const area = makeArea('.github', ['hyoklee', 'lrknox', 'jhendersonHDF', 'glennsong09'], 5);
+  return {
+    owner: 'HDFGroup', repo: 'hdf5', pr_number: 1,
+    prData: {
+      user: { login: 'lrknox' },
+      draft: false,
+      requested_reviewers: [{ login: 'hyoklee' }, { login: 'jhendersonHDF' }, { login: 'glennsong09' }],
+    },
+    allCodeOwners: new Set(['hyoklee', 'lrknox', 'jhendersonHDF', 'glennsong09']),
+    catchAllOwners: new Set(),
+    touchedAreas: [area],
+    reviewerLoad: {},
+    excludedReviewers: new Set(),
+    allReviews: [],
+    LINE_THRESHOLD: 300,
+    AREA_THRESHOLDS: {},
+    PUBLIC_HEADER: /public\.h$/,
+    ...overrides,
+  };
+}
+
+asyncTest('coordinateReviewers: ready_for_review prunes the CODEOWNERS avalanche to one load-balanced pick', async () => {
+  const github = makeGithubMock();
+  const context = { eventName: 'pull_request_target', payload: { action: 'ready_for_review', sender: { type: 'User' } } };
+  const args = makeCoordinateBaseArgs();
+
+  const { confirmedRequested } = await coordinateReviewers(github, context, makeCore(), args);
+
+  // hyoklee is first non-author owner in CODEOWNERS order with equal (zero) load.
+  assert.deepStrictEqual([...confirmedRequested], ['hyoklee']);
+  // The other two avalanche-assigned owners get removed.
+  assert.ok(github.calls.removeRequestedReviewers.includes('jhendersonHDF'));
+  assert.ok(github.calls.removeRequestedReviewers.includes('glennsong09'));
+  assert.strictEqual(github.calls.removeRequestedReviewers.length, 2);
+  // hyoklee was already requested, so no redundant request call.
+  assert.strictEqual(github.calls.requestReviewers.length, 0);
+});
+
+asyncTest('coordinateReviewers: ready_for_review on a draft-opened PR (still draft) does not prune', async () => {
+  // Sanity check the branch ordering: if somehow still draft (shouldn't
+  // happen for a real ready_for_review payload, but guards the isDraft
+  // branch precedence), the draft path's "leave alone" rule wins.
+  const github = makeGithubMock();
+  const context = { eventName: 'pull_request_target', payload: { action: 'ready_for_review', sender: { type: 'User' } } };
+  const args = makeCoordinateBaseArgs({ prData: { ...makeCoordinateBaseArgs().prData, draft: true } });
+
+  const { confirmedRequested } = await coordinateReviewers(github, context, makeCore(), args);
+
+  assert.strictEqual(github.calls.removeRequestedReviewers.length, 0);
+  assert.deepStrictEqual([...confirmedRequested].sort(), ['glennsong09', 'hyoklee', 'jhendersonHDF']);
+});
+
+asyncTest('coordinateReviewers: plain synchronize (no dismissed reviews) is left to additive fill, not pruned', async () => {
+  // Contrast case: a synchronize with no dismissed reviews must NOT trigger
+  // avalanche-style pruning — only opened/reopened/ready_for_review do. All
+  // three avalanche-style owners stay; nothing is removed, nothing new is
+  // requested since the area is already covered.
+  const github = makeGithubMock();
+  const context = { eventName: 'pull_request_target', payload: { action: 'synchronize', sender: { type: 'User' } } };
+  const args = makeCoordinateBaseArgs();
+
+  const { confirmedRequested } = await coordinateReviewers(github, context, makeCore(), args);
+
+  assert.strictEqual(github.calls.removeRequestedReviewers.length, 0);
+  assert.strictEqual(github.calls.requestReviewers.length, 0);
+  assert.deepStrictEqual([...confirmedRequested].sort(), ['glennsong09', 'hyoklee', 'jhendersonHDF']);
+});
+
+// ----------------------------------------------------------------
+// coordinateReviewers — bot-self-triggered review_request_removed must not
+// create a sticky exclusion (the bot's own removeUnselected/removeRequestedReviewers
+// calls fire this very event and would otherwise self-trigger a run that reads
+// its own bookkeeping removal as a deliberate human decision).
+// ----------------------------------------------------------------
+
+function makeRemovalContext(senderType) {
+  return {
+    eventName: 'pull_request_target',
+    payload: {
+      action: 'review_request_removed',
+      requested_reviewer: { login: 'jhendersonHDF' },
+      sender: { type: senderType },
+    },
+  };
+}
+
+asyncTest('coordinateReviewers: bot-sender review_request_removed does not persist a sticky exclusion', async () => {
+  const github = makeGithubMock();
+  const args = makeCoordinateBaseArgs({
+    prData: {
+      user: { login: 'lrknox' },
+      draft: false,
+      requested_reviewers: [{ login: 'hyoklee' }, { login: 'glennsong09' }],
+    },
+  });
+
+  const { excludedReviewers } = await coordinateReviewers(github, makeRemovalContext('Bot'), makeCore(), args);
+
+  assert.ok(!excludedReviewers.has('jhendersonHDF'));
+});
+
+asyncTest('coordinateReviewers: human-sender review_request_removed does persist a sticky exclusion', async () => {
+  const github = makeGithubMock();
+  const args = makeCoordinateBaseArgs({
+    prData: {
+      user: { login: 'lrknox' },
+      draft: false,
+      requested_reviewers: [{ login: 'hyoklee' }, { login: 'glennsong09' }],
+    },
+  });
+
+  const { excludedReviewers } = await coordinateReviewers(github, makeRemovalContext('User'), makeCore(), args);
+
+  assert.ok(excludedReviewers.has('jhendersonHDF'));
+});
+
+// ----------------------------------------------------------------
 // Summary
 // ----------------------------------------------------------------
 
-console.log('');
-console.log(`${passed} passed, ${failed} failed`);
-process.exit(failed > 0 ? 1 : 0);
+(async () => {
+  for (const { name, fn } of asyncTests) {
+    try {
+      await fn();
+      console.log(`✓ ${name}`);
+      passed++;
+    } catch (e) {
+      console.log(`✗ ${name} — ${e.message}`);
+      failed++;
+    }
+  }
+  console.log('');
+  console.log(`${passed} passed, ${failed} failed`);
+  process.exit(failed > 0 ? 1 : 0);
+})();

--- a/.github/scripts/review-checklist.test.js
+++ b/.github/scripts/review-checklist.test.js
@@ -585,6 +585,72 @@ test('planSynchronizeSwaps: manually added non-CODEOWNER is not treated as a fre
   assert.strictEqual(swaps[0].freshPick, null); // outsider not swapped out
 });
 
+test('planSynchronizeSwaps: fresh pick covering a second, unrelated touched area is not removed', () => {
+  // joe covers both areas; jordan was dismissed only on area "a". Removing joe
+  // to restore jordan would silently uncover area "b", which has nothing to
+  // do with the dismissal.
+  const areaA = makeArea('a', ['jordan', 'joe'], 5);
+  const areaB = makeArea('b', ['joe', 'glenn'], 5);
+  const reviews = [{ user: { login: 'jordan' }, state: 'DISMISSED' }];
+  const ctx = makeSyncCtx({
+    prAuthor: 'author',
+    existingRequested: new Set(['joe']),
+    touchedAreaOwners: new Set(['jordan', 'joe', 'glenn']),
+  });
+  const swaps = planSynchronizeSwaps([areaA, areaB], reviews, ctx);
+  assert.strictEqual(swaps.length, 1);
+  assert.strictEqual(swaps[0].area.label, 'a');
+  assert.strictEqual(swaps[0].dismissedOwner, 'jordan');
+  assert.strictEqual(swaps[0].freshPick, null); // joe is NOT removed — still needed for area "b"
+});
+
+test('planSynchronizeSwaps: fresh pick is removed when not needed by any other area', () => {
+  // Sanity check that the "needed elsewhere" guard doesn't over-fire: when the
+  // candidate truly owns only the one area in question, they ARE swapped out.
+  const areaA = makeArea('a', ['jordan', 'joe'], 5);
+  const areaB = makeArea('b', ['glenn'], 5); // joe is not an owner of area b
+  const reviews = [{ user: { login: 'jordan' }, state: 'DISMISSED' }];
+  const ctx = makeSyncCtx({
+    prAuthor: 'author',
+    existingRequested: new Set(['joe']),
+    touchedAreaOwners: new Set(['jordan', 'joe', 'glenn']),
+  });
+  const swaps = planSynchronizeSwaps([areaA, areaB], reviews, ctx);
+  assert.strictEqual(swaps.length, 1);
+  assert.strictEqual(swaps[0].freshPick, 'joe');
+});
+
+test('planSynchronizeSwaps: two areas independently dismissed for the same owner both restore them', () => {
+  // jordan owns both areas and was dismissed on the PR as a whole (one review
+  // covers both); each area independently plans to re-request him. The
+  // consuming loop re-requesting him twice is idempotent, not a correctness bug.
+  const areaA = makeArea('a', ['jordan', 'joe'], 5);
+  const areaB = makeArea('b', ['jordan', 'glenn'], 5);
+  const reviews = [{ user: { login: 'jordan' }, state: 'DISMISSED' }];
+  const ctx = makeSyncCtx({
+    prAuthor: 'author',
+    existingRequested: new Set(['joe', 'glenn']),
+    touchedAreaOwners: new Set(['jordan', 'joe', 'glenn']),
+  });
+  const swaps = planSynchronizeSwaps([areaA, areaB], reviews, ctx);
+  assert.strictEqual(swaps.length, 2);
+  assert.ok(swaps.every(s => s.dismissedOwner === 'jordan'));
+});
+
+test('planSynchronizeSwaps: dismissedOwner already covering a different area is not re-flagged', () => {
+  // jordan was dismissed but is already requested (e.g. restored by a prior
+  // area's swap, or independently re-requested) — no duplicate swap planned.
+  const areaA = makeArea('a', ['jordan', 'joe'], 5);
+  const reviews = [{ user: { login: 'jordan' }, state: 'DISMISSED' }];
+  const ctx = makeSyncCtx({
+    prAuthor: 'author',
+    existingRequested: new Set(['jordan']),
+    touchedAreaOwners: new Set(['jordan', 'joe']),
+  });
+  const swaps = planSynchronizeSwaps([areaA], reviews, ctx);
+  assert.strictEqual(swaps.length, 0);
+});
+
 // ----------------------------------------------------------------
 // Summary
 // ----------------------------------------------------------------


### PR DESCRIPTION
## Summary

When a PR author pushes a fixup commit, GitHub dismisses existing approvals and its CODEOWNERS engine auto-assigns a fresh (possibly different) owner for the changed area. The `synchronize` event handler previously treated the fresh CODEOWNERS pick as the authoritative assignment and did nothing — leaving the dismissed reviewer (who already has context) off the PR.

- Adds `planSynchronizeSwaps()` — a pure helper that identifies dismissed area-owners who should be re-requested and the fresh CODEOWNERS pick to remove in their place
- On `synchronize`, the handler now removes the fresh pick and re-requests the dismissed reviewer
- If GitHub didn't auto-assign anyone new, the dismissed reviewer is still re-requested
- Explicitly excluded reviewers (via `review_request_removed`) are never re-requested
- 7 new unit tests including the exact PR #6475 scenario (Jordan reviewed, Larry pushed a fixup, Joe was incorrectly assigned instead of Jordan being re-requested)