### PR TITLE
Address these zizmor github-advanced-security alerts in workflows:

### DIFF
--- a/.github/workflows/clang-format-fix.yml
+++ b/.github/workflows/clang-format-fix.yml
@@ -24,6 +24,8 @@ jobs:
         contents: write # In order to allow EndBug/add-and-commit to commit changes
     steps:
     - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+      with:
+        persist-credentials: false # Prevents tokens from being written to Git config files
 
     - name: Fix C and Java formatting issues detected by clang-format
       uses: DoozyX/clang-format-lint-action@bcb4eb2cb0d707ee4f3e5cc3b456eb075f12cf73 # v0.20

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -251,7 +251,7 @@ jobs:
 
       - name: Upload empty SARIF for skipped analysis
         if: needs.analyze.result == 'skipped' && github.event_name == 'pull_request'
-        uses: github/codeql-action/upload-sarif@c1e7c7a0de342c642bc11d2219ba7a3cb2281f19 # v4.32.4
+        uses: github/codeql-action/upload-sarif@c1e7c7a0de342c642bc11d2219ba7a3cb2281f19 
         with:
           sarif_file: ${{ github.workspace }}/empty.sarif
           category: "/language:c-cpp"

--- a/.github/workflows/cve.yml
+++ b/.github/workflows/cve.yml
@@ -37,6 +37,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false # Prevents tokens from being written to Git config files
 
       - name: Install HDF5
         run: |

--- a/.github/workflows/daily-build.yml
+++ b/.github/workflows/daily-build.yml
@@ -40,6 +40,8 @@ jobs:
 
     steps:
     - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+      with:
+        persist-credentials: false # Prevents tokens from being written to Git config files
 
     - name: Get hdf5 release base name
       uses: dsaltares/fetch-gh-release-asset@aa2ab1243d6e0d5b405b973c89fa4d06a2d0fff7 # master

--- a/.github/workflows/java-implementation-test.yml
+++ b/.github/workflows/java-implementation-test.yml
@@ -153,7 +153,7 @@ jobs:
           choco install ninja
 
       - name: Cache CMake build
-        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v4
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6
         with:
           path: |
             build-test-*

--- a/.github/workflows/markdown-link-check.yml
+++ b/.github/workflows/markdown-link-check.yml
@@ -16,6 +16,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # master
+      with:
+        persist-credentials: false # Prevents tokens from being written to Git config files
+
     - uses: gaurav-nelson/github-action-markdown-link-check@5c5dfc0ac2e225883c0e5f03a85311ec2830d368 # v1
       with:
         config-file: '.github/workflows/markdown_config.json'

--- a/.github/workflows/maven-staging.yml
+++ b/.github/workflows/maven-staging.yml
@@ -816,7 +816,7 @@ jobs:
         continue-on-error: true
 
       - name: Cache Maven dependencies
-        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v4
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6
         with:
           path: ~/.m2/repository
           key: ${{ runner.os }}-maven-examples-${{ hashFiles('**/pom-examples.xml*') }}

--- a/.github/workflows/review-checklist-test.yml
+++ b/.github/workflows/review-checklist-test.yml
@@ -19,5 +19,8 @@ jobs:
     runs-on: ubuntu-latest
     if: github.repository == 'HDFGroup/hdf5' && (github.event_name == 'push' || github.event.pull_request.head.repo.full_name == github.repository)
     steps:
-      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v4
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+        with:
+          persist-credentials: false # Prevents tokens from being written to Git config files
+
       - run: node .github/scripts/review-checklist.test.js


### PR DESCRIPTION
  - action's hash pin has mismatched or missing version comment
  - credential persistence through GitHub Actions artifacts: does not set persist-credentials: false