### PR TITLE
Fix clang-format-fix.yml: give EndBug/add-and-commit its own push token

### DIFF
--- a/.github/workflows/clang-format-fix.yml
+++ b/.github/workflows/clang-format-fix.yml
@@ -42,3 +42,4 @@ jobs:
           author_name: github-actions
           author_email: 41898282+github-actions[bot]@users.noreply.github.com
           message: 'Committing clang-format changes'
+          github_token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary
- The `clang-format Commit Changes` workflow's checkout step uses `persist-credentials: false`, so no push credentials are left in the git config. The `EndBug/add-and-commit` step never received a token of its own to authenticate the push, so any push where clang-format actually found something to fix failed with `fatal: could not read Username for 'https://github.com'`, regardless of the repo's Actions workflow write-permission setting.
- Pass `github_token: ${{ secrets.GITHUB_TOKEN }}` to the `EndBug/add-and-commit` step so it authenticates its own push.