### PR TITLE
Fix leaked identifiers in H5DSattach_scale()

### DIFF
--- a/CMakeBuildOptions.cmake
+++ b/CMakeBuildOptions.cmake
@@ -83,6 +83,17 @@ mark_as_advanced (HDF5_ENABLE_PLUGIN_SUPPORT)
 
 option (HDF5_BUILD_HL_LIB "Build HIGH Level HDF5 Library" ON)
 
+# Must be set here, not in hl/, so that it reaches the H5pubconf.h and
+# build-settings configure_file() calls
+option (HDF5_DIMENSION_SCALES_NEW_REF "Use new-style references with dimension scale APIs" OFF)
+mark_as_advanced (HDF5_DIMENSION_SCALES_NEW_REF)
+if (HDF5_DIMENSION_SCALES_NEW_REF)
+  set (H5_DIMENSION_SCALES_WITH_NEW_REF 1)
+  set (DIMENSION_SCALES_WITH_NEW_REF "yes")
+else ()
+  set (DIMENSION_SCALES_WITH_NEW_REF "no")
+endif ()
+
 option (HDF5_BUILD_FORTRAN "Build FORTRAN support" OFF)
 
 option (HDF5_BUILD_CPP_LIB "Build HDF5 C++ Library" OFF)

--- a/hl/CMakeLists.txt
+++ b/hl/CMakeLists.txt
@@ -2,15 +2,6 @@ cmake_minimum_required (VERSION 3.26)
 project (HDF5_HL C)
 
 #-----------------------------------------------------------------------------
-# Option to use new-style references with dimension scale APIs
-#-----------------------------------------------------------------------------
-option (HDF5_DIMENSION_SCALES_NEW_REF  "Use new-style references with dimension scale APIs" OFF)
-mark_as_advanced (HDF5_DIMENSION_SCALES_NEW_REF)
-if (HDF5_DIMENSION_SCALES_NEW_REF)
-  set (H5_DIMENSION_SCALES_WITH_NEW_REF 1)
-endif ()
-
-#-----------------------------------------------------------------------------
 # List Source files
 #-----------------------------------------------------------------------------
 

--- a/hl/src/H5DS.c
+++ b/hl/src/H5DS.c
@@ -24,8 +24,11 @@ static herr_t H5DS_is_reserved(hid_t did, bool *is_reserved);
  * Purpose: Determines if new references are used with dimension scales.
  *   The function H5DSwith_new_ref takes any object identifier and checks
  *   if new references are used for dimension scales. Currently,
- *   new references are used when non-native VOL connector is used or when
- *   H5_DIMENSION_SCALES_WITH_NEW_REF is set up via configure option.
+ *   new references are used when the object's terminal VOL connector is not
+ *   the native one -- note that a pass-through connector stacked over the
+ *   native connector still has a native terminal connector, and so does not
+ *   count -- or when H5_DIMENSION_SCALES_WITH_NEW_REF is set up via configure
+ *   option.
  *
  * Return: Non-negative on success/Negative on failure
  *
@@ -592,11 +595,21 @@ H5DSattach_scale(hid_t did, hid_t dsid, unsigned int idx)
                     H5Dclose(tmp_id);
                     goto out;
                 }
-                /* Only the error path above closed this, so each reference
-                 * already in REFERENCE_LIST leaked a dataset ID, which in turn
-                 * kept its file open. H5DSdetach_scale's matching loop closes
-                 * it here.
-                 */
+                /* The error path above closed this; the success path did not,
+                 * so every reference already in REFERENCE_LIST leaked a dataset
+                 * ID (and, through it, kept the file open). H5DSdetach_scale's
+                 * identical loop has always had this close.
+                 *
+                 * Unreachable for a native object in a library built without
+                 * H5_DIMENSION_SCALES_WITH_NEW_REF, which takes the `else`
+                 * branch and opens nothing: H5DSwith_new_ref() sets
+                 * is_new_ref = (config_flag || !native), and the `native` there
+                 * is decided by the object's *terminal* connector, so a
+                 * pass-through connector over the native one is still native.
+                 * Where this does run, the leak surfaces as a later
+                 * H5Fcreate(H5F_ACC_TRUNC) on the same file failing with
+                 * "unable to truncate a file which is already open" -- an error
+                 * with nothing in it to suggest a dimension scale. */
                 if (H5Dclose(tmp_id) < 0)
                     goto out;
             }
