### PR TITLE
Fix MSVC Debug CRT asserts

### DIFF
--- a/tools/lib/h5diff_array.c
+++ b/tools/lib/h5diff_array.c
@@ -4677,10 +4677,10 @@ h5diff_print_char(char ch)
             parallel_print("\\t");
             break;
         default:
-            if (isprint(ch))
+            if (isprint((unsigned char)ch))
                 parallel_print("%c", ch);
             else
-                parallel_print("\\%03o", ch);
+                parallel_print("\\%03o", (unsigned char)ch);
             break;
     }
 }

--- a/tools/lib/h5tools_str.c
+++ b/tools/lib/h5tools_str.c
@@ -607,10 +607,10 @@ h5tools_print_char(h5tools_str_t *str, const h5tool_format_t *info, char ch)
                     h5tools_str_append(str, "\\t");
                 break;
             default:
-                if (isprint(ch))
+                if (isprint((unsigned char)ch))
                     h5tools_str_append(str, "%c", ch);
                 else
-                    h5tools_str_append(str, "\\%03o", ch);
+                    h5tools_str_append(str, "\\%03o", (unsigned char)ch);
 
                 break;
         }
@@ -1610,7 +1610,7 @@ h5tools_escape(char *s /*in,out*/, size_t size)
                 escape = "\\v";
                 break;
             default:
-                if (!isprint(s[i])) {
+                if (!isprint((unsigned char)s[i])) {
                     snprintf(octal, sizeof(octal), "\\%03o", (unsigned char)s[i]);
                     escape = octal;
                 }

--- a/tools/src/h5ls/h5ls.c
+++ b/tools/src/h5ls/h5ls.c
@@ -341,7 +341,7 @@ print_string(h5tools_str_t *buffer, const char *s, bool escape_spaces)
                 }
                 break;
             default:
-                if (isprint((int)*s)) {
+                if (isprint((unsigned char)*s)) {
                     if (buffer)
                         h5tools_str_append(buffer, "%c", *s);
                     nprint++;


### PR DESCRIPTION
Fix MSVC Debug CRT asserts c >= -1 && c <= 255 in isctype whenever a <cctype> function (isprint, etc.) is called with a negative value