### PR TITLE
Add stable, linkage-agnostic CMake target names

### DIFF
--- a/CMakeInstallation.cmake
+++ b/CMakeInstallation.cmake
@@ -169,6 +169,28 @@ if (NOT HDF5_EXTERNALLY_CONFIGURED)
 endif ()
 
 #-----------------------------------------------------------------------------
+# Ship the module that defines the public target names (hdf5::hdf5 and
+# friends) alongside the config file, which includes it from its own
+# directory.
+#
+# The copy into the build tree is what the build-tree config file includes,
+# so that consuming HDF5 from its build directory yields the same names as
+# consuming it from an installation.
+#-----------------------------------------------------------------------------
+configure_file (
+    ${HDF_RESOURCES_DIR}/HDF5PublicTargets.cmake
+    ${HDF5_BINARY_DIR}/HDF5PublicTargets.cmake
+    COPYONLY
+)
+if (NOT HDF5_EXTERNALLY_CONFIGURED)
+  install (
+      FILES ${HDF_RESOURCES_DIR}/HDF5PublicTargets.cmake
+      DESTINATION ${HDF5_INSTALL_CMAKE_DIR}
+      COMPONENT configinstall
+  )
+endif ()
+
+#-----------------------------------------------------------------------------
 # Add CMake Find modules to installation
 #-----------------------------------------------------------------------------
 install (

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1441,10 +1441,16 @@ set (H5PUB_CONCRETE_hdf5_hl_fortran_static "${HDF5_HL_F90_LIB_TARGET}")
 set (H5PUB_CONCRETE_hdf5_hl_fortran_shared "${HDF5_HL_F90_LIBSH_TARGET}")
 
 h5_define_public_tools (TOOLS ${HDF5_UTILS_TO_EXPORT})
+if (H5PUB_ERROR)
+  message (FATAL_ERROR "${H5PUB_ERROR}")
+endif ()
 
 h5_default_public_linkage ("${BUILD_SHARED_LIBS}" "${BUILD_STATIC_LIBS}" HDF5_PUBLIC_TARGET_LINKAGE)
 if (HDF5_PUBLIC_TARGET_LINKAGE)
   h5_define_public_targets (LINKAGE ${HDF5_PUBLIC_TARGET_LINKAGE})
+  if (H5PUB_ERROR)
+    message (FATAL_ERROR "${H5PUB_ERROR}")
+  endif ()
 endif ()
 
 #-----------------------------------------------------------------------------

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -535,6 +535,7 @@ include (${HDF_CONFIG_DIR}/HDFMacros.cmake)
 HDF_DIR_PATHS(${HDF5_PACKAGE_NAME})
 
 include (${HDF_CONFIG_DIR}/HDF5Macros.cmake)
+include (${HDF_RESOURCES_DIR}/HDF5PublicTargets.cmake)
 
 #-----------------------------------------------------------------------------
 # Targets built within this project are exported at Install time for use
@@ -1412,6 +1413,38 @@ if (EXISTS "${HDF5_SOURCE_DIR}/java" AND IS_DIRECTORY "${HDF5_SOURCE_DIR}/java")
       add_subdirectory (java)
     endif ()
   endif ()
+endif ()
+
+#-----------------------------------------------------------------------------
+# Define stable, linkage-agnostic public target names (hdf5::hdf5 and
+# friends) as aliases onto the built targets.
+#
+# This must appear AFTER every library and tool add_subdirectory() call, so
+# that all of the concrete targets exist and HDF5_UTILS_TO_EXPORT has
+# collected the full set of tool executables. It must appear BEFORE
+# HDF5Examples is added, so that the examples can consume the public names.
+#
+# The same names are defined for an installed package by hdf5-config.cmake,
+# which calls the same function from the same module.
+#-----------------------------------------------------------------------------
+set (H5PUB_CONCRETE_hdf5_static            "${HDF5_LIB_TARGET}")
+set (H5PUB_CONCRETE_hdf5_shared            "${HDF5_LIBSH_TARGET}")
+set (H5PUB_CONCRETE_hdf5_hl_static         "${HDF5_HL_LIB_TARGET}")
+set (H5PUB_CONCRETE_hdf5_hl_shared         "${HDF5_HL_LIBSH_TARGET}")
+set (H5PUB_CONCRETE_hdf5_cpp_static        "${HDF5_CPP_LIB_TARGET}")
+set (H5PUB_CONCRETE_hdf5_cpp_shared        "${HDF5_CPP_LIBSH_TARGET}")
+set (H5PUB_CONCRETE_hdf5_hl_cpp_static     "${HDF5_HL_CPP_LIB_TARGET}")
+set (H5PUB_CONCRETE_hdf5_hl_cpp_shared     "${HDF5_HL_CPP_LIBSH_TARGET}")
+set (H5PUB_CONCRETE_hdf5_fortran_static    "${HDF5_F90_LIB_TARGET}")
+set (H5PUB_CONCRETE_hdf5_fortran_shared    "${HDF5_F90_LIBSH_TARGET}")
+set (H5PUB_CONCRETE_hdf5_hl_fortran_static "${HDF5_HL_F90_LIB_TARGET}")
+set (H5PUB_CONCRETE_hdf5_hl_fortran_shared "${HDF5_HL_F90_LIBSH_TARGET}")
+
+h5_define_public_tools (TOOLS ${HDF5_UTILS_TO_EXPORT})
+
+h5_default_public_linkage ("${BUILD_SHARED_LIBS}" "${BUILD_STATIC_LIBS}" HDF5_PUBLIC_TARGET_LINKAGE)
+if (HDF5_PUBLIC_TARGET_LINKAGE)
+  h5_define_public_targets (LINKAGE ${HDF5_PUBLIC_TARGET_LINKAGE})
 endif ()
 
 #-----------------------------------------------------------------------------

--- a/HDF5Examples/config/cmake/HDFExampleMacros.cmake
+++ b/HDF5Examples/config/cmake/HDFExampleMacros.cmake
@@ -224,7 +224,14 @@ macro (HDF5_SUPPORT)
         endif ()
         get_filename_component (_LIBRARY_PATH ${HDF5_INCLUDE_DIR} DIRECTORY)
         set (HDF5_LIBRARY_PATH "${_LIBRARY_PATH}/lib")
-        if (H5EXAMPLE_USE_SHARED_LIBS AND HDF5_shared_C_FOUND)
+        # This configures against an external HDF5, which may predate 2.3.0.
+        # As such, the arms that decide between HDF5_C_SHARED_LIBRARY and
+        # HDF5_C_STATIC_LIBRARY are left in place, even though from 2.3.0 on
+        # the stable target names do not encode the linkage and find_package()
+        # has already selected one via the component list.
+        if (TARGET hdf5::hdf5)
+          set (H5EXAMPLE_HDF5_LINK_LIBS ${H5EXAMPLE_HDF5_LINK_LIBS} hdf5::hdf5)
+        elseif (H5EXAMPLE_USE_SHARED_LIBS AND HDF5_shared_C_FOUND)
           set (H5EXAMPLE_HDF5_LINK_LIBS ${H5EXAMPLE_HDF5_LINK_LIBS} ${HDF5_C_SHARED_LIBRARY})
         else ()
           set (H5EXAMPLE_HDF5_LINK_LIBS ${H5EXAMPLE_HDF5_LINK_LIBS} ${HDF5_C_STATIC_LIBRARY})

--- a/config/cmake/HDF5PublicTargets.cmake
+++ b/config/cmake/HDF5PublicTargets.cmake
@@ -33,12 +33,14 @@
 # The module defines identical names across the HDF5 build tree,
 # add_subdirectory() embeddings, and find_package() installations.
 #
-# This module is purely additive with respect to the pre-2.3.0 targets. It
-# defines new names and neither removes nor alters the existing hdf5-static /
-# hdf5-shared targets or the HDF5_<lang>_<LINKAGE>_LIBRARY variables.
+# This module only defines names. It neither removes nor alters the pre-2.3.0
+# hdf5-static / hdf5-shared targets or the HDF5_<lang>_<LINKAGE>_LIBRARY
+# variables.
 #
 # The default linkage is shared if shared libraries are available, otherwise
-# static.
+# static. As of 2.3.0 the rest of the package resolves the same way, reversing
+# the pre-2.3.0 preference for static in a find_package() call that names no
+# linkage component.
 # -----------------------------------------------------------------------------
 
 # The public library names this module can define. For each one, the caller

--- a/config/cmake/HDF5PublicTargets.cmake
+++ b/config/cmake/HDF5PublicTargets.cmake
@@ -97,14 +97,22 @@ function (h5_define_public_tools)
       continue ()
     endif ()
 
+    # Tools carry no linkage suffix, so wherever the export namespace is
+    # already hdf5:: the exported name is the public name and there is
+    # nothing to alias.
+    if (_concrete STREQUAL "hdf5::${_tool}")
+      continue ()
+    endif ()
+
     # Same rule as the libraries: an existing name must refer to our executable,
     # or the consumer runs someone else's under the hdf5:: namespace.
     if (TARGET "hdf5::${_tool}")
       get_target_property (_aliased "hdf5::${_tool}" ALIASED_TARGET)
       if (NOT _aliased STREQUAL _concrete)
         message (FATAL_ERROR
-            "hdf5::${_tool} already exists and refers to ${_aliased}, not "
-            "${_concrete}. Has another project has claimed an hdf5:: name?")
+            "hdf5::${_tool} already exists and does not refer to ${_concrete}. "
+            "Another project (possibly CMake's own FindHDF5 module) has "
+            "claimed a name in the hdf5:: namespace.")
       endif ()
     else ()
       add_executable ("hdf5::${_tool}" ALIAS "${_concrete}")

