### PR TITLE
Fix segfault in ph5_f90_filtered_writes_no_sel: swap inverted mem_space_id

### DIFF
--- a/HDF5Examples/FORTRAN/H5PAR/ph5_f90_filtered_writes_no_sel.F90
+++ b/HDF5Examples/FORTRAN/H5PAR/ph5_f90_filtered_writes_no_sel.F90
@@ -186,7 +186,7 @@ CONTAINS
        ! passed to H5Dwrite.
          
        CALL H5Sselect_none_f(file_dataspace, status)
-       sel_type = H5S_BLOCK_F
+       sel_type = H5S_ALL_F
     ELSE
         !
         ! Even MPI ranks contribute data to
@@ -206,7 +206,7 @@ CONTAINS
 
         CALL H5Sselect_hyperslab_f(file_dataspace, H5S_SELECT_SET_F, start, count, status, stride=stride)
 
-        sel_type = H5S_ALL_F
+        sel_type = H5S_BLOCK_F
         !
         ! --------------------------------------
         ! Fill data buffer with MPI rank's rank


### PR DESCRIPTION
Fixes #6632.

## Summary
- `ph5_f90_filtered_writes_no_sel.F90` had its `sel_type` (`mem_space_id`)
  assignment inverted relative to the C reference example
  (`ph5_filtered_writes_no_sel.c`): `H5S_BLOCK_F` was used on the
  no-selection branch and `H5S_ALL_F` on the real-hyperslab branch, when it
  should be the other way around.
- The inversion feeds a bogus selection into the collective filtered I/O
  path, corrupting element/byte-length accounting and segfaulting inside
  `H5D_select_io_mem` / `H5VM_memcpyvv` under a 12-rank parallel run.
- The bug has been present since the example was added (#3916); this is
  not a recent regression.
