### PR TITLE
CI: skip draft-pr-policy checkout on issue-only comments

### DIFF
--- a/.github/workflows/stale-pr-policy.yml
+++ b/.github/workflows/stale-pr-policy.yml
@@ -30,6 +30,8 @@ jobs:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           persist-credentials: false
+          sparse-checkout: .github/scripts
+          fetch-depth: 1
       - uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         with:
           script: |
@@ -37,7 +39,9 @@ jobs:
             await runMarkStale({ github, context, core });
 
   draft-pr-policy:
-    if: github.repository_owner == 'HDFGroup'
+    if: >-
+      github.repository_owner == 'HDFGroup' &&
+      (github.event_name != 'issue_comment' || github.event.issue.pull_request != null)
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -47,6 +51,8 @@ jobs:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           persist-credentials: false
+          sparse-checkout: .github/scripts
+          fetch-depth: 1
       - uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         with:
           script: |
@@ -65,6 +71,8 @@ jobs:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           persist-credentials: false
+          sparse-checkout: .github/scripts
+          fetch-depth: 1
       - uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         with:
           script: |

--- a/.github/workflows/stale-pr-policy.yml
+++ b/.github/workflows/stale-pr-policy.yml
@@ -41,7 +41,8 @@ jobs:
   draft-pr-policy:
     if: >-
       github.repository_owner == 'HDFGroup' &&
-      (github.event_name != 'issue_comment' || github.event.issue.pull_request != null)
+      (github.event_name != 'issue_comment' ||
+       (github.event.issue.pull_request != null && github.event.comment.user.type != 'Bot'))
     runs-on: ubuntu-latest
     permissions:
       contents: read

--- a/.github/workflows/stale-pr-policy.yml
+++ b/.github/workflows/stale-pr-policy.yml
@@ -49,12 +49,29 @@ jobs:
       issues: write
       pull-requests: write
     steps:
+      # No checkout needed here — just an API call to see if this comment's
+      # PR is even a draft, before paying for checkout + loading the script.
+      - name: Check draft status
+        id: check
+        if: github.event_name == 'issue_comment'
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
+        with:
+          script: |
+            const { data: pr } = await github.rest.pulls.get({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              pull_number: context.payload.issue.number,
+            });
+            core.setOutput('is_draft', pr.draft ? 'true' : 'false');
+
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        if: steps.check.outputs.is_draft != 'false'
         with:
           persist-credentials: false
           sparse-checkout: .github/scripts
           fetch-depth: 1
       - uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
+        if: steps.check.outputs.is_draft != 'false'
         with:
           script: |
             const { runDraftPolicy } = require('${{ github.workspace }}/.github/scripts/draft-pr-policy.js');


### PR DESCRIPTION
## Summary
- `issue_comment` fires for comments on both issues and PRs. `mark-stale` and `alert-stale` already skip on `issue_comment`, but `draft-pr-policy` had no such guard, so it ran a full checkout + script on every comment on every issue/PR in the repo to check draft-PR staleness — almost always a no-op.
- Added `github.event.issue.pull_request != null` to `draft-pr-policy`'s `if:` so it short-circuits before checkout when the comment is on a plain issue (available directly from the webhook payload, no API call needed).
- Switched all three jobs' checkout to sparse + shallow (`sparse-checkout: .github/scripts`, `fetch-depth: 1`), since they only need that directory to `require()` the github-script payload — cuts the cost of the runs that do proceed.