--- a/config/cmake/HDF5PublicTargets.cmake
+++ b/config/cmake/HDF5PublicTargets.cmake
@@ -87,9 +87,14 @@ endfunction ()
 #
 # PREFIX is prepended to the concrete target names before lookup: empty in
 # HDF5's build tree, HDF_PACKAGE_NAMESPACE in an installed package.
+#
+# Sets H5PUB_ERROR in the caller's scope to a message if a public name is
+# already claimed by an unrelated target, and to an empty string otherwise.
 #-----------------------------------------------------------------------------
 function (h5_define_public_tools)
   cmake_parse_arguments (H5PUB "" "PREFIX" "TOOLS" ${ARGN})
+
+  set (H5PUB_ERROR "" PARENT_SCOPE)
 
   foreach (_tool IN LISTS H5PUB_TOOLS)
     set (_concrete "${H5PUB_PREFIX}${_tool}")
@@ -109,10 +114,10 @@ function (h5_define_public_tools)
     if (TARGET "hdf5::${_tool}")
       get_target_property (_aliased "hdf5::${_tool}" ALIASED_TARGET)
       if (NOT _aliased STREQUAL _concrete)
-        message (FATAL_ERROR
-            "hdf5::${_tool} already exists and does not refer to ${_concrete}. "
-            "Another project (possibly CMake's own FindHDF5 module) has "
-            "claimed a name in the hdf5:: namespace.")
+        set (H5PUB_ERROR
+            "hdf5::${_tool} already exists and does not refer to ${_concrete}. Another project (possibly CMake's own FindHDF5 module) has claimed a name in the hdf5:: namespace."
+            PARENT_SCOPE)
+        return ()
       endif ()
     else ()
       add_executable ("hdf5::${_tool}" ALIAS "${_concrete}")
@@ -130,21 +135,24 @@ endfunction ()
 #
 # Components that were not built are skipped silently. Every name is guarded
 # by an existence check, so repeated calls are harmless. A name already
-# claimed by another project, referring to a different target, is a fatal
-# error -- see the loop below.
+# claimed by another project, referring to a different target, is reported
+# through H5PUB_ERROR.
 #
 # The caller must have set H5PUB_CONCRETE_<name>_<linkage> for each public
 # library name it wants defined.
+#
+# Sets H5PUB_ERROR in the caller's scope as h5_define_public_tools() does.
 #-----------------------------------------------------------------------------
 function (h5_define_public_targets)
   cmake_parse_arguments (H5PUB "" "LINKAGE;PREFIX" "" ${ARGN})
 
-  if (NOT H5PUB_LINKAGE)
-    message (FATAL_ERROR "h5_define_public_targets: LINKAGE is required")
-  endif ()
+  set (H5PUB_ERROR "" PARENT_SCOPE)
+
   if (NOT H5PUB_LINKAGE STREQUAL "shared" AND NOT H5PUB_LINKAGE STREQUAL "static")
-    message (FATAL_ERROR
-        "h5_define_public_targets: LINKAGE must be \"shared\" or \"static\", got \"${H5PUB_LINKAGE}\"")
+    set (H5PUB_ERROR
+        "h5_define_public_targets: LINKAGE must be \"shared\" or \"static\", got \"${H5PUB_LINKAGE}\"."
+        PARENT_SCOPE)
+    return ()
   endif ()
 
   set (_public_targets_defined)
@@ -164,9 +172,10 @@ function (h5_define_public_targets)
     if (TARGET "hdf5::${_public_name}")
       get_target_property (_aliased "hdf5::${_public_name}" ALIASED_TARGET)
       if (NOT _aliased STREQUAL _concrete)
-        message (FATAL_ERROR
-            "hdf5::${_public_name} already exists and refers to ${_aliased}, not "
-            "${_concrete} -- another project has claimed the hdf5:: names.")
+        set (H5PUB_ERROR
+            "hdf5::${_public_name} already exists and refers to ${_aliased}, not ${_concrete} -- another project has claimed the hdf5:: names."
+            PARENT_SCOPE)
+        return ()
       endif ()
     else ()
       add_library ("hdf5::${_public_name}" ALIAS "${_concrete}")

