### PR TITLE
bound nbit decompression reads to the stored chunk length

### DIFF
--- a/release_docs/CHANGELOG.md
+++ b/release_docs/CHANGELOG.md
@@ -54,9 +54,9 @@ We would like to thank the many HDF5 community members who contributed to this r
 
 ## Library
 
-### Bound nbit decompression reads to the stored chunk length
+### Bound n-bit decompression reads to the stored chunk length
 
-   The reverse nbit filter walked its bit reader through the chunk buffer using only the element count and precision from the filter pipeline message, never the number of bytes actually stored for the chunk. The chunk buffer the filter is handed is sized to hold the larger unfiltered chunk, so a truncated or corrupted chunk decompressed out of the uninitialized remainder of that allocation and returned it as dataset data. The decompression path now carries the stored length and rejects any read past it.
+   The reverse n-bit filter walked its bit reader through the chunk buffer using only the element count and precision from the filter pipeline message, never checking the number of bytes actually stored for the chunk. Because the chunk buffer provided to the filter is sized to hold the larger unfiltered chunk, a truncated or corrupted chunk would decompress out of the uninitialized remainder of that allocation and return it as dataset data. The decompression path now tracks the stored length and rejects any read past it.
 
 ## Parallel Library
 

--- a/release_docs/CHANGELOG.md
+++ b/release_docs/CHANGELOG.md
@@ -54,6 +54,10 @@ We would like to thank the many HDF5 community members who contributed to this r
 
 ## Library
 
+### Bound nbit decompression reads to the stored chunk length
+
+   The reverse nbit filter walked its bit reader through the chunk buffer using only the element count and precision from the filter pipeline message, never the number of bytes actually stored for the chunk. The chunk buffer the filter is handed is sized to hold the larger unfiltered chunk, so a truncated or corrupted chunk decompressed out of the uninitialized remainder of that allocation and returned it as dataset data. The decompression path now carries the stored length and rejects any read past it.
+
 ## Parallel Library
 
 ## Fortran Library

