### PR TITLE
Fix version references left wrong by the 2.2.0 alias update

### DIFF
--- a/docs/doxygen/dox/hdf5_2x.dox
+++ b/docs/doxygen/dox/hdf5_2x.dox
@@ -98,7 +98,7 @@ Since this portion of the HDF5 documentation is now part of the source code, it 
 
 \section sec_rel_spec_2x_migrate Migrating from HDF5 1.14 to HDF5 2.x
 
-This section highlights some changes that might affect migrating to HDF5 2.x, please refer to the \ref sec_rel_spec_2x_change or the <a href="https://\SRCURLALL/hdf5_\PREVIOUS_VER/release_docs/CHANGELOG.md">CHANGELOG.md</a> for detail.
+This section highlights some changes that might affect migrating to HDF5 2.x, please refer to the \ref sec_rel_spec_2x_change or the <a href="https://\SRCURLALL/hdf5_2.0.0/release_docs/CHANGELOG.md">CHANGELOG.md</a> for detail.
 
 \li Default file format is now 1.8
 \li The file format has been updated to 4.0<a name="fileformat"></a>
@@ -106,10 +106,10 @@ This section highlights some changes that might affect migrating to HDF5 2.x, pl
     - `H5Dread_chunk()`<br>
     - `H5Tdecode()`<br>
     - `H5Iregister_type()`<br>
-\li A new backend based on the [aws-c-s3 library](https://github.com/awslabs/aws-c-s3) replaced the ROS3 VFD's S3 backend based on libcurl.  The ROS3 VFD now requires the `aws-c-s3` library in order to be built.  See the <a href="https://\SRCURLALL/hdf5_\PREVIOUS_VER/release_docs/CHANGELOG.md">CHANGELOG.md</a> for a complete description on this feature.
+\li A new backend based on the [aws-c-s3 library](https://github.com/awslabs/aws-c-s3) replaced the ROS3 VFD's S3 backend based on libcurl.  The ROS3 VFD now requires the `aws-c-s3` library in order to be built.  See the <a href="https://\SRCURLALL/hdf5_2.0.0/release_docs/CHANGELOG.md">CHANGELOG.md</a> for a complete description on this feature.
 \li Significance in tools
     - The tool h5dump has a new option `--lformat` and its `XML` option is deprecated.
-    - The high-level GIF tools, `h52gif` and `gif2h5` have been removed. We may move them to a separate repository in the future.  See <a href="https://\SRCURLALL/hdf5_\PREVIOUS_VER/release_docs/CHANGELOG.md">CHANGELOG.md</a> for an explanation.
+    - The high-level GIF tools, `h52gif` and `gif2h5` have been removed. We may move them to a separate repository in the future.  See <a href="https://\SRCURLALL/hdf5_2.0.0/release_docs/CHANGELOG.md">CHANGELOG.md</a> for an explanation.
 
 \section sec_rel_spec_2x_feat New Features in HDF5 Release 2.x
 

--- a/docs/doxygen/dox/sw_changes_2.x.dox
+++ b/docs/doxygen/dox/sw_changes_2.x.dox
@@ -15,7 +15,7 @@ be aware of between successive releases of HDF5, such as:
 \subsection subsec_rel_spec_2x_change_compat API Compatibility
 See \ref api-compat-macros for details of HDF5 versions when considering upgrading to the later HDF5 release to take advantage of the library features and enhancements.
 
-\li <a href="https://github.com/HDFGroup/hdf5/releases/download/2.2.0/hdf5-2.2.0.html.abi.reports.tar.gz">Compatibility reports for Release 2.2.0 versus Release 2.1.0</a>
+\li <a href="https://github.com/HDFGroup/hdf5/releases/download/2.2.0/hdf5-2.2.0.html.abi.reports.tar.gz">Compatibility reports for Release 2.2.0 versus Release 2.1.1</a>
 \li <a href="https://github.com/HDFGroup/hdf5/releases/download/2.1.0/hdf5-2.1.0.html.abi.reports.tar.gz">Compatibility reports for Release 2.1.0 versus Release 2.0.0</a>
 \li <a href="https://\RELURL/v2_0/v2_0_0/downloads/hdf5-2.0.0.html.abi.reports.tar.gz">Compatibility reports for Release 2.0.0 versus Release 1.14.6</a>
 

--- a/docs/doxygen/dox/sw_changes_2.x.dox
+++ b/docs/doxygen/dox/sw_changes_2.x.dox
@@ -15,7 +15,7 @@ be aware of between successive releases of HDF5, such as:
 \subsection subsec_rel_spec_2x_change_compat API Compatibility
 See \ref api-compat-macros for details of HDF5 versions when considering upgrading to the later HDF5 release to take advantage of the library features and enhancements.
 
-\li <a href="https://github.com/HDFGroup/hdf5/releases/download/2.2.0/hdf5-2.2.0.html.abi.reports.tar.gz">Compatibility reports for Release 2.2.0 versus Release 2.1.1</a>
+\li <a href="https://github.com/HDFGroup/hdf5/releases/download/\CURRENT_VER/hdf5-\CURRENT_VER.html.abi.reports.tar.gz">Compatibility reports for Release \CURRENT_VER versus Release \PREVIOUS_VER</a>
 \li <a href="https://github.com/HDFGroup/hdf5/releases/download/2.1.0/hdf5-2.1.0.html.abi.reports.tar.gz">Compatibility reports for Release 2.1.0 versus Release 2.0.0</a>
 \li <a href="https://\RELURL/v2_0/v2_0_0/downloads/hdf5-2.0.0.html.abi.reports.tar.gz">Compatibility reports for Release 2.0.0 versus Release 1.14.6</a>
 


### PR DESCRIPTION
Follow-up to #6567, per review comment: https://github.com/HDFGroup/hdf5/pull/6567#issuecomment-5110473563

## Summary
- `sec_rel_spec_2x_migrate` in `hdf5_2x.dox` documents the fixed 1.14->2.0 transition (H5Dread_chunk/H5Tdecode/H5Iregister_type signature changes, the aws-c-s3 ROS3 backend swap), but its three CHANGELOG links used `\PREVIOUS_VER`, which floats to whatever release preceded the current one (now 2.1.1) instead of staying pointed at the 2.0.0 CHANGELOG that actually documents these changes. Pinned to `2.0.0` explicitly.
- `sw_changes_2.x.dox`'s ABI compatibility report entry said "Release 2.2.0 versus Release 2.1.0", but the true predecessor of 2.2.0 is 2.1.1 (the latest published release per `gh release list` and the abi-report.yml auto-detect logic). Converted this entry to use `\CURRENT_VER`/`\PREVIOUS_VER` (matching `hdf5_2x.dox`'s equivalent line) instead of a hardcoded literal — that duplication of the same fact across two files, one aliased and one not, is what let them drift out of sync in the first place.
- Left the `subsubsec_rel_spec_2x_change_22versus21` section heading/API list at 2.1.0 since that section tracks new APIs since the last minor release (2.1.1 was a patch release with no new APIs).

Note for future releases: before bumping `CURRENT_VER`/`PREVIOUS_VER` in `Doxyfile.in`, freeze the `sw_changes_2.x.dox` ABI entry to a literal first (it becomes historical record once superseded), then add a new aliased line above it for the new release.

## Test plan
- [ ] Doxygen build renders both pages without broken links