### PR TITLE
CI: allow safe fork-PR checkout in review-checklist workflow

### DIFF
--- a/.github/workflows/review-checklist.yml
+++ b/.github/workflows/review-checklist.yml
@@ -48,6 +48,10 @@ jobs:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           persist-credentials: false
+          # checkout v7 blocks all checkouts on pull_request_target/workflow_run
+          # triggers by default. Safe to opt in here: no ref: override is set,
+          # so this always checks out the base branch (develop), never fork code.
+          allow-unsafe-pr-checkout: true
       - uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         with:
           retries: 3


### PR DESCRIPTION
## Summary
- `actions/checkout` v7.0.0 (bumped in #6500) added a blanket safety check that blocks checkout entirely on `pull_request_target`/`workflow_run` triggers, even when no fork ref is being checked out.
- The `review-checklist` workflow only ever checks out the base branch (`develop`) — no `ref:` override — so it's safe to opt in via `allow-unsafe-pr-checkout: true`.
- Fixes checkout failures like: https://github.com/HDFGroup/hdf5/actions/runs/28817725055/job/85461361531
