### PR TITLE
H5Pget_driver_info: do not push an error when the driver has no info block

### DIFF
--- a/src/H5Pfapl.c
+++ b/src/H5Pfapl.c
@@ -1541,9 +1541,22 @@ H5Pget_driver_info(hid_t plist_id)
     if (NULL == (plist = (H5P_genplist_t *)H5I_object_verify(plist_id, H5I_GENPROP_LST)))
         HGOTO_ERROR(H5E_ARGS, H5E_BADTYPE, NULL, "not a property list");
 
-    /* Get the driver info */
-    if (NULL == (ret_value = (const void *)H5P_peek_driver_info(plist)))
-        HGOTO_ERROR(H5E_PLIST, H5E_CANTGET, NULL, "can't get driver info");
+    /* Get the driver info.
+     *
+     * NULL here is not necessarily a failure: a driver that registered no
+     * driver-specific properties leaves driver_info NULL, and both this
+     * function's own header above and its entry in H5Ppublic.h say that case
+     * returns NULL with nothing pushed on the error stack.  It used to push
+     * H5E_CANTGET anyway, so every H5Fopen through a driver selected by
+     * H5Pset_driver_by_name() or the HDF5_DRIVER environment variable -- which
+     * set no info block -- printed an error stack that described no error.
+     *
+     * The two real failures still report themselves: H5P_peek_driver_info()
+     * pushes H5E_BADTYPE for a list that is not a file access property list,
+     * and H5E_CANTGET when the property cannot be read.  Adding a second frame
+     * on top of those said nothing the first did not.
+     */
+    ret_value = (const void *)H5P_peek_driver_info(plist);
 
 done:
     FUNC_LEAVE_API(ret_value)


### PR DESCRIPTION
Fixes #6651.

`H5Pget_driver_info()` pushed `H5E_CANTGET` whenever `H5P_peek_driver_info()` returned NULL. NULL is not necessarily a failure there: a driver that registered no driver-specific properties leaves `driver_info` NULL, which is exactly what `H5Pset_driver_by_name()` and the `HDF5_DRIVER` environment variable produce.

Both the function's own header comment and its entry in `H5Ppublic.h` say that case returns NULL with no error pushed:

> Failure: NULL. Null is also returned if the driver has not registered any driver-specific properties although no error is pushed on the stack in this case.

and

> If no driver-specific properties have been registered, H5Pget_driver_info() returns NULL.

The sibling `H5Pget_driver_config_str()` already handles the same situation correctly:

```c
    if ((config_str = H5P_peek_driver_config_str(plist))) {
```

### Effect

Any VFD that fetches its optional FAPL info block — including HDF5's own `H5FDmulti.c`, in four places — prints an HDF5-DIAG stack on every open describing an error that did not occur:

```
HDF5-DIAG: Error detected in HDF5 (2.3.0):
  #000: src/H5Pfapl.c line 1546 in H5Pget_driver_info(): can't get driver info
    major: Property lists
    minor: Can't get value
```

I hit this running the netCDF-C test suite over an out-of-tree VFD selected with `HDF5_DRIVER=<name>`: every `H5Fopen` in the run produced one of these. Harmless to the operation, but not to testing — any test comparing a program's stderr against a reference sees a diff, and someone reading the output of a driver under development is told there is an error when there is not.

### The change

Drop the wrapper `HGOTO_ERROR` and assign the result. Nothing that was diagnosed stops being diagnosed: `H5P_peek_driver_info()` pushes `H5E_BADTYPE` itself for a list that is not a file access property list, and `H5E_CANTGET` when the property cannot be read. The removed frame only ever duplicated one of those or fired on a normal NULL.

Not a recent regression — the code dates to at least [svn-r15510] (2008).

🤖 Generated with [Claude Code](https://claude.com/claude-code)