### PR TITLE
Publish hdf5.tag alongside the Doxygen HTML documentation

### DIFF
--- a/.github/workflows/ctest.yml
+++ b/.github/workflows/ctest.yml
@@ -540,6 +540,13 @@ jobs:
               path: ${{ runner.workspace }}/buildrpm/${{ steps.set-file-base.outputs.FILE_BASE }}-ubuntu-2404_gcc.rpm
               if-no-files-found: error # 'warn' or 'ignore' are also available, defaults to `warn`
 
+      # Verify the doxygen tag file was generated inside the html output
+      # directory so it is captured by the docs-doxygen artifact below and
+      # published alongside the HTML documentation (e.g. to
+      # https://support.hdfgroup.org/documentation/hdf5/latest/hdf5.tag).
+      - name: Verify hdf5.tag is present (Linux)
+        run: test -f "${{ runner.workspace }}/hdf5/build/${{ steps.run-ctest.outputs.ACTIVE_PRESET }}/hdf5lib_docs/html/hdf5.tag"
+
       # Save doxygen files created by CTest script
       - name: Save published doxygen (Linux)
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v5

--- a/.github/workflows/ctest.yml
+++ b/.github/workflows/ctest.yml
@@ -540,9 +540,9 @@ jobs:
               path: ${{ runner.workspace }}/buildrpm/${{ steps.set-file-base.outputs.FILE_BASE }}-ubuntu-2404_gcc.rpm
               if-no-files-found: error # 'warn' or 'ignore' are also available, defaults to `warn`
 
-      # Verify the doxygen tag file was generated inside the html output
+      # Verify the Doxygen tag file was generated inside the HTML output
       # directory so it is captured by the docs-doxygen artifact below and
-      # published alongside the HTML documentation (e.g. to
+      # published alongside the HTML documentation (e.g., to
       # https://support.hdfgroup.org/documentation/hdf5/latest/hdf5.tag).
       - name: Verify hdf5.tag is present (Linux)
         env:

--- a/.github/workflows/ctest.yml
+++ b/.github/workflows/ctest.yml
@@ -545,7 +545,15 @@ jobs:
       # published alongside the HTML documentation (e.g. to
       # https://support.hdfgroup.org/documentation/hdf5/latest/hdf5.tag).
       - name: Verify hdf5.tag is present (Linux)
-        run: test -f "${{ runner.workspace }}/hdf5/build/${{ steps.run-ctest.outputs.ACTIVE_PRESET }}/hdf5lib_docs/html/hdf5.tag"
+        env:
+          TAG_FILE: ${{ runner.workspace }}/hdf5/build/${{ steps.run-ctest.outputs.ACTIVE_PRESET }}/hdf5lib_docs/html/hdf5.tag
+        run: |
+          if [ ! -f "$TAG_FILE" ]; then
+            echo "::error::Expected doxygen tag file not found: $TAG_FILE"
+            echo "The hdf5.tag file must be generated inside the doxygen html output directory so it is included in the docs-doxygen artifact."
+            exit 1
+          fi
+          echo "Found doxygen tag file: $TAG_FILE"
 
       # Save doxygen files created by CTest script
       - name: Save published doxygen (Linux)

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -140,6 +140,13 @@ jobs:
               echo "❌ Documentation extraction failed"
               exit 1
             fi
+            # The doxygen tag file is published alongside the HTML docs
+            if [ -f "${{ inputs.file_name }}.doxygen/hdf5.tag" ]; then
+              echo "✅ Found: hdf5.tag"
+            else
+              echo "❌ hdf5.tag not found in documentation"
+              exit 1
+            fi
           else
             echo "⚠️  Documentation file not found, skipping..."
           fi

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -128,20 +128,22 @@ jobs:
           echo "✅ Release files sync completed"
 
       - name: Process documentation
+        env:
+          FILE_NAME: ${{ inputs.file_name }}
         run: |
           set -euo pipefail
-          DOC_FILE="HDF5/${{ inputs.file_name }}.doxygen.zip"
+          DOC_FILE="HDF5/${FILE_NAME}.doxygen.zip"
           if [ -f "$DOC_FILE" ]; then
             echo "📚 Processing documentation..."
             unzip -q "$DOC_FILE"
-            if [ -d "${{ inputs.file_name }}.doxygen" ]; then
+            if [ -d "${FILE_NAME}.doxygen" ]; then
               echo "✅ Documentation extracted successfully"
             else
               echo "❌ Documentation extraction failed"
               exit 1
             fi
             # The doxygen tag file is published alongside the HTML docs
-            if [ -f "${{ inputs.file_name }}.doxygen/hdf5.tag" ]; then
+            if [ -f "${FILE_NAME}.doxygen/hdf5.tag" ]; then
               echo "✅ Found: hdf5.tag"
             else
               echo "❌ hdf5.tag not found in documentation"

--- a/docs/doxygen/CMakeLists.txt
+++ b/docs/doxygen/CMakeLists.txt
@@ -26,7 +26,7 @@ if (DOXYGEN_FOUND)
   set (DOXYGEN_HTML_FOOTER ${HDF5_DOXYGEN_DIR}/hdf5_footer.html)
   set (DOXYGEN_HTML_EXTRA_STYLESHEET "${HDF5_DOXYGEN_DIR}/hdf5doxy.css ${HDF5_DOXYGEN_DIR}/doxygen-awesome.css")
   set (DOXYGEN_HTML_EXTRA_FILES "${HDF5_DOXYGEN_DIR}/hdf5_navtree_hacks.js ${HDF5_DOXYGEN_DIR}/doxygen-awesome-tabs.js")