--- a/config/cmake/HDF5PublicTargets.cmake
+++ b/config/cmake/HDF5PublicTargets.cmake
@@ -91,7 +91,20 @@ function (h5_define_public_tools)
 
   foreach (_tool IN LISTS H5PUB_TOOLS)
     set (_concrete "${H5PUB_PREFIX}${_tool}")
-    if (TARGET "${_concrete}" AND NOT TARGET "hdf5::${_tool}")
+    if (NOT TARGET "${_concrete}")
+      continue ()
+    endif ()
+
+    # Same rule as the libraries: an existing name must refer to our executable,
+    # or the consumer runs someone else's under the hdf5:: namespace.
+    if (TARGET "hdf5::${_tool}")
+      get_target_property (_aliased "hdf5::${_tool}" ALIASED_TARGET)
+      if (NOT _aliased STREQUAL _concrete)
+        message (FATAL_ERROR
+            "hdf5::${_tool} already exists and refers to ${_aliased}, not "
+            "${_concrete}. Has another project has claimed an hdf5:: name?")
+      endif ()
+    else ()
       add_executable ("hdf5::${_tool}" ALIAS "${_concrete}")
     endif ()
   endforeach ()
@@ -129,27 +142,26 @@ function (h5_define_public_targets)
   foreach (_public_name IN LISTS HDF5_PUBLIC_LIBRARY_NAMES)
     set (_concrete "${H5PUB_PREFIX}${H5PUB_CONCRETE_${_public_name}_${H5PUB_LINKAGE}}")
 
-    # A name that already exists is left alone, but must still refer to the
-    # target we would have aliased -- otherwise the consumer links something
-    # other than this HDF5. Nothing to check when our own component was not
-    # built, since then we have no expectation to compare against.
-    if (TARGET "hdf5::${_public_name}")
-      get_target_property (_aliased "hdf5::${_public_name}" ALIASED_TARGET)
-      if (TARGET "${_concrete}" AND NOT _aliased STREQUAL _concrete)
-        message (FATAL_ERROR
-            "hdf5::${_public_name} already exists and refers to ${_aliased}, not "
-            "${_concrete} -- another project has claimed the hdf5:: names.")
-      endif ()
-      list (APPEND _public_targets_defined "hdf5::${_public_name}")
-      continue ()
-    endif ()
-
-    # Components that were not built have no public name.
+    # Components that were not built have no public name. A same-named target
+    # from somewhere else is not ours to check, and must not reach the
+    # aggregate either.
     if (NOT TARGET "${_concrete}")
       continue ()
     endif ()
 
-    add_library ("hdf5::${_public_name}" ALIAS "${_concrete}")
+    # A name that already exists is left alone, but must refer to the target we
+    # would have aliased.
+    if (TARGET "hdf5::${_public_name}")
+      get_target_property (_aliased "hdf5::${_public_name}" ALIASED_TARGET)
+      if (NOT _aliased STREQUAL _concrete)
+        message (FATAL_ERROR
+            "hdf5::${_public_name} already exists and refers to ${_aliased}, not "
+            "${_concrete} -- another project has claimed the hdf5:: names.")
+      endif ()
+    else ()
+      add_library ("hdf5::${_public_name}" ALIAS "${_concrete}")
+    endif ()
+
     list (APPEND _public_targets_defined "hdf5::${_public_name}")
   endforeach ()
 

