### PR TITLE
Fix macos-26 workflow failure;  update nvhpc version to 26.5

### DIFF
--- a/.github/workflows/macos-26-matrix.yml
+++ b/.github/workflows/macos-26-matrix.yml
@@ -236,7 +236,7 @@ jobs:
           elif [[ "${{ matrix.mpi }}" == "mpich" ]]; then
             CMAKE_OPTS="$CMAKE_OPTS -DMPI_C_COMPILER=mpicc"
             CMAKE_OPTS="$CMAKE_OPTS -DCMAKE_Fortran_COMPILER=mpifort"
-            sudo ln -s /opt/homebrew/bin/gfortran-15 /opt/homebrew/bin/gfortran
+            #sudo ln -s /opt/homebrew/bin/gfortran-15 /opt/homebrew/bin/gfortran
             mpifort --version
           fi
         fi

--- a/.github/workflows/macos-26-matrix.yml
+++ b/.github/workflows/macos-26-matrix.yml
@@ -236,7 +236,6 @@ jobs:
           elif [[ "${{ matrix.mpi }}" == "mpich" ]]; then
             CMAKE_OPTS="$CMAKE_OPTS -DMPI_C_COMPILER=mpicc"
             CMAKE_OPTS="$CMAKE_OPTS -DCMAKE_Fortran_COMPILER=mpifort"
-            #sudo ln -s /opt/homebrew/bin/gfortran-15 /opt/homebrew/bin/gfortran
             mpifort --version
           fi
         fi

--- a/.github/workflows/nvhpc.yml
+++ b/.github/workflows/nvhpc.yml
@@ -21,8 +21,8 @@ jobs:
     runs-on: ubuntu-latest
     env:
       CUDAVERDOT: "13.1"
-      NVERDOT: "26.3"
-      NVERDASH: "26-3"
+      NVERDOT: "26.5"
+      NVERDASH: "26-5"
 
     steps:
       - name: Get Sources

--- a/.github/workflows/nvhpc.yml
+++ b/.github/workflows/nvhpc.yml
@@ -20,7 +20,7 @@ jobs:
     name: "nvhpc ${{ inputs.build_mode }}"
     runs-on: ubuntu-latest
     env:
-      CUDAVERDOT: "13.1"
+      CUDAVERDOT: "13.2"
       NVERDOT: "26.5"
       NVERDASH: "26-5"
 


### PR DESCRIPTION
macos-26-matrix.yml created a symbolic gfortran link to gfortran-15 that began failing when homebrew apparently added gfortran.  The workflow runs without the link.

 