### PR TITLE
Fix value returned by H5Pget_fapl_ros3_block_caching()

### DIFF
--- a/src/H5FDros3.c
+++ b/src/H5FDros3.c
@@ -1150,7 +1150,7 @@ H5Pget_fapl_ros3_block_caching(hid_t fapl_id, size_t *block_size, size_t *block_
         if (block_size)
             *block_size = HDF5_ROS3_VFD_DEFAULT_BLOCK_SIZE;
         if (block_cache_size)
-            *block_cache_size = ROS3_DEF_PAGE_BUF_SIZE;
+            *block_cache_size = HDF5_ROS3_VFD_DEFAULT_BLOCK_CACHE_SIZE;
         if (lock_superblock)
             *lock_superblock = true;
     }

--- a/test/ros3.c
+++ b/test/ros3.c
@@ -1188,6 +1188,16 @@ test_ros3_block_caching_apis(void)
         if (H5Pset_fapl_ros3_token(fapl_id, s3_test_aws_session_token) < 0)
             TEST_ERROR;
 
+    /* Test settings on FAPL without ROS3 VFD block caching set yet */
+    if (H5Pget_fapl_ros3_block_caching(fapl_id, &block_size, &block_cache_size, &lock_superblock) < 0)
+        TEST_ERROR;
+    if (block_size != HDF5_ROS3_VFD_DEFAULT_BLOCK_SIZE)
+        TEST_ERROR;
+    if (block_cache_size != HDF5_ROS3_VFD_DEFAULT_BLOCK_CACHE_SIZE)
+        TEST_ERROR;
+    if (!lock_superblock)
+        TEST_ERROR;
+
     /* Set block size to 0 - should disable block caching */
     if (H5Pset_fapl_ros3_block_caching(fapl_id, 0, HDF5_ROS3_VFD_DEFAULT_BLOCK_CACHE_SIZE, true) < 0)
         TEST_ERROR;


### PR DESCRIPTION
When called on a FAPL without ROS3 VFD block caching parameters set on it, the H5Pget_fapl_ros3_block_caching() function previously returned the VFD's default page buffer size value instead of its default I/O block cache size value.