### PR TITLE
CMake Fortran float128 check simplification / correction

### DIFF
--- a/config/ConfigureChecks.cmake
+++ b/config/ConfigureChecks.cmake
@@ -745,7 +745,7 @@ if (HDF5_BUILD_FORTRAN)
         message (VERBOSE "Detecting C ${FUNCTION_NAME}")
         file (WRITE
             ${CMAKE_BINARY_DIR}${CMAKE_FILES_DIRECTORY}/CMakeTmp/testCCompiler1.c
-            ${SOURCE_CODE}
+          "${SOURCE_CODE}"
         )
         try_run (RUN_RESULT_VAR COMPILE_RESULT_VAR
             SOURCES ${CMAKE_BINARY_DIR}${CMAKE_FILES_DIRECTORY}/CMakeTmp/testCCompiler1.c
@@ -781,29 +781,30 @@ if (HDF5_BUILD_FORTRAN)
             message (FATAL_ERROR "Compilation of C ${FUNCTION_NAME} - Failed")
         endif ()
     endmacro ()
-    set (PROG_SRC
-        "
-#include <float.h>\n\
-#include <stdio.h>\n\
-#if ${C_HAVE_FLOAT128}\n\
-#  if ${C_INCLUDE_QUADMATH_H}\n\
-#    include <quadmath.h>\n\
-#  endif\n\
-#  ifdef FLT128_DIG\n\
-#    define C_FLT128_DIG FLT128_DIG\n\
-#  else\n\
-#    define C_FLT128_DIG 0\n\
-#  endif\n\
-#else\n\
-#  define C_FLT128_DIG 0\n\
-#endif\n\
-#define C_LDBL_DIG DECIMAL_DIG\n\
-\n\
-int main(void) {\nprintf(\"\\%d\\\;\\%d\\\;\", C_LDBL_DIG, C_FLT128_DIG)\\\;\n\nreturn 0\\\;\n}\n
-        "
-    )
+    string (CONFIGURE [=[
+  #include <float.h>
+  #include <stdio.h>
+  #if @C_HAVE_FLOAT128@
+  #  if @C_INCLUDE_QUADMATH_H@
+  #    include <quadmath.h>
+  #  endif
+  #  ifdef FLT128_DIG
+  #    define C_FLT128_DIG FLT128_DIG
+  #  else
+  #    define C_FLT128_DIG 0
+  #  endif
+  #else
+  #  define C_FLT128_DIG 0
+  #endif
+  #define C_LDBL_DIG DECIMAL_DIG
 
-    C_RUN ("maximum decimal precision for C" ${PROG_SRC} PROG_RES PROG_OUTPUT4)
+  int main(void) {
+    printf("%d;%d;", C_LDBL_DIG, C_FLT128_DIG);
+    return 0;
+  }
+  ]=] PROG_SRC @ONLY)
+
+    C_RUN ("maximum decimal precision for C" "${PROG_SRC}" PROG_RES PROG_OUTPUT4)
     message (STATUS "Testing maximum decimal precision for C - ${PROG_OUTPUT4}")
 
     # The output from the above program will be:

--- a/tools/test/h5dump/CMakeTests.cmake
+++ b/tools/test/h5dump/CMakeTests.cmake
@@ -477,7 +477,7 @@ foreach (external_vol_tgt ${HDF5_EXTERNAL_VOL_TARGETS})
   # Special file handling
   # --------------------------------------------------------------------
   HDFTEST_COPY_FILE ("${HDF5_TOOLS_TST_DIR}/h5dump/expected/tbin1.ddl" "${PROJECT_BINARY_DIR}/${ext_vol_dir_name}/testfiles/std/tbin1LE.ddl" "h5dump_vol_files")
-  
+
   # Certain versions of Visual Studio produce rounding differences compared with the reference data of the tfloatsattr test
   if (WIN32 AND (CMAKE_VS_WINDOWS_TARGET_PLATFORM_VERSION VERSION_LESS 10.0.18362.0))
     configure_file (${HDF5_TOOLS_TST_DIR}/h5dump/exportfiles/tbinregR.exp ${PROJECT_BINARY_DIR}/${ext_vol_dir_name}/testfiles/std/tbinregR.exp NEWLINE_STYLE CRLF)
@@ -592,7 +592,7 @@ macro (ADD_H5_TEST testname)
     # With -n, oputput that must be filtered appears different
     list (APPEND filters_in "datatype [ \t]*(/?#)[0-9]+")
     list (APPEND filters_out "datatype [ \t]*(/?#)XXXX")
-  
+
     # Size/Offset within file will differ across VOL connectors
     list (APPEND filters_in "OFFSET [0-9]+")
     list (APPEND filters_out "OFFSET XXXX")
@@ -618,7 +618,7 @@ macro (ADD_H5_TEST testname)
   endif ()
 
   # both of these args want to define argument to -o flag
-  if (DEFINED ARG_OUTPUT_FILE AND ${ARG_BINFILE}) 
+  if (DEFINED ARG_OUTPUT_FILE AND ${ARG_BINFILE})
     message  (FATAL_ERROR "ADD_H5_TEST: OUTPUT_FILE and BINFILE are mutually exclusive")
   endif()
 
@@ -794,7 +794,7 @@ macro (ADD_H5_TEST testname)
     if ("${vol_prefix}H5DUMP-${ctest_testname}" MATCHES "${HDF5_DISABLE_TESTS_REGEX}")
       set_tests_properties (${vol_prefix}H5DUMP-${ctest_testname} PROPERTIES DISABLED true)
     endif ()
-      
+
     set (CLEANUP_DEPENDENCIES "${vol_prefix}H5DUMP-${ctest_testname}")
 
     if (DEFINED ARG_TARGET_FILE AND DEFINED ARG_OUTPUT_FILE)
@@ -1018,8 +1018,16 @@ ADD_H5_TEST (tdset-2 RESULT_CODE 1 H5ERRREF "h5dump error: unable to get link in
 # test for displaying attributes
 ADD_H5_TEST (tattr-1 RESULT_CODE 0 --enable-error-stack TARGET_FILE tattr.h5)
 # test for displaying the selected attributes of string type and scalar space
-ADD_H5_TEST (tattr-2 RESULT_CODE 0 --enable-error-stack -a /\\\\/attr1 --attribute /attr4 --attribute=/attr5 TARGET_FILE tattr.h5)
-ADD_H5_TEST (tattr-2-N RESULT_CODE 0 --enable-error-stack  TARGET_FILE tattr.h5 ANY_PATHS /\\\\/attr1 /attr4 /attr5)
+block (SCOPE_FOR POLICIES)
+  if (POLICY CMP0219)
+    cmake_policy (SET CMP0219 NEW)
+    set (_H5DUMP_ATTR1_PATH /\\/attr1)
+  else ()
+    set (_H5DUMP_ATTR1_PATH /\\\\/attr1)
+  endif ()
+  ADD_H5_TEST (tattr-2 RESULT_CODE 0 --enable-error-stack -a ${_H5DUMP_ATTR1_PATH} --attribute /attr4 --attribute=/attr5 TARGET_FILE tattr.h5)
+  ADD_H5_TEST (tattr-2-N RESULT_CODE 0 --enable-error-stack  TARGET_FILE tattr.h5 ANY_PATHS ${_H5DUMP_ATTR1_PATH} /attr4 /attr5)
+endblock ()
 # test for header and error messages
 ADD_H5_TEST (tattr-3 RESULT_CODE 1 H5ERRREF "h5dump error: unable to open attribute \"attr\"" --enable-error-stack --header -a /attr2 --attribute=/attr TARGET_FILE tattr.h5)
 # test for displaying at least 9 attributes on root from a be machine


### PR DESCRIPTION
fixes #6583
by simplifying Fortran float128 capability check by using CMake bracket-quoting instead of nested escapes. This was warned about in CMake 4.4 CMP0219.

## Log before our change

```sh
> git switch -d 2.2.0
> cmake -Bbuildi --fresh -DBUILD_TESTING=off -DHDF5_BUILD_FORTRAN=on
-- Building for: Ninja
-- The C compiler identification is IntelLLVM 2026.1.0 with MSVC-like command-line
-- Detecting C compiler ABI info
-- Detecting C compiler ABI info - done
-- Check for working C compiler: C:/Program Files (x86)/Intel/oneAPI/compiler/latest/bin/icx.exe - skipped
-- Detecting C compile features
-- Detecting C compile features - done
-- Looking for include file sys/file.h
-- Looking for include file sys/file.h - not found
-- Looking for include file sys/ioctl.h
-- Looking for include file sys/ioctl.h - not found
-- Looking for include file sys/resource.h
-- Looking for include file sys/resource.h - not found
-- Looking for include file sys/socket.h
-- Looking for include file sys/socket.h - not found
-- Looking for include file sys/stat.h
-- Looking for include file sys/stat.h - found
-- Looking for include files sys/stat.h, sys/time.h
-- Looking for include files sys/stat.h, sys/time.h - not found
-- Looking for include files sys/stat.h, dirent.h
-- Looking for include files sys/stat.h, dirent.h - not found
-- Looking for include files sys/stat.h, unistd.h
-- Looking for include files sys/stat.h, unistd.h - not found
-- Looking for include files sys/stat.h, pwd.h
-- Looking for include files sys/stat.h, pwd.h - not found
-- Looking for include files sys/stat.h, pthread.h
-- Looking for include files sys/stat.h, pthread.h - not found
-- Looking for include files sys/stat.h, dlfcn.h
-- Looking for include files sys/stat.h, dlfcn.h - not found
-- Looking for include files sys/stat.h, netinet/in.h
-- Looking for include files sys/stat.h, netinet/in.h - not found
-- Looking for include files sys/stat.h, netdb.h
-- Looking for include files sys/stat.h, netdb.h - not found
-- Looking for include files sys/stat.h, arpa/inet.h
-- Looking for include files sys/stat.h, arpa/inet.h - not found
-- Looking for include files sys/stat.h, shlwapi.h
-- Looking for include files sys/stat.h, shlwapi.h - found
-- Looking for include file quadmath.h
-- Looking for include file quadmath.h - not found
-- Looking for gethostname in ucb;
-- Looking for gethostname in ucb; - not found
-- Looking for sys/types.h
-- Looking for sys/types.h - found
-- Looking for stdint.h
-- Looking for stdint.h - found
-- Looking for stddef.h
-- Looking for stddef.h - found
-- Check size of char
-- Check size of char - done
-- Check size of short
-- Check size of short - done
-- Check size of int
-- Check size of int - done
-- Check size of unsigned
-- Check size of unsigned - done
-- Check size of long
-- Check size of long - done
-- Check size of long long
-- Check size of long long - done
-- Check size of float
-- Check size of float - done
-- Check size of double
-- Check size of double - done
-- Check size of long double
-- Check size of long double - done
-- Check size of int8_t
-- Check size of int8_t - done
-- Check size of uint8_t
-- Check size of uint8_t - done
-- Check size of int_least8_t
-- Check size of int_least8_t - done
-- Check size of uint_least8_t
-- Check size of uint_least8_t - done
-- Check size of int_fast8_t
-- Check size of int_fast8_t - done
-- Check size of uint_fast8_t
-- Check size of uint_fast8_t - done
-- Check size of int16_t
-- Check size of int16_t - done
-- Check size of uint16_t
-- Check size of uint16_t - done
-- Check size of int_least16_t
-- Check size of int_least16_t - done
-- Check size of uint_least16_t
-- Check size of uint_least16_t - done
-- Check size of int_fast16_t
-- Check size of int_fast16_t - done
-- Check size of uint_fast16_t
-- Check size of uint_fast16_t - done
-- Check size of int32_t
-- Check size of int32_t - done
-- Check size of uint32_t
-- Check size of uint32_t - done
-- Check size of int_least32_t
-- Check size of int_least32_t - done
-- Check size of uint_least32_t
-- Check size of uint_least32_t - done
-- Check size of int_fast32_t
-- Check size of int_fast32_t - done
-- Check size of uint_fast32_t
-- Check size of uint_fast32_t - done
-- Check size of int64_t
-- Check size of int64_t - done
-- Check size of uint64_t
-- Check size of uint64_t - done
-- Check size of int_least64_t
-- Check size of int_least64_t - done
-- Check size of uint_least64_t
-- Check size of uint_least64_t - done
-- Check size of int_fast64_t
-- Check size of int_fast64_t - done
-- Check size of uint_fast64_t
-- Check size of uint_fast64_t - done
-- Check size of size_t
-- Check size of size_t - done
-- Check size of ssize_t
-- Check size of ssize_t - failed
-- Check size of off_t
-- Check size of off_t - done
-- Check size of time_t
-- Check size of time_t - done
-- Check size of _Bool
-- Check size of _Bool - done
-- Looking for alarm
-- Looking for alarm - not found
-- Looking for fcntl
-- Looking for fcntl - not found
-- Looking for flock
-- Looking for flock - not found
-- Looking for fork
-- Looking for fork - not found
-- Looking for getrusage
-- Looking for getrusage - not found
-- Looking for pread
-- Looking for pread - not found
-- Looking for pwrite
-- Looking for pwrite - not found
-- Looking for strcasestr
-- Looking for strcasestr - not found
-- Looking for symlink
-- Looking for symlink - not found
-- Looking for tmpfile
-- Looking for tmpfile - found
-- Looking for asprintf
-- Looking for asprintf - not found
-- Looking for vasprintf
-- Looking for vasprintf - not found
-- Looking for waitpid
-- Looking for waitpid - not found
-- Looking for qsort_r
-- Looking for qsort_r - not found
-- Looking for qsort_s
-- Looking for qsort_s - found
-- Looking for sigsetjmp
-- Looking for sigsetjmp - not found
CMake Warning (policy) at config/ConfigureChecks.cmake:806 (C_RUN):
  Policy CMP0219 is not set: Macro invocations preserve backslashes in
  arguments.  Run "cmake --help-policy CMP0219" for policy details.  Use the
  cmake_policy command to set the policy and suppress this warning.

  Command "C_RUN" called with arguments containing backslashes.

  Since the policy is not set, backslashes in the arguments:

   "

  #include <float.h>

  #include <stdio.h>

  #if 1

  # if 0

  # include <quadmath.h>

  # endif

  # ifdef FLT128_DIG

  # define C_FLT128_DIG FLT128_DIG

  # else

  # define C_FLT128_DIG 0

  # endif

  #else

  # define C_FLT128_DIG 0

  #endif

  #define C_LDBL_DIG DECIMAL_DIG



  int main(void) {

  printf("\%d\;\%d\;", C_LDBL_DIG, C_FLT128_DIG)\;



  return 0\;

  }



          "

  will be interpreted as escape sequences for compatibility.

  Set the policy to NEW to instead pass

   "

  #include <float.h>

  #include <stdio.h>

  #if 1

  # if 0

  # include <quadmath.h>

  # endif

  # ifdef FLT128_DIG

  # define C_FLT128_DIG FLT128_DIG

  # else

  # define C_FLT128_DIG 0

  # endif

  #else

  # define C_FLT128_DIG 0

  #endif

  #define C_LDBL_DIG DECIMAL_DIG



  int main(void) {

  printf("\\%d\\;\\%d\\;", C_LDBL_DIG, C_FLT128_DIG)\\;



  return 0\\;

  }



          "

  so that argument parsing will preserve the original values.
Call Stack (most recent call first):
  CMakeLists.txt:562 (include)
This warning is for project developers.  Use -Wno-author or -Wno-policy to
suppress it.

-- Testing maximum decimal precision for C - 21;0
-- maximum decimal precision for C var - 21
-- Checking if complex number support is available
-- Looking for complex.h
-- Looking for complex.h - found
-- Check size of float _Complex
-- Check size of float _Complex - done
-- Check size of double _Complex
-- Check size of double _Complex - done
-- Check size of long double _Complex
-- Check size of long double _Complex - done
-- Using C99 complex number types
-- Checking if _Float16 support is available
-- Check size of _Float16
-- Check size of _Float16 - done
-- Looking for FLT16_EPSILON
-- Looking for FLT16_EPSILON - found
-- Looking for FLT16_MIN
-- Looking for FLT16_MIN - found
-- Looking for FLT16_MAX
-- Looking for FLT16_MAX - found
-- Looking for FLT16_MIN_10_EXP
-- Looking for FLT16_MIN_10_EXP - found
-- Looking for FLT16_MAX_10_EXP
-- Looking for FLT16_MAX_10_EXP - found
-- Looking for FLT16_MANT_DIG
-- Looking for FLT16_MANT_DIG - found
-- _Float16 support has been disabled because the compiler couldn't compile and run a test program for _Float16 conversions
-- Check hdf5/buildi/CMakeFiles/CMakeError.log for information on why the test program couldn't be compiled/run
-- Could NOT find PkgConfig (missing: PKG_CONFIG_EXECUTABLE)
-- Found Perl: C:/msys64/usr/bin/perl.exe (found version "5.42.2")
-- ....All Warnings are enabled
-- Performing Test CMAKE_HAVE_LIBC_PTHREAD
-- Performing Test CMAKE_HAVE_LIBC_PTHREAD - Failed
-- Looking for pthread_create in pthreads
-- Looking for pthread_create in pthreads - not found
-- Looking for pthread_create in pthread
-- Looking for pthread_create in pthread - not found
-- Found Threads: TRUE
-- Looking for stdatomic.h
-- Looking for stdatomic.h - found
-- The Fortran compiler identification is IntelLLVM 2026.1.0 with MSVC-like command-line
-- Detecting Fortran compiler ABI info
-- Detecting Fortran compiler ABI info - done
-- Check for working Fortran compiler: C:/Program Files (x86)/Intel/oneAPI/compiler/latest/bin/ifx.exe - skipped
-- Detecting Fortran/C Interface
-- Detecting Fortran/C Interface - Found GLOBAL and MODULE mangling
-- Verifying Fortran/C Compiler Compatibility
-- Verifying Fortran/C Compiler Compatibility - Success
-- Performing Test H5_FORTRAN_HAVE_SIZEOF
-- Performing Test H5_FORTRAN_HAVE_SIZEOF - Success
-- Performing Test H5_FORTRAN_HAVE_C_SIZEOF
-- Performing Test H5_FORTRAN_HAVE_C_SIZEOF - Success
-- Performing Test H5_FORTRAN_HAVE_STORAGE_SIZE
-- Performing Test H5_FORTRAN_HAVE_STORAGE_SIZE - Success
-- Performing Test H5_FORTRAN_HAVE_ISO_C_BINDING
-- Performing Test H5_FORTRAN_HAVE_ISO_C_BINDING - Success
-- Performing Test FORTRAN_HAVE_C_LONG_DOUBLE
-- Performing Test FORTRAN_HAVE_C_LONG_DOUBLE - Success
-- Performing Test FORTRAN_C_LONG_DOUBLE_IS_UNIQUE
-- Performing Test FORTRAN_C_LONG_DOUBLE_IS_UNIQUE - Failed
-- Performing Test FORTRAN_C_BOOL_IS_UNIQUE
-- Performing Test FORTRAN_C_BOOL_IS_UNIQUE - Success
-- Performing Test HAVE_ISO_FORTRAN_ENV
-- Performing Test HAVE_ISO_FORTRAN_ENV - Success
-- Performing Test FORTRAN_CHAR_ALLOC
-- Performing Test FORTRAN_CHAR_ALLOC - Success
-- ....LOGICAL KINDS FOUND {1,2,4,8}
-- ....NUMBER OF INTEGER KINDS FOUND 4
-- ....REAL KINDS FOUND {4,8,16}
-- ....INTEGER KINDS FOUND {1,2,4,8}
-- ....MAX DECIMAL PRECISION 33
-- ....FOUND SIZEOF for REAL KINDs {4,8,16}
-- No pre-generated H5fortran_types.F90 file found - generating one
-- No pre-generated H5_gen.F90 file found - generating one
-- No pre-generated H5LTff_gen.F90 H5TBff_gen.F90 file found - generating one
-- HDF5 Example H5EXAMPLE_RESOURCES_DIR: hdf5/config/cmake
-- HDF5 H5_LIBVER_DIR: 202 HDF5_API_VERSION: v200
-- HDF5 Example link libs: hdf5-shared;hdf5_hl-shared;hdf5_fortran-shared;hdf5_hl_fortran-shared Includes: hdf5/src;hdf5/src/H5FDsubfiling;hdf5/buildi/src;hdf5/hl/src;hdf5/buildi/hl/src
-- HDF5 link libs: hdf5-shared;hdf5_hl-shared;hdf5_fortran-shared;hdf5_hl_fortran-shared
-- HDF5 H5_LIBVER_DIR: 202 HDF5_VERSION_MAJOR: 2.2
-- Configuring done (99.4s)
-- Generating done (0.5s)
```

## Log after our change

```sh
Our PR
> git switch fortran-float128-check
> cmake -Bbuildi --fresh -DBUILD_TESTING=off -DHDF5_BUILD_FORTRAN=on
-- Building for: Ninja
-- The C compiler identification is IntelLLVM 2026.1.0 with MSVC-like command-line
-- Detecting C compiler ABI info
-- Detecting C compiler ABI info - done
-- Check for working C compiler: C:/Program Files (x86)/Intel/oneAPI/compiler/latest/bin/icx.exe - skipped
-- Detecting C compile features
-- Detecting C compile features - done
-- Looking for include file sys/file.h
-- Looking for include file sys/file.h - not found
-- Looking for include file sys/ioctl.h
-- Looking for include file sys/ioctl.h - not found
-- Looking for include file sys/resource.h
-- Looking for include file sys/resource.h - not found
-- Looking for include file sys/socket.h
-- Looking for include file sys/socket.h - not found
-- Looking for include file sys/stat.h
-- Looking for include file sys/stat.h - found
-- Looking for include files sys/stat.h, sys/time.h
-- Looking for include files sys/stat.h, sys/time.h - not found
-- Looking for include files sys/stat.h, dirent.h
-- Looking for include files sys/stat.h, dirent.h - not found
-- Looking for include files sys/stat.h, unistd.h
-- Looking for include files sys/stat.h, unistd.h - not found
-- Looking for include files sys/stat.h, pwd.h
-- Looking for include files sys/stat.h, pwd.h - not found
-- Looking for include files sys/stat.h, pthread.h
-- Looking for include files sys/stat.h, pthread.h - not found
-- Looking for include files sys/stat.h, dlfcn.h
-- Looking for include files sys/stat.h, dlfcn.h - not found
-- Looking for include files sys/stat.h, netinet/in.h
-- Looking for include files sys/stat.h, netinet/in.h - not found
-- Looking for include files sys/stat.h, netdb.h
-- Looking for include files sys/stat.h, netdb.h - not found
-- Looking for include files sys/stat.h, arpa/inet.h
-- Looking for include files sys/stat.h, arpa/inet.h - not found
-- Looking for include files sys/stat.h, shlwapi.h
-- Looking for include files sys/stat.h, shlwapi.h - found
-- Looking for include file quadmath.h
-- Looking for include file quadmath.h - not found
-- Looking for gethostname in ucb;
-- Looking for gethostname in ucb; - not found
-- Looking for sys/types.h
-- Looking for sys/types.h - found
-- Looking for stdint.h
-- Looking for stdint.h - found
-- Looking for stddef.h
-- Looking for stddef.h - found
-- Check size of char
-- Check size of char - done
-- Check size of short
-- Check size of short - done
-- Check size of int
-- Check size of int - done
-- Check size of unsigned
-- Check size of unsigned - done
-- Check size of long
-- Check size of long - done
-- Check size of long long
-- Check size of long long - done
-- Check size of float
-- Check size of float - done
-- Check size of double
-- Check size of double - done
-- Check size of long double
-- Check size of long double - done
-- Check size of int8_t
-- Check size of int8_t - done
-- Check size of uint8_t
-- Check size of uint8_t - done
-- Check size of int_least8_t
-- Check size of int_least8_t - done
-- Check size of uint_least8_t
-- Check size of uint_least8_t - done
-- Check size of int_fast8_t
-- Check size of int_fast8_t - done
-- Check size of uint_fast8_t
-- Check size of uint_fast8_t - done
-- Check size of int16_t
-- Check size of int16_t - done
-- Check size of uint16_t
-- Check size of uint16_t - done
-- Check size of int_least16_t
-- Check size of int_least16_t - done
-- Check size of uint_least16_t
-- Check size of uint_least16_t - done
-- Check size of int_fast16_t
-- Check size of int_fast16_t - done
-- Check size of uint_fast16_t
-- Check size of uint_fast16_t - done
-- Check size of int32_t
-- Check size of int32_t - done
-- Check size of uint32_t
-- Check size of uint32_t - done
-- Check size of int_least32_t
-- Check size of int_least32_t - done
-- Check size of uint_least32_t
-- Check size of uint_least32_t - done
-- Check size of int_fast32_t
-- Check size of int_fast32_t - done
-- Check size of uint_fast32_t
-- Check size of uint_fast32_t - done
-- Check size of int64_t
-- Check size of int64_t - done
-- Check size of uint64_t
-- Check size of uint64_t - done
-- Check size of int_least64_t
-- Check size of int_least64_t - done
-- Check size of uint_least64_t
-- Check size of uint_least64_t - done
-- Check size of int_fast64_t
-- Check size of int_fast64_t - done
-- Check size of uint_fast64_t
-- Check size of uint_fast64_t - done
-- Check size of size_t
-- Check size of size_t - done
-- Check size of ssize_t
-- Check size of ssize_t - failed
-- Check size of off_t
-- Check size of off_t - done
-- Check size of time_t
-- Check size of time_t - done
-- Check size of _Bool
-- Check size of _Bool - done
-- Looking for alarm
-- Looking for alarm - not found
-- Looking for fcntl
-- Looking for fcntl - not found
-- Looking for flock
-- Looking for flock - not found
-- Looking for fork
-- Looking for fork - not found
-- Looking for getrusage
-- Looking for getrusage - not found
-- Looking for pread
-- Looking for pread - not found
-- Looking for pwrite
-- Looking for pwrite - not found
-- Looking for strcasestr
-- Looking for strcasestr - not found
-- Looking for symlink
-- Looking for symlink - not found
-- Looking for tmpfile
-- Looking for tmpfile - found
-- Looking for asprintf
-- Looking for asprintf - not found
-- Looking for vasprintf
-- Looking for vasprintf - not found
-- Looking for waitpid
-- Looking for waitpid - not found
-- Looking for qsort_r
-- Looking for qsort_r - not found
-- Looking for qsort_s
-- Looking for qsort_s - found
-- Looking for sigsetjmp
-- Looking for sigsetjmp - not found
-- Testing maximum decimal precision for C - 21;0
-- maximum decimal precision for C var - 21
-- Checking if complex number support is available
-- Looking for complex.h
-- Looking for complex.h - found
-- Check size of float _Complex
-- Check size of float _Complex - done
-- Check size of double _Complex
-- Check size of double _Complex - done
-- Check size of long double _Complex
-- Check size of long double _Complex - done
-- Using C99 complex number types
-- Checking if _Float16 support is available
-- Check size of _Float16
-- Check size of _Float16 - done
-- Looking for FLT16_EPSILON
-- Looking for FLT16_EPSILON - found
-- Looking for FLT16_MIN
-- Looking for FLT16_MIN - found
-- Looking for FLT16_MAX
-- Looking for FLT16_MAX - found
-- Looking for FLT16_MIN_10_EXP
-- Looking for FLT16_MIN_10_EXP - found
-- Looking for FLT16_MAX_10_EXP
-- Looking for FLT16_MAX_10_EXP - found
-- Looking for FLT16_MANT_DIG
-- Looking for FLT16_MANT_DIG - found
-- _Float16 support has been disabled because the compiler couldn't compile and run a test program for _Float16 conversions
-- Check C:/Users/micha/code_other/hdf5/buildi/CMakeFiles/CMakeError.log for information on why the test program couldn't be compiled/run
-- Could NOT find PkgConfig (missing: PKG_CONFIG_EXECUTABLE)
-- Found Perl: C:/msys64/usr/bin/perl.exe (found version "5.42.2")
-- ....All Warnings are enabled
-- Performing Test CMAKE_HAVE_LIBC_PTHREAD
-- Performing Test CMAKE_HAVE_LIBC_PTHREAD - Failed
-- Looking for pthread_create in pthreads
-- Looking for pthread_create in pthreads - not found
-- Looking for pthread_create in pthread
-- Looking for pthread_create in pthread - not found
-- Found Threads: TRUE
-- Looking for stdatomic.h
-- Looking for stdatomic.h - found
-- The Fortran compiler identification is IntelLLVM 2026.1.0 with MSVC-like command-line
-- Detecting Fortran compiler ABI info
-- Detecting Fortran compiler ABI info - done
-- Check for working Fortran compiler: C:/Program Files (x86)/Intel/oneAPI/compiler/latest/bin/ifx.exe - skipped
-- Verifying Fortran/C Compiler Compatibility
-- Verifying Fortran/C Compiler Compatibility - Success
-- Performing Test H5_FORTRAN_HAVE_SIZEOF
-- Performing Test H5_FORTRAN_HAVE_SIZEOF - Success
-- Performing Test H5_FORTRAN_HAVE_C_SIZEOF
-- Performing Test H5_FORTRAN_HAVE_C_SIZEOF - Success
-- Performing Test H5_FORTRAN_HAVE_STORAGE_SIZE
-- Performing Test H5_FORTRAN_HAVE_STORAGE_SIZE - Success
-- Performing Test H5_FORTRAN_HAVE_ISO_C_BINDING
-- Performing Test H5_FORTRAN_HAVE_ISO_C_BINDING - Success
-- Performing Test FORTRAN_HAVE_C_LONG_DOUBLE
-- Performing Test FORTRAN_HAVE_C_LONG_DOUBLE - Success
-- Performing Test FORTRAN_C_LONG_DOUBLE_IS_UNIQUE
-- Performing Test FORTRAN_C_LONG_DOUBLE_IS_UNIQUE - Failed
-- Performing Test FORTRAN_C_BOOL_IS_UNIQUE
-- Performing Test FORTRAN_C_BOOL_IS_UNIQUE - Success
-- Performing Test HAVE_ISO_FORTRAN_ENV
-- Performing Test HAVE_ISO_FORTRAN_ENV - Success
-- Performing Test FORTRAN_CHAR_ALLOC
-- Performing Test FORTRAN_CHAR_ALLOC - Success
-- ....LOGICAL KINDS FOUND {1,2,4,8}
-- ....NUMBER OF INTEGER KINDS FOUND 4
-- ....REAL KINDS FOUND {4,8,16}
-- ....INTEGER KINDS FOUND {1,2,4,8}
-- ....MAX DECIMAL PRECISION 33
-- ....FOUND SIZEOF for REAL KINDs {4,8,16}
-- No pre-generated H5fortran_types.F90 file found - generating one
-- No pre-generated H5_gen.F90 file found - generating one
-- No pre-generated H5LTff_gen.F90 H5TBff_gen.F90 file found - generating one
-- HDF5 Example H5EXAMPLE_RESOURCES_DIR: hdf5/config/cmake
-- HDF5 H5_LIBVER_DIR: 203 HDF5_API_VERSION: v200
-- HDF5 Example link libs: hdf5-shared;hdf5_hl-shared;hdf5_fortran-shared;hdf5_hl_fortran-shared Includes: hdf5/src;Chdf5/src/H5FDsubfiling;hdf5/buildi/src;hdf5/hl/src;/hdf5/buildi/hl/src
-- HDF5 link libs: hdf5-shared;hdf5_hl-shared;hdf5_fortran-shared;hdf5_hl_fortran-shared
-- HDF5 H5_LIBVER_DIR: 203 HDF5_VERSION_MAJOR: 2.3
-- Configuring done (106.1s)
-- Generating done (0.5s)
```