--- a/config/cmake/HDF5PublicTargets.cmake
+++ b/config/cmake/HDF5PublicTargets.cmake
@@ -1,0 +1,170 @@
+#
+# Copyright by The HDF Group.
+# All rights reserved.
+#
+# This file is part of HDF5.  The full HDF5 copyright notice, including
+# terms governing use, modification, and redistribution, is contained in
+# the LICENSE file, which can be found at the root of the source code
+# distribution tree, or in https://www.hdfgroup.org/licenses.
+# If you do not have access to either file, you may request a copy from
+# help@hdfgroup.org.
+#
+
+# -----------------------------------------------------------------------------
+# HDF5 public (stable) CMake target names
+# -----------------------------------------------------------------------------
+#
+# This module defines a parallel set of stable, linkage-agnostic names:
+#
+#   hdf5::hdf5              the C library
+#   hdf5::hdf5_hl           the high-level C library
+#   hdf5::hdf5_cpp          the C++ bindings
+#   hdf5::hdf5_hl_cpp       the high-level C++ bindings
+#   hdf5::hdf5_fortran      the Fortran bindings
+#   hdf5::hdf5_hl_fortran   the high-level Fortran bindings
+#   hdf5::<tool>            each installed tool executable, e.g. hdf5::h5diff
+#   HDF5::HDF5              aggregate of the available library targets
+#
+# Each name is an ALIAS onto the concrete target for the selected linkage, so
+# the public name and the legacy (pre-2.3.0) name refer to the same target.
+#
+# These names match the ones in CMake's FindHDF5 module.
+#
+# The module defines identical names across the HDF5 build tree,
+# add_subdirectory() embeddings, and find_package() installations.
+#
+# This module is purely additive with respect to the pre-2.3.0 targets. It
+# defines new names and neither removes nor alters the existing hdf5-static /
+# hdf5-shared targets or the HDF5_<lang>_<LINKAGE>_LIBRARY variables.
+#
+# The default linkage is shared if shared libraries are available, otherwise
+# static.
+# -----------------------------------------------------------------------------
+
+# The public library names this module can define. For each one, the caller
+# sets H5PUB_CONCRETE_<name>_static and H5PUB_CONCRETE_<name>_shared to the
+# corresponding concrete target names before calling
+# h5_define_public_targets(), leaving unset whatever was not built.
+#
+# The H5PUB_ prefix keeps these out of the consuming project's namespace:
+# hdf5-config.cmake runs in the consumer's variable scope and unsets them once
+# the targets are defined.
+set (HDF5_PUBLIC_LIBRARY_NAMES
+    hdf5
+    hdf5_hl
+    hdf5_cpp
+    hdf5_hl_cpp
+    hdf5_fortran
+    hdf5_hl_fortran
+)
+
+#-----------------------------------------------------------------------------
+# h5_default_public_linkage (<shared_available> <static_available> <out_var>)
+#
+# Sets <out_var> in the caller's scope to the linkage to use when the consumer
+# expresses no preference: prefer shared, fall back to static, empty string if
+# neither was built.
+#-----------------------------------------------------------------------------
+function (h5_default_public_linkage _shared_available _static_available _out_var)
+  if (_shared_available)
+    set (${_out_var} "shared" PARENT_SCOPE)
+  elseif (_static_available)
+    set (${_out_var} "static" PARENT_SCOPE)
+  else ()
+    set (${_out_var} "" PARENT_SCOPE)
+  endif ()
+endfunction ()
+
+#-----------------------------------------------------------------------------
+# h5_define_public_tools ([PREFIX <prefix>] TOOLS <target> ...)
+#
+# Defines hdf5::<tool> for each named tool executable.
+#
+# Tool targets are already linkage-agnostic, so this is independent of the
+# library linkage selection.
+#
+# PREFIX is prepended to the concrete target names before lookup: empty in
+# HDF5's build tree, HDF_PACKAGE_NAMESPACE in an installed package.
+#-----------------------------------------------------------------------------
+function (h5_define_public_tools)
+  cmake_parse_arguments (H5PUB "" "PREFIX" "TOOLS" ${ARGN})
+
+  foreach (_tool IN LISTS H5PUB_TOOLS)
+    set (_concrete "${H5PUB_PREFIX}${_tool}")
+    if (TARGET "${_concrete}" AND NOT TARGET "hdf5::${_tool}")
+      add_executable ("hdf5::${_tool}" ALIAS "${_concrete}")
+    endif ()
+  endforeach ()
+endfunction ()
+
+#-----------------------------------------------------------------------------
+# h5_define_public_targets (LINKAGE <shared|static> [PREFIX <prefix>])
+#
+# Defines the public library names listed above, plus the HDF5::HDF5
+# aggregate, as aliases onto the concrete targets for LINKAGE.
+#
+# PREFIX has the same meaning as in h5_define_public_tools() above.
+#
+# Components that were not built are skipped silently. Every name is guarded
+# by an existence check, so repeated calls are harmless. A name already
+# claimed by another project, referring to a different target, is a fatal
+# error -- see the loop below.
+#
+# The caller must have set H5PUB_CONCRETE_<name>_<linkage> for each public
+# library name it wants defined.
+#-----------------------------------------------------------------------------
+function (h5_define_public_targets)
+  cmake_parse_arguments (H5PUB "" "LINKAGE;PREFIX" "" ${ARGN})
+
+  if (NOT H5PUB_LINKAGE)
+    message (FATAL_ERROR "h5_define_public_targets: LINKAGE is required")
+  endif ()
+  if (NOT H5PUB_LINKAGE STREQUAL "shared" AND NOT H5PUB_LINKAGE STREQUAL "static")
+    message (FATAL_ERROR
+        "h5_define_public_targets: LINKAGE must be \"shared\" or \"static\", got \"${H5PUB_LINKAGE}\"")
+  endif ()
+
+  set (_public_targets_defined)
+
+  foreach (_public_name IN LISTS HDF5_PUBLIC_LIBRARY_NAMES)
+    set (_concrete "${H5PUB_PREFIX}${H5PUB_CONCRETE_${_public_name}_${H5PUB_LINKAGE}}")
+
+    # A name that already exists is left alone, but must still refer to the
+    # target we would have aliased -- otherwise the consumer links something
+    # other than this HDF5. Nothing to check when our own component was not
+    # built, since then we have no expectation to compare against.
+    if (TARGET "hdf5::${_public_name}")
+      get_target_property (_aliased "hdf5::${_public_name}" ALIASED_TARGET)
+      if (TARGET "${_concrete}" AND NOT _aliased STREQUAL _concrete)
+        message (FATAL_ERROR
+            "hdf5::${_public_name} already exists and refers to ${_aliased}, not "
+            "${_concrete} -- another project has claimed the hdf5:: names.")
+      endif ()
+      list (APPEND _public_targets_defined "hdf5::${_public_name}")
+      continue ()
+    endif ()
+
+    # Components that were not built have no public name.
+    if (NOT TARGET "${_concrete}")
+      continue ()
+    endif ()
+
+    add_library ("hdf5::${_public_name}" ALIAS "${_concrete}")
+    list (APPEND _public_targets_defined "hdf5::${_public_name}")
+  endforeach ()
+
+  # HDF5::HDF5 aggregates the available library targets, matching FindHDF5's
+  # convenience target. It stands for more than one target, so it is an
+  # INTERFACE library rather than an alias, and $<TARGET_FILE:> does not apply
+  # to it.
+  #
+  # A name containing "::" must be IMPORTED or an ALIAS, and IMPORTED targets
+  # are scoped to the directory that creates them. GLOBAL is therefore required
+  # for an add_subdirectory() embedding.
+  if (_public_targets_defined AND NOT TARGET HDF5::HDF5)
+    add_library (HDF5::HDF5 INTERFACE IMPORTED GLOBAL)
+    set_target_properties (HDF5::HDF5 PROPERTIES
+        INTERFACE_LINK_LIBRARIES "${_public_targets_defined}"
+    )
+  endif ()
+endfunction ()

--- a/config/install/hdf5-config.cmake.in
+++ b/config/install/hdf5-config.cmake.in
@@ -371,6 +371,13 @@ h5_define_public_tools (
     PREFIX "@HDF_PACKAGE_NAMESPACE@"
     TOOLS  @HDF5_UTILS_TO_EXPORT@
 )