@@ -632,13 +645,23 @@ H5DSattach_scale(hid_t did, hid_t dsid, unsigned int idx)
         if (is_new_ref) {
             if (H5Awrite(aid, ntid, ndsbuf_w) < 0)
                 goto out;
-            if (H5Treclaim(tid, sid, H5P_DEFAULT, ndsbuf_w) < 0)
+            /* Free the references.  The ones read from the old attribute hold
+             * the file they came from open until they are destroyed, and the
+             * new buffer has to be reclaimed with its own space: the reference
+             * just appended sits at index nelmts - 1, one past the extent of
+             * SID.  Leaving either behind kept the file open, so a later
+             * H5Fcreate(H5F_ACC_TRUNC) on it failed with "unable to truncate a
+             * file which is already open".  H5DSdetach_scale() reclaims both.
+             */
+            if (H5Treclaim(tid, sid, H5P_DEFAULT, ndsbuf) < 0)
+                goto out;
+            if (H5Treclaim(tid, sid_w, H5P_DEFAULT, ndsbuf_w) < 0)
                 goto out;
         }
         else {
             if (H5Awrite(aid, ntid, dsbuf_w) < 0)
                 goto out;
-            if (H5Treclaim(tid, sid, H5P_DEFAULT, dsbuf_w) < 0)
+            if (H5Treclaim(tid, sid_w, H5P_DEFAULT, dsbuf_w) < 0)
                 goto out;
         }
         if (H5Sclose(sid) < 0)

--- a/hl/src/H5DS.c
+++ b/hl/src/H5DS.c
@@ -592,6 +592,13 @@ H5DSattach_scale(hid_t did, hid_t dsid, unsigned int idx)
                     H5Dclose(tmp_id);
                     goto out;
                 }
