### PR TITLE
CI: restrict review-checklist workflows to HDFGroup/hdf5 only

### DIFF
--- a/.github/workflows/review-checklist-gather.yml
+++ b/.github/workflows/review-checklist-gather.yml
@@ -21,6 +21,6 @@ permissions: {}
 jobs:
   signal:
     runs-on: ubuntu-latest
-    if: github.event.pull_request.base.ref == 'develop'
+    if: github.repository == 'HDFGroup/hdf5' && github.event.pull_request.base.ref == 'develop'
     steps:
       - run: echo "Review submitted on PR ${{ github.event.pull_request.number }}"

--- a/.github/workflows/review-checklist.yml
+++ b/.github/workflows/review-checklist.yml
@@ -42,8 +42,9 @@ jobs:
   checklist:
     runs-on: ubuntu-latest
     if: >
-      (github.event_name == 'pull_request_target' && github.event.pull_request.base.ref == 'develop') ||
-      (github.event_name == 'workflow_run' && github.event.workflow_run.conclusion == 'success')
+      github.repository == 'HDFGroup/hdf5' &&
+      ((github.event_name == 'pull_request_target' && github.event.pull_request.base.ref == 'develop') ||
+      (github.event_name == 'workflow_run' && github.event.workflow_run.conclusion == 'success'))
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:


### PR DESCRIPTION
## Summary
- `review-checklist.yml` and `review-checklist-gather.yml` use `pull_request_target`/`workflow_run`/`pull_request_review` triggers with elevated permissions (`pull-requests: write`, `issues: write`).
- GitHub copies workflow files into forks. Any fork with Actions enabled ends up independently running these privileged workflows against its own PRs — observed happening on a course sandbox fork: https://github.com/sp26-hdfgroup/hdf5-sandbox/pull/2#issuecomment-4924102301
- Add `github.repository == 'HDFGroup/hdf5'` to both jobs' `if:` conditions, matching the guard already used in `review-checklist-test.yml`, so the job short-circuits before doing anything when running from a fork's own copy.