### PR TITLE
Add a missing H5D__chunk_unlock() call in the failure case

### DIFF
--- a/src/H5Dchunk.c
+++ b/src/H5Dchunk.c
@@ -5722,7 +5722,6 @@ H5D__chunk_update_old_edge_chunks(H5D_t *dset, hsize_t old_dim[])
     H5D_chunk_ud_t      chk_udata;                        /* User data for locking chunk */
     H5D_storage_t       chk_store;                        /* Chunk storage information */
     H5D_dset_io_info_t  chk_dset_info;                    /* Chunked I/O dset info object */
-    bool                chunk_locked = false;             /* Indicates whether the chunk is locked */
     void               *chunk = NULL;                     /* The file chunk  */
     bool                carry; /* Flag to indicate that chunk increment carrys to higher dimension (sorta) */
     herr_t              ret_value = SUCCEED; /* Return value */
@@ -5832,7 +5831,6 @@ H5D__chunk_update_old_edge_chunks(H5D_t *dset, hsize_t old_dim[])
                     HGOTO_ERROR(H5E_DATASET, H5E_CANTLOCK, FAIL, "unable to lock raw data chunk");
 
                 /* Unlock the chunk */
-                chunk_locked = false;
                 if (H5D__chunk_unlock(&chk_io_info, &chk_dset_info, &chk_udata, true, chunk, (hsize_t)0) < 0)
                     HGOTO_ERROR(H5E_IO, H5E_CANTUNLOCK, FAIL, "unable to unlock raw data chunk");
                 chunk = NULL;

--- a/src/H5Dchunk.c
+++ b/src/H5Dchunk.c
@@ -3507,7 +3507,7 @@ H5D__chunk_write(H5D_io_info_t *io_info, H5D_dset_io_info_t *dset_info)
         while (chunk_node) {
             H5D_piece_info_t  *chunk_info;  /* Chunk information */
             H5D_chk_idx_info_t idx_info;    /* Chunked index info */
-            H5D_io_info_t     *chk_io_info; /* Pointer to I/O info object for this chunk */
+            H5D_io_info_t     *chk_io_info = NULL; /* Pointer to I/O info object for this chunk */
             htri_t             cacheable;   /* Whether the chunk is cacheable */
             bool need_insert = false;       /* Whether the chunk needs to be inserted into the index */
 
@@ -3591,6 +3591,7 @@ H5D__chunk_write(H5D_io_info_t *io_info, H5D_dset_io_info_t *dset_info)
             } /* end else */
 
             /* Perform the actual write operation */
+            assert(chk_io_info);
             assert(chk_io_info->count == 1);
             chk_io_info->dsets_info[0].layout_io_info.contig_piece_info = chunk_info;
             chk_io_info->dsets_info[0].file_space                       = chunk_info->fspace;

--- a/src/H5Dchunk.c
+++ b/src/H5Dchunk.c
@@ -3200,10 +3200,15 @@ H5D__chunk_read(H5D_io_info_t *io_info, H5D_dset_io_info_t *dset_info)
                 chk_io_info->dsets_info[0].file_space                       = chunk_info->fspace;
                 chk_io_info->dsets_info[0].mem_space                        = chunk_info->mspace;
                 chk_io_info->dsets_info[0].nelmts                           = chunk_info->piece_points;
-                if ((dset_info->io_ops.single_read)(chk_io_info, &chk_io_info->dsets_info[0]) < 0)
-                    HGOTO_ERROR(H5E_DATASET, H5E_READERROR, FAIL, "chunked read failed");
+                if ((dset_info->io_ops.single_read)(chk_io_info, &chk_io_info->dsets_info[0]) < 0) {
+                    /* Release the cache lock on the chunk when failure occurs */
+                    if (chunk &&
+                        H5D__chunk_unlock(io_info, dset_info, &udata, false, chunk, src_accessed_bytes) < 0)
+                        HGOTO_ERROR(H5E_IO, H5E_READERROR, FAIL, "unable to unlock raw data chunk");
+                     HGOTO_ERROR(H5E_DATASET, H5E_READERROR, FAIL, "chunked read failed");
+                }
 
-                /* Release the cache lock on the chunk. */
+                /* Release the cache lock on the chunk in normal flow */
                 if (chunk &&
                     H5D__chunk_unlock(io_info, dset_info, &udata, false, chunk, src_accessed_bytes) < 0)
                     HGOTO_ERROR(H5E_IO, H5E_READERROR, FAIL, "unable to unlock raw data chunk");

--- a/src/H5Dchunk.c
+++ b/src/H5Dchunk.c
@@ -3279,6 +3279,7 @@ H5D__chunk_write(H5D_io_info_t *io_info, H5D_dset_io_info_t *dset_info)
     void              *chunk = NULL;               /* Pointer to locked chunk buffer */
     H5D_chunk_ud_t     udata;                      /* Index pass-through    */
     bool               chunk_locked = false;       /* Indicates whether the chunk is locked */
+    bool               chunk_dirty  = false;       /* Indicates whether writing is needed   */
     herr_t             ret_value    = SUCCEED;     /* Return value        */
 
     FUNC_ENTER_PACKAGE
@@ -3426,10 +3427,11 @@ H5D__chunk_write(H5D_io_info_t *io_info, H5D_dset_io_info_t *dset_info)
                 /* Perform the actual write operation */
                 if ((dset_info->io_ops.single_write)(&cpt_io_info, &cpt_dset_info) < 0)
                     HGOTO_ERROR(H5E_DATASET, H5E_WRITEERROR, FAIL, "chunked write failed");
+                chunk_dirty = true;
 
                 /* Release the cache lock on the chunk */
                 chunk_locked = false;
-                if (H5D__chunk_unlock(io_info, dset_info, &udata, true, chunk, dst_accessed_bytes) < 0)
+                if (H5D__chunk_unlock(io_info, dset_info, &udata, chunk_dirty, chunk, dst_accessed_bytes) < 0)
                     HGOTO_ERROR(H5E_IO, H5E_CANTUNLOCK, FAIL, "unable to unlock raw data chunk");
                 chunk = NULL;
             } /* end if */
@@ -3624,11 +3626,12 @@ H5D__chunk_write(H5D_io_info_t *io_info, H5D_dset_io_info_t *dset_info)
             chk_io_info->dsets_info[0].nelmts                           = chunk_info->piece_points;
             if ((dset_info->io_ops.single_write)(chk_io_info, &chk_io_info->dsets_info[0]) < 0)
                 HGOTO_ERROR(H5E_DATASET, H5E_READERROR, FAIL, "chunked write failed");
+            chunk_dirty = true;
 
             /* Release the cache lock on the chunk, or insert chunk into index. */
             if (chunk) {
                 chunk_locked = false;
-                if (H5D__chunk_unlock(io_info, dset_info, &udata, true, chunk, dst_accessed_bytes) < 0)
+                if (H5D__chunk_unlock(io_info, dset_info, &udata, chunk_dirty, chunk, dst_accessed_bytes) < 0)
                     HGOTO_ERROR(H5E_IO, H5E_CANTUNLOCK, FAIL, "unable to unlock raw data chunk");
                 chunk = NULL;
             } /* end if */