-  set (DOXYGEN_TAG_FILE ${HDF5_BINARY_DIR}/hdf5lib_docs/html/hdf5.tag)
+  set (DOXYGEN_TAG_FILE ${DOXYGEN_OUTPUT_DIRECTORY}/html/hdf5.tag)
   set (DOXYGEN_SERVER_BASED_SEARCH NO)
   set (DOXYGEN_EXTERNAL_SEARCH NO)
   set (DOXYGEN_SEARCHENGINE_URL)
@@ -70,7 +70,7 @@ if (DOXYGEN_FOUND)
   # output directory also ensures it is captured by the docs-doxygen CI artifact
   # that publishes the documentation (and hdf5.tag) to S3.
   install (
-      DIRECTORY ${HDF5_BINARY_DIR}/hdf5lib_docs/html
+      DIRECTORY ${DOXYGEN_OUTPUT_DIRECTORY}/html
       DESTINATION ${HDF5_INSTALL_DOC_DIR}
       COMPONENT hdfdocuments
   )

--- a/docs/doxygen/CMakeLists.txt
+++ b/docs/doxygen/CMakeLists.txt
@@ -26,7 +26,7 @@ if (DOXYGEN_FOUND)
   set (DOXYGEN_HTML_FOOTER ${HDF5_DOXYGEN_DIR}/hdf5_footer.html)
   set (DOXYGEN_HTML_EXTRA_STYLESHEET "${HDF5_DOXYGEN_DIR}/hdf5doxy.css ${HDF5_DOXYGEN_DIR}/doxygen-awesome.css")
   set (DOXYGEN_HTML_EXTRA_FILES "${HDF5_DOXYGEN_DIR}/hdf5_navtree_hacks.js ${HDF5_DOXYGEN_DIR}/doxygen-awesome-tabs.js")
-  set (DOXYGEN_TAG_FILE ${HDF5_BINARY_DIR}/hdf5.tag)
+  set (DOXYGEN_TAG_FILE ${HDF5_BINARY_DIR}/hdf5lib_docs/html/hdf5.tag)
   set (DOXYGEN_SERVER_BASED_SEARCH NO)
   set (DOXYGEN_EXTERNAL_SEARCH NO)
   set (DOXYGEN_SEARCHENGINE_URL)
@@ -64,14 +64,14 @@ if (DOXYGEN_FOUND)
   # Replace variables inside @@ with the current values
   configure_file (${HDF5_DOXYGEN_DIR}/Doxyfile.in ${HDF5_BINARY_DIR}/Doxyfile @ONLY)
 
+  # The hdf5.tag file is generated inside hdf5lib_docs/html (see
+  # DOXYGEN_TAG_FILE above), so this DIRECTORY install also installs it to
+  # ${HDF5_INSTALL_DOC_DIR}/html/hdf5.tag. Keeping the tag file within the html
+  # output directory also ensures it is captured by the docs-doxygen CI artifact
+  # that publishes the documentation (and hdf5.tag) to S3.
   install (
       DIRECTORY ${HDF5_BINARY_DIR}/hdf5lib_docs/html
       DESTINATION ${HDF5_INSTALL_DOC_DIR}
-      COMPONENT hdfdocuments
-  )
-  install (
-      FILES ${HDF5_BINARY_DIR}/hdf5.tag
-      DESTINATION ${HDF5_INSTALL_DOC_DIR}/html
       COMPONENT hdfdocuments
   )
 


### PR DESCRIPTION
## Summary

Follow-up to #6535. That PR moved the **install** destination of `hdf5.tag` to `${HDF5_INSTALL_DOC_DIR}/html`, intending to deploy it to https://support.hdfgroup.org/documentation/hdf5/latest/hdf5.tag. However, the S3-published web docs do not come from the install tree — they come from the `docs-doxygen` GitHub Actions artifact, which is uploaded from the **build tree** (`hdf5lib_docs/html`, see `ctest.yml`). The tag file was generated at the build *root* (`${HDF5_BINARY_DIR}/hdf5.tag`), a sibling of `hdf5lib_docs/`, so it never made it into the artifact or any downstream publish.

This PR generates the tag file **inside** `hdf5lib_docs/html/` so it is captured by the `docs-doxygen` artifact and flows to every destination that consumes it:

- `daily-schedule.yml` → `documentation/hdf5/latest/hdf5.tag` (the primary target URL)
- `release-files.yml` → included in `*.doxygen.zip`
- `publish-release.yml` → `…/documentation/doxygen/hdf5.tag`
- `publish-branch.yml` → included wherever the html dir is synced

## Changes

- **`docs/doxygen/CMakeLists.txt`**: point `DOXYGEN_TAG_FILE` at `${HDF5_BINARY_DIR}/hdf5lib_docs/html/hdf5.tag`. The existing `DIRECTORY` install of `hdf5lib_docs/html` now installs the tag file to `${HDF5_INSTALL_DOC_DIR}/html/hdf5.tag` (preserving #6535's intent), so the redundant standalone `install(FILES … hdf5.tag …)` is removed — it would otherwise reference a file no longer present at the build root.
- **`.github/workflows/ctest.yml`**: verify `hdf5.tag` exists before uploading the `docs-doxygen` artifact.
- **`.github/workflows/publish-release.yml`**: verify `hdf5.tag` is present after extracting the documentation zip.

## Testing

Built docs locally with `-DHDF5_BUILD_DOC=ON` (doxygen 1.9.8):

- `hdf5lib_docs/html/hdf5.tag` is generated (and no longer at the build root)
- `cmake --install --component hdfdocuments` places it at `share/doc/HDF5/html/hdf5.tag` with no missing-file error

🤖 Generated with [Claude Code](https://claude.com/claude-code)