### PR TITLE
Fix memory leaks and ID reference counting in H5E code

### DIFF
--- a/release_docs/CHANGELOG.md
+++ b/release_docs/CHANGELOG.md
@@ -77,6 +77,17 @@ We would like to thank the many HDF5 community members who contributed to this r
 
 ## Library
 
+### Fixed memory leaks and ID reference count issues when pushing an error to an error stack that is full
+
+   When an error is pushed to an error stack, the library may make a copy of the file
+   and function strings to ensure that they exist for the same duration as the error
+   stack entry. When an error stack is full, the library simply makes any further pushes
+   no-ops, but previously gave no information to calling code that this happened. This
+   caused calling code to assume that the duplicated strings were owned by an error stack
+   entry that was never pushed, leaking the duplicated strings. Additionally, IDs
+   associated with the error stack entry were left with incremented reference counts,
+   resulting in an infinite loop while closing the library.
+
 ### Library shutdown no longer aborts on a detected infinite loop
 
    When the library detects that it cannot make progress closing itself (an "infinite loop closing library"), it no longer calls `abort()`. The abort behaved inconsistently, only firing when automatic error message display was enabled. Additionally, terminating the entire host process on a shutdown-time condition is undesirable for applications that embed HDF5. The library now reports the condition (when error display is enabled) and returns without aborting.

--- a/src/H5E.c
+++ b/src/H5E.c
@@ -525,12 +525,16 @@ herr_t
 H5Epush2(hid_t err_stack, const char *file, const char *func, unsigned line, hid_t cls_id, hid_t maj_id,
          hid_t min_id, const char *fmt, ...)
 {
-    H5E_stack_t *estack;              /* Pointer to error stack to modify */
-    va_list      ap;                  /* Varargs info */
-    bool         va_started = false;  /* Whether the variable argument list is open */
-    const char  *tmp_file;            /* Copy of the file name */
-    const char  *tmp_func;            /* Copy of the function name */
-    herr_t       ret_value = SUCCEED; /* Return value */
+    H5E_stack_t *estack;               /* Pointer to error stack to modify */
+    va_list      ap;                   /* Varargs info */
+    htri_t       push_ret   = true;    /* Was an error stack entry actually pushed? */
+    bool         va_started = false;   /* Whether the variable argument list is open */
+    char        *tmp_file   = NULL;    /* Copy of the file name */
+    char        *tmp_func   = NULL;    /* Copy of the function name */
+    bool         inc_cls_id = false;   /* Incremented error class ID ref. count? */
+    bool         inc_maj_id = false;   /* Incremented major error ID ref. count? */
+    bool         inc_min_id = false;   /* Incremented minor error ID ref. count? */
+    herr_t       ret_value  = SUCCEED; /* Return value */
 
     /* Don't clear the error stack! :-) */
     FUNC_ENTER_API_NOCLEAR(FAIL)
@@ -562,24 +566,43 @@ H5Epush2(hid_t err_stack, const char *file, const char *func, unsigned line, hid
             HGOTO_ERROR(H5E_ERROR, H5E_CANTALLOC, FAIL, "can't duplicate function string");
 
         /* Increment refcount on non-library IDs */
-        if (cls_id != H5E_ERR_CLS_g)
+        if (cls_id != H5E_ERR_CLS_g) {
             if (H5I_inc_ref(cls_id, false) < 0)
                 HGOTO_ERROR(H5E_ERROR, H5E_CANTINC, FAIL, "can't increment class ID");
-        if (maj_id < H5E_first_maj_id_g || maj_id > H5E_last_maj_id_g)
+            inc_cls_id = true;
+        }
+        if (maj_id < H5E_first_maj_id_g || maj_id > H5E_last_maj_id_g) {
             if (H5I_inc_ref(maj_id, false) < 0)
                 HGOTO_ERROR(H5E_ERROR, H5E_CANTINC, FAIL, "can't increment major error ID");
-        if (min_id < H5E_first_min_id_g || min_id > H5E_last_min_id_g)
+            inc_maj_id = true;
+        }
+        if (min_id < H5E_first_min_id_g || min_id > H5E_last_min_id_g) {
             if (H5I_inc_ref(min_id, false) < 0)
                 HGOTO_ERROR(H5E_ERROR, H5E_CANTINC, FAIL, "can't increment minor error ID");
+            inc_min_id = true;
+        }
 
         /* Push the error on the stack */
-        if (H5E__push_stack(estack, true, tmp_file, tmp_func, line, cls_id, maj_id, min_id, fmt, &ap) < 0)
+        push_ret = H5E__push_stack(estack, true, tmp_file, tmp_func, line, cls_id, maj_id, min_id, fmt, &ap);
+        if (push_ret < 0)
             HGOTO_ERROR(H5E_ERROR, H5E_CANTSET, FAIL, "can't push error on stack");
     }
 
 done:
     if (va_started)
         va_end(ap);
+
+    if (ret_value < 0 || !push_ret) {
+        if (inc_cls_id && H5I_dec_ref(cls_id) < 0)
+            HDONE_ERROR(H5E_ERROR, H5E_CANTDEC, FAIL, "can't decrement class ID");
+        if (inc_maj_id && H5I_dec_ref(maj_id) < 0)
+            HDONE_ERROR(H5E_ERROR, H5E_CANTDEC, FAIL, "can't decrement major error ID");
+        if (inc_min_id && H5I_dec_ref(min_id) < 0)
+            HDONE_ERROR(H5E_ERROR, H5E_CANTDEC, FAIL, "can't decrement minor error ID");
+
+        free(tmp_func);
+        free(tmp_file);
+    }
 
     FUNC_LEAVE_API(ret_value)
 } /* end H5Epush2() */