@@ -3655,7 +3658,7 @@ H5D__chunk_write(H5D_io_info_t *io_info, H5D_dset_io_info_t *dset_info)
 done:
     /* Release chunk lock if we failed while holding it */
     if (chunk_locked && chunk)
-        if (H5D__chunk_unlock(io_info, dset_info, &udata, false, chunk, dst_accessed_bytes) < 0)
+        if (H5D__chunk_unlock(io_info, dset_info, &udata, chunk_dirty, chunk, dst_accessed_bytes) < 0)
             HDONE_ERROR(H5E_IO, H5E_CANTUNLOCK, FAIL, "unable to unlock raw data chunk");
 
     /* Free dataset sieve buffer and reset cached fields */
@@ -6107,12 +6110,13 @@ H5D__chunk_prune_fill(H5D_chunk_it_ud1_t *udata, bool new_unfilt_chunk)
     hsize_t              sel_nelmts;              /* Number of elements in selection */
     hsize_t              count[H5O_LAYOUT_NDIMS]; /* Element count of hyperslab */
     size_t               chunk_size;              /*size of a chunk       */
-    void                *chunk = NULL;            /* The file chunk  */
+    void                *chunk          = NULL;   /* The file chunk  */
     H5D_chunk_ud_t       chk_udata;               /* User data for locking chunk */
     hsize_t              bytes_accessed = 0;      /* Bytes accessed in chunk */
     unsigned             u;                       /* Local index variable */
-    bool                 chunk_locked = false;    /* Indicates whether the chunk is locked */
-    herr_t               ret_value    = SUCCEED;  /* Return value */
+    bool                 chunk_locked   = false;  /* Indicates whether the chunk is locked */
+    bool                 chunk_dirty    = false;  /* Indicates whether writing is needed */
+    herr_t               ret_value      = SUCCEED;/* Return value */
 
     FUNC_ENTER_PACKAGE
 
@@ -6185,6 +6189,7 @@ H5D__chunk_prune_fill(H5D_chunk_it_ud1_t *udata, bool new_unfilt_chunk)
     /* Scatter the data into memory */
     if (H5D__scatter_mem(udata->fb_info.fill_buf, chunk_iter, (size_t)sel_nelmts, chunk /*out*/) < 0)
         HGOTO_ERROR(H5E_DATASET, H5E_WRITEERROR, FAIL, "scatter failed");
+    chunk_dirty = true;
 
     /* The number of bytes accessed in the chunk */
     /* (i.e. the bytes replaced with fill values) */
@@ -6192,18 +6197,19 @@ H5D__chunk_prune_fill(H5D_chunk_it_ud1_t *udata, bool new_unfilt_chunk)
 
     /* Release lock on chunk */
     chunk_locked = false;
-    if (H5D__chunk_unlock(io_info, udata->dset_info, &chk_udata, true, chunk, bytes_accessed) < 0)
+    if (H5D__chunk_unlock(io_info, udata->dset_info, &chk_udata, chunk_dirty, chunk, bytes_accessed) < 0)
         HGOTO_ERROR(H5E_IO, H5E_CANTUNLOCK, FAIL, "unable to unlock raw data chunk");
     chunk = NULL;
 
 done:
+    /* Release chunk lock if we failed while holding it */
     if (chunk_locked && chunk)
-        if (H5D__chunk_unlock(io_info, udata->dset_info, &chk_udata, false, chunk, bytes_accessed) < 0)
+        if (H5D__chunk_unlock(io_info, udata->dset_info, &chk_udata, chunk_dirty, chunk, bytes_accessed) < 0)
             HDONE_ERROR(H5E_IO, H5E_CANTUNLOCK, FAIL, "unable to unlock raw data chunk");
 
     /* Release the selection iterator */
     if (chunk_iter_init && H5S_SELECT_ITER_RELEASE(chunk_iter) < 0)
-        HDONE_ERROR(H5E_DATASET, H5E_CANTFREE, FAIL, "Can't release selection iterator");
+        HDONE_ERROR(H5E_DATASET, H5E_CANTFREE, FAIL, "can't release selection iterator");
     if (chunk_iter)
         chunk_iter = H5FL_FREE(H5S_sel_iter_t, chunk_iter);
 

