### PR TITLE
Install the hdf5.tag file to the html directory

### DIFF
--- a/docs/doxygen/CMakeLists.txt
+++ b/docs/doxygen/CMakeLists.txt
@@ -71,7 +71,7 @@ if (DOXYGEN_FOUND)
   )
   install (
       FILES ${HDF5_BINARY_DIR}/hdf5.tag
-      DESTINATION ${HDF5_INSTALL_DOC_DIR}
+      DESTINATION ${HDF5_INSTALL_DOC_DIR}/html
       COMPONENT hdfdocuments
   )
 


### PR DESCRIPTION
Moves the hdf5.tag file to ${HDF5_INSTALL_DOC_DIR}/html which defaults to ${PREFIX}/share/html. The intention is to deploy the hdf5.tag file to https://support.hdfgroup.org/documentation/hdf5/latest/hdf5.tag

This may fix https://github.com/HDFGroup/hdf5/issues/5593