### PR TITLE
Minor correction to H5Tget_super failure checks in JNI helpers

### DIFF
--- a/java/src-jni/jni/h5util.c
+++ b/java/src-jni/jni/h5util.c
@@ -4291,7 +4291,7 @@ translate_atomic_rbuf(JNIEnv *env, jlong mem_type_id, H5T_class_t type_class, vo
 
     switch (type_class) {
         case H5T_VLEN: {
-            if (!(memb = H5Tget_super(mem_type_id)))
+            if ((memb = H5Tget_super(mem_type_id)) < 0)
                 H5_LIBRARY_ERROR(ENVONLY);
             if ((vlClass = H5Tget_class(memb)) < 0)
                 H5_LIBRARY_ERROR(ENVONLY);
@@ -4355,7 +4355,7 @@ translate_atomic_rbuf(JNIEnv *env, jlong mem_type_id, H5T_class_t type_class, vo
             void  *objBuf = NULL;
             size_t typeCount;
 
-            if (!(memb = H5Tget_super(mem_type_id)))
+            if ((memb = H5Tget_super(mem_type_id)) < 0)
                 H5_LIBRARY_ERROR(ENVONLY);
             if ((vlClass = H5Tget_class(memb)) < 0)
                 H5_LIBRARY_ERROR(ENVONLY);
@@ -4603,7 +4603,7 @@ translate_atomic_wbuf(JNIEnv *env, jobject in_obj, jlong mem_type_id, H5T_class_
 
     switch (type_class) {
         case H5T_VLEN: {
-            if (!(memb = H5Tget_super(mem_type_id)))
+            if ((memb = H5Tget_super(mem_type_id)) < 0)
                 H5_LIBRARY_ERROR(ENVONLY);
             if ((vlClass = H5Tget_class((hid_t)memb)) < 0)
                 H5_LIBRARY_ERROR(ENVONLY);
@@ -4686,7 +4686,7 @@ translate_atomic_wbuf(JNIEnv *env, jobject in_obj, jlong mem_type_id, H5T_class_
         case H5T_ARRAY: {
             void *objBuf = NULL;
 
-            if (!(memb = H5Tget_super(mem_type_id)))
+            if ((memb = H5Tget_super(mem_type_id)) < 0)
                 H5_LIBRARY_ERROR(ENVONLY);
             if ((vlClass = H5Tget_class(memb)) < 0)
                 H5_LIBRARY_ERROR(ENVONLY);
@@ -4916,7 +4916,7 @@ translate_rbuf(JNIEnv *env, jobjectArray ret_buf, jlong mem_type_id, H5T_class_t
 
     switch (type_class) {
         case H5T_VLEN: {
-            if (!(memb = H5Tget_super(mem_type_id)))
+            if ((memb = H5Tget_super(mem_type_id)) < 0)
                 H5_LIBRARY_ERROR(ENVONLY);
             if ((vlClass = H5Tget_class(memb)) < 0)
                 H5_LIBRARY_ERROR(ENVONLY);
@@ -4997,7 +4997,7 @@ translate_rbuf(JNIEnv *env, jobjectArray ret_buf, jlong mem_type_id, H5T_class_t
             void  *objBuf = NULL;
             size_t typeCount;
 
-            if (!(memb = H5Tget_super(mem_type_id)))
+            if ((memb = H5Tget_super(mem_type_id)) < 0)
                 H5_LIBRARY_ERROR(ENVONLY);
             if ((vlClass = H5Tget_class(memb)) < 0)
                 H5_LIBRARY_ERROR(ENVONLY);
@@ -5145,7 +5145,7 @@ translate_wbuf(JNIEnv *env, jobjectArray in_buf, jlong mem_type_id, H5T_class_t 
 
     switch (type_class) {
         case H5T_VLEN: {
-            if (!(memb = H5Tget_super(mem_type_id)))
+            if ((memb = H5Tget_super(mem_type_id)) < 0)
                 H5_LIBRARY_ERROR(ENVONLY);
             if ((vlClass = H5Tget_class((hid_t)memb)) < 0)
                 H5_LIBRARY_ERROR(ENVONLY);
@@ -5251,7 +5251,7 @@ translate_wbuf(JNIEnv *env, jobjectArray in_buf, jlong mem_type_id, H5T_class_t 
             break;
         } /* H5T_COMPOUND */
         case H5T_ARRAY: {
-            if (!(memb = H5Tget_super(mem_type_id)))
+            if ((memb = H5Tget_super(mem_type_id)) < 0)
                 H5_LIBRARY_ERROR(ENVONLY);
             if ((vlClass = H5Tget_class(memb)) < 0)
                 H5_LIBRARY_ERROR(ENVONLY);
@@ -5446,7 +5446,7 @@ h5validate_atomic_wbuf(JNIEnv *env, jobject in_obj, jlong mem_type_id, H5T_class
             if (!ENVPTR->IsInstanceOf(ENVONLY, in_obj, arrCList))
                 H5_BAD_ARGUMENT_ERROR(ENVONLY, "h5validate_wbuf: expected a java.util.ArrayList element");
 
-            if (!(memb = H5Tget_super(mem_type_id)))
+            if ((memb = H5Tget_super(mem_type_id)) < 0)
                 H5_LIBRARY_ERROR(ENVONLY);
             if ((vlClass = H5Tget_class(memb)) < 0)
                 H5_LIBRARY_ERROR(ENVONLY);


### PR DESCRIPTION
The base type lookups in the object-tree helpers tested the returned hid_t for truth rather than for a negative value. A failed lookup returns H5I_INVALID_HID, so any failure wouldn't be caught until later.

Rework the checks to use the more standard `< 0` comparison for ID-related failures.