### PR TITLE
Harden dense attr/link table builds against bogus record counts

### DIFF
--- a/src/H5Aint.c
+++ b/src/H5Aint.c
@@ -1613,7 +1613,15 @@ H5A__dense_build_table_cb(const H5A_t *attr, void *_udata)
     /* check arguments */
     assert(attr);
     assert(atable);
-    assert(atable->num_attrs < atable->max_attrs);
+
+    /* max_attrs comes from the name index's stored record count, which is
+     * attacker-controlled metadata, while this callback is driven by the tree
+     * walk.  A count below the tree's real size makes the walk overrun the
+     * table, so this bound must hold in a Release build.
+     */
+    if (atable->num_attrs >= atable->max_attrs)
+        HGOTO_ERROR(H5E_ATTR, H5E_OVERFLOW, H5_ITER_ERROR,
+                    "dense attribute index yields more attributes than its record count declares");
 
     /* Allocate attribute for entry in the table */
     if (NULL == (atable->attrs[atable->num_attrs] = H5FL_CALLOC(H5A_t)))
@@ -1691,6 +1699,15 @@ H5A__dense_build_table(H5F_t *f, const H5O_ainfo_t *ainfo, H5_index_t idx_type, 
         if (H5A__dense_iterate(f, (hid_t)0, ainfo, H5_INDEX_NAME, H5_ITER_NATIVE, (hsize_t)0, NULL, &attr_op,
                                atable) < 0)
             HGOTO_ERROR(H5E_ATTR, H5E_CANTINIT, FAIL, "error building attribute table");
+
+        /* The walk must have filled the table exactly.  A stored record count
+         * above the tree's real size leaves NULL entries that the sort below
+         * dereferences; the fill count is the only thing that can falsify the
+         * stored one.
+         */
+        if (atable->num_attrs != atable->max_attrs)
+            HGOTO_ERROR(H5E_ATTR, H5E_BADVALUE, FAIL,
+                        "dense attribute index record count does not match the attributes found");
 
         /* Sort attribute table in correct iteration order */
         if (H5A__attr_sort_table(atable, idx_type, order) < 0)

--- a/src/H5Aint.c
+++ b/src/H5Aint.c
@@ -1660,10 +1660,10 @@ herr_t
 H5A__dense_build_table(H5F_t *f, const H5O_ainfo_t *ainfo, H5_index_t idx_type, H5_iter_order_t order,
                        H5A_attr_table_t *atable)
 {
-    H5B2_t           *bt2_name = NULL;     /* v2 B-tree handle for name index */
+    H5B2_t            *bt2_name = NULL;     /* v2 B-tree handle for name index */
     H5A_attr_iter_op_t attr_op;             /* Attribute operator */
-    hsize_t           nrec;                /* # of records in v2 B-tree */
-    herr_t            ret_value = SUCCEED; /* Return value */
+    hsize_t            nrec;                /* # of records in v2 B-tree */
+    herr_t             ret_value = SUCCEED; /* Return value */
 
     FUNC_ENTER_PACKAGE
 
@@ -1692,7 +1692,7 @@ H5A__dense_build_table(H5F_t *f, const H5O_ainfo_t *ainfo, H5_index_t idx_type, 
 
     /* Visit records even when the declared count is zero. */
     if (H5A__dense_iterate(f, (hid_t)0, ainfo, H5_INDEX_NAME, H5_ITER_NATIVE, (hsize_t)0, NULL, &attr_op,
-                         atable) < 0)
+                           atable) < 0)
         HGOTO_ERROR(H5E_ATTR, H5E_CANTINIT, FAIL, "error building attribute table");
 
     /* Reject inconsistent metadata without allocating from the stored count. */

--- a/src/H5Aint.c
+++ b/src/H5Aint.c
@@ -1657,6 +1657,7 @@ H5A__dense_build_table(H5F_t *f, const H5O_ainfo_t *ainfo, H5_index_t idx_type, 
                        H5A_attr_table_t *atable)
 {
     H5B2_t *bt2_name = NULL;     /* v2 B-tree handle for name index */
+    haddr_t eoa;                  /* End of allocated space in the file */
     hsize_t nrec;                /* # of records in v2 B-tree */
     herr_t  ret_value = SUCCEED; /* Return value */
 
@@ -1682,8 +1683,11 @@ H5A__dense_build_table(H5F_t *f, const H5O_ainfo_t *ainfo, H5_index_t idx_type, 
     if (nrec > 0) {
         H5A_attr_iter_op_t attr_op; /* Attribute operator */
 
-        /* Check for overflow on the downcast */
-        H5_CHECK_OVERFLOW(nrec, /* From: */ hsize_t, /* To: */ size_t);
+        /* Reject counts that cannot be represented by the file or allocation. */
+        if (HADDR_UNDEF == (eoa = H5F_get_eoa(f, H5FD_MEM_DEFAULT)))
+            HGOTO_ERROR(H5E_ATTR, H5E_CANTGET, FAIL, "unable to determine file size");
+        if (nrec > eoa || nrec > (hsize_t)(SIZE_MAX / sizeof(*atable->attrs)))
+            HGOTO_ERROR(H5E_ATTR, H5E_OVERFLOW, FAIL, "invalid dense attribute index record count");
 
         /* Allocate the table to store the attributes */
         if (NULL == (atable->attrs = (H5A_t **)H5FL_SEQ_CALLOC(H5A_t_ptr, (size_t)nrec)))
@@ -1701,9 +1705,9 @@ H5A__dense_build_table(H5F_t *f, const H5O_ainfo_t *ainfo, H5_index_t idx_type, 
             HGOTO_ERROR(H5E_ATTR, H5E_CANTINIT, FAIL, "error building attribute table");
 
         /* The walk must have filled the table exactly.  A stored record count
-         * above the tree's real size leaves NULL entries that the sort below
-         * dereferences; the fill count is the only thing that can falsify the
-         * stored one.
+         * above the tree's real size would otherwise silently return a
+         * truncated attribute list; the fill count is the only thing that can
+         * falsify the stored one.
          */
         if (atable->num_attrs != atable->max_attrs)
             HGOTO_ERROR(H5E_ATTR, H5E_BADVALUE, FAIL,
@@ -1977,8 +1981,8 @@ H5A__attr_release_table(H5A_attr_table_t *atable)
     /* Sanity check */
     assert(atable);
 
-    /* Release attribute info, if any. */
-    if (atable->num_attrs > 0) {
+    /* Release attribute info and its table, if allocated. */
+    if (atable->attrs) {
         size_t u; /* Local index variable */
 
         /* Free attribute message information */
@@ -1989,8 +1993,6 @@ H5A__attr_release_table(H5A_attr_table_t *atable)
         /* Release array */
         atable->attrs = (H5A_t **)H5FL_SEQ_FREE(H5A_t_ptr, atable->attrs);
     } /* end if */
-    else
-        assert(atable->attrs == NULL);
 
 done:
     FUNC_LEAVE_NOAPI(ret_value)

--- a/src/H5Aint.c
+++ b/src/H5Aint.c
@@ -1614,21 +1614,25 @@ H5A__dense_build_table_cb(const H5A_t *attr, void *_udata)
     assert(attr);
     assert(atable);
 
-    /* max_attrs comes from the name index's stored record count, which is
-     * attacker-controlled metadata, while this callback is driven by the tree
-     * walk.  A count below the tree's real size makes the walk overrun the
-     * table, so this bound must hold in a Release build.
+    /* Grow only as attributes are found.  Leave room for the free-list
+     * block header as well as checking the element-size multiplication.
      */
-    if (atable->num_attrs >= atable->max_attrs)
-        HGOTO_ERROR(H5E_ATTR, H5E_OVERFLOW, H5_ITER_ERROR,
-                    "dense attribute index yields more attributes than its record count declares");
+    if (atable->num_attrs == atable->max_attrs) {
+        H5A_t **new_table;
+        size_t  new_capacity;
+        size_t  max_capacity = (SIZE_MAX - sizeof(H5FL_blk_list_t)) / sizeof(*atable->attrs);
 
-    /* Allocate attribute for entry in the table */
-    if (NULL == (atable->attrs[atable->num_attrs] = H5FL_CALLOC(H5A_t)))
-        HGOTO_ERROR(H5E_ATTR, H5E_CANTALLOC, H5_ITER_ERROR, "can't allocate attribute");
+        if (atable->max_attrs >= max_capacity)
+            HGOTO_ERROR(H5E_RESOURCE, H5E_OVERFLOW, H5_ITER_ERROR, "attribute table is too large");
+        new_capacity = atable->max_attrs > max_capacity / 2 ? max_capacity : MAX(1, 2 * atable->max_attrs);
+        if (NULL == (new_table = (H5A_t **)H5FL_SEQ_REALLOC(H5A_t_ptr, atable->attrs, new_capacity)))
+            HGOTO_ERROR(H5E_RESOURCE, H5E_NOSPACE, H5_ITER_ERROR, "unable to extend attribute table");
+        atable->attrs     = new_table;
+        atable->max_attrs = new_capacity;
+    }
 
-    /* Copy attribute information.  Share the attribute object in copying. */
-    if (NULL == H5A__copy(atable->attrs[atable->num_attrs], attr))
+    /* Let H5A__copy own allocation and cleanup if copying fails. */
+    if (NULL == (atable->attrs[atable->num_attrs] = H5A__copy(NULL, attr)))
         HGOTO_ERROR(H5E_ATTR, H5E_CANTCOPY, H5_ITER_ERROR, "can't copy attribute");
 
     /* Increment number of attributes stored */
@@ -1656,10 +1660,10 @@ herr_t
 H5A__dense_build_table(H5F_t *f, const H5O_ainfo_t *ainfo, H5_index_t idx_type, H5_iter_order_t order,
                        H5A_attr_table_t *atable)
 {
-    H5B2_t *bt2_name = NULL;     /* v2 B-tree handle for name index */
-    haddr_t eoa;                 /* End of allocated space in the file */
-    hsize_t nrec;                /* # of records in v2 B-tree */
-    herr_t  ret_value = SUCCEED; /* Return value */
+    H5B2_t           *bt2_name = NULL;     /* v2 B-tree handle for name index */
+    H5A_attr_iter_op_t attr_op;             /* Attribute operator */
+    hsize_t           nrec;                /* # of records in v2 B-tree */
+    herr_t            ret_value = SUCCEED; /* Return value */
 
     FUNC_ENTER_PACKAGE
 
@@ -1670,6 +1674,10 @@ H5A__dense_build_table(H5F_t *f, const H5O_ainfo_t *ainfo, H5_index_t idx_type, 
     assert(H5_addr_defined(ainfo->name_bt2_addr));
     assert(atable);
 
+    atable->attrs     = NULL;
+    atable->num_attrs = 0;
+    atable->max_attrs = 0;
+
     /* Open the name index v2 B-tree */
     if (NULL == (bt2_name = H5B2_open(f, ainfo->name_bt2_addr, NULL)))
         HGOTO_ERROR(H5E_ATTR, H5E_CANTOPENOBJ, FAIL, "unable to open v2 B-tree for name index");
@@ -1679,51 +1687,29 @@ H5A__dense_build_table(H5F_t *f, const H5O_ainfo_t *ainfo, H5_index_t idx_type, 
     if (H5B2_get_nrec(bt2_name, &nrec) < 0)
         HGOTO_ERROR(H5E_ATTR, H5E_CANTGET, FAIL, "can't retrieve # of records in index");
 
-    /* Allocate space for the table entries */
-    if (nrec > 0) {
-        H5A_attr_iter_op_t attr_op; /* Attribute operator */
+    attr_op.op_type  = H5A_ATTR_OP_LIB;
+    attr_op.u.lib_op = H5A__dense_build_table_cb;
 
-        /* Reject counts that cannot be represented by the file or allocation. */
-        if (HADDR_UNDEF == (eoa = H5F_get_eoa(f, H5FD_MEM_DEFAULT)))
-            HGOTO_ERROR(H5E_ATTR, H5E_CANTGET, FAIL, "unable to determine file size");
-        if (nrec > eoa || nrec > (hsize_t)(SIZE_MAX / sizeof(*atable->attrs)))
-            HGOTO_ERROR(H5E_ATTR, H5E_OVERFLOW, FAIL, "invalid dense attribute index record count");
+    /* Visit records even when the declared count is zero. */
+    if (H5A__dense_iterate(f, (hid_t)0, ainfo, H5_INDEX_NAME, H5_ITER_NATIVE, (hsize_t)0, NULL, &attr_op,
+                         atable) < 0)
+        HGOTO_ERROR(H5E_ATTR, H5E_CANTINIT, FAIL, "error building attribute table");
 
-        /* Allocate the table to store the attributes */
-        if (NULL == (atable->attrs = (H5A_t **)H5FL_SEQ_CALLOC(H5A_t_ptr, (size_t)nrec)))
-            HGOTO_ERROR(H5E_ATTR, H5E_CANTALLOC, FAIL, "memory allocation failed");
-        atable->num_attrs = 0;
-        atable->max_attrs = (size_t)nrec;
+    /* Reject inconsistent metadata without allocating from the stored count. */
+    if (atable->num_attrs != nrec)
+        HGOTO_ERROR(H5E_ATTR, H5E_BADVALUE, FAIL,
+                    "dense attribute index record count does not match the attributes found");
 
-        /* Build iterator operator */
-        attr_op.op_type  = H5A_ATTR_OP_LIB;
-        attr_op.u.lib_op = H5A__dense_build_table_cb;
-
-        /* Iterate over the links in the group, building a table of the link messages */
-        if (H5A__dense_iterate(f, (hid_t)0, ainfo, H5_INDEX_NAME, H5_ITER_NATIVE, (hsize_t)0, NULL, &attr_op,
-                               atable) < 0)
-            HGOTO_ERROR(H5E_ATTR, H5E_CANTINIT, FAIL, "error building attribute table");
-
-        /* The walk must have filled the table exactly.  A stored record count
-         * above the tree's real size would otherwise silently return a
-         * truncated attribute list; the fill count is the only thing that can
-         * falsify the stored one.
-         */
-        if (atable->num_attrs != atable->max_attrs)
-            HGOTO_ERROR(H5E_ATTR, H5E_BADVALUE, FAIL,
-                        "dense attribute index record count does not match the attributes found");
-
-        /* Sort attribute table in correct iteration order */
-        if (H5A__attr_sort_table(atable, idx_type, order) < 0)
-            HGOTO_ERROR(H5E_ATTR, H5E_CANTSORT, FAIL, "error sorting attribute table");
-    } /* end if */
-    else
-        atable->attrs = NULL;
+    if (atable->num_attrs > 0 && H5A__attr_sort_table(atable, idx_type, order) < 0)
+        HGOTO_ERROR(H5E_ATTR, H5E_CANTSORT, FAIL, "error sorting attribute table");
 
 done:
     /* Release resources */
     if (bt2_name && H5B2_close(bt2_name) < 0)
         HDONE_ERROR(H5E_ATTR, H5E_CLOSEERROR, FAIL, "can't close v2 B-tree for name index");
+
+    if (ret_value < 0 && atable->attrs && H5A__attr_release_table(atable) < 0)
+        HDONE_ERROR(H5E_ATTR, H5E_CANTFREE, FAIL, "unable to release attribute table");
 
     FUNC_LEAVE_NOAPI(ret_value)
 } /* end H5A__dense_build_table() */
@@ -1993,6 +1979,8 @@ H5A__attr_release_table(H5A_attr_table_t *atable)
         /* Release array */
         atable->attrs = (H5A_t **)H5FL_SEQ_FREE(H5A_t_ptr, atable->attrs);
     } /* end if */
+    atable->num_attrs = 0;
+    atable->max_attrs = 0;
 
 done:
     FUNC_LEAVE_NOAPI(ret_value)

--- a/src/H5Aint.c
+++ b/src/H5Aint.c
@@ -1657,7 +1657,7 @@ H5A__dense_build_table(H5F_t *f, const H5O_ainfo_t *ainfo, H5_index_t idx_type, 
                        H5A_attr_table_t *atable)
 {
     H5B2_t *bt2_name = NULL;     /* v2 B-tree handle for name index */
-    haddr_t eoa;                  /* End of allocated space in the file */
+    haddr_t eoa;                 /* End of allocated space in the file */
     hsize_t nrec;                /* # of records in v2 B-tree */
     herr_t  ret_value = SUCCEED; /* Return value */
 

--- a/src/H5Gcompact.c
+++ b/src/H5Gcompact.c
@@ -113,7 +113,7 @@ static herr_t
 H5G__compact_build_table(const H5O_loc_t *oloc, const H5O_linfo_t *linfo, H5_index_t idx_type,
                          H5_iter_order_t order, H5G_link_table_t *ltable)
 {
-    haddr_t eoa;                  /* End of allocated space in the file */
+    haddr_t eoa;                 /* End of allocated space in the file */
     herr_t  ret_value = SUCCEED; /* Return value */
 
     FUNC_ENTER_PACKAGE

--- a/src/H5Gcompact.c
+++ b/src/H5Gcompact.c
@@ -104,7 +104,7 @@ H5G__compact_build_table(const H5O_loc_t *oloc, const H5O_linfo_t *linfo, H5_ind
 {
     H5G_iter_bt_t       udata;               /* User data for iteration callback */
     H5O_mesg_operator_t op;                  /* Message operator */
-    herr_t             ret_value = SUCCEED; /* Return value */
+    herr_t              ret_value = SUCCEED; /* Return value */
 
     FUNC_ENTER_PACKAGE
 

--- a/src/H5Gcompact.c
+++ b/src/H5Gcompact.c
@@ -31,7 +31,7 @@
 /* User data for link message iteration when building link table */
 typedef struct {
     H5G_link_table_t *ltable;   /* Pointer to link table to build */
-    size_t            curr_lnk; /* Current link to operate on */
+    size_t            capacity; /* Allocated entries in the link table */
 } H5G_iter_bt_t;
 
 /* User data for deleting a link in the link messages */
@@ -79,20 +79,9 @@ H5G__compact_build_table_cb(const void *_mesg, unsigned H5_ATTR_UNUSED idx, void
 
     FUNC_ENTER_PACKAGE
 
-    /* check arguments */
-    assert(lnk);
-    assert(udata);
-
-    if (udata->curr_lnk >= udata->ltable->nlinks)
-        HGOTO_ERROR(H5E_SYM, H5E_OVERFLOW, H5_ITER_ERROR,
-                    "compact link messages exceed the declared link count");
-
-    /* Copy link message into table */
-    if (NULL == H5O_msg_copy(H5O_LINK_ID, lnk, &(udata->ltable->lnks[udata->curr_lnk])))
-        HGOTO_ERROR(H5E_SYM, H5E_CANTCOPY, H5_ITER_ERROR, "can't copy link message");
-
-    /* Increment current link entry to operate on */
-    udata->curr_lnk++;
+    /* Grow from the records found, not the stored count. */
+    if (H5G__link_append_table(udata->ltable, &udata->capacity, lnk) < 0)
+        HGOTO_ERROR(H5E_SYM, H5E_CANTINSERT, H5_ITER_ERROR, "can't append link to table");
 
 done:
     FUNC_LEAVE_NOAPI(ret_value)
@@ -113,57 +102,38 @@ static herr_t
 H5G__compact_build_table(const H5O_loc_t *oloc, const H5O_linfo_t *linfo, H5_index_t idx_type,
                          H5_iter_order_t order, H5G_link_table_t *ltable)
 {
-    haddr_t eoa;                 /* End of allocated space in the file */
-    herr_t  ret_value = SUCCEED; /* Return value */
+    H5G_iter_bt_t       udata;               /* User data for iteration callback */
+    H5O_mesg_operator_t op;                  /* Message operator */
+    herr_t             ret_value = SUCCEED; /* Return value */
 
     FUNC_ENTER_PACKAGE
 
-    /* Sanity check */
     assert(oloc);
     assert(linfo);
     assert(ltable);
 
-    /* Reject counts that cannot be represented by the file or allocation. */
-    if (HADDR_UNDEF == (eoa = H5F_get_eoa(oloc->file, H5FD_MEM_DEFAULT)))
-        HGOTO_ERROR(H5E_SYM, H5E_CANTGET, FAIL, "unable to determine file size");
-    if (linfo->nlinks > eoa || linfo->nlinks > (hsize_t)(SIZE_MAX / sizeof(*ltable->lnks)))
-        HGOTO_ERROR(H5E_SYM, H5E_OVERFLOW, FAIL, "invalid compact link count");
+    ltable->lnks   = NULL;
+    ltable->nlinks = 0;
+    udata.ltable   = ltable;
+    udata.capacity = 0;
 
-    /* Set size of table */
-    ltable->nlinks = (size_t)linfo->nlinks;
+    /* Visit records even when the declared count is zero. */
+    op.op_type  = H5O_MESG_OP_APP;
+    op.u.app_op = H5G__compact_build_table_cb;
+    if (H5O_msg_iterate(oloc, H5O_LINK_ID, &op, &udata) < 0)
+        HGOTO_ERROR(H5E_SYM, H5E_NOTFOUND, FAIL, "error iterating over link messages");
 
-    /* Allocate space for the table entries */
-    if (ltable->nlinks > 0) {
-        H5G_iter_bt_t       udata; /* User data for iteration callback */
-        H5O_mesg_operator_t op;    /* Message operator */
+    /* Keep rejecting inconsistent metadata, without using it to size memory. */
+    if (ltable->nlinks != linfo->nlinks)
+        HGOTO_ERROR(H5E_SYM, H5E_BADVALUE, FAIL, "compact link count does not match the links found");
 
-        /* Allocate the link table */
-        if ((ltable->lnks = (H5O_link_t *)H5MM_calloc(sizeof(H5O_link_t) * ltable->nlinks)) == NULL)
-            HGOTO_ERROR(H5E_RESOURCE, H5E_NOSPACE, FAIL, "memory allocation failed");
-
-        /* Set up user data for iteration */
-        udata.ltable   = ltable;
-        udata.curr_lnk = 0;
-
-        /* Iterate through the link messages, adding them to the table */
-        op.op_type  = H5O_MESG_OP_APP;
-        op.u.app_op = H5G__compact_build_table_cb;
-        if (H5O_msg_iterate(oloc, H5O_LINK_ID, &op, &udata) < 0)
-            HGOTO_ERROR(H5E_SYM, H5E_NOTFOUND, FAIL, "error iterating over link messages");
-
-        /* The link-info count and the number of link messages must agree. */
-        if (udata.curr_lnk != ltable->nlinks)
-            HGOTO_ERROR(H5E_SYM, H5E_BADVALUE, FAIL,
-                        "compact link count does not match the link messages found");
-
-        /* Sort link table in correct iteration order */
-        if (H5G__link_sort_table(ltable, idx_type, order) < 0)
-            HGOTO_ERROR(H5E_SYM, H5E_CANTSORT, FAIL, "error sorting link messages");
-    } /* end if */
-    else
-        ltable->lnks = NULL;
+    if (ltable->nlinks > 0 && H5G__link_sort_table(ltable, idx_type, order) < 0)
+        HGOTO_ERROR(H5E_SYM, H5E_CANTSORT, FAIL, "error sorting link messages");
 
 done:
+    if (ret_value < 0 && ltable->lnks && H5G__link_release_table(ltable) < 0)
+        HDONE_ERROR(H5E_SYM, H5E_CANTFREE, FAIL, "unable to release link table");
+
     FUNC_LEAVE_NOAPI(ret_value)
 } /* end H5G__compact_build_table() */
 

--- a/src/H5Gcompact.c
+++ b/src/H5Gcompact.c
@@ -82,7 +82,10 @@ H5G__compact_build_table_cb(const void *_mesg, unsigned H5_ATTR_UNUSED idx, void
     /* check arguments */
     assert(lnk);
     assert(udata);
-    assert(udata->curr_lnk < udata->ltable->nlinks);
+
+    if (udata->curr_lnk >= udata->ltable->nlinks)
+        HGOTO_ERROR(H5E_SYM, H5E_OVERFLOW, H5_ITER_ERROR,
+                    "compact link messages exceed the declared link count");
 
     /* Copy link message into table */
     if (NULL == H5O_msg_copy(H5O_LINK_ID, lnk, &(udata->ltable->lnks[udata->curr_lnk])))
@@ -110,7 +113,8 @@ static herr_t
 H5G__compact_build_table(const H5O_loc_t *oloc, const H5O_linfo_t *linfo, H5_index_t idx_type,
                          H5_iter_order_t order, H5G_link_table_t *ltable)
 {
-    herr_t ret_value = SUCCEED; /* Return value */
+    haddr_t eoa;                  /* End of allocated space in the file */
+    herr_t  ret_value = SUCCEED; /* Return value */
 
     FUNC_ENTER_PACKAGE
 
@@ -119,8 +123,13 @@ H5G__compact_build_table(const H5O_loc_t *oloc, const H5O_linfo_t *linfo, H5_ind
     assert(linfo);
     assert(ltable);
 
+    /* Reject counts that cannot be represented by the file or allocation. */
+    if (HADDR_UNDEF == (eoa = H5F_get_eoa(oloc->file, H5FD_MEM_DEFAULT)))
+        HGOTO_ERROR(H5E_SYM, H5E_CANTGET, FAIL, "unable to determine file size");
+    if (linfo->nlinks > eoa || linfo->nlinks > (hsize_t)(SIZE_MAX / sizeof(*ltable->lnks)))
+        HGOTO_ERROR(H5E_SYM, H5E_OVERFLOW, FAIL, "invalid compact link count");
+
     /* Set size of table */
-    H5_CHECK_OVERFLOW(linfo->nlinks, hsize_t, size_t);
     ltable->nlinks = (size_t)linfo->nlinks;
 
     /* Allocate space for the table entries */
@@ -141,6 +150,11 @@ H5G__compact_build_table(const H5O_loc_t *oloc, const H5O_linfo_t *linfo, H5_ind
         op.u.app_op = H5G__compact_build_table_cb;
         if (H5O_msg_iterate(oloc, H5O_LINK_ID, &op, &udata) < 0)
             HGOTO_ERROR(H5E_SYM, H5E_NOTFOUND, FAIL, "error iterating over link messages");
+
+        /* The link-info count and the number of link messages must agree. */
+        if (udata.curr_lnk != ltable->nlinks)
+            HGOTO_ERROR(H5E_SYM, H5E_BADVALUE, FAIL,
+                        "compact link count does not match the link messages found");
 
         /* Sort link table in correct iteration order */
         if (H5G__link_sort_table(ltable, idx_type, order) < 0)

--- a/src/H5Gdense.c
+++ b/src/H5Gdense.c
@@ -68,7 +68,7 @@
 /* Data exchange structure to use when building table of links in group */
 typedef struct {
     H5G_link_table_t *ltable;   /* Pointer to link table to build */
-    size_t            curr_lnk; /* Current link to operate on */
+    size_t            capacity; /* Allocated entries in the link table */
 } H5G_dense_bt_ud_t;
 
 /*
@@ -711,26 +711,9 @@ H5G__dense_build_table_cb(const H5O_link_t *lnk, void *_udata)
 
     FUNC_ENTER_PACKAGE
 
-    /* check arguments */
-    assert(lnk);
-    assert(udata);
-
-    /* The table was sized from the name index's stored record count, which is
-     * attacker-controlled metadata, while this callback is driven by the tree
-     * walk.  A malformed count below the tree's real size makes the walk
-     * overrun the table, so this bound must hold in a Release build and cannot
-     * remain an assert.
-     */
-    if (udata->curr_lnk >= udata->ltable->nlinks)
-        HGOTO_ERROR(H5E_SYM, H5E_OVERFLOW, H5_ITER_ERROR,
-                    "dense link index yields more links than its record count declares");
-
-    /* Copy link information */
-    if (H5O_msg_copy(H5O_LINK_ID, lnk, &(udata->ltable->lnks[udata->curr_lnk])) == NULL)
-        HGOTO_ERROR(H5E_SYM, H5E_CANTCOPY, H5_ITER_ERROR, "can't copy link message");
-
-    /* Increment number of links stored */
-    udata->curr_lnk++;
+    /* Grow from the records found, not the stored count. */
+    if (H5G__link_append_table(udata->ltable, &udata->capacity, lnk) < 0)
+        HGOTO_ERROR(H5E_SYM, H5E_CANTINSERT, H5_ITER_ERROR, "can't append link to table");
 
 done:
     FUNC_LEAVE_NOAPI(ret_value)
@@ -753,66 +736,36 @@ herr_t
 H5G__dense_build_table(H5F_t *f, const H5O_linfo_t *linfo, H5_index_t idx_type, H5_iter_order_t order,
                        H5G_link_table_t *ltable)
 {
-    haddr_t eoa;                 /* End of allocated space in the file */
-    herr_t  ret_value = SUCCEED; /* Return value */
+    H5G_dense_bt_ud_t udata;               /* User data for iteration callback */
+    herr_t           ret_value = SUCCEED; /* Return value */
 
     FUNC_ENTER_PACKAGE
 
-    /* Sanity check */
     assert(f);
     assert(linfo);
     assert(ltable);
 
-    /* Reject counts that cannot be represented by the file or allocation. */
-    if (HADDR_UNDEF == (eoa = H5F_get_eoa(f, H5FD_MEM_DEFAULT)))
-        HGOTO_ERROR(H5E_SYM, H5E_CANTGET, FAIL, "unable to determine file size");
-    if (linfo->nlinks > eoa || linfo->nlinks > (hsize_t)(SIZE_MAX / sizeof(*ltable->lnks)))
-        HGOTO_ERROR(H5E_SYM, H5E_OVERFLOW, FAIL, "invalid dense link index record count");
+    ltable->lnks   = NULL;
+    ltable->nlinks = 0;
+    udata.ltable   = ltable;
+    udata.capacity = 0;
 
-    /* Set size of table */
-    ltable->nlinks = (size_t)linfo->nlinks;
+    /* Visit records even when the declared count is zero. */
+    if (H5G__dense_iterate(f, linfo, H5_INDEX_NAME, H5_ITER_NATIVE, (hsize_t)0, NULL,
+                           H5G__dense_build_table_cb, &udata) < 0)
+        HGOTO_ERROR(H5E_SYM, H5E_CANTNEXT, FAIL, "error iterating over links");
 
-    /* Allocate space for the table entries */
-    if (ltable->nlinks > 0) {
-        H5G_dense_bt_ud_t udata; /* User data for iteration callback */
+    /* Keep rejecting inconsistent metadata, without using it to size memory. */
+    if (ltable->nlinks != linfo->nlinks)
+        HGOTO_ERROR(H5E_SYM, H5E_BADVALUE, FAIL, "dense link count does not match the links found");
 
-        /* Allocate the table to store the links */
-        if ((ltable->lnks = (H5O_link_t *)H5MM_calloc(sizeof(H5O_link_t) * ltable->nlinks)) == NULL)
-            HGOTO_ERROR(H5E_RESOURCE, H5E_NOSPACE, FAIL, "memory allocation failed");
-
-        /* Initialize all links to invalid. NOTE: If H5O_link_t changes, update this loop. */
-        for (size_t i = 0; i < ltable->nlinks; i++)
-            ltable->lnks[i].type = H5L_TYPE_ERROR;
-
-        /* Set up user data for iteration */
-        udata.ltable   = ltable;
-        udata.curr_lnk = 0;
-
-        /* Iterate over the links in the group, building a table of the link messages */
-        if (H5G__dense_iterate(f, linfo, H5_INDEX_NAME, H5_ITER_NATIVE, (hsize_t)0, NULL,
-                               H5G__dense_build_table_cb, &udata) < 0)
-            HGOTO_ERROR(H5E_SYM, H5E_CANTNEXT, FAIL, "error iterating over links");
-
-        /* The walk must have filled the table exactly.  A stored record count
-         * ABOVE the tree's real size leaves entries as H5MM_calloc made them,
-         * with a NULL name, and the sort below hands those to strcmp.  There is
-         * no second copy of this count to reconcile against -- H5O__linfo_decode
-         * sets linfo->nlinks to HSIZET_MAX and H5G__obj_get_linfo fills it from
-         * H5B2_get_nrec -- so the fill count is the only thing that can falsify
-         * it.
-         */
-        if (udata.curr_lnk != ltable->nlinks)
-            HGOTO_ERROR(H5E_SYM, H5E_BADVALUE, FAIL,
-                        "dense link index record count does not match the links found");
-
-        /* Sort link table in correct iteration order */
-        if (H5G__link_sort_table(ltable, idx_type, order) < 0)
-            HGOTO_ERROR(H5E_SYM, H5E_CANTSORT, FAIL, "error sorting link messages");
-    } /* end if */
-    else
-        ltable->lnks = NULL;
+    if (ltable->nlinks > 0 && H5G__link_sort_table(ltable, idx_type, order) < 0)
+        HGOTO_ERROR(H5E_SYM, H5E_CANTSORT, FAIL, "error sorting link messages");
 
 done:
+    if (ret_value < 0 && ltable->lnks && H5G__link_release_table(ltable) < 0)
+        HDONE_ERROR(H5E_SYM, H5E_CANTFREE, FAIL, "unable to release link table");
+
     FUNC_LEAVE_NOAPI(ret_value)
 } /* end H5G__dense_build_table() */
 

--- a/src/H5Gdense.c
+++ b/src/H5Gdense.c
@@ -714,7 +714,16 @@ H5G__dense_build_table_cb(const H5O_link_t *lnk, void *_udata)
     /* check arguments */
     assert(lnk);
     assert(udata);
-    assert(udata->curr_lnk < udata->ltable->nlinks);
+
+    /* The table was sized from the name index's stored record count, which is
+     * attacker-controlled metadata, while this callback is driven by the tree
+     * walk.  A malformed count below the tree's real size makes the walk
+     * overrun the table, so this bound must hold in a Release build and cannot
+     * remain an assert.
+     */
+    if (udata->curr_lnk >= udata->ltable->nlinks)
+        HGOTO_ERROR(H5E_SYM, H5E_OVERFLOW, H5_ITER_ERROR,
+                    "dense link index yields more links than its record count declares");
 
     /* Copy link information */
     if (H5O_msg_copy(H5O_LINK_ID, lnk, &(udata->ltable->lnks[udata->curr_lnk])) == NULL)
@@ -777,6 +786,18 @@ H5G__dense_build_table(H5F_t *f, const H5O_linfo_t *linfo, H5_index_t idx_type, 
         if (H5G__dense_iterate(f, linfo, H5_INDEX_NAME, H5_ITER_NATIVE, (hsize_t)0, NULL,
                                H5G__dense_build_table_cb, &udata) < 0)
             HGOTO_ERROR(H5E_SYM, H5E_CANTNEXT, FAIL, "error iterating over links");
+
+        /* The walk must have filled the table exactly.  A stored record count
+         * ABOVE the tree's real size leaves entries as H5MM_calloc made them,
+         * with a NULL name, and the sort below hands those to strcmp.  There is
+         * no second copy of this count to reconcile against -- H5O__linfo_decode
+         * sets linfo->nlinks to HSIZET_MAX and H5G__obj_get_linfo fills it from
+         * H5B2_get_nrec -- so the fill count is the only thing that can falsify
+         * it.
+         */
+        if (udata.curr_lnk != ltable->nlinks)
+            HGOTO_ERROR(H5E_SYM, H5E_BADVALUE, FAIL,
+                        "dense link index record count does not match the links found");
 
         /* Sort link table in correct iteration order */
         if (H5G__link_sort_table(ltable, idx_type, order) < 0)

--- a/src/H5Gdense.c
+++ b/src/H5Gdense.c
@@ -737,7 +737,7 @@ H5G__dense_build_table(H5F_t *f, const H5O_linfo_t *linfo, H5_index_t idx_type, 
                        H5G_link_table_t *ltable)
 {
     H5G_dense_bt_ud_t udata;               /* User data for iteration callback */
-    herr_t           ret_value = SUCCEED; /* Return value */
+    herr_t            ret_value = SUCCEED; /* Return value */
 
     FUNC_ENTER_PACKAGE
 

--- a/src/H5Gdense.c
+++ b/src/H5Gdense.c
@@ -753,7 +753,7 @@ herr_t
 H5G__dense_build_table(H5F_t *f, const H5O_linfo_t *linfo, H5_index_t idx_type, H5_iter_order_t order,
                        H5G_link_table_t *ltable)
 {
-    haddr_t eoa;                  /* End of allocated space in the file */
+    haddr_t eoa;                 /* End of allocated space in the file */
     herr_t  ret_value = SUCCEED; /* Return value */
 
     FUNC_ENTER_PACKAGE

--- a/src/H5Gdense.c
+++ b/src/H5Gdense.c
@@ -753,7 +753,8 @@ herr_t
 H5G__dense_build_table(H5F_t *f, const H5O_linfo_t *linfo, H5_index_t idx_type, H5_iter_order_t order,
                        H5G_link_table_t *ltable)
 {
-    herr_t ret_value = SUCCEED; /* Return value */
+    haddr_t eoa;                  /* End of allocated space in the file */
+    herr_t  ret_value = SUCCEED; /* Return value */
 
     FUNC_ENTER_PACKAGE
 
@@ -762,8 +763,13 @@ H5G__dense_build_table(H5F_t *f, const H5O_linfo_t *linfo, H5_index_t idx_type, 
     assert(linfo);
     assert(ltable);
 
+    /* Reject counts that cannot be represented by the file or allocation. */
+    if (HADDR_UNDEF == (eoa = H5F_get_eoa(f, H5FD_MEM_DEFAULT)))
+        HGOTO_ERROR(H5E_SYM, H5E_CANTGET, FAIL, "unable to determine file size");
+    if (linfo->nlinks > eoa || linfo->nlinks > (hsize_t)(SIZE_MAX / sizeof(*ltable->lnks)))
+        HGOTO_ERROR(H5E_SYM, H5E_OVERFLOW, FAIL, "invalid dense link index record count");
+
     /* Set size of table */
-    H5_CHECK_OVERFLOW(linfo->nlinks, /* From: */ hsize_t, /* To: */ size_t);
     ltable->nlinks = (size_t)linfo->nlinks;
 
     /* Allocate space for the table entries */

--- a/src/H5Glink.c
+++ b/src/H5Glink.c
@@ -532,6 +532,53 @@ H5G__link_iterate_table(const H5G_link_table_t *ltable, hsize_t skip, hsize_t *l
 } /* end H5G__link_iterate_table() */
 
 /*-------------------------------------------------------------------------
+ * Function:    H5G__link_append_table
+ *
+ * Purpose:     Grow a link table as links are found, without allocating from
+ *              an untrusted stored record count.  Only successfully copied
+ *              links are counted, so sorting and cleanup visit valid entries.
+ *
+ * Return:      SUCCEED/FAIL
+ *-------------------------------------------------------------------------
+ */
+herr_t
+H5G__link_append_table(H5G_link_table_t *ltable, size_t *capacity, const H5O_link_t *lnk)
+{
+    herr_t ret_value = SUCCEED; /* Return value */
+
+    FUNC_ENTER_PACKAGE
+
+    assert(ltable);
+    assert(capacity);
+    assert(lnk);
+    assert(ltable->nlinks <= *capacity);
+
+    if (ltable->nlinks == *capacity) {
+        H5O_link_t *new_table;
+        size_t      new_capacity;
+        size_t      max_capacity = SIZE_MAX / sizeof(*ltable->lnks);
+
+        /* Check both doubling and the allocation-size multiplication. */
+        if (*capacity >= max_capacity)
+            HGOTO_ERROR(H5E_RESOURCE, H5E_OVERFLOW, FAIL, "link table is too large");
+        new_capacity = *capacity > max_capacity / 2 ? max_capacity : MAX(1, 2 * *capacity);
+        if (NULL == (new_table = (H5O_link_t *)H5MM_realloc(ltable->lnks,
+                                                          new_capacity * sizeof(*ltable->lnks))))
+            HGOTO_ERROR(H5E_RESOURCE, H5E_NOSPACE, FAIL, "unable to extend link table");
+        ltable->lnks = new_table;
+        *capacity   = new_capacity;
+    }
+
+    /* H5O_msg_copy cleans up its copy on failure; do not count that slot. */
+    if (NULL == H5O_msg_copy(H5O_LINK_ID, lnk, &ltable->lnks[ltable->nlinks]))
+        HGOTO_ERROR(H5E_SYM, H5E_CANTCOPY, FAIL, "can't copy link message");
+    ltable->nlinks++;
+
+done:
+    FUNC_LEAVE_NOAPI(ret_value)
+} /* end H5G__link_append_table() */
+
+/*-------------------------------------------------------------------------
  * Function:	H5G__link_release_table
  *
  * Purpose:     Release table containing a list of links for a group
@@ -552,18 +599,15 @@ H5G__link_release_table(H5G_link_table_t *ltable)
     /* Sanity check */
     assert(ltable);
 
-    /* Release link info, if any */
-    if (ltable->nlinks > 0) {
-        /* Free link message information */
+    /* An allocated table may be empty if copying the first link failed. */
+    if (ltable->lnks) {
         for (u = 0; u < ltable->nlinks; u++)
             if (H5O_msg_reset(H5O_LINK_ID, &(ltable->lnks[u])) < 0)
                 HGOTO_ERROR(H5E_SYM, H5E_CANTFREE, FAIL, "unable to release link message");
 
-        /* Free table of links */
-        H5MM_xfree(ltable->lnks);
-    } /* end if */
-    else
-        assert(ltable->lnks == NULL);
+        ltable->lnks = (H5O_link_t *)H5MM_xfree(ltable->lnks);
+    }
+    ltable->nlinks = 0;
 
 done:
     FUNC_LEAVE_NOAPI(ret_value)

--- a/src/H5Glink.c
+++ b/src/H5Glink.c
@@ -562,11 +562,11 @@ H5G__link_append_table(H5G_link_table_t *ltable, size_t *capacity, const H5O_lin
         if (*capacity >= max_capacity)
             HGOTO_ERROR(H5E_RESOURCE, H5E_OVERFLOW, FAIL, "link table is too large");
         new_capacity = *capacity > max_capacity / 2 ? max_capacity : MAX(1, 2 * *capacity);
-        if (NULL == (new_table = (H5O_link_t *)H5MM_realloc(ltable->lnks,
-                                                          new_capacity * sizeof(*ltable->lnks))))
+        if (NULL ==
+            (new_table = (H5O_link_t *)H5MM_realloc(ltable->lnks, new_capacity * sizeof(*ltable->lnks))))
             HGOTO_ERROR(H5E_RESOURCE, H5E_NOSPACE, FAIL, "unable to extend link table");
         ltable->lnks = new_table;
-        *capacity   = new_capacity;
+        *capacity    = new_capacity;
     }
 
     /* H5O_msg_copy cleans up its copy on failure; do not count that slot. */

--- a/src/H5Gobj.c
+++ b/src/H5Gobj.c
@@ -816,7 +816,8 @@ done:
 static herr_t
 H5G__obj_remove_update_linfo(const H5O_loc_t *oloc, H5O_linfo_t *linfo)
 {
-    herr_t ret_value = SUCCEED; /* Return value */
+    H5G_link_table_t ltable    = {0, NULL}; /* Table of links */
+    herr_t           ret_value = SUCCEED;   /* Return value */
 
     FUNC_ENTER_PACKAGE
 
@@ -841,7 +842,7 @@ H5G__obj_remove_update_linfo(const H5O_loc_t *oloc, H5O_linfo_t *linfo)
         } /* end if */
         /* Check for switching back to compact storage */
         else {
-            H5O_ginfo_t ginfo; /* Group info message            */
+            H5O_ginfo_t ginfo; /* Group info message */
 
             /* Get the group info */
             if (NULL == H5O_msg_read(oloc, H5O_GINFO_ID, &ginfo))
@@ -849,10 +850,9 @@ H5G__obj_remove_update_linfo(const H5O_loc_t *oloc, H5O_linfo_t *linfo)
 
             /* Check if we should switch from dense storage back to link messages */
             if (linfo->nlinks < ginfo.min_dense) {
-                struct H5O_t    *oh = NULL;          /* Pointer to group's object header */
-                H5G_link_table_t ltable;             /* Table of links */
-                bool             can_convert = true; /* Whether converting to link messages is possible */
-                size_t           u;                  /* Local index */
+                struct H5O_t *oh          = NULL; /* Pointer to group's object header */
+                bool          can_convert = true; /* Whether converting to link messages is possible */
+                size_t        u;                  /* Local index */
 
                 /* Build the table of links for this group */
                 if (H5G__dense_build_table(oloc->file, linfo, H5_INDEX_NAME, H5_ITER_NATIVE, &ltable) < 0)
@@ -895,10 +895,6 @@ H5G__obj_remove_update_linfo(const H5O_loc_t *oloc, H5O_linfo_t *linfo)
                 /* Release object header */
                 if (H5O_unpin(oh) < 0)
                     HGOTO_ERROR(H5E_SYM, H5E_CANTUNPIN, FAIL, "unable to unpin group object header");
-
-                /* Free link table information */
-                if (H5G__link_release_table(&ltable) < 0)
-                    HGOTO_ERROR(H5E_SYM, H5E_CANTFREE, FAIL, "unable to release link table");
             } /* end if */
         }     /* end else */
     }         /* end if */
@@ -908,6 +904,10 @@ H5G__obj_remove_update_linfo(const H5O_loc_t *oloc, H5O_linfo_t *linfo)
         HGOTO_ERROR(H5E_DATASPACE, H5E_CANTINIT, FAIL, "can't update link info message");
 
 done:
+    /* Release resources */
+    if (ltable.lnks && H5G__link_release_table(&ltable) < 0)
+        HDONE_ERROR(H5E_SYM, H5E_CANTFREE, FAIL, "unable to release link table");
+
     FUNC_LEAVE_NOAPI(ret_value)
 } /* end H5G__obj_remove_update_linfo() */
 

--- a/src/H5Gpkg.h
+++ b/src/H5Gpkg.h
@@ -396,6 +396,7 @@ H5_DLL herr_t H5G__node_free(H5G_node_t *sym);
 H5_DLL herr_t H5G__link_to_ent(H5F_t *f, H5HL_t *heap, const H5O_link_t *lnk, H5O_type_t obj_type,
                                const void *crt_info, H5G_entry_t *ent);
 H5_DLL herr_t H5G__link_to_loc(const H5G_loc_t *grp_loc, const H5O_link_t *lnk, H5G_loc_t *obj_loc);
+H5_DLL herr_t H5G__link_append_table(H5G_link_table_t *ltable, size_t *capacity, const H5O_link_t *lnk);
 H5_DLL herr_t H5G__link_sort_table(H5G_link_table_t *ltable, H5_index_t idx_type, H5_iter_order_t order);
 H5_DLL herr_t H5G__link_iterate_table(const H5G_link_table_t *ltable, hsize_t skip, hsize_t *last_lnk,
                                       const H5G_lib_iterate_t op, void *op_data);

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -486,6 +486,7 @@ set (H5_TESTS
     external_env
     efc
     links
+    table_counts
     unlink
     twriteorder
     big

--- a/test/table_counts.c
+++ b/test/table_counts.c
@@ -1,0 +1,233 @@
+/* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * *
+ * Copyright by The HDF Group.                                               *
+ * All rights reserved.                                                      *
+ *                                                                           *
+ * This file is part of HDF5.  The full HDF5 copyright notice, including     *
+ * terms governing use, modification, and redistribution, is contained in    *
+ * the LICENSE file, which can be found at the root of the source code       *
+ * distribution tree, or in https://www.hdfgroup.org/licenses.               *
+ * If you do not have access to either file, you may request a copy from     *
+ * help@hdfgroup.org.                                                        *
+ * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
+
+/* Regression tests for table builders with inconsistent stored counts. */
+#include "h5test.h"
+#define H5A_FRIEND
+#define H5B2_FRIEND
+#define H5G_FRIEND
+#include "H5ACprivate.h"
+#include "H5Apkg.h"
+#include "H5B2pkg.h"
+#include "H5Gpkg.h"
+#include "H5CXprivate.h"
+#include "H5VLnative_private.h"
+
+#define NRECORDS 40
+
+static herr_t
+check_link(const H5O_link_t *lnk, void *op_data)
+{
+    unsigned *seen = (unsigned *)op_data;
+    char      expected[32];
+
+    snprintf(expected, sizeof(expected), "link%02u", *seen);
+    if (strcmp(lnk->name, expected))
+        return FAIL;
+    (*seen)++;
+    return SUCCEED;
+}
+
+/* Alter only in-memory counts and restore them before closing the file. This
+ * reaches the builders directly, including compact counts normally derived
+ * from the object header, without relying on a particular disk encoding.
+ */
+static int
+test_table_counts(bool attributes, bool dense)
+{
+    hid_t             file = H5I_INVALID_HID, group = H5I_INVALID_HID;
+    hid_t             gcpl = H5I_INVALID_HID, space = H5I_INVALID_HID, attr = H5I_INVALID_HID;
+    H5G_t            *grp;
+    H5O_loc_t        *oloc;
+    H5O_linfo_t       linfo;
+    H5O_ainfo_t       ainfo;
+    H5B2_t           *bt2 = NULL;
+    H5G_link_table_t  ltable = {0, NULL};
+    H5A_attr_table_t  atable = {0, 0, NULL};
+    H5CX_node_t       api_ctx = {{0}, NULL};
+    bool              pushed = false;
+    hsize_t           saved_count = 0;
+    unsigned          saved_node_count = 0;
+    const hsize_t     counts[] = {0, 1, NRECORDS - 1, NRECORDS, NRECORDS + 1,
+                                 (hsize_t)0x3ffffffd, (hsize_t)0x3fffffff, HSIZET_MAX};
+    char              name[32];
+    herr_t            status;
+    unsigned          seen;
+
+    TESTING(attributes ? "dense attribute tables with fabricated counts"
+                       : dense ? "dense link tables with fabricated counts"
+                               : "compact link tables with fabricated counts");
+
+    if ((file = H5Fcreate("table_counts.h5", H5F_ACC_TRUNC, H5P_DEFAULT, H5P_DEFAULT)) < 0)
+        TEST_ERROR;
+    if ((gcpl = H5Pcreate(H5P_GROUP_CREATE)) < 0)
+        TEST_ERROR;
+    if (H5Pset_link_creation_order(gcpl, H5P_CRT_ORDER_TRACKED) < 0)
+        TEST_ERROR;
+    if (H5Pset_link_phase_change(gcpl, dense ? 0 : NRECORDS + 1, 0) < 0)
+        TEST_ERROR;
+    if (H5Pset_attr_phase_change(gcpl, 0, 0) < 0)
+        TEST_ERROR;
+    if ((group = H5Gcreate2(file, "group", H5P_DEFAULT, gcpl, H5P_DEFAULT)) < 0)
+        TEST_ERROR;
+    if ((space = H5Screate(H5S_SCALAR)) < 0)
+        TEST_ERROR;
+    for (unsigned i = 0; i < NRECORDS; i++) {
+        snprintf(name, sizeof(name), attributes ? "attr%02u" : "link%02u", i);
+        if (attributes) {
+            if ((attr = H5Acreate2(group, name, H5T_NATIVE_INT, space, H5P_DEFAULT, H5P_DEFAULT)) < 0)
+                TEST_ERROR;
+            if (H5Aclose(attr) < 0)
+                TEST_ERROR;
+            attr = H5I_INVALID_HID;
+        }
+        else if (H5Lcreate_soft("/target", group, name, H5P_DEFAULT, H5P_DEFAULT) < 0)
+            TEST_ERROR;
+    }
+
+    if (H5CX_push(&api_ctx) < 0)
+        TEST_ERROR;
+    pushed = true;
+    if (NULL == (grp = (H5G_t *)H5VL_object_verify(group, H5I_GROUP)))
+        TEST_ERROR;
+    oloc = H5G_oloc(grp);
+    H5AC_tag(oloc->addr, NULL);
+    if (attributes) {
+        if (NULL == H5O_msg_read(oloc, H5O_AINFO_ID, &ainfo))
+            TEST_ERROR;
+        if (NULL == (bt2 = H5B2_open(oloc->file, ainfo.name_bt2_addr, NULL)))
+            TEST_ERROR;
+    }
+    else {
+        if (H5G__obj_get_linfo(oloc, &linfo) <= 0)
+            TEST_ERROR;
+        if (dense && NULL == (bt2 = H5B2_open(oloc->file, linfo.name_bt2_addr, NULL)))
+            TEST_ERROR;
+    }
+    if (bt2) {
+        saved_count      = bt2->hdr->root.all_nrec;
+        saved_node_count = bt2->hdr->root.node_nrec;
+    }
+
+    /* Also exercise an empty tree with a nonzero total count: no records
+     * are copied, but malformed metadata must still fail without leaking.
+     */
+    for (unsigned empty = 0; empty < (bt2 ? 2u : 1u); empty++) {
+        unsigned actual = empty ? 0 : NRECORDS;
+
+        if (bt2)
+            bt2->hdr->root.node_nrec = empty ? 0 : (uint16_t)saved_node_count;
+        for (size_t i = 0; i < sizeof(counts) / sizeof(counts[0]); i++) {
+            if (bt2)
+                bt2->hdr->root.all_nrec = counts[i];
+            if (!attributes)
+                linfo.nlinks = counts[i];
+            seen = 0;
+            H5E_BEGIN_TRY
+            {
+                if (attributes)
+                    status = H5A__dense_build_table(oloc->file, &ainfo, H5_INDEX_NAME, H5_ITER_INC, &atable);
+                else if (dense)
+                    status = H5G__dense_build_table(oloc->file, &linfo, H5_INDEX_NAME, H5_ITER_INC, &ltable);
+                else
+                    status = H5G__compact_iterate(oloc, &linfo, H5_INDEX_NAME, H5_ITER_INC, 0, NULL,
+                                                 check_link, &seen);
+            }
+            H5E_END_TRY
+            if (counts[i] != actual) {
+                if (status >= 0 || atable.attrs || ltable.lnks || seen || atable.num_attrs || ltable.nlinks)
+                    TEST_ERROR;
+            }
+            else {
+                if (status < 0)
+                    TEST_ERROR;
+                if (attributes) {
+                    if (atable.num_attrs != actual || atable.max_attrs > 2 * actual)
+                        TEST_ERROR;
+                    for (unsigned j = 0; j < actual; j++) {
+                        snprintf(name, sizeof(name), "attr%02u", j);
+                        if (strcmp(atable.attrs[j]->shared->name, name))
+                            TEST_ERROR;
+                    }
+                    if (H5A__attr_release_table(&atable) < 0)
+                        TEST_ERROR;
+                }
+                else if (dense) {
+                    if (ltable.nlinks != actual)
+                        TEST_ERROR;
+                    for (unsigned j = 0; j < actual; j++)
+                        if (check_link(&ltable.lnks[j], &seen) < 0)
+                            TEST_ERROR;
+                    if (H5G__link_release_table(&ltable) < 0)
+                        TEST_ERROR;
+                }
+                else if (seen != actual)
+                    TEST_ERROR;
+            }
+        }
+    }
+
+    if (bt2) {
+        bt2->hdr->root.all_nrec  = saved_count;
+        bt2->hdr->root.node_nrec = (uint16_t)saved_node_count;
+        if (H5B2_close(bt2) < 0)
+            TEST_ERROR;
+        bt2 = NULL;
+    }
+    if (H5CX_pop(false) < 0)
+        TEST_ERROR;
+    pushed = false;
+    if (H5Sclose(space) < 0 || H5Pclose(gcpl) < 0 || H5Gclose(group) < 0 || H5Fclose(file) < 0)
+        TEST_ERROR;
+    PASSED();
+    return 0;
+
+error:
+    H5Eprint2(H5E_DEFAULT, stdout);
+    H5E_BEGIN_TRY
+    {
+        if (bt2) {
+            bt2->hdr->root.all_nrec  = saved_count;
+            bt2->hdr->root.node_nrec = (uint16_t)saved_node_count;
+            H5B2_close(bt2);
+        }
+        if (atable.attrs)
+            H5A__attr_release_table(&atable);
+        if (ltable.lnks)
+            H5G__link_release_table(&ltable);
+        if (pushed)
+            H5CX_pop(false);
+        H5Aclose(attr);
+        H5Sclose(space);
+        H5Pclose(gcpl);
+        H5Gclose(group);
+        H5Fclose(file);
+    }
+    H5E_END_TRY
+    return 1;
+}
+
+int
+main(void)
+{
+    int nerrors = 0;
+
+    h5_test_init();
+    nerrors += test_table_counts(false, false);
+    nerrors += test_table_counts(false, true);
+    nerrors += test_table_counts(true, true);
+    if (nerrors)
+        return EXIT_FAILURE;
+    if (remove("table_counts.h5") < 0)
+        return EXIT_FAILURE;
+    return EXIT_SUCCESS;
+}

--- a/test/table_counts.c
+++ b/test/table_counts.c
@@ -44,28 +44,28 @@ check_link(const H5O_link_t *lnk, void *op_data)
 static int
 test_table_counts(bool attributes, bool dense)
 {
-    hid_t             file = H5I_INVALID_HID, group = H5I_INVALID_HID;
-    hid_t             gcpl = H5I_INVALID_HID, space = H5I_INVALID_HID, attr = H5I_INVALID_HID;
-    H5G_t            *grp;
-    H5O_loc_t        *oloc;
-    H5O_linfo_t       linfo;
-    H5O_ainfo_t       ainfo;
-    H5B2_t           *bt2 = NULL;
-    H5G_link_table_t  ltable = {0, NULL};
-    H5A_attr_table_t  atable = {0, 0, NULL};
-    H5CX_node_t       api_ctx = {{0}, NULL};
-    bool              pushed = false;
-    hsize_t           saved_count = 0;
-    unsigned          saved_node_count = 0;
-    const hsize_t     counts[] = {0, 1, NRECORDS - 1, NRECORDS, NRECORDS + 1,
-                                 (hsize_t)0x3ffffffd, (hsize_t)0x3fffffff, HSIZET_MAX};
-    char              name[32];
-    herr_t            status;
-    unsigned          seen;
+    hid_t            file = H5I_INVALID_HID, group = H5I_INVALID_HID;
+    hid_t            gcpl = H5I_INVALID_HID, space = H5I_INVALID_HID, attr = H5I_INVALID_HID;
+    H5G_t           *grp;
+    H5O_loc_t       *oloc;
+    H5O_linfo_t      linfo;
+    H5O_ainfo_t      ainfo;
+    H5B2_t          *bt2              = NULL;
+    H5G_link_table_t ltable           = {0, NULL};
+    H5A_attr_table_t atable           = {0, 0, NULL};
+    H5CX_node_t      api_ctx          = {{0}, NULL};
+    bool             pushed           = false;
+    hsize_t          saved_count      = 0;
+    unsigned         saved_node_count = 0;
+    const hsize_t    counts[]         = {
+        0, 1, NRECORDS - 1, NRECORDS, NRECORDS + 1, (hsize_t)0x3ffffffd, (hsize_t)0x3fffffff, HSIZET_MAX};
+    char     name[32];
+    herr_t   status;
+    unsigned seen;
 
     TESTING(attributes ? "dense attribute tables with fabricated counts"
-                       : dense ? "dense link tables with fabricated counts"
-                               : "compact link tables with fabricated counts");
+            : dense ? "dense link tables with fabricated counts"
+                    : "compact link tables with fabricated counts");
 
     if ((file = H5Fcreate("table_counts.h5", H5F_ACC_TRUNC, H5P_DEFAULT, H5P_DEFAULT)) < 0)
         TEST_ERROR;
@@ -140,7 +140,7 @@ test_table_counts(bool attributes, bool dense)
                     status = H5G__dense_build_table(oloc->file, &linfo, H5_INDEX_NAME, H5_ITER_INC, &ltable);
                 else
                     status = H5G__compact_iterate(oloc, &linfo, H5_INDEX_NAME, H5_ITER_INC, 0, NULL,
-                                                 check_link, &seen);
+                                                  check_link, &seen);
             }
             H5E_END_TRY
             if (counts[i] != actual) {

--- a/test/table_counts.c
+++ b/test/table_counts.c
@@ -64,8 +64,8 @@ test_table_counts(bool attributes, bool dense)
     unsigned seen;
 
     TESTING(attributes ? "dense attribute tables with fabricated counts"
-            : dense ? "dense link tables with fabricated counts"
-                    : "compact link tables with fabricated counts");
+            : dense    ? "dense link tables with fabricated counts"
+                       : "compact link tables with fabricated counts");
 
     if ((file = H5Fcreate("table_counts.h5", H5F_ACC_TRUNC, H5P_DEFAULT, H5P_DEFAULT)) < 0)
         TEST_ERROR;


### PR DESCRIPTION
- Replace debug-only asserts with runtime checks so the B-tree walk cannot overrun tables sized from stored record counts
- After iteration, require the table be filled exactly to avoid leaving NULL entries that the subsequent sort dereferences
- Prevents OOB writes and sort-time strcmp on NULL when dense index metadata is malformed or attacker-controlled