+if (H5PUB_ERROR)
+  set (${HDF5_PACKAGE_NAME}_FOUND FALSE)
+  set (${HDF5_PACKAGE_NAME}_NOT_FOUND_MESSAGE "${H5PUB_ERROR}")
+  unset (H5PUB_ERROR)
+  unset (HDF5_PUBLIC_LIBRARY_NAMES)
+  return ()
+endif ()
 
 h5_default_public_linkage (
     "${${HDF5_PACKAGE_NAME}_PROVIDES_SHARED_LIBS}"
@@ -382,16 +389,11 @@ list (FIND ${HDF5_PACKAGE_NAME}_LIB_TYPE "shared" _h5_wants_shared)
 list (FIND ${HDF5_PACKAGE_NAME}_LIB_TYPE "static" _h5_wants_static)
 
 if (_h5_wants_shared GREATER -1 AND _h5_wants_static GREATER -1)
-  # Both linkages were requested. The pre-2.3.0 variables can express that, but
-  # a single public target name cannot, so fall back to the default and say so
-  # rather than picking one silently.
+  # Both linkages were requested, and both are available. The
+  # ${HDF5_PACKAGE_NAME}_<lang>_<LINKAGE>_LIBRARY variables can name both and
+  # still do, but a single public target name cannot, so the public names fall
+  # back to the default linkage.
   set (_h5_public_linkage "${_h5_default_linkage}")
-  message (WARNING
-      "find_package(${CMAKE_FIND_PACKAGE_NAME}) requested both the \"static\" and \"shared\" "
-      "components. The hdf5:: targets can only refer to one linkage and will refer to the "
-      "${_h5_public_linkage} libraries. Request exactly one of \"static\" or \"shared\", or set "
-      "HDF5_USE_STATIC_LIBRARIES, to choose deliberately. The "
-      "${HDF5_PACKAGE_NAME}_<lang>_<LINKAGE>_LIBRARY variables still name both.")
 elseif (_h5_wants_shared GREATER -1)
   set (_h5_public_linkage "shared")
 elseif (_h5_wants_static GREATER -1)
@@ -403,13 +405,13 @@ else ()
 endif ()
 
 if (_h5_public_linkage STREQUAL "shared" AND NOT ${HDF5_PACKAGE_NAME}_PROVIDES_SHARED_LIBS)
-  message (WARNING
-      "This HDF5 installation does not provide shared libraries, so no hdf5:: targets were "
-      "defined. Request the \"static\" component instead.")
+  set (${HDF5_PACKAGE_NAME}_FOUND FALSE)
+  set (${HDF5_PACKAGE_NAME}_NOT_FOUND_MESSAGE
+      "The shared libraries were requested, but this HDF5 installation only provides static libraries. Request the \"static\" component instead.")
 elseif (_h5_public_linkage STREQUAL "static" AND NOT ${HDF5_PACKAGE_NAME}_PROVIDES_STATIC_LIBS)
-  message (WARNING
-      "This HDF5 installation does not provide static libraries, so no hdf5:: targets were "
-      "defined. Request the \"shared\" component instead.")
+  set (${HDF5_PACKAGE_NAME}_FOUND FALSE)
+  set (${HDF5_PACKAGE_NAME}_NOT_FOUND_MESSAGE
+      "The static libraries were requested, but this HDF5 installation only provides shared libraries. Request the \"shared\" component instead.")
 elseif (_h5_public_linkage)
   # The concrete names are substituted in from the build that produced this
   # installation, so a build that renamed its libraries via HDF5_LIB_BASE still
@@ -439,8 +441,14 @@ elseif (_h5_public_linkage)
     unset (H5PUB_CONCRETE_${_h5_name}_shared)
   endforeach ()
   unset (_h5_name)
+
+  if (H5PUB_ERROR)
+    set (${HDF5_PACKAGE_NAME}_FOUND FALSE)
+    set (${HDF5_PACKAGE_NAME}_NOT_FOUND_MESSAGE "${H5PUB_ERROR}")
+  endif ()
 endif ()
 
+unset (H5PUB_ERROR)
 unset (_h5_default_linkage)
 unset (_h5_wants_shared)
 unset (_h5_wants_static)

--- a/config/install/hdf5-config.cmake.in
+++ b/config/install/hdf5-config.cmake.in
@@ -346,6 +346,104 @@ foreach (libtype IN LISTS ${HDF5_PACKAGE_NAME}_LIB_TYPE)
   endforeach ()
 endforeach ()
 
+#-----------------------------------------------------------------------------
+# Stable, linkage-agnostic public target names: hdf5::hdf5, hdf5::hdf5_hl,
+# HDF5::HDF5 and friends.
+#
+# These are aliases onto the linkage-qualified targets loaded above, so they
+# are purely additive -- the targets and the HDF5_<lang>_<LINKAGE>_LIBRARY
+# variables set above are untouched. See HDF5PublicTargets.cmake for the full
+# list of names.
+#
+# Which linkage the public names resolve to, in order of precedence:
+#   1. an explicit "static" or "shared" component
+#   2. HDF5_USE_STATIC_LIBRARIES, for consistency with CMake's FindHDF5
+#   3. shared if this installation provides it, otherwise static
+#-----------------------------------------------------------------------------
+include ("${CMAKE_CURRENT_LIST_DIR}/HDF5PublicTargets.cmake")
+
+# Tool executables have no linkage variants, so they are defined independently
+# of the library linkage.
+h5_define_public_tools (
+    PREFIX "@HDF_PACKAGE_NAMESPACE@"
+    TOOLS  @HDF5_UTILS_TO_EXPORT@
+)
+
+h5_default_public_linkage (
+    "${${HDF5_PACKAGE_NAME}_PROVIDES_SHARED_LIBS}"
+    "${${HDF5_PACKAGE_NAME}_PROVIDES_STATIC_LIBS}"
+    _h5_default_linkage
+)
+
+list (FIND ${HDF5_PACKAGE_NAME}_LIB_TYPE "shared" _h5_wants_shared)
+list (FIND ${HDF5_PACKAGE_NAME}_LIB_TYPE "static" _h5_wants_static)
+
+if (_h5_wants_shared GREATER -1 AND _h5_wants_static GREATER -1)
+  # Both linkages were requested. The pre-2.3.0 variables can express that, but
+  # a single public target name cannot, so fall back to the default and say so
+  # rather than picking one silently.
+  set (_h5_public_linkage "${_h5_default_linkage}")
+  message (WARNING
+      "find_package(${CMAKE_FIND_PACKAGE_NAME}) requested both the \"static\" and \"shared\" "
+      "components. The hdf5:: targets can only refer to one linkage and will refer to the "
+      "${_h5_public_linkage} libraries. Request exactly one of \"static\" or \"shared\", or set "
+      "HDF5_USE_STATIC_LIBRARIES, to choose deliberately. The "
+      "${HDF5_PACKAGE_NAME}_<lang>_<LINKAGE>_LIBRARY variables still name both.")
+elseif (_h5_wants_shared GREATER -1)
+  set (_h5_public_linkage "shared")
+elseif (_h5_wants_static GREATER -1)
+  set (_h5_public_linkage "static")
+elseif (HDF5_USE_STATIC_LIBRARIES)
+  set (_h5_public_linkage "static")
+else ()
+  set (_h5_public_linkage "${_h5_default_linkage}")
+endif ()
+
+if (_h5_public_linkage STREQUAL "shared" AND NOT ${HDF5_PACKAGE_NAME}_PROVIDES_SHARED_LIBS)
+  message (WARNING
+      "This HDF5 installation does not provide shared libraries, so no hdf5:: targets were "
+      "defined. Request the \"static\" component instead.")
+elseif (_h5_public_linkage STREQUAL "static" AND NOT ${HDF5_PACKAGE_NAME}_PROVIDES_STATIC_LIBS)
+  message (WARNING
+      "This HDF5 installation does not provide static libraries, so no hdf5:: targets were "
+      "defined. Request the \"shared\" component instead.")
+elseif (_h5_public_linkage)
+  # The concrete names are substituted in from the build that produced this
+  # installation, so a build that renamed its libraries via HDF5_LIB_BASE still
+  # gets the same public names. These are the same target variables the build
+  # tree passes to h5_define_public_targets(), so the linkage suffix convention
+  # is not restated here.
+  set (H5PUB_CONCRETE_hdf5_static            "@HDF5_LIB_TARGET@")
+  set (H5PUB_CONCRETE_hdf5_shared            "@HDF5_LIBSH_TARGET@")
+  set (H5PUB_CONCRETE_hdf5_hl_static         "@HDF5_HL_LIB_TARGET@")
+  set (H5PUB_CONCRETE_hdf5_hl_shared         "@HDF5_HL_LIBSH_TARGET@")
+  set (H5PUB_CONCRETE_hdf5_cpp_static        "@HDF5_CPP_LIB_TARGET@")
+  set (H5PUB_CONCRETE_hdf5_cpp_shared        "@HDF5_CPP_LIBSH_TARGET@")
+  set (H5PUB_CONCRETE_hdf5_hl_cpp_static     "@HDF5_HL_CPP_LIB_TARGET@")
+  set (H5PUB_CONCRETE_hdf5_hl_cpp_shared     "@HDF5_HL_CPP_LIBSH_TARGET@")
+  set (H5PUB_CONCRETE_hdf5_fortran_static    "@HDF5_F90_LIB_TARGET@")
+  set (H5PUB_CONCRETE_hdf5_fortran_shared    "@HDF5_F90_LIBSH_TARGET@")
+  set (H5PUB_CONCRETE_hdf5_hl_fortran_static "@HDF5_HL_F90_LIB_TARGET@")
+  set (H5PUB_CONCRETE_hdf5_hl_fortran_shared "@HDF5_HL_F90_LIBSH_TARGET@")
+
+  h5_define_public_targets (
+      LINKAGE ${_h5_public_linkage}
+      PREFIX  "@HDF_PACKAGE_NAMESPACE@"
+  )
+
+  foreach (_h5_name IN LISTS HDF5_PUBLIC_LIBRARY_NAMES)
+    unset (H5PUB_CONCRETE_${_h5_name}_static)
+    unset (H5PUB_CONCRETE_${_h5_name}_shared)
+  endforeach ()
+  unset (_h5_name)
+endif ()
+
+unset (_h5_default_linkage)
+unset (_h5_wants_shared)
+unset (_h5_wants_static)
+unset (_h5_public_linkage)
+unset (HDF5_PUBLIC_LIBRARY_NAMES)
+
 foreach (libtype IN LISTS ${HDF5_PACKAGE_NAME}_LIB_TYPE)
   check_required_components(${HDF5_PACKAGE_NAME}_${libtype})
 endforeach ()

--- a/config/install/hdf5-config.cmake.in
+++ b/config/install/hdf5-config.cmake.in
@@ -250,16 +250,19 @@ if (NOT TARGET "@HDF5_PACKAGE@")
   endif ()
 endif ()
 
-# Handle default component(static) :
+# Handle the default components when no linkage was requested. HDF5_USE_STATIC_LIBRARIES
+# asks for static, for consistency with CMake's FindHDF5; otherwise shared is preferred
+# and static is the fallback. This is the same order the public hdf5:: targets below
+# resolve, so the targets and the ${HDF5_PACKAGE_NAME}_<lang>_<LINKAGE>_LIBRARY variables
+# agree on the linkage.
 if (NOT ${HDF5_PACKAGE_NAME}_FIND_COMPONENTS)
-  if (${HDF5_PACKAGE_NAME}_PROVIDES_STATIC_LIBS)
-    set (${HDF5_PACKAGE_NAME}_LIB_TYPE)
-    set (${HDF5_PACKAGE_NAME}_FIND_COMPONENTS C HL static)
-    set (${HDF5_PACKAGE_NAME}_FIND_REQUIRED_static_C true)
-  else ()
-    set (${HDF5_PACKAGE_NAME}_LIB_TYPE)
+  set (${HDF5_PACKAGE_NAME}_LIB_TYPE)
+  if (${HDF5_PACKAGE_NAME}_PROVIDES_SHARED_LIBS AND NOT (HDF5_USE_STATIC_LIBRARIES AND ${HDF5_PACKAGE_NAME}_PROVIDES_STATIC_LIBS))
     set (${HDF5_PACKAGE_NAME}_FIND_COMPONENTS C HL shared)
     set (${HDF5_PACKAGE_NAME}_FIND_REQUIRED_shared_C true)
+  else ()
+    set (${HDF5_PACKAGE_NAME}_FIND_COMPONENTS C HL static)
+    set (${HDF5_PACKAGE_NAME}_FIND_REQUIRED_static_C true)
   endif ()
 endif ()
 
@@ -350,10 +353,10 @@ endforeach ()
 # Stable, linkage-agnostic public target names: hdf5::hdf5, hdf5::hdf5_hl,
 # HDF5::HDF5 and friends.
 #
-# These are aliases onto the linkage-qualified targets loaded above, so they
-# are purely additive -- the targets and the HDF5_<lang>_<LINKAGE>_LIBRARY
-# variables set above are untouched. See HDF5PublicTargets.cmake for the full
-# list of names.
+# These are aliases onto the linkage-qualified targets loaded above, so defining
+# them neither removes nor alters those targets or the
+# HDF5_<lang>_<LINKAGE>_LIBRARY variables set above. See HDF5PublicTargets.cmake
+# for the full list of names.
 #
 # Which linkage the public names resolve to, in order of precedence:
 #   1. an explicit "static" or "shared" component

--- a/docs/INSTALL_CMake.md
+++ b/docs/INSTALL_CMake.md
@@ -989,10 +989,17 @@ use forward slashes)
 Add the following to your `CMakeLists.txt` file:
 ```cmake
 find_package (HDF5 NAMES hdf5 COMPONENTS C shared)
+target_link_libraries (my_app PRIVATE hdf5::hdf5)
 ```
 
 The components are optional and can be omitted if not needed. The
 components are: `shared`, `static`, `C`, `CXX`, `Fortran`, `HL`, `Java`, `Tools`, and `VOL`.
