### PR TITLE
Harden serialized selection decoding

### DIFF
--- a/src/H5Sall.c
+++ b/src/H5Sall.c
@@ -636,6 +636,8 @@ H5S__all_deserialize(H5S_t **space, const uint8_t **p, const size_t p_size, bool
 
     if (skip)
         p_end = *p;
+    else if (p_size == 0)
+        HGOTO_ERROR(H5E_DATASPACE, H5E_OVERFLOW, FAIL, "empty all selection buffer");
     else
         p_end = *p + p_size - 1; /* Pointer to last valid byte in buffer */
 

--- a/src/H5Shyper.c
+++ b/src/H5Shyper.c
@@ -4263,6 +4263,8 @@ H5S__hyper_deserialize(H5S_t **space, const uint8_t **p, const size_t p_size, bo
 
     if (skip)
         p_end = *p;
+    else if (p_size == 0)
+        HGOTO_ERROR(H5E_DATASPACE, H5E_OVERFLOW, FAIL, "empty hyperslab selection buffer");
     else
         p_end = *p + p_size - 1; /* Pointer to last valid byte in buffer */
 
@@ -4328,6 +4330,9 @@ H5S__hyper_deserialize(H5S_t **space, const uint8_t **p, const size_t p_size, bo
     if (H5_IS_KNOWN_BUFFER_OVERFLOW(skip, pp, sizeof(uint32_t), p_end))
         HGOTO_ERROR(H5E_DATASPACE, H5E_OVERFLOW, FAIL, "buffer overflow while decoding selection rank");
     UINT32DECODE(pp, rank);
+    if (0 == rank || rank > H5S_MAX_RANK)
+        HGOTO_ERROR(H5E_DATASPACE, H5E_BADVALUE, FAIL, "invalid rank (%u) for serialized hyperslab selection",
+                    rank);
 
     if (!*space) {
         /* Patch the rank of the allocated dataspace */

--- a/src/H5Snone.c
+++ b/src/H5Snone.c
@@ -579,16 +579,23 @@ H5S__none_serialize(H5S_t *space, uint8_t **p)
 static herr_t
 H5S__none_deserialize(H5S_t **space, const uint8_t **p, const size_t p_size, bool skip)
 {
-    H5S_t *tmp_space = NULL;                    /* Pointer to actual dataspace to use,
-                                                   either *space or a newly allocated one */
-    uint32_t       version;                     /* Version number */
-    herr_t         ret_value = SUCCEED;         /* return value */
-    const uint8_t *p_end     = *p + p_size - 1; /* Pointer to last valid byte in buffer */
+    H5S_t *tmp_space = NULL;            /* Pointer to actual dataspace to use,
+                                           either *space or a newly allocated one */
+    uint32_t       version;             /* Version number */
+    herr_t         ret_value = SUCCEED; /* return value */
+    const uint8_t *p_end;               /* Pointer to last valid byte in buffer */
 
     FUNC_ENTER_PACKAGE
 
     assert(p);
     assert(*p);
+
+    if (skip)
+        p_end = *p;
+    else if (p_size == 0)
+        HGOTO_ERROR(H5E_DATASPACE, H5E_OVERFLOW, FAIL, "empty none selection buffer");
+    else
+        p_end = *p + p_size - 1;
 
     /* As part of the efforts to push all selection-type specific coding
        to the callbacks, the coding for the allocation of a null dataspace

--- a/src/H5Spoint.c
+++ b/src/H5Spoint.c
@@ -1375,6 +1375,8 @@ H5S__point_deserialize(H5S_t **space, const uint8_t **p, const size_t p_size, bo
 
     if (skip)
         p_end = *p;
+    else if (p_size == 0)
+        HGOTO_ERROR(H5E_DATASPACE, H5E_OVERFLOW, FAIL, "empty point selection buffer");
     else
         p_end = *p + p_size - 1; /* Pointer to last valid byte in buffer */
 

--- a/src/H5Sselect.c
+++ b/src/H5Sselect.c
@@ -526,7 +526,8 @@ H5S_select_deserialize(H5S_t **space, const uint8_t **p, const size_t p_size)
     uint32_t       sel_type;         /* Pointer to the selection type */
     herr_t         ret_value = FAIL; /* Return value */
     const uint8_t *p_end     = NULL; /* Pointer to last valid byte in buffer */
-    bool           skip      = false;
+    size_t         sel_info_size;    /* Size of selection-type-specific information */
+    bool           skip = false;
 
     FUNC_ENTER_NOAPI(FAIL)
 
@@ -536,6 +537,8 @@ H5S_select_deserialize(H5S_t **space, const uint8_t **p, const size_t p_size)
     skip = (p_size == SIZE_MAX ? true : false);
     if (skip)
         p_end = *p;
+    else if (p_size < sizeof(uint32_t))
+        HGOTO_ERROR(H5E_DATASPACE, H5E_OVERFLOW, FAIL, "selection buffer too small");
     else
         p_end = *p + p_size - 1;
 
@@ -545,23 +548,24 @@ H5S_select_deserialize(H5S_t **space, const uint8_t **p, const size_t p_size)
     if (H5_IS_KNOWN_BUFFER_OVERFLOW(skip, *p, sizeof(uint32_t), p_end))
         HGOTO_ERROR(H5E_DATASPACE, H5E_OVERFLOW, FAIL, "buffer overflow while decoding selection type");
     UINT32DECODE(*p, sel_type);
+    sel_info_size = (skip ? SIZE_MAX : p_size - sizeof(uint32_t));
 
     /* Make routine for selection type */
     switch (sel_type) {
         case H5S_SEL_POINTS: /* Sequence of points selected */
-            ret_value = (*H5S_sel_point->deserialize)(space, p, p_size - sizeof(uint32_t), skip);
+            ret_value = (*H5S_sel_point->deserialize)(space, p, sel_info_size, skip);
             break;
 
         case H5S_SEL_HYPERSLABS: /* Hyperslab selection defined */
-            ret_value = (*H5S_sel_hyper->deserialize)(space, p, p_size - sizeof(uint32_t), skip);
+            ret_value = (*H5S_sel_hyper->deserialize)(space, p, sel_info_size, skip);
             break;
 
         case H5S_SEL_ALL: /* Entire extent selected */
-            ret_value = (*H5S_sel_all->deserialize)(space, p, p_size - sizeof(uint32_t), skip);
+            ret_value = (*H5S_sel_all->deserialize)(space, p, sel_info_size, skip);
             break;
 
         case H5S_SEL_NONE: /* Nothing selected */
-            ret_value = (*H5S_sel_none->deserialize)(space, p, p_size - sizeof(uint32_t), skip);
+            ret_value = (*H5S_sel_none->deserialize)(space, p, sel_info_size, skip);
             break;
 
         default:

--- a/test/tselect.c
+++ b/test/tselect.c
@@ -16056,6 +16056,65 @@ test_h5s_set_extent_none(void)
 
 /****************************************************************
 **
+**  test_select_deserialize_invalid:
+**  Test malformed serialized selections that should fail cleanly.
+**
+****************************************************************/
+static void
+test_select_deserialize_invalid(void)
+{
+    uint8_t        hyper_bad_rank[14];
+    uint8_t        short_selection_type[1] = {0};
+    uint8_t        none_selection[16];
+    uint8_t       *w;
+    const uint8_t *r;
+    H5S_t         *space = NULL;
+    herr_t         ret;
+
+    TESTING("deserialization of malformed serialized selections");
+
+    w = hyper_bad_rank;
+    UINT32ENCODE(w, (uint32_t)H5S_SEL_HYPERSLABS);
+    UINT32ENCODE(w, (uint32_t)H5S_HYPER_VERSION_3);
+    *w++ = 0;
+    *w++ = H5S_SELECT_INFO_ENC_SIZE_4;
+    UINT32ENCODE(w, (uint32_t)H5S_MAX_RANK + 1);
+
+    r = hyper_bad_rank;
+    H5E_BEGIN_TRY
+    {
+        ret = H5S_SELECT_DESERIALIZE(&space, &r, sizeof(hyper_bad_rank));
+    }
+    H5E_END_TRY
+    VERIFY(ret, FAIL, "H5S_SELECT_DESERIALIZE");
+    VERIFY(space, NULL, "H5S_SELECT_DESERIALIZE");
+
+    r = short_selection_type;
+    H5E_BEGIN_TRY
+    {
+        ret = H5S_SELECT_DESERIALIZE(&space, &r, 0);
+    }
+    H5E_END_TRY
+    VERIFY(ret, FAIL, "H5S_SELECT_DESERIALIZE");
+    VERIFY(space, NULL, "H5S_SELECT_DESERIALIZE");
+
+    w = none_selection;
+    UINT32ENCODE(w, (uint32_t)H5S_SEL_NONE);
+    UINT32ENCODE(w, (uint32_t)H5S_NONE_VERSION_1);
+    memset(w, 0, 8);
+
+    r   = none_selection;
+    ret = H5S_SELECT_DESERIALIZE(&space, &r, SIZE_MAX);
+    CHECK(ret, FAIL, "H5S_SELECT_DESERIALIZE");
+    CHECK_PTR(space, "H5S_SELECT_DESERIALIZE");
+    ret = H5S_close(space);
+    CHECK(ret, FAIL, "H5S_close");
+
+    PASSED();
+} /* test_select_deserialize_invalid() */
+
+/****************************************************************
+**
 **  test_select(): Main H5S selection testing routine.
 **
 ****************************************************************/
@@ -16259,6 +16318,9 @@ test_select(void H5_ATTR_UNUSED *params)
      * the class to H5S_NULL instead of H5S_NO_CLASS.
      */
     test_h5s_set_extent_none();
+
+    /* Test malformed serialized selections */
+    test_select_deserialize_invalid();
 
 } /* test_select() */
 


### PR DESCRIPTION
## Summary

This hardens serialized dataspace selection decoding against malformed or truncated selection buffers.

The patch adds explicit length validation before decoding the common serialized selection type, passes the remaining selection-type-specific payload size to the concrete deserializers, rejects zero-length concrete selection payloads, and validates the decoded hyperslab rank before it is used to patch or allocate a dataspace.

## Motivation and context

Several selection deserializers computed `*p + p_size - 1` before proving that `p_size` was non-zero. A malformed serialized selection can therefore underflow the end pointer and let later bounds checks reason about an invalid buffer range. Hyperslab selection decoding also accepted an unchecked serialized rank before patching the dataspace rank.

## Testing

Built and tested with Clang 18 ASan/UBSan on `develop`:

- `cmake -S . -B build-asan -G "Unix Makefiles" -DCMAKE_C_COMPILER=clang-18 -DCMAKE_BUILD_TYPE=RelWithDebInfo -DBUILD_TESTING=ON -DHDF5_BUILD_TOOLS=ON -DHDF5_BUILD_CPP_LIB=OFF -DHDF5_BUILD_FORTRAN=OFF -DHDF5_BUILD_JAVA=OFF -DHDF5_ENABLE_PARALLEL=OFF -DCMAKE_C_FLAGS_RELWITHDEBINFO="-O1 -g -DNDEBUG -fsanitize=address,undefined -fno-omit-frame-pointer" -DCMAKE_EXE_LINKER_FLAGS="-fsanitize=address,undefined"`
- `cmake --build build-asan --target testhdf5 h5dump h5ls -j2`
- `ASAN_OPTIONS=allocator_may_return_null=1:detect_leaks=0:abort_on_error=1 UBSAN_OPTIONS=halt_on_error=1:abort_on_error=1 build-asan/bin/testhdf5 -only select`
- 57-file `test/testfiles` tool baseline across 456 `h5dump`/`h5ls` invocations: 0 sanitizer failures. The existing slow `tlayouto.h5` default `h5dump` case still timed out and was treated separately from sanitizer findings.
- Targeted mutation fuzz pass over the same 57-file corpus: 6,526 runs, 0 new sanitizer findings, 0 skipped known-submitted findings.

AI assistance was used to find and prepare this patch. I reviewed the changes and verified them locally with the commands above.
