### PR TITLE
Auto merge dependabot

### DIFF
--- a/.github/scripts/dependabot-auto-merge.js
+++ b/.github/scripts/dependabot-auto-merge.js
@@ -63,7 +63,7 @@ async function alreadyApproved({ github, owner, repo, pull_number }) {
   return reviews.some((r) => r.user?.login === APPROVER_LOGIN && r.state === "APPROVED");
 }
 
-async function processPR({ github, owner, repo, pr, core }) {
+async function processPullRequest({ github, owner, repo, pr, core }) {
   const { ready, reason } = await allChecksPassed({ github, owner, repo, ref: pr.head.sha });
   if (!ready) {
     core.info(`Skipping: ${reason}`);
@@ -125,7 +125,7 @@ async function run({ github, context, core }) {
   for (const pr of candidates) {
     core.startGroup(`#${pr.number} — ${pr.title}`);
     try {
-      await processPR({ github, owner, repo, pr, core });
+      await processPullRequest({ github, owner, repo, pr, core });
     } catch (e) {
       core.error(`#${pr.number}: ${e.message}`);
     } finally {

--- a/.github/scripts/dependabot-auto-merge.js
+++ b/.github/scripts/dependabot-auto-merge.js
@@ -1,0 +1,137 @@
+// Approves and squash-merges dependabot's "bump the github-actions group" PRs
+// once every check and status reported on the PR's head commit has completed
+// successfully. Runs daily, early morning Central time — after dependabot's
+// typical PR-creation window (~22:00-23:30 UTC) has had all night for CI to
+// finish, and before typical developer activity begins.
+//
+// PRs that are still running, have any failed/cancelled/timed-out check, or
+// turn out not to be mergeable are left untouched and picked up on a later
+// run — nothing here ever closes or dismisses a PR.
+const TITLE_PATTERN = /bump the github-actions group\b/i;
+const DEPENDABOT_LOGIN = "dependabot[bot]";
+const APPROVER_LOGIN = "github-actions[bot]"; // identity behind the default GITHUB_TOKEN
+const MERGE_METHOD = "squash";
+
+// Check-run conclusions and legacy status states that don't block a merge.
+const OK_CHECK_CONCLUSIONS = new Set(["success", "neutral", "skipped"]);
+const OK_STATUS_STATES = new Set(["success"]);
+
+function matchesTitle(title) {
+  return TITLE_PATTERN.test(title);
+}
+
+// Inspects every check-run and legacy commit status on `ref`. Returns
+// { ready: true } only once at least one has reported and all of them have
+// completed with a non-blocking outcome.
+async function allChecksPassed({ github, owner, repo, ref }) {
+  const checkRuns = await github.paginate(github.rest.checks.listForRef, {
+    owner,
+    repo,
+    ref,
+    per_page: 100,
+  });
+  for (const run of checkRuns) {
+    if (run.status !== "completed") {
+      return { ready: false, reason: `check "${run.name}" is still ${run.status}` };
+    }
+    if (!OK_CHECK_CONCLUSIONS.has(run.conclusion)) {
+      return { ready: false, reason: `check "${run.name}" concluded ${run.conclusion}` };
+    }
+  }
+
+  const { data: combined } = await github.rest.repos.getCombinedStatusForRef({ owner, repo, ref });
+  for (const status of combined.statuses) {
+    if (!OK_STATUS_STATES.has(status.state)) {
+      return { ready: false, reason: `status "${status.context}" is ${status.state}` };
+    }
+  }
+
+  if (checkRuns.length === 0 && combined.statuses.length === 0) {
+    return { ready: false, reason: "no checks or statuses reported yet" };
+  }
+
+  return { ready: true };
+}
+
+async function alreadyApproved({ github, owner, repo, pull_number }) {
+  const reviews = await github.paginate(github.rest.pulls.listReviews, {
+    owner,
+    repo,
+    pull_number,
+    per_page: 100,
+  });
+  return reviews.some((r) => r.user?.login === APPROVER_LOGIN && r.state === "APPROVED");
+}
+
+async function processPR({ github, owner, repo, pr, core }) {
+  const { ready, reason } = await allChecksPassed({ github, owner, repo, ref: pr.head.sha });
+  if (!ready) {
+    core.info(`Skipping: ${reason}`);
+    return;
+  }
+
+  const { data: freshPR } = await github.rest.pulls.get({ owner, repo, pull_number: pr.number });
+  if (freshPR.merged) {
+    core.info("Already merged.");
+    return;
+  }
+  if (freshPR.mergeable === false) {
+    core.info(`Skipping: not mergeable (${freshPR.mergeable_state}).`);
+    return;
+  }
+
+  if (await alreadyApproved({ github, owner, repo, pull_number: pr.number })) {
+    core.info("Already approved.");
+  } else {
+    await github.rest.pulls.createReview({
+      owner,
+      repo,
+      pull_number: pr.number,
+      event: "APPROVE",
+      body: "All checks passed — auto-approving dependabot GitHub Actions group update.",
+    });
+    core.info("Approved.");
+  }
+
+  await github.rest.pulls.merge({
+    owner,
+    repo,
+    pull_number: pr.number,
+    sha: pr.head.sha,
+    merge_method: MERGE_METHOD,
+  });
+  core.notice(`Merged #${pr.number} — ${pr.title}`);
+}
+
+async function run({ github, context, core }) {
+  const { owner, repo } = context.repo;
+
+  const openPRs = await github.paginate(github.rest.pulls.list, {
+    owner,
+    repo,
+    state: "open",
+    per_page: 100,
+  });
+
+  const candidates = openPRs.filter(
+    (pr) => pr.user?.login === DEPENDABOT_LOGIN && !pr.draft && matchesTitle(pr.title)
+  );
+
+  if (candidates.length === 0) {
+    core.info("No open dependabot github-actions-group PRs found.");
+    return;
+  }
+
+  for (const pr of candidates) {
+    core.startGroup(`#${pr.number} — ${pr.title}`);
+    try {
+      await processPR({ github, owner, repo, pr, core });
+    } catch (e) {
+      core.error(`#${pr.number}: ${e.message}`);
+    } finally {
+      core.endGroup();
+    }
+  }
+}
+
+module.exports = { run, matchesTitle, allChecksPassed };

--- a/.github/scripts/dependabot-auto-merge.test.js
+++ b/.github/scripts/dependabot-auto-merge.test.js
@@ -1,0 +1,138 @@
+'use strict';
+// Run with: node .github/scripts/dependabot-auto-merge.test.js
+
+const assert = require('assert');
+const { matchesTitle, allChecksPassed } = require('./dependabot-auto-merge.js');
+
+let passed = 0;
+let failed = 0;
+
+function test(name, fn) {
+  try {
+    fn();
+    console.log(`✓ ${name}`);
+    passed++;
+  } catch (e) {
+    console.log(`✗ ${name} — ${e.message}`);
+    failed++;
+  }
+}
+
+const asyncTests = [];
+function asyncTest(name, fn) {
+  asyncTests.push({ name, fn });
+}
+
+// Minimal recording mock for the github.rest/paginate surface allChecksPassed touches.
+function makeGithubMock({ checkRuns = [], statuses = [] }) {
+  return {
+    paginate: async (fn) => fn(),
+    rest: {
+      checks: {
+        listForRef: async () => checkRuns,
+      },
+      repos: {
+        getCombinedStatusForRef: async () => ({ data: { statuses } }),
+      },
+    },
+  };
+}
+
+// ----------------------------------------------------------------
+// matchesTitle
+// ----------------------------------------------------------------
+
+test('matches plain "Bump the github-actions group with N updates"', () => {
+  assert.strictEqual(matchesTitle('Bump the github-actions group with 12 updates'), true);
+});
+
+test('matches "build(deps): bump the github-actions group with N updates"', () => {
+  assert.strictEqual(matchesTitle('build(deps): bump the github-actions group with 17 updates'), true);
+});
+
+test('matches "across 1 directory" variant', () => {
+  assert.strictEqual(matchesTitle('Bump the github-actions group across 1 directory with 11 updates'), true);
+});
+
+test('is case-insensitive', () => {
+  assert.strictEqual(matchesTitle('BUMP THE GITHUB-ACTIONS GROUP WITH 3 UPDATES'), true);
+});
+
+test('does not match an unrelated dependabot title', () => {
+  assert.strictEqual(matchesTitle('Bump lycheeverse/lychee-action from 1.9.3 to 2.0.2 in /.github/workflows'), false);
+});
+
+test('does not match a human PR title that happens to mention bumping', () => {
+  assert.strictEqual(matchesTitle('Bump minimum CMake version'), false);
+});
+
+// ----------------------------------------------------------------
+// allChecksPassed
+// ----------------------------------------------------------------
+
+asyncTest('not ready when a check run is still in progress', async () => {
+  const github = makeGithubMock({
+    checkRuns: [{ name: 'build', status: 'in_progress', conclusion: null }],
+  });
+  const result = await allChecksPassed({ github, owner: 'o', repo: 'r', ref: 'sha' });
+  assert.strictEqual(result.ready, false);
+  assert.match(result.reason, /still in_progress/);
+});
+
+asyncTest('not ready when a completed check run failed', async () => {
+  const github = makeGithubMock({
+    checkRuns: [{ name: 'build', status: 'completed', conclusion: 'failure' }],
+  });
+  const result = await allChecksPassed({ github, owner: 'o', repo: 'r', ref: 'sha' });
+  assert.strictEqual(result.ready, false);
+  assert.match(result.reason, /concluded failure/);
+});
+
+asyncTest('ready when all check runs are success/neutral/skipped', async () => {
+  const github = makeGithubMock({
+    checkRuns: [
+      { name: 'build', status: 'completed', conclusion: 'success' },
+      { name: 'lint', status: 'completed', conclusion: 'neutral' },
+      { name: 'matrix-unused-leg', status: 'completed', conclusion: 'skipped' },
+    ],
+  });
+  const result = await allChecksPassed({ github, owner: 'o', repo: 'r', ref: 'sha' });
+  assert.strictEqual(result.ready, true);
+});
+
+asyncTest('not ready when a legacy commit status is pending', async () => {
+  const github = makeGithubMock({
+    checkRuns: [{ name: 'build', status: 'completed', conclusion: 'success' }],
+    statuses: [{ context: 'ci/legacy', state: 'pending' }],
+  });
+  const result = await allChecksPassed({ github, owner: 'o', repo: 'r', ref: 'sha' });
+  assert.strictEqual(result.ready, false);
+  assert.match(result.reason, /ci\/legacy/);
+});
+
+asyncTest('not ready when there are no checks or statuses at all yet', async () => {
+  const github = makeGithubMock({});
+  const result = await allChecksPassed({ github, owner: 'o', repo: 'r', ref: 'sha' });
+  assert.strictEqual(result.ready, false);
+  assert.match(result.reason, /no checks or statuses/);
+});
+
+// ----------------------------------------------------------------
+// Summary
+// ----------------------------------------------------------------
+
+(async () => {
+  for (const { name, fn } of asyncTests) {
+    try {
+      await fn();
+      console.log(`✓ ${name}`);
+      passed++;
+    } catch (e) {
+      console.log(`✗ ${name} — ${e.message}`);
+      failed++;
+    }
+  }
+  console.log('');
+  console.log(`${passed} passed, ${failed} failed`);
+  process.exit(failed > 0 ? 1 : 0);
+})();

--- a/.github/workflows/dependabot-auto-merge-test.yml
+++ b/.github/workflows/dependabot-auto-merge-test.yml
@@ -18,7 +18,7 @@ permissions:
 jobs:
   test:
     runs-on: ubuntu-latest
-    if: github.repository == 'HDFGroup/hdf5' && (github.event_name == 'push' || github.event.pull_request.head.repo.full_name == github.repository)
+    if: github.repository == 'HDFGroup/hdf5'
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:

--- a/.github/workflows/dependabot-auto-merge-test.yml
+++ b/.github/workflows/dependabot-auto-merge-test.yml
@@ -1,0 +1,26 @@
+name: Dependabot Auto-Merge Tests
+
+on:
+  push:
+    paths:
+      - .github/scripts/dependabot-auto-merge.js
+      - .github/scripts/dependabot-auto-merge.test.js
+  pull_request:
+    branches: [develop]
+    paths:
+      - .github/scripts/dependabot-auto-merge.js
+      - .github/scripts/dependabot-auto-merge.test.js
+
+permissions:
+  contents: read
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    if: github.repository == 'HDFGroup/hdf5' && (github.event_name == 'push' || github.event.pull_request.head.repo.full_name == github.repository)
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false # Prevents tokens from being written to Git config files
+
+      - run: node .github/scripts/dependabot-auto-merge.test.js

--- a/.github/workflows/dependabot-auto-merge-test.yml
+++ b/.github/workflows/dependabot-auto-merge-test.yml
@@ -1,6 +1,7 @@
 name: Dependabot Auto-Merge Tests
 
 on:
+  workflow_dispatch:
   push:
     paths:
       - .github/scripts/dependabot-auto-merge.js

--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -1,0 +1,44 @@
+name: Dependabot Auto-Merge (GitHub Actions group)
+
+# Approves and squash-merges dependabot's "bump the github-actions group" PRs
+# once every check and status on the PR's head commit has completed
+# successfully. Runs daily, early morning Central time — dependabot creates
+# these PRs around 22:00-23:30 UTC, so this gives CI all night to finish and
+# still runs before typical developer activity begins. PRs that are still
+# running, have any failed check, or aren't otherwise mergeable are left
+# alone and picked up on a later run — see .github/scripts/dependabot-auto-merge.js.
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: "0 11 * * *" # 06:00 America/Chicago (CDT); 05:00 during CST
+
+permissions:
+  contents: read
+
+concurrency:
+  group: dependabot-auto-merge
+  cancel-in-progress: false
+
+jobs:
+  auto-merge:
+    if: github.repository == 'HDFGroup/hdf5'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write # to squash-merge
+      pull-requests: write # to approve and merge PRs
+      checks: read # to read check-run conclusions
+      statuses: read # to read legacy commit statuses
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false # Prevents tokens from being written to Git config files
+          sparse-checkout: .github/scripts
+          fetch-depth: 1
+      - uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
+        with:
+          retries: 3
+          retry-exempt-status-codes: 400,403,404,422
+          script: |
+            const { run } = require('${{ github.workspace }}/.github/scripts/dependabot-auto-merge.js');
+            await run({ github, context, core });


### PR DESCRIPTION
This was the prompt given to Claude:

dependabot creates github PRs with "bump he github-actions group with" in the title.  I would like to add a workflow that reviews the checks for any PR created by dependabot, verifies that all checks are finished and that none of them failed and that there were no errors.  If not, the workflow will approve and commit the PR.  If such workflow can be created it should run daily at an appropriate time after dependabot creates PRs, probably at an early morning time before typical developer activity begins.