+Omitting `shared` and `static` lets HDF5 choose, preferring shared libraries.
+
+Link against the `hdf5::` targets, such as `hdf5::hdf5` and `hdf5::hdf5_hl`. The
+linkage-qualified `hdf5-shared` and `hdf5-static` names are deprecated as of 2.3.0
+and will be removed in a future major release. See
+[USING_HDF5_CMake.md](USING_HDF5_CMake.md) for the full list of target names.
 
 ---
 

--- a/docs/USING_HDF5_CMake.md
+++ b/docs/USING_HDF5_CMake.md
@@ -206,7 +206,8 @@ target_link_libraries (${example} PRIVATE hdf5::hdf5)
 
 Setting `HDF5_USE_STATIC_LIBRARIES` before `find_package()` has the same
 effect, matching `FindHDF5`. Requesting both `static` and `shared` leaves the
-public targets on the default and warns, since one name cannot refer to both.
+public targets on the default, since one name cannot refer to both; the
+`HDF5_<lang>_<LINKAGE>_LIBRARY` variables still name both.
 
 This preference applies to the whole `find_package()` call, not just to the
 public targets: it also decides which `HDF5_<lang>_<LINKAGE>_LIBRARY` variables

--- a/docs/USING_HDF5_CMake.md
+++ b/docs/USING_HDF5_CMake.md
@@ -214,9 +214,23 @@ and Fortran module directory are set. Before HDF5 2.3.0, a call that named no
 linkage component preferred the static libraries. A project that relied on that
 should request the `static` component or set `HDF5_USE_STATIC_LIBRARIES`.
 
