### PR TITLE
Add Kitware/cdash-status action

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -41,6 +41,7 @@ There are a few that only get triggered manually.
 - java-examples-maven-test.yml comprehensive Java examples testing with Maven artifacts
 
 ## Triggered Workflows
+- cdash-status.yml links commit/PR statuses to their CDash build
 - clang-format-check.yml runs clang-format and reports issues
 - call-workflows.yml
 - codespell.yml checks spelling

--- a/.github/workflows/cdash-status.yml
+++ b/.github/workflows/cdash-status.yml
@@ -1,0 +1,24 @@
+# GitHub Action to link commit/PR statuses to the corresponding CDash build
+# https://github.com/Kitware/cdash-status
+name: cdash-status
+on:
+  push:
+  pull_request_target:
+permissions:
+  contents: read
+jobs:
+  generate_statuses:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      statuses: write
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+          # Required for pull_request_target with checkout v7; safe here because no ref override is set.
+          allow-unsafe-pr-checkout: true
+      - uses: Kitware/cdash-status@697751fc655b300a9e16e285f2e2ee981f59e45a # v2.0.0
+        with:
+          project: HDF5
+          base_url: https://my.cdash.org


### PR DESCRIPTION
This provides a commit status that links to the CDash build of a commit/PR, as done in ADIOS2, ZFP, Viskores, and many others.

Here is a screenshot how it appears in a PR, the cdash keyword is a link to the cdash page for the commit.

<img width="669" height="657" alt="Screenshot From 2026-08-19 17-53-04" src="https://github.com/user-attachments/assets/c9584fec-f08c-4ab4-a3c0-e5b8ba409643" />

