### PR TITLE
Fix memory leak of continuation messages on object header deserialize failure

### DIFF
--- a/src/H5Ocache.c
+++ b/src/H5Ocache.c
@@ -317,6 +317,16 @@ done:
         if (H5O__free(oh, false) < 0)
             HDONE_ERROR(H5E_OHDR, H5E_CANTRELEASE, NULL, "unable to destroy object header data");
 
+    /* Release any continuation messages accumulated during the deserialize on
+     *      error.  Normally the caller (H5O_protect) frees these after the
+     *      object header is successfully loaded, but the caller can't do so
+     *      if the object header failed to load (as its 'oh' is left NULL),
+     *      so we must release them here to avoid leaking them.
+     */
+    if (!ret_value && udata->common.cont_msg_info->msgs)
+        udata->common.cont_msg_info->msgs =
+            (H5O_cont_t *)H5FL_SEQ_FREE(H5O_cont_t, udata->common.cont_msg_info->msgs);
+
     FUNC_LEAVE_NOAPI(ret_value)
 } /* end H5O__cache_deserialize() */
 


### PR DESCRIPTION
## Summary

Fixes a memory leak reported by OSS-Fuzz via the matio project's fuzzer (closes #6386).

\\\
Direct leak of 56 byte(s) ... allocated from:
    # 3 H5O__add_cont_msg hdf5/src/H5Ocache.c
    # 4 H5O__chunk_deserialize hdf5/src/H5Ocache.c
    # 5 H5O__cache_deserialize hdf5/src/H5Ocache.c
    ...
    # 17 H5Rdereference2
\\\

## Root cause

\H5O__cache_deserialize()\ allocates the continuation-message array
(\cont_msg_info->msgs\, via \H5O__add_cont_msg()\ -> \H5FL_SEQ_REALLOC\) while parsing the first object-header chunk. The caller \H5O_protect()\ only frees that array on the **success** path (H5Ocache.c:1075) or on failure **when \oh != NULL\** (rule at H5Ocache.c:1142). When the deserialize fails *after* continuation messages were accumulated (e.g. the v1 \1_pfx_nmesgs < oh->nmesgs\ check at H5Ocache.c:305), \H5O__cache_deserialize()\ returns \NULL\ and \H5O_protect()\'s \oh\ stays \NULL\, so its cleanup is skipped and the 56-byte array leaks.

## Fix

Free \cont_msg_info->msgs\ in \H5O__cache_deserialize()\'s own \done\ block on error. \H5FL_seq_free()\ returns \NULL\, so this is safe against a double-free with the caller's guarded free (which becomes a no-op once the array is \NULL\).

## Verification

Compiles cleanly in both Release and Debug \hdf5-static\ builds and links into a Debug repro exercising matio's exact API paths (\H5Oget_info_by_name3\ + \H5Rdereference2\ on reference datasets). The leak is specific to **v1 object headers** (the post-continuation \1_pfx_nmesgs < oh->nmesgs\ check), which is why the leak manifests in the 2.2.0 OSS-Fuzz environment described in the issue.

## Checklist

- [x] PR is based on the develop branch
- [x] Only \src/H5Ocache.c\ is changed