-The linkage-qualified `hdf5-shared` and `hdf5-static` targets and the
-`HDF5_C_SHARED_LIBRARY` / `HDF5_C_STATIC_LIBRARY` variables remain available
-for existing projects.
+#### Deprecated names
+
+The linkage-qualified targets, and the library variables that go with them, are
+deprecated as of 2.3.0:
+
+| Deprecated | Use instead |
+| ---------- | ----------- |
+| `hdf5-shared`, `hdf5-static` | `hdf5::hdf5` |
+| `hdf5_hl-shared`, `hdf5_hl-static` | `hdf5::hdf5_hl` |
+| `hdf5_cpp-shared`, `hdf5_cpp-static` | `hdf5::hdf5_cpp` |
+| `hdf5_hl_cpp-shared`, `hdf5_hl_cpp-static` | `hdf5::hdf5_hl_cpp` |
+| `hdf5_fortran-shared`, `hdf5_fortran-static` | `hdf5::hdf5_fortran` |
+| `hdf5_hl_fortran-shared`, `hdf5_hl_fortran-static` | `hdf5::hdf5_hl_fortran` |
+| `HDF5_<lang>_SHARED_LIBRARY`, `HDF5_<lang>_STATIC_LIBRARY` | the matching `hdf5::` target |
+
+They will be removed in a future major release, so new projects should use the `hdf5::` names, and existing
+projects should migrate to use the new names.
 
 ---
 

--- a/docs/USING_HDF5_CMake.md
+++ b/docs/USING_HDF5_CMake.md
@@ -195,8 +195,9 @@ built as a subproject with `add_subdirectory()`, so the same
 
 #### Choosing static or shared
 
-When an installation provides both, the public targets refer to the shared
-libraries. To choose deliberately, request the linkage as a component:
+When an installation provides both, `find_package()` resolves to the shared
+libraries and falls back to static. To choose deliberately, request the linkage
+as a component:
 
 ```cmake
 find_package (HDF5 NAMES hdf5 CONFIG REQUIRED COMPONENTS C static)
@@ -206,6 +207,12 @@ target_link_libraries (${example} PRIVATE hdf5::hdf5)
 Setting `HDF5_USE_STATIC_LIBRARIES` before `find_package()` has the same
 effect, matching `FindHDF5`. Requesting both `static` and `shared` leaves the
 public targets on the default and warns, since one name cannot refer to both.
+
+This preference applies to the whole `find_package()` call, not just to the
+public targets: it also decides which `HDF5_<lang>_<LINKAGE>_LIBRARY` variables
+and Fortran module directory are set. Before HDF5 2.3.0, a call that named no
+linkage component preferred the static libraries. A project that relied on that
+should request the `static` component or set `HDF5_USE_STATIC_LIBRARIES`.
 
 The linkage-qualified `hdf5-shared` and `hdf5-static` targets and the
 `HDF5_C_SHARED_LIBRARY` / `HDF5_C_STATIC_LIBRARY` variables remain available

--- a/docs/USING_HDF5_CMake.md
+++ b/docs/USING_HDF5_CMake.md
@@ -151,25 +151,65 @@ Given the preconditions in Section I, create a `CMakeLists.txt` file at the sour
 cmake_minimum_required (VERSION 3.26)
 project (HDF5MyApp C)
 
-set (LIB_TYPE STATIC) # or SHARED
-string(TOLOWER ${LIB_TYPE} SEARCH_TYPE)
-
-find_package (HDF5 NAMES hdf5 COMPONENTS C ${SEARCH_TYPE})
+find_package (HDF5 NAMES hdf5 CONFIG REQUIRED COMPONENTS C)
 # find_package (HDF5) # Find non-cmake built HDF5
-
-set_directory_properties(PROPERTIES INCLUDE_DIRECTORIES "${HDF5_INCLUDE_DIR}")
-set (LINK_LIBS ${LINK_LIBS} ${HDF5_C_${LIB_TYPE}_LIBRARY})
 
 set (example hdf_example)
 
 add_executable (${example} ${PROJECT_SOURCE_DIR}/${example}.c)
-target_link_libraries (${example} ${LINK_LIBS})
+target_link_libraries (${example} PRIVATE hdf5::hdf5)
 
 enable_testing ()
 include (CTest)
 
 add_test (NAME test_example COMMAND ${example})
 ```
+
+`hdf5::hdf5` carries HDF5's include directories and its own dependencies, so
+there is no need to set `INCLUDE_DIRECTORIES` or to name the library variables
+directly.
+
+#### Public target names
+
+Link against these rather than against `hdf5-shared` or `hdf5-static`. The
+names do not encode the linkage, so the same project file works against a
+static installation, a shared one, or one providing both:
+
+| Target | Library |
+| ------ | ------- |
+| `hdf5::hdf5` | C |
+| `hdf5::hdf5_hl` | High-level C |
+| `hdf5::hdf5_cpp` | C++ |
+| `hdf5::hdf5_hl_cpp` | High-level C++ |
+| `hdf5::hdf5_fortran` | Fortran |
+| `hdf5::hdf5_hl_fortran` | High-level Fortran |
+| `HDF5::HDF5` | All of the above that are available |
+
+Each installed tool is available as `hdf5::<tool>`, for example `hdf5::h5diff`.
+
+These are the same names CMake's own `FindHDF5` module provides, so a project
+using them does not need to know whether HDF5 was located through `FindHDF5`
+or through HDF5's `hdf5-config.cmake`. They are also defined when HDF5 is
+built as a subproject with `add_subdirectory()`, so the same
+`target_link_libraries()` call works there too.
+
+#### Choosing static or shared
+
+When an installation provides both, the public targets refer to the shared
+libraries. To choose deliberately, request the linkage as a component:
+
+```cmake
+find_package (HDF5 NAMES hdf5 CONFIG REQUIRED COMPONENTS C static)
+target_link_libraries (${example} PRIVATE hdf5::hdf5)
+```
+
+Setting `HDF5_USE_STATIC_LIBRARIES` before `find_package()` has the same
+effect, matching `FindHDF5`. Requesting both `static` and `shared` leaves the
+public targets on the default and warns, since one name cannot refer to both.
+
+The linkage-qualified `hdf5-shared` and `hdf5-static` targets and the
+`HDF5_C_SHARED_LIBRARY` / `HDF5_C_STATIC_LIBRARY` variables remain available
+for existing projects.
 
 ---
 

--- a/release_docs/CHANGELOG.md
+++ b/release_docs/CHANGELOG.md
@@ -52,6 +52,10 @@ We would like to thank the many HDF5 community members who contributed to this r
 
 # 🪦 Deprecations
 
+### Deprecated the linkage-qualified CMake target names
+
+   The `hdf5-shared` / `hdf5-static` targets, their `_hl`, `_cpp`, `_hl_cpp`, `_fortran` and `_hl_fortran` counterparts, and the `HDF5_<lang>_<LINKAGE>_LIBRARY` variables are deprecated in favor of the stable `hdf5::` target names described under Configuration below. They will be removed in a future major release, so new projects should link `hdf5::hdf5` and friends, and existing projects should migrate to the name names when convenient. See `docs/USING_HDF5_CMake.md` for the mapping from old names to new ones.
+
 
 # 🚀 New Features & Improvements
 

--- a/release_docs/CHANGELOG.md
+++ b/release_docs/CHANGELOG.md
@@ -51,6 +51,10 @@ We would like to thank the many HDF5 community members who contributed to this r
 
 ## Configuration
 