+                /* Only the error path above closed this, so each reference
+                 * already in REFERENCE_LIST leaked a dataset ID, which in turn
+                 * kept its file open. H5DSdetach_scale's matching loop closes
+                 * it here.
+                 */
+                if (H5Dclose(tmp_id) < 0)
+                    goto out;
             }
             else {
                 dsbuf_w[j] = dsbuf[j];

--- a/hl/src/H5DSpublic.h
+++ b/hl/src/H5DSpublic.h
@@ -799,9 +799,11 @@ extern "C" {
  *
  *  \details H5DSwith_new_ref() takes any object identifier and checks
  *           if new references are used for dimension scales. Currently,
- *           new references are used when non-native VOL connector is
- *           used or when H5_DIMENSION_SCALES_WITH_NEW_REF is set up
- *           via configure option.
+ *           new references are used when the object's terminal VOL
+ *           connector is not the native one -- a pass-through connector
+ *           stacked over the native connector still has a native terminal
+ *           connector, and so does not count -- or when
+ *           H5_DIMENSION_SCALES_WITH_NEW_REF is set up via configure option.
  *
  */
 H5HL_DLL herr_t H5DSwith_new_ref(hid_t obj_id, bool *with_new_ref);

--- a/hl/test/CMakeTests.cmake
+++ b/hl/test/CMakeTests.cmake
@@ -67,6 +67,7 @@ set (test_hl_CLEANFILES
     test_ds10.h5
     test_ds_class_prefix.h5
     test_ds_reserved_prefix.h5
+    test_ds_id_leak.h5
     test_image1.h5
     test_image2.h5
     test_image3.h5

--- a/hl/test/test_ds.c
+++ b/hl/test/test_ds.c
@@ -95,6 +95,7 @@ static int read_data(const char *fname, int ndims, hsize_t *dims, float **buf);
 static int test_attach_detach(void);
 static int test_is_scale_class_prefix(void);
 static int test_is_reserved_class_prefix(void);
+static int test_attach_scale_id_leak(void);
 
 #define RANK1     1
 #define RANK      2
@@ -148,14 +149,15 @@ static int test_is_reserved_class_prefix(void);
 #define FILENAME "test_ds"
 #define FILEEXT  ".h5"
 
-#define FILE1 "test_ds3.h5"
-#define FILE2 "test_ds4.h5"
-#define FILE3 "test_ds5.h5"
-#define FILE4 "test_ds6.h5"
-#define FILE5 "test_ds7.h5"
-#define FILE6 "test_ds8.h5"
-#define FILE7 "test_ds9.h5"
-#define FILE8 "test_ds10.h5"
+#define FILE1     "test_ds3.h5"
+#define FILE2     "test_ds4.h5"
+#define FILE3     "test_ds5.h5"
+#define FILE4     "test_ds6.h5"
+#define FILE5     "test_ds7.h5"
+#define FILE6     "test_ds8.h5"
+#define FILE7     "test_ds9.h5"
+#define FILE8     "test_ds10.h5"
+#define FILE_LEAK "test_ds_id_leak.h5"
 
 #define DIMENSION_LIST "DIMENSION_LIST"
 #define REFERENCE_LIST "REFERENCE_LIST"
@@ -215,6 +217,7 @@ main(void)
     nerrors += test_data() < 0 ? 1 : 0;
     nerrors += test_is_scale_class_prefix() < 0 ? 1 : 0;
     nerrors += test_is_reserved_class_prefix() < 0 ? 1 : 0;
+    nerrors += test_attach_scale_id_leak() < 0 ? 1 : 0;
 
     if (nerrors)
         goto error;
@@ -5701,6 +5704,116 @@ out:
         H5Tclose(atid);
         H5Dclose(dsid);
         H5Dclose(did);
+        H5Sclose(sid);
+        H5Fclose(fid);
+    }
+    H5E_END_TRY
+    H5_FAILED();
+    return FAIL;
+}
+
+/*-------------------------------------------------------------------------
+ * test that H5DSattach_scale() does not leak the dataset IDs it opens while
+ * rewriting an existing REFERENCE_LIST attribute
+ *
+ * That rewriting loop only runs on the "new reference" code path, which
+ * H5DSwith_new_ref() selects when the library is built with
+ * H5_DIMENSION_SCALES_WITH_NEW_REF (-DHDF5_DIMENSION_SCALES_NEW_REF=ON) or
+ * when the object lives behind a VOL connector whose terminal connector is not
+ * the native one.  The test skips itself on the old-reference path, where the
+ * loop reopens nothing.
+ *
+ * Every reference already stored in the scale's REFERENCE_LIST used to leak one
+ * dataset ID, and the references themselves were never destroyed.  Both kept
+ * the file open, so a later H5Fcreate(H5F_ACC_TRUNC) on it failed with "unable
+ * to truncate a file which is already open".  Both symptoms are checked here.
+ *-------------------------------------------------------------------------
+ */
+static int
+test_attach_scale_id_leak(void)
+{
+    hid_t   fid       = H5I_INVALID_HID;
+    hid_t   sid       = H5I_INVALID_HID;
+    hid_t   dsid      = H5I_INVALID_HID;
+    hid_t   did       = H5I_INVALID_HID;
+    bool    new_ref   = false;
+    hsize_t dims[1]   = {4};
+    ssize_t ndatasets = 0;
+    int     i;
+
+    HL_TESTING2("H5DSattach_scale does not leak dataset IDs");
+
+    if ((fid = H5Fcreate(FILE_LEAK, H5F_ACC_TRUNC, H5P_DEFAULT, H5P_DEFAULT)) < 0)
+        goto out;
+    if ((sid = H5Screate_simple(1, dims, NULL)) < 0)
+        goto out;
+
+    /* the dimension scale that all of the datasets below get attached to */
+    if ((dsid = H5Dcreate2(fid, "ds", H5T_NATIVE_INT, sid, H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT)) < 0)
+        goto out;
+    if (H5DSset_scale(dsid, "xdim") < 0)
+        goto out;
+
+    /* the leaking loop only exists on the new-reference path */
+    if (H5DSwith_new_ref(dsid, &new_ref) < 0)
+        goto out;
+
+    /* Attach the scale to several datasets.  On the new-reference path, each
+     * attach after the first rewrites the scale's REFERENCE_LIST attribute,
+     * reopening every reference already stored in it -- one leaked dataset ID
+     * apiece. */
+    for (i = 0; i < 4; i++) {
+        char dname[32];
+
+        snprintf(dname, sizeof(dname), "data%d", i);
+        if ((did = H5Dcreate2(fid, dname, H5T_NATIVE_INT, sid, H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT)) < 0)
+            goto out;
+        if (H5DSattach_scale(did, dsid, 0) < 0)
+            goto out;
+        if (H5Dclose(did) < 0)
+            goto out;
+        did = H5I_INVALID_HID;
+    }
+
+    /* the scale is the only dataset this test still holds open */
+    if ((ndatasets = H5Fget_obj_count(fid, H5F_OBJ_DATASET | H5F_OBJ_LOCAL)) < 0)
+        goto out;
+    if (ndatasets != 1) {
+        printf("    %ld dataset ID(s) open after attaching, expected 1\n", (long)ndatasets);
+        goto out;
+    }
+
+    if (H5Dclose(dsid) < 0)
+        goto out;
+    dsid = H5I_INVALID_HID;
+    if (H5Sclose(sid) < 0)
+        goto out;
+    sid = H5I_INVALID_HID;
+    if (H5Fclose(fid) < 0)
+        goto out;
+    fid = H5I_INVALID_HID;
+
+    /* With anything left open, the file cannot be truncated */
+    if ((fid = H5Fcreate(FILE_LEAK, H5F_ACC_TRUNC, H5P_DEFAULT, H5P_DEFAULT)) < 0)
+        goto out;
+    if (H5Fclose(fid) < 0)
+        goto out;
+    fid = H5I_INVALID_HID;
+
+    if (!new_ref) {
+        SKIPPED();
+        printf("    dimension scales do not use new references in this build\n");
+        return 0;
+    }
+
+    PASSED();
+    return 0;
+
+out:
+    H5E_BEGIN_TRY
+    {
+        H5Dclose(did);
+        H5Dclose(dsid);
         H5Sclose(sid);
         H5Fclose(fid);
     }

--- a/release_docs/CHANGELOG.md
+++ b/release_docs/CHANGELOG.md
@@ -146,6 +146,23 @@ We would like to thank the many HDF5 community members who contributed to this r
 
 ## High-Level Library
 
+### Fixed a leaked dataset ID in H5DSattach_scale()
+
+   When attaching a dimension scale that already had one or more datasets
+   attached to it, `H5DSattach_scale()` reopened each reference stored in the
+   scale's `REFERENCE_LIST` attribute with `H5Ropen_object()` but only closed
+   the resulting identifier on the error path. One dataset identifier was
+   leaked per reference already attached, and each leaked identifier kept its
+   file open, so a later `H5Fcreate()` with `H5F_ACC_TRUNC` on the same file
+   failed with "unable to truncate a file which is already open".
+
+   The identifier is now closed on the success path as well, matching the
+   equivalent loop in `H5DSdetach_scale()`. The leak was only reachable through
+   a pass-through VOL connector, since `H5DSwith_new_ref()` selects the
+   old-style reference path -- which opens nothing -- whenever the object is
+   native and the library was not built with
+   `H5_DIMENSION_SCALES_WITH_NEW_REF`.
+
 ## Fortran High-Level APIs
 
 ## Documentation

--- a/release_docs/CHANGELOG.md
+++ b/release_docs/CHANGELOG.md
@@ -146,22 +146,28 @@ We would like to thank the many HDF5 community members who contributed to this r
 
 ## High-Level Library
 
-### Fixed a leaked dataset ID in H5DSattach_scale()
+### Fixed leaked identifiers in H5DSattach_scale()
 
    When attaching a dimension scale that already had one or more datasets
-   attached to it, `H5DSattach_scale()` reopened each reference stored in the
-   scale's `REFERENCE_LIST` attribute with `H5Ropen_object()` but only closed
-   the resulting identifier on the error path. One dataset identifier was
-   leaked per reference already attached, and each leaked identifier kept its
-   file open, so a later `H5Fcreate()` with `H5F_ACC_TRUNC` on the same file
-   failed with "unable to truncate a file which is already open".
+   attached to it, `H5DSattach_scale()` rewrote the scale's `REFERENCE_LIST`
+   attribute without releasing everything it had acquired to do so. It reopened
+   each reference in the existing list with `H5Ropen_object()` but only closed
+   the resulting identifier on the error path, and it destroyed neither the
+   references it read from the old attribute nor the one it appended to the new
+   one -- the buffer being written was reclaimed with the old, one element
+   shorter, dataspace. Every one of those kept the file open, so a later
+   `H5Fcreate()` with `H5F_ACC_TRUNC` on the same file failed with "unable to
+   truncate a file which is already open", an error with nothing in it to point
+   back at a dimension scale.
 
-   The identifier is now closed on the success path as well, matching the
-   equivalent loop in `H5DSdetach_scale()`. The leak was only reachable through
-   a pass-through VOL connector, since `H5DSwith_new_ref()` selects the
-   old-style reference path -- which opens nothing -- whenever the object is
-   native and the library was not built with
-   `H5_DIMENSION_SCALES_WITH_NEW_REF`.
+   The identifier is now closed on the success path as well, and both reference
+   buffers are reclaimed, matching the equivalent code in
+   `H5DSdetach_scale()`. This code is only reached when `H5DSwith_new_ref()`
+   selects the new-style reference path, which happens when the object's
+   terminal VOL connector is not the native one -- a pass-through connector
+   stacked over the native connector does not qualify -- or when the library is
+   built with `H5_DIMENSION_SCALES_WITH_NEW_REF`; the old-style path opens
+   nothing.
 
 ## Fortran High-Level APIs
 


### PR DESCRIPTION
## Describe your changes

`H5DSattach_scale()` rewrites the scale's `REFERENCE_LIST` attribute whenever a
dataset is attached to a scale that already has one, and that rewrite acquired
three things it never released:

```c
tmp_id = H5Ropen_object(&ndsbuf[j].ref, H5P_DEFAULT, H5P_DEFAULT);
if (tmp_id < 0)
    goto out;
if (H5Rcreate_object(tmp_id, ".", H5P_DEFAULT, &ndsbuf_w[j].ref) < 0) {
    H5Dclose(tmp_id);      /* error path closed it */
    goto out;
}
                           /* success path did not */
```

1. the reopened dataset identifier above -- one per reference already attached
   to the scale;
2. the references read from the old attribute into `ndsbuf`, which were
   `free()`d without ever being destroyed;
3. the reference appended at index `nelmts - 1` of `ndsbuf_w`, because that
   buffer was reclaimed with `sid`, the *old* dataspace, which is one element
   shorter than the buffer.

Each of these keeps the file open, which is the symptom in the issue: a later
`H5Fcreate()` with `H5F_ACC_TRUNC` on the same file fails with *"unable to
truncate a file which is already open"*, an error with nothing in it to point
back at a dimension scale. `H5DSdetach_scale()` closes the identifier and
reclaims both buffers; attach now does the same.

### Reachability

The rewrite loop runs only on the new-style reference path, which
`H5DSwith_new_ref()` selects when the library is built with
`H5_DIMENSION_SCALES_WITH_NEW_REF` or when the object's **terminal** VOL
connector is not the native one. Stacking a pass-through connector over the
native connector does *not* reach it -- `H5VLobject_is_native()` compares the
terminal connector class, so pass-through-over-native still counts as native.
An earlier revision of this PR said "only a pass-through VOL connector"; the
comments and the `H5DSwith_new_ref()` documentation are corrected accordingly.

### Test

`test_attach_scale_id_leak()` in `hl/test/test_ds.c` attaches one scale to four
datasets, then checks that the scale is the only dataset identifier still open
and that the file can be truncated after being closed. It skips itself on the
old-reference path, where the loop opens nothing. Reverting either fix fails
it:

| reverted | result |
| --- | --- |
| `H5Dclose(tmp_id)` | `7 dataset ID(s) open after attaching, expected 1` |
| the `H5Treclaim()` calls | the truncate fails |
| nothing | passes |

All 133 tests pass in a `-DHDF5_DIMENSION_SCALES_NEW_REF=ON` build; `HL_*` and
the `h5dump`/`h5ls`/`h5repack` tool tests pass in a default build.

### CMake

`-DHDF5_DIMENSION_SCALES_NEW_REF=ON` was a no-op, so the code path above could
not be exercised from a stock build at all. The option was declared in
`hl/CMakeLists.txt`, a child scope that the top-level `H5pubconf.h`
`configure_file()` never sees, so `H5_DIMENSION_SCALES_WITH_NEW_REF` was never
defined and `libhdf5.settings` reported nothing for it. It now lives in
`CMakeBuildOptions.cmake`, which is included before both `src/` and `hl/`.

## Issue ticket number (GitHub or JIRA)

Fixes #6639

## Checklist before requesting a review
- [x] My code conforms to the guidelines in CONTRIBUTING.md
- [x] I made an entry in release_docs/CHANGELOG.md (bug fixes, new features)
- [x] I added a test (bug fixes, new features)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