--- a/src/H5Edeprec.c
+++ b/src/H5Edeprec.c
@@ -182,10 +182,13 @@ done:
 herr_t
 H5Epush1(const char *file, const char *func, unsigned line, H5E_major_t maj, H5E_minor_t min, const char *str)
 {
-    H5E_stack_t *estack;              /* Pointer to error stack to modify */
-    const char  *tmp_file;            /* Copy of the file name */
-    const char  *tmp_func;            /* Copy of the function name */
-    herr_t       ret_value = SUCCEED; /* Return value */
+    H5E_stack_t *estack;               /* Pointer to error stack to modify */
+    htri_t       push_ret   = true;    /* Was an error stack entry actually pushed? */
+    char        *tmp_file   = NULL;    /* Copy of the file name */
+    char        *tmp_func   = NULL;    /* Copy of the function name */
+    bool         inc_maj_id = false;   /* Incremented major error ID ref. count? */
+    bool         inc_min_id = false;   /* Incremented minor error ID ref. count? */
+    herr_t       ret_value  = SUCCEED; /* Return value */
 
     /* Don't clear the error stack! :-) */
     FUNC_ENTER_API_NOCLEAR(FAIL)
@@ -203,19 +206,35 @@ H5Epush1(const char *file, const char *func, unsigned line, H5E_major_t maj, H5E
             HGOTO_ERROR(H5E_ERROR, H5E_CANTALLOC, FAIL, "can't duplicate function string");
 
         /* Increment refcount on non-library IDs */
-        if (maj < H5E_first_maj_id_g || maj > H5E_last_maj_id_g)
+        if (maj < H5E_first_maj_id_g || maj > H5E_last_maj_id_g) {
             if (H5I_inc_ref(maj, false) < 0)
                 HGOTO_ERROR(H5E_ERROR, H5E_CANTINC, FAIL, "can't increment major error ID");
-        if (min < H5E_first_min_id_g || min > H5E_last_min_id_g)
+            inc_maj_id = true;
+        }
+        if (min < H5E_first_min_id_g || min > H5E_last_min_id_g) {
             if (H5I_inc_ref(min, false) < 0)
                 HGOTO_ERROR(H5E_ERROR, H5E_CANTINC, FAIL, "can't increment minor error ID");
+            inc_min_id = true;
+        }
 
         /* Push the error on the default error stack */
-        if (H5E__push_stack(estack, true, tmp_file, tmp_func, line, H5E_ERR_CLS_g, maj, min, str, NULL) < 0)
+        push_ret =
+            H5E__push_stack(estack, true, tmp_file, tmp_func, line, H5E_ERR_CLS_g, maj, min, str, NULL);
+        if (push_ret < 0)
             HGOTO_ERROR(H5E_ERROR, H5E_CANTSET, FAIL, "can't push error on stack");
     }
 
 done:
+    if (ret_value < 0 || !push_ret) {
+        if (inc_maj_id && H5I_dec_ref(maj) < 0)
+            HDONE_ERROR(H5E_ERROR, H5E_CANTDEC, FAIL, "can't decrement major error ID");
+        if (inc_min_id && H5I_dec_ref(min) < 0)
+            HDONE_ERROR(H5E_ERROR, H5E_CANTDEC, FAIL, "can't decrement minor error ID");
+
+        free(tmp_func);
+        free(tmp_file);
+    }
+
     FUNC_LEAVE_API(ret_value)
 } /* end H5Epush1() */
 

--- a/src/H5Eint.c
+++ b/src/H5Eint.c
@@ -1594,20 +1594,22 @@ done:
  *              MIN_ID, the name of a function where the error was detected,
  *              the name of the file where the error was detected, the
  *              line within that file, and an error description string.  The
- *              function name, file name, and error description strings must
- *              be statically allocated (the FUNC_ENTER() macro takes care of
- *              the function name and file name automatically, but the
- *              programmer is responsible for the description string).
+ *              error description string must be statically allocated (the
+ *              FUNC_ENTER() macro takes care of the function name and file
+ *              name automatically, but the programmer is responsible for
+ *              the description string).
  *
