### PR TITLE
Solaris: only pass SunPro -erroff to SunPro compilers

### DIFF
--- a/config/flags/HDFCompilerCXXFlags.cmake
+++ b/config/flags/HDFCompilerCXXFlags.cmake
@@ -90,7 +90,14 @@ if (CMAKE_CXX_COMPILER_LOADED)
   #-----------------------------------------------------------------------------
 
   if (${CMAKE_SYSTEM_NAME} MATCHES "SunOS")
-    list (APPEND HDF5_CMAKE_CXX_FLAGS "-erroff=%none -DBSD_COMP")
+    # -erroff is an Oracle Developer Studio (SunPro) option. gcc quietly ignores
+    # it (it parses the leading -e as the linker entry option) but clang rejects
+    # it, so only hand it to the compiler that understands it. Each flag must be
+    # a separate list element or they are passed as one bogus argument.
+    if (CMAKE_CXX_COMPILER_ID MATCHES "SunPro")
+      list (APPEND HDF5_CMAKE_CXX_FLAGS "-erroff=%none")
+    endif ()
+    list (APPEND HDF5_CMAKE_CXX_FLAGS "-DBSD_COMP")
   else ()
     # General flags
     #

--- a/config/flags/HDFCompilerFlags.cmake
+++ b/config/flags/HDFCompilerFlags.cmake
@@ -96,7 +96,14 @@ if (HDF5_ENABLE_WARNINGS_AS_ERRORS)
 endif ()
 
 if (${CMAKE_SYSTEM_NAME} MATCHES "SunOS")
-  list (APPEND HDF5_CMAKE_C_FLAGS "-erroff=%none -DBSD_COMP")
+  # -erroff is an Oracle Developer Studio (SunPro) option. gcc quietly ignores
+  # it (it parses the leading -e as the linker entry option) but clang rejects
+  # it, so only hand it to the compiler that understands it. Each flag must be
+  # a separate list element or they are passed as one bogus argument.
+  if (CMAKE_C_COMPILER_ID MATCHES "SunPro")
+    list (APPEND HDF5_CMAKE_C_FLAGS "-erroff=%none")
+  endif ()
+  list (APPEND HDF5_CMAKE_C_FLAGS "-DBSD_COMP")
 else ()
   # General flags
   #


### PR DESCRIPTION
Fixes #6569

### Problem

On Solaris, both flag files append the SunPro-only `-erroff` option for *every* compiler, bundled with `-DBSD_COMP` in a single list element:

```cmake
if (${CMAKE_SYSTEM_NAME} MATCHES "SunOS")
  list (APPEND HDF5_CMAKE_C_FLAGS "-erroff=%none -DBSD_COMP")
```

Since that is one list element, `target_compile_options()` passes it to the compiler as one argument. Clang rejects it and the build fails on the very first object file:

```
[  0%] Building C object src/CMakeFiles/hdf5-static.dir/H5.c.o
clang: error: unknown argument: '-erroff=%none -DBSD_COMP'
gmake[2]: *** [src/CMakeFiles/hdf5-static.dir/build.make:76: src/CMakeFiles/hdf5-static.dir/H5.c.o] Error 1
```

GCC masks the bug rather than hitting it: it parses the leading `-e` of `-erroff=...` as the linker entry-symbol option and consumes the rest as that option's argument, so at compile time the whole string is simply discarded. Reproducible anywhere:

```console
$ echo 'int main(void){return 0;}' > t.c
$ gcc "-erroff=%none -DBSD_COMP" -c t.c -o t.o ; echo $?
0
$ clang "-erroff=%none -DBSD_COMP" -c t.c -o t.o
clang: error: unknown argument: '-erroff=%none -DBSD_COMP'
```

A side effect worth noting: `-DBSD_COMP` was not actually reaching any Solaris compiler as a define, under GCC or SunPro.

### Fix

Pass `-erroff=%none` only when the compiler is Oracle Developer Studio (`SunPro`), and append `-DBSD_COMP` as its own list element so it is a separate argument for all Solaris compilers. Same change in the C and C++ flag files; nothing else is touched.

### Testing

Built and tested on Solaris 11.4 in CI:

- **clang 19** — was failing at `H5.c.o`; now **0 compiler errors, 0 compiler warnings, 2847/2847 tests passed**.
- **gcc 15.2.0** — unaffected, as expected, since it was silently discarding the flag before. Still green.

No behavior change on any non-SunOS platform: the modified branch is inside `if (${CMAKE_SYSTEM_NAME} MATCHES "SunOS")`.
