### PR TITLE
Fix REST VOL CI: HSDS now requires Python >= 3.11

### DIFF
--- a/.github/workflows/vol_rest.yml
+++ b/.github/workflows/vol_rest.yml
@@ -34,7 +34,10 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.10"]
+        # HSDS requires Python >= 3.11 (its pinned numpy has no 3.10 wheels).
+        # 3.12 matches the Python version HSDS uses for its own unix-socket
+        # test job, which is the configuration exercised here.
+        python-version: ["3.12"]
 
     steps:
       - name: Install dependencies
@@ -128,11 +131,6 @@ jobs:
       #  with:
       #    path: ${{ runner.workspace }}/hsds-${{ env.HSDS_COMMIT_SHORT }}-install
       #    key: ${{ runner.os }}-${{ runner.arch }}-hsds-${{ env.HSDS_COMMIT }}-${{ inputs.build_mode }}-cache
-
-      # Requests 2.32.0 breaks requests-unixsocket, used by HSDS for socket connections
-      - name: Fix requests version
-        run: |
-          pip install requests==2.31.0
 
       - name: Run HSDS unit tests
         shell: bash


### PR DESCRIPTION
The `hdf5_vol_rest_fetchcontent` job fails at **Install HSDS dependencies**, while the other six VOL jobs in the same run pass.

## Root cause

HSDS pins `numpy==2.4.6`, which publishes no distributions for Python 3.10:

```
ERROR: Could not find a version that satisfies the requirement numpy==2.4.6
       (from versions: ... 2.2.5, 2.2.6)
ERROR: No matching distribution found for numpy==2.4.6
```

`numpy` 2.4.6 declares `requires_python >= 3.11`, and HSDS's `pyproject.toml` now says `requires-python = ">=3.11"`. `vol_rest.yml` was the only workflow in the repo still pinning Python 3.10.

## Changes

1. Matrix `python-version: ["3.10"]` -> `["3.12"]`. 3.12 is what HSDS uses for its own `build-and-test-socket` job, i.e. exactly the unix-socket configuration this job exercises.
2. Removed the stale **Fix requests version** step that force-downgraded to `requests==2.31.0`. HSDS now pins `requests-unixsocket==0.4.1` (released March 2025, which fixed the requests-2.32 breakage that step worked around), so the downgrade only fights HSDS's own pins. Upstream HSDS has already commented the same step out of its socket-test job.

## Verification

- Confirmed `numpy==2.4.6` resolution fails for Python 3.10 and succeeds on 3.11+.
- Ran a full `pip install --dry-run -r requirements.txt` against HSDS master on a clean venv using the workflow's pinned `pip==24.3.1` - resolves cleanly (69 packages, `numpy-2.4.6`, `requests-2.34.2`, `requests-unixsocket-0.4.1`).
- Confirmed `runall.sh`, `tests/integ/setup_test.py`, and `admin/config/passwd.default` still exist in HSDS master, so the later steps remain valid.
- Workflow YAML parses; matrix and step list are as intended.

Fixes #6657

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011qUw9C11arB1WftiT56EA4
