### PR TITLE
bound the table title read in H5TBinsert_field/H5TBdelete_field

### DIFF
--- a/hl/src/H5TB.c
+++ b/hl/src/H5TB.c
@@ -28,6 +28,8 @@ static herr_t H5TB_attach_attributes(const char *table_title, hid_t loc_id, cons
 static hid_t H5TB_create_type(hid_t loc_id, const char *dset_name, size_t type_size,
                               const size_t *field_offset, const size_t *field_sizes, hid_t ftype_id);
 
+static herr_t H5TB_get_title(hid_t loc_id, char *title, size_t title_size);
+
 /*-------------------------------------------------------------------------
  *
  * Create functions
@@ -2027,7 +2029,7 @@ H5TBinsert_field(hid_t loc_id, const char *dset_name, const char *field_name, hi
      */
 
     /* get the table title */
-    if ((H5TBAget_title(did_1, table_title)) < 0)
+    if (H5TB_get_title(did_1, table_title, sizeof(table_title)) < 0)
         goto out;
 
     /* alloc fill value attribute buffer */
@@ -2502,7 +2504,7 @@ H5TBdelete_field(hid_t loc_id, const char *dset_name, const char *field_name)
      */
 
     /* get the table title */
-    if ((H5TBAget_title(did_1, table_title)) < 0)
+    if (H5TB_get_title(did_1, table_title, sizeof(table_title)) < 0)
         goto out;
 
     /* insert the old fields except the one to delete */
@@ -2804,6 +2806,61 @@ out:
  *
  *-------------------------------------------------------------------------
  */
+
+/*-------------------------------------------------------------------------
+ * Function: H5TB_get_title
+ *
+ * Purpose: Read the TITLE attribute into a caller-supplied buffer without
+ *          writing past it. H5TBAget_title() hands the buffer straight to
+ *          H5Aread(), which copies the whole stored attribute, so a table
+ *          whose TITLE is longer than the buffer overruns it. Read into a
+ *          buffer sized to the stored attribute instead and copy back a
+ *          bounded, NUL-terminated title.
+ *
+ * Return: Success: 0, Failure: -1
+ *
+ *-------------------------------------------------------------------------
+ */
+static herr_t
+H5TB_get_title(hid_t loc_id, char *title, size_t title_size)
+{
+    hid_t  attr_id   = H5I_INVALID_HID;
+    hid_t  attr_type = H5I_INVALID_HID;
+    size_t attr_size;
+    size_t copy_len;
+    char  *buf     = NULL;
+    herr_t ret_val = -1;
+
+    if (title == NULL || title_size == 0)
+        goto out;
+
+    if ((attr_id = H5Aopen(loc_id, "TITLE", H5P_DEFAULT)) < 0)
+        goto out;
+    if ((attr_type = H5Aget_type(attr_id)) < 0)
+        goto out;
+    if (0 == (attr_size = H5Tget_size(attr_type)))
+        goto out;
+
+    if (NULL == (buf = (char *)malloc(attr_size)))
+        goto out;
+    if (H5Aread(attr_id, attr_type, buf) < 0)
+        goto out;
+
+    copy_len = (attr_size < title_size) ? attr_size : title_size - 1;
+    memcpy(title, buf, copy_len);
+    title[copy_len] = '\0';
+
+    ret_val = 0;
+
+out:
+    free(buf);
+    if (attr_type != H5I_INVALID_HID)
+        H5Tclose(attr_type);
+    if (attr_id != H5I_INVALID_HID)
+        H5Aclose(attr_id);
+
+    return ret_val;
+}
 
 /*-------------------------------------------------------------------------
  * Function: H5TBAget_title

--- a/hl/test/test_table.c
+++ b/hl/test/test_table.c
@@ -1692,10 +1692,58 @@ out:
 }
 
 /*-------------------------------------------------------------------------
+ * A table whose TITLE attribute is longer than the fixed buffer that
+ * H5TBinsert_field / H5TBdelete_field read it back into used to overrun that
+ * buffer. Round-trip a long title through both to make sure it no longer does.
+ *-------------------------------------------------------------------------
+ */
+static int
+test_table_long_title(void)
+{
+    hid_t       fid             = H5I_INVALID_HID;
+    const char *field_names[1]  = {"field"};
+    size_t      field_offset[1] = {0};
+    hid_t       field_types[1]  = {H5T_NATIVE_INT};
+    int         data            = 0;
+    int         fill            = 0;
+    int         newdata         = 1;
+    char        long_title[600];
+
+    HL_TESTING2("table title longer than internal buffer");
+
+    memset(long_title, 'A', sizeof(long_title));
+    long_title[sizeof(long_title) - 1] = '\0';
+
+    if ((fid = H5Fcreate("test_table_title.h5", H5F_ACC_TRUNC, H5P_DEFAULT, H5P_DEFAULT)) < 0)
+        goto out;
+
+    if (H5TBmake_table(long_title, fid, "tbl", (hsize_t)1, (hsize_t)1, sizeof(int), field_names, field_offset,
+                       field_types, (hsize_t)10, NULL, 0, &data) < 0)
+        goto out;
+
+    if (H5TBinsert_field(fid, "tbl", "newf", H5T_NATIVE_INT, (hsize_t)1, &fill, &newdata) < 0)
+        goto out;
+
+    if (H5TBdelete_field(fid, "tbl", "newf") < 0)
+        goto out;
+
+    if (H5Fclose(fid) < 0)
+        goto out;
+
+    PASSED();
+    return 0;
+
+out:
+    if (fid != H5I_INVALID_HID)
+        H5Fclose(fid);
+    H5_FAILED();
+    return -1;
+}
+
+/*-------------------------------------------------------------------------
  * the main program
  *-------------------------------------------------------------------------
  */
-
 int
 main(void)
 {
@@ -1718,6 +1766,11 @@ main(void)
 
     /* close */
     H5Fclose(fid);
+
+    puts("Testing table with a title longer than the internal title buffer:");
+
+    if (test_table_long_title() < 0)
+        return 1;
 
     /*-------------------------------------------------------------------------
      * test2: open a file written in test1 on a big-endian machine

--- a/release_docs/CHANGELOG.md
+++ b/release_docs/CHANGELOG.md
@@ -148,12 +148,12 @@ We would like to thank the many HDF5 community members who contributed to this r
 
 ### Bounded the table TITLE read in H5TBinsert_field/H5TBdelete_field
 
-   Both functions read a table's TITLE attribute back with H5TBAget_title(),
+   Both functions read a table's TITLE attribute back using H5TBAget_title(),
    which passes the caller's buffer straight to H5Aread(). The buffer is a
    fixed 255-byte stack array, but H5Aread() copies the whole stored
-   attribute, so opening a table whose TITLE is longer than that buffer
-   overran the stack. The title is now read into a buffer sized to the stored
-   attribute and copied back with a length cap.
+   attribute. Consequently, opening a table with a TITLE longer than the
+   buffer overran the stack. The title is now read into a buffer sized to the
+   stored attribute and copied back with a length cap.
 
 ## Fortran High-Level APIs
 

--- a/release_docs/CHANGELOG.md
+++ b/release_docs/CHANGELOG.md
@@ -146,6 +146,15 @@ We would like to thank the many HDF5 community members who contributed to this r
 
 ## High-Level Library
 
+### Bounded the table TITLE read in H5TBinsert_field/H5TBdelete_field
+
+   Both functions read a table's TITLE attribute back with H5TBAget_title(),
+   which passes the caller's buffer straight to H5Aread(). The buffer is a
+   fixed 255-byte stack array, but H5Aread() copies the whole stored
+   attribute, so opening a table whose TITLE is longer than that buffer
+   overran the stack. The title is now read into a buffer sized to the stored
+   attribute and copied back with a length cap.
+
 ## Fortran High-Level APIs
 
 ## Documentation


### PR DESCRIPTION
## Describe your changes

Repro: open a table whose TITLE attribute is longer than 254 bytes, then call H5TBinsert_field or H5TBdelete_field on it.
Cause: both read the title back with H5TBAget_title(), which passes their fixed char[255] straight to H5Aread(). H5Aread() copies the whole stored attribute, so a longer title runs off the stack buffer (ASan reports a 600-byte write into table_title[255]).
Fix: read the title through a bounded helper that sizes its own buffer to the stored attribute and copies back a length-capped, NUL-terminated string. H5TBAget_title() has no length argument so it cannot be made safe in place; the fix lives at the two callers that pair it with a fixed buffer.

## Issue ticket number (GitHub or JIRA)

N/A

## Checklist before requesting a review
- [x] My code conforms to the guidelines in CONTRIBUTING.md
- [x] I made an entry in release_docs/CHANGELOG.md (bug fixes, new features)
- [x] I added a test (bug fixes, new features)