--- a/src/H5Dchunk.c
+++ b/src/H5Dchunk.c
@@ -4157,7 +4157,7 @@ H5D__chunk_lookup(const H5D_t *dset, const hsize_t *scaled, H5D_chunk_ud_t *udat
             if ((sc->ops->get_addr)(&idx_info, udata) < 0)
                 HGOTO_ERROR(H5E_DATASET, H5E_CANTGET, FAIL, "can't query chunk address");
 
-                 /*
+                /*
                  * Cache the information retrieved.
                  *
                  * Note that if we are writing to the dataset in parallel and filters

--- a/src/H5Dchunk.c
+++ b/src/H5Dchunk.c
@@ -2919,6 +2919,9 @@ H5D__chunk_read(H5D_io_info_t *io_info, H5D_dset_io_info_t *dset_info)
     H5S_t             *chunk_file_spaces_local[8];  /* Local buffer for chunk_file_spaces */
     haddr_t           *chunk_addrs = NULL;          /* Array of chunk addresses */
     haddr_t            chunk_addrs_local[8];        /* Local buffer for chunk_addrs */
+    void              *chunk = NULL;                /* Pointer to locked chunk buffer */
+    bool               chunk_locked = false;        /* Indicates whether the chunk is locked */
+    H5D_chunk_ud_t     udata;                       /* Chunk index pass-through    */
     herr_t             ret_value = SUCCEED;         /*return value        */
 
     FUNC_ENTER_PACKAGE
@@ -2995,7 +2998,6 @@ H5D__chunk_read(H5D_io_info_t *io_info, H5D_dset_io_info_t *dset_info)
         chunk_node = H5D_CHUNK_GET_FIRST_NODE(dset_info);
         while (chunk_node) {
             H5D_piece_info_t *chunk_info; /* Chunk information */
-            H5D_chunk_ud_t    udata;      /* Chunk index pass-through    */
 
             /* Get the actual chunk information from the skip list node */
             chunk_info = H5D_CHUNK_GET_NODE_INFO(dset_info, chunk_node);
@@ -3137,7 +3139,6 @@ H5D__chunk_read(H5D_io_info_t *io_info, H5D_dset_io_info_t *dset_info)
         chunk_node = H5D_CHUNK_GET_FIRST_NODE(dset_info);
         while (chunk_node) {
             H5D_piece_info_t *chunk_info; /* Chunk information */
-            H5D_chunk_ud_t    udata;      /* Chunk index pass-through    */
             htri_t            cacheable;  /* Whether the chunk is cacheable */
 
             /* Get the actual chunk information from the skip list node */
@@ -3155,7 +3156,6 @@ H5D__chunk_read(H5D_io_info_t *io_info, H5D_dset_io_info_t *dset_info)
             if (H5_addr_defined(udata.chunk_block.offset) || UINT_MAX != udata.idx_hint ||
                 !skip_missing_chunks) {
                 H5D_io_info_t *chk_io_info;  /* Pointer to I/O info object for this chunk */
-                void          *chunk = NULL; /* Pointer to locked chunk buffer */
 
                 /* Set chunk's [scaled] coordinates */
                 dset_info->store->chunk.scaled = chunk_info->scaled;
@@ -3174,7 +3174,8 @@ H5D__chunk_read(H5D_io_info_t *io_info, H5D_dset_io_info_t *dset_info)
 
                     /* Lock the chunk into the cache */
                     if (NULL == (chunk = H5D__chunk_lock(io_info, dset_info, &udata, false, false)))
-                        HGOTO_ERROR(H5E_IO, H5E_READERROR, FAIL, "unable to read raw data chunk");
+                        HGOTO_ERROR(H5E_IO, H5E_CANTLOCK, FAIL, "unable to lock raw data chunk");
+                    chunk_locked = true;
 
                     /* Set up the storage buffer information for this chunk */
                     cpt_store.compact.buf = chunk;
@@ -3200,18 +3201,15 @@ H5D__chunk_read(H5D_io_info_t *io_info, H5D_dset_io_info_t *dset_info)
                 chk_io_info->dsets_info[0].file_space                       = chunk_info->fspace;
                 chk_io_info->dsets_info[0].mem_space                        = chunk_info->mspace;
                 chk_io_info->dsets_info[0].nelmts                           = chunk_info->piece_points;
-                if ((dset_info->io_ops.single_read)(chk_io_info, &chk_io_info->dsets_info[0]) < 0) {
-                    /* Release the cache lock on the chunk when failure occurs */
-                    if (chunk &&
-                        H5D__chunk_unlock(io_info, dset_info, &udata, false, chunk, src_accessed_bytes) < 0)
-                        HGOTO_ERROR(H5E_IO, H5E_READERROR, FAIL, "unable to unlock raw data chunk");
+                if ((dset_info->io_ops.single_read)(chk_io_info, &chk_io_info->dsets_info[0]) < 0)
                     HGOTO_ERROR(H5E_DATASET, H5E_READERROR, FAIL, "chunked read failed");
-                }
 
-                /* Release the cache lock on the chunk in normal flow */
+                /* Release the cache lock on the chunk */
+                chunk_locked = false;
                 if (chunk &&
                     H5D__chunk_unlock(io_info, dset_info, &udata, false, chunk, src_accessed_bytes) < 0)
-                    HGOTO_ERROR(H5E_IO, H5E_READERROR, FAIL, "unable to unlock raw data chunk");
+                    HGOTO_ERROR(H5E_IO, H5E_CANTUNLOCK, FAIL, "unable to unlock raw data chunk");
+                chunk = NULL;
             } /* end if */
 
             /* Advance to next chunk in list */
@@ -3220,6 +3218,11 @@ H5D__chunk_read(H5D_io_info_t *io_info, H5D_dset_io_info_t *dset_info)
     }     /* end else */
 
 done:
+    /* Release chunk lock if we failed while holding it */
+    if (chunk_locked && chunk)
+        if (H5D__chunk_unlock(io_info, dset_info, &udata, false, chunk, src_accessed_bytes) < 0)
+            HDONE_ERROR(H5E_IO, H5E_CANTUNLOCK, FAIL, "unable to unlock raw data chunk");
+
     /* Free dataset sieve buffer and reset cached fields */
     if (dset_info->dset->shared->cache.sieve.sieve_buf) {
         dset_info->dset->shared->cache.sieve.sieve_loc  = HADDR_UNDEF;
@@ -3273,6 +3276,9 @@ H5D__chunk_write(H5D_io_info_t *io_info, H5D_dset_io_info_t *dset_info)
     H5S_t             *chunk_file_spaces_local[8]; /* Local buffer for chunk_file_spaces */
     haddr_t           *chunk_addrs = NULL;         /* Array of chunk addresses */
     haddr_t            chunk_addrs_local[8];       /* Local buffer for chunk_addrs */
+    void              *chunk;                      /* Pointer to locked chunk buffer */
+    H5D_chunk_ud_t     udata;                      /* Index pass-through    */
+    bool               chunk_locked = false;       /* Indicates whether the chunk is locked */
     herr_t             ret_value = SUCCEED;        /* Return value        */
 
     FUNC_ENTER_PACKAGE
@@ -3357,7 +3363,6 @@ H5D__chunk_write(H5D_io_info_t *io_info, H5D_dset_io_info_t *dset_info)
         while (chunk_node) {
             H5D_piece_info_t  *chunk_info; /* Chunk information */
             H5D_chk_idx_info_t idx_info;   /* Chunked index info */
-            H5D_chunk_ud_t     udata;      /* Index pass-through    */
             htri_t             cacheable;  /* Whether the chunk is cacheable */
             bool need_insert = false;      /* Whether the chunk needs to be inserted into the index */
 
@@ -3384,7 +3389,6 @@ H5D__chunk_write(H5D_io_info_t *io_info, H5D_dset_io_info_t *dset_info)
             if (cacheable) {
                 /* Load the chunk into cache.  But if the whole chunk is written,
                  * simply allocate space instead of load the chunk. */
-                void *chunk;               /* Pointer to locked chunk buffer */
                 bool  entire_chunk = true; /* Whether whole chunk is selected */
 
                 /* Compute # of bytes accessed in chunk */
@@ -3400,7 +3404,8 @@ H5D__chunk_write(H5D_io_info_t *io_info, H5D_dset_io_info_t *dset_info)
 
                 /* Lock the chunk into the cache */
                 if (NULL == (chunk = H5D__chunk_lock(io_info, dset_info, &udata, entire_chunk, false)))
-                    HGOTO_ERROR(H5E_IO, H5E_READERROR, FAIL, "unable to read raw data chunk");
+                    HGOTO_ERROR(H5E_IO, H5E_CANTLOCK, FAIL, "unable to lock raw data chunk");
+                chunk_locked = true;
 
                 /* Set up the storage buffer information for this chunk */
                 cpt_store.compact.buf = chunk;
@@ -3420,11 +3425,13 @@ H5D__chunk_write(H5D_io_info_t *io_info, H5D_dset_io_info_t *dset_info)
 
                 /* Perform the actual write operation */
                 if ((dset_info->io_ops.single_write)(&cpt_io_info, &cpt_dset_info) < 0)
-                    HGOTO_ERROR(H5E_DATASET, H5E_READERROR, FAIL, "chunked write failed");
+                    HGOTO_ERROR(H5E_DATASET, H5E_WRITEERROR, FAIL, "chunked write failed");
 
                 /* Release the cache lock on the chunk */
+                chunk_locked = false;
                 if (H5D__chunk_unlock(io_info, dset_info, &udata, true, chunk, dst_accessed_bytes) < 0)
-                    HGOTO_ERROR(H5E_IO, H5E_READERROR, FAIL, "unable to unlock raw data chunk");
+                    HGOTO_ERROR(H5E_IO, H5E_CANTUNLOCK, FAIL, "unable to unlock raw data chunk");
+                chunk = NULL;
             } /* end if */
             else {
                 /* If the chunk hasn't been allocated on disk, do so now. */
@@ -3527,8 +3534,6 @@ H5D__chunk_write(H5D_io_info_t *io_info, H5D_dset_io_info_t *dset_info)
             H5D_piece_info_t  *chunk_info;  /* Chunk information */
             H5D_chk_idx_info_t idx_info;    /* Chunked index info */
             H5D_io_info_t     *chk_io_info; /* Pointer to I/O info object for this chunk */
-            void              *chunk;       /* Pointer to locked chunk buffer */
-            H5D_chunk_ud_t     udata;       /* Index pass-through    */
             htri_t             cacheable;   /* Whether the chunk is cacheable */
             bool need_insert = false;       /* Whether the chunk needs to be inserted into the index */
 
@@ -3567,7 +3572,8 @@ H5D__chunk_write(H5D_io_info_t *io_info, H5D_dset_io_info_t *dset_info)
 
                 /* Lock the chunk into the cache */
                 if (NULL == (chunk = H5D__chunk_lock(io_info, dset_info, &udata, entire_chunk, false)))
-                    HGOTO_ERROR(H5E_IO, H5E_READERROR, FAIL, "unable to read raw data chunk");
+                    HGOTO_ERROR(H5E_IO, H5E_CANTLOCK, FAIL, "unable to lock raw data chunk");
+                chunk_locked = true;
 
                 /* Set up the storage buffer information for this chunk */
                 cpt_store.compact.buf = chunk;
@@ -3621,8 +3627,10 @@ H5D__chunk_write(H5D_io_info_t *io_info, H5D_dset_io_info_t *dset_info)
 
             /* Release the cache lock on the chunk, or insert chunk into index. */
             if (chunk) {
+                chunk_locked = false;
                 if (H5D__chunk_unlock(io_info, dset_info, &udata, true, chunk, dst_accessed_bytes) < 0)
-                    HGOTO_ERROR(H5E_IO, H5E_READERROR, FAIL, "unable to unlock raw data chunk");
+                    HGOTO_ERROR(H5E_IO, H5E_CANTUNLOCK, FAIL, "unable to unlock raw data chunk");
+                chunk = NULL;
             } /* end if */
             else {
                 if (need_insert && dset_info->dset->shared->layout.storage.u.chunk.ops->insert)
@@ -3645,6 +3653,11 @@ H5D__chunk_write(H5D_io_info_t *io_info, H5D_dset_io_info_t *dset_info)
     } /* end else */
 
 done:
+    /* Release chunk lock if we failed while holding it */
+    if (chunk_locked && chunk)
+        if (H5D__chunk_unlock(io_info, dset_info, &udata, false, chunk, dst_accessed_bytes) < 0)
+            HDONE_ERROR(H5E_IO, H5E_CANTUNLOCK, FAIL, "unable to unlock raw data chunk");
+
     /* Free dataset sieve buffer and reset cached fields */
     if (dset_info->dset->shared->cache.sieve.sieve_buf) {
         dset_info->dset->shared->cache.sieve.sieve_loc  = HADDR_UNDEF;
@@ -5709,6 +5722,7 @@ H5D__chunk_update_old_edge_chunks(H5D_t *dset, hsize_t old_dim[])
     H5D_chunk_ud_t      chk_udata;                        /* User data for locking chunk */
     H5D_storage_t       chk_store;                        /* Chunk storage information */
     H5D_dset_io_info_t  chk_dset_info;                    /* Chunked I/O dset info object */
+    bool                chunk_locked = false;             /* Indicates whether the chunk is locked */
     void               *chunk;                            /* The file chunk  */
     bool                carry; /* Flag to indicate that chunk increment carrys to higher dimension (sorta) */
     herr_t              ret_value = SUCCEED; /* Return value */
@@ -5815,11 +5829,13 @@ H5D__chunk_update_old_edge_chunks(H5D_t *dset, hsize_t old_dim[])
                  * updating the chunk to no longer be an edge chunk. */
                 if (NULL ==
                     (chunk = (void *)H5D__chunk_lock(&chk_io_info, &chk_dset_info, &chk_udata, false, true)))
-                    HGOTO_ERROR(H5E_DATASET, H5E_READERROR, FAIL, "unable to lock raw data chunk");
+                    HGOTO_ERROR(H5E_DATASET, H5E_CANTLOCK, FAIL, "unable to lock raw data chunk");
 
                 /* Unlock the chunk */
+                chunk_locked = false;
                 if (H5D__chunk_unlock(&chk_io_info, &chk_dset_info, &chk_udata, true, chunk, (hsize_t)0) < 0)
-                    HGOTO_ERROR(H5E_IO, H5E_WRITEERROR, FAIL, "unable to unlock raw data chunk");
+                    HGOTO_ERROR(H5E_IO, H5E_CANTUNLOCK, FAIL, "unable to unlock raw data chunk");
+                chunk = NULL;
             } /* end if */
 
             /* Increment indices */
@@ -6097,6 +6113,7 @@ H5D__chunk_prune_fill(H5D_chunk_it_ud1_t *udata, bool new_unfilt_chunk)
     H5D_chunk_ud_t       chk_udata;               /* User data for locking chunk */
     hsize_t              bytes_accessed;          /* Bytes accessed in chunk */
     unsigned             u;                       /* Local index variable */
+    bool                 chunk_locked = false;    /* Indicates whether the chunk is locked */
     herr_t               ret_value = SUCCEED;     /* Return value */
 
     FUNC_ENTER_PACKAGE
@@ -6139,7 +6156,8 @@ H5D__chunk_prune_fill(H5D_chunk_it_ud1_t *udata, bool new_unfilt_chunk)
 
     /* Lock the chunk into the cache, to get a pointer to the chunk buffer */
     if (NULL == (chunk = (void *)H5D__chunk_lock(io_info, udata->dset_info, &chk_udata, false, false)))
-        HGOTO_ERROR(H5E_DATASET, H5E_READERROR, FAIL, "unable to lock raw data chunk");
+        HGOTO_ERROR(H5E_DATASET, H5E_CANTLOCK, FAIL, "unable to lock raw data chunk");
+    chunk_locked = true;
 
     /* Fill the selection in the memory buffer */
     /* Use the size of the elements in the chunk directly instead of */
@@ -6175,10 +6193,16 @@ H5D__chunk_prune_fill(H5D_chunk_it_ud1_t *udata, bool new_unfilt_chunk)
     bytes_accessed = sel_nelmts * layout->u.chunk.dim[rank];
 
     /* Release lock on chunk */
+    chunk_locked = false;
     if (H5D__chunk_unlock(io_info, udata->dset_info, &chk_udata, true, chunk, bytes_accessed) < 0)
-        HGOTO_ERROR(H5E_IO, H5E_WRITEERROR, FAIL, "unable to unlock raw data chunk");
+        HGOTO_ERROR(H5E_IO, H5E_CANTUNLOCK, FAIL, "unable to unlock raw data chunk");
+    chunk = NULL;
 
 done:
+    if (chunk_locked && chunk)
+        if (H5D__chunk_unlock(io_info, udata->dset_info, &chk_udata, false, chunk, bytes_accessed) < 0)
+            HDONE_ERROR(H5E_IO, H5E_CANTUNLOCK, FAIL, "unable to unlock raw data chunk");
+
     /* Release the selection iterator */
     if (chunk_iter_init && H5S_SELECT_ITER_RELEASE(chunk_iter) < 0)
         HDONE_ERROR(H5E_DATASET, H5E_CANTFREE, FAIL, "Can't release selection iterator");

--- a/src/H5Dchunk.c
+++ b/src/H5Dchunk.c
@@ -3276,7 +3276,7 @@ H5D__chunk_write(H5D_io_info_t *io_info, H5D_dset_io_info_t *dset_info)
     H5S_t             *chunk_file_spaces_local[8]; /* Local buffer for chunk_file_spaces */
     haddr_t           *chunk_addrs = NULL;         /* Array of chunk addresses */
     haddr_t            chunk_addrs_local[8];       /* Local buffer for chunk_addrs */
-    void              *chunk;                      /* Pointer to locked chunk buffer */
+    void              *chunk = NULL;               /* Pointer to locked chunk buffer */
     H5D_chunk_ud_t     udata;                      /* Index pass-through    */
     bool               chunk_locked = false;       /* Indicates whether the chunk is locked */
     herr_t             ret_value    = SUCCEED;     /* Return value        */
@@ -5723,7 +5723,7 @@ H5D__chunk_update_old_edge_chunks(H5D_t *dset, hsize_t old_dim[])
     H5D_storage_t       chk_store;                        /* Chunk storage information */
     H5D_dset_io_info_t  chk_dset_info;                    /* Chunked I/O dset info object */
     bool                chunk_locked = false;             /* Indicates whether the chunk is locked */
-    void               *chunk;                            /* The file chunk  */
+    void               *chunk = NULL;                     /* The file chunk  */
     bool                carry; /* Flag to indicate that chunk increment carrys to higher dimension (sorta) */
     herr_t              ret_value = SUCCEED; /* Return value */
 
@@ -6109,7 +6109,7 @@ H5D__chunk_prune_fill(H5D_chunk_it_ud1_t *udata, bool new_unfilt_chunk)
     hsize_t              sel_nelmts;              /* Number of elements in selection */
     hsize_t              count[H5O_LAYOUT_NDIMS]; /* Element count of hyperslab */
     size_t               chunk_size;              /*size of a chunk       */
-    void                *chunk;                   /* The file chunk  */
+    void                *chunk = NULL;            /* The file chunk  */
     H5D_chunk_ud_t       chk_udata;               /* User data for locking chunk */
     hsize_t              bytes_accessed;          /* Bytes accessed in chunk */
     unsigned             u;                       /* Local index variable */

--- a/src/H5Dchunk.c
+++ b/src/H5Dchunk.c
@@ -4157,33 +4157,33 @@ H5D__chunk_lookup(const H5D_t *dset, const hsize_t *scaled, H5D_chunk_ud_t *udat
             if ((sc->ops->get_addr)(&idx_info, udata) < 0)
                 HGOTO_ERROR(H5E_DATASET, H5E_CANTGET, FAIL, "can't query chunk address");
 
-                /*
-                * Cache the information retrieved.
-                *
-                * Note that if we are writing to the dataset in parallel and filters
-                * are involved, we skip caching this information as it is highly likely
-                * that the chunk information will be invalidated as a result of the
-                * filter operation (e.g. the chunk gets re-allocated to a different
-                * address in the file and/or gets re-allocated with a different size).
-                * If we were to cache this information, subsequent reads/writes would
-                * retrieve the invalid information and cause a variety of issues.
-                *
-                * It has been verified that in the serial library, when writing to chunks
-                * with the real chunk cache disabled and with filters involved, the
-                * functions within this file are correctly called in such a manner that
-                * this single chunk cache is always updated correctly. Therefore, this
-                * check is not needed for the serial library.
-                *
-                * This is an ugly and potentially frail check, but the
-                * H5D__chunk_cinfo_cache_reset() function is not currently available
-                * to functions outside of this file, so outside functions can not
-                * invalidate this single chunk cache. Even if the function were available,
-                * this check prevents us from doing the work of going through and caching
-                * each chunk in the write operation, when we're only going to invalidate
-                * the cache at the end of a parallel write anyway.
-                *
-                *  - JTH (7/13/2018)
-                */
+                 /*
+                 * Cache the information retrieved.
+                 *
+                 * Note that if we are writing to the dataset in parallel and filters
+                 * are involved, we skip caching this information as it is highly likely
+                 * that the chunk information will be invalidated as a result of the
+                 * filter operation (e.g. the chunk gets re-allocated to a different
+                 * address in the file and/or gets re-allocated with a different size).
+                 * If we were to cache this information, subsequent reads/writes would
+                 * retrieve the invalid information and cause a variety of issues.
+                 *
+                 * It has been verified that in the serial library, when writing to chunks
+                 * with the real chunk cache disabled and with filters involved, the
+                 * functions within this file are correctly called in such a manner that
+                 * this single chunk cache is always updated correctly. Therefore, this
+                 * check is not needed for the serial library.
+                 *
+                 * This is an ugly and potentially frail check, but the
+                 * H5D__chunk_cinfo_cache_reset() function is not currently available
+                 * to functions outside of this file, so outside functions can not
+                 * invalidate this single chunk cache. Even if the function were available,
+                 * this check prevents us from doing the work of going through and caching
+                 * each chunk in the write operation, when we're only going to invalidate
+                 * the cache at the end of a parallel write anyway.
+                 *
+                 *  - JTH (7/13/2018)
+                 */
 #ifdef H5_HAVE_PARALLEL
             if (!((H5F_HAS_FEATURE(idx_info.f, H5FD_FEAT_HAS_MPI)) &&
                   (H5F_INTENT(dset->oloc.file) & H5F_ACC_RDWR) && dset->shared->dcpl_cache.pline.nused))

--- a/src/H5Dchunk.c
+++ b/src/H5Dchunk.c
@@ -3155,7 +3155,7 @@ H5D__chunk_read(H5D_io_info_t *io_info, H5D_dset_io_info_t *dset_info)
             /* Check for non-existent chunk & skip it if appropriate */
             if (H5_addr_defined(udata.chunk_block.offset) || UINT_MAX != udata.idx_hint ||
                 !skip_missing_chunks) {
-                H5D_io_info_t *chk_io_info; /* Pointer to I/O info object for this chunk */
+                H5D_io_info_t *chk_io_info = NULL; /* Pointer to I/O info object for this chunk */
 
                 /* Set chunk's [scaled] coordinates */
                 dset_info->store->chunk.scaled = chunk_info->scaled;
@@ -3196,6 +3196,7 @@ H5D__chunk_read(H5D_io_info_t *io_info, H5D_dset_io_info_t *dset_info)
                 } /* end else */
 
                 /* Perform the actual read operation */
+                assert(chk_io_info);
                 assert(chk_io_info->count == 1);
                 chk_io_info->dsets_info[0].layout_io_info.contig_piece_info = chunk_info;
                 chk_io_info->dsets_info[0].file_space                       = chunk_info->fspace;

--- a/src/H5Dchunk.c
+++ b/src/H5Dchunk.c
@@ -3505,11 +3505,11 @@ H5D__chunk_write(H5D_io_info_t *io_info, H5D_dset_io_info_t *dset_info)
         /* Iterate through nodes in chunk skip list */
         chunk_node = H5D_CHUNK_GET_FIRST_NODE(dset_info);
         while (chunk_node) {
-            H5D_piece_info_t  *chunk_info;  /* Chunk information */
-            H5D_chk_idx_info_t idx_info;    /* Chunked index info */
+            H5D_piece_info_t  *chunk_info;         /* Chunk information */
+            H5D_chk_idx_info_t idx_info;           /* Chunked index info */
             H5D_io_info_t     *chk_io_info = NULL; /* Pointer to I/O info object for this chunk */
-            htri_t             cacheable;   /* Whether the chunk is cacheable */
-            bool need_insert = false;       /* Whether the chunk needs to be inserted into the index */
+            htri_t             cacheable;          /* Whether the chunk is cacheable */
+            bool need_insert = false;              /* Whether the chunk needs to be inserted into the index */
 
             /* Get the actual chunk information from the skip list node */
             chunk_info = H5D_CHUNK_GET_NODE_INFO(dset_info, chunk_node);
@@ -4157,33 +4157,33 @@ H5D__chunk_lookup(const H5D_t *dset, const hsize_t *scaled, H5D_chunk_ud_t *udat
             if ((sc->ops->get_addr)(&idx_info, udata) < 0)
                 HGOTO_ERROR(H5E_DATASET, H5E_CANTGET, FAIL, "can't query chunk address");
 
-                /*
-                 * Cache the information retrieved.
-                 *
-                 * Note that if we are writing to the dataset in parallel and filters
-                 * are involved, we skip caching this information as it is highly likely
-                 * that the chunk information will be invalidated as a result of the
-                 * filter operation (e.g. the chunk gets re-allocated to a different
-                 * address in the file and/or gets re-allocated with a different size).
-                 * If we were to cache this information, subsequent reads/writes would
-                 * retrieve the invalid information and cause a variety of issues.
-                 *
-                 * It has been verified that in the serial library, when writing to chunks
-                 * with the real chunk cache disabled and with filters involved, the
-                 * functions within this file are correctly called in such a manner that
-                 * this single chunk cache is always updated correctly. Therefore, this
-                 * check is not needed for the serial library.
-                 *
-                 * This is an ugly and potentially frail check, but the
-                 * H5D__chunk_cinfo_cache_reset() function is not currently available
-                 * to functions outside of this file, so outside functions can not
-                 * invalidate this single chunk cache. Even if the function were available,
-                 * this check prevents us from doing the work of going through and caching
-                 * each chunk in the write operation, when we're only going to invalidate
-                 * the cache at the end of a parallel write anyway.
-                 *
-                 *  - JTH (7/13/2018)
-                 */
+            /*
+             * Cache the information retrieved.
+             *
+             * Note that if we are writing to the dataset in parallel and filters
+             * are involved, we skip caching this information as it is highly likely
+             * that the chunk information will be invalidated as a result of the
+             * filter operation (e.g. the chunk gets re-allocated to a different
+             * address in the file and/or gets re-allocated with a different size).
+             * If we were to cache this information, subsequent reads/writes would
+             * retrieve the invalid information and cause a variety of issues.
+             *
+             * It has been verified that in the serial library, when writing to chunks
+             * with the real chunk cache disabled and with filters involved, the
+             * functions within this file are correctly called in such a manner that
+             * this single chunk cache is always updated correctly. Therefore, this
+             * check is not needed for the serial library.
+             *
+             * This is an ugly and potentially frail check, but the
+             * H5D__chunk_cinfo_cache_reset() function is not currently available
+             * to functions outside of this file, so outside functions can not
+             * invalidate this single chunk cache. Even if the function were available,
+             * this check prevents us from doing the work of going through and caching
+             * each chunk in the write operation, when we're only going to invalidate
+             * the cache at the end of a parallel write anyway.
+             *
+             *  - JTH (7/13/2018)
+             */
 #ifdef H5_HAVE_PARALLEL
             if (!((H5F_HAS_FEATURE(idx_info.f, H5FD_FEAT_HAS_MPI)) &&
                   (H5F_INTENT(dset->oloc.file) & H5F_ACC_RDWR) && dset->shared->dcpl_cache.pline.nused))
@@ -6083,13 +6083,13 @@ H5D__chunk_prune_fill(H5D_chunk_it_ud1_t *udata, bool new_unfilt_chunk)
     hsize_t              sel_nelmts;              /* Number of elements in selection */
     hsize_t              count[H5O_LAYOUT_NDIMS]; /* Element count of hyperslab */
     size_t               chunk_size;              /*size of a chunk       */
-    void                *chunk          = NULL;   /* The file chunk  */
+    void                *chunk = NULL;            /* The file chunk  */
     H5D_chunk_ud_t       chk_udata;               /* User data for locking chunk */
     hsize_t              bytes_accessed = 0;      /* Bytes accessed in chunk */
     unsigned             u;                       /* Local index variable */
-    bool                 chunk_locked   = false;  /* Indicates whether the chunk is locked */
-    bool                 chunk_dirty    = false;  /* Indicates whether writing is needed */
-    herr_t               ret_value      = SUCCEED;/* Return value */
+    bool                 chunk_locked = false;    /* Indicates whether the chunk is locked */
+    bool                 chunk_dirty  = false;    /* Indicates whether writing is needed */
+    herr_t               ret_value    = SUCCEED;  /* Return value */
 
     FUNC_ENTER_PACKAGE
 

--- a/src/H5Dchunk.c
+++ b/src/H5Dchunk.c
@@ -4157,33 +4157,33 @@ H5D__chunk_lookup(const H5D_t *dset, const hsize_t *scaled, H5D_chunk_ud_t *udat
             if ((sc->ops->get_addr)(&idx_info, udata) < 0)
                 HGOTO_ERROR(H5E_DATASET, H5E_CANTGET, FAIL, "can't query chunk address");
 
-            /*
-             * Cache the information retrieved.
-             *
-             * Note that if we are writing to the dataset in parallel and filters
-             * are involved, we skip caching this information as it is highly likely
-             * that the chunk information will be invalidated as a result of the
-             * filter operation (e.g. the chunk gets re-allocated to a different
-             * address in the file and/or gets re-allocated with a different size).
-             * If we were to cache this information, subsequent reads/writes would
-             * retrieve the invalid information and cause a variety of issues.
-             *
-             * It has been verified that in the serial library, when writing to chunks
-             * with the real chunk cache disabled and with filters involved, the
-             * functions within this file are correctly called in such a manner that
-             * this single chunk cache is always updated correctly. Therefore, this
-             * check is not needed for the serial library.
-             *
-             * This is an ugly and potentially frail check, but the
-             * H5D__chunk_cinfo_cache_reset() function is not currently available
-             * to functions outside of this file, so outside functions can not
-             * invalidate this single chunk cache. Even if the function were available,
-             * this check prevents us from doing the work of going through and caching
-             * each chunk in the write operation, when we're only going to invalidate
-             * the cache at the end of a parallel write anyway.
-             *
-             *  - JTH (7/13/2018)
-             */
+                /*
+                * Cache the information retrieved.
+                *
+                * Note that if we are writing to the dataset in parallel and filters
+                * are involved, we skip caching this information as it is highly likely
+                * that the chunk information will be invalidated as a result of the
+                * filter operation (e.g. the chunk gets re-allocated to a different
+                * address in the file and/or gets re-allocated with a different size).
+                * If we were to cache this information, subsequent reads/writes would
+                * retrieve the invalid information and cause a variety of issues.
+                *
+                * It has been verified that in the serial library, when writing to chunks
+                * with the real chunk cache disabled and with filters involved, the
+                * functions within this file are correctly called in such a manner that
+                * this single chunk cache is always updated correctly. Therefore, this
+                * check is not needed for the serial library.
+                *
+                * This is an ugly and potentially frail check, but the
+                * H5D__chunk_cinfo_cache_reset() function is not currently available
+                * to functions outside of this file, so outside functions can not
+                * invalidate this single chunk cache. Even if the function were available,
+                * this check prevents us from doing the work of going through and caching
+                * each chunk in the write operation, when we're only going to invalidate
+                * the cache at the end of a parallel write anyway.
+                *
+                *  - JTH (7/13/2018)
+                */
 #ifdef H5_HAVE_PARALLEL
             if (!((H5F_HAS_FEATURE(idx_info.f, H5FD_FEAT_HAS_MPI)) &&
                   (H5F_INTENT(dset->oloc.file) & H5F_ACC_RDWR) && dset->shared->dcpl_cache.pline.nused))

--- a/src/H5Dchunk.c
+++ b/src/H5Dchunk.c
@@ -2919,7 +2919,7 @@ H5D__chunk_read(H5D_io_info_t *io_info, H5D_dset_io_info_t *dset_info)
     H5S_t             *chunk_file_spaces_local[8];  /* Local buffer for chunk_file_spaces */
     haddr_t           *chunk_addrs = NULL;          /* Array of chunk addresses */
     haddr_t            chunk_addrs_local[8];        /* Local buffer for chunk_addrs */
-    void              *chunk = NULL;                /* Pointer to locked chunk buffer */
+    void              *chunk        = NULL;         /* Pointer to locked chunk buffer */
     bool               chunk_locked = false;        /* Indicates whether the chunk is locked */
     H5D_chunk_ud_t     udata;                       /* Chunk index pass-through    */
     herr_t             ret_value = SUCCEED;         /*return value        */
@@ -3155,7 +3155,7 @@ H5D__chunk_read(H5D_io_info_t *io_info, H5D_dset_io_info_t *dset_info)
             /* Check for non-existent chunk & skip it if appropriate */
             if (H5_addr_defined(udata.chunk_block.offset) || UINT_MAX != udata.idx_hint ||
                 !skip_missing_chunks) {
-                H5D_io_info_t *chk_io_info;  /* Pointer to I/O info object for this chunk */
+                H5D_io_info_t *chk_io_info; /* Pointer to I/O info object for this chunk */
 
                 /* Set chunk's [scaled] coordinates */
                 dset_info->store->chunk.scaled = chunk_info->scaled;
@@ -3279,7 +3279,7 @@ H5D__chunk_write(H5D_io_info_t *io_info, H5D_dset_io_info_t *dset_info)
     void              *chunk;                      /* Pointer to locked chunk buffer */
     H5D_chunk_ud_t     udata;                      /* Index pass-through    */
     bool               chunk_locked = false;       /* Indicates whether the chunk is locked */
-    herr_t             ret_value = SUCCEED;        /* Return value        */
+    herr_t             ret_value    = SUCCEED;     /* Return value        */
 
     FUNC_ENTER_PACKAGE
 
@@ -3389,7 +3389,7 @@ H5D__chunk_write(H5D_io_info_t *io_info, H5D_dset_io_info_t *dset_info)
             if (cacheable) {
                 /* Load the chunk into cache.  But if the whole chunk is written,
                  * simply allocate space instead of load the chunk. */
-                bool  entire_chunk = true; /* Whether whole chunk is selected */
+                bool entire_chunk = true; /* Whether whole chunk is selected */
 
                 /* Compute # of bytes accessed in chunk */
                 H5_CHECK_OVERFLOW(dset_info->type_info.dst_type_size, /*From:*/ size_t, /*To:*/ hsize_t);
@@ -6114,7 +6114,7 @@ H5D__chunk_prune_fill(H5D_chunk_it_ud1_t *udata, bool new_unfilt_chunk)
     hsize_t              bytes_accessed;          /* Bytes accessed in chunk */
     unsigned             u;                       /* Local index variable */
     bool                 chunk_locked = false;    /* Indicates whether the chunk is locked */
-    herr_t               ret_value = SUCCEED;     /* Return value */
+    herr_t               ret_value    = SUCCEED;  /* Return value */
 
     FUNC_ENTER_PACKAGE
 

--- a/src/H5Dchunk.c
+++ b/src/H5Dchunk.c
@@ -3121,25 +3121,37 @@ H5D__chunk_read(H5D_io_info_t *io_info, H5D_dset_io_info_t *dset_info)
                 /* Set chunk's [scaled] coordinates */
                 dset_info->store->chunk.scaled = chunk_info->scaled;
 
-                /* Determine if we should use the chunk cache */
-                if ((cacheable = H5D__chunk_cacheable(io_info, dset_info, udata.chunk_block.offset, false)) <
-                    0)
-                    HGOTO_ERROR(H5E_DATASET, H5E_CANTGET, FAIL, "can't tell if chunk is cacheable");
-                if (cacheable) {
-                    /* Load the chunk into cache and lock it. */
+                /* Don't lock the chunk if it doesn't exist on disk or in cache, to avoid unnecessary
+                 * allocation and conversion */
+                if (H5_addr_defined(udata.chunk_block.offset) || UINT_MAX != udata.idx_hint) {
+                    /* Determine if we should use the chunk cache */
+                    if ((cacheable =
+                             H5D__chunk_cacheable(io_info, dset_info, udata.chunk_block.offset, false)) < 0)
+                        HGOTO_ERROR(H5E_DATASET, H5E_CANTGET, FAIL, "can't tell if chunk is cacheable");
+                    if (cacheable) {
+                        /* Load the chunk into cache and lock it. */
 
-                    /* Compute # of bytes accessed in chunk */
-                    H5_CHECK_OVERFLOW(dset_info->type_info.src_type_size, /*From:*/ size_t, /*To:*/ hsize_t);
-                    src_accessed_bytes =
-                        chunk_info->piece_points * (hsize_t)dset_info->type_info.src_type_size;
+                        /* Compute # of bytes accessed in chunk */
+                        H5_CHECK_OVERFLOW(dset_info->type_info.src_type_size, /*From:*/ size_t,
+                                          /*To:*/ hsize_t);
+                        src_accessed_bytes =
+                            chunk_info->piece_points * (hsize_t)dset_info->type_info.src_type_size;
 
-                    /* Lock the chunk into the cache */
-                    if (NULL == (chunk = H5D__chunk_lock(io_info, dset_info, &udata, false, false)))
-                        HGOTO_ERROR(H5E_IO, H5E_CANTLOCK, FAIL, "unable to lock raw data chunk");
-                    chunk_locked = true;
+                        /* Lock the chunk into the cache */
+                        if (NULL == (chunk = H5D__chunk_lock(io_info, dset_info, &udata, false, false)))
+                            HGOTO_ERROR(H5E_IO, H5E_CANTLOCK, FAIL, "unable to lock raw data chunk");
+                        chunk_locked = true;
 
-                    /* Set up the storage buffer information for this chunk */
-                    cpt_store.compact.buf = chunk;
+                        /* Set up the storage buffer information for this chunk */
+                        cpt_store.compact.buf = chunk;
+
+                        /* Point I/O info at contiguous I/O info for this chunk */
+                        chk_io_info = &cpt_io_info;
+                    }
+                    else {
+                        /* Since the chunk isn't cacheable it must not be in cache, therefore it must exist on
+                         * disk if it made it into the outer if statement */
+                        assert(H5_addr_defined(udata.chunk_block.offset));
 
                         /* Set up the storage address information for this chunk */
                         ctg_store.contig.dset_addr = udata.chunk_block.offset;
@@ -3148,23 +3160,29 @@ H5D__chunk_read(H5D_io_info_t *io_info, H5D_dset_io_info_t *dset_info)
                         chk_io_info = &ctg_io_info;
                     }
 
-                /* Perform the actual read operation */
-                assert(chk_io_info);
-                assert(chk_io_info->count == 1);
-                chk_io_info->dsets_info[0].layout_io_info.contig_piece_info = chunk_info;
-                chk_io_info->dsets_info[0].file_space                       = chunk_info->fspace;
-                chk_io_info->dsets_info[0].mem_space                        = chunk_info->mspace;
-                chk_io_info->dsets_info[0].nelmts                           = chunk_info->piece_points;
-                if ((dset_info->io_ops.single_read)(chk_io_info, &chk_io_info->dsets_info[0]) < 0)
-                    HGOTO_ERROR(H5E_DATASET, H5E_READERROR, FAIL, "chunked read failed");
+                    /* Perform the actual read operation */
+                    assert(chk_io_info);
+                    assert(chk_io_info->count == 1);
+                    chk_io_info->dsets_info[0].layout_io_info.contig_piece_info = chunk_info;
+                    chk_io_info->dsets_info[0].file_space                       = chunk_info->fspace;
+                    chk_io_info->dsets_info[0].mem_space                        = chunk_info->mspace;
+                    chk_io_info->dsets_info[0].nelmts                           = chunk_info->piece_points;
+                    if ((dset_info->io_ops.single_read)(chk_io_info, &chk_io_info->dsets_info[0]) < 0)
+                        HGOTO_ERROR(H5E_DATASET, H5E_READERROR, FAIL, "chunked read failed");
 
-                /* Release the cache lock on the chunk */
-                chunk_locked = false;
-                if (chunk &&
-                    H5D__chunk_unlock(io_info, dset_info, &udata, false, chunk, src_accessed_bytes) < 0)
-                    HGOTO_ERROR(H5E_IO, H5E_CANTUNLOCK, FAIL, "unable to unlock raw data chunk");
-                chunk = NULL;
-            } /* end if */
+                    /* Release the cache lock on the chunk */
+                    chunk_locked = false;
+                    if (chunk &&
+                        H5D__chunk_unlock(io_info, dset_info, &udata, false, chunk, src_accessed_bytes) < 0)
+                        HGOTO_ERROR(H5E_IO, H5E_CANTUNLOCK, FAIL, "unable to unlock raw data chunk");
+                    chunk = NULL;
+                } /* end if */
+                else
+                    /* Write fill values to memory buffer */
+                    if (H5D__fill(dset_info->dset->shared->dcpl_cache.fill.buf, dset_info->dset->shared->type,
+                                  dset_info->buf.vp, dset_info->type_info.mem_type, chunk_info->mspace) < 0)
+                        HGOTO_ERROR(H5E_DATASET, H5E_CANTINIT, FAIL, "filling buf failed");
+            }
 
             /* Advance to next chunk in list */
             chunk_node = H5D_CHUNK_GET_NEXT_NODE(dset_info, chunk_node);

--- a/src/H5Dchunk.c
+++ b/src/H5Dchunk.c
@@ -6111,7 +6111,7 @@ H5D__chunk_prune_fill(H5D_chunk_it_ud1_t *udata, bool new_unfilt_chunk)
     size_t               chunk_size;              /*size of a chunk       */
     void                *chunk = NULL;            /* The file chunk  */
     H5D_chunk_ud_t       chk_udata;               /* User data for locking chunk */
-    hsize_t              bytes_accessed;          /* Bytes accessed in chunk */
+    hsize_t              bytes_accessed = 0;      /* Bytes accessed in chunk */
     unsigned             u;                       /* Local index variable */
     bool                 chunk_locked = false;    /* Indicates whether the chunk is locked */
     herr_t               ret_value    = SUCCEED;  /* Return value */

--- a/src/H5Dchunk.c
+++ b/src/H5Dchunk.c
@@ -3205,7 +3205,7 @@ H5D__chunk_read(H5D_io_info_t *io_info, H5D_dset_io_info_t *dset_info)
                     if (chunk &&
                         H5D__chunk_unlock(io_info, dset_info, &udata, false, chunk, src_accessed_bytes) < 0)
                         HGOTO_ERROR(H5E_IO, H5E_READERROR, FAIL, "unable to unlock raw data chunk");
-                     HGOTO_ERROR(H5E_DATASET, H5E_READERROR, FAIL, "chunked read failed");
+                    HGOTO_ERROR(H5E_DATASET, H5E_READERROR, FAIL, "chunked read failed");
                 }
 
                 /* Release the cache lock on the chunk in normal flow */


### PR DESCRIPTION
The H5D__chunk_lock() call has a matching H5D__chunk_unlock() in normal conditions, but it is missing when an operation fails after H5D__chunk_lock() succeeds.

Updated: This PR adds a chunk_locked flag to track whether a chunk is currently locked, ensuring that H5D__chunk_unlock is called in the cleanup section when a failure occurs while a chunk is locked. The flag is set to true after a successful lock and set to false before the unlock call to prevent a double-free in case the unlock itself fails. The chunk pointer is also reset to NULL after each successful unlock to avoid stale pointer references across loop iterations.

Fixes #6454 