### PR TITLE
Reviewed 2.0.0 occurrences in workflow files, updated "previous release"

### DIFF
--- a/.github/workflows/daily-build.yml
+++ b/.github/workflows/daily-build.yml
@@ -162,7 +162,7 @@ jobs:
     uses: ./.github/workflows/abi-report.yml
     with:
       # previous release version
-      file_ref: '2.0.0'
+      file_ref: '2.1.0'
       file_base: ${{ needs.call-workflow-tarball.outputs.file_base }}
       use_tag: snapshot
       use_environ: snapshots

--- a/.github/workflows/main-spc.yml
+++ b/.github/workflows/main-spc.yml
@@ -309,7 +309,7 @@ jobs:
         working-directory: ${{ runner.workspace }}/build
 
   build_v2_0_linux:
-    name: "gcc DBG v2.0.0 default API no deprecated"
+    name: "gcc DBG v200 default API no deprecated"
     runs-on: ubuntu-latest
     steps:
       # SETUP
@@ -365,7 +365,7 @@ jobs:
         working-directory: ${{ runner.workspace }}/build
 
   build_v2_0_win:
-    name: "Intel DBG v2.0.0 default API no deprecated"
+    name: "Intel DBG v200 default API no deprecated"
     runs-on: windows-2022
     steps:
       # SETUP

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -83,7 +83,7 @@ jobs:
     uses: ./.github/workflows/abi-report.yml
     with:
       # previous release version
-      file_ref: '2.0.0'
+      file_ref: '2.1.0'
       file_base: ${{ needs.call-workflow-tarball.outputs.file_base }}
       use_tag: ${{ needs.log-the-inputs.outputs.rel_tag }}
       use_environ: release


### PR DESCRIPTION
versions to 2.1.0, changed default api tags to v200 and did not change azure/trusted-signing-action versions.