+### Added stable, linkage-agnostic CMake target names to the installed package
+
+   Downstream projects can now link `hdf5::hdf5`, `hdf5::hdf5_hl`, `hdf5::hdf5_cpp`, `hdf5::hdf5_hl_cpp`, `hdf5::hdf5_fortran` and `hdf5::hdf5_hl_fortran` instead of the linkage-qualified `hdf5-shared` and `hdf5-static` targets, along with an `HDF5::HDF5` aggregate and `hdf5::<tool>` for each installed tool. The names do not encode whether the library is static or shared, so the same project file works against a static installation, a shared one, or one providing both. These are the names CMake's own `FindHDF5` module provides, so a project using them no longer needs different code depending on whether HDF5 was located through `FindHDF5` or through HDF5's `hdf5-config.cmake`, and they are defined identically when HDF5 is built as a subproject with `add_subdirectory()`. Which linkage the targets refer to is chosen while resolving the package: by a `static` or `shared` component, by `HDF5_USE_STATIC_LIBRARIES`, or by default shared-if-available and static otherwise. This change is purely additive, as the existing `hdf5-shared` / `hdf5-static` targets and the `HDF5_<lang>_<LINKAGE>_LIBRARY` variables are unchanged.
+
 
 ## Library
 

--- a/release_docs/CHANGELOG.md
+++ b/release_docs/CHANGELOG.md
@@ -43,6 +43,12 @@ We would like to thank the many HDF5 community members who contributed to this r
 
 # ⚠️ Breaking Changes
 
+### The installed CMake package now prefers the shared libraries when no linkage is requested
+
+   A `find_package(HDF5 NAMES hdf5 CONFIG)` call that names neither the `static` nor the `shared` component previously resolved to the static libraries of an installation providing both, and only fell back to shared when no static libraries were installed. That preference is now reversed: shared is used when available, with static as the fallback. Setting `HDF5_USE_STATIC_LIBRARIES` before the call still selects the static libraries, matching the behavior of CMake's `FindHDF5` module.
+
+   The preference decides which `HDF5_<lang>_<LINKAGE>_LIBRARY` variables and Fortran module directory the call sets, as well as the linkage the new `hdf5::` targets refer to, so a project that relied on the previous default and did not name a linkage will now link the shared libraries. Such a project should request the `static` component explicitly or set `HDF5_USE_STATIC_LIBRARIES`. Calls that already name a `static` or `shared` component are unaffected.
+
 
 # 🪦 Deprecations
 
@@ -53,7 +59,7 @@ We would like to thank the many HDF5 community members who contributed to this r
 
 ### Added stable, linkage-agnostic CMake target names to the installed package
 
-   Downstream projects can now link `hdf5::hdf5`, `hdf5::hdf5_hl`, `hdf5::hdf5_cpp`, `hdf5::hdf5_hl_cpp`, `hdf5::hdf5_fortran` and `hdf5::hdf5_hl_fortran` instead of the linkage-qualified `hdf5-shared` and `hdf5-static` targets, along with an `HDF5::HDF5` aggregate and `hdf5::<tool>` for each installed tool. The names do not encode whether the library is static or shared, so the same project file works against a static installation, a shared one, or one providing both. These are the names CMake's own `FindHDF5` module provides, so a project using them no longer needs different code depending on whether HDF5 was located through `FindHDF5` or through HDF5's `hdf5-config.cmake`, and they are defined identically when HDF5 is built as a subproject with `add_subdirectory()`. Which linkage the targets refer to is chosen while resolving the package: by a `static` or `shared` component, by `HDF5_USE_STATIC_LIBRARIES`, or by default shared-if-available and static otherwise. This change is purely additive, as the existing `hdf5-shared` / `hdf5-static` targets and the `HDF5_<lang>_<LINKAGE>_LIBRARY` variables are unchanged.
+   Downstream projects can now link `hdf5::hdf5`, `hdf5::hdf5_hl`, `hdf5::hdf5_cpp`, `hdf5::hdf5_hl_cpp`, `hdf5::hdf5_fortran` and `hdf5::hdf5_hl_fortran` instead of the linkage-qualified `hdf5-shared` and `hdf5-static` targets, along with an `HDF5::HDF5` aggregate and `hdf5::<tool>` for each installed tool. The names do not encode whether the library is static or shared, so the same project file works against a static installation, a shared one, or one providing both. These are the names CMake's own `FindHDF5` module provides, so a project using them no longer needs different code depending on whether HDF5 was located through `FindHDF5` or through HDF5's `hdf5-config.cmake`, and they are defined identically when HDF5 is built as a subproject with `add_subdirectory()`. Which linkage the targets refer to is chosen while resolving the package: by a `static` or `shared` component, by `HDF5_USE_STATIC_LIBRARIES`, or by default shared-if-available and static otherwise, which is the same order the rest of the package resolution now follows (see Breaking Changes). The existing `hdf5-shared` / `hdf5-static` targets and the `HDF5_<lang>_<LINKAGE>_LIBRARY` variables are otherwise unchanged, and the public names are aliases onto those same targets, so a project naming both on its link line still gets a single library.
 
 
 ## Library


### PR DESCRIPTION
At present, the installed CMake package exports linkage-qualified targets (`hdf5-shared`, `hdf5-static`, `hdf5_hl-shared`). That pushes the implementation details of internal target naming and provided linkage onto consumers in a way we would ideally avoid.

This PR adds a new  `config/cmake/HDF5PublicTargets.cmake` which defines stable names as ALIASes onto the concrete targets:

| Target | Library |
| --- | --- |
| `hdf5::hdf5` | C |
| `hdf5::hdf5_hl` | High-level C |
| `hdf5::hdf5_cpp` / `hdf5::hdf5_hl_cpp` | C++ |
| `hdf5::hdf5_fortran` / `hdf5::hdf5_hl_fortran` | Fortran | | `hdf5::<tool>` | each installed tool, e.g. `hdf5::h5diff` | | `HDF5::HDF5` | aggregate of the available libraries |

The find process in CMake then simplifies to:

```cmake
find_package (HDF5 NAMES hdf5 CONFIG REQUIRED COMPONENTS C)
target_link_libraries (app PRIVATE hdf5::hdf5)
```

The same module now has identical names across the HDF5 build tree, `add_subdirectory` embeddings, and `find_package()` installations.

The linkage type is decided while resolving the package, by (in order of precedence):

1. explicit `static`/`shared` component
2. `HDF5_USE_STATIC_LIBRARIES` (matching `FindHDF5`)
3. shared if available, static otherwise

Requesting both components will give a warning and fall back to the default.

This changeset is purely additive. The old shared/static targets, `HDF5_<lang>_<LINKAGE>_LIBRARY` variables, and the exported target set are unchanged, and the public names are ALIASes onto the same targets, so a project with both on its link line still gets only one library.

Nothing is deprecated yet, though we may want to do so in the future.

Partially addresses #6580