--- a/src/H5Znbit.c
+++ b/src/H5Znbit.c
@@ -1173,6 +1173,9 @@ H5Z__nbit_decompress_one_array(unsigned char *data, size_t data_offset, unsigned
             if (p.precision > p.size * 8 || (p.precision + p.offset) > p.size * 8)
                 HGOTO_ERROR(H5E_PLINE, H5E_BADTYPE, FAIL, "invalid datatype precision/offset");
 
+            if (p.size == 0)
+                HGOTO_ERROR(H5E_PLINE, H5E_BADVALUE, FAIL, "invalid datatype size");
+
             n = total_size / p.size;
             for (i = 0; i < n; i++)
                 if (H5Z__nbit_decompress_one_atomic(data, data_offset + i * (size_t)p.size, buffer,
@@ -1181,7 +1184,9 @@ H5Z__nbit_decompress_one_array(unsigned char *data, size_t data_offset, unsigned
             break;
 
         case H5Z_NBIT_ARRAY:
-            base_size   = parms[*parms_index];    /* read in advance */
+            base_size = parms[*parms_index]; /* read in advance */
+            if (base_size == 0)
+                HGOTO_ERROR(H5E_PLINE, H5E_BADVALUE, FAIL, "invalid datatype size");
             n           = total_size / base_size; /* number of base_type elements inside the array datatype */
             begin_index = *parms_index;
             for (i = 0; i < n; i++) {
@@ -1193,7 +1198,9 @@ H5Z__nbit_decompress_one_array(unsigned char *data, size_t data_offset, unsigned
             break;
 
         case H5Z_NBIT_COMPOUND:
-            base_size   = parms[*parms_index];    /* read in advance */
+            base_size = parms[*parms_index]; /* read in advance */
+            if (base_size == 0)
+                HGOTO_ERROR(H5E_PLINE, H5E_BADVALUE, FAIL, "invalid datatype size");
             n           = total_size / base_size; /* number of base_type elements inside the array datatype */
             begin_index = *parms_index;
             for (i = 0; i < n; i++) {

--- a/src/H5Znbit.c
+++ b/src/H5Znbit.c
@@ -51,26 +51,28 @@ static herr_t H5Z__set_parms_compound(const H5T_t *type, unsigned *cd_values_ind
                                       bool *need_not_compress);
 
 static void   H5Z__nbit_next_byte(size_t *j, size_t *buf_len);
-static void   H5Z__nbit_decompress_one_byte(unsigned char *data, size_t data_offset, unsigned k,
+static herr_t H5Z__nbit_decompress_one_byte(unsigned char *data, size_t data_offset, unsigned k,
                                             unsigned begin_i, unsigned end_i, const unsigned char *buffer,
-                                            size_t *j, size_t *buf_len, const parms_atomic *p,
-                                            size_t datatype_len);
+                                            size_t buffer_size, size_t *j, size_t *buf_len,
+                                            const parms_atomic *p, size_t datatype_len);
 static void   H5Z__nbit_compress_one_byte(const unsigned char *data, size_t data_offset, unsigned k,
                                           unsigned begin_i, unsigned end_i, unsigned char *buffer, size_t *j,
                                           size_t *buf_len, const parms_atomic *p, size_t datatype_len);
-static void   H5Z__nbit_decompress_one_nooptype(unsigned char *data, size_t data_offset,
-                                                const unsigned char *buffer, size_t *j, size_t *buf_len,
-                                                unsigned size);
-static void   H5Z__nbit_decompress_one_atomic(unsigned char *data, size_t data_offset, unsigned char *buffer,
-                                              size_t *j, size_t *buf_len, const parms_atomic *p);
+static herr_t H5Z__nbit_decompress_one_nooptype(unsigned char *data, size_t data_offset,
+                                                const unsigned char *buffer, size_t buffer_size, size_t *j,
+                                                size_t *buf_len, unsigned size);
+static herr_t H5Z__nbit_decompress_one_atomic(unsigned char *data, size_t data_offset, unsigned char *buffer,
+                                              size_t buffer_size, size_t *j, size_t *buf_len,
+                                              const parms_atomic *p);
 static herr_t H5Z__nbit_decompress_one_array(unsigned char *data, size_t data_offset, unsigned char *buffer,
-                                             size_t *j, size_t *buf_len, const unsigned parms[],
-                                             unsigned *parms_index);
+                                             size_t buffer_size, size_t *j, size_t *buf_len,
+                                             const unsigned parms[], unsigned *parms_index);
 static herr_t H5Z__nbit_decompress_one_compound(unsigned char *data, size_t data_offset,
-                                                unsigned char *buffer, size_t *j, size_t *buf_len,
-                                                const unsigned parms[], unsigned *parms_index);
+                                                unsigned char *buffer, size_t buffer_size, size_t *j,
+                                                size_t *buf_len, const unsigned parms[],
+                                                unsigned *parms_index);
 static herr_t H5Z__nbit_decompress(unsigned char *data, unsigned d_nelmts, unsigned char *buffer,
-                                   const unsigned parms[]);
+                                   size_t buffer_size, const unsigned parms[]);
 static void   H5Z__nbit_compress_one_nooptype(const unsigned char *data, size_t data_offset,
                                               unsigned char *buffer, size_t *j, size_t *buf_len, unsigned size);
 static void   H5Z__nbit_compress_one_array(unsigned char *data, size_t data_offset, unsigned char *buffer,
@@ -953,7 +955,7 @@ H5Z__filter_nbit(unsigned flags, size_t cd_nelmts, const unsigned cd_values[], s
             HGOTO_ERROR(H5E_RESOURCE, H5E_NOSPACE, 0, "memory allocation failed for nbit decompression");
 
         /* decompress the buffer */
-        if (H5Z__nbit_decompress(outbuf, d_nelmts, (unsigned char *)*buf, cd_values) < 0) {
+        if (H5Z__nbit_decompress(outbuf, d_nelmts, (unsigned char *)*buf, nbytes, cd_values) < 0) {
             H5MM_xfree(outbuf);
             HGOTO_ERROR(H5E_PLINE, H5E_CANTFILTER, 0, "can't decompress buffer");
         }
@@ -999,14 +1001,20 @@ H5Z__nbit_next_byte(size_t *j, size_t *buf_len)
     *buf_len = 8 * sizeof(unsigned char);
 }
 
-static void
+static herr_t
 H5Z__nbit_decompress_one_byte(unsigned char *data, size_t data_offset, unsigned k, unsigned begin_i,
-                              unsigned end_i, const unsigned char *buffer, size_t *j, size_t *buf_len,
-                              const parms_atomic *p, size_t datatype_len)
+                              unsigned end_i, const unsigned char *buffer, size_t buffer_size, size_t *j,
+                              size_t *buf_len, const parms_atomic *p, size_t datatype_len)
 {
     size_t        dat_len; /* dat_len is the number of bits to be copied in each data byte */
     size_t        dat_offset;
-    unsigned char val; /* value to be copied in each data byte */
+    unsigned char val;                 /* value to be copied in each data byte */
+    herr_t        ret_value = SUCCEED; /* Return value */
+
+    FUNC_ENTER_PACKAGE
+
+    if (*j >= buffer_size)
+        HGOTO_ERROR(H5E_PLINE, H5E_BADVALUE, FAIL, "buffer too short");
 
     /* initialize value and bits of unsigned char to be copied */
     val        = buffer[*j];
@@ -1039,26 +1047,36 @@ H5Z__nbit_decompress_one_byte(unsigned char *data, size_t data_offset, unsigned 
         dat_len -= *buf_len;
         H5Z__nbit_next_byte(j, buf_len);
         if (dat_len == 0)
-            return;
+            HGOTO_DONE(SUCCEED);
 
+        if (*j >= buffer_size)
+            HGOTO_ERROR(H5E_PLINE, H5E_BADVALUE, FAIL, "buffer too short");
         val = buffer[*j];
         data[data_offset + k] |= (unsigned char)(((unsigned)(val >> (*buf_len - dat_len)) &
                                                   (unsigned)(~((unsigned)(~0) << dat_len)))
                                                  << dat_offset);
         *buf_len -= dat_len;
     }
+
+done:
+    FUNC_LEAVE_NOAPI(ret_value)
 }
 
-static void
+static herr_t
 H5Z__nbit_decompress_one_nooptype(unsigned char *data, size_t data_offset, const unsigned char *buffer,
-                                  size_t *j, size_t *buf_len, unsigned size)
+                                  size_t buffer_size, size_t *j, size_t *buf_len, unsigned size)
 {
-    unsigned      i;       /* index */
-    size_t        dat_len; /* dat_len is the number of bits to be copied in each data byte */
-    unsigned char val;     /* value to be copied in each data byte */
+    unsigned      i;                   /* index */
+    size_t        dat_len;             /* dat_len is the number of bits to be copied in each data byte */
+    unsigned char val;                 /* value to be copied in each data byte */
+    herr_t        ret_value = SUCCEED; /* Return value */
+
+    FUNC_ENTER_PACKAGE
 
     for (i = 0; i < size; i++) {
         /* initialize value and bits of unsigned char to be copied */
+        if (*j >= buffer_size)
+            HGOTO_ERROR(H5E_PLINE, H5E_BADVALUE, FAIL, "buffer too short");
         val     = buffer[*j];
         dat_len = sizeof(unsigned char) * 8;
 
@@ -1069,22 +1087,30 @@ H5Z__nbit_decompress_one_nooptype(unsigned char *data, size_t data_offset, const
         if (dat_len == 0)
             continue;
 
+        if (*j >= buffer_size)
+            HGOTO_ERROR(H5E_PLINE, H5E_BADVALUE, FAIL, "buffer too short");
         val = buffer[*j];
         data[data_offset + i] |= (unsigned char)((unsigned)(val >> (*buf_len - dat_len)) &
                                                  (unsigned)(~((unsigned)(~0) << dat_len)));
         *buf_len -= dat_len;
     }
+
+done:
+    FUNC_LEAVE_NOAPI(ret_value)
 }
 
-static void
-H5Z__nbit_decompress_one_atomic(unsigned char *data, size_t data_offset, unsigned char *buffer, size_t *j,
-                                size_t *buf_len, const parms_atomic *p)
+static herr_t
+H5Z__nbit_decompress_one_atomic(unsigned char *data, size_t data_offset, unsigned char *buffer,
+                                size_t buffer_size, size_t *j, size_t *buf_len, const parms_atomic *p)
 {
     /* begin_i: the index of byte having first significant bit
        end_i: the index of byte having last significant bit */
     int      k;
     unsigned begin_i, end_i;
     size_t   datatype_len;
+    herr_t   ret_value = SUCCEED; /* Return value */
+
+    FUNC_ENTER_PACKAGE
 
     datatype_len = p->size * 8;
 
@@ -1097,8 +1123,9 @@ H5Z__nbit_decompress_one_atomic(unsigned char *data, size_t data_offset, unsigne
         end_i = p->offset / 8;
 
         for (k = (int)begin_i; k >= (int)end_i; k--)
-            H5Z__nbit_decompress_one_byte(data, data_offset, (unsigned)k, begin_i, end_i, buffer, j, buf_len,
-                                          p, datatype_len);
+            if (H5Z__nbit_decompress_one_byte(data, data_offset, (unsigned)k, begin_i, end_i, buffer,
+                                              buffer_size, j, buf_len, p, datatype_len) < 0)
+                HGOTO_ERROR(H5E_PLINE, H5E_CANTFILTER, FAIL, "can't decompress atomic");
     }
     else { /* big endian */
         /* Sanity check */
@@ -1112,14 +1139,19 @@ H5Z__nbit_decompress_one_atomic(unsigned char *data, size_t data_offset, unsigne
             end_i = ((unsigned)datatype_len - p->offset) / 8 - 1;
 
         for (k = (int)begin_i; k <= (int)end_i; k++)
-            H5Z__nbit_decompress_one_byte(data, data_offset, (unsigned)k, begin_i, end_i, buffer, j, buf_len,
-                                          p, datatype_len);
+            if (H5Z__nbit_decompress_one_byte(data, data_offset, (unsigned)k, begin_i, end_i, buffer,
+                                              buffer_size, j, buf_len, p, datatype_len) < 0)
+                HGOTO_ERROR(H5E_PLINE, H5E_CANTFILTER, FAIL, "can't decompress atomic");
     }
+
+done:
+    FUNC_LEAVE_NOAPI(ret_value)
 }
 
 static herr_t
-H5Z__nbit_decompress_one_array(unsigned char *data, size_t data_offset, unsigned char *buffer, size_t *j,
-                               size_t *buf_len, const unsigned parms[], unsigned *parms_index)
+H5Z__nbit_decompress_one_array(unsigned char *data, size_t data_offset, unsigned char *buffer,
+                               size_t buffer_size, size_t *j, size_t *buf_len, const unsigned parms[],
+                               unsigned *parms_index)
 {
     unsigned     i, total_size, base_class, base_size, n, begin_index;
     parms_atomic p;
@@ -1143,8 +1175,9 @@ H5Z__nbit_decompress_one_array(unsigned char *data, size_t data_offset, unsigned
 
             n = total_size / p.size;
             for (i = 0; i < n; i++)
-                H5Z__nbit_decompress_one_atomic(data, data_offset + i * (size_t)p.size, buffer, j, buf_len,
-                                                &p);
+                if (H5Z__nbit_decompress_one_atomic(data, data_offset + i * (size_t)p.size, buffer,
+                                                    buffer_size, j, buf_len, &p) < 0)
+                    HGOTO_ERROR(H5E_PLINE, H5E_CANTFILTER, FAIL, "can't decompress atomic");
             break;
 
         case H5Z_NBIT_ARRAY:
@@ -1152,8 +1185,8 @@ H5Z__nbit_decompress_one_array(unsigned char *data, size_t data_offset, unsigned
             n           = total_size / base_size; /* number of base_type elements inside the array datatype */
             begin_index = *parms_index;
             for (i = 0; i < n; i++) {
-                if (H5Z__nbit_decompress_one_array(data, data_offset + i * (size_t)base_size, buffer, j,
-                                                   buf_len, parms, parms_index) < 0)
+                if (H5Z__nbit_decompress_one_array(data, data_offset + i * (size_t)base_size, buffer,
+                                                   buffer_size, j, buf_len, parms, parms_index) < 0)
                     HGOTO_ERROR(H5E_PLINE, H5E_CANTFILTER, FAIL, "can't decompress array");
                 *parms_index = begin_index;
             }
@@ -1164,8 +1197,8 @@ H5Z__nbit_decompress_one_array(unsigned char *data, size_t data_offset, unsigned
             n           = total_size / base_size; /* number of base_type elements inside the array datatype */
             begin_index = *parms_index;
             for (i = 0; i < n; i++) {
-                if (H5Z__nbit_decompress_one_compound(data, data_offset + i * (size_t)base_size, buffer, j,
-                                                      buf_len, parms, parms_index) < 0)
+                if (H5Z__nbit_decompress_one_compound(data, data_offset + i * (size_t)base_size, buffer,
+                                                      buffer_size, j, buf_len, parms, parms_index) < 0)
                     HGOTO_ERROR(H5E_PLINE, H5E_CANTFILTER, FAIL, "can't decompress compound");
                 *parms_index = begin_index;
             }
@@ -1173,7 +1206,9 @@ H5Z__nbit_decompress_one_array(unsigned char *data, size_t data_offset, unsigned
 
         case H5Z_NBIT_NOOPTYPE:
             (*parms_index)++; /* skip size of no-op type */
-            H5Z__nbit_decompress_one_nooptype(data, data_offset, buffer, j, buf_len, total_size);
+            if (H5Z__nbit_decompress_one_nooptype(data, data_offset, buffer, buffer_size, j, buf_len,
+                                                  total_size) < 0)
+                HGOTO_ERROR(H5E_PLINE, H5E_CANTFILTER, FAIL, "can't decompress no-op type");
             break;
 
         default:
@@ -1185,8 +1220,9 @@ done:
 }
 
 static herr_t
-H5Z__nbit_decompress_one_compound(unsigned char *data, size_t data_offset, unsigned char *buffer, size_t *j,
-                                  size_t *buf_len, const unsigned parms[], unsigned *parms_index)
+H5Z__nbit_decompress_one_compound(unsigned char *data, size_t data_offset, unsigned char *buffer,
+                                  size_t buffer_size, size_t *j, size_t *buf_len, const unsigned parms[],
+                                  unsigned *parms_index)
 {
     unsigned     i, nmembers, member_offset, member_class, member_size, used_size = 0, prev_used_size, size;
     parms_atomic p;
@@ -1224,26 +1260,29 @@ H5Z__nbit_decompress_one_compound(unsigned char *data, size_t data_offset, unsig
                 if (p.precision > p.size * 8 || (p.precision + p.offset) > p.size * 8)
                     HGOTO_ERROR(H5E_PLINE, H5E_BADTYPE, FAIL, "invalid datatype precision/offset");
 
-                H5Z__nbit_decompress_one_atomic(data, data_offset + member_offset, buffer, j, buf_len, &p);
+                if (H5Z__nbit_decompress_one_atomic(data, data_offset + member_offset, buffer, buffer_size, j,
+                                                    buf_len, &p) < 0)
+                    HGOTO_ERROR(H5E_PLINE, H5E_CANTFILTER, FAIL, "can't decompress atomic");
                 break;
 
             case H5Z_NBIT_ARRAY:
-                if (H5Z__nbit_decompress_one_array(data, data_offset + member_offset, buffer, j, buf_len,
-                                                   parms, parms_index) < 0)
+                if (H5Z__nbit_decompress_one_array(data, data_offset + member_offset, buffer, buffer_size, j,
+                                                   buf_len, parms, parms_index) < 0)
                     HGOTO_ERROR(H5E_PLINE, H5E_CANTFILTER, FAIL, "can't decompress array");
                 break;
 
             case H5Z_NBIT_COMPOUND:
-                if (H5Z__nbit_decompress_one_compound(data, data_offset + member_offset, buffer, j, buf_len,
-                                                      parms, parms_index) < 0)
+                if (H5Z__nbit_decompress_one_compound(data, data_offset + member_offset, buffer, buffer_size,
+                                                      j, buf_len, parms, parms_index) < 0)
                     HGOTO_ERROR(H5E_PLINE, H5E_CANTFILTER, FAIL, "can't decompress compound");
                 break;
 
             case H5Z_NBIT_NOOPTYPE:
                 /* Advance past member size */
                 (*parms_index)++;
-                H5Z__nbit_decompress_one_nooptype(data, data_offset + member_offset, buffer, j, buf_len,
-                                                  member_size);
+                if (H5Z__nbit_decompress_one_nooptype(data, data_offset + member_offset, buffer, buffer_size,
+                                                      j, buf_len, member_size) < 0)
+                    HGOTO_ERROR(H5E_PLINE, H5E_CANTFILTER, FAIL, "can't decompress no-op type");
                 break;
 
             default:
@@ -1256,7 +1295,8 @@ done:
 }
 
 static herr_t
-H5Z__nbit_decompress(unsigned char *data, unsigned d_nelmts, unsigned char *buffer, const unsigned parms[])
+H5Z__nbit_decompress(unsigned char *data, unsigned d_nelmts, unsigned char *buffer, size_t buffer_size,
+                     const unsigned parms[])
 {
     /* i: index of data, j: index of buffer,
        buf_len: number of bits to be filled in current byte */
@@ -1288,14 +1328,16 @@ H5Z__nbit_decompress(unsigned char *data, unsigned d_nelmts, unsigned char *buff
                 HGOTO_ERROR(H5E_PLINE, H5E_BADTYPE, FAIL, "invalid datatype precision/offset");
 
             for (i = 0; i < d_nelmts; i++)
-                H5Z__nbit_decompress_one_atomic(data, i * (size_t)p.size, buffer, &j, &buf_len, &p);
+                if (H5Z__nbit_decompress_one_atomic(data, i * (size_t)p.size, buffer, buffer_size, &j,
+                                                    &buf_len, &p) < 0)
+                    HGOTO_ERROR(H5E_PLINE, H5E_CANTFILTER, FAIL, "can't decompress atomic");
             break;
 
         case H5Z_NBIT_ARRAY:
             size        = parms[4];
             parms_index = 4; /* set the index before goto function call */
             for (i = 0; i < d_nelmts; i++) {
-                if (H5Z__nbit_decompress_one_array(data, i * size, buffer, &j, &buf_len, parms,
+                if (H5Z__nbit_decompress_one_array(data, i * size, buffer, buffer_size, &j, &buf_len, parms,
                                                    &parms_index) < 0)
                     HGOTO_ERROR(H5E_PLINE, H5E_CANTFILTER, FAIL, "can't decompress array");
                 parms_index = 4;
@@ -1306,8 +1348,8 @@ H5Z__nbit_decompress(unsigned char *data, unsigned d_nelmts, unsigned char *buff
             size        = parms[4];
             parms_index = 4; /* set the index before goto function call */
             for (i = 0; i < d_nelmts; i++) {
-                if (H5Z__nbit_decompress_one_compound(data, i * size, buffer, &j, &buf_len, parms,
-                                                      &parms_index) < 0)
+                if (H5Z__nbit_decompress_one_compound(data, i * size, buffer, buffer_size, &j, &buf_len,
+                                                      parms, &parms_index) < 0)
                     HGOTO_ERROR(H5E_PLINE, H5E_CANTFILTER, FAIL, "can't decompress compound");
                 parms_index = 4;
             }

--- a/test/direct_chunk.c
+++ b/test/direct_chunk.c
@@ -45,6 +45,7 @@
 #ifndef H5_NO_DEPRECATED_SYMBOLS
 #define DATASETNAME14 "deprec"
 #endif /* H5_NO_DEPRECATED_SYMBOLS */
+#define DATASETNAME15 "short_nbit_chunk"
 
 #define RANK     2
 #define NX       16
@@ -2267,6 +2268,103 @@ error:
 } /* test_read_unallocated_chunk() */
 
 /*-------------------------------------------------------------------------
+ * Function:    test_read_short_nbit_chunk
+ *
+ * Purpose:     Store, via H5Dwrite_chunk, an nbit-filtered chunk whose raw
+ *              length is far shorter than the unfiltered chunk, then read it
+ *              back.  The reverse nbit filter must reject the truncated chunk
+ *              instead of decompressing past its stored bytes.
+ *
+ * Return:      Success:    0
+ *              Failure:    1
+ *
+ *-------------------------------------------------------------------------
+ */
+static int
+test_read_short_nbit_chunk(hid_t file)
+{
+    hid_t         sid         = H5I_INVALID_HID;
+    hid_t         did         = H5I_INVALID_HID;
+    hid_t         dcpl        = H5I_INVALID_HID;
+    hid_t         dtype       = H5I_INVALID_HID;
+    hsize_t       dims[1]     = {1000}; /* unfiltered chunk dwarfs the stored bytes */
+    hsize_t       offset[1]   = {0};
+    unsigned char raw[8]      = {0}; /* absurdly short stored chunk */
+    unsigned      filter_mask = 0;
+    uint32_t     *rdata       = NULL;
+    herr_t        status;
+
+    TESTING("reading a truncated nbit chunk");
+
+    if ((sid = H5Screate_simple(1, dims, NULL)) < 0)
+        FAIL_STACK_ERROR;
+
+    /* 16 significant bits in a 4-byte type so nbit actually packs the data */
+    if ((dtype = H5Tcopy(H5T_NATIVE_UINT32)) < 0)
+        FAIL_STACK_ERROR;
+    if (H5Tset_precision(dtype, 16) < 0)
+        FAIL_STACK_ERROR;
+    if (H5Tset_offset(dtype, 0) < 0)
+        FAIL_STACK_ERROR;
+
+    if ((dcpl = H5Pcreate(H5P_DATASET_CREATE)) < 0)
+        FAIL_STACK_ERROR;
+    if (H5Pset_chunk(dcpl, 1, dims) < 0)
+        FAIL_STACK_ERROR;
+    if (H5Pset_nbit(dcpl) < 0)
+        FAIL_STACK_ERROR;
+
+    if ((did = H5Dcreate2(file, DATASETNAME15, dtype, sid, H5P_DEFAULT, dcpl, H5P_DEFAULT)) < 0)
+        FAIL_STACK_ERROR;
+
+    /* Store only 8 raw bytes as the whole chunk */
+    if (H5Dwrite_chunk(did, H5P_DEFAULT, filter_mask, offset, sizeof(raw), raw) < 0)
+        FAIL_STACK_ERROR;
+
+    if (NULL == (rdata = malloc((size_t)dims[0] * sizeof(uint32_t))))
+        TEST_ERROR;
+
+    /* The reverse nbit filter should fail rather than read past the stored bytes */
+    H5E_BEGIN_TRY
+    {
+        status = H5Dread(did, H5T_NATIVE_UINT32, H5S_ALL, H5S_ALL, H5P_DEFAULT, rdata);
+    }
+    H5E_END_TRY
+
+    if (status >= 0)
+        TEST_ERROR;
+
+    free(rdata);
+    rdata = NULL;
+
+    if (H5Dclose(did) < 0)
+        FAIL_STACK_ERROR;
+    if (H5Tclose(dtype) < 0)
+        FAIL_STACK_ERROR;
+    if (H5Pclose(dcpl) < 0)
+        FAIL_STACK_ERROR;
+    if (H5Sclose(sid) < 0)
+        FAIL_STACK_ERROR;
+
+    PASSED();
+    return 0;
+
+error:
+    free(rdata);
+    H5E_BEGIN_TRY
+    {
+        H5Dclose(did);
+        H5Tclose(dtype);
+        H5Pclose(dcpl);
+        H5Sclose(sid);
+    }
+    H5E_END_TRY
+
+    H5_FAILED();
+    return 1;
+} /* test_read_short_nbit_chunk() */
+
+/*-------------------------------------------------------------------------
  * Function:    test_direct_chunk_read_buf_size
  *
  * Purpose:     Test buffer size parameter/query for H5Dread_chunk2
@@ -2748,6 +2846,7 @@ main(void)
 #endif /* H5_HAVE_FILTER_DEFLATE */
     nerrors += test_read_unfiltered_dset(file_id);
     nerrors += test_read_unallocated_chunk(file_id);
+    nerrors += test_read_short_nbit_chunk(file_id);
     nerrors += test_direct_chunk_read_buf_size(file_id);
 #ifndef H5_NO_DEPRECATED_SYMBOLS
     nerrors += test_deprec(file_id);


### PR DESCRIPTION
## Describe your changes

The reverse nbit filter decompresses a chunk by walking its bit reader through the input buffer using the element count and precision from the on-disk filter pipeline message, but it never gets the number of bytes actually stored for the chunk. `H5D__chunk_lock()` sizes a filtered chunk buffer to `MAX(stored, unfiltered)` and fills only the stored bytes, so the buffer handed to the filter is routinely longer than the data in it. A truncated or corrupted chunk then decompresses out of the uninitialized remainder of that allocation and hands it back as dataset data.

This threads the stored length through `H5Z__nbit_decompress` and its per-type helpers and rejects any read past it, matching the bound the scaleoffset decompressor already carries. Keeping the check next to each `buffer[*j]` read means every element/array/compound path is covered without callers having to pre-validate the chunk. This is the nbit case left over from the filter bounds discussion in #6585.

## Issue ticket number (GitHub or JIRA)

Follow-up to #6585 (nbit was noted there as a separate fix).

## Checklist before requesting a review
- [x] My code conforms to the guidelines in CONTRIBUTING.md
- [x] I made an entry in release_docs/CHANGELOG.md (bug fixes, new features)
- [x] I added a test (bug fixes, new features)
