### PR TITLE
Stabilize nvhpc CI: avoid flaky UCX worker failures

### DIFF
--- a/.github/workflows/nvhpc.yml
+++ b/.github/workflows/nvhpc.yml
@@ -23,6 +23,16 @@ jobs:
       CUDAVERDOT: "13.2"
       NVERDOT: "26.5"
       NVERDASH: "26-5"
+      # CI stabilization: GitHub-hosted runners have no real InfiniBand, and the
+      # Open MPI bundled with NVIDIA HPC-X sometimes has UCX select a
+      # non-functional verbs interface (e.g. ud_verbs/mana_0), causing
+      # intermittent "Failed to create UCP worker" / MPI_Init unreachable (-12)
+      # failures. Force ob1 + tcp/shared-memory transports and skip UCX.
+      OMPI_MCA_pml: ob1
+      OMPI_MCA_btl: self,tcp,sm
+      OMPI_MCA_mtl: ^ucx
+      UCX_TLS: tcp,self,sm
+      OMPI_MCA_btl_tcp_if_exclude: lo,docker0
 
     steps:
       - name: Get Sources


### PR DESCRIPTION
## Summary
- The `nvhpc Workflows / nvhpc Release` job intermittently fails during the "Run Tests" step with `Failed to create UCP worker` / `MPI_INIT has failed because at least one MPI process is unreachable`, e.g. https://github.com/HDFGroup/hdf5/actions/runs/29780673970/job/88627182999
- Root cause: GitHub-hosted runners have no real InfiniBand, and the Open MPI bundled with NVIDIA HPC-X ships UCX, which sometimes selects a non-functional verbs interface (`ud_verbs/mana_0`) on these runners.
- Fix: set job-level env vars on `nvhpc_build_and_test` to force Open MPI onto `ob1` + `tcp,self,sm` transports and skip UCX entirely (`OMPI_MCA_pml=ob1`, `OMPI_MCA_btl=self,tcp,sm`, `OMPI_MCA_mtl=^ucx`, `UCX_TLS=tcp,self,sm`, `OMPI_MCA_btl_tcp_if_exclude=lo,docker0`).
- `main-par.yml` is unaffected (it uses Ubuntu's `openmpi-bin` package, not HPC-X's UCX-enabled Open MPI), so it isn't touched here — confirmed by checking recent `hdf5 dev cmake CI` runs, where the `main-par.yml`-driven Parallel jobs pass consistently while `nvhpc Release` fails intermittently.
- This flake has been causing spurious CI failures unrelated to the actual changes on other open PRs (e.g. #6545).

## Test plan
- [ ] Confirm the `nvhpc Workflows / nvhpc Release` job passes on this PR's CI run
- [ ] Watch subsequent `develop` runs for absence of the `Failed to create UCP worker` error (failure was intermittent, so a single green run isn't full proof but is the practical signal here)

🤖 Generated with [Claude Code](https://claude.com/claude-code)