### PR TITLE
Muffle unused parameter warnings.

### DIFF
--- a/src/H5Gname.c
+++ b/src/H5Gname.c
@@ -1040,7 +1040,7 @@ done:
  *-------------------------------------------------------------------------
  */
 static herr_t
-H5G__get_name_by_addr_cb(hid_t gid, const char *path, const H5O_loc_t *obj_oloc, void *_udata)
+H5G__get_name_by_addr_cb(hid_t H5_ATTR_UNUSED gid, const char *path, const H5O_loc_t *obj_oloc, void *_udata)
 {
     H5G_gnba_iter_t *udata     = (H5G_gnba_iter_t *)_udata; /* User data for iteration */
     herr_t           ret_value = H5_ITER_CONT;              /* Return value */

--- a/src/H5Ocopy.c
+++ b/src/H5Ocopy.c
@@ -1343,7 +1343,7 @@ done:
  *-------------------------------------------------------------------------
  */
 static herr_t
-H5O__copy_search_comm_dt_cb(hid_t H5_ATTR_UNUSED group, const char *name, const H5O_loc_t *obj_oloc,
+H5O__copy_search_comm_dt_cb(hid_t H5_ATTR_UNUSED group, const char H5_ATTR_UNUSED *name, const H5O_loc_t *obj_oloc,
                             void *_udata)
 {
     H5O_copy_search_comm_dt_ud_t *udata =

--- a/src/H5Ocopy.c
+++ b/src/H5Ocopy.c
@@ -1343,8 +1343,8 @@ done:
  *-------------------------------------------------------------------------
  */
 static herr_t
-H5O__copy_search_comm_dt_cb(hid_t H5_ATTR_UNUSED group, const char H5_ATTR_UNUSED *name, const H5O_loc_t *obj_oloc,
-                            void *_udata)
+H5O__copy_search_comm_dt_cb(hid_t H5_ATTR_UNUSED group, const char H5_ATTR_UNUSED *name,
+                            const H5O_loc_t *obj_oloc, void *_udata)
 {
     H5O_copy_search_comm_dt_ud_t *udata =
         (H5O_copy_search_comm_dt_ud_t *)_udata; /* Skip list of dtypes in dest file */


### PR DESCRIPTION
Added missing `H5_ATTR_UNUSED` macros.