- * Return:      SUCCEED/FAIL
+ * Return:      true if an error stack entry was pushed
+ *              false if an error stack entry was not pushed
+ *              FAIL on failure
  *
  *-------------------------------------------------------------------------
  */
-herr_t
+htri_t
 H5E__push_stack(H5E_stack_t *estack, bool app_entry, const char *file, const char *func, unsigned line,
                 hid_t cls_id, hid_t maj_id, hid_t min_id, const char *fmt, va_list *ap)
 {
-    herr_t ret_value = SUCCEED; /* Return value */
+    htri_t ret_value = true;
 
     /*
      * WARNING: We cannot call HERROR() from within this function or else we
@@ -1633,6 +1635,8 @@ H5E__push_stack(H5E_stack_t *estack, bool app_entry, const char *file, const cha
             HGOTO_DONE(FAIL);
         estack->nused++;
     } /* end if */
+    else
+        HGOTO_DONE(false);
 
 done:
     FUNC_LEAVE_NOAPI(ret_value)

--- a/src/H5Epkg.h
+++ b/src/H5Epkg.h
@@ -142,7 +142,7 @@ H5_DLL void         H5E__set_default_auto(H5E_stack_t *stk);
 H5_DLL H5E_stack_t *H5E__get_current_stack(void);
 H5_DLL herr_t       H5E__set_current_stack(H5E_stack_t *estack);
 H5_DLL ssize_t      H5E__get_num(const H5E_stack_t *err_stack);
-H5_DLL herr_t       H5E__push_stack(H5E_stack_t *estack, bool app_entry, const char *file, const char *func,
+H5_DLL htri_t       H5E__push_stack(H5E_stack_t *estack, bool app_entry, const char *file, const char *func,
                                     unsigned line, hid_t cls_id, hid_t maj_id, hid_t min_id, const char *fmt,
                                     va_list *ap);
 H5_DLL herr_t       H5E__print(const H5E_stack_t *estack, FILE *stream, bool bk_compat);

--- a/test/error_test.c
+++ b/test/error_test.c
@@ -16,6 +16,9 @@
 #include "h5test.h"
 #include "H5srcdir.h"
 
+#define H5E_FRIEND
+#include "H5Epkg.h" /* For access to H5E-specific macros */
+
 #ifdef H5_USE_16_API
 int
 main(void)
@@ -837,6 +840,50 @@ error:
 } /* end test_pause() */
 
 /*-------------------------------------------------------------------------
+ * Function:    test_overflow_stack
+ *
+ * Purpose:     Test pushing more than H5E_MAX_ENTRIES entries to an error
+ *              stack. Once the stack is full, the next push is simply a
+ *              no-op.
+ *
+ * Return:      Success:    0
+ *              Failure:    -1
+ *
+ *-------------------------------------------------------------------------
+ */
+static herr_t
+test_overflow_stack(void)
+{
+    ssize_t err_num;
+    char    err_buf[32];
+
+    if (H5Eclear2(H5E_DEFAULT) < 0)
+        TEST_ERROR;
+
+    err_num = H5Eget_num(H5E_DEFAULT);
+    if (err_num != 0)
+        TEST_ERROR;
+
+    for (int i = 0; i < H5E_MAX_ENTRIES; i++) {
+        snprintf(err_buf, sizeof(err_buf), "error number %d", i + 1);
+
+        if (H5Epush(H5E_DEFAULT, __FILE__, __func__, __LINE__, ERR_CLS, ERR_MAJ_TEST, ERR_MIN_SUBROUTINE,
+                    "%s", err_buf) < 0)
+            TEST_ERROR;
+    }
+
+    snprintf(err_buf, sizeof(err_buf), "error number %d", H5E_MAX_ENTRIES + 1);
+    if (H5Epush(H5E_DEFAULT, __FILE__, __func__, __LINE__, ERR_CLS, ERR_MAJ_TEST, ERR_MIN_SUBROUTINE, "%s",
+                err_buf) < 0)
+        TEST_ERROR;
+
+    return 0;
+
+error:
+    return -1;
+}
+
+/*-------------------------------------------------------------------------
  * Function:    close_error
  *
  * Purpose:     Closes error information.
@@ -1021,6 +1068,10 @@ main(void)
 
     /* Test pausing error stacks */
     if (test_pause() < 0)
+        TEST_ERROR;
+
+    /* Test pushing more than H5E_MAX_ENTRIES entries to an error stack */
+    if (test_overflow_stack() < 0)
         TEST_ERROR;
 
     /* Close error information */


### PR DESCRIPTION
When pushing errors to an error stack that is already full, the library skipped the push operation but didn't inform calling code about what happened. This resulted in calling code leaking memory, leaving reference counts on IDs incremented and causing an infinite